### PR TITLE
all: clean up multiple `is` infix expr

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -526,8 +526,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 					}
 				}
 				.key_in, .not_in {
-					if (cond.left is ast.TypeNode || cond.left is ast.SelectorExpr)
-						&& cond.right is ast.ArrayInit {
+					if cond.left in [ast.TypeNode, ast.SelectorExpr] && cond.right is ast.ArrayInit {
 						checked_type := g.get_expr_type(cond.left)
 
 						for expr in cond.right.exprs {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2262,7 +2262,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 				}
 				return
 			} else if arg_sym.kind == .sum_type && exp_sym.kind == .sum_type
-				&& (arg.expr is ast.Ident || arg.expr is ast.SelectorExpr) {
+				&& arg.expr in [ast.Ident, ast.SelectorExpr] {
 				g.write('&/*sum*/')
 				g.expr(arg.expr)
 				return

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -343,7 +343,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		}
 		g.indent--
 	} else if node.kind == .string {
-		cond := if node.cond is ast.StringLiteral || node.cond is ast.StringInterLiteral {
+		cond := if node.cond in [ast.StringLiteral, ast.StringInterLiteral] {
 			ast.Expr(g.new_ctemp_var_then_gen(node.cond, ast.string_type))
 		} else {
 			node.cond

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1544,9 +1544,8 @@ fn (mut g JsGen) gen_const_decl(it ast.ConstDecl) {
 			g.push_pub_var(field.name)
 		}
 
-		if field.expr is ast.StringInterLiteral || field.expr is ast.StringLiteral
-			|| field.expr is ast.IntegerLiteral || field.expr is ast.FloatLiteral
-			|| field.expr is ast.BoolLiteral {
+		if field.expr in [ast.StringInterLiteral, ast.StringLiteral, ast.IntegerLiteral, ast.FloatLiteral,
+			ast.BoolLiteral] {
 			g.write('const ${g.js_name(field.name)} = ')
 			g.expr(field.expr)
 		} else {


### PR DESCRIPTION
This PR clean up multiple `is` infix expr.