### PR TITLE
docs: separate code block with a space (`fn (Once) do_with_param`)

### DIFF
--- a/vlib/sync/once.v
+++ b/vlib/sync/once.v
@@ -41,6 +41,7 @@ fn (mut o Once) do_slow(f fn ()) {
 //        o.add(5)
 // })
 // ```
+//
 // ... you can use:
 // ```v
 //    once.do_with_param(fn (mut o One) {


### PR DESCRIPTION
From this:

![2023-01-31-021044_1366x768_scrot](https://user-images.githubusercontent.com/99479536/215560335-9f983442-967a-4a40-831f-b03e550ace28.png)

To this:

![2023-01-31-020755_1366x768_scrot](https://user-images.githubusercontent.com/99479536/215560136-8033a5a5-aa59-4e35-8e98-7f2c64b90068.png)

