### PR TITLE
checker: fix generic information is lost of the map built-in method call (fix #16077)

### DIFF
--- a/vlib/v/tests/map_builtin_call_test.v
+++ b/vlib/v/tests/map_builtin_call_test.v
@@ -8,8 +8,20 @@ fn call_value_is_generic<T>(v T) {
 	_ := a.values().filter(it == v)
 }
 
+fn call_all_is_generic_keys_method<T, U>(v T) {
+	a := map[T]U{}
+	_ := a.keys().filter(it == v)
+}
+
+fn call_all_is_generic_values_method<T, U>(v U) {
+	a := map[T]U{}
+	_ := a.values().filter(it == v)
+}
+
 fn test_call_has_generic() {
 	call_key_is_generic<int>(1)
 	call_value_is_generic<string>('')
+	call_all_is_generic_keys_method<int, string>(1)
+	call_all_is_generic_values_method<int, string>('')
 	assert true
 }

--- a/vlib/v/tests/map_builtin_call_test.v
+++ b/vlib/v/tests/map_builtin_call_test.v
@@ -1,0 +1,15 @@
+fn call_key_is_generic<T>(v T) {
+	a := map[T]u8{}
+	_ := a.keys().filter(it == v)
+}
+
+fn call_value_is_generic<T>(v T) {
+	a := map[u8]T{}
+	_ := a.values().filter(it == v)
+}
+
+fn test_call_has_generic() {
+	call_key_is_generic<int>(1)
+	call_value_is_generic<string>('')
+	assert true
+}


### PR DESCRIPTION
1. Fix #16077 
2. Add tests.

```v
pub struct Set<T> {
mut:
	elements map[T]u8
}

pub fn (mut set Set<T>) rest() ?[]T {
	element := set.pick()?
	return set.elements.keys().filter(it != element)
}

pub fn (set Set<T>) pick() ?T {
	for k, _ in set.elements {
		return k
	}
	return error('Set is empty.')
}

fn mian() {
	_ := Set<string>{}
	_ := Set<int>{}
}
```

output:

passed.

