### PR TITLE
checker, cgen: fix array index optional with if expr (fix #12197)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3403,6 +3403,9 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 			typ = value_type
 		}
 	}
+	if node.or_expr.stmts.len > 0 && node.or_expr.stmts.last() is ast.ExprStmt {
+		c.expected_or_type = typ
+	}
 	c.stmts_ending_with_expression(node.or_expr.stmts)
 	c.check_expr_opt_call(node, typ)
 	return typ

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -85,7 +85,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			g.stmts(branch.stmts)
 			g.expected_cast_type = prev_expected_cast_type
 		}
-		if node.branches.len == 1 {
+		if node.branches.len == 1 && !node.is_expr {
 			g.write(': 0')
 		}
 		g.write(')')

--- a/vlib/v/tests/array_index_optional_with_if_expr_test.v
+++ b/vlib/v/tests/array_index_optional_with_if_expr_test.v
@@ -1,0 +1,7 @@
+fn test_array_index_optional_with_if_expr() {
+	ret := []string{}[0] or {
+		if true { 'a' } else { 'b' }
+	}
+	println(ret)
+	assert ret == 'a'
+}


### PR DESCRIPTION
This PR fix array index optional with if expr (fix #12197).

- Fix array index optional with if expr.
- Add test.

```v
fn main() {
	ret := []string{}[0] or {
		if true { 'a' } else { 'b' }
	}
	println(ret)
	assert ret == 'a'
}

PS D:\Test\v\tt1> v run .
a
```