### PR TITLE
builtin: add carray_to_varray, closes #15493

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -126,7 +126,7 @@ fn new_array_from_c_array_no_alloc(len int, cap int, elm_size int, c_array voidp
 	return arr
 }
 
-// carray_to_varray converts a C byte array into a V `u8` array.
+// carray_to_varray copies a C byte array into a V `u8` array.
 // See also: `cstring_to_vstring`
 [unsafe]
 pub fn carray_to_varray(c_array voidptr, c_array_len int) []u8 {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -126,6 +126,15 @@ fn new_array_from_c_array_no_alloc(len int, cap int, elm_size int, c_array voidp
 	return arr
 }
 
+// carray_to_varray converts a C byte array into a V `u8` array.
+// See also: `cstring_to_vstring`
+[unsafe]
+pub fn carray_to_varray(c_array voidptr, c_array_len int) []u8 {
+	mut v_array := []u8{len: c_array_len}
+	unsafe { vmemcpy(v_array.data, c_array, c_array_len * int(sizeof(u8))) }
+	return v_array
+}
+
 // Private function. Increases the `cap` of an array to the
 // required value by copying the data to a new memory location
 // (creating a clone) unless `a.cap` is already large enough.

--- a/vlib/v/tests/c_array_test.c
+++ b/vlib/v/tests/c_array_test.c
@@ -1,7 +1,7 @@
 void* gen_c_array(int size) {
-    unsigned char *c_array = calloc(sizeof(*c_array) * size, size);
+    unsigned char *c_array = malloc(size);
     for(int i = 0; i < size; i++) {
-        c_array[i] = i;
+        c_array[i] = i & 0xFF;
     }
     return c_array;
 }

--- a/vlib/v/tests/c_array_test.c
+++ b/vlib/v/tests/c_array_test.c
@@ -1,0 +1,8 @@
+void* gen_c_array(int size) {
+    unsigned char *c_array = calloc(sizeof(*c_array) * size, size);
+    for(int i = 0; i < size; i++) {
+        c_array[i] = i;
+    }
+    return c_array;
+}
+

--- a/vlib/v/tests/c_array_test.v
+++ b/vlib/v/tests/c_array_test.v
@@ -1,0 +1,13 @@
+#insert "@VEXEROOT/vlib/v/tests/c_array_test.c"
+
+fn C.gen_c_array(size int) voidptr
+
+fn test_carray_to_varray() {
+	size := 10
+	mut c_array := C.gen_c_array(size)
+	v_array := unsafe { carray_to_varray(c_array, size) }
+	assert v_array.len == size
+	for i, elem in v_array {
+		assert elem == i
+	}
+}

--- a/vlib/v/tests/c_array_test.v
+++ b/vlib/v/tests/c_array_test.v
@@ -6,6 +6,7 @@ fn test_carray_to_varray() {
 	size := 10
 	mut c_array := C.gen_c_array(size)
 	v_array := unsafe { carray_to_varray(c_array, size) }
+	unsafe { C.free(c_array) }
 	assert v_array.len == size
 	for i, elem in v_array {
 		assert elem == i


### PR DESCRIPTION
This PR adds a convenience function like `cstring_to_vstring`.

Closes #15493 