### PR TITLE
30 Jul 2022 9:17 pm : Updating docs to include example for Function literals in Functions section

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -241,6 +241,17 @@ Again, the type comes after the argument's name.
 Just like in Go and C, functions cannot be overloaded.
 This simplifies the code and improves maintainability and readability.
 
+An alternative syntax to declare is to use Function literal :
+
+```v
+fn main() {
+	add:= fn(x int, y int) int {
+		return x + y
+	}
+}
+```
+
+
 ### Hoistings
 
 Functions can be used before their declaration:

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -241,7 +241,7 @@ Again, the type comes after the argument's name.
 Just like in Go and C, functions cannot be overloaded.
 This simplifies the code and improves maintainability and readability.
 
-An alternative syntax to declare is to use Function literal :
+An alternative syntax to declare functions is to use Function literal :
 
 ```v
 fn main() {


### PR DESCRIPTION
Functions section in vlang docs does not explicitly state that Function literals are supported , although it is used at other  sections.Hence the PR adds an example demonstrating the Function literals creation under the Function section of docs.