### PR TITLE
fix comptime value recognize on generic argument

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -590,6 +590,7 @@ pub mut:
 	is_ctor_new        bool // if JS ctor calls requires `new` before call, marked as `[use_new]` in V
 	args               []CallArg
 	expected_arg_types []Type
+	comptime_ret_val   bool
 	language           Language
 	or_block           OrExpr
 	left               Expr // `user` in `user.register()`

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -883,8 +883,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 
 								if func.return_type.has_flag(.generic)
 									&& gt_name == c.table.type_to_str(func.return_type) {
-									c.error('cannot use value known only on compile-time as return',
-										node.pos)
+									node.comptime_ret_val = true
 								}
 							}
 						}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -95,6 +95,7 @@ mut:
 	vweb_gen_types                   []ast.Type // vweb route checks
 	timers                           &util.Timers = util.get_timers()
 	for_in_any_val_type              ast.Type
+	comptime_for_field_var           string
 	comptime_fields_default_type     ast.Type
 	comptime_fields_type             map[string]ast.Type
 	fn_scope                         &ast.Scope = unsafe { nil }

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -180,6 +180,7 @@ fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 			sym_info := sym.info as ast.Struct
 			c.inside_comptime_for_field = true
 			for field in sym_info.fields {
+				c.comptime_for_field_var = node.val_var
 				c.comptime_fields_type[node.val_var] = node.typ
 				c.comptime_fields_default_type = field.typ
 				c.stmts(node.stmts)

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -189,6 +189,7 @@ fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 				tsym := c.table.sym(unwrapped_expr_type)
 				c.table.dumps[int(unwrapped_expr_type.clear_flag(.optional).clear_flag(.result))] = tsym.cname
 			}
+			c.comptime_for_field_var = ''
 			c.inside_comptime_for_field = false
 		}
 	} else {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -136,7 +136,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				is_auto_heap = left.obj.is_auto_heap
 			}
 		}
-		styp := g.typ(var_type)
+		mut styp := g.typ(var_type)
 		mut is_fixed_array_init := false
 		mut has_val := false
 		match val {
@@ -146,7 +146,12 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 			}
 			ast.CallExpr {
 				is_call = true
-				return_type = val.return_type
+				if val.comptime_ret_val {
+					return_type = g.comptime_for_field_type
+					styp = g.typ(return_type)
+				} else {
+					return_type = val.return_type
+				}
 			}
 			// TODO: no buffer fiddling
 			ast.AnonFn {

--- a/vlib/v/tests/comptime_on_generics_func_test.v
+++ b/vlib/v/tests/comptime_on_generics_func_test.v
@@ -1,0 +1,25 @@
+module main
+
+struct MyStruct {
+	b string
+	c bool
+}
+
+fn get_type[T](t T) T {
+	return t
+}
+
+
+fn test_main() {
+    my := MyStruct{'cool', false}
+	$for field2 in MyStruct.fields {
+		$if field2.typ is string {
+			var := get_type(my.$(field2.name))
+			assert dump(var) == 'cool'
+		}
+		$if field2.typ is bool {
+			var := get_type(my.$(field2.name))
+			assert dump(var).str() == 'false'
+		}
+	}
+}

--- a/vlib/v/tests/comptime_on_generics_func_test.v
+++ b/vlib/v/tests/comptime_on_generics_func_test.v
@@ -9,9 +9,8 @@ fn get_type[T](t T) T {
 	return t
 }
 
-
 fn test_main() {
-    my := MyStruct{'cool', false}
+	my := MyStruct{'cool', false}
 	$for field2 in MyStruct.fields {
 		$if field2.typ is string {
 			var := get_type(my.$(field2.name))

--- a/vlib/v/tests/comptime_var_on_multiple_args_test.v
+++ b/vlib/v/tests/comptime_var_on_multiple_args_test.v
@@ -1,0 +1,33 @@
+module main
+
+fn ok3[T](o T) T {
+	return o
+}
+
+fn ok2[T](o T, s string) string {
+	return s
+}
+
+fn ok[T](o T, s string) string {
+	return "${o}${s}"
+}
+
+struct Test {
+	s string
+}
+
+fn test_main() {
+	s := Test{'foo'}
+
+	$for f in Test.fields {
+		assert ok3(s.$(f.name)).str() == 'foo'
+	}
+
+	$for f in Test.fields {
+		assert ok(s.$(f.name), 'bar') == 'foobar'
+	}
+
+	$for f in Test.fields {
+		assert ok2(s.$(f.name), 'ok') == 'ok'
+	}
+}

--- a/vlib/v/tests/comptime_var_on_multiple_args_test.v
+++ b/vlib/v/tests/comptime_var_on_multiple_args_test.v
@@ -9,7 +9,7 @@ fn ok2[T](o T, s string) string {
 }
 
 fn ok[T](o T, s string) string {
-	return "${o}${s}"
+	return '${o}${s}'
 }
 
 struct Test {
@@ -22,11 +22,9 @@ fn test_main() {
 	$for f in Test.fields {
 		assert ok3(s.$(f.name)).str() == 'foo'
 	}
-
 	$for f in Test.fields {
 		assert ok(s.$(f.name), 'bar') == 'foobar'
 	}
-
 	$for f in Test.fields {
 		assert ok2(s.$(f.name), 'ok') == 'ok'
 	}


### PR DESCRIPTION
Fix #16759 (not completely, it just works from dump() call)

```V
struct MyStruct {
	b string
	c bool
}

fn get_type[T](t T) T {
	return t
}


fn main() {
    my := MyStruct{'cool', false}
	$for field2 in MyStruct.fields {
		$if field2.typ is string {
			var := get_type(my.$(field2.name))
			dump(var)
		}
		$if field2.typ is bool {
			var := get_type(my.$(field2.name))
			dump(var)
		}
	}
}
```

Prints

```
[test.v:16] var: cool
[test.v:20] var: false
```