### PR TITLE
cgen: fix nonarray method first or last call (fix #17249)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1167,7 +1167,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write('${name}(')
 		}
 	}
-	is_node_name_in_first_last_repeat := node.name in ['first', 'last', 'repeat']
+	is_array_method_first_last_repeat := final_left_sym.kind == .array
+		&& node.name in ['first', 'last', 'repeat']
 	if node.receiver_type.is_ptr() && (!left_type.is_ptr()
 		|| node.from_embed_types.len != 0 || (left_type.has_flag(.shared_f) && node.name != 'str')) {
 		// The receiver is a reference, but the caller provided a value
@@ -1177,7 +1178,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			if !node.left.is_lvalue() {
 				g.write('ADDR(${rec_cc_type}, ')
 				has_cast = true
-			} else if !is_node_name_in_first_last_repeat && !(left_type.has_flag(.shared_f)
+			} else if !is_array_method_first_last_repeat && !(left_type.has_flag(.shared_f)
 				&& left_type == node.receiver_type) {
 				g.write('&')
 			}
@@ -1205,7 +1206,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.write('/*af receiver arg*/' + arg_name)
 	} else {
 		if left_sym.kind == .array && node.left.is_auto_deref_var()
-			&& is_node_name_in_first_last_repeat {
+			&& is_array_method_first_last_repeat {
 			g.write('*')
 		}
 		if node.left is ast.MapInit {
@@ -1241,7 +1242,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write(embed_name)
 		}
 		if left_type.has_flag(.shared_f)
-			&& (left_type != node.receiver_type || is_node_name_in_first_last_repeat) {
+			&& (left_type != node.receiver_type || is_array_method_first_last_repeat) {
 			g.write('->val')
 		}
 	}

--- a/vlib/v/tests/method_first_last_call_test.v
+++ b/vlib/v/tests/method_first_last_call_test.v
@@ -1,0 +1,12 @@
+struct Foo {}
+
+fn (l &Foo) first() {}
+
+fn (l &Foo) last() {}
+
+fn test_method_first_last_call() {
+	f := Foo{}
+	f.first()
+	f.last()
+	assert true
+}


### PR DESCRIPTION
This PR fix nonarray method first or last call (fix #17249).

- Fix nonarray method first or last call.
- Add test.

```v
struct Foo {}

fn (l &Foo) first() {}

fn (l &Foo) last() {}

fn main() {
	f := Foo{}
	f.first()
	f.last()
	assert true
}

PS D:\Test\v\tt1> v run .
```