### PR TITLE
checker: fix fn call with incompatible u8 ref

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -224,6 +224,15 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 			&& got == ast.int_type_idx {
 			return
 		}
+	} else {
+		exp_sym_idx := c.table.sym(expected).idx
+		got_sym_idx := c.table.sym(got).idx
+		if expected.is_ptr() && got.is_ptr() && exp_sym_idx != got_sym_idx
+			&& exp_sym_idx in [ast.u8_type_idx, ast.byteptr_type_idx]
+			&& got_sym_idx !in [ast.u8_type_idx, ast.byteptr_type_idx] {
+			got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
+			return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
+		}
 	}
 	// check int signed/unsigned mismatch
 	if got == ast.int_literal_type_idx && expected in ast.unsigned_integer_type_idxs

--- a/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.out
+++ b/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.vv:9:28: error: cannot use `&[]int` as `&u8` in argument 1 to `accept_only_u8_references`
+    7 | fn test_main() {
+    8 |     a := [1, 2, 3]
+    9 |     accept_only_u8_references(&a)
+      |                               ~~
+   10 | }

--- a/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.vv
+++ b/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.vv
@@ -1,0 +1,10 @@
+module main
+
+fn accept_only_u8_references(x &u8) {
+	println(ptr_str(x))
+}
+
+fn test_main() {
+	a := [1, 2, 3]
+	accept_only_u8_references(&a)
+}


### PR DESCRIPTION
Fix #16354

```V
fn accept_only_u8_references(x &u8) {
	println(ptr_str(x))
}

fn main() {
	a := [1, 2, 3]
	accept_only_u8_references(&a)
}
```