### PR TITLE
rand: add rand.element and prng.element functions with unit test

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -384,6 +384,7 @@ pub fn (mut rng PRNG) choose<T>(array []T, k int) ?[]T {
 }
 
 // element returns a random element from the given array.
+// Note that all the positions in the array have an equal chance of being selected. This means that if the array has repeating elements, then the probability of selecting a particular element is not uniform.
 pub fn (mut rng PRNG) element<T>(array []T) ?T {
 	if array.len == 0 {
 		return error('Cannot choose an element from an empty array.')
@@ -616,6 +617,7 @@ pub fn choose<T>(array []T, k int) ?[]T {
 }
 
 // element returns a random element from the given array.
+// Note that all the positions in the array have an equal chance of being selected. This means that if the array has repeating elements, then the probability of selecting a particular element is not uniform.
 pub fn element<T>(array []T) ?T {
 	return default_rng.element<T>(array)
 }

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -383,6 +383,14 @@ pub fn (mut rng PRNG) choose<T>(array []T, k int) ?[]T {
 	return results
 }
 
+// element returns a random element from the given array.
+pub fn (mut rng PRNG) element<T>(array []T) ?T {
+	if array.len == 0 {
+		return error('Cannot choose an element from an empty array.')
+	}
+	return array[rng.intn(array.len)!]
+}
+
 // sample samples k elements from the array with replacement.
 // This means the elements can repeat and the size of the sample may exceed the size of the array.
 pub fn (mut rng PRNG) sample<T>(array []T, k int) []T {
@@ -605,6 +613,11 @@ pub fn shuffle_clone<T>(a []T, config config.ShuffleConfigStruct) ?[]T {
 // Note that if the array has repeating elements, then the sample may have repeats as well.
 pub fn choose<T>(array []T, k int) ?[]T {
 	return default_rng.choose<T>(array, k)
+}
+
+// element returns a random element from the given array.
+pub fn element<T>(array []T) ?T {
+	return default_rng.element<T>(array)
 }
 
 // sample samples k elements from the array with replacement.

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -412,11 +412,20 @@ fn test_sample() {
 	}
 }
 
-fn test_element() {
+fn test_element1() {
 	a := ['one', 'two', 'four', 'five', 'six', 'seven']
 	for _ in 0 .. 30 {
 		e := rand.element(a)?
 		assert e in a
 		assert 'three' != e
+	}
+}
+
+fn test_element2() {
+	for _ in 0 .. 30 {
+		e := rand.element([1, 2, 5, 6, 7, 8])?
+		assert e in [1, 2, 5, 6, 7, 8]
+		assert 3 != e
+		assert 4 != e
 	}
 }

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -411,3 +411,12 @@ fn test_sample() {
 		assert element in a
 	}
 }
+
+fn test_element() {
+	a := ['one', 'two', 'four', 'five', 'six', 'seven']
+	for _ in 0 .. 30 {
+		e := rand.element(a)?
+		assert e in a
+		assert 'three' != e
+	}
+}


### PR DESCRIPTION
It was suggested to add a convenience function `rand.element` (and the corresponding `PRNG.element`) that takes an array as an argument (variable or literal) and returns an arbitrary element from the array.