### PR TITLE
vrepl: fix output error of print and fn call

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -390,7 +390,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			source_code := r.current_source_code(false, false) + '\n$r.line\n'
 			os.write_file(temp_file, source_code) or { panic(err) }
 			s := repl_run_vfile(temp_file) or { return 1 }
-			print_output(s.output)
+			if s.output.len > r.last_output.len {
+				cur_line_output := s.output[r.last_output.len..]
+				print_output(cur_line_output)
+			}
 		} else {
 			mut temp_line := r.line
 			func_call, fntype := r.function_call(r.line)
@@ -441,7 +444,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				source_code := r.current_source_code(false, false) + '\n$temp_line\n'
 				os.write_file(temp_file, source_code) or { panic(err) }
 				s := repl_run_vfile(temp_file) or { return 1 }
-				print_output(s.output)
+				if s.output.len > r.last_output.len {
+					cur_line_output := s.output[r.last_output.len..]
+					print_output(cur_line_output)
+				}
 				continue
 			}
 			mut temp_source_code := ''

--- a/vlib/v/tests/repl/print_and_fn_call.repl
+++ b/vlib/v/tests/repl/print_and_fn_call.repl
@@ -1,0 +1,10 @@
+println('hello')
+fn abc(x int) { println(x) }
+abc(123)
+abc(456)
+println('hello')
+===output===
+hello
+123
+456
+hello


### PR DESCRIPTION
This PR fix output error of print and fn call.

- Fix output error of print and fn call.
- Add test.

```v
PS D:\vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.3.1 26443cf . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> println('hello')
hello
>>> fn abc(x int) { println(x) }
>>> abc(123)
123
>>> abc(456)
456
>>> println('hello')
hello
>>> 
```