### PR TITLE
parser: struct field initialized declaration consistency

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -29,7 +29,12 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		line_nr := p.tok.line_nr
 		p.next()
 		// []string
-		if p.tok.kind in [.name, .amp, .lsbr, .question, .key_shared] && p.tok.line_nr == line_nr {
+		if p.tok.kind in [.name, .amp, .lsbr, .question, .key_shared, .lpar]
+			&& p.tok.line_nr == line_nr {
+			has_lpar := p.tok.kind == .lpar // [](type)
+			if has_lpar {
+				p.next()
+			}
 			elem_type_pos = p.tok.pos()
 			elem_type = p.parse_type()
 			// this is set here because it's a known type, others could be the
@@ -41,6 +46,9 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 				array_type = ast.new_type(idx)
 			}
 			has_type = true
+			if has_lpar {
+				p.check(.rpar)
+			}
 		}
 		last_pos = p.tok.pos()
 	} else {

--- a/vlib/v/tests/var_decl_with_par_test.v
+++ b/vlib/v/tests/var_decl_with_par_test.v
@@ -1,0 +1,30 @@
+struct Struc {}
+
+type StrucOpt = ?Struc
+
+struct StrucContainer {
+	a []?Struc
+	b []?Struc
+	c ?[]Struc
+	d []?Struc = []?Struc{}
+	e []?Struc = []?Struc{}
+}
+
+fn test_par_decl_types() {
+	a := []?Struc{}
+	b := []?Struc{}
+	c := []StrucOpt{}
+
+	if typeof(a).idx != typeof[[]?Struc]().idx {
+		assert false
+	}
+	if typeof(a).idx != typeof[[]?Struc]().idx {
+		assert false
+	}
+	if typeof(b).idx != typeof[[]?Struc]().idx {
+		assert false
+	}
+	if typeof(c).idx != typeof[[]StrucOpt]().idx {
+		assert false
+	}
+}

--- a/vlib/v/tests/var_decl_with_par_test.v
+++ b/vlib/v/tests/var_decl_with_par_test.v
@@ -2,13 +2,15 @@ struct Struc {}
 
 type StrucOpt = ?Struc
 
+// vfmt off
 struct StrucContainer {
-	a []?Struc
+	a [](?Struc)
 	b []?Struc
 	c ?[]Struc
-	d []?Struc = []?Struc{}
+	d [](?Struc) = [](?Struc){}
 	e []?Struc = []?Struc{}
 }
+// vfmt on
 
 fn test_par_decl_types() {
 	a := []?Struc{}


### PR DESCRIPTION
Fix #16515

Makes possible to initialize struct field declared as `[](?Struc)`.

```V
struct StrucContainer {
    a [](?Struc) // already works
    d [](?Struc) = [](?Struc){} // it was not working
}
```