### PR TITLE
orm: orm querys with parentheses not work

### DIFF
--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -26,6 +26,7 @@ struct Foo {
     created_at  time.Time   [sql_type: 'DATETIME']
     updated_at  string      [sql_type: 'DATETIME']
     deleted_at  time.Time
+    status  	string
 }
 ```
 
@@ -50,6 +51,7 @@ sql db {
 ```v ignore
 var := Foo{
     name:       'abc'
+    status:     'pending'
     created_at: time.now()
     updated_at: time.now().str()
     deleted_at: time.now()
@@ -79,6 +81,11 @@ sql db {
 ```v ignore
 result := sql db {
     select from Foo where id == 1
+}
+```
+```v ignore
+result := sql db {
+    select from Foo where (name == 'b' && status == 'done') || id == 1 order by id
 }
 ```
 ```v ignore


### PR DESCRIPTION
I create this PR, but, I have yet not ideia of how solve this. 
I need some tips of how parameters are passed from built-in sql to `orm.Connection.@select(config SelectConfig, data QueryData, where QueryData)`

In resume, when I write:
```v
results := sql db {
        select from Task where id == 1 || (title == "Outras coisa3" && status == 'done')
}
```
The function `orm_stmt_gen` in the path '/vlib/orm/orm.v' receive this where param:
```v
where: orm.QueryData{
    fields: ['id']
    data: [orm.Primitive(1)]
    types: []
    kinds: [eq]
    is_and: [true]
}
```
and genarete this query: 
`SELECT "id", "title", "status", "description", "check_list", "deadline_at", "created_at", "updated_at" FROM "task" WHERE "id" = $1;`
