### PR TITLE
parser: fix channel pop with or expression (fix #17384)

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -711,11 +711,14 @@ fn (mut p Parser) prefix_expr() ast.Expr {
 	mut or_pos := p.tok.pos()
 	// allow `x := <-ch or {...}` to handle closed channel
 	if op == .arrow {
-		if p.tok.kind == .key_orelse {
+		if mut right is ast.SelectorExpr {
+			or_kind = right.or_block.kind
+			or_stmts = right.or_block.stmts.clone()
+			right.or_block = ast.OrExpr{}
+		} else if p.tok.kind == .key_orelse {
 			or_kind = .block
 			or_stmts, or_pos = p.or_block(.with_err_var)
-		}
-		if p.tok.kind == .question {
+		} else if p.tok.kind == .question {
 			p.next()
 			or_kind = .propagate_option
 		}

--- a/vlib/v/tests/channels_test.v
+++ b/vlib/v/tests/channels_test.v
@@ -45,3 +45,30 @@ fn test_chan_of_sumtype() {
 	println(ret)
 	assert '${ret}' == 'As(Aa{})'
 }
+
+struct Iter[T] {
+	item chan T
+}
+
+fn new_iter[T](ch chan T) Iter[T] {
+	return Iter[T]{
+		item: ch
+	}
+}
+
+fn (self Iter[T]) next() ?T {
+	self.item.close()
+	ch := <-self.item or { return none }
+	return ch
+}
+
+fn test_channel_with_or_block() {
+	ch := chan int{}
+	iter := new_iter[int](ch)
+	ret := iter.next() or {
+		assert true
+		return
+	}
+	println(ret)
+	assert false
+}


### PR DESCRIPTION
This PR fix channel pop with or expression (fix #17384).

- Fix channel pop with or expression.
- Add test.

```v
struct Iter[T] {
	item chan T
}

fn new_iter[T](ch chan T) Iter[T] {
	return Iter[T]{
		item: ch
	}
}

fn (self Iter[T]) next() ?T {
	self.item.close()
	ch := <-self.item or { return none }
	return ch
}

fn main() {
	ch := chan int{}
	iter := new_iter[int](ch)
	ret := iter.next() or {
		println('channel closed')
		assert true
		return
	}
	println(ret)
	assert false
}

PS D:\Test\v\tt1> v run .
channel closed
```