### PR TITLE
add Blackman/Vigna xoroshiro128++ PRNG

### DIFF
--- a/vlib/rand/xoroshiro128pp/xoros128pp.v
+++ b/vlib/rand/xoroshiro128pp/xoros128pp.v
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 John Lloyd. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module xoroshiro128pp
+
+import rand.seed
+import rand.buffer
+
+pub const seed_len = 4 // u32, that is
+
+fn rotl(x u64, k int) u64 {
+	return (x << k) | (x >> (64 - k))
+}
+// XOROS128PPRNG ported from https://prng.di.unimi.it/xoroshiro128plusplus.c
+pub struct XOROS128PPRNG {
+	buffer.PRNGBuffer
+mut:
+	state0 u64 = u64(0x853c49e6748fea9b) ^ seed.time_seed_64()
+	state1 u64 = u64(0xda3e39cb94b95bdb) ^ seed.time_seed_64()
+}
+
+// seed seeds the XOROS128PPRNG with 4 `u32` values.
+pub fn (mut rng XOROS128PPRNG) seed(seed_data []u32) {
+	if seed_data.len != 4 {
+		eprintln('XOROS128PPRNG needs 4 u32s to be seeded.')
+		exit(1)
+	}
+	init_state0 := u64(seed_data[0]) | (u64(seed_data[1]) << 32)
+	init_state1 := u64(seed_data[2]) | (u64(seed_data[3]) << 32)
+	rng.state0 = init_state0
+	rng.state1 = init_state1
+	rng.u64()
+	rng.u64()
+	rng.bytes_left = 0
+	rng.buffer = 0
+}
+
+// byte returns a uniformly distributed pseudorandom 8-bit unsigned `byte`.
+[inline]
+pub fn (mut rng XOROS128PPRNG) u8() u8 {
+	if rng.bytes_left >= 1 {
+		rng.bytes_left -= 1
+		value := u8(rng.buffer)
+		rng.buffer >>= 8
+		return value
+	}
+	ans := rng.u64()
+	rng.buffer = ans >> 8
+	rng.bytes_left = 7
+	value := u8(ans)
+	return value
+}
+
+// u16 returns a pseudorandom 16-bit unsigned integer (`u16`).
+[inline]
+pub fn (mut rng XOROS128PPRNG) u16() u16 {
+	if rng.bytes_left >= 2 {
+		rng.bytes_left -= 2
+		value := u16(rng.buffer)
+		rng.buffer >>= 16
+		return value
+	}
+	ans := rng.u64()
+	rng.buffer = u32(ans >> 16)
+	rng.bytes_left = 6
+	return u16(ans)
+}
+
+// u32 returns a pseudorandom unsigned `u32`.
+[inline]
+pub fn (mut rng XOROS128PPRNG) u32() u32 {
+	if rng.bytes_left >= 4 {
+		rng.bytes_left -= 4
+		value := u32(rng.buffer)
+		rng.buffer >>= 32
+		return value
+	}
+	ans := rng.u64()
+	rng.buffer = ans >> 32
+	rng.bytes_left = 4
+	return u32(ans)
+}
+
+// u64 returns a pseudorandom 64-bit unsigned `u64`.
+[inline]
+pub fn (mut rng XOROS128PPRNG) u64() u64 {
+	oldstate0 := rng.state0
+	mut oldstate1 := rng.state1
+	res := rotl(oldstate0 + oldstate1, 17) + oldstate0
+	oldstate1 = oldstate1 ^ oldstate0
+	rng.state0 = rotl(oldstate0, 49) ^ oldstate1 ^ (oldstate1 << 21)
+	rng.state1 = rotl(oldstate1, 28)
+	return res
+	
+}
+
+// block_size returns the number of bits that the RNG can produce in a single iteration.
+[inline]
+pub fn (mut rng XOROS128PPRNG) block_size() int {
+	return 64
+}
+
+// free should be called when the generator is no longer needed
+[unsafe]
+pub fn (mut rng XOROS128PPRNG) free() {
+	unsafe { free(rng) }
+}

--- a/vlib/rand/xoroshiro128pp/xoros128pp.v
+++ b/vlib/rand/xoroshiro128pp/xoros128pp.v
@@ -11,6 +11,7 @@ pub const seed_len = 4 // u32, that is
 fn rotl(x u64, k int) u64 {
 	return (x << k) | (x >> (64 - k))
 }
+
 // XOROS128PPRNG ported from https://prng.di.unimi.it/xoroshiro128plusplus.c
 pub struct XOROS128PPRNG {
 	buffer.PRNGBuffer
@@ -91,7 +92,6 @@ pub fn (mut rng XOROS128PPRNG) u64() u64 {
 	rng.state0 = rotl(oldstate0, 49) ^ oldstate1 ^ (oldstate1 << 21)
 	rng.state1 = rotl(oldstate1, 28)
 	return res
-	
 }
 
 // block_size returns the number of bits that the RNG can produce in a single iteration.

--- a/vlib/rand/xoroshiro128pp/xoros128pp_test.v
+++ b/vlib/rand/xoroshiro128pp/xoros128pp_test.v
@@ -1,0 +1,329 @@
+module xoroshiro128pp
+
+import math
+import rand
+import rand.seed
+
+const (
+	range_limit = 40
+	value_count = 1000
+	seeds       = [[u32(42), 242, 267, 14195], [u32(256), 340, 1451, 1505]]
+)
+
+const (
+	sample_size   = 1000
+	stats_epsilon = 0.05
+	inv_sqrt_12   = 1.0 / math.sqrt(12)
+)
+
+fn gen_randoms(seed_data []u32, bound int) []u32 {
+	mut randoms := []u32{len: 20}
+	mut rng := &rand.PRNG(&XOROS128PPRNG{})
+	rng.seed(seed_data)
+	for i in 0 .. 20 {
+		randoms[i] = rng.u32n(u32(bound)) or { panic("Couldn't obtain u32") }
+	}
+	return randoms
+}
+
+fn test_xoroshiro128pp_reproducibility() {
+	seed_data := seed.time_seed_array(4)
+	randoms1 := gen_randoms(seed_data, 1000)
+	randoms2 := gen_randoms(seed_data, 1000)
+	assert randoms1.len == randoms2.len
+	len := randoms1.len
+	for i in 0 .. len {
+		r1 := randoms1[i]
+		r2 := randoms2[i]
+		assert r1 == r2
+	}
+}
+
+fn test_xoroshiro128pp_variability() {
+	// If this test fails and if it is certainly not the implementation
+	// at fault, try changing the seed values. Repeated values are
+	// improbable but not impossible.
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		mut values := []u64{cap: value_count}
+		for i in 0 .. value_count {
+			value := rng.u64()
+			assert value !in values
+			assert values.len == i
+			values << value
+		}
+	}
+}
+
+fn check_uniformity_u64(mut rng rand.PRNG, range u64) {
+	range_f64 := f64(range)
+	expected_mean := range_f64 / 2.0
+	mut variance := 0.0
+	for _ in 0 .. sample_size {
+		diff := f64(rng.u64n(range) or { panic("Couldn't obtain u64") }) - expected_mean
+		variance += diff * diff
+	}
+	variance /= sample_size - 1
+	sigma := math.sqrt(variance)
+	expected_sigma := range_f64 * inv_sqrt_12
+	error := (sigma - expected_sigma) / expected_sigma
+	assert math.abs(error) < stats_epsilon
+}
+
+fn test_xoroshiro128pp_uniformity_u64() {
+	ranges := [14019545, 80240, 130]
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for range in ranges {
+			check_uniformity_u64(mut rng, u64(range))
+		}
+	}
+}
+
+fn check_uniformity_f64(mut rng rand.PRNG) {
+	expected_mean := 0.5
+	mut variance := 0.0
+	for _ in 0 .. sample_size {
+		diff := rng.f64() - expected_mean
+		variance += diff * diff
+	}
+	variance /= sample_size - 1
+	sigma := math.sqrt(variance)
+	expected_sigma := inv_sqrt_12
+	error := (sigma - expected_sigma) / expected_sigma
+	assert math.abs(error) < stats_epsilon
+}
+
+fn test_xoroshiro128pp_uniformity_f64() {
+	// The f64 version
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		check_uniformity_f64(mut rng)
+	}
+}
+
+fn test_xoroshiro128pp_u32n() {
+	max := u32(16384)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.u32n(max) or { panic("Couldn't obtain u32") }
+			assert value >= 0
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_u64n() {
+	max := u64(379091181005)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.u64n(max) or { panic("Couldn't obtain u64") }
+			assert value >= 0
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_u32_in_range() {
+	max := u32(484468466)
+	min := u32(316846)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.u32_in_range(u32(min), u32(max)) or {
+				panic("Couldn't obtain u32 in range")
+			}
+			assert value >= min
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_u64_in_range() {
+	max := u64(216468454685163)
+	min := u64(6848646868)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.u64_in_range(min, max) or { panic("Couldn't obtain u64 in range") }
+			assert value >= min
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_int31() {
+	max_u31 := int(0x7FFFFFFF)
+	sign_mask := int(0x80000000)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.int31()
+			assert value >= 0
+			assert value <= max_u31
+			// This statement ensures that the sign bit is zero
+			assert (value & sign_mask) == 0
+		}
+	}
+}
+
+fn test_xoroshiro128pp_int63() {
+	max_u63 := i64(0x7FFFFFFFFFFFFFFF)
+	sign_mask := i64(0x8000000000000000)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.int63()
+			assert value >= 0
+			assert value <= max_u63
+			assert (value & sign_mask) == 0
+		}
+	}
+}
+
+fn test_xoroshiro128pp_intn() {
+	max := 2525642
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.intn(max) or { panic("Couldn't obtain int") }
+			assert value >= 0
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_i64n() {
+	max := i64(3246727724653636)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.i64n(max) or { panic("Couldn't obtain i64") }
+			assert value >= 0
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_int_in_range() {
+	min := -4252
+	max := 1034
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.int_in_range(min, max) or { panic("Couldn't obtain int in range") }
+			assert value >= min
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_i64_in_range() {
+	min := i64(-24095)
+	max := i64(324058)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.i64_in_range(min, max) or { panic("Couldn't obtain i64 in range") }
+			assert value >= min
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_f32() {
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.f32()
+			assert value >= 0.0
+			assert value < 1.0
+		}
+	}
+}
+
+fn test_xoroshiro128pp_f64() {
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.f64()
+			assert value >= 0.0
+			assert value < 1.0
+		}
+	}
+}
+
+fn test_xoroshiro128pp_f32n() {
+	max := f32(357.0)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.f32n(max) or { panic("Couldn't obtain f32") }
+			assert value >= 0.0
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_f64n() {
+	max := 1.52e6
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.f64n(max) or { panic("Couldn't obtain f64") }
+			assert value >= 0.0
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_f32_in_range() {
+	min := f32(-24.0)
+	max := f32(125.0)
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.f32_in_range(min, max) or { panic("Couldn't obtain f32 in range") }
+			assert value >= min
+			assert value < max
+		}
+	}
+}
+
+fn test_xoroshiro128pp_f64_in_range() {
+	min := -548.7
+	max := 5015.2
+	for seed in seeds {
+		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+		rng.seed(seed)
+		for _ in 0 .. range_limit {
+			value := rng.f64_in_range(min, max) or { panic("Couldn't obtain f64 in range") }
+			assert value >= min
+			assert value < max
+		}
+	}
+}
+
+fn test_change_default_random_generator() {
+	rand.set_rng(&rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{}))
+}

--- a/vlib/rand/xoroshiro128pp/xoros128pp_test.v
+++ b/vlib/rand/xoroshiro128pp/xoros128pp_test.v
@@ -43,11 +43,11 @@ fn test_xoroshiro128pp_variability() {
 	// If this test fails and if it is certainly not the implementation
 	// at fault, try changing the seed values. Repeated values are
 	// improbable but not impossible.
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		mut values := []u64{cap: value_count}
-		for i in 0 .. value_count {
+		mut values := []u64{cap: xoroshiro128pp.value_count}
+		for i in 0 .. xoroshiro128pp.value_count {
 			value := rng.u64()
 			assert value !in values
 			assert values.len == i
@@ -60,21 +60,21 @@ fn check_uniformity_u64(mut rng rand.PRNG, range u64) {
 	range_f64 := f64(range)
 	expected_mean := range_f64 / 2.0
 	mut variance := 0.0
-	for _ in 0 .. sample_size {
+	for _ in 0 .. xoroshiro128pp.sample_size {
 		diff := f64(rng.u64n(range) or { panic("Couldn't obtain u64") }) - expected_mean
 		variance += diff * diff
 	}
-	variance /= sample_size - 1
+	variance /= xoroshiro128pp.sample_size - 1
 	sigma := math.sqrt(variance)
-	expected_sigma := range_f64 * inv_sqrt_12
+	expected_sigma := range_f64 * xoroshiro128pp.inv_sqrt_12
 	error := (sigma - expected_sigma) / expected_sigma
-	assert math.abs(error) < stats_epsilon
+	assert math.abs(error) < xoroshiro128pp.stats_epsilon
 }
 
 fn test_xoroshiro128pp_uniformity_u64() {
 	ranges := [14019545, 80240, 130]
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
 		for range in ranges {
 			check_uniformity_u64(mut rng, u64(range))
@@ -85,21 +85,21 @@ fn test_xoroshiro128pp_uniformity_u64() {
 fn check_uniformity_f64(mut rng rand.PRNG) {
 	expected_mean := 0.5
 	mut variance := 0.0
-	for _ in 0 .. sample_size {
+	for _ in 0 .. xoroshiro128pp.sample_size {
 		diff := rng.f64() - expected_mean
 		variance += diff * diff
 	}
-	variance /= sample_size - 1
+	variance /= xoroshiro128pp.sample_size - 1
 	sigma := math.sqrt(variance)
-	expected_sigma := inv_sqrt_12
+	expected_sigma := xoroshiro128pp.inv_sqrt_12
 	error := (sigma - expected_sigma) / expected_sigma
-	assert math.abs(error) < stats_epsilon
+	assert math.abs(error) < xoroshiro128pp.stats_epsilon
 }
 
 fn test_xoroshiro128pp_uniformity_f64() {
 	// The f64 version
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
 		check_uniformity_f64(mut rng)
 	}
@@ -107,10 +107,10 @@ fn test_xoroshiro128pp_uniformity_f64() {
 
 fn test_xoroshiro128pp_u32n() {
 	max := u32(16384)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.u32n(max) or { panic("Couldn't obtain u32") }
 			assert value >= 0
 			assert value < max
@@ -120,10 +120,10 @@ fn test_xoroshiro128pp_u32n() {
 
 fn test_xoroshiro128pp_u64n() {
 	max := u64(379091181005)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.u64n(max) or { panic("Couldn't obtain u64") }
 			assert value >= 0
 			assert value < max
@@ -134,10 +134,10 @@ fn test_xoroshiro128pp_u64n() {
 fn test_xoroshiro128pp_u32_in_range() {
 	max := u32(484468466)
 	min := u32(316846)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.u32_in_range(u32(min), u32(max)) or {
 				panic("Couldn't obtain u32 in range")
 			}
@@ -150,10 +150,10 @@ fn test_xoroshiro128pp_u32_in_range() {
 fn test_xoroshiro128pp_u64_in_range() {
 	max := u64(216468454685163)
 	min := u64(6848646868)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.u64_in_range(min, max) or { panic("Couldn't obtain u64 in range") }
 			assert value >= min
 			assert value < max
@@ -164,10 +164,10 @@ fn test_xoroshiro128pp_u64_in_range() {
 fn test_xoroshiro128pp_int31() {
 	max_u31 := int(0x7FFFFFFF)
 	sign_mask := int(0x80000000)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.int31()
 			assert value >= 0
 			assert value <= max_u31
@@ -180,10 +180,10 @@ fn test_xoroshiro128pp_int31() {
 fn test_xoroshiro128pp_int63() {
 	max_u63 := i64(0x7FFFFFFFFFFFFFFF)
 	sign_mask := i64(0x8000000000000000)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.int63()
 			assert value >= 0
 			assert value <= max_u63
@@ -194,10 +194,10 @@ fn test_xoroshiro128pp_int63() {
 
 fn test_xoroshiro128pp_intn() {
 	max := 2525642
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.intn(max) or { panic("Couldn't obtain int") }
 			assert value >= 0
 			assert value < max
@@ -207,10 +207,10 @@ fn test_xoroshiro128pp_intn() {
 
 fn test_xoroshiro128pp_i64n() {
 	max := i64(3246727724653636)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.i64n(max) or { panic("Couldn't obtain i64") }
 			assert value >= 0
 			assert value < max
@@ -221,10 +221,10 @@ fn test_xoroshiro128pp_i64n() {
 fn test_xoroshiro128pp_int_in_range() {
 	min := -4252
 	max := 1034
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.int_in_range(min, max) or { panic("Couldn't obtain int in range") }
 			assert value >= min
 			assert value < max
@@ -235,10 +235,10 @@ fn test_xoroshiro128pp_int_in_range() {
 fn test_xoroshiro128pp_i64_in_range() {
 	min := i64(-24095)
 	max := i64(324058)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.i64_in_range(min, max) or { panic("Couldn't obtain i64 in range") }
 			assert value >= min
 			assert value < max
@@ -247,10 +247,10 @@ fn test_xoroshiro128pp_i64_in_range() {
 }
 
 fn test_xoroshiro128pp_f32() {
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.f32()
 			assert value >= 0.0
 			assert value < 1.0
@@ -259,10 +259,10 @@ fn test_xoroshiro128pp_f32() {
 }
 
 fn test_xoroshiro128pp_f64() {
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.f64()
 			assert value >= 0.0
 			assert value < 1.0
@@ -272,10 +272,10 @@ fn test_xoroshiro128pp_f64() {
 
 fn test_xoroshiro128pp_f32n() {
 	max := f32(357.0)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.f32n(max) or { panic("Couldn't obtain f32") }
 			assert value >= 0.0
 			assert value < max
@@ -285,10 +285,10 @@ fn test_xoroshiro128pp_f32n() {
 
 fn test_xoroshiro128pp_f64n() {
 	max := 1.52e6
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.f64n(max) or { panic("Couldn't obtain f64") }
 			assert value >= 0.0
 			assert value < max
@@ -299,10 +299,10 @@ fn test_xoroshiro128pp_f64n() {
 fn test_xoroshiro128pp_f32_in_range() {
 	min := f32(-24.0)
 	max := f32(125.0)
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.f32_in_range(min, max) or { panic("Couldn't obtain f32 in range") }
 			assert value >= min
 			assert value < max
@@ -313,10 +313,10 @@ fn test_xoroshiro128pp_f32_in_range() {
 fn test_xoroshiro128pp_f64_in_range() {
 	min := -548.7
 	max := 5015.2
-	for seed in seeds {
-		mut rng := &rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{})
+	for seed in xoroshiro128pp.seeds {
+		mut rng := &rand.PRNG(&XOROS128PPRNG{})
 		rng.seed(seed)
-		for _ in 0 .. range_limit {
+		for _ in 0 .. xoroshiro128pp.range_limit {
 			value := rng.f64_in_range(min, max) or { panic("Couldn't obtain f64 in range") }
 			assert value >= min
 			assert value < max
@@ -325,5 +325,5 @@ fn test_xoroshiro128pp_f64_in_range() {
 }
 
 fn test_change_default_random_generator() {
-	rand.set_rng(&rand.PRNG(&xoroshiro128pp.XOROS128PPRNG{}))
+	rand.set_rng(&rand.PRNG(&XOROS128PPRNG{}))
 }


### PR DESCRIPTION
This is a fast PRNG useful for signed/unsigned ints and for floating point conversions.  A smaller footprint than xoroshiro256++ (a smaller state vector), otherwise seems to be equivalent (according to the paper published with the code.)

This is a cut and paste and edit from pcg32 so apologies if I missed something in the doc.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
