### PR TITLE
checker: fix generic fn casting &u8 to &alias to u32  (fix #16417)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2557,7 +2557,7 @@ pub fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		}
 	} else if mut to_sym.info is ast.Alias && !(final_to_sym.kind == .struct_ && to_type.is_ptr()) {
 		if !c.check_types(from_type, to_sym.info.parent_type) && !(final_to_sym.is_int()
-			&& final_from_sym.kind in [.enum_, .bool, .i8, .char]) {
+			&& final_from_sym.kind in [.enum_, .bool, .i8, .u8, .char]) {
 			ft := c.table.type_to_str(from_type)
 			tt := c.table.type_to_str(to_type)
 			c.error('cannot cast `$ft` to `$tt` (alias to `$final_to_sym.name`)', node.pos)

--- a/vlib/v/tests/generic_fn_cast_to_alias_test.v
+++ b/vlib/v/tests/generic_fn_cast_to_alias_test.v
@@ -1,0 +1,15 @@
+module main
+
+type VkPresentModeKHR = u32
+
+fn create_c_array<T>(len u32) &T {
+	return unsafe { &T(malloc(int(sizeof(T) * len))) }
+}
+
+fn test_generic_fn_cast_to_alias() {
+	arr_vk := create_c_array<VkPresentModeKHR>(5)
+
+	println(typeof(arr_vk).name)
+	assert typeof(arr_vk).name == '&VkPresentModeKHR'
+	unsafe { free(arr_vk) }
+}


### PR DESCRIPTION
This PR fix generic fn casting &u8 to &alias to u32  (fix #16417).

- Fix generic fn casting &u8 to &alias to u32.
- Add test.

```v
module main

type VkPresentModeKHR = u32

fn create_c_array<T>(len u32) &T {
	return unsafe { &T(malloc(int(sizeof(T) * len))) }
}

fn main() {
	arr_vk := create_c_array<VkPresentModeKHR>(5)

	println(typeof(arr_vk).name)
	assert typeof(arr_vk).name == '&VkPresentModeKHR'
	unsafe { free(arr_vk) }
}

PS D:\Test\v\tt1> v run .
&VkPresentModeKHR
```