### PR TITLE
checker: fix generic fn infering error with alias argument (fix #17022)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -865,7 +865,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 
 			if param.typ.has_flag(.generic) && param_type_sym.name == gt_name {
 				typ = ast.mktyp(arg.typ)
-				sym := c.table.sym(arg.typ)
+				sym := c.table.final_sym(arg.typ)
 				if sym.info is ast.FnType {
 					mut func_ := sym.info.func
 					func_.name = ''
@@ -898,7 +898,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					typ = typ.set_nr_muls(0)
 				}
 			} else if param.typ.has_flag(.generic) {
-				arg_sym := c.table.sym(arg.typ)
+				arg_sym := c.table.final_sym(arg.typ)
 				if param.typ.has_flag(.variadic) {
 					typ = ast.mktyp(arg.typ)
 				} else if arg_sym.kind == .array && param_type_sym.kind == .array {

--- a/vlib/v/slow_tests/inout/generic_fn_with_alias_arg.out
+++ b/vlib/v/slow_tests/inout/generic_fn_with_alias_arg.out
@@ -1,0 +1,12 @@
+MyStruct[int]{
+    a: 0
+}
+MyStructAlias(MyStruct[int]{
+    a: 0
+})
+MyStruct[int]{
+    a: 0
+}
+MyStructAlias(MyStruct[int]{
+    a: 0
+})

--- a/vlib/v/slow_tests/inout/generic_fn_with_alias_arg.vv
+++ b/vlib/v/slow_tests/inout/generic_fn_with_alias_arg.vv
@@ -1,0 +1,23 @@
+struct MyStruct[T] {
+	a T
+}
+
+fn mprint[T](s MyStruct[T]) {
+	println(s)
+}
+
+fn mprint_with_alias(s MyStructAlias) {
+	println(s)
+}
+
+type MyStructAlias = MyStruct[int]
+
+fn main() {
+	a := MyStruct[int]{}
+	mprint(a)              // works
+	mprint_with_alias(a)   // works
+
+	b := MyStructAlias{}
+	mprint(b)              // does not work, requires mprint[int](b)
+	mprint_with_alias(b)   // works
+}


### PR DESCRIPTION
This PR fix generic fn infering error with alias argument (fix #17022).

- Fix generic fn infering error with alias argument.
- Add test.

```v
struct MyStruct[T] {
	a T
}

fn mprint[T](s MyStruct[T]) {
	println(s)
}

fn mprint_with_alias(s MyStructAlias) {
	println(s)
}

type MyStructAlias = MyStruct[int]

fn main() {
	a := MyStruct[int]{}
	mprint(a)              // works
	mprint_with_alias(a)   // works

	b := MyStructAlias{}
	mprint(b)              // does not work, requires mprint[int](b)
	mprint_with_alias(b)   // works
}

PS D:\Test\v\tt1> v run .
MyStruct[int]{
    a: 0
}
MyStructAlias(MyStruct[int]{
    a: 0
})
MyStruct[int]{
    a: 0
}
MyStructAlias(MyStruct[int]{
    a: 0
})
```