### PR TITLE
cgen: fix default initialization of option array with none values

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -353,7 +353,11 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.write(' (voidptr)${tmp})')
 	} else if node.has_default {
 		g.write('&(${elem_styp}[]){')
-		g.expr_with_cast(node.default_expr, node.default_type, node.elem_type)
+		if node.elem_type.has_flag(.option) {
+			g.expr_with_opt(node.default_expr, node.default_type, node.elem_type)
+		} else {
+			g.expr_with_cast(node.default_expr, node.default_type, node.elem_type)
+		}
 		g.write('})')
 	} else if node.has_len && node.elem_type == ast.string_type {
 		g.write('&(${elem_styp}[]){')

--- a/vlib/v/tests/option_array_init_test.v
+++ b/vlib/v/tests/option_array_init_test.v
@@ -1,0 +1,10 @@
+fn test_main() {
+	a := []?int{len: 3, init: none}
+	mut t := a[0]
+	assert t == none
+	t = a[1]
+	assert t == none
+	t = a[2]
+	assert t == none
+	assert a.len == 3
+}


### PR DESCRIPTION
Fix #17534
