### PR TITLE
parser: fix pos error when define reference array type (fix: #15907)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -431,8 +431,8 @@ pub fn (mut p Parser) parse_type() ast.Type {
 	language := p.parse_language()
 	mut typ := ast.void_type
 	is_array := p.tok.kind == .lsbr
+	pos := p.tok.pos()
 	if p.tok.kind != .lcbr {
-		pos := p.tok.pos()
 		typ = p.parse_any_type(language, nr_muls > 0, true)
 		if typ.idx() == 0 {
 			// error is set in parse_type
@@ -462,9 +462,10 @@ pub fn (mut p Parser) parse_type() ast.Type {
 	if nr_muls > 0 {
 		typ = typ.set_nr_muls(nr_muls)
 		if is_array && nr_amps > 0 {
-			p.error('V arrays are already references behind the scenes,
+			p.error_with_pos('V arrays are already references behind the scenes,
 there is no need to use a reference to an array (e.g. use `[]string` instead of `&[]string`).
-If you need to modify an array in a function, use a mutable argument instead: `fn foo(mut s []string) {}`.')
+If you need to modify an array in a function, use a mutable argument instead: `fn foo(mut s []string) {}`.',
+				pos)
 			return 0
 		}
 	}

--- a/vlib/v/parser/tests/ref_array_pos_err.out
+++ b/vlib/v/parser/tests/ref_array_pos_err.out
@@ -1,0 +1,8 @@
+vlib/v/parser/tests/ref_array_pos_err.vv:2:5: error: V arrays are already references behind the scenes,
+there is no need to use a reference to an array (e.g. use `[]string` instead of `&[]string`).
+If you need to modify an array in a function, use a mutable argument instead: `fn foo(mut s []string) {}`.
+    1 | struct Foo {
+    2 |     b &[]u8
+      |        ^
+    3 |     n int
+    4 | }

--- a/vlib/v/parser/tests/ref_array_pos_err.vv
+++ b/vlib/v/parser/tests/ref_array_pos_err.vv
@@ -1,0 +1,4 @@
+struct Foo {
+	b &[]u8
+	n int
+}


### PR DESCRIPTION
1. Fix #15907
2. Add test.

```v
struct Foo {
	b &[]u8
	n int
}
```

output:

```
vlib/v/parser/tests/ref_array_pos_err.vv:2:5: error: V arrays are already references behind the scenes,
there is no need to use a reference to an array (e.g. use `[]string` instead of `&[]string`).
If you need to modify an array in a function, use a mutable argument instead: `fn foo(mut s []string) {}`.
    1 | struct Foo {
    2 |     b &[]u8
      |        ^
    3 |     n int
    4 | }
```