### PR TITLE
cgen: fix struct init with chan field (fix #16996)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5910,7 +5910,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 				for field in info.fields {
 					field_sym := g.table.sym(field.typ)
 					if field.has_default_expr
-						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .u8, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_] {
+						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .u8, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_, .chan] {
 						field_name := c_name(field.name)
 						if field.has_default_expr {
 							mut expr_str := ''

--- a/vlib/v/tests/struct_init_with_chan_field_test.v
+++ b/vlib/v/tests/struct_init_with_chan_field_test.v
@@ -1,0 +1,19 @@
+struct Abc {
+	def Def
+}
+
+struct Def {
+	ch chan string
+}
+
+fn test_struct_init_with_chan_field() {
+	abc1 := Abc{Def{}}
+	println('printing abc1')
+	println(abc1) // this works
+
+	abc2 := Abc{}
+	println('printing abc2')
+	println(abc2) // this gives invalid memory access
+
+	assert '${abc1}' == '${abc2}'
+}


### PR DESCRIPTION
This PR fix struct init with chan field (fix #16996).

- Fix struct init with chan field.
- Add test.

```v
struct Abc {
	def Def
}

struct Def {
	ch chan string
}

fn main() {
	abc1 := Abc{Def{}}
	println('printing abc1')
	println(abc1) // this works

	abc2 := Abc{}
	println('printing abc2')
	println(abc2) // this gives invalid memory access

	assert '${abc1}' == '${abc2}'
}

PS D:\Test\v\tt1> v run .
printing abc1
Abc{
    def: Def{
        ch: chan string{cap: 0, closed: 0}
    }
}
printing abc2
Abc{
    def: Def{
        ch: chan string{cap: 0, closed: 0}
    }
}
```