### PR TITLE
doc: update json2

### DIFF
--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -55,13 +55,8 @@ fn main() {
 > Codegen for this feature is still WIP.
 > You need to manually define the methods before using the module to structs.
 
-In order to use the `decode[T]` and `encode[T]` function, you need to explicitly define
-two methods: `from_json` and `to_json`. `from_json` accepts a `json2.Any` argument
-and inside of it you need to map the fields you're going to put into the type.
-As for `to_json` method, you just need to map the values into `json2.Any`
-and turn it into a string.
 
-```v ignore
+```v
 struct Person {
 mut:
     name string
@@ -69,60 +64,12 @@ mut:
     pets []string
 }
 
-fn (mut p Person) from_json(f json2.Any) {
-    obj := f.as_map()
-    for k, v in obj {
-        match k {
-            'name' { p.name = v.str() }
-            'age' { p.age = v.int() }
-            'pets' { p.pets = v.arr().map(it.str()) }
-            else {}
-        }
-    }
-}
-
-fn (p Person) to_json() string {
-    mut obj := map[string]json2.Any
-    obj['name'] = p.name
-    obj['age'] = p.age
-    obj['pets'] = p.pets
-    return obj.str()
-}
-
 fn main() {
-    resp := os.read_file('./person.json')!
+    resp := '{"name": "Bob", "age": 28, "pets": ["Floof"]}'
     person := json2.decode[Person](resp)!
     println(person) // Person{name: 'Bob', age: 28, pets: ['Floof']}
     person_json := json2.encode[Person](person)
     println(person_json) // {"name": "Bob", "age": 28, "pets": ["Floof"]}
-}
-```
-
-## Using struct tags
-`x.json2` can access and use the struct field tags similar to the
-`json` module by using the comp-time `$for` for structs.
-
-```v ignore
-fn (mut p Person) from_json(f json2.Any) {
-    mp := an.as_map()
-	mut js_field_name := ''
-    $for field in Person.fields {
-        js_field_name = field.name
-
-        for attr in field.attrs {
-			if attr.starts_with('json:') {
-				js_field_name = attr.all_after('json:').trim_left(' ')
-				break
-			}
-		}
-
-        match field.name {
-            'name' { p.name = mp[js_field_name].str() }
-			'age' { u.age = mp[js_field_name].int() }
-			'pets' { u.pets = mp[js_field_name].arr().map(it.str()) }
-			else {}
-		}
-    }
 }
 ```
 
@@ -137,27 +84,6 @@ fn (mut p Person) from_json(f json2.Any) {
         // use a default value
         p.age = 10
     }
-}
-```
-
-### Custom field names
-Aside from using struct tags, you can also just simply cast the base field into a map (`as_map()`)
-and access the field you wish to put into the struct/type.
-
-```v ignore
-fn (mut p Person) from_json(f json2.Any) {
-    obj := f.as_map()
-    p.name = obj['nickname'].str()
-}
-```
-
-```v oksyntax
-import x.json2
-
-fn (p Person) to_json() string {
-	mut obj := map[string]json2.Any{}
-	obj['nickname'] = p.name
-	return obj.str()
 }
 ```
 

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -129,7 +129,7 @@ fn main() {
 ```
 ### Null Values
 `x.json2` has a separate `null` type for differentiating an undefined value and a null value.
-To verify that the field you're accessing is a `null`, use `[typ] is json2.Null`.
+To verify that the field you're accessing is a `Null`, use `[typ] is json2.Null`.
 
 ```v ignore
 fn (mut p Person) from_json(f json2.Any) {

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -12,19 +12,19 @@ import time
 
 struct Person {
 mut:
-    name string
-    age  ?int = 20
-    birthday time.Time
-    deathday ?time.Time = none
+	name     string
+	age      ?int = 20
+	birthday time.Time
+	deathday ?time.Time = none
 }
 
 fn main() {
-    mut person := Person {
-        name "Bob"
-        birthday time.now()
-    }
-    person_json := json2.encode[Person](person) 
-    // person_json == {"name": "Bob", "age": 28, "birthday": "2022-03-11T13:54:25.000Z"}
+	mut person := Person{
+		name: 'Bob'
+		birthday: time.now()
+	}
+	person_json := json2.encode[Person](person)
+	// person_json == {"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}
 }
 ```
 
@@ -32,26 +32,27 @@ fn main() {
 
 ```v
 import x.json2
+import time
 
 struct Person {
 mut:
-    name string
-    age  ?int = 20
-    birthday time.Time
-    deathday ?time.Time = none
+	name     string
+	age      ?int = 20
+	birthday time.Time
+	deathday ?time.Time = none
 }
 
 fn main() {
-    resp := '{"name": "Bob", "age": 20, "birthday": ${time.now()}}'
-    person := json2.decode[Person](resp)!
-    /*
-      struct Person {
+	resp := '{"name": "Bob", "age": 20, "birthday": ${time.now()}}'
+	person := json2.decode[Person](resp)!
+	/*
+	struct Person {
       mut:
           name "Bob"
-          age  int = 20
+          age  20
           birthday "2022-03-11 13:54:25"
       }
-    */
+	*/
 }
 ```
 decode[T] is smart and can auto convert the type of struct fields this means that all

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -69,26 +69,31 @@ json2.decode[Person]('{"name": "Bob", "age": "20", "birthday": "1647006865"}}')!
 
 ```v
 import x.json2
+import net.http
 
 fn main() {
-	resp := '{"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}'
+	resp := http.get('https://reqres.in/api/products/1')!
 
 	// This return a Any type
-	raw_person := json2.raw_decode(resp)!
+	raw_product := json2.raw_decode(resp.body)!
 }
 ```
 #### Casting `Any` type / Navigating
 ```v
 import x.json2
+import net.http
 
 fn main() {
-	resp := '{"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}'
+	resp := http.get('https://reqres.in/api/products/1')!
 
-	raw_person := json2.raw_decode(resp)!
+	raw_product := json2.raw_decode(resp.body)!
 
-	person := raw_person.as_map()
-	name := person['name'].str() // Bob
-	age := person['age'].int() // 20
+	product := raw_product.as_map()
+	data := product['data'] as map[string]json2.Any
+
+	id := data['id'].int() // 1
+	name := data['name'].str() // cerulean
+	year := data['year'].int() // 2000
 }
 ```
 #### Constructing an `Any` type

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -74,7 +74,7 @@ import net.http
 fn main() {
 	resp := http.get('https://reqres.in/api/products/1')!
 
-	// This return a Any type
+	// This returns an Any type
 	raw_product := json2.raw_decode(resp.body)!
 }
 ```

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -128,7 +128,7 @@ fn main() {
 }
 ```
 ### Null Values
-`x.json2` has a separate `null` type for differentiating an undefined value and a null value.
+`x.json2` has a separate `Null` type for differentiating an undefined value and a null value.
 To verify that the field you're accessing is a `Null`, use `[typ] is json2.Null`.
 
 ```v ignore

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -78,9 +78,8 @@ fn main() {
 }
 ```
 #### Casting `Any` type / Navigating
-```v oksyntax
+```v
 import x.json2
-import net.http
 
 fn main() {
 	resp := '{"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}'
@@ -90,6 +89,37 @@ fn main() {
 	person := raw_person.as_map()
 	name := person['name'].str() // Bob
 	age := person['age'].int() // 20
+}
+```
+#### Constructing an `Any` type
+```v
+import x.json2
+
+fn main() {
+	mut me := map[string]json2.Any{}
+	me['name'] = 'Bob'
+	me['age'] = 18
+
+	mut arr := []json2.Any{}
+	arr << 'rock'
+	arr << 'papers'
+	arr << json2.null
+	arr << 12
+
+	me['interests'] = arr
+
+	mut pets := map[string]json2.Any{}
+	pets['Sam'] = 'Maltese Shitzu'
+	me['pets'] = pets
+
+	// Stringify to JSON
+	println(me.str())
+	//{
+	//   "name":"Bob",
+	//   "age":18,
+	//   "interests":["rock","papers","scissors",null,12],
+	//   "pets":{"Sam":"Maltese"}
+	//}
 }
 ```
 ### Null Values

--- a/vlib/x/json2/README.md
+++ b/vlib/x/json2/README.md
@@ -55,8 +55,8 @@ fn main() {
 	*/
 }
 ```
-decode[T] is smart and can auto convert the type of struct fields this means that all
-bellow will have the same result
+decode[T] is smart and can auto-convert the types of struct fields - this means
+examples below will have the same result
 
 ```v ignore
 json2.decode[Person]('{"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}')!


### PR DESCRIPTION
> The name `json2` was chosen to avoid any unwanted potential conflicts with the
> existing codegen tailored for the main `json` module which is powered by CJSON.

`x.json2` is an experimental JSON parser written from scratch on V.

## Usage
#### encode[T]

```v
import x.json2
import time

struct Person {
mut:
	name     string
	age      ?int = 20
	birthday time.Time
	deathday ?time.Time = none
}

fn main() {
	mut person := Person{
		name: 'Bob'
		birthday: time.now()
	}
	person_json := json2.encode[Person](person)
	// person_json == {"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}
}
```

#### decode[T]

```v
import x.json2
import time

struct Person {
mut:
	name     string
	age      ?int = 20
	birthday time.Time
	deathday ?time.Time = none
}

fn main() {
	resp := '{"name": "Bob", "age": 20, "birthday": ${time.now()}}'
	person := json2.decode[Person](resp)!
	/*
	struct Person {
      mut:
          name "Bob"
          age  20
          birthday "2022-03-11 13:54:25"
      }
	*/
}
```
decode[T] is smart and can auto convert the type of struct fields this means that all
bellow will have the same result

```v ignore
json2.decode[Person]('{"name": "Bob", "age": 20, "birthday": "2022-03-11T13:54:25.000Z"}')!
json2.decode[Person]('{"name": "Bob", "age": 20, "birthday": "2022-03-11 13:54:25.000"}')!
json2.decode[Person]('{"name": "Bob", "age": "20", "birthday": 1647006865}')!
json2.decode[Person]('{"name": "Bob", "age": "20", "birthday": "1647006865"}}')!
```

#### raw decode

```v
import x.json2
import net.http

fn main() {
	resp := http.get('https://reqres.in/api/products/1')!

	// This return a Any type
	raw_product := json2.raw_decode(resp.body)!
}
```
#### Casting `Any` type / Navigating
```v
import x.json2
import net.http

fn main() {
	resp := http.get('https://reqres.in/api/products/1')!

	raw_product := json2.raw_decode(resp.body)!

	product := raw_product.as_map()
	data := product['data'] as map[string]json2.Any

	id := data['id'].int() // 1
	name := data['name'].str() // cerulean
	year := data['year'].int() // 2000
}
```
#### Constructing an `Any` type
```v
import x.json2

fn main() {
	mut me := map[string]json2.Any{}
	me['name'] = 'Bob'
	me['age'] = 18

	mut arr := []json2.Any{}
	arr << 'rock'
	arr << 'papers'
	arr << json2.null
	arr << 12

	me['interests'] = arr

	mut pets := map[string]json2.Any{}
	pets['Sam'] = 'Maltese Shitzu'
	me['pets'] = pets

	// Stringify to JSON
	println(me.str())
	//{
	//   "name":"Bob",
	//   "age":18,
	//   "interests":["rock","papers","scissors",null,12],
	//   "pets":{"Sam":"Maltese"}
	//}
}
```
### Null Values
`x.json2` has a separate `null` type for differentiating an undefined value and a null value.
To verify that the field you're accessing is a `null`, use `[typ] is json2.Null`.

```v ignore
fn (mut p Person) from_json(f json2.Any) {
    obj := f.as_map()
    if obj['age'] is json2.Null {
        // use a default value
        p.age = 10
    }
}
```

## Casting a value to an incompatible type
`x.json2` provides methods for turning `Any` types into usable types.
The following list shows the possible outputs when casting a value to an incompatible type.

1. Casting non-array values as array (`arr()`) will return an array with the value as the content.
2. Casting non-map values as map (`as_map()`) will return a map with the value as the content.
3. Casting non-string values to string (`str()`) will return the
JSON string representation of the value.
4. Casting non-numeric values to int/float (`int()`/`i64()`/`f32()`/`f64()`) will return zero.
