### PR TITLE
os: make os.FileMode public

### DIFF
--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -36,7 +36,7 @@ pub fn (p FilePermission) bitmask() u32 {
 	return mask
 }
 
-struct FileMode {
+pub struct FileMode {
 pub:
 	typ    FileType
 	owner  FilePermission


### PR DESCRIPTION
This PR makes `os.FileMode` public. This is necessary for the `pathlib` module I'm working on (#16782), because `Path.inode()` returns the result from `os.inode()`, which is `os.FileMode`.

I've ran the tests for tests for the os module, which still work. Let me know if I need to do anything else.

See discussion under the aforementioned PR: https://github.com/vlang/v/pull/16782#issuecomment-1375560314