### PR TITLE
os: add `raw_execute` on Windows

### DIFF
--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -367,6 +367,15 @@ pub fn execute(cmd string) Result {
 	}
 }
 
+// raw_execute does the same as `execute` on Unix platforms.
+// On Windows raw_execute starts the specified command, waits for it to complete, and returns its output.
+// It's marked as `unsafe` to help emphasize the problems that may arise by allowing, for example,
+// user provided escape sequences.
+[unsafe]
+pub fn raw_execute(cmd string) Result {
+	return execute(cmd)
+}
+
 [manualfree]
 pub fn (mut c Command) start() ? {
 	pcmd := c.path + ' 2>&1'

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -293,6 +293,8 @@ pub fn get_error_msg(code int) string {
 }
 
 // execute starts the specified command, waits for it to complete, and returns its output.
+// In opposition to `raw_execute` this function will safeguard against content that is known to cause
+// a lot of problems when executing shell commands on Windows.
 pub fn execute(cmd string) Result {
 	if cmd.contains(';') || cmd.contains('&&') || cmd.contains('||') || cmd.contains('\n') {
 		return Result{
@@ -300,6 +302,14 @@ pub fn execute(cmd string) Result {
 			output: ';, &&, || and \\n are not allowed in shell commands'
 		}
 	}
+	return unsafe { raw_execute(cmd) }
+}
+
+// raw_execute starts the specified command, waits for it to complete, and returns its output.
+// It's marked as `unsafe` to help emphasize the problems that may arise by allowing, for example,
+// user provided escape sequences.
+[unsafe]
+pub fn raw_execute(cmd string) Result {
 	mut child_stdin := &u32(0)
 	mut child_stdout_read := &u32(0)
 	mut child_stdout_write := &u32(0)


### PR DESCRIPTION
I'm adding this to be able to do my own character escaping on Windows to be able to bootstrap `vab`.
See https://discord.com/channels/592103645835821068/592320321995014154/971422720803893298 for reference discussions.