### PR TITLE
all: replace generic '<>' with '[]' in .vv files

### DIFF
--- a/vlib/v/checker/tests/array_of_generic_struct_init_err.vv
+++ b/vlib/v/checker/tests/array_of_generic_struct_init_err.vv
@@ -1,4 +1,4 @@
-struct Item<T>{
+struct Item[T]{
 	val T
 }
 

--- a/vlib/v/checker/tests/assign_generic_fn_err.out
+++ b/vlib/v/checker/tests/assign_generic_fn_err.out
@@ -7,6 +7,6 @@ vlib/v/checker/tests/assign_generic_fn_err.vv:2:9: error: cannot assign generic 
 vlib/v/checker/tests/assign_generic_fn_err.vv:6:13: error: a non generic function called like a generic one
     4 |     }
     5 |
-    6 |     println(fun<int>(100))
+    6 |     println(fun[int](100))
       |                ~~~~~
     7 | }

--- a/vlib/v/checker/tests/assign_generic_fn_err.vv
+++ b/vlib/v/checker/tests/assign_generic_fn_err.vv
@@ -3,5 +3,5 @@ fn main() {
 		return value
 	}
 
-	println(fun<int>(100))
+	println(fun[int](100))
 } 

--- a/vlib/v/checker/tests/cast_voidptr_to_struct_err.out
+++ b/vlib/v/checker/tests/cast_voidptr_to_struct_err.out
@@ -7,7 +7,7 @@ vlib/v/checker/tests/cast_voidptr_to_struct_err.vv:6:9: error: cannot cast `void
     8 |
 vlib/v/checker/tests/cast_voidptr_to_struct_err.vv:10:9: error: cannot cast `voidptr` to struct
     8 |
-    9 | fn unwrap_generic<T>(ptr voidptr) T {
+    9 | fn unwrap_generic[T](ptr voidptr) T {
    10 |     return T(ptr)
       |            ~~~~~~
    11 | }

--- a/vlib/v/checker/tests/cast_voidptr_to_struct_err.vv
+++ b/vlib/v/checker/tests/cast_voidptr_to_struct_err.vv
@@ -6,13 +6,13 @@ fn unwrap_concrete(ptr voidptr) Foo {
 	return Foo(ptr)
 }
 
-fn unwrap_generic<T>(ptr voidptr) T {
+fn unwrap_generic[T](ptr voidptr) T {
 	return T(ptr)
 }
 
 pub fn main() {
 	foo1 := unwrap_concrete(voidptr(0))
-	foo2 := unwrap_generic<Foo>(voidptr(0))
+	foo2 := unwrap_generic[Foo](voidptr(0))
 
 	println(foo1)
 	println(foo2)

--- a/vlib/v/checker/tests/comptime_field_selector_not_in_for_err.vv
+++ b/vlib/v/checker/tests/comptime_field_selector_not_in_for_err.vv
@@ -3,12 +3,12 @@ struct Foo {
 	name string
 }
 
-fn test<T>() {
+fn test[T]() {
 	mut t := T{}
 	name := 'test'
 	t.$(name) = '3'
 }
 
 fn main() {
-	test<Foo>()
+	test[Foo]()
 }

--- a/vlib/v/checker/tests/comptime_field_selector_not_name_err.vv
+++ b/vlib/v/checker/tests/comptime_field_selector_not_name_err.vv
@@ -3,7 +3,7 @@ struct Foo {
 	name string
 }
 
-fn test<T>() {
+fn test[T]() {
 	mut t := T{}
 	$for f in T.fields {
 		$if f.typ is string {
@@ -16,5 +16,5 @@ fn test<T>() {
 }
 
 fn main() {
-	test<Foo>()
+	test[Foo]()
 }

--- a/vlib/v/checker/tests/comptime_for.vv
+++ b/vlib/v/checker/tests/comptime_for.vv
@@ -8,7 +8,7 @@ fn unknown() {
 	_ = m
 }
 
-fn gf<T>() {
+fn gf[T]() {
 	$for f in T.fields {
 		$if f.typ is T {}
 		$if f.typ is U {}
@@ -21,5 +21,5 @@ struct S1 {
 }
 
 fn main() {
-	gf<S1>()
+	gf[S1]()
 }

--- a/vlib/v/checker/tests/fn_ref_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_ref_arg_mismatch_err.out
@@ -1,13 +1,13 @@
 vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv:15:10: error: literal argument cannot be passed as reference parameter `&T`
    13 | fn main() {
-   14 |     foo := Foo<int>{}
+   14 |     foo := Foo[int]{}
    15 |     foo.foo(12)
       |             ~~
    16 |
-   17 |     bar<int>(12)
+   17 |     bar[int](12)
 vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv:17:11: error: literal argument cannot be passed as reference parameter `&T`
    15 |     foo.foo(12)
    16 |
-   17 |     bar<int>(12)
+   17 |     bar[int](12)
       |              ~~
    18 | }

--- a/vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv
@@ -1,18 +1,18 @@
 module main
 
-struct Foo<T> { }
+struct Foo[T] { }
 
-fn (f &Foo<T>) foo(a &T) {
+fn (f &Foo[T]) foo(a &T) {
 	println(a)
 }
 
-fn bar<T>(a &T) {
+fn bar[T](a &T) {
 	println(a)
 }
 
 fn main() {
-	foo := Foo<int>{}
+	foo := Foo[int]{}
 	foo.foo(12)
 
-	bar<int>(12)
+	bar[int](12)
 }

--- a/vlib/v/checker/tests/function_count_of_args_mismatch_err.vv
+++ b/vlib/v/checker/tests/function_count_of_args_mismatch_err.vv
@@ -1,7 +1,7 @@
 fn test(b bool) {
 }
 
-fn test2<T>(b bool, v T) {
+fn test2[T](b bool, v T) {
 }
 
 fn main() {

--- a/vlib/v/checker/tests/generic_closure_fn_decl_err.out
+++ b/vlib/v/checker/tests/generic_closure_fn_decl_err.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/generic_closure_fn_decl_err.vv:5:2: error: generic closure fn must specify type parameter, e.g. fn [foo] [T]()
     3 |
-    4 | pub fn (mut app App) register<T>(service T) {
+    4 | pub fn (mut app App) register[T](service T) {
     5 |     fn [service] () {
       |     ~~~~~~~~~~~~~~~~~
     6 |         println(service)

--- a/vlib/v/checker/tests/generic_closure_fn_decl_err.vv
+++ b/vlib/v/checker/tests/generic_closure_fn_decl_err.vv
@@ -1,7 +1,7 @@
 pub struct App {
 }
 
-pub fn (mut app App) register<T>(service T) {
+pub fn (mut app App) register[T](service T) {
 	fn [service] () {
 		println(service)
 	}()

--- a/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
+++ b/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:26:1: error: generic function declaration must specify generic type names
    24 | }
    25 |
-   26 | fn g_worker(g Generic<T>) {
+   26 | fn g_worker(g Generic[T]) {
       | ~~~~~~~~~~~~~~~~~~~~~~~~~
    27 |     t := <-g.ch
    28 |     handle(t)
@@ -15,9 +15,9 @@ vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:32:1: error: g
    34 | }
 Details: use `fn foo[T](x T) {`, not just `fn foo(x T) {`
 vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:40:1: error: generic method declaration must specify generic type names
-   38 | type MayBe<T> = None | T
+   38 | type MayBe[T] = None | T
    39 |
-   40 | fn (m MayBe<T>) is_some() bool {
+   40 | fn (m MayBe[T]) is_some() bool {
       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    41 |     return m is T
    42 | }

--- a/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv
+++ b/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv
@@ -1,4 +1,4 @@
-struct Generic<T> {
+struct Generic[T] {
 	ch chan T
 }
 
@@ -7,14 +7,14 @@ struct Concrete {
 }
 
 fn main() {
-	g := create_generic_t<Concrete>()
+	g := create_generic_t[Concrete]()
 	g.ch <- Concrete{
 		msg: 'hello'
 	}
 }
 
-fn create_generic_t<T>() Generic<T> {
-	g := Generic<T>{
+fn create_generic_t[T]() Generic[T] {
+	g := Generic[T]{
 		ch: chan T{}
 	}
 
@@ -23,7 +23,7 @@ fn create_generic_t<T>() Generic<T> {
 	return g
 }
 
-fn g_worker(g Generic<T>) {
+fn g_worker(g Generic[T]) {
 	t := <-g.ch
 	handle(t)
 	// println("${t.msg}")
@@ -35,8 +35,8 @@ fn handle(t T) {
 
 struct None {}
 
-type MayBe<T> = None | T
+type MayBe[T] = None | T
 
-fn (m MayBe<T>) is_some() bool {
+fn (m MayBe[T]) is_some() bool {
 	return m is T
 }

--- a/vlib/v/checker/tests/generic_infix_plus_err.out
+++ b/vlib/v/checker/tests/generic_infix_plus_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/generic_infix_plus_err.vv:2:9: error: undefined operation `map[string]int` + `map[string]int`
-    1 | fn sum<T>(a T, b T) T {
+    1 | fn sum[T](a T, b T) T {
     2 |     return a + b
       |            ~~~~~
     3 | }

--- a/vlib/v/checker/tests/generic_infix_plus_err.vv
+++ b/vlib/v/checker/tests/generic_infix_plus_err.vv
@@ -1,4 +1,4 @@
-fn sum<T>(a T, b T) T {
+fn sum[T](a T, b T) T {
 	return a + b
 }
 

--- a/vlib/v/checker/tests/generic_interface_err.vv
+++ b/vlib/v/checker/tests/generic_interface_err.vv
@@ -1,8 +1,8 @@
-struct Struct<T> {
+struct Struct[T] {
 	value int
 }
 
-interface Interface<T> {
+interface Interface[T] {
 	method() T
 }
 

--- a/vlib/v/checker/tests/generic_interface_missing_type_names_err.vv
+++ b/vlib/v/checker/tests/generic_interface_missing_type_names_err.vv
@@ -1,4 +1,4 @@
-interface Output<T> {
+interface Output[T] {
   val T
   name string
 }

--- a/vlib/v/checker/tests/generic_sumtype_decl_err_a.vv
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err_a.vv
@@ -1,4 +1,4 @@
-struct Just<T> {
+struct Just[T] {
   value T
 }
 

--- a/vlib/v/checker/tests/generic_sumtype_decl_err_b.out
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err_b.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generic_sumtype_decl_err_b.vv:7:6: error: generic sumtype `Maybe` must specify generic type names, e.g. Foo[T]
     5 | struct Nothing {}
     6 |
-    7 | type Maybe = Nothing | Just<T>
+    7 | type Maybe = Nothing | Just[T]
       |      ~~~~~
     8 |
     9 | fn main() {

--- a/vlib/v/checker/tests/generic_sumtype_decl_err_b.vv
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err_b.vv
@@ -1,10 +1,10 @@
-struct Just<T> {
+struct Just[T] {
   value T
 }
 
 struct Nothing {}
 
-type Maybe = Nothing | Just<T>
+type Maybe = Nothing | Just[T]
 
 fn main() {
 }

--- a/vlib/v/checker/tests/generic_sumtype_decl_err_c.out
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err_c.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generic_sumtype_decl_err_c.vv:7:27: error: generic type name `T` of generic struct `Just<T>` is not mentioned in sumtype `Maybe<B>`
     5 | struct Nothing {}
     6 |
-    7 | type Maybe<B> = Nothing | Just<T>
+    7 | type Maybe[B] = Nothing | Just[T]
       |                           ~~~~~~~
     8 |
     9 | fn main() {

--- a/vlib/v/checker/tests/generic_sumtype_decl_err_c.vv
+++ b/vlib/v/checker/tests/generic_sumtype_decl_err_c.vv
@@ -1,10 +1,10 @@
-struct Just<T> {
+struct Just[T] {
   value T
 }
 
 struct Nothing {}
 
-type Maybe<B> = Nothing | Just<T>
+type Maybe[B] = Nothing | Just[T]
 
 fn main() {
 }

--- a/vlib/v/checker/tests/generic_type_inference.vv
+++ b/vlib/v/checker/tests/generic_type_inference.vv
@@ -1,20 +1,20 @@
 import datatypes
 
-struct KeyVal<T> {
+struct KeyVal[T] {
 	key string
 	val T
 }
 
-fn (a KeyVal<T>) == (b KeyVal<T>) bool {
+fn (a KeyVal[T]) == (b KeyVal[T]) bool {
 	return a.key == b.key
 }
 
-fn (a KeyVal<T>) < (b KeyVal<T>) bool {
+fn (a KeyVal[T]) < (b KeyVal[T]) bool {
 	return a.key < b.key
 }
 
 fn main() {
-	mut bst := datatypes.BSTree<KeyVal<int>>{}
-	bst.insert(KeyVal<int>{key: "alibaba", val: 12})
+	mut bst := datatypes.BSTree[KeyVal[int]]{}
+	bst.insert(KeyVal[int]{key: "alibaba", val: 12})
 	println(bst.in_order_traversal())
 }

--- a/vlib/v/checker/tests/generics_fn_arg_type_err.vv
+++ b/vlib/v/checker/tests/generics_fn_arg_type_err.vv
@@ -1,13 +1,13 @@
-interface List<T> {
+interface List[T] {
 mut:
 	add(e T) bool
 }
 
-struct LinkedList<T> {
+struct LinkedList[T] {
 	// ...
 }
 
-fn (mut list LinkedList<T>) add(e T) {
+fn (mut list LinkedList[T]) add(e T) {
 	// ...
 }
 

--- a/vlib/v/checker/tests/generics_fn_called_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_arg_mismatch.out
@@ -1,27 +1,27 @@
 vlib/v/checker/tests/generics_fn_called_arg_mismatch.vv:6:15: error: cannot use `int literal` as `bool` in argument 1 to `foo`
     4 |
     5 | fn main() {
-    6 |     foo<bool>(1)
+    6 |     foo[bool](1)
       |               ^
-    7 |     foo<bool>(2.2)
-    8 |     foo<string>(true)
+    7 |     foo[bool](2.2)
+    8 |     foo[string](true)
 vlib/v/checker/tests/generics_fn_called_arg_mismatch.vv:7:15: error: cannot use `float literal` as `bool` in argument 1 to `foo`
     5 | fn main() {
-    6 |     foo<bool>(1)
-    7 |     foo<bool>(2.2)
+    6 |     foo[bool](1)
+    7 |     foo[bool](2.2)
       |               ~~~
-    8 |     foo<string>(true)
-    9 |     foo<int>('aaa')
+    8 |     foo[string](true)
+    9 |     foo[int]('aaa')
 vlib/v/checker/tests/generics_fn_called_arg_mismatch.vv:8:17: error: cannot use `bool` as `string` in argument 1 to `foo`
-    6 |     foo<bool>(1)
-    7 |     foo<bool>(2.2)
-    8 |     foo<string>(true)
+    6 |     foo[bool](1)
+    7 |     foo[bool](2.2)
+    8 |     foo[string](true)
       |                 ~~~~
-    9 |     foo<int>('aaa')
+    9 |     foo[int]('aaa')
    10 | }
 vlib/v/checker/tests/generics_fn_called_arg_mismatch.vv:9:14: error: cannot use `string` as `int` in argument 1 to `foo`
-    7 |     foo<bool>(2.2)
-    8 |     foo<string>(true)
-    9 |     foo<int>('aaa')
+    7 |     foo[bool](2.2)
+    8 |     foo[string](true)
+    9 |     foo[int]('aaa')
       |              ~~~~~
    10 | }

--- a/vlib/v/checker/tests/generics_fn_called_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_arg_mismatch.vv
@@ -1,10 +1,10 @@
-fn foo<T>(b T) {
+fn foo[T](b T) {
     println(b)
 }
 
 fn main() {
-    foo<bool>(1)
-    foo<bool>(2.2)
-    foo<string>(true)
-    foo<int>('aaa')
+    foo[bool](1)
+    foo[bool](2.2)
+    foo[string](true)
+    foo[int]('aaa')
 }

--- a/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv:24:37: error: cannot use `fn (int) f64` as `fn (int) Point3D` in argument 2 to `new_array`
    22 |     println(good_cloud)
    23 |     // this should be a compilation error, because the function signature does not match:
-   24 |     bad_cloud := new_array<Point3D>(3, fn (idx int) f64 {
+   24 |     bad_cloud := new_array[Point3D](3, fn (idx int) f64 {
       |                                        ~~~~~~~~~~~~~~~~~~
    25 |         return 12345
    26 |     })

--- a/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv
@@ -1,6 +1,6 @@
 pub type FnArrayInit = fn (idx int) T
 
-pub fn new_array<T>(len int, initfn FnArrayInit<T>) []T {
+pub fn new_array[T](len int, initfn FnArrayInit[T]) []T {
 	mut res := []T{len: len}
 	for idx in 0 .. res.len {
 		res[idx] = initfn(idx)
@@ -16,12 +16,12 @@ struct Point3D {
 
 fn main() {
 	// this works as expected:
-	good_cloud := new_array<Point3D>(3, fn (idx int) Point3D {
+	good_cloud := new_array[Point3D](3, fn (idx int) Point3D {
 		return Point3D{idx, idx * 10, idx * -10}
 	})
 	println(good_cloud)
 	// this should be a compilation error, because the function signature does not match:
-	bad_cloud := new_array<Point3D>(3, fn (idx int) f64 {
+	bad_cloud := new_array[Point3D](3, fn (idx int) f64 {
 		return 12345
 	})
 	println(bad_cloud)

--- a/vlib/v/checker/tests/generics_fn_called_no_arg_err.vv
+++ b/vlib/v/checker/tests/generics_fn_called_no_arg_err.vv
@@ -1,9 +1,9 @@
-struct Queue<T>{
+struct Queue[T]{
     buffer []T
 }
 
-fn new_queue<T>() Queue<T> {
-    q := Queue<T>{
+fn new_queue[T]() Queue[T] {
+    q := Queue[T]{
         buffer: []T{cap: 1024}
     }
     return q

--- a/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.out
+++ b/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.vv:4:2: error: generic fn using generic types cannot be called outside of generic fn
     2 |
     3 | fn main() {
-    4 |     foo<T>()
+    4 |     foo[T]()
       |     ~~~~~~~~
     5 | }

--- a/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.vv
+++ b/vlib/v/checker/tests/generics_fn_called_outside_of_generic_fn.vv
@@ -1,5 +1,5 @@
-fn foo<T>() {}
+fn foo[T]() {}
 
 fn main() {
-	foo<T>()
+	foo[T]()
 }

--- a/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv:12:16: error: cannot use `[]int` as `int` in argument 1 to `max`
    10 |
    11 | fn main() {
-   12 |     b := max<int>([1, 2, 3, 4])
+   12 |     b := max[int]([1, 2, 3, 4])
       |                   ~~~~~~~~~~~~
    13 |     println(b)
    14 | }

--- a/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_variadic_arg_mismatch.vv
@@ -1,4 +1,4 @@
-fn max<T>(a ...T) T {
+fn max[T](a ...T) T {
 	mut max := a[0]
 	for item in a[1..] {
 		if max < item {
@@ -9,6 +9,6 @@ fn max<T>(a ...T) T {
 }
 
 fn main() {
-	b := max<int>([1, 2, 3, 4])
+	b := max[int]([1, 2, 3, 4])
 	println(b)
 }

--- a/vlib/v/checker/tests/generics_interface_decl_no_mention_err.out
+++ b/vlib/v/checker/tests/generics_interface_decl_no_mention_err.out
@@ -1,12 +1,12 @@
 vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:4:2: error: generic type name `T` is not mentioned in interface `Foo<U>`
     2 |
-    3 | interface Foo<U> {
+    3 | interface Foo[U] {
     4 |     Bar<T>
       |     ~~~
     5 |     foo(u U, p P)
     6 |     bar(u U) []P
 vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:5:13: error: generic type name `P` is not mentioned in interface `Foo<U>`
-    3 | interface Foo<U> {
+    3 | interface Foo[U] {
     4 |     Bar<T>
     5 |     foo(u U, p P)
       |                ^

--- a/vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv
+++ b/vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv
@@ -1,10 +1,10 @@
 fn main() {}
 
-interface Foo<U> {
+interface Foo[U] {
 	Bar<T>
 	foo(u U, p P)
 	bar(u U) []P
 }
 
-interface Bar<T> {
+interface Bar[T] {
 }

--- a/vlib/v/checker/tests/generics_interface_field_type_err.vv
+++ b/vlib/v/checker/tests/generics_interface_field_type_err.vv
@@ -12,18 +12,18 @@ pub mut:
 	z f64
 }
 
-pub interface IComponentStore<T> {
+pub interface IComponentStore[T] {
 mut:
 	add(Entity, T)
 }
 
-pub struct ComponentStore<T> {
+pub struct ComponentStore[T] {
 pub mut:
 	typ string
 	// data etc
 }
 
-pub fn (mut cs ComponentStore<T>) add(e Entity, value T) {
+pub fn (mut cs ComponentStore[T]) add(e Entity, value T) {
 	//	index := cs.set.add(e.id)
 	//	cs.instances[index] = value
 }

--- a/vlib/v/checker/tests/generics_method_arg_type_err.vv
+++ b/vlib/v/checker/tests/generics_method_arg_type_err.vv
@@ -14,6 +14,6 @@ fn main() {
 	r.node_create(mut g)
 }
 
-pub fn (mut r Redis) node_create<T>(t T) bool {
+pub fn (mut r Redis) node_create[T](t T) bool {
 	return true
 }

--- a/vlib/v/checker/tests/generics_method_called_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_method_called_arg_mismatch.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generics_method_called_arg_mismatch.vv:3:15: error: cannot use `Foo` as `Bar` in argument 1 to `Obj.set`
     1 | fn main() {
     2 |     mut obj := Obj{}
-    3 |     obj.set<Bar>(Foo{})
+    3 |     obj.set[Bar](Foo{})
       |                  ~~~~~
     4 | }
     5 |

--- a/vlib/v/checker/tests/generics_method_called_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_method_called_arg_mismatch.vv
@@ -1,6 +1,6 @@
 fn main() {
 	mut obj := Obj{}
-	obj.set<Bar>(Foo{})
+	obj.set[Bar](Foo{})
 }
 
 struct Foo {}
@@ -11,4 +11,4 @@ struct Bar {
 
 struct Obj {}
 
-fn (mut o Obj) set<T>(val T) {}
+fn (mut o Obj) set[T](val T) {}

--- a/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv:8:4: error: to pass `options` (string) to `req` (which accepts type `...string`), use `...options`
     6 |
     7 | fn (c Client) products_list(options ...string) {
-    8 |     c.req<Product>(options) // (...options) works
+    8 |     c.req[Product](options) // (...options) works
       |       ~~~~~~~~~~~~~~~~~~~~~
     9 | }
    10 |

--- a/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv
@@ -1,11 +1,11 @@
 struct Client {}
 
-fn (cl Client) req<T>(data ...string) {}
+fn (cl Client) req[T](data ...string) {}
 
 struct Product {}
 
 fn (c Client) products_list(options ...string) {
-	c.req<Product>(options) // (...options) works
+	c.req[Product](options) // (...options) works
 }
 
 fn main() {

--- a/vlib/v/checker/tests/generics_method_receiver_type_err.vv
+++ b/vlib/v/checker/tests/generics_method_receiver_type_err.vv
@@ -1,4 +1,4 @@
-struct Node<T> {
+struct Node[T] {
 	val  T
 	name string
 }
@@ -8,7 +8,7 @@ pub fn (x Node) str() string {
 }
 
 fn main() {
-	xx := Node<u16>{
+	xx := Node[u16]{
 		val: u16(11)
 		name: 'man'
 	}

--- a/vlib/v/checker/tests/generics_method_sumtype_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_method_sumtype_arg_mismatch.vv
@@ -2,9 +2,9 @@ module main
 
 struct None {}
 
-pub type Maybe<T> = None | T
+pub type Maybe[T] = None | T
 
-pub fn (m Maybe<T>) str<T>() string {
+pub fn (m Maybe[T]) str[T]() string {
 	return if m is T {
 		x := m as T
 		'Some($x)'
@@ -13,29 +13,29 @@ pub fn (m Maybe<T>) str<T>() string {
 	}
 }
 
-pub fn some<T>(v T) Maybe<T> {
-	return Maybe<T>(v)
+pub fn some[T](v T) Maybe[T] {
+	return Maybe[T](v)
 }
 
-pub fn noth<T>() Maybe<T> {
-	return Maybe<T>(None{})
+pub fn noth[T]() Maybe[T] {
+	return Maybe[T](None{})
 }
 
-pub fn (m Maybe<T>) is_some<T>() bool {
+pub fn (m Maybe[T]) is_some[T]() bool {
 	return match m {
 		None { false }
 		T { true }
 	}
 }
 
-pub fn (m Maybe<T>) is_noth<T>() bool {
+pub fn (m Maybe[T]) is_noth[T]() bool {
 	return match m {
 		None { true }
 		T { false }
 	}
 }
 
-pub fn (m Maybe<T>) @or<T>(m2 Maybe<T>) Maybe<T> {
+pub fn (m Maybe[T]) @or[T](m2 Maybe[T]) Maybe[T] {
 	return match m {
 		None {
 			match m2 {

--- a/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.out
+++ b/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.out
@@ -1,14 +1,14 @@
 vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv:6:9: error: a non generic struct `Toy` used like a generic struct
     4 |
     5 | fn get_toy1(toy Toy) Toy{
-    6 |     return Toy<T>{toy.toy_name}
+    6 |     return Toy[T]{toy.toy_name}
       |            ~~~
     7 | }
     8 |
 vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv:10:9: error: a non generic struct `Toy` used like a generic struct
     8 |
     9 | fn get_toy2(toy Toy) Toy{
-   10 |     return Toy<T,U>{toy.toy_name}
+   10 |     return Toy[T,U]{toy.toy_name}
       |            ~~~
    11 | }
    12 |

--- a/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv
+++ b/vlib/v/checker/tests/generics_non_generic_struct_used_like_a_generic_one.vv
@@ -3,11 +3,11 @@ struct Toy{
 }
 
 fn get_toy1(toy Toy) Toy{
-	return Toy<T>{toy.toy_name}
+	return Toy[T]{toy.toy_name}
 }
 
 fn get_toy2(toy Toy) Toy{
-	return Toy<T,U>{toy.toy_name}
+	return Toy[T,U]{toy.toy_name}
 }
 
 fn main() {

--- a/vlib/v/checker/tests/generics_struct_field_type_err.vv
+++ b/vlib/v/checker/tests/generics_struct_field_type_err.vv
@@ -1,11 +1,11 @@
-struct LL<T> {
+struct LL[T] {
 	mut:
 		value T
 		next &LL = unsafe { 0 }
 }
 
 fn main() {
-	mut l := LL<int>{}
+	mut l := LL[int]{}
 	l.value = 5
 	println(l.value)
 }

--- a/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.out
+++ b/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.vv:5:7: error: generic struct cannot be used in non-generic function
     3 |
     4 | fn main() {
-    5 |     _ := []Example<T>{}
+    5 |     _ := []Example[T]{}
       |          ~~~~~~~~~~~~~
     6 | }

--- a/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.vv
+++ b/vlib/v/checker/tests/generics_struct_in_non_generic_fn_err.vv
@@ -1,6 +1,6 @@
-struct Example<T> {
+struct Example[T] {
 }
 
 fn main() {
-	_ := []Example<T>{}
+	_ := []Example[T]{}
 }

--- a/vlib/v/checker/tests/generics_struct_type_mismatch_err.out
+++ b/vlib/v/checker/tests/generics_struct_type_mismatch_err.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/generics_struct_type_mismatch_err.vv:7:20: error: the number of generic types of struct `Example` is inconsistent with the concrete types
     5 |
     6 | fn main() {
-    7 |     example := Example<string>{
+    7 |     example := Example[string]{
       |                       ~~~~~~~~
     8 |         key: 'key'
     9 |         value: 'value'

--- a/vlib/v/checker/tests/generics_struct_type_mismatch_err.vv
+++ b/vlib/v/checker/tests/generics_struct_type_mismatch_err.vv
@@ -1,10 +1,10 @@
-struct Example<T, V> {
+struct Example[T, V] {
 	key   T
 	value V
 }
 
 fn main() {
-	example := Example<string>{
+	example := Example[string]{
 		key: 'key'
 		value: 'value'
 	}

--- a/vlib/v/checker/tests/generics_too_many_parameters.out
+++ b/vlib/v/checker/tests/generics_too_many_parameters.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/generics_too_many_parameters.vv:6:8: error: expected 1 generic parameter, got 5
     4 |
     5 | fn main() {
-    6 |     foo<bool, int, bool, bool, int>(1)
+    6 |     foo[bool, int, bool, bool, int](1)
       |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     7 | }

--- a/vlib/v/checker/tests/generics_too_many_parameters.vv
+++ b/vlib/v/checker/tests/generics_too_many_parameters.vv
@@ -1,7 +1,7 @@
-fn foo<T>(b T) {
+fn foo[T](b T) {
     println(b)
 }
 
 fn main() {
-    foo<bool, int, bool, bool, int>(1)
+    foo[bool, int, bool, bool, int](1)
 }

--- a/vlib/v/checker/tests/generics_type_ambiguous.vv
+++ b/vlib/v/checker/tests/generics_type_ambiguous.vv
@@ -1,4 +1,4 @@
-fn test<T, B> (a T, b T, c B, d B) {
+fn test[T, B] (a T, b T, c B, d B) {
     println("$a $b $c $d")
 }
 

--- a/vlib/v/checker/tests/incorrect_smartcast2_err.out
+++ b/vlib/v/checker/tests/incorrect_smartcast2_err.out
@@ -1,13 +1,13 @@
 vlib/v/checker/tests/incorrect_smartcast2_err.vv:24:9: notice: smartcast can only be used on the ident or selector, e.g. match foo, match foo.bar
    22 |
-   23 | fn doesntwork(v []Either<int, int>) {
+   23 | fn doesntwork(v []Either[int, int]) {
    24 |     match v[0] {
       |            ~~~
-   25 |         Left<int> {
+   25 |         Left[int] {
    26 |             println(v[0].error)
 vlib/v/checker/tests/incorrect_smartcast2_err.vv:26:17: error: field `error` does not exist or have the same type in all sumtype variants
    24 |     match v[0] {
-   25 |         Left<int> {
+   25 |         Left[int] {
    26 |             println(v[0].error)
       |                          ~~~~~
    27 |         }

--- a/vlib/v/checker/tests/incorrect_smartcast2_err.vv
+++ b/vlib/v/checker/tests/incorrect_smartcast2_err.vv
@@ -1,28 +1,28 @@
-struct Left<E> {
+struct Left[E] {
 	error E
 }
 
-struct Right<T> {
+struct Right[T] {
 	inner T
 }
 
-type Either<T, E> =
-	Left<E> |
-	Right<T>
+type Either[T, E] =
+	Left[E] |
+	Right[T]
 
-fn works(v []Either<int, int>) {
+fn works(v []Either[int, int]) {
 	first := v[0]
 	match first {
-		Left<int> {
+		Left[int] {
 			println(first.error)
 		}
 		else {}
 	}
 }
 
-fn doesntwork(v []Either<int, int>) {
+fn doesntwork(v []Either[int, int]) {
 	match v[0] {
-		Left<int> {
+		Left[int] {
 			println(v[0].error)
 		}
 		else {}

--- a/vlib/v/checker/tests/map_of_generic_struct_init_err.vv
+++ b/vlib/v/checker/tests/map_of_generic_struct_init_err.vv
@@ -1,4 +1,4 @@
-struct Item<T>{
+struct Item[T]{
 	val T
 }
 

--- a/vlib/v/checker/tests/method_generic_infer_err.vv
+++ b/vlib/v/checker/tests/method_generic_infer_err.vv
@@ -1,6 +1,6 @@
 struct Data {}
 
-fn (_ Data) func<T>() T {
+fn (_ Data) func[T]() T {
 	return T{}
 }
 

--- a/vlib/v/checker/tests/optional_fn_err.vv
+++ b/vlib/v/checker/tests/optional_fn_err.vv
@@ -5,7 +5,7 @@ fn foo() ? {
 	println('foo is called')
 }
 
-fn bar<T>(v T) ?T {
+fn bar[T](v T) ?T {
 	return none
 }
 

--- a/vlib/v/checker/tests/struct_field_with_default_err.out
+++ b/vlib/v/checker/tests/struct_field_with_default_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/struct_field_with_default_err.vv:2:22: error: unknown struct `T`
-    1 | struct Dummy<T> {
+    1 | struct Dummy[T] {
     2 |     arbitrary_field T = T{}
       |                         ~~~
     3 | }

--- a/vlib/v/checker/tests/struct_field_with_default_err.vv
+++ b/vlib/v/checker/tests/struct_field_with_default_err.vv
@@ -1,4 +1,4 @@
-struct Dummy<T> {
+struct Dummy[T] {
 	arbitrary_field T = T{}
 }
 

--- a/vlib/v/checker/tests/type_alias_struct_generic_unknown_name_err.out
+++ b/vlib/v/checker/tests/type_alias_struct_generic_unknown_name_err.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/type_alias_struct_generic_unknown_name_err.vv:7:16: error: unknown type `UnknownType`
     5 | }
-    6 | 
-    7 | type NewType = Foo<UnknownType>
+    6 |
+    7 | type NewType = Foo[UnknownType]
       |                ~~~~~~~~~~~~~~~~
-    8 | 
+    8 |
     9 | fn main() {

--- a/vlib/v/checker/tests/type_alias_struct_generic_unknown_name_err.vv
+++ b/vlib/v/checker/tests/type_alias_struct_generic_unknown_name_err.vv
@@ -1,10 +1,10 @@
 module main
 
-struct Foo<T> {
+struct Foo[T] {
 	value T
 }
 
-type NewType = Foo<UnknownType>
+type NewType = Foo[UnknownType]
 
 fn main() {
 }

--- a/vlib/v/checker/tests/unknown_generic_type.out
+++ b/vlib/v/checker/tests/unknown_generic_type.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/unknown_generic_type.vv:6:13: error: unknown type `Foo`
     4 |
     5 | fn main() {
-    6 |     x := decode<Foo>('{"name": "test"}')?
+    6 |     x := decode[Foo]('{"name": "test"}')?
       |                ~~~~~
     7 |     println(x)
     8 | }

--- a/vlib/v/checker/tests/unknown_generic_type.vv
+++ b/vlib/v/checker/tests/unknown_generic_type.vv
@@ -1,8 +1,8 @@
-fn decode<T>(raw_data string) ?T {
+fn decode[T](raw_data string) ?T {
 	return none
 }
 
 fn main() {
-	x := decode<Foo>('{"name": "test"}')?
+	x := decode[Foo]('{"name": "test"}')?
 	println(x)
 }

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -54,8 +54,8 @@ fn (s Struct) method(v StructMethodArg) StructMethodRet {
 	return StructMethodRet{}
 }
 
-fn (s Struct) method_generic<T>(v StructMethodArgGeneric<T>) StructMethodRetGeneric<T> {
-	return StructMethodRet<T>{}
+fn (s Struct) method_generic[T](v StructMethodArgGeneric[T]) StructMethodRetGeneric[T] {
+	return StructMethodRet[T]{}
 }
 
 interface Interface {
@@ -74,8 +74,8 @@ fn f(v FnArg) FnRet {
 
 fn f2(v Generic<FnArgTypeParam1, FnArgTypeParam2>) Generic<FnRetTypeParam1, FnRetTypeParam2> {}
 
-fn f_generic<T>(v FnArgGeneric<T>) FnRetGeneric<T> {
-	return FnRetGeneric<T>{}
+fn f_generic[T](v FnArgGeneric[T]) FnRetGeneric[T] {
+	return FnRetGeneric[T]{}
 }
 
 struct App {

--- a/vlib/v/gen/c/testdata/check_combination_of_alias_and_sumtype.vv
+++ b/vlib/v/gen/c/testdata/check_combination_of_alias_and_sumtype.vv
@@ -4,31 +4,31 @@ struct Token {}
 
 struct ParseErr {}
 
-type Opt<T> = None<T> | Some<T>
+type Opt[T] = None[T] | Some[T]
 
-struct None<T> {}
+struct None[T] {}
 
-struct Some<T> {
+struct Some[T] {
 	value T
 }
 
-type Result<T, U> = Err<U> | Ok<T>
+type Result[T, U] = Err[U] | Ok[T]
 
-struct Ok<T> {
+struct Ok[T] {
 	value T
 }
 
-struct Err<U> {
+struct Err[U] {
 	value U
 }
 
 fn main() {
-	r := Opt<ParseRes>(None<ParseRes>{})
+	r := Opt[ParseRes](None[ParseRes]{})
 	match r {
-		Some<ParseRes> {
+		Some[ParseRes] {
 			// make possible cast fo the same type!
-			rx := Result<[]Token, ParseErr>(r.value)
+			rx := Result[[]Token, ParseErr](r.value)
 		}
-		None<ParseRes> {}
+		None[ParseRes] {}
 	}
 }

--- a/vlib/v/parser/tests/fn_param_name_cap.out
+++ b/vlib/v/parser/tests/fn_param_name_cap.out
@@ -1,7 +1,7 @@
-vlib/v/parser/tests/fn_param_name_cap.vv:6:9: error: parameter name must not begin with upper case letter (`T`)
-    4 | fn f(Type)
-    5 | 
-    6 | fn g<T>(T v) {
+vlib/v/parser/tests/fn_param_name_cap.vv:5:9: error: parameter name must not begin with upper case letter (`T`)
+    3 | fn f(Type)
+    4 |
+    5 | fn g[T](T v) {
       |         ^
-    7 |     
-    8 | }
+    6 | }
+    7 |

--- a/vlib/v/parser/tests/fn_param_name_cap.vv
+++ b/vlib/v/parser/tests/fn_param_name_cap.vv
@@ -1,10 +1,8 @@
 type Type = int
 
-// OK
 fn f(Type)
 
-fn g<T>(T v) {
-	
+fn g[T](T v) {
 }
 
 g(5)

--- a/vlib/v/parser/tests/generic_struct_parameter_err.out
+++ b/vlib/v/parser/tests/generic_struct_parameter_err.out
@@ -1,7 +1,7 @@
 vlib/v/parser/tests/generic_struct_parameter_err.vv:10:17: error: the parameter type name of a generic struct, must be a single capital letter placeholder name, like T or X, or a non-generic type name like int, string, etc.
-    8 | struct MyContainer<T> {
+    8 | struct MyContainer[T] {
     9 | mut:
-   10 |     lst LinkedList<MyNode<T>>
+   10 |     lst LinkedList[MyNode[T]]
       |                    ~~~~~~~~~
    11 | }
    12 |

--- a/vlib/v/parser/tests/generic_struct_parameter_err.vv
+++ b/vlib/v/parser/tests/generic_struct_parameter_err.vv
@@ -1,23 +1,23 @@
 import datatypes { LinkedList }
 
-struct MyNode<T> {
+struct MyNode[T] {
 mut:
 	data T
 }
 
-struct MyContainer<T> {
+struct MyContainer[T] {
 mut:
-	lst LinkedList<MyNode<T>>
+	lst LinkedList[MyNode[T]]
 }
 
-fn (mut c MyContainer<T>) push(data T) {
-	node := MyNode<T>{
+fn (mut c MyContainer[T]) push(data T) {
+	node := MyNode[T]{
 		data: data
 	}
-	c.lst.push<T>(node)
+	c.lst.push[T](node)
 }
 
 fn main() {
-	mut c := MyContainer<string>{}
+	mut c := MyContainer[string]{}
 	println(c)
 }

--- a/vlib/v/parser/tests/generic_struct_receiver_nested_generic_err.out
+++ b/vlib/v/parser/tests/generic_struct_receiver_nested_generic_err.out
@@ -1,5 +1,5 @@
 vlib/v/parser/tests/generic_struct_receiver_nested_generic_err.vv:5:11: error: the parameter type name of a generic struct, must be a single capital letter placeholder name, like T or X, or a non-generic type name like int, string, etc.
     3 | }
-    4 | 
-    5 | fn (a Foo<Foo<T>>) baz() {}
+    4 |
+    5 | fn (a Foo[Foo[T]]) baz() {}
       |           ~~~~~~

--- a/vlib/v/parser/tests/generic_struct_receiver_nested_generic_err.vv
+++ b/vlib/v/parser/tests/generic_struct_receiver_nested_generic_err.vv
@@ -1,5 +1,5 @@
-struct Foo<T> {
+struct Foo[T] {
 	bar T
 }
 
-fn (a Foo<Foo<T>>) baz() {}
+fn (a Foo[Foo[T]]) baz() {}

--- a/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.out
+++ b/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.out
@@ -1,7 +1,7 @@
 vlib/v/parser/tests/generic_struct_type_using_multi_return_err.vv:6:18: error: cannot use multi return as generic concrete type
     4 |
     5 | fn main() {
-    6 |     sample := Tuple<(int, int)>{}
+    6 |     sample := Tuple[(int, int)]{}
       |                     ~~~~~~~~~~
     7 |     println(sample)
     8 | }

--- a/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.vv
+++ b/vlib/v/parser/tests/generic_struct_type_using_multi_return_err.vv
@@ -1,8 +1,8 @@
-struct Tuple<T> {
+struct Tuple[T] {
 	data T
 }
 
 fn main() {
-	sample := Tuple<(int, int)>{}
+	sample := Tuple[(int, int)]{}
 	println(sample)
 }

--- a/vlib/v/parser/tests/generic_type_alias_decl.out
+++ b/vlib/v/parser/tests/generic_type_alias_decl.out
@@ -1,3 +1,3 @@
 vlib/v/parser/tests/generic_type_alias_decl.vv:1:1: error: generic type aliases are not yet implemented
-    1 | type Pointer<T> = &T
+    1 | type Pointer[T] = &T
       | ~~~~~~~~~~~~~~~

--- a/vlib/v/parser/tests/generic_type_alias_decl.vv
+++ b/vlib/v/parser/tests/generic_type_alias_decl.vv
@@ -1,1 +1,1 @@
-type Pointer<T> = &T
+type Pointer[T] = &T

--- a/vlib/v/tests/inout/dump_generic_fn_mut_arg.vv
+++ b/vlib/v/tests/inout/dump_generic_fn_mut_arg.vv
@@ -7,6 +7,6 @@ fn main() {
 	do(mut r)
 }
 
-pub fn do<T>(mut t T) {
+pub fn do[T](mut t T) {
 	dump(t)
 }

--- a/vlib/v/tests/inout/dump_generic_interface_ref_arg.vv
+++ b/vlib/v/tests/inout/dump_generic_interface_ref_arg.vv
@@ -32,7 +32,7 @@ fn main() {
 	run(&mi)
 }
 
-fn run<T>(in_put T) {
+fn run[T](in_put T) {
 	dump(in_put.in_())
 	dump(in_put.out())
 	$if T is InOut {

--- a/vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv
+++ b/vlib/v/tests/inout/dump_nested_generic_fn_call_ref_arg.vv
@@ -10,19 +10,19 @@ pub fn (s &Score) ave() f64 {
 	return s.ave
 }
 
-fn next<T>(input T) f64 {
+fn next[T](input T) f64 {
 	$if T is Average {
 		dump('${T.name} $input')
-		ret := next2<T>(input)
+		ret := next2[T](input)
 		return ret
 	} $else {
 		dump('${T.name} $input')
-		ret := next2<T>(input)
+		ret := next2[T](input)
 		return ret
 	}
 }
 
-fn next2<T>(input T) f64 {
+fn next2[T](input T) f64 {
 	dump('${T.name} $input')
 	$if T is Average {
 		return input.ave()

--- a/vlib/v/tests/inout/generic_fn_with_array_arg.vv
+++ b/vlib/v/tests/inout/generic_fn_with_array_arg.vv
@@ -6,7 +6,7 @@ fn main() {
 	func(mut b)
 }
 
-fn func<T>(mut t T) {
+fn func[T](mut t T) {
 	$if T is $Array {
 		for i in 0 .. t.len {
 			println(t[i])

--- a/vlib/v/tests/inout/nested_generic_fn_call.vv
+++ b/vlib/v/tests/inout/nested_generic_fn_call.vv
@@ -1,10 +1,10 @@
 module main
 
-fn shuffle_impl<T>(mut a []T) ? {
+fn shuffle_impl[T](mut a []T) ? {
 	println('FN: ${@FN:20} | T: ${typeof(a).name}')
 }
 
-fn shuffle<T>(mut a []T) ? {
+fn shuffle[T](mut a []T) ? {
 	println('FN: ${@FN:20} | T: ${typeof(a).name}')
 	shuffle_impl(mut a)?
 }

--- a/vlib/v/tests/inout/printing_comptime_if.vv
+++ b/vlib/v/tests/inout/printing_comptime_if.vv
@@ -3,7 +3,7 @@ fn main() {
 	proc(c)
 }
 
-fn proc<T>(input T) {
+fn proc[T](input T) {
 	$if T is &u8 {
 		println('T is $T.name')
 	}

--- a/vlib/v/tests/known_errors/testdata/cast_aliases_on_generics_type.vv
+++ b/vlib/v/tests/known_errors/testdata/cast_aliases_on_generics_type.vv
@@ -2,30 +2,30 @@ type ParseRes = Result<[]Token, ParseErr>
 
 struct ParseErr {}
 
-type Opt<T> = None<T> | Some<T>
+type Opt[T] = None[T] | Some[T]
 
-struct None<T> {}
+struct None[T] {}
 
-struct Some<T> {
+struct Some[T] {
 	value T
 }
 
-type Result<T, U> = Err<U> | Ok<T>
+type Result[T, U] = Err[U] | Ok[T]
 
-struct Ok<T> {
+struct Ok[T] {
 	value T
 }
 
-struct Err<U> {
+struct Err[U] {
 	value U
 }
 
 fn test_report() {
-	r := Opt<ParseRes>(None<ParseRes>{})
+	r := Opt[ParseRes](None[ParseRes]{})
 	match r {
-		Some<ParseRes> {
-			rx := Result<[]Token, ParseErr>(r.value)
+		Some[ParseRes] {
+			rx := Result[[]Token, ParseErr](r.value)
 		}
-		None<ParseRes> {}
+		None[ParseRes] {}
 	}
 }

--- a/vlib/v/tests/skip_unused/nested_generics_method.vv
+++ b/vlib/v/tests/skip_unused/nested_generics_method.vv
@@ -7,7 +7,7 @@ struct TypeA {}
 
 struct TypeB {}
 
-fn (mut c Calc<S>) next<T>(input T) f64 {
+fn (mut c Calc<S>) next[T](input T) f64 {
 	$if S is TypeA || S is TypeB {
 		return c.typ.next(input)
 	} $else {
@@ -15,21 +15,21 @@ fn (mut c Calc<S>) next<T>(input T) f64 {
 	}
 }
 
-fn (mut t TypeA) next<T>(input T) f64 {
+fn (mut t TypeA) next[T](input T) f64 {
 	return 10
 }
 
-fn (mut t TypeB) next<T>(input T) f64 {
+fn (mut t TypeB) next[T](input T) f64 {
 	return 11
 }
 
-fn new<S>() Calc<S> {
+fn new[S]() Calc[S] {
 	$if S is TypeA {
-		return Calc<TypeA>{
+		return Calc[TypeA]{
 			typ: TypeA{}
 		}
 	} $else $if S is TypeB {
-		return Calc<TypeB>{
+		return Calc[TypeB]{
 			typ: TypeB{}
 		}
 	} $else {
@@ -39,13 +39,13 @@ fn new<S>() Calc<S> {
 
 fn main() {
 	{
-		mut c := Calc<TypeA>{
+		mut c := Calc[TypeA]{
 			typ: TypeA{}
 		}
 		assert c.next(100) == 10.0
 	}
 	{
-		mut c := Calc<TypeB>{
+		mut c := Calc[TypeB]{
 			typ: TypeB{}
 		}
 		assert c.next(100) == 11.0

--- a/vlib/x/json2/json_module_compatibility_test/json_decode_todo_test.vv
+++ b/vlib/x/json2/json_module_compatibility_test/json_decode_todo_test.vv
@@ -13,7 +13,7 @@ mut:
 
 fn test_json_decode_fails_to_decode_unrecognised_array_of_dicts() {
 	data := '[{"twins":[{"id":123,"seed":"abcde","pubkey":"xyzasd"},{"id":456,"seed":"dfgdfgdfgd","pubkey":"skjldskljh45sdf"}]}]'
-	json.decode<TestTwins>(data) or {
+	json.decode[TestTwins](data) or {
 		assert err.msg() == "expected field 'twins' is missing"
 		return
 	}
@@ -22,7 +22,7 @@ fn test_json_decode_fails_to_decode_unrecognised_array_of_dicts() {
 
 fn test_json_decode_works_with_a_dict_of_arrays() {
 	data := '{"twins":[{"id":123,"seed":"abcde","pubkey":"xyzasd"},{"id":456,"seed":"dfgdfgdfgd","pubkey":"skjldskljh45sdf"}]}'
-	res := json.decode<TestTwins>(data) or {
+	res := json.decode[TestTwins](data) or {
 		assert false
 		exit(1)
 	}
@@ -40,7 +40,7 @@ struct Mount {
 
 fn test_decode_u64() {
 	data := '{"size": 10737418240}'
-	m := json.decode<Mount>(data)!
+	m := json.decode[Mount](data)!
 	assert m.size == 10737418240
 	// println(m)
 }
@@ -64,7 +64,7 @@ mut:
 
 fn test_skip_fields_should_be_initialised_by_json_decode() {
 	data := '{"total_comments": 55, "id": 123}'
-	mut task := json.decode<Task>(data)!
+	mut task := json.decode[Task](data)!
 	assert task.id == 123
 	assert task.total_comments == 55
 	assert task.comments == []
@@ -79,7 +79,7 @@ struct DbConfig {
 }
 
 fn test_decode_error_message_should_have_enough_context_empty() {
-	json.decode<DbConfig>('') or {
+	json.decode[DbConfig]('') or {
 		assert err.msg().len < 2
 		return
 	}
@@ -87,7 +87,7 @@ fn test_decode_error_message_should_have_enough_context_empty() {
 }
 
 fn test_decode_error_message_should_have_enough_context_just_brace() {
-	json.decode<DbConfig>('{') or {
+	json.decode[DbConfig]('{') or {
 		assert err.msg() == '{'
 		return
 	}
@@ -100,7 +100,7 @@ fn test_decode_error_message_should_have_enough_context_trailing_comma_at_end() 
     "dbname": "alex",
     "user": "alex",
 }'
-	json.decode<DbConfig>(txt) or {
+	json.decode[DbConfig](txt) or {
 		assert err.msg() == '    "user": "alex",\n}'
 		return
 	}
@@ -109,7 +109,7 @@ fn test_decode_error_message_should_have_enough_context_trailing_comma_at_end() 
 
 fn test_decode_error_message_should_have_enough_context_in_the_middle() {
 	txt := '{"host": "localhost", "dbname": "alex" "user": "alex", "port": "1234"}'
-	json.decode<DbConfig>(txt) or {
+	json.decode[DbConfig](txt) or {
 		assert err.msg() == 'ost", "dbname": "alex" "user":'
 		return
 	}

--- a/vlib/x/json2/json_module_compatibility_test/json_decode_with_encode_arg_todo_test.vv
+++ b/vlib/x/json2/json_module_compatibility_test/json_decode_with_encode_arg_todo_test.vv
@@ -6,7 +6,7 @@ struct TodoDto {
 
 fn test_decode_with_encode_arg() {
 	body := TodoDto{}
-	ret := json.decode<TodoDto>(json.encode(body))!
+	ret := json.decode[TodoDto](json.encode(body))!
 	println(ret)
 	assert ret.foo == 0
 }

--- a/vlib/x/json2/json_module_compatibility_test/json_decode_with_generic_todo_test.vv
+++ b/vlib/x/json2/json_module_compatibility_test/json_decode_with_generic_todo_test.vv
@@ -1,6 +1,6 @@
 import x.json2 as json
 
-struct Result<T> {
+struct Result[T] {
 	ok     bool
 	result T
 }
@@ -10,14 +10,14 @@ struct User {
 	username string
 }
 
-fn func<T>() !T {
+fn func[T]() !T {
 	text := '{"ok": true, "result":{"id":37467243, "username": "ciao"}}'
-	a := json.decode<Result<T>>(text)!
+	a := json.decode[Result[T]](text)!
 	return a.result
 }
 
 fn test_decode_with_generic_struct() {
-	ret := func<User>()!
+	ret := func[User]()!
 	println(ret)
 	assert ret.id == 37467243
 	assert ret.username == 'ciao'

--- a/vlib/x/json2/json_module_compatibility_test/json_todo_test.vv
+++ b/vlib/x/json2/json_module_compatibility_test/json_todo_test.vv
@@ -282,7 +282,7 @@ fn test_nested_type() {
 	}
 }
 
-struct Foo<T> {
+struct Foo[T] {
 pub:
 	name string
 	data T
@@ -290,10 +290,10 @@ pub:
 
 //! BUGFIX - .from_json(res)
 fn test_generic_struct() {
-	foo_int := Foo<int>{'bar', 12}
+	foo_int := Foo[int]{'bar', 12}
 	foo_enc := json.encode(foo_int)
 	assert foo_enc == '{"name":"bar","data":12}'
-	foo_dec := json.decode<Foo<int>>(foo_enc)!
+	foo_dec := json.decode[Foo[int]](foo_enc)!
 	assert foo_dec.name == 'bar'
 	assert foo_dec.data == 12
 }
@@ -302,7 +302,7 @@ fn test_generic_struct() {
 fn test_errors() {
 	invalid_array := fn () {
 		data := '{"countries":[{"cities":[{"name":"London"},{"name":"Manchester"}],"name":"UK"},{"cities":{"name":"Donlon"},"name":"KU"}],"users":{"Foo":{"age":10,"nums":[1,2,3],"lastName":"Johnson","IsRegistered":true,"type":0,"pet_animals":"little foo"},"Boo":{"age":20,"nums":[5,3,1],"lastName":"Smith","IsRegistered":false,"type":4,"pet_animals":"little boo"}},"extra":{"2":{"n1":2,"n2":4,"n3":8,"n4":16},"3":{"n1":3,"n2":9,"n3":27,"n4":81}}}'
-		json.decode<Data>(data) or {
+		json.decode[Data](data) or {
 			assert err.msg().starts_with('Json element is not an array:')
 			return
 		}
@@ -310,7 +310,7 @@ fn test_errors() {
 	}
 	invalid_object := fn () {
 		data := '{"countries":[{"cities":[{"name":"London"},{"name":"Manchester"}],"name":"UK"},{"cities":[{"name":"Donlon"},{"name":"Termanches"}],"name":"KU"}],"users":[{"age":10,"nums":[1,2,3],"lastName":"Johnson","IsRegistered":true,"type":0,"pet_animals":"little foo"},{"age":20,"nums":[5,3,1],"lastName":"Smith","IsRegistered":false,"type":4,"pet_animals":"little boo"}],"extra":{"2":{"n1":2,"n2":4,"n3":8,"n4":16},"3":{"n1":3,"n2":9,"n3":27,"n4":81}}}'
-		json.decode<Data>(data) or {
+		json.decode[Data](data) or {
 			assert err.msg().starts_with('Json element is not an object:')
 			return
 		}
@@ -330,7 +330,7 @@ struct Message {
 
 //! BUGFIX - .from_json(res)
 fn test_decode_alias_struct() {
-	msg := json.decode<Message>('{"id": "118499178790780929"}')!
+	msg := json.decode[Message]('{"id": "118499178790780929"}')!
 	// hacky way of comparing aliased strings
 	assert msg.id.str() == '118499178790780929'
 }
@@ -342,21 +342,21 @@ struct List {
 
 //! BUGFIX - .from_json(res)
 fn test_list() {
-	list := json.decode<List>('{"id": 1, "items": ["1", "2"]}')!
+	list := json.decode[List]('{"id": 1, "items": ["1", "2"]}')!
 	assert list.id == 1
 	assert list.items == ['1', '2']
 }
 
 //! BUGFIX - .from_json(res)
 fn test_list_no_id() {
-	list := json.decode<List>('{"items": ["1", "2"]}')!
+	list := json.decode[List]('{"items": ["1", "2"]}')!
 	assert list.id == 0
 	assert list.items == ['1', '2']
 }
 
 //! BUGFIX - .from_json(res)
 fn test_list_no_items() {
-	list := json.decode<List>('{"id": 1}')!
+	list := json.decode[List]('{"id": 1}')!
 	assert list.id == 1
 	assert list.items == []
 }
@@ -369,7 +369,7 @@ struct Info {
 
 //! BUGFIX - .from_json(res)
 fn test_decode_null_object() {
-	info := json.decode<Info>('{"id": 22, "items": null, "maps": null}')!
+	info := json.decode[Info]('{"id": 22, "items": null, "maps": null}')!
 	assert info.id == 22
 	assert '${info.items}' == '[]'
 	assert '${info.maps}' == '{}'
@@ -377,7 +377,7 @@ fn test_decode_null_object() {
 
 //! BUGFIX - .from_json(res)
 fn test_decode_missing_maps_field() {
-	info := json.decode<Info>('{"id": 22, "items": null}')!
+	info := json.decode[Info]('{"id": 22, "items": null}')!
 	assert info.id == 22
 	assert '${info.items}' == '[]'
 	assert '${info.maps}' == '{}'


### PR DESCRIPTION
This PR replace generic '<>' with '[]' in .vv files.