### PR TITLE
datatypes: fix fsm.set_state() and cleanup fsm module

### DIFF
--- a/vlib/datatypes/fsm/fsm.v
+++ b/vlib/datatypes/fsm/fsm.v
@@ -28,11 +28,11 @@ pub fn new() StateMachine {
 	return StateMachine{}
 }
 
-pub fn (mut s StateMachine) set_state(name string) ? {
+pub fn (mut s StateMachine) set_state(name string) ! {
 	if name in s.states {
 		s.current_state = name
 	} else {
-		return none
+		return error('unknown state: ${name}')
 	}
 }
 
@@ -63,7 +63,7 @@ pub fn (mut s StateMachine) add_transition(from string, to string, condition_han
 	s.transitions[from] = [t]
 }
 
-pub fn (mut s StateMachine) run(receiver voidptr) ? {
+pub fn (mut s StateMachine) run(receiver voidptr) ! {
 	from_state := s.current_state
 	mut to_state := s.current_state
 	if transitions := s.transitions[s.current_state] {
@@ -76,7 +76,7 @@ pub fn (mut s StateMachine) run(receiver voidptr) ? {
 		}
 	} else {
 		s.states[s.current_state].run_handler(receiver, from_state, to_state)
-		return none
+		return error('no more transitions')
 	}
 	s.states[s.current_state].run_handler(receiver, from_state, to_state)
 }

--- a/vlib/datatypes/fsm/fsm.v
+++ b/vlib/datatypes/fsm/fsm.v
@@ -31,8 +31,9 @@ pub fn new() StateMachine {
 pub fn (mut s StateMachine) set_state(name string) ? {
 	if name in s.states {
 		s.current_state = name
+	} else {
+		return none
 	}
-	return error('unknown state: ${name}')
 }
 
 pub fn (mut s StateMachine) get_state() string {
@@ -75,7 +76,7 @@ pub fn (mut s StateMachine) run(receiver voidptr) ? {
 		}
 	} else {
 		s.states[s.current_state].run_handler(receiver, from_state, to_state)
-		return error('no more transitions')
+		return none
 	}
 	s.states[s.current_state].run_handler(receiver, from_state, to_state)
 }

--- a/vlib/datatypes/fsm/fsm_test.v
+++ b/vlib/datatypes/fsm/fsm_test.v
@@ -14,7 +14,7 @@ fn default_setup() (MyReceiver, fsm.StateMachine) {
 	return receiver, s
 }
 
-fn test_statemachine_number_of_callbacks_correct_when_single_transition() ? {
+fn test_statemachine_number_of_callbacks_correct_when_single_transition() {
 	mut receiver, mut s := default_setup()
 
 	s.run(receiver)?
@@ -22,7 +22,7 @@ fn test_statemachine_number_of_callbacks_correct_when_single_transition() ? {
 	assert receiver.data.len == 3
 }
 
-fn test_statemachine_sequence_works_when_typical() ? {
+fn test_statemachine_sequence_works_when_typical() {
 	mut receiver, mut s := default_setup()
 
 	s.run(receiver)?
@@ -32,7 +32,7 @@ fn test_statemachine_sequence_works_when_typical() ? {
 	assert receiver.data[2] == 'on_state_run: A -> B'
 }
 
-fn test_statemachine_works_when_final_state() ? {
+fn test_statemachine_works_when_final_state() {
 	mut receiver, mut s := default_setup()
 
 	// current state `A`, with a possible transition to `B`:
@@ -49,7 +49,7 @@ fn test_statemachine_works_when_final_state() ? {
 	assert receiver.data[4] == 'on_state_run: B -> B'
 }
 
-fn test_simple_loop() ? {
+fn test_simple_loop() {
 	mut receiver, mut s := default_setup()
 
 	// Add a transition back to `A` too:

--- a/vlib/datatypes/fsm/fsm_test.v
+++ b/vlib/datatypes/fsm/fsm_test.v
@@ -17,7 +17,7 @@ fn default_setup() (MyReceiver, fsm.StateMachine) {
 fn test_statemachine_number_of_callbacks_correct_when_single_transition() {
 	mut receiver, mut s := default_setup()
 
-	s.run(receiver)?
+	s.run(receiver)!
 
 	assert receiver.data.len == 3
 }
@@ -25,7 +25,7 @@ fn test_statemachine_number_of_callbacks_correct_when_single_transition() {
 fn test_statemachine_sequence_works_when_typical() {
 	mut receiver, mut s := default_setup()
 
-	s.run(receiver)?
+	s.run(receiver)!
 
 	assert receiver.data[0] == 'on_state_exit: A -> B'
 	assert receiver.data[1] == 'on_state_entry: A -> B'
@@ -36,7 +36,7 @@ fn test_statemachine_works_when_final_state() {
 	mut receiver, mut s := default_setup()
 
 	// current state `A`, with a possible transition to `B`:
-	s.run(receiver)? // run should not error here
+	s.run(receiver)! // run should not error here
 
 	// Note: run will now return error, because for state `B`,
 	// there are no more transitions:

--- a/vlib/datatypes/fsm/tools/fsm_graph.v
+++ b/vlib/datatypes/fsm/tools/fsm_graph.v
@@ -1,7 +1,7 @@
 import os
 import flag
 
-pub fn read_file(file string) ?[]string {
+pub fn read_file(file string) ![]string {
 	if os.is_file(file) {
 		text := os.read_lines(file) or {
 			return error(@MOD + '.' + @STRUCT + '.' + @FN +
@@ -33,7 +33,7 @@ pub fn get_transitions(line string) ?string {
 pub fn main() {
 	mut fp := flag.new_flag_parser(os.args)
 	file := fp.string('file', `f`, '', 'input V file with transitions to generate graph from.')
-	lines := read_file(file)?
+	lines := read_file(file)!
 	println('digraph fsm {')
 	for line in lines {
 		if line.contains('add_transition') {


### PR DESCRIPTION
This PR fix fsm.set_state() and cleanup fsm module.