### PR TITLE
checker: fix generic stack of sumtype push() (fix #16834)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -458,7 +458,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					return ast.void_type
 				} else if left_value_sym.kind == .sum_type {
 					if right_sym.kind != .array {
-						if !c.table.is_sumtype_or_in_variant(left_value_type, ast.mktyp(right_type)) {
+						if !c.table.is_sumtype_or_in_variant(left_value_type, ast.mktyp(c.unwrap_generic(right_type))) {
 							c.error('cannot append `${right_sym.name}` to `${left_sym.name}`',
 								right_pos)
 						}

--- a/vlib/v/checker/tests/check_err_msg_with_generics.out
+++ b/vlib/v/checker/tests/check_err_msg_with_generics.out
@@ -4,24 +4,3 @@ vlib/v/checker/tests/check_err_msg_with_generics.vv:15:10: error: cannot cast st
    15 |     println(int(typ))
       |             ~~~~~~~~
    16 | }
-vlib/datatypes/bstree.v:196:17: error: cannot append `T` to `[]T`
-  194 |     }
-  195 |     bst.in_order_traversal_helper(node.left, mut result)
-  196 |     result << node.value
-      |                    ~~~~~
-  197 |     bst.in_order_traversal_helper(node.right, mut result)
-  198 | }
-vlib/datatypes/bstree.v:216:17: error: cannot append `T` to `[]T`
-  214 |     bst.post_order_traversal_helper(node.left, mut result)
-  215 |     bst.post_order_traversal_helper(node.right, mut result)
-  216 |     result << node.value
-      |                    ~~~~~
-  217 | }
-  218 |
-vlib/datatypes/bstree.v:232:17: error: cannot append `T` to `[]T`
-  230 |         return
-  231 |     }
-  232 |     result << node.value
-      |                    ~~~~~
-  233 |     bst.pre_order_traversal_helper(node.left, mut result)
-  234 |     bst.pre_order_traversal_helper(node.right, mut result)

--- a/vlib/v/tests/generics_stack_of_sumtype_push_test.v
+++ b/vlib/v/tests/generics_stack_of_sumtype_push_test.v
@@ -1,0 +1,21 @@
+import datatypes
+
+type Content = bool | string
+
+struct DataStack {
+mut:
+	data datatypes.Stack[Content]
+}
+
+fn (mut dstack DataStack) push(content Content) {
+	dstack.data.push(content)
+}
+
+fn test_generic_stack_of_sumtype_push() {
+	mut dstack := DataStack{}
+	dstack.push('hello')
+
+	println(dstack)
+	assert dstack.data.len() == 1
+	assert dstack.data.array() == [Content('hello')]
+}


### PR DESCRIPTION
This PR fix generic stack of sumtype push() (fix #16834).

- Fix generic stack of sumtype push().
- Add test.

```v
import datatypes

type Content = bool | string

struct DataStack {
mut:
	data datatypes.Stack[Content]
}

fn (mut dstack DataStack) push(content Content) {
	dstack.data.push(content)
}

fn main() {
	mut dstack := DataStack{}
	dstack.push('hello')

	println(dstack)
	assert dstack.data.len() == 1
	assert dstack.data.array() == [Content('hello')]
}

PS D:\Test\v\tt1> v run .
DataStack{
    data: [Content('hello')]
}
```