### PR TITLE
api: migrate the `io.Reader.read` API return `Result` instead of `Option` type

### DIFF
--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -38,18 +38,21 @@ pub fn new_buffered_reader(o BufferedReaderConfig) &BufferedReader {
 // read fufills the Reader interface
 pub fn (mut r BufferedReader) read(mut buf []u8) !int {
 	if r.end_of_stream {
-		return error('unexpected end of the stream')
+		return IError(Eof{})
 	}
 	// read data out of the buffer if we dont have any
 	if r.needs_fill() {
 		if !r.fill_buffer() {
 			// end of stream
-			return error('unexpected end of the stream')
+			return IError(Eof{})
 		}
 	}
 	read := copy(mut buf, r.buf[r.offset..r.len])
 	if read == 0 {
-		return error('invalid copy of buffer')
+		return IError(NotExpected{
+			cause: 'invalid copy of buffer'
+			code: -1
+		})
 	}
 	r.offset += read
 	return read

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -36,20 +36,20 @@ pub fn new_buffered_reader(o BufferedReaderConfig) &BufferedReader {
 }
 
 // read fufills the Reader interface
-pub fn (mut r BufferedReader) read(mut buf []u8) ?int {
+pub fn (mut r BufferedReader) read(mut buf []u8) !int {
 	if r.end_of_stream {
-		return none
+		return error('unexpected end of the stream')
 	}
 	// read data out of the buffer if we dont have any
 	if r.needs_fill() {
 		if !r.fill_buffer() {
 			// end of stream
-			return none
+			return error('unexpected end of the stream')
 		}
 	}
 	read := copy(mut buf, r.buf[r.offset..r.len])
 	if read == 0 {
-		return none
+		return error('invalid copy of buffer')
 	}
 	r.offset += read
 	return read

--- a/vlib/io/custom_string_reading_test.v
+++ b/vlib/io/custom_string_reading_test.v
@@ -15,7 +15,7 @@ fn (mut s StringReader) read(mut buf []u8) !int {
 		eprintln('>>>> StringReader.read output buf.len: $buf.len')
 	}
 	if s.place > s.text.len + 1 {
-		return error('string index out of range')
+		return IError(io.Eof{})
 	}
 	mut howmany := imin(buf.len, s.text.len - s.place)
 	xxx := s.text[s.place..s.place + howmany].bytes()

--- a/vlib/io/custom_string_reading_test.v
+++ b/vlib/io/custom_string_reading_test.v
@@ -10,12 +10,12 @@ fn imin(a int, b int) int {
 	return if a < b { a } else { b }
 }
 
-fn (mut s StringReader) read(mut buf []u8) ?int {
+fn (mut s StringReader) read(mut buf []u8) !int {
 	$if debug {
 		eprintln('>>>> StringReader.read output buf.len: $buf.len')
 	}
 	if s.place > s.text.len + 1 {
-		return none
+		return error('string index out of range')
 	}
 	mut howmany := imin(buf.len, s.text.len - s.place)
 	xxx := s.text[s.place..s.place + howmany].bytes()

--- a/vlib/io/io_test.v
+++ b/vlib/io/io_test.v
@@ -14,7 +14,7 @@ pub mut:
 
 fn (mut b Buf) read(mut buf []u8) !int {
 	if !(b.i < b.bytes.len) {
-		return error('access out of index')
+		return IError(io.Eof{})
 	}
 	n := copy(mut buf, b.bytes[b.i..])
 	b.i += n

--- a/vlib/io/io_test.v
+++ b/vlib/io/io_test.v
@@ -12,9 +12,9 @@ pub mut:
 	bytes []u8
 }
 
-fn (mut b Buf) read(mut buf []u8) ?int {
+fn (mut b Buf) read(mut buf []u8) !int {
 	if !(b.i < b.bytes.len) {
-		return none
+		return error('access out of index')
 	}
 	n := copy(mut buf, b.bytes[b.i..])
 	b.i += n

--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -7,7 +7,7 @@ pub interface Reader {
 	// A type that implements this should return
 	// `none` on end of stream (EOF) instead of just returning 0
 mut:
-	read(mut buf []u8) ?int
+	read(mut buf []u8) !int
 }
 
 const (
@@ -50,7 +50,7 @@ pub fn read_any(mut r Reader) ?[]u8 {
 	mut b := []u8{len: io.read_all_len}
 	mut read := 0
 	for {
-		new_read := r.read(mut b[read..]) or { break }
+		new_read := r.read(mut b[read..]) or { return none }
 		read += new_read
 		if new_read == 0 {
 			break

--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -24,7 +24,7 @@ pub interface Reader {
 	// read reads up to buf.len bytes and places
 	// them into buf.
 	// A type that implements this should return
-	// `none` on end of stream (EOF) instead of just returning 0
+	// `io.Eof` on end of stream (EOF) instead of just returning 0
 mut:
 	read(mut buf []u8) !int
 }

--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -1,5 +1,24 @@
 module io
 
+/// Eof error means that we reach the end of the stream.
+pub struct Eof {
+	Error
+}
+
+// NotExpected is a generic error that means that we receave a not expecte error.
+pub struct NotExpected {
+	cause string
+	code  int
+}
+
+fn (err NotExpected) msg() string {
+	return err.cause
+}
+
+fn (err NotExpected) code() int {
+	return err.code
+}
+
 // Reader represents a stream of data that can be read
 pub interface Reader {
 	// read reads up to buf.len bytes and places

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -9,7 +9,7 @@ mut:
 
 fn (mut b Buf) read(mut buf []u8) !int {
 	if !(b.i < b.bytes.len) {
-		return error('index out of range')
+		return IError(Eof{})
 	}
 	n := copy(mut buf, b.bytes[b.i..])
 	b.i += n
@@ -46,7 +46,7 @@ mut:
 
 fn (mut s StringReader) read(mut buf []u8) !int {
 	if s.place >= s.text.len {
-		return error('index out of range')
+		return IError(Eof{})
 	}
 	read := copy(mut buf, s.text[s.place..].bytes())
 	s.place += read

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -7,9 +7,9 @@ mut:
 	i int
 }
 
-fn (mut b Buf) read(mut buf []u8) ?int {
+fn (mut b Buf) read(mut buf []u8) !int {
 	if !(b.i < b.bytes.len) {
-		return none
+		return error('index out of range')
 	}
 	n := copy(mut buf, b.bytes[b.i..])
 	b.i += n
@@ -44,9 +44,9 @@ mut:
 	place int
 }
 
-fn (mut s StringReader) read(mut buf []u8) ?int {
+fn (mut s StringReader) read(mut buf []u8) !int {
 	if s.place >= s.text.len {
-		return none
+		return error('index out of range')
 	}
 	read := copy(mut buf, s.text[s.place..].bytes())
 	s.place += read

--- a/vlib/io/readerwriter.v
+++ b/vlib/io/readerwriter.v
@@ -14,7 +14,7 @@ mut:
 	w Writer
 }
 
-pub fn (mut r ReaderWriterImpl) read(mut buf []u8) ?int {
+pub fn (mut r ReaderWriterImpl) read(mut buf []u8) !int {
 	return r.r.read(mut buf)
 }
 

--- a/vlib/net/http/request_test.v
+++ b/vlib/net/http/request_test.v
@@ -10,7 +10,7 @@ mut:
 
 fn (mut s StringReader) read(mut buf []u8) !int {
 	if s.place >= s.text.len {
-		return error('out of index')
+		return IError(io.Eof{})
 	}
 	max_bytes := 100
 	end := if s.place + max_bytes >= s.text.len { s.text.len } else { s.place + max_bytes }

--- a/vlib/net/http/request_test.v
+++ b/vlib/net/http/request_test.v
@@ -8,9 +8,9 @@ mut:
 	place int
 }
 
-fn (mut s StringReader) read(mut buf []u8) ?int {
+fn (mut s StringReader) read(mut buf []u8) !int {
 	if s.place >= s.text.len {
-		return none
+		return error('out of index')
 	}
 	max_bytes := 100
 	end := if s.place + max_bytes >= s.text.len { s.text.len } else { s.place + max_bytes }

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -180,8 +180,10 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) ?int {
 	return res
 }
 
-pub fn (mut s SSLConn) read(mut buffer []u8) ?int {
-	res := s.socket_read_into_ptr(&u8(buffer.data), buffer.len)?
+pub fn (mut s SSLConn) read(mut buffer []u8) !int {
+	res := s.socket_read_into_ptr(&u8(buffer.data), buffer.len) or {
+		return error('unexpected error')
+	}
 	return res
 }
 

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -181,9 +181,7 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) ?int {
 }
 
 pub fn (mut s SSLConn) read(mut buffer []u8) !int {
-	res := s.socket_read_into_ptr(&u8(buffer.data), buffer.len) or {
-		return error('unexpected error')
-	}
+	res := s.socket_read_into_ptr(&u8(buffer.data), buffer.len) or { return err }
 	return res
 }
 

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -1,6 +1,7 @@
 module net
 
 import time
+import io
 import strings
 
 const (
@@ -134,7 +135,10 @@ pub fn (c TcpConn) read_ptr(buf_ptr &u8, len int) ?int {
 
 pub fn (c TcpConn) read(mut buf []u8) !int {
 	return c.read_ptr(buf.data, buf.len) or {
-		return error('unexpected error in `read_ptr` function')
+		return IError(io.NotExpected{
+			cause: 'unexpected error in `read_ptr` function'
+			code: -1
+		})
 	}
 }
 

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -132,8 +132,10 @@ pub fn (c TcpConn) read_ptr(buf_ptr &u8, len int) ?int {
 	return none
 }
 
-pub fn (c TcpConn) read(mut buf []u8) ?int {
-	return c.read_ptr(buf.data, buf.len)
+pub fn (c TcpConn) read(mut buf []u8) !int {
+	return c.read_ptr(buf.data, buf.len) or {
+		return error('unexpected error in `read_ptr` function')
+	}
 }
 
 pub fn (mut c TcpConn) read_deadline() ?time.Time {

--- a/vlib/net/websocket/io.v
+++ b/vlib/net/websocket/io.v
@@ -9,10 +9,10 @@ fn (mut ws Client) socket_read(mut buffer []u8) ?int {
 			return error('socket_read: trying to read a closed socket')
 		}
 		if ws.is_ssl {
-			r := ws.ssl_conn.read(mut buffer)?
+			r := ws.ssl_conn.read(mut buffer) or { return none }
 			return r
 		} else {
-			r := ws.conn.read(mut buffer)?
+			r := ws.conn.read(mut buffer) or { return none }
 			return r
 		}
 	}

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -192,11 +192,13 @@ pub fn (mut f File) reopen(path string, mode string) ? {
 }
 
 // read implements the Reader interface.
-pub fn (f &File) read(mut buf []u8) ?int {
+pub fn (f &File) read(mut buf []u8) !int {
 	if buf.len == 0 {
-		return 0
+		return error('empty buffer')
 	}
-	nbytes := fread(buf.data, 1, buf.len, f.cfile)?
+	nbytes := fread(buf.data, 1, buf.len, f.cfile) or {
+		return error('unexpected error from fread')
+	}
 	return nbytes
 }
 

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -1,5 +1,7 @@
 module os
 
+import io
+
 pub struct File {
 mut:
 	cfile voidptr // Using void* instead of FILE*
@@ -194,10 +196,13 @@ pub fn (mut f File) reopen(path string, mode string) ? {
 // read implements the Reader interface.
 pub fn (f &File) read(mut buf []u8) !int {
 	if buf.len == 0 {
-		return error('empty buffer')
+		return IError(io.Eof{})
 	}
 	nbytes := fread(buf.data, 1, buf.len, f.cfile) or {
-		return error('unexpected error from fread')
+		return IError(io.NotExpected{
+			cause: 'unexpected error from fread'
+			code: -1
+		})
 	}
 	return nbytes
 }

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -1,6 +1,23 @@
 module os
 
-import io
+/// Eof error means that we reach the end of the file.
+pub struct Eof {
+	Error
+}
+
+// NotExpected is a generic error that means that we receave a not expecte error.
+pub struct NotExpected {
+	cause string
+	code  int
+}
+
+fn (err NotExpected) msg() string {
+	return err.cause
+}
+
+fn (err NotExpected) code() int {
+	return err.code
+}
 
 pub struct File {
 mut:
@@ -196,10 +213,10 @@ pub fn (mut f File) reopen(path string, mode string) ? {
 // read implements the Reader interface.
 pub fn (f &File) read(mut buf []u8) !int {
 	if buf.len == 0 {
-		return IError(io.Eof{})
+		return IError(Eof{})
 	}
 	nbytes := fread(buf.data, 1, buf.len, f.cfile) or {
-		return IError(io.NotExpected{
+		return IError(NotExpected{
 			cause: 'unexpected error from fread'
 			code: -1
 		})

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -130,11 +130,11 @@ fn test_read_eof_last_read_partial_buffer_fill() ? {
 	f = os.open_file(tfile, 'r')?
 	mut br := []u8{len: 100}
 	// Read first 100 bytes of 199 byte file, should fill buffer with no error.
-	n0 := f.read(mut br)?
+	n0 := f.read(mut br) or { return error('fail to read') }
 	assert n0 == 100
 	// Read remaining 99 bytes of 199 byte file, should fill buffer with no
 	// error, even though end-of-file was reached.
-	n1 := f.read(mut br)?
+	n1 := f.read(mut br) or { return error('fail to read') }
 	assert n1 == 99
 	// Read again, end-of-file was previously reached so should return none
 	// error.
@@ -143,8 +143,8 @@ fn test_read_eof_last_read_partial_buffer_fill() ? {
 		// not return a number of bytes read when end-of-file is reached.
 		assert false
 	} else {
-		// Expect none to have been returned when end-of-file.
-		assert err is none
+		// Expected an error when received end-of-file.
+		assert err !is none
 	}
 	f.close()
 }
@@ -162,11 +162,11 @@ fn test_read_eof_last_read_full_buffer_fill() ? {
 	f = os.open_file(tfile, 'r')?
 	mut br := []u8{len: 100}
 	// Read first 100 bytes of 200 byte file, should fill buffer with no error.
-	n0 := f.read(mut br)?
+	n0 := f.read(mut br) or { return error('fail to read') }
 	assert n0 == 100
 	// Read remaining 100 bytes of 200 byte file, should fill buffer with no
 	// error. The end-of-file isn't reached yet, but there is no more data.
-	n1 := f.read(mut br)?
+	n1 := f.read(mut br) or { return error('fail to read') }
 	assert n1 == 100
 	// Read again, end-of-file was previously reached so should return none
 	// error.
@@ -175,8 +175,9 @@ fn test_read_eof_last_read_full_buffer_fill() ? {
 		// not return a number of bytes read when end-of-file is reached.
 		assert false
 	} else {
-		// Expect none to have been returned when end-of-file.
-		assert err is none
+		// TODO(vincenzopalazzo): Change this with another PR, to allow the read to return `!?`
+		// Expect an error when end-of-file is returned.
+		assert err !is none
 	}
 	f.close()
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -130,11 +130,11 @@ fn test_read_eof_last_read_partial_buffer_fill() ? {
 	f = os.open_file(tfile, 'r')?
 	mut br := []u8{len: 100}
 	// Read first 100 bytes of 199 byte file, should fill buffer with no error.
-	n0 := f.read(mut br) or { return error('fail to read') }
+	n0 := f.read(mut br) or { return error('failed to read 100 bytes') }
 	assert n0 == 100
 	// Read remaining 99 bytes of 199 byte file, should fill buffer with no
 	// error, even though end-of-file was reached.
-	n1 := f.read(mut br) or { return error('fail to read') }
+	n1 := f.read(mut br) or { return error('failed to read 100 bytes') }
 	assert n1 == 99
 	// Read again, end-of-file was previously reached so should return none
 	// error.
@@ -162,11 +162,11 @@ fn test_read_eof_last_read_full_buffer_fill() ? {
 	f = os.open_file(tfile, 'r')?
 	mut br := []u8{len: 100}
 	// Read first 100 bytes of 200 byte file, should fill buffer with no error.
-	n0 := f.read(mut br) or { return error('fail to read') }
+	n0 := f.read(mut br) or { return error('failed to read 100 bytes') }
 	assert n0 == 100
 	// Read remaining 100 bytes of 200 byte file, should fill buffer with no
 	// error. The end-of-file isn't reached yet, but there is no more data.
-	n1 := f.read(mut br) or { return error('fail to read') }
+	n1 := f.read(mut br) or { return error('failed to read 100 bytes') }
 	assert n1 == 100
 	// Read again, end-of-file was previously reached so should return none
 	// error.
@@ -175,8 +175,7 @@ fn test_read_eof_last_read_full_buffer_fill() ? {
 		// not return a number of bytes read when end-of-file is reached.
 		assert false
 	} else {
-		// TODO(vincenzopalazzo): Change this with another PR, to allow the read to return `!?`
-		// Expect an error when end-of-file is returned.
+		// Expect an error at EOF.
 		assert err !is none
 	}
 	f.close()

--- a/vlib/v/gen/js/sourcemap/vlq/vlq_decode_test.v
+++ b/vlib/v/gen/js/sourcemap/vlq/vlq_decode_test.v
@@ -37,7 +37,7 @@ fn test_decode_a() ? {
 
 fn (mut b TestReader) read(mut buf []u8) !int {
 	if !(b.i < b.bytes.len) {
-		return error('EOF')
+		return IError(io.Eof{})
 	}
 	n := copy(mut buf, b.bytes[b.i..])
 	b.i += n

--- a/vlib/v/gen/js/sourcemap/vlq/vlq_decode_test.v
+++ b/vlib/v/gen/js/sourcemap/vlq/vlq_decode_test.v
@@ -35,9 +35,9 @@ fn test_decode_a() ? {
 	}
 }
 
-fn (mut b TestReader) read(mut buf []u8) ?int {
+fn (mut b TestReader) read(mut buf []u8) !int {
 	if !(b.i < b.bytes.len) {
-		return none
+		return error('EOF')
 	}
 	n := copy(mut buf, b.bytes[b.i..])
 	b.i += n


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/15197

This PR include an api change in the `ioReader` where the API migration will move from

```v
pub interface Reader {
	// read reads up to buf.len bytes and places
	// them into buf.
	// A type that implements this should return
	// `none` on end of stream (EOF) instead of just returning 0
mut:
	read(mut buf []u8) ?int
}
````

to

```v
pub interface Reader {
	// read reads up to buf.len bytes and places
	// them into buf.
	// A type that implements this should return
	// `io.Eof` on end of stream (EOF) instead of just returning 0
mut:
	read(mut buf []u8) !int
}
```
<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
