### PR TITLE
checker: check mutable reference unimmutable reference variable (fix #14803)

### DIFF
--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -205,7 +205,7 @@ pub fn resolve_ipaddrs(addr string, family AddrFamily, typ SocketType) ?[]Addr {
 	// convert them into an array
 	mut addresses := []Addr{}
 
-	for result := results; !isnil(result); result = result.ai_next {
+	for result := unsafe { results }; !isnil(result); result = result.ai_next {
 		match AddrFamily(result.ai_family) {
 			.ip {
 				new_addr := Addr{

--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -86,7 +86,7 @@ pub fn init(cfg Config) &Context {
 	C.atexit(restore_terminal_state)
 	for code in ctx.cfg.reset {
 		os.signal_opt(code, fn (_ os.Signal) {
-			mut c := ui.ctx_ptr
+			mut c := unsafe { ui.ctx_ptr }
 			if unsafe { c != 0 } {
 				c.cleanup()
 			}

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -42,7 +42,7 @@ fn (s &Scope) dont_lookup_parent() bool {
 }
 
 pub fn (s &Scope) find(name string) ?ScopeObject {
-	for sc := s; true; sc = sc.parent {
+	for sc := unsafe { s }; true; sc = sc.parent {
 		if name in sc.objects {
 			return unsafe { sc.objects[name] }
 		}
@@ -55,7 +55,7 @@ pub fn (s &Scope) find(name string) ?ScopeObject {
 
 // selector_expr:  name.field_name
 pub fn (s &Scope) find_struct_field(name string, struct_type Type, field_name string) ?ScopeStructField {
-	for sc := s; true; sc = sc.parent {
+	for sc := unsafe { s }; true; sc = sc.parent {
 		if field := sc.struct_fields[name] {
 			if field.struct_type == struct_type && field.name == field_name {
 				return field

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -157,6 +157,13 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					}
 				}
 			}
+			if mut left is ast.Ident && mut right is ast.Ident {
+				if !c.inside_unsafe && left_type.is_ptr() && left.is_mut() && right_type.is_ptr()
+					&& !right.is_mut() {
+					c.error('`$right.name` is immutable, cannot have a mutable reference to it',
+						right.pos)
+				}
+			}
 		} else {
 			// Make sure the variable is mutable
 			c.fail_if_immutable(left)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -174,7 +174,7 @@ fn (mut c Checker) reset_checker_state_at_start_of_new_file() {
 }
 
 pub fn (mut c Checker) check(ast_file_ &ast.File) {
-	mut ast_file := ast_file_
+	mut ast_file := unsafe { ast_file_ }
 	c.reset_checker_state_at_start_of_new_file()
 	c.change_current_file(ast_file)
 	for i, ast_import in ast_file.imports {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -877,7 +877,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				c.fail_if_unreadable(call_arg.expr, arg_typ, 'argument')
 			}
 		}
-		mut final_param_sym := param_typ_sym
+		mut final_param_sym := unsafe { param_typ_sym }
 		mut final_param_typ := param.typ
 		if func.is_variadic && param_typ_sym.info is ast.Array {
 			final_param_typ = param_typ_sym.info.elem_type
@@ -1349,7 +1349,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				c.error('when forwarding a variadic variable, it must be the final argument',
 					arg.pos)
 			}
-			mut final_arg_sym := exp_arg_sym
+			mut final_arg_sym := unsafe { exp_arg_sym }
 			mut final_arg_typ := exp_arg_typ
 			if method.is_variadic && exp_arg_sym.info is ast.Array {
 				final_arg_typ = exp_arg_sym.info.elem_type

--- a/vlib/v/checker/tests/assign_immutable_reference_var_err.out
+++ b/vlib/v/checker/tests/assign_immutable_reference_var_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/assign_immutable_reference_var_err.vv:8:11: error: `x` is immutable, cannot have a mutable reference to it
+    6 |
+    7 | fn y(x &Foo) {
+    8 |     mut m := x
+      |              ^
+    9 |     m.value = 42
+   10 | }

--- a/vlib/v/checker/tests/assign_immutable_reference_var_err.vv
+++ b/vlib/v/checker/tests/assign_immutable_reference_var_err.vv
@@ -1,0 +1,16 @@
+[heap]
+struct Foo {
+mut:
+	value int
+}
+
+fn y(x &Foo) {
+	mut m := x
+	m.value = 42
+}
+
+fn main() {
+	x := Foo{123}
+	y(x)
+	println(x)
+}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -89,7 +89,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					p.scope_register_it_as_index()
 					default_expr = p.expr(0)
 					has_it = if var := p.scope.find_var('it') {
-						mut variable := var
+						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
 						is_used
@@ -148,7 +148,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					p.scope_register_it_as_index()
 					default_expr = p.expr(0)
 					has_it = if var := p.scope.find_var('it') {
-						mut variable := var
+						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
 						is_used


### PR DESCRIPTION
This PR check mutable reference unimmutable reference variable (fix #14803).

- Check mutable reference unimmutable reference variable.
- Add test.

```v
[heap]
struct Foo {
mut:
	value int
}

fn y(x &Foo) {
	mut m := x
	m.value = 42
}

fn main() {
	x := Foo{123}
	y(x)
	println(x)
}

PS D:\Test\v\tt1> v run .
./tt1.v:8:11: error: `x` is immutable, cannot have a mutable reference to it
    6 |
    7 | fn y(x &Foo) {
    8 |     mut m := x
      |              ^
    9 |     m.value = 42
   10 | }
```