### PR TITLE
cgen: fix cast to generic interface (fix #14699)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2126,8 +2126,8 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		g.expr(expr)
 		return
 	}
-	if exp_sym.info is ast.Interface && got_type.idx() != expected_type.idx()
-		&& !expected_type.has_flag(.optional) {
+	if got_sym.info !is ast.Interface && exp_sym.info is ast.Interface
+		&& got_type.idx() != expected_type.idx() && !expected_type.has_flag(.optional) {
 		if expr is ast.StructInit && !got_type.is_ptr() {
 			g.inside_cast_in_heap++
 			got_styp := g.cc_type(got_type.ref(), true)

--- a/vlib/v/tests/generics_interface_with_non_generic_method_test.v
+++ b/vlib/v/tests/generics_interface_with_non_generic_method_test.v
@@ -13,7 +13,7 @@ enum NodeType {
 
 struct EnumTypeFactory {}
 
-fn (f EnumTypeFactory) get_type(type_name string) NodeType {
+fn (f &EnumTypeFactory) get_type(type_name string) NodeType {
 	return match type_name {
 		'expression' { NodeType.expression }
 		'statement' { NodeType.statement }
@@ -22,24 +22,34 @@ fn (f EnumTypeFactory) get_type(type_name string) NodeType {
 	}
 }
 
+struct RawNode {
+	type_name string
+}
+
 struct Node<T> {
 	factory   TypeFactory<T>
 	type_name NodeType
+	raw_node  RawNode
 }
 
-fn new_node<T>(type_name string, factory TypeFactory<T>) Node<T> {
+fn new_node<T>(factory TypeFactory<T>, raw_node RawNode) ?Node<T> {
 	return Node<T>{
 		factory: factory
-		type_name: factory.get_type(type_name)
+		type_name: factory.get_type(raw_node.type_name)
+		raw_node: raw_node
 	}
 }
 
-fn test_generic_interface_with_non_generic_method() {
-	root1 := new_node<NodeType>('literal', EnumTypeFactory{})
+fn program<T>(factory TypeFactory<T>) ? {
+	root1 := new_node<T>(factory, RawNode{'literal'})?
 	println(root1)
 	assert root1.type_name == .literal
 
-	root2 := new_node<NodeType>('expression', root1.factory)
+	root2 := new_node<T>(root1.factory, RawNode{'expression'})?
 	println(root2)
 	assert root2.type_name == .expression
+}
+
+fn test_generic_interface_with_non_generic_method() ? {
+	program<NodeType>(&EnumTypeFactory{})?
 }


### PR DESCRIPTION
This PR fix cast to generic interface (fix #14699).

- Fix cast to generic interface.
- Add test.

```v
module main

interface TypeFactory<T> {
	get_type(type_name string) T
}

enum NodeType {
	unknown
	expression
	statement
	literal
}

struct EnumTypeFactory {}

fn (f &EnumTypeFactory) get_type(type_name string) NodeType {
	return match type_name {
		'expression' { NodeType.expression }
		'statement' { NodeType.statement }
		'literal' { NodeType.literal }
		else { NodeType.unknown }
	}
}

struct RawNode {
	type_name string
}

struct Node<T> {
	factory   TypeFactory<T>
	type_name NodeType
	raw_node  RawNode
}

fn new_node<T>(factory TypeFactory<T>, raw_node RawNode) ?Node<T> {
	return Node<T>{
		factory: factory
		type_name: factory.get_type(raw_node.type_name)
		raw_node: raw_node
	}
}

fn program<T>(factory TypeFactory<T>) ? {
	root1 := new_node<T>(factory, RawNode{'literal'})?
	println(root1)
	assert root1.type_name == .literal

	root2 := new_node<T>(root1.factory, RawNode{'expression'})?
	println(root2)
	assert root2.type_name == .expression
}

fn main() {
	program<NodeType>(&EnumTypeFactory{})?
}

PS D:\Test\v\tt1> v run .
Node<NodeType>{
    factory: TypeFactory<NodeType>(EnumTypeFactory{})
    type_name: literal
    raw_node: RawNode{
        type_name: 'literal'
    }
}
Node<NodeType>{
    factory: TypeFactory<NodeType>(EnumTypeFactory{})
    type_name: expression
    raw_node: RawNode{
        type_name: 'expression'
    }
}
```