### PR TITLE
ast: disallow append fn() optional or result to go threads (fix #16061)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -975,6 +975,8 @@ pub fn (t &Table) thread_name(return_type Type) string {
 	if return_type.idx() == void_type_idx {
 		if return_type.has_flag(.optional) {
 			return 'thread ?'
+		} else if return_type.has_flag(.result) {
+			return 'thread !'
 		} else {
 			return 'thread'
 		}
@@ -991,6 +993,8 @@ pub fn (t &Table) thread_cname(return_type Type) string {
 	if return_type == void_type {
 		if return_type.has_flag(.optional) {
 			return '__v_thread_Option_void'
+		} else if return_type.has_flag(.result) {
+			return '__v_thread_Result_void'
 		} else {
 			return '__v_thread'
 		}

--- a/vlib/v/checker/tests/go_append_optional_to_threads_err.out
+++ b/vlib/v/checker/tests/go_append_optional_to_threads_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/go_append_optional_to_threads_err.vv:5:12: error: cannot append `thread !` to `[]thread`
+    3 | fn main() {
+    4 |     mut ths := []thread{}
+    5 |     ths << go foo()
+      |               ~~~~~
+    6 |     ths.wait()
+    7 | }

--- a/vlib/v/checker/tests/go_append_optional_to_threads_err.vv
+++ b/vlib/v/checker/tests/go_append_optional_to_threads_err.vv
@@ -1,0 +1,7 @@
+fn foo() ! {}
+
+fn main() {
+	mut ths := []thread{}
+	ths << go foo()
+	ths.wait()
+}


### PR DESCRIPTION
1. Fix #16061 
2. Add tests.

```v
fn foo() ! {}

fn main() {
	mut ths := []thread{}
	ths << go foo()
	ths.wait()
}
```

output:

```
vlib/v/checker/tests/go_append_optional_to_threads_err.vv:5:12: error: cannot append `thread !` to `[]thread`
    3 | fn main() {
    4 |     mut ths := []thread{}
    5 |     ths << go foo()
      |               ~~~~~
    6 |     ths.wait()
    7 | }
```
