### PR TITLE
checker: check generic interface declaration

### DIFF
--- a/vlib/v/checker/tests/generics_interface_decl_no_mention_err.out
+++ b/vlib/v/checker/tests/generics_interface_decl_no_mention_err.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:4:2: error: generic type name `T` is not mentioned in interface `Foo<U>`
+    2 |
+    3 | interface Foo<U> {
+    4 |     Bar<T>
+      |     ~~~
+    5 |     foo(u U, p P)
+    6 |     bar(u U) []P
+vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:5:13: error: generic type name `P` is not mentioned in interface `Foo<U>`
+    3 | interface Foo<U> {
+    4 |     Bar<T>
+    5 |     foo(u U, p P)
+      |                ^
+    6 |     bar(u U) []P
+    7 | }
+vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:6:11: error: generic type name `P` is not mentioned in interface `Foo<U>`
+    4 |     Bar<T>
+    5 |     foo(u U, p P)
+    6 |     bar(u U) []P
+      |              ~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv
+++ b/vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv
@@ -1,0 +1,10 @@
+fn main() {}
+
+interface Foo<U> {
+	Bar<T>
+	foo(u U, p P)
+	bar(u U) []P
+}
+
+interface Bar<T> {
+}


### PR DESCRIPTION
This PR check generic interface declaration.

- Check generic interface declaration.
- Add test.

```v
fn main() {}

interface Foo<U> {
	Bar<T>
	foo(u U, p P)
	bar(u U) []P
}

interface Bar<T> {
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:2: error: generic type name `T` is not mentioned in interface `Foo<U>`
    2 |
    3 | interface Foo<U> {
    4 |     Bar<T>
      |     ~~~
    5 |     foo(u U, p P)
    6 |     bar(u U) []P
./tt1.v:5:13: error: generic type name `P` is not mentioned in interface `Foo<U>`
    3 | interface Foo<U> {
    4 |     Bar<T>
    5 |     foo(u U, p P)
      |                ^
    6 |     bar(u U) []P
    7 | }
./tt1.v:6:11: error: generic type name `P` is not mentioned in interface `Foo<U>`
    4 |     Bar<T>
    5 |     foo(u U, p P)
    6 |     bar(u U) []P
      |              ~~~
    7 | }
    8 |
```