### PR TITLE
gg: Revamp `Context` pipeline for more effects

### DIFF
--- a/examples/gg/additive.v
+++ b/examples/gg/additive.v
@@ -1,0 +1,94 @@
+module main
+
+import os
+import gg
+import gx
+import math
+
+[heap]
+pub struct Window {
+pub mut:
+	ctx   &gg.Context = unsafe { 0 }
+	image gg.Image
+}
+
+pub fn (mut window Window) init(_ voidptr) {
+	logo_path := os.resource_abs_path(os.join_path('..', 'assets', 'logo.png'))
+	window.image = window.ctx.create_image(logo_path)
+}
+
+pub fn (mut window Window) draw(_ voidptr) {
+	window.ctx.begin()
+
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: 400 - window.image.width / 2
+			y: 300 - window.image.height / 2
+			width: window.image.width
+			height: window.image.height
+		}
+		// additive: false <-- this can be omitted completely as it is false by default.
+	)
+
+	// Red
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: (400 - window.image.width / 2) + f32(math.sin(f32(window.ctx.frame) / 10.0) * 60)
+			y: (300 - window.image.height / 2) + f32(math.cos(f32(window.ctx.frame) / 10.0) * 60)
+			width: window.image.width
+			height: window.image.height
+		}
+		color: gx.Color{255, 0, 0, 255}
+		additive: true
+	)
+
+	// Green
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: (400 - window.image.width / 2) + f32(math.sin(f32(window.ctx.frame) / 10.0) * 80)
+			y: (300 - window.image.height / 2) + f32(math.cos(f32(window.ctx.frame) / 10.0) * 80)
+			width: window.image.width
+			height: window.image.height
+		}
+		color: gx.Color{0, 255, 0, 255}
+		additive: true
+	)
+
+	// Blue
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: (400 - window.image.width / 2) + f32(math.sin(f32(window.ctx.frame) / 10.0) * 100)
+			y: (300 - window.image.height / 2) + f32(math.cos(f32(window.ctx.frame) / 10.0) * 100)
+			width: window.image.width
+			height: window.image.height
+		}
+		color: gx.Color{0, 0, 255, 255}
+		additive: true
+	)
+
+	window.ctx.end()
+}
+
+fn main() {
+	mut window := &Window{}
+
+	window.ctx = gg.new_context(
+		width: 800
+		height: 600
+		user_data: window
+		bg_color: gx.gray
+		// FNs
+		init_fn: window.init
+		frame_fn: window.draw
+	)
+
+	window.ctx.run()
+}

--- a/examples/gg/additive.v
+++ b/examples/gg/additive.v
@@ -29,7 +29,7 @@ pub fn (mut window Window) draw(_ voidptr) {
 			width: window.image.width
 			height: window.image.height
 		}
-		// additive: false <-- this can be omitted completely as it is false by default.
+		// effect: .alpha <-- this can be omitted completely as it is alpha by default.
 	)
 
 	// Red
@@ -43,7 +43,7 @@ pub fn (mut window Window) draw(_ voidptr) {
 			height: window.image.height
 		}
 		color: gx.Color{255, 0, 0, 255}
-		additive: true
+		effect: .add
 	)
 
 	// Green
@@ -57,7 +57,7 @@ pub fn (mut window Window) draw(_ voidptr) {
 			height: window.image.height
 		}
 		color: gx.Color{0, 255, 0, 255}
-		additive: true
+		effect: .add
 	)
 
 	// Blue
@@ -71,7 +71,47 @@ pub fn (mut window Window) draw(_ voidptr) {
 			height: window.image.height
 		}
 		color: gx.Color{0, 0, 255, 255}
-		additive: true
+		effect: .add
+	)
+
+	// More examples
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: 50,
+			y: 0,
+			width: window.image.width
+			height: window.image.height
+		}
+		color: gx.Color{255, 0, 0, 255}
+		effect: .add
+	)
+
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: 50,
+			y: 50,
+			width: window.image.width
+			height: window.image.height
+		}
+		color: gx.Color{0, 255, 0, 255}
+		effect: .add
+	)
+
+	window.ctx.draw_image_with_config(
+		img: &window.image
+		img_id: window.image.id
+		img_rect: gg.Rect{
+			x: 50,
+			y: 100,
+			width: window.image.width
+			height: window.image.height
+		}
+		color: gx.Color{0, 0, 255, 255}
+		effect: .add
 	)
 
 	window.ctx.end()

--- a/examples/gg/additive.v
+++ b/examples/gg/additive.v
@@ -79,8 +79,8 @@ pub fn (mut window Window) draw(_ voidptr) {
 		img: &window.image
 		img_id: window.image.id
 		img_rect: gg.Rect{
-			x: 50,
-			y: 0,
+			x: 50
+			y: 0
 			width: window.image.width
 			height: window.image.height
 		}
@@ -92,8 +92,8 @@ pub fn (mut window Window) draw(_ voidptr) {
 		img: &window.image
 		img_id: window.image.id
 		img_rect: gg.Rect{
-			x: 50,
-			y: 50,
+			x: 50
+			y: 50
 			width: window.image.width
 			height: window.image.height
 		}
@@ -105,8 +105,8 @@ pub fn (mut window Window) draw(_ voidptr) {
 		img: &window.image
 		img_id: window.image.id
 		img_rect: gg.Rect{
-			x: 50,
-			y: 100,
+			x: 50
+			y: 100
 			width: window.image.width
 			height: window.image.height
 		}

--- a/examples/gg/rotating_textured_quad.v
+++ b/examples/gg/rotating_textured_quad.v
@@ -16,7 +16,7 @@ pub fn (mut window Window) init() {
 pub fn (mut window Window) draw() {
 	angle := f32(window.ctx.frame) / 64 // since window.ctx.frame is increased by 1 on every frame -> the angle will be increasing too
 	window.ctx.begin()
-	sgl.load_pipeline(window.ctx.timage_pip)
+	sgl.load_pipeline(window.ctx.pipeline.alpha)
 
 	sgl.translate(400, 400, 0) // center of the screen
 	sgl.rotate(angle, 0.0, 0.0, 1.0) // rotate around the Z axis pointing towards the camera

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -15,7 +15,7 @@ import math
 [inline]
 pub fn (ctx &Context) draw_pixel(x f32, y f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -37,7 +37,7 @@ pub fn (ctx &Context) draw_pixels(points []f32, c gx.Color) {
 	len := points.len / 2
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -67,7 +67,7 @@ pub fn (ctx &Context) draw_line(x f32, y f32, x2 f32, y2 f32, c gx.Color) {
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -80,7 +80,7 @@ pub fn (ctx &Context) draw_line(x f32, y f32, x2 f32, y2 f32, c gx.Color) {
 // draw_line_with_config draws a line between the points `x,y` and `x2,y2` using `PenConfig`.
 pub fn (ctx &Context) draw_line_with_config(x f32, y f32, x2 f32, y2 f32, config PenConfig) {
 	if config.color.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 
 	if config.thickness <= 0 {
@@ -137,7 +137,7 @@ pub fn (ctx &Context) draw_poly_empty(points []f32, c gx.Color) {
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -159,7 +159,7 @@ pub fn (ctx &Context) draw_convex_poly(points []f32, c gx.Color) {
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -182,7 +182,7 @@ pub fn (ctx &Context) draw_convex_poly(points []f32, c gx.Color) {
 // `w` is the width, `h` is the height and `c` is the color of the outline.
 pub fn (ctx &Context) draw_rect_empty(x f32, y f32, w f32, h f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -207,7 +207,7 @@ pub fn (ctx &Context) draw_rect_filled(x f32, y f32, w f32, h f32, c gx.Color) {
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -230,7 +230,7 @@ pub fn (ctx &Context) draw_rounded_rect_empty(x f32, y f32, w f32, h f32, radius
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -329,7 +329,7 @@ pub fn (ctx &Context) draw_rounded_rect_filled(x f32, y f32, w f32, h f32, radiu
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -435,7 +435,7 @@ pub fn (ctx &Context) draw_rounded_rect_filled(x f32, y f32, w f32, h f32, radiu
 // `c` is the color of the outline.
 pub fn (ctx &Context) draw_triangle_empty(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -454,7 +454,7 @@ pub fn (ctx &Context) draw_triangle_empty(x f32, y f32, x2 f32, y2 f32, x3 f32, 
 // `c` is the color of the outline.
 pub fn (ctx &Context) draw_triangle_filled(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -505,7 +505,7 @@ fn radius_to_segments(r f32) int {
 // `c` is the color of the outline.
 pub fn (ctx &Context) draw_circle_empty(x f32, y f32, radius f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -554,7 +554,7 @@ pub fn (ctx &Context) draw_polygon_filled(x f32, y f32, size f32, edges int, rot
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -604,7 +604,7 @@ pub fn (ctx &Context) draw_circle_line(x f32, y f32, radius int, segments int, c
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -631,7 +631,7 @@ pub fn (ctx &Context) draw_slice_empty(x f32, y f32, radius f32, start_angle f32
 		return
 	}
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -672,7 +672,7 @@ pub fn (ctx &Context) draw_slice_filled(x f32, y f32, radius f32, start_angle f3
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -721,7 +721,7 @@ pub fn (ctx Context) draw_arc_line(x f32, y f32, radius f32, start_angle f32, en
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -768,7 +768,7 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -835,7 +835,7 @@ pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_radius f32, thickness 
 	}
 
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -874,7 +874,7 @@ pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_radius f32, thickness 
 // `c` is the color of the outline.
 pub fn (ctx &Context) draw_ellipse_empty(x f32, y f32, rw f32, rh f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -894,7 +894,7 @@ pub fn (ctx &Context) draw_ellipse_empty(x f32, y f32, rw f32, rh f32, c gx.Colo
 // `c` is the fill color.
 pub fn (ctx &Context) draw_ellipse_filled(x f32, y f32, rw f32, rh f32, c gx.Color) {
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 
@@ -926,7 +926,7 @@ pub fn (ctx &Context) draw_cubic_bezier_in_steps(points []f32, steps u32, c gx.C
 		return
 	}
 	if c.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
 

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -115,19 +115,19 @@ mut:
 pub:
 	native_rendering bool
 pub mut:
-	scale       f32 = 1.0 // will get set to 2.0 for retina, will remain 1.0 for normal
-	width       int
-	height      int
-	clear_pass  gfx.PassAction
-	window      sapp.Desc
-	timage_pip  sgl.Pipeline
+	scale               f32 = 1.0 // will get set to 2.0 for retina, will remain 1.0 for normal
+	width               int
+	height              int
+	clear_pass          gfx.PassAction
+	window              sapp.Desc
+	timage_pip          sgl.Pipeline
 	timage_additive_pip sgl.Pipeline // For drawing additive images (and maybe shapes)
-	config      Config
-	user_data   voidptr
-	ft          &FT = unsafe { nil }
-	font_inited bool
-	ui_mode     bool // do not redraw everything 60 times/second, but only when the user requests
-	frame       u64  // the current frame counted from the start of the application; always increasing
+	config              Config
+	user_data           voidptr
+	ft                  &FT = unsafe { nil }
+	font_inited         bool
+	ui_mode             bool         // do not redraw everything 60 times/second, but only when the user requests
+	frame               u64  // the current frame counted from the start of the application; always increasing
 	//
 	mbtn_mask     u8
 	mouse_buttons MouseButtons // typed version of mbtn_mask; easier to use for user programs

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -121,6 +121,7 @@ pub mut:
 	clear_pass  gfx.PassAction
 	window      sapp.Desc
 	timage_pip  sgl.Pipeline
+	timage_additive_pip sgl.Pipeline // For drawing additive images (and maybe shapes)
 	config      Config
 	user_data   voidptr
 	ft          &FT = unsafe { nil }
@@ -205,7 +206,8 @@ fn gg_init_sokol_window(user_data voidptr) {
 			ctx.font_inited = true
 		}
 	}
-	//
+
+	// Alpha Pipeline
 	mut pipdesc := gfx.PipelineDesc{
 		label: c'alpha_image'
 	}
@@ -221,6 +223,25 @@ fn gg_init_sokol_window(user_data voidptr) {
 	pipdesc.colors[0] = color_state
 
 	ctx.timage_pip = sgl.make_pipeline(&pipdesc)
+
+	// Additive Pipeline
+	mut additive_pipdesc := gfx.PipelineDesc{
+		label: c'additive_alpha_image'
+	}
+	unsafe { vmemset(&additive_pipdesc, 0, int(sizeof(additive_pipdesc))) }
+
+	additive_color_state := gfx.ColorState{
+		blend: gfx.BlendState{
+			enabled: true
+			src_factor_rgb: .src_alpha
+			dst_factor_rgb: .one
+		}
+	}
+
+	additive_pipdesc.colors[0] = additive_color_state
+
+	ctx.timage_additive_pip = sgl.make_pipeline(&additive_pipdesc)
+
 	//
 	if ctx.config.init_fn != unsafe { nil } {
 		$if android {

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -110,7 +110,7 @@ pub mut:
 	add   sgl.Pipeline
 }
 
-pub fn (mut container PipelineContainer) init_pipeline() {
+fn (mut container PipelineContainer) init_pipeline() {
 	// FIXME(FireRedz): this looks kinda funny, find a better way to initialize pipeline.
 
 	// Alpha

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -297,11 +297,11 @@ pub fn (ctx &Context) draw_image_with_config(config DrawImageConfig) {
 	mut v1f := if !flip_y { v1 } else { v0 }
 
 	if config.additive {
-		sgl.load_pipeline(ctx.timage_additive_pip)	
+		sgl.load_pipeline(ctx.timage_additive_pip)
 	} else {
 		sgl.load_pipeline(ctx.timage_pip)
 	}
-	
+
 	sgl.enable_texture()
 	sgl.texture(img.simg)
 

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -296,10 +296,10 @@ pub fn (ctx &Context) draw_image_with_config(config DrawImageConfig) {
 	mut v0f := if !flip_y { v0 } else { v1 }
 	mut v1f := if !flip_y { v1 } else { v0 }
 
-	if config.additive {
-		sgl.load_pipeline(ctx.timage_additive_pip)
-	} else {
-		sgl.load_pipeline(ctx.timage_pip)
+	// FIXME: is this okay?
+	match config.effect {
+		.alpha { sgl.load_pipeline(ctx.pipeline.alpha) }
+		.add { sgl.load_pipeline(ctx.pipeline.add) }
 	}
 
 	sgl.enable_texture()

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -296,7 +296,12 @@ pub fn (ctx &Context) draw_image_with_config(config DrawImageConfig) {
 	mut v0f := if !flip_y { v0 } else { v1 }
 	mut v1f := if !flip_y { v1 } else { v0 }
 
-	sgl.load_pipeline(ctx.timage_pip)
+	if config.additive {
+		sgl.load_pipeline(ctx.timage_additive_pip)	
+	} else {
+		sgl.load_pipeline(ctx.timage_pip)
+	}
+	
 	sgl.enable_texture()
 	sgl.texture(img.simg)
 

--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -16,8 +16,14 @@ pub:
 	part_rect Rect // defines the size and position of part of the image to use when rendering
 	rotate    int  // amount to rotate the image in degrees
 	z         f32
-	color     gx.Color = gx.white
-	additive  bool // Whether to draw the image with additive effect or not.
+	color     gx.Color    = gx.white
+	effect    ImageEffect = .alpha
+}
+
+pub enum ImageEffect {
+	// TODO(FireRedz): Add more effects
+	alpha
+	add
 }
 
 // Rect represents a rectangular shape in `gg`.

--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -17,6 +17,7 @@ pub:
 	rotate    int  // amount to rotate the image in degrees
 	z         f32
 	color     gx.Color = gx.white
+	additive  bool // Whether to draw the image with additive effect or not.
 }
 
 // Rect represents a rectangular shape in `gg`.

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -138,7 +138,7 @@ pub fn (ctx &Context) set_text_cfg(cfg gx.TextCfg) {
 	ctx.ft.fons.set_align(int(cfg.align) | int(cfg.vertical_align))
 	color := sfons.rgba(cfg.color.r, cfg.color.g, cfg.color.b, cfg.color.a)
 	if cfg.color.a != 255 {
-		sgl.load_pipeline(ctx.timage_pip)
+		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	ctx.ft.fons.set_color(color)
 	ascender := f32(0.0)

--- a/vlib/x/ttf/render_sokol_cpu.v
+++ b/vlib/x/ttf/render_sokol_cpu.v
@@ -196,7 +196,7 @@ pub fn (tf_skl TTF_render_Sokol) draw_text_bmp(ctx &gg.Context, x f32, y f32) {
 	]
 	sgl.mult_matrix(m)
 	//
-	sgl.load_pipeline(ctx.timage_pip)
+	sgl.load_pipeline(ctx.pipeline.alpha)
 	sgl.enable_texture()
 	sgl.texture(tf_skl.sg_img)
 	sgl.begin_quads()


### PR DESCRIPTION
This PR changes the way pipeline works in `gg`, Context's `timage_pip` is now deprecated in favour of the new `PipelineContainer` in Context.

## Note

The reason why I'm keeping the `timage_pip` (for now) is because of v ui, some of the code depends on it and I'm not quite sure how to handle it, [here](https://github.com/vlang/ui/blob/62dd926bcdc2b189c34003aa758185303b5f3897/src/interface_drawtextwidget.v#L150) and [here](https://github.com/vlang/ui/blob/8866addcc2758effe4d0bd773840f844921077a7/src/extra_draw.v#L374)

## Changes

* PipelineContainer to store `alpha`, `add` pipeline (more effects will be added later on)
* DrawImageConfig now has a `effect`, which can be used with `ImageEffect` enum.

```v
pub enum ImageEffect {
    // TODO: Add more effects
    alpha
    add
}
```

Instead of using `timage_pip`, we can now do this for example.

```v
if c.a != 255 {
    sgl.load_pipeline(ctx.pipeline.alpha)
}
```

and to use it with image drawing, we can do

```v
window.ctx.draw_image_with_config(
    img: &window.image
    img_id: window.image.id
    img_rect: gg.Rect{
        x: 50,
        y: 0,
        width: window.image.width
        height: window.image.height
    }
    color: gx.Color{255, 0, 0, 255}
    effect: .add // <-- This
)
```

## How it looks like

### **effect: .alpha**
![without](https://user-images.githubusercontent.com/44401509/201337013-658fc1ec-069e-4188-acc8-5ac868513c16.png)

### **effect: .add**
![with](https://user-images.githubusercontent.com/44401509/201337058-8fa68c49-4d0c-4fdb-aec7-04e35530ea03.png)

### **In GIMP**
![image](https://user-images.githubusercontent.com/44401509/201338012-febd79fa-5213-491e-ae60-1a515097612f.png)

## Examples:

https://user-images.githubusercontent.com/44401509/201454232-224f344d-f0e9-4434-9dcf-f34b824d1492.mp4