### PR TITLE
gen c/js: `[autostr: allowrecurse]` attribute

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -860,6 +860,8 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 	}
 	fn_body.writeln('\tstring res = str_intp( ${(info.fields.len - field_skips.len) * 4 + 3}, _MOV((StrIntpData[]){')
 	fn_body.writeln('\t\t{_SLIT("${clean_struct_v_type_name}{\\n"), 0, {.d_c=0}},')
+
+	allow_circular := info.attrs.any(it.name == 'autostr' && it.arg == 'allowrecurse')
 	mut is_first := true
 	for i, field in info.fields {
 		// Skip `str:skip` fields
@@ -937,7 +939,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 			}
 		}
 		// handle circular ref type of struct to the struct itself
-		if styp == field_styp {
+		if styp == field_styp && !allow_circular {
 			fn_body.write_string('${funcprefix}_SLIT("<circular>")')
 		} else {
 			// manage C charptr

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -712,6 +712,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 
 	fn_builder.writeln('\tlet res = /*struct name*/new string("${clean_struct_v_type_name}{\\n")')
 
+	allow_circular := info.attrs.any(it.name == 'autostr' && it.arg == 'allowrecurse')
 	for i, field in info.fields {
 		mut ptr_amp := if field.typ.is_ptr() { '&' } else { '' }
 		mut prefix := ''
@@ -758,7 +759,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 			}
 		}
 		// handle circular ref type of struct to the struct itself
-		if styp == field_styp {
+		if styp == field_styp && !allow_circular {
 			fn_builder.write_string('res.str += new string("<circular>")')
 		} else {
 			// manage C charptr

--- a/vlib/v/tests/tag_autostr_allowrecurse_test.v
+++ b/vlib/v/tests/tag_autostr_allowrecurse_test.v
@@ -1,0 +1,23 @@
+[autostr: allowrecurse]
+struct Node {
+	a &Node = unsafe { nil }
+	b &Node = unsafe { nil }
+}
+
+fn test_stringifying_a_value_of_a_struct_tagged_with_autostr_allowrecurse() {
+	abc := &Node{
+		a: &Node{
+			b: &Node{}
+		}
+		b: &Node{
+			a: &Node{}
+		}
+	}
+	// println(abc)
+	s := abc.str()
+	assert !s.contains('&<circular>')
+	assert s.contains('a: &Node{')
+	assert s.contains('a: &nil')
+	assert s.contains('b: &Node{')
+	assert s.contains('b: &nil')
+}


### PR DESCRIPTION
This PR implements the `[autostr: allowrecurse]` struct attribute to hint to the compiler that it is safe to dereference recursive structures without fear of a circular reference.

A `[autostr: allowrecurse]` struct attribute can be used to guarantee that in printing operations, the entirety of a node tree is dereferenced.

```v
[autostr: allowrecurse]
struct Node {
	a &Node = unsafe { nil }
	b &Node = unsafe { nil }
}

fn main() {
	abc := &Node{
		a: &Node{
			b: &Node{}
		}
		b: &Node{
			a: &Node{}
		}
	}
	println(abc)
} 
```

Without `allowrecurse`:
```
&Node{
    a: &<circular>
    b: &<circular>
}
```
With `allowrecurse`:
```
&Node{
    a: &Node{
        a: &nil
        b: &Node{
            a: &nil
            b: &nil
        }
    }
    b: &Node{
        a: &Node{
            a: &nil
            b: &nil
        }
        b: &nil
    }
}
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
