### PR TITLE
checker: minor cleanup in infer_fn_generic_types()

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1010,7 +1010,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 		}
 		if c.pref.is_verbose {
 			s := c.table.type_to_str(typ)
-			println('inferred `${func.name}<${s}>`')
+			println('inferred `${func.name}[${s}]`')
 		}
 		inferred_types << c.unwrap_generic(typ)
 		node.concrete_types << typ


### PR DESCRIPTION
This PR makes a minor cleanup in infer_fn_generic_types().

- Change generic seperator `<>` to `[]`.