### PR TITLE
tools: fix vcompletion for single-file directories

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -518,6 +518,17 @@ fn auto_complete_request(args []string) []string {
 					}
 				}
 			} else {
+				// Handle special case, where there is only one file in the directory
+				// being completed - if it can be resolved we return that since
+				// handling it in the generalized logic below will result in
+				// more complexity.
+				if entries.len == 1 && os.is_file(os.join_path(ls_path, entries[0])) {
+					mut keep_input_path_format := ls_path
+					if !part.starts_with('./') && ls_path.starts_with('./') {
+						keep_input_path_format = keep_input_path_format.all_after('./')
+					}
+					return [os.join_path(keep_input_path_format, entries[0])]
+				}
 				for entry in entries {
 					if collect_all || entry.starts_with(last) {
 						list << append_separator_if_dir(entry)


### PR DESCRIPTION
This PR fixes return values from `v complete <SHELL> v /path/to/dir-containing-only-one-file/`

Previously it would return only the filename e.g. `v file.v` - after this PR it now keep the path it was completing and return it with the filname: `v /path/to/dir-containing-only-one-file/file.v`.

Related: #16587