### PR TITLE
cgen: fix shared optional (fix #9569)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2903,7 +2903,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				node.return_type.clear_flag(.optional)
 			}
 			mut shared_styp := ''
-			if g.is_shared && !ret_type.has_flag(.shared_f) {
+			if g.is_shared && !ret_type.has_flag(.shared_f) && !g.inside_or_block {
 				ret_sym := g.table.sym(ret_type)
 				shared_typ := ret_type.set_flag(.shared_f)
 				shared_styp = g.typ(shared_typ)
@@ -2932,7 +2932,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				g.strs_to_free0 = []
 				// println('pos=$node.pos.pos')
 			}
-			if g.is_shared && !ret_type.has_flag(.shared_f) {
+			if g.is_shared && !ret_type.has_flag(.shared_f) && !g.inside_or_block {
 				g.writeln('}, sizeof($shared_styp))')
 			}
 			// if g.autofree && node.autofree_pregen != '' { // g.strs_to_free0.len != 0 {

--- a/vlib/v/tests/shared_optional_test.v
+++ b/vlib/v/tests/shared_optional_test.v
@@ -1,0 +1,25 @@
+module main
+
+struct ABC {
+mut:
+	s string
+}
+
+fn test_shared_optional() {
+	shared abc := foo() or { panic('scared') }
+	rlock abc {
+		println(abc)
+		assert abc.s == 'hello'
+	}
+}
+
+fn foo() ?ABC {
+	mut a := ABC{}
+	a.bar()?
+	return a
+}
+
+fn (mut a ABC) bar() ? {
+	a.s = 'hello'
+	println(a.s)
+}


### PR DESCRIPTION
This PR fix shared optional (fix #9569).

- Fix shared optional.
- Add test.

```v
module main

struct ABC {
mut:
	s string
}

fn main() {
	shared abc := foo() or { panic('scared') }
	rlock abc {
		println(abc)
		assert abc.s == 'hello'
	}
}

fn foo() ?ABC {
	mut a := ABC{}
	a.bar()?
	return a
}

fn (mut a ABC) bar() ? {
	a.s = 'hello'
	println(a.s)
}

PS D:\Test\v\tt1> v run .
hello
ABC{
    s: 'hello'
}
```