### PR TITLE
checker: check struct embed required field (fix #17587)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -656,6 +656,13 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					c.struct_init(mut zero_struct_init, true)
 				}
 			}
+			for embed in info.embeds {
+				mut zero_struct_init := ast.StructInit{
+					pos: node.pos
+					typ: embed
+				}
+				c.struct_init(mut zero_struct_init, true)
+			}
 			// println('>> checked_types.len: $checked_types.len | checked_types: $checked_types | type_sym: $type_sym.name ')
 		}
 		else {}

--- a/vlib/v/checker/tests/struct_embed_required_field_err.out
+++ b/vlib/v/checker/tests/struct_embed_required_field_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_embed_required_field_err.vv:11:7: error: field `Foo.foo` must be initialized
+    9 |
+   10 | fn main() {
+   11 |     b := Bar {
+      |          ~~~~~
+   12 |         foo: 1
+   13 |     }

--- a/vlib/v/checker/tests/struct_embed_required_field_err.vv
+++ b/vlib/v/checker/tests/struct_embed_required_field_err.vv
@@ -1,0 +1,15 @@
+struct Foo {
+	foo u8 [required]
+}
+
+struct Bar {
+	Foo
+	foo u8 [required]
+}
+
+fn main() {
+	b := Bar {
+		foo: 1
+	}
+	println(b)
+}

--- a/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/struct_ref_fields_uninitialized_err.out
@@ -25,3 +25,9 @@ vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:26:7: warning: refer
    26 |     _ := Struct{}
       |          ~~~~~~~~
    27 | }
+vlib/v/checker/tests/struct_ref_fields_uninitialized_err.vv:26:7: warning: reference field `EmbedStruct.ref2` must be initialized
+   24 | fn main() {
+   25 |     _ := Outer{}
+   26 |     _ := Struct{}
+      |          ~~~~~~~~
+   27 | }


### PR DESCRIPTION
This PR check struct embed required field (fix #17587).

- Check struct embed required field.
- Add test.

```v
struct Foo {
	foo u8 [required]
}

struct Bar {
	Foo
	foo u8 [required]
}

fn main() {
	b := Bar {
		foo: 1
	}
	println(b)
}

PS D:\Test\v\tt1> v run .
tt1.v:11:7: error: field `Foo.foo` must be initialized
    9 |
   10 | fn main() {
   11 |     b := Bar {
      |          ~~~~~
   12 |         foo: 1
   13 |     }
```