### PR TITLE
cgen: fix array filter using direct closure (fix #16770)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -368,9 +368,9 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 				var := g.new_tmp_var()
 				line := g.go_before_stmt(0).trim_space()
 				g.empty_line = true
-				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var))
-				g.write(' = ')
+				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var)
+				g.write('${fn_ptr_name} = ')
 				g.gen_anon_fn(mut expr)
 				g.writeln(';')
 				g.write(line)
@@ -576,9 +576,9 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 				var := g.new_tmp_var()
 				line := g.go_before_stmt(0).trim_space()
 				g.empty_line = true
-				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var))
-				g.write(' = ')
+				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var)
+				g.write('${fn_ptr_name} = ')
 				g.gen_anon_fn(mut expr)
 				g.writeln(';')
 				g.write(line)
@@ -948,9 +948,9 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 				var := g.new_tmp_var()
 				line := g.go_before_stmt(0).trim_space()
 				g.empty_line = true
-				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var))
-				g.write(' = ')
+				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var)
+				g.write('${fn_ptr_name} = ')
 				g.gen_anon_fn(mut expr)
 				g.writeln(';')
 				g.write(line)
@@ -1037,9 +1037,9 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 				var := g.new_tmp_var()
 				line := g.go_before_stmt(0).trim_space()
 				g.empty_line = true
-				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var))
-				g.write(' = ')
+				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var)
+				g.write('${fn_ptr_name} = ')
 				g.gen_anon_fn(mut expr)
 				g.writeln(';')
 				g.write(line)

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -364,8 +364,21 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	match mut expr {
 		ast.AnonFn {
 			g.write('${ret_elem_type} ti = ')
-			g.gen_anon_fn_decl(mut expr)
-			g.write('${expr.decl.name}(it)')
+			if expr.inherited_vars.len > 0 {
+				var := g.new_tmp_var()
+				line := g.go_before_stmt(0).trim_space()
+				g.empty_line = true
+				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var))
+				g.write(' = ')
+				g.gen_anon_fn(mut expr)
+				g.writeln(';')
+				g.write(line)
+				g.write('${var}(it)')
+			} else {
+				g.gen_anon_fn_decl(mut expr)
+				g.write('${expr.decl.name}(it)')
+			}
 		}
 		ast.Ident {
 			g.write('${ret_elem_type} ti = ')
@@ -559,8 +572,21 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	match mut expr {
 		ast.AnonFn {
 			g.write('if (')
-			g.gen_anon_fn_decl(mut expr)
-			g.write('${expr.decl.name}(it)')
+			if expr.inherited_vars.len > 0 {
+				var := g.new_tmp_var()
+				line := g.go_before_stmt(0).trim_space()
+				g.empty_line = true
+				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var))
+				g.write(' = ')
+				g.gen_anon_fn(mut expr)
+				g.writeln(';')
+				g.write(line)
+				g.write('${var}(it)')
+			} else {
+				g.gen_anon_fn_decl(mut expr)
+				g.write('${expr.decl.name}(it)')
+			}
 		}
 		ast.Ident {
 			g.write('if (')
@@ -918,8 +944,21 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	match mut expr {
 		ast.AnonFn {
 			g.write('if (')
-			g.gen_anon_fn_decl(mut expr)
-			g.write('${expr.decl.name}(it)')
+			if expr.inherited_vars.len > 0 {
+				var := g.new_tmp_var()
+				line := g.go_before_stmt(0).trim_space()
+				g.empty_line = true
+				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var))
+				g.write(' = ')
+				g.gen_anon_fn(mut expr)
+				g.writeln(';')
+				g.write(line)
+				g.write('${var}(it)')
+			} else {
+				g.gen_anon_fn_decl(mut expr)
+				g.write('${expr.decl.name}(it)')
+			}
 		}
 		ast.Ident {
 			g.write('if (')
@@ -994,8 +1033,21 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	match mut expr {
 		ast.AnonFn {
 			g.write('if (!(')
-			g.gen_anon_fn_decl(mut expr)
-			g.write('${expr.decl.name}(it)')
+			if expr.inherited_vars.len > 0 {
+				var := g.new_tmp_var()
+				line := g.go_before_stmt(0).trim_space()
+				g.empty_line = true
+				g.write(g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+					var))
+				g.write(' = ')
+				g.gen_anon_fn(mut expr)
+				g.writeln(';')
+				g.write(line)
+				g.write('${var}(it)')
+			} else {
+				g.gen_anon_fn_decl(mut expr)
+				g.write('${expr.decl.name}(it)')
+			}
 		}
 		ast.Ident {
 			g.write('if (!(')

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -331,6 +331,19 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 	}
 }
 
+fn (mut g Gen) write_closure_fn(mut expr ast.AnonFn) {
+	var := g.new_tmp_var()
+	line := g.go_before_stmt(0).trim_space()
+	g.empty_line = true
+	fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
+		var)
+	g.write('${fn_ptr_name} = ')
+	g.gen_anon_fn(mut expr)
+	g.writeln(';')
+	g.write(line)
+	g.write('${var}(it)')
+}
+
 // `nums.map(it % 2 == 0)`
 fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	g.inside_lambda = true
@@ -365,16 +378,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 		ast.AnonFn {
 			g.write('${ret_elem_type} ti = ')
 			if expr.inherited_vars.len > 0 {
-				var := g.new_tmp_var()
-				line := g.go_before_stmt(0).trim_space()
-				g.empty_line = true
-				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var)
-				g.write('${fn_ptr_name} = ')
-				g.gen_anon_fn(mut expr)
-				g.writeln(';')
-				g.write(line)
-				g.write('${var}(it)')
+				g.write_closure_fn(mut expr)
 			} else {
 				g.gen_anon_fn_decl(mut expr)
 				g.write('${expr.decl.name}(it)')
@@ -573,16 +577,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 		ast.AnonFn {
 			g.write('if (')
 			if expr.inherited_vars.len > 0 {
-				var := g.new_tmp_var()
-				line := g.go_before_stmt(0).trim_space()
-				g.empty_line = true
-				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var)
-				g.write('${fn_ptr_name} = ')
-				g.gen_anon_fn(mut expr)
-				g.writeln(';')
-				g.write(line)
-				g.write('${var}(it)')
+				g.write_closure_fn(mut expr)
 			} else {
 				g.gen_anon_fn_decl(mut expr)
 				g.write('${expr.decl.name}(it)')
@@ -945,16 +940,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 		ast.AnonFn {
 			g.write('if (')
 			if expr.inherited_vars.len > 0 {
-				var := g.new_tmp_var()
-				line := g.go_before_stmt(0).trim_space()
-				g.empty_line = true
-				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var)
-				g.write('${fn_ptr_name} = ')
-				g.gen_anon_fn(mut expr)
-				g.writeln(';')
-				g.write(line)
-				g.write('${var}(it)')
+				g.write_closure_fn(mut expr)
 			} else {
 				g.gen_anon_fn_decl(mut expr)
 				g.write('${expr.decl.name}(it)')
@@ -1034,16 +1020,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 		ast.AnonFn {
 			g.write('if (!(')
 			if expr.inherited_vars.len > 0 {
-				var := g.new_tmp_var()
-				line := g.go_before_stmt(0).trim_space()
-				g.empty_line = true
-				fn_ptr_name := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-					var)
-				g.write('${fn_ptr_name} = ')
-				g.gen_anon_fn(mut expr)
-				g.writeln(';')
-				g.write(line)
-				g.write('${var}(it)')
+				g.write_closure_fn(mut expr)
 			} else {
 				g.gen_anon_fn_decl(mut expr)
 				g.write('${expr.decl.name}(it)')

--- a/vlib/v/tests/array_filter_using_direct_closure_test.v
+++ b/vlib/v/tests/array_filter_using_direct_closure_test.v
@@ -1,0 +1,42 @@
+struct File {
+	name   string
+	typ    string
+	is_dir bool
+}
+
+fn filter(all_files []File, interested_file File) []File {
+	println(interested_file)
+	return all_files.filter(fn [interested_file] (f File) bool {
+		println(interested_file)
+		return true
+	})
+}
+
+fn test_array_filter_using_direct_closure() {
+	filenames := ['one', 'two', 'three']
+	files := filenames.map(fn (f string) File {
+		return File{
+			name: f
+			typ: if f == 'one' {
+				'file'
+			} else {
+				'dir'
+			}
+			is_dir: if f == 'one' {
+				false
+			} else {
+				true
+			}
+		}
+	})
+
+	ret := filter(files, files[0])
+	println(ret)
+	assert ret.len == 3
+	assert ret[0].name == 'one'
+	assert ret[0].typ == 'file'
+	assert ret[1].name == 'two'
+	assert ret[1].typ == 'dir'
+	assert ret[2].name == 'three'
+	assert ret[2].typ == 'dir'
+}


### PR DESCRIPTION
This PR fix array filter using direct closure (fix #16770).

- Fix array filter/all/any/map using direct closure.
- Add test.

```v
struct File {
	name   string
	typ    string
	is_dir bool
}

fn filter(all_files []File, interested_file File) []File {
	println(interested_file)
	return all_files.filter(fn [interested_file] (f File) bool {
		println(interested_file)
		return true
	})
}

fn main() {
	filenames := ['one', 'two', 'three']
	files := filenames.map(fn (f string) File {
		return File{
			name: f
			typ: if f == 'one' {
				'file'
			} else {
				'dir'
			}
			is_dir: if f == 'one' {
				false
			} else {
				true
			}
		}
	})

	ret := filter(files, files[0])
	println(ret)
	assert ret.len == 3
	assert ret[0].name == 'one'
	assert ret[0].typ == 'file'
	assert ret[1].name == 'two'
	assert ret[1].typ == 'dir'
	assert ret[2].name == 'three'
	assert ret[2].typ == 'dir'
}

PS D:\Test\v\tt1> v run .
File{
    name: 'one'
    typ: 'file'
    is_dir: false
}
File{
    name: 'one'
    typ: 'file'
    is_dir: false
}
File{
    name: 'one'
    typ: 'file'
    is_dir: false
}
File{
    name: 'one'
    typ: 'file'
    is_dir: false
}
[File{
    name: 'one'
    typ: 'file'
    is_dir: false
}, File{
    name: 'two'
    typ: 'dir'
    is_dir: true
}, File{
    name: 'three'
    typ: 'dir'
    is_dir: true
}]
```