### PR TITLE
parser: fix panic for parse invalid map type (fix #14425)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -113,12 +113,12 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 	}
 	p.check(.lsbr)
 	key_type := p.parse_type()
-	key_sym := p.table.sym(key_type)
-	is_alias := key_sym.kind == .alias
 	if key_type.idx() == 0 {
 		// error is reported in parse_type
 		return 0
 	}
+	key_sym := p.table.sym(key_type)
+	is_alias := key_sym.kind == .alias
 	key_type_supported := key_type in [ast.string_type_idx, ast.voidptr_type_idx]
 		|| key_sym.kind in [.enum_, .placeholder, .any]
 		|| ((key_type.is_int() || key_type.is_float() || is_alias) && !key_type.is_ptr())

--- a/vlib/v/tests/parse_invalid_map_type_test.v
+++ b/vlib/v/tests/parse_invalid_map_type_test.v
@@ -1,0 +1,13 @@
+import v.ast
+import v.parser
+import v.pref
+
+fn test_parser_map_type() {
+	result := parser.parse_text('a := map[*Node]bool', '', ast.new_table(), .parse_comments,
+		&pref.Preferences{
+		output_mode: .silent
+		is_fmt: true
+	})
+	println(result)
+	assert true
+}


### PR DESCRIPTION
This PR fix panic for parse invalid map type (fix #14425).

- Fix panic for parse invalid map type.
- Add test.

```v
import v.ast
import v.parser
import v.pref

fn main() {
	result := parser.parse_text('a := map[*Node]bool', '', ast.new_table(), .parse_comments,
		&pref.Preferences{
		output_mode: .silent
		is_fmt: true
	})
	println(result)
	assert true
}

PS D:\Test\v\tt1> v run .
&v.ast.File{
    nr_lines: 0
    nr_bytes: 19
    mod: v.ast.Module{
        name: 'main'
        short_name: 'main'
        attrs: []
        pos: v.token.Pos{
            len: 0
            line_nr: 0
            pos: 0
            col: 0
            last_line: 0
        }
        name_pos: v.token.Pos{
            len: 0
            line_nr: 0
            pos: 0
            col: 0
            last_line: 0
        }
        is_skipped: true
    }
    global_scope: &# 0 - 0

    is_test: false
    is_generated: false
    is_translated: false
    idx: 0
    path: ''
    path_base: '.'
    scope: &# 0 - 19
  * var: a - ast.Type(0x0 = 0)

    stmts: [module main, a := map{  }, Node, ast.NodeError, [unhandled stmt str type: v.ast.NodeError ]]
    imports: []
    auto_imports: []
    embedded_files: []
    imported_symbols: {}
    errors: [v.errors.Error{
        details: ''
        file_path: ''
        backtrace: ''
        message: 'use `&Type` instead of `*Type` when declaring references'
        pos: v.token.Pos{
            len: 1
            line_nr: 0
            pos: 9
            col: 9
            last_line: 0
        }
        reporter: parser
    }, v.errors.Error{
        details: ''
        file_path: ''
        backtrace: ''
        message: 'invalid expression: unexpected token `]`'
        pos: v.token.Pos{
            len: 1
            line_nr: 0
            pos: 14
            col: 14
            last_line: 0
        }
        reporter: parser
    }, v.errors.Error{
        details: ''
        file_path: ''
        backtrace: ''
        message: '`bool` evaluated but not used'
        pos: v.token.Pos{
            len: 4
            line_nr: 0
            pos: 15
            col: 15
            last_line: 0
        }
        reporter: parser
    }]
    warnings: []
    notices: []
    generic_fns: []
    global_labels: []
}
```