### PR TITLE
cgen: fix assigning optional of multi_return with heap (fix #16041)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -529,9 +529,6 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 		styp := if ident.name in g.defer_vars { '' } else { g.typ(node.left_types[i]) }
 		if node.op == .decl_assign {
 			g.write('$styp ')
-			if is_auto_heap {
-				g.write('*')
-			}
 		}
 		if lx.is_auto_deref_var() {
 			g.write('*')

--- a/vlib/v/tests/assign_optional_of_multi_return_with_heap_test.v
+++ b/vlib/v/tests/assign_optional_of_multi_return_with_heap_test.v
@@ -1,0 +1,50 @@
+struct Poss1 {}
+
+struct Poss2 {}
+
+type Possibilities = Poss1 | Poss2
+
+// comment out this attribute to make error go away BUT now you need to remember to use &PossOwner everytime you create new instance :(
+[heap]
+pub struct PossOwner {
+pub:
+	name    string
+	details Possibilities
+}
+
+fn (t PossOwner) get_file(path string) ?(PossOwner, Poss1) {
+	match t.details {
+		Poss1 { return t, t.details }
+		else { return error('not a file') }
+	}
+}
+
+fn (item PossOwner) check() ?int {
+	assert item.name == 'x'
+
+	return 0
+}
+
+fn somefun() ?int {
+	t := PossOwner{
+		name: 'x'
+		details: Poss1{}
+	}
+
+	path_info, _ := t.get_file('') or {
+		println('NOTOK1')
+		return 1
+	}
+
+	_ := path_info.check() or {
+		println('NOTOK2')
+		return 2
+	}
+
+	return 0
+}
+
+fn test_assign_optional_of_multi_return_with_heap() {
+	somefun() or { return }
+	println('success')
+}


### PR DESCRIPTION
This PR fix assigning optional of multi_return with heap (fix #16041).

- Fix assigning optional of multi_return with heap.
- Add test.

```v
struct Poss1 {}

struct Poss2 {}

type Possibilities = Poss1 | Poss2

// comment out this attribute to make error go away BUT now you need to remember to use &PossOwner everytime you create new instance :(
[heap]
pub struct PossOwner {
pub:
	name    string
	details Possibilities
}

fn (t PossOwner) get_file(path string) ?(PossOwner, Poss1) {
	match t.details {
		Poss1 { return t, t.details }
		else { return error('not a file') }
	}
}

fn (item PossOwner) check() ?int {
	assert item.name == 'x'

	return 0
}

fn somefun() ?int {
	t := PossOwner{
		name: 'x'
		details: Poss1{}
	}

	path_info, _ := t.get_file('') or {
		println('NOTOK1')
		return 1
	}

	_ := path_info.check() or {
		println('NOTOK2')
		return 2
	}

	return 0
}

fn main() {
	somefun() or { return }
	println('success')
}

PS D:\Test\v\tt1> v run .
success
```