### PR TITLE
cmd/tools/where: check if parent already included vlib_dir

### DIFF
--- a/cmd/tools/vwhere/finder.v
+++ b/cmd/tools/vwhere/finder.v
@@ -62,7 +62,7 @@ fn (mut fdr Finder) search_for_matches() {
 	mut paths_to_search := []string{}
 	if fdr.dirs.len == 0 && fdr.modul == '' {
 		paths_to_search << [current_dir, vmod_dir]
-		if vlib_dir !in paths_to_search {
+		if vlib_dir !in paths_to_search && paths_to_search.all(!vlib_dir.starts_with(it)) {
 			paths_to_search << vlib_dir
 		}
 		paths_to_search << vmod_paths


### PR DESCRIPTION
Fix #15046 edge case, when you are in the v compilers directory, and you run `v where fn <function to look for>` and it will collect the results two times, first time in the current dir, second time in the vlib_dir.