### PR TITLE
vtest-self: add skipping ssl tests on windows

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -214,6 +214,8 @@ const (
 		'vlib/net/openssl/openssl_compiles_test.v',
 		'vlib/net/http/request_test.v',
 		'vlib/net/smtp/smtp_test.v',
+		'vlib/net/ssl/ssl_compiles_test.v',
+		'vlib/net/mbedtls/mbedtls_compiles_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/request_test.v',
 		'vlib/vweb/route_test.v',


### PR DESCRIPTION
This PR add skipping ssl tests on windows.

errors:
```v
 FAIL  [ 158/1136]  4422.398 ms vlib/net/mbedtls/mbedtls_compiles_test.v
D:/Vlang/v/thirdparty/mbedtls/library/platform_util.c:113: warning: implicit declaration of function 'gmtime_s'

==================
C:/Users/yuyi9/AppData/Local/Temp/v/tsession_22b4_255301100/mbedtls_compiles_test.exe.14270699108114662994.tmp.c:25149: warning: assignment from incompatible pointer type
tcc: error: undefined symbol 'CryptAcquireContextA'
tcc: error: undefined symbol 'CryptGenRandom'
tcc: error: undefined symbol 'CryptReleaseContext'
tcc: error: undefined symbol 'gmtime_s'
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.

This is a compiler bug, please report it using `v bug file.v`.

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang

 FAIL  [ 159/1136]  4168.511 ms vlib/net/ssl/ssl_compiles_test.v
D:/Vlang/v/thirdparty/mbedtls/library/platform_util.c:113: warning: implicit declaration of function 'gmtime_s'

==================
C:/Users/yuyi9/AppData/Local/Temp/v/tsession_22b4_255301100/ssl_compiles_test.exe.17063397903785297049.tmp.c:25203: warning: assignment from incompatible pointer type
tcc: error: undefined symbol 'CryptAcquireContextA'
tcc: error: undefined symbol 'CryptGenRandom'
tcc: error: undefined symbol 'CryptReleaseContext'
tcc: error: undefined symbol 'gmtime_s'
...
==================
(Use `v -cg` to print the entire error message)

builder error:
==================
C error. This should never happen.

This is a compiler bug, please report it using `v bug file.v`.

https://github.com/vlang/v/issues/new/choose

You can also use #help on Discord: https://discord.gg/vlang
```