### PR TITLE
checker, cgen: fix for in mut array with mul operation (fix #17019)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -69,7 +69,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		c.error('invalid number of operand for `${node.op}`. Only one allowed on each side.',
 			left_right_pos)
 	}
-	if left_type.is_any_kind_of_pointer()
+	if left_type.is_any_kind_of_pointer() && !node.left.is_auto_deref_var()
 		&& node.op in [.plus, .minus, .mul, .div, .mod, .xor, .amp, .pipe] {
 		if !c.pref.translated && ((right_type.is_any_kind_of_pointer() && node.op != .minus)
 			|| (!right_type.is_any_kind_of_pointer() && node.op !in [.plus, .minus])) {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -966,7 +966,12 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 	}
 	g.expr(node.left)
 	g.write(' ${node.op.str()} ')
-	g.expr_with_cast(node.right, node.right_type, node.left_type)
+	if node.right_type.is_ptr() && node.right.is_auto_deref_var() {
+		g.write('*')
+		g.expr(node.right)
+	} else {
+		g.expr_with_cast(node.right, node.right_type, node.left_type)
+	}
 }
 
 fn (mut g Gen) op_arg(expr ast.Expr, expected ast.Type, got ast.Type) {

--- a/vlib/v/tests/for_in_mut_array_with_mul_test.v
+++ b/vlib/v/tests/for_in_mut_array_with_mul_test.v
@@ -1,0 +1,8 @@
+fn test_for_in_mut_array_with_mul() {
+	mut ints_a := [1, 2]
+	for mut i in ints_a {
+		i = i * i
+	}
+	print('${ints_a}')
+	assert ints_a == [1, 4]
+}


### PR DESCRIPTION
This PR fix for in mut array with mul operation (fix #17019).

- Fix for in mut array with mul operation.
- Add test.

```v
fn main() {
	mut ints_a := [1, 2]
	for mut i in ints_a {
		i = i * i
	}
	print('${ints_a}')
	assert ints_a == [1, 4]
}

PS D:\Test\v\tt1> v run .
[1, 4]
```