### PR TITLE
cgen, checker: fix comptimeselector resolution + if comptime branching improvement + comptimeselector cleanup

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -385,7 +385,7 @@ pub fn (x Expr) str() string {
 			}
 		}
 		ComptimeSelector {
-			return '${x.left}.$${x.field_expr}'
+			return '${x.left}.$(${x.field_expr})'
 		}
 		ConcatExpr {
 			return x.vals.map(it.str()).join(',')

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -149,8 +149,6 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					}
 				}
 			}
-		} else if right is ast.ComptimeSelector {
-			right_type = c.comptime_fields_default_type
 		}
 		if is_decl {
 			// check generic struct init and return unwrap generic struct type

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -294,6 +294,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 								}
 								if right is ast.ComptimeSelector {
 									left.obj.is_comptime_field = true
+									left.obj.typ = c.comptime_fields_default_type
 								}
 							}
 							ast.GlobalField {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -149,6 +149,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					}
 				}
 			}
+		} else if right is ast.ComptimeSelector {
+			right_type = c.comptime_fields_default_type
 		}
 		if is_decl {
 			// check generic struct init and return unwrap generic struct type

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -873,19 +873,12 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					typ = ast.new_type(idx).derive(arg.typ)
 				} else if c.inside_comptime_for_field && sym.kind in [.struct_, .any]
 					&& arg.expr is ast.ComptimeSelector {
-					compselector := arg.expr as ast.ComptimeSelector
-					if compselector.field_expr is ast.SelectorExpr {
-						selectorexpr := compselector.field_expr as ast.SelectorExpr
-						if selectorexpr.expr is ast.Ident {
-							ident := selectorexpr.expr as ast.Ident
-							if ident.name == c.comptime_for_field_var {
-								typ = c.comptime_fields_default_type
-
-								if func.return_type.has_flag(.generic)
-									&& gt_name == c.table.type_to_str(func.return_type) {
-									node.comptime_ret_val = true
-								}
-							}
+					comptime_typ := c.get_comptime_selector_type(arg.expr, ast.void_type)
+					if comptime_typ != ast.void_type {
+						typ = comptime_typ
+						if func.return_type.has_flag(.generic)
+							&& gt_name == c.table.type_to_str(func.return_type) {
+							node.comptime_ret_val = true
 						}
 					}
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2688,15 +2688,6 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 // 	return ast.void_type
 // }
 
-fn (mut c Checker) get_comptime_selector_type(node ast.ComptimeSelector, default_type ast.Type) ast.Type {
-	if node.field_expr is ast.SelectorExpr
-		&& c.check_comptime_is_field_selector(node.field_expr as ast.SelectorExpr)
-		&& (node.field_expr as ast.SelectorExpr).field_name == 'name' {
-		return c.comptime_fields_default_type
-	}
-	return default_type
-}
-
 fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	// Given: `Outside( Inside(xyz) )`,
 	//        node.expr_type: `Inside`

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2688,25 +2688,11 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 // 	return ast.void_type
 // }
 
-fn (mut c Checker) get_comptime_selector_type(node ast.ComptimeSelector, default_type ast.Type) ast.Type {
-	if node.field_expr is ast.SelectorExpr
-		&& c.check_comptime_is_field_selector(node.field_expr as ast.SelectorExpr)
-		&& (node.field_expr as ast.SelectorExpr).field_name == 'name' {
-		return c.comptime_fields_default_type
-	}
-	return default_type
-}
-
 fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	// Given: `Outside( Inside(xyz) )`,
 	//        node.expr_type: `Inside`
 	//        node.typ: `Outside`
 	node.expr_type = c.expr(node.expr) // type to be casted
-
-	if node.expr is ast.ComptimeSelector {
-		node.expr_type = c.get_comptime_selector_type(node.expr as ast.ComptimeSelector,
-			node.expr_type)
-	}
 
 	mut from_type := c.unwrap_generic(node.expr_type)
 	from_sym := c.table.sym(from_type)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2688,11 +2688,25 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 // 	return ast.void_type
 // }
 
+fn (mut c Checker) get_comptime_selector_type(node ast.ComptimeSelector, default_type ast.Type) ast.Type {
+	if node.field_expr is ast.SelectorExpr
+		&& c.check_comptime_is_field_selector(node.field_expr as ast.SelectorExpr)
+		&& (node.field_expr as ast.SelectorExpr).field_name == 'name' {
+		return c.comptime_fields_default_type
+	}
+	return default_type
+}
+
 fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	// Given: `Outside( Inside(xyz) )`,
 	//        node.expr_type: `Inside`
 	//        node.typ: `Outside`
 	node.expr_type = c.expr(node.expr) // type to be casted
+
+	if node.expr is ast.ComptimeSelector {
+		node.expr_type = c.get_comptime_selector_type(node.expr as ast.ComptimeSelector,
+			node.expr_type)
+	}
 
 	mut from_type := c.unwrap_generic(node.expr_type)
 	from_sym := c.table.sym(from_type)

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -146,7 +146,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 
 fn (mut c Checker) comptime_selector(mut node ast.ComptimeSelector) ast.Type {
 	node.left_type = c.expr(node.left)
-	expr_type := c.unwrap_generic(c.expr(node.field_expr))
+	mut expr_type := c.unwrap_generic(c.expr(node.field_expr))
 	expr_sym := c.table.sym(expr_type)
 	if expr_type != ast.string_type {
 		c.error('expected `string` instead of `${expr_sym.name}` (e.g. `field.name`)',
@@ -159,6 +159,10 @@ fn (mut c Checker) comptime_selector(mut node ast.ComptimeSelector) ast.Type {
 				left_pos)
 		}
 		expr_name := node.field_expr.expr.str()
+		expr_type = c.get_comptime_selector_type(node, ast.void_type)
+		if expr_type != ast.void_type {
+			return expr_type
+		}
 		if expr_name in c.comptime_fields_type {
 			return c.comptime_fields_type[expr_name]
 		}
@@ -755,6 +759,18 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 	return .unknown
 }
 
+// get_comptime_selector_type retrieves the var.$(field.name) type when field_name is 'name' otherwise default_type is returned
+[inline]
+fn (mut c Checker) get_comptime_selector_type(node ast.ComptimeSelector, default_type ast.Type) ast.Type {
+	if node.field_expr is ast.SelectorExpr
+		&& c.check_comptime_is_field_selector(node.field_expr as ast.SelectorExpr)
+		&& (node.field_expr as ast.SelectorExpr).field_name == 'name' {
+		return c.unwrap_generic(c.comptime_fields_default_type)
+	}
+	return default_type
+}
+
+// check_comptime_is_field_selector checks if the SelectorExpr is related to $for variable
 [inline]
 fn (mut c Checker) check_comptime_is_field_selector(node ast.SelectorExpr) bool {
 	if c.inside_comptime_for_field && node.expr is ast.Ident {
@@ -763,6 +779,7 @@ fn (mut c Checker) check_comptime_is_field_selector(node ast.SelectorExpr) bool 
 	return false
 }
 
+// check_comptime_is_field_selector_bool checks if the SelectorExpr is related to field.is_* boolean fields
 [inline]
 fn (mut c Checker) check_comptime_is_field_selector_bool(node ast.SelectorExpr) bool {
 	if c.check_comptime_is_field_selector(node) {
@@ -772,6 +789,7 @@ fn (mut c Checker) check_comptime_is_field_selector_bool(node ast.SelectorExpr) 
 	return false
 }
 
+// get_comptime_selector_bool_field evaluates the bool value for field.is_* fields
 fn (mut c Checker) get_comptime_selector_bool_field(field_name string) bool {
 	field := c.comptime_for_field_value
 	field_typ := c.comptime_fields_default_type

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -158,11 +158,11 @@ fn (mut c Checker) comptime_selector(mut node ast.ComptimeSelector) ast.Type {
 			c.error('compile time field access can only be used when iterating over `T.fields`',
 				left_pos)
 		}
-		expr_name := node.field_expr.expr.str()
 		expr_type = c.get_comptime_selector_type(node, ast.void_type)
 		if expr_type != ast.void_type {
 			return expr_type
 		}
+		expr_name := node.field_expr.expr.str()
 		if expr_name in c.comptime_fields_type {
 			return c.comptime_fields_type[expr_name]
 		}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -121,7 +121,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							comptime_field_name = left.expr.str()
 							c.comptime_fields_type[comptime_field_name] = got_type
 							is_comptime_type_is_expr = true
-							skip_state = if c.comptime_fields_default_type == got_type { .eval } else { .skip }
+							skip_state = if c.comptime_fields_default_type == got_type {
+								.eval
+							} else {
+								.skip
+							}
 						} else if right is ast.TypeNode && left is ast.TypeNode
 							&& sym.kind == .interface_ {
 							is_comptime_type_is_expr = true

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -137,10 +137,14 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							comptime_field_name = left.expr.str()
 							c.comptime_fields_type[comptime_field_name] = got_type
 							is_comptime_type_is_expr = true
-							if comptime_field_name == c.comptime_for_field_var
-								&& left.field_name in ['unaliased_typ', 'typ'] {
-								skip_state = c.check_compatible_types(c.comptime_fields_default_type,
-									right as ast.TypeNode)
+							if comptime_field_name == c.comptime_for_field_var {
+								if left.field_name == 'typ' {
+									skip_state = c.check_compatible_types(c.comptime_fields_default_type,
+										right as ast.TypeNode)
+								} else if left.field_name == 'unaliased_typ' {
+									skip_state = c.check_compatible_types(c.table.unaliased_type(c.comptime_fields_default_type),
+										right as ast.TypeNode)
+								}
 							} else if c.check_comptime_is_field_selector_bool(left) {
 								skip_state = if c.get_comptime_selector_bool_field(left.field_name) {
 									.eval

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -141,6 +141,12 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 								&& left.field_name in ['unaliased_typ', 'typ'] {
 								skip_state = c.check_compatible_types(c.comptime_fields_default_type,
 									right as ast.TypeNode)
+							} else if c.check_comptime_is_field_selector_bool(left) {
+								skip_state = if c.get_comptime_selector_bool_field(left.field_name) {
+									.eval
+								} else {
+									.skip
+								}
 							}
 						} else if left is ast.TypeNode {
 							is_comptime_type_is_expr = true

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -138,11 +138,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							c.comptime_fields_type[comptime_field_name] = got_type
 							is_comptime_type_is_expr = true
 							if comptime_field_name == c.comptime_for_field_var {
+								left_type := c.unwrap_generic(c.comptime_fields_default_type)
 								if left.field_name == 'typ' {
-									skip_state = c.check_compatible_types(c.comptime_fields_default_type,
-										right as ast.TypeNode)
+									skip_state = c.check_compatible_types(left_type, right as ast.TypeNode)
 								} else if left.field_name == 'unaliased_typ' {
-									skip_state = c.check_compatible_types(c.table.unaliased_type(c.comptime_fields_default_type),
+									skip_state = c.check_compatible_types(c.table.unaliased_type(left_type),
 										right as ast.TypeNode)
 								}
 							} else if c.check_comptime_is_field_selector_bool(left) {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -121,10 +121,13 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							comptime_field_name = left.expr.str()
 							c.comptime_fields_type[comptime_field_name] = got_type
 							is_comptime_type_is_expr = true
-							skip_state = if c.comptime_fields_default_type == got_type {
-								.eval
-							} else {
-								.skip
+							if comptime_field_name == c.comptime_for_field_var
+								&& left.field_name == 'typ' {
+								skip_state = if c.comptime_fields_default_type == got_type {
+									.eval
+								} else {
+									.skip
+								}
 							}
 						} else if right is ast.TypeNode && left is ast.TypeNode
 							&& sym.kind == .interface_ {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -121,6 +121,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							comptime_field_name = left.expr.str()
 							c.comptime_fields_type[comptime_field_name] = got_type
 							is_comptime_type_is_expr = true
+							skip_state = if c.comptime_fields_default_type == got_type { .eval } else { .skip }
 						} else if right is ast.TypeNode && left is ast.TypeNode
 							&& sym.kind == .interface_ {
 							is_comptime_type_is_expr = true

--- a/vlib/v/checker/postfix.v
+++ b/vlib/v/checker/postfix.v
@@ -24,7 +24,7 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	}
 	if !(typ_sym.is_number() || ((c.inside_unsafe || c.pref.translated) && is_non_void_pointer)) {
 		if c.inside_comptime_for_field {
-			if c.is_comptime_var(node.expr) {
+			if c.is_comptime_var(node.expr) || node.expr is ast.ComptimeSelector {
 				return c.comptime_fields_default_type
 			}
 		}

--- a/vlib/v/checker/postfix.v
+++ b/vlib/v/checker/postfix.v
@@ -26,8 +26,6 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 		if c.inside_comptime_for_field {
 			if c.is_comptime_var(node.expr) {
 				return c.comptime_fields_default_type
-			} else if node.expr is ast.ComptimeSelector {
-				return c.comptime_fields_default_type
 			}
 		}
 

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -647,8 +647,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 		node.update_expr_type = update_type
 		if node.update_expr is ast.ComptimeSelector {
 			c.error('cannot use struct update syntax in compile time expressions', node.update_expr_pos)
-		}
-		if c.table.final_sym(update_type).kind != .struct_ {
+		} else if c.table.final_sym(update_type).kind != .struct_ {
 			s := c.table.type_to_str(update_type)
 			c.error('expected struct, found `${s}`', node.update_expr.pos())
 		} else if update_type != node.typ {

--- a/vlib/v/checker/tests/comptime_dump_fields_var_test.out
+++ b/vlib/v/checker/tests/comptime_dump_fields_var_test.out
@@ -1,8 +1,8 @@
-[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: c
-[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: d
-[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: 1
-[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: 0
-[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$field.name: struct {
+[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$(field.name): c
+[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$(field.name): d
+[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$(field.name): 1
+[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$(field.name): 0
+[vlib/v/checker/tests/comptime_dump_fields_var_test.vv:13] val.$(field.name): struct {
     i: 100
 }
 ok

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -131,6 +131,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					key_str := g.get_comptime_selector_key_type(val)
 					if key_str != '' {
 						var_type = g.comptime_var_type_map[key_str] or { var_type }
+						val_type = var_type
 						left.obj.typ = var_type
 						is_comptime_var = true
 					}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -143,6 +143,17 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				}
 				is_auto_heap = left.obj.is_auto_heap
 			}
+		} else if mut left is ast.ComptimeSelector {
+			key_str := g.get_comptime_selector_key_type(left)
+			if key_str != '' {
+				var_type = g.comptime_var_type_map[key_str] or { var_type }
+			}
+			if val is ast.ComptimeSelector {
+				key_str_right := g.get_comptime_selector_key_type(val)
+				if key_str_right != '' {
+					val_type = g.comptime_var_type_map[key_str_right] or { var_type }
+				}
+			}
 		}
 		mut styp := g.typ(var_type)
 		mut is_fixed_array_init := false

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -490,8 +490,12 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						} else if val_type.has_flag(.shared_f) {
 							g.expr_with_cast(val, val_type, var_type)
 						} else if is_comptime_var && g.right_is_opt {
-							tmp_var := g.new_tmp_var()
-							g.expr_with_tmp_var(val, val_type, var_type, tmp_var)
+							if var_type.has_flag(.option) && val is ast.ComptimeSelector {
+								g.expr(val)
+							} else {
+								tmp_var := g.new_tmp_var()
+								g.expr_with_tmp_var(val, val_type, var_type, tmp_var)
+							}
 						} else {
 							g.expr(val)
 						}

--- a/vlib/v/tests/comptime_sumtype_cast_test.v
+++ b/vlib/v/tests/comptime_sumtype_cast_test.v
@@ -1,0 +1,29 @@
+pub type Any = bool | int | map[string]Any | string
+
+struct StructType {
+mut:
+	val string
+}
+
+fn test_main() {
+	struct_to_map_string()
+}
+
+fn map_from[T](t T) {
+	$if T is $Struct {
+		$for field in T.fields {
+			assert Any('string').str() == "Any('string')"
+			assert t.$(field.name).str() == 'true'
+			a := t.$(field.name)
+			assert Any(a).str() == "Any('true')"
+			assert Any(t.$(field.name)).str() == "Any('true')"
+		}
+	}
+}
+
+fn struct_to_map_string() {
+	struct_type := StructType{
+		val: 'true'
+	}
+	map_from(struct_type)
+}

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -320,7 +320,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut wr io.Writer) ! {
 				$if field.unaliased_typ is string {
 					e.encode_string(val.$(field.name).str(), mut wr)!
 				} $else $if field.unaliased_typ is time.Time {
-					parsed_time := val.$(field.name) as time.Time
+					parsed_time := time.parse(val.$(field.name).str()) or { time.Time{} }
 					e.encode_string(parsed_time.format_rfc3339(), mut wr)!
 				} $else $if field.unaliased_typ in [bool, $Float, $Int] {
 					wr.write(val.$(field.name).str().bytes())!


### PR DESCRIPTION
This PR does a minor clean up on ComptimeSelector checking.

Doing such clean up I've spotted some bugs so I've fixed them.

Improved $if comp branching detecting `field.unaliased_typ is TypeNode`, `field.is_* is TypeNode` and `field.typ is TypeNode` checking.