### PR TITLE
cgen: fix assert value is '*unknown value*' (fix #15640)

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -147,8 +147,15 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 	// eprintln('> gen_assert_single_expr typ: $typ | expr: $expr | typeof(expr): ${typeof(expr)}')
 	unknown_value := '*unknown value*'
 	match expr {
-		ast.CastExpr, ast.IfExpr, ast.IndexExpr, ast.MatchExpr {
+		ast.CastExpr, ast.IfExpr, ast.MatchExpr {
 			g.write(ctoslit(unknown_value))
+		}
+		ast.IndexExpr {
+			if expr.index is ast.RangeExpr {
+				g.write(ctoslit(unknown_value))
+			} else {
+				g.gen_expr_to_string(expr, typ)
+			}
 		}
 		ast.PrefixExpr {
 			if expr.right is ast.CastExpr {


### PR DESCRIPTION
This PR fix assert value is '*unknown value*' (fix #15640).

```v
fn main() {
	res := ['one', 'two', 'three']
	assert res[0] == 'three'
}

PS D:\Test\v\tt1> v run .
.\\tt1.v:3: FAIL: fn main.main: assert res[0] == 'three'
   left value: res[0] = one
  right value: 'three' = three
V panic: Assertion failed...
v hash: 4bd49a0
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.8983093021732834113.tmp.c:6667: at _v_panic: Backtrace
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.8983093021732834113.tmp.c:12188: by main__main
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.8983093021732834113.tmp.c:12559: by wmain
0046ec38 : by ???
0046ed9b : by ???
7ff889d2244d : by ???
```