### PR TITLE
native: add printing support for boolean and string variables

### DIFF
--- a/vlib/v/gen/native/builtins.v
+++ b/vlib/v/gen/native/builtins.v
@@ -24,6 +24,12 @@ pub fn (mut g Gen) init_builtins() {
 			}
 			arg_regs: [.rcx, .rdi]
 		}
+		'bool_to_string': BuiltinFn{
+			body: fn (builtin BuiltinFn, mut g Gen) {
+				g.convert_bool_to_string(builtin.arg_regs[0])
+			}
+			arg_regs: [.rax]
+		}
 		'reverse_string': BuiltinFn{
 			body: fn (builtin BuiltinFn, mut g Gen) {
 				g.reverse_string(builtin.arg_regs[0])

--- a/vlib/v/gen/native/tests/print.vv
+++ b/vlib/v/gen/native/tests/print.vv
@@ -30,6 +30,8 @@ fn test_stderr() {
 }
 
 fn test_idents() {
+	// signed integer
+	
 	x := 0
 	println(x)
 
@@ -44,6 +46,22 @@ fn test_idents() {
 
 	b := -456
 	println(b)
+
+	// booleans
+
+	bool_true := true
+	println(bool_true)
+
+	bool_false := false
+	println(bool_false)
+
+	// strings
+
+	str := 'string blah blah blah'
+	println(str)
+
+	unicode := '😀😆😎💻🌎'
+	println(unicode)
 }
 
 fn main() {

--- a/vlib/v/gen/native/tests/print.vv.out
+++ b/vlib/v/gen/native/tests/print.vv.out
@@ -8,3 +8,7 @@ Hello World
 -8
 123
 -456
+true
+false
+string blah blah blah
+😀😆😎💻🌎


### PR DESCRIPTION
This PR adds support for printing `bool` and `string` -typed identifiers for the native backend.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
