### PR TITLE
cgen: fix selector expr with alias to ptr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3635,10 +3635,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			g.write(embed_name)
 		}
 	}
-	if (node.expr_type.is_ptr() || sym.kind == .chan) && node.from_embed_types.len == 0 {
+	alias_to_ptr := sym.info is ast.Alias && (sym.info as ast.Alias).parent_type.is_ptr()
+	if (node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
+		&& node.from_embed_types.len == 0 {
 		g.write('->')
 	} else {
-		// g.write('. /*typ=  $it.expr_type */') // ${g.typ(it.expr_type)} /')
 		g.write('.')
 	}
 	if node.expr_type.has_flag(.shared_f) {

--- a/vlib/v/tests/selectorexpr_alias_to_ptr_test.v
+++ b/vlib/v/tests/selectorexpr_alias_to_ptr_test.v
@@ -1,0 +1,16 @@
+struct ABC {
+	data int
+}
+
+type RABC = &ABC
+
+fn do(abc RABC) {
+	println(abc.data)
+}
+
+fn test_alias_to_ptr() {
+	abc := &ABC{
+		data: 5
+	}
+	do(abc)
+}


### PR DESCRIPTION
Fix #17634

```V
struct ABC {
	data int
}

type RABC = &ABC

fn do(abc RABC) {
	println(abc.data)
}

fn main() {
	abc := &ABC{
		data: 5
	}
	do(abc)
}
```