### PR TITLE
parser: fix cast or dump arguments ending with comma (fix #14551)

### DIFF
--- a/vlib/v/fmt/tests/cast_or_dump_arg_ending_with_comma_expected.vv
+++ b/vlib/v/fmt/tests/cast_or_dump_arg_ending_with_comma_expected.vv
@@ -1,0 +1,4 @@
+fn main() {
+	println(u8(1))
+	dump(1)
+}

--- a/vlib/v/fmt/tests/cast_or_dump_arg_ending_with_comma_input.vv
+++ b/vlib/v/fmt/tests/cast_or_dump_arg_ending_with_comma_input.vv
@@ -1,0 +1,4 @@
+fn main() {
+	println(u8(1,),)
+	dump(1,)
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -272,6 +272,9 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			p.next()
 			p.check(.lpar)
 			expr := p.expr(0)
+			if p.tok.kind == .comma && p.peek_tok.kind == .rpar {
+				p.next()
+			}
 			p.check(.rpar)
 			node = ast.DumpExpr{
 				expr: expr

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2345,6 +2345,9 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				arg = p.expr(0) // len
 				has_arg = true
 			}
+			if p.tok.kind == .comma && p.peek_tok.kind == .rpar {
+				p.next()
+			}
 			end_pos := p.tok.pos()
 			p.check(.rpar)
 			node = ast.CastExpr{


### PR DESCRIPTION
This PR fix cast or dump arguments ending with comma (fix #14551).

- Fix cast or dump arguments ending with comma.
- Add test.

```v
fn main() {
	println(u8(1,),)
	dump(1,)
}
```
vfmt to:
```v
fn main() {
	println(u8(1))
	dump(1)
}
```