### PR TITLE
checker: check fn call with argument mismatch (fix #14514)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -897,15 +897,6 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 		c.check_expected_call_arg(arg_typ, c.unwrap_generic(param.typ), node.language,
 			call_arg) or {
-			// str method, allow type with str method if fn arg is string
-			// Passing an int or a string array produces a c error here
-			// Deleting this condition results in propper V error messages
-			// if arg_typ_sym.kind == .string && typ_sym.has_method('str') {
-			// continue
-			// }
-			if arg_typ_sym.kind == .void && param_typ_sym.kind == .string {
-				continue
-			}
 			if param.typ.has_flag(.generic) {
 				continue
 			}
@@ -990,7 +981,6 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		if func.language != .c && !c.inside_unsafe && arg_typ.nr_muls() != param.typ.nr_muls()
 			&& !(call_arg.is_mut && param.is_mut) && !(!call_arg.is_mut && !param.is_mut)
 			&& param.typ !in [ast.byteptr_type, ast.charptr_type, ast.voidptr_type] {
-			// sym := c.table.sym(typ)
 			c.warn('automatic referencing/dereferencing is deprecated and will be removed soon (got: $arg_typ.nr_muls() references, expected: $param.typ.nr_muls() references)',
 				call_arg.pos)
 		}

--- a/vlib/v/checker/tests/fn_call_arg_mismatch_err_c.out
+++ b/vlib/v/checker/tests/fn_call_arg_mismatch_err_c.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fn_call_arg_mismatch_err_c.vv:13:18: error: `os.chdir(files) ?` (no value) used as value in argument 1 to `os.ls`
+   11 |             println(files)
+   12 |         } else {
+   13 |             println(os.ls(os.chdir(files)?)?)
+      |                           ~~~~~~~~~~~~~~~~
+   14 |         }
+   15 |         println(files)

--- a/vlib/v/checker/tests/fn_call_arg_mismatch_err_c.vv
+++ b/vlib/v/checker/tests/fn_call_arg_mismatch_err_c.vv
@@ -1,0 +1,29 @@
+module main
+
+import os
+
+fn list_files() ?[][]string {
+	mut unchecked_files := os.ls('utilities/modules')?
+	println(unchecked_files)
+	for files in unchecked_files {
+		println(files)
+		if os.is_file(files) == true {
+			println(files)
+		} else {
+			println(os.ls(os.chdir(files)?)?)
+		}
+		println(files)
+	}
+	mut modules := [['Module:', 'Path:', 'Description']]
+	return modules
+}
+
+fn main() {
+	mut data := [
+		['Module:', 'Path:', 'Description'],
+	]
+	mods := list_files() or { [['null', 'null', 'null']] }
+	for _, mod in mods {
+		data << mod
+	}
+}


### PR DESCRIPTION
This PR check fn call with argument mismatch (fix #14514).

- Check fn call with argument mismatch.
- Add test.

```v
module main

import os

fn list_files() ?[][]string {
	mut unchecked_files := os.ls('utilities/modules')?
	println(unchecked_files)
	for files in unchecked_files {
		println(files)
		if os.is_file(files) == true {
			println(files)
		} else {
			println(os.ls(os.chdir(files)?)?)
		}
		println(files)
	}
	mut modules := [['Module:', 'Path:', 'Description']]
	return modules
}

fn main() {
	mut data := [
		['Module:', 'Path:', 'Description'],
	]
	mods := list_files() or { [['null', 'null', 'null']] }
	for _, mod in mods {
		data << mod
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:13:18: error: `os.chdir(files) ?` (no value) used as value in argument 1 to `os.ls`
   11 |             println(files)
   12 |         } else {
   13 |             println(os.ls(os.chdir(files)?)?)
      |                           ~~~~~~~~~~~~~~~~
   14 |         }
   15 |         println(files)
```