### PR TITLE
sync: fix error of empty struct channel (fix #17556)

### DIFF
--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -59,7 +59,7 @@ pub:
 }
 
 pub fn new_channel[T](n u32) &Channel {
-	st := sizeof(T)
+	st := if sizeof(T) > 0 { sizeof(T) } else { 1 }
 	if isreftype(T) {
 		return new_channel_st(n, st)
 	} else {

--- a/vlib/sync/empty_struct_chan_init_test.v
+++ b/vlib/sync/empty_struct_chan_init_test.v
@@ -1,0 +1,8 @@
+struct User {
+}
+
+fn test_empty_struct_chan_init() {
+	user_ch := chan User{cap: 10}
+	println(user_ch)
+	assert true
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3095,7 +3095,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			}
 			g.write(', sizeof(')
 			g.write(elem_typ_str)
-			g.write('))')
+			g.write(')>0 ? sizeof(')
+			g.write(elem_typ_str)
+			g.write(') : 1)')
 		}
 		ast.CharLiteral {
 			g.char_literal(node)


### PR DESCRIPTION
This PR fix error of empty struct channel (fix #17556).

- Fix error of empty struct channel.
- Add test.

```v
struct User {
}

fn main() {
	user_ch := chan User{cap: 10}
	println(user_ch)
	assert true
}

PS D:\Test\v\tt1> v run .
chan User{cap: 10, closed: 0}
```