### PR TITLE
cgen: fix fixed array literal index (fix #14959)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -327,15 +327,27 @@ fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	elem_sym := g.table.sym(elem_type)
 	is_fn_index_call := g.is_fn_index_call && elem_sym.info is ast.FnType
 
-	if is_fn_index_call {
-		g.write('(*')
-	}
-	if node.left_type.is_ptr() {
-		g.write('(*')
+	if node.left is ast.ArrayInit {
+		tmp := g.new_tmp_var()
+		line := g.go_before_stmt(0).trim_space()
+		styp := g.typ(node.left_type)
+		g.empty_line = true
+		g.write('$styp $tmp = ')
 		g.expr(node.left)
-		g.write(')')
+		g.writeln(';')
+		g.write(line)
+		g.write(tmp)
 	} else {
-		g.expr(node.left)
+		if is_fn_index_call {
+			g.write('(*')
+		}
+		if node.left_type.is_ptr() {
+			g.write('(*')
+			g.expr(node.left)
+			g.write(')')
+		} else {
+			g.expr(node.left)
+		}
 	}
 	g.write('[')
 	direct := unsafe { g.fn_decl != 0 } && g.fn_decl.is_direct_arr

--- a/vlib/v/tests/fixed_array_literal_index_test.v
+++ b/vlib/v/tests/fixed_array_literal_index_test.v
@@ -1,0 +1,7 @@
+fn test_fixed_array_literal_index() {
+   println([1]int{}[0])
+	assert [1]int{}[0] == 0
+
+	println([1, 2]![1])
+	assert [1, 2]![1] == 2
+}

--- a/vlib/v/tests/fixed_array_literal_index_test.v
+++ b/vlib/v/tests/fixed_array_literal_index_test.v
@@ -1,5 +1,5 @@
 fn test_fixed_array_literal_index() {
-   println([1]int{}[0])
+	println([1]int{}[0])
 	assert [1]int{}[0] == 0
 
 	println([1, 2]![1])


### PR DESCRIPTION
This PR fix fixed array literal index (fix #14959).

- Fix fixed array literal index.
- Add test.

```v
fn main() {
   println([1]int{}[0])
	assert [1]int{}[0] == 0

	println([1, 2]![1])
	assert [1, 2]![1] == 2
}

PS D:\Test\v\tt1> v run .
0
2
```
```v
fn main() {
   println([1]&int{}[0])
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:12: warning: fixed arrays of references need to be initialized right away (unless inside `unsafe`)
    1 | fn main() {
    2 |    println([1]&int{}[0])
      |            ~~~~~~~~~
    3 | }
&nil
```