### PR TITLE
fmt: fix compiler_error('...') broken by fmt (fix #16218)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1868,6 +1868,8 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 			f.write("\$env('$node.args_var')")
 		} else if node.is_pkgconfig {
 			f.write("\$pkgconfig('$node.args_var')")
+		} else if node.method_name == 'compile_error' {
+			f.write("\$compile_error('$node.args_var')")
 		} else {
 			inner_args := if node.args_var != '' {
 				node.args_var

--- a/vlib/v/fmt/tests/comptime_method_args_expected.vv
+++ b/vlib/v/fmt/tests/comptime_method_args_expected.vv
@@ -1,0 +1,3 @@
+$if !linux {
+        $compile_error('Only Lin\"ux is currently supported')
+}

--- a/vlib/v/fmt/tests/comptime_method_args_expected.vv
+++ b/vlib/v/fmt/tests/comptime_method_args_expected.vv
@@ -1,3 +1,3 @@
 $if !linux {
-        $compile_error('Only Lin\"ux is currently supported')
+	$compile_error('Only Lin\"ux is currently supported')
 }

--- a/vlib/v/fmt/tests/comptime_method_args_input.vv
+++ b/vlib/v/fmt/tests/comptime_method_args_input.vv
@@ -1,0 +1,3 @@
+$if !linux {
+	$compile_error("Only Lin\"ux is currently supported")
+}

--- a/vlib/v/tests/comptime_method_args_test.v
+++ b/vlib/v/tests/comptime_method_args_test.v
@@ -52,9 +52,3 @@ fn test_comptime_call_method() {
 	assert t.two_args_called
 	assert t.three_args_called
 }
-
-fn test_compile_error_and_args() {
-	$if !linux {
-		$compile_error('Only Lin\"ux is currently supported')
-	}
-}

--- a/vlib/v/tests/comptime_method_args_test.v
+++ b/vlib/v/tests/comptime_method_args_test.v
@@ -52,3 +52,9 @@ fn test_comptime_call_method() {
 	assert t.two_args_called
 	assert t.three_args_called
 }
+
+fn test_compile_error_and_args() {
+	$if !linux {
+		$compile_error('Only Lin\"ux is currently supported')
+	}
+}


### PR DESCRIPTION
1. Fix #16218 
2. Add tests.

```v
fn main() {
	$if !linux {
		$compile_error('Only Lin\"ux is currently supported')
	}
}
```

output (on macos):

```
a.v:2:2: error: Only Lin\"ux is currently supported
    1 | $if !linux {
    2 |     $compile_error("Only Lin\"ux is currently supported")
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    3 | }
    4 |
```

------------------------

```v
$if !linux {
	$compile_error("Only Lin\"ux is currently supported")
}
```

v fmt output:
```v
$if !linux {
	$compile_error('Only Lin\"ux is currently supported')
}
```
