### PR TITLE
cgen: remove unused generated func

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6466,15 +6466,18 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 		}
 		for vtyp, variants in inter_info.conversions {
 			vsym := g.table.sym(vtyp)
-			conversion_functions.write_string('static inline bool I_${interface_name}_is_I_${vsym.cname}(${interface_name} x) {\n\treturn ')
-			for i, variant in variants {
-				variant_sym := g.table.sym(variant)
-				if i > 0 {
-					conversion_functions.write_string(' || ')
+
+			if variants.len > 0 {
+				conversion_functions.write_string('static inline bool I_${interface_name}_is_I_${vsym.cname}(${interface_name} x) {\n\treturn ')
+				for i, variant in variants {
+					variant_sym := g.table.sym(variant)
+					if i > 0 {
+						conversion_functions.write_string(' || ')
+					}
+					conversion_functions.write_string('(x._typ == _${interface_name}_${variant_sym.cname}_index)')
 				}
-				conversion_functions.write_string('(x._typ == _${interface_name}_${variant_sym.cname}_index)')
+				conversion_functions.writeln(';\n}')
 			}
-			conversion_functions.writeln(';\n}')
 
 			conversion_functions.writeln('static inline ${vsym.cname} I_${interface_name}_as_I_${vsym.cname}(${interface_name} x) {')
 			for variant in variants {

--- a/vlib/v/tests/empty_interface_is_another_empty_interface_check_test.v
+++ b/vlib/v/tests/empty_interface_is_another_empty_interface_check_test.v
@@ -1,0 +1,10 @@
+interface Foo {}
+
+interface Bar {}
+
+pub fn set_foo(mut foo Foo) {
+	if foo is Bar {
+	}
+}
+
+fn test_main() {}


### PR DESCRIPTION
Fix #15691

This PR stops generating wrong func code when interface variants is zero:

```V
static inline bool I_main__Foo_is_I_main__Bar(main__Foo x) {
	return ;
}
```

Because in this case currently `Foo is TypeNode` produces `false`, not the call for wrong function:

```V
void main__set_foo(main__Foo* foo) {
	if (false) {
	}
}
```