### PR TITLE
gen.c: simplify `unwrap_generic` method

### DIFF
--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -7,7 +7,7 @@ import v.ast
 
 fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 	if typ.has_flag(.generic) {
-		// `resolve_generic_to_concrete` should not mutate the table.
+		// NOTE: `resolve_generic_to_concrete` should not mutate the table.
 		//
 		// It mutates if the generic type is for example `[]T` and the concrete
 		// type is an array type that has not been registered yet.

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -16,8 +16,8 @@ fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 		// `resolve_generic_to_concrete`. `g.table` is made non-mut to make sure
 		// no one else can accidentally mutates the table.
 		unsafe {
-			mut muttable := &ast.Table(g.table)
-			if t_typ := muttable.resolve_generic_to_concrete(typ, if g.cur_fn != nil {
+			mut mut_table := &ast.Table(g.table)
+			if t_typ := mut_table.resolve_generic_to_concrete(typ, if g.cur_fn != nil {
 				g.cur_fn.generic_names
 			} else {
 				[]string{}

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -7,22 +7,24 @@ import v.ast
 
 fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 	if typ.has_flag(.generic) {
-		/*
-		resolve_generic_to_concrete should not mutate the table.
-		It mutates if the generic type is for example []T and the
-		concrete type is an array type that has not been registered
-		yet. This should have already happened in the checker, since
-		it also calls resolve_generic_to_concrete. g.table is made
-		non-mut to make sure no one else can accidentally mutates the table.
-		*/
-		mut muttable := unsafe { &ast.Table(g.table) }
-		if t_typ := muttable.resolve_generic_to_concrete(typ, if unsafe { g.cur_fn != 0 } {
-			g.cur_fn.generic_names
-		} else {
-			[]string{}
-		}, g.cur_concrete_types)
-		{
-			return t_typ
+		// `resolve_generic_to_concrete` should not mutate the table.
+		//
+		// It mutates if the generic type is for example `[]T` and the concrete
+		// type is an array type that has not been registered yet.
+		//
+		// This should have already happened in the checker, since it also calls
+		// `resolve_generic_to_concrete`. `g.table` is made non-mut to make sure
+		// no one else can accidentally mutates the table.
+		unsafe {
+			mut muttable := &ast.Table(g.table)
+			if t_typ := muttable.resolve_generic_to_concrete(typ, if g.cur_fn != nil {
+				g.cur_fn.generic_names
+			} else {
+				[]string{}
+			}, g.cur_concrete_types)
+			{
+				return t_typ
+			}
 		}
 	}
 	return typ


### PR DESCRIPTION
* Improve comment formatting.
* Wrap unsafe code inside an `unsafe` block instead of using 2 blocks.
* Replace `0` with `nil`.
* Replace `muttable` => `mut_table`.