### PR TITLE
ast, cgen: fix printing nested generic struct

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1395,9 +1395,9 @@ fn (t Table) shorten_user_defined_typenames(originalname string, import_aliases 
 		}
 		// types defined by the user
 		// mod.submod.submod2.Type => submod2.Type
-		if res.count('[') < 2 {
-			mut parts := res.split('.')
-			if parts.len > 1 {
+		mut parts := res.split('.')
+		if parts.len > 1 {
+			if parts[..parts.len - 1].all(!it.contains('[')) {
 				ind := parts.len - 2
 				if t.is_fmt {
 					// Rejoin the module parts for correct usage of aliases
@@ -1408,9 +1408,9 @@ fn (t Table) shorten_user_defined_typenames(originalname string, import_aliases 
 				}
 
 				res = parts[ind..].join('.')
-			} else {
-				res = parts[0]
 			}
+		} else {
+			res = parts[0]
 		}
 	}
 	return res

--- a/vlib/v/tests/inout/printing_nested_generic_struct.out
+++ b/vlib/v/tests/inout/printing_nested_generic_struct.out
@@ -1,0 +1,80 @@
+{'one': 1, 'two': 2}
+[Tuple2[int, Tuple2[string, int]]{
+    a: 0
+    b: Tuple2[string, int]{
+        a: 'one'
+        b: 1
+    }
+}, Tuple2[int, Tuple2[string, int]]{
+    a: 1
+    b: Tuple2[string, int]{
+        a: 'two'
+        b: 2
+    }
+}]
+[Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{
+    a: 0
+    b: Tuple2[Tuple2[string, int], Tuple2[int, string]]{
+        a: Tuple2[string, int]{
+            a: 'one'
+            b: 1
+        }
+        b: Tuple2[int, string]{
+            a: 1
+            b: 'one'
+        }
+    }
+}, Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{
+    a: 1
+    b: Tuple2[Tuple2[string, int], Tuple2[int, string]]{
+        a: Tuple2[string, int]{
+            a: 'two'
+            b: 2
+        }
+        b: Tuple2[int, string]{
+            a: 2
+            b: 'two'
+        }
+    }
+}]
+{3: 'three', 4: 'four'}
+[Tuple2[int, Tuple2[int, string]]{
+    a: 0
+    b: Tuple2[int, string]{
+        a: 3
+        b: 'three'
+    }
+}, Tuple2[int, Tuple2[int, string]]{
+    a: 1
+    b: Tuple2[int, string]{
+        a: 4
+        b: 'four'
+    }
+}]
+[Tuple2[int, Tuple2[Tuple2[int, string], Tuple2[string, int]]]{
+    a: 0
+    b: Tuple2[Tuple2[int, string], Tuple2[string, int]]{
+        a: Tuple2[int, string]{
+            a: 3
+            b: 'three'
+        }
+        b: Tuple2[string, int]{
+            a: 'three'
+            b: 3
+        }
+    }
+}, Tuple2[int, Tuple2[Tuple2[int, string], Tuple2[string, int]]]{
+    a: 1
+    b: Tuple2[Tuple2[int, string], Tuple2[string, int]]{
+        a: Tuple2[int, string]{
+            a: 4
+            b: 'four'
+        }
+        b: Tuple2[string, int]{
+            a: 'four'
+            b: 4
+        }
+    }
+}]
+[]Tuple2[int, Tuple2[string, int]]
+[]Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]

--- a/vlib/v/tests/inout/printing_nested_generic_struct.vv
+++ b/vlib/v/tests/inout/printing_nested_generic_struct.vv
@@ -1,0 +1,55 @@
+struct Tuple2[A, B] {
+	a A
+	b B
+}
+
+// map to array of Tuple2[int, Tuple2[key, value]] tuples
+fn map_to_array_int_kv[K, V](m map[K]V) []Tuple2[int, Tuple2[K, V]] {
+	mut r := []Tuple2[int, Tuple2[K, V]]{cap: m.len}
+	mut i := 0
+	for k, v in m {
+		r << Tuple2[int, Tuple2[K, V]]{i, Tuple2[K, V]{k, v}}
+		i += 1
+	}
+	return r
+}
+
+// map to array of Tuple2[int, Tuple2[Tuple2[key, value], Tuple2[value, key]]] tuples
+fn map_to_array_int_kv_vk[K, V](m map[K]V) []Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]] {
+	mut r := []Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]]{cap: m.len}
+	mut i := 0
+	for k, v in m {
+		r << Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]]{i, Tuple2[Tuple2[K, V], Tuple2[V, K]]{Tuple2[K, V]{k, v}, Tuple2[V, K]{v, k}}}
+		i += 1
+	}
+	return r
+}
+
+fn main() {
+	x := {
+		'one': 1
+		'two': 2
+	}
+	y := {
+		3: 'three'
+		4: 'four'
+	}
+
+	println(x)
+	rx1 := map_to_array_int_kv(x)
+	println(rx1)
+	rx2 := map_to_array_int_kv_vk(x)
+	println(rx2)
+
+	println(y)
+	ry1 := map_to_array_int_kv(y)
+	println(ry1)
+	ry2 := map_to_array_int_kv_vk(y)
+	println(ry2)
+
+	// test typeof(X).name
+	zx1 := []Tuple2[int, Tuple2[string, int]]{}
+	println(typeof(zx1).name)
+	zx2 := []Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{}
+	println(typeof(zx2).name)
+}

--- a/vlib/v/tests/printing_c_structs/string_interpolation_test.v
+++ b/vlib/v/tests/printing_c_structs/string_interpolation_test.v
@@ -19,7 +19,7 @@ fn test_interpolation_of_v_structs_containing_c_structs() {
 	}
 	sxxx := xxx.str()
 	assert sxxx == 'VStruct{
-    a_c_struct: struct Abc{
+    a_c_struct: C.Abc{
         char_pointer_field: &C"the string"
     }
 }'

--- a/vlib/v/tests/str_gen_test.v
+++ b/vlib/v/tests/str_gen_test.v
@@ -458,7 +458,7 @@ fn test_c_struct_typedef() {
 		}
 		assert c.str() == r'CTypeDefStruct{
     mutex: &sync.Mutex{
-        mutex: pthread_mutex_t{}
+        mutex: C.pthread_mutex_t{}
     }
 }'
 	}


### PR DESCRIPTION
This PR fix printing nested generic struct.

- Fix printing nested generic struct.
- Add test.

```v
struct Tuple2[A, B] {
	a A
	b B
}

// map to array of Tuple2[int, Tuple2[key, value]] tuples
fn map_to_array_int_kv[K, V](m map[K]V) []Tuple2[int, Tuple2[K, V]] {
	mut r := []Tuple2[int, Tuple2[K, V]]{cap: m.len}
	mut i := 0
	for k, v in m {
		r << Tuple2[int, Tuple2[K, V]]{i, Tuple2[K, V]{k, v}}
		i += 1
	}
	return r
}

// map to array of Tuple2[int, Tuple2[Tuple2[key, value], Tuple2[value, key]]] tuples
fn map_to_array_int_kv_vk[K, V](m map[K]V) []Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]] {
	mut r := []Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]]{cap: m.len}
	mut i := 0
	for k, v in m {
		r << Tuple2[int, Tuple2[Tuple2[K, V], Tuple2[V, K]]]{i, Tuple2[Tuple2[K, V], Tuple2[V, K]]{Tuple2[K, V]{k, v}, Tuple2[V, K]{v, k}}}
		i += 1
	}
	return r
}

fn main() {
	x := {
		'one': 1
		'two': 2
	}
	y := {
		3: 'three'
		4: 'four'
	}

	println(x)
	rx1 := map_to_array_int_kv(x)
	println(rx1)
	rx2 := map_to_array_int_kv_vk(x)
	println(rx2)

	println(y)
	ry1 := map_to_array_int_kv(y)
	println(ry1)
	ry2 := map_to_array_int_kv_vk(y)
	println(ry2)

	// test typeof(X).name
	zx1 := []Tuple2[int, Tuple2[string, int]]{}
	println(typeof(zx1).name)
	zx2 := []Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{}
	println(typeof(zx2).name)
}

PS D:\Test\v\tt1> v run .
{'one': 1, 'two': 2}
[Tuple2[int, Tuple2[string, int]]{
    a: 0
    b: Tuple2[string, int]{
        a: 'one'
        b: 1
    }
}, Tuple2[int, Tuple2[string, int]]{
    a: 1
    b: Tuple2[string, int]{
        a: 'two'
        b: 2
    }
}]
[Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{
    a: 0
    b: Tuple2[Tuple2[string, int], Tuple2[int, string]]{
        a: Tuple2[string, int]{
            a: 'one'
            b: 1
        }
        b: Tuple2[int, string]{
            a: 1
            b: 'one'
        }
    }
}, Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]{
    a: 1
    b: Tuple2[Tuple2[string, int], Tuple2[int, string]]{
        a: Tuple2[string, int]{
            a: 'two'
            b: 2
        }
        b: Tuple2[int, string]{
            a: 2
            b: 'two'
        }
    }
}]
{3: 'three', 4: 'four'}
[Tuple2[int, Tuple2[int, string]]{
    a: 0
    b: Tuple2[int, string]{
        a: 3
        b: 'three'
    }
}, Tuple2[int, Tuple2[int, string]]{
    a: 1
    b: Tuple2[int, string]{
        a: 4
        b: 'four'
    }
}]
[Tuple2[int, Tuple2[Tuple2[int, string], Tuple2[string, int]]]{
    a: 0
    b: Tuple2[Tuple2[int, string], Tuple2[string, int]]{
        a: Tuple2[int, string]{
            a: 3
            b: 'three'
        }
        b: Tuple2[string, int]{
            a: 'three'
            b: 3
        }
    }
}, Tuple2[int, Tuple2[Tuple2[int, string], Tuple2[string, int]]]{
    a: 1
    b: Tuple2[Tuple2[int, string], Tuple2[string, int]]{
        a: Tuple2[int, string]{
            a: 4
            b: 'four'
        }
        b: Tuple2[string, int]{
            a: 'four'
            b: 4
        }
    }
}]
[]Tuple2[int, Tuple2[string, int]]
[]Tuple2[int, Tuple2[Tuple2[string, int], Tuple2[int, string]]]
```