### PR TITLE
parser: fix match expr case with struct init (fix #14531)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2381,9 +2381,10 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		&& !p.inside_match_case && (!p.inside_if || p.inside_select)
 		&& (!p.inside_for || p.inside_select) && !known_var {
 		return p.struct_init(p.mod + '.' + p.tok.lit, false) // short_syntax: false
-	} else if p.peek_tok.kind == .lcbr && p.inside_if && lit0_is_capital && !known_var
-		&& language == .v {
-		// if a == Foo{} {...}
+	} else if p.peek_tok.kind == .lcbr
+		&& ((p.inside_if && lit0_is_capital && !known_var && language == .v)
+		|| (p.inside_match_case && p.tok.kind == .name && p.peek_tok.pos - p.tok.pos == p.tok.len)) {
+		// `if a == Foo{} {...}` or `match foo { Foo{} {...} }`
 		return p.struct_init(p.mod + '.' + p.tok.lit, false)
 	} else if p.peek_tok.kind == .dot && (lit0_is_capital && !known_var && language == .v) {
 		// T.name

--- a/vlib/v/tests/match_case_with_struct_init_test.v
+++ b/vlib/v/tests/match_case_with_struct_init_test.v
@@ -1,0 +1,29 @@
+struct Get {}
+
+struct Post {}
+
+struct Part {
+	value string
+}
+
+type RoutePart = Get | Part | Post
+
+fn test_match_case_with_struct_init() {
+	route := [RoutePart(Get{}), RoutePart(Part{
+		value: '/'
+	})]
+
+	status_code := match route {
+		[RoutePart(Get{}), RoutePart(Part{
+			value: '/'
+		})] {
+			'200'
+		}
+		else {
+			'404'
+		}
+	}
+
+	print(status_code)
+	assert status_code == '200'
+}


### PR DESCRIPTION
This PR fix match expr case with struct init (fix #14531).

- Fix match expr case with struct init.
- Add test.

```v
struct Get {}

struct Post {}

struct Part {
	value string
}

type RoutePart = Get | Part | Post

fn main() {
	route := [RoutePart(Get{}), RoutePart(Part{
		value: '/'
	})]

	status_code := match route {
		[RoutePart(Get{}), RoutePart(Part{
			value: '/'
		})] {
			'200'
		}
		else {
			'404'
		}
	}

	print(status_code)
	assert status_code == '200'
}

PS D:\Test\v\tt1> v run .
200
```