### PR TITLE
ast, checker, cgen: sort consts with call expr (fix #14748)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -117,9 +117,10 @@ pub mut:
 	source_fn      voidptr // set in the checker, while processing fn declarations
 	usages         int
 	generic_names  []string
-	attrs          []Attr // all fn attributes
-	is_conditional bool   // true for `[if abc]fn(){}`
-	ctdefine_idx   int    // the index of the attribute, containing the compile time define [if mytag]
+	dep_names      []string // globals or consts dependent names
+	attrs          []Attr   // all fn attributes
+	is_conditional bool     // true for `[if abc]fn(){}`
+	ctdefine_idx   int      // the index of the attribute, containing the compile time define [if mytag]
 }
 
 fn (f &Fn) method_equals(o &Fn) bool {
@@ -2154,4 +2155,91 @@ pub fn (t &Table) is_comptime_type(x Type, y ComptimeType) bool {
 			return x_kind == .enum_
 		}
 	}
+}
+
+pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
+	mut names := []string{}
+	match expr {
+		Ident {
+			if expr.kind in [.global, .constant] {
+				names << util.no_dots(expr.name)
+			}
+		}
+		ArrayInit {
+			for elem_expr in expr.exprs {
+				names << t.dependent_names_in_expr(elem_expr)
+			}
+		}
+		StructInit {
+			for field in expr.fields {
+				names << t.dependent_names_in_expr(field.expr)
+			}
+		}
+		InfixExpr {
+			names << t.dependent_names_in_expr(expr.left)
+			names << t.dependent_names_in_expr(expr.right)
+		}
+		PostfixExpr {
+			names << t.dependent_names_in_expr(expr.expr)
+		}
+		PrefixExpr {
+			names << t.dependent_names_in_expr(expr.right)
+		}
+		CallExpr {
+			for arg in expr.args {
+				names << t.dependent_names_in_expr(arg.expr)
+			}
+			if func := t.find_fn(expr.name) {
+				names << func.dep_names
+			}
+		}
+		IfExpr {
+			for branch in expr.branches {
+				names << t.dependent_names_in_expr(branch.cond)
+				for stmt in branch.stmts {
+					names << t.dependent_names_in_stmt(stmt)
+				}
+			}
+		}
+		MatchExpr {
+			names << t.dependent_names_in_expr(expr.cond)
+			for branch in expr.branches {
+				for stmt in branch.stmts {
+					names << t.dependent_names_in_stmt(stmt)
+				}
+			}
+		}
+		else {}
+	}
+	return names
+}
+
+pub fn (t &Table) dependent_names_in_stmt(stmt Stmt) []string {
+	mut names := []string{}
+	match stmt {
+		AssignStmt {
+			for expr in stmt.left {
+				names << t.dependent_names_in_expr(expr)
+			}
+			for expr in stmt.right {
+				names << t.dependent_names_in_expr(expr)
+			}
+		}
+		ExprStmt {
+			names << t.dependent_names_in_expr(stmt.expr)
+		}
+		ForInStmt {
+			names << t.dependent_names_in_expr(stmt.cond)
+			for stmt_ in stmt.stmts {
+				names << t.dependent_names_in_stmt(stmt_)
+			}
+		}
+		Return {
+			for expr in stmt.exprs {
+				names << t.dependent_names_in_expr(expr)
+			}
+		}
+		else {}
+	}
+	return names
 }

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -334,6 +334,16 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 	}
 	node.source_file = c.file
+
+	if c.table.known_fn(node.name) {
+		mut dep_names := []string{}
+		for stmt in node.stmts {
+			dep_names << c.table.dependent_names_in_stmt(stmt)
+		}
+		if dep_names.len > 0 {
+			c.table.fns[node.name].dep_names = dep_names
+		}
+	}
 }
 
 // check_same_type_ignoring_pointers util function to check if the Types are the same, including all

--- a/vlib/v/tests/const_call_expr_order_test.v
+++ b/vlib/v/tests/const_call_expr_order_test.v
@@ -1,0 +1,18 @@
+import os
+
+const (
+	shdc_exe_name = 'sokol-shdc.exe'
+	tool_name     = os.file_name(os.executable())
+	cache_dir     = os.join_path(os.cache_dir(), 'v', tool_name)
+	shdc          = shdc_exe()
+)
+
+fn test_const_call_expr_order() {
+	dump(cache_dir)
+	dump(shdc)
+	assert true
+}
+
+fn shdc_exe() string {
+	return os.join_path(cache_dir, shdc_exe_name)
+}


### PR DESCRIPTION
This PR sort consts with call expr (fix #14748).

- Sort consts with call expr.
- Add test.

```v
import os

const (
	shdc_exe_name = 'sokol-shdc.exe'
	tool_name     = os.file_name(os.executable())
	cache_dir     = os.join_path(os.cache_dir(), 'v', tool_name)
	shdc          = shdc_exe()
)

fn main() {
	dump(cache_dir)
	dump(shdc)
}

fn shdc_exe() string {
	return os.join_path(cache_dir, shdc_exe_name)
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:11] main.cache_dir: C:\Users\yuyi9\.cache\v\tt1.exe
[.\\tt1.v:12] main.shdc: C:\Users\yuyi9\.cache\v\tt1.exe\sokol-shdc.exe
```
```v
const (
	cst3 = [[[cst1, cst2]]]
	cst1 = [11]
	cst2 = [22]
)

fn main() {
	println(cst3)
	assert cst3 == [[[[11], [22]]]]
}

PS D:\Test\v\tt1> v run .
[[[[11], [22]]]]
```