### PR TITLE
cgen: fix sumtype with alias fntype variant (fix #16514)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2285,6 +2285,17 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 			got_name := 'fn ${g.table.fn_type_source_signature(got_sym.info.func)}'
 			got_cname = 'anon_fn_${g.table.fn_type_signature(got_sym.info.func)}'
 			type_idx = g.table.type_idxs[got_name].str()
+			exp_info := exp_sym.info as ast.SumType
+			for variant in exp_info.variants {
+				variant_sym := g.table.sym(variant)
+				if variant_sym.info is ast.FnType {
+					if g.table.fn_type_source_signature(variant_sym.info.func) == g.table.fn_type_source_signature(got_sym.info.func) {
+						got_cname = variant_sym.cname
+						type_idx = variant.idx().str()
+						break
+					}
+				}
+			}
 			sb.writeln('static inline ${exp_cname} ${fun.fn_name}(${got_cname} x) {')
 			sb.writeln('\t${got_cname} ptr = x;')
 			is_anon_fn = true

--- a/vlib/v/tests/sumtype_with_alias_fntype_test.v
+++ b/vlib/v/tests/sumtype_with_alias_fntype_test.v
@@ -1,0 +1,37 @@
+struct None {}
+
+type Myfn = fn (int) int
+
+type Myfnfact = fn () Myfn
+
+type Maybefnfact = Myfnfact | None
+
+// Myfn
+fn abc(i int) int {
+	return i
+}
+
+fn run(mmff Maybefnfact) string {
+	match mmff {
+		Myfnfact { return 'yes fn' }
+		None { return 'None fn' }
+	}
+}
+
+fn test_sumtype_with_alias_fntype() {
+	// create Myfn
+	myfnfact := fn () Myfn {
+		return abc
+	}
+	r1 := main.myfnfact()(1)
+	println(r1)
+	assert r1 == 1
+
+	r2 := run(None{})
+	println(r2)
+	assert r2 == 'None fn'
+
+	r3 := run(myfnfact)
+	println(r3)
+	assert r3 == 'yes fn'
+}


### PR DESCRIPTION
This PR fix sumtype with alias fntype variant (fix #16514).

- Fix sumtype with alias fntype variant.
- Add test.

```v
struct None {}

type Myfn = fn (int) int

type Myfnfact = fn () Myfn

type Maybefnfact = Myfnfact | None

// Myfn
fn abc(i int) int {
	return i
}

fn run(mmff Maybefnfact) string {
	match mmff {
		Myfnfact { return 'yes fn' }
		None { return 'None fn' }
	}
}

fn main() {
	// create Myfn
	myfnfact := fn () Myfn {
		return abc
	}
	r1 := main.myfnfact()(1)
	println(r1)
	assert r1 == 1

	r2 := run(None{})
	println(r2)
	assert r2 == 'None fn'

	r3 := run(myfnfact)
	println(r3)
	assert r3 == 'yes fn'
}

PS D:\Test\v\tt1> v run .
1
None fn
yes fn
```