### PR TITLE
cgen: fix nested match expr with optional or result  (fix #15710)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1589,9 +1589,16 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 								styp = 'f64'
 							}
 						}
-						g.write('opt_ok2(&($styp[]) { ')
-						g.stmt(stmt)
-						g.writeln(' }, ($c.option_name*)(&$tmp_var), sizeof($styp));')
+						if stmt.typ.has_flag(.optional) {
+							g.writeln('')
+							g.write('$tmp_var = ')
+							g.expr(stmt.expr)
+							g.writeln(';')
+						} else {
+							g.write('opt_ok2(&($styp[]) { ')
+							g.expr(stmt.expr)
+							g.writeln(' }, ($c.option_name*)(&$tmp_var), sizeof($styp));')
+						}
 					}
 				}
 			} else if g.inside_if_result || g.inside_match_result {
@@ -1612,9 +1619,16 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 								styp = 'f64'
 							}
 						}
-						g.write('opt_ok2(&($styp[]) { ')
-						g.stmt(stmt)
-						g.writeln(' }, ($c.result_name*)(&$tmp_var), sizeof($styp));')
+						if stmt.typ.has_flag(.result) {
+							g.writeln('')
+							g.write('$tmp_var = ')
+							g.expr(stmt.expr)
+							g.writeln(';')
+						} else {
+							g.write('opt_ok2(&($styp[]) { ')
+							g.expr(stmt.expr)
+							g.writeln(' }, ($c.result_name*)(&$tmp_var), sizeof($styp));')
+						}
 					}
 				}
 			} else {

--- a/vlib/v/tests/match_expr_nested_with_optional_result_test.v
+++ b/vlib/v/tests/match_expr_nested_with_optional_result_test.v
@@ -1,0 +1,57 @@
+// optional
+fn foo1() ?int {
+	return 1
+}
+
+fn bar1(i int) bool {
+	return true
+}
+
+fn is_ok1(y int, m int) ?bool {
+	return match true {
+		y > 0 {
+			match m {
+				1 { bar1(foo1()?) }
+				2 { false }
+				else { none }
+			}
+		}
+		else {
+			none
+		}
+	}
+}
+
+// result
+fn foo2() !int {
+	return 1
+}
+
+fn bar2(i int) bool {
+	return true
+}
+
+fn is_ok2(y int, m int) !bool {
+	return match true {
+		y > 0 {
+			match m {
+				1 { bar2(foo2()!) }
+				2 { false }
+				else { error('') }
+			}
+		}
+		else {
+			error('')
+		}
+	}
+}
+
+fn test_match_expr_nested_with_optional_result() {
+	ret1 := is_ok1(2, 1) or { false }
+	println(ret1)
+	assert ret1
+
+	ret2 := is_ok2(2, 1) or { false }
+	println(ret2)
+	assert ret2
+}


### PR DESCRIPTION
This PR fix nested match expr with optional or result  (fix #15710).

- Fix nested match expr with optional or result.
- Add test.

```v
// optional
fn foo1() ?int {
	return 1
}

fn bar1(i int) bool {
	return true
}

fn is_ok1(y int, m int) ?bool {
	return match true {
		y > 0 {
			match m {
				1 { bar1(foo1()?) }
				2 { false }
				else { none }
			}
		}
		else {
			none
		}
	}
}

// result
fn foo2() !int {
	return 1
}

fn bar2(i int) bool {
	return true
}

fn is_ok2(y int, m int) !bool {
	return match true {
		y > 0 {
			match m {
				1 { bar2(foo2()!) }
				2 { false }
				else { error('') }
			}
		}
		else {
			error('')
		}
	}
}

fn main() {
	ret1 := is_ok1(2, 1) or { false }
	println(ret1)
	assert ret1

	ret2 := is_ok2(2, 1) or { false }
	println(ret2)
	assert ret2
}

PS D:\Test\v\tt1> v run .
true
true
```