### PR TITLE
v: support an optional `fn cleanup() {` in each module, to complement the existing optional `fn init() {`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5378,7 +5378,7 @@ fn (mut g Gen) write_init_function() {
 			g.writeln(g.cleanups[mod_name].str())
 		}
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
-	}	
+	}
 	for mod_name in g.table.modules {
 		cleanup_fn_name := '${mod_name}.cleanup'
 		if cleanupfn := g.table.find_fn(cleanup_fn_name) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5378,6 +5378,17 @@ fn (mut g Gen) write_init_function() {
 			g.writeln(g.cleanups[mod_name].str())
 		}
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
+	}	
+	for mod_name in g.table.modules {
+		cleanup_fn_name := '${mod_name}.cleanup'
+		if cleanupfn := g.table.find_fn(cleanup_fn_name) {
+			if cleanupfn.return_type == ast.void_type && cleanupfn.params.len == 0 {
+				g.writeln('\t// Cleaning up for module ${mod_name}')
+				mod_c_name := util.no_dots(mod_name)
+				cleanup_fn_c_name := '${mod_c_name}__cleanup'
+				g.writeln('\t${cleanup_fn_c_name}();')
+			}
+		}
 	}
 	g.writeln('}')
 	if g.pref.printfn_list.len > 0 && '_vcleanup' in g.pref.printfn_list {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5363,10 +5363,10 @@ fn (mut g Gen) write_init_function() {
 		cleanup_fn_name := '${mod_name}.cleanup'
 		if cleanupfn := g.table.find_fn(cleanup_fn_name) {
 			if cleanupfn.return_type == ast.void_type && cleanupfn.params.len == 0 {
-				cleaning_up_array << ('\t// Cleaning up for module ${mod_name}')
 				mod_c_name := util.no_dots(mod_name)
 				cleanup_fn_c_name := '${mod_c_name}__cleanup'
-				cleaning_up_array << ('\t${cleanup_fn_c_name}();')
+				cleaning_up_array << '\t${cleanup_fn_c_name}();'
+				cleaning_up_array << '\t// Cleaning up for module ${mod_name}'
 			}
 		}
 	}
@@ -5390,9 +5390,8 @@ fn (mut g Gen) write_init_function() {
 		}
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
 	}
-	for i := cleaning_up_array.len - 1; i >= 1; i -= 2 {
-		g.writeln(cleaning_up_array[i - 1])
-		g.writeln(cleaning_up_array[i])
+	for x in cleaning_up_array.reverse() {
+		g.writeln(x)
 	}
 	g.writeln('}')
 	if g.pref.printfn_list.len > 0 && '_vcleanup' in g.pref.printfn_list {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5329,6 +5329,8 @@ fn (mut g Gen) write_init_function() {
 		}
 	}
 
+	mut cleaning_up_array := []string{cap: g.table.modules.len}
+
 	for mod_name in g.table.modules {
 		if g.has_reflection && mod_name == 'v.reflection' {
 			// ignore v.reflection already initialized above
@@ -5358,6 +5360,15 @@ fn (mut g Gen) write_init_function() {
 				g.writeln('\t${init_fn_c_name}();')
 			}
 		}
+		cleanup_fn_name := '${mod_name}.cleanup'
+		if cleanupfn := g.table.find_fn(cleanup_fn_name) {
+			if cleanupfn.return_type == ast.void_type && cleanupfn.params.len == 0 {
+				cleaning_up_array << ('\t// Cleaning up for module ${mod_name}')
+				mod_c_name := util.no_dots(mod_name)
+				cleanup_fn_c_name := '${mod_c_name}__cleanup'
+				cleaning_up_array << ('\t${cleanup_fn_c_name}();')
+			}
+		}
 	}
 
 	g.writeln('}')
@@ -5379,16 +5390,9 @@ fn (mut g Gen) write_init_function() {
 		}
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
 	}
-	for mod_name in g.table.modules {
-		cleanup_fn_name := '${mod_name}.cleanup'
-		if cleanupfn := g.table.find_fn(cleanup_fn_name) {
-			if cleanupfn.return_type == ast.void_type && cleanupfn.params.len == 0 {
-				g.writeln('\t// Cleaning up for module ${mod_name}')
-				mod_c_name := util.no_dots(mod_name)
-				cleanup_fn_c_name := '${mod_c_name}__cleanup'
-				g.writeln('\t${cleanup_fn_c_name}();')
-			}
-		}
+	for i := cleaning_up_array.len - 1; i >= 1; i -= 2 {
+		g.writeln(cleaning_up_array[i - 1])
+		g.writeln(cleaning_up_array[i])
 	}
 	g.writeln('}')
 	if g.pref.printfn_list.len > 0 && '_vcleanup' in g.pref.printfn_list {


### PR DESCRIPTION
why not use cleanup like .init() too, example:
```
fn main(){
        println('text')
}

fn init() {
        println('init')
}

fn cleanup(){
        println('clean')
}
```
produce:
```
init
text
clean
```
I know that will more rare than .init() but in some c libraries can be usefull to not give duty to "end-point" programers ... 