### PR TITLE
parser: fix error for sizeof(c'hello') (fix #14499)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5448,8 +5448,12 @@ fn (mut g Gen) size_of(node ast.SizeOf) {
 	if sym.language == .v && sym.kind in [.placeholder, .any] {
 		g.error('unknown type `$sym.name`', node.pos)
 	}
-	styp := g.typ(node_typ)
-	g.write('sizeof(${util.no_dots(styp)})')
+	if node.expr is ast.StringLiteral {
+		g.write('sizeof("${node.expr.val}")')
+	} else {
+		styp := g.typ(node_typ)
+		g.write('sizeof(${util.no_dots(styp)})')
+	}
 }
 
 fn (mut g Gen) enum_val(node ast.EnumVal) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5449,7 +5449,7 @@ fn (mut g Gen) size_of(node ast.SizeOf) {
 		g.error('unknown type `$sym.name`', node.pos)
 	}
 	if node.expr is ast.StringLiteral {
-		g.write('sizeof("${node.expr.val}")')
+		g.write('sizeof("$node.expr.val")')
 	} else {
 		styp := g.typ(node_typ)
 		g.write('sizeof(${util.no_dots(styp)})')

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -202,15 +202,17 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			p.next() // sizeof
 			p.check(.lpar)
 			pos := p.tok.pos()
-			if p.tok.lit in ['c', 'r'] && p.peek_tok.kind == .string {
-				p.next()
-			}
-			is_known_var := p.mark_var_as_used(p.tok.lit)
+			mut is_known_var := p.mark_var_as_used(p.tok.lit)
 				|| p.table.global_scope.known_const(p.mod + '.' + p.tok.lit)
 			//|| p.table.known_fn(p.mod + '.' + p.tok.lit)
 			// assume `mod.` prefix leads to a type
-			is_type := p.known_import(p.tok.lit) || p.tok.kind.is_start_of_type()
+			mut is_type := p.known_import(p.tok.lit) || p.tok.kind.is_start_of_type()
 				|| (p.tok.lit.len > 0 && p.tok.lit[0].is_capital())
+
+			if p.tok.lit in ['c', 'r'] && p.peek_tok.kind == .string {
+				is_known_var = false
+				is_type = false
+			}
 			if is_known_var || !is_type {
 				expr := p.expr(0)
 				if is_reftype {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -202,6 +202,9 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			p.next() // sizeof
 			p.check(.lpar)
 			pos := p.tok.pos()
+			if p.tok.lit in ['c', 'r'] && p.peek_tok.kind == .string {
+				p.next()
+			}
 			is_known_var := p.mark_var_as_used(p.tok.lit)
 				|| p.table.global_scope.known_const(p.mod + '.' + p.tok.lit)
 			//|| p.table.known_fn(p.mod + '.' + p.tok.lit)

--- a/vlib/v/tests/sizeof_test.v
+++ b/vlib/v/tests/sizeof_test.v
@@ -23,4 +23,7 @@ fn test_sizeof() {
 	s := S2{}
 	assert sizeof(s.i) == 4
 	assert sizeof(flag.Flag) > 4
+
+	assert sizeof(c'hello') == 16
+	assert sizeof(r'hello') == 16
 }

--- a/vlib/v/tests/sizeof_test.v
+++ b/vlib/v/tests/sizeof_test.v
@@ -24,6 +24,6 @@ fn test_sizeof() {
 	assert sizeof(s.i) == 4
 	assert sizeof(flag.Flag) > 4
 
-	assert sizeof(c'hello') == 16
-	assert sizeof(r'hello') == 16
+	assert sizeof(c'hello') == 6
+	assert sizeof(r'hello') == 6
 }


### PR DESCRIPTION
This PR fix error for sizeof(c'hello') (fix #14499).

- Fix error for sizeof(c'hello').
- Add test.

```v
fn main() {
	println(sizeof(c'hello'))
	println(sizeof(r'hello'))
}

PS D:\Test\v\tt1> v run .
6
6
```