### PR TITLE
cgen: fix ref_struct.str() with null pointer (fix #14785)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -111,7 +111,9 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.get_str_fn(typ)
 		if is_ptr && !is_var_mut {
-			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("&"), $si_s_code ,{.d_s=')
+			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("&"), $si_s_code ,{.d_s = isnil(')
+			g.expr(expr)
+			g.write(') ? _SLIT("nil") : ')
 		}
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {

--- a/vlib/v/tests/string_ref_struct_test.v
+++ b/vlib/v/tests/string_ref_struct_test.v
@@ -1,0 +1,11 @@
+struct Node {
+	val   int
+	left  &Node
+	right &Node
+}
+
+fn test_string_ref_struct() {
+	n := Node{123, 0, 0}
+	println(n.left)
+	assert '$n.left' == '&nil'
+}


### PR DESCRIPTION
This PR fix ref_struct.str() with null pointer (fix #14785).

- Fix ref_struct.str() with null pointer.
- Add test.

```v
struct Node {
	val   int
	left  &Node
	right &Node
}

fn main() {
	n := Node{123, 0, 0}
	println(n.left)
	assert '$n.left' == '&nil'
}

PS D:\Test\v\tt1> v run .
&nil
```