### PR TITLE
sapp/gg: add a `tool_type` field to `gg.TouchPoint` (differenciate different types of touch input)

### DIFF
--- a/thirdparty/sokol/sokol_app.h
+++ b/thirdparty/sokol/sokol_app.h
@@ -1230,6 +1230,7 @@ typedef struct sapp_touchpoint {
     uintptr_t identifier;
     float pos_x;
     float pos_y;
+    int tool_type;
     bool changed;
 } sapp_touchpoint;
 
@@ -8569,6 +8570,7 @@ _SOKOL_PRIVATE bool _sapp_android_touch_event(const AInputEvent* e) {
         dst->identifier = (uintptr_t)AMotionEvent_getPointerId(e, (size_t)i);
         dst->pos_x = (AMotionEvent_getRawX(e, (size_t)i) / _sapp.window_width) * _sapp.framebuffer_width;
         dst->pos_y = (AMotionEvent_getRawY(e, (size_t)i) / _sapp.window_height) * _sapp.framebuffer_height;
+        dst->tool_type = AMotionEvent_getToolType(e, (size_t)i);
 
         if (action == AMOTION_EVENT_ACTION_POINTER_DOWN ||
             action == AMOTION_EVENT_ACTION_POINTER_UP) {

--- a/thirdparty/sokol/sokol_app.h
+++ b/thirdparty/sokol/sokol_app.h
@@ -1230,7 +1230,7 @@ typedef struct sapp_touchpoint {
     uintptr_t identifier;
     float pos_x;
     float pos_y;
-    int tool_type;
+    int tool_type; // __v_
     bool changed;
 } sapp_touchpoint;
 
@@ -8570,7 +8570,7 @@ _SOKOL_PRIVATE bool _sapp_android_touch_event(const AInputEvent* e) {
         dst->identifier = (uintptr_t)AMotionEvent_getPointerId(e, (size_t)i);
         dst->pos_x = (AMotionEvent_getRawX(e, (size_t)i) / _sapp.window_width) * _sapp.framebuffer_width;
         dst->pos_y = (AMotionEvent_getRawY(e, (size_t)i) / _sapp.window_height) * _sapp.framebuffer_height;
-        dst->tool_type = AMotionEvent_getToolType(e, (size_t)i);
+        dst->tool_type = AMotionEvent_getToolType(e, (size_t)i); // __v_
 
         if (action == AMOTION_EVENT_ACTION_POINTER_DOWN ||
             action == AMOTION_EVENT_ACTION_POINTER_UP) {

--- a/vlib/sokol/sapp/enums.v
+++ b/vlib/sokol/sapp/enums.v
@@ -183,3 +183,12 @@ pub enum KeyCode {
 	right_super = 347
 	menu = 348
 }
+
+pub enum TouchToolType {
+	unknown
+	finger
+	stylus
+	mouse
+	eraser
+	palm
+}

--- a/vlib/sokol/sapp/sapp_structs.c.v
+++ b/vlib/sokol/sapp/sapp_structs.c.v
@@ -112,6 +112,7 @@ pub:
 	identifier u64
 	pos_x      f32
 	pos_y      f32
+	tool_type  TouchToolType
 	changed    bool
 }
 


### PR DESCRIPTION
See https://github.com/floooh/sokol/pull/717 for the associated sokol PR; it hasn't been merged yet, but I've tested my changes and they work, so we can either merge this before it gets into upstream sokol or wait until then.

https://developer.android.com/ndk/reference/group/input#amotionevent_gettooltype