### PR TITLE
checker: fix declare assign literal with closure (fix #14539)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -305,7 +305,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
-		left_type_unwrapped := c.unwrap_generic(left_type)
+		left_type_unwrapped := c.unwrap_generic(ast.mktyp(left_type))
 		right_type_unwrapped := c.unwrap_generic(right_type)
 		if right_type_unwrapped == 0 {
 			// right type was a generic `T`

--- a/vlib/v/tests/assign_literal_with_closure_test.v
+++ b/vlib/v/tests/assign_literal_with_closure_test.v
@@ -1,0 +1,26 @@
+fn sma(period int) fn (f64) f64 {
+	mut i := 0
+	mut sum := 0.0
+	mut storage := []f64{len: 0, cap: period}
+
+	return fn [mut storage, mut sum, mut i, period] (input f64) f64 {
+		if storage.len < period {
+			sum += input
+			storage << input
+		}
+
+		sum += input - storage[i]
+		storage[i], i = input, (i + 1) % period
+		return sum / f64(storage.len)
+	}
+}
+
+fn test_assign_literal_with_closure() {
+	sma3 := sma(3)
+	sma5 := sma(5)
+	println('x       sma3   sma5')
+	for x in [f64(1), 2, 3, 4, 5, 5, 4, 3, 2, 1] {
+		println('${x:5.3f}  ${sma3(x):5.3f}  ${sma5(x):5.3f}')
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix declare assign literal with closure (fix #14539).

- Fix declare assign literal with closure.
- Add test.

```v
fn sma(period int) fn (f64) f64 {
	mut i := 0
	mut sum := 0.0
	mut storage := []f64{len: 0, cap: period}

	return fn [mut storage, mut sum, mut i, period] (input f64) f64 {
		if storage.len < period {
			sum += input
			storage << input
		}

		sum += input - storage[i]
		storage[i], i = input, (i + 1) % period
		return sum / f64(storage.len)
	}
}

fn main() {
	sma3 := sma(3)
	sma5 := sma(5)
	println('x       sma3   sma5')
	for x in [f64(1), 2, 3, 4, 5, 5, 4, 3, 2, 1] {
		println('${x:5.3f}  ${sma3(x):5.3f}  ${sma5(x):5.3f}')
	}
}

PS D:\Test\v\tt1> v run .
x       sma3   sma5
1.000  1.000  1.000
2.000  1.500  1.500
3.000  2.000  2.000
4.000  3.000  2.500
5.000  4.000  3.000
5.000  4.667  3.800
4.000  4.667  4.200
3.000  4.000  4.200
2.000  3.000  3.800
1.000  2.000  3.000
```