### PR TITLE
parser: fix checking for duplicate main functions (fix #15933)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -6,6 +6,7 @@ module parser
 import v.ast
 import v.token
 import v.util
+import os
 
 pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 	first_pos := p.tok.pos()
@@ -399,6 +400,16 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	is_test := (!is_method && params.len == 0) && p.inside_test_file
 		&& (short_fn_name.starts_with('test_') || short_fn_name.starts_with('testsuite_'))
 	file_mode := p.file_backend_mode
+	if is_main {
+		if _ := p.table.find_fn('main.main') {
+			if '.' in os.args {
+				p.error_with_pos('multiple `main` functions detected, and you ran `v .`
+perhaps there are multiple V programs in this directory, and you need to
+run them via `v file.v` instead',
+					name_pos)
+			}
+		}
+	}
 	// Register
 	if is_method {
 		mut type_sym := p.table.sym(rec.typ)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -6,7 +6,6 @@ module parser
 import v.ast
 import v.token
 import v.util
-import os
 
 fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	p.top_level_statement_start()
@@ -361,15 +360,6 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	}
 	// allow duplicate c struct declarations
 	if ret == -1 && language != .c {
-		if _ := p.table.find_fn('main.main') {
-			if '.' in os.args {
-				p.error_with_pos('multiple `main` functions detected, and you ran `v .`
-perhaps there are multiple V programs in this directory, and you need to
-run them via `v file.v` instead',
-					name_pos)
-				return ast.StructDecl{}
-			}
-		}
 		p.error_with_pos('cannot register struct `$name`, another type with this name exists',
 			name_pos)
 		return ast.StructDecl{}


### PR DESCRIPTION
This PR fix checking for duplicate main functions (fix #15933).

```v
import mod

fn main() {}

PS D:\Test\v\tt1> v run .
./tt1.v:1:8: warning: module 'mod' is imported but never used
    1 | import mod
      |        ~~~
    2 |
    3 | fn main() {}
mod/mod.v:5:12: error: cannot register struct `mod.Foo`, another type with this name exists
    3 | pub struct Foo{}
    4 |
    5 | pub struct Foo<T>{}
      |            ~~~
```

multiple main files in the folder.
tt1.v 
```v
fn main() {}
```
tt2.v
```v
fn  main() {}
```

```v
PS D:\Test\v\tt1> v run .
./tt2.v:1:4: error: multiple `main` functions detected, and you ran `v .`
perhaps there are multiple V programs in this directory, and you need to
run them via `v file.v` instead
    1 | fn main() {}
      |    ~~~~
```