### PR TITLE
docs.md: document [noinit] attribute with example

### DIFF
--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -541,6 +541,16 @@ fn (mut f MDFile) check_examples() CheckResult {
 					}
 					oks++
 				}
+				'okfmt' {
+					if fmt_res != 0 {
+						eprintln(eline(f.path, e.sline, 0, 'okfmt example is not formatted'))
+						eprintln(vcontent)
+						should_cleanup_vfile = false
+						errors++
+						continue
+					}
+					oks++
+				}
 				'badsyntax' {
 					res := silent_cmdexecute('${os.quoted_path(vexe)} -w -Wfatal-errors -check-syntax ${os.quoted_path(vfile)}')
 					if res == 0 {
@@ -554,7 +564,7 @@ fn (mut f MDFile) check_examples() CheckResult {
 				}
 				'nofmt' {}
 				else {
-					eprintln(eline(f.path, e.sline, 0, 'unrecognized command: "$command", use one of: wip/ignore/compile/cgen/failcompile/oksyntax/badsyntax/nofmt'))
+					eprintln(eline(f.path, e.sline, 0, 'unrecognized command: "$command", use one of: wip/ignore/compile/cgen/failcompile/okfmt/oksyntax/badsyntax/nofmt'))
 					should_cleanup_vfile = false
 					errors++
 				}

--- a/cmd/v/help/check-md.txt
+++ b/cmd/v/help/check-md.txt
@@ -17,7 +17,8 @@ These are:
 	live         - Compile hot reload examples with the ´-live´ flag set and verify formatting.
 	ignore       - Ignore the example, useful for examples that just use the syntax highlighting
 	failcompile  - Known failing compilation. Useful for examples demonstrating compiler errors.
-	oksyntax     - Should parse and be formatted but may not compile. Useful for partial examples.
-	badsyntax    - Known bad syntax, it should not even parse.
+	okfmt        - Should only be formatted, but it can refer to invalid modules, missing functions etc. Useful for partial examples.
+	oksyntax     - Should parse, and be formatted, but may not compile. Useful for partial examples.
+	badsyntax    - Known bad syntax, it should NOT even parse.
 	wip          - Like ignore; a planned feature; easy to search.
 	nofmt        - Disable fmt verification for individual code blocks.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2170,7 +2170,7 @@ Note that `new_information` is a _factory_ function. Now when we want to make us
 outside the module:
 
 ```v oksyntax
-// ... Imports and stuff ...
+import sample
 
 fn main() {
 	// This doesn't work when the [noinit] attribute is present:

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2147,7 +2147,7 @@ through _factory functions_.
 
 For an example, consider the following source in a directory `sample`:
 
-```v oksyntax
+```v ignore
 module sample
 
 [noinit]

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -139,7 +139,7 @@ To do so, run the command `v up`.
 
 <!--
 NB: there are several special keywords, which you can put after the code fences for v:
-compile, cgen, live, ignore, failcompile, oksyntax, badsyntax, wip, nofmt
+compile, cgen, live, ignore, failcompile, okfmt, oksyntax, badsyntax, wip, nofmt
 For more details, do: `v check-md`
 -->
 
@@ -2147,7 +2147,7 @@ through _factory functions_.
 
 For an example, consider the following source in a directory `sample`:
 
-```v ignore
+```v oksyntax
 module sample
 
 [noinit]
@@ -2169,7 +2169,7 @@ pub fn new_information(data string) !Information {
 Note that `new_information` is a _factory_ function. Now when we want to use this struct
 outside the module:
 
-```v oksyntax
+```v okfmt
 import sample
 
 fn main() {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2139,6 +2139,52 @@ assert book.author.name == 'Samantha Black'
 assert book.author.age == 24
 ```
 
+### `[noinit]` structs
+
+V supports `[noinit]` structs, which are structs that cannot be initialised outside the module
+they are defined in. They are either meant to be used internally or they can be used externally
+through _factory functions_.
+
+For an example, consider the following source in a directory `sample`:
+
+```v oksyntax
+module sample
+
+[noinit]
+pub struct Information {
+pub:
+	data string
+}
+
+pub fn new_information(data string) !Information {
+	if data.len == 0 || data.len > 100 {
+		return error('data must be between 1 and 100 characters')
+	}
+	return Information{
+		data: data
+	}
+}
+```
+
+Note that `new_information` is a _factory_ function. Now when we want to make use of this struct
+outside the module:
+
+```v oksyntax
+// ... Imports and stuff ...
+
+fn main() {
+	// This doesn't work when the [noinit] attribute is present:
+	// info := sample.Information{
+	// 	data: 'Sample information.'
+	// }
+
+	// Use this instead:
+	info := sample.new_information('Sample information.')!
+
+	println(info)
+}
+```
+
 ### Methods
 
 ```v

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2166,7 +2166,7 @@ pub fn new_information(data string) !Information {
 }
 ```
 
-Note that `new_information` is a _factory_ function. Now when we want to make use of this struct
+Note that `new_information` is a _factory_ function. Now when we want to use this struct
 outside the module:
 
 ```v oksyntax


### PR DESCRIPTION
- Documents the `[noinit]` attribute for structs.
- Closes https://github.com/vlang/v/issues/15655