### PR TITLE
checker: fix json decoder with generic struct (fix #9190)

### DIFF
--- a/vlib/json/json_decode_with_generic_test.v
+++ b/vlib/json/json_decode_with_generic_test.v
@@ -1,0 +1,24 @@
+import json
+
+struct Result<T> {
+	ok     bool
+	result T
+}
+
+struct User {
+	id       int
+	username string
+}
+
+fn func<T>() ?T {
+	text := '{"ok": true, "result":{"id":37467243, "username": "ciao"}}'
+	a := json.decode(Result<T>, text)?
+	return a.result
+}
+
+fn test_decode_with_generic_struct() ? {
+	ret := func<User>()?
+	println(ret)
+	assert ret.id == 37467243
+	assert ret.username == 'ciao'
+}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -506,7 +506,12 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 		expr := node.args[0].expr
 		if expr is ast.TypeNode {
-			sym := c.table.sym(c.unwrap_generic(expr.typ))
+			mut unwrapped_typ := c.unwrap_generic(expr.typ)
+			if c.table.sym(expr.typ).kind == .struct_ && expr.typ.has_flag(.generic) {
+				unwrapped_typ = c.table.unwrap_generic_type(expr.typ, c.table.cur_fn.generic_names,
+					c.table.cur_concrete_types)
+			}
+			sym := c.table.sym(unwrapped_typ)
 			if c.table.known_type(sym.name) && sym.kind != .placeholder {
 				mut kind := sym.kind
 				if sym.info is ast.Alias {


### PR DESCRIPTION
This PR fix json decoder with generic struct (fix #9190).

- Fix json decoder with generic struct.
- Add test.

```v
import json

struct Result<T> {
	ok     bool
	result T
}

struct User {
	id       int
	username string
}

fn func<T>() ?T {
	text := '{"ok": true, "result":{"id":37467243, "username": "ciao"}}'
	a := json.decode(Result<T>, text)?
	return a.result
}

fn main() {
	ret := func<User>()?
	println(ret)
	assert ret.id == 37467243
	assert ret.username == 'ciao'
}

PS D:\Test\v\tt1> v run .
User{
    id: 37467243
    username: 'ciao'
}
```