### PR TITLE
parser: check closure capture global variable (fix #15004)

### DIFF
--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -103,6 +103,11 @@ pub fn (s &Scope) known_var(name string) bool {
 	return true
 }
 
+pub fn (s &Scope) known_global(name string) bool {
+	s.find_global(name) or { return false }
+	return true
+}
+
 pub fn (s &Scope) known_const(name string) bool {
 	s.find_const(name) or { return false }
 	return true

--- a/vlib/v/checker/tests/globals/closure_capture_global_var.out
+++ b/vlib/v/checker/tests/globals/closure_capture_global_var.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/globals/closure_capture_global_var.vv:12:12: error: no need to capture global variable `number` in closure
+   10 |
+   11 | fn main() {
+   12 |     f1 := fn [number] () {
+      |               ~~~~~~
+   13 |         println(number)
+   14 |     }

--- a/vlib/v/checker/tests/globals/closure_capture_global_var.vv
+++ b/vlib/v/checker/tests/globals/closure_capture_global_var.vv
@@ -1,0 +1,16 @@
+module main
+
+__global (
+	number	int
+)
+
+fn init() {
+	number = 123
+}
+
+fn main() {
+	f1 := fn [number] () {
+		println(number)
+	}
+	f1()
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1031,6 +1031,11 @@ fn (mut p Parser) closure_vars() []ast.Param {
 		p.check(.name)
 		var_name := p.prev_tok.lit
 		mut var := p.scope.parent.find_var(var_name) or {
+			if p.table.global_scope.known_global(var_name) {
+				p.error_with_pos('no need to capture global variable `$var_name` in closure',
+					p.prev_tok.pos())
+				continue
+			}
 			p.error_with_pos('undefined ident: `$var_name`', p.prev_tok.pos())
 			continue
 		}


### PR DESCRIPTION
This PR check closure capture global variable (fix #15004).

- Check closure capture global variable.
- Add test.

```v
module main

__global (
	number	int
)

fn init() {
	number = 123
}

fn main() {
	f1 := fn [number] () {
		println(number)
	}
	f1()
}

PS D:\Test\v\tt1> v -enable-globals run .
./tt1.v:12:12: error: no need to capture global variable `number` in closure
   10 |
   11 | fn main() {
   12 |     f1 := fn [number] () {
      |               ~~~~~~
   13 |         println(number)
   14 |     }
```