### PR TITLE
fmt: fix interface method with fntype argument (fix #15276)

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1736,6 +1736,18 @@ pub fn (s string) all_after_last(sub string) string {
 	return s[pos + sub.len..]
 }
 
+// all_after_first returns the contents after the first occurence of `sub` in the string.
+// If the substring is not found, it returns the full input string.
+// Example: assert '23:34:45.234'.all_after_first(':') == '34:45.234'
+// Example: assert 'abcd'.all_after_first('z') == 'abcd'
+pub fn (s string) all_after_first(sub string) string {
+	pos := s.index_(sub)
+	if pos == -1 {
+		return s.clone()
+	}
+	return s[pos + sub.len..]
+}
+
 // after returns the contents after the last occurence of `sub` in the string.
 // If the substring is not found, it returns the full input string.
 // Example: assert '23:34:45.234'.after(':') == '45.234'

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1202,7 +1202,7 @@ pub fn (mut f Fmt) interface_field(field ast.StructField) {
 
 pub fn (mut f Fmt) interface_method(method ast.FnDecl) {
 	f.write('\t')
-	f.write(method.stringify(f.table, f.cur_mod, f.mod2alias).after('fn '))
+	f.write(method.stringify(f.table, f.cur_mod, f.mod2alias).all_after_first('fn '))
 	f.comments(method.comments, inline: true, has_nl: false, level: .indent)
 	f.writeln('')
 	f.comments(method.next_comments, inline: false, has_nl: true, level: .indent)

--- a/vlib/v/fmt/tests/interface_method_with_fntype_arg_keep.vv
+++ b/vlib/v/fmt/tests/interface_method_with_fntype_arg_keep.vv
@@ -1,0 +1,23 @@
+module main
+
+interface Test {
+	test(fn (Test))
+}
+
+struct Test1 {
+}
+
+fn (t Test1) test(f fn (Test)) {
+	f(Test(t))
+}
+
+fn main() {
+	t := Test1{}
+
+	t.test(fn [t] (t1 Test) {
+		println('$t, $t1')
+		t.test(fn [t] (t2 Test) {
+			println('$t, $t2')
+		})
+	})
+}


### PR DESCRIPTION
This PR fix interface method with fntype argument (fix #15276).

- Fix interface method with fntype argument.
- Add test.

vlib\v\fmt\tests\interface_method_with_fntype_arg_keep.vv
```v
module main

interface Test {
	test(fn (Test))
}

struct Test1 {
}

fn (t Test1) test(f fn (Test)) {
	f(Test(t))
}

fn main() {
	t := Test1{}

	t.test(fn [t] (t1 Test) {
		println('$t, $t1')
		t.test(fn [t] (t2 Test) {
			println('$t, $t2')
		})
	})
}
```