### PR TITLE
cgen: fix fixed array literal range index (fix #16807)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -120,8 +120,20 @@ fn (mut g Gen) index_range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		if node.left_type.is_ptr() {
 			g.write('*')
 		}
-		g.expr(node.left)
-		g.write(')')
+		if node.left is ast.ArrayInit {
+			var := g.new_tmp_var()
+			line := g.go_before_stmt(0).trim_space()
+			styp := g.typ(node.left_type)
+			g.empty_line = true
+			g.write('${styp} ${var} = ')
+			g.expr(node.left)
+			g.writeln(';')
+			g.write(line)
+			g.write(' ${var})')
+		} else {
+			g.expr(node.left)
+			g.write(')')
+		}
 	} else {
 		g.expr(node.left)
 	}

--- a/vlib/v/tests/fixed_array_literal_range_index_test.v
+++ b/vlib/v/tests/fixed_array_literal_range_index_test.v
@@ -1,0 +1,7 @@
+fn test_fixed_array_literal_range_index() {
+	arr := [1, 2, 3, 4]![..]
+	println(arr)
+	println(typeof(arr).name)
+	assert typeof(arr).name == '[]int'
+	assert '${arr}' == '[1, 2, 3, 4]'
+}


### PR DESCRIPTION
This PR fix fixed array literal range index (fix #16807).

- Fix fixed array literal range index.
- Add test.

```v
fn main() {
	arr := [1, 2, 3, 4]![..]
	println(arr)
	println(typeof(arr).name)
	assert typeof(arr).name == '[]int'
	assert '${arr}' == '[1, 2, 3, 4]'
}

PS D:\Test\v\tt1> v run .
[1, 2, 3, 4]
[]int
```