### PR TITLE
checker: check error for fn call with extra parenthesis (fix #16026)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -715,11 +715,13 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 	}
 	if !found && mut node.left is ast.CallExpr {
 		c.expr(node.left)
-		sym := c.table.sym(node.left.return_type)
-		if sym.info is ast.FnType {
-			node.return_type = sym.info.func.return_type
-			found = true
-			func = sym.info.func
+		if node.left.return_type != 0 {
+			sym := c.table.sym(node.left.return_type)
+			if sym.info is ast.FnType {
+				node.return_type = sym.info.func.return_type
+				found = true
+				func = sym.info.func
+			}
 		}
 	}
 	// already prefixed (mod.fn) or C/builtin/main

--- a/vlib/v/checker/tests/fn_call_with_extra_parenthesis.out
+++ b/vlib/v/checker/tests/fn_call_with_extra_parenthesis.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv:5:7: error: expected 1 arguments, but got 0
+    3 |
+    4 | fn main() {
+    5 |     main.doit()(1)
+      |          ~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv
+++ b/vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv
@@ -1,0 +1,6 @@
+fn doit(i int) {
+}
+
+fn main() {
+	main.doit()(1)
+}


### PR DESCRIPTION
This PR check error for fn call with extra parenthesis (fix #16026).

- Check error for fn call with extra parenthesis.
- Add test.

```v
fn doit(i int) {
}

fn main() {
	main.doit()(1)
}

PS D:\Test\v\tt1> v run .
./tt1.v:5:7: error: expected 1 arguments, but got 0
    3 |
    4 | fn main() {
    5 |     main.doit()(1)
      |          ~~~~~~
    6 | }
```