### PR TITLE
cgen: fix error of `in array of sumtype` (fix #12239)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -437,12 +437,12 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 			elem_type := right.sym.info.elem_type
 			elem_type_ := g.unwrap(elem_type)
 			if elem_type_.sym.kind == .sum_type {
-				if node.left_type in elem_type_.sym.sumtype_info().variants {
+				if ast.mktyp(node.left_type) in elem_type_.sym.sumtype_info().variants {
 					new_node_left := ast.CastExpr{
 						arg: ast.empty_expr
 						typ: elem_type
 						expr: node.left
-						expr_type: node.left_type
+						expr_type: ast.mktyp(node.left_type)
 					}
 					g.gen_array_contains(node.right_type, node.right, new_node_left)
 					return
@@ -507,12 +507,12 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 			elem_type := right.sym.info.elem_type
 			elem_type_ := g.unwrap(elem_type)
 			if elem_type_.sym.kind == .sum_type {
-				if node.left_type in elem_type_.sym.sumtype_info().variants {
+				if ast.mktyp(node.left_type) in elem_type_.sym.sumtype_info().variants {
 					new_node_left := ast.CastExpr{
 						arg: ast.empty_expr
 						typ: elem_type
 						expr: node.left
-						expr_type: node.left_type
+						expr_type: ast.mktyp(node.left_type)
 					}
 					g.gen_array_contains(node.right_type, node.right, new_node_left)
 					return

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -319,3 +319,11 @@ fn test_in_array_literal_of_sumtype() {
 	val2 := `+`
 	assert val2 in [TokenValue(`+`), TokenValue(`-`)]
 }
+
+type StringOrNumber = int | string
+
+fn test_in_array_of_sumtype() {
+	arr := [StringOrNumber(1), 2, 'test']
+	println(1 in arr)
+	assert 1 in arr
+}


### PR DESCRIPTION
This PR fix error of `in array of sumtype` (fix #12239).

- Fix error of `in array of sumtype`.
- Add test.

```v
type StringOrNumber = int | string

fn main() {
	arr := [StringOrNumber(1), 2, 'test']
	println(1 in arr)
	assert 1 in arr
}

PS D:\Test\v\tt1> v run .
true
```