### PR TITLE
net: add unsafe block to int -> enum cast

### DIFF
--- a/vlib/net/net_windows.c.v
+++ b/vlib/net/net_windows.c.v
@@ -736,7 +736,7 @@ pub enum WsaError {
 
 // wsa_error casts an int to its WsaError value
 pub fn wsa_error(code int) WsaError {
-	return WsaError(code)
+	return unsafe { WsaError(code) }
 }
 
 const (


### PR DESCRIPTION
fixes https://github.com/vlang/v/issues/15959 and part of https://github.com/vlang/v/pull/15932