### PR TITLE
builtin: fix array init with array default (fix #16662)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -63,7 +63,7 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 	return arr
 }
 
-fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array) array {
+fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array, depth int) array {
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -74,7 +74,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array) a
 	mut eptr := &u8(arr.data)
 	unsafe {
 		for _ in 0 .. arr.len {
-			val_clone := val.clone_to_depth(1)
+			val_clone := val.clone_to_depth(depth)
 			vmemcpy(eptr, &val_clone, arr.element_size)
 			eptr += arr.element_size
 		}

--- a/vlib/builtin/array_notd_gcboehm_opt.v
+++ b/vlib/builtin/array_notd_gcboehm_opt.v
@@ -13,6 +13,6 @@ fn __new_array_with_default_noscan(mylen int, cap int, elm_size int, val voidptr
 	return __new_array_with_default(mylen, cap, elm_size, val)
 }
 
-fn __new_array_with_array_default_noscan(mylen int, cap int, elm_size int, val array) array {
-	return __new_array_with_array_default(mylen, cap, elm_size, val)
+fn __new_array_with_array_default_noscan(mylen int, cap int, elm_size int, val array, depth int) array {
+	return __new_array_with_array_default(mylen, cap, elm_size, val, depth)
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -222,9 +222,15 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 			g.write('sizeof(${elem_styp}), ')
 		}
 		if is_default_array {
+			info := elem_type.unaliased_sym.info as ast.Array
+			depth := if g.table.sym(info.elem_type).kind == .array {
+				1
+			} else {
+				0
+			}
 			g.write('(${elem_styp}[]){')
 			g.write(g.type_default(node.elem_type))
-			g.write('}[0])')
+			g.write('}[0], ${depth})')
 		} else if node.has_len && node.elem_type == ast.string_type {
 			g.write('&(${elem_styp}[]){')
 			g.write('_SLIT("")')
@@ -291,7 +297,17 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 	} else {
 		g.write('sizeof(${elem_styp}), ')
 	}
-	if is_default_array || is_default_map {
+	if is_default_array {
+		info := elem_type.unaliased_sym.info as ast.Array
+		depth := if g.table.sym(info.elem_type).kind == .array {
+			1
+		} else {
+			0
+		}
+		g.write('(${elem_styp}[]){')
+		g.expr(node.default_expr)
+		g.write('}[0], ${depth})')
+	} else if is_default_map {
 		g.write('(${elem_styp}[]){')
 		g.expr(node.default_expr)
 		g.write('}[0])')

--- a/vlib/v/tests/array_init_element_size_equal_array_size_test.v
+++ b/vlib/v/tests/array_init_element_size_equal_array_size_test.v
@@ -1,0 +1,19 @@
+import math
+
+struct Cell {
+	p_i int
+	p_j int
+	f   f64 = math.max_f64
+	g   f64 = math.max_f64
+	h   f64 = math.max_f64
+}
+
+fn test_array_init_element_size_equal_array_size() {
+	mut cells := [][]Cell{len: 1, init: []Cell{len: 1}}
+	println(cells)
+	assert '${cells[0][0].p_i}' == '0'
+	assert '${cells[0][0].p_j}' == '0'
+	assert '${cells[0][0].f}' == '1.7976931348623157e+308'
+	assert '${cells[0][0].g}' == '1.7976931348623157e+308'
+	assert '${cells[0][0].h}' == '1.7976931348623157e+308'
+}


### PR DESCRIPTION
This PR fix array init with array default (fix #16662).

- Fix array init with array default.
- Add test.

```v
import math

struct Cell {
	p_i int
	p_j int
	f   f64 = math.max_f64
	g   f64 = math.max_f64
	h   f64 = math.max_f64
}

fn main() {
	mut cells := [][]Cell{len: 1, init: []Cell{len: 1}}
	println(cells)
	assert '${cells[0][0].p_i}' == '0'
	assert '${cells[0][0].p_j}' == '0'
	assert '${cells[0][0].f}' == '1.7976931348623157e+308'
	assert '${cells[0][0].g}' == '1.7976931348623157e+308'
	assert '${cells[0][0].h}' == '1.7976931348623157e+308'
}

PS D:\Test\v\tt1> v run .
[[Cell{
    p_i: 0
    p_j: 0
    f: 1.7976931348623157e+308
    g: 1.7976931348623157e+308
    h: 1.7976931348623157e+308
}]]
```