### PR TITLE
cgen: fix vweb using generic method (fix #15888)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -467,12 +467,18 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 		if methods.len > 0 {
 			g.writeln('FunctionData $node.val_var = {0};')
 		}
-		for method in methods { // sym.methods {
-			/*
-			if method.return_type != vweb_result_type { // ast.void_type {
-				continue
+		for method in methods {
+			// filter vweb route methods (non-generic method)
+			if method.receiver_type != 0 {
+				rec_sym := g.table.sym(method.receiver_type)
+				if rec_sym.kind == .struct_ {
+					if _ := g.table.find_field_with_embeds(rec_sym, 'Context') {
+						if method.generic_names.len > 0 {
+							continue
+						}
+					}
+				}
 			}
-			*/
 			g.comptime_for_method = method.name
 			g.writeln('/* method $i */ {')
 			g.writeln('\t${node.val_var}.name = _SLIT("$method.name");')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -467,9 +467,10 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 		if methods.len > 0 {
 			g.writeln('FunctionData $node.val_var = {0};')
 		}
+		typ_vweb_result := g.table.find_type_idx('vweb.Result')
 		for method in methods {
 			// filter vweb route methods (non-generic method)
-			if method.receiver_type != 0 {
+			if method.receiver_type != 0 && method.return_type == typ_vweb_result {
 				rec_sym := g.table.sym(method.receiver_type)
 				if rec_sym.kind == .struct_ {
 					if _ := g.table.find_field_with_embeds(rec_sym, 'Context') {

--- a/vlib/vweb/vweb_app_test.v
+++ b/vlib/vweb/vweb_app_test.v
@@ -64,3 +64,17 @@ fn (mut app App) time_json_pretty() {
 		'time': time.now().format()
 	})
 }
+
+struct ApiSuccessResponse<T> {
+	success bool
+	result  T
+}
+
+fn (mut app App) json_success<T>(result T) vweb.Result {
+	response := ApiSuccessResponse<T>{
+		success: true
+		result: result
+	}
+
+	return app.json(response)
+}

--- a/vlib/vweb/vweb_app_test.v
+++ b/vlib/vweb/vweb_app_test.v
@@ -78,3 +78,17 @@ fn (mut app App) json_success<T>(result T) vweb.Result {
 
 	return app.json(response)
 }
+
+// should compile, this is a helper method, not exposed as a route
+fn (mut app App) some_helper<T>(result T) ApiSuccessResponse<T> {
+	response := ApiSuccessResponse<T>{
+		success: true
+		result: result
+	}
+	return response
+}
+
+// should compile, the route method itself is not generic
+fn (mut app App) ok() vweb.Result {
+	return app.json(app.some_helper(123))
+}


### PR DESCRIPTION
This PR fix vweb using generic method (fix #15888).

- Fix vweb using generic method.

```v
import vweb

struct ApiSuccessResponse<T> {
	success bool
	result  T
}

struct App {
	vweb.Context
}

fn (mut app App) json_success<T>(result T) vweb.Result {
	response := ApiSuccessResponse<T>{
		success: true
		result: result
	}

	return app.json(response)
}

fn main() {
	mut app := &App{}

	vweb.run(app, 80)
}

PS D:\Test\v\tt1> v run .
[Vweb] Running app on http://localhost:80/
```