### PR TITLE
cgen: fix dumping c structs (fix #15878)

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -12,7 +12,11 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		g.expr(node.expr)
 		return
 	}
-	dump_fn_name := '_v_dump_expr_$node.cname' + (if node.expr_type.is_ptr() { '_ptr' } else { '' })
+	mut name := node.cname
+	if g.table.sym(node.expr_type).language == .c {
+		name = name[3..]
+	}
+	dump_fn_name := '_v_dump_expr_$name' + (if node.expr_type.is_ptr() { '_ptr' } else { '' })
 	g.write(' ${dump_fn_name}(${ctoslit(fpath)}, $line, $sexpr, ')
 	if node.expr_type.has_flag(.shared_f) {
 		g.write('&')
@@ -21,7 +25,7 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 	} else {
 		g.expr(node.expr)
 	}
-	g.write(' )')
+	g.write(')')
 }
 
 fn (mut g Gen) dump_expr_definitions() {
@@ -30,22 +34,26 @@ fn (mut g Gen) dump_expr_definitions() {
 	mut dump_fn_defs := strings.new_builder(100)
 	for dump_type, cname in g.table.dumps {
 		dump_sym := g.table.sym(dump_type)
+		mut name := cname
+		if dump_sym.language == .c {
+			name = name[3..]
+		}
 		_, str_method_expects_ptr, _ := dump_sym.str_method_info()
 		is_ptr := ast.Type(dump_type).is_ptr()
 		deref, _ := deref_kind(str_method_expects_ptr, is_ptr, dump_type)
 		to_string_fn_name := g.get_str_fn(ast.Type(dump_type).clear_flag(.shared_f))
 		ptr_asterisk := if is_ptr { '*' } else { '' }
-		mut str_dumparg_type := '$cname$ptr_asterisk'
+		mut str_dumparg_type := g.cc_type(dump_type, true) + ptr_asterisk
 		if dump_sym.kind == .function {
 			fninfo := dump_sym.info as ast.FnType
-			str_dumparg_type = 'DumpFNType_$cname'
+			str_dumparg_type = 'DumpFNType_$name'
 			tdef_pos := g.out.len
 			g.write_fn_ptr_decl(&fninfo, str_dumparg_type)
 			str_tdef := g.out.after(tdef_pos)
 			g.out.go_back(str_tdef.len)
 			dump_typedefs['typedef $str_tdef;'] = true
 		}
-		dump_fn_name := '_v_dump_expr_$cname' + (if is_ptr { '_ptr' } else { '' })
+		dump_fn_name := '_v_dump_expr_$name' + (if is_ptr { '_ptr' } else { '' })
 		dump_fn_defs.writeln('$str_dumparg_type ${dump_fn_name}(string fpath, int line, string sexpr, $str_dumparg_type dump_arg);')
 		if g.writeln_fn_header('$str_dumparg_type ${dump_fn_name}(string fpath, int line, string sexpr, $str_dumparg_type dump_arg)', mut
 			dump_fns)

--- a/vlib/v/tests/dump_c_structs/dump_c_struct_test.v
+++ b/vlib/v/tests/dump_c_structs/dump_c_struct_test.v
@@ -1,0 +1,34 @@
+#include "@VMODROOT/epoll.h"
+
+pub struct C.epoll_event {
+mut:
+	events u32
+	data   C.epoll_data_t
+}
+
+[typedef]
+pub union C.epoll_data_t {
+mut:
+	ptr voidptr
+	fd  int
+	u32 u32
+	u64 u64
+}
+
+struct Epoll{
+	ev C.epoll_event
+}
+
+fn test_dump_c_struct(){
+	ev := C.epoll_event{}
+	unsafe{ C.memset(&ev, 0, sizeof(ev))}
+	dump(ev)
+	println(ev)
+
+	e := Epoll{
+		ev: C.epoll_event{}
+	}
+	dump(e)
+	println(e)
+	assert true
+}

--- a/vlib/v/tests/dump_c_structs/dump_c_struct_test.v
+++ b/vlib/v/tests/dump_c_structs/dump_c_struct_test.v
@@ -15,13 +15,13 @@ mut:
 	u64 u64
 }
 
-struct Epoll{
+struct Epoll {
 	ev C.epoll_event
 }
 
-fn test_dump_c_struct(){
+fn test_dump_c_struct() {
 	ev := C.epoll_event{}
-	unsafe{ C.memset(&ev, 0, sizeof(ev))}
+	unsafe { C.memset(&ev, 0, sizeof(ev)) }
 	dump(ev)
 	println(ev)
 

--- a/vlib/v/tests/dump_c_structs/epoll.h
+++ b/vlib/v/tests/dump_c_structs/epoll.h
@@ -1,0 +1,11 @@
+typedef union epoll_data {
+     void *ptr;
+     int fd;
+     uint32_t u32;
+     uint64_t u64;
+} epoll_data_t;
+ 
+struct epoll_event {
+    uint32_t events; /* Epoll events */
+    epoll_data_t data; /* User data variable */
+};


### PR DESCRIPTION
This PR fix dumping c structs (fix #15878).

- Fix dumping c structs.
- Add test.

epoll.h
```v
typedef union epoll_data {
     void *ptr;
     int fd;
     uint32_t u32;
     uint64_t u64;
} epoll_data_t;
 
struct epoll_event {
    uint32_t events; /* Epoll events */
    epoll_data_t data; /* User data variable */
};
```

```v
#include "@VMODROOT/epoll.h"

pub struct C.epoll_event {
mut:
	events u32
	data   C.epoll_data_t
}

[typedef]
pub union C.epoll_data_t {
mut:
	ptr voidptr
	fd  int
	u32 u32
	u64 u64
}

struct Epoll{
	ev C.epoll_event
}

fn main(){
	ev := C.epoll_event{}
	unsafe{ C.memset(&ev, 0, sizeof(ev))}
	dump(ev)
	println(ev)

	e := Epoll{
		ev: C.epoll_event{}
	}
	dump(e)
	println(e)
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:25] ev: struct epoll_event{
    events: 0
    data: epoll_data_t{
        ptr: 0
        fd: 0
        u32: 0
        u64: 0
    }
}
struct epoll_event{
    events: 0
    data: epoll_data_t{
        ptr: 0
        fd: 0
        u32: 0
        u64: 0
    }
}
[.\\tt1.v:31] e: Epoll{
    ev: struct epoll_event{
        events: 0
        data: epoll_data_t{
            ptr: 0
            fd: 0
            u32: 0
            u64: 0
        }
    }
}
Epoll{
    ev: struct epoll_event{
        events: 0
        data: epoll_data_t{
            ptr: 0
            fd: 0
            u32: 0
            u64: 0
        }
    }
}
```