### PR TITLE
checker: check sumtype in unknown type (fix #17221)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -165,6 +165,12 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 							c.error('left operand to `${node.op}` does not match the array element type: ${err.msg()}',
 								left_right_pos)
 						}
+					} else {
+						if mut node.right is ast.ArrayInit {
+							for i, typ in node.right.expr_types {
+								c.ensure_type_exists(typ, node.right.exprs[i].pos()) or {}
+							}
+						}
 					}
 				}
 				.map {

--- a/vlib/v/checker/tests/sumtype_in_unknown_types_err.out
+++ b/vlib/v/checker/tests/sumtype_in_unknown_types_err.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/sumtype_in_unknown_types_err.vv:11:25: error: unknown type `FooD`.
+Did you mean `Foo`?
+    9 | fn main() {
+   10 |     foo := Foo(FooA{})
+   11 |     if foo in [FooB, FooC, FooD] {
+      |                            ~~~~
+   12 |         panic('not possible')
+   13 |     } else {

--- a/vlib/v/checker/tests/sumtype_in_unknown_types_err.vv
+++ b/vlib/v/checker/tests/sumtype_in_unknown_types_err.vv
@@ -1,0 +1,16 @@
+type Foo = FooA | FooB | FooC
+
+struct FooA {}
+
+struct FooB {}
+
+struct FooC {}
+
+fn main() {
+	foo := Foo(FooA{})
+	if foo in [FooB, FooC, FooD] {
+		panic('not possible')
+	} else {
+		println('ok')
+	}
+}


### PR DESCRIPTION
This PR check sumtype in unknown type (fix #17221).

- Check sumtype in unknown type.
- Add test.

```v
type Foo = FooA | FooB | FooC

struct FooA {}

struct FooB {}

struct FooC {}

fn main() {
	foo := Foo(FooA{})
	if foo in [FooB, FooC, FooD] {
		panic('not possible')
	} else {
		println('ok')
	}
}

PS D:\Test\v\tt1> v run .
tt1.v:11:25: error: unknown type `FooD`.
Did you mean `Foo`?
    9 | fn main() {
   10 |     foo := Foo(FooA{})
   11 |     if foo in [FooB, FooC, FooD] {
      |                            ~~~~
   12 |         panic('not possible')
   13 |     } else {
```