### PR TITLE
cgen: fix call method with an empty args on an interface with variadic (fix #16286)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -847,7 +847,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.expr(node.left)
 		}
 		g.write('${dot}_object')
-		if node.args.len > 0 {
+		is_variadic := node.expected_arg_types.len > 0
+			&& node.expected_arg_types[node.expected_arg_types.len - 1].has_flag(.variadic)
+		if node.args.len > 0 || is_variadic {
 			g.write(', ')
 			g.call_args(node)
 		}

--- a/vlib/v/tests/interface_variadic_test.v
+++ b/vlib/v/tests/interface_variadic_test.v
@@ -40,3 +40,29 @@ fn check_animals(animals ...Animal) {
 	assert animals[0] is Cat
 	assert animals[1] is Dog
 }
+
+// For issue: 16286 passing nothing to a variatic parameter on an interface method gives builder error
+interface Bar {
+	get(...int) []int
+}
+
+struct Baz {}
+
+fn (b Baz) get(n ...int) []int {
+	if n.len == 0 {
+		return [-1]
+	} else {
+		return n
+	}
+}
+
+fn test_empty_args_call_interface_methods() {
+	b := Baz{}
+	assert b.get() == [-1]
+
+	b_values := Bar(Baz{})
+	assert b_values.get(1, 2, 3) == [1, 2, 3]
+
+	b_empty := Bar(Baz{})
+	assert b_empty.get() == [-1]
+}


### PR DESCRIPTION
1. Fix #16286 
2. Add tests.

```v
interface Bar {
	get(...int) []int
}

struct Foo {}

fn (f Foo) get(n ...int) []int {
	if n.len == 0 {
		return [-1]
	} else {
		return n
    }
}

fn main() {
	f := Foo{}
	println(f.get())

	b_values := Bar(Foo{})
	println(b_values.get(1, 2, 3))

	b_empty := Bar(Foo{})
	println(b_empty.get())
}
```

output:

```
[-1]
[1, 2, 3]
[-1]
```