### PR TITLE
js: fix the js backend that cannot support `match true {}`.

### DIFF
--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -2431,7 +2431,7 @@ fn (mut g JsGen) match_expr(node ast.MatchExpr) {
 	}
 
 	if node.cond in [ast.Ident, ast.SelectorExpr, ast.IntegerLiteral, ast.StringLiteral, ast.FloatLiteral,
-		ast.CallExpr, ast.EnumVal] {
+		ast.BoolLiteral, ast.CallExpr, ast.EnumVal] {
 		cond_var = CondExpr{node.cond}
 	} else {
 		s := g.new_tmp_var()

--- a/vlib/v/gen/js/tests/testdata/match.out
+++ b/vlib/v/gen/js/tests/testdata/match.out
@@ -2,3 +2,4 @@ Vec2d(42,43)
 Vec2d(46,74,21)
 life
 V is running on JS
+c:

--- a/vlib/v/gen/js/tests/testdata/match.v
+++ b/vlib/v/gen/js/tests/testdata/match.v
@@ -52,9 +52,21 @@ fn match_classic_string() {
 	}
 }
 
+fn match_bool_cond() {
+	volume := 'c:'
+	rooted := false
+	path_separator := '/'
+	println( match true {
+		volume.len != 0 { volume }
+		!rooted { '.' }
+		else { path_separator }
+	} )
+}
+
 fn main() {
 	match_vec(Vec2d{42, 43})
 	match_vec(Vec3d{46, 74, 21})
 	match_classic_num()
 	match_classic_string()
+	match_bool_cond()
 }

--- a/vlib/v/gen/js/tests/testdata/match.v
+++ b/vlib/v/gen/js/tests/testdata/match.v
@@ -56,11 +56,11 @@ fn match_bool_cond() {
 	volume := 'c:'
 	rooted := false
 	path_separator := '/'
-	println( match true {
+	println(match true {
 		volume.len != 0 { volume }
 		!rooted { '.' }
 		else { path_separator }
-	} )
+	})
 }
 
 fn main() {


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
## Summary

This PR enables the JS backend to support `match true {}` expression.

## Testplan

1. Run the following command.
    ```
    v -b js run vlib/v/gen/js/tests/testdata/match.v
    ```
2. Make sure the output is the same with the content of the `match.out` file.

Resovles #14473