### PR TITLE
cgen: fix typeof[T]() return

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3525,9 +3525,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 		varg_elem_type_sym := g.table.sym(g.table.value_type(typ))
 		g.write('_SLIT("...${util.strip_main_name(varg_elem_type_sym.name)}")')
 	} else {
-		x := g.table.type_to_str(typ)
-		y := util.strip_main_name(x)
-		g.write('_SLIT("${y}")')
+		g.type_name(typ)
 	}
 }
 

--- a/vlib/v/tests/fn_return_typeof_test.v
+++ b/vlib/v/tests/fn_return_typeof_test.v
@@ -1,0 +1,12 @@
+fn foo[T]() string {
+	return typeof[T]().name
+}
+
+fn bar[T]() string {
+	return typeof[T]()
+}
+
+fn test_main() {
+	assert foo[int]() == 'int'
+	assert bar[int]() == 'int'
+}


### PR DESCRIPTION
Fixes the following bug (#16611):

```
fn bar[T]() string {
    return typeof[T]()
}

print(bar[int]()) // 'T' instead of 'int'
```