### PR TITLE
checker, cgen: fix closure with fn variables (fix #15286)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -674,7 +674,15 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 					node.fn_var_type = typ
 				}
 				ast.Var {
-					typ = if obj.smartcasts.len != 0 { obj.smartcasts.last() } else { obj.typ }
+					if obj.smartcasts.len != 0 {
+						typ = obj.smartcasts.last()
+					} else {
+						if obj.typ == 0 {
+							typ = c.expr(obj.expr)
+						} else {
+							typ = obj.typ
+						}
+					}
 					node.is_fn_var = true
 					node.fn_var_type = typ
 				}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -473,8 +473,23 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 		ctx_struct := closure_ctx(node.decl)
 		builder.writeln('$ctx_struct {')
 		for var in node.inherited_vars {
-			styp := g.typ(var.typ)
-			builder.writeln('\t$styp $var.name;')
+			if g.table.sym(var.typ).kind == .function {
+				func := g.table.sym(var.typ).info as ast.FnType
+				ret_styp := g.typ(func.func.return_type)
+				builder.write_string('\t$ret_styp (*$var.name) (')
+				arg_len := func.func.params.len
+				for j, arg in func.func.params {
+					arg_styp := g.typ(arg.typ)
+					builder.write_string('$arg_styp $arg.name')
+					if j < arg_len - 1 {
+						builder.write_string(', ')
+					}
+				}
+				builder.writeln(');')
+			} else {
+				styp := g.typ(var.typ)
+				builder.writeln('\t$styp $var.name;')
+			}
 		}
 		builder.writeln('};\n')
 	}
@@ -1321,6 +1336,9 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 								}
 								g.write(')')
 							}
+							is_fn_var = true
+						} else if obj.is_inherited {
+							g.write(c.closure_ctx + '->' + node.name)
 							is_fn_var = true
 						}
 					}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -473,12 +473,12 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 		ctx_struct := closure_ctx(node.decl)
 		builder.writeln('$ctx_struct {')
 		for var in node.inherited_vars {
-			if g.table.sym(var.typ).kind == .function {
-				func := g.table.sym(var.typ).info as ast.FnType
-				ret_styp := g.typ(func.func.return_type)
+			var_sym := g.table.sym(var.typ)
+			if var_sym.info is ast.FnType {
+				ret_styp := g.typ(var_sym.info.func.return_type)
 				builder.write_string('\t$ret_styp (*$var.name) (')
-				arg_len := func.func.params.len
-				for j, arg in func.func.params {
+				arg_len := var_sym.info.func.params.len
+				for j, arg in var_sym.info.func.params {
 					arg_styp := g.typ(arg.typ)
 					builder.write_string('$arg_styp $arg.name')
 					if j < arg_len - 1 {

--- a/vlib/v/tests/inout/closure_with_fn_variables.out
+++ b/vlib/v/tests/inout/closure_with_fn_variables.out
@@ -1,0 +1,2 @@
+test1
+test2

--- a/vlib/v/tests/inout/closure_with_fn_variables.vv
+++ b/vlib/v/tests/inout/closure_with_fn_variables.vv
@@ -1,0 +1,19 @@
+module main
+
+fn test1() {
+	println('test1')
+}
+
+fn test2() {
+	println('test2')
+}
+
+fn main() {
+	t1 := test1
+	t2 := test2
+	anon := fn [t1, t2] () {
+		t1()
+		t2()
+	}
+	anon()
+}


### PR DESCRIPTION
This PR fix closure with fn variables (fix #15286).

- Fix closure with fn variables.
- Add test.

```v
module main

fn test1() {
	println('test1')
}

fn test2() {
	println('test2')
}

fn main() {
	t1 := test1
	t2 := test2
	anon := fn [t1, t2] () {
		t1()
		t2()
	}
	anon()
}

PS D:\Test\v\tt1> v run .
test1
test2
```