### PR TITLE
create and use `parser.unexpected` to cleanup

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -261,8 +261,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 		for r in right {
 			has_cross_var = p.check_cross_variables(left, r)
 			if op !in [.assign, .decl_assign] {
-				return p.error_with_pos('unexpected $op.str(), expecting := or = or comma',
-					pos)
+				return p.unexpected_with_pos(pos, got: op.str(), expecting: ':= or = or comma')
 			}
 			if has_cross_var {
 				break

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -12,7 +12,7 @@ pub fn (mut p Parser) expr(precedence int) ast.Expr {
 		if token.is_decl(p.tok.kind) && p.disallow_declarations_in_script_mode() {
 			return ast.empty_expr
 		}
-		p.error_with_pos('invalid expression: unexpected $p.tok', p.tok.pos())
+		p.unexpected(prepend_msg: 'invalid expression:')
 	}
 }
 
@@ -91,7 +91,9 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 					return p.if_expr(true)
 				}
 				else {
-					return p.error_with_pos('unexpected `$`', p.peek_tok.pos())
+					return p.unexpected_with_pos(p.peek_tok.pos(),
+						got: '`$`'
+					)
 				}
 			}
 		}
@@ -294,8 +296,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			st := p.parse_type()
 			p.check(.comma)
 			if p.tok.kind != .name {
-				return p.error_with_pos('unexpected `$p.tok.lit`, expecting struct field',
-					p.tok.pos())
+				return p.unexpected(got: '`$p.tok.lit`', additional_msg: 'expecting struct field')
 			}
 			field := p.tok.lit
 			p.next()
@@ -365,7 +366,7 @@ pub fn (mut p Parser) check_expr(precedence int) ?ast.Expr {
 			if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {
 				// eof should be handled where it happens
 				return none
-				// return p.error_with_pos('invalid expression: unexpected $p.tok', p.tok.pos())
+				// return p.unexpected(prepend_msg: 'invalid expression: ')
 			}
 		}
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -712,8 +712,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	no_body := p.tok.kind != .lcbr
 	same_line = p.tok.line_nr == p.prev_tok.line_nr
 	if no_body && same_line {
-		p.error_with_pos('unexpected $p.tok after anonymous function signature, expecting `{`',
-			p.tok.pos())
+		p.unexpected(got: '$p.tok after anonymous function signature', expecting: '`{`')
 	}
 	mut label_names := []string{}
 	mut func := ast.Fn{

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -10,8 +10,7 @@ fn (mut p Parser) lockable() ast.Expr {
 	mut pos := p.tok.pos()
 	for {
 		if p.tok.kind != .name {
-			p.error_with_pos('unexpected `$p.tok.lit` (field/variable name expected)',
-				p.tok.pos())
+			p.unexpected(got: '`$p.tok.lit`', expecting: 'field or variable name')
 		}
 		names << p.tok.lit
 		positions << pos
@@ -74,7 +73,7 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 	for {
 		is_rlock := p.tok.kind == .key_rlock
 		if !is_rlock && p.tok.kind != .key_lock {
-			p.error_with_pos('unexpected `$p.tok`, expected `lock` or `rlock`', p.tok.pos())
+			p.unexpected(expecting: '`lock` or `rlock`')
 		}
 		p.next()
 		if p.tok.kind == .lcbr {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -529,7 +529,7 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 			if p.tok.kind == .lpar && !p.inside_sum_type {
 				// multiple return
 				if is_ptr {
-					p.error('parse_type: unexpected `&` before multiple returns')
+					p.unexpected(prepend_msg: 'parse_type:', got: '`&` before multiple returns')
 					return 0
 				}
 				return p.parse_multi_return_type()

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -10,8 +10,7 @@ fn (mut p Parser) sql_expr() ast.Expr {
 	pos := p.tok.pos()
 	p.check_name()
 	db_expr := p.check_expr(0) or {
-		p.error_with_pos('invalid expression: unexpected $p.tok, expecting database',
-			p.tok.pos())
+		p.unexpected(prepend_msg: 'invalid expression:', expecting: 'database')
 	}
 	p.check(.lcbr)
 	p.check(.key_select)
@@ -125,8 +124,7 @@ fn (mut p Parser) sql_stmt() ast.SqlStmt {
 	// `sql db {`
 	p.check_name()
 	db_expr := p.check_expr(0) or {
-		p.error_with_pos('invalid expression: unexpected $p.tok, expecting database',
-			p.tok.pos())
+		p.unexpected(prepend_msg: 'invalid expression:', expecting: 'database')
 	}
 	// println(typeof(db_expr))
 	p.check(.lcbr)


### PR DESCRIPTION
Creating similar error messages with same function improves consistency of error messages and makes  code clearer.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
