### PR TITLE
parser: check generic struct init using multi return type (fix #15369)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -675,6 +675,9 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 			is_instance = true
 		}
 		gts := p.table.sym(gt)
+		if gts.kind == .multi_return {
+			p.error_with_pos('cannot use multi return as generic concrete type', type_pos)
+		}
 		if !is_instance && gts.name.len > 1 {
 			p.error_with_pos('generic struct parameter name needs to be exactly one char',
 				type_pos)

--- a/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.out
+++ b/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/generic_struct_type_using_multi_return_err.vv:6:18: error: cannot use multi return as generic concrete type
+    4 |
+    5 | fn main() {
+    6 |     sample := Tuple<(int, int)>{}
+      |                     ~~~~~~~~~~
+    7 |     println(sample)
+    8 | }

--- a/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.vv
+++ b/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.vv
@@ -1,0 +1,8 @@
+struct Tuple<T> {
+	data T
+}
+
+fn main() {
+	sample := Tuple<(int, int)>{}
+	println(sample)
+}


### PR DESCRIPTION
This PR check generic struct init using multi return type (fix #15369, fix #15366).

- Check generic struct init using multi return type.
- Add test.

```v
struct Tuple<T> {
	data T
}

fn main() {
	sample := Tuple<(int, int)>{}
	println(sample)
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:18: error: cannot use multi return as generic concrete type
    4 | 
    5 | fn main() {
    6 |     sample := Tuple<(int, int)>{}
      |                     ~~~~~~~~~~
    7 |     println(sample)
    8 | }
```
```v
import datatypes { Queue }

fn main() {
	example := Queue<(int, int)>{}
	// ...
	first, second := example.pop()?
	// ...
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:19: error: cannot use multi return as generic concrete type
    2 |
    3 | fn main() {
    4 |     example := Queue<(int, int)>{}
      |                      ~~~~~~~~~~
    5 |     // ...
    6 |     first, second := example.pop()?
```