### PR TITLE
.github: Add example on PR template  title to avoid confusion

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 
 <!--
 
-Please title your PR as follows: `time: fix foo bar`.
+Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
 Always start with the thing you are fixing, then describe the fix.
 Don't use past tense (e.g. "fixed foo bar").
 


### PR DESCRIPTION
I saw a PR that had the title `30 Jul 2022 9:17 pm : Updating docs to include example for Function literals in Functions section`. This PR tries to avoid that confusion by giving an example with a module different than `time`.