### PR TITLE
cgen: fix type not being unaliased (Fix #14568)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -752,7 +752,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		left_is_shared := node.left_type.has_flag(.shared_f)
 		left_cc_type := g.cc_type(node.left_type, false)
 		left_type_name := util.no_dots(left_cc_type)
-		g.write('${c_name(left_type_name)}_name_table[')
+		g.write('${c_name(typ_sym.name)}_name_table[')
 		if node.left.is_auto_deref_var() && node.left_type.nr_muls() > 1 {
 			g.write('(')
 			g.write('*'.repeat(node.left_type.nr_muls() - 1))

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -750,9 +750,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 
 		left_is_shared := node.left_type.has_flag(.shared_f)
-		left_cc_type := g.cc_type(node.left_type, false)
+		left_cc_type := g.cc_type(g.table.unaliased_type(node.left_type), false)
 		left_type_name := util.no_dots(left_cc_type)
-		g.write('${c_name(typ_sym.name)}_name_table[')
+		g.write('${c_name(left_type_name)}_name_table[')
 		if node.left.is_auto_deref_var() && node.left_type.nr_muls() > 1 {
 			g.write('(')
 			g.write('*'.repeat(node.left_type.nr_muls() - 1))

--- a/vlib/v/gen/c/testdata/alias_interface_method_call.vv
+++ b/vlib/v/gen/c/testdata/alias_interface_method_call.vv
@@ -1,0 +1,9 @@
+import io { Reader }
+
+type Decoder = Reader
+
+fn (mut d Decoder) decode(len int) ?[]u8 {
+	mut buf := []u8{len: len}
+	d.read(mut buf)?
+	return buf
+}


### PR DESCRIPTION
- Fix #14568, fix alaised type method call on interface is not being unaliased.
- Add output test:
```v
import io { Reader }

type Decoder = Reader

fn (mut d Decoder) decode(len int) ?[]u8 {
	mut buf := []u8{len: len}
	d.read(mut buf)?
	return buf
}
```