### PR TITLE
fmt: fix fmt error of anon fn with if expr (fix #14393)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1951,7 +1951,8 @@ pub fn (mut f Fmt) if_expr(node ast.IfExpr) {
 }
 
 fn branch_is_single_line(b ast.IfBranch) bool {
-	if b.stmts.len == 1 && b.comments.len == 0 && stmt_is_single_line(b.stmts[0]) {
+	if b.stmts.len == 1 && b.comments.len == 0 && stmt_is_single_line(b.stmts[0])
+		&& b.pos.line_nr == b.stmts[0].pos.line_nr {
 		return true
 	}
 	return false

--- a/vlib/v/fmt/tests/anon_fn_with_if_expr_expected.vv
+++ b/vlib/v/fmt/tests/anon_fn_with_if_expr_expected.vv
@@ -1,0 +1,10 @@
+fn main() {
+	a := fn () {
+		if true {
+			println('a')
+		} else {
+			println('a')
+		}
+	}
+	a()
+}

--- a/vlib/v/fmt/tests/anon_fn_with_if_expr_input.vv
+++ b/vlib/v/fmt/tests/anon_fn_with_if_expr_input.vv
@@ -1,0 +1,10 @@
+fn main() {
+a := fn () {
+	if true {
+		println('a')
+	} else {
+		println('a')
+	}
+}
+	a()
+}

--- a/vlib/v/fmt/tests/shared_input.vv
+++ b/vlib/v/fmt/tests/shared_input.vv
@@ -64,8 +64,7 @@ a: 5
  lock x { // wait for ongoing reads to finish, don't start new ones
 			 x.a = 17 // this value should never be read
 	time.sleep(50* time.millisecond)
-	x.a = if (i & 1) == 0 {
-7} else {5}
+	x.a = if (i & 1) ==  0 {    7 } else {  5  }
 	} // now new reads are possible again
 time.sleep(20*time.millisecond)
 	}

--- a/vlib/v/tests/bench/math_big_gcd/bench_euclid.v
+++ b/vlib/v/tests/bench/math_big_gcd/bench_euclid.v
@@ -60,7 +60,11 @@ fn main() {
 			(aa % gcd) == big.zero_int,
 			(bb % gcd) == big.zero_int,
 		].all(it == true)
-		{ true } else { false }
+		{
+			true
+		} else {
+			false
+		}
 	}
 
 	cfgs := [


### PR DESCRIPTION
This PR fix fmt error of anon fn with if expr (fix #14393).

- Fix fmt error of anon fn with if expr.
- Add test.

```v
fn main() {
a := fn () {
	if true {
		println('a')
	} else {
		println('a')
	}
}
	a()
}
```
formated:
```v
fn main() {
	a := fn () {
		if true {
			println('a')
		} else {
			println('a')
		}
	}
	a()
}
```