### PR TITLE
parser: check for illegal use of any type (fix #15003)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -35,10 +35,6 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			}
 		}
 		for i, field in node.fields {
-			if field.typ == ast.any_type {
-				c.error('struct field cannot be the `any` type, use generics instead',
-					field.type_pos)
-			}
 			c.ensure_type_exists(field.typ, field.type_pos) or { return }
 			if field.typ.has_flag(.generic) {
 				has_generic_types = true

--- a/vlib/v/checker/tests/struct_field_with_any_type_err.out
+++ b/vlib/v/checker/tests/struct_field_with_any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use `any` type here, it can only be used in js backend
+vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use `any` type here, `any` will be implemented in V 0.4
     1 | struct My_type {
     2 |     fld any
       |         ~~~

--- a/vlib/v/checker/tests/struct_field_with_any_type_err.out
+++ b/vlib/v/checker/tests/struct_field_with_any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: struct field cannot be the `any` type, use generics instead
+vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use `any` type here, it can only be used in js backend
     1 | struct My_type {
     2 |     fld any
       |         ~~~

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -607,6 +607,12 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 					'int_literal' {
 						ret = ast.int_literal_type
 					}
+					'any' {
+						if p.file_backend_mode != .js && p.mod != 'builtin' {
+							p.error('cannot use `any` type here, it can only be used in js backend')
+						}
+						ret = ast.any_type
+					}
 					else {
 						p.next()
 						if name.len == 1 && name[0].is_capital() {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -609,7 +609,7 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 					}
 					'any' {
 						if p.file_backend_mode != .js && p.mod != 'builtin' {
-							p.error('cannot use `any` type here, it can only be used in js backend')
+							p.error('cannot use `any` type here, `any` will be implemented in V 0.4')
 						}
 						ret = ast.any_type
 					}

--- a/vlib/v/parser/tests/cast_to_any_type_err.out
+++ b/vlib/v/parser/tests/cast_to_any_type_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/cast_to_any_type_err.vv:2:7: error: cannot use `any` type here, it can only be used in js backend
+    1 | fn main() {
+    2 |     a := any(22)
+      |          ~~~
+    3 |     println(a)
+    4 | }

--- a/vlib/v/parser/tests/cast_to_any_type_err.out
+++ b/vlib/v/parser/tests/cast_to_any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/cast_to_any_type_err.vv:2:7: error: cannot use `any` type here, it can only be used in js backend
+vlib/v/parser/tests/cast_to_any_type_err.vv:2:7: error: cannot use `any` type here, `any` will be implemented in V 0.4
     1 | fn main() {
     2 |     a := any(22)
       |          ~~~

--- a/vlib/v/parser/tests/cast_to_any_type_err.vv
+++ b/vlib/v/parser/tests/cast_to_any_type_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := any(22)
+	println(a)
+}


### PR DESCRIPTION
This PR check for illegal use of any type (fix #15003).

- Check for illegal use of any type.
- Add test.

```v
fn main() {
	a := any(22)
	println(a)
}

PS D:\test\v\tt1> v run .
./tt1.v:2:7: error: cannot use `any` type here, `any` will be implemented in V 0.4
    1 | fn main() {
    2 |     a := any(22)
      |          ~~~
    3 |     println(a)
    4 | }
```