### PR TITLE
parser: check undefined variable in if guard (fix #15880)

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -200,6 +200,9 @@ fn (mut p Parser) check_undefined_variables_by_names(names []string, val ast.Exp
 		ast.PrefixExpr {
 			p.check_undefined_variables_by_names(names, val.right)?
 		}
+		ast.SelectorExpr {
+			p.check_undefined_variables_by_names(names, val.expr)?
+		}
 		ast.StringInterLiteral {
 			for expr_ in val.exprs {
 				p.check_undefined_variables_by_names(names, expr_)?

--- a/vlib/v/parser/tests/if_guard_undefined_variable_err.out
+++ b/vlib/v/parser/tests/if_guard_undefined_variable_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/if_guard_undefined_variable_err.vv:4:10: error: undefined variable: `f`
+    2 |
+    3 | fn main() {
+    4 |     if f := f.g.x() {
+      |             ^
+    5 |     }
+    6 | }

--- a/vlib/v/parser/tests/if_guard_undefined_variable_err.vv
+++ b/vlib/v/parser/tests/if_guard_undefined_variable_err.vv
@@ -1,0 +1,6 @@
+module main
+
+fn main() {
+	if f := f.g.x() {
+	}
+}


### PR DESCRIPTION
This PR check undefined variable in if guard (fix #15880).

- Check undefined variable in if guard.
- Add test.

```v
module main

fn main() {
	if f := f.g.x() {
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:4:10: error: undefined variable: `f`
    2 |
    3 | fn main() {
    4 |     if f := f.g.x() {
      |             ^
    5 |     }
    6 | }
```