### PR TITLE
make: add 'rebuild' target (clean and reset sub-repos, then rebuild V)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -85,7 +85,7 @@ endif
 endif
 endif
 
-.PHONY: all clean check fresh_vc fresh_tcc fresh_legacy check_for_working_tcc
+.PHONY: all clean rebuild check fresh_vc fresh_tcc fresh_legacy check_for_working_tcc
 
 ifdef prod
 VFLAGS+=-prod
@@ -118,6 +118,8 @@ clean:
 	rm -rf $(TMPTCC)
 	rm -rf $(LEGACYLIBS)
 	rm -rf $(VC)
+
+rebuild: clean all
 
 ifndef local
 latest_vc: $(VC)/.git/config

--- a/make.bat
+++ b/make.bat
@@ -44,7 +44,7 @@ if !shift_counter! LSS 1 (
     if "%~1" == "help" (
         if not ["%~2"] == [""] set "subcmd=%~2"& shift& set /a shift_counter+=1
     )
-    for %%z in (build clean cleanall check help) do (
+    for %%z in (build clean cleanall check help rebuild) do (
         if "%~1" == "%%z" set target=%1& shift& set /a shift_counter+=1& goto :verifyopt
     )
 )
@@ -97,6 +97,10 @@ del *.pdb *.lib *.bak *.out *.ilk *.exp *.obj *.o *.a *.so
 echo  ^> Delete old V executable(s)
 del v*.exe
 exit /b 0
+
+:rebuild
+call :cleanall
+goto :build
 
 :help
 if [!subcmd!] == [] (
@@ -271,6 +275,7 @@ echo     clean             Clean build artifacts and debugging symbols
 echo     cleanall          Cleanup entire ALL build artifacts and vc repository
 echo     check             Check that tests pass, and the repository is in a good shape for Pull Requests
 echo     help              Display help for the given target
+echo     rebuild           Fully clean/reset repository and rebuild V
 echo.
 echo Examples:
 echo     make.bat -msvc
@@ -307,6 +312,18 @@ exit /b 0
 :help_build
 echo Usage:
 echo     make.bat build [compiler] [options]
+echo.
+echo Compiler:
+echo     -msvc ^| -gcc ^| -tcc ^| -tcc32 ^| -clang    Set C compiler
+echo.
+echo Options:
+echo    --local     Use the local vc repository without
+echo                syncing with remote
+exit /b 0
+
+:help_rebuild
+echo Usage:
+echo     make.bat rebuild [compiler] [options]
 echo.
 echo Compiler:
 echo     -msvc ^| -gcc ^| -tcc ^| -tcc32 ^| -clang    Set C compiler


### PR DESCRIPTION
`make rebuild` (for both POSIX and WinOS platforms)

- cleans repository, including removal of TCC, LEGACY, and VC sub-repos, then initiates a clean rebuild of V

## [why]

During development, especially jumping between CMD and WSL, the sub-repositories may become altered or be in an incorrect state for the currently in-use platform. `make rebuild` will remove the sub-repos and initiate a new clean build of V (using newly retrieved, correct, copies of the sub-repos).

---

Currently, an equivalent process would be `make clean && make` for POSIX and a slightly different `make cleanall && make` for WinOS. This just combines the steps into one, easy-to-remember, `make rebuild` command, which is the same for either platform-type. This can really be helpful when you're jumping back and forth between platforms, ie, between CMD and WSL.

Help text is also included within the `make.bat` WinOS.

I hope this is useful. And I'm happy to make changes, if requested.