### PR TITLE
doc: token auth_verify example

### DIFF
--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -51,6 +51,7 @@ import crypto.hmac
 import crypto.sha256
 import encoding.base64
 import json
+import time
 
 struct JwtHeader {
 	alg string
@@ -64,32 +65,30 @@ struct JwtPayload {
 }
 
 fn main() {
-	token := make_token()
-	println(token)
+	sw := time.new_stopwatch()
+	secret := 'your-256-bit-secret'
+	token := make_token(secret)
+	ok := auth_verify(secret, token)
+	dt := sw.elapsed().microseconds()
+	println('token: $token')
+	println('auth_verify(secret, token): $ok')
+	println('Elapsed time: $dt uS')
 }
 
-fn make_token() string {
-	secret := 'your-256-bit-secret'
-
+fn make_token(secret string) string {
 	header := base64.url_encode(json.encode(JwtHeader{'HS256', 'JWT'}).bytes())
 	payload := base64.url_encode(json.encode(JwtPayload{'1234567890', 'John Doe', 1516239022}).bytes())
 	signature := base64.url_encode(hmac.new(secret.bytes(), '${header}.$payload'.bytes(),
-		sha256.sum, sha256.block_size).bytestr().bytes())
-
+		sha256.sum, sha256.block_size))
 	jwt := '${header}.${payload}.$signature'
-
 	return jwt
 }
 
-fn auth_verify(token string) bool {
-	secret := 'your-256-bit-secret'
+fn auth_verify(secret string, token string) bool {
 	token_split := token.split('.')
-
 	signature_mirror := hmac.new(secret.bytes(), '${token_split[0]}.${token_split[1]}'.bytes(),
-		sha256.sum, sha256.block_size).bytestr().bytes()
-
+		sha256.sum, sha256.block_size)
 	signature_from_token := base64.url_decode(token_split[2])
-
 	return hmac.equal(signature_from_token, signature_mirror)
 }
 ```

--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -80,4 +80,16 @@ fn make_token() string {
 
 	return jwt
 }
+
+fn auth_verify(token string) bool {
+	secret := 'your-256-bit-secret'
+	token_split := token.split('.')
+
+	signature_mirror := hmac.new(secret.bytes(), '${token_split[0]}.${token_split[1]}'.bytes(),
+		sha256.sum, sha256.block_size).bytestr().bytes()
+
+	signature_from_token := base64.url_decode(token_split[2])
+
+	return hmac.equal(signature_from_token, signature_mirror)
+}
 ```


### PR DESCRIPTION
add v example for validate token using crypto lib

```v
fn auth_verify(token string) bool {
	secret := 'your-256-bit-secret'
	token_split := token.split('.')

	signature_mirror := hmac.new(secret.bytes(), '${token_split[0]}.${token_split[1]}'.bytes(),
		sha256.sum, sha256.block_size).bytestr().bytes()

	signature_from_token := base64.url_decode(token_split[2])

	return hmac.equal(signature_from_token, signature_mirror)
}
```