### PR TITLE
os: fix file_ext function

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -173,6 +173,12 @@ pub fn is_dir_empty(path string) bool {
 
 // file_ext will return the part after the last occurence of `.` in `path`.
 // The `.` is included.
+// Examples:
+// ```v
+// assert os.file_ext('file.v') == '.v'
+// assert os.file_ext('.ignore_me') == ''
+// assert os.file_ext('.') == ''
+// ```
 pub fn file_ext(path string) string {
 	if path.len < 2 {
 		return empty_str

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -174,7 +174,13 @@ pub fn is_dir_empty(path string) bool {
 // file_ext will return the part after the last occurence of `.` in `path`.
 // The `.` is included.
 pub fn file_ext(path string) string {
-	pos := path.last_index('.') or { return '' }
+	if path.len < 2 {
+		return empty_str
+	}
+	pos := path.last_index(dot_str) or { return empty_str }
+	if pos + 1 >= path.len || pos == 0 {
+		return empty_str
+	}
 	return path[pos..]
 }
 

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -180,7 +180,7 @@ pub fn is_dir_empty(path string) bool {
 // assert os.file_ext('.') == ''
 // ```
 pub fn file_ext(path string) string {
-	if path.len < 2 {
+	if path.len < 3 {
 		return empty_str
 	}
 	pos := path.last_index(dot_str) or { return empty_str }

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -585,9 +585,19 @@ fn test_is_executable_writable_readable() ? {
 	os.rm(file_name) or { panic(err) }
 }
 
-fn test_ext() {
+fn test_file_ext() {
 	assert os.file_ext('file.v') == '.v'
+	assert os.file_ext('file.js.v') == '.v'
+	assert os.file_ext('file.ext1.ext2.ext3') == '.ext3'
+	assert os.file_ext('.ignore_me.v') == '.v'
 	assert os.file_ext('file') == ''
+	assert os.file_ext('.git') == ''
+	assert os.file_ext('file.') == ''
+	assert os.file_ext('.') == ''
+	assert os.file_ext('..') == ''
+	assert os.file_ext('file...') == ''
+	assert os.file_ext('.file.') == ''
+	assert os.file_ext('..file..') == ''
 }
 
 fn test_join() {


### PR DESCRIPTION
Right **now** the `os.file_ext` function handles file extensions as follows:
```v
assert os.file_ext('file.v') == '.v'  // ok
assert os.file_ext('.') == '.'      // wrong imo
assert os.file_ext('.git') == '.git' // wrong imo
assert os.file_ext('file.') == '.'  // wrong imo
assert os.file_ext('..') == '.'  // wrong imo
```
In my eyes a file extension is a file extension if there is something in prefix to the `.` (otherwise it would not be an *extension*).

My fix would do the following:
```v
assert os.file_ext('file.v') == '.v'
assert os.file_ext('.') == '' 
assert os.file_ext('.git') == '' 
assert os.file_ext('file.') == ''
assert os.file_ext('..') == ''
``` 