### PR TITLE
ci: remove `continue-on-error: true` for most ci jobs

### DIFF
--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -89,7 +89,6 @@ jobs:
       - name: g++ version
         run: g++-9 --version
       - name: V self compilation with g++
-        continue-on-error: true
         run: ./v -cc g++-9 -no-std -cflags -std=c++11 -o v2 cmd/v && ./v2 -cc g++-9 -no-std -cflags -std=c++11 -o v3 cmd/v
         ##    - name: Running tests with g++
         ##      run: ./v -cc g++-9 test-self
@@ -98,7 +97,6 @@ jobs:
         run: ./v -autofree -o v2 cmd/v  ## NB: this does not mean it runs, but at least keeps it from regressing
 
       - name: Shader examples can be build
-        continue-on-error: true
         run: |
           wget https://github.com/floooh/sokol-tools-bin/raw/33d2e4cc26088c6c28eaef5467990f8940d15aab/bin/linux/sokol-shdc
           chmod +x ./sokol-shdc

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -86,7 +86,6 @@ jobs:
           v -gc boehm -skip-unused /tmp/vab
 
       - name: Build Gitly
-        continue-on-error: true
         run: |
           echo "Clone markdown"
           git clone https://github.com/vlang/markdown ~/.vmodules/markdown

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -31,13 +31,11 @@ jobs:
           sudo apt-get install --quiet -y xfonts-75dpi xfonts-base
 
       - name: Install UI through VPM
-        continue-on-error: true
         run: |
           echo "Official VPM modules should be installable"
           ./v install ui
 
       - name: Build V Language Server (VLS)
-        continue-on-error: true
         run: |
           echo "Clone VLS"
           git clone --depth 1 https://github.com/vlang/vls
@@ -49,7 +47,6 @@ jobs:
           pushd vls; v -gc boehm -skip-unused cmd/vls; popd
 
       - name: Build VSL
-        continue-on-error: true
         run: |
           git clone --depth 1 https://github.com/vlang/vsl ~/.vmodules/vsl
           sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev libgc-dev
@@ -63,7 +60,6 @@ jobs:
           ~/.vmodules/vsl/bin/test --use-cblas --use-gc boehm
 
       - name: Build VTL
-        continue-on-error: true
         run: |
           echo "Clone VTL"
           git clone --depth 1 https://github.com/vlang/vtl ~/.vmodules/vtl
@@ -79,7 +75,6 @@ jobs:
           ~/.vmodules/vtl/bin/test --use-cblas --use-gc boehm
 
       - name: Build VAB
-        continue-on-error: true
         run: |
           echo "Clone vab"
           git clone --depth 1 https://github.com/vlang/vab
@@ -89,7 +84,6 @@ jobs:
           cd vab; ../v -gc boehm -skip-unused ./vab.v ; cd ..
 
       - name: Build Gitly
-        continue-on-error: true
         run: |
           echo "Clone markdown"
           git clone https://github.com/vlang/markdown ~/.vmodules/markdown
@@ -105,7 +99,6 @@ jobs:
           # ./gitly -ci_run
 
       - name: Build libsodium
-        continue-on-error: true
         run: |
           echo "Install libsodium-dev package"
           sudo apt-get install --quiet -y libsodium-dev
@@ -115,7 +108,6 @@ jobs:
           VJOBS=1 ./v -stats test ~/.vmodules/libsodium
 
       - name: Build VEX
-        continue-on-error: true
         run: |
           echo "Install Vex dependencies"
           sudo apt-get install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev
@@ -129,7 +121,6 @@ jobs:
           ./v test ~/.vmodules/nedpals/vex
 
       - name: Build go2v
-        continue-on-error: true
         run: |
           echo "Clone Go2V"
           clone --depth=1 https://github.com/vlang/go2v go2v/
@@ -139,7 +130,6 @@ jobs:
           VJOBS=1 ./v -stats test go2v/
 
       - name: Build vlang/pdf
-        continue-on-error: true
         run: |
           git clone --depth=1 https://github.com/vlang/pdf ~/.vmodules/pdf/
           echo "PDF examples should compile"

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -25,10 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --quiet -y libgc-dev
-          sudo apt-get install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
-          sudo apt-get install --quiet -y xfonts-75dpi xfonts-base
+          sudo apt-get install --quiet -y libgc-dev   libsodium-dev libssl-dev sqlite3 libsqlite3-dev    valgrind    libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
+          sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev
 
       - name: Build V Language Server (VLS)
         run: |
@@ -48,36 +46,6 @@ jobs:
           echo "Build Coreutils"
           cd /tmp/coreutils; make
 
-      - name: Build VSL
-        run: |
-          echo "Install VSL"
-          v install vsl
-          echo "Install dependencies"
-          sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev libgc-dev
-          echo "Execute Tests using Pure V Backend"
-          ~/.vmodules/vsl/bin/test
-          echo "Execute Tests using Pure V Backend with Pure V Math"
-          ~/.vmodules/vsl/bin/test --use-cblas
-          echo "Execute Tests using Pure V Backend and Garbage Collection enabled"
-          ~/.vmodules/vsl/bin/test --use-gc boehm
-          echo "Execute Tests using Pure V Backend with Pure V Math and Garbage Collection enabled"
-          ~/.vmodules/vsl/bin/test --use-cblas --use-gc boehm
-
-      - name: Build VTL
-        run: |
-          echo "Install VTL"
-          v install vtl
-          echo "Install dependencies"
-          sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev libgc-dev
-          echo "Execute Tests using Pure V Backend"
-          ~/.vmodules/vtl/bin/test
-          echo "Execute Tests using Pure V Backend with Pure V Math"
-          ~/.vmodules/vtl/bin/test --use-cblas
-          echo "Execute Tests using Pure V Backend and Garbage Collection enabled"
-          ~/.vmodules/vtl/bin/test --use-gc boehm
-          echo "Execute Tests using Pure V Backend with Pure V Math and Garbage Collection enabled"
-          ~/.vmodules/vtl/bin/test --use-cblas --use-gc boehm
-
       - name: Build VAB
         run: |
           echo "Install VAB"
@@ -92,7 +60,7 @@ jobs:
           echo "Install markdown"
           v install markdown
           echo "Clone Gitly"
-          git clone --depth 1 https://github.com/vlang/gitly /tmp/gitly
+          git clone https://github.com/vlang/gitly /tmp/gitly
           echo "Build Gitly"
           v /tmp/gitly
           echo "Build Gitly with -autofree"
@@ -103,8 +71,6 @@ jobs:
 
       - name: Build libsodium
         run: |
-          echo "Install libsodium-dev package"
-          sudo apt-get install --quiet -y libsodium-dev
           echo "Install the libsodium wrapper"
           v install libsodium
           echo "Test libsodium"
@@ -112,8 +78,6 @@ jobs:
 
       - name: Build VEX
         run: |
-          echo "Install Vex dependencies"
-          sudo apt-get install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev
           echo "Install Vex"
           v install nedpals.vex
           echo "Compile all of the Vex examples"
@@ -139,9 +103,35 @@ jobs:
           v should-compile-all ~/.vmodules/pdf/examples
 
       - name: Install UI through VPM
-        continue-on-error: true
         run: |
           echo "Official VPM modules should be installable"
           v install ui
           echo "Examples of UI should compile"
           v ~/.vmodules/ui/examples/build_examples.vsh
+
+      - name: Build VSL
+        run: |
+          echo "Install VSL"
+          v install vsl
+          echo "Execute Tests using Pure V Backend"
+          ~/.vmodules/vsl/bin/test
+          echo "Execute Tests using Pure V Backend with Pure V Math"
+          ~/.vmodules/vsl/bin/test --use-cblas
+          echo "Execute Tests using Pure V Backend and Garbage Collection enabled"
+          ~/.vmodules/vsl/bin/test --use-gc boehm
+          echo "Execute Tests using Pure V Backend with Pure V Math and Garbage Collection enabled"
+          ~/.vmodules/vsl/bin/test --use-cblas --use-gc boehm
+
+      - name: Build VTL
+        run: |
+          echo "Install VTL"
+          v install vtl
+          echo "Install dependencies"
+          echo "Execute Tests using Pure V Backend"
+          ~/.vmodules/vtl/bin/test
+          echo "Execute Tests using Pure V Backend with Pure V Math"
+          ~/.vmodules/vtl/bin/test --use-cblas
+          echo "Execute Tests using Pure V Backend and Garbage Collection enabled"
+          ~/.vmodules/vtl/bin/test --use-gc boehm
+          echo "Execute Tests using Pure V Backend with Pure V Math and Garbage Collection enabled"
+          ~/.vmodules/vtl/bin/test --use-cblas --use-gc boehm

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -46,6 +46,13 @@ jobs:
           echo "Build VLS with -gc boehm -skip-unused"
           pushd vls; v -gc boehm -skip-unused cmd/vls; popd
 
+      - name: Build V Coreutils
+        run: |
+          echo "Clone Coreutils"
+          git clone --depth 1 https://github.com/vlang/coreutils
+          echo "Build Coreutils"
+          pushd coreutils; make; popd
+
       - name: Build VSL
         run: |
           git clone --depth 1 https://github.com/vlang/vsl ~/.vmodules/vsl

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -33,25 +33,25 @@ jobs:
       - name: Install UI through VPM
         run: |
           echo "Official VPM modules should be installable"
-          ./v install ui
+          v install ui
 
       - name: Build V Language Server (VLS)
         run: |
           echo "Clone VLS"
-          git clone --depth 1 https://github.com/vlang/vls
+          git clone --depth 1 https://github.com/vlang/vls /tmp/vls
           echo "Build VLS"
-          pushd vls; v cmd/vls ; popd
+          v /tmp/vls/cmd/vls
           echo "Build VLS with -prod"
-          pushd vls; v -prod cmd/vls; popd
+          v -prod /tmp/vls/cmd/vls
           echo "Build VLS with -gc boehm -skip-unused"
-          pushd vls; v -gc boehm -skip-unused cmd/vls; popd
+          v -gc boehm -skip-unused /tmp/vls/cmd/vls
 
       - name: Build V Coreutils
         run: |
           echo "Clone Coreutils"
-          git clone --depth 1 https://github.com/vlang/coreutils
+          git clone --depth 1 https://github.com/vlang/coreutils /tmp/coreutils
           echo "Build Coreutils"
-          pushd coreutils; make; popd
+          cd /tmp/coreutils; make
 
       - name: Build VSL
         run: |
@@ -84,26 +84,25 @@ jobs:
       - name: Build VAB
         run: |
           echo "Clone vab"
-          git clone --depth 1 https://github.com/vlang/vab
+          git clone --depth 1 https://github.com/vlang/vab /tmp/vab
           echo "Build vab"
-          cd vab; ../v ./vab.v ; cd ..
+          v /tmp/vab
           echo "Build vab with -gc boehm -skip-unused"
-          cd vab; ../v -gc boehm -skip-unused ./vab.v ; cd ..
+          v -gc boehm -skip-unused /tmp/vab
 
       - name: Build Gitly
         run: |
           echo "Clone markdown"
           git clone https://github.com/vlang/markdown ~/.vmodules/markdown
           echo "Clone Gitly"
-          git clone --depth 1 https://github.com/vlang/gitly
-          cd gitly
+          git clone --depth 1 https://github.com/vlang/gitly /tmp/gitly
           echo "Build Gitly"
-          ../v .
+          v /tmp/gitly
           echo "Build Gitly with -autofree"
-          ../v -autofree .
+          v -autofree /tmp/gitly
           echo "Run first_run.v"
-          ../v run tests/first_run.v
-          # ./gitly -ci_run
+          v run /tmp/gitly/tests/first_run.v
+          # /tmp/gitly/gitly -ci_run
 
       - name: Build libsodium
         run: |
@@ -112,7 +111,7 @@ jobs:
           echo "Clone the libsodium wrapper"
           git clone https://github.com/vlang/libsodium ~/.vmodules/libsodium
           echo "Test libsodium"
-          VJOBS=1 ./v -stats test ~/.vmodules/libsodium
+          VJOBS=1 v -stats test ~/.vmodules/libsodium
 
       - name: Build VEX
         run: |
@@ -121,23 +120,23 @@ jobs:
           echo "Clone Vex"
           mkdir -p ~/.vmodules/nedpals; git clone https://github.com/nedpals/vex ~/.vmodules/nedpals/vex
           echo "Compile all of the Vex examples"
-          ./v should-compile-all ~/.vmodules/nedpals/vex/examples
+          v should-compile-all ~/.vmodules/nedpals/vex/examples
           echo "Compile the simple Vex example with -gc boehm -skip-unused"
-          ./v -gc boehm -skip-unused ~/.vmodules/nedpals/vex/examples/simple_example.v
+          v -gc boehm -skip-unused ~/.vmodules/nedpals/vex/examples/simple_example.v
           echo "Run Vex Tests"
-          ./v test ~/.vmodules/nedpals/vex
+          v test ~/.vmodules/nedpals/vex
 
       - name: Build go2v
         run: |
           echo "Clone Go2V"
-          clone --depth=1 https://github.com/vlang/go2v go2v/
+          clone --depth=1 https://github.com/vlang/go2v /tmp/go2v/
           echo "Build Go2V"
-          ./v go2v/
+          v /tmp/go2v/
           echo "Run Go2V tests"
-          VJOBS=1 ./v -stats test go2v/
+          VJOBS=1 v -stats test /tmp/go2v/
 
       - name: Build vlang/pdf
         run: |
           git clone --depth=1 https://github.com/vlang/pdf ~/.vmodules/pdf/
           echo "PDF examples should compile"
-          ./v should-compile-all ~/.vmodules/pdf/examples
+          v should-compile-all ~/.vmodules/pdf/examples

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -67,7 +67,6 @@ jobs:
           ~/.vmodules/vsl/bin/test --use-cblas --use-gc boehm
 
       - name: Build VTL
-        continue-on-error: true
         run: |
           echo "Clone VTL"
           git clone --depth 1 https://github.com/vlang/vtl ~/.vmodules/vtl

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -30,11 +30,6 @@ jobs:
           sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
           sudo apt-get install --quiet -y xfonts-75dpi xfonts-base
 
-      - name: Install UI through VPM
-        run: |
-          echo "Official VPM modules should be installable"
-          v install ui
-
       - name: Build V Language Server (VLS)
         run: |
           echo "Clone VLS"
@@ -140,3 +135,9 @@ jobs:
           git clone --depth=1 https://github.com/vlang/pdf ~/.vmodules/pdf/
           echo "PDF examples should compile"
           v should-compile-all ~/.vmodules/pdf/examples
+
+      - name: Install UI through VPM
+        continue-on-error: true
+        run: |
+          echo "Official VPM modules should be installable"
+          v install ui

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -86,6 +86,7 @@ jobs:
           v -gc boehm -skip-unused /tmp/vab
 
       - name: Build Gitly
+        continue-on-error: true
         run: |
           echo "Clone markdown"
           git clone https://github.com/vlang/markdown ~/.vmodules/markdown

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Build VSL
         run: |
-          git clone --depth 1 https://github.com/vlang/vsl ~/.vmodules/vsl
+          echo "Install VSL"
+          v install vsl
+          echo "Install dependencies"
           sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev libgc-dev
           echo "Execute Tests using Pure V Backend"
           ~/.vmodules/vsl/bin/test
@@ -63,8 +65,8 @@ jobs:
 
       - name: Build VTL
         run: |
-          echo "Clone VTL"
-          git clone --depth 1 https://github.com/vlang/vtl ~/.vmodules/vtl
+          echo "Install VTL"
+          v install vtl
           echo "Install dependencies"
           sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev libgc-dev
           echo "Execute Tests using Pure V Backend"
@@ -78,17 +80,17 @@ jobs:
 
       - name: Build VAB
         run: |
-          echo "Clone vab"
-          git clone --depth 1 https://github.com/vlang/vab /tmp/vab
+          echo "Install VAB"
+          v install vab
           echo "Build vab"
-          v /tmp/vab
+          v ~/.vmodules/vab
           echo "Build vab with -gc boehm -skip-unused"
-          v -gc boehm -skip-unused /tmp/vab
+          v -gc boehm -skip-unused ~/.vmodules/vab
 
       - name: Build Gitly
         run: |
-          echo "Clone markdown"
-          git clone https://github.com/vlang/markdown ~/.vmodules/markdown
+          echo "Install markdown"
+          v install markdown
           echo "Clone Gitly"
           git clone --depth 1 https://github.com/vlang/gitly /tmp/gitly
           echo "Build Gitly"
@@ -103,17 +105,17 @@ jobs:
         run: |
           echo "Install libsodium-dev package"
           sudo apt-get install --quiet -y libsodium-dev
-          echo "Clone the libsodium wrapper"
-          git clone https://github.com/vlang/libsodium ~/.vmodules/libsodium
+          echo "Install the libsodium wrapper"
+          v install libsodium
           echo "Test libsodium"
-          VJOBS=1 v -stats test ~/.vmodules/libsodium
+          VJOBS=1 v test ~/.vmodules/libsodium
 
       - name: Build VEX
         run: |
           echo "Install Vex dependencies"
           sudo apt-get install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev
-          echo "Clone Vex"
-          mkdir -p ~/.vmodules/nedpals; git clone https://github.com/nedpals/vex ~/.vmodules/nedpals/vex
+          echo "Install Vex"
+          v install nedpals.vex
           echo "Compile all of the Vex examples"
           v should-compile-all ~/.vmodules/nedpals/vex/examples
           echo "Compile the simple Vex example with -gc boehm -skip-unused"
@@ -132,7 +134,7 @@ jobs:
 
       - name: Build vlang/pdf
         run: |
-          git clone --depth=1 https://github.com/vlang/pdf ~/.vmodules/pdf/
+          v install pdf
           echo "PDF examples should compile"
           v should-compile-all ~/.vmodules/pdf/examples
 
@@ -141,3 +143,5 @@ jobs:
         run: |
           echo "Official VPM modules should be installable"
           v install ui
+          echo "Examples of UI should compile"
+          v ~/.vmodules/ui/examples/build_examples.vsh

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -67,6 +67,7 @@ jobs:
           ~/.vmodules/vsl/bin/test --use-cblas --use-gc boehm
 
       - name: Build VTL
+        continue-on-error: true
         run: |
           echo "Clone VTL"
           git clone --depth 1 https://github.com/vlang/vtl ~/.vmodules/vtl

--- a/.github/workflows/v_apps_and_modules_compile.yml
+++ b/.github/workflows/v_apps_and_modules_compile.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Build go2v
         run: |
           echo "Clone Go2V"
-          clone --depth=1 https://github.com/vlang/go2v /tmp/go2v/
+          git clone --depth=1 https://github.com/vlang/go2v /tmp/go2v/
           echo "Build Go2V"
           v /tmp/go2v/
           echo "Run Go2V tests"

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install vab
       run: |
-        git clone --depth 1 https://github.com/vlang/vab ~/.vmodules/vab
+        v install vab
         v -g ~/.vmodules/vab
         sudo ln -s ~/.vmodules/vab/vab /usr/local/bin/vab
 

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install vab
       run: |
-        v install vab
+        git clone --depth 1 https://github.com/vlang/vab ~/.vmodules/vab
         v -g ~/.vmodules/vab
         sudo ln -s ~/.vmodules/vab/vab /usr/local/bin/vab
 


### PR DESCRIPTION
Since github does show the status of failed tasks as OK, with `continue-on-error: true`
using it can and did hide important errors after bigger V changes (like the new pub
requirement for private C. types, used in external modules).

This removes that attribute, to see what the failures are, so that they can be fixed quicker.
