### PR TITLE
gg: setup ctx.window.user_data and ctx.user_data on ctx.run()

### DIFF
--- a/examples/gg/cursor.v
+++ b/examples/gg/cursor.v
@@ -5,12 +5,13 @@ import gx
 import sokol.sapp
 
 fn main() {
-	gg.new_context(
+	mut ctx := gg.new_context(
 		bg_color: gx.white
 		window_title: 'Cursor'
 		frame_fn: frame
 		init_fn: init
-	).run()
+	)
+	ctx.run()
 }
 
 fn init(mut ctx gg.Context) {

--- a/examples/pendulum-simulation/modules/sim/anim/app.v
+++ b/examples/pendulum-simulation/modules/sim/anim/app.v
@@ -13,7 +13,7 @@ struct Pixel {
 	color gx.Color
 }
 
-struct App {
+pub struct App {
 pub:
 	args         simargs.ParallelArgs
 	request_chan chan &sim.SimRequest

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -486,7 +486,7 @@ pub fn new_context(cfg Config) &Context {
 
 // run starts the main loop of the context.
 pub fn (mut ctx Context) run() {
-	// ensure context set correctly
+	// set context late, in case it changed (e.g., due to embedding)
 	ctx.window = sapp.Desc{
 		...ctx.window
 		user_data: ctx

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -458,39 +458,42 @@ pub fn new_context(cfg Config) &Context {
 		ft: 0
 		ui_mode: cfg.ui_mode
 		native_rendering: cfg.native_rendering
-	}
-	if cfg.user_data == unsafe { nil } {
-		ctx.user_data = ctx
+		window: sapp.Desc{
+			init_userdata_cb: gg_init_sokol_window
+			frame_userdata_cb: gg_frame_fn
+			event_userdata_cb: gg_event_fn
+			fail_userdata_cb: gg_fail_fn
+			cleanup_userdata_cb: gg_cleanup_fn
+			window_title: &char(cfg.window_title.str)
+			html5_canvas_name: &char(cfg.window_title.str)
+			width: cfg.width
+			height: cfg.height
+			sample_count: cfg.sample_count
+			high_dpi: true
+			fullscreen: cfg.fullscreen
+			__v_native_render: cfg.native_rendering
+			// drag&drop
+			enable_dragndrop: cfg.enable_dragndrop
+			max_dropped_files: cfg.max_dropped_files
+			max_dropped_file_path_length: cfg.max_dropped_file_path_length
+			swap_interval: cfg.swap_interval
+		}
 	}
 	ctx.set_bg_color(cfg.bg_color)
 	// C.printf('new_context() %p\n', cfg.user_data)
-	window := sapp.Desc{
-		user_data: ctx
-		init_userdata_cb: gg_init_sokol_window
-		frame_userdata_cb: gg_frame_fn
-		event_userdata_cb: gg_event_fn
-		fail_userdata_cb: gg_fail_fn
-		cleanup_userdata_cb: gg_cleanup_fn
-		window_title: &char(cfg.window_title.str)
-		html5_canvas_name: &char(cfg.window_title.str)
-		width: cfg.width
-		height: cfg.height
-		sample_count: cfg.sample_count
-		high_dpi: true
-		fullscreen: cfg.fullscreen
-		__v_native_render: cfg.native_rendering
-		// drag&drop
-		enable_dragndrop: cfg.enable_dragndrop
-		max_dropped_files: cfg.max_dropped_files
-		max_dropped_file_path_length: cfg.max_dropped_file_path_length
-		swap_interval: cfg.swap_interval
-	}
-	ctx.window = window
 	return ctx
 }
 
 // run starts the main loop of the context.
-pub fn (ctx &Context) run() {
+pub fn (mut ctx Context) run() {
+	// ensure context set correctly
+	ctx.window = sapp.Desc{
+		...ctx.window
+		user_data: ctx
+	}
+	if ctx.user_data == unsafe { nil } {
+		ctx.user_data = ctx
+	}
 	sapp.run(&ctx.window)
 }
 

--- a/vlib/gg/gg.js.v
+++ b/vlib/gg/gg.js.v
@@ -328,9 +328,6 @@ pub fn new_context(cfg Config) &Context {
 	sz.height = g.height
 	sz.width = g.width
 	g.config = cfg
-	if isnil(cfg.user_data) {
-		g.user_data = g
-	}
 	g.window = dom.window()
 	document := dom.document
 	canvas_elem := document.getElementById(cfg.canvas.str) or {
@@ -453,6 +450,11 @@ pub fn new_context(cfg Config) &Context {
 }
 
 pub fn (mut ctx Context) run() {
+	// set context late, in case it changed (e.g., due to embedding)
+	if isnil(ctx.user_data) {
+		ctx.user_data = ctx
+	}
+
 	gg_animation_frame_fn(mut ctx)
 }
 


### PR DESCRIPTION
This PR sets
* `Context.user_data` (if the user didn't set it), and
* `Context.window.user_data`

as before, but late, when `Context.run()` is called, rather than on initial setup of the `Context` returned by `new_context()`. 

Currently, `new_context()` returns a `Context` which holds a reference to itself in a field inside itself. So the assumption currently is that the reference will still be correct at the time `Context.run()` is called. This is problematic when embedding the `Context` in another struct, which necessarily *copies* it.

E.g., in the V UI library we're looking at doing this:
```v
pub struct DrawDeviceContext {
	gg.Context
	// ...
}
```
Setting up a new `DrawDeviceContext` would look something like:
```v
	mut dd := DrawDeviceContext{
		Context: gg.new_context(
			// ...
		)
		//...
	}
```
Which means that the `gg.Context` returned from `gg.new_context()` is *copied* in to the `DrawDeviceStruct`, and the internal reference to the original `gg.Context` is no longer correct.

NOTE
As a side effect of this change, you can no longer chain calls to `new_context()` and `run()`:
```v
// error: Context passed to run() is not mut
gg.new_context(
  // ...
).run()

// do this instead
mut ctx := new_context(
  // ...
)
ctx.run()
```
Is this acceptable? It seems like a rare breakage, and one that can easily be worked around.