### PR TITLE
`vlib/gx`: add missing docs or update previous docs

### DIFF
--- a/vlib/gx/color.v
+++ b/vlib/gx/color.v
@@ -223,7 +223,7 @@ pub fn (c Color) / (c2 Color) Color {
 	}
 }
 
-// over - implements an `a` over `b` operation.
+// over implements an `a` over `b` operation.
 // see https://keithp.com/~keithp/porterduff/p253-porter.pdf
 pub fn (a Color) over(b Color) Color {
 	aa := f32(a.a) / 255
@@ -251,21 +251,21 @@ pub fn (c Color) str() string {
 	return 'Color{${c.r}, ${c.g}, ${c.b}, ${c.a}}'
 }
 
-// rgba8 - convert a color value to an int in the RGBA8 order.
+// rgba8 converts a color value to an int in the RGBA8 order.
 // see https://developer.apple.com/documentation/coreimage/ciformat
 [inline]
 pub fn (c Color) rgba8() int {
 	return int(u32(c.r) << 24 | u32(c.g) << 16 | u32(c.b) << 8 | u32(c.a))
 }
 
-// bgra8 - convert a color value to an int in the BGRA8 order.
+// bgra8 converts a color value to an int in the BGRA8 order.
 // see https://developer.apple.com/documentation/coreimage/ciformat
 [inline]
 pub fn (c Color) bgra8() int {
 	return int(u32(c.b) << 24 | u32(c.g) << 16 | u32(c.r) << 8 | u32(c.a))
 }
 
-// abgr8 - convert a color value to an int in the ABGR8 order.
+// abgr8 converts a color value to an int in the ABGR8 order.
 // see https://developer.apple.com/documentation/coreimage/ciformat
 [inline]
 pub fn (c Color) abgr8() int {

--- a/vlib/gx/image.v
+++ b/vlib/gx/image.v
@@ -9,6 +9,7 @@ pub:
 	height int
 }
 
+// is_empty returns true if the Image `i` is empty.
 pub fn (i Image) is_empty() bool {
 	return i.obj == unsafe { nil }
 }

--- a/vlib/gx/text.v
+++ b/vlib/gx/text.v
@@ -20,6 +20,8 @@ pub:
 	italic         bool
 }
 
+// to_css_string returns a CSS compatible string of the TextCfg `cfg`.
+// For example: `'mono 14px serif'`.
 pub fn (cfg TextCfg) to_css_string() string {
 	mut font_style := ''
 	if cfg.bold {


### PR DESCRIPTION
Sorry it's a short PR today for low-hanging fruits (eyes are a bit sore and need to rest) :see_no_evil: 

Add missing documentation for all remaining public functions inside `vlib/gx/` per `v missdoc vlib/gx/` command for [#7047](https://github.com/vlang/v/issues/7047).

The following could be updated to [#7047](https://github.com/vlang/v/issues/7047):

- [x] vlib/gx/color.v
- [x] vlib/gx/image.v
- [x] vlib/gx/text.v

