### PR TITLE
parser: check closure var name conflict (fix #14787)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -751,6 +751,17 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	typ := ast.new_type(idx)
 	p.inside_defer = old_inside_defer
 	// name := p.table.get_type_name(typ)
+	if inherited_vars.len > 0 && args.len > 0 {
+		for arg in args {
+			for var in inherited_vars {
+				if arg.name == var.name {
+					p.error_with_pos('the parameter name `$arg.name` conflicts with the captured value name',
+						arg.pos)
+					break
+				}
+			}
+		}
+	}
 	return ast.AnonFn{
 		decl: ast.FnDecl{
 			name: name

--- a/vlib/v/parser/tests/closure_var_name_conflict.out
+++ b/vlib/v/parser/tests/closure_var_name_conflict.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/closure_var_name_conflict.vv:4:15: error: the parameter name `x` conflicts with the captured value name
+    2 |     x := 1
+    3 |
+    4 |     y := fn [x] (x int) {
+      |                  ^
+    5 |         println(x)
+    6 |     }

--- a/vlib/v/parser/tests/closure_var_name_conflict.vv
+++ b/vlib/v/parser/tests/closure_var_name_conflict.vv
@@ -1,0 +1,10 @@
+fn main() {
+	x := 1
+
+	y := fn [x] (x int) {
+		println(x)
+	}
+
+	y(x)
+	y(2)
+}


### PR DESCRIPTION
This PR check closure var name conflict (fix #14787).

- Check closure var name conflict.
- Add test.

```v
fn main() {
	x := 1

	y := fn [x] (x int) {
		println(x)
	}

	y(x)
	y(2)
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:15: error: the parameter name `x` conflicts with the captured value name
    2 |     x := 1
    3 | 
    4 |     y := fn [x] (x int) {
      |                  ^
    5 |         println(x)
    6 |     }
```