### PR TITLE
ci: check fmt before all other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   ubuntu-tcc:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     env:
@@ -90,6 +91,7 @@ jobs:
           ./v3 -o tetris  -usecache examples/tetris/tetris.v
 
   ubuntu-tcc-boehm-gc:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     env:
@@ -144,6 +146,7 @@ jobs:
           [ "$(stat -c %s leaks.txt)" = "0" ]
 
   macos:
+    needs: [code-formatting]
     runs-on: macOS-latest
     timeout-minutes: 121
     env:
@@ -205,14 +208,14 @@ jobs:
           cd ved && ../v -o ved .
           ../v -autofree .
           cd ..
-#      - name: Test c2v
-#        run: |
-#          git clone --depth 1 https://github.com/vlang/c2v
-#          cd c2v && ../v -o c2v .
-#          ../v .
-#          ../v run tests/run_tests.vsh
-#          ../v -experimental -w c2v_test.v
-#          cd ..
+      #      - name: Test c2v
+      #        run: |
+      #          git clone --depth 1 https://github.com/vlang/c2v
+      #          cd c2v && ../v -o c2v .
+      #          ../v .
+      #          ../v run tests/run_tests.vsh
+      #          ../v -experimental -w c2v_test.v
+      #          cd ..
       - name: Build V UI examples
         run: |
           git clone --depth 1 https://github.com/vlang/ui
@@ -231,6 +234,7 @@ jobs:
           ./v3 -o tetris  -usecache examples/tetris/tetris.v
 
   ubuntu:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     steps:
@@ -328,6 +332,7 @@ jobs:
   #        github-token: ${{ secrets.GITHUB_TOKEN }}
 
   ubuntu-clang:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     env:
@@ -412,6 +417,7 @@ jobs:
           ls
 
   windows-gcc:
+    needs: [code-formatting]
     runs-on: windows-2019
     timeout-minutes: 121
     env:
@@ -472,6 +478,7 @@ jobs:
         run: .\v.exe -o v2.exe cmd/v && .\v2.exe -o v3.exe cmd/v
 
   windows-msvc:
+    needs: [code-formatting]
     runs-on: windows-2019
     timeout-minutes: 121
     env:
@@ -504,8 +511,8 @@ jobs:
         run: |
           ./v -cg cmd\tools\vtest-self.v
           ./v test-self
-  #    - name: Test
-  #      run: .\v.exe test-all
+      #    - name: Test
+      #      run: .\v.exe test-all
       - name: Test v->js
         run: ./v -o hi.js examples/hello_v_js.v && node hi.js
       - name: Test v binaries
@@ -516,6 +523,7 @@ jobs:
         run: .\v.exe -o v2.exe cmd/v && .\v2.exe -o v3.exe cmd/v
 
   windows-tcc:
+    needs: [code-formatting]
     runs-on: windows-2019
     timeout-minutes: 121
     env:
@@ -608,7 +616,6 @@ jobs:
         ##      - name: v2 self compilation
         ##        run: .\v.exe -o v2.exe cmd/v && .\v2.exe -o v3.exe cmd/v
 
-
   #  ubuntu-autofree-selfcompile:
   #    runs-on: ubuntu-20.04
   #    timeout-minutes: 121
@@ -620,7 +627,6 @@ jobs:
   #      run: make -j4
   #    - name: V self compilation with -autofree
   #      run: ./v -o v2 -autofree cmd/v && ./v2 -o v3 -autofree cmd/v && ./v3 -o v4 -autofree cmd/v
-
 
   #   ubuntu-musl:
   #     runs-on: ubuntu-20.04

--- a/.github/workflows/ci_bootstrapping_works.yml
+++ b/.github/workflows/ci_bootstrapping_works.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   ubuntu:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     env:
@@ -48,6 +49,7 @@ jobs:
           ./v2 -o v3 cmd/v
 
   macos:
+    needs: [code-formatting]
     runs-on: macos-11
     timeout-minutes: 30
     env:

--- a/.github/workflows/ci_cross.yml
+++ b/.github/workflows/ci_cross.yml
@@ -9,8 +9,8 @@ on:
       - "**.md"
 
 jobs:
-
   macos-cross:
+    needs: [code-formatting]
     runs-on: macOS-latest
     timeout-minutes: 25
     env:
@@ -47,6 +47,7 @@ jobs:
           ./v -os android examples/toml.v
 
   linux-cross:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     env:
@@ -98,8 +99,8 @@ jobs:
           # Test that V can compile non-graphic app to Android compatible code *without* using the -apk flag
           ./v -os android examples/toml.v
 
-
   windows-cross:
+    needs: [code-formatting]
     runs-on: windows-2019
     timeout-minutes: 25
     steps:

--- a/.github/workflows/ci_sanitized.yml
+++ b/.github/workflows/ci_sanitized.yml
@@ -14,58 +14,58 @@ name: Sanitized CI
 on:
   push:
     paths:
-      - '!**'
-      - 'cmd/tools/vtest*'
-      - 'cmd/tools/builders/**.v'	  
-      - 'vlib/builtin/**.v'
-      - 'vlib/strconv/**.v'
-      - 'vlib/strings/**.v'
-      - 'vlib/math/**.v'
-      - 'vlib/math/big/**.v'
-      - 'vlib/arrays/**.v'
-      - 'vlib/datatypes/**.v'
-      - 'vlib/os/**.v'
-      - 'vlib/sync/**.v'
-      - 'vlib/v/tests/**.v'
-      - 'vlib/v/ast/**.v'
-      - 'vlib/v/scanner/**.v'
-      - 'vlib/v/parser/**.v'
-      - 'vlib/v/checker/**.v'
-      - 'vlib/v/gen/c/**.v'
-      - 'vlib/v/builder/**.v'
-      - 'vlib/v/cflag/**.v'
-      - 'vlib/v/live/**.v'
-      - 'vlib/v/util/**.v'
-      - 'vlib/v/markused/**.v'
-      - 'vlib/v/preludes/**.v'
-      - 'vlib/v/embed_file/**.v'
+      - "!**"
+      - "cmd/tools/vtest*"
+      - "cmd/tools/builders/**.v"
+      - "vlib/builtin/**.v"
+      - "vlib/strconv/**.v"
+      - "vlib/strings/**.v"
+      - "vlib/math/**.v"
+      - "vlib/math/big/**.v"
+      - "vlib/arrays/**.v"
+      - "vlib/datatypes/**.v"
+      - "vlib/os/**.v"
+      - "vlib/sync/**.v"
+      - "vlib/v/tests/**.v"
+      - "vlib/v/ast/**.v"
+      - "vlib/v/scanner/**.v"
+      - "vlib/v/parser/**.v"
+      - "vlib/v/checker/**.v"
+      - "vlib/v/gen/c/**.v"
+      - "vlib/v/builder/**.v"
+      - "vlib/v/cflag/**.v"
+      - "vlib/v/live/**.v"
+      - "vlib/v/util/**.v"
+      - "vlib/v/markused/**.v"
+      - "vlib/v/preludes/**.v"
+      - "vlib/v/embed_file/**.v"
   pull_request:
     paths:
-      - '!**'
-      - 'cmd/tools/vtest*'
-      - 'cmd/tools/builders/**.v'	  
-      - 'vlib/builtin/**.v'
-      - 'vlib/strconv/**.v'
-      - 'vlib/strings/**.v'
-      - 'vlib/math/**.v'
-      - 'vlib/math/big/**.v'
-      - 'vlib/arrays/**.v'
-      - 'vlib/datatypes/**.v'
-      - 'vlib/os/**.v'
-      - 'vlib/sync/**.v'
-      - 'vlib/v/tests/**.v'
-      - 'vlib/v/ast/**.v'
-      - 'vlib/v/scanner/**.v'
-      - 'vlib/v/parser/**.v'
-      - 'vlib/v/checker/**.v'
-      - 'vlib/v/gen/c/**.v'
-      - 'vlib/v/builder/**.v'
-      - 'vlib/v/cflag/**.v'
-      - 'vlib/v/live/**.v'
-      - 'vlib/v/util/**.v'
-      - 'vlib/v/markused/**.v'
-      - 'vlib/v/preludes/**.v'
-      - 'vlib/v/embed_file/**.v'
+      - "!**"
+      - "cmd/tools/vtest*"
+      - "cmd/tools/builders/**.v"
+      - "vlib/builtin/**.v"
+      - "vlib/strconv/**.v"
+      - "vlib/strings/**.v"
+      - "vlib/math/**.v"
+      - "vlib/math/big/**.v"
+      - "vlib/arrays/**.v"
+      - "vlib/datatypes/**.v"
+      - "vlib/os/**.v"
+      - "vlib/sync/**.v"
+      - "vlib/v/tests/**.v"
+      - "vlib/v/ast/**.v"
+      - "vlib/v/scanner/**.v"
+      - "vlib/v/parser/**.v"
+      - "vlib/v/checker/**.v"
+      - "vlib/v/gen/c/**.v"
+      - "vlib/v/builder/**.v"
+      - "vlib/v/cflag/**.v"
+      - "vlib/v/live/**.v"
+      - "vlib/v/util/**.v"
+      - "vlib/v/markused/**.v"
+      - "vlib/v/preludes/**.v"
+      - "vlib/v/embed_file/**.v"
 
 concurrency:
   group: build-sanitized-${{ github.event.pull_request.number || github.sha }}
@@ -73,6 +73,7 @@ concurrency:
 
 jobs:
   tests-sanitize-undefined-clang:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 180
     env:
@@ -98,6 +99,7 @@ jobs:
         run: ./v2 build-examples
 
   tests-sanitize-undefined-gcc:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 180
     env:
@@ -122,6 +124,7 @@ jobs:
         run: ./v2 build-examples
 
   tests-sanitize-address-clang:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 180
     env:
@@ -144,13 +147,13 @@ jobs:
       - name: Self tests (-fsanitize=address)
         run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self
       - name: Self tests (V compiled with -fsanitize=address)
-        run:
-          ./v -cflags -fsanitize=address -o v cmd/v &&
+        run: ./v -cflags -fsanitize=address -o v cmd/v &&
           ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler
       - name: Build examples (V compiled with -fsanitize=address)
         run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
   tests-sanitize-address-msvc:
+    needs: [code-formatting]
     runs-on: windows-2019
     timeout-minutes: 180
     env:
@@ -177,6 +180,7 @@ jobs:
       ##          .\v.exe -cflags "/fsanitize=address" test-self
 
   tests-sanitize-address-gcc:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 180
     env:
@@ -206,6 +210,7 @@ jobs:
         run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
   tests-sanitize-memory-clang:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 180
     env:
@@ -228,7 +233,6 @@ jobs:
       - name: Self tests (-fsanitize=memory)
         run: ./v -cflags -fsanitize=memory test-self
       - name: Self tests (V compiled with -fsanitize=memory)
-        run:
-          ./v -cflags -fsanitize=memory -o v cmd/v && ./v -cc tcc test-self -msan-compiler
+        run: ./v -cflags -fsanitize=memory -o v cmd/v && ./v -cc tcc test-self -msan-compiler
       - name: Build examples (V compiled with -fsanitize=memory)
         run: ./v build-examples

--- a/.github/workflows/ci_v_benchmark.yml
+++ b/.github/workflows/ci_v_benchmark.yml
@@ -10,26 +10,27 @@ on:
 
 jobs:
   run:
+    needs: [code-formatting]
     name: Run
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Install google benchmark
-      run: |
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install google benchmark
+        run: |
           git clone https://github.com/google/benchmark.git
           cd benchmark
           cmake -E make_directory "build"
           cmake -E chdir "build" cmake -DBENCHMARK_DOWNLOAD_DEPENDENCIES=on -DCMAKE_BUILD_TYPE=Release ../
           sudo cmake --build "build" --config Release --target install
-    - name: Run V benchmark
-      run: |
-        make
-        sudo ./v symlink
-        git clone https://github.com/vincenzopalazzo/benchmarks.git
-        cd benchmarks
-        make vdep && make v
-    - uses: actions/upload-artifact@v3
-      with:
-        name: vlang-benchmark
-        path: benchmarks/vlang/*.json
+      - name: Run V benchmark
+        run: |
+          make
+          sudo ./v symlink
+          git clone https://github.com/vincenzopalazzo/benchmarks.git
+          cd benchmarks
+          make vdep && make v
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vlang-benchmark
+          path: benchmarks/vlang/*.json

--- a/.github/workflows/containers_ci.yml
+++ b/.github/workflows/containers_ci.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   alpine-docker-musl-gcc:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     container:
@@ -46,6 +46,7 @@ jobs:
         run: ./v test-self
 
   ubuntu-docker-musl:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     container:

--- a/.github/workflows/debug_ci.yml
+++ b/.github/workflows/debug_ci.yml
@@ -3,8 +3,8 @@ name: Debug CI
 on: [workflow_dispatch]
 
 jobs:
-
   debug-msvc:
+    needs: [code-formatting]
     runs-on: windows-2019
     timeout-minutes: 121
     env:

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -6,6 +6,7 @@ on: [push, pull_request]
 
 jobs:
   check-markdown:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
@@ -18,6 +19,7 @@ jobs:
         ## thus real errors are easier to spot.
 
   report-missing-fn-doc:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     env:

--- a/.github/workflows/gfx_ci.yml
+++ b/.github/workflows/gfx_ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   gg-regressions:
+    needs: [code-formatting]
     runs-on: ubuntu-18.04
     timeout-minutes: 10
     env:

--- a/.github/workflows/module_docs.yml
+++ b/.github/workflows/module_docs.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-module-docs:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -26,7 +26,7 @@ jobs:
   code-formatting:
     ### NOTE: code-formatting is run *BEFORE* everything else, to detect formatting problems earlier.
     ### It uses a separate runner to minimize the chance of bottlenecking all the rest of the jobs.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     env:
       VFLAGS: -cc gcc

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -24,7 +24,9 @@ jobs:
           ! grep -r --exclude="*.yml" "a GPL license" .
 
   code-formatting:
-    runs-on: ubuntu-20.04
+    ### NOTE: code-formatting is run *BEFORE* everything else, to detect formatting problems earlier.
+    ### It uses a separate runner to minimize the chance of bottlenecking all the rest of the jobs.
+    runs-on: ubuntu-18.04
     timeout-minutes: 15
     env:
       VFLAGS: -cc gcc
@@ -93,7 +95,8 @@ jobs:
         ##      run: ./v -cc g++-9 test-self
 
       - name: Ensure V can be compiled with -autofree
-        run: ./v -autofree -o v2 cmd/v ## NB: this does not mean it runs, but at least keeps it from regressing
+        ## NB: this does not mean it runs, but at least keeps it from regressing
+        run: ./v -autofree -o v2 cmd/v
 
       - name: Shader examples can be build
         run: |

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   no-gpl-by-accident:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
@@ -39,6 +40,7 @@ jobs:
         run: ./v test-fmt
 
   performance-regressions:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     env:
@@ -63,6 +65,7 @@ jobs:
         run: cmd/tools/repeat --max_time 1501 --series 3 --count 20 --nmins 2 --nmaxs 5 --warmup 3 --fail_percent 10 -t 'cd {T} ; ./v -show-timings -o v.c cmd/v' . ./vmaster
 
   misc-tooling:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     env:
@@ -90,7 +93,7 @@ jobs:
         ##      run: ./v -cc g++-9 test-self
 
       - name: Ensure V can be compiled with -autofree
-        run: ./v -autofree -o v2 cmd/v  ## NB: this does not mean it runs, but at least keeps it from regressing
+        run: ./v -autofree -o v2 cmd/v ## NB: this does not mean it runs, but at least keeps it from regressing
 
       - name: Shader examples can be build
         run: |
@@ -109,6 +112,7 @@ jobs:
           ./v should-compile-all examples/sokol/*.v examples/sokol/0?*/*.v
 
   parser-silent:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     steps:
@@ -147,6 +151,7 @@ jobs:
           ./v test-parser -S examples/2048/2048_fuzz.v
 
   v-apps-compile:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     steps:
@@ -229,7 +234,6 @@ jobs:
         run: git clone https://github.com/vlang/libsodium ~/.vmodules/libsodium
       - name: Test libsodium
         run: VJOBS=1 ./v -stats test ~/.vmodules/libsodium
-
 
       ## vex
       - name: Install Vex dependencies

--- a/.github/workflows/paths_ci.yml
+++ b/.github/workflows/paths_ci.yml
@@ -13,12 +13,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   space-paths-linux:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     env:
-      MY_V_PATH: '你好 my $path, @с интервали'
+      MY_V_PATH: "你好 my $path, @с интервали"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -40,10 +40,11 @@ jobs:
           ./v test vlib/builtin vlib/os
 
   space-paths-macos:
+    needs: [code-formatting]
     runs-on: macOS-latest
     timeout-minutes: 30
     env:
-      MY_V_PATH: '你好 my $path, @с интервали'
+      MY_V_PATH: "你好 my $path, @с интервали"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -68,10 +69,11 @@ jobs:
           ./v test vlib/builtin vlib/os
 
   space-paths-windows:
+    needs: [code-formatting]
     runs-on: windows-2022
     timeout-minutes: 30
     env:
-      MY_V_PATH: 'path with some $punctuation, and some spaces'
+      MY_V_PATH: "path with some $punctuation, and some spaces"
 
       ## NB: the following paths do not work for now:
       ##### MY_V_PATH: '你好 my $path, @с интервали'

--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   v-compiles-sdl-examples:
+    needs: [code-formatting]
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   toml-module-pass-external-test-suites:
+    needs: [code-formatting]
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     env:
@@ -22,7 +23,6 @@ jobs:
       VTEST_TOML_DO_LARGE_FILES: 1
       VTEST_TOML_DO_YAML_CONVERSION: 1
     steps:
-
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -10,46 +10,47 @@ on:
 
 jobs:
   vab-compiles-v-examples:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     env:
       VAB_FLAGS: --api 30 --build-tools 29.0.0 -v 3
     steps:
-    - uses: actions/setup-java@v2
-      with:
-        distribution: 'adopt'
-        java-version: 8
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: 8
 
-    - uses: actions/checkout@v2
-    - name: Build V
-      run: make && sudo ./v symlink
+      - uses: actions/checkout@v2
+      - name: Build V
+        run: make && sudo ./v symlink
 
-    - name: Checkout vab
-      uses: actions/checkout@v2
-      with:
-        repository: vlang/vab
-        path: vab
+      - name: Checkout vab
+        uses: actions/checkout@v2
+        with:
+          repository: vlang/vab
+          path: vab
 
-    - name: Build vab
-      run: |
-        cd vab
-        v -g vab.v
-        sudo ln -s $(pwd)/vab /usr/local/bin/vab
+      - name: Build vab
+        run: |
+          cd vab
+          v -g vab.v
+          sudo ln -s $(pwd)/vab /usr/local/bin/vab
 
-    - name: Run tests
-      run: v test vab
+      - name: Run tests
+        run: v test vab
 
-    - name: Run vab --help
-      run: vab --help
+      - name: Run vab --help
+        run: vab --help
 
-    - name: Run vab doctor
-      run: vab doctor
+      - name: Run vab doctor
+        run: vab doctor
 
-    - name: Build graphical V examples as APK
-      run: |
-        declare -a v_examples=('flappylearning' '2048' 'fireworks' 'tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
-        mkdir apks
-        for example in "${v_examples[@]}"; do
-          safe_name=$(echo "$example" | sed 's%/%-%' | sed 's%\.%-%' )
-          vab examples/$example -o apks/$safe_name.apk
-        done
+      - name: Build graphical V examples as APK
+        run: |
+          declare -a v_examples=('flappylearning' '2048' 'fireworks' 'tetris' 'sokol/particles' 'sokol/drawing.v' 'sokol/freetype_raven.v' 'gg/polygons.v' 'gg/raven_text_rendering.v' 'gg/rectangles.v' 'gg/stars.v' 'gg/worker_thread.v')
+          mkdir apks
+          for example in "${v_examples[@]}"; do
+            safe_name=$(echo "$example" | sed 's%/%-%' | sed 's%\.%-%' )
+            vab examples/$example -o apks/$safe_name.apk
+          done

--- a/.github/workflows/vinix-kernel.yml
+++ b/.github/workflows/vinix-kernel.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   vinix-build:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/websockets.yml
+++ b/.github/workflows/websockets.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   websocket_tests:
+    needs: [code-formatting]
     runs-on: ubuntu-20.04
     timeout-minutes: 121
     env:
@@ -29,7 +30,7 @@ jobs:
       - name: Run websockets tests
         run: ./v -g test vlib/net/websocket/
 
-  ## Autobahn integrations tests
+      ## Autobahn integrations tests
       - name: Run autobahn services
         run: docker-compose -f ${{github.workspace}}/vlib/net/websocket/tests/autobahn/docker-compose.yml up -d
 
@@ -87,4 +88,3 @@ jobs:
         with:
           name: client wss
           path: ${{github.workspace}}/reports_wss/clients/index.html
-


### PR DESCRIPTION
Because our CI is often very full and the code formatting check is the one that fails most of the time, all CI checks will run only if code formatting was successful.