### PR TITLE
checker: check mismatch of the fn array decompose argument (fix #15926)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -905,13 +905,20 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				c.expected_type = info.elem_type
 			}
 			typ := c.expr(call_arg.expr)
-			if i == node.args.len - 1 && c.table.sym(typ).kind == .array
-				&& call_arg.expr !is ast.ArrayDecompose && !param.typ.has_flag(.generic)
-				&& c.expected_type != typ {
-				styp := c.table.type_to_str(typ)
-				elem_styp := c.table.type_to_str(c.expected_type)
-				c.error('to pass `$call_arg.expr` ($styp) to `$func.name` (which accepts type `...$elem_styp`), use `...$call_arg.expr`',
-					node.pos)
+			if i == node.args.len - 1 {
+				if c.table.sym(typ).kind == .array && call_arg.expr !is ast.ArrayDecompose
+					&& !param.typ.has_flag(.generic) && c.expected_type != typ {
+					styp := c.table.type_to_str(typ)
+					elem_styp := c.table.type_to_str(c.expected_type)
+					c.error('to pass `$call_arg.expr` ($styp) to `$func.name` (which accepts type `...$elem_styp`), use `...$call_arg.expr`',
+						node.pos)
+				} else if call_arg.expr is ast.ArrayDecompose
+					&& c.table.sym(c.expected_type).kind == .sum_type && c.expected_type != typ {
+					expected_type := c.table.type_to_str(c.expected_type)
+					got_type := c.table.type_to_str(typ)
+					c.error('cannot use `...$got_type` as `...$expected_type` in argument ${i + 1} to `$fn_name`',
+						call_arg.pos)
+				}
 			}
 		} else {
 			c.expected_type = param.typ

--- a/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err.vv:12:7: error: cannot use `...string` as `...Any` in argument 1 to `test`
+   10 |     mut args := []string{cap: 3}
+   11 |     args << ['test', 'test1', 'test2']
+   12 |     test(...args)
+      |          ~~~~~~~
+   13 | }

--- a/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err.vv
@@ -1,0 +1,13 @@
+module main
+
+type Any = string | u8
+
+fn test(args ...Any) {
+	println('args $args')
+}
+
+fn main() {
+	mut args := []string{cap: 3}
+	args << ['test', 'test1', 'test2']
+	test(...args)
+}


### PR DESCRIPTION
This PR check mismatch of the fn array decompose argument (fix #15926).

- Check mismatch of the fn array decompose argument.
- Add test.

```v
module main

type Any = string | u8

fn test(args ...Any) {
	println('args $args')
}

fn main() {
	mut args := []string{cap: 3}
	args << ['test', 'test1', 'test2']
	test(...args)
}

PS D:\Test\v\tt1> v run .
./tt1.v:12:7: error: cannot use `...string` as `...Any` in argument 1 to `test`
   10 |     mut args := []string{cap: 3}
   11 |     args << ['test', 'test1', 'test2']
   12 |     test(...args)
      |          ~~~~~~~
   13 | }
```