### PR TITLE
fmt: fix fmt error for chain calls with comments (fix #10590)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1639,6 +1639,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 	for arg in node.args {
 		f.comments(arg.comments)
 	}
+	mut is_method_newline := false
 	if node.is_method {
 		if node.name in ['map', 'filter', 'all', 'any'] {
 			f.in_lambda_depth++
@@ -1658,6 +1659,11 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			}
 		}
 		f.expr(node.left)
+		is_method_newline = node.left.pos().last_line != node.name_pos.line_nr
+		if is_method_newline {
+			f.indent++
+			f.writeln('')
+		}
 		f.write('.' + node.name)
 	} else {
 		f.write_language_prefix(node.language)
@@ -1680,6 +1686,9 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 	f.write(')')
 	f.or_expr(node.or_block)
 	f.comments(node.comments, has_nl: false)
+	if is_method_newline {
+		f.indent--
+	}
 }
 
 fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {

--- a/vlib/v/fmt/tests/chain_calls_with_comments_expected.vv
+++ b/vlib/v/fmt/tests/chain_calls_with_comments_expected.vv
@@ -1,0 +1,10 @@
+fn main() {
+	options := cmdline
+		.only_options(args)
+		.filter(it != '-') // options, not including '-'
+		.map(if it.bytes().len > 1 {
+			1
+		})
+
+	println(options)
+}

--- a/vlib/v/fmt/tests/chain_calls_with_comments_input.vv
+++ b/vlib/v/fmt/tests/chain_calls_with_comments_input.vv
@@ -1,0 +1,10 @@
+fn main() {
+	options := cmdline
+                .only_options(args)
+          .filter(it != '-') // options, not including '-'
+              .map(if it.bytes().len>1{
+               1
+          })
+
+	   println(options)
+}


### PR DESCRIPTION
This PR fix fmt error for chain calls with comments (fix #10590).

- Fix fmt error for chain calls with comments.
- Add test.

```v
fn main() {
	options := cmdline
                .only_options(args)
          .filter(it != '-') // options, not including '-'
              .map(if it.bytes().len>1{
               1
          })

	   println(options)
}
```
fmt to:
```v
fn main() {
	options := cmdline
		.only_options(args)
		.filter(it != '-') // options, not including '-'
		.map(if it.bytes().len > 1 {
			1
		})

	println(options)
}
```