### PR TITLE
vrepl: fix output errors (fix #15801)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -494,7 +494,9 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			}
 			if s.output.len > r.last_output.len {
 				len := r.last_output.len
-				r.last_output = s.output.clone()
+				if s.exit_code == 0 {
+					r.last_output = s.output.clone()
+				}
 				cur_line_output := s.output[len..]
 				print_output(cur_line_output)
 			}

--- a/vlib/v/tests/repl/error_and_continue_print.repl
+++ b/vlib/v/tests/repl/error_and_continue_print.repl
@@ -4,12 +4,12 @@ b
 ===output===
 error: undefined ident: `a` (use `:=` to declare a variable)
     5 | import math
-    6 |
+    6 | 
     7 | a = 3
       | ^
 error: undefined ident: `b`
     5 | import math
-    6 | 
+    6 |
     7 | println(b)
       |         ^
 [4]

--- a/vlib/v/tests/repl/error_and_continue_print.repl
+++ b/vlib/v/tests/repl/error_and_continue_print.repl
@@ -4,7 +4,7 @@ b
 ===output===
 error: undefined ident: `a` (use `:=` to declare a variable)
     5 | import math
-    6 | 
+    6 |
     7 | a = 3
       | ^
 error: undefined ident: `b`

--- a/vlib/v/tests/repl/error_and_continue_print.repl
+++ b/vlib/v/tests/repl/error_and_continue_print.repl
@@ -1,0 +1,15 @@
+a = 3
+b
+[4, 5].filter(it < 5)
+===output===
+error: undefined ident: `a` (use `:=` to declare a variable)
+    5 | import math
+    6 |
+    7 | a = 3
+      | ^
+error: undefined ident: `b`
+    5 | import math
+    6 | 
+    7 | println(b)
+      |         ^
+[4]

--- a/vlib/v/tests/repl/error_and_continue_print.repl
+++ b/vlib/v/tests/repl/error_and_continue_print.repl
@@ -4,12 +4,12 @@ b
 ===output===
 error: undefined ident: `a` (use `:=` to declare a variable)
     5 | import math
-    6 |
+    6 | 
     7 | a = 3
       | ^
 error: undefined ident: `b`
     5 | import math
-    6 |
+    6 | 
     7 | println(b)
       |         ^
 [4]


### PR DESCRIPTION
This PR fix output errors (fix #15801).

- Fix output errors in vrepl.
- Add test.

```v
PS D:\vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.3.1 d67aa8d . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> a = 3
error: undefined ident: `a` (use `:=` to declare a variable)
    5 | import math
    6 |
    7 | a = 3
      | ^
>>> b
error: undefined ident: `b`
    5 | import math
    6 |
    7 | println(b)
      |         ^
>>> [4, 5].filter(it < 5)
[4]
>>>
```