### PR TITLE
Include Max number in enums check

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1629,7 +1629,7 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 					if signed {
 						val := field.expr.val.i64()
 						ival = val
-						if val < enum_imin || val >= enum_imax {
+						if val < enum_imin || val > enum_imax {
 							c.error('enum value `${field.expr.val}` overflows the enum type `${senum_type}`, values of which have to be in [${enum_imin}, ${enum_imax}]',
 								field.expr.pos)
 							overflows = true


### PR DESCRIPTION
When trying to translate OpenGL's /usr/include/KHR/khrplatform.h it thows this error on this line

error: enum value `2147483647` overflows the enum type `int`, values of which have to be in [-2147483648, 2147483647

```
enum Khronos_boolean_enum_t {
	khronos_false = 0	khronos_true = 1	khronos_boolean_enum_force_size = 2147483647}
```