### PR TITLE
cgen: fix cross assign of fixed array (fix #15577)

### DIFF
--- a/vlib/v/tests/cross_assign_fixed_array_test.v
+++ b/vlib/v/tests/cross_assign_fixed_array_test.v
@@ -1,0 +1,25 @@
+fn test_cross_assign_fixed_array() {
+	number := 5
+	ans := fib(number)
+
+	println(ans)
+	assert ans == 21
+}
+
+fn fib(n int) u64 {
+	if n <= 0 {
+		panic('Bad number')
+	}
+	return match n {
+		1 | 2 {
+			1
+		}
+		else {
+			mut pair := [1, 2]!
+			for _ in 0 .. n {
+				pair[0], pair[1] = pair[1], pair[0] + pair[1]
+			}
+			pair[1]
+		}
+	}
+}


### PR DESCRIPTION
This PR fix cross assign of fixed array (fix #15577).

- Fix cross assign of fixed array.
- Add test.

```v
fn main() {
	number := 5
	ans := fib(number)

	println(ans)
	assert ans == 21
}

fn fib(n int) u64 {
	if n <= 0 {
		panic('Bad number')
	}
	return match n {
		1 | 2 {
			1
		}
		else {
			mut pair := [1, 2]!
			for _ in 0 .. n {
				pair[0], pair[1] = pair[1], pair[0] + pair[1]
			}
			pair[1]
		}
	}
}

PS D:\Test\v\tt1> v run .
21
```