### PR TITLE
datatypes: rewritten ringbuffer-feature

### DIFF
--- a/vlib/datatypes/ringbuffer.v
+++ b/vlib/datatypes/ringbuffer.v
@@ -1,0 +1,65 @@
+// Written by flopetautschnig (floscodes) (c) 2022
+
+module datatypes
+
+pub struct RingBuffer<T> {
+mut:
+	content []T
+}
+
+// new - creates an empty ringbuffer
+pub fn new_ringbuffer<T>(s int) RingBuffer<T> {
+	return RingBuffer<T>{
+		content: []T{cap: s}
+	}
+}
+
+// push - adds an element to the ringbuffer ensuring that the buffer will never grow
+pub fn (mut rb RingBuffer<T>) push(element T) ? {
+	if rb.content.len == rb.content.cap {
+		eprintln('Error: buffer overflow\n\nCannot push value $element to buffer because buffer has only a capacity of $rb.content.cap')
+	} else {
+		rb.content.insert(0, element)
+	}
+}
+
+// pop - returns the oldest element and deletes it from the ringbuffer
+pub fn (mut rb RingBuffer<T>) pop() ?T {
+	if rb.content.len == 0 {
+		eprintln('Error: buffer is empty')
+	}
+	return rb.content.pop()
+}
+
+// clear - emptys the ringbuffer
+pub fn (mut rb RingBuffer<T>) clear() {
+	rb.content = []T{len: 0, cap: rb.content.cap}
+}
+
+// capacity - returns the capacity of the ringbuffer
+pub fn (rb RingBuffer<T>) capacity() int {
+	return rb.content.cap
+}
+
+// is_empty - checks if the ringbuffer is empty
+pub fn (rb RingBuffer<T>) is_empty() bool {
+	if rb.content.len == 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+// is_full - checks if the ringbuffer is full
+pub fn (rb RingBuffer<T>) is_full() bool {
+	if rb.content.len < rb.content.cap {
+		return false
+	} else {
+		return true
+	}
+}
+
+// remaining -  returns the remaining capacity of the ringbuffer
+pub fn (rb RingBuffer<T>) remaining() int {
+	return rb.content.cap - rb.content.len
+}

--- a/vlib/datatypes/ringbuffer_test.v
+++ b/vlib/datatypes/ringbuffer_test.v
@@ -1,0 +1,42 @@
+import datatypes
+
+fn test_push_and_pop() {
+	mut r := datatypes.new_ringbuffer<int>(2)
+
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	mut oldest_value := r.pop() or { panic(err) }
+
+	assert oldest_value == 3
+
+	r.push(5) or { panic(err) }
+
+	oldest_value = r.pop() or { panic(err) }
+
+	assert oldest_value == 4
+}
+
+fn test_clear_and_empty() {
+	mut r := datatypes.new_ringbuffer<int>(4)
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	oldest_value := r.pop() or { panic(err) }
+	assert oldest_value == 3
+
+	r.clear()
+
+	assert r.is_empty() == true
+}
+
+fn test_capacity_remaining_is_full() {
+	mut r := datatypes.new_ringbuffer<int>(4)
+
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	assert r.is_full() == false
+	assert r.capacity() == 4
+	assert r.remaining() == 2
+}


### PR DESCRIPTION
**Rewritten ringbuffer-feature moved to vlib/datatypes. Now the buffer starts with a dynamic array with a fixed capacity, ensuring that it will never grow.**

Example:

```
module main

import datatypes

fn main() {

    // create a new ringbuffer with size 4
    // the generic argument sets the type
    mut r := datatypes.new_ringbuffer<int>(4)

    // push elements
    r.push(3)?
    r.push(4)?

    // get the oldest element. It will be removed from the buffer when calling `pop()`
    oldest_value := r.pop()?

    println(oldest_value) // Output: 3

    }

```

