### PR TITLE
cgen: fix for in mut array with infix expr (fix #17228)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -144,12 +144,12 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				}
 				g.write('${ptr_typ}_alias_eq(')
 				if left.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(left.typ.nr_muls()))
 				}
 				g.expr(node.left)
 				g.write(', ')
 				if right.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(right.typ.nr_muls()))
 				}
 				g.expr(node.right)
 				g.write(')')
@@ -161,7 +161,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				}
 				g.write('${ptr_typ}_arr_eq(')
 				if left.typ.is_ptr() && !left.typ.has_flag(.shared_f) {
-					g.write('*')
+					g.write('*'.repeat(left.typ.nr_muls()))
 				}
 				g.expr(node.left)
 				if left.typ.has_flag(.shared_f) {
@@ -169,7 +169,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				}
 				g.write(', ')
 				if right.typ.is_ptr() && !right.typ.has_flag(.shared_f) {
-					g.write('*')
+					g.write('*'.repeat(right.typ.nr_muls()))
 				}
 				g.expr(node.right)
 				if right.typ.has_flag(.shared_f) {
@@ -210,36 +210,32 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				}
 				g.write('${ptr_typ}_map_eq(')
 				if left.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(left.typ.nr_muls()))
 				}
 				g.expr(node.left)
 				g.write(', ')
 				if right.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(right.typ.nr_muls()))
 				}
 				g.expr(node.right)
 				g.write(')')
 			}
 			.struct_ {
-				// if g.pref.translated {
-				// g.gen_plain_infix_expr(node)
-				//} else {
 				ptr_typ := g.equality_fn(left.unaliased)
 				if node.op == .ne {
 					g.write('!')
 				}
 				g.write('${ptr_typ}_struct_eq(')
 				if left.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(left.typ.nr_muls()))
 				}
 				g.expr(node.left)
 				g.write(', ')
 				if right.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(right.typ.nr_muls()))
 				}
 				g.expr(node.right)
 				g.write(')')
-				//}
 			}
 			.sum_type {
 				ptr_typ := g.equality_fn(left.unaliased)
@@ -248,12 +244,12 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				}
 				g.write('${ptr_typ}_sumtype_eq(')
 				if left.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(left.typ.nr_muls()))
 				}
 				g.expr(node.left)
 				g.write(', ')
 				if right.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(right.typ.nr_muls()))
 				}
 				g.expr(node.right)
 				g.write(')')
@@ -265,12 +261,12 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				}
 				g.write('${ptr_typ}_interface_eq(')
 				if left.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(left.typ.nr_muls()))
 				}
 				g.expr(node.left)
 				g.write(', ')
 				if right.typ.is_ptr() {
-					g.write('*')
+					g.write('*'.repeat(right.typ.nr_muls()))
 				}
 				g.expr(node.right)
 				g.write(')')

--- a/vlib/v/tests/for_in_mut_array_with_infix_expr_test.v
+++ b/vlib/v/tests/for_in_mut_array_with_infix_expr_test.v
@@ -1,0 +1,13 @@
+import net
+
+fn test_for_in_mut_array_with_infix_expr() {
+	ignore := net.TcpConn{}
+	mut array := []&net.TcpConn{}
+
+	for mut socket in array {
+		if ignore != socket {
+			println('not eq')
+		}
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix for in mut array with infix expr (fix #17228).

- Fix for in mut array with infix expr.
- Add test.

```v
import net

fn main() {
	ignore := net.TcpConn{}
	mut array := []&net.TcpConn{}

	for mut socket in array {
		if ignore != socket {
			println('not eq')
		}
	}
	assert true
}

PS D:\Test\v\tt1> v run .
```