### PR TITLE
cgen: fix using 'array' name variable in array_init  (fix #16165)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1601,3 +1601,9 @@ fn test_2d_array_init_with_it() {
 	a := [][]int{len: 6, init: f(it, 2 * it)}
 	assert a == [[0, 0], [1, 2], [2, 4], [3, 6], [4, 8], [5, 10]]
 }
+
+fn test_using_array_name_variable() {
+	array := []int{len: 4, init: it}
+	println(array)
+	assert array == [0, 1, 2, 3]
+}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -448,7 +448,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					g.is_shared = var_type.has_flag(.shared_f)
 					if is_fixed_array_init && !has_val {
 						if val is ast.ArrayInit {
-							g.array_init(val, ident.name)
+							g.array_init(val, c_name(ident.name))
 						} else {
 							g.write('{0}')
 						}
@@ -460,7 +460,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							g.write('*')
 						}
 						if val is ast.ArrayInit {
-							g.array_init(val, ident.name)
+							g.array_init(val, c_name(ident.name))
 						} else if val_type.has_flag(.shared_f) {
 							g.expr_with_cast(val, val_type, var_type)
 						} else {


### PR DESCRIPTION
This PR fix using 'array' name variable in array_init  (fix #16165).

- Fix using 'array' name variable in array_init.
- Add test.

```v
fn main() {
	array := []int{len: 4, init: it}
	println(array)
	assert array == [0, 1, 2, 3]
}

PS D:\Test\v\tt1> v run .
[0, 1, 2, 3]
```