### PR TITLE
checker: fix nested struct ref field init check for embedded structs (fix #15768)

### DIFF
--- a/vlib/v/checker/tests/reference_field_must_be_initialized.out
+++ b/vlib/v/checker/tests/reference_field_must_be_initialized.out
@@ -1,11 +1,4 @@
-vlib/v/checker/tests/reference_field_must_be_initialized.vv:8:7: warning: reference field `Node.next.next` must be initialized
-    6 | 
-    7 | fn main(){
-    8 |     n := Node{ data: 123 }
-      |          ~~~~~~~~~~~~~~~~~
-    9 |     eprintln('n.data: $n.data')
-   10 | }
-vlib/v/checker/tests/reference_field_must_be_initialized.vv:8:7: error: reference field `Node.next` must be initialized
+vlib/v/checker/tests/reference_field_must_be_initialized.vv:8:7: warning: reference field `Node.next` must be initialized
     6 | 
     7 | fn main(){
     8 |     n := Node{ data: 123 }

--- a/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
@@ -1,7 +1,13 @@
-vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:11:7: warning: reference field `Outer.c.b` must be initialized
-    9 | 
-   10 | fn main() {
-   11 |     o := Outer{}
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:22:7: warning: reference field `Outer.c.b` must be initialized
+   20 | 
+   21 | fn main() {
+   22 |     _ := Outer{}
       |          ~~~~~~~
-   12 |     dump(o)
-   13 | }
+   23 |     _ := Struct{}
+   24 | }
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:23:7: warning: reference field `Struct.ref2` must be initialized
+   21 | fn main() {
+   22 |     _ := Outer{}
+   23 |     _ := Struct{}
+      |          ~~~~~~~~
+   24 | }

--- a/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv
+++ b/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv
@@ -7,7 +7,18 @@ struct Outer {
 	c ContainsRef
 }
 
+struct Ref {}
+
+struct EmbedStruct {
+	ref1 &Ref = unsafe { nil }
+	ref2 &Ref
+}
+
+struct Struct {
+	EmbedStruct
+}
+
 fn main() {
-	o := Outer{}
-	dump(o)
+	_ := Outer{}
+	_ := Struct{}
 }


### PR DESCRIPTION
1. Fix #15768
2. Add test.

```v
struct ContainsRef {
	a &int = unsafe { nil }
	b &int
}

struct Outer {
	c ContainsRef
}

struct Ref {}

struct EmbedStruct {
	ref1 &Ref = unsafe { nil }
	ref2 &Ref
}

struct Struct {
	EmbedStruct
}

fn main() {
	_ := Outer{}
	_ := Struct{}
}

```
output:
```
vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:22:7: warning: reference field `Outer.c.b` must be initialized
   20 | 
   21 | fn main() {
   22 |     _ := Outer{}
      |          ~~~~~~~
   23 |     _ := Struct{}
   24 | }
vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:23:7: warning: reference field `Struct.ref2` must be initialized
   21 | fn main() {
   22 |     _ := Outer{}
   23 |     _ := Struct{}
      |          ~~~~~~~~
   24 | }
```