### PR TITLE
builder: remove outdated tcc error

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -60,14 +60,6 @@ fn (mut v Builder) post_process_c_compiler_output(res os.Result) {
 		}
 		return
 	}
-	if res.exit_code != 0 && v.pref.gc_mode != .no_gc && res.output.contains('libgc.a')
-		&& !v.pref.is_o {
-		$if windows {
-			verror(r'Your V installation may be out-of-date. Try removing `thirdparty\tcc\` and running `.\make.bat`')
-		} $else {
-			verror('Your V installation may be out-of-date. Try removing `thirdparty/tcc/` and running `make`')
-		}
-	}
 	for emsg_marker in [builder.c_verror_message_marker, 'error: include file '] {
 		if res.output.contains(emsg_marker) {
 			emessage := res.output.all_after(emsg_marker).all_before('\n').all_before('\r').trim_right('\r\n')


### PR DESCRIPTION
This was introduced when we enabled the GC by default,as a suggestion for resolving C errors caused by the user having an outdated TCC clone. However, now that several months have passed, it is very unlikely that people still have out-of-date copies of TCC, and instead it is more likely that this error message is hiding the true cause of some C errors unrelated to TCC or the GC.



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
