### PR TITLE
checker: check generic struct no_keys init (fix #17061)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -387,6 +387,14 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 				field.typ = c.expr(field.expr)
 				field.expected_type = field.typ
 			}
+			sym := c.table.sym(c.unwrap_generic(node.typ))
+			if sym.kind == .struct_ {
+				info := sym.info as ast.Struct
+				if node.no_keys && node.fields.len != info.fields.len {
+					c.error('struct `${sym.name}` no_keys init expected `${info.fields.len}` fields, but got `${node.fields.len}`',
+						node.pos)
+				}
+			}
 		}
 		// string & array are also structs but .kind of string/array
 		.struct_, .string, .array, .alias {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -391,7 +391,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct
 				if node.no_keys && node.fields.len != info.fields.len {
-					c.error('initializing struct `${sym.name}` needs `${info.fields.len}` field${if info.fields.len != 1 { 's' } else { '' }}, but got `${node.fields.len}`',
+					fname := if info.fields.len != 1 { 'fields' } else { 'field' }
+					c.error('initializing struct `${sym.name}` needs `${info.fields.len}` ${fname}, but got `${node.fields.len}`',
 						node.pos)
 				}
 			}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -391,7 +391,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct
 				if node.no_keys && node.fields.len != info.fields.len {
-					c.error('struct `${sym.name}` no_keys init expected `${info.fields.len}` fields, but got `${node.fields.len}`',
+					c.error('initializing struct `${sym.name}` needs `${info.fields.len}` field${if info.fields.len != 1 { 's' } else { '' }}, but got `${node.fields.len}`',
 						node.pos)
 				}
 			}

--- a/vlib/v/checker/tests/generics_struct_nokeys_init_err.out
+++ b/vlib/v/checker/tests/generics_struct_nokeys_init_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/generics_struct_nokeys_init_err.vv:6:9: error: struct `Am` no_keys init expected `1` fields, but got `2`
-    4 |
+vlib/v/checker/tests/generics_struct_nokeys_init_err.vv:6:9: error: initializing struct `Am` needs `1` field, but got `2`
+    4 | 
     5 | fn convert[T](num int) T {
     6 |     return T{num, 1}
       |            ~~~~~~~~~

--- a/vlib/v/checker/tests/generics_struct_nokeys_init_err.out
+++ b/vlib/v/checker/tests/generics_struct_nokeys_init_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_struct_nokeys_init_err.vv:6:9: error: struct `Am` no_keys init expected `1` fields, but got `2`
+    4 |
+    5 | fn convert[T](num int) T {
+    6 |     return T{num, 1}
+      |            ~~~~~~~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/generics_struct_nokeys_init_err.vv
+++ b/vlib/v/checker/tests/generics_struct_nokeys_init_err.vv
@@ -1,0 +1,12 @@
+struct Am {
+	inner int
+}
+
+fn convert[T](num int) T {
+	return T{num, 1}
+}
+
+fn main() {
+	println(convert[Am](3).inner)
+	assert convert[Am](3).inner == 3
+}


### PR DESCRIPTION
This PR check generic struct no_keys init (fix #17061).

- Check generic struct no_keys init.
- Add test.

```v
struct Am {
	inner int
}

fn convert[T](num int) T {
	return T{num, 1}
}

fn main() {
	println(convert[Am](3).inner)
	assert convert[Am](3).inner == 3
}

PS D:\Test\v\tt1> v run .
tt1.v:4:9: error: struct `Am` no_keys init expected `1` fields, but got `2`
    2 |
    3 | fn convert[T](num int) T {
    4 |     return T{num, 1}
      |            ~~~~~~~~~
    5 | }
    6 |
```