### PR TITLE
checker, cgen: fix match expr with result (fix #15703)

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -61,6 +61,7 @@ pub fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 				expr_type := c.expr(stmt.expr)
 				if first_iteration {
 					if node.is_expr && (node.expected_type.has_flag(.optional)
+						|| node.expected_type.has_flag(.result)
 						|| c.table.type_kind(node.expected_type) in [.sum_type, .multi_return]) {
 						ret_type = node.expected_type
 					} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -116,7 +116,9 @@ mut:
 	inside_map_index          bool
 	inside_opt_data           bool
 	inside_if_optional        bool
+	inside_if_result          bool
 	inside_match_optional     bool
+	inside_match_result       bool
 	inside_vweb_tmpl          bool
 	inside_return             bool
 	inside_struct_init        bool
@@ -1592,6 +1594,29 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 						g.writeln(' }, ($c.option_name*)(&$tmp_var), sizeof($styp));')
 					}
 				}
+			} else if g.inside_if_result || g.inside_match_result {
+				g.set_current_pos_as_last_stmt_pos()
+				g.skip_stmt_pos = true
+				if stmt is ast.ExprStmt {
+					if stmt.typ == ast.error_type_idx {
+						g.writeln('${tmp_var}.is_error = true;')
+						g.write('${tmp_var}.err = ')
+						g.expr(stmt.expr)
+						g.writeln(';')
+					} else {
+						mut styp := g.base_type(stmt.typ)
+						$if tinyc && x32 && windows {
+							if stmt.typ == ast.int_literal_type {
+								styp = 'int'
+							} else if stmt.typ == ast.float_literal_type {
+								styp = 'f64'
+							}
+						}
+						g.write('opt_ok2(&($styp[]) { ')
+						g.stmt(stmt)
+						g.writeln(' }, ($c.result_name*)(&$tmp_var), sizeof($styp));')
+					}
+				}
 			} else {
 				g.set_current_pos_as_last_stmt_pos()
 				g.skip_stmt_pos = true
@@ -1609,7 +1634,8 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 			}
 		} else {
 			g.stmt(stmt)
-			if (g.inside_if_optional || g.inside_match_optional) && stmt is ast.ExprStmt {
+			if (g.inside_if_optional || g.inside_if_result || g.inside_match_optional
+				|| g.inside_match_result) && stmt is ast.ExprStmt {
 				g.writeln(';')
 			}
 		}
@@ -1796,7 +1822,8 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// g.autofree_call_postgen()
 			// }
 			if g.inside_ternary == 0 && !g.inside_if_optional && !g.inside_match_optional
-				&& !node.is_expr && node.expr !is ast.IfExpr {
+				&& !g.inside_if_result && !g.inside_match_result && !node.is_expr
+				&& node.expr !is ast.IfExpr {
 				if node.expr is ast.MatchExpr {
 					g.writeln('')
 				} else {

--- a/vlib/v/tests/match_expr_with_result_test.v
+++ b/vlib/v/tests/match_expr_with_result_test.v
@@ -1,0 +1,23 @@
+fn foo(i int) ?bool {
+	return match true {
+		i == 0 { true }
+		else { none }
+	}
+}
+
+fn bar(i int) !bool {
+	return match true {
+		i == 0 { true }
+		else { error('') }
+	}
+}
+
+fn test_match_expr_with_result() {
+	r1 := foo(0) or { false }
+	println(r1)
+	assert r1
+
+	r2 := bar(0) or { false }
+	println(r2)
+	assert r2
+}


### PR DESCRIPTION
This PR fix match expr with result (fix #15703).

- Fix match expr with result.
- Add test.

```v
fn foo(i int) ?bool {
	return match true {
		i == 0 { true }
		else { none }
	}
}

fn bar(i int) !bool {
	return match true {
		i == 0 { true }
		else { error('') }
	}
}

fn main() {
	r1 := foo(0) or { false }
	println(r1)
	assert r1

	r2 := bar(0) or { false }
	println(r2)
	assert r2
}

PS D:\Test\v\tt1> v run .
true
true
```