### PR TITLE
checker: Fix incompatible struct checking

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4000,7 +4000,7 @@ fn (mut c Checker) error(message string, pos token.Pos) {
 
 fn (c &Checker) check_struct_signature_init_fields(from ast.Struct, to ast.Struct, node ast.StructInit) bool {
 	if node.fields.len == 0 {
-		return true
+		return from.fields.len == to.fields.len
 	}
 
 	mut count_not_in_from := 0
@@ -4011,11 +4011,7 @@ fn (c &Checker) check_struct_signature_init_fields(from ast.Struct, to ast.Struc
 		}
 	}
 
-	if (from.fields.len + count_not_in_from) != to.fields.len {
-		return false
-	}
-
-	return true
+	return (from.fields.len + count_not_in_from) == to.fields.len
 }
 
 // check `to` has all fields of `from`

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3998,10 +3998,30 @@ fn (mut c Checker) error(message string, pos token.Pos) {
 	c.warn_or_error(msg, pos, false)
 }
 
+fn (c &Checker) check_struct_signature_init_fields(from ast.Struct, to ast.Struct, node ast.StructInit) bool {
+	if node.fields.len == 0 {
+		return true
+	}
+
+	mut count_not_in_from := 0
+	for field in node.fields {
+		filtered := from.fields.filter(it.name == field.name)
+		if filtered.len != 1 {
+			count_not_in_from++
+		}
+	}
+
+	if (from.fields.len + count_not_in_from) != to.fields.len {
+		return false
+	}
+
+	return true
+}
+
 // check `to` has all fields of `from`
 fn (c &Checker) check_struct_signature(from ast.Struct, to ast.Struct) bool {
 	// Note: `to` can have extra fields
-	if from.fields.len == 0 || from.fields.len != to.fields.len {
+	if from.fields.len == 0 {
 		return false
 	}
 	for field in from.fields {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4001,7 +4001,7 @@ fn (mut c Checker) error(message string, pos token.Pos) {
 // check `to` has all fields of `from`
 fn (c &Checker) check_struct_signature(from ast.Struct, to ast.Struct) bool {
 	// Note: `to` can have extra fields
-	if from.fields.len == 0 {
+	if from.fields.len == 0 || from.fields.len != to.fields.len {
 		return false
 	}
 	for field in from.fields {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -603,7 +603,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			from_info := from_sym.info as ast.Struct
 			to_info := to_sym.info as ast.Struct
 			// TODO this check is too strict
-			if !c.check_struct_signature(from_info, to_info) {
+			if !c.check_struct_signature(from_info, to_info) || !c.check_struct_signature_init_fields(from_info, to_info, node) {
 				c.error('struct `${from_sym.name}` is not compatible with struct `${to_sym.name}`',
 					node.update_expr.pos())
 			}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -603,7 +603,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			from_info := from_sym.info as ast.Struct
 			to_info := to_sym.info as ast.Struct
 			// TODO this check is too strict
-			if !c.check_struct_signature(from_info, to_info) || !c.check_struct_signature_init_fields(from_info, to_info, node) {
+			if !c.check_struct_signature(from_info, to_info)
+				|| !c.check_struct_signature_init_fields(from_info, to_info, node) {
 				c.error('struct `${from_sym.name}` is not compatible with struct `${to_sym.name}`',
 					node.update_expr.pos())
 			}

--- a/vlib/v/checker/tests/check_incompatible_struct.out
+++ b/vlib/v/checker/tests/check_incompatible_struct.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/check_incompatible_struct.vv:13:6: error: struct `Foo` is not compatible with struct `Bar`
+   11 |     foo := Foo{2}
+   12 |     bar := Bar{
+   13 |         ...foo
+      |            ~~~
+   14 |     }
+   15 |     print(bar)

--- a/vlib/v/checker/tests/check_incompatible_struct.out
+++ b/vlib/v/checker/tests/check_incompatible_struct.out
@@ -1,7 +1,14 @@
-vlib/v/checker/tests/check_incompatible_struct.vv:13:17: error: struct `Foo` is not compatible with struct `Bar`
-   11 |     foo := Foo{2}
-   12 |     bar2 := Bar{...foo a: 1}
-   13 |     bar3 := Bar{...foo b: 1}
-      |                    ~~~
-   14 |     bar4 := Bar{...foo b: 1 a: 2}
-   15 |     bar := Bar{...foo}
+vlib/v/checker/tests/check_incompatible_struct.vv:17:6: error: struct `Foo` is not compatible with struct `Bar`
+   15 |     }
+   16 |     bar3 := Bar{
+   17 |         ...foo
+      |            ~~~
+   18 |         b: 1
+   19 |     }
+vlib/v/checker/tests/check_incompatible_struct.vv:26:6: error: struct `Foo` is not compatible with struct `Bar`
+   24 |     }
+   25 |     bar := Bar{
+   26 |         ...foo
+      |            ~~~
+   27 |     }
+   28 |     print(bar)

--- a/vlib/v/checker/tests/check_incompatible_struct.out
+++ b/vlib/v/checker/tests/check_incompatible_struct.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/check_incompatible_struct.vv:13:6: error: struct `Foo` is not compatible with struct `Bar`
+vlib/v/checker/tests/check_incompatible_struct.vv:13:17: error: struct `Foo` is not compatible with struct `Bar`
    11 |     foo := Foo{2}
-   12 |     bar := Bar{
-   13 |         ...foo
-      |            ~~~
-   14 |     }
-   15 |     print(bar)
+   12 |     bar2 := Bar{...foo a: 1}
+   13 |     bar3 := Bar{...foo b: 1}
+      |                    ~~~
+   14 |     bar4 := Bar{...foo b: 1 a: 2}
+   15 |     bar := Bar{...foo}

--- a/vlib/v/checker/tests/check_incompatible_struct.vv
+++ b/vlib/v/checker/tests/check_incompatible_struct.vv
@@ -1,0 +1,16 @@
+struct Foo {
+	b int
+}
+
+struct Bar {
+	a int
+	b int
+}
+
+fn main() {
+	foo := Foo{2}
+	bar := Bar{
+		...foo
+	}
+	print(bar)
+}

--- a/vlib/v/checker/tests/check_incompatible_struct.vv
+++ b/vlib/v/checker/tests/check_incompatible_struct.vv
@@ -9,8 +9,12 @@ struct Bar {
 
 fn main() {
 	foo := Foo{2}
-	bar := Bar{
-		...foo
-	}
+	bar2 := Bar{...foo a: 1}
+	bar3 := Bar{...foo b: 1}
+	bar4 := Bar{...foo b: 1 a: 2}
+	bar := Bar{...foo}
 	print(bar)
+	print(bar2)
+	print(bar3)
+	print(bar4)
 }

--- a/vlib/v/checker/tests/check_incompatible_struct.vv
+++ b/vlib/v/checker/tests/check_incompatible_struct.vv
@@ -9,10 +9,22 @@ struct Bar {
 
 fn main() {
 	foo := Foo{2}
-	bar2 := Bar{...foo a: 1}
-	bar3 := Bar{...foo b: 1}
-	bar4 := Bar{...foo b: 1 a: 2}
-	bar := Bar{...foo}
+	bar2 := Bar{
+		...foo
+		a: 1
+	}
+	bar3 := Bar{
+		...foo
+		b: 1
+	}
+	bar4 := Bar{
+		...foo
+		b: 1
+		a: 2
+	}
+	bar := Bar{
+		...foo
+	}
 	print(bar)
 	print(bar2)
 	print(bar3)


### PR DESCRIPTION
Fixes #16608 bug

```
struct Foo {
	b int
}

struct Bar {
	a int
	b int
}

fn main() {
	foo := Foo{2}
	bar2 := Bar{...foo a: 1}
	bar3 := Bar{...foo b: 1}
	bar4 := Bar{...foo b: 1 a: 2}
	bar := Bar{...foo}
	print(bar)
	print(bar2)
	print(bar3)
	print(bar4)
}
```

As long Foo and Bar has 'b' field, the 'a' field on Bar was not taken in count when checking both.
