### PR TITLE
checker: check result type method call (fix #15778)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1199,6 +1199,9 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if left_type.has_flag(.optional) {
 		c.error('optional type cannot be called directly', node.left.pos())
 		return ast.void_type
+	} else if left_type.has_flag(.result) {
+		c.error('result type cannot be called directly', node.left.pos())
+		return ast.void_type
 	}
 	if left_sym.kind in [.sum_type, .interface_] {
 		if method_name == 'type_name' {

--- a/vlib/v/checker/tests/result_type_call_err.out
+++ b/vlib/v/checker/tests/result_type_call_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/result_type_call_err.vv:12:2: error: result type cannot be called directly
+   10 |
+   11 | fn main() {
+   12 |     new_foo().foo()
+      |     ~~~~~~~~~
+   13 | }

--- a/vlib/v/checker/tests/result_type_call_err.vv
+++ b/vlib/v/checker/tests/result_type_call_err.vv
@@ -1,0 +1,13 @@
+struct Foo {}
+
+fn (f Foo) foo() int {
+	return 1
+}
+
+fn new_foo() !Foo {
+	return Foo{}
+}
+
+fn main() {
+	new_foo().foo()
+}


### PR DESCRIPTION
This PR check result type method call (fix #15778).

- Check result type method call.
- Add test.

```v
struct Foo {}

fn (f Foo) foo() int {
	return 1
}

fn new_foo() !Foo {
	return Foo{}
}

fn main() {
	new_foo().foo()
}

PS D:\Test\v\tt1> v run .
./tt1.v:12:2: error: result type cannot be called directly
   10 |
   11 | fn main() {
   12 |     new_foo().foo()
      |     ~~~~~~~~~
   13 | }
```