### PR TITLE
Regex: bug fix for last group with OR inside

### DIFF
--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -1931,6 +1931,12 @@ pub fn (mut re RE) match_base(in_txt &u8, in_txt_len int) (int, int) {
 			}
 
 			// println("No good exit!!")
+			if re.prog[re.prog_len - 1].ist == regex.ist_group_end {
+				// println("last ist is a group end!")
+				if re.prog[re.prog_len - 1].group_rep >= re.prog[re.prog_len - 1].rep_min {
+					return state.first_match, state.i
+				}
+			}
 			return regex.no_match_found, state.i
 		}
 

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -376,6 +376,12 @@ find_all_test_suite = [
 		r"([^\n]*)",
 		[0, 2],
 		['ab']
+	},
+	Test_find_all{
+		"ab",
+		r"([^\n]|a)*",
+		[0, 2],
+		['ab']
 	}
 
 ]


### PR DESCRIPTION
**What's inside**
- fix for problem with last group
- added test

Example code:
```v
any_but_newline_group := "([^\n]|a)*"
mut re_group := regex.regex_opt(any_but_newline_group) or { panic(err) }
txt := "a"
start_group, end_group := re_group.find(txt)
println("group  | start: {start_group}, end: {end_group}")
```
must return [0,1]