### PR TITLE
Adding C function putchar to supported builtins

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -184,6 +184,7 @@ fn C.strchr(s &char, c int) &char
 [trusted]
 fn C.getchar() int
 
+[trusted]
 fn C.putchar(int) int
 
 fn C.strdup(s &char) &char

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -184,6 +184,8 @@ fn C.strchr(s &char, c int) &char
 [trusted]
 fn C.getchar() int
 
+fn C.putchar(int) int
+
 fn C.strdup(s &char) &char
 
 fn C.strncasecmp(s &char, s2 &char, n int) int


### PR DESCRIPTION
The C function putchar is missing in "v\vlib\builtin\cfns.c.v". Adding this will help us enable it in c2v as supported built-in function. And it would help us translate programs like below.
```c
#include <stdio.h>

int main(void)
{
  int c;

  c = getchar();
  while (c != EOF)
    {
      putchar(c);
      c = getchar();
    }

  return 0;
}
```