### PR TITLE
fmt: fix replaces anonymous struct in paramter with invalid type name (fix #15696)

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -253,7 +253,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		if node.pos.line_nr < node.pos.last_line || node.pre_comments.len > 0 {
 			single_line_fields = false
 		}
-		if !use_short_args {
+		if !use_short_args || node.is_anon {
 			f.write('$name{')
 			f.mark_import_as_used(name)
 			if single_line_fields {
@@ -315,7 +315,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 		if !single_line_fields {
 			f.indent--
 		}
-		if !use_short_args {
+		if !use_short_args || node.is_anon {
 			if single_line_fields {
 				f.write(' ')
 			}

--- a/vlib/v/fmt/tests/anon_struct_as_param_expected.vv
+++ b/vlib/v/fmt/tests/anon_struct_as_param_expected.vv
@@ -1,0 +1,9 @@
+fn func(arg struct { foo string = 'bar' }) {
+	println(arg.foo)
+}
+
+fn main() {
+	func(struct {
+		foo: 'foo'
+	})
+}

--- a/vlib/v/fmt/tests/anon_struct_as_param_input.vv
+++ b/vlib/v/fmt/tests/anon_struct_as_param_input.vv
@@ -1,0 +1,8 @@
+fn func(arg struct{foo string='bar'}) {
+	println(arg.foo)
+}
+
+fn main() {
+	func(struct {foo: 'foo'
+	})
+}


### PR DESCRIPTION
input:

```v
fn func(arg struct{foo string='bar'}) {
	println(arg.foo)
}

fn main() {
	func(struct {foo: 'foo'
	})
}
```

output:

```v
fn func(arg struct { foo string = 'bar' }) {
	println(arg.foo)
}

fn main() {
	func(struct {
		foo: 'foo'
	})
}

```