### PR TITLE
checker,cgen: support `const y = term.yellow`, then `println(y('abc'))`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -580,7 +580,8 @@ pub mut:
 	name               string // left.name()
 	is_method          bool
 	is_field           bool // temp hack, remove ASAP when re-impl CallExpr / Selector (joe)
-	is_fn_var          bool // fn variable
+	is_fn_var          bool // fn variable, `a := fn() {}`, then: `a()`
+	is_fn_a_const      bool // fn const, `const c = abc`, where `abc` is a function, then: `c()`
 	is_keep_alive      bool // GC must not free arguments before fn returns
 	is_noreturn        bool // whether the function/method is marked as [noreturn]
 	is_ctor_new        bool // if JS ctor calls requires `new` before call, marked as `[use_new]` in V
@@ -592,7 +593,8 @@ pub mut:
 	left_type          Type // type of `user`
 	receiver_type      Type // User
 	return_type        Type
-	fn_var_type        Type   // fn variable type
+	fn_var_type        Type   // the fn type, when `is_fn_a_const` or `is_fn_var` is true
+	const_name         string // the fully qualified name of the const, i.e. `main.c`, given `const c = abc`, and callexpr: `c()`
 	should_be_skipped  bool   // true for calls to `[if someflag?]` functions, when there is no `-d someflag`
 	concrete_types     []Type // concrete types, e.g. <int, string>
 	concrete_list_pos  token.Pos

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1434,8 +1434,8 @@ pub fn (t &Table) fn_signature_using_aliases(func &Fn, import_aliases map[string
 	return sb.str()
 }
 
-// Get the name of the complete quanlified name of the type
-// without the generic parts.
+// symbol_name_except_generic return the name of the complete qualified name of the type,
+// but without the generic parts. For example, `main.Abc<int>` -> `main.Abc`
 pub fn (t &TypeSymbol) symbol_name_except_generic() string {
 	// main.Abc<int>
 	mut embed_name := t.name

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -638,6 +638,9 @@ fn (mut g Gen) get_anon_fn_type_name(mut node ast.AnonFn, var_name string) strin
 }
 
 fn (mut g Gen) call_expr(node ast.CallExpr) {
+	if node.should_be_skipped {
+		return
+	}
 	// NOTE: everything could be done this way
 	// see my comment in parser near anon_fn
 	if node.left is ast.AnonFn {
@@ -658,9 +661,6 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		g.is_fn_index_call = false
 	} else if node.left is ast.CallExpr && node.name == '' {
 		g.expr(node.left)
-	}
-	if node.should_be_skipped {
-		return
 	}
 	old_inside_call := g.inside_call
 	g.inside_call = true
@@ -1357,6 +1357,9 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				}
 			}
 		}
+	}
+	if node.is_fn_a_const {
+		name = g.c_const_name(node.const_name.replace('.', '__'))
 	}
 	// TODO2
 	// cgen shouldn't modify ast nodes, this should be moved

--- a/vlib/v/tests/const_name_equals_fn_name_test.v
+++ b/vlib/v/tests/const_name_equals_fn_name_test.v
@@ -1,0 +1,65 @@
+module main
+
+import term
+
+fn abc() {
+	println('xyz')
+}
+
+fn def() string {
+	return 'xyz'
+}
+
+const a_const_that_is_fn = abc
+
+const a_const_that_is_fn_returning_value = def
+
+const a_const_same_as_fn_in_another_module = term.yellow
+
+fn test_simple_fn_assigned_to_const_can_be_called() {
+	a_const_that_is_fn()
+	assert true
+}
+
+fn test_simple_fn_assigned_to_const_can_be_called_and_returns_value() {
+	assert def == a_const_that_is_fn_returning_value
+	assert def() == 'xyz'
+	assert a_const_that_is_fn_returning_value() == 'xyz'
+	assert def() == a_const_that_is_fn_returning_value()
+	assert a_const_that_is_fn_returning_value() == def()
+}
+
+//
+
+fn test_a_const_that_is_alias_to_fn_from_module() {
+	assert a_const_same_as_fn_in_another_module == term.yellow
+	assert term.yellow('x') == a_const_same_as_fn_in_another_module('x')
+	assert ptr_str(term.yellow) == ptr_str(a_const_same_as_fn_in_another_module)
+}
+
+//
+
+const pg = fn_generator()
+
+const pg2 = main.fn_generator()()
+
+fn fn_generator() fn () string {
+	return fn () string {
+		println('hello')
+		return 'ok'
+	}
+}
+
+fn test_a_const_can_be_assigned_a_fn_produced_by_a_fn_generator_and_the_const_can_be_used() {
+	assert main.fn_generator()() == 'ok'
+
+	x := fn_generator()
+	assert x() == 'ok'
+
+	y := pg
+	assert y() == 'ok'
+
+	assert pg() == 'ok'
+
+	assert pg2 == 'ok'
+}


### PR DESCRIPTION
Previously, this was a cgen error:
```v
import term
const y = term.yellow // previously this was a cgen error: incompatible types for redefinition of 'term__yellow'
println(y)
```