### PR TITLE
vrepl: fix array method call error (fix #15769)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -454,7 +454,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			}
 			os.write_file(temp_file, temp_source_code) or { panic(err) }
 			s := repl_run_vfile(temp_file) or { return 1 }
-			if !func_call && s.exit_code == 0 && !temp_flag {
+			if s.exit_code == 0 && !temp_flag {
 				for r.temp_lines.len > 0 {
 					if !r.temp_lines[0].starts_with('print') {
 						r.lines << r.temp_lines[0]

--- a/vlib/v/tests/repl/array_method.repl
+++ b/vlib/v/tests/repl/array_method.repl
@@ -1,0 +1,10 @@
+mut arr := [1, 2, 3]
+arr
+arr.delete_last()
+arr
+arr.clear()
+arr
+===output===
+[1, 2, 3]
+[1, 2]
+[]

--- a/vlib/v/tests/repl/fn_calls.repl
+++ b/vlib/v/tests/repl/fn_calls.repl
@@ -1,10 +1,8 @@
 math.sinf(50.0)
 println(1+math.sinf(50.0))
-fn test() { println('foo') } fn test2(a int) { println(a) }
+fn test() { println('foo') }
 test()
-test2(123)
 ===output===
 -0.2623749
 0.7376251
 foo
-123


### PR DESCRIPTION
This PR fix array method call error in vrepl (fix #15769).

- Fix array method call error.
- Add test.

```v
PS D:\vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.3.1 7e69619 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut arr := [1, 2, 3]
>>> arr
[1, 2, 3]
>>> arr.delete_last()
>>> arr
[1, 2]
>>> arr.clear()
>>> arr
[]
>>>
```