### PR TITLE
fmt: fix error when comments inside if and condition. (fix #15914)

### DIFF
--- a/vlib/v/fmt/comments.v
+++ b/vlib/v/fmt/comments.v
@@ -86,11 +86,12 @@ pub fn (mut f Fmt) comment(node ast.Comment, options CommentsOptions) {
 pub fn (mut f Fmt) comments(comments []ast.Comment, options CommentsOptions) {
 	mut prev_line := options.prev_line
 	for i, c in comments {
-		if options.prev_line > -1 && ((c.pos.line_nr > prev_line && f.out.last_n(1) != '\n')
-			|| (c.pos.line_nr > prev_line + 1 && f.out.last_n(2) != '\n\n')) {
+		if options.prev_line > -1
+			&& ((c.pos.line_nr > prev_line && f.out.len > 1 && f.out.last_n(1) != '\n')
+			|| (c.pos.line_nr > prev_line + 1 && f.out.len > 2 && f.out.last_n(2) != '\n\n')) {
 			f.writeln('')
 		}
-		if !f.out.last_n(1)[0].is_space() {
+		if f.out.len > 1 && !f.out.last_n(1)[0].is_space() {
 			f.write(' ')
 		}
 		f.comment(c, options)

--- a/vlib/v/fmt/tests/comments_inside_if_cond_expected.vv
+++ b/vlib/v/fmt/tests/comments_inside_if_cond_expected.vv
@@ -1,0 +1,3 @@
+// comments
+if true {
+}

--- a/vlib/v/fmt/tests/comments_inside_if_cond_input.vv
+++ b/vlib/v/fmt/tests/comments_inside_if_cond_input.vv
@@ -1,0 +1,2 @@
+if true /* comments */ {
+}


### PR DESCRIPTION
1. Fix: #15914
2. Add test.

a.v:

```v
if true /* comments */ {
}
```

v fmt -w a.v
output:

```v
// comments
if true {
}
```
