### PR TITLE
cgen: minor cleanup in stmt()

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -5,7 +5,7 @@ module c
 
 import v.ast
 
-fn (mut g Gen) gen_assert_stmt(original_assert_statement ast.AssertStmt) {
+fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 	if !original_assert_statement.is_used {
 		return
 	}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -7,7 +7,7 @@ import v.ast
 import v.util
 import v.token
 
-fn (mut g Gen) gen_assign_stmt(node_ ast.AssignStmt) {
+fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 	mut node := unsafe { node_ }
 	if node.is_static {
 		g.write('static ')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1729,6 +1729,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			g.writeln('${g.defer_flag_var(defer_stmt)} = true;')
 			g.defer_stmts << defer_stmt
 		}
+		ast.EmptyStmt {}
 		ast.EnumDecl {
 			g.enum_decl(node)
 		}
@@ -1882,6 +1883,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				}
 			}
 		}
+		ast.Import {}
 		ast.InterfaceDecl {
 			// definitions are sorted and added in write_types
 			ts := g.table.sym(node.typ)
@@ -1905,6 +1907,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// g.cur_mod = node.name
 			g.cur_mod = node
 		}
+		ast.NodeError {}
 		ast.Return {
 			g.return_stmt(node)
 		}
@@ -1949,7 +1952,6 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				g.writeln('// TypeDecl')
 			}
 		}
-		else {}
 	}
 	if !g.skip_stmt_pos { // && g.stmt_path_pos.len > 0 {
 		g.stmt_path_pos.delete_last()

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1631,18 +1631,17 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		g.set_current_pos_as_last_stmt_pos()
 	}
 	match node {
-		ast.EmptyStmt {}
 		ast.AsmStmt {
 			g.write_v_source_line_info(node.pos)
-			g.gen_asm_stmt(node)
+			g.asm_stmt(node)
 		}
 		ast.AssertStmt {
 			g.write_v_source_line_info(node.pos)
-			g.gen_assert_stmt(node)
+			g.assert_stmt(node)
 		}
 		ast.AssignStmt {
 			g.write_v_source_line_info(node.pos)
-			g.gen_assign_stmt(node)
+			g.assign_stmt(node)
 		}
 		ast.Block {
 			g.write_v_source_line_info(node.pos)
@@ -1883,7 +1882,6 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				}
 			}
 		}
-		ast.Import {}
 		ast.InterfaceDecl {
 			// definitions are sorted and added in write_types
 			ts := g.table.sym(node.typ)
@@ -1907,7 +1905,6 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// g.cur_mod = node.name
 			g.cur_mod = node
 		}
-		ast.NodeError {}
 		ast.Return {
 			g.return_stmt(node)
 		}
@@ -1952,6 +1949,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				g.writeln('// TypeDecl')
 			}
 		}
+		else {}
 	}
 	if !g.skip_stmt_pos { // && g.stmt_path_pos.len > 0 {
 		g.stmt_path_pos.delete_last()
@@ -2279,7 +2277,7 @@ fn (mut g Gen) gen_attrs(attrs []ast.Attr) {
 	}
 }
 
-fn (mut g Gen) gen_asm_stmt(stmt ast.AsmStmt) {
+fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 	g.write('__asm__')
 	if stmt.is_volatile {
 		g.write(' volatile')


### PR DESCRIPTION
This PR makes minor cleanup in stmt().

- `gen_assign_stmt` rename to `assign_stmt` for consistency.
- `gen_assert_stmt` rename to `assert_stmt` for consistency.
- `gen_asm_stmt` rename to `asm_stmt` for consistency.