### PR TITLE
checker.v: fix #15002 compiler bug about dereferencing voidptr.

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -332,6 +332,11 @@ pub fn (typ Type) is_pointer() bool {
 }
 
 [inline]
+pub fn (typ Type) is_voidptr() bool {
+	return typ.idx() == ast.voidptr_type_idx
+}
+
+[inline]
 pub fn (typ Type) is_real_pointer() bool {
 	return typ.is_ptr() || typ.is_pointer()
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3305,6 +3305,9 @@ pub fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 			s := c.table.type_to_str(right_type)
 			c.error('invalid indirect of `$s`', node.pos)
 		}
+		if right_type.is_voidptr() {
+			c.error('cannot dereference to void', node.pos)
+		}
 	}
 	if node.op == .bit_not && !right_type.is_int() && !c.pref.translated && !c.file.is_translated {
 		c.error('operator ~ only defined on int types', node.pos)

--- a/vlib/v/checker/tests/voidptr_dereference_err.out
+++ b/vlib/v/checker/tests/voidptr_dereference_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/voidptr_dereference_err.vv:5:10: error: cannot dereference to void
+    3 |     mut b := 123
+    4 |     a = &b
+    5 |     println(*a)
+      |             ^
+    6 | }

--- a/vlib/v/checker/tests/voidptr_dereference_err.vv
+++ b/vlib/v/checker/tests/voidptr_dereference_err.vv
@@ -1,0 +1,6 @@
+fn main() {
+	mut a := voidptr(0)
+	mut b := 123
+	a = &b
+	println(*a)
+}


### PR DESCRIPTION
As mentioned in #15002, the compiler allows you to dereference a `voidptr`, but it shouldn't.
This PR fixes it and introduces one more test.