### PR TITLE
cgen: fix array of reference sumtype index()  (fix #14801)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -858,10 +858,18 @@ fn (mut g Gen) gen_array_index_methods() {
 			fn_builder.writeln('\t\tif (${ptr_typ}_struct_eq(*pelem, v)) {')
 		} else if elem_sym.kind == .interface_ {
 			ptr_typ := g.equality_fn(info.elem_type)
-			fn_builder.writeln('\t\tif (${ptr_typ}_interface_eq(*pelem, v)) {')
+			if info.elem_type.is_ptr() {
+				fn_builder.writeln('\t\tif (${ptr_typ}_interface_eq(**pelem, *v)) {')
+			} else {
+				fn_builder.writeln('\t\tif (${ptr_typ}_interface_eq(*pelem, v)) {')
+			}
 		} else if elem_sym.kind == .sum_type {
 			ptr_typ := g.equality_fn(info.elem_type)
-			fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq(*pelem, v)) {')
+			if info.elem_type.is_ptr() {
+				fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq(**pelem, *v)) {')
+			} else {
+				fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq(*pelem, v)) {')
+			}
 		} else if elem_sym.kind == .alias {
 			ptr_typ := g.equality_fn(info.elem_type)
 			fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq(*pelem, v)) {')

--- a/vlib/v/tests/array_of_reference_sumtype_test.v
+++ b/vlib/v/tests/array_of_reference_sumtype_test.v
@@ -1,11 +1,14 @@
 struct Element {
 	AbstractNode
+mut:
 	name       string
+	value      string
 	attributes []&Attribute
 }
 
 struct Attribute {
 	AbstractNode
+mut:
 	name  string
 	value string
 }
@@ -21,7 +24,11 @@ pub fn (mut n AbstractNode) append_child(child &Node) {
 	n.child_nodes << child
 }
 
-fn test_array_of_reference_sumtype_append() {
+pub fn (n &AbstractNode) has_child(child &Node) int {
+	return n.child_nodes.index(child)
+}
+
+fn test_array_of_reference_sumtype() {
 	mut parent := &Element{
 		name: 'parent'
 	}
@@ -30,6 +37,9 @@ fn test_array_of_reference_sumtype_append() {
 	}
 	parent.append_child(child)
 
+	ret := parent.has_child(child)
+	println(ret)
 	dump(parent)
 	assert parent.child_nodes[0].name == 'child'
+	assert ret == 0
 }


### PR DESCRIPTION
This PR fix array of reference sumtype index()  (fix #14801).

- Fix array of reference sumtype index().
- Add test.

```v
struct Element {
	AbstractNode
mut:
	name       string
	value      string
	attributes []&Attribute
}

struct Attribute {
	AbstractNode
mut:
	name  string
	value string
}

pub type Node = Attribute | Element

struct AbstractNode {
pub mut:
	child_nodes []&Node
}

pub fn (mut n AbstractNode) append_child(child &Node) {
	n.child_nodes << child
}

pub fn (n &AbstractNode) has_child(child &Node) int {
	return n.child_nodes.index(child)
}

fn main() {
	mut parent := &Element{
		name: 'parent'
	}
	mut child := &Element{
		name: 'child'
	}
	parent.append_child(child)

	ret := parent.has_child(child)
	println(ret)
	dump(parent)
	assert parent.child_nodes[0].name == 'child'
	assert ret == 0
}

PS D:\Test\v\tt1> v run .
0
[.\\tt1.v:42] parent: &Element{
    AbstractNode: AbstractNode{
        child_nodes: [Node(Element{
            AbstractNode: AbstractNode{
                child_nodes: []
            }
            name: 'child'
            value: ''
            attributes: []
        })]
    }
    name: 'parent'
    value: ''
    attributes: []
}
```