### PR TITLE
checker: check unused last expression in if (fix #16084)

### DIFF
--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -53,10 +53,10 @@ pub fn (mut l FileLock) wait_acquire(s int) !bool {
 fn open(f string) voidptr {
 	f_wide := f.to_wide()
 	// locking it
-	fd := C.CreateFileW(f_wide, C.GENERIC_READ | C.GENERIC_WRITE, 0, 0, C.OPEN_ALWAYS,
+	mut fd := C.CreateFileW(f_wide, C.GENERIC_READ | C.GENERIC_WRITE, 0, 0, C.OPEN_ALWAYS,
 		C.FILE_ATTRIBUTE_NORMAL, 0)
 	if fd == C.INVALID_HANDLE_VALUE {
-		fd == -1
+		fd = unsafe { nil }
 	}
 	return fd
 }

--- a/vlib/v/checker/tests/unused_last_expr_stmt_in_if.out
+++ b/vlib/v/checker/tests/unused_last_expr_stmt_in_if.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/unused_last_expr_stmt_in_if.vv:16:5: error: expression evaluated but not used
+   14 |     if a.mode == .zz {
+   15 |         println('hello')
+   16 |         a.mode == .yy
+      |           ~~~~~~~~~~~
+   17 |     }
+   18 | }

--- a/vlib/v/checker/tests/unused_last_expr_stmt_in_if.vv
+++ b/vlib/v/checker/tests/unused_last_expr_stmt_in_if.vv
@@ -1,0 +1,18 @@
+enum MyEnum {
+	xx
+	yy
+	zz
+}
+
+struct Abc {
+mut:
+	mode MyEnum
+}
+
+fn main() {
+	a := Abc{}
+	if a.mode == .zz {
+		println('hello')
+		a.mode == .yy
+	}
+}


### PR DESCRIPTION
This PR check unused last expression in if (fix #16084).

- Check unused last expression in if.
- Add test.

```v
enum MyEnum {
	xx
	yy
	zz
}

struct Abc {
mut:
	mode MyEnum
}

fn main() {
	a := Abc{}
	if a.mode == .zz {
		println('hello')
		a.mode == .yy
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:16:5: error: expression evaluated but not used
   14 |     if a.mode == .zz {
   15 |         println('hello')
   16 |         a.mode == .yy
      |           ~~~~~~~~~~~
   17 |     }
   18 | }
```