### PR TITLE
checker: fix if guard with struct option fntype field (fix #17149)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -800,7 +800,11 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 						typ = obj.smartcasts.last()
 					} else {
 						if obj.typ == 0 {
-							typ = c.expr(obj.expr)
+							if obj.expr is ast.IfGuardExpr {
+								typ = c.expr(obj.expr.expr)
+							} else {
+								typ = c.expr(obj.expr)
+							}
 						} else {
 							typ = obj.typ
 						}

--- a/vlib/v/tests/if_guard_with_struct_option_fntype_field_test.v
+++ b/vlib/v/tests/if_guard_with_struct_option_fntype_field_test.v
@@ -1,0 +1,19 @@
+struct Foo {
+	f ?fn (int) int
+}
+
+fn t1(a int) int {
+	println(a)
+	return a
+}
+
+fn test_if_guard_with_struct_option_fntype_field() {
+	foo := Foo{t1}
+
+	if ff := foo.f {
+		ret := ff(22)
+		assert ret == 22
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix if guard with struct option fntype field (fix #17149).

- Fix if guard with struct option fntype field.
- Add test.

```v
struct Foo {
	f ?fn (int) int
}

fn t1(a int) int {
	println(a)
	return a
}

fn main() {
	foo := Foo{t1}

	if ff := foo.f {
		ret := ff(22)
		assert ret == 22
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
22
```