### PR TITLE
orm: set v "time.Time" type to sql "datetime(3)"

### DIFF
--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -255,8 +255,11 @@ fn mysql_type_from_v(typ int) ?string {
 		orm.type_idx['i16'], orm.type_idx['u16'] {
 			'SMALLINT'
 		}
-		orm.type_idx['int'], orm.type_idx['u32'], orm.time {
+		orm.type_idx['int'], orm.type_idx['u32'] {
 			'INT'
+		}
+		orm.time {
+			'datetime(3)'
 		}
 		orm.type_idx['i64'], orm.type_idx['u64'] {
 			'BIGINT'


### PR DESCRIPTION
Explain what your PR does and why.

set v "time.Time" type to sql "datetime(3)"
like in go https://gorm.io/docs/models.html

solution init in v discord channel
