### PR TITLE
Feat add multi-platform portability to string `split_into_lines()`

### DIFF
--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -792,7 +792,7 @@ pub fn (s string) split_into_lines() []string {
 	if s.len == 0 {
 		return res
 	}
-	#res.arr.arr = s.str.split("\n")
+	#res.arr.arr = s.str.split(/\r?\n|\r/)
 	#if (res.arr.arr[res.arr.arr.length-1] == "") res.arr.arr.pop();
 	#res.arr.len = new int(res.arr.arr.length);
 	#res.arr.cap = new int(res.arr.arr.length);

--- a/vlib/builtin/js/string_test.js.v
+++ b/vlib/builtin/js/string_test.js.v
@@ -791,10 +791,18 @@ fn filter(b u8) bool {
 	return b != `a`
 }
 
-/*
 fn test_split_into_lines() {
-	line_content := 'Line'
-	text_crlf := '$line_content\r\n$line_content\r\n$line_content'
+	line_content := 'line content'
+
+	text_cr := '${line_content}\r${line_content}\r${line_content}'
+	lines_cr := text_cr.split_into_lines()
+
+	assert lines_cr.len == 3
+	for line in lines_cr {
+		assert line == line_content
+	}
+
+	text_crlf := '${line_content}\r\n${line_content}\r\n${line_content}'
 	lines_crlf := text_crlf.split_into_lines()
 
 	assert lines_crlf.len == 3
@@ -802,15 +810,31 @@ fn test_split_into_lines() {
 		assert line == line_content
 	}
 
-	text_lf := '$line_content\n$line_content\n$line_content'
+	text_lf := '${line_content}\n${line_content}\n${line_content}'
 	lines_lf := text_lf.split_into_lines()
 
 	assert lines_lf.len == 3
 	for line in lines_lf {
 		assert line == line_content
 	}
+
+	text_mixed := '${line_content}\n${line_content}\r${line_content}'
+	lines_mixed := text_mixed.split_into_lines()
+
+	assert lines_mixed.len == 3
+	for line in lines_mixed {
+		assert line == line_content
+	}
+
+	text_mixed_trailers := '${line_content}\n${line_content}\r${line_content}\r\r\r\n\n\n\r\r'
+	lines_mixed_trailers := text_mixed_trailers.split_into_lines()
+
+	assert lines_mixed_trailers.len == 9
+	for line in lines_mixed_trailers {
+		assert (line == line_content) || (line == '')
+	}
 }
-*/
+
 fn test_string_literal_with_backslash() {
 	a := 'HelloWorld'
 	assert a == 'HelloWorld'

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -883,7 +883,16 @@ fn filter(b u8) bool {
 }
 
 fn test_split_into_lines() {
-	line_content := 'Line'
+	line_content := 'line content'
+
+	text_cr := '${line_content}\r${line_content}\r${line_content}'
+	lines_cr := text_cr.split_into_lines()
+
+	assert lines_cr.len == 3
+	for line in lines_cr {
+		assert line == line_content
+	}
+
 	text_crlf := '${line_content}\r\n${line_content}\r\n${line_content}'
 	lines_crlf := text_crlf.split_into_lines()
 
@@ -898,6 +907,22 @@ fn test_split_into_lines() {
 	assert lines_lf.len == 3
 	for line in lines_lf {
 		assert line == line_content
+	}
+
+	text_mixed := '${line_content}\n${line_content}\r${line_content}'
+	lines_mixed := text_mixed.split_into_lines()
+
+	assert lines_mixed.len == 3
+	for line in lines_mixed {
+		assert line == line_content
+	}
+
+	text_mixed_trailers := '${line_content}\n${line_content}\r${line_content}\r\r\r\n\n\n\r\r'
+	lines_mixed_trailers := text_mixed_trailers.split_into_lines()
+
+	assert lines_mixed_trailers.len == 9
+	for line in lines_mixed_trailers {
+		assert (line == line_content) || (line == '')
 	}
 }
 


### PR DESCRIPTION
* fixes and increases cross-platform portability of `split_into_lines()`; now has MacOS (`\r`), POSIX (`\n`), and WinOS (`\r\n`) compatibility
* added/revised tests for the updated capability
* also fixes the builtin/js version and activated/corrected it's tests as well

Could you explain the *builtin/js* version? I did correct it's function and activated the respective test, but I'm not sure about the applicability.

Anyway, CI with all tests (both *builtin* and *builtin/js*) are now passing.