### PR TITLE
vweb: fix vweb static url (fix #15382)

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -622,7 +622,7 @@ fn (mut ctx Context) scan_static_directory(directory_path string, mount_path str
 				// Rudimentary guard against adding files not in mime_types.
 				// Use serve_static directly to add non-standard mime types.
 				if ext in vweb.mime_types {
-					ctx.serve_static(mount_path + '/' + file, full_path)
+					ctx.serve_static(mount_path.trim_right('/') + '/' + file, full_path)
 				}
 			}
 		}


### PR DESCRIPTION
This PR fix vweb static url (fix #15382).

```v
module main

import os
import vweb

struct App {
	vweb.Context
}

fn main() {
	mut app := App{}

	if !os.is_dir(os.resource_abs_path('static')) {
		os.mkdir(os.resource_abs_path('static'))?
		os.mkdir(os.resource_abs_path('static/css'))?
		os.create(os.resource_abs_path('static/hello.css'))?
		os.create(os.resource_abs_path('static/css/style.css'))?
	}

	app.mount_static_folder_at('./static', '/')
	app.display_recorded_static()

	vweb.run<App>(&app, 8181)
}

pub fn (mut app App) index() vweb.Result {
	return app.text('yo')
}

pub fn (mut app App) display_recorded_static() {
	for k,v  in app.static_files {
		mut tab := ""
		for _ in k.len/8..8 {
			tab += "\t"
		}
		println( k + tab + v)
	}
}

PS D:\Test\v\tt1> v run .
/css/style.css                                                  ./static\css\style.css
/hello.css                                                      ./static\hello.css
[Vweb] Running app on http://localhost:8181/
```