### PR TITLE
cgen: fix json encoding struct with option field (fix #16868)

### DIFF
--- a/vlib/json/json_encode_struct_with_option_field_test.v
+++ b/vlib/json/json_encode_struct_with_option_field_test.v
@@ -1,4 +1,5 @@
 import json
+import x.json2
 
 struct Foo {
 	name string
@@ -11,10 +12,18 @@ fn test_json_encode_struct_with_option_field() {
 	}
 	ret1 := json.encode(f1)
 	println(ret1)
-	assert ret1 == '{"name":"hello","num":null}'
+	assert ret1 == '{"name":"hello"}'
+
+	ret2 := json2.encode(f1)
+	println(ret2)
+	assert ret2 == '{"name":"hello"}'
 
 	f2 := Foo{'hello', 22}
-	ret2 := json.encode(f2)
-	println(ret2)
-	assert ret2 == '{"name":"hello","num":22}'
+	ret3 := json.encode(f2)
+	println(ret3)
+	assert ret3 == '{"name":"hello","num":22}'
+
+	ret4 := json2.encode(f2)
+	println(ret4)
+	assert ret4 == '{"name":"hello","num":22}'
 }

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -170,7 +170,7 @@ ${enc_fn_dec} {
 
 fn (mut g Gen) gen_option_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec strings.Builder) {
 	enc.writeln('\tif (val.state == 2) {')
-	enc.writeln('\t\treturn cJSON_CreateNull();')
+	enc.writeln('\t\treturn NULL;')
 	enc.writeln('\t}')
 	type_str := g.typ(typ.clear_flag(.option))
 	encode_name := js_enc_name(type_str)


### PR DESCRIPTION
This PR fix json encoding struct with option field (fix #16868).

- Fix json encoding struct with option field.
- Add test.

```v
import json
import x.json2

struct Foo {
	name string
	num  ?int
}

fn main() {
	f1 := Foo{
		name: 'hello'
	}
	ret1 := json.encode(f1)
	println(ret1)
	assert ret1 == '{"name":"hello"}'

	ret2 := json2.encode(f1)
	println(ret2)
	assert ret2 == '{"name":"hello"}'

	f2 := Foo{'hello', 22}
	ret3 := json.encode(f2)
	println(ret3)
	assert ret3 == '{"name":"hello","num":22}'

	ret4 := json2.encode(f2)
	println(ret4)
	assert ret4 == '{"name":"hello","num":22}'
}

PS D:\Test\v\tt1> v run .
{"name":"hello"}
{"name":"hello"}
{"name":"hello","num":22}
{"name":"hello","num":22}
```