### PR TITLE
cgen: fix comptime for method call with arguments (fix #15234)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -147,12 +147,13 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			} else {
 				// last argument; try to expand if it's []string
 				idx := i - node.args.len
+				last_arg := g.expr_string(node.args.last().expr)
 				if m.params[i].typ.is_int() || m.params[i].typ.idx() == ast.bool_type_idx {
 					// Gets the type name and cast the string to the type with the string_<type> function
 					type_name := g.table.type_symbols[int(m.params[i].typ)].str()
-					g.write('string_${type_name}(((string*)${node.args[node.args.len - 1]}.data) [$idx])')
+					g.write('string_${type_name}(((string*)${last_arg}.data) [$idx])')
 				} else {
-					g.write('((string*)${node.args[node.args.len - 1]}.data) [$idx] ')
+					g.write('((string*)${last_arg}.data) [$idx] ')
 				}
 				if i < m.params.len - 1 {
 					g.write(', ')

--- a/vlib/v/tests/comptime_for_method_call_with_args_test.v
+++ b/vlib/v/tests/comptime_for_method_call_with_args_test.v
@@ -1,0 +1,17 @@
+import os
+
+struct Dummy {}
+
+fn (d Dummy) sample(file_name string) {
+	println(file_name)
+}
+
+fn test_comptime_for_method_call_with_args() {
+	$for method in Dummy.methods {
+		if os.args.len > 1 {
+			d := Dummy{}
+			d.$method(os.args)
+		}
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix comptime for method call with arguments (fix #15234).

- Fix comptime for method call with arguments.
- Add test.

```v
import os

struct Dummy {}

fn (d Dummy) sample(file_name string) {
    println(file_name)
}

fn main() {
    $for method in Dummy.methods {
        if os.args.len > 1 {
            Dummy{}.$method(os.args)
        }
    }
}

PS D:\Test\v\tt1> v run . hello
D:\Test\v\tt1\tt1.exe
```