### PR TITLE
ast: clean up struct Table

### DIFF
--- a/vlib/v/ast/type_size_test.v
+++ b/vlib/v/ast/type_size_test.v
@@ -41,21 +41,21 @@ fn test_type_size() ? {
 
 	mut t := b.table
 
-	size01, _ := t.type_size(t.type_idxs['main.T01']?)
+	size01, _ := t.type_size(t.idxs['main.T01']?)
 	assert sizeof(T01) == size01
-	size02, _ := t.type_size(t.type_idxs['main.T02']?)
+	size02, _ := t.type_size(t.idxs['main.T02']?)
 	assert sizeof(T02) == size02
-	size03, _ := t.type_size(t.type_idxs['main.T03']?)
+	size03, _ := t.type_size(t.idxs['main.T03']?)
 	assert sizeof(T03) == size03
-	size04, _ := t.type_size(t.type_idxs['main.T04']?)
+	size04, _ := t.type_size(t.idxs['main.T04']?)
 	assert sizeof(T04) == size04
-	size05, _ := t.type_size(t.type_idxs['main.T05']?)
+	size05, _ := t.type_size(t.idxs['main.T05']?)
 	assert sizeof(T05) == size05
-	size06, _ := t.type_size(t.type_idxs['main.T06']?)
+	size06, _ := t.type_size(t.idxs['main.T06']?)
 	assert sizeof(T06) == size06
-	size07, _ := t.type_size(t.type_idxs['main.T07']?)
+	size07, _ := t.type_size(t.idxs['main.T07']?)
 	assert sizeof(T07) == size07
-	size08, _ := t.type_size(t.type_idxs['main.T08']?)
+	size08, _ := t.type_size(t.idxs['main.T08']?)
 	assert sizeof(T08) == size08
 
 	println('done')

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -281,7 +281,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 					}
 					agg_name.write_string(')')
 					name := agg_name.str()
-					existing_idx := c.table.type_idxs[name]
+					existing_idx := c.table.idxs[name]
 					if existing_idx > 0 {
 						expr_type = existing_idx
 					} else {

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -24,7 +24,7 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 	info := sym.info as ast.Struct
 	mut fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, sym.name)
 	mut sub_structs := map[int]ast.SqlExpr{}
-	for f in fields.filter((c.table.type_symbols[int(it.typ)].kind == .struct_
+	for f in fields.filter((c.table.syms[int(it.typ)].kind == .struct_
 		|| (c.table.sym(it.typ).kind == .array
 		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
 		&& c.table.get_type_name(it.typ) != 'time.Time') {
@@ -137,7 +137,7 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 	info := table_sym.info as ast.Struct
 	fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, table_sym.name)
 	mut sub_structs := map[int]ast.SqlStmtLine{}
-	for f in fields.filter(((c.table.type_symbols[int(it.typ)].kind == .struct_)
+	for f in fields.filter(((c.table.syms[int(it.typ)].kind == .struct_)
 		|| (c.table.sym(it.typ).kind == .array
 		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
 		&& c.table.get_type_name(it.typ) != 'time.Time') {
@@ -192,7 +192,7 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, table_name string) []ast.StructField {
 	fields := info.fields.filter(
 		(it.typ in [ast.string_type, ast.bool_type] || int(it.typ) in ast.number_type_idxs
-		|| c.table.type_symbols[int(it.typ)].kind == .struct_
+		|| c.table.syms[int(it.typ)].kind == .struct_
 		|| (c.table.sym(it.typ).kind == .array
 		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
 		&& !it.attrs.contains('skip'))

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -77,8 +77,8 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 		}
 	}
 	// allow `none` & `error` return types for function that returns optional
-	option_type_idx := c.table.type_idxs['_option']
-	result_type_idx := c.table.type_idxs['_result']
+	option_type_idx := c.table.idxs['_option']
+	result_type_idx := c.table.idxs['_result']
 	got_types_0_idx := got_types[0].idx()
 	if (exp_is_optional
 		&& got_types_0_idx in [ast.none_type_idx, ast.error_type_idx, option_type_idx])

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -149,7 +149,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				idx := i - node.args.len
 				if m.params[i].typ.is_int() || m.params[i].typ.idx() == ast.bool_type_idx {
 					// Gets the type name and cast the string to the type with the string_<type> function
-					type_name := g.table.type_symbols[int(m.params[i].typ)].str()
+					type_name := g.table.syms[int(m.params[i].typ)].str()
 					g.write('string_${type_name}(((string*)${node.args[node.args.len - 1]}.data) [$idx])')
 				} else {
 					g.write('((string*)${node.args[node.args.len - 1]}.data) [$idx] ')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -607,7 +607,7 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 				g.unwrap_generic(node.right.typ)
 			}
 			ast.None {
-				g.table.type_idxs['None__']
+				g.table.idxs['None__']
 			}
 			else {
 				ast.Type(0)

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -161,7 +161,7 @@ $enc_fn_dec {
 fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, mut dec strings.Builder) {
 	info := sym.info as ast.SumType
 	type_var := g.new_tmp_var()
-	typ := g.table.type_idxs[sym.name]
+	typ := g.table.idxs[sym.name]
 
 	// DECODING (inline)
 	$if !json_no_inline_sumtypes ? {

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -813,7 +813,7 @@ fn (mut g Gen) get_table_name(table_expr ast.TypeNode) string {
 }
 
 fn (mut g Gen) get_struct_field(name string) ast.StructField {
-	info := g.table.sym(g.table.type_idxs[g.sql_table_name]).struct_info()
+	info := g.table.sym(g.table.idxs[g.sql_table_name]).struct_info()
 	mut f := ast.StructField{}
 	for field in info.fields {
 		if field.name == name {

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -225,7 +225,7 @@ pub fn gen(files []&ast.File, table &ast.Table, out_name string, pref &pref.Pref
 }
 
 pub fn (mut g Gen) typ(a int) &ast.TypeSymbol {
-	return g.table.type_symbols[a]
+	return g.table.syms[a]
 }
 
 pub fn (mut g Gen) generate_header() {

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -256,7 +256,7 @@ pub fn mark_used(mut table ast.Table, pref &pref.Preferences, ast_files []&ast.F
 	}
 
 	// handle interface implementation methods:
-	for isym in table.type_symbols {
+	for isym in table.syms {
 		if isym.kind != .interface_ {
 			continue
 		}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -512,7 +512,7 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 		name = p.expr_mod + '.' + name
 	} else if name in p.imported_symbols {
 		name = p.imported_symbols[name]
-	} else if !p.builtin_mod && name.len > 1 && name !in p.table.type_idxs {
+	} else if !p.builtin_mod && name.len > 1 && name !in p.table.idxs {
 		// `Foo` in module `mod` means `mod.Foo`
 		name = p.mod + '.' + name
 	}
@@ -703,7 +703,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 			return ast.new_type(gt_idx)
 		}
 		gt_idx = p.table.add_placeholder_type(bs_name, .v)
-		mut parent_idx := p.table.type_idxs[name]
+		mut parent_idx := p.table.idxs[name]
 		if parent_idx == 0 {
 			parent_idx = p.table.add_placeholder_type(name, .v)
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2368,7 +2368,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 		name_w_mod := p.prepend_mod(name)
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
-		if (!known_var && (name in p.table.type_idxs || name_w_mod in p.table.type_idxs)
+		if (!known_var && (name in p.table.idxs || name_w_mod in p.table.idxs)
 			&& name !in ['C.stat', 'C.sigaction']) || is_mod_cast || is_generic_cast
 			|| (language == .v && name.len > 0 && name[0].is_capital()) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`


### PR DESCRIPTION
This PR clean up struct Table.

To keep it simple, and to keep it consistent:
- Rename `type_symbols` to `syms`.
- Rename `type_idxs` to `idxs`.
- Modify all the related.