### PR TITLE
checker: fix optionals in infix expression check (fix #14354)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1145,6 +1145,8 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	right_is_optional := right_type.has_flag(.optional)
 	if (left_is_optional && !right_is_optional) || (!left_is_optional && right_is_optional) {
 		c.error('unwrapped optional cannot be used in an infix expression', left_right_pos)
+	} else if left_is_optional && right_is_optional {
+		c.error('unwrapped optionals cannot be used in an infix expression', left_right_pos)
 	}
 	// Dual sides check (compatibility check)
 	if !(c.symmetric_check(left_type, right_type) && c.symmetric_check(right_type, left_type))

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -927,9 +927,10 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						}
 					}
 				}
-			} else if left_type.has_flag(.optional) && right_type.has_flag(.optional) {
+			} else if left_type.has_flag(.optional) || right_type.has_flag(.optional) {
+				opt_comp_pos := if left_type.has_flag(.optional) { left_pos } else { right_pos }
 				c.error('unwrapped optional cannot be compared in an infix expression',
-					left_right_pos)
+					opt_comp_pos)
 			}
 		}
 		.left_shift {
@@ -1144,7 +1145,8 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	left_is_optional := left_type.has_flag(.optional)
 	right_is_optional := right_type.has_flag(.optional)
 	if (left_is_optional && !right_is_optional) || (!left_is_optional && right_is_optional) {
-		c.error('unwrapped optional cannot be used in an infix expression', left_right_pos)
+		opt_infix_pos := if left_is_optional { left_pos } else { right_pos }
+		c.error('unwrapped optional cannot be used in an infix expression', opt_infix_pos)
 	} else if left_is_optional && right_is_optional {
 		c.error('unwrapped optionals cannot be used in an infix expression', left_right_pos)
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1144,11 +1144,11 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	// TODO move this to symmetric_check? Right now it would break `return 0` for `fn()?int `
 	left_is_optional := left_type.has_flag(.optional)
 	right_is_optional := right_type.has_flag(.optional)
-	if (left_is_optional && !right_is_optional) || (!left_is_optional && right_is_optional) {
+	if left_is_optional && right_is_optional {
+		c.error('unwrapped optionals cannot be used in an infix expression', left_right_pos)
+	} else if left_is_optional || right_is_optional {
 		opt_infix_pos := if left_is_optional { left_pos } else { right_pos }
 		c.error('unwrapped optional cannot be used in an infix expression', opt_infix_pos)
-	} else if left_is_optional && right_is_optional {
-		c.error('unwrapped optionals cannot be used in an infix expression', left_right_pos)
 	}
 	// Dual sides check (compatibility check)
 	if !(c.symmetric_check(left_type, right_type) && c.symmetric_check(right_type, left_type))

--- a/vlib/v/checker/tests/infix_compare_optional_err.out
+++ b/vlib/v/checker/tests/infix_compare_optional_err.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/infix_compare_optional_err.vv:6:5: error: unwrapped optional cannot be compared in an infix expression
-    4 |
+    4 | 
     5 | fn main(){
     6 |     if foo() > foo() {}
-      |        ~~~~~~~~~~~~~
+      |        ~~~~~
     7 | }

--- a/vlib/v/checker/tests/infix_err.out
+++ b/vlib/v/checker/tests/infix_err.out
@@ -26,11 +26,11 @@ vlib/v/checker/tests/infix_err.vv:11:7: error: `+` cannot be used with `?int`
       |       ^
    12 | _ = int(0) + g() // FIXME not detected
    13 | _ = g() + int(3)
-vlib/v/checker/tests/infix_err.vv:12:5: error: unwrapped optional cannot be used in an infix expression
+vlib/v/checker/tests/infix_err.vv:12:14: error: unwrapped optional cannot be used in an infix expression
    10 | 
    11 | _ = 4 + g()
    12 | _ = int(0) + g() // FIXME not detected
-      |     ~~~~~~~~~~~~
+      |              ~~~
    13 | _ = g() + int(3)
    14 | _ = g() + 3
 vlib/v/checker/tests/infix_err.vv:13:9: error: `+` cannot be used with `?int`

--- a/vlib/v/checker/tests/unwrapped_optional_infix.out
+++ b/vlib/v/checker/tests/unwrapped_optional_infix.out
@@ -2,5 +2,4 @@ vlib/v/checker/tests/unwrapped_optional_infix.vv:5:9: error: unwrapped optional 
     3 | }
     4 | 
     5 | println(test() == "")
-      |         ~~~~~~~~~~~~
-
+      |         ~~~~~~


### PR DESCRIPTION
This PR fixes the checker error when an infix expression has an optional on both sides. It also slightly improves that check message by highlighting which side(s) contain the optional.

Apologies if my commit messages are formatted wrong or too numerous -- I will gladly start over from scratch & Do It Right if necessary (but I'd rather not, I've burnt an inordinate amount of time working on this due to git troubles... >.>)

I don't understand this comment... it seems outdated? -- Should I just remove it?
```// TODO move this to symmetric_check? Right now it would break `return 0` for `fn()?int ` ```

The "unwrapped optional infix comparison" check overlaps highly with "unwrapped optional infix use" check. In fact I'm inclined to remove it as redundant -- should I?

The checker specifically highlighting the left/right side with the optional isn't too "fancy" for V, is it?

Sorry for so many questions and (again) so many commits for a simple bug-fix. :sweat_smile:

Aside: I would just like to say that I only learned V a week or two ago, and the fact I was able to so easily locate & fix this bug is a testament to V's simplicity. ^^