### PR TITLE
transformer: improve -trace-calls output, enable tracing of builtin fns, show elapsed ns and used stack size too

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -236,6 +236,9 @@ pub fn (v &Builder) get_user_files() []string {
 	if v.pref.backend == .js_node {
 		preludes_path = os.join_path(vroot, 'vlib', 'v', 'preludes_js')
 	}
+	if v.pref.trace_calls {
+		user_files << os.join_path(preludes_path, 'trace_calls.v')
+	}
 	if v.pref.is_livemain || v.pref.is_liveshared {
 		user_files << os.join_path(preludes_path, 'live.v')
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5040,6 +5040,9 @@ fn (mut g Gen) write_init_function() {
 
 	// ___argv is declared as voidptr here, because that unifies the windows/unix logic
 	g.writeln('void _vinit(int ___argc, voidptr ___argv) {')
+	if g.pref.trace_calls {
+		g.writeln('\tv__trace_calls__on_call(_SLIT("_vinit"));')
+	}
 
 	if g.use_segfault_handler {
 		// 11 is SIGSEGV. It is hardcoded here, to avoid FreeBSD compilation errors for trivial examples.
@@ -5095,6 +5098,9 @@ fn (mut g Gen) write_init_function() {
 	//
 	fn_vcleanup_start_pos := g.out.len
 	g.writeln('void _vcleanup(void) {')
+	if g.pref.trace_calls {
+		g.writeln('\tv__trace_calls__on_call(_SLIT("_vcleanup"));')
+	}
 	if g.is_autofree {
 		// g.writeln('puts("cleaning up...");')
 		reversed_table_modules := g.table.modules.reverse()

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -94,6 +94,7 @@ fn (mut g Gen) gen_c_main_function_only_header() {
 
 fn (mut g Gen) gen_c_main_function_header() {
 	g.gen_c_main_function_only_header()
+	g.gen_c_main_trace_calls_hook()
 	g.writeln('\tg_main_argc = ___argc;')
 	g.writeln('\tg_main_argv = ___argv;')
 	if g.nr_closures > 0 {
@@ -153,6 +154,7 @@ void (_vsokol_cleanup_userdata_cb)(void* user_data) {
 	g.writeln('// The sokol_main entry point on Android
 sapp_desc sokol_main(int argc, char* argv[]) {
 	(void)argc; (void)argv;')
+	g.gen_c_main_trace_calls_hook()
 
 	if g.pref.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm_leak] {
 		g.writeln('#if defined(_VGCBOEHM)')
@@ -333,4 +335,13 @@ pub fn (mut g Gen) filter_only_matching_fn_names(fnames []string) []string {
 		res << tname
 	}
 	return res
+}
+
+pub fn (mut g Gen) gen_c_main_trace_calls_hook() {
+	if !g.pref.trace_calls {
+		return
+	}
+	g.writeln('\tu8 bottom_of_stack = 0; g_stack_base = &bottom_of_stack; v__trace_calls__on_c_main();')
+	}
+')
 }

--- a/vlib/v/preludes/trace_calls.v
+++ b/vlib/v/preludes/trace_calls.v
@@ -1,0 +1,5 @@
+module main
+
+import v.trace_calls
+
+const trace_calls_used = trace_calls.is_used

--- a/vlib/v/trace_calls/tracing_calls.v
+++ b/vlib/v/trace_calls/tracing_calls.v
@@ -1,0 +1,66 @@
+[has_globals]
+module trace_calls
+
+[markused]
+__global g_stack_base = &u8(0)
+__global g_start_time = u64(0)
+
+pub const is_used = 1
+
+// unix:
+struct C.timespec {
+mut:
+	tv_sec  i64
+	tv_nsec i64
+}
+
+fn C.gettid() u32
+fn C.clock_gettime(int, &C.timespec)
+
+// windows:
+fn C.GetCurrentThreadId() u32
+fn C.QueryPerformanceCounter(&u64) C.BOOL
+
+[markused]
+pub fn on_call(fname string) {
+	mut volatile pfbase := unsafe { &u8(0) }
+	mut ssize := u64(0)
+	mut tid := u32(0)
+	unsafe {
+		fbase := u8(0)
+		pfbase = &fbase
+		ssize = u64(g_stack_base) - u64(pfbase)
+		$if windows {
+			tid = C.GetCurrentThreadId()
+		} $else {
+			tid = C.gettid()
+		}
+	}
+	ns := current_time() - g_start_time
+	C.fprintf(C.stderr, c'> trace %8d %8ld %8d %s\n', tid, ns, ssize, fname.str)
+	C.fflush(C.stderr)
+}
+
+[inline]
+fn current_time() u64 {
+	unsafe {
+		$if windows {
+			tm := u64(0)
+			C.QueryPerformanceCounter(&tm)
+			return tm
+		} $else {
+			ts := C.timespec{}
+			C.clock_gettime(C.CLOCK_MONOTONIC, &ts)
+			return u64(ts.tv_sec) * 1000000000 + u64(ts.tv_nsec)
+		}
+	}
+}
+
+[markused]
+pub fn on_c_main() {
+	g_start_time = current_time()
+	C.fprintf(C.stderr, c'#          tid       ns      ssize name\n')
+	C.fflush(C.stderr)
+	on_call('C.main')
+	//                    > trace  2128896   714640    28148 fn
+}

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -1041,45 +1041,31 @@ pub fn (mut t Transformer) sql_expr(mut node ast.SqlExpr) ast.Expr {
 // stmts list to let the gen backend generate the target specific code for the print.
 pub fn (mut t Transformer) fn_decl(mut node ast.FnDecl) {
 	if t.pref.trace_calls {
-		// Skip `C.fn()` and all of builtin
-		// builtin could probably be traced also but would need
-		// special cases for, at least, println/eprintln
-		if node.no_body || node.is_builtin {
+		if node.no_body {
+			// Skip `C.fn()` calls
 			return
 		}
-		call_expr := t.gen_trace_print_call_expr(node)
+		if node.name.starts_with('v.trace_calls.') {
+			// do not instrument the tracing functions, to avoid infinite regress
+			return
+		}
 		expr_stmt := ast.ExprStmt{
-			expr: call_expr
+			expr: ast.CallExpr{
+				mod: node.mod
+				pos: node.pos
+				language: .v
+				scope: node.scope
+				name: 'v.trace_calls.on_call'
+				args: [
+					ast.CallArg{
+						expr: ast.StringLiteral{
+							val: node.stringify(t.table, node.mod, {})
+						}
+						typ: ast.string_type_idx
+					},
+				]
+			}
 		}
 		node.stmts.prepend(expr_stmt)
 	}
-}
-
-// gen_trace_print_expr_stmt generates an ast.CallExpr representation of a
-// `eprint(...)` V code statement.
-fn (t Transformer) gen_trace_print_call_expr(node ast.FnDecl) ast.CallExpr {
-	print_str := '> trace ' + node.stringify(t.table, node.mod, map[string]string{})
-
-	call_arg := ast.CallArg{
-		expr: ast.StringLiteral{
-			val: print_str
-		}
-		typ: ast.string_type_idx
-	}
-	args := [call_arg]
-
-	fn_name := 'eprintln'
-	call_expr := ast.CallExpr{
-		name: fn_name
-		args: args
-		mod: node.mod
-		pos: node.pos
-		language: node.language
-		scope: node.scope
-		comments: [ast.Comment{
-			text: 'fn $node.short_name trace call'
-		}]
-	}
-
-	return call_expr
 }


### PR DESCRIPTION
Make it easier to change the implementation later, by splitting the tracing call into its own `v.trace_calls` module, so that it can be iterated upon without changing the compiler itself.