### PR TITLE
change exec_none behaviour

### DIFF
--- a/vlib/sqlite/README.md
+++ b/vlib/sqlite/README.md
@@ -1,4 +1,4 @@
-## Description:
+## Description
 
 `sqlite` is a thin wrapper for [the SQLite library](https://sqlite.org/), which in turn is
 "a C-language library that implements a small, fast, self-contained,
@@ -23,3 +23,13 @@ library installed on your system.
 - Download the source zip from [SQLite Downloads](https://sqlite.org/download.html)
 - Create a new `sqlite` subfolder inside `v/thirdparty`
 - Extract the zip into that folder
+
+# Performance Tips
+
+When performing a large amount of database calls (i.e. INSERTS), significant performance increase
+can be obtained by issuing to sqlite the following pragma commands.
+
+```
+db.exec('pragma synchronous = off;')
+db.exec('pragma journal_mode = MEMORY;')
+```

--- a/vlib/sqlite/sqlite.v
+++ b/vlib/sqlite/sqlite.v
@@ -222,7 +222,10 @@ pub fn (db DB) error_message(code int, query string) IError {
 // In case you don't expect any result, but still want an error code
 // e.g. INSERT INTO ... VALUES (...)
 pub fn (db DB) exec_none(query string) int {
-	_, code := db.exec(query)
+	stmt := &C.sqlite3_stmt(0)
+	C.sqlite3_prepare_v2(db.conn, &char(query.str), query.len, &stmt, 0)
+	code := C.sqlite3_step(stmt)
+	C.sqlite3_finalize(stmt)
 	return code
 }
 


### PR DESCRIPTION
The current behavior of exec_none merely discards the row data array from the call to exec, and therefore calls to exec_none will still walk the row result data for no reason, affecting performance.

This revised exec_none performs only what's required (execute the database statement, and return the int code)

Also added a couple tips to the README in regards to increasing performance when performing a large number of exec calls (i.e. 300K insertions, etc).