### PR TITLE
checker: fix comptime if in const declaration (fix #15160)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1338,6 +1338,15 @@ pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 			}
 		}
 		node.fields[i].typ = ast.mktyp(typ)
+		if mut field.expr is ast.IfExpr {
+			stmts := field.expr.branches[0].stmts
+			if stmts.len > 0 && stmts.last() is ast.ExprStmt
+				&& (stmts.last() as ast.ExprStmt).typ != ast.void_type {
+				field.expr.is_expr = true
+				field.expr.typ = (stmts.last() as ast.ExprStmt).typ
+				field.typ = field.expr.typ
+			}
+		}
 		c.const_deps = []
 		c.const_var = prev_const_var
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1339,12 +1339,20 @@ pub fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 		}
 		node.fields[i].typ = ast.mktyp(typ)
 		if mut field.expr is ast.IfExpr {
-			stmts := field.expr.branches[0].stmts
-			if stmts.len > 0 && stmts.last() is ast.ExprStmt
-				&& (stmts.last() as ast.ExprStmt).typ != ast.void_type {
-				field.expr.is_expr = true
-				field.expr.typ = (stmts.last() as ast.ExprStmt).typ
-				field.typ = field.expr.typ
+			if field.expr.branches.len == 2 {
+				first_stmts := field.expr.branches[0].stmts
+				second_stmts := field.expr.branches[1].stmts
+				if first_stmts.len > 0 && first_stmts.last() is ast.ExprStmt
+					&& (first_stmts.last() as ast.ExprStmt).typ != ast.void_type {
+					field.expr.is_expr = true
+					field.expr.typ = (first_stmts.last() as ast.ExprStmt).typ
+					field.typ = field.expr.typ
+				} else if second_stmts.len > 0 && second_stmts.last() is ast.ExprStmt
+					&& (second_stmts.last() as ast.ExprStmt).typ != ast.void_type {
+					field.expr.is_expr = true
+					field.expr.typ = (second_stmts.last() as ast.ExprStmt).typ
+					field.typ = field.expr.typ
+				}
 			}
 		}
 		c.const_deps = []

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -227,7 +227,7 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(last_expr.typ)}`',
 						node.pos)
 				}
-			} else {
+			} else if !node.is_comptime {
 				c.error('`$if_kind` expression requires an expression as the last statement of every branch',
 					branch.pos)
 			}

--- a/vlib/v/tests/comptime_if_expr_in_const_decl_test.v
+++ b/vlib/v/tests/comptime_if_expr_in_const_decl_test.v
@@ -1,0 +1,10 @@
+const msg = $if windows {
+	'windows, eh?'
+} $else {
+	'ok, then'
+}
+
+fn test_comptime_if_in_const_decl() {
+	println(msg)
+	assert msg.len > 0
+}


### PR DESCRIPTION
This PR fix comptime if in const declaration (fix #15160, fix #9886, fix #10395).

- Fix comptime if in const declaration.
- Add test.

```v
const msg = $if windows {
	'windows, eh?'
} $else {
	'ok, then'
}

fn main() {
	println(msg)
	assert msg.len > 0
}

PS D:\test\v\tt1> v run .
windows, eh?
```
```v
const(
    a = $if linux { 1 } $else { 2 }
)

fn main(){
    println(a)
}

PS D:\test\v\tt1> v run .
2
```