### PR TITLE
checker: fix struct field unsigned type check (fix #16457)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -318,6 +318,14 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						left.expr.is_setter = true
 					}
 				}
+				if left_type in ast.unsigned_integer_type_idxs {
+					if mut right is ast.IntegerLiteral {
+						if right.val[0] == `-` {
+							c.error('Cannot assign negative value to unsigned integer type',
+								right.pos)
+						}
+					}
+				}
 			}
 			else {
 				if mut left is ast.IndexExpr {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -121,6 +121,14 @@ pub fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 					}
 					continue
 				}
+				if field.typ in ast.unsigned_integer_type_idxs {
+					if field.default_expr is ast.IntegerLiteral {
+						if field.default_expr.val[0] == `-` {
+							c.error('Cannot assign negative value to unsigned integer type',
+								field.default_expr.pos)
+						}
+					}
+				}
 				if field.default_expr is ast.UnsafeExpr {
 					if field.default_expr.expr is ast.Nil && !field.typ.is_ptr()
 						&& c.table.sym(field.typ).kind != .function && !field.typ.is_pointer() {
@@ -484,6 +492,14 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 										field.expr.pos)
 								}
 							}
+						}
+					}
+				}
+				if field_info.typ in ast.unsigned_integer_type_idxs {
+					if mut field.expr is ast.IntegerLiteral {
+						if field.expr.val[0] == `-` {
+							c.error('Cannot assign negative value to unsigned integer type',
+								field.expr.pos)
 						}
 					}
 				}

--- a/vlib/v/checker/tests/struct_field_unsign_type_check_err.out
+++ b/vlib/v/checker/tests/struct_field_unsign_type_check_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/struct_field_unsign_type_check_err.vv:3:10: error: Cannot assign negative value to unsigned integer type
+    1 | struct Foo {
+    2 | mut:
+    3 |     n u32 = -1
+      |             ~~
+    4 | }
+    5 |
+vlib/v/checker/tests/struct_field_unsign_type_check_err.vv:8:6: error: Cannot assign negative value to unsigned integer type
+    6 | fn main() {
+    7 |     mut foo := Foo{
+    8 |         n: -1
+      |            ~~
+    9 |     }
+   10 |
+vlib/v/checker/tests/struct_field_unsign_type_check_err.vv:11:10: error: Cannot assign negative value to unsigned integer type
+    9 |     }
+   10 | 
+   11 |     foo.n = -1
+      |             ~~
+   12 | }

--- a/vlib/v/checker/tests/struct_field_unsign_type_check_err.vv
+++ b/vlib/v/checker/tests/struct_field_unsign_type_check_err.vv
@@ -1,0 +1,12 @@
+struct Foo {
+mut:
+	n u32 = -1
+}
+
+fn main() {
+	mut foo := Foo{
+		n: -1
+	}
+
+	foo.n = -1
+}


### PR DESCRIPTION
1. Fix #16457
2. Add test.

```v
struct Foo {
mut:
	n u32 = -1
}

fn main() {
	mut foo := Foo {
		n: -1
	}

	foo.n = -1
}
```

output:

```
vlib/v/checker/tests/struct_field_unsign_type_check_err.vv:3:10: error: Cannot assign negative value to unsigned integer type
    1 | struct Foo {
    2 | mut:
    3 |     n u32 = -1
      |             ~~
    4 | }
    5 |
vlib/v/checker/tests/struct_field_unsign_type_check_err.vv:8:6: error: Cannot assign negative value to unsigned integer type
    6 | fn main() {
    7 |     mut foo := Foo{
    8 |         n: -1
      |            ~~
    9 |     }
   10 |
vlib/v/checker/tests/struct_field_unsign_type_check_err.vv:11:10: error: Cannot assign negative value to unsigned integer type
    9 |     }
   10 | 
   11 |     foo.n = -1
      |             ~~
   12 | }
```

