### PR TITLE
cgen: fix dump option value on generic function

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -20,7 +20,8 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		if node.expr is ast.Ident {
 			// var
 			if node.expr.info is ast.IdentVar && node.expr.language == .v {
-				name = g.typ(g.unwrap_generic(node.expr.info.typ)).replace('*', '')
+				name = g.typ(g.unwrap_generic(node.expr.info.typ.clear_flag(.shared_f).clear_flag(.option).clear_flag(.result))).replace('*',
+					'')
 			}
 		}
 	}

--- a/vlib/v/tests/option_array_dump_in_generic_fn_test.v
+++ b/vlib/v/tests/option_array_dump_in_generic_fn_test.v
@@ -1,0 +1,15 @@
+fn abc[T]() []int {
+	a := []?int{len: 2}
+	mut s := []int{}
+	for v in a {
+		s << dump(v)
+	}
+	return s
+}
+
+fn test_main() {
+	arr := abc[int]()
+	assert arr.len == 2
+	assert arr[0] == 0
+	assert arr[1] == 0
+}


### PR DESCRIPTION
Fix #17533