### PR TITLE
cgen: fix struct shared field with default init (fix #10813)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5360,8 +5360,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			mut has_none_zero := false
 			mut init_str := '{'
 			info := sym.info as ast.Struct
-			typ_is_shared_f := typ.has_flag(.shared_f)
-			if sym.language == .v && !typ_is_shared_f {
+			if sym.language == .v {
 				for field in info.fields {
 					field_sym := g.table.sym(field.typ)
 					if field.has_default_expr
@@ -5392,21 +5391,24 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 					}
 				}
 			}
+			typ_is_shared_f := typ.has_flag(.shared_f)
 			if has_none_zero {
 				init_str += '}'
-				type_name := if info.is_anon {
-					// No name needed for anon structs, C figures it out on its own.
-					''
-				} else {
-					'(${g.typ(typ)})'
+				if !typ_is_shared_f {
+					type_name := if info.is_anon {
+						// No name needed for anon structs, C figures it out on its own.
+						''
+					} else {
+						'(${g.typ(typ)})'
+					}
+					init_str = type_name + init_str
 				}
-				init_str = type_name + init_str
 			} else {
 				init_str += '0}'
 			}
-			if typ.has_flag(.shared_f) {
+			if typ_is_shared_f {
 				styp := '__shared__${g.table.sym(typ).cname}'
-				return '($styp*)__dup${styp}(&($styp){.mtx = {0}, .val =$init_str}, sizeof($styp))'
+				return '($styp*)__dup${styp}(&($styp){.mtx = {0}, .val = $init_str}, sizeof($styp))'
 			} else {
 				return init_str
 			}

--- a/vlib/v/tests/struct_shared_field_with_default_init_test.v
+++ b/vlib/v/tests/struct_shared_field_with_default_init_test.v
@@ -1,0 +1,23 @@
+struct App {
+	id string
+mut:
+	app_data shared AppData
+}
+
+struct AppData {
+	id           string
+	sub_app_data SubAppData
+}
+
+struct SubAppData {
+	id      string
+	message string = 'Default message'
+}
+
+fn test_struct_field_with_default_init() {
+	mut app := App{}
+	println(app)
+	rlock app.app_data {
+		assert app.app_data.sub_app_data.message == 'Default message'
+	}
+}


### PR DESCRIPTION
This PR fix struct shared field with default init (fix #10813).

- Fix struct shared field with default init.
- Add test.

```v
struct App {
	id string
mut:
	app_data shared AppData
}

struct AppData {
	id           string
	sub_app_data SubAppData
}

struct SubAppData {
	id      string
	message string = 'Default message'
}

fn main() {
	mut app := App{}
	println(app)
	rlock app.app_data {
		assert app.app_data.sub_app_data.message == 'Default message'
	}
}

PS D:\Test\v\tt1> v run .
App{
    id: ''
    app_data: AppData{
        id: ''
        sub_app_data: SubAppData{
            id: ''
            message: 'Default message'
        }
    }
}
```