### PR TITLE
ast, parser: fix wrong type name of nested generics  (fix #16745)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1154,6 +1154,37 @@ pub fn (t &Table) clean_generics_type_str(typ Type) string {
 	return result.all_before('[')
 }
 
+fn strip_extra_struct_types(name string) string {
+	mut start := 0
+	mut is_start := false
+	mut nested_count := 0
+	mut strips := []string{}
+
+	for i, ch in name {
+		if ch == `<` {
+			if is_start {
+				nested_count++
+			} else {
+				is_start = true
+				start = i
+			}
+		} else if ch == `>` {
+			if nested_count > 0 {
+				nested_count--
+			} else {
+				strips << name.substr(start, i + 1)
+				strips << ''
+				is_start = false
+			}
+		}
+	}
+	if strips.len > 0 {
+		return name.replace_each(strips)
+	} else {
+		return name
+	}
+}
+
 // import_aliases is a map of imported symbol aliases 'module.Type' => 'Type'
 pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]string) string {
 	cache_key := (u64(import_aliases.len) << 32) | u64(typ)
@@ -1280,6 +1311,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 					import_aliases))
 				res = '${variant_names.join('|')}'
 			} else {
+				res = strip_extra_struct_types(res)
 				res = t.shorten_user_defined_typenames(res, import_aliases)
 			}
 		}
@@ -1363,20 +1395,22 @@ fn (t Table) shorten_user_defined_typenames(originalname string, import_aliases 
 		}
 		// types defined by the user
 		// mod.submod.submod2.Type => submod2.Type
-		mut parts := res.split('.')
-		if parts.len > 1 {
-			ind := parts.len - 2
-			if t.is_fmt {
-				// Rejoin the module parts for correct usage of aliases
-				parts[ind] = parts[..ind + 1].join('.')
-			}
-			if parts[ind] in import_aliases {
-				parts[ind] = import_aliases[parts[ind]]
-			}
+		if res.count('[') < 2 {
+			mut parts := res.split('.')
+			if parts.len > 1 {
+				ind := parts.len - 2
+				if t.is_fmt {
+					// Rejoin the module parts for correct usage of aliases
+					parts[ind] = parts[..ind + 1].join('.')
+				}
+				if parts[ind] in import_aliases {
+					parts[ind] = import_aliases[parts[ind]]
+				}
 
-			res = parts[ind..].join('.')
-		} else {
-			res = parts[0]
+				res = parts[ind..].join('.')
+			} else {
+				res = parts[0]
+			}
 		}
 	}
 	return res

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -654,14 +654,14 @@ pub fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Lan
 				if p.struct_init_generic_types.len > 0 && sym.info.generic_types.len > 0
 					&& p.struct_init_generic_types != sym.info.generic_types {
 					generic_names := p.struct_init_generic_types.map(p.table.sym(it).name)
-					mut sym_name := sym.name + '['
+					mut sym_name := sym.name + '<'
 					for i, gt in generic_names {
 						sym_name += gt
 						if i != generic_names.len - 1 {
 							sym_name += ','
 						}
 					}
-					sym_name += ']'
+					sym_name += '>'
 					existing_idx := p.table.type_idxs[sym_name]
 					if existing_idx > 0 {
 						idx = existing_idx

--- a/vlib/v/tests/generics_struct_init_with_inconsistent_generic_types_5_test.v
+++ b/vlib/v/tests/generics_struct_init_with_inconsistent_generic_types_5_test.v
@@ -80,4 +80,15 @@ fn test_generics_struct_init_with_inconsistent_generic_types() {
 	assert ry2[1].b.a.b == 'four'
 	assert ry2[1].b.b.a == 'four'
 	assert ry2[1].b.b.b == 4
+
+	zx1 := []Tuple2[int, Tuple2[string, int]]{}
+	println(typeof(zx1).name)
+	println(typeof(rx1).name)
+	zx2 := []Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{}
+	println(typeof(zx2).name)
+	println(typeof(rx2).name)
+	assert typeof(zx1).name == '[]Tuple2[int, Tuple2[string, int]]'
+	assert typeof(zx2).name == '[]Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]'
+	assert typeof(zx1).name == typeof(rx1).name
+	assert typeof(zx2).name == typeof(rx2).name
 }


### PR DESCRIPTION
This PR fix wrong type name of nested generics  (fix #16745).

- Fix wrong type name of nested generics.
- Add test.

```v
struct Tuple2[A, B] {
	a A
	b B
}

// map to array of Tuple2[int, Tuple2[key, value]] tuples
fn map_to_array_int_kv[K, V](m map[K]V) []Tuple2[int, Tuple2[K, V]] {
	mut r := []Tuple2[int, Tuple2[K, V]]{cap: m.len}
	mut i := 0
	for k, v in m {
		r << Tuple2[int, Tuple2[K, V]]{i, Tuple2[K, V]{k, v}}
		i += 1
	}
	return r
}

// map to array of Tuple2[int, Tuple2[Tuple2[key, value], Tuple2[value, key]]] tuples
fn map_to_array_int_kv_vk[K, V](m map[K]V) []Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]] {
	mut r := []Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]]{cap: m.len}
	mut i := 0
	for k, v in m {
		r << Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]]{i, Tuple2[Tuple2[K, V], Tuple2[V, K]]{Tuple2[K, V]{k, v}, Tuple2[V, K]{v, k}}}
		i += 1
	}
	return r
}

fn main() {
	x := {
		'one': 1
		'two': 2
	}
	y := {
		3: 'three'
		4: 'four'
	}

	println(x)
	rx1 := map_to_array_int_kv(x)
	println(rx1)
	rx2 := map_to_array_int_kv_vk(x)
	println(rx2)

	println(y)
	ry1 := map_to_array_int_kv(y)
	println(ry1)

	ry2 := map_to_array_int_kv_vk(y)
	println(ry2)

	// test typeof(X).name
	zx1 := []Tuple2[int, Tuple2[string, int]]{}
	println(typeof(zx1).name)
	println(typeof(rx1).name)
	zx2 := []Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{}
	println(typeof(zx2).name)
	println(typeof(rx2).name)
	assert typeof(zx1).name == '[]Tuple2[int, Tuple2[string, int]]'
	assert typeof(zx2).name == '[]Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]'
	assert typeof(zx1).name == typeof(rx1).name
	assert typeof(zx2).name == typeof(rx2).name
}

PS D:\Test\v\tt1> v run .
{'one': 1, 'two': 2}
[Tuple2[int, Tuple2[string, int]{
    a: 0
    b: Tuple2[string, int]{
        a: 'one'
        b: 1
    }
}, Tuple2[int, Tuple2[string, int]{
    a: 1
    b: Tuple2[string, int]{
        a: 'two'
        b: 2
    }
}]
[Tuple2[int, Tuple2[Tuple2[string, int, Tuple2[int, string]{
    a: 0
    b: Tuple2[Tuple2[string, int, Tuple2[int, string]{
        a: Tuple2[string, int]{
            a: 'one'
            b: 1
        }
        b: Tuple2[int, string]{
            a: 1
            b: 'one'
        }
    }
}, Tuple2[int, Tuple2[Tuple2[string, int, Tuple2[int, string]{
    a: 1
    b: Tuple2[Tuple2[string, int, Tuple2[int, string]{
        a: Tuple2[string, int]{
            a: 'two'
            b: 2
        }
        b: Tuple2[int, string]{
            a: 2
            b: 'two'
        }
    }
}]
{3: 'three', 4: 'four'}
[Tuple2[int, Tuple2[int, string]{
    a: 0
    b: Tuple2[int, string]{
        a: 3
        b: 'three'
    }
}, Tuple2[int, Tuple2[int, string]{
    a: 1
    b: Tuple2[int, string]{
        a: 4
        b: 'four'
    }
}]
[Tuple2[int, Tuple2[Tuple2[int, string, Tuple2[string, int]{
    a: 0
    b: Tuple2[Tuple2[int, string, Tuple2[string, int]{
        a: Tuple2[int, string]{
            a: 3
            b: 'three'
        }
        b: Tuple2[string, int]{
            a: 'three'
            b: 3
        }
    }
}, Tuple2[int, Tuple2[Tuple2[int, string, Tuple2[string, int]{
    a: 1
    b: Tuple2[Tuple2[int, string, Tuple2[string, int]{
        a: Tuple2[int, string]{
            a: 4
            b: 'four'
        }
        b: Tuple2[string, int]{
            a: 'four'
            b: 4
        }
    }
}]
[]Tuple2[int, Tuple2[string, int]]
[]Tuple2[int, Tuple2[string, int]]
[]Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]
[]Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]
```