### PR TITLE
examples: add missing v.mod file

### DIFF
--- a/examples/submodule/v.mod
+++ b/examples/submodule/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'submodule'
+	description: ''
+	version: ''
+	license: ''
+	dependencies: []
+}


### PR DESCRIPTION
Adds missing v.mod file to actually make the example work correctly.