### PR TITLE
 fix for issue v init on an existing project, and V re-writes main.v file https://github.com/vlang/v/issues/17362

### DIFF
--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -133,10 +133,11 @@ fn init_project() {
 		c.write_vmod(false)
 		println('Change the description of your project in `v.mod`')
 	}
-
-	c.files << ProjectFiles{
-		path: 'src/main.v'
-		content: hello_world_content()
+	if !os.exists('src/main.v') {
+		c.files << ProjectFiles{
+			path: 'src/main.v'
+			content: hello_world_content()
+		}
 	}
 	c.create_files_and_directories()
 	c.write_gitattributes(false)


### PR DESCRIPTION
`v init` behaviour fix : `v init` on an existing project, and V re-writes main.v file , the PR contains changes to fix the behavior where a if a src/main.v file already exists it will remain unmodified on running `v init` command.

The PR fixes the issue https://github.com/vlang/v/issues/17362