### PR TITLE
Fix deprecated import

### DIFF
--- a/cmd/tools/vcreate.v
+++ b/cmd/tools/vcreate.v
@@ -301,7 +301,7 @@ fn (mut c Create) set_web_project_files() {
 		path: '${c.name}/src/databases/config_databases_sqlite.v'
 		content: "module databases
 
-import sqlite // can change to 'mysql', 'pg'
+import db.sqlite // can change to 'db.mysql', 'db.pg'
 
 pub fn create_db_connection() !sqlite.DB {
 	mut db := sqlite.connect('vweb.sql')!

--- a/examples/vweb_fullstack/src/databases/config_databases_sqlite.v
+++ b/examples/vweb_fullstack/src/databases/config_databases_sqlite.v
@@ -1,6 +1,6 @@
 module databases
 
-import sqlite // can change to 'mysql', 'pg'
+import db.sqlite // can change to 'db.mysql', 'db.pg'
 
 pub fn create_db_connection() !sqlite.DB {
 	mut db := sqlite.connect('vweb.sql')!

--- a/vlib/v/tests/orm_stmt_wrong_return_checking_test.v
+++ b/vlib/v/tests/orm_stmt_wrong_return_checking_test.v
@@ -1,4 +1,4 @@
-import sqlite
+import db.sqlite
 
 struct Target {
 pub mut:


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all`.
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR fixes an import statement from 3 files.
They use `import sqlite`, which will be deprecated after 2023-02-01.
Note that  #16820 fixed almost every other DB import statement.