### PR TITLE
cgen: fix array insert in fn as mut receiver (fix #15800)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -605,10 +605,11 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 	arg2_sym := g.table.sym(node.args[1].typ)
 	is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
+	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg2_array {
-		g.write('array_insert_many${noscan}(&')
+		g.write('array_insert_many${noscan}($addr')
 	} else {
-		g.write('array_insert${noscan}(&')
+		g.write('array_insert${noscan}($addr')
 	}
 	g.expr(node.left)
 	g.write(', ')
@@ -640,10 +641,11 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 	arg_sym := g.table.sym(node.args[0].typ)
 	is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
+	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg_array {
-		g.write('array_prepend_many${noscan}(&')
+		g.write('array_prepend_many${noscan}($addr')
 	} else {
-		g.write('array_prepend${noscan}(&')
+		g.write('array_prepend${noscan}($addr')
 	}
 	g.expr(node.left)
 	if is_arg_array {

--- a/vlib/v/tests/array_insert_as_mut_receiver_test.v
+++ b/vlib/v/tests/array_insert_as_mut_receiver_test.v
@@ -1,0 +1,21 @@
+fn test_array_insert_as_mut_receiver() {
+	mut ns := []Node{cap: 2}
+	other(mut ns)
+	println(ns)
+	assert ns.len == 1
+	assert ns[0].id == 1
+	assert ns[0].a == 0
+}
+
+fn other(mut ns []Node) {
+	n1 := Node{
+		id: 1
+	}
+	ns.insert(0, n1)
+}
+
+pub struct Node {
+pub:
+	id u32 [required]
+	a  int
+}


### PR DESCRIPTION
This PR fix array insert in fn as mut receiver (fix #15800).

- Fix array insert in fn as mut receiver.
- Add test.

```v
fn main() {
	mut ns := []Node{cap: 2}
	other(mut ns)
	println(ns)
	assert ns.len == 1
	assert ns[0].id == 1
	assert ns[0].a == 0
}

fn other(mut ns []Node) {
	n1 := Node{
		id: 1
	}
	ns.insert(0, n1)
}

pub struct Node {
pub:
	id u32 [required]
	a  int
}

PS D:\Test\v\tt1> v run .
[Node{
    id: 1
    a: 0
}]
```