### PR TITLE
ast, cgen: fix generic method with variadic generic argument (fix #14401)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1464,7 +1464,6 @@ pub fn (t &TypeSymbol) find_method_with_generic_parent(name string) ?Fn {
 									param.typ = pt
 								}
 							}
-							method.generic_names.clear()
 							return method
 						}
 						else {}

--- a/vlib/v/tests/generic_method_with_variadic_generic_args_test.v
+++ b/vlib/v/tests/generic_method_with_variadic_generic_args_test.v
@@ -1,0 +1,17 @@
+struct Foo<T> {
+mut:
+	arr []T
+}
+
+fn (mut foo Foo<T>) push<T>(items ...T) {
+	for item in items {
+		foo.arr << item
+	}
+}
+
+fn test_generic_method_with_variadic_args() {
+	mut f := Foo<int>{}
+	f.push(1, 2, 3, 5, 8, 13, 21, 34, 55)
+	println(f.arr)
+	assert f.arr == [1, 2, 3, 5, 8, 13, 21, 34, 55]
+}


### PR DESCRIPTION
This PR fix generic method with variadic generic argument (fix #14401).

- Fix generic method with variadic generic argument.
- Add test.

```v
struct Foo<T> {
mut:
	arr []T
}

fn (mut foo Foo<T>) push(items ...T) {
	for item in items {
		foo.arr << item
	}
}

fn main() {
	mut f := Foo<int>{}
	f.push(1, 2, 3, 5, 8, 13, 21, 34, 55)
	println(f.arr)
	assert f.arr == [1, 2, 3, 5, 8, 13, 21, 34, 55]
}

PS D:\Test\v\tt1> v run .
[1, 2, 3, 5, 8, 13, 21, 34, 55]
```