### PR TITLE
checker: check error for cast sumtype (fix #14771)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2505,7 +2505,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		&& final_to_sym.kind !in [.sum_type, .interface_] {
 		ft := c.table.type_to_str(from_type)
 		tt := c.table.type_to_str(to_type)
-		c.error('cannot cast `$ft` to `$tt`, please use `as` instead, .e.g `expr as Ident`',
+		c.error('cannot cast `$ft` to `$tt`, please use `as` instead, e.g. `expr as Ident`',
 			node.pos)
 	}
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2500,6 +2500,14 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			c.error(error_msg, node.pos)
 		}
 	}
+	if from_sym.language == .v && !from_type.is_ptr()
+		&& final_from_sym.kind in [.sum_type, .interface_]
+		&& final_to_sym.kind !in [.sum_type, .interface_] {
+		ft := c.table.type_to_str(from_type)
+		tt := c.table.type_to_str(to_type)
+		c.error('cannot cast `$ft` to `$tt`, please use `as` instead, .e.g `expr as Ident`',
+			node.pos)
+	}
 
 	if node.has_arg {
 		c.expr(node.arg)

--- a/vlib/v/checker/tests/cast_sumtype_err.out
+++ b/vlib/v/checker/tests/cast_sumtype_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/cast_sumtype_err.vv:7:14: error: cannot cast `Test` to `int`, please use `as` instead, .e.g `expr as Ident`
+    5 | fn main() {
+    6 |     data := Test(12)
+    7 |     eprintln(int(data))
+      |              ~~~~~~~~~
+    8 | }

--- a/vlib/v/checker/tests/cast_sumtype_err.out
+++ b/vlib/v/checker/tests/cast_sumtype_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/cast_sumtype_err.vv:7:14: error: cannot cast `Test` to `int`, please use `as` instead, .e.g `expr as Ident`
+vlib/v/checker/tests/cast_sumtype_err.vv:7:14: error: cannot cast `Test` to `int`, please use `as` instead, e.g. `expr as Ident`
     5 | fn main() {
     6 |     data := Test(12)
     7 |     eprintln(int(data))

--- a/vlib/v/checker/tests/cast_sumtype_err.vv
+++ b/vlib/v/checker/tests/cast_sumtype_err.vv
@@ -1,0 +1,8 @@
+module main
+
+type Test = int | u32 | f32
+
+fn main() {
+    data := Test(12)
+    eprintln(int(data))
+}


### PR DESCRIPTION
This PR check error for cast sumtype (fix #14771).

- Check error for cast sumtype.
- Add test.

```v
module main

type Test = int | u32 | f32

fn main() {
    data := Test(12)
    eprintln(int(data))
}

PS D:\Test\v\tt1> v run .
./tt1.v:7:14: error: cannot cast `Test` to `int`, please use `as` instead, .e.g `expr as Ident`
    5 | fn main() {
    6 |     data := Test(12)
    7 |     eprintln(int(data))
      |              ~~~~~~~~~
    8 | }
```