### PR TITLE
builtin: make the C. WIN32 API declarations more precise, to catch errors earlier

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -226,15 +226,15 @@ fn C._fileno(int) int
 
 fn C._get_osfhandle(fd int) C.intptr_t
 
-fn C.GetModuleFileName(hModule voidptr, lpFilename &u16, nSize u32) int
+fn C.GetModuleFileName(hModule voidptr, lpFilename &u16, nSize u32) u32
 
 fn C.GetModuleFileNameW(hModule voidptr, lpFilename &u16, nSize u32) u32
 
 fn C.CreateFile(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
 
-fn C.CreateFileW(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) u32
+fn C.CreateFileW(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
 
-fn C.GetFinalPathNameByHandleW(hFile voidptr, lpFilePath &u16, nSize u32, dwFlags u32) int
+fn C.GetFinalPathNameByHandleW(hFile voidptr, lpFilePath &u16, nSize u32, dwFlags u32) u32
 
 fn C.CreatePipe(hReadPipe &voidptr, hWritePipe &voidptr, lpPipeAttributes voidptr, nSize u32) bool
 
@@ -247,9 +247,9 @@ fn C.GetComputerNameW(&u16, &u32) bool
 fn C.GetUserNameW(&u16, &u32) bool
 
 [trusted]
-fn C.SendMessageTimeout() u32
+fn C.SendMessageTimeout() isize
 
-fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlags u32, uTimeout u32, lpdwResult &u64) u32
+fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlags u32, uTimeout u32, lpdwResult &u64) isize
 
 fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
 
@@ -257,33 +257,32 @@ fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumbe
 
 fn C.GetFileAttributesW(lpFileName &u8) u32
 
-fn C.RegQueryValueEx(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8, lpcbData &u32) voidptr
+fn C.RegQueryValueEx(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8, lpcbData &u32) int
 
 fn C.RegQueryValueExW(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8, lpcbData &u32) int
 
-fn C.RegOpenKeyEx(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, phkResult voidptr) voidptr
+fn C.RegOpenKeyEx(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, phkResult voidptr) int
 
 fn C.RegOpenKeyExW(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, phkResult voidptr) int
 
-fn C.RegSetValueEx() voidptr
+fn C.RegSetValueEx(hKey voidptr, lpValueName &u16, dwType u32, lpData &u16, cbData u32) int
 
-fn C.RegSetValueExW(hKey voidptr, lpValueName &u16, reserved u32, dwType u32, lpData &u8, lpcbData u32) int
+fn C.RegSetValueExW(hKey voidptr, lpValueName &u16, reserved u32, dwType u32, const_lpData &u8, cbData u32) int
 
-fn C.RegCloseKey(hKey voidptr)
+fn C.RegCloseKey(hKey voidptr) int
 
-fn C.RemoveDirectory(lpPathName &u16) int
+fn C.RemoveDirectory(lpPathName &u16) bool
 
-// fn C.GetStdHandle() voidptr
+fn C.RemoveDirectoryW(lpPathName &u16) bool
+
 fn C.GetStdHandle(u32) voidptr
 
-// fn C.SetConsoleMode()
-fn C.SetConsoleMode(voidptr, u32) int
+fn C.SetConsoleMode(voidptr, u32) bool
 
-// fn C.GetConsoleMode() int
-fn C.GetConsoleMode(voidptr, &u32) int
+fn C.GetConsoleMode(voidptr, &u32) bool
 
 [trusted]
-fn C.GetCurrentProcessId() int
+fn C.GetCurrentProcessId() u32
 
 fn C.wprintf()
 

--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -45,17 +45,17 @@ pub fn init(cfg Config) &Context {
 		panic('could not get stdin handle')
 	}
 	// save the current input mode, to be restored on exit
-	if C.GetConsoleMode(stdin_handle, &ui.stdin_at_startup) == 0 {
+	if !C.GetConsoleMode(stdin_handle, &ui.stdin_at_startup) {
 		panic('could not get stdin console mode')
 	}
 
 	// enable extended input flags (see https://stackoverflow.com/a/46802726)
 	// 0x80 == C.ENABLE_EXTENDED_FLAGS
-	if C.SetConsoleMode(stdin_handle, 0x80) == 0 {
+	if !C.SetConsoleMode(stdin_handle, 0x80) {
 		panic('could not set raw input mode')
 	}
 	// enable window and mouse input events.
-	if C.SetConsoleMode(stdin_handle, C.ENABLE_WINDOW_INPUT | C.ENABLE_MOUSE_INPUT) == 0 {
+	if !C.SetConsoleMode(stdin_handle, C.ENABLE_WINDOW_INPUT | C.ENABLE_MOUSE_INPUT) {
 		panic('could not set raw input mode')
 	}
 	// store the current title, so restore_terminal_state can get it back


### PR DESCRIPTION
Updates the WIN32 declarations in vlib/builtin/cfns.c.v so that invalid usages can be caught earlier by the V compiler.