### PR TITLE
cgen, checker, ast: support pointer value in `for in` loop

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1047,6 +1047,7 @@ pub:
 	pos        token.Pos
 	val_is_mut bool // `for mut val in vals {` means that modifying `val` will modify the array
 	// and the array cannot be indexed inside the loop
+	vals_is_ref bool // `for val in &arr {` means that value of `val` will be the reference of the value in `arr`
 pub mut:
 	cond      Expr
 	key_type  Type

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -148,6 +148,8 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 					}
 					else {}
 				}
+			} else if node.vals_is_ref {
+				value_type = value_type.ref()
 			}
 			node.cond_type = typ
 			node.kind = sym.kind

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -178,7 +178,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 				// instead of
 				// `int* val = ((int**)arr.data)[i];`
 				// right := if node.val_is_mut { styp } else { styp + '*' }
-				right := if node.val_is_mut {
+				right := if node.val_is_mut || node.vals_is_ref {
 					'(($styp)$cond_var${op_field}data) + $i'
 				} else {
 					'(($styp*)$cond_var${op_field}data)[$i]'
@@ -295,7 +295,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) {
 			} else {
 				val_styp := g.typ(node.val_type)
 				if node.val_type.is_ptr() {
-					if node.val_is_mut {
+					if node.val_is_mut || node.vals_is_ref {
 						g.write('$val_styp ${c_name(node.val_var)} = &(*($val_styp)')
 					} else {
 						g.write('$val_styp ${c_name(node.val_var)} = (*($val_styp*)')

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -171,7 +171,15 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
 		pos.update_last_line(p.prev_tok.line_nr)
-		// println('nr stmts=$stmts.len')
+
+		vals_is_ref := match cond {
+			ast.PrefixExpr {
+				if cond.op == .amp { true } else { false }
+			}
+			else {
+				false
+			}
+		}
 		for_in_stmt := ast.ForInStmt{
 			stmts: stmts
 			cond: cond
@@ -181,6 +189,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 			is_range: is_range
 			pos: pos
 			val_is_mut: val_is_mut
+			vals_is_ref: vals_is_ref
 			scope: p.scope
 		}
 		p.close_scope()

--- a/vlib/v/tests/for_in_ref_arr_test.v
+++ b/vlib/v/tests/for_in_ref_arr_test.v
@@ -1,0 +1,15 @@
+fn test_for_in_ref_array_pointer() {
+	arr := [1, 2, 3, 4, 5]
+	mut rets := []&int{}
+	mut expects := unsafe { []&int{len: 5, init: &arr[it]} }
+
+	for val in &arr {
+		println(val)
+		rets << val
+	}
+
+	for i, val in &arr {
+		assert voidptr(val) == voidptr(rets[i])
+	}
+	assert rets == expects
+}

--- a/vlib/v/tests/for_in_ref_map_test.v
+++ b/vlib/v/tests/for_in_ref_map_test.v
@@ -1,0 +1,23 @@
+fn test_for_in_ref_array_pointer() {
+	mut mp := {
+		'a': 1
+		'b': 2
+		'c': 3
+		'd': 4
+		'e': 5
+	}
+	mut rets := map[string]&int{}
+	mut expects := map[string]&int{}
+
+	for k, mut val in mp {
+		expects[k] = unsafe { val }
+	}
+	for k, val in &mp {
+		rets[k] = unsafe { val }
+	}
+
+	for k, val in &mp {
+		assert voidptr(val) == voidptr(expects[k])
+	}
+	assert rets == expects
+}


### PR DESCRIPTION
NOTE:
- changing behavior for `for k, v in &map` is not intentional, but works.
- fixed array doesn't work yet, as it requires to write `for val in unsafe { &fixed_arr } {}`

Related: https://github.com/vlang/v/discussions/15584

Other contexts on discord
https://discord.com/channels/592103645835821068/700746775962714232/1013438849654984745