### PR TITLE
cgen: fix error for result multi_return (fix #14932)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -508,9 +508,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Type) {
 	// multi return
 	// TODO Handle in if_expr
-	is_opt := return_type.has_flag(.optional)
+	is_opt := return_type.has_flag(.optional) || return_type.has_flag(.result)
 	mr_var_name := 'mr_$node.pos.pos'
-	mr_styp := g.typ(return_type.clear_flag(.optional))
+	mr_styp := g.typ(return_type.clear_flag(.optional).clear_flag(.result))
 	g.write('$mr_styp $mr_var_name = ')
 	g.expr(node.right[0])
 	g.writeln(';')

--- a/vlib/v/tests/results_multi_return_test.v
+++ b/vlib/v/tests/results_multi_return_test.v
@@ -1,0 +1,29 @@
+struct Err {
+	msg  string
+	code int
+}
+
+fn (e Err) msg() string {
+	return e.msg
+}
+
+fn (e Err) code() int {
+	return e.code
+}
+
+fn foo() ?string {
+	return 'foo'
+}
+
+fn bar() !(string, int) {
+	a := foo() or { return IError(Err{
+		msg: 'error test'
+	}) }
+	return a, 1
+}
+
+fn test_results_multi_return() {
+	b, _ := bar() or { panic(err) }
+	println(b)
+	assert b == 'foo'
+}


### PR DESCRIPTION
This PR fix error for result multi_return (fix #14932).

- Fix error for result multi_return.
- Add test.

```v
struct Err {
	msg  string
	code int
}

fn (e Err) msg() string {
	return e.msg
}

fn (e Err) code() int {
	return e.code
}

fn foo() ?string {
	return 'foo'
}

fn bar() !(string, int) {
	a := foo() or { return IError(Err{
		msg: 'error test'
	}) }
	return a, 1
}

fn main() {
	b, _ := bar() or { panic(err) }
	println(b)
	assert b == 'foo'
}

PS D:\Test\v\tt1> v run .
foo
```