### PR TITLE
cgen: minor cleanup in expr()

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2993,7 +2993,6 @@ fn (mut g Gen) map_fn_ptrs(key_typ ast.TypeSymbol) (string, string, string, stri
 }
 
 fn (mut g Gen) expr(node_ ast.Expr) {
-	// println('cgen expr() line_nr=$node.pos.line_nr')
 	old_discard_or_result := g.discard_or_result
 	old_is_void_expr_stmt := g.is_void_expr_stmt
 	if g.is_void_expr_stmt {
@@ -3033,9 +3032,6 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			g.write(node.val.str())
 		}
 		ast.CallExpr {
-			// if g.fileis('1.strings') {
-			// println('\ncall_expr()()')
-			// }
 			ret_type := if node.or_block.kind == .absent {
 				node.return_type
 			} else {
@@ -3056,11 +3052,8 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			}
 			last_stmt_pos := if g.stmt_path_pos.len > 0 { g.stmt_path_pos.last() } else { 0 }
 			g.call_expr(node)
-			// if g.fileis('1.strings') {
-			// println('before:' + node.autofree_pregen)
-			// }
 			if g.is_autofree && !g.is_builtin_mod && !g.is_js_call && g.strs_to_free0.len == 0
-				&& !g.inside_lambda { // && g.inside_ternary ==
+				&& !g.inside_lambda {
 				// if len != 0, that means we are handling call expr inside call expr (arg)
 				// and it'll get messed up here, since it's handled recursively in autofree_call_pregen()
 				// so just skip it
@@ -3069,12 +3062,10 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					g.insert_at(last_stmt_pos, g.strs_to_free0.join('\n') + '/* inserted before */')
 				}
 				g.strs_to_free0 = []
-				// println('pos=$node.pos.pos')
 			}
 			if g.is_shared && !ret_type.has_flag(.shared_f) && !g.inside_or_block {
 				g.writeln('}, sizeof(${shared_styp}))')
 			}
-			// if g.autofree && node.autofree_pregen != '' { // g.strs_to_free0.len != 0 {
 			/*
 			if g.autofree {
 				s := g.autofree_pregen[node.pos.pos.str()]
@@ -3120,7 +3111,6 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			g.concat_expr(node)
 		}
 		ast.CTempVar {
-			// g.write('/*ctmp .orig: $node.orig.str() , ._typ: $node.typ, .is_ptr: $node.is_ptr */ ')
 			g.write(node.name)
 		}
 		ast.DumpExpr {
@@ -3168,7 +3158,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				g.write('-0')
 				g.write(node.val[3..])
 			} else {
-				g.write(node.val) // .int().str())
+				g.write(node.val)
 			}
 		}
 		ast.IsRefType {
@@ -3282,11 +3272,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					}
 				}
 			} else {
-				// g.write('/*pref*/')
 				if !(g.is_amp && node.right.is_auto_deref_var()) {
 					g.write(node.op.str())
 				}
-				// g.write('(')
 				g.expr(node.right)
 			}
 			g.is_amp = false
@@ -3326,12 +3314,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 		}
 		ast.TypeNode {
 			// match sum Type
-			// g.write('/* Type */')
-			// type_idx := node.typ.idx()
 			typ := g.unwrap_generic(node.typ)
 			sym := g.table.sym(typ)
 			sidx := g.type_sidx(typ)
-			// g.write('$type_idx /* $sym.name */')
 			g.write('${sidx} /* ${sym.name} */')
 		}
 		ast.TypeOf {


### PR DESCRIPTION
This PR makes a minor cleanup in expr().

- Remove useless comments in expr().