### PR TITLE
pref: detect termux more reliably

### DIFF
--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -93,13 +93,13 @@ pub fn (o OS) str() string {
 }
 
 pub fn get_host_os() OS {
+	if os.getenv('TERMUX_VERSION') != '' {
+		return .termux
+	}
+	$if android {
+		return .android
+	}
 	$if linux {
-		$if android {
-			$if termux {
-				return .termux
-			}
-			return .android
-		}
 		return .linux
 	}
 	$if ios {
@@ -134,10 +134,6 @@ pub fn get_host_os() OS {
 	}
 	$if haiku {
 		return .haiku
-	}
-	// without this workaround Termux thinks it is js_node
-	if os.getenv('TERMUX_VERSION') != '' {
-		return .termux
 	}
 	$if js_node {
 		return .js_node

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module pref
 
+import os
+
 pub enum OS {
 	_auto // Reserved so .macos cannot be misunderstood as auto
 	ios
@@ -132,6 +134,10 @@ pub fn get_host_os() OS {
 	}
 	$if haiku {
 		return .haiku
+	}
+	// without this workaround Termux thinks it is js_node
+	if os.getenv('TERMUX_VERSION') != '' {
+		return .termux
 	}
 	$if js_node {
 		return .js_node


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Without this workaround Termux thinks it is js_node when running examples/fetch.v and is unable to use openssl for the request.

