### PR TITLE
os: add `file_extensions` function

### DIFF
--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -285,5 +285,8 @@ fn is_normal_path(path string) bool {
 }
 
 fn trim_right_slashes(s string) string {
-	return $if windows { s.trim_right('\\/') } $else { s.trim_right(path_separator) }
+	$if windows {
+		return s.trim_right('\\/')
+	}
+	return s.trim_right(path_separator)
 }

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -8,13 +8,13 @@ import strings.textscanner
 // therefore results may be different for certain operating systems.
 
 const (
-	fslash  = `/`
-	bslash  = `\\`
-	dot     = `.`
-	qmark   = `?`
-	dot_dot = '..'
-	empty   = ''
-	dot_str = '.'
+	fslash    = `/`
+	bslash    = `\\`
+	dot       = `.`
+	qmark     = `?`
+	dot_dot   = '..'
+	empty_str = ''
+	dot_str   = '.'
 )
 
 // is_abs_path returns `true` if the given `path` is absolute.
@@ -59,14 +59,14 @@ pub fn abs_path(path string) string {
 [direct_array_access]
 pub fn norm_path(path string) string {
 	if path.len == 0 {
-		return '.'
+		return os.dot_str
 	}
 	rooted := is_abs_path(path)
 	volume := get_volume(path)
 	volume_len := volume.len
 	cpath := clean_path(path[volume_len..])
 	if cpath.len == 0 && volume_len == 0 {
-		return '.'
+		return os.dot_str
 	}
 	spath := cpath.split(path_separator)
 	if os.dot_dot !in spath {
@@ -82,7 +82,7 @@ pub fn norm_path(path string) string {
 	mut backlink_count := 0
 	for i := spath_len - 1; i >= 0; i-- {
 		part := spath[i]
-		if part == os.empty {
+		if part == os.empty_str {
 			continue
 		}
 		if part == os.dot_dot {
@@ -113,7 +113,7 @@ pub fn norm_path(path string) string {
 			return volume
 		}
 		if !rooted {
-			return '.'
+			return os.dot_str
 		}
 		return path_separator
 	}
@@ -121,6 +121,43 @@ pub fn norm_path(path string) string {
 		return volume + res
 	}
 	return res
+}
+
+// file_extensions returns the (file) extensions
+// from the last part of the given `path`.
+[direct_array_access]
+pub fn file_extensions(path string) []string {
+	if path.len == 0 {
+		return []
+	}
+	tpath := trim_right_slashes(path)
+	if tpath.len == 0 {
+		return []
+	}
+	spath := tpath.split(path_separator)
+	last := spath[spath.len - 1]
+	mut extensions := []string{}
+	last_len := last.len
+	mut buf := []u8{cap: last_len}
+	for i := 1; i < last_len; i++ {
+		if last[i] == os.dot && i + 1 < last_len {
+			i++
+			if last[i] == os.dot {
+				continue
+			}
+			buf << last[i - 1]
+			for ; i < last_len; i++ {
+				buf << last[i]
+				if i + 1 < last_len && last[i + 1] != os.dot {
+					continue
+				}
+				extensions << buf.bytestr()
+				buf.clear()
+				break
+			}
+		}
+	}
+	return extensions
 }
 
 // clean_path returns the "cleaned" version of the given `path`
@@ -131,7 +168,7 @@ pub fn norm_path(path string) string {
 // - the last path separator
 fn clean_path(path string) string {
 	if path.len == 0 {
-		return ''
+		return os.empty_str
 	}
 	mut sb := strings.new_builder(path.len)
 	mut sc := textscanner.new(path)
@@ -201,11 +238,11 @@ fn win_volume_len(path string) int {
 
 fn get_volume(path string) string {
 	$if !windows {
-		return ''
+		return os.empty_str
 	}
 	volume := path[..win_volume_len(path)]
 	if volume.len == 0 {
-		return ''
+		return os.empty_str
 	}
 	if volume[0] == os.fslash {
 		return volume.replace('/', '\\')
@@ -245,4 +282,8 @@ fn is_normal_path(path string) bool {
 	}
 	return (plen == 1 && is_slash(path[0])) || (plen >= 2 && is_slash(path[0])
 		&& !is_slash(path[1]))
+}
+
+fn trim_right_slashes(s string) string {
+	return $if windows { s.trim_right('\\/') } $else { s.trim_right(path_separator) }
 }

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -133,7 +133,11 @@ fn test_file_extensions() {
 		assert file_extensions('.') == []
 		assert file_extensions('.git') == []
 		assert file_extensions(r'C:\path\to\file.js.v\\//\/') == ['.js', '.v']
-		assert file_extensions(r'C:\path\to\file.ext1.ext2.ext3...//\\///') == ['.ext1', '.ext2', '.ext3']
+		assert file_extensions(r'C:\path\to\file.ext1.ext2.ext3...//\\///') == [
+			'.ext1',
+			'.ext2',
+			'.ext3',
+		]
 		assert file_extensions('.ignore_me.v') == ['.v']
 		assert file_extensions('') == []
 		return

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -146,6 +146,6 @@ fn test_file_extensions() {
 	assert file_extensions('.git') == []
 	assert file_extensions('/path/to/file.js.v///') == ['.js', '.v']
 	assert file_extensions('.ignore_me.v') == ['.v']
-	assert file_extensions(r'path/to/file.ext1.ext2.ext3...////') == ['.ext1', '.ext2', '.ext3']
+	assert file_extensions('path/to/file.ext1.ext2.ext3...////') == ['.ext1', '.ext2', '.ext3']
 	assert file_extensions('') == []
 }

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -127,3 +127,21 @@ fn test_abs_path() {
 	assert abs_path('path/../file.v/..') == wd
 	assert abs_path('///') == '/'
 }
+
+fn test_file_extensions() {
+	$if windows {
+		assert file_extensions('.') == []
+		assert file_extensions('.git') == []
+		assert file_extensions(r'C:\path\to\file.js.v\\//\/') == ['.js', '.v']
+		assert file_extensions(r'C:\path\to\file.ext1.ext2.ext3...//\\///') == ['.ext1', '.ext2', '.ext3']
+		assert file_extensions('.ignore_me.v') == ['.v']
+		assert file_extensions('') == []
+		return
+	}
+	assert file_extensions('.') == []
+	assert file_extensions('.git') == []
+	assert file_extensions('/path/to/file.js.v///') == ['.js', '.v']
+	assert file_extensions('.ignore_me.v') == ['.v']
+	assert file_extensions(r'path/to/file.ext1.ext2.ext3...////') == ['.ext1', '.ext2', '.ext3']
+	assert file_extensions('') == []
+}


### PR DESCRIPTION
This PR will add the `file_extensions` function to the `os` module.
The `file_extensions` function returns the (file) extensions or suffixes from the last part of the path.

Examples:
```v
assert os.file_extensions('v/vlib/os/file.js.v') == ['.js', '.v']
assert os.file_extensions('.git') == []
assert os.file_extensions('.') == []
assert os.file_extensions('.ignore_me.vsh') == ['.vsh']
```
And i have cleaned up the file `filepath.v` a bit ... :slightly_smiling_face: