### PR TITLE
checker: check error for simple assignment with dumping of multireturn value

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -17,7 +17,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 	mut right_len := node.right.len
 	mut right_type0 := ast.void_type
 	for i, mut right in node.right {
-		if right in [ast.CallExpr, ast.IfExpr, ast.LockExpr, ast.MatchExpr] {
+		if right in [ast.CallExpr, ast.IfExpr, ast.LockExpr, ast.MatchExpr, ast.DumpExpr] {
 			if right in [ast.IfExpr, ast.MatchExpr] && node.left.len == node.right.len && !is_decl
 				&& node.left[i] in [ast.Ident, ast.SelectorExpr] && !node.left[i].is_blank_ident() {
 				c.expected_type = c.expr(node.left[i])

--- a/vlib/v/checker/tests/assign_with_dump_multireturn_value.out
+++ b/vlib/v/checker/tests/assign_with_dump_multireturn_value.out
@@ -1,4 +1,4 @@
-vlib/v/checker/assign_with_dump_multireturn_value.vv:5:3: error: assignment mismatch: 1 variable(s) 2 value(s)
+vlib/v/checker/tests/assign_with_dump_multireturn_value.vv:5:3: error: assignment mismatch: 1 variable(s) 2 value(s)
     3 | }
     4 | 
     5 | x := dump(two_returns())

--- a/vlib/v/checker/tests/assign_with_dump_multireturn_value.out
+++ b/vlib/v/checker/tests/assign_with_dump_multireturn_value.out
@@ -1,0 +1,6 @@
+vlib/v/checker/assign_with_dump_multireturn_value.vv:5:3: error: assignment mismatch: 1 variable(s) 2 value(s)
+    3 | }
+    4 | 
+    5 | x := dump(two_returns())
+      |   ~~
+    6 | println(x)

--- a/vlib/v/checker/tests/assign_with_dump_multireturn_value.vv
+++ b/vlib/v/checker/tests/assign_with_dump_multireturn_value.vv
@@ -1,0 +1,6 @@
+fn two_returns() (string, string) {
+	return 'hello', 'world'
+}
+
+x := dump(two_returns())
+println(x)


### PR DESCRIPTION
This PR check error for simple assignment with dumping of multireturn value

```v
fn two_returns() (string, string) {
	return 'hello', 'world'
}

x := dump(two_returns())
println(x)
```

```v
x.v:3:3: error: assignment mismatch: 1 variable(s) 2 value(s)
    1 | fn two_returns() (string, string) { return 'hello', 'world' }
    2 |
    3 | x := dump(two_returns())
      |   ~~
    4 | println(x)
```

Fix #9346.