### PR TITLE
cgen: fix another error for 'in array of sumtype'  (fix #14439)

### DIFF
--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -312,7 +312,10 @@ fn test_in_alias_array() {
 
 type TokenValue = rune | u64
 
-fn test_in_array_of_sumtype() {
-	val := TokenValue(`+`)
-	assert val in [TokenValue(`+`), TokenValue(`-`)]
+fn test_in_array_literal_of_sumtype() {
+	val1 := TokenValue(`+`)
+	assert val1 in [TokenValue(`+`), TokenValue(`-`)]
+
+	val2 := `+`
+	assert val2 in [TokenValue(`+`), TokenValue(`-`)]
 }


### PR DESCRIPTION
This PR fix another error for 'in array of sumtype'  (fix #14439).

- Fix another error for 'in array of sumtype'.
- Add test.

```v
type TokenValue = rune | u64

fn main() {
	val := `+`
	if val in [TokenValue(`+`), TokenValue(`-`)] {
		println("ok")
	}
}

PS D:\Test\v\tt1> v run .
ok
```