### PR TITLE
cgen: fix printing multi-reference struct (fix #16549)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -91,8 +91,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		if expr !is ast.EnumVal {
 			str_fn_name := g.get_str_fn(typ)
 			g.write('${str_fn_name}(')
-			if typ.is_ptr() {
-				g.write('*')
+			if typ.nr_muls() > 0 {
+				g.write('*'.repeat(typ.nr_muls()))
 			}
 			g.enum_expr(expr)
 			g.write(')')
@@ -107,7 +107,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.get_str_fn(typ)
 		if is_ptr && !is_var_mut {
-			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("&"), ${si_s_code} ,{.d_s = isnil(')
+			ref_str := '&'.repeat(typ.nr_muls())
+			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("${ref_str}"), ${si_s_code} ,{.d_s = isnil(')
 			g.expr(expr)
 			g.write(') ? _SLIT("nil") : ')
 		}
@@ -115,7 +116,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		if str_method_expects_ptr && !is_ptr {
 			g.write('&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
-			g.write('*')
+			g.write('*'.repeat(typ.nr_muls()))
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {

--- a/vlib/v/tests/inout/printing_reference_struct.out
+++ b/vlib/v/tests/inout/printing_reference_struct.out
@@ -1,0 +1,3 @@
+&AStruct{}
+AStruct{}
+&&AStruct{}

--- a/vlib/v/tests/inout/printing_reference_struct.vv
+++ b/vlib/v/tests/inout/printing_reference_struct.vv
@@ -1,0 +1,8 @@
+struct AStruct{}
+
+fn main() {
+	ast := &AStruct{}
+	println(ast)
+	println(*ast)
+	println(&ast)
+}


### PR DESCRIPTION
This PR fix printing multi-reference struct (fix #16549).

- Fix printing multi-reference struct.
- Add test.

```v
struct AStruct{}

fn main() {
	ast := &AStruct{}
	println(ast)
	println(*ast)
	println(&ast)
}

PS D:\Test\v\tt1> v run .
&AStruct{}
AStruct{}
&&AStruct{}
```