### PR TITLE
stbi: fix loading images from memory

### DIFF
--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -140,6 +140,10 @@ pub fn load_from_memory(buf &u8, bufsize int) !Image {
 	flag := C.STBI_rgb_alpha
 	res.data = C.stbi_load_from_memory(buf, bufsize, &res.width, &res.height, &res.nr_channels,
 		flag)
+	if res.nr_channels == 3 {
+		// Fix an alpha png bug (see above)
+		res.nr_channels = 4
+	}
 	if isnil(res.data) {
 		return error('stbi_image failed to load from memory')
 	}


### PR DESCRIPTION
This is similar to the (reverted) issue #15981, but it only addresses the core problem (stbi bug) which seems to return a wrong nr_channels for PNG images with a color palette.

Without this fix I get the following error (Fedora Linux):

  sg_image_data: data size doesn't match expected surface size
  ^^^^  SOKOL-GFX VALIDATION FAILED, TERMINATING ^^^^



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
