### PR TITLE
github: change bug template Envionment field to textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -73,7 +73,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: environment
     attributes:
       label: Environment details (OS name and version, etc.)


### PR DESCRIPTION
Environment field suggests using `v doctor`, but only gave a single line input field.

This changes the field to a textarea to accommodate full `v doctor` output.