### PR TITLE
ast: fix IfExpr.str()

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -363,6 +363,8 @@ pub fn (x Expr) str() string {
 				}
 				if i < x.branches.len - 1 || !x.has_else {
 					parts << ' ${dollar}if ' + branch.cond.str() + ' { '
+				} else if x.has_else && i == x.branches.len - 1 {
+					parts << '{ '
 				}
 				for stmt in branch.stmts {
 					parts << stmt.str()


### PR DESCRIPTION
This PR fix IfExpr.str().

before: (missing `{` after else).
`if true { 'a' } else 'b' }`
now:
`if true { 'a' } else { 'b' }`
