### PR TITLE
fmt: fix fmt of Ok<[]Token>{[]} (fix #13852)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -249,7 +249,7 @@ pub fn (mut f Fmt) short_module(name string) string {
 		}
 	}
 	if aname == '' {
-		return symname
+		return '$tprefix$symname'
 	}
 	return '$tprefix${aname}.$symname'
 }

--- a/vlib/v/fmt/tests/generic_struct_init_keep.vv
+++ b/vlib/v/fmt/tests/generic_struct_init_keep.vv
@@ -1,0 +1,9 @@
+module x
+
+struct Ok<T> {
+	foo []T
+}
+
+fn test_fmt() {
+	r := Ok<[]Token>{[]}
+}


### PR DESCRIPTION
This PR fix fmt of Ok<[]Token>{[]} (fix #13852).

- Fix fmt of Ok<[]Token>{[]}.
- Add test.

```v
module x

struct Ok<T> {
	foo []T
}

fn test_fmt() {
	r := Ok<[]Token>{[]}
}
```
vfmt keep.