### PR TITLE
parser, checker, cgen: implement generics anon fn (fix #15120)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -122,6 +122,11 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 				}
 				continue
 			}
+			if got_typ_sym.kind == .function && exp_typ_sym.kind == .function {
+				if (got_typ_sym.info as ast.FnType).is_anon {
+					continue
+				}
+			}
 			pos := node.exprs[expr_idxs[i]].pos()
 			c.error('cannot use `$got_typ_sym.name` as type `${c.table.type_to_str(exp_type)}` in return argument',
 				pos)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -677,7 +677,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	}
 	p.scope.detached_from_parent = true
 	inherited_vars := if p.tok.kind == .lsbr { p.closure_vars() } else { []ast.Param{} }
-	// TODO generics
+	_, generic_names := p.parse_generic_types()
 	args, _, is_variadic := p.fn_args()
 	for arg in args {
 		if arg.name.len == 0 && p.table.sym(arg.typ).kind != .placeholder {
@@ -759,6 +759,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			params: args
 			is_variadic: is_variadic
 			is_method: false
+			generic_names: generic_names
 			is_anon: true
 			no_body: no_body
 			pos: pos.extend(p.prev_tok.pos())

--- a/vlib/v/tests/generics_closure_fn_test.v
+++ b/vlib/v/tests/generics_closure_fn_test.v
@@ -1,0 +1,20 @@
+fn setter<T>(mut m map[T]int) fn (T, int) {
+	return fn [mut m] <T>(x T, k int) {
+		m[x] = k
+	}
+}
+
+fn test_generics_closure_fn() {
+	mut m := {
+		f32(0.1): 1
+	}
+
+	f := setter(mut m)
+	f(0.2, 2)
+
+	println(m)
+	assert m == {
+		f32(0.1): 1
+		0.2:      2
+	}
+}


### PR DESCRIPTION
This PR implement generics anon fn (fix #15120, fix #13253).

- Implement generics anon fn.
- Add test.

```v
fn setter<T>(mut m map[T]int) fn (T, int) {
	return fn [mut m] <T>(x T, k int) {
		m[x] = k
	}
}

fn main() {
	mut m := {
		f32(0.1): 1
	}

	f := setter(mut m)
	f(0.2, 2)

	println(m)
	assert m == {
		f32(0.1): 1
		0.2:      2
	}
}

PS D:\Test\v\tt1> v run .
{0.1: 1, 0.2: 2}
```
```v
fn closure<T>(input T) fn () T {
	return fn [input] <T>() T {
		return input
	}
}

fn main() {
	f := closure(123)
	println(f())
}

PS D:\Test\v\tt1> v run .
123
```