### PR TITLE
v.eval: consistency in commit hash shown on panic

### DIFF
--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -231,8 +231,9 @@ fn (e Eval) error(msg string) {
 }
 
 fn (e Eval) panic(s string) {
+	commithash := unsafe { tos5(&char(C.V_CURRENT_COMMIT_HASH)) }
 	eprintln('V panic: $s')
-	eprintln('V hash: ${@VHASH}')
+	eprintln('V hash: ${commithash}')
 	e.print_backtrace()
 	exit(1)
 }

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -233,7 +233,7 @@ fn (e Eval) error(msg string) {
 fn (e Eval) panic(s string) {
 	commithash := unsafe { tos5(&char(C.V_CURRENT_COMMIT_HASH)) }
 	eprintln('V panic: $s')
-	eprintln('V hash: ${commithash}')
+	eprintln('V hash: $commithash')
 	e.print_backtrace()
 	exit(1)
 }


### PR DESCRIPTION
Now it shows the same commit hash on panic:

```v
$ cat x.v
panic('panic!')

$ ./v2 run x.v
V panic: panic!
v hash: 71bff21
/tmp/v_1000/x.11155285029361023853.tmp.c:6650: at _v_panic: Backtrace
/tmp/v_1000/x.11155285029361023853.tmp.c:12115: by main__main
/tmp/v_1000/x.11155285029361023853.tmp.c:12486: by main

$ ./v2 -interpret run x.v
V panic: panic!
V hash: 71bff21
/home/jomaca/dev/v-world/vdev/vlib/builtin/builtin.c.v:88: at panic
/home/jomaca/dev/v-world/vdev/x.v:1: by main.main
```