### PR TITLE
parser: fix 'val in array' as condition in for stmt (fix #14440)

### DIFF
--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -82,7 +82,8 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.close_scope()
 		return for_c_stmt
-	} else if p.peek_tok.kind in [.key_in, .comma]
+	} else if (p.peek_tok.kind in [.key_in, .comma] && !(p.tok.kind == .name
+		&& p.peek_tok.kind == .key_in && p.scope.known_var(p.tok.lit)))
 		|| (p.tok.kind == .key_mut && p.peek_token(2).kind in [.key_in, .comma]) {
 		// `for i in vals`, `for i in start .. end`, `for mut user in users`, `for i, mut user in users`
 		mut val_is_mut := p.tok.kind == .key_mut

--- a/vlib/v/tests/for_cond_test.v
+++ b/vlib/v/tests/for_cond_test.v
@@ -1,0 +1,10 @@
+type TokenValue = rune | u64
+
+fn test_for_cond() {
+	val := `+`
+	for val in [TokenValue(`+`), TokenValue(`-`)] {
+		println("ok")
+		break
+	}
+	assert true
+}

--- a/vlib/v/tests/for_cond_test.v
+++ b/vlib/v/tests/for_cond_test.v
@@ -3,7 +3,7 @@ type TokenValue = rune | u64
 fn test_for_cond() {
 	val := `+`
 	for val in [TokenValue(`+`), TokenValue(`-`)] {
-		println("ok")
+		println('ok')
 		break
 	}
 	assert true


### PR DESCRIPTION
This PR fix 'val in array' as condition in for stmt (fix #14440).

- Fix 'val in array' as condition in for stmt.
- Add test.

```v
type TokenValue = rune | u64

fn main() {
	val := `+`
	for val in [TokenValue(`+`), TokenValue(`-`)] {
		println("ok")
		break
	}
}

PS D:\Test\v\tt1> v run .
ok
```