### PR TITLE
cgen: fix nested generic fn call with reference argument (fix #15349)

### DIFF
--- a/vlib/v/tests/generic_fn_call_with_reference_argument_test.v
+++ b/vlib/v/tests/generic_fn_call_with_reference_argument_test.v
@@ -6,7 +6,7 @@ struct ContainerType<T> {
 	typ &Type<T>
 }
 
-fn (instance &ContainerType<T>) contains(typ Type<T>) bool {
+fn (instance &ContainerType<T>) contains(typ &Type<T>) bool {
 	println(typ)
 	if instance.typ == typ {
 		return true

--- a/vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.out
+++ b/vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.out
@@ -1,0 +1,23 @@
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:19] '$T.name $input': int 1
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:26] '$T.name $input': int 1
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:36] next(1): 0
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:19] '$T.name $input': f64 1.
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:26] '$T.name $input': f64 1.
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:37] next(1.0): 64.
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:19] '$T.name $input': f64 11.1
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:26] '$T.name $input': f64 11.1
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:38] next(11.1): 64.
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:15] '$T.name $input': Score Score{
+    ave: 23.4
+}
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:26] '$T.name $input': Score Score{
+    ave: 23.4
+}
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:42] next(ave): 23.4
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:15] '$T.name $input': &Score &Score{
+    ave: 23.4
+}
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:26] '$T.name $input': &Score &Score{
+    ave: 23.4
+}
+[vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv:43] next(&ave): 23.4

--- a/vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv
+++ b/vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv
@@ -1,0 +1,44 @@
+interface Average {
+	ave() f64
+}
+
+struct Score {
+	ave f64
+}
+
+pub fn (s &Score) ave() f64 {
+	return s.ave
+}
+
+fn next<T>(input T) f64 {
+	$if T is Average {
+		dump('${T.name} $input')
+		ret := next2<T>(input)
+		return ret
+	} $else {
+		dump('${T.name} $input')
+		ret := next2<T>(input)
+		return ret
+	}
+}
+
+fn next2<T>(input T) f64 {
+	dump('${T.name} $input')
+	$if T is Average {
+		return input.ave()
+	} $else $if T is f64 {
+		return 64.0
+	}
+	return 0.0
+}
+
+fn main() {
+	dump(next(1))
+	dump(next(1.0))
+	dump(next(11.1))
+	ave := Score {
+		ave: 23.4
+	}
+	dump(next(ave))
+	dump(next(&ave))
+}


### PR DESCRIPTION
This PR fix nested generic fn call with reference argument (fix #15349).

- Fix nested generic fn call with reference argument.
- Add test.

```v
interface Average {
	ave() f64
}

struct Score {
	ave f64
}

pub fn (s &Score) ave() f64 {
	return s.ave
}

fn next<T>(input T) f64 {
	$if T is Average {
		dump('${T.name} $input')
		return next2<T>(input)
	} $else {
		dump('${T.name} $input')
		return next2<T>(input)
	}
}

fn next2<T>(input T) f64 {
	dump('${T.name} $input')
	$if T is Average {
		return input.ave()
	} $else $if T is f64 {
		return 64.0
	}
	return 0.0
}

fn main() {
	dump(next(1))
	dump(next(1.0))
	dump(next(11.1))
	ave := Score {
		ave: 23.4
	}
	dump(next(ave))
	dump(next(&ave))
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:19] '$T.name $input': int 1
[.\\tt1.v:26] '$T.name $input': int 1
[.\\tt1.v:36] next(1): 0
[.\\tt1.v:19] '$T.name $input': f64 1.
[.\\tt1.v:26] '$T.name $input': f64 1.
[.\\tt1.v:37] next(1.0): 64.
[.\\tt1.v:19] '$T.name $input': f64 11.1
[.\\tt1.v:26] '$T.name $input': f64 11.1
[.\\tt1.v:38] next(11.1): 64.
[.\\tt1.v:15] '$T.name $input': Score Score{
    ave: 23.4
}
[.\\tt1.v:26] '$T.name $input': Score Score{
    ave: 23.4
}
[.\\tt1.v:42] next(ave): 23.4
[.\\tt1.v:15] '$T.name $input': &Score &Score{
    ave: 23.4
}
[.\\tt1.v:26] '$T.name $input': &Score &Score{
    ave: 23.4
}
[.\\tt1.v:43] next(&ave): 23.4
```