### PR TITLE
builtin: created contains_only builtin method on string

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1130,6 +1130,23 @@ pub fn (s string) contains_any(chars string) bool {
 	return false
 }
 
+// contains_only returns `true` if the string contains only the chars in `chars`.
+pub fn (s string) contains_only(chars string) bool {
+	if chars.len == 0 {
+		return false
+	}
+	for i in s {
+		mut tt := false
+		for j in chars {
+			tt = tt || j == i
+		}
+		if !tt {
+			return false
+		}
+	}
+	return true
+}
+
 // contains_any_substr returns `true` if the string contains any of the strings in `substrs`.
 pub fn (s string) contains_any_substr(substrs []string) bool {
 	if substrs.len == 0 {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1130,13 +1130,17 @@ pub fn (s string) contains_any(chars string) bool {
 	return false
 }
 
-// contains_only returns `true` if the string contains only the chars in `chars`.
+// contains_only returns `true`, if the string contains only the characters in `chars`.
 pub fn (s string) contains_only(chars string) bool {
 	if chars.len == 0 {
 		return false
 	}
 	for ch in s {
-		if ch !in chars.bytes() {
+		mut res := 0
+		for i := 0; i < chars.len && res == 0; i++ {
+			res += int(ch == unsafe { chars.str[i] })
+		}
+		if res == 0 {
 			return false
 		}
 	}

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1135,12 +1135,8 @@ pub fn (s string) contains_only(chars string) bool {
 	if chars.len == 0 {
 		return false
 	}
-	for i in s {
-		mut tt := false
-		for j in chars {
-			tt = tt || j == i
-		}
-		if !tt {
+	for ch in s {
+		if ch !in chars.bytes() {
 			return false
 		}
 	}

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -448,9 +448,9 @@ fn test_contains_any() {
 }
 
 fn test_contains_only() {
-	assert "23885".contains_only("0123456789")
-	assert "23gg885".contains_only("01g23456789")
-	assert !"hello;".contains_only("hello")
+	assert '23885'.contains_only('0123456789')
+	assert '23gg885'.contains_only('01g23456789')
+	assert !'hello;'.contains_only('hello')
 	assert !''.contains_only('')
 }
 

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -447,6 +447,13 @@ fn test_contains_any() {
 	assert !''.contains_any('')
 }
 
+fn test_contains_only() {
+	assert "23885".contains_only("0123456789")
+	assert "23gg885".contains_only("01g23456789")
+	assert !"hello;".contains_only("hello")
+	assert !''.contains_only('')
+}
+
 fn test_contains_any_substr() {
 	s := 'Some random text'
 	assert s.contains_any_substr(['false', 'not', 'rand'])


### PR DESCRIPTION
Adding contains_only method to complement contains_any. Added tests and made sure it was functionally similar, for example
```vlang
assert !''.contains_any('')
assert !''.contains_only('')
```
Both work fine.

\- Liam
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
