### PR TITLE
token: optimized msg for unexpected string interpolation (fix #16240)

### DIFF
--- a/vlib/v/parser/tests/unexpected_string_interpolation.out
+++ b/vlib/v/parser/tests/unexpected_string_interpolation.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/unexpected_string_interpolation.vv:5:26: error: unexpected string interpolation, expecting `{`
+    3 |     a := 123
+    4 |     println('Foo = ${a}')
+    5 |     println('Foo = ${unsafe {a}}')
+      |                             ^
+    6 | }

--- a/vlib/v/parser/tests/unexpected_string_interpolation.vv
+++ b/vlib/v/parser/tests/unexpected_string_interpolation.vv
@@ -1,0 +1,6 @@
+
+fn main() {
+	a := 123
+	println('Foo = ${a}')
+	println('Foo = ${unsafe {a}}')
+}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -269,7 +269,7 @@ fn build_token_str() []string {
 	s[Kind.nl] = 'NLL'
 	s[Kind.dollar] = '$'
 	s[Kind.at] = '@'
-	s[Kind.str_dollar] = '$2'
+	s[Kind.str_dollar] = 'string interpolation'
 	s[Kind.key_assert] = 'assert'
 	s[Kind.key_struct] = 'struct'
 	s[Kind.key_if] = 'if'


### PR DESCRIPTION
1. Minor optimization of token error messages, Fix #16240
2. Add tests.

```v
fn main() {
	a := 123
	println('Foo = ${a}')
	println('Foo = ${unsafe {a}}')
}
```

output:

```
vlib/v/parser/tests/unexpected_string_interpolation.vv:5:26: error: unexpected string interpolation, expecting `{`
    3 |     a := 123
    4 |     println('Foo = ${a}')
    5 |     println('Foo = ${unsafe {a}}')
      |                             ^
    6 | }
```
