### PR TITLE
cgen: Fix struct selector with or block

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3583,10 +3583,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
 		g.write('${styp} ${tmp_var} = ')
-		if is_opt_or_res { g.write('*(') }
+		if is_opt_or_res {
+			g.write('*(')
+		}
 		g.expr(node.expr)
 		g.write('.${node.field_name}')
-		if is_opt_or_res { g.write(')') }
+		if is_opt_or_res {
+			g.write(')')
+		}
 		g.or_block(tmp_var, node.or_block, node.typ)
 		g.write(stmt_str)
 		g.write(' ')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3583,7 +3583,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
 		g.write('${styp} ${tmp_var} = ')
-		if is_opt_or_res { g.write('*)') }
+		if is_opt_or_res { g.write('*(') }
 		g.expr(node.expr)
 		g.write('.${node.field_name}')
 		if is_opt_or_res { g.write(')') }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3577,18 +3577,18 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 
 	if node.or_block.kind != .absent && !g.is_assign_lhs && g.table.sym(node.typ).kind != .chan {
-		mut is_opt_or_res := node.typ.has_flag(.optional) || node.typ.has_flag(.result)
+		is_ptr := g.table.sym(g.unwrap_generic(node.expr_type)).kind in [.interface_, .sum_type]
 		stmt_str := g.go_before_stmt(0).trim_space()
 		styp := g.typ(node.typ)
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
 		g.write('${styp} ${tmp_var} = ')
-		if is_opt_or_res {
+		if is_ptr {
 			g.write('*(')
 		}
 		g.expr(node.expr)
 		g.write('.${node.field_name}')
-		if is_opt_or_res {
+		if is_ptr {
 			g.write(')')
 		}
 		g.or_block(tmp_var, node.or_block, node.typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3582,8 +3582,10 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
 		g.write('${styp} ${tmp_var} = ')
+		g.write('*(')
 		g.expr(node.expr)
 		g.write('.${node.field_name}')
+		g.write(')')
 		g.or_block(tmp_var, node.or_block, node.typ)
 		g.write(stmt_str)
 		g.write(' ')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3577,15 +3577,16 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 
 	if node.or_block.kind != .absent && !g.is_assign_lhs && g.table.sym(node.typ).kind != .chan {
+		mut is_opt_or_res := node.typ.has_flag(.optional) || node.typ.has_flag(.result)
 		stmt_str := g.go_before_stmt(0).trim_space()
 		styp := g.typ(node.typ)
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
 		g.write('${styp} ${tmp_var} = ')
-		g.write('*(')
+		if is_opt_or_res { g.write('*)') }
 		g.expr(node.expr)
 		g.write('.${node.field_name}')
-		g.write(')')
+		if is_opt_or_res { g.write(')') }
 		g.or_block(tmp_var, node.or_block, node.typ)
 		g.write(stmt_str)
 		g.write(' ')

--- a/vlib/v/tests/struct_selector_or_block_test.v
+++ b/vlib/v/tests/struct_selector_or_block_test.v
@@ -1,0 +1,26 @@
+module main
+
+interface Greeting {
+	tt ?string
+}
+
+struct Hello {
+	tt    ?string = none
+	value string
+}
+
+struct Hi {
+	tt ?string = none
+}
+
+fn greet(g Greeting) string {
+	// Problematic piece of code here
+	// If I leave it unchecked, the compiler complains (as expected)
+	t := g.tt or { 'UNKNOWN' }
+	return t
+}
+
+fn test_main() {
+	assert greet(Hello{}) == 'UNKNOWN'
+	assert greet(Hello{'cool', ''}) == 'cool'
+}


### PR DESCRIPTION
Fix #16581

```V
module main

interface Greeting {
	tt ?string
}

struct Hello {
	tt    ?string = none
	value string
}

struct Hi {
	tt ?string = none
}

fn greet(g Greeting) string {
	// Problematic piece of code here
	// If I leave it unchecked, the compiler complains (as expected)
	t := g.tt or { 'UNKNOWN' }
	return t
}

fn test_main() {
	assert greet(Hello{}) == 'UNKNOWN'
	assert greet(Hello{'cool', ''}) == 'cool'
}
```