### PR TITLE
net: connect error contains addrs, and why they failed

### DIFF
--- a/examples/net_failconnect.v
+++ b/examples/net_failconnect.v
@@ -1,0 +1,5 @@
+import net
+
+conn := net.dial_tcp('[::1]:57000')?
+peer_addr := conn.peer_addr()?
+println('$peer_addr')

--- a/vlib/net/errors.v
+++ b/vlib/net/errors.v
@@ -12,12 +12,13 @@ pub const (
 		errors_base + 2)
 	err_option_wrong_type   = error_with_code('net: set_option_xxx option wrong type',
 		errors_base + 3)
-	err_port_out_of_range   = error_with_code('', errors_base + 5)
-	err_no_udp_remote       = error_with_code('', errors_base + 6)
+	err_port_out_of_range   = error_with_code('net: port out of range', errors_base + 5)
+	err_no_udp_remote       = error_with_code('net: no udp remote', errors_base + 6)
 	err_connect_failed      = error_with_code('net: connect failed', errors_base + 7)
 	err_connect_timed_out   = error_with_code('net: connect timed out', errors_base + 8)
 	err_timed_out           = error_with_code('net: op timed out', errors_base + 9)
 	err_timed_out_code      = errors_base + 9
+	err_connection_refused  = error_with_code('net: connection refused', errors_base + 10)
 )
 
 pub fn socket_error_message(potential_code int, s string) ?int {
@@ -43,13 +44,13 @@ pub fn socket_error(potential_code int) ?int {
 }
 
 pub fn wrap_error(error_code int) ? {
+	if error_code == 0 {
+		return
+	}
 	$if windows {
 		enum_error := wsa_error(error_code)
 		return error_with_code('net: socket error: $enum_error', error_code)
 	} $else {
-		if error_code == 0 {
-			return
-		}
 		return error_with_code('net: socket error: $error_code', error_code)
 	}
 }

--- a/vlib/net/net_nix.c.v
+++ b/vlib/net/net_nix.c.v
@@ -23,4 +23,5 @@ pub const (
 
 const (
 	error_ewouldblock = C.EWOULDBLOCK
+	error_einprogress = C.EINPROGRESS
 )

--- a/vlib/net/net_nix.c.v
+++ b/vlib/net/net_nix.c.v
@@ -10,6 +10,8 @@ module net
 
 #flag solaris -lsocket
 
+const is_windows = false
+
 fn error_code() int {
 	return C.errno
 }

--- a/vlib/net/net_windows.c.v
+++ b/vlib/net/net_windows.c.v
@@ -1,5 +1,7 @@
 module net
 
+const is_windows = true
+
 // WsaError is all of the socket errors that WSA provides from WSAGetLastError
 pub enum WsaError {
 	//

--- a/vlib/net/net_windows.c.v
+++ b/vlib/net/net_windows.c.v
@@ -739,6 +739,7 @@ pub fn wsa_error(code int) WsaError {
 
 const (
 	error_ewouldblock = WsaError.wsaewouldblock
+	error_einprogress = WsaError.wsaeinprogress
 )
 
 // Link to Winsock library

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -451,8 +451,7 @@ fn (mut s TcpSocket) connect(a Addr) ? {
 
 		// On nix non-blocking sockets we expect einprogress
 		// On windows we expect res == -1 && error_code() == ewouldblock
-		if res == int(error_einprogress) || 
-			error_code() == int(error_ewouldblock) {
+		if res == int(error_einprogress) || error_code() == int(error_ewouldblock) {
 			// The  socket  is  nonblocking and the connection cannot be completed
 			// immediately.  (UNIX domain sockets failed with EAGAIN instead.)
 			// It is possible to select(2) or poll(2) for completion by selecting

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -451,7 +451,8 @@ fn (mut s TcpSocket) connect(a Addr) ? {
 
 		// On nix non-blocking sockets we expect einprogress
 		// On windows we expect res == -1 && error_code() == ewouldblock
-		if res == int(error_einprogress) || error_code() == int(error_ewouldblock) {
+		if (is_windows && error_code() == int(error_ewouldblock))
+			|| (!is_windows && res == -1 && error_code() == int(error_einprogress)) {
 			// The  socket  is  nonblocking and the connection cannot be completed
 			// immediately.  (UNIX domain sockets failed with EAGAIN instead.)
 			// It is possible to select(2) or poll(2) for completion by selecting

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -1,6 +1,7 @@
 module net
 
 import time
+import strings
 
 const (
 	tcp_default_read_timeout  = 30 * time.second
@@ -24,12 +25,16 @@ pub fn dial_tcp(address string) ?&TcpConn {
 		return error('$err.msg(); could not resolve address $address in dial_tcp')
 	}
 
+	// Keep track of dialing errors that take place
+	mut errs := []IError{}
+
 	// Very simple dialer
 	for addr in addrs {
 		mut s := new_tcp_socket(addr.family()) or {
 			return error('$err.msg(); could not create new tcp socket in dial_tcp')
 		}
 		s.connect(addr) or {
+			errs << err
 			// Connection failed
 			s.close() or { continue }
 			continue
@@ -41,8 +46,20 @@ pub fn dial_tcp(address string) ?&TcpConn {
 			write_timeout: net.tcp_default_write_timeout
 		}
 	}
+
+	// Once we've failed now try and explain why we failed to connect
+	// to any of these addresses
+	mut err_builder := strings.new_builder(1024)
+	err_builder.write_string('dial_tcp failed for address $address\n')
+	err_builder.write_string('tried addrs:\n')
+	for i := 0; i < errs.len; i++ {
+		addr := addrs[i]
+		why := errs[i]
+		err_builder.write_string('\t$addr: $why\n')
+	}
+
 	// failed
-	return error('dial_tcp failed for address $address')
+	return error(err_builder.str())
 }
 
 // bind local address and dail.
@@ -432,32 +449,35 @@ fn (mut s TcpSocket) connect(a Addr) ? {
 			return
 		}
 
-		// The  socket  is  nonblocking and the connection cannot be completed
-		// immediately.  (UNIX domain sockets failed with EAGAIN instead.)
-		// It is possible to select(2) or poll(2) for completion by selecting
-		// the socket for  writing.   After  select(2) indicates  writability,
-		// use getsockopt(2) to read the SO_ERROR option at level SOL_SOCKET to
-		// determine whether connect() completed successfully (SO_ERROR is zero) or
-		// unsuccessfully (SO_ERROR is one of the usual error codes  listed  here,
-		// ex‐ plaining the reason for the failure).
-		write_result := s.@select(.write, net.connect_timeout)?
-		if write_result {
-			err := 0
-			len := sizeof(err)
-			socket_error(C.getsockopt(s.handle, C.SOL_SOCKET, C.SO_ERROR, &err, &len))?
+		// On nix non-blocking sockets we expect einprogress
+		// On windows we expect res == -1 && error_code() == ewouldblock
+		if res == int(error_einprogress) || 
+			error_code() == int(error_ewouldblock) {
+			// The  socket  is  nonblocking and the connection cannot be completed
+			// immediately.  (UNIX domain sockets failed with EAGAIN instead.)
+			// It is possible to select(2) or poll(2) for completion by selecting
+			// the socket for  writing.   After  select(2) indicates  writability,
+			// use getsockopt(2) to read the SO_ERROR option at level SOL_SOCKET to
+			// determine whether connect() completed successfully (SO_ERROR is zero) or
+			// unsuccessfully (SO_ERROR is one of the usual error codes  listed  here,
+			// ex‐ plaining the reason for the failure).
+			write_result := s.@select(.write, net.connect_timeout)?
+			if write_result {
+				err := 0
+				len := sizeof(err)
+				socket_error(C.getsockopt(s.handle, C.SOL_SOCKET, C.SO_ERROR, &err, &len))?
 
-			if err != 0 {
-				return wrap_error(err)
+				if err != 0 {
+					return wrap_error(err)
+				}
+				// Succeeded
+				return
 			}
-			// Succeeded
-			return
+			return err_timed_out
 		}
+		socket_error(res)?
 
-		// Get the error
-		socket_error(C.connect(s.handle, voidptr(&a), a.len()))?
-
-		// otherwise we timed out
-		return err_connect_timed_out
+		return
 	} $else {
 		socket_error(C.connect(s.handle, voidptr(&a), a.len()))?
 	}

--- a/vlib/net/tcp_self_dial_from_many_clients_test.v
+++ b/vlib/net/tcp_self_dial_from_many_clients_test.v
@@ -74,9 +74,7 @@ fn test_tcp_self_dialing() {
 		if dt > max_dt {
 			eprintln('>>> exiting after $dt.milliseconds() ms ...')
 			dump(ctx)
-			if ctx.fail_client_dials > 2 {
-				assert false, 'failed $ctx.fail_client_dials client dials'
-			}
+			assert ctx.fail_client_dials < 2, 'allowed failed client dials, from $ctx.ok_server_accepts connections'
 			exit(0)
 		}
 		time.sleep(10 * time.millisecond)

--- a/vlib/net/tcp_self_dial_from_many_clients_test.v
+++ b/vlib/net/tcp_self_dial_from_many_clients_test.v
@@ -12,9 +12,30 @@ mut:
 	//
 	ok_client_close   int
 	fail_client_close int
-	//
+	////
 	ok_server_accepts   int
 	fail_server_accepts int
+	//
+	ok_server_close   int
+	fail_server_close int
+	//
+	received []int
+}
+
+fn receive_data(mut con net.TcpConn, mut ctx Context) {
+	mut buf := []u8{len: 5}
+	for {
+		bytes := con.read(mut buf) or { -1 }
+		if bytes < 0 {
+			break
+		}
+		ctx.received << buf[0]
+	}
+	con.close() or {
+		ctx.fail_server_close++
+		return
+	}
+	ctx.ok_server_close++
 }
 
 fn start_server(schannel chan int, mut ctx Context) {
@@ -27,11 +48,12 @@ fn start_server(schannel chan int, mut ctx Context) {
 	schannel <- 0
 
 	for {
-		tcp_con := tcp_listener.accept() or {
+		mut tcp_con := tcp_listener.accept() or {
 			eprintln('server: accept error: $err')
 			ctx.fail_server_accepts++
 			continue
 		}
+		go receive_data(mut tcp_con, mut ctx)
 		ctx.ok_server_accepts++
 		eprintln('server: new tcp connection con.sock.handle: $tcp_con.sock.handle')
 		continue
@@ -47,6 +69,7 @@ fn start_client(i int, mut ctx Context) {
 	}
 	ctx.ok_client_dials++
 	eprintln('client [$i]: conn is connected, con.sock.handle: $tcp_con.sock.handle')
+	tcp_con.write([u8(i)]) or { eprintln('client [$i]: write failed, err: $err') }
 	tcp_con.close() or {
 		eprintln('client [$i]: close failed, err: $err')
 		ctx.fail_client_close++
@@ -65,7 +88,7 @@ fn test_tcp_self_dialing() {
 	for i := int(0); i < 20; i++ {
 		go start_client(i, mut ctx)
 		eprintln('>>> started client $i')
-		time.sleep(10 * time.millisecond)
+		// time.sleep(2 * time.millisecond)
 	}
 	max_dt := 5 * time.second
 	for {
@@ -75,6 +98,7 @@ fn test_tcp_self_dialing() {
 			eprintln('>>> exiting after $dt.milliseconds() ms ...')
 			dump(ctx)
 			assert ctx.fail_client_dials < 2, 'allowed failed client dials, from $ctx.ok_server_accepts connections'
+			assert ctx.received.len > ctx.ok_server_accepts / 2, 'at least half the clients sent some data, that was later received by the server'
 			exit(0)
 		}
 		time.sleep(10 * time.millisecond)

--- a/vlib/net/tcp_self_dial_from_many_clients_test.v
+++ b/vlib/net/tcp_self_dial_from_many_clients_test.v
@@ -22,6 +22,10 @@ mut:
 	received []int
 }
 
+fn elog(msg string) {
+	eprintln('$time.now().format_ss_micro() | $msg')
+}
+
 fn receive_data(mut con net.TcpConn, mut ctx Context) {
 	mut buf := []u8{len: 5}
 	for {
@@ -39,39 +43,41 @@ fn receive_data(mut con net.TcpConn, mut ctx Context) {
 }
 
 fn start_server(schannel chan int, mut ctx Context) {
-	eprintln('server: start_server')
+	elog('server: start_server')
 	mut tcp_listener := net.listen_tcp(net.AddrFamily.ip, ':$xport') or {
-		eprintln('server: start server error $err')
+		elog('server: start server error $err')
 		return
 	}
-	eprintln('server: server started listening at port :$xport')
+	elog('server: server started listening at port :$xport')
 	schannel <- 0
 
 	for {
 		mut tcp_con := tcp_listener.accept() or {
-			eprintln('server: accept error: $err')
+			elog('server: accept error: $err')
 			ctx.fail_server_accepts++
 			continue
 		}
 		go receive_data(mut tcp_con, mut ctx)
 		ctx.ok_server_accepts++
-		eprintln('server: new tcp connection con.sock.handle: $tcp_con.sock.handle')
+		elog('server: new tcp connection con.sock.handle: $tcp_con.sock.handle')
 		continue
 	}
 }
 
 fn start_client(i int, mut ctx Context) {
-	eprintln('client [$i]: start')
+	elog('client [$i]: start')
 	mut tcp_con := net.dial_tcp('127.0.0.1:$xport') or {
-		eprintln('client [$i]: net.dial_tcp err $err')
+		elog('client [$i]: net.dial_tcp err $err')
 		ctx.fail_client_dials++
 		return
 	}
 	ctx.ok_client_dials++
-	eprintln('client [$i]: conn is connected, con.sock.handle: $tcp_con.sock.handle')
-	tcp_con.write([u8(i)]) or { eprintln('client [$i]: write failed, err: $err') }
+	elog('client [$i]: conn is connected, con.sock.handle: $tcp_con.sock.handle')
+	tcp_con.write([u8(i)]) or { elog('client [$i]: write failed, err: $err') }
+	time.sleep(1 * time.second)
+	elog('client [$i]: closing connection...')
 	tcp_con.close() or {
-		eprintln('client [$i]: close failed, err: $err')
+		elog('client [$i]: close failed, err: $err')
 		ctx.fail_client_close++
 		return
 	}
@@ -79,15 +85,16 @@ fn start_client(i int, mut ctx Context) {
 }
 
 fn test_tcp_self_dialing() {
+	elog('>>> start')
 	start_time := time.now()
 	mut ctx := &Context{}
 	mut server_channel := chan int{cap: 1}
 	go start_server(server_channel, mut ctx)
 	svalue := <-server_channel
-	eprintln('>>> server was started: ${svalue}. Starting clients:')
+	elog('>>> server was started: ${svalue}. Starting clients:')
 	for i := int(0); i < 20; i++ {
 		go start_client(i, mut ctx)
-		eprintln('>>> started client $i')
+		elog('>>> started client $i')
 		// time.sleep(2 * time.millisecond)
 	}
 	max_dt := 5 * time.second
@@ -95,10 +102,11 @@ fn test_tcp_self_dialing() {
 		t := time.now()
 		dt := t - start_time
 		if dt > max_dt {
-			eprintln('>>> exiting after $dt.milliseconds() ms ...')
+			elog('>>> exiting after $dt.milliseconds() ms ...')
 			dump(ctx)
 			assert ctx.fail_client_dials < 2, 'allowed failed client dials, from $ctx.ok_server_accepts connections'
 			assert ctx.received.len > ctx.ok_server_accepts / 2, 'at least half the clients sent some data, that was later received by the server'
+			elog('>>> goodbye')
 			exit(0)
 		}
 		time.sleep(10 * time.millisecond)

--- a/vlib/net/tcp_self_dial_from_many_clients_test.v
+++ b/vlib/net/tcp_self_dial_from_many_clients_test.v
@@ -1,0 +1,84 @@
+module main
+
+import net
+import time
+
+const xport = 15523
+
+struct Context {
+mut:
+	ok_client_dials   int
+	fail_client_dials int
+	//
+	ok_client_close   int
+	fail_client_close int
+	//
+	ok_server_accepts   int
+	fail_server_accepts int
+}
+
+fn start_server(schannel chan int, mut ctx Context) {
+	eprintln('server: start_server')
+	mut tcp_listener := net.listen_tcp(net.AddrFamily.ip, ':$xport') or {
+		eprintln('server: start server error $err')
+		return
+	}
+	eprintln('server: server started listening at port :$xport')
+	schannel <- 0
+
+	for {
+		tcp_con := tcp_listener.accept() or {
+			eprintln('server: accept error: $err')
+			ctx.fail_server_accepts++
+			continue
+		}
+		ctx.ok_server_accepts++
+		eprintln('server: new tcp connection con.sock.handle: $tcp_con.sock.handle')
+		continue
+	}
+}
+
+fn start_client(i int, mut ctx Context) {
+	eprintln('client [$i]: start')
+	mut tcp_con := net.dial_tcp('127.0.0.1:$xport') or {
+		eprintln('client [$i]: net.dial_tcp err $err')
+		ctx.fail_client_dials++
+		return
+	}
+	ctx.ok_client_dials++
+	eprintln('client [$i]: conn is connected, con.sock.handle: $tcp_con.sock.handle')
+	tcp_con.close() or {
+		eprintln('client [$i]: close failed, err: $err')
+		ctx.fail_client_close++
+		return
+	}
+	ctx.ok_client_close++
+}
+
+fn test_tcp_self_dialing() {
+	start_time := time.now()
+	mut ctx := &Context{}
+	mut server_channel := chan int{cap: 1}
+	go start_server(server_channel, mut ctx)
+	svalue := <-server_channel
+	eprintln('>>> server was started: ${svalue}. Starting clients:')
+	for i := int(0); i < 20; i++ {
+		go start_client(i, mut ctx)
+		eprintln('>>> started client $i')
+		time.sleep(10 * time.millisecond)
+	}
+	max_dt := 5 * time.second
+	for {
+		t := time.now()
+		dt := t - start_time
+		if dt > max_dt {
+			eprintln('>>> exiting after $dt.milliseconds() ms ...')
+			dump(ctx)
+			if ctx.fail_client_dials > 2 {
+				assert false, 'failed $ctx.fail_client_dials client dials'
+			}
+			exit(0)
+		}
+		time.sleep(10 * time.millisecond)
+	}
+}

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -269,6 +269,7 @@ fn simple_tcp_client(config SimpleTcpClientConfig) ?string {
 	mut tries := 0
 	for tries < config.retries {
 		tries++
+		eprintln('> client retries: $tries')
 		client = net.dial_tcp(localserver) or {
 			if tries > config.retries {
 				return err
@@ -277,6 +278,10 @@ fn simple_tcp_client(config SimpleTcpClientConfig) ?string {
 			continue
 		}
 		break
+	}
+	if client == unsafe { nil } {
+		eprintln('coult not create a tcp client connection to $localserver after $config.retries retries')
+		exit(1)
 	}
 	client.set_read_timeout(tcp_r_timeout)
 	client.set_write_timeout(tcp_w_timeout)

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -21,7 +21,7 @@ struct Config {
 
 fn exit_after_timeout(timeout_in_ms int) {
 	time.sleep(timeout_in_ms * time.millisecond)
-	// eprintln('webserver is exiting ...')
+	println('>> webserver: pid: $os.getpid(), exiting ...')
 	exit(0)
 }
 
@@ -43,7 +43,7 @@ fn main() {
 		timeout: timeout
 		global_config: config
 	}
-	eprintln('>> webserver: started on http://localhost:$app.port/ , with maximum runtime of $app.timeout milliseconds.')
+	eprintln('>> webserver: pid: $os.getpid(), started on http://localhost:$app.port/ , with maximum runtime of $app.timeout milliseconds.')
 	vweb.run_at(app, host: 'localhost', port: http_port, family: .ip)?
 }
 


### PR DESCRIPTION
Resolves #15336 where the socket error is quered incorrectly, resulting in error 56 returned. Also adds better logging as to why your dial_tcp() failed.

This supercedes and therefore closes #15335