### PR TITLE
cgen: fix fn call of sumtype with alias fntype variant (fix #16514)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2281,25 +2281,23 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	mut sb := strings.new_builder(128)
 	mut is_anon_fn := false
 	if got_sym.info is ast.FnType {
-		if got_sym.info.is_anon || g.table.known_fn(got_sym.name) {
-			got_name := 'fn ${g.table.fn_type_source_signature(got_sym.info.func)}'
-			got_cname = 'anon_fn_${g.table.fn_type_signature(got_sym.info.func)}'
-			type_idx = g.table.type_idxs[got_name].str()
-			exp_info := exp_sym.info as ast.SumType
-			for variant in exp_info.variants {
-				variant_sym := g.table.sym(variant)
-				if variant_sym.info is ast.FnType {
-					if g.table.fn_type_source_signature(variant_sym.info.func) == g.table.fn_type_source_signature(got_sym.info.func) {
-						got_cname = variant_sym.cname
-						type_idx = variant.idx().str()
-						break
-					}
+		got_name := 'fn ${g.table.fn_type_source_signature(got_sym.info.func)}'
+		got_cname = 'anon_fn_${g.table.fn_type_signature(got_sym.info.func)}'
+		type_idx = g.table.type_idxs[got_name].str()
+		exp_info := exp_sym.info as ast.SumType
+		for variant in exp_info.variants {
+			variant_sym := g.table.sym(variant)
+			if variant_sym.info is ast.FnType {
+				if g.table.fn_type_source_signature(variant_sym.info.func) == g.table.fn_type_source_signature(got_sym.info.func) {
+					got_cname = variant_sym.cname
+					type_idx = variant.idx().str()
+					break
 				}
 			}
-			sb.writeln('static inline ${exp_cname} ${fun.fn_name}(${got_cname} x) {')
-			sb.writeln('\t${got_cname} ptr = x;')
-			is_anon_fn = true
 		}
+		sb.writeln('static inline ${exp_cname} ${fun.fn_name}(${got_cname} x) {')
+		sb.writeln('\t${got_cname} ptr = x;')
+		is_anon_fn = true
 	}
 	if !is_anon_fn {
 		sb.writeln('static inline ${exp_cname} ${fun.fn_name}(${got_cname}* x) {')
@@ -2436,8 +2434,8 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	if got_sym.info is ast.FnType {
 		if got_sym.info.is_anon {
 			got_styp = 'anon_fn_${g.table.fn_type_signature(got_sym.info.func)}'
-			got_is_fn = true
 		}
+		got_is_fn = true
 	}
 	if expected_type != ast.void_type {
 		unwrapped_expected_type := g.unwrap_generic(expected_type)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1452,8 +1452,9 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 							}
 						}
 						if obj.smartcasts.len > 0 && is_cast_needed {
-							for _ in obj.smartcasts {
-								g.write('(*')
+							for typ in obj.smartcasts {
+								sym := g.table.sym(typ)
+								g.write('(*(${sym.cname})(')
 							}
 							for i, typ in obj.smartcasts {
 								cast_sym := g.table.sym(g.unwrap_generic(typ))
@@ -1471,7 +1472,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 								} else {
 									g.write('${dot}_${cast_sym.cname}')
 								}
-								g.write(')')
+								g.write('))')
 							}
 							is_fn_var = true
 						} else if obj.is_inherited {

--- a/vlib/v/tests/sumtype_with_alias_fntype_test.v
+++ b/vlib/v/tests/sumtype_with_alias_fntype_test.v
@@ -11,18 +11,25 @@ fn abc(i int) int {
 	return i
 }
 
+// create Myfn
+fn myfnfact() Myfn {
+	return abc
+}
+
+// run fn if exists
 fn run(mmff Maybefnfact) string {
 	match mmff {
-		Myfnfact { return 'yes fn' }
-		None { return 'None fn' }
+		Myfnfact {
+			r := mmff()
+			return 'yes fn: ${r}'
+		}
+		None {
+			return 'None fn'
+		}
 	}
 }
 
 fn test_sumtype_with_alias_fntype() {
-	// create Myfn
-	myfnfact := fn () Myfn {
-		return abc
-	}
 	r1 := main.myfnfact()(1)
 	println(r1)
 	assert r1 == 1
@@ -33,5 +40,5 @@ fn test_sumtype_with_alias_fntype() {
 
 	r3 := run(myfnfact)
 	println(r3)
-	assert r3 == 'yes fn'
+	assert r3 == 'yes fn: fn (int) int'
 }


### PR DESCRIPTION
This PR fix fn call of sumtype with alias fntype variant (fix #16514).

- Fix fn call of sumtype with alias fntype variant.
- Add test.

```v
struct None {}

type Myfn = fn (int) int

type Myfnfact = fn () Myfn

type Maybefnfact = Myfnfact | None

// Myfn
fn abc(i int) int {
	return i
}

// create Myfn
fn myfnfact() Myfn {
	return abc
}

// run fn if exists
fn run(mmff Maybefnfact) string {
	match mmff {
		Myfnfact {
			r := mmff()
			return 'yes fn: ${r}'
		}
		None {
			return 'None fn'
		}
	}
}

fn main() {
	r1 := main.myfnfact()(1)
	println(r1)
	assert r1 == 1

	r2 := run(None{})
	println(r2)
	assert r2 == 'None fn'

	r3 := run(myfnfact)
	println(r3)
	assert r3 == 'yes fn: fn (int) int'
}

PS D:\Test\v\tt1> v run .
1
None fn
yes fn: fn (int) int
```