### PR TITLE
cgen: fix struct optional field zero init (fix #16623)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -314,6 +314,10 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 		}
 
 		g.expr(field.default_expr)
+	} else if field.typ.has_flag(.optional) {
+		tmp_var := g.new_tmp_var()
+		g.expr_with_tmp_var(ast.None{}, ast.none_type, field.typ, tmp_var)
+		return true
 	} else {
 		g.write(g.type_default(field.typ))
 	}

--- a/vlib/v/gen/c/testdata/comptime_optional_call.out
+++ b/vlib/v/gen/c/testdata/comptime_optional_call.out
@@ -1,7 +1,7 @@
 0
 0
-Option(0)
-Option(0)
+Option(error: none)
+Option(error: none)
 Option(error: none)
 Option(error: none)
 1

--- a/vlib/v/tests/struct_optional_field_zero_test.v
+++ b/vlib/v/tests/struct_optional_field_zero_test.v
@@ -1,0 +1,21 @@
+struct Foo {
+	foo ?string
+}
+
+fn test_struct_optional_field_zero() {
+	a := Foo{}
+	if foo := a.foo {
+		println(foo)
+		assert false
+	} else {
+		assert true
+	}
+
+	b := Foo{'hello'}
+	if foo := b.foo {
+		println(foo)
+		assert true
+	} else {
+		assert false
+	}
+}

--- a/vlib/x/json2/encode_struct_test.v
+++ b/vlib/x/json2/encode_struct_test.v
@@ -60,21 +60,21 @@ fn test_types() {
 
 fn test_optional_types() {
 	assert json.encode(StructTypeOptional[string]{ val: none }) == '{}'
-	assert json.encode(StructTypeOptional[string]{}) == '{"val":""}'
+	assert json.encode(StructTypeOptional[string]{}) == '{}'
 	assert json.encode(StructTypeOptional[string]{ val: '' }) == '{"val":""}'
 	assert json.encode(StructTypeOptional[string]{ val: 'a' }) == '{"val":"a"}'
 
 	assert json.encode(StructTypeOptional[bool]{ val: none }) == '{}'
-	assert json.encode(StructTypeOptional[bool]{}) == '{"val":false}'
+	assert json.encode(StructTypeOptional[bool]{}) == '{}'
 	assert json.encode(StructTypeOptional[bool]{ val: false }) == '{"val":false}'
 	assert json.encode(StructTypeOptional[bool]{ val: true }) == '{"val":true}'
 
 	assert json.encode(StructTypeOptional[int]{ val: none }) == '{}'
-	assert json.encode(StructTypeOptional[int]{}) == '{"val":0}'
+	assert json.encode(StructTypeOptional[int]{}) == '{}'
 	assert json.encode(StructTypeOptional[int]{ val: 0 }) == '{"val":0}'
 	assert json.encode(StructTypeOptional[int]{ val: 1 }) == '{"val":1}'
 
-	assert json.encode(StructTypeOptional[time.Time]{}) == '{"val":"0000-00-00T00:00:00.000Z"}'
+	assert json.encode(StructTypeOptional[time.Time]{}) == '{}'
 	assert json.encode(StructTypeOptional[time.Time]{ val: fixed_time }) == '{"val":"2022-03-11T13:54:25.000Z"}'
 }
 
@@ -123,7 +123,7 @@ fn test_array() {
 
 fn test_optional_array() {
 	assert json.encode(StructTypeOptional[[]int]{ val: none }) == '{}'
-	assert json.encode(StructTypeOptional[[]int]{}) == '{"val":[]}'
+	assert json.encode(StructTypeOptional[[]int]{}) == '{}'
 	assert json.encode(StructTypeOptional[[]int]{ val: [] }) == '{"val":[]}'
 	assert json.encode(StructTypeOptional[[]int]{ val: [0] }) == '{"val":[0]}'
 	assert json.encode(StructTypeOptional[[]int]{ val: [1] }) == '{"val":[1]}'


### PR DESCRIPTION
This PR fix struct optional field zero init (fix #16623).

- Fix struct optional field zero init.
- Add test.

```v
struct Foo {
	foo ?string
}

fn main() {
	a := Foo{}
	if foo := a.foo {
		println(foo)
		assert false
	} else {
		assert true
	}

	b := Foo{'hello'}
	if foo := b.foo {
		println(foo)
		assert true
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
hello
```