### PR TITLE
doc: ignore `builtin/wasm`

### DIFF
--- a/vlib/.vdocignore
+++ b/vlib/.vdocignore
@@ -1,4 +1,5 @@
 builtin/js
+builtin/wasm
 builtin/linux_bare
 builtin/wasm_bare
 os/bare


### PR DESCRIPTION
This will fix multiple issues relating to the conflicting builtin library files, where the WebAssembly `builtin` library would overwrite the main builtin.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
