### PR TITLE
ast: fix anon fn with nested anon fn argument (fix #15403)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -219,7 +219,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 		} else {
 			sig += arg_type_sym.str().to_lower().replace_each(['.', '__', '&', '', '[', 'arr_',
 				'chan ', 'chan_', 'map[', 'map_of_', ']', '_to_', '<', '_T_', ',', '_', ' ', '',
-				'>', ''])
+				'>', '', '(', '_', ')', '_'])
 		}
 		if i < f.params.len - 1 {
 			sig += '_'

--- a/vlib/v/tests/anon_fn_with_nested_anon_fn_args_test.v
+++ b/vlib/v/tests/anon_fn_with_nested_anon_fn_args_test.v
@@ -1,0 +1,12 @@
+module main
+
+fn test_anon_fn_with_nested_anon_fn_args() {
+	mut xa := fn (x fn (int) string, y int) string {
+		return x(y)
+	}
+	a := xa(fn (i int) string {
+		return 'a' + i.str()
+	}, 8)
+	println(a)
+	assert a == 'a8'
+}


### PR DESCRIPTION
This PR fix anon fn with nested anon fn argument (fix #15403).

- Fix anon fn with nested anon fn argument.
- Add test.

```v
module main

fn main() {
	mut xa := fn (x fn (int) string, y int) string {
		return x(y)
	}
	a := xa(fn (i int) string {
		return 'a' + i.str()
	}, 8)
	println(a)
	assert a == 'a8'
}

PS D:\Test\v\tt1> v run .
a8
```