### PR TITLE
checker: fix multiple pointer check of fn and method args (fix #16261 #16262 #16263)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -170,7 +170,7 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 
 fn (c Checker) check_multiple_ptr_match(got ast.Type, expected ast.Type, param ast.Param, arg ast.CallArg) bool {
 	param_nr_muls := if param.is_mut && !expected.is_ptr() { 1 } else { expected.nr_muls() }
-	if got.is_ptr() && got.nr_muls() != param_nr_muls {
+	if got.is_ptr() && got.nr_muls() > 1 && got.nr_muls() != param_nr_muls {
 		if arg.expr is ast.PrefixExpr && (arg.expr as ast.PrefixExpr).op == .amp {
 			return false
 		}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -168,6 +168,22 @@ pub fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	return true
 }
 
+fn (c Checker) check_multiple_ptr_match(got ast.Type, expected ast.Type, param ast.Param, arg ast.CallArg) bool {
+	param_nr_muls := if param.is_mut && !expected.is_ptr() { 1 } else { expected.nr_muls() }
+	if got.is_ptr() && got.nr_muls() != param_nr_muls {
+		if arg.expr is ast.PrefixExpr && (arg.expr as ast.PrefixExpr).op == .amp {
+			return false
+		}
+		if arg.expr is ast.UnsafeExpr {
+			expr := (arg.expr as ast.UnsafeExpr).expr
+			if expr is ast.PrefixExpr && (expr as ast.PrefixExpr).op == .amp {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, language ast.Language, arg ast.CallArg) ? {
 	if got == 0 {
 		return error('unexpected 0 type')

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1048,7 +1048,8 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 				}
 			}
 
-			if !c.check_multiple_ptr_match(arg_typ, param.typ, param, call_arg) {
+			if arg_typ !in [ast.voidptr_type, ast.nil_type]
+				&& !c.check_multiple_ptr_match(arg_typ, param.typ, param, call_arg) {
 				got_typ_str, expected_typ_str := c.get_string_names_of(arg_typ, param.typ)
 				c.error('cannot use `$got_typ_str` as `$expected_typ_str` in argument ${i + 1} to `$fn_name`',
 					call_arg.pos)
@@ -1678,7 +1679,8 @@ pub fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					}
 				}
 
-				if !c.check_multiple_ptr_match(got_arg_typ, param.typ, param, arg) {
+				if got_arg_typ !in [ast.voidptr_type, ast.nil_type]
+					&& !c.check_multiple_ptr_match(got_arg_typ, param.typ, param, arg) {
 					got_typ_str, expected_typ_str := c.get_string_names_of(got_arg_typ,
 						param.typ)
 					c.error('cannot use `$got_typ_str` as `$expected_typ_str` in argument ${i + 1} to `$method_name`',

--- a/vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv:31:29: error: cannot use `&&SomethingImplemented` as `&ISomething` in argument 1 to `get_value_implemented`
+   29 |     }
+   30 |     // fn call
+   31 |     _ := get_value_implemented(&s1)
+      |                                ~~~
+   32 |     // method call
+   33 |     _ := s1.get_value_implemented(&s1)
+vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv:33:32: error: cannot use `&&SomethingImplemented` as `&ISomething` in argument 1 to `get_value_implemented`
+   31 |     _ := get_value_implemented(&s1)
+   32 |     // method call
+   33 |     _ := s1.get_value_implemented(&s1)
+      |                                   ~~~
+   34 | 
+   35 |     s2 := &SomethingNotImplemented{
+vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv:39:33: error: cannot use `&&SomethingNotImplemented` as `&SomethingNotImplemented` in argument 1 to `get_value_not_implemented`
+   37 |     }
+   38 |     // fn call
+   39 |     _ := get_value_not_implemented(&s2)
+      |                                    ~~~
+   40 | }

--- a/vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv
@@ -1,0 +1,40 @@
+interface ISomething {
+	value int
+	get_value_implemented(s &ISomething) int
+}
+
+struct SomethingImplemented {
+	value int
+}
+
+fn (s SomethingImplemented) get_value_implemented(s_ &ISomething) int {
+	return s.value
+}
+
+fn get_value_implemented(s &ISomething) int {
+	return s.value
+}
+
+struct SomethingNotImplemented {
+	value int
+}
+
+fn get_value_not_implemented(s &SomethingNotImplemented) int {
+	return s.value
+}
+
+fn main() {
+	s1 := &SomethingImplemented{
+		value: 1
+	}
+	// fn call
+	_ := get_value_implemented(&s1)
+	// method call
+	_ := s1.get_value_implemented(&s1)
+
+	s2 := &SomethingNotImplemented{
+		value: 1
+	}
+	// fn call
+	_ := get_value_not_implemented(&s2)
+}


### PR DESCRIPTION
1. Fix:
	#16261
	#16262
	#16263
2. Add tests.

```v
struct Something {
	value int
}

fn get_value(s &Something) int {
	return s.value
}

fn main() {
	s := &Something{
		value: 1
	}
 
	v := get_value(&s)
	println(v)
}
```

output:

```
a.v:58:17: error: cannot use `&&Something` as `&Something` in argument 1 to `get_value`
   56 |     }
   57 |  
   58 |     v := get_value(&s)
      |                    ~~
   59 |     println(v)
   60 | }
```

--------------

```v
interface ISomething {
	value int
	get_value() int
}

struct Something {
	value int
}

fn (s Something) get_value() int {
	return s.value
}

fn get_value(s &ISomething) int {
	return s.value
}

fn main() {
	s := &Something{
		value: 1
	}
 
	v := get_value(&s)
	println(v)
}
```

output:

```
a.v:87:17: error: cannot use `&&Something` as `&ISomething` in argument 1 to `get_value`
   85 |     }
   86 |  
   87 |     v := get_value(&s)
      |                    ~~
   88 |     println(v)
   89 | }
```
