### PR TITLE
cgen: fix push on closed channel (fix #15442)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -390,8 +390,6 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) string {
 	}
 
 	global_g.gen_jsons()
-	global_g.write_optionals()
-	global_g.write_results()
 	global_g.dump_expr_definitions() // this uses global_g.get_str_fn, so it has to go before the below for loop
 	for i := 0; i < global_g.str_types.len; i++ {
 		global_g.final_gen_str(global_g.str_types[i])
@@ -406,6 +404,8 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) string {
 	global_g.gen_array_index_methods()
 	global_g.gen_equality_fns()
 	global_g.gen_free_methods()
+	global_g.write_results()
+	global_g.write_optionals()
 	global_g.sort_globals_consts()
 	global_g.timers.show('cgen unification')
 

--- a/vlib/v/tests/inout/push_on_closed_channel.out
+++ b/vlib/v/tests/inout/push_on_closed_channel.out
@@ -1,0 +1,1 @@
+Channel closed.

--- a/vlib/v/tests/inout/push_on_closed_channel.vv
+++ b/vlib/v/tests/inout/push_on_closed_channel.vv
@@ -1,0 +1,7 @@
+module main
+
+fn main() {
+	ch := chan int{cap: 100}
+	ch.close()
+	ch <- 1 or { println('Channel closed.') }
+}


### PR DESCRIPTION
This PR fix push on closed channel (fix #15442).

- Fix push on closed channel.
- Add test.

```v
fn main() {
	ch := chan int{cap: 100}
	ch.close()
	ch <- 1 or { println('Channel closed.') }
}

PS D:\Test\v\tt1> v run .
Channel closed.
```