### PR TITLE
parser, fmt: fix fmt in struct decl with array of anon struct field (fix #16947)

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -203,24 +203,26 @@ fn (mut f Fmt) write_anon_struct_field_decl(field_typ ast.Type, field_anon_decl 
 			}
 		}
 		.array {
-			info := sym.info as ast.Array
-			elem_sym := f.table.sym(info.elem_type)
-			if elem_sym.info is ast.Struct {
-				if elem_sym.info.is_anon {
-					f.write('[]'.repeat(info.nr_dims))
-					f.write_anon_struct_field_decl(info.elem_type, field_anon_decl)
-					return true
+			if sym.info is ast.Array {
+				elem_sym := f.table.sym(sym.info.elem_type)
+				if elem_sym.info is ast.Struct {
+					if elem_sym.info.is_anon {
+						f.write('[]'.repeat(sym.info.nr_dims))
+						f.write_anon_struct_field_decl(sym.info.elem_type, field_anon_decl)
+						return true
+					}
 				}
 			}
 		}
 		.array_fixed {
-			info := sym.info as ast.ArrayFixed
-			elem_sym := f.table.sym(info.elem_type)
-			if elem_sym.info is ast.Struct {
-				if elem_sym.info.is_anon {
-					f.write('[${info.size}]')
-					f.write_anon_struct_field_decl(info.elem_type, field_anon_decl)
-					return true
+			if sym.info is ast.ArrayFixed {
+				elem_sym := f.table.sym(sym.info.elem_type)
+				if elem_sym.info is ast.Struct {
+					if elem_sym.info.is_anon {
+						f.write('[${sym.info.size}]')
+						f.write_anon_struct_field_decl(sym.info.elem_type, field_anon_decl)
+						return true
+					}
 				}
 			}
 		}

--- a/vlib/v/fmt/tests/struct_with_array_of_anon_struct_field_decl_keep.vv
+++ b/vlib/v/fmt/tests/struct_with_array_of_anon_struct_field_decl_keep.vv
@@ -1,0 +1,13 @@
+struct Abc {
+	a []struct {
+		b string
+	}
+}
+
+fn main() {
+	abc := Abc{
+		a: [struct {'this is b'}]
+	}
+
+	dump(abc)
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -434,9 +434,9 @@ pub fn (mut p Parser) parse_type() ast.Type {
 	}
 	// Anon structs
 	if p.tok.kind == .key_struct {
-		struct_decl := p.struct_decl(true)
+		p.anon_struct_decl = p.struct_decl(true)
 		// Find the registered anon struct type, it was registered above in `p.struct_decl()`
-		return p.table.find_type_idx(struct_decl.name)
+		return p.table.find_type_idx(p.anon_struct_decl.name)
 	}
 
 	language := p.parse_language()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -89,6 +89,7 @@ mut:
 	defer_vars                []ast.Ident
 	should_abort              bool // when too many errors/warnings/notices are accumulated, should_abort becomes true, and the parser should stop
 	codegen_text              string
+	anon_struct_decl          ast.StructDecl
 	struct_init_generic_types []ast.Type
 	if_cond_comments          []ast.Comment
 	script_mode               bool

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -202,7 +202,6 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 			mut type_pos := token.Pos{}
 			mut field_pos := token.Pos{}
 			mut option_pos := token.Pos{}
-			mut anon_struct_decl := ast.StructDecl{}
 			if is_embed {
 				// struct embedding
 				type_pos = p.tok.pos()
@@ -247,9 +246,9 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				if p.tok.kind == .key_struct {
 					// Anon structs
 					if p.tok.kind == .key_struct {
-						anon_struct_decl = p.struct_decl(true)
+						p.anon_struct_decl = p.struct_decl(true)
 						// Find the registered anon struct type, it was registered above in `p.struct_decl()`
-						typ = p.table.find_type_idx(anon_struct_decl.name)
+						typ = p.table.find_type_idx(p.anon_struct_decl.name)
 					}
 				} else {
 					start_type_pos := p.tok.pos()
@@ -308,8 +307,9 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					is_global: is_field_global
 					is_volatile: is_field_volatile
 					is_deprecated: is_field_deprecated
-					anon_struct_decl: anon_struct_decl
+					anon_struct_decl: p.anon_struct_decl
 				}
+				p.anon_struct_decl = ast.StructDecl{}
 			}
 			// save embeds as table fields too, it will be used in generation phase
 			fields << ast.StructField{


### PR DESCRIPTION
This PR fix fmt in struct decl with array of anon struct field (fix #16947).

- Fix fmt in struct decl with array of anon struct field.
- Add test.

struct_with_array_of_anon_struct_field_decl_keep.vv
```v
struct Abc {
	a []struct {
		b string
	}
}

fn main() {
	abc := Abc{
		a: [struct {'this is b'}]
	}

	dump(abc)
}
```