### PR TITLE
gg:  toggle_fullscreen and is_fullscreen added

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -676,6 +676,16 @@ pub fn window_size_real_pixels() Size {
 	return Size{sapp.width(), sapp.height()}
 }
 
+// is it fullscreen
+pub fn is_fullscreen() bool {
+	return sapp.is_fullscreen()
+}
+
+// toggle fullscreen
+pub fn toggle_fullscreen() {
+	sapp.toggle_fullscreen()
+}
+
 /*
 pub fn wait_events() {
 	unsafe {


### PR DESCRIPTION
From sokol.sapp, delegate toggle_fullscreen and is_fullscreen to gg to avoid import sokol.sapp when using gg.
