### PR TITLE
checker: fix no error on plus-assigning array (fix #15544)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -361,7 +361,7 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					node.pos)
 			}
 		}
-		if left_sym.kind == .array && right_sym.kind == .array {
+		if left_sym.kind == .array && right_sym.kind == .array && node.op == .assign {
 			// `mut arr := [u8(1),2,3]`
 			// `arr = [byte(4),5,6]`
 			left_info := left_sym.info as ast.Array

--- a/vlib/v/checker/tests/array_plus_assign_err.out
+++ b/vlib/v/checker/tests/array_plus_assign_err.out
@@ -1,0 +1,8 @@
+./vlib/v/checker/tests/array_plus_assign_err.vv:1:5: warning: unused variable: `buffer`
+    1 | mut buffer := []u8{cap: 1024}
+      |     ~~~~~~
+    2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
+./vlib/v/checker/tests/array_plus_assign_err.vv:2:1: error: operator `+=` not defined on left operand type `[]u8`
+    1 | mut buffer := []u8{cap: 1024}
+    2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
+      | ~~~~~~

--- a/vlib/v/checker/tests/array_plus_assign_err.out
+++ b/vlib/v/checker/tests/array_plus_assign_err.out
@@ -1,8 +1,8 @@
-./vlib/v/checker/tests/array_plus_assign_err.vv:1:5: warning: unused variable: `buffer`
+vlib/v/checker/tests/array_plus_assign_err.vv:1:5: warning: unused variable: `buffer`
     1 | mut buffer := []u8{cap: 1024}
       |     ~~~~~~
     2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
-./vlib/v/checker/tests/array_plus_assign_err.vv:2:1: error: operator `+=` not defined on left operand type `[]u8`
+vlib/v/checker/tests/array_plus_assign_err.vv:2:1: error: operator `+=` not defined on left operand type `[]u8`
     1 | mut buffer := []u8{cap: 1024}
     2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
       | ~~~~~~

--- a/vlib/v/checker/tests/array_plus_assign_err.vv
+++ b/vlib/v/checker/tests/array_plus_assign_err.vv
@@ -1,0 +1,2 @@
+mut buffer := []u8{cap: 1024}
+buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()


### PR DESCRIPTION
This PR fix no error on performing plus-assigning on array (fix #15544):
- Fix condition checking
- Add output test

```v
mut buffer := []u8{cap: 1024}
buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()

>>>
./vlib/v/checker/tests/array_plus_assign_err.vv:1:5: warning: unused variable: `buffer`
    1 | mut buffer := []u8{cap: 1024}
      |     ~~~~~~
    2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
./vlib/v/checker/tests/array_plus_assign_err.vv:2:1: error: operator `+=` not defined on left operand type `[]u8`
    1 | mut buffer := []u8{cap: 1024}
    2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
      | ~~~~~~
```