### PR TITLE
cgen: fix dependency order error between sumtype and fixed array type (fix #16003)

### DIFF
--- a/vlib/v/gen/c/testdata/sumtype_struct_depend_order.vv
+++ b/vlib/v/gen/c/testdata/sumtype_struct_depend_order.vv
@@ -1,0 +1,20 @@
+type OneOrTwo = One | Two
+
+struct One {
+	sig   u32
+	num   u32
+	items [16]Three
+}
+
+struct Two {
+	sig   u32
+	num   u64
+	items [16]Three
+}
+
+struct Three {
+}
+
+pub fn (obj OneOrTwo) get_sig() u32 {
+	return obj.sig
+}


### PR DESCRIPTION
1. Fix #16003
2. Add tests.

```v
type OneOrTwo = One | Two

struct One {
	sig u32
	num u32
	items [16]Three
}

struct Two {
	sig u32
	num u64
	items [16]Three
}

struct Three {
}

pub fn (obj OneOrTwo) get_sig() u32 {
	return obj.sig
}
```

output:

passed.