### PR TITLE
cgen: fix passing sumtype parameter in sumtype matching results (fix #15078)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2306,7 +2306,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			scope := g.file.scope.innermost(expr.pos().pos)
 			if expr is ast.Ident {
 				if v := scope.find_var(expr.name) {
-					if v.smartcasts.len > 0 {
+					if v.smartcasts.len > 0 && unwrapped_expected_type == v.orig_type {
 						is_already_sum_type = true
 					}
 				}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1598,8 +1598,10 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 			if arg.expr.obj is ast.Var {
 				if arg.expr.obj.smartcasts.len > 0 {
 					exp_sym := g.table.sym(expected_types[i])
-					if exp_sym.kind != .sum_type || (exp_sym.kind == .sum_type
-						&& expected_types[i] != arg.expr.obj.orig_type) {
+					orig_sym := g.table.sym(arg.expr.obj.orig_type)
+					if orig_sym.kind != .interface_ && (exp_sym.kind != .sum_type
+						|| (exp_sym.kind == .sum_type
+						&& expected_types[i] != arg.expr.obj.orig_type)) {
 						expected_types[i] = g.unwrap_generic(arg.expr.obj.smartcasts.last())
 						cast_sym := g.table.sym(expected_types[i])
 						if cast_sym.info is ast.Aggregate {

--- a/vlib/v/tests/passing_sumtype_parameter_in_sumtype_matching_results_test.v
+++ b/vlib/v/tests/passing_sumtype_parameter_in_sumtype_matching_results_test.v
@@ -1,0 +1,25 @@
+struct Foo {}
+
+type Bar = Foo | int
+type Baz = Foo | f32
+
+fn foo(a Bar) int {
+	return 22
+}
+
+fn bar() Baz {
+	return Foo{}
+}
+
+fn test_passing_sumtype_parameter_in_sumtype_matching_results() {
+	a := bar()
+	mut ret := 0
+	match a {
+		Foo {
+			ret = foo(Bar(a))
+		}
+		f32 {}
+	}
+	println(ret)
+	assert ret == 22
+}


### PR DESCRIPTION
This PR fix passing sumtype parameter in sumtype matching results (fix #15078).

- Fix passing sumtype parameter in sumtype matching results.
- Add test.

```v
struct Foo {}

type Bar = Foo | int
type Baz = Foo | f32

fn foo(a Bar) int {
	return 22
}

fn bar() Baz {
	return Foo{}
}

fn main() {
	a := bar()
	mut ret := 0
	match a {
		Foo {
			ret = foo(Bar(a))
		}
		f32 {}
	}
	println(ret)
	assert ret == 22
}

PS D:\Test\v\tt1> v run .
22
```