### PR TITLE
scanner: check undefined ident in string literal (fix #15209)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -666,7 +666,8 @@ fn (mut s Scanner) text_scan() token.Token {
 			// Check if not .eof to prevent panic
 			next_char := s.look_ahead(1)
 			kind := token.scanner_matcher.find(name)
-			if kind != -1 {
+			// '$type' '$struct'... will be recognized as ident (not keyword token)
+			if kind != -1 && !(s.is_inter_start && next_char == s.quote) {
 				return s.new_token(token.Kind(kind), name, name.len)
 			}
 			// 'asdf $b' => "b" is the last name in the string, dont start parsing string

--- a/vlib/v/scanner/tests/undefined_ident_in_string_literal_err.out
+++ b/vlib/v/scanner/tests/undefined_ident_in_string_literal_err.out
@@ -1,0 +1,6 @@
+vlib/v/scanner/tests/undefined_ident_in_string_literal_err.vv:2:15: error: undefined ident: `type`
+    1 | fn abc() string {
+    2 |     return 'abc $type'
+      |                  ~~~~
+    3 | }
+    4 |

--- a/vlib/v/scanner/tests/undefined_ident_in_string_literal_err.vv
+++ b/vlib/v/scanner/tests/undefined_ident_in_string_literal_err.vv
@@ -1,0 +1,9 @@
+fn abc() string {
+	return 'abc $type'
+}
+
+fn xyz() string {
+	return '42P01'
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check undefined ident in string literal (fix #15209).

- Check undefined ident in string literal.
- Add test.

```v
fn abc() string {
	return 'abc $type'
}

fn xyz() string {
	return '42P01'
}

fn main() {}

PS D:\Test\v\tt1> v run .
./tt1.v:2:15: error: undefined ident: `type`
    1 | fn abc() string {
    2 |     return 'abc $type'
      |                  ~~~~
    3 | }
    4 |
```