### PR TITLE
wasm: `binaryen.c.v` compile flags to assist darwin

### DIFF
--- a/vlib/v/gen/wasm/binaryen/binaryen.c.v
+++ b/vlib/v/gen/wasm/binaryen/binaryen.c.v
@@ -1,14 +1,10 @@
 [translated]
 module binaryen
 
-$if dynamic_binaryen ? {
-	#flag -lbinaryen
-} $else {
-	#flag -I@VEXEROOT/thirdparty/binaryen/include
-	#flag -L@VEXEROOT/thirdparty/binaryen/lib
-	#flag -lbinaryen
-	#flag linux -lstdc++
-}
+#flag -I@VEXEROOT/thirdparty/binaryen/include
+#flag -L@VEXEROOT/thirdparty/binaryen/lib
+#flag -lbinaryen -lstdc++
+#flag darwin -Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,@VEXEROOT/thirdparty/binaryen/lib
 
 type Index = u32
 type Type = u64


### PR DESCRIPTION
The current `#flags` for linking with `lbinaryen` does not support MacOS + homebrew. These changes add it in.

This change could get a fast pass through the CI since the CI only performs checks on Linux, not MacOS.

\- l-m
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
