### PR TITLE
cgen: fix missing type name when anonymous struct is used as parameter.

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -49,8 +49,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		}
 	}
 	if is_anon {
-		// No name needed for anon structs, C figures it out on its own.
-		g.writeln('{')
+		g.writeln('($styp){')
 	} else if g.is_shared && !g.inside_opt_data && !g.is_arraymap_set {
 		mut shared_typ := node.typ.set_flag(.shared_f)
 		shared_styp = g.typ(shared_typ)

--- a/vlib/v/tests/anon_struct_type_test.v
+++ b/vlib/v/tests/anon_struct_type_test.v
@@ -1,0 +1,11 @@
+module main
+
+fn func(arg struct { foo string }) {
+	assert arg.foo == 'foo'
+}
+
+fn test_anon_struct_as_parameter() {
+	func(struct {
+		foo: 'foo'
+	})
+}


### PR DESCRIPTION
1. fix #15698
2. add test.

```v
fn func(arg struct { foo string }) {
	println(arg.foo)
}

fn main() {
	func(struct { 
		foo: 'foo' 
	})
}
```
output:
```
foo
```