### PR TITLE
cgen: fix map with optional or result on return

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -378,7 +378,11 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	elem_type_str := if elem_sym.kind == .function {
 		'voidptr'
 	} else {
-		g.typ(elem_type.clear_flag(.optional).clear_flag(.result))
+		if g.inside_return {
+			g.typ(elem_type)
+		} else {
+			g.typ(elem_type.clear_flag(.optional).clear_flag(.result))
+		}
 	}
 	get_and_set_types := elem_sym.kind in [.struct_, .map]
 	if g.is_assign_lhs && !g.is_arraymap_set && !get_and_set_types {

--- a/vlib/v/tests/map_value_with_optional_result_test.v
+++ b/vlib/v/tests/map_value_with_optional_result_test.v
@@ -9,3 +9,7 @@ fn test_map_value_with_optional_result() {
 	_ := os.max_path_len
 	assert true
 }
+
+fn foo(arg map[string]?string) ?string {
+	return arg['akey']
+}


### PR DESCRIPTION
1. This pr is a supplement and fix to pr#16036
2. Add tests.

```v
import os

struct AdbDevice {
	opts map[string]?string
}

fn test_map_value_with_optional_result() {
	// avoid warnings
	_ := os.max_path_len
	assert true
}

fn foo(arg map[string]?string) ?string {
	return arg['akey']
}
```

run passed.


I'm so sorry to miss a situation: when returning value of map[], still need to keep its optional. 😭 

