### PR TITLE
checker: fix struct init with update expr (fix #9472)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -563,11 +563,6 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 					node.update_expr.pos())
 			}
 		}
-		if !node.update_expr.is_lvalue() {
-			// cgen will repeat `update_expr` for each field
-			// so enforce an lvalue for efficiency
-			c.error('expression is not an lvalue', node.update_expr.pos())
-		}
 	}
 	return node.typ
 }

--- a/vlib/v/checker/tests/struct_init_update_type_err.out
+++ b/vlib/v/checker/tests/struct_init_update_type_err.out
@@ -19,13 +19,6 @@ vlib/v/checker/tests/struct_init_update_type_err.vv:20:6: error: struct `Foo2` i
       |            ~~
    21 |     }
    22 |     _ = Foo{
-vlib/v/checker/tests/struct_init_update_type_err.vv:23:6: error: expression is not an lvalue
-   21 |     }
-   22 |     _ = Foo{
-   23 |         ...Foo{}
-      |            ~~~~~
-   24 |     }
-   25 | }
 vlib/v/checker/tests/struct_init_update_type_err.vv:32:6: error: struct `Empty` is not compatible with struct `Foo`
    30 |     e := Empty{}
    31 |     _ = Foo{

--- a/vlib/v/tests/struct_init_with_update_test.v
+++ b/vlib/v/tests/struct_init_with_update_test.v
@@ -1,0 +1,23 @@
+module main
+
+struct Author {
+  username string
+  age int
+}
+
+fn cool_author() Author {
+  return Author{
+    username: 'Terisback'
+    age: 18
+  }
+}
+
+fn test_struct_init_with_update_expr() {
+  mut o := Author{
+    ...cool_author()
+    age: 21
+  }
+  println(o)
+  assert o.username == 'Terisback'
+  assert o.age == 21
+}

--- a/vlib/v/tests/struct_init_with_update_test.v
+++ b/vlib/v/tests/struct_init_with_update_test.v
@@ -1,23 +1,23 @@
 module main
 
 struct Author {
-  username string
-  age int
+	username string
+	age      int
 }
 
 fn cool_author() Author {
-  return Author{
-    username: 'Terisback'
-    age: 18
-  }
+	return Author{
+		username: 'Terisback'
+		age: 18
+	}
 }
 
 fn test_struct_init_with_update_expr() {
-  mut o := Author{
-    ...cool_author()
-    age: 21
-  }
-  println(o)
-  assert o.username == 'Terisback'
-  assert o.age == 21
+	mut o := Author{
+		...cool_author()
+		age: 21
+	}
+	println(o)
+	assert o.username == 'Terisback'
+	assert o.age == 21
 }

--- a/vlib/v/tests/struct_init_with_update_test.v
+++ b/vlib/v/tests/struct_init_with_update_test.v
@@ -2,12 +2,18 @@ module main
 
 struct Author {
 	username string
+	name     string
+	pass     string
+	height   int
 	age      int
 }
 
 fn cool_author() Author {
 	return Author{
 		username: 'Terisback'
+		name: 'Bob'
+		pass: '123456'
+		height: 175
 		age: 18
 	}
 }
@@ -19,5 +25,8 @@ fn test_struct_init_with_update_expr() {
 	}
 	println(o)
 	assert o.username == 'Terisback'
+	assert o.name == 'Bob'
+	assert o.pass == '123456'
+	assert o.height == 175
 	assert o.age == 21
 }


### PR DESCRIPTION
This PR fix struct init with update expr (fix #9472).

- Fix struct init with update expr.
- Using temporary value when update expr is not lvalue.
- Add test.

```v
module main

struct Author {
	username string
	name     string
	pass     string
	height   int
	age      int
}

fn cool_author() Author {
	return Author{
		username: 'Terisback'
		name: 'Bob'
		pass: '123456'
		height: 175
		age: 18
	}
}

fn main() {
	mut o := Author{
		...cool_author()
		age: 21
	}
	println(o)
	assert o.username == 'Terisback'
	assert o.name == 'Bob'
	assert o.pass == '123456'
	assert o.height == 175
	assert o.age == 21
}

PS D:\Test\v\tt1> v run .
Author{
    username: 'Terisback'
    name: 'Bob'
    pass: '123456'
    height: 175
    age: 21
}
```
generated c codes:
```v
VV_LOCAL_SYMBOL void main__main(void) {
	main__Author _t1 = main__cool_author();
	main__Author o = ((main__Author){.username = _t1.username,.name = _t1.name,.pass = _t1.pass,.height = _t1.height,.age = 21,});
	println(main__Author_str(o));
...
```