### PR TITLE
cgen: fix match sumtype var with `none` (fix #15481)

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -172,7 +172,11 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 				be := unsafe { &branch.exprs[sumtype_index] }
 				if sym.kind == .sum_type {
 					g.write('${dot_or_ptr}_typ == ')
-					g.expr(be)
+					if be is ast.None {
+						g.write('$ast.none_type.idx() /* none */')
+					} else {
+						g.expr(be)
+					}
 				} else if sym.kind == .interface_ {
 					if be is ast.TypeNode {
 						typ := be as ast.TypeNode

--- a/vlib/v/tests/match_sumtype_var_with_none_test.v
+++ b/vlib/v/tests/match_sumtype_var_with_none_test.v
@@ -1,0 +1,13 @@
+fn number() int|none {
+	return none
+}
+
+fn test_match_sumtype_var_with_none() {
+	n := number()
+	ret := match n {
+		int { 'n: $n' }
+		none { '?' }
+	}
+	println(ret)
+	assert ret == '?'
+}


### PR DESCRIPTION
This PR fix match sumtyp var with `none` (fix #15481).

- Fix match sumtyp var with `none`.
- Add test.

```v
fn number() int|none {
	return none
}

fn main() {
	n := number()
	ret := match n {
		int { 'n: $n' }
		none { '?' }
	}
	println(ret)
	assert ret == '?'
}

PS D:\Test\v\tt1> v run .
?
```