### PR TITLE
orm: declare missing functions to handle literal types

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -137,6 +137,7 @@ const (
 		'vlib/crypto/rand/crypto_rand_read_test.v',
 		'vlib/net/smtp/smtp_test.v',
 		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
+		'vlib/v/tests/fn_literal_type_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'vlib/net/websocket/websocket_test.v',
@@ -189,6 +190,7 @@ const (
 		'vlib/builtin/js/array_test.js.v',
 		'vlib/net/smtp/smtp_test.v',
 		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
+		'vlib/v/tests/fn_literal_type_test.v',
 	]
 	skip_on_linux                 = [
 		'do_not_remove',
@@ -224,6 +226,7 @@ const (
 		'vlib/sync/many_times_test.v',
 		'vlib/sync/once_test.v',
 		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
+		'vlib/v/tests/fn_literal_type_test.v',
 	]
 	skip_on_non_windows           = [
 		'do_not_remove',

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -562,10 +562,12 @@ pub fn int_to_primitive(b int) Primitive {
 	return Primitive(b)
 }
 
+// Handles int literal value
 pub fn int_literal_to_primitive(b int) Primitive {
 	return Primitive(b)
 }
 
+// Handles float literal value
 pub fn float_literal_to_primitive(b f64) Primitive {
 	return Primitive(b)
 }

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -562,12 +562,12 @@ pub fn int_to_primitive(b int) Primitive {
 	return Primitive(b)
 }
 
-// Handles int literal value
+// int_literal_to_primitive handles int literal value
 pub fn int_literal_to_primitive(b int) Primitive {
 	return Primitive(b)
 }
 
-// Handles float literal value
+// float_literal_to_primitive handles float literal value
 pub fn float_literal_to_primitive(b f64) Primitive {
 	return Primitive(b)
 }

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -562,6 +562,14 @@ pub fn int_to_primitive(b int) Primitive {
 	return Primitive(b)
 }
 
+pub fn int_literal_to_primitive(b int) Primitive {
+	return Primitive(b)
+}
+
+pub fn float_literal_to_primitive(b f64) Primitive {
+	return Primitive(b)
+}
+
 pub fn i64_to_primitive(b i64) Primitive {
 	return Primitive(b)
 }

--- a/vlib/v/tests/fn_literal_type_test.v
+++ b/vlib/v/tests/fn_literal_type_test.v
@@ -2,12 +2,12 @@ import sqlite
 
 [table: 'Users']
 struct User {
-	id int [primary; sql: serial]
+	id   int    [primary; sql: serial]
 	name string
 }
 
 const (
-	const_users_offset = 1
+	const_users_offset  = 1
 	const_users_offset2 = 1
 )
 

--- a/vlib/v/tests/fn_literal_type_test.v
+++ b/vlib/v/tests/fn_literal_type_test.v
@@ -1,0 +1,36 @@
+import sqlite
+
+[table: 'Users']
+struct User {
+	id int [primary; sql: serial]
+	name string
+}
+
+const (
+	const_users_offset = 1
+	const_users_offset2 = 1
+)
+
+fn test_orm() {
+	db := sqlite.connect(':memory:') or { panic(err) }
+
+	upper_1 := User{
+		name: 'Test'
+	}
+
+	upper_2 := User{
+		name: 'Test2'
+	}
+
+	sql db {
+		create table User
+		insert upper_1 into User
+		insert upper_2 into User
+	} or { panic(err) }
+
+	result := sql db {
+		select from User limit const_users_offset2
+	} or { panic(err) }
+
+	assert result[0].name == 'Test'
+}


### PR DESCRIPTION
Fix #16579 bug

```
const (
	const_users_offset = 5
	const_users_offset2 = 5.2
)
```