### PR TITLE
fmt: fix removal of selective imporcted types used as array elements

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -285,16 +285,23 @@ pub fn (mut f Fmt) short_module(name string) string {
 
 pub fn (mut f Fmt) mark_types_import_as_used(typ ast.Type) {
 	sym := f.table.sym(typ)
-	if sym.info is ast.Map {
-		map_info := sym.map_info()
-		f.mark_types_import_as_used(map_info.key_type)
-		f.mark_types_import_as_used(map_info.value_type)
-		return
-	}
-	if sym.info is ast.GenericInst {
-		for concrete_typ in sym.info.concrete_types {
-			f.mark_types_import_as_used(concrete_typ)
+	match sym.info {
+		ast.Map {
+			map_info := sym.map_info()
+			f.mark_types_import_as_used(map_info.key_type)
+			f.mark_types_import_as_used(map_info.value_type)
+			return
 		}
+		ast.Array, ast.ArrayFixed {
+			f.mark_types_import_as_used(sym.info.elem_type)
+			return
+		}
+		ast.GenericInst {
+			for concrete_typ in sym.info.concrete_types {
+				f.mark_types_import_as_used(concrete_typ)
+			}
+		}
+		else {}
 	}
 	name := sym.name.split('[')[0] // take `Type` from `Type[T]`
 	f.mark_import_as_used(name)

--- a/vlib/v/fmt/tests/import_selective_expected.vv
+++ b/vlib/v/fmt/tests/import_selective_expected.vv
@@ -14,6 +14,7 @@ import mod {
 	FnArgGeneric,
 	FnArgTypeParam1,
 	FnArgTypeParam2,
+	FnArgVariadic,
 	FnRet,
 	FnRetGeneric,
 	FnRetTypeParam1,
@@ -23,8 +24,10 @@ import mod {
 	InterfaceMethodRet,
 	RightOfAs,
 	RightOfIs,
+	StructArrayFieldElem,
 	StructEmbed,
 	StructField,
+	StructFixedArrayFieldElem,
 	StructMapFieldKey,
 	StructMapFieldValue,
 	StructMethodArg,
@@ -42,9 +45,11 @@ type Fn = fn (FnAliasParam) FnAliasRet
 
 struct Struct {
 	StructEmbed
-	v   StructField
-	ref &StructRefField
-	map map[StructMapFieldKey]StructMapFieldValue
+	v         StructField
+	ref       &StructRefField
+	map       map[StructMapFieldKey]StructMapFieldValue
+	arr       []StructArrayFieldElem
+	arr_fixed [2]StructFixedArrayFieldElem
 }
 
 fn (s Struct) method(v StructMethodArg) StructMethodRet {
@@ -60,7 +65,7 @@ interface Interface {
 	f(InterfaceMethodArg) InterfaceMethodRet
 }
 
-fn f(v FnArg) FnRet {
+fn f(v FnArg, vv ...FnArgVariadic) FnRet {
 	if v is RightOfIs {
 	}
 	_ = v as RightOfAs

--- a/vlib/v/fmt/tests/import_selective_input.vv
+++ b/vlib/v/fmt/tests/import_selective_input.vv
@@ -11,6 +11,7 @@ import mod {
 	Unused,
 	StructEmbed, StructField, StructRefField
 	StructMapFieldKey, StructMapFieldValue,
+	StructArrayFieldElem, StructFixedArrayFieldElem
 	StructMethodArg,
 	StructMethodArgGeneric,
 	StructMethodRet,
@@ -21,6 +22,7 @@ import mod {
 	InterfaceMethodRet,
 
 	FnArg,
+	FnArgVariadic
 	FnArgGeneric
 	FnArgTypeParam1
 	FnArgTypeParam2
@@ -48,6 +50,8 @@ struct Struct {
 	v StructField
 	ref &StructRefField
 	map map[StructMapFieldKey]StructMapFieldValue
+	arr []StructArrayFieldElem
+	arr_fixed [2]StructFixedArrayFieldElem
 }
 
 fn (s Struct) method(v StructMethodArg) StructMethodRet {
@@ -63,7 +67,7 @@ interface Interface {
 	f(InterfaceMethodArg) InterfaceMethodRet
 }
 
-fn f(v FnArg) FnRet {
+fn f(v FnArg, vv ...FnArgVariadic) FnRet {
 	if v is RightOfIs {}
 	_ = v as RightOfAs
 


### PR DESCRIPTION
See test. Added imports will be remove by v fmt on current master

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
