### PR TITLE
checker: check generic closure fn declaration (related #16012)

### DIFF
--- a/vlib/v/checker/tests/generic_closure_fn_decl_err.out
+++ b/vlib/v/checker/tests/generic_closure_fn_decl_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generic_closure_fn_decl_err.vv:5:2: error: generic closure fn must specify type parameter, e.g. fn [foo] <T>()
+    3 |
+    4 | pub fn (mut app App) register<T>(service T) {
+    5 |     fn [service] () {
+      |     ~~~~~~~~~~~~~~~~~
+    6 |         println(service)
+    7 |     }()

--- a/vlib/v/checker/tests/generic_closure_fn_decl_err.vv
+++ b/vlib/v/checker/tests/generic_closure_fn_decl_err.vv
@@ -1,0 +1,16 @@
+pub struct App {
+}
+
+pub fn (mut app App) register<T>(service T) {
+	fn [service] () {
+		println(service)
+	}()
+}
+
+pub struct Service {
+}
+
+fn main() {
+	mut app := App{}
+	app.register(Service{})
+}


### PR DESCRIPTION
This PR check generic closure fn declaration (related #16012).

- Check generic closure fn declaration.
- Add test.

```v
pub struct App {
}

pub fn (mut app App) register<T>(service T) {
	fn [service] () {
		println(service)
	}()
}

pub struct Service {
}

fn main() {
	mut app := App{}
	app.register(Service{})
}

PS D:\Test\v\tt1> v run .
./tt1.v:5:2: error: generic closure fn must specify type parameter, e.g. fn [foo] <T>()
    3 | 
    4 | pub fn (mut app App) register<T>(service T) {
    5 |     fn [service] () {
      |     ~~~~~~~~~~~~~~~~~
    6 |         println(service)
    7 |     }()
```