### PR TITLE
cgen: fix generic interface with non-generic method (fix #14692)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5742,7 +5742,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 
 			for method in methods {
 				mut name := method.name
-				if inter_info.parent_type.has_flag(.generic) {
+				if method.generic_names.len > 0 && inter_info.parent_type.has_flag(.generic) {
 					parent_sym := g.table.sym(inter_info.parent_type)
 					match parent_sym.info {
 						ast.Struct, ast.Interface, ast.SumType {
@@ -5759,7 +5759,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 				}
 				// .speak = Cat_speak
 				if st_sym.info is ast.Struct {
-					if st_sym.info.parent_type.has_flag(.generic) {
+					if method.generic_names.len > 0 && st_sym.info.parent_type.has_flag(.generic) {
 						name = g.generic_fn_name(st_sym.info.concrete_types, method.name,
 							false)
 					}

--- a/vlib/v/tests/generics_interface_with_non_generic_method_test.v
+++ b/vlib/v/tests/generics_interface_with_non_generic_method_test.v
@@ -1,0 +1,45 @@
+module main
+
+interface TypeFactory<T> {
+	get_type(type_name string) T
+}
+
+enum NodeType {
+	unknown
+	expression
+	statement
+	literal
+}
+
+struct EnumTypeFactory {}
+
+fn (f EnumTypeFactory) get_type(type_name string) NodeType {
+	return match type_name {
+		'expression' { NodeType.expression }
+		'statement' { NodeType.statement }
+		'literal' { NodeType.literal }
+		else { NodeType.unknown }
+	}
+}
+
+struct Node<T> {
+	factory   TypeFactory<T>
+	type_name NodeType
+}
+
+fn new_node<T>(type_name string, factory TypeFactory<T>) Node<T> {
+	return Node<T>{
+		factory: factory
+		type_name: factory.get_type(type_name)
+	}
+}
+
+fn test_generic_interface_with_non_generic_method() {
+	root1 := new_node<NodeType>('literal', EnumTypeFactory{})
+	println(root1)
+	assert root1.type_name == .literal
+
+	root2 := new_node<NodeType>('expression', root1.factory)
+	println(root2)
+	assert root2.type_name == .expression
+}


### PR DESCRIPTION
This PR fix generic interface with non-generic method (fix #14692).

- Fix generic interface with non-generic method.
- Add test.

```v
module main

interface TypeFactory<T> {
	get_type(type_name string) T
}

enum NodeType {
	unknown
	expression
	statement
	literal
}

struct EnumTypeFactory {}

fn (f EnumTypeFactory) get_type(type_name string) NodeType {
	return match type_name {
		'expression' { NodeType.expression }
		'statement' { NodeType.statement }
		'literal' { NodeType.literal }
		else { NodeType.unknown }
	}
}

struct Node<T> {
	factory   TypeFactory<T>
	type_name NodeType
}

fn new_node<T>(type_name string, factory TypeFactory<T>) Node<T> {
	return Node<T>{
		factory: factory
		type_name: factory.get_type(type_name)
	}
}

fn main() {
	root1 := new_node<NodeType>('literal', EnumTypeFactory{})
	println(root1)
	assert root1.type_name == .literal

	root2 := new_node<NodeType>('expression', root1.factory)
	println(root2)
	assert root2.type_name == .expression
}

PS D:\Test\v\tt1> v run .
Node<NodeType>{
    factory: TypeFactory<NodeType>(EnumTypeFactory{})
    type_name: literal
}
Node<NodeType>{
    factory: TypeFactory<NodeType>(EnumTypeFactory{})
    type_name: expression
}
```