### PR TITLE
fmt: fix unreasonable wrap when infix expression is too long (fix #15635)

### DIFF
--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -94,9 +94,7 @@ pub fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Typ
 				c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
 					node.fmt_poss[i])
 			}
-			// v fmt doesn't format this correctly
-			if
-				c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
+			if c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
 				&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`] {
 				c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
 					node.fmt_poss[i])

--- a/vlib/v/fmt/tests/infix_expr_expected.vv
+++ b/vlib/v/fmt/tests/infix_expr_expected.vv
@@ -31,3 +31,9 @@ fn main() {
 		}
 	}
 }
+
+if c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
+	&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`] {
+	c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
+		node.fmt_poss[i])
+}

--- a/vlib/v/fmt/tests/infix_expr_input.vv
+++ b/vlib/v/fmt/tests/infix_expr_input.vv
@@ -22,3 +22,9 @@ fn main() {
 		}
 	}
 }
+
+if c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
+	&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`] {
+	c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
+		node.fmt_poss[i])
+}


### PR DESCRIPTION
1. Fix #15635
2. Add tests.

```v
if 
    c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
	&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`] {
	c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`', node.fmt_poss[i])
}
```

v fmt -w:
output:

```v
if c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
	&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`] {
	c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
		node.fmt_poss[i])
}
```
