### PR TITLE
builtin: `.nogrow` and `.nofree` flags in array

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -24,6 +24,8 @@ pub mut:
 pub enum ArrayFlags {
 	noslices // when <<, `.noslices` will free the old data block immediately (you have to be sure, that there are *no slices* to that specific array). TODO: integrate with reference counting/compiler support for the static cases.
 	noshrink // when `.noslices` and `.noshrink` are *both set*, .delete(x) will NOT allocate new memory and free the old. It will just move the elements in place, and adjust .len.
+	nogrow // the array will never be allowed to grow past `.cap`. set `.nogrow` and `.noshrink` for a truly fixed heap array
+	nofree // `.data` will never be freed
 }
 
 // Internal function, used by V (`nums := []int`)
@@ -132,6 +134,9 @@ fn new_array_from_c_array_no_alloc(len int, cap int, elm_size int, c_array voidp
 fn (mut a array) ensure_cap(required int) {
 	if required <= a.cap {
 		return
+	}
+	if a.flags.has(.nogrow) {
+		panic('array.ensure_cap: array with the flag `.nogrow` cannot grow in size')
 	}
 	mut cap := if a.cap > 0 { a.cap } else { 2 }
 	for required > cap {
@@ -698,6 +703,9 @@ pub fn (a &array) free() {
 	// if a.is_slice {
 	// return
 	// }
+	if a.flags.has(.nofree) {
+		return
+	}
 	mblock_ptr := &u8(u64(a.data) - u64(a.offset))
 	unsafe { free(mblock_ptr) }
 }

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -136,7 +136,7 @@ fn (mut a array) ensure_cap(required int) {
 		return
 	}
 	if a.flags.has(.nogrow) {
-		panic('array.ensure_cap: array with the flag `.nogrow` cannot grow in size')
+		panic('array.ensure_cap: array with the flag `.nogrow` cannot grow in size, array required new size: $required')
 	}
 	mut cap := if a.cap > 0 { a.cap } else { 2 }
 	for required > cap {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -136,7 +136,7 @@ fn (mut a array) ensure_cap(required int) {
 		return
 	}
 	if a.flags.has(.nogrow) {
-		panic('array.ensure_cap: array with the flag `.nogrow` cannot grow in size, array required new size: $required')
+		panic('array.ensure_cap: array with the flag `.nogrow` cannot grow in size, array required new size: ${required}')
 	}
 	mut cap := if a.cap > 0 { a.cap } else { 2 }
 	for required > cap {

--- a/vlib/builtin/array_flags_test.v
+++ b/vlib/builtin/array_flags_test.v
@@ -55,3 +55,40 @@ fn test_array_cap_shrinkage_after_deletion() {
 	assert a.len == 12
 	assert a.cap == 20
 }
+
+fn fixed_array_on_the_heap(len int, size int) []u8 {
+	data := vcalloc(size)
+	println(ptr_str(data))
+	return unsafe {
+		array{
+			element_size: 1
+			len: len
+			cap: size
+			data: data
+			flags: .noshrink | .nogrow | .nofree
+		}
+	}
+}
+
+fn test_array_fixed_growth() {
+	mut x := fixed_array_on_the_heap(0, 10)
+	println(ptr_str(x.data))
+	x << 5
+	x << 10
+	x << 15
+	x << 20
+	dump(x)
+	dump(x.flags)
+	assert x[2] == 15
+	assert x.flags == .noshrink | .nogrow | .nofree
+}
+
+fn test_array_fixed() {
+	mut x := fixed_array_on_the_heap(10, 10)
+	println(ptr_str(x.data))
+	x[2] = 5
+	dump(x)
+	dump(x.flags)
+	assert x[2] == 5
+	assert x.flags == .noshrink | .nogrow | .nofree
+}


### PR DESCRIPTION
The `.nogrow` array flag and `.nofree` flags were implemented to serve the purpose of specific manually allocated regions of memory.

```v
mut a := unsafe {
	array {
		element_size: 1
		data: C.mmap(...)
		cap: ...
		flags: .noshrink | .nogrow | .nofree
	}
}
```

On the freeing of the array, if `.nofree` flag is set the libc `free()` function will not be called on `.data` and would simply return.

Using the `.nogrow` and `.noshrink` flags in tandem will allow the a heap allocated array to behave like a fixed one.

```v
mut a := []u64{cap: 100}
unsafe { a.flags.set(.nogrow | .noshrink) }
```

[Related conversation on the V discord.](https://discord.com/channels/592103645835821068/592294828432424960/1052064181500780604)

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
