### PR TITLE
checker: fix generic array of sumtype push operation (fix #17259)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -476,7 +476,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 								right_pos)
 						}
 					} else {
-						right_value_type := c.table.value_type(right_type)
+						right_value_type := c.table.value_type(c.unwrap_generic(right_type))
 						if !c.table.is_sumtype_or_in_variant(left_value_type, ast.mktyp(right_value_type)) {
 							c.error('cannot append `${right_sym.name}` to `${left_sym.name}`',
 								right_pos)

--- a/vlib/v/tests/generic_array_of_sumtype_push_test.v
+++ b/vlib/v/tests/generic_array_of_sumtype_push_test.v
@@ -1,0 +1,19 @@
+type SumType = int | string
+
+fn template_fn[T](a []T) []T {
+	mut b := []T{}
+	b << a
+	return b
+}
+
+fn test_generic_array_of_sumtype_push() {
+	ret1 := template_fn([SumType(1)])
+	println(ret1)
+	assert ret1.len == 1
+	assert ret1[0] == SumType(1)
+
+	ret2 := template_fn([SumType('hello')])
+	println(ret2)
+	assert ret2.len == 1
+	assert ret2[0] == SumType('hello')
+}


### PR DESCRIPTION
This PR fix generic array of sumtype push operation (fix #17259).

- Fix generic array of sumtype push operation.
- Add test.

```v
type SumType = int | string

fn template_fn[T](a []T) []T {
	mut b := []T{}
	b << a
	return b
}

fn main() {
	ret1 := template_fn([SumType(1)])
	println(ret1)
	assert ret1.len == 1
	assert ret1[0] == SumType(1)

	ret2 := template_fn([SumType('hello')])
	println(ret2)
	assert ret2.len == 1
	assert ret2[0] == SumType('hello')
}

PS D:\Test\v\tt1> v run .
[SumType(1)]
[SumType('hello')]
```