### PR TITLE
checker, ast: field `promoted_type` for `InfixExpr`

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1350,6 +1350,7 @@ fn (t Tree) infix_expr(node ast.InfixExpr) &Node {
 	obj.add_terse('left_type', t.type_node(node.left_type))
 	obj.add_terse('right', t.expr(node.right))
 	obj.add_terse('right_type', t.type_node(node.right_type))
+	obj.add_terse('promoted_type', t.type_node(node.promoted_type))
 	obj.add('auto_locked', t.string_node(node.auto_locked))
 	obj.add_terse('or_block', t.or_expr(node.or_block))
 	obj.add_terse('is_stmt', t.bool_node(node.is_stmt))

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -870,7 +870,7 @@ pub mut:
 	right         Expr
 	left_type     Type
 	right_type    Type
-	promoted_type Type = void_type 
+	promoted_type Type = void_type
 	auto_locked   string
 	or_block      OrExpr
 	//

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -866,12 +866,13 @@ pub:
 	pos     token.Pos
 	is_stmt bool
 pub mut:
-	left        Expr
-	right       Expr
-	left_type   Type
-	right_type  Type
-	auto_locked string
-	or_block    OrExpr
+	left          Expr
+	right         Expr
+	left_type     Type
+	right_type    Type
+	promoted_type Type = void_type 
+	auto_locked   string
+	or_block      OrExpr
 	//
 	ct_left_value_evaled  bool
 	ct_left_value         ComptTimeConstValue = empty_comptime_const_expr()

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -23,6 +23,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	if node.op == .amp && left_type.is_bool() && right_type.is_bool() && right_type.is_ptr() {
 		pos := node.pos.extend(node.right.pos())
 		c.error('the right expression should be separated from the `&&` by a space', pos)
+		node.promoted_type = ast.bool_type
 		return ast.bool_type
 	}
 	node.right_type = right_type
@@ -188,6 +189,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						node.pos)
 				}
 			}
+			node.promoted_type = ast.bool_type
 			return ast.bool_type
 		}
 		.plus, .minus, .mul, .div, .mod, .xor, .amp, .pipe {
@@ -367,6 +369,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				c.error('only `==` and `!=` are defined on arrays', node.pos)
 			} else if left_sym.kind == .struct_
 				&& (left_sym.info as ast.Struct).generic_types.len > 0 {
+				node.promoted_type = ast.bool_type
 				return ast.bool_type
 			} else if left_sym.kind == .struct_ && right_sym.kind == .struct_
 				&& node.op in [.eq, .lt] {
@@ -489,11 +492,13 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				c.error('cannot append `${right_sym.name}` to `${left_sym.name}`', right_pos)
 				return ast.void_type
 			} else {
-				return c.check_shift(mut node, left_type, right_type)
+				node.promoted_type = c.check_shift(mut node, left_type, right_type)
+				return node.promoted_type
 			}
 		}
 		.right_shift {
-			return c.check_shift(mut node, left_type, right_type)
+			node.promoted_type = c.check_shift(mut node, left_type, right_type)
+			return node.promoted_type
 		}
 		.unsigned_right_shift {
 			modified_left_type := if !left_type.is_int() {
@@ -520,6 +525,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				return ast.void_type
 			}
 
+			typ := c.check_shift(mut node, left_type, right_type)
 			node = ast.InfixExpr{
 				left: ast.CastExpr{
 					expr: node.left
@@ -532,13 +538,14 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				op: .right_shift
 				right: node.right
 				right_type: right_type
+				promoted_type: typ
 				is_stmt: false
 				pos: node.pos
 				auto_locked: node.auto_locked
 				or_block: node.or_block
 			}
 
-			return c.check_shift(mut node, left_type, right_type)
+			return typ
 		}
 		.key_is, .not_is {
 			right_expr := node.right
@@ -579,6 +586,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 				}
 			}
+			node.promoted_type = ast.bool_type
 			return ast.bool_type
 		}
 		.arrow { // `chan <- elem`
@@ -677,6 +685,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			}
 			if left_type.nr_muls() > 0 && right_type.is_int() {
 				// pointer arithmetic is fine, it is checked in other places
+				node.promoted_type = return_type
 				return return_type
 			}
 			c.error('infix expr: cannot use `${right_sym.name}` (right expression) as `${left_sym.name}`',
@@ -698,7 +707,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		c.warn('`++` and `--` are statements, not expressions', node.pos)
 	}
 	*/
-	return if node.op.is_relational() { ast.bool_type } else { return_type }
+	node.promoted_type = if node.op.is_relational() { ast.bool_type } else { return_type }
+	return node.promoted_type
 }
 
 fn (mut c Checker) check_div_mod_by_zero(expr ast.Expr, op_kind token.Kind) {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -525,7 +525,6 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				return ast.void_type
 			}
 
-			typ := c.check_shift(mut node, left_type, right_type)
 			node = ast.InfixExpr{
 				left: ast.CastExpr{
 					expr: node.left
@@ -538,14 +537,15 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				op: .right_shift
 				right: node.right
 				right_type: right_type
-				promoted_type: typ
 				is_stmt: false
 				pos: node.pos
 				auto_locked: node.auto_locked
 				or_block: node.or_block
 			}
 
-			return typ
+			node.promoted_type = c.check_shift(mut node, left_type, right_type)
+
+			return node.promoted_type
 		}
 		.key_is, .not_is {
 			right_expr := node.right


### PR DESCRIPTION
This PR is to solve a problem with infix expressions that popped up whilst developing a new backend.

There is a discrepancy between the resulting type of an infix expression inside the checker and backends.

```v
int + i64 == int // cgen: uses the type on the left hand side
int + i64 == i64 // checker: type promotion, returned value of Checker.expr()
```

For example `cgen` takes the type of the left hand side as the resulting type of the expression, but the checker performs type promotion. It is okay for the checker to do this, however the promoted type is not exposed to/filled in on the infix expression itself.

So the checker can run `c.expr(InfixExpr)` and use that resulting type as the type of the infix expression, but compiler backends will only have `left_type` and `right_type` avaliable.

Take this function.

```v
fn add(a int, b i64) i64 {
    return a / b
}
```

Inside `cgen` the type of `a / b` is `int`. However the return statement reports that the type of `a / b` is i64 due to type promotion (function return value is unrelated).

```v
return_stmt.exprs[0].left_type == int
return_stmt.exprs[0].right_type == i64

return_stmt.types[0] == i64
```

This is okay for `cgen` as it creates temporary variables which cause it to be cast accordingly, then returning the temporary variable. For other backends that are not as flexible? There is simply not enough information to generate code with respect to proper casting.

## impl

- `Checker.expr(InfixExpr)` -> fills in `InfixExpr.promoted_type`
- The return value of `Checker.expr(InfixExpr)` equals the value of `InfixExpr.promoted_type`

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
