### PR TITLE
cgen: fix sizeof('str') and sizeof(r'str')

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5450,11 +5450,13 @@ fn (mut g Gen) size_of(node ast.SizeOf) {
 		g.error('unknown type `$sym.name`', node.pos)
 	}
 	if node.expr is ast.StringLiteral {
-		g.write('sizeof("$node.expr.val")')
-	} else {
-		styp := g.typ(node_typ)
-		g.write('sizeof(${util.no_dots(styp)})')
+		if node.expr.language == .c {
+			g.write('sizeof("$node.expr.val")')
+			return
+		}
 	}
+	styp := g.typ(node_typ)
+	g.write('sizeof(${util.no_dots(styp)})')
 }
 
 fn (mut g Gen) enum_val(node ast.EnumVal) {

--- a/vlib/v/tests/sizeof_test.v
+++ b/vlib/v/tests/sizeof_test.v
@@ -25,5 +25,6 @@ fn test_sizeof() {
 	assert sizeof(flag.Flag) > 4
 
 	assert sizeof(c'hello') == 6
-	assert sizeof(r'hello') == 6
+	assert sizeof(r'hello') == 16
+	assert sizeof('hello') == 16
 }


### PR DESCRIPTION
This PR fix sizeof('str') and sizeof(r'str').

- Fix sizeof('str') and sizeof(r'str').
- Add test.

```v
fn main() {
	println(sizeof(r'hello'))
	println(sizeof(c'hello'))
	println(sizeof('hello'))
}

PS D:\Test\v\tt1> v run .
16
6
16
```