### PR TITLE
cgen: fix array init with it (fix #14679)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1590,3 +1590,14 @@ fn test_inline_array_element_access() {
 	a2 := [1][0]
 	assert a2 == 1
 }
+
+//
+
+fn f(x int, y int) []int {
+	return [x, y]
+}
+
+fn test_2d_array_init_with_it() {
+	a := [][]int{len: 6, init: f(it, 2 * it)}
+	assert a == [[0, 0], [1, 2], [2, 4], [3, 6], [4, 8], [5, 10]]
+}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -223,7 +223,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		}
 		if is_default_array {
 			g.write('($elem_styp[]){')
-			g.expr(node.default_expr)
+			g.write(g.type_default(node.elem_type))
 			g.write('}[0])')
 		} else if node.has_len && node.elem_type == ast.string_type {
 			g.write('&($elem_styp[]){')

--- a/vlib/v/gen/c/testdata/array_init_no_error.vv
+++ b/vlib/v/gen/c/testdata/array_init_no_error.vv
@@ -1,0 +1,11 @@
+// From issue #14679
+fn iterate_linear(value1 u32, value2 u32, length u32) []u32 {
+	step := u32((value2 - value1) / (length - 1))
+	return []u32{len: int(length), init: value1 + step * u32(it + 1)}
+}
+
+pub fn iterate_rect_single(val1 u32, val2 u32, val3 u32, val4 u32, width u32, height u32) [][]u32 {
+	left := iterate_linear(val1, val3, height)
+	right := iterate_linear(val2, val4, height)
+	return [][]u32{len: int(width), init: iterate_linear(left[it], right[it], width)}
+}


### PR DESCRIPTION
- fix #14679, fix array init with it when initializing an default array.
- Add output test (no error test):
```v
// From issue #14679
fn iterate_linear(value1 u32, value2 u32, length u32) []u32 {
	step := u32((value2 - value1) / (length - 1))
	return []u32{len: int(length), init: value1 + step * u32(it + 1)}
}

pub fn iterate_rect_single(val1 u32, val2 u32, val3 u32, val4 u32, width u32, height u32) [][]u32 {
	left := iterate_linear(val1, val3, height)
	right := iterate_linear(val2, val4, height)
	return [][]u32{len: int(width), init: iterate_linear(left[it], right[it], width)}
}
```
