### PR TITLE
ci macos wasm

### DIFF
--- a/.github/workflows/wasm_backend_tests_ci.yml
+++ b/.github/workflows/wasm_backend_tests_ci.yml
@@ -72,24 +72,24 @@ jobs:
       - name: Build examples
         run: VTEST_ONLY=wasm ./v build-examples
 
-##  wasm-backend-macos:
-##    runs-on: macOS-12
-##    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
-##    timeout-minutes: 121
-##    steps:
-##      - uses: actions/checkout@v3
-##
-##      - name: Build V
-##        run: make -j4 && ./v symlink -githubci
-##
-##      - name: Install binaryen as build dependency for the V WASM backend
-##        run: ./v cmd/tools/install_binaryen.vsh
-##
-##      - name: Build the V WASM backend
-##        run: ./v -cc clang -showcc -v cmd/tools/builders/wasm_builder.v
-##
-##      - name: Test the WASM backend
-##        run: ./v test vlib/v/gen/wasm/tests/
-##
-##      - name: Build examples
-##        run: VTEST_ONLY=wasm ./v build-examples
+  wasm-backend-macos:
+    runs-on: macOS-12
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    timeout-minutes: 121
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build V
+        run: make -j4 && ./v symlink -githubci
+
+      - name: Install binaryen as build dependency for the V WASM backend
+        run: ./v cmd/tools/install_binaryen.vsh
+
+      - name: Build the V WASM backend
+        run: ./v -cc clang -showcc -v cmd/tools/builders/wasm_builder.v
+
+      - name: Test the WASM backend
+        run: ./v test vlib/v/gen/wasm/tests/
+
+      - name: Build examples
+        run: VTEST_ONLY=wasm ./v build-examples

--- a/vlib/v/gen/wasm/binaryen/binaryen.c.v
+++ b/vlib/v/gen/wasm/binaryen/binaryen.c.v
@@ -1,11 +1,15 @@
 [translated]
 module binaryen
 
-#flag -I@VEXEROOT/thirdparty/binaryen/include
-#flag -L@VEXEROOT/thirdparty/binaryen/lib
-#flag -lbinaryen
-#flag darwin -lc++
-#flag linux -lstdc++
+$if dynamic_binaryen ? {
+	#flag -lbinaryen
+} $else {
+	#flag -I@VEXEROOT/thirdparty/binaryen/include
+	#flag -L@VEXEROOT/thirdparty/binaryen/lib
+	#flag -lbinaryen
+	#flag darwin -lc++ -Wl,-rpath,"@executable_path/../../../thirdparty/binaryen/lib"
+	#flag linux -lstdc++
+}
 
 type Index = u32
 type Type = u64

--- a/vlib/v/gen/wasm/binaryen/binaryen.c.v
+++ b/vlib/v/gen/wasm/binaryen/binaryen.c.v
@@ -4,9 +4,8 @@ module binaryen
 #flag -I@VEXEROOT/thirdparty/binaryen/include
 #flag -L@VEXEROOT/thirdparty/binaryen/lib
 #flag -lbinaryen
-#flag linux -lstdc++
-#flag darwin --Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,@VEXEROOT/thirdparty/binaryen/lib
 #flag darwin -lc++
+#flag linux -lstdc++
 
 type Index = u32
 type Type = u64

--- a/vlib/v/gen/wasm/binaryen/binaryen.c.v
+++ b/vlib/v/gen/wasm/binaryen/binaryen.c.v
@@ -3,8 +3,10 @@ module binaryen
 
 #flag -I@VEXEROOT/thirdparty/binaryen/include
 #flag -L@VEXEROOT/thirdparty/binaryen/lib
-#flag -lbinaryen -lstdc++
-#flag darwin -Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,@VEXEROOT/thirdparty/binaryen/lib
+#flag -lbinaryen
+#flag linux -lstdc++
+#flag darwin --Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,@VEXEROOT/thirdparty/binaryen/lib
+#flag darwin -lc++
 
 type Index = u32
 type Type = u64


### PR DESCRIPTION
- ci: test the wasm backend on macos too
- use -lc++ on macos
- do not pass --Wl,-rpath,/opt/homebrew/lib on macos
- fix -Wl,-rpath on macos
