### PR TITLE
term.ui: don't print event data in readme example (vlang#14719)

### DIFF
--- a/vlib/term/ui/README.md
+++ b/vlib/term/ui/README.md
@@ -13,7 +13,6 @@ mut:
 }
 
 fn event(e &tui.Event, x voidptr) {
-	println(e)
 	if e.typ == .key_down && e.code == .escape {
 		exit(0)
 	}


### PR DESCRIPTION
The event data flickers on the screen. Video in referenced issue. Seems like this line was meant for debugging but never removed?