### PR TITLE
cgen: fix nested map index check (fix #14683)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -484,7 +484,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 			if !node.is_option {
 				g.or_block(tmp_opt, node.or_expr, elem_type)
 			}
-			g.write('\n$cur_line*($elem_type_str*)${tmp_opt}.data')
+			g.write('\n${cur_line}(*($elem_type_str*)${tmp_opt}.data)')
 		}
 	}
 }

--- a/vlib/v/tests/nested_map_index_test.v
+++ b/vlib/v/tests/nested_map_index_test.v
@@ -1,0 +1,113 @@
+import encoding.binary as bin
+
+[heap]
+struct NMachine {
+mut:
+	threads shared map[u16]NThread
+pub mut:
+	modules   map[u64]NModule
+	constants shared map[u64]NStackValue
+}
+
+pub struct NModule {
+pub mut:
+	functions map[u64]NFunction
+	constants map[u64]NStackValue
+}
+
+[heap]
+pub struct NFunction {
+pub mut:
+	labels map[u64]int
+mut:
+	code []u8
+}
+
+[heap]
+pub struct NThread {
+pub mut:
+	last_index     int
+	current_module u64
+mut:
+	stack NStack
+}
+
+pub type NStackValue = []u8 | u8
+
+pub struct NStack {
+mut:
+	values []NStackValue
+}
+
+pub fn (mut stack NStack) push(val NStackValue) {
+	stack.values << val
+}
+
+pub fn (mut stack NStack) pop() NStackValue {
+	return stack.values.pop()
+}
+
+pub struct OperationArgs {
+pub:
+	opcode u8
+pub mut:
+	nm     &NMachine
+	func   &NFunction
+	thread &NThread
+	code   &BytecodeIterator
+}
+
+pub struct BytecodeIterator {
+	arr []u8 [required]
+mut:
+	idx int
+}
+
+pub fn (mut iter BytecodeIterator) next() ?u8 {
+	if iter.idx >= iter.arr.len {
+		return none
+	}
+	defer {
+		iter.idx++
+	}
+	return iter.arr[iter.idx]
+}
+
+pub fn (mut iter BytecodeIterator) next_u64() ?u64 {
+	return read_u64(iter.next_n(8)?)
+}
+
+fn load_const(mut args OperationArgs) ? {
+	name := args.code.next_u64()?
+	val := args.nm.modules[args.thread.current_module]?.constants[name]?
+	args.thread.push_stack(val)
+}
+
+pub fn read_u64(bytes []u8) u64 {
+	mut nb := bytes.clone()
+	len := nb.len
+	if len < 8 {
+		for _ in 0 .. (9 - len) {
+			nb << u8(0)
+		}
+	}
+	i := bin.little_endian_u64(nb)
+	return i
+}
+
+pub fn (mut thread NThread) push_stack(val NStackValue) {
+	thread.stack.push(val)
+}
+
+pub fn (mut iter BytecodeIterator) next_n(n int) ?[]u8 {
+	mut results := []u8{}
+	for _ in 0 .. n {
+		results << iter.next()?
+	}
+	return results
+}
+
+fn test_nested_map_index() {
+	println('hi')
+	assert true
+}

--- a/vlib/v/tests/nested_map_index_test.v
+++ b/vlib/v/tests/nested_map_index_test.v
@@ -1,113 +1,24 @@
-import encoding.binary as bin
-
-[heap]
-struct NMachine {
+struct Foo {
 mut:
-	threads shared map[u16]NThread
-pub mut:
-	modules   map[u64]NModule
-	constants shared map[u64]NStackValue
+	foo map[int]Bar
 }
 
-pub struct NModule {
-pub mut:
-	functions map[u64]NFunction
-	constants map[u64]NStackValue
-}
-
-[heap]
-pub struct NFunction {
-pub mut:
-	labels map[u64]int
+struct Bar {
 mut:
-	code []u8
+	bar map[int]string
 }
 
-[heap]
-pub struct NThread {
-pub mut:
-	last_index     int
-	current_module u64
-mut:
-	stack NStack
-}
-
-pub type NStackValue = []u8 | u8
-
-pub struct NStack {
-mut:
-	values []NStackValue
-}
-
-pub fn (mut stack NStack) push(val NStackValue) {
-	stack.values << val
-}
-
-pub fn (mut stack NStack) pop() NStackValue {
-	return stack.values.pop()
-}
-
-pub struct OperationArgs {
-pub:
-	opcode u8
-pub mut:
-	nm     &NMachine
-	func   &NFunction
-	thread &NThread
-	code   &BytecodeIterator
-}
-
-pub struct BytecodeIterator {
-	arr []u8 [required]
-mut:
-	idx int
-}
-
-pub fn (mut iter BytecodeIterator) next() ?u8 {
-	if iter.idx >= iter.arr.len {
-		return none
-	}
-	defer {
-		iter.idx++
-	}
-	return iter.arr[iter.idx]
-}
-
-pub fn (mut iter BytecodeIterator) next_u64() ?u64 {
-	return read_u64(iter.next_n(8)?)
-}
-
-fn load_const(mut args OperationArgs) ? {
-	name := args.code.next_u64()?
-	val := args.nm.modules[args.thread.current_module]?.constants[name]?
-	args.thread.push_stack(val)
-}
-
-pub fn read_u64(bytes []u8) u64 {
-	mut nb := bytes.clone()
-	len := nb.len
-	if len < 8 {
-		for _ in 0 .. (9 - len) {
-			nb << u8(0)
+fn test_nested_map_index() ? {
+	f := Foo{
+		foo: {
+			11: Bar{
+				bar: {
+					22: 'hello'
+				}
+			}
 		}
 	}
-	i := bin.little_endian_u64(nb)
-	return i
-}
-
-pub fn (mut thread NThread) push_stack(val NStackValue) {
-	thread.stack.push(val)
-}
-
-pub fn (mut iter BytecodeIterator) next_n(n int) ?[]u8 {
-	mut results := []u8{}
-	for _ in 0 .. n {
-		results << iter.next()?
-	}
-	return results
-}
-
-fn test_nested_map_index() {
-	println('hi')
-	assert true
+	ret := f.foo[11]?.bar[22]?
+	println(ret)
+	assert ret == 'hello'
 }


### PR DESCRIPTION
This PR fix nested map index check (fix #14683).

- Fix nested map index check.
- Add test.

```v
struct Foo {
mut:
	foo map[int]Bar
}

struct Bar {
mut:
	bar map[int]string
}

fn main() {
	f := Foo{
		foo: {
			11: Bar{
				bar: {
					22: 'hello'
				}
			}
		}
	}
	ret := f.foo[11]?.bar[22]?
	println(ret)
	assert ret == 'hello'
}

PS D:\Test\v\tt1> v run .
hello
```
```v
import encoding.binary as bin

[heap]
struct NMachine {
mut:
	threads shared map[u16]NThread
pub mut:
	modules   map[u64]NModule
	constants shared map[u64]NStackValue
}

pub struct NModule {
pub mut:
	functions map[u64]NFunction
	constants map[u64]NStackValue
}

[heap]
pub struct NFunction {
pub mut:
	labels map[u64]int
mut:
	code []u8
}

[heap]
pub struct NThread {
pub mut:
	last_index     int
	current_module u64
mut:
	stack NStack
}

pub type NStackValue = []u8 | u8

pub struct NStack {
mut:
	values []NStackValue
}

pub fn (mut stack NStack) push(val NStackValue) {
	stack.values << val
}

pub fn (mut stack NStack) pop() NStackValue {
	return stack.values.pop()
}

pub struct OperationArgs {
pub:
	opcode u8
pub mut:
	nm     &NMachine
	func   &NFunction
	thread &NThread
	code   &BytecodeIterator
}

pub struct BytecodeIterator {
	arr []u8 [required]
mut:
	idx int
}

pub fn (mut iter BytecodeIterator) next() ?u8 {
	if iter.idx >= iter.arr.len {
		return none
	}
	defer {
		iter.idx++
	}
	return iter.arr[iter.idx]
}

pub fn (mut iter BytecodeIterator) next_u64() ?u64 {
	return read_u64(iter.next_n(8)?)
}

fn load_const(mut args OperationArgs) ? {
	name := args.code.next_u64()?
	val := args.nm.modules[args.thread.current_module]?.constants[name]?
	args.thread.push_stack(val)
}

pub fn read_u64(bytes []u8) u64 {
	mut nb := bytes.clone()
	len := nb.len
	if len < 8 {
		for _ in 0 .. (9 - len) {
			nb << u8(0)
		}
	}
	i := bin.little_endian_u64(nb)
	return i
}

pub fn (mut thread NThread) push_stack(val NStackValue) {
	thread.stack.push(val)
}

pub fn (mut iter BytecodeIterator) next_n(n int) ?[]u8 {
	mut results := []u8{}
	for _ in 0 .. n {
		results << iter.next()?
	}
	return results
}

fn main() {
	println('hi')
}

PS D:\Test\v\tt1> v run .
hi
```