### PR TITLE
cgen: fix fn variable name using reserved c word (fix #15647)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -339,7 +339,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					''
 				}
 
-				g.write('$ret_styp ($msvc_call_conv*${g.get_ternary_name(ident.name)}) (')
+				g.write('$ret_styp ($msvc_call_conv*${c_name(g.get_ternary_name(ident.name))}) (')
 				def_pos := g.definitions.len
 				g.fn_decl_params(func.func.params, unsafe { nil }, false)
 				g.definitions.go_back(g.definitions.len - def_pos)

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -339,7 +339,8 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					''
 				}
 
-				g.write('$ret_styp ($msvc_call_conv*${c_name(g.get_ternary_name(ident.name))}) (')
+				fn_name := c_name(g.get_ternary_name(ident.name))
+				g.write('$ret_styp ($msvc_call_conv*$fn_name) (')
 				def_pos := g.definitions.len
 				g.fn_decl_params(func.func.params, unsafe { nil }, false)
 				g.definitions.go_back(g.definitions.len - def_pos)

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -65,7 +65,7 @@ fn (mut g Gen) unwrap(typ ast.Type) Type {
 // generate function variable definition, e.g. `void (*var_name) (int, string)`
 fn (mut g Gen) fn_var_signature(return_type ast.Type, arg_types []ast.Type, var_name string) string {
 	ret_styp := g.typ(return_type)
-	mut sig := '$ret_styp (*$var_name) ('
+	mut sig := '$ret_styp (*${c_name(var_name)}) ('
 	for j, arg_typ in arg_types {
 		arg_sym := g.table.sym(arg_typ)
 		if arg_sym.info is ast.FnType {

--- a/vlib/v/tests/fn_var_name_using_reserved_test.v
+++ b/vlib/v/tests/fn_var_name_using_reserved_test.v
@@ -1,0 +1,11 @@
+fn ret_int() fn (int) int {
+	return fn (i int) int {
+		return i
+	}
+}
+
+fn test_fn_var_name_using_reserved() {
+	new := ret_int()
+	println(new(42))
+	assert new(42) == 42
+}


### PR DESCRIPTION
This PR fix fn variable name using reserved c word (fix #15647).

- Fix fn variable name using reserved c word.
- Add test.

```v
fn ret_int() fn (int) int {
	return fn (i int) int {
		return i
	}
}

fn main() {
	new := ret_int()
	println(new(42))
	assert new(42) == 42
}

PS D:\Test\v\tt1> v run .
42
```