### PR TITLE
docs: common jwt example

### DIFF
--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -63,12 +63,10 @@ struct JwtPayload {
 	iat  int
 }
 
-
 fn main() {
 	token := make_token()
 	println(token)
 }
-
 
 fn make_token() string {
 	secret := 'your-256-bit-secret'
@@ -79,8 +77,7 @@ fn make_token() string {
 		sha256.sum, sha256.block_size).bytestr().bytes())
 
 	jwt := '${header}.${payload}.$signature'
-	
+
 	return jwt
 }
-
 ```

--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -15,6 +15,7 @@ The implementations here are loosely based on [Go's crypto package](https://pkg.
 
 ## Examples:
 
+### AES:
 ```v
 import crypto.aes
 import crypto.rand
@@ -42,4 +43,44 @@ fn main() {
 
 	assert decrypted == data
 }
+```
+
+### JWT:
+```v
+import crypto.hmac
+import crypto.sha256
+import encoding.base64
+import json
+
+struct JwtHeader {
+	alg string
+	typ string
+}
+
+struct JwtPayload {
+	sub  string
+	name string
+	iat  int
+}
+
+
+fn main() {
+	token := make_token()
+	println(token)
+}
+
+
+fn make_token() string {
+	secret := 'your-256-bit-secret'
+
+	header := base64.url_encode(json.encode(JwtHeader{'HS256', 'JWT'}).bytes())
+	payload := base64.url_encode(json.encode(JwtPayload{'1234567890', 'John Doe', 1516239022}).bytes())
+	signature := base64.url_encode(hmac.new(secret.bytes(), '${header}.$payload'.bytes(),
+		sha256.sum, sha256.block_size).bytestr().bytes())
+
+	jwt := '${header}.${payload}.$signature'
+	
+	return jwt
+}
+
 ```


### PR DESCRIPTION
Very useful and didactic example implementing "crypto.hmac" and "crypto.sha256". 
The data used match with data presented on the website "https://jwt.io/"
