### PR TITLE
ast: fix string interpolation fmt with result call (fix #15465)

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -210,7 +210,7 @@ pub fn (lit &StringInterLiteral) get_fspec_braces(i int) (string, bool) {
 				}
 				CallExpr {
 					if sub_expr.args.len != 0 || sub_expr.concrete_types.len != 0
-						|| sub_expr.or_block.kind == .propagate_option
+						|| sub_expr.or_block.kind in [.propagate_option, .propagate_result]
 						|| sub_expr.or_block.stmts.len > 0 {
 						needs_braces = true
 					} else if sub_expr.left is CallExpr {

--- a/vlib/v/fmt/tests/string_intp_with_result_keep.vv
+++ b/vlib/v/fmt/tests/string_intp_with_result_keep.vv
@@ -1,0 +1,7 @@
+fn err() !u8 {
+	return 1
+}
+
+fn main() {
+	println('${err()!}')
+}


### PR DESCRIPTION
This PR fix string interpolation fmt with result call (fix #15465).

- Fix string interpolation fmt with result call.
- Add test.

keep fmt:
```v
fn err() !u8 {
	return 1
}

fn main() {
	println('${err()!}')
}
```