### PR TITLE
cgen: fix vweb app route methods filtering (fix #9636)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -477,7 +477,8 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				rec_sym := g.table.sym(method.receiver_type)
 				if rec_sym.kind == .struct_ {
 					if _ := g.table.find_field_with_embeds(rec_sym, 'Context') {
-						if method.generic_names.len > 0 {
+						if method.generic_names.len > 0
+							|| (method.params.len > 1 && method.attrs.len == 0) {
 							continue
 						}
 					}

--- a/vlib/vweb/vweb_app_test.v
+++ b/vlib/vweb/vweb_app_test.v
@@ -92,3 +92,17 @@ fn (mut app App) some_helper<T>(result T) ApiSuccessResponse<T> {
 fn (mut app App) ok() vweb.Result {
 	return app.json(app.some_helper(123))
 }
+
+struct ExampleStruct {
+	example int
+}
+
+fn (mut app App) request_raw_2() vweb.Result {
+	stuff := []ExampleStruct{}
+	return app.request_raw(stuff)
+}
+
+// should compile, this is a helper method, not exposed as a route
+fn (mut app App) request_raw(foo []ExampleStruct) vweb.Result {
+	return app.text('Hello world')
+}


### PR DESCRIPTION
This PR fix vweb app route methods filtering (fix #9636).

- Fix vweb app route methods filtering.
- Add test.

```v
module main

import vweb

pub struct App {
	vweb.Context
}

fn main() {
	vweb.run(&App{}, 9080)
}

struct ExampleStruct {
	example int
}

pub fn (mut app App) request_raw_2() vweb.Result {
	stuff := []ExampleStruct{}
	return app.request_raw(stuff)
}

pub fn (mut app App) request_raw(foo []ExampleStruct) vweb.Result {
	return $vweb.html()
}

PS D:\Test\v\tt1> v run .
[Vweb] Running app on http://localhost:9080/
```