### PR TITLE
parser: check interface name using single letter capital  (fix #14005)

### DIFF
--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -493,6 +493,11 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		return ast.InterfaceDecl{}
 	}
 	modless_name := p.check_name()
+	if modless_name.len == 1 && modless_name[0].is_capital() {
+		p.error_with_pos('single letter capital names are reserved for generic template types.',
+			name_pos)
+		return ast.InterfaceDecl{}
+	}
 	if modless_name == 'IError' && p.mod != 'builtin' {
 		p.error_with_pos('cannot register interface `IError`, it is builtin interface type',
 			name_pos)

--- a/vlib/v/parser/tests/interface_name_err.out
+++ b/vlib/v/parser/tests/interface_name_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/interface_name_err.vv:1:11: error: single letter capital names are reserved for generic template types.
+    1 | interface A {
+      |           ^
+    2 |     a int
+    3 |     b() int

--- a/vlib/v/parser/tests/interface_name_err.vv
+++ b/vlib/v/parser/tests/interface_name_err.vv
@@ -1,0 +1,19 @@
+interface A {
+	a int
+	b() int
+}
+
+struct Ba {
+	a int
+}
+
+fn (b &Ba) b() int {
+	return b.a
+}
+
+fn main() {
+	a := &Ba{
+		a: 1
+	}
+	b := A(a)
+}


### PR DESCRIPTION
This PR check interface name using single letter capital  (fix #14005).

- Check interface name using single letter capital.
- Add test.

```v
interface A {
	a int
	b() int
}

struct Ba {
	a int
}

fn (b &Ba) b() int {
	return b.a
}

fn main() {
	a := &Ba{
		a: 1
	}
	b := A(a)
}

PS D:\Test\v\tt1> v run .
./tt1.v:1:11: error: single letter capital names are reserved for generic template types.
    1 | interface A {
      |           ^
    2 |     a int
    3 |     b() int
```