### PR TITLE
cgen: fix fn with optional of multi_return (fix #16038)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4166,11 +4166,11 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 }
 
 fn (mut g Gen) concat_expr(node ast.ConcatExpr) {
-	mut styp := g.typ(node.return_type)
+	mut styp := g.typ(node.return_type.clear_flag(.optional).clear_flag(.result))
 	if g.inside_return {
-		styp = g.typ(g.fn_decl.return_type)
+		styp = g.typ(g.fn_decl.return_type.clear_flag(.optional).clear_flag(.result))
 	} else if g.inside_or_block {
-		styp = g.typ(g.or_expr_return_type)
+		styp = g.typ(g.or_expr_return_type.clear_flag(.optional).clear_flag(.result))
 	}
 	sym := g.table.sym(node.return_type)
 	is_multi := sym.kind == .multi_return

--- a/vlib/v/tests/fn_with_opt_or_res_of_multi_return_test.v
+++ b/vlib/v/tests/fn_with_opt_or_res_of_multi_return_test.v
@@ -1,0 +1,25 @@
+struct Aa {
+	x string
+}
+
+struct Bb {
+	a int
+}
+
+fn give(succ Aa) ?(Aa, Bb) {
+	return match succ.x {
+		'x' {
+			succ, Bb{}
+		}
+		else {
+			error('nok')
+		}
+	}
+}
+
+fn test_fn_with_opt_of_multi_return() {
+	res, _ := give(Aa{ x: 'x' }) or { panic('got unexpected err') }
+
+	assert res.x == 'x'
+	println('success')
+}


### PR DESCRIPTION
This PR fix fn with optional of multi_return (fix #16038).

- Fix fn with optional of multi_return.
- Add test.

```v
struct Aa {
	x string
}

struct Bb {
	a int
}

fn give(succ Aa) ?(Aa, Bb) {
	return match succ.x {
		'x' {
			succ, Bb{}
		}
		else {
			error('nok')
		}
	}
}

fn main() {
	res, _ := give(Aa{ x: 'x' }) or { panic('got unexpected err') }

	assert res.x == 'x'
	println('success')
}

PS D:\Test\v\tt1> v run .
success
```