### PR TITLE
scanner: fix new string interpolation - print('{a}{{b}}') (fix #16294)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -811,7 +811,7 @@ fn (mut s Scanner) text_scan() token.Token {
 					next_char := s.text[s.pos + 1]
 					// Handle new `hello {name}` string interpolation
 					if !s.is_inside_interpolation && !next_char.is_space() && next_char != `}`
-						&& prev_char !in [`$`, `{`] {
+						&& prev_char != `$` {
 						s.is_inside_interpolation = true
 						return s.new_token(.str_dollar, '', 1)
 					}

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -6,4 +6,13 @@ fn test_string_new_interpolation() {
 
 	println('{a} {b} {c} {d}')
 	assert '{a} {b} {c} {d}' == '1 2 3 4'
+
+	println('{a}{{b}}')
+	assert '{a}{{b}}' == '1{2}'
+
+	println('{a}\{{b}}')
+	assert '{a}\{{b}}' == '1{2}'
+
+	println('{a}{{{{{b}}}}}')
+	assert '{a}{{{{{b}}}}}' == '1{{{{2}}}}'
 }


### PR DESCRIPTION
This PR fix new string interpolation - print('{a}{{b}}') (fix #16294).

- Fix new string interpolation - print('{a}{{b}}').
- Add test.

```v
fn main() {
	a, b := 1, 2
	println('{a}{{b}}')
	println('{a}\{{b}}')
	println('{a}{{{b}}}')
}

PS D:\Test\v\tt1> v run .
1{2}
1{2}
1{{2}}
```