### PR TITLE
checker: check fn variadic passing arg error (fix #15629)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -872,6 +872,14 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				info := param_sym.array_info()
 				c.expected_type = info.elem_type
 			}
+			typ := c.expr(call_arg.expr)
+			if i == node.args.len - 1 && c.table.sym(typ).kind == .array
+				&& !param.typ.has_flag(.generic) && c.expected_type != typ {
+				styp := c.table.type_to_str(typ)
+				elem_styp := c.table.type_to_str(c.expected_type)
+				c.error('to pass `$call_arg.expr` ($styp) to `$func.name` (which accepts type `...$elem_styp`), use `...$call_arg.expr`',
+					node.pos)
+			}
 		} else {
 			c.expected_type = param.typ
 		}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -874,7 +874,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			}
 			typ := c.expr(call_arg.expr)
 			if i == node.args.len - 1 && c.table.sym(typ).kind == .array
-				&& !param.typ.has_flag(.generic) && c.expected_type != typ {
+				&& call_arg.expr !is ast.ArrayDecompose && !param.typ.has_flag(.generic)
+				&& c.expected_type != typ {
 				styp := c.table.type_to_str(typ)
 				elem_styp := c.table.type_to_str(c.expected_type)
 				c.error('to pass `$call_arg.expr` ($styp) to `$func.name` (which accepts type `...$elem_styp`), use `...$call_arg.expr`',

--- a/vlib/v/checker/tests/fn_variadic_arg_err.out
+++ b/vlib/v/checker/tests/fn_variadic_arg_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fn_variadic_arg_err.vv:5:2: error: to pass `a` ([]u8) to `varg_fn_a` (which accepts type `...u8`), use `...a`
+    3 | fn main() {
+    4 |     a := [u8(1), 2, 3, 4]
+    5 |     varg_fn_a(a)
+      |     ~~~~~~~~~~~~
+    6 | }
+    7 |

--- a/vlib/v/checker/tests/fn_variadic_arg_err.vv
+++ b/vlib/v/checker/tests/fn_variadic_arg_err.vv
@@ -1,0 +1,10 @@
+module main
+
+fn main() {
+	a := [u8(1), 2, 3, 4]
+	varg_fn_a(a)
+}
+
+fn varg_fn_a(b ...u8) {
+	println(b)
+}


### PR DESCRIPTION
This PR check fn variadic passing arg error (fix #15629).

- Check fn variadic passing arg error.
- Add test.

```v
module main

fn main() {
	a := [u8(1), 2, 3, 4]
	varg_fn_a(a)
}

fn varg_fn_a(b ...u8) {
	println(b)
}

PS D:\Test\v\tt1> v run .
./tt1.v:5:2: error: to pass `a` ([]u8) to `varg_fn_a` (which accepts type `...u8`), use `...a`
    3 | fn main() {
    4 |     a := [u8(1), 2, 3, 4]
    5 |     varg_fn_a(a)
      |     ~~~~~~~~~~~~
    6 | }
    7 |
```