### PR TITLE
ast: is_primitive ignores bool type

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -855,8 +855,13 @@ pub fn (t &TypeSymbol) is_number() bool {
 }
 
 [inline]
+pub fn (t &TypeSymbol) is_bool() bool {
+	return t.kind == .bool
+}
+
+[inline]
 pub fn (t &TypeSymbol) is_primitive() bool {
-	return t.is_number() || t.is_pointer() || t.is_string()
+	return t.is_number() || t.is_pointer() || t.is_string() || t.is_bool()
 }
 
 [inline]


### PR DESCRIPTION
I need to use `is_primitive()`, and noticed that it ignores boolean types. Is it deliberate or not?