### PR TITLE
cgen: fix array init with fields (fix #16596)

### DIFF
--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -460,7 +460,7 @@ const (
 
 struct CharClass {
 mut:
-	cc_type   int = regex.cc_null // type of cc token
+	cc_type   int         // type of cc token
 	ch0       rune        // first char of the interval a-b  a in this case
 	ch1       rune        // second char of the interval a-b b in this case
 	validator FnValidator // validator function pointer

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -303,7 +303,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.write('&(${elem_styp}[]){')
 		g.write('_SLIT("")')
 		g.write('})')
-	} else if node.has_len && elem_type.unaliased_sym.kind in [.array, .map] {
+	} else if node.has_len && elem_type.unaliased_sym.kind in [.struct_, .array, .map] {
 		g.write('(voidptr)&(${elem_styp}[]){')
 		g.write(g.type_default(node.elem_type))
 		g.write('}[0])')

--- a/vlib/v/tests/array_init_with_fields_test.v
+++ b/vlib/v/tests/array_init_with_fields_test.v
@@ -1,0 +1,63 @@
+import datatypes
+
+struct Fluid[T] {
+mut:
+	elements  datatypes.Queue[T]
+	switch    bool // 0 by default
+	selements datatypes.Stack[T]
+}
+
+fn (mut fluid Fluid[T]) push(item T) {
+	if fluid.switch {
+		fluid.selements.push(item)
+	} else {
+		fluid.elements.push(item)
+	}
+}
+
+fn (mut fluid Fluid[T]) pop() !T {
+	if fluid.switch {
+		return fluid.selements.pop()!
+	} else {
+		return fluid.elements.pop()!
+	}
+}
+
+fn (fluid Fluid[T]) str() string {
+	if fluid.switch {
+		return fluid.selements.str()
+	} else {
+		return fluid.elements.str()
+	}
+}
+
+fn (fluid Fluid[T]) peek() !T {
+	if fluid.switch {
+		return fluid.selements.peek()!
+	} else {
+		return fluid.elements.peek()!
+	}
+}
+
+// this function converts queue to stack
+fn (mut fluid Fluid[T]) to_stack() !bool {
+	if !fluid.switch {
+		// convert queue to stack
+		for i in 1 .. fluid.elements.len() + 1 {
+			fluid.selements.push(fluid.elements.index(fluid.elements.len() - i)!)
+		}
+		fluid.switch = true
+	}
+	return true
+}
+
+fn test_array_init_with_fields() {
+	mut arr := []Fluid[string]{len: 10}
+	for i in 0 .. arr.len {
+		// add str to queue
+		arr[i].push('${10 + i}')
+	}
+	println(arr)
+	ret := arr[1].to_stack()!
+	assert ret
+}


### PR DESCRIPTION
This PR fix array init with fields (fix #16596).

- Fix array init with fields.
- Add test.

```v
import datatypes

struct Fluid[T] {
mut:
	elements  datatypes.Queue[T]
	switch    bool // 0 by default
	selements datatypes.Stack[T]
}

fn (mut fluid Fluid[T]) push(item T) {
	if fluid.switch {
		fluid.selements.push(item)
	} else {
		fluid.elements.push(item)
	}
}

fn (mut fluid Fluid[T]) pop() !T {
	if fluid.switch {
		return fluid.selements.pop()!
	} else {
		return fluid.elements.pop()!
	}
}

fn (fluid Fluid[T]) str() string {
	if fluid.switch {
		return fluid.selements.str()
	} else {
		return fluid.elements.str()
	}
}

fn (fluid Fluid[T]) peek() !T {
	if fluid.switch {
		return fluid.selements.peek()!
	} else {
		return fluid.elements.peek()!
	}
}

// this function converts queue to stack
fn (mut fluid Fluid[T]) to_stack() !bool {
	if !fluid.switch {
		// convert queue to stack
		for i in 1 .. fluid.elements.len() + 1 {
			fluid.selements.push(fluid.elements.index(fluid.elements.len() - i)!)
		}
		fluid.switch = true
	}
	return true
}

fn main() {
	mut arr := []Fluid[string]{len: 10}
	for i in 0 .. arr.len {
		// add str to queue
		arr[i].push('${10 + i}')
	}
	println(arr)
	ret := arr[1].to_stack()!
	assert ret
}

PS D:\Test\v\tt1> v run .
[['10'], ['11'], ['12'], ['13'], ['14'], ['15'], ['16'], ['17'], ['18'], ['19']]
```