### PR TITLE
cgen: fix alias of array that has builtin method (fix #14422)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -941,7 +941,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if left_sym.kind == .map && node.name in ['clone', 'move'] {
 		receiver_type_name = 'map'
 	}
-	if final_left_sym.kind == .array
+	if final_left_sym.kind == .array && !(left_sym.kind == .alias && left_sym.has_method(node.name))
 		&& node.name in ['repeat', 'sort_with_compare', 'free', 'push_many', 'trim', 'first', 'last', 'pop', 'clone', 'reverse', 'slice', 'pointers'] {
 		if !(left_sym.info is ast.Alias && typ_sym.has_method(node.name)) {
 			// `array_Xyz_clone` => `array_clone`

--- a/vlib/v/tests/alias_array_has_method_test.v
+++ b/vlib/v/tests/alias_array_has_method_test.v
@@ -1,0 +1,11 @@
+type Alias = []int
+
+fn (a Alias) last() int {
+	return 22
+}
+
+fn test_alias_array_has_method() {
+	ret := Alias([0]).last()
+	println(ret)
+	assert ret == 22
+}


### PR DESCRIPTION
This PR fix alias of array that has builtin method (fix #14422).

- Fix alias of array that has builtin method.
- Add test.

```v
type Alias = []int

fn (a Alias) last() int {
	return 22
}

fn main() {
	ret := Alias([0]).last()
	println(ret)
	assert ret == 22
}

PS D:\Test\v\tt1> v run .
22
```