### PR TITLE
parser: fix line number error of comptime atExpr in the last token of the line (fix: #15672)

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -329,12 +329,13 @@ fn (mut p Parser) at() ast.AtExpr {
 		'@VROOT' { token.AtKind.vroot_path } // deprecated, use @VEXEROOT or @VMODROOT
 		else { token.AtKind.unknown }
 	}
-	p.next()
-	return ast.AtExpr{
+	expr := ast.AtExpr{
 		name: name
 		pos: p.tok.pos()
 		kind: kind
 	}
+	p.next()
+	return expr
 }
 
 fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {

--- a/vlib/v/tests/comptime_at_test.v
+++ b/vlib/v/tests/comptime_at_test.v
@@ -126,3 +126,11 @@ fn test_vmod_file() {
 fn test_comptime_at() {
 	assert @VEXE == pref.vexe_path()
 }
+
+// Reasons for assertions that are not literal:
+// to prevent assertion invalidation due to "line" changes in subsequent code changes
+fn test_line_number_last_token() {
+	line1, line2, line3 := @LINE, @LINE, @LINE
+	assert line1 == line2
+	assert line1 == line3
+}


### PR DESCRIPTION
1. Fix: #15672 
2. Add test.

```v
fn main() {
	line1, line2, line3 := @LINE, @LINE, @LINE
	dump(line1)
	dump(line2)
	dump(line3)
}
```

output:

```
[vlib/v/parser/tests/comptime_at_last_token_line_number.vv:3] line1: 2
[vlib/v/parser/tests/comptime_at_last_token_line_number.vv:4] line2: 2
[vlib/v/parser/tests/comptime_at_last_token_line_number.vv:5] line3: 2
```