### PR TITLE
encoding.binary: fix function names in comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 
 <!--
 
-Please title your PR as follows: `time: fix foo bar`.
+Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
 Always start with the thing you are fixing, then describe the fix.
 Don't use past tense (e.g. "fixed foo bar").
 

--- a/vlib/encoding/binary/big_endian.v
+++ b/vlib/encoding/binary/big_endian.v
@@ -10,7 +10,7 @@ pub fn big_endian_u16(b []u8) u16 {
 	return u16(b[1]) | (u16(b[0]) << u16(8))
 }
 
-// big_endian_u16 creates a u16 from two bytes in the array b at the specified offset in big endian order.
+// big_endian_u16_at creates a u16 from two bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_u16_at(b []u8, o int) u16 {
 	_ = b[o] // bounds check
@@ -18,7 +18,7 @@ pub fn big_endian_u16_at(b []u8, o int) u16 {
 	return u16(b[o + 1]) | (u16(b[o]) << u16(8))
 }
 
-// big_endian_u16 creates a u16 from two bytes in the array b at the specified offset in big endian order.
+// big_endian_u16_end creates a u16 from two bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_u16_end(b []u8) u16 {
 	return big_endian_u16_at(b, b.len - 2)
@@ -32,7 +32,7 @@ pub fn big_endian_put_u16(mut b []u8, v u16) {
 	b[1] = u8(v)
 }
 
-// big_endian_put_u16 writes a u16 to the two bytes in the array b at the specified offset in big endian order.
+// big_endian_put_u16_at writes a u16 to the two bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_put_u16_at(mut b []u8, v u16, o int) {
 	_ = b[o] // bounds check
@@ -41,7 +41,7 @@ pub fn big_endian_put_u16_at(mut b []u8, v u16, o int) {
 	b[o + 1] = u8(v)
 }
 
-// big_endian_put_u16 writes a u16 to the last two bytes in the array b in big endian order.
+// big_endian_put_u16_end writes a u16 to the last two bytes in the array b in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_put_u16_end(mut b []u8, v u16) {
 	big_endian_put_u16_at(mut b, v, b.len - 2)
@@ -54,7 +54,7 @@ pub fn big_endian_u32(b []u8) u32 {
 	return u32(b[3]) | (u32(b[2]) << u32(8)) | (u32(b[1]) << u32(16)) | (u32(b[0]) << u32(24))
 }
 
-// big_endian_u32 creates a u32 from four bytes in the array b at the specified offset in big endian order.
+// big_endian_u32_at creates a u32 from four bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_u32_at(b []u8, o int) u32 {
 	_ = b[o] // bounds check
@@ -62,7 +62,7 @@ pub fn big_endian_u32_at(b []u8, o int) u32 {
 	return u32(b[o + 3]) | (u32(b[o + 2]) << u32(8)) | (u32(b[o + 1]) << u32(16)) | (u32(b[o]) << u32(24))
 }
 
-// big_endian_u32 creates a u32 from the last four bytes in the array b in big endian order.
+// big_endian_u32_end creates a u32 from the last four bytes in the array b in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_u32_end(b []u8) u32 {
 	return big_endian_u32_at(b, b.len - 4)
@@ -78,7 +78,7 @@ pub fn big_endian_put_u32(mut b []u8, v u32) {
 	b[3] = u8(v)
 }
 
-// big_endian_put_u32 writes a u32 to four bytes in the array b at the specified offset in big endian order.
+// big_endian_put_u32_at writes a u32 to four bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_put_u32_at(mut b []u8, v u32, o int) {
 	_ = b[o] // bounds check
@@ -89,7 +89,7 @@ pub fn big_endian_put_u32_at(mut b []u8, v u32, o int) {
 	b[o + 3] = u8(v)
 }
 
-// big_endian_put_u32 writes a u32 to the last four bytes in the array b in big endian order.
+// big_endian_put_u32_end writes a u32 to the last four bytes in the array b in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_put_u32_end(mut b []u8, v u32) {
 	big_endian_put_u32_at(mut b, v, b.len - 4)
@@ -102,7 +102,7 @@ pub fn big_endian_u64(b []u8) u64 {
 	return u64(b[7]) | (u64(b[6]) << u64(8)) | (u64(b[5]) << u64(16)) | (u64(b[4]) << u64(24)) | (u64(b[3]) << u64(32)) | (u64(b[2]) << u64(40)) | (u64(b[1]) << u64(48)) | (u64(b[0]) << u64(56))
 }
 
-// big_endian_u64 creates a u64 from eight bytes in the array b at the specified offset in big endian order.
+// big_endian_u64_at creates a u64 from eight bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_u64_at(b []u8, o int) u64 {
 	_ = b[o] // bounds check
@@ -111,7 +111,7 @@ pub fn big_endian_u64_at(b []u8, o int) u64 {
 		o + 3]) << u64(32)) | (u64(b[o + 2]) << u64(40)) | (u64(b[o + 1]) << u64(48)) | (u64(b[o]) << u64(56))
 }
 
-// big_endian_u64 creates a u64 from the last eight bytes in the array b in big endian order.
+// big_endian_u64_end creates a u64 from the last eight bytes in the array b in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_u64_end(b []u8) u64 {
 	return big_endian_u64_at(b, b.len - 8)
@@ -131,7 +131,7 @@ pub fn big_endian_put_u64(mut b []u8, v u64) {
 	b[7] = u8(v)
 }
 
-// big_endian_put_u64 writes a u64 to eight bytes in the array b at the specified offset in big endian order.
+// big_endian_put_u64_at writes a u64 to eight bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_put_u64_at(mut b []u8, v u64, o int) {
 	_ = b[o] // bounds check
@@ -146,7 +146,7 @@ pub fn big_endian_put_u64_at(mut b []u8, v u64, o int) {
 	b[o + 7] = u8(v)
 }
 
-// big_endian_put_u64 writes a u64 to the last eight bytes in the array b at the specified offset in big endian order.
+// big_endian_put_u64_end writes a u64 to the last eight bytes in the array b at the specified offset in big endian order.
 [direct_array_access; inline]
 pub fn big_endian_put_u64_end(mut b []u8, v u64) {
 	big_endian_put_u64_at(mut b, v, b.len - 8)

--- a/vlib/encoding/binary/little_endian.v
+++ b/vlib/encoding/binary/little_endian.v
@@ -10,7 +10,7 @@ pub fn little_endian_u16(b []u8) u16 {
 	return u16(b[0]) | (u16(b[1]) << u16(8))
 }
 
-// little_endian_u16 creates a u16 from two bytes in the array b at the specified offset in little endian order.
+// little_endian_u16_at creates a u16 from two bytes in the array b at the specified offset in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_u16_at(b []u8, o int) u16 {
 	_ = b[o] // bounds check
@@ -18,7 +18,7 @@ pub fn little_endian_u16_at(b []u8, o int) u16 {
 	return u16(b[o]) | (u16(b[o + 1]) << u16(8))
 }
 
-// little_endian_u16 creates a u16 from the last two bytes of the array b in little endian order.
+// little_endian_u16_end creates a u16 from the last two bytes of the array b in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_u16_end(b []u8) u16 {
 	return little_endian_u16_at(b, b.len - 2)
@@ -32,7 +32,7 @@ pub fn little_endian_put_u16(mut b []u8, v u16) {
 	b[1] = u8(v >> u16(8))
 }
 
-// little_endian_put_u16 writes a u16 to the two bytes in the array b at the specified offset in little endian order.
+// little_endian_put_u16_at writes a u16 to the two bytes in the array b at the specified offset in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_put_u16_at(mut b []u8, v u16, o int) {
 	_ = b[o] // bounds check
@@ -41,7 +41,7 @@ pub fn little_endian_put_u16_at(mut b []u8, v u16, o int) {
 	b[o + 1] = u8(v >> u16(8))
 }
 
-// little_endian_put_u16 writes a u16 to the last two bytes of the array b in little endian order.
+// little_endian_put_u16_end writes a u16 to the last two bytes of the array b in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_put_u16_end(mut b []u8, v u16) {
 	little_endian_put_u16_at(mut b, v, b.len - 2)
@@ -54,7 +54,7 @@ pub fn little_endian_u32(b []u8) u32 {
 	return u32(b[0]) | (u32(b[1]) << u32(8)) | (u32(b[2]) << u32(16)) | (u32(b[3]) << u32(24))
 }
 
-// little_endian_u32 creates a u32 from four bytes in the array b at the specified offset in little endian order.
+// little_endian_u32_at creates a u32 from four bytes in the array b at the specified offset in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_u32_at(b []u8, o int) u32 {
 	_ = b[o] // bounds check
@@ -62,7 +62,7 @@ pub fn little_endian_u32_at(b []u8, o int) u32 {
 	return u32(b[o]) | (u32(b[o + 1]) << u32(8)) | (u32(b[o + 2]) << u32(16)) | (u32(b[o + 3]) << u32(24))
 }
 
-// little_endian_u32 creates a u32 from the last four bytes in the array b in little endian order.
+// little_endian_u32_end creates a u32 from the last four bytes in the array b in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_u32_end(b []u8) u32 {
 	return little_endian_u32_at(b, b.len - 4)
@@ -78,7 +78,7 @@ pub fn little_endian_put_u32(mut b []u8, v u32) {
 	b[3] = u8(v >> u32(24))
 }
 
-// little_endian_put_u32 writes a u32 to the two bytes in the array b at the specified offset in little endian order.
+// little_endian_put_u32_at writes a u32 to the two bytes in the array b at the specified offset in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_put_u32_at(mut b []u8, v u32, o int) {
 	_ = b[o] // bounds check
@@ -89,7 +89,7 @@ pub fn little_endian_put_u32_at(mut b []u8, v u32, o int) {
 	b[o + 3] = u8(v >> u32(24))
 }
 
-// little_endian_put_u32 writes a u32 to the last two bytes in the array b in little endian order.
+// little_endian_put_u32_end writes a u32 to the last two bytes in the array b in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_put_u32_end(mut b []u8, v u32) {
 	little_endian_put_u32_at(mut b, v, b.len - 4)
@@ -102,7 +102,7 @@ pub fn little_endian_u64(b []u8) u64 {
 	return u64(b[0]) | (u64(b[1]) << u64(8)) | (u64(b[2]) << u64(16)) | (u64(b[3]) << u64(24)) | (u64(b[4]) << u64(32)) | (u64(b[5]) << u64(40)) | (u64(b[6]) << u64(48)) | (u64(b[7]) << u64(56))
 }
 
-// little_endian_u64 creates a u64 from eight bytes in the array b at the specified offset in little endian order.
+// little_endian_u64_at creates a u64 from eight bytes in the array b at the specified offset in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_u64_at(b []u8, o int) u64 {
 	_ = b[o] // bounds check
@@ -111,7 +111,7 @@ pub fn little_endian_u64_at(b []u8, o int) u64 {
 		o + 4]) << u64(32)) | (u64(b[o + 5]) << u64(40)) | (u64(b[o + 6]) << u64(48)) | (u64(b[o + 7]) << u64(56))
 }
 
-// little_endian_u64 creates a u64 from the last eight bytes in the array b in little endian order.
+// little_endian_u64_end creates a u64 from the last eight bytes in the array b in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_u64_end(b []u8) u64 {
 	return little_endian_u64_at(b, b.len - 8)
@@ -131,7 +131,7 @@ pub fn little_endian_put_u64(mut b []u8, v u64) {
 	b[7] = u8(v >> u64(56))
 }
 
-// little_endian_put_u64 writes a u64 to the eight bytes in the array b at the specified offset in little endian order.
+// little_endian_put_u64_at writes a u64 to the eight bytes in the array b at the specified offset in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_put_u64_at(mut b []u8, v u64, o int) {
 	_ = b[o] // bounds check
@@ -146,7 +146,7 @@ pub fn little_endian_put_u64_at(mut b []u8, v u64, o int) {
 	b[o + 7] = u8(v >> u64(56))
 }
 
-// little_endian_put_u64 writes a u64 to the last eight bytes in the array b at in little endian order.
+// little_endian_put_u64_end writes a u64 to the last eight bytes in the array b at in little endian order.
 [direct_array_access; inline]
 pub fn little_endian_put_u64_end(mut b []u8, v u64) {
 	little_endian_put_u64_at(mut b, v, b.len - 8)


### PR DESCRIPTION
I forgot to match the name of the functions in their documentation comments, this PR fixes it. Woopsies.