### PR TITLE
ast: fix const values defined in the wrong order (fix #16995)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2284,6 +2284,9 @@ pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
 			for elem_expr in expr.exprs {
 				names << t.dependent_names_in_expr(elem_expr)
 			}
+			names << t.dependent_names_in_expr(expr.len_expr)
+			names << t.dependent_names_in_expr(expr.cap_expr)
+			names << t.dependent_names_in_expr(expr.default_expr)
 		}
 		CallExpr {
 			for arg in expr.args {

--- a/vlib/v/slow_tests/inout/printing_const_array.out
+++ b/vlib/v/slow_tests/inout/printing_const_array.out
@@ -1,0 +1,9 @@
+[Info{
+    val: 'No data'
+}, Info{
+    val: 'Data tag 1'
+}, Info{
+    val: 'Data tag 2'
+}, Info{
+    val: 'No data'
+}]

--- a/vlib/v/slow_tests/inout/printing_const_array.vv
+++ b/vlib/v/slow_tests/inout/printing_const_array.vv
@@ -1,0 +1,13 @@
+const (
+	dat = 'Data tag ,No data'.split(',')
+	dd  = []Info{len: 4, init: Info{if it in tag { dat[0] + it.str() } else { dat[1] }}}
+	tag = [1, 2]
+)
+
+struct Info {
+	val string
+}
+
+fn main() {
+	println(dd)
+}


### PR DESCRIPTION
This PR fix const values defined in the wrong order (fix #16995).

- Fix const values defined in the wrong order.
- Add test.

```v
const (
	dat = 'Data tag ,No data'.split(',')
	dd  = []Info{len: 4, init: Info{if it in tag { dat[0] + it.str() } else { dat[1] }}}
	tag = [1, 2]
)

struct Info {
	val string
}

fn main() {
	println(dd)
}

PS D:\Test\v\tt1> v run .
[Info{
    val: 'No data'
}, Info{
    val: 'Data tag 1'
}, Info{
    val: 'Data tag 2'
}, Info{
    val: 'No data'
}]
```