### PR TITLE
os: add `#include <sys/types.h>` to debugger_darwin

### DIFF
--- a/vlib/os/debugger_darwin.c.v
+++ b/vlib/os/debugger_darwin.c.v
@@ -1,5 +1,6 @@
 module os
 
+#include <sys/types.h>
 #include <sys/ptrace.h>
 
 fn C.ptrace(int, u32, voidptr, int) int


### PR DESCRIPTION
The current weekly release doesn't build on macOS 11 or below. This PR should hopefully fix that.

The build error is the following ([full log](https://build.macports.org/builders/ports-11_x86_64-builder/builds/104908/steps/install-port/logs/stdio)):

```
In file included from /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_vlang/vlang/work/vc-fed3800f83b51aba951a88e4d3d9d37ed5c10ee2/v.c:1943:
/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/sys/ptrace.h:99:42: error: unknown type name 'caddr_t'
int     ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
                                         ^
1 error generated.
make: *** [all] Error 1
```

This is the [corresponding patch file](https://github.com/macports/macports-ports/blob/83b6ae060066926be1f622ca7db0e73b4bb67530/lang/vlang/files/patch-ptrace.diff) in the MacPorts build that's used to fix it (https://github.com/macports/macports-ports/commit/83b6ae060066926be1f622ca7db0e73b4bb67530).

```diff
--- vlib/os/debugger_darwin.c.v.original	2023-02-28 17:51:48.000000000 +0000
+++ vlib/os/debugger_darwin.c.v	2023-02-28 17:51:57.000000000 +0000
@@ -1,5 +1,6 @@
 module os
 
+#include <sys/types.h>
 #include <sys/ptrace.h>
 
 fn C.ptrace(int, u32, voidptr, int) int

--- vc/v.c.original	2023-02-28 17:54:17.000000000 +0000
+++ vc/v.c	2023-02-28 18:56:27.000000000 +0000
@@ -1940,6 +1940,7 @@
 #if defined(__has_include)
 
 #if __has_include(<sys/ptrace.h>)
+#include <sys/types.h>
 #include <sys/ptrace.h>
 #else
 #error VERROR_MESSAGE Header file <sys/ptrace.h>, needed for module `os` was not found. Please install the corresponding development headers.
```

Thanks to @spytheman for the suggested fix.