### PR TITLE
checker: optimize casting sumtype error message (fix #14023)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2508,7 +2508,8 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		&& final_to_sym.kind !in [.sum_type, .interface_] {
 		ft := c.table.type_to_str(from_type)
 		tt := c.table.type_to_str(to_type)
-		c.error('cannot cast `$ft` $from_sym.kind value to `$tt`, use `$node.expr as $tt` instead',
+		kind_name := if from_sym.kind == .sum_type { 'sum type' } else { 'interface' }
+		c.error('cannot cast `$ft` $kind_name value to `$tt`, use `$node.expr as $tt` instead',
 			node.pos)
 	}
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2508,7 +2508,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		&& final_to_sym.kind !in [.sum_type, .interface_] {
 		ft := c.table.type_to_str(from_type)
 		tt := c.table.type_to_str(to_type)
-		c.error('cannot cast `$ft` to `$tt`, please use `as` instead, e.g. `expr as Ident`',
+		c.error('cannot cast `$ft` $from_sym.kind value to `$tt`, use `$node.expr as $tt` instead',
 			node.pos)
 	}
 

--- a/vlib/v/checker/tests/cast_sumtype_err.out
+++ b/vlib/v/checker/tests/cast_sumtype_err.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/cast_sumtype_err.vv:8:11: error: cannot cast `Test` sum_type value to `int`, use `data as int` instead
+vlib/v/checker/tests/cast_sumtype_err.vv:8:11: error: cannot cast `Test` sum type value to `int`, use `data as int` instead
     6 | fn main() {
     7 |     data := Test(12)
     8 |     eprintln(int(data))
       |              ~~~~~~~~~
     9 |
    10 |     foo := Bar('123.45')
-vlib/v/checker/tests/cast_sumtype_err.vv:11:10: error: cannot cast `Bar` sum_type value to `f32`, use `foo as f32` instead
+vlib/v/checker/tests/cast_sumtype_err.vv:11:10: error: cannot cast `Bar` sum type value to `f32`, use `foo as f32` instead
     9 |
    10 |     foo := Bar('123.45')
    11 |     println(f32(foo))

--- a/vlib/v/checker/tests/cast_sumtype_err.out
+++ b/vlib/v/checker/tests/cast_sumtype_err.out
@@ -1,6 +1,13 @@
-vlib/v/checker/tests/cast_sumtype_err.vv:7:14: error: cannot cast `Test` to `int`, please use `as` instead, e.g. `expr as Ident`
-    5 | fn main() {
-    6 |     data := Test(12)
-    7 |     eprintln(int(data))
+vlib/v/checker/tests/cast_sumtype_err.vv:8:11: error: cannot cast `Test` sum_type value to `int`, use `data as int` instead
+    6 | fn main() {
+    7 |     data := Test(12)
+    8 |     eprintln(int(data))
       |              ~~~~~~~~~
-    8 | }
+    9 |
+   10 |     foo := Bar('123.45')
+vlib/v/checker/tests/cast_sumtype_err.vv:11:10: error: cannot cast `Bar` sum_type value to `f32`, use `foo as f32` instead
+    9 |
+   10 |     foo := Bar('123.45')
+   11 |     println(f32(foo))
+      |             ~~~~~~~~
+   12 | }

--- a/vlib/v/checker/tests/cast_sumtype_err.vv
+++ b/vlib/v/checker/tests/cast_sumtype_err.vv
@@ -1,8 +1,12 @@
 module main
 
 type Test = int | u32 | f32
+type Bar = int | string
 
 fn main() {
-    data := Test(12)
-    eprintln(int(data))
+	data := Test(12)
+	eprintln(int(data))
+
+	foo := Bar('123.45')
+	println(f32(foo))
 }


### PR DESCRIPTION
This PR optimize casting sumtype error message (fix #14023).

- Optimize casting sumtype error message.
- Modify test.

```v
module main

type Test = int | u32 | f32
type Bar = int | string

fn main() {
	data := Test(12)
	eprintln(int(data))

	foo := Bar('123.45')
	println(f32(foo))
}

PS D:\Test\v\tt1> v run .
./tt1.v:8:11: error: cannot cast `Test` sum type value to `int`, use `data as int` instead
    6 | fn main() {
    7 |     data := Test(12)
    8 |     eprintln(int(data))
      |              ~~~~~~~~~
    9 |
   10 |     foo := Bar('123.45')
./tt1.v:11:10: error: cannot cast `Bar` sum type value to `f32`, use `foo as f32` instead
    9 |
   10 |     foo := Bar('123.45')
   11 |     println(f32(foo))
      |             ~~~~~~~~
   12 | }
```