### PR TITLE
cgen: fix if sumtype var is `none` (fix #15479)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -619,7 +619,11 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 	} else if left_sym.kind == .sum_type {
 		g.write('_typ $cmp_op ')
 	}
-	g.expr(node.right)
+	if node.right is ast.None {
+		g.write('$ast.none_type.idx() /* none */')
+	} else {
+		g.expr(node.right)
+	}
 }
 
 fn (mut g Gen) gen_interface_is_op(node ast.InfixExpr) {

--- a/vlib/v/tests/inout/printing_sumtype_with_none.out
+++ b/vlib/v/tests/inout/printing_sumtype_with_none.out
@@ -1,0 +1,3 @@
+first field is a string
+second field is none
+third field is None

--- a/vlib/v/tests/inout/printing_sumtype_with_none.vv
+++ b/vlib/v/tests/inout/printing_sumtype_with_none.vv
@@ -1,0 +1,35 @@
+module main
+
+struct None {}
+
+struct MyStruct {
+	my_first_field  string|none
+	my_second_field string|none
+	my_third_field  string|None
+}
+
+fn main() {
+	s := MyStruct{
+		my_first_field: 'blah'
+		my_second_field: none
+		my_third_field: None{}
+	}
+
+	println(if s.my_first_field is string {
+		'first field is a string'
+	} else {
+		'first field is none'
+	})
+
+	println(if s.my_second_field is none {
+		'second field is none'
+	} else {
+		'second field is a string'
+	})
+
+	println(if s.my_third_field is None {
+		'third field is None'
+	} else {
+		'third field is a string'
+	})
+}


### PR DESCRIPTION
This PR fix if sumtype var is `none` (fix #15479).

- Fix if sumtype var is `none`.
- Add test.

```v
module main

struct None {}

struct MyStruct {
	my_first_field  string|none
	my_second_field string|none
	my_third_field  string|None
}

fn main() {
	s := MyStruct{
		my_first_field: 'blah'
		my_second_field: none
		my_third_field: None{}
	}

	println(if s.my_first_field is string {
		'first field is a string'
	} else {
		'first field is none'
	})

	println(if s.my_second_field is none {
		'second field is none'
	} else {
		'second field is a string'
	})

	println(if s.my_third_field is None {
		'third field is None'
	} else {
		'third field is a string'
	})
}

PS D:\Test\v\tt1> v run .
first field is a string
second field is none
third field is None
```