### PR TITLE
os: add to and from slash function

### DIFF
--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -220,6 +220,24 @@ fn clean_path(path string) string {
 	return res
 }
 
+// to_slash returns the result of replacing each separator character
+// in path with a slash (`/`).
+pub fn to_slash(path string) string {
+	if path_separator == '/' {
+		return path
+	}
+	return path.replace(path_separator, '/')
+}
+
+// from_slash returns the result of replacing each slash (`/`) character
+// is path with a separator character.
+pub fn from_slash(path string) string {
+	if path_separator == '/' {
+		return path
+	}
+	return path.replace('/', path_separator)
+}
+
 // win_volume_len returns the length of the
 // Windows volume/drive from the given `path`.
 fn win_volume_len(path string) int {

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -53,6 +53,22 @@ fn test_clean_path() {
 	assert clean_path('//////////') == '/'
 }
 
+fn test_to_slash() {
+	sep := path_separator
+	assert to_slash('') == ''
+	assert to_slash(sep) == ('/')
+	assert to_slash([sep, 'a', sep, 'b'].join('')) == '/a/b'
+	assert to_slash(['a', sep, sep, 'b'].join('')) == 'a//b'
+}
+
+fn test_from_slash() {
+	sep := path_separator
+	assert from_slash('') == ''
+	assert from_slash('/') == sep
+	assert from_slash('/a/b') == [sep, 'a', sep, 'b'].join('')
+	assert from_slash('a//b') == ['a', sep, sep, 'b'].join('')
+}
+
 fn test_norm_path() {
 	$if windows {
 		assert norm_path(r'C:/path/to//file.v\\') == r'C:\path\to\file.v'


### PR DESCRIPTION
This PR adds `from_slash` and `to_slash` functions and their tests.

They work the same as Go's ToSlash and FromSlash, respectively.

- `from_slash` returns the result of replacing each slash (`/`) character is path with a separator character.
- `to_slash` returns the result of replacing each separator character in path with a slash (`/`).

These functions help to perform cross-platform file path operations.

image:
```v
module main

import os

fn main() {
    println(os.to_slash(r'C:\Users\takum\dev\sandbox\vdev'))
    println(os.from_slash(r'C:/Users/takum/dev/sandbox/vdev'))
}
```

output:
```shell
C:/Users/takum/dev/sandbox/vdev # to_slash
C:\Users\takum\dev\sandbox\vdev # from_slash
```

reference
- https://pkg.go.dev/path/filepath#FromSlash
- https://pkg.go.dev/path/filepath#ToSlash