### PR TITLE
checker: fix dumping generic fn mut argument (fix #15358)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2166,8 +2166,9 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 				return ast.void_type
 			}
 
-			tsym := c.table.sym(node.expr_type)
-			c.table.dumps[int(node.expr_type)] = tsym.cname
+			unwrapped_expr_type := c.unwrap_generic(node.expr_type)
+			tsym := c.table.sym(unwrapped_expr_type)
+			c.table.dumps[int(unwrapped_expr_type)] = tsym.cname
 			node.cname = tsym.cname
 			return node.expr_type
 		}

--- a/vlib/v/tests/inout/dump_generic_fn_mut_arg.out
+++ b/vlib/v/tests/inout/dump_generic_fn_mut_arg.out
@@ -1,0 +1,1 @@
+[vlib/v/tests/inout/dump_generic_fn_mut_arg.vv:11] t: &Reptile{}

--- a/vlib/v/tests/inout/dump_generic_fn_mut_arg.vv
+++ b/vlib/v/tests/inout/dump_generic_fn_mut_arg.vv
@@ -1,0 +1,12 @@
+module main
+
+pub struct Reptile {}
+
+fn main() {
+	mut r := Reptile{}
+	do(mut r)
+}
+
+pub fn do<T>(mut t T) {
+	dump(t)
+}


### PR DESCRIPTION
This PR fix dumping generic fn mut argument (fix #15358).

- Fix dumping generic fn mut argument.
- Add test.

```v
module main

pub struct Reptile {}

fn main() {
	mut r := Reptile{}
	do(mut r)
}

pub fn do<T>(mut t T) {
	dump(t)
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:11] t: &Reptile{}
```