### PR TITLE
fmt: fix comments between for and { is wrong (fix #15918)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1062,10 +1062,15 @@ pub fn (mut f Fmt) for_stmt(node ast.ForStmt) {
 	if node.label.len > 0 {
 		f.write('$node.label: ')
 	}
+	if node.cond is ast.Comment {
+		f.comments([node.cond])
+	}
 	f.write('for ')
-	f.expr(node.cond)
-	if !node.is_inf {
-		f.write(' ')
+	if node.cond !is ast.Comment {
+		f.expr(node.cond)
+		if !node.is_inf {
+			f.write(' ')
+		}
 	}
 	f.write('{')
 	if node.stmts.len > 0 || node.pos.line_nr < node.pos.last_line {

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -103,3 +103,8 @@ fn between_if_branches() {
 	else {
 	}
 }
+
+// comments
+for {
+	break
+}

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -87,3 +87,8 @@ fn between_if_branches() {
 	else {
 	}
 }
+
+for // comments
+{
+	break
+}


### PR DESCRIPTION
1. Fix #15918
2. Add test.

```v
for // comments
{
	break
}
```

output:

```v
// comments
for {
        break
}
```
