### PR TITLE
checker: check casting array to number (fix #11480)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2506,6 +2506,10 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		snexpr := node.expr.str()
 		tt := c.table.type_to_str(to_type)
 		c.error('cannot cast string to `$tt`, use `${snexpr}.str` instead.', node.pos)
+	} else if final_from_sym.kind == .array && !from_type.is_ptr() && to_type != ast.string_type {
+		ft := c.table.type_to_str(from_type)
+		tt := c.table.type_to_str(to_type)
+		c.error('cannot cast array `$ft` to `$tt`', node.pos)
 	}
 
 	if to_sym.kind == .rune && from_sym.is_string() {

--- a/vlib/v/checker/tests/cast_array_to_number_err.out
+++ b/vlib/v/checker/tests/cast_array_to_number_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/cast_array_to_number_err.vv:5:8: error: cannot cast array `[]u8` to `i16`
+    3 | fn main() {
+    4 |     bytes := '010000150107120508d37445a0d7e5c5071980710c64310d9e12043000777369ff0424ab78b91a05164b00e50034003300'
+    5 |     yr := i16(hx.decode(bytes.substr(6,8))?)
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    6 |     println(bytes)
+    7 |     println('yr: $yr')

--- a/vlib/v/checker/tests/cast_array_to_number_err.vv
+++ b/vlib/v/checker/tests/cast_array_to_number_err.vv
@@ -1,0 +1,8 @@
+import encoding.hex as hx
+
+fn main() {
+	bytes := '010000150107120508d37445a0d7e5c5071980710c64310d9e12043000777369ff0424ab78b91a05164b00e50034003300'
+	yr := i16(hx.decode(bytes.substr(6,8))?)
+	println(bytes)
+	println('yr: $yr')
+}


### PR DESCRIPTION
This PR check casting array to number (fix #11480, fix #12591).

- Check casting array to number.
- Add test.

```v
import encoding.hex as hx

fn main() {
	bytes := '010000150107120508d37445a0d7e5c5071980710c64310d9e12043000777369ff0424ab78b91a05164b00e50034003300'
	yr := i16(hx.decode(bytes.substr(6,8))?)
	println(bytes)
	println('yr: $yr')
}

PS D:\Test\v\tt1> v run .
./tt1.v:5:8: error: cannot cast array `[]u8` to `i16`
    3 | fn main() {
    4 |     bytes := '010000150107120508d37445a0d7e5c5071980710c64310d9e12043000777369ff0424ab78b91a05164b00e50034003300'
    5 |     yr := i16(hx.decode(bytes.substr(6,8))?)
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 |     println(bytes)
    7 |     println('yr: $yr')
```
```v
type IP = []byte

fn main() {
	mut ip := IP([]byte{cap:4})
	ip << 0
	ip << 0
	ip << 0
	ip << 1

	value := match 32 {
		25...32 {
			u32(u16(ip[0..4]))
		}
		else { 0 }
	}
	println(value)
}

PS D:\Test\v\tt1> v run .
./tt1.v:12:8: error: cannot cast array `IP` to `u16`
   10 |     value := match 32 {
   11 |         25...32 {
   12 |             u32(u16(ip[0..4]))
      |                 ~~~~~~~~~~~~~
   13 |         }
   14 |         else { 0 }
```