### PR TITLE
native: system for defining internal builtin algorithms which are not inlined

### DIFF
--- a/vlib/v/gen/native/builtins.v
+++ b/vlib/v/gen/native/builtins.v
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2022 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module native
+
+import os
+import strings
+import v.ast
+import v.util
+import v.mathutil as mu
+import v.token
+import v.errors
+import v.pref
+import term
+
+struct BuiltinFn {
+	body     fn (builtin BuiltinFn, mut g Gen)
+	arg_regs []Register
+}
+
+pub const inline_builtins = ['assert', 'print', 'eprint', 'println', 'eprintln', 'exit', 'C.syscall'] // classic V builtin functios accessible to the user get inlined
+
+pub const builtins = {
+	// longer algorithms and internal functions inaccessible to the user
+	// used to keep executable size small and the bytecode distraction-free
+	'reverse_string': BuiltinFn{
+		body: fn (builtin BuiltinFn, mut g Gen) {
+			g.reverse_string(builtin.arg_regs[0])
+		}
+		arg_regs: [.rdi]
+	}
+	'int_to_string':  BuiltinFn{
+		body: fn (builtin BuiltinFn, mut g Gen) {
+			g.convert_int_to_string(builtin.arg_regs[0], builtin.arg_regs[1])
+		}
+		arg_regs: [.rcx, .rdi]
+	}
+}
+
+pub fn (mut g Gen) register_builtin_address(name string) {
+	g.builtin_addr[name] = g.pos()
+}
+
+pub fn (mut g Gen) generate_builtins() {
+	for name, builtin in native.builtins {
+		if g.pref.is_verbose {
+			println(term.green('\n(builtin) $name:'))
+		}
+
+		g.stack_var_pos = 0
+		g.register_builtin_address(name)
+		g.defer_stmts.clear()
+		g.labels = &LabelTable{}
+
+		if g.pref.arch == .arm64 {
+			g.n_error('builtins are not implemented for arm64')
+		} else {
+			g.builtin_decl_amd64(builtin)
+		}
+
+		g.patch_labels()
+	}
+}
+
+pub fn (mut g Gen) get_builtin_arg_reg(name string, index int) Register {
+	builtin := native.builtins[name] or { panic('undefined builtin function $name') }
+	if index >= builtin.arg_regs.len {
+		g.n_error('builtin $name does only have $builtin.arg_regs.len arguments, wanted $index')
+	}
+	return builtin.arg_regs[index]
+}
+
+pub fn (mut g Gen) call_builtin(name string) {
+	if g.pref.arch == .arm64 {
+		g.n_error('builtin calls are not implemented for amd64')
+	} else {
+		g.call_builtin_amd64(name)
+	}
+}

--- a/vlib/v/gen/native/builtins.v
+++ b/vlib/v/gen/native/builtins.v
@@ -3,52 +3,48 @@
 // that can be found in the LICENSE file.
 module native
 
-import os
-import strings
-import v.ast
-import v.util
-import v.mathutil as mu
-import v.token
-import v.errors
-import v.pref
 import term
 
 struct BuiltinFn {
 	body     fn (builtin BuiltinFn, mut g Gen)
 	arg_regs []Register
+mut:
+	calls []i64 // call addresses
 }
 
 pub const inline_builtins = ['assert', 'print', 'eprint', 'println', 'eprintln', 'exit', 'C.syscall'] // classic V builtin functios accessible to the user get inlined
 
-pub const builtins = {
-	// longer algorithms and internal functions inaccessible to the user
-	// used to keep executable size small and the bytecode distraction-free
-	'reverse_string': BuiltinFn{
-		body: fn (builtin BuiltinFn, mut g Gen) {
-			g.reverse_string(builtin.arg_regs[0])
+pub fn (mut g Gen) init_builtins() {
+	g.builtins = {
+		// longer algorithms and internal functions inaccessible to the user
+		// used to keep executable size small and the bytecode distraction-free
+		'int_to_string':  BuiltinFn{
+			body: fn (builtin BuiltinFn, mut g Gen) {
+				g.convert_int_to_string(builtin.arg_regs[0], builtin.arg_regs[1])
+			}
+			arg_regs: [.rcx, .rdi]
 		}
-		arg_regs: [.rdi]
-	}
-	'int_to_string':  BuiltinFn{
-		body: fn (builtin BuiltinFn, mut g Gen) {
-			g.convert_int_to_string(builtin.arg_regs[0], builtin.arg_regs[1])
+		'reverse_string': BuiltinFn{
+			body: fn (builtin BuiltinFn, mut g Gen) {
+				g.reverse_string(builtin.arg_regs[0])
+			}
+			arg_regs: [.rdi]
 		}
-		arg_regs: [.rcx, .rdi]
 	}
-}
-
-pub fn (mut g Gen) register_builtin_address(name string) {
-	g.builtin_addr[name] = g.pos()
 }
 
 pub fn (mut g Gen) generate_builtins() {
-	for name, builtin in native.builtins {
+	for name, builtin in g.builtins {
+		if builtin.calls.len == 0 { // if a builtin does not get called, do not emit it
+			continue
+		}
+
 		if g.pref.is_verbose {
 			println(term.green('\n(builtin) $name:'))
 		}
 
 		g.stack_var_pos = 0
-		g.register_builtin_address(name)
+		call_addr := g.pos()
 		g.defer_stmts.clear()
 		g.labels = &LabelTable{}
 
@@ -59,11 +55,17 @@ pub fn (mut g Gen) generate_builtins() {
 		}
 
 		g.patch_labels()
+
+		// patch all call addresses where this builtin gets called
+		for call in builtin.calls {
+			rel := g.call_addr_at(int(call_addr), call)
+			g.write32_at(call + 1, int(rel))
+		}
 	}
 }
 
 pub fn (mut g Gen) get_builtin_arg_reg(name string, index int) Register {
-	builtin := native.builtins[name] or { panic('undefined builtin function $name') }
+	builtin := g.builtins[name] or { panic('undefined builtin function $name') }
 	if index >= builtin.arg_regs.len {
 		g.n_error('builtin $name does only have $builtin.arg_regs.len arguments, wanted $index')
 	}
@@ -74,6 +76,6 @@ pub fn (mut g Gen) call_builtin(name string) {
 	if g.pref.arch == .arm64 {
 		g.n_error('builtin calls are not implemented for amd64')
 	} else {
-		g.call_builtin_amd64(name)
+		g.builtins[name].calls << g.call_builtin_amd64(name)
 	}
 }

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -34,7 +34,6 @@ mut:
 	main_fn_addr         i64
 	code_start_pos       i64 // location of the start of the assembly instructions
 	fn_addr              map[string]i64
-	builtin_addr         map[string]i64
 	var_offset           map[string]int // local var stack offset
 	var_alloc_size       map[string]int // local var allocation size
 	stack_var_pos        int
@@ -48,6 +47,7 @@ mut:
 	strs                 []String
 	labels               &LabelTable
 	defer_stmts          []ast.DeferStmt
+	builtins             map[string]BuiltinFn
 	// macho specific
 	macho_ncmds   int
 	macho_cmdsize int
@@ -193,7 +193,7 @@ pub fn gen(files []&ast.File, table &ast.Table, out_name string, pref &pref.Pref
 	}
 	g.code_gen.g = g
 	g.generate_header()
-	g.generate_builtins()
+	g.init_builtins()
 	for file in files {
 		/*
 		if file.warnings.len > 0 {
@@ -205,6 +205,7 @@ pub fn gen(files []&ast.File, table &ast.Table, out_name string, pref &pref.Pref
 		}
 		g.stmts(file.stmts)
 	}
+	g.generate_builtins()
 	g.generate_footer()
 	return g.nlines, g.buf.len
 }


### PR DESCRIPTION
Adding a system for defining internal algorithms which are not inlined, but rather treated like functions.
This is necessary to keep executable sizes small and the generated code clean (especially for debugging). Algorithms like the int-to-string conversion, etc. no longer get duplicated when needed.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
