### PR TITLE
cgen: fix generic for_in using iteration (fix #15969)

### DIFF
--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -358,7 +358,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 			g.writeln('for (size_t $node.key_var = 0;; ++$node.key_var) {')
 		}
 		t_var := g.new_tmp_var()
-		receiver_typ := next_fn.params[0].typ
+		receiver_typ := g.unwrap_generic(next_fn.params[0].typ)
 		receiver_styp := g.typ(receiver_typ)
 		mut fn_name := receiver_styp.replace_each(['*', '', '.', '__']) + '_next'
 		receiver_sym := g.table.sym(receiver_typ)

--- a/vlib/v/tests/generics_for_in_iterate_test.v
+++ b/vlib/v/tests/generics_for_in_iterate_test.v
@@ -1,0 +1,50 @@
+pub struct Vec<T> {
+mut:
+	data &T    [required]
+	cap  usize [required]
+	len  usize [required]
+}
+
+pub fn new<T>() Vec<T> {
+	return Vec<T>{
+		data: unsafe { nil }
+		cap: 0
+		len: 0
+	}
+}
+
+pub fn (ar &Vec<T>) iter() Iter<T> {
+	return Iter<T>{
+		v: unsafe { ar }
+	}
+}
+
+pub struct Iter<T> {
+mut:
+	v   &Vec<T> [required]
+	pos usize
+}
+
+pub fn (mut iter Iter<T>) next() ?&T {
+	if iter.pos >= iter.v.len {
+		return none
+	}
+	defer {
+		iter.pos++
+	}
+	return unsafe { &iter.v.data[iter.pos] }
+}
+
+fn test_generics_for_in_iterate() {
+	mut goods := new<int>()
+	goods.call_generic_fn(fn (a &int) bool {
+		return *a > 1
+	})
+	assert true
+}
+
+fn (arr Vec<T>) call_generic_fn(cb fn (&T) bool) {
+	for val in arr.iter() {
+		println(cb(val))
+	}
+}


### PR DESCRIPTION
This PR fix generic for_in using iteration (fix #15969).

- Fix generic for_in using iteration.
- Add test.

```v
pub struct Vec<T> {
mut:
	data &T    [required]
	cap  usize [required]
	len  usize [required]
}

pub fn new<T>() Vec<T> {
	return Vec<T>{
		data: unsafe { nil }
		cap: 0
		len: 0
	}
}

pub fn (ar &Vec<T>) iter() Iter<T> {
	return Iter<T>{
		v: unsafe { ar }
	}
}

pub struct Iter<T> {
mut:
	v   &Vec<T> [required]
	pos usize
}

pub fn (mut iter Iter<T>) next() ?&T {
	if iter.pos >= iter.v.len {
		return none
	}
	defer {
		iter.pos++
	}
	return unsafe { &iter.v.data[iter.pos] }
}

fn main() {
	mut goods := new<int>()
	goods.call_generic_fn(fn (a &int) bool {
		return *a > 1
	})
        assert true
}

fn (arr Vec<T>) call_generic_fn(cb fn (&T) bool) {
	for val in arr.iter() {
		println(cb(val))
	}
}

PS D:\Test\v\tt1> v run .
```