### PR TITLE
native: don't generate duplicate strings

### DIFF
--- a/vlib/v/gen/native/elf.v
+++ b/vlib/v/gen/native/elf.v
@@ -823,20 +823,27 @@ pub fn (mut g Gen) generate_simple_elf_header() {
 }
 
 pub fn (mut g Gen) elf_string_table() {
+	mut generated := map[string]int{}
+
 	for _, s in g.strs {
+		pos := generated[s.str] or { g.buf.len }
+
 		match s.typ {
 			.abs64 {
-				// g.write64_at(native.segment_start + g.buf.len, int(g.str_pos[i]))
-				g.write64_at(s.pos, g.buf.len)
+				g.write64_at(s.pos, pos)
 			}
 			.rel32 {
-				g.write32_at(s.pos, g.buf.len - s.pos - 4)
+				g.write32_at(s.pos, pos - s.pos - 4)
 			}
 			else {
 				g.n_error('unsupported string reloc type')
 			}
 		}
-		g.write_string(s.str)
+
+		if s.str !in generated {
+			generated[s.str] = pos
+			g.write_string(s.str)
+		}
 	}
 }
 

--- a/vlib/v/gen/native/macho.v
+++ b/vlib/v/gen/native/macho.v
@@ -482,7 +482,7 @@ fn (mut g Gen) sym_string_table() int {
 	mut generated := map[string]int{}
 
 	for _, s in g.strs {
-		pos := generated[s.str] or { g.buf.len - s.pos - 4 }
+		pos := generated[s.str] or { g.buf.len }
 
 		match s.typ {
 			.rel32 {
@@ -493,7 +493,7 @@ fn (mut g Gen) sym_string_table() int {
 					// that should be .rel32, not windows-specific
 					g.write32_at(s.pos, pos)
 				} else {
-					g.write64_at(s.pos, pos + native.base_addr)
+					g.write64_at(s.pos, pos - s.pos - 4 + native.base_addr)
 				}
 			}
 		}

--- a/vlib/v/gen/native/macho.v
+++ b/vlib/v/gen/native/macho.v
@@ -486,14 +486,14 @@ fn (mut g Gen) sym_string_table() int {
 
 		match s.typ {
 			.rel32 {
-				g.write32_at(s.pos, pos)
+				g.write32_at(s.pos, pos - s.pos - 4)
 			}
 			else {
 				if g.pref.os == .windows {
 					// that should be .rel32, not windows-specific
-					g.write32_at(s.pos, pos)
+					g.write32_at(s.pos, pos - s.pos - 4)
 				} else {
-					g.write64_at(s.pos, pos - s.pos - 4 + native.base_addr)
+					g.write64_at(s.pos, pos + native.base_addr)
 				}
 			}
 		}

--- a/vlib/v/gen/native/macho.v
+++ b/vlib/v/gen/native/macho.v
@@ -478,8 +478,12 @@ fn (mut g Gen) write_symbol(s Symbol) {
 fn (mut g Gen) sym_string_table() int {
 	begin := g.buf.len
 	g.zeroes(1)
+
+	mut generated := map[string]int{}
+
 	for _, s in g.strs {
-		pos := g.buf.len - s.pos - 4
+		pos := generated[s.str] or { g.buf.len - s.pos - 4 }
+
 		match s.typ {
 			.rel32 {
 				g.write32_at(s.pos, pos)
@@ -493,7 +497,11 @@ fn (mut g Gen) sym_string_table() int {
 				}
 			}
 		}
-		g.write_string(s.str)
+
+		if s.str !in generated {
+			generated[s.str] = pos
+			g.write_string(s.str)
+		}
 	}
 	return g.buf.len - begin
 }

--- a/vlib/v/gen/native/macho.v
+++ b/vlib/v/gen/native/macho.v
@@ -493,7 +493,7 @@ fn (mut g Gen) sym_string_table() int {
 					// that should be .rel32, not windows-specific
 					g.write32_at(s.pos, pos)
 				} else {
-					g.write64_at(s.pos, g.buf.len + native.base_addr)
+					g.write64_at(s.pos, pos + native.base_addr)
 				}
 			}
 		}


### PR DESCRIPTION
With this PR, string literals will only generate once, even if used multiple times in the native backend. This should be no problem since strings are immutable and enables optimizations when comparing strings in the future.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
