### PR TITLE
parser: fix initializing option type syntax

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -28,7 +28,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		line_nr := p.tok.line_nr
 		p.next()
 		// []string
-		if p.tok.kind in [.name, .amp, .lsbr, .key_shared] && p.tok.line_nr == line_nr {
+		if p.tok.kind in [.name, .amp, .lsbr, .question, .key_shared] && p.tok.line_nr == line_nr {
 			elem_type_pos = p.tok.pos()
 			elem_type = p.parse_type()
 			// this is set here because it's a known type, others could be the

--- a/vlib/v/tests/option_init_test.v
+++ b/vlib/v/tests/option_init_test.v
@@ -1,0 +1,6 @@
+struct Cell {}
+
+fn test_main() {
+	mut var := []?Cell{len: 1}
+	assert var.len == 1
+}


### PR DESCRIPTION
Fix bug #16651

```
struct Cell {}
fn main() {
	dump([]?Cell{len:1})
}
```

After patching produces:
```
[test.v:3] []T{len: 1}: [Option(Cell{})]
```