### PR TITLE
string: Fix bug with split_into_lines when strings have extra CR's

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -851,7 +851,7 @@ pub fn (s string) split_into_lines() []string {
 	mut start := 0
 	for i := 0; i < s.len; i++ {
 		if s[i] == 10 {
-			res << if start == i { '' } else { s[start..i].trim_right("\r") }
+			res << if start == i { '' } else { s[start..i].trim_right('\r') }
 			start = i + 1
 		}
 	}

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -849,11 +849,9 @@ pub fn (s string) split_into_lines() []string {
 		return res
 	}
 	mut start := 0
-	mut end := 0
 	for i := 0; i < s.len; i++ {
 		if s[i] == 10 {
-			end = if i > 0 && s[i - 1] == 13 { i - 1 } else { i }
-			res << if start == end { '' } else { s[start..end] }
+			res << if start == i { '' } else { s[start..i].trim_right("\r") }
 			start = i + 1
 		}
 	}


### PR DESCRIPTION
Explain what your PR does and why.

- When checking out V for my first time, I tried running `println(os.user_names()!)`. I expected an array of all the users on the system to be printed, but instead `'] 'WDAGUtilityAccount` was printed. After a lot of digging, I found the culprit to be that the output of the WMI command `os.user_names()` run on Windows has line ends consisting of `\r\r\n` instead of the standard `\r\n`
  - Seems that this is an issue that occurs in lot of Windows programs
  - I fixed this by replacing the check for a single `\r` at the end of each string with `trim_right('\r')` that removes every `\r` at the end of each string