### PR TITLE
cgen: fix generic array of alias .str() (fix #17569)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -992,7 +992,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		&& !typ_sym.has_method(node.name) {
 		unwrapped_rec_type = (typ_sym.info as ast.Alias).parent_type
 		typ_sym = g.table.sym(unwrapped_rec_type)
-	} else if typ_sym.kind == .array && !typ_sym.has_method(node.name) {
+	} else if typ_sym.kind == .array && !typ_sym.has_method(node.name) && node.name != 'str' {
 		typ := g.table.unaliased_type((typ_sym.info as ast.Array).elem_type)
 		typ_idx := g.table.find_type_idx(g.table.array_name(typ))
 		if typ_idx > 0 {

--- a/vlib/v/tests/generic_array_of_alias_test.v
+++ b/vlib/v/tests/generic_array_of_alias_test.v
@@ -1,0 +1,13 @@
+import datatypes
+
+type Distance = int
+
+struct Foo {
+	field datatypes.LinkedList[Distance]
+}
+
+fn test_generic_array_of_alias() {
+	foo := Foo{}
+	println(foo)
+	assert '${foo.field}' == '[]'
+}


### PR DESCRIPTION
This PR fix generic array of alias .str() (fix #17569).

- Fix generic array of alias .str().
- Add test.

```v
import datatypes

type Distance = int

struct Foo {
	field datatypes.LinkedList[Distance]
}

fn main() {
	foo := Foo{}
	println(foo)
	assert '${foo.field}' == '[]'
}

PS D:\Test\v\tt1> v run .
Foo{
    field: []
}
```