### PR TITLE
checker: check fntype mismatch of struct field init (fix #16372)

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -10,7 +10,7 @@ struct Story {
 	url   string
 }
 
-fn worker_fetch(p &pool.PoolProcessor, cursor int, worker_id int) voidptr {
+fn worker_fetch(mut p pool.PoolProcessor, cursor int, worker_id int) voidptr {
 	id := p.get_item<int>(cursor)
 	resp := http.get('https://hacker-news.firebaseio.com/v0/item/${id}.json') or {
 		println('failed to fetch data from /v0/item/${id}.json')

--- a/vlib/crypto/ed25519/internal/ed25519_test.v
+++ b/vlib/crypto/ed25519/internal/ed25519_test.v
@@ -129,7 +129,7 @@ fn works_check_on_sign_input_string(item string) bool {
 	return true
 }
 
-fn worker_for_string_content(p &pool.PoolProcessor, idx int, worker_id int) &SignResult {
+fn worker_for_string_content(mut p pool.PoolProcessor, idx int, worker_id int) &SignResult {
 	item := p.get_item<string>(idx)
 	// println('worker_s worker_id: $worker_id | idx: $idx ')
 	res := works_check_on_sign_input_string(item)

--- a/vlib/sync/pool/README.md
+++ b/vlib/sync/pool/README.md
@@ -16,7 +16,7 @@ pub struct SResult {
 	s string
 }
 
-fn sprocess(pp &pool.PoolProcessor, idx int, wid int) &SResult {
+fn sprocess(mut pp pool.PoolProcessor, idx int, wid int) &SResult {
 	item := pp.get_item<string>(idx)
 	println('idx: $idx, wid: $wid, item: ' + item)
 	return &SResult{item.reverse()}

--- a/vlib/sync/pool/pool.v
+++ b/vlib/sync/pool/pool.v
@@ -22,7 +22,7 @@ mut:
 	thread_contexts []voidptr
 }
 
-pub type ThreadCB = fn (p &PoolProcessor, idx int, task_id int) voidptr
+pub type ThreadCB = fn (mut p PoolProcessor, idx int, task_id int) voidptr
 
 pub struct PoolProcessorConfig {
 	maxjobs  int
@@ -110,7 +110,7 @@ fn process_in_thread(mut pool PoolProcessor, task_id int) {
 		if idx >= ilen {
 			break
 		}
-		pool.results[idx] = cb(pool, idx, task_id)
+		pool.results[idx] = cb(mut pool, idx, task_id)
 	}
 	pool.waitgroup.done()
 }

--- a/vlib/sync/pool/pool_test.v
+++ b/vlib/sync/pool/pool_test.v
@@ -9,14 +9,14 @@ pub struct IResult {
 	i int
 }
 
-fn worker_s(p &pool.PoolProcessor, idx int, worker_id int) &SResult {
+fn worker_s(mut p pool.PoolProcessor, idx int, worker_id int) &SResult {
 	item := p.get_item<string>(idx)
 	println('worker_s worker_id: $worker_id | idx: $idx | item: $item')
 	time.sleep(3 * time.millisecond)
 	return &SResult{'$item $item'}
 }
 
-fn worker_i(p &pool.PoolProcessor, idx int, worker_id int) &IResult {
+fn worker_i(mut p pool.PoolProcessor, idx int, worker_id int) &IResult {
 	item := p.get_item<int>(idx)
 	println('worker_i worker_id: $worker_id | idx: $idx | item: $item')
 	time.sleep(5 * time.millisecond)

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -68,7 +68,7 @@ fn parallel_cc(mut b builder.Builder, header string, res string, out_str string,
 	eprint_time('link_cmd', link_cmd, link_res, sw_link)
 }
 
-fn build_parallel_o_cb(p &pool.PoolProcessor, idx int, wid int) voidptr {
+fn build_parallel_o_cb(mut p pool.PoolProcessor, idx int, wid int) voidptr {
 	postfix := p.get_item<string>(idx)
 	sw := time.new_stopwatch()
 	cmd := '${os.quoted_path(cbuilder.cc_compiler)} $cbuilder.cc_cflags -c -w -o out_${postfix}.o out_${postfix}.c'

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -409,6 +409,9 @@ pub fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSym
 		got_arg_typ := c.unwrap_generic(got_arg.typ)
 		exp_arg_is_ptr := exp_arg_typ.is_ptr() || exp_arg_typ.is_pointer()
 		got_arg_is_ptr := got_arg_typ.is_ptr() || got_arg_typ.is_pointer()
+		if exp_arg.is_mut && !got_arg.is_mut {
+			return false
+		}
 		if exp_arg_is_ptr != got_arg_is_ptr {
 			exp_arg_pointedness := if exp_arg_is_ptr { 'a pointer' } else { 'NOT a pointer' }
 			got_arg_pointedness := if got_arg_is_ptr { 'a pointer' } else { 'NOT a pointer' }

--- a/vlib/v/checker/tests/struct_field_init_fntype_mismatch.out
+++ b/vlib/v/checker/tests/struct_field_init_fntype_mismatch.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_init_fntype_mismatch.vv:13:3: error: cannot assign to field `foo_fn`: expected `fn (mut Foo)`, not `fn (&Foo)`
+   11 | fn main(){
+   12 |     srv := Server{
+   13 |         foo_fn: foo
+      |         ~~~~~~~~~~~
+   14 |     }
+   15 |     dump(isnil(srv.foo_fn))

--- a/vlib/v/checker/tests/struct_field_init_fntype_mismatch.vv
+++ b/vlib/v/checker/tests/struct_field_init_fntype_mismatch.vv
@@ -1,0 +1,16 @@
+struct Foo{}
+
+type FooFn = fn(mut f Foo) 
+
+struct Server{
+	foo_fn FooFn = unsafe{ nil }
+}
+
+fn foo(f &Foo) {}
+
+fn main(){
+	srv := Server{
+		foo_fn: foo
+	}
+	dump(isnil(srv.foo_fn))
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -598,7 +598,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) (string,
 	return header, res, out_str, out_fn_start_pos
 }
 
-fn cgen_process_one_file_cb(p &pool.PoolProcessor, idx int, wid int) &Gen {
+fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) &Gen {
 	file := p.get_item<&ast.File>(idx)
 	mut global_g := &Gen(p.get_shared_context())
 	mut g := &Gen{


### PR DESCRIPTION
This PR check fntype mismatch of struct field init (fix #16372).

- Check fntype mismatch of struct field init.
- Add test.

```v
struct Foo{}

type FooFn = fn(mut f Foo) 

struct Server{
	foo_fn FooFn = unsafe{ nil }
}

fn foo(f &Foo) {}

fn main(){
	srv := Server{
		foo_fn: foo
	}
	dump(isnil(srv.foo_fn))
}

PS D:\Test\v\tt1> v run .
./tt1.v:13:3: error: cannot assign to field `foo_fn`: expected `fn (mut Foo)`, not `fn (&Foo)`
   11 | fn main(){
   12 |     srv := Server{
   13 |         foo_fn: foo
      |         ~~~~~~~~~~~
   14 |     }
   15 |     dump(isnil(srv.foo_fn))
```