### PR TITLE
checker: fix missing name conflict check of const and __global variables. fix: #15668

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1656,6 +1656,9 @@ fn (mut c Checker) global_decl(mut node ast.GlobalDecl) {
 		if field.name in c.global_names {
 			c.error('duplicate global `$field.name`', field.pos)
 		}
+		if '${c.mod}.$field.name' in c.const_names {
+			c.error('duplicate global and const `$field.name`', field.pos)
+		}
 		sym := c.table.sym(field.typ)
 		if sym.kind == .placeholder {
 			c.error('unknown type `$sym.name`', field.typ_pos)

--- a/vlib/v/checker/tests/globals/name_conflict_with_const.out
+++ b/vlib/v/checker/tests/globals/name_conflict_with_const.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/globals/name_conflict_with_const.vv:6:2: error: duplicate global and const `foo`
+    4 | 
+    5 | __global (
+    6 |     foo = 123
+      |     ~~~
+    7 | )

--- a/vlib/v/checker/tests/globals/name_conflict_with_const.vv
+++ b/vlib/v/checker/tests/globals/name_conflict_with_const.vv
@@ -1,0 +1,7 @@
+const (
+	foo = 'abc'
+)
+
+__global (
+	foo = 123
+)


### PR DESCRIPTION
```v
const (
	aaaa = 'abc'
)

__global (
	aaaa = 123
)
```

output:

```
a.v:47:2: error: duplicate global and const `aaaa`
   45 | 
   46 | __global (
   47 |     aaaa = 123
      |     ~~~~
   48 | )
   49 |
```