### PR TITLE
checker: check method call argument type mismatch (fix #14490)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1463,10 +1463,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 						continue
 					}
 				}
-				if got_arg_typ != ast.void_type {
-					c.error('$err.msg() in argument ${i + 1} to `${left_sym.name}.$method_name`',
-						arg.pos)
-				}
+				c.error('$err.msg() in argument ${i + 1} to `${left_sym.name}.$method_name`',
+					arg.pos)
 			}
 		}
 		if method.is_unsafe && !c.inside_unsafe {

--- a/vlib/v/checker/tests/method_call_arg_mismatch.out
+++ b/vlib/v/checker/tests/method_call_arg_mismatch.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/method_call_arg_mismatch.vv:9:10: error: `baz()` (no value) used as value in argument 1 to `Foo.bar`
+    7 | fn main() {
+    8 |     foo := Foo{}
+    9 |     foo.bar(baz())
+      |             ~~~~~
+   10 | }

--- a/vlib/v/checker/tests/method_call_arg_mismatch.vv
+++ b/vlib/v/checker/tests/method_call_arg_mismatch.vv
@@ -1,0 +1,10 @@
+struct Foo {}
+
+fn (f Foo) bar(baz fn ()) {}
+
+fn baz() {}
+
+fn main() {
+	foo := Foo{}
+	foo.bar(baz())
+}


### PR DESCRIPTION
This PR check method call argument type mismatch (fix #14490).

- Check method call argument type mismatch.
- Add test.

```v
struct Foo {}

fn (f Foo) bar(baz fn ()) {}

fn baz() {}

fn main() {
	foo := Foo{}
	foo.bar(baz())
}

PS D:\Test\v\tt1> v run .
./tt1.v:9:10: error: `baz()` (no value) used as value in argument 1 to `Foo.bar`
    7 | fn main() {
    8 |     foo := Foo{}
    9 |     foo.bar(baz())
      |             ~~~~~
   10 | }
```