### PR TITLE
tests: correct the test comment in generic_fn_with_alias_arg.vv

### DIFF
--- a/vlib/v/slow_tests/inout/generic_fn_with_alias_arg.vv
+++ b/vlib/v/slow_tests/inout/generic_fn_with_alias_arg.vv
@@ -14,10 +14,10 @@ type MyStructAlias = MyStruct[int]
 
 fn main() {
 	a := MyStruct[int]{}
-	mprint(a)              // works
-	mprint_with_alias(a)   // works
+	mprint(a)
+	mprint_with_alias(a)
 
 	b := MyStructAlias{}
-	mprint(b)              // does not work, requires mprint[int](b)
-	mprint_with_alias(b)   // works
+	mprint(b)
+	mprint_with_alias(b)
 }


### PR DESCRIPTION
This PR correct the test comment in generic_fn_with_alias_arg.vv.