### PR TITLE
cgen: fix generated code for matchexpr with call expr using propagation

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -67,7 +67,9 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	}
 	if node.cond in [ast.Ident, ast.IntegerLiteral, ast.StringLiteral, ast.FloatLiteral]
 		|| (node.cond is ast.SelectorExpr
-		&& (node.cond as ast.SelectorExpr).or_block.kind == .absent) {
+		&& (node.cond as ast.SelectorExpr).or_block.kind == .absent
+		&& ((node.cond as ast.SelectorExpr).expr !is ast.CallExpr
+		|| ((node.cond as ast.SelectorExpr).expr as ast.CallExpr).or_block.kind == .absent)) {
 		cond_var = g.expr_string(node.cond)
 	} else {
 		line := if is_expr {

--- a/vlib/v/tests/match_expr_with_opt_result_test.v
+++ b/vlib/v/tests/match_expr_with_opt_result_test.v
@@ -1,0 +1,32 @@
+struct Foo {
+pub:
+	a int
+}
+
+fn foo() !Foo {
+	return Foo{1}
+}
+
+fn bar() ?Foo {
+	return Foo{2}
+}
+
+fn test_main() {
+	match foo()!.a {
+		1 {
+			assert true
+		}
+		else {
+			assert false
+		}
+	}
+
+	match bar()?.a {
+		2 {
+			assert true
+		}
+		else {
+			assert false
+		}
+	}
+}


### PR DESCRIPTION
Fix #17146

```V
struct Foo {
pub:
	a int
}

fn foo() !Foo {
	return Foo{1}
}

fn bar() ?Foo {
        return Foo{2}
}

fn main() {
	match foo()!.a {
		1 {
			assert true
		}
		else {
			assert false
		}
	}

        match bar()?.a {
                2 {
                        assert true
                }
                else {
                        assert false
                }
        }
}
``` 