### PR TITLE
parser: fix sumtype with multi fntype (fix #15557)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1215,11 +1215,6 @@ pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon bool, has_decl bool)
 	)
 }
 
-pub fn (mut t Table) unregister_fn_type(f Fn) {
-	name := if f.name.len == 0 { 'fn ${t.fn_type_source_signature(f)}' } else { f.name.clone() }
-	t.type_idxs.delete(name)
-}
-
 pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 	mut modname := ''
 	if name.contains('.') {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1215,6 +1215,11 @@ pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon bool, has_decl bool)
 	)
 }
 
+pub fn (mut t Table) unregister_fn_type(f Fn) {
+	name := if f.name.len == 0 { 'fn ${t.fn_type_source_signature(f)}' } else { f.name.clone() }
+	t.type_idxs.delete(name)
+}
+
 pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 	mut modname := ''
 	if name.contains('.') {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -526,7 +526,7 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 			return p.parse_array_type(p.tok.kind)
 		}
 		else {
-			if p.tok.kind == .lpar && !p.inside_sum_type {
+			if p.tok.kind == .lpar {
 				// multiple return
 				if is_ptr {
 					p.unexpected(prepend_msg: 'parse_type:', got: '`&` before multiple returns')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3799,7 +3799,8 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		mut func := parent_sym.info.func
 		p.table.unregister_fn_type(func)
 		func.name = fn_name
-		idx := p.table.find_or_register_fn_type(func, false, false)
+		has_decl := p.builtin_mod && fn_name.starts_with('Map') && fn_name.ends_with('Fn')
+		idx := p.table.find_or_register_fn_type(func, false, has_decl)
 		fn_type := ast.new_type(idx)
 		mut fn_sym := p.table.sym(fn_type)
 		fn_sym.is_pub = is_pub

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3797,6 +3797,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		// function type: `type mycallback = fn(string, int)`
 		fn_name := p.prepend_mod(name)
 		mut func := parent_sym.info.func
+		p.table.unregister_fn_type(func)
 		func.name = fn_name
 		idx := p.table.find_or_register_fn_type(func, false, false)
 		fn_type := ast.new_type(idx)

--- a/vlib/v/tests/inout/sumtype_with_fntype.out
+++ b/vlib/v/tests/inout/sumtype_with_fntype.out
@@ -1,1 +1,2 @@
-Fns
+Fn
+Fn

--- a/vlib/v/tests/inout/sumtype_with_fntype.vv
+++ b/vlib/v/tests/inout/sumtype_with_fntype.vv
@@ -1,8 +1,13 @@
-type Fns = bool | fn (int) int
+type Fn = fn () int | fn (int) int | string
 
 fn main() {
-	f := Fns(fn (a int) int {
+	f1 := Fn(fn (a int) int {
 		return a
 	})
-	println(typeof(f).name)
+	println(typeof(f1).name)
+
+	f2 := Fn(fn () int {
+		return 22
+	})
+	println(typeof(f2).name)
 }

--- a/vlib/v/tests/inout/sumtype_with_fntype.vv
+++ b/vlib/v/tests/inout/sumtype_with_fntype.vv
@@ -1,4 +1,4 @@
-type Fn = fn () int | fn (int) int | string
+type Fn = fn () int | fn (int) int
 
 fn main() {
 	f1 := Fn(fn (a int) int {


### PR DESCRIPTION
This PR fix sumtype with multi fntype (fix #15557).

- Fix sumtype with multi fntype.
- Add test.

```v
type Fn = fn () int | fn (int) int

fn main() {
	f1 := Fn(fn (a int) int {
		return a
	})
	println(typeof(f1).name)

	f2 := Fn(fn () int {
		return 22
	})
	println(typeof(f2).name)
}

PS D:\Test\v\tt1> v run .
Fn
Fn
```