### PR TITLE
parser: fix if-guard for struct optional fields (fix #16460)

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -113,7 +113,7 @@ fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
 			p.check(.decl_assign)
 			comments << p.eat_comments()
 			expr := p.expr(0)
-			if expr !in [ast.CallExpr, ast.IndexExpr, ast.PrefixExpr] {
+			if expr !in [ast.CallExpr, ast.IndexExpr, ast.PrefixExpr, ast.SelectorExpr] {
 				p.error_with_pos('if guard condition expression is illegal, it should return optional',
 					expr.pos())
 			}

--- a/vlib/v/tests/inout/struct_field_optional.out
+++ b/vlib/v/tests/inout/struct_field_optional.out
@@ -12,11 +12,13 @@
 [vlib/v/tests/inout/struct_field_optional.vv:33] sum: 4
 4
 [vlib/v/tests/inout/struct_field_optional.vv:36] sum: 4
+3
+none
 Foo{
     bar: 3
     baz: 0
 }
-[vlib/v/tests/inout/struct_field_optional.vv:39] f: Foo{
+[vlib/v/tests/inout/struct_field_optional.vv:50] f: Foo{
     bar: 3
     baz: 0
 }

--- a/vlib/v/tests/inout/struct_field_optional.vv
+++ b/vlib/v/tests/inout/struct_field_optional.vv
@@ -34,6 +34,17 @@ fn main() {
 	sum = f.bar or { 123 } + 1
 	println(sum)
 	dump(sum)
+	// `if guard` test
+	if c := f.bar {
+		println(c)
+	} else {
+		println(err)
+	}
+	if c := f.baz {
+		println(c)
+	} else {
+		println(err)
+	}
 	// others test
 	println(f)
 	dump(f)


### PR DESCRIPTION
1. Fix #16460
2. Add test.

```v
struct Foo {
	bar ?int = 1
	baz ?int = none
}

fn main(){
	f := Foo{}

	if a := f.bar {
		println(a)
	} else {
		println(err)
	}

	if a := f.baz {
		println(a)
	} else {
		println(err)
	}
}
```

output:

```
1
none
```
