### PR TITLE
examples: use of before_request function for multi-route examples and bugfix

### DIFF
--- a/examples/vweb/vweb_example.v
+++ b/examples/vweb/vweb_example.v
@@ -18,6 +18,10 @@ mut:
 	cnt int
 }
 
+pub fn (app App) before_request() {
+	println('[Vweb] $app.Context.req.method $app.Context.req.url')
+}
+
 fn main() {
 	println('vweb example')
 	vweb.run(&App{}, port)

--- a/examples/vweb_orm_jwt/src/main.v
+++ b/examples/vweb_orm_jwt/src/main.v
@@ -20,7 +20,7 @@ fn main() {
 
 	sql db {
 		create table User
-	}
+	} or { panic('error on create table: $err') }
 
 	db.close() or { panic(err) }
 

--- a/examples/vweb_orm_jwt/src/main.v
+++ b/examples/vweb_orm_jwt/src/main.v
@@ -11,6 +11,10 @@ struct App {
 	vweb.Context
 }
 
+pub fn (app App) before_request() {
+	println('[Vweb] $app.Context.req.method $app.Context.req.url')
+}
+
 fn main() {
 	mut db := databases.create_db_connection() or { panic(err) }
 


### PR DESCRIPTION
Use of before_request in examples
```bash
$ v run .
[Vweb] Running app on http://0.0.0.0:8081/
[Vweb] POST /task/create
[Vweb] POST /task/create_all
```
bugfix: create table panic