### PR TITLE
parser: correct error message for selector_expr_assign.vv (fix #14744)

### DIFF
--- a/vlib/v/checker/tests/selector_expr_assign.out
+++ b/vlib/v/checker/tests/selector_expr_assign.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/selector_expr_assign.vv:7:6: error: struct fields can only be declared during the initialization
+vlib/v/checker/tests/selector_expr_assign.vv:7:8: error: use assignment `=` instead of declaration `:=` when modifying struct fields
     5 | fn main() {
     6 |     abc := Abc{}
     7 |     abc.a := 2
-      |         ^
+      |           ~~
     8 | }

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -244,8 +244,8 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 			ast.PrefixExpr {}
 			ast.SelectorExpr {
 				if op == .decl_assign {
-					return p.error_with_pos('struct fields can only be declared during the initialization',
-						lx.pos)
+					return p.error_with_pos('use assignment `=` instead of declaration `:=` when modifying struct fields',
+						pos)
 				}
 			}
 			else {


### PR DESCRIPTION
This PR correct error message for seclector_expr_assign.vv (fix #14744).

- Correct error message for seclector_expr_assign.vv.

```v
struct Abc {
	a int
}

fn main() {
	abc := Abc{}
	abc.a := 2
}

PS D:\Test\v\tt1> v run .
./tt1.v:7:8: error: use assignment `=` instead of declaration `:=` when modifying struct fields
    5 | fn main() {
    6 |     abc := Abc{}
    7 |     abc.a := 2
      |           ~~
    8 | }
```