### PR TITLE
compiler: fix able to append reference to array and change const (FIX #14916)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -420,6 +420,16 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 					return ast.void_type
 				}
+
+				if right_type.is_any_kind_of_pointer() {
+					c.fail_if_immutable(
+						node.right,
+						restrict_to_const: true,
+						modify_const_error_msg_prefix: 'cannot append constant `$right_sym.name` to `$left_sym.name`'
+					)
+					return ast.void_type
+				}
+
 				// []T << T or []T << []T
 				unwrapped_right_type := c.unwrap_generic(right_type)
 				if c.check_types(unwrapped_right_type, left_value_type) {


### PR DESCRIPTION
This PR adds a check to ensure that references to constants are unable to be appended to arrays as shown in this issue: https://github.com/vlang/v/issues/14916
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
