### PR TITLE
sync: fix C.pthread_mutex_t struct typedef is missing in darwin (fix: #15491)

### DIFF
--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -30,6 +30,18 @@ fn C.pthread_cond_wait(voidptr, voidptr) int
 fn C.pthread_cond_timedwait(voidptr, voidptr, voidptr) int
 fn C.pthread_cond_destroy(voidptr) int
 
+[typedef]
+struct C.pthread_mutex_t {}
+
+[typedef]
+struct C.pthread_rwlock_t {}
+
+[typedef]
+struct C.pthread_rwlockattr_t {}
+
+[typedef]
+struct C.sem_t {}
+
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 [heap]
 pub struct Mutex {

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -1,3 +1,5 @@
+import sync
+
 fn test_array_of_floats() {
 	// f64 array
 	aa := [1.2, 3.4, 5.67]
@@ -443,4 +445,19 @@ fn test_fixed_array_of_function() {
 	a := [println, println]!
 	println(a)
 	assert '$a' == '[fn (string), fn (string)]'
+}
+
+struct CTypeDefStruct {
+	mutex &sync.Mutex
+}
+
+fn test_c_struct_typedef() {
+	c := CTypeDefStruct{
+		mutex: sync.new_mutex()
+	}
+	assert c.str() == r'CTypeDefStruct{
+    mutex: &sync.Mutex{
+        mutex: pthread_mutex_t{}
+    }
+}'
 }

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -452,12 +452,14 @@ struct CTypeDefStruct {
 }
 
 fn test_c_struct_typedef() {
-	c := CTypeDefStruct{
-		mutex: sync.new_mutex()
-	}
-	assert c.str() == r'CTypeDefStruct{
+	$if macos || linux {
+		c := CTypeDefStruct{
+			mutex: sync.new_mutex()
+		}
+		assert c.str() == r'CTypeDefStruct{
     mutex: &sync.Mutex{
         mutex: pthread_mutex_t{}
     }
 }'
+	}
 }


### PR DESCRIPTION
1. Fix #15491 
2. Add test.

```v
import sync

struct Foo {
	mutex &sync.Mutex
}

fn main() {
	foo := Foo{
		mutex: sync.new_mutex()
	}
	println(foo)
}
```

output:

```
Foo{
    mutex: &sync.Mutex{
        mutex: pthread_mutex_t{}
    }
}
```