### PR TITLE
cgen: fix fixed array of threads (fix #15082)

### DIFF
--- a/vlib/v/tests/fixed_array_of_threads_test.v
+++ b/vlib/v/tests/fixed_array_of_threads_test.v
@@ -1,0 +1,13 @@
+module main
+
+fn test_fixed_array_of_threads() {
+	mut avar := [8]thread string{}
+	avar[0] = go printme()
+	ret := avar[0].wait()
+	assert ret == 'me'
+}
+
+fn printme() string {
+	println('me')
+	return 'me'
+}


### PR DESCRIPTION
This PR fix fixed array of threads (fix #15082).

- Fix fixed array of threads.
- Add test.

```v
module main

fn main() {
	mut avar := [8]thread string{}
	avar[0] = go printme()
	ret := avar[0].wait()
	assert ret == 'me'
}

fn printme() string {
	println('me')
	return 'me'
}

PS D:\Test\v\tt1> v run .
me
```