### PR TITLE
os: remove unix_environ() helper function as no longer needed

### DIFF
--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -79,11 +79,6 @@ pub fn unsetenv(name string) int {
 // See: https://docs.microsoft.com/bg-bg/windows/win32/api/processenv/nf-processenv-getenvironmentstrings
 // os.environ returns a map of all the current environment variables
 
-fn unix_environ() &&char {
-	// TODO: remove this helper function, when `&&char(C.environ)` works properly
-	return voidptr(C.environ)
-}
-
 pub fn environ() map[string]string {
 	mut res := map[string]string{}
 	$if windows {
@@ -101,7 +96,7 @@ pub fn environ() map[string]string {
 		}
 		C.FreeEnvironmentStringsW(estrings)
 	} $else {
-		start := unix_environ()
+		start := &&char(C.environ)
 		mut i := 0
 		for {
 			x := unsafe { start[i] }


### PR DESCRIPTION
I noticed that this function wasn't needed anymore after I went  hunting for references to `C.environ` in vlib as I wanted a multi-argument `os.system` using `C.posix_spawnp` (so that I didn't have to worry about the shell possibly interpreting some arbitrary text passed to the command).

This patch just removes the function, replacing its one use with `&&char(C.environ)`

`v test-all` is the same with and without the patch.