### PR TITLE
cgen: fix custom str on struct with too many fields (fix #15193)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -106,7 +106,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {
 			g.write('&')
-		} else if (!str_method_expects_ptr && is_ptr && !is_shared) || is_var_mut {
+		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
 			g.write('*')
 		}
 		if expr is ast.ArrayInit {

--- a/vlib/v/tests/custom_str_on_struct_with_too_many_fields_test.v
+++ b/vlib/v/tests/custom_str_on_struct_with_too_many_fields_test.v
@@ -1,0 +1,29 @@
+struct Abc {
+	a string
+	b string
+	c string
+	d string
+	//
+	e string
+	f string
+	g string
+	h string
+	//
+	x int // number of fields must be > 8
+}
+
+fn (a Abc) str() string {
+	return 'abc'
+}
+
+fn (a Abc) some_method() string {
+	println(a)
+	return '$a'
+}
+
+fn test_custom_str_on_struct_with_too_many_fields() {
+	abc := Abc{}
+	ret := abc.some_method()
+	println(ret)
+	assert ret == 'abc'
+}


### PR DESCRIPTION
This PR fix custom str on struct with too many fields (fix #15193).

- Fix custom str on struct with too many fields.
- Add test.

```v
struct Abc {
	a string
	b string
	c string
	d string
	//
	e string
	f string
	g string
	h string
	//
	x int // number of fields must be > 8
}

fn (a Abc) str() string {
	return 'abc'
}

fn (a Abc) some_method() string {
	println(a)
	return '$a'
}

fn main() {
	abc := Abc{}
	ret := abc.some_method()
	println(ret)
	assert ret == 'abc'
}

PS D:\test\v\tt1> v run .
abc
abc
```