### PR TITLE
orm: feat/ default attribute

### DIFF
--- a/vlib/mysql/mysql_orm_test.v
+++ b/vlib/mysql/mysql_orm_test.v
@@ -31,15 +31,14 @@ mut:
 }
 
 fn test_mysql_orm() {
-	mut mdb := mysql.Connection{
+	mut db := mysql.Connection{
 		host: 'localhost'
 		port: 3306
 		username: 'root'
 		password: ''
 		dbname: 'mysql'
 	}
-	mdb.connect() or { panic(err) }
-	db := orm.Connection(mdb)
+	db.connect() or { panic(err) }
 	db.create('Test', [
 		orm.TableField{
 			name: 'id'
@@ -89,7 +88,6 @@ fn test_mysql_orm() {
 	name := res[0][1]
 	age := res[0][2]
 
-	mdb.close()
 
 	assert id is int
 	if id is int {
@@ -105,22 +103,15 @@ fn test_mysql_orm() {
 	if age is i64 {
 		assert age == 101
 	}
-}
-
-fn test_orm() {
-	mut db := mysql.Connection{
-		host: 'localhost'
-		port: 3306
-		username: 'root'
-		password: ''
-		dbname: 'mysql'
-	}
 
 	db.connect() or {
 		println(err)
 		panic(err)
 	}
-
+	
+	/** test orm sql type
+	* - verify if all type create by attribute sql_type has created
+	*/
 	sql db {
 		create table TestCustomSqlType
 	}
@@ -169,26 +160,18 @@ fn test_orm() {
 	sql db {
 		drop table TestCustomSqlType
 	}
-	db.close()
 
 	assert result_custom_sql.maps() == information_schema_custom_sql
-}
 
-fn test_orm_time_type() ? {
-	mut db := mysql.Connection{
-		host: 'localhost'
-		port: 3306
-		username: 'root'
-		password: ''
-		dbname: 'mysql'
-	}
-
-	db.connect() or {
+	/** test_orm_time_type
+	* - test time.Time v type with sql_type: 'TIMESTAMP'
+	* - test string v type with sql_type: 'TIMESTAMP'
+	* - test time.Time v type without
+	*/
+	today := time.parse('2022-07-16 15:13:27') or {
 		println(err)
 		panic(err)
 	}
-
-	today := time.parse('2022-07-16 15:13:27')?
 
 	model := TestTimeType{
 		username: 'hitalo'

--- a/vlib/mysql/mysql_orm_test.v
+++ b/vlib/mysql/mysql_orm_test.v
@@ -1,6 +1,7 @@
 import orm
 import mysql
 import time
+import v.ast
 
 struct TestCustomSqlType {
 	id      int    [primary; sql: serial]
@@ -42,7 +43,7 @@ fn test_mysql_orm() {
 	db.create('Test', [
 		orm.TableField{
 			name: 'id'
-			typ: 7
+			typ: ast.int_type_idx
 			attrs: [
 				StructAttribute{
 					name: 'primary'
@@ -57,12 +58,12 @@ fn test_mysql_orm() {
 		},
 		orm.TableField{
 			name: 'name'
-			typ: 20
+			typ: ast.string_type_idx
 			attrs: []
 		},
 		orm.TableField{
 			name: 'age'
-			typ: 7
+			typ: ast.int_type_idx
 		},
 	]) or { panic(err) }
 
@@ -75,11 +76,11 @@ fn test_mysql_orm() {
 		table: 'Test'
 		has_where: true
 		fields: ['id', 'name', 'age']
-		types: [7, 20, 8]
+		types: [ast.int_type_idx, ast.string_type_idx, ast.i64_type_idx]
 	}, orm.QueryData{}, orm.QueryData{
 		fields: ['name', 'age']
 		data: [orm.Primitive('Louis'), i64(101)]
-		types: [20, 8]
+		types: [ast.string_type_idx, ast.i64_type_idx]
 		is_and: [true, true]
 		kinds: [.eq, .eq]
 	}) or { panic(err) }

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -124,7 +124,7 @@ pub fn (db Connection) insert(table string, data orm.QueryData) ? {
 	mut converted_primitive_array := db.factory_orm_primitive_converted_from_sql(table,
 		data)?
 
-	converted_data := orm.QueryData{
+	converted_primitive_data := orm.QueryData{
 		fields: data.fields
 		data: converted_primitive_array
 		types: []
@@ -132,17 +132,17 @@ pub fn (db Connection) insert(table string, data orm.QueryData) ? {
 		is_and: []
 	}
 
-	query := orm.orm_stmt_gen(table, '`', .insert, false, '?', 1, converted_data, orm.QueryData{})
+	query, converted_data := orm.orm_stmt_gen(table, '`', .insert, false, '?', 1, converted_primitive_data, orm.QueryData{})
 	mysql_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 
 pub fn (db Connection) update(table string, data orm.QueryData, where orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '`', .update, false, '?', 1, data, where)
+	query, _ := orm.orm_stmt_gen(table, '`', .update, false, '?', 1, data, where)
 	mysql_stmt_worker(db, query, data, where)?
 }
 
 pub fn (db Connection) delete(table string, where orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '`', .delete, false, '?', 1, orm.QueryData{}, where)
+	query, _ := orm.orm_stmt_gen(table, '`', .delete, false, '?', 1, orm.QueryData{}, where)
 	mysql_stmt_worker(db, query, orm.QueryData{}, where)?
 }
 

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -132,7 +132,8 @@ pub fn (db Connection) insert(table string, data orm.QueryData) ? {
 		is_and: []
 	}
 
-	query, converted_data := orm.orm_stmt_gen(table, '`', .insert, false, '?', 1, converted_primitive_data, orm.QueryData{})
+	query, converted_data := orm.orm_stmt_gen(table, '`', .insert, false, '?', 1, converted_primitive_data,
+		orm.QueryData{})
 	mysql_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 
@@ -142,7 +143,8 @@ pub fn (db Connection) update(table string, data orm.QueryData, where orm.QueryD
 }
 
 pub fn (db Connection) delete(table string, where orm.QueryData) ? {
-	query, _ := orm.orm_stmt_gen(table, '`', .delete, false, '?', 1, orm.QueryData{}, where)
+	query, _ := orm.orm_stmt_gen(table, '`', .delete, false, '?', 1, orm.QueryData{},
+		where)
 	mysql_stmt_worker(db, query, orm.QueryData{}, where)?
 }
 

--- a/vlib/mysql/orm.v
+++ b/vlib/mysql/orm.v
@@ -160,7 +160,7 @@ pub fn (db Connection) last_id() orm.Primitive {
 
 // table
 pub fn (db Connection) create(table string, fields []orm.TableField) ? {
-	query := orm.orm_table_gen(table, '`', false, 0, fields, mysql_type_from_v, false) or {
+	query := orm.orm_table_gen(table, '`', true, 0, fields, mysql_type_from_v, false) or {
 		return err
 	}
 	mysql_stmt_worker(db, query, orm.QueryData{}, orm.QueryData{})?

--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -15,6 +15,7 @@
 - `[sql: type]` where `type` is a V type such as `int` or `f64`, or special type `serial`
 - `[sql: 'name']` sets a custom column name for the field
 - `[sql_type: 'SQL TYPE']` sets the sql type which is used in sql
+- `[default: 'sql defaults']` sets the default value or function when create a new table
 
 ## Usage
 
@@ -89,4 +90,54 @@ result := sql db {
 result := sql db {
     select from Foo where id > 1 order by id
 }
+```
+
+### Example
+```v ignore
+import pg
+
+struct Member {
+	id         string [default: 'gen_random_uuid()'; primary; sql_type: 'uuid']
+	name       string
+	created_at string [default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
+}
+
+fn main() {
+	db := pg.connect(pg.Config{
+		host: 'localhost'
+		port: 5432
+		user: 'user'
+		password: 'password'
+		dbname: 'dbname'
+	}) or {
+		println(err)
+		return
+	}
+
+	defer {
+		db.close()
+	}
+
+	sql db {
+		create table Member
+	}
+
+	new_member := Member{
+		name: 'John Doe'
+	}
+
+	sql db {
+		insert new_member into Member
+	}
+
+	selected_member := sql db {
+		select from Member where name == 'John Doe' limit 1
+	}
+
+	sql db {
+		update Member set name = 'Hitalo' where id == selected_member.id
+	}
+}
+
+
 ```

--- a/vlib/orm/orm_fn_test.v
+++ b/vlib/orm/orm_fn_test.v
@@ -2,7 +2,7 @@ import orm
 import v.ast
 
 fn test_orm_stmt_gen_update() {
-	query := orm.orm_stmt_gen('Test', "'", .update, true, '?', 0, orm.QueryData{
+	query, _ := orm.orm_stmt_gen('Test', "'", .update, true, '?', 0, orm.QueryData{
 		fields: ['test', 'a']
 		data: []
 		types: []
@@ -17,7 +17,7 @@ fn test_orm_stmt_gen_update() {
 }
 
 fn test_orm_stmt_gen_insert() {
-	query := orm.orm_stmt_gen('Test', "'", .insert, true, '?', 0, orm.QueryData{
+	query, _ := orm.orm_stmt_gen('Test', "'", .insert, true, '?', 0, orm.QueryData{
 		fields: ['test', 'a']
 		data: []
 		types: []
@@ -27,7 +27,7 @@ fn test_orm_stmt_gen_insert() {
 }
 
 fn test_orm_stmt_gen_delete() {
-	query := orm.orm_stmt_gen('Test', "'", .delete, true, '?', 0, orm.QueryData{
+	query, _ := orm.orm_stmt_gen('Test', "'", .delete, true, '?', 0, orm.QueryData{
 		fields: ['test', 'a']
 		data: []
 		types: []

--- a/vlib/pg/orm.v
+++ b/vlib/pg/orm.v
@@ -167,18 +167,17 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 			// If paramTypes is NULL, or any particular element in the array is zero,
 			// the server infers a data type for the parameter symbol in the same way
 			// it would do for an untyped literal string.
+			types << &u8(0)
 			vals << data.str
 			lens << data.len
-			types << &u8(0)
 			formats << 0
 		}
 		time.Time {
-			types << u32(Oid.t_int4)
-			unix := int(data.unix)
-			num := conv.htn32(unsafe { &u32(&unix) })
-			vals << &char(&num)
-			lens << int(sizeof(u32))
-			formats << 1
+			datetime := ((d as time.Time).format_ss() as string)
+			types << &u8(0)
+			vals << datetime.str
+			lens << datetime.len
+			formats << 0
 		}
 		orm.InfixType {
 			pg_stmt_match(mut types, mut vals, mut lens, mut formats, data.right)
@@ -194,8 +193,11 @@ fn pg_type_from_v(typ int) ?string {
 		orm.type_idx['bool'] {
 			'BOOLEAN'
 		}
-		orm.type_idx['int'], orm.type_idx['u32'], orm.time {
+		orm.type_idx['int'], orm.type_idx['u32'] {
 			'INT'
+		}
+		orm.time {
+			'TIMESTAMP'
 		}
 		orm.type_idx['i64'], orm.type_idx['u64'] {
 			'BIGINT'

--- a/vlib/pg/orm.v
+++ b/vlib/pg/orm.v
@@ -31,17 +31,17 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 // sql stmt
 
 pub fn (db DB) insert(table string, data orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '"', .insert, true, '$', 1, data, orm.QueryData{})
-	pg_stmt_worker(db, query, data, orm.QueryData{})?
+	query, converted_data := orm.orm_stmt_gen(table, '"', .insert, true, '$', 1, data, orm.QueryData{})
+	pg_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 
 pub fn (db DB) update(table string, data orm.QueryData, where orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '"', .update, true, '$', 1, data, where)
+	query, _ := orm.orm_stmt_gen(table, '"', .update, true, '$', 1, data, where)
 	pg_stmt_worker(db, query, data, where)?
 }
 
 pub fn (db DB) delete(table string, where orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '"', .delete, true, '$', 1, orm.QueryData{}, where)
+	query, _ := orm.orm_stmt_gen(table, '"', .delete, true, '$', 1, orm.QueryData{}, where)
 	pg_stmt_worker(db, query, orm.QueryData{}, where)?
 }
 
@@ -163,10 +163,13 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 			formats << 1
 		}
 		string {
-			types << u32(Oid.t_text)
-			vals << data.str
-			lens << data.len
-			formats << 0
+			// If paramTypes is NULL, or any particular element in the array is zero, 
+			// the server infers a data type for the parameter symbol in the same way 
+			// it would do for an untyped literal string.
+				vals << data.str
+				lens << data.len
+				types << &u8(0)
+				formats << 0
 		}
 		time.Time {
 			types << u32(Oid.t_int4)

--- a/vlib/pg/orm.v
+++ b/vlib/pg/orm.v
@@ -31,7 +31,8 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 // sql stmt
 
 pub fn (db DB) insert(table string, data orm.QueryData) ? {
-	query, converted_data := orm.orm_stmt_gen(table, '"', .insert, true, '$', 1, data, orm.QueryData{})
+	query, converted_data := orm.orm_stmt_gen(table, '"', .insert, true, '$', 1, data,
+		orm.QueryData{})
 	pg_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 
@@ -163,13 +164,13 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 			formats << 1
 		}
 		string {
-			// If paramTypes is NULL, or any particular element in the array is zero, 
-			// the server infers a data type for the parameter symbol in the same way 
+			// If paramTypes is NULL, or any particular element in the array is zero,
+			// the server infers a data type for the parameter symbol in the same way
 			// it would do for an untyped literal string.
-				vals << data.str
-				lens << data.len
-				types << &u8(0)
-				formats << 0
+			vals << data.str
+			lens << data.len
+			types << &u8(0)
+			formats << 0
 		}
 		time.Time {
 			types << u32(Oid.t_int4)

--- a/vlib/pg/pg_orm_test.v
+++ b/vlib/pg/pg_orm_test.v
@@ -31,9 +31,9 @@ mut:
 }
 
 struct TestDefaultAtribute {
-	id         string    [default: 'gen_random_uuid()'; primary; sql_type: 'uuid']
+	id         string [default: 'gen_random_uuid()'; primary; sql_type: 'uuid']
 	name       string
-	created_at string    [default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
+	created_at string [default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
 }
 
 fn test_pg_orm() {
@@ -44,7 +44,7 @@ fn test_pg_orm() {
 		dbname: 'postgres'
 	) or { panic(err) }
 
-	defer{
+	defer {
 		db.close()
 	}
 

--- a/vlib/pg/pg_orm_test.v
+++ b/vlib/pg/pg_orm_test.v
@@ -102,7 +102,6 @@ fn test_pg_orm() {
 		kinds: [.eq, .eq]
 		is_and: [true]
 	}) or { panic(err) }
-	println('res $res')
 
 	id := res[0][0]
 	name := res[0][1]
@@ -122,16 +121,10 @@ fn test_pg_orm() {
 	if age is i64 {
 		assert age == 101
 	}
-}
 
-fn test_orm() {
-	println('text-------------------')
-	mut db := pg.connect(
-		host: 'localhost'
-		user: 'postgres'
-		password: ''
-		dbname: 'postgres'
-	) or { panic(err) }
+	/** test orm sql type
+	* - verify if all type create by attribute sql_type has created
+	*/
 
 	sql db {
 		create table TestCustomSqlType
@@ -146,8 +139,6 @@ fn test_orm() {
 		println(err)
 		panic(err)
 	}
-	println('result_custom_sql: $result_custom_sql')
-	println('result_custom_sql')
 	mut information_schema_data_types_results := []string{}
 	information_schema_custom_sql := ['integer', 'text', 'character varying',
 		'timestamp without time zone', 'uuid']
@@ -158,20 +149,18 @@ fn test_orm() {
 	sql db {
 		drop table TestCustomSqlType
 	}
-	db.close()
 
 	assert information_schema_data_types_results == information_schema_custom_sql
-}
 
-fn test_orm_time_type() ? {
-	mut db := pg.connect(
-		host: 'localhost'
-		user: 'postgres'
-		password: ''
-		dbname: 'postgres'
-	) or { panic(err) }
-
-	today := time.parse('2022-07-16 15:13:27')?
+	/** test_orm_time_type
+	* - test time.Time v type with sql_type: 'TIMESTAMP'
+	* - test string v type with sql_type: 'TIMESTAMP'
+	* - test time.Time v type without
+	*/
+	today := time.parse('2022-07-16 15:13:27') or {
+		println(err)
+		panic(err)
+	}
 
 	model := TestTimeType{
 		username: 'hitalo'

--- a/vlib/sqlite/orm.v
+++ b/vlib/sqlite/orm.v
@@ -51,17 +51,17 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 // sql stmt
 
 pub fn (db DB) insert(table string, data orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '`', .insert, true, '?', 1, data, orm.QueryData{})
-	sqlite_stmt_worker(db, query, data, orm.QueryData{})?
+	query, converted_data := orm.orm_stmt_gen(table, '`', .insert, true, '?', 1, data, orm.QueryData{})
+	sqlite_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 
 pub fn (db DB) update(table string, data orm.QueryData, where orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '`', .update, true, '?', 1, data, where)
+	query, _ := orm.orm_stmt_gen(table, '`', .update, true, '?', 1, data, where)
 	sqlite_stmt_worker(db, query, data, where)?
 }
 
 pub fn (db DB) delete(table string, where orm.QueryData) ? {
-	query := orm.orm_stmt_gen(table, '`', .delete, true, '?', 1, orm.QueryData{}, where)
+	query, _ := orm.orm_stmt_gen(table, '`', .delete, true, '?', 1, orm.QueryData{}, where)
 	sqlite_stmt_worker(db, query, orm.QueryData{}, where)?
 }
 

--- a/vlib/sqlite/orm.v
+++ b/vlib/sqlite/orm.v
@@ -51,7 +51,8 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 // sql stmt
 
 pub fn (db DB) insert(table string, data orm.QueryData) ? {
-	query, converted_data := orm.orm_stmt_gen(table, '`', .insert, true, '?', 1, data, orm.QueryData{})
+	query, converted_data := orm.orm_stmt_gen(table, '`', .insert, true, '?', 1, data,
+		orm.QueryData{})
 	sqlite_stmt_worker(db, query, converted_data, orm.QueryData{})?
 }
 

--- a/vlib/sqlite/sqlite_orm_test.v
+++ b/vlib/sqlite/sqlite_orm_test.v
@@ -1,10 +1,32 @@
 import orm
 import sqlite
 import v.ast
+import time
+
+struct TestCustomSqlType {
+	id      int       [primary; sql: serial]
+	custom  string    [sql_type: 'INTEGER']
+	custom1 string    [sql_type: 'TEXT']
+	custom2 string    [sql_type: 'REAL']
+	custom3 string    [sql_type: 'NUMERIC']
+	custom4 string
+	custom5 int
+	custom6 time.Time
+}
+
+struct TestDefaultAtribute {
+	id          string [primary; sql: serial]
+	name        string
+	created_at  string [default: 'CURRENT_TIME']
+	created_at1 string [default: 'CURRENT_DATE']
+	created_at2 string [default: 'CURRENT_TIMESTAMP']
+}
 
 fn test_sqlite_orm() {
-	sdb := sqlite.connect(':memory:') or { panic(err) }
-	db := orm.Connection(sdb)
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	defer {
+		db.close() or { panic(err) }
+	}
 	db.create('Test', [
 		orm.TableField{
 			name: 'id'
@@ -67,5 +89,75 @@ fn test_sqlite_orm() {
 	assert age is i64
 	if age is i64 {
 		assert age == 100
+	}
+
+	/** test orm sql type
+	* - verify if all type create by attribute sql_type has created
+	*/
+
+	sql db {
+		create table TestCustomSqlType
+	}
+
+	mut result_custom_sql, mut exec_custom_code := db.exec('
+		pragma table_info(TestCustomSqlType);
+	')
+
+	assert exec_custom_code == 101
+	mut table_info_types_results := []string{}
+	information_schema_custom_sql := ['INTEGER', 'INTEGER', 'TEXT', 'REAL', 'NUMERIC', 'TEXT',
+		'INTEGER', 'INTEGER']
+
+	for data_type in result_custom_sql {
+		table_info_types_results << data_type.vals[2]
+	}
+	assert table_info_types_results == information_schema_custom_sql
+
+	sql db {
+		drop table TestCustomSqlType
+	}
+
+	/** test default attribute
+	*/
+
+	sql db {
+		create table TestDefaultAtribute
+	}
+
+	mut result_default_sql, mut code := db.exec('
+			pragma table_info(TestDefaultAtribute);
+		')
+
+	assert code == 101
+	mut information_schema_data_types_results := []string{}
+	information_schema_default_sql := ['', '', 'CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
+
+	for data_type in result_default_sql {
+		information_schema_data_types_results << data_type.vals[4]
+	}
+	assert information_schema_data_types_results == information_schema_default_sql
+
+	test_default_atribute := TestDefaultAtribute{
+		name: 'Hitalo'
+	}
+
+	sql db {
+		insert test_default_atribute into TestDefaultAtribute
+	}
+
+	result_test_default_atribute := sql db {
+		select from TestDefaultAtribute limit 1
+	}
+
+	assert result_test_default_atribute.name == 'Hitalo'
+	assert test_default_atribute.created_at.len == 0
+	assert test_default_atribute.created_at1.len == 0
+	assert test_default_atribute.created_at2.len == 0
+	assert result_test_default_atribute.created_at.len == 8 // HH:MM:SS
+	assert result_test_default_atribute.created_at1.len == 10 // YYYY-MM-DD
+	assert result_test_default_atribute.created_at2.len == 19 // YYYY-MM-DD HH:MM:SS
+
+	sql db {
+		drop table TestDefaultAtribute
 	}
 }

--- a/vlib/sqlite/sqlite_test.v
+++ b/vlib/sqlite/sqlite_test.v
@@ -33,6 +33,7 @@ fn test_sqlite() {
 fn test_can_access_sqlite_result_consts() {
 	assert sqlite.sqlite_ok == 0
 	assert sqlite.sqlite_error == 1
+	// assert sqlite.misuse == 21
 	assert sqlite.sqlite_row == 100
 	assert sqlite.sqlite_done == 101
 }

--- a/vlib/sqlite/stmt.v
+++ b/vlib/sqlite/stmt.v
@@ -51,6 +51,10 @@ fn (stmt Stmt) get_f64(idx int) f64 {
 
 fn (stmt Stmt) get_text(idx int) string {
 	b := &char(C.sqlite3_column_text(stmt.stmt, idx))
+
+	if b == &char(0) {
+		return ''
+	}
 	return unsafe { b.vstring() }
 }
 


### PR DESCRIPTION
## default attribute

- [x] orm
- [x] pg
- [x] mysql
- [x] sqlite

### Example
```v
import pg

struct Member {
	id         string [default: 'gen_random_uuid()'; primary; sql_type: 'uuid']
	name       string
	created_at string [default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
}

fn main() {
	db := pg.connect(pg.Config{
		host: 'localhost'
		port: 5432
		user: 'user'
		password: 'password'
		dbname: 'dbname'
	}) or {
		println(err)
		return
	}

	defer {
		db.close()
	}

	sql db {
		create table Member
	}

	new_member := Member{
		name: 'John Doe'
	}

	sql db {
		insert new_member into Member
	}

	selected_member := sql db {
		select from Member where name == 'John Doe' limit 1
	}

	sql db {
		update Member set name = 'Hitalo' where id == selected_member.id
	}
}

```