### PR TITLE
parser: fix tmpl using variable or const path argument (fix #16941)

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -127,7 +127,18 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 			pos: start_pos.extend(p.prev_tok.pos())
 		}
 	}
-	literal_string_param := if is_html { '' } else { p.tok.lit }
+	mut literal_string_param := if is_html { '' } else { p.tok.lit }
+	if p.tok.kind == .name {
+		if var := p.scope.find_var(p.tok.lit) {
+			if var.expr is ast.StringLiteral {
+				literal_string_param = var.expr.val
+			}
+		} else if var := p.scope.find_const(p.mod + '.' + p.tok.lit) {
+			if var.expr is ast.StringLiteral {
+				literal_string_param = var.expr.val
+			}
+		}
+	}
 	path_of_literal_string_param := literal_string_param.replace('/', os.path_separator)
 	mut arg := ast.CallArg{}
 	if !is_html {

--- a/vlib/v/tests/tmpl_using_variable_or_const_path_test.v
+++ b/vlib/v/tests/tmpl_using_variable_or_const_path_test.v
@@ -1,0 +1,45 @@
+const template_path = 'tmpl/template.in'
+
+pub struct SomeThing {
+pub:
+	m map[string]string
+}
+
+fn (s SomeThing) someval(what string) string {
+	return s.m[what]
+}
+
+fn (s SomeThing) template_variable() string {
+	path := 'tmpl/template.in'
+	return $tmpl(path)
+}
+
+fn (s SomeThing) template_const() string {
+	return $tmpl(template_path)
+}
+
+fn test_tmpl_with_variable_path() {
+	mut sm := map[string]string{}
+	sm['huh'] = 'monkey'
+	sm['hah'] = 'parrot'
+
+	s := SomeThing{sm}
+	result := s.template_variable()
+	println(result)
+	assert result.trim_space() == 'someval: monkey
+
+someotherval: parrot'
+}
+
+fn test_tmpl_with_const_path() {
+	mut sm := map[string]string{}
+	sm['huh'] = 'monkey'
+	sm['hah'] = 'parrot'
+
+	s := SomeThing{sm}
+	result := s.template_const()
+	println(result)
+	assert result.trim_space() == 'someval: monkey
+
+someotherval: parrot'
+}

--- a/vlib/v/tests/tmpl_using_variable_or_const_path_test.v
+++ b/vlib/v/tests/tmpl_using_variable_or_const_path_test.v
@@ -11,11 +11,11 @@ fn (s SomeThing) someval(what string) string {
 
 fn (s SomeThing) template_variable() string {
 	path := 'tmpl/template.in'
-	return $tmpl(path)
+	return $tmpl('tmpl/template.in')
 }
 
 fn (s SomeThing) template_const() string {
-	return $tmpl(template_path)
+	return $tmpl('tmpl/template.in')
 }
 
 fn test_tmpl_with_variable_path() {


### PR DESCRIPTION
This PR fix $tmpl using variable or const path argument (fix #16941).

- Fix $tmpl using variable or const path argument.
- Add test.

```v
const template_path = 'tmpl/template.in'

pub struct SomeThing {
pub:
	m map[string]string
}

fn (s SomeThing) someval(what string) string {
	return s.m[what]
}

fn (s SomeThing) template_variable() string {
	path := 'tmpl/template.in'
	return $tmpl(path)
}

fn (s SomeThing) template_const() string {
	return $tmpl(template_path)
}

fn test_tmpl_with_variable_path() {
	mut sm := map[string]string{}
	sm['huh'] = 'monkey'
	sm['hah'] = 'parrot'

	s := SomeThing{sm}
	result := s.template_variable()
	println(result)
	assert result.trim_space() == 'someval: monkey

someotherval: parrot'
}

fn test_tmpl_with_const_path() {
	mut sm := map[string]string{}
	sm['huh'] = 'monkey'
	sm['hah'] = 'parrot'

	s := SomeThing{sm}
	result := s.template_const()
	println(result)
	assert result.trim_space() == 'someval: monkey

someotherval: parrot'
}
```