### PR TITLE
checker, cgen: fix interface embedding ierror smartcast (fix #13296)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2903,7 +2903,11 @@ pub fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
 fn (mut c Checker) smartcast(expr_ ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
 	sym := c.table.sym(cur_type)
-	to_type := if sym.kind == .interface_ { to_type_.ref() } else { to_type_ }
+	to_type := if sym.kind == .interface_ && c.table.sym(to_type_).kind != .interface_ {
+		to_type_.ref()
+	} else {
+		to_type_
+	}
 	mut expr := unsafe { expr_ }
 	match mut expr {
 		ast.SelectorExpr {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -311,8 +311,6 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 				if left_sym.kind == .interface_ {
 					if right_sym.kind != .interface_ {
 						c.type_implements(right_type, expr_type, node.pos)
-					} else {
-						return
 					}
 				} else if !c.check_types(right_type, expr_type) && left_sym.kind != .sum_type {
 					expect_str := c.table.type_to_str(right_type)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3894,19 +3894,24 @@ fn (mut g Gen) ident(node ast.Ident) {
 					}
 					for i, typ in node.obj.smartcasts {
 						cast_sym := g.table.sym(g.unwrap_generic(typ))
-						mut is_ptr := false
-						if i == 0 {
-							g.write(name)
-							if node.obj.orig_type.is_ptr() {
-								is_ptr = true
-							}
-						}
-						dot := if is_ptr || is_auto_heap { '->' } else { '.' }
-						if cast_sym.info is ast.Aggregate {
-							sym := g.table.sym(cast_sym.info.types[g.aggregate_type_idx])
-							g.write('${dot}_$sym.cname')
+						if obj_sym.kind == .interface_ && cast_sym.kind == .interface_ {
+							ptr := '*'.repeat(node.obj.typ.nr_muls())
+							g.write('I_${obj_sym.cname}_as_I_${cast_sym.cname}($ptr$node.name)')
 						} else {
-							g.write('${dot}_$cast_sym.cname')
+							mut is_ptr := false
+							if i == 0 {
+								g.write(name)
+								if node.obj.orig_type.is_ptr() {
+									is_ptr = true
+								}
+							}
+							dot := if is_ptr || is_auto_heap { '->' } else { '.' }
+							if cast_sym.info is ast.Aggregate {
+								sym := g.table.sym(cast_sym.info.types[g.aggregate_type_idx])
+								g.write('${dot}_$sym.cname')
+							} else {
+								g.write('${dot}_$cast_sym.cname')
+							}
 						}
 						g.write(')')
 					}

--- a/vlib/v/tests/interface_embedding_smartcast_test.v
+++ b/vlib/v/tests/interface_embedding_smartcast_test.v
@@ -1,0 +1,47 @@
+// Common interface to all error custom types.
+interface ESpeaker {
+	IError
+	speak() string
+}
+
+// One custom error implementation.
+struct MyError {
+	// Mandatory fields from IError.
+	msg  string
+	code int
+	// Custom field.
+	blah string
+}
+
+// Interface implementation for this example custom type.
+fn (e MyError) speak() string {
+	return e.blah
+}
+
+fn (e MyError) msg() string {
+	return e.msg
+}
+
+fn (e MyError) code() int {
+	return e.code
+}
+
+// An example function that returns a custom error.
+fn foo() ?string {
+	return IError(MyError{
+		msg: 'foo'
+		blah: 'world'
+	})
+}
+
+fn test_interface_embedding_smartcast() {
+	x := foo() or {
+		if err is ESpeaker {
+			err.speak()
+		} else {
+			'undefined'
+		}
+	}
+	println(x)
+	assert x == 'world'
+}

--- a/vlib/v/tests/interface_with_multi_nested_embed_1_test.v
+++ b/vlib/v/tests/interface_with_multi_nested_embed_1_test.v
@@ -34,8 +34,8 @@ mut:
 
 fn (mut w Window) init() {
 	for wd in w.initables {
-		if mut wd is Container {
-			mut c := wd as Container
+		if wd is Container {
+			mut c := unsafe { wd }
 			c.layout()
 		}
 	}


### PR DESCRIPTION
This PR fix interface embedding ierror smartcast (fix #13296).

- Fix interface embedding ierror smartcast.
- Add test.

```v
// Common interface to all error custom types.
interface ESpeaker {
	IError
	speak() string
}

// One custom error implementation.
struct MyError {
	// Mandatory fields from IError.
	msg  string
	code int
	// Custom field.
	blah string
}

// Interface implementation for this example custom type.
fn (e MyError) speak() string {
	return e.blah
}

fn (e MyError) msg() string {
	return e.msg
}

fn (e MyError) code() int {
	return e.code
}

// An example function that returns a custom error.
fn foo() ?string {
	return IError(MyError{
		msg: 'foo'
		blah: 'world'
	})
}

fn main() {
	x := foo() or {
		if err is ESpeaker {
			err.speak()
		} else {
			'undefined'
		}
	}
	println(x)
	assert x == 'world'
}

PS D:\Test\v\tt1> v run .
world
```