### PR TITLE
bcrypt: fix issue #16769 security problem in compare_hash_and_password

### DIFF
--- a/vlib/crypto/bcrypt/bcrypt.v
+++ b/vlib/crypto/bcrypt/bcrypt.v
@@ -125,14 +125,16 @@ fn bcrypt(password []u8, cost int, salt []u8) ?[]u8 {
 // expensive_blowfish_setup generate a Blowfish cipher, given key, cost and salt.
 fn expensive_blowfish_setup(key []u8, cost u32, salt []u8) ?&blowfish.Blowfish {
 	csalt := base64.decode(salt.bytestr())
+	mut ckey := key.clone()
+	ckey.push(0)
 
-	mut bf := blowfish.new_salted_cipher(key, csalt) or { return err }
+	mut bf := blowfish.new_salted_cipher(ckey, csalt) or { return err }
 
 	mut i := u64(0)
 	mut rounds := u64(0)
 	rounds = 1 << cost
 	for i = 0; i < rounds; i++ {
-		blowfish.expand_key(key, mut bf)
+		blowfish.expand_key(ckey, mut bf)
 		blowfish.expand_key(csalt, mut bf)
 	}
 

--- a/vlib/crypto/bcrypt/bcrypt.v
+++ b/vlib/crypto/bcrypt/bcrypt.v
@@ -125,8 +125,10 @@ fn bcrypt(password []u8, cost int, salt []u8) ?[]u8 {
 // expensive_blowfish_setup generate a Blowfish cipher, given key, cost and salt.
 fn expensive_blowfish_setup(key []u8, cost u32, salt []u8) ?&blowfish.Blowfish {
 	csalt := base64.decode(salt.bytestr())
+	// Bug compatibility with C bcrypt implementations, which use the trailing NULL in the key string during expansion.
+	// See https://cs.opensource.google/go/x/crypto/+/master:bcrypt/bcrypt.go;l=226
 	mut ckey := key.clone()
-	ckey.push(0)
+	ckey << 0
 
 	mut bf := blowfish.new_salted_cipher(ckey, csalt) or { return err }
 

--- a/vlib/crypto/bcrypt/bcrypt_test.v
+++ b/vlib/crypto/bcrypt/bcrypt_test.v
@@ -8,4 +8,14 @@ fn test_crypto_bcrypt() {
 	bcrypt.compare_hash_and_password('password2'.bytes(), hash.bytes()) or {
 		assert err.msg() == 'mismatched hash and password'
 	}
+
+	hash2 := bcrypt.generate_from_password('bb'.bytes(), 10) or { panic(err) }
+	mut hash2_must_mismatch := false
+
+	bcrypt.compare_hash_and_password('bbb'.bytes(), hash2.bytes()) or {
+		hash2_must_mismatch = true
+		assert err.msg() == 'mismatched hash and password'
+	}
+
+	assert hash2_must_mismatch
 }


### PR DESCRIPTION
Fix issue #16769 security problem in compare_hash_and_password

The function compare_hash_and_password gaves ok for password with same chars "bb" or "bbb" or "bbbbb".

The solution is based on https://cs.opensource.google/go/x/crypto/+/master:bcrypt/bcrypt.go;l=226 that copy the key and add a NULL char at the end of the key

Tests are added in  file vlib/crypto/bcrypt/bcrypt_test.v

PS: I'm new Vlang maybe there is a better way to clone and append NULL char to an array.