### PR TITLE
cgen: fix c_fn_name() for mongo module

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -904,7 +904,9 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 		sftyp := g.typ(ftyp_noshared)
 		mut field_styp := sftyp.replace('*', '')
 		field_styp_fn_name := if sym_has_str_method {
-			mut field_fn_name := '${field_styp}_str'
+			left_cc_type := g.cc_type(ftyp_noshared, false)
+			left_fn_name := util.no_dots(left_cc_type)
+			mut field_fn_name := '${left_fn_name}_str'
 			if sym.info is ast.Struct {
 				field_fn_name = g.generic_fn_name(sym.info.concrete_types, field_fn_name)
 			}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -434,11 +434,6 @@ fn (mut g Gen) c_fn_name(node &ast.FnDecl) !string {
 			return error('none')
 		}
 		name = g.cc_type(node.receiver.typ, false) + '_' + name
-		if unwrapped_rec_sym.language == .c && node.receiver.typ.is_real_pointer()
-			&& node.name == 'str' {
-			// TODO: handle this in a more general way, perhaps add a `[typedef_incomplete]` attribute, for C structs instead of this hack
-			name = name.replace_once('C__', '')
-		}
 	}
 	if node.language == .c {
 		name = util.no_dots(name)


### PR DESCRIPTION
This PR fix c_fn_name() for mongo module.

```v
pub fn (document &C.bson_t) str() string {
	return unsafe {
		C.bson_as_json(document, 0).vstring()
	}
}
```
Before: generated fn name: `bson_t_str()`.
Now: generated fn name: `C__bson_t_str()`.
- Use consistent function naming.