### PR TITLE
checker, cgen: fix array of sumtype appending alias (fix #12606)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -406,7 +406,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 					return ast.void_type
 				} else if left_value_sym.kind == .sum_type {
-					if right_final_sym.kind != .array {
+					if right_sym.kind != .array {
 						if !c.table.is_sumtype_or_in_variant(left_value_type, ast.mktyp(right_type)) {
 							c.error('cannot append `$right_sym.name` to `$left_sym.name`',
 								right_pos)

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -695,8 +695,9 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 		tmp_var := g.new_tmp_var()
 		array_info := left.unaliased_sym.info as ast.Array
 		noscan := g.check_noscan(array_info.elem_type)
-		//&& array_info.elem_type != g.unwrap_generic(node.right_type)
-		if right.unaliased_sym.kind == .array && array_info.elem_type != right.typ {
+		if right.unaliased_sym.kind == .array && array_info.elem_type != right.typ
+			&& !(right.sym.kind == .alias
+			&& g.table.sumtype_has_variant(array_info.elem_type, node.right_type, false)) {
 			// push an array => PUSH_MANY, but not if pushing an array to 2d array (`[][]int << []int`)
 			g.write('_PUSH_MANY${noscan}(')
 			mut expected_push_many_atype := left.typ

--- a/vlib/v/tests/array_of_sumtype_append_alias_test.v
+++ b/vlib/v/tests/array_of_sumtype_append_alias_test.v
@@ -1,0 +1,27 @@
+type Attribute = NextHop | Origin
+
+type Origin = u8
+type NextHop = []u8
+
+fn test_array_of_sumtype_append_alias() {
+	mut attrs := []Attribute{cap: 100}
+	bytes := []u8{len: 4}
+
+	attrs << NextHop(bytes)
+	attrs << Origin(1)
+
+	for attr in attrs {
+		if attr is Origin {
+			println(attr)
+			continue
+		}
+		if attr is NextHop {
+			println(attr)
+			continue
+		}
+		panic('oh no !')
+	}
+	assert attrs.len == 2
+	assert attrs[0] == Attribute(NextHop(bytes))
+	assert attrs[1] == Attribute(Origin(1))
+}


### PR DESCRIPTION
This PR fix array of sumtype appending alias (fix #12606).

- Fix array of sumtype appending alias.
- Add test.

```v
type Attribute = NextHop | Origin

type Origin = u8
type NextHop = []u8

fn main() {
	mut attrs := []Attribute{cap: 100}
	bytes := []u8{len: 4}

	attrs << NextHop(bytes)
	attrs << Origin(1)

	for attr in attrs {
		if attr is Origin {
			println(attr)
			continue
		}
		if attr is NextHop {
			println(attr)
			continue
		}
		panic('oh no !')
	}
	assert attrs.len == 2
	assert attrs[0] == Attribute(NextHop(bytes))
	assert attrs[1] == Attribute(Origin(1))
}

PS D:\test\v\tt1> v run .
NextHop([`\0`, `\0`, `\0`, `\0`])
1
```