### PR TITLE
cgen: fix shared map delete (fix #15430)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -827,11 +827,19 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		left_info := left_sym.info as ast.Map
 		elem_type_str := g.typ(left_info.key_type)
 		g.write('map_delete(')
-		if left_type.is_ptr() {
+		if left_type.has_flag(.shared_f) {
+			if left_type.is_ptr() {
+				g.write('&')
+			}
 			g.expr(node.left)
+			g.write('->val')
 		} else {
-			g.write('&')
-			g.expr(node.left)
+			if left_type.is_ptr() {
+				g.expr(node.left)
+			} else {
+				g.write('&')
+				g.expr(node.left)
+			}
 		}
 		g.write(', &($elem_type_str[]){')
 		g.expr(node.args[0].expr)
@@ -839,11 +847,19 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		return
 	} else if left_sym.kind == .array && node.name == 'delete' {
 		g.write('array_delete(')
-		if left_type.is_ptr() {
+		if left_type.has_flag(.shared_f) {
+			if left_type.is_ptr() {
+				g.write('&')
+			}
 			g.expr(node.left)
+			g.write('->val')
 		} else {
-			g.write('&')
-			g.expr(node.left)
+			if left_type.is_ptr() {
+				g.expr(node.left)
+			} else {
+				g.write('&')
+				g.expr(node.left)
+			}
 		}
 		g.write(', ')
 		g.expr(node.args[0].expr)

--- a/vlib/v/tests/shared_map_delete_test.v
+++ b/vlib/v/tests/shared_map_delete_test.v
@@ -1,0 +1,14 @@
+fn test_shared_map_delete() {
+	shared store := map[string]int{}
+	lock store {
+		store['abc'] = 5
+		store['xyz'] = 10
+	}
+
+	lock store {
+		assert store.len == 2
+		store.delete('abc')
+		assert store.len == 1
+		assert store['xyz'] == 10
+	}
+}


### PR DESCRIPTION
This PR fix shared map delete (fix #15430).

- Fix shared map/array delete.
- Add test.

```v
fn main() {
	shared store := map[string]int{}
	lock store {
		store['abc'] = 5
		store['xyz'] = 10
	}

	lock store {
		assert store.len == 2
		store.delete('abc')
		assert store.len == 1
		assert store['xyz'] == 10
	}
}

PS D:\Test\v\tt1> v run .
```