### PR TITLE
checker: add pref.is_verbose for print_backtrace (related #15383)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2049,7 +2049,9 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 			c.error('incorrect use of compile-time type', node.pos)
 		}
 		ast.EmptyExpr {
-			print_backtrace()
+			if c.pref.is_verbose {
+				print_backtrace()
+			}
 			c.error('checker.expr(): unhandled EmptyExpr', token.Pos{})
 			return ast.void_type
 		}


### PR DESCRIPTION
This PR add pref.is_verbose for print_backtrace() (related #15383)

```v
sample :=

PS D:\Test\v\tt1> v run tt1.v
tt1.v:1:1: warning: unused variable: `sample`
    1 | sample :=
      | ~~~~~~
tt1.v:1:1: error: checker.expr(): unhandled EmptyExpr
    1 | sample :=
      | ^
```