### PR TITLE
table: check sumtype of fntype assign error (fix #15683)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1308,7 +1308,14 @@ pub fn (t &Table) sumtype_has_variant(parent Type, variant Type, is_as bool) boo
 
 fn (t &Table) sumtype_check_function_variant(parent_info SumType, variant Type, is_as bool) bool {
 	for v in parent_info.variants {
-		if '$v.idx' == '$variant.idx' && (!is_as || v.nr_muls() == variant.nr_muls()) {
+		v_sym := t.sym(v)
+		if v_sym.kind != .function {
+			continue
+		}
+		v_fn := (v_sym.info as FnType).func
+		variant_fn := (t.sym(variant).info as FnType).func
+		if t.fn_type_source_signature(v_fn) == t.fn_type_source_signature(variant_fn)
+			&& (!is_as || v.nr_muls() == variant.nr_muls()) {
 			return true
 		}
 	}

--- a/vlib/v/checker/tests/sumtype_of_fntype_assign_err.out
+++ b/vlib/v/checker/tests/sumtype_of_fntype_assign_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/sumtype_of_fntype_assign_err.vv:14:11: error: cannot assign to `m['f']`: expected `Expr`, not `fn () Expr`
+   12 |     mut m := map[string]Expr{}
+   13 |
+   14 |     m['f'] = f
+      |              ^
+   15 | }

--- a/vlib/v/checker/tests/sumtype_of_fntype_assign_err.vv
+++ b/vlib/v/checker/tests/sumtype_of_fntype_assign_err.vv
@@ -1,0 +1,15 @@
+type Expr = fn (int) int | int
+
+fn id(n int) int {
+	return n
+}
+
+fn f() Expr {
+	return id
+}
+
+fn main() {
+	mut m := map[string]Expr{}
+
+	m['f'] = f
+}


### PR DESCRIPTION
This PR check sumtype of fntype assign error (fix #15683).

- Check sumtype of fntype assign error.
- Add test.

```v
type Expr = fn (int) int | int

fn id(n int) int {
	return n
}

fn f() Expr {
	return id
}

fn main() {
	mut m := map[string]Expr{}

	m['f'] = f
}

PS D:\Test\v\tt1> v run .
./tt1.v:14:11: error: cannot assign to `m['f']`: expected `Expr`, not `fn () Expr`
   12 |     mut m := map[string]Expr{}
   13 | 
   14 |     m['f'] = f
      |              ^
   15 | }
```