### PR TITLE
checker: fix printing address of integer variable (fix #17326)

### DIFF
--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -83,14 +83,15 @@ fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Type {
 			if node.pluss[i] && !typ.is_number() {
 				c.error('plus prefix only allowed for numbers', node.fmt_poss[i])
 			}
-			if (typ.is_unsigned() && fmt !in [`u`, `x`, `X`, `o`, `c`, `b`])
+			if ((typ.is_unsigned() && fmt !in [`u`, `x`, `X`, `o`, `c`, `b`])
 				|| (typ.is_signed() && fmt !in [`d`, `x`, `X`, `o`, `c`, `b`])
 				|| (typ.is_int_literal()
 				&& fmt !in [`d`, `c`, `x`, `X`, `o`, `u`, `x`, `X`, `o`, `b`])
 				|| (typ.is_float() && fmt !in [`E`, `F`, `G`, `e`, `f`, `g`])
 				|| (typ.is_pointer() && fmt !in [`p`, `x`, `X`])
 				|| (typ.is_string() && fmt !in [`s`, `S`])
-				|| (typ.idx() in [ast.i64_type_idx, ast.f64_type_idx] && fmt == `c`) {
+				|| (typ.idx() in [ast.i64_type_idx, ast.f64_type_idx] && fmt == `c`))
+				&& !(typ.is_ptr() && fmt in [`p`, `x`, `X`]) {
 				c.error('illegal format specifier `${fmt:c}` for type `${c.table.get_type_name(ftyp)}`',
 					node.fmt_poss[i])
 			}

--- a/vlib/v/tests/print_address_of_reference_int_test.v
+++ b/vlib/v/tests/print_address_of_reference_int_test.v
@@ -1,0 +1,14 @@
+fn test_print_address_of_reference_base_type() {
+	a1 := 22
+	println('${&a1:p}')
+	a2 := 22.22
+	println('${&a2:p}')
+	a3 := `a`
+	println('${&a3:p}')
+	a4 := 'hello'
+	println('${&a4:p}')
+	a5 := true
+	println('${&a5:p}')
+
+	assert true
+}


### PR DESCRIPTION
This PR fix printing address of integer variable (fix #17326).

- Fix printing address of integer variable.
- Add test.

```v
fn main() {
	a1 := 22
	println('${&a1:p}')
	a2 := 22.22
	println('${&a2:p}')
	a3 := `a`
	println('${&a3:p}')
	a4 := 'hello'
	println('${&a4:p}')
	a5 := true
	println('${&a5:p}')

	assert true
}

PS D:\Test\v\tt1> v run .
14efe5c
14efdd0
14efd4c
14efcb8
14efc27
```