### PR TITLE
cgen,checker: support simple voidptr casts in consts, without delaying the initialisation to _vinit

### DIFF
--- a/vlib/dl/dl.v
+++ b/vlib/dl/dl.v
@@ -4,6 +4,8 @@ pub const version = 1
 
 pub const dl_ext = get_shared_library_extension()
 
+pub const rtld_next = voidptr(-1)
+
 // get_shared_library_extension returns the platform dependent shared library extension
 // i.e. .dll on windows, .so on most unixes, .dylib on macos.
 [inline]

--- a/vlib/dl/dl_nix.c.v
+++ b/vlib/dl/dl_nix.c.v
@@ -38,5 +38,9 @@ pub fn sym(handle voidptr, symbol string) voidptr {
 // that occurred from a call to one of the `dl` functions, since the last
 // call to dlerror()
 pub fn dlerror() string {
-	return unsafe { cstring_to_vstring(C.dlerror()) }
+	sptr := C.dlerror()
+	if sptr == unsafe { nil } {
+		return ''
+	}
+	return unsafe { cstring_to_vstring(sptr) }
 }

--- a/vlib/dl/rtld_next_test.v
+++ b/vlib/dl/rtld_next_test.v
@@ -1,0 +1,14 @@
+import dl
+
+type RealOpen = fn (charptr, int, int) int
+
+fn test_rtld_next() {
+	$if windows {
+		println('skipping test_rtld_next on windows')
+		return
+	}
+	real_open := RealOpen((dl.sym(dl.rtld_next, 'open')))
+	println(ptr_str(real_open))
+	assert real_open != unsafe { nil }
+	assert dl.dlerror() == ''
+}

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -13,6 +13,7 @@ pub type ComptTimeConstValue = EmptyExpr
 	| u32
 	| u64
 	| u8
+	| voidptr
 
 pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
@@ -38,6 +39,18 @@ pub fn (val ComptTimeConstValue) int() ?int {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
 		return int(x)
+	}
+	return none
+}
+
+pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
+	match val {
+		i8, i16, int, i64 { return voidptr(val) }
+		u8, u16, u32, u64 { return voidptr(val) }
+		rune { return voidptr(val) }
+		f32, f64 { return voidptr(val) }
+		voidptr { return val }
+		string, EmptyExpr {}
 	}
 	return none
 }
@@ -87,6 +100,9 @@ pub fn (val ComptTimeConstValue) i64() ?i64 {
 		}
 		rune {
 			return int(val)
+		}
+		voidptr {
+			return i64(val)
 		}
 		EmptyExpr {}
 	}
@@ -164,6 +180,9 @@ pub fn (val ComptTimeConstValue) u64() ?u64 {
 		string {
 			return val.u64()
 		}
+		voidptr {
+			return u64(val)
+		}
 		rune {}
 		EmptyExpr {}
 	}
@@ -206,6 +225,9 @@ pub fn (val ComptTimeConstValue) f64() ?f64 {
 		}
 		f64 {
 			return val
+		}
+		voidptr {
+			return f64(val)
 		}
 		string {
 			return val.f64()
@@ -253,6 +275,9 @@ pub fn (val ComptTimeConstValue) string() ?string {
 		}
 		string {
 			return val
+		}
+		voidptr {
+			return ptr_str(val)
 		}
 		EmptyExpr {}
 	}

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -48,9 +48,8 @@ pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 		i8, i16, int, i64 { return voidptr(val) }
 		u8, u16, u32, u64 { return voidptr(val) }
 		rune { return voidptr(val) }
-		f32, f64 { return voidptr(val) }
 		voidptr { return val }
-		string, EmptyExpr {}
+		string, EmptyExpr, f32, f64 {}
 	}
 	return none
 }
@@ -226,12 +225,10 @@ pub fn (val ComptTimeConstValue) f64() ?f64 {
 		f64 {
 			return val
 		}
-		voidptr {
-			return f64(val)
-		}
 		string {
 			return val.f64()
 		}
+		voidptr {}
 		rune {}
 		EmptyExpr {}
 	}

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -45,9 +45,9 @@ pub fn (val ComptTimeConstValue) int() ?int {
 
 pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	match val {
-		i8, i16, int, i64 { return voidptr(val) }
-		u8, u16, u32, u64 { return voidptr(val) }
-		rune { return voidptr(val) }
+		i8, i16, int, i64 { return voidptr(i64(val)) }
+		u8, u16, u32, u64 { return voidptr(u64(val)) }
+		rune { return voidptr(u64(val)) }
 		voidptr { return val }
 		string, EmptyExpr, f32, f64 {}
 	}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -224,6 +224,10 @@ fn (mut c Checker) eval_comptime_const_expr(expr ast.Expr, nlevel int) ?ast.Comp
 			if expr.typ == ast.f64_type {
 				return cast_expr_value.f64() or { return none }
 			}
+			if expr.typ == ast.voidptr_type {
+				ptrvalue := cast_expr_value.voidptr() or { return none }
+				return ast.ComptTimeConstValue(ptrvalue)
+			}
 		}
 		ast.InfixExpr {
 			left := c.eval_comptime_const_expr(expr.left, nlevel + 1)?

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4716,6 +4716,9 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, field_name string
 				g.cleanups[mod].writeln('\tstring_free(&$cname);')
 			}
 		}
+		voidptr {
+			g.const_decl_write_precomputed(mod, styp, cname, field_name, '(voidptr)(0x$ct_value)')
+		}
 		ast.EmptyExpr {
 			return false
 		}


### PR DESCRIPTION
With this PR, the following program compiles:
```v
module main

import dl

#flag -D_GNU_SOURCE

type RealOpen = fn(charptr, int, int) int

[export: open]
fn open(filename charptr, oflag int, mode int) int {
	println('dl.rtld_next: ${ptr_str(dl.rtld_next)}')
	real_open := RealOpen((dl.sym(dl.rtld_next, "open")))
	println('> real_open: ${ptr_str(real_open)} | filename:
	${unsafe{cstring_to_vstring(filename)}}')
	return real_open(filename, oflag, mode)
}
```

... and produces:
```
dl.rtld_next: ffffffffffffffff
> real_open: 7ffff7e95ce0 | filename: /proc/stat
```