### PR TITLE
cgen: fix dump() multi ptr (fix #16247)

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -16,7 +16,8 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 	if g.table.sym(node.expr_type).language == .c {
 		name = name[3..]
 	}
-	dump_fn_name := '_v_dump_expr_$name' + (if node.expr_type.is_ptr() { '_ptr' } else { '' })
+	dump_fn_name := '_v_dump_expr_$name' +
+		(if node.expr_type.is_ptr() { '_ptr'.repeat(node.expr_type.nr_muls()) } else { '' })
 	g.write(' ${dump_fn_name}(${ctoslit(fpath)}, $line, $sexpr, ')
 	if node.expr_type.has_flag(.shared_f) {
 		g.write('&')
@@ -39,10 +40,11 @@ fn (mut g Gen) dump_expr_definitions() {
 			name = name[3..]
 		}
 		_, str_method_expects_ptr, _ := dump_sym.str_method_info()
-		is_ptr := ast.Type(dump_type).is_ptr()
+		typ := ast.Type(dump_type)
+		is_ptr := typ.is_ptr()
 		deref, _ := deref_kind(str_method_expects_ptr, is_ptr, dump_type)
-		to_string_fn_name := g.get_str_fn(ast.Type(dump_type).clear_flag(.shared_f))
-		ptr_asterisk := if is_ptr { '*' } else { '' }
+		to_string_fn_name := g.get_str_fn(typ.clear_flag(.shared_f))
+		ptr_asterisk := if is_ptr { '*'.repeat(typ.nr_muls()) } else { '' }
 		mut str_dumparg_type := g.cc_type(dump_type, true) + ptr_asterisk
 		if dump_sym.kind == .function {
 			fninfo := dump_sym.info as ast.FnType
@@ -53,7 +55,8 @@ fn (mut g Gen) dump_expr_definitions() {
 			g.go_back(str_tdef.len)
 			dump_typedefs['typedef $str_tdef;'] = true
 		}
-		dump_fn_name := '_v_dump_expr_$name' + (if is_ptr { '_ptr' } else { '' })
+		dump_fn_name := '_v_dump_expr_$name' +
+			(if is_ptr { '_ptr'.repeat(typ.nr_muls()) } else { '' })
 		dump_fn_defs.writeln('$str_dumparg_type ${dump_fn_name}(string fpath, int line, string sexpr, $str_dumparg_type dump_arg);')
 		if g.writeln_fn_header('$str_dumparg_type ${dump_fn_name}(string fpath, int line, string sexpr, $str_dumparg_type dump_arg)', mut
 			dump_fns)
@@ -88,7 +91,9 @@ fn (mut g Gen) dump_expr_definitions() {
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, ':');")
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, ' ');")
 		if is_ptr {
-			dump_fns.writeln("\tstrings__Builder_write_rune(&sb, '&');")
+			for i := 0; i < typ.nr_muls(); i++ {
+				dump_fns.writeln("\tstrings__Builder_write_rune(&sb, '&');")
+			}
 		}
 		dump_fns.writeln('\tstrings__Builder_write_string(&sb, value);')
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, '\\n');")

--- a/vlib/v/tests/inout/dump_multiple_ptr.out
+++ b/vlib/v/tests/inout/dump_multiple_ptr.out
@@ -1,0 +1,4 @@
+[vlib/v/tests/inout/dump_multiple_ptr.vv:3] i: 42
+[vlib/v/tests/inout/dump_multiple_ptr.vv:5] ir: &42
+[vlib/v/tests/inout/dump_multiple_ptr.vv:7] irr: &&42
+[vlib/v/tests/inout/dump_multiple_ptr.vv:9] irrr: &&&42

--- a/vlib/v/tests/inout/dump_multiple_ptr.vv
+++ b/vlib/v/tests/inout/dump_multiple_ptr.vv
@@ -1,0 +1,10 @@
+fn main() {
+	i := 42
+	dump(i)
+	ir := &i
+	dump(ir)
+	irr := &ir
+	dump(irr)
+	irrr := &irr
+	dump(irrr)
+}


### PR DESCRIPTION
1. Fix #16247 
2. Add tests.

```v
fn main() {
	i := 42
	dump(i)
	ir := &i
	dump(ir)
	irr := &ir
	dump(irr)
	irrr := &irr
	dump(irrr)
}
```

output:

```
[vlib/v/tests/inout/dump_multiple_ptr.vv:3] i: 42
[vlib/v/tests/inout/dump_multiple_ptr.vv:5] ir: &42
[vlib/v/tests/inout/dump_multiple_ptr.vv:7] irr: &&42
[vlib/v/tests/inout/dump_multiple_ptr.vv:9] irrr: &&&42
```
