### PR TITLE
fix scan_static_directory 

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -613,7 +613,7 @@ fn (mut ctx Context) scan_static_directory(directory_path string, mount_path str
 		for file in files {
 			full_path := os.join_path(directory_path, file)
 			if os.is_dir(full_path) {
-				ctx.scan_static_directory(full_path, mount_path + '/' + file)
+				ctx.scan_static_directory(full_path, mount_path + file)
 			} else if file.contains('.') && !file.starts_with('.') && !file.ends_with('.') {
 				ext := os.file_ext(file)
 				// Rudimentary guard against adding files not in mime_types.


### PR DESCRIPTION
remove the extra '/' when calling scan_static_directory, or the moun_path will be '//$file'.

Tests pasted with examples\vweb\server_sent_events.
I found this bug when running this example too , static files in assets/  were not served , because the mount_path being '//assets'.
Removing the extra '\' , it  worked correctly.