### PR TITLE
ast, checker, cgen: fix the wrongs when the struct interface type field is nil (fix #16198)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1530,7 +1530,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 		}
 		// verify fields
 		for ifield in inter_sym.info.fields {
-			if ifield.typ == voidptr_type {
+			if ifield.typ == voidptr_type || ifield.typ == nil_type {
 				// Allow `voidptr` fields in interfaces for now. (for example
 				// to enable .db check in vweb)
 				if t.struct_has_field(sym, ifield.name) {
@@ -1549,7 +1549,9 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 			}
 			return false
 		}
-		inter_sym.info.types << typ
+		if typ != voidptr_type && typ != nil_type && !inter_sym.info.types.contains(typ) {
+			inter_sym.info.types << typ
+		}
 		if !inter_sym.info.types.contains(voidptr_type) {
 			inter_sym.info.types << voidptr_type
 		}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -19,7 +19,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 		if expected == ast.byteptr_type {
 			return true
 		}
-		if expected == ast.voidptr_type {
+		if expected == ast.voidptr_type || expected == ast.nil_type {
 			return true
 		}
 		if (expected == ast.bool_type && (got.is_any_kind_of_pointer() || got.is_int()))
@@ -112,7 +112,8 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	if exp_idx == got_idx {
 		return true
 	}
-	if exp_idx == ast.voidptr_type_idx || exp_idx == ast.byteptr_type_idx
+	if exp_idx == ast.voidptr_type_idx || exp_idx == ast.nil_type_idx
+		|| exp_idx == ast.byteptr_type_idx
 		|| (expected.is_ptr() && expected.deref().idx() == ast.u8_type_idx) {
 		if got.is_ptr() || got.is_pointer() {
 			return true
@@ -125,7 +126,8 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 	}
-	if got_idx == ast.voidptr_type_idx || got_idx == ast.byteptr_type_idx
+	if got_idx == ast.voidptr_type_idx || got_idx == ast.nil_type_idx
+		|| got_idx == ast.byteptr_type_idx
 		|| (got_idx == ast.u8_type_idx && got.is_ptr()) {
 		if expected.is_ptr() || expected.is_pointer() {
 			return true

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -850,7 +850,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		inter_sym.methods
 	}
 	// voidptr is an escape hatch, it should be allowed to be passed
-	if utyp != ast.voidptr_type {
+	if utyp != ast.voidptr_type && utyp != ast.nil_type {
 		// Verify methods
 		for imethod in imethods {
 			method := c.table.find_method_with_embeds(typ_sym, imethod.name) or {
@@ -900,7 +900,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 				continue
 			}
 			// voidptr is an escape hatch, it should be allowed to be passed
-			if utyp != ast.voidptr_type {
+			if utyp != ast.voidptr_type && utyp != ast.nil_type {
 				// >> Hack to allow old style custom error implementations
 				// TODO: remove once deprecation period for `IError` methods has ended
 				if inter_sym.idx == ast.error_type_idx
@@ -913,7 +913,12 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 				}
 			}
 		}
-		inter_sym.info.types << utyp
+		if utyp != ast.voidptr_type && utyp != ast.nil_type && !inter_sym.info.types.contains(utyp) {
+			inter_sym.info.types << utyp
+		}
+		if !inter_sym.info.types.contains(ast.voidptr_type) {
+			inter_sym.info.types << ast.voidptr_type
+		}
 	}
 	return true
 }

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -224,7 +224,7 @@ fn (mut c Checker) eval_comptime_const_expr(expr ast.Expr, nlevel int) ?ast.Comp
 			if expr.typ == ast.f64_type {
 				return cast_expr_value.f64() or { return none }
 			}
-			if expr.typ == ast.voidptr_type {
+			if expr.typ == ast.voidptr_type || expr.typ == ast.nil_type {
 				ptrvalue := cast_expr_value.voidptr() or { return none }
 				return ast.ComptTimeConstValue(ptrvalue)
 			}

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -58,7 +58,7 @@ pub fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			if !c.inside_unsafe && !node.left.is_auto_deref_var() && !node.right.is_auto_deref_var() {
 				c.warn('pointer arithmetic is only allowed in `unsafe` blocks', left_right_pos)
 			}
-			if left_type == ast.voidptr_type && !c.pref.translated {
+			if (left_type == ast.voidptr_type || left_type == ast.nil_type) && !c.pref.translated {
 				c.error('`$node.op` cannot be used with `voidptr`', left_pos)
 			}
 		}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -91,9 +91,10 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 					c.check_expr_opt_call(field.default_expr, default_expr_type)
 				}
 				struct_sym.info.fields[i].default_expr_typ = default_expr_type
+				interface_implemented := sym.kind == .interface_
+					&& c.type_implements(default_expr_type, field.typ, field.pos)
 				c.check_expected(default_expr_type, field.typ) or {
-					if sym.kind == .interface_
-						&& c.type_implements(default_expr_type, field.typ, field.pos) {
+					if sym.kind == .interface_ && interface_implemented {
 						if !default_expr_type.is_ptr() && !default_expr_type.is_pointer()
 							&& !c.inside_unsafe {
 							if c.table.sym(default_expr_type).kind != .interface_ {

--- a/vlib/v/checker/tests/pointer_ops.out
+++ b/vlib/v/checker/tests/pointer_ops.out
@@ -54,6 +54,13 @@ vlib/v/checker/tests/pointer_ops.vv:15:3: error: invalid operator `%` to `&Foo` 
       |         ~~~~~~~
    16 |     }
    17 | }
+vlib/v/checker/tests/pointer_ops.vv:22:7: error: `+` cannot be used with `voidptr`
+   20 |     unsafe {
+   21 |         mut p := nil
+   22 |         _ = p + 1
+      |             ^
+   23 |         p++
+   24 |         p += 3
 vlib/v/checker/tests/pointer_ops.vv:23:4: error: invalid operation: ++ (non-numeric type `voidptr`)
    21 |         mut p := nil
    22 |         _ = p + 1
@@ -68,6 +75,13 @@ vlib/v/checker/tests/pointer_ops.vv:24:3: error: operator `+=` not defined on le
       |         ^
    25 |         _ = p - 1
    26 |         p--
+vlib/v/checker/tests/pointer_ops.vv:25:7: error: `-` cannot be used with `voidptr`
+   23 |         p++
+   24 |         p += 3
+   25 |         _ = p - 1
+      |             ^
+   26 |         p--
+   27 |         p -= 3
 vlib/v/checker/tests/pointer_ops.vv:26:4: error: invalid operation: -- (non-numeric type `voidptr`)
    24 |         p += 3
    25 |         _ = p - 1

--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -366,7 +366,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 							e.error('unknown cast: ${e.table.sym(expr.expr_type).str()} to ${e.table.sym(expr.typ).str()}')
 						}
 					}
-				} else if expr.typ == ast.voidptr_type_idx {
+				} else if expr.typ == ast.voidptr_type_idx || expr.typ == ast.nil_type_idx {
 					match y {
 						char, Int {
 							unsafe {
@@ -540,7 +540,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 
 fn (e Eval) type_to_size(typ ast.Type) u64 {
 	match typ {
-		ast.voidptr_type_idx, ast.byteptr_type_idx, ast.charptr_type_idx {
+		ast.voidptr_type_idx, ast.nil_type_idx, ast.byteptr_type_idx, ast.charptr_type_idx {
 			return u64(if e.pref.m64 {
 				64
 			} else {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -766,7 +766,7 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 	if typ == ast.char_type_idx {
 		return .si_c
 	}
-	if typ in ast.voidptr_types || typ in ast.byteptr_types {
+	if typ in ast.voidptr_types || typ == ast.nil_type || typ in ast.byteptr_types {
 		return .si_p
 	}
 	if typ in ast.charptr_types {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -436,7 +436,7 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 			}
 			g.write('}')
 		} else {
-			if sfield.typ != ast.nil_type
+			if sfield.typ != ast.voidptr_type && sfield.typ != ast.nil_type
 				&& (sfield.expected_type.is_ptr() && !sfield.expected_type.has_flag(.shared_f))
 				&& !(sfield.typ.is_ptr() || sfield.typ.is_pointer()) && !sfield.typ.is_number() {
 				g.write('/* autoref */&')

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -651,7 +651,7 @@ fn (g &JsGen) type_to_fmt(typ ast.Type) StrIntpType {
 	if typ == ast.char_type_idx {
 		return .si_c
 	}
-	if typ in ast.voidptr_types || typ in ast.byteptr_types {
+	if typ in ast.voidptr_types || typ == ast.nil_type || typ in ast.byteptr_types {
 		return .si_p
 	}
 	if typ in ast.charptr_types {

--- a/vlib/v/tests/interface_fields_test.v
+++ b/vlib/v/tests/interface_fields_test.v
@@ -72,3 +72,32 @@ fn test_interface_fn_pointer_fields() {
 	nf := NofunInterface(Nofun{my_fn})
 	assert nf.foo(123) == 246
 }
+
+// For issue: 16198 errors when the reference interface type field of the struct is nil(init, assign...)
+interface Speaker {
+	speak() string
+}
+
+struct Wolf {}
+
+fn (w Wolf) speak() string {
+	return 'woof'
+}
+
+struct Foo {
+mut:
+	speaker &Speaker = unsafe { nil }
+}
+
+fn test_set_nil_to_ref_interface_type_fields() {
+	mut foo := Foo{
+		speaker: unsafe { nil }
+	}
+	assert true
+
+	foo.speaker = unsafe { nil }
+	assert true
+
+	foo.speaker = &Wolf{}
+	assert foo.speaker.speak() == 'woof'
+}


### PR DESCRIPTION
1. Fix #16198
2. Add tests.

```v
interface Speaker {
	speak() string
}

struct Dog {}

fn (d Dog) speak() string {
	return 'woof'
}

struct Foo {
mut:
	speaker &Speaker = unsafe { nil }
}

fn main() {
	mut foo := Foo{
		speaker: unsafe { nil }
	}
	assert true

	foo.speaker = unsafe { nil }
	assert true

	foo.speaker = &Dog{}
	assert foo.speaker.speak() == 'woof'
}
```

output:

passed.
