### PR TITLE
checker: fix check omission in cast string to ptr. (fix #14921)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2492,6 +2492,10 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		tt := c.table.type_to_str(to_type)
 		c.error('cannot cast string to `$tt`, use `${snexpr}.${final_to_sym.name}()` instead.',
 			node.pos)
+	} else if final_from_sym.kind == .string && to_type.is_ptr() && to_sym.kind != .string {
+		snexpr := node.expr.str()
+		tt := c.table.type_to_str(to_type)
+		c.error('cannot cast string to `$tt`, use `${snexpr}.str` instead.', node.pos)
 	}
 
 	if to_sym.kind == .rune && from_sym.is_string() {

--- a/vlib/v/checker/tests/cast_string_to_ptr_err.out
+++ b/vlib/v/checker/tests/cast_string_to_ptr_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/cast_string_to_ptr_err.vv:2:7: error: cannot cast string to `&char`, use `'foo'.str` instead.
+    1 | fn main() {
+    2 |     _ := &char('foo')
+      |          ~~~~~~~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/cast_string_to_ptr_err.vv
+++ b/vlib/v/checker/tests/cast_string_to_ptr_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	_ := &char('foo')
+}


### PR DESCRIPTION
1. Fix #14921
2. Add test.

```v
fn main() {
	_ := &char('foo')
}

```

output:

```
vlib/v/checker/tests/cast_string_to_ptr_err.vv:2:7: error: cannot cast string to `&char`, use `'foo'.str` instead.
    1 | fn main() {
    2 |     _ := &char('foo')
      |          ~~~~~~~~~~~~
    3 | }

```