### PR TITLE
added clear() to map in builtin module

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -294,6 +294,14 @@ pub fn (mut m map) move() map {
 	return r
 }
 
+// clear clears the map without deallocating the allocated data.
+// It does it by setting the map length to `0`
+// Example: a.clear() // `a.len` and `a.key_values.len` is now 0
+pub fn (mut m map) clear() {
+	m.len = 0
+	m.key_values.len = 0
+}
+
 [inline]
 fn (m &map) key_to_index(pkey voidptr) (u32, u32) {
 	hash := m.hash_fn(pkey)

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -245,6 +245,14 @@ fn test_mut_arg() {
 	assert a == 10
 }
 
+fn test_clear() {
+	mut m := map[string]int{}
+	m['one'] = 1
+	m['two'] = 2
+	m.clear()
+	assert m.len == 0
+}
+
 fn test_delete() {
 	mut m := map[string]int{}
 	m['one'] = 1


### PR DESCRIPTION
Added clear() to builtin module, and added associated tests.

clear() is present in array builtin, so makes logical sense to also be present in map builtin, for uniformity.

clear() in map acts similar to way it does in array; wherein it does not deallocate memory but instead sets lengths to 0.
