### PR TITLE
cgen: fix error of match expr (fix #16554)

### DIFF
--- a/vlib/v/tests/match_expr_in_infix_expr_test.v
+++ b/vlib/v/tests/match_expr_in_infix_expr_test.v
@@ -1,4 +1,4 @@
-fn main() {
+fn test_match_expr_in_infix_expr() {
 	mut a := true
 	b := a && match true {
 		true {

--- a/vlib/v/tests/valgrind/match_expr.v
+++ b/vlib/v/tests/valgrind/match_expr.v
@@ -1,0 +1,16 @@
+fn main() {
+	mut a := true
+	b := a && match true {
+		true {
+			a = false
+			true
+		}
+		false {
+			false
+		}
+	}
+	println(a)
+	assert a == false
+	println(b)
+	assert b == true
+}


### PR DESCRIPTION
This PR fix error of match expr (fix #16554).

- Fix error of match expr.
- Add test.

```v
fn main() {
	mut a := true
	b := a && match true {
		true {
			a = false
			true
		}
		false {
			false
		}
	}
	println(a)
	assert a == false
	println(b)
	assert b == true
}

PS D:\Test\v\tt1> v run .
false
true
```