### PR TITLE
smtp: Add base64 encoding to the body of the email to prevent the format confusion

### DIFF
--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -245,12 +245,13 @@ fn (mut c Client) send_body(cfg Mail) ? {
 	}
 
 	if is_html {
-		sb.write_string('Content-Type: text/html; charset=UTF-8')
+		sb.write_string('Content-Type: text/html; charset=UTF-8\r\n')
 	} else {
-		sb.write_string('Content-Type: text/plain; charset=UTF-8')
+		sb.write_string('Content-Type: text/plain; charset=UTF-8\r\n')
 	}
+	sb.write_string('Content-Transfer-Encoding: base64')
 	sb.write_string('\r\n\r\n')
-	sb.write_string(cfg.body)
+	sb.write_string(base64.encode_str(cfg.body))
 	sb.write_string('\r\n.\r\n')
 	c.send_str(sb.str())?
 	c.expect_reply(.action_ok)?

--- a/vlib/net/smtp/smtp_test.v
+++ b/vlib/net/smtp/smtp_test.v
@@ -131,3 +131,11 @@ fn test_smtp_multiple_recipients() ? {
 
 	assert true
 }
+
+fn test_smtp_body_base64encode() ? {
+	$if !network ? {
+		return
+	}
+
+	assert true
+}


### PR DESCRIPTION
When the format of the message body is a little complicated, the body display will be very confusing, and base64 encoding needs to be added.