### PR TITLE
cgen: fix alias of map delete (fix #15641)

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -980,3 +980,16 @@ fn test_map_set_fixed_array_variable() {
 	println(m2)
 	assert '$m2' == "{'A': [1.1, 2.2]}"
 }
+
+type Map = map[int]int
+
+fn test_alias_of_map_delete() {
+	mut m := Map(map[int]int{})
+	m[11] = 111
+	m[22] = 222
+	println(m)
+	m.delete(11)
+	println(m)
+	assert m.len == 1
+	assert m[22] == 222
+}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -832,8 +832,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 	}
 
-	if left_sym.kind == .map && node.name == 'delete' {
-		left_info := left_sym.info as ast.Map
+	if final_left_sym.kind == .map && node.name == 'delete' {
+		left_info := final_left_sym.info as ast.Map
 		elem_type_str := g.typ(left_info.key_type)
 		g.write('map_delete(')
 		if left_type.has_flag(.shared_f) {


### PR DESCRIPTION
This PR fix alias of map delete (fix #15641).

- Fix alias of map delete.
- Add test.

```v
type Map = map[int]int

fn main() {
	mut m := Map(map[int]int{})
	m[11] = 111
	m[22] = 222
	println(m)
	m.delete(11)
	println(m)
	assert m.len == 1
	assert m[22] == 222
}

PS D:\Test\v\tt1> v run .
Map({11: 111, 22: 222})
Map({22: 222})
```