### PR TITLE
builtin: fix math.min_i64.str() (fix #16086)

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -177,7 +177,7 @@ pub fn (nn i64) str() string {
 		mut d := i64(0)
 		if n == 0 {
 			return '0'
-		} else if n == i64(-9223372036854775808) {
+		} else if n == i64(-9223372036854775807 - 1) {
 			// math.min_i64
 			return '-9223372036854775808'
 		}

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -177,6 +177,9 @@ pub fn (nn i64) str() string {
 		mut d := i64(0)
 		if n == 0 {
 			return '0'
+		} else if n == i64(-9223372036854775808) {
+			// math.min_i64
+			return '-9223372036854775808'
 		}
 		max := 20
 		mut buf := malloc_noscan(max + 1)

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -1,5 +1,3 @@
-import math
-
 const (
 	a = 3
 	u = u64(1)
@@ -255,11 +253,4 @@ fn test_byte_vs_u8() {
 	bb := byte(1)
 	uu := u8(1)
 	assert bb == uu
-}
-
-fn test_min_int_str() {
-	assert math.min_i64.str() == '-9223372036854775808'
-	assert math.min_i32.str() == '-2147483648'
-	assert math.min_i16.str() == '-32768'
-	assert math.min_i8.str() == '-128'
 }

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -1,3 +1,5 @@
+import math
+
 const (
 	a = 3
 	u = u64(1)
@@ -253,4 +255,11 @@ fn test_byte_vs_u8() {
 	bb := byte(1)
 	uu := u8(1)
 	assert bb == uu
+}
+
+fn test_min_int_str() {
+	assert math.min_i64.str() == '-9223372036854775808'
+	assert math.min_i32.str() == '-2147483648'
+	assert math.min_i16.str() == '-32768'
+	assert math.min_i8.str() == '-128'
 }

--- a/vlib/math/const.v
+++ b/vlib/math/const.v
@@ -42,19 +42,23 @@ pub const (
 
 // Integer limit values
 pub const (
-	max_i8  = 127
-	min_i8  = -128
-	max_i16 = 32767
-	min_i16 = -32768
-	max_i32 = 2147483647
-	min_i32 = -2147483648
-	// -9223372036854775808 is wrong because C compilers parse literal values
+	max_i8  = i8(127)
+	min_i8  = i8(-128)
+	max_i16 = i16(32767)
+	min_i16 = i16(-32768)
+	max_i32 = int(2147483647)
+	min_i32 = int(-2147483647 - 1) // -2147483648 is wrong, see below:
+	// -9223372036854775808 is wrong too, because C compilers parse literal values
 	// without sign first, and 9223372036854775808 overflows i64, hence the
 	// consecutive subtraction by 1
 	min_i64 = i64(-9223372036854775807 - 1)
 	max_i64 = i64(9223372036854775807)
-	max_u8  = 255
-	max_u16 = 65535
+	min_u8  = u8(0)
+	max_u8  = u8(255)
+	min_u16 = u16(0)
+	max_u16 = u16(65535)
+	min_u32 = u32(0)
 	max_u32 = u32(4294967295)
+	min_u64 = u64(0)
 	max_u64 = u64(18446744073709551615)
 )

--- a/vlib/math/const.v
+++ b/vlib/math/const.v
@@ -42,13 +42,13 @@ pub const (
 
 // Integer limit values
 pub const (
-	max_i8  = i8(127)
 	min_i8  = i8(-128)
-	max_i16 = i16(32767)
+	max_i8  = i8(127)
 	min_i16 = i16(-32768)
+	max_i16 = i16(32767)
+	min_i32 = int(-2147483648)
 	max_i32 = int(2147483647)
-	min_i32 = int(-2147483647 - 1) // -2147483648 is wrong, see below:
-	// -9223372036854775808 is wrong too, because C compilers parse literal values
+	// -9223372036854775808 is wrong, because C compilers parse literal values
 	// without sign first, and 9223372036854775808 overflows i64, hence the
 	// consecutive subtraction by 1
 	min_i64 = i64(-9223372036854775807 - 1)

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -1048,3 +1048,14 @@ fn test_count_digits() {
 	assert count_digits(123456789012345) == 15
 	assert count_digits(-67345) == 5
 }
+
+fn test_min_max_int_str() {
+	assert min_i64.str() == '-9223372036854775808'
+	assert max_i64.str() == '9223372036854775807'
+	assert min_i32.str() == '-2147483648'
+	assert max_i32.str() == '2147483647'
+	assert min_i16.str() == '-32768'
+	assert max_i16.str() == '32767'
+	assert min_i8.str() == '-128'
+	assert max_i8.str() == '127'
+}


### PR DESCRIPTION
This PR fix math.min_i64.str() (fix #16086).

- Fix math.min_i64.str().
- Add test.

```v
import math

fn main() {
	println(math.min_i64.str())
}

PS D:\Test\v\tt1> v run .
-9223372036854775808
```