### PR TITLE
parser: fix fn attrs with anon struct param (fix #17264)

### DIFF
--- a/vlib/v/fmt/tests/anon_struct_as_param_with_fn_attrs_keep.vv
+++ b/vlib/v/fmt/tests/anon_struct_as_param_with_fn_attrs_keep.vv
@@ -1,0 +1,14 @@
+// foo.v
+
+[params]
+fn hello(person struct { name string }) string {
+	if person.name == '' {
+		return 'Hello World!'
+	} else {
+		return 'Hello ${person.name}'
+	}
+}
+
+fn main() {
+	println(hello())
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -11,7 +11,6 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	p.top_level_statement_start()
 	// save attributes, they will be changed later in fields
 	attrs := p.attrs
-	p.attrs = []
 	start_pos := p.tok.pos()
 	mut is_pub := p.tok.kind == .key_pub
 	if is_pub {
@@ -267,6 +266,8 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 			}
 			// Comments after type (same line)
 			comments << p.eat_comments()
+			prev_attrs := p.attrs
+			p.attrs = []
 			if p.tok.kind == .lsbr {
 				p.inside_struct_attr_decl = true
 				// attrs are stored in `p.attrs`
@@ -331,7 +332,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				is_volatile: is_field_volatile
 				is_deprecated: is_field_deprecated
 			}
-			p.attrs = []
+			p.attrs = prev_attrs
 			i++
 		}
 		p.top_level_statement_end()


### PR DESCRIPTION
This PR fix fn attrs with anon struct param (fix #17264).

- Fix fn attrs with anon struct param.
- Add test.

anon_struct_as_param_with_fn_attrs_keep.vv
```v
// foo.v

[params]
fn hello(person struct { name string }) string {
	if person.name == '' {
		return 'Hello World!'
	} else {
		return 'Hello ${person.name}'
	}
}

fn main() {
	println(hello())
}
```