### PR TITLE
v: support interface field compile time reflection

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -180,10 +180,22 @@ fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 		c.error('unknown type `${sym.name}`', node.typ_pos)
 	}
 	if node.kind == .fields {
-		if sym.kind == .struct_ {
-			sym_info := sym.info as ast.Struct
+		if sym.kind in [.struct_, .interface_] {
+			fields := match sym.info {
+				ast.Struct {
+					sym.info.fields
+				}
+				ast.Interface {
+					sym.info.fields
+				}
+				else {
+					c.error('internal error: unsupported type for comptime field lookup at cheker phase: ${sym.name}',
+						node.typ_pos)
+					[]ast.StructField{len: 0}
+				}
+			}
 			c.inside_comptime_for_field = true
-			for field in sym_info.fields {
+			for field in fields {
 				c.comptime_for_field_value = field
 				c.comptime_for_field_var = node.val_var
 				c.comptime_fields_type[node.val_var] = node.typ

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -189,9 +189,9 @@ fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 					sym.info.fields
 				}
 				else {
-					c.error('internal error: unsupported type for comptime field lookup at checker phase: ${sym.name}',
+					c.error('comptime field lookup supports only structs and interfaces currently, and ${sym.name} is neither',
 						node.typ_pos)
-					[]ast.StructField{len: 0}
+					return
 				}
 			}
 			c.inside_comptime_for_field = true

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -189,7 +189,7 @@ fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 					sym.info.fields
 				}
 				else {
-					c.error('internal error: unsupported type for comptime field lookup at cheker phase: ${sym.name}',
+					c.error('internal error: unsupported type for comptime field lookup at checker phase: ${sym.name}',
 						node.typ_pos)
 					[]ast.StructField{len: 0}
 				}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -181,12 +181,13 @@ fn (mut c Checker) comptime_for(node ast.ComptimeFor) {
 	}
 	if node.kind == .fields {
 		if sym.kind in [.struct_, .interface_] {
-			fields := match sym.info {
+			mut fields := []ast.StructField{}
+			match sym.info {
 				ast.Struct {
-					sym.info.fields
+					fields = sym.info.fields.clone()
 				}
 				ast.Interface {
-					sym.info.fields
+					fields = sym.info.fields.clone()
 				}
 				else {
 					c.error('comptime field lookup supports only structs and interfaces currently, and ${sym.name} is neither',

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -772,7 +772,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					sym.info.fields
 				}
 				else {
-					error('internal error: unsupported type for comptime field lookup at cgen phase: ${sym.name}')
+					g.error('comptime field lookup is supported only for structs and interfaces, and ${sym.name} is neither', node.pos)
 					[]ast.StructField{len: 0}
 				}
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -763,12 +763,24 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 		}
 	} else if node.kind == .fields {
 		// TODO add fields
-		if sym.kind == .struct_ {
-			sym_info := sym.info as ast.Struct
-			if sym_info.fields.len > 0 {
+		if sym.kind in [.struct_, .interface_] {
+			fields := match sym.info {
+				ast.Struct {
+					sym.info.fields
+				}
+				ast.Interface {
+					sym.info.fields
+				}
+				else {
+					error('internal error: unsupported type for comptime field lookup at cheker phase: ${sym.name}',
+						node.typ_pos)
+					[]ast.StructField{len: 0}
+				}
+			}
+			if fields.len > 0 {
 				g.writeln('\tFieldData ${node.val_var} = {0};')
 			}
-			for field in sym_info.fields {
+			for field in fields {
 				g.push_existing_comptime_values()
 				g.inside_comptime_for_field = true
 				g.comptime_for_field_var = node.val_var

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -772,7 +772,8 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					sym.info.fields
 				}
 				else {
-					g.error('comptime field lookup is supported only for structs and interfaces, and ${sym.name} is neither', node.pos)
+					g.error('comptime field lookup is supported only for structs and interfaces, and ${sym.name} is neither',
+						node.pos)
 					[]ast.StructField{len: 0}
 				}
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -772,8 +772,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					sym.info.fields
 				}
 				else {
-					error('internal error: unsupported type for comptime field lookup at cheker phase: ${sym.name}',
-						node.typ_pos)
+					error('internal error: unsupported type for comptime field lookup at cgen phase: ${sym.name}')
 					[]ast.StructField{len: 0}
 				}
 			}

--- a/vlib/v/gen/c/testdata/comptime_interface_field.out
+++ b/vlib/v/gen/c/testdata/comptime_interface_field.out
@@ -1,0 +1,2 @@
+name
+age

--- a/vlib/v/gen/c/testdata/comptime_interface_field.vv
+++ b/vlib/v/gen/c/testdata/comptime_interface_field.vv
@@ -1,0 +1,10 @@
+interface User {
+	name string
+	age int
+}
+
+fn main() {
+	$for field in User.fields {
+		println(field.name)
+	}
+}


### PR DESCRIPTION
- Fix #17346, support interface field compile time reflection
- Add output test

`vlib/v/gen/c/testdata/comptime_interface_field.vv`
```v
interface User {
	name string
	age int
}

fn main() {
	$for field in User.fields {
		println(field.name)
	}
}
```

`vlib/v/gen/c/testdata/comptime_interface_field.out`
```v
name
age
```