### PR TITLE
embed_file: rename debug_embed_file_in_prod -> force_embed_file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,6 @@ to create a copy of the compiler rather than replacing it with `v self`.
 | `debug_codegen` | Prints automatically generated V code during the scanning phase |
 | `debug_interface_table` | Prints generated interfaces during C generation |
 | `debug_interface_type_implements` | Prints debug information when checking that a type implements in interface |
-| `force_embed_file` | Force embedding and prints debug information about the embedded file(s) with `$embed_file('somefile')` |
 | `print_vweb_template_expansions` | Prints vweb compiled HTML files |
 | `time_checking` | Prints the time spent checking files and other related information |
 | `time_parsing` | Prints the time spent parsing files and other related information |
@@ -204,3 +203,4 @@ to create a copy of the compiler rather than replacing it with `v self`.
 | `trace_thirdparty_obj_files` | Prints details about built thirdparty obj files |
 | `trace_usecache` | Prints details when -usecache is used |
 | `trace_embed_file` | Prints details when $embed_file is used |
+| `force_embed_file` | Force embedding of file(s) with `$embed_file('somefile')` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ to create a copy of the compiler rather than replacing it with `v self`.
 | `debug_codegen` | Prints automatically generated V code during the scanning phase |
 | `debug_interface_table` | Prints generated interfaces during C generation |
 | `debug_interface_type_implements` | Prints debug information when checking that a type implements in interface |
-| `debug_embed_file_in_prod` | Prints debug information about the embedded files with `$embed_file('somefile')` |
+| `force_embed_file` | Force embedding and prints debug information about the embedded file(s) with `$embed_file('somefile')` |
 | `print_vweb_template_expansions` | Prints vweb compiled HTML files |
 | `time_checking` | Prints the time spent checking files and other related information |
 | `time_parsing` | Prints the time spent parsing files and other related information |

--- a/vlib/v/embed_file/embed_file.v
+++ b/vlib/v/embed_file/embed_file.v
@@ -112,7 +112,7 @@ pub fn find_index_entry_by_path(start voidptr, path string, algo string) &EmbedF
 		}
 	}
 	$if trace_embed_file ? {
-		eprintln('>> v.embed_file (forced embedding) find_index_entry_by_path ${ptr_str(start)}, id: $x.id, path: "$path", algo: "$algo" => ${ptr_str(x)}')
+		eprintln('>> v.embed_file find_index_entry_by_path ${ptr_str(start)}, id: $x.id, path: "$path", algo: "$algo" => ${ptr_str(x)}')
 	}
 	return x
 }

--- a/vlib/v/embed_file/embed_file.v
+++ b/vlib/v/embed_file/embed_file.v
@@ -111,8 +111,8 @@ pub fn find_index_entry_by_path(start voidptr, path string, algo string) &EmbedF
 			x++
 		}
 	}
-	$if debug_embed_file_in_prod ? {
-		eprintln('>> v.embed_file find_index_entry_by_path ${ptr_str(start)}, id: $x.id, path: "$path", algo: "$algo" => ${ptr_str(x)}')
+	$if force_embed_file ? {
+		eprintln('>> v.embed_file (forced embedding) find_index_entry_by_path ${ptr_str(start)}, id: $x.id, path: "$path", algo: "$algo" => ${ptr_str(x)}')
 	}
 	return x
 }

--- a/vlib/v/embed_file/embed_file.v
+++ b/vlib/v/embed_file/embed_file.v
@@ -111,7 +111,7 @@ pub fn find_index_entry_by_path(start voidptr, path string, algo string) &EmbedF
 			x++
 		}
 	}
-	$if force_embed_file ? {
+	$if trace_embed_file ? {
 		eprintln('>> v.embed_file (forced embedding) find_index_entry_by_path ${ptr_str(start)}, id: $x.id, path: "$path", algo: "$algo" => ${ptr_str(x)}')
 	}
 	return x

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -6,7 +6,7 @@ import v.ast
 import v.pref
 
 fn (mut g Gen) embed_file_is_prod_mode() bool {
-	if g.pref.is_prod || 'debug_embed_file_in_prod' in g.pref.compile_defines {
+	if g.pref.is_prod || 'force_embed_file' in g.pref.compile_defines {
 		return true
 	}
 	return false

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -165,7 +165,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 		}
 		p.register_auto_import('v.preludes.embed_file')
 		if embed_compression_type == 'zlib'
-			&& (p.pref.is_prod || 'debug_embed_file_in_prod' in p.pref.compile_defines) {
+			&& (p.pref.is_prod || 'force_embed_file' in p.pref.compile_defines) {
 			p.register_auto_import('v.preludes.embed_file.zlib')
 		}
 		return ast.ComptimeCall{


### PR DESCRIPTION
As discussed on Discord and in #14430.

~~I think an additional *dedicated* debug flag (for the debug print) might be overkill in this case.~~
(Edit: see comments below)