### PR TITLE
cgen: Fix comptime checking optional type with IS operator

### DIFF
--- a/vlib/v/checker/tests/comptime_if_optional_string_test.out
+++ b/vlib/v/checker/tests/comptime_if_optional_string_test.out
@@ -1,4 +1,1 @@
-[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:10] field.name: a
-[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:14] 2: 2
-[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:10] field.name: b
-[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:12] 1: 1
+202201

--- a/vlib/v/checker/tests/comptime_if_optional_string_test.out
+++ b/vlib/v/checker/tests/comptime_if_optional_string_test.out
@@ -1,0 +1,4 @@
+[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:10] field.name: a
+[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:14] 2: 2
+[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:10] field.name: b
+[/home/felipe/github/v/vlib/v/checker/tests/comptime_if_optional_string_test.vv:12] 1: 1

--- a/vlib/v/checker/tests/comptime_if_optional_string_test.vv
+++ b/vlib/v/checker/tests/comptime_if_optional_string_test.vv
@@ -1,0 +1,17 @@
+module main
+
+struct Foo{
+	a string 
+	b ?string
+}
+
+fn test_main(){
+	$for field in Foo.fields {
+		dump(field.name)
+		$if field.typ is ?string {
+			dump(1)
+		} $else $if field.typ is string {
+			dump(2)
+		}
+	}
+}

--- a/vlib/v/checker/tests/comptime_if_optional_string_test.vv
+++ b/vlib/v/checker/tests/comptime_if_optional_string_test.vv
@@ -1,11 +1,11 @@
 module main
 
-struct Foo{
-	a string 
+struct Foo {
+	a string
 	b ?string
 }
 
-fn test_main(){
+fn test_main() {
 	$for field in Foo.fields {
 		print(field.typ)
 		$if field.typ is ?string {

--- a/vlib/v/checker/tests/comptime_if_optional_string_test.vv
+++ b/vlib/v/checker/tests/comptime_if_optional_string_test.vv
@@ -7,11 +7,11 @@ struct Foo{
 
 fn test_main(){
 	$for field in Foo.fields {
-		dump(field.name)
+		print(field.typ)
 		$if field.typ is ?string {
-			dump(1)
+			print(1)
 		} $else $if field.typ is string {
-			dump(2)
+			print(2)
 		}
 	}
 }

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -434,7 +434,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					}
 
 					if cond.op == .key_is {
-						g.write('${exp_type.idx()} == ${got_type.idx()}')
+						g.write('${exp_type.idx()} == ${got_type.idx()} && ${exp_type.has_flag(.optional)} == ${got_type.has_flag(.optional)}')
 						return exp_type == got_type
 					} else {
 						g.write('${exp_type.idx()} != ${got_type.idx()}')


### PR DESCRIPTION
Fix #16630

```V
module main

struct Foo{
	a string 
	b ?string
}

fn main(){
	$for field in Foo.fields {
		dump(field.name)
		$if field.typ is ?string {
			dump(1)
		} $else $if field.typ is string {
			dump(2)
		}
	}
}
```