### PR TITLE
cgen: fix fn_var_signature() when param type is function

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -155,12 +155,8 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				}
 				// if it's a decl assign (`:=`) or a blank assignment `_ =`/`_ :=` then generate `void (*ident) (args) =`
 				if (is_decl || blank_assign) && left is ast.Ident {
-					ret_styp := g.typ(val.decl.return_type)
-					g.write('$ret_styp (*$ident.name) (')
-					def_pos := g.definitions.len
-					g.fn_decl_params(val.decl.params, unsafe { nil }, false)
-					g.definitions.go_back(g.definitions.len - def_pos)
-					g.write(') = ')
+					sig := g.fn_var_signature(val.decl.return_type, val.decl.params, ident.name)
+					g.write(sig + ' = ')
 				} else {
 					g.is_assign_lhs = true
 					g.assign_op = node.op

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -343,8 +343,8 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 	fn_builder.writeln('\t\tif (!map_exists(&b, k)) return false;')
 	kind := g.table.type_kind(value.typ)
 	if kind == .function {
-		func := value.sym.info as ast.FnType
-		sig := g.fn_var_signature(func, 'v')
+		info := value.sym.info as ast.FnType
+		sig := g.fn_var_signature(info.func.return_type, info.func.params, 'v')
 		fn_builder.writeln('\t\t$sig = *(voidptr*)map_get(&a, k, &(voidptr[]){ 0 });')
 	} else {
 		fn_builder.writeln('\t\t$ptr_value_styp v = *($ptr_value_styp*)map_get(&a, k, &($ptr_value_styp[]){ 0 });')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -475,7 +475,8 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 		for var in node.inherited_vars {
 			var_sym := g.table.sym(var.typ)
 			if var_sym.info is ast.FnType {
-				sig := g.fn_var_signature(var_sym.info, var.name)
+				sig := g.fn_var_signature(var_sym.info.func.return_type, var_sym.info.func.params,
+					var.name)
 				builder.writeln('\t' + sig + ';')
 			} else {
 				styp := g.typ(var.typ)

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -63,13 +63,20 @@ fn (mut g Gen) unwrap(typ ast.Type) Type {
 }
 
 // generate function variable definition, e.g. `void (*var_name) (int, string)`
-fn (mut g Gen) fn_var_signature(info ast.FnType, var_name string) string {
-	ret_styp := g.typ(info.func.return_type)
+fn (mut g Gen) fn_var_signature(return_type ast.Type, params []ast.Param, var_name string) string {
+	ret_styp := g.typ(return_type)
 	mut sig := '$ret_styp (*$var_name) ('
-	for j, arg in info.func.params {
-		arg_styp := g.typ(arg.typ)
-		sig += '$arg_styp $arg.name'
-		if j < info.func.params.len - 1 {
+	for j, arg in params {
+		arg_sym := g.table.sym(arg.typ)
+		if arg_sym.info is ast.FnType {
+			arg_sig := g.fn_var_signature(arg_sym.info.func.return_type, arg_sym.info.func.params,
+				arg.name)
+			sig += arg_sig
+		} else {
+			arg_styp := g.typ(arg.typ)
+			sig += '$arg_styp $arg.name'
+		}
+		if j < params.len - 1 {
 			sig += ', '
 		}
 	}

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -70,11 +70,11 @@ fn (mut g Gen) fn_var_signature(return_type ast.Type, params []ast.Param, var_na
 		arg_sym := g.table.sym(arg.typ)
 		if arg_sym.info is ast.FnType {
 			arg_sig := g.fn_var_signature(arg_sym.info.func.return_type, arg_sym.info.func.params,
-				arg.name)
+				'')
 			sig += arg_sig
 		} else {
 			arg_styp := g.typ(arg.typ)
-			sig += '$arg_styp $arg.name'
+			sig += '$arg_styp'
 		}
 		if j < params.len - 1 {
 			sig += ', '

--- a/vlib/v/tests/anon_fn_decl_with_anon_fn_params_test.v
+++ b/vlib/v/tests/anon_fn_decl_with_anon_fn_params_test.v
@@ -1,0 +1,13 @@
+fn test_anon_fn_decl_with_anon_fn_params() {
+	a := fn (p1 fn () int, p2 string) string {
+		n := p1()
+		return '$n' + p2
+	}
+	ret := a(aaa, 'hello')
+	println(ret)
+	assert ret == '22hello'
+}
+
+fn aaa() int {
+	return 22
+}


### PR DESCRIPTION
This PR fix fn_var_signature() when param type is function.

- Fix fn_var_signature() when param type is function.
- Add test.

```v
fn main() {
	a := fn (p1 fn () int, p2 string) string {
		n := p1()
		return '$n' + p2
	}
	ret := a(aaa, 'hello')
	println(ret)
	assert ret == '22hello'
}

fn aaa() int {
	return 22
}

PS D:\test\v\tt1> v run .
22hello
```
generated c codes
```v
VV_LOCAL_SYMBOL void main__main(void) {
	string (*a) (int (*) (), string) = 	anon_fn_1315efd87adb6e70_fn__int_string__string_54;
	string ret = a((voidptr)main__aaa, _SLIT("hello"));
	println(ret);
}
```