### PR TITLE
ast: fix array of reference sumtype appending (fix #14794)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1342,7 +1342,7 @@ pub fn (t &Table) is_sumtype_or_in_variant(parent Type, typ Type) bool {
 	if typ == 0 {
 		return false
 	}
-	if t.type_kind(typ) == .sum_type && parent.idx() == typ.idx()
+	if t.sym(typ).kind == .sum_type && parent.idx() == typ.idx()
 		&& parent.nr_muls() == typ.nr_muls() {
 		return true
 	}

--- a/vlib/v/tests/array_of_reference_sumtype_append_test.v
+++ b/vlib/v/tests/array_of_reference_sumtype_append_test.v
@@ -1,0 +1,35 @@
+struct Element {
+	AbstractNode
+	name       string
+	attributes []&Attribute
+}
+
+struct Attribute {
+	AbstractNode
+	name  string
+	value string
+}
+
+pub type Node = Attribute | Element
+
+struct AbstractNode {
+pub mut:
+	child_nodes []&Node
+}
+
+pub fn (mut n AbstractNode) append_child(child &Node) {
+	n.child_nodes << child
+}
+
+fn test_array_of_reference_sumtype_append() {
+	mut parent := &Element{
+		name: 'parent'
+	}
+	mut child := &Element{
+		name: 'child'
+	}
+	parent.append_child(child)
+
+	dump(parent)
+	assert parent.child_nodes[0].name == 'child'
+}


### PR DESCRIPTION
This PR fix array of reference sumtype appending (fix #14794).

- Fix array of reference sumtype appending.
- Add test.

```v
struct Element {
	AbstractNode
	name       string
	attributes []&Attribute
}

struct Attribute {
	AbstractNode
	name  string
	value string
}

pub type Node = Attribute | Element

struct AbstractNode {
pub mut:
	child_nodes []&Node
}

pub fn (mut n AbstractNode) append_child(child &Node) {
	n.child_nodes << child
}

fn main() {
	mut parent := &Element{
		name: 'parent'
	}
	mut child := &Element{
		name: 'child'
	}
	parent.append_child(child)

	dump(parent)
	assert parent.child_nodes[0].name == 'child'
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:33] parent: &Element{
    AbstractNode: AbstractNode{
        child_nodes: [Node(Element{
            AbstractNode: AbstractNode{
                child_nodes: []
            }
            name: 'child'
            attributes: []
        })]
    }
    name: 'parent'
    attributes: []
}
```