### PR TITLE
scanner: fix the new string interpolation - println('{s == 'hello'}') (fix #16318)

### DIFF
--- a/vlib/net/html/parser_test.v
+++ b/vlib/net/html/parser_test.v
@@ -34,7 +34,7 @@ fn test_giant_string() {
 
 fn test_script_tag() {
 	mut parser := Parser{}
-	script_content := "\nvar googletag = googletag || {};\ngoogletag.cmd = googletag.cmd || [];if(3 > 5) {console.log('Birl');}\n"
+	script_content := "\nvar googletag = googletag || {};\ngoogletag.cmd = googletag.cmd || [];if(3 > 5) { console.log('Birl');}\n"
 	temp_html := '<html><body><script>$script_content</script></body></html>'
 	parser.parse_html(temp_html)
 	assert parser.tags[2].content.len == script_content.replace('\n', '').len

--- a/vlib/v/eval/gen/infix_gen.v
+++ b/vlib/v/eval/gen/infix_gen.v
@@ -100,7 +100,7 @@ fn main() {
 			if op in ['<<', '>>'] && lt == 'f64' {
 				continue
 			}
-			b.write_string('$lt{match right{')
+			b.write_string('$lt{ match right{')
 			for ct2 in compound_types {
 				if op in ['<<', '>>'] && ct2 == 'Float' {
 					continue

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -15,4 +15,16 @@ fn test_string_new_interpolation() {
 
 	println('{a}{{{{{b}}}}}')
 	assert '{a}{{{{{b}}}}}' == '1{{{{2}}}}'
+
+	s := 'hello'
+	println('{s == 'hello'}')
+	assert '{s == 'hello'}' == 'true'
+	println('{s != 'hello'}')
+	assert '{s != 'hello'}' == 'false'
+
+	n := 22
+	println('{n >= 10}')
+	assert '{n >= 10}' == 'true'
+	println('{n <= 10}')
+	assert '{n <= 10}' == 'false'
 }


### PR DESCRIPTION
This PR fix the new string interpolation - println('{s == 'hello'}') (fix #16318).

- Fix the new string interpolation - println('{s == 'hello'}').
- Add test.

```v
fn main() {
	s := 'hello'
	println('{s == 'hello'}')
	println('{s != 'hello'}')

	n := 22
	println('{n >= 10}')
	println('{n <= 10}')
}

PS D:\Test\v\tt1> v run .
true
false
true
false
```