### PR TITLE
cgen: fix optional indexes with mutable arrays

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -252,6 +252,9 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		tmp_opt_ptr := if gen_or { g.new_tmp_var() } else { '' }
 		if gen_or {
 			g.write('$elem_type_str* $tmp_opt_ptr = ($elem_type_str*)/*ee elem_ptr_typ */(array_get_with_check(')
+			if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+				g.write('*')
+			}
 		} else {
 			if needs_clone {
 				g.write('/*2*/string_clone(')

--- a/vlib/v/tests/array_index_optional.v
+++ b/vlib/v/tests/array_index_optional.v
@@ -4,10 +4,13 @@ mut:
 }
 
 fn test_mut_array_index_optional() {
-	mut arr := Arrs{}
+	mut arr := Arrs{
+		x: [[1, 2]]
+	}
 	for mut sub_arr in arr.x {
-		x := sub_arr[0] or { 666 }
-		assert x == 666
+		x := sub_arr[0] or { 3 }
+		println(x)
+		assert x == 1
 	}
 }
 

--- a/vlib/v/tests/array_index_optional.v
+++ b/vlib/v/tests/array_index_optional.v
@@ -1,0 +1,20 @@
+struct Arrs {
+mut:
+	x [][]int
+}
+
+fn test_mut_array_index_optional() {
+	mut arr := Arrs{}
+	for mut sub_arr in arr.x {
+		x := sub_arr[0] or { 666 }
+		assert x == 666
+	}
+}
+
+fn test_array_index_optional_with_if_expr() {
+	ret := []string{}[0] or {
+		if true { 'a' } else { 'b' }
+	}
+	println(ret)
+	assert ret == 'a'
+}

--- a/vlib/v/tests/array_index_optional_with_if_expr_test.v
+++ b/vlib/v/tests/array_index_optional_with_if_expr_test.v
@@ -1,7 +1,0 @@
-fn test_array_index_optional_with_if_expr() {
-	ret := []string{}[0] or {
-		if true { 'a' } else { 'b' }
-	}
-	println(ret)
-	assert ret == 'a'
-}


### PR DESCRIPTION
This PR fixes a bug with the use of optional indexes with mutable arrays.

```v
$ cat x.v
struct Arrs {
mut:
	x [][]int
}

fn main() {
	mut arr := Arrs{
	        x: [[1, 2]]
	}
	for mut sub_arr in arr.x {
	        x := sub_arr[0] or { 3 }
	        println(x)
	        assert x == 1
	}
}
$ ./v2 run x.v
1
```

Fix #15116.