### PR TITLE
cgen: fix if expr with fn call result (fix #15700)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -50,6 +50,11 @@ fn (mut g Gen) need_tmp_var_in_expr(expr ast.Expr) bool {
 			if expr.or_block.kind != .absent {
 				return true
 			}
+			for arg in expr.args {
+				if g.need_tmp_var_in_expr(arg.expr) {
+					return true
+				}
+			}
 		}
 		ast.CastExpr {
 			return g.need_tmp_var_in_expr(expr.expr)

--- a/vlib/v/tests/if_expr_with_fn_call_result_test.v
+++ b/vlib/v/tests/if_expr_with_fn_call_result_test.v
@@ -1,0 +1,21 @@
+fn foo() !int {
+	return 0
+}
+
+fn bar(n int) bool {
+	return true
+}
+
+fn is_ok(b bool) !bool {
+	return if b {
+		bar(foo()!)
+	} else {
+		true
+	}
+}
+
+fn test_if_expr_with_fn_call_result() {
+	ret := is_ok(true) or { false }
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR fix if expr with fn call result (fix #15700).

- Fix if expr with fn call result.
- Add test.

```v
fn foo() !int {
	return 0
}

fn bar(n int) bool {
	return true
}

fn is_ok(b bool) !bool {
	return if b {
		bar(foo()!)
	} else {
		true
	}
}

fn main() {
	ret := is_ok(true) or { false }
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
true
```