### PR TITLE
cgen: fix return match expr of sumtype result  (fix #16255)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1666,8 +1666,10 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 							g.expr(stmt.expr)
 							g.writeln(';')
 						} else {
+							ret_typ := g.fn_decl.return_type.clear_flag(.optional)
+							styp = g.base_type(ret_typ)
 							g.write('_option_ok(&($styp[]) { ')
-							g.expr(stmt.expr)
+							g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
 							g.writeln(' }, ($c.option_name*)(&$tmp_var), sizeof($styp));')
 						}
 					}
@@ -1696,8 +1698,10 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 							g.expr(stmt.expr)
 							g.writeln(';')
 						} else {
+							ret_typ := g.fn_decl.return_type.clear_flag(.result)
+							styp = g.base_type(ret_typ)
 							g.write('_result_ok(&($styp[]) { ')
-							g.expr(stmt.expr)
+							g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
 							g.writeln(' }, ($c.result_name*)(&$tmp_var), sizeof($styp));')
 						}
 					}

--- a/vlib/v/tests/return_match_expr_of_sumtype_result_test.v
+++ b/vlib/v/tests/return_match_expr_of_sumtype_result_test.v
@@ -1,0 +1,25 @@
+type Foo = int | string
+
+fn foo1() !Foo {
+	return match true {
+		true { 1 }
+		else { '' }
+	}
+}
+
+fn foo2() ?Foo {
+	return match true {
+		true { 1 }
+		else { '' }
+	}
+}
+
+fn test_return_match_expr_of_sumtype_opt_res() {
+	ret1 := foo1() or { return }
+	println(ret1)
+	assert '$ret1' == 'Foo(1)'
+
+	ret2 := foo2() or { return }
+	println(ret2)
+	assert '$ret2' == 'Foo(1)'
+}


### PR DESCRIPTION
This PR fix return match expr of sumtype result  (fix #16255).

- Fix return match expr of sumtype result.
- Add test.

```v
type Foo = int | string

fn foo1() !Foo {
	return match true {
		true { 1 }
		else { '' }
	}
}

fn foo2() ?Foo {
	return match true {
		true { 1 }
		else { '' }
	}
}

fn main() {
	ret1 := foo1() or { return }
	println(ret1)
	assert '$ret1' == 'Foo(1)'

	ret2 := foo2() or { return }
	println(ret2)
	assert '$ret2' == 'Foo(1)'
}

PS D:\Test\v\tt1> v run .
Foo(1)
Foo(1)
```