### PR TITLE
cgen: fix string of map with generic struct value (fix #16594)

### DIFF
--- a/vlib/v/tests/string_map_with_generic_struct_value_test.v
+++ b/vlib/v/tests/string_map_with_generic_struct_value_test.v
@@ -1,0 +1,7 @@
+import datatypes
+
+fn test_string_map_with_generic_struct_value() {
+	p := map[string]datatypes.Stack[int]{}
+	println(p)
+	assert '${p}' == '{}'
+}


### PR DESCRIPTION
This PR fix string of map with generic struct value (fix #16594).

- Fix string of map with generic struct value.
- Add test.

```v
import datatypes

fn main() {
	p := map[string]datatypes.Stack[int]{}
	println(p)
	assert '${p}' == '{}'
}

PS D:\Test\v\tt1> v run .
{}
```