### PR TITLE
checker: check undefined ident in reference selector (fix #14947)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1124,6 +1124,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		// This means that the field has an undefined type.
 		// This error was handled before.
 		// c.error('`void` type has no fields', node.pos)
+		node.expr_type = ast.void_type
 		return ast.void_type
 	}
 	node.expr_type = typ

--- a/vlib/v/checker/tests/undefined_ident_in_ref_selector.out
+++ b/vlib/v/checker/tests/undefined_ident_in_ref_selector.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/undefined_ident_in_ref_selector.vv:6:10: error: undefined ident: `line`
+    4 |
+    5 | fn read() int {
+    6 |     return &line.len
+      |             ~~~~
+    7 | }

--- a/vlib/v/checker/tests/undefined_ident_in_ref_selector.vv
+++ b/vlib/v/checker/tests/undefined_ident_in_ref_selector.vv
@@ -1,0 +1,7 @@
+module main
+
+fn main() {}
+
+fn read() int {
+	return &line.len
+}


### PR DESCRIPTION
This PR check undefined ident in reference selector (fix #14947).

- Check undefined ident in reference selector.
- Add test.

```v
module main

fn main() {}

fn read() int {
	return &line.len
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:10: error: undefined ident: `line`
    4 |
    5 | fn read() int {
    6 |     return &line.len
      |             ~~~~
    7 | }
```