### PR TITLE
cgen: automatically passing sum types by reference if the argument expects it

### DIFF
--- a/vlib/v/gen/c/testdata/sumtype_pass_by_reference.out
+++ b/vlib/v/gen/c/testdata/sumtype_pass_by_reference.out
@@ -1,0 +1,20 @@
+&Expr(ParExpr{
+    expr: Expr(InfixExpr{
+        left: unknown sum type value
+        right: unknown sum type value
+    })
+})
+&Expr(ParExpr{
+    expr: Expr(InfixExpr{
+        left: unknown sum type value
+        right: unknown sum type value
+    })
+})
+&Expr(InfixExpr{
+    left: unknown sum type value
+    right: unknown sum type value
+})
+&Expr(InfixExpr{
+    left: unknown sum type value
+    right: unknown sum type value
+})

--- a/vlib/v/gen/c/testdata/sumtype_pass_by_reference.vv
+++ b/vlib/v/gen/c/testdata/sumtype_pass_by_reference.vv
@@ -1,0 +1,27 @@
+module main
+
+struct ParExpr {
+	expr Expr
+}
+
+struct InfixExpr {
+	left  Expr
+	right Expr
+}
+
+type Expr = InfixExpr | ParExpr
+
+fn print_expr(expr &Expr) {
+	println(expr)
+}
+
+fn main() {
+	par := ParExpr{
+		expr: InfixExpr{}
+	}
+
+	print_expr(par)
+	print_expr(Expr(par))
+	print_expr(par.expr)
+	print_expr(&par.expr)
+}


### PR DESCRIPTION
Fixes #17160 

Passing `Expr(pair)` or `par.expr`, where `par.expr` is a sum type, generates the wrong C code, which is not compiled. And I had to insert `&` by hand in ORM fixes. I fixed It, but I need a good review because I first-time contribute to such "low-level" V things.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
