### PR TITLE
ci: use ubuntu-latest for toml tests

### DIFF
--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   toml-module-pass-external-test-suites:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
     timeout-minutes: 30
     env:


### PR DESCRIPTION
This PR phases out the use of Ubuntu 18.04 in the TOML tests.