### PR TITLE
cgen: fix comptime if expr with optional or result call (fix #16837)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -278,6 +278,8 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 	line := if node.is_expr {
 		stmt_str := g.go_before_stmt(0)
 		g.write(util.tabs(g.indent))
+		styp := g.typ(node.typ)
+		g.writeln('${styp} ${tmp_var};')
 		stmt_str.trim_space()
 	} else {
 		''
@@ -320,21 +322,27 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 			len := branch.stmts.len
 			if len > 0 {
 				last := branch.stmts.last() as ast.ExprStmt
-				styp := g.typ(node.typ)
 				if len > 1 {
 					g.indent++
-					g.writeln('${styp} ${tmp_var};')
 					g.writeln('{')
 					g.stmts(branch.stmts[..len - 1])
+					g.set_current_pos_as_last_stmt_pos()
+					prev_skip_stmt_pos := g.skip_stmt_pos
+					g.skip_stmt_pos = true
 					g.write('\t${tmp_var} = ')
 					g.stmt(last)
+					g.skip_stmt_pos = prev_skip_stmt_pos
 					g.writeln(';')
 					g.writeln('}')
 					g.indent--
 				} else {
 					g.indent++
-					g.write('${styp} ${tmp_var} = ')
+					g.set_current_pos_as_last_stmt_pos()
+					prev_skip_stmt_pos := g.skip_stmt_pos
+					g.skip_stmt_pos = true
+					g.write('${tmp_var} = ')
 					g.stmt(last)
+					g.skip_stmt_pos = prev_skip_stmt_pos
 					g.writeln(';')
 					g.indent--
 				}

--- a/vlib/v/tests/comptime_if_expr_with_result_call_test.v
+++ b/vlib/v/tests/comptime_if_expr_with_result_call_test.v
@@ -1,0 +1,11 @@
+import os
+
+fn test_comptime_if_expr_with_result_call() {
+	config_dir := $if windows {
+		os.home_dir()
+	} $else {
+		os.config_dir() or { os.home_dir() }
+	}
+	println(config_dir)
+	assert true
+}


### PR DESCRIPTION
This PR fix comptime if expr with optional or result call (fix #16837).

- Fix comptime if expr with optional or result call.
- Add test.

```v
import os

fn main() {
	config_dir := $if !windows {
		os.home_dir()
	} $else {
		os.config_dir() or { os.home_dir() }
	}
	println(config_dir)
}

PS D:\Test\v\tt1> v run .
C:\Users\yuyi9\AppData\Roaming
```