### PR TITLE
examples: fix 2048 scaling on Android

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -557,10 +557,16 @@ fn (mut app App) set_theme(idx int) {
 
 fn (mut app App) resize() {
 	mut s := gg.dpi_scale()
+	$if android {
+		s = app.gg.scale
+	}
 	if s == 0.0 {
 		s = 1.0
 	}
-	window_size := gg.window_size()
+	mut window_size := gg.window_size()
+	$if android {
+		window_size = app.gg.window_size()
+	}
 	w := window_size.width
 	h := window_size.height
 	m := f32(math.min(w, h))

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -556,17 +556,11 @@ fn (mut app App) set_theme(idx int) {
 }
 
 fn (mut app App) resize() {
-	mut s := gg.dpi_scale()
-	$if android {
-		s = app.gg.scale
-	}
+	mut s := app.gg.scale
 	if s == 0.0 {
 		s = 1.0
 	}
-	mut window_size := gg.window_size()
-	$if android {
-		window_size = app.gg.window_size()
-	}
+	window_size := app.gg.window_size()
 	w := window_size.width
 	h := window_size.height
 	m := f32(math.min(w, h))


### PR DESCRIPTION
This PR uses `gg.Context`'s methods instead of just `gg`'s on Android.

Before:
<img src="https://user-images.githubusercontent.com/768942/168065692-7696ce57-de66-4a38-a67c-a413f2cc6c78.jpg" width="200" />

After:
<img src="https://user-images.githubusercontent.com/768942/168065712-b20cbdcc-247b-4a31-8a36-e01897131999.jpg" width="200" />


