### PR TITLE
checker, cgen: fix aliased optional or result fn call (fix #16409)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -12,6 +12,12 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 	}
 	c.expected_type = c.table.cur_fn.return_type
 	mut expected_type := c.unwrap_generic(c.expected_type)
+	if expected_type != 0 && c.table.sym(expected_type).kind == .alias {
+		unaliased_type := c.table.unaliased_type(expected_type)
+		if unaliased_type.has_flag(.optional) || unaliased_type.has_flag(.result) {
+			expected_type = unaliased_type
+		}
+	}
 	expected_type_sym := c.table.sym(expected_type)
 	if node.exprs.len > 0 && c.table.cur_fn.return_type == ast.void_type {
 		c.error('unexpected argument, current function does not return anything', node.exprs[0].pos())

--- a/vlib/v/checker/tests/aliased_optional_fn_call_err.out
+++ b/vlib/v/checker/tests/aliased_optional_fn_call_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/aliased_optional_fn_call_err.vv:8:10: error: foo() returns an option, so it should have either an `or {}` block, or `?` at the end
+    6 |
+    7 | fn main(){
+    8 |     println(foo())
+      |             ~~~~~
+    9 | }

--- a/vlib/v/checker/tests/aliased_optional_fn_call_err.vv
+++ b/vlib/v/checker/tests/aliased_optional_fn_call_err.vv
@@ -1,0 +1,9 @@
+type OptStr = ?string
+
+fn foo() OptStr{
+	return 'abc'
+}
+
+fn main(){
+	println(foo())
+}

--- a/vlib/v/tests/aliased_optional_fn_call_test.v
+++ b/vlib/v/tests/aliased_optional_fn_call_test.v
@@ -1,0 +1,11 @@
+type OptStr = ?string
+
+fn foo() OptStr {
+	return 'abc'
+}
+
+fn test_aliased_optional_fn_call() {
+	ret := foo()?
+	println(ret)
+	assert ret == 'abc'
+}


### PR DESCRIPTION
This PR fix aliased optional or result fn call (fix #16409).

- Fix aliased optional or result fn call.
- Add test.

```v
type OptStr = ?string

fn foo() OptStr {
	return 'abc'
}

fn main() {
	ret := foo()?
	println(ret)
	assert ret == 'abc'
}

PS D:\Test\v\tt1> v run .
abc
```

```v
type OptStr = ?string

fn foo() OptStr{
	return 'abc'
}

fn main(){
	println(foo())
}

PS D:\Test\v\tt1> v run .
tt1.v:8:10: error: foo() returns an option, so it should have either an `or {}` block, or `?` at the end
    6 |
    7 | fn main(){
    8 |     println(foo())
      |             ~~~~~
    9 | }
```