### PR TITLE
v.pref: support `v -trace-calls ...`

### DIFF
--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -77,6 +77,7 @@ fn test_all() {
 	global_run_dir := '$checker_dir/globals_run'
 	run_dir := '$checker_dir/run'
 	skip_unused_dir := 'vlib/v/tests/skip_unused'
+	trace_calls_dir := 'vlib/v/tests/trace_calls'
 	//
 	checker_tests := get_tests_in_dir(checker_dir, false)
 	parser_tests := get_tests_in_dir(parser_dir, false)
@@ -86,6 +87,7 @@ fn test_all() {
 	module_tests := get_tests_in_dir(module_dir, true)
 	run_tests := get_tests_in_dir(run_dir, false)
 	skip_unused_dir_tests := get_tests_in_dir(skip_unused_dir, false)
+	trace_calls_dir_tests := get_tests_in_dir(trace_calls_dir, false)
 	mut tasks := Tasks{
 		vexe: vexe
 		label: 'all tests'
@@ -114,6 +116,15 @@ fn test_all() {
 			'.skip_unused.run.out', skip_unused_dir_tests, false)
 		skip_unused_tasks.run()
 	}
+	//
+	mut trace_calls_tasks := Tasks{
+		vexe: vexe
+		parallel_jobs: 1
+		label: '-trace-calls tests'
+	}
+	trace_calls_tasks.add('', trace_calls_dir, '-trace-calls run', '.run.out', trace_calls_dir_tests,
+		false)
+	trace_calls_tasks.run()
 	//
 	if github_job == 'ubuntu-tcc' {
 		// This is done with tcc only, because the error output is compiler specific.

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -115,16 +115,16 @@ fn test_all() {
 		skip_unused_tasks.add('', skip_unused_dir, '-d no_backtrace -skip-unused run',
 			'.skip_unused.run.out', skip_unused_dir_tests, false)
 		skip_unused_tasks.run()
+		//
+		mut trace_calls_tasks := Tasks{
+			vexe: vexe
+			parallel_jobs: 1
+			label: '-trace-calls tests'
+		}
+		trace_calls_tasks.add('', trace_calls_dir, '-trace-calls run', '.run.out', trace_calls_dir_tests,
+			false)
+		trace_calls_tasks.run()
 	}
-	//
-	mut trace_calls_tasks := Tasks{
-		vexe: vexe
-		parallel_jobs: 1
-		label: '-trace-calls tests'
-	}
-	trace_calls_tasks.add('', trace_calls_dir, '-trace-calls run', '.run.out', trace_calls_dir_tests,
-		false)
-	trace_calls_tasks.run()
 	//
 	if github_job == 'ubuntu-tcc' {
 		// This is done with tcc only, because the error output is compiler specific.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -157,8 +157,8 @@ pub mut:
 	third_party_option string
 	building_v         bool
 	autofree           bool // `v -manualfree` => false, `v -autofree` => true; false by default for now.
-	trace_calls        bool // -trace-calls true = the transformer stage will generate and inject print calls for tracing function calls
 	// Disabling `free()` insertion results in better performance in some applications (e.g. compilers)
+	trace_calls        bool // -trace-calls true = the transformer stage will generate and inject print calls for tracing function calls
 	compress bool // when set, use `upx` to compress the generated executable
 	// generating_vh    bool
 	no_builtin       bool   // Skip adding the `builtin` module implicitly. The generated C code may not compile.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -158,8 +158,8 @@ pub mut:
 	building_v         bool
 	autofree           bool // `v -manualfree` => false, `v -autofree` => true; false by default for now.
 	// Disabling `free()` insertion results in better performance in some applications (e.g. compilers)
-	trace_calls        bool // -trace-calls true = the transformer stage will generate and inject print calls for tracing function calls
-	compress bool // when set, use `upx` to compress the generated executable
+	trace_calls bool // -trace-calls true = the transformer stage will generate and inject print calls for tracing function calls
+	compress    bool // when set, use `upx` to compress the generated executable
 	// generating_vh    bool
 	no_builtin       bool   // Skip adding the `builtin` module implicitly. The generated C code may not compile.
 	enable_globals   bool   // allow __global for low level code

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -157,6 +157,7 @@ pub mut:
 	third_party_option string
 	building_v         bool
 	autofree           bool // `v -manualfree` => false, `v -autofree` => true; false by default for now.
+	trace_calls        bool // -trace-calls true = the transformer stage will generate and inject print calls for tracing function calls
 	// Disabling `free()` insertion results in better performance in some applications (e.g. compilers)
 	compress bool // when set, use `upx` to compress the generated executable
 	// generating_vh    bool
@@ -428,6 +429,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-autofree' {
 				res.autofree = true
 				res.build_options << arg
+			}
+			'-trace-calls' {
+				res.trace_calls = true
 			}
 			'-manualfree' {
 				res.autofree = false

--- a/vlib/v/tests/trace_calls/simple.run.out
+++ b/vlib/v/tests/trace_calls/simple.run.out
@@ -1,6 +1,6 @@
-fn main()
-fn foo()
-fn bar()
-fn baz()
-fn (b Boo) call_1()
+> trace fn main()
+> trace fn foo()
+> trace fn bar()
+> trace fn baz()
+> trace fn (b Boo) call_1()
 end

--- a/vlib/v/tests/trace_calls/simple.run.out
+++ b/vlib/v/tests/trace_calls/simple.run.out
@@ -1,0 +1,6 @@
+fn main()
+fn foo()
+fn bar()
+fn baz()
+fn (b Boo) call_1()
+end

--- a/vlib/v/tests/trace_calls/simple.vv
+++ b/vlib/v/tests/trace_calls/simple.vv
@@ -1,0 +1,25 @@
+module main
+
+fn C.test()
+
+struct Boo {}
+
+fn (b Boo) call_1() {}
+
+fn foo() {
+	bar()
+}
+
+fn bar() {
+	baz()
+}
+
+fn baz() {
+	boo := Boo{}
+	boo.call_1()
+}
+
+fn main() {
+	foo()
+	println('end')
+}

--- a/vlib/v/tests/trace_calls/simple.vv
+++ b/vlib/v/tests/trace_calls/simple.vv
@@ -21,5 +21,5 @@ fn baz() {
 
 fn main() {
 	foo()
-	println('end')
+	eprintln('end')
 }

--- a/vlib/v/tests/trace_calls/with_modules.run.out
+++ b/vlib/v/tests/trace_calls/with_modules.run.out
@@ -1,6 +1,5 @@
 > trace fn init_os_args(argc int, argv &&u8) []string
 > trace pub fn getwd() string
-> trace fn max_path_bufffer_size() int
 > trace fn main()
 > trace fn f1()
 > trace fn f2()

--- a/vlib/v/tests/trace_calls/with_modules.run.out
+++ b/vlib/v/tests/trace_calls/with_modules.run.out
@@ -1,0 +1,9 @@
+fn init_os_args(argc int, argv &&u8) []string
+pub fn getwd() string
+fn max_path_bufffer_size() int
+fn main()
+fn f1()
+fn f2()
+fn f3()
+pub fn join_path(base string, dirs ...string) string
+end

--- a/vlib/v/tests/trace_calls/with_modules.run.out
+++ b/vlib/v/tests/trace_calls/with_modules.run.out
@@ -1,9 +1,9 @@
-fn init_os_args(argc int, argv &&u8) []string
-pub fn getwd() string
-fn max_path_bufffer_size() int
-fn main()
-fn f1()
-fn f2()
-fn f3()
-pub fn join_path(base string, dirs ...string) string
+> trace fn init_os_args(argc int, argv &&u8) []string
+> trace pub fn getwd() string
+> trace fn max_path_bufffer_size() int
+> trace fn main()
+> trace fn f1()
+> trace fn f2()
+> trace fn f3()
+> trace pub fn join_path(base string, dirs ...string) string
 end

--- a/vlib/v/tests/trace_calls/with_modules.vv
+++ b/vlib/v/tests/trace_calls/with_modules.vv
@@ -1,0 +1,20 @@
+module main
+
+import os
+
+fn f1() {
+	f2()
+}
+
+fn f2() {
+	f3()
+}
+
+fn f3() {
+	_ := os.join_path('1', '2', '3')
+}
+
+fn main() {
+	f1()
+	println('end')
+}

--- a/vlib/v/tests/trace_calls/with_modules.vv
+++ b/vlib/v/tests/trace_calls/with_modules.vv
@@ -16,5 +16,5 @@ fn f3() {
 
 fn main() {
 	f1()
-	println('end')
+	eprintln('end')
 }

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -226,6 +226,7 @@ pub fn (mut t Transformer) stmt(mut node ast.Stmt) ast.Stmt {
 			}
 		}
 		ast.FnDecl {
+			t.fn_decl(mut node)
 			t.index.indent(true)
 			for mut stmt in node.stmts {
 				stmt = t.stmt(mut stmt)
@@ -1033,4 +1034,49 @@ pub fn (mut t Transformer) sql_expr(mut node ast.SqlExpr) ast.Expr {
 		sub_struct = t.expr(mut sub_struct) as ast.SqlExpr
 	}
 	return node
+}
+
+pub fn (mut t Transformer) fn_decl(mut node ast.FnDecl) {
+	if t.pref.trace_calls {
+		// Skip `C.fn()` and all of builtin
+		// builtin could probably be traced also but would need
+		// special cases for, at least, println/eprintln
+		if node.no_body || node.is_builtin {
+			return
+		}
+		call_expr := t.gen_trace_print_expr_stmt(node)
+		expr_stmt := ast.ExprStmt{
+			expr: call_expr
+		}
+		node.stmts.prepend(expr_stmt)
+	}
+}
+
+// gen_trace_print_expr_stmt generates an ast.CallExpr representation of a
+// `eprint(...)` V code statement.
+fn (t Transformer) gen_trace_print_expr_stmt(node ast.FnDecl) ast.CallExpr {
+	print_str := node.stringify(t.table, node.mod, map[string]string{})
+
+	call_arg := ast.CallArg{
+		expr: ast.StringLiteral{
+			val: print_str
+		}
+		typ: ast.string_type_idx
+	}
+	args := [call_arg]
+
+	fn_name := 'eprintln'
+	call_expr := ast.CallExpr{
+		name: fn_name
+		args: args
+		mod: node.mod
+		pos: node.pos
+		language: node.language
+		scope: node.scope
+		comments: [ast.Comment{
+			text: 'fn $node.short_name trace call'
+		}]
+	}
+
+	return call_expr
 }

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -1058,7 +1058,7 @@ pub fn (mut t Transformer) fn_decl(mut node ast.FnDecl) {
 // gen_trace_print_expr_stmt generates an ast.CallExpr representation of a
 // `eprint(...)` V code statement.
 fn (t Transformer) gen_trace_print_call_expr(node ast.FnDecl) ast.CallExpr {
-	print_str := node.stringify(t.table, node.mod, map[string]string{})
+	print_str := '> trace ' + node.stringify(t.table, node.mod, map[string]string{})
 
 	call_arg := ast.CallArg{
 		expr: ast.StringLiteral{

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -1036,6 +1036,9 @@ pub fn (mut t Transformer) sql_expr(mut node ast.SqlExpr) ast.Expr {
 	return node
 }
 
+// fn_decl mutates `node`.
+// if `pref.trace_calls` is true ast Nodes for `eprintln(...)` is prepended to the `FnDecl`'s
+// stmts list to let the gen backend generate the target specific code for the print.
 pub fn (mut t Transformer) fn_decl(mut node ast.FnDecl) {
 	if t.pref.trace_calls {
 		// Skip `C.fn()` and all of builtin
@@ -1044,7 +1047,7 @@ pub fn (mut t Transformer) fn_decl(mut node ast.FnDecl) {
 		if node.no_body || node.is_builtin {
 			return
 		}
-		call_expr := t.gen_trace_print_expr_stmt(node)
+		call_expr := t.gen_trace_print_call_expr(node)
 		expr_stmt := ast.ExprStmt{
 			expr: call_expr
 		}
@@ -1054,7 +1057,7 @@ pub fn (mut t Transformer) fn_decl(mut node ast.FnDecl) {
 
 // gen_trace_print_expr_stmt generates an ast.CallExpr representation of a
 // `eprint(...)` V code statement.
-fn (t Transformer) gen_trace_print_expr_stmt(node ast.FnDecl) ast.CallExpr {
+fn (t Transformer) gen_trace_print_call_expr(node ast.FnDecl) ast.CallExpr {
 	print_str := node.stringify(t.table, node.mod, map[string]string{})
 
 	call_arg := ast.CallArg{


### PR DESCRIPTION
This PR will add a new `-trace-calls` flag to `v`:

```
v -trace-calls run examples/json.v
fn main()
fn json_parse(s string) &C.cJSON
fn decode_string(root &C.cJSON) string
fn decode_int(root &C.cJSON) int
fn decode_string(root &C.cJSON) string
fn decode_int(root &C.cJSON) int
Frodo: 25
Bobby: 10

0) Frodo
fn (u User) can_register() bool
fn (mut u User) register()
Frodo is registered
1) Bobby
fn (u User) can_register() bool
Cannot register Bobby, they are too young

fn encode_string(val string) &C.cJSON
fn encode_int(val int) &C.cJSON
fn encode_bool(val bool) &C.cJSON
fn encode_string(val string) &C.cJSON
fn encode_int(val int) &C.cJSON
fn encode_bool(val bool) &C.cJSON
fn json_print(json &C.cJSON) string
[{"name":"Frodo","age":25,"is_registered":true},{"name":"Bobby","age":10,"is_registered":false}]
```

The flag will trigger the transformer step to inject (prepend) an `eprintln(...)` call into the AST for all `ast.FnDecl`.

By prepending it, the print is thus the first function to be called in the body of the function when it executes, resulting in a flow printing all function calls in their call order to the terminal. This is very useful to debug [certain kinds of bugs](https://discord.com/channels/592103645835821068/592294828432424960/1008729603940028528) where e.g. debuggers fail to be of any use. It can also be used to see the program's execution flow, which can be very helpful in general.

I chose to implement it via the transformer since then *all* backends will benefit from it.

Known improvements I can think of is tracing `C.fn()` calls also - but this will require a different approach in the transformer - where you'd have to inject the print call expr *before* the C call expr itself. This can be tested and improved later on.
We could also add filenames/line numbers to the output but maybe it gets too verbose - and maybe an option to dump them to a file directly?

**Notes:**
* I'm not sure if the tests belongs in `compiler_errors_test.v` but this was the most straightforward place for me to add them.
* The tests only runs on Linux since they would otherwise differ from platform to platform in some cases since using `$if windows {...}` etc. can result in a different function flow (typically the functions that run before main is called).
* It is, expectedly, very verbose in graphical apps or apps with loops in general.
* `builtin` is skipped since this will need some special cases like the print call itself, it can probably be added if it proves useful.
* Anonymous functions work also but are currently printed with their long ids - which may, or may not, be useful?