### PR TITLE
Examples: Call V From C - Use `-Wl,-rpath=.` instead of `LD_LIBRARY_PATH=.`

### DIFF
--- a/examples/call_v_from_c/README.md
+++ b/examples/call_v_from_c/README.md
@@ -7,11 +7,10 @@
 Step 1: Compile the v code to a shared library using `v -cc gcc -shared v_test_print.v` or
 `v -cc gcc -shared v_test_math.v`.
 
-Step 2: Compile the c file using `gcc test_print.c v_test_print.so -o test_print` or
-`gcc test_math.c v_test_math.so -o test_math`.
+Step 2: Compile the c file using `gcc test_print.c v_test_print.so -o test_print -Wl,-rpath=.` or
+`gcc test_math.c v_test_math.so -o test_math -Wl,-rpath=.`.
 
-Step 3: Run the compiled c file using `LD_LIBRARY_PATH=. ./test_print` or
-`LD_LIBRARY_PATH=. ./test_math`.
+Step 3: Run the compiled c file using `./test_print` or `./test_math`.
 
 
 #### On Mac OSX:


### PR DESCRIPTION
It will make the executables more portable like windows. And with the way, you can run application without `LD_LIBRARY_PATH`.

It could be possible to work the way on MacOS. But I can not test it on a Mac. So, i updated only Linux instructions.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
