### PR TITLE
checker: fix fn returning result of array (fix #15973)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -121,7 +121,7 @@ pub fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.expected_type.clear_flag(.shared_f).deref()
 		} else {
 			c.expected_type
-		}.clear_flag(.optional)
+		}.clear_flag(.optional).clear_flag(.result)
 	}
 	// [1,2,3]
 	if node.exprs.len > 0 && node.elem_type == ast.void_type {

--- a/vlib/v/tests/fn_return_opt_or_res_of_array_test.v
+++ b/vlib/v/tests/fn_return_opt_or_res_of_array_test.v
@@ -1,0 +1,13 @@
+fn foo_res() ![]string {
+	return []
+}
+
+fn foo_opt() ?[]string {
+	return []
+}
+
+fn test_fn_return_opt_or_res_of_array() {
+	foo_res() or { panic(err) }
+	foo_opt() or { panic(err) }
+	assert true
+}


### PR DESCRIPTION
This PR fix fn returning result of array (fix #15973).

- Fix fn returning result of array.
- Add test.

```v
fn foo_res() ![]string {
	return []
}

fn foo_opt() ?[]string {
	return []
}

fn main() {
	foo_res() or { panic(err) }
	foo_opt() or { panic(err) }
	assert true
}

PS D:\Test\v\tt1> v run .
```