### PR TITLE
doc: remove misleading comment about stdin()

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -133,7 +133,7 @@ pub fn create(path string) ?File {
 	}
 }
 
-// stdin - return an os.File for stdin, so that you can use .get_line on it too.
+// stdin - return an os.File for stdin
 pub fn stdin() File {
 	return File{
 		fd: 0


### PR DESCRIPTION
The comment refers to a .get_line() method, but there is no such method,
only a global function.