### PR TITLE
cgen: fix "fn()?.field?" expr cgen error (fix #16482)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3568,7 +3568,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		styp := g.typ(node.typ)
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
-		g.write('${styp} ${tmp_var} = ${node.expr}.${node.field_name};')
+		g.write('${styp} ${tmp_var} = ')
+		g.expr(node.expr)
+		g.write('.${node.field_name}')
 		g.or_block(tmp_var, node.or_block, node.typ)
 		g.write(stmt_str)
 		g.write(' ')

--- a/vlib/v/tests/inout/struct_field_optional.out
+++ b/vlib/v/tests/inout/struct_field_optional.out
@@ -1,17 +1,17 @@
 1
-[vlib/v/tests/inout/struct_field_optional.vv:11] f.bar?: 1
+[vlib/v/tests/inout/struct_field_optional.vv:15] f.bar?: 1
 2
-[vlib/v/tests/inout/struct_field_optional.vv:18] f.bar?: 2
+[vlib/v/tests/inout/struct_field_optional.vv:22] f.bar?: 2
 3
-[vlib/v/tests/inout/struct_field_optional.vv:22] f.bar?: 3
+[vlib/v/tests/inout/struct_field_optional.vv:26] f.bar?: 3
 3
-[vlib/v/tests/inout/struct_field_optional.vv:26] a: 3
+[vlib/v/tests/inout/struct_field_optional.vv:30] a: 3
 9999
-[vlib/v/tests/inout/struct_field_optional.vv:29] b: 9999
+[vlib/v/tests/inout/struct_field_optional.vv:33] b: 9999
 4
-[vlib/v/tests/inout/struct_field_optional.vv:33] sum: 4
+[vlib/v/tests/inout/struct_field_optional.vv:37] sum: 4
 4
-[vlib/v/tests/inout/struct_field_optional.vv:36] sum: 4
+[vlib/v/tests/inout/struct_field_optional.vv:40] sum: 4
 3
 none
 3
@@ -19,7 +19,8 @@ Foo{
     bar: 3
     baz: 0
 }
-[vlib/v/tests/inout/struct_field_optional.vv:57] f: Foo{
+[vlib/v/tests/inout/struct_field_optional.vv:61] f: Foo{
     bar: 3
     baz: 0
 }
+1

--- a/vlib/v/tests/inout/struct_field_optional.vv
+++ b/vlib/v/tests/inout/struct_field_optional.vv
@@ -4,6 +4,10 @@ mut:
 	baz ?int = none
 }
 
+fn get_foo() ?Foo {
+	return Foo{}
+}
+
 fn main() {
 	// `default value` test
 	mut f := Foo{}
@@ -55,4 +59,5 @@ fn main() {
 	// others test
 	println(f)
 	dump(f)
+	println(get_foo()?.bar?)
 }


### PR DESCRIPTION
1. Fix #16482
2. Add test.

```v
struct Foo {
	a ?int
}

fn goo() ?Foo {
	return Foo{}
}

fn main() {
	println(goo()?.a?)
}
```

output:

```
0
```
