### PR TITLE
ast: fix dumping sumtype of fntype (fix #15729)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -230,11 +230,9 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 	if f.return_type != 0 && f.return_type != void_type {
 		sym := t.sym(f.return_type)
 		opt := if f.return_type.has_flag(.optional) { 'option_' } else { '' }
-		if sym.kind == .alias {
-			sig += '__$opt$sym.cname'
-		} else {
-			sig += '__$opt$sym.kind'
-		}
+		res := if f.return_type.has_flag(.result) { 'result_' } else { '' }
+
+		sig += '__$opt$res$sym.cname'
 	}
 	return sig
 }

--- a/vlib/v/tests/inout/dump_sumtype_of_fntype.out
+++ b/vlib/v/tests/inout/dump_sumtype_of_fntype.out
@@ -1,0 +1,1 @@
+[vlib/v/tests/inout/dump_sumtype_of_fntype.vv:10] main.MyFnSumtype(main.f): MyFnSumtype(fn (int) v.ast.Expr)

--- a/vlib/v/tests/inout/dump_sumtype_of_fntype.vv
+++ b/vlib/v/tests/inout/dump_sumtype_of_fntype.vv
@@ -1,0 +1,11 @@
+import v.ast
+
+type MyFnSumtype = fn () | fn (int) ast.Expr
+
+fn f(z int) ast.Expr {
+	return ast.empty_expr
+}
+
+fn main() {
+	dump(MyFnSumtype(f))
+}


### PR DESCRIPTION
This PR fix dumping sumtype of fntype (fix #15729).

- Fix dumping sumtype of fntype.
- Add test.

```v
import v.ast

type MyFnSumtype = fn () | fn (int) ast.Expr

fn f(z int) ast.Expr {
	return ast.empty_expr
}

fn main() {
	dump(MyFnSumtype(f))
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:10] main.MyFnSumtype(main.f): MyFnSumtype(fn (int) v.ast.Expr)
```