### PR TITLE
checker: fix returning embedded error result

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -858,9 +858,9 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 				// TODO: remove once deprecation period for `IError` methods has ended
 				if inter_sym.idx == ast.error_type_idx
 					&& (imethod.name == 'msg' || imethod.name == 'code') {
-					c.note("`$styp` doesn't implement method `$imethod.name` of interface `$inter_sym.name`. The usage of fields is being deprecated in favor of methods.",
-						pos)
-					continue
+					// c.note("`$styp` doesn't implement method `$imethod.name` of interface `$inter_sym.name`. The usage of fields is being deprecated in favor of methods.",
+					// 	pos)
+					return false
 				}
 				// <<
 

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -138,6 +138,17 @@ pub fn (mut c Checker) return_stmt(mut node ast.Return) {
 					}
 					continue
 				}
+				if got_typ_sym.kind == .struct_
+					&& c.type_implements(got_typ, ast.error_type, node.pos) {
+					node.exprs[expr_idxs[i]] = ast.CastExpr{
+						expr: node.exprs[expr_idxs[i]]
+						typname: 'IError'
+						typ: ast.error_type
+						expr_type: got_typ
+					}
+					node.types[expr_idxs[i]] = ast.error_type
+					continue
+				}
 				got_typ_name := if got_typ_sym.kind == .function {
 					'${c.table.type_to_str(got_typ)}'
 				} else {

--- a/vlib/v/tests/embed_error_in_returning_result_test.v
+++ b/vlib/v/tests/embed_error_in_returning_result_test.v
@@ -1,0 +1,21 @@
+struct NotFoundErr {
+	Error
+	id string
+}
+
+struct User {}
+
+fn find_by_id(id string) !User {
+	return NotFoundErr{
+		id: id
+	}
+}
+
+fn test_embed_error_in_returning_result() {
+	find_by_id('id123') or {
+		println(err)
+		assert true
+		return
+	}
+	assert false
+}


### PR DESCRIPTION
This PR fix returning embedded error result.

- Fix returning embedded error result.
- Add test.

```v
struct NotFoundErr {
	Error
	id string
}

struct User {}

fn find_by_id(id string) !User {
	return NotFoundErr{
		id: id
	}
}

fn main() {
	find_by_id('id123') or {
		println(err)
		assert true
		return
	}
	assert false
}

PS D:\Test\v\tt1> v run .
NotFoundErr:
```