### PR TITLE
checker: fix returning if expr with custom error (fix #17187)

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -285,6 +285,19 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						if is_noreturn_callexpr(stmt.expr) {
 							continue
 						}
+						if (node.typ.has_flag(.option) || node.typ.has_flag(.result))
+							&& c.table.sym(stmt.typ).kind == .struct_
+							&& c.type_implements(stmt.typ, ast.error_type, node.pos) {
+							stmt.expr = ast.CastExpr{
+								expr: stmt.expr
+								typname: 'IError'
+								typ: ast.error_type
+								expr_type: stmt.typ
+								pos: node.pos
+							}
+							stmt.typ = ast.error_type
+							continue
+						}
 						c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 							node.pos)
 					}

--- a/vlib/v/tests/return_if_expr_with_custom_error_test.v
+++ b/vlib/v/tests/return_if_expr_with_custom_error_test.v
@@ -1,0 +1,19 @@
+struct CustomError {
+	Error
+}
+
+fn ret() !string {
+	return if true {
+		'ok'
+	} else {
+		CustomError{}
+	}
+}
+
+fn test_return_if_expr_with_custom_error() {
+	if r := ret() {
+		assert r == 'ok'
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix returning if expr with custom error (fix #17187).

- Fix returning if expr with custom error.
- Add test.

```v
struct CustomError {
	Error
}

fn ret() !string {
	return if true {
		'ok'
	} else {
		CustomError{}
	}
}

fn main() {
	if r := ret() {
		println(r)
		assert r == 'ok'
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
ok
```