### PR TITLE
docs: add a new line before tables

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -935,6 +935,7 @@ mut square := []int{len: 6, init: it * it}
 #### Array Types
 
 An array can be of these types:
+
 | Types        | Example Definition                   |
 | ------------ | ------------------------------------ |
 | Number       | `[]int,[]i64`                        |
@@ -5299,6 +5300,7 @@ Right now it can be used to detect an OS, compiler, platform or compilation opti
 is compiled with `v -g` or `v -cg`.
 If you're using a custom ifdef, then you do need `$if option ? {}` and compile with`v -d option`.
 Full list of builtin options:
+
 | OS                            | Compilers         | Platforms             | Other                     |
 | ---                           | ---               | ---                   | ---                       |
 | `windows`, `linux`, `macos`   | `gcc`, `tinyc`    | `amd64`, `arm64`      | `debug`, `prod`, `test`   |


### PR DESCRIPTION
Non-GitHub markdown parsers can't process tables if there is no new line before. V markdown library doesn't parse it too.

Before: <img width="1448" alt="before" src="https://user-images.githubusercontent.com/104449470/217956273-20457c26-1b02-4427-a114-b6e3be97766a.png">

After: <img width="1448" alt="after" src="https://user-images.githubusercontent.com/104449470/217956286-1c63e3f8-5e81-475c-9287-9c7df89c740d.png">
