### PR TITLE
cgen: fix wrong when string attributes with quotes (fix #15194)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -202,6 +202,9 @@ fn cgen_attrs(attrs []ast.Attr) []string {
 		if attr.arg.len > 0 {
 			s += ': $attr.arg'
 		}
+		if attr.kind == .string {
+			s = escape_quotes(s)
+		}
 		res << '_SLIT("$s")'
 	}
 	return res

--- a/vlib/v/gen/c/testdata/attr_string_quotes_escape.out
+++ b/vlib/v/gen/c/testdata/attr_string_quotes_escape.out
@@ -1,0 +1,7 @@
+FunctionData{
+    name: 'sample_method'
+    attrs: ['option: "1"']
+    args: []
+    return_type: 1
+    typ: 0
+}

--- a/vlib/v/gen/c/testdata/attr_string_quotes_escape.vv
+++ b/vlib/v/gen/c/testdata/attr_string_quotes_escape.vv
@@ -1,0 +1,11 @@
+struct Dummy {}
+
+['option: "1"']
+fn (d Dummy) sample_method() {
+}
+
+fn main() {
+	$for method in Dummy.methods {
+		println(method)
+	}
+}

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -83,3 +83,15 @@ fn (mut g Gen) fn_var_signature(return_type ast.Type, arg_types []ast.Type, var_
 	sig += ')'
 	return sig
 }
+
+// escape quotes for string
+fn escape_quotes(val string) string {
+	bs := '\\'
+	unescaped_val := val.replace('$bs$bs', '\x01').replace_each([
+		"$bs'",
+		"'",
+		'$bs"',
+		'"',
+	])
+	return unescaped_val.replace_each(['\x01', '$bs$bs', "'", "$bs'", '"', '$bs"'])
+}


### PR DESCRIPTION
1. Fix #15194
2. Add tests.

```v
struct Dummy {}

['option1: "1"']
["option2: '1'"]
['option3: \'1\'']
["option4: \"1\""]
fn (d Dummy) sample_method() {
}

fn main() {
	$for method in Dummy.methods {
		println(method)
	}
}
```

output:

```
FunctionData{
    name: 'sample_method'
    attrs: ['option1: "1"', 'option2: '1'', 'option3: '1'', 'option4: "1"']
    args: []
    return_type: 1
    typ: 0
}
```
