### PR TITLE
cgen: cleanup generic_fn_name()

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -291,7 +291,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				if left_sym.kind == .struct_ && (left_sym.info as ast.Struct).generic_types.len > 0 {
 					concrete_types := (left_sym.info as ast.Struct).concrete_types
 					mut method_name := left_sym.cname + '_' + util.replace_op(extracted_op)
-					method_name = g.generic_fn_name(concrete_types, method_name, true)
+					method_name = g.generic_fn_name(concrete_types, method_name)
 					g.write(' = ${method_name}(')
 					g.expr(left)
 					g.write(', ')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -77,7 +77,7 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 		}
 	}
 	if sym.has_method_with_generic_parent('str') && mut sym.info is ast.Struct {
-		str_fn_name = g.generic_fn_name(sym.info.concrete_types, str_fn_name, false)
+		str_fn_name = g.generic_fn_name(sym.info.concrete_types, str_fn_name)
 	}
 	g.str_types << StrType{
 		typ: unwrapped
@@ -895,8 +895,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		field_styp_fn_name := if sym_has_str_method {
 			mut field_fn_name := '${field_styp}_str'
 			if sym.info is ast.Struct {
-				field_fn_name = g.generic_fn_name(sym.info.concrete_types, field_fn_name,
-					false)
+				field_fn_name = g.generic_fn_name(sym.info.concrete_types, field_fn_name)
 			}
 			field_fn_name
 		} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -920,7 +920,7 @@ fn (mut g Gen) base_type(_t ast.Type) string {
 	return styp
 }
 
-fn (mut g Gen) generic_fn_name(types []ast.Type, before string, is_decl bool) string {
+fn (mut g Gen) generic_fn_name(types []ast.Type, before string) string {
 	if types.len == 0 {
 		return before
 	}
@@ -2202,7 +2202,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			exp_styp := exp_sym.cname
 			mut fname := 'I_${got_styp}_to_Interface_$exp_styp'
 			if exp_sym.info.is_generic {
-				fname = g.generic_fn_name(exp_sym.info.concrete_types, fname, false)
+				fname = g.generic_fn_name(exp_sym.info.concrete_types, fname)
 			}
 			g.call_cfn_for_casting_expr(fname, expr, expected_is_ptr, exp_styp, true,
 				got_styp)
@@ -2222,7 +2222,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			}
 			fname = '/*$exp_sym*/$fname'
 			if exp_sym.info.is_generic {
-				fname = g.generic_fn_name(exp_sym.info.concrete_types, fname, false)
+				fname = g.generic_fn_name(exp_sym.info.concrete_types, fname)
 			}
 			g.call_cfn_for_casting_expr(fname, expr, expected_is_ptr, exp_styp, got_is_ptr,
 				got_styp)
@@ -5844,8 +5844,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 					parent_sym := g.table.sym(inter_info.parent_type)
 					match parent_sym.info {
 						ast.Struct, ast.Interface, ast.SumType {
-							name = g.generic_fn_name(parent_sym.info.concrete_types, method.name,
-								false)
+							name = g.generic_fn_name(parent_sym.info.concrete_types, method.name)
 						}
 						else {}
 					}
@@ -5858,8 +5857,7 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 				// .speak = Cat_speak
 				if st_sym.info is ast.Struct {
 					if method.generic_names.len > 0 && st_sym.info.parent_type.has_flag(.generic) {
-						name = g.generic_fn_name(st_sym.info.concrete_types, method.name,
-							false)
+						name = g.generic_fn_name(st_sym.info.concrete_types, method.name)
 					}
 				}
 				styp := g.cc_type(method.params[0].typ, true)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -420,7 +420,7 @@ fn (mut g Gen) c_fn_name(node &ast.FnDecl) ?string {
 	}
 
 	if node.generic_names.len > 0 {
-		name = g.generic_fn_name(g.cur_concrete_types, name, true)
+		name = g.generic_fn_name(g.cur_concrete_types, name)
 	}
 
 	if g.pref.translated || g.file.is_translated {
@@ -447,7 +447,7 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	g.gen_anon_fn_decl(mut node)
 	mut fn_name := node.decl.name
 	if node.decl.generic_names.len > 0 {
-		fn_name = g.generic_fn_name(g.cur_concrete_types, fn_name, true)
+		fn_name = g.generic_fn_name(g.cur_concrete_types, fn_name)
 	}
 
 	if !node.decl.scope.has_inherited_vars() {
@@ -1009,7 +1009,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 	}
 	concrete_types := node.concrete_types.map(g.unwrap_generic(it))
-	name = g.generic_fn_name(concrete_types, name, false)
+	name = g.generic_fn_name(concrete_types, name)
 	// TODO2
 	// g.generate_tmp_autofree_arg_vars(node, name)
 	if !node.receiver_type.is_ptr() && left_type.is_ptr() && node.name == 'str' {
@@ -1238,10 +1238,10 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		if func := g.table.find_fn(node.name) {
 			if func.generic_names.len > 0 {
 				if g.comptime_for_field_type != 0 && g.inside_comptime_for_field {
-					name = g.generic_fn_name([g.comptime_for_field_type], name, false)
+					name = g.generic_fn_name([g.comptime_for_field_type], name)
 				} else {
 					concrete_types := node.concrete_types.map(g.unwrap_generic(it))
-					name = g.generic_fn_name(concrete_types, name, false)
+					name = g.generic_fn_name(concrete_types, name)
 				}
 			}
 		}

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -346,8 +346,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 		receiver_sym := g.table.sym(receiver_typ)
 		if receiver_sym.info is ast.Struct {
 			if receiver_sym.info.concrete_types.len > 0 {
-				fn_name = g.generic_fn_name(receiver_sym.info.concrete_types, fn_name,
-					false)
+				fn_name = g.generic_fn_name(receiver_sym.info.concrete_types, fn_name)
 			}
 		}
 		g.write('\t${g.typ(ret_typ)} $t_var = ${fn_name}(')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -305,7 +305,7 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 		}
 		concrete_types := (left.sym.info as ast.Struct).concrete_types
 		mut method_name := left.sym.cname + '__lt'
-		method_name = g.generic_fn_name(concrete_types, method_name, true)
+		method_name = g.generic_fn_name(concrete_types, method_name)
 		g.write(method_name)
 		if node.op in [.lt, .ge] {
 			g.write('(')
@@ -660,7 +660,7 @@ fn (mut g Gen) infix_expr_arithmetic_op(node ast.InfixExpr) {
 	if left.sym.kind == .struct_ && (left.sym.info as ast.Struct).generic_types.len > 0 {
 		concrete_types := (left.sym.info as ast.Struct).concrete_types
 		mut method_name := left.sym.cname + '_' + util.replace_op(node.op.str())
-		method_name = g.generic_fn_name(concrete_types, method_name, true)
+		method_name = g.generic_fn_name(concrete_types, method_name)
 		g.write(method_name)
 		g.write('(')
 		g.expr(node.left)

--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -332,7 +332,7 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 	} else {
 		mut name := util.no_dots('${receiver_type_name}_$node.name')
 
-		name = g.generic_fn_name(node.concrete_types, name, false)
+		name = g.generic_fn_name(node.concrete_types, name)
 		g.write('${name}(')
 		g.expr(it.left)
 		g.gen_deref_ptr(it.left_type)
@@ -434,7 +434,7 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 		g.write(')')
 		return
 	}
-	name = g.generic_fn_name(node.concrete_types, name, false)
+	name = g.generic_fn_name(node.concrete_types, name)
 	g.expr(it.left)
 
 	g.write('${name}(')
@@ -574,7 +574,7 @@ fn fn_has_go(node ast.FnDecl) bool {
 	return has_go
 }
 
-fn (mut g JsGen) generic_fn_name(types []ast.Type, before string, is_decl bool) string {
+fn (mut g JsGen) generic_fn_name(types []ast.Type, before string) string {
 	if types.len == 0 {
 		return before
 	}
@@ -623,7 +623,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl, typ FnGenType) {
 	}
 	name = g.js_name(name)
 
-	name = g.generic_fn_name(g.cur_concrete_types, name, true)
+	name = g.generic_fn_name(g.cur_concrete_types, name)
 	if name in js.builtin_functions {
 		name = 'builtin__$name'
 	}
@@ -797,7 +797,7 @@ fn (mut g JsGen) gen_anon_fn(mut fun ast.AnonFn) {
 
 	name = g.js_name(name)
 
-	name = g.generic_fn_name(g.table.cur_concrete_types, name, true)
+	name = g.generic_fn_name(g.table.cur_concrete_types, name)
 	if name in js.builtin_functions {
 		name = 'builtin__$name'
 	}


### PR DESCRIPTION
This PR clean up generic_fn_name() in cgen.

- Remove unused parameter `is_decl`.
- Modify all the related calls.