### PR TITLE
checker: Fix fn call with generic []T arg

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -263,8 +263,8 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 			return
 		}
 	} else {
-		got_typ_sym := c.table.sym(got)
-		expected_typ_sym := c.table.sym(expected_)
+		got_typ_sym := c.table.sym(c.unwrap_generic(got))
+		expected_typ_sym := c.table.sym(c.unwrap_generic(expected_))
 
 		// Check on Generics types, there are some case where we have the following case
 		// `&Type[int] == &Type[]`. This is a common case we are implementing a function

--- a/vlib/v/tests/fn_call_generic_array_arg_test.v
+++ b/vlib/v/tests/fn_call_generic_array_arg_test.v
@@ -1,0 +1,15 @@
+fn f64_fun(x []f64) f64 {
+	return x[0] + x[1]
+}
+
+fn t_fun[T](x []T) T {
+	$if T is f64 {
+		return f64_fun(x)
+	} $else {
+		return T(0)
+	}
+}
+
+fn test_main() {
+	assert t_fun([1.0, 2.0]) == 3.0
+}


### PR DESCRIPTION
Fix #14047

```V
fn f64_fun(x []f64) f64 {
        return x[0] + x[1]
}

fn t_fun<T>(x []T) T {
        $if T is f64 {
                return f64_fun(x)
        }
        $else {
                return T(0)
        }
}

fn main() {
        print(t_fun([1.0, 2.0]))
}
```