### PR TITLE
docs: add `__global` to keyword list

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6394,7 +6394,7 @@ use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp run`.
 
 ## Appendix I: Keywords
 
-V has 42 reserved keywords (3 are literals):
+V has 43 reserved keywords (3 are literals):
 
 ```v ignore
 as
@@ -6438,6 +6438,7 @@ typeof
 union
 unsafe
 volatile
+__global
 __offsetof
 ```
 See also [V Types](#v-types).


### PR DESCRIPTION
`__global` cannot be used as identifier so it can be treated like `__offsetof` as keyword.

See https://play.vlang.io/p/f7142536dc