### PR TITLE
ast, parser, fmt: fix fmt error of infix expr with comments (fix #17560)

### DIFF
--- a/vlib/crypto/internal/subtle/aliasing.v
+++ b/vlib/crypto/internal/subtle/aliasing.v
@@ -12,7 +12,7 @@ pub fn any_overlap(x []u8, y []u8) bool {
 	// NOTE: Remember to come back to this (joe-c)
 	return x.len > 0 && y.len > 0 && // &x.data[0] <= &y.data[y.len-1] &&
 	// &y.data[0] <= &x.data[x.len-1]
-	unsafe { &x[0] <= &y[y.len - 1] && &y[0] <= &x[x.len - 1] }
+	 unsafe { &x[0] <= &y[y.len - 1] && &y[0] <= &x[x.len - 1] }
 }
 
 // inexact_overlap reports whether x and y share memory at any non-corresponding

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -879,6 +879,9 @@ pub mut:
 	ct_left_value         ComptTimeConstValue = empty_comptime_const_expr()
 	ct_right_value_evaled bool
 	ct_right_value        ComptTimeConstValue = empty_comptime_const_expr()
+	//
+	before_op_comments []Comment
+	after_op_comments  []Comment
 }
 
 // ++, --

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2137,6 +2137,9 @@ pub fn (mut f Fmt) infix_expr(node ast.InfixExpr) {
 	start_pos := f.out.len
 	start_len := f.line_len
 	f.expr(node.left)
+	if node.before_op_comments.len > 0 {
+		f.comments(node.before_op_comments, iembed: node.before_op_comments[0].is_inline)
+	}
 	is_one_val_array_init := node.op in [.key_in, .not_in] && node.right is ast.ArrayInit
 		&& (node.right as ast.ArrayInit).exprs.len == 1
 	is_and := node.op == .amp && f.node_str(node.right).starts_with('&')
@@ -2148,6 +2151,10 @@ pub fn (mut f Fmt) infix_expr(node ast.InfixExpr) {
 		f.write(' && ')
 	} else {
 		f.write(' ${node.op.str()} ')
+	}
+	if node.after_op_comments.len > 0 {
+		f.comments(node.after_op_comments, iembed: node.after_op_comments[0].is_inline)
+		f.write(' ')
 	}
 	if is_one_val_array_init && !f.inside_comptime_if {
 		// `var in [val]` => `var == val`

--- a/vlib/v/fmt/tests/infix_expr_with_comments_keep.vv
+++ b/vlib/v/fmt/tests/infix_expr_with_comments_keep.vv
@@ -1,0 +1,9 @@
+fn main() {
+	a := 4 // comment1
+	 + /* comment2 */ 6
+
+	b := 5 /* comment1 */ + // comment2
+	 6
+
+	c := 4 /* comment1 */ + /* comment2 */ 6 // comment3
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -454,7 +454,7 @@ pub fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 	if p.inside_if_cond {
 		p.if_cond_comments << p.eat_comments()
 	}
-	if p.tok.kind == .comment && p.peek_tok.kind.is_infix() && !p.inside_infix
+	if p.pref.is_fmt && p.tok.kind == .comment && p.peek_tok.kind.is_infix() && !p.inside_infix
 		&& !(p.peek_tok.kind == .mul && p.peek_tok.pos().line_nr != p.tok.pos().line_nr) {
 		p.left_comments = p.eat_comments()
 	}
@@ -611,7 +611,11 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 	if p.inside_if_cond {
 		p.if_cond_comments << p.eat_comments()
 	}
-	before_op_comments := p.left_comments.clone()
+	mut before_op_comments := []ast.Comment{}
+	if p.pref.is_fmt && p.left_comments.len > 0 {
+		before_op_comments = p.left_comments.clone()
+		p.left_comments = []
+	}
 	p.left_comments = []
 	after_op_comments := p.eat_comments()
 	mut right := ast.empty_expr

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -454,7 +454,8 @@ pub fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 	if p.inside_if_cond {
 		p.if_cond_comments << p.eat_comments()
 	}
-	if p.tok.kind == .comment && p.peek_tok.kind.is_infix() && p.inside_infix {
+	if p.tok.kind == .comment && p.peek_tok.kind.is_infix() && !p.inside_infix
+		&& !(p.peek_tok.kind == .mul && p.peek_tok.pos().line_nr != p.tok.pos().line_nr) {
 		p.left_comments = p.eat_comments()
 	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -454,6 +454,9 @@ pub fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 	if p.inside_if_cond {
 		p.if_cond_comments << p.eat_comments()
 	}
+	if p.tok.kind == .comment && p.peek_tok.kind.is_infix() {
+		p.left_comments = p.eat_comments()
+	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)
 }
 
@@ -606,6 +609,8 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 	if p.inside_if_cond {
 		p.if_cond_comments << p.eat_comments()
 	}
+	before_op_comments := p.left_comments
+	after_op_comments := p.eat_comments()
 	mut right := ast.empty_expr
 	prev_expecting_type := p.expecting_type
 	if op in [.key_is, .not_is] {
@@ -648,6 +653,8 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		op: op
 		pos: pos
 		is_stmt: p.is_stmt_ident
+		before_op_comments: before_op_comments
+		after_op_comments: after_op_comments
 		or_block: ast.OrExpr{
 			stmts: or_stmts
 			kind: or_kind

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -599,7 +599,11 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 }
 
 fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
+	prev_inside_infix := p.inside_infix
 	p.inside_infix = true
+	defer {
+		p.inside_infix = prev_inside_infix
+	}
 	op := p.tok.kind
 	if op == .arrow {
 		p.or_is_handled = true
@@ -654,7 +658,6 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		p.or_is_handled = false
 	}
 	pos.update_last_line(p.prev_tok.line_nr)
-	p.inside_infix = false
 	return ast.InfixExpr{
 		left: left
 		right: right

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -48,6 +48,7 @@ mut:
 	inside_str_interp         bool
 	inside_array_lit          bool
 	inside_in_array           bool
+	inside_infix              bool
 	inside_match              bool // to separate `match A { }` from `Struct{}`
 	inside_select             bool // to allow `ch <- Struct{} {` inside `select`
 	inside_match_case         bool // to separate `match_expr { }` from `Struct{}`

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -93,6 +93,7 @@ mut:
 	anon_struct_decl          ast.StructDecl
 	struct_init_generic_types []ast.Type
 	if_cond_comments          []ast.Comment
+	left_comments             []ast.Comment
 	script_mode               bool
 	script_mode_start_token   token.Token
 pub mut:


### PR DESCRIPTION
This PR fix fmt error of infix expr with comments (fix #17560).

- Fix fmt error of infix expr with comments.
- Add test.

infix_expr_with_comments_keep.vv
```v
fn main() {
	a := 4 // comment1
	 + /* comment2 */ 6

	b := 5 /* comment1 */ + // comment2
	 6

	c := 4 /* comment1 */ + /* comment2 */ 6 // comment3
}
```