### PR TITLE
checker: fix const init with comptime

### DIFF
--- a/vlib/v/tests/comptime_const_def_test.v
+++ b/vlib/v/tests/comptime_const_def_test.v
@@ -1,0 +1,12 @@
+const (
+	buf_size = $if true {
+		2
+	} $else {
+		1
+	}
+)
+
+fn test_main() {
+	mut buf := [buf_size]u8{}
+	assert buf.len == 2
+}


### PR DESCRIPTION
Fix #17521

Make possible:

```V
const (
    buf_size = $if windows { os.max_path_len * 2 } $else { os.max_path_len }
)
``` 