### PR TITLE
cgen: Fix nested struct generation for gcc

### DIFF
--- a/vlib/v/checker/tests/globals_run/global_nested_struct_test.vv
+++ b/vlib/v/checker/tests/globals_run/global_nested_struct_test.vv
@@ -1,0 +1,21 @@
+pub struct Foo {
+    val Bar
+}
+
+pub struct Bar {
+    number int
+}
+
+fn test_get() {
+    
+}
+
+[cinit]
+__global (
+    baz = Foo{Bar{number: 5}}
+)
+
+
+fn main() {
+    print(baz)
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -131,6 +131,7 @@ mut:
 	inside_return             bool
 	inside_return_tmpl        bool
 	inside_struct_init        bool
+	inside_struct_fields      bool
 	inside_or_block           bool
 	inside_call               bool
 	inside_for_c_stmt         bool

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -141,6 +141,7 @@ mut:
 	inside_const_opt_or_res   bool
 	inside_lambda             bool
 	inside_for_in_any_cond    bool
+	inside_cinit              bool
 	loop_depth                int
 	ternary_names             map[string]string
 	ternary_level_names       map[string][]string
@@ -5051,6 +5052,10 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 	}
 	// should the global be initialized now, not later in `vinit()`
 	cinit := node.attrs.contains('cinit')
+	g.inside_cinit = cinit
+	defer {
+		g.inside_cinit = false
+	}
 	cextern := node.attrs.contains('c_extern')
 	should_init := (!g.pref.use_cache && g.pref.build_mode != .build_module)
 		|| (g.pref.build_mode == .build_module && g.module_built == node.mod)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -131,7 +131,6 @@ mut:
 	inside_return             bool
 	inside_return_tmpl        bool
 	inside_struct_init        bool
-	inside_struct_fields      bool
 	inside_or_block           bool
 	inside_call               bool
 	inside_for_c_stmt         bool

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -44,7 +44,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !(is_gcc && g.inside_struct_fields && !g.inside_call) && !is_anon {
+	if !is_gcc && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')
@@ -65,7 +65,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		} else {
 			g.write('&(${basetyp}){')
 		}
-	} else if is_gcc && g.inside_struct_fields && !g.inside_call {
+	} else if is_gcc && g.inside_struct_fields {
 		if is_multiline {
 			g.writeln('{')
 		} else {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -143,9 +143,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					g.inside_cast_in_heap = 0 // prevent use of pointers in child structs
 
 					g.write('.${embed_name} = ')
-					g.inside_struct_fields = true
 					g.struct_init(default_init)
-					g.inside_struct_fields = false
 
 					g.inside_cast_in_heap = inside_cast_in_heap // restore value for further struct inits
 					if is_multiline {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -44,7 +44,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !is_gcc && !is_anon {
+	if !(is_gcc && g.inside_cinit) && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -93,9 +93,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			if field.typ == 0 {
 				g.checker_bug('struct init, field.typ is 0', field.pos)
 			}
-			g.inside_struct_fields = true
 			g.struct_init_field(field, sym.language)
-			g.inside_struct_fields = false
 			if i != node.fields.len - 1 {
 				if is_multiline {
 					g.writeln(',')
@@ -176,9 +174,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 				if sfield.typ == 0 {
 					continue
 				}
-				g.inside_struct_fields = true
 				g.struct_init_field(sfield, sym.language)
-				g.inside_struct_fields = false
 				if is_multiline {
 					g.writeln(',')
 				} else {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -8,7 +8,6 @@ import v.ast
 const skip_struct_init = ['struct stat', 'struct addrinfo']
 
 fn (mut g Gen) struct_init(node ast.StructInit) {
-	mut is_gcc := g.pref.ccompiler_type == .gcc
 	mut is_update_tmp_var := false
 	mut tmp_update_var := ''
 	if node.has_update_expr && !node.update_expr.is_lvalue() {
@@ -44,7 +43,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !(is_gcc && g.inside_cinit) && !is_anon {
+	if !g.inside_cinit && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')
@@ -65,7 +64,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		} else {
 			g.write('&(${basetyp}){')
 		}
-	} else if is_gcc && g.inside_cinit && g.inside_struct_fields {
+	} else if g.inside_cinit && g.inside_struct_fields {
 		if is_multiline {
 			g.writeln('{')
 		} else {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -65,7 +65,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		} else {
 			g.write('&(${basetyp}){')
 		}
-	} else if is_gcc && g.inside_struct_fields {
+	} else if is_gcc && g.inside_cinit && g.inside_struct_fields {
 		if is_multiline {
 			g.writeln('{')
 		} else {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -44,7 +44,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !is_gcc && !is_anon {
+	if !(is_gcc && !g.inside_call) && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -44,7 +44,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !(is_gcc && !g.inside_call) && !is_anon {
+	if !(is_gcc && g.inside_struct_fields && !g.inside_call) && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -44,7 +44,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !is_gcc && !is_anon {
+	if !(is_gcc && g.inside_struct_fields) && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -64,7 +64,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		} else {
 			g.write('&(${basetyp}){')
 		}
-	} else if g.inside_cinit && g.inside_struct_fields {
+	} else if g.inside_cinit {
 		if is_multiline {
 			g.writeln('{')
 		} else {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -44,7 +44,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = info.is_anon
 	}
 
-	if !(is_gcc && g.inside_struct_fields) && !is_anon {
+	if !is_gcc && !is_anon {
 		g.write('(')
 		defer {
 			g.write(')')
@@ -65,7 +65,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		} else {
 			g.write('&(${basetyp}){')
 		}
-	} else if is_gcc && g.inside_struct_fields {
+	} else if is_gcc && g.inside_struct_fields && !g.inside_call {
 		if is_multiline {
 			g.writeln('{')
 		} else {


### PR DESCRIPTION
Fixes issue #16528

```
pub struct Foo {
    val Bar
}

pub struct Bar {
    number int
}

[cinit]
__global (
    baz = Foo{Bar{number: 5}}
)

fn main() {
    print(baz)
}
```