### PR TITLE
fmt: remove comma inside map_init using multi_line

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2305,11 +2305,6 @@ pub fn (mut f Fmt) map_init(node ast.MapInit) {
 		f.write(': ')
 		f.write(strings.repeat(` `, max_field_len - skey.len))
 		f.expr(node.vals[i])
-		if key is ast.EnumVal && skey.starts_with('.') {
-			// enforce the use of `,` for maps with short enum keys, otherwise there is ambiguity
-			// when the values are struct values, and the code will no longer parse properly
-			f.write(',')
-		}
 		f.comments(node.comments[i], prev_line: node.vals[i].pos().last_line, has_nl: false)
 		f.writeln('')
 	}

--- a/vlib/v/fmt/tests/maps_expected.vv
+++ b/vlib/v/fmt/tests/maps_expected.vv
@@ -22,6 +22,6 @@ explicit_init_with_value := {
 }
 
 headers := http.new_header_from_map({
-	.content_type:  'application/json',
-	.authorization: 'Bearer abcdef',
+	.content_type:  'application/json'
+	.authorization: 'Bearer abcdef'
 })

--- a/vlib/v/tests/map_init_with_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_enum_keys_test.v
@@ -12,7 +12,7 @@ fn test_map_init_with_enum_keys() {
 	mut st := St{}
 
 	st.m = {
-		.ea: 'a',
+		.ea: 'a'
 	}
 
 	println(st.m)

--- a/vlib/v/tests/map_init_with_multi_enum_keys_test.v
+++ b/vlib/v/tests/map_init_with_multi_enum_keys_test.v
@@ -14,7 +14,7 @@ enum NestedFoo {
 fn test_map_init_with_multi_enum_keys() {
 	mp := {
 		Foo.a: 'A'
-		.b:    'B',
+		.b:    'B'
 	}
 	println(mp)
 	assert mp[.a] == 'A'
@@ -26,10 +26,10 @@ fn test_nested_map_init_with_multi_enum_keys() {
 		NestedFoo.a: NestedAbc({
 			'A': 'AA'
 		})
-		.b:          'B',
+		.b:          'B'
 		.c:          {
 			'c': 'C'
-		},
+		}
 	}
 	println(mp)
 	assert mp[.a]? == NestedAbc({

--- a/vlib/v/tests/vargs_with_enum_value_test.v
+++ b/vlib/v/tests/vargs_with_enum_value_test.v
@@ -12,8 +12,8 @@ fn foo(n int, m ...map[Foo]int) {
 
 fn test_vargs_with_enum_value() {
 	foo(1, {
-		.a: 1,
+		.a: 1
 	}, {
-		.b: 2,
+		.b: 2
 	})
 }


### PR DESCRIPTION
This PR remove comma inside map_init using multi_line.

```v
enum Foo {
	a
	b
}

type NestedAbc = map[string]string | string

enum NestedFoo {
	a
	b
	c
}

fn test_map_init_with_multi_enum_keys() {
	mp := {
		Foo.a: 'A'
		.b:    'B'
	}
	println(mp)
	assert mp[.a] == 'A'
	assert mp[.b] == 'B'
}

fn test_nested_map_init_with_multi_enum_keys() {
	mp := {
		NestedFoo.a: NestedAbc({
			'A': 'AA'
		})
		.b:          'B'
		.c:          {
			'c': 'C'
		}
	}
	println(mp)
	assert mp[.a]? == NestedAbc({
		'A': 'AA'
	})
	assert mp[.b]? == NestedAbc('B')
	assert mp[.c]? == NestedAbc({
		'c': 'C'
	})
}
```