### PR TITLE
generic: replace generic `<>` with `[]` part 1

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -35,7 +35,7 @@ pub fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr 
 
 	mut concrete_types := []ast.Type{}
 	mut concrete_list_pos := p.tok.pos()
-	if p.tok.kind == .lt {
+	if p.tok.kind in [.lt, .lsbr] {
 		// `foo<int>(10)`
 		p.expr_mod = ''
 		concrete_types = p.parse_concrete_types()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -675,7 +675,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	start_pos := p.tok.pos()
 	p.next()
 	p.inside_generic_params = true
-	bs_name += '['
+	bs_name += '<'
 	bs_cname += '_T_'
 	mut concrete_types := []ast.Type{}
 	mut is_instance := false
@@ -710,7 +710,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	concrete_types_pos := start_pos.extend(p.tok.pos())
 	p.next()
 	p.inside_generic_params = false
-	bs_name += ']'
+	bs_name += '>'
 	// fmt operates on a per-file basis, so is_instance might be not set correctly. Thus it's ignored.
 	if (is_instance || p.pref.is_fmt) && concrete_types.len > 0 {
 		mut gt_idx := p.table.find_type_idx(bs_name)

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -629,7 +629,8 @@ pub fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_d
 						if name.len == 1 && name[0].is_capital() {
 							return p.parse_generic_type(name)
 						}
-						if p.tok.kind == .lt {
+						if p.tok.kind in [.lt, .lsbr]
+							&& p.tok.pos - p.prev_tok.pos == p.prev_tok.len {
 							return p.parse_generic_inst_type(name)
 						}
 						return p.find_type_or_add_placeholder(name, language)
@@ -674,7 +675,7 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	start_pos := p.tok.pos()
 	p.next()
 	p.inside_generic_params = true
-	bs_name += '<'
+	bs_name += '['
 	bs_cname += '_T_'
 	mut concrete_types := []ast.Type{}
 	mut is_instance := false
@@ -707,9 +708,9 @@ pub fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 		p.struct_init_generic_types = concrete_types
 	}
 	concrete_types_pos := start_pos.extend(p.tok.pos())
-	p.check(.gt)
+	p.next()
 	p.inside_generic_params = false
-	bs_name += '>'
+	bs_name += ']'
 	// fmt operates on a per-file basis, so is_instance might be not set correctly. Thus it's ignored.
 	if (is_instance || p.pref.is_fmt) && concrete_types.len > 0 {
 		mut gt_idx := p.table.find_type_idx(bs_name)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2219,6 +2219,9 @@ fn (p &Parser) is_generic_call() bool {
 			mut i := 3
 			for {
 				cur_tok := p.peek_token(i)
+				if cur_tok.kind == .eof || cur_tok.kind !in [.dot, .comma, .name] {
+					break
+				}
 				if cur_tok.kind == .rsbr {
 					after_tok := p.peek_token(i + 1)
 					if after_tok.kind == .lpar {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2513,7 +2513,7 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				}
 			}
 		}
-	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind in [.lt, .lsbr] && lit0_is_capital))
+	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind == .lt && lit0_is_capital))
 		&& (!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital))
 		&& !p.inside_match_case && (!p.inside_if || p.inside_select)
 		&& (!p.inside_for || p.inside_select) && !known_var {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2216,11 +2216,17 @@ fn (p &Parser) is_generic_call() bool {
 				else { false }
 			}
 		} else if p.peek_tok.kind == .lsbr {
-			return match kind3 {
-				.rsbr { p.is_typename(tok2) && tok4.kind == .lpar }
-				.comma { p.is_typename(tok2) } // case 5
-				.dot { kind4 == .name && tok4.lit[0].is_capital() && tok5.kind != .dot }
-				else { false }
+			mut i := 3
+			for {
+				cur_tok := p.peek_token(i)
+				if cur_tok.kind == .rsbr {
+					after_tok := p.peek_token(i + 1)
+					if after_tok.kind == .lpar {
+						return true
+					}
+					break
+				}
+				i++
 			}
 		}
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2219,7 +2219,7 @@ fn (p &Parser) is_generic_call() bool {
 			mut i := 3
 			for {
 				cur_tok := p.peek_token(i)
-				if cur_tok.kind == .eof || cur_tok.kind !in [.dot, .comma, .name] {
+				if cur_tok.kind == .eof || cur_tok.kind !in [.dot, .comma, .name, .rsbr] {
 					break
 				}
 				if cur_tok.kind == .rsbr {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2217,10 +2217,9 @@ fn (p &Parser) is_generic_call() bool {
 			}
 		} else if p.peek_tok.kind == .lsbr {
 			return match kind3 {
-				.rsbr { p.is_typename(tok2) }
-				//.lsbr { !(tok4.lit.len == 1 && tok4.lit[0].is_capital()) } // case 4
+				.rsbr { p.is_typename(tok2) && tok4.kind == .lpar }
 				.comma { p.is_typename(tok2) } // case 5
-				.dot { kind4 == .name && tok4.lit[0].is_capital() }
+				.dot { kind4 == .name && tok4.lit[0].is_capital() && tok5.kind != .dot }
 				else { false }
 			}
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2219,7 +2219,8 @@ fn (p &Parser) is_generic_call() bool {
 			mut i := 3
 			for {
 				cur_tok := p.peek_token(i)
-				if cur_tok.kind == .eof || cur_tok.kind !in [.dot, .comma, .name, .rsbr] {
+				if cur_tok.kind == .eof
+					|| cur_tok.kind !in [.amp, .dot, .comma, .name, .lsbr, .rsbr] {
 					break
 				}
 				if cur_tok.kind == .rsbr {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2513,7 +2513,8 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 				}
 			}
 		}
-	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind == .lt && lit0_is_capital))
+	} else if (p.peek_tok.kind == .lcbr || (p.peek_tok.kind in [.lt, .lsbr] && lit0_is_capital
+		&& p.peek_tok.pos - p.tok.pos == p.tok.len))
 		&& (!p.inside_match || (p.inside_select && prev_tok_kind == .arrow && lit0_is_capital))
 		&& !p.inside_match_case && (!p.inside_if || p.inside_select)
 		&& (!p.inside_for || p.inside_select) && !known_var {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -624,7 +624,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_mut = true
 			mut_pos = fields.len
 		}
-		if p.peek_tok.kind == .lt {
+		if p.peek_tok.kind in [.lt, .lsbr] {
 			p.error_with_pos("no need to add generic type names in generic interface's method",
 				p.peek_tok.pos())
 			return ast.InterfaceDecl{}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -624,7 +624,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_mut = true
 			mut_pos = fields.len
 		}
-		if p.peek_tok.kind in [.lt, .lsbr] {
+		if p.peek_tok.kind == .lt {
 			p.error_with_pos("no need to add generic type names in generic interface's method",
 				p.peek_tok.pos())
 			return ast.InterfaceDecl{}


### PR DESCRIPTION
This PR replace generic `<>` with `[]` part 1.

- Add `[]` in addition to `<>`.

```v
struct Tuple[K, V] {
	a K
	b V
}

// map to array of key-value tuples
fn map_to_array[K, V](m map[K]V) []Tuple[K, V] {
	mut r := []Tuple[K, V]{cap: m.len}
	for k, v in m {
		r << Tuple[K, V]{k, v}
	}
	return r
}

fn main() {
	x := {
		'one': 1
		'two': 2
	}
	println(x)
	println(map_to_array(x))
}

PS D:\Test\v\tt1> v run .
{'one': 1, 'two': 2}
[Tuple<string, int>{
    a: 'one'
    b: 1
}, Tuple<string, int>{
    a: 'two'
    b: 2
}]
```