### PR TITLE
vrepl: fix error for exitasdfasdf in repl (fix #14593)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -305,7 +305,6 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 					return int(rc)
 				}
 			}
-			break
 		}
 		r.line = line
 		if r.line == '\n' {
@@ -388,13 +387,13 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				'#include ',
 				'for ',
 				'or ',
-				'insert',
-				'delete',
-				'prepend',
-				'sort',
-				'clear',
-				'trim',
-				'as',
+				'insert(',
+				'delete(',
+				'prepend(',
+				'sort(',
+				'clear(',
+				'trim(',
+				' as ',
 			]
 			mut is_statement := false
 			if filter_line.count('=') % 2 == 1 {

--- a/vlib/v/tests/repl/error_exitasdfasdf.repl
+++ b/vlib/v/tests/repl/error_exitasdfasdf.repl
@@ -1,0 +1,7 @@
+exitasdfasdf
+===output===
+error: undefined ident: `exitasdfasdf`
+    5 | import math
+    6 |
+    7 | println(exitasdfasdf)
+      |         ~~~~~~~~~~~~

--- a/vlib/v/tests/repl/error_exitasdfasdf.repl
+++ b/vlib/v/tests/repl/error_exitasdfasdf.repl
@@ -2,6 +2,6 @@ exitasdfasdf
 ===output===
 error: undefined ident: `exitasdfasdf`
     5 | import math
-    6 |
+    6 | 
     7 | println(exitasdfasdf)
       |         ~~~~~~~~~~~~


### PR DESCRIPTION
This PR fix error for exitasdfasdf in repl (fix #14593).

- Fix error for exitasdfasdf in repl.
- Add test.

```v
>>> exitasdfasdf
error: undefined ident: `exitasdfasdf`
    5 | import math
    6 |
    7 | println(exitasdfasdf)
      |         ~~~~~~~~~~~~
>>>
```