### PR TITLE
fmt: fix 'strings' name variable call generate auto import (fix #9713)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1651,7 +1651,9 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			// `time.now()` without `time imported` is processed as a method call with `time` being
 			// a `node.left` expression. Import `time` automatically.
 			// TODO fetch all available modules
-			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64'] {
+			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64']
+				&& !node.left.scope.known_var(node.left.name) {
+				println(node.left)
 				f.file.imports << ast.Import{
 					mod: node.left.name
 					alias: node.left.name

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1653,7 +1653,6 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			// TODO fetch all available modules
 			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64']
 				&& !node.left.scope.known_var(node.left.name) {
-				println(node.left)
 				f.file.imports << ast.Import{
 					mod: node.left.name
 					alias: node.left.name

--- a/vlib/v/fmt/tests/strings_name_variable_call_keep.vv
+++ b/vlib/v/fmt/tests/strings_name_variable_call_keep.vv
@@ -1,0 +1,5 @@
+fn main() {
+	strings := 'hello'
+	a := strings.repeat(2)
+	println(a)
+}


### PR DESCRIPTION
This PR fix 'strings' name variable call generate auto import (fix #9713).

- Fix 'strings' name variable call generate auto import.
- Add test.

```v
fn main() {
	strings := 'hello'
	a := strings.repeat(2)
	println(a)
}
```
fmt to:
```v
fn main() {
	strings := 'hello'
	a := strings.repeat(2)
	println(a)
}
```