### PR TITLE
sokol: allow thirdparty window control

### DIFF
--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -57,7 +57,11 @@ $if gcboehm ? {
 }
 
 #include "sokol_v.pre.h"
-#include "sokol_app.h"
+// To allow for thirdparty initializing window / acceleration contexts
+// but still be able to use sokol.gfx e.g. SDL+sokol_gfx
+$if !no_sokol_app ? {
+	#include "sokol_app.h"
+}
 #define SOKOL_IMPL
 #define SOKOL_NO_DEPRECATED
 #include "sokol_gfx.h"


### PR DESCRIPTION
This PR allows for thirdparty control of platform window handles - still allowing for `sokol.gfx` to be used.

It could probably be more automatic if we had some kind of: `$if imported 'sokol.sapp' { .. }`-like directive that would only include the block if the given module is actually imported. But for now this flag will allow for compiling apps that use e.g. SDL (and others) as window manager - and sokol for accelerated graphics/drawing - it's especially useful in the Android SDL build tool I'm working on since it allows for me to compile and run apps on Android using SDL and sokol.gfx without the need to patch any V sources:
`v -os android -nocache -d no_sokol_app -o "/dev/shm/v_sdl_android/v_android.c" /tmp/test.v`

