### PR TITLE
cgen: fix printing and dumping of struct having referenced interface as field

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -921,7 +921,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 			funcprefix += 'isnil(it.${c_name(field.name)})'
 			funcprefix += ' ? _SLIT("nil") : '
 			// struct, floats and ints have a special case through the _str function
-			if sym.kind !in [.struct_, .alias, .enum_] && !field.typ.is_int_valptr()
+			if sym.kind !in [.struct_, .alias, .enum_, .interface_] && !field.typ.is_int_valptr()
 				&& !field.typ.is_float_valptr() {
 				funcprefix += '*'
 			}

--- a/vlib/v/tests/inout/dump_expression.out
+++ b/vlib/v/tests/inout/dump_expression.out
@@ -1,19 +1,32 @@
-[vlib/v/tests/inout/dump_expression.vv:4] 1: 1
-[vlib/v/tests/inout/dump_expression.vv:9] 'a': a
-[vlib/v/tests/inout/dump_expression.vv:25] p: Point{
+[vlib/v/tests/inout/dump_expression.vv:5] 1: 1
+[vlib/v/tests/inout/dump_expression.vv:10] 'a': a
+[vlib/v/tests/inout/dump_expression.vv:32] a: Aa{
+    log: &log.Logger(log.Log{
+        level: disabled
+        output_label: ''
+        ofile: os.File{
+            cfile: 0
+            fd: 0
+            is_opened: false
+        }
+        output_target: console
+        output_file_name: ''
+    })
+}
+[vlib/v/tests/inout/dump_expression.vv:33] p: Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/tests/inout/dump_expression.vv:26] p_mut: Point{
+[vlib/v/tests/inout/dump_expression.vv:34] p_mut: Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/tests/inout/dump_expression.vv:27] p_ptr: &Point{
+[vlib/v/tests/inout/dump_expression.vv:35] p_ptr: &Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/tests/inout/dump_expression.vv:38] os.file_name(vfile): dump_expression.vv
-[vlib/v/tests/inout/dump_expression.vv:41] f.read(mut buf): 10
+[vlib/v/tests/inout/dump_expression.vv:46] os.file_name(vfile): dump_expression.vv
+[vlib/v/tests/inout/dump_expression.vv:49] f.read(mut buf): 10

--- a/vlib/v/tests/inout/dump_expression.vv
+++ b/vlib/v/tests/inout/dump_expression.vv
@@ -1,4 +1,5 @@
 import os
+import log
 
 fn dump_of_int() {
 	x := dump(1) + 1
@@ -17,11 +18,18 @@ mut:
 	z int
 }
 
+struct Aa{
+	log &log.Logger
+}
+
 fn dump_of_struct() {
 	p := Point{1, 2, 3}
 	mut p_mut := Point{1, 2, 3}
 	p_ptr := &Point{1, 2, 3}
+	l := &log.Log{}
+	a := Aa{log:l}
 
+	dump(a)
 	mut x1 := dump(p)
 	mut x2 := dump(p_mut)
 	mut x3 := dump(p_ptr)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->


Fixes https://github.com/vlang/v/issues/15740