### PR TITLE
parser, fmt: fix fmt error of `$tmpl(path)`

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1880,7 +1880,7 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 		if node.method_name == 'html' {
 			f.write('\$vweb.html()')
 		} else {
-			f.write("\$tmpl('${node.args_var}')")
+			f.write("\$tmpl(${node.args[0].expr})")
 		}
 	} else {
 		if node.is_embed {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1880,7 +1880,7 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 		if node.method_name == 'html' {
 			f.write('\$vweb.html()')
 		} else {
-			f.write("\$tmpl(${node.args[0].expr})")
+			f.write('\$tmpl(${node.args[0].expr})')
 		}
 	} else {
 		if node.is_embed {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -203,6 +203,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 					is_vweb: true
 					method_name: method_name
 					args_var: literal_string_param
+					args: [arg]
 					pos: start_pos.extend(p.prev_tok.pos())
 				}
 			}
@@ -244,6 +245,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 		vweb_tmpl: file
 		method_name: method_name
 		args_var: literal_string_param
+		args: [arg]
 		pos: start_pos.extend(p.prev_tok.pos())
 	}
 }

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -133,7 +133,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 			if var.expr is ast.StringLiteral {
 				literal_string_param = var.expr.val
 			}
-		} else if var := p.scope.find_const(p.mod + '.' + p.tok.lit) {
+		} else if var := p.table.global_scope.find_const(p.mod + '.' + p.tok.lit) {
 			if var.expr is ast.StringLiteral {
 				literal_string_param = var.expr.val
 			}

--- a/vlib/v/tests/tmpl_using_variable_or_const_path_test.v
+++ b/vlib/v/tests/tmpl_using_variable_or_const_path_test.v
@@ -11,11 +11,11 @@ fn (s SomeThing) someval(what string) string {
 
 fn (s SomeThing) template_variable() string {
 	path := 'tmpl/template.in'
-	return $tmpl('tmpl/template.in')
+	return $tmpl(path)
 }
 
 fn (s SomeThing) template_const() string {
-	return $tmpl('tmpl/template.in')
+	return $tmpl(template_path)
 }
 
 fn test_tmpl_with_variable_path() {


### PR DESCRIPTION
This PR fix fmt error of `$tmpl(path)`.