### PR TITLE
parser: check error for generic struct parameter (fix #14311)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -661,11 +661,17 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	mut concrete_types := []ast.Type{}
 	mut is_instance := false
 	for p.tok.kind != .eof {
+		mut type_pos := p.tok.pos()
 		gt := p.parse_type()
+		type_pos = type_pos.extend(p.prev_tok.pos())
 		if !gt.has_flag(.generic) {
 			is_instance = true
 		}
 		gts := p.table.sym(gt)
+		if !is_instance && gts.name.len > 1 {
+			p.error_with_pos('generic struct parameter name needs to be exactly one char',
+				type_pos)
+		}
 		bs_name += gts.name
 		bs_cname += gts.cname
 		concrete_types << gt

--- a/vlib/v/parser/tests/generic_struct_parameter_err.out
+++ b/vlib/v/parser/tests/generic_struct_parameter_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/generic_struct_parameter_err.vv:10:17: error: generic struct parameter name needs to be exactly one char
+    8 | struct MyContainer<T> {
+    9 | mut:
+   10 |     lst LinkedList<MyNode<T>>
+      |                    ~~~~~~~~~
+   11 | }
+   12 |

--- a/vlib/v/parser/tests/generic_struct_parameter_err.vv
+++ b/vlib/v/parser/tests/generic_struct_parameter_err.vv
@@ -1,0 +1,23 @@
+import datatypes { LinkedList }
+
+struct MyNode<T> {
+mut:
+	data T
+}
+
+struct MyContainer<T> {
+mut:
+	lst LinkedList<MyNode<T>>
+}
+
+fn (mut c MyContainer<T>) push(data T) {
+	node := MyNode<T>{
+		data: data
+	}
+	c.lst.push<T>(node)
+}
+
+fn main() {
+	mut c := MyContainer<string>{}
+	println(c)
+}


### PR DESCRIPTION
This PR check error for generic struct parameter (fix #14311).

- Check error for generic struct parameter.
- Add test.

```v
import datatypes { LinkedList }

struct MyNode<T> {
mut:
	data T
}

struct MyContainer<T> {
mut:
	lst LinkedList<MyNode<T>>
}

fn (mut c MyContainer<T>) push(data T) {
	node := MyNode<T>{
		data: data
	}
	c.lst.push<T>(node)
}

fn main() {
	mut c := MyContainer<string>{}
	println(c)
}

PS D:\Test\v\tt1> v run .
./tt1.v:10:17: error: generic struct parameter name needs to be exactly one char
    8 | struct MyContainer<T> {
    9 | mut:
   10 |     lst LinkedList<MyNode<T>>
      |                    ~~~~~~~~~
   11 | }
   12 |
```