### PR TITLE
cgen: fix a bug that compile-time-for does not find methods typ

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -512,20 +512,23 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				}
 				g.writeln('}));\n')
 			}
-			mut sig := 'anon_fn_'
+			mut sig := 'fn ('
 			// skip the first (receiver) arg
 			for j, arg in method.params[1..] {
 				// TODO: ignore mut/pts in sig for now
 				typ := arg.typ.set_nr_muls(0)
-				sig += '$typ'
+				sig += g.table.sym(typ).name
 				if j < method.params.len - 2 {
-					sig += '_'
+					sig += ', '
 				}
 			}
-			sig += '_$method.return_type'
+			sig += ')'
+			ret_type := g.table.sym(method.return_type).name
+			if ret_type != 'void' {
+				sig += ' $ret_type'
+			}
 			styp := g.table.find_type_idx(sig)
-			// println(styp)
-			// if styp == 0 { }
+
 			// TODO: type aliases
 			ret_typ := method.return_type.idx()
 			g.writeln('\t${node.val_var}.typ = $styp;')

--- a/vlib/v/tests/comptime_for_test.v
+++ b/vlib/v/tests/comptime_for_test.v
@@ -48,18 +48,29 @@ fn test_comptime_for() {
 
 fn test_comptime_for_with_if() {
 	println(@FN)
+	mut methods_found := map[string]int{}
 	$for method in App.methods {
 		println('  method: ' + no_lines('$method'))
 		$if method.typ is fn () {
+			methods_found['fn()'] += 1
 			assert method.name in ['run', 'method2']
+		}
+		$if method.typ is fn () int {
+			methods_found['fn() int'] += 1
 		}
 		$if method.return_type is int {
 			assert method.name in ['int_method1', 'int_method2']
+		}
+		$if method.typ is fn (string) {
+			methods_found['fn(string)'] += 1
 		}
 		$if method.args[0].typ is string {
 			assert method.name == 'string_arg'
 		}
 	}
+	assert methods_found['fn()'] == 2
+	assert methods_found['fn() int'] == 2
+	assert methods_found['fn(string)'] == 1
 }
 
 fn test_comptime_for_fields() {


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
The compile-time-for can iterate methods in a struct and it is supposed to provide a method's details such as `name`, `typ`, and `return_type`. However, the `typ` has not worked properly as reported in #16277. This PR fixes compile-time-for, so it finds methods' `typ` correctly.

Once this patch is applied, `vlib/v/gen/c/compiletime/methods.v` will result in:

```console
method_one is NOT `fn(string) string`
method_one does NOT return `int`
method_one's first arg is NOT `string`
method_one IS a void method

method_two is NOT `fn(string) string`
method_two DOES return `int`
method_two's first arg is NOT `string`
method_two is NOT a void method

method_three IS `fn(string) string`
method_three does NOT return `int`
method_three's first arg IS `string`
method_three is NOT a void method
```

Resolves #16277 