### PR TITLE
builder: add support for icc (Intel C Compiler)

### DIFF
--- a/cmd/v/help/build-c.txt
+++ b/cmd/v/help/build-c.txt
@@ -10,7 +10,7 @@ see also `v help build`.
       Change the C compiler V invokes to the specified compiler.
       The C compiler is required to support C99.
       Officially supported/tested C compilers include:
-      `clang`, `gcc`, `tcc`, `icc`, `mingw-w64` and `msvc`.
+      `clang`, `gcc`, `tcc`, `mingw-w64` and `msvc`.
 
    -cflags <flag>
       Pass the provided flag as is to the C compiler.

--- a/cmd/v/help/build-c.txt
+++ b/cmd/v/help/build-c.txt
@@ -10,7 +10,7 @@ see also `v help build`.
       Change the C compiler V invokes to the specified compiler.
       The C compiler is required to support C99.
       Officially supported/tested C compilers include:
-      `clang`, `gcc`, `tcc`, `mingw-w64` and `msvc`.
+      `clang`, `gcc`, `tcc`, `icc`, `mingw-w64` and `msvc`.
 
    -cflags <flag>
       Pass the provided flag as is to the C compiler.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -22,7 +22,7 @@ The major way to get the latest and greatest V, is to __install it from source__
 It is __easy__, and it usually takes __only a few seconds__.
 
 ### Linux, macOS, FreeBSD, etc:
-You need `git`, and a C compiler like `tcc`, `gcc` or `clang`, and `make`:
+You need `git`, and a C compiler like `tcc`, `gcc`, `icc` or `clang`, and `make`:
 ```bash
 git clone https://github.com/vlang/v
 cd v
@@ -38,7 +38,7 @@ git clone https://github.com/vlang/v
 cd v
 make.bat -tcc
 ```
-NB: You can also pass one of `-gcc`, `-msvc`, `-clang` to `make.bat` instead,
+NB: You can also pass one of `-gcc`, `-msvc`, `-clang`, `-icc` to `make.bat` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -38,7 +38,7 @@ git clone https://github.com/vlang/v
 cd v
 make.bat -tcc
 ```
-NB: You can also pass one of `-gcc`, `-msvc`, `-clang`, `-icc` to `make.bat` instead,
+NB: You can also pass one of `-gcc`, `-msvc`, `-clang`, to `make.bat` instead,
 if you do prefer to use a different C compiler, but -tcc is small, fast, and
 easy to install (V will download a prebuilt binary automatically).
 

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -147,6 +147,7 @@ mut:
 	debug_mode  bool
 	is_cc_tcc   bool
 	is_cc_gcc   bool
+	is_cc_icc	bool
 	is_cc_msvc  bool
 	is_cc_clang bool
 	//
@@ -240,6 +241,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	//
 	ccoptions.is_cc_tcc = ccompiler.contains('tcc') || ccoptions.guessed_compiler == 'tcc'
 	ccoptions.is_cc_gcc = ccompiler.contains('gcc') || ccoptions.guessed_compiler == 'gcc'
+	ccoptions.is_cc_icc = ccompiler.contains('icc') || ccoptions.guessed_compiler == 'icc'
 	ccoptions.is_cc_msvc = ccompiler.contains('msvc') || ccoptions.guessed_compiler == 'msvc'
 	ccoptions.is_cc_clang = ccompiler.contains('clang') || ccoptions.guessed_compiler == 'clang'
 	// For C++ we must be very tolerant
@@ -274,6 +276,15 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 			}
 		}
 		optimization_options = ['-O3', '-fno-strict-aliasing', '-flto']
+	}
+	if ccoptions.is_cc_icc {
+		if ccoptions.debug_mode {
+			debug_options = ['-g']
+			if user_darwin_version > 9 {
+				debug_options << '-no-pie'
+			}
+		}
+		optimization_options = ['-Ofast', '-fno-strict-aliasing']
 	}
 	//
 	if ccoptions.debug_mode {


### PR DESCRIPTION
Support for the Intel C Compiler (icc) is added in this PR.

It can be [downloaded here](https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#dpcpp-cpp).  I can add it to the Wiki if this PR is merged.

Of course, icc must be in PATH first; (the default installation directory is `/opt/intel/oneapi/compiler/2022.1.0/linux/bin/intel64/icc`)

Running benchmarks on various tests it is very fast with optimization, and likely has some specific Intel optimizations for Intel CPUs.  It shares almost all the same flags as gcc when analyzing `icc -help` and `icc -help opt`, the only difference is no -lfto flag in icc, and -0fast which covers -03 and some other optimizations.

I have tested as well with more complex programs with OpenSSL, SQLite, etc to ensure the linker and flags work the same, and have seen no issues.
