### PR TITLE
builtin: fix map.clear() (fix #16711)

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -299,6 +299,7 @@ pub fn (mut m map) move() map {
 // Example: a.clear() // `a.len` and `a.key_values.len` is now 0
 pub fn (mut m map) clear() {
 	m.len = 0
+	m.even_index = 0
 	m.key_values.len = 0
 }
 

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -993,3 +993,45 @@ fn test_alias_of_map_delete() {
 	assert m.len == 1
 	assert m[22] == 222
 }
+
+struct State {
+mut:
+	state map[string]rune
+}
+
+struct Foo {
+	bar int
+	baz int
+}
+
+fn (mut st State) add(s string, r rune) {
+	st.state[s] = r
+}
+
+fn (mut st State) add2(foos []Foo) {
+	for f in foos {
+		st.state['${f.bar},${f.baz}'] = `z`
+	}
+}
+
+fn (mut st State) reset() {
+	st.state.clear()
+}
+
+fn test_map_clear() {
+	mut s := State{}
+
+	item1 := [Foo{
+		bar: 1
+		baz: 2
+	}, Foo{
+		bar: 3
+		baz: 4
+	}]
+	s.add2(item1)
+	assert s.state.len == 2
+
+	s.reset()
+	s.add2(item1)
+	assert s.state.len == 2
+}


### PR DESCRIPTION
This PR fix map.clear() (fix #16711).

- Fix map.clear().
- Add test.

```v
struct State {
mut:
	state map[string]rune
}

struct Foo {
	bar int
	baz int
}

fn (mut st State) add(s string, r rune) {
	st.state[s] = r
}

fn (mut st State) add2(foos []Foo) {
	for f in foos {
		st.state['${f.bar},${f.baz}'] = `z`
	}
}

fn (mut st State) reset() {
	st.state.clear()
}

fn main() {
	mut s := State{}

	item1 := [Foo{
		bar: 1
		baz: 2
	}, Foo{
		bar: 3
		baz: 4
	}]
	s.add2(item1)
	println(s)
	assert s.state.len == 2

	s.reset()
	println(s)
	
	s.add2(item1)
	println(s)
	assert s.state.len == 2
}

PS D:\Test\v\tt1> v run .
State{
    state: {'1,2': `z`, '3,4': `z`}
}
State{
    state: {}
}
State{
    state: {'1,2': `z`, '3,4': `z`}
}
```