### PR TITLE
ast: clean up `table.find_or_register_fn_type()`

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1206,6 +1206,7 @@ pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon bool, has_decl bool)
 		kind: .function
 		name: name
 		cname: cname
+		mod: f.mod
 		info: FnType{
 			is_anon: anon
 			has_decl: has_decl

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1190,7 +1190,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 	return t.register_sym(mr_type)
 }
 
-pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, has_decl bool) int {
+pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon bool, has_decl bool) int {
 	name := if f.name.len == 0 { 'fn ${t.fn_type_source_signature(f)}' } else { f.name.clone() }
 	cname := if f.name.len == 0 {
 		'anon_fn_${t.fn_type_signature(f)}'
@@ -1206,7 +1206,6 @@ pub fn (mut t Table) find_or_register_fn_type(mod string, f Fn, is_anon bool, ha
 		kind: .function
 		name: name
 		cname: cname
-		mod: mod
 		info: FnType{
 			is_anon: anon
 			has_decl: has_decl
@@ -1609,7 +1608,7 @@ pub fn (mut t Table) resolve_generic_to_concrete(generic_type Type, generic_name
 				}
 			}
 			func.name = ''
-			idx := t.find_or_register_fn_type('', func, true, false)
+			idx := t.find_or_register_fn_type(func, true, false)
 			if has_generic {
 				return new_type(idx).derive_add_muls(generic_type).set_flag(.generic)
 			} else {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -676,7 +676,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 				if sym.info is ast.FnType {
 					mut func_ := sym.info.func
 					func_.name = ''
-					idx := c.table.find_or_register_fn_type(c.mod, func_, true, false)
+					idx := c.table.find_or_register_fn_type(func_, true, false)
 					typ = ast.new_type(idx).derive(arg.typ)
 				}
 				if arg.expr.is_auto_deref_var() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1252,8 +1252,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	}
 	if mut method := c.table.find_method(sym, field_name) {
 		if c.expected_type != 0 && c.expected_type != ast.none_type {
-			fn_type := ast.new_type(c.table.find_or_register_fn_type(c.mod, method, false,
-				true))
+			fn_type := ast.new_type(c.table.find_or_register_fn_type(method, false, true))
 			// if the expected type includes the receiver, don't hide it behind a closure
 			if c.check_types(fn_type, c.expected_type) {
 				return fn_type
@@ -1277,8 +1276,7 @@ pub fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		method.params = method.params[1..]
 		node.has_hidden_receiver = true
 		method.name = ''
-		fn_type := ast.new_type(c.table.find_or_register_fn_type(c.mod, method, false,
-			true))
+		fn_type := ast.new_type(c.table.find_or_register_fn_type(method, false, true))
 		return fn_type
 	}
 	if sym.kind !in [.struct_, .aggregate, .interface_, .sum_type] {
@@ -2845,8 +2843,7 @@ pub fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		}
 		// Non-anon-function object (not a call), e.g. `onclick(my_click)`
 		if func := c.table.find_fn(name) {
-			fn_type := ast.new_type(c.table.find_or_register_fn_type(node.mod, func, false,
-				true))
+			fn_type := ast.new_type(c.table.find_or_register_fn_type(func, false, true))
 			node.name = name
 			node.kind = .function
 			node.info = ast.IdentFn{

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -733,7 +733,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	}
 	p.cur_fn_name = keep_fn_name
 	func.name = name
-	idx := p.table.find_or_register_fn_type(p.mod, func, true, false)
+	idx := p.table.find_or_register_fn_type(func, true, false)
 	typ := ast.new_type(idx)
 	p.inside_defer = old_inside_defer
 	// name := p.table.get_type_name(typ)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -271,7 +271,7 @@ pub fn (mut p Parser) parse_fn_type(name string) ast.Type {
 	// MapFooFn typedefs are manually added in cheaders.v
 	// because typedefs get generated after the map struct is generated
 	has_decl := p.builtin_mod && name.starts_with('Map') && name.ends_with('Fn')
-	idx := p.table.find_or_register_fn_type(p.mod, func, false, has_decl)
+	idx := p.table.find_or_register_fn_type(func, false, has_decl)
 	if has_generic {
 		return ast.new_type(idx).set_flag(.generic)
 	}


### PR DESCRIPTION
This PR clean up `table.find_or_register_fn_type()`.

- Remove `mod` parameter.
- Modify all the related calls.