### PR TITLE
checker: add error for `type Alias = map[string]Alias` (fix #17008)

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -784,8 +784,9 @@ fn (t Tree) alias_type_decl(node ast.AliasTypeDecl) &Node {
 	mut obj := new_object()
 	obj.add_terse('ast_type', t.string_node('AliasTypeDecl'))
 	obj.add_terse('name', t.string_node(node.name))
-	obj.add_terse('is_pub', t.bool_node(node.is_pub))
+	obj.add_terse('typ', t.type_node(node.typ))
 	obj.add_terse('parent_type', t.type_node(node.parent_type))
+	obj.add_terse('is_pub', t.bool_node(node.is_pub))
 	obj.add('comments', t.array_node_comment(node.comments))
 	obj.add('pos', t.pos(node.pos))
 	return obj

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1183,6 +1183,7 @@ pub struct AliasTypeDecl {
 pub:
 	name        string
 	is_pub      bool
+	typ         Type
 	parent_type Type
 	pos         token.Pos
 	type_pos    token.Pos

--- a/vlib/v/checker/tests/recursive_alias_type_err.out
+++ b/vlib/v/checker/tests/recursive_alias_type_err.out
@@ -1,0 +1,50 @@
+vlib/v/checker/tests/recursive_alias_type_err.vv:1:24: error: recursive declarations of aliases are not allowed - the alias `VTableTypeArray` is used in the array
+    1 | type VTableTypeArray = []VTableTypeArray
+      |                        ~~~~~~~~~~~~~~~~~
+    2 | type VTableTypeArrayPointer = []&VTableTypeArrayPointer
+    3 |
+vlib/v/checker/tests/recursive_alias_type_err.vv:2:31: error: recursive declarations of aliases are not allowed - the alias `VTableTypeArrayPointer` is used in the array
+    1 | type VTableTypeArray = []VTableTypeArray
+    2 | type VTableTypeArrayPointer = []&VTableTypeArrayPointer
+      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 | 
+    4 | type VTableTypeArrayFixed = [5]VTableTypeArrayFixed
+vlib/v/checker/tests/recursive_alias_type_err.vv:4:29: error: recursive declarations of aliases are not allowed - the alias `VTableTypeArrayFixed` is used in the fixed array
+    2 | type VTableTypeArrayPointer = []&VTableTypeArrayPointer
+    3 | 
+    4 | type VTableTypeArrayFixed = [5]VTableTypeArrayFixed
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~
+    5 | type VTableTypeArrayFixedPointer = [5]&VTableTypeArrayFixedPointer
+    6 |
+vlib/v/checker/tests/recursive_alias_type_err.vv:5:36: error: recursive declarations of aliases are not allowed - the alias `VTableTypeArrayFixedPointer` is used in the fixed array
+    3 | 
+    4 | type VTableTypeArrayFixed = [5]VTableTypeArrayFixed
+    5 | type VTableTypeArrayFixedPointer = [5]&VTableTypeArrayFixedPointer
+      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    6 | 
+    7 | type VTableTypeMap = map[string]VTableTypeMap
+vlib/v/checker/tests/recursive_alias_type_err.vv:7:22: error: recursive declarations of aliases are not allowed - the alias `VTableTypeMap` is used in the map value
+    5 | type VTableTypeArrayFixedPointer = [5]&VTableTypeArrayFixedPointer
+    6 | 
+    7 | type VTableTypeMap = map[string]VTableTypeMap
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~
+    8 | type VTableTypeMapOfPointer = map[string]&VTableTypeMapOfPointer
+    9 |
+vlib/v/checker/tests/recursive_alias_type_err.vv:8:31: error: recursive declarations of aliases are not allowed - the alias `VTableTypeMapOfPointer` is used in the map value
+    6 | 
+    7 | type VTableTypeMap = map[string]VTableTypeMap
+    8 | type VTableTypeMapOfPointer = map[string]&VTableTypeMapOfPointer
+      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 | 
+   10 | type VTableTypeMapKey = map[VTableTypeMapKey]int
+vlib/v/checker/tests/recursive_alias_type_err.vv:10:25: error: recursive declarations of aliases are not allowed - the alias `VTableTypeMapKey` is used in the map key
+    8 | type VTableTypeMapOfPointer = map[string]&VTableTypeMapOfPointer
+    9 | 
+   10 | type VTableTypeMapKey = map[VTableTypeMapKey]int
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~
+   11 | type VTableTypeMapOfPointerKey = map[&VTableTypeMapOfPointerKey]int
+vlib/v/checker/tests/recursive_alias_type_err.vv:11:34: error: recursive declarations of aliases are not allowed - the alias `VTableTypeMapOfPointerKey` is used in the map key
+    9 | 
+   10 | type VTableTypeMapKey = map[VTableTypeMapKey]int
+   11 | type VTableTypeMapOfPointerKey = map[&VTableTypeMapOfPointerKey]int
+      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/recursive_alias_type_err.vv
+++ b/vlib/v/checker/tests/recursive_alias_type_err.vv
@@ -1,0 +1,11 @@
+type VTableTypeArray = []VTableTypeArray
+type VTableTypeArrayPointer = []&VTableTypeArrayPointer
+
+type VTableTypeArrayFixed = [5]VTableTypeArrayFixed
+type VTableTypeArrayFixedPointer = [5]&VTableTypeArrayFixedPointer
+
+type VTableTypeMap = map[string]VTableTypeMap
+type VTableTypeMapOfPointer = map[string]&VTableTypeMapOfPointer
+
+type VTableTypeMapKey = map[VTableTypeMapKey]int
+type VTableTypeMapOfPointerKey = map[&VTableTypeMapOfPointerKey]int

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4000,6 +4000,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 	return ast.AliasTypeDecl{
 		name: name
 		is_pub: is_pub
+		typ: idx
 		parent_type: parent_type
 		type_pos: type_pos.extend(type_end_pos)
 		pos: decl_pos


### PR DESCRIPTION
Fix #17008 by disallowing recursive alias declarations with more precise/helpful error messages