### PR TITLE
cgen: fix shared array.last() (fix #15363)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1009,7 +1009,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			if !node.left.is_lvalue() {
 				g.write('ADDR($rec_cc_type, ')
 				has_cast = true
-			} else {
+			} else if node.name !in ['first', 'last', 'repeat'] {
 				g.write('&')
 			}
 		}

--- a/vlib/v/tests/shared_array_last_test.v
+++ b/vlib/v/tests/shared_array_last_test.v
@@ -1,0 +1,13 @@
+module main
+
+fn test_shared_array_last() {
+	shared a := []int{}
+	lock  {
+		a << 1
+		a << 2
+	}
+	rlock a {
+		println(a.last())
+		assert a.last() == 2
+	}
+}


### PR DESCRIPTION
This PR fix shared array.last() (fix #15363).

- Fix shared array.last().
- Add test.

```v
module main

fn main() {
	shared a := []int{}
	lock  {
		a << 1
		a << 2
	}
	rlock a {
		println(a.last())
		assert a.last() == 2
	}
}

PS D:\Test\v\tt1> v run .
2
```