### PR TITLE
cgen: fix generic closure fn direct call (fix #16012)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -635,7 +635,17 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	// NOTE: everything could be done this way
 	// see my comment in parser near anon_fn
 	if node.left is ast.AnonFn {
-		g.expr(node.left)
+		if node.left.inherited_vars.len > 0 {
+			tmp_var := g.new_tmp_var()
+			fn_type := g.fn_var_signature(node.left.decl.return_type, node.left.decl.params.map(it.typ),
+				tmp_var)
+			g.write('$fn_type = ')
+			g.expr(node.left)
+			g.writeln(';')
+			g.write(tmp_var)
+		} else {
+			g.expr(node.left)
+		}
 	} else if node.left is ast.IndexExpr && node.name == '' {
 		g.is_fn_index_call = true
 		g.expr(node.left)

--- a/vlib/v/tests/generics_closure_fn_direct_call_test.v
+++ b/vlib/v/tests/generics_closure_fn_direct_call_test.v
@@ -1,0 +1,17 @@
+pub struct App {
+}
+
+pub fn (mut app App) register<T>(service T) {
+	fn [service] <T>() {
+		println(service)
+	}()
+}
+
+pub struct Service {
+}
+
+fn test_generics_closure_fn_direct_call() {
+	mut app := App{}
+	app.register(Service{})
+	assert true
+}


### PR DESCRIPTION
This PR fix generic closure fn direct call (fix #16012).

- Fix generic closure fn direct call.
- Add test.

```v
pub struct App {
}

pub fn (mut app App) register<T>(service T) {
	fn [service] <T>() {
		println(service)
	}()
}

pub struct Service {
}

fn main() {
	mut app := App{}
	app.register(Service{})
	assert true
}

PS D:\Test\v\tt1> v run .
Service{}
```