### PR TITLE
net.websocket: swap unsafe use of nil for a safe default value

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -165,6 +165,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 			skip_files << 'examples/websocket/ping.v' // requires OpenSSL
 			skip_files << 'examples/websocket/client-server/client.v' // requires OpenSSL
 			skip_files << 'examples/websocket/client-server/server.v' // requires OpenSSL
+			skip_files << 'vlib/v/tests/websocket_logger_interface_should_compile_test.v' // requires OpenSSL
 			skip_files << 'examples/vweb_orm_jwt' // requires mysql
 			$if tinyc {
 				skip_files << 'examples/database/orm.v' // try fix it

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -135,9 +135,11 @@ const (
 		'vlib/net/websocket/websocket_test.v',
 		'vlib/crypto/rand/crypto_rand_read_test.v',
 		'vlib/net/smtp/smtp_test.v',
+		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/net/websocket/websocket_test.v',
+		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
 	]
 	skip_with_fsanitize_undefined = [
 		'do_not_remove',
@@ -184,6 +186,7 @@ const (
 		'vlib/net/http/response_test.v',
 		'vlib/builtin/js/array_test.js.v',
 		'vlib/net/smtp/smtp_test.v',
+		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
 	]
 	skip_on_linux                 = [
 		'do_not_remove',
@@ -214,6 +217,7 @@ const (
 		'vlib/sync/many_times_test.v',
 		'vlib/sync/once_test.v',
 		'vlib/net/smtp/smtp_test.v',
+		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
 	]
 	skip_on_non_windows           = [
 		'do_not_remove',

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -38,7 +38,8 @@ pub mut:
 	nonce_size        int = 16 // size of nounce used for masking
 	panic_on_callback bool        // set to true of callbacks can panic
 	state             State       // current state of connection
-	logger            &log.Logger = unsafe { nil } // logger used to log messages
+	// logger            &log.Logger = unsafe { nil } // logger used to log messages
+	logger            &log.Logger = &log.Logger(&log.Log{level: .info}) // logger used to log messages
 	resource_name     string      // name of current resource
 	last_pong_ut      i64 // last time in unix time we got a pong message
 }

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -39,7 +39,7 @@ pub mut:
 	panic_on_callback bool  // set to true of callbacks can panic
 	state             State // current state of connection
 	// logger used to log messages
-	logger            &log.Logger = &log.Logger(&log.Log{
+	logger &log.Logger = &log.Logger(&log.Log{
 	level: .info
 })
 	resource_name string // name of current resource

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -36,11 +36,14 @@ pub mut:
 	header            http.Header  // headers that will be passed when connecting
 	conn              &net.TcpConn = unsafe { nil } // underlying TCP socket connection
 	nonce_size        int = 16 // size of nounce used for masking
-	panic_on_callback bool        // set to true of callbacks can panic
-	state             State       // current state of connection
-	logger            &log.Logger = &log.Logger(&log.Log{level: .info}) // logger used to log messages
-	resource_name     string      // name of current resource
-	last_pong_ut      i64 // last time in unix time we got a pong message
+	panic_on_callback bool  // set to true of callbacks can panic
+	state             State // current state of connection
+	// logger used to log messages
+	logger            &log.Logger = &log.Logger(&log.Log{
+	level: .info
+})
+	resource_name string // name of current resource
+	last_pong_ut  i64    // last time in unix time we got a pong message
 }
 
 // Flag represents different types of headers in websocket handshake

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -38,7 +38,6 @@ pub mut:
 	nonce_size        int = 16 // size of nounce used for masking
 	panic_on_callback bool        // set to true of callbacks can panic
 	state             State       // current state of connection
-	// logger            &log.Logger = unsafe { nil } // logger used to log messages
 	logger            &log.Logger = &log.Logger(&log.Log{level: .info}) // logger used to log messages
 	resource_name     string      // name of current resource
 	last_pong_ut      i64 // last time in unix time we got a pong message

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -9,7 +9,9 @@ import rand
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	logger                  &log.Logger = &log.Logger(&log.Log{level: .info})
+	logger &log.Logger = &log.Logger(&log.Log{
+	level: .info
+})
 	ls                      &net.TcpListener = unsafe { nil } // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions
 	message_callbacks       []MessageEventHandler // new message callback functions

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -9,7 +9,8 @@ import rand
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	logger                  &log.Logger      = unsafe { nil } // logger used to log
+	// logger                  &log.Logger      = unsafe { nil } // logger used to log
+	logger                  &log.Logger = &log.Logger(&log.Log{level: .info})
 	ls                      &net.TcpListener = unsafe { nil } // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions
 	message_callbacks       []MessageEventHandler // new message callback functions

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -9,7 +9,6 @@ import rand
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	// logger                  &log.Logger      = unsafe { nil } // logger used to log
 	logger                  &log.Logger = &log.Logger(&log.Log{level: .info})
 	ls                      &net.TcpListener = unsafe { nil } // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions

--- a/vlib/v/tests/websocket_logger_interface_should_compile_test.v
+++ b/vlib/v/tests/websocket_logger_interface_should_compile_test.v
@@ -1,0 +1,68 @@
+import net.websocket as ws
+
+pub type RawMessage = ws.Message
+
+pub struct WsTransport {
+pub mut:
+	ws ws.Client
+}
+
+struct WsClient {
+pub mut:
+	transport Transport
+}
+
+pub interface Transport {
+	send()
+	wait()
+}
+
+fn (wst WsTransport) send() {
+	println('send is called')
+}
+
+fn (wst WsTransport) wait() {
+	println('wait is called')
+}
+
+pub fn new_ws_client(transport Transport) ?WsClient {
+	return WsClient{
+		transport: transport
+	}
+}
+
+fn server() ? {
+	mut s := ws.new_server(.ip6, 8081, '/')
+
+	s.on_connect(fn (mut s ws.ServerClient) ?bool {
+		if s.resource_name != '/' {
+			return false
+		}
+		println('Client has connected...')
+		return true
+	})?
+
+	s.on_message(fn (mut ws ws.Client, msg &RawMessage) ? {
+		mut transport := WsTransport{}
+		mut ws_client := new_ws_client(transport)?
+		_ := ws_client
+	})
+
+	s.on_close(fn (mut ws ws.Client, code int, reason string) ? {
+		println('client ($ws.id) closed connection')
+	})
+
+	s.listen() or { println('error on server listen: $err') }
+
+	unsafe {
+		s.free()
+	}
+}
+
+fn abc() ? {
+	server()?
+}
+
+fn test_compilation_of_the_example_code_in_issue_15839() {
+	assert true
+}


### PR DESCRIPTION
Removed a use of `unsafe { nil }` from the net.websocket module due to it causing edge case errors where the V compiler generated C code that tried to use a non-existent function that converted an integer to the log.Logger interface.

The value I replaced this with (in both cases as it was effectively the same code) was `&log.Logger(&log.Log{level: .info})` since that is the default value supplied by the ServerOpt and ClientOpt structs when the initiate the struct of which was edited.

Here's the ServerOpt struct for proof:
`[params]
pub struct ServerOpt {
	logger &log.Logger = &log.Logger(&log.Log{
	level: .info
})
}`