### PR TITLE
cgen: fix using reference of sumtype or map as struct field (fix: #15827)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -921,8 +921,8 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 			funcprefix += 'isnil(it.${c_name(field.name)})'
 			funcprefix += ' ? _SLIT("nil") : '
 			// struct, floats and ints have a special case through the _str function
-			if sym.kind !in [.struct_, .alias, .enum_, .interface_] && !field.typ.is_int_valptr()
-				&& !field.typ.is_float_valptr() {
+			if sym.kind !in [.struct_, .alias, .enum_, .sum_type, .map, .interface_]
+				&& !field.typ.is_int_valptr() && !field.typ.is_float_valptr() {
 				funcprefix += '*'
 			}
 		}

--- a/vlib/v/gen/c/testdata/ref_sumtype_as_struct_field.out
+++ b/vlib/v/gen/c/testdata/ref_sumtype_as_struct_field.out
@@ -1,0 +1,3 @@
+SumTypePtr{
+    ptr: &nil
+}

--- a/vlib/v/gen/c/testdata/ref_sumtype_as_struct_field.vv
+++ b/vlib/v/gen/c/testdata/ref_sumtype_as_struct_field.vv
@@ -1,0 +1,14 @@
+struct S1 {}
+
+struct S2 {}
+
+type T1 = S1 | S2
+
+struct SumTypePtr {
+	ptr &T1 = unsafe { nil }
+}
+
+fn main() {
+	ptr := SumTypePtr{}
+	println(ptr)
+}


### PR DESCRIPTION
1. Fix #15827 
2. Add test

```v
struct S1 {}

struct S2 {}

type T1 = S1 | S2

struct SumTypePtr {
	ptr &T1 = unsafe { nil }
}

fn main() {
	ptr := SumTypePtr{}
	dump(ptr)
}

```

output:

```
[vlib/v/gen/c/testdata/ref_sumtype_as_struct_field.vv:13] ptr: SumTypePtr{
    ptr: &nil
}

```