### PR TITLE
checker: fix array filter of fn mut argument (fix #17226)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2329,6 +2329,8 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		// check fn
 		if node.return_type.has_flag(.shared_f) {
 			node.return_type = node.return_type.clear_flag(.shared_f).deref()
+		} else if node.left.is_auto_deref_var() {
+			node.return_type = node.return_type.deref()
 		}
 		c.check_map_and_filter(false, elem_typ, node)
 	} else if method_name in ['any', 'all'] {

--- a/vlib/v/tests/array_filter_of_fn_mut_arg_test.v
+++ b/vlib/v/tests/array_filter_of_fn_mut_arg_test.v
@@ -1,0 +1,10 @@
+fn foo(mut arr []&int) {
+	arr = arr.filter(it != unsafe { nil })
+}
+
+fn test_array_filter_of_fn_mut_arg() {
+	mut arr := []&int{}
+	foo(mut arr)
+	println(arr.len)
+	assert arr.len == 0
+}


### PR DESCRIPTION
This PR fix array filter of fn mut argument (fix #17226).

- Fix array filter of fn mut argument.
- Add test.

```v
fn foo(mut arr []&int) {
	arr = arr.filter(it != unsafe { nil })
}

fn main() {
	mut arr := []&int{}
	foo(mut arr)
	println(arr.len)
	assert arr.len == 0
}

PS D:\Test\v\tt1> v run .
0
```