### PR TITLE
vwatch: speedup by monitoring only files returned by -print-v-files switch

### DIFF
--- a/cmd/tools/vwatch.v
+++ b/cmd/tools/vwatch.v
@@ -275,7 +275,7 @@ fn main() {
 	}
 	fp.version('0.0.2')
 	fp.description('Collect all .v files needed for a compilation, then re-run the compilation when any of the source changes.')
-	fp.arguments_description('[--silent] [--clear] [--ignore .db] [--add /path/to/a/file.v] [run] program.v')
+	fp.arguments_description('[--silent] [--clear] [--add /path/to/a/file.v] [run] program.v')
 	fp.allow_unknown_args()
 	fp.limit_free_args_to_at_least(1)!
 	context.is_worker = fp.bool('vwatchworker', 0, false, 'Internal flag. Used to distinguish vwatch manager and worker processes.')

--- a/cmd/v/help/watch.txt
+++ b/cmd/v/help/watch.txt
@@ -14,11 +14,6 @@ Options:
                             when you want to change *both* the V compiler,
                             and the `feature.v` file.
 
-  -i, --ignore <string>     Ignore files having these extensions.
-                            Useful with `v watch -ignore=.db run vwebserver.v`,
-                            if your `vwebserver` writes to an sqlite.db file in the
-                            same folder.
-
   --before <string>         A command to execute *before* each re-run. Example: --before 'v wipe-cache'
   
   --after <string>          A command to execute *after* each re-run. Example: --after 'rm -rf /tmp/v/'


### PR DESCRIPTION
Hello, here's an improvement done on vwatch.v file.
Indeed, current implementation polls much more files than those returned by `-print-v-files` switch.
It can lead to high CPU usage especially on slow filesystems (NTFS).

I propose an improvement by monitoring only the files returned by `-print-v-files` switch.

I tested on a Windows PC (NTFS filesystem) and on a Linux PC (ext4 filesystem) and CPU usage is reduced a lot.

Remark : now that only needed files are monitored, I removed the `-i, --ignore <string>` option.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
