### PR TITLE
fmt: fix fmt for $compile_warn

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1901,8 +1901,8 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 			f.write("\$env('${node.args_var}')")
 		} else if node.is_pkgconfig {
 			f.write("\$pkgconfig('${node.args_var}')")
-		} else if node.method_name == 'compile_error' {
-			f.write("\$compile_error('${node.args_var}')")
+		} else if node.method_name in ['compile_error', 'compile_warn'] {
+			f.write("\$${node.method_name}('${node.args_var}')")
 		} else {
 			inner_args := if node.args_var != '' {
 				node.args_var

--- a/vlib/v/fmt/tests/comptime_warn_keep.vv
+++ b/vlib/v/fmt/tests/comptime_warn_keep.vv
@@ -1,0 +1,3 @@
+fn main() {
+	$compile_warn('WARN')
+}


### PR DESCRIPTION
Fix #17445

```
felipe@~/github/v (master)$ v run bug.v
bug.v:2:2: warning: WARN
    1 | fn main() {
    2 |     $compile_warn('WARN')
      |     ~~~~~~~~~~~~~~~~~~~~~
    3 | }
felipe@~/github/v (master)$ v fmt bug.v
fn main() {
        .$compile_warn(WARN)
}
```