### PR TITLE
orm: init or implementation

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1709,6 +1709,7 @@ pub struct SqlStmt {
 pub:
 	pos     token.Pos
 	db_expr Expr // `db` in `sql db {`
+	or_expr OrExpr
 pub mut:
 	lines []SqlStmtLine
 }
@@ -1729,7 +1730,6 @@ pub mut:
 
 pub struct SqlExpr {
 pub:
-	typ        Type
 	is_count   bool
 	has_where  bool
 	has_order  bool
@@ -1737,8 +1737,11 @@ pub:
 	has_offset bool
 	has_desc   bool
 	is_array   bool
+	or_expr    OrExpr
 	pos        token.Pos
 pub mut:
+	typ         Type
+	err_impl    Expr
 	db_expr     Expr // `db` in `sql db {`
 	where_expr  Expr
 	order_expr  Expr

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -92,9 +92,11 @@ fn (mut p Parser) sql_expr() ast.Expr {
 		typ = table_type
 	}
 	p.check(.rcbr)
+	or_expr := p.parse_sql_or_block()
 	return ast.SqlExpr{
 		is_count: is_count
 		typ: typ
+		or_expr: or_expr
 		db_expr: db_expr
 		where_expr: where_expr
 		has_where: has_where
@@ -138,11 +140,45 @@ fn (mut p Parser) sql_stmt() ast.SqlStmt {
 	}
 
 	p.next()
+
+	mut or_expr := p.parse_sql_or_block()
+
 	pos.last_line = p.prev_tok.line_nr
 	return ast.SqlStmt{
 		pos: pos.extend(p.prev_tok.pos())
 		db_expr: db_expr
 		lines: lines
+		or_expr: or_expr
+	}
+}
+
+fn (mut p Parser) parse_sql_or_block() ast.OrExpr {
+	mut stmts := []ast.Stmt{}
+	mut kind := ast.OrKind.absent
+	mut pos := p.tok.pos()
+
+	if p.tok.kind == .key_orelse {
+		was_inside_or_expr := p.inside_or_expr
+		p.inside_or_expr = true
+		p.next()
+		p.open_scope()
+		p.scope.register(ast.Var{
+			name: 'err'
+			typ: ast.error_type
+			pos: p.tok.pos()
+			is_used: true
+		})
+		kind = .block
+		stmts = p.parse_block_no_scope(false)
+		pos = pos.extend(p.prev_tok.pos())
+		p.close_scope()
+		p.inside_or_expr = was_inside_or_expr
+	}
+
+	return ast.OrExpr{
+		stmts: stmts
+		kind: kind
+		pos: pos
 	}
 }
 


### PR DESCRIPTION
This PR adds or to the orm:

```v
import sqlite

struct Foo {
	id int [primary; sql: serial]
}

fn main() {
	db := sqlite.connect(':memory:') ?

	mut foo := Foo{}

	sql db {
		insert foo into Foo
	} or {
		eprintln(err)
	}

	res := sql db {
		select from Foo
	} or {
		[]Foo{}
	}


	eprintln(res)
}
```