### PR TITLE
cgen: fix mismatch when the default expression or block has optional (fix #16050)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1070,7 +1070,9 @@ fn (mut c Checker) check_or_last_stmt(stmt ast.Stmt, ret_type ast.Type, expr_ret
 					return
 				}
 				if c.check_types(stmt.typ, expr_return_type) {
-					return
+					if stmt.typ.is_ptr() == expr_return_type.is_ptr() {
+						return
+					}
 				}
 				// opt_returning_string() or { ... 123 }
 				type_name := c.table.type_to_str(stmt.typ)

--- a/vlib/v/checker/tests/optional_or_block_mismatch.out
+++ b/vlib/v/checker/tests/optional_or_block_mismatch.out
@@ -4,4 +4,10 @@ vlib/v/checker/tests/optional_or_block_mismatch.vv:10:18: error: wrong return ty
    10 |     x := foo() or { Bar{} }
       |                     ~~~~~
    11 |     println(x)
-   12 | }
+   12 |
+vlib/v/checker/tests/optional_or_block_mismatch.vv:13:13: error: the default expression type in the `or` block should be `&Bar`, instead you gave a value of type `Bar`
+   11 |     println(x)
+   12 | 
+   13 |     foo() or { Bar{} }
+      |                ~~~~~
+   14 | }

--- a/vlib/v/checker/tests/optional_or_block_mismatch.vv
+++ b/vlib/v/checker/tests/optional_or_block_mismatch.vv
@@ -9,4 +9,6 @@ fn foo() ?&Bar {
 fn main() {
 	x := foo() or { Bar{} }
 	println(x)
+
+	foo() or { Bar{} }
 }


### PR DESCRIPTION
1. Fix: #16050 
2. Add tests.

```v
module main

struct Bar {}

fn foo() ?&Bar {
	return none
}

fn main() {
	x := foo() or { Bar{} }
	println(x)

	foo() or { Bar{} }
}
```

output:

```
vlib/v/checker/tests/optional_or_block_mismatch.vv:10:18: error: wrong return type `Bar` in the `or {}` block, expected `&Bar`
    8 | 
    9 | fn main() {
   10 |     x := foo() or { Bar{} }
      |                     ~~~~~
   11 |     println(x)
   12 |
vlib/v/checker/tests/optional_or_block_mismatch.vv:13:13: error: the default expression type in the `or` block should be `&Bar`, instead you gave a value of type `Bar`
   11 |     println(x)
   12 | 
   13 |     foo() or { Bar{} }
      |                ~~~~~
   14 | }
```
