### PR TITLE
cgen: fix comptime optional methods call and optional field (fix #16499 #16465)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -434,8 +434,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				*/
 			}
 			if !cloned {
-				if (var_type.has_flag(.optional) && !val_type.has_flag(.optional))
-					|| (var_type.has_flag(.result) && !val_type.has_flag(.result)) {
+				if !g.inside_comptime_for_field
+					&& ((var_type.has_flag(.optional) && !val_type.has_flag(.optional))
+					|| (var_type.has_flag(.result) && !val_type.has_flag(.result))) {
 					tmp_var := g.new_tmp_var()
 					g.expr_with_tmp_var(val, val_type, var_type, tmp_var)
 				} else if is_fixed_array_var {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -121,6 +121,10 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			}
 			return
 		}
+
+		if !g.inside_call && (m.return_type.has_flag(.optional) || m.return_type.has_flag(.result)) {
+			g.write('(*(${g.base_type(m.return_type)}*)')
+		}
 		// TODO: check argument types
 		g.write('${util.no_dots(sym.name)}_${g.comptime_for_method}(')
 
@@ -165,6 +169,9 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			}
 		}
 		g.write(')')
+		if !g.inside_call && (m.return_type.has_flag(.optional) || m.return_type.has_flag(.result)) {
+			g.write('.data)')
+		}
 		return
 	}
 	mut j := 0

--- a/vlib/v/gen/c/testdata/comptime_optional_call.out
+++ b/vlib/v/gen/c/testdata/comptime_optional_call.out
@@ -1,0 +1,10 @@
+0
+0
+Option(0)
+Option(0)
+Option(error: none)
+Option(error: none)
+1
+1
+println(NIL)
+Option(error: none)

--- a/vlib/v/gen/c/testdata/comptime_optional_call.vv
+++ b/vlib/v/gen/c/testdata/comptime_optional_call.vv
@@ -1,0 +1,28 @@
+struct Foo {
+	foobar int
+	bar    ?int
+	baz    ?int = none
+}
+
+fn (f Foo) bar() int {
+	return 1
+}
+
+fn (f Foo) baz() ?string {
+	return none
+}
+
+fn main() {
+	foo := Foo{}
+
+	$for field in Foo.fields {
+		var := foo.$(field.name)
+		println(var)
+		println(foo.$(field.name))
+	}
+	$for method in Foo.methods {
+		var := foo.$method()
+		println(var)
+		println(foo.$method())
+	}
+}


### PR DESCRIPTION
1. Fix #16499 
2. Fix #16465
3. Add test.

```v
struct Foo {
	foobar int
	bar    ?int
	baz    ?int = none
}

fn (f Foo) bar() int {
	return 1
}

fn (f Foo) baz() ?string {
	return none
}

fn main() {
	foo := Foo{}

	$for field in Foo.fields {
		var := foo.$(field.name)
		println(var)
		println(foo.$(field.name))
	}
	$for method in Foo.methods {
		var := foo.$method()
		println(var)
		println(foo.$method())
	}
}
```

output:

```
0
0
Option(0)
Option(0)
Option(error: none)
Option(error: none)
1
1
println(NIL)
Option(error: none)
```

-------

```v
struct Test {
	a ?int = none
	b ?int
}

fn fuba<U>(val U) {
	$for field in U.fields {
		println(val.$(field.name))
		variable := val.$(field.name)
	}
}

fn main() {
	test := Test{}
	fuba(test)
}
```

output:

```
Option(error: none)
Option(0)
```
