### PR TITLE
cgen: fix shared struct method call (fix #15380)

### DIFF
--- a/vlib/v/tests/shared_struct_method_call_test.v
+++ b/vlib/v/tests/shared_struct_method_call_test.v
@@ -1,0 +1,28 @@
+module main
+
+struct Aa {
+mut:
+	b []int
+}
+
+fn append_ok(shared a Aa, new_b int) {
+	lock a {
+		a.b << new_b
+	}
+}
+
+fn (shared a Aa) append_fails(new_b int) {
+	lock a {
+		a.b << new_b
+	}
+}
+
+fn test_shared_struct_method_call() {
+	shared a := Aa{}
+	append_ok(shared a, 1)
+	a.append_fails(2)
+	rlock a {
+		println(a.b)
+		assert a.b == [1, 2]
+	}
+}


### PR DESCRIPTION
This PR fix shared struct method call (fix #15380).

- Fix shared struct method call.
- Add test.

```v
module main

struct Aa {
mut:
	b []int
}

fn append_ok(shared a Aa, new_b int) {
	lock a {
		a.b << new_b
	}
}

fn (shared a Aa) append_fails(new_b int) {
	lock a {
		a.b << new_b
	}
}

fn main() {
	shared a := Aa{}
	append_ok(shared a, 1)
	a.append_fails(2)
	rlock a {
		println(a.b)
		assert a.b == [1, 2]
	}
}

PS D:\Test\v\tt1> v run .
[1, 2]
```