### PR TITLE
os: rework mv so it works with different partitions

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -211,9 +211,9 @@ pub fn file_size(path string) u64 {
 	return 0
 }
 
-// mv moves files or folders from `src` to `dst`.
-// if you are not sure that the source and target are on the same mount/partition use mv_by_cp
-pub fn mv(src string, dst string) ! {
+// rename renames the file or folder from `src` to `dst`.
+// Use mv to move or rename a file in a platform independent manner.
+pub fn rename(src string, dst string) ! {
 	mut rdst := dst
 	if is_dir(rdst) {
 		rdst = join_path_single(rdst.trim_right(path_separator), file_name(src.trim_right(path_separator)))

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -126,6 +126,11 @@ pub fn mv_by_cp(source string, target string) ! {
 	rm(source)!
 }
 
+// mv moves files or folders from `src` to `dst`.
+pub fn mv(source string, target string) ! {
+	rename(source, target) or { mv_by_cp(source, target)! }
+}
+
 // read_lines reads the file in `path` into an array of lines.
 [manualfree]
 pub fn read_lines(path string) ![]string {

--- a/vlib/os/os_js.js.v
+++ b/vlib/os/os_js.js.v
@@ -123,6 +123,20 @@ pub fn cp(src string, dst string) ! {
 	}
 }
 
+pub fn rename(src string, dst string) ! {
+	$if js_node {
+		err := ''
+		#try {
+		#$fs.renameSync(src.str,dst.str);
+		#return;
+		#} catch (e) {
+		#err.str = 'failed to rename ' + src.str + ' to ' + dst.str + ': ' + e.toString();
+		#}
+
+		return error(err)
+	}
+}
+
 pub fn read_file(s string) !string {
 	mut err := ''
 	err = err


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Fixes #16985 .
Moves the existing `os.mv` implementation to `os.rename`.
The new `os.mv` first tries to move/rename with the old fast platform specific version and falls back to `os.mv_by_cp` if the former didn't work.

Note: We should somehow add a test to cover "moving files from one partition to another", but I'm currently unsure how to do that.
