### PR TITLE
cgen: Fix uneeded C generated code when using selectorexpr on $if

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -491,7 +491,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 				&& (cond.expr as ast.Ident).name == g.comptime_for_field_var && cond.field_name in ['is_mut', 'is_pub', 'is_shared', 'is_atomic', 'is_optional', 'is_array', 'is_map', 'is_chan', 'is_struct'] {
 				ret_bool := g.get_comptime_selector_bool_field(cond.field_name)
 				g.write(ret_bool.str())
-				return true
+				return ret_bool
 			} else {
 				g.write('1')
 				return true


### PR DESCRIPTION
Fix #16801

Thanks @enghitalo for finding it! :-)