### PR TITLE
checker: check unknown array of fn type in struct field  (fix #9380)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3827,6 +3827,13 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) ? {
 				return
 			}
 		}
+		.function {
+			fn_info := sym.info as ast.FnType
+			c.ensure_type_exists(fn_info.func.return_type, fn_info.func.return_type_pos)?
+			for param in fn_info.func.params {
+				c.ensure_type_exists(param.typ, param.type_pos)?
+			}
+		}
 		.array {
 			c.ensure_type_exists((sym.info as ast.Array).elem_type, pos)?
 		}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -68,16 +68,6 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 							field.type_pos)
 					}
 				}
-				field_sym := c.table.sym(field.typ)
-				if field_sym.kind == .function {
-					fn_info := field_sym.info as ast.FnType
-					c.ensure_type_exists(fn_info.func.return_type, fn_info.func.return_type_pos) or {
-						return
-					}
-					for param in fn_info.func.params {
-						c.ensure_type_exists(param.typ, param.type_pos) or { return }
-					}
-				}
 			}
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct

--- a/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
+++ b/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv:2:22: error: unknown type `UnknownThing`.
+Did you mean `[2]fn (u32) UnknownThing`?
+    1 | struct Virt {
+    2 |     fns [2]fn (num u32) UnknownThing
+      |                         ~~~~~~~~~~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv
+++ b/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv
@@ -1,0 +1,10 @@
+struct Virt {
+	fns [2]fn (num u32) UnknownThing
+}
+
+fn (virt Virt) caller() {
+	func := virt.fns[0]
+	func(5)
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check unknown array of fn type in struct field  (fix #9380).

- Check unknown array of fn type in struct field.
- Add test.

```v
struct Virt {
	fns [2]fn (num u32) UnknownThing
}

fn (virt Virt) caller() {
	func := virt.fns[0]
	func(5)
}

fn main() {}

PS D:\Test\v\tt1> v run .
./tt1.v:2:22: error: unknown type `UnknownThing`.
Did you mean `[2]fn (u32) UnknownThing`?
    1 | struct Virt {
    2 |     fns [2]fn (num u32) UnknownThing
      |                         ~~~~~~~~~~~~
    3 | }
    4 |
```
```v
struct Virt {
	fns[2] fn (num u32)
}

fn print_table(virt &Virt) {
	println(virt)
}

fn main() {
	virt := Virt{}
	print_table(&virt)
}

PS D:\Test\v\tt1> v run .
&Virt{
    fns: [fn (u32), fn (u32)]
}
```
```v
struct Context {
	virt &Virt
}

struct Virt {
	set[2] fn (virt &Virt)
}

pub fn (ctx &Context) set_fill_style() {
	ctx.virt.set[0](ctx.virt)
}

fn main() {}

PS D:\Test\v\tt1> v run .
```