### PR TITLE
ci: fix report-missing-fn-doc

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: vlang/v
+          ref: master # important
           path: pv
 
       - name: Check against parent commit


### PR DESCRIPTION
I found out that undocumented functions are still sneaking through CI.

Looks like the same ref is getting checked out for the comparison:
https://github.com/vlang/v/runs/7377406097?check_suite_focus=true#step:3:27

https://github.com/vlang/v/runs/7377406097?check_suite_focus=true#step:4:486

I'm not sure how to checkout the PR's target branch (the branch that the PR will merge to) - so I'm using `ref: master` as this is where most PRs go AFAIK