### PR TITLE
cgen: fix error for 'in array of sumtype' (fix #14439)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -382,7 +382,8 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 	if right.unaliased_sym.kind == .array {
 		if left.sym.kind in [.sum_type, .interface_] {
 			if node.right is ast.ArrayInit {
-				if node.right.exprs.len > 0 {
+				if node.right.exprs.len > 0
+					&& g.table.sym(node.right.expr_types[0]).kind !in [.sum_type, .interface_] {
 					mut infix_exprs := []ast.InfixExpr{}
 					for i in 0 .. node.right.exprs.len {
 						infix_exprs << ast.InfixExpr{

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -309,3 +309,10 @@ fn test_in_alias_array() {
 	assert Str('') in [Str(''), Str('a')]
 	assert Struct{} == Struct{}
 }
+
+type TokenValue = rune | u64
+
+fn test_in_array_of_sumtype() {
+	val := TokenValue(`+`)
+	assert val in [TokenValue(`+`), TokenValue(`-`)]
+}


### PR DESCRIPTION
This PR fix error for 'in array of sumtype' (fix #14439).

- Fix error for 'in array of sumtype'.
- Add test.

```v
type TokenValue = rune | u64

fn main() {
	val := TokenValue(`+`)
	if val in [TokenValue(`+`), TokenValue(`-`)] {
		println("ok")
	}
}

PS D:\Test\v\tt1> v run .
ok
```