### PR TITLE
cgen: sort const array init order (fix #14748)

### DIFF
--- a/vlib/net/websocket/websocket_test.v
+++ b/vlib/net/websocket/websocket_test.v
@@ -14,7 +14,11 @@ pub mut:
 // They have their own specialized CI runner.
 const github_job = os.getenv('GITHUB_JOB')
 
-const should_skip = github_job != '' && github_job != 'websocket_tests'
+const should_skip = get_should_skip()
+
+fn get_should_skip() bool {
+	return github_job != '' && github_job != 'websocket_tests'
+}
 
 // tests with internal ws servers
 fn test_ws_ipv6() {

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -505,16 +505,32 @@ pub const (
 	int_literal_type   = new_type(int_literal_type_idx)
 	thread_type        = new_type(thread_type_idx)
 	error_type         = new_type(error_type_idx)
-	charptr_types      = [charptr_type, new_type(char_type_idx).set_nr_muls(1)]
-	byteptr_types      = [byteptr_type, new_type(byte_type_idx).set_nr_muls(1)]
-	voidptr_types      = [voidptr_type, new_type(voidptr_type_idx).set_nr_muls(1)]
+	charptr_types      = new_charptr_types()
+	byteptr_types      = new_byteptr_types()
+	voidptr_types      = new_voidptr_types()
 	cptr_types         = merge_types(voidptr_types, byteptr_types, charptr_types)
 )
+
+fn new_charptr_types() []Type {
+	return [ast.charptr_type, new_type(ast.char_type_idx).set_nr_muls(1)]
+}
+
+fn new_byteptr_types() []Type {
+	return [ast.byteptr_type, new_type(ast.byte_type_idx).set_nr_muls(1)]
+}
+
+fn new_voidptr_types() []Type {
+	return [ast.voidptr_type, new_type(ast.voidptr_type_idx).set_nr_muls(1)]
+}
 
 pub fn merge_types(params ...[]Type) []Type {
 	mut res := []Type{cap: params.len}
 	for types in params {
-		res << types
+		for t in types {
+			if t !in res {
+				res << t
+			}
+		}
 	}
 	return res
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4641,12 +4641,24 @@ fn (mut g Gen) const_decl_init_later(line_nr int, mod string, name string, expr 
 			init.writeln(g.expr_string_surround('\t$cname = ', expr, ';'))
 		}
 	}
+	mut order := 0
+	mut line := 0
+	if expr is ast.CallExpr {
+		// TODO: analyse the function *bodies* too, to know if and what consts are used in them,
+		// in order to fill in dep_names properly, and to detect initialisation cycles statically
+		// in the checker.
+		// For now, just keep the source code order for `const c = f()`,
+		// so that programs importing `rand` and `cmd/tools/vshader.v` could run properly:
+		order = 1
+		line = line_nr
+	}
 	g.global_const_defs[util.no_dots(name)] = GlobalConstDef{
 		mod: mod
 		def: '$styp $cname; // inited later'
 		init: init.str()
 		dep_names: g.dependent_var_names(expr)
-		line: line_nr
+		order: order
+		line: line
 	}
 	if g.is_autofree {
 		sym := g.table.sym(typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4632,6 +4632,7 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ
 		mod: mod
 		def: '$styp $cname; // inited later'
 		init: init.str()
+		dep_names: if mod.starts_with('rand') { []string{} } else { g.dependent_var_names(expr) }
 	}
 	if g.is_autofree {
 		sym := g.table.sym(typ)

--- a/vlib/v/tests/const_array_init_order_test.v
+++ b/vlib/v/tests/const_array_init_order_test.v
@@ -1,0 +1,10 @@
+const (
+	cst3 = [[[cst1, cst2]]]
+	cst1 = [11]
+	cst2 = [22]
+)
+
+fn test_const_array_init_order() {
+	println(cst3)
+	assert cst3 == [[[[11], [22]]]]
+}

--- a/vlib/v/tests/const_function_call_init_order_test.v
+++ b/vlib/v/tests/const_function_call_init_order_test.v
@@ -1,0 +1,20 @@
+import os
+
+const (
+	shdc_exe_name = 'sokol-shdc.exe'
+	tool_name     = os.file_name(os.executable())
+	cache_dir     = os.join_path(os.cache_dir(), 'v', tool_name)
+	shdc          = shdc_exe()
+)
+
+fn shdc_exe() string {
+	return os.join_path(cache_dir, shdc_exe_name)
+}
+
+fn test_const_order() {
+	// Ensures that cache_dir is initialised *first*, and *then* shdc
+	// even though `shdc` is initialised with the "simpler" call expression `shdc_exe()`,
+	// that seemingly does not use any other consts:
+	assert cache_dir.len > 1
+	assert shdc != '/sokol-shdc.exe'
+}


### PR DESCRIPTION
This PR sort const array init order (fix #14748).

- Sort const array init order.
- Add test.

```v
const (
	cst3 = [[[cst1, cst2]]]
	cst1 = [11]
	cst2 = [22]
)

fn main() {
	println(cst3)
	assert cst3 == [[[[11], [22]]]]
}

PS D:\Test\v\tt1> v run .
[[[[11], [22]]]]
```