### PR TITLE
scanner: add check for invalid unicode

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1237,7 +1237,7 @@ fn (mut s Scanner) ident_string() string {
 	if start <= s.pos {
 		mut string_so_far := s.text[start..end]
 		if !s.is_fmt && u_escapes_pos.len > 0 {
-			string_so_far = decode_u_escapes(string_so_far, start, u_escapes_pos)
+			string_so_far = s.decode_u_escapes(string_so_far, start, u_escapes_pos)
 		}
 		if !s.is_fmt && h_escapes_pos.len > 0 {
 			string_so_far = decode_h_escapes(string_so_far, start, h_escapes_pos)
@@ -1297,23 +1297,30 @@ fn decode_o_escapes(s string, start int, escapes_pos []int) string {
 }
 
 // decode the flagged unicode escape sequences into their utf-8 bytes
-fn decode_u_escapes(s string, start int, escapes_pos []int) string {
+fn (mut s Scanner) decode_u_escapes(str string, start int, escapes_pos []int) string {
 	if escapes_pos.len == 0 {
-		return s
+		return str
 	}
 	mut ss := []string{cap: escapes_pos.len * 2 + 1}
-	ss << s[..escapes_pos.first() - start]
+	ss << str[..escapes_pos.first() - start]
 	for i, pos in escapes_pos {
 		idx := pos - start
 		end_idx := idx + 6 // "\uXXXX".len == 6
-		ss << utf32_to_str(u32(strconv.parse_uint(s[idx + 2..end_idx], 16, 32) or { 0 }))
+		ss << utf32_to_str(u32(strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }))
 		if i + 1 < escapes_pos.len {
-			ss << s[end_idx..escapes_pos[i + 1] - start]
+			ss << str[end_idx..escapes_pos[i + 1] - start]
 		} else {
-			ss << s[end_idx..]
+			ss << str[end_idx..]
 		}
 	}
-	return ss.join('')
+	str_from_utf := ss.join('')
+	// Check if string has valid Unicode Points
+	for st in str_from_utf.runes() {
+		if st.length_in_bytes() == -1 {
+			s.error('invalid unicode point `$str`')
+		}
+	}
+	return str_from_utf
 }
 
 fn trim_slash_line_break(s string) string {
@@ -1391,7 +1398,7 @@ fn (mut s Scanner) ident_char() string {
 		if (c.len % 2 == 0) && (escaped_hex || escaped_unicode || escaped_octal) {
 			if escaped_unicode {
 				// there can only be one, so attempt to decode it now
-				c = decode_u_escapes(c, 0, [0])
+				c = s.decode_u_escapes(c, 0, [0])
 			} else {
 				// find escape sequence start positions
 				mut escapes_pos := []int{}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1306,21 +1306,19 @@ fn (mut s Scanner) decode_u_escapes(str string, start int, escapes_pos []int) st
 	for i, pos in escapes_pos {
 		idx := pos - start
 		end_idx := idx + 6 // "\uXXXX".len == 6
-		ss << utf32_to_str(u32(strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }))
+		escaped_code_point := strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }
+		// Check if Escaped Code Point is invalid or not
+		if rune(escaped_code_point).length_in_bytes() == -1 {
+			s.error('invalid unicode point `$str`')
+		}
+		ss << utf32_to_str(u32(escaped_code_point))
 		if i + 1 < escapes_pos.len {
 			ss << str[end_idx..escapes_pos[i + 1] - start]
 		} else {
 			ss << str[end_idx..]
 		}
 	}
-	str_from_utf := ss.join('')
-	// Check if string has valid Unicode Points
-	for st in str_from_utf.runes() {
-		if st.length_in_bytes() == -1 {
-			s.error('invalid unicode point `$str`')
-		}
-	}
-	return str_from_utf
+	return ss.join('')
 }
 
 fn trim_slash_line_break(s string) string {

--- a/vlib/v/scanner/tests/invalid_unicode_err.out
+++ b/vlib/v/scanner/tests/invalid_unicode_err.out
@@ -1,0 +1,4 @@
+vlib/v/scanner/tests/invalid_unicode_err.vv:1:13: error: invalid unicode point `\uD8FF`
+    1 | a := '\uD8FF'
+      |             ^
+    2 | println(a)

--- a/vlib/v/scanner/tests/invalid_unicode_err.vv
+++ b/vlib/v/scanner/tests/invalid_unicode_err.vv
@@ -1,0 +1,2 @@
+a := '\uD8FF'
+println(a)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fixes https://github.com/vlang/v/issues/10717

Works for both `rune` and `string` types
![image](https://user-images.githubusercontent.com/28479139/185801556-662d9f20-0705-4f2b-b91b-df39707e8f31.png)



