### PR TITLE
clipboard: make clipboard.Clipboard public on windows

### DIFF
--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -55,7 +55,7 @@ fn C.DestroyWindow(hwnd C.HWND)
 //
 // System "copy" and "paste" actions utilize the clipboard for temporary storage.
 [heap]
-struct Clipboard {
+pub struct Clipboard {
 	max_retries int
 	retry_delay int
 mut:


### PR DESCRIPTION
This PR makes clipboard.Clipboard public on windows.

- To fix vui errors on windows.