### PR TITLE
checker: fix illegal result propagate on non-result type (fix #15574)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -931,6 +931,9 @@ pub fn (mut c Checker) check_expr_opt_call(expr ast.Expr, ret_type ast.Type) ast
 		} else if expr.or_block.kind == .propagate_option {
 			c.error('unexpected `?`, the function `$expr.name` does not return an optional',
 				expr.or_block.pos)
+		} else if expr.or_block.kind == .propagate_result {
+			c.error('unexpected `!`, the function `$expr.name` does not return an optional',
+				expr.or_block.pos)
 		}
 	} else if expr is ast.IndexExpr {
 		if expr.or_expr.kind != .absent {
@@ -2119,6 +2122,9 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 						node.or_block.pos)
 				} else if node.or_block.kind == .propagate_option {
 					c.error('unexpected `?`, the function `$node.name` does neither return an optional nor a result',
+						node.or_block.pos)
+				} else if node.or_block.kind == .propagate_result {
+					c.error('unexpected `!`, the function `$node.name` does neither return an optional nor a result',
 						node.or_block.pos)
 				}
 			}

--- a/vlib/v/checker/tests/result_missing_propagate_err.out
+++ b/vlib/v/checker/tests/result_missing_propagate_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/result_missing_propagate_err.vv:6:7: error: result() returns a result, so it should have either an `or {}` block, or `!` at the end
+    4 |
+    5 | fn main() {
+    6 |     a := result()
+      |          ~~~~~~~~
+    7 |     println(a)
+    8 | }

--- a/vlib/v/checker/tests/result_missing_propagate_err.vv
+++ b/vlib/v/checker/tests/result_missing_propagate_err.vv
@@ -1,0 +1,8 @@
+fn result() !int {
+	return 1
+}
+
+fn main() {
+	a := result()
+	println(a)
+}

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.out
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.out
@@ -1,10 +1,10 @@
-vlib/v/checker/tests/wrong_propagate_ret_type.vv:6:17: error: to propagate the optional call, `opt_call` must return an optional
-    4 |
-    5 | fn opt_call() int {
-    6 |     a := ret_none()?
+vlib/v/checker/tests/wrong_propagate_ret_type.vv:10:17: error: to propagate the optional call, `opt_call` must return an optional
+    8 |
+    9 | fn opt_call() int {
+   10 |     a := ret_none()?
       |                    ^
-    7 |     return a
-    8 | }
+   11 |     return a
+   12 | }
 vlib/v/checker/tests/wrong_propagate_ret_type.vv:15:17: error: unexpected `!`, the function `ret_bool` does neither return an optional nor a result
    13 |
    14 | fn res_call() bool {

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.out
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.out
@@ -5,3 +5,10 @@ vlib/v/checker/tests/wrong_propagate_ret_type.vv:6:17: error: to propagate the o
       |                    ^
     7 |     return a
     8 | }
+vlib/v/checker/tests/wrong_propagate_ret_type.vv:15:17: error: unexpected `!`, the function `ret_bool` does neither return an optional nor a result
+   13 |
+   14 | fn res_call() bool {
+   15 |     a := ret_bool()!
+      |                    ^
+   16 |     return a
+   17 | }

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.vv
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.vv
@@ -2,7 +2,16 @@ fn ret_none() ?int {
 	return none
 }
 
+fn ret_bool() bool {
+	return true
+}
+
 fn opt_call() int {
 	a := ret_none()?
+	return a
+}
+
+fn res_call() bool {
+	a := ret_bool()!
 	return a
 }


### PR DESCRIPTION
This PR fix illegal result propagate on non-result type (fix #15574):
- Error on illegal result propagate
- Add output tests

```v
fn result() !int {
	return 1
}

fn main() {
	a := result()
	println(a)
}

>>>
vlib/v/checker/tests/result_missing_propagate_err.vv:6:7: error: result() returns a result, so it should have either an `or {}` block, or `!` at the end
    4 |
    5 | fn main() {
    6 |     a := result()
      |          ~~~~~~~~
    7 |     println(a)
    8 | }
```

```v
fn ret_none() ?int {
	return none
}

fn ret_bool() bool {
	return true
}

fn opt_call() int {
	a := ret_none()?
	return a
}

fn res_call() bool {
	a := ret_bool()!
	return a
}

>>>
vlib/v/checker/tests/wrong_propagate_ret_type.vv:6:17: error: to propagate the optional call, `opt_call` must return an optional
    4 |
    5 | fn opt_call() int {
    6 |     a := ret_none()?
      |                    ^
    7 |     return a
    8 | }
vlib/v/checker/tests/wrong_propagate_ret_type.vv:15:17: error: unexpected `!`, the function `ret_bool` does neither return an optional nor a result
   13 |
   14 | fn res_call() bool {
   15 |     a := ret_bool()!
      |                    ^
   16 |     return a
   17 | }
```