### PR TITLE
cgen: autofree bug in `or` block for array of strings

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -314,7 +314,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.write('))')
 			}
 		}
-		if needs_clone {
+		if !gen_or && needs_clone {
 			g.write(')')
 		}
 		if gen_or {


### PR DESCRIPTION
Fixed #16964 