### PR TITLE
all: clean up multiple `!is` infix expr

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -205,7 +205,7 @@ pub fn (mut c Checker) check(ast_file_ &ast.File) {
 
 	c.stmt_level = 0
 	for mut stmt in ast_file.stmts {
-		if stmt !is ast.ConstDecl && stmt !is ast.GlobalDecl && stmt !is ast.ExprStmt {
+		if stmt !in [ast.ConstDecl, ast.GlobalDecl, ast.ExprStmt] {
 			c.expr_level = 0
 			c.stmt(stmt)
 		}
@@ -3360,9 +3360,7 @@ fn (mut c Checker) select_expr(mut node ast.SelectExpr) ast.Type {
 					}
 				} else {
 					if branch.stmt.expr is ast.InfixExpr {
-						if branch.stmt.expr.left !is ast.Ident
-							&& branch.stmt.expr.left !is ast.SelectorExpr
-							&& branch.stmt.expr.left !is ast.IndexExpr {
+						if branch.stmt.expr.left !in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
 							c.error('channel in `select` key must be predefined', branch.stmt.expr.left.pos())
 						}
 					} else {
@@ -3374,8 +3372,7 @@ fn (mut c Checker) select_expr(mut node ast.SelectExpr) ast.Type {
 				expr := branch.stmt.right[0]
 				match expr {
 					ast.PrefixExpr {
-						if expr.right !is ast.Ident && expr.right !is ast.SelectorExpr
-							&& expr.right !is ast.IndexExpr {
+						if expr.right !in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
 							c.error('channel in `select` key must be predefined', expr.right.pos())
 						}
 						if expr.or_block.kind != .absent {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -609,7 +609,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 				.key_in, .not_in {
 					if cond.left in [ast.SelectorExpr, ast.TypeNode] && cond.right is ast.ArrayInit {
 						for expr in cond.right.exprs {
-							if expr !is ast.ComptimeType && expr !is ast.TypeNode {
+							if expr !in [ast.ComptimeType, ast.TypeNode] {
 								c.error('invalid `\$if` condition, only types are allowed',
 									expr.pos())
 							}
@@ -708,8 +708,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 				}
 				// `$if some_var {}`, or `[if user_defined_tag] fn abc(){}`
 				typ := c.unwrap_generic(c.expr(cond))
-				if cond.obj !is ast.Var && cond.obj !is ast.ConstField
-					&& cond.obj !is ast.GlobalField {
+				if cond.obj !in [ast.Var, ast.ConstField, ast.GlobalField] {
 					if !c.inside_ct_attr {
 						c.error('unknown var: `${cname}`', pos)
 					}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2255,12 +2255,8 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 				} else if left_name == right_name {
 					c.error('`.sort()` cannot use same argument', node.pos)
 				}
-				if (node.args[0].expr.left !is ast.Ident
-					&& node.args[0].expr.left !is ast.SelectorExpr
-					&& node.args[0].expr.left !is ast.IndexExpr)
-					|| (node.args[0].expr.right !is ast.Ident
-					&& node.args[0].expr.right !is ast.SelectorExpr
-					&& node.args[0].expr.right !is ast.IndexExpr) {
+				if node.args[0].expr.left !in [ast.Ident, ast.SelectorExpr, ast.IndexExpr]
+					|| node.args[0].expr.right !in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
 					c.error('`.sort()` can only use ident, index or selector as argument, \ne.g. `arr.sort(a < b)`, `arr.sort(a.id < b.id)`, `arr.sort(a[0] < b[0])`',
 						node.pos)
 				}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -393,7 +393,7 @@ fn (f Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) 
 		stmt := node
 		prev_stmt := prev_node
 		// Force a newline after a block of HashStmts
-		if prev_stmt is ast.HashStmt && stmt !is ast.HashStmt && stmt !is ast.ExprStmt {
+		if prev_stmt is ast.HashStmt && stmt !in [ast.HashStmt, ast.ExprStmt] {
 			return true
 		}
 		// Force a newline after function declarations

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -45,8 +45,8 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 			g.write('\t\t')
 		}
 		for i, expr in node.exprs {
-			if node.expr_types[i] == ast.string_type && expr !is ast.StringLiteral
-				&& expr !is ast.StringInterLiteral {
+			if node.expr_types[i] == ast.string_type
+				&& expr !in [ast.StringLiteral, ast.StringInterLiteral] {
 				g.write('string_clone(')
 				g.expr(expr)
 				g.write(')')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2857,7 +2857,7 @@ fn (mut g Gen) get_ternary_name(name string) string {
 }
 
 fn (mut g Gen) gen_clone_assignment(val ast.Expr, typ ast.Type, add_eq bool) bool {
-	if val !is ast.Ident && val !is ast.SelectorExpr {
+	if val !in [ast.Ident, ast.SelectorExpr] {
 		return false
 	}
 	right_sym := g.table.sym(typ)

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -227,7 +227,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				guard_idx = i
 				guard_vars = []string{len: node.branches.len}
 			}
-			if cond.expr !is ast.IndexExpr && cond.expr !is ast.PrefixExpr {
+			if cond.expr !in [ast.IndexExpr, ast.PrefixExpr] {
 				var_name := g.new_tmp_var()
 				guard_vars[i] = var_name
 				g.writeln('${g.typ(cond.expr_type)} ${var_name};')

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -326,7 +326,7 @@ fn (f Gen) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) 
 		stmt := node
 		prev_stmt := prev_node
 		// Force a newline after a block of HashStmts
-		if prev_stmt is ast.HashStmt && stmt !is ast.HashStmt && stmt !is ast.ExprStmt {
+		if prev_stmt is ast.HashStmt && stmt !in [ast.HashStmt, ast.ExprStmt] {
 			return true
 		}
 		// Force a newline after function declarations

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -2810,7 +2810,7 @@ fn (mut g JsGen) gen_if_expr(node ast.IfExpr) {
 				guard_idx = i
 				guard_vars = []string{len: node.branches.len}
 			}
-			if cond.expr !is ast.IndexExpr && cond.expr !is ast.PrefixExpr {
+			if cond.expr !in [ast.IndexExpr, ast.PrefixExpr] {
 				var_name := g.new_tmp_var()
 				guard_vars[i] = var_name
 				g.writeln('let ${var_name};')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2069,9 +2069,8 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	} else if !p.pref.translated && !p.is_translated && !p.pref.is_fmt && !p.pref.is_vet
 		&& tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select] {
 		for node in left {
-			if (is_top_level || p.tok.kind != .rcbr) && node !is ast.CallExpr
-				&& node !is ast.PostfixExpr && node !is ast.ComptimeCall
-				&& node !is ast.SelectorExpr && node !is ast.DumpExpr {
+			if (is_top_level || p.tok.kind != .rcbr)
+				&& node !in [ast.CallExpr, ast.PostfixExpr, ast.ComptimeCall, ast.SelectorExpr, ast.DumpExpr] {
 				is_complex_infix_expr := node is ast.InfixExpr
 					&& (node as ast.InfixExpr).op in [.left_shift, .right_shift, .unsigned_right_shift, .arrow]
 				if !is_complex_infix_expr {


### PR DESCRIPTION
This PR clean up multiple `!is` infix expr.