### PR TITLE
cgen: Fix generic func arg type when passing array compile-time field

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1367,7 +1367,12 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 					&& has_comptime_field {
 					mut concrete_types := node.concrete_types.map(g.unwrap_generic(it))
 					for k in comptime_args {
-						concrete_types[k] = g.comptime_for_field_type
+						arg_sym := g.table.sym(g.comptime_for_field_type)
+						if arg_sym.kind == .array {
+							concrete_types[k] = (arg_sym.info as ast.Array).elem_type
+						} else {
+							concrete_types[k] = g.comptime_for_field_type
+						}
 					}
 					name = g.generic_fn_name(concrete_types, name)
 				} else {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1366,8 +1366,8 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				if g.comptime_for_field_type != 0 && g.inside_comptime_for_field
 					&& has_comptime_field {
 					mut concrete_types := node.concrete_types.map(g.unwrap_generic(it))
+					arg_sym := g.table.sym(g.comptime_for_field_type)
 					for k in comptime_args {
-						arg_sym := g.table.sym(g.comptime_for_field_type)
 						if arg_sym.kind == .array {
 							concrete_types[k] = (arg_sym.info as ast.Array).elem_type
 						} else {

--- a/vlib/v/tests/fn_call_comptime_array_arg_test.v
+++ b/vlib/v/tests/fn_call_comptime_array_arg_test.v
@@ -1,0 +1,30 @@
+struct IntArray {
+	a []int
+}
+
+fn encode_array[U](val []U) []string {
+	mut out := []string{}
+	$if U is int {
+		out << 'is int'
+	} $else $if U is $Struct {
+		out << 'is struct'
+	}
+	return out
+}
+
+fn encode_struct[U](val U) ?[]string {
+	$for field in U.fields {
+		if field.is_array {
+			value := val.$(field.name)
+			return encode_array(value)
+		}
+	}
+	return none
+}
+
+fn test_main() {
+	int_array := IntArray{
+		a: [1, 2, 3]
+	}
+	assert encode_struct(int_array)?.str() == "['is int']"
+}


### PR DESCRIPTION
Fix #16792
