### PR TITLE
cgen: fix json encode struct with optional field (fix #16462)

### DIFF
--- a/vlib/json/json_encode_struct_with_optional_field_test.v
+++ b/vlib/json/json_encode_struct_with_optional_field_test.v
@@ -1,0 +1,20 @@
+import json
+
+struct Foo {
+	name string
+	num  ?int
+}
+
+fn test_json_encode_struct_with_optional_field() {
+	f1 := Foo{
+		name: 'hello'
+	}
+	ret1 := json.encode(f1)
+	println(ret1)
+	assert ret1 == '{"name":"hello","num":null}'
+
+	f2 := Foo{'hello', 22}
+	ret2 := json.encode(f2)
+	println(ret2)
+	assert ret2 == '{"name":"hello","num":22}'
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1061,7 +1061,11 @@ fn (mut g Gen) optional_type_name(t ast.Type) (string, string) {
 }
 
 fn (mut g Gen) result_type_name(t ast.Type) (string, string) {
-	base := g.base_type(t)
+	mut base := g.base_type(t)
+	if t.has_flag(.optional) {
+		g.register_optional(t)
+		base = '_option_' + base
+	}
 	mut styp := ''
 	sym := g.table.sym(t)
 	if sym.language == .c && sym.kind == .struct_ {


### PR DESCRIPTION
This PR fix json encode struct with optional field (fix #16462).

- Fix json encode struct with optional field.
- Add test.

```v
import json

struct Foo {
	name string
	num  ?int
}

fn main() {
	f1 := Foo{
		name: 'hello'
	}
	ret1 := json.encode(f1)
	println(ret1)
	assert ret1 == '{"name":"hello","num":null}'

	f2 := Foo{'hello', 22}
	ret2 := json.encode(f2)
	println(ret2)
	assert ret2 == '{"name":"hello","num":22}'
}

PS D:\Test\v\tt1> v run .
{"name":"hello","num":null}
{"name":"hello","num":22}
```