### PR TITLE
pref,os,sokol,cgen: ease compilation of 2048 with `-os wasm32_emscripten`

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -909,6 +909,10 @@ fn (mut app App) showfps() {
 	}
 }
 
+$if emscripten ? {
+	#flag --embed-file ./examples/assets/fonts/RobotoMono-Regular.ttf@/assets/fonts/RobotoMono-Regular.ttf
+}
+
 fn main() {
 	mut app := &App{}
 	app.new_game()

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -901,7 +901,9 @@ pub fn fork() int {
 pub fn wait() int {
 	mut pid := -1
 	$if !windows {
-		pid = C.wait(0)
+		$if !emscripten ? {
+			pid = C.wait(0)
+		}
 	}
 	$if windows {
 		panic('os.wait not supported in windows') // TODO

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -8,7 +8,7 @@ import strings
 #include <sys/utsname.h>
 #include <sys/types.h>
 #include <utime.h>
-$if !solaris && !haiku {
+$if !solaris && !haiku && !emscripten ? {
 	#include <sys/ptrace.h>
 }
 

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -75,7 +75,10 @@ fn (mut p Process) unix_kill_pgroup() {
 
 fn (mut p Process) unix_wait() {
 	cstatus := 0
-	ret := C.waitpid(p.pid, &cstatus, 0)
+	mut ret := -1
+	$if !emscripten ? {
+		ret = C.waitpid(p.pid, &cstatus, 0)
+	}
 	if ret == -1 {
 		p.err = posix_get_error_msg(C.errno)
 		return
@@ -92,7 +95,10 @@ fn (mut p Process) unix_wait() {
 
 fn (mut p Process) unix_is_alive() bool {
 	cstatus := 0
-	ret := C.waitpid(p.pid, &cstatus, C.WNOHANG)
+	mut ret := -1
+	$if !emscripten ? {
+		ret = C.waitpid(p.pid, &cstatus, C.WNOHANG)
+	}
 	if ret == -1 {
 		p.err = posix_get_error_msg(C.errno)
 		return false

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -25,6 +25,15 @@ $if ios {
 	#flag -DSOKOL_METAL
 	#flag -framework Foundation -framework Metal -framework MetalKit -framework UIKit
 }
+
+$if emscripten ? {
+	#flag -DSOKOL_GLES2
+	#flag -DSOKOL_NO_ENTRY
+	#flag -s ERROR_ON_UNDEFINED_SYMBOLS=0
+	#flag -s ASSERTIONS=1
+	#flag -s MODULARIZE
+}
+
 // OPENGL
 #flag linux -DSOKOL_GLCORE33
 #flag freebsd -DSOKOL_GLCORE33

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -42,6 +42,7 @@ pub enum Language {
 	arm32 // 32-bit arm
 	rv64 // 64-bit risc-v
 	rv32 // 32-bit risc-v
+	wasm32
 }
 
 pub fn pref_arch_to_table_language(pref_arch pref.Arch) Language {
@@ -66,6 +67,9 @@ pub fn pref_arch_to_table_language(pref_arch pref.Arch) Language {
 		}
 		.js_node, .js_browser, .js_freestanding {
 			.js
+		}
+		.wasm32 {
+			.wasm32
 		}
 		._auto, ._max {
 			.v

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -32,7 +32,7 @@ pub const (
 	valid_comptime_if_cpu_features   = ['x64', 'x32', 'little_endian', 'big_endian']
 	valid_comptime_if_other          = ['apk', 'js', 'debug', 'prod', 'test', 'glibc', 'prealloc',
 		'no_bounds_checking', 'freestanding', 'threads', 'js_node', 'js_browser', 'js_freestanding',
-		'interpreter', 'es5', 'profile']
+		'interpreter', 'es5', 'profile', 'wasm32_emscripten']
 	valid_comptime_not_user_defined  = all_valid_comptime_idents()
 	array_builtin_methods            = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice',
 		'sort', 'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -279,7 +279,8 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) string {
 		inner_loop: &ast.empty_stmt
 		field_data_type: ast.Type(table.find_type_idx('FieldData'))
 		is_cc_msvc: pref.ccompiler == 'msvc'
-		use_segfault_handler: !('no_segfault_handler' in pref.compile_defines || pref.os == .wasm32)
+		use_segfault_handler: !('no_segfault_handler' in pref.compile_defines
+			|| pref.os in [.wasm32, .wasm32_emscripten])
 	}
 	// anon fn may include assert and thus this needs
 	// to be included before any test contents are written

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -657,6 +657,9 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_optional bool) ?str
 		'js' {
 			return '_VJS'
 		}
+		'wasm32_emscripten' {
+			return '__EMSCRIPTEN__'
+		}
 		// compilers:
 		'gcc' {
 			return '__V_GCC__'

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -102,6 +102,10 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	if p.is_debug {
 		p.parse_define('debug')
 	}
+	if p.os == .wasm32_emscripten {
+		// TODO: remove after `$if wasm32_emscripten {` works
+		p.parse_define('emscripten')
+	}
 	if p.os == ._auto {
 		// No OS specifed? Use current system
 		p.os = get_host_os()

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -276,6 +276,9 @@ pub fn (p &Preferences) vcross_compiler_name() string {
 	if p.os == .linux {
 		return 'clang'
 	}
+	if p.os == .wasm32_emscripten {
+		return 'emcc'
+	}
 	if p.backend == .c && !p.out_name.ends_with('.c') {
 		eprintln('Note: V can only cross compile to windows and linux for now by default.')
 		eprintln('It will use `cc` as a cross compiler for now, although that will probably fail.')

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -34,33 +34,94 @@ pub enum OS {
 // Helper function to convert string names to OS enum
 pub fn os_from_string(os_str string) ?OS {
 	match os_str {
-		'linux' { return .linux }
-		'windows' { return .windows }
-		'ios' { return .ios }
-		'macos' { return .macos }
-		'darwin' { return .macos }
-		'freebsd' { return .freebsd }
-		'openbsd' { return .openbsd }
-		'netbsd' { return .netbsd }
-		'dragonfly' { return .dragonfly }
-		'js', 'js_node' { return .js_node }
-		'js_freestanding' { return .js_freestanding }
-		'js_browser' { return .js_browser }
-		'solaris' { return .solaris }
-		'serenity' { return .serenity }
-		'vinix' { return .vinix }
-		'android' { return .android }
-		'termux' { return .termux }
-		'haiku' { return .haiku }
-		'raw' { return .raw }
-		'nix' { return .linux }
-		'wasm32' { return .wasm32 }
-		'wasm32-wasi' { return .wasm32_wasi } // TODO: remove these *or* the _ ones
-		'wasm32-emscripten' { return .wasm32_emscripten }
-		'wasm32_wasi' { return .wasm32_wasi }
-		'wasm32_emscripten' { return .wasm32_emscripten }
-		'' { return ._auto }
-		else { return error('bad OS $os_str') }
+		'' {
+			return ._auto
+		}
+		'linux' {
+			return .linux
+		}
+		'nix' {
+			return .linux
+		}
+		'windows' {
+			return .windows
+		}
+		'ios' {
+			return .ios
+		}
+		'macos' {
+			return .macos
+		}
+		'darwin' {
+			return .macos
+		}
+		'freebsd' {
+			return .freebsd
+		}
+		'openbsd' {
+			return .openbsd
+		}
+		'netbsd' {
+			return .netbsd
+		}
+		'dragonfly' {
+			return .dragonfly
+		}
+		'js', 'js_node' {
+			return .js_node
+		}
+		'js_freestanding' {
+			return .js_freestanding
+		}
+		'js_browser' {
+			return .js_browser
+		}
+		'solaris' {
+			return .solaris
+		}
+		'serenity' {
+			return .serenity
+		}
+		'vinix' {
+			return .vinix
+		}
+		'android' {
+			return .android
+		}
+		'termux' {
+			return .termux
+		}
+		'haiku' {
+			return .haiku
+		}
+		'raw' {
+			return .raw
+		}
+		// WASM options:
+		'wasm32' {
+			return .wasm32
+		}
+		'wasm32_wasi' {
+			return .wasm32_wasi
+		}
+		'wasm32_emscripten' {
+			return .wasm32_emscripten
+		}
+		else {
+			// handle deprecated names:
+			match os_str {
+				'wasm32-emscripten' {
+					eprintln('Please use `-os wasm32_emscripten` instead.')
+					return .wasm32_emscripten
+				}
+				'wasm32-wasi' {
+					eprintln('Please use `-os wasm32_wasi` instead.')
+					return .wasm32_wasi
+				}
+				else {}
+			}
+			return error('bad OS $os_str')
+		}
 	}
 }
 
@@ -102,6 +163,10 @@ pub fn get_host_os() OS {
 	$if emscripten ? {
 		return .wasm32_emscripten
 	}
+	// TODO: make this work:
+	// $if wasm32_emscripten {
+	// 	return .wasm32_emscripten
+	// }
 	$if linux {
 		return .linux
 	}

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -99,6 +99,9 @@ pub fn get_host_os() OS {
 	$if android {
 		return .android
 	}
+	$if emscripten ? {
+		return .wasm32_emscripten
+	}
 	$if linux {
 		return .linux
 	}


### PR DESCRIPTION
This `./v -os wasm32_emscripten examples/2048/` will generate 2 files:
`examples/2048/2048`      <-- a .js loader
`examples/2048/2048.wasm` <-- a .wasm file with the game (with an embedded font)

The `emcc` cross compiler, can be changed by setting the `VCROSS_COMPILER_NAME` env variable.

This makes generating apps like https://v2048.vercel.app/ hopefully easier.

TODO:
- [ ] Generate `examples/2048/2048.js` with that command, not `examples/2048/2048`, which then needs renaming to .js .