### PR TITLE
refactor: checker: move comptime constants into separate module

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -24,14 +24,14 @@ const (
 )
 
 pub const (
-	array_builtin_methods            = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice',
-		'sort', 'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
-	array_builtin_methods_chk        = token.new_keywords_matcher_from_array_trie(array_builtin_methods)
+	array_builtin_methods       = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice', 'sort',
+		'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
+	array_builtin_methods_chk   = token.new_keywords_matcher_from_array_trie(array_builtin_methods)
 	// TODO: remove `byte` from this list when it is no longer supported
-	reserved_type_names              = ['byte', 'bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8',
-		'u16', 'u32', 'u64', 'f32', 'f64', 'map', 'string', 'rune']
-	reserved_type_names_chk          = token.new_keywords_matcher_from_array_trie(reserved_type_names)
-	vroot_is_deprecated_message      = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
+	reserved_type_names         = ['byte', 'bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8', 'u16',
+		'u32', 'u64', 'f32', 'f64', 'map', 'string', 'rune']
+	reserved_type_names_chk     = token.new_keywords_matcher_from_array_trie(reserved_type_names)
+	vroot_is_deprecated_message = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
 )
 
 [heap; minify]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -12,6 +12,7 @@ import v.util
 import v.util.version
 import v.errors
 import v.pkgconfig
+import v.checker.constants
 
 const (
 	int_min                  = int(0x80000000)
@@ -23,17 +24,6 @@ const (
 )
 
 pub const (
-	valid_comptime_if_os             = ['windows', 'ios', 'macos', 'mach', 'darwin', 'hpux', 'gnu',
-		'qnx', 'linux', 'freebsd', 'openbsd', 'netbsd', 'bsd', 'dragonfly', 'android', 'termux',
-		'solaris', 'haiku', 'serenity', 'vinix']
-	valid_comptime_compression_types = ['none', 'zlib']
-	valid_comptime_if_compilers      = ['gcc', 'tinyc', 'clang', 'mingw', 'msvc', 'cplusplus']
-	valid_comptime_if_platforms      = ['amd64', 'i386', 'aarch64', 'arm64', 'arm32', 'rv64', 'rv32']
-	valid_comptime_if_cpu_features   = ['x64', 'x32', 'little_endian', 'big_endian']
-	valid_comptime_if_other          = ['apk', 'js', 'debug', 'prod', 'test', 'glibc', 'prealloc',
-		'no_bounds_checking', 'freestanding', 'threads', 'js_node', 'js_browser', 'js_freestanding',
-		'interpreter', 'es5', 'profile', 'wasm32_emscripten']
-	valid_comptime_not_user_defined  = all_valid_comptime_idents()
 	array_builtin_methods            = ['filter', 'clone', 'repeat', 'reverse', 'map', 'slice',
 		'sort', 'contains', 'index', 'wait', 'any', 'all', 'first', 'last', 'pop']
 	array_builtin_methods_chk        = token.new_keywords_matcher_from_array_trie(array_builtin_methods)
@@ -43,16 +33,6 @@ pub const (
 	reserved_type_names_chk          = token.new_keywords_matcher_from_array_trie(reserved_type_names)
 	vroot_is_deprecated_message      = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
 )
-
-fn all_valid_comptime_idents() []string {
-	mut res := []string{}
-	res << checker.valid_comptime_if_os
-	res << checker.valid_comptime_if_compilers
-	res << checker.valid_comptime_if_platforms
-	res << checker.valid_comptime_if_cpu_features
-	res << checker.valid_comptime_if_other
-	return res
-}
 
 [heap; minify]
 pub struct Checker {
@@ -1644,7 +1624,7 @@ fn (mut c Checker) stmt(node_ ast.Stmt) {
 			for i, ident in node.defer_vars {
 				mut id := ident
 				if mut id.info is ast.IdentVar {
-					if id.comptime && id.name in checker.valid_comptime_not_user_defined {
+					if id.comptime && id.name in constants.valid_comptime_not_user_defined {
 						node.defer_vars[i] = ast.Ident{
 							scope: 0
 							name: ''

--- a/vlib/v/checker/constants/constants.v
+++ b/vlib/v/checker/constants/constants.v
@@ -1,10 +1,25 @@
 module constants
 
-// TODO: move all constants from `checker` to here, and replace the hardcoded one with the computed one
-pub const valid_comptime_not_user_defined = ['windows', 'ios', 'macos', 'mach', 'darwin', 'hpux',
-	'gnu', 'qnx', 'linux', 'freebsd', 'openbsd', 'netbsd', 'bsd', 'dragonfly', 'android', 'termux',
-	'solaris', 'haiku', 'serenity', 'vinix', 'gcc', 'tinyc', 'clang', 'mingw', 'msvc', 'cplusplus',
-	'amd64', 'i386', 'aarch64', 'arm64', 'arm32', 'rv64', 'rv32', 'x64', 'x32', 'little_endian',
-	'big_endian', 'apk', 'js', 'debug', 'prod', 'test', 'glibc', 'prealloc', 'no_bounds_checking',
-	'freestanding', 'threads', 'js_node', 'js_browser', 'js_freestanding', 'interpreter', 'es5',
-	'profile', 'wasm32_emscripten']
+pub const (
+	valid_comptime_if_os             = ['windows', 'ios', 'macos', 'mach', 'darwin', 'hpux', 'gnu',
+		'qnx', 'linux', 'freebsd', 'openbsd', 'netbsd', 'bsd', 'dragonfly', 'android', 'termux',
+		'solaris', 'haiku', 'serenity', 'vinix']
+	valid_comptime_compression_types = ['none', 'zlib']
+	valid_comptime_if_compilers      = ['gcc', 'tinyc', 'clang', 'mingw', 'msvc', 'cplusplus']
+	valid_comptime_if_platforms      = ['amd64', 'i386', 'aarch64', 'arm64', 'arm32', 'rv64', 'rv32']
+	valid_comptime_if_cpu_features   = ['x64', 'x32', 'little_endian', 'big_endian']
+	valid_comptime_if_other          = ['apk', 'js', 'debug', 'prod', 'test', 'glibc', 'prealloc',
+		'no_bounds_checking', 'freestanding', 'threads', 'js_node', 'js_browser', 'js_freestanding',
+		'interpreter', 'es5', 'profile', 'wasm32_emscripten']
+	valid_comptime_not_user_defined  = all_valid_comptime_idents()
+)
+
+fn all_valid_comptime_idents() []string {
+	mut res := []string{}
+	res << constants.valid_comptime_if_os
+	res << constants.valid_comptime_if_compilers
+	res << constants.valid_comptime_if_platforms
+	res << constants.valid_comptime_if_cpu_features
+	res << constants.valid_comptime_if_other
+	return res
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

### Summary

This is a follow-up PR of #16351. It moves comptime constants into a separate module - `v.checker.constants` as per @spytheman 's suggestion.

### Test plan

Make sure that no errors occur while compiling `v`.