### PR TITLE
scanner: fix string interpolation with inner curly braces (fix #12242)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -658,7 +658,6 @@ fn (mut s Scanner) text_scan() token.Token {
 			return s.end_of_file()
 		}
 		// handle each char
-		prevc := s.text[s.pos - 1]
 		c := s.text[s.pos]
 		nextc := s.look_ahead(1)
 		// name or keyword
@@ -805,7 +804,7 @@ fn (mut s Scanner) text_scan() token.Token {
 			`{` {
 				// Skip { in `${` in strings
 				if s.is_inside_string {
-					if prevc == `$` {
+					if s.text[s.pos - 1] == `$` {
 						continue
 					} else {
 						s.inter_cbr_count++

--- a/vlib/v/tests/string_interpolation_inner_cbr_test.v
+++ b/vlib/v/tests/string_interpolation_inner_cbr_test.v
@@ -1,0 +1,21 @@
+struct St {}
+
+fn foo() ?int {
+	return 22
+}
+
+fn test_string_interpolation_inner_cbr() {
+	s1 := '${foo() or { 11 }}'
+	println(s1)
+	assert s1 == '22'
+
+	s2 := '${St{}}'
+	println(s2)
+	assert s2 == 'St{}'
+
+	s3 := '${{
+		'a': 1
+	}}'
+	println(s3)
+	assert s3 == "{'a': 1}"
+}


### PR DESCRIPTION
This PR fix string interpolation with inner curly braces (fix #12242).

- Fix string interpolation with inner curly braces.
- Add test.

```v
struct St {}

fn foo() ?int { return 22 }

fn main() {
	println('${ foo() or { 11 } }')
	println('${ St{} }')
	println('${ {'a': 1} }')
}

PS D:\Test\v\tt1> v run .
22
St{}
{'a': 1}
```