### PR TITLE
ast, parser, cgen: fix closure with nested closure variable (fix #15270)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -644,6 +644,7 @@ pub:
 	is_arg          bool // fn args should not be autofreed
 	is_auto_deref   bool
 	is_inherited    bool
+	has_inherited   bool
 pub mut:
 	expr       Expr
 	typ        Type

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -460,7 +460,18 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	g.write('__closure_create($fn_name, ($ctx_struct*) memdup_uncollectable(&($ctx_struct){')
 	g.indent++
 	for var in node.inherited_vars {
-		g.writeln('.$var.name = $var.name,')
+		mut has_inherited := false
+		if obj := node.decl.scope.find(var.name) {
+			if obj is ast.Var {
+				if obj.has_inherited {
+					has_inherited = true
+					g.writeln('.$var.name = $c.closure_ctx->$var.name,')
+				}
+			}
+		}
+		if !has_inherited {
+			g.writeln('.$var.name = $var.name,')
+		}
 	}
 	g.indent--
 	g.write('}, sizeof($ctx_struct)))')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1042,6 +1042,7 @@ fn (mut p Parser) closure_vars() []ast.Param {
 			...(*var)
 			pos: var_pos
 			is_inherited: true
+			has_inherited: var.is_inherited
 			is_used: false
 			is_changed: false
 			is_mut: is_mut

--- a/vlib/v/tests/inout/closure_with_nested_closure_var.out
+++ b/vlib/v/tests/inout/closure_with_nested_closure_var.out
@@ -1,0 +1,2 @@
+Test1{}, Test(Test1{})
+Test1{}, Test(Test1{})

--- a/vlib/v/tests/inout/closure_with_nested_closure_var.vv
+++ b/vlib/v/tests/inout/closure_with_nested_closure_var.vv
@@ -1,0 +1,23 @@
+module main
+
+interface Test {
+	test(fn (Test))
+}
+
+struct Test1 {
+}
+
+fn (t Test1) test(f fn (Test)) {
+	f(Test(t))
+}
+
+fn main() {
+	t := Test1{}
+
+	t.test(fn [t] (t1 Test) {
+		println('$t, $t1')
+		t.test(fn [t] (t2 Test) {
+			println('$t, $t2')
+		})
+	})
+}


### PR DESCRIPTION
This PR fix closure with nested closure variable (fix #15270).

- Fix closure with nested closure variable.
- Add test.

```v
module main

interface Test {
	test(fn (Test))
}

struct Test1 {
}

fn (t Test1) test(f fn (Test)) {
	f(Test(t))
}

fn main() {
	t := Test1{}

	t.test(fn [t] (t1 Test) {
		println('$t, $t1')
		t.test(fn [t] (t2 Test) {
			println('$t, $t2')
		})
	})
}

PS D:\Test\v\tt1> v run .
Test1{}, Test(Test1{})
Test1{}, Test(Test1{})
```