### PR TITLE
os: add existing_path function

### DIFF
--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -154,6 +154,17 @@ pub fn existing_path(path string) string {
 }
 
 // logical_path_parts returns the logical parts of the given `path`.
+// Examples:
+// on a unix-based system:
+// ```v
+// assert os.logical_path_parts('/path/to/file.v') == ['/', '/path', '/path/to', '/path/to/file.v']
+// assert os.logical_path_parts('path/to/file.v') == ['path', 'path/to', 'path/to/file.v']
+// ```
+// on a Windows system:
+// ```v
+// assert os.logical_path_parts(r'C:\path\to\file.v') == ['C:\\', 'C:\\path', r'C:\path\to', r'C:\path\to\file.v']
+// assert os.logical_path_parts(r'C:path\to\file.v') == ['C:', 'C:path', 'C:path\\to', r'C:path\to\file.v']
+// ```
 [direct_array_access]
 fn logical_path_parts(path string) []string {
 	if path.len == 0 {

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -145,7 +145,7 @@ pub fn existing_path(path string) string {
 	for i, part in parts {
 		if !exists(part) {
 			if i - 1 < 0 {
-				return os.empty_str
+				break
 			}
 			return parts[i - 1]
 		}

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -133,7 +133,10 @@ pub fn existing_path(path string) ?string {
 	if exists(path) {
 		return path
 	}
-	mut volume_len := $if windows { win_volume_len(path) } $else { 0 }
+	mut volume_len := 0
+	$if windows {
+		volume_len = win_volume_len(path)
+	}
 	if volume_len > 0 && is_slash(path[volume_len - 1]) {
 		volume_len++
 	}

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -130,16 +130,7 @@ pub fn existing_path(path string) string {
 		return os.empty_str
 	}
 	if exists(path) {
-		volume := get_volume(path)
-		volume_len := volume.len
-		cpath := clean_path(path[volume_len..])
-		if volume_len == 0 {
-			return cpath
-		}
-		if cpath.len != 0 {
-			return volume + cpath
-		}
-		return volume
+		return path
 	}
 	parts := logical_path_parts(path)
 	for i, part in parts {

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -34,16 +34,16 @@ fn test_clean_path() {
 		assert clean_path(r'\/\//\/') == '\\'
 		assert clean_path(r'./path\\dir/\\./\/\\/file.v\.\\\.') == r'path\dir\file.v'
 		assert clean_path(r'\./path/dir\\file.exe') == r'\path\dir\file.exe'
-		assert clean_path(r'.') == '.'
-		assert clean_path(r'./') == '.'
+		assert clean_path(r'.') == ''
+		assert clean_path(r'./') == ''
 		assert clean_path(r'\./') == '\\'
 		assert clean_path(r'//\/\/////') == '\\'
 		return
 	}
 	assert clean_path('./../.././././//') == '../..'
-	assert clean_path('.') == '.'
+	assert clean_path('') == ''
 	assert clean_path('./path/to/file.v//./') == 'path/to/file.v'
-	assert clean_path('./') == '.'
+	assert clean_path('./') == ''
 	assert clean_path('/.') == '/'
 	assert clean_path('//path/./to/.///files/file.v///') == '/path/to/files/file.v'
 	assert clean_path('path/./to/.///files/.././file.v///') == 'path/to/files/../file.v'
@@ -131,43 +131,22 @@ fn test_abs_path() {
 fn test_existing_path() {
 	wd := getwd()
 	$if windows {
-		assert existing_path('') == ''
-		assert existing_path('..') == '..'
-		assert existing_path('.') == '.'
-		assert existing_path(wd) == wd
-		assert existing_path('$wd\\does/not/exist\\.\\') == wd
-		assert existing_path('$wd\\\\/\\.\\.\\/.') == wd
+		assert existing_path('') or { '' } == ''
+		assert existing_path('..') or { '' } == '..'
+		assert existing_path('.') or { '' } == '.'
+		assert existing_path(wd) or { '' } == wd
+		assert existing_path('\\') or { '' } == '\\'
+		assert existing_path('$wd\\.\\\\does/not/exist\\.\\') or { '' } == '$wd\\.\\\\'
+		assert existing_path('$wd\\\\/\\.\\.\\/.') or { '' } == '$wd\\\\/\\.\\.\\/.'
+		assert existing_path('$wd\\././/\\/oh') or { '' } == '$wd\\././/\\/'
 		return
 	}
-	assert existing_path('') == ''
-	assert existing_path('..') == '..'
-	assert existing_path('.') == '.'
-	assert existing_path(wd) == wd
-	assert existing_path('$wd/does/.///not/exist///.//') == wd
-	assert existing_path('$wd/does/././/.//') == wd
-}
-
-fn test_logical_path_parts() {
-	$if windows {
-		assert logical_path_parts('.') == ['.']
-		assert logical_path_parts('..') == ['..']
-		assert logical_path_parts('\\') == ['\\']
-		assert logical_path_parts('\\\\') == ['\\']
-		assert logical_path_parts(r'\dir\text.txt\./\.') == ['\\', '\\dir', '\\dir\\text.txt']
-		assert logical_path_parts(r'C:\path/to/file.v') == ['C:\\', 'C:\\path', r'C:\path\to',
-			r'C:\path\to\file.v']
-		assert logical_path_parts(r'\\.\C:\path\.\to\file.v') == [r'\\.\C:\', r'\\.\C:\path',
-			r'\\.\C:\path\to', r'\\.\C:\path\to\file.v']
-		return
-	}
-	assert logical_path_parts('/path/to/.///file.v/.') == ['/', '/path', '/path/to',
-		'/path/to/file.v']
-	assert logical_path_parts('path/../dir//./') == ['path', 'path/..', 'path/../dir']
-	assert logical_path_parts('path/to/dir/files/file.v.///.') == ['path', 'path/to', 'path/to/dir',
-		'path/to/dir/files', 'path/to/dir/files/file.v.']
-	assert logical_path_parts('.') == ['.']
-	assert logical_path_parts('..') == ['..']
-	assert logical_path_parts('/') == ['/']
-	assert logical_path_parts('////./') == ['/']
-	assert logical_path_parts('./') == ['.']
+	assert existing_path('') or { '' } == ''
+	assert existing_path('..') or { '' } == '..'
+	assert existing_path('.') or { '' } == '.'
+	assert existing_path(wd) or { '' } == wd
+	assert existing_path('/') or { '' } == '/'
+	assert existing_path('$wd/does/.///not/exist///.//') or { '' } == '$wd/'
+	assert existing_path('$wd//././/.//') or { '' } == '$wd//././/.//'
+	assert existing_path('$wd//././/.//oh') or { '' } == '$wd//././/.//'
 }

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -36,6 +36,7 @@ fn test_clean_path() {
 		assert clean_path(r'\./path/dir\\file.exe') == r'\path\dir\file.exe'
 		assert clean_path(r'.') == ''
 		assert clean_path(r'./') == ''
+		assert clean_path('') == ''
 		assert clean_path(r'\./') == '\\'
 		assert clean_path(r'//\/\/////') == '\\'
 		return

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -34,16 +34,16 @@ fn test_clean_path() {
 		assert clean_path(r'\/\//\/') == '\\'
 		assert clean_path(r'./path\\dir/\\./\/\\/file.v\.\\\.') == r'path\dir\file.v'
 		assert clean_path(r'\./path/dir\\file.exe') == r'\path\dir\file.exe'
-		assert clean_path(r'.') == ''
-		assert clean_path(r'./') == ''
+		assert clean_path(r'.') == '.'
+		assert clean_path(r'./') == '.'
 		assert clean_path(r'\./') == '\\'
 		assert clean_path(r'//\/\/////') == '\\'
 		return
 	}
 	assert clean_path('./../.././././//') == '../..'
-	assert clean_path('.') == ''
+	assert clean_path('.') == '.'
 	assert clean_path('./path/to/file.v//./') == 'path/to/file.v'
-	assert clean_path('./') == ''
+	assert clean_path('./') == '.'
 	assert clean_path('/.') == '/'
 	assert clean_path('//path/./to/.///files/file.v///') == '/path/to/files/file.v'
 	assert clean_path('path/./to/.///files/.././file.v///') == 'path/to/files/../file.v'
@@ -126,4 +126,48 @@ fn test_abs_path() {
 	assert abs_path('/path/to/file.v/../..') == '/path'
 	assert abs_path('path/../file.v/..') == wd
 	assert abs_path('///') == '/'
+}
+
+fn test_existing_path() {
+	wd := getwd()
+	$if windows {
+		assert existing_path('') == ''
+		assert existing_path('..') == '..'
+		assert existing_path('.') == '.'
+		assert existing_path(wd) == wd
+		assert existing_path('$wd\\does/not/exist\\.\\') == wd
+		assert existing_path('$wd\\\\/\\.\\.\\/.') == wd
+		return
+	}
+	assert existing_path('') == ''
+	assert existing_path('..') == '..'
+	assert existing_path('.') == '.'
+	assert existing_path(wd) == wd
+	assert existing_path('$wd/does/.///not/exist///.//') == wd
+	assert existing_path('$wd/does/././/.//') == wd
+}
+
+fn test_logical_path_parts() {
+	$if windows {
+		assert logical_path_parts('.') == ['.']
+		assert logical_path_parts('..') == ['..']
+		assert logical_path_parts('\\') == ['\\']
+		assert logical_path_parts('\\\\') == ['\\']
+		assert logical_path_parts(r'\dir\text.txt\./\.') == ['\\', '\\dir', '\\dir\\text.txt']
+		assert logical_path_parts(r'C:\path/to/file.v') == ['C:\\', 'C:\\path', r'C:\path\to',
+			r'C:\path\to\file.v']
+		assert logical_path_parts(r'\\.\C:\path\.\to\file.v') == [r'\\.\C:\', r'\\.\C:\path',
+			r'\\.\C:\path\to', r'\\.\C:\path\to\file.v']
+		return
+	}
+	assert logical_path_parts('/path/to/.///file.v/.') == ['/', '/path', '/path/to',
+		'/path/to/file.v']
+	assert logical_path_parts('path/../dir//./') == ['path', 'path/..', 'path/../dir']
+	assert logical_path_parts('path/to/dir/files/file.v.///.') == ['path', 'path/to', 'path/to/dir',
+		'path/to/dir/files', 'path/to/dir/files/file.v.']
+	assert logical_path_parts('.') == ['.']
+	assert logical_path_parts('..') == ['..']
+	assert logical_path_parts('/') == ['/']
+	assert logical_path_parts('////./') == ['/']
+	assert logical_path_parts('./') == ['.']
 }

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -42,6 +42,7 @@ fn test_clean_path() {
 	}
 	assert clean_path('./../.././././//') == '../..'
 	assert clean_path('') == ''
+	assert clean_path('.') == ''
 	assert clean_path('./path/to/file.v//./') == 'path/to/file.v'
 	assert clean_path('./') == ''
 	assert clean_path('/.') == '/'


### PR DESCRIPTION
This PR adds the proposed function `existing_path` from @JalonSolov  to the `os` module. The function checks all parts of the given path for their existence and returns the existing part.

Here are a few examples:
```v
os.existing_path('/my/existing/path/OOF/this/does/not/exist') // returns: '/my/existing/path'
```
```v
os.existing_path('this/does/not/exist') // returns: ''
```
```v
os.existing_path('/myTYPO/existing/path') // returns: '/'
```
Of course, this also works for Windows paths...

Thanks to @JalonSolov  for the great idea! :slightly_smiling_face: 