### PR TITLE
fmt: fix module src prefix

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -367,7 +367,8 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 
 pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 	mod := if imp.mod.len == 0 { imp.alias } else { imp.mod }
-	is_diff := imp.alias != mod && !mod.ends_with('.' + imp.alias)
+	normalized_mod := mod.all_after('src.') // Ignore the 'src.' folder prefix since src/ folder is root of code
+	is_diff := imp.alias != normalized_mod && !normalized_mod.ends_with('.' + imp.alias)
 	mut imp_alias_suffix := if is_diff { ' as ${imp.alias}' } else { '' }
 	mut syms := imp.syms.map(it.name).filter(f.import_syms_used[it])
 	syms.sort()
@@ -378,7 +379,7 @@ pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 			' {\n\t' + syms.join(',\n\t') + ',\n}'
 		}
 	}
-	return '${mod}${imp_alias_suffix}'
+	return '${normalized_mod}${imp_alias_suffix}'
 }
 
 //=== Node helpers ===//


### PR DESCRIPTION
# Fix

#16288

This PR fixes a bug when your project contains all code in the `src` folder and you created a local module.

`v fmt` will change your local module name with `src.<module_name>` which is wrong both logically (`src` is a root folder of your code and shouldn't be counted in a module path) and "programmatically" (after this change your code won't compile, because `src.<module_name> doesn't exist).

# Example

## Projects folders structure

```
my-project/
   src/
      main.v
   graphics/
```

## `main.v`

```v
module main

import graphics

fn main() {
	mut app := graphics.create_app()
	graphics.run(mut app)
}
```

## `v fmt` wrong change

```v
module main

import src.graphics

fn main() {
	mut app := graphics.create_app()
	graphics.run(mut app)
}
```

## `v fmt` change after fix

no changes