### PR TITLE
ast: fix expr.str() (fix #12650 #13312)

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -346,13 +346,13 @@ pub fn (x Expr) str() string {
 			return '.$x.val'
 		}
 		FloatLiteral, IntegerLiteral {
-			return x.val
+			return '$x.val'
 		}
 		GoExpr {
 			return 'go $x.call_expr'
 		}
 		Ident {
-			return x.name
+			return '$x.name'
 		}
 		IfExpr {
 			mut parts := []string{}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -346,13 +346,13 @@ pub fn (x Expr) str() string {
 			return '.$x.val'
 		}
 		FloatLiteral, IntegerLiteral {
-			return '$x.val'
+			return x.val.clone()
 		}
 		GoExpr {
 			return 'go $x.call_expr'
 		}
 		Ident {
-			return '$x.name'
+			return x.name.clone()
 		}
 		IfExpr {
 			mut parts := []string{}


### PR DESCRIPTION
This PR fix expr.str() (fix #12650, fix #13312).