### PR TITLE
checker: perfect infer_struct_generic_types()

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -256,8 +256,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 		}
 		if struct_sym.info.generic_types.len > 0 && struct_sym.info.concrete_types.len == 0 {
 			if node.is_short_syntax {
-				concrete_types := c.infer_generic_struct_init_concrete_types(node.typ,
-					node)
+				concrete_types := c.infer_struct_generic_types(node.typ, node)
 				if concrete_types.len > 0 {
 					generic_names := struct_sym.info.generic_types.map(c.table.sym(it).name)
 					node.typ = c.table.unwrap_generic_type(node.typ, generic_names, concrete_types)


### PR DESCRIPTION
This PR perfect infer_struct_generic_types().

- Change `infer_generic_struct_init_concrete_types()` to `infer_struct_generic_types()`.
- Add `.function` processing.