### PR TITLE
cgen: fix generic struct init with generic cast

### DIFF
--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -15,15 +15,26 @@ fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 		// This should have already happened in the checker, since it also calls
 		// `resolve_generic_to_concrete`. `g.table` is made non-mut to make sure
 		// no one else can accidentally mutates the table.
-		unsafe {
-			mut mut_table := &ast.Table(g.table)
-			if t_typ := mut_table.resolve_generic_to_concrete(typ, if g.cur_fn != nil {
-				g.cur_fn.generic_names
-			} else {
-				[]string{}
-			}, g.cur_concrete_types)
+		mut mut_table := unsafe { &ast.Table(g.table) }
+		if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0 {
+			if t_typ := mut_table.resolve_generic_to_concrete(typ, g.cur_fn.generic_names,
+				g.cur_concrete_types)
 			{
 				return t_typ
+			}
+		} else if g.inside_struct_init {
+			if g.cur_struct_init_typ != 0 {
+				sym := g.table.sym(g.cur_struct_init_typ)
+				if sym.info is ast.Struct {
+					if sym.info.generic_types.len > 0 {
+						generic_names := sym.info.generic_types.map(g.table.sym(it).name)
+						if t_typ := mut_table.resolve_generic_to_concrete(typ, generic_names,
+							sym.info.concrete_types)
+						{
+							return t_typ
+						}
+					}
+				}
 			}
 		}
 	}

--- a/vlib/v/tests/generic_struct_init_with_generic_cast_test.v
+++ b/vlib/v/tests/generic_struct_init_with_generic_cast_test.v
@@ -1,0 +1,21 @@
+pub struct Range<T> {
+	start T
+	end   T [required]
+	step  T = T(1)
+mut:
+	now T
+}
+
+fn test_generic_struct_init_with_generic_cast() {
+	r1 := Range<int>{
+		end: 10
+	}
+	println(r1)
+
+	r2 := Range<f64>{
+		end: 2.2
+	}
+	println(r2)
+
+	assert true
+}


### PR DESCRIPTION
This PR fix generic struct init with generic cast (fix #16011).

- Fix generic struct init with generic cast.
- Add test.

```v
pub struct Range<T> {
	start T
	end   T [required]
	step  T = T(1)
mut:
	now T
}

fn main() {
	r1 := Range<int>{
		end: 10
	}
	println(r1)

	r2 := Range<f64>{
		end: 2.2
	}
	println(r2)

	assert true
}

PS D:\Test\v\tt1> v run .
Range<int>{
    start: 0
    end: 10
    step: 1
    now: 0
}
Range<f64>{
    start: 0
    end: 2.2
    step: 1
    now: 0
}
```