### PR TITLE
checker: allow method call from option

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1328,10 +1328,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	} else {
 		'unknown method or field: `${left_sym.name}.${method_name}`'
 	}
-	if left_type.has_flag(.optional) {
-		c.error('optional type cannot be called directly', node.left.pos())
-		return ast.void_type
-	} else if left_type.has_flag(.result) {
+	if left_type.has_flag(.result) {
 		c.error('result type cannot be called directly', node.left.pos())
 		return ast.void_type
 	}


### PR DESCRIPTION
Fix #16885

```V
struct FixedStruct1 {
    c ?int
    d ?string
	e ?[]int
	f ?f64
	g ?[]string
	h ?[]f64
}

fn encode_struct[T](val T) map[string]string {
	mut out := map[string]string
	$for field in T.fields {
		value := val.$(field.name)
		$if field.is_optional {
			out[field.name] = value.str()
		}
	}
	return out
}

fn test_optional_none() {
    out := encode_struct(FixedStruct1{
		c: none,
		d: none,
		e: none,
		f: none,
		g: none,
		h: none,
	}) 
	assert out['c'] == 'Option(error: none)'
	assert out['d'] == 'Option(error: none)'
	assert out['e'] == 'Option(error: none)'
	assert out['f'] == 'Option(error: none)'
	assert out['g'] == 'Option(error: none)'
	assert out['h'] == 'Option(error: none)'
}

fn test_optional_filled() {
    out := encode_struct(FixedStruct1{
		c: 1,
		d: 'vlang',
		e: [1,2],
		f: 1.5,
		g: ['v', 'lang'],
		h: [2.0],
	}) 
	assert out['c'] == 'Option(1)'
	assert out['d'] == "Option('vlang')"
	assert out['e'] == 'Option([1, 2])'
	assert out['f'] == 'Option(1.5)'
	assert out['g'] == "Option(['v', 'lang'])"
	assert out['h'] == "Option([2.0])"
}
```