### PR TITLE
checker: check fn type mismatch of return result type fn (fix #16260)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -381,6 +381,9 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 	if got_fn.return_type.has_flag(.optional) != exp_fn.return_type.has_flag(.optional) {
 		return false
 	}
+	if got_fn.return_type.has_flag(.result) != exp_fn.return_type.has_flag(.result) {
+		return false
+	}
 	if !c.check_basic(got_fn.return_type, exp_fn.return_type) {
 		return false
 	}

--- a/vlib/v/checker/tests/return_result_fn_mismatch.out
+++ b/vlib/v/checker/tests/return_result_fn_mismatch.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/return_result_fn_mismatch.vv:15:10: error: cannot use `fn ()` as `fn () !` in argument 1 to `do_test`
+   13 |         foo() or { return }
+   14 |     }
+   15 |     do_test(test)
+      |             ~~~~
+   16 | }

--- a/vlib/v/checker/tests/return_result_fn_mismatch.vv
+++ b/vlib/v/checker/tests/return_result_fn_mismatch.vv
@@ -1,0 +1,16 @@
+type AnonOptionalFun = fn () !
+
+// do_test is used to test functionality
+pub fn do_test(cb AnonOptionalFun) {
+	cb() or { panic(err) }
+}
+
+fn foo () ! {
+}
+
+fn main() {
+	test := fn () {
+		foo() or { return }
+	}
+	do_test(test)
+}


### PR DESCRIPTION
This PR check fn type mismatch of return result type fn (fix #16260).

- Check fn type mismatch of return result type fn.
- Add test.

```v
type AnonOptionalFun = fn () !

// do_test is used to test functionality
pub fn do_test(cb AnonOptionalFun) {
	cb() or { panic(err) }
}

fn foo () ! {
}

fn main() {
	test := fn () {
		foo() or { return }
	}
	do_test(test)
}

PS D:\Test\v\tt1> v run .
./tt1.v:15:10: error: cannot use `fn ()` as `fn () !` in argument 1 to `do_test`
   13 |         foo() or { return }
   14 |     }
   15 |     do_test(test)
      |             ~~~~
   16 | }
```