### PR TITLE
cgen: fix printing for mut v in arr (fix #17123)

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -16,6 +16,9 @@ fn (mut g Gen) str_format(node ast.StringInterLiteral, i int) (u64, string) {
 	mut base := 0 // numeric base
 	mut upper_case := false // set upercase for the result string
 	mut typ := g.unwrap_generic(node.expr_types[i])
+	if node.exprs[i].is_auto_deref_var() {
+		typ = typ.deref()
+	}
 	sym := g.table.sym(typ)
 
 	if sym.kind == .alias {

--- a/vlib/v/slow_tests/inout/printing_for_mut_v_in_a.out
+++ b/vlib/v/slow_tests/inout/printing_for_mut_v_in_a.out
@@ -1,0 +1,4 @@
+mutable num is 255
+imutable element is 255
+mutable element is 255
+mutable element is 255

--- a/vlib/v/slow_tests/inout/printing_for_mut_v_in_a.vv
+++ b/vlib/v/slow_tests/inout/printing_for_mut_v_in_a.vv
@@ -1,0 +1,21 @@
+fn main() {
+	// check to see if mutable integers work as expected
+	mut num := 255
+	println('mutable num is ${num}')
+
+	mut arr := [255]
+	// check to see if mutable arrays with immutable iteration work as expected
+	for elem in arr {
+		println('imutable element is ${elem}')
+	}
+
+	// check to see if mutable arrays with mutable iteration work as expected
+	for mut elem in arr {
+		println('mutable element is ${elem}')
+	}
+
+	// check to see if mutable arrays with mutable iteration work as expected (explicit format)
+	for mut elem in arr {
+		println('mutable element is ${elem:d}')
+	}
+}


### PR DESCRIPTION
This PR fix printing for mut v in arr (fix #17123).

- Fix printing for mut v in arr.
- Add test.

```v
fn main() {
	// check to see if mutable integers work as expected
	mut num := 255
	println('mutable num is ${num}')

	mut arr := [255]
	// check to see if mutable arrays with immutable iteration work as expected
	for elem in arr {
		println('imutable element is ${elem}')
	}

	// check to see if mutable arrays with mutable iteration work as expected
	for mut elem in arr {
		println('mutable element is ${elem}')
	}

	// check to see if mutable arrays with mutable iteration work as expected (explicit format)
	for mut elem in arr {
		println('mutable element is ${elem:d}')
	}
}

PS D:\Test\v\tt1> v run .
mutable num is 255
imutable element is 255
mutable element is 255
mutable element is 255
```