### PR TITLE
fmt: fix inter quote of nested string in string interpolation

### DIFF
--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -228,7 +228,7 @@ fn (upd VlsUpdater) download_prebuilt() ! {
 fn (upd VlsUpdater) print_new_vls_version(new_vls_exec_path string) {
 	exec_version := os.execute('$new_vls_exec_path --version')
 	if exec_version.exit_code == 0 {
-		upd.log('VLS was updated to version: ${exec_version.output.all_after('vls version ').trim_space()}')
+		upd.log('VLS was updated to version: ${exec_version.output.all_after("vls version ").trim_space()}')
 	}
 }
 
@@ -269,7 +269,7 @@ fn (upd VlsUpdater) compile_from_source() ! {
 		return error('Cannot compile VLS from source: no appropriate C compiler found.')
 	}
 
-	compile_result := os.execute('v run ${os.join_path(vls_src_folder, 'build.vsh')} ${possible_compilers[selected_compiler_idx]}')
+	compile_result := os.execute('v run ${os.join_path(vls_src_folder, "build.vsh")} ${possible_compilers[selected_compiler_idx]}')
 	if compile_result.exit_code != 0 {
 		return error('Cannot compile VLS from source: $compile_result.output')
 	}
@@ -457,7 +457,7 @@ fn (upd VlsUpdater) run(fp flag.FlagParser) ! {
 			}
 		}
 	} else if upd.pass_to_ls {
-		exit(os.system('$upd.ls_path ${upd.args.join(' ')}'))
+		exit(os.system('$upd.ls_path ${upd.args.join(" ")}'))
 	} else if upd.is_help {
 		println(fp.usage())
 		exit(0)

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -795,7 +795,7 @@ Homepage: $mod.repo_url
 Author: $mod.author
 License: $mod.license
 Location: $path
-Requires: ${mod.dependencies.join(', ')}
+Requires: ${mod.dependencies.join(", ")}
 --------
 ')
 	}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -224,7 +224,7 @@ fn (mut r Repl) pin() {
 // print source code
 fn (mut r Repl) list_source() {
 	source_code := r.current_source_code(true, true)
-	println('\n${source_code.replace('\n\n', '\n')}')
+	println('\n${source_code.replace("\n\n", "\n")}')
 }
 
 fn highlight_console_command(command string) string {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -21,7 +21,7 @@ fn main() {
 	jargs := args.join(' ')
 	obinary := cmdline.option(args, '-o', '')
 	sargs := if obinary != '' { jargs } else { '$jargs -o v2' }
-	cmd := '${os.quoted_path(vexe)} $sargs ${os.quoted_path('cmd/v')}'
+	cmd := '${os.quoted_path(vexe)} $sargs ${os.quoted_path("cmd/v")}'
 	options := if args.len > 0 { '($sargs)' } else { '' }
 	println('V self compiling ${options}...')
 	compile(vroot, cmd)

--- a/cmd/tools/vwatch.v
+++ b/cmd/tools/vwatch.v
@@ -232,7 +232,7 @@ fn (mut context Context) run_after_cmd() {
 }
 
 fn (mut context Context) compilation_runner_loop() {
-	cmd := '"$context.vexe" ${context.opts.join(' ')}'
+	cmd := '"$context.vexe" ${context.opts.join(" ")}'
 	_ := <-context.rerun_channel
 	for {
 		context.elog('>> loop: v_cycles: $context.v_cycles')

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -150,7 +150,7 @@ fn main() {
 	all_commands << other_commands
 	all_commands.sort()
 	eprintln(util.new_suggestion(command, all_commands).say('v: unknown command `$command`'))
-	eprintln('Run ${term.highlight_command('v help')} for usage.')
+	eprintln('Run ${term.highlight_command("v help")} for usage.')
 	exit(1)
 }
 
@@ -160,8 +160,8 @@ fn invoke_help_and_exit(remaining []string) {
 		2 { help.print_and_exit(remaining[1]) }
 		else {}
 	}
-	eprintln('${term.highlight_command('v help')}: provide only one help topic.')
-	eprintln('For usage information, use ${term.highlight_command('v help')}.')
+	eprintln('${term.highlight_command("v help")}: provide only one help topic.')
+	eprintln('For usage information, use ${term.highlight_command("v help")}.')
 	exit(1)
 }
 

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -209,7 +209,7 @@ pub fn (b &Benchmark) total_message(msg string) string {
 			njobs_label = ', on ${term.colorize(term.bold, b.njobs.str())} parallel jobs'
 		}
 	}
-	tmsg += '$b.ntotal total. ${term.colorize(term.bold, 'Runtime:')} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.\n'
+	tmsg += '$b.ntotal total. ${term.colorize(term.bold, "Runtime:")} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.\n'
 	return tmsg
 }
 

--- a/vlib/cli/man.v
+++ b/vlib/cli/man.v
@@ -50,9 +50,9 @@ pub fn print_manpage_for_command(man_cmd Command) ! {
 // manpage returns a `string` containing the mdoc(7) manpage for
 // this `Command`
 pub fn (cmd Command) manpage() string {
-	mut mdoc := '.Dd ${time.now().strftime('%B %d, %Y')}\n'
-	mdoc += '.Dt ${cmd.full_name().replace(' ', '-').to_upper()} 1\n'
-	mdoc += '.Os\n.Sh NAME\n.Nm ${cmd.full_name().replace(' ', '-')}\n.Nd $cmd.description\n'
+	mut mdoc := '.Dd ${time.now().strftime("%B %d, %Y")}\n'
+	mdoc += '.Dt ${cmd.full_name().replace(" ", "-").to_upper()} 1\n'
+	mdoc += '.Os\n.Sh NAME\n.Nm ${cmd.full_name().replace(" ", "-")}\n.Nd $cmd.description\n'
 	mdoc += '.Sh SYNOPSIS\n'
 	mdoc += '.Nm $cmd.root().name\n'
 	if unsafe { cmd.parent != 0 } {

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -686,7 +686,7 @@ fn parse_headers(s string) !Header {
 		}
 		// handle header fold
 		if line[0] == ` ` || line[0] == `\t` {
-			last_value += ' ${line.trim(' \t')}'
+			last_value += ' ${line.trim(" \t")}'
 			continue
 		} else if last_key != '' {
 			h.add_custom(last_key, last_value)!

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -233,9 +233,9 @@ fn (mut c Client) send_body(cfg Mail) ! {
 	nonascii_subject := cfg.subject.bytes().any(it < u8(` `) || it > u8(`~`))
 	mut sb := strings.new_builder(200)
 	sb.write_string('From: $cfg.from\r\n')
-	sb.write_string('To: <${cfg.to.split(';').join('>; <')}>\r\n')
-	sb.write_string('Cc: <${cfg.cc.split(';').join('>; <')}>\r\n')
-	sb.write_string('Bcc: <${cfg.bcc.split(';').join('>; <')}>\r\n')
+	sb.write_string('To: <${cfg.to.split(";").join(">; <")}>\r\n')
+	sb.write_string('Cc: <${cfg.cc.split(";").join(">; <")}>\r\n')
+	sb.write_string('Bcc: <${cfg.bcc.split(";").join(">; <")}>\r\n')
 	sb.write_string('Date: $date\r\n')
 	if nonascii_subject {
 		// handle UTF-8 subjects according RFC 1342

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -496,7 +496,7 @@ pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, 
 			for f in v {
 				tmp << '$q$f$q'
 			}
-			fs << '/* $k */UNIQUE(${tmp.join(', ')})'
+			fs << '/* $k */UNIQUE(${tmp.join(", ")})'
 		}
 	}
 	fs << 'PRIMARY KEY($q$primary$q)'

--- a/vlib/term/ui/1_term_and_ui_compilation_test.v
+++ b/vlib/term/ui/1_term_and_ui_compilation_test.v
@@ -2,6 +2,6 @@ import term.ui
 import term
 
 fn test_term_and_term_ui_can_compile_together() {
-	println('${term.bold('hello')} world ${ui.color_table[0]}')
+	println('${term.bold("hello")} world ${ui.color_table[0]}')
 	assert true
 }

--- a/vlib/term/ui/2_term_and_ui_compilation_test.v
+++ b/vlib/term/ui/2_term_and_ui_compilation_test.v
@@ -2,6 +2,6 @@ import term
 import term.ui
 
 fn test_term_and_term_ui_can_compile_together() {
-	println('${term.bold('hello')} world ${ui.color_table[0]}')
+	println('${term.bold("hello")} world ${ui.color_table[0]}')
 	assert true
 }

--- a/vlib/time/relative_test.v
+++ b/vlib/time/relative_test.v
@@ -23,7 +23,7 @@ fn test_relative() {
 	assert date.relative() == '5 days ago'
 	assert date.relative_short() == '5d ago'
 	date = time.now().add_seconds(-75 * time.seconds_per_day)
-	assert date.relative() == 'last ${date.custom_format('MMM')} ${date.custom_format('D')}'
+	assert date.relative() == 'last ${date.custom_format("MMM")} ${date.custom_format("D")}'
 	assert date.relative_short() == '75d ago'
 	date = time.now().add_seconds(-400 * time.seconds_per_day)
 	assert date.relative() == '1 year ago'
@@ -50,7 +50,7 @@ fn test_relative() {
 	assert date.relative() == 'in 5 days'
 	assert date.relative_short() == 'in 5d'
 	date = time.now().add_seconds(75 * time.seconds_per_day)
-	assert date.relative() == 'on ${date.custom_format('MMM')} ${date.custom_format('D')}'
+	assert date.relative() == 'on ${date.custom_format("MMM")} ${date.custom_format("D")}'
 	assert date.relative_short() == 'in 75d'
 	date = time.now().add_seconds(400 * time.seconds_per_day)
 	assert date.relative() == 'in 1 year'

--- a/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
+++ b/vlib/toml/tests/alexcrichton.toml-rs-tests_test.v
@@ -195,7 +195,7 @@ fn test_alexcrichton_toml_rs() {
 			}
 			if toml_doc := toml.parse_file(invalid_test_file) {
 				content_that_should_have_failed := os.read_file(invalid_test_file)!
-				println('     This TOML should have failed:\n${'-'.repeat(40)}\n$content_that_should_have_failed\n${'-'.repeat(40)}')
+				println('     This TOML should have failed:\n${"-".repeat(40)}\n$content_that_should_have_failed\n${"-".repeat(40)}')
 				assert false
 			} else {
 				if !hide_oks {

--- a/vlib/toml/tests/burntsushi.toml-test_test.v
+++ b/vlib/toml/tests/burntsushi.toml-test_test.v
@@ -178,7 +178,7 @@ fn test_burnt_sushi_tomltest() {
 		}
 		if toml_doc := toml.parse_file(invalid_test_file) {
 			content_that_should_have_failed := os.read_file(invalid_test_file)!
-			println('     This TOML should have failed:\n${'-'.repeat(40)}\n$content_that_should_have_failed\n${'-'.repeat(40)}')
+			println('     This TOML should have failed:\n${"-".repeat(40)}\n$content_that_should_have_failed\n${"-".repeat(40)}')
 			assert false
 		} else {
 			if !hide_oks {

--- a/vlib/toml/tests/iarna.toml-spec-tests_test.v
+++ b/vlib/toml/tests/iarna.toml-spec-tests_test.v
@@ -213,7 +213,7 @@ fn test_iarna_toml_spec_tests() {
 				cmd := [jq, '-S', '-f "$jq_normalize_path"', iarna_toml_json_path]
 				iarna_normalized_json := run(cmd) or {
 					contents := os.read_file(v_toml_json_path)?
-					panic(err.msg() + '\n$contents\n\ncmd: ${cmd.join(' ')}')
+					panic(err.msg() + '\n$contents\n\ncmd: ${cmd.join(" ")}')
 				}
 
 				assert iarna_normalized_json == v_normalized_json
@@ -246,7 +246,7 @@ fn test_iarna_toml_spec_tests() {
 			}
 			if toml_doc := toml.parse_file(invalid_test_file) {
 				content_that_should_have_failed := os.read_file(invalid_test_file)?
-				println('     This TOML should have failed:\n${'-'.repeat(40)}\n$content_that_should_have_failed\n${'-'.repeat(40)}')
+				println('     This TOML should have failed:\n${"-".repeat(40)}\n$content_that_should_have_failed\n${"-".repeat(40)}')
 				assert false
 			} else {
 				if !hide_oks {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -326,7 +326,7 @@ pub fn (x Expr) str() string {
 				fields << 'init: $x.default_expr.str()'
 			}
 			if fields.len > 0 {
-				return '[]T{${fields.join(', ')}}'
+				return '[]T{${fields.join(", ")}}'
 			} else {
 				return x.exprs.str()
 			}
@@ -430,7 +430,7 @@ pub fn (x Expr) str() string {
 				mv := x.vals[ik].str()
 				pairs << '$kv: $mv'
 			}
-			return 'map{ ${pairs.join(' ')} }'
+			return 'map{ ${pairs.join(" ")} }'
 		}
 		Nil {
 			return 'nil'
@@ -625,7 +625,7 @@ pub fn (node Stmt) str() string {
 		}
 		ConstDecl {
 			fields := node.fields.map(field_to_string)
-			return 'const (${fields.join(' ')})'
+			return 'const (${fields.join(" ")})'
 		}
 		ExprStmt {
 			return node.expr.str()

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1274,7 +1274,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			} else if sym.info is SumType && (sym.info as SumType).is_anon {
 				variant_names := sym.info.variants.map(t.shorten_user_defined_typenames(t.sym(it).name,
 					import_aliases))
-				res = '${variant_names.join('|')}'
+				res = '${variant_names.join("|")}'
 			} else {
 				res = t.shorten_user_defined_typenames(res, import_aliases)
 			}

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -61,8 +61,8 @@ fn parallel_cc(mut b builder.Builder, header string, res string, out_str string,
 	pp.set_max_jobs(nthreads)
 	pp.work_on_items(o_postfixes)
 	eprintln('> C compilation on $nthreads threads, working on $o_postfixes.len files took: $sw.elapsed().milliseconds() ms')
-	link_cmd := '${os.quoted_path(cbuilder.cc_compiler)} -o ${os.quoted_path(b.pref.out_name)} out_0.o ${fnames.map(it.replace('.c',
-		'.o')).join(' ')} out_x.o -lpthread $cbuilder.cc_ldflags'
+	link_cmd := '${os.quoted_path(cbuilder.cc_compiler)} -o ${os.quoted_path(b.pref.out_name)} out_0.o ${fnames.map(it.replace(".c",
+		".o")).join(" ")} out_x.o -lpthread $cbuilder.cc_ldflags'
 	sw_link := time.new_stopwatch()
 	link_res := os.execute(link_cmd)
 	eprint_time('link_cmd', link_cmd, link_res, sw_link)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -185,7 +185,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	ccoptions.guessed_compiler = v.pref.ccompiler
 	if ccoptions.guessed_compiler == 'cc' && v.pref.is_prod {
 		// deliberately guessing only for -prod builds for performance reasons
-		ccversion := os.execute('${os.quoted_path('cc')} --version')
+		ccversion := os.execute('${os.quoted_path("cc")} --version')
 		if ccversion.exit_code == 0 {
 			if ccversion.output.contains('This is free software;')
 				&& ccversion.output.contains('Free Software Foundation, Inc.') {

--- a/vlib/v/builder/interpreterbuilder/v_interpret_test.v
+++ b/vlib/v/builder/interpreterbuilder/v_interpret_test.v
@@ -31,8 +31,8 @@ fn interp_test(expression string, expected string) ! {
 		eprintln('     expected: |$expected|')
 		return error('test')
 	}
-	println('${term.colorize(term.green, 'OK')} ${term.colorize(term.bright_blue, expression.replace('\n',
-		' '))}')
+	println('${term.colorize(term.green, "OK")} ${term.colorize(term.bright_blue, expression.replace("\n",
+		" "))}')
 	println('   >> ${term.colorize(term.bright_yellow, output)}')
 }
 

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -48,7 +48,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 				continue
 			}
 			if comment.pos.pos > field.pos.pos {
-				comments_len += '/* ${comment.text.trim_left('\x01')} */ '.len
+				comments_len += '/* ${comment.text.trim_left("\x01")} */ '.len
 			}
 		}
 		field_aligns.add_info(comments_len + field.name.len, ft.len, field.pos.line_nr)

--- a/vlib/v/fmt/tests/string_quotes_expected.vv
+++ b/vlib/v/fmt/tests/string_quotes_expected.vv
@@ -14,7 +14,5 @@ _ := "<font color=\\\"warning\\\">message</font>\\n>${arr.join('\\n>')}"
 _ := "<font color=\\\"warning\\\">message</font>\\n>${arr.join('\\n>')}"
 _ := '<font color=\\"warning\\">message</font>\\n>'
 _ := '<font color=\\"warning\\">message</font>\\n>'
-_ := 'values: ${arr.join('\\n')}'
-_ := 'values: ${arr.join('\\n')}'
-_ := 'values: ${arr.join('\\n')}'
-_ := 'values: ${arr.join('\\n')}'
+_ := 'values: ${arr.join("\\n")}'
+_ := 'values: ${arr.join("\\n")}'

--- a/vlib/v/fmt/tests/string_quotes_input.vv
+++ b/vlib/v/fmt/tests/string_quotes_input.vv
@@ -10,11 +10,9 @@ fn main() {
 }
 
 arr := ['a', 'b']
-_ := '<font color=\\"warning\\">message</font>\\n>${arr.join('\\n>')}'
+_ := '<font color=\\"warning\\">message</font>\\n>${arr.join("\\n>")}'
 _ := "<font color=\\\"warning\\\">message</font>\\n>${arr.join('\\n>')}"
 _ := '<font color=\\"warning\\">message</font>\\n>'
 _ := "<font color=\\\"warning\\\">message</font>\\n>"
-_ := 'values: ${arr.join('\\n')}'
-_ := "values: ${arr.join('\\n')}"
 _ := 'values: ${arr.join("\\n")}'
-_ := "values: ${arr.join("\\n")}"
+_ := "values: ${arr.join('\\n')}"

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -420,7 +420,7 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	// `users.sort(a.age > b.age)`
 	// Generate a comparison function for a custom type
 	elem_stype := g.typ(info.elem_type)
-	mut compare_fn := 'compare_${g.unique_file_path_hash}_${elem_stype.replace('*', '_ptr')}'
+	mut compare_fn := 'compare_${g.unique_file_path_hash}_${elem_stype.replace("*", "_ptr")}'
 	mut comparison_type := g.unwrap(ast.void_type)
 	mut left_expr, mut right_expr := '', ''
 	// the only argument can only be an infix expression like `a < b` or `b.field > a.field`

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -187,7 +187,7 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 	g.auto_str_funcs.writeln('\t\tres = $tmp_str;')
 	g.auto_str_funcs.writeln('\t}')
 
-	g.auto_str_funcs.writeln('\treturn ${str_intp_sub('Option(%%)', 'res')};')
+	g.auto_str_funcs.writeln('\treturn ${str_intp_sub("Option(%%)", "res")};')
 	g.auto_str_funcs.writeln('}')
 }
 
@@ -220,7 +220,7 @@ fn (mut g Gen) gen_str_for_result(typ ast.Type, styp string, str_fn_name string)
 	g.auto_str_funcs.writeln('\t\tres = $tmp_str;')
 	g.auto_str_funcs.writeln('\t}')
 
-	g.auto_str_funcs.writeln('\treturn ${str_intp_sub('result(%%)', 'res')};')
+	g.auto_str_funcs.writeln('\treturn ${str_intp_sub("result(%%)", "res")};')
 	g.auto_str_funcs.writeln('}')
 }
 
@@ -405,7 +405,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, str_fn_
 	mut clean_sum_type_v_type_name := ''
 	if info.is_anon {
 		variant_names := info.variants.map(util.strip_main_name(g.table.sym(it).name))
-		clean_sum_type_v_type_name = '${variant_names.join('|')}'
+		clean_sum_type_v_type_name = '${variant_names.join("|")}'
 	} else {
 		clean_sum_type_v_type_name = styp.replace('__', '.')
 		if styp.ends_with('*') {
@@ -569,9 +569,9 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 			}
 		} else if sym.kind in [.f32, .f64] {
 			if sym.kind == .f32 {
-				g.auto_str_funcs.writeln('\t\tstring x = ${str_intp_g32('it')};')
+				g.auto_str_funcs.writeln('\t\tstring x = ${str_intp_g32("it")};')
 			} else {
-				g.auto_str_funcs.writeln('\t\tstring x = ${str_intp_g64('it')};')
+				g.auto_str_funcs.writeln('\t\tstring x = ${str_intp_g64("it")};')
 			}
 		} else if sym.kind == .rune {
 			// Rune are managed at this level as strings
@@ -654,12 +654,12 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 			}
 		} else if sym.kind in [.f32, .f64] {
 			if sym.kind == .f32 {
-				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_g32('a[i]')} );')
+				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_g32("a[i]")} );')
 			} else {
-				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_g64('a[i]')} );')
+				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_g64("a[i]")} );')
 			}
 		} else if sym.kind == .string {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_sq('a[i]')});')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_sq("a[i]")});')
 		} else if sym.kind == .rune {
 			tmp_str := str_intp_rune('${elem_str_fn_name}(  $deref a[i])')
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, $tmp_str);')
@@ -721,7 +721,7 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		g.auto_str_funcs.writeln('\t\t$key_styp key = *($key_styp*)DenseArray_key(&m.key_values, i);')
 	}
 	if key_sym.kind == .string {
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_sq('key')});')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_sq("key")});')
 	} else if key_sym.kind == .rune {
 		tmp_str := str_intp_rune('${key_str_fn_name}(key)')
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, $tmp_str);')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1036,7 +1036,7 @@ fn (mut g Gen) optional_type_name(t ast.Type) (string, string) {
 	mut styp := ''
 	sym := g.table.sym(t)
 	if sym.language == .c && sym.kind == .struct_ {
-		styp = '${c.option_name}_${base.replace(' ', '_')}'
+		styp = '${c.option_name}_${base.replace(" ", "_")}'
 	} else {
 		styp = '${c.option_name}_$base'
 	}
@@ -1051,7 +1051,7 @@ fn (mut g Gen) result_type_name(t ast.Type) (string, string) {
 	mut styp := ''
 	sym := g.table.sym(t)
 	if sym.language == .c && sym.kind == .struct_ {
-		styp = '${c.result_name}_${base.replace(' ', '_')}'
+		styp = '${c.result_name}_${base.replace(" ", "_")}'
 	} else {
 		styp = '${c.result_name}_$base'
 	}
@@ -1779,7 +1779,7 @@ fn (mut g Gen) write_v_source_line_info(pos token.Pos) {
 		nline := pos.line_nr + 1
 		lineinfo := '\n#line $nline "$g.vlines_path"'
 		$if trace_gen_source_line_info ? {
-			eprintln('> lineinfo: ${lineinfo.replace('\n', '')}')
+			eprintln('> lineinfo: ${lineinfo.replace("\n", "")}')
 		}
 		g.writeln(lineinfo)
 	}
@@ -6147,9 +6147,9 @@ static inline __shared__$interface_name ${shared_fn_name}(__shared__$cctype* x) 
 						methods_wrapper.writeln('$args);')
 					} else {
 						if parameter_name.starts_with('__shared__') {
-							methods_wrapper.writeln('${method_call}(${fargs.join(', ')}->val);')
+							methods_wrapper.writeln('${method_call}(${fargs.join(", ")}->val);')
 						} else {
-							methods_wrapper.writeln('${method_call}(*${fargs.join(', ')});')
+							methods_wrapper.writeln('${method_call}(*${fargs.join(", ")});')
 						}
 					}
 					methods_wrapper.writeln('}')

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -95,7 +95,7 @@ fn (mut g Gen) gen_embedded_metadata() {
 		g.embedded_data.writeln('\t\t\tres.path = ${ctoslit(emfile.rpath)};')
 		if g.should_really_embed_file() {
 			// apath is not needed in production and may leak information
-			g.embedded_data.writeln('\t\t\tres.apath = ${ctoslit('')};')
+			g.embedded_data.writeln('\t\t\tres.apath = ${ctoslit("")};')
 		} else {
 			g.embedded_data.writeln('\t\t\tres.apath = ${ctoslit(emfile.apath)};')
 		}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -201,9 +201,9 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 		enc.writeln('\tif (val._typ == $variant.idx()) {')
 		$if json_no_inline_sumtypes ? {
 			if variant_sym.kind == .enum_ {
-				enc.writeln('\t\tcJSON_AddItemToObject(o, "$unmangled_variant_name", ${js_enc_name('u64')}(*val._$variant_typ));')
+				enc.writeln('\t\tcJSON_AddItemToObject(o, "$unmangled_variant_name", ${js_enc_name("u64")}(*val._$variant_typ));')
 			} else if variant_sym.name == 'time.Time' {
-				enc.writeln('\t\tcJSON_AddItemToObject(o, "$unmangled_variant_name", ${js_enc_name('i64')}(val._$variant_typ->_v_unix));')
+				enc.writeln('\t\tcJSON_AddItemToObject(o, "$unmangled_variant_name", ${js_enc_name("i64")}(val._$variant_typ->_v_unix));')
 			} else {
 				enc.writeln('\t\tcJSON_AddItemToObject(o, "$unmangled_variant_name", ${js_enc_name(variant_typ)}(*val._$variant_typ));')
 			}
@@ -211,10 +211,10 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 			if is_js_prim(variant_typ) {
 				enc.writeln('\t\to = ${js_enc_name(variant_typ)}(*val._$variant_typ);')
 			} else if variant_sym.kind == .enum_ {
-				enc.writeln('\t\to = ${js_enc_name('u64')}(*val._$variant_typ);')
+				enc.writeln('\t\to = ${js_enc_name("u64")}(*val._$variant_typ);')
 			} else if variant_sym.name == 'time.Time' {
 				enc.writeln('\t\tcJSON_AddItemToObject(o, "_type", cJSON_CreateString("$unmangled_variant_name"));')
-				enc.writeln('\t\tcJSON_AddItemToObject(o, "value", ${js_enc_name('i64')}(val._$variant_typ->_v_unix));')
+				enc.writeln('\t\tcJSON_AddItemToObject(o, "value", ${js_enc_name("i64")}(val._$variant_typ->_v_unix));')
 			} else {
 				enc.writeln('\t\to = ${js_enc_name(variant_typ)}(*val._$variant_typ);')
 				enc.writeln('\t\tcJSON_AddItemToObject(o, "_type", cJSON_CreateString("$unmangled_variant_name"));')
@@ -231,10 +231,10 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 				dec.writeln('\t\t$variant_typ value = ${js_dec_name(variant_typ)}(jsonroot_$tmp);')
 			} else if variant_sym.kind == .enum_ {
 				gen_js_get(variant_typ, tmp, unmangled_variant_name, mut dec, true)
-				dec.writeln('\t\t$variant_typ value = ${js_dec_name('u64')}(jsonroot_$tmp);')
+				dec.writeln('\t\t$variant_typ value = ${js_dec_name("u64")}(jsonroot_$tmp);')
 			} else if variant_sym.name == 'time.Time' {
 				gen_js_get(variant_typ, tmp, unmangled_variant_name, mut dec, true)
-				dec.writeln('\t\t$variant_typ value = time__unix(${js_dec_name('i64')}(jsonroot_$tmp));')
+				dec.writeln('\t\t$variant_typ value = time__unix(${js_dec_name("i64")}(jsonroot_$tmp));')
 			} else {
 				gen_js_get_opt(js_dec_name(variant_typ), variant_typ, sym.cname, tmp,
 					unmangled_variant_name, mut dec, true)
@@ -246,7 +246,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 			if variant_sym.name == 'time.Time' {
 				dec.writeln('\t\t\tif (strcmp("Time", $type_var) == 0) {')
 				gen_js_get(sym.cname, tmp, 'value', mut dec, true)
-				dec.writeln('\t\t\t\t$variant_typ $tmp = time__unix(${js_dec_name('i64')}(jsonroot_$tmp));')
+				dec.writeln('\t\t\t\t$variant_typ $tmp = time__unix(${js_dec_name("i64")}(jsonroot_$tmp));')
 				dec.writeln('\t\t\t\tres = ${variant_typ}_to_sumtype_${sym.cname}(&$tmp);')
 				dec.writeln('\t\t\t}')
 			} else if !is_js_prim(variant_typ) && variant_sym.kind != .enum_ {
@@ -290,7 +290,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(sym ast.TypeSymbol, mut enc strings.Builder, 
 					number_is_met = true
 					last_number_type = var_t
 					dec.writeln('\t\tif (cJSON_IsNumber(root)) {')
-					dec.writeln('\t\t\t$var_t value = ${js_dec_name('u64')}(root);')
+					dec.writeln('\t\t\t$var_t value = ${js_dec_name("u64")}(root);')
 					dec.writeln('\t\t\tres = ${var_t}_to_sumtype_${sym.cname}(&value);')
 					dec.writeln('\t\t}')
 				}

--- a/vlib/v/gen/c/sql.v
+++ b/vlib/v/gen/c/sql.v
@@ -117,7 +117,7 @@ fn (mut g Gen) sql_create_table(node ast.SqlStmtLine, expr string, table_name st
 			}
 			g.write('.typ = $typ,')
 			g.write('.is_arr = ${sym.kind == .array}, ')
-			g.write('.is_time = ${g.table.get_type_name(field.typ) == 'time__Time'},')
+			g.write('.is_time = ${g.table.get_type_name(field.typ) == "time__Time"},')
 			g.write('.default_val = (string){.str = (byteptr) "$field.default_val", .is_lit = 1},')
 			g.write('.attrs = new_array_from_c_array($field.attrs.len, $field.attrs.len, sizeof(StructAttribute),')
 			if field.attrs.len > 0 {

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -73,10 +73,10 @@ pub fn (mut f Gen) process_file_imports(file &ast.File) {
 		f.mod2alias[imp.mod] = imp.alias
 		for sym in imp.syms {
 			f.mod2alias['${imp.mod}.$sym.name'] = sym.name
-			f.mod2alias['${imp.mod.all_after_last('.')}.$sym.name'] = sym.name
+			f.mod2alias['${imp.mod.all_after_last(".")}.$sym.name'] = sym.name
 			f.mod2alias[sym.name] = sym.name
 			f.mod2syms['${imp.mod}.$sym.name'] = sym.name
-			f.mod2syms['${imp.mod.all_after_last('.')}.$sym.name'] = sym.name
+			f.mod2syms['${imp.mod.all_after_last(".")}.$sym.name'] = sym.name
 			f.mod2syms[sym.name] = sym.name
 			f.import_syms_used[sym.name] = false
 		}

--- a/vlib/v/gen/js/array.v
+++ b/vlib/v/gen/js/array.v
@@ -223,7 +223,7 @@ fn (mut g JsGen) gen_array_sort(node ast.CallExpr) {
 	info := rec_sym.info as ast.Array
 
 	elem_stype := g.typ(info.elem_type)
-	mut compare_fn := 'compare_${elem_stype.replace('*', '_ptr')}'
+	mut compare_fn := 'compare_${elem_stype.replace("*", "_ptr")}'
 	mut comparison_type := g.unwrap(ast.void_type)
 	mut left_expr, mut right_expr := '', ''
 

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -240,7 +240,7 @@ fn (mut g JsGen) gen_str_for_option(typ ast.Type, styp string, str_fn_name strin
 	g.definitions.writeln('\t\tres = $tmp_str;')
 	g.definitions.writeln('\t}')
 
-	g.definitions.writeln('\treturn ${str_intp_sub('Option(%%)', 'res')};')
+	g.definitions.writeln('\treturn ${str_intp_sub("Option(%%)", "res")};')
 	g.definitions.writeln('}')
 }
 

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -317,7 +317,7 @@ pub fn (mut p Parser) parse_inline_sum_type() ast.Type {
 		mut variant_names := variants.map(p.table.sym(it.typ).name)
 		variant_names.sort()
 		// deterministic name
-		name := '_v_anon_sum_type_${variant_names.join('_')}'
+		name := '_v_anon_sum_type_${variant_names.join("_")}'
 		variant_types := variants.map(it.typ)
 		prepend_mod_name := p.prepend_mod(name)
 		mut idx := p.table.find_type_idx(prepend_mod_name)

--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -137,9 +137,9 @@ fn test_big_closure_${typ}_${i}() {
 			values := all_param_values[..i]
 
 			assert_line := if !return_type.no_assert_kw {
-				'assert c(${values.join(', ')}) $assertion'
+				'assert c(${values.join(", ")}) $assertion'
 			} else {
-				'c(${values.join(', ')}) $assertion'
+				'c(${values.join(", ")}) $assertion'
 			}
 			// Note: the captured arg doesn't matter for this test, as closures always receive
 			// a pointer to the entire closure context as their last argument anyways
@@ -161,7 +161,7 @@ fn test_closure_return_${styp}_${i}() ? {
 	}
 
 	code := v_code.str()
-	println('Compiling V code (${code.count('\n')} lines) ...')
+	println('Compiling V code (${code.count("\n")} lines) ...')
 	wrkdir := os.join_path(os.vtmp_dir(), 'v', 'tests', 'closures')
 	os.mkdir_all(wrkdir)?
 	os.chdir(wrkdir)?

--- a/vlib/v/tests/map_assign_array_of_interface_test.v
+++ b/vlib/v/tests/map_assign_array_of_interface_test.v
@@ -34,7 +34,7 @@ fn test_map_assign_array_of_interface() {
 	println(owner_and_animals)
 	assert owner_and_animals['John Doe'].len == 2
 	println(owner_and_animals['John Doe'][0])
-	assert '${owner_and_animals['John Doe'][0]}'.contains("name: 'Bobby'")
+	assert '${owner_and_animals["John Doe"][0]}'.contains("name: 'Bobby'")
 	println(owner_and_animals['John Doe'][1])
-	assert '${owner_and_animals['John Doe'][1]}'.contains("name: 'Hulk'")
+	assert '${owner_and_animals["John Doe"][1]}'.contains("name: 'Hulk'")
 }

--- a/vlib/v/tests/map_complex_fixed_array_test.v
+++ b/vlib/v/tests/map_complex_fixed_array_test.v
@@ -23,7 +23,7 @@ fn test_innermost_value_of_map_fixed_array() {
 	println(m['foo'][0][0]['bar'])
 	println(m['foo'][0][0]['bar'] == 1)
 	assert m['foo'][0][0]['bar'] == 1
-	assert '${m['foo'][0][0]['bar']}' == '1'
+	assert '${m["foo"][0][0]["bar"]}' == '1'
 }
 
 fn test_complex_map_high_order_fixed_array() {

--- a/vlib/v/tests/run_project_folders_test.v
+++ b/vlib/v/tests/run_project_folders_test.v
@@ -34,6 +34,6 @@ fn test_v_profile_works() {
 		assert res.output.len > 0
 		assert res.output.contains('OK')
 		term.clear_previous_line()
-		println('${term.bold('OK')} in ${delta:4}ms  v run $local_path/')
+		println('${term.bold("OK")} in ${delta:4}ms  v run $local_path/')
 	}
 }

--- a/vlib/v/tests/string_interpolation_inner_cbr_test.v
+++ b/vlib/v/tests/string_interpolation_inner_cbr_test.v
@@ -14,7 +14,7 @@ fn test_string_interpolation_inner_cbr() {
 	assert s2 == 'St{}'
 
 	s3 := '${{
-		'a': 1
+		"a": 1
 	}}'
 	println(s3)
 	assert s3 == "{'a': 1}"

--- a/vlib/v/tests/string_interpolation_string_args_test.v
+++ b/vlib/v/tests/string_interpolation_string_args_test.v
@@ -7,25 +7,25 @@ fn show_more_info(a string, b string) string {
 }
 
 fn test_interpolation_string_args() {
-	assert '${show_info('abc')}' == 'abc'
-	assert '${show_info('abc')}' == 'abc'
+	assert '${show_info("abc")}' == 'abc'
+	assert '${show_info("abc")}' == 'abc'
 
-	assert '1_${show_info('aaa')} 2_${show_info('bbb')}' == '1_aaa 2_bbb'
-	assert '1_${show_info('aaa')} 2_${show_info('bbb')}' == '1_aaa 2_bbb'
+	assert '1_${show_info("aaa")} 2_${show_info("bbb")}' == '1_aaa 2_bbb'
+	assert '1_${show_info("aaa")} 2_${show_info("bbb")}' == '1_aaa 2_bbb'
 
-	assert '${'aaa'}' == 'aaa'
-	assert '${'aaa'}' == 'aaa'
+	assert '${"aaa"}' == 'aaa'
+	assert '${"aaa"}' == 'aaa'
 
-	assert '${'aaa' + 'bbb'}' == 'aaabbb'
-	assert '${'aaa' + 'bbb'}' == 'aaabbb'
-	assert '${'aaa' + 'bbb'}' == 'aaabbb'
-	assert '${'aaa' + 'bbb'}' == 'aaabbb'
+	assert '${"aaa" + "bbb"}' == 'aaabbb'
+	assert '${"aaa" + "bbb"}' == 'aaabbb'
+	assert '${"aaa" + "bbb"}' == 'aaabbb'
+	assert '${"aaa" + "bbb"}' == 'aaabbb'
 
-	assert '${show_more_info('aaa', 'bbb')}' == 'aaabbb'
-	assert '${show_more_info('aaa', 'bbb')}' == 'aaabbb'
-	assert '${show_more_info('aaa', 'bbb')}' == 'aaabbb'
-	assert '${show_more_info('aaa', 'bbb')}' == 'aaabbb'
+	assert '${show_more_info("aaa", "bbb")}' == 'aaabbb'
+	assert '${show_more_info("aaa", "bbb")}' == 'aaabbb'
+	assert '${show_more_info("aaa", "bbb")}' == 'aaabbb'
+	assert '${show_more_info("aaa", "bbb")}' == 'aaabbb'
 
-	assert '1_${show_more_info('aaa', '111')} 2_${show_more_info('bbb', '222')}' == '1_aaa111 2_bbb222'
-	assert '1_${show_more_info('aaa', '111')} 2_${show_more_info('bbb', '222')}' == '1_aaa111 2_bbb222'
+	assert '1_${show_more_info("aaa", "111")} 2_${show_more_info("bbb", "222")}' == '1_aaa111 2_bbb222'
+	assert '1_${show_more_info("aaa", "111")} 2_${show_more_info("bbb", "222")}' == '1_aaa111 2_bbb222'
 }

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -16,13 +16,11 @@ fn test_string_new_interpolation() {
 	println('{a}{{{{{b}}}}}')
 	assert '{a}{{{{{b}}}}}' == '1{{{{2}}}}'
 
-	// vfmt off
 	s := 'hello'
 	println('{s == "hello"}')
 	assert '{s == "hello"}' == 'true'
 	println('{s != "hello"}')
 	assert '{s != "hello"}' == 'false'
-	// vfmt on
 
 	n := 22
 	println('{n >= 10}')

--- a/vlib/v/vcache/vcache.v
+++ b/vlib/v/vcache/vcache.v
@@ -39,7 +39,7 @@ pub fn new_cache_manager(opts []string) CacheManager {
 	if vcache_basepath == '' {
 		vcache_basepath = os.join_path(os.vmodules_dir(), 'cache')
 	}
-	nlog(@FN, 'vcache_basepath: $vcache_basepath\n         opts: $opts\n      os.args: ${os.args.join(' ')}')
+	nlog(@FN, 'vcache_basepath: $vcache_basepath\n         opts: $opts\n      os.args: ${os.args.join(" ")}')
 	dlog(@FN, 'vcache_basepath: $vcache_basepath | opts:\n     $opts')
 	if !os.is_dir(vcache_basepath) {
 		os.mkdir_all(vcache_basepath, mode: 0o700) or { panic(err) } // keep directory private


### PR DESCRIPTION
This PR fix inter quote of nested string in string interpolation.

keep fmt:
- Inter quote is not same as outer quote in string interpolation.

```v
fn foo() string {
	match true {
		true {
			fields := ['aaa', 'bbb', 'ccc']
			return '[]T{{fields.join(", ")}}'
			
		}
		else {
			fields := ['aaa', 'bbb', 'ccc']
			return ('const ({fields.join(" ")})')
		}
	}
}

fn main() {
	ret := foo()
	println(ret)
}
```