### PR TITLE
checker, fmt: check infix_expr with 'and' op

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -20,6 +20,11 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	if node.op == .key_is {
 		c.inside_x_is_type = false
 	}
+	if node.op == .amp && left_type.is_bool() && right_type.is_bool() && right_type.is_ptr() {
+		pos := node.pos.extend(node.right.pos())
+		c.error('the right expression should be separated from the `&&` by a space', pos)
+		return ast.bool_type
+	}
 	node.right_type = right_type
 	if left_type.is_number() && !left_type.is_ptr()
 		&& right_type in [ast.int_literal_type, ast.float_literal_type] {

--- a/vlib/v/checker/tests/infix_and_op_expr_err.out
+++ b/vlib/v/checker/tests/infix_and_op_expr_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/infix_and_op_expr_err.vv:3:17: error: the right expression should be separated from the `&&` by a space
+    1 | fn main() {
+    2 |     ok1 := true
+    3 |     ok2 := false&&ok1
+      |                 ~~
+    4 |     println(ok2)
+    5 | }

--- a/vlib/v/checker/tests/infix_and_op_expr_err.vv
+++ b/vlib/v/checker/tests/infix_and_op_expr_err.vv
@@ -1,0 +1,5 @@
+fn main() {
+    ok1 := true
+    ok2 := false&&ok1
+    println(ok2)
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2055,16 +2055,21 @@ pub fn (mut f Fmt) infix_expr(node ast.InfixExpr) {
 	f.expr(node.left)
 	is_one_val_array_init := node.op in [.key_in, .not_in] && node.right is ast.ArrayInit
 		&& (node.right as ast.ArrayInit).exprs.len == 1
+	is_and := node.op == .amp && f.node_str(node.right).starts_with('&')
 	if is_one_val_array_init {
 		// `var in [val]` => `var == val`
 		op := if node.op == .key_in { ' == ' } else { ' != ' }
 		f.write(op)
+	} else if is_and {
+		f.write(' && ')
 	} else {
 		f.write(' $node.op.str() ')
 	}
 	if is_one_val_array_init {
 		// `var in [val]` => `var == val`
 		f.expr((node.right as ast.ArrayInit).exprs[0])
+	} else if is_and {
+		f.write(f.node_str(node.right).trim_string_left('&'))
 	} else {
 		f.expr(node.right)
 	}

--- a/vlib/v/fmt/tests/infix_expr_and_op_expected.vv
+++ b/vlib/v/fmt/tests/infix_expr_and_op_expected.vv
@@ -1,0 +1,5 @@
+fn main() {
+	ok1 := true
+	ok2 := false && ok1
+	println(ok2)
+}

--- a/vlib/v/fmt/tests/infix_expr_and_op_input.vv
+++ b/vlib/v/fmt/tests/infix_expr_and_op_input.vv
@@ -1,0 +1,5 @@
+fn main() {
+    ok1 := true
+    ok2 := false&&ok1
+    println(ok2)
+}


### PR DESCRIPTION
This PR check infix_expr with `and` op.

- Check infix_expr with `and` op.
- Fix vfmt of infix_expr with `and` op.
- Add tests.

```v
fn main() {
    ok1 := true
    ok2 := false&&ok1
    println(ok2)
}

PS D:\Test\v\tt1> v run .
./tt1.v:3:17: error: the right expression should be separated from the `&&` by a space
    1 | fn main() {
    2 |     ok1 := true
    3 |     ok2 := false&&ok1
      |                 ~~
    4 |     println(ok2)
    5 | }
```
v fmt:
```v
fn main() {
    ok1 := true
    ok2 := false&&ok1
    println(ok2)
}
```
fmt to
```v
fn main() {
	ok1 := true
	ok2 := false && ok1
	println(ok2)
}
```