### PR TITLE
checker: fix comptime if generic value shift (fix #15470)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -401,7 +401,9 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 	return true
 }
 
-fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type ast.Type, right_type ast.Type) ast.Type {
+fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type_ ast.Type, right_type_ ast.Type) ast.Type {
+	left_type := c.unwrap_generic(left_type_)
+	right_type := c.unwrap_generic(right_type_)
 	if !left_type.is_int() {
 		left_sym := c.table.sym(left_type)
 		// maybe it's an int alias? TODO move this to is_int()?

--- a/vlib/v/tests/comptime_if_generic_shift_test.v
+++ b/vlib/v/tests/comptime_if_generic_shift_test.v
@@ -1,0 +1,13 @@
+fn generic<T>(val T) T {
+	$if T is u64 {
+		println(val << 1)
+		return val << 1
+	}
+	return val
+}
+
+fn test_comptime_if_generic_shift() {
+	ret := generic(u64(2))
+	println(ret)
+	assert ret == 4
+}


### PR DESCRIPTION
This PR fix comptime if generic value shift (fix #15470).

- Fix comptime if generic value shift.
- Add test.

```v
fn generic<T>(val T) T {
	$if T is u64 {
		println(val << 1)
		return val << 1
	}
	return val
}

fn main() {
	ret := generic(u64(2))
	println(ret)
	assert ret == 4
}

PS D:\Test\v\tt1> v run .
4
4
```