### PR TITLE
http: avoid costly string interpolation of resp.body

### DIFF
--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -31,7 +31,7 @@ pub fn (resp Response) bytes() []u8 {
 pub fn (resp Response) bytestr() string {
 	return 'HTTP/$resp.http_version $resp.status_code $resp.status_msg\r\n' + '${resp.header.render(
 		version: resp.version()
-	)}\r\n' + '$resp.body'
+	)}\r\n' + resp.body
 }
 
 // Parse a raw HTTP response into a Response object


### PR DESCRIPTION
Currently (on V 0.3.0 8c33a40, with default flags, and with -prod) the following simple vweb fileserver is capable of immediately serving small text files, 1 MB zip files, 512 MB zip files ... but hung permanently, using 100% CPU per thread per request attempt, if asked to serve a 1.9G zip file.

```v
module main

import vweb

struct App {
	vweb.Context
}

fn main() {
	mut app := App{}
	if !app.mount_static_folder_at('static', '/down') {
		eprintln('failed to mount static folder')
		exit(1)
	}
	vweb.run(app, 6060)
}
```

This was traced to the string interpolation that's removed with this patch, of `'$resp.body'`. Since resp.body is already a string, the interpolation isn't necessary, but it's the difference between 'working' and 'not working' in this case.

I realize the server has other issues, and maybe "interpolating a string into a string causes problems" is an issue in itself, but since this was a trivial fix that helped me I thought I'd submit it, and it makes sense so long as resp.body is defined to be a `string`.