### PR TITLE
json2: encode alias struct

### DIFF
--- a/vlib/x/json2/encode_struct_test.v
+++ b/vlib/x/json2/encode_struct_test.v
@@ -14,6 +14,7 @@ const fixed_time = time.Time{
 type StringAlias = string
 type BoolAlias = bool
 type IntAlias = int
+type StructAlias = StructType[int]
 
 type SumTypes = bool | int | string
 
@@ -197,4 +198,8 @@ fn test_alias() {
 	assert json.encode(StructType[IntAlias]{}) == '{"val":0}'
 	assert json.encode(StructType[IntAlias]{ val: 0 }) == '{"val":0}'
 	assert json.encode(StructType[IntAlias]{ val: 1 }) == '{"val":1}'
+
+	assert json.encode(StructType[StructAlias]{}) == '{"val":{"val":0}}'
+	assert json.encode(StructType[StructAlias]{ val: StructType[int]{0} }) == '{"val":{"val":0}}'
+	assert json.encode(StructType[StructAlias]{ val: StructType[int]{1} }) == '{"val":{"val":1}}'
 }

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -271,6 +271,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut wr io.Writer) ! {
 						// e.encode_array(value, level, mut wr)!
 					}
 					else {
+						e.encode_struct(value, level + 1, mut wr)!
 						// e.encode_value_with_level(value, level + 1, mut wr)!
 					}
 				}

--- a/vlib/x/json2/json_module_compatibility_test/json_test.v
+++ b/vlib/x/json2/json_module_compatibility_test/json_test.v
@@ -217,3 +217,22 @@ fn test_pretty() {
   "c": "aliens"
 }'
 }
+
+struct Aa {
+	sub AliasType
+}
+
+struct Bb {
+	a int
+}
+
+type AliasType = Bb
+
+fn test_encode_alias_field() {
+	s := json.encode(Aa{
+		sub: Bb{
+			a: 1
+		}
+	})
+	assert s == '{"sub":{"a":1}}'
+}

--- a/vlib/x/json2/json_module_compatibility_test/json_todo_test.vv
+++ b/vlib/x/json2/json_module_compatibility_test/json_todo_test.vv
@@ -371,26 +371,6 @@ fn test_encode_sumtype_defined_ahead() {
 	assert ret == '{"value":0,"_type":"GPScale"}'
 }
 
-struct Aa {
-	sub AliasType
-}
-
-struct Bb {
-	a int
-}
-
-type AliasType = Bb
-
-//! FIX: returning null
-fn test_encode_alias_field() {
-	s := json.encode(Aa{
-		sub: Bb{
-			a: 1
-		}
-	})
-	assert s == '{"sub":{"a":1}}'
-}
-
 struct APrice {}
 
 struct Association {


### PR DESCRIPTION
Thanks @spytheman @Delta456 !
```v
struct Aa {
	sub AliasType
}

struct Bb {
	a int
}

type AliasType = Bb

fn test_encode_alias_field() {
	s := json.encode(Aa{
		sub: Bb{
			a: 1
		}
	})
	assert s == '{"sub":{"a":1}}'
}
```