### PR TITLE
checker: check struct field init with void expression (fix #13944)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -377,6 +377,10 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				expected_type = field_info.typ
 				c.expected_type = expected_type
 				expr_type = c.expr(field.expr)
+				if expr_type == ast.void_type {
+					c.error('cannot assign `void` expression to field `$field_info.name`',
+						field.pos)
+				}
 				if !field_info.typ.has_flag(.optional) {
 					expr_type = c.check_expr_opt_call(field.expr, expr_type)
 				}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -378,8 +378,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				c.expected_type = expected_type
 				expr_type = c.expr(field.expr)
 				if expr_type == ast.void_type {
-					c.error('cannot assign `void` expression to field `$field_info.name`',
-						field.pos)
+					c.error('`$field.expr` (no value) used as value', field.pos)
 				}
 				if !field_info.typ.has_flag(.optional) {
 					expr_type = c.check_expr_opt_call(field.expr, expr_type)

--- a/vlib/v/checker/tests/struct_field_init_with_void_expr_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_void_expr_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv:19:3: error: cannot assign `void` expression to field `execute`
+vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv:19:3: error: `app.test_func()` (no value) used as value
    17 |         name: 'add'
    18 |         description: 'Add something.'
    19 |         execute: app.test_func()

--- a/vlib/v/checker/tests/struct_field_init_with_void_expr_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_void_expr_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv:19:3: error: cannot assign `void` expression to field `execute`
+   17 |         name: 'add'
+   18 |         description: 'Add something.'
+   19 |         execute: app.test_func()
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~
+   20 |     }
+   21 |

--- a/vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv
+++ b/vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv
@@ -1,0 +1,25 @@
+import cli { Command }
+import os
+
+struct App {}
+
+fn (a App) test_func() {}
+
+fn main() {
+	mut cmd := Command{
+		name: 'cli'
+		version: '0.0.1'
+	}
+
+	app := App{}
+
+	mut add := Command{
+		name: 'add'
+		description: 'Add something.'
+		execute: app.test_func()
+	}
+
+	cmd.add_command(add)
+	cmd.setup()
+	cmd.parse(os.args)
+}


### PR DESCRIPTION
This PR check struct field init with void expression (fix #13944).

- Check struct field init with void expression.
- Add test.

```v
import cli { Command }
import os

struct App {}

fn (a App) test_func() {}

fn main() {
	mut cmd := Command{
		name: 'cli'
		version: '0.0.1'
	}

	app := App{}

	mut add := Command{
		name: 'add'
		description: 'Add something.'
		execute: app.test_func()
	}

	cmd.add_command(add)
	cmd.setup()
	cmd.parse(os.args)
}

PS D:\Test\v\tt1> v run .
./tt1.v:19:3: error: `app.test_func()` (no value) used as value
   17 |         name: 'add'
   18 |         description: 'Add something.'
   19 |         execute: app.test_func()
      |         ~~~~~~~~~~~~~~~~~~~~~~~~
   20 |     }
   21 |
```