### PR TITLE
vcomplete: improve flag completion, add missdoc

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -132,7 +132,7 @@ const (
 		'build-module',
 		'missdoc',
 	]
-	// Flag entries in the array below should be entered as is:
+	// Entries in the flag arrays below should be entered as is:
 	// * Short flags, e.g.: "-v", should be entered: '-v'
 	// * Long flags, e.g.: "--version", should be entered: '--version'
 	// * Single-dash flags, e.g.: "-version", should be entered: '-version'

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -75,10 +75,6 @@ SUBCMD:
 )
 
 // Snooped from cmd/v/v.v, vlib/v/pref/pref.v
-// Flag entries in the array below should be entered as is:
-// * Short flags, e.g.: "-v", should be entered: '-v'
-// * Long flags, e.g.: "--version", should be entered: '--version'
-// * Single-dash flags, e.g.: "-version", should be entered: '-version'
 const (
 	auto_complete_commands      = [
 		// simple_cmd
@@ -136,6 +132,10 @@ const (
 		'build-module',
 		'missdoc',
 	]
+	// Flag entries in the array below should be entered as is:
+	// * Short flags, e.g.: "-v", should be entered: '-v'
+	// * Long flags, e.g.: "--version", should be entered: '--version'
+	// * Single-dash flags, e.g.: "-version", should be entered: '-version'
 	auto_complete_flags         = [
 		'-apk',
 		'-show-timings',

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -397,7 +397,6 @@ fn auto_complete_request(args []string) []string {
 		if part.starts_with('-') { // 'v [subcmd] -<tab>' or 'v [subcmd] --<tab>'-> flags.
 			get_flags := fn (base []string, flag string) []string {
 				mut results := []string{}
-				// starts with just '-'
 				for entry in base {
 					if entry.starts_with(flag) {
 						results << entry

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -114,7 +114,6 @@ const (
 		'help',
 		'new',
 		'init',
-		'complete',
 		'translate',
 		'self',
 		'search',

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -75,6 +75,10 @@ SUBCMD:
 )
 
 // Snooped from cmd/v/v.v, vlib/v/pref/pref.v
+// Flag entries in the array below should be entered as is:
+// * Short flags, e.g.: "-v", should be entered: '-v'
+// * Long flags, e.g.: "--version", should be entered: '--version'
+// * Single-dash flags, e.g.: "-version", should be entered: '-version'
 const (
 	auto_complete_commands      = [
 		// simple_cmd
@@ -229,33 +233,33 @@ const (
 		'--write',
 	]
 	auto_complete_flags_shader  = [
-		'help',
-		'h',
-		'force-update',
-		'u',
-		'verbose',
-		'v',
-		'slang',
-		'l',
-		'output',
-		'o',
+		'--help',
+		'-h',
+		'--force-update',
+		'-u',
+		'--verbose',
+		'-v',
+		'--slang',
+		'-l',
+		'--output',
+		'-o',
 	]
 	auto_complete_flags_missdoc = [
-		'help',
-		'h',
-		'tags',
-		't',
-		'deprecated',
-		'd',
-		'private',
-		'p',
-		'no-line-numbers',
-		'n',
-		'exclude',
-		'e',
-		'relative-paths',
-		'r',
-		'js',
+		'--help',
+		'-h',
+		'--tags',
+		'-t',
+		'--deprecated',
+		'-d',
+		'--private',
+		'-p',
+		'--no-line-numbers',
+		'-n',
+		'--exclude',
+		'-e',
+		'--relative-paths',
+		'-r',
+		'--js',
 	]
 	auto_complete_flags_self    = [
 		'-prod',
@@ -390,38 +394,18 @@ fn auto_complete_request(args []string) []string {
 			parent_command = parts[i]
 			break
 		}
-		if part.starts_with('-') { // 'v -<tab>' or 'v --<tab>'-> flags.
+		if part.starts_with('-') { // 'v [subcmd] -<tab>' or 'v [subcmd] --<tab>'-> flags.
 			get_flags := fn (base []string, flag string) []string {
-				if flag == '-' {
-					return base.map(fn (e string) string {
-						if e.len == 1 {
-							return '-' + e
-						} else {
-							return '--' + e
-						}
-					})
-				}
-				if flag == '--' {
-					mut m := base.map(fn (e string) string {
-						if e.len > 1 {
-							return '--' + e
-						}
-						return ''
-					})
-					return m.filter(it != '')
-				}
 				mut results := []string{}
-				if flag.starts_with('--') {
-					for entry in base {
-						if entry.len > 1 && entry.starts_with(flag.trim_left('-')) {
-							results << '--' + entry
-						}
+				// starts with just '-'
+				for entry in base {
+					if entry.starts_with(flag) {
+						results << entry
 					}
-				} else {
-					results << flag
 				}
 				return results
 			}
+
 			match parent_command {
 				'bin2v' { // 'v bin2v -<tab>'
 					list = get_flags(auto_complete_flags_bin2v, part)


### PR DESCRIPTION
This PR improves flag tab completion.

On top I've added the `missdoc` tool to completions, since this was my initial intend - before discovering
that flag completion didn't work very well :slightly_smiling_face: 

With this PR you'll now get a flag list when doing e.g.: `v -<tab>` or only long flags: `v --<tab>`. This also works
for sub commands like e.g. `missdoc` or `doc`

I'm still fighting a couple of known odd cases:
`v -v<tab>` -> `bash: syntax error near unexpected token '('`
`v -V<tab>` -> `V: command not found`
`v -version<tab>` -> `V: command not found`
`v --version<tab>` -> `V: command not found`
I'm puzzled why the bugs only shows when the version is involved.

One more odd one is:
`v --enable-globals<tab>` -> `--enable-globals` flag is deprecated, please use `-enable-globals` instead`

To see the output returned it's clear that something is wrong:
Running: `v complete bash v -v` gives:
```
launch_tool vexe        : /home/lmp/Projects/v/v
launch_tool vroot       : /home/lmp/Projects/v
launch_tool tool_source : /home/lmp/Projects/v/cmd/tools/vcomplete.v
launch_tool tool_exe    : /home/lmp/Projects/v/cmd/tools/vcomplete
launch_tool tool_args   : 'complete' 'bash' 'v' '-v'
launch_tool should_compile: false
COMPREPLY+=('-version')
```

And running: `v complete bash v -version` gives:
```
V 0.2.4 cbb24d3
```

These aren't the `COMPREPLY('...')` results that the completion script expects.

Whereas running just: `v complete bash v v`
The results look as they should:
```
COMPREPLY+=('vet')
COMPREPLY+=('vlib-docs')
COMPREPLY+=('version')
```

So I suspect something is output via `println` *before* vcomplete returns it's results to the completion script.
I think it might be related to how V launches sub tools or parses commands/flags - if/when this PR is merged I'll open a bug report with the above so we can track it.

Maybe it's enough to let the `launch_tool` output use `std_err` and `v -v` should probably `exit(0)` after it's output? :shrug: 

There's similar symptoms in the current `vcomplete` command also - which I suspect is caused by the same source.