### PR TITLE
cgen: fix argument dereference for str method when receiver is ptr

### DIFF
--- a/vlib/v/tests/ptr_str_method_test.v
+++ b/vlib/v/tests/ptr_str_method_test.v
@@ -1,0 +1,18 @@
+module main
+
+struct Name {
+	age int = 222
+}
+
+fn (n &Name) str() string {
+	return n.age.str()
+}
+
+fn test_str_method_with_ptr() {
+	name := &Name{}
+	mut mp := map[string]&Name{}
+	mp['aaa'] = name
+
+	assert mp.str() == "{'aaa': 222}"
+	assert name.str() == '222'
+}


### PR DESCRIPTION
Fix #17641

```V
module main

struct Name {
	age int = 222
}

fn (n &Name) str() string {
	return n.age.str()
}

fn test_str_method_with_ptr() {
	name := &Name{}
	mut mp := map[string]&Name{}
	mp['aaa'] = name

	assert mp.str() == "{'aaa': 222}"
	assert name.str() == '222'
}
```