### PR TITLE
tests: add unsafe block to enum cast

### DIFF
--- a/vlib/v/tests/bench/bench_compare_tokens.v
+++ b/vlib/v/tests/bench/bench_compare_tokens.v
@@ -15,7 +15,7 @@ fn main() {
 		bmark.measure('${max_repetitions} repetitions of token.keywords["${kw}"] = ${res}')
 
 		for _ in 0 .. max_repetitions {
-			res = token.Kind(km_trie.find(kw))
+			res = unsafe { token.Kind(km_trie.find(kw)) }
 		}
 		bmark.measure('${max_repetitions} repetitions of km_trie.find("${kw}") = ${res}')
 


### PR DESCRIPTION
tests: add unsafe block to enum cast 

In [bench_compare_tokens.v](https://github.com/vlang/v/blob/master/vlib/v/tests/bench/bench_compare_tokens.v) on line 18, the result of `km_trie.find` is cast to an enum without an unsafe block, generating an error.

This pull request fixes this by adding an unsafe block to this line.