### PR TITLE
checker: check nested struct field with required attr (fix #10913)

### DIFF
--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -71,7 +71,7 @@ fn todo_del() {}
 [typedef]
 struct C.XSelectionRequestEvent {
 mut:
-	display   &C.Display // Display the event was read from
+	display   &C.Display = unsafe { nil } // Display the event was read from
 	owner     Window
 	requestor Window
 	selection Atom
@@ -84,7 +84,7 @@ mut:
 struct C.XSelectionEvent {
 mut:
 	@type     int
-	display   &C.Display // Display the event was read from
+	display   &C.Display = unsafe { nil } // Display the event was read from
 	requestor Window
 	selection Atom
 	target    Atom

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -6,7 +6,6 @@ module http
 import strings
 
 // Header represents the key-value pairs in an HTTP header
-[noinit]
 pub struct Header {
 mut:
 	data map[string][]string

--- a/vlib/net/mbedtls/c.v
+++ b/vlib/net/mbedtls/c.v
@@ -118,31 +118,31 @@ $if prod && opt_size ? {
 #include <mbedtls/error.h>
 
 [typedef]
-struct C.mbedtls_net_context {
+pub struct C.mbedtls_net_context {
 mut:
 	fd int
 }
 
 [typedef]
-struct C.mbedtls_x509_crt {}
+pub struct C.mbedtls_x509_crt {}
 
 [typedef]
-struct C.mbedtls_x509_crl {}
+pub struct C.mbedtls_x509_crl {}
 
 [typedef]
-struct C.mbedtls_pk_context {}
+pub struct C.mbedtls_pk_context {}
 
 [typedef]
-struct C.mbedtls_entropy_context {}
+pub struct C.mbedtls_entropy_context {}
 
 [typedef]
-struct C.mbedtls_ctr_drbg_context {}
+pub struct C.mbedtls_ctr_drbg_context {}
 
 [typedef]
-struct C.mbedtls_ssl_context {}
+pub struct C.mbedtls_ssl_context {}
 
 [typedef]
-struct C.mbedtls_ssl_config {}
+pub struct C.mbedtls_ssl_config {}
 
 fn C.mbedtls_net_init(&C.mbedtls_net_context)
 fn C.mbedtls_ssl_init(&C.mbedtls_ssl_context)

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -349,7 +349,7 @@ pub fn (c &TcpListener) addr() !Addr {
 	return c.sock.address()
 }
 
-struct TcpSocket {
+pub struct TcpSocket {
 	Socket
 }
 

--- a/vlib/net/websocket/uri.v
+++ b/vlib/net/websocket/uri.v
@@ -1,7 +1,7 @@
 module websocket
 
 // Uri represents an Uri for websocket connections
-struct Uri {
+pub struct Uri {
 mut:
 	url         string // url to the websocket endpoint
 	hostname    string // hostname of the websocket endpoint

--- a/vlib/readline/readline_default.c.v
+++ b/vlib/readline/readline_default.c.v
@@ -10,7 +10,7 @@ module readline
 
 import os
 
-struct Termios {
+pub struct Termios {
 }
 
 // Only use standard os.get_line

--- a/vlib/readline/readline_js.js.v
+++ b/vlib/readline/readline_js.js.v
@@ -2,7 +2,7 @@ module readline
 
 #const $readline = require('readline')
 
-struct Termios {}
+pub struct Termios {}
 
 // Only use standard os.get_line
 // Need implementation for readline capabilities

--- a/vlib/readline/readline_linux.c.v
+++ b/vlib/readline/readline_linux.c.v
@@ -26,7 +26,7 @@ mut:
 	c_cc    [cclen]int
 }
 
-struct Termios {
+pub struct Termios {
 mut:
 	c_iflag u32
 	c_oflag u32

--- a/vlib/readline/readline_windows.c.v
+++ b/vlib/readline/readline_windows.c.v
@@ -11,7 +11,7 @@ module readline
 import os
 
 // needed for parity with readline_default.c.v
-struct Termios {
+pub struct Termios {
 }
 
 // Only use standard os.get_line

--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -31,19 +31,19 @@ fn C.pthread_cond_timedwait(voidptr, voidptr, voidptr) int
 fn C.pthread_cond_destroy(voidptr) int
 
 [typedef]
-struct C.pthread_mutex_t {}
+pub struct C.pthread_mutex_t {}
 
 [typedef]
-struct C.pthread_cond_t {}
+pub struct C.pthread_cond_t {}
 
 [typedef]
-struct C.pthread_rwlock_t {}
+pub struct C.pthread_rwlock_t {}
 
 [typedef]
-struct C.pthread_rwlockattr_t {}
+pub struct C.pthread_rwlockattr_t {}
 
 [typedef]
-struct C.sem_t {}
+pub struct C.sem_t {}
 
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 [heap]

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -33,16 +33,16 @@ fn C.sem_timedwait(voidptr, voidptr) int
 fn C.sem_destroy(voidptr) int
 
 [typedef]
-struct C.pthread_mutex_t {}
+pub struct C.pthread_mutex_t {}
 
 [typedef]
-struct C.pthread_rwlock_t {}
+pub struct C.pthread_rwlock_t {}
 
 [typedef]
-struct C.pthread_rwlockattr_t {}
+pub struct C.pthread_rwlockattr_t {}
 
 [typedef]
-struct C.sem_t {}
+pub struct C.sem_t {}
 
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 [heap]

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -583,6 +583,11 @@ fn (mut c Checker) struct_init(mut node ast.StructInit) ast.Type {
 					continue
 				}
 				if sym.kind == .struct_ {
+					mut zero_struct_init := ast.StructInit{
+						pos: node.pos
+						typ: field.typ
+					}
+					c.struct_init(mut zero_struct_init)
 					c.check_ref_fields_initialized(sym, mut checked_types, '${type_sym.name}.${field.name}',
 						node)
 				} else if sym.kind == .alias {

--- a/vlib/v/checker/tests/nested_struct_with_required_attr_err.out
+++ b/vlib/v/checker/tests/nested_struct_with_required_attr_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/nested_struct_with_required_attr_err.vv:13:7: error: field `Egg.name` must be initialized
+   11 |
+   12 | fn main() {
+   13 |     f := Foo{}
+      |          ~~~~~
+   14 |     println(f)
+   15 | }

--- a/vlib/v/checker/tests/nested_struct_with_required_attr_err.vv
+++ b/vlib/v/checker/tests/nested_struct_with_required_attr_err.vv
@@ -1,0 +1,15 @@
+struct Foo {
+	bar Bar
+}
+struct Bar {
+	egg Egg
+}
+
+struct Egg {
+	name string [required]
+}
+
+fn main() {
+	f := Foo{}
+	println(f)
+}

--- a/vlib/v/checker/tests/struct_field_generic_struct_unknown_type_err.out
+++ b/vlib/v/checker/tests/struct_field_generic_struct_unknown_type_err.out
@@ -5,3 +5,9 @@ vlib/v/checker/tests/struct_field_generic_struct_unknown_type_err.vv:9:7: error:
       |       ~~~~~~~~~~~~~~~~~~
    10 | }
    11 |
+vlib/v/checker/tests/struct_field_generic_struct_unknown_type_err.vv:13:9: error: unknown type `UnknownType`
+   11 |
+   12 | fn main() {
+   13 |     _ = MyType {}
+      |         ~~~~~~~~~
+   14 | }

--- a/vlib/v/checker/tests/struct_field_reference_type_err.out
+++ b/vlib/v/checker/tests/struct_field_reference_type_err.out
@@ -1,12 +1,19 @@
+vlib/v/checker/tests/struct_field_reference_type_err.vv:12:16: warning: reference field `Duck.age` must be initialized
+   10 |
+   11 | fn main() {
+   12 |     mut animal := Animal{
+      |                   ~~~~~~~
+   13 |         ageee: 20
+   14 |     }
 vlib/v/checker/tests/struct_field_reference_type_err.vv:12:16: warning: reference field `Animal.duck.age` must be initialized (part of struct `Duck`)
-   10 | 
+   10 |
    11 | fn main() {
    12 |     mut animal := Animal{
       |                   ~~~~~~~
    13 |         ageee: 20
    14 |     }
 vlib/v/checker/tests/struct_field_reference_type_err.vv:17:3: error: reference field must be initialized with reference
-   15 | 
+   15 |
    16 |     animal.duck = Duck{
    17 |         age: animal.ageee
       |         ~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
@@ -1,12 +1,19 @@
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `ContainsRef.b` must be initialized
+   23 |
+   24 | fn main() {
+   25 |     _ := Outer{}
+      |          ~~~~~~~
+   26 |     _ := Struct{}
+   27 | }
 vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `Outer.c1.b` must be initialized (part of struct `ContainsRef`)
-   23 | 
+   23 |
    24 | fn main() {
    25 |     _ := Outer{}
       |          ~~~~~~~
    26 |     _ := Struct{}
    27 | }
 vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:25:7: warning: reference field `Outer.c2.b` must be initialized (part of struct `ContainsRef`)
-   23 | 
+   23 |
    24 | fn main() {
    25 |     _ := Outer{}
       |          ~~~~~~~

--- a/vlib/v/fmt/vfmt_on_off.v
+++ b/vlib/v/fmt/vfmt_on_off.v
@@ -21,7 +21,7 @@ import v.util
 // All lines after `// vfmt off` are passed on *without any modification* to the output.
 // All lines after `// vfmt on` are going to be formatted, and then added to the output.
 
-struct FormatState {
+pub struct FormatState {
 mut:
 	is_vfmt_on           bool = true
 	last_off_source_line int // the source line where // vfmt off was encountered first

--- a/vlib/v/gen/native/elf.v
+++ b/vlib/v/gen/native/elf.v
@@ -277,7 +277,7 @@ fn (mut g Gen) gen_program_header(p ProgramHeader) {
 	g.println('; ^^^ program header (64)')
 }
 
-struct SectionHeader {
+pub struct SectionHeader {
 mut:
 	name      int // Offset to name string in .shstrtab.
 	typ       int // Section type.
@@ -439,7 +439,7 @@ type SectionData = DynSymSection
 	| []RelASection
 	| []SymbolTableSection
 
-struct Section {
+pub struct Section {
 	name string
 mut:
 	header SectionHeader


### PR DESCRIPTION
This PR check nested struct field with required attr (fix #10913).

- Check nested struct field with required attr.
- Add test.

```v
struct Foo {
	bar Bar
}
struct Bar {
	egg Egg
}

struct Egg {
	name string [required]
}

fn main() {
	f := Foo{}
	println(f)
}

PS D:\Test\v\tt1> v run .
tt1.v:13:7: error: field `Egg.name` must be initialized
   11 |
   12 | fn main() {
   13 |     f := Foo{}
      |          ~~~~~
   14 |     println(f)
   15 | }
```