### PR TITLE
cgen: fix generated code for cast with result/option

### DIFF
--- a/vlib/v/tests/cast_expr_with_opt_result_test.v
+++ b/vlib/v/tests/cast_expr_with_opt_result_test.v
@@ -1,0 +1,35 @@
+type Sum = int | string
+
+struct Test {
+}
+
+fn (t Test) test() !Sum {
+	return 0
+}
+
+fn (t Test) test2() ?Sum {
+	return 0
+}
+
+fn ret_sum() !Sum {
+	return 0
+}
+
+fn ret_sum2() ?Sum {
+	return 0
+}
+
+fn test_main() {
+	value := ret_sum() as int
+	assert value == 0
+
+	value2 := ret_sum2() as int
+	assert value2 == 0
+
+	t := Test{}
+	value3 := t.test() as int
+	assert value3 == 0
+
+	value4 := t.test2() as int
+	assert value4 == 0
+}


### PR DESCRIPTION
Fix #17129

This is another way to fix the bug, I just noticed @Delta456 already did a PR for it, not sure what is the desired way to handle such situations.