### PR TITLE
parser: fix error for match expr with 'fn'  (fix #15803)

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -238,7 +238,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			&& (((ast.builtin_type_names_matcher.matches(p.tok.lit) || p.tok.lit[0].is_capital())
 			&& p.peek_tok.kind != .lpar) || (p.peek_tok.kind == .dot && p.peek_token(2).lit.len > 0
 			&& p.peek_token(2).lit[0].is_capital()))) || p.is_only_array_type()
-			|| p.tok.lit == 'fn' {
+			|| p.tok.kind == .key_fn {
 			mut types := []ast.Type{}
 			for {
 				// Sum type match

--- a/vlib/v/tests/match_expr_with_string_fn_test.v
+++ b/vlib/v/tests/match_expr_with_string_fn_test.v
@@ -1,0 +1,10 @@
+fn test_match_expr_with_string_fn() {
+	a := 'hello'
+	ret := match a {
+		'hello' { 1 }
+		'fn' { 2 }
+		else { 0 }
+	}
+	println(ret)
+	assert ret == 1
+}


### PR DESCRIPTION
This PR fix error for match expr with 'fn'  (fix #15803).

- Fix error for match expr with 'fn'.
- Add test.

```v
fn main() {
	a := 'hello'
	ret := match a {
		'hello' { 1 }
		'fn' { 2 }
		else { 0 }
	}
	println(ret)
	assert ret == 1
}

PS D:\Test\v\tt1> v run .
1
```