### PR TITLE
builder: fix cross compiling for linux on windows (fix #6241, fix #12922)

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -790,7 +790,7 @@ fn (mut b Builder) cc_linux_cross() {
 		verror(res.output)
 		return
 	}
-	println(b.pref.out_name + ' has been successfully compiled')
+	println(out_name + ' has been successfully compiled')
 }
 
 fn (mut c Builder) cc_windows_cross() {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -750,10 +750,10 @@ fn (mut b Builder) cc_linux_cross() {
 	cc_args << '-c "$b.out_name_c"'
 	cc_args << libs
 	b.dump_c_options(cc_args)
-	mut cc_name := 'cc '
+	mut cc_name := 'cc'
 	mut out_name := b.pref.out_name
 	$if windows {
-		cc_name = 'clang.exe '
+		cc_name = 'clang.exe'
 		out_name = out_name.trim_string_right('.exe')
 	}
 	cc_cmd := '${os.quoted_path(cc_name)} ' + cc_args.join(' ')
@@ -774,9 +774,9 @@ fn (mut b Builder) cc_linux_cross() {
 	linker_args << cflags.c_options_only_object_files()
 	// -ldl
 	b.dump_c_options(linker_args)
-	mut ldlld := '$sysroot/ld.lld '
+	mut ldlld := '$sysroot/ld.lld'
 	$if windows {
-		ldlld = 'ld.lld.exe '
+		ldlld = 'ld.lld.exe'
 	}
 	linker_cmd := '${os.quoted_path(ldlld)} ' + linker_args.join(' ')
 	// s = s.replace('SYSROOT', sysroot) // TODO $ inter bug

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -750,7 +750,13 @@ fn (mut b Builder) cc_linux_cross() {
 	cc_args << '-c "$b.out_name_c"'
 	cc_args << libs
 	b.dump_c_options(cc_args)
-	cc_cmd := '${os.quoted_path('cc')} ' + cc_args.join(' ')
+	mut cc_name := 'cc '
+	mut out_name := b.pref.out_name
+	$if windows {
+		cc_name = 'clang.exe '
+		out_name = out_name.trim_string_right('.exe')
+	}
+	cc_cmd := '${os.quoted_path(cc_name)} ' + cc_args.join(' ')
 	if b.pref.show_cc {
 		println(cc_cmd)
 	}
@@ -761,14 +767,17 @@ fn (mut b Builder) cc_linux_cross() {
 		return
 	}
 	mut linker_args := ['-L$sysroot/usr/lib/x86_64-linux-gnu/', '-L$sysroot/lib/x86_64-linux-gnu',
-		'--sysroot=$sysroot', '-v', '-o $b.pref.out_name', '-m elf_x86_64',
+		'--sysroot=$sysroot', '-v', '-o $out_name', '-m elf_x86_64',
 		'-dynamic-linker /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2',
 		'$sysroot/crt1.o $sysroot/crti.o $obj_file', '-lc', '-lcrypto', '-lssl', '-lpthread',
 		'$sysroot/crtn.o', '-lm']
 	linker_args << cflags.c_options_only_object_files()
 	// -ldl
 	b.dump_c_options(linker_args)
-	ldlld := '$sysroot/ld.lld'
+	mut ldlld := '$sysroot/ld.lld '
+	$if windows {
+		ldlld = 'ld.lld.exe '
+	}
 	linker_cmd := '${os.quoted_path(ldlld)} ' + linker_args.join(' ')
 	// s = s.replace('SYSROOT', sysroot) // TODO $ inter bug
 	// s = s.replace('-o hi', '-o ' + c.pref.out_name)


### PR DESCRIPTION
This PR fix cross compiling for linux on windows (fix #6241, fix #12922).

- Fix cross compiling for linux on windows.
- `gc` mode now cannot successfully compiled.

```v
fn main() {
	println('hello, world')
}

PS D:\Test\v\tt1> v -gc none -os linux .
D:\Test\v\tt1\tt1 has been successfully compiled
```

test on ubuntu:
![image](https://user-images.githubusercontent.com/6949593/176852571-3d867d9c-bb91-4a44-bcd3-068f1a769801.png)
