### PR TITLE
ast: fix missing 'optional' and 'result' in type name and cname of map

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -982,7 +982,8 @@ pub fn (t &Table) thread_name(return_type Type) string {
 	return_type_sym := t.sym(return_type)
 	ptr := if return_type.is_ptr() { '&' } else { '' }
 	opt := if return_type.has_flag(.optional) { '?' } else { '' }
-	return 'thread $opt$ptr$return_type_sym.name'
+	res := if return_type.has_flag(.result) { '!' } else { '' }
+	return 'thread $opt$res$ptr$return_type_sym.name'
 }
 
 [inline]
@@ -996,8 +997,9 @@ pub fn (t &Table) thread_cname(return_type Type) string {
 	}
 	return_type_sym := t.sym(return_type)
 	suffix := if return_type.is_ptr() { '_ptr' } else { '' }
-	prefix := if return_type.has_flag(.optional) { '_option_' } else { '' }
-	return '__v_thread_$prefix$return_type_sym.cname$suffix'
+	opt := if return_type.has_flag(.optional) { '_option_' } else { '' }
+	res := if return_type.has_flag(.result) { '_result_' } else { '' }
+	return '__v_thread_$opt$res$return_type_sym.cname$suffix'
 }
 
 // map_source_name generates the original name for the v source.
@@ -1007,7 +1009,9 @@ pub fn (t &Table) map_name(key_type Type, value_type Type) string {
 	key_type_sym := t.sym(key_type)
 	value_type_sym := t.sym(value_type)
 	ptr := if value_type.is_ptr() { '&' } else { '' }
-	return 'map[$key_type_sym.name]$ptr$value_type_sym.name'
+	opt := if value_type.has_flag(.optional) { '?' } else { '' }
+	res := if value_type.has_flag(.result) { '!' } else { '' }
+	return 'map[$key_type_sym.name]$opt$res$ptr$value_type_sym.name'
 }
 
 [inline]
@@ -1015,7 +1019,9 @@ pub fn (t &Table) map_cname(key_type Type, value_type Type) string {
 	key_type_sym := t.sym(key_type)
 	value_type_sym := t.sym(value_type)
 	suffix := if value_type.is_ptr() { '_ptr' } else { '' }
-	return 'Map_${key_type_sym.cname}_$value_type_sym.cname' + suffix
+	opt := if value_type.has_flag(.optional) { '_option_' } else { '' }
+	res := if value_type.has_flag(.result) { '_result_' } else { '' }
+	return 'Map_${key_type_sym.cname}_$opt$res$value_type_sym.cname$suffix'
 }
 
 pub fn (mut t Table) find_or_register_chan(elem_type Type, is_mut bool) int {

--- a/vlib/v/fmt/tests/map_value_with_optional_result_expected.vv
+++ b/vlib/v/fmt/tests/map_value_with_optional_result_expected.vv
@@ -1,0 +1,13 @@
+struct Foo {
+	map1 map[string]!string
+	map2 map[string]?string
+}
+
+fn foo() {
+	map1 := map[string]!string{}
+	map2 := map[string]?string{}
+}
+
+fn bar(arg map[string]?string) ?string {
+	return arg['akey']
+}

--- a/vlib/v/fmt/tests/map_value_with_optional_result_input.vv
+++ b/vlib/v/fmt/tests/map_value_with_optional_result_input.vv
@@ -1,0 +1,13 @@
+struct Foo {
+	map1 map[string]!string
+	map2 map[string]?string
+}
+
+fn foo() {
+	map1 := map[string]!string{}
+	map2 := map[string]?string{}
+}
+
+fn bar(arg map[string]?string) ?string {
+	return arg['akey']
+}

--- a/vlib/v/tests/map_value_with_optional_result_test.v
+++ b/vlib/v/tests/map_value_with_optional_result_test.v
@@ -13,3 +13,17 @@ fn test_map_value_with_optional_result() {
 fn foo(arg map[string]?string) ?string {
 	return arg['akey']
 }
+
+struct Foo {
+	map1 map[string]!string
+	map2 map[string]?string
+}
+
+fn bar() {
+	map1 := map[string]?string{}
+	map2 := map[string]!string{}
+}
+
+fn baz(arg map[string]?string) ?string {
+	return arg['akey']
+}


### PR DESCRIPTION
This PR fixes the missing optional and result in the type name and cname of the map.

For this reason, fmt and run fail:

```v
struct Foo {
	map1 map[string]!string
	map2 map[string]?string
}

fn foo() {
	map1 := map[string]!string{}
	map2 := map[string]!string{}
}

fn bar(arg map[string]?string) ?string {
	return arg['akey']
}
```

fmt -w:

```v
struct Foo {
	map1 map[string]!string
	map2 map[string]!string
}

fn foo() {
	map1 := map[string]!string{}
	map2 := map[string]!string{}
}

fn bar(arg map[string]!string) ?string {
	return arg['akey']
}
```

and run fail:

```
a.v:12:12: error: cannot use `!string` as type `?string` in return argument
   10 | 
   11 | fn bar(arg map[string]?string) ?string {
   12 |     return arg['akey']
      |               ~~~~~~~~
   13 | }
```
