### PR TITLE
cgen: format module_init generated c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4791,11 +4791,15 @@ fn (mut g Gen) write_init_function() {
 		g.writeln('\t_closure_mtx_init();')
 	}
 	for mod_name in g.table.modules {
-		g.writeln('\t// Initializations for module $mod_name')
+		mut is_empty := true
 		// write globals and consts init later
 		for var_name in g.sorted_global_const_names {
 			if var := g.global_const_defs[var_name] {
 				if var.mod == mod_name && var.init.len > 0 {
+					if is_empty {
+						is_empty = false
+						g.writeln('\t// Initializations for module $mod_name')
+					}
 					g.writeln(var.init)
 				}
 			}
@@ -4803,6 +4807,9 @@ fn (mut g Gen) write_init_function() {
 		init_fn_name := '${mod_name}.init'
 		if initfn := g.table.find_fn(init_fn_name) {
 			if initfn.return_type == ast.void_type && initfn.params.len == 0 {
+				if is_empty {
+					g.writeln('\t// Initializations for module $mod_name')
+				}
 				mod_c_name := util.no_dots(mod_name)
 				init_fn_c_name := '${mod_c_name}__init'
 				g.writeln('\t${init_fn_c_name}();')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4791,7 +4791,7 @@ fn (mut g Gen) write_init_function() {
 		g.writeln('\t_closure_mtx_init();')
 	}
 	for mod_name in g.table.modules {
-		g.writeln('\t{ // Initializations for module $mod_name :')
+		g.writeln('\t// Initializations for module $mod_name')
 		// write globals and consts init later
 		for var_name in g.sorted_global_const_names {
 			if var := g.global_const_defs[var_name] {
@@ -4808,7 +4808,6 @@ fn (mut g Gen) write_init_function() {
 				g.writeln('\t${init_fn_c_name}();')
 			}
 		}
-		g.writeln('\t}')
 	}
 	g.writeln('}')
 	if g.pref.printfn_list.len > 0 && '_vinit' in g.pref.printfn_list {

--- a/vlib/v/gen/c/testdata/embed.c.must_have
+++ b/vlib/v/gen/c/testdata/embed.c.must_have
@@ -15,5 +15,3 @@ v__embed_file__EmbedFileIndexEntry* v__embed_file__find_index_entry_by_path(void
 
 v__embed_file__EmbedFileData my_source = _v_embed_file_metadata(
 res.path = _SLIT("embed.vv");
-
-// Initializations for module v.embed_file :

--- a/vlib/v/gen/c/testdata/embed_with_prod.c.must_have
+++ b/vlib/v/gen/c/testdata/embed_with_prod.c.must_have
@@ -28,5 +28,3 @@ v__embed_file__EmbedFileData my_source = _v_embed_file_metadata(
 res.path = _SLIT("embed.vv");
 res.apath = _SLIT("");
 res.uncompressed = v__embed_file__find_index_entry_by_path((voidptr)_v_embed_file_index, _SLIT("embed.vv"), _SLIT("none"))->data;
-
-// Initializations for module v.embed_file :

--- a/vlib/v/gen/c/testdata/embed_with_prod_zlib.c.must_have
+++ b/vlib/v/gen/c/testdata/embed_with_prod_zlib.c.must_have
@@ -28,5 +28,3 @@ v__embed_file__EmbedFileData my_source = _v_embed_file_metadata(
 res.path = _SLIT("embed.vv");
 res.apath = _SLIT("");
 res.compressed = v__embed_file__find_index_entry_by_path((voidptr)_v_embed_file_index, _SLIT("embed.vv"), _SLIT("zlib"))->data;
-
-// Initializations for module v.embed_file :


### PR DESCRIPTION
This PR format module_init generated c codes.

before:
```v
	{ // Initializations for module strings :
	}
	{ // Initializations for module math.bits :
	_const_math__bits__overflow_error = _SLIT("Overflow Error");
	_const_math__bits__divide_error = _SLIT("Divide Error");
	_const_math__bits__de_bruijn32tab = new_array_from_c_array(32, 32, sizeof(u8), _MOV((u8[32]){
		((u8)(0)), 1, 28, 2, 29, 14, 24, 3, 30,
		22, 20, 15, 25, 17, 4, 8, 31,
		27, 13, 23, 21, 19, 16, 7, 26,
		12, 18, 6, 11, 5, 10, 9}));
...
```

format to:
```v
	// Initializations for module math.bits
	_const_math__bits__overflow_error = _SLIT("Overflow Error");
	_const_math__bits__divide_error = _SLIT("Divide Error");
	_const_math__bits__de_bruijn32tab = new_array_from_c_array(32, 32, sizeof(u8), _MOV((u8[32]){
		((u8)(0)), 1, 28, 2, 29, 14, 24, 3, 30,
		22, 20, 15, 25, 17, 4, 8, 31,
		27, 13, 23, 21, 19, 16, 7, 26,
		12, 18, 6, 11, 5, 10, 9}));
...
```