### PR TITLE
checker: disallow use of `nil` when a pointer is not expected

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -264,7 +264,7 @@ pub fn vfopen(path string, mode string) ?&C.FILE {
 	if path.len == 0 {
 		return error('vfopen called with ""')
 	}
-	mut fp := $if windows {
+	fp := $if windows {
 		C._wfopen(path.to_wide(), mode.to_wide())
 	} $else {
 		C.fopen(&char(path.str), &char(mode.str))

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -264,11 +264,10 @@ pub fn vfopen(path string, mode string) ?&C.FILE {
 	if path.len == 0 {
 		return error('vfopen called with ""')
 	}
-	mut fp := unsafe { nil }
-	$if windows {
-		fp = C._wfopen(path.to_wide(), mode.to_wide())
+	mut fp := $if windows {
+		C._wfopen(path.to_wide(), mode.to_wide())
 	} $else {
-		fp = C.fopen(&char(path.str), &char(mode.str))
+		C.fopen(&char(path.str), &char(mode.str))
 	}
 	if isnil(fp) {
 		return error('failed to open file "$path"')

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -124,7 +124,7 @@ pub fn (mut ch Channel) close() {
 	if !C.atomic_compare_exchange_strong_u16(&ch.closed, &open_val, 1) {
 		return
 	}
-	mut nulladr := unsafe { nil }
+	mut nulladr := unsafe { voidptr(nil) }
 	for !C.atomic_compare_exchange_weak_ptr(unsafe { &voidptr(&ch.adr_written) }, &nulladr,
 		voidptr(-1)) {
 		nulladr = unsafe { nil }

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -191,7 +191,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			{
 				// there is a reader waiting for us
 				unsafe { C.memcpy(wradr, src, ch.objsize) }
-				mut nulladr := unsafe { nil }
+				mut nulladr := voidptr(unsafe { nil })
 				for !C.atomic_compare_exchange_weak_ptr(unsafe { &voidptr(&ch.adr_written) },
 					&nulladr, wradr) {
 					nulladr = unsafe { nil }
@@ -382,7 +382,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 				{
 					// there is a writer waiting for us
 					unsafe { C.memcpy(dest, rdadr, ch.objsize) }
-					mut nulladr := unsafe { nil }
+					mut nulladr := voidptr(unsafe { nil })
 					for !C.atomic_compare_exchange_weak_ptr(unsafe { &voidptr(&ch.adr_read) },
 						&nulladr, rdadr) {
 						nulladr = unsafe { nil }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2357,6 +2357,12 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	// Given: `Outside( Inside(xyz) )`,
 	//        node.expr_type: `Inside`
 	//        node.typ: `Outside`
+	old_expected_type := c.expected_type
+	c.expected_type = node.typ
+	defer {
+		c.expected_type = old_expected_type
+	}
+
 	node.expr_type = c.expr(node.expr) // type to be casted
 
 	mut from_type := c.unwrap_generic(node.expr_type)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2235,7 +2235,8 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 		ast.Nil {
 			if !c.inside_unsafe {
 				c.error('`nil` is only allowed in `unsafe` code', node.pos)
-			} else if c.expected_type != ast.void_type && !c.expected_type.is_any_kind_of_pointer() {
+			} else if !c.pref.backend.is_js() && c.expected_type != ast.void_type
+				&& !c.expected_type.is_any_kind_of_pointer() {
 				c.error('`nil` can only be used with pointers', node.pos)
 			}
 			return ast.nil_type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2235,6 +2235,8 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 		ast.Nil {
 			if !c.inside_unsafe {
 				c.error('`nil` is only allowed in `unsafe` code', node.pos)
+			} else if c.expected_type != ast.void_type && !c.expected_type.is_any_kind_of_pointer() {
+				c.error('`nil` can only be used with pointers', node.pos)
 			}
 			return ast.nil_type
 		}


### PR DESCRIPTION
This PR disallow the use of `nil` where a pointer is not expected.

Fix #15201.