### PR TITLE
checker: fix orm unreachable code checking

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -127,6 +127,7 @@ const (
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_joined_tables_select_test.v',
 		'vlib/v/tests/sql_statement_inside_fn_call_test.v',
+		'vlib/v/tests/orm_stmt_wrong_return_checking_test.v',
 		'vlib/vweb/tests/vweb_test.v',
 		'vlib/vweb/csrf/csrf_test.v',
 		'vlib/vweb/request_test.v',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -177,6 +177,7 @@ const (
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_joined_tables_select_test.v',
+		'vlib/v/tests/orm_stmt_wrong_return_checking_test.v',
 		'vlib/v/tests/sql_statement_inside_fn_call_test.v',
 		'vlib/clipboard/clipboard_test.v',
 		'vlib/vweb/tests/vweb_test.v',

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -128,9 +128,7 @@ fn (mut c Checker) sql_stmt(mut node ast.SqlStmt) ast.Type {
 		}
 	}
 	if node.or_expr.kind == .block {
-		for s in node.or_expr.stmts {
-			c.stmt(s)
-		}
+		c.stmts_ending_with_expression(node.or_expr.stmts)
 	}
 	return typ
 }

--- a/vlib/v/tests/orm_stmt_wrong_return_checking_test.v
+++ b/vlib/v/tests/orm_stmt_wrong_return_checking_test.v
@@ -1,0 +1,29 @@
+import sqlite
+
+struct Target {
+pub mut:
+	id   int    [primary; sql: serial]
+	kind string [nonull]
+}
+
+fn add_target(repo Target) !int {
+	mut dbs := sqlite.connect('test.db')!
+	defer {
+		dbs.close() or { panic(err) }
+	}
+	sql dbs {
+		insert repo into Target
+	} or {
+		println(err)
+		return 1
+	}
+
+	assert true
+
+	return 1
+}
+
+fn test_main() {
+	add_target(Target{1, 'foo'}) or { println('>> ${err}') }
+	assert true
+}


### PR DESCRIPTION
Fix #16330

```V
sql dbs {
        insert repo into Target
    } or {
        println(err)
        return 1
    }
    assert true // checker was pointing as unreachable code
    return 1 
```