### PR TITLE
parser, cgen: fix cross assign with parentheses (fix #14540)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -762,6 +762,22 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 				g.gen_cross_tmp_variable(left, val.right)
 			}
 		}
+		ast.ParExpr {
+			g.write('(')
+			g.gen_cross_tmp_variable(left, val.expr)
+			g.write(')')
+		}
+		ast.CallExpr {
+			fn_name := val.name.replace('.', '__')
+			g.write('${fn_name}(')
+			for i, arg in val.args {
+				g.gen_cross_tmp_variable(left, arg.expr)
+				if i != val.args.len - 1 {
+					g.write(', ')
+				}
+			}
+			g.write(')')
+		}
 		ast.PrefixExpr {
 			g.write(val.op.str())
 			g.gen_cross_tmp_variable(left, val.right)

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -141,6 +141,16 @@ fn (mut p Parser) check_cross_variables(exprs []ast.Expr, val ast.Expr) bool {
 			return p.check_cross_variables(exprs, val.left)
 				|| p.check_cross_variables(exprs, val.right)
 		}
+		ast.ParExpr {
+			return p.check_cross_variables(exprs, val.expr)
+		}
+		ast.CallExpr {
+			for arg in val.args {
+				if p.check_cross_variables(exprs, arg.expr) {
+					return true
+				}
+			}
+		}
 		ast.PrefixExpr {
 			return p.check_cross_variables(exprs, val.right)
 		}

--- a/vlib/v/tests/cross_assign_with_parentheses_test.v
+++ b/vlib/v/tests/cross_assign_with_parentheses_test.v
@@ -1,0 +1,17 @@
+import math
+
+const ep = 1e-14
+
+fn agm(aa f64, gg f64) f64 {
+	mut a, mut g := aa, gg
+	for math.abs(a - g) > math.abs(a) * ep {
+		a, g = (a + g) * .5, math.sqrt(a * g)
+	}
+	return a
+}
+
+fn test_cross_assign_with_parentheses() {
+	ret := agm(1.0, 1.0 / math.sqrt2)
+	println(ret)
+	assert ret == 0.8472130847939792
+}


### PR DESCRIPTION
This PR fix cross assign with parentheses (fix #14540).

- Fix cross assign with parentheses.
- Add test.

```v
import math

const ep = 1e-14

fn agm(aa f64, gg f64) f64 {
	mut a, mut g := aa, gg
	for math.abs(a - g) > math.abs(a) * ep {
		a, g = (a + g) * .5, math.sqrt(a * g)
	}
	return a
}

fn main() {
	ret := agm(1.0, 1.0 / math.sqrt2)
	println(ret)
	assert ret == 0.8472130847939792
}

PS D:\Test\v\tt1> v run .
0.8472130847939792
```