### PR TITLE
cgen: fix array_init generated code for reference var

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -25,6 +25,9 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 	len := node.exprs.len
 	if array_type.unaliased_sym.kind == .array_fixed {
 		g.fixed_array_init(node, array_type, var_name)
+		if is_amp {
+			g.write(')')
+		}
 	} else if len == 0 {
 		// `[]int{len: 6, cap:10, init:22}`
 		g.array_init_with_fields(node, elem_type, is_amp, shared_styp, var_name)
@@ -60,11 +63,11 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 			}
 		}
 		g.write('}))')
-	}
-	if g.is_shared {
-		g.write('}, sizeof(${shared_styp}))')
-	} else if is_amp {
-		g.write(')')
+		if g.is_shared {
+			g.write('}, sizeof(${shared_styp}))')
+		} else if is_amp {
+			g.write(')')
+		}
 	}
 }
 

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -60,11 +60,11 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 			}
 		}
 		g.write('}))')
-		if g.is_shared {
-			g.write('}, sizeof(${shared_styp}))')
-		} else if is_amp {
-			g.write(')')
-		}
+	}
+	if g.is_shared {
+		g.write('}, sizeof(${shared_styp}))')
+	} else if is_amp {
+		g.write(')')
 	}
 }
 

--- a/vlib/v/tests/assert_with_array_ref_test.v
+++ b/vlib/v/tests/assert_with_array_ref_test.v
@@ -1,0 +1,10 @@
+fn test_main() {
+	myu16 := u16(50)
+	size_of_u16 := sizeof(u16)
+
+	mut asu8 := unsafe { &u8(malloc(size_of_u16)) }
+
+	asu8 = &[myu16]! // look this
+
+	assert unsafe { asu8.vbytes(int(size_of_u16)) } == [u8(50), 0]
+}


### PR DESCRIPTION
Fix #16891

Cgen generates wrong code for:

```V
fn test_main() {
	myu16 := u16(50)
	size_of_u16 := sizeof(u16)

	mut asu8 := unsafe { &u8(malloc(size_of_u16)) }

	asu8 = &[myu16]! // look this

	assert unsafe { asu8.vbytes(int(size_of_u16)) } == [u8(50), 0]
}
```

It does generates `HEAP(Array_fixed_u16_1, {myu16};` missing the final `)` char.