### PR TITLE
os: fixes issue #15852

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -122,7 +122,7 @@ fn C.chdir(path &char) int
 
 fn C.rewind(stream &C.FILE) int
 
-fn C.ftell(&C.FILE) int
+fn C.ftell(&C.FILE) isize
 
 fn C.stat(&char, voidptr) int
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -893,3 +893,36 @@ fn test_command() {
 	// dump( cmd_to_fail )
 	assert cmd_to_fail.exit_code != 0 // 2 on linux, 1 on macos
 }
+
+fn test_reading_from_proc_cpuinfo() {
+	// This test is only for plain linux systems (they have a /proc virtual filesystem).
+	$if android {
+		assert true
+		return
+	}
+	$if !linux {
+		assert true
+		return
+	}
+	info := os.read_file('/proc/cpuinfo')?
+	assert info.len > 0
+	assert info.contains('processor')
+	assert info.ends_with('\n\n')
+
+	info_bytes := os.read_bytes('/proc/cpuinfo')?
+	assert info_bytes.len > 0
+	assert info.len == info_bytes.len
+}
+
+fn test_reading_from_empty_file() {
+	empty_file := os.join_path_single(tfolder, 'empty_file.txt')
+	os.rm(empty_file) or {}
+	assert !os.exists(empty_file)
+	os.write_file(empty_file, '')?
+	assert os.exists(empty_file)
+	content := os.read_file(empty_file)?
+	assert content.len == 0
+	content_bytes := os.read_bytes(empty_file)?
+	assert content_bytes.len == 0
+	os.rm(empty_file)?
+}

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -47,7 +47,7 @@ fn test_open_file() {
 	os.rm(filename) or { panic(err) }
 }
 
-fn test_readfile_from_virtual_filesystem() {
+fn test_read_file_from_virtual_filesystem() {
 	$if linux {
 		mounts := os.read_file('/proc/mounts')?
 

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -47,6 +47,29 @@ fn test_open_file() {
 	os.rm(filename) or { panic(err) }
 }
 
+fn test_readfile_from_virtual_filesystem() {
+	$if linux {
+		mounts := os.read_file('/proc/mounts')?
+
+		// it is not empty, contains some mounting such as root filesystem: /dev/x / ext4 rw 0 0
+		assert mounts.len > 20
+		assert mounts.contains('/')
+		assert mounts.contains(' ')
+	}
+}
+
+fn test_read_binary_from_virtual_filesystem() {
+	$if linux {
+		mounts_raw := os.read_bytes('/proc/mounts')?
+		mounts := mounts_raw.bytestr()
+
+		// it is not empty, contains some mounting such as root filesystem: /dev/x / ext4 rw 0 0
+		assert mounts.len > 20
+		assert mounts.contains('/')
+		assert mounts.contains(' ')
+	}
+}
+
 fn test_open_file_binary() {
 	filename := './test1.dat'
 	hello := 'hello \n world!'

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -16,6 +16,17 @@ pub fn new_builder(initial_size int) Builder {
 	return res
 }
 
+// reuse_as_plain_u8_array allows using the Builder instance as a plain []u8 return value.
+// It is useful, when you have accumulated data in the builder, that you want to
+// pass/access as []u8 later, without copying or freeing the buffer.
+// NB: you *should NOT use* the string builder instance after calling this method.
+// Use only the return value after calling this method.
+[unsafe]
+pub fn (mut b Builder) reuse_as_plain_u8_array() []u8 {
+	unsafe { b.flags.clear(.noslices) }
+	return *b
+}
+
 // write_ptr writes `len` bytes provided byteptr to the accumulated buffer
 [unsafe]
 pub fn (mut b Builder) write_ptr(ptr &u8, len int) {


### PR DESCRIPTION
os.read_text and os.read_bytes rely on file size returned by ftell. Virtual filesystems such as /proc on Linux return zero size. It prevents both functions to read anything from those files. I've added extra case that when size is zero it attempts to read 4096 bytes instead. Now both functions are able to read /proc entries.

I didn't add test as I'm not sure if e.g. /proc/mounts is available in your CI environment. Should I assume it is?
