### PR TITLE
cgen: fix fixed array assignment from unsafe block

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -329,7 +329,8 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
 			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr]
-			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit))
+			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit)
+			|| (val is ast.UnsafeExpr && (val as ast.UnsafeExpr).expr is ast.Ident))
 			&& !g.pref.translated
 		g.is_assign_lhs = true
 		g.assign_op = node.op

--- a/vlib/v/tests/unsafe_fixed_array_test.v
+++ b/vlib/v/tests/unsafe_fixed_array_test.v
@@ -1,0 +1,11 @@
+fn test_fixed_array_on_unsafe_int() {
+	x := [3]int{}
+	y := unsafe { x }
+	assert x == [0, 0, 0]!
+}
+
+fn test_fixed_array_on_unsafe_string() {
+	x := [3]string{init: ''}
+	y := unsafe { x }
+	assert x == ['', '', '']!
+}


### PR DESCRIPTION
Fix #17642

```V
fn test_fixed_array_on_unsafe_int() {
	x := [3]int{}
	y := unsafe { x }
	assert x == [0, 0, 0]!
}

fn test_fixed_array_on_unsafe_string() {
	x := [3]string{init: ''}
	y := unsafe { x }
	assert x == ['', '', '']!
}
```