### PR TITLE
checker: check assigning generic function to a variable (fix #16485)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -65,6 +65,11 @@ pub fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				c.error('cannot use `none` in `unsafe` blocks', right.expr.pos)
 			}
 		}
+		if mut right is ast.AnonFn {
+			if right.decl.generic_names.len > 0 {
+				c.error('cannot assign generic function to a variable', right.decl.pos)
+			}
+		}
 	}
 	if node.left.len != right_len {
 		if right_first is ast.CallExpr {

--- a/vlib/v/checker/tests/assign_generic_fn_err.out
+++ b/vlib/v/checker/tests/assign_generic_fn_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/assign_generic_fn_err.vv:2:9: error: cannot assign generic function to a variable
+    1 | fn main() {
+    2 |     fun := fn <T> (value T) T {
+      |            ~~~~~~~~~~~~~~~~~~~~
+    3 |         return value
+    4 |     }
+vlib/v/checker/tests/assign_generic_fn_err.vv:6:13: error: a non generic function called like a generic one
+    4 |     }
+    5 |
+    6 |     println(fun<int>(100))
+      |                ~~~~~
+    7 | }

--- a/vlib/v/checker/tests/assign_generic_fn_err.vv
+++ b/vlib/v/checker/tests/assign_generic_fn_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	fun := fn <T> (value T) T {
+		return value
+	}
+
+	println(fun<int>(100))
+} 


### PR DESCRIPTION
This PR check assigning generic function to a variable (fix #16485).

- Check assigning generic function to a variable.
- Add test.

```v
fn main() {
	fun := fn <T> (value T) T {
		return value
	}

	println(fun<int>(100))
} 

PS D:\Test\v\tt1> v run .
./tt1.v:2:9: error: cannot assign generic function to a variable
    1 | fn main() {
    2 |     fun := fn <T> (value T) T {
      |            ~~~~~~~~~~~~~~~~~~~~
    3 |         return value
    4 |     }
./tt1.v:6:13: error: a non generic function called like a generic one
    4 |     }
    5 |
    6 |     println(fun<int>(100))
      |                ~~~~~
    7 | }
```