### PR TITLE
checker: cleanup obsolete code for compatibility between byteptr and &byte

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -219,18 +219,6 @@ pub fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type,
 	idx_expected := expected.idx()
 	if idx_got in [ast.byteptr_type_idx, ast.charptr_type_idx]
 		|| idx_expected in [ast.byteptr_type_idx, ast.charptr_type_idx] {
-		igot := int(got)
-		iexpected := int(expected)
-		// TODO: remove; transitional compatibility for byteptr === &byte
-		if (igot == ast.byteptr_type_idx && iexpected == 65545)
-			|| (iexpected == ast.byteptr_type_idx && igot == 65545) {
-			return
-		}
-		// TODO: remove; transitional compatibility for charptr === &char
-		if (igot == ast.charptr_type_idx && iexpected == 65551)
-			|| (iexpected == ast.charptr_type_idx && igot == 65551) {
-			return
-		}
 		muls_got := got.nr_muls()
 		muls_expected := expected.nr_muls()
 		if idx_got == ast.byteptr_type_idx && idx_expected == ast.u8_type_idx


### PR DESCRIPTION
This PR just removes code that is no longer needed (added in 0da827f 2021-04-04).