### PR TITLE
docs: fix v wrapper command

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6221,7 +6221,7 @@ fn main() {
 To generate a wrapper on top of a C library use this command:
 
 ```bash
-v wrapper c_code/libsodium/src/libsodium
+v translate wrapper c_code/libsodium/src/libsodium
 ```
 
 This will generate a directory `libsodium` with a V module.


### PR DESCRIPTION
C wrapper generates by the `v translate wrapper` command, not the `v wrapper`.