### PR TITLE
native: implement  `neg()` for arm64

### DIFF
--- a/vlib/v/gen/native/arm64.v
+++ b/vlib/v/gen/native/arm64.v
@@ -77,6 +77,19 @@ fn (mut g Gen) mov_arm(reg Arm64Register, val u64) {
 	*/
 }
 
+fn (mut g Gen) neg_arm(r Arm64Register) {
+	g.neg_regs_arm(r, r)
+}
+
+fn (mut g Gen) neg_regs_arm(a Arm64Register, b Arm64Register) {
+	if int(a) < 0x0f && int(b) < 0x0f {
+		g.write32(0xe2600000 | int(a) << 16 | int(b) << 12)
+		g.println('neg $a, $b')
+	} else {
+		g.n_error('unhandled neg $a, $b')
+	}
+}
+
 pub fn (mut g Gen) fn_decl_arm64(node ast.FnDecl) {
 	g.gen_arm64_helloworld()
 	// TODO


### PR DESCRIPTION
Implement the `neg()` function of the amd64 generator for arm64.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
