### PR TITLE
checker: fix missing check for wrong assignment: non-option to option type

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -208,6 +208,10 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		} else {
 			// Make sure the variable is mutable
 			c.fail_if_immutable(left)
+
+			if !left_type.has_flag(.option) && right_type.has_flag(.option) {
+				c.error('cannot assign an Option value to a non-option variable', right.pos())
+			}
 			// left_type = c.expr(left)
 			// if right is ast.None && !left_type.has_flag(.option) {
 			// 	println(left_type)

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -209,7 +209,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			// Make sure the variable is mutable
 			c.fail_if_immutable(left)
 
-			if !left_type.has_flag(.option) && right_type.has_flag(.option) {
+			if !is_blank_ident && !left_type.has_flag(.option) && right_type.has_flag(.option) {
 				c.error('cannot assign an Option value to a non-option variable', right.pos())
 			}
 			// left_type = c.expr(left)

--- a/vlib/v/checker/tests/option_var_assign_err.out
+++ b/vlib/v/checker/tests/option_var_assign_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/option_var_assign_err.vv:7:12: error: cannot assign an Option value to a non-option variable
+    5 |     
+    6 |     if value == 1  {
+    7 |         result = trying_to_change_non_opt_to_option(0)
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    8 |     }
+    9 |     return result

--- a/vlib/v/checker/tests/option_var_assign_err.out
+++ b/vlib/v/checker/tests/option_var_assign_err.out
@@ -1,6 +1,6 @@
 vlib/v/checker/tests/option_var_assign_err.vv:7:12: error: cannot assign an Option value to a non-option variable
-    5 |     
-    6 |     if value == 1  {
+    5 | 
+    6 |     if value == 1 {
     7 |         result = trying_to_change_non_opt_to_option(0)
       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     8 |     }

--- a/vlib/v/checker/tests/option_var_assign_err.vv
+++ b/vlib/v/checker/tests/option_var_assign_err.vv
@@ -1,0 +1,14 @@
+module main
+
+fn trying_to_change_non_opt_to_option(value int) ?int {
+	mut result := 122
+
+	if value == 1 {
+		result = trying_to_change_non_opt_to_option(0)
+	}
+	return result
+}
+
+fn main() {
+	println(trying_to_change_non_opt_to_option(0))
+}


### PR DESCRIPTION
Fix #17624