### PR TITLE
cgen: fix missing * of optional non-ref structs (fix: #16070)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1036,7 +1036,7 @@ fn (g Gen) optional_type_text(styp string, base string) string {
 	} else if base.starts_with('anon_fn') {
 		'void*'
 	} else {
-		base
+		if base.starts_with('struct ') && !base.ends_with('*') { '$base*' } else { base }
 	}
 	ret := 'struct $styp {
 	byte state;
@@ -1053,7 +1053,7 @@ fn (g Gen) result_type_text(styp string, base string) string {
 	} else if base.starts_with('anon_fn') {
 		'void*'
 	} else {
-		base
+		if base.starts_with('struct ') && !base.ends_with('*') { '$base*' } else { base }
 	}
 	ret := 'struct $styp {
 	bool is_error;

--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -390,6 +390,15 @@ fn test_optional_ref_c_struct_gen() {
 	_ := get_opt_pointer_to_c_struct() or { &C.stat{} }
 }
 
+// For issue #16070: cgen error: missing * of optional non-ref structs
+fn get_opt_to_c_struct() ?C.stat {
+	return none
+}
+
+fn test_optional_c_struct_gen() {
+	_ := get_opt_to_c_struct() or { C.stat{} }
+}
+
 // For issue #16062: checker disallow the return of voidptr(nil) in or block
 struct Bar {}
 


### PR DESCRIPTION
1. Fix #16070
2. Add tests.

```v
import os

fn foo() ?C.stat {
	buf := C.stat{}
	return buf
}

fn main() {
	_ := foo() or { C.stat{} }
}
```

output:

passed.
