### PR TITLE
vlib: fix os.file_ext() (fix #16751)

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -209,10 +209,11 @@ pub fn is_dir_empty(path string) bool {
 // assert os.file_ext('.ignore_me') == ''
 // assert os.file_ext('.') == ''
 // ```
-pub fn file_ext(path string) string {
-	if path.len < 3 {
+pub fn file_ext(opath string) string {
+	if opath.len < 3 {
 		return empty_str
 	}
+	path := file_name(opath)
 	pos := path.last_index(dot_str) or { return empty_str }
 	if pos + 1 >= path.len || pos == 0 {
 		return empty_str

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -599,6 +599,10 @@ fn test_file_ext() {
 	assert os.file_ext('file...') == ''
 	assert os.file_ext('.file.') == ''
 	assert os.file_ext('..file..') == ''
+	assert os.file_ext('./.git') == ''
+	assert os.file_ext('./.git/') == ''
+	assert os.file_ext('\\.git') == ''
+	assert os.file_ext('\\.git\\') == ''
 }
 
 fn test_join() {


### PR DESCRIPTION
This PR fix os.file_ext() (fix #16751).

- Fix os.file_ext().
- Add test.

```v
import os

fn main() {
	println(os.file_ext('.gitignore'))
	println(os.file_ext('/.git/'))
}

PS D:\Test\v\tt1> v run .

```