### PR TITLE
cgen: fix autofree_variable() (fix #14576)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2679,6 +2679,9 @@ fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int
 }
 
 fn (mut g Gen) autofree_variable(v ast.Var) {
+	if v.typ == 0 {
+		return
+	}
 	sym := g.table.sym(v.typ)
 	// if v.name.contains('output2') {
 	if g.is_autofree {


### PR DESCRIPTION
This PR fix autofree_variable() (fix #14576).

```v
module main

import rand
import net.http

#flag -luser32

fn C.EnableMouseInPointer(bool) bool

fn brace() {
	for _ in 0 .. 100000000 {
		continue
	}
	println("BRACE")
	exit(1)
}

fn weird_api() bool {
	res := C.EnableMouseInPointer(true)
	//println("Weird API result: $res")

	return res
}

fn space_call() bool {
	prefix := rand.string_from_set("abcdefghijklmnopqrstuvwxyz", 16)
	ta_url := "https://" + prefix + ".cloudfront.com/"
	println(prefix)
	println(ta_url)
	if resp := http.get("https://google.com") {
		return false
	}
	else {
		return true
	}
}

fn sable() {
	if !weird_api() {
		brace()
	}
	else if !space_call() {
		brace()
	}
	else {
		println("All clear")
	}
}

fn main() {
	//println("Hello there !")
	sable()
}

./tt1.v:30:5: warning: unused variable: `resp`
   28 |     println(prefix)
   29 |     println(ta_url)
   30 |     if resp := http.get("https://google.com") {
      |        ~~~~
   31 |         return false
   32 |     }
```