### PR TITLE
checker: give an error message when using void type in multi-return (fix #16311)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3112,6 +3112,12 @@ pub fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 		node.return_type = typ
 		return typ
 	} else {
+		for i := 0; i < mr_types.len; i++ {
+			if mr_types[i] == ast.void_type {
+				c.error('type `void` cannot be used in multi-return', node.vals[i].pos())
+				return ast.void_type
+			}
+		}
 		typ := c.table.find_or_register_multi_return(mr_types)
 		ast.new_type(typ)
 		node.return_type = typ

--- a/vlib/v/checker/tests/multi_return_use_void_type_err.out
+++ b/vlib/v/checker/tests/multi_return_use_void_type_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/multi_return_use_void_type_err.vv:2:2: error: type `void` cannot be used in multi-return
+    1 | fn main() {
+    2 |     print('a'), print('b')
+      |     ~~~~~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/multi_return_use_void_type_err.vv
+++ b/vlib/v/checker/tests/multi_return_use_void_type_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	print('a'), print('b')
+}


### PR DESCRIPTION
1. Fix #16311 
2. Add tests.

Explain:
This is a temporary fix to prevent the C code from crashing, because several problems are involved and need to be solved step by step. I have recorded it, and then gradually deal with it. Note: This is a temporary fix to prevent the C code from crashing, because several problems are involved and need to be solved step by step. I have recorded it, and then gradually deal with it.

```v
fn main() {
	print('a'), print('b')
}
```

output:

```
a.v:2:2: error: type `void` cannot be used in multi-return
    1 | fn main() {
    2 |     print('a'), print('b')
      |     ~~~~~~~~~~
    3 | }
    4 |
```

