### PR TITLE
checker: fix taking a closure of x, where `x` may be coming from a non trivial parent scope, like `for x in y {` or `x,y := multi()` (fix #16141)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -428,6 +428,7 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 		if var.typ.has_flag(.generic) {
 			has_generic = true
 		}
+		node.decl.scope.update_var_type(var.name, var.typ)
 	}
 	c.stmts(node.decl.stmts)
 	c.fn_decl(mut node.decl)

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -179,7 +179,7 @@ struct Command {
 
 struct App {}
 
-fn main() {
+fn test_larger_closure_parameters() {
 	mut app := &App{}
 	eprintln('app ptr: ${u64(app)}')
 	f := fn [mut app] (cmd Command) u64 {
@@ -197,4 +197,16 @@ fn main() {
 	res := f(cmd)
 	println('> res: $res | sizeof Command: ${sizeof(Command)}')
 	assert res == u64(app)
+}
+
+fn test_closure_in_for_in_loop() {
+	a := [2, 4, 6, 9]
+	for v in a {
+		func := fn [v] (msg string) string {
+			return '$msg: $v'
+		}
+		res := func('hello')
+		assert res == 'hello: $v'
+		// dump(res)
+	}
 }

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -210,3 +210,16 @@ fn test_closure_in_for_in_loop() {
 		// dump(res)
 	}
 }
+
+fn ret_two() (int, int) {
+	return 2, 5
+}
+
+fn test_closure_over_variable_that_is_returned_from_a_multi_value_function() {
+	one, two := ret_two()
+	a := fn [one] () {
+		println(one)
+	}
+	a()
+	println(two)
+}


### PR DESCRIPTION
Fix updating of the scope, that has the closed over variable, when that variable is from a `for x in y {` loop, `x,y := multi()` (and probably others as well). Add tests.