### PR TITLE
builtin: apply `.nogrow` flags to gcboehm array

### DIFF
--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -66,6 +66,9 @@ fn (mut a array) ensure_cap_noscan(required int) {
 	if required <= a.cap {
 		return
 	}
+	if a.flags.has(.nogrow) {
+		panic('array.ensure_cap_noscan: array with the flag `.nogrow` cannot grow in size, array required new size: ${required}')
+	}
 	mut cap := if a.cap > 0 { a.cap } else { 2 }
 	for required > cap {
 		cap *= 2


### PR DESCRIPTION
[This is a follow up to a earlier PR.](https://github.com/vlang/v/pull/16661)

V contains separate array definitions in the `array_d_gcboehm_opt.v`, different to the main `array.v` file in the builtin library.

The array implementation specific to the boehm GC did not contain the changes needed to make use of the `.nogrow` array flag. This PR adds them in so that the programs compiled with and without the boehm GC are equivalent to ones without it.

This is a bugfix and should be applied relatively quickly.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
