### PR TITLE
parser: fix parsing generic types using '[]' in anon fn decl

### DIFF
--- a/vlib/v/checker/tests/assign_generic_fn_err.out
+++ b/vlib/v/checker/tests/assign_generic_fn_err.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/assign_generic_fn_err.vv:2:9: error: cannot assign generic function to a variable
     1 | fn main() {
-    2 |     fun := fn <T> (value T) T {
+    2 |     fun := fn [T] (value T) T {
       |            ~~~~~~~~~~~~~~~~~~~~
     3 |         return value
     4 |     }

--- a/vlib/v/checker/tests/assign_generic_fn_err.vv
+++ b/vlib/v/checker/tests/assign_generic_fn_err.vv
@@ -1,5 +1,5 @@
 fn main() {
-	fun := fn <T> (value T) T {
+	fun := fn [T] (value T) T {
 		return value
 	}
 

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -687,7 +687,12 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		p.close_scope()
 	}
 	p.scope.detached_from_parent = true
-	inherited_vars := if p.tok.kind == .lsbr { p.closure_vars() } else { []ast.Param{} }
+	inherited_vars := if p.tok.kind == .lsbr && !(p.peek_tok.kind == .name
+		&& p.peek_tok.lit.len == 1 && p.peek_tok.lit[0].is_capital()) {
+		p.closure_vars()
+	} else {
+		[]ast.Param{}
+	}
 	_, generic_names := p.parse_generic_types()
 	args, _, is_variadic := p.fn_args()
 	for arg in args {


### PR DESCRIPTION
This PR fix parsing generic types using '[]' in anon fn decl.