### PR TITLE
mysql: fix for adapting mysql types to v structs

### DIFF
--- a/vlib/mysql/_cdefs.c.v
+++ b/vlib/mysql/_cdefs.c.v
@@ -38,6 +38,8 @@ fn C.mysql_real_connect(mysql &C.MYSQL, host &char, user &char, passwd &char, db
 
 fn C.mysql_query(mysql &C.MYSQL, q &u8) int
 
+fn C.mysql_use_result(mysql &C.MYSQL)
+
 fn C.mysql_real_query(mysql &C.MYSQL, q &u8, len u32) int
 
 fn C.mysql_select_db(mysql &C.MYSQL, db &u8) int

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -58,6 +58,14 @@ pub fn (conn Connection) query(q string) ?Result {
 	return Result{res}
 }
 
+// use_result - reads the result of a query
+// used after invoking mysql_real_query() or mysql_query(),
+// for every statement that successfully produces a result set
+// (SELECT, SHOW, DESCRIBE, EXPLAIN, CHECK TABLE, and so forth).
+// This reads the result of a query directly from the server
+// without storing it in a temporary table or local buffer, 
+// mysql_use_result is faster and uses much less memory than C.mysql_store_result().
+// You must mysql_free_result() after you are done with the result set.
 pub fn (conn Connection) use_result() {
 	C.mysql_use_result(conn.conn)
 }

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -63,7 +63,7 @@ pub fn (conn Connection) query(q string) ?Result {
 // for every statement that successfully produces a result set
 // (SELECT, SHOW, DESCRIBE, EXPLAIN, CHECK TABLE, and so forth).
 // This reads the result of a query directly from the server
-// without storing it in a temporary table or local buffer, 
+// without storing it in a temporary table or local buffer,
 // mysql_use_result is faster and uses much less memory than C.mysql_store_result().
 // You must mysql_free_result() after you are done with the result set.
 pub fn (conn Connection) use_result() {

--- a/vlib/mysql/mysql.v
+++ b/vlib/mysql/mysql.v
@@ -58,6 +58,10 @@ pub fn (conn Connection) query(q string) ?Result {
 	return Result{res}
 }
 
+pub fn (conn Connection) use_result() {
+	C.mysql_use_result(conn.conn)
+}
+
 // real_query - make an SQL query and receive the results.
 // `real_query()` can be used for statements containing binary data.
 // (Binary data may contain the `\0` character, which `query()`

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -57,7 +57,7 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 				dataptr << unsafe { malloc(2) }
 			}
 			else {
-				dataptr << &u8(0)
+				return error('\'${FieldType(f.@type)}\' is not yet implemented. Please create a new issue at https://github.com/vlang/v/issues/new')
 			}
 		}
 	}

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -47,8 +47,8 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 			.type_double {
 				dataptr << unsafe { malloc(8) }
 			}
-			.type_datetime {
-				dataptr << unsafe { malloc(512) }
+			.type_time, .type_date, .type_datetime {
+				dataptr << unsafe { malloc(sizeof(C.MYSQL_TIME)) }
 			}
 			.type_string, .type_blob {
 				dataptr << unsafe { malloc(512) }
@@ -80,10 +80,9 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 			orm.time {
 				match FieldType(f.@type) {
 					.type_long {
-						println(C.MYSQL_TYPE_INT24)
 						mysql_bind.buffer_type = C.MYSQL_TYPE_LONG
 					}
-					.type_datetime {
+					.type_time, .type_date, .type_datetime  {
 						mysql_bind.buffer_type = C.MYSQL_TYPE_BLOB
 						mysql_bind.buffer_length = FieldType.type_blob.get_len()
 					}
@@ -340,7 +339,7 @@ fn mysql_type_from_v(typ int) ?string {
 fn (db Connection) factory_orm_primitive_converted_from_sql(table string, data orm.QueryData) ?[]orm.Primitive {
 	mut map_val := db.get_table_data_type_map(table)?
 
-	// adabt v type to sql time
+	// adapt v type to sql time
 	mut converted_data := []orm.Primitive{}
 	for i, field in data.fields {
 		match data.data[i].type_name() {

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -47,7 +47,7 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 			.type_double {
 				dataptr << unsafe { malloc(8) }
 			}
-			.type_time, .type_date, .type_datetime, .type_time2, .type_date2, .type_datetime2 {
+			.type_time, .type_date, .type_datetime, .type_time2, .type_datetime2 {
 				dataptr << unsafe { malloc(sizeof(C.MYSQL_TIME)) }
 			}
 			.type_string, .type_blob {

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -24,7 +24,6 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 	num_fields := stmt.get_field_count()
 	metadata := stmt.gen_metadata()
 	fields := stmt.fetch_fields(metadata)
-
 	mut dataptr := []&u8{}
 
 	for i in 0 .. num_fields {
@@ -48,6 +47,9 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 			.type_double {
 				dataptr << unsafe { malloc(8) }
 			}
+			.type_datetime {
+				dataptr << unsafe { malloc(512) }
+			}
 			.type_string, .type_blob {
 				dataptr << unsafe { malloc(512) }
 			}
@@ -59,15 +61,44 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 
 	lens := []u32{len: int(num_fields), init: 0}
 	stmt.bind_res(fields, dataptr, lens, num_fields)
-	stmt.bind_result_buffer()?
-	stmt.store_result()?
 
 	mut row := 0
 	mut types := config.types
+	mut field_types := []FieldType{}
 	if config.is_count {
 		types = [orm.type_idx['u64']]
 	}
 
+	for i, mut mysql_bind in stmt.res {
+		f := unsafe { fields[i] }
+		field_types << FieldType(f.@type)
+		match types[i] {
+			orm.string {
+				mysql_bind.buffer_type = C.MYSQL_TYPE_BLOB
+				mysql_bind.buffer_length = FieldType.type_blob.get_len()
+			}
+			orm.time {
+				match FieldType(f.@type) {
+					.type_long {
+						println(C.MYSQL_TYPE_INT24)
+						mysql_bind.buffer_type = C.MYSQL_TYPE_LONG
+					}
+					.type_datetime {
+						mysql_bind.buffer_type = C.MYSQL_TYPE_BLOB
+						mysql_bind.buffer_length = FieldType.type_blob.get_len()
+					}
+					.type_string, .type_blob {}
+					else {
+						return error('Unknown type ${f.@type}')
+					}
+				}
+			}
+			else {}
+		}
+	}
+
+	stmt.bind_result_buffer()?
+	stmt.store_result()?
 	for {
 		status = stmt.fetch_stmt()?
 
@@ -76,7 +107,7 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 		}
 		row++
 
-		data_list := buffer_to_primitive(dataptr, types)?
+		data_list := buffer_to_primitive(dataptr, types, field_types)?
 		ret << data_list
 	}
 
@@ -88,8 +119,19 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 // sql stmt
 
 pub fn (db Connection) insert(table string, data orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '`', .insert, false, '?', 1, data, orm.QueryData{})
-	mysql_stmt_worker(db, query, data, orm.QueryData{})?
+	mut converted_primitive_array := db.factory_orm_primitive_converted_from_sql(table,
+		data)?
+
+	converted_data := orm.QueryData{
+		fields: data.fields
+		data: converted_primitive_array
+		types: []
+		kinds: []
+		is_and: []
+	}
+
+	query := orm.orm_stmt_gen(table, '`', .insert, false, '?', 1, converted_data, orm.QueryData{})
+	mysql_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 
 pub fn (db Connection) update(table string, data orm.QueryData, where orm.QueryData) ? {
@@ -191,7 +233,7 @@ fn stmt_binder_match(mut stmt Stmt, data orm.Primitive) {
 	}
 }
 
-fn buffer_to_primitive(data_list []&u8, types []int) ?[]orm.Primitive {
+fn buffer_to_primitive(data_list []&u8, types []int, field_types []FieldType) ?[]orm.Primitive {
 	mut res := []orm.Primitive{}
 
 	for i, data in data_list {
@@ -234,8 +276,17 @@ fn buffer_to_primitive(data_list []&u8, types []int) ?[]orm.Primitive {
 				primitive = unsafe { cstring_to_vstring(&char(data)) }
 			}
 			orm.time {
-				timestamp := *(unsafe { &int(data) })
-				primitive = time.unix(timestamp)
+				match field_types[i] {
+					.type_long {
+						timestamp := *(unsafe { &int(data) })
+						primitive = time.unix(timestamp)
+					}
+					.type_datetime {
+						string_time := unsafe { cstring_to_vstring(&char(data)) }
+						primitive = time.parse(string_time)?
+					}
+					else {}
+				}
 			}
 			else {
 				return error('Unknown type ${types[i]}')
@@ -284,4 +335,41 @@ fn mysql_type_from_v(typ int) ?string {
 		return error('Unknown type $typ')
 	}
 	return str
+}
+
+fn (db Connection) factory_orm_primitive_converted_from_sql(table string, data orm.QueryData) ?[]orm.Primitive {
+	mut map_val := db.get_table_data_type_map(table)?
+
+	// adabt v type to sql time
+	mut converted_data := []orm.Primitive{}
+	for i, field in data.fields {
+		match data.data[i].type_name() {
+			'time.Time' {
+				if map_val[field] == 'datetime' {
+					converted_data << orm.Primitive((data.data[i] as time.Time).str())
+				} else {
+					converted_data << data.data[i]
+				}
+			}
+			else {
+				converted_data << data.data[i]
+			}
+		}
+	}
+	return converted_data
+}
+
+fn (db Connection) get_table_data_type_map(table string) ?map[string]string {
+	data_type_querys := "SELECT COLUMN_NAME, DATA_TYPE  FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = '$table'"
+	mut map_val := map[string]string{}
+
+	results := db.query(data_type_querys)?
+	db.use_result()
+
+	for row in results.rows() {
+		map_val[row.vals[0]] = row.vals[1]
+	}
+
+	unsafe { results.free() }
+	return map_val
 }

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -82,7 +82,7 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 					.type_long {
 						mysql_bind.buffer_type = C.MYSQL_TYPE_LONG
 					}
-					.type_time, .type_date, .type_datetime  {
+					.type_time, .type_date, .type_datetime {
 						mysql_bind.buffer_type = C.MYSQL_TYPE_BLOB
 						mysql_bind.buffer_length = FieldType.type_blob.get_len()
 					}

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -47,11 +47,14 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 			.type_double {
 				dataptr << unsafe { malloc(8) }
 			}
-			.type_time, .type_date, .type_datetime {
+			.type_time, .type_date, .type_datetime, .type_time2, .type_date2, .type_datetime2 {
 				dataptr << unsafe { malloc(sizeof(C.MYSQL_TIME)) }
 			}
 			.type_string, .type_blob {
 				dataptr << unsafe { malloc(512) }
+			}
+			.type_var_string {
+				dataptr << unsafe { malloc(2) }
 			}
 			else {
 				dataptr << &u8(0)

--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -20,8 +20,11 @@
 
 ```v ignore
 struct Foo {
-    id   int    [primary; sql: serial]
-    name string [nonull]
+    id          int         [primary; sql: serial]
+    name        string      [nonull]
+    created_at  time.Time   [sql_type: 'DATETIME']
+    updated_at  string      [sql_type: 'DATETIME']
+    deleted_at  time.Time
 }
 ```
 
@@ -45,7 +48,10 @@ sql db {
 
 ```v ignore
 var := Foo{
-    name: 'abc'
+    name:       'abc'
+    created_at: time.now()
+    updated_at: time.now().str()
+    deleted_at: time.now()
 }
 
 sql db {


### PR DESCRIPTION
FIX1: ```V panic: mysql.SQLError: Incorrect datetime value: '1657993703' for column 'created_at' at row 1 (1) (INSERT INTO `TestTimeType` (`username`, `created_at`, `updated_at`, `deleted_at`) VALUES (?, ?, ?, ?);)```

FIX2:
```
/tmp/v_1000/v.10678589466079111090.tmp.c:17797: at print_backtrace: Backtrace
/tmp/v_1000/v.10678589466079111090.tmp.c:17868: by v_segmentation_fault_handler
7fcb42179520 : by ???
7fcb4210dcf0 : by ???
7fcb4210e2fb : by ???
/tmp/v_1000/v.10678589466079111090.tmp.c:54587: by mysql__Stmt_fetch_stmt
/tmp/v_1000/v.10678589466079111090.tmp.c:54148: by mysql__Connection_select
/tmp/v_1000/v.10678589466079111090.tmp.c:10274: by mysql__Connection_select_Interface_orm__Connection_method_wrapper
/tmp/v_1000/v.10678589466079111090.tmp.c:54876: by main__main
/tmp/v_1000/v.10678589466079111090.tmp.c:56346: by main
```

### mysql
- [x] fix
- [x] test
- [x] doc

_*pg(PostgreSQL) and sqlite will be implemented after this PR be accepted_ 

### Now will be possible
use this
```v
model := TestTimeType{
  username: 'hitalo'
  created_at: time.now()
  updated_at: time.now().str()
  deleted_at: time.now()
}
```
to **_insert_** or **_select_** this

```v
struct TestTimeType {
mut:
  id         int       [primary; sql: serial]
  username   string
  created_at time.Time [sql_type: 'DATETIME']
  updated_at string    [sql_type: 'DATETIME']
  deleted_at time.Time
}
```
