### PR TITLE
table: fix inferring generic struct (fix #16830)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1975,6 +1975,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				cname: util.no_dots(c_nrt)
 				mod: ts.mod
 				info: info
+				is_pub: ts.is_pub
 			)
 			for typ_ in needs_unwrap_types {
 				t.unwrap_generic_type(typ_, generic_names, concrete_types)
@@ -2010,6 +2011,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				cname: util.no_dots(c_nrt)
 				mod: ts.mod
 				info: info
+				is_pub: ts.is_pub
 			)
 			for typ_ in needs_unwrap_types {
 				t.unwrap_generic_type(typ_, generic_names, concrete_types)
@@ -2053,6 +2055,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 				cname: util.no_dots(c_nrt)
 				mod: ts.mod
 				info: info
+				is_pub: ts.is_pub
 			)
 			mut ts_copy := t.sym(new_idx)
 			for method in all_methods {

--- a/vlib/v/tests/generics_from_modules/infer_generic_struct_test.v
+++ b/vlib/v/tests/generics_from_modules/infer_generic_struct_test.v
@@ -1,0 +1,9 @@
+import v.tests.generics_from_modules.newmodule as nm
+
+fn test_infer_generic_struct() {
+    a_in := [int(1), 2, 4]
+    res := nm.take_input(a: a_in, b: 3, c: int(5))
+
+    println(res)
+	 assert res == [f32(1.0), 2.0, 4.0, 3.0, 5.0]
+}

--- a/vlib/v/tests/generics_from_modules/infer_generic_struct_test.v
+++ b/vlib/v/tests/generics_from_modules/infer_generic_struct_test.v
@@ -1,9 +1,9 @@
 import v.tests.generics_from_modules.newmodule as nm
 
 fn test_infer_generic_struct() {
-    a_in := [int(1), 2, 4]
-    res := nm.take_input(a: a_in, b: 3, c: int(5))
+	a_in := [int(1), 2, 4]
+	res := nm.take_input(a: a_in, b: 3, c: int(5))
 
-    println(res)
-	 assert res == [f32(1.0), 2.0, 4.0, 3.0, 5.0]
+	println(res)
+	assert res == [f32(1.0), 2.0, 4.0, 3.0, 5.0]
 }

--- a/vlib/v/tests/generics_from_modules/newmodule/newmodule.v
+++ b/vlib/v/tests/generics_from_modules/newmodule/newmodule.v
@@ -1,0 +1,18 @@
+module newmodule
+
+pub struct Params[T] {
+mut:
+	a []T
+	b int
+	c T
+}
+
+pub fn take_input[T](p Params[T]) []f32 {
+	mut res := []f32{}
+	for x in p.a {
+		res << f32(x)
+	}
+	res << f32(p.b)
+	res << f32(p.c)
+	return res
+}


### PR DESCRIPTION
This PR fix inferring generic struct (fix #16830).

- Fix inferring generic struct.
- Add test.

```v
import newmodule as nm

fn main() {
    a_in := [int(1), 2, 4]
    res := nm.take_input(a: a_in, b: 3, c: int(5))

    // res := nm.take_input(nm.Params[int]{a: a_in, b: 3, c: int(5)})  // this works
    println(res)
}

PS D:\Test\v\tt1> v run .
[1.0, 2.0, 4.0, 3.0, 5.0]
```
```v
module newmodule

pub struct Params[T] {
mut:
	a []T
	b int
	c T
}

pub fn take_input[T](p Params[T]) []f32 {
	mut res := []f32{}
	for x in p.a {
		res << f32(x)
	}
	res << f32(p.b)
	res << f32(p.c)
	return res
}
```