### PR TITLE
checker: fix the pos information in the warning message when the label is not used (fix #16146)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1238,6 +1238,8 @@ pub struct GotoLabel {
 pub:
 	name string
 	pos  token.Pos
+pub mut:
+	is_used bool
 }
 
 pub struct GotoStmt {

--- a/vlib/v/checker/tests/unused_label.out
+++ b/vlib/v/checker/tests/unused_label.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/unused_label.vv:1:1: warning: label `mylabel` defined and not used
+vlib/v/checker/tests/unused_label.vv:2:5: warning: label `mylabel` defined and not used
     1 | fn main() {
-      | ^
     2 |     mylabel:
+      |     ~~~~~~~~
     3 | }


### PR DESCRIPTION
1. Fix #16146
2. Add tests.

```v
module main

fn main() {
	label:
}
```

output:

```
vlib/v/checker/tests/label_not_used_warning.vv:4:2: warning: label `label` defined and not used
    2 | 
    3 | fn main() {
    4 |     label:
      |     ~~~~~~
    5 | }
```
