### PR TITLE
cgen: fix generic interface call with reference argument (fix #15341)

### DIFF
--- a/vlib/v/tests/inout/dump_generic_interface_ref_arg.out
+++ b/vlib/v/tests/inout/dump_generic_interface_ref_arg.out
@@ -1,0 +1,6 @@
+[vlib/v/tests/inout/dump_generic_interface_ref_arg.vv:30] mi.in_(): 1.
+[vlib/v/tests/inout/dump_generic_interface_ref_arg.vv:31] mi.out(): 2.
+[vlib/v/tests/inout/dump_generic_interface_ref_arg.vv:36] in_put.in_(): 1.
+[vlib/v/tests/inout/dump_generic_interface_ref_arg.vv:37] in_put.out(): 2.
+[vlib/v/tests/inout/dump_generic_interface_ref_arg.vv:39] in_put.in_(): 1.
+[vlib/v/tests/inout/dump_generic_interface_ref_arg.vv:40] in_put.out(): 2.

--- a/vlib/v/tests/inout/dump_generic_interface_ref_arg.vv
+++ b/vlib/v/tests/inout/dump_generic_interface_ref_arg.vv
@@ -1,0 +1,46 @@
+interface In {
+	in_() f64
+}
+
+interface Out {
+	out() f64
+}
+
+interface InOut {
+}
+
+struct MyImpl {
+	in_ f64
+	out f64
+}
+
+pub fn (mi &MyImpl) in_() f64 {
+	return mi.in_
+}
+
+pub fn (mi &MyImpl) out() f64 {
+	return mi.out
+}
+
+fn main() {
+	mi := MyImpl{
+		in_: 1.0
+		out: 2.0
+	}
+	dump(mi.in_())
+	dump(mi.out())
+	run(&mi)
+}
+
+fn run<T>(in_put T) {
+	dump(in_put.in_())
+	dump(in_put.out())
+	$if T is InOut {
+		dump(in_put.in_())
+		dump(in_put.out())
+	} $else $if T is In {
+		dump(in_put.in_())
+	} $else $if T is Out {
+		dump(in_put.out())
+	}
+}


### PR DESCRIPTION
This PR fix generic interface call with reference argument (fix #15341).

- Fix generic interface call with reference argument.
- Add test.

```v
interface In {
	in_() f64
}

interface Out {
	out() f64
}

interface InOut {
}

struct MyImpl {
	in_ f64
	out f64
}

pub fn (mi &MyImpl) in_() f64 {
	return mi.in_
}

pub fn (mi &MyImpl) out() f64 {
	return mi.out
}

fn main() {
	mi := MyImpl{
		in_: 1.0
		out: 2.0
	}
	dump(mi.in_())
	dump(mi.out())
	run(&mi)
}

fn run<T>(in_put T) {
	dump(in_put.in_())
	dump(in_put.out())
	$if T is InOut {
		dump(in_put.in_())
		dump(in_put.out())
	} $else $if T is In {
		dump(in_put.in_())
	} $else $if T is Out {
		dump(in_put.out())
	}
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:30] mi.in_(): 1.
[.\\tt1.v:31] mi.out(): 2.
[.\\tt1.v:36] in_put.in_(): 1.
[.\\tt1.v:37] in_put.out(): 2.
[.\\tt1.v:39] in_put.in_(): 1.
[.\\tt1.v:40] in_put.out(): 2.
```