### PR TITLE
native: skip linking when no library functions get called

### DIFF
--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -6,6 +6,7 @@ module native
 import os
 import strings
 import v.ast
+import v.ast.walker
 import v.util
 import v.mathutil as mu
 import v.token
@@ -26,6 +27,7 @@ mut:
 pub struct Gen {
 	out_name string
 	pref     &pref.Preferences = unsafe { nil } // Preferences shared from V struct
+	files    []&ast.File
 mut:
 	code_gen             CodeGen
 	table                &ast.Table = unsafe { nil }
@@ -33,7 +35,7 @@ mut:
 	sect_header_name_pos int
 	offset               i64
 	file_size_pos        i64
-	elf_text_header_addr i64
+	elf_text_header_addr i64 = -1
 	main_fn_addr         i64
 	main_fn_size         i64
 	start_symbol_addr    i64
@@ -59,6 +61,8 @@ mut:
 	// macho specific
 	macho_ncmds   int
 	macho_cmdsize int
+
+	requires_linking bool
 }
 
 enum RelocType {
@@ -218,6 +222,7 @@ pub fn gen(files []&ast.File, table &ast.Table, out_name string, pref &pref.Pref
 		sect_header_name_pos: 0
 		out_name: exe_name
 		pref: pref
+		files: files
 		// TODO: workaround, needs to support recursive init
 		code_gen: get_backend(pref.arch) or {
 			eprintln('No available backend for this configuration. Use `-a arm64` or `-a amd64`.')
@@ -232,7 +237,7 @@ pub fn gen(files []&ast.File, table &ast.Table, out_name string, pref &pref.Pref
 	g.init_builtins()
 	g.calculate_all_size_align()
 	g.calculate_enum_fields()
-	for file in files {
+	for file in g.files {
 		/*
 		if file.warnings.len > 0 {
 			eprintln('warning: ${file.warnings[0]}')
@@ -253,7 +258,33 @@ pub fn (mut g Gen) typ(a int) &ast.TypeSymbol {
 	return g.table.type_symbols[a]
 }
 
+pub fn (mut g Gen) ast_has_external_functions() bool {
+	mut has_external_fn := false
+
+	for file in g.files {
+		walker.inspect(file, unsafe { &mut has_external_fn }, fn (node &ast.Node, data voidptr) bool {
+			if node is ast.Expr && (node as ast.Expr) is ast.CallExpr
+				&& ((node as ast.Expr) as ast.CallExpr).language != .v {
+				unsafe {
+					*&bool(data) = true // an external function was found
+				}
+				return false
+			}
+
+			return true
+		})
+
+		if has_external_fn {
+			break
+		}
+	}
+
+	return has_external_fn
+}
+
 pub fn (mut g Gen) generate_header() {
+	g.requires_linking = g.ast_has_external_functions()
+
 	match g.pref.os {
 		.macos {
 			g.generate_macho_header()
@@ -262,7 +293,11 @@ pub fn (mut g Gen) generate_header() {
 			g.generate_pe_header()
 		}
 		.linux {
-			g.generate_elf_header()
+			if g.requires_linking {
+				g.generate_linkable_elf_header()
+			} else {
+				g.generate_simple_elf_header()
+			}
 		}
 		.raw {
 			if g.pref.arch == .arm64 {
@@ -270,26 +305,36 @@ pub fn (mut g Gen) generate_header() {
 			}
 		}
 		else {
-			g.n_error('only `raw`, `linux` and `macos` are supported for -os in -native')
+			g.n_error('only `raw`, `linux`, `windows` and `macos` are supported for -os in -native')
 		}
 	}
 }
 
 pub fn (mut g Gen) create_executable() {
 	obj_name := match g.pref.os {
-		.linux { g.out_name + '.o' }
-		else { g.out_name }
+		.linux {
+			if g.requires_linking {
+				g.out_name + '.o'
+			} else {
+				g.out_name
+			}
+		}
+		else {
+			g.out_name
+		}
 	}
 
 	os.write_file_array(obj_name, g.buf) or { panic(err) }
 
-	match g.pref.os {
-		// TEMPORARY
-		.linux { // TEMPORARY
-			g.link(obj_name)
+	if g.requires_linking {
+		match g.pref.os {
+			// TEMPORARY
+			.linux { // TEMPORARY
+				g.link(obj_name)
+			} // TEMPORARY
+			else {} // TEMPORARY
 		} // TEMPORARY
-		else {} // TEMPORARY
-	} // TEMPORARY
+	}
 
 	os.chmod(g.out_name, 0o775) or { panic(err) } // make it executable
 	if g.pref.is_verbose {


### PR DESCRIPTION
Skip the linking step of the native backend in favor of smaller executable sizes when no library functions get called.

Also fixes linking errors on `aarch64-linux-gnu` targets.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
