### PR TITLE
cgen: fix array initilize with len and no default (fix #17358)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -195,7 +195,8 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 	noscan := g.check_noscan(elem_type.typ)
 	is_default_array := elem_type.unaliased_sym.kind == .array && node.has_default
 	is_default_map := elem_type.unaliased_sym.kind == .map && node.has_default
-	needs_more_defaults := node.has_len && g.struct_has_array_or_map_field(elem_type.typ)
+	needs_more_defaults := node.has_len && (g.struct_has_array_or_map_field(elem_type.typ)
+		|| elem_type.unaliased_sym.kind in [.array, .map])
 	if node.has_it { // []int{len: 6, init: it * it} when variable it is used in init expression
 		g.inside_lambda = true
 		mut tmp := g.new_tmp_var()

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -258,7 +258,7 @@ fn test_multi_array_update_data() {
 	assert '${a}' == '[[[0, 0], [0, 2], [0, 0]], [[0, 0], [0, 0], [0, 0]]]'
 }
 
-fn test_multi_array_with_len_no_default() {
+fn test_array_of_map_with_len_no_default() {
 	mut arr := []map[int]int{len: 3}
 	arr[0][0] = 0
 	arr[1][1] = 1

--- a/vlib/v/tests/array_init_test.v
+++ b/vlib/v/tests/array_init_test.v
@@ -257,3 +257,18 @@ fn test_multi_array_update_data() {
 	println(a)
 	assert '${a}' == '[[[0, 0], [0, 2], [0, 0]], [[0, 0], [0, 0], [0, 0]]]'
 }
+
+fn test_multi_array_with_len_no_default() {
+	mut arr := []map[int]int{len: 3}
+	arr[0][0] = 0
+	arr[1][1] = 1
+	arr[2][2] = 2
+	println(arr)
+	assert arr == [{
+		0: 0
+	}, {
+		1: 1
+	}, {
+		2: 2
+	}]
+}


### PR DESCRIPTION
This PR fix array initilize with len and no default (fix #17358).

- Fix array initilize with len and no default.
- Add test.

```v
fn main() {
	mut arr := []map[int]int{len: 3}
	arr[0][0] = 0
	arr[1][1] = 1
	arr[2][2] = 2
	println(arr)
}

PS D:\Test\v\tt1> v run .
[{0: 0}, {1: 1}, {2: 2}]
```