### PR TITLE
vlib: fix array of refs init warning

### DIFF
--- a/vlib/sync/pool/pool.v
+++ b/vlib/sync/pool/pool.v
@@ -138,7 +138,7 @@ pub fn (pool &PoolProcessor) get_results<T>() []T {
 
 // get_results_ref - get a list of type safe results in the main thread.
 pub fn (pool &PoolProcessor) get_results_ref<T>() []&T {
-	mut res := []&T{cap: pool.results.len}
+	mut res := []&T{cap: pool.results.len}{}
 	for i in 0 .. pool.results.len {
 		res << &T(pool.results[i])
 	}


### PR DESCRIPTION
Fixes this
```
vlib/sync/pool/pool.v:141:13: warning: arrays of references need to be initialized right away (unless used inside `unsafe`)
  139 | // get_results_ref - get a list of type safe results in the main thread.
  140 | pub fn (pool &PoolProcessor) get_results_ref<T>() []&T {
  141 |     mut res := []&T{cap: pool.results.len}
      |                ~~~~~
  142 |     for i in 0 .. pool.results.len {
  143 |         res << &T(pool.results[i])
```