### PR TITLE
checker: check generic interface missing type parameter (fix #15342)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -24,6 +24,30 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 							node.elem_type_pos)
 					}
 				}
+			} else if elem_sym.kind == .interface_ {
+				elem_info := elem_sym.info as ast.Interface
+				if elem_info.generic_types.len > 0 && elem_info.concrete_types.len == 0
+					&& !node.elem_type.has_flag(.generic) {
+					if c.table.cur_concrete_types.len == 0 {
+						c.error('generic interface must specify type parameter, e.g. Foo<int>',
+							node.elem_type_pos)
+					} else {
+						c.error('generic interface must specify type parameter, e.g. Foo<T>',
+							node.elem_type_pos)
+					}
+				}
+			} else if elem_sym.kind == .sum_type {
+				elem_info := elem_sym.info as ast.SumType
+				if elem_info.generic_types.len > 0 && elem_info.concrete_types.len == 0
+					&& !node.elem_type.has_flag(.generic) {
+					if c.table.cur_concrete_types.len == 0 {
+						c.error('generic sumtype must specify type parameter, e.g. Foo<int>',
+							node.elem_type_pos)
+					} else {
+						c.error('generic sumtype must specify type parameter, e.g. Foo<T>',
+							node.elem_type_pos)
+					}
+				}
 			}
 		}
 		if node.exprs.len == 0 {

--- a/vlib/v/checker/tests/generic_interface_missing_type_names_err.out
+++ b/vlib/v/checker/tests/generic_interface_missing_type_names_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generic_interface_missing_type_names_err.vv:16:17: error: generic interface must specify type parameter, e.g. Foo<int>
+   14 |
+   15 | fn main() {
+   16 |   mut outs := []Output{}
+      |                 ~~~~~~
+   17 |   outs << Coil { name: 'outhole' }
+   18 |   outs << Light { name: 'shoot again' }

--- a/vlib/v/checker/tests/generic_interface_missing_type_names_err.vv
+++ b/vlib/v/checker/tests/generic_interface_missing_type_names_err.vv
@@ -1,0 +1,19 @@
+interface Output<T> {
+  val T
+  name string
+}
+
+struct Coil {
+  pub mut: val int
+  pub: name string [required]
+}
+struct Light {
+  pub mut: val int
+  pub: name string [required]
+}
+
+fn main() {
+  mut outs := []Output{}
+  outs << Coil { name: 'outhole' }
+  outs << Light { name: 'shoot again' }
+}


### PR DESCRIPTION
This PR check generic interface missing type parameter (fix #15342).

- Check generic interface missing type parameter.
- Add test.

```v
interface Output<T> {
  val T
  name string
}

struct Coil {
  pub mut: val int
  pub: name string [required]
}
struct Light {
  pub mut: val int
  pub: name string [required]
}

fn main() {
  mut outs := []Output{}
  outs << Coil { name: 'outhole' }
  outs << Light { name: 'shoot again' }
}

PS D:\Test\v\tt1> v run .
./tt1.v:16:17: error: generic interface must specify type parameter, e.g. Foo<int>
   14 |
   15 | fn main() {
   16 |   mut outs := []Output{}
      |                 ~~~~~~
   17 |   outs << Coil { name: 'outhole' }
   18 |   outs << Light { name: 'shoot again' }
```