### PR TITLE
native: added new helper functions

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -872,6 +872,82 @@ fn (mut g Gen) add_reg(a Register, b Register) {
 	g.println('add $a, $b')
 }
 
+fn (mut g Gen) inc_reg(r Register) {
+	g.write8(0x48)
+	g.write8(0x83)
+	
+	match r {
+		.rax {
+			g.write8(0xc0)
+		}
+		.rcx {
+			g.write8(0xc1)
+		}
+		.rdx {
+			g.write8(0xc2)
+		}
+		.rbx {
+			g.write8(0xc3)
+		}
+		.rsp {
+			g.write8(0xc4)
+		}
+		.rbp {
+			g.write8(0xc5)
+		}
+		.rsi {
+			g.write8(0xc6)
+		}
+		.rdi {
+			g.write8(0xc7)
+		}
+		else {
+			panic('unhandled inc $r, \$1')
+		}
+	}
+	g.write8(0x01)
+
+	g.println('add $r, \$1')
+}
+
+fn (mut g Gen) dec_reg(r Register) {
+	g.write8(0x48)
+	g.write8(0x83)
+	
+	match r {
+		.rax {
+			g.write8(0xe8)
+		}
+		.rcx {
+			g.write8(0xe9)
+		}
+		.rdx {
+			g.write8(0xea)
+		}
+		.rbx {
+			g.write8(0xeb)
+		}
+		.rsp {
+			g.write8(0xec)
+		}
+		.rbp {
+			g.write8(0xed)
+		}
+		.rsi {
+			g.write8(0xee)
+		}
+		.rdi {
+			g.write8(0xef)
+		}
+		else {
+			panic('unhandled inc $r, \$1')
+		}
+	}
+	g.write8(0x01)
+
+	g.println('sub $r, \$1')
+}
+
 fn (mut g Gen) mov_reg(a Register, b Register) {
 	if a == .rax && b == .rsi {
 		g.write([u8(0x48), 0x89, 0xf0])

--- a/vlib/v/gen/native/tests/print.vv
+++ b/vlib/v/gen/native/tests/print.vv
@@ -29,9 +29,15 @@ fn test_stderr() {
 	eprintln('2(World)')
 }
 
+fn test_idents() {
+	x := 5
+	println(x)
+}
+
 fn main() {
 	test_stdout()
 	test_stderr()
 	test_numbers()
 	test_oof()
+	test_idents()
 }


### PR DESCRIPTION
### This PR contains helper functions of the native backend for integer-to-string conversion and other new features

`cmp_zero()`: compare a given register with 0

`mov32()`: move a 32 bit number into a given register

`lea_var_to_reg()`: equivalent to `lea <reg>, [rbp - <var> ]`

`var_zero()`, `rep_stosb()`: initialize a variable to 0

`test_reg()`: equivalent to `test <reg>, <reg>`

`imul_reg()`: integer multiplication on a register

`mod_reg()`: Register **a** % Register **b**

`sar8()`: bit-shift the contents of a register

`convert_int_to_string()`: currently not implemented -> will take a number from a register and write it to a string buffer

`gen_var_to_string()`: wrapper for `convert_int_to_string()`, provides the string buffer

**The test `vlib/v/gen/native/tests/print.vv` currently fails as int-to-string conversion is still work-in-progress**
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
