### PR TITLE
v.pkgconfig: fix parsing mid-line comments

### DIFF
--- a/vlib/v/pkgconfig/pkgconfig.v
+++ b/vlib/v/pkgconfig/pkgconfig.v
@@ -70,7 +70,7 @@ fn (mut pc PkgConfig) parse_list(s string) []string {
 }
 
 fn (mut pc PkgConfig) parse_line(s string) string {
-	mut r := s.trim_space()
+	mut r := s.split('#')[0]
 	for r.contains('\${') {
 		tok0 := r.index('\${') or { break }
 		mut tok1 := r[tok0..].index('}') or { break }

--- a/vlib/v/pkgconfig/test_samples/hogweed.pc
+++ b/vlib/v/pkgconfig/test_samples/hogweed.pc
@@ -1,0 +1,19 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+# Uses Requires.private and Libs.private, under the assumption that
+# when using shared libraries, the ELF dependencies from libhogweed.so
+# to nettle and gmp work.
+
+Name: Hogweed
+Description: Nettle low-level cryptographic library (public-key algorithms)
+URL: http://www.lysator.liu.se/~nisse/nettle
+Version: 3.8
+Requires: # nettle
+Requires.private:  nettle
+Libs: -L${libdir} -lhogweed # -lgmp 
+Libs.private:  -lgmp 
+Cflags: -I${includedir}
+

--- a/vlib/v/pkgconfig/test_samples/nettle.pc
+++ b/vlib/v/pkgconfig/test_samples/nettle.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Nettle
+Description: Nettle low-level cryptographic library (symmetric algorithms)
+URL: http://www.lysator.liu.se/~nisse/nettle
+Version: 3.8
+Libs: -L${libdir} -lnettle
+Cflags: -I${includedir}


### PR DESCRIPTION
Fix parsing comments appearing mid-line.
Currently:
```
$ ./bin/bin /lib/pkgconfig/hogweed.pc
could not resolve dependency #
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
