### PR TITLE
checker: check undefined operation of the generic infix expr  (fix #15967)

### DIFF
--- a/vlib/v/checker/tests/generic_infix_plus_err.out
+++ b/vlib/v/checker/tests/generic_infix_plus_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/generic_infix_plus_err.vv:2:9: error: undefined operation `map[string]int` + `map[string]int`
+    1 | fn sum<T>(a T, b T) T {
+    2 |     return a + b
+      |            ~~~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/generic_infix_plus_err.vv
+++ b/vlib/v/checker/tests/generic_infix_plus_err.vv
@@ -1,0 +1,11 @@
+fn sum<T>(a T, b T) T {
+	return a + b
+}
+
+fn main() {
+	sum({
+		'id': 1
+	}, {
+		'id': 1
+	})
+}


### PR DESCRIPTION
This PR check undefined operation of the generic infix expr  (fix #15967).

- Check undefined operation of the generic infix expr.
- Add test.

```v
fn sum<T>(a T, b T) T {
	return a + b
}

fn main() {
	sum({
		'id': 1
	}, {
		'id': 1
	})
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:9: error: undefined operation `map[string]int` + `map[string]int`
    1 | fn sum<T>(a T, b T) T {
    2 |     return a + b
      |            ~~~~~
    3 | }
    4 |
```