### PR TITLE
parser: fixed #15516 Anonymous struct name conflict

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -47,6 +47,8 @@ pub mut:
 	// cache for type_to_str_using_aliases
 	cached_type_to_str map[u64]string
 	anon_struct_names  map[string]int // anon struct name -> struct sym idx
+	// counter for anon struct, avoid name conflicts.
+	anon_struct_counter int
 }
 
 // used by vls to avoid leaks

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -91,7 +91,6 @@ mut:
 	if_cond_comments          []ast.Comment
 	script_mode               bool
 	script_mode_start_token   token.Token
-	anon_struct_counter       int
 pub mut:
 	scanner    &scanner.Scanner
 	errors     []errors.Error

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -41,8 +41,8 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 		return ast.StructDecl{}
 	}
 	mut name := if is_anon {
-		p.anon_struct_counter++
-		'_VAnonStruct$p.anon_struct_counter'
+		p.table.anon_struct_counter++
+		'_VAnonStruct$p.table.anon_struct_counter'
 	} else {
 		p.check_name()
 	}

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -261,3 +261,7 @@ fn test_fn_is_html_open_tag() {
 	b = is_html_open_tag('style', s)
 	assert b == false
 }
+
+// For issue #15516
+fn test_anon_struct() {
+}


### PR DESCRIPTION
a.v:

```v
module main

import json

fn main() {
	_ := json.decode(Foo, '{}') or { return }
}

struct Foo {
	data []struct {
		name string
	}
}

```

b.v:

```v
module main

pub struct Bar {
	data []struct {
		name string
	}
}

```

pass through.
