### PR TITLE
cgen: fix json encode struct with alias field (fix #15486)

### DIFF
--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -488,3 +488,23 @@ struct StByteArray {
 fn test_byte_array() {
 	assert json.encode(StByteArray{ ba: [byte(1), 2, 3, 4, 5] }) == '{"ba":[1,2,3,4,5]}'
 }
+
+struct Aa {
+	sub SumType
+}
+
+struct Bb {
+	a int
+}
+
+type SumType = Bb
+
+fn test_encode_alias_field() {
+	s := json.encode(Aa{
+		sub: SumType(Bb{
+			a: 1
+		})
+	})
+	println(s)
+	assert s == '{"sub":{"a":1}}'
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -436,7 +436,7 @@ fn (mut g Gen) gen_struct_enc_dec(type_info ast.TypeInfo, styp string, mut enc s
 					}
 					dec.writeln('\t}')
 				} else {
-					g.gen_json_for_type(field.typ)
+					g.gen_json_for_type(alias.parent_type)
 					tmp := g.new_tmp_var()
 					gen_js_get_opt(dec_name, field_type, styp, tmp, name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_$tmp) {')


### PR DESCRIPTION
This PR fix json encode struct with alias field (fix #15486).

- Fix json encode struct with alias field.
- Add test.

```v
import json

struct Aa {
	sub SumType
}

struct Bb {
	a int
}

type SumType = Bb

fn main() {
	s := json.encode(Aa{
		sub: Bb{
			a: 1
		}
	})
	println(s)
	assert s == '{"sub":{"a":1}}'
}

PS D:\Test\v\tt1> v run .
{"sub":{"a":1}}
```