### PR TITLE
builtin: printing libbacktrace to stderr when printing panics/segfault crash

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -55,7 +55,7 @@ fn panic_debug(line_no int, file string, mod string, fn_name string, s string) {
 				C.exit(1)
 			}
 			$if use_libbacktrace ? {
-				print_libbacktrace(1)
+				eprint_libbacktrace(1)
 			} $else {
 				print_backtrace_skipping_top_frames(1)
 			}
@@ -106,7 +106,7 @@ pub fn panic(s string) {
 				C.exit(1)
 			}
 			$if use_libbacktrace ? {
-				print_libbacktrace(1)
+				eprint_libbacktrace(1)
 			} $else {
 				print_backtrace_skipping_top_frames(1)
 			}

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -130,6 +130,10 @@ pub:
 [markused]
 fn v_segmentation_fault_handler(signal int) {
 	eprintln('signal 11: segmentation fault')
-	print_backtrace()
+	$if use_libbacktrace ? {
+		eprint_libbacktrace(1)
+	} $else {
+		print_backtrace()
+	}
 	exit(128 + 11)
 }

--- a/vlib/builtin/builtin_notd_use_libbacktrace.c.v
+++ b/vlib/builtin/builtin_notd_use_libbacktrace.c.v
@@ -2,3 +2,7 @@ module builtin
 
 fn print_libbacktrace(frames_to_skip int) {
 }
+
+[noinline]
+fn eprint_libbacktrace(frames_to_skip int) {
+}


### PR DESCRIPTION
This PR adds a new variant of print_libbacktrace, named `eprint_libbacktrace` which prints the backtrace to stderr instead of the usual stdin. 

This is meant for some applications such as [VLS](https://github.com/vlang/vls) where crash reports depend on outputs in the stderr pipe.