### PR TITLE
checker: fix generic method with nested generic method (fix #15475)

### DIFF
--- a/vlib/v/tests/generics_method_with_nested_generic_method_test.v
+++ b/vlib/v/tests/generics_method_with_nested_generic_method_test.v
@@ -1,0 +1,23 @@
+struct Dummy {}
+
+fn (dummy &Dummy) res<T>() !T {
+	$if T is int {
+		return 1
+	} $else $if T is f32 {
+		return dummy.res<int>()! + 1
+	} $else {
+		return error('exhausted')
+	}
+}
+
+fn test_generics_method_with_nested_generic_method() ! {
+	d := Dummy{}
+
+	println(d.res<int>()!)
+	ret1 := d.res<int>()!
+	assert ret1 == 1
+
+	println(d.res<f32>()!)
+	ret2 := d.res<f32>()!
+	assert ret2 == 2.0
+}


### PR DESCRIPTION
This PR fix generic method with nested generic method (fix #15475).

- Fix generic method with nested generic method.
- Fix test with propgate result.
- Add test.

```v
struct Dummy {}

fn (dummy &Dummy) res<T>() !T {
	$if T is int {
		return 1
	} $else $if T is f32 {
		return dummy.res<int>()! + 1
	} $else {
		return error('exhausted')
	}
}

fn main() {
	d := Dummy{}

	println(d.res<int>()!)
	ret1 := d.res<int>()!
	assert ret1 == 1

	println(d.res<f32>()!)
	ret2 := d.res<f32>()!
	assert ret2 == 2.0
}

PS D:\Test\v\tt1> v run .
1
2.
```