### PR TITLE
datatypes: adding ringbuffer

### DIFF
--- a/vlib/datatypes/ringbuffer.v
+++ b/vlib/datatypes/ringbuffer.v
@@ -24,7 +24,7 @@ pub fn (mut rb RingBuffer<T>) push(element T) {
 		eprintln('Buffer overflow')
 	} else {
 		rb.content[rb.writer] = element
-		rb.writer = rb.writer + 1
+		rb.writer++
 		if rb.writer > rb.content.len - 1 {
 			rb.writer = 0
 		}

--- a/vlib/datatypes/ringbuffer.v
+++ b/vlib/datatypes/ringbuffer.v
@@ -1,0 +1,65 @@
+// Written by flopetautschnig (floscodes) (c) 2022
+
+module datatypes
+
+pub struct RingBuffer<T> {
+mut:
+	content []T
+}
+
+// new - creates an empty ringbuffer
+pub fn new_ringbuffer<T>(s int) RingBuffer<T> {
+	return RingBuffer<T>{
+		content: []T{cap: s}
+	}
+}
+
+// push - adds an element to the ringbuffer ensuring that the buffer will never grow
+pub fn (mut rb RingBuffer<T>) push(element T) ? {
+	if rb.content.len == rb.content.cap {
+		eprintln('Error: buffer overflow\n\nCannot push value $element to buffer because buffer has only a capacity of $rb.content.cap')
+	} else {
+		rb.content.insert(0, element)
+	}
+}
+
+// pop - returns the oldest element and deletes it from the ringbuffer
+pub fn (mut rb RingBuffer<T>) pop() ?T {
+	if rb.content.len == 0 {
+		eprintln('Error: buffer is empty')
+	}
+	return rb.content.pop()
+}
+
+// clear - emptys the ringbuffer
+pub fn (mut rb RingBuffer<T>) clear() {
+	rb.content = []T{len: 0, cap: rb.content.cap}
+}
+
+// capacity - returns the capacity of the ringbuffer
+pub fn (rb RingBuffer<T>) capacity() int {
+	return rb.content.cap
+}
+
+// is_empty - checks if the ringbuffer is empty
+pub fn (rb RingBuffer<T>) is_empty() bool {
+	if rb.content.len == 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+// is_full - checks if the ringbuffer is full
+pub fn (rb RingBuffer<T>) is_full() bool {
+	if rb.content.len < rb.content.cap {
+		return false
+	} else {
+		return true
+	}
+}
+
+// remaining -  returns the remaining capacity of the ringbuffer
+pub fn (rb RingBuffer<T>) remaining() int {
+	return rb.content.cap - rb.content.len
+}

--- a/vlib/datatypes/ringbuffer.v
+++ b/vlib/datatypes/ringbuffer.v
@@ -32,12 +32,12 @@ pub fn (mut rb RingBuffer<T>) push(element T) {
 }
 
 // pop - returns the oldest element of the buffer
-pub fn (mut rb RingBuffer<T>) pop() T {
+pub fn (mut rb RingBuffer<T>) pop() ?T {
 	mut v := rb.content[rb.reader]
 	if rb.is_empty() {
-		eprintln('Buffer is empty')
+		none
 	} else {
-		rb.reader = rb.reader + 1
+		rb.reader++
 		if rb.reader > rb.content.len - 1 {
 			rb.reader = 0
 		}
@@ -72,9 +72,5 @@ pub fn (rb RingBuffer<T>) capacity() int {
 
 // clear - emptys the ringbuffer
 pub fn (mut rb RingBuffer<T>) clear() {
-	rb = RingBuffer<T>{
-		reader: 0
-		writer: 0
-		content: []T{len: rb.content.len, cap: rb.content.cap}
-	}
+	rb.reader, rb.writer = 0, 0
 }

--- a/vlib/datatypes/ringbuffer.v
+++ b/vlib/datatypes/ringbuffer.v
@@ -4,47 +4,51 @@ module datatypes
 
 pub struct RingBuffer<T> {
 mut:
+	reader  int // index of the tail where data is going to be read
+	writer  int // index of the head where data is going to be written
 	content []T
 }
 
-// new - creates an empty ringbuffer
+// new_ringbuffer - creates an empty ringbuffer
 pub fn new_ringbuffer<T>(s int) RingBuffer<T> {
 	return RingBuffer<T>{
-		content: []T{cap: s}
-	}
+		reader: 0
+		writer: 0
+		content: []T{len: s + 1, cap: s + 1}
+	} // increasing custom set size by one element in order to make ring flow possible, so that writer cannot equal reader before reader-index has been read.
 }
 
-// push - adds an element to the ringbuffer ensuring that the buffer will never grow
-pub fn (mut rb RingBuffer<T>) push(element T) ? {
-	if rb.content.len == rb.content.cap {
-		eprintln('Error: buffer overflow\n\nCannot push value $element to buffer because buffer has only a capacity of $rb.content.cap')
+// push - adds an element to the ringbuffer
+pub fn (mut rb RingBuffer<T>) push(element T) {
+	if rb.is_full() {
+		eprintln('Buffer overflow')
 	} else {
-		rb.content.insert(0, element)
+		rb.content[rb.writer] = element
+		rb.writer = rb.writer + 1
+		if rb.writer > rb.content.len - 1 {
+			rb.writer = 0
+		}
 	}
 }
 
-// pop - returns the oldest element and deletes it from the ringbuffer
-pub fn (mut rb RingBuffer<T>) pop() ?T {
-	if rb.content.len == 0 {
-		eprintln('Error: buffer is empty')
+// pop - returns the oldest element of the buffer
+pub fn (mut rb RingBuffer<T>) pop() T {
+	mut v := rb.content[rb.reader]
+	if rb.is_empty() {
+		eprintln('Buffer is empty')
+	} else {
+		rb.reader = rb.reader + 1
+		if rb.reader > rb.content.len - 1 {
+			rb.reader = 0
+		}
 	}
-	return rb.content.pop()
-}
-
-// clear - emptys the ringbuffer
-pub fn (mut rb RingBuffer<T>) clear() {
-	rb.content = []T{len: 0, cap: rb.content.cap}
-}
-
-// capacity - returns the capacity of the ringbuffer
-pub fn (rb RingBuffer<T>) capacity() int {
-	return rb.content.cap
+	return v
 }
 
 // is_empty - checks if the ringbuffer is empty
 pub fn (rb RingBuffer<T>) is_empty() bool {
-	if rb.content.len == 0 {
-		return true
+	if rb.reader == rb.writer {
+		return true // if reader equals writer it means that no value to read has been written before. It follows that the buffer is empty.
 	} else {
 		return false
 	}
@@ -52,14 +56,25 @@ pub fn (rb RingBuffer<T>) is_empty() bool {
 
 // is_full - checks if the ringbuffer is full
 pub fn (rb RingBuffer<T>) is_full() bool {
-	if rb.content.len < rb.content.cap {
-		return false
-	} else {
+	if rb.writer + 1 == rb.reader {
 		return true
+	} else if rb.writer == rb.content.len - 1 && rb.reader == 0 {
+		return true
+	} else {
+		return false
 	}
 }
 
-// remaining -  returns the remaining capacity of the ringbuffer
-pub fn (rb RingBuffer<T>) remaining() int {
-	return rb.content.cap - rb.content.len
+// capacity - returns the capacity of the ringbuffer
+pub fn (rb RingBuffer<T>) capacity() int {
+	return rb.content.cap - 1 // reduce by one because of the extra element explained in function `new_ringbuffer()`
+}
+
+// clear - emptys the ringbuffer
+pub fn (mut rb RingBuffer<T>) clear() {
+	rb = RingBuffer<T>{
+		reader: 0
+		writer: 0
+		content: []T{len: rb.content.len, cap: rb.content.cap}
+	}
 }

--- a/vlib/datatypes/ringbuffer.v
+++ b/vlib/datatypes/ringbuffer.v
@@ -2,6 +2,7 @@
 
 module datatypes
 
+// RingBuffer - public struct that represents the ringbuffer
 pub struct RingBuffer<T> {
 mut:
 	reader  int // index of the tail where data is going to be read
@@ -12,16 +13,14 @@ mut:
 // new_ringbuffer - creates an empty ringbuffer
 pub fn new_ringbuffer<T>(s int) RingBuffer<T> {
 	return RingBuffer<T>{
-		reader: 0
-		writer: 0
 		content: []T{len: s + 1, cap: s + 1}
 	} // increasing custom set size by one element in order to make ring flow possible, so that writer cannot equal reader before reader-index has been read.
 }
 
 // push - adds an element to the ringbuffer
-pub fn (mut rb RingBuffer<T>) push(element T) {
+pub fn (mut rb RingBuffer<T>) push(element T) ? {
 	if rb.is_full() {
-		eprintln('Buffer overflow')
+		return error('Buffer overflow')
 	} else {
 		rb.content[rb.writer] = element
 		rb.writer++
@@ -35,7 +34,7 @@ pub fn (mut rb RingBuffer<T>) push(element T) {
 pub fn (mut rb RingBuffer<T>) pop() ?T {
 	mut v := rb.content[rb.reader]
 	if rb.is_empty() {
-		none
+		return error('Buffer is empty')
 	} else {
 		rb.reader++
 		if rb.reader > rb.content.len - 1 {
@@ -47,11 +46,7 @@ pub fn (mut rb RingBuffer<T>) pop() ?T {
 
 // is_empty - checks if the ringbuffer is empty
 pub fn (rb RingBuffer<T>) is_empty() bool {
-	if rb.reader == rb.writer {
-		return true // if reader equals writer it means that no value to read has been written before. It follows that the buffer is empty.
-	} else {
-		return false
-	}
+	return rb.reader == rb.writer // if reader equals writer it means that no value to read has been written before. It follows that the buffer is empty.
 }
 
 // is_full - checks if the ringbuffer is full
@@ -70,7 +65,9 @@ pub fn (rb RingBuffer<T>) capacity() int {
 	return rb.content.cap - 1 // reduce by one because of the extra element explained in function `new_ringbuffer()`
 }
 
-// clear - emptys the ringbuffer
+// clear - emptys the ringbuffer and all pushed elements
 pub fn (mut rb RingBuffer<T>) clear() {
-	rb.reader, rb.writer = 0, 0
+	rb = RingBuffer<T>{
+		content: []T{len: rb.content.len, cap: rb.content.cap}
+	}
 }

--- a/vlib/datatypes/ringbuffer_test.v
+++ b/vlib/datatypes/ringbuffer_test.v
@@ -6,13 +6,13 @@ fn test_push_and_pop() {
 	r.push(3)
 	r.push(4)
 
-	mut oldest_value := r.pop()
+	mut oldest_value := r.pop() or { 0 }
 
 	assert oldest_value == 3
 
 	r.push(5)
 
-	oldest_value = r.pop()
+	oldest_value = r.pop() or { 0 }
 
 	assert oldest_value == 4
 }
@@ -22,7 +22,7 @@ fn test_clear_and_empty() {
 	r.push(3)
 	r.push(4)
 
-	oldest_value := r.pop()
+	oldest_value := r.pop() or { 0 }
 	assert oldest_value == 3
 
 	r.clear()

--- a/vlib/datatypes/ringbuffer_test.v
+++ b/vlib/datatypes/ringbuffer_test.v
@@ -42,3 +42,24 @@ fn test_capacity_and_is_full() {
 
 	assert r.is_full() == true
 }
+
+fn test_occupied_and_remaining() {
+	mut r := datatypes.new_ringbuffer<int>(4)
+
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	assert r.occupied() == r.remaining()
+}
+
+fn test_push_and_pop_many() {
+	mut r := datatypes.new_ringbuffer<int>(4)
+	a := [1, 2, 3, 4]
+	r.push_many(a) or { panic(err) }
+
+	assert r.is_full() == true
+
+	b := r.pop_many(4) or { panic(err) }
+
+	assert a == b
+}

--- a/vlib/datatypes/ringbuffer_test.v
+++ b/vlib/datatypes/ringbuffer_test.v
@@ -3,26 +3,26 @@ import datatypes
 fn test_push_and_pop() {
 	mut r := datatypes.new_ringbuffer<int>(2)
 
-	r.push(3) or { panic(err) }
-	r.push(4) or { panic(err) }
+	r.push(3)
+	r.push(4)
 
-	mut oldest_value := r.pop() or { panic(err) }
+	mut oldest_value := r.pop()
 
 	assert oldest_value == 3
 
-	r.push(5) or { panic(err) }
+	r.push(5)
 
-	oldest_value = r.pop() or { panic(err) }
+	oldest_value = r.pop()
 
 	assert oldest_value == 4
 }
 
 fn test_clear_and_empty() {
 	mut r := datatypes.new_ringbuffer<int>(4)
-	r.push(3) or { panic(err) }
-	r.push(4) or { panic(err) }
+	r.push(3)
+	r.push(4)
 
-	oldest_value := r.pop() or { panic(err) }
+	oldest_value := r.pop()
 	assert oldest_value == 3
 
 	r.clear()
@@ -30,13 +30,15 @@ fn test_clear_and_empty() {
 	assert r.is_empty() == true
 }
 
-fn test_capacity_remaining_is_full() {
+fn test_capacity_and_is_full() {
 	mut r := datatypes.new_ringbuffer<int>(4)
 
-	r.push(3) or { panic(err) }
-	r.push(4) or { panic(err) }
-
-	assert r.is_full() == false
 	assert r.capacity() == 4
-	assert r.remaining() == 2
+
+	r.push(3)
+	r.push(4)
+	r.push(5)
+	r.push(6)
+
+	assert r.is_full() == true
 }

--- a/vlib/datatypes/ringbuffer_test.v
+++ b/vlib/datatypes/ringbuffer_test.v
@@ -3,14 +3,14 @@ import datatypes
 fn test_push_and_pop() {
 	mut r := datatypes.new_ringbuffer<int>(2)
 
-	r.push(3)
-	r.push(4)
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
 
 	mut oldest_value := r.pop() or { 0 }
 
 	assert oldest_value == 3
 
-	r.push(5)
+	r.push(5) or { panic(err) }
 
 	oldest_value = r.pop() or { 0 }
 
@@ -19,8 +19,8 @@ fn test_push_and_pop() {
 
 fn test_clear_and_empty() {
 	mut r := datatypes.new_ringbuffer<int>(4)
-	r.push(3)
-	r.push(4)
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
 
 	oldest_value := r.pop() or { 0 }
 	assert oldest_value == 3
@@ -35,10 +35,10 @@ fn test_capacity_and_is_full() {
 
 	assert r.capacity() == 4
 
-	r.push(3)
-	r.push(4)
-	r.push(5)
-	r.push(6)
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+	r.push(5) or { panic(err) }
+	r.push(6) or { panic(err) }
 
 	assert r.is_full() == true
 }

--- a/vlib/datatypes/ringbuffer_test.v
+++ b/vlib/datatypes/ringbuffer_test.v
@@ -1,0 +1,42 @@
+import datatypes
+
+fn test_push_and_pop() {
+	mut r := datatypes.new_ringbuffer<int>(2)
+
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	mut oldest_value := r.pop() or { panic(err) }
+
+	assert oldest_value == 3
+
+	r.push(5) or { panic(err) }
+
+	oldest_value = r.pop() or { panic(err) }
+
+	assert oldest_value == 4
+}
+
+fn test_clear_and_empty() {
+	mut r := datatypes.new_ringbuffer<int>(4)
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	oldest_value := r.pop() or { panic(err) }
+	assert oldest_value == 3
+
+	r.clear()
+
+	assert r.is_empty() == true
+}
+
+fn test_capacity_remaining_is_full() {
+	mut r := datatypes.new_ringbuffer<int>(4)
+
+	r.push(3) or { panic(err) }
+	r.push(4) or { panic(err) }
+
+	assert r.is_full() == false
+	assert r.capacity() == 4
+	assert r.remaining() == 2
+}


### PR DESCRIPTION
**Rewritten ringbuffer-feature moved to vlib/datatypes. Implementing head and tail pointers, as well as fixed sized array**

Example:

```
module main

import datatypes

fn main() {

    // create a new ringbuffer with size 4
    // the generic argument sets the type
    mut r := datatypes.new_ringbuffer<int>(4)

    // push elements
    r.push(3)
    r.push(4)

    // get the oldest element. It will be removed from the buffer when calling `pop()`
    oldest_value := r.pop()

    println(oldest_value) // Output: 3

    }

```
