### PR TITLE
checker, parser, fmt: Fix visibility of anon struct in different modules.(fix #15763)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -290,8 +290,9 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		&& c.table.cur_concrete_types.len == 0 {
 		pos := type_sym.name.last_index('.') or { -1 }
 		first_letter := type_sym.name[pos + 1]
-		if !first_letter.is_capital() && type_sym.kind != .placeholder
-			&& !type_sym.name.starts_with('main._VAnonStruct') {
+		if !first_letter.is_capital()
+			&& (type_sym.kind != .struct_ || !(type_sym.info as ast.Struct).is_anon)
+			&& type_sym.kind != .placeholder {
 			c.error('cannot initialize builtin type `$type_sym.name`', node.pos)
 		}
 	}

--- a/vlib/v/checker/tests/anon_structs_visibility.out
+++ b/vlib/v/checker/tests/anon_structs_visibility.out
@@ -1,0 +1,1 @@
+foo.bar.baz == 1

--- a/vlib/v/checker/tests/anon_structs_visibility/amod/amod.v
+++ b/vlib/v/checker/tests/anon_structs_visibility/amod/amod.v
@@ -1,0 +1,9 @@
+module amod
+
+pub struct Foo {
+pub mut:
+	bar struct  {
+	pub mut:
+		baz int
+	}
+}

--- a/vlib/v/checker/tests/anon_structs_visibility/main.v
+++ b/vlib/v/checker/tests/anon_structs_visibility/main.v
@@ -1,0 +1,10 @@
+import v.checker.tests.anon_structs_visibility.amod
+
+fn main() {
+	foo := amod.Foo{
+		bar: struct {
+			baz: 1
+		}
+	}
+	println('foo.bar.baz == $foo.bar.baz')
+}

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -8,7 +8,7 @@ import v.ast
 
 pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 	f.attrs(node.attrs)
-	if node.is_pub {
+	if node.is_pub && !is_anon {
 		f.write('pub ')
 	}
 	if node.is_union {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -14,9 +14,12 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	attrs := p.attrs
 	p.attrs = []
 	start_pos := p.tok.pos()
-	is_pub := p.tok.kind == .key_pub
+	mut is_pub := p.tok.kind == .key_pub
 	if is_pub {
 		p.next()
+	}
+	if is_anon {
+		is_pub = true
 	}
 	is_union := p.tok.kind == .key_union
 	if p.tok.kind == .key_struct {


### PR DESCRIPTION
1. Fix #15763
2. Add test

amod.v:
```v
module amod

pub struct Foo {
pub mut:
	bar struct  {
	pub mut:
		baz int
	}
}
```
main.v:
```v
import amod

fn main() {
	foo := amod.Foo{
		bar: struct {
			baz: 1
		}
	}
	assert foo.bar.baz == 1
}
```

output:

pass.
