### PR TITLE
checker, cgen: add typeof() type checking

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -551,7 +551,15 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 						} else {
 							.skip
 						}
-					} else if cond.left in [ast.SelectorExpr, ast.TypeNode] {
+					} else if cond.left is ast.TypeOf && cond.right is ast.ComptimeType {
+						c.expr(cond.left)
+						checked_type := c.unwrap_generic((cond.left as ast.TypeOf).typ)
+						return if c.table.is_comptime_type(checked_type, cond.right) {
+							.eval
+						} else {
+							.skip
+						}
+					} else if cond.left in [ast.SelectorExpr, ast.TypeNode, ast.TypeOf] {
 						// `$if method.@type is string`
 						c.expr(cond.left)
 						return .unknown

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -139,9 +139,9 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							} else {
 								.skip
 							}
-						} else if left is ast.TypeNode {
+						} else if left in [ast.TypeOf, ast.TypeNode] {
 							is_comptime_type_is_expr = true
-							left_type := c.unwrap_generic(left.typ)
+							left_type := c.unwrap_generic(c.get_expr_type(left))
 							skip_state = if left_type == got_type { .eval } else { .skip }
 						}
 					}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -484,6 +484,8 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 					} else if left is ast.TypeNode {
 						// this is only allowed for generics currently, otherwise blocked by checker
 						exp_type = g.unwrap_generic(left.typ)
+					} else if left is ast.TypeOf {
+						exp_type = g.unwrap_generic(left.typ)
 					}
 
 					if cond.op == .key_is {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -421,8 +421,8 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 				.key_is, .not_is {
 					left := cond.left
 					mut name := ''
-					if left is ast.TypeNode && cond.right is ast.ComptimeType {
-						checked_type := g.unwrap_generic(left.typ)
+					if left in [ast.TypeNode, ast.TypeOf] && cond.right is ast.ComptimeType {
+						checked_type := g.unwrap_generic((left as ast.TypeOf).typ)
 						is_true := g.table.is_comptime_type(checked_type, cond.right)
 						if cond.op == .key_is {
 							if is_true {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -222,7 +222,7 @@ pub fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				p.check(.lpar)
 				expr := p.expr(0)
 				p.check(.rpar)
-				if p.tok.kind != .dot && p.tok.line_nr == p.prev_tok.line_nr {
+				if !p.inside_comptime_if && p.tok.kind != .dot && p.tok.line_nr == p.prev_tok.line_nr {
 					p.warn_with_pos('use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead',
 						spos)
 				}

--- a/vlib/v/tests/typeof_type_checking_test.v
+++ b/vlib/v/tests/typeof_type_checking_test.v
@@ -1,0 +1,33 @@
+struct Test {
+	a int
+	b ?int
+}
+
+fn test_main() {
+	hh := '' // i64(4)
+	$if typeof(hh) is $Int {
+		println('int')
+		assert false
+	} $else {
+		println('string')
+		assert true
+	}
+
+	b := 1
+	$if typeof(b) is $Int {
+		println('int')
+		assert true
+	}
+
+	c := true
+	$if typeof(c) is bool {
+		println('bool')
+		assert true
+	}
+
+	d := Test{}
+	$if typeof(d.b) is ?int {
+		println('?int')
+		assert true
+	}
+}


### PR DESCRIPTION
Makes possible to do:

```V
struct Test {
    a int
    b ?int
}

fn test_main() {
    hh := ''
    $if typeof(hh) is $Int {
        println('int')
        assert false
    } $else {
        println('string')
        assert true
    }

    b := 1
    $if typeof(b) is $Int {
        println('int')
        assert true
    }

    c := true
    $if typeof(c) is bool {
        println('bool')
        assert true
    }

    d := Test{}
    $if typeof(d.b) is ?int {
        println('?int')
        assert true
    }
}
```