### PR TITLE
cgen: fix generic struct no_key init (fix #17040)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -86,7 +86,14 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		if !field.typ.has_flag(.shared_f) {
 			g.is_shared = false
 		}
-		inited_fields[field.name] = i
+		mut field_name := field.name
+		if node.no_keys && sym.kind == .struct_ {
+			info := sym.info as ast.Struct
+			if info.fields.len == node.fields.len {
+				field_name = info.fields[i].name
+			}
+		}
+		inited_fields[field_name] = i
 		if sym.kind != .struct_ {
 			if field.typ == 0 {
 				g.checker_bug('struct init, field.typ is 0', field.pos)
@@ -203,6 +210,12 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 						t_generic_names, t_concrete_types)
 					{
 						sfield.expected_type = tt
+					}
+				}
+				if node.no_keys && sym.kind == .struct_ {
+					sym_info := sym.info as ast.Struct
+					if sym_info.fields.len == node.fields.len {
+						sfield.name = sym_info.fields[already_initalised_node_field_index].name
 					}
 				}
 				g.struct_init_field(sfield, sym.language)

--- a/vlib/v/tests/generics_struct_no_key_init_test.v
+++ b/vlib/v/tests/generics_struct_no_key_init_test.v
@@ -1,0 +1,12 @@
+struct Am {
+	inner int
+}
+
+fn convert[T](num int) T {
+	return T{num}
+}
+
+fn test_generic_struct_no_key_init() {
+	println(convert[Am](3).inner)
+	assert convert[Am](3).inner == 3
+}


### PR DESCRIPTION
This PR fix generic struct no_key init (fix #17040).

- Fix generic struct no_key init.
- Add test.

```v
struct Am {
	inner int
}

fn convert[T](num int) T {
	return T{num}
}

fn main() {
	println(convert[Am](3).inner)
	assert convert[Am](3).inner == 3
}

PS D:\Test\v\tt1> v run .
3
```