### PR TITLE
parser: check fn decl multi return types without parentheses (fix #14505)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -400,6 +400,11 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		p.inside_fn_return = false
 		return_type_pos = return_type_pos.extend(p.prev_tok.pos())
 	}
+	if p.tok.kind == .comma {
+		mr_pos := return_type_pos.extend(p.peek_tok.pos())
+		p.error_with_pos('multiple return types in function declaration must use parentheses, .e.g (int, string)',
+			mr_pos)
+	}
 	mut type_sym_method_idx := 0
 	no_body := p.tok.kind != .lcbr
 	end_pos := p.prev_tok.pos()

--- a/vlib/v/parser/tests/fn_decl_multi_return_types_err.out
+++ b/vlib/v/parser/tests/fn_decl_multi_return_types_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/fn_decl_multi_return_types_err.vv:4:10: error: multiple return types in function declaration must use parentheses, .e.g (int, string)
+    2 | }
+    3 |
+    4 | fn foo() int, int {
+      |          ~~~~~~~~
+    5 |     return 0, 0
+    6 | }

--- a/vlib/v/parser/tests/fn_decl_multi_return_types_err.vv
+++ b/vlib/v/parser/tests/fn_decl_multi_return_types_err.vv
@@ -1,0 +1,6 @@
+fn main() {
+}
+
+fn foo() int, int {
+	return 0, 0
+}


### PR DESCRIPTION
This PR check fn decl multi return types without parentheses (fix #14505).

- Check fn decl multi return types without parentheses.
- Add test.

```v
fn main() {
}

fn foo() int, int {
	return 0, 0
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:10: error: multiple return types in function declaration must use parentheses, .e.g (int, string)
    2 | }
    3 | 
    4 | fn foo() int, int {
      |          ~~~~~~~~
    5 |     return 0, 0
    6 | }
```