### PR TITLE
crypt: add OS-specific source of random bytes for OpenBSD and FreeBSD

### DIFF
--- a/vlib/crypto/rand/rand_freebsd.c.v
+++ b/vlib/crypto/rand/rand_freebsd.c.v
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 John Lloyd. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module rand
+
+#include <stdlib.h>
+
+fn C.arc4random_buf(p &byte, n usize)
+
+// read returns an array of `bytes_needed` random bytes read from the OS.
+pub fn read(bytes_needed int) ?[]u8 {
+	mut buffer := unsafe { malloc_noscan(bytes_needed) }
+	C.arc4random_buf(buffer, bytes_needed)
+	return unsafe { buffer.vbytes(bytes_needed) }
+}

--- a/vlib/crypto/rand/rand_openbsd.c.v
+++ b/vlib/crypto/rand/rand_openbsd.c.v
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 John Lloyd. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module rand
+
+#include <stdlib.h>
+
+fn C.arc4random_buf(p &byte, n usize)
+
+pub fn read(bytes_needed int) ?[]u8 {
+	mut buffer := unsafe { malloc_noscan(bytes_needed) }
+	C.arc4random_buf(buffer, bytes_needed)
+	return unsafe { buffer.vbytes(bytes_needed) }
+}

--- a/vlib/crypto/rand/rand_openbsd.c.v
+++ b/vlib/crypto/rand/rand_openbsd.c.v
@@ -8,6 +8,7 @@ module rand
 
 fn C.arc4random_buf(p &byte, n usize)
 
+// read returns an array of `bytes_needed` random bytes read from the OS.
 pub fn read(bytes_needed int) ?[]u8 {
 	mut buffer := unsafe { malloc_noscan(bytes_needed) }
 	C.arc4random_buf(buffer, bytes_needed)


### PR DESCRIPTION
Add the OpenBSD arc4random syscall.  Platform-specific of course.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
