### PR TITLE
cgen: unwrap and c-mangle field selectors in or blocks

### DIFF
--- a/vlib/v/tests/struct_selector_or_block_test.v
+++ b/vlib/v/tests/struct_selector_or_block_test.v
@@ -22,3 +22,14 @@ fn test_main() {
 	assert greet(Hello{}) == 'UNKNOWN'
 	assert greet(Hello{'cool', ''}) == 'cool'
 }
+
+struct CnameTest {
+    long ?string
+    short ?string
+}
+
+fn test_cname_opt_field_selecor() {
+    x := CnameTest{short: 'xyz'}
+    assert (x.long or { 'NOPE' }) == 'NOPE'
+    assert (x.short or { 'NOPE' }) == 'xyz'
+}


### PR DESCRIPTION
This PR fixes the case where C keywords are not correctly mangled in field selectors with or blocks.

The following code otherwise generates invalid C:

```v
struct Foo {
    long ?string // field is C keyword
}
fn main() {
    foo = Foo{''}
    println(foo.long or {''}) // generates invalid code
}
```

The following C code is generated:

```c
VV_LOCAL_SYMBOL void main__main(void) {
	_option_string _t1;
	_option_ok(&(string[]) { _SLIT("") }, (_option*)(&_t1), sizeof(string));
	main__Foo f = ((main__Foo){._v_long = _t1,});
	_option_string _t2 = f.long;  // ERROR: field name is keyword
	if (_t2.state != 0) {
		IError err = _t2.err;
		*(string*) _t2.data = _SLIT("");
	}
	println( (*(string*)_t2.data));
}
```

There is no open ticket for this issue (that I'm aware of).

PR includes test.
