### PR TITLE
v.vcache, v.builder: use the module name inside the usecache paths (for more readable cache entries at a glance)

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -891,8 +891,8 @@ fn (mut b Builder) build_thirdparty_obj_files() {
 			$if windows {
 				if b.pref.ccompiler == 'msvc' {
 					b.build_thirdparty_obj_file_with_msvc(flag.mod, flag.value, rest_of_module_flags)
+					continue
 				}
-				continue
 			}
 			b.build_thirdparty_obj_file(flag.mod, flag.value, rest_of_module_flags)
 		}

--- a/vlib/v/builder/cflags.v
+++ b/vlib/v/builder/cflags.v
@@ -13,7 +13,8 @@ fn (mut v Builder) get_os_cflags() []cflag.CFlag {
 	}
 	for mut flag in v.table.cflags {
 		if flag.value.ends_with('.o') {
-			flag.cached = v.pref.cache_manager.postfix_with_key2cpath('.o', os.real_path(flag.value))
+			flag.cached = v.pref.cache_manager.mod_postfix_with_key2cpath(flag.mod, '.o',
+				os.real_path(flag.value))
 		}
 		if flag.os == '' || flag.os in ctimedefines {
 			flags << flag

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -388,7 +388,7 @@ pub fn (mut v Builder) cc_msvc() {
 	os.rm(out_name_obj) or {}
 }
 
-fn (mut v Builder) build_thirdparty_obj_file_with_msvc(path string, moduleflags []cflag.CFlag) {
+fn (mut v Builder) build_thirdparty_obj_file_with_msvc(mod string, path string, moduleflags []cflag.CFlag) {
 	msvc := v.cached_msvc
 	if msvc.valid == false {
 		verror('Cannot find MSVC on this OS')

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -193,12 +193,12 @@ fn (mut b Builder) v_build_module(vexe string, imp_path string) {
 }
 
 fn (mut b Builder) rebuild_cached_module(vexe string, imp_path string) string {
-	res := b.pref.cache_manager.exists('.o', imp_path) or {
+	res := b.pref.cache_manager.mod_exists(imp_path, '.o', imp_path) or {
 		if b.pref.is_verbose {
 			println('Cached $imp_path .o file not found... Building .o file for $imp_path')
 		}
 		b.v_build_module(vexe, imp_path)
-		rebuilded_o := b.pref.cache_manager.exists('.o', imp_path) or {
+		rebuilded_o := b.pref.cache_manager.mod_exists(imp_path, '.o', imp_path) or {
 			panic('could not rebuild cache module for $imp_path, error: $err.msg()')
 		}
 		return rebuilded_o

--- a/vlib/v/vcache/vcache.v
+++ b/vlib/v/vcache/vcache.v
@@ -107,6 +107,16 @@ pub fn (mut cm CacheManager) postfix_with_key2cpath(postfix string, key string) 
 	return res
 }
 
+fn normalise_mod(mod string) string {
+	return mod.replace('/', '.').replace('\\', '.').replace('vlib.', '').trim('.')
+}
+
+pub fn (mut cm CacheManager) mod_postfix_with_key2cpath(mod string, postfix string, key string) string {
+	prefix := cm.key2cpath(key)
+	res := '${prefix}.module.${normalise_mod(mod)}$postfix'
+	return res
+}
+
 pub fn (mut cm CacheManager) exists(postfix string, key string) ?string {
 	fpath := cm.postfix_with_key2cpath(postfix, key)
 	dlog(@FN, 'postfix: $postfix | key: $key | fpath: $fpath')
@@ -116,6 +126,17 @@ pub fn (mut cm CacheManager) exists(postfix string, key string) ?string {
 	return fpath
 }
 
+pub fn (mut cm CacheManager) mod_exists(mod string, postfix string, key string) ?string {
+	fpath := cm.mod_postfix_with_key2cpath(mod, postfix, key)
+	dlog(@FN, 'mod: $mod | postfix: $postfix | key: $key | fpath: $fpath')
+	if !os.exists(fpath) {
+		return error('does not exist yet')
+	}
+	return fpath
+}
+
+//
+
 pub fn (mut cm CacheManager) save(postfix string, key string, content string) ?string {
 	fpath := cm.postfix_with_key2cpath(postfix, key)
 	os.write_file(fpath, content)?
@@ -123,10 +144,26 @@ pub fn (mut cm CacheManager) save(postfix string, key string, content string) ?s
 	return fpath
 }
 
+pub fn (mut cm CacheManager) mod_save(mod string, postfix string, key string, content string) ?string {
+	fpath := cm.mod_postfix_with_key2cpath(mod, postfix, key)
+	os.write_file(fpath, content)?
+	dlog(@FN, 'mod: $mod | postfix: $postfix | key: $key | fpath: $fpath')
+	return fpath
+}
+
+//
+
 pub fn (mut cm CacheManager) load(postfix string, key string) ?string {
 	fpath := cm.exists(postfix, key)?
 	content := os.read_file(fpath)?
 	dlog(@FN, 'postfix: $postfix | key: $key | fpath: $fpath')
+	return content
+}
+
+pub fn (mut cm CacheManager) mod_load(mod string, postfix string, key string) ?string {
+	fpath := cm.mod_exists(mod, postfix, key)?
+	content := os.read_file(fpath)?
+	dlog(@FN, 'mod: $mod | postfix: $postfix | key: $key | fpath: $fpath')
 	return content
 }
 


### PR DESCRIPTION
The new cache paths look like this:
```
~/.vmodules/cache/49/49c109d7fb7f6c858a87b8bc7bb1b0f6.dependencies
~/.vmodules/cache/49/49c109d7fb7f6c858a87b8bc7bb1b0f6.build_options
~/.vmodules/cache/98
~/.vmodules/cache/98/982b25d7ee599f6992721973814f1dad.module.v.vnew.os.description.txt
~/.vmodules/cache/98/982b25d7ee599f6992721973814f1dad.module.v.vnew.os.o
~/.vmodules/cache/a8
~/.vmodules/cache/a8/a8bbfbaffbdd74d9123249a226d92a80.module.v.vnew.strings.textscanner.o
~/.vmodules/cache/a8/a8bbfbaffbdd74d9123249a226d92a80.module.v.vnew.strings.textscanner.description.txt
~/.vmodules/cache/b7
~/.vmodules/cache/b7/b7dc6d156ddb2811a4684aefe4889354.hashes
~/.vmodules/cache/embed_file
~/.vmodules/cache/8e
~/.vmodules/cache/8e/8e2cfe3dbe1495b4d5dd51633a0346b2.module.v.vnew.sokol.sapp.description.txt
~/.vmodules/cache/8e/8e2cfe3dbe1495b4d5dd51633a0346b2.module.v.vnew.sokol.sapp.o
~/.vmodules/cache/85
~/.vmodules/cache/85/85db2065b7916c346ee7ae467fd60a36.module.v.vnew.sokol.f.o
~/.vmodules/cache/85/85db2065b7916c346ee7ae467fd60a36.module.v.vnew.sokol.f.description.txt
~/.vmodules/cache/df
~/.vmodules/cache/df/df3735d6ce3958b81d079d3677937d3c.module.builtin.description.txt
~/.vmodules/cache/df/df3735d6ce3958b81d079d3677937d3c.module.builtin.o
```

=> -showcc now looks like this:

```
  -std=gnu99 -D_DEFAULT_SOURCE -o "/v/vnew/examples/hello_world" -D GC_BUILTIN_ATOMIC=1
  -D GC_THREADS=1 -I "/v/vnew/thirdparty/libgc/include" "/tmp/v_1000/hello_world.16247884100066807359.tmp.c"
  -bt25 /home/delian/.vmodules/cache/df/df3735d6ce3958b81d079d3677937d3c.module.builtin.o
"/v/vnew/thirdparty/tcc/lib/libgc.a" -ldl -lpthread 
```