### PR TITLE
builtin: fix wrong module name

### DIFF
--- a/vlib/builtin/linux_bare/old/.checks/linuxsys/linuxsys.v
+++ b/vlib/builtin/linux_bare/old/.checks/linuxsys/linuxsys.v
@@ -1,6 +1,6 @@
 module main
 
-import builtin.linux_bare.old..checks.forkedtest
+import builtin.linux_bare.old.checks.forkedtest
 
 const (
 	sample_text_file1 = ''

--- a/vlib/builtin/linux_bare/old/.checks/string/string.v
+++ b/vlib/builtin/linux_bare/old/.checks/string/string.v
@@ -1,6 +1,6 @@
 module main
 
-import builtin.linux_bare.old..checks.forkedtest
+import builtin.linux_bare.old.checks.forkedtest
 
 fn check_string_eq() {
 	assert 'monkey' != 'rat'


### PR DESCRIPTION
It's strange that it worked at all, but somehow it seems we can't write like that.