### PR TITLE
os: typo in error message - `folder` instead of `$folder`

### DIFF
--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -482,7 +482,7 @@ pub fn is_writable_folder(folder string) ?bool {
 		return error('`$folder` does not exist')
 	}
 	if !is_dir(folder) {
-		return error('`folder` is not a folder')
+		return error('`$folder` is not a folder')
 	}
 	tmp_perm_check := join_path_single(folder, 'XXXXXX')
 	defer {


### PR DESCRIPTION
Hey,

I found a small typo in your error handling when passed a folder which isn't a folder. 
The resulting error message is: "builder error: `folder` is not a folder"

I can reproduce it on my ubuntu 20.04.1 by typing: touch not_a_folder ; v not_a_folder/main.v

I hope that was helpful. It was also my very first pull request to v.

:wave: 