### PR TITLE
checker, cgen: fix concrete type resolution on generic call expr

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -847,11 +847,8 @@ fn (g Checker) get_generic_array_element_type(array ast.Array) ast.Type {
 	return typ
 }
 
-fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr, has_reused_gargs bool) {
+fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 	mut inferred_types := []ast.Type{}
-	if has_reused_gargs {
-		node.concrete_types = []
-	}
 	for gi, gt_name in func.generic_names {
 		// skip known types
 		if gi < node.concrete_types.len {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1000,10 +1000,9 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 						idx := generic_names.index(gt_name)
 						typ = concrete_types[idx]
 					}
-				} else if (!node.is_method || i > 0) && c.table.cur_fn.generic_names.len > 0
+				} else if !node.is_method && c.table.cur_fn.generic_names.len > 0
 					&& c.table.cur_fn.params.len > 0 && arg.expr is ast.Ident {
 					var_name := (arg.expr as ast.Ident).name
-
 					for cur_param in c.table.cur_fn.params {
 						if !cur_param.typ.has_flag(.generic) || cur_param.name != var_name {
 							continue
@@ -1017,6 +1016,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 								typ = typ.set_nr_muls(0)
 							}
 						}
+						break
 					}
 				}
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1023,7 +1023,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr, ha
 						typ = concrete_types[idx]
 					}
 				} else if c.table.cur_fn.generic_names.len > 0 && c.table.cur_fn.params.len > 0
-					&& arg.expr is ast.Ident {
+					&& func.generic_names.len > 0 && arg.expr is ast.Ident {
 					var_name := (arg.expr as ast.Ident).name
 					for cur_param in c.table.cur_fn.params {
 						if !cur_param.typ.has_flag(.generic) || cur_param.name != var_name {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -828,15 +828,14 @@ fn (mut c Checker) has_reused_generic_param(func ast.Fn, node ast.CallExpr) bool
 	return false
 }
 
-fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
+fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr, has_reused_gargs bool) {
 	mut inferred_types := []ast.Type{}
-	has_reused_args := func.generic_names.len > 0 && c.has_reused_generic_param(func, node)
-	if has_reused_args {
+	if has_reused_gargs {
 		node.concrete_types = []
 	}
 	for gi, gt_name in func.generic_names {
 		// skip known types
-		if gi < node.concrete_types.len && !has_reused_args {
+		if gi < node.concrete_types.len {
 			inferred_types << node.concrete_types[gi]
 			continue
 		}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1022,26 +1022,8 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr, ha
 						idx := generic_names.index(gt_name)
 						typ = concrete_types[idx]
 					}
-				} else if !node.is_method && c.table.cur_fn.generic_names.len > 0
-					&& c.table.cur_fn.params.len > 0 && arg.expr is ast.Ident {
-					var_name := (arg.expr as ast.Ident).name
-					for cur_param in c.table.cur_fn.params {
-						if !cur_param.typ.has_flag(.generic) || cur_param.name != var_name {
-							continue
-						}
-						typ = c.unwrap_generic(cur_param.typ)
-						parg_sym := c.table.sym(typ)
-						if parg_sym.kind == .array {
-							mut arg_elem_info := parg_sym.info as ast.Array
-							typ = arg_elem_info.elem_type
-							if arg_elem_info.elem_type.nr_muls() > 0 && typ.nr_muls() > 0 {
-								typ = typ.set_nr_muls(0)
-							}
-						}
-						break
-					}
-				} else if node.is_method && c.table.cur_fn.generic_names.len > 0
-					&& c.table.cur_fn.params.len > 0 && arg.expr is ast.Ident {
+				} else if c.table.cur_fn.generic_names.len > 0 && c.table.cur_fn.params.len > 0
+					&& arg.expr is ast.Ident {
 					var_name := (arg.expr as ast.Ident).name
 					for cur_param in c.table.cur_fn.params {
 						if !cur_param.typ.has_flag(.generic) || cur_param.name != var_name {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1000,8 +1000,8 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 						idx := generic_names.index(gt_name)
 						typ = concrete_types[idx]
 					}
-				} else if c.table.cur_fn.generic_names.len > 0 && c.table.cur_fn.params.len > 0
-					&& arg.expr is ast.Ident {
+				} else if (!node.is_method || i > 0) && c.table.cur_fn.generic_names.len > 0
+					&& c.table.cur_fn.params.len > 0 && arg.expr is ast.Ident {
 					var_name := (arg.expr as ast.Ident).name
 
 					for cur_param in c.table.cur_fn.params {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1000,6 +1000,24 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 						idx := generic_names.index(gt_name)
 						typ = concrete_types[idx]
 					}
+				} else if c.table.cur_fn.generic_names.len > 0 && c.table.cur_fn.params.len > 0
+					&& arg.expr is ast.Ident {
+					var_name := (arg.expr as ast.Ident).name
+
+					for cur_param in c.table.cur_fn.params {
+						if !cur_param.typ.has_flag(.generic) || cur_param.name != var_name {
+							continue
+						}
+						typ = c.unwrap_generic(cur_param.typ)
+						parg_sym := c.table.sym(typ)
+						if parg_sym.kind == .array {
+							mut arg_elem_info := parg_sym.info as ast.Array
+							typ = arg_elem_info.elem_type
+							if arg_elem_info.elem_type.nr_muls() > 0 && typ.nr_muls() > 0 {
+								typ = typ.set_nr_muls(0)
+							}
+						}
+					}
 				}
 			}
 		}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1811,7 +1811,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		} else {
 			node.receiver_type = method.params[0].typ
 		}
-		if method.generic_names.len != node.concrete_types.len {
+
+		if method.generic_names.len != node.concrete_types.len
+			|| c.has_reused_generic_param(method, node) {
 			// no type arguments given in call, attempt implicit instantiation
 			c.infer_fn_generic_types(method, mut node)
 			concrete_types = node.concrete_types.map(c.unwrap_generic(it))

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1761,6 +1761,11 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					arg.pos)
 			}
 			c.check_expected_call_arg(got_arg_typ, exp_arg_typ, node.language, arg) or {
+				if c.table.cur_fn.generic_names.len > 0 && param.typ.has_flag(.generic)
+					&& node.concrete_list_pos.len == 1 {
+					// ignores method call repassing generic parameters
+					continue
+				}
 				// str method, allow type with str method if fn arg is string
 				// Passing an int or a string array produces a c error here
 				// Deleting this condition results in propper V error messages

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1221,7 +1221,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 	}
 	if func.generic_names.len != node.concrete_types.len {
 		// no type arguments given in call, attempt implicit instantiation
-		c.infer_fn_generic_types(func, mut node)
+		c.infer_fn_generic_types(func, mut node, false)
 		concrete_types = node.concrete_types.map(c.unwrap_generic(it))
 	}
 	if func.generic_names.len > 0 {
@@ -1812,10 +1812,12 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			node.receiver_type = method.params[0].typ
 		}
 
-		if method.generic_names.len != node.concrete_types.len
-			|| c.has_reused_generic_param(method, node) {
+		if method.generic_names.len != node.concrete_types.len {
 			// no type arguments given in call, attempt implicit instantiation
-			c.infer_fn_generic_types(method, mut node)
+			c.infer_fn_generic_types(method, mut node, false)
+			concrete_types = node.concrete_types.map(c.unwrap_generic(it))
+		} else if c.has_reused_generic_param(method, node) {
+			c.infer_fn_generic_types(method, mut node, true)
 			concrete_types = node.concrete_types.map(c.unwrap_generic(it))
 		}
 		if concrete_types.len > 0 && !concrete_types[0].has_flag(.generic) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1275,12 +1275,18 @@ fn (mut g Gen) resolve_generic_call_args(func ast.Fn, node ast.CallExpr, mut con
 		if i >= node.args.len || concrete_i == concrete_types.len {
 			break
 		}
-		if !param.typ.has_flag(.generic) || node.args[i].expr !is ast.Ident {
+		if (i == 0 && func.is_method) || !param.typ.has_flag(.generic)
+			|| node.args[i].expr !is ast.Ident {
 			continue
 		}
-		var_name := (node.args[i].expr as ast.Ident).name
-		for cur_param in g.cur_fn.params {
-			if !cur_param.typ.has_flag(.generic) || var_name != cur_param.name {
+		ident := node.args[i].expr as ast.Ident
+		var_name := ident.name
+		if ident.is_mut() {
+			continue
+		}
+		for k, cur_param in g.cur_fn.params {
+			if (k == 0 && g.cur_fn.is_method && !cur_param.typ.has_flag(.generic))
+				|| var_name != cur_param.name {
 				continue
 			}
 			mut typ := g.unwrap_generic(cur_param.typ)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1146,15 +1146,15 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		name = g.generic_fn_name([for_in_any_var_type], name)
 	} else {
 		mut concrete_types := node.concrete_types.map(g.unwrap_generic(it))
-		// if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0
-		// 	&& node.concrete_list_pos.len == 1 && node.args.len > 0 {
-		// 	if m := g.table.find_method(g.table.sym(node.left_type), node.name) {
-		// 		if m.generic_names.len > 0 {
-		// 			// repassing generic argument to another function
-		// 			g.resolve_generic_call_args(m, node, mut concrete_types)
-		// 		}
-		// 	}
-		// }
+		if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0
+			&& node.concrete_list_pos.len == 1 && node.args.len > 0 {
+			if m := g.table.find_method(g.table.sym(node.left_type), node.name) {
+				if m.generic_names.len > 0 {
+					// repassing generic argument to another function
+					g.resolve_generic_call_args(m, node, mut concrete_types)
+				}
+			}
+		}
 		name = g.generic_fn_name(concrete_types, name)
 	}
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1146,7 +1146,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		name = g.generic_fn_name([for_in_any_var_type], name)
 	} else {
 		mut concrete_types := node.concrete_types.map(g.unwrap_generic(it))
-		if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0 {
+		if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0
+			&& node.concrete_list_pos.len == 1 {
 			if m := g.table.find_method(g.table.sym(node.left_type), node.name) {
 				if m.generic_names.len > 0 {
 					// repassing generic argument to another function
@@ -1436,7 +1437,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				} else {
 					mut concrete_types := node.concrete_types.map(g.unwrap_generic(it))
 					if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0
-						&& func.generic_names.len > 0 {
+						&& func.generic_names.len > 0 && node.concrete_list_pos.len == 1 {
 						// repassing generic argument to another function
 						g.resolve_generic_call_args(func, node, mut concrete_types)
 					}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1278,11 +1278,20 @@ fn (mut g Gen) resolve_generic_call_args(func ast.Fn, node ast.CallExpr, mut con
 			break
 		}
 		if i == 0 && func.is_method {
-			// skip receiver
+			if param.typ.has_flag(.generic) {
+				// skip receiver
+				concrete_i++
+			}
 			continue
 		}
-		if !param.typ.has_flag(.generic) || node.args[node_i].expr !is ast.Ident {
+		if !param.typ.has_flag(.generic) {
 			node_i++
+			continue
+		}
+
+		if node.args[node_i].expr !is ast.Ident {
+			node_i++
+			concrete_i++
 			continue
 		}
 		ident := node.args[node_i].expr as ast.Ident
@@ -1306,8 +1315,10 @@ fn (mut g Gen) resolve_generic_call_args(func ast.Fn, node ast.CallExpr, mut con
 				}
 			}
 			concrete_types[concrete_i] = typ
-			concrete_i++
 			break
+		}
+		if param.typ.has_flag(.generic) {
+			concrete_i++
 		}
 	}
 }

--- a/vlib/v/tests/generic_call_arg_resolution_test.v
+++ b/vlib/v/tests/generic_call_arg_resolution_test.v
@@ -1,30 +1,30 @@
-struct Test {
-}
+// struct Test {
+// }
 
-fn (tt Test) encode[U](val U) {
-	tt.g_array(val)
-	// tt.g_array2(typeof(val).name, val)
-	// tt.g_array3(typeof(val).name, val, val)
-}
+// fn (tt Test) encode[U](val U) {
+// 	tt.g_array(val)
+// 	//tt.g_array2(typeof(val).name, val)
+// 	//tt.g_array3(typeof(val).name, val, val)
+// }
 
-fn (tt Test) encode2[U](idx int, val U) {
-	tt.g_array(val)
-	// tt.g_array2(typeof(val).name, val)
-	// tt.g_array3(typeof(val).name, val, val)
-}
+// fn (tt Test) encode2[U](idx int, val U) {
+// 	tt.g_array(val)
+// 	//tt.g_array2(typeof(val).name, val)
+// 	//tt.g_array3(typeof(val).name, val, val)
+// }
 
-fn (tt Test) g_array[T](t []T) {
-	assert true
-}
+// fn (tt Test) g_array[T](t []T)  {
+//     assert true
+// }
 
-fn (tt Test) g_array2[T](name string, t []T) {
-	assert name == typeof(t).name
-}
+// fn (tt Test) g_array2[T](name string, t []T)  {
+// 	assert name == typeof(t).name
+// }
 
-fn (tt Test) g_array3[T, U](name string, t []T, u []U) {
-	assert name == typeof(t).name
-	assert name == typeof(u).name
-}
+// fn (tt Test) g_array3[T,U](name string, t []T, u []U)  {
+// 	assert name == typeof(t).name
+// 	assert name == typeof(u).name
+// }
 
 fn test_func() {
 	encode([true])
@@ -38,18 +38,18 @@ fn test_func() {
 	encode2(4, [1.2])
 }
 
-fn test_method() {
-	t := Test{}
-	t.encode([true])
-	t.encode([1])
-	t.encode(['1'])
-	t.encode([1.2])
+// fn test_method() {
+// 	t := Test{}
+// 	t.encode([true])
+// 	t.encode([1])
+// 	t.encode(['1'])
+// 	t.encode([1.2])
 
-	t.encode2(1, [true])
-	t.encode2(2, [1])
-	t.encode2(3, ['1'])
-	t.encode2(4, [1.2])
-}
+// 	t.encode2(1, [true])
+//     t.encode2(2, [1])
+//     t.encode2(3, ['1'])
+// 	t.encode2(4, [1.2])
+// }
 
 fn encode[U](val U) {
 	g_array(val)

--- a/vlib/v/tests/generic_call_arg_resolution_test.v
+++ b/vlib/v/tests/generic_call_arg_resolution_test.v
@@ -1,0 +1,77 @@
+struct Test {
+}
+
+fn (tt Test) encode[U](val U) {
+	tt.g_array(val)
+	// tt.g_array2(typeof(val).name, val)
+	// tt.g_array3(typeof(val).name, val, val)
+}
+
+fn (tt Test) encode2[U](idx int, val U) {
+	tt.g_array(val)
+	// tt.g_array2(typeof(val).name, val)
+	// tt.g_array3(typeof(val).name, val, val)
+}
+
+fn (tt Test) g_array[T](t []T) {
+	assert true
+}
+
+fn (tt Test) g_array2[T](name string, t []T) {
+	assert name == typeof(t).name
+}
+
+fn (tt Test) g_array3[T, U](name string, t []T, u []U) {
+	assert name == typeof(t).name
+	assert name == typeof(u).name
+}
+
+fn test_func() {
+	encode([true])
+	encode([1])
+	encode(['1'])
+	encode([1.2])
+
+	encode2(1, [true])
+	encode2(2, [1])
+	encode2(3, ['1'])
+	encode2(4, [1.2])
+}
+
+fn test_method() {
+	t := Test{}
+	t.encode([true])
+	t.encode([1])
+	t.encode(['1'])
+	t.encode([1.2])
+
+	t.encode2(1, [true])
+	t.encode2(2, [1])
+	t.encode2(3, ['1'])
+	t.encode2(4, [1.2])
+}
+
+fn encode[U](val U) {
+	g_array(val)
+	g_array2(typeof(val).name, val)
+	g_array3(typeof(val).name, val, val)
+}
+
+fn encode2[U](idx int, val U) {
+	g_array(val)
+	g_array2(typeof(val).name, val)
+	g_array3(typeof(val).name, val, val)
+}
+
+fn g_array[T](t []T) {
+	assert true
+}
+
+fn g_array2[T](name string, t []T) {
+	assert name == typeof(t).name
+}
+
+fn g_array3[T, U](name string, t []T, u []U) {
+	assert name == typeof(t).name
+	assert name == typeof(u).name
+}

--- a/vlib/v/tests/generic_call_arg_resolution_test.v
+++ b/vlib/v/tests/generic_call_arg_resolution_test.v
@@ -1,30 +1,30 @@
-// struct Test {
-// }
+struct Test {
+}
 
-// fn (tt Test) encode[U](val U) {
-// 	tt.g_array(val)
-// 	//tt.g_array2(typeof(val).name, val)
-// 	//tt.g_array3(typeof(val).name, val, val)
-// }
+fn (tt Test) encode[U](val U) {
+	tt.g_array(val)
+	tt.g_array2(typeof(val).name, val)
+	tt.g_array3(typeof(val).name, val, val)
+}
 
-// fn (tt Test) encode2[U](idx int, val U) {
-// 	tt.g_array(val)
-// 	//tt.g_array2(typeof(val).name, val)
-// 	//tt.g_array3(typeof(val).name, val, val)
-// }
+fn (tt Test) encode2[U](idx int, val U) {
+	tt.g_array(val)
+	tt.g_array2(typeof(val).name, val)
+	tt.g_array3(typeof(val).name, val, val)
+}
 
-// fn (tt Test) g_array[T](t []T)  {
-//     assert true
-// }
+fn (tt Test) g_array[T](t []T) {
+	assert true
+}
 
-// fn (tt Test) g_array2[T](name string, t []T)  {
-// 	assert name == typeof(t).name
-// }
+fn (tt Test) g_array2[T](name string, t []T) {
+	assert name == typeof(t).name
+}
 
-// fn (tt Test) g_array3[T,U](name string, t []T, u []U)  {
-// 	assert name == typeof(t).name
-// 	assert name == typeof(u).name
-// }
+fn (tt Test) g_array3[T, U](name string, t []T, u []U) {
+	assert name == typeof(t).name
+	assert name == typeof(u).name
+}
 
 fn test_func() {
 	encode([true])
@@ -38,18 +38,18 @@ fn test_func() {
 	encode2(4, [1.2])
 }
 
-// fn test_method() {
-// 	t := Test{}
-// 	t.encode([true])
-// 	t.encode([1])
-// 	t.encode(['1'])
-// 	t.encode([1.2])
+fn test_method() {
+	t := Test{}
+	t.encode([true])
+	t.encode([1])
+	t.encode(['1'])
+	t.encode([1.2])
 
-// 	t.encode2(1, [true])
-//     t.encode2(2, [1])
-//     t.encode2(3, ['1'])
-// 	t.encode2(4, [1.2])
-// }
+	t.encode2(1, [true])
+	t.encode2(2, [1])
+	t.encode2(3, ['1'])
+	t.encode2(4, [1.2])
+}
 
 fn encode[U](val U) {
 	g_array(val)


### PR DESCRIPTION
Fix #17117

```V
fn main() {
	t := Test{}
	t.encode([true])
	t.encode([1])
	t.encode(['1'])
	t.encode([1.2])
}

fn encode[U](val U) {
	g_array(val) // automatic generic param resolution
	g_array2(typeof(val).name, val) // automatic generic param resolution
	g_array3(typeof(val).name, val, val) // automatic generic param resolution
}

fn g_array[T](t []T) {
	assert true
}

fn g_array2[T](name string, t []T) {
	assert name == typeof(t).name
}

fn g_array3[T, U](name string, t []T, u []U) {
	assert name == typeof(t).name
	assert name == typeof(u).name
}
``` 