### PR TITLE
checker: optimized the position indicated by pos when the function needs to return an optional or result(fix #15780)

### DIFF
--- a/examples/js_dom_draw_bechmark_chart/chart/main.v
+++ b/examples/js_dom_draw_bechmark_chart/chart/main.v
@@ -85,13 +85,19 @@ pub fn (mut app App) controller_get_all_task() ?vweb.Result {
 	for orm_stmt_kind in orm_stmt_kinds {
 		match orm_stmt_kind {
 			'insert' {
-				framework_platform[orm_stmt_kind] = insert_framework_benchmark_times().to_map()
+				framework_platform[orm_stmt_kind] = insert_framework_benchmark_times() or {
+					return error('')
+				}.to_map()
 			}
 			'select' {
-				framework_platform[orm_stmt_kind] = select_framework_benchmark_times().to_map()
+				framework_platform[orm_stmt_kind] = select_framework_benchmark_times() or {
+					return error('')
+				}.to_map()
 			}
 			'update' {
-				framework_platform[orm_stmt_kind] = update_framework_benchmark_times().to_map()
+				framework_platform[orm_stmt_kind] = update_framework_benchmark_times() or {
+					return error('')
+				}.to_map()
 			}
 			else {}
 		}
@@ -109,7 +115,7 @@ pub fn (mut app App) controller_get_all_task() ?vweb.Result {
 	return $vweb.html()
 }
 
-fn insert_framework_benchmark_times() FrameworkPlatform {
+fn insert_framework_benchmark_times() !FrameworkPlatform {
 	numbers := FrameworkPlatform{
 		v_sqlite_memory: v_sqlite_memory()!.insert
 		// v_sqlite_file: v_sqlite_file()!.insert
@@ -119,7 +125,7 @@ fn insert_framework_benchmark_times() FrameworkPlatform {
 	return numbers
 }
 
-fn select_framework_benchmark_times() FrameworkPlatform {
+fn select_framework_benchmark_times() !FrameworkPlatform {
 	numbers := FrameworkPlatform{
 		v_sqlite_memory: v_sqlite_memory()!.@select
 		// v_sqlite_file: v_sqlite_file()!.@select
@@ -129,7 +135,7 @@ fn select_framework_benchmark_times() FrameworkPlatform {
 	return numbers
 }
 
-fn update_framework_benchmark_times() FrameworkPlatform {
+fn update_framework_benchmark_times() !FrameworkPlatform {
 	numbers := FrameworkPlatform{
 		v_sqlite_memory: v_sqlite_memory()!.update
 		// v_sqlite_file: v_sqlite_file()!.@select

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -958,7 +958,7 @@ pub fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_re
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.optional)
 			&& c.table.cur_fn.name != 'main.main' && !c.inside_const {
 			c.error('to propagate the call, `$c.table.cur_fn.name` must return an optional type',
-				node.pos)
+				c.table.cur_fn.return_type_pos)
 		}
 		if !expr_return_type.has_flag(.optional) {
 			if expr_return_type.has_flag(.result) {
@@ -975,7 +975,7 @@ pub fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_re
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.result)
 			&& c.table.cur_fn.name != 'main.main' && !c.inside_const {
 			c.error('to propagate the call, `$c.table.cur_fn.name` must return an result type',
-				node.pos)
+				c.table.cur_fn.return_type_pos)
 		}
 		if !expr_return_type.has_flag(.result) {
 			c.error('to propagate a result, the call must also return a result type',

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -957,8 +957,9 @@ pub fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_re
 	if node.kind == .propagate_option {
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.optional)
 			&& c.table.cur_fn.name != 'main.main' && !c.inside_const {
+			c.add_instruction_for_optional_type()
 			c.error('to propagate the call, `$c.table.cur_fn.name` must return an optional type',
-				c.table.cur_fn.return_type_pos)
+				node.pos)
 		}
 		if !expr_return_type.has_flag(.optional) {
 			if expr_return_type.has_flag(.result) {
@@ -974,8 +975,9 @@ pub fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_re
 	if node.kind == .propagate_result {
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.result)
 			&& c.table.cur_fn.name != 'main.main' && !c.inside_const {
-			c.error('to propagate the call, `$c.table.cur_fn.name` must return an result type',
-				c.table.cur_fn.return_type_pos)
+			c.add_instruction_for_result_type()
+			c.error('to propagate the call, `$c.table.cur_fn.name` must return a result type',
+				node.pos)
 		}
 		if !expr_return_type.has_flag(.result) {
 			c.error('to propagate a result, the call must also return a result type',
@@ -3684,6 +3686,20 @@ pub fn (mut c Checker) check_dup_keys(node &ast.MapInit, i int) {
 // call this *before* calling error or warn
 pub fn (mut c Checker) add_error_detail(s string) {
 	c.error_details << s
+}
+
+pub fn (mut c Checker) add_error_detail_with_pos(msg string, pos token.Pos) {
+	c.add_error_detail(util.formatted_error('details:', msg, c.file.path, pos))
+}
+
+pub fn (mut c Checker) add_instruction_for_optional_type() {
+	c.add_error_detail_with_pos('prepend ? before the declaration of the return type of `$c.table.cur_fn.name`',
+		c.table.cur_fn.return_type_pos)
+}
+
+pub fn (mut c Checker) add_instruction_for_result_type() {
+	c.add_error_detail_with_pos('prepend ! before the declaration of the return type of `$c.table.cur_fn.name`',
+		c.table.cur_fn.return_type_pos)
 }
 
 pub fn (mut c Checker) warn(s string, pos token.Pos) {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -466,11 +466,19 @@ pub fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	c.expected_or_type = node.return_type.clear_flag(.optional)
 	c.stmts_ending_with_expression(node.or_block.stmts)
 	c.expected_or_type = ast.void_type
-	if node.or_block.kind == .propagate_option && c.table.cur_fn != unsafe { nil }
-		&& !c.table.cur_fn.return_type.has_flag(.optional) && !c.inside_const {
+	if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.optional)
+		&& !c.inside_const {
 		if !c.table.cur_fn.is_main {
-			c.error('to propagate the optional call, `$c.table.cur_fn.name` must return an optional',
-				node.or_block.pos)
+			if node.or_block.kind == .propagate_option {
+				c.add_instruction_for_optional_type()
+				c.error('to propagate the optional call, `$c.table.cur_fn.name` must return an optional',
+					node.or_block.pos)
+			}
+			if node.or_block.kind == .propagate_result {
+				c.add_instruction_for_result_type()
+				c.error('to propagate the result call, `$c.table.cur_fn.name` must return a result',
+					node.or_block.pos)
+			}
 		}
 	}
 	return typ

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -466,21 +466,23 @@ pub fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	c.expected_or_type = node.return_type.clear_flag(.optional)
 	c.stmts_ending_with_expression(node.or_block.stmts)
 	c.expected_or_type = ast.void_type
-	if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.optional)
-		&& !c.inside_const {
-		if !c.table.cur_fn.is_main {
-			if node.or_block.kind == .propagate_option {
-				c.add_instruction_for_optional_type()
-				c.error('to propagate the optional call, `$c.table.cur_fn.name` must return an optional',
-					node.or_block.pos)
-			}
-			if node.or_block.kind == .propagate_result {
-				c.add_instruction_for_result_type()
-				c.error('to propagate the result call, `$c.table.cur_fn.name` must return a result',
-					node.or_block.pos)
-			}
+
+	if !c.inside_const && c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_main {
+		// TODO: use just `if node.or_block.kind == .propagate_result && !c.table.cur_fn.return_type.has_flag(.result) {` after the deprecation for ?!Type
+		if node.or_block.kind == .propagate_result && !c.table.cur_fn.return_type.has_flag(.result)
+			&& !c.table.cur_fn.return_type.has_flag(.optional) {
+			c.add_instruction_for_result_type()
+			c.error('to propagate the result call, `$c.table.cur_fn.name` must return a result',
+				node.or_block.pos)
+		}
+		if node.or_block.kind == .propagate_option
+			&& !c.table.cur_fn.return_type.has_flag(.optional) {
+			c.add_instruction_for_optional_type()
+			c.error('to propagate the optional call, `$c.table.cur_fn.name` must return an optional',
+				node.or_block.pos)
 		}
 	}
+
 	return typ
 }
 

--- a/vlib/v/checker/tests/optional_propagate_nested.out
+++ b/vlib/v/checker/tests/optional_propagate_nested.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/optional_propagate_nested.vv:10:18: error: to propagate the
       |                     ^
    11 |     return s
    12 | }
-vlib/v/checker/tests/optional_propagate_nested.vv:9:14: error: to propagate the call, `xx_prop` must return an optional type
+Details: vlib/v/checker/tests/optional_propagate_nested.vv:9:14: details: prepend ? before the declaration of the return type of `xx_prop`
     7 | }
     8 | 
     9 | fn xx_prop() string {
@@ -19,7 +19,7 @@ vlib/v/checker/tests/optional_propagate_nested.vv:28:21: error: to propagate the
       |                        ^
    29 |     s.z = 7.5
    30 |     println(f)
-vlib/v/checker/tests/optional_propagate_nested.vv:27:30: error: to propagate the call, `aa_propagate` must return an optional type
+Details: vlib/v/checker/tests/optional_propagate_nested.vv:27:30: details: prepend ? before the declaration of the return type of `aa_propagate`
    25 | }
    26 | 
    27 | fn (mut s St) aa_propagate() {

--- a/vlib/v/checker/tests/optional_propagate_nested.out
+++ b/vlib/v/checker/tests/optional_propagate_nested.out
@@ -5,6 +5,13 @@ vlib/v/checker/tests/optional_propagate_nested.vv:10:18: error: to propagate the
       |                     ^
    11 |     return s
    12 | }
+vlib/v/checker/tests/optional_propagate_nested.vv:9:14: error: to propagate the call, `xx_prop` must return an optional type
+    7 | }
+    8 | 
+    9 | fn xx_prop() string {
+      |              ~~~~~~
+   10 |     s := ret(raise()?)
+   11 |     return s
 vlib/v/checker/tests/optional_propagate_nested.vv:28:21: error: to propagate the optional call, `aa_propagate` must return an optional
    26 | 
    27 | fn (mut s St) aa_propagate() {
@@ -12,3 +19,10 @@ vlib/v/checker/tests/optional_propagate_nested.vv:28:21: error: to propagate the
       |                        ^
    29 |     s.z = 7.5
    30 |     println(f)
+vlib/v/checker/tests/optional_propagate_nested.vv:27:30: error: to propagate the call, `aa_propagate` must return an optional type
+   25 | }
+   26 | 
+   27 | fn (mut s St) aa_propagate() {
+      |                              ^
+   28 |     f := retf(s.raise()?)
+   29 |     s.z = 7.5

--- a/vlib/v/checker/tests/propagate_result_with_option.out
+++ b/vlib/v/checker/tests/propagate_result_with_option.out
@@ -1,14 +1,7 @@
-vlib/v/checker/tests/propagate_result_with_option.vv:6:8: error: to propagate the result call, `bar` must return a result
+vlib/v/checker/tests/propagate_result_with_option.vv:6:8: error: to propagate a result, the call must also return a result type
     4 | 
     5 | fn bar() !string {
     6 |     foo() !
       |           ^
     7 |     return ''
     8 | }
-Details: vlib/v/checker/tests/propagate_result_with_option.vv:5:10: details: prepend ! before the declaration of the return type of `bar`
-    3 | }
-    4 | 
-    5 | fn bar() !string {
-      |          ~~~~~~~
-    6 |     foo() !
-    7 |     return ''

--- a/vlib/v/checker/tests/propagate_result_with_option.out
+++ b/vlib/v/checker/tests/propagate_result_with_option.out
@@ -1,7 +1,14 @@
-vlib/v/checker/tests/propagate_result_with_option.vv:6:8: error: to propagate a result, the call must also return a result type
+vlib/v/checker/tests/propagate_result_with_option.vv:6:8: error: to propagate the result call, `bar` must return a result
     4 | 
     5 | fn bar() !string {
     6 |     foo() !
       |           ^
     7 |     return ''
     8 | }
+Details: vlib/v/checker/tests/propagate_result_with_option.vv:5:10: details: prepend ! before the declaration of the return type of `bar`
+    3 | }
+    4 | 
+    5 | fn bar() !string {
+      |          ~~~~~~~
+    6 |     foo() !
+    7 |     return ''

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.out
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.out
@@ -5,17 +5,24 @@ vlib/v/checker/tests/wrong_propagate_ret_type.vv:10:17: error: to propagate the 
       |                    ^
    11 |     return a
    12 | }
-vlib/v/checker/tests/wrong_propagate_ret_type.vv:9:15: error: to propagate the call, `opt_call` must return an optional type
+Details: vlib/v/checker/tests/wrong_propagate_ret_type.vv:9:15: details: prepend ? before the declaration of the return type of `opt_call`
     7 | }
     8 | 
     9 | fn opt_call() int {
       |               ~~~
    10 |     a := ret_none()?
    11 |     return a
-vlib/v/checker/tests/wrong_propagate_ret_type.vv:15:17: error: unexpected `!`, the function `ret_bool` does neither return an optional nor a result
+vlib/v/checker/tests/wrong_propagate_ret_type.vv:15:17: error: to propagate the result call, `res_call` must return a result
    13 | 
    14 | fn res_call() bool {
    15 |     a := ret_bool()!
       |                    ^
    16 |     return a
    17 | }
+Details: vlib/v/checker/tests/wrong_propagate_ret_type.vv:14:15: details: prepend ! before the declaration of the return type of `res_call`
+   12 | }
+   13 | 
+   14 | fn res_call() bool {
+      |               ~~~~
+   15 |     a := ret_bool()!
+   16 |     return a

--- a/vlib/v/checker/tests/wrong_propagate_ret_type.out
+++ b/vlib/v/checker/tests/wrong_propagate_ret_type.out
@@ -1,12 +1,19 @@
 vlib/v/checker/tests/wrong_propagate_ret_type.vv:10:17: error: to propagate the optional call, `opt_call` must return an optional
-    8 |
+    8 | 
     9 | fn opt_call() int {
    10 |     a := ret_none()?
       |                    ^
    11 |     return a
    12 | }
+vlib/v/checker/tests/wrong_propagate_ret_type.vv:9:15: error: to propagate the call, `opt_call` must return an optional type
+    7 | }
+    8 | 
+    9 | fn opt_call() int {
+      |               ~~~
+   10 |     a := ret_none()?
+   11 |     return a
 vlib/v/checker/tests/wrong_propagate_ret_type.vv:15:17: error: unexpected `!`, the function `ret_bool` does neither return an optional nor a result
-   13 |
+   13 | 
    14 | fn res_call() bool {
    15 |     a := ret_bool()!
       |                    ^


### PR DESCRIPTION
1. Optimized #15780
2. Add test.

```v
fn foo() !string{
	return ''
}

fn bar() {
	println(foo()!)
}
```

output:
```
vlib/v/checker/tests/fn_must_return_optional_or_result_pos.vv:5:10: error: to propagate the call, `bar` must return an result type
    3 | }
    4 | 
    5 | fn bar() {
      |          ^
    6 |     println(foo()!)
    7 | }
```
