### PR TITLE
ast, cgen: fix match struct.field? {...}

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -440,7 +440,14 @@ pub fn (x Expr) str() string {
 			return 'ast.SelectExpr'
 		}
 		SelectorExpr {
-			return '${x.expr.str()}.${x.field_name}'
+			propagate_suffix := if x.or_block.kind == .propagate_option {
+				'?'
+			} else if x.or_block.kind == .propagate_result {
+				'!'
+			} else {
+				''
+			}
+			return '${x.expr.str()}.${x.field_name}${propagate_suffix}'
 		}
 		SizeOf {
 			if x.is_type {

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -63,7 +63,9 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 			g.inside_match_result = true
 		}
 	}
-	if node.cond in [ast.Ident, ast.IntegerLiteral, ast.StringLiteral, ast.FloatLiteral] {
+	if node.cond in [ast.Ident, ast.IntegerLiteral, ast.StringLiteral, ast.FloatLiteral]
+		|| (node.cond is ast.SelectorExpr
+		&& (node.cond as ast.SelectorExpr).or_block.kind == .absent) {
 		cond_var = g.expr_string(node.cond)
 	} else {
 		line := if is_expr {

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -63,7 +63,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 			g.inside_match_result = true
 		}
 	}
-	if node.cond in [ast.Ident, ast.SelectorExpr, ast.IntegerLiteral, ast.StringLiteral, ast.FloatLiteral] {
+	if node.cond in [ast.Ident, ast.IntegerLiteral, ast.StringLiteral, ast.FloatLiteral] {
 		cond_var = g.expr_string(node.cond)
 	} else {
 		line := if is_expr {

--- a/vlib/v/tests/inout/struct_field_optional.out
+++ b/vlib/v/tests/inout/struct_field_optional.out
@@ -1,9 +1,9 @@
 1
-[vlib/v/tests/inout/struct_field_optional.vv:11] f.bar: 1
+[vlib/v/tests/inout/struct_field_optional.vv:11] f.bar?: 1
 2
-[vlib/v/tests/inout/struct_field_optional.vv:18] f.bar: 2
+[vlib/v/tests/inout/struct_field_optional.vv:18] f.bar?: 2
 3
-[vlib/v/tests/inout/struct_field_optional.vv:22] f.bar: 3
+[vlib/v/tests/inout/struct_field_optional.vv:22] f.bar?: 3
 3
 [vlib/v/tests/inout/struct_field_optional.vv:26] a: 3
 9999
@@ -14,11 +14,12 @@
 [vlib/v/tests/inout/struct_field_optional.vv:36] sum: 4
 3
 none
+3
 Foo{
     bar: 3
     baz: 0
 }
-[vlib/v/tests/inout/struct_field_optional.vv:50] f: Foo{
+[vlib/v/tests/inout/struct_field_optional.vv:57] f: Foo{
     bar: 3
     baz: 0
 }

--- a/vlib/v/tests/inout/struct_field_optional.vv
+++ b/vlib/v/tests/inout/struct_field_optional.vv
@@ -45,6 +45,13 @@ fn main() {
 	} else {
 		println(err)
 	}
+	// `match` test
+	match f.bar? {
+		f.bar? {
+			println(f.bar?)
+		}
+		else {}
+	}
 	// others test
 	println(f)
 	dump(f)


### PR DESCRIPTION
This PR fix match struct.field? {...}.

```v
struct Foo {
	bar ?int = 1
	baz ?int = none
}

fn main() {
	f := Foo{}

	match f.bar? {
		1 {
			println(1)
		}
		else {
		}
	}
}
```

output:

```
1
```