### PR TITLE
cgen: fix multi return with option type

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1191,7 +1191,11 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 	for i, mr_typ in mr_typs {
 		mr_type_sym := t.sym(mktyp(mr_typ))
 		ref, cref := if mr_typ.is_ptr() { '&', 'ref_' } else { '', '' }
+		name += if mr_typ.has_flag(.option) { '?' } else { '' }
+		name += if mr_typ.has_flag(.result) { '!' } else { '' }
 		name += '${ref}${mr_type_sym.name}'
+		cname += if mr_typ.has_flag(.option) { '_option' } else { '' }
+		cname += if mr_typ.has_flag(.option) { '_result' } else { '' }
 		cname += '_${cref}${mr_type_sym.cname}'
 		if i < mr_typs.len - 1 {
 			name += ', '

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1195,7 +1195,7 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 		name += if mr_typ.has_flag(.result) { '!' } else { '' }
 		name += '${ref}${mr_type_sym.name}'
 		cname += if mr_typ.has_flag(.option) { '_option' } else { '' }
-		cname += if mr_typ.has_flag(.option) { '_result' } else { '' }
+		cname += if mr_typ.has_flag(.result) { '_result' } else { '' }
 		cname += '_${cref}${mr_type_sym.cname}'
 		if i < mr_typs.len - 1 {
 			name += ', '

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -652,10 +652,11 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 	// multi return
 	// TODO Handle in if_expr
 	mr_var_name := 'mr_${node.pos.pos}'
-	mr_styp := g.typ(return_type.clear_flag(.result))
-	is_option := return_type.has_flag(.option)
-	if is_option {
-		g.left_is_opt = true
+	mut is_option := return_type.has_flag(.option)
+	mut mr_styp := g.typ(return_type.clear_flag(.result))
+	if node.right[0] is ast.CallExpr && (node.right[0] as ast.CallExpr).or_block.kind != .absent {
+		is_option = false
+		mr_styp = g.typ(return_type.clear_flag(.option).clear_flag(.result))
 	}
 	g.write('${mr_styp} ${mr_var_name} = ')
 	g.expr(node.right[0])

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4563,8 +4563,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	ret_typ := g.typ(g.unwrap_generic(fn_ret_type))
 	mut use_tmp_var := g.defer_stmts.len > 0 || g.defer_profile_code.len > 0
 		|| g.cur_lock.lockeds.len > 0
+		|| (fn_return_is_multi && node.exprs.len >= 1 && fn_return_is_option)
 	// handle promoting none/error/function returning _option'
-	if fn_return_is_option && !fn_return_is_multi {
+	if fn_return_is_option {
 		option_none := node.exprs[0] is ast.None
 		ftyp := g.typ(node.types[0])
 		mut is_regular_option := ftyp == '_option'
@@ -4586,6 +4587,17 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.gen_option_error(fn_ret_type, node.exprs[0])
 			g.writeln(';')
 			if use_tmp_var {
+				// handle options when returning `none` for `?(int, ?int)`
+				if fn_return_is_multi && node.exprs.len >= 1 {
+					mr_info := sym.info as ast.MultiReturn
+					for i in 0 .. mr_info.types.len {
+						if mr_info.types[i].has_flag(.option) {
+							g.write('(*(${g.base_type(fn_ret_type)}*)${tmpvar}.data).arg${i} = ')
+							g.gen_option_error(mr_info.types[i], ast.None{})
+							g.writeln(';')
+						}
+					}
+				}
 				g.write_defer_stmts_when_needed()
 				g.writeln('return ${tmpvar};')
 			}
@@ -4631,9 +4643,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.writeln('return ${tmpvar};')
 			return
 		}
-		typ_sym := g.table.sym(g.fn_decl.return_type)
-		mr_info := typ_sym.info as ast.MultiReturn
-		expected_vals := mr_info.types.len
+		mr_info := sym.info as ast.MultiReturn
 		mut styp := ''
 		if fn_return_is_option {
 			g.writeln('${ret_typ} ${tmpvar};')
@@ -4655,75 +4665,56 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		mut multi_unpack := ''
 		g.write('(${styp}){')
 		mut arg_idx := 0
-		mut i := 0
-
-		for {
-			// ?(?type, ?type) can return `none`
-			// so we should init the leading option values
-			if i == expected_vals {
-				break
-			}
-			if i < node.exprs.len {
-				expr := node.exprs[i]
-				// Check if we are dealing with a multi return and handle it seperately
-				if g.expr_is_multi_return_call(expr) {
-					call_expr := expr as ast.CallExpr
-					expr_sym := g.table.sym(call_expr.return_type)
-					mut tmp := g.new_tmp_var()
-					if !call_expr.return_type.has_flag(.option)
-						&& !call_expr.return_type.has_flag(.result) {
-						line := g.go_before_stmt(0)
-						expr_styp := g.typ(call_expr.return_type)
-						g.write('${expr_styp} ${tmp}=')
-						g.expr(expr)
-						g.writeln(';')
-						multi_unpack += g.go_before_stmt(0)
-						g.write(line)
-					} else {
-						line := g.go_before_stmt(0)
-						g.tmp_count--
-						g.expr(expr)
-						multi_unpack += g.go_before_stmt(0)
-						g.write(line)
-						expr_styp := g.base_type(call_expr.return_type)
-						tmp = ('(*(${expr_styp}*)${tmp}.data)')
-					}
-					expr_types := expr_sym.mr_info().types
-					for j, _ in expr_types {
-						g.write('.arg${arg_idx}=${tmp}.arg${j}')
-						if j < expr_types.len || i < node.exprs.len - 1 {
-							g.write(',')
-						}
-						arg_idx++
-					}
-					continue
-				}
-				g.write('.arg${arg_idx}=')
-				if expr.is_auto_deref_var() {
-					g.write('*')
-				}
-				if g.table.sym(mr_info.types[i]).kind in [.sum_type, .interface_] {
-					g.expr_with_cast(expr, node.types[i], mr_info.types[i])
-				} else if mr_info.types[i].has_flag(.option) {
-					g.expr_with_opt(expr, node.types[i], mr_info.types[i])
-				} else {
+		for i, expr in node.exprs {
+			// Check if we are dealing with a multi return and handle it seperately
+			if g.expr_is_multi_return_call(expr) {
+				call_expr := expr as ast.CallExpr
+				expr_sym := g.table.sym(call_expr.return_type)
+				mut tmp := g.new_tmp_var()
+				if !call_expr.return_type.has_flag(.option)
+					&& !call_expr.return_type.has_flag(.result) {
+					line := g.go_before_stmt(0)
+					expr_styp := g.typ(call_expr.return_type)
+					g.write('${expr_styp} ${tmp}=')
 					g.expr(expr)
+					g.writeln(';')
+					multi_unpack += g.go_before_stmt(0)
+					g.write(line)
+				} else {
+					line := g.go_before_stmt(0)
+					g.tmp_count--
+					g.expr(expr)
+					multi_unpack += g.go_before_stmt(0)
+					g.write(line)
+					expr_styp := g.base_type(call_expr.return_type)
+					tmp = ('(*(${expr_styp}*)${tmp}.data)')
 				}
-
-				if i < expected_vals - 1 {
-					g.write(', ')
-				}
-			} else {
-				if mr_info.types[i].has_flag(.option) {
-					g.expr_with_opt(ast.None{}, ast.none_type, mr_info.types[i])
-
-					if i < expected_vals - 1 {
-						g.write(', ')
+				expr_types := expr_sym.mr_info().types
+				for j, _ in expr_types {
+					g.write('.arg${arg_idx}=${tmp}.arg${j}')
+					if j < expr_types.len || i < node.exprs.len - 1 {
+						g.write(',')
 					}
+					arg_idx++
 				}
+				continue
+			}
+			g.write('.arg${arg_idx}=')
+			if expr.is_auto_deref_var() {
+				g.write('*')
+			}
+			if g.table.sym(mr_info.types[i]).kind in [.sum_type, .interface_] {
+				g.expr_with_cast(expr, node.types[i], mr_info.types[i])
+			} else if mr_info.types[i].has_flag(.option) {
+				g.expr_with_opt(expr, node.types[i], mr_info.types[i])
+			} else {
+				g.expr(expr)
+			}
+
+			if i < node.exprs.len - 1 {
+				g.write(', ')
 			}
 			arg_idx++
-			i++
 		}
 		g.write('}')
 		if fn_return_is_option {

--- a/vlib/v/tests/option_multi_return_test.v
+++ b/vlib/v/tests/option_multi_return_test.v
@@ -1,3 +1,9 @@
+struct MmapRangeLocal {}
+
+fn addr2range() ?(&MmapRangeLocal, ?u64, u64) {
+	return none
+}
+
 fn foo(val ?int) (?int, ?int) {
 	return val, none
 }
@@ -46,4 +52,10 @@ fn test_tuple_4() {
 	a, b := tuple4()
 	assert a == none
 	assert b == none
+}
+
+fn test_none_ret() {
+	_, b, c := addr2range()
+	assert b == none
+	assert c == 0
 }

--- a/vlib/v/tests/option_multi_return_test.v
+++ b/vlib/v/tests/option_multi_return_test.v
@@ -7,3 +7,43 @@ fn test_multi_return() {
 	assert a == 100
 	assert b == none
 }
+
+fn tuple() ?(int, int) {
+	return 1, 2
+}
+
+fn tuple2() ?(string, int) {
+	return '', 2
+}
+
+fn tuple3() ?(?int, ?int) {
+	return none, none
+}
+
+fn tuple4() ?(?int, ?int) {
+	return none
+}
+
+fn test_tuple_1() {
+	a, b := tuple()
+	assert a == 1
+	assert b == 2
+}
+
+fn test_tuple_2() {
+	a, b := tuple2()
+	assert a == ''
+	assert b == 2
+}
+
+fn test_tuple_3() {
+	a, b := tuple3()
+	assert a == none
+	assert b == none
+}
+
+fn test_tuple_4() {
+	a, b := tuple4()
+	assert a == none
+	assert b == none
+}

--- a/vlib/v/tests/option_multi_return_test.v
+++ b/vlib/v/tests/option_multi_return_test.v
@@ -1,10 +1,9 @@
-fn tuple() ?(int, int) {
-	return 1, 2
+fn foo(val ?int) (?int, ?int) {
+	return val, none
 }
 
-fn test_option_multi_return() {
-	println(tuple()?)
-	a, b := tuple()?
-	assert a == 1
-	assert b == 2
+fn test_multi_return() {
+	a, b := foo(100)
+	assert a == 100
+	assert b == none
 }


### PR DESCRIPTION
Fix #17465

```V
fn tuple() ?(int, int) {
	return 1, 2
}

fn tuple2() ?(string, int) {
	return '', 2
}

fn tuple3() ?(?int, ?int) {
	return none, none
}

fn tuple4() ?(?int, ?int) {
	return none
}

fn test_tuple_1() {
	a, b := tuple()
	assert a == 1
	assert b == 2
}

fn test_tuple_2() {
	a, b := tuple2()
	assert a == ''
	assert b == 2
}

fn test_tuple_3() {
	a, b := tuple3()
	assert a == none
	assert b == none
}

fn test_tuple_4() {
	a, b := tuple4()
	assert a == none
	assert b == none
}
```