### PR TITLE
cgen: fix result or option of multi return (fix #16873)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -521,7 +521,6 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Type) {
 	// multi return
 	// TODO Handle in if_expr
-	is_opt := return_type.has_flag(.option) || return_type.has_flag(.result)
 	mr_var_name := 'mr_${node.pos.pos}'
 	mr_styp := g.typ(return_type.clear_flag(.option).clear_flag(.result))
 	g.write('${mr_styp} ${mr_var_name} = ')
@@ -551,34 +550,16 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 		g.expr(lx)
 		noscan := if is_auto_heap { g.check_noscan(return_type) } else { '' }
 		if g.is_arraymap_set {
-			if is_opt {
-				mr_base_styp := g.base_type(return_type)
-				if is_auto_heap {
-					g.writeln('HEAP${noscan}(${mr_base_styp}, ${mr_var_name}.arg${i}) });')
-				} else {
-					g.writeln('${mr_var_name}.arg${i} });')
-				}
+			if is_auto_heap {
+				g.writeln('HEAP${noscan}(${styp}, ${mr_var_name}.arg${i}) });')
 			} else {
-				if is_auto_heap {
-					g.writeln('HEAP${noscan}(${styp}, ${mr_var_name}.arg${i}) });')
-				} else {
-					g.writeln('${mr_var_name}.arg${i} });')
-				}
+				g.writeln('${mr_var_name}.arg${i} });')
 			}
 		} else {
-			if is_opt {
-				mr_base_styp := g.base_type(return_type)
-				if is_auto_heap {
-					g.writeln(' = HEAP${noscan}(${mr_base_styp}, ${mr_var_name}.arg${i});')
-				} else {
-					g.writeln(' = ${mr_var_name}.arg${i};')
-				}
+			if is_auto_heap {
+				g.writeln(' = HEAP${noscan}(${styp}, ${mr_var_name}.arg${i});')
 			} else {
-				if is_auto_heap {
-					g.writeln(' = HEAP${noscan}(${styp}, ${mr_var_name}.arg${i});')
-				} else {
-					g.writeln(' = ${mr_var_name}.arg${i};')
-				}
+				g.writeln(' = ${mr_var_name}.arg${i};')
 			}
 		}
 	}

--- a/vlib/v/tests/multiret_with_result_test.v
+++ b/vlib/v/tests/multiret_with_result_test.v
@@ -1,0 +1,13 @@
+import sqlite
+
+fn ret() !(int, sqlite.DB) {
+	db := sqlite.connect(':memory:')!
+
+	return 0, db
+}
+
+fn test_multiret_with_result() {
+	_, db := ret()!
+	println(db)
+	assert true
+}


### PR DESCRIPTION
This PR fix result or option of multi return (fix #16873).

- Fix result or option of multi return.
- Add test.

```v
import sqlite

fn ret() !(int, sqlite.DB) {
	db := sqlite.connect(':memory:')!

	return 0, db
}

fn main() {
	_, db := ret()!
	println(db)
	assert true
}

PS D:\Test\v\tt1> v run .
sqlite.DB{ conn: 16b14b8 }
```