### PR TITLE
fmt,parser,ast: fix and optimized comments for 'for, for_c, for_in' stmts (fix: #15922)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1028,8 +1028,9 @@ pub mut:
 
 pub struct ForStmt {
 pub:
-	is_inf bool // `for {}`
-	pos    token.Pos
+	is_inf   bool // `for {}`
+	pos      token.Pos
+	comments []Comment
 pub mut:
 	cond  Expr
 	stmts []Stmt
@@ -1046,6 +1047,7 @@ pub:
 	high       Expr // `10` in `for i in 0..10 {`
 	stmts      []Stmt
 	pos        token.Pos
+	comments   []Comment
 	val_is_mut bool // `for mut val in vals {` means that modifying `val` will modify the array
 	// and the array cannot be indexed inside the loop
 pub mut:
@@ -1067,6 +1069,7 @@ pub:
 	has_inc  bool
 	is_multi bool // for a,b := 0,1; a < 10; a,b = a+b, a {...}
 	pos      token.Pos
+	comments []Comment
 pub mut:
 	init  Stmt // i := 0;
 	cond  Expr // i < 10;

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1008,6 +1008,9 @@ pub fn (mut f Fmt) for_c_stmt(node ast.ForCStmt) {
 	if node.label.len > 0 {
 		f.write('$node.label: ')
 	}
+	if node.comments.len > 0 {
+		f.comments(node.comments)
+	}
 	f.write('for ')
 	if node.has_init {
 		f.single_line_if = true // to keep all for ;; exprs on the same line
@@ -1030,6 +1033,9 @@ pub fn (mut f Fmt) for_c_stmt(node ast.ForCStmt) {
 pub fn (mut f Fmt) for_in_stmt(node ast.ForInStmt) {
 	if node.label.len > 0 {
 		f.write('$node.label: ')
+	}
+	if node.comments.len > 0 {
+		f.comments(node.comments)
 	}
 	f.write('for ')
 	if node.key_var != '' {
@@ -1062,15 +1068,13 @@ pub fn (mut f Fmt) for_stmt(node ast.ForStmt) {
 	if node.label.len > 0 {
 		f.write('$node.label: ')
 	}
-	if node.cond is ast.Comment {
-		f.comments([node.cond])
+	if node.comments.len > 0 {
+		f.comments(node.comments)
 	}
 	f.write('for ')
-	if node.cond !is ast.Comment {
-		f.expr(node.cond)
-		if !node.is_inf {
-			f.write(' ')
-		}
+	f.expr(node.cond)
+	if !node.is_inf {
+		f.write(' ')
 	}
 	f.write('{')
 	if node.stmts.len > 0 || node.pos.line_nr < node.pos.last_line {

--- a/vlib/v/fmt/tests/comments_expected.vv
+++ b/vlib/v/fmt/tests/comments_expected.vv
@@ -108,3 +108,43 @@ fn between_if_branches() {
 for {
 	break
 }
+
+// comments
+for {
+	break
+}
+
+// comments
+for i := 0; i < 1; i++ {
+	break
+}
+
+// comments
+for i := 0; i < 1; i++ {
+	break
+}
+
+// comments1
+// comments2
+// comments3
+// comments4
+for i := 0; i < 1; i++ {
+	break
+}
+
+// comments
+for _ in [1, 2] {
+	break
+}
+
+// comments
+for _ in [1, 2] {
+	break
+}
+
+// comments1
+// comments2
+// comments3
+for _ in [1, 2] {
+	break
+}

--- a/vlib/v/fmt/tests/comments_input.vv
+++ b/vlib/v/fmt/tests/comments_input.vv
@@ -92,3 +92,33 @@ for // comments
 {
 	break
 }
+
+for /* comments */ {
+	break
+}
+
+for i := 0; i < 1; i++ // comments
+{
+	break
+}
+
+for i := 0; i < 1; i++ /* comments */ {
+	break
+}
+
+for /* comments1 */ i := 0; /* comments2 */ i < 1; /* comments3 */ i++ /* comments4 */ {
+	break
+}
+
+for _ in [1, 2] /* comments */ {
+	break
+}
+
+for _ in [1, 2] // comments
+{
+	break
+}
+
+for /* comments1 */ _ in /* comments2 */ [1, 2] /* comments3 */ {
+	break
+}


### PR DESCRIPTION
1. Fix #15922
2. Add tests.

a.v:

```v
for // comments
{
	break
}

for /* comments */ {
	break
}

for i := 0; i < 1; i++ // comments
{
	break
}

for i := 0; i < 1; i++ /* comments */ {
	break
}

for /* comments1 */ i := 0; /* comments2 */ i < 1; /* comments3 */ i++ /* comments4 */ {
	break
}

for _ in [1, 2] /* comments */ {
	break
}

for _ in [1, 2] // comments
{
	break
}

for /* comments1 */ _ in /* comments2 */ [1, 2] /* comments3 */ {
	break
}
```

v fmt -w a.v
output:

```v
// comments
for {
	break
}

// comments
for {
	break
}

// comments
for i := 0; i < 1; i++ {
	break
}

// comments
for i := 0; i < 1; i++ {
	break
}

// comments1
// comments2
// comments3
// comments4
for i := 0; i < 1; i++ {
	break
}

// comments
for _ in [1, 2] {
	break
}

// comments
for _ in [1, 2] {
	break
}

// comments1
// comments2
// comments3
for _ in [1, 2] {
	break
}
```
