### PR TITLE
gg: always use 4 channels in init_sokol_image

### DIFF
--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -84,9 +84,22 @@ pub fn (mut img Image) init_sokol_image() &Image {
 		label: img.path.str
 		d3d11_texture: 0
 	}
+
+	// NOTE the following code, sometimes, result in hard-to-detect visual errors/bugs:
+	// img_size := usize(img.nr_channels * img.width * img.height)
+	// As an example see https://github.com/vlang/vab/issues/239
+	// The image will come out blank for some reason and no SOKOL_ASSERT
+	// nor any CI check will/can currently catch this.
+	// Since all of gg currently runs with more or less *defaults* from sokol_gfx/sokol_gl
+	// we should currently just use the size of .rgba (= 4 channels) here instead.
+	// Optimized PNG images that have no alpha channel is often optimized to only have
+	// 3 (or less) channels which stbi will correctly detect and set as `img.nr_channels`
+	// but the current sokol_gl pipeline setup expects 4. It *should* be the same with
+	// all other stbi supported formats.
+	img_size := usize(4 * img.width * img.height)
 	img_desc.data.subimage[0][0] = gfx.Range{
 		ptr: img.data
-		size: usize(img.nr_channels * img.width * img.height)
+		size: img_size
 	}
 	img.simg = gfx.make_image(&img_desc)
 	img.simg_ok = true

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -91,10 +91,10 @@ pub fn (mut img Image) init_sokol_image() &Image {
 	// The image will come out blank for some reason and no SOKOL_ASSERT
 	// nor any CI check will/can currently catch this.
 	// Since all of gg currently runs with more or less *defaults* from sokol_gfx/sokol_gl
-	// we should currently just use the size of .rgba (= 4 channels) here instead.
+	// we should currently just use the sum of each of the RGB and A channels (= 4) here instead.
 	// Optimized PNG images that have no alpha channel is often optimized to only have
 	// 3 (or less) channels which stbi will correctly detect and set as `img.nr_channels`
-	// but the current sokol_gl pipeline setup expects 4. It *should* be the same with
+	// but the current sokol_gl context setup expects 4. It *should* be the same with
 	// all other stbi supported formats.
 	img_size := usize(4 * img.width * img.height)
 	img_desc.data.subimage[0][0] = gfx.Range{

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -117,14 +117,9 @@ pub fn load(path string) !Image {
 		ext: ext
 		data: 0
 	}
-	// flag := if ext == 'png' { C.STBI_rgb_alpha } else { 0 }
-	desired_channels := if ext in ['png', 'jpg', 'jpeg'] { 4 } else { 0 }
 	res.data = C.stbi_load(&char(path.str), &res.width, &res.height, &res.nr_channels,
-		desired_channels)
-	if desired_channels == 4 && res.nr_channels == 3 {
-		// Fix an alpha png bug
-		res.nr_channels = 4
-	}
+		C.STBI_rgb_alpha)
+
 	if isnil(res.data) {
 		return error('stbi_image failed to load from "${path}"')
 	}


### PR DESCRIPTION
Fixes vlang/vab#239

Will probably obsolete #16561

At some point `init_sokol_image()` was changed to use the number of channels detected by stbi instead of the hardcoded `4`. While this should've been a good idea, and the most logical thing to do - reality is a little different. [sokol_gl expects `.rgba8`/4 channels](https://github.com/floooh/sokol/blob/7cf434a922fe1bab285db96bf792f647b83314f7/util/sokol_gl.h#L3195) in it's default contexts, which `gg` currently also uses when loading images. This PR set the number of channels back where it came from and leaves a more juicy note for next time :)

I don't think it's a good idea to manipulate the channel number like this in unexpected places:
https://github.com/vlang/v/pull/15981/files#diff-3566edbb636a40b3c608bb8b51fb2403f57929e1626e96f39ccb7256f0573a99R121
The *correct* channel info is nice to have in other situations - the "problem" is the sokol_gl default contexts which expects 4 channels. So I've removed [the ugly workaround](https://github.com/vlang/v/blob/master/vlib/stbi/stbi.c.v#L120-L127) in this PR as well

I guess this is a good reason to look at getting `v gret` visual tests up and running for Android/`vab` as well...

I've tested the PR against the images provided in #16024 with the image viewer also - they all load and work except for `basn3p08.png` and `basn3p08.gif` which also both fail to load in GIMP.