### PR TITLE
cgen: fix match expr with last aggregate branch (fix #16100)

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -145,7 +145,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 		// iterates through all types in sumtype branches
 		for {
 			g.aggregate_type_idx = sumtype_index
-			is_last := j == node.branches.len - 1
+			is_last := j == node.branches.len - 1 && sumtype_index == branch.exprs.len - 1
 			sym := g.table.sym(node.cond_type)
 			if branch.is_else || (use_ternary && is_last) {
 				if use_ternary {

--- a/vlib/v/tests/match_expr_with_last_branch_aggregate_test.v
+++ b/vlib/v/tests/match_expr_with_last_branch_aggregate_test.v
@@ -1,0 +1,24 @@
+type MyT = f32 | f64 | i64 | int | rune | string | u32 | u64
+type FnMyT = fn (MyT)
+
+fn (any []MyT) each(fun FnMyT) {
+	for x in any {
+		fun(x)
+	}
+}
+
+fn (myt MyT) to_s() string {
+	return match myt {
+		string { myt }
+		rune { rune(myt).str() }
+		int, u32, i64, u64, f32, f64 { myt.str() } // FAIL compilation
+	}
+}
+
+fn test_match_expr_with_last_branch_aggregate() {
+	mut arr := [MyT(1), `😝`, 'we are mamamoo', f32(u64(-1)), f64(u64(-1)), i64(-1), u64(-1)]
+	arr.each(fn (my MyT) {
+		println(my.to_s())
+	})
+	assert true
+}


### PR DESCRIPTION
This PR fix match expr with last aggregate branch (fix #16100).

- Fix match expr with last aggregate branch.
- Add test.

```v
type MyT = f32 | f64 | i64 | int | rune | string | u32 | u64
type FnMyT = fn (MyT)

fn (any []MyT) each(fun FnMyT) {
	for x in any {
		fun(x)
	}
}

fn (myt MyT) to_s() string {
	return match myt {
		string { myt }
		rune { rune(myt).str() }
		int, u32, i64, u64, f32, f64 { myt.str() } // FAIL compilation
	}
}

fn main() {
	mut arr := [MyT(1), `😝`, 'we are mamamoo', f32(u64(-1)), f64(u64(-1)), i64(-1), u64(-1)]
	arr.each(fn (my MyT) {
		println(my.to_s())
	})
}

PS D:\Test\v\tt1> v run .
1
😝
we are mamamoo
1.8446744e+19
1.8446744073709552e+19
-1
18446744073709551615
```