### PR TITLE
scanner: fix fn is_valid_interpolation() (fix #16368)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1340,6 +1340,7 @@ fn (s Scanner) is_valid_interpolation(start_pos int) bool {
 		if s.text[i] == `}` {
 			// No } in this string, so it's not a valid `{x}` interpolation
 			has_rcbr = true
+			break
 		}
 		if s.text[i] == `=` && (s.text[i - 1] in [`!`, `>`, `<`] || s.text[i + 1] == `=`) {
 			// `!=` `>=` `<=` `==`

--- a/vlib/v/tests/string_new_interpolation_test.v
+++ b/vlib/v/tests/string_new_interpolation_test.v
@@ -1,4 +1,4 @@
-fn test_string_new_interpolation() {
+fn test_string_new_interpolation_1() {
 	a, b, c, d := 1, 2, 3, 4
 
 	println('{a}{b}{c}{d}')
@@ -54,4 +54,12 @@ fn foo() string {
 			return 'const ({fields.join(' ')})'
 		}
 	}
+}
+
+// For issue: 16368
+fn test_string_new_interpolation_2() {
+	y := 1
+	x := y
+
+	assert '{x} = {y}' == '1 = 1'
 }


### PR DESCRIPTION
1. Fix #16368 
2. Add test.

```v
y := 1
x := y

println('{x} = {y}')
```

output:

```
1 = 1
```

