### PR TITLE
checker: check unknown chan element type (fix #14775)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3515,6 +3515,12 @@ pub fn (mut c Checker) chan_init(mut node ast.ChanInit) ast.Type {
 	if node.typ != 0 {
 		info := c.table.sym(node.typ).chan_info()
 		node.elem_type = info.elem_type
+		if node.elem_type != 0 {
+			elem_sym := c.table.sym(node.elem_type)
+			if elem_sym.kind == .placeholder {
+				c.error('unknown type `$elem_sym.name`', node.pos)
+			}
+		}
 		if node.has_cap {
 			c.check_array_init_para_type('cap', node.cap_expr, node.pos)
 		}

--- a/vlib/v/checker/tests/chan_elem_type_unknown.out
+++ b/vlib/v/checker/tests/chan_elem_type_unknown.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/chan_elem_type_unknown.vv:2:7: error: unknown type `NonExistingType`
+    1 | fn main() {
+    2 |     _ := chan NonExistingType{}
+      |          ~~~~~~~~~~~~~~~~~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/chan_elem_type_unknown.vv
+++ b/vlib/v/checker/tests/chan_elem_type_unknown.vv
@@ -1,0 +1,3 @@
+fn main() {
+	_ := chan NonExistingType{}
+}


### PR DESCRIPTION
This PR check unknown chan element type (fix #14775).

- Check unknown chan element type.
- Add test.

```v
fn main() {
	_ := chan NonExistingType{}
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:7: error: unknown type `NonExistingType`
    1 | fn main() {
    2 |     _ := chan NonExistingType{}
      |          ~~~~~~~~~~~~~~~~~~~~~~
    3 | }
```