### PR TITLE
Remove unnecessary file extensions in docs.md

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -36,9 +36,9 @@ You need `git`, and a C compiler like `tcc`, `gcc`, `clang` or `msvc`:
 ```bash
 git clone https://github.com/vlang/v
 cd v
-make.bat -tcc
+make -tcc
 ```
-NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make.bat` instead,
+NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 
@@ -46,7 +46,7 @@ For C compiler downloads and more info, see
 [here](https://github.com/vlang/v/wiki/Installing-a-C-compiler-on-Windows).
 
 It is recommended to add this folder to the PATH of your environment variables.
-This can be done with the command `v.exe symlink`.
+This can be done with the command `v symlink`.
 
 NB: Some antivirus programs (like Symantec) are paranoid about executables with
 1 letter names (like `v.exe`). One possible workaround in that situation is


### PR DESCRIPTION
In Windows it's unnecessary to add `.exe` or `.bat` to a command.

If you type `foo.exe` and then `foo` you'll get the same result, since cmd always assumes the first argument is an executable.