### PR TITLE
checker: fix generic fn returning result (fix #16644)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1285,7 +1285,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		} else if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
 			concrete_types)
 		{
-			node.return_type = typ
+			if typ.has_flag(.generic) {
+				node.return_type = typ
+			}
 			return typ
 		}
 	}

--- a/vlib/v/tests/generics_fn_return_result_test.v
+++ b/vlib/v/tests/generics_fn_return_result_test.v
@@ -1,0 +1,21 @@
+fn make_2x3[T](mut res [][]T) ! {
+	mut a := []T{len: 6}
+	res = reshape(a, [2, 3])!
+}
+
+fn reshape[T](y []T, dims []int) ![][]T {
+	mut res := [][]T{len: dims[0], init: []T{len: 1}}
+	return res
+}
+
+fn test_generic_fn_return_result() {
+	mut acopy := [][]f32{len: 1, init: []f32{len: 1}}
+	make_2x3(mut acopy)!
+	dump(acopy)
+	assert '${acopy}' == '[[0.0], [0.0]]'
+
+	mut bcopy := [][]u8{len: 1, init: []u8{len: 1}}
+	make_2x3(mut bcopy)!
+	dump(bcopy)
+	assert '${bcopy}' == '[[0], [0]]'
+}


### PR DESCRIPTION
This PR fix generic fn returning result (fix #16644).

- Fix generic fn returning result.
- Add test.

```v
fn make_2x3[T](mut res [][]T) ! {
	mut a := []T{len: 6}
	res = reshape(a, [2, 3])!
}

fn reshape[T](y []T, dims []int) ![][]T {
	mut res := [][]T{len: dims[0], init: []T{len: 1}}
	return res
}

fn main() {
	mut acopy := [][]f32{len: 1, init: []f32{len: 1}}
	make_2x3(mut acopy)!
	dump(acopy)
	assert '${acopy}' == '[[0.0], [0.0]]'

	mut bcopy := [][]u8{len: 1, init: []u8{len: 1}}
	make_2x3(mut bcopy)!
	dump(bcopy)
	assert '${bcopy}' == '[[0], [0]]'
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:14] acopy: [[0.0], [0.0]]
[.\\tt1.v:18] bcopy: [[0], [0]]
```