### PR TITLE
v.eval: support `&&` and `||`, also support basic `assert`

### DIFF
--- a/vlib/v/eval/expr.v
+++ b/vlib/v/eval/expr.v
@@ -194,6 +194,14 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 		ast.InfixExpr {
 			left := e.expr(expr.left, expr.left_type)
 			right := e.expr(expr.right, expr.right_type)
+			if expecting == ast.bool_type_idx && expr.op in [.logical_or, .and] {
+				left_b := left as bool
+				right_b := right as bool
+				if expr.op == .logical_or {
+					return left_b || right_b
+				}
+				return left_b && right_b
+			}
 			return e.infix_expr(left, right, expr.op, expecting)
 		}
 		ast.IntegerLiteral {

--- a/vlib/v/eval/stmt.v
+++ b/vlib/v/eval/stmt.v
@@ -104,6 +104,20 @@ pub fn (mut e Eval) stmt(stmt ast.Stmt) {
 		ast.Block {
 			e.stmts(stmt.stmts)
 		}
+		ast.AssertStmt {
+			cond := e.expr(stmt.expr, ast.bool_type_idx)
+			if !(cond as bool) {
+				t := e.back_trace.last()
+				file_path := if path := e.trace_file_paths[t.file_idx] {
+					path
+				} else {
+					t.file_idx.str()
+				}
+				fn_name := e.trace_function_names[t.fn_idx] or { t.fn_idx.str() }
+				eprintln('$file_path:${stmt.pos.line_nr + 1}: FAIL: fn $fn_name: assert $stmt.expr')
+				e.panic('Assertion failed...')
+			}
+		}
 		else {
 			e.error('unhandled statement $stmt.type_name()')
 		}

--- a/vlib/v/eval/testdata/boolean_infix.out
+++ b/vlib/v/eval/testdata/boolean_infix.out
@@ -1,0 +1,2 @@
+a: true
+b: true

--- a/vlib/v/eval/testdata/boolean_infix.vv
+++ b/vlib/v/eval/testdata/boolean_infix.vv
@@ -1,0 +1,21 @@
+fn is_greater_than(a int, b int) bool {
+    return a > b
+}
+
+fn is_less_than(a int, b int) bool {
+    return a < b
+}
+
+a := is_greater_than(5, 2) && is_less_than(8, 10)
+if a {
+    println('a: true')
+} else {
+    println('a: false')
+}
+
+b := is_greater_than(100, 20) || is_less_than(31, 18)
+if b {
+    println('b: true')
+} else {
+    println('b: false')
+}


### PR DESCRIPTION
Adds support for `&&` and `||` operations.

```v
$ cat x.v
fn is_greater_than(a int, b int) bool {
    return a > b
}

fn is_less_than(a int, b int) bool {
    return a < b
}

a := is_greater_than(5, 2) && is_less_than(8, 10)
if a {
    println('a: true')
} else {
    println('a: false')
}
$ ./v2 -interpret run x.v
a: true
```

And a basic `assert`:

```v
$ cat x.v
assert false
$ ./v2 -interpret run x.v
x.v:1: FAIL: fn main.main: assert false
V panic: Assertion failed...
V hash: e3379bc
/home/jomaca/dev/v-world/vdev/x.v:1: at main.main
```