### PR TITLE
cgen: fix printing reference function (fix #17303)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -139,12 +139,12 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.get_str_fn(typ)
 		g.write('${str_fn_name}(')
-		if str_method_expects_ptr && !is_ptr {
-			g.write('&')
-		} else if (!str_method_expects_ptr && is_ptr && !is_shared) || is_var_mut {
-			g.write('*')
-		}
 		if sym.kind != .function {
+			if str_method_expects_ptr && !is_ptr {
+				g.write('&')
+			} else if (!str_method_expects_ptr && is_ptr && !is_shared) || is_var_mut {
+				g.write('*')
+			}
 			g.expr_with_cast(expr, typ, typ)
 		}
 		g.write(')')

--- a/vlib/v/tests/print_reference_function_test.v
+++ b/vlib/v/tests/print_reference_function_test.v
@@ -1,0 +1,7 @@
+fn foo() {
+}
+
+fn test_print_reference_function() {
+	println(&foo)
+	assert '${&foo}' == 'fn ()'
+}


### PR DESCRIPTION
This PR fix printing reference function (fix #17303).

- Fix printing reference function.
- Add test.

```v
fn foo() {
}

fn main() {
	println(&foo)
	assert '${&foo}' == 'fn ()'
}

PS D:\Test\v\tt1> v run .
fn ()
```