### PR TITLE
tool/vmissdoc: Filter out attributes, when missdoc is run

### DIFF
--- a/cmd/tools/vmissdoc.v
+++ b/cmd/tools/vmissdoc.v
@@ -65,16 +65,18 @@ fn (opt &Options) collect_undocumented_functions_in_file(nfile string) []Undocum
 	mut comments := []string{}
 	mut tags := []string{}
 	for i, line in lines {
-		if line.starts_with("//") {
+		if line.starts_with('//') {
 			comments << line
 		} else if line.trim_space().starts_with('[') {
 			tags << collect_tags(line)
-		} else if line.starts_with('pub fn') || (opt.private && (line.starts_with('fn ')
-			&& !(line.starts_with('fn C.') || line.starts_with('fn main')))) {
+		} else if line.starts_with('pub fn')
+			|| (opt.private && (line.starts_with('fn ') && !(line.starts_with('fn C.')
+			|| line.starts_with('fn main')))) {
 			if comments.len == 0 {
+				clean_line := line.all_before_last(' {')
 				list << UndocumentedFN{
 					line: i + 1
-					signature: line
+					signature: clean_line
 					tags: tags
 					file: file
 				}

--- a/cmd/tools/vmissdoc.v
+++ b/cmd/tools/vmissdoc.v
@@ -60,8 +60,7 @@ fn (opt Options) collect_undocumented_functions_in_dir(directory string) []Undoc
 fn (opt &Options) collect_undocumented_functions_in_file(nfile string) []UndocumentedFN {
 	file := os.real_path(nfile)
 	contents := os.read_file(file) or { panic(err) }
-	lines := contents.split('\n').filter(!(it.trim_space().starts_with('[')
-		&& it.trim_space().ends_with(']')))
+	lines := contents.split('\n')
 	mut list := []UndocumentedFN{}
 	mut comments := []string{}
 	mut tags := []string{}

--- a/cmd/tools/vmissdoc.v
+++ b/cmd/tools/vmissdoc.v
@@ -60,7 +60,8 @@ fn (opt Options) collect_undocumented_functions_in_dir(directory string) []Undoc
 fn (opt &Options) collect_undocumented_functions_in_file(nfile string) []UndocumentedFN {
 	file := os.real_path(nfile)
 	contents := os.read_file(file) or { panic(err) }
-	lines := contents.split('\n').filter(!(it.trim_space().starts_with("[") && it.trim_space().ends_with("]")))
+	lines := contents.split('\n').filter(!(it.trim_space().starts_with('[')
+		&& it.trim_space().ends_with(']')))
 	mut list := []UndocumentedFN{}
 	for i, line in lines {
 		if line.starts_with('pub fn') || (opt.private && (line.starts_with('fn ')

--- a/cmd/tools/vmissdoc.v
+++ b/cmd/tools/vmissdoc.v
@@ -60,7 +60,7 @@ fn (opt Options) collect_undocumented_functions_in_dir(directory string) []Undoc
 fn (opt &Options) collect_undocumented_functions_in_file(nfile string) []UndocumentedFN {
 	file := os.real_path(nfile)
 	contents := os.read_file(file) or { panic(err) }
-	lines := contents.split('\n')
+	lines := contents.split('\n').filter(!(it.trim_space().starts_with("[") && it.trim_space().ends_with("]")))
 	mut list := []UndocumentedFN{}
 	for i, line in lines {
 		if line.starts_with('pub fn') || (opt.private && (line.starts_with('fn ')


### PR DESCRIPTION
#14773 

Fix Vmissdoc to ignore attributes

The PR adds a simple filter to remove the attributes from checking, fixing the cases where docs are present  but an attribute is in between the documented object.