### PR TITLE
cgen: Fix dump fn name using generic var

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -19,8 +19,7 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		// generic func with recursion rewrite node.expr_type
 		if node.expr is ast.Ident {
 			// var
-			if (node.expr as ast.Ident).info is ast.IdentVar
-				&& (node.expr as ast.Ident).language == .v {
+			if (node.expr as ast.Ident).info is ast.IdentVar && (node.expr as ast.Ident).language == .v {
 				name = g.typ(g.unwrap_generic((node.expr as ast.Ident).info.typ))
 			}
 		}

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -20,7 +20,8 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		if node.expr is ast.Ident {
 			// var
 			if (node.expr as ast.Ident).info is ast.IdentVar && (node.expr as ast.Ident).language == .v {
-				name = g.typ(g.unwrap_generic((node.expr as ast.Ident).info.typ)).replace('*', '')
+				name = g.typ(g.unwrap_generic((node.expr as ast.Ident).info.typ)).replace('*',
+					'')
 			}
 		}
 	}

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -20,7 +20,7 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		if node.expr is ast.Ident {
 			// var
 			if (node.expr as ast.Ident).info is ast.IdentVar && (node.expr as ast.Ident).language == .v {
-				name = g.typ(g.unwrap_generic((node.expr as ast.Ident).info.typ))
+				name = g.typ(g.unwrap_generic((node.expr as ast.Ident).info.typ)).replace('*', '')
 			}
 		}
 	}

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -15,6 +15,16 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 	mut name := node.cname
 	mut expr_type := node.expr_type
 
+	if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0 {
+		// generic func with recursion rewrite node.expr_type
+		if node.expr is ast.Ident {
+			// var
+			if (node.expr as ast.Ident).info is ast.IdentVar
+				&& (node.expr as ast.Ident).language == .v {
+				name = g.typ(g.unwrap_generic((node.expr as ast.Ident).info.typ))
+			}
+		}
+	}
 	// var.${field.name}
 	if node.expr is ast.ComptimeSelector {
 		selector := node.expr as ast.ComptimeSelector

--- a/vlib/v/tests/dump_on_generic_func_test.v
+++ b/vlib/v/tests/dump_on_generic_func_test.v
@@ -1,0 +1,25 @@
+interface Refresher {
+	refresh()
+}
+
+struct Dummy {}
+
+fn (d Dummy) refresh() {}
+
+struct Source {
+mut:
+	refresher Refresher = Dummy{}
+}
+
+struct App {
+mut:
+	src Source
+}
+
+fn test_struct_init_with_interface_field() {
+	mut app := &App{}
+	app.src = Source{}
+
+	println(app)
+	assert '${app}'.contains('refresher: Refresher(Dummy{})')
+}

--- a/vlib/v/tests/dump_on_generic_func_test.v
+++ b/vlib/v/tests/dump_on_generic_func_test.v
@@ -1,25 +1,24 @@
-interface Refresher {
-	refresh()
+struct Aa {
+	sub AliasType
 }
 
-struct Dummy {}
+type AliasType = Bb
 
-fn (d Dummy) refresh() {}
-
-struct Source {
-mut:
-	refresher Refresher = Dummy{}
+struct Bb {
+	a int
 }
 
-struct App {
-mut:
-	src Source
+fn encode_struct[U](val U) {
+	dump(val)
+	println(val)
+	$for field in U.fields {
+		encode_struct(val.$(field.name))
+	}
 }
 
-fn test_struct_init_with_interface_field() {
-	mut app := &App{}
-	app.src = Source{}
+fn test_main() {
+	aa := Aa{}
 
-	println(app)
-	assert '${app}'.contains('refresher: Refresher(Dummy{})')
+	encode_struct(aa)
+	assert true
 }


### PR DESCRIPTION
Fix #16784
