### PR TITLE
cgen, checker: var type checking at compile-time

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -551,7 +551,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 						} else {
 							.skip
 						}
-					} else if cond.left in [ast.SelectorExpr, ast.TypeNode] {
+					} else if cond.left in [ast.Ident, ast.SelectorExpr, ast.TypeNode] {
 						// `$if method.@type is string`
 						c.expr(cond.left)
 						return .unknown

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -94,6 +94,17 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						} else {
 							.skip
 						}
+					} else if right is ast.ComptimeType && left is ast.Ident
+						&& (left as ast.Ident).info is ast.IdentVar {
+						is_comptime_type_is_expr = true
+						if var := left.scope.find_var(left.name) {
+							checked_type := c.unwrap_generic(var.typ)
+							skip_state = if c.table.is_comptime_type(checked_type, right as ast.ComptimeType) {
+								.eval
+							} else {
+								.skip
+							}
+						}
 					} else {
 						got_type := c.unwrap_generic((right as ast.TypeNode).typ)
 						sym := c.table.sym(got_type)

--- a/vlib/v/checker/tests/unknown_comptime_expr.out
+++ b/vlib/v/checker/tests/unknown_comptime_expr.out
@@ -1,35 +1,35 @@
-vlib/v/checker/tests/unknown_comptime_expr.vv:5:6: error: `foo` is mut and may have changed since its definition
-    3 | fn main() {
-    4 |     mut foo := 0
-    5 |     $if foo == 0 {}
+vlib/v/checker/tests/unknown_comptime_expr.vv:7:6: error: `foo` is mut and may have changed since its definition
+    5 | fn main() {
+    6 |     mut foo := 0
+    7 |     $if foo == 0 {
       |         ~~~
-    6 | 
-    7 |     bar := unknown_at_ct()
-vlib/v/checker/tests/unknown_comptime_expr.vv:8:6: error: definition of `bar` is unknown at compile time
-    6 | 
-    7 |     bar := unknown_at_ct()
-    8 |     $if bar == 0 {}
+    8 |     }
+    9 |
+vlib/v/checker/tests/unknown_comptime_expr.vv:11:6: error: definition of `bar` is unknown at compile time
+    9 | 
+   10 |     bar := unknown_at_ct()
+   11 |     $if bar == 0 {
       |         ~~~
-    9 | }
-   10 |
-vlib/v/checker/tests/unknown_comptime_expr.vv:13:6: error: undefined ident: `huh`
-   11 | fn if_is() {
-   12 |     s := S1{}
-   13 |     $if huh.typ is T {}
+   12 |     }
+   13 | }
+vlib/v/checker/tests/unknown_comptime_expr.vv:17:6: error: undefined ident: `huh`
+   15 | fn if_is() {
+   16 |     s := S1{}
+   17 |     $if huh.typ is T {
       |         ~~~
-   14 |     $if s is int {}
-   15 |     $if s.i is 5 {}
-vlib/v/checker/tests/unknown_comptime_expr.vv:15:13: error: invalid `$if` condition: expected a type
-   13 |     $if huh.typ is T {}
-   14 |     $if s is int {}
-   15 |     $if s.i is 5 {}
+   18 |     }
+   19 |     $if s is int {
+vlib/v/checker/tests/unknown_comptime_expr.vv:21:13: error: invalid `$if` condition: expected a type
+   19 |     $if s is int {
+   20 |     }
+   21 |     $if s.i is 5 {
       |                ^
-   16 |     $if s.i is T {}
-   17 | }
-vlib/v/checker/tests/unknown_comptime_expr.vv:16:13: error: unknown type `T`
-   14 |     $if s is int {}
-   15 |     $if s.i is 5 {}
-   16 |     $if s.i is T {}
+   22 |     }
+   23 |     $if s.i is T {
+vlib/v/checker/tests/unknown_comptime_expr.vv:23:13: error: unknown type `T`
+   21 |     $if s.i is 5 {
+   22 |     }
+   23 |     $if s.i is T {
       |                ^
-   17 | }
-   18 |
+   24 |     }
+   25 | }

--- a/vlib/v/checker/tests/unknown_comptime_expr.out
+++ b/vlib/v/checker/tests/unknown_comptime_expr.out
@@ -19,13 +19,6 @@ vlib/v/checker/tests/unknown_comptime_expr.vv:13:6: error: undefined ident: `huh
       |         ~~~
    14 |     $if s is int {}
    15 |     $if s.i is 5 {}
-vlib/v/checker/tests/unknown_comptime_expr.vv:14:6: error: invalid `$if` condition: expected a type or a selector expression or an interface check
-   12 |     s := S1{}
-   13 |     $if huh.typ is T {}
-   14 |     $if s is int {}
-      |         ^
-   15 |     $if s.i is 5 {}
-   16 |     $if s.i is T {}
 vlib/v/checker/tests/unknown_comptime_expr.vv:15:13: error: invalid `$if` condition: expected a type
    13 |     $if huh.typ is T {}
    14 |     $if s is int {}

--- a/vlib/v/checker/tests/unknown_comptime_expr.vv
+++ b/vlib/v/checker/tests/unknown_comptime_expr.vv
@@ -1,22 +1,29 @@
-fn unknown_at_ct() int { return 0 }
+fn unknown_at_ct() int {
+	return 0
+}
 
 fn main() {
 	mut foo := 0
-	$if foo == 0 {}
+	$if foo == 0 {
+	}
 
 	bar := unknown_at_ct()
-	$if bar == 0 {}
+	$if bar == 0 {
+	}
 }
 
 fn if_is() {
 	s := S1{}
-	$if huh.typ is T {}
-	$if s is int {}
-	$if s.i is 5 {}
-	$if s.i is T {}
+	$if huh.typ is T {
+	}
+	$if s is int {
+	}
+	$if s.i is 5 {
+	}
+	$if s.i is T {
+	}
 }
 
 struct S1 {
 	i int
 }
-

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -762,6 +762,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				g.writeln('\t${node.val_var}.indirections = ${field.typ.nr_muls()};')
 				//
 				g.comptime_var_type_map['${node.val_var}.typ'] = styp
+				g.comptime_var_type_map['${node.val_var}.unaliased_typ'] = unaliased_styp
 				g.stmts(node.stmts)
 				i++
 				g.writeln('}')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -387,14 +387,15 @@ fn (mut g Gen) get_expr_type(cond ast.Expr) ast.Type {
 			return g.unwrap_generic(cond.typ)
 		}
 		ast.SelectorExpr {
-			if g.inside_comptime_for_field && cond.expr is ast.Ident
-				&& (cond.expr as ast.Ident).name == g.comptime_for_field_var && cond.field_name == 'typ' {
-				return g.comptime_for_field_type
-			} else if cond.typ != 0 {
-				return g.unwrap_generic(cond.typ)
+			if cond.gkind_field == .typ {
+				return g.unwrap_generic(cond.name_type)
 			} else {
 				name := '${cond.expr}.${cond.field_name}'
-				return g.comptime_var_type_map[name]
+				if name in g.comptime_var_type_map {
+					return g.comptime_var_type_map[name]
+				} else {
+					return g.unwrap_generic(cond.typ)
+				}
 			}
 		}
 		else {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -467,7 +467,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 								return !is_true, true
 							}
 						} else {
-							got_type := (cond.right as ast.TypeNode).typ
+							got_type := g.unwrap_generic((cond.right as ast.TypeNode).typ)
 							got_sym := g.table.sym(got_type)
 
 							if got_sym.kind == .interface_ && got_sym.info is ast.Interface {

--- a/vlib/v/tests/var_type_is_checking2_test.v
+++ b/vlib/v/tests/var_type_is_checking2_test.v
@@ -1,0 +1,60 @@
+type MyAlias = string
+type MyAlias2 = rune
+
+struct Foo {
+	a string
+	b ?string
+	c MyAlias
+	d MyAlias2
+	e []int
+}
+
+fn is_t[T](val T) bool {
+	$if val is T {
+		return true
+	}
+	return false
+}
+
+fn test_main() {
+	a := Foo{}
+	$for field in Foo.fields {
+		$if field.unaliased_typ is ?string {
+			assert field.name == 'b'
+			println('is option string')
+		} $else $if field.unaliased_typ is string {
+			assert field.name in ['a', 'c']
+			println('is string')
+		} $else $if field.unaliased_typ is MyAlias {
+			assert false
+			println('is string')
+		} $else $if field.typ is MyAlias2 {
+			assert field.name == 'd'
+			println('is MyAlias')
+		} $else $if field.typ is []int {
+			assert field.name == 'e'
+			println('is int')
+		} $else {
+			assert false
+		}
+	}
+}
+
+fn test_generic() {
+	a := Foo{}
+	$for field in Foo.fields {
+		if is_t(field) {
+			println('T')
+			assert true
+		} else {
+			assert false
+		}
+		val := a.$(field.name)
+		if is_t(val) {
+			println('T')
+			assert true
+		} else {
+			assert false
+		}
+	}
+}

--- a/vlib/v/tests/var_type_is_checking_test.v
+++ b/vlib/v/tests/var_type_is_checking_test.v
@@ -1,0 +1,46 @@
+struct Test {
+	a int
+	b ?int
+}
+
+fn test_main() {
+	hh := 1 // i64(4)
+	$if hh is $Int {
+		println('int')
+		assert true
+	} $else $if hh !is $Int {
+		println('string')
+		assert false
+	}
+
+	b := 1.2
+	$if b is $Int {
+		assert false
+	} $else $if b is $Float {
+		println('float')
+		assert true
+	}
+
+	c := true
+	$if c is bool {
+		println('bool')
+		assert true
+	}
+
+	d := Test{}
+	$if d.b is ?int {
+		println('?int')
+		assert true
+	}
+	$if d.a is ?int {
+		println('?int')
+		assert false
+	} $else $if d.a is int {
+		println('int')
+		assert true
+	}
+
+	$if d is Test {
+		println('Test')
+	}
+}


### PR DESCRIPTION
Fix #16930

Makes possible to do:

```V
struct Test {
	a int
	b ?int
}

fn test_main() {
	hh := 1 // i64(4)
	$if hh is $Int {
		println('int')
		assert true
	} $else $if hh !is $Int {
		println('string')
		assert false
	}

	b := 1.2
	$if b is $Int {
		assert false
	} $else $if b is $Float {
		println('float')
		assert true
	}

	c := true
	$if c is bool {
		println('bool')
		assert true
	}

	d := Test{}
	$if d.b is ?int {
		println('?int')
		assert true
	}
	$if d.a is ?int {
		println('?int')
		assert false
	} $else $if d.a is int {
		println('int')
		assert true
	}

	$if d is Test {
		println('Test')
	}
}
```

field.unaliased_typ 

```V

type MyAlias = string

struct Foo {
    a string
    b ?string
    c MyAlias
}

fn main() {
    $for field in Foo.fields {
        println('${field.name} - ${field.typ} - ${field.unaliased_typ}')
        $if field.unaliased_typ is ?string {
            println('is option string')
        } $else $if field.unaliased_typ is string {
            println('is string')
        }
    }
}
```