### PR TITLE
cgen: fix generate call fn error when the struct type of sumtype has the fn field and is same to the struct name. (fix #15730)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1342,7 +1342,16 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			if obj := node.scope.find(node.name) {
 				match obj {
 					ast.Var {
-						if obj.smartcasts.len > 0 {
+						// Temp fix generate call fn error when the struct type of sumtype
+						// has the fn field and is same to the struct name.
+						mut is_need_cast := true
+						if node.left_type != 0 {
+							left_sym := g.table.sym(node.left_type)
+							if left_sym.kind == .struct_ && node.name == obj.name {
+								is_need_cast = false
+							}
+						}
+						if obj.smartcasts.len > 0 && is_need_cast {
 							for _ in obj.smartcasts {
 								g.write('(*')
 							}

--- a/vlib/v/tests/sumtype_with_struct_fn_field_call_test.v
+++ b/vlib/v/tests/sumtype_with_struct_fn_field_call_test.v
@@ -1,0 +1,13 @@
+type Expr = Fun | int
+
+struct Fun {
+	f fn (int) int
+}
+
+fn test_sumtype_with_struct_fn_field_call() {
+	f := Expr(0)
+	if f is Fun {
+		println((f as Fun).f(0))
+	}
+	assert true
+}


### PR DESCRIPTION
1. Fix: #15730
2. Add test.

```v
type Expr = Fun | int

struct Fun {
	f fn (int) int
}

fn test_sumtype_with_struct_fn_field_call() {
	f := Expr(0)
	if f is Fun {
		println((f as Fun).f(0))
	}
	assert true
}

```

output:

pass
