### PR TITLE
builder: perfect error message (fix #14386)

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -556,7 +556,9 @@ pub fn (mut b Builder) print_warnings_and_errors() {
 				}
 			}
 			if redefines.len > 0 {
-				eprintln('builder error: redefinition of function `$fn_name`')
+				ferror := util.formatted_error('builder error:', 'redefinition of function `$fn_name`',
+					'', token.Pos{})
+				eprintln(ferror)
 				for redefine in redefines {
 					eprintln(util.formatted_error('conflicting declaration:', redefine.fheader,
 						redefine.fpath, redefine.f.pos))

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -556,7 +556,7 @@ pub fn (mut b Builder) print_warnings_and_errors() {
 				}
 			}
 			if redefines.len > 0 {
-				eprintln('redefinition of function `$fn_name`')
+				eprintln('builder error: redefinition of function `$fn_name`')
 				for redefine in redefines {
 					eprintln(util.formatted_error('conflicting declaration:', redefine.fheader,
 						redefine.fpath, redefine.f.pos))

--- a/vlib/v/checker/tests/fn_duplicate.out
+++ b/vlib/v/checker/tests/fn_duplicate.out
@@ -1,13 +1,12 @@
-redefinition of function `main.f`
+builder error: redefinition of function `main.f`
 vlib/v/checker/tests/fn_duplicate.vv:1:1: conflicting declaration: fn f()
     1 | fn f() {
       | ~~~~~~
-    2 |     
-    3 | }
-vlib/v/checker/tests/fn_duplicate.vv:5:1: conflicting declaration: fn f(i int)
-    3 | }
-    4 | 
-    5 | fn f(i int) {
+    2 | }
+    3 |
+vlib/v/checker/tests/fn_duplicate.vv:4:1: conflicting declaration: fn f(i int)
+    2 | }
+    3 |
+    4 | fn f(i int) {
       | ~~~~~~~~~~~
-    6 |     
-    7 | }
+    5 | }

--- a/vlib/v/checker/tests/fn_duplicate.out
+++ b/vlib/v/checker/tests/fn_duplicate.out
@@ -1,4 +1,4 @@
-builder error: redefinition of function `main.f`
+builder error: redefinition of function `f`
 vlib/v/checker/tests/fn_duplicate.vv:1:1: conflicting declaration: fn f()
     1 | fn f() {
       | ~~~~~~

--- a/vlib/v/checker/tests/fn_duplicate.vv
+++ b/vlib/v/checker/tests/fn_duplicate.vv
@@ -1,7 +1,5 @@
 fn f() {
-	
 }
 
 fn f(i int) {
-	
 }

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -86,14 +86,18 @@ pub fn formatted_error(kind string, omsg string, filepath string, pos token.Pos)
 			path = path.replace_once(util.normalised_workdir, '')
 		}
 	}
-	//
-	position := '$path:${pos.line_nr + 1}:${mu.max(1, pos.col + 1)}:'
+
+	position := if filepath.len > 0 {
+		'$path:${pos.line_nr + 1}:${mu.max(1, pos.col + 1)}:'
+	} else {
+		''
+	}
 	scontext := source_file_context(kind, filepath, pos).join('\n')
 	final_position := bold(position)
 	final_kind := bold(color(kind, kind))
 	final_msg := emsg
 	final_context := if scontext.len > 0 { '\n$scontext' } else { '' }
-	//
+
 	return '$final_position $final_kind $final_msg$final_context'.trim_space()
 }
 


### PR DESCRIPTION
This PR perfect error message (fix #14386).

- Perfect error message.
- Modify test.

```v
module main

fn main() {
	say_something()
}

pub fn say_something(yo string) {

	println('yo with arg')
}


pub fn say_something() {

	println('yo')
}

PS D:\Test\v\tt1> v run .
 builder error: redefinition of function `say_something`
./tt1.v:7:1: conflicting declaration: pub fn say_something(yo string)
    5 | }
    6 |
    7 | pub fn say_something(yo string) {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    8 |
    9 |     println('yo with arg')
./tt1.v:13:1: conflicting declaration: pub fn say_something()
   11 |
   12 |
   13 | pub fn say_something() {
      | ~~~~~~~~~~~~~~~~~~~~~~
   14 |
   15 |     println('yo')
```
![image](https://user-images.githubusercontent.com/6949593/168737331-e1cb10d7-f8e9-4979-bcf9-3f012b2febfb.png)
