### PR TITLE
cgen: minimise `sizeof(EmptyStruct)` by changing EMPTY_STRUCT_DECLARATION and EMPTY_STRUCT_INITIALIZATION

### DIFF
--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -355,7 +355,7 @@ fn test_array_append_empty_struct() {
 	assert (XYZ{} in names) == true
 
 	// test fixed array
-	array := [XYZ{}]
+	array := [XYZ{}]!
 	assert (XYZ{} in names) == true
 }
 

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -33,7 +33,7 @@ fn __new_array(mylen int, cap int, elm_size int) array {
 	cap_ := if cap < mylen { mylen } else { cap }
 	arr := array{
 		element_size: elm_size
-		data: vcalloc(u64(cap_) * u64(elm_size))
+		data: vcalloc(__at_least_one(u64(cap_) * u64(elm_size)))
 		len: mylen
 		cap: cap_
 	}
@@ -47,7 +47,11 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 		len: mylen
 		cap: cap_
 	}
-	total_size := u64(cap_) * u64(elm_size)
+	// x := []EmptyStruct{cap:5} ; for clang/gcc with -gc none,
+	//    -> sizeof(EmptyStruct) == 0 -> elm_size == 0
+	//    -> total_size == 0 -> malloc(0) -> panic;
+	//    to avoid it, just allocate a single byte
+	total_size := __at_least_one(u64(cap_) * u64(elm_size))
 	if cap_ > 0 && mylen == 0 {
 		arr.data = unsafe { malloc(total_size) }
 	} else {
@@ -69,7 +73,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array, d
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
-		data: unsafe { malloc(u64(cap_) * u64(elm_size)) }
+		data: unsafe { malloc(__at_least_one(u64(cap_) * u64(elm_size))) }
 		len: mylen
 		cap: cap_
 	}
@@ -88,7 +92,7 @@ fn __new_array_with_map_default(mylen int, cap int, elm_size int, val map) array
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
-		data: unsafe { malloc(u64(cap_) * u64(elm_size)) }
+		data: unsafe { malloc(__at_least_one(u64(cap_) * u64(elm_size))) }
 		len: mylen
 		cap: cap_
 	}
@@ -108,7 +112,7 @@ fn new_array_from_c_array(len int, cap int, elm_size int, c_array voidptr) array
 	cap_ := if cap < len { len } else { cap }
 	arr := array{
 		element_size: elm_size
-		data: vcalloc(u64(cap_) * u64(elm_size))
+		data: vcalloc(__at_least_one(u64(cap_) * u64(elm_size)))
 		len: len
 		cap: cap_
 	}
@@ -143,7 +147,7 @@ fn (mut a array) ensure_cap(required int) {
 		cap *= 2
 	}
 	new_size := u64(cap) * u64(a.element_size)
-	new_data := unsafe { malloc(new_size) }
+	new_data := unsafe { malloc(__at_least_one(new_size)) }
 	if a.data != unsafe { nil } {
 		unsafe { vmemcpy(new_data, a.data, u64(a.len) * u64(a.element_size)) }
 		// TODO: the old data may be leaked when no GC is used (ref-counting?)
@@ -321,7 +325,7 @@ pub fn (mut a array) delete_many(i int, size int) {
 	old_data := a.data
 	new_size := a.len - size
 	new_cap := if new_size == 0 { 1 } else { new_size }
-	a.data = vcalloc(u64(new_cap) * u64(a.element_size))
+	a.data = vcalloc(__at_least_one(u64(new_cap) * u64(a.element_size)))
 	unsafe { vmemcpy(a.data, old_data, u64(i) * u64(a.element_size)) }
 	unsafe {
 		vmemcpy(&u8(a.data) + u64(i) * u64(a.element_size), &u8(old_data) + u64(i +
@@ -586,13 +590,9 @@ pub fn (a &array) clone() array {
 // recursively clone given array - `unsafe` when called directly because depth is not checked
 [unsafe]
 pub fn (a &array) clone_to_depth(depth int) array {
-	mut size := u64(a.cap) * u64(a.element_size)
-	if size == 0 {
-		size++
-	}
 	mut arr := array{
 		element_size: a.element_size
-		data: vcalloc(size)
+		data: vcalloc(__at_least_one(u64(a.cap) * u64(a.element_size)))
 		len: a.len
 		cap: a.cap
 	}

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -33,7 +33,7 @@ fn __new_array(mylen int, cap int, elm_size int) array {
 	cap_ := if cap < mylen { mylen } else { cap }
 	arr := array{
 		element_size: elm_size
-		data: vcalloc(__at_least_one(u64(cap_) * u64(elm_size)))
+		data: vcalloc(u64(cap_) * u64(elm_size))
 		len: mylen
 		cap: cap_
 	}
@@ -51,9 +51,9 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 	//    -> sizeof(EmptyStruct) == 0 -> elm_size == 0
 	//    -> total_size == 0 -> malloc(0) -> panic;
 	//    to avoid it, just allocate a single byte
-	total_size := __at_least_one(u64(cap_) * u64(elm_size))
+	total_size := u64(cap_) * u64(elm_size)
 	if cap_ > 0 && mylen == 0 {
-		arr.data = unsafe { malloc(total_size) }
+		arr.data = unsafe { malloc(__at_least_one(total_size)) }
 	} else {
 		arr.data = vcalloc(total_size)
 	}
@@ -112,7 +112,7 @@ fn new_array_from_c_array(len int, cap int, elm_size int, c_array voidptr) array
 	cap_ := if cap < len { len } else { cap }
 	arr := array{
 		element_size: elm_size
-		data: vcalloc(__at_least_one(u64(cap_) * u64(elm_size)))
+		data: vcalloc(u64(cap_) * u64(elm_size))
 		len: len
 		cap: cap_
 	}
@@ -325,7 +325,7 @@ pub fn (mut a array) delete_many(i int, size int) {
 	old_data := a.data
 	new_size := a.len - size
 	new_cap := if new_size == 0 { 1 } else { new_size }
-	a.data = vcalloc(__at_least_one(u64(new_cap) * u64(a.element_size)))
+	a.data = vcalloc(u64(new_cap) * u64(a.element_size))
 	unsafe { vmemcpy(a.data, old_data, u64(i) * u64(a.element_size)) }
 	unsafe {
 		vmemcpy(&u8(a.data) + u64(i) * u64(a.element_size), &u8(old_data) + u64(i +
@@ -592,7 +592,7 @@ pub fn (a &array) clone() array {
 pub fn (a &array) clone_to_depth(depth int) array {
 	mut arr := array{
 		element_size: a.element_size
-		data: vcalloc(__at_least_one(u64(a.cap) * u64(a.element_size)))
+		data: vcalloc(u64(a.cap) * u64(a.element_size))
 		len: a.len
 		cap: a.cap
 	}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -403,7 +403,10 @@ pub fn malloc_noscan(n isize) &u8 {
 fn __at_least_one(how_many u64) u64 {
 	// handle the case for allocating memory for empty structs, which have sizeof(EmptyStruct) == 0
 	// in this case, just allocate a single byte, avoiding the panic for malloc(0)
-	return how_many + u64(how_many == 0)
+	if how_many == 0 {
+		return 1
+	}
+	return how_many
 }
 
 // malloc_uncollectable dynamically allocates a `n` bytes block of memory

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -403,10 +403,7 @@ pub fn malloc_noscan(n isize) &u8 {
 fn __at_least_one(how_many u64) u64 {
 	// handle the case for allocating memory for empty structs, which have sizeof(EmptyStruct) == 0
 	// in this case, just allocate a single byte, avoiding the panic for malloc(0)
-	if how_many == 0 {
-		return 1
-	}
-	return how_many
+	return how_many + u64(how_many == 0)
 }
 
 // malloc_uncollectable dynamically allocates a `n` bytes block of memory

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -399,6 +399,16 @@ pub fn malloc_noscan(n isize) &u8 {
 	return res
 }
 
+[inline]
+fn __at_least_one(how_many u64) u64 {
+	// handle the case for allocating memory for empty structs, which have sizeof(EmptyStruct) == 0
+	// in this case, just allocate a single byte, avoiding the panic for malloc(0)
+	if how_many == 0 {
+		return 1
+	}
+	return how_many
+}
+
 // malloc_uncollectable dynamically allocates a `n` bytes block of memory
 // on the heap, which will NOT be garbage-collected (but its contents will).
 [unsafe]

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -100,8 +100,8 @@ fn new_dense_array(key_bytes int, value_bytes int) DenseArray {
 		len: 0
 		deletes: 0
 		all_deleted: 0
-		keys: unsafe { malloc(cap * key_bytes) }
-		values: unsafe { malloc(cap * value_bytes) }
+		keys: unsafe { malloc(__at_least_one(u64(cap) * u64(key_bytes))) }
+		values: unsafe { malloc(__at_least_one(u64(cap) * u64(value_bytes))) }
 	}
 }
 

--- a/vlib/builtin/map_d_gcboehm_opt.v
+++ b/vlib/builtin/map_d_gcboehm_opt.v
@@ -7,18 +7,16 @@
 module builtin
 
 [inline]
+fn __malloc_at_least_one(how_many_bytes u64, noscan bool) &u8 {
+	if noscan {
+		return unsafe { malloc_noscan(__at_least_one(how_many_bytes)) }
+	}
+	return unsafe { malloc(__at_least_one(how_many_bytes)) }
+}
+
+[inline]
 fn new_dense_array_noscan(key_bytes int, key_noscan bool, value_bytes int, value_noscan bool) DenseArray {
 	cap := 8
-	keys := if key_noscan {
-		unsafe { malloc_noscan(cap * key_bytes) }
-	} else {
-		unsafe { malloc(cap * key_bytes) }
-	}
-	values := if value_noscan {
-		unsafe { malloc_noscan(cap * value_bytes) }
-	} else {
-		unsafe { malloc(cap * value_bytes) }
-	}
 	return DenseArray{
 		key_bytes: key_bytes
 		value_bytes: value_bytes
@@ -26,8 +24,8 @@ fn new_dense_array_noscan(key_bytes int, key_noscan bool, value_bytes int, value
 		len: 0
 		deletes: 0
 		all_deleted: 0
-		keys: keys
-		values: values
+		keys: __malloc_at_least_one(u64(cap) * u64(key_bytes), key_noscan)
+		values: __malloc_at_least_one(u64(cap) * u64(value_bytes), value_noscan)
 	}
 }
 

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -34,8 +34,6 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 		noscan := g.check_noscan(elem_type.typ)
 		if elem_type.unaliased_sym.kind == .function {
 			g.write('new_array_from_c_array(${len}, ${len}, sizeof(voidptr), _MOV((voidptr[${len}]){')
-		} else if g.is_empty_struct(elem_type) {
-			g.write('new_array_from_c_array${noscan}(${len}, ${len}, sizeof(voidptr), _MOV((${elem_styp}[${len}]){')
 		} else {
 			g.write('new_array_from_c_array${noscan}(${len}, ${len}, sizeof(${elem_styp}), _MOV((${elem_styp}[${len}]){')
 		}
@@ -216,7 +214,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		} else {
 			g.write('0, ')
 		}
-		if elem_type.unaliased_sym.kind == .function || g.is_empty_struct(elem_type) {
+		if elem_type.unaliased_sym.kind == .function {
 			g.write('sizeof(voidptr), ')
 		} else {
 			g.write('sizeof(${elem_styp}), ')
@@ -292,7 +290,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 	} else {
 		g.write('0, ')
 	}
-	if elem_type.unaliased_sym.kind == .function || g.is_empty_struct(elem_type) {
+	if elem_type.unaliased_sym.kind == .function {
 		g.write('sizeof(voidptr), ')
 	} else {
 		g.write('sizeof(${elem_styp}), ')

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -312,11 +312,12 @@ const c_common_macros = '
 #ifdef __clang__
 	#undef __V_GCC__
 #endif
+
 #ifdef _MSC_VER
 	#undef __V_GCC__
 	#undef EMPTY_STRUCT_DECLARATION
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_DECLARATION int _dummy_pad
+	#define EMPTY_STRUCT_DECLARATION char _dummy_pad
 	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 
@@ -598,10 +599,7 @@ voidptr memdup(voidptr src, int sz);
 		#define _Atomic volatile
 
 		// MSVC cannot parse some things properly
-		#undef EMPTY_STRUCT_DECLARATION
 		#undef OPTION_CAST
-
-		#define EMPTY_STRUCT_DECLARATION 
 		#define OPTION_CAST(x)
 		#undef __NOINLINE
 		#undef __IRQHANDLER

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -253,8 +253,8 @@ static void* __closure_create(void* fn, void* data) {
 
 const c_common_macros = '
 #define EMPTY_VARG_INITIALIZATION 0
-#define EMPTY_STRUCT_INITIALIZATION 0
-#define EMPTY_STRUCT_DECLARATION voidptr _dummy_pad
+#define EMPTY_STRUCT_INITIALIZATION
+#define EMPTY_STRUCT_DECLARATION 
 // Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
 #define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
 #define TCCSKIP(x) x
@@ -315,7 +315,7 @@ const c_common_macros = '
 #ifdef _MSC_VER
 	#undef __V_GCC__
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_INITIALIZATION 0
+	#define EMPTY_STRUCT_INITIALIZATION
 #endif
 
 #ifndef _WIN32
@@ -332,7 +332,7 @@ const c_common_macros = '
 #ifdef __TINYC__
 	#define _Atomic volatile
 	#undef EMPTY_STRUCT_DECLARATION
-	#define EMPTY_STRUCT_DECLARATION voidptr _dummy_pad
+	#define EMPTY_STRUCT_DECLARATION 
 	#undef EMPTY_ARRAY_OF_ELEMS
 	#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
 	#undef __NOINLINE
@@ -597,7 +597,7 @@ voidptr memdup(voidptr src, int sz);
 		#undef EMPTY_STRUCT_DECLARATION
 		#undef OPTION_CAST
 
-		#define EMPTY_STRUCT_DECLARATION voidptr _dummy_pad
+		#define EMPTY_STRUCT_DECLARATION 
 		#define OPTION_CAST(x)
 		#undef __NOINLINE
 		#undef __IRQHANDLER

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -314,7 +314,9 @@ const c_common_macros = '
 #endif
 #ifdef _MSC_VER
 	#undef __V_GCC__
+	#undef EMPTY_STRUCT_DECLARATION
 	#undef EMPTY_STRUCT_INITIALIZATION
+	#define EMPTY_STRUCT_DECLARATION u8 _dummy_pad
 	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 
@@ -332,7 +334,9 @@ const c_common_macros = '
 #ifdef __TINYC__
 	#define _Atomic volatile
 	#undef EMPTY_STRUCT_DECLARATION
-	#define EMPTY_STRUCT_DECLARATION 
+	#undef EMPTY_STRUCT_INITIALIZATION
+	#define EMPTY_STRUCT_DECLARATION
+	#define EMPTY_STRUCT_INITIALIZATION
 	#undef EMPTY_ARRAY_OF_ELEMS
 	#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
 	#undef __NOINLINE

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -253,8 +253,8 @@ static void* __closure_create(void* fn, void* data) {
 
 const c_common_macros = '
 #define EMPTY_VARG_INITIALIZATION 0
+#define EMPTY_STRUCT_DECLARATION
 #define EMPTY_STRUCT_INITIALIZATION
-#define EMPTY_STRUCT_DECLARATION 
 // Due to a tcc bug, the length of an array needs to be specified, but GCC crashes if it is...
 #define EMPTY_ARRAY_OF_ELEMS(x,n) (x[])
 #define TCCSKIP(x) x
@@ -317,7 +317,7 @@ const c_common_macros = '
 	#undef __V_GCC__
 	#undef EMPTY_STRUCT_DECLARATION
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_DECLARATION char _dummy_pad
+	#define EMPTY_STRUCT_DECLARATION unsigned char _dummy_pad
 	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 
@@ -336,7 +336,7 @@ const c_common_macros = '
 	#define _Atomic volatile
 	#undef EMPTY_STRUCT_DECLARATION
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_DECLARATION char _dummy_pad
+	#define EMPTY_STRUCT_DECLARATION unsigned char _dummy_pad
 	#define EMPTY_STRUCT_INITIALIZATION 0
 	#undef EMPTY_ARRAY_OF_ELEMS
 	#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -315,7 +315,7 @@ const c_common_macros = '
 #ifdef _MSC_VER
 	#undef __V_GCC__
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_INITIALIZATION
+	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 
 #ifndef _WIN32

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -316,7 +316,7 @@ const c_common_macros = '
 	#undef __V_GCC__
 	#undef EMPTY_STRUCT_DECLARATION
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_DECLARATION u8 _dummy_pad
+	#define EMPTY_STRUCT_DECLARATION int _dummy_pad
 	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -336,8 +336,8 @@ const c_common_macros = '
 	#define _Atomic volatile
 	#undef EMPTY_STRUCT_DECLARATION
 	#undef EMPTY_STRUCT_INITIALIZATION
-	#define EMPTY_STRUCT_DECLARATION
-	#define EMPTY_STRUCT_INITIALIZATION
+	#define EMPTY_STRUCT_DECLARATION char _dummy_pad
+	#define EMPTY_STRUCT_INITIALIZATION 0
 	#undef EMPTY_ARRAY_OF_ELEMS
 	#define EMPTY_ARRAY_OF_ELEMS(x,n) (x[n])
 	#undef __NOINLINE

--- a/vlib/v/tests/arrays_and_maps_of_empty_structs_should_work_test.v
+++ b/vlib/v/tests/arrays_and_maps_of_empty_structs_should_work_test.v
@@ -1,0 +1,40 @@
+struct EmptyStruct {}
+
+fn test_array_append_empty_struct() {
+	size_of_empty_struct := dump(sizeof(EmptyStruct))
+	assert size_of_empty_struct <= 1
+	mut names := []EmptyStruct{cap: 2}
+	names << EmptyStruct{}
+	dump(names)
+	assert (EmptyStruct{} in names) == true
+	//
+	mut fa := [EmptyStruct{}, EmptyStruct{}]!
+	assert fa.len == 2
+	dump(fa[0])
+	fa[0] = EmptyStruct{}
+	dump(fa[0])
+	assert fa[0] == EmptyStruct{}
+	assert fa[1] == EmptyStruct{}
+}
+
+fn test_map_of_int_set_empty_struct() {
+	mut names := map[int]EmptyStruct{}
+	names[10] = EmptyStruct{}
+	names[99] = EmptyStruct{}
+	dump(names)
+	assert 10 in names
+	assert 99 in names
+	assert names[10] == EmptyStruct{}
+	assert names[99] == EmptyStruct{}
+}
+
+fn test_map_of_string_set_empty_struct() {
+	mut names := map[string]EmptyStruct{}
+	names['ab'] = EmptyStruct{}
+	names['cd'] = EmptyStruct{}
+	dump(names)
+	assert 'ab' in names
+	assert 'cd' in names
+	assert names['ab'] == EmptyStruct{}
+	assert names['cd'] == EmptyStruct{}
+}

--- a/vlib/v/tests/empty_struct_test.v
+++ b/vlib/v/tests/empty_struct_test.v
@@ -1,0 +1,38 @@
+struct Z0 {}
+
+struct Z1 {
+	padding1 char
+}
+
+struct Z2 {
+	padding1 char
+	padding2 char
+}
+
+struct Z3 {
+	padding1 char
+	padding2 char
+	padding3 char
+}
+
+struct Z4 {
+	padding1 char
+	padding2 char
+	padding3 char
+	padding4 char
+}
+
+fn test_struct_sizes() {
+	assert dump(sizeof(Z0)) < 2
+	$if tinyc {
+		assert dump(sizeof(Z0)) == 1
+	} $else $if msvc {
+		assert dump(sizeof(Z0)) == 1
+	} $else {
+		assert dump(sizeof(Z0)) == 0
+	}
+	assert dump(sizeof(Z1)) < sizeof(Z2)
+	assert dump(sizeof(Z2)) < sizeof(Z3)
+	assert dump(sizeof(Z3)) < sizeof(Z4)
+	assert dump(sizeof(Z4)) == 4
+}

--- a/vlib/v/tests/empty_struct_test.v
+++ b/vlib/v/tests/empty_struct_test.v
@@ -23,12 +23,27 @@ struct Z4 {
 }
 
 fn test_struct_sizes() {
-	assert dump(sizeof(Z0)) < 2
+	assert dump(sizeof(Z0)) <= 1 // valid for all
 	$if tinyc {
+		// TCC has no problems with 0 sized structs in almost cases,
+		// except when they are used in fixed arrays, or their address is taken,
+		// in which case, it produces a compilation error. To avoid it, for it
+		// empty structs are 1 byte in size.
 		assert dump(sizeof(Z0)) == 1
-	} $else $if msvc {
+	}
+	$if msvc {
+		// MSVC seems to have no way at all to have empty structs in C mode. It produces the following error:
+		// `error c2016: C requires that a struct or union have at least one member`.
+		// Note that MSVC allows empty structs in C++ mode, but that has other restrictions,
+		// and is not suitable for the generated code of most V programs. Besides, even in C++  mode, the size of
+		// an empty struct is still 1, not 0.
+		// For that reason, empty structs are 1 byte in size for MSVC too.
 		assert dump(sizeof(Z0)) == 1
-	} $else {
+	}
+	$if clang {
+		assert dump(sizeof(Z0)) == 0
+	}
+	$if gcc {
 		assert dump(sizeof(Z0)) == 0
 	}
 	assert dump(sizeof(Z1)) < sizeof(Z2)


### PR DESCRIPTION
Instead of sizeof(EmptyStruct) == 8, now it is 1 for msvc and tcc, and 0 otherwise.

Note: MSVC does not allow for completely empty structs, so there is still a 1 byte padding in its case.

TCC now *does allow for empty structs, in most cases*, except when they are used in an array or another context that may require taking their address. A failing example is trying to compile `cmd/tools/vgret.v` which uses `toml`, which in turn has toml.Null declared as an empty struct and `pub const null = Any(Null{})` with EMPTY_STRUCT_INITIALIZATION and EMPTY_STRUCT_DECLARATION being set to ''.


```v

struct Z0 {}
struct Z1 { padding1 char}
struct Z2 { padding1 char padding2 char}
struct Z3 { padding1 char padding2 char padding3 char}
struct Z4 { padding1 char padding2 char padding3 char padding4 char}

fn main() {
	dump(sizeof(Z0))
	dump(sizeof(Z1))
	dump(sizeof(Z2))
	dump(sizeof(Z3))
	dump(sizeof(Z4))
}
```
on master produced:
```
[sizes.v:9] sizeof(main.Z0): 8
[sizes.v:10] sizeof(main.Z1): 1
[sizes.v:11] sizeof(main.Z2): 2
[sizes.v:12] sizeof(main.Z3): 3
[sizes.v:13] sizeof(main.Z4): 4
```
... for all compilers.

With this PR, for clang/gcc:
```
[sizes.v:9] sizeof(main.Z0): 0
[sizes.v:10] sizeof(main.Z1): 1
[sizes.v:11] sizeof(main.Z2): 2
[sizes.v:12] sizeof(main.Z3): 3
[sizes.v:13] sizeof(main.Z4): 4
```
For tcc/msvc:
```
[sizes.v:9] sizeof(main.Z0): 1
[sizes.v:10] sizeof(main.Z1): 1
[sizes.v:11] sizeof(main.Z2): 2
[sizes.v:12] sizeof(main.Z3): 3
[sizes.v:13] sizeof(main.Z4): 4
```