### PR TITLE
checker: check casting voidptr to generic struct (fix #15618)

### DIFF
--- a/vlib/crypto/ed25519/internal/ed25519_test.v
+++ b/vlib/crypto/ed25519/internal/ed25519_test.v
@@ -140,7 +140,7 @@ fn worker_for_string_content(p &pool.PoolProcessor, idx int, worker_id int) &Sig
 	return sr
 }
 
-struct SignResult {
+pub struct SignResult {
 mut:
 	item   string
 	result bool

--- a/vlib/sync/pool/README.md
+++ b/vlib/sync/pool/README.md
@@ -12,7 +12,7 @@ for each input item. Example:
 ```v
 import sync.pool
 
-struct SResult {
+pub struct SResult {
 	s string
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2367,7 +2367,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	from_sym := c.table.sym(from_type)
 	final_from_sym := c.table.final_sym(from_type)
 
-	mut to_type := node.typ
+	mut to_type := c.unwrap_generic(node.typ)
 	mut to_sym := c.table.sym(to_type) // type to be used as cast
 	mut final_to_sym := c.table.final_sym(to_type)
 
@@ -2597,8 +2597,8 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			}
 		}
 	}
-	node.typname = c.table.sym(to_type).name
-	return to_type
+	node.typname = c.table.sym(node.typ).name
+	return node.typ
 }
 
 fn (mut c Checker) at_expr(mut node ast.AtExpr) ast.Type {

--- a/vlib/v/checker/tests/cast_voidptr_to_struct_err.out
+++ b/vlib/v/checker/tests/cast_voidptr_to_struct_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/cast_voidptr_to_struct_err.vv:6:9: error: cannot cast `voidptr` to struct
+    4 |
+    5 | fn unwrap_concrete(ptr voidptr) Foo {
+    6 |     return Foo(ptr)
+      |            ~~~~~~~~
+    7 | }
+    8 |
+vlib/v/checker/tests/cast_voidptr_to_struct_err.vv:10:9: error: cannot cast `voidptr` to struct
+    8 |
+    9 | fn unwrap_generic<T>(ptr voidptr) T {
+   10 |     return T(ptr)
+      |            ~~~~~~
+   11 | }
+   12 |

--- a/vlib/v/checker/tests/cast_voidptr_to_struct_err.vv
+++ b/vlib/v/checker/tests/cast_voidptr_to_struct_err.vv
@@ -1,0 +1,19 @@
+struct Foo {
+	x int
+}
+
+fn unwrap_concrete(ptr voidptr) Foo {
+	return Foo(ptr)
+}
+
+fn unwrap_generic<T>(ptr voidptr) T {
+	return T(ptr)
+}
+
+pub fn main() {
+	foo1 := unwrap_concrete(voidptr(0))
+	foo2 := unwrap_generic<Foo>(voidptr(0))
+
+	println(foo1)
+	println(foo2)
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -43,7 +43,7 @@ fn string_array_to_map(a []string) map[string]bool {
 	return res
 }
 
-struct Gen {
+pub struct Gen {
 	pref                &pref.Preferences
 	field_data_type     ast.Type // cache her to avoid map lookups
 	module_built        string

--- a/vlib/v/tests/generic_interface_infer_test.v
+++ b/vlib/v/tests/generic_interface_infer_test.v
@@ -14,7 +14,7 @@ interface Interface<T> {
 fn test_infer_generic_interface() {
 	s := Struct<u32>{7, 5}
 	println(s)
-	i := Interface(s)
+	i := Interface<u32>(s)
 	println(i)
 	assert i.method() == 10
 }


### PR DESCRIPTION
This PR check casting voidptr to generic struct (fix #15618).

- Check casting voidptr to generic struct.
- Add test.

```v
struct Foo {
	x int
}

fn unwrap_concrete(ptr voidptr) Foo {
	return Foo(ptr)
}

fn unwrap_generic<T>(ptr voidptr) T {
	return T(ptr)
}

pub fn main() {
	foo1 := unwrap_concrete(voidptr(0))
	foo2 := unwrap_generic<Foo>(voidptr(0))

	println(foo1)
	println(foo2)
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:9: error: cannot cast `voidptr` to struct
    4 |
    5 | fn unwrap_concrete(ptr voidptr) Foo {
    6 |     return Foo(ptr)
      |            ~~~~~~~~
    7 | }
    8 |
./tt1.v:10:9: error: cannot cast `voidptr` to struct
    8 |
    9 | fn unwrap_generic<T>(ptr voidptr) T {
   10 |     return T(ptr)
      |            ~~~~~~
   11 | }
   12 |
```