### PR TITLE
checker, cgen: when the array element is an alias, enable to call the method of the parent element array (fix #16169)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1358,7 +1358,7 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		method = m
 		has_method = true
 	} else {
-		if final_left_sym.kind in [.struct_, .sum_type, .interface_] {
+		if final_left_sym.kind in [.struct_, .sum_type, .interface_, .alias, .array] {
 			mut parent_type := ast.void_type
 			if final_left_sym.info is ast.Struct {
 				parent_type = final_left_sym.info.parent_type
@@ -1366,7 +1366,13 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				parent_type = final_left_sym.info.parent_type
 			} else if final_left_sym.info is ast.Interface {
 				parent_type = final_left_sym.info.parent_type
+			} else if final_left_sym.info is ast.Alias {
+				parent_type = final_left_sym.info.parent_type
+			} else if final_left_sym.info is ast.Array {
+				typ := c.table.unaliased_type(final_left_sym.info.elem_type)
+				parent_type = ast.Type(c.table.find_or_register_array(typ))
 			}
+
 			if parent_type != 0 {
 				type_sym := c.table.sym(parent_type)
 				if m := c.table.find_method(type_sym, method_name) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -800,7 +800,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		typ := g.table.unaliased_type((typ_sym.info as ast.Array).elem_type)
 		typ_idx := g.table.find_type_idx(g.table.array_name(typ))
 		if typ_idx > 0 {
-			unwrapped_rec_type = ast.Type(g.table.find_type_idx(g.table.array_name(typ)))
+			unwrapped_rec_type = ast.Type(typ_idx)
 			typ_sym = g.table.sym(unwrapped_rec_type)
 		}
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -796,6 +796,13 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	if typ_sym.kind == .alias && node.name != 'str' && !typ_sym.has_method(node.name) {
 		unwrapped_rec_type = (typ_sym.info as ast.Alias).parent_type
 		typ_sym = g.table.sym(unwrapped_rec_type)
+	} else if typ_sym.kind == .array && !typ_sym.has_method(node.name) {
+		typ := g.table.unaliased_type((typ_sym.info as ast.Array).elem_type)
+		typ_idx := g.table.find_type_idx(g.table.array_name(typ))
+		if typ_idx > 0 {
+			unwrapped_rec_type = ast.Type(g.table.find_type_idx(g.table.array_name(typ)))
+			typ_sym = g.table.sym(unwrapped_rec_type)
+		}
 	}
 	rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 	mut receiver_type_name := util.no_dots(rec_cc_type)

--- a/vlib/v/tests/aliased_array_method_call_test.v
+++ b/vlib/v/tests/aliased_array_method_call_test.v
@@ -1,0 +1,10 @@
+fn get_bytes_array() []byte {
+	return [byte(97), 98, 99]
+}
+
+fn test_element_aliased_array_method_call() {
+	assert get_bytes_array().bytestr() == 'abc'
+
+	arr := [byte(97), 98, 99]
+	assert arr.bytestr() == 'abc'
+}


### PR DESCRIPTION
1. Fix #16169 
2. Add tests.

```v
fn get_bytes_array() []byte {
	return [byte(97), 98, 99]
}

fn main() {
	println(get_bytes_array().bytestr())

	arr := [byte(97), 98, 99]
	println(arr.bytestr())
}
```

output:

```
abc
abc
```

