### PR TITLE
scanner: fix new string interpolation: print('{n:10}') (fix #16321)

### DIFF
--- a/examples/vweb/vweb_assets/index.html
+++ b/examples/vweb/vweb_assets/index.html
@@ -1,7 +1,7 @@
 <html>
 <header>
 	<title>@title</title>
-	<style>html{display:none}</style>
+	<style>html{display: none}</style>
 	@css 'index.css'
 </header>
 <body>
@@ -10,4 +10,3 @@
 	<p>@message</p>
 </body>
 </html>
-

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -264,7 +264,7 @@ fn test_rand_ascii() {
 		'fsx!@uRc?re/fSPXj`Y&\\BU}p',
 		'fI_qM"):2;CUno!<dX:Yv*FX$',
 		'FnA(Fr|D`WZVWEzp<k)O;auub',
-		"QRkxH!kjXh&/j{)uSe&\{D'v?|",
+		"QRkxH!kjXh&/j{)uSe&{D'v?|",
 		"_CyaU\$z':#}At*v2|xDu6w=;1",
 	]
 	for output in outputs {

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -264,7 +264,7 @@ fn test_rand_ascii() {
 		'fsx!@uRc?re/fSPXj`Y&\\BU}p',
 		'fI_qM"):2;CUno!<dX:Yv*FX$',
 		'FnA(Fr|D`WZVWEzp<k)O;auub',
-		"QRkxH!kjXh&/j{)uSe&{D'v?|",
+		"QRkxH!kjXh&/j{)uSe&\{D'v?|",
 		"_CyaU\$z':#}At*v2|xDu6w=;1",
 	]
 	for output in outputs {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1255,7 +1255,7 @@ fn (mut s Scanner) ident_string() string {
 					// `!=` `>=` `<=` `==`
 					break
 				}
-				if s.text[i] in [`=`, `:`] {
+				if s.text[i] == `=` || (s.text[i] == `:` && s.text[i + 1].is_space()) {
 					// We reached the end of the line or string without reaching "}".
 					// Also if there's "=", there's no way it's a valid interpolation expression:
 					// e.g. `println("{a.b = 42}")` `println('{foo:bar}')`
@@ -1284,7 +1284,7 @@ fn (mut s Scanner) ident_string() string {
 					// `!=` `>=` `<=` `==`
 					break
 				}
-				if s.text[i] in [`=`, `:`] {
+				if s.text[i] == `=` || (s.text[i] == `:` && s.text[i + 1].is_space()) {
 					// We reached the end of the line or string without reaching "}".
 					// Also if there's "=", there's no way it's a valid interpolation expression:
 					// e.g. `println("{a.b = 42}")` `println('{foo:bar}')`

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1327,7 +1327,7 @@ fn (s Scanner) is_valid_interpolation(start_pos int) bool {
 	mut is_valid_inter := true
 	mut has_rcbr := false
 	mut is_assign := true
-	for i := start_pos; i < s.text.len; i++ {
+	for i := start_pos; i < s.text.len - 1; i++ {
 		if s.text[i] == s.quote {
 			break
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1247,23 +1247,7 @@ fn (mut s Scanner) ident_string() string {
 			&& s.count_symbol_before(s.pos - 1, scanner.backslash) % 2 == 0 {
 			// Detect certain strings with "{" that are not interpolation:
 			// e.g. "{init: " (no "}" at the end)
-			mut is_valid_inter := true
-			for i := s.pos + 1; i < s.text.len; i++ {
-				if s.text[i] == `}` || (s.text[i] == `=` && (s.text[i - 1] in [`!`, `>`, `<`]
-					|| s.text[i + 1] == `=`)) {
-					// No } in this string, so it's not a valid `{x}` interpolation
-					// `!=` `>=` `<=` `==`
-					break
-				}
-				if s.text[i] == `=` || (s.text[i] == `:` && s.text[i + 1].is_space()) {
-					// We reached the end of the line or string without reaching "}".
-					// Also if there's "=", there's no way it's a valid interpolation expression:
-					// e.g. `println("{a.b = 42}")` `println('{foo:bar}')`
-					is_valid_inter = false
-					break
-				}
-			}
-			if is_valid_inter {
+			if s.is_valid_interpolation(s.pos + 1) {
 				s.is_inside_string = true
 				s.is_enclosed_inter = true
 				// so that s.pos points to $ at the next step
@@ -1276,23 +1260,7 @@ fn (mut s Scanner) ident_string() string {
 			&& s.count_symbol_before(s.pos - 2, scanner.backslash) % 2 == 0 {
 			// Detect certain strings with "{" that are not interpolation:
 			// e.g. "{init: " (no "}" at the end)
-			mut is_valid_inter := true
-			for i := s.pos; i < s.text.len; i++ {
-				if s.text[i] == `}` || (s.text[i] == `=` && (s.text[i - 1] in [`!`, `>`, `<`]
-					|| s.text[i + 1] == `=`)) {
-					// No } in this string, so it's not a valid `{x}` interpolation
-					// `!=` `>=` `<=` `==`
-					break
-				}
-				if s.text[i] == `=` || (s.text[i] == `:` && s.text[i + 1].is_space()) {
-					// We reached the end of the line or string without reaching "}".
-					// Also if there's "=", there's no way it's a valid interpolation expression:
-					// e.g. `println("{a.b = 42}")` `println('{foo:bar}')`
-					is_valid_inter = false
-					break
-				}
-			}
-			if is_valid_inter {
+			if s.is_valid_interpolation(s.pos) {
 				s.is_inside_string = true
 				s.is_enclosed_inter = true
 				// so that s.pos points to $ at the next step
@@ -1353,6 +1321,33 @@ fn (mut s Scanner) ident_string() string {
 		}
 	}
 	return lit
+}
+
+fn (s Scanner) is_valid_interpolation(start_pos int) bool {
+	mut is_valid_inter := true
+	mut has_rcbr := false
+	mut is_assign := true
+	for i := start_pos; i < s.text.len; i++ {
+		if s.text[i] == s.quote {
+			break
+		}
+		if s.text[i] == `}` {
+			// No } in this string, so it's not a valid `{x}` interpolation
+			has_rcbr = true
+		}
+		if s.text[i] == `=` && (s.text[i - 1] in [`!`, `>`, `<`] || s.text[i + 1] == `=`) {
+			// `!=` `>=` `<=` `==`
+			is_assign = false
+		}
+		if (s.text[i] == `=` && is_assign) || (s.text[i] == `:` && s.text[i + 1].is_space()) {
+			// We reached the end of the line or string without reaching "}".
+			// Also if there's "=", there's no way it's a valid interpolation expression:
+			// e.g. `println("{a.b = 42}")` `println('{foo:bar}')`
+			is_valid_inter = false
+			break
+		}
+	}
+	return is_valid_inter && has_rcbr
 }
 
 fn decode_h_escape_single(str string, idx int) (int, string) {

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -27,4 +27,11 @@ fn test_string_new_interpolation() {
 	assert '{n >= 10}' == 'true'
 	println('{n <= 10}')
 	assert '{n <= 10}' == 'false'
+
+	println('{n:10}')
+	assert '{n:10}' == '        22'
+
+	f := 2.234
+	print('{f:05.2f}')
+	assert '{f:05.2f}' == '02.23'
 }

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -34,6 +34,9 @@ fn test_string_new_interpolation() {
 	assert '{n:10}' == '        22'
 
 	f := 2.234
-	print('{f:05.2f}')
+	println('{f:05.2f}')
 	assert '{f:05.2f}' == '02.23'
+
+	println('{@FILE}')
+	assert '{@FILE}'.contains('string_new_interpolation_test.v')
 }

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -17,10 +17,10 @@ fn test_string_new_interpolation() {
 	assert '{a}{{{{{b}}}}}' == '1{{{{2}}}}'
 
 	s := 'hello'
-	println('{s == 'hello'}')
-	assert '{s == 'hello'}' == 'true'
-	println('{s != 'hello'}')
-	assert '{s != 'hello'}' == 'false'
+	println('{s == "hello"}')
+	assert '{s == "hello"}' == 'true'
+	println('{s != "hello"}')
+	assert '{s != "hello"}' == 'false'
 
 	n := 22
 	println('{n >= 10}')

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -16,11 +16,13 @@ fn test_string_new_interpolation() {
 	println('{a}{{{{{b}}}}}')
 	assert '{a}{{{{{b}}}}}' == '1{{{{2}}}}'
 
+	// vfmt off
 	s := 'hello'
 	println('{s == "hello"}')
 	assert '{s == "hello"}' == 'true'
 	println('{s != "hello"}')
 	assert '{s != "hello"}' == 'false'
+	// vfmt on
 
 	n := 22
 	println('{n >= 10}')


### PR DESCRIPTION
This PR fix new string interpolation: print('{n:10}') (fix #16321).

- Fix new string interpolation: print('{n:10}').
- Add test.

```v
fn main() {
	n := 22
	println('{n:10}')

	f := 2.345
	println('{f:05.2}')

	println('{@FILE}')
}

PS D:\Test\v\tt1> v run .
        22
02.35
D:\Test\v\tt1\tt1.v
```