### PR TITLE
cgen: fix match expr with optional (fix #15650)

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -28,7 +28,7 @@ fn (mut g Gen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 			if branch.stmts.len == 1 {
 				if branch.stmts[0] is ast.ExprStmt {
 					stmt := branch.stmts[0] as ast.ExprStmt
-					if stmt.expr in [ast.CallExpr, ast.IfExpr, ast.MatchExpr]
+					if stmt.expr in [ast.CallExpr, ast.IfExpr, ast.MatchExpr, ast.StructInit]
 						|| (stmt.expr is ast.IndexExpr
 						&& (stmt.expr as ast.IndexExpr).or_expr.kind != .absent) {
 						return true

--- a/vlib/v/tests/match_expr_with_struct_init_test.v
+++ b/vlib/v/tests/match_expr_with_struct_init_test.v
@@ -1,0 +1,17 @@
+struct Test {
+	a string
+}
+
+fn test_match_expr_with_struct_init() {
+	a := map[string]string{}
+	b := match 'test' {
+		'test' {
+			Test{a['test'] or { '' }}
+		}
+		else {
+			Test{''}
+		}
+	}
+	println(b)
+	assert b.a == ''
+}


### PR DESCRIPTION
This PR fix match expr with optional (fix #15650).

- Fix match expr with optional.
- Add test.

```v
struct Test {
	a string
}

fn main() {
	a := map[string]string{}
	b := match 'test' {
		'test' {
			Test{a['test'] or { '' }}
		}
		else {
			Test{''}
		}
	}
	println(b)
	assert b.a == ''
}

PS D:\Test\v\tt1> v run .
Test{
    a: ''
}
```