### PR TITLE
checker: fix warn of unnnecessary default value for optional

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -168,7 +168,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 							field.default_expr.pos)
 					}
 				} else if field.typ.has_flag(.result) {
-					// struct field does not support result for now. Nothing to do
+					// struct field does not support result. Nothing to do
 				} else {
 					match field.default_expr {
 						ast.IntegerLiteral {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -161,20 +161,35 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 						}
 					}
 				}
-				if field.default_expr is ast.IntegerLiteral {
-					if field.default_expr.val == '0' {
-						c.warn('unnecessary default value of `0`: struct fields are zeroed by default',
+
+				if field.typ.has_flag(.option) {
+					if field.default_expr is ast.None {
+						c.warn('unnecessary default value of `none`: struct fields are zeroed by default',
 							field.default_expr.pos)
 					}
-				} else if field.default_expr is ast.StringLiteral {
-					if field.default_expr.val == '' {
-						c.warn("unnecessary default value of '': struct fields are zeroed by default",
-							field.default_expr.pos)
-					}
-				} else if field.default_expr is ast.BoolLiteral {
-					if field.default_expr.val == false {
-						c.warn('unnecessary default value `false`: struct fields are zeroed by default',
-							field.default_expr.pos)
+				} else if field.typ.has_flag(.result) {
+					// struct field does not support result for now. Nothing to do
+				} else {
+					match field.default_expr {
+						ast.IntegerLiteral {
+							if field.default_expr.val == '0' {
+								c.warn('unnecessary default value of `0`: struct fields are zeroed by default',
+									field.default_expr.pos)
+							}
+						}
+						ast.StringLiteral {
+							if field.default_expr.val == '' {
+								c.warn("unnecessary default value of '': struct fields are zeroed by default",
+									field.default_expr.pos)
+							}
+						}
+						ast.BoolLiteral {
+							if field.default_expr.val == false {
+								c.warn('unnecessary default value `false`: struct fields are zeroed by default',
+									field.default_expr.pos)
+							}
+						}
+						else {}
 					}
 				}
 			}

--- a/vlib/v/checker/tests/struct_unneeded_default.out
+++ b/vlib/v/checker/tests/struct_unneeded_default.out
@@ -1,20 +1,27 @@
-vlib/v/checker/tests/struct_unneeded_default.vv:2:10: warning: unnecessary default value of `0`: struct fields are zeroed by default
+vlib/v/checker/tests/struct_unneeded_default.vv:2:18: warning: unnecessary default value of `0`: struct fields are zeroed by default
     1 | struct Test {
-    2 |     n int = 0
-      |             ^
-    3 |     s string = ''
-    4 |     b bool = false
-vlib/v/checker/tests/struct_unneeded_default.vv:3:13: warning: unnecessary default value of '': struct fields are zeroed by default
-    1 | struct Test {
-    2 |     n int = 0
-    3 |     s string = ''
-      |                ~~
-    4 |     b bool = false
-    5 | }
-vlib/v/checker/tests/struct_unneeded_default.vv:4:11: warning: unnecessary default value `false`: struct fields are zeroed by default
-    2 |     n int = 0
-    3 |     s string = ''
-    4 |     b bool = false
-      |              ~~~~~
-    5 | }
-    6 |
+    2 |     n      int    = 0
+      |                     ^
+    3 |     n_ok   int    = 1
+    4 |     s      string = ''
+vlib/v/checker/tests/struct_unneeded_default.vv:4:18: warning: unnecessary default value of '': struct fields are zeroed by default
+    2 |     n      int    = 0
+    3 |     n_ok   int    = 1
+    4 |     s      string = ''
+      |                     ~~
+    5 |     s_ok   string = 's'
+    6 |     b      bool   = false
+vlib/v/checker/tests/struct_unneeded_default.vv:6:18: warning: unnecessary default value `false`: struct fields are zeroed by default
+    4 |     s      string = ''
+    5 |     s_ok   string = 's'
+    6 |     b      bool   = false
+      |                     ~~~~~
+    7 |     b_ok   bool   = true
+    8 |     opt    ?int   = none
+vlib/v/checker/tests/struct_unneeded_default.vv:8:18: warning: unnecessary default value of `none`: struct fields are zeroed by default
+    6 |     b      bool   = false
+    7 |     b_ok   bool   = true
+    8 |     opt    ?int   = none
+      |                     ~~~~
+    9 |     opt_ok ?int   = 1
+   10 | }

--- a/vlib/v/checker/tests/struct_unneeded_default.vv
+++ b/vlib/v/checker/tests/struct_unneeded_default.vv
@@ -1,7 +1,12 @@
 struct Test {
-	n int = 0
-	s string = ''
-	b bool = false
+	n      int    = 0
+	n_ok   int    = 1
+	s      string = ''
+	s_ok   string = 's'
+	b      bool   = false
+	b_ok   bool   = true
+	opt    ?int   = none
+	opt_ok ?int   = 1
 }
 
 fn main() {


### PR DESCRIPTION
Default value of `?int` is `none`.

https://github.com/vlang/v/blob/b13f7118ab6ae9afd78c92c312510eab20201973/vlib/v/tests/option_test.v#L183-L188
https://github.com/vlang/v/blob/b13f7118ab6ae9afd78c92c312510eab20201973/vlib/v/tests/option_test.v#L194-L196

But checker show warn for `= 0` not `= none`.

This PR fix it.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
