### PR TITLE
stbi: don't use garbage collection for memory management in `stb_image_write.h` for now

### DIFF
--- a/thirdparty/stb_image/stbi.c
+++ b/thirdparty/stb_image/stbi.c
@@ -10,9 +10,10 @@ extern void   stbi__callback_free(void *ptr);
 #define STBI_MALLOC(sz)           stbi__callback_malloc(sz)
 #define STBI_REALLOC(p,newsz)     stbi__callback_realloc(p,newsz)
 #define STBI_FREE(p)              stbi__callback_free(p)
-#define STBIW_MALLOC(sz)          stbi__callback_malloc(sz)
-#define STBIW_REALLOC(p,newsz)    stbi__callback_realloc(p,newsz)
-#define STBIW_FREE(p)             stbi__callback_free(p)
+// TODO: Using garbage collection in `stb_image_write.h` currently causes memory corruption sometimes
+//#define STBIW_MALLOC(sz)          stbi__callback_malloc(sz)
+//#define STBIW_REALLOC(p,newsz)    stbi__callback_realloc(p,newsz)
+//#define STBIW_FREE(p)             stbi__callback_free(p)
 
 #include "stb_image.h"
 #include "stb_image_write.h"


### PR DESCRIPTION
(follow-up to #16028)

There is a memory access/corruption bug (that I couldn't fix) when using the `GC_` functions for memory management in `stb_image_write`.

Furthermore, the library should free allocated memory by itself anyway.

Note that this may still allow some leaks, but it's definitely better than corrupted memory and crashes caused by it.