### PR TITLE
v.eval: support comptime `if`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -918,6 +918,8 @@ pub:
 pub mut:
 	left     Expr       // `a` in `a := if ...`
 	branches []IfBranch // includes all `else if` branches
+	// contains the index of the branch that returned the condition true or is `else`
+	comptime_branch_idx int = -1
 	is_expr  bool
 	typ      Type
 	has_else bool

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -42,7 +42,11 @@ pub fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 		if !node.has_else || i < node.branches.len - 1 {
 			if node.is_comptime {
 				skip_state = c.comptime_if_branch(branch.cond, branch.pos)
-				node.branches[i].pkg_exist = if skip_state == .eval { true } else { false }
+				evalue := skip_state == .eval
+				node.branches[i].pkg_exist = evalue
+				if evalue {
+					node.comptime_branch_idx = i
+				}
 			} else {
 				// check condition type is boolean
 				c.expected_type = ast.bool_type

--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -143,32 +143,8 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 			}
 
 			if expr.is_comptime {
-				for i, branch in expr.branches {
-					mut do_if := false
-					if expr.has_else && i + 1 == expr.branches.len { // else branch
-						do_if = true
-					} else {
-						if branch.cond is ast.Ident {
-							if known_os := pref.os_from_string(branch.cond.name) {
-								do_if = e.pref.os == known_os
-							} else {
-								match branch.cond.name {
-									'prealloc' {
-										do_if = e.pref.prealloc
-									}
-									else {
-										e.error('unknown compile time if: $branch.cond.name')
-									}
-								}
-							}
-						} else if branch.cond is ast.PostfixExpr {
-							do_if = (branch.cond.expr as ast.Ident).name in e.pref.compile_defines
-						}
-					}
-					if do_if {
-						e.stmts(branch.stmts)
-						break
-					}
+				if expr.comptime_branch_idx > -1 {
+					e.stmts(expr.branches[expr.comptime_branch_idx].stmts)
 				}
 				return empty
 			} else {


### PR DESCRIPTION
Fully support comptime `if`, using a `.comptime_branch_idx` field, which contains the branch index evaluated to true.

```v
$ cat x.v
fn main() {
    $if linux {
        println("linux!")
    }
}
$ ./v2 -interpret run x.v
linux!
```
