### PR TITLE
net.websocket: make logger configurable

### DIFF
--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -36,11 +36,11 @@ pub mut:
 	header            http.Header  // headers that will be passed when connecting
 	conn              &net.TcpConn // underlying TCP socket connection
 	nonce_size        int = 16 // size of nounce used for masking
-	panic_on_callback bool     // set to true of callbacks can panic
-	state             State    // current state of connection
-	logger            &log.Log // logger used to log messages
-	resource_name     string   // name of current resource
-	last_pong_ut      i64      // last time in unix time we got a pong message
+	panic_on_callback bool        // set to true of callbacks can panic
+	state             State       // current state of connection
+	logger            &log.Logger // logger used to log messages
+	resource_name     string      // name of current resource
+	last_pong_ut      i64         // last time in unix time we got a pong message
 }
 
 // Flag represents different types of headers in websocket handshake
@@ -79,6 +79,9 @@ pub enum OPCode {
 pub struct ClientOpt {
 	read_timeout  i64 = 30 * time.second
 	write_timeout i64 = 30 * time.second
+	logger        &log.Logger = &log.Logger(&log.Log{
+		level: .info
+	})
 }
 
 // new_client instance a new websocket client
@@ -89,9 +92,7 @@ pub fn new_client(address string, opt ClientOpt) ?&Client {
 		is_server: false
 		ssl_conn: openssl.new_ssl_conn()
 		is_ssl: address.starts_with('wss')
-		logger: &log.Log{
-			level: .info
-		}
+		logger: opt.logger
 		uri: uri
 		state: .closed
 		id: rand.uuid_v4()

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -40,7 +40,7 @@ pub mut:
 	state             State       // current state of connection
 	logger            &log.Logger // logger used to log messages
 	resource_name     string      // name of current resource
-	last_pong_ut      i64         // last time in unix time we got a pong message
+	last_pong_ut      i64 // last time in unix time we got a pong message
 }
 
 // Flag represents different types of headers in websocket handshake
@@ -80,8 +80,8 @@ pub struct ClientOpt {
 	read_timeout  i64 = 30 * time.second
 	write_timeout i64 = 30 * time.second
 	logger        &log.Logger = &log.Logger(&log.Log{
-		level: .info
-	})
+	level: .info
+})
 }
 
 // new_client instance a new websocket client

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -37,8 +37,8 @@ pub mut:
 [params]
 pub struct ServerOpt {
 	logger &log.Logger = &log.Logger(&log.Log{
-		level: .info
-	})
+	level: .info
+})
 }
 
 // new_server instance a new websocket server on provided port and route

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -9,7 +9,7 @@ import rand
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	logger                  &log.Log // logger used to log
+	logger                  &log.Logger           // logger used to log
 	ls                      &net.TcpListener      // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions
 	message_callbacks       []MessageEventHandler // new message callback functions
@@ -34,15 +34,20 @@ pub mut:
 	client &Client
 }
 
+[params]
+pub struct ServerOpt {
+	logger &log.Logger = &log.Logger(&log.Log{
+		level: .info
+	})
+}
+
 // new_server instance a new websocket server on provided port and route
-pub fn new_server(family net.AddrFamily, port int, route string) &Server {
+pub fn new_server(family net.AddrFamily, port int, route string, opt ServerOpt) &Server {
 	return &Server{
 		ls: 0
 		family: family
 		port: port
-		logger: &log.Log{
-			level: .info
-		}
+		logger: opt.logger
 		state: .closed
 	}
 }


### PR DESCRIPTION
This PR allow user to use custom logger, by allowing to pass logger as an arg.

Currently, logger is hardcoded and impossible to change log format.

## Example usage
https://github.com/vpkgs/slog/blob/v3.0.0/targeted.v#L44-L54
```v
logger := slog.get_v_logger('net.websocket')
websocket.new_client(url, logger: &logger)
```

## Warning
This PR can be breaking change, for users setting log level for each websocket connection like followings
```v
mut conn := websocket.new_client(wck.url)?
conn.logger.set_level(.debug)
```

The above code will be follows, after these changes
```v
mut conn := websocket.new_client(wck.url)?
if conn.logger is log.Logger as logger {
	logger.set_level(.debug)
}
```

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
