### PR TITLE
checker: check generics struct field type error (fix #15588)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -74,6 +74,11 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 				if info.is_heap && !field.typ.is_ptr() {
 					struct_sym.info.is_heap = true
 				}
+				if info.generic_types.len > 0 && !field.typ.has_flag(.generic)
+					&& info.concrete_types.len == 0 {
+					c.error('field `$field.name` type is generic struct, must specify the generic type names, e.g. Foo<T>, Foo<int>',
+						field.type_pos)
+				}
 			}
 			if sym.kind == .multi_return {
 				c.error('cannot use multi return as field type', field.type_pos)

--- a/vlib/v/checker/tests/generics_struct_field_type_err.out
+++ b/vlib/v/checker/tests/generics_struct_field_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_struct_field_type_err.vv:4:9: error: field `next` type is generic struct, must specify the generic type names, e.g. Foo<T>, Foo<int>
+    2 |     mut:
+    3 |         value T
+    4 |         next &LL = unsafe { 0 }
+      |               ~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/generics_struct_field_type_err.vv
+++ b/vlib/v/checker/tests/generics_struct_field_type_err.vv
@@ -1,0 +1,11 @@
+struct LL<T> {
+	mut:
+		value T
+		next &LL = unsafe { 0 }
+}
+
+fn main() {
+	mut l := LL<int>{}
+	l.value = 5
+	println(l.value)
+}


### PR DESCRIPTION
This PR check generics struct field type error (fix #15588).

- Check generics struct field type error.
- Add test.

```v
struct LL<T> {
	mut:
		value T
		next &LL = unsafe { 0 }
}

fn main() {
	mut l := LL<int>{}
	l.value = 5
	println(l.value)
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:9: error: field `next` type is generic struct, must specify the generic type names, e.g. Foo<T>
    2 |     mut:
    3 |         value T
    4 |         next &LL = unsafe { 0 }
      |               ~~
    5 | }
    6 |
```