### PR TITLE
checker: fix fn call with mut array of aliases arguments (fix #15439)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -958,8 +958,14 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				param_elem_type := c.table.unaliased_type(param_info.elem_type)
 				arg_info := arg_typ_sym.info as ast.Array
 				arg_elem_type := c.table.unaliased_type(arg_info.elem_type)
-				if param.typ.nr_muls() == arg_typ.nr_muls()
-					&& param_info.nr_dims == arg_info.nr_dims && param_elem_type == arg_elem_type {
+				param_nr_muls := param.typ.nr_muls()
+				arg_nr_muls := if call_arg.is_mut {
+					arg_typ.nr_muls() + 1
+				} else {
+					arg_typ.nr_muls()
+				}
+				if param_nr_muls == arg_nr_muls && param_info.nr_dims == arg_info.nr_dims
+					&& param_elem_type == arg_elem_type {
 					continue
 				}
 			}

--- a/vlib/v/tests/fn_call_mut_array_of_aliases_args_test.v
+++ b/vlib/v/tests/fn_call_mut_array_of_aliases_args_test.v
@@ -1,0 +1,27 @@
+fn f1(mut b []byte) string {
+	return '$b'
+}
+
+fn f2(b []byte) string {
+	return '$b'
+}
+
+fn f3(mut b []u8) string {
+	return '$b'
+}
+
+fn test_fn_call_mut_array_of_aliases() {
+	mut s1 := 'test'.bytes()
+
+	ret1 := f1(mut s1)
+	println(ret1)
+	assert ret1 == '[116, 101, 115, 116]'
+
+	ret2 := f2(s1)
+	println(ret2)
+	assert ret2 == '[116, 101, 115, 116]'
+
+	ret3 := f3(mut s1)
+	println(ret3)
+	assert ret3 == '[116, 101, 115, 116]'
+}


### PR DESCRIPTION
This PR fix fn call with mut array of aliases arguments (fix #15439).

- Fix fn call with mut array of aliases arguments.
- Add test.

```v
fn f1(mut b []byte) string {
	return '$b'
}

fn f2(b []byte) string {
	return '$b'
}

fn f3(mut b []u8) string {
	return '$b'
}

fn main() {
	mut s1 := 'test'.bytes()

	ret1 := f1(mut s1)
	println(ret1)
	assert ret1 == '[116, 101, 115, 116]'

	ret2 := f2(s1)
	println(ret2)
	assert ret2 == '[116, 101, 115, 116]'

	ret3 := f3(mut s1)
	println(ret3)
	assert ret3 == '[116, 101, 115, 116]'
}

PS D:\Test\v\tt1> v run .
[116, 101, 115, 116]
[116, 101, 115, 116]
[116, 101, 115, 116]
```