### PR TITLE
doc: fix 'specifing' typo

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -616,7 +616,7 @@ Also note: in most cases, it's best to leave the format type empty. Floats will 
 default as `g`, integers will be rendered by default as `d`, and `s` is almost always redundant.
 There are only three cases where specifying a type is recommended:
 
-- format strings are parsed at compile time, so specifing a type can help detect errors then
+- format strings are parsed at compile time, so specifying a type can help detect errors then
 - format strings default to using lowercase letters for hex digits and the `e` in exponents. Use a
   uppercase type to force the use of uppercase hex digits and an uppercase `E` in exponents.
 - format strings are the most convenient way to get hex, binary or octal strings from an integer.


### PR DESCRIPTION
Hello,

This is a really cool project! Noticed a typo while reading the documentation. 😃 

Best,
Danilo Lekovic