### PR TITLE
Fix broken link in tutorial

### DIFF
--- a/tutorials/building_a_simple_web_blog_with_vweb/README.md
+++ b/tutorials/building_a_simple_web_blog_with_vweb/README.md
@@ -18,7 +18,7 @@ The benefits of using V for web:
 
 _Please note that V and Vweb are at a very early stage and are changing rapidly._
 
-The code is available <a href='https://github.com/vlang/v/tree/master/tutorials/code/blog'>here</a>.
+The code is available [here](./code/blog).
 
 ### Installing V
 


### PR DESCRIPTION
Old address:
https://github.com/vlang/v/tree/master/tutorials/code/blog

New address:
https://github.com/vlang/v/tree/master/tutorials/building_a_simple_web_blog_with_vweb/code/blog

Also the link now uses a relative path so it will still work if the folder gets moved/renamed.
