### PR TITLE
cgen, parser: add $Alias as compile-time type

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -126,6 +126,7 @@ pub enum ComptimeTypeKind {
 	array
 	sum_type
 	enum_
+	alias
 }
 
 pub struct ComptimeType {
@@ -144,6 +145,7 @@ pub fn (cty ComptimeType) str() string {
 		.array { '\$Array' }
 		.sum_type { '\$Sumtype' }
 		.enum_ { '\$Enum' }
+		.alias { '\$Alias' }
 	}
 }
 

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2262,6 +2262,9 @@ pub fn (t &Table) is_comptime_type(x Type, y ComptimeType) bool {
 		.enum_ {
 			return x_kind == .enum_
 		}
+		.alias {
+			return x_kind == .alias
+		}
 	}
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -731,6 +731,7 @@ pub fn (mut f Fmt) expr(node_ ast.Expr) {
 				.float { f.write('\$Float') }
 				.sum_type { f.write('\$Sumtype') }
 				.enum_ { f.write('\$Enum') }
+				.alias { f.write('\$Alias') }
 			}
 		}
 	}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -12,7 +12,7 @@ const (
 	supported_comptime_calls = ['html', 'tmpl', 'env', 'embed_file', 'pkgconfig', 'compile_error',
 		'compile_warn']
 	comptime_types           = ['Map', 'Array', 'Int', 'Float', 'Struct', 'Interface', 'Enum',
-		'Sumtype']
+		'Sumtype', 'Alias']
 )
 
 pub fn (mut p Parser) parse_comptime_type() ast.ComptimeType {
@@ -48,6 +48,9 @@ pub fn (mut p Parser) parse_comptime_type() ast.ComptimeType {
 		}
 		'Sumtype' {
 			cty = .sum_type
+		}
+		'Alias' {
+			cty = .alias
 		}
 		else {}
 	}


### PR DESCRIPTION
Fix #16924

```V
fn testa[U](val U) string {
	$if U is $Alias {
		return 'alias'
	}
	return ''
}
```