### PR TITLE
cgen: fix when waiting for a go thread and only one result is returned (fix #16065)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1885,12 +1885,20 @@ fn (mut g Gen) go_expr(node ast.GoExpr) {
 		g.writeln('$arg_tmp_var->ret_ptr = malloc(sizeof($s_ret_typ));')
 	}
 	is_opt := node.call_expr.return_type.has_flag(.optional)
+	is_res := node.call_expr.return_type.has_flag(.result)
 	mut gohandle_name := ''
 	if node.call_expr.return_type == ast.void_type {
-		gohandle_name = if is_opt { '__v_thread_Option_void' } else { '__v_thread' }
+		if is_opt {
+			gohandle_name = '__v_thread_Option_void'
+		} else if is_res {
+			gohandle_name = '__v_thread_Result_void'
+		} else {
+			gohandle_name = '__v_thread'
+		}
 	} else {
 		opt := if is_opt { '${option_name}_' } else { '' }
-		gohandle_name = '__v_thread_$opt${g.table.sym(g.unwrap_generic(node.call_expr.return_type)).cname}'
+		res := if is_res { '${result_name}_' } else { '' }
+		gohandle_name = '__v_thread_$opt$res${g.table.sym(g.unwrap_generic(node.call_expr.return_type)).cname}'
 	}
 	if g.pref.os == .windows {
 		simple_handle := if node.is_expr && node.call_expr.return_type != ast.void_type {

--- a/vlib/v/tests/go_wait_option_test.v
+++ b/vlib/v/tests/go_wait_option_test.v
@@ -80,3 +80,29 @@ fn test_array_val_interate() {
 	assert res[1] == 0.0
 	assert res[2] == 1.5
 }
+
+// For issue 16065
+fn get_only_a_option_return(return_none bool) ? {
+	if return_none {
+		return
+	}
+	return error('msg')
+}
+
+fn get_only_a_result_return() ! {
+	return error('msg')
+}
+
+fn test_only_a_option_return() {
+	t1 := go get_only_a_option_return(true)
+	t1.wait() or { assert false }
+	t2 := go get_only_a_option_return(false)
+	t2.wait() or { assert true }
+	assert true
+}
+
+fn test_only_a_result_return() {
+	t := go get_only_a_result_return()
+	t.wait() or { assert true }
+	assert true
+}


### PR DESCRIPTION
1. Fix #16065
2. Add tests.

```v
fn get_only_a_option_return(return_none bool) ? {
	if return_none {
		return
	}
	return error('msg')
}

fn get_only_a_result_return() ! {
	return error('msg')
}

fn test_only_a_option_return() {
	t1 := go get_only_a_option_return(true)
	t1.wait() or { assert false }
	t2 := go get_only_a_option_return(false)
	t2.wait() or { assert true }
	assert true
}

fn test_only_a_result_return() {
	t := go get_only_a_result_return()
	t.wait() or { assert true }
	assert true
}
```

output:

passed.
