### PR TITLE
ast: fix call_expr.str() with propagate_option or propagate_result

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -303,7 +303,13 @@ pub fn (x Expr) str() string {
 		}
 		CallExpr {
 			sargs := args2str(x.args)
-			propagate_suffix := if x.or_block.kind == .propagate_option { ' ?' } else { '' }
+			propagate_suffix := if x.or_block.kind == .propagate_option {
+				'?'
+			} else if x.or_block.kind == .propagate_result {
+				'!'
+			} else {
+				''
+			}
 			if x.is_method {
 				return '${x.left.str()}.${x.name}($sargs)$propagate_suffix'
 			}

--- a/vlib/v/checker/tests/fn_call_arg_mismatch_err_c.out
+++ b/vlib/v/checker/tests/fn_call_arg_mismatch_err_c.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/fn_call_arg_mismatch_err_c.vv:13:18: error: `os.chdir(files) ?` (no value) used as value in argument 1 to `os.ls`
+vlib/v/checker/tests/fn_call_arg_mismatch_err_c.vv:13:18: error: `os.chdir(files)?` (no value) used as value in argument 1 to `os.ls`
    11 |             println(files)
    12 |         } else {
    13 |             println(os.ls(os.chdir(files)?)?)


### PR DESCRIPTION
This PR fix call_expr.str() with propagate_option or propagate_result.

- Fix call_expr.str() with propagate_option or propagate_result.
- Modify test.

```v
module main

import os

fn list_files() ?[][]string {
	mut unchecked_files := os.ls('utilities/modules')?
	println(unchecked_files)
	for files in unchecked_files {
		println(files)
		if os.is_file(files) == true {
			println(files)
		} else {
			println(os.ls(os.chdir(files)?)?)
		}
		println(files)
	}
	mut modules := [['Module:', 'Path:', 'Description']]
	return modules
}

fn main() {
	mut data := [
		['Module:', 'Path:', 'Description'],
	]
	mods := list_files() or { [['null', 'null', 'null']] }
	for _, mod in mods {
		data << mod
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:13:18: error: `os.chdir(files)?` (no value) used as value in argument 1 to `os.ls`
   11 |             println(files)
   12 |         } else {
   13 |             println(os.ls(os.chdir(files)?)?)
      |                           ~~~~~~~~~~~~~~~~
   14 |         }
   15 |         println(files)
```