### PR TITLE
checker: fixed error pointer for #17108

### DIFF
--- a/vlib/v/checker/tests/for_in_key_redefinition.out
+++ b/vlib/v/checker/tests/for_in_key_redefinition.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/for_in_key_redefinition.vv:4:5: error: redefinition of key iteration variable `value`
+    2 | value := 2
+    3 |
+    4 | for value, _ in arr {
+      |     ~~~~~
+    5 |     println(value)
+    6 | }

--- a/vlib/v/checker/tests/for_in_key_redefinition.vv
+++ b/vlib/v/checker/tests/for_in_key_redefinition.vv
@@ -1,0 +1,6 @@
+arr := [1,2,3]
+value := 2
+
+for value, _ in arr {
+	println(value)
+}

--- a/vlib/v/checker/tests/for_in_value_redefinition.out
+++ b/vlib/v/checker/tests/for_in_value_redefinition.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/for_in_value_redefinition.vv:4:8: error: redefinition of value iteration variable `value`
+    2 | value := 2
+    3 |
+    4 | for _, value in arr {
+      |        ~~~~~
+    5 |     println(value)
+    6 | }

--- a/vlib/v/checker/tests/for_in_value_redefinition.vv
+++ b/vlib/v/checker/tests/for_in_value_redefinition.vv
@@ -1,0 +1,6 @@
+arr := [1,2,3]
+value := 2
+
+for _, value in arr {
+	println(value)
+}

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -121,10 +121,12 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 					val_var_pos)
 			}
 			if p.scope.known_var(key_var_name) {
-				return p.error('redefinition of key iteration variable `${key_var_name}`')
+				return p.error_with_pos('redefinition of key iteration variable `${key_var_name}`',
+					key_var_pos)
 			}
 			if p.scope.known_var(val_var_name) {
-				return p.error('redefinition of value iteration variable `${val_var_name}`')
+				return p.error_with_pos('redefinition of value iteration variable `${val_var_name}`',
+					val_var_pos)
 			}
 			p.scope.register(ast.Var{
 				name: key_var_name


### PR DESCRIPTION
Fixed error pointer for "redefinition of key iteration variable" and "redefinition of value iteration variable" errors

Fixes #17108