### PR TITLE
parser: check const declaration using multiple assign (fix #5125)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3364,6 +3364,9 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 				pos)
 		}
 		full_name := p.prepend_mod(name)
+		if p.tok.kind == .comma {
+			p.error_with_pos('const declaration do not support multiple assign yet', p.tok.pos())
+		}
 		p.check(.assign)
 		end_comments << p.eat_comments()
 		if p.tok.kind == .key_fn {

--- a/vlib/v/parser/tests/const_decl_err.out
+++ b/vlib/v/parser/tests/const_decl_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/const_decl_err.vv:6:3: error: const declaration do not support multiple assign yet
+    4 |
+    5 | const (
+    6 |     a, b, c = foo()
+      |      ^
+    7 | )
+    8 |

--- a/vlib/v/parser/tests/const_decl_err.vv
+++ b/vlib/v/parser/tests/const_decl_err.vv
@@ -1,0 +1,12 @@
+fn foo() (int, int, int) {
+	return 1, 2, 3
+}
+
+const (
+	a, b, c = foo()
+)
+
+
+fn main() {
+	println("$a $b $c")
+}


### PR DESCRIPTION
This PR check const declaration using multiple assign (fix #5125).

- Check const declaration using multiple assign.
- Add test.

```v
fn foo() (int, int, int) {
	return 1, 2, 3
}

const (
	a, b, c = foo()
)

fn main() {
	println("$a $b $c")
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:3: error: const declaration do not support multiple assign yet
    4 |
    5 | const (
    6 |     a, b, c = foo()
      |      ^
    7 | )
    8 |
```