### PR TITLE
checker: allow struct updates from struct aliases

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -598,7 +598,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 	if node.has_update_expr {
 		update_type := c.expr(node.update_expr)
 		node.update_expr_type = update_type
-		if c.table.sym(update_type).kind != .struct_ {
+		if c.table.final_sym(update_type).kind != .struct_ {
 			s := c.table.type_to_str(update_type)
 			c.error('expected struct, found `${s}`', node.update_expr.pos())
 		} else if update_type != node.typ {

--- a/vlib/v/checker/tests/struct_init_update_type_err.out
+++ b/vlib/v/checker/tests/struct_init_update_type_err.out
@@ -1,28 +1,28 @@
-vlib/v/checker/tests/struct_init_update_type_err.vv:11:6: error: expected struct, found `int`
-    9 |     i := 2
-   10 |     _ := Foo{
-   11 |         ...i
+vlib/v/checker/tests/struct_init_update_type_err.vv:13:6: error: expected struct, found `int`
+   11 |     i := 2
+   12 |     _ := Foo{
+   13 |         ...i
       |            ^
-   12 |         name: 'f2'
-   13 |     }
-vlib/v/checker/tests/struct_init_update_type_err.vv:16:6: error: expected struct, found `&int`
-   14 |     p := &i
-   15 |     _ = Foo{
-   16 |         ...p
+   14 |         name: 'f2'
+   15 |     }
+vlib/v/checker/tests/struct_init_update_type_err.vv:18:6: error: expected struct, found `&int`
+   16 |     p := &i
+   17 |     _ = Foo{
+   18 |         ...p
       |            ^
-   17 |     }
-   18 |     f2 := Foo2{}
-vlib/v/checker/tests/struct_init_update_type_err.vv:20:6: error: struct `Foo2` is not compatible with struct `Foo`
-   18 |     f2 := Foo2{}
-   19 |     _ = Foo{
-   20 |         ...f2
+   19 |     }
+   20 |     f2 := Foo2{}
+vlib/v/checker/tests/struct_init_update_type_err.vv:22:6: error: struct `Foo2` is not compatible with struct `Foo`
+   20 |     f2 := Foo2{}
+   21 |     _ = Foo{
+   22 |         ...f2
       |            ~~
-   21 |     }
-   22 |     _ = Foo{
-vlib/v/checker/tests/struct_init_update_type_err.vv:32:6: error: struct `Empty` is not compatible with struct `Foo`
-   30 |     e := Empty{}
-   31 |     _ = Foo{
-   32 |         ...e
+   23 |     }
+   24 |     _ = Foo{
+vlib/v/checker/tests/struct_init_update_type_err.vv:34:6: error: struct `Empty` is not compatible with struct `Foo`
+   32 |     e := Empty{}
+   33 |     _ = Foo{
+   34 |         ...e
       |            ^
-   33 |     }
-   34 | }
+   35 |     }
+   36 | }

--- a/vlib/v/checker/tests/struct_init_update_type_err.vv
+++ b/vlib/v/checker/tests/struct_init_update_type_err.vv
@@ -1,9 +1,11 @@
 struct Foo {
 	name string
-	age int
+	age  int
 }
 
-struct Foo2 {b bool}
+struct Foo2 {
+	b bool
+}
 
 fn main() {
 	i := 2
@@ -33,3 +35,11 @@ fn empty() {
 	}
 }
 
+type AliasFoo = Foo
+
+fn alias() {
+	a := AliasFoo{}
+	_ = AliasFoo{
+		...a
+	}
+}


### PR DESCRIPTION
Fixes #16565

This now works:
```v
struct Foo {}
type FooAlias{}
fn main() {
  foo := FooAlias{}
  bar := FooAlias{
    ...foo // <-- previously a compiler error: expected struct, found `FooAlias`
  }
}
```