### PR TITLE
os/uname: fix WinOS uname() recipe

### DIFF
--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -458,16 +458,24 @@ pub fn debugger_present() bool {
 	return C.IsDebuggerPresent()
 }
 
+// `uname` is not standardized, so mimic current practices
+// busybox-v1.35.0 * `busybox uname -a` => "Windows_NT HOSTNAME 10.0 19044 x86_64 MS/Windows"
+// rust/coreutils-v0.0.17 * `coreutils uname -a` => `Windows_NT HOSTNAME 10.0 19044 x86_64 MS/Windows (Windows 10)`
+// Python3 => `uname_result(system='Windows', node='HOSTNAME', release='10', version='10.0.19044', machine='AMD64')`
+// ref: [NT Version Info](https://en.wikipedia.org/wiki/Windows_NT) @@ <https://archive.is/GnnvF>
+// ref: [NT Version Info (detailed)](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions#NT_Kernel-based_2)
 pub fn uname() Uname {
-	sys_and_ver := execute('cmd /c ver').output.split('[')
 	nodename := hostname()
-	machine := getenv('PROCESSOR_ARCHITECTURE')
+	// ToDO: environment variables have low reliability; check for another quick way
+	machine := getenv('PROCESSOR_ARCHITECTURE') // * note: 'AMD64' == 'x86_64' (not standardized, but 'x86_64' use is more common; but, python == 'AMD64')
+	version_info := execute('cmd /d/c ver').output
+	version_n := (version_info.split(' '))[3].replace(']', '').trim_space()
 	return Uname{
-		sysname: sys_and_ver[0].trim_space()
+		sysname: 'Windows_NT' // as of 2022-12, WinOS has only two possible kernels ~ 'Windows_NT' or 'Windows_9x'
 		nodename: nodename
-		release: sys_and_ver[1].replace(']', '')
-		version: sys_and_ver[0] + '[' + sys_and_ver[1]
 		machine: machine
+		release: (version_n.split('.'))[0..2].join('.').trim_space() // Major.minor-only == "primary"/release version
+		version: (version_n.split('.'))[2]
 	}
 }
 

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -473,9 +473,9 @@ pub fn uname() Uname {
 	return Uname{
 		sysname: 'Windows_NT' // as of 2022-12, WinOS has only two possible kernels ~ 'Windows_NT' or 'Windows_9x'
 		nodename: nodename
-		machine: machine
+		machine: machine.trim_space()
 		release: (version_n.split('.'))[0..2].join('.').trim_space() // Major.minor-only == "primary"/release version
-		version: (version_n.split('.'))[2]
+		version: (version_n.split('.'))[2].trim_space()
 	}
 }
 


### PR DESCRIPTION
Fix somewhat messy and scattered `uname()`, instead mimicking other current utilities (busybox/uutils).