### PR TITLE
builtin, compiler: replace isnil(x) calls with `x == unsafe { nil }` (a little faster without -prod)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -636,7 +636,7 @@ fn (mut a array) push(val voidptr) {
 // `val` is array.data and user facing usage is `a << [1,2,3]`
 [unsafe]
 pub fn (mut a3 array) push_many(val voidptr, size int) {
-	if size <= 0 || isnil(val) {
+	if size <= 0 || val == unsafe { nil } {
 		return
 	}
 	a3.ensure_cap(a3.len + size)

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -227,7 +227,7 @@ fn (mut a array) push_noscan(val voidptr) {
 // `val` is array.data and user facing usage is `a << [1,2,3]`
 [unsafe]
 fn (mut a3 array) push_many_noscan(val voidptr, size int) {
-	if size <= 0 || isnil(val) {
+	if size <= 0 || val == unsafe { nil } {
 		return
 	}
 	if a3.data == val && a3.data != 0 {

--- a/vlib/builtin/builtin_d_use_libbacktrace.c.v
+++ b/vlib/builtin/builtin_d_use_libbacktrace.c.v
@@ -38,8 +38,12 @@ struct BacktraceOptions {
 }
 
 fn bt_print_callback(data &BacktraceOptions, pc voidptr, filename_ptr &char, line int, fn_name_ptr &char) int {
-	filename := if isnil(filename_ptr) { '???' } else { unsafe { filename_ptr.vstring() } }
-	fn_name := if isnil(fn_name_ptr) {
+	filename := if filename_ptr == unsafe { nil } {
+		'???'
+	} else {
+		unsafe { filename_ptr.vstring() }
+	}
+	fn_name := if fn_name_ptr == unsafe { nil } {
 		'???'
 	} else {
 		(unsafe { fn_name_ptr.vstring() }).replace('__', '.')
@@ -56,7 +60,7 @@ fn bt_print_callback(data &BacktraceOptions, pc voidptr, filename_ptr &char, lin
 }
 
 fn bt_error_callback(data voidptr, msg_ptr &char, errnum int) {
-	// if !isnil(data) && !isnil(data.state) && !isnil(data.state.filename) {
+	// if data != unsafe { nil } && data.state != unsafe { nil } && data.state.filename != unsafe { nil } {
 	// 	filename := unsafe{ data.state.filename.vstring() }
 	// 	eprint('$filename: ')
 	// }

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -96,7 +96,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 				cmd := 'addr2line -e $executable $addr'
 				// taken from os, to avoid depending on the os module inside builtin.v
 				f := C.popen(&char(cmd.str), c'r')
-				if isnil(f) {
+				if f == unsafe { nil } {
 					eprintln(sframe)
 					continue
 				}

--- a/vlib/darwin/darwin.v
+++ b/vlib/darwin/darwin.v
@@ -38,7 +38,7 @@ fn C.CFRelease(url &u8)
 pub fn resource_path() string {
 	main_bundle := C.CFBundleGetMainBundle()
 	resource_dir_url := C.CFBundleCopyResourcesDirectoryURL(main_bundle)
-	if isnil(resource_dir_url) {
+	if resource_dir_url == unsafe { nil } {
 		panic('CFBundleCopyResourcesDirectoryURL failed')
 	}
 	buffer_size := 4096

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -421,7 +421,7 @@ pub fn new_context(cfg Config) &Context {
 		ui_mode: cfg.ui_mode
 		native_rendering: cfg.native_rendering
 	}
-	if isnil(cfg.user_data) {
+	if cfg.user_data == unsafe { nil } {
 		ctx.user_data = ctx
 	}
 	ctx.set_bg_color(cfg.bg_color)

--- a/vlib/gx/image.v
+++ b/vlib/gx/image.v
@@ -10,5 +10,5 @@ pub:
 }
 
 pub fn (i Image) is_empty() bool {
-	return isnil(i.obj)
+	return i.obj == unsafe { nil }
 }

--- a/vlib/sync/pool/pool.v
+++ b/vlib/sync/pool/pool.v
@@ -42,7 +42,7 @@ pub struct PoolProcessorConfig {
 //      3) task_id - the index of the worker thread in which the callback
 //            function is running.
 pub fn new_pool_processor(context PoolProcessorConfig) &PoolProcessor {
-	if isnil(context.callback) {
+	if context.callback == unsafe { nil } {
 		panic('You need to pass a valid callback to new_pool_processor.')
 	}
 	mut pool := PoolProcessor{

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -38,7 +38,7 @@ pub fn new_scope(parent &Scope, start_pos int) &Scope {
 */
 
 fn (s &Scope) dont_lookup_parent() bool {
-	return isnil(s.parent) || s.detached_from_parent
+	return s.parent == unsafe { nil } || s.detached_from_parent
 }
 
 pub fn (s &Scope) find(name string) ?ScopeObject {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -34,7 +34,7 @@ fn find_windows_kit_internal(key RegKey, versions []string) ?string {
 				}
 				alloc_length := (required_bytes + 2)
 				mut value := &u16(malloc_noscan(int(alloc_length)))
-				if isnil(value) {
+				if value == nil {
 					continue
 				}
 				//

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -651,7 +651,8 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 				} else {
 					match sym.info {
 						ast.Struct, ast.Interface, ast.SumType {
-							if !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len > 0 { // in generic fn
+							if c.table.cur_fn != unsafe { nil }
+								&& c.table.cur_fn.generic_names.len > 0 { // in generic fn
 								if gt_name in c.table.cur_fn.generic_names
 									&& c.table.cur_fn.generic_names.len == c.table.cur_concrete_types.len {
 									idx := c.table.cur_fn.generic_names.index(gt_name)
@@ -704,7 +705,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 					mut param_elem_sym := c.table.sym(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array && param_elem_sym.kind == .array
-							&& !isnil(c.table.cur_fn)
+							&& c.table.cur_fn != unsafe { nil }
 							&& param_elem_sym.name !in c.table.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.Array
 							arg_elem_sym = c.table.sym(arg_elem_info.elem_type)
@@ -724,7 +725,7 @@ pub fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr
 					mut param_elem_sym := c.table.sym(param_elem_info.elem_type)
 					for {
 						if arg_elem_sym.kind == .array_fixed && param_elem_sym.kind == .array_fixed
-							&& !isnil(c.table.cur_fn)
+							&& c.table.cur_fn != unsafe { nil }
 							&& param_elem_sym.name !in c.table.cur_fn.generic_names {
 							arg_elem_info = arg_elem_sym.info as ast.ArrayFixed
 							arg_elem_sym = c.table.sym(arg_elem_info.elem_type)

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -365,7 +365,7 @@ fn (mut c Checker) verify_all_vweb_routes() {
 				is_ok, nroute_attributes, nargs := c.verify_vweb_params_for_method(m)
 				if !is_ok {
 					f := &ast.FnDecl(m.source_fn)
-					if isnil(f) {
+					if f == unsafe { nil } {
 						continue
 					}
 					if f.return_type == typ_vweb_result && f.receiver.typ == m.params[0].typ

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -77,7 +77,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.ensure_sumtype_array_has_default_value(node)
 		}
 		c.ensure_type_exists(node.elem_type, node.elem_type_pos) or {}
-		if node.typ.has_flag(.generic) && !isnil(c.table.cur_fn)
+		if node.typ.has_flag(.generic) && c.table.cur_fn != unsafe { nil }
 			&& c.table.cur_fn.generic_names.len == 0 {
 			c.error('generic struct cannot be used in non-generic function', node.pos)
 		}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -460,7 +460,7 @@ pub fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	c.expected_or_type = node.return_type.clear_flag(.optional)
 	c.stmts_ending_with_expression(node.or_block.stmts)
 	c.expected_or_type = ast.void_type
-	if node.or_block.kind == .propagate_option && !isnil(c.table.cur_fn)
+	if node.or_block.kind == .propagate_option && c.table.cur_fn != unsafe { nil }
 		&& !c.table.cur_fn.return_type.has_flag(.optional) && !c.inside_const {
 		if !c.table.cur_fn.is_main {
 			c.error('to propagate the optional call, `$c.table.cur_fn.name` must return an optional',
@@ -486,7 +486,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			concrete_types << concrete_type
 		}
 	}
-	if !isnil(c.table.cur_fn) && c.table.cur_concrete_types.len == 0 && has_generic {
+	if c.table.cur_fn != unsafe { nil } && c.table.cur_concrete_types.len == 0 && has_generic {
 		c.error('generic fn using generic types cannot be called outside of generic fn',
 			node.pos)
 	}
@@ -521,7 +521,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			c.error('JS.await: first argument must be a promise, got `$tsym.name`', node.pos)
 			return ast.void_type
 		}
-		if !isnil(c.table.cur_fn) {
+		if c.table.cur_fn != unsafe { nil } {
 			c.table.cur_fn.has_await = true
 		}
 		match tsym.info {
@@ -787,7 +787,7 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		&& func.mod != c.mod && !c.pref.is_test {
 		c.error('function `$func.name` is private', node.pos)
 	}
-	if !isnil(c.table.cur_fn) && !c.table.cur_fn.is_deprecated && func.is_deprecated {
+	if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_deprecated && func.is_deprecated {
 		c.deprecate('function', func.name, func.attrs, node.pos)
 	}
 	if func.is_unsafe && !c.inside_unsafe
@@ -1129,14 +1129,14 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 		}
 	}
 	// resolve return generics struct to concrete type
-	if func.generic_names.len > 0 && func.return_type.has_flag(.generic) && !isnil(c.table.cur_fn)
-		&& c.table.cur_fn.generic_names.len == 0 {
+	if func.generic_names.len > 0 && func.return_type.has_flag(.generic)
+		&& c.table.cur_fn != unsafe { nil } && c.table.cur_fn.generic_names.len == 0 {
 		node.return_type = c.table.unwrap_generic_type(func.return_type, func.generic_names,
 			concrete_types)
 	} else {
 		node.return_type = func.return_type
 	}
-	if node.concrete_types.len > 0 && func.return_type != 0 && !isnil(c.table.cur_fn)
+	if node.concrete_types.len > 0 && func.return_type != 0 && c.table.cur_fn != unsafe { nil }
 		&& c.table.cur_fn.generic_names.len == 0 {
 		if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
 			concrete_types)
@@ -1183,7 +1183,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	node.return_type = left_type
 	node.receiver_type = left_type
 
-	if !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len > 0 {
+	if c.table.cur_fn != unsafe { nil } && c.table.cur_fn.generic_names.len > 0 {
 		c.table.unwrap_generic_type(left_type, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
 	}
 	unwrapped_left_type := c.unwrap_generic(left_type)
@@ -1262,7 +1262,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		if node.args.len > 0 {
 			c.error('wait() does not have any arguments', node.args[0].pos)
 		}
-		if !isnil(c.table.cur_fn) {
+		if c.table.cur_fn != unsafe { nil } {
 			c.table.cur_fn.has_await = true
 		}
 		node.return_type = info.concrete_types[0]
@@ -1569,7 +1569,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			c.warn('method `${left_sym.name}.$method_name` must be called from an `unsafe` block',
 				node.pos)
 		}
-		if !isnil(c.table.cur_fn) && !c.table.cur_fn.is_deprecated && method.is_deprecated {
+		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_deprecated && method.is_deprecated {
 			c.deprecate('method', '${left_sym.name}.$method.name', method.attrs, node.pos)
 		}
 		c.set_node_expected_arg_types(mut node, method)
@@ -1593,7 +1593,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 
 		// resolve return generics struct to concrete type
 		if method.generic_names.len > 0 && method.return_type.has_flag(.generic)
-			&& !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len == 0 {
+			&& c.table.cur_fn != unsafe { nil } && c.table.cur_fn.generic_names.len == 0 {
 			node.return_type = c.table.unwrap_generic_type(method.return_type, method.generic_names,
 				concrete_types)
 		} else {

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -7,7 +7,7 @@ import v.pref
 
 // TODO: non deferred
 pub fn (mut c Checker) return_stmt(mut node ast.Return) {
-	if isnil(c.table.cur_fn) {
+	if c.table.cur_fn == unsafe { nil } {
 		return
 	}
 	c.expected_type = c.table.cur_fn.return_type

--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -104,8 +104,8 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Typ
 			node.need_fmts[i] = fmt != c.get_default_fmt(ftyp, typ)
 		}
 		// check recursive str
-		if !isnil(c.table.cur_fn) && c.table.cur_fn.is_method && c.table.cur_fn.name == 'str'
-			&& c.table.cur_fn.receiver.name == expr.str() {
+		if c.table.cur_fn != unsafe { nil } && c.table.cur_fn.is_method
+			&& c.table.cur_fn.name == 'str' && c.table.cur_fn.receiver.name == expr.str() {
 			c.error('cannot call `str()` method recursively', expr.pos())
 		}
 	}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -244,7 +244,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				&& node.generic_types.len != struct_sym.info.generic_types.len {
 				c.error('generic struct init expects $struct_sym.info.generic_types.len generic parameter, but got $node.generic_types.len',
 					node.pos)
-			} else if node.generic_types.len > 0 && !isnil(c.table.cur_fn) {
+			} else if node.generic_types.len > 0 && c.table.cur_fn != unsafe { nil } {
 				for gtyp in node.generic_types {
 					gtyp_name := c.table.sym(gtyp).name
 					if gtyp_name !in c.table.cur_fn.generic_names {
@@ -276,7 +276,7 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		}
 	}
 	// register generic struct type when current fn is generic fn
-	if !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len > 0 {
+	if c.table.cur_fn != unsafe { nil } && c.table.cur_fn.generic_names.len > 0 {
 		c.table.unwrap_generic_type(node.typ, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
 	}
 	c.ensure_type_exists(node.typ, node.pos) or {}
@@ -321,7 +321,8 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				'it cannot be initialized with `$type_sym.name{}`', node.pos)
 		}
 	}
-	if type_sym.name.len == 1 && !isnil(c.table.cur_fn) && c.table.cur_fn.generic_names.len == 0 {
+	if type_sym.name.len == 1 && c.table.cur_fn != unsafe { nil }
+		&& c.table.cur_fn.generic_names.len == 0 {
 		c.error('unknown struct `$type_sym.name`', node.pos)
 		return ast.void_type
 	}

--- a/vlib/v/embed_file/embed_file.v
+++ b/vlib/v/embed_file/embed_file.v
@@ -59,10 +59,10 @@ pub fn (original &EmbedFileData) to_bytes() []u8 {
 }
 
 pub fn (mut ed EmbedFileData) data() &u8 {
-	if !isnil(ed.uncompressed) {
+	if ed.uncompressed != unsafe { nil } {
 		return ed.uncompressed
 	}
-	if isnil(ed.uncompressed) && !isnil(ed.compressed) {
+	if ed.uncompressed == unsafe { nil } && ed.compressed != unsafe { nil } {
 		decoder := g_embed_file_decoders.decoders[ed.compression_type] or {
 			panic('EmbedFileData error: unknown compression of "$ed.path": "$ed.compression_type"')
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1903,7 +1903,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 		f.write('_')
 	} else {
 		mut is_local := false
-		if !isnil(f.fn_scope) {
+		if f.fn_scope != unsafe { nil } {
 			if _ := f.fn_scope.find_var(node.name) {
 				is_local = true
 			}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -295,7 +295,7 @@ mut:
 [unsafe]
 pub fn cached_read_source_file(path string) ?string {
 	mut static cache := &SourceCache(0)
-	if isnil(cache) {
+	if cache == unsafe { nil } {
 		cache = &SourceCache{}
 	}
 


### PR DESCRIPTION
This PR makes `v self` ~2% faster (that is with tcc on Ubuntu 20.04, i3, without -prod. With -prod the speedup is <~1%).