### PR TITLE
os: fix is_abs_path function for Windows systems

### DIFF
--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -11,9 +11,6 @@ const (
 	is_win = user_os() == 'windows'
 )
 
-// the path separator based on the operating system
-pub const path_sep = get_path_sep()
-
 // is_abs_path returns `true` if the given `path` is absolute.
 pub fn is_abs_path(path string) bool {
 	if path.len == 0 {

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -52,10 +52,6 @@ fn win_volume_len(path string) int {
 	return 0
 }
 
-fn get_path_sep() string {
-	return if os.is_win { '\\' } else { '/' }
-}
-
 fn is_slash(b u8) bool {
 	return b == os.fslash || (os.is_win && b == os.bslash)
 }

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -8,7 +8,6 @@ const (
 	fslash = `/`
 	bslash = `\\`
 	dot    = `.`
-	is_win = user_os() == 'windows'
 )
 
 // is_abs_path returns `true` if the given `path` is absolute.
@@ -16,7 +15,7 @@ pub fn is_abs_path(path string) bool {
 	if path.len == 0 {
 		return false
 	}
-	if os.is_win {
+	$if windows {
 		return is_device_path(path) || is_drive_rooted(path) || is_normal_path(path)
 	}
 	return path[0] == os.fslash
@@ -53,7 +52,10 @@ fn win_volume_len(path string) int {
 }
 
 fn is_slash(b u8) bool {
-	return b == os.fslash || (os.is_win && b == os.bslash)
+	$if windows {
+		return b == os.bslash || b == os.fslash
+	}
+	return b == os.fslash
 }
 
 fn is_device_path(path string) bool {

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -1,0 +1,91 @@
+module os
+
+// Collection of useful functions for manipulation, validation and analysis of system paths.
+// The following functions handle paths depending on the operating system,
+// therefore results may be different for certain operating systems.
+
+const (
+	fslash = `/`
+	bslash = `\\`
+	dot    = `.`
+	is_win = user_os() == 'windows'
+)
+
+// the path separator based on the operating system
+pub const path_sep = get_path_sep()
+
+// is_abs_path returns `true` if the given `path` is absolute.
+pub fn is_abs_path(path string) bool {
+	if path.len == 0 {
+		return false
+	}
+	if os.is_win {
+		return is_device_path(path) || is_drive_rooted(path) || is_normal_path(path)
+	}
+	return path[0] == os.fslash
+}
+
+// win_volume_len returns the length of the
+// Windows volume/drive from the given `path`.
+fn win_volume_len(path string) int {
+	plen := path.len
+	if plen < 2 {
+		return 0
+	}
+	if has_drive_letter(path) {
+		return 2
+	}
+	// its UNC path / DOS device path?
+	if path.len >= 5 && starts_w_slash_slash(path) && !is_slash(path[2]) {
+		for i := 3; i < plen; i++ {
+			if is_slash(path[i]) {
+				if i + 1 >= plen || is_slash(path[i + 1]) {
+					break
+				}
+				i++
+				for ; i < plen; i++ {
+					if is_slash(path[i]) {
+						return i
+					}
+				}
+				return i
+			}
+		}
+	}
+	return 0
+}
+
+fn get_path_sep() string {
+	return if os.is_win { '\\' } else { '/' }
+}
+
+fn is_slash(b u8) bool {
+	return b == os.fslash || (os.is_win && b == os.bslash)
+}
+
+fn is_device_path(path string) bool {
+	return win_volume_len(path) >= 5 && starts_w_slash_slash(path)
+}
+
+fn has_drive_letter(path string) bool {
+	return path.len >= 2 && path[0].is_letter() && path[1] == `:`
+}
+
+fn starts_w_slash_slash(path string) bool {
+	return path.len >= 2 && is_slash(path[0]) && is_slash(path[1])
+}
+
+fn is_drive_rooted(path string) bool {
+	return path.len >= 3 && has_drive_letter(path) && is_slash(path[2])
+}
+
+// is_normal_path returns `true` if the given
+// `path` is NOT a network or Windows device path.
+fn is_normal_path(path string) bool {
+	plen := path.len
+	if plen == 0 {
+		return false
+	}
+	return (plen == 1 && is_slash(path[0])) || (plen >= 2 && is_slash(path[0])
+		&& !is_slash(path[1]))
+}

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -1,0 +1,29 @@
+module os
+
+fn test_is_abs_path() {
+	if is_win {
+		assert is_abs_path('/')
+		assert is_abs_path('\\')
+		assert !is_abs_path('\\\\')
+		assert is_abs_path(r'C:\path\to\files\file.v')
+		assert is_abs_path(r'\\Host\share')
+		assert is_abs_path(r'//Host\share\files\file.v')
+		assert is_abs_path(r'\\.\BootPartition\Windows')
+		assert !is_abs_path(r'\\.\')
+		assert !is_abs_path(r'\\?\\')
+		assert !is_abs_path(r'C:path\to\dir')
+		assert !is_abs_path(r'dir')
+		assert !is_abs_path(r'.\')
+		assert !is_abs_path(r'.')
+		assert !is_abs_path(r'\\Host')
+		assert !is_abs_path(r'\\Host\')
+		return
+	}
+	assert is_abs_path('/')
+	assert is_abs_path('/path/to/files/file.v')
+	assert !is_abs_path('\\')
+	assert !is_abs_path('path/to/files/file.v')
+	assert !is_abs_path('dir')
+	assert !is_abs_path('./')
+	assert !is_abs_path('.')
+}

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -1,7 +1,7 @@
 module os
 
 fn test_is_abs_path() {
-	if is_win {
+	$if windows {
 		assert is_abs_path('/')
 		assert is_abs_path('\\')
 		assert !is_abs_path('\\\\')

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -454,18 +454,6 @@ pub fn is_file(path string) bool {
 	return exists(path) && !is_dir(path)
 }
 
-// is_abs_path returns `true` if `path` is absolute.
-pub fn is_abs_path(path string) bool {
-	if path.len == 0 {
-		return false
-	}
-	$if windows {
-		return path[0] == `/` || // incase we're in MingGW bash
-		(path[0].is_letter() && path.len > 1 && path[1] == `:`)
-	}
-	return path[0] == `/`
-}
-
 // join_path returns a path as string from input string parameter(s).
 [manualfree]
 pub fn join_path(base string, dirs ...string) string {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -590,14 +590,6 @@ fn test_ext() {
 	assert os.file_ext('file') == ''
 }
 
-fn test_is_abs() {
-	assert os.is_abs_path('/home/user')
-	assert os.is_abs_path('v/vlib') == false
-	$if windows {
-		assert os.is_abs_path('C:\\Windows\\')
-	}
-}
-
 fn test_join() {
 	$if windows {
 		assert os.join_path('v', 'vlib', 'os') == 'v\\vlib\\os'


### PR DESCRIPTION
The current `os.is_abs_path` function ([source](https://github.com/vlang/v/blob/master/vlib/os/os.v#L458)) is **not** implemented correctly for Windows systems, because the function only checks whether the passed path starts with a drive letter on a Windows system, and not whether the path is rooted.

Here is a comparison of the **current**  `os.is_abs_path` function with the `filepath.IsAbs()` function of Go (on a Windows system): 

Go:
```go
package main

import (
	"fmt"
	"path/filepath"
)

func main() {
	fmt.Println(filepath.IsAbs("C:rel\\path\\to\\file.v"))   	// false
	fmt.Println(filepath.IsAbs("C:.."))   					// false
	fmt.Println(filepath.IsAbs("C:\\abs\\path\\to\\file.v"))  	// true
}

```
V:
```v
module main

import os { is_abs_path }

fn main() {
	println(is_abs_path(r'C:rel\path\to\file.v')) 	// true <- should be false
	println(is_abs_path('C:..'))					// true <- should be false too
	println(is_abs_path(r'C:\abs\path\to\file.v')) 	// true 
}

```

Furthermore, the current `os.is_abs_path` function does not handle UNC paths nor DOS device paths on a Windows system.
- https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths
- https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths

So, why I want the `os.is_abs_path()` function to be in a separate file ('os/filepath.v')?
Because I want to keep things separate and I would like to implement some more useful functionalities for validation, manipulation and analysis of paths (see https://github.com/benwalksaway/path).