### PR TITLE
os: cleanup APIs returning `!bool` to either return `!` or `bool`

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -257,8 +257,8 @@ fn (mut a App) report_info() {
 }
 
 fn is_writable_dir(path string) bool {
-	res := os.is_writable_folder(path) or { false }
-	return res
+	os.ensure_folder_is_writable(path) or { return false }
+	return true
 }
 
 fn main() {

--- a/vlib/io/util/util.v
+++ b/vlib/io/util/util.v
@@ -19,7 +19,7 @@ pub fn temp_file(tfo TempFileOptions) !(os.File, string) {
 	if d == '' {
 		d = os.temp_dir()
 	}
-	os.is_writable_folder(d) or {
+	os.ensure_folder_is_writable(d) or {
 		return error(@FN +
 			' could not create temporary file in "$d". Please ensure write permissions.')
 	}
@@ -46,31 +46,28 @@ pub struct TempDirOptions {
 	pattern string
 }
 
+fn error_for_temporary_folder(fn_name string, d string) !string {
+	return error('$fn_name could not create temporary directory "$d". Please ensure you have write permissions for it.')
+}
+
 // temp_dir returns an uniquely named, writable, directory path
 pub fn temp_dir(tdo TempFileOptions) !string {
 	mut d := tdo.path
 	if d == '' {
 		d = os.temp_dir()
 	}
-	os.is_writable_folder(d) or {
-		return error(@FN +
-			' could not create temporary directory "$d". Please ensure write permissions.')
-	}
+	os.ensure_folder_is_writable(d) or { return error_for_temporary_folder(@FN, d) }
 	d = d.trim_right(os.path_separator)
 	prefix, suffix := prefix_and_suffix(tdo.pattern) or { return error(@FN + ' $err.msg()') }
 	for retry := 0; retry < util.retries; retry++ {
 		path := os.join_path(d, prefix + random_number() + suffix)
 		os.mkdir_all(path) or { continue }
 		if os.is_dir(path) && os.exists(path) {
-			os.is_writable_folder(path) or {
-				return error(@FN +
-					' could not create temporary directory "$d". Please ensure write permissions.')
-			}
+			os.ensure_folder_is_writable(path) or { return error_for_temporary_folder(@FN, d) }
 			return path
 		}
 	}
-	return error(@FN +
-		' could not create temporary directory "$d". Retry limit ($util.retries) exhausted. Please ensure write permissions.')
+	return error('${@FN} could not create temporary directory "$d". Retry limit ($util.retries) exhausted.')
 }
 
 // * Utility functions

--- a/vlib/io/util/util_test.v
+++ b/vlib/io/util/util_test.v
@@ -81,11 +81,10 @@ fn test_temp_dir() {
 		return
 	}
 	assert os.is_dir(path)
-	mut writable := os.is_writable_folder(path) or {
+	os.ensure_folder_is_writable(path) or {
 		assert false
 		return
 	}
-	assert writable
 	mut prev_path := path
 	// Test pattern
 	path = util.temp_dir(
@@ -114,11 +113,10 @@ fn test_temp_dir() {
 	}
 	assert path != prev_path
 	assert os.is_dir(path)
-	writable = os.is_writable_folder(path) or {
+	os.ensure_folder_is_writable(path) or {
 		assert false
 		return
 	}
-	assert writable
 	assert path.contains(tfolder)
 	filename = os.file_name(path)
 	for c in filename {

--- a/vlib/os/dir_expansions_test.v
+++ b/vlib/os/dir_expansions_test.v
@@ -13,13 +13,12 @@ fn test_tmpdir() {
 	os.rm(tfile) or { panic(err) }
 }
 
-fn test_is_writable_folder() {
+fn test_ensure_folder_is_writable() {
 	tmp := os.temp_dir()
-	f := os.is_writable_folder(tmp) or {
+	os.ensure_folder_is_writable(tmp) or {
 		eprintln('err: $err')
-		false
+		assert false
 	}
-	assert f
 }
 
 fn test_expand_tilde_to_home() {

--- a/vlib/os/filelock/lib_nix.c.v
+++ b/vlib/os/filelock/lib_nix.c.v
@@ -17,21 +17,19 @@ pub fn (mut l FileLock) unlink() {
 	C.unlink(&char(l.name.str))
 }
 
-pub fn (mut l FileLock) acquire() !bool {
+pub fn (mut l FileLock) acquire() ! {
 	if l.fd != -1 {
-		// lock already acquired by this instance
-		return false
+		return error_with_code('lock already acquired by this instance', 1)
 	}
 	fd := open_lockfile(l.name)
 	if fd == -1 {
-		return error('cannot create lock file $l.name')
+		return error_with_code('cannot create lock file $l.name', -1)
 	}
 	if C.flock(fd, C.LOCK_EX) == -1 {
 		C.close(fd)
-		return error('cannot lock')
+		return error_with_code('cannot lock', -2)
 	}
 	l.fd = fd
-	return true
 }
 
 pub fn (mut l FileLock) release() bool {
@@ -44,7 +42,7 @@ pub fn (mut l FileLock) release() bool {
 	return false
 }
 
-pub fn (mut l FileLock) wait_acquire(s int) !bool {
+pub fn (mut l FileLock) wait_acquire(s int) bool {
 	fin := time.now().add(s)
 	for time.now() < fin {
 		if l.try_acquire() {

--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -15,17 +15,15 @@ pub fn (mut l FileLock) unlink() {
 	C.DeleteFileW(t_wide)
 }
 
-pub fn (mut l FileLock) acquire() !bool {
+pub fn (mut l FileLock) acquire() ! {
 	if l.fd != -1 {
-		// lock already acquired by this instance
-		return false
+		return error_with_code('lock already acquired by this instance', 1)
 	}
 	fd := open(l.name)
 	if fd == -1 {
-		return error('cannot create lock file $l.name')
+		return error_with_code('cannot create lock file $l.name', -1)
 	}
 	l.fd = fd
-	return true
 }
 
 pub fn (mut l FileLock) release() bool {
@@ -39,7 +37,7 @@ pub fn (mut l FileLock) release() bool {
 	return false
 }
 
-pub fn (mut l FileLock) wait_acquire(s int) !bool {
+pub fn (mut l FileLock) wait_acquire(s int) bool {
 	fin := time.now().add(s)
 	for time.now() < fin {
 		if l.try_acquire() {

--- a/vlib/os/os.js.v
+++ b/vlib/os/os.js.v
@@ -177,3 +177,10 @@ pub fn file_last_mod_unix(path string) int {
 
 	return mtime
 }
+
+pub fn ensure_folder_is_writable(path string) ! {
+	fpath := join_path(path, 'some_newfile')
+	#try { $fs.writeFileSync(fpath); $fs.unlinkSync(fpath) } catch(e) { return error(new string('could not write to ' + path)) }
+
+	_ := fpath
+}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -856,3 +856,9 @@ pub fn config_dir() !string {
 	}
 	return error('Cannot find config directory')
 }
+
+[deprecated: 'use os.ensure_folder_is_writable instead']
+pub fn is_writable_folder(folder string) !bool {
+	ensure_folder_is_writable(folder)!
+	return true
+}

--- a/vlib/os/os_js.js.v
+++ b/vlib/os/os_js.js.v
@@ -1,15 +1,15 @@
 module os
 
-pub fn mkdir(path string, params MkdirParams) !bool {
+pub fn mkdir(path string, params MkdirParams) ! {
 	$if js_node {
 		if path == '.' {
-			return true
+			return
 		}
 		#$fs.mkdirSync(path.valueOf())
 
-		return true
+		return
 	} $else {
-		return false
+		return error('could not create folder')
 	}
 }
 

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -291,7 +291,6 @@ pub fn mkdir(path string, params MkdirParams) ! {
 	if r == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}
-	return
 }
 
 // execute starts the specified command, waits for it to complete, and returns its output.

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -469,7 +469,7 @@ fn test_realpath_absolutepath_symlink() {
 	file_name := 'tolink_file.txt'
 	symlink_name := 'symlink.txt'
 	create_file(file_name)!
-	assert os.symlink(file_name, symlink_name)!
+	os.symlink(file_name, symlink_name)!
 	rpath := os.real_path(symlink_name)
 	println(rpath)
 	assert os.is_abs_path(rpath)

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -31,7 +31,7 @@ fn check_if_output_folder_is_writable(pref &pref.Preferences) {
 	if odir.len == pref.out_name.len {
 		output_folder = os.getwd()
 	}
-	os.is_writable_folder(output_folder) or {
+	os.ensure_folder_is_writable(output_folder) or {
 		// An early error here, is better than an unclear C error later:
 		verror(err.msg())
 	}


### PR DESCRIPTION
APIs like the existing `os.mkdir()!` return `!bool`, but in actuality,
they will be clearer if they just returned `!` instead, since their
boolean return value is ignored in practically 100% of the call sites.