### PR TITLE
scanner: prevent resolving to nested interpolation (fix #16240)

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -47,6 +47,7 @@ const verify_known_failing_exceptions = [
 	'vlib/builtin/int_test.v' /* special number formatting that should be tested */,
 	// TODOs and unfixed vfmt bugs
 	'vlib/v/gen/js/tests/js.v', /* local `hello` fn, gets replaced with module `hello` aliased as `hl` */
+	'vlib/v/tests/inout/string_interpolation_inner_expr_cbr.vv', /* for new string interpolation, prevent resolving to nested interpolation */
 ]
 
 const vfmt_verify_list = [

--- a/vlib/v/tests/inout/string_interpolation_inner_expr_cbr.out
+++ b/vlib/v/tests/inout/string_interpolation_inner_expr_cbr.out
@@ -1,0 +1,2 @@
+Foo = def
+Foo = def

--- a/vlib/v/tests/inout/string_interpolation_inner_expr_cbr.vv
+++ b/vlib/v/tests/inout/string_interpolation_inner_expr_cbr.vv
@@ -1,0 +1,9 @@
+enum Foo {
+	abc
+	def
+}
+
+fn main() {
+	println('Foo = {Foo.def}')
+	println('Foo = {unsafe{Foo(1)}}')
+}


### PR DESCRIPTION
Fix #16240 

```v
enum Foo{
	abc
	def
}

fn main() {
	println('Foo = {Foo.def}')
	println('Foo = {unsafe{Foo(1)}}')
}
```

output:

```
Foo = def
Foo = def
```
