### PR TITLE
cgen: avoid a compiler warning in generated code

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -987,7 +987,7 @@ fn (g Gen) optional_type_text(styp string, base string) string {
 	ret := 'struct $styp {
 	byte state;
 	IError err;
-	byte data[sizeof($size) > 0 ? sizeof($size) : 1];
+	byte data[sizeof($size) > 1 ? sizeof($size) : 1];
 }'
 	return ret
 }


### PR DESCRIPTION
Avoid a "Suspicious comparison of 'sizeof(expr)' to a constant" warning
issued by clangd LSP while inspecting the generated C code.



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
