### PR TITLE
cgen: add calls to all typeof functions for interfaces and sum-types 

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5317,8 +5317,8 @@ fn (g &Gen) checker_bug(s string, pos token.Pos) {
 // write_calls_typeof_functions inserts calls to all typeof functions for
 // interfaces and sum-types in debug mode so that the compiler does not optimize them.
 // These functions are needed to be able to get the name of a specific structure/type in the debugger.
-fn (mut g Gen) write_calls_typeof_functions() {
-	if g.pref.is_debug {
+fn (mut g Gen) write_debug_calls_typeof_functions() {
+	if !g.pref.is_debug {
 		return
 	}
 
@@ -5361,7 +5361,7 @@ fn (mut g Gen) write_init_function() {
 	// ___argv is declared as voidptr here, because that unifies the windows/unix logic
 	g.writeln('void _vinit(int ___argc, voidptr ___argv) {')
 
-	g.write_calls_typeof_functions()
+	g.write_debug_calls_typeof_functions()
 
 	if g.pref.trace_calls {
 		g.writeln('\tv__trace_calls__on_call(_SLIT("_vinit"));')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5314,6 +5314,37 @@ fn (g &Gen) checker_bug(s string, pos token.Pos) {
 	g.error('checker bug; ${s}', pos)
 }
 
+// write_calls_typeof_functions inserts calls to all typeof functions for
+// interfaces and sum-types in debug mode so that the compiler does not optimize them.
+// These functions are needed to be able to get the name of a specific structure/type in the debugger.
+fn (mut g Gen) write_calls_typeof_functions() {
+	if g.pref.is_debug {
+		return
+	}
+
+	g.writeln('\t// we call these functions in debug mode so that the C compiler')
+	g.writeln('\t// does not optimize them and we can access them in the debugger.')
+	for _, sym in g.table.type_symbols {
+		if sym.kind == .sum_type {
+			sum_info := sym.info as ast.SumType
+			if sum_info.is_generic {
+				continue
+			}
+			g.writeln('\tv_typeof_sumtype_${sym.cname}(0);')
+		}
+		if sym.kind == .interface_ {
+			if sym.info !is ast.Interface {
+				continue
+			}
+			inter_info := sym.info as ast.Interface
+			if inter_info.is_generic {
+				continue
+			}
+			g.writeln('\tv_typeof_interface_${sym.cname}(0);')
+		}
+	}
+}
+
 fn (mut g Gen) write_init_function() {
 	if g.pref.no_builtin || (g.pref.translated && g.pref.is_o) {
 		return
@@ -5329,6 +5360,8 @@ fn (mut g Gen) write_init_function() {
 
 	// ___argv is declared as voidptr here, because that unifies the windows/unix logic
 	g.writeln('void _vinit(int ___argc, voidptr ___argv) {')
+
+	g.write_calls_typeof_functions()
 
 	if g.pref.trace_calls {
 		g.writeln('\tv__trace_calls__on_call(_SLIT("_vinit"));')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5314,7 +5314,7 @@ fn (g &Gen) checker_bug(s string, pos token.Pos) {
 	g.error('checker bug; ${s}', pos)
 }
 
-// write_calls_typeof_functions inserts calls to all typeof functions for
+// write_debug_calls_typeof_functions inserts calls to all typeof functions for
 // interfaces and sum-types in debug mode so that the compiler does not optimize them.
 // These functions are needed to be able to get the name of a specific structure/type in the debugger.
 fn (mut g Gen) write_debug_calls_typeof_functions() {


### PR DESCRIPTION
Add calls to all typeof functions for interfaces and sum-types in **debug** mode, to be able to call them in the debugger, otherwise the C compiler will optimize them

This will allow the IDEA plugin to add pretty-printers that output concrete types in the debugger.

For example:

![](https://cdn.discordapp.com/attachments/1054279908408434829/1081189165682655354/2023-03-03_16.19.11.png)
