### PR TITLE
net.websocket: call close event

### DIFF
--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -337,6 +337,7 @@ pub fn (mut ws Client) close(code int, message string) ! {
 	defer {
 		ws.shutdown_socket() or {}
 		ws.reset_state() or {}
+		ws.send_close_event(code, message)
 	}
 	ws.set_state(.closing)
 	// mut code32 := 0


### PR DESCRIPTION
This pr calls the client's close events when closed abruptly