### PR TITLE
cgen: fix printing struct with arrays of anonymous struct fields (fix #16947)

### DIFF
--- a/vlib/v/checker/tests/comptime_dump_fields_var_test.out
+++ b/vlib/v/checker/tests/comptime_dump_fields_var_test.out
@@ -2,7 +2,7 @@
 [vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: d
 [vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: 1
 [vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: 0
-[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: _VAnonStruct1{
+[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: struct {
     i: 100
 }
 ok

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -829,7 +829,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 		g.auto_fn_definitions << fn_builder.str()
 	}
 	fn_builder.writeln('static string indent_${str_fn_name}(${styp} it, int indent_count) {')
-	clean_struct_v_type_name := util.strip_main_name(typ_str)
+	clean_struct_v_type_name := if info.is_anon { 'struct ' } else { util.strip_main_name(typ_str) }
 	// generate ident / indent length = 4 spaces
 	if info.fields.len == 0 {
 		fn_builder.writeln('\treturn _SLIT("${clean_struct_v_type_name}{}");')

--- a/vlib/v/slow_tests/inout/printing_struct_with_arrays_of_anon_struct_field.out
+++ b/vlib/v/slow_tests/inout/printing_struct_with_arrays_of_anon_struct_field.out
@@ -1,0 +1,5 @@
+Abc{
+    a: [struct {
+        b: 'this is b'
+    }]
+}

--- a/vlib/v/slow_tests/inout/printing_struct_with_arrays_of_anon_struct_field.vv
+++ b/vlib/v/slow_tests/inout/printing_struct_with_arrays_of_anon_struct_field.vv
@@ -1,0 +1,13 @@
+struct Abc {
+	a []struct {
+		b string
+	}
+}
+
+fn main() {
+	abc := Abc{
+		a: [struct {'this is b'}]
+	}
+
+	println(abc)
+}


### PR DESCRIPTION
This PR fix printing struct with arrays of anonymous struct fields. (fix #16947)

- Fix printing struct with arrays of anonymous struct fields. 
- Add test.

```v
struct Abc {
	a []struct {
		b string
	}
}

fn main() {
	abc := Abc{
		a: [struct {'this is b'}]
	}

	println(abc)
}

PS D:\Test\v\tt1> v run .
Abc{
    a: [struct {
        b: 'this is b'
    }]
}
```