### PR TITLE
parser: add error for `none` used as variant in un-named sum type

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -312,6 +312,13 @@ pub fn (mut p Parser) parse_inline_sum_type() ast.Type {
 			p.warn_with_pos('an inline sum type expects a maximum of $parser.maximum_inline_sum_type_variants types ($variants.len were given)',
 				pos)
 		}
+		for variant in variants {
+			variant_sym := p.table.sym(variant.typ)
+			if variant_sym.kind == .none_ {
+				p.error_with_pos('sum type cannot have none as its variant', variant.pos)
+				return ast.Type(0)
+			}
+		}
 		mut variant_names := variants.map(p.table.sym(it.typ).name)
 		variant_names.sort()
 		// deterministic name

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3773,9 +3773,8 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	if sum_variants.len > 1 {
 		for variant in sum_variants {
 			variant_sym := p.table.sym(variant.typ)
-			// TODO: implement this check for error too
 			if variant_sym.kind == .none_ {
-				p.error_with_pos('named sum type cannot have none as its variant', variant.pos)
+				p.error_with_pos('sum type cannot have none as its variant', variant.pos)
 				return ast.AliasTypeDecl{}
 			}
 		}

--- a/vlib/v/parser/tests/named_sum_type_none_err.out
+++ b/vlib/v/parser/tests/named_sum_type_none_err.out
@@ -1,3 +1,3 @@
-vlib/v/parser/tests/named_sum_type_none_err.vv:1:34: error: named sum type cannot have none as its variant
+vlib/v/parser/tests/named_sum_type_none_err.vv:1:34: error: sum type cannot have none as its variant
     1 | type Abc = string | int | bool | none
       |                                  ~~~~

--- a/vlib/v/parser/tests/unnamed_sum_type_none_err.out
+++ b/vlib/v/parser/tests/unnamed_sum_type_none_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/unnamed_sum_type_none_err.vv:1:19: error: sum type cannot have none as its variant
+    1 | fn number() int | none {
+      |                   ~~~~
+    2 |     return none
+    3 | }

--- a/vlib/v/parser/tests/unnamed_sum_type_none_err.vv
+++ b/vlib/v/parser/tests/unnamed_sum_type_none_err.vv
@@ -1,0 +1,3 @@
+fn number() int | none {
+	return none
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fixes https://github.com/vlang/v/issues/15481 and https://github.com/vlang/v/issues/15479
