### PR TITLE
cgen: fix printing struct with skip fields

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -843,14 +843,21 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		fn_builder.writeln('\treturn res;')
 		fn_builder.writeln('}')
 	}
-	fn_body.writeln('\tstring res = str_intp( ${info.fields.len * 4 + 3}, _MOV((StrIntpData[]){')
+	// find skip fields
+	mut skip_field_count := 0
+	for field in info.fields {
+		if attr := field.attrs.find_first('str') {
+			if attr.arg == 'skip' {
+				skip_field_count++
+			}
+		}
+	}
+	fn_body.writeln('\tstring res = str_intp( ${(info.fields.len - skip_field_count) * 4 + 3}, _MOV((StrIntpData[]){')
 	fn_body.writeln('\t\t{_SLIT("$clean_struct_v_type_name{\\n"), 0, {.d_c=0}},')
 	for i, field in info.fields {
 		// Skip `str:skip` fields
 		if attr := field.attrs.find_first('str') {
 			if attr.arg == 'skip' {
-				fn_body.writeln('{_SLIT(""), 0, {.d_c=0}},')
-				fn_body.writeln('{_SLIT(""), 0, {.d_c=0}},')
 				continue
 			}
 		}

--- a/vlib/v/tests/inout/printing_struct_with_skip_fields.out
+++ b/vlib/v/tests/inout/printing_struct_with_skip_fields.out
@@ -1,0 +1,3 @@
+Foo{
+    name: 'Peter'
+}

--- a/vlib/v/tests/inout/printing_struct_with_skip_fields.vv
+++ b/vlib/v/tests/inout/printing_struct_with_skip_fields.vv
@@ -1,0 +1,9 @@
+struct Foo {
+	name string
+	age  int    [str: skip]
+}
+
+fn main() {
+	x := Foo{'Peter', 25}
+	println(x)
+}


### PR DESCRIPTION
This PR fix printing struct with skip fields.

- Fix printing struct with skip fields.
- Add test.

```v
struct Foo {
	name string
	age  int    [str: skip]
}

fn main() {
	x := Foo{'Peter', 25}
	println(x)
}

PS D:\Test\v\tt1> v run .
Foo{
    name: 'Peter'
}
```