### PR TITLE
term: add format_esc

### DIFF
--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -3,12 +3,16 @@
 // that can be found in the LICENSE file.
 module term
 
+pub fn format_esc(code string) {
+	return '\x1b[${code}m'
+}
+
 pub fn format(msg string, open string, close string) string {
-	return '\x1b[${open}m${msg}\x1b[${close}m'
+	return '${format_esc(open)}${msg}${format_esc(close)}'
 }
 
 pub fn format_rgb(r int, g int, b int, msg string, open string, close string) string {
-	return '\x1b[${open};2;${r};${g};${b}m${msg}\x1b[${close}m'
+	return '\x1b[${open};2;${r};${g};${b}m${msg}${format_esc(close)}'
 }
 
 pub fn rgb(r int, g int, b int, msg string) string {

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module term
 
-pub fn format_esc(code string) {
+pub fn format_esc(code string) string {
 	return '\x1b[${code}m'
 }
 

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -3,6 +3,10 @@
 // that can be found in the LICENSE file.
 module term
 
+// format_esc produces an ANSI escape code, for selecting the graphics rendition of the following
+// text. Each of the attributes that can be passed in `code`, separated by `;`, will be in effect,
+// until the terminal encounters another SGR ANSI escape code. For more details about the different
+// codes, and their meaning, see: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 pub fn format_esc(code string) string {
 	return '\x1b[${code}m'
 }

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -8,11 +8,11 @@ pub fn format_esc(code string) string {
 }
 
 pub fn format(msg string, open string, close string) string {
-	return '${format_esc(open)}${msg}${format_esc(close)}'
+	return '\x1b[${open}m${msg}\x1b[${close}m'
 }
 
 pub fn format_rgb(r int, g int, b int, msg string, open string, close string) string {
-	return '\x1b[${open};2;${r};${g};${b}m${msg}${format_esc(close)}'
+	return '\x1b[${open};2;${r};${g};${b}m${msg}\x1b[${close}m'
 }
 
 pub fn rgb(r int, g int, b int, msg string) string {


### PR DESCRIPTION
I was going to implement this method in my color.v library for efficent tag rendering, but i decided it would be better to add here