### PR TITLE
fix hardcoded param name vweb html

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -70,7 +70,8 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		fn_name := g.fn_decl.name.replace('.', '__') + node.pos.pos.str()
 		if is_html {
 			// return vweb html template
-			g.writeln('vweb__Context_html(&app->Context, _tmpl_res_$fn_name); strings__Builder_free(&sb_$fn_name); string_free(&_tmpl_res_$fn_name);')
+			app_name := g.fn_decl.params[0].name
+			g.writeln('vweb__Context_html(&$app_name->Context, _tmpl_res_$fn_name); strings__Builder_free(&sb_$fn_name); string_free(&_tmpl_res_$fn_name);')
 		} else {
 			// return $tmpl string
 			g.write(cur_line)


### PR DESCRIPTION
Fix the hardcoded app param name, o/w using any other name leads to builder error, e.g.

```
/tmp/v_1000/vweb_crash.10723254446889791592.tmp.c:30259: error: 'app' undeclared
```

## How to reproduce
Change `app` to anything, e.g. `server` in /examples/vweb/vweb_example.v

```diff
- pub fn (mut app App) index() vweb.Result 
+ pub fn (mut server App) index() vweb.Result  
```
