### PR TITLE
parser: fix $tmpl with single quotes (fix #16154)

### DIFF
--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -80,7 +80,10 @@ fn insert_template_code(fn_name string, tmpl_str_start string, line string) stri
 	round1 := ['\\', '\\\\', r"'", "\\'", r'@', r'$']
 	round2 := [r'$$', r'\@', r'.$', r'.@']
 	mut rline := line.replace_each(round1).replace_each(round2)
-
+	comptime_call_str := rline.find_between('\${', '}')
+	if comptime_call_str.contains("\\'") {
+		rline = rline.replace(comptime_call_str, comptime_call_str.replace("\\'", r"'"))
+	}
 	if rline.ends_with('\\') {
 		rline = rline[0..rline.len - 2] + trailing_bs
 	}

--- a/vlib/v/tests/tmpl/template.in
+++ b/vlib/v/tests/tmpl/template.in
@@ -1,0 +1,3 @@
+someval: @{s.someval('huh')}
+
+someotherval: @{s.m['hah']}

--- a/vlib/v/tests/tmpl_with_single_quotes_test.v
+++ b/vlib/v/tests/tmpl_with_single_quotes_test.v
@@ -1,0 +1,27 @@
+module main
+
+pub struct SomeThing {
+pub:
+	m map[string]string
+}
+
+fn (s SomeThing) someval(what string) string {
+	return s.m[what]
+}
+
+fn (s SomeThing) template() string {
+	return $tmpl('tmpl/template.in')
+}
+
+fn test_tmpl_with_single_quotes() {
+	mut sm := map[string]string{}
+	sm['huh'] = 'monkey'
+	sm['hah'] = 'parrot'
+
+	s := SomeThing{sm}
+	result := s.template()
+	println(result)
+	assert result.trim_space() == "someval: monkey
+
+someotherval: parrot"
+}

--- a/vlib/v/tests/tmpl_with_single_quotes_test.v
+++ b/vlib/v/tests/tmpl_with_single_quotes_test.v
@@ -21,7 +21,7 @@ fn test_tmpl_with_single_quotes() {
 	s := SomeThing{sm}
 	result := s.template()
 	println(result)
-	assert result.trim_space() == "someval: monkey
+	assert result.trim_space() == 'someval: monkey
 
-someotherval: parrot"
+someotherval: parrot'
 }


### PR DESCRIPTION
This PR fix vtmpl with single quotes (fix #16154).

- Fix vtmpl with single quotes.
- Add test.

template.in
```v
someval: @{s.someval('huh')}

someotherval: @{s.m['hah']}
```

```v
module main

pub struct SomeThing {
pub:
	m map[string]string
}

fn (s SomeThing) someval(what string) string {
	return s.m[what]
}

fn (s SomeThing) template() string {
	return $tmpl('template.in')
}

fn main() {
	mut sm := map[string]string{}
	sm['huh'] = 'monkey'
	sm['hah'] = 'parrot'

	s := SomeThing{sm}
	result := s.template()
	println(result)
	assert result.trim_space() == "someval: monkey

someotherval: parrot"
}

PS D:\Test\v\tt1> v run .
someval: monkey

someotherval: parrot
```