### PR TITLE
checker: fix printing address of reference struct (fix #17312)

### DIFF
--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -95,7 +95,8 @@ fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Type {
 					node.fmt_poss[i])
 			}
 			if c.table.final_sym(typ).kind in [.array, .array_fixed, .struct_, .interface_, .none_, .map, .sum_type]
-				&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`] {
+				&& fmt in [`E`, `F`, `G`, `e`, `f`, `g`, `d`, `u`, `x`, `X`, `o`, `c`, `p`, `b`]
+				&& !(typ.is_ptr() && fmt in [`p`, `x`, `X`]) {
 				c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
 					node.fmt_poss[i])
 			}

--- a/vlib/v/tests/print_address_of_reference_struct_test.v
+++ b/vlib/v/tests/print_address_of_reference_struct_test.v
@@ -1,0 +1,11 @@
+struct Foo {
+	abc int
+}
+
+fn test_print_address_of_reference_struct() {
+	foo := Foo{}
+	foo_ptr := &foo
+	println('${foo_ptr:p}')
+	println('${&foo:p}')
+	assert true
+}


### PR DESCRIPTION
This PR fix printing address of reference struct (fix #17312).

- Fix printing address of reference struct.
- Add test.

```v
struct Foo {
	abc int
}

fn main() {
	foo := Foo{}
	foo_ptr := &foo
	println('${foo_ptr:p}')
	println('${&foo:p}')
	assert true
}

PS D:\Test\v\tt1> v run .
1fefe0
1fefe0
```