### PR TITLE
checker: check generic method called variadic argument mismatch (fix #16106)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -941,8 +941,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			typ := c.expr(call_arg.expr)
 			if i == node.args.len - 1 {
 				if c.table.sym(typ).kind == .array && call_arg.expr !is ast.ArrayDecompose
-					&& c.table.sym(expected_type).kind != .array && !param.typ.has_flag(.generic)
-					&& expected_type != typ {
+					&& c.table.sym(expected_type).kind !in [.sum_type, .interface_]
+					&& !param.typ.has_flag(.generic) && expected_type != typ {
 					styp := c.table.type_to_str(typ)
 					elem_styp := c.table.type_to_str(expected_type)
 					c.error('to pass `$call_arg.expr` ($styp) to `$func.name` (which accepts type `...$elem_styp`), use `...$call_arg.expr`',
@@ -1551,7 +1551,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				typ := c.expr(arg.expr)
 				if i == node.args.len - 1 {
 					if c.table.sym(typ).kind == .array && arg.expr !is ast.ArrayDecompose
-						&& c.table.sym(expected_type).kind != .array
+						&& c.table.sym(expected_type).kind !in [.sum_type, .interface_]
 						&& !param.typ.has_flag(.generic) && expected_type != typ {
 						styp := c.table.type_to_str(typ)
 						elem_styp := c.table.type_to_str(expected_type)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -941,7 +941,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			typ := c.expr(call_arg.expr)
 			if i == node.args.len - 1 {
 				if c.table.sym(typ).kind == .array && call_arg.expr !is ast.ArrayDecompose
-					&& !param.typ.has_flag(.generic) && expected_type != typ {
+					&& c.table.sym(expected_type).kind != .array && !param.typ.has_flag(.generic)
+					&& expected_type != typ {
 					styp := c.table.type_to_str(typ)
 					elem_styp := c.table.type_to_str(expected_type)
 					c.error('to pass `$call_arg.expr` ($styp) to `$func.name` (which accepts type `...$elem_styp`), use `...$call_arg.expr`',
@@ -1550,6 +1551,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				typ := c.expr(arg.expr)
 				if i == node.args.len - 1 {
 					if c.table.sym(typ).kind == .array && arg.expr !is ast.ArrayDecompose
+						&& c.table.sym(expected_type).kind != .array
 						&& !param.typ.has_flag(.generic) && expected_type != typ {
 						styp := c.table.type_to_str(typ)
 						elem_styp := c.table.type_to_str(expected_type)

--- a/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv:8:4: error: to pass `options` (string) to `req` (which accepts type `...string`), use `...options`
+    6 |
+    7 | fn (c Client) products_list(options ...string) {
+    8 |     c.req<Product>(options) // (...options) works
+      |       ~~~~~~~~~~~~~~~~~~~~~
+    9 | }
+   10 |

--- a/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv
@@ -1,0 +1,14 @@
+struct Client {}
+
+fn (cl Client) req<T>(data ...string) {}
+
+struct Product {}
+
+fn (c Client) products_list(options ...string) {
+	c.req<Product>(options) // (...options) works
+}
+
+fn main() {
+	mut sc := Client{}
+	sc.products_list()
+}


### PR DESCRIPTION
This PR check generic method called variadic argument mismatch (fix #16106).

- Check generic method called variadic argument mismatch.
- Add test.

```v
struct Client {}

fn (cl Client) req<T>(data ...string) {}

struct Product {}

fn (c Client) products_list(options ...string) {
	c.req<Product>(options) // (...options) works
}

fn main() {
	mut sc := Client{}
	sc.products_list()
}

PS D:\Test\v\tt1> v run .
./tt1.v:8:4: error: to pass `options` (string) to `req` (which accepts type `...string`), use `...options`
    6 | 
    7 | fn (c Client) products_list(options ...string) {
    8 |     c.req<Product>(options) // (...options) works
      |       ~~~~~~~~~~~~~~~~~~~~~
    9 | }
   10 |
```