### PR TITLE
scanner: correct error message of empty character literal (fix #15226)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1415,7 +1415,7 @@ fn (mut s Scanner) ident_char() string {
 			} else if u.len == 0 {
 				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
 					lspos)
-				s.error('invalid character literal `$orig` => `$c` ($u) (empty literal)')
+				s.error('invalid empty character literal `$orig`')
 			} else {
 				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
 					lspos)

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1412,6 +1412,10 @@ fn (mut s Scanner) ident_char() string {
 		if u.len != 1 {
 			if escaped_hex || escaped_unicode {
 				s.error('invalid character literal `$orig` => `$c` ($u) (escape sequence did not refer to a singular rune)')
+			} else if u.len == 0 {
+				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
+					lspos)
+				s.error('invalid character literal `$orig` => `$c` ($u) (empty literal)')
 			} else {
 				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
 					lspos)

--- a/vlib/v/scanner/tests/empty_character_literal_err.out
+++ b/vlib/v/scanner/tests/empty_character_literal_err.out
@@ -1,0 +1,12 @@
+vlib/v/scanner/tests/empty_character_literal_err.vv:2:8: error: invalid character literal `` => `` ([]) (empty literal)
+    1 | fn main() {
+    2 |     a := ``
+      |           ^
+    3 |     println(a)
+    4 | }
+vlib/v/scanner/tests/empty_character_literal_err.vv:2:7: details: use quotes for strings, backticks for characters
+    1 | fn main() {
+    2 |     a := ``
+      |          ^
+    3 |     println(a)
+    4 | }

--- a/vlib/v/scanner/tests/empty_character_literal_err.out
+++ b/vlib/v/scanner/tests/empty_character_literal_err.out
@@ -1,4 +1,4 @@
-vlib/v/scanner/tests/empty_character_literal_err.vv:2:8: error: invalid character literal `` => `` ([]) (empty literal)
+vlib/v/scanner/tests/empty_character_literal_err.vv:2:8: error: invalid empty character literal ``
     1 | fn main() {
     2 |     a := ``
       |           ^

--- a/vlib/v/scanner/tests/empty_character_literal_err.vv
+++ b/vlib/v/scanner/tests/empty_character_literal_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := ``
+	println(a)
+}


### PR DESCRIPTION
This PR correct error message of empty character literal (fix #15226).

- Correct error message of empty character literal.
- Add test.

```v
fn main() {
	a := ``
	println(a)
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:8: error: invalid character literal `` => `` ([]) (empty literal)
    1 | fn main() {
    2 |     a := ``
      |           ^
    3 |     println(a)
    4 | }
./tt1.v:2:7: details: use quotes for strings, backticks for characters
    1 | fn main() {
    2 |     a := ``
      |          ^
    3 |     println(a)
    4 | }
```