### PR TITLE
vvet: fix false positive, add test

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -164,6 +164,7 @@ fn main() {
 	cmd_prefix := args_string.all_before('test-self')
 	title := 'testing vlib'
 	mut all_test_files := os.walk_ext(os.join_path(vroot, 'vlib'), '_test.v')
+	all_test_files << os.walk_ext(os.join_path(vroot, 'cmd'), '_test.v')
 	test_js_files := os.walk_ext(os.join_path(vroot, 'vlib'), '_test.js.v')
 	all_test_files << test_js_files
 	testing.eheader(title)

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -9,6 +9,7 @@ const github_job = os.getenv('GITHUB_JOB')
 const (
 	skip_test_files               = [
 		'cmd/tools/vdoc/html_tag_escape_test.v', /* can't locate local module: markdown */
+		'cmd/tools/vdoc/tests/vdoc_file_test.v', /* fails on Windows; order of output is not as expected */
 		'vlib/context/onecontext/onecontext_test.v',
 		'vlib/context/deadline_test.v' /* sometimes blocks */,
 		'vlib/mysql/mysql_orm_test.v' /* mysql not installed */,

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -8,6 +8,7 @@ const github_job = os.getenv('GITHUB_JOB')
 
 const (
 	skip_test_files               = [
+		'cmd/tools/vdoc/html_tag_escape_test.v', /* can't locate local module: markdown */
 		'vlib/context/onecontext/onecontext_test.v',
 		'vlib/context/deadline_test.v' /* sometimes blocks */,
 		'vlib/mysql/mysql_orm_test.v' /* mysql not installed */,

--- a/cmd/tools/vvet/tests/array_init_one_val.out
+++ b/cmd/tools/vvet/tests/array_init_one_val.out
@@ -1,2 +1,2 @@
 cmd/tools/vvet/tests/array_init_one_val.vv:2: error: Use `var == value` instead of `var in [value]`
-NB: You can run `v fmt -w file.v` to fix these errors automatically
+Note: You can run `v fmt -w file.v` to fix these errors automatically

--- a/cmd/tools/vvet/tests/indent_with_space.out
+++ b/cmd/tools/vvet/tests/indent_with_space.out
@@ -3,4 +3,4 @@ cmd/tools/vvet/tests/indent_with_space.vv:10: error: Looks like you are using sp
 cmd/tools/vvet/tests/indent_with_space.vv:17: error: Looks like you are using spaces for indentation.
 cmd/tools/vvet/tests/indent_with_space.vv:20: error: Looks like you are using spaces for indentation.
 cmd/tools/vvet/tests/indent_with_space.vv:22: error: Looks like you are using spaces for indentation.
-NB: You can run `v fmt -w file.v` to fix these errors automatically
+Note: You can run `v fmt -w file.v` to fix these errors automatically

--- a/cmd/tools/vvet/tests/no_warn_about_missing.vv
+++ b/cmd/tools/vvet/tests/no_warn_about_missing.vv
@@ -1,0 +1,6 @@
+// Some header comment
+
+// read_response is a carefully constructed comment.
+// read_response_body. <-- this would earlier trigger a false
+// postive.
+pub fn read_response() ?(string, string) {}

--- a/cmd/tools/vvet/tests/parens_space_a.out
+++ b/cmd/tools/vvet/tests/parens_space_a.out
@@ -1,2 +1,2 @@
 cmd/tools/vvet/tests/parens_space_a.vv:1: error: Looks like you are adding a space after `(`
-NB: You can run `v fmt -w file.v` to fix these errors automatically
+Note: You can run `v fmt -w file.v` to fix these errors automatically

--- a/cmd/tools/vvet/tests/parens_space_b.out
+++ b/cmd/tools/vvet/tests/parens_space_b.out
@@ -1,2 +1,2 @@
 cmd/tools/vvet/tests/parens_space_b.vv:1: error: Looks like you are adding a space before `)`
-NB: You can run `v fmt -w file.v` to fix these errors automatically
+Note: You can run `v fmt -w file.v` to fix these errors automatically

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -182,13 +182,17 @@ fn (mut vt Vet) vet_fn_documentation(lines []string, line string, lnumber int) {
 			fn_name := ident_fn_name(line)
 			mut grab := true
 			for j := lnumber - 1; j >= 0; j-- {
+				mut prev_prev_line := ''
+				if j - 1 >= 0 {
+					prev_prev_line = lines[j - 1]
+				}
 				prev_line := lines[j]
 				if prev_line.contains('}') { // We've looked back to the above scope, stop here
 					break
 				} else if prev_line.starts_with('// $fn_name ') {
 					grab = false
 					break
-				} else if prev_line.starts_with('// $fn_name') {
+				} else if prev_line.starts_with('// $fn_name') && !prev_prev_line.starts_with('//') {
 					grab = false
 					clean_line := line.all_before_last('{').trim(' ')
 					vt.warn('The documentation for "$clean_line" seems incomplete.', lnumber,


### PR DESCRIPTION
Fixes #14402 

On a side note there seem to have been updates related to the `NB` -> `Note` wording - which I've fixed also so the tests actually pass if I run `v test .` locally in the directory, I wonder why this didn't show in CI - has the `vvet` tests been disabled?