### PR TITLE
checker: fix panic caused by compile-time code within or block

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1049,12 +1049,16 @@ fn (mut c Checker) check_or_last_stmt(stmt ast.Stmt, ret_type ast.Type, expr_ret
 				if stmt.typ == ast.void_type {
 					if stmt.expr is ast.IfExpr {
 						for branch in stmt.expr.branches {
-							c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+							if branch.stmts.len > 0 {
+								c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+							}
 						}
 						return
 					} else if stmt.expr is ast.MatchExpr {
 						for branch in stmt.expr.branches {
-							c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+							if branch.stmts.len > 0 {
+								c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+							}
 						}
 						return
 					}
@@ -1090,12 +1094,16 @@ fn (mut c Checker) check_or_last_stmt(stmt ast.Stmt, ret_type ast.Type, expr_ret
 		match stmt.expr {
 			ast.IfExpr {
 				for branch in stmt.expr.branches {
-					c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+					if branch.stmts.len > 0 {
+						c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+					}
 				}
 			}
 			ast.MatchExpr {
 				for branch in stmt.expr.branches {
-					c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+					if branch.stmts.len > 0 {
+						c.check_or_last_stmt(branch.stmts.last(), ret_type, expr_return_type)
+					}
 				}
 			}
 			else {

--- a/vlib/v/tests/or_expr_with_comptime_test.v
+++ b/vlib/v/tests/or_expr_with_comptime_test.v
@@ -1,0 +1,9 @@
+fn foo() ! {
+}
+
+fn test_bar() {
+	foo() or {
+		$if linux {
+		}
+	}
+}


### PR DESCRIPTION
Fix for #16538 bug

```
fn foo() ! {
}

foo() or {
    $if linux {
    }
}
```