### PR TITLE
checker: check struct field with default expression (fix #15147)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -320,7 +320,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 	}
 	if type_sym.name.len == 1 && !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len == 0 {
 		c.error('unknown struct `$type_sym.name`', node.pos)
-		return 0
+		return ast.void_type
 	}
 	match type_sym.kind {
 		.placeholder {

--- a/vlib/v/checker/tests/struct_field_with_default_err.out
+++ b/vlib/v/checker/tests/struct_field_with_default_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/struct_field_with_default_err.vv:2:22: error: unknown struct `T`
+    1 | struct Dummy<T> {
+    2 |     arbitrary_field T = T{}
+      |                         ~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/struct_field_with_default_err.vv
+++ b/vlib/v/checker/tests/struct_field_with_default_err.vv
@@ -1,0 +1,5 @@
+struct Dummy<T> {
+	arbitrary_field T = T{}
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check struct field with default expression (fix #15147).

- Check struct field with default expression.
- Add test.

```v
struct Dummy<T> {
	arbitrary_field T = T{}
}

fn main() {}

PS D:\test\v\tt1> v run .
./tt1.v:2:22: error: unknown struct `T`
    1 | struct Dummy<T> {
    2 |     arbitrary_field T = T{}
      |                         ~~~
    3 | }
    4 |
```