### PR TITLE
term: fix errors of input_windows.c.v

### DIFF
--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -165,11 +165,11 @@ fn (mut ctx Context) parse_events() {
 					C.VK_DOWN { KeyCode.down }
 					C.VK_INSERT { KeyCode.insert }
 					C.VK_DELETE { KeyCode.delete }
-					65...90 { KeyCode(ch + 32) } // letters
+					65...90 { unsafe { KeyCode(ch + 32) } } // letters
 					91...93 { KeyCode.null } // special keys
-					96...105 { KeyCode(ch - 48) } // numpad numbers
-					112...135 { KeyCode(ch + 178) } // f1 - f24
-					else { KeyCode(ascii) }
+					96...105 { unsafe { KeyCode(ch - 48) } } // numpad numbers
+					112...135 { unsafe { KeyCode(ch + 178) } } // f1 - f24
+					else { unsafe { KeyCode(ascii) } }
 				}
 
 				mut modifiers := Modifiers{}


### PR DESCRIPTION
This PR fix errors of input_windows.c.v.

errors in windows:
```v
 FAIL  [ 240/1120]   203.977 ms vlib/term/ui/1_term_and_ui_compilation_test.v
vlib/term/ui/input_windows.c.v:168:16: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  166 |                     C.VK_INSERT { KeyCode.insert }
  167 |                     C.VK_DELETE { KeyCode.delete }
  168 |                     65...90 { KeyCode(ch + 32) } // letters
      |                               ~~~~~~~~~~~~~~~~
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
vlib/term/ui/input_windows.c.v:170:17: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  168 |                     65...90 { KeyCode(ch + 32) } // letters
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
      |                                ~~~~~~~~~~~~~~~~
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
  172 |                     else { KeyCode(ascii) }
vlib/term/ui/input_windows.c.v:171:18: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
      |                                 ~~~~~~~~~~~~~~~~~
  172 |                     else { KeyCode(ascii) }
  173 |                 }
vlib/term/ui/input_windows.c.v:172:13: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
  172 |                     else { KeyCode(ascii) }
      |                            ~~~~~~~~~~~~~~
  173 |                 }
  174 |

 FAIL  [ 241/1120]   203.116 ms vlib/term/ui/2_term_and_ui_compilation_test.v
vlib/term/ui/input_windows.c.v:168:16: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  166 |                     C.VK_INSERT { KeyCode.insert }
  167 |                     C.VK_DELETE { KeyCode.delete }
  168 |                     65...90 { KeyCode(ch + 32) } // letters
      |                               ~~~~~~~~~~~~~~~~
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
vlib/term/ui/input_windows.c.v:170:17: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  168 |                     65...90 { KeyCode(ch + 32) } // letters
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
      |                                ~~~~~~~~~~~~~~~~
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
  172 |                     else { KeyCode(ascii) }
vlib/term/ui/input_windows.c.v:171:18: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
      |                                 ~~~~~~~~~~~~~~~~~
  172 |                     else { KeyCode(ascii) }
  173 |                 }
vlib/term/ui/input_windows.c.v:172:13: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
  172 |                     else { KeyCode(ascii) }
      |                            ~~~~~~~~~~~~~~
  173 |                 }
  174 |

 FAIL  [ 242/1120]   202.223 ms vlib/term/ui/ui_test.v
vlib/term/ui/input_windows.c.v:168:16: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  166 |                     C.VK_INSERT { KeyCode.insert }
  167 |                     C.VK_DELETE { KeyCode.delete }
  168 |                     65...90 { KeyCode(ch + 32) } // letters
      |                               ~~~~~~~~~~~~~~~~
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
vlib/term/ui/input_windows.c.v:170:17: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  168 |                     65...90 { KeyCode(ch + 32) } // letters
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
      |                                ~~~~~~~~~~~~~~~~
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
  172 |                     else { KeyCode(ascii) }
vlib/term/ui/input_windows.c.v:171:18: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  169 |                     91...93 { KeyCode.null } // special keys
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
      |                                 ~~~~~~~~~~~~~~~~~
  172 |                     else { KeyCode(ascii) }
  173 |                 }
vlib/term/ui/input_windows.c.v:172:13: error: casting numbers to enums, should be done inside `unsafe{}` blocks
  170 |                     96...105 { KeyCode(ch - 48) } // numpad numbers
  171 |                     112...135 { KeyCode(ch + 178) } // f1 - f24
  172 |                     else { KeyCode(ascii) }
      |                            ~~~~~~~~~~~~~~
  173 |                 }
  174 |
```