### PR TITLE
cgen: fix option value with or_block (fix #17549)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4117,14 +4117,17 @@ fn (mut g Gen) ident(node ast.Ident) {
 		// `x = new_opt()` => `x = new_opt()` (g.right_is_opt == true)
 		// `println(x)` => `println(*(int*)x.data)`
 		if node.info.is_option && !(g.is_assign_lhs && g.right_is_opt) {
-			if (g.inside_opt_or_res && node.or_expr.kind == .absent) || g.left_is_opt {
+			if (g.inside_opt_or_res && node.or_expr.kind == .absent)
+				|| (g.left_is_opt && !(g.inside_assign && g.assign_op != .decl_assign
+				&& !g.is_assign_lhs)) {
 				g.write('${name}')
 			} else {
 				g.write('/*opt*/')
 				styp := g.base_type(node.info.typ)
 				g.write('(*(${styp}*)${name}.data)')
 			}
-			if node.or_expr.kind != .absent && !(g.inside_assign && !g.is_assign_lhs) {
+			if node.or_expr.kind != .absent && !(g.inside_assign && g.assign_op == .decl_assign
+				&& !g.is_assign_lhs) {
 				stmt_str := g.go_before_stmt(0).trim_space()
 				g.empty_line = true
 				g.or_block(name, node.or_expr, node.info.typ)

--- a/vlib/v/tests/option_value_with_or_block_test.v
+++ b/vlib/v/tests/option_value_with_or_block_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+mut:
+	x string
+	y ?string
+}
+
+fn test_option_value_with_or_block() {
+	a := ?string(none)
+	mut foo := Foo{}
+	foo.x = a or { 'test' }
+	foo.y = a or { 'test' }
+	println(foo)
+	assert foo.x == 'test'
+	assert foo.y? == 'test'
+}


### PR DESCRIPTION
This PR fix option value with or_block (fix #17549).

- Fix option value with or_block.
- Add test.

```v
struct Foo {
mut:
	x string
	y ?string
}

fn main() {
	a := ?string(none)
	mut foo := Foo{}
	foo.x = a or { 'test' }
	foo.y = a or { 'test' }
	println(foo)
	assert foo.x == 'test'
	assert foo.y? == 'test'
}

PS D:\Test\v\tt1> v run .
Foo{
    x: 'test'
    y: 'test'
}
```