### PR TITLE
cgen: fix assigning option of struct fntype field (fix #17223)

### DIFF
--- a/vlib/v/tests/assign_option_of_struct_fntype_field_test.v
+++ b/vlib/v/tests/assign_option_of_struct_fntype_field_test.v
@@ -1,0 +1,16 @@
+struct Foo {
+mut:
+	bar ?fn (string) string
+}
+
+fn test_assign_option_of_struct_fntype_field() {
+	mut foo := Foo{}
+	foo.bar = fn (s string) string {
+		return s
+	}
+	if ff := foo.bar {
+		ret := ff('hello')
+		println(ret)
+		assert ret == 'hello'
+	}
+}


### PR DESCRIPTION
This PR fix assigning option of struct fntype field (fix #17223).

- Fix assigning option of struct fntype field.
- Add test.

```v
struct Foo {
mut:
	bar ?fn (string) string
}

fn main() {
	mut foo := Foo{}
	foo.bar = fn (s string) string {
		return s
	}
	if ff := foo.bar {
		ret := ff('hello')
		println(ret)
		assert ret == 'hello'
	}
}

PS D:\Test\v\tt1> v run .
hello
```