### PR TITLE
checker: relax checks on operators done on aliases of primitives like int, u8, string etc.; add tests

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -576,10 +576,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			} else {
 				if !parent_sym.is_primitive() {
 					if left_name == right_name {
-						c.error('undefined operation ${left_name} ${extracted_op} ${right_name}',
+						c.error('undefined operation `${left_name}` ${extracted_op} `${right_name}`',
 							node.pos)
 					} else {
-						c.error('mismatched types ${left_name} and ${right_name}', node.pos)
+						c.error('mismatched types `${left_name}` and `${right_name}`',
+							node.pos)
 					}
 				}
 			}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -553,7 +553,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			right_name := c.table.type_to_str(right_type_unwrapped)
 			parent_sym := c.table.final_sym(left_type_unwrapped)
 			if left_sym.kind == .alias && right_sym.kind != .alias {
-				c.error('mismatched types `${left_name}` and `${right_name}`', node.pos)
+				if !parent_sym.is_primitive() {
+					c.error('mismatched types `${left_name}` and `${right_name}`', node.pos)
+				}
 			}
 			extracted_op := match node.op {
 				.plus_assign { '+' }
@@ -570,17 +572,6 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				if method.return_type != left_type_unwrapped {
 					c.error('operator `${extracted_op}` must return `${left_name}` to be used as an assignment operator',
 						node.pos)
-				}
-			} else {
-				if parent_sym.is_primitive() {
-					c.error('cannot use operator methods on type alias for `${parent_sym.name}`',
-						node.pos)
-				}
-				if left_name == right_name {
-					c.error('undefined operation `${left_name}` ${extracted_op} `${right_name}`',
-						node.pos)
-				} else {
-					c.error('mismatched types `${left_name}` and `${right_name}`', node.pos)
 				}
 			}
 		}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -573,6 +573,15 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					c.error('operator `${extracted_op}` must return `${left_name}` to be used as an assignment operator',
 						node.pos)
 				}
+			} else {
+				if !parent_sym.is_primitive() {
+					if left_name == right_name {
+						c.error('undefined operation ${left_name} ${extracted_op} ${right_name}',
+							node.pos)
+					} else {
+						c.error('mismatched types ${left_name} and ${right_name}', node.pos)
+					}
+				}
 			}
 		}
 		if !is_blank_ident && !left.is_auto_deref_var() && !right.is_auto_deref_var()

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -301,8 +301,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					} else if node.name in ['<', '=='] && node.return_type != ast.bool_type {
 						c.error('operator comparison methods should return `bool`', node.pos)
 					} else if parent_sym.is_primitive() {
-						c.error('cannot define operator methods on type alias for `${parent_sym.name}`',
-							node.pos)
+						// aliases of primitive types are explicitly allowed
 					} else if receiver_type != param_type {
 						srtype := c.table.type_to_str(receiver_type)
 						sptype := c.table.type_to_str(param_type)

--- a/vlib/v/checker/tests/method_op_alias_err.out
+++ b/vlib/v/checker/tests/method_op_alias_err.out
@@ -19,7 +19,7 @@ vlib/v/checker/tests/method_op_alias_err.vv:8:1: error: cannot define operator m
       | ~~~~~~~~~~~~~~~~~~~~~~~~~
     9 |     return Foo(f + f1)
    10 | }
-vlib/v/checker/tests/method_op_alias_err.vv:14:6: error: mismatched types `Foo` and `string`
+vlib/v/checker/tests/method_op_alias_err.vv:14:6: error: operator `+` must return `Foo` to be used as an assignment operator
    12 | fn main() {
    13 |    mut f := Foo('fg')
    14 |    f += 'fg'
@@ -33,10 +33,3 @@ vlib/v/checker/tests/method_op_alias_err.vv:15:9: error: cannot assign to `f`: e
       |         ~~~~~~~~~
    16 |    f -= Foo('fo') 
    17 |     println(f)
-vlib/v/checker/tests/method_op_alias_err.vv:16:6: error: cannot use operator methods on type alias for `string`
-   14 |    f += 'fg'
-   15 |    f *= Foo2('2')
-   16 |    f -= Foo('fo') 
-      |      ~~
-   17 |     println(f)
-   18 | }

--- a/vlib/v/checker/tests/method_op_alias_err.out
+++ b/vlib/v/checker/tests/method_op_alias_err.out
@@ -12,13 +12,6 @@ vlib/v/checker/tests/method_op_alias_err.vv:5:17: error: infix expr: cannot use 
       |                 ~~~~~~
     6 | }
     7 |
-vlib/v/checker/tests/method_op_alias_err.vv:8:1: error: cannot define operator methods on type alias for `string`
-    6 | }
-    7 | 
-    8 | fn (f Foo) * (f1 Foo) Foo {
-      | ~~~~~~~~~~~~~~~~~~~~~~~~~
-    9 |     return Foo(f + f1)
-   10 | }
 vlib/v/checker/tests/method_op_alias_err.vv:14:6: error: operator `+` must return `Foo` to be used as an assignment operator
    12 | fn main() {
    13 |    mut f := Foo('fg')

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -275,7 +275,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 			mut op_overloaded := false
 			mut op_expected_left := ast.Type(0)
 			mut op_expected_right := ast.Type(0)
-			if var_type == ast.string_type_idx && node.op == .plus_assign {
+			if node.op == .plus_assign && unaliased_right_sym.kind == .string {
 				if left is ast.IndexExpr {
 					// a[0] += str => `array_set(&a, 0, &(string[]) {string__plus(...))})`
 					g.expr(left)

--- a/vlib/v/tests/alias_basic_types_test.v
+++ b/vlib/v/tests/alias_basic_types_test.v
@@ -4,16 +4,12 @@ type MyInt = int
 
 type MyString = string
 
-fn ok() {
-	assert true
-}
-
 // bytes
 fn test_byte_aliasing() {
 	dump(u8(123))
 	dump(MyByte(u8(123)))
 	dump(u8(MyByte(u8(123))))
-	ok()
+	assert true
 }
 
 fn test_pbyte_aliasing() {
@@ -22,7 +18,7 @@ fn test_pbyte_aliasing() {
 		dump(voidptr(&MyByte(&u8(123))))
 		dump(voidptr(&u8(&MyByte(&u8(123)))))
 	}
-	ok()
+	assert true
 }
 
 // ints
@@ -30,7 +26,7 @@ fn test_int_aliasing() {
 	dump(int(123))
 	dump(int(MyInt(123)))
 	dump(MyInt(int(MyInt(123))))
-	ok()
+	assert true
 }
 
 fn test_pint_aliasing() {
@@ -39,7 +35,7 @@ fn test_pint_aliasing() {
 		dump(voidptr(&MyInt(&int(123456))))
 		dump(voidptr(&int(&MyInt(&int(123456)))))
 	}
-	ok()
+	assert true
 }
 
 // strings
@@ -52,7 +48,7 @@ fn test_string_aliasing() {
 		dump(string(MyString('abc')))
 		dump(MyString(string(MyString('abc'))))
 	}
-	ok()
+	assert true
 }
 
 fn test_pstring_aliasing() {
@@ -62,5 +58,25 @@ fn test_pstring_aliasing() {
 		dump(voidptr(&string(&MyString(&s))))
 		dump(voidptr(&MyString(&string(&MyString(&s)))))
 	}
-	ok()
+	assert true
+}
+
+//
+
+struct MyStruct {
+mut:
+	a MyInt
+	b MyByte
+}
+
+fn test_modifying_a_struct_using_an_alias_to_int() {
+	mut my_struct := MyStruct{}
+	my_struct.a += 5
+	my_struct.b += 10
+	println(my_struct)
+	assert my_struct.a == 5
+	my_struct.a += 3
+	my_struct.b += 20
+	assert my_struct.a == 8
+	assert my_struct.b == 30
 }

--- a/vlib/v/tests/alias_basic_types_test.v
+++ b/vlib/v/tests/alias_basic_types_test.v
@@ -4,6 +4,8 @@ type MyInt = int
 
 type MyString = string
 
+type Foo = string
+
 // bytes
 fn test_byte_aliasing() {
 	dump(u8(123))
@@ -84,4 +86,29 @@ fn test_modifying_a_struct_using_an_alias_to_int() {
 	assert my_struct.a == 8
 	assert my_struct.b == 30
 	assert my_struct.c == 'abcdef'
+}
+
+fn (f Foo) + (f1 Foo) Foo {
+	return '${f} _+_ ${f1}'
+}
+
+fn (f Foo) - (f1 Foo) Foo {
+	return '${f} _-_ ${f1}'
+}
+
+fn (f Foo) * (f1 Foo) Foo {
+	return '${f} _*_ ${f1}'
+}
+
+fn (f Foo) / (f1 Foo) Foo {
+	return '${f} _/_ ${f1}'
+}
+
+fn test_op_overrides_for_string_aliases() {
+	a := Foo('abc')
+	b := Foo('def')
+	assert a + b == 'abc _+_ def'
+	assert a - b == 'abc _-_ def'
+	assert a * b == 'abc _*_ def'
+	assert a / b == 'abc _/_ def'
 }

--- a/vlib/v/tests/alias_basic_types_test.v
+++ b/vlib/v/tests/alias_basic_types_test.v
@@ -67,16 +67,21 @@ struct MyStruct {
 mut:
 	a MyInt
 	b MyByte
+	c MyString
 }
 
 fn test_modifying_a_struct_using_an_alias_to_int() {
 	mut my_struct := MyStruct{}
 	my_struct.a += 5
 	my_struct.b += 10
-	println(my_struct)
-	assert my_struct.a == 5
+	my_struct.c += 'abc'
+	//
 	my_struct.a += 3
 	my_struct.b += 20
+	my_struct.c += 'def'
+	println(my_struct)
+	//
 	assert my_struct.a == 8
 	assert my_struct.b == 30
+	assert my_struct.c == 'abcdef'
 }


### PR DESCRIPTION
Fix #17023 .

Allow using +,-,*,/ and += etc for aliases of int like i32, allow the op method overriding for the aliases too.