### PR TITLE
README: add back align=center to make github happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div style="display:grid;place-items:center;">
+<div align="center" style="display:grid;place-items:center;">
 <p>
     <a href="https://vlang.io/" target="_blank"><img width="80" src="https://raw.githubusercontent.com/vlang/v-logo/master/dist/v-logo.svg?sanitize=true" alt="V logo"></a>
 </p>
@@ -6,7 +6,7 @@
 
 [vlang.io](https://vlang.io) | [Docs](https://github.com/vlang/v/blob/master/doc/docs.md) | [Changelog](https://github.com/vlang/v/blob/master/CHANGELOG.md) | [Speed](https://fast.vlang.io/) | [Contributing & compiler design](https://github.com/vlang/v/blob/master/CONTRIBUTING.md)
 </div>
-<div style="display:grid;place-items:center;">
+<div align="center" style="display:grid;place-items:center;">
 <!--
 [![Build Status][WorkflowBadge]][WorkflowUrl]
 -->


### PR DESCRIPTION
GitHub "sanitizes" readme files by removing all css styles.  This means that even though `align="center"` is deprecated, it's the only thing that works on GitHub.

However, it doesn't hurt to have that along with the newer way of doing things, so adding it back.  When browsers stop supporting `align="center"`, they'll have to fix it, but until then, at least it'll look "pretty" on GitHub.