### PR TITLE
log: add target_from_label and unit tests

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -48,7 +48,7 @@ fn tag_to_file(l Level) string {
 	}
 }
 
-// level_from_tag returns the log level from the given string if matches.
+// level_from_tag returns the log level from the given string if it matches.
 pub fn level_from_tag(tag string) ?Level {
 	return match tag {
 		'DISABLED' { Level.disabled }
@@ -57,6 +57,16 @@ pub fn level_from_tag(tag string) ?Level {
 		'WARN' { Level.warn }
 		'INFO' { Level.info }
 		'DEBUG' { Level.debug }
+		else { none }
+	}
+}
+
+// target_from_label returns the log target from the given string if it matches.
+pub fn target_from_label(label string) ?LogTarget {
+	return match label {
+		'console' { LogTarget.console }
+		'file' { LogTarget.file }
+		'both' { LogTarget.both }
 		else { none }
 	}
 }

--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -80,3 +80,33 @@ fn test_logger_mutable_reference() {
 	assert true
 	println(@FN + ' end')
 }
+
+fn test_level_from_tag() ? {
+	assert level_from_tag('INFO')? == .info
+	assert level_from_tag('FATAL')? == .fatal
+	assert level_from_tag('WARN')? == .warn
+	assert level_from_tag('ERROR')? == .error
+	assert level_from_tag('DEBUG')? == .debug
+
+	invalid := ['', 'FOO', 'nope']
+
+	for value in invalid {
+		mut passed := false
+		level_from_tag(value) or { passed = true }
+		assert passed
+	}
+}
+
+fn test_target_from_label() ? {
+	assert target_from_label('console')? == .console
+	assert target_from_label('file')? == .file
+	assert target_from_label('both')? == .both
+
+	invalid := ['', 'FOO', 'nope']
+
+	for value in invalid {
+		mut passed := false
+		target_from_label(value) or { passed = true }
+		assert passed
+	}
+}


### PR DESCRIPTION
There is a utility function `level_from_tag` for `LogLevel`, but the same did not exist for `LogTarget`. This PR adds it, along with some unit tests.