### PR TITLE
cgen: fix exists spaces in the name of the ?&C.struct (fix #16058)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1001,7 +1001,13 @@ fn (mut g Gen) expr_string_surround(prepend string, expr ast.Expr, append string
 // if one location changes
 fn (mut g Gen) optional_type_name(t ast.Type) (string, string) {
 	base := g.base_type(t)
-	mut styp := '_option_$base'
+	mut styp := ''
+	sym := g.table.sym(t)
+	if sym.language == .c && sym.kind == .struct_ {
+		styp = '${c.option_name}_${base.replace(' ', '_')}'
+	} else {
+		styp = '${c.option_name}_$base'
+	}
 	if t.is_ptr() {
 		styp = styp.replace('*', '_ptr')
 	}
@@ -1010,7 +1016,13 @@ fn (mut g Gen) optional_type_name(t ast.Type) (string, string) {
 
 fn (mut g Gen) result_type_name(t ast.Type) (string, string) {
 	base := g.base_type(t)
-	mut styp := '${c.result_name}_$base'
+	mut styp := ''
+	sym := g.table.sym(t)
+	if sym.language == .c && sym.kind == .struct_ {
+		styp = '${c.result_name}_${base.replace(' ', '_')}'
+	} else {
+		styp = '${c.result_name}_$base'
+	}
 	if t.is_ptr() {
 		styp = styp.replace('*', '_ptr')
 	}

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -380,3 +380,13 @@ fn test_return_or() {
 	x := foo2() or { return }
 	assert x == 0
 }
+
+// For issue #16058: cgen error: exists spaces in the name of the ?&C.struct
+fn bar() ?&C.stat {
+	return none
+}
+
+fn test_optional_ref_c_struct_gen() {
+	_ := bar() or { &C.stat{} }
+	assert true
+}


### PR DESCRIPTION
1. Fix #16058
2. Add tests.

```v
struct C.stat{}

fn foo() ?&C.stat {
	return none
}

fn main() {
	_ := foo() or { &C.stat{} }
	assert true
}
```

output:

passed.