### PR TITLE
log: mark fatal as [noreturn]

### DIFF
--- a/examples/log.v
+++ b/examples/log.v
@@ -19,6 +19,4 @@ fn main() {
 	l.set_level(log.level_from_tag('') or { log.Level.disabled }) // set level from string, sample
 	l.error('no output anymore')
 	l.fatal('fatal') // panic, next statements won't be executed
-	l.set_level(.info)
-	l.warn('warn')
 }

--- a/examples/logfatal.v
+++ b/examples/logfatal.v
@@ -1,0 +1,11 @@
+import log
+
+[noreturn]
+fn should_not_return(mut logger log.Log) {
+	logger.fatal('${@FILE_LINE}: yikes!')
+}
+
+fn main() {
+	mut my_log := log.Log{}
+	should_not_return(mut my_log)
+}

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -179,6 +179,7 @@ pub fn (mut l Log) send_output(s &string, level Level) {
 
 // fatal logs line `s` via `send_output` if `Log.level` is greater than or equal to the `Level.fatal` category.
 // Note that this method performs a panic at the end, even if log level is not enabled.
+[noreturn]
 pub fn (mut l Log) fatal(s string) {
 	if int(l.level) >= int(Level.fatal) {
 		l.send_output(s, .fatal)


### PR DESCRIPTION
This PR marks Log fatal as `[noreturn]`, addressing issue #16128

Log fatal is documented as calling panic, and therefore can't return.

However, Log fatal can't be used in places that require `[noreturn]`
