### PR TITLE
parser: improve error messages of 'for val in array'

### DIFF
--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -125,7 +125,8 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 				is_stack_obj: true
 			})
 		} else if p.scope.known_var(val_var_name) {
-			return p.error('redefinition of value iteration variable `$val_var_name`')
+			return p.error_with_pos('redefinition of value iteration variable `$val_var_name`, use `for ($val_var_name in array) {` if you want to check for a condition instead',
+				val_var_pos)
 		}
 		p.check(.key_in)
 		if p.tok.kind == .name && p.tok.lit in [key_var_name, val_var_name] {

--- a/vlib/v/parser/tests/for_val_in_array_err.out
+++ b/vlib/v/parser/tests/for_val_in_array_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/for_val_in_array_err.vv:5:6: error: redefinition of value iteration variable `val`, use `for (val in array) {` if you want to check for a condition instead
+    3 | fn main() {
+    4 |     val := `+`
+    5 |     for val in [TokenValue(`+`), TokenValue(`-`)] {
+      |         ~~~
+    6 |         println("ok")
+    7 |         break

--- a/vlib/v/parser/tests/for_val_in_array_err.vv
+++ b/vlib/v/parser/tests/for_val_in_array_err.vv
@@ -1,0 +1,9 @@
+type TokenValue = rune | u64
+
+fn main() {
+	val := `+`
+	for val in [TokenValue(`+`), TokenValue(`-`)] {
+		println("ok")
+		break
+	}
+}


### PR DESCRIPTION
This PR improve error messages of 'for val in array'.

- Improve error messages of 'for val in array'.
- Add test.

```v
type TokenValue = rune | u64

fn main() {
	val := `+`
	for val in [TokenValue(`+`), TokenValue(`-`)] {
		println("ok")
		break
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:5:6: error: redefinition of value iteration variable `val`, use `for (val in array) {` if you want to check for a condition instead
    3 | fn main() {
    4 |     val := `+`
    5 |     for val in [TokenValue(`+`), TokenValue(`-`)] {
      |         ~~~
    6 |         println("ok")
    7 |         break
```