### PR TITLE
cgen: fix reference embed method call (fix #15831)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1086,6 +1086,16 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write('(map[]){')
 			g.expr(node.left)
 			g.write('}[0]')
+		} else if node.from_embed_types.len > 0 {
+			n_ptr := node.left_type.nr_muls() - 1
+			if n_ptr > 0 {
+				g.write('(')
+				g.write('*'.repeat(n_ptr))
+				g.expr(node.left)
+				g.write(')')
+			} else {
+				g.expr(node.left)
+			}
 		} else {
 			g.expr(node.left)
 		}

--- a/vlib/v/tests/embed_method_call_test.v
+++ b/vlib/v/tests/embed_method_call_test.v
@@ -1,0 +1,23 @@
+struct Access {}
+
+fn (access &Access) acc() bool {
+	return true
+}
+
+struct Field {
+	Access
+}
+
+fn test_embed_method_call() {
+	mut fields := []&Field{}
+	fields << &Field{}
+
+	mut rets := []bool{}
+	for mut field in fields {
+		println(field.acc())
+		rets << field.acc()
+	}
+
+	assert rets.len == 1
+	assert rets[0]
+}


### PR DESCRIPTION
This PR fix reference embed method call (fix #15831).

- Fix reference embed method call.
- Add test.

```v
struct Access {}

fn (access &Access) acc() bool {
	return true
}

struct Field {
	Access
}

fn main() {
	mut fields := []&Field{}
	fields << &Field{}

	mut rets := []bool{}
	for mut field in fields {
		println(field.acc())
		rets << field.acc()
	}

	assert rets.len == 1
	assert rets[0]
}

PS D:\Test\v\tt1> v run .
true
```