### PR TITLE
cgen: fix comptime if in struct field default (fix #15058)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -274,14 +274,18 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 					g.stmts(branch.stmts[..len - 1])
 					g.write('\t$tmp_var = ')
 					g.stmt(last)
-					g.writeln(';')
+					if !g.out.last_n(2).trim_space().ends_with(';') {
+						g.writeln(';')
+					}
 					g.writeln('}')
 					g.indent--
 				} else {
 					g.indent++
 					g.write('$styp $tmp_var = ')
 					g.stmt(last)
-					g.writeln(';')
+					if !g.out.last_n(2).trim_space().ends_with(';') {
+						g.writeln(';')
+					}
 					g.indent--
 				}
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -274,7 +274,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 					g.stmts(branch.stmts[..len - 1])
 					g.write('\t$tmp_var = ')
 					g.stmt(last)
-					if !g.out.last_n(2).trim_space().ends_with(';') {
+					if !g.out.last_n(3).trim_space().ends_with(';') {
 						g.writeln(';')
 					}
 					g.writeln('}')
@@ -283,7 +283,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 					g.indent++
 					g.write('$styp $tmp_var = ')
 					g.stmt(last)
-					if !g.out.last_n(2).trim_space().ends_with(';') {
+					if !g.out.last_n(3).trim_space().ends_with(';') {
 						g.writeln(';')
 					}
 					g.indent--

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -274,18 +274,14 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 					g.stmts(branch.stmts[..len - 1])
 					g.write('\t$tmp_var = ')
 					g.stmt(last)
-					if !g.out.last_n(3).trim_space().ends_with(';') {
-						g.writeln(';')
-					}
+					g.writeln(';')
 					g.writeln('}')
 					g.indent--
 				} else {
 					g.indent++
 					g.write('$styp $tmp_var = ')
 					g.stmt(last)
-					if !g.out.last_n(3).trim_space().ends_with(';') {
-						g.writeln(';')
-					}
+					g.writeln(';')
 					g.indent--
 				}
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -234,6 +234,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 			}
 		}
 	}
+	tmp_var := g.new_tmp_var()
 	line := if node.is_expr {
 		stmt_str := g.go_before_stmt(0)
 		g.write(util.tabs(g.indent))
@@ -265,21 +266,21 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 			len := branch.stmts.len
 			if len > 0 {
 				last := branch.stmts.last() as ast.ExprStmt
+				styp := g.typ(node.typ)
 				if len > 1 {
-					tmp := g.new_tmp_var()
-					styp := g.typ(last.typ)
 					g.indent++
-					g.writeln('$styp $tmp;')
+					g.writeln('$styp $tmp_var;')
 					g.writeln('{')
 					g.stmts(branch.stmts[..len - 1])
-					g.write('\t$tmp = ')
+					g.write('\t$tmp_var = ')
 					g.stmt(last)
 					g.writeln('}')
 					g.indent--
-					g.writeln('$line $tmp;')
 				} else {
-					g.write('$line ')
+					g.indent++
+					g.write('$styp $tmp_var = ')
 					g.stmt(last)
+					g.indent--
 				}
 			}
 		} else {
@@ -298,6 +299,9 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 		g.defer_ifdef = ''
 	}
 	g.writeln('#endif')
+	if node.is_expr {
+		g.write('$line $tmp_var')
+	}
 }
 
 // returns the value of the bool comptime expression

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -274,12 +274,14 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 					g.stmts(branch.stmts[..len - 1])
 					g.write('\t$tmp_var = ')
 					g.stmt(last)
+					g.writeln(';')
 					g.writeln('}')
 					g.indent--
 				} else {
 					g.indent++
 					g.write('$styp $tmp_var = ')
 					g.stmt(last)
+					g.writeln(';')
 					g.indent--
 				}
 			}

--- a/vlib/v/tests/comptime_if_expr_in_struct_field_default_test.v
+++ b/vlib/v/tests/comptime_if_expr_in_struct_field_default_test.v
@@ -1,0 +1,12 @@
+struct Foo{
+	text string = $if linux { 'linux' } $else {
+		println('else')
+		'else'
+	}
+}
+
+fn test_comptime_if_expr_in_struct_field_default(){
+	f := Foo{}
+	println(f)
+	assert f.text.len > 0
+}

--- a/vlib/v/tests/comptime_if_expr_in_struct_field_default_test.v
+++ b/vlib/v/tests/comptime_if_expr_in_struct_field_default_test.v
@@ -1,11 +1,13 @@
-struct Foo{
-	text string = $if linux { 'linux' } $else {
+struct Foo {
+	text string = $if linux {
+		'linux'
+	} $else {
 		println('else')
 		'else'
 	}
 }
 
-fn test_comptime_if_expr_in_struct_field_default(){
+fn test_comptime_if_expr_in_struct_field_default() {
 	f := Foo{}
 	println(f)
 	assert f.text.len > 0


### PR DESCRIPTION
This PR fix comptime if in struct field default (fix #15058).

- Fix comptime if in struct field default.
- Add test.

```v
struct Foo{
	text string = $if linux { 'linux' } $else {
		println('else')
		'else'
	}
}

fn main(){
	f := Foo{}
	println(f)
	assert f.text.len > 0
}

PS D:\test\v\tt1> v run .
else
Foo{
    text: 'else'
}
```