### PR TITLE
os: Windows get_raw_line() should not break lines on \r (fix #5900)

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -510,7 +510,7 @@ pub fn get_raw_line() string {
 				if !res || bytes_read == 0 {
 					break
 				}
-				if *pos == `\n` || *pos == `\r` {
+				if *pos == `\n` {
 					offset++
 					break
 				}


### PR DESCRIPTION
On Windows `get_raw_line()` is breaking lines incorrectly at `\r`, which causes the behavior described in #5900. The `\r\n` line ending is interpreted incorrectly as a line ending followed by an empty line. This fixes #5900 by ignoring the `\r`.