### PR TITLE
add test for fn call arg of fn pointer mismatch (fix #9966)

### DIFF
--- a/vlib/v/checker/tests/fn_call_arg_mismatch_err_d.out
+++ b/vlib/v/checker/tests/fn_call_arg_mismatch_err_d.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fn_call_arg_mismatch_err_d.vv:17:26: error: cannot use `fn (string) f64` as `fn (string) ?Flag` in argument 2 to `parse_option`
+   15 |
+   16 | fn main() {
+   17 |     t := parse_option('45', parse_percent)?
+      |                             ~~~~~~~~~~~~~
+   18 |     println(t)
+   19 | }

--- a/vlib/v/checker/tests/fn_call_arg_mismatch_err_d.vv
+++ b/vlib/v/checker/tests/fn_call_arg_mismatch_err_d.vv
@@ -1,0 +1,19 @@
+type Flag = bool | f64 | int | string
+
+fn parse_percent(value string) f64 {
+	f_val := value.f64()
+	if f_val >= 0 && f_val <= 100 {
+		return f_val
+	} else {
+		return 0
+	}
+}
+
+fn parse_option(str string, validator fn (string) ?Flag) ?Flag {
+	return validator(str)
+}
+
+fn main() {
+	t := parse_option('45', parse_percent)?
+	println(t)
+}


### PR DESCRIPTION
This PR add test for fn call arg of fn pointer mismatch (fix #9966).

- #9966 is fixed.
- Add test.

```v
type Flag = bool | f64 | int | string

fn parse_percent(value string) f64 {
	f_val := value.f64()
	if f_val >= 0 && f_val <= 100 {
		return f_val
	} else {
		return 0
	}
}

fn parse_option(str string, validator fn (string) ?Flag) ?Flag {
	return validator(str)
}

fn main() {
	t := parse_option('45', parse_percent)?
	println(t)
}

PS D:\Test\v\tt1> v run .
./tt1.v:17:26: error: cannot use `fn (string) f64` as `fn (string) ?Flag` in argument 2 to `parse_option`
   15 |
   16 | fn main() {
   17 |     t := parse_option('45', parse_percent)?
      |                             ~~~~~~~~~~~~~
   18 |     println(t)
   19 | }
```