### PR TITLE
checker: check type mismatch of return match expr (fix #15989)

### DIFF
--- a/vlib/v/checker/tests/return_match_expr_type_mismatch.out
+++ b/vlib/v/checker/tests/return_match_expr_type_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/return_match_expr_type_mismatch.vv:18:16: error: return type mismatch, it should be `SomeTuple`
+   16 | fn get_file(item PossOwner) ?SomeTuple {
+   17 |     return match item.pos {
+   18 |         Poss1 { item.pos }
+      |                      ~~~
+   19 |         else { error('not poss1') }
+   20 |     }

--- a/vlib/v/checker/tests/return_match_expr_type_mismatch.vv
+++ b/vlib/v/checker/tests/return_match_expr_type_mismatch.vv
@@ -1,0 +1,34 @@
+struct Poss1 {}
+
+struct Poss2 {}
+
+type Possibilities = Poss1 | Poss2
+
+struct PossOwner {
+	pos Possibilities
+}
+
+struct SomeTuple {
+	p PossOwner
+	f Poss1
+}
+
+fn get_file(item PossOwner) ?SomeTuple {
+	return match item.pos {
+		Poss1 { item.pos }
+		else { error('not poss1') }
+	}
+}
+
+fn main() {
+	item := PossOwner{
+		pos: Poss1{}
+	}
+
+	r := get_file(item) or {
+		println('err=$err')
+		return
+	}
+
+	println('got $r')
+}


### PR DESCRIPTION
This PR check type mismatch of return match expr (fix #15989).

- Check type mismatch of return match expr.
- Add test.

```v
struct Poss1 {}

struct Poss2 {}

type Possibilities = Poss1 | Poss2

struct PossOwner {
	pos Possibilities
}

struct SomeTuple {
	p PossOwner
	f Poss1
}

fn get_file(item PossOwner) ?SomeTuple {
	return match item.pos {
		Poss1 { item.pos }
		else { error('not poss1') }
	}
}

fn main() {
	item := PossOwner{
		pos: Poss1{}
	}

	r := get_file(item) or {
		println('err=$err')
		return
	}

	println('got $r')
}

PS D:\Test\v\tt1> v run .
./tt1.v:18:16: error: return type mismatch, it should be `SomeTuple`
   16 | fn get_file(item PossOwner) ?SomeTuple {
   17 |     return match item.pos {
   18 |         Poss1 { item.pos }
      |                      ~~~
   19 |         else { error('not poss1') }
   20 |     }
```