### PR TITLE
checker: fix generics with pointer index (fix #15810)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3468,8 +3468,12 @@ pub fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 			node.is_farray = true
 		}
 		.any {
-			typ = c.unwrap_generic(typ)
-			typ_sym = c.table.final_sym(typ)
+			unwrapped_typ := c.unwrap_generic(typ)
+			unwrapped_sym := c.table.final_sym(unwrapped_typ)
+			if unwrapped_sym.kind in [.map, .array, .array_fixed] {
+				typ = unwrapped_typ
+				typ_sym = unwrapped_sym
+			}
 		}
 		else {}
 	}

--- a/vlib/v/tests/generics_with_pointer_index_test.v
+++ b/vlib/v/tests/generics_with_pointer_index_test.v
@@ -1,0 +1,61 @@
+module main
+
+pub struct Vec<T> {
+mut:
+	data &T
+	cap  int
+	len  int
+}
+
+pub struct Iter<T> {
+mut:
+	v   &Vec<T>
+	pos int
+}
+
+pub fn with_cap<T>(cap int) Vec<T> {
+	new_data := unsafe { C.malloc(cap * int(sizeof(T))) }
+
+	return Vec<T>{
+		data: new_data
+		cap: cap
+		len: 0
+	}
+}
+
+pub fn (ar &Vec<T>) iter() Iter<T> {
+	return Iter<T>{
+		v: unsafe { ar }
+	}
+}
+
+pub fn (mut iter Iter<T>) next() ?&T {
+	if iter.pos >= iter.v.len {
+		return none
+	}
+	res := unsafe { &iter.v.data[iter.pos] }
+	iter.pos++
+	return res
+}
+
+pub fn (mut ar Vec<T>) push(elm T) {
+	unsafe {
+		ar.data[ar.len - 1] = elm
+	}
+}
+
+struct Product {
+	price f64
+}
+
+fn test_generic_with_pointer_index() {
+	vec1 := with_cap<Product>(5)
+	println(vec1)
+	assert vec1.len == 0
+	assert vec1.cap == 5
+
+	vec2 := with_cap<int>(5)
+	println(vec2)
+	assert vec2.len == 0
+	assert vec2.cap == 5
+}


### PR DESCRIPTION
This PR fix generics with pointer index (fix #15810).

- Fix generics with pointer index.
- Add test.

```v
module main

pub struct Vec<T> {
mut:
	data &T
	cap  int
	len  int
}

pub struct Iter<T> {
mut:
	v   &Vec<T>
	pos int
}

pub fn with_cap<T>(cap int) Vec<T> {
	new_data := unsafe { C.malloc(cap * int(sizeof(T))) }

	return Vec<T>{
		data: new_data
		cap: cap
		len: 0
	}
}

pub fn (ar &Vec<T>) iter() Iter<T> {
	return Iter<T>{
		v: unsafe { ar }
	}
}

pub fn (mut iter Iter<T>) next() ?&T {
	if iter.pos >= iter.v.len {
		return none
	}
	res := unsafe { &iter.v.data[iter.pos] }
	iter.pos++
	return res
}

pub fn (mut ar Vec<T>) push(elm T) {
	unsafe {
		ar.data[ar.len - 1] = elm
	}
}

struct Product {
	price f64
}

fn main() {
	vec1 := with_cap<Product>(5)
	println(vec1)
	assert vec1.len == 0
	assert vec1.cap == 5

	vec2 := with_cap<int>(5)
	println(vec2)
	assert vec2.len == 0
	assert vec2.cap == 5
}

PS D:\Test\v\tt1> v run .
Vec<Product>{
    data: &Product{
        price: 3.720606e-316
    }
    cap: 5
    len: 0
}
Vec<int>{
    data: &75305904
    cap: 5
    len: 0
}
```