### PR TITLE
json2: perf time encode. around 2x faster

### DIFF
--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -236,9 +236,9 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut wr io.Writer) ! {
 			$if field.typ is string {
 				e.encode_string(val.$(field.name).str(), mut wr)!
 			} $else $if field.typ is time.Time {
-				wr.write([u8(`\\"`)])!
+				wr.write(json2.quote_bytes)!
 				wr.write(val.$(field.name).format_rfc3339().bytes())!
-				wr.write([u8(`\\"`)])!
+				wr.write(json2.quote_bytes)!
 			} $else $if field.typ in [bool, $Float, $Int] {
 				wr.write(val.$(field.name).str().bytes())!
 			} $else $if field.is_array {

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -236,8 +236,9 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut wr io.Writer) ! {
 			$if field.typ is string {
 				e.encode_string(val.$(field.name).str(), mut wr)!
 			} $else $if field.typ is time.Time {
-				parsed_time := val.$(field.name) as time.Time
-				e.encode_string(parsed_time.format_rfc3339(), mut wr)!
+				wr.write([u8(`\\"`)])!
+				wr.write(val.$(field.name).format_rfc3339().bytes())!
+				wr.write([u8(`\\"`)])!
 			} $else $if field.typ in [bool, $Float, $Int] {
 				wr.write(val.$(field.name).str().bytes())!
 			} $else $if field.is_array {
@@ -432,6 +433,7 @@ fn (mut iter CharLengthIterator) next() ?int {
 	return len
 }
 
+// TODO - Need refactor. Is so slow. The longer the string, the lower the performance.
 // encode_string returns the JSON spec-compliant version of the string.
 [manualfree]
 fn (e &Encoder) encode_string(s string, mut wr io.Writer) ! {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63821277/213798724-85b16672-c4bf-4386-b259-9dd0dfc19294.png)
`v run`
![image](https://user-images.githubusercontent.com/63821277/213798842-20a7d48c-52be-4af2-b806-8078de4d1170.png)

