### PR TITLE
tests: add more tests for struct option fields in `vlib/v/tests/option_test.v`

### DIFF
--- a/vlib/v/tests/option_test.v
+++ b/vlib/v/tests/option_test.v
@@ -180,52 +180,59 @@ fn test_reassignment() {
 	assert x3 == 777
 }
 
-struct Person {
+struct OptionFieldsStruct {
 mut:
-	name  string
-	age   int
-	title ?string
+	text ?string
+	n    ?int
+	n1   ?int = 1
 }
 
-fn test_field_or() {
-	name := foo_str() or { 'nada' }
-	assert name == 'something'
-	/*
-	QTODO
-	mut p := Person{}
-	p.name = foo_str() or {
-		'nothing'
+fn get_opt_struct() ?OptionFieldsStruct {
+	return OptionFieldsStruct{}
+}
+
+fn test_option_field() ? {
+	mut v := OptionFieldsStruct{}
+	assert v.text or { 'default' } == 'default'
+	assert v.n or { 42 } == 42
+	assert v.n1 or { 42 } == 1
+	assert (v.n or { v.n1? }) == 1
+
+	if n := v.n {
+		assert false
+	} else {
+		assert true
 	}
-	assert p.name == 'something'
-	p.age = foo_ok() or {
-		panic('no age')
+	if n1 := v.n1 {
+		assert n1 == 1
+	} else {
+		assert false
 	}
-	assert p.age == 777
-	mytitle := p.title or {
-		'default'
+
+	n := v.n or { 10 }
+	assert n == 10
+	n1 := v.n1 or { 10 }
+	assert n1 == 1
+	n1_1 := v.n1? + (v.n or { 10 })
+	assert n1_1 == 11
+
+	v.text = 'text'
+	assert v.text? == 'text'
+	v.n = 42
+	assert v.n? == 42
+	v.n1 = 43
+	assert v.n1? == 43
+
+	v = OptionFieldsStruct{
+		text: 'init'
+		n: 0
+		n1: none
 	}
-	assert mytitle == 'default'
-	*/
-}
+	assert v.text? == 'init'
+	assert v.n? == 0
+	assert v.n1 or { 42 } == 42
 
-struct Thing {
-mut:
-	opt ?int
-}
-
-struct Thing2 {
-mut:
-	opt ?Thing
-}
-
-fn test_opt_field() {
-	/*
-	QTODO
-	mut t := Thing{}
-	t.opt = 5
-	val := t.opt or { return }
-	assert val == 5
-	*/
+	assert get_opt_struct()?.n1? == 1
 }
 
 fn opt_ptr(a &int) ?&int {
@@ -358,11 +365,6 @@ fn test_option_sum_type() {
 		return
 	}
 	assert false
-}
-
-struct MultiOptionFieldTest {
-	a ?int
-	b ?int
 }
 
 fn foo() ?int {


### PR DESCRIPTION
There are tests for struct option fields only in `slow_tests/inout/`.
I think it is better to also exists as normal tests.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
