### PR TITLE
parser: fix map init with multi enum keys (fix #15965)

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -192,6 +192,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 
 // parse tokens between braces
 fn (mut p Parser) map_init() ast.MapInit {
+	p.inside_map_init = true
 	first_pos := p.prev_tok.pos()
 	mut keys := []ast.Expr{}
 	mut vals := []ast.Expr{}
@@ -208,6 +209,7 @@ fn (mut p Parser) map_init() ast.MapInit {
 		}
 		comments << p.eat_comments()
 	}
+	p.inside_map_init = false
 	return ast.MapInit{
 		keys: keys
 		vals: vals

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -192,7 +192,11 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 
 // parse tokens between braces
 fn (mut p Parser) map_init() ast.MapInit {
+	old_inside_map_init := p.inside_map_init
 	p.inside_map_init = true
+	defer {
+		p.inside_map_init = old_inside_map_init
+	}
 	first_pos := p.prev_tok.pos()
 	mut keys := []ast.Expr{}
 	mut vals := []ast.Expr{}
@@ -209,7 +213,6 @@ fn (mut p Parser) map_init() ast.MapInit {
 		}
 		comments << p.eat_comments()
 	}
-	p.inside_map_init = false
 	return ast.MapInit{
 		keys: keys
 		vals: vals

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -387,13 +387,11 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 	}
 	// Infix
 	for precedence < p.tok.precedence() {
-		if p.tok.kind == .dot { //&& (p.tok.line_nr == p.prev_tok.line_nr
-			// TODO fix a bug with prev_tok.last_line
-			//|| p.prev_tok.pos().last_line == p.tok.line_nr) {
-			// if p.fileis('vcache.v') {
-			// p.warn('tok.line_nr = $p.tok.line_nr; prev_tok.line_nr=$p.prev_tok.line_nr;
-			// prev_tok.last_line=$p.prev_tok.pos().last_line')
-			//}
+		if p.tok.kind == .dot {
+			// no spaces or line break before dot in map_init
+			if p.inside_map_init && p.tok.pos - p.prev_tok.pos > p.prev_tok.len {
+				return node
+			}
 			node = p.dot_expr(node)
 			if p.name_error {
 				return node

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -59,6 +59,7 @@ mut:
 	inside_generic_params     bool // indicates if parsing between `<` and `>` of a method/function
 	inside_receiver_param     bool // indicates if parsing the receiver parameter inside the first `(` and `)` of a method
 	inside_struct_field_decl  bool
+	inside_map_init           bool
 	or_is_handled             bool       // ignore `or` in this expression
 	builtin_mod               bool       // are we in the `builtin` module?
 	mod                       string     // current module name

--- a/vlib/v/tests/map_init_with_multi_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_multi_enum_keys_test.v
@@ -1,0 +1,14 @@
+enum Foo {
+	a
+	b
+}
+
+fn test_map_init_with_multi_enum_keys() {
+	mp := {
+		Foo.a: 'A' // Foo.a: 'A', Works if comma is there.
+		.b:    'B',
+	}
+	println(mp)
+	assert mp[.a] == 'A'
+	assert mp[.b] == 'B'
+}

--- a/vlib/v/tests/map_init_with_multi_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_multi_enum_keys_test.v
@@ -3,6 +3,14 @@ enum Foo {
 	b
 }
 
+type NestedAbc = map[string]string | string
+
+enum NestedFoo {
+	a
+	b
+	c
+}
+
 fn test_map_init_with_multi_enum_keys() {
 	mp := {
 		Foo.a: 'A'
@@ -11,4 +19,24 @@ fn test_map_init_with_multi_enum_keys() {
 	println(mp)
 	assert mp[.a] == 'A'
 	assert mp[.b] == 'B'
+}
+
+fn test_nested_map_init_with_multi_enum_keys() {
+	mp := {
+		NestedFoo.a: NestedAbc({
+			'A': 'AA'
+		})
+		.b:          'B',
+		.c:          {
+			'c': 'C'
+		},
+	}
+	println(mp)
+	assert mp[.a]? == NestedAbc({
+		'A': 'AA'
+	})
+	assert mp[.b]? == NestedAbc('B')
+	assert mp[.c]? == NestedAbc({
+		'c': 'C'
+	})
 }

--- a/vlib/v/tests/map_init_with_multi_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_multi_enum_keys_test.v
@@ -5,8 +5,8 @@ enum Foo {
 
 fn test_map_init_with_multi_enum_keys() {
 	mp := {
-		Foo.a: 'A' // Foo.a: 'A', Works if comma is there.
-		.b:    'B',
+		Foo.a: 'A'
+		.b:    'B'
 	}
 	println(mp)
 	assert mp[.a] == 'A'

--- a/vlib/v/tests/map_init_with_multi_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_multi_enum_keys_test.v
@@ -6,7 +6,7 @@ enum Foo {
 fn test_map_init_with_multi_enum_keys() {
 	mp := {
 		Foo.a: 'A'
-		.b:    'B'
+		.b:    'B',
 	}
 	println(mp)
 	assert mp[.a] == 'A'


### PR DESCRIPTION
This PR fix map init with multi enum keys (fix #15965).

- Fix map init with multi enum keys.
- Add test.

```v
enum Foo {
	a
	b
}

fn main() {
	mp := {
		Foo.a: 'A' // Foo.a: 'A', Works if comma is there.
		.b:    'B'
	}
	println(mp)
	assert mp[.a] == 'A'
	assert mp[.b] == 'B'
}

PS D:\Test\v\tt1> v run .
{a: 'A', b: 'B'}
```