### PR TITLE
cgen: fix call arg type changing on match expr

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1718,8 +1718,8 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 				if arg.expr.obj.smartcasts.len > 0 {
 					exp_sym := g.table.sym(expected_types[i])
 					orig_sym := g.table.sym(arg.expr.obj.orig_type)
-					if orig_sym.kind != .interface_ && 
-						(exp_sym.kind != .sum_type && expected_types[i] != arg.expr.obj.orig_type) {
+					if orig_sym.kind != .interface_ && (exp_sym.kind != .sum_type
+						&& expected_types[i] != arg.expr.obj.orig_type) {
 						expected_types[i] = g.unwrap_generic(arg.expr.obj.smartcasts.last())
 						cast_sym := g.table.sym(expected_types[i])
 						if cast_sym.info is ast.Aggregate {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1718,9 +1718,8 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 				if arg.expr.obj.smartcasts.len > 0 {
 					exp_sym := g.table.sym(expected_types[i])
 					orig_sym := g.table.sym(arg.expr.obj.orig_type)
-					if orig_sym.kind != .interface_ && (exp_sym.kind != .sum_type
-						|| (exp_sym.kind == .sum_type
-						&& expected_types[i] != arg.expr.obj.orig_type)) {
+					if orig_sym.kind != .interface_ && 
+						(exp_sym.kind != .sum_type && expected_types[i] != arg.expr.obj.orig_type) {
 						expected_types[i] = g.unwrap_generic(arg.expr.obj.smartcasts.last())
 						cast_sym := g.table.sym(expected_types[i])
 						if cast_sym.info is ast.Aggregate {

--- a/vlib/v/tests/sumtype_on_match_test.v
+++ b/vlib/v/tests/sumtype_on_match_test.v
@@ -1,0 +1,35 @@
+struct MotionEvent {}
+
+struct ButtonEvent {}
+
+struct WheelEvent {}
+
+type Event = MotionEvent | ButtonEvent | WheelEvent
+
+type GameEvent = MotionEvent | ButtonEvent
+
+fn test_main() {
+	be := ButtonEvent{}
+	assert handle_event(be) == true
+	e := Event(be)
+	assert handle_event(e) == true
+	match e {
+		MotionEvent {
+			assert handle_game_event(e) == true
+		}
+		ButtonEvent {
+			assert handle_game_event(e) == true
+		}
+		else {}
+	}
+}
+
+fn handle_game_event(ge GameEvent) bool {
+	is_button_event := ge is ButtonEvent
+	return is_button_event
+}
+
+fn handle_event(e Event) bool {
+	is_button_event := e is ButtonEvent
+	return is_button_event
+}

--- a/vlib/v/tests/sumtype_on_match_test.v
+++ b/vlib/v/tests/sumtype_on_match_test.v
@@ -4,9 +4,9 @@ struct ButtonEvent {}
 
 struct WheelEvent {}
 
-type Event = MotionEvent | ButtonEvent | WheelEvent
+type Event = ButtonEvent | MotionEvent | WheelEvent
 
-type GameEvent = MotionEvent | ButtonEvent
+type GameEvent = ButtonEvent | MotionEvent
 
 fn test_main() {
 	be := ButtonEvent{}


### PR DESCRIPTION
Fix #16742

On V code like:

```V
	e := Event(be) // type Event = MotionEvent | ButtonEvent | WheelEvent

	match e {
		MotionEvent {
			handle_game_event(e)
		}
		ButtonEvent {
			handle_game_event(e)
		}
		else {}
	}
```
It was generating:

```C
        if (e._typ == 94 /* main.MotionEvent */) {
                main__handle_game_event((*e._main__MotionEvent));
        }
        else if (e._typ == 95 /* main.ButtonEvent */) {
                main__handle_game_event((*e._main__ButtonEvent));
        }
```

instead of 

```C
        if (e._typ == 94 /* main.MotionEvent */) {
                main__handle_game_event(main__MotionEvent_to_sumtype_main__GameEvent(&(*e._main__MotionEvent)));
        }
        else if (e._typ == 95 /* main.ButtonEvent */) {
                main__handle_game_event(main__ButtonEvent_to_sumtype_main__GameEvent(&(*e._main__ButtonEvent)));
        }
```