### PR TITLE
x.json2: generic-based encoder

### DIFF
--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -14,6 +14,8 @@ pub struct Encoder {
 	escape_unicode       bool = true
 }
 
+pub const default_encoder = Encoder{}
+
 // byte array versions of the most common tokens/chars
 // to avoid reallocations
 const null_in_bytes = 'null'.bytes()
@@ -37,9 +39,9 @@ const quote_bytes = [u8(`"`)]
 const escaped_chars = [(r'\b').bytes(), (r'\f').bytes(), (r'\n').bytes(),
 	(r'\r').bytes(), (r'\t').bytes()]
 
-// encode_value encodes an `Any` value to the specific writer.
-pub fn (e &Encoder) encode_value(f Any, mut wr io.Writer) ? {
-	e.encode_value_with_level(f, 1, mut wr)?
+// encode_value encodes a value to the specific writer.
+pub fn (e &Encoder) encode_value<T>(val T, mut wr io.Writer) ? {
+	e.encode_value_with_level<T>(val, 1, mut wr)?
 }
 
 fn (e &Encoder) encode_newline(level int, mut wr io.Writer) ? {
@@ -51,24 +53,24 @@ fn (e &Encoder) encode_newline(level int, mut wr io.Writer) ? {
 	}
 }
 
-fn (e &Encoder) encode_value_with_level(f Any, level int, mut wr io.Writer) ? {
-	match f {
+fn (e &Encoder) encode_any(val Any, level int, mut wr io.Writer) ? {
+	match val {
 		string {
-			e.encode_string(f, mut wr)?
+			e.encode_string(val, mut wr)?
 		}
 		bool {
-			if f == true {
+			if val == true {
 				wr.write(json2.true_in_bytes)?
 			} else {
 				wr.write(json2.false_in_bytes)?
 			}
 		}
 		int, u64, i64 {
-			wr.write(f.str().bytes())?
+			wr.write(val.str().bytes())?
 		}
 		f32, f64 {
 			$if !nofloat ? {
-				str_float := f.str().bytes()
+				str_float := val.str().bytes()
 				wr.write(str_float)?
 				if str_float[str_float.len - 1] == `.` {
 					wr.write(json2.zero_in_bytes)?
@@ -80,7 +82,7 @@ fn (e &Encoder) encode_value_with_level(f Any, level int, mut wr io.Writer) ? {
 		map[string]Any {
 			wr.write([u8(`{`)])?
 			mut i := 0
-			for k, v in f {
+			for k, v in val {
 				e.encode_newline(level, mut wr)?
 				e.encode_string(k, mut wr)?
 				wr.write(json2.colon_bytes)?
@@ -88,7 +90,7 @@ fn (e &Encoder) encode_value_with_level(f Any, level int, mut wr io.Writer) ? {
 					wr.write(json2.space_bytes)?
 				}
 				e.encode_value_with_level(v, level + 1, mut wr)?
-				if i < f.len - 1 {
+				if i < val.len - 1 {
 					wr.write(json2.comma_bytes)?
 				}
 				i++
@@ -97,16 +99,7 @@ fn (e &Encoder) encode_value_with_level(f Any, level int, mut wr io.Writer) ? {
 			wr.write([u8(`}`)])?
 		}
 		[]Any {
-			wr.write([u8(`[`)])?
-			for i, v in f {
-				e.encode_newline(level, mut wr)?
-				e.encode_value_with_level(v, level + 1, mut wr)?
-				if i < f.len - 1 {
-					wr.write(json2.comma_bytes)?
-				}
-			}
-			e.encode_newline(level - 1, mut wr)?
-			wr.write([u8(`]`)])?
+			e.encode_array(val, level, mut wr)?
 		}
 		Null {
 			wr.write(json2.null_in_bytes)?
@@ -114,9 +107,71 @@ fn (e &Encoder) encode_value_with_level(f Any, level int, mut wr io.Writer) ? {
 	}
 }
 
-// str returns the JSON string representation of the `map[string]Any` type.
-pub fn (f map[string]Any) str() string {
-	return Any(f).json_str()
+fn (e &Encoder) encode_value_with_level<T>(val T, level int, mut wr io.Writer) ? {
+	$if T is string {
+		e.encode_string(val, mut wr)?
+	} $else $if T is Any {
+		e.encode_any(val, level, mut wr)?
+	} $else $if T is map[string]Any || T is []Any {
+		// weird quirk but val is destructured immediately to Any
+		e.encode_any(val, level, mut wr)?
+	} $else $if T is Null || T is bool || T is f32 || T is f64 || T is i64 || T is int || T is u64 {
+		e.encode_any(val, level, mut wr)?
+	} $else $if T is Encodable {
+		wr.write(val.json_str().bytes())?
+	} $else $if T is $Struct {
+		e.encode_struct(val, level, mut wr)?
+	} $else $if T is $Enum {
+		e.encode_any(Any(int(val)), level, mut wr)?
+	} $else {
+		return error('cannot encode value with ${typeof(val).name} type')
+	}
+}
+
+fn (e &Encoder) encode_struct<U>(val U, level int, mut wr io.Writer) ? {
+	wr.write([u8(`{`)])?
+	mut i := 0
+	mut fields_len := 0
+
+	$for _ in U.fields {
+		fields_len++
+	}
+
+	$for field in U.fields {
+		e.encode_newline(level, mut wr)?
+		e.encode_string(field.name, mut wr)?
+		wr.write(json2.colon_bytes)?
+		if e.newline != 0 {
+			wr.write(json2.space_bytes)?
+		}
+		field_value := val.$(field.name)
+		e.encode_value_with_level(field_value, level + 1, mut wr)?
+		if i < fields_len - 1 {
+			wr.write(json2.comma_bytes)?
+		}
+		i++
+	}
+	e.encode_newline(level - 1, mut wr)?
+	wr.write([u8(`}`)])?
+}
+
+fn (e &Encoder) encode_array<U>(val U, level int, mut wr io.Writer) ? {
+	$if U is $Array {
+		wr.write([u8(`[`)])?
+		unsafe {
+			for i in 0 .. val.len {
+				e.encode_newline(level, mut wr)?
+				e.encode_value_with_level(&val[i], level + 1, mut wr)?
+				if i < val.len - 1 {
+					wr.write(json2.comma_bytes)?
+				}
+			}
+		}
+		e.encode_newline(level - 1, mut wr)?
+		wr.write([u8(`]`)])?
+	} $else {
+		return error('encoded array value is not an array')
+	}
 }
 
 // str returns the JSON string representation of the `[]Any` type.
@@ -157,7 +212,7 @@ pub fn (f Any) prettify_json_str() string {
 		newline: `\n`
 		newline_spaces_count: 4
 	}
-	enc.encode_value(f, mut sb) or { return '' }
+	enc.encode_value(f, mut sb) or {}
 	return sb.str()
 }
 

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -192,13 +192,7 @@ pub fn (f Any) str() string {
 // json_str returns the JSON string representation of the `Any` type.
 [manualfree]
 pub fn (f Any) json_str() string {
-	mut sb := strings.new_builder(4096)
-	defer {
-		unsafe { sb.free() }
-	}
-	mut enc := Encoder{}
-	enc.encode_value(f, mut sb) or { return '' }
-	return sb.str()
+	return encode(f)
 }
 
 // prettify_json_str returns the pretty-formatted JSON string representation of the `Any` type.

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -88,3 +88,34 @@ fn test_encoder_prettify() ? {
   }
 }'
 }
+
+pub struct Test {
+	val string
+}
+
+fn test_encode_struct() {
+	enc := json2.encode(Test{'hello!'})
+	assert enc == '{"val":"hello!"}'
+}
+
+pub struct Uri {
+	protocol string
+	path string
+}
+
+pub fn (u Uri) json_str() string {
+	return '"$u.protocol://$u.path"'
+}
+
+fn test_encode_encodable() {
+	assert json2.encode(Uri{'file','path/to/file'}) == '"file://path/to/file"'
+}
+
+fn test_encode_array() {
+	assert json2.encode([1,2,3]) == '[1,2,3]'
+}
+
+fn test_encode_simple() {
+	assert json2.encode('hello!') == '"hello!"'
+	assert json2.encode(1) == '1'
+}

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module json2
 
+import strings
+
 pub const (
 	null = Null{}
 )
@@ -36,8 +38,12 @@ pub fn decode<T>(src string) ?T {
 }
 
 // encode is a generic function that encodes a type into a JSON string.
-pub fn encode<T>(typ T) string {
-	return typ.to_json()
+pub fn encode<T>(val T) string {
+	mut sb := strings.new_builder(64)
+	default_encoder.encode_value(val, mut sb) or {
+		default_encoder.encode_value<Null>(null, mut sb) or {}
+	}
+	return sb.str()
 }
 
 // as_map uses `Any` as a map.

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -7,9 +7,12 @@ pub const (
 	null = Null{}
 )
 
-pub interface Serializable {
+pub interface Decodable {
 	from_json(f Any)
-	to_json() string
+}
+
+pub interface Encodable {
+	json_str() string
 }
 
 // Decodes a JSON string into an `Any` type. Returns an option.


### PR DESCRIPTION
This PR makes the existing json2 `Encoder` a generic function and should replace the CJSON-based `json.encode` function.

## What's working
- [x] Existing `Any` member types
- [x] Structs
- [x] Enums
- [x] Arrays
- [ ] Maps

## Blockers (will be posted in separate issues)
- Generic call expressions whose generic function has `T` as type parameter with no explicit type (and should infer on the argument's value) are inferred as type specified in the function signature.
  - Workaround? Create a separate function with a different type parameter other than `T` (see encoder.v#131)
- Call expressions with no explicit type and relies on generic function parameter causes one instance for e.g. `json.encode<T>` to leak on other instances on code generation (example: `json.encode<Foo>(...)` works but calling `json.encode<Bar>(...)` on another line causes cgen error because it uses the `json.encode<Foo>(...)` version)
  
![image](https://user-images.githubusercontent.com/7358345/179970278-a7aa2878-f226-41c0-92fe-4e770fb90ad7.png)

- In relation to previous bullet, adding explicit type to generic fn call results to implict function decl error
![image](https://user-images.githubusercontent.com/7358345/179970461-39c2ffa2-4c18-4811-be44-0feecb8b6151.png)
