### PR TITLE
checker: check fn call using 'none' as argument (fix #17057)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1019,6 +1019,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 		}
 		arg_typ_sym := c.table.sym(arg_typ)
+		if arg_typ_sym.kind == .none_ {
+			c.error('cannot use `none` as function argument', call_arg.pos)
+		}
 		param_typ_sym := c.table.sym(param.typ)
 		if func.is_variadic && arg_typ.has_flag(.variadic) && node.args.len - 1 > i {
 			c.error('when forwarding a variadic variable, it must be the final argument',
@@ -1747,6 +1750,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 						1} to `${method_name}`', arg.pos)
 				}
 				continue
+			}
+			if final_arg_sym.kind == .none_ {
+				c.error('cannot use `none` as method argument', arg.pos)
 			}
 			if param.typ.is_ptr() && !arg.typ.is_real_pointer() && arg.expr.is_literal()
 				&& !c.pref.translated {

--- a/vlib/v/checker/tests/fn_call_using_none_arg_err.out
+++ b/vlib/v/checker/tests/fn_call_using_none_arg_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_call_using_none_arg_err.vv:6:4: error: cannot use `none` as function argument
+    4 |
+    5 | fn main() {
+    6 |     f(none)
+      |       ~~~~
+    7 | }

--- a/vlib/v/checker/tests/fn_call_using_none_arg_err.vv
+++ b/vlib/v/checker/tests/fn_call_using_none_arg_err.vv
@@ -1,0 +1,7 @@
+fn f[T](v T) {
+	println(v)
+}
+
+fn main() {
+	f(none)
+}


### PR DESCRIPTION
This PR check fn call using 'none' as argument (fix #17057).

- Check fn call using 'none' as argument.
- Add test.

```v
fn f[T](v T) {
	println(v)
}

fn main() {
	f(none)
}

PS D:\Test\v\tt1> v run .
tt1.v:6:4: error: cannot use `none` as function argument
    4 |
    5 | fn main() {
    6 |     f(none)
      |       ~~~~
    7 | }
```