### PR TITLE
checker: check cast to reference struct (fix #15590)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2432,7 +2432,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	} else if to_sym.kind == .struct_ && to_type.is_ptr() {
 		if from_sym.kind == .alias {
-			from_type = (from_sym.info as ast.Alias).parent_type.derive(from_type)
+			from_type = (from_sym.info as ast.Alias).parent_type.derive_add_muls(from_type)
 		}
 		if !from_type.is_int() && final_from_sym.kind != .enum_ && !from_type.is_pointer()
 			&& !from_type.is_ptr() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2432,7 +2432,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	} else if to_sym.kind == .struct_ && to_type.is_ptr() {
 		if from_sym.kind == .alias {
-			from_type = (from_sym.info as ast.Alias).parent_type
+			from_type = (from_sym.info as ast.Alias).parent_type.derive(from_type)
 		}
 		if !from_type.is_int() && final_from_sym.kind != .enum_ && !from_type.is_pointer()
 			&& !from_type.is_ptr() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2430,6 +2430,19 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			ft := c.table.type_to_str(from_type)
 			c.error('cannot cast `$ft` to struct', node.pos)
 		}
+	} else if to_sym.kind == .struct_ && to_type.is_ptr() {
+		if from_sym.kind == .alias {
+			from_type = (from_sym.info as ast.Alias).parent_type
+		}
+		mut is_int_lit := false
+		if node.expr is ast.IntegerLiteral {
+			is_int_lit = true
+		}
+		if !is_int_lit && !from_type.is_pointer() && !from_type.is_ptr() {
+			ft := c.table.type_to_str(from_type)
+			tt := c.table.type_to_str(to_type)
+			c.error('cannot cast `$ft` to `$tt`', node.pos)
+		}
 	} else if to_sym.kind == .interface_ {
 		if c.type_implements(from_type, to_type, node.pos) {
 			if !from_type.is_ptr() && !from_type.is_pointer() && from_sym.kind != .interface_

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2434,11 +2434,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		if from_sym.kind == .alias {
 			from_type = (from_sym.info as ast.Alias).parent_type
 		}
-		mut is_int_lit := false
-		if node.expr is ast.IntegerLiteral {
-			is_int_lit = true
-		}
-		if !is_int_lit && !from_type.is_pointer() && !from_type.is_ptr() {
+		if !from_type.is_int() && !from_type.is_pointer() && !from_type.is_ptr() {
 			ft := c.table.type_to_str(from_type)
 			tt := c.table.type_to_str(to_type)
 			c.error('cannot cast `$ft` to `$tt`', node.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2434,7 +2434,8 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		if from_sym.kind == .alias {
 			from_type = (from_sym.info as ast.Alias).parent_type
 		}
-		if !from_type.is_int() && !from_type.is_pointer() && !from_type.is_ptr() {
+		if !from_type.is_int() && final_from_sym.kind != .enum_ && !from_type.is_pointer()
+			&& !from_type.is_ptr() {
 			ft := c.table.type_to_str(from_type)
 			tt := c.table.type_to_str(to_type)
 			c.error('cannot cast `$ft` to `$tt`', node.pos)

--- a/vlib/v/checker/tests/cast_to_ref_struct_err.out
+++ b/vlib/v/checker/tests/cast_to_ref_struct_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/cast_to_ref_struct_err.vv:9:16: error: cannot cast `string` to `&SomeError`
+    7 |
+    8 | fn main() {
+    9 |     a := unsafe { &SomeError('yo') }
+      |                   ~~~~~~~~~~~~~~~~
+   10 |     println(a)
+   11 | }

--- a/vlib/v/checker/tests/cast_to_ref_struct_err.vv
+++ b/vlib/v/checker/tests/cast_to_ref_struct_err.vv
@@ -1,0 +1,11 @@
+module main
+
+pub struct SomeError {
+mut:
+	msg string
+}
+
+fn main() {
+	a := unsafe { &SomeError('yo') }
+	println(a)
+}


### PR DESCRIPTION
This PR check cast to reference struct (fix #15590).

- Check cast to reference struct.
- Add test.

```v
module main

pub struct SomeError {
mut:
	msg string
}

fn main() {
	a := unsafe { &SomeError('yo') }
	println(a)
}

PS D:\Test\v\tt1> v run .
./tt1.v:9:16: error: cannot cast `string` to `&SomeError`
    7 |
    8 | fn main() {
    9 |     a := unsafe { &SomeError('yo') }
      |                   ~~~~~~~~~~~~~~~~
   10 |     println(a)
   11 | }
```