### PR TITLE
cmd/tools/vls: add helpful message when server is not found

### DIFF
--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -16,6 +16,7 @@ import net.http
 import runtime
 import crypto.sha256
 import time
+import json
 
 enum UpdateSource {
 	github_releases
@@ -380,7 +381,7 @@ fn (upd VlsUpdater) log(msg string) {
 	}
 }
 
-fn (upd VlsUpdater) error_details(err IError) {
+fn (upd VlsUpdater) error_details(err IError) string {
 	match err.code() {
 		101 {
 			mut vls_dir_shortened := '\$HOME/.vls'
@@ -388,7 +389,7 @@ fn (upd VlsUpdater) error_details(err IError) {
 				vls_dir_shortened = '%USERPROFILE%\\.vls'
 			}
 
-			eprintln('
+			return '
 - If you are using this for the first time, please run
   `v ls --install` first to download and install VLS.
 - If you are using a custom version of VLS, check if
@@ -399,9 +400,11 @@ fn (upd VlsUpdater) error_details(err IError) {
 
   If none of the options listed have solved your issue,
   please report it at https://github.com/vlang/v/issues
-')
+'
 		}
-		else {}
+		else {
+			return ''
+		}
 	}
 }
 
@@ -411,13 +414,13 @@ fn (upd VlsUpdater) cli_error(err IError) {
 		.text {
 			eprintln('v ls error: $err.msg() ($err.code())')
 			if err !is none {
-				upd.error_details(err)
+				eprintln(upd.error_details(err))
 			}
 
 			print_backtrace()
 		}
 		.json {
-			print('{"error":{"message":"$err.msg()","code":"$err.code()"}}')
+			print('{"error":{"message":${json.encode(err.msg())},"code":"$err.code()","details":${json.encode(upd.error_details(err).trim_space())}}}')
 			flush_stdout()
 		}
 		.silent {}


### PR DESCRIPTION
This PR adds helpful message when using `v ls` for the first time or when using a custom copy specified through `--path` (inspired by @Hunam6 's [comment](https://github.com/vlang/v/pull/15009#issuecomment-1181624855)):

```
v ls error: Language server is not installed nor found. (101)

- If you are using this for the first time, please run
  `v ls --install` first to download and install VLS.
- If you are using a custom version of VLS, check if
  the specified path exists and is a valid executable.
- If you have an existing installation of VLS, be sure
  to remove "vls.config.json" and "bin" located inside
  "$HOME_DIR/.vls" and re-install.

If none of the options listed have solved your issue,
please report it at https://github.com/vlang/v/issues
```