### PR TITLE
v/scanner: fix string escape handling 

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1236,32 +1236,35 @@ fn (mut s Scanner) ident_string() string {
 	}
 	if start <= s.pos {
 		mut string_so_far := s.text[start..end]
-		mut str_segments := []string{}
-		mut all_pos := u_escapes_pos.clone()
-		all_pos << h_escapes_pos
-		all_pos.sort()
-
 		if !s.is_fmt {
 			mut segment_idx := 0
-			for pos in all_pos {
-				str_segments << string_so_far[segment_idx..(pos - start)]
-				segment_idx = pos - start
-
-				if pos in u_escapes_pos {
-					end_idx, segment := s.decode_u_escape_single(string_so_far, segment_idx)
-					str_segments << segment
-					segment_idx = end_idx
+			mut str_segments := []string{}
+			if u_escapes_pos.len + h_escapes_pos.len > 0 {
+				mut all_pos := []int{}
+				all_pos << u_escapes_pos
+				all_pos << h_escapes_pos
+				if u_escapes_pos.len != 0 && h_escapes_pos.len != 0 {
+					all_pos.sort()
 				}
-				if pos in h_escapes_pos {
-					end_idx, segment := decode_h_escape_single(string_so_far, segment_idx)
-					str_segments << segment
-					segment_idx = end_idx
+				for pos in all_pos {
+					str_segments << string_so_far[segment_idx..(pos - start)]
+					segment_idx = pos - start
+
+					if pos in u_escapes_pos {
+						end_idx, segment := s.decode_u_escape_single(string_so_far, segment_idx)
+						str_segments << segment
+						segment_idx = end_idx
+					}
+					if pos in h_escapes_pos {
+						end_idx, segment := decode_h_escape_single(string_so_far, segment_idx)
+						str_segments << segment
+						segment_idx = end_idx
+					}
 				}
 			}
 			if segment_idx < string_so_far.len {
 				str_segments << string_so_far[segment_idx..]
 			}
-
 			string_so_far = str_segments.join('')
 		}
 

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1236,34 +1236,34 @@ fn (mut s Scanner) ident_string() string {
 	}
 	if start <= s.pos {
 		mut string_so_far := s.text[start..end]
-    mut str_segments := []string{}
-    mut all_pos := u_escapes_pos.clone()
-    all_pos << h_escapes_pos
-    all_pos.sort()
+		mut str_segments := []string{}
+		mut all_pos := u_escapes_pos.clone()
+		all_pos << h_escapes_pos
+		all_pos.sort()
 
-    if !s.is_fmt {
-      mut segment_idx := 0
-      for pos in all_pos {
-        str_segments << string_so_far[segment_idx..(pos-start)]
-        segment_idx = pos-start
+		if !s.is_fmt {
+			mut segment_idx := 0
+			for pos in all_pos {
+				str_segments << string_so_far[segment_idx..(pos - start)]
+				segment_idx = pos - start
 
-        if pos in u_escapes_pos {
-          str_segments << s.decode_u_escape_single(string_so_far, segment_idx)
+				if pos in u_escapes_pos {
+					str_segments << s.decode_u_escape_single(string_so_far, segment_idx)
 
-          segment_idx += 6
-        }
-        if pos in h_escapes_pos {
-          str_segments << decode_h_escape_single(string_so_far, segment_idx)
+					segment_idx += 6
+				}
+				if pos in h_escapes_pos {
+					str_segments << decode_h_escape_single(string_so_far, segment_idx)
 
-          segment_idx += 4
-        }
-      }
-      if segment_idx < string_so_far.len {
-        str_segments << string_so_far[segment_idx..]
-      }
+					segment_idx += 4
+				}
+			}
+			if segment_idx < string_so_far.len {
+				str_segments << string_so_far[segment_idx..]
+			}
 
-      string_so_far = str_segments.join('')
-    }
+			string_so_far = str_segments.join('')
+		}
 
 		if n_cr_chars > 0 {
 			string_so_far = string_so_far.replace('\r', '')
@@ -1277,15 +1277,15 @@ fn (mut s Scanner) ident_string() string {
 	return lit
 }
 
-
 // TODO use multiple return values for `end_idx`
 // TODO add 4, 6 constants
 fn decode_h_escape_single(str string, idx int) string {
-  end_idx := idx + 4 // "\xXX".len == 4
+	end_idx := idx + 4 // "\xXX".len == 4
 
-  // notice this function doesn't do any decoding... it just replaces '\xc0' with the byte 0xc0
-  return [u8(strconv.parse_uint(str[idx + 2..end_idx], 16, 8) or { 0 })].bytestr()
+	// notice this function doesn't do any decoding... it just replaces '\xc0' with the byte 0xc0
+	return [u8(strconv.parse_uint(str[idx + 2..end_idx], 16, 8) or { 0 })].bytestr()
 }
+
 // only handle single-byte inline escapes like '\xc0'
 fn decode_h_escapes(s string, start int, escapes_pos []int) string {
 	if escapes_pos.len == 0 {
@@ -1295,7 +1295,7 @@ fn decode_h_escapes(s string, start int, escapes_pos []int) string {
 	ss << s[..escapes_pos.first() - start]
 	for i, pos in escapes_pos {
 		idx := pos - start
-    end_idx := idx +4
+		end_idx := idx + 4
 		ss << decode_h_escape_single(s, idx)
 
 		if i + 1 < escapes_pos.len {
@@ -1329,15 +1329,16 @@ fn decode_o_escapes(s string, start int, escapes_pos []int) string {
 }
 
 fn (mut s Scanner) decode_u_escape_single(str string, idx int) string {
-		end_idx := idx + 6 // "\uXXXX".len == 6
-		escaped_code_point := strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }
-		// Check if Escaped Code Point is invalid or not
-		if rune(escaped_code_point).length_in_bytes() == -1 {
-			s.error('invalid unicode point `$str`')
-		}
+	end_idx := idx + 6 // "\uXXXX".len == 6
+	escaped_code_point := strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }
+	// Check if Escaped Code Point is invalid or not
+	if rune(escaped_code_point).length_in_bytes() == -1 {
+		s.error('invalid unicode point `$str`')
+	}
 
-		return utf32_to_str(u32(escaped_code_point))
+	return utf32_to_str(u32(escaped_code_point))
 }
+
 // decode the flagged unicode escape sequences into their utf-8 bytes
 fn (mut s Scanner) decode_u_escapes(str string, start int, escapes_pos []int) string {
 	if escapes_pos.len == 0 {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1236,12 +1236,35 @@ fn (mut s Scanner) ident_string() string {
 	}
 	if start <= s.pos {
 		mut string_so_far := s.text[start..end]
-		if !s.is_fmt && u_escapes_pos.len > 0 {
-			string_so_far = s.decode_u_escapes(string_so_far, start, u_escapes_pos)
-		}
-		if !s.is_fmt && h_escapes_pos.len > 0 {
-			string_so_far = decode_h_escapes(string_so_far, start, h_escapes_pos)
-		}
+    mut str_segments := []string{}
+    mut all_pos := u_escapes_pos.clone()
+    all_pos << h_escapes_pos
+    all_pos.sort()
+
+    if !s.is_fmt {
+      mut segment_idx := 0
+      for pos in all_pos {
+        str_segments << string_so_far[segment_idx..(pos-start)]
+        segment_idx = pos-start
+
+        if pos in u_escapes_pos {
+          str_segments << s.decode_u_escape_single(string_so_far, segment_idx)
+
+          segment_idx += 6
+        }
+        if pos in h_escapes_pos {
+          str_segments << decode_h_escape_single(string_so_far, segment_idx)
+
+          segment_idx += 4
+        }
+      }
+      if segment_idx < string_so_far.len {
+        str_segments << string_so_far[segment_idx..]
+      }
+
+      string_so_far = str_segments.join('')
+    }
+
 		if n_cr_chars > 0 {
 			string_so_far = string_so_far.replace('\r', '')
 		}
@@ -1254,6 +1277,15 @@ fn (mut s Scanner) ident_string() string {
 	return lit
 }
 
+
+// TODO use multiple return values for `end_idx`
+// TODO add 4, 6 constants
+fn decode_h_escape_single(str string, idx int) string {
+  end_idx := idx + 4 // "\xXX".len == 4
+
+  // notice this function doesn't do any decoding... it just replaces '\xc0' with the byte 0xc0
+  return [u8(strconv.parse_uint(str[idx + 2..end_idx], 16, 8) or { 0 })].bytestr()
+}
 // only handle single-byte inline escapes like '\xc0'
 fn decode_h_escapes(s string, start int, escapes_pos []int) string {
 	if escapes_pos.len == 0 {
@@ -1263,9 +1295,9 @@ fn decode_h_escapes(s string, start int, escapes_pos []int) string {
 	ss << s[..escapes_pos.first() - start]
 	for i, pos in escapes_pos {
 		idx := pos - start
-		end_idx := idx + 4 // "\xXX".len == 4
-		// notice this function doesn't do any decoding... it just replaces '\xc0' with the byte 0xc0
-		ss << [u8(strconv.parse_uint(s[idx + 2..end_idx], 16, 8) or { 0 })].bytestr()
+    end_idx := idx +4
+		ss << decode_h_escape_single(s, idx)
+
 		if i + 1 < escapes_pos.len {
 			ss << s[end_idx..escapes_pos[i + 1] - start]
 		} else {
@@ -1296,6 +1328,16 @@ fn decode_o_escapes(s string, start int, escapes_pos []int) string {
 	return ss.join('')
 }
 
+fn (mut s Scanner) decode_u_escape_single(str string, idx int) string {
+		end_idx := idx + 6 // "\uXXXX".len == 6
+		escaped_code_point := strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }
+		// Check if Escaped Code Point is invalid or not
+		if rune(escaped_code_point).length_in_bytes() == -1 {
+			s.error('invalid unicode point `$str`')
+		}
+
+		return utf32_to_str(u32(escaped_code_point))
+}
 // decode the flagged unicode escape sequences into their utf-8 bytes
 fn (mut s Scanner) decode_u_escapes(str string, start int, escapes_pos []int) string {
 	if escapes_pos.len == 0 {
@@ -1306,12 +1348,7 @@ fn (mut s Scanner) decode_u_escapes(str string, start int, escapes_pos []int) st
 	for i, pos in escapes_pos {
 		idx := pos - start
 		end_idx := idx + 6 // "\uXXXX".len == 6
-		escaped_code_point := strconv.parse_uint(str[idx + 2..end_idx], 16, 32) or { 0 }
-		// Check if Escaped Code Point is invalid or not
-		if rune(escaped_code_point).length_in_bytes() == -1 {
-			s.error('invalid unicode point `$str`')
-		}
-		ss << utf32_to_str(u32(escaped_code_point))
+		ss << s.decode_u_escape_single(str, idx)
 		if i + 1 < escapes_pos.len {
 			ss << str[end_idx..escapes_pos[i + 1] - start]
 		} else {

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -234,6 +234,9 @@ fn test_escape_string() {
 	result = scan_tokens(r"'\u2605'")
 	assert result[0].kind == .string
 	assert result[0].lit == r'★'
+	result = scan_tokens(r"'H\u2605H'")
+	assert result[0].kind == .string
+	assert result[0].lit == r'H★H'
 
 	// STRING ESCAPED ASCII
 	result = scan_tokens(r"'\x61'")

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -257,6 +257,14 @@ fn test_escape_string() {
 	assert result[0].kind == .string
 	assert result[0].lit == r'★a'
 
+	// MIX STRING ESCAPES with offset
+	result = scan_tokens(r"'x  \x61\u2605\x61'")
+	assert result[0].kind == .string
+	assert result[0].lit == r'x  a★a'
+	result = scan_tokens(r"'x  \u2605\x61\u2605'")
+	assert result[0].kind == .string
+	assert result[0].lit == r'x  ★a★'
+
 	// SHOULD RESULT IN ERRORS
 	// result = scan_tokens(r'`\x61\x61`') // should always result in an error
 	// result = scan_tokens(r"'\x'") // should always result in an error

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -246,6 +246,14 @@ fn test_escape_string() {
 	assert result[0].kind == .string
 	assert result[0].lit.bytes() == [u8(0xe2), `9`, `8`, `8`, `5`]
 
+	// MIX STRING ESCAPES
+	result = scan_tokens(r"'\x61\u2605'")
+	assert result[0].kind == .string
+	assert result[0].lit == r'a★'
+	result = scan_tokens(r"'\u2605\x61'")
+	assert result[0].kind == .string
+	assert result[0].lit == r'★a'
+
 	// SHOULD RESULT IN ERRORS
 	// result = scan_tokens(r'`\x61\x61`') // should always result in an error
 	// result = scan_tokens(r"'\x'") // should always result in an error


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR fixes a bug in escape handling in scanner.

Presently `s.decode_u_escapes` may change `string_so_far` and thus invalidates positions stored in  `h_escapes_pos`. For example, for the string '\u2605\x61'

```
>>> '\u2605\x61'
V panic: substr(8, 10) out of bounds (len=7)
v hash: 69c9d47
/tmp/v_1000/v.7489314593549803884.tmp.c:19538: at _v_panic: Backtrace
/tmp/v_1000/v.7489314593549803884.tmp.c:22773: by string_substr
/tmp/v_1000/v.7489314593549803884.tmp.c:19872: by v__scanner__decode_h_escapes
/tmp/v_1000/v.7489314593549803884.tmp.c:19848: by v__scanner__Scanner_ident_string
/tmp/v_1000/v.7489314593549803884.tmp.c:19345: by v__scanner__Scanner_text_scan
```

Instead

```
>>> '\u2605\x61'
★a
```

This fix merges and sorts all escape pos and go through them in one pass avoid changing `string_so_far` in the middle.

Two helper functions are added to avoid duplicates.