### PR TITLE
checker: vfmt overload_return_type.vv

### DIFF
--- a/vlib/v/checker/tests/overload_return_type.out
+++ b/vlib/v/checker/tests/overload_return_type.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/overload_return_type.vv:14:11: error: cannot assign to `two`: expected `Point`, not `int`
-   12 |     mut one := Point {x:1, y:2}
-   13 |     mut two := Point {x:5, y:1}
-   14 |     two = one + two
+vlib/v/checker/tests/overload_return_type.vv:20:8: error: cannot assign to `two`: expected `Point`, not `int`
+   18 |         y: 1
+   19 |     }
+   20 |     two = one + two
       |           ~~~~~~~~~
-   15 | }
+   21 | }

--- a/vlib/v/checker/tests/overload_return_type.vv
+++ b/vlib/v/checker/tests/overload_return_type.vv
@@ -1,15 +1,21 @@
 struct Point {
-    mut:
-        x int
-        y int
+mut:
+	x int
+	y int
 }
 
-fn (a Point) +(b Point) int {
-    return a.x + b.x
+fn (a Point) + (b Point) int {
+	return a.x + b.x
 }
 
 fn main() {
-    mut one := Point {x:1, y:2}
-    mut two := Point {x:5, y:1}
-    two = one + two
+	mut one := Point{
+		x: 1
+		y: 2
+	}
+	mut two := Point{
+		x: 5
+		y: 1
+	}
+	two = one + two
 }


### PR DESCRIPTION
This PR vfmt overload_return_type.vv.

- `mut one := Point {x:1, y:2}` should be `mut one := Point{x:1, y:2}`.

before:
```
struct Point {
    mut:
        x int
        y int
}

fn (a Point) +(b Point) int {
    return a.x + b.x
}

fn main() {
    mut one := Point {x:1, y:2}
    mut two := Point {x:5, y:1}
    two = one + two
}
```
vfmt to:
```v
struct Point {
mut:
	x int
	y int
}

fn (a Point) + (b Point) int {
	return a.x + b.x
}

fn main() {
	mut one := Point{
		x: 1
		y: 2
	}
	mut two := Point{
		x: 5
		y: 1
	}
	two = one + two
}
```