### PR TITLE
cgen: check comptime call method (no value) used as value (fix #15233)

### DIFF
--- a/vlib/v/checker/tests/comptime_call_method_void_err.out
+++ b/vlib/v/checker/tests/comptime_call_method_void_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/comptime_call_method_void_err.vv:17:20: cgen error: method `sample1()` (no value) used as value
+   15 |     $for method in Dummy.methods {
+   16 |         if os.args.len >= 1 {
+   17 |             println(Dummy{}.$method(os.args[0]))
+      |                             ~~~~~~~~~~~~~~~~~~~
+   18 |         }
+   19 |     }

--- a/vlib/v/checker/tests/comptime_call_method_void_err.vv
+++ b/vlib/v/checker/tests/comptime_call_method_void_err.vv
@@ -1,0 +1,20 @@
+import os
+
+struct Dummy {}
+
+fn (d Dummy) sample2(file_name string) int {
+	println(file_name)
+	return 22
+}
+
+fn (d Dummy) sample1(file_name string) {
+	println(file_name)
+}
+
+fn main() {
+	$for method in Dummy.methods {
+		if os.args.len >= 1 {
+			println(Dummy{}.$method(os.args[0]))
+		}
+	}
+}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -93,6 +93,9 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		for val in vals {
 		}
 		*/
+		if g.inside_call && m.return_type == ast.void_type {
+			g.error('method `${m.name}()` (no value) used as value', node.pos)
+		}
 		expand_strs := if node.args.len > 0 && m.params.len - 1 >= node.args.len {
 			arg := node.args[node.args.len - 1]
 			param := m.params[node.args.len]


### PR DESCRIPTION
This PR check comptime call method (no value) used as value (fix #15233).

- Check comptime call method (no value) used as value.
- Add test.

```v
import os

struct Dummy {}

fn (d Dummy) sample2(file_name string) int {
	println(file_name)
	return 22
}

fn (d Dummy) sample1(file_name string) {
	println(file_name)
}

fn main() {
	$for method in Dummy.methods {
		if os.args.len >= 1 {
			println(Dummy{}.$method(os.args[0]))
		}
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:17:20: cgen error: method `sample1()` (no value) used as value
   15 |     $for method in Dummy.methods {
   16 |         if os.args.len >= 1 {
   17 |             println(Dummy{}.$method(os.args[0]))
      |                             ~~~~~~~~~~~~~~~~~~~
   18 |         }
   19 |     }
```