### PR TITLE
parser: block option on receiver

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -146,6 +146,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 	}
 	if node.is_method {
+		if node.receiver.typ.has_flag(.option) {
+			c.error('option types cannot have methods', node.receiver_pos)
+		}
 		mut sym := c.table.sym(node.receiver.typ)
 		if sym.kind == .array && !c.is_builtin_mod && node.name == 'map' {
 			// TODO `node.map in array_builtin_methods`

--- a/vlib/v/checker/tests/option_in_receiver_err.out
+++ b/vlib/v/checker/tests/option_in_receiver_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/option_in_receiver_err.vv:10:11: error: unexpected token `?`
+vlib/v/checker/tests/option_in_receiver_err.vv:10:9: error: option types cannot have methods
     8 | }
     9 | 
    10 | fn (mut f ?Foo) t1(arr ?[]int) ?string {
-      |           ^
+      |         ~~~
    11 |     return arr?.len.str()
    12 | }

--- a/vlib/v/checker/tests/option_in_receiver_err.out
+++ b/vlib/v/checker/tests/option_in_receiver_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/option_in_receiver_err.vv:10:11: error: unexpected token `?`
+    8 | }
+    9 | 
+   10 | fn (mut f ?Foo) t1(arr ?[]int) ?string {
+      |           ^
+   11 |     return arr?.len.str()
+   12 | }

--- a/vlib/v/checker/tests/option_in_receiver_err.vv
+++ b/vlib/v/checker/tests/option_in_receiver_err.vv
@@ -1,0 +1,12 @@
+struct Foo {
+mut:
+	name string
+}
+
+fn (mut f Foo) t0(arr ?[]int) ?string {
+	return arr?.len.str()
+}
+
+fn (mut f ?Foo) t1(arr ?[]int) ?string {
+	return arr?.len.str()
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -629,9 +629,6 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	if p.tok.kind == .name && p.tok.lit == 'JS' {
 		rec.language = ast.Language.js
 	}
-	if p.tok.kind == .question {
-		p.unexpected()
-	}
 	// if rec.is_mut {
 	// p.check(.key_mut)
 	// }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -629,6 +629,9 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	if p.tok.kind == .name && p.tok.lit == 'JS' {
 		rec.language = ast.Language.js
 	}
+	if p.tok.kind == .question {
+		p.unexpected()
+	}
 	// if rec.is_mut {
 	// p.check(.key_mut)
 	// }


### PR DESCRIPTION
This PR blocks using .question on receiver declaration

`fn (f ?Foo) test() {}`