### PR TITLE
readme: add section about editor plugins and IntelliSense

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ V has plugins for many editors:
 
 V has a Language Server:
 [VLS](https://github.com/vlang/vls).
-VS Code plugin provides built-in support for VLS.
+The VS Code plugin provides built-in support for VLS.
 
 > **Note**
 > 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ VS Code plugin provides built-in support for VLS.
 > If you encounter any problem, please create a new
 > [issue](https://github.com/vlang/vls/issues).
 
-Plugin for JetBrains IDE (IntelliJ, CLion, GoLand, etc) at the moment
+The plugin for JetBrains IDE (IntelliJ, CLion, GoLand, etc) at the moment is
 the best choice if you want a great V development experience.
 You can see all its features in
 [documentation](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html).

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ VS Code plugin provides built-in support for VLS.
 The plugin for JetBrains IDE (IntelliJ, CLion, GoLand, etc) at the moment is
 the best choice if you want a great V development experience.
 You can see all its features in
-[documentation](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html).
+[its documentation](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html).
 
 ## Testing and running the examples
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,34 @@ cd v
 make
 ```
 
+## Installing editor/IDE plugin
+
+V has plugins for many editors:
+
+- [VS Code plugin](https://github.com/vlang/vscode-vlang)
+- [JetBrains IDE plugin](https://plugins.jetbrains.com/plugin/20287-vlang/docs/quick-start-guide.html)
+- [Vim plugins](https://github.com/vlang/awesome-v#vim)
+- [Emacs plugins](https://github.com/vlang/awesome-v#emacs)
+- [Sublime Text 3 plugins](https://github.com/vlang/awesome-v#sublime-text-3)
+- [Atom plugins](https://github.com/vlang/awesome-v#atom)
+
+### IntelliSense
+
+V has a Language Server:
+[VLS](https://github.com/vlang/vls).
+VS Code plugin provides built-in support for VLS.
+
+> **Note**
+> 
+> VLS may be unstable at the moment.
+> If you encounter any problem, please create a new
+> [issue](https://github.com/vlang/vls/issues).
+
+Plugin for JetBrains IDE (IntelliJ, CLion, GoLand, etc) at the moment
+the best choice if you want a great V development experience.
+You can see all its features in
+[documentation](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html).
+
 ## Testing and running the examples
 
 Make sure V can compile itself:


### PR DESCRIPTION
I'm seeing more and more IntelliSense questions on Discord, so I think it's worth adding the info to the main README.