### PR TITLE
ast/parser: varg with pointer type fix: #15943

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -236,10 +236,10 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					}
 				}
 			}
-			if (c.pref.translated || c.file.is_translated) && node.is_variadic && param.typ.is_ptr() {
-				// TODO c2v hack to fix `(const char *s, ...)`
-				param.typ = ast.int_type.ref()
-			}
+			// if (c.pref.translated || c.file.is_translated) && node.is_variadic && param.typ.is_ptr() {
+			// 	// TODO c2v hack to fix `(const char *s, ...)`
+			// 	param.typ = ast.int_type.ref()
+			// }
 		}
 	}
 	if node.language == .v && node.name.after_char(`.`) == 'init' && !node.is_method

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -236,10 +236,6 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					}
 				}
 			}
-			// if (c.pref.translated || c.file.is_translated) && node.is_variadic && param.typ.is_ptr() {
-			// 	// TODO c2v hack to fix `(const char *s, ...)`
-			// 	param.typ = ast.int_type.ref()
-			// }
 		}
 	}
 	if node.language == .v && node.name.after_char(`.`) == 'init' && !node.is_method

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1045,17 +1045,17 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				// TODO duplicated logic in check_types() (check_types.v)
 				// Allow enums to be used as ints and vice versa in translated code
 
-				// in case if variadic make sure to use array elem type for checks before
-				// check_call_args already sets expected to elem_type before doing checks.
+				// in case of variadic make sure to use array elem type for checks
+				// check_expected_call_arg already does this before checks also.
 				param_type := if param.typ.has_flag(.variadic) {
 					c.table.sym(param.typ).array_info().elem_type
 				} else {
 					param.typ
 				}
-				if param_type == ast.int_type && arg_typ_sym.kind == .enum_ {
+				if param_type.idx() in ast.integer_type_idxs && arg_typ_sym.kind == .enum_ {
 					continue
 				}
-				if arg_typ == ast.int_type && param_typ_sym.kind == .enum_ {
+				if arg_typ.idx() in ast.integer_type_idxs && param_typ_sym.kind == .enum_ {
 					continue
 				}
 

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1038,9 +1038,6 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				}
 			}
 			if c.pref.translated || c.file.is_translated {
-				// TODO duplicated logic in check_types() (check_types.v)
-				// Allow enums to be used as ints and vice versa in translated code
-
 				// in case of variadic make sure to use array elem type for checks
 				// check_expected_call_arg already does this before checks also.
 				param_type := if param.typ.has_flag(.variadic) {
@@ -1048,6 +1045,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				} else {
 					param.typ
 				}
+				// TODO duplicated logic in check_types() (check_types.v)
+				// Allow enums to be used as ints and vice versa in translated code
 				if param_type.idx() in ast.integer_type_idxs && arg_typ_sym.kind == .enum_ {
 					continue
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -941,11 +941,9 @@ fn (mut g Gen) base_type(_t ast.Type) string {
 	if t.has_flag(.shared_f) {
 		styp = g.find_or_register_shared(t, styp)
 	}
-	if !t.has_flag(.variadic) {
-		nr_muls := g.unwrap_generic(t).nr_muls()
-		if nr_muls > 0 {
-			styp += strings.repeat(`*`, nr_muls)
-		}
+	nr_muls := g.unwrap_generic(t).nr_muls()
+	if nr_muls > 0 {
+		styp += strings.repeat(`*`, nr_muls)
 	}
 	return styp
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -559,7 +559,10 @@ fn (mut g Gen) fn_decl_params(params []ast.Param, scope &ast.Scope, is_variadic 
 		} else {
 			c_name(param.name)
 		}
-		typ := g.unwrap_generic(param.typ)
+		mut typ := g.unwrap_generic(param.typ)
+		if g.pref.translated && g.file.is_translated && param.typ.has_flag(.variadic) {
+			typ = g.table.sym(g.unwrap_generic(param.typ)).array_info().elem_type.set_flag(.variadic)
+		}
 		param_type_sym := g.table.sym(typ)
 		mut param_type_name := g.typ(typ) // util.no_dots(param_type_sym.name)
 		if param_type_sym.kind == .function {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -859,7 +859,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				}
 			}
 			if is_variadic {
-				arg_type = ast.new_type(p.table.find_or_register_array(arg_type)).set_flag(.variadic)
+				// derive flags, however nr_muls only needs to be set on the array elem type, so clear it on the arg type
+				arg_type = ast.new_type(p.table.find_or_register_array(arg_type)).derive(arg_type).set_nr_muls(0).set_flag(.variadic)
 			}
 			if p.tok.kind == .eof {
 				p.error_with_pos('expecting `)`', p.prev_tok.pos())
@@ -967,7 +968,8 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				}
 			}
 			if is_variadic {
-				typ = ast.new_type(p.table.find_or_register_array(typ)).derive(typ).set_flag(.variadic)
+				// derive flags, however nr_muls only needs to be set on the array elem type, so clear it on the arg type
+				typ = ast.new_type(p.table.find_or_register_array(typ)).derive(typ).set_nr_muls(0).set_flag(.variadic)
 			}
 			for i, arg_name in arg_names {
 				alanguage := p.table.sym(typ).language

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -859,8 +859,7 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 				}
 			}
 			if is_variadic {
-				// derive flags, however nr_muls only needs to be set on the array elem type, so clear it on the arg type
-				arg_type = ast.new_type(p.table.find_or_register_array(arg_type)).derive(arg_type).set_nr_muls(0).set_flag(.variadic)
+				arg_type = ast.new_type(p.table.find_or_register_array(arg_type)).set_flag(.variadic)
 			}
 			if p.tok.kind == .eof {
 				p.error_with_pos('expecting `)`', p.prev_tok.pos())

--- a/vlib/v/tests/fn_variadic_test.v
+++ b/vlib/v/tests/fn_variadic_test.v
@@ -105,6 +105,8 @@ fn take_variadic_string_ptr(strings ...&string) {
 
 fn take_array_string_ptr(strings []&string) {
 	assert strings.len == 2
+	assert *strings[0] == 'a'
+	assert *strings[1] == 'b'
 }
 
 fn test_varg_pointer() {

--- a/vlib/v/tests/fn_variadic_test.v
+++ b/vlib/v/tests/fn_variadic_test.v
@@ -97,3 +97,18 @@ fn test_fn_variadic_method_no_args() {
 	a := VaTestStruct{}
 	a.variadic_method_no_args('marko')
 }
+
+// test vargs with pointer type
+fn take_variadic_string_ptr(strings ...&string) {
+	take_array_string_ptr(strings)
+}
+
+fn take_array_string_ptr(strings []&string) {
+	assert strings.len == 2
+}
+
+fn test_varg_pointer() {
+	a := 'a'
+	b := 'b'
+	take_variadic_string_ptr(&a, &b)
+}


### PR DESCRIPTION
fixes #15943

nr_muls are derived onto the parent type instead of just the elem type, this was happening when flags were copied using derive.

A few fixes were added to workaround the underlying issue, this PR fixes the underlying issue so have removed them:
- https://github.com/vlang/v/pull/11115
- https://github.com/vlang/v/blob/master/vlib/v/checker/fn.v#L239

I wonder if some of these extra checks could now be removed? https://github.com/vlang/v/blob/master/vlib/v/checker/fn.v#L1053

```go
fn fn_varg_a(strings ...&string) {
	fn_a(strings)
}

fn fn_a(s []&string) {
	println(s)
}

fn main() {
	a := 'a'
	b := 'b'
	fn_varg_a(&a, &b)
}
```
expected no error, but got:
```sh
➜  v-algorand-sdk git:(master) ✗ v ../varg_ptr.v
../varg_ptr.v:4:7: error: cannot use `&[]&string` as `[]&string` in argument 1 to `fn_a`
    2 |
    3 | fn fn_varg_a(strings ...&string) {
    4 |     fn_a(strings)
      |          ~~~~~~~
    5 | }
    6 |
    ```