### PR TITLE
checker,cgen: allow ?.str() on compile-time fields var

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3518,7 +3518,6 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	if !(typ_sym.is_number() || ((c.inside_unsafe || c.pref.translated) && is_non_void_pointer)) {
 		if c.inside_comptime_for_field {
 			if c.is_comptime_var(node.expr) {
-				// typeof(var) from T.fields
 				return c.comptime_fields_default_type
 			} else if node.expr is ast.ComptimeSelector {
 				return c.comptime_fields_default_type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3503,6 +3503,11 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 	return none
 }
 
+pub fn (mut c Checker) is_comptime_var(node ast.Expr) bool {
+	return c.inside_comptime_for_field && node is ast.Ident
+		&& (node as ast.Ident).info is ast.IdentVar && ((node as ast.Ident).obj as ast.Var).is_comptime_field
+}
+
 fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	typ := c.unwrap_generic(c.expr(node.expr))
 	typ_sym := c.table.sym(typ)
@@ -3511,6 +3516,15 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 		c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
 	}
 	if !(typ_sym.is_number() || ((c.inside_unsafe || c.pref.translated) && is_non_void_pointer)) {
+		if c.inside_comptime_for_field {
+			if c.is_comptime_var(node.expr) {
+				// typeof(var) from T.fields
+				return c.comptime_fields_default_type
+			} else if node.expr is ast.ComptimeSelector {
+				return c.comptime_fields_default_type
+			}
+		}
+
 		typ_str := c.table.type_to_str(typ)
 		c.error('invalid operation: ${node.op.str()} (non-numeric type `${typ_str}`)',
 			node.pos)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1326,7 +1326,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	} else {
 		'unknown method or field: `${left_sym.name}.${method_name}`'
 	}
-	if left_type.has_flag(.option) {
+	if left_type.has_flag(.option) && method_name != 'str' {
 		c.error('option type cannot be called directly', node.left.pos())
 		return ast.void_type
 	} else if left_type.has_flag(.result) {

--- a/vlib/v/tests/call_to_str_on_option_test.v
+++ b/vlib/v/tests/call_to_str_on_option_test.v
@@ -1,0 +1,38 @@
+struct FixedStruct1 {
+	a int
+	b string
+	c ?int
+	d ?string
+}
+
+struct Encoder {}
+
+fn test_main() {
+	fixed := FixedStruct1{123, '456', 789, '321'}
+	// this work well
+	println(fixed.a.str())
+	println(fixed.c?.str())
+
+	println(fixed.b.int())
+	println(fixed.d?.int())
+
+	e := Encoder{}
+	// this not work
+	e.encode_struct(fixed)
+}
+
+fn (e &Encoder) encode_struct[T](val T) {
+	mut count := 0
+	$for field in T.fields {
+		mut value := val.$(field.name)
+		$if field.is_option {
+			if field.name in ['c', 'd'] {
+				assert true
+			}
+			println('>> ${value ?.str()}')
+			println(val.$(field.name) ?.str())
+			count += 1
+		}
+	}
+	assert count == 2
+}


### PR DESCRIPTION
Fix #16897

Makes `.str()` consistent on compile-time with option values.

```V
	$for field in T.fields {
		mut value := val.$(field.name)
		$if field.is_option {
			println(value?.str())
			println(val.$(field.name)?.str())
			count += 1
		}
	}
```