### PR TITLE
fontstash: use `cbrt` instead of `pow` in `stb_truetype.h`

### DIFF
--- a/thirdparty/fontstash/stb_truetype.h
+++ b/thirdparty/fontstash/stb_truetype.h
@@ -442,7 +442,7 @@ int main(int arg, char **argv)
    #ifndef STBTT_sqrt
    #include <math.h>
    #define STBTT_sqrt(x)      sqrt(x)
-   #define STBTT_pow(x,y)     pow(x,y)
+   #define STBTT_cbrt(x)      cbrt(x)
    #endif
 
    #ifndef STBTT_fmod
@@ -4479,9 +4479,9 @@ static int stbtt__compute_crossings_x(float x, float y, int nverts, stbtt_vertex
 static float stbtt__cuberoot( float x )
 {
    if (x<0)
-      return -(float) STBTT_pow(-x,1.0f/3.0f);
+      return -STBTT_cbrt(-x);
    else
-      return  (float) STBTT_pow( x,1.0f/3.0f);
+      return  STBTT_cbrt(x);
 }
 
 // x^3 + c*x^2 + b*x + a = 0


### PR DESCRIPTION
This is useful for readability and because `pow` requires a relatively new `glibc` version and `cbrt` does not, which is good for backwards compatibility and cross-compilation.

`cbrt` was added in C99[^1].

[^1]: https://en.cppreference.com/w/c/numeric/math/cbrt

PS: I am not sure if this is the way to go (or if it should maybe go into upstream `stb_truetype.h` as well), but I think this should work for now.