### PR TITLE
checker: fix return error with multi_return optional

### DIFF
--- a/vlib/v/tests/results_multi_return_test.v
+++ b/vlib/v/tests/results_multi_return_test.v
@@ -16,9 +16,9 @@ fn foo() ?string {
 }
 
 fn bar() !(string, int) {
-	a := foo() or { return IError(Err{
+	a := foo() or { return Err{
 		msg: 'error test'
-	}) }
+	} }
 	return a, 1
 }
 

--- a/vlib/v/tests/string_optional_none_test.v
+++ b/vlib/v/tests/string_optional_none_test.v
@@ -12,7 +12,7 @@ fn (err MyError) code() int {
 }
 
 fn foo() int|none|IError {
-	return IError(MyError{})
+	return MyError{}
 }
 
 fn test_string_optional_none() {

--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -24,7 +24,7 @@ fn parse_attrs(name string, attrs []string) !([]http.Method, string) {
 		}
 		if attr.starts_with('/') {
 			if path != '' {
-				return IError(http.MultiplePathAttributesError{})
+				return http.MultiplePathAttributesError{}
 			}
 			path = attr
 			x.delete(i)
@@ -33,9 +33,9 @@ fn parse_attrs(name string, attrs []string) !([]http.Method, string) {
 		i++
 	}
 	if x.len > 0 {
-		return IError(http.UnexpectedExtraAttributeError{
+		return http.UnexpectedExtraAttributeError{
 			attributes: x
-		})
+		}
 	}
 	if methods.len == 0 {
 		methods = [http.Method.get]


### PR DESCRIPTION
This PR fix return error with multi_return optional.

- Fix return error with multi_return optional.
- Modify the related tests.

```v
struct Err {
	msg  string
	code int
}

fn (e Err) msg() string {
	return e.msg
}

fn (e Err) code() int {
	return e.code
}

fn foo() ?string {
	return 'foo'
}

fn bar() !(string, int) {
	a := foo() or { return Err{
		msg: 'error test'
	} }
	return a, 1
}

fn main() {
	b, _ := bar() or { panic(err) }
	println(b)
	assert b == 'foo'
}

PS D:\Test\v\tt1> v run .
foo
```