### PR TITLE
comptime: fix embed file with variable argument  (fix #16360)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -713,10 +713,10 @@ pub mut:
 [minify]
 pub struct EmbeddedFile {
 pub:
-	rpath            string // used in the source code, as an ID/key to the embed
-	apath            string // absolute path during compilation to the resource
 	compression_type string
 pub mut:
+	rpath string // used in the source code, as an ID/key to the embed
+	apath string // absolute path during compilation to the resource
 	// these are set by gen_embed_file_init in v/gen/c/embed
 	is_compressed bool
 	bytes         []u8
@@ -1684,7 +1684,6 @@ pub:
 	method_pos  token.Pos
 	scope       &Scope = unsafe { nil }
 	left        Expr
-	args_var    string
 	//
 	is_vweb   bool
 	vweb_tmpl File
@@ -1699,6 +1698,7 @@ pub mut:
 	left_type   Type
 	result_type Type
 	env_value   string
+	args_var    string
 	args        []CallArg
 	embed_file  EmbeddedFile
 }

--- a/vlib/v/embed_file/tests/embed_file_with_variable_arg_test.v
+++ b/vlib/v/embed_file/tests/embed_file_with_variable_arg_test.v
@@ -1,0 +1,6 @@
+fn test_embed_file_with_variable_arg() {
+	path := './a.txt'
+	s := $embed_file(path).to_string()
+	println(s)
+	assert s.trim_space() == 'test'
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1882,9 +1882,9 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 	} else {
 		if node.is_embed {
 			if node.embed_file.compression_type == 'none' {
-				f.write("\$embed_file('$node.embed_file.rpath')")
+				f.write('\$embed_file(${node.args[0].expr})')
 			} else {
-				f.write("\$embed_file('$node.embed_file.rpath', .$node.embed_file.compression_type)")
+				f.write('\$embed_file(${node.args[0].expr}, .$node.embed_file.compression_type)')
 			}
 		} else if node.is_env {
 			f.write("\$env('$node.args_var')")


### PR DESCRIPTION
This PR fix embed file with variable argument  (fix #16360).

- Fix embed file with variable argument.
- Add test.

```v
fn main() {
	path := './tt1.v'
	s := $embed_file(path).to_string()
	println(s)
}

PS D:\Test\v\tt1> v run .
fn main() {
        path := './tt1.v'
        s := $embed_file(path).to_string()
        println(s)
}
```