### PR TITLE
cgen: fix fn option-only return print

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -87,6 +87,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		g.write(' ? _SLIT("true") : _SLIT("false")')
 	} else if sym.kind == .none_ {
 		g.write('_SLIT("<none>")')
+	} else if typ.clear_flag(.option) == ast.void_type {
+		g.write('_SLIT("<void>")')
 	} else if sym.kind == .enum_ {
 		if expr !is ast.EnumVal {
 			str_fn_name := g.get_str_fn(typ)

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -85,7 +85,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	} else if typ == ast.bool_type {
 		g.expr(expr)
 		g.write(' ? _SLIT("true") : _SLIT("false")')
-	} else if sym.kind == .none_ || typ.clear_flag(.option) == ast.void_type {
+	} else if sym.kind == .none_ || typ == ast.void_type.set_flag(.option) {
 		g.write('_SLIT("<none>")')
 	} else if sym.kind == .enum_ {
 		if expr !is ast.EnumVal {

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -85,10 +85,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 	} else if typ == ast.bool_type {
 		g.expr(expr)
 		g.write(' ? _SLIT("true") : _SLIT("false")')
-	} else if sym.kind == .none_ {
+	} else if sym.kind == .none_ || typ.clear_flag(.option) == ast.void_type {
 		g.write('_SLIT("<none>")')
-	} else if typ.clear_flag(.option) == ast.void_type {
-		g.write('_SLIT("<void>")')
 	} else if sym.kind == .enum_ {
 		if expr !is ast.EnumVal {
 			str_fn_name := g.get_str_fn(typ)

--- a/vlib/v/tests/option_void_fn_return_test.v
+++ b/vlib/v/tests/option_void_fn_return_test.v
@@ -1,0 +1,8 @@
+fn foo() ? {
+	return none
+}
+
+fn test_main() {
+	println(foo()) // <void>
+	assert true
+}

--- a/vlib/v/tests/option_void_fn_return_test.v
+++ b/vlib/v/tests/option_void_fn_return_test.v
@@ -3,6 +3,6 @@ fn foo() ? {
 }
 
 fn test_main() {
-	println(foo()) // <void>
+	println(foo()) // <none>
 	assert true
 }


### PR DESCRIPTION
Fix #17472

```V
fn foo() ? {
	return none
}

fn test_main() {
	println(foo()) // <none>
	assert true
}
```