### PR TITLE
docs: fix incorrect struct literal and interface smart cast errors

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2611,8 +2611,10 @@ For this reason V doesn't allow the modification of arguments with primitive typ
 Only more complex types such as arrays and maps may be modified.
 
 ### Variable number of arguments
-V supports functions that receive an arbitrary, variable amounts of arguments, denoted with the `...` prefix.
-Below, `a ...int` refers to an arbitrary amount of parameters that will be collected into an array named `a`.
+V supports functions that receive an arbitrary, variable amounts of arguments, denoted with the 
+`...` prefix.
+Below, `a ...int` refers to an arbitrary amount of parameters that will be collected 
+into an array named `a`.
 
 ```v
 fn sum(a ...int) int {
@@ -3268,7 +3270,7 @@ fn (c Cat) speak() string {
 	return 'meow'
 }
 
-// unlike Go, but like TypeScript, V's interfaces can define fields, not just methods.
+// unlike Go, but like TypeScript, V's interfaces can define both fields and methods.
 interface Speaker {
 	breed string
 	speak() string

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3396,10 +3396,7 @@ fn main() {
 		dump(a)
 		// In order to execute instances that implements IBar.
 		if a is IBar {
-			// a.bar() // Error.
-			b := a as IBar
-			dump(b)
-			b.bar()
+			a.bar()
 		}
 	}
 }

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -254,7 +254,7 @@ println('hello world')
 ```
 
 > **Note**
-> If you do not explicitly use `fn main() {}` you need to make sure that all your
+> If you do not explicitly use `fn main() {}`, you need to make sure that all your
 > declarations come before any variable assignment statements or top level function calls,
 > since V will consider everything after the first assignment/function call as part of your
 > implicit main function.
@@ -402,9 +402,9 @@ age = 21
 println(age)
 ```
 
-To change the value of the variable use `=`. In V variables are
+To change the value of the variable use `=`. In V, variables are
 immutable by default.
-To be able to change the value of the variable you have to declare it with `mut`.
+To be able to change the value of the variable, you have to declare it with `mut`.
 
 Try compiling the program above after removing `mut` from the first line.
 
@@ -2547,7 +2547,7 @@ Union member access must be performed in an `unsafe` block.
 
 ### Immutable function args by default
 
-In V function arguments are immutable by default and mutable args have to be
+In V function arguments are immutable by default, and mutable args have to be
 marked on call.
 
 Since there are also no globals, that means that the return values of the functions,
@@ -2612,7 +2612,7 @@ Only more complex types such as arrays and maps may be modified.
 
 ### Variable number of arguments
 V supports functions that receive an arbitrary, variable amounts of arguments, denoted with the `...` prefix.
-Below, `a ...int` refers to an arbitrary amount of parameters that will be collected into `a`.
+Below, `a ...int` refers to an arbitrary amount of parameters that will be collected into an array named `a`.
 
 ```v
 fn sum(a ...int) int {
@@ -3268,7 +3268,7 @@ fn (c Cat) speak() string {
 	return 'meow'
 }
 
-// unlike Go but like TypeScript, V's interfaces can define fields, not just methods.
+// unlike Go, but like TypeScript, V's interfaces can define fields, not just methods.
 interface Speaker {
 	breed string
 	speak() string

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -254,8 +254,8 @@ println('hello world')
 ```
 
 > **Note**
-> If you do not use explicitly `fn main() {}`, you need to make sure, that all your
-> declarations, come before any variable assignment statements, or top level function calls,
+> If you do not explicitly use `fn main() {}` you need to make sure that all your
+> declarations come before any variable assignment statements or top level function calls,
 > since V will consider everything after the first assignment/function call as part of your
 > implicit main function.
 
@@ -402,9 +402,9 @@ age = 21
 println(age)
 ```
 
-To change the value of the variable use `=`. In V, variables are
+To change the value of the variable use `=`. In V variables are
 immutable by default.
-To be able to change the value of the variable, you have to declare it with `mut`.
+To be able to change the value of the variable you have to declare it with `mut`.
 
 Try compiling the program above after removing `mut` from the first line.
 
@@ -2171,7 +2171,7 @@ struct Foo {
 
 All struct fields are zeroed by default during the creation of the struct.
 Array and map fields are allocated.
-In case of reference value, [see](#structs-with-reference-fields).
+In case of reference value, see [here](#structs-with-reference-fields).
 
 It's also possible to define custom default values.
 
@@ -2547,7 +2547,7 @@ Union member access must be performed in an `unsafe` block.
 
 ### Immutable function args by default
 
-In V function arguments are immutable by default, and mutable args have to be
+In V function arguments are immutable by default and mutable args have to be
 marked on call.
 
 Since there are also no globals, that means that the return values of the functions,
@@ -2557,7 +2557,7 @@ are a function of their arguments only, and their evaluation has no side effects
 Function arguments are immutable by default, even when [references](#references) are passed.
 
 > **Note**
-> V is not a purely functional language however.
+> However, V is not a purely functional language.
 
 There is a compiler flag to enable global variables (`-enable-globals`), but this is
 intended for low-level applications like kernels and drivers.
@@ -2611,6 +2611,8 @@ For this reason V doesn't allow the modification of arguments with primitive typ
 Only more complex types such as arrays and maps may be modified.
 
 ### Variable number of arguments
+V supports functions that receive an arbitrary, variable amounts of arguments, denoted with the `...` prefix.
+Below, `a ...int` refers to an arbitrary amount of parameters that will be collected into `a`.
 
 ```v
 fn sum(a ...int) int {
@@ -2745,9 +2747,10 @@ fn main() {
 }
 ```
 
-V currently does not guarantee, that it will print 100, 200, 300 in that order.
-The only guarantee is that 600 (from the body of `f`), will be printed after all of them.
-That *may* change in V 1.0 .
+V currently does not guarantee that it will print 100, 200, 300 in that order.
+The only guarantee is that 600 (from the body of `f`) will be printed after all of them.
+
+This *may* change in V 1.0 .
 
 ## References
 
@@ -3265,7 +3268,7 @@ fn (c Cat) speak() string {
 	return 'meow'
 }
 
-// unlike Go and like TypeScript, V's interfaces can define fields, not just methods.
+// unlike Go but like TypeScript, V's interfaces can define fields, not just methods.
 interface Speaker {
 	breed string
 	speak() string
@@ -3593,7 +3596,7 @@ if mut w is Mars {
 ```
 
 Otherwise `w` would keep its original type.
-> This works for both, simple variables and complex expressions like `user.name`
+> This works for both simple variables and complex expressions like `user.name`
 
 #### Matching sum types
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2107,7 +2107,7 @@ mut p := Point{
 	y: 20
 }
 println(p.x) // Struct fields are accessed using a dot
-// Alternative literal syntax for structs with 3 fields or fewer
+// Alternative literal syntax
 p = Point{10, 20}
 assert p.x == 10
 ```


### PR DESCRIPTION
While learning V I noticed a few things didn't work as shown in the docs and tested locally to verify. 
I also made some minor grammar / readability improvements while I was at it.

Changes:
## 1. Struct literal syntax works for any number of fields.
The syntax `p = Point{10, 20}` is said to only work with 3 or less fields, but it works with larger amounts: `p = Point{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}` compiles and runs with no error.
## 2. Interface smart casting
Best explained by reading the code in https://github.com/vlang/v/commit/bb1b519500165ef7998225463f4be80dbe757eaa. Due to the way smart casting with `is` works, the explicit cast inside of the `if a is IBar {...}` should not be necessary. The `if a is ...` smart casts `a` correctly as expected and calling `a.bar()` works fine without the explicit cast.

Let me know if there's anything else I should do for this PR.