### PR TITLE
docs: add note that clang is required

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5759,6 +5759,7 @@ For more examples, see [github.com/vlang/v/tree/master/vlib/v/tests/assembly/asm
 
 V can translate your C code to human readable V code and generate V wrappers on top of C libraries.
 
+C2V uses Clang's AST to generate V, so to translate a file from C to V, you have to have Clang installed on your machine.
 
 Let's create a simple program `test.c` first:
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5757,9 +5757,11 @@ For more examples, see [github.com/vlang/v/tree/master/vlib/v/tests/assembly/asm
 
 ## Translating C to V
 
-V can translate your C code to human readable V code and generate V wrappers on top of C libraries.
+V can translate your C code to human readable V code, and generating V wrappers
+on top of C libraries.
 
-C2V uses Clang's AST to generate V, so to translate a file from C to V, you have to have Clang installed on your machine.
+C2V currently uses Clang's AST to generate V, so to translate a C file to V
+you need to have Clang installed on your machine.
 
 Let's create a simple program `test.c` first:
 


### PR DESCRIPTION
I added a note saying that Clang is required to translate C to V, fixing this issue: https://github.com/vlang/v/issues/15783.