### PR TITLE
builtin: string test refactor, string functions inlining

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -308,6 +308,7 @@ pub fn (s string) len_utf8() int {
 
 // clone_static returns an independent copy of a given array.
 // It should be used only in -autofree generated code.
+[inline]
 fn (a string) clone_static() string {
 	return a.clone()
 }
@@ -565,56 +566,67 @@ pub fn (s string) normalize_tabs(tab_len int) string {
 }
 
 // bool returns `true` if the string equals the word "true" it will return `false` otherwise.
+[inline]
 pub fn (s string) bool() bool {
 	return s == 'true' || s == 't' // TODO t for pg, remove
 }
 
 // int returns the value of the string as an integer `'1'.int() == 1`.
+[inline]
 pub fn (s string) int() int {
 	return int(strconv.common_parse_int(s, 0, 32, false, false) or { 0 })
 }
 
 // i64 returns the value of the string as i64 `'1'.i64() == i64(1)`.
+[inline]
 pub fn (s string) i64() i64 {
 	return strconv.common_parse_int(s, 0, 64, false, false) or { 0 }
 }
 
 // i8 returns the value of the string as i8 `'1'.i8() == i8(1)`.
+[inline]
 pub fn (s string) i8() i8 {
 	return i8(strconv.common_parse_int(s, 0, 8, false, false) or { 0 })
 }
 
 // i16 returns the value of the string as i16 `'1'.i16() == i16(1)`.
+[inline]
 pub fn (s string) i16() i16 {
 	return i16(strconv.common_parse_int(s, 0, 16, false, false) or { 0 })
 }
 
 // f32 returns the value of the string as f32 `'1.0'.f32() == f32(1)`.
+[inline]
 pub fn (s string) f32() f32 {
 	return f32(strconv.atof64(s) or { 0 })
 }
 
 // f64 returns the value of the string as f64 `'1.0'.f64() == f64(1)`.
+[inline]
 pub fn (s string) f64() f64 {
 	return strconv.atof64(s) or { 0 }
 }
 
 // u8 returns the value of the string as u8 `'1'.u8() == u8(1)`.
+[inline]
 pub fn (s string) u8() u8 {
 	return u8(strconv.common_parse_uint(s, 0, 8, false, false) or { 0 })
 }
 
 // u16 returns the value of the string as u16 `'1'.u16() == u16(1)`.
+[inline]
 pub fn (s string) u16() u16 {
 	return u16(strconv.common_parse_uint(s, 0, 16, false, false) or { 0 })
 }
 
 // u32 returns the value of the string as u32 `'1'.u32() == u32(1)`.
+[inline]
 pub fn (s string) u32() u32 {
 	return u32(strconv.common_parse_uint(s, 0, 32, false, false) or { 0 })
 }
 
 // u64 returns the value of the string as u64 `'1'.u64() == u64(1)`.
+[inline]
 pub fn (s string) u64() u64 {
 	return strconv.common_parse_uint(s, 0, 64, false, false) or { 0 }
 }
@@ -624,6 +636,7 @@ pub fn (s string) u64() u64 {
 // This method directly exposes the `parse_int` function from `strconv`
 // as a method on `string`. For more advanced features,
 // consider calling `strconv.common_parse_int` directly.
+[inline]
 pub fn (s string) parse_uint(_base int, _bit_size int) !u64 {
 	return strconv.parse_uint(s, _base, _bit_size)
 }
@@ -644,6 +657,7 @@ pub fn (s string) parse_uint(_base int, _bit_size int) !u64 {
 // This method directly exposes the `parse_uint` function from `strconv`
 // as a method on `string`. For more advanced features,
 // consider calling `strconv.common_parse_uint` directly.
+[inline]
 pub fn (s string) parse_int(_base int, _bit_size int) !i64 {
 	return strconv.parse_int(s, _base, _bit_size)
 }
@@ -791,6 +805,7 @@ pub fn (s string) rsplit_any(delim string) []string {
 // Example: assert 'A B C'.split(' ') == ['A','B','C']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.split('') == ['D','E','F']
+[inline]
 pub fn (s string) split(delim string) []string {
 	return s.split_nth(delim, 0)
 }
@@ -799,6 +814,7 @@ pub fn (s string) split(delim string) []string {
 // Example: assert 'A B C'.rsplit(' ') == ['C','B','A']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.rsplit('') == ['F','E','D']
+[inline]
 pub fn (s string) rsplit(delim string) []string {
 	return s.rsplit_nth(delim, 0)
 }
@@ -1018,6 +1034,7 @@ pub fn (s string) split_into_lines() []string {
 }
 
 // used internally for [2..4]
+[inline]
 fn (s string) substr2(start int, _end int, end_max bool) string {
 	end := if end_max { s.len } else { _end }
 	return s.substr(start, end)
@@ -1561,6 +1578,7 @@ pub fn (s string) find_between(start string, end string) string {
 
 // trim_space strips any of ` `, `\n`, `\t`, `\v`, `\f`, `\r` from the start and end of the string.
 // Example: assert ' Hello V '.trim_space() == 'Hello V'
+[inline]
 pub fn (s string) trim_space() string {
 	return s.trim(' \n\t\v\f\r')
 }
@@ -1719,16 +1737,19 @@ fn compare_lower_strings(a &string, b &string) int {
 }
 
 // sort_ignore_case sorts the string array using case insesitive comparing.
+[inline]
 pub fn (mut s []string) sort_ignore_case() {
 	s.sort_with_compare(compare_lower_strings)
 }
 
 // sort_by_len sorts the the string array by each string's `.len` length.
+[inline]
 pub fn (mut s []string) sort_by_len() {
 	s.sort_with_compare(compare_strings_by_len)
 }
 
 // str returns a copy of the string
+[inline]
 pub fn (s string) str() string {
 	return s.clone()
 }
@@ -1914,6 +1935,7 @@ pub fn (s string) all_after_first(sub string) string {
 // Example: assert '23:34:45.234'.after(':') == '45.234'
 // Example: assert 'abcd'.after('z') == 'abcd'
 // TODO: deprecate either .all_after_last or .after
+[inline]
 pub fn (s string) after(sub string) string {
 	return s.all_after_last(sub)
 }
@@ -1973,6 +1995,7 @@ pub fn (a []string) join(sep string) string {
 }
 
 // join joins a string array into a string using a `\n` newline delimiter.
+[inline]
 pub fn (s []string) join_lines() string {
 	return s.join('\n')
 }
@@ -2107,6 +2130,7 @@ pub fn (s string) fields() []string {
 //   this is a string,
 //   Everything before the first | is removed'
 // ```
+[inline]
 pub fn (s string) strip_margin() string {
 	return s.strip_margin_custom(`|`)
 }
@@ -2360,6 +2384,7 @@ pub fn (name string) match_glob(pattern string) bool {
 }
 
 // is_ascii returns true  if all characters belong to the US-ASCII set ([` `..`~`])
+[inline]
 pub fn (s string) is_ascii() bool {
 	return !s.bytes().any(it < u8(` `) || it > u8(`~`))
 }

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -172,7 +172,6 @@ fn test_split_nth() {
 	assert b.split_nth('::', 2).len == 2
 	assert b.split_nth('::', 10).len == 3
 	c := 'ABCDEF'
-	println(c.split('').len)
 	assert c.split('').len == 6
 	assert c.split_nth('', 3).len == 3
 	assert c.split_nth('BC', -1).len == 2
@@ -760,7 +759,6 @@ fn test_bytes_to_string() {
 
 fn test_charptr() {
 	foo := &char('VLANG'.str)
-	println(typeof(foo).name)
 	assert typeof(foo).name == '&char'
 	assert unsafe { foo.vstring() } == 'VLANG'
 	assert unsafe { foo.vstring_with_len(3) } == 'VLA'
@@ -872,7 +870,6 @@ fn test_for_loop_two() {
 
 fn test_quote() {
 	a := `'`
-	println('testing double quotes')
 	b := 'hi'
 	assert b == 'hi'
 	assert a.str() == "'"
@@ -946,9 +943,7 @@ fn test_trim_string_right() {
 fn test_raw() {
 	raw := r'raw\nstring'
 	lines := raw.split('\n')
-	println(lines)
 	assert lines.len == 1
-	println('raw string: "${raw}"')
 
 	raw2 := r'Hello V\0'
 	assert raw2[7] == `\\`
@@ -970,7 +965,6 @@ fn test_raw_with_quotes() {
 
 fn test_escape() {
 	a := 10
-	println("\"${a}")
 	assert "\"${a}" == '"10'
 }
 
@@ -986,7 +980,6 @@ fn test_atoi() {
 
 fn test_raw_inter() {
 	world := 'world'
-	println(world)
 	s := r'hello\n$world'
 	assert s == r'hello\n$world'
 	assert s.contains('$')
@@ -995,16 +988,15 @@ fn test_raw_inter() {
 fn test_c_r() {
 	// This used to break because of r'' and c''
 	c := 42
-	println('${c}')
+	cs := '${c}'
 	r := 50
-	println('${r}')
+	rs := '${r}'
 }
 
 fn test_inter_before_comptime_if() {
 	s := '123'
 	// This used to break ('123 $....')
 	$if linux {
-		println(s)
 	}
 	assert s == '123'
 }
@@ -1012,7 +1004,6 @@ fn test_inter_before_comptime_if() {
 fn test_double_quote_inter() {
 	a := 1
 	b := 2
-	println('${a} ${b}')
 	assert '${a} ${b}' == '1 2'
 	assert '${a} ${b}' == '1 2'
 }


### PR DESCRIPTION
- This PR refactors `string_test.v` by removing `println` invocations in test functions.
- And adds `[inline]` attribute to appropriate functions that has small function body.