### PR TITLE
checker: fix struct init with update of mutable receiver (fix #7033)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -548,7 +548,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 	if node.has_update_expr {
 		update_type := c.expr(node.update_expr)
 		node.update_expr_type = update_type
-		if c.table.type_kind(update_type) != .struct_ {
+		if c.table.sym(update_type).kind != .struct_ {
 			s := c.table.type_to_str(update_type)
 			c.error('expected struct, found `$s`', node.update_expr.pos())
 		} else if update_type != node.typ {

--- a/vlib/v/tests/struct_init_update_with_mutable_receiver_test.v
+++ b/vlib/v/tests/struct_init_update_with_mutable_receiver_test.v
@@ -1,0 +1,21 @@
+module main
+
+struct Person {
+	name string
+	age  int
+}
+
+fn (mut p Person) change(name string) {
+	p = Person{
+		...p
+		name: name
+	}
+}
+
+fn test_struct_init_update_with_mutable_receiver() {
+	mut p := Person{'bob', 22}
+	p.change('tom')
+	println(p)
+	assert p.name == 'tom'
+	assert p.age == 22
+}


### PR DESCRIPTION
This PR fix struct init with update of mutable receiver (fix #7033).

- Fix struct init with update of mutable receiver.
- Add test.

```v
module main

struct Person {
	name string
	age  int
}

fn (mut p Person) change(name string) {
	p = Person{
		...p
		name: name
	}
}

fn main() {
	mut p := Person{'bob', 22}
	p.change('tom')
	println(p)
	assert p.name == 'tom'
	assert p.age == 22
}

PS D:\Test\v\tt1> v run .
Person{
    name: 'tom'
    age: 22
}
```