### PR TITLE
checker && parser: remove redundant `&` for passing sum types after #17476

### DIFF
--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -369,7 +369,7 @@ fn (mut c Checker) check_sql_expr_type_is_int(expr &ast.Expr, sql_keyword string
 
 		return
 	} else if expr is ast.ParExpr {
-		c.check_sql_expr_type_is_int(&expr.expr, sql_keyword)
+		c.check_sql_expr_type_is_int(expr.expr, sql_keyword)
 		return
 	}
 
@@ -407,10 +407,10 @@ fn (mut c Checker) check_expr_has_no_fn_calls_with_non_orm_return_type(expr &ast
 				expr.pos)
 		}
 	} else if expr is ast.ParExpr {
-		c.check_expr_has_no_fn_calls_with_non_orm_return_type(&expr.expr)
+		c.check_expr_has_no_fn_calls_with_non_orm_return_type(expr.expr)
 	} else if expr is ast.InfixExpr {
-		c.check_expr_has_no_fn_calls_with_non_orm_return_type(&expr.left)
-		c.check_expr_has_no_fn_calls_with_non_orm_return_type(&expr.right)
+		c.check_expr_has_no_fn_calls_with_non_orm_return_type(expr.left)
+		c.check_expr_has_no_fn_calls_with_non_orm_return_type(expr.right)
 	}
 }
 
@@ -437,19 +437,19 @@ fn (mut c Checker) check_where_expr_has_no_pointless_exprs(table_type_symbol &as
 		} else if expr.left is ast.InfixExpr || expr.left is ast.ParExpr
 			|| expr.left is ast.PrefixExpr {
 			c.check_where_expr_has_no_pointless_exprs(table_type_symbol, field_names,
-				&expr.left)
+				expr.left)
 		} else {
 			c.orm_error(has_no_field_error, expr.left.pos())
 		}
 
 		if expr.right is ast.InfixExpr || expr.right is ast.ParExpr || expr.right is ast.PrefixExpr {
 			c.check_where_expr_has_no_pointless_exprs(table_type_symbol, field_names,
-				&expr.right)
+				expr.right)
 		}
 	} else if expr is ast.ParExpr {
-		c.check_where_expr_has_no_pointless_exprs(table_type_symbol, field_names, &expr.expr)
+		c.check_where_expr_has_no_pointless_exprs(table_type_symbol, field_names, expr.expr)
 	} else if expr is ast.PrefixExpr {
-		c.check_where_expr_has_no_pointless_exprs(table_type_symbol, field_names, &expr.right)
+		c.check_where_expr_has_no_pointless_exprs(table_type_symbol, field_names, expr.right)
 	} else {
 		c.orm_error('`where` expression must have at least one comparison for filtering rows',
 			expr.pos())

--- a/vlib/v/parser/sql.v
+++ b/vlib/v/parser/sql.v
@@ -318,7 +318,7 @@ fn (p &Parser) has_sql_where_expr_with_comparison_with_id(expr &ast.Expr) bool {
 			return expr.left.name == 'id'
 		}
 	} else if expr is ast.ParExpr {
-		return p.has_sql_where_expr_with_comparison_with_id(&expr.expr)
+		return p.has_sql_where_expr_with_comparison_with_id(expr.expr)
 	}
 
 	return false
@@ -334,12 +334,12 @@ fn (mut p Parser) check_sql_where_expr_has_no_undefined_variables(expr &ast.Expr
 		}
 	} else if expr is ast.InfixExpr {
 		if expr.left is ast.Ident && expr.right is ast.Ident {
-			return p.check_sql_where_expr_has_no_undefined_variables(&expr.right, [
+			return p.check_sql_where_expr_has_no_undefined_variables(expr.right, [
 				expr.left.str(),
 			])
 		}
 
-		left_check_result := p.check_sql_where_expr_has_no_undefined_variables(&expr.left,
+		left_check_result := p.check_sql_where_expr_has_no_undefined_variables(expr.left,
 			[])
 
 		if left_check_result is ast.NodeError {
@@ -347,14 +347,14 @@ fn (mut p Parser) check_sql_where_expr_has_no_undefined_variables(expr &ast.Expr
 		}
 
 		variable_names := if expr.left is ast.Ident { [expr.left.str()] } else { []string{} }
-		right_check_result := p.check_sql_where_expr_has_no_undefined_variables(&expr.right,
+		right_check_result := p.check_sql_where_expr_has_no_undefined_variables(expr.right,
 			variable_names)
 
 		if right_check_result is ast.NodeError {
 			return right_check_result
 		}
 	} else if expr is ast.ParExpr {
-		return p.check_sql_where_expr_has_no_undefined_variables(&expr.expr, [])
+		return p.check_sql_where_expr_has_no_undefined_variables(expr.expr, [])
 	}
 
 	return ast.empty_expr


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
