### PR TITLE
cgen: fix struct init with update expr (fix #15595)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -195,7 +195,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 				if is_update_tmp_var {
 					g.write(tmp_update_var)
 				} else {
+					g.write('(')
 					g.expr(node.update_expr)
+					g.write(')')
 				}
 				if node.update_expr_type.is_ptr() {
 					g.write('->')

--- a/vlib/v/tests/struct_init_with_update_test.v
+++ b/vlib/v/tests/struct_init_with_update_test.v
@@ -31,13 +31,15 @@ fn test_struct_init_with_update_expr() {
 	assert o.age == 21
 }
 
-struct Foo{
+struct Foo {
 	s string
 	n int
 }
 
-fn test_struct_init_with_update_expr2(){
-	f := &Foo{s:'AA'}
+fn test_struct_init_with_update_expr2() {
+	f := &Foo{
+		s: 'AA'
+	}
 	b := Foo{
 		...*f
 		n: 3

--- a/vlib/v/tests/struct_init_with_update_test.v
+++ b/vlib/v/tests/struct_init_with_update_test.v
@@ -30,3 +30,19 @@ fn test_struct_init_with_update_expr() {
 	assert o.height == 175
 	assert o.age == 21
 }
+
+struct Foo{
+	s string
+	n int
+}
+
+fn test_struct_init_with_update_expr2(){
+	f := &Foo{s:'AA'}
+	b := Foo{
+		...*f
+		n: 3
+	}
+	println(b)
+	assert b.s == 'AA'
+	assert b.n == 3
+}


### PR DESCRIPTION
This PR fix struct init with update expr (fix #15595).

- Fix struct init with update expr.
- Add test.

```v
struct Foo{
	s string
	n int
}

fn main(){
	f := &Foo{s:'AA'}
	b := Foo{
		...*f
		n: 3
	}
	println(b)
	assert b.s == 'AA'
	assert b.n == 3
}

PS D:\Test\v\tt1> v run .
Foo{
    s: 'AA'
    n: 3
}
```