### PR TITLE
docs: fix ALL `db.pg` docs is italic in html format

### DIFF
--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -47,6 +47,6 @@ gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin
 ##Getting Started with [PostgreSQL](https://www.postgresqltutorial.com/postgresql-getting-started)
 
 Read this section to learn how to install and connect to PostgreSQL
-*[Windows](https://www.postgresqltutorial.com/install-postgresql)*;
-*[Linux](https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-linux)*;
-*[macOS](https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-macos)*.
+[*Windows*](https://www.postgresqltutorial.com/install-postgresql);
+[*Linux*](https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-linux);
+[*macOS*](https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-macos).


### PR DESCRIPTION
Current: 

![2023-01-14-001656_1366x768_scrot](https://user-images.githubusercontent.com/99479536/212367690-cfcdbf6a-eaef-4939-9726-353943b2cce3.png)

After this PR:

![2023-01-14-001529_1366x768_scrot](https://user-images.githubusercontent.com/99479536/212367741-47f4c2c1-e72c-4240-af97-db5988665f1d.png)
