### PR TITLE
cgen: fix sumtype with none type (fix #14963)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2078,7 +2078,11 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 			g.write('&')
 		}
 	}
-	g.expr(expr)
+	if got_styp == 'none' && !g.cur_fn.return_type.has_flag(.optional) {
+		g.write('(none){EMPTY_STRUCT_INITIALIZATION}')
+	} else {
+		g.expr(expr)
+	}
 	g.write(')'.repeat(rparen_n))
 }
 

--- a/vlib/v/tests/sumtype_with_none_test.v
+++ b/vlib/v/tests/sumtype_with_none_test.v
@@ -1,0 +1,18 @@
+module main
+
+fn string_none() string | none {
+	return none
+}
+
+fn test_sumtype_with_none() {
+	x := string_none()
+	res := match x {
+		string {
+			false
+		}
+		none {
+			true
+		}
+	}
+	assert res
+}


### PR DESCRIPTION
This PR fix sumtype with none type (fix #14963).

- Fix sumtype with none type.
- Add test.

```v
module main

fn string_none() string | none {
	return none
}

fn main() {
	x := string_none()
	res := match x {
		string {
			false
		}
		none {
			true
		}
	}
	assert res
}

PS D:\Test\v\tt1> v run .

```