### PR TITLE
checker: check undefined ident in closure anon fn (fix #16274)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -108,6 +108,7 @@ mut:
 	files                            []ast.File
 	expr_level                       int // to avoid infinite recursion segfaults due to compiler bugs
 	cur_orm_ts                       ast.TypeSymbol
+	cur_anon_fn                      &ast.AnonFn = unsafe { nil }
 	error_details                    []string
 	vmod_file_content                string     // needed for @VMOD_FILE, contents of the file, *NOT its path**
 	loop_label                       string     // set when inside a labelled for loop

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -62,6 +62,9 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 		return rtyp
 	}
 	if node.method_name == 'method' {
+		if c.inside_anon_fn && 'method' !in c.cur_anon_fn.inherited_vars.map(it.name) {
+			c.error('undefined ident `method` in the anonymous function', node.pos)
+		}
 		for i, arg in node.args {
 			// check each arg expression
 			node.args[i].typ = c.expr(arg.expr)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -407,6 +407,7 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 	defer {
 		c.table.cur_fn = keep_fn
 		c.inside_anon_fn = keep_inside_anon
+		c.cur_anon_fn = unsafe { nil }
 	}
 	for param in node.decl.params {
 		if param.name.len == 0 {
@@ -415,6 +416,7 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 	}
 	c.table.cur_fn = unsafe { &node.decl }
 	c.inside_anon_fn = true
+	c.cur_anon_fn = unsafe { &node }
 	mut has_generic := false
 	for mut var in node.inherited_vars {
 		parent_var := node.decl.scope.parent.find_var(var.name) or {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -404,10 +404,11 @@ fn (c Checker) check_same_type_ignoring_pointers(type_a ast.Type, type_b ast.Typ
 fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 	keep_fn := c.table.cur_fn
 	keep_inside_anon := c.inside_anon_fn
+	keep_anon_fn := c.cur_anon_fn
 	defer {
 		c.table.cur_fn = keep_fn
 		c.inside_anon_fn = keep_inside_anon
-		c.cur_anon_fn = unsafe { nil }
+		c.cur_anon_fn = keep_anon_fn
 	}
 	for param in node.decl.params {
 		if param.name.len == 0 {

--- a/vlib/v/checker/tests/closure_undefined_ident_err.out
+++ b/vlib/v/checker/tests/closure_undefined_ident_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/closure_undefined_ident_err.vv:25:7: warning: unused variable: `method`
+   23 |     c := Custom{'noname'}
+   24 |
+   25 |     $for method in MyInterface.methods {
+      |          ~~~~~~
+   26 |         z := fn [c] () {
+   27 |             c.$method()
+vlib/v/checker/tests/closure_undefined_ident_err.vv:27:6: error: undefined ident `method` in the anonymous function
+   25 |     $for method in MyInterface.methods {
+   26 |         z := fn [c] () {
+   27 |             c.$method()
+      |               ~~~~~~~~~
+   28 |         }
+   29 |         z()

--- a/vlib/v/checker/tests/closure_undefined_ident_err.vv
+++ b/vlib/v/checker/tests/closure_undefined_ident_err.vv
@@ -1,0 +1,31 @@
+module main
+
+struct Custom {
+	name string
+}
+
+interface MyInterface {
+	some_function()
+}
+
+fn (c Custom) some_function() {
+	println('hello $c.name from ${@METHOD}')
+}
+
+fn main() {
+	a := Custom{'rabbit'}
+	x := a.some_function
+	x()
+	b := Custom{'horse'}
+	y := b.some_function
+	y()
+
+	c := Custom{'noname'}
+
+	$for method in MyInterface.methods {
+		z := fn [c] () {
+			c.$method()
+		}
+		z()
+	}
+}


### PR DESCRIPTION
This PR check undefined ident in closure anon fn (fix #16274).

- Check undefined ident in closure anon fn.
- Add test.

```v
module main

struct Custom {
	name string
}

interface MyInterface {
	some_function()
}

fn (c Custom) some_function() {
	println('hello $c.name from ${@METHOD}')
}

fn main() {
	a := Custom{'rabbit'}
	x := a.some_function
	x()
	b := Custom{'horse'}
	y := b.some_function
	y()

	c := Custom{'noname'}

	$for method in MyInterface.methods {
		z := fn [c] () {
			c.$method()
		}
		z()
	}
}

PS D:\Test\v\tt1> v run .
./tt1.v:25:7: warning: unused variable: `method`
   23 |     c := Custom{'noname'}
   24 | 
   25 |     $for method in MyInterface.methods {
      |          ~~~~~~
   26 |         z := fn [c] () {
   27 |             c.$method()
./tt1.v:27:6: error: undefined ident `method` in the anonymous function
   25 |     $for method in MyInterface.methods {
   26 |         z := fn [c] () {
   27 |             c.$method()
      |               ~~~~~~~~~
   28 |         }
   29 |         z()
```