### PR TITLE
gen: make struct Gen on cgen.v public to solve v compilation error

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -43,7 +43,7 @@ fn string_array_to_map(a []string) map[string]bool {
 	return res
 }
 
-struct Gen {
+pub struct Gen {
 	pref                &pref.Preferences
 	field_data_type     ast.Type // cache her to avoid map lookups
 	module_built        string


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Previously, I couldn't build v from the source described in https://github.com/vlang/v/issues/15628.
This PR aims to fix that issue.
