### PR TITLE
datatypes: fix linked list of map (fix #17570)

### DIFF
--- a/vlib/datatypes/linked_list.v
+++ b/vlib/datatypes/linked_list.v
@@ -207,7 +207,7 @@ pub fn (mut iter ListIter[T]) next() ?T {
 	if iter.node == unsafe { nil } {
 		return none
 	}
-	res := iter.node.data
+	res := unsafe { iter.node.data }
 	iter.node = iter.node.next
 	return res
 }

--- a/vlib/datatypes/linked_list_test.v
+++ b/vlib/datatypes/linked_list_test.v
@@ -168,3 +168,18 @@ fn test_linked_list_separate_iterators() {
 	}
 	assert res == [1, 2, 3]
 }
+
+struct Foo {
+mut:
+	field LinkedList[map[string]int]
+}
+
+fn test_linked_list_map() {
+	mut foo := Foo{}
+	foo.field.push({'one': 1})
+	foo.field.push({'two': 2})
+	println(foo)
+	mut iter := foo.field.iterator()
+	assert iter.next()! == {'one': 1}
+	assert iter.next()! == {'two': 2}
+}


### PR DESCRIPTION
This PR fix linked list of map (fix #17570).

- Fix linked list of map.
- Add test.

```v
import datatypes

struct Foo {
mut:
	field datatypes.LinkedList[map[string]int]
}

fn main() {
	mut foo := Foo{}
	foo.field.push({'one': 1})
	foo.field.push({'two': 2})
	println(foo)
	mut iter := foo.field.iterator()
	assert iter.next()! == {'one': 1}
	assert iter.next()! == {'two': 2}
}

PS D:\Test\v\tt1> v run .
Foo{
    field: [{'one': 1}, {'two': 2}]
}
```