### PR TITLE
cgen: fix option unwrap on assignment

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1119,8 +1119,9 @@ fn (mut c Checker) check_or_last_stmt(stmt ast.Stmt, ret_type ast.Type, expr_ret
 				c.expected_or_type = ret_type.clear_flag(.option).clear_flag(.result)
 				last_stmt_typ := c.expr(stmt.expr)
 
-				if ret_type.has_flag(.option) && last_stmt_typ.has_flag(.option) {
-					if stmt.expr in [ast.Ident, ast.SelectorExpr, ast.CallExpr] {
+				if ret_type.has_flag(.option)
+					&& (last_stmt_typ.has_flag(.option) || last_stmt_typ == ast.none_type) {
+					if stmt.expr in [ast.Ident, ast.SelectorExpr, ast.CallExpr, ast.None] {
 						expected_type_name := c.table.type_to_str(ret_type.clear_flag(.option).clear_flag(.result))
 						got_type_name := c.table.type_to_str(last_stmt_typ)
 						c.error('`or` block must provide a value of type `${expected_type_name}`, not `${got_type_name}`',

--- a/vlib/v/checker/tests/wrong_option_unwrap_err.out
+++ b/vlib/v/checker/tests/wrong_option_unwrap_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/wrong_option_unwrap_err.vv:3:14: error: `or` block must provide a value of type `string`, not `none`
+    1 | fn main() {
+    2 |     a := ?string('c')
+    3 |     b := a or { none }
+      |                 ~~~~
+    4 |     println(b)
+    5 | }

--- a/vlib/v/checker/tests/wrong_option_unwrap_err.vv
+++ b/vlib/v/checker/tests/wrong_option_unwrap_err.vv
@@ -1,0 +1,5 @@
+fn main() {
+	a := ?string('c')
+	b := a or { none }
+	println(b)
+}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -10,8 +10,8 @@ import v.token
 fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr ast.Expr, ret_typ ast.Type) {
 	gen_or := expr is ast.Ident && (expr as ast.Ident).or_expr.kind != .absent
 	if gen_or {
-		old_inside_opt_data := g.inside_opt_data
-		g.inside_opt_data = true
+		old_inside_opt_or_res := g.inside_opt_or_res
+		g.inside_opt_or_res = true
 		g.expr_with_cast(expr, expr_typ, ret_typ)
 		g.writeln(';')
 		g.writeln('if (${expr}.state != 0) {')
@@ -40,7 +40,7 @@ fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr
 			}
 		}
 		g.writeln('}')
-		g.inside_opt_data = old_inside_opt_data
+		g.inside_opt_or_res = old_inside_opt_or_res
 	} else {
 		g.expr_with_opt(expr, expr_typ, ret_typ)
 	}

--- a/vlib/v/tests/option_unwrap_assign_test.v
+++ b/vlib/v/tests/option_unwrap_assign_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+mut:
+	x string
+	y ?string
+}
+
+fn test_main() {
+	a := ?string(none)
+	mut foo := Foo{}
+	foo.x = a or { 'test' }
+	foo.y = a or { 'test' }
+
+	assert foo.x == 'test'
+	assert foo.y? == 'test'
+}


### PR DESCRIPTION
Fix #17549
Fix #17548

It also fixes missing check for:

```V
fn main() {
	a := ?string('c')
	b := a or { none }
	println(b)
}
```