### PR TITLE
fmt: fix - `v fmt` transforms compile time options in some cases

### DIFF
--- a/vlib/v/checker/constants/constants.v
+++ b/vlib/v/checker/constants/constants.v
@@ -1,0 +1,10 @@
+module constants
+
+// TODO: move all constants from `checker` to here, and replace the hardcoded one with the computed one
+pub const valid_comptime_not_user_defined = ['windows', 'ios', 'macos', 'mach', 'darwin', 'hpux',
+	'gnu', 'qnx', 'linux', 'freebsd', 'openbsd', 'netbsd', 'bsd', 'dragonfly', 'android', 'termux',
+	'solaris', 'haiku', 'serenity', 'vinix', 'gcc', 'tinyc', 'clang', 'mingw', 'msvc', 'cplusplus',
+	'amd64', 'i386', 'aarch64', 'arm64', 'arm32', 'rv64', 'rv32', 'x64', 'x32', 'little_endian',
+	'big_endian', 'apk', 'js', 'debug', 'prod', 'test', 'glibc', 'prealloc', 'no_bounds_checking',
+	'freestanding', 'threads', 'js_node', 'js_browser', 'js_freestanding', 'interpreter', 'es5',
+	'profile', 'wasm32_emscripten']

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -7,6 +7,7 @@ import strings
 import v.ast
 import v.util
 import v.pref
+import v.checker
 
 const (
 	bs      = '\\'
@@ -1936,6 +1937,10 @@ pub fn (mut f Fmt) enum_val(node ast.EnumVal) {
 
 pub fn (mut f Fmt) ident(node ast.Ident) {
 	if node.info is ast.IdentVar {
+		if node.comptime && node.name in checker.valid_comptime_not_user_defined {
+			f.write(node.name)
+			return
+		}
 		if node.info.is_mut {
 			f.write(node.info.share.str() + ' ')
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -7,7 +7,7 @@ import strings
 import v.ast
 import v.util
 import v.pref
-import v.checker
+import v.checker.constants
 
 const (
 	bs      = '\\'
@@ -1937,7 +1937,7 @@ pub fn (mut f Fmt) enum_val(node ast.EnumVal) {
 
 pub fn (mut f Fmt) ident(node ast.Ident) {
 	if node.info is ast.IdentVar {
-		if node.comptime && node.name in checker.valid_comptime_not_user_defined {
+		if node.comptime && node.name in constants.valid_comptime_not_user_defined {
 			f.write(node.name)
 			return
 		}

--- a/vlib/v/fmt/tests/conditional_compilation_keep_in_module.vv
+++ b/vlib/v/fmt/tests/conditional_compilation_keep_in_module.vv
@@ -1,0 +1,15 @@
+module log
+
+const (
+	debug = 'debug'
+	prod  = 'prod'
+)
+
+fn log() {
+	$if debug {
+		println('debug')
+	}
+	$if !prod {
+		println('prod')
+	}
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

### Summary

As reported in #16328, `fmt` transforms compile time options when conflicting names are used. With this patch, the comptime options will be kept even in that case.

### Test plan

No errors should occur when running `v fmt` against the new test file.

```
v fmt -c vlib/v/fmt/tests/conditional_compilation_keep.vv
```

Resolves #16328