### PR TITLE
build: handle _qnx.c.v

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -386,6 +386,9 @@ pub fn user_os() string {
 	$if solaris {
 		return 'solaris'
 	}
+	$if qnx {
+		return 'qnx'
+	}
 	$if haiku {
 		return 'haiku'
 	}

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -21,6 +21,7 @@ pub enum OS {
 	android
 	termux // like android, but compiling/running natively on the devices
 	solaris
+	qnx
 	serenity
 	vinix
 	haiku
@@ -151,6 +152,7 @@ pub fn (o OS) str() string {
 		.android { return 'Android' }
 		.termux { return 'Termux' }
 		.solaris { return 'Solaris' }
+		.qnx { return 'QNX' }
 		.serenity { return 'SerenityOS' }
 		.vinix { return 'Vinix' }
 		.haiku { return 'Haiku' }

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -204,6 +204,9 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 	if prefs.os != .solaris && file.ends_with('_solaris.c.v') {
 		return false
 	}
+	if prefs.os != .qnx && file.ends_with('_qnx.c.v') {
+		return false
+	}
 	if prefs.os != .serenity && file.ends_with('_serenity.c.v') {
 		return false
 	}


### PR DESCRIPTION
This patch should be a resolution for https://github.com/vlang/v/issues/17606

As I do not run QNX I can not check if works, but a _qnx.c.v file stops to cause a compilation error.