### PR TITLE
cgen: fix nested option struct init (fix #17415)

### DIFF
--- a/vlib/v/tests/nested_option_struct_init_test.v
+++ b/vlib/v/tests/nested_option_struct_init_test.v
@@ -1,0 +1,18 @@
+struct Data {
+	a ?int
+	b ?int = 1
+	c ?int = none
+}
+
+struct Data2 {
+	d Data
+}
+
+fn test_nested_option_struct_init() {
+	d2 := Data2{}
+	println(d2)
+	assert d2.d.a == none
+	assert d2.d.b != none
+	assert d2.d.b? == 1
+	assert d2.d.c == none
+}

--- a/vlib/v/tests/nested_option_struct_init_test.v
+++ b/vlib/v/tests/nested_option_struct_init_test.v
@@ -1,7 +1,6 @@
 struct Data {
 	a ?int
 	b ?int = 1
-	c ?int = none
 }
 
 struct Data2 {
@@ -14,5 +13,4 @@ fn test_nested_option_struct_init() {
 	assert d2.d.a == none
 	assert d2.d.b != none
 	assert d2.d.b? == 1
-	assert d2.d.c == none
 }


### PR DESCRIPTION
This PR fix nested option struct init (fix #17415).

- Fix nested option struct init.
- Add test.

```v
struct Data {
	a ?int
	b ?int = 1
	c ?int = none
}

struct Data2 {
	d Data
}

fn main() {
	d2 := Data2{}
	println(d2)
	assert d2.d.a == none
	assert d2.d.b != none
	assert d2.d.b? == 1
	assert d2.d.c == none
}

PS D:\Test\v\tt1> v run .
tt1.v:4:11: warning: unnecessary default value of `none`: struct fields are zeroed by default
    2 |     a ?int
    3 |     b ?int = 1
    4 |     c ?int = none
      |              ~~~~
    5 | }
    6 |
Data2{
    d: Data{
        a: 0
        b: 1
        c: 0
    }
}
```