### PR TITLE
doc: add more examples to vlib/time/README.md

### DIFF
--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -46,7 +46,7 @@ You can also parse strings to produce time.Time values,
 import time
 
 s := '2018-01-27 12:48:34'
-t := time.parse(s) or { panic('> failing format: $s | err: $err') }
+t := time.parse(s) or { panic('failing format: $s | err: $err') }
 println(t)
 println(t.unix)
 ```
@@ -61,7 +61,7 @@ fn parse_rfc3339(s string) !Time
 
 Another very useful feature of the `time` module is the stop watch,
 for when you want to measure short time periods, elapsed while you
-executed other tasks. [See](https://play.vlang.io/?query=550658437e):
+executed other tasks. [See](https://play.vlang.io/?query=f6c008bc34):
 ```v
 import time
 
@@ -69,7 +69,9 @@ fn do_something() {
 	time.sleep(510 * time.millisecond)
 }
 
-sw := time.new_stopwatch()
-do_something()
-println('> do_something() took: $sw.elapsed().milliseconds() ms')
+fn main() {
+	sw := time.new_stopwatch()
+	do_something()
+	println('Note: do_something() took: $sw.elapsed().milliseconds() ms')
+}	
 ```

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -10,7 +10,7 @@ V's `time` module, provides utilities for working with time and dates:
 
 ## Examples:
 
-You can see the current time with:
+You can see the current time. [See](https://play.vlang.io/?query=c121a6dda7):
 ```v
 import time
 
@@ -61,7 +61,7 @@ fn parse_rfc3339(s string) !Time
 
 Another very useful feature of the `time` module is the stop watch,
 for when you want to measure short time periods, elapsed while you
-executed other tasks:
+executed other tasks. [See](https://play.vlang.io/?query=550658437e):
 ```v
 import time
 

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -32,11 +32,30 @@ println(time.now())
 
 **Example:**
 
+see: [V Playground](https://play.vlang.io/p/133d1a0ce5)
+
 ```v
-assert time_to_test.format() =='1980-07-11 21:23'
-assert time_to_test.format_ss() =='1980-07-11 21:23:42'
-assert time_to_test.format_ss_milli() =='1980-07-11 21:23:42.123'
-assert time_to_test.format_ss_micro() =='1980-07-11 21:23:42.123456'
+import time
+
+const (
+	time_to_test = time.Time{
+		year: 1980
+		month: 7
+		day: 11
+		hour: 21
+		minute: 23
+		second: 42
+		microsecond: 123456
+		unix: 332198622
+	}
+)
+
+println(time_to_test.format())
+
+assert '1980-07-11 21:23' == time_to_test.format()
+assert '1980-07-11 21:23:42'== time_to_test.format_ss()
+assert '1980-07-11 21:23:42.123' == time_to_test.format_ss_milli()
+assert '1980-07-11 21:23:42.123456' == time_to_test.format_ss_micro()
 ```
 
 **v doc:**

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -1,3 +1,10 @@
+# time
+
+A time library
+
+## Features
+TODO
+
 ## Description:
 
 `time` provides utilities for working with time and dates:
@@ -8,10 +15,73 @@
 - stop watches for accurately measuring time durations
 - sleeping for a period of time
 
-## Examples:
+**Example:**
+time can be comparable
 
+see: [V Playground](https://play.vlang.io/p/c121a6dda7)
 ```v
 import time
 
 println(time.now())
 ```
+### format
+
+**v doc:**
+```v ignore
+fn (t Time) format() string
+fn (t Time) format_ss() string
+fn (t Time) format_ss_milli() string
+fn (t Time) format_ss_micro() string
+```
+
+**Example:**
+
+```v
+assert time_to_test.format() =='1980-07-11 21:23'
+assert time_to_test.format_ss() =='1980-07-11 21:23:42'
+assert time_to_test.format_ss_milli() =='1980-07-11 21:23:42.123'
+assert time_to_test.format_ss_micro() =='1980-07-11 21:23:42.123456'
+```
+
+### parse
+
+**v doc:**
+```v ignore
+fn parse(s string) !Time
+fn parse_iso8601(s string) !Time
+fn parse_rfc2822(s string) !Time
+fn parse_rfc3339(s string) !Time
+```
+
+**Example:**
+
+see: [V Playground](https://play.vlang.io/p/b02ca6027f)
+```v
+import time
+
+s := '2018-01-27 12:48:34'
+t := time.parse(s) or {
+    panic('> failing format: $s | err: $err')
+}
+println(t)
+println(t.unix)
+```
+### stopwatch
+
+**Example:**
+
+```v
+
+```
+### unix
+
+**Example:**
+
+```v
+
+```
+### chrono
+// days_from_civil - return the number of days since the
+// Unix epoch 1970-01-01. A detailed description of the algorithm here
+// is in: http://howardhinnant.github.io/date_algorithms.html
+// Note that it will return negative values for days before 1970-01-01.

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -1,15 +1,6 @@
-# time
-
-A time library
-
-## Features
-
-TODO
-
 ## Description:
 
-`time` provides utilities for working with time and dates:
-
+V's `time` module, provides utilities for working with time and dates:
 - parsing of time values expressed in one of the commonly used standard time/date formats
 - formatting of time values
 - arithmetic over times/durations
@@ -17,75 +8,50 @@ TODO
 - stop watches for accurately measuring time durations
 - sleeping for a period of time
 
-**Example:**
-time can be comparable
+## Examples:
 
-see: [V Playground](https://play.vlang.io/p/c121a6dda7)
-
+You can see the current time with:
 ```v
 import time
 
 println(time.now())
 ```
 
-### format
-
-**Example:**
-
-see: [V Playground](https://play.vlang.io/p/133d1a0ce5)
-
+`time.Time` values can be compared, [see](https://play.vlang.io/?query=133d1a0ce5):
 ```v
 import time
 
-const (
-	time_to_test = time.Time{
-		year: 1980
-		month: 7
-		day: 11
-		hour: 21
-		minute: 23
-		second: 42
-		microsecond: 123456
-		unix: 332198622
-	}
-)
+const time_to_test = time.Time{
+	year: 1980
+	month: 7
+	day: 11
+	hour: 21
+	minute: 23
+	second: 42
+	microsecond: 123456
+	unix: 332198622
+}
 
 println(time_to_test.format())
 
 assert '1980-07-11 21:23' == time_to_test.format()
-assert '1980-07-11 21:23:42'== time_to_test.format_ss()
+assert '1980-07-11 21:23:42' == time_to_test.format_ss()
 assert '1980-07-11 21:23:42.123' == time_to_test.format_ss_milli()
 assert '1980-07-11 21:23:42.123456' == time_to_test.format_ss_micro()
 ```
 
-**v doc:**
-
-```v ignore
-fn (t Time) format() string
-fn (t Time) format_ss() string
-fn (t Time) format_ss_milli() string
-fn (t Time) format_ss_micro() string
-```
-
-### parse
-
-**Example:**
-
-see: [V Playground](https://play.vlang.io/p/b02ca6027f)
-
+You can also parse strings to produce time.Time values,
+[see](https://play.vlang.io/p/b02ca6027f):
 ```v
 import time
 
 s := '2018-01-27 12:48:34'
-t := time.parse(s) or {
-    panic('> failing format: $s | err: $err')
-}
+t := time.parse(s) or { panic('> failing format: $s | err: $err') }
 println(t)
 println(t.unix)
 ```
 
-**v doc:**
-
+V's time module also has these parse methods:
 ```v ignore
 fn parse(s string) !Time
 fn parse_iso8601(s string) !Time
@@ -93,25 +59,17 @@ fn parse_rfc2822(s string) !Time
 fn parse_rfc3339(s string) !Time
 ```
 
-### stopwatch
-
-**Example:**
-
+Another very useful feature of the `time` module is the stop watch,
+for when you want to measure short time periods, elapsed while you
+executed other tasks:
 ```v
+import time
 
+fn do_something() {
+	time.sleep(510 * time.millisecond)
+}
+
+sw := time.new_stopwatch()
+do_something()
+println('> do_something() took: $sw.elapsed().milliseconds() ms')
 ```
-
-### unix
-
-**Example:**
-
-```v
-
-```
-
-### chrono
-
-// days_from_civil - return the number of days since the
-// Unix epoch 1970-01-01. A detailed description of the algorithm here
-// is in: http://howardhinnant.github.io/date_algorithms.html
-// Note that it will return negative values for days before 1970-01-01.

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -73,5 +73,5 @@ fn main() {
 	sw := time.new_stopwatch()
 	do_something()
 	println('Note: do_something() took: $sw.elapsed().milliseconds() ms')
-}	
+}
 ```

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -3,11 +3,13 @@
 A time library
 
 ## Features
+
 TODO
 
 ## Description:
 
 `time` provides utilities for working with time and dates:
+
 - parsing of time values expressed in one of the commonly used standard time/date formats
 - formatting of time values
 - arithmetic over times/durations
@@ -19,20 +21,14 @@ TODO
 time can be comparable
 
 see: [V Playground](https://play.vlang.io/p/c121a6dda7)
+
 ```v
 import time
 
 println(time.now())
 ```
-### format
 
-**v doc:**
-```v ignore
-fn (t Time) format() string
-fn (t Time) format_ss() string
-fn (t Time) format_ss_milli() string
-fn (t Time) format_ss_micro() string
-```
+### format
 
 **Example:**
 
@@ -43,19 +39,21 @@ assert time_to_test.format_ss_milli() =='1980-07-11 21:23:42.123'
 assert time_to_test.format_ss_micro() =='1980-07-11 21:23:42.123456'
 ```
 
-### parse
-
 **v doc:**
+
 ```v ignore
-fn parse(s string) !Time
-fn parse_iso8601(s string) !Time
-fn parse_rfc2822(s string) !Time
-fn parse_rfc3339(s string) !Time
+fn (t Time) format() string
+fn (t Time) format_ss() string
+fn (t Time) format_ss_milli() string
+fn (t Time) format_ss_micro() string
 ```
+
+### parse
 
 **Example:**
 
 see: [V Playground](https://play.vlang.io/p/b02ca6027f)
+
 ```v
 import time
 
@@ -66,6 +64,16 @@ t := time.parse(s) or {
 println(t)
 println(t.unix)
 ```
+
+**v doc:**
+
+```v ignore
+fn parse(s string) !Time
+fn parse_iso8601(s string) !Time
+fn parse_rfc2822(s string) !Time
+fn parse_rfc3339(s string) !Time
+```
+
 ### stopwatch
 
 **Example:**
@@ -73,6 +81,7 @@ println(t.unix)
 ```v
 
 ```
+
 ### unix
 
 **Example:**
@@ -80,7 +89,9 @@ println(t.unix)
 ```v
 
 ```
+
 ### chrono
+
 // days_from_civil - return the number of days since the
 // Unix epoch 1970-01-01. A detailed description of the algorithm here
 // is in: http://howardhinnant.github.io/date_algorithms.html


### PR DESCRIPTION
# time

A library that provides utilities for working with time and dates:

## Features

TODO

## Description:

- parsing of time values expressed in one of the commonly used standard time/date formats
- formatting of time values
- arithmetic over times/durations
- converting between local time and UTC (timezone support)
- stop watches for accurately measuring time durations
- sleeping for a period of time

**Examples:**
time can be comparable

see: [V Playground](https://play.vlang.io/p/c121a6dda7)

```v
import time

println(time.now())
```

### format

**Examples:**

see: [V Playground](https://play.vlang.io/p/133d1a0ce5)

```v
import time

const (
	time_to_test = time.Time{
		year: 1980
		month: 7
		day: 11
		hour: 21
		minute: 23
		second: 42
		microsecond: 123456
		unix: 332198622
	}
)

println(time_to_test.format())

assert '1980-07-11 21:23' == time_to_test.format()
assert '1980-07-11 21:23:42'== time_to_test.format_ss()
assert '1980-07-11 21:23:42.123' == time_to_test.format_ss_milli()
assert '1980-07-11 21:23:42.123456' == time_to_test.format_ss_micro()
```

**v doc:**

```v ignore
fn (t Time) format() string
fn (t Time) format_ss() string
fn (t Time) format_ss_milli() string
fn (t Time) format_ss_micro() string
```

### parse

**Examples:**

see: [V Playground](https://play.vlang.io/p/b02ca6027f)

```v
import time

s := '2018-01-27 12:48:34'
t := time.parse(s) or {
    panic('> failing format: $s | err: $err')
}
println(t)
println(t.unix)
```

**v doc:**

```v ignore
fn parse(s string) !Time
fn parse_iso8601(s string) !Time
fn parse_rfc2822(s string) !Time
fn parse_rfc3339(s string) !Time
```

### stopwatch

**Example:**

```v

```

### unix

**Examples:**

```v

```

### chrono

// days_from_civil - return the number of days since the
// Unix epoch 1970-01-01. A detailed description of the algorithm here
// is in: http://howardhinnant.github.io/date_algorithms.html
// Note that it will return negative values for days before 1970-01-01.
