### PR TITLE
Compiler: add -raw-vsh-tmp-prefix compiler flag

### DIFF
--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -258,6 +258,22 @@ fn get_all_commands() []Command {
 			rmfile: 'v.c'
 		}
 	}
+	$if !windows {
+		res << Command{
+			line: '$vexe -raw-vsh-tmp-prefix tmp vlib/v/tests/script_with_no_extension'
+			okmsg: 'V can crun a script, that lacks a .vsh extension'
+			runcmd: .execute
+			expect: 'Test\n'
+			rmfile: 'vlib/v/tests/tmp.script_with_no_extension'
+		}
+
+		res << Command{
+			line: '$vexe -raw-vsh-tmp-prefix tmp run vlib/v/tests/script_with_no_extension'
+			okmsg: 'V can run a script, that lacks a .vsh extension'
+			runcmd: .execute
+			expect: 'Test\n'
+		}
+	}
 	return res
 }
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -127,6 +127,7 @@ To upgrade the version run the command ` v up`
     * [Hot code reloading](#hot-code-reloading)
     * [Cross compilation](#cross-compilation)
     * [Cross-platform shell scripts in V](#cross-platform-shell-scripts-in-v)
+	* [Vsh scripts with no extension](#vsh-scripts-with-no-extension)
     * [Attributes](#attributes)
     * [Goto](#goto)
 * [Appendices](#appendices)
@@ -5919,6 +5920,18 @@ Or just run it more like a traditional Bash script:
 
 On Unix-like platforms, the file can be run directly after making it executable using `chmod +x`:
 `./deploy.vsh`
+
+## Vsh scripts with no extension
+
+Whilst V does normally not allow vsh scripts without the designated file extension, there is a way
+to circumvent this rule and have a file with a fully custom name and shebang. Whilst this feature
+exists it is only recommended for specific usecases like scripts that will be put in the path and
+should **not** be used for things like build or deploy scripts. To access this feature start the
+file with `#!/usr/bin/env -S v -raw-vsh-tmp-prefix <prefix>` where `<prefix>` is the prefix for
+the built executable. This will run in crun mode so it will only rebuild if changes to the script
+were made and keep the binary as `<prefix>.<scriptfilename>`. **Caution**: if this filename already
+exists the file will be overriden. If you want to rebuild each time and not keep this binary instead
+use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix <prefix> run`.
 
 ## Attributes
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5927,11 +5927,11 @@ Whilst V does normally not allow vsh scripts without the designated file extensi
 to circumvent this rule and have a file with a fully custom name and shebang. Whilst this feature
 exists it is only recommended for specific usecases like scripts that will be put in the path and
 should **not** be used for things like build or deploy scripts. To access this feature start the
-file with `#!/usr/bin/env -S v -raw-vsh-tmp-prefix <prefix>` where `<prefix>` is the prefix for
+file with `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp` where `tmp` is the prefix for
 the built executable. This will run in crun mode so it will only rebuild if changes to the script
-were made and keep the binary as `<prefix>.<scriptfilename>`. **Caution**: if this filename already
+were made and keep the binary as `tmp.<scriptfilename>`. **Caution**: if this filename already
 exists the file will be overriden. If you want to rebuild each time and not keep this binary instead
-use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix <prefix> run`.
+use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp run`.
 
 ## Attributes
 

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -309,7 +309,7 @@ pub fn (v &Builder) get_user_files() []string {
 	is_real_file := does_exist && !os.is_dir(dir)
 	resolved_link := if is_real_file && os.is_link(dir) { os.real_path(dir) } else { dir }
 	if is_real_file && (dir.ends_with('.v') || resolved_link.ends_with('.vsh')
-		|| dir.ends_with('.vv')) {
+		|| v.pref.raw_vsh_tmp_prefix != '' || dir.ends_with('.vv')) {
 		single_v_file := if resolved_link.ends_with('.vsh') { resolved_link } else { dir }
 		// Just compile one file and get parent dir
 		user_files << single_v_file

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -50,7 +50,11 @@ pub fn (mut p Preferences) fill_with_defaults() {
 			base = filename
 		}
 		target_dir := if os.is_dir(rpath) { rpath } else { os.dir(rpath) }
-		p.out_name = os.join_path(target_dir, base)
+		if p.raw_vsh_tmp_prefix != '' {
+			p.out_name = os.join_path(target_dir, p.raw_vsh_tmp_prefix + '.' + base)
+		} else {
+			p.out_name = os.join_path(target_dir, base)
+		}
 		// Do *NOT* be tempted to generate binaries in the current work folder,
 		// when -o is not given by default, like Go, Clang, GCC etc do.
 		//
@@ -115,7 +119,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	p.ccompiler_type = cc_from_string(p.ccompiler)
 	p.is_test = p.path.ends_with('_test.v') || p.path.ends_with('_test.vv')
 		|| p.path.all_before_last('.v').all_before_last('.').ends_with('_test')
-	p.is_vsh = p.path.ends_with('.vsh')
+	p.is_vsh = p.path.ends_with('.vsh') || p.raw_vsh_tmp_prefix != ''
 	p.is_script = p.is_vsh || p.path.ends_with('.v') || p.path.ends_with('.vv')
 	if p.third_party_option == '' {
 		p.third_party_option = p.cflags

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -106,7 +106,7 @@ pub mut:
 	is_test            bool   // `v test string_test.v`
 	is_script          bool   // single file mode (`v program.v`), main function can be skipped
 	is_vsh             bool   // v script (`file.vsh`) file, the `os` module should be made global
-	raw_vsh_tmp_prefix string // The prefix for raw_vsh executables.
+	raw_vsh_tmp_prefix string // The prefix used for executables, when a script lacks the .vsh extension
 	is_livemain        bool   // main program that contains live/hot code
 	is_liveshared      bool   // a shared library, that will be used in a -live main program
 	is_shared          bool   // an ordinary shared library, -shared, no matter if it is live or not


### PR DESCRIPTION
This allows users to use shebangs and be more free by not being forced to have the vsh file extension(see the changes to docs.md for details)