### PR TITLE
Enlarge `ftm` line hard wrap from 100 to 120

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -12,7 +12,7 @@ import v.checker.constants
 const (
 	bs      = '\\'
 	// when to break a line dependant on penalty
-	max_len = [0, 35, 60, 85, 93, 100]
+	max_len = [0, 35, 60, 85, 93, 100, 120]
 )
 
 [minify]


### PR DESCRIPTION
Hi, I think that line hard wrap at 100 is too tight, so sometimes the code becomes unreadable because of this. It's also wrapped in unexpected and strange places.

For example,
```v
'G':  ['G', 'Ⓖ', 'Ｇ', 'Ǵ', 'Ĝ', 'Ḡ', 'Ğ', 'Ġ', 'Ǧ', 'Ģ', 'Ǥ', 'Ɠ', 'Ꞡ', 'Ᵹ', 'Ꝿ']
'H':  ['H', 'Ⓗ', 'Ｈ', 'Ĥ', 'Ḣ', 'Ḧ', 'Ȟ', 'Ḥ', 'Ḩ', 'Ḫ', 'Ħ', 'Ⱨ', 'Ⱶ', 'Ɥ']
'I':  ['I', 'Ⓘ', 'Ｉ', 'Ì', 'Í', 'Î', 'Ĩ', 'Ī', 'Ĭ', 'İ', 'Ï', 'Ḯ', 'Ỉ', 'Ǐ', 'Ȉ', 'Ȋ', 'Ị', 'Į', 'Ḭ', 'Ɨ'] <- this line has 103 chars length
```
becomes

```v
'G':  ['G', 'Ⓖ', 'Ｇ', 'Ǵ', 'Ĝ', 'Ḡ', 'Ğ', 'Ġ', 'Ǧ', 'Ģ', 'Ǥ', 'Ɠ', 'Ꞡ', 'Ᵹ',
		'Ꝿ']
'H':  ['H', 'Ⓗ', 'Ｈ', 'Ĥ', 'Ḣ', 'Ḧ', 'Ȟ', 'Ḥ', 'Ḩ', 'Ḫ', 'Ħ', 'Ⱨ', 'Ⱶ',
		'Ɥ']
'I':  ['I', 'Ⓘ', 'Ｉ', 'Ì', 'Í', 'Î', 'Ĩ', 'Ī', 'Ĭ', 'İ', 'Ï', 'Ḯ', 'Ỉ', 'Ǐ',
		'Ȉ', 'Ȋ', 'Ị', 'Į', 'Ḭ', 'Ɨ']
```

I believe for modern monitors (both horizontal and vertical) lines with a length of 120 are OK.
Guys on Discord let me know about `//v fmt off` way, but in some cases that's still not the best solution.

Please, let me know what you think about this