### PR TITLE
cgen: fix code generated for optional comptime var

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4243,6 +4243,22 @@ fn (mut g Gen) ident(node ast.Ident) {
 	}
 	mut is_auto_heap := false
 	if node.info is ast.IdentVar {
+		if node.obj is ast.Var {
+			if !g.is_assign_lhs && node.obj.is_comptime_field {
+				if g.comptime_for_field_type.has_flag(.optional) {
+					if g.inside_opt_or_res {
+						g.write('${name}')
+					} else {
+						g.write('/*opt*/')
+						styp := g.base_type(g.comptime_for_field_type)
+						g.write('(*(${styp}*)${name}.data)')
+					}
+				} else {
+					g.write('${name}')
+				}
+				return
+			}
+		}
 		// x ?int
 		// `x = 10` => `x.data = 10` (g.right_is_opt == false)
 		// `x = new_opt()` => `x = new_opt()` (g.right_is_opt == true)
@@ -4262,20 +4278,6 @@ fn (mut g Gen) ident(node ast.Ident) {
 			return
 		}
 		if node.obj is ast.Var {
-			if !g.is_assign_lhs && node.obj.is_comptime_field {
-				if g.comptime_for_field_type.has_flag(.optional) {
-					if g.inside_opt_or_res {
-						g.write('${name}')
-					} else {
-						g.write('/*opt*/')
-						styp := g.base_type(node.info.typ)
-						g.write('(*(${styp}*)${name}.data)')
-					}
-				} else {
-					g.write('${name}')
-				}
-				return
-			}
 			is_auto_heap = node.obj.is_auto_heap
 				&& (!g.is_assign_lhs || g.assign_op != .decl_assign)
 			if is_auto_heap {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4262,6 +4262,20 @@ fn (mut g Gen) ident(node ast.Ident) {
 			return
 		}
 		if node.obj is ast.Var {
+			if !g.is_assign_lhs && node.obj.is_comptime_field {
+				if g.comptime_for_field_type.has_flag(.optional) {
+					if g.inside_opt_or_res {
+						g.write('${name}')
+					} else {
+						g.write('/*opt*/')
+						styp := g.base_type(node.info.typ)
+						g.write('(*(${styp}*)${name}.data)')
+					}
+				} else {
+					g.write('${name}')
+				}
+				return
+			}
 			is_auto_heap = node.obj.is_auto_heap
 				&& (!g.is_assign_lhs || g.assign_op != .decl_assign)
 			if is_auto_heap {

--- a/vlib/v/tests/optional_compvar_types_test.v
+++ b/vlib/v/tests/optional_compvar_types_test.v
@@ -1,0 +1,34 @@
+struct FixedStruct1 {
+	a int
+	b string
+}
+
+struct FixedStruct2 {
+	c ?int
+	d ?string
+}
+
+struct Writer {}
+
+fn write1[T](val T) {
+	println(val)
+}
+
+fn (wr &Writer) write2[T](val T) {
+	println(val)
+}
+
+fn encode_struct[T](val T) bool {
+	wr := Writer{}
+	$for field in T.fields {
+		value := val.$(field.name)
+		write1(value)
+		wr.write2(value)
+	}
+	return true
+}
+
+fn test_main() {
+	assert encode_struct(FixedStruct1{}) == true
+	assert encode_struct(FixedStruct2{}) == true
+}

--- a/vlib/v/tests/optional_compvar_val_test.v
+++ b/vlib/v/tests/optional_compvar_val_test.v
@@ -1,0 +1,60 @@
+struct FixedStruct1 {
+	a int
+	b ?int
+	c ?int = 4
+}
+
+// struct FixedStruct2 {
+//     b ?int
+// }
+
+struct Encoder {}
+
+struct Writer {}
+
+fn write1[T](val T) {
+	println(val)
+}
+
+fn (wr &Writer) write2[T](val T) {
+	println(val)
+}
+
+fn encode_struct[T](val T) map[string][]string {
+	wr := Writer{}
+	mut out := map[string][]string{}
+	$if T is $Struct {
+		$for field in T.fields {
+			value := val.$(field.name)
+			$if field.typ is ?int {
+				// work if comment lines 27 and 28
+				write1(value)
+				wr.write2(value)
+				out[field.name] << '${value}'
+			} $else {
+				write1(value)
+				wr.write2(value)
+				out[field.name] << value.str()
+			}
+			// This work well
+			$if field.is_optional {
+				write1(value)
+				wr.write2(value)
+				out[field.name] << '${value}'
+			} $else {
+				write1(value)
+				wr.write2(value)
+				out[field.name] << value.str()
+			}
+		}
+	}
+	return out
+}
+
+fn main_test() {
+	// cgen error: cannot convert 'struct _option_int' to 'int'
+	out := encode_struct(FixedStruct1{})
+	assert out['a'] == ['0', '0']
+	assert out['b'] == ['0', '0']
+	assert out['c'] == ['4', '4']
+}

--- a/vlib/v/tests/optional_compvar_val_test.v
+++ b/vlib/v/tests/optional_compvar_val_test.v
@@ -51,7 +51,7 @@ fn encode_struct[T](val T) map[string][]string {
 	return out
 }
 
-fn main_test() {
+fn test_main() {
 	// cgen error: cannot convert 'struct _option_int' to 'int'
 	out := encode_struct(FixedStruct1{})
 	assert out['a'] == ['0', '0']


### PR DESCRIPTION
Fix #16848
Fix #16849

```V
struct FixedStruct1 {
	a int
	b string
}

struct FixedStruct2 {
	c ?int
	d ?string
}

fn encode_struct[T](val T) bool {
	wr := Writer{}
	$for field in T.fields {
		value := val.$(field.name)
		write1(value) // it was broken
		wr.write2(value) // it was broken
	}
	return true
}
```