### PR TITLE
parser: fix type alias of fn with mut argument (fix #16970)

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -804,9 +804,9 @@ fn (mut p Parser) fn_args() ([]ast.Param, bool, bool) {
 	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
 		|| (p.peek_tok.kind == .comma && (p.table.known_type(argname) || is_generic_type))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar || p.fn_language == .c
-		|| (p.tok.kind == .key_mut && (p.peek_token(2).kind == .comma
-		|| p.peek_token(2).kind == .rpar || (p.peek_tok.kind == .name
-		&& p.peek_token(2).kind == .dot)))
+		|| (p.tok.kind == .key_mut && (p.peek_tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
+		|| p.peek_token(2).kind == .comma || p.peek_token(2).kind == .rpar
+		|| (p.peek_tok.kind == .name && p.peek_token(2).kind == .dot)))
 	// TODO copy paste, merge 2 branches
 	if types_only {
 		mut arg_no := 1

--- a/vlib/v/tests/type_alias_of_fn_with_mut_args_test.v
+++ b/vlib/v/tests/type_alias_of_fn_with_mut_args_test.v
@@ -1,0 +1,13 @@
+type MutCallback = fn (mut []string)
+
+fn mutate(mut ss []string, cb MutCallback) {
+	cb(mut ss)
+}
+
+fn test_type_alias_of_fn_with_mut_args() {
+	mut s := ['a']
+	mutate(mut s, fn (mut ss []string) {
+		ss << 'b'
+	})
+	assert s == ['a', 'b']
+}


### PR DESCRIPTION
This PR fix type alias of fn with mut argument (fix #16970).

- Fix type alias of fn with mut argument.
- Add test.

```v
type MutCallback = fn (mut []string)

fn mutate(mut ss []string, cb MutCallback) {
	cb(mut ss)
}

fn main() {
	mut s := ['a']
	mutate(mut s, fn (mut ss []string) {
		ss << 'b'
	})
	println(s)
	assert s == ['a', 'b']
}

PS D:\Test\v\tt1> v run .
['a', 'b']
```