### PR TITLE
checker: fix postfix var checking break

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3505,7 +3505,7 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 
 pub fn (mut c Checker) is_comptime_var(node ast.Expr) bool {
 	return c.inside_comptime_for_field && node is ast.Ident
-		&& (node as ast.Ident).info is ast.IdentVar && ((node as ast.Ident).obj as ast.Var).is_comptime_field
+		&& (node as ast.Ident).info is ast.IdentVar && (node as ast.Ident).kind == .variable && ((node as ast.Ident).obj as ast.Var).is_comptime_field
 }
 
 fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {

--- a/vlib/v/checker/tests/undefined_var_in_comptime_for_test.out
+++ b/vlib/v/checker/tests/undefined_var_in_comptime_for_test.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/undefined_var_in_comptime_for_test.vv:11:3: error: undefined ident: `fields_len`
+    9 | fn test[U](val U) {
+   10 |     $for field in U.fields {
+   11 |         fields_len++
+      |         ~~~~~~~~~~
+   12 |         println(field)
+   13 |     }

--- a/vlib/v/checker/tests/undefined_var_in_comptime_for_test.vv
+++ b/vlib/v/checker/tests/undefined_var_in_comptime_for_test.vv
@@ -1,0 +1,18 @@
+module main
+
+struct Struct {
+	b string
+	a ?string
+	c string
+}
+
+fn test[U](val U) {
+	$for field in U.fields {
+		fields_len++
+		println(field)
+	}
+}
+
+fn test_main() {
+	test(Struct{})
+}


### PR DESCRIPTION
```V
    $for field in U.fields {
		value := val.$(field.name)
		if value.str() != 'Option(error: none)' {
			fields_len++ // crashing
		}
	}
```