### PR TITLE
fmt: fix fn return types list ending with comma (fix #13592)

### DIFF
--- a/vlib/v/fmt/tests/fn_types_list_ending_with_comma_expected.vv
+++ b/vlib/v/fmt/tests/fn_types_list_ending_with_comma_expected.vv
@@ -1,0 +1,5 @@
+fn ok(a int) (int, string) {
+	return 11, 'hello'
+}
+
+fn main() {}

--- a/vlib/v/fmt/tests/fn_types_list_ending_with_comma_input.vv
+++ b/vlib/v/fmt/tests/fn_types_list_ending_with_comma_input.vv
@@ -1,0 +1,5 @@
+fn ok(a int,) (int, string,) {
+	return 11, 'hello'
+}
+
+fn main() {}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -198,7 +198,7 @@ pub fn (mut p Parser) parse_multi_return_type() ast.Type {
 	p.check(.lpar)
 	mut mr_types := []ast.Type{}
 	mut has_generic := false
-	for p.tok.kind != .eof {
+	for p.tok.kind !in [.eof, .rpar] {
 		mr_type := p.parse_type()
 		if mr_type.idx() == 0 {
 			break


### PR DESCRIPTION
This PR fix fn return types list ending with comma (fix #13592).

- Fix fn return types list ending with comma.
- Add test.

```v
fn ok(a int,) (int, string,) {
	return 11, 'hello'
}

fn main() {}
```
fmt to:
```v
fn ok(a int) (int, string) {
	return 11, 'hello'
}

fn main() {}
```