### PR TITLE
checker: check struct field's fn call  (fix #15249)

### DIFF
--- a/vlib/net/websocket/events.v
+++ b/vlib/net/websocket/events.v
@@ -171,9 +171,9 @@ fn (mut ws Client) send_message_event(msg &Message) {
 	ws.debug_log('sending on_message event')
 	for ev_handler in ws.message_callbacks {
 		if !ev_handler.is_ref {
-			ev_handler.handler(ws, msg) or { ws.logger.error('send_message_event error: $err') }
+			ev_handler.handler(mut ws, msg) or { ws.logger.error('send_message_event error: $err') }
 		} else {
-			ev_handler.handler2(ws, msg, ev_handler.ref) or {
+			ev_handler.handler2(mut ws, msg, ev_handler.ref) or {
 				ws.logger.error('send_message_event error: $err')
 			}
 		}

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -158,20 +158,20 @@ fn rw_callback(loop &C.picoev_loop, fd int, events int, context voidptr) {
 			if pret > 0 { // Success
 				break
 			} else if pret == -1 { // Parse error
-				p.err_cb(mut p.user_data, req, mut &res, error('ParseError'))
+				p.err_cb(p.user_data, req, mut &res, error('ParseError'))
 				return
 			}
 
 			assert pret == -2
 			// request is incomplete, continue the loop
 			if p.idx[fd] == sizeof(buf) {
-				p.err_cb(mut p.user_data, req, mut &res, error('RequestIsTooLongError'))
+				p.err_cb(p.user_data, req, mut &res, error('RequestIsTooLongError'))
 				return
 			}
 		}
 
 		// Callback (should call .end() itself)
-		p.cb(mut p.user_data, req, mut &res)
+		p.cb(p.user_data, req, mut &res)
 	}
 }
 
@@ -180,7 +180,7 @@ fn accept_callback(loop &C.picoev_loop, fd int, events int, cb_arg voidptr) {
 	newfd := C.accept(fd, 0, 0)
 	if newfd != -1 {
 		setup_sock(newfd) or {
-			p.err_cb(mut p.user_data, picohttpparser.Request{}, mut &picohttpparser.Response{},
+			p.err_cb(p.user_data, picohttpparser.Request{}, mut &picohttpparser.Response{},
 				err)
 		}
 		C.picoev_add(voidptr(loop), newfd, int(Event.read), p.timeout_secs, rw_callback,
@@ -221,7 +221,7 @@ pub fn new(config Config) &Picoev {
 	listen_res := C.listen(fd, C.SOMAXCONN)
 	assert listen_res == 0
 	setup_sock(fd) or {
-		config.err_cb(mut config.user_data, picohttpparser.Request{}, mut &picohttpparser.Response{},
+		config.err_cb(config.user_data, picohttpparser.Request{}, mut &picohttpparser.Response{},
 			err)
 	}
 

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -66,14 +66,14 @@ struct Picoev {
 	loop         &C.picoev_loop
 	cb           fn (voidptr, picohttpparser.Request, mut picohttpparser.Response)
 	err_cb       fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError)
-	user_data    voidptr
 	timeout_secs int
 	max_headers  int
 mut:
-	date &u8
-	buf  &u8
-	idx  [1024]int
-	out  &u8
+	user_data voidptr
+	date      &u8
+	buf       &u8
+	idx       [1024]int
+	out       &u8
 }
 
 [inline]

--- a/vlib/v/checker/tests/method_call_arg_no_mut_err.out
+++ b/vlib/v/checker/tests/method_call_arg_no_mut_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/method_call_arg_no_mut_err.vv:25:14: error: method `alarm_fkt` parameter `a` is `mut`, so use `mut last` instead
+   23 |     c.arr << Alarm{}
+   24 |     mut last := c.arr.last()
+   25 |     c.alarm_fkt(last)
+      |                 ~~~~
+   26 | }

--- a/vlib/v/checker/tests/method_call_arg_no_mut_err.vv
+++ b/vlib/v/checker/tests/method_call_arg_no_mut_err.vv
@@ -1,0 +1,26 @@
+module main
+
+type Fkt = fn (mut a Alarm)
+
+struct Alarm {
+	x int
+}
+
+struct Clock {
+mut:
+	arr       []Alarm
+	alarm_fkt Fkt
+}
+
+fn fkt(mut a Alarm) {
+	println(a.x)
+}
+
+fn main() {
+	mut c := Clock{
+		alarm_fkt: fkt
+	}
+	c.arr << Alarm{}
+	mut last := c.arr.last()
+	c.alarm_fkt(last)
+}

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -2125,7 +2125,7 @@ pub fn (mut g Gen) builtin_decl_amd64(builtin BuiltinFn) {
 	local_alloc_pos := g.pos()
 	g.sub(.rsp, 0)
 
-	builtin.body(builtin, g)
+	builtin.body(builtin, mut g)
 	g.println('; stack frame size: $g.stack_var_pos')
 	g.write32_at(local_alloc_pos + 3, g.stack_var_pos)
 


### PR DESCRIPTION
This PR check struct field's fn call  (fix #15249).

- Check struct field's fn call.
- Add test.

```v
module main

type Fkt = fn (mut a Alarm)

struct Alarm {
	x int
}

struct Clock {
mut:
	arr       []Alarm
	alarm_fkt Fkt
}

fn fkt(mut a Alarm) {
	println(a.x)
}

fn main() {
	mut c := Clock{
		alarm_fkt: fkt
	}
	c.arr << Alarm{}
	mut last := c.arr.last()
	c.alarm_fkt(last)
}

PS D:\Test\v\tt1> v run .
./tt1.v:25:14: error: method `alarm_fkt` parameter `a` is `mut`, so use `mut last` instead
   23 |     c.arr << Alarm{}
   24 |     mut last := c.arr.last()
   25 |     c.alarm_fkt(last)
      |                 ~~~~
   26 | }
```