### PR TITLE
fmt: fix import with symbol of struct (fix #14889)

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -178,7 +178,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 	defer {
 		f.is_struct_init = struct_init_save
 	}
-
+	f.mark_types_import_as_used(node.typ)
 	type_sym := f.table.sym(node.typ)
 	// f.write('<old name: $type_sym.name>')
 	mut name := type_sym.name

--- a/vlib/v/fmt/tests/import_with_symbol_of_struct_keep.vv
+++ b/vlib/v/fmt/tests/import_with_symbol_of_struct_keep.vv
@@ -1,0 +1,5 @@
+import datatypes { Stack }
+
+fn main() {
+	stack := Stack<int>{}
+}


### PR DESCRIPTION
This PR fix fmt error for import with symbol of struct (fix #14889).

- fix fmt error for import with symbol of struct.
- Add test.

fmt keep:
```v
import datatypes { Stack }

fn main() {
	stack := Stack<int>{}
}
```