### PR TITLE
parser: add anon func param redefinition checking

### DIFF
--- a/vlib/v/checker/tests/anon_arg_redefinition_err.out
+++ b/vlib/v/checker/tests/anon_arg_redefinition_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/anon_arg_redefinition_err.vv:2:18: error: redefinition of parameter `a`
+    1 | fn main() {
+    2 |     a := fn (a int, a int) {
+      |                     ^
+    3 |     }
+    4 | }

--- a/vlib/v/checker/tests/anon_arg_redefinition_err.vv
+++ b/vlib/v/checker/tests/anon_arg_redefinition_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := fn (a int, a int) {
+	}
+}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -713,6 +713,9 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 		if arg.name.len == 0 && p.table.sym(arg.typ).kind != .placeholder {
 			p.error_with_pos('use `_` to name an unused parameter', arg.pos)
 		}
+		if p.scope.known_var(arg.name) {
+			p.error_with_pos('redefinition of parameter `${arg.name}`', arg.pos)
+		}
 		is_stack_obj := !arg.typ.has_flag(.shared_f) && (arg.is_mut || arg.typ.is_ptr())
 		p.scope.register(ast.Var{
 			name: arg.name

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -707,13 +707,17 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	} else {
 		[]ast.Param{}
 	}
+	inherited_vars_name := inherited_vars.map(it.name)
 	_, generic_names := p.parse_generic_types()
 	args, _, is_variadic := p.fn_args()
 	for arg in args {
 		if arg.name.len == 0 && p.table.sym(arg.typ).kind != .placeholder {
 			p.error_with_pos('use `_` to name an unused parameter', arg.pos)
 		}
-		if p.scope.known_var(arg.name) {
+		if arg.name in inherited_vars_name {
+			p.error_with_pos('the parameter name `${arg.name}` conflicts with the captured value name',
+				arg.pos)
+		} else if p.scope.known_var(arg.name) {
 			p.error_with_pos('redefinition of parameter `${arg.name}`', arg.pos)
 		}
 		is_stack_obj := !arg.typ.has_flag(.shared_f) && (arg.is_mut || arg.typ.is_ptr())
@@ -770,17 +774,6 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	typ := ast.new_type(idx)
 	p.inside_defer = old_inside_defer
 	// name := p.table.get_type_name(typ)
-	if inherited_vars.len > 0 && args.len > 0 {
-		for arg in args {
-			for var in inherited_vars {
-				if arg.name == var.name {
-					p.error_with_pos('the parameter name `${arg.name}` conflicts with the captured value name',
-						arg.pos)
-					break
-				}
-			}
-		}
-	}
 	return ast.AnonFn{
 		decl: ast.FnDecl{
 			name: name


### PR DESCRIPTION
Fix missing redefinition checking for anon func.

```V
fn main() {
	a := fn (a int, a int) {
	}
}
```