### PR TITLE
cgen: fix match_expr generated c codes for redundant semicolons

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1751,7 +1751,11 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// }
 			if g.inside_ternary == 0 && !g.inside_if_optional && !g.inside_match_optional
 				&& !node.is_expr && node.expr !is ast.IfExpr {
-				g.writeln(';')
+				if node.expr is ast.MatchExpr {
+					g.writeln('')
+				} else {
+					g.writeln(';')
+				}
 			}
 		}
 		ast.FnDecl {


### PR DESCRIPTION
This PR fix match_expr generated c codes for redundant semicolons.

```v
fn main() {
	a := 22
	match a {
		11 {
			println('11')
		}
		else {
			println('others')
		}
	}
}
```
then:
```v
VV_LOCAL_SYMBOL void main__main(void) {
	int a = 22;

	if (a == (11)) {
		println(_SLIT("11"));
	}
	else {
		println(_SLIT("others"));
	};
}
```

now:
```v
VV_LOCAL_SYMBOL void main__main(void) {
	int a = 22;

	if (a == (11)) {
		println(_SLIT("11"));
	}
	else {
		println(_SLIT("others"));
	}
}
```