### PR TITLE
parser: check generic interface method declaration (fix #15043)

### DIFF
--- a/vlib/v/checker/tests/generic_interface_method_decl_err.out
+++ b/vlib/v/checker/tests/generic_interface_method_decl_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/generic_interface_method_decl_err.vv:2:8: error: no need to add generic type names in generic interface's method
+    1 | interface Expr {
+    2 |     accept<R>(v Visitor<R>) R
+      |           ^
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/generic_interface_method_decl_err.vv
+++ b/vlib/v/checker/tests/generic_interface_method_decl_err.vv
@@ -1,0 +1,9 @@
+interface Expr {
+	accept<R>(v Visitor<R>) R
+}
+
+interface Visitor<R> {
+}
+
+fn main() {
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -622,6 +622,11 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_mut = true
 			mut_pos = fields.len
 		}
+		if p.peek_tok.kind == .lt {
+			p.error_with_pos("no need to add generic type names in generic interface's method",
+				p.peek_tok.pos())
+			return ast.InterfaceDecl{}
+		}
 		if p.peek_tok.kind == .lpar {
 			method_start_pos := p.tok.pos()
 			line_nr := p.tok.line_nr


### PR DESCRIPTION
This PR check generic interface method declaration (fix #15043).

- Check generic interface method declaration.
- Add test.

```v
interface Expr {
	accept<R>(v Visitor<R>) R
}

interface Visitor<R> {
}

fn main() {
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:8: error: no need to add generic type names in generic interface's method
    1 | interface Expr {
    2 |     accept<R>(v Visitor<R>) R
      |           ^
    3 | }
    4 |
```