### PR TITLE
ast: add elem_type_pos in struct ChanInit (related #14775)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1271,8 +1271,9 @@ pub mut:
 
 pub struct ChanInit {
 pub:
-	pos     token.Pos
-	has_cap bool
+	pos           token.Pos
+	elem_type_pos token.Pos
+	has_cap       bool
 pub mut:
 	cap_expr  Expr
 	typ       Type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3529,7 +3529,7 @@ pub fn (mut c Checker) chan_init(mut node ast.ChanInit) ast.Type {
 		if node.elem_type != 0 {
 			elem_sym := c.table.sym(node.elem_type)
 			if elem_sym.kind == .placeholder {
-				c.error('unknown type `$elem_sym.name`', node.pos)
+				c.error('unknown type `$elem_sym.name`', node.elem_type_pos)
 			}
 		}
 		if node.has_cap {

--- a/vlib/v/checker/tests/chan_elem_type_unknown.out
+++ b/vlib/v/checker/tests/chan_elem_type_unknown.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/chan_elem_type_unknown.vv:2:7: error: unknown type `NonExistingType`
+vlib/v/checker/tests/chan_elem_type_unknown.vv:2:12: error: unknown type `NonExistingType`
     1 | fn main() {
     2 |     _ := chan NonExistingType{}
-      |          ~~~~~~~~~~~~~~~~~~~~~~
+      |               ~~~~~~~~~~~~~~~
     3 | }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2238,7 +2238,9 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 	if p.tok.lit == 'chan' {
 		first_pos := p.tok.pos()
 		mut last_pos := first_pos
+		mut elem_type_pos := p.peek_tok.pos()
 		chan_type := p.parse_chan_type()
+		elem_type_pos = elem_type_pos.extend(p.prev_tok.pos())
 		mut has_cap := false
 		mut cap_expr := ast.empty_expr()
 		p.check(.lcbr)
@@ -2265,6 +2267,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		}
 		return ast.ChanInit{
 			pos: first_pos.extend(last_pos)
+			elem_type_pos: elem_type_pos
 			has_cap: has_cap
 			cap_expr: cap_expr
 			typ: chan_type


### PR DESCRIPTION
This PR add elem_type_pos in struct ChanInit (related #14775).

- Add elem_type_pos in struct ChanInit.
- Modify test.

```v
fn main() {
	_ := chan NonExistingType{}
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:12: error: unknown type `NonExistingType`
    1 | fn main() {
    2 |     _ := chan NonExistingType{}
      |               ~~~~~~~~~~~~~~~
    3 | }
```