### PR TITLE
parser: fix parse c function with optional argument name (fix #13234)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -819,8 +819,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 			if is_mut {
 				p.next()
 			}
-			if p.fn_language == .c && p.tok.kind == .name && p.tok.lit.len > 0
-				&& !p.tok.lit[0].is_capital() && p.peek_tok.kind !in [.comma, .rpar, .dot] {
+			if p.fn_language == .c && p.tok.kind == .name
+				&& p.peek_tok.kind !in [.comma, .rpar, .dot] {
 				name = p.tok.lit
 				p.next()
 			}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -820,7 +820,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				p.next()
 			}
 			if p.fn_language == .c && p.tok.kind == .name && p.tok.lit.len > 0
-				&& !p.tok.lit[0].is_capital() && p.peek_tok.kind !in [.comma, .rpar] {
+				&& !p.tok.lit[0].is_capital() && p.peek_tok.kind !in [.comma, .rpar, .dot] {
 				name = p.tok.lit
 				p.next()
 			}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -800,7 +800,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
 		|| (p.peek_tok.kind == .comma && (p.table.known_type(argname) || is_generic_type))
-		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar
+		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar || p.fn_language == .c
 		|| (p.tok.kind == .key_mut && (p.peek_token(2).kind == .comma
 		|| p.peek_token(2).kind == .rpar || (p.peek_tok.kind == .name
 		&& p.peek_token(2).kind == .dot)))
@@ -815,7 +815,13 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 			is_shared := p.tok.kind == .key_shared
 			is_atomic := p.tok.kind == .key_atomic
 			is_mut := p.tok.kind == .key_mut || is_shared || is_atomic
+			mut name := ''
 			if is_mut {
+				p.next()
+			}
+			if p.fn_language == .c && p.tok.kind == .name && p.tok.lit.len > 0
+				&& !p.tok.lit[0].is_capital() && p.peek_tok.kind !in [.comma, .rpar] {
+				name = p.tok.lit
 				p.next()
 			}
 			if p.tok.kind == .ellipsis {
@@ -875,7 +881,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 			}
 			args << ast.Param{
 				pos: pos
-				name: ''
+				name: name
 				is_mut: is_mut
 				typ: arg_type
 				type_pos: pos

--- a/vlib/v/tests/c_function_mut_param/optional_args_test.v
+++ b/vlib/v/tests/c_function_mut_param/optional_args_test.v
@@ -1,0 +1,12 @@
+module main
+
+#include "@VMODROOT/code.c"
+
+fn C.mut_arg(&u8, mut val usize)
+
+fn test_c_function_mut_param() {
+	key := &u8(1)
+	mut val := usize(1)
+	C.mut_arg(key, mut &val)
+	assert val == usize(5)
+}


### PR DESCRIPTION
This PR fix parse c function with optional argument name (fix #13234).

- Fix parse c function with optional argument name.
- Add test.

```v
module main

#include "@VMODROOT/code.c"

fn C.mut_arg(&u8, mut val usize)

fn test_c_function_mut_param() {
	key := &u8(1)
	mut val := usize(1)
	C.mut_arg(key, mut &val)
	assert val == usize(5)
}
```