### PR TITLE
checker: check error for cast function to string (fix #14357)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3026,6 +3026,9 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			ft := c.table.type_to_str(from_type)
 			c.error('cannot cast sumtype `$ft` to string, use `${snexpr}.str()` instead.',
 				node.pos)
+		} else if final_from_sym.kind == .function {
+			fnexpr := node.expr.str()
+			c.error('cannot cast function `$fnexpr` to string', node.pos)
 		} else if to_type != ast.string_type && from_type == ast.string_type
 			&& (!(to_sym.kind == .alias && final_to_sym.name == 'string')) {
 			mut error_msg := 'cannot cast a string to a type `$final_to_sym.name`, that is not an alias of string'

--- a/vlib/v/checker/tests/cast_function_to_string_err.out
+++ b/vlib/v/checker/tests/cast_function_to_string_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/cast_function_to_string_err.vv:2:10: error: cannot cast function `main` to string
+    1 | fn main() {
+    2 |     println(string(main))
+      |             ~~~~~~~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/cast_function_to_string_err.vv
+++ b/vlib/v/checker/tests/cast_function_to_string_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	println(string(main))
+}


### PR DESCRIPTION
This PR check error for cast function to string (fix #14357).

- Check error for cast function to string.
- Add test.

```v
fn main() {
	println(string(main))
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:10: error: cannot cast function `main` to string
    1 | fn main() {
    2 |     println(string(main))
      |             ~~~~~~~~~~~~
    3 | }
```