### PR TITLE
parser: fix the incorrect location of the type declaration name

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3667,8 +3667,8 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	}
 	name := p.check_name()
 	if name.len == 1 && name[0].is_capital() {
-		p.error_with_pos('single letter capital names are reserved for generic template types.',
-			decl_pos)
+		p.error_with_pos('single letter capital names are reserved for generic template types',
+			name_pos)
 		return ast.FnTypeDecl{}
 	}
 	if name in p.imported_symbols {

--- a/vlib/v/parser/tests/type_decl_name_err.out
+++ b/vlib/v/parser/tests/type_decl_name_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/type_decl_name_err.vv:1:6: error: single letter capital names are reserved for generic template types
+    1 | type A = int | string
+      |      ^
+    2 |
+    3 | fn main() {

--- a/vlib/v/parser/tests/type_decl_name_err.vv
+++ b/vlib/v/parser/tests/type_decl_name_err.vv
@@ -1,0 +1,6 @@
+type A = int | string
+
+fn main() {
+	a := A(11)
+	println(a)
+}


### PR DESCRIPTION
This PR fix the incorrect location of the type declaration name.

- Fix the incorrect location of the type declaration name.
- Add test.

```v
type A = int | string

fn main() {
	a := A(11)
	println(a)
}

PS D:\Test\v\tt1> v run .
./tt1.v:1:6: error: single letter capital names are reserved for generic template types
    1 | type A = int | string
      |      ^
    2 | 
    3 | fn main() {
```