### PR TITLE
checker: notice generic route methods of vweb

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -11,6 +11,18 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			eprintln('>>> post processing node.name: ${node.name:-30} | $node.generic_names <=> $c.table.cur_concrete_types')
 		}
 	}
+	// notice vweb route methods (non-generic method)
+	if node.generic_names.len > 0 {
+		typ_vweb_result := c.table.find_type_idx('vweb.Result')
+		if node.return_type == typ_vweb_result {
+			rec_sym := c.table.sym(node.receiver.typ)
+			if rec_sym.kind == .struct_ {
+				if _ := c.table.find_field_with_embeds(rec_sym, 'Context') {
+					c.note('generic method routes of vweb will be skipped', node.pos)
+				}
+			}
+		}
+	}
 	if node.generic_names.len > 0 && c.table.cur_concrete_types.len == 0 {
 		// Just remember the generic function for now.
 		// It will be processed later in c.post_process_generic_fns,


### PR DESCRIPTION
This PR notice generic route methods of vweb. (related #15888)

```v
import vweb

struct ApiSuccessResponse<T> {
	success bool
	result  T
}

struct App {
	vweb.Context
}

fn (mut app App) json_success<T>(result T) vweb.Result {
	response := ApiSuccessResponse<T>{
		success: true
		result: result
	}

	return app.json(response)
}

fn main() {
	mut app := &App{}

	vweb.run(app, 80)
}

PS D:\Test\v\tt1> v run .
./tt1.v:12:1: notice: generic method routes of vweb will be skipped
   10 | }
   11 |
   12 | fn (mut app App) json_success<T>(result T) vweb.Result {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   13 |     response := ApiSuccessResponse<T>{
   14 |         success: true
[Vweb] Running app on http://localhost:80/
```