### PR TITLE
cgen: fix const expr using optional or result

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -128,7 +128,7 @@ mut:
 	inside_comptime_for_field bool
 	inside_cast_in_heap       int // inside cast to interface type in heap (resolve recursive calls)
 	inside_const              bool
-	inside_const_optional     bool
+	inside_const_opt_or_res   bool
 	inside_lambda             bool
 	loop_depth                int
 	ternary_names             map[string]string
@@ -4570,14 +4570,15 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 				}
 			}
 			ast.CallExpr {
-				if field.expr.return_type.has_flag(.optional) {
-					g.inside_const_optional = true
-					unwrap_option := field.expr.or_block.kind != .absent
-					g.const_decl_init_later(field.mod, name, field.expr, field.typ, unwrap_option)
+				if field.expr.return_type.has_flag(.optional)
+					|| field.expr.return_type.has_flag(.result) {
+					g.inside_const_opt_or_res = true
+					unwrap_opt_res := field.expr.or_block.kind != .absent
+					g.const_decl_init_later(field.mod, name, field.expr, field.typ, unwrap_opt_res)
 				} else {
 					g.const_decl_init_later(field.mod, name, field.expr, field.typ, false)
 				}
-				g.inside_const_optional = false
+				g.inside_const_opt_or_res = false
 			}
 			else {
 				// Note: -usecache uses prebuilt modules, each compiled with:

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -671,7 +671,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		if unwrapped_typ == ast.void_type {
 			g.write('\n $cur_line')
 		} else {
-			if !g.inside_const_optional {
+			if !g.inside_const_opt_or_res {
 				g.write('\n $cur_line (*($unwrapped_styp*)${tmp_opt}.data)')
 			} else {
 				g.write('\n $cur_line $tmp_opt')

--- a/vlib/v/tests/const_can_use_optionals_results_test.v
+++ b/vlib/v/tests/const_can_use_optionals_results_test.v
@@ -1,13 +1,13 @@
 const (
 	aaa = iopt()?
-	bbb = sopt()?
+	bbb = sopt()!
 )
 
 fn iopt() ?int {
 	return 1234
 }
 
-fn sopt() ?string {
+fn sopt() !string {
 	return 'xyz'
 }
 


### PR DESCRIPTION
This PR fix const expr using optional or result.

- Fix const expr using optional or result.
- Add test.

```v
const (
	aaa = iopt()?
	bbb = sopt()!
)

fn iopt() ?int {
	return 1234
}

fn sopt() !string {
	return 'xyz'
}

fn main() {
	z1 := aaa
	println(z1)
	assert z1 == 1234

	z2 := bbb
	println(z2)
	assert z2 == 'xyz'
}

PS D:\Test\v\tt1> v run .
1234
xyz
```