### PR TITLE
checker: fix fn variadic with enum value (fix #15174)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -838,7 +838,15 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				c.error('too many arguments in call to `$func.name`', node.pos)
 			}
 		}
-		c.expected_type = param.typ
+		if func.is_variadic && i >= func.params.len - 1 {
+			param_sym := c.table.sym(param.typ)
+			if param_sym.kind == .array {
+				info := param_sym.array_info()
+				c.expected_type = info.elem_type
+			}
+		} else {
+			c.expected_type = param.typ
+		}
 
 		e_sym := c.table.sym(c.expected_type)
 		if call_arg.expr is ast.MapInit && e_sym.kind == .struct_ {

--- a/vlib/v/tests/vargs_with_enum_value_test.v
+++ b/vlib/v/tests/vargs_with_enum_value_test.v
@@ -1,0 +1,19 @@
+enum Foo {
+	a
+	b
+	c
+}
+
+fn foo(n int, m ...map[Foo]int) {
+	println(m)
+	assert m.len == 2
+	assert '$m' == '[{a: 1}, {b: 2}]'
+}
+
+fn test_vargs_with_enum_value() {
+	foo(1, {
+		.a: 1,
+	}, {
+		.b: 2,
+	})
+}


### PR DESCRIPTION
This PR fix fn variadic with enum value (fix #15174).

- Fix fn variadic with enum value.
- Add test.

```v
enum Foo {
	a
	b
	c
}

fn foo(n int, m ...map[Foo]int) {
	println(m)
	assert m.len == 2
	assert '$m' == '[{a: 1}, {b: 2}]'
}

fn main() {
	foo(1, {
		.a: 1,
	}, {
		.b: 2,
	})
}

PS D:\test\v\tt1> v run .
[{a: 1}, {b: 2}]
```