### PR TITLE
encoding: Make csv.Reader public

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -38,7 +38,7 @@ fn (err InvalidLineEndingError) msg() string {
 	return 'encoding.csv: could not find any valid line endings'
 }
 
-struct Reader {
+pub struct Reader {
 	// not used yet
 	// has_header        bool
 	// headings          []string


### PR DESCRIPTION
This will fix the following implementation on VTL. Link [here](https://github.com/vlang/vtl/runs/6977385326?check_suite_focus=true).

It is needed to have the struct public so it is possible to write a Database loader around it.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
