### PR TITLE
cgen: fix printing map reference value (fix #17492)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -759,7 +759,8 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		tmp_str := str_intp_rune('${elem_str_fn_name}(*(${val_styp}*)DenseArray_value(&m.key_values, i))')
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${tmp_str});')
 	} else {
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*(${val_styp}*)DenseArray_value(&m.key_values, i)));')
+		ptr_str := '*'.repeat(val_typ.nr_muls())
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*${ptr_str}(${val_styp}*)DenseArray_value(&m.key_values, i)));')
 	}
 	g.auto_str_funcs.writeln('\t\tif (i != m.key_values.len-1) {')
 	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT(", "));')

--- a/vlib/v/tests/map_reference_value_test.v
+++ b/vlib/v/tests/map_reference_value_test.v
@@ -1,3 +1,5 @@
+import datatypes
+
 struct Foo {
 	bar string
 }
@@ -14,4 +16,10 @@ fn test_map_reference_value() {
 	println(m2)
 
 	assert true
+}
+
+fn test_map_reference_value2() {
+	mut m := map[string]&datatypes.Queue[i64]{}
+	println('${m}')
+	assert '${m}' == '{}'
 }


### PR DESCRIPTION
This PR fix printing map reference value (fix #17492).

- Fix printing map reference value.
- Add test.

```v
import datatypes

fn main() {
	mut m := map[string]&datatypes.Queue[i64]{}
	println('${m}')
}

PS D:\Test\v\tt1> v run .
{}
```