### PR TITLE
scanner: fix false &&!ok1 (fix #7524)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -849,7 +849,7 @@ fn (mut s Scanner) text_scan() token.Token {
 					return s.new_token(.and_assign, '', 2)
 				}
 				afternextc := s.look_ahead(2)
-				if nextc == `&` && afternextc.is_space() {
+				if nextc == `&` && (afternextc.is_space() || afternextc == `!`) {
 					s.pos++
 					return s.new_token(.and, '', 2)
 				}

--- a/vlib/v/tests/scanner_and_and_not_test.v
+++ b/vlib/v/tests/scanner_and_and_not_test.v
@@ -1,0 +1,5 @@
+fn test_and_and_not_parses() {
+	ok1 := true
+	ok2 := false && !ok1
+	assert ok2 == false
+}


### PR DESCRIPTION
This PR fix false &&!ok1 (fix #7524).

```v
fn main() {
    ok1 := true
    ok2 := false &&!ok1
    println(ok2)
}

PS D:\Test\v\tt1> v run .
false
```