### PR TITLE
parser: fix parsing embedded generic interface using '[]'

### DIFF
--- a/vlib/v/checker/tests/generics_interface_decl_no_mention_err.out
+++ b/vlib/v/checker/tests/generics_interface_decl_no_mention_err.out
@@ -1,19 +1,19 @@
 vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:4:2: error: generic type name `T` is not mentioned in interface `Foo<U>`
     2 |
     3 | interface Foo[U] {
-    4 |     Bar<T>
+    4 |     Bar[T]
       |     ~~~
     5 |     foo(u U, p P)
     6 |     bar(u U) []P
 vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:5:13: error: generic type name `P` is not mentioned in interface `Foo<U>`
     3 | interface Foo[U] {
-    4 |     Bar<T>
+    4 |     Bar[T]
     5 |     foo(u U, p P)
       |                ^
     6 |     bar(u U) []P
     7 | }
 vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv:6:11: error: generic type name `P` is not mentioned in interface `Foo<U>`
-    4 |     Bar<T>
+    4 |     Bar[T]
     5 |     foo(u U, p P)
     6 |     bar(u U) []P
       |              ~~~

--- a/vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv
+++ b/vlib/v/checker/tests/generics_interface_decl_no_mention_err.vv
@@ -1,7 +1,7 @@
 fn main() {}
 
 interface Foo[U] {
-	Bar<T>
+	Bar[T]
 	foo(u U, p P)
 	bar(u U) []P
 }

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -569,7 +569,8 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
 		if p.tok.kind == .name && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 			&& (p.peek_tok.line_nr != p.tok.line_nr
-			|| p.peek_tok.kind !in [.name, .amp, .lsbr, .lpar]) {
+			|| p.peek_tok.kind !in [.name, .amp, .lsbr, .lpar]
+			|| (p.peek_tok.kind == .lsbr && p.peek_tok.pos - p.tok.pos == p.tok.len)) {
 			iface_pos := p.tok.pos()
 			mut iface_name := p.tok.lit
 			iface_type := p.parse_type()
@@ -624,7 +625,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_mut = true
 			mut_pos = fields.len
 		}
-		if p.peek_tok.kind == .lt {
+		if p.peek_tok.kind in [.lt, .lsbr] && p.peek_tok.pos - p.tok.pos == p.tok.len {
 			p.error_with_pos("no need to add generic type names in generic interface's method",
 				p.peek_tok.pos())
 			return ast.InterfaceDecl{}


### PR DESCRIPTION
This PR fix parsing embedded generic interface using '[]'.