### PR TITLE
rand: minor cleanup in choose() (fix #13897)

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -327,9 +327,7 @@ pub fn (mut rng PRNG) choose<T>(array []T, k int) ?[]T {
 	}
 	mut results := []T{len: k}
 	mut indices := []int{len: n, init: it}
-	// TODO: see why exactly it is necessary to enfoce the type here in Checker.infer_fn_generic_types
-	// (v errors with: `inferred generic type T is ambiguous: got int, expected string`, when <int> is missing)
-	rng.shuffle<int>(mut indices) ?
+	rng.shuffle(mut indices) ?
 	for i in 0 .. k {
 		results[i] = array[indices[i]]
 	}


### PR DESCRIPTION
This PR makes a minor cleanup in choose() (fix #13897).

- Use `rng.shuffle(mut indices) ?` instead of `rng.shuffle<int>(mut indices) ?`.
- `infer_fn_generic_types` can work.