### PR TITLE
Fix: parse error when required field attribute follows void optional or result type

### DIFF
--- a/vlib/v/parser/tests/struct_field_required_fn_optional_type.out
+++ b/vlib/v/parser/tests/struct_field_required_fn_optional_type.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/struct_field_required_fn_optional_type.vv:6:7: error: field `Foo.foo` must be initialized
+    4 |
+    5 | fn main() {
+    6 |     f := Foo{}
+      |          ~~~~~
+    7 |     println(f)
+    8 | }

--- a/vlib/v/parser/tests/struct_field_required_fn_optional_type.vv
+++ b/vlib/v/parser/tests/struct_field_required_fn_optional_type.vv
@@ -1,0 +1,8 @@
+struct Foo {
+	foo fn() ? [required]
+}
+
+fn main() {
+	f := Foo{}
+	println(f)
+}

--- a/vlib/v/parser/tests/struct_field_required_fn_result_type.out
+++ b/vlib/v/parser/tests/struct_field_required_fn_result_type.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/struct_field_required_fn_result_type.vv:6:7: error: field `Foo.foo` must be initialized
+    4 |
+    5 | fn main() {
+    6 |     f := Foo{}
+      |          ~~~~~
+    7 |     println(f)
+    8 | }

--- a/vlib/v/parser/tests/struct_field_required_fn_result_type.vv
+++ b/vlib/v/parser/tests/struct_field_required_fn_result_type.vv
@@ -1,0 +1,8 @@
+struct Foo {
+	foo fn() ! [required]
+}
+
+fn main() {
+	f := Foo{}
+	println(f)
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

### Summary

When a `required` field attribute follows `void` optional or result type, the parser handles it as an array which results in a type error as reported in #16388. This PR fixes the parser so it handles the field attribute properly.

### Test plan

Run the new tests files and make sure each output is the same with the corresponding output file. For example, let's run the following code.

```v
struct Foo {
	foo fn() ! [required]
}

fn main() {
	f := Foo{}
	println(f)
}
```

It should produce:

```console
vlib/v/parser/tests/struct_field_required_fn_result_type.vv:6:7: error: field `Foo.foo` must be initialized
    4 |
    5 | fn main() {
    6 |     f := Foo{}
      |          ~~~~~
    7 |     println(f)
    8 | }
```

Resolves #16388 