### PR TITLE
checker: fix generics with nested generic method call (fix #15387)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1526,12 +1526,12 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		if method.generic_names.len != node.concrete_types.len {
 			// no type arguments given in call, attempt implicit instantiation
 			c.infer_fn_generic_types(method, mut node)
-			concrete_types = node.concrete_types
-		} else {
-			if node.concrete_types.len > 0 && !node.concrete_types[0].has_flag(.generic) {
-				c.table.register_fn_concrete_types(method.fkey(), node.concrete_types)
-			}
+			concrete_types = node.concrete_types.map(c.unwrap_generic(it))
 		}
+		if concrete_types.len > 0 && !concrete_types[0].has_flag(.generic) {
+			c.table.register_fn_concrete_types(method.fkey(), concrete_types)
+		}
+
 		// resolve return generics struct to concrete type
 		if method.generic_names.len > 0 && method.return_type.has_flag(.generic)
 			&& !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len == 0 {

--- a/vlib/v/tests/generics_with_nested_generic_method_call_test.v
+++ b/vlib/v/tests/generics_with_nested_generic_method_call_test.v
@@ -1,0 +1,40 @@
+struct Calc<S> {
+mut:
+	typ S
+}
+
+struct TypeA {}
+
+struct TypeB {}
+
+fn (mut c Calc<S>) next<T>(input T) f64 {
+	$if S is TypeA || S is TypeB {
+		return c.typ.next(input)
+	} $else {
+		return 99.0
+	}
+}
+
+fn (mut t TypeA) next<T>(input T) f64 {
+	return 10.0
+}
+
+fn (mut t TypeB) next<T>(input T) f64 {
+	return 11.0
+}
+
+fn test_generics_with_nested_generic_method_call() {
+	{
+		mut c := Calc<TypeA>{
+			typ: TypeA{}
+		}
+		assert c.next(100) == 10.0
+	}
+	{
+		mut c := Calc<TypeB>{
+			typ: TypeB{}
+		}
+		assert c.next(100) == 11.0
+	}
+	println('OK!!')
+}


### PR DESCRIPTION
This PR fix generics with nested generic method call (fix #15387).

- Fix generics with nested generic method call.
- Add test.

```v
struct Calc<S> {
mut:
	typ S
}

struct TypeA {}

struct TypeB {}

fn (mut c Calc<S>) next<T>(input T) f64 {
	$if S is TypeA || S is TypeB {
		return c.typ.next(input)
	} $else {
		return 99.0
	}
}

fn (mut t TypeA) next<T>(input T) f64 {
	return 10.0
}

fn (mut t TypeB) next<T>(input T) f64 {
	return 11.0
}

fn main() {
	{
		mut c := Calc<TypeA>{
			typ: TypeA{}
		}
		assert c.next(100) == 10.0
	}
	{
		mut c := Calc<TypeB>{
			typ: TypeB{}
		}
		assert c.next(100) == 11.0
	}
	println('OK!!')
}

PS D:\Test\v\tt1> v run .
OK!!
```