### PR TITLE
checker: fix: anon fn without body block doesn't trigger errors

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -410,6 +410,9 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 		c.inside_anon_fn = keep_inside_anon
 		c.cur_anon_fn = keep_anon_fn
 	}
+	if node.decl.no_body {
+		c.error('anonymous function must declare a body', node.decl.pos)
+	}
 	for param in node.decl.params {
 		if param.name.len == 0 {
 			c.error('use `_` to name an unused parameter', param.pos)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -450,15 +450,6 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 							field.pos)
 					}
 				}
-				if field_type_sym.kind == .function && field_type_sym.language == .v {
-					pos := field.expr.pos()
-					if mut field.expr is ast.AnonFn {
-						if field.expr.decl.no_body {
-							c.error('cannot initialize the fn field with anonymous fn that does not have a body',
-								pos)
-						}
-					}
-				}
 				node.fields[i].typ = expr_type
 				node.fields[i].expected_type = field_info.typ
 

--- a/vlib/v/checker/tests/anon_fn_without_body.out
+++ b/vlib/v/checker/tests/anon_fn_without_body.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/anon_fn_without_body.vv:4:10: error: anonymous function must declare a body
+    2 |
+    3 | fn main() {
+    4 |     func := fn () int
+      |             ~~~~~~~~~
+    5 |
+    6 |     println(func())

--- a/vlib/v/checker/tests/anon_fn_without_body.vv
+++ b/vlib/v/checker/tests/anon_fn_without_body.vv
@@ -1,0 +1,7 @@
+module main
+
+fn main() {
+	func := fn () int
+
+	println(func())
+}

--- a/vlib/v/checker/tests/globals/global_anon_fn_without_body.out
+++ b/vlib/v/checker/tests/globals/global_anon_fn_without_body.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/globals/global_anon_fn_without_body.vv:1:14: error: anonymous function must declare a body
+    1 | __global f = fn ()
+      |              ~~~~~

--- a/vlib/v/checker/tests/globals/global_anon_fn_without_body.vv
+++ b/vlib/v/checker/tests/globals/global_anon_fn_without_body.vv
@@ -1,0 +1,1 @@
+__global f = fn ()

--- a/vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.vv:7:7: error: cannot initialize the fn field with anonymous fn that does not have a body
+vlib/v/checker/tests/struct_field_init_with_nobody_anon_fn_err.vv:7:7: error: anonymous function must declare a body
     5 | fn main() {
     6 |     _ = App{
     7 |         cb: fn(x int)  // Note the missing `{}` (the function body) here


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

### Summary

The check doesn't trigger errors for anonymous functions without body block as reported in #16212. This PR makes the checker disallow the no-body-block anon functions.

It also deletes lines of code from `checker > struct.v` because it will be never called and the relevant test is updated accordingly.

### Test plan

Run the two new test files. The output should be the same as the corresponding `.out` files.

Resolves #16212 