### PR TITLE
net: update new_request from http.v

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -33,7 +33,7 @@ pub mut:
 
 // new_request creates a new Request given the request `method`, `url_`, and
 // `data`.
-pub fn new_request(method Method, url_ string, data string) ?Request {
+pub fn new_request(method Method, url_ string, data string) Request {
 	url := if method == .get && !url_.contains('?') { url_ + '?' + data } else { url_ }
 	// println('new req() method=$method url="$url" dta="$data"')
 	return Request{


### PR DESCRIPTION
No need to make the function return an optional Request. It always returns a proper Request object.

