### PR TITLE
checker: fix feferences for alias type can still be uninitalized (fix #15935)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -522,6 +522,12 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				if sym.kind == .struct_ && !(sym.info as ast.Struct).is_typedef {
 					c.check_ref_fields_initialized(sym, mut checked_structs, '${type_sym.name}.$field.name',
 						node)
+				} else if sym.kind == .alias {
+					parent_sym := c.table.sym((sym.info as ast.Alias).parent_type)
+					if parent_sym.kind == .struct_ {
+						c.check_ref_fields_initialized(parent_sym, mut checked_structs,
+							'${type_sym.name}.$field.name', node)
+					}
 				}
 				// Do not allow empty uninitialized interfaces
 				mut has_noinit := false
@@ -608,6 +614,13 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 			checked_structs << field.typ
 			c.check_ref_fields_initialized(sym, mut checked_structs, '${linked_name}.$field.name',
 				node)
+		} else if sym.kind == .alias {
+			parent_sym := c.table.sym((sym.info as ast.Alias).parent_type)
+			if parent_sym.kind == .struct_ {
+				checked_structs << field.typ
+				c.check_ref_fields_initialized(parent_sym, mut checked_structs, '${linked_name}.$field.name',
+					node)
+			}
 		}
 	}
 }

--- a/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
@@ -1,13 +1,20 @@
-vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:22:7: warning: reference field `Outer.c.b` must be initialized
-   20 | 
-   21 | fn main() {
-   22 |     _ := Outer{}
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `Outer.c1.b` must be initialized
+   23 | 
+   24 | fn main() {
+   25 |     _ := Outer{}
       |          ~~~~~~~
-   23 |     _ := Struct{}
-   24 | }
-vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:23:7: warning: reference field `Struct.ref2` must be initialized
-   21 | fn main() {
-   22 |     _ := Outer{}
-   23 |     _ := Struct{}
+   26 |     _ := Struct{}
+   27 | }
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `Outer.c2.b` must be initialized
+   23 | 
+   24 | fn main() {
+   25 |     _ := Outer{}
+      |          ~~~~~~~
+   26 |     _ := Struct{}
+   27 | }
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:26:7: warning: reference field `Struct.ref2` must be initialized
+   24 | fn main() {
+   25 |     _ := Outer{}
+   26 |     _ := Struct{}
       |          ~~~~~~~~
-   24 | }
+   27 | }

--- a/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv
+++ b/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv
@@ -3,8 +3,11 @@ struct ContainsRef {
 	b &int
 }
 
+type TypeForContainsRef = ContainsRef
+
 struct Outer {
-	c ContainsRef
+	c1 ContainsRef
+	c2 TypeForContainsRef
 }
 
 struct Ref {}


### PR DESCRIPTION
1. Fix #15935 
2. Add test.

```v
struct ContainsRef {
	a &int = unsafe { nil }
	b &int
}

type TypeForContainsRef = ContainsRef

struct Outer {
	c1 ContainsRef
	c2 TypeForContainsRef
}

struct Ref {}

struct EmbedStruct {
	ref1 &Ref = unsafe { nil }
	ref2 &Ref
}

struct Struct {
	EmbedStruct
}

fn main() {
	_ := Outer{}
	_ := Struct{}
}
```

output:

```
vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `Outer.c1.b` must be initialized
   23 | 
   24 | fn main() {
   25 |     _ := Outer{}
      |          ~~~~~~~
   26 |     _ := Struct{}
   27 | }
vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `Outer.c2.b` must be initialized
   23 | 
   24 | fn main() {
   25 |     _ := Outer{}
      |          ~~~~~~~
   26 |     _ := Struct{}
   27 | }
vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:26:7: warning: reference field `Struct.ref2` must be initialized
   24 | fn main() {
   25 |     _ := Outer{}
   26 |     _ := Struct{}
      |          ~~~~~~~~
   27 | }
```

