### PR TITLE
parser: fix array of functions direct call (fix #16835, fix #16578)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2272,6 +2272,11 @@ fn (p &Parser) is_generic_call() bool {
 					if nested_sbr_count > 0 {
 						nested_sbr_count--
 					} else {
+						prev_tok := p.peek_token(i - 1)
+						// `funcs[i]()` is not generic call
+						if !(p.is_typename(prev_tok) || prev_tok.kind == .rsbr) {
+							return false
+						}
 						if p.peek_token(i + 1).kind == .lpar {
 							return true
 						}

--- a/vlib/v/tests/array_of_functions_direct_call_test.v
+++ b/vlib/v/tests/array_of_functions_direct_call_test.v
@@ -1,0 +1,20 @@
+fn foo() string {
+	println('foo')
+	return 'foo'
+}
+
+fn bar() string {
+	println('bar')
+	return 'bar'
+}
+
+fn call() {
+	funcs := [foo, bar]
+	i := 1
+	ret := funcs[i]()
+	assert ret == 'bar'
+}
+
+fn test_array_of_functions_direct_call() {
+	call()
+}


### PR DESCRIPTION
This PR fix array of functions direct call (fix #16835, fix #16578).

- Fix array of functions direct call.
- Add test.

```v
fn foo() string {
	println('foo')
	return 'foo'
}

fn bar() string {
	println('bar')
	return 'bar'
}

fn call() {
	funcs := [foo, bar]
	i := 1
	ret := funcs[i]()
	assert ret == 'bar'
}

fn main() {
	call()
}

PS D:\Test\v\tt1> v run .
bar
```
```v
type Sfn = fn() string
const greeting = 'hallo gday aloha'.split(' ')

fn main() {
	mut greet := []Sfn{ len: 3, init: fn [it] ()string { return greeting[it] } }

	println( greet[1]() )

	for g in greet {
		println( g() )
	}

	println('')

	// compiler error unknown function greet
	tmp := 1
	println( greet[tmp]() ) 

	for ind in 0..greet.len { 
		println( greet[ind]() )
	}
}

PS D:\Test\v\tt1> v run .
gday
hallo
gday
aloha

gday
hallo
gday
aloha
```