### PR TITLE
cgen: fix cross assign in closure

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -625,12 +625,13 @@ fn (mut g Gen) gen_cross_var_assign(node &ast.AssignStmt) {
 			ast.Ident {
 				left_typ := node.left_types[i]
 				left_sym := g.table.sym(left_typ)
+				anon_ctx := if g.anon_fn { '$closure_ctx->' } else { '' }
 				if left_sym.kind == .function {
 					g.write_fn_ptr_decl(left_sym.info as ast.FnType, '_var_$left.pos.pos')
-					g.writeln(' = ${c_name(left.name)};')
+					g.writeln(' = $anon_ctx${c_name(left.name)};')
 				} else {
 					styp := g.typ(left_typ)
-					g.writeln('$styp _var_$left.pos.pos = ${c_name(left.name)};')
+					g.writeln('$styp _var_$left.pos.pos = $anon_ctx${c_name(left.name)};')
 				}
 			}
 			ast.IndexExpr {

--- a/vlib/v/tests/assign_literal_with_closure_test.v
+++ b/vlib/v/tests/assign_literal_with_closure_test.v
@@ -10,8 +10,7 @@ fn sma(period int) fn (f64) f64 {
 		}
 
 		sum += input - storage[i]
-		storage[i] = input
-		i = (i + 1) % period
+		storage[i], i = input, (i + 1) % period
 		return sum / f64(storage.len)
 	}
 }


### PR DESCRIPTION
This PR fix cross assign in closure.

- Fix cross assign in closure.
- Add test.

```v
fn sma(period int) fn (f64) f64 {
	mut i := 0
	mut sum := 0.0
	mut storage := []f64{len: 0, cap: period}

	return fn [mut storage, mut sum, mut i, period] (input f64) f64 {
		if storage.len < period {
			sum += input
			storage << input
		}

		sum += input - storage[i]
		storage[i], i = input, (i + 1) % period
		return sum / f64(storage.len)
	}
}

fn main() {
	sma3 := sma(3)
	sma5 := sma(5)
	println('x       sma3   sma5')
	for x in [f64(1), 2, 3, 4, 5, 5, 4, 3, 2, 1] {
		println('${x:5.3f}  ${sma3(x):5.3f}  ${sma5(x):5.3f}')
	}
	assert true
}

PS D:\Test\v\tt1> v run .
x       sma3   sma5
1.000  1.000  1.000
2.000  1.500  1.500
3.000  2.000  2.000
4.000  3.000  2.500
5.000  4.000  3.000
5.000  4.667  3.800
4.000  4.667  4.200
3.000  4.000  4.200
2.000  3.000  3.800
1.000  2.000  3.000
```