### PR TITLE
checker: fix error for aliases_of_array.pop() (fix #14860)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1165,8 +1165,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			c.error('cannot $method_name `$arg_sym.name` to `$left_sym.name`', arg_expr.pos())
 		}
 	} else if final_left_sym.info is ast.Array && method_name in ['first', 'last', 'pop'] {
-		node.return_type = final_left_sym.info.elem_type
-		return node.return_type
+		return c.array_builtin_method_call(mut node, left_type, final_left_sym)
 	} else if c.pref.backend.is_js() && left_sym.name.starts_with('Promise<')
 		&& method_name == 'wait' {
 		info := left_sym.info as ast.Struct

--- a/vlib/v/tests/array_of_alias_pop_test.v
+++ b/vlib/v/tests/array_of_alias_pop_test.v
@@ -1,0 +1,17 @@
+[heap]
+struct Attribute {
+mut:
+	name  string
+	value string
+}
+
+type AttributeStack = []&Attribute
+
+fn test_array_of_alias_pop() {
+	mut stack := AttributeStack([]&Attribute{})
+	stack << &Attribute{'foo', 'bar'}
+	ret := stack.pop()
+	println(ret)
+	assert ret.name == 'foo'
+	assert ret.value == 'bar'
+}


### PR DESCRIPTION
This PR fix error for aliases_of_array.pop() (fix #14860).

- Fix error for aliases_of_array.pop().
- Add test.

```v
[heap]
struct Attribute {
mut:
	name  string
	value string
}

type AttributeStack = []&Attribute

fn main() {
	mut stack := AttributeStack([]&Attribute{})
	stack << &Attribute{'foo', 'bar'}
	ret := stack.pop()
	println(ret)
	assert ret.name == 'foo'
	assert ret.value == 'bar'
}

PS D:\Test\v\tt1> v run .
&Attribute{
    name: 'foo'
    value: 'bar'
}
```