### PR TITLE
v: Rename variable it into index

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1611,7 +1611,7 @@ fn (t Tree) array_init(node ast.ArrayInit) &Node {
 	obj.add_terse('has_len', t.bool_node(node.has_len))
 	obj.add_terse('has_cap', t.bool_node(node.has_cap))
 	obj.add_terse('has_default', t.bool_node(node.has_default))
-	obj.add_terse('has_it', t.bool_node(node.has_it))
+	obj.add_terse('has_index', t.bool_node(node.has_index))
 	obj.add_terse('expr_types', t.array_node_type(node.expr_types))
 	obj.add('pos', t.pos(node.pos))
 	return obj

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -946,14 +946,14 @@ for i in 0 .. 1000 {
 > **Note**
 > The above code uses a [range `for`](#range-for) statement.
 
-You can initialize the array by accessing the `it` variable which gives
+You can initialize the array by accessing the `index` variable which gives
 the index as shown here:
 
 ```v
-count := []int{len: 4, init: it}
+count := []int{len: 4, init: index}
 assert count == [0, 1, 2, 3]
 
-mut square := []int{len: 6, init: it * it}
+mut square := []int{len: 6, init: index * index}
 // square == [0, 1, 4, 9, 16, 25]
 ```
 

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1598,12 +1598,12 @@ fn f(x int, y int) []int {
 }
 
 fn test_2d_array_init_with_it() {
-	a := [][]int{len: 6, init: f(it, 2 * it)}
+	a := [][]int{len: 6, init: f(index, 2 * index)}
 	assert a == [[0, 0], [1, 2], [2, 4], [3, 6], [4, 8], [5, 10]]
 }
 
 fn test_using_array_name_variable() {
-	array := []int{len: 4, init: it}
+	array := []int{len: 4, init: index}
 	println(array)
 	assert array == [0, 1, 2, 3]
 }

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -444,7 +444,7 @@ pub fn (mut rng PRNG) choose[T](array []T, k int) ![]T {
 		return error('Cannot choose ${k} elements without replacement from a ${n}-element array.')
 	}
 	mut results := []T{len: k}
-	mut indices := []int{len: n, init: it}
+	mut indices := []int{len: n, init: index}
 	rng.shuffle[int](mut indices)!
 	for i in 0 .. k {
 		results[i] = array[indices[i]]

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1280,7 +1280,7 @@ pub:
 	has_len       bool
 	has_cap       bool
 	has_default   bool
-	has_it        bool // true if temp variable it is used
+	has_index     bool // true if temp variable index is used
 pub mut:
 	exprs        []Expr // `[expr, expr]` or `[expr]Type{}` for fixed array
 	len_expr     Expr   // len: expr

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -118,6 +118,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		g.writeln('int _len = (int)sizeof(${tmp}) / sizeof(${elem_typ});')
 		g.writeln('for(int index=0; index<_len; index++, pelem++) {')
 		g.indent++
+		g.writeln('int it = index;') // FIXME: Remove this line when it is fully forbidden
 		g.write('*pelem = ')
 		g.expr(node.default_expr)
 		g.writeln(';')
@@ -271,6 +272,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.writeln('for(int index=0; index<${tmp}.len; index++, pelem++) {')
 		g.set_current_pos_as_last_stmt_pos()
 		g.indent++
+		g.writeln('int it = index;') // FIXME: Remove this line when it is fully forbidden	
 		g.write('*pelem = ')
 		g.expr(node.default_expr)
 		g.writeln(';')

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -72,7 +72,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 }
 
 fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name string) {
-	if node.has_it {
+	if node.has_index {
 		g.inside_lambda = true
 		mut tmp := g.new_tmp_var()
 		mut s := ''
@@ -116,7 +116,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		g.indent++
 		g.writeln('${elem_typ}* pelem = (${elem_typ}*)${tmp};')
 		g.writeln('int _len = (int)sizeof(${tmp}) / sizeof(${elem_typ});')
-		g.writeln('for(int it=0; it<_len; it++, pelem++) {')
+		g.writeln('for(int index=0; index<_len; index++, pelem++) {')
 		g.indent++
 		g.write('*pelem = ')
 		g.expr(node.default_expr)
@@ -197,7 +197,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 	is_default_map := elem_type.unaliased_sym.kind == .map && node.has_default
 	needs_more_defaults := node.has_len && (g.struct_has_array_or_map_field(elem_type.typ)
 		|| elem_type.unaliased_sym.kind in [.array, .map])
-	if node.has_it { // []int{len: 6, init: it * it} when variable it is used in init expression
+	if node.has_index { // []int{len: 6, init: it * it} when variable it is used in init expression
 		g.inside_lambda = true
 		mut tmp := g.new_tmp_var()
 		mut s := ''
@@ -268,7 +268,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.writeln('{')
 		g.indent++
 		g.writeln('${elem_typ}* pelem = (${elem_typ}*)${tmp}.data;')
-		g.writeln('for(int it=0; it<${tmp}.len; it++, pelem++) {')
+		g.writeln('for(int index=0; index<${tmp}.len; index++, pelem++) {')
 		g.set_current_pos_as_last_stmt_pos()
 		g.indent++
 		g.write('*pelem = ')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2380,7 +2380,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 		return
 	} else if arg.expr is ast.ArrayInit {
 		if arg.expr.is_fixed {
-			if !arg.expr.has_it {
+			if !arg.expr.has_index {
 				g.write('(${g.typ(arg.expr.typ)})')
 			}
 		}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -190,7 +190,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 					g.write('*')
 				}
 				if node.left is ast.ArrayInit {
-					if !node.left.has_it {
+					if !node.left.has_index {
 						s := g.typ(left.unaliased)
 						g.write('(${s})')
 					}
@@ -198,7 +198,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				g.expr(node.left)
 				g.write(', ')
 				if node.right is ast.ArrayInit {
-					if !node.right.has_it {
+					if !node.right.has_index {
 						s := g.typ(right.unaliased)
 						g.write('(${s})')
 					}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -132,7 +132,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {
 				s := g.typ(expr.typ)
-				if !expr.has_it {
+				if !expr.has_index {
 					g.write('(${s})')
 				}
 			}

--- a/vlib/v/gen/c/testdata/array_init_no_error.vv
+++ b/vlib/v/gen/c/testdata/array_init_no_error.vv
@@ -1,11 +1,11 @@
 // From issue #14679
 fn iterate_linear(value1 u32, value2 u32, length u32) []u32 {
 	step := u32((value2 - value1) / (length - 1))
-	return []u32{len: int(length), init: value1 + step * u32(it + 1)}
+	return []u32{len: int(length), init: value1 + step * u32(index + 1)}
 }
 
 pub fn iterate_rect_single(val1 u32, val2 u32, val3 u32, val4 u32, width u32, height u32) [][]u32 {
 	left := iterate_linear(val1, val3, height)
 	right := iterate_linear(val2, val4, height)
-	return [][]u32{len: int(width), init: iterate_linear(left[it], right[it], width)}
+	return [][]u32{len: int(width), init: iterate_linear(left[index], right[index], width)}
 }

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -3717,7 +3717,7 @@ fn (mut g Gen) reverse_string(reg Register) {
 }
 
 fn (mut g Gen) gen_match_expr_amd64(expr ast.MatchExpr) {
-	branch_labels := []int{len: expr.branches.len, init: g.labels.new_label() + it * 0} // call new_label for all elements in the array
+	branch_labels := []int{len: expr.branches.len, init: g.labels.new_label() + index * 0} // call new_label for all elements in the array
 	end_label := g.labels.new_label()
 
 	if expr.is_sum_type {

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -107,7 +107,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						is_used
 					} else if var := p.scope.find_var('it') {
-						p.warning('variable `it` in array initialization will soon replaced with `index` in future version')
+						p.warning('variable `it` in array initialization will be soon replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
@@ -180,7 +180,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						is_used
 					} else if var := p.scope.find_var('it') {
-						p.warning('variable `it` in array initialization will soon replaced with `index` in future version')
+						p.warning('variable `it` in array initialization will soon be replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -106,6 +106,12 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						is_used := variable.is_used
 						variable.is_used = true
 						is_used
+					} else if var := p.scope.find_var('it') {
+						p.wraning('variable `it` in array initialization will soon replaced with `index` in future version')
+						mut variable := unsafe { var }
+						is_used := variable.is_used
+						variable.is_used = true
+						is_used
 					} else {
 						false
 					}
@@ -169,6 +175,12 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					p.scope_register_index()
 					default_expr = p.expr(0)
 					has_index = if var := p.scope.find_var('index') {
+						mut variable := unsafe { var }
+						is_used := variable.is_used
+						variable.is_used = true
+						is_used
+					} else if var := p.scope.find_var('it') {
+						p.wraning('variable `it` in array initialization will soon replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
@@ -255,6 +267,13 @@ fn (mut p Parser) map_init() ast.MapInit {
 fn (mut p Parser) scope_register_index() {
 	p.scope.objects['index'] = ast.Var{ // override index variable if it already exist, else create index variable
 		name: 'index'
+		pos: p.tok.pos()
+		typ: ast.int_type
+		is_mut: false
+		is_used: false
+	}
+	p.scope.objects['it'] = ast.Var{ // it is now deprecated, will be removed in future stable release
+		name: 'it'
 		pos: p.tok.pos()
 		typ: ast.int_type
 		is_mut: false

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -107,7 +107,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						is_used
 					} else if var := p.scope.find_var('it') {
-						p.warning('variable `it` in array initialization will be soon replaced with `index` in future version')
+						p.warn('variable `it` in array initialization will be soon replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
@@ -180,7 +180,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						is_used
 					} else if var := p.scope.find_var('it') {
-						p.warning('variable `it` in array initialization will soon be replaced with `index` in future version')
+						p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -180,7 +180,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						is_used := variable.is_used
 						variable.is_used = true
 						has_index = is_used
-					} 
+					}
 					if var := p.scope.find_var('it') {
 						mut variable := unsafe { var }
 						is_used := variable.is_used

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -107,7 +107,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						has_index = is_used
 					}
-					if var := p.scope.find_var('it') {
+					if !has_index && var := p.scope.find_var('it') { // FIXME: Remove this block when `it` is forbidden
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						if is_used {
@@ -181,7 +181,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						has_index = is_used
 					}
-					if var := p.scope.find_var('it') {
+					if !has_index && var := p.scope.find_var('it') { // FIXME: Remove this block when `it` is forbidden
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						if is_used {

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -111,7 +111,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						if is_used {
-							p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
+							p.warn('variable `it` in array initialization will soon be replaced with `index`')
 						}
 						variable.is_used = true
 						has_index = is_used
@@ -182,11 +182,10 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						has_index = is_used
 					} 
 					if var := p.scope.find_var('it') {
-						p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						if is_used {
-							p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
+							p.warn('variable `it` in array initialization will soon be replaced with `index`')
 						}
 						variable.is_used = true
 						has_index = is_used

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -101,19 +101,20 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					has_default = true
 					p.scope_register_index()
 					default_expr = p.expr(0)
-					has_index = if var := p.scope.find_var('index') {
+					if var := p.scope.find_var('index') {
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
-						is_used
-					} else if var := p.scope.find_var('it') {
-						p.warn('variable `it` in array initialization will be soon replaced with `index` in future version')
+						has_index = is_used
+					}
+					if var := p.scope.find_var('it') {
 						mut variable := unsafe { var }
 						is_used := variable.is_used
+						if is_used {
+							p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
+						}
 						variable.is_used = true
-						is_used
-					} else {
-						false
+						has_index = is_used
 					}
 					p.close_scope()
 				}
@@ -174,19 +175,21 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					has_default = true
 					p.scope_register_index()
 					default_expr = p.expr(0)
-					has_index = if var := p.scope.find_var('index') {
+					if var := p.scope.find_var('index') {
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
-						is_used
-					} else if var := p.scope.find_var('it') {
+						has_index = is_used
+					} 
+					if var := p.scope.find_var('it') {
 						p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
+						if is_used {
+							p.warn('variable `it` in array initialization will soon be replaced with `index` in future version')
+						}
 						variable.is_used = true
-						is_used
-					} else {
-						false
+						has_index = is_used
 					}
 					p.close_scope()
 				}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -107,7 +107,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						is_used
 					} else if var := p.scope.find_var('it') {
-						p.wraning('variable `it` in array initialization will soon replaced with `index` in future version')
+						p.warning('variable `it` in array initialization will soon replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
@@ -180,7 +180,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 						variable.is_used = true
 						is_used
 					} else if var := p.scope.find_var('it') {
-						p.wraning('variable `it` in array initialization will soon replaced with `index` in future version')
+						p.warning('variable `it` in array initialization will soon replaced with `index` in future version')
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -25,7 +25,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 	mut has_val := false
 	mut has_type := false
 	mut has_default := false
-	mut has_it := false
+	mut has_index := false
 	mut default_expr := ast.empty_expr
 	if p.tok.kind == .rsbr {
 		last_pos = p.tok.pos()
@@ -99,9 +99,9 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 					p.check(.colon)
 					p.open_scope()
 					has_default = true
-					p.scope_register_it_as_index()
+					p.scope_register_index()
 					default_expr = p.expr(0)
-					has_it = if var := p.scope.find_var('it') {
+					has_index = if var := p.scope.find_var('index') {
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
@@ -166,9 +166,9 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 				'init' {
 					p.open_scope()
 					has_default = true
-					p.scope_register_it_as_index()
+					p.scope_register_index()
 					default_expr = p.expr(0)
-					has_it = if var := p.scope.find_var('it') {
+					has_index = if var := p.scope.find_var('index') {
 						mut variable := unsafe { var }
 						is_used := variable.is_used
 						variable.is_used = true
@@ -209,7 +209,7 @@ fn (mut p Parser) array_init() ast.ArrayInit {
 		len_expr: len_expr
 		has_cap: has_cap
 		has_default: has_default
-		has_it: has_it
+		has_index: has_index
 		cap_expr: cap_expr
 		default_expr: default_expr
 	}
@@ -252,9 +252,9 @@ fn (mut p Parser) map_init() ast.MapInit {
 	}
 }
 
-fn (mut p Parser) scope_register_it_as_index() {
-	p.scope.objects['it'] = ast.Var{ // override it variable if it already exist, else create it variable
-		name: 'it'
+fn (mut p Parser) scope_register_index() {
+	p.scope.objects['index'] = ast.Var{ // override index variable if it already exist, else create index variable
+		name: 'index'
 		pos: p.tok.pos()
 		typ: ast.int_type
 		is_mut: false

--- a/vlib/v/slow_tests/inout/printing_const_array.vv
+++ b/vlib/v/slow_tests/inout/printing_const_array.vv
@@ -1,6 +1,6 @@
 const (
 	dat = 'Data tag ,No data'.split(',')
-	dd  = []Info{len: 4, init: Info{if it in tag { dat[0] + it.str() } else { dat[1] }}}
+	dd  = []Info{len: 4, init: Info{if index in tag { dat[0] + index.str() } else { dat[1] }}}
 	tag = [1, 2]
 )
 

--- a/vlib/v/tests/array_with_it_test.v
+++ b/vlib/v/tests/array_with_it_test.v
@@ -1,24 +1,24 @@
 fn test_array_with_it() {
-	assert [0, 1, 2, 3, 4, 5]! == [6]int{init: it}
-	a1 := [6]int{init: it}
+	assert [0, 1, 2, 3, 4, 5]! == [6]int{init: index}
+	a1 := [6]int{init: index}
 	assert a1 == [0, 1, 2, 3, 4, 5]!
 
-	assert [0, 1, 4, 9, 16, 25] == []int{len: 6, init: it * it}
-	a2 := []int{len: 6, init: it * it}
+	assert [0, 1, 4, 9, 16, 25] == []int{len: 6, init: index * index}
+	a2 := []int{len: 6, init: index * index}
 	assert a2 == [0, 1, 4, 9, 16, 25]
 
-	assert [1, 2, 3, 4, 5] == []int{len: 5, init: it + 1}
-	a3 := []int{len: 5, init: it + 1}
+	assert [1, 2, 3, 4, 5] == []int{len: 5, init: index + 1}
+	a3 := []int{len: 5, init: index + 1}
 	assert a3 == [1, 2, 3, 4, 5]
 
-	assert [5, 4, 3, 2, 1] == []int{len: 5, init: 5 - it}
-	a4 := []int{len: 5, init: 5 - it}
+	assert [5, 4, 3, 2, 1] == []int{len: 5, init: 5 - index}
+	a4 := []int{len: 5, init: 5 - index}
 	assert a4 == [5, 4, 3, 2, 1]
 }
 
 fn test_array_init_with_option() {
 	input := [3.1, 1.1]
-	arr := []f64{len: 3, init: input[it] or { 0.0 }}
+	arr := []f64{len: 3, init: input[index] or { 0.0 }}
 	println(arr)
 	assert arr[0] == 3.1
 	assert arr[1] == 1.1

--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -3,8 +3,8 @@ import os
 
 const (
 	max_params       = 16
-	all_param_names  = []string{len: max_params, init: '${`a` + it}'}
-	all_param_values = []string{len: max_params, init: '${it + 1}'}
+	all_param_names  = []string{len: max_params, init: '${`a` + index}'}
+	all_param_values = []string{len: max_params, init: '${index + 1}'}
 )
 
 struct ReturnType {

--- a/vlib/v/tests/for_in_ref_arr_test.v
+++ b/vlib/v/tests/for_in_ref_arr_test.v
@@ -1,7 +1,7 @@
 fn test_for_in_ref_val_ref_arr() {
 	arr := [1, 2, 3, 4, 5]
 	mut rets := []&int{}
-	mut expects := unsafe { []&int{len: 5, init: &arr[it]} }
+	mut expects := unsafe { []&int{len: 5, init: &arr[index]} }
 
 	for val in &arr {
 		println(val)
@@ -18,7 +18,7 @@ fn test_for_in_ref_val_ref_arr_ident() {
 	arr_ := [1, 2, 3, 4, 5]
 	arr := &arr_
 	mut rets := []&int{}
-	mut expects := unsafe { []&int{len: 5, init: &arr_[it]} }
+	mut expects := unsafe { []&int{len: 5, init: &arr_[index]} }
 
 	for val in arr {
 		rets << val

--- a/vlib/v/tests/generic_fn_infer_fn_type_argument_test.v
+++ b/vlib/v/tests/generic_fn_infer_fn_type_argument_test.v
@@ -27,5 +27,5 @@ fn test_generic_fn_infer_fn_type_argument() {
 
 // [noah04 #14214] code
 fn fmap[I, O](func fn (I) O, list []I) []O {
-	return []O{len: list.len, init: func(list[it])}
+	return []O{len: list.len, init: func(list[index])}
 }


### PR DESCRIPTION
- Fix #17541, avoid confusion by renaming `it` variable in array initialization syntax into `index`.