### PR TITLE
encoding.csv: Re-encapsulate fields in Writer/Reader (fix #15558)

### DIFF
--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -38,22 +38,23 @@ fn (err InvalidLineEndingError) msg() string {
 	return 'encoding.csv: could not find any valid line endings'
 }
 
-pub struct Reader {
+struct Reader {
 	// not used yet
 	// has_header        bool
 	// headings          []string
-	data string
-pub mut:
+	data              string
 	delimiter         u8
 	comment           u8
 	is_mac_pre_osx_le bool
-	row_pos           int
+mut:
+	row_pos int
 }
 
 [params]
 pub struct ReaderConfig {
-	delimiter u8 = `,`
-	comment   u8 = `#`
+	delimiter         u8   = `,`
+	comment           u8   = `#`
+	is_mac_pre_osx_le bool = false
 }
 
 // new_reader initializes a Reader with string data to parse and,
@@ -63,6 +64,7 @@ pub fn new_reader(data string, config ReaderConfig) &Reader {
 		data: data
 		delimiter: config.delimiter
 		comment: config.comment
+		is_mac_pre_osx_le: config.is_mac_pre_osx_le
 	}
 }
 

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -42,19 +42,18 @@ struct Reader {
 	// not used yet
 	// has_header        bool
 	// headings          []string
-	data              string
-	delimiter         u8
-	comment           u8
-	is_mac_pre_osx_le bool
+	data      string
+	delimiter u8
+	comment   u8
 mut:
-	row_pos int
+	is_mac_pre_osx_le bool
+	row_pos           int
 }
 
 [params]
 pub struct ReaderConfig {
-	delimiter         u8   = `,`
-	comment           u8   = `#`
-	is_mac_pre_osx_le bool = false
+	delimiter u8 = `,`
+	comment   u8 = `#`
 }
 
 // new_reader initializes a Reader with string data to parse and,
@@ -64,7 +63,6 @@ pub fn new_reader(data string, config ReaderConfig) &Reader {
 		data: data
 		delimiter: config.delimiter
 		comment: config.comment
-		is_mac_pre_osx_le: config.is_mac_pre_osx_le
 	}
 }
 

--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -6,18 +6,24 @@ module csv
 import strings
 
 struct Writer {
-mut:
-	sb strings.Builder
-pub mut:
 	use_crlf  bool
 	delimiter u8
+mut:
+	sb strings.Builder
+}
+
+[params]
+pub struct WriterConfig {
+	use_crlf  bool = false
+	delimiter u8   = `,`
 }
 
 // new_writer returns a reference to a Writer
-pub fn new_writer() &Writer {
+pub fn new_writer(config WriterConfig) &Writer {
 	return &Writer{
-		delimiter: `,`
 		sb: strings.new_builder(200)
+		use_crlf: config.use_crlf
+		delimiter: config.delimiter
 	}
 }
 

--- a/vlib/encoding/csv/writer_test.v
+++ b/vlib/encoding/csv/writer_test.v
@@ -9,3 +9,13 @@ fn test_encoding_csv_writer() {
 
 	assert csv_writer.str() == 'name,email,phone,other\njoe,joe@blow.com,0400000000,test\nsam,sam@likesham.com,0433000000,"needs, quoting"\n'
 }
+
+fn test_encoding_csv_writer_delimiter() {
+	mut csv_writer := csv.new_writer(delimiter: ` `)
+
+	csv_writer.write(['name', 'email', 'phone', 'other']) or {}
+	csv_writer.write(['joe', 'joe@blow.com', '0400000000', 'test']) or {}
+	csv_writer.write(['sam', 'sam@likesham.com', '0433000000', 'needs, quoting']) or {}
+
+	assert csv_writer.str() == 'name email phone other\njoe joe@blow.com 0400000000 test\nsam sam@likesham.com 0433000000 "needs, quoting"\n'
+}


### PR DESCRIPTION
This PR tweaks the encapsulation of fields in encoding.csv.Writer and encoding.csv.Reader (fix #15558):
- Writer now follows up Reader's config struct to allow users to customize `delimiter` and `use_crlf` options
- Reader is now unable to be created outside of the module, and makes `delimiter` and `comment` immutable
