### PR TITLE
checker: check non generic struct used like a generic one  (fix #15677)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -256,6 +256,10 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				}
 			}
 		}
+		if node.generic_types.len > 0 && struct_sym.info.generic_types.len == 0 {
+			c.error('a non generic struct `$node.typ_str` used like a generic struct',
+				node.name_pos)
+		}
 		if node.generic_types.len > 0 && struct_sym.info.generic_types.len == node.generic_types.len
 			&& struct_sym.info.generic_types != node.generic_types {
 			c.table.replace_generic_type(node.typ, node.generic_types)

--- a/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.out
+++ b/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv:6:9: error: a non generic struct `Toy` used like a generic struct
+    4 |
+    5 | fn get_toy1(toy Toy) Toy{
+    6 |     return Toy<T>{toy.toy_name}
+      |            ~~~
+    7 | }
+    8 |
+vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv:10:9: error: a non generic struct `Toy` used like a generic struct
+    8 |
+    9 | fn get_toy2(toy Toy) Toy{
+   10 |     return Toy<T,U>{toy.toy_name}
+      |            ~~~
+   11 | }
+   12 |

--- a/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv
+++ b/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv
@@ -1,0 +1,16 @@
+struct Toy{
+	toy_name string
+}
+
+fn get_toy1(toy Toy) Toy{
+	return Toy<T>{toy.toy_name}
+}
+
+fn get_toy2(toy Toy) Toy{
+	return Toy<T,U>{toy.toy_name}
+}
+
+fn main() {
+	println(get_toy1(Toy{'Fire Truck'}))
+	println(get_toy2(Toy{'Police Car'}))
+}


### PR DESCRIPTION
This PR check non generic struct used like a generic one  (fix #15677).

- Check non generic struct used like a generic one.
- Add test.

```v
struct Toy{
	toy_name string
}

fn get_toy1(toy Toy) Toy{
	return Toy<T>{toy.toy_name}
}

fn get_toy2(toy Toy) Toy{
	return Toy<T,U>{toy.toy_name}
}

fn main() {
	println(get_toy1(Toy{'Fire Truck'}))
	println(get_toy2(Toy{'Police Car'}))
}

PS D:\Test\v\tt1> v run .
./tt1.v:6:9: error: a non generic struct `Toy` used like a generic struct
    4 | 
    5 | fn get_toy1(toy Toy) Toy{
    6 |     return Toy<T>{toy.toy_name}
      |            ~~~
    7 | }
    8 |
./tt1.v:10:9: error: a non generic struct `Toy` used like a generic struct
    8 |
    9 | fn get_toy2(toy Toy) Toy{
   10 |     return Toy<T,U>{toy.toy_name}
      |            ~~~
   11 | }
   12 |
```