### PR TITLE
gg: proposed rename of Context.set_cfg() -> Context.set_text_cfg()

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -539,7 +539,7 @@ pub fn (ctx &Context) show_fps() {
 	sgl.defaults()
 	sgl.matrix_mode_projection()
 	sgl.ortho(0.0, f32(sapp.width()), f32(sapp.height()), 0.0, -1.0, 1.0)
-	ctx.set_cfg(ctx.fps.text_config)
+	ctx.set_text_cfg(ctx.fps.text_config)
 	if ctx.fps.width == 0 {
 		mut fps := unsafe { &ctx.fps }
 		fps.width, fps.height = ctx.text_size('00') // maximum size; prevents blinking on variable width fonts

--- a/vlib/gg/gg_ui.c.v
+++ b/vlib/gg/gg_ui.c.v
@@ -17,7 +17,7 @@ pub fn (ctx &Context) has_text_style() bool {
 
 pub fn (ctx &Context) set_text_style(font_name string, font_path string, size int, color gx.Color, align int, vertical_align int) {}
 
-// default draw_text (draw_text_def but without set_cfg)
+// default draw_text (draw_text_def but without set_text_cfg)
 pub fn (ctx &Context) draw_text_default(x int, y int, text string) {
 	scale := if ctx.ft.scale == 0 { f32(1) } else { ctx.ft.scale }
 	ctx.ft.fons.draw_text(x * scale, y * scale, text) // TODO: check offsets/alignment

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -118,8 +118,8 @@ fn new_ft(c FTConfig) ?&FT {
 	}
 }
 
-// set_cfg sets the current text configuration
-pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
+// set_text_cfg sets the current text configuration
+pub fn (ctx &Context) set_text_cfg(cfg gx.TextCfg) {
 	if !ctx.font_inited {
 		return
 	}
@@ -147,6 +147,11 @@ pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
 	ctx.ft.fons.vert_metrics(&ascender, &descender, &lh)
 }
 
+[deprecated: 'use set_text_cfg() instead']
+pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
+    ctx.set_text_cfg(cfg)
+}
+
 // draw_text draws the string in `text_` starting at top-left position `x`,`y`.
 // Text settings can be provided with `cfg`.
 pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
@@ -170,7 +175,7 @@ pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
 	// if text.contains('\t') {
 	// text = text.replace('\t', '    ')
 	// }
-	ctx.set_cfg(cfg)
+	ctx.set_text_cfg(cfg)
 	scale := if ctx.ft.scale == 0 { f32(1) } else { ctx.ft.scale }
 	ctx.ft.fons.draw_text(x * scale, y * scale, text_) // TODO: check offsets/alignment
 }
@@ -193,7 +198,7 @@ pub fn (ctx &Context) text_width(s string) int {
 			return C.darwin_text_width(s)
 		}
 	}
-	// ctx.set_cfg(cfg) TODO
+	// ctx.set_text_cfg(cfg) TODO
 	if !ctx.font_inited {
 		return 0
 	}
@@ -215,7 +220,7 @@ pub fn (ctx &Context) text_width(s string) int {
 
 // text_height returns the height of the `string` `s` in pixels.
 pub fn (ctx &Context) text_height(s string) int {
-	// ctx.set_cfg(cfg) TODO
+	// ctx.set_text_cfg(cfg) TODO
 	if !ctx.font_inited {
 		return 0
 	}
@@ -226,7 +231,7 @@ pub fn (ctx &Context) text_height(s string) int {
 
 // text_size returns the width and height of the `string` `s` in pixels.
 pub fn (ctx &Context) text_size(s string) (int, int) {
-	// ctx.set_cfg(cfg) TODO
+	// ctx.set_text_cfg(cfg) TODO
 	if !ctx.font_inited {
 		return 0, 0
 	}

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -149,7 +149,7 @@ pub fn (ctx &Context) set_text_cfg(cfg gx.TextCfg) {
 
 [deprecated: 'use set_text_cfg() instead']
 pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
-    ctx.set_text_cfg(cfg)
+	ctx.set_text_cfg(cfg)
 }
 
 // draw_text draws the string in `text_` starting at top-left position `x`,`y`.

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -147,6 +147,7 @@ pub fn (ctx &Context) set_text_cfg(cfg gx.TextCfg) {
 	ctx.ft.fons.vert_metrics(&ascender, &descender, &lh)
 }
 
+// set_cfg sets the current text configuration
 [deprecated: 'use set_text_cfg() instead']
 pub fn (ctx &Context) set_cfg(cfg gx.TextCfg) {
 	ctx.set_text_cfg(cfg)


### PR DESCRIPTION
Most of the function in `gg.Context` are to do with drawing stuff, or setting colours or text. And the functions to do with text are clearly labelled as such, since text rendering is only a part of what you can do with a `Context`.

Except for `set_cfg()`. It takes a `gx.TextCfg` argument, but is named as though it sets config for the `Context`, rather than just the text rendering.

So this is a proposal to rename `gg.Context.set_cfg()` to `gg.Context.set_text_cfg()`.

PR includes a deprecated `gg.Context.set_cfg()` shim for compatibility.

Note: I'm also submitting work to ui and will update calls there.