### PR TITLE
cgen: fix array of fixed array map/filter/any/all(it[0]) (fix #15422)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -341,12 +341,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.indent++
-	if g.table.sym(inp_info.elem_type).kind == .array_fixed {
-		g.writeln('$inp_elem_type it;')
-		g.writeln('memcpy(&it, (($inp_elem_type*) ${tmp}_orig.data)[$i], sizeof($inp_elem_type));')
-	} else {
-		g.writeln('$inp_elem_type it = (($inp_elem_type*) ${tmp}_orig.data)[$i];')
-	}
+	g.write_prepared_it(inp_info, inp_elem_type, tmp, i)
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	mut expr := node.args[0].expr
@@ -541,7 +536,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.indent++
-	g.writeln('$elem_type_str it = (($elem_type_str*) ${tmp}_orig.data)[$i];')
+	g.write_prepared_it(info, elem_type_str, tmp, i)
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	mut expr := node.args[0].expr
@@ -898,7 +893,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.indent++
-	g.writeln('$elem_type_str it = (($elem_type_str*) ${tmp}_orig.data)[$i];')
+	g.write_prepared_it(info, elem_type_str, tmp, i)
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	mut expr := node.args[0].expr
@@ -972,7 +967,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.indent++
-	g.writeln('$elem_type_str it = (($elem_type_str*) ${tmp}_orig.data)[$i];')
+	g.write_prepared_it(info, elem_type_str, tmp, i)
 	g.empty_line = true
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
@@ -1059,4 +1054,13 @@ fn (mut g Gen) write_prepared_tmp_value(tmp string, node &ast.CallExpr, tmp_styp
 	g.writeln(';')
 	g.writeln('int ${tmp}_len = ${tmp}_orig.len;')
 	return has_infix_left_var_name
+}
+
+fn (mut g Gen) write_prepared_it(inp_info ast.Array, inp_elem_type string, tmp string, i string) {
+	if g.table.sym(inp_info.elem_type).kind == .array_fixed {
+		g.writeln('$inp_elem_type it;')
+		g.writeln('memcpy(&it, (($inp_elem_type*) ${tmp}_orig.data)[$i], sizeof($inp_elem_type));')
+	} else {
+		g.writeln('$inp_elem_type it = (($inp_elem_type*) ${tmp}_orig.data)[$i];')
+	}
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -341,7 +341,12 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	i := g.new_tmp_var()
 	g.writeln('for (int $i = 0; $i < ${tmp}_len; ++$i) {')
 	g.indent++
-	g.writeln('$inp_elem_type it = (($inp_elem_type*) ${tmp}_orig.data)[$i];')
+	if g.table.sym(inp_info.elem_type).kind == .array_fixed {
+		g.writeln('$inp_elem_type it;')
+		g.writeln('memcpy(&it, (($inp_elem_type*) ${tmp}_orig.data)[$i], sizeof($inp_elem_type));')
+	} else {
+		g.writeln('$inp_elem_type it = (($inp_elem_type*) ${tmp}_orig.data)[$i];')
+	}
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	mut expr := node.args[0].expr

--- a/vlib/v/tests/array_of_fixed_array_map_test.v
+++ b/vlib/v/tests/array_of_fixed_array_map_test.v
@@ -1,0 +1,12 @@
+fn test_array_of_fixed_array_map() {
+	mut db := [][2]string{}
+
+	db << ['aaa', '111']!
+	db << ['bbb', '222']!
+	db << ['ccc', '333']!
+
+	keys := db.map(it[0])
+
+	println(keys)
+	assert keys == ['aaa', 'bbb', 'ccc']
+}

--- a/vlib/v/tests/array_of_fixed_array_map_test.v
+++ b/vlib/v/tests/array_of_fixed_array_map_test.v
@@ -1,4 +1,4 @@
-fn test_array_of_fixed_array_map() {
+fn test_array_of_fixed_array_map_filter_any_all() {
 	mut db := [][2]string{}
 
 	db << ['aaa', '111']!
@@ -9,4 +9,9 @@ fn test_array_of_fixed_array_map() {
 
 	println(keys)
 	assert keys == ['aaa', 'bbb', 'ccc']
+
+	assert db.map(it[0] == 'aaa') == [true, false, false]
+	assert db.filter(it[0] == 'bbb') == [['bbb', '222']!]
+	assert db.any(it[0] == 'aaa') == true
+	assert db.all(it[0] == 'aaa') == false
 }


### PR DESCRIPTION
This PR fix array of fixed array map(it[0]) (fix #15422).

- Fix array of fixed array map(it[0]).
- Add test.

```v
fn main() {
	mut db := [][2]string{}

	db << ['aaa', '111']!
	db << ['bbb', '222']!
	db << ['ccc', '333']!

	keys := db.map(it[0])
	
	println(keys)
	assert keys == ['aaa', 'bbb', 'ccc']
}

PS D:\Test\v\tt1> v run .
['aaa', 'bbb', 'ccc']
```