### PR TITLE
cgen: fix error for comptime method call (fix #14991)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -159,11 +159,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				}
 			}
 		}
-		if g.inside_call {
-			g.write(')')
-		} else {
-			g.write(');')
-		}
+		g.write(')')
 		return
 	}
 	mut j := 0

--- a/vlib/v/tests/comptime_method_call_test.v
+++ b/vlib/v/tests/comptime_method_call_test.v
@@ -1,0 +1,25 @@
+struct App {}
+
+fn (mut app App) method_one() string {
+	return '1'
+}
+
+fn (mut app App) method_two() string {
+	return '2'
+}
+
+fn reflect_call(method_name string) string {
+	a := App{}
+	$for method in App.methods {
+		if method.name == method_name {
+			return a.$method() + ''
+		}
+	}
+	panic('Method not supported: $method_name')
+}
+
+fn test_comptime_method_call() {
+	result := reflect_call('method_one')
+	println(result)
+	assert result == '1'
+}


### PR DESCRIPTION
This PR fix error for comptime method call (fix #14991).

- Fix error for comptime method call.
- Add test.

```v
struct App {}

fn (mut app App) method_one() string {
	return '1'
}

fn (mut app App) method_two() string {
	return '2'
}

fn reflect_call(method_name string) string {
	a := App{}
	$for method in App.methods {
		if method.name == method_name {
			return a.$method() + ''
		}
	}
	panic('Method not supported: $method_name')
}

fn main() {
	result := reflect_call('method_one')
	println(result)
	assert result == '1'
}

PS D:\Test\v\tt1> v run .
1
```