### PR TITLE
cgen: fix error of match c generation (fix #16554)

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -86,6 +86,11 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		cur_line = g.go_before_stmt(0).trim_left(' \t')
 		tmp_var = g.new_tmp_var()
 		g.writeln('${g.typ(node.return_type)} ${tmp_var} = ${g.type_default(node.return_type)};')
+		g.empty_line = true
+		if g.infix_left_var_name.len > 0 {
+			g.writeln('if (${g.infix_left_var_name}) {')
+			g.indent++
+		}
 	}
 
 	if is_expr && !need_tmp_var {
@@ -125,6 +130,14 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		}
 	}
 	g.set_current_pos_as_last_stmt_pos()
+	if need_tmp_var {
+		if g.infix_left_var_name.len > 0 {
+			g.writeln('')
+			g.indent--
+			g.writeln('}')
+			g.set_current_pos_as_last_stmt_pos()
+		}
+	}
 	g.write(cur_line)
 	if need_tmp_var {
 		g.write('${tmp_var}')

--- a/vlib/v/tests/match_expr_skip_in_infix_expr_test.v
+++ b/vlib/v/tests/match_expr_skip_in_infix_expr_test.v
@@ -1,0 +1,33 @@
+fn test_match_expr_skip_in_infix_expr_1() {
+	mut a := false
+	b := a && match true {
+		true {
+			a = true
+			true
+		}
+		false {
+			false
+		}
+	}
+	println(a)
+	assert a == false
+	println(b)
+	assert b == false
+}
+
+fn test_match_expr_skip_in_infix_expr_2() {
+	mut a := true
+	b := a || match true {
+		true {
+			a = false
+			true
+		}
+		false {
+			false
+		}
+	}
+	println(a)
+	assert a == true
+	println(b)
+	assert b == true
+}


### PR DESCRIPTION
This PR fix error of match c generation (fix #16554).

- #16555 is not complete enough.
- Fix it completely.

generated c codes:
```v
VV_LOCAL_SYMBOL void main__main(void) {
	bool a = true;
	bool _t1 = (a);
	bool _t2 = true;
	bool _t3 = 0;
	if (_t1) {
		
		if (_t2 == (true)) {
			a = false;
			_t3 = true;
		}
		else if (_t2 == (false)) {
			_t3 = false;
		}
	}
	bool b = _t1 && _t3;
	println(a ? _SLIT("true") : _SLIT("false"));
	println(b ? _SLIT("true") : _SLIT("false"));
}
```
```v
fn test_match_expr_skip_in_infix_expr_1() {
	mut a := false
	b := a && match true {
		true {
			a = true
			true
		}
		false {
			false
		}
	}
	println(a)
	assert a == false
	println(b)
	assert b == false
}

fn test_match_expr_skip_in_infix_expr_2() {
	mut a := true
	b := a || match true {
		true {
			a = false
			true
		}
		false {
			false
		}
	}
	println(a)
	assert a == true
	println(b)
	assert b == true
}
```