### PR TITLE
parser: correct comptime path not found error position (fix #16189)

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -214,9 +214,9 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 				}
 			}
 			if is_html {
-				p.error_with_pos('vweb HTML template "$path" not found', arg_pos)
+				p.error_with_pos('vweb HTML template "$tmpl_path" not found', arg_pos)
 			} else {
-				p.error_with_pos('template file "$path" not found', arg_pos)
+				p.error_with_pos('template file "$tmpl_path" not found', arg_pos)
 			}
 			return err_node
 		}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -106,6 +106,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	is_html := method_name == 'html'
 	// $env('ENV_VAR_NAME')
 	p.check(.lpar)
+	arg_pos := p.tok.pos()
 	if method_name in ['env', 'pkgconfig', 'compile_error', 'compile_warn'] {
 		s := p.tok.lit
 		p.check(.string)
@@ -213,9 +214,9 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 				}
 			}
 			if is_html {
-				p.error('vweb HTML template "$path" not found')
+				p.error_with_pos('vweb HTML template "$path" not found', arg_pos)
 			} else {
-				p.error('template file "$path" not found')
+				p.error_with_pos('template file "$path" not found', arg_pos)
 			}
 			return err_node
 		}

--- a/vlib/v/parser/tests/comptime_path_not_found_err.out
+++ b/vlib/v/parser/tests/comptime_path_not_found_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/comptime_path_not_found_err.vv:2:15: error: template file "D:\Vlang\v\vlib\v\parser\tests\tempate.txt" not found
+    1 | fn main() {
+    2 |     tmp := $tmpl('tempate.txt')
+      |                  ~~~~~~~~~~~~~
+    3 |     a := tmp
+    4 | }

--- a/vlib/v/parser/tests/comptime_path_not_found_err.out
+++ b/vlib/v/parser/tests/comptime_path_not_found_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/comptime_path_not_found_err.vv:2:15: error: template file "D:\Vlang\v\vlib\v\parser\tests\tempate.txt" not found
+vlib/v/parser/tests/comptime_path_not_found_err.vv:2:15: error: template file "/home/runner/work/v/v/vlib/v/parser/tests/tempate.txt" not found
     1 | fn main() {
     2 |     tmp := $tmpl('tempate.txt')
       |                  ~~~~~~~~~~~~~

--- a/vlib/v/parser/tests/comptime_path_not_found_err.out
+++ b/vlib/v/parser/tests/comptime_path_not_found_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/comptime_path_not_found_err.vv:2:15: error: template file "/home/runner/work/v/v/vlib/v/parser/tests/tempate.txt" not found
+vlib/v/parser/tests/comptime_path_not_found_err.vv:2:15: error: template file "tempate.txt" not found
     1 | fn main() {
     2 |     tmp := $tmpl('tempate.txt')
       |                  ~~~~~~~~~~~~~

--- a/vlib/v/parser/tests/comptime_path_not_found_err.vv
+++ b/vlib/v/parser/tests/comptime_path_not_found_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	tmp := $tmpl('tempate.txt')
+	a := tmp
+}


### PR DESCRIPTION
This PR correct comptime path not found error position (fix #16189).

- Correct comptime path not found error position.
- Add test.

```v
fn main() {
	tmp := $tmpl('tempate.txt')
	a := tmp
}

PS D:\Test\v\tt1> v run .
./tt1.v:2:15: error: template file "tempate.txt" not found
    1 | fn main() {
    2 |     tmp := $tmpl('tempate.txt')
      |                  ~~~~~~~~~~~~~
    3 |     a := tmp
    4 | }
```