### PR TITLE
cgen: fix if expr with multiple array call (fix #16583)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -948,6 +948,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	if has_infix_left_var_name {
 		g.indent--
 		g.writeln('}')
+		g.set_current_pos_as_last_stmt_pos()
 	}
 	if s_ends_with_ln {
 		g.writeln(s)

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1023,6 +1023,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	if has_infix_left_var_name {
 		g.indent--
 		g.writeln('}')
+		g.set_current_pos_as_last_stmt_pos()
 	}
 	if s_ends_with_ln {
 		g.writeln(s)

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -337,12 +337,13 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 	}
 	if node.branches.len > 0 {
 		g.writeln('}')
+		g.set_current_pos_as_last_stmt_pos()
 	}
-	g.set_current_pos_as_last_stmt_pos()
 	if needs_tmp_var {
 		if g.infix_left_var_name.len > 0 {
 			g.indent--
 			g.writeln('}')
+			g.set_current_pos_as_last_stmt_pos()
 		}
 		g.empty_line = false
 		g.write('${cur_line} ${tmp}')

--- a/vlib/v/tests/if_expr_with_multi_array_call_test.v
+++ b/vlib/v/tests/if_expr_with_multi_array_call_test.v
@@ -14,3 +14,16 @@ fn foo() string {
 	}
 	return ''
 }
+
+fn test_if_expr_with_several_any_calls() {
+	x := [3, 4]
+	y := [2, 3, 4, 5]
+	if x.any(it in y) || y.any(it in x) {
+		println('then')
+		assert true
+	} else if x.any(it in y) {
+		println('else')
+		assert false
+	}
+	assert true
+}

--- a/vlib/v/tests/if_expr_with_multi_array_call_test.v
+++ b/vlib/v/tests/if_expr_with_multi_array_call_test.v
@@ -1,0 +1,16 @@
+fn test_if_expr_with_multi_array_call() {
+	ret := foo()
+	println(ret)
+	assert ret == 'all'
+}
+
+fn foo() string {
+	x := [3, 4]
+	y := [2, 3, 4, 5]
+	if x.all(it in y) || y.all(it in x) {
+		return 'all'
+	} else if x.any(it in y) {
+		return 'any'
+	}
+	return ''
+}


### PR DESCRIPTION
This PR fix if expr with multiple array call (fix #16583).

- Fix if expr with multiple array call.
- Add test.

```v
fn main() {
	ret := foo()
	println(ret)
	assert ret == 'all'
}

fn foo() string {
	x := [3, 4]
	y := [2, 3, 4, 5]
	if x.all(it in y) || y.all(it in x) {
		return 'all'
	} else if x.any(it in y) {
		return 'any'
	}
	return ''
}

PS D:\Test\v\tt1> v run .
all
```