### PR TITLE
parser: fix fmt error for json decode (fix #10175)

### DIFF
--- a/vlib/v/fmt/tests/json_decode_fmt_keep.vv
+++ b/vlib/v/fmt/tests/json_decode_fmt_keep.vv
@@ -1,0 +1,19 @@
+import json
+
+struct Request {
+	a int
+}
+
+fn parse(s string) ?Request {
+	return json.decode(Request, s)
+}
+
+fn parse2(s string) ?Request {
+	req := json.decode(Request, s)?
+	return req
+}
+
+fn main() {
+	println(parse('{"a": 22} ')?)
+	println(parse2('{"a": 22} ')?)
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -24,7 +24,6 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 	mut or_kind := ast.OrKind.absent
 	if fn_name == 'json.decode' {
 		p.expecting_type = true // Makes name_expr() parse the type `User` in `json.decode(User, txt)`
-		or_kind = .block
 	}
 
 	old_expr_mod := p.expr_mod


### PR DESCRIPTION
This PR fix fmt error for json decode (fix #10175).

- Fix fmt error for json decode.
- Add test.

```v
import json

struct Request {
	a int
}

fn parse(s string) ?Request {
	return json.decode(Request, s)
}

fn parse2(s string) ?Request {
	req := json.decode(Request, s)?
	return req
}

fn main() {
	println(parse('{"a": 22} ')?)
	println(parse2('{"a": 22} ')?)
}
```
keep fmt.