### PR TITLE
checker: disallow method calls with invalid expressions

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1114,7 +1114,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	left_type := c.expr(node.left)
 	if left_type == ast.void_type {
-		c.error("cannot call a method using an invalid expression", node.pos)
+		c.error('cannot call a method using an invalid expression', node.pos)
 		return ast.void_type
 	}
 	c.expected_type = left_type

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1113,6 +1113,10 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 
 pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	left_type := c.expr(node.left)
+	if left_type == ast.void_type {
+		c.error("cannot call method using an invalid expression", node.pos)
+		return ast.void_type
+	}
 	c.expected_type = left_type
 	mut is_generic := left_type.has_flag(.generic)
 	node.left_type = left_type

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1114,7 +1114,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	left_type := c.expr(node.left)
 	if left_type == ast.void_type {
-		c.error("cannot call method using an invalid expression", node.pos)
+		c.error("cannot call a method using an invalid expression", node.pos)
 		return ast.void_type
 	}
 	c.expected_type = left_type

--- a/vlib/v/checker/tests/void_method_call.out
+++ b/vlib/v/checker/tests/void_method_call.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/void_method_call.vv:5:17: error: cannot call a method using an invalid expression
+    3 |
+    4 | fn main() {
+    5 |     simple_fn().method()
+      |                 ~~~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/void_method_call.vv
+++ b/vlib/v/checker/tests/void_method_call.vv
@@ -1,0 +1,6 @@
+fn simple_fn() {
+}
+
+fn main() {
+    simple_fn().method()
+}


### PR DESCRIPTION
There used to be an error showing that the type `void` had no such method, but that check was removed.

This PR redoes that check and throws an error when a method is called using an expression whose result type is `void`.

Fix #15324.