### PR TITLE
scanner: fix and restore string interpolation tests

### DIFF
--- a/vlib/v/checker/tests/str_interpol_invalid_err.out
+++ b/vlib/v/checker/tests/str_interpol_invalid_err.out
@@ -4,31 +4,52 @@ vlib/v/checker/tests/str_interpol_invalid_err.vv:8:13: error: illegal format spe
     8 |     _ = '${[1]:x}'
       |                ^
     9 |     _ = '${[1]!:x}'
-   10 |     //_ = '${Foo{}:x}'
+   10 |     _ = '${Foo{}:x}'
 vlib/v/checker/tests/str_interpol_invalid_err.vv:9:14: error: illegal format specifier `x` for type `[1]int`
     7 | fn main() {
     8 |     _ = '${[1]:x}'
     9 |     _ = '${[1]!:x}'
       |                 ^
-   10 |     //_ = '${Foo{}:x}'
+   10 |     _ = '${Foo{}:x}'
    11 |     _ = '${[1]:f}'
+vlib/v/checker/tests/str_interpol_invalid_err.vv:10:15: error: illegal format specifier `x` for type `Foo`
+    8 |     _ = '${[1]:x}'
+    9 |     _ = '${[1]!:x}'
+   10 |     _ = '${Foo{}:x}'
+      |                  ^
+   11 |     _ = '${[1]:f}'
+   12 |     _ := '${none:F}'
 vlib/v/checker/tests/str_interpol_invalid_err.vv:11:13: error: illegal format specifier `f` for type `[]int`
     9 |     _ = '${[1]!:x}'
-   10 |     //_ = '${Foo{}:x}'
+   10 |     _ = '${Foo{}:x}'
    11 |     _ = '${[1]:f}'
       |                ^
    12 |     _ := '${none:F}'
-   13 |     //_ = '${{"a": "b"}:x}'
+   13 |     _ = '${{"a": "b"}:x}'
 vlib/v/checker/tests/str_interpol_invalid_err.vv:12:15: error: illegal format specifier `F` for type `none`
-   10 |     //_ = '${Foo{}:x}'
+   10 |     _ = '${Foo{}:x}'
    11 |     _ = '${[1]:f}'
    12 |     _ := '${none:F}'
       |                  ^
-   13 |     //_ = '${{"a": "b"}:x}'
-   14 |     //_ = '${Alias(Foo{}):x}'
+   13 |     _ = '${{"a": "b"}:x}'
+   14 |     _ = '${Alias(Foo{}):x}'
+vlib/v/checker/tests/str_interpol_invalid_err.vv:13:20: error: illegal format specifier `x` for type `map[string]string`
+   11 |     _ = '${[1]:f}'
+   12 |     _ := '${none:F}'
+   13 |     _ = '${{"a": "b"}:x}'
+      |                       ^
+   14 |     _ = '${Alias(Foo{}):x}'
+   15 |     _ = '${SumType(int(5)):o}'
+vlib/v/checker/tests/str_interpol_invalid_err.vv:14:22: error: illegal format specifier `x` for type `Alias`
+   12 |     _ := '${none:F}'
+   13 |     _ = '${{"a": "b"}:x}'
+   14 |     _ = '${Alias(Foo{}):x}'
+      |                         ^
+   15 |     _ = '${SumType(int(5)):o}'
+   16 | }
 vlib/v/checker/tests/str_interpol_invalid_err.vv:15:25: error: illegal format specifier `o` for type `SumType`
-   13 |     //_ = '${{"a": "b"}:x}'
-   14 |     //_ = '${Alias(Foo{}):x}'
+   13 |     _ = '${{"a": "b"}:x}'
+   14 |     _ = '${Alias(Foo{}):x}'
    15 |     _ = '${SumType(int(5)):o}'
       |                            ^
    16 | }

--- a/vlib/v/checker/tests/str_interpol_invalid_err.vv
+++ b/vlib/v/checker/tests/str_interpol_invalid_err.vv
@@ -7,10 +7,10 @@ type SumType = Alias | int
 fn main() {
 	_ = '${[1]:x}'
 	_ = '${[1]!:x}'
-	//_ = '${Foo{}:x}'
+	_ = '${Foo{}:x}'
 	_ = '${[1]:f}'
 	_ := '${none:F}'
-	//_ = '${{"a": "b"}:x}'
-	//_ = '${Alias(Foo{}):x}'
+	_ = '${{"a": "b"}:x}'
+	_ = '${Alias(Foo{}):x}'
 	_ = '${SumType(int(5)):o}'
 }

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -803,11 +803,13 @@ fn (mut s Scanner) text_scan() token.Token {
 			}
 			`{` {
 				if s.is_inside_string {
+					prev_char := s.text[s.pos - 1]
+					next_char := s.text[s.pos + 1]
 					// Handle new `hello {name}` string interpolation
-					if !s.text[s.pos + 1].is_space() && s.text[s.pos - 1] != `$` {
+					if !next_char.is_space() && next_char != `}` && prev_char !in [`$`, `{`] {
 						return s.new_token(.str_dollar, '', 1)
 					}
-					if s.text[s.pos - 1] == `$` {
+					if prev_char == `$` {
 						// Skip { in `${` in strings
 						continue
 					} else {

--- a/vlib/v/tests/string_interpolation_inner_cbr_test.v
+++ b/vlib/v/tests/string_interpolation_inner_cbr_test.v
@@ -9,12 +9,9 @@ fn test_string_interpolation_inner_cbr() {
 	println(s1)
 	assert s1 == '22'
 
-	/*
-	XTODO
 	s2 := '${St{}}'
 	println(s2)
 	assert s2 == 'St{}'
-	*/
 
 	s3 := '${{
 		'a': 1


### PR DESCRIPTION
This PR fix and resotre string interpolation tests.

```v
struct St {}

fn foo() ?int {
	return 22
}

fn main() {
	s1 := '${foo() or { 11 }}'
	println(s1)
	assert s1 == '22'

	s2 := '${St{}}'
	println(s2)
	assert s2 == 'St{}'

	s3 := '${{
		'a': 1
	}}'
	println(s3)
	assert s3 == "{'a': 1}"
}

PS D:\Test\v\tt1> v run .
22
St{}
{'a': 1}
```
```v
struct Foo {}

type Alias = Foo

type SumType = Alias | int

fn main() {
	_ = '${[1]:x}'
	_ = '${[1]!:x}'
	_ = '${Foo{}:x}'
	_ = '${[1]:f}'
	_ := '${none:F}'
	_ = '${{"a": "b"}:x}'
	_ = '${Alias(Foo{}):x}'
	_ = '${SumType(int(5)):o}'
}

PS D:\Test\v\tt1> v run .
./tt1.v:8:13: error: illegal format specifier `x` for type `[]int`
    6 | 
    7 | fn main() {
    8 |     _ = '${[1]:x}'
      |                ^
    9 |     _ = '${[1]!:x}'
   10 |     _ = '${Foo{}:x}'
./tt1.v:9:14: error: illegal format specifier `x` for type `[1]int`
    7 | fn main() {
    8 |     _ = '${[1]:x}'
    9 |     _ = '${[1]!:x}'
      |                 ^
   10 |     _ = '${Foo{}:x}'
   11 |     _ = '${[1]:f}'
./tt1.v:10:15: error: illegal format specifier `x` for type `Foo`
    8 |     _ = '${[1]:x}'
    9 |     _ = '${[1]!:x}'
   10 |     _ = '${Foo{}:x}'
      |                  ^
   11 |     _ = '${[1]:f}'
   12 |     _ := '${none:F}'
./tt1.v:11:13: error: illegal format specifier `f` for type `[]int`
    9 |     _ = '${[1]!:x}'
   10 |     _ = '${Foo{}:x}'
   11 |     _ = '${[1]:f}'
      |                ^
   12 |     _ := '${none:F}'
   13 |     _ = '${{"a": "b"}:x}'
./tt1.v:12:15: error: illegal format specifier `F` for type `none`
   10 |     _ = '${Foo{}:x}'
   11 |     _ = '${[1]:f}'
   12 |     _ := '${none:F}'
      |                  ^
   13 |     _ = '${{"a": "b"}:x}'
   14 |     _ = '${Alias(Foo{}):x}'
./tt1.v:13:20: error: illegal format specifier `x` for type `map[string]string`
   11 |     _ = '${[1]:f}'
   12 |     _ := '${none:F}'
   13 |     _ = '${{"a": "b"}:x}'
      |                       ^
   14 |     _ = '${Alias(Foo{}):x}'
   15 |     _ = '${SumType(int(5)):o}'
./tt1.v:14:22: error: illegal format specifier `x` for type `Alias`
   12 |     _ := '${none:F}'
   13 |     _ = '${{"a": "b"}:x}'
   14 |     _ = '${Alias(Foo{}):x}'
      |                         ^
   15 |     _ = '${SumType(int(5)):o}'
   16 | }
./tt1.v:15:25: error: illegal format specifier `o` for type `SumType`
   13 |     _ = '${{"a": "b"}:x}'
   14 |     _ = '${Alias(Foo{}):x}'
   15 |     _ = '${SumType(int(5)):o}'
      |                            ^
   16 | }
```