### PR TITLE
fmt: fix file with just imports (fix #14267)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -7,7 +7,6 @@ import strings
 import v.ast
 import v.util
 import v.pref
-import v.mathutil
 
 const (
 	bs      = '\\'
@@ -72,8 +71,11 @@ pub fn fmt(file ast.File, table &ast.Table, pref &pref.Preferences, is_debug boo
 	if res.len == 1 {
 		return f.out_imports.str().trim_space() + '\n'
 	}
-	bounded_import_pos := mathutil.min(res.len, f.import_pos)
-	return res[..bounded_import_pos] + f.out_imports.str() + res[bounded_import_pos..]
+	if res.len <= f.import_pos {
+		return res + '\n' + f.out_imports.str().trim_space() + '\n'
+	} else {
+		return res[..f.import_pos] + f.out_imports.str() + res[f.import_pos..]
+	}
 }
 
 pub fn (mut f Fmt) process_file_imports(file &ast.File) {

--- a/vlib/v/fmt/tests/file_with_just_imports_keep.vv
+++ b/vlib/v/fmt/tests/file_with_just_imports_keep.vv
@@ -1,3 +1,3 @@
 module proto
-import emily33901.vproto
 
+import emily33901.vproto


### PR DESCRIPTION
This PR fix file with just imports (fix #14267).

- Fix file with just imports.
- Modify test.

```v
module main

import os
```
fmt to:
```v
module main

import os
```