### PR TITLE
cgen: fix if expr with sumtype value of map (fix #16427)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -11,7 +11,10 @@ fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 			return true
 		}
 		for branch in node.branches {
-			if branch.cond is ast.IfGuardExpr || branch.stmts.len > 1 {
+			if branch.stmts.len > 1 {
+				return true
+			}
+			if g.need_tmp_var_in_expr(branch.cond) {
 				return true
 			}
 			if branch.stmts.len == 1 {
@@ -34,6 +37,17 @@ fn (mut g Gen) need_tmp_var_in_expr(expr ast.Expr) bool {
 	match expr {
 		ast.IfExpr {
 			if g.need_tmp_var_in_if(expr) {
+				return true
+			}
+		}
+		ast.IfGuardExpr {
+			return true
+		}
+		ast.InfixExpr {
+			if g.need_tmp_var_in_expr(expr.left) {
+				return true
+			}
+			if g.need_tmp_var_in_expr(expr.right) {
 				return true
 			}
 		}

--- a/vlib/v/tests/if_expr_with_sumtype_map_test.v
+++ b/vlib/v/tests/if_expr_with_sumtype_map_test.v
@@ -1,0 +1,24 @@
+module main
+
+type ConfigValue = bool | int | string
+type ConfigMap = map[string]ConfigValue
+
+fn foo(conf ConfigMap) bool {
+	mut bar := false
+	// Check type
+	bar = if conf['baz'] or { false } is bool {
+		conf['baz'] or { false } as bool
+	} else {
+		false
+	} // Default value
+	return bar
+}
+
+fn test_if_expr_with_sumtype_map() {
+	conf := {
+		'baz': ConfigValue(123)
+	}
+	ret := foo(conf)
+	println(ret)
+	assert !ret
+}


### PR DESCRIPTION
This PR fix if expr with sumtype value of map (fix #16427).

- Fix if expr with sumtype value of map.
- Add test.

```v
module main

type ConfigValue = bool | int | string
type ConfigMap = map[string]ConfigValue

fn foo(conf ConfigMap) bool {
	mut bar := false
	// Check type
	bar = if conf['baz'] or { false } is bool {
		conf['baz'] or { false } as bool
	} else {
		false
	} // Default value
	return bar
}

fn main() {
	conf := {
		'baz': ConfigValue(123)
	}
	ret := foo(conf)
	println(ret)
	assert !ret
}

PS D:\Test\v\tt1> v run .
false
```