### PR TITLE
tutorials: remove unnecessary json.encode in vweb tutorial

### DIFF
--- a/tutorials/building_a_simple_web_blog_with_vweb/README.md
+++ b/tutorials/building_a_simple_web_blog_with_vweb/README.md
@@ -384,12 +384,11 @@ in V is very simple:
 ```v oksyntax
 // article.v
 import vweb
-import json
 
 ['/articles'; get]
 pub fn (mut app App) articles() vweb.Result {
 	articles := app.find_all_articles()
-	return app.json(json.encode(articles))
+	return app.json(articles)
 }
 ```
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Remove unnecessary `json.encode` in the `/articles` JSON endpoint because the `app.json` already does that.
If it is not removed, the response will look like this:

```
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 151
Server: VWeb
Connection: close

"[{\"id\":1,\"title\":\"Hello, World!\",\"text\":\"V is great!\"},{\"id\":2,\"title\":\"Second post\",\"text\":\"Hmm... What should I write about?\"}]"
```

Here's the response after the proposed changes:

```
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 129
Server: VWeb
Connection: close

[{"id":1,"title":"Hello, World!","text":"V is great!"},{"id":2,"title":"Second post","text":"Hmm... What should I write about?"}]
```
