### PR TITLE
cgen: format cgen.init() generated c codes

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -657,10 +657,10 @@ pub fn (mut g Gen) init() {
 			g.cheaders.writeln('#include <stddef.h>')
 		} else {
 			tcc_undef_has_include := '
-	#if defined(__TINYC__) && defined(__has_include)
-	// tcc does not support has_include properly yet, turn it off completely
-	#undef __has_include
-	#endif'
+#if defined(__TINYC__) && defined(__has_include)
+// tcc does not support has_include properly yet, turn it off completely
+#undef __has_include
+#endif'
 			g.cheaders.writeln(tcc_undef_has_include)
 			g.includes.writeln(tcc_undef_has_include)
 			if g.pref.os == .freebsd {


### PR DESCRIPTION
This PR format cgen.init() generated c codes.

before:
```v
// V cheaders:
// Generated by the V compiler

	#if defined(__TINYC__) && defined(__has_include)
	// tcc does not support has_include properly yet, turn it off completely
	#undef __has_include
	#endif

#if defined(__has_include)
```
format to:
```v
// V cheaders:
// Generated by the V compiler

#if defined(__TINYC__) && defined(__has_include)
// tcc does not support has_include properly yet, turn it off completely
#undef __has_include
#endif

#if defined(__has_include)
```