### PR TITLE
sokol: apply bug fix from latest upstream sokol_audio.h

### DIFF
--- a/thirdparty/sokol/sokol_audio.h
+++ b/thirdparty/sokol/sokol_audio.h
@@ -1611,7 +1611,12 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     fmtex.Format.nAvgBytesPerSec = fmtex.Format.nSamplesPerSec * fmtex.Format.nBlockAlign;
     fmtex.Format.cbSize = 22;   /* WORD + DWORD + GUID */
     fmtex.Samples.wValidBitsPerSample = 32;
-    fmtex.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
+    if (_saudio.num_channels == 1) {
+        fmtex.dwChannelMask = SPEAKER_FRONT_CENTER;
+    }
+    else {
+        fmtex.dwChannelMask = SPEAKER_FRONT_LEFT|SPEAKER_FRONT_RIGHT;
+    }
     fmtex.SubFormat = _saudio_KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
     dur = (REFERENCE_TIME)
         (((double)_saudio.buffer_frames) / (((double)_saudio.sample_rate) * (1.0/10000000.0)));


### PR DESCRIPTION
For me, the issue was that sound was only played with my speakers, but not my headset.
I haven't applied all changes from the latest sokol since it would need some reworking of the malloc/free system.