### PR TITLE
tests: make error handling the same as the main function

### DIFF
--- a/cmd/tools/vcreate_test.v
+++ b/cmd/tools/vcreate_test.v
@@ -65,25 +65,25 @@ fn prepare_test_path() ? {
 	os.chdir(test_path)?
 }
 
-fn test_v_init() ? {
+fn test_v_init() {
 	prepare_test_path()?
 	init_and_check()?
 }
 
-fn test_v_init_in_git_dir() ? {
+fn test_v_init_in_git_dir() {
 	prepare_test_path()?
 	os.execute_or_exit('git init .')
 	init_and_check()?
 }
 
-fn test_v_init_no_overwrite_gitignore() ? {
+fn test_v_init_no_overwrite_gitignore() {
 	prepare_test_path()?
 	os.write_file('.gitignore', 'blah')?
 	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
 	assert os.read_file('.gitignore')? == 'blah'
 }
 
-fn test_v_init_no_overwrite_gitattributes_and_editorconfig() ? {
+fn test_v_init_no_overwrite_gitattributes_and_editorconfig() {
 	git_attributes_content := '*.v linguist-language=V text=auto eol=lf'
 	editor_config_content := '[*]
 charset = utf-8

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -14,7 +14,7 @@ fn find_diff_cmd() string {
 	return diff.find_working_diff_command() or { '' }
 }
 
-fn test_vet() ? {
+fn test_vet() {
 	os.setenv('VCOLORS', 'never', true)
 	os.chdir(vroot)?
 	test_dir := 'cmd/tools/vdoc/tests/testdata'

--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -11,7 +11,7 @@ fn find_diff_cmd() string {
 	return res
 }
 
-fn test_vet() ? {
+fn test_vet() {
 	vexe := os.getenv('VEXE')
 	vroot := os.dir(vexe)
 	os.chdir(vroot)?

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4103,7 +4103,7 @@ If a test function has an error return type, any propagated errors will fail the
 ```v
 import strconv
 
-fn test_atoi() {
+fn test_atoi() ? {
 	assert strconv.atoi('1')? == 1
 	assert strconv.atoi('one')? == 1 // test will fail
 }

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4103,7 +4103,7 @@ If a test function has an error return type, any propagated errors will fail the
 ```v
 import strconv
 
-fn test_atoi() ? {
+fn test_atoi() {
 	assert strconv.atoi('1')? == 1
 	assert strconv.atoi('one')? == 1 // test will fail
 }

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -1,6 +1,6 @@
 module arrays
 
-fn test_min() ? {
+fn test_min() {
 	a := [8, 2, 6, 4]
 	mut ri := min(a)?
 	assert ri == 2
@@ -18,7 +18,7 @@ fn test_min() ? {
 	assert rb == u8(3)
 }
 
-fn test_max() ? {
+fn test_max() {
 	a := [8, 2, 6, 4]
 	mut ri := max(a)?
 	assert ri == 8
@@ -36,7 +36,7 @@ fn test_max() ? {
 	assert rb == u8(3)
 }
 
-fn test_idx_min() ? {
+fn test_idx_min() {
 	a := [8, 2, 6, 4]
 	ri := idx_min(a)?
 	assert ri == 1
@@ -48,7 +48,7 @@ fn test_idx_min() ? {
 	assert rb == 3
 }
 
-fn test_idx_max() ? {
+fn test_idx_max() {
 	a := [8, 2, 6, 4]
 	ri := idx_max(a)?
 	assert ri == 0
@@ -195,13 +195,13 @@ fn test_concat_string() {
 	assert concat(a, ...b) == ['1', '2', '3', '3', '2', '1']
 }
 
-fn test_binary_search() ? {
+fn test_binary_search() {
 	a := [1, 3, 3, 4, 5, 6, 7, 8, 10]
 	assert binary_search(a, 3)? == 1
 	assert (binary_search(a, 0) or { -1 }) == -1
 }
 
-fn test_lower_bound() ? {
+fn test_lower_bound() {
 	a := [1, 3, 3, 4, 5, 6, 7, 8, 10]
 	b := []int{}
 	c := [1, 2, 3]
@@ -210,7 +210,7 @@ fn test_lower_bound() ? {
 	assert lower_bound(c, 3)? == 3
 }
 
-fn test_upper_bound() ? {
+fn test_upper_bound() {
 	a := [1, 3, 3, 4, 5, 6, 7, 8, 10]
 	b := []int{}
 	c := [1, 2, 3]

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -27,7 +27,7 @@ fn test_header_adds_multiple() {
 	assert h.values(.accept) == ['one', 'two']
 }
 
-fn test_header_get() ? {
+fn test_header_get() {
 	mut h := new_header(key: .dnt, value: 'one')
 	h.add_custom('dnt', 'two')?
 	dnt := h.get_custom('dnt') or { '' }
@@ -36,7 +36,7 @@ fn test_header_get() ? {
 	assert exact == 'two'
 }
 
-fn test_header_set() ? {
+fn test_header_set() {
 	mut h := new_header(HeaderConfig{ key: .dnt, value: 'one' },
 		key: .dnt
 		value: 'two'
@@ -65,7 +65,7 @@ fn test_header_delete_not_existing() {
 	assert h.keys.len == 0
 }
 
-fn test_custom_header() ? {
+fn test_custom_header() {
 	mut h := new_header()
 	h.add_custom('AbC', 'dEf')?
 	h.add_custom('aBc', 'GhI')?
@@ -89,7 +89,7 @@ fn test_custom_header() ? {
 	assert h.keys() == ['accEPT']
 }
 
-fn test_contains_custom() ? {
+fn test_contains_custom() {
 	mut h := new_header()
 	h.add_custom('Hello', 'world')?
 	assert h.contains_custom('hello')
@@ -99,7 +99,7 @@ fn test_contains_custom() ? {
 	assert h.contains_custom('HELLO', exact: true) == false
 }
 
-fn test_get_custom() ? {
+fn test_get_custom() {
 	mut h := new_header()
 	h.add_custom('Hello', 'world')?
 	assert h.get_custom('hello')? == 'world'
@@ -115,7 +115,7 @@ fn test_get_custom() ? {
 	}
 }
 
-fn test_starting_with() ? {
+fn test_starting_with() {
 	mut h := new_header()
 	h.add_custom('Hello-1', 'world')?
 	h.add_custom('Hello-21', 'world')?
@@ -123,7 +123,7 @@ fn test_starting_with() ? {
 	assert h.starting_with('Hello-2')? == 'Hello-21'
 }
 
-fn test_custom_values() ? {
+fn test_custom_values() {
 	mut h := new_header()
 	h.add_custom('Hello', 'world')?
 	assert h.custom_values('hello') == ['world']
@@ -133,7 +133,7 @@ fn test_custom_values() ? {
 	assert h.custom_values('HELLO', exact: true) == []
 }
 
-fn test_coerce() ? {
+fn test_coerce() {
 	mut h := new_header()
 	h.add_custom('accept', 'foo')?
 	h.add(.accept, 'bar')
@@ -145,7 +145,7 @@ fn test_coerce() ? {
 	assert h.keys() == ['accept'] // takes the first occurrence
 }
 
-fn test_coerce_canonicalize() ? {
+fn test_coerce_canonicalize() {
 	mut h := new_header()
 	h.add_custom('accept', 'foo')?
 	h.add(.accept, 'bar')
@@ -157,7 +157,7 @@ fn test_coerce_canonicalize() ? {
 	assert h.keys() == ['Accept'] // canonicalize header
 }
 
-fn test_coerce_custom() ? {
+fn test_coerce_custom() {
 	mut h := new_header()
 	h.add_custom('Hello', 'foo')?
 	h.add_custom('hello', 'bar')?
@@ -170,7 +170,7 @@ fn test_coerce_custom() ? {
 	assert h.keys() == ['Hello'] // takes the first occurrence
 }
 
-fn test_coerce_canonicalize_custom() ? {
+fn test_coerce_canonicalize_custom() {
 	mut h := new_header()
 	h.add_custom('foo-BAR', 'foo')?
 	h.add_custom('FOO-bar', 'bar')?
@@ -182,7 +182,7 @@ fn test_coerce_canonicalize_custom() ? {
 	assert h.keys() == ['Foo-Bar'] // capitalizes the header
 }
 
-fn test_render_version() ? {
+fn test_render_version() {
 	mut h := new_header()
 	h.add_custom('accept', 'foo')?
 	h.add_custom('Accept', 'bar')?
@@ -204,7 +204,7 @@ fn test_render_version() ? {
 	assert s2_0.contains('accept: baz\r\n')
 }
 
-fn test_render_coerce() ? {
+fn test_render_coerce() {
 	mut h := new_header()
 	h.add_custom('accept', 'foo')?
 	h.add_custom('Accept', 'bar')?
@@ -230,7 +230,7 @@ fn test_render_coerce() ? {
 	assert s2_0.contains('host: host\r\n')
 }
 
-fn test_render_canonicalize() ? {
+fn test_render_canonicalize() {
 	mut h := new_header()
 	h.add_custom('accept', 'foo')?
 	h.add_custom('Accept', 'bar')?
@@ -256,7 +256,7 @@ fn test_render_canonicalize() ? {
 	assert s2_0.contains('host: host\r\n')
 }
 
-fn test_render_coerce_canonicalize() ? {
+fn test_render_coerce_canonicalize() {
 	mut h := new_header()
 	h.add_custom('accept', 'foo')?
 	h.add_custom('Accept', 'bar')?
@@ -282,7 +282,7 @@ fn test_render_coerce_canonicalize() ? {
 	assert s2_0.contains('host: host\r\n')
 }
 
-fn test_str() ? {
+fn test_str() {
 	mut h := new_header()
 	h.add(.accept, 'text/html')
 	h.add_custom('Accept', 'image/jpeg')?
@@ -293,7 +293,7 @@ fn test_str() ? {
 		|| h.str() == 'X-custom: Hello\r\nAccept:text/html\r\nAccept: image/jpeg\r\n'
 }
 
-fn test_header_from_map() ? {
+fn test_header_from_map() {
 	h := new_header_from_map({
 		CommonHeader.accept:  'nothing'
 		CommonHeader.expires: 'yesterday'
@@ -304,7 +304,7 @@ fn test_header_from_map() ? {
 	assert h.get(.expires) or { '' } == 'yesterday'
 }
 
-fn test_custom_header_from_map() ? {
+fn test_custom_header_from_map() {
 	h := new_custom_header_from_map({
 		'Server': 'VWeb'
 		'foo':    'bar'
@@ -315,7 +315,7 @@ fn test_custom_header_from_map() ? {
 	assert h.get_custom('foo') or { '' } == 'bar'
 }
 
-fn test_header_join() ? {
+fn test_header_join() {
 	h1 := new_header_from_map({
 		CommonHeader.accept:  'nothing'
 		CommonHeader.expires: 'yesterday'

--- a/vlib/net/http/request_test.v
+++ b/vlib/net/http/request_test.v
@@ -174,7 +174,7 @@ fn test_multipart_form_body() {
 	assert parsed_form == form
 }
 
-fn test_parse_large_body() ? {
+fn test_parse_large_body() {
 	body := 'A'.repeat(101) // greater than max_bytes
 	req := 'GET / HTTP/1.1\r\nContent-Length: $body.len\r\n\r\n$body'
 	mut reader_ := reader(req)

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -1,6 +1,6 @@
 module http
 
-fn test_response_bytestr() ? {
+fn test_response_bytestr() {
 	{
 		resp := new_response(
 			status: .ok

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -1,7 +1,7 @@
 import net.http
 import time
 
-fn test_server_stop() ? {
+fn test_server_stop() {
 	mut server := &http.Server{
 		accept_timeout: 1 * time.second
 	}
@@ -15,7 +15,7 @@ fn test_server_stop() ? {
 	assert watch.elapsed() < 999 * time.millisecond
 }
 
-fn test_server_close() ? {
+fn test_server_close() {
 	mut server := &http.Server{
 		accept_timeout: 1 * time.second
 		handler: MyHttpHandler{}
@@ -60,7 +60,7 @@ fn (mut handler MyHttpHandler) handle(req http.Request) http.Response {
 
 const cport = 8198
 
-fn test_server_custom_handler() ? {
+fn test_server_custom_handler() {
 	mut handler := MyHttpHandler{}
 	mut server := &http.Server{
 		accept_timeout: 1 * time.second

--- a/vlib/net/smtp/smtp_test.v
+++ b/vlib/net/smtp/smtp_test.v
@@ -124,7 +124,7 @@ fn test_smtp_implicit_ssl() {
 	assert client.is_open && client.encrypted
 }
 
-fn test_smtp_multiple_recipients() ? {
+fn test_smtp_multiple_recipients() {
 	$if !network ? {
 		return
 	}
@@ -132,7 +132,7 @@ fn test_smtp_multiple_recipients() ? {
 	assert true
 }
 
-fn test_smtp_body_base64encode() ? {
+fn test_smtp_body_base64encode() {
 	$if !network ? {
 		return
 	}

--- a/vlib/net/tcp_test.v
+++ b/vlib/net/tcp_test.v
@@ -101,7 +101,7 @@ fn testsuite_end() {
 	eprintln('\ndone')
 }
 
-fn test_bind() ? {
+fn test_bind() {
 	$if !network ? {
 		return
 	}

--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -35,7 +35,7 @@ fn test_escape_unescape() {
 	assert unescaped == original
 }
 
-fn test_parse_query() ? {
+fn test_parse_query() {
 	q1 := urllib.parse_query('format=%22%25l%3A+%25c+%25t%22')?
 	q2 := urllib.parse_query('format="%l:+%c+%t"')?
 	// dump(q1)
@@ -44,13 +44,13 @@ fn test_parse_query() ? {
 	assert q2.get('format') == '"%l: %c %t"'
 }
 
-fn test_parse_query_orders() ? {
+fn test_parse_query_orders() {
 	query_one := urllib.parse_query('https://someapi.com/endpoint?gamma=zalibaba&tau=1&alpha=alibaba&signature=alibaba123')?
 	qvalues := query_one.values()
 	assert qvalues == ['zalibaba', '1', 'alibaba', 'alibaba123']
 }
 
-fn test_parse_missing_host() ? {
+fn test_parse_missing_host() {
 	// issue #10311
 	url := urllib.parse('http:///')?
 	assert url.str() == 'http://///'
@@ -58,7 +58,7 @@ fn test_parse_missing_host() ? {
 
 // testing the case where the key as a null value
 // e.g ?key=
-fn test_parse_none_value() ? {
+fn test_parse_none_value() {
 	query_one := urllib.parse_query('gamma=zalibaba&tau=1&alpha=alibaba&signature=')?
 	qvalues := query_one.values()
 	qvalues_map := query_one.to_map()
@@ -73,7 +73,7 @@ fn test_parse_none_value() ? {
 
 // testing the case where the query as empity value
 // e.g https://www.vlang.dev?alibaba
-fn test_parse_empty_query_one() ? {
+fn test_parse_empty_query_one() {
 	query_str := 'alibaba'
 	query_one := urllib.parse_query(query_str)?
 	qvalues := query_one.values()
@@ -88,7 +88,7 @@ fn test_parse_empty_query_one() ? {
 
 // testing the case where the query as empity value
 // e.g https://www.vlang.dev?
-fn test_parse_empty_query_two() ? {
+fn test_parse_empty_query_two() {
 	query_str := ''
 	query_one := urllib.parse_query(query_str)?
 	qvalues := query_one.values()
@@ -99,7 +99,7 @@ fn test_parse_empty_query_two() ? {
 	assert query_str == query_encode
 }
 
-fn test_parse() ? {
+fn test_parse() {
 	urls := [
 		'jdbc:mysql://test_user:ouupppssss@localhost:3306/sakila?profileSQL=true',
 		'ftp://ftp.is.co.za/rfc/rfc1808.txt',

--- a/vlib/orm/orm_sql_or_blocks_test.v
+++ b/vlib/orm/orm_sql_or_blocks_test.v
@@ -18,7 +18,7 @@ fn testsuite_end() {
 	os.rmdir_all(db_folder) or {}
 }
 
-fn test_ensure_db_exists_and_user_table_is_ok() ? {
+fn test_ensure_db_exists_and_user_table_is_ok() {
 	mut db := sqlite.connect(db_path)?
 	assert true
 
@@ -33,7 +33,7 @@ fn test_ensure_db_exists_and_user_table_is_ok() ? {
 	db.close()?
 }
 
-fn test_sql_or_block_for_insert() ? {
+fn test_sql_or_block_for_insert() {
 	mut db := sqlite.connect(db_path)?
 	user := User{1, 'bilbo'}
 
@@ -56,7 +56,7 @@ fn test_sql_or_block_for_insert() ? {
 	db.close()?
 }
 
-fn test_sql_or_block_for_select() ? {
+fn test_sql_or_block_for_select() {
 	mut db := sqlite.connect(db_path)?
 
 	eprintln('> selecting user with id 1...')
@@ -96,7 +96,7 @@ fn test_sql_or_block_for_select() ? {
 	db.close()?
 }
 
-fn test_finish() ? {
+fn test_finish() {
 	eprintln('done')
 	assert true
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -60,7 +60,7 @@ const (
 // This test simulates reading a larger text file step by step into a buffer and
 // returning on each newline, even before the buffer is full, and reaching EOF before
 // the buffer is completely filled.
-fn test_read_bytes_into_newline_text() ? {
+fn test_read_bytes_into_newline_text() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write_string('Hello World!\nGood\r morning.')?
 	f.close()
@@ -86,7 +86,7 @@ fn test_read_bytes_into_newline_text() ? {
 // test_read_bytes_into_newline_binary tests reading a binary file with NUL bytes.
 // This test simulates the scenario when a byte stream is read and a newline byte
 // appears in that stream and an EOF occurs before the buffer is full.
-fn test_read_bytes_into_newline_binary() ? {
+fn test_read_bytes_into_newline_binary() {
 	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
 	mut bw := []u8{len: 15}
 	bw[9] = 0xff
@@ -121,7 +121,7 @@ fn test_read_bytes_into_newline_binary() ? {
 // the end-of-file is detected and results in a none error being returned. This
 // test simulates file reading where the end-of-file is reached inside an fread
 // containing data.
-fn test_read_eof_last_read_partial_buffer_fill() ? {
+fn test_read_eof_last_read_partial_buffer_fill() {
 	mut f := os.open_file(tfile, 'w')?
 	bw := []u8{len: 199, init: 5}
 	f.write(bw)?
@@ -130,11 +130,11 @@ fn test_read_eof_last_read_partial_buffer_fill() ? {
 	f = os.open_file(tfile, 'r')?
 	mut br := []u8{len: 100}
 	// Read first 100 bytes of 199 byte file, should fill buffer with no error.
-	n0 := f.read(mut br) or { return error('failed to read 100 bytes') }
+	n0 := f.read(mut br)!
 	assert n0 == 100
 	// Read remaining 99 bytes of 199 byte file, should fill buffer with no
 	// error, even though end-of-file was reached.
-	n1 := f.read(mut br) or { return error('failed to read 100 bytes') }
+	n1 := f.read(mut br)!
 	assert n1 == 99
 	// Read again, end-of-file was previously reached so should return none
 	// error.
@@ -153,7 +153,7 @@ fn test_read_eof_last_read_partial_buffer_fill() ? {
 // end-of-file is detected and results in a none error being returned. This test
 // simulates file reading where the end-of-file is reached at the beinning of an
 // fread that returns no data.
-fn test_read_eof_last_read_full_buffer_fill() ? {
+fn test_read_eof_last_read_full_buffer_fill() {
 	mut f := os.open_file(tfile, 'w')?
 	bw := []u8{len: 200, init: 5}
 	f.write(bw)?
@@ -162,11 +162,11 @@ fn test_read_eof_last_read_full_buffer_fill() ? {
 	f = os.open_file(tfile, 'r')?
 	mut br := []u8{len: 100}
 	// Read first 100 bytes of 200 byte file, should fill buffer with no error.
-	n0 := f.read(mut br) or { return error('failed to read 100 bytes') }
+	n0 := f.read(mut br)!
 	assert n0 == 100
 	// Read remaining 100 bytes of 200 byte file, should fill buffer with no
 	// error. The end-of-file isn't reached yet, but there is no more data.
-	n1 := f.read(mut br) or { return error('failed to read 100 bytes') }
+	n1 := f.read(mut br)!
 	assert n1 == 100
 	// Read again, end-of-file was previously reached so should return none
 	// error.
@@ -181,7 +181,7 @@ fn test_read_eof_last_read_full_buffer_fill() ? {
 	f.close()
 }
 
-fn test_write_struct() ? {
+fn test_write_struct() {
 	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w')?
@@ -197,7 +197,7 @@ fn test_write_struct() ? {
 	}
 }
 
-fn test_write_struct_at() ? {
+fn test_write_struct_at() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write_struct(extended_point)?
 	f.write_struct_at(another_point, 3)?
@@ -210,7 +210,7 @@ fn test_write_struct_at() ? {
 	assert p == another_point
 }
 
-fn test_read_struct() ? {
+fn test_read_struct() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write_struct(another_point)?
 	f.close()
@@ -223,7 +223,7 @@ fn test_read_struct() ? {
 	assert p == another_point
 }
 
-fn test_read_struct_at() ? {
+fn test_read_struct_at() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write([u8(1), 2, 3])?
 	f.write_struct(another_point)?
@@ -236,7 +236,7 @@ fn test_read_struct_at() ? {
 	assert p == another_point
 }
 
-fn test_write_raw() ? {
+fn test_write_raw() {
 	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w')?
@@ -252,7 +252,7 @@ fn test_write_raw() ? {
 	}
 }
 
-fn test_write_raw_at() ? {
+fn test_write_raw_at() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write_raw(extended_point)?
 	f.write_raw_at(another_point, 3)?
@@ -265,7 +265,7 @@ fn test_write_raw_at() ? {
 	assert p == another_point
 }
 
-fn test_write_raw_at_negative_pos() ? {
+fn test_write_raw_at_negative_pos() {
 	mut f := os.open_file(tfile, 'w')?
 	if _ := f.write_raw_at(another_point, -1) {
 		assert false
@@ -274,7 +274,7 @@ fn test_write_raw_at_negative_pos() ? {
 	f.close()
 }
 
-fn test_read_raw() ? {
+fn test_read_raw() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write_raw(another_point)?
 	f.write_raw(another_byte)?
@@ -294,7 +294,7 @@ fn test_read_raw() ? {
 	assert x == another_permission
 }
 
-fn test_read_raw_at() ? {
+fn test_read_raw_at() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write([u8(1), 2, 3])?
 	f.write_raw(another_point)?
@@ -320,7 +320,7 @@ fn test_read_raw_at() ? {
 	assert x == another_permission
 }
 
-fn test_read_raw_at_negative_pos() ? {
+fn test_read_raw_at_negative_pos() {
 	mut f := os.open_file(tfile, 'r')?
 	if _ := f.read_raw_at<Point>(-1) {
 		assert false
@@ -329,7 +329,7 @@ fn test_read_raw_at_negative_pos() ? {
 	f.close()
 }
 
-fn test_seek() ? {
+fn test_seek() {
 	mut f := os.open_file(tfile, 'w')?
 	f.write_raw(another_point)?
 	f.write_raw(another_byte)?
@@ -352,7 +352,7 @@ fn test_seek() ? {
 	f.close()
 }
 
-fn test_tell() ? {
+fn test_tell() {
 	for size in 10 .. 30 {
 		s := 'x'.repeat(size)
 		os.write_file(tfile, s)?
@@ -368,7 +368,7 @@ fn test_tell() ? {
 	}
 }
 
-fn test_reopen() ? {
+fn test_reopen() {
 	tfile1 := os.join_path_single(tfolder, 'tfile1')
 	tfile2 := os.join_path_single(tfolder, 'tfile2')
 	os.write_file(tfile1, 'Hello World!\nGood\r morning.\nBye 1.')?
@@ -397,7 +397,7 @@ fn test_reopen() ? {
 	assert content.ends_with('Bye 1.')
 }
 
-fn test_eof() ? {
+fn test_eof() {
 	os.write_file(tfile, 'Hello World!\n')?
 
 	mut f := os.open(tfile)?
@@ -407,7 +407,7 @@ fn test_eof() ? {
 	assert f.eof()
 }
 
-fn test_open_file_wb_ab() ? {
+fn test_open_file_wb_ab() {
 	os.rm(tfile) or {}
 	mut wfile := os.open_file('text.txt', 'wb', 0o666)?
 	wfile.write_string('hello')?

--- a/vlib/os/find_abs_path_of_executable_test.v
+++ b/vlib/os/find_abs_path_of_executable_test.v
@@ -1,6 +1,6 @@
 module os
 
-fn test_find_abs_path_of_executable() ? {
+fn test_find_abs_path_of_executable() {
 	tfolder := join_path(temp_dir(), 'v', 'tests', 'filepath_test')
 	rmdir_all(tfolder) or {}
 	assert !is_dir(tfolder)

--- a/vlib/os/glob_test.v
+++ b/vlib/os/glob_test.v
@@ -30,7 +30,7 @@ fn redeep_glob() ? {
 	}
 }
 
-fn test_glob_can_find_v_files_3_levels_deep() ? {
+fn test_glob_can_find_v_files_3_levels_deep() {
 	$if !windows {
 		deep_glob()?
 		redeep_glob()?
@@ -38,7 +38,7 @@ fn test_glob_can_find_v_files_3_levels_deep() ? {
 	assert true
 }
 
-fn test_glob_can_find_files_in_current_folder() ? {
+fn test_glob_can_find_files_in_current_folder() {
 	os.chdir(@VMODROOT)?
 	matches := os.glob('*')?
 	assert '.gitignore' in matches
@@ -52,7 +52,7 @@ fn test_glob_can_find_files_in_current_folder() ? {
 	assert 'thirdparty/' in matches
 }
 
-fn test_glob_can_be_used_with_multiple_patterns() ? {
+fn test_glob_can_be_used_with_multiple_patterns() {
 	os.chdir(@VMODROOT)?
 	matches := os.glob('*', 'cmd/tools/*')?
 	assert 'README.md' in matches
@@ -65,14 +65,14 @@ fn test_glob_can_be_used_with_multiple_patterns() ? {
 	}
 }
 
-fn test_glob_star() ? {
+fn test_glob_star() {
 	os.chdir(@VMODROOT)?
 	matches := os.glob('*ake*')?
 	assert 'Makefile' in matches
 	assert 'make.bat' in matches
 }
 
-fn test_glob_not_found() ? {
+fn test_glob_not_found() {
 	os.glob('an_unknown_folder/*.v') or {
 		assert true
 		return

--- a/vlib/os/notify/notify_test.v
+++ b/vlib/os/notify/notify_test.v
@@ -15,7 +15,7 @@ fn make_pipe() ?(int, int) {
 	return -1, -1
 }
 
-fn test_level_trigger() ? {
+fn test_level_trigger() {
 	// currently only linux is supported
 	$if linux {
 		mut notifier := notify.new()?
@@ -36,7 +36,7 @@ fn test_level_trigger() ? {
 	}
 }
 
-fn test_edge_trigger() ? {
+fn test_edge_trigger() {
 	// currently only linux is supported
 	$if linux {
 		mut notifier := notify.new()?
@@ -64,7 +64,7 @@ fn test_edge_trigger() ? {
 	}
 }
 
-fn test_one_shot() ? {
+fn test_one_shot() {
 	$if linux {
 		mut notifier := notify.new()?
 		reader, writer := make_pipe()?
@@ -89,7 +89,7 @@ fn test_one_shot() ? {
 	}
 }
 
-fn test_hangup() ? {
+fn test_hangup() {
 	$if linux {
 		mut notifier := notify.new()?
 		reader, writer := make_pipe()?
@@ -111,7 +111,7 @@ fn test_hangup() ? {
 	}
 }
 
-fn test_write() ? {
+fn test_write() {
 	$if linux {
 		mut notifier := notify.new()?
 		reader, writer := make_pipe()?
@@ -132,7 +132,7 @@ fn test_write() ? {
 	}
 }
 
-fn test_remove() ? {
+fn test_remove() {
 	$if linux {
 		mut notifier := notify.new()?
 		reader, writer := make_pipe()?

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -96,7 +96,7 @@ fn create_and_write_to_file(fpath string, content string) ? {
 	f.close()
 }
 
-fn test_create_file() ? {
+fn test_create_file() {
 	filename := './test1.txt'
 	hello := 'hello world!'
 	create_and_write_to_file(filename, hello)?
@@ -226,7 +226,7 @@ fn normalise_paths(paths []string) []string {
 	return res
 }
 
-fn test_walk_ext() ? {
+fn test_walk_ext() {
 	create_tree()?
 	defer {
 		remove_tree()
@@ -442,7 +442,7 @@ fn test_realpath_does_not_absolutize_non_existing_relative_paths() {
 	}
 }
 
-fn test_realpath_absolutepath_symlink() ? {
+fn test_realpath_absolutepath_symlink() {
 	file_name := 'tolink_file.txt'
 	symlink_name := 'symlink.txt'
 	create_file(file_name)?
@@ -482,7 +482,7 @@ fn test_make_symlink_check_is_link_and_remove_symlink() {
 	assert symlink_exists == false
 }
 
-fn test_make_symlink_check_is_link_and_remove_symlink_with_file() ? {
+fn test_make_symlink_check_is_link_and_remove_symlink_with_file() {
 	file := 'tfile'
 	symlink := 'tsymlink'
 	os.rm(symlink) or {}
@@ -496,7 +496,7 @@ fn test_make_symlink_check_is_link_and_remove_symlink_with_file() ? {
 	assert symlink_exists == false
 }
 
-fn test_make_hardlink_check_is_link_and_remove_hardlink_with_file() ? {
+fn test_make_hardlink_check_is_link_and_remove_hardlink_with_file() {
 	file := 'tfile'
 	symlink := 'tsymlink'
 	os.rm(symlink) or {}
@@ -544,7 +544,7 @@ fn test_symlink() {
 	}
 }
 
-fn test_is_executable_writable_readable() ? {
+fn test_is_executable_writable_readable() {
 	file_name := 'rwxfile.exe'
 	create_file(file_name)?
 	$if !windows {
@@ -704,7 +704,7 @@ cmd.close()
 	*/
 }
 
-fn test_posix_set_bit() ? {
+fn test_posix_set_bit() {
 	$if windows {
 		assert true
 	} $else {
@@ -764,7 +764,7 @@ fn test_exists_in_system_path() {
 	assert os.exists_in_system_path('ls')
 }
 
-fn test_truncate() ? {
+fn test_truncate() {
 	filename := './test_trunc.txt'
 	hello := 'hello world!'
 	mut f := os.create(filename)?
@@ -781,7 +781,7 @@ fn test_hostname() {
 	assert os.hostname().len > 2
 }
 
-fn test_glob() ? {
+fn test_glob() {
 	os.mkdir('test_dir') or { panic(err) }
 	for i in 0 .. 4 {
 		if i == 3 {
@@ -818,7 +818,7 @@ fn test_utime() {
 	assert os.file_last_mod_unix(filename) == mtime
 }
 
-fn test_execute() ? {
+fn test_execute() {
 	print0script := os.join_path_single(tfolder, 'print0.v')
 	// The output of the next command contains a 0 byte in the middle.
 	// Nevertheless, the execute function *should* return a string that

--- a/vlib/rand/random_bytes_test.v
+++ b/vlib/rand/random_bytes_test.v
@@ -1,6 +1,6 @@
 import rand
 
-fn test_rand_bytes() ? {
+fn test_rand_bytes() {
 	mut randoms := []string{}
 	for i in 0 .. 100 {
 		x := rand.bytes(i)?.hex()
@@ -21,7 +21,7 @@ fn test_rand_bytes() ? {
 	dump(differences)
 }
 
-fn test_prng_rand_bytes() ? {
+fn test_prng_rand_bytes() {
 	mut randoms := []string{}
 	mut rng := rand.get_current_rng()
 	for i in 0 .. 100 {
@@ -43,7 +43,7 @@ fn test_prng_rand_bytes() ? {
 	dump(differences)
 }
 
-fn test_rand_read() ? {
+fn test_rand_read() {
 	max := 50
 	mut a := []u8{len: max}
 	mut differences := 0
@@ -72,7 +72,7 @@ fn test_rand_read() ? {
 	assert differences > 11700 // normally around 11758
 }
 
-fn test_prng_rand_read() ? {
+fn test_prng_rand_read() {
 	max := 50
 	mut a := []u8{len: max}
 	mut differences := 0

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -354,7 +354,7 @@ fn test_shuffle() {
 	}
 }
 
-fn test_shuffle_partial() ? {
+fn test_shuffle_partial() {
 	mut a := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 	mut b := a.clone()
 
@@ -382,7 +382,7 @@ fn test_shuffle_clone() {
 	}
 }
 
-fn test_choose() ? {
+fn test_choose() {
 	lengths := [1, 3, 4, 5, 6, 7]
 	a := ['one', 'two', 'three', 'four', 'five', 'six', 'seven']
 	for length in lengths {

--- a/vlib/szip/szip_test.v
+++ b/vlib/szip/szip_test.v
@@ -40,7 +40,7 @@ fn testsuite_end() ? {
 	cleanup()
 }
 
-fn test_szip_create_temp_files() ? {
+fn test_szip_create_temp_files() {
 	os.mkdir(test_path)?
 	os.mkdir(test_path2)?
 	os.write_file(fpath1, 'file one')?
@@ -51,7 +51,7 @@ fn test_szip_create_temp_files() ? {
 	assert os.exists(fpath3)
 }
 
-fn test_zipping_files() ? {
+fn test_zipping_files() {
 	mut files := (os.ls(test_path)?).map(os.join_path(test_path, it))
 	files << (os.ls(test_path2)?).map(os.join_path(test_path2, it))
 	szip.zip_files(files, test_out_zip)?
@@ -61,7 +61,7 @@ fn test_zipping_files() ? {
 	os.rm(fpath3)?
 }
 
-fn test_extract_zipped_files() ? {
+fn test_extract_zipped_files() {
 	szip.extract_zip_to_dir(test_out_zip, test_path)?
 	szip.extract_zip_to_dir(test_out_zip, test_path2)?
 	assert os.exists(fpath1)
@@ -123,7 +123,7 @@ fn test_reading_zipping_files() ? {
 	zp.close()
 }
 
-fn test_zip_folder() ? {
+fn test_zip_folder() {
 	cleanup()
 	os.mkdir_all(test_path3_1)?
 	os.mkdir_all(test_path3_2)?
@@ -148,7 +148,7 @@ fn test_zip_folder() ? {
 	assert (os.read_file(fpath6)?) == '6'
 }
 
-fn test_zip_folder_omit_empty_directories() ? {
+fn test_zip_folder_omit_empty_directories() {
 	cleanup()
 	os.mkdir_all(test_path3_1)?
 	os.mkdir_all(test_path3_2)?

--- a/vlib/term/term_test.v
+++ b/vlib/term/term_test.v
@@ -57,7 +57,7 @@ fn test_header() {
 	assert term_width == term.header('1234', '_-/\\/\\').len
 }
 
-fn test_get_cursor_position() ? {
+fn test_get_cursor_position() {
 	original_position := term.get_cursor_position()?
 	cursor_position_1 := term.get_cursor_position()?
 	assert original_position.x == cursor_position_1.x

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -185,14 +185,14 @@ fn test_parse_rfc3339() {
 	}
 }
 
-fn test_ad_second_to_parse_result_in_2001() ? {
+fn test_ad_second_to_parse_result_in_2001() {
 	now_tm := time.parse('2001-01-01 04:00:00')?
 	future_tm := now_tm.add_seconds(60)
 	assert future_tm.str() == '2001-01-01 04:01:00'
 	assert now_tm.unix < future_tm.unix
 }
 
-fn test_ad_second_to_parse_result_pre_2001() ? {
+fn test_ad_second_to_parse_result_pre_2001() {
 	now_tm := time.parse('2000-01-01 04:00:00')?
 	future_tm := now_tm.add_seconds(60)
 	assert future_tm.str() == '2000-01-01 04:01:00'

--- a/vlib/time/time_addition_test.v
+++ b/vlib/time/time_addition_test.v
@@ -1,6 +1,6 @@
 import time
 
-fn test_add_to_day_in_the_previous_century() ? {
+fn test_add_to_day_in_the_previous_century() {
 	a := time.parse_iso8601('1900-01-01')?
 	aa := a.add_days(180)
 	dump(a.debug())
@@ -8,25 +8,25 @@ fn test_add_to_day_in_the_previous_century() ? {
 	assert aa.ymmdd() == '1900-06-30'
 }
 
-fn test_add_to_day_in_the_past() ? {
+fn test_add_to_day_in_the_past() {
 	a := time.parse_iso8601('1990-03-01')?
 	aa := a.add_days(180)
 	assert aa.ymmdd() == '1990-08-28'
 }
 
-fn test_add_to_day_in_the_recent_past() ? {
+fn test_add_to_day_in_the_recent_past() {
 	a := time.parse_iso8601('2021-03-01')?
 	aa := a.add_days(180)
 	assert aa.ymmdd() == '2021-08-28'
 }
 
-fn test_add_to_day_in_the_future_1() ? {
+fn test_add_to_day_in_the_future_1() {
 	a := time.parse_iso8601('3000-11-01')?
 	aa := a.add_days(180)
 	assert aa.ymmdd() == '3001-04-30'
 }
 
-fn test_add_to_day_in_the_future_2() ? {
+fn test_add_to_day_in_the_future_2() {
 	a := time.parse_iso8601('3000-12-30')?
 	aa := a.add_days(180)
 	assert aa.ymmdd() == '3001-06-28'

--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -63,7 +63,7 @@ fn run(args []string) ?string {
 }
 
 // test_alexcrichton_toml_rs run though 'testdata/alexcrichton/toml-test/test-suite/tests/*' if found.
-fn test_alexcrichton_toml_rs() ? {
+fn test_alexcrichton_toml_rs() {
 	this_file := @FILE
 	test_root := os.join_path(os.dir(this_file), 'testdata', 'alexcrichton', 'toml-test')
 	if os.is_dir(test_root) {

--- a/vlib/toml/tests/array_of_tables_2_level_test.v
+++ b/vlib/toml/tests/array_of_tables_2_level_test.v
@@ -24,7 +24,7 @@ name = "Born in the USA"
 
 const fprefix = os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))
 
-fn test_nested_array_of_tables() ? {
+fn test_nested_array_of_tables() {
 	mut toml_doc := toml.parse_text(toml_text)?
 
 	toml_json := to.json(toml_doc)

--- a/vlib/toml/tests/array_of_tables_edge_case_2_test.v
+++ b/vlib/toml/tests/array_of_tables_edge_case_2_test.v
@@ -4,7 +4,7 @@ import toml.to
 
 const fprefix = os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))
 
-fn test_array_of_tables_edge_case_file() ? {
+fn test_array_of_tables_edge_case_file() {
 	toml_doc := toml.parse_file(os.real_path(fprefix + '.toml'))?
 
 	toml_json := to.json(toml_doc)

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -53,7 +53,7 @@ fn run(args []string) ?string {
 }
 
 // test_burnt_sushi_tomltest run though 'testdata/burntsushi/toml-test/*' if found.
-fn test_burnt_sushi_tomltest() ? {
+fn test_burnt_sushi_tomltest() {
 	this_file := @FILE
 	test_root := os.join_path(os.dir(this_file), 'testdata', 'burntsushi', 'toml-test',
 		'tests')

--- a/vlib/toml/tests/crlf_test.v
+++ b/vlib/toml/tests/crlf_test.v
@@ -12,7 +12,7 @@ fn test_crlf() {
 	assert value.string() == str_value
 }
 
-fn test_crlf_is_parsable_just_like_lf() ? {
+fn test_crlf_is_parsable_just_like_lf() {
 	crlf_content := '# a comment\r\ntitle = "TOML Example"\r\n[database]\r\nserver = "192.168.1.1"\r\nports = [ 8000, 8001, 8002 ]\r\n'
 	all := [crlf_content, crlf_content.replace('\r\n', '\n')]
 	for content in all {

--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -69,7 +69,7 @@ fn run(args []string) ?string {
 }
 
 // test_iarna_toml_spec_tests run though 'testdata/iarna/toml-test/*' if found.
-fn test_iarna_toml_spec_tests() ? {
+fn test_iarna_toml_spec_tests() {
 	this_file := @FILE
 	test_root := os.join_path(os.dir(this_file), 'testdata', 'iarna', 'toml-test')
 	if os.is_dir(test_root) {

--- a/vlib/toml/tests/json_encoding_test.v
+++ b/vlib/toml/tests/json_encoding_test.v
@@ -4,7 +4,7 @@ import toml.to
 
 const fprefix = os.join_path(os.dir(@FILE), 'testdata', os.file_name(@FILE).all_before_last('.'))
 
-fn test_parse() ? {
+fn test_parse() {
 	toml_doc := toml.parse_file(os.real_path(fprefix + '.toml'))?
 
 	toml_json := to.json(toml_doc)

--- a/vlib/toml/tests/key_test.v
+++ b/vlib/toml/tests/key_test.v
@@ -6,7 +6,7 @@ fn path_by_extension(ext string) string {
 	return os.join_path(os.dir(@VEXE), 'vlib/toml/tests/testdata/key_test.$ext')
 }
 
-fn test_keys() ? {
+fn test_keys() {
 	toml_doc := toml.parse_file(path_by_extension('toml'))?
 
 	mut value := toml_doc.value('34-11')
@@ -35,7 +35,7 @@ fn test_keys() ? {
 	}
 }
 
-fn test_parse_dotted_key() ? {
+fn test_parse_dotted_key() {
 	assert toml.parse_dotted_key('')? == []
 	assert toml.parse_dotted_key('abc')? == ['abc']
 	assert toml.parse_dotted_key('tube.test."test.test".h."i.j."."k"')? == ['tube', 'test',

--- a/vlib/v/ast/type_size_test.v
+++ b/vlib/v/ast/type_size_test.v
@@ -27,7 +27,7 @@ struct T08 {
 	x string
 }
 
-fn test_type_size() ? {
+fn test_type_size() {
 	mut pref := pref.new_preferences()
 	$if x64 {
 		pref.m64 = true

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -14,7 +14,7 @@ fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }
 
-fn test_conditional_executable_removal() ? {
+fn test_conditional_executable_removal() {
 	os.chdir(test_path)?
 	os.execute_or_exit('${os.quoted_path(vexe)} init')
 

--- a/vlib/v/builder/interpreterbuilder/v_interpret_test.v
+++ b/vlib/v/builder/interpreterbuilder/v_interpret_test.v
@@ -41,7 +41,7 @@ struct InterpTest {
 	output string
 }
 
-fn test_interpreter() ? {
+fn test_interpreter() {
 	mut tests := []InterpTest{}
 	tests << InterpTest{'println(3+3)', '6'}
 	tests << InterpTest{'println(3)', '3'}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -956,7 +956,7 @@ pub fn (mut c Checker) check_expr_opt_call(expr ast.Expr, ret_type ast.Type) ast
 pub fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_return_type ast.Type) {
 	if node.kind == .propagate_option {
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.optional)
-			&& c.table.cur_fn.name != 'main.main' && !c.inside_const {
+			&& !c.table.cur_fn.is_main && !c.table.cur_fn.is_test && !c.inside_const {
 			c.add_instruction_for_optional_type()
 			c.error('to propagate the call, `$c.table.cur_fn.name` must return an optional type',
 				node.pos)
@@ -974,7 +974,7 @@ pub fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_re
 	}
 	if node.kind == .propagate_result {
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.result)
-			&& c.table.cur_fn.name != 'main.main' && !c.inside_const {
+			&& !c.table.cur_fn.is_main && !c.table.cur_fn.is_test && !c.inside_const {
 			c.add_instruction_for_result_type()
 			c.error('to propagate the call, `$c.table.cur_fn.name` must return a result type',
 				node.pos)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -467,7 +467,8 @@ pub fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	c.stmts_ending_with_expression(node.or_block.stmts)
 	c.expected_or_type = ast.void_type
 
-	if !c.inside_const && c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_main {
+	if !c.inside_const && c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_main
+		&& !c.table.cur_fn.is_test {
 		// TODO: use just `if node.or_block.kind == .propagate_result && !c.table.cur_fn.return_type.has_flag(.result) {` after the deprecation for ?!Type
 		if node.or_block.kind == .propagate_result && !c.table.cur_fn.return_type.has_flag(.result)
 			&& !c.table.cur_fn.return_type.has_flag(.optional) {

--- a/vlib/v/checker/tests/test_functions_wrong_signature_test.vv
+++ b/vlib/v/checker/tests/test_functions_wrong_signature_test.vv
@@ -11,7 +11,7 @@ fn test_returning_int() int {
 
 // NB: this is allowed explicitly now, to allow for shorter tests
 // of functions returning optionals.
-fn test_returning_opt() ? {
+fn test_returning_opt() {
 	assert true
 }
 

--- a/vlib/v/doc/doc_private_fn_test.v
+++ b/vlib/v/doc/doc_private_fn_test.v
@@ -25,14 +25,14 @@ fn test_get_parent_mod_current_folder() {
 	// }
 }
 
-fn test_get_parent_mod_on_temp_dir() ? {
+fn test_get_parent_mod_on_temp_dir() {
 	// TODO: fix this on windows
 	$if !windows {
 		assert get_parent_mod(os.temp_dir())? == ''
 	}
 }
 
-fn test_get_parent_mod_normal_cases() ? {
+fn test_get_parent_mod_normal_cases() {
 	assert '---' == get_parent_mod(os.join_path(@VMODROOT, 'vlib/v')) or {
 		assert err.msg() == 'No V files found.'
 		'---'

--- a/vlib/v/eval/interpret_test.v
+++ b/vlib/v/eval/interpret_test.v
@@ -4,7 +4,7 @@ import term
 
 const is_verbose = os.getenv('VTEST_SHOW_CMD') != ''
 
-fn test_interpret() ? {
+fn test_interpret() {
 	mut bench := benchmark.new_benchmark()
 	vexe := os.getenv('VEXE')
 	vroot := os.dir(vexe)

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -18,7 +18,7 @@ fn mm(s string) string {
 	return term.colorize(term.magenta, s)
 }
 
-fn test_out_files() ? {
+fn test_out_files() {
 	println(term.colorize(term.green, '> testing whether .out files match:'))
 	os.chdir(vroot) or {}
 	output_path := os.join_path(os.temp_dir(), 'v', 'coutput', 'out')
@@ -89,7 +89,7 @@ fn test_out_files() ? {
 	assert total_errors == 0
 }
 
-fn test_c_must_have_files() ? {
+fn test_c_must_have_files() {
 	println(term.colorize(term.green, '> testing whether `.c.must_have` files match:'))
 	os.chdir(vroot) or {}
 	output_path := os.join_path(os.temp_dir(), 'v', 'coutput', 'c_must_have')

--- a/vlib/v/gen/js/sourcemap/vlq/vlq_decode_test.v
+++ b/vlib/v/gen/js/sourcemap/vlq/vlq_decode_test.v
@@ -16,7 +16,7 @@ struct TestData {
 
 type TestDataList = []TestData
 
-fn test_decode_a() ? {
+fn test_decode_a() {
 	decode_values := [
 		TestData{'A', 0},
 		TestData{'C', 1},

--- a/vlib/v/gen/js/sourcemap/vlq/vlq_encode_test.v
+++ b/vlib/v/gen/js/sourcemap/vlq/vlq_encode_test.v
@@ -10,7 +10,7 @@ pub mut:
 	bytes []u8
 }
 
-fn test_encode_a() ? {
+fn test_encode_a() {
 	decode_values := [
 		TestData{'A', 0},
 		TestData{'C', 1},

--- a/vlib/v/pkgconfig/bin/pkgconfig_test.v
+++ b/vlib/v/pkgconfig/bin/pkgconfig_test.v
@@ -4,7 +4,7 @@ const vexe = os.getenv('VEXE')
 
 const vroot = os.dir(vexe)
 
-fn test_pkgconfig_can_be_compiled() ? {
+fn test_pkgconfig_can_be_compiled() {
 	tmp_exe := os.join_path(os.temp_dir(), '${os.getpid()}_pkgconfig.exe')
 	pkgconfig_v_file := os.real_path(os.join_path(vroot, 'vlib/v/pkgconfig/bin/pkgconfig.v'))
 	assert !os.exists(tmp_exe)

--- a/vlib/v/tests/cast_optional_to_interface_test.v
+++ b/vlib/v/tests/cast_optional_to_interface_test.v
@@ -28,7 +28,7 @@ struct Engine {
 	parser Parser
 }
 
-fn test_cast_optional_to_interface() ? {
+fn test_cast_optional_to_interface() {
 	parser := new_parser()?
 	assert parser.main.str == 'test'
 	eprintln(voidptr(parser.main))

--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -61,7 +61,7 @@ const return_types = [
 
 // test_closures_with_n_args generates a new V file containing closures of `i`
 // and parameters of type `typ`, to makes sure that all combinations work correctly
-fn test_closures_with_n_args() ? {
+fn test_closures_with_n_args() {
 	mut v_code := strings.new_builder(1024)
 	// Note: the type or value of the captured arg doesn't matter for this test,
 	// as the entire closure context is always passed as one pointer anyways

--- a/vlib/v/tests/crun_mode/crun_test.v
+++ b/vlib/v/tests/crun_mode/crun_test.v
@@ -20,12 +20,12 @@ fn testsuite_end() {
 	assert !os.is_dir(crun_folder)
 }
 
-fn test_saving_simple_v_program() ? {
+fn test_saving_simple_v_program() {
 	os.write_file(vprogram_file, 'print("hello")')?
 	assert true
 }
 
-fn test_crun_simple_v_program_several_times() ? {
+fn test_crun_simple_v_program_several_times() {
 	mut sw := time.new_stopwatch()
 	mut times := []i64{}
 	for i in 0 .. 10 {

--- a/vlib/v/tests/fn_mut_arg_of_interface_test.v
+++ b/vlib/v/tests/fn_mut_arg_of_interface_test.v
@@ -19,7 +19,7 @@ fn do(mut inter TheInterface) string {
 	return 'ok'
 }
 
-fn test_fn_mut_arg_of_interface() ? {
+fn test_fn_mut_arg_of_interface() {
 	mut inner := maker()?
 	ret := do(mut inner)
 	println(ret)

--- a/vlib/v/tests/generics_interface_with_non_generic_method_test.v
+++ b/vlib/v/tests/generics_interface_with_non_generic_method_test.v
@@ -50,6 +50,6 @@ fn program<T>(factory TypeFactory<T>) ? {
 	assert root2.type_name == .expression
 }
 
-fn test_generic_interface_with_non_generic_method() ? {
+fn test_generic_interface_with_non_generic_method() {
 	program<NodeType>(&EnumTypeFactory{})?
 }

--- a/vlib/v/tests/generics_method_returning_optional_test.v
+++ b/vlib/v/tests/generics_method_returning_optional_test.v
@@ -23,7 +23,7 @@ pub fn (mut x Abc) diagnostics() ?Res {
 	return got.params
 }
 
-fn test_generic_method_returning_optional() ? {
+fn test_generic_method_returning_optional() {
 	mut a := Abc{}
 	a.diagnostics()?
 	assert true

--- a/vlib/v/tests/generics_with_nested_external_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_external_generics_fn_test.v
@@ -9,7 +9,7 @@ pub fn sample<T>(arr []T, k int) ?[]T {
 	return result[0..k]
 }
 
-fn test_generics_with_nested_external_generics_fn() ? {
+fn test_generics_with_nested_external_generics_fn() {
 	mut arr := [11, 32, 24, 45, 57, 32, 37, 52, 37, 24]
 	println(arr)
 

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -218,7 +218,7 @@ fn return_optional() ?int {
 	return 1
 }
 
-fn test_if_expr_with_optional() ? {
+fn test_if_expr_with_optional() {
 	m := map[string]int{}
 	v := if a := m['a'] {
 		println('$a')

--- a/vlib/v/tests/init_multiple_branches_test.v
+++ b/vlib/v/tests/init_multiple_branches_test.v
@@ -14,7 +14,7 @@ struct App {
 	t bool
 }
 
-fn test_init_multiple_branches() ? {
+fn test_init_multiple_branches() {
 	mut m := map[string]json2.Any{}
 	app := App{
 		t: m['t'] or { 0 }.bool()

--- a/vlib/v/tests/json_serialisation_of_fixed_arrays_test.v
+++ b/vlib/v/tests/json_serialisation_of_fixed_arrays_test.v
@@ -10,7 +10,7 @@ struct Fixed_Array {
 	abc [5]Abc
 }
 
-fn test_json_serialisation_of_fixed_arrays() ? {
+fn test_json_serialisation_of_fixed_arrays() {
 	a := Fixed_Array{[
 		Abc{
 			my_ints: [1, 2, 3, 4, 5, 6]!

--- a/vlib/v/tests/known_errors/known_errors_test.v
+++ b/vlib/v/tests/known_errors/known_errors_test.v
@@ -6,12 +6,12 @@ const vroot = os.dir(vexe)
 
 const testdata_folder = 'vlib/v/tests/known_errors/testdata'
 
-fn test_known_errors_testdata_folder_exists() ? {
+fn test_known_errors_testdata_folder_exists() {
 	os.chdir(vroot)?
 	assert os.is_dir(testdata_folder)
 }
 
-fn test_known_failures_are_still_failures() ? {
+fn test_known_failures_are_still_failures() {
 	mut oks := []string{}
 	mut files := os.walk_ext(testdata_folder, '.v')
 	files << os.walk_ext(testdata_folder, '.vv')

--- a/vlib/v/tests/multi_line_with_optionals_test.v
+++ b/vlib/v/tests/multi_line_with_optionals_test.v
@@ -4,7 +4,7 @@ fn has_optional() ?int {
 	return 51
 }
 
-fn test_optionals_multi_line() ? {
+fn test_optionals_multi_line() {
 	var11, var12, var13, var14, var15 := if true {
 		println('dd')
 		if true {

--- a/vlib/v/tests/nested_map_index_test.v
+++ b/vlib/v/tests/nested_map_index_test.v
@@ -8,7 +8,7 @@ mut:
 	bar map[int]string
 }
 
-fn test_nested_map_index() ? {
+fn test_nested_map_index() {
 	f := Foo{
 		foo: {
 			11: Bar{

--- a/vlib/v/tests/option_2_test.v
+++ b/vlib/v/tests/option_2_test.v
@@ -61,6 +61,6 @@ fn foo() ?string {
 	return 'hi'
 }
 
-fn test_opt_subexp_field() ? {
+fn test_opt_subexp_field() {
 	assert foo()?.len == 2
 }

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -128,7 +128,7 @@ fn test_propagation() {
 	println(6)
 }
 
-fn test_q() ? {
+fn test_q() {
 	assert foo_ok()? == 777
 }
 

--- a/vlib/v/tests/optional_multi_return_test.v
+++ b/vlib/v/tests/optional_multi_return_test.v
@@ -2,7 +2,7 @@ fn tuple() ?(int, int) {
 	return 1, 2
 }
 
-fn test_optional_multi_return() ? {
+fn test_optional_multi_return() {
 	println(tuple()?)
 	a, b := tuple()?
 	assert a == 1

--- a/vlib/v/tests/return_optional_test.v
+++ b/vlib/v/tests/return_optional_test.v
@@ -6,7 +6,7 @@ fn func2() ?(int, int) {
 	return func1()?, 1
 }
 
-fn test_return_optional() ? {
+fn test_return_optional() {
 	a, b := func2()?
 	println('$a, $b')
 	assert a == 0

--- a/vlib/v/tests/run_project_folders_test.v
+++ b/vlib/v/tests/run_project_folders_test.v
@@ -11,7 +11,7 @@ fn test_vexe_exists() {
 	assert os.is_file(vexe)
 }
 
-fn test_v_profile_works() ? {
+fn test_v_profile_works() {
 	os.chdir(vroot) or {}
 	folders_root := os.join_path(vroot, 'vlib/v/tests/run_project_folders')
 	folder_names := os.ls(folders_root)?

--- a/vlib/v/tests/shared_array_sort_test.v
+++ b/vlib/v/tests/shared_array_sort_test.v
@@ -14,7 +14,7 @@ fn (alarms Alarms) add(alarm time.Time) {
 	}
 }
 
-fn test_sorting_shared_arrays() ? {
+fn test_sorting_shared_arrays() {
 	alarms := Alarms{}
 	utc := time.utc()
 	alarms.add(utc)

--- a/vlib/v/tests/testdata/tests_returning_options_failing_test.v
+++ b/vlib/v/tests/testdata/tests_returning_options_failing_test.v
@@ -1,4 +1,4 @@
-fn example() ? {
+fn example() ! {
 	return error('oh no')
 }
 
@@ -7,13 +7,13 @@ fn test_simple() {
 	assert true
 }
 
-fn test_example() ? {
+fn test_example() ! {
 	assert true
 	assert true
 	example() or { return error('failing test with return, err: $err') }
 }
 
-fn test_example_2() ? {
+fn test_example_2() {
 	assert true
 	assert true
 	example()?

--- a/vlib/v/tests/vsh_envbang_test.v
+++ b/vlib/v/tests/vsh_envbang_test.v
@@ -1,7 +1,7 @@
 import os
 import rand
 
-fn test_envbang_script_runs() ? {
+fn test_envbang_script_runs() {
 	env_location := '/usr/bin/env'
 	$if windows {
 		skip_test('windows does not support envbang lines')

--- a/vlib/v/vmod/parser_test.v
+++ b/vlib/v/vmod/parser_test.v
@@ -4,7 +4,7 @@ const quote = '\x22'
 
 const apos = '\x27'
 
-fn test_ok() ? {
+fn test_ok() {
 	ok_source := "Module {
 	name: 'V'
 	description: 'The V programming language.'
@@ -34,7 +34,7 @@ fn test_ok() ? {
 	assert e.unknown == {}
 }
 
-fn test_invalid_start() ? {
+fn test_invalid_start() {
 	vmod.decode('\n\nXYZ') or {
 		assert err.msg() == 'vmod: v.mod files should start with Module, at line 3'
 		return
@@ -42,7 +42,7 @@ fn test_invalid_start() ? {
 	assert false
 }
 
-fn test_invalid_end() ? {
+fn test_invalid_end() {
 	vmod.decode('\nModule{\n \nname: ${quote}zzzz}') or {
 		assert err.msg() == 'vmod: invalid token ${quote}eof$quote, at line 4'
 		return

--- a/vlib/vweb/csrf/csrf_test.v
+++ b/vlib/vweb/csrf/csrf_test.v
@@ -18,7 +18,7 @@ fn (mut app App) index() vweb.Result {
 	return app.text("Csrf-Token set! It's value is: $token")
 }
 
-fn test_send_a_request_to_homepage_expecting_a_csrf_cookie() ? {
+fn test_send_a_request_to_homepage_expecting_a_csrf_cookie() {
 	go vweb.run_at(&App{}, vweb.RunParams{ port: sport })
 	time.sleep(500 * time.millisecond)
 	res := http.get('http://localhost:$sport/')?

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -116,14 +116,14 @@ fn assert_common_http_headers(x http.Response) ? {
 	assert x.header.get(.connection)? == 'close'
 }
 
-fn test_http_client_index() ? {
+fn test_http_client_index() {
 	x := http.get('http://$localserver/') or { panic(err) }
 	assert_common_http_headers(x)?
 	assert x.header.get(.content_type)? == 'text/plain'
 	assert x.body == 'Welcome to VWeb'
 }
 
-fn test_http_client_404() ? {
+fn test_http_client_404() {
 	url_404_list := [
 		'http://$localserver/zxcnbnm',
 		'http://$localserver/JHKAJA',
@@ -135,21 +135,21 @@ fn test_http_client_404() ? {
 	}
 }
 
-fn test_http_client_simple() ? {
+fn test_http_client_simple() {
 	x := http.get('http://$localserver/simple') or { panic(err) }
 	assert_common_http_headers(x)?
 	assert x.header.get(.content_type)? == 'text/plain'
 	assert x.body == 'A simple result'
 }
 
-fn test_http_client_html_page() ? {
+fn test_http_client_html_page() {
 	x := http.get('http://$localserver/html_page') or { panic(err) }
 	assert_common_http_headers(x)?
 	assert x.header.get(.content_type)? == 'text/html'
 	assert x.body == '<h1>ok</h1>'
 }
 
-fn test_http_client_settings_page() ? {
+fn test_http_client_settings_page() {
 	x := http.get('http://$localserver/bilbo/settings') or { panic(err) }
 	assert_common_http_headers(x)?
 	assert x.body == 'username: bilbo'
@@ -159,7 +159,7 @@ fn test_http_client_settings_page() ? {
 	assert y.body == 'username: kent'
 }
 
-fn test_http_client_user_repo_settings_page() ? {
+fn test_http_client_user_repo_settings_page() {
 	x := http.get('http://$localserver/bilbo/gostamp/settings') or { panic(err) }
 	assert_common_http_headers(x)?
 	assert x.body == 'username: bilbo | repository: gostamp'
@@ -177,7 +177,7 @@ struct User {
 	age  int
 }
 
-fn test_http_client_json_post() ? {
+fn test_http_client_json_post() {
 	ouser := User{
 		name: 'Bilbo'
 		age: 123
@@ -202,7 +202,7 @@ fn test_http_client_json_post() ? {
 	assert '$ouser' == '$nuser2'
 }
 
-fn test_http_client_multipart_form_data() ? {
+fn test_http_client_multipart_form_data() {
 	boundary := '6844a625b1f0b299'
 	name := 'foo'
 	ct := 'multipart/form-data; boundary=$boundary'

--- a/vlib/x/json2/decoder_test.v
+++ b/vlib/x/json2/decoder_test.v
@@ -1,47 +1,47 @@
 module json2
 
-fn test_raw_decode_string() ? {
+fn test_raw_decode_string() {
 	str := raw_decode('"Hello!"')?
 	assert str.str() == 'Hello!'
 }
 
-fn test_raw_decode_string_escape() ? {
+fn test_raw_decode_string_escape() {
 	jstr := raw_decode('"\u001b"')?
 	str := jstr.str()
 	assert str.len == 1
 	assert str[0] == 27
 }
 
-fn test_raw_decode_number() ? {
+fn test_raw_decode_number() {
 	num := raw_decode('123')?
 	assert num.int() == 123
 }
 
-fn test_raw_decode_array() ? {
+fn test_raw_decode_array() {
 	raw_arr := raw_decode('["Foo", 1]')?
 	arr := raw_arr.arr()
 	assert arr[0] or { 0 }.str() == 'Foo'
 	assert arr[1] or { 0 }.int() == 1
 }
 
-fn test_raw_decode_bool() ? {
+fn test_raw_decode_bool() {
 	bol := raw_decode('false')?
 	assert bol.bool() == false
 }
 
-fn test_raw_decode_map() ? {
+fn test_raw_decode_map() {
 	raw_mp := raw_decode('{"name":"Bob","age":20}')?
 	mp := raw_mp.as_map()
 	assert mp['name'] or { 0 }.str() == 'Bob'
 	assert mp['age'] or { 0 }.int() == 20
 }
 
-fn test_raw_decode_null() ? {
+fn test_raw_decode_null() {
 	nul := raw_decode('null')?
 	assert nul is Null
 }
 
-fn test_raw_decode_invalid() ? {
+fn test_raw_decode_invalid() {
 	raw_decode('1z') or {
 		assert err.msg() == '[x.json2] invalid token `z` (0:17)'
 		return
@@ -49,25 +49,25 @@ fn test_raw_decode_invalid() ? {
 	assert false
 }
 
-fn test_raw_decode_string_with_dollarsign() ? {
+fn test_raw_decode_string_with_dollarsign() {
 	str := raw_decode(r'"Hello $world"')?
 	assert str.str() == r'Hello $world'
 }
 
-fn test_raw_decode_map_with_whitespaces() ? {
+fn test_raw_decode_map_with_whitespaces() {
 	raw_mp := raw_decode(' \n\t{"name":"Bob","age":20}\n\t')?
 	mp := raw_mp.as_map()
 	assert mp['name'] or { 0 }.str() == 'Bob'
 	assert mp['age'] or { 0 }.int() == 20
 }
 
-fn test_nested_array_object() ? {
+fn test_nested_array_object() {
 	mut parser := new_parser(r'[[[[[],[],[]]]],{"Test":{}},[[]]]', false)
 	decoded := parser.decode()?
 	assert parser.n_level == 0
 }
 
-fn test_raw_decode_map_invalid() ? {
+fn test_raw_decode_map_invalid() {
 	raw_decode('{"name","Bob","age":20}') or {
 		assert err.msg() == '[x.json2] invalid token `comma`, expecting `colon` (0:5)'
 		return
@@ -75,7 +75,7 @@ fn test_raw_decode_map_invalid() ? {
 	assert false
 }
 
-fn test_raw_decode_array_invalid() ? {
+fn test_raw_decode_array_invalid() {
 	raw_decode('["Foo", 1,}') or {
 		assert err.msg() == '[x.json2] invalid token `rcbr` (0:5)'
 		return

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -36,7 +36,7 @@ fn test_json_string_non_ascii() {
 	assert text.json_str() == r'"\u3072\u3089\u304c\u306a"'
 }
 
-fn test_utf8_strings_are_not_modified() ? {
+fn test_utf8_strings_are_not_modified() {
 	original := '{"s":"Schilddrüsenerkrankungen"}'
 	// dump(original)
 	deresult := json2.raw_decode(original)?
@@ -44,7 +44,7 @@ fn test_utf8_strings_are_not_modified() ? {
 	assert deresult.str() == original
 }
 
-fn test_encoder_unescaped_utf32() ? {
+fn test_encoder_unescaped_utf32() {
 	jap_text := json2.Any('ひらがな')
 	enc := json2.Encoder{
 		escape_unicode: false
@@ -61,7 +61,7 @@ fn test_encoder_unescaped_utf32() ? {
 	assert sb.str() == '"$emoji_text"'
 }
 
-fn test_encoder_prettify() ? {
+fn test_encoder_prettify() {
 	obj := {
 		'hello': json2.Any('world')
 		'arr':   [json2.Any('im a string'), [json2.Any('3rd level')]]


### PR DESCRIPTION
This PR make error handling the same as the main function.

- Make error handling the same as the main function.
- Modify all the related tests.

e.g.
```v
fn test_write_struct_at() {
	mut f := os.open_file(tfile, 'w')?
	f.write_struct(extended_point)?
	f.write_struct_at(another_point, 3)?
	f.close()
	f = os.open_file(tfile, 'r')?
	mut p := Point{}
	f.read_struct_at(mut p, 3)?
	f.close()

	assert p == another_point
}
```