### PR TITLE
cgen: fix error when defer inside comptime if {} else {} (fix #15891)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2093,6 +2093,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 }
 
 fn (mut g Gen) write_defer_stmts() {
+	g.indent++
 	for i := g.defer_stmts.len - 1; i >= 0; i-- {
 		defer_stmt := g.defer_stmts[i]
 		g.writeln('// Defer begin')
@@ -2112,6 +2113,7 @@ fn (mut g Gen) write_defer_stmts() {
 		g.writeln('}')
 		g.writeln('// Defer end')
 	}
+	g.indent--
 }
 
 struct SumtypeCastingFn {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -266,7 +266,12 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 			g.writeln('')
 		}
 		expr_str := g.out.last_n(g.out.len - start_pos).trim_space()
-		g.defer_ifdef = expr_str
+		if expr_str != '' {
+			if g.defer_ifdef != '' {
+				g.defer_ifdef += '\r\n' + '\t'.repeat(g.indent + 1)
+			}
+			g.defer_ifdef += expr_str
+		}
 		if node.is_expr {
 			len := branch.stmts.len
 			if len > 0 {
@@ -303,8 +308,8 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 				g.writeln('}')
 			}
 		}
-		g.defer_ifdef = ''
 	}
+	g.defer_ifdef = ''
 	g.writeln('#endif')
 	if node.is_expr {
 		g.write('$line $tmp_var')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -296,6 +296,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 			g.writeln('${fargtypes[i]}* ${fargs[i]} = HEAP(${fargtypes[i]}, _v_toheap_${fargs[i]});')
 		}
 	}
+	g.indent++
 	for defer_stmt in node.defer_stmts {
 		g.writeln('bool ${g.defer_flag_var(defer_stmt)} = false;')
 		for var in defer_stmt.defer_vars {
@@ -319,6 +320,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 			}
 		}
 	}
+	g.indent--
 	if is_live_wrap {
 		// The live function just calls its implementation dual, while ensuring
 		// that the call is wrapped by the mutex lock & unlock calls.

--- a/vlib/v/tests/defer/defer_test.v
+++ b/vlib/v/tests/defer/defer_test.v
@@ -175,3 +175,17 @@ fn test_defer_with_reserved_words() {
 	eprintln('Done')
 	assert true
 }
+
+fn test_defer_inside_comptime_if_else() {
+	$if false {
+	} $else {
+		defer {
+		}
+	}
+	$if true {
+		defer {
+		}
+	} $else {
+	}
+	assert true
+}


### PR DESCRIPTION
1. Fix #15891
2. Add test.
3. Fix cgen: indent for defer stmts.

```v
fn main() {
	$if cond ? {
	} $else {
		defer {
			_ := 1
		}
	}
}
```

cgen output:

```c
VV_LOCAL_SYMBOL void main__main(void) {
	bool main__main_defer_0 = false;
	#if defined(CUSTOM_DEFINE_cond)
	{
	}
	#else
	{
		main__main_defer_0 = true;
	}
	#endif
	// Defer begin
	if (main__main_defer_0) {
		#if defined(CUSTOM_DEFINE_cond)
		#else
			{int_literal _ = 1;}
			;
		#endif
	}
	// Defer end
}
```