### PR TITLE
make: add clock_gettime on macOS < 10.12 (fix #6605)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,9 +7,12 @@ VC     ?= ./vc
 VEXE   ?= ./v
 VCREPO ?= https://github.com/vlang/vc
 TCCREPO ?= https://github.com/vlang/tccbin
+LEGACYREPO ?= https://github.com/macports/macports-legacy-support
 
 VCFILE := v.c
 TMPTCC := $(VROOT)/thirdparty/tcc
+LEGACYLIBS := $(VROOT)/thirdparty/legacy
+TMPLEGACY := $(LEGACYLIBS)/source
 TCCOS := unknown
 TCCARCH := unknown
 GITCLEANPULL := git clean -xf && git pull --quiet
@@ -36,6 +39,9 @@ endif
 ifeq ($(_SYS),Darwin)
 MAC := 1
 TCCOS := macos
+ifeq ($(shell expr $(shell uname -r | cut -d. -f1) \<= 15), 1)
+LEGACY := 1
+endif
 endif
 
 ifeq ($(_SYS),FreeBSD)
@@ -79,13 +85,13 @@ endif
 endif
 endif
 
-.PHONY: all clean check fresh_vc fresh_tcc check_for_working_tcc
+.PHONY: all clean check fresh_vc fresh_tcc fresh_legacy check_for_working_tcc
 
 ifdef prod
 VFLAGS+=-prod
 endif
 
-all: latest_vc latest_tcc
+all: latest_vc latest_tcc latest_legacy
 ifdef WIN32
 	$(CC) $(CFLAGS) -std=c99 -municode -w -o v1.exe $(VC)/$(VCFILE) $(LDFLAGS)
 	v1.exe -no-parallel -o v2.exe $(VFLAGS) cmd/v
@@ -93,6 +99,12 @@ ifdef WIN32
 	del v1.exe
 	del v2.exe
 else
+ifdef LEGACY
+	$(MAKE) -C $(TMPLEGACY)
+	$(MAKE) -C $(TMPLEGACY) PREFIX=$(realpath $(LEGACYLIBS)) CFLAGS=$(CFLAGS) LDFLAGS=$(LDFLAGS) install
+	rm -rf $(TMPLEGACY)
+	$(eval override LDFLAGS+=-L$(realpath $(LEGACYLIBS))/lib -lMacportsLegacySupport)
+endif
 	$(CC) $(CFLAGS) -std=gnu99 -w -o v1.exe $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS)
 	./v1.exe -no-parallel -o v2.exe $(VFLAGS) cmd/v
 	./v2.exe -o $(VEXE) $(VFLAGS) cmd/v
@@ -104,6 +116,7 @@ endif
 
 clean:
 	rm -rf $(TMPTCC)
+	rm -rf $(LEGACYLIBS)
 	rm -rf $(VC)
 
 ifndef local
@@ -148,11 +161,32 @@ else
 	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
 endif
 
+ifndef local
+latest_legacy: $(TMPLEGACY)/.git/config
+ifdef LEGACY
+	cd $(TMPLEGACY) && $(GITCLEANPULL)
+endif
+else
+latest_legacy:
+ifdef LEGACY
+	@echo "Using local legacysupport"
+endif
+endif
+
+fresh_legacy:
+	rm -rf $(LEGACYLIBS)
+	$(GITFASTCLONE) $(LEGACYREPO) $(TMPLEGACY)
+
 $(TMPTCC)/.git/config:
 	$(MAKE) fresh_tcc
 
 $(VC)/.git/config:
 	$(MAKE) fresh_vc
+
+$(TMPLEGACY)/.git/config:
+ifdef LEGACY
+	$(MAKE) fresh_legacy
+endif
 
 asan:
 	$(MAKE) all CFLAGS='-fsanitize=address,undefined'

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module time
 
+#flag darwin -I@VEXEROOT/thirdparty/legacy/include/LegacySupport
 #include <time.h>
 #include <errno.h>
 


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

#6605 has been fixed in the [MacPorts build](https://ports.macports.org/port/vlang/) of V. This has been tested since it builds from source on the [MacPorts builders](https://ports.macports.org/port/vlang/builds/) pre-10.12 (Darwin 16), whilst without the patches it doesn't. (see ﻿https://github.com/vlang/v/issues/7396).

This PR aims to replicate these changes in the upstream source code as closely as possible. [MacPorts legacy support](https://github.com/macports/macports-legacy-support) is built on required macOS versions in `TMPLEGACY`, and the V binary is linked to the libs in `LEGACYLIBS`.

I don't have a machine to test this on, so this PR is a bit of guesswork. For reference, [here](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/110524/steps/install-port/logs/stdio) are the full logs of the MacPorts V weekly.2022.34 building on 10.7.

CC @guizhenwei @ssb22
