### PR TITLE
fix: loading image from memory with stbi

### DIFF
--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -227,8 +227,9 @@ pub fn (mut ctx Context) create_image_from_memory(buf &u8, bufsize int) Image {
 		ok: stb_img.ok
 		data: stb_img.data
 		ext: stb_img.ext
-		id: ctx.image_cache.len
 	}
+	img.init_sokol_image()
+	img.id = ctx.image_cache.len
 	ctx.image_cache << img
 	return img
 }

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -108,13 +108,21 @@ pub fn load(path string) ?Image {
 
 // load_from_memory load an image from a memory buffer
 pub fn load_from_memory(buf &u8, bufsize int) ?Image {
+	return load_from_memory_with_channels(buf, bufsize, 0)
+}
+
+// load_from_memory_with_channels an image from a memory buffer, with user-defined number of image channels
+pub fn load_from_memory_with_channels(buf &u8, bufsize int, desired_channels int) ?Image {
 	mut res := Image{
 		ok: true
 		data: 0
 	}
-	flag := C.STBI_rgb_alpha
 	res.data = C.stbi_load_from_memory(buf, bufsize, &res.width, &res.height, &res.nr_channels,
-		flag)
+		desired_channels)
+	if desired_channels == 4 && res.nr_channels == 3 {
+		// Fix an alpha png bug
+		res.nr_channels = 4
+	}
 	if isnil(res.data) {
 		return error('stbi_image failed to load from memory')
 	}


### PR DESCRIPTION
Now image load from `stbi` works with `gg`.

I'm using it in https://git.envs.net/iacore/adbctl