### PR TITLE
cgen: fix if expr with index expr (fix #15664)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -60,6 +60,14 @@ fn (mut g Gen) need_tmp_var_in_expr(expr ast.Expr) bool {
 			}
 		}
 	}
+	if expr is ast.IndexExpr {
+		if expr.or_expr.kind != .absent {
+			return true
+		}
+		if g.need_tmp_var_in_expr(expr.index) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/vlib/v/tests/if_expr_with_index_expr_test.v
+++ b/vlib/v/tests/if_expr_with_index_expr_test.v
@@ -1,0 +1,9 @@
+import rand
+
+fn test_if_expr_with_index_expr() {
+	a := [1, 2, 3]
+
+	b := if true { a[rand.intn(a.len) or { 0 }] } else { 0 }
+	println(b)
+	assert true
+}


### PR DESCRIPTION
This PR fix if expr with index expr (fix #15664).

- Fix if expr with index expr.
- Add test.

```v
import rand

fn main() {
	a := [1, 2, 3]

	b := if true { a[rand.intn(a.len) or { 0 }] } else { 0 }
	println(b)
}

PS D:\Test\v\tt1> v run .
3
```