### PR TITLE
cgen: fix array appending when array is used as fn parameter (fix: #15855)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -722,7 +722,11 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			if node.left_type.has_flag(.shared_f) {
 				g.write('->val')
 			}
-			g.write(', (')
+			if left.typ.is_ptr() && right.typ.is_ptr() {
+				g.write(', *(')
+			} else {
+				g.write(', (')
+			}
 			g.expr_with_cast(node.right, node.right_type, left.unaliased.clear_flag(.shared_f))
 			styp := g.typ(expected_push_many_atype)
 			g.write('), $tmp_var, $styp)')

--- a/vlib/v/tests/array_test.v
+++ b/vlib/v/tests/array_test.v
@@ -25,3 +25,29 @@ fn test_fixed_array_to_dynamic_array() {
 	x << 4
 	assert x.len == 4
 }
+
+fn test_append_array_used_as_fn_param() {
+	mut arr1 := [][]string{}
+	mut arr2 := [][]string{}
+	mut arr3 := []string{}
+	arr4 := []string{}
+	arr1 << arr2
+	arr1 << arr3
+	arr3 << arr4
+	append_2d_2d(mut arr1, arr2)
+	append_2d_1d(mut arr1, arr3)
+	append_1d_1d(mut arr3, arr4)
+	assert true
+}
+
+fn append_2d_2d(mut arr1 [][]string, arr2 [][]string) {
+	arr1 << arr2
+}
+
+fn append_2d_1d(mut arr1 [][]string, arr2 []string) {
+	arr1 << arr2
+}
+
+fn append_1d_1d(mut arr1 []string, arr2 []string) {
+	arr1 << arr2
+}


### PR DESCRIPTION
1. Fix #15855 
2. Add test.

```v
fn main() {
	mut arr1 := [][]string{}
	mut arr2 := [][]string{}
	mut arr3 := []string{}
	arr4 := []string{}
	arr1 << arr2
	arr1 << arr3
	arr3 << arr4
	append_2d_2d(mut arr1, arr2)
	append_2d_1d(mut arr1, arr3)
	append_1d_1d(mut arr3, arr4)
	assert true
}

fn append_2d_2d(mut arr1 [][]string, arr2 [][]string) {
	arr1 << arr2
}

fn append_2d_1d(mut arr1 [][]string, arr2 []string) {
	arr1 << arr2
}

fn append_1d_1d(mut arr1 []string, arr2 []string) {
	arr1 << arr2
}
```

output:

```
nothing, passed
```