### PR TITLE
ast, parser: fix generic struct init with inconsistent generic types (fix #16668)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -89,17 +89,18 @@ pub struct TypeSymbol {
 pub:
 	parent_idx int
 pub mut:
-	info     TypeInfo
-	kind     Kind
-	name     string // the internal & source name of the type, i.e. `[5]int`.
-	cname    string // the name with no dots for use in the generated C code
-	methods  []Fn
-	mod      string
-	is_pub   bool
-	language Language
-	idx      int
-	size     int = -1
-	align    int = -1
+	info          TypeInfo
+	kind          Kind
+	name          string // the internal & source name of the type, i.e. `[5]int`.
+	cname         string // the name with no dots for use in the generated C code
+	methods       []Fn
+	generic_types []Type
+	mod           string
+	is_pub        bool
+	language      Language
+	idx           int
+	size          int = -1
+	align         int = -1
 }
 
 // max of 8

--- a/vlib/v/tests/generics_struct_init_with_inconsistent_generic_types_3_test.v
+++ b/vlib/v/tests/generics_struct_init_with_inconsistent_generic_types_3_test.v
@@ -1,0 +1,34 @@
+module main
+
+pub struct Maybe[T] {
+	present bool
+	val     T
+}
+
+pub fn some[T](t T) Maybe[T] {
+	return Maybe[T]{true, t}
+}
+
+pub fn (me Maybe[T]) map[T, U](f fn (T) U) Maybe[U] {
+	if me.present {
+		return Maybe[U]{true, f(me.val)}
+	}
+	return Maybe[U]{}
+}
+
+pub fn (o Maybe[T]) get() ?T {
+	if o.present {
+		return o.val
+	} else {
+		return none
+	}
+}
+
+fn test_generics_struct_init_with_inconsistent_generic_types() {
+	m := some[int](12)
+	ret := m.map[int, string](fn (i int) string {
+		return i.str()
+	})
+	println(ret)
+	assert ret.val == '12'
+}


### PR DESCRIPTION
This PR fix generic struct init with inconsistent generic types (fix #16668).

- Fix generic struct init with inconsistent generic types.
- Add test.

```v
module main

pub struct Maybe[T] {
	present bool
	val     T
}

pub fn some[T](t T) Maybe[T] {
	return Maybe[T]{true, t}
}

pub fn (me Maybe[T]) map[T, U](f fn (T) U) Maybe[U] {
	if me.present {
		return Maybe[U]{true, f(me.val)}
	}
	return Maybe[U]{}
}

pub fn (o Maybe[T]) get() ?T {
	if o.present {
		return o.val
	} else {
		return none
	}
}

fn main() {
	m := some[int](12)
	ret := m.map[int, string](fn (i int) string {
		return i.str()
	})
	println(ret)
	assert ret.val == '12'
}

PS D:\Test\v\tt1> v run .
Maybe[string]{
    present: true
    val: '12'
}
```