### PR TITLE
tools: Share to Playground

### DIFF
--- a/cmd/tools/vshare.v
+++ b/cmd/tools/vshare.v
@@ -1,0 +1,39 @@
+module main
+
+import net.http
+import os
+import clipboard
+
+fn main() {
+	mut cb := clipboard.new()
+
+	if os.args.len < 3 {
+		eprintln('Please provide a file')
+		exit(1)
+	}
+
+	if os.file_ext(os.args[2]) != '.v' {
+		eprintln('Must be a V source file.')
+		exit(1)
+	}
+
+	if !os.is_file(os.args[2]) {
+		eprintln('File not found.')
+		exit(1)
+	}
+
+	to_send := os.args[2]
+
+	content := os.read_file(to_send) or {
+		eprintln(err)
+		exit(1)
+	}
+
+	share := http.post_form('https://play.vlang.io/share', {
+		'code': content
+	})!
+	url := 'https://play.vlang.io/p/${share.body}'
+
+	cb.copy(url)
+	println(url)
+}

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -34,6 +34,7 @@ const (
 		'self',
 		'setup-freetype',
 		'shader',
+		'share',
 		'should-compile-all',
 		'symlink',
 		'scan',

--- a/vlib/v/help/other/other.txt
+++ b/vlib/v/help/other/other.txt
@@ -19,6 +19,8 @@ Other less frequently used commands supported by V include:
 
   setup-freetype   Setup thirdparty freetype on Windows.
 
+  share            Send your code to the V Playground
+
   translate        Translate C code to V.
 
   tracev           Produce a tracing version of the v compiler.

--- a/vlib/v/help/other/share.txt
+++ b/vlib/v/help/other/share.txt
@@ -1,0 +1,4 @@
+Send your code to the V Playground
+
+Usage:
+  v share FILE


### PR DESCRIPTION
## Preamble

Earlier today in the Discord, user [Sarctiann](https://github.com/Sarctiann) brought up being able to submit code with a command from V.

## Proposal

Add a way to submit code to the Playground to make it easier to share code.

## Implementation

Add `vshare.v` to `cmd/tools/` that allows users to submit code to the Playground from the terminal.

It is currently implemented by generating code from `os.read_file()` and then POSTing to `https://play.vlang.io/share`

There are currently two ways to check for errors: first it ensures the file has a `.v` extension and exists in the current directories `.` and `os.getwd()/src/`.

Upon successful share, it prints out a link to the Playground. 

Example:
https://play.vlang.io/?query=e8669cf46d

### Potential Issues

- `.vsh` and extensionless v shell files are currently ignored, an exception will have to be made (if the playground runs them).