### PR TITLE
cgen: fix dump(nil), dump(voidptr) (fix #16455)

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -74,6 +74,9 @@ fn (mut g Gen) dump_expr_definitions() {
 			surrounder.add('\tstring value = ${to_string_fn_name}();', '\tstring_free(&value);')
 		} else if dump_sym.kind == .none_ {
 			surrounder.add('\tstring value = _SLIT("none");', '\tstring_free(&value);')
+		} else if is_ptr {
+			surrounder.add('\tstring value = (dump_arg == NULL) ? _SLIT("nil") : ${to_string_fn_name}(${deref}dump_arg);',
+				'\tif (dump_arg != NULL) string_free(&value);')
 		} else {
 			surrounder.add('\tstring value = ${to_string_fn_name}(${deref}dump_arg);',
 				'\tstring_free(&value);')

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -76,7 +76,7 @@ fn (mut g Gen) dump_expr_definitions() {
 			surrounder.add('\tstring value = _SLIT("none");', '\tstring_free(&value);')
 		} else if is_ptr {
 			surrounder.add('\tstring value = (dump_arg == NULL) ? _SLIT("nil") : ${to_string_fn_name}(${deref}dump_arg);',
-				'\tif (dump_arg != NULL) string_free(&value);')
+				'\tstring_free(&value);')
 		} else {
 			surrounder.add('\tstring value = ${to_string_fn_name}(${deref}dump_arg);',
 				'\tstring_free(&value);')

--- a/vlib/v/tests/inout/dump_nil_voidptr.out
+++ b/vlib/v/tests/inout/dump_nil_voidptr.out
@@ -1,0 +1,2 @@
+[vlib/v/tests/inout/dump_nil_voidptr.vv:11] a: &nil
+[vlib/v/tests/inout/dump_nil_voidptr.vv:13] a: &nil

--- a/vlib/v/tests/inout/dump_nil_voidptr.vv
+++ b/vlib/v/tests/inout/dump_nil_voidptr.vv
@@ -1,0 +1,14 @@
+fn get_nil() ?&int {
+	return unsafe { nil }
+}
+
+fn get_voidptr() ?&int {
+	return unsafe { nil }
+}
+
+fn main() {
+	mut a := get_nil()?
+	dump(a)
+	a = get_voidptr()?
+	dump(a)
+}

--- a/vlib/v/tests/inout/dump_nil_voidptr.vv
+++ b/vlib/v/tests/inout/dump_nil_voidptr.vv
@@ -3,7 +3,7 @@ fn get_nil() ?&int {
 }
 
 fn get_voidptr() ?&int {
-	return unsafe { nil }
+	return voidptr(0)
 }
 
 fn main() {


### PR DESCRIPTION
1. Fix #16455
2. Add test.

```v
fn get_nil() ?&int {
	return unsafe { nil }
}

fn get_voidptr() ?&int {
	return voidptr(0)
}

fn main() {
	mut a := get_nil()?
	dump(a)
	a = get_voidptr()?
	dump(a)
}
```

output:

```
[vlib/v/tests/inout/dump_nil_voidptr.vv:11] a: &nil
[vlib/v/tests/inout/dump_nil_voidptr.vv:13] a: &nil
```
