### PR TITLE
parser, cgen: fix anon fn optional call in if expr (fix #16673)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -652,7 +652,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.expr(node.left)
 			g.writeln(';')
 			g.write(tmp_var)
-		} else {
+		} else if node.or_block.kind == .absent {
 			g.expr(node.left)
 		}
 	} else if node.left is ast.IndexExpr && node.name == '' {
@@ -695,6 +695,9 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.write('${tmp_opt} = ')
 		} else {
 			g.write('${styp} ${tmp_opt} = ')
+			if node.left is ast.AnonFn {
+				g.expr(node.left)
+			}
 		}
 	}
 	if node.is_method && !node.is_field {

--- a/vlib/v/tests/anon_fn_optional_call_in_if_expr_test.v
+++ b/vlib/v/tests/anon_fn_optional_call_in_if_expr_test.v
@@ -1,0 +1,35 @@
+fn test_anon_fn_optional_call_in_if_expr_1() {
+	if fn () ?bool {
+		return true
+	}() or { false }
+	{
+		println('ok')
+		assert true
+	} else {
+		assert false
+	}
+}
+
+fn test_anon_fn_optional_call_in_if_expr_2() {
+	if fn () ?bool {
+		return true
+	}()?
+	{
+		println('ok')
+		assert true
+	} else {
+		assert false
+	}
+}
+
+fn test_anon_fn_optional_call_in_if_expr_3() {
+	if fn () !bool {
+		return true
+	}()!
+	{
+		println('ok')
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix anon fn optional call in if expr (fix #16673).

- Fix anon fn optional call in if expr.
- Add test.

```v
fn main() {
	if fn () ?bool {
		return true
	}() or { false }
	{
		println('ok')
		assert true
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
ok
```