### PR TITLE
checker: fix nested option struct with required attr init (fix #17513)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -648,7 +648,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					}
 				}
 				if !field.has_default_expr && field.name !in inited_fields && !field.typ.is_ptr()
-					&& c.table.final_sym(field.typ).kind == .struct_ {
+					&& !field.typ.has_flag(.option) && c.table.final_sym(field.typ).kind == .struct_ {
 					mut zero_struct_init := ast.StructInit{
 						pos: node.pos
 						typ: field.typ

--- a/vlib/v/tests/nested_option_struct_init_test.v
+++ b/vlib/v/tests/nested_option_struct_init_test.v
@@ -14,3 +14,17 @@ fn test_nested_option_struct_init() {
 	assert d2.d.b != none
 	assert d2.d.b? == 1
 }
+
+struct AA {
+	bb ?BB // defaults to none
+}
+
+struct BB {
+	x string [required]
+}
+
+fn test_nested_option_struct_with_attr_init() {
+	aa := AA{}
+	println(aa)
+	assert aa.bb == none
+}


### PR DESCRIPTION
This PR fix nested option struct with required attr init (fix #17513).

- Fix nested option struct with required attr init.
- Add test.

```v
struct AA {
	bb ?BB // defaults to none
}

struct BB {
	x string [required]
}

fn main() {
	aa := AA{}
	println(aa)
	assert aa.bb == none
}

PS D:\Test\v\tt1> v run .
AA{
    bb: Option(error: none)
}
```