### PR TITLE
gen: make the closure implementation more performant

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2422,8 +2422,6 @@ V supports closures too.
 This means that anonymous functions can inherit variables from the scope they were created in.
 They must do so explicitly by listing all variables that are inherited.
 
-> Warning: currently works on x64 and arm64 architectures only.
-
 ```v oksyntax
 my_int := 1
 my_closure := fn [my_int] () {

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -69,11 +69,11 @@ fn c_closure_helpers(pref &pref.Preferences) string {
 
 	builder.write_string('
 #ifdef _MSC_VER
-	#define __RETURN_ADDRESS() _ReturnAddress()
+	#define __RETURN_ADDRESS() ((char*)_ReturnAddress())
 #elif defined(__TINYC__) && defined(_WIN32)
-	#define __RETURN_ADDRESS() (char*)__builtin_return_address(0)
+	#define __RETURN_ADDRESS() ((char*)__builtin_return_address(0))
 #else
-	#define __RETURN_ADDRESS() (char*)__builtin_extract_return_addr(__builtin_return_address(0))
+	#define __RETURN_ADDRESS() ((char*)__builtin_extract_return_addr(__builtin_return_address(0)))
 #endif
 
 #ifdef __V_amd64

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -77,86 +77,43 @@ fn c_closure_helpers(pref &pref.Preferences) string {
 #endif
 
 #ifdef __V_amd64
-#ifdef _WIN32
 static const char __closure_thunk[] = {
-	0x48, 0x89, 0x0d, 0xc1, 0xff, 0xff, 0xff,  // mov   qword ptr [rip - 63], rcx   # <_orig_rcx>
-	0x8f, 0x05, 0xc3, 0xff, 0xff, 0xff,        // pop   qword ptr [rip - 61]        # <_orig_rbp>
-	0xff, 0x15, 0xd5, 0xff, 0xff, 0xff,        // call  qword ptr [rip - 43]        # <wrapper>
-	0x48, 0x8b, 0x0d, 0xae, 0xff, 0xff, 0xff,  // mov   rcx, qword ptr [rip - 82]   # <_orig_rcx>
-	0xff, 0x15, 0xc0, 0xff, 0xff, 0xff,        // call  qword ptr [rip - 64]        # <unwrapper>
-	0xff, 0x35, 0xaa, 0xff, 0xff, 0xff,        // push  qword ptr [rip - 86]        # <_orig_rbp>
-	0xc3                                       // ret
+	0x8f, 0x05, 0xda, 0xff, 0xff, 0xff,  // pop   QWORD PTR [rip - 0x26] # <_orig_rbp>
+	0xff, 0x15, 0xdc, 0xff, 0xff, 0xff,  // call  QWORD PTR [rip - 0x24] # <wrapper>
+	0xff, 0x25, 0xce, 0xff, 0xff, 0xff,  // jmp   QWORD PTR [rip - 0x32] # <orig_rbp>
 };
-#else
-static const char __closure_thunk[] = {
-	0x48, 0x89, 0x3d, 0xc1, 0xff, 0xff, 0xff,  // mov   qword ptr [rip - 63], rdi   # <_orig_rdi>
-	0x8f, 0x05, 0xc3, 0xff, 0xff, 0xff,        // pop   qword ptr [rip - 61]        # <_orig_rbp>
-	0xff, 0x15, 0xd5, 0xff, 0xff, 0xff,        // call  qword ptr [rip - 43]        # <wrapper>
-	0x48, 0x8b, 0x3d, 0xae, 0xff, 0xff, 0xff,  // mov   rdi, qword ptr [rip - 82]   # <_orig_rdi>
-	0xff, 0x15, 0xc0, 0xff, 0xff, 0xff,        // call  qword ptr [rip - 64]        # <unwrapper>
-	0xff, 0x35, 0xaa, 0xff, 0xff, 0xff,        // push  qword ptr [rip - 86]        # <_orig_rbp>
-	0xc3                                       // ret
-};
-#endif
-#define __CLOSURE_WRAPPER_OFFSET 19
-#define __CLOSURE_UNWRAPPER_OFFSET 32
-#define __CLOSURE_WRAPPER_EXTRA_PARAM   void* _t
-#define __CLOSURE_WRAPPER_EXTRA_PARAM_COMMA ,
+#define __CLOSURE_WRAPPER_OFFSET 12
 #elif defined(__V_x86)
 static char __closure_thunk[] = {
-    0xe8, 0x00, 0x00, 0x00, 0x00,  // call 4
-    0x58,                          // pop  eax
-    0x8f, 0x40, 0xe3,              // pop  dword ptr [eax - 29] # <_orig_rbp>
-    0xff, 0x50, 0xef,              // call dword ptr [eax - 17] # <wrapper>
-    0xe8, 0x00, 0x00, 0x00, 0x00,  // call 4
-    0x58,                          // pop  eax
-    0xff, 0x50, 0xdf,              // call dword ptr [eax - 33] # <unwrapper>
-    0xe8, 0x00, 0x00, 0x00, 0x00,  // call 4
-    0x58,                          // pop  eax
-    0xff, 0x70, 0xce,              // push dword ptr [eax - 50] # <_orig_rbp>
-    0xc3                           // ret
+	0xe8, 0x00, 0x00, 0x00, 0x00,  // call 4
+	0x59,                          // pop  ecx
+	0x8f, 0x41, 0xeb,              // pop  DWORD PTR [ecx - 21] # <_orig_rbp>
+	0xff, 0x51, 0xef,              // call DWORD PTR [ecx - 17] # <wrapper>
+	0xe8, 0x00, 0x00, 0x00, 0x00,  // call 4
+	0x59,                          // pop  ecx
+	0xff, 0x61, 0xdf,              // jmp  DWORD PTR [ecx - 33] # <_orig_rbp>
 };
 
 #define __CLOSURE_WRAPPER_OFFSET 12
-#define __CLOSURE_UNWRAPPER_OFFSET 21
-#define __CLOSURE_WRAPPER_EXTRA_PARAM   void* _t
-#define __CLOSURE_WRAPPER_EXTRA_PARAM_COMMA ,
-
 #elif defined(__V_arm64)
 static char __closure_thunk[] = {
 	0x10, 0x00, 0x00, 0x10,  // adr x16, start
-	0x08, 0x82, 0x1c, 0xf8,  // str x8, _orig_x8
-	0x1e, 0x02, 0x1d, 0xf8,  // str x30, _orig_x30
-	0xf0, 0xfe, 0xff, 0x58,  // ldr x16, wrapper
+	0x1e, 0x02, 0x1e, 0xf8,  // str x30, _orig_x30
+	0x10, 0xff, 0xff, 0x58,  // ldr x16, wrapper
 	0x00, 0x02, 0x3f, 0xd6,  // blr x16
-	0x70, 0xff, 0xff, 0x10,  // adr x16, start
-	0x08, 0x82, 0x5c, 0xf8,  // ldr x8, _orig_x8
-	0x30, 0xfe, 0xff, 0x58,  // ldr x16, unwrapper
-	0x00, 0x02, 0x3f, 0xd6,  // blr x16
-	0xf0, 0xfe, 0xff, 0x10,  // adr x16, start
-	0x1e, 0x02, 0x5d, 0xf8,  // ldr x30, _orig_x30
+	0x9e, 0xfe, 0xff, 0x58,  // ldr x30, _orig_x30
 	0xc0, 0x03, 0x5f, 0xd6   // ret
 };
-#define __CLOSURE_WRAPPER_OFFSET 20
-#define __CLOSURE_UNWRAPPER_OFFSET 36
-#define __CLOSURE_WRAPPER_EXTRA_PARAM
-#define __CLOSURE_WRAPPER_EXTRA_PARAM_COMMA
+#define __CLOSURE_WRAPPER_OFFSET 16
 #elif defined(__V_arm32)
 static char __closure_thunk[] = {
-    0x24, 0x00, 0x0f, 0xe5,  //  str r0, orig_r0
-    0x24, 0xe0, 0x0f, 0xe5,  //  str lr, orig_lr
-    0x1c, 0xc0, 0x1f, 0xe5,  //  ldr ip, wrapper
-    0x3c, 0xff, 0x2f, 0xe1,  //  blx ip
-    0x34, 0x00, 0x1f, 0xe5,  //  ldr r0, orig_r0
-    0x2c, 0xc0, 0x1f, 0xe5,  //  ldr ip, unwrapper
-    0x3c, 0xff, 0x2f, 0xe1,  //  blx ip
-    0x3c, 0xe0, 0x1f, 0xe5,  //  ldr lr, orig_lr
-    0x1e, 0xff, 0x2f, 0xe1   //  bx  lr
+	0x18, 0xe0, 0x0f, 0xe5,  //  str lr, orig_lr
+	0x18, 0xc0, 0x1f, 0xe5,  //  ldr ip, wrapper
+	0x3c, 0xff, 0x2f, 0xe1,  //  blx ip
+	0x24, 0xe0, 0x1f, 0xe5,  //  ldr lr, orig_lr
+	0x1e, 0xff, 0x2f, 0xe1   //  bx  lr
 };
-#define __CLOSURE_WRAPPER_OFFSET 16
-#define __CLOSURE_UNWRAPPER_OFFSET 28
-#define __CLOSURE_WRAPPER_EXTRA_PARAM   void* _t
-#define __CLOSURE_WRAPPER_EXTRA_PARAM_COMMA ,
+#define __CLOSURE_WRAPPER_OFFSET 12
 #endif
 
 static int _V_PAGE_SIZE = 4096; // pre-initialized to the most common value, in case _vinit is not called (in a DLL, for example)
@@ -176,17 +133,7 @@ static inline void __closure_set_wrapper(void* closure, void* f) {
     p[-3] = f;
 }
 
-static inline void __closure_set_unwrapper(void* closure, void* f) {
-    void** p = closure;
-    p[-4] = f;
-}
-
-static inline void __closure_set_base_ptr(void* closure, void* bp) {
-    void** p = closure;
-    p[-5] = bp;
-}
-
-static void* __closure_create(void* fn, void* wrapper, void* unwrapper, void* data) {
+static void* __closure_create(void* fn, void* wrapper, void* data) {
 #ifdef _WIN32
 	SYSTEM_INFO si;
 	GetNativeSystemInfo(&si);
@@ -214,8 +161,6 @@ static void* __closure_create(void* fn, void* wrapper, void* unwrapper, void* da
 	__closure_set_data(closure, data);
 	__closure_set_function(closure, fn);
 	__closure_set_wrapper(closure, wrapper);
-	__closure_set_unwrapper(closure, unwrapper);
-	__closure_set_base_ptr(closure, p);
 	return closure;
 }
 ')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -304,7 +304,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	g.definitions.writeln(');')
 	g.writeln(') {')
 	if is_closure {
-		g.writeln('$cur_closure_ctx* $closure_ctx = *(void**)(__RETURN_ADDRESS() - __CLOSURE_DATA_OFFSET);')
+		g.writeln('$cur_closure_ctx* $c.closure_ctx = *(void**)(__RETURN_ADDRESS() - __CLOSURE_DATA_OFFSET);')
 	}
 	for i, is_promoted in heap_promoted {
 		if is_promoted {


### PR DESCRIPTION
This PR optimizes the closure implementation: calling a closure is now anywhere from 1.5x - 5x faster (depending on the number/size of its arguments).

![screenshot](https://media.discordapp.net/attachments/722442086984450159/973577998454374490/unknown.png)
(`old` is the current master, `new` is the first commit of the PR, and `new2` is the most up-to-date version here)


This PR also improves support for closures on x86 / arm32.