### PR TITLE
checker: check generic sumtype declare error (fix #14004)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -492,7 +492,13 @@ pub fn (mut c Checker) sum_type_decl(node ast.SumTypeDecl) {
 			c.error('sum type cannot hold an interface', variant.pos)
 		} else if sym.kind == .struct_ && sym.language == .js {
 			c.error('sum type cannot hold an JS struct', variant.pos)
+		} else if mut sym.info is ast.Struct {
+			if sym.info.is_generic && !variant.typ.has_flag(.generic) {
+				c.error('generic struct `$sym.name` must specify generic type names, e.g. Foo<T>',
+					variant.pos)
+			}
 		}
+
 		if sym.name.trim_string_left(sym.mod + '.') == node.name {
 			c.error('sum type cannot hold itself', variant.pos)
 		}

--- a/vlib/v/checker/tests/generic_sumtype_decl_err.out
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generic_sumtype_decl_err.vv:7:24: error: generic struct `Just` must specify generic type names, e.g. Foo<T>
+    5 | struct Nothing {}
+    6 |
+    7 | type Maybe = Nothing | Just
+      |                        ~~~~
+    8 |
+    9 | fn main() {

--- a/vlib/v/checker/tests/generic_sumtype_decl_err.vv
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err.vv
@@ -1,0 +1,10 @@
+struct Just<T> {
+  value T
+}
+
+struct Nothing {}
+
+type Maybe = Nothing | Just
+
+fn main() {
+}


### PR DESCRIPTION
This PR check generic sumtype declare error (fix #14004).

- Check generic sumtype declare error.
- Add test.

```v
struct Just<T> {
  value T
}

struct Nothing {}

type Maybe = Nothing | Just

fn main() {
}

PS D:\Test\v\tt1> v run .
./tt1.v:7:24: error: generic struct `Just` must specify generic type names, e.g. Foo<T>
    5 | struct Nothing {}
    6 |
    7 | type Maybe = Nothing | Just
      |                        ~~~~
    8 |
    9 | fn main() {
```