### PR TITLE
generic: replace generic <> with []

### DIFF
--- a/vlib/hash/fnv1a/fnv1a.v
+++ b/vlib/hash/fnv1a/fnv1a.v
@@ -33,7 +33,7 @@ pub fn sum32(data []u8) u32 {
 
 // sum32_bytes returns a fnv1a hash of the struct `s`.
 [direct_array_access; inline]
-pub fn sum32_struct<T>(s &T) u32 {
+pub fn sum32_struct[T](s &T) u32 {
 	bp := unsafe { &u8(s) }
 	sz := int(sizeof(T))
 	mut hash := fnv1a.fnv32_offset_basis
@@ -88,7 +88,7 @@ pub fn sum64_bytes(data &u8, data_len int) u64 {
 
 // sum64_bytes returns a fnv1a hash of the struct `s`.
 [direct_array_access; inline]
-pub fn sum64_struct<T>(s &T) u64 {
+pub fn sum64_struct[T](s &T) u64 {
 	bp := unsafe { &u8(s) }
 	sz := int(sizeof(T))
 	mut hash := fnv1a.fnv64_offset_basis

--- a/vlib/math/mathutil.v
+++ b/vlib/math/mathutil.v
@@ -5,18 +5,18 @@ module math
 
 // min returns the minimum of `a` and `b`
 [inline]
-pub fn min<T>(a T, b T) T {
+pub fn min[T](a T, b T) T {
 	return if a < b { a } else { b }
 }
 
 // max returns the maximum of `a` and `b`
 [inline]
-pub fn max<T>(a T, b T) T {
+pub fn max[T](a T, b T) T {
 	return if a > b { a } else { b }
 }
 
 // abs returns the absolute value of `a`
 [inline]
-pub fn abs<T>(a T) T {
+pub fn abs[T](a T) T {
 	return if a < 0 { -a } else { a }
 }

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -588,7 +588,7 @@ fn error_size_of_type_0() IError {
 }
 
 // read_struct reads a single struct of type `T`
-pub fn (mut f File) read_struct<T>(mut t T) ! {
+pub fn (mut f File) read_struct[T](mut t T) ! {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -603,7 +603,7 @@ pub fn (mut f File) read_struct<T>(mut t T) ! {
 }
 
 // read_struct_at reads a single struct of type `T` at position specified in file
-pub fn (mut f File) read_struct_at<T>(mut t T, pos u64) ! {
+pub fn (mut f File) read_struct_at[T](mut t T, pos u64) ! {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -634,7 +634,7 @@ pub fn (mut f File) read_struct_at<T>(mut t T, pos u64) ! {
 }
 
 // read_raw reads and returns a single instance of type `T`
-pub fn (mut f File) read_raw<T>() !T {
+pub fn (mut f File) read_raw[T]() !T {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -651,7 +651,7 @@ pub fn (mut f File) read_raw<T>() !T {
 }
 
 // read_raw_at reads and returns a single instance of type `T` starting at file byte offset `pos`
-pub fn (mut f File) read_raw_at<T>(pos u64) !T {
+pub fn (mut f File) read_raw_at[T](pos u64) !T {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -697,7 +697,7 @@ pub fn (mut f File) read_raw_at<T>(pos u64) !T {
 }
 
 // write_struct writes a single struct of type `T`
-pub fn (mut f File) write_struct<T>(t &T) ! {
+pub fn (mut f File) write_struct[T](t &T) ! {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -716,7 +716,7 @@ pub fn (mut f File) write_struct<T>(t &T) ! {
 }
 
 // write_struct_at writes a single struct of type `T` at position specified in file
-pub fn (mut f File) write_struct_at<T>(t &T, pos u64) ! {
+pub fn (mut f File) write_struct_at[T](t &T, pos u64) ! {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -753,7 +753,7 @@ pub fn (mut f File) write_struct_at<T>(t &T, pos u64) ! {
 // TODO `write_raw[_at]` implementations are copy-pasted from `write_struct[_at]`
 
 // write_raw writes a single instance of type `T`
-pub fn (mut f File) write_raw<T>(t &T) ! {
+pub fn (mut f File) write_raw[T](t &T) ! {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}
@@ -772,7 +772,7 @@ pub fn (mut f File) write_raw<T>(t &T) ! {
 }
 
 // write_raw_at writes a single instance of type `T` starting at file byte offset `pos`
-pub fn (mut f File) write_raw_at<T>(t &T, pos u64) ! {
+pub fn (mut f File) write_raw_at[T](t &T, pos u64) ! {
 	if !f.is_opened {
 		return error_file_not_opened()
 	}

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -598,7 +598,7 @@ pub fn get_raw_stdin() []u8 {
 }
 
 // read_file_array reads an array of `T` values from file `path`.
-pub fn read_file_array<T>(path string) []T {
+pub fn read_file_array[T](path string) []T {
 	a := T{}
 	tsize := int(sizeof(a))
 	// prepare for reading, get current file size

--- a/vlib/rand/config/config.v
+++ b/vlib/rand/config/config.v
@@ -36,7 +36,7 @@ pub:
 }
 
 // validate_for is a helper function for validating the configuration struct for the given array.
-pub fn (config ShuffleConfigStruct) validate_for<T>(a []T) ! {
+pub fn (config ShuffleConfigStruct) validate_for[T](a []T) ! {
 	if config.start < 0 || config.start >= a.len {
 		return error("argument 'config.start' must be in range [0, a.len)")
 	}

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -342,7 +342,7 @@ pub fn (mut rng PRNG) exponential(lambda f64) f64 {
 // optional and the entire array is shuffled by default. Leave the end as 0 to
 // shuffle all elements until the end.
 [direct_array_access]
-pub fn (mut rng PRNG) shuffle<T>(mut a []T, config config.ShuffleConfigStruct) ! {
+pub fn (mut rng PRNG) shuffle[T](mut a []T, config config.ShuffleConfigStruct) ! {
 	config.validate_for(a)!
 	new_end := if config.end == 0 { a.len } else { config.end }
 
@@ -360,23 +360,23 @@ pub fn (mut rng PRNG) shuffle<T>(mut a []T, config config.ShuffleConfigStruct) !
 
 // shuffle_clone returns a random permutation of the elements in `a`.
 // The permutation is done on a fresh clone of `a`, so `a` remains unchanged.
-pub fn (mut rng PRNG) shuffle_clone<T>(a []T, config config.ShuffleConfigStruct) ![]T {
+pub fn (mut rng PRNG) shuffle_clone[T](a []T, config config.ShuffleConfigStruct) ![]T {
 	mut res := a.clone()
-	rng.shuffle<T>(mut res, config)!
+	rng.shuffle[T](mut res, config)!
 	return res
 }
 
 // choose samples k elements from the array without replacement.
 // This means the indices cannot repeat and it restricts the sample size to be less than or equal to the size of the given array.
 // Note that if the array has repeating elements, then the sample may have repeats as well.
-pub fn (mut rng PRNG) choose<T>(array []T, k int) ![]T {
+pub fn (mut rng PRNG) choose[T](array []T, k int) ![]T {
 	n := array.len
 	if k > n {
 		return error('Cannot choose ${k} elements without replacement from a ${n}-element array.')
 	}
 	mut results := []T{len: k}
 	mut indices := []int{len: n, init: it}
-	rng.shuffle<int>(mut indices)!
+	rng.shuffle[int](mut indices)!
 	for i in 0 .. k {
 		results[i] = array[indices[i]]
 	}
@@ -385,7 +385,7 @@ pub fn (mut rng PRNG) choose<T>(array []T, k int) ![]T {
 
 // element returns a random element from the given array.
 // Note that all the positions in the array have an equal chance of being selected. This means that if the array has repeating elements, then the probability of selecting a particular element is not uniform.
-pub fn (mut rng PRNG) element<T>(array []T) !T {
+pub fn (mut rng PRNG) element[T](array []T) !T {
 	if array.len == 0 {
 		return error('Cannot choose an element from an empty array.')
 	}
@@ -394,7 +394,7 @@ pub fn (mut rng PRNG) element<T>(array []T) !T {
 
 // sample samples k elements from the array with replacement.
 // This means the elements can repeat and the size of the sample may exceed the size of the array.
-pub fn (mut rng PRNG) sample<T>(array []T, k int) []T {
+pub fn (mut rng PRNG) sample[T](array []T, k int) []T {
 	mut results := []T{len: k}
 	for i in 0 .. k {
 		results[i] = array[rng.intn(array.len) or { 0 }]
@@ -599,33 +599,33 @@ pub fn ascii(len int) string {
 // shuffle randomly permutates the elements in `a`. The range for shuffling is
 // optional and the entire array is shuffled by default. Leave the end as 0 to
 // shuffle all elements until the end.
-pub fn shuffle<T>(mut a []T, config config.ShuffleConfigStruct) ! {
-	default_rng.shuffle<T>(mut a, config)!
+pub fn shuffle[T](mut a []T, config config.ShuffleConfigStruct) ! {
+	default_rng.shuffle[T](mut a, config)!
 }
 
 // shuffle_clone returns a random permutation of the elements in `a`.
 // The permutation is done on a fresh clone of `a`, so `a` remains unchanged.
-pub fn shuffle_clone<T>(a []T, config config.ShuffleConfigStruct) ![]T {
-	return default_rng.shuffle_clone<T>(a, config)
+pub fn shuffle_clone[T](a []T, config config.ShuffleConfigStruct) ![]T {
+	return default_rng.shuffle_clone[T](a, config)
 }
 
 // choose samples k elements from the array without replacement.
 // This means the indices cannot repeat and it restricts the sample size to be less than or equal to the size of the given array.
 // Note that if the array has repeating elements, then the sample may have repeats as well.
-pub fn choose<T>(array []T, k int) ![]T {
-	return default_rng.choose<T>(array, k)
+pub fn choose[T](array []T, k int) ![]T {
+	return default_rng.choose[T](array, k)
 }
 
 // element returns a random element from the given array.
 // Note that all the positions in the array have an equal chance of being selected. This means that if the array has repeating elements, then the probability of selecting a particular element is not uniform.
-pub fn element<T>(array []T) !T {
-	return default_rng.element<T>(array)
+pub fn element[T](array []T) !T {
+	return default_rng.element[T](array)
 }
 
 // sample samples k elements from the array with replacement.
 // This means the elements can repeat and the size of the sample may exceed the size of the array.
-pub fn sample<T>(array []T, k int) []T {
-	return default_rng.sample<T>(array, k)
+pub fn sample[T](array []T, k int) []T {
+	return default_rng.sample[T](array, k)
 }
 
 // bernoulli returns true with a probability p. Note that 0 <= p <= 1.

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -58,7 +58,7 @@ pub:
 	cap u32 // queue length in #objects
 }
 
-pub fn new_channel<T>(n u32) &Channel {
+pub fn new_channel[T](n u32) &Channel {
 	st := sizeof(T)
 	if isreftype(T) {
 		return new_channel_st(n, st)

--- a/vlib/sync/pool/pool.v
+++ b/vlib/sync/pool/pool.v
@@ -72,7 +72,7 @@ pub fn (mut pool PoolProcessor) set_max_jobs(njobs int) {
 // by the number of available cores on the system.
 // work_on_items returns *after* all threads finish.
 // You can optionally call get_results after that.
-pub fn (mut pool PoolProcessor) work_on_items<T>(items []T) {
+pub fn (mut pool PoolProcessor) work_on_items[T](items []T) {
 	pool.work_on_pointers(unsafe { items.pointers() })
 }
 
@@ -117,18 +117,18 @@ fn process_in_thread(mut pool PoolProcessor, task_id int) {
 
 // get_item - called by the worker callback.
 // Retrieves a type safe instance of the currently processed item
-pub fn (pool &PoolProcessor) get_item<T>(idx int) T {
+pub fn (pool &PoolProcessor) get_item[T](idx int) T {
 	return *(&T(pool.items[idx]))
 }
 
 // get_result - called by the main thread to get a specific result.
 // Retrieves a type safe instance of the produced result.
-pub fn (pool &PoolProcessor) get_result<T>(idx int) T {
+pub fn (pool &PoolProcessor) get_result[T](idx int) T {
 	return *(&T(pool.results[idx]))
 }
 
 // get_results - get a list of type safe results in the main thread.
-pub fn (pool &PoolProcessor) get_results<T>() []T {
+pub fn (pool &PoolProcessor) get_results[T]() []T {
 	mut res := []T{cap: pool.results.len}
 	for i in 0 .. pool.results.len {
 		res << *(&T(pool.results[i]))
@@ -137,7 +137,7 @@ pub fn (pool &PoolProcessor) get_results<T>() []T {
 }
 
 // get_results_ref - get a list of type safe results in the main thread.
-pub fn (pool &PoolProcessor) get_results_ref<T>() []&T {
+pub fn (pool &PoolProcessor) get_results_ref[T]() []&T {
 	mut res := []&T{cap: pool.results.len}
 	for i in 0 .. pool.results.len {
 		res << &T(pool.results[i])

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -69,7 +69,7 @@ fn parallel_cc(mut b builder.Builder, header string, res string, out_str string,
 }
 
 fn build_parallel_o_cb(mut p pool.PoolProcessor, idx int, wid int) voidptr {
-	postfix := p.get_item<string>(idx)
+	postfix := p.get_item[string](idx)
 	sw := time.new_stopwatch()
 	cmd := '${os.quoted_path(cbuilder.cc_compiler)} ${cbuilder.cc_cflags} -c -w -o out_${postfix}.o out_${postfix}.c'
 	res := os.execute(cmd)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -332,7 +332,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) (string,
 		pp.work_on_items(files)
 		global_g.timers.start('cgen unification')
 		// tg = thread gen
-		for g in pp.get_results_ref<Gen>() {
+		for g in pp.get_results_ref[Gen]() {
 			global_g.embedded_files << g.embedded_files
 			global_g.out.write(g.out) or { panic(err) }
 			global_g.cheaders.write(g.cheaders) or { panic(err) }
@@ -603,7 +603,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref &pref.Preferences) (string,
 }
 
 fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) &Gen {
-	file := p.get_item<&ast.File>(idx)
+	file := p.get_item[&ast.File](idx)
 	mut global_g := &Gen(p.get_shared_context())
 	mut g := &Gen{
 		file: file

--- a/vlib/v/mathutil/mathutil.v
+++ b/vlib/v/mathutil/mathutil.v
@@ -4,16 +4,16 @@
 module mathutil
 
 [inline]
-pub fn min<T>(a T, b T) T {
+pub fn min[T](a T, b T) T {
 	return if a < b { a } else { b }
 }
 
 [inline]
-pub fn max<T>(a T, b T) T {
+pub fn max[T](a T, b T) T {
 	return if a > b { a } else { b }
 }
 
 [inline]
-pub fn abs<T>(a T) T {
+pub fn abs[T](a T) T {
 	return if a > 0 { a } else { -a }
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -35,8 +35,8 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 
 	mut concrete_types := []ast.Type{}
 	mut concrete_list_pos := p.tok.pos()
-	if p.tok.kind == .lt {
-		// `foo<int>(10)`
+	if p.tok.kind == .lsbr {
+		// `foo[int](10)`
 		p.expr_mod = ''
 		concrete_types = p.parse_concrete_types()
 		concrete_list_pos = concrete_list_pos.extend(p.prev_tok.pos())
@@ -333,7 +333,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			scope: 0
 		}
 	}
-	// <T>
+	// [T]
 	_, mut generic_names := p.parse_generic_types()
 	// generic names can be infer with receiver's generic names
 	if is_method && rec.typ.has_flag(.generic) {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -629,7 +629,7 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 						if name.len == 1 && name[0].is_capital() {
 							return p.parse_generic_type(name)
 						}
-						if p.tok.kind == .lt {
+						if p.tok.kind == .lsbr && p.tok.pos - p.prev_tok.pos == p.prev_tok.len {
 							return p.parse_generic_inst_type(name)
 						}
 						return p.find_type_or_add_placeholder(name, language)
@@ -674,7 +674,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	start_pos := p.tok.pos()
 	p.next()
 	p.inside_generic_params = true
-	bs_name += '<'
+	bs_name += '['
 	bs_cname += '_T_'
 	mut concrete_types := []ast.Type{}
 	mut is_instance := false
@@ -707,9 +707,9 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 		p.struct_init_generic_types = concrete_types
 	}
 	concrete_types_pos := start_pos.extend(p.tok.pos())
-	p.check(.gt)
+	p.check(.rsbr)
 	p.inside_generic_params = false
-	bs_name += '>'
+	bs_name += ']'
 	// fmt operates on a per-file basis, so is_instance might be not set correctly. Thus it's ignored.
 	if (is_instance || p.pref.is_fmt) && concrete_types.len > 0 {
 		mut gt_idx := p.table.find_type_idx(bs_name)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -624,7 +624,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_mut = true
 			mut_pos = fields.len
 		}
-		if p.peek_tok.kind == .lt {
+		if p.peek_tok.kind == .lsbr {
 			p.error_with_pos("no need to add generic type names in generic interface's method",
 				p.peek_tok.pos())
 			return ast.InterfaceDecl{}

--- a/vlib/v/token/keywords_matcher_trie.v
+++ b/vlib/v/token/keywords_matcher_trie.v
@@ -62,7 +62,7 @@ pub fn (mut km KeywordsMatcherTrie) add_word(word string, value int) {
 
 // new_keywords_matcher_trie creates a new KeywordsMatcherTrie instance from a given map
 // with string keys, and integer or enum values.
-pub fn new_keywords_matcher_trie<T>(kw_map map[string]T) KeywordsMatcherTrie {
+pub fn new_keywords_matcher_trie[T](kw_map map[string]T) KeywordsMatcherTrie {
 	mut km := KeywordsMatcherTrie{
 		nodes: []&TrieNode{cap: 20}
 	}
@@ -85,7 +85,7 @@ pub fn new_keywords_matcher_from_array_trie(names []string) KeywordsMatcherTrie 
 	for i, name in names {
 		m[name] = i
 	}
-	return new_keywords_matcher_trie<int>(m)
+	return new_keywords_matcher_trie[int](m)
 }
 
 //

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -190,7 +190,7 @@ pub const (
 	keywords        = build_keys()
 )
 
-pub const scanner_matcher = new_keywords_matcher_trie<Kind>(keywords)
+pub const scanner_matcher = new_keywords_matcher_trie[Kind](keywords)
 
 // build_keys genereates a map with keywords' string values:
 // Keywords['return'] == .key_return


### PR DESCRIPTION
This PR replace generic `<>` with `[]`.

Because this is a break change, I don't know how to push the PR partly.
@spytheman  Could you help me?

```v
struct Tuple[K, V] {
	a K
	b V
}

// map to array of key-value tuples
fn map_to_array[K, V](m map[K]V) []Tuple[K, V] {
	mut r := []Tuple[K, V]{cap: m.len}
	for k, v in m {
		r << Tuple[K, V]{k, v}
	}
	return r
}

fn main() {
	x := {
		'one': 1
		'two': 2
	}
	println(x)
	println(map_to_array(x))
}

PS D:\Test\v\tt1> v run .
{'one': 1, 'two': 2}
[Tuple<string, int>{
    a: 'one'
    b: 1
}, Tuple<string, int>{
    a: 'two'
    b: 2
}]
```