### PR TITLE
cgen: fix error for struct field array index (fix #14394)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -172,8 +172,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	}
 	// `vals[i].field = x` is an exception and requires `array_get`:
 	// `(*(Val*)array_get(vals, i)).field = x;`
-	is_selector := node.left is ast.SelectorExpr
-	if g.is_assign_lhs && !is_selector && node.is_setter {
+	if g.is_assign_lhs && node.is_setter {
 		is_direct_array_access := (g.fn_decl != 0 && g.fn_decl.is_direct_arr) || node.is_direct
 		is_op_assign := g.assign_op != .assign && info.elem_type != ast.string_type
 		if is_direct_array_access {

--- a/vlib/v/tests/struct_field_array_index_test.v
+++ b/vlib/v/tests/struct_field_array_index_test.v
@@ -1,0 +1,17 @@
+struct App {
+mut:
+	buffer []string
+}
+
+fn test_struct_field_array_index() {
+	mut app := &App{
+		buffer: []string{len: 2}
+	}
+
+	app.buffer[0] += 'hello'
+	app.buffer[1] += 'world'
+
+	println(app)
+
+	assert app.buffer == ['hello', 'world']
+}


### PR DESCRIPTION
This PR fix error for struct field array index (fix #14394).

- Fix error for struct field array index.
- Add test.

```v
struct App {
mut:
	buffer []string
}

fn main() {
	mut app := &App{
		buffer: []string{len: 2}
	}

	app.buffer[0] += 'hello'
	app.buffer[1] += 'world'

	println(app)

	assert app.buffer == ['hello', 'world']
}

PS D:\Test\v\tt1> v run .
&App{
    buffer: ['hello', 'world']
}
```
```v
import term.ui as tui
import term

struct App {
mut:
	tui    &tui.Context = 0
	buffer []string
	cursor term.Coord
}

fn event(e &tui.Event, x voidptr) {
	mut app := &App(x)

	if e.typ == .key_down {
		app.buffer[app.cursor.y] += e.utf8
	}
}

fn main() {
	mut app := &App{
		buffer: []string{}
	}
	app.tui = tui.init(
		user_data: app
		event_fn: event
		hide_cursor: false
	)
	app.tui.run()?
}

PS D:\Test\v\tt1> v run .
PS D:\Test\v\tt1>
```