### PR TITLE
cgen: fix return result in or block (fix #15219)

### DIFF
--- a/vlib/v/tests/return_result_in_or_block_test.v
+++ b/vlib/v/tests/return_result_in_or_block_test.v
@@ -1,0 +1,21 @@
+fn unwrap_int() ?int {
+	return 1
+}
+
+fn unwrap_function1() !int {
+	return unwrap_int() or { error('we are issing the return?') }
+}
+
+fn unwrap_function2() ?int {
+	return unwrap_int() or { none }
+}
+
+fn test_return_result_in_or_block() {
+	x1 := unwrap_function1() or { panic(err) }
+	println(x1)
+	assert x1 == 1
+
+	x2 := unwrap_function2() or { panic(err) }
+	println(x2)
+	assert x2 == 1
+}


### PR DESCRIPTION
This PR fix return result in or block (fix #15219).

- Fix return result in or block.
- Add test.

```v
fn unwrap_int() ?int {
	return 1
}

fn unwrap_function1() !int {
	return unwrap_int() or { error('we are issing the return?') }
}

fn unwrap_function2() ?int {
	return unwrap_int() or { none }
}

fn main() {
	x1 := unwrap_function1() or { panic(err) }
	println(x1)
	assert x1 == 1

	x2 := unwrap_function2() or { panic(err) }
	println(x2)
	assert x2 == 1
}

PS D:\Test\v\tt1> v run .
1
1
```