### PR TITLE
fmt: fix comptime method call

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1841,13 +1841,15 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 			} else {
 				'${node.method_name}($inner_args)'
 			}
-			f.write('${node.left}.$$method_expr')
+			f.expr(node.left)
+			f.write('.$$method_expr')
 		}
 	}
 }
 
 pub fn (mut f Fmt) comptime_selector(node ast.ComptimeSelector) {
-	f.write('${node.left}.\$($node.field_expr)')
+	f.expr(node.left)
+	f.write('.\$($node.field_expr)')
 }
 
 pub fn (mut f Fmt) concat_expr(node ast.ConcatExpr) {

--- a/vlib/v/fmt/tests/comptime_method_call_keep.vv
+++ b/vlib/v/fmt/tests/comptime_method_call_keep.vv
@@ -1,0 +1,15 @@
+import os
+
+struct Dummy {}
+
+fn (d Dummy) sample(x int) int {
+	return x + 1
+}
+
+fn main() {
+	$for method in Dummy.methods {
+		if os.args.len > 1 {
+			Dummy{}.$method(os.args[1].int())
+		}
+	}
+}


### PR DESCRIPTION
This PR fix fmt of comptime method call.

- Fix comptime method call.
- Add test.

comptime_method_call_keep.vv
```v
import os

struct Dummy {}

fn (d Dummy) sample(x int) int {
	return x + 1
}

fn main() {
	$for method in Dummy.methods {
		if os.args.len > 1 {
			Dummy{}.$method(os.args[1].int())
		}
	}
}
```