### PR TITLE
checker: check incorrect generic fn call inside generic fn (fix #15328)

### DIFF
--- a/examples/graphs/bellman-ford.v
+++ b/examples/graphs/bellman-ford.v
@@ -53,7 +53,7 @@ fn print_sol(dist []int) {
 // to all other vertices using Bellman-Ford algorithm.  The
 // function also detects negative weight cycle
 fn bellman_ford<T>(graph [][]T, src int) {
-	mut edges := build_map_edges_from_graph(graph)
+	mut edges := build_map_edges_from_graph<T>(graph)
 	// this function was done to adapt a graph representation
 	// by a adjacency matrix, to list of adjacency (using a MAP)
 	n_edges := edges.len // number of EDGES

--- a/examples/graphs/bellman-ford.v
+++ b/examples/graphs/bellman-ford.v
@@ -53,7 +53,7 @@ fn print_sol(dist []int) {
 // to all other vertices using Bellman-Ford algorithm.  The
 // function also detects negative weight cycle
 fn bellman_ford<T>(graph [][]T, src int) {
-	mut edges := build_map_edges_from_graph<T>(graph)
+	mut edges := build_map_edges_from_graph<int>(graph)
 	// this function was done to adapt a graph representation
 	// by a adjacency matrix, to list of adjacency (using a MAP)
 	n_edges := edges.len // number of EDGES

--- a/examples/graphs/minimal_spann_tree_prim.v
+++ b/examples/graphs/minimal_spann_tree_prim.v
@@ -56,16 +56,16 @@ fn updating_priority<T>(mut prior_queue []T, search_data int, new_priority int) 
 
 	for i < lenght_pq {
 		if search_data == prior_queue[i].data {
-			prior_queue[i] = NODE{search_data, new_priority} // do the copy in the right place	
+			prior_queue[i] = NODE{search_data, new_priority} // do the copy in the right place
 			break
 		}
 		i++
 		// all the list was examined
 		if i >= lenght_pq {
-			// print('\n Priority Queue:  ${prior_queue}')		
+			// print('\n Priority Queue:  ${prior_queue}')
 			// print('\n These data ${search_data} and ${new_priority} do not exist ... PRIORITY QUEUE problem\n')
 			// if it does not find ... then push it
-			push_pq(mut prior_queue, search_data, new_priority)
+			push_pq<T>(mut prior_queue, search_data, new_priority)
 			// exit(1) // panic(s string)
 		}
 	} // end for

--- a/vlib/datatypes/bstree.v
+++ b/vlib/datatypes/bstree.v
@@ -67,7 +67,7 @@ mut:
 // insert give the possibility to insert an element in the BST.
 pub fn (mut bst BSTree<T>) insert(value T) bool {
 	if bst.is_empty() {
-		bst.root = new_root_node(value)
+		bst.root = new_root_node<T>(value)
 		return true
 	}
 	return bst.insert_helper(mut bst.root, value)
@@ -79,13 +79,13 @@ fn (mut bst BSTree<T>) insert_helper(mut node BSTreeNode<T>, value T) bool {
 		if unsafe { node.right != 0 } && node.right.is_init {
 			return bst.insert_helper(mut node.right, value)
 		}
-		node.right = new_node(node, value)
+		node.right = new_node<T>(node, value)
 		return true
 	} else if node.value > value {
 		if unsafe { node.left != 0 } && node.left.is_init {
 			return bst.insert_helper(mut node.left, value)
 		}
-		node.left = new_node(node, value)
+		node.left = new_node<T>(node, value)
 		return true
 	}
 	return false

--- a/vlib/math/stats/stats.v
+++ b/vlib/math/stats/stats.v
@@ -88,7 +88,7 @@ pub fn mode<T>(data []T) T {
 	}
 	mut freqs := []int{}
 	for v in data {
-		freqs << freq(data, v)
+		freqs << freq<T>(data, v)
 	}
 	mut max := 0
 	for i := 0; i < freqs.len; i++ {
@@ -234,7 +234,7 @@ pub fn absdev_mean<T>(data []T, mean T) T {
 	}
 	mut sum := T(0)
 	for v in data {
-		sum += math.abs(v - mean)
+		sum += math.abs<T>(v - mean)
 	}
 	return sum / T(data.len)
 }

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -757,6 +757,12 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		&& !func.is_unsafe && func.mod != 'builtin' {
 		c.error('cannot call a function that does not have a body', node.pos)
 	}
+	if func.generic_names.len > 0 && node.concrete_types.len == 0 && !has_generic
+		&& !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len > 0
+		&& func.name != c.table.cur_fn.name {
+		c.error('generic fn call inside generic fn must specify the generic type names, e.g. foo<T>()',
+			node.pos)
+	}
 	if node.concrete_types.len > 0 && func.generic_names.len > 0
 		&& node.concrete_types.len != func.generic_names.len {
 		plural := if func.generic_names.len == 1 { '' } else { 's' }

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -760,8 +760,17 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	if func.generic_names.len > 0 && node.concrete_types.len == 0 && !has_generic
 		&& !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len > 0
 		&& func.name != c.table.cur_fn.name {
-		c.error('generic fn call inside generic fn must specify the generic type names, e.g. foo<T>()',
-			node.pos)
+		mut arg_has_generic := false
+		for arg in node.args {
+			if arg.typ.has_flag(.generic) {
+				arg_has_generic = true
+				break
+			}
+		}
+		if arg_has_generic {
+			c.error('generic fn call inside generic fn must specify the generic type names, e.g. foo<T>()',
+				node.pos)
+		}
 	}
 	if node.concrete_types.len > 0 && func.generic_names.len > 0
 		&& node.concrete_types.len != func.generic_names.len {

--- a/vlib/v/checker/tests/generics_fn_called_inside_of_generic_fn.out
+++ b/vlib/v/checker/tests/generics_fn_called_inside_of_generic_fn.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_fn_called_inside_of_generic_fn.vv:9:2: error: generic fn call inside generic fn must specify the generic type names, e.g. foo<T>()
+    7 | fn shuffle<T>(mut a []T) ? {
+    8 |     println('FN: ${@FN:20} | T: ${typeof(a).name}')
+    9 |     shuffle_impl(mut a)?
+      |     ~~~~~~~~~~~~~~~~~~~
+   10 | }
+   11 |

--- a/vlib/v/checker/tests/generics_fn_called_inside_of_generic_fn.vv
+++ b/vlib/v/checker/tests/generics_fn_called_inside_of_generic_fn.vv
@@ -1,0 +1,17 @@
+module main
+
+fn shuffle_impl<T>(mut a []T) ? {
+	println('FN: ${@FN:20} | T: ${typeof(a).name}')
+}
+
+fn shuffle<T>(mut a []T) ? {
+	println('FN: ${@FN:20} | T: ${typeof(a).name}')
+	shuffle_impl(mut a)?
+}
+
+fn main() {
+	mut a := [1, 2]
+	mut b := [f64(1.0), 2.0]
+	shuffle<int>(mut a)?
+	shuffle<f64>(mut b)?
+}

--- a/vlib/v/tests/generic_fn_infer_multi_paras_test.v
+++ b/vlib/v/tests/generic_fn_infer_multi_paras_test.v
@@ -26,7 +26,7 @@ fn get_keys_and_values<T>(mut keys []string, mut values []string, mut data T) ([
 fn awesome<T>(mut data T) {
 	mut keys := []string{}
 	mut values := []string{}
-	keys, values, data = get_keys_and_values(mut keys, mut values, mut data)
+	keys, values, data = get_keys_and_values<T>(mut keys, mut values, mut data)
 	println(keys)
 	assert keys == ['lang', 'page', 'var_one', 'var_two']
 	println(values)

--- a/vlib/v/tests/generic_fn_infer_nested_generic_fn_test.v
+++ b/vlib/v/tests/generic_fn_infer_nested_generic_fn_test.v
@@ -34,9 +34,9 @@ fn walk<T>(path string, mut array []T) {
 	for file in files {
 		p := path + os.path_separator + file
 		if os.is_dir(p) && !os.is_link(p) {
-			walk(p, mut array)
+			walk<T>(p, mut array)
 		} else if os.exists(p) {
-			parse_json(p, mut array)
+			parse_json<T>(p, mut array)
 		}
 	}
 }

--- a/vlib/v/tests/generics_with_cascaded_multiple_nested_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_cascaded_multiple_nested_generics_fn_test.v
@@ -14,22 +14,7 @@ fn gfn4<T>(var T) T {
 	return gfn3<T>(var)
 }
 
-// don't give concrete types
-fn gfn2_infer<T>(var T) T {
-	return gfn1(var)
-}
-
-fn gfn3_infer<T>(var T) T {
-	return gfn2_infer(var)
-}
-
-fn gfn4_infer<T>(var T) T {
-	return gfn3_infer(var)
-}
-
 fn test_generics_with_cascaded_multiple_nested_generics_fn() {
 	println(gfn4(1234))
 	assert gfn4(1234) == 1234
-	println(gfn4_infer(1234))
-	assert gfn4_infer(1234) == 1234
 }


### PR DESCRIPTION
This PR check incorrect generic fn call inside generic fn (fix #15328).

- Check incorrect generic fn call inside generic fn.
- Add test.
- Fix all the related errors.

```v
module main

fn shuffle_impl<T>(mut a []T) ? {
	println('FN: ${@FN:20} | T: ${typeof(a).name}')
}

fn shuffle<T>(mut a []T) ? {
	println('FN: ${@FN:20} | T: ${typeof(a).name}')
	shuffle_impl(mut a)?
}

fn main() {
	mut a := [1, 2]
	mut b := [f64(1.0), 2.0]
	shuffle<int>(mut a)?
	shuffle<f64>(mut b)?
}

PS D:\Test\v\tt1> v run .
./tt1.v:9:2: error: generic fn call inside generic fn must specify the generic type names, e.g. foo<T>()
    7 | fn shuffle<T>(mut a []T) ? {
    8 |     println('FN: ${@FN:20} | T: ${typeof(a).name}')
    9 |     shuffle_impl(mut a)?
      |     ~~~~~~~~~~~~~~~~~~~
   10 | }
   11 |
```