### PR TITLE
cmd/tools/vls: skip 'ls' argument on `v ls`

### DIFF
--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -431,6 +431,17 @@ fn main() {
 	fp.application('v ls')
 	fp.description('Installs, updates, and executes the V language server program')
 	fp.version('0.1')
+
+	// just to make sure whenever user wants to
+	// interact directly with the executable
+	// instead of the usual `v ls` command
+	if fp.args.len >= 2 && fp.args[0..2] == [os.executable(), 'ls'] {
+		// skip the executable here, the next skip_executable
+		// outside the if statement will skip the `ls` part
+		fp.skip_executable()
+	}
+
+	// skip the executable or the `ls` part
 	fp.skip_executable()
 
 	upd.parse(mut fp) or {


### PR DESCRIPTION
Fixes an issue when executing `v ls --socket` causes the language server to start in stdio mode because of the beginning `ls` argument when the `v ls` launcher passed the remaining arguments to the server executable (`['ls', '--socket']` instead of `['--socket']`).