### PR TITLE
v fmt: fix extra space for lock/rlock without expressions

### DIFF
--- a/vlib/net/websocket/io.v
+++ b/vlib/net/websocket/io.v
@@ -4,7 +4,7 @@ import net
 
 // socket_read reads from socket into the provided buffer
 fn (mut ws Client) socket_read(mut buffer []u8) !int {
-	lock  {
+	lock {
 		if ws.state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
 			return error('socket_read: trying to read a closed socket')
 		}
@@ -21,7 +21,7 @@ fn (mut ws Client) socket_read(mut buffer []u8) !int {
 
 // socket_read reads from socket into the provided byte pointer and length
 fn (mut ws Client) socket_read_ptr(buf_ptr &u8, len int) !int {
-	lock  {
+	lock {
 		if ws.state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
 			return error('socket_read_ptr: trying to read a closed socket')
 		}
@@ -38,7 +38,7 @@ fn (mut ws Client) socket_read_ptr(buf_ptr &u8, len int) !int {
 
 // socket_write writes the provided byte array to the socket
 fn (mut ws Client) socket_write(bytes []u8) !int {
-	lock  {
+	lock {
 		if ws.state == .closed || ws.conn.sock.handle <= 1 {
 			ws.debug_log('socket_write: Socket allready closed')
 			return error('socket_write: trying to write on a closed socket')

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -446,7 +446,7 @@ fn parse_uri(url string) !&Uri {
 
 // set_state sets current state of the websocket connection
 fn (mut ws Client) set_state(state State) {
-	lock  {
+	lock {
 		ws.state = state
 	}
 }
@@ -463,7 +463,7 @@ fn (ws Client) assert_not_connected() ! {
 
 // reset_state resets the websocket and initialize default settings
 fn (mut ws Client) reset_state() ! {
-	lock  {
+	lock {
 		ws.state = .closed
 		ws.ssl_conn = ssl.new_ssl_conn()!
 		ws.flags = []

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -101,7 +101,7 @@ fn (mut s Server) handle_ping() {
 		}
 		// TODO: replace for with s.clients.delete_all(clients_to_remove) if (https://github.com/vlang/v/pull/6020) merges
 		for client in clients_to_remove {
-			lock  {
+			lock {
 				s.clients.delete(client)
 			}
 		}
@@ -124,7 +124,7 @@ fn (mut s Server) serve_client(mut c Client) ! {
 	}
 	// the client is accepted
 	c.socket_write(handshake_response.bytes())!
-	lock  {
+	lock {
 		s.clients[server_client.client.id] = server_client
 	}
 	s.setup_callbacks(mut server_client)
@@ -157,7 +157,7 @@ fn (mut s Server) setup_callbacks(mut sc ServerClient) {
 	// set standard close so we can remove client if closed
 	sc.client.on_close_ref(fn (mut c Client, code int, reason string, mut sc ServerClient) ! {
 		c.logger.debug('server-> Delete client')
-		lock  {
+		lock {
 			sc.server.clients.delete(sc.client.id)
 		}
 	}, sc)
@@ -180,7 +180,7 @@ fn (mut s Server) accept_new_client() !&Client {
 
 // set_state sets current state in a thread safe way
 fn (mut s Server) set_state(state State) {
-	lock  {
+	lock {
 		s.state = state
 	}
 }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2237,7 +2237,10 @@ pub fn (mut f Fmt) lock_expr(node ast.LockExpr) {
 		}
 	}
 	if num_locked > 0 || num_rlocked == 0 {
-		f.write('lock ')
+		f.write('lock')
+		if num_locked > 0 {
+			f.write(' ')
+		}
 		mut n := 0
 		for i, v in node.lockeds {
 			if !node.is_rlock[i] {

--- a/vlib/v/fmt/tests/lock_expected.vv
+++ b/vlib/v/fmt/tests/lock_expected.vv
@@ -1,0 +1,50 @@
+fn simple_lock() {
+	a := 100
+	b := 100
+
+	lock {
+	}
+
+	lock {
+	}
+
+	lock a {
+	}
+
+	lock a, b {
+	}
+}
+
+fn lock_with_statements() {
+	shared a := []int{}
+	lock {
+		a << 1
+		a << 2
+	}
+
+	lock a {
+		a << 1
+		a << 2
+	}
+}
+
+fn simple_rlock() {
+	a := 100
+
+	lock {
+	}
+
+	rlock a {
+	}
+}
+
+fn rlock_with_statements() {
+	shared a := [1]
+	lock {
+		println(a[0])
+	}
+
+	rlock a {
+		println(a[0])
+	}
+}

--- a/vlib/v/fmt/tests/lock_input.vv
+++ b/vlib/v/fmt/tests/lock_input.vv
@@ -1,0 +1,52 @@
+fn simple_lock() {
+	a := 100
+	b := 100
+
+	lock  {
+	}
+
+	lock       {         }
+
+	lock    a     {
+
+	}
+
+	lock    a  , b    {
+
+	}
+}
+
+fn lock_with_statements() {
+	shared a := []int{}
+	lock  {
+		a << 1
+		a << 2
+	}
+
+	lock   a   {
+		a << 1
+		a << 2
+	}
+}
+
+fn simple_rlock() {
+	a := 100
+
+	rlock  {
+	}
+
+	rlock    a     {
+
+	}
+}
+
+fn rlock_with_statements() {
+	shared a := [1]
+	rlock  {
+		println(a[0])
+	}
+
+	rlock  a     {
+		println(a[0])
+	}
+}

--- a/vlib/v/tests/shared_array_last_test.v
+++ b/vlib/v/tests/shared_array_last_test.v
@@ -2,7 +2,7 @@ module main
 
 fn test_shared_array_last() {
 	shared a := []int{}
-	lock  {
+	lock {
 		a << 1
 		a << 2
 	}


### PR DESCRIPTION
Fixes #16102 