### PR TITLE
cgen: fix sumtype as cast with calling twice (fix #17156)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6088,23 +6088,43 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	mut expr_type_sym := g.table.sym(g.unwrap_generic(node.expr_type))
 	if mut expr_type_sym.info is ast.SumType {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
-		if sym.info is ast.FnType {
-			g.write('/* as */ (${styp})__as_cast(')
+		if node.expr !in [ast.Ident, ast.SelectorExpr] {
+			tmp_var := g.new_tmp_var()
+			expr_styp := g.typ(node.expr_type)
+			g.write('({ ${expr_styp} ${tmp_var} = ')
+			g.expr(node.expr)
+			g.write('; ')
+			if sym.info is ast.FnType {
+				g.write('/* as */ (${styp})__as_cast(')
+			} else {
+				g.write('/* as */ *(${styp}*)__as_cast(')
+			}
+			g.write(tmp_var)
+			g.write(dot)
+			g.write('_${sym.cname},')
+			g.write(tmp_var)
+			g.write(dot)
+			sidx := g.type_sidx(unwrapped_node_typ)
+			g.write('_typ, ${sidx}); }) /*expected idx: ${sidx}, name: ${sym.name} */ ')
 		} else {
-			g.write('/* as */ *(${styp}*)__as_cast(')
+			if sym.info is ast.FnType {
+				g.write('/* as */ (${styp})__as_cast(')
+			} else {
+				g.write('/* as */ *(${styp}*)__as_cast(')
+			}
+			g.write('(')
+			g.expr(node.expr)
+			g.write(')')
+			g.write(dot)
+			g.write('_${sym.cname},')
+			g.write('(')
+			g.expr(node.expr)
+			g.write(')')
+			g.write(dot)
+			// g.write('typ, /*expected:*/$node.typ)')
+			sidx := g.type_sidx(unwrapped_node_typ)
+			g.write('_typ, ${sidx}) /*expected idx: ${sidx}, name: ${sym.name} */ ')
 		}
-		g.write('(')
-		g.expr(node.expr)
-		g.write(')')
-		g.write(dot)
-		g.write('_${sym.cname},')
-		g.write('(')
-		g.expr(node.expr)
-		g.write(')')
-		g.write(dot)
-		// g.write('typ, /*expected:*/$node.typ)')
-		sidx := g.type_sidx(unwrapped_node_typ)
-		g.write('_typ, ${sidx}) /*expected idx: ${sidx}, name: ${sym.name} */ ')
 
 		// fill as cast name table
 		for variant in expr_type_sym.info.variants {

--- a/vlib/v/slow_tests/inout/printing_sumtype_as_cast.out
+++ b/vlib/v/slow_tests/inout/printing_sumtype_as_cast.out
@@ -1,0 +1,1 @@
+println

--- a/vlib/v/slow_tests/inout/printing_sumtype_as_cast.vv
+++ b/vlib/v/slow_tests/inout/printing_sumtype_as_cast.vv
@@ -1,0 +1,10 @@
+type Sum = int | string
+
+fn ret_sum() Sum {
+	println('println')
+	return 22
+}
+
+fn main() {
+	_ := ret_sum() as int
+}


### PR DESCRIPTION
This PR fix sumtype as cast with calling twice (fix #17156).

- Fix sumtype as cast with calling twice.
- Add test.

```v
type Sum = int | string

fn ret_sum() Sum {
	println('println')
	return 22
}

fn main() {
	_ := ret_sum() as int
}

PS D:\Test\v\tt1> v run .
println
```