### PR TITLE
native: fix order and add missing path in find_o_path()

### DIFF
--- a/vlib/v/gen/native/elf.v
+++ b/vlib/v/gen/native/elf.v
@@ -746,7 +746,7 @@ pub fn (mut g Gen) prepend_vobjpath(paths []string) []string {
 }
 
 pub fn (mut g Gen) find_o_path(fname string) string {
-	opaths := g.prepend_vobjpath(['/usr/lib', '/usr/lib/x86_64-linux-gnu'])
+	opaths := g.prepend_vobjpath(['/usr/lib/x86_64-linux-gnu', '/usr/lib64', '/usr/lib'])
 	for opath in opaths {
 		fpath := os.join_path_single(opath, fname)
 		if os.is_file(fpath) {


### PR DESCRIPTION
This fixes the linker failing when:

- 32 bit libraries exist in `/usr/lib`.
- 64 bit libraries are in `/usr/lib64` and not `/usr/lib/x86_64-linux-gnu`.