### PR TITLE
checker: check error for struct type is private (fix #14446)

### DIFF
--- a/examples/flappylearning/modules/neuroevolution/neuronevolution.v
+++ b/examples/flappylearning/modules/neuroevolution/neuronevolution.v
@@ -42,7 +42,7 @@ fn (mut l Layer) populate(nb_neurons int, nb_inputs int) {
 	}
 }
 
-struct Network {
+pub struct Network {
 mut:
 	layers []Layer
 }

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -1,7 +1,7 @@
 module io
 
 // BufferedReader provides a buffered interface for a reader
-struct BufferedReader {
+pub struct BufferedReader {
 mut:
 	reader Reader
 	buf    []u8

--- a/vlib/json/json_primitives.v
+++ b/vlib/json/json_primitives.v
@@ -8,7 +8,7 @@ module json
 #include "cJSON.h"
 #define js_get(object, key) cJSON_GetObjectItemCaseSensitive((object), (key))
 
-struct C.cJSON {
+pub struct C.cJSON {
 	valueint    int
 	valuedouble f64
 	valuestring &char

--- a/vlib/net/address_android.c.v
+++ b/vlib/net/address_android.c.v
@@ -2,7 +2,7 @@ module net
 
 const max_unix_path = 108
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -14,28 +14,28 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_family u16
 	sin_port   u16
 	sin_addr   u32
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	sin6_family u16
 	sin6_port   u16
 	sin6_addr   [4]u32
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_family u16
 	sun_path   [max_unix_path]char
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -43,7 +43,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -54,12 +54,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]u8
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	f    u16
 	addr AddrData

--- a/vlib/net/address_darwin.c.v
+++ b/vlib/net/address_darwin.c.v
@@ -2,7 +2,7 @@ module net
 
 const max_unix_path = 104
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -14,7 +14,7 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	// 1 + 1 + 2 + 4 + 16 + 4 = 28;
 	sin6_len      u8     // 1
@@ -25,7 +25,7 @@ mut:
 	sin6_scope_id u32    // 4
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_len    u8
 	sin_family u8
@@ -34,7 +34,7 @@ mut:
 	sin_zero   [8]char
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_len    u8
 	sun_family u8
@@ -42,7 +42,7 @@ mut:
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -50,7 +50,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -61,12 +61,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]char
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	len  u8
 	f    u8

--- a/vlib/net/address_default.c.v
+++ b/vlib/net/address_default.c.v
@@ -2,7 +2,7 @@ module net
 
 const max_unix_path = 104
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -14,21 +14,21 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_family u8
 	sin_port   u16
 	sin_addr   u32
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	sin6_family u8
 	sin6_port   u16
 	sin6_addr   [4]u32
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_family u8
 	sun_path   [max_unix_path]char

--- a/vlib/net/address_dragonfly.c.v
+++ b/vlib/net/address_dragonfly.c.v
@@ -7,7 +7,7 @@ module net
 
 const max_unix_path = 104
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -19,7 +19,7 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	// 1 + 1 + 2 + 4 + 16 + 4 = 28;
 	sin6_len      u8     // 1
@@ -30,7 +30,7 @@ mut:
 	sin6_scope_id u32    // 4
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_len    u8
 	sin_family u8
@@ -39,7 +39,7 @@ mut:
 	sin_zero   [8]char
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_len    u8
 	sun_family u8
@@ -47,7 +47,7 @@ mut:
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -55,7 +55,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -66,12 +66,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]char
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	len  u8
 	f    u8

--- a/vlib/net/address_freebsd.c.v
+++ b/vlib/net/address_freebsd.c.v
@@ -5,7 +5,7 @@ module net
 
 const max_unix_path = 104
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -17,7 +17,7 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	// 1 + 1 + 2 + 4 + 16 + 4 = 28;
 	sin6_len      u8     // 1
@@ -28,7 +28,7 @@ mut:
 	sin6_scope_id u32    // 4
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_len    u8
 	sin_family u8
@@ -37,7 +37,7 @@ mut:
 	sin_zero   [8]char
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_len    u8
 	sun_family u8
@@ -45,7 +45,7 @@ mut:
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -53,7 +53,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -64,12 +64,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]char
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	len  u8
 	f    u8

--- a/vlib/net/address_linux.c.v
+++ b/vlib/net/address_linux.c.v
@@ -2,7 +2,7 @@ module net
 
 const max_unix_path = 108
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -14,28 +14,28 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_family u16
 	sin_port   u16
 	sin_addr   u32
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	sin6_family u16
 	sin6_port   u16
 	sin6_addr   [4]u32
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_family u16
 	sun_path   [max_unix_path]char
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -43,7 +43,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -54,12 +54,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]u8
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	f    u16
 	addr AddrData

--- a/vlib/net/address_netbsd.c.v
+++ b/vlib/net/address_netbsd.c.v
@@ -7,7 +7,7 @@ module net
 
 const max_unix_path = 104
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -19,7 +19,7 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	// 1 + 1 + 2 + 4 + 16 + 4 = 28;
 	sin6_len      u8     // 1
@@ -30,7 +30,7 @@ mut:
 	sin6_scope_id u32    // 4
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_len    u8
 	sin_family u8
@@ -39,7 +39,7 @@ mut:
 	sin_zero   [8]char
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_len    u8
 	sun_family u8
@@ -47,7 +47,7 @@ mut:
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -55,7 +55,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -66,12 +66,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]char
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	len  u8
 	f    u8

--- a/vlib/net/address_openbsd.c.v
+++ b/vlib/net/address_openbsd.c.v
@@ -5,7 +5,7 @@ module net
 
 const max_unix_path = 104
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -17,7 +17,7 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	// 1 + 1 + 2 + 4 + 16 + 4 = 28;
 	sin6_len      u8     // 1
@@ -28,7 +28,7 @@ mut:
 	sin6_scope_id u32    // 4
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_len    u8
 	sin_family u8
@@ -37,7 +37,7 @@ mut:
 	sin_zero   [8]char
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_len    u8
 	sun_family u8
@@ -45,7 +45,7 @@ mut:
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -53,7 +53,7 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port u16
 	addr [4]u8
 	// Pad to size so that socket functions
@@ -64,12 +64,12 @@ struct Ip {
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]char
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	len  u8
 	f    u8

--- a/vlib/net/address_windows.c.v
+++ b/vlib/net/address_windows.c.v
@@ -2,7 +2,7 @@ module net
 
 const max_unix_path = 108
 
-struct C.addrinfo {
+pub struct C.addrinfo {
 mut:
 	ai_family    int
 	ai_socktype  int
@@ -14,28 +14,28 @@ mut:
 	ai_next      voidptr
 }
 
-struct C.sockaddr_in {
+pub struct C.sockaddr_in {
 mut:
 	sin_family u16
 	sin_port   u16
 	sin_addr   u32
 }
 
-struct C.sockaddr_in6 {
+pub struct C.sockaddr_in6 {
 mut:
 	sin6_family u16
 	sin6_port   u16
 	sin6_addr   [4]u32
 }
 
-struct C.sockaddr_un {
+pub struct C.sockaddr_un {
 mut:
 	sun_family u16
 	sun_path   [max_unix_path]char
 }
 
 [_pack: '1']
-struct Ip6 {
+pub struct Ip6 {
 	port      u16
 	flow_info u32
 	addr      [16]u8
@@ -43,18 +43,18 @@ struct Ip6 {
 }
 
 [_pack: '1']
-struct Ip {
+pub struct Ip {
 	port    u16
 	addr    [4]u8
 	sin_pad [8]u8
 }
 
-struct Unix {
+pub struct Unix {
 	path [max_unix_path]u8
 }
 
 [_pack: '1']
-struct Addr {
+pub struct Addr {
 pub:
 	f    u16
 	addr AddrData

--- a/vlib/net/unix/stream_nix.v
+++ b/vlib/net/unix/stream_nix.v
@@ -11,14 +11,14 @@ const (
 	msg_nosignal               = 0x4000
 )
 
-struct StreamSocket {
+pub struct StreamSocket {
 pub:
 	handle int
 mut:
 	path string
 }
 
-struct StreamConn {
+pub struct StreamConn {
 pub mut:
 	sock StreamSocket
 mut:
@@ -28,7 +28,7 @@ mut:
 	write_timeout  time.Duration
 }
 
-struct StreamListener {
+pub struct StreamListener {
 pub mut:
 	sock StreamSocket
 mut:

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -25,7 +25,7 @@ pub mut:
 }
 
 // ServerClient represents a connected client
-struct ServerClient {
+pub struct ServerClient {
 pub:
 	resource_name string // resource that the client access
 	client_key    string // unique key of client

--- a/vlib/os/os_structs_stat_default.c.v
+++ b/vlib/os/os_structs_stat_default.c.v
@@ -1,6 +1,6 @@
 module os
 
-struct C.stat {
+pub struct C.stat {
 	st_size  u64
 	st_mode  u32
 	st_mtime int

--- a/vlib/os/os_structs_stat_linux.c.v
+++ b/vlib/os/os_structs_stat_linux.c.v
@@ -1,6 +1,6 @@
 module os
 
-struct C.stat {
+pub struct C.stat {
 	st_dev     u64 // 8
 	st_ino     u64 // 8
 	st_nlink   u64 // 8

--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -16,7 +16,7 @@ import os
 const cclen = 10
 
 // Termios stores the terminal options on Linux.
-struct C.termios {
+pub struct C.termios {
 mut:
 	c_iflag int
 	c_oflag int

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -31,7 +31,7 @@ enum Direction {
 	push
 }
 
-struct Channel {
+pub struct Channel {
 	ringbuf   &u8 // queue for buffered channels
 	statusbuf &u8 // flags to synchronize write/read in ringbuf
 	objsize   u32

--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -54,7 +54,7 @@ MacOSX has no unnamed semaphores and no `timed_wait()` at all
    so we emulate the behaviour with other devices
 */
 [heap]
-struct Semaphore {
+pub struct Semaphore {
 	mtx  C.pthread_mutex_t
 	cond C.pthread_cond_t
 mut:

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -60,7 +60,7 @@ struct RwMutexAttr {
 }
 
 [heap]
-struct Semaphore {
+pub struct Semaphore {
 	sem C.sem_t
 }
 

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -38,7 +38,7 @@ mut:
 }
 
 [heap]
-struct Semaphore {
+pub struct Semaphore {
 	mtx  C.SRWLOCK
 	cond C.CONDITION_VARIABLE
 mut:

--- a/vlib/sync/waitgroup.c.v
+++ b/vlib/sync/waitgroup.c.v
@@ -25,7 +25,7 @@ fn C.atomic_compare_exchange_weak_u32(voidptr, voidptr, u32) bool
 //
 // [init_with=new_waitgroup] // TODO: implement support for init_with struct attribute, and disallow WaitGroup{} from outside the sync.new_waitgroup() function.
 [heap]
-struct WaitGroup {
+pub struct WaitGroup {
 mut:
 	task_count u32       // current task count - reading/writing should be atomic
 	wait_count u32       // current wait count - reading/writing should be atomic

--- a/vlib/term/term_windows.c.v
+++ b/vlib/term/term_windows.c.v
@@ -3,14 +3,14 @@ module term
 import os
 
 [typedef]
-struct C.COORD {
+pub struct C.COORD {
 mut:
 	X i16
 	Y i16
 }
 
 [typedef]
-struct C.SMALL_RECT {
+pub struct C.SMALL_RECT {
 mut:
 	Left   u16
 	Top    u16
@@ -21,7 +21,7 @@ mut:
 // win: CONSOLE_SCREEN_BUFFER_INFO
 // https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str
 [typedef]
-struct C.CONSOLE_SCREEN_BUFFER_INFO {
+pub struct C.CONSOLE_SCREEN_BUFFER_INFO {
 mut:
 	dwSize              C.COORD
 	dwCursorPosition    C.COORD
@@ -30,14 +30,14 @@ mut:
 	dwMaximumWindowSize C.COORD
 }
 
-union C.uChar {
+pub union C.uChar {
 mut:
 	UnicodeChar rune
 	AsciiChar   u8
 }
 
 [typedef]
-struct C.CHAR_INFO {
+pub struct C.CHAR_INFO {
 mut:
 	Char       C.uChar
 	Attributes u16

--- a/vlib/term/ui/declarations_linux.c.v
+++ b/vlib/term/ui/declarations_linux.c.v
@@ -1,6 +1,6 @@
 module ui
 
-struct C.termios {
+pub struct C.termios {
 mut:
 	c_iflag int
 	c_oflag int

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -15,7 +15,7 @@ struct C.tm {
 	tm_sec  int
 }
 
-struct C._FILETIME {
+pub struct C._FILETIME {
 	dwLowDateTime  u32
 	dwHighDateTime u32
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3724,6 +3724,10 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) ? {
 		return
 	}
 	sym := c.table.sym(typ)
+	if !c.is_builtin_mod && sym.kind == .struct_ && sym.mod != c.mod && !sym.is_pub {
+		c.error('type `$sym.name` is private', pos)
+		return
+	}
 	match sym.kind {
 		.placeholder {
 			if sym.language == .v && !sym.name.starts_with('C.') {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -261,7 +261,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		&& c.table.cur_concrete_types.len == 0 {
 		pos := type_sym.name.last_index('.') or { -1 }
 		first_letter := type_sym.name[pos + 1]
-		if !first_letter.is_capital() {
+		if !first_letter.is_capital() && type_sym.kind != .placeholder {
 			c.error('cannot initialize builtin type `$type_sym.name`', node.pos)
 		}
 	}

--- a/vlib/v/checker/tests/struct_type_is_private_err.out
+++ b/vlib/v/checker/tests/struct_type_is_private_err.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/struct_type_is_private_err.vv:1:8: warning: module 'sqlite' is imported but never used
+    1 | import sqlite
+      |        ~~~~~~
+    2 |
+    3 | fn main(){
+vlib/v/checker/tests/struct_type_is_private_err.vv:4:10: error: type `C.sqlite3` is private
+    2 |
+    3 | fn main(){
+    4 |     _ := &C.sqlite3{}
+      |             ~~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/struct_type_is_private_err.vv
+++ b/vlib/v/checker/tests/struct_type_is_private_err.vv
@@ -1,0 +1,5 @@
+import sqlite
+
+fn main(){
+	_ := &C.sqlite3{}
+}

--- a/vlib/v/depgraph/depgraph.v
+++ b/vlib/v/depgraph/depgraph.v
@@ -14,7 +14,7 @@ pub mut:
 	deps  []string
 }
 
-struct DepGraph {
+pub struct DepGraph {
 pub mut:
 	acyclic bool
 	nodes   []DepGraphNode

--- a/vlib/v/dotgraph/dotgraph.v
+++ b/vlib/v/dotgraph/dotgraph.v
@@ -3,7 +3,7 @@ module dotgraph
 import strings
 
 [heap]
-struct DotGraph {
+pub struct DotGraph {
 mut:
 	sb strings.Builder
 }

--- a/vlib/v/gen/js/sourcemap/source_map.v
+++ b/vlib/v/gen/js/sourcemap/source_map.v
@@ -10,7 +10,7 @@ const (
 
 type SourceMapJson = map[string]json2.Any
 
-struct SourceMap {
+pub struct SourceMap {
 pub mut:
 	version                int               [json: version]
 	file                   string            [json: file]

--- a/vlib/vweb/assets/assets.v
+++ b/vlib/vweb/assets/assets.v
@@ -10,7 +10,7 @@ const (
 	unknown_asset_type_error = 'vweb.assets: unknown asset type'
 )
 
-struct AssetManager {
+pub struct AssetManager {
 mut:
 	css []Asset
 	js  []Asset


### PR DESCRIPTION
This PR check error for struct type is private (fix #14446).

- Check error for struct type is private.
- Add test.
- Fix all the related errors.

```v
import sqlite

fn main(){
	_ := &C.sqlite3{}
}

PS D:\Test\v\tt1> v run .
./tt1.v:1:8: warning: module 'sqlite' is imported but never used
    1 | import sqlite
      |        ~~~~~~
    2 |
    3 | fn main(){
./tt1.v:4:9: error: type `C.sqlite3` is private
    2 |
    3 | fn main(){
    4 | _ := &C.sqlite3{}
      |         ~~~~~~~~~
    5 | }
```