### PR TITLE
v.pref: skip vlib/builtin/prealloc.c.v, when -prealloc is not passed

### DIFF
--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -30,7 +30,7 @@ pub fn (prefs &Preferences) should_compile_filtered_files(dir string, files_ []s
 		if file.starts_with('.#') {
 			continue
 		}
-		if !prefs.prealloc && file.ends_with('prealloc.c.v') {
+		if !prefs.prealloc && !prefs.output_cross_c && file.ends_with('prealloc.c.v') {
 			continue
 		}
 		if prefs.nofloat && file.ends_with('float.c.v') {

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -30,6 +30,9 @@ pub fn (prefs &Preferences) should_compile_filtered_files(dir string, files_ []s
 		if file.starts_with('.#') {
 			continue
 		}
+		if !prefs.prealloc && file.ends_with('prealloc.c.v') {
+			continue
+		}
 		if prefs.nofloat && file.ends_with('float.c.v') {
 			continue
 		}


### PR DESCRIPTION
Reduces the generated C source code by ~2KB.

It also makes it more compatible with https://github.com/vnmakarov/mir (use `v -gc none -o x.c examples/hello_world.v`, then `c2m ./x.c -ei`).