### PR TITLE
cgen: improve generated source compatibility with latest Alpine (lacking libexecinfo-dev and execinfo.h) and the prebuilt tcc

### DIFF
--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -75,52 +75,53 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 			$if tinyc {
 				C.tcc_backtrace(c'Backtrace')
 				return false
-			}
-			buffer := [100]voidptr{}
-			nr_ptrs := C.backtrace(&buffer[0], 100)
-			if nr_ptrs < 2 {
-				eprintln('C.backtrace returned less than 2 frames')
-				return false
-			}
-			nr_actual_frames := nr_ptrs - skipframes
-			mut sframes := []string{}
-			//////csymbols := backtrace_symbols(*voidptr(&buffer[skipframes]), nr_actual_frames)
-			csymbols := C.backtrace_symbols(voidptr(&buffer[skipframes]), nr_actual_frames)
-			for i in 0 .. nr_actual_frames {
-				sframes << unsafe { tos2(&u8(csymbols[i])) }
-			}
-			for sframe in sframes {
-				executable := sframe.all_before('(')
-				addr := sframe.all_after('[').all_before(']')
-				beforeaddr := sframe.all_before('[')
-				cmd := 'addr2line -e ${executable} ${addr}'
-				// taken from os, to avoid depending on the os module inside builtin.v
-				f := C.popen(&char(cmd.str), c'r')
-				if f == unsafe { nil } {
-					eprintln(sframe)
-					continue
+			} $else {
+				buffer := [100]voidptr{}
+				nr_ptrs := C.backtrace(&buffer[0], 100)
+				if nr_ptrs < 2 {
+					eprintln('C.backtrace returned less than 2 frames')
+					return false
 				}
-				buf := [1000]u8{}
-				mut output := ''
-				unsafe {
-					bp := &buf[0]
-					for C.fgets(&char(bp), 1000, f) != 0 {
-						output += tos(bp, vstrlen(bp))
+				nr_actual_frames := nr_ptrs - skipframes
+				mut sframes := []string{}
+				//////csymbols := backtrace_symbols(*voidptr(&buffer[skipframes]), nr_actual_frames)
+				csymbols := C.backtrace_symbols(voidptr(&buffer[skipframes]), nr_actual_frames)
+				for i in 0 .. nr_actual_frames {
+					sframes << unsafe { tos2(&u8(csymbols[i])) }
+				}
+				for sframe in sframes {
+					executable := sframe.all_before('(')
+					addr := sframe.all_after('[').all_before(']')
+					beforeaddr := sframe.all_before('[')
+					cmd := 'addr2line -e ${executable} ${addr}'
+					// taken from os, to avoid depending on the os module inside builtin.v
+					f := C.popen(&char(cmd.str), c'r')
+					if f == unsafe { nil } {
+						eprintln(sframe)
+						continue
 					}
+					buf := [1000]u8{}
+					mut output := ''
+					unsafe {
+						bp := &buf[0]
+						for C.fgets(&char(bp), 1000, f) != 0 {
+							output += tos(bp, vstrlen(bp))
+						}
+					}
+					output = output.trim_space() + ':'
+					if C.pclose(f) != 0 {
+						eprintln(sframe)
+						continue
+					}
+					if output in ['??:0:', '??:?:'] {
+						output = ''
+					}
+					// See http://wiki.dwarfstd.org/index.php?title=Path_Discriminators
+					// Note: it is shortened here to just d. , just so that it fits, and so
+					// that the common error file:lineno: line format is enforced.
+					output = output.replace(' (discriminator', ': (d.')
+					eprintln('${output:-55s} | ${addr:14s} | ${beforeaddr}')
 				}
-				output = output.trim_space() + ':'
-				if C.pclose(f) != 0 {
-					eprintln(sframe)
-					continue
-				}
-				if output in ['??:0:', '??:?:'] {
-					output = ''
-				}
-				// See http://wiki.dwarfstd.org/index.php?title=Path_Discriminators
-				// Note: it is shortened here to just d. , just so that it fits, and so
-				// that the common error file:lineno: line format is enforced.
-				output = output.replace(' (discriminator', ': (d.')
-				eprintln('${output:-55s} | ${addr:14s} | ${beforeaddr}')
 			}
 		}
 	}

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -318,6 +318,14 @@ const c_common_macros = '
 	#define EMPTY_STRUCT_INITIALIZATION 0
 #endif
 
+#ifndef _WIN32
+	#if defined __has_include
+		#if __has_include (<execinfo.h>)
+			#include <execinfo.h>
+		#endif
+	#endif
+#endif
+		      
 #ifdef __TINYC__
 	#define _Atomic volatile
 	#undef EMPTY_STRUCT_DECLARATION
@@ -333,7 +341,6 @@ const c_common_macros = '
 	#define TCCSKIP(x)
 	// #include <byteswap.h>
 	#ifndef _WIN32
-		#include <execinfo.h>
 		int tcc_backtrace(const char *fmt, ...);
 	#endif
 #endif
@@ -500,14 +507,6 @@ typedef int (*qsort_callback_func)(const void*, const void*);
 #include <stdio.h>  // TODO remove all these includes, define all function signatures and types manually
 #include <stdlib.h>
 #include <string.h>
-
-#ifndef _WIN32
-	#if defined __has_include
-		#if __has_include (<execinfo.h>)
-			#include <execinfo.h>
-		#endif
-	#endif
-#endif
 
 #include <stdarg.h> // for va_list
 

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -322,7 +322,10 @@ const c_common_macros = '
 	#if defined __has_include
 		#if __has_include (<execinfo.h>)
 			#include <execinfo.h>
-		#endif
+		#else
+			// On linux: int backtrace(void **__array, int __size);
+			// On BSD: size_t backtrace(void **, size_t);
+		#endif		
 	#endif
 #endif
 		      


### PR DESCRIPTION
On latest Alpine, `libexecinfo-dev` and the file `execinfo.h` are not
easily available anymore.

This makes V programs buildable on latest Alpine, with the prebuild tcc,
without having to install `libexecinfo-dev` from external sources.