### PR TITLE
builder: show a hint about `v .`, on unknown errors, suggesting that the user tried to compile a single .v file from a multi file project

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -432,6 +432,18 @@ pub fn (b &Builder) show_total_warns_and_errors_stats() {
 			println('checker summary: ${estring} V errors, ${wstring} V warnings, ${nstring} V notices')
 		}
 	}
+	if b.checker.nr_errors > 0 && b.pref.path.ends_with('.v') && os.is_file(b.pref.path) {
+		for err in b.checker.errors {
+			if err.message.starts_with('unknown ') {
+				// Sometimes users try to `v main.v`, when they have several .v files in their project.
+				// Then, they encounter puzzling errors about missing or unknown types. In this case,
+				// the intended command may have been `v .` instead, so just suggest that:
+				old_cmd := util.bold('v ${b.pref.path}')
+				new_cmd := util.bold('v ${os.dir(b.pref.path)}')
+				eprintln(util.color('notice', 'If the code of your project is in multiple files, try with `${new_cmd}` instead of `${old_cmd}`'))
+			}
+		}
+	}
 }
 
 pub fn (mut b Builder) print_warnings_and_errors() {

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -57,7 +57,7 @@ pub fn bold(msg string) string {
 	return term.bold(msg)
 }
 
-fn color(kind string, msg string) string {
+pub fn color(kind string, msg string) string {
 	if !util.emanager.support_color {
 		return msg
 	}


### PR DESCRIPTION
V will try to detect that situation now, and show a hint like this:
```
If the code of your project is in multiple files, try with `v project` instead of `v project/main.v`
```