### PR TITLE
checker: check generic struct declaration

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -24,6 +24,18 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 					struct_sym.info.is_heap = true
 				}
 			}
+			// Ensure each generic type of the embed was declared in the struct's definition
+			if node.generic_types.len > 0 && embed.typ.has_flag(.generic) {
+				embed_generic_names := c.table.generic_type_names(embed.typ)
+				node_generic_names := node.generic_types.map(c.table.type_to_str(it))
+				for name in embed_generic_names {
+					if name !in node_generic_names {
+						struct_generic_names := node_generic_names.join(', ')
+						c.error('generic type name `$name` is not mentioned in struct `$node.name<$struct_generic_names>`',
+							embed.pos)
+					}
+				}
+			}
 		}
 		if struct_sym.info.is_minify {
 			node.fields.sort_with_compare(minify_sort_fn)
@@ -119,6 +131,18 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 					if field.default_expr.val == false {
 						c.warn('unnecessary default value `false`: struct fields are zeroed by default',
 							field.default_expr.pos)
+					}
+				}
+			}
+			// Ensure each generic type of the field was declared in the struct's definition
+			if node.generic_types.len > 0 && field.typ.has_flag(.generic) {
+				field_generic_names := c.table.generic_type_names(field.typ)
+				node_generic_names := node.generic_types.map(c.table.type_to_str(it))
+				for name in field_generic_names {
+					if name !in node_generic_names {
+						struct_generic_names := node_generic_names.join(', ')
+						c.error('generic type name `$name` is not mentioned in struct `$node.name<$struct_generic_names>`',
+							field.type_pos)
 					}
 				}
 			}

--- a/vlib/v/checker/tests/generics_struct_decl_no_mention_err.out
+++ b/vlib/v/checker/tests/generics_struct_decl_no_mention_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/generics_struct_decl_no_mention_err.vv:4:2: error: generic type name `T` is not mentioned in struct `Foo<U>`
+    2 |
+    3 | struct Foo<U> {
+    4 |     Bar<T>
+      |     ~~~~~~
+    5 |     foo U
+    6 |     bar P
+vlib/v/checker/tests/generics_struct_decl_no_mention_err.vv:6:6: error: generic type name `P` is not mentioned in struct `Foo<U>`
+    4 |     Bar<T>
+    5 |     foo U
+    6 |     bar P
+      |         ^
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/generics_struct_decl_no_mention_err.vv
+++ b/vlib/v/checker/tests/generics_struct_decl_no_mention_err.vv
@@ -1,0 +1,10 @@
+fn main() {}
+
+struct Foo<U> {
+	Bar<T>
+	foo U
+	bar P
+}
+
+struct Bar<T> {
+}


### PR DESCRIPTION
This PR check generic struct declaration.

- Check generic struct declaration.
- Add test.

```v
fn main() {}

struct Foo<U> {
	Bar<T>
	foo U
	bar P
}

struct Bar<T> {
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:2: error: generic type name `T` is not mentioned in struct `Foo<U>`
    2 | 
    3 | struct Foo<U> {
    4 |     Bar<T>
      |     ~~~~~~
    5 |     foo U
    6 |     bar P
./tt1.v:6:6: error: generic type name `P` is not mentioned in struct `Foo<U>`
    4 |     Bar<T>
    5 |     foo U
    6 |     bar P
      |         ^
    7 | }
    8 |
```