### PR TITLE
cgen: fix str() fails when the structure 'charptr' type field is nil (fix #15970)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -932,7 +932,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name stri
 		} else {
 			// manage C charptr
 			if field.typ in ast.charptr_types {
-				fn_body.write_string('tos2((byteptr)$func)')
+				fn_body.write_string('tos4((byteptr)$func)')
 			} else {
 				if field.typ.is_ptr() && sym.kind == .struct_ {
 					funcprefix += '(indent_count > 25)? _SLIT("<probably circular>") : '

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -763,7 +763,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 		} else {
 			// manage C charptr
 			if field.typ in ast.charptr_types {
-				fn_builder.write_string('tos2((byteptr)$func)')
+				fn_builder.write_string('tos4((byteptr)$func)')
 			} else {
 				if field.typ.is_ptr() && sym.kind == .struct_ {
 					fn_builder.write_string('(indent_count > 25)? new string("<probably circular>") : ')

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -463,3 +463,14 @@ fn test_c_struct_typedef() {
 }'
 	}
 }
+
+struct CharptrToStr {
+	cp charptr = charptr(0)
+}
+
+fn test_charptr_nil_to_str() {
+	c := CharptrToStr{}
+	assert c.str() == r'CharptrToStr{
+    cp: C""
+}'
+}


### PR DESCRIPTION
1. Fix #15970 
2. Add tests.

```v
struct Foo {
	cp charptr = charptr(0)
}

fn main() {
	println(charptr(0))
	f := Foo{}
	println(f)
}
```

output:

```
0x0
Foo{
    cp: C""
}
```
