### PR TITLE
checker: improve error msg

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1028,7 +1028,12 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		if call_arg.is_mut {
 			to_lock, pos := c.fail_if_immutable(call_arg.expr)
 			if !call_arg.expr.is_lvalue() {
-				c.error('cannot pass expression as `mut`', call_arg.expr.pos())
+				if call_arg.expr is ast.StructInit {
+					c.error('cannot pass a struct initialization as `mut`, you may want to use a variable `mut var := ${call_arg.expr}`',
+						call_arg.expr.pos())
+				} else {
+					c.error('cannot pass expression as `mut`', call_arg.expr.pos())
+				}
 			}
 			if !param.is_mut {
 				tok := call_arg.share.str()

--- a/vlib/v/checker/tests/check_fn_init_as_mutable.out
+++ b/vlib/v/checker/tests/check_fn_init_as_mutable.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/check_fn_init_as_mutable.vv:6:14: error: cannot pass a struct initialization as `mut`, you may want to use a variable `mut var := MyStruct{....}`
+    4 | 
+    5 | fn main() {
+    6 |     process(mut MyStruct{})
+      |                 ~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/check_fn_init_as_mutable.vv
+++ b/vlib/v/checker/tests/check_fn_init_as_mutable.vv
@@ -1,0 +1,7 @@
+struct MyStruct {}
+
+fn process(mut ms MyStruct) {}
+
+fn main() {
+	process(mut MyStruct{})
+}

--- a/vlib/v/checker/tests/pass_mut_lit.out
+++ b/vlib/v/checker/tests/pass_mut_lit.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/pass_mut_lit.vv:10:12: error: cannot pass expression as `mut`
+vlib/v/checker/tests/pass_mut_lit.vv:10:12: error: cannot pass a struct initialization as `mut`, you may want to use a variable `mut var := Box{....}`
     8 | }
-    9 | 
+    9 |
    10 | modify(mut Box{}, 10)
       |            ~~~~~


### PR DESCRIPTION
This commit improves the error message that v provides, to make the error more user-friendly for users that are not familiar with how `mut` works.

With the following code
```v
struct MyStruct {}

fn process(mut ms MyStruct) {}

fn main() {
	process(mut MyStruct{})
}
```

produce the following error

```
test.v:6:14: error: cannot pass a struct initialization as `mut`, you may want to use a variable `mut var := MyStruct{....}`
    4 |
    5 | fn main() {
    6 |     process(mut MyStruct{})
      |                 ~~~~~~~~~~
    7 | }
```

Instead of this generic one

```
code.v:4:13: error: cannot pass expression as `mut`
    2 | struct MyStruct {}
    3 | fn process(mut ms MyStruct) {}
    4 | process(mut MyStruct{})
      |             ~~~~~~~~~~
Exited with error status 1
```

Fixes https://github.com/vlang/v/issues/16535



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
