### PR TITLE
ast: fix const dependency order for consts initialised with ast.SelectorExpr (fix #15049)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2339,6 +2339,9 @@ pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
 		PrefixExpr {
 			names << t.dependent_names_in_expr(expr.right)
 		}
+		SelectorExpr {
+			names << t.dependent_names_in_expr(expr.expr)
+		}
 		StructInit {
 			for field in expr.fields {
 				names << t.dependent_names_in_expr(field.expr)

--- a/vlib/v/tests/const_call_expr_order_test.v
+++ b/vlib/v/tests/const_call_expr_order_test.v
@@ -10,7 +10,9 @@ const (
 fn test_const_call_expr_order() {
 	dump(cache_dir)
 	dump(shdc)
-	assert true
+	assert shdc.contains(cache_dir)
+	assert shdc.contains(tool_name)
+	assert shdc.ends_with(shdc_exe_name)
 }
 
 fn shdc_exe() string {

--- a/vlib/v/tests/const_selector_expr_order_test.v
+++ b/vlib/v/tests/const_selector_expr_order_test.v
@@ -1,0 +1,26 @@
+struct Abc {
+	version string
+	name    string
+}
+
+fn abc() !Abc {
+	return Abc{
+		version: 'abc'
+		name: 'xyz'
+	}
+}
+
+// Note: version depends on a field in manifest, even though it is declared before it
+pub const version = manifest.version
+
+pub const manifest = abc() or { panic(err) }
+
+// Note: name depends on a field in manifest too, but it is declared after it
+pub const name = manifest.name
+
+fn test_order_of_const_initialisation_should_take_into_account_selector_expressions() {
+	println(version)
+	println(name)
+	assert version == 'abc'
+	assert name == 'xyz'
+}


### PR DESCRIPTION
Fix #15049 .

```v
module main

import v.vmod

pub const manifest = vmod.from_file('v.mod') or { panic(err) }

pub const (
	version = manifest.version
	name    = manifest.name
)
```

... now properly initialises the const `version` after `manifest` was initialised.

Previously it was done before `manifest` was assigned the value from the function call, which led to `version` having .str == 0 -> println(version) was outputing `println(NIL)` instead.