### PR TITLE
ast, parser, cgen: fix error for cast to anon sumtype (fix #14967)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1264,7 +1264,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			} else if sym.info is SumType && (sym.info as SumType).is_anon {
 				variant_names := sym.info.variants.map(t.shorten_user_defined_typenames(t.sym(it).name,
 					import_aliases))
-				res = '${variant_names.join(' | ')}'
+				res = '${variant_names.join('|')}'
 			} else {
 				res = t.shorten_user_defined_typenames(res, import_aliases)
 			}

--- a/vlib/v/fmt/tests/inline_sum_type_keep.vv
+++ b/vlib/v/fmt/tests/inline_sum_type_keep.vv
@@ -1,13 +1,13 @@
 import v.token
 
 struct Foo {
-	bar string | int
+	bar string|int
 }
 
 interface Egg {
-	milk string | int
+	milk string|int
 }
 
-fn foo(bar string | int) int | string | token.Pos {
+fn foo(bar string|int) int|string|token.Pos {
 	return 1
 }

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -401,7 +401,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 	mut clean_sum_type_v_type_name := ''
 	if info.is_anon {
 		variant_names := info.variants.map(util.strip_main_name(g.table.sym(it).name))
-		clean_sum_type_v_type_name = '(${variant_names.join(' | ')})'
+		clean_sum_type_v_type_name = '${variant_names.join('|')}'
 	} else {
 		clean_sum_type_v_type_name = styp.replace('__', '.')
 		if styp.ends_with('*') {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2498,18 +2498,15 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			start_pos := p.tok.pos()
 			mut to_typ := p.parse_type()
 			p.check(.lpar)
-			mut expr := ast.empty_expr()
-			mut arg := ast.empty_expr()
-			mut has_arg := false
-			expr = p.expr(0)
+			expr := p.expr(0)
 			end_pos := p.tok.pos()
 			p.check(.rpar)
 			node = ast.CastExpr{
 				typ: to_typ
 				typname: p.table.sym(to_typ).name
 				expr: expr
-				arg: arg
-				has_arg: has_arg
+				arg: ast.empty_expr()
+				has_arg: false
 				pos: start_pos.extend(end_pos)
 			}
 			p.expr_mod = ''

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2493,6 +2493,27 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				typ: typ
 				pos: type_pos
 			}
+		} else if !known_var && language == .v && (p.table.known_type(p.tok.lit) || lit0_is_capital)
+			&& p.peek_tok.kind == .pipe {
+			start_pos := p.tok.pos()
+			mut to_typ := p.parse_type()
+			p.check(.lpar)
+			mut expr := ast.empty_expr()
+			mut arg := ast.empty_expr()
+			mut has_arg := false
+			expr = p.expr(0)
+			end_pos := p.tok.pos()
+			p.check(.rpar)
+			node = ast.CastExpr{
+				typ: to_typ
+				typname: p.table.sym(to_typ).name
+				expr: expr
+				arg: arg
+				has_arg: has_arg
+				pos: start_pos.extend(end_pos)
+			}
+			p.expr_mod = ''
+			return node
 		}
 
 		ident := p.parse_ident(language)

--- a/vlib/v/tests/anon_sum_type_test.v
+++ b/vlib/v/tests/anon_sum_type_test.v
@@ -1,8 +1,8 @@
-fn returns_sumtype() int | string {
+fn returns_sumtype() int|string {
 	return 1
 }
 
-fn returns_sumtype_reverse() int | string {
+fn returns_sumtype_reverse() int|string {
 	return 1
 }
 
@@ -13,7 +13,7 @@ fn test_stringification() {
 }
 
 struct Milk {
-	egg int | string
+	egg int|string
 }
 
 fn test_struct_with_inline_sumtype() {
@@ -24,7 +24,7 @@ fn test_struct_with_inline_sumtype() {
 }
 
 interface IMilk {
-	egg int | string
+	egg int|string
 }
 
 fn receive_imilk(milk IMilk) {}
@@ -36,6 +36,6 @@ fn test_interface_with_inline_sumtype() {
 	receive_imilk(m)
 }
 
-fn returns_sumtype_in_multireturn() (int | string, string) {
+fn returns_sumtype_in_multireturn() (int|string, string) {
 	return 1, ''
 }

--- a/vlib/v/tests/cast_to_anon_sumtype_test.v
+++ b/vlib/v/tests/cast_to_anon_sumtype_test.v
@@ -1,0 +1,7 @@
+module main
+
+fn test_cast_to_anon_sumtype() {
+	x := string|none(none)
+	println(x)
+	assert '$x' == 'string|none(none)'
+}

--- a/vlib/v/tests/string_optional_none_test.v
+++ b/vlib/v/tests/string_optional_none_test.v
@@ -11,7 +11,7 @@ fn (err MyError) code() int {
 	return err.code
 }
 
-fn foo() int | none | IError {
+fn foo() int|none|IError {
 	return IError(MyError{})
 }
 

--- a/vlib/v/tests/sumtype_with_none_test.v
+++ b/vlib/v/tests/sumtype_with_none_test.v
@@ -1,6 +1,6 @@
 module main
 
-fn string_none() string | none {
+fn string_none() string|none {
 	return none
 }
 


### PR DESCRIPTION
This PR fix error for cast to anon sumtype (fix #14967).

- Fix error for cast to anon sumtype.
- Add test.

```v
module main

fn main() {
	x := string|none(none)
	println(x)
	assert '$x' == 'string|none(none)'
}

PS D:\Test\v\tt1> v run .
string|none(none)
```