### PR TITLE
cgen: fix option struct init with reference option (fix #17616)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -547,10 +547,11 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 				g.write('/* autoref */&')
 			}
 
-			if sfield.expected_type.has_flag(.option)
+			if (sfield.expected_type.has_flag(.option) && !sfield.typ.has_flag(.option))
 				|| (sfield.expected_type.has_flag(.result) && !sfield.typ.has_flag(.result)) {
 				g.expr_with_opt(sfield.expr, sfield.typ, sfield.expected_type)
 			} else {
+				g.left_is_opt = true
 				g.expr_with_cast(sfield.expr, sfield.typ, sfield.expected_type)
 			}
 		}

--- a/vlib/v/tests/option_struct_init_with_ref_opt_test.v
+++ b/vlib/v/tests/option_struct_init_with_ref_opt_test.v
@@ -1,0 +1,51 @@
+struct Node {
+	value int
+mut:
+	prev ?&Node = none
+	next ?&Node = none
+}
+
+struct LinkedList {
+mut:
+	head ?&Node = none
+	tail ?&Node = none
+}
+
+pub fn (mut l LinkedList) push(value int) {
+	node := &Node{
+		value: value
+		prev: l.tail
+	}
+	if l.head == none {
+		l.head = node
+	} else {
+		mut tail := l.tail or { panic('head is not none but tail is') }
+		tail.next = node
+	}
+	l.tail = node
+}
+
+pub fn (mut l LinkedList) pop() int {
+	tail := l.tail or { panic('Empty list not supported') }
+	if tail.prev == none { // single element
+		l.head = none
+		l.tail = none
+	} else { // multiple elements
+		mut prev := tail.prev or { panic('prev cannot be none at this point') }
+		prev.next = none
+		l.tail = prev
+	}
+	return tail.value
+}
+
+fn test_option_struct_init_with_ref_opt() {
+	mut ll := LinkedList{}
+	ll.push(11)
+	ll.push(22)
+	ret1 := ll.pop()
+	println(ret1)
+	assert ret1 == 22
+	ret2 := ll.pop()
+	println(ret2)
+	assert ret2 == 11
+}


### PR DESCRIPTION
This PR fix option struct init with reference option (fix #17616).

- Fix option struct init with reference option.
- Add test.

```v
struct Node {
	value int
mut:
	prev ?&Node = none
	next ?&Node = none
}

struct LinkedList {
mut:
	head ?&Node = none
	tail ?&Node = none
}

pub fn (mut l LinkedList) push(value int) {
	node := &Node{
		value: value
		prev: l.tail
	}
	if l.head == none {
		l.head = node
	} else {
		mut tail := l.tail or { panic('head is not none but tail is') }
		tail.next = node
	}
	l.tail = node
}

pub fn (mut l LinkedList) pop() int {
	tail := l.tail or { panic('Empty list not supported') }
	if tail.prev == none { // single element
		l.head = none
		l.tail = none
	} else { // multiple elements
		mut prev := tail.prev or { panic('prev cannot be none at this point') }
		prev.next = none
		l.tail = prev
	}
	return tail.value
}

fn main() {
	mut ll := LinkedList{}
	ll.push(11)
	ll.push(22)
	ret1 := ll.pop()
	println(ret1)
	assert ret1 == 22
	ret2 := ll.pop()
	println(ret2)
	assert ret2 == 11
}

PS D:\Test\v\tt1> v run .
22
11
```