### PR TITLE
v: forbid local variable names, shadowing imported module names

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1424,8 +1424,8 @@ import os { input, user_os }
 
 name := input('Enter your name: ')
 println('Name: ${name}')
-os := user_os()
-println('Your OS is ${os}.')
+current_os := user_os()
+println('Your OS is ${current_os}.')
 ```
 
 ### Module import aliasing

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -293,16 +293,16 @@ fn main() {
 }
 
 fn test_join() {
-	mut strings := ['a', 'b', 'c']
-	mut s := strings.join(' ')
+	mut strs := ['a', 'b', 'c']
+	mut s := strs.join(' ')
 	assert s == 'a b c'
-	strings = [
+	strs = [
 		'one
 two ',
 		'three!
 four!',
 	]
-	s = strings.join(' ')
+	s = strs.join(' ')
 	assert s.contains('one') && s.contains('two ') && s.contains('four')
 	empty := []string{len: 0}
 	assert empty.join('A') == ''

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -119,9 +119,9 @@ pub fn (mut ws Client) connect() ! {
 
 // listen listens and processes incoming messages
 pub fn (mut ws Client) listen() ! {
-	mut log := 'Starting client listener, server(${ws.is_server})...'
-	ws.logger.info(log)
-	unsafe { log.free() }
+	mut log_msg := 'Starting client listener, server(${ws.is_server})...'
+	ws.logger.info(log_msg)
+	unsafe { log_msg.free() }
 	defer {
 		ws.logger.info('Quit client listener, server(${ws.is_server})...')
 		if ws.state == .open {
@@ -143,9 +143,9 @@ pub fn (mut ws Client) listen() ! {
 		ws.debug_log('got message: ${msg.opcode}')
 		match msg.opcode {
 			.text_frame {
-				log = 'read: text'
-				ws.debug_log(log)
-				unsafe { log.free() }
+				log_msg = 'read: text'
+				ws.debug_log(log_msg)
+				unsafe { log_msg.free() }
 				ws.send_message_event(msg)
 				unsafe { msg.free() }
 			}
@@ -177,9 +177,9 @@ pub fn (mut ws Client) listen() ! {
 				}
 			}
 			.close {
-				log = 'read: close'
-				ws.debug_log(log)
-				unsafe { log.free() }
+				log_msg = 'read: close'
+				ws.debug_log(log_msg)
+				unsafe { log_msg.free() }
 				defer {
 					ws.manage_clean_close()
 				}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -304,6 +304,10 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 								c.warn('duplicate of a const name `${full_name}`', left.pos)
 							}
 						}
+						// Check if variable name is already registered as imported module symbol
+						if c.file.imports.any(it.mod == left.name) {
+							c.error('duplicate of a import symbol `${left.name}`', left.pos)
+						}
 					}
 				}
 			}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -306,7 +306,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						}
 						// Check if variable name is already registered as imported module symbol
 						if c.file.imports.any(it.mod == left.name) {
-							c.error('duplicate of a import symbol `${left.name}`', left.pos)
+							c.error('duplicate of an import symbol `${left.name}`', left.pos)
 						}
 					}
 				}

--- a/vlib/v/checker/tests/var_decl_import_sym_conflict.out
+++ b/vlib/v/checker/tests/var_decl_import_sym_conflict.out
@@ -1,0 +1,17 @@
+vlib/v/checker/tests/var_decl_import_sym_conflict.vv:1:8: warning: module 'arrays' is imported but never used
+    1 | import arrays
+      |        ~~~~~~
+    2 |
+    3 | fn x() {
+vlib/v/checker/tests/var_decl_import_sym_conflict.vv:4:2: warning: unused variable: `arrays`
+    2 |
+    3 | fn x() {
+    4 |     arrays := 1
+      |     ~~~~~~
+    5 | }
+vlib/v/checker/tests/var_decl_import_sym_conflict.vv:4:2: error: duplicate of a import symbol `arrays`
+    2 |
+    3 | fn x() {
+    4 |     arrays := 1
+      |     ~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/var_decl_import_sym_conflict.out
+++ b/vlib/v/checker/tests/var_decl_import_sym_conflict.out
@@ -1,16 +1,16 @@
 vlib/v/checker/tests/var_decl_import_sym_conflict.vv:1:8: warning: module 'arrays' is imported but never used
     1 | import arrays
       |        ~~~~~~
-    2 |
+    2 | 
     3 | fn x() {
 vlib/v/checker/tests/var_decl_import_sym_conflict.vv:4:2: warning: unused variable: `arrays`
-    2 |
+    2 | 
     3 | fn x() {
     4 |     arrays := 1
       |     ~~~~~~
     5 | }
-vlib/v/checker/tests/var_decl_import_sym_conflict.vv:4:2: error: duplicate of a import symbol `arrays`
-    2 |
+vlib/v/checker/tests/var_decl_import_sym_conflict.vv:4:2: error: duplicate of an import symbol `arrays`
+    2 | 
     3 | fn x() {
     4 |     arrays := 1
       |     ~~~~~~

--- a/vlib/v/checker/tests/var_decl_import_sym_conflict.vv
+++ b/vlib/v/checker/tests/var_decl_import_sym_conflict.vv
@@ -1,0 +1,5 @@
+import arrays
+
+fn x() {
+	arrays := 1
+}

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -247,9 +247,9 @@ pub fn (prefs &Preferences) should_compile_asm(path string) bool {
 	if arch != prefs.arch && prefs.arch != ._auto && arch != ._auto {
 		return false
 	}
-	os := os_from_string(file.all_after_last('_').all_before('.')) or { OS._auto }
+	file_os := os_from_string(file.all_after_last('_').all_before('.')) or { OS._auto }
 
-	if os != prefs.os && prefs.os != ._auto && os != ._auto {
+	if file_os != prefs.os && prefs.os != ._auto && file_os != ._auto {
 		return false
 	}
 	return true


### PR DESCRIPTION
- Fix #17173, forbids variable name shadowing import symbol.
- Add output test
`var_decl_import_sym_conflict.vv`
```v
import arrays

fn x() {
	arrays := 1
}
```
```v
var_decl_import_sym_conflict.vv:4:2: error: duplicate of an import symbol `arrays`
    2 |
    3 | fn x() {
    4 |     arrays := 1
      |     ~~~~~~
    5 | }
```

## Note
This is a breaking change, serveral modules and tests are effected. Including vinix, stdlib etc.