### PR TITLE
cgen: fix go call fn with anon fn argument (fix #10351, fix #10270)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1826,8 +1826,14 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 			g.type_definitions.writeln('EMPTY_STRUCT_DECLARATION;')
 		} else {
 			for i, arg in expr.args {
-				styp := g.typ(arg.typ)
-				g.type_definitions.writeln('\t$styp arg${i + 1};')
+				arg_sym := g.table.sym(arg.typ)
+				if arg_sym.info is ast.FnType {
+					sig := g.fn_var_signature(arg_sym.info.func.return_type, arg_sym.info.func.params, 'arg${i + 1}')
+					g.type_definitions.writeln('\t' + sig + ';')
+				} else {
+					styp := g.typ(arg.typ)
+					g.type_definitions.writeln('\t$styp arg${i + 1};')
+				}
 			}
 		}
 		if need_return_ptr {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1828,7 +1828,8 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 			for i, arg in expr.args {
 				arg_sym := g.table.sym(arg.typ)
 				if arg_sym.info is ast.FnType {
-					sig := g.fn_var_signature(arg_sym.info.func.return_type, arg_sym.info.func.params, 'arg${i + 1}')
+					sig := g.fn_var_signature(arg_sym.info.func.return_type, arg_sym.info.func.params,
+						'arg${i + 1}')
 					g.type_definitions.writeln('\t' + sig + ';')
 				} else {
 					styp := g.typ(arg.typ)

--- a/vlib/v/tests/go_call_fn_with_anon_fn_arg_test.v
+++ b/vlib/v/tests/go_call_fn_with_anon_fn_arg_test.v
@@ -1,0 +1,14 @@
+fn start(f fn ()) string {
+	f()
+	return 'ok!!'
+}
+
+fn on_connect() {
+	println('fn ok!!')
+}
+
+fn test_go_call_fn_with_anon_fn_arg() {
+	g := go start(on_connect)
+	ret := g.wait()
+	assert ret == 'ok!!'
+}


### PR DESCRIPTION
This PR fix go call fn with anon fn argument (fix #10351, fix #10270).

- Fix go call fn with anon fn argument.
- Add test.

```v
fn start(f fn ()) string {
	f()
	return 'ok!!'
}

fn on_connect() {
	println('fn ok!!')
}

fn main() {
	g := go start(on_connect)
	ret := g.wait()
	assert ret == 'ok!!'
}

PS D:\Test\v\tt1> v run .
fn ok!!
```