### PR TITLE
checker: fix missing option function field checking

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1890,6 +1890,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	// call struct field fn type
 	// TODO: can we use SelectorExpr for all? this dosent really belong here
 	if field := c.table.find_field_with_embeds(left_sym, method_name) {
+		if field.typ.has_flag(.option) {
+			c.error('Option function field must be unwrapped first', node.pos)
+		}
 		field_sym := c.table.sym(c.unwrap_generic(field.typ))
 		if field_sym.kind == .function {
 			node.is_method = false

--- a/vlib/v/checker/tests/option_fn_field_err.out
+++ b/vlib/v/checker/tests/option_fn_field_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/option_fn_field_err.vv:7:6: error: Option function field must be unwrapped first
+    5 | fn main() {
+    6 |     foo := Foo{}
+    7 |     foo.f(1)
+      |         ~~~~
+    8 | }

--- a/vlib/v/checker/tests/option_fn_field_err.vv
+++ b/vlib/v/checker/tests/option_fn_field_err.vv
@@ -1,0 +1,8 @@
+struct Foo {
+	f ?fn(int)
+}
+
+fn main() {
+	foo := Foo{}
+	foo.f(1)
+}


### PR DESCRIPTION
Fix #17148
Fix #17627

```V
struct Foo {
	f ?fn(int)
}

fn main() {
	foo := Foo{}
	foo.f(1)
}
```

```
vlib/v/checker/tests/option_fn_field_err.vv:7:6: error: Option function field must be unwrapped first
    5 | fn main() {
    6 |     foo := Foo{}
    7 |     foo.f(1)
      |         ~~~~
    8 | }
```