### PR TITLE
os: return the long path for os.temp_dir() on windows

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -716,6 +716,7 @@ pub fn temp_dir() string {
 				path = 'C:/tmp'
 			}
 		}
+		path = get_long_path(path) or { path }
 	}
 	$if macos {
 		// avoid /var/folders/6j/cmsk8gd90pd.... on macs

--- a/vlib/os/os_js.js.v
+++ b/vlib/os/os_js.js.v
@@ -183,3 +183,9 @@ pub fn is_readable(path string) bool {
 		return false
 	}
 }
+
+// get_long_path has no meaning for *nix, but has for windows, where `c:\folder\some~1` for example
+// can be the equivalent of `c:\folder\some spa ces`. On *nix, it just returns a copy of the input path.
+fn get_long_path(path string) !string {
+	return path
+}

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -500,3 +500,9 @@ pub fn posix_set_permission_bit(path_s string, mode u32, enable bool) {
 	}
 	C.chmod(path, int(new_mode))
 }
+
+// get_long_path has no meaning for *nix, but has for windows, where `c:\folder\some~1` for example
+// can be the equivalent of `c:\folder\some spa ces`. On *nix, it just returns a copy of the input path.
+fn get_long_path(path string) !string {
+	return path
+}

--- a/vlib/os/signal.js.v
+++ b/vlib/os/signal.js.v
@@ -115,7 +115,7 @@ fn signal_from_str(str JS.String) Signal {
 // - Browser: Will use `window.addEventListener` for handling signal
 //
 // TODO: Add signal events implementation for browser backend
-pub fn signal_opt(signum Signal, handler SignalHandler) ?SignalHandler {
+pub fn signal_opt(signum Signal, handler SignalHandler) !SignalHandler {
 	signame := signal_str(signum)
 	_ := signame
 	$if js_node {


### PR DESCRIPTION
Make os.temp_dir() always return a full path name on windows.