### PR TITLE
checker: fix generic fn with short generic struct init syntax  (fix #16471)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1002,7 +1002,10 @@ pub fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) 
 			continue
 		}
 
-		arg_typ := c.check_expr_opt_call(call_arg.expr, c.expr(call_arg.expr))
+		mut arg_typ := c.check_expr_opt_call(call_arg.expr, c.expr(call_arg.expr))
+		if call_arg.expr is ast.StructInit {
+			arg_typ = c.expr(call_arg.expr)
+		}
 		node.args[i].typ = arg_typ
 		if c.inside_comptime_for_field {
 			if mut call_arg.expr is ast.Ident {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -254,26 +254,35 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				c.error('unknown type `${ct_sym.name}`', node.pos)
 			}
 		}
-		if struct_sym.info.generic_types.len > 0 && struct_sym.info.concrete_types.len == 0
-			&& !node.is_short_syntax {
-			if c.table.cur_concrete_types.len == 0 {
-				c.error('generic struct init must specify type parameter, e.g. Foo<int>',
-					node.pos)
-			} else if node.generic_types.len == 0 {
-				c.error('generic struct init must specify type parameter, e.g. Foo<T>',
-					node.pos)
-			} else if node.generic_types.len > 0
-				&& node.generic_types.len != struct_sym.info.generic_types.len {
-				c.error('generic struct init expects ${struct_sym.info.generic_types.len} generic parameter, but got ${node.generic_types.len}',
-					node.pos)
-			} else if node.generic_types.len > 0 && c.table.cur_fn != unsafe { nil } {
-				for gtyp in node.generic_types {
-					gtyp_name := c.table.sym(gtyp).name
-					if gtyp_name !in c.table.cur_fn.generic_names {
-						cur_generic_names := '(' + c.table.cur_fn.generic_names.join(',') + ')'
-						c.error('generic struct init type parameter `${gtyp_name}` must be within the parameters `${cur_generic_names}` of the current generic function',
-							node.pos)
-						break
+		if struct_sym.info.generic_types.len > 0 && struct_sym.info.concrete_types.len == 0 {
+			if node.is_short_syntax {
+				concrete_types := c.infer_generic_struct_init_concrete_types(node.typ,
+					node)
+				if concrete_types.len > 0 {
+					generic_names := struct_sym.info.generic_types.map(c.table.sym(it).name)
+					node.typ = c.table.unwrap_generic_type(node.typ, generic_names, concrete_types)
+					return node.typ
+				}
+			} else {
+				if c.table.cur_concrete_types.len == 0 {
+					c.error('generic struct init must specify type parameter, e.g. Foo<int>',
+						node.pos)
+				} else if node.generic_types.len == 0 {
+					c.error('generic struct init must specify type parameter, e.g. Foo<T>',
+						node.pos)
+				} else if node.generic_types.len > 0
+					&& node.generic_types.len != struct_sym.info.generic_types.len {
+					c.error('generic struct init expects ${struct_sym.info.generic_types.len} generic parameter, but got ${node.generic_types.len}',
+						node.pos)
+				} else if node.generic_types.len > 0 && c.table.cur_fn != unsafe { nil } {
+					for gtyp in node.generic_types {
+						gtyp_name := c.table.sym(gtyp).name
+						if gtyp_name !in c.table.cur_fn.generic_names {
+							cur_generic_names := '(' + c.table.cur_fn.generic_names.join(',') + ')'
+							c.error('generic struct init type parameter `${gtyp_name}` must be within the parameters `${cur_generic_names}` of the current generic function',
+								node.pos)
+							break
+						}
 					}
 				}
 			}
@@ -447,7 +456,8 @@ pub fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 							c.mark_as_referenced(mut &field.expr, true)
 						}
 					}
-				} else if expr_type != ast.void_type && expr_type_sym.kind != .placeholder {
+				} else if expr_type != ast.void_type && expr_type_sym.kind != .placeholder
+					&& !field_info.typ.has_flag(.generic) {
 					c.check_expected(c.unwrap_generic(expr_type), c.unwrap_generic(field_info.typ)) or {
 						c.error('cannot assign to field `${field_info.name}`: ${err.msg()}',
 							field.pos)

--- a/vlib/v/checker/tests/generics_struct_init_type_parameter_err.out
+++ b/vlib/v/checker/tests/generics_struct_init_type_parameter_err.out
@@ -5,13 +5,6 @@ vlib/v/checker/tests/generics_struct_init_type_parameter_err.vv:6:9: error: gene
       |            ~~~~~~~~~~~~
     7 |         result: res
     8 |     }
-vlib/v/checker/tests/generics_struct_init_type_parameter_err.vv:7:3: error: cannot assign to field `result`: expected `U`, not `int`
-    5 | fn send_1<A, B>(res A, b B) string {
-    6 |     msg := Response<U>{
-    7 |         result: res
-      |         ~~~~~~~~~~~
-    8 |     }
-    9 |     println(b)
 vlib/v/checker/tests/generics_struct_init_type_parameter_err.vv:14:9: error: generic struct init expects 1 generic parameter, but got 2
    12 |
    13 | fn send_2<A, B>(res A, b B) string {
@@ -19,10 +12,3 @@ vlib/v/checker/tests/generics_struct_init_type_parameter_err.vv:14:9: error: gen
       |            ~~~~~~~~~~~~~~~
    15 |         result: res
    16 |     }
-vlib/v/checker/tests/generics_struct_init_type_parameter_err.vv:15:3: error: cannot assign to field `result`: expected `U`, not `int`
-   13 | fn send_2<A, B>(res A, b B) string {
-   14 |     msg := Response<A, B>{
-   15 |         result: res
-      |         ~~~~~~~~~~~
-   16 |     }
-   17 |     println(b)

--- a/vlib/v/tests/generic_fn_with_short_generic_struct_init_syntax_test.v
+++ b/vlib/v/tests/generic_fn_with_short_generic_struct_init_syntax_test.v
@@ -1,0 +1,18 @@
+pub struct EncodeOptions<T> {
+	payload   T
+	key       string
+	algorithm string = 'HS256'
+}
+
+pub fn encode<T>(options EncodeOptions<T>) !string {
+	return 'test'
+}
+
+fn test_generic_fn_with_generic_struct_init_syntax() {
+	payload := {
+		'test': 'test'
+	}
+	ret := encode(payload: payload, key: 'test')!
+	println(ret)
+	assert ret == 'test'
+}


### PR DESCRIPTION
This PR fix generic fn with short generic struct init syntax  (fix #16471).

- Fix generic fn with short generic struct init syntax.
- Add test.

```v
pub struct EncodeOptions<T> {
	payload   T
	key       string
	algorithm string = 'HS256'
}

pub fn encode<T>(options EncodeOptions<T>) !string {
	return 'test'
}

fn main() {
	payload := {
		'test': 'test'
	}
	ret := encode(payload: payload, key: 'test')!
	println(ret)
	assert ret == 'test'
}

PS D:\Test\v\tt1> v run .
test
```