### PR TITLE
docs: fix typos using codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
 - `utf8.is_number()`, `utf8.is_space()` functions.
 - New `encoding.base32` module.
 - `-skip-unused` fixes, soon to be made the default.
-- `gg.TouchPoint` to differenciate between different types of touch input.
+- `gg.TouchPoint` to differentiate between different types of touch input.
 - Anonymous structs visibility issues fixed.
 - orm: support parenthesized expressions like `select from User where (name == 'Sam' && is_customer == true) || id == 1`.
 - `vweb.csrf` module.
@@ -190,7 +190,7 @@
 - Generic interfaces.
 - TCC is now bundled with the language, this allows building V programs without an external C compiler dependency.
 - Null can be used in `unsafe` only (for example, for C interop).
-- Pointer arithmetics and comparing pointers to numbers is now also only allowed in `unsafe`.
+- Pointer arithmetic and comparing pointers to numbers is now also only allowed in `unsafe`.
 - Inline sumtypes.
 - New module `compress.gzip`.
 - Lots of `net`/`net.http`/`vweb` fixes (also used for the upcoming Gitly launch).
@@ -447,7 +447,7 @@ files with compilation errors.
 - V now enforces short enum syntax (`.green` instead of `Color.green`) when it's enough.
 - V UI for macOS.
 - Interfaces have been rewritten. `[]interface` support.
-- `os.cp()` for copying files and directores.
+- `os.cp()` for copying files and directories.
 - Additional compile-time flags: `$if clang, msvc, mingw, x32, x64, big_endian, little_endian {`.
 - All C functions now have to be declared, all missing C functions have been defined.
 - Global variables (only with the `-enable-globals` flag)
@@ -597,7 +597,7 @@ this backend.
 - `map.delete(key)`.
 - `libcurl` dependency was removed from the `http` module.
 - All function arguments are now immutable by default (previously they could be
-  modifed inside the function).
+  modified inside the function).
 - `http` functions now return options.
 - `sync.WaitGroup`.
 - `vweb` static files serving.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ accordingly in the steps below.)
 
    Note: The remote named `pullrequest` should point to YOUR own forked repo, not the
    main v repository! After this, your local cloned repository is prepared for
-   making pullrequests, and you can just do normal git operations such as:
+   making pull requests, and you can just do normal git operations such as:
    `git pull` `git status` and so on.
 
 5. When finished with a feature/bugfix/change, you can:
@@ -103,7 +103,7 @@ accordingly in the steps below.)
    the new pushed branch.
    (Example dialog: https://url4e.com/gyazo/images/364edc04.png)
 
-8. After making your pullrequest (aka, PR), you can continue to work on the
+8. After making your pull request (aka, PR), you can continue to work on the
    branch `fix_alabala` ... just do again `git push pullrequest` when you have more
    commits.
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -10,7 +10,7 @@ hundreds/thousands of times.
 
 ## `v test-all`
 
-Test and build *everything*. Usefull to verify *locally*, that the CI will
+Test and build *everything*. Useful to verify *locally*, that the CI will
 most likely pass. Slowest, but most comprehensive.
 
 It works, by running these in succession:
@@ -168,7 +168,7 @@ NB 2: in case you need to modify many .out files, run *twice* in a row:
 `VAUTOFIX=1 ./v vlib/v/compiler_errors_test.v`
 This will fail the first time, but it will record the new output for each
 .vv file, and store it into the corresponding .out file. The second run
-should be now successfull, and so you can inspect the difference, and
+should be now successful, and so you can inspect the difference, and
 commit the new .out files with minimum manual effort.
 
 NB 3: To run only some of the tests, use:

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3095,7 +3095,7 @@ match color {
 }
 ```
 
-The enum type can be any integer type, but can be ommited, if it is `int`: `enum Color {`.
+The enum type can be any integer type, but can be omitted, if it is `int`: `enum Color {`.
 
 Enum match must be exhaustive or have an `else` branch.
 This ensures that if a new enum field is added, it's handled everywhere in the code.
@@ -4987,7 +4987,7 @@ contain one or more V modules. A V *package* should have a `v.mod` file
 at its top folder, describing the contents of the package.
 
 V packages are installed normally in your `~/.vmodules` folder. That
-location can be overriden by setting the env variable `VMODULES`.
+location can be overridden by setting the env variable `VMODULES`.
 
 ### Package commands
 
@@ -5314,7 +5314,7 @@ struct C.Foo {
 }
 
 // Used to add a custom calling convention to a function, available calling convention: stdcall, fastcall and cdecl.
-// This list aslo apply for type aliases (see below).
+// This list also apply for type aliases (see below).
 [callconv: "stdcall"]
 fn C.DefWindowProc(hwnd int, msg int, lparam int, wparam int)
 
@@ -5644,7 +5644,7 @@ With the example above:
   > **Note**
 > A combinatorial `_d_customflag_linux.c.v` postfix will not work.
   > If you do need a custom flag file, that has platform dependent code, use the
-  > postfix `_d_customflag.v`, and then use plaftorm dependent compile time
+  > postfix `_d_customflag.v`, and then use platform dependent compile time
   > conditional blocks inside it, i.e. `$if linux {}` etc.
 
 - `_notd_customflag.v` => similar to _d_customflag.v, but will be used
@@ -5982,7 +5982,7 @@ to race conditions. There are several approaches to deal with these:
   where global variables are used to generate (non cryptographic) pseudo random numbers.
   In this case data races lead to random numbers in different threads becoming somewhat
   correlated, which is acceptable considering the performance penalty that using
-  synchonization primitives would represent.
+  synchronization primitives would represent.
 
 ## Cross compilation
 
@@ -6602,7 +6602,7 @@ should **not** be used for things like build or deploy scripts. To access this f
 file with `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp` where `tmp` is the prefix for
 the built executable. This will run in crun mode so it will only rebuild if changes to the script
 were made and keep the binary as `tmp.<scriptfilename>`. **Caution**: if this filename already
-exists the file will be overriden. If you want to rebuild each time and not keep this binary instead
+exists the file will be overridden. If you want to rebuild each time and not keep this binary instead
 use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp run`.
 
 # Appendices

--- a/doc/upcoming.md
+++ b/doc/upcoming.md
@@ -190,7 +190,7 @@ shared b := map[string]int{}
 go h3(shared b)
 b['apple'] = 3
 c['plume'] = 7
-y := b['apple'] // not necesarily `3`
+y := b['apple'] // not necessarily `3`
 
 // iteration over elements
 for k, v in b {

--- a/examples/js_dom_cube/README.md
+++ b/examples/js_dom_cube/README.md
@@ -19,7 +19,7 @@ Then you can open `index.html` with your favourite browser.
 # Serve examples
 
 ### JS server
-Afer run `npm init -y` code and genared `./package.json`
+After run `npm init -y` code and genared `./package.json`
 You can put `start` and `build` at script in jason leaf.
 `path './package.json'`
 ```json

--- a/examples/js_dom_draw/README.md
+++ b/examples/js_dom_draw/README.md
@@ -9,7 +9,7 @@ Then you can open `index.html` with your favourite browser.
 # Serve examples
 
 ### JS server
-Afer run `npm init -y` code and genared `./package.json`
+After run `npm init -y` code and genared `./package.json`
 You can put `start` and `build` at script in jason leaf.
 `path './package.json'`
 ```json

--- a/examples/js_dom_draw_bechmark_chart/README.md
+++ b/examples/js_dom_draw_bechmark_chart/README.md
@@ -26,7 +26,7 @@ A message like `[Vweb] Running app on http://localhost:3001/` should appear
 
 `exit`
 
-# To implement new bechmarks in v
+# To implement new benchmarks in v
 
 In `examples/js_dom_draw_bechmark_chart/v_vweb_orm/src/main.v` path
 Create a route returning a `Response` struct like:

--- a/examples/js_dom_draw_bechmark_chart/chart/README.md
+++ b/examples/js_dom_draw_bechmark_chart/chart/README.md
@@ -13,7 +13,7 @@ A message like `[Vweb] Running app on http://localhost:3001/` should appear
 
 `exit`
 
-# To implement new bechmarks in v
+# To implement new benchmarks in v
 
 In `examples/js_dom_draw_bechmark_chart/v_vweb_orm/src/main.v` path
 Create a route returning a `Response` struct like:

--- a/vlib/crypto/ed25519/internal/edwards25519/README.md
+++ b/vlib/crypto/ed25519/internal/edwards25519/README.md
@@ -13,7 +13,7 @@ This modules was port of Golang `edwards25519` library from [edwards25519](https
 About Edwards25519
 ------------------
 
-Twisted Edwards curves are a familly of elliptic curves allowing complete addition 
+Twisted Edwards curves are a family of elliptic curves allowing complete addition 
 formulas without any special case and no point at infinity. 
 Curve edwards25519 is based on prime 2^255 - 19 for efficient implementation. 
 Equation and parameters are given in RFC 7748.

--- a/vlib/datatypes/fsm/README.md
+++ b/vlib/datatypes/fsm/README.md
@@ -12,7 +12,7 @@ On each `run()`, all the possible transitions from the current state are evaluat
 The first transition for the current state, whose condition evaluates to true is
 taken (the condition is specified by a transition callback function). 
 
-In a successfull transition, the current state changes to the new one.
+In a successful transition, the current state changes to the new one.
 When that happens:
 * the client-specified `on_exit()` handler from the current state is called.
 * the client-specified `on_entry()` handler of the new state is called.

--- a/vlib/eventbus/README.md
+++ b/vlib/eventbus/README.md
@@ -77,7 +77,7 @@ fn main() {
 
 // the event handler
 fn on_error(receiver voidptr, e &Error, work &Work) {
-	println('error occured on ${work.hours}. Error: ${e.message}')
+	println('error occurred on ${work.hours}. Error: ${e.message}')
 }
 ```
 

--- a/vlib/net/websocket/tests/autobahn/README.md
+++ b/vlib/net/websocket/tests/autobahn/README.md
@@ -13,7 +13,7 @@ This is how to test the client:
 2. From the `local_run` folder, compile and run `autobahn_client.v` to test non ws (no TLS) and 
 `autobahn_client_wss.v` to run the TLS tests
 3. Open `http://localhost:8080` and browse client test results for non TLS and `https://localhost:8081` 
-if you ran the wss tests (it uses local certificat so you will get trust error but just accept use)
+if you ran the wss tests (it uses local certificate so you will get trust error but just accept use)
 
 ### Test the server
 

--- a/vlib/os/README.md
+++ b/vlib/os/README.md
@@ -44,7 +44,7 @@ mut f := os.create('path/to/file') or {
     println("file not writable")
 }
 
-// >> do someting with file; file is locked <<
+// >> do something with file; file is locked <<
 
 f.close()
 ```

--- a/vlib/rand/README.md
+++ b/vlib/rand/README.md
@@ -114,5 +114,5 @@ A workaround (if you _must_ use the libc RNG) is to:
 [Math interval](<https://en.wikipedia.org/wiki/Interval_(mathematics)#Including_or_excluding_endpoints>)
 notation is used throughout the function documentation to denote what numbers ranges include.
 
-An example of `[0, max)` thus denotes a range with all posible values
+An example of `[0, max)` thus denotes a range with all possible values
 between `0` and `max` **including** 0 but **excluding** `max`.

--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -415,7 +415,7 @@ use a name map in the `re` struct, using the function `re.get_group_by_name`.
 
 Here is a more complex example of using them:
 ```v oksyntax
-// This function demostrate the use of the named groups
+// This function demonstrate the use of the named groups
 fn convert_html_rgb_n(in_col string) u32 {
 	mut n_digit := if in_col.len == 4 { 1 } else { 2 }
 	mut col_mul := if in_col.len == 4 { 4 } else { 0 }
@@ -535,9 +535,9 @@ re.prog = []Token    {len: pattern.len + 1}
 // can not be more char class the the length of the pattern
 re.cc   = []CharClass{len: pattern.len}
 
-re.group_csave_flag = false          // true enable continuos group saving if needed
+re.group_csave_flag = false          // true enable continuous group saving if needed
 re.group_max_nested = 128            // set max 128 group nested possible
-re.group_max        = pattern.len>>1 // we can't have more groups than the half of the pattern legth
+re.group_max        = pattern.len>>1 // we can't have more groups than the half of the pattern length
 re.group_stack = []int{len: re.group_max, init: -1}
 re.group_data  = []int{len: re.group_max, init: -1}
 ```
@@ -618,7 +618,7 @@ pub fn (mut re RE) replace_simple(in_txt string, repl string) string
 
 If it is needed to replace N instances of the found strings it is possible to use:
 ```v ignore
-// replace_n return a string where the firts `count` matches are replaced with the repl_str string
+// replace_n return a string where the first `count` matches are replaced with the repl_str string
 // `count` indicate the number of max replacements that will be done.
 // if count is > 0 the replace began from the start of the string toward the end
 // if count is < 0 the replace began from the end of the string toward the start
@@ -847,11 +847,11 @@ fn main(){
 	// can not be more char class the the length of the query
     re.cc   = []regex.CharClass{len: query.len}
     re.prog = []regex.Token    {len: query.len+1}
-	// enable continuos group saving
+	// enable continuous group saving
     re.group_csave_flag = true
 	// set max 128 group nested
     re.group_max_nested = 128
-	// we can't have more groups than the half of the query legth
+	// we can't have more groups than the half of the query length
     re.group_max        = query.len>>1
 
     // compile the query
@@ -864,7 +864,7 @@ fn main(){
         println("No Match")
     }
 
-    // show results for continuos group saving
+    // show results for continuous group saving
     if re.group_csave_flag == true && start >= 0 && re.group_csave.len > 0{
         println("cg: ${re.group_csave}")
         mut cs_i := 1

--- a/vlib/toml/README.md
+++ b/vlib/toml/README.md
@@ -79,7 +79,7 @@ To query for a value that might not be in the document you
 can use the `.default_to(...)` function to provide a
 default value.
 
-For cases where a default value might not be appropiate or
+For cases where a default value might not be appropriate or
 to check if a value exists you can use `doc.value_opt('query')!`
 instead.
 

--- a/vlib/v/TEMPLATES.md
+++ b/vlib/v/TEMPLATES.md
@@ -1,6 +1,6 @@
 V allows for easily using text templates, expanded at compile time to
 V functions, that efficiently produce text output. This is especially
-usefull for templated HTML views, but the mechanism is general enough
+useful for templated HTML views, but the mechanism is general enough
 to be used for other kinds of text output also.
 
 # Template directives

--- a/vlib/v/pkgconfig/README.md
+++ b/vlib/v/pkgconfig/README.md
@@ -5,7 +5,7 @@ This module implements the `pkg-config` tool as a library in pure V.
 
 Features:
 
-* Simple API, but still not stable, but shouldnt change much
+* Simple API, but still not stable, but shouldn't change much
 * Runs 2x faster than original pkg-config
 * Commandline tool that aims to be compatible with `pkg-config`
 * Resolve full path for `.pc` file given a name
@@ -16,7 +16,7 @@ Features:
 Todo/Future/Wish:
 
 * 100% compatibility with `pkg-config` options
-* Strictier pc parsing logic, with better error reporting
+* Stricter pc parsing logic, with better error reporting
 
 Example
 -------

--- a/vlib/v/token/README.md
+++ b/vlib/v/token/README.md
@@ -4,7 +4,7 @@
 syntax - the tokens, as well as utilities for working with them.
 
 ## KeywordsMatcherTrie 
-KeywordsMatcherTrie provides a faster way of determinining whether a given name is a reserved
+KeywordsMatcherTrie provides a faster way of determining whether a given name is a reserved
 word (belongs to a given set of previously known words `R`). It works by exploiting the fact,
 that the set of reserved words is small, and the words short.
 

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -202,7 +202,7 @@ fn (mut app App) create_product() vweb.Result {
 
 #### - Parameters
 
-Parameters are passed direcly in endpoint route using colon sign `:` and received using the same
+Parameters are passed directly in endpoint route using colon sign `:` and received using the same
 name at function
 To pass a parameter to an endpoint, you simply define it inside an attribute, e. g.
 `['/hello/:user]`.
@@ -628,7 +628,7 @@ fn (mut app App) index() vweb.Result {
     // Set a Csrf-Cookie (Token will be generated automatically)
 	app.set_csrf_cookie()
 
-	// Get the token-value from the csrf-cookie that was just setted
+	// Get the token-value from the csrf-cookie that was just set
 	token := app.get_csrf_token() or { panic(err) }
 
 	return app.text("Csrf-Token set! It's value is: $token")

--- a/vlib/x/ttf/README.md
+++ b/vlib/x/ttf/README.md
@@ -52,7 +52,7 @@ At high level no more action are required to use the loaded font.
 Multiple fonts can be loaded without problems at the same time.
 
 ## TTF Bitmap render
-In this modue it is possible to have different renders running at the same time.
+In this module it is possible to have different renders running at the same time.
 At the present time all the rendering are made on the CPU, sokol is used only to draw the
 rendered text to the screen.
 Let's start with a simple snippet of code:
@@ -68,7 +68,7 @@ fn main() {
 	println(ttf_font.get_info_string())
 }
 ```
-This simple code load a TTF font and display its basic informations.
+This simple code load a TTF font and display its basic information.
 
 ### draw_text
 The draw text function draw simple strings without indentation or other imagination tasks.
@@ -116,7 +116,7 @@ fn main() {
 	bmp.save_as_ppm('test.ppm')
 }
 ```
-This is the low level render that draw ther text on a bitmap and save the bitmap on a disk as
+This is the low level render that draw the text on a bitmap and save the bitmap on a disk as
 `.ppm` file.
 
 > **Note**
@@ -130,7 +130,7 @@ You can specify the style for the text rendering in the `BitMap` struct::
 enum Style {
 	outline
 	outline_aliased
-	filled // default syle
+	filled // default style
 	raw
 }
 ```
@@ -191,16 +191,16 @@ This is the low level render that draw text block on the bitmap.
 A text block is defined from a `Text_block` struct:
 ```v
 struct Text_block {
-	x         int  // x postion of the left high corner
-	y         int  // y postion of the left high corner
+	x         int  // x position of the left high corner
+	y         int  // y position of the left high corner
 	w         int  // width of the text block
-	h         int  // heigth of the text block
+	h         int  // height of the text block
 	cut_lines bool = true // force to cut the line if the length is over the text block width
 }
 ```
 and use the following bitmap fields:
 ```v ignore
-	style              Style      = .filled // default syle
+	style              Style      = .filled // default style
 	align              Text_align = .left   // default text align
 	justify            bool				    // justify text flag, default deactivated
 	justify_fill_ratio f32        = 0.5     // justify fill ratio, if the ratio of the filled


### PR DESCRIPTION
https://github.com/codespell-project/codespell

`codespell --ignore-words-list='ist' --interactive 3 --context 2 --write-change **/*.md`. 