### PR TITLE
os: fix file.read() (fix #15513)

### DIFF
--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -144,7 +144,7 @@ fn test_read_eof_last_read_partial_buffer_fill() {
 		assert false
 	} else {
 		// Expected an error when received end-of-file.
-		assert err !is none
+		assert err == IError(os.Eof{})
 	}
 	f.close()
 }
@@ -176,7 +176,7 @@ fn test_read_eof_last_read_full_buffer_fill() {
 		assert false
 	} else {
 		// Expect an error at EOF.
-		assert err !is none
+		assert err == IError(os.Eof{})
 	}
 	f.close()
 }


### PR DESCRIPTION
This PR fix file.read() (fix #15513).

- Change file.read(), return `IError(Eof{})` when end of file. It always return `NotExpected` before.
- Change test.

```v
import os

fn slurp(path string) !string {
	mut result := []u8{}
	mut buffer := []u8{len: 4096}
	mut f := os.open(path) or { return err }
	defer {
		f.close()
	}
	for {
		len := f.read(mut buffer) or {
			if err == IError(os.Eof{}) {
				break
			}
			return err
		}
		result << buffer[0..len]
	}
	return result.bytestr()
}

fn main() {
	println(slurp(@FILE)!)
}

PS D:\Test\v\tt1> v run .
import os

fn slurp(path string) !string {
        mut result := []u8{}
        mut buffer := []u8{len: 4096}
        mut f := os.open(path) or { return err }
        defer {
                f.close()
        }
        for {
                len := f.read(mut buffer) or {
                        if err == IError(os.Eof{}) {
                                break
                        }
                        return err
                }
                result << buffer[0..len]
        }
        return result.bytestr()
}

fn main() {
        println(slurp(@FILE)!)
}
```