### PR TITLE
net.urllib change Values struct to public

### DIFF
--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -9,7 +9,7 @@ pub mut:
 	value string
 }
 
-struct Values {
+pub struct Values {
 pub mut:
 	data []QueryValue
 	len  int


### PR DESCRIPTION
## Purpose

To allow the Values struct to be defined in function arguments.

Specifically, the goal is to have the following code work:
```v
fn new_request(method http.Method, endpoint string, query urllib.Values) ?http.Request {}
```

Currently it is private, so the following compile error occurs:
```shell
error: struct `net.urllib.Values` was declared as private to module `net.urllib`, so it can not be used inside module `zztkm.microcms`
```

If there are no problems, I would like to change to a public struct.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
