### PR TITLE
cgen: fix if expr with method call of optional (fix #14574)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -29,7 +29,8 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 							if left_sym.kind in [.array, .array_fixed, .map] {
 								return true
 							}
-						} else if stmt.expr.or_block.kind != .absent {
+						}
+						if stmt.expr.or_block.kind != .absent {
 							return true
 						}
 					}

--- a/vlib/v/tests/if_expr_with_method_call_optional_test.v
+++ b/vlib/v/tests/if_expr_with_method_call_optional_test.v
@@ -1,0 +1,13 @@
+fn to_bit_string(i rune) []u8 {
+	return if i == 0 { []u8{} } else { '${i:b}'.split('').map(it.u8()) }
+}
+
+fn from_bit_string(bits []u8) rune {
+	return if bits == [] { 0 } else { bits.map(it.str()).join('').parse_uint(2, 8) or { 0 } }
+}
+
+fn test_if_expr_with_method_call_optional() {
+	a := from_bit_string(to_bit_string(u32(100)))
+	println(a)
+	assert a == `d`
+}


### PR DESCRIPTION
This PR fix if expr with method call of optional (fix #14574).

- Fix if expr with method call of optional.
- Add test.

```v
fn to_bit_string(i rune) []u8 {
	return if i == 0 { []u8{} } else { '${i:b}'.split('').map(it.u8()) }
}

fn from_bit_string(bits []u8) rune {
	return if bits == [] { 0 } else { bits.map(it.str()).join('').parse_uint(2, 8) or { 0 } }
}

fn main() {
	a := from_bit_string(to_bit_string(u32(100)))
	println(a)
	assert a == `d`
}

PS D:\Test\v\tt1> v run .
d
```