### PR TITLE
os: add `.cmd` to list of Windows executable suffixes

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -404,7 +404,7 @@ pub fn is_executable(path string) bool {
 		// 04 Read-only
 		// 06 Read and write
 		p := real_path(path)
-		return exists(p) && (p.ends_with('.exe') || p.ends_with('.bat'))
+		return exists(p) && (p.ends_with('.exe') || p.ends_with('.bat') || p.ends_with('.cmd'))
 	}
 	$if solaris {
 		statbuf := C.stat{}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -14,7 +14,7 @@ fn C.CreateHardLinkW(&u16, &u16, C.SECURITY_ATTRIBUTES) int
 
 fn C._getpid() int
 
-const executable_suffixes = ['.exe', '.bat', '']
+const executable_suffixes = ['.exe', '.bat', '.cmd', '']
 
 pub const (
 	path_separator = '\\'


### PR DESCRIPTION
As @JalonSolov mentioned (https://github.com/vlang/v/pull/14835#discussion_r904465164), `.cmd` is also a valid extension for batch files (I think).