### PR TITLE
checker,cgen: allow method.name checking in comptime

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -561,7 +561,9 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 					}
 				}
 				.eq, .ne {
-					if cond.left is ast.SelectorExpr && cond.right is ast.IntegerLiteral {
+					if cond.left is ast.SelectorExpr
+						&& cond.right in [ast.IntegerLiteral, ast.StringLiteral] {
+						return .unknown
 						// $if method.args.len == 1
 					} else if cond.left is ast.SelectorExpr
 						&& c.check_comptime_is_field_selector_bool(cond.left as ast.SelectorExpr) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -193,6 +193,7 @@ mut:
 	// nr_vars_to_free       int
 	// doing_autofree_tmp    bool
 	comptime_for_method              string // $for method in T.methods {}
+	comptime_for_method_var          string // $for method in T.methods {}; the variable name
 	comptime_for_field_var           string // $for field in T.fields {}; the variable name
 	comptime_for_field_value         ast.StructField // value of the field variable
 	comptime_for_field_type          ast.Type        // type of the field variable inferred from `$if field.typ is T {}`

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -608,6 +608,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 struct CurrentComptimeValues {
 	inside_comptime_for_field bool
 	comptime_for_method       string
+	comptime_for_method_var   string
 	comptime_for_field_var    string
 	comptime_for_field_value  ast.StructField
 	comptime_for_field_type   ast.Type
@@ -615,13 +616,14 @@ struct CurrentComptimeValues {
 }
 
 fn (mut g Gen) push_existing_comptime_values() {
-	g.comptime_values_stack << CurrentComptimeValues{g.inside_comptime_for_field, g.comptime_for_method, g.comptime_for_field_var, g.comptime_for_field_value, g.comptime_for_field_type, g.comptime_var_type_map.clone()}
+	g.comptime_values_stack << CurrentComptimeValues{g.inside_comptime_for_field, g.comptime_for_method, g.comptime_for_method_var, g.comptime_for_field_var, g.comptime_for_field_value, g.comptime_for_field_type, g.comptime_var_type_map.clone()}
 }
 
 fn (mut g Gen) pop_existing_comptime_values() {
 	old := g.comptime_values_stack.pop()
 	g.inside_comptime_for_field = old.inside_comptime_for_field
 	g.comptime_for_method = old.comptime_for_method
+	g.comptime_for_method_var = old.comptime_for_method_var
 	g.comptime_for_field_var = old.comptime_for_field_var
 	g.comptime_for_field_value = old.comptime_for_field_value
 	g.comptime_for_field_type = old.comptime_for_field_type

--- a/vlib/v/tests/comptime_method_call_with_check_test.v
+++ b/vlib/v/tests/comptime_method_call_with_check_test.v
@@ -6,22 +6,21 @@ fn (t TestStruct) one_arg(a string) string {
 }
 
 fn (t TestStruct) two_args(a string, b int) string {
-	println('$a:$b')
+	println('${a}:${b}')
 	return a
 }
 
 fn test_main() {
 	t := TestStruct{}
 	mut out := ''
-	$for method in TestStruct.methods { 
-    	$if method.name == 'one_arg' {
+	$for method in TestStruct.methods {
+		$if method.name == 'one_arg' {
 			res := t.$method(method.name)
 			out += res
-    	} $else $if method.name == 'two_args' {
-      	  	res := t.$method(method.name, 42) 
+		} $else $if method.name == 'two_args' {
+			res := t.$method(method.name, 42)
 			out += res
-    	}
+		}
 	}
-
 	assert out == 'one_argtwo_args'
 }

--- a/vlib/v/tests/comptime_method_call_with_check_test.v
+++ b/vlib/v/tests/comptime_method_call_with_check_test.v
@@ -1,0 +1,27 @@
+struct TestStruct {}
+
+fn (t TestStruct) one_arg(a string) string {
+	println(a)
+	return a
+}
+
+fn (t TestStruct) two_args(a string, b int) string {
+	println('$a:$b')
+	return a
+}
+
+fn test_main() {
+	t := TestStruct{}
+	mut out := ''
+	$for method in TestStruct.methods { 
+    	$if method.name == 'one_arg' {
+			res := t.$method(method.name)
+			out += res
+    	} $else $if method.name == 'two_args' {
+      	  	res := t.$method(method.name, 42) 
+			out += res
+    	}
+	}
+
+	assert out == 'one_argtwo_args'
+}


### PR DESCRIPTION
Fix #9357

Makes possible to run code like:

```V
struct TestStruct {}

fn (t TestStruct) one_arg(a string) {
	println(a)
}

fn (t TestStruct) two_args(a string, b int) string {
	println('${a}:${b}')
	return a
}

fn test_main() {
	t := TestStruct{}
	mut out := ''
	$for method in TestStruct.methods {
		$if method.name == 'one_arg' {
			res := t.$method(method.name)
			out += res
			println(res)
		} $else $if method.name == 'two_args' {
			res := t.$method(method.name, 42)
			out += res
			println(res)
		}
	}
}
```