### PR TITLE
all: support a Struct as map key (minimal draft)

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -149,13 +149,13 @@ fn (mut d DenseArray) expand() int {
 	return push_index
 }
 
-type MapHashFn = fn (voidptr) u64
+type MapHashFn = fn (new_key voidptr) u64
 
-type MapEqFn = fn (voidptr, voidptr) bool
+type MapEqFn = fn (new_key voidptr, existing_map_key voidptr) bool
 
-type MapCloneFn = fn (voidptr, voidptr)
+type MapCloneFn = fn (existing_map_key voidptr, new_key voidptr)
 
-type MapFreeFn = fn (voidptr)
+type MapFreeFn = fn (existing_map_key voidptr)
 
 // map is the internal representation of a V `map` type.
 pub struct map {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -117,7 +117,7 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 	key_sym := p.table.sym(key_type)
 	is_alias := key_sym.kind == .alias
 	key_type_supported := key_type in [ast.string_type_idx, ast.voidptr_type_idx]
-		|| key_sym.kind in [.enum_, .placeholder, .any]
+		|| key_sym.kind in [.enum_, .placeholder, .any, .struct_]
 		|| ((key_type.is_int() || key_type.is_float() || is_alias) && !key_type.is_ptr())
 	if !key_type_supported {
 		if is_alias {
@@ -125,7 +125,7 @@ pub fn (mut p Parser) parse_map_type() ast.Type {
 			return 0
 		}
 		s := p.table.type_to_str(key_type)
-		p.error_with_pos('maps only support string, integer, float, rune, enum or voidptr keys for now (not `${s}`)',
+		p.error_with_pos('maps only support string, integer, float, rune, enum, struct or voidptr keys for now (not `${s}`)',
 			p.tok.pos())
 		return 0
 	}

--- a/vlib/v/tests/map_struct_as_key_test.v
+++ b/vlib/v/tests/map_struct_as_key_test.v
@@ -1,0 +1,41 @@
+struct Abc {
+	x int
+	y int
+}
+
+fn (s &Abc) map_hash() u64 {
+	//    eprintln('${@METHOD} called, s: $s')
+	return u64(s.x) << 32 + u64(s.y)
+}
+
+fn (s &Abc) map_eq(b &Abc) bool {
+	//    eprintln('${@METHOD} called, s: $s')
+	return s.x == b.x && s.y == b.y
+}
+
+fn (mut s Abc) map_clone(new &Abc) {
+	//    eprintln('${@METHOD} called, s: $s | new: $new')
+	unsafe {
+		*s = *new
+	}
+}
+
+fn (s &Abc) map_free() {
+	eprintln('${@METHOD} called, s: ${s}')
+}
+
+fn test_map_with_struct_as_key() {
+	s0 := Abc{}
+	s1 := Abc{1, 2}
+	mut m := map[Abc]int{}
+	m[s0] = 123
+	m[s1] = 456
+	assert m[s0] == 123
+	assert m[s1] == 456
+	dump(m)
+	m[s1] = 789
+	dump(m[s1])
+	dump(m)
+	assert m[s0] == 123
+	assert m[s1] == 789
+}


### PR DESCRIPTION
Allows for:
```v
struct Abc{ x int y int }
// ... some callback methods, needed for Abc to be usable with the builtin maps
fn main() {
	s0 := Abc{}
	s1 := Abc{1, 2}
	mut m := map[Abc]int{}
	m[s0] = 123
	m[s1] = 456
	dump(m)
}
```	

Note: this is very experimental and subject to change/redesign.