### PR TITLE
builtin: clean up interface IError

### DIFF
--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -14,10 +14,6 @@ pub fn panic(s string) {
 
 // IError holds information about an error instance
 pub interface IError {
-	// >> Hack to allow old style custom error implementations
-	// TODO: remove once deprecation period for `IError` methods has ended
-	msg string
-	code int // <<
 	msg() string
 	code() int
 }

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -5,10 +5,6 @@ module builtin
 
 // IError holds information about an error instance
 pub interface IError {
-	// >> Hack to allow old style custom error implementations
-	// TODO: remove once deprecation period for `IError` methods has ended
-	msg string
-	code int // <<
 	msg() string
 	code() int
 }


### PR DESCRIPTION
This PR clean up interface IError.

- Remove `msg` and `code` fields.