### PR TITLE
parser: fix formating fn with variadic argument  (fix #15889)

### DIFF
--- a/vlib/v/fmt/tests/fn_with_variadic_arg_expected.vv
+++ b/vlib/v/fmt/tests/fn_with_variadic_arg_expected.vv
@@ -1,0 +1,3 @@
+fn abc(a ...int) {}
+
+fn main() {}

--- a/vlib/v/fmt/tests/fn_with_variadic_arg_input.vv
+++ b/vlib/v/fmt/tests/fn_with_variadic_arg_input.vv
@@ -1,0 +1,3 @@
+fn abc(a ...int, ) {}
+
+fn main() {}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -971,7 +971,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 					type_pos: type_pos[i]
 				}
 				// if typ.typ.kind == .variadic && p.tok.kind == .comma {
-				if is_variadic && p.tok.kind == .comma {
+				if is_variadic && p.tok.kind == .comma && p.peek_tok.kind != .rpar {
 					p.error_with_pos('cannot use ...(variadic) with non-final parameter $arg_name',
 						arg_pos[i])
 					return []ast.Param{}, false, false


### PR DESCRIPTION
This PR fix formating fn with variadic argument  (fix #15889).

- Fix formating fn with variadic argument.
- Add test.

```v
fn abc(a ...int, ) {}

fn main() {}
```
fmt to:
```v
fn abc(a ...int) {}

fn main() {}
```