### PR TITLE
gg.m4: Transposed the translation function on matrices

### DIFF
--- a/vlib/gg/m4/matrix.v
+++ b/vlib/gg/m4/matrix.v
@@ -568,17 +568,17 @@ pub fn rotate(angle f32, w Vec4) Mat4 {
 * Graphic
 *
 *********************************************************************/
-// Get a matrix translated by a vector w
+// Get a matrix translated by a vector w, only xyz are evaluated.
 pub fn (x Mat4) translate(w Vec4) Mat4 {
-	unsafe {
-		return Mat4{ e: [
-				x.e[0],	x.e[1], x.e[2 ], 	x.e[3 ] ,
-				x.e[4], x.e[5],	x.e[6 ], 	x.e[7 ] ,
-				x.e[8], x.e[9], x.e[10], 	x.e[11] ,
-				x.e[12] + w.e[0], 	x.e[13] + w.e[1], x.e[14] + w.e[2], x.e[15],
-				]!
-		}
-	}
+    unsafe {
+        return Mat4{ e: [
+                x.e[0], x.e[1], x.e[2 ], x.e[3 ]  + w.e[0],
+                x.e[4], x.e[5], x.e[6 ], x.e[7 ]  + w.e[1],
+                x.e[8], x.e[9], x.e[10], x.e[11]  + w.e[2],
+                x.e[12],x.e[13],x.e[14], x.e[15],
+                ]!
+        }
+    }
 }
 
 // Get a scale matrix, the scale vector is w, only xyz are evaluated.


### PR DESCRIPTION
Changing gg.m4's translate matrix function to use a transposed version of the translation matrix.
```diff
- // Get a matrix translated by a vector w
+ // Get a matrix translated by a vector w, only xyz are evaluated.
pub fn (x Mat4) translate(w Vec4) Mat4 {
...
```
Rewriting the description to keep it similar to the standalone `scale()` function.
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
