### PR TITLE
fmt: fix fmt removes attrs for embedded structs (fix #15848)

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -630,6 +630,7 @@ fn (t Tree) embed(node ast.Embed) &Node {
 	obj.add_terse('typ', t.type_node(node.typ))
 	obj.add('pos', t.pos(node.pos))
 	obj.add('comments', t.array_node_comment(node.comments))
+	obj.add('attr', t.array_node_attr(node.attrs))
 	return obj
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -379,6 +379,8 @@ pub:
 	typ      Type
 	pos      token.Pos
 	comments []Comment
+pub mut:
+	attrs []Attr
 }
 
 pub struct InterfaceEmbedding {

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -63,12 +63,17 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 
 		pre_comments := embed.comments.filter(it.pos.pos < embed.pos.pos)
 		comments := embed.comments[pre_comments.len..]
-
 		f.comments_before_field(pre_comments)
+		f.write('\t$styp')
+
+		has_attrs := embed.attrs.len > 0
+		if has_attrs {
+			f.single_line_attrs(embed.attrs, inline: true)
+		}
+
 		if comments.len == 0 {
-			f.writeln('\t$styp')
+			f.writeln('')
 		} else {
-			f.write('\t$styp')
 			f.comments(comments, level: .indent)
 		}
 	}

--- a/vlib/v/fmt/tests/struct_embed_keep.vv
+++ b/vlib/v/fmt/tests/struct_embed_keep.vv
@@ -18,3 +18,15 @@ struct Baz {
 	Foo // Another comment for Foo
 	Test
 }
+
+struct Size {
+	width int
+}
+
+struct Button {
+	// embedds
+	Size [json: size]
+	// fields
+	a  int [json: a]
+	bb int [json: b]
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -302,6 +302,8 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					is_deprecated: is_field_deprecated
 					anon_struct_decl: anon_struct_decl
 				}
+			} else {
+				embeds[embeds.len - 1].attrs = p.attrs
 			}
 			// save embeds as table fields too, it will be used in generation phase
 			fields << ast.StructField{


### PR DESCRIPTION
1. Fix #15848 
2. Add test.

```v
struct Size {
	width int
}

struct Button {
	Size [json: size] // attrs is reserved
}
```

v fmt -w:
```v
struct Size {
	width int
}

struct Button {
	Size [json: size] // attrs is reserved
}
```
