### PR TITLE
csv: minor cleanup in writer.v

### DIFF
--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -14,8 +14,8 @@ mut:
 
 [params]
 pub struct WriterConfig {
-	use_crlf  bool = false
-	delimiter u8   = `,`
+	use_crlf  bool
+	delimiter u8 = `,`
 }
 
 // new_writer returns a reference to a Writer


### PR DESCRIPTION
This PR makes a minor cleanup in writer.v.

warning before:
```v
vlib/encoding/csv/writer.v:17:19: warning: unnecessary default value `false`: struct fields are zeroed by default
   15 | [params]
   16 | pub struct WriterConfig {
   17 |     use_crlf  bool = false
      |                      ~~~~~
   18 |     delimiter u8   = `,`
   19 | }
```