### PR TITLE
parser: fix raw string as map keys (fix #16285)

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -208,8 +208,13 @@ fn (mut p Parser) map_init() ast.MapInit {
 	mut comments := [][]ast.Comment{}
 	pre_cmnts := p.eat_comments()
 	for p.tok.kind !in [.rcbr, .eof] {
-		key := p.expr(0)
-		keys << key
+		if p.tok.kind == .name && p.tok.lit in ['r', 'c', 'js'] {
+			key := p.string_expr()
+			keys << key
+		} else {
+			key := p.expr(0)
+			keys << key
+		}
 		p.check(.colon)
 		val := p.expr(0)
 		vals << val

--- a/vlib/v/tests/map_test.v
+++ b/vlib/v/tests/map_test.v
@@ -1,0 +1,10 @@
+// For issue 16285 Raw string in map literal key triggers compiler error
+fn test_raw_string_as_key() {
+	mut m := {
+		r'key': 1
+	}
+	assert m[r'key'] == 1
+
+	m[r'key'] = 2
+	assert m[r'key'] == 2
+}


### PR DESCRIPTION
1. Fix #16285 
2. Add tests.

```v
fn main() {
	mut m := {
		r'key': 1
	}
	assert m[r'key'] == 1

	m[r'key'] = 2
	assert m[r'key'] == 2
}
```

output:

passed.