### PR TITLE
cgen: fix array init with it (fix #15521)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -246,6 +246,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.indent++
 		g.writeln('$elem_typ* pelem = ($elem_typ*)${tmp}.data;')
 		g.writeln('for(int it=0; it<${tmp}.len; it++, pelem++) {')
+		g.set_current_pos_as_last_stmt_pos()
 		g.indent++
 		g.write('*pelem = ')
 		g.expr(node.default_expr)
@@ -254,6 +255,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.writeln('}')
 		g.indent--
 		g.writeln('}')
+		g.set_current_pos_as_last_stmt_pos()
 		if var_name.len == 0 {
 			if s_ends_with_ln {
 				g.writeln(s)

--- a/vlib/v/tests/array_with_it_test.v
+++ b/vlib/v/tests/array_with_it_test.v
@@ -15,3 +15,12 @@ fn test_array_with_it() {
 	a4 := []int{len: 5, init: 5 - it}
 	assert a4 == [5, 4, 3, 2, 1]
 }
+
+fn test_array_init_with_optional() {
+	input := [3.1, 1.1]
+	arr := []f64{len: 3, init: input[it] or { 0.0 }}
+	println(arr)
+	assert arr[0] == 3.1
+	assert arr[1] == 1.1
+	assert arr[2] == 0.0
+}


### PR DESCRIPTION
This PR fix array init with it (fix #15521).

- Fix array init with it.
- Add test.

```v
fn main() {
	input := [3.1, 1.1]
	arr := []f64{len: 3, init: input[it] or { 0.0 }}
	println(arr)
	assert arr[0] == 3.1
	assert arr[1] == 1.1
	assert arr[2] == 0.0
}

PS D:\Test\v\tt1> v run .
[3.1, 1.1, 0]
```