### PR TITLE
cgen: fix comparison with == of structs with pointers to interfaces autogenerates invalid eq comparison method (fix #16074)

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -156,8 +156,9 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 			} else if field_type.sym.kind == .function {
 				fn_builder.write_string('*((voidptr*)(a.$field_name)) == *((voidptr*)(b.$field_name))')
 			} else if field_type.sym.kind == .interface_ {
+				ptr := if field.typ.is_ptr() { '*'.repeat(field.typ.nr_muls()) } else { '' }
 				eq_fn := g.gen_interface_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_interface_eq(a.$field_name, b.$field_name)')
+				fn_builder.write_string('${eq_fn}_interface_eq(${ptr}a.$field_name, ${ptr}b.$field_name)')
 			} else {
 				fn_builder.write_string('a.$field_name == b.$field_name')
 			}
@@ -450,7 +451,7 @@ fn (mut g Gen) gen_interface_equality_fn(left_type ast.Type) string {
 					fn_builder.write_string('${eq_fn}_alias_eq(*(a._$eq_fn), *(b._$eq_fn))')
 				}
 				else {
-					fn_builder.write_string('false')
+					fn_builder.write_string('true')
 				}
 			}
 			fn_builder.writeln(';')

--- a/vlib/v/tests/struct_auto_eq_gen_interface_test.v
+++ b/vlib/v/tests/struct_auto_eq_gen_interface_test.v
@@ -21,3 +21,23 @@ fn test_struct_auto_eq_gen_interface_case() {
 	w2 := new()
 	assert w1 == w2
 }
+
+// For https://github.com/vlang/v/issues/16074
+pub interface Logger {
+mut:
+	info(s string)
+}
+
+struct LogContainer {
+	name string
+mut:
+	logger &Logger = unsafe { nil }
+}
+
+fn test_comparing_struct_with_pointers_to_interface_values_autogenerates_working_eq_method() {
+	assert LogContainer{
+		name: 'abc'
+	} == LogContainer{
+		name: 'abc'
+	}
+}


### PR DESCRIPTION
(This issue is related to the merged PR #16199 to some extent, so I fixed it by the way)

1. Fix: #16074 
2. Add tests.

```v
pub interface Logger {
mut:
	info(s string)
}

struct LogContainer {
	name string
mut:
	logger &Logger = unsafe { nil }
}

fn main() {
	assert LogContainer{
		name: 'abc'
	} == LogContainer{
		name: 'abc'
	}
}
```

output:

passed.
