### PR TITLE
cgen: fix fixed array of aliases struct (fix #14580)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5070,7 +5070,7 @@ fn (mut g Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 		mut field_deps := []string{}
 		match sym.info {
 			ast.ArrayFixed {
-				dep := g.table.sym(sym.info.elem_type).name
+				dep := g.table.final_sym(sym.info.elem_type).name
 				if dep in type_names {
 					field_deps << dep
 				}

--- a/vlib/v/tests/fixed_array_of_alias_struct_test.v
+++ b/vlib/v/tests/fixed_array_of_alias_struct_test.v
@@ -1,0 +1,11 @@
+type Sfxinfo_t = Sfxinfo_struct
+
+struct Sfxinfo_struct {
+	name [9]i8
+}
+
+fn test_fixed_array_of_alias_struct() {
+	a := [5]Sfxinfo_t{}
+	println(a)
+	assert true
+}


### PR DESCRIPTION
This PR fix fixed array of aliases struct (fix #14580).

- Fix fixed array of aliases struct.
- Add test.

```v
type Sfxinfo_t = Sfxinfo_struct

struct Sfxinfo_struct {
	name [9]i8
}

fn main() {
	a := [5]Sfxinfo_t{}
	println(a)
	assert true
}

PS D:\Test\v\tt1> v run .
[Sfxinfo_struct{
    name: [0, 0, 0, 0, 0, 0, 0, 0, 0]
}, Sfxinfo_struct{
    name: [0, 0, 0, 0, 0, 0, 0, 0, 0]
}, Sfxinfo_struct{
    name: [0, 0, 0, 0, 0, 0, 0, 0, 0]
}, Sfxinfo_struct{
    name: [0, 0, 0, 0, 0, 0, 0, 0, 0]
}, Sfxinfo_struct{
    name: [0, 0, 0, 0, 0, 0, 0, 0, 0]
}]
```