### PR TITLE
cgen: fix generic sumtype auto str  (fix #16340 part1)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -76,8 +76,14 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 			str_fn_name = styp_to_str_fn_name(sym.name)
 		}
 	}
-	if sym.has_method_with_generic_parent('str') && mut sym.info is ast.Struct {
-		str_fn_name = g.generic_fn_name(sym.info.concrete_types, str_fn_name)
+	if sym.has_method_with_generic_parent('str') {
+		if mut sym.info is ast.Struct {
+			str_fn_name = g.generic_fn_name(sym.info.concrete_types, str_fn_name)
+		} else if mut sym.info is ast.SumType {
+			str_fn_name = g.generic_fn_name(sym.info.concrete_types, str_fn_name)
+		} else if mut sym.info is ast.Interface {
+			str_fn_name = g.generic_fn_name(sym.info.concrete_types, str_fn_name)
+		}
 	}
 	g.str_types << StrType{
 		typ: unwrapped

--- a/vlib/v/tests/generic_sumtype_str_test.v
+++ b/vlib/v/tests/generic_sumtype_str_test.v
@@ -1,0 +1,33 @@
+module main
+
+struct None {}
+
+pub type Maybe<T> = None | T
+
+pub fn (m Maybe<T>) str<T>() string {
+	return if m is T {
+		x := m as T
+		'Some($x)'
+	} else {
+		'Noth'
+	}
+}
+
+pub fn some<T>(v T) Maybe<T> {
+	return Maybe<T>(v)
+}
+
+fn test_generic_sumtype_str() {
+	a := some(123)
+	b := some('abc')
+
+	println(a.str())
+	println(a)
+	println('$a')
+	assert '$a' == 'Some(123)'
+
+	println(b.str())
+	println(b)
+	println('$b')
+	assert '$b' == 'Some(abc)'
+}


### PR DESCRIPTION
This PR fix generic sumtype auto str  (fix #16340 part1).

- Fix generic sumtype auto str.
- Add test.

```v
module main

struct None {}
pub type Maybe<T> = None | T

pub fn (m Maybe<T>) str<T>() string {
	return if m is T {
		x := m as T
		'Some($x)'
	} else {
		'Noth'
	}
}

pub fn some<T>(v T) Maybe<T> {
	return Maybe<T>(v)
}

fn main() {
	a := some(123)
	b := some('abc')

	println(a.str())
	println(a)
	println('$a')
	assert '$a' == 'Some(123)'

	println(b.str())
	println(b)
	println('$b')
	assert '$b' == 'Some(abc)'
}

PS D:\Test\v\tt1> v run .
Some(123)
Some(123)
Some(123)
Some(abc)
Some(abc)
Some(abc)
```