### PR TITLE
urllib: change Values.get to return option type

### DIFF
--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -40,8 +40,8 @@ fn test_parse_query() {
 	q2 := urllib.parse_query('format="%l:+%c+%t"')!
 	// dump(q1)
 	// dump(q2)
-	assert q1.get('format') == '"%l: %c %t"'
-	assert q2.get('format') == '"%l: %c %t"'
+	assert q1.get('format')? == '"%l: %c %t"'
+	assert q2.get('format')? == '"%l: %c %t"'
 }
 
 fn test_parse_query_orders() {

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -27,17 +27,17 @@ pub fn new_values() Values {
 
 // get gets the first value associated with the given key.
 // If there are no values associated with the key, get returns
-// a empty string.
-pub fn (v &Values) get(key string) string {
+// none.
+pub fn (v &Values) get(key string) ?string {
 	if v.data.len == 0 {
-		return ''
+		return none
 	}
 	for qvalue in v.data {
 		if qvalue.key == key {
 			return qvalue.value
 		}
 	}
-	return ''
+	return none
 }
 
 // get_all gets the all the values associated with the given key.

--- a/vlib/net/urllib/values_test.v
+++ b/vlib/net/urllib/values_test.v
@@ -3,11 +3,13 @@
 // that can be found in the LICENSE file.
 module urllib
 
-fn test_add_key_val() {
+fn test_add_and_get_key_val() {
 	mut values := Values{}
 	values.add('key', 'value')
-	val := values.get('key')
-	assert val == 'value'
+	present_val := values.get('key') or { '' }
+	absent_val := values.get('key1') or { '' }
+	assert present_val == 'value'
+	assert absent_val == ''
 }
 
 fn test_get_all_with_key() {


### PR DESCRIPTION
The `net.urllib.Values.get` method's return type is changed to an option type. 
This allows for a better handling of missing keys and should allows to distinguish keys with empty values from actual missing keys.
