### PR TITLE
checker: check invalid variable (fix #15240)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2039,6 +2039,7 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 			c.error('incorrect use of compile-time type', node.pos)
 		}
 		ast.EmptyExpr {
+			print_backtrace()
 			c.error('checker.expr(): unhandled EmptyExpr', token.Pos{})
 			return ast.void_type
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2039,7 +2039,6 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 			c.error('incorrect use of compile-time type', node.pos)
 		}
 		ast.EmptyExpr {
-			print_backtrace()
 			c.error('checker.expr(): unhandled EmptyExpr', token.Pos{})
 			return ast.void_type
 		}
@@ -2754,6 +2753,9 @@ pub fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 							} else {
 								typ = obj.expr.expr_type.clear_flag(.optional).clear_flag(.result)
 							}
+						} else if obj.expr is ast.EmptyExpr {
+							c.error('invalid variable `$node.name`', node.pos)
+							typ = ast.void_type
 						} else {
 							typ = c.expr(obj.expr)
 						}

--- a/vlib/v/checker/tests/invalid_variable_err.out
+++ b/vlib/v/checker/tests/invalid_variable_err.out
@@ -1,0 +1,19 @@
+vlib/v/checker/tests/invalid_variable_err.vv:2:5: warning: unused variable: `b`
+    1 | fn main() {
+    2 |     a, b := c
+      |        ^
+    3 |     if a {
+    4 |     }
+vlib/v/checker/tests/invalid_variable_err.vv:2:7: error: assignment mismatch: 2 variable(s) 1 value(s)
+    1 | fn main() {
+    2 |     a, b := c
+      |          ~~
+    3 |     if a {
+    4 |     }
+vlib/v/checker/tests/invalid_variable_err.vv:3:5: error: invalid variable `a`
+    1 | fn main() {
+    2 |     a, b := c
+    3 |     if a {
+      |        ^
+    4 |     }
+    5 | }

--- a/vlib/v/checker/tests/invalid_variable_err.vv
+++ b/vlib/v/checker/tests/invalid_variable_err.vv
@@ -1,0 +1,5 @@
+fn main() {
+	a, b := c
+	if a {
+	}
+}


### PR DESCRIPTION
This PR check invalid variable (fix #15240).

- Check invalid variable.
- Add test.

```v
fn main() {
	a, b := c
	if a {
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:5: warning: unused variable: `b`
    1 | fn main() {
    2 |     a, b := c
      |        ^
    3 |     if a {
    4 |     }
./tt1.v:2:7: error: assignment mismatch: 2 variable(s) 1 value(s)
    1 | fn main() {
    2 |     a, b := c
      |          ~~
    3 |     if a {
    4 |     }
./tt1.v:3:5: error: invalid variable `a`
    1 | fn main() {
    2 |     a, b := c
    3 |     if a {
      |        ^
    4 |     }
    5 | }
```