### PR TITLE
checker: don't show warning with `free` methods already marked as `unsafe`

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1165,10 +1165,6 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			return ast.int_type
 		}
 	}
-	if !c.is_builtin_mod && !c.inside_unsafe && method_name == 'free' {
-		c.warn('manual memory management with `free()` is only allowed in unsafe code',
-			node.pos)
-	}
 	if left_type == ast.void_type {
 		// No need to print this error, since this means that the variable is unknown,
 		// and there already was an error before.
@@ -1602,6 +1598,10 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		c.fail_if_unreadable(node.left, left_type, 'receiver')
 		return ast.string_type
 	} else if method_name == 'free' {
+		if !c.is_builtin_mod && !c.inside_unsafe && !method.is_unsafe {
+			c.warn('manual memory management with `free()` is only allowed in unsafe code',
+				node.pos)
+		}
 		return ast.void_type
 	}
 	// call struct field fn type


### PR DESCRIPTION
This PR prevents warning from being displayed with `free` methods already marked as `unsafe`.

before:
```v
warning: manual memory management with `free()` is only allowed in unsafe code
    6 |
    7 | x := ""
    8 | x.free()
      |   ~~~~~~
warning: method `string.free` must be called from an `unsafe` block
    6 |
    7 | x := ""
    8 | x.free()
      |   ~~~~~~
```

after:
```v
warning: method `string.free` must be called from an `unsafe` block
    5 | import math
    6 |
    7 | "".free()
      |    ~~~~~~
```