### PR TITLE
cgen: fix map with optional or result (fix #15972)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3757,7 +3757,7 @@ fn (mut g Gen) unlock_locks() {
 
 fn (mut g Gen) map_init(node ast.MapInit) {
 	unwrap_key_typ := g.unwrap_generic(node.key_type)
-	unwrap_val_typ := g.unwrap_generic(node.value_type)
+	unwrap_val_typ := g.unwrap_generic(node.value_type).clear_flag(.optional).clear_flag(.result)
 	key_typ_str := g.typ(unwrap_key_typ)
 	value_typ_str := g.typ(unwrap_val_typ)
 	value_sym := g.table.sym(unwrap_val_typ)

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -378,7 +378,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	elem_type_str := if elem_sym.kind == .function {
 		'voidptr'
 	} else {
-		g.typ(elem_type)
+		g.typ(elem_type.clear_flag(.optional).clear_flag(.result))
 	}
 	get_and_set_types := elem_sym.kind in [.struct_, .map]
 	if g.is_assign_lhs && !g.is_arraymap_set && !get_and_set_types {

--- a/vlib/v/tests/map_value_with_optional_result_test.v
+++ b/vlib/v/tests/map_value_with_optional_result_test.v
@@ -1,0 +1,11 @@
+import os
+
+struct AdbDevice {
+	opts map[string]?string
+}
+
+fn test_map_value_with_optional_result() {
+	// void warnings
+	_ := os.max_path_len
+	assert true
+}

--- a/vlib/v/tests/map_value_with_optional_result_test.v
+++ b/vlib/v/tests/map_value_with_optional_result_test.v
@@ -5,7 +5,7 @@ struct AdbDevice {
 }
 
 fn test_map_value_with_optional_result() {
-	// void warnings
+	// avoid warnings
 	_ := os.max_path_len
 	assert true
 }


### PR DESCRIPTION
1. Fix #15972
2. Add tests.

```v
import os

struct AdbDevice {
	opts1 map[string]?string
	opts2 map[string]!string
}

fn test_map_value_with_optional_result() {
	// avoid warnings
	_ := os.max_path_len
	assert true
}
```

output:

passed.
