### PR TITLE
vdoc: highlight variadic function parameters

### DIFF
--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -214,7 +214,7 @@ fn color_highlight(code string, tb &ast.Table) string {
 					} else if
 						(next_tok.kind in [.lcbr, .rpar, .eof, .comma, .pipe, .name, .rcbr, .assign, .key_pub, .key_mut, .pipe, .comma, .comment]
 						&& next_tok.lit !in builtin)
-						&& (prev.kind in [.name, .amp, .lcbr, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe, .key_interface, .comment]
+						&& (prev.kind in [.name, .amp, .lcbr, .rsbr, .key_type, .assign, .dot, .question, .rpar, .key_struct, .key_enum, .pipe, .key_interface, .comment, .ellipsis]
 						&& prev.lit !in builtin) && ((tok.lit != '' && tok.lit[0].is_capital())
 						|| prev_prev.lit in ['C', 'JS']) {
 						tok_typ = .symbol


### PR DESCRIPTION
With this PR `v doc`'s syntax highlighter now highlights symbols which are provided as `variadic` type.

![image](https://user-images.githubusercontent.com/28479139/185732983-966cca6d-b136-4d55-a874-8ec1540d5a64.png)


