### PR TITLE
util: optimize in launch_tool()

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -176,10 +176,19 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 		if is_verbose {
 			println('Compiling $tool_name with: "$compilation_command"')
 		}
-		tool_compilation := os.execute_or_exit(compilation_command)
-		if tool_compilation.exit_code != 0 {
-			eprintln('cannot compile `$tool_source`: \n$tool_compilation.output')
-			exit(1)
+
+		retry_max_count := 3
+		for i in 0 .. retry_max_count {
+			tool_compilation := os.execute(compilation_command)
+			if tool_compilation.exit_code == 0 {
+				break
+			} else {
+				if i == retry_max_count - 1 {
+					eprintln('cannot compile `$tool_source`: \n$tool_compilation.output')
+					exit(1)
+				}
+				time.sleep(20 * time.millisecond)
+			}
 		}
 	}
 	$if windows {


### PR DESCRIPTION
This PR optimize in launch_tool().

- Add a retry mechanism for the occasional command execution failure.

The original multi-tasking tests produced the following errors.
```v
 FAIL  [  41/1022]  8766.738 ms vlib/builtin/js/int_test.js.v
failed    cmd: "D:\v\v.exe" -skip-unused "D:\v\cmd\tools\builders\js_builder.v"
failed   code: 1
==================
C:/Users/yuyi9/AppData/Local/Temp/v/test_session_65330900/js_builder.505065901838222281.tmp.c:69435: warning: cast between pointer and integer of different size
tcc: error: could not write 'D:\v\cmd\tools\builders\js_builder.exe': Permission denied
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.

This is a compiler bug, please report it using `v bug file.v`.

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 OK    [  42/1022]   315.011 ms vlib/crypto/aes/aes_test.v
 FAIL  [  43/1022]  8657.754 ms vlib/builtin/js/map_test.js.v
failed    cmd: "D:\v\v.exe" -skip-unused "D:\v\cmd\tools\builders\js_builder.v"
failed   code: 1
==================
C:/Users/yuyi9/AppData/Local/Temp/v/test_session_65330900/js_builder.3495563698005233000.tmp.c:69435: warning: cast between pointer and integer of different size
tcc: error: could not write 'D:\v\cmd\tools\builders\js_builder.exe': Permission denied
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.

This is a compiler bug, please report it using `v bug file.v`.

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang
```