### PR TITLE
cgen: fix option ptr printing

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -125,7 +125,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		if str_method_expects_ptr && !is_ptr {
 			g.write('&')
 		} else if is_ptr && typ.has_flag(.option) {
-			g.write('*(${g.typ(typ.set_nr_muls(0))}*)&')
+			g.write('*(${g.typ(typ)}*)&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
 			g.write('*'.repeat(typ.nr_muls()))
 		}

--- a/vlib/v/tests/option_print_ptr_test.v
+++ b/vlib/v/tests/option_print_ptr_test.v
@@ -1,0 +1,14 @@
+struct One {
+	thing string = 'thing 1'
+}
+
+struct Two {
+	maybe_one ?&One
+}
+
+fn test_dump_option_ptr() {
+	a := Two{}
+	println(a)
+	println(Two{})
+	dump(Two{})
+}


### PR DESCRIPTION
Fix #17632

```V
struct One {
    thing string = 'thing 1'
}
struct Two {
    maybe_one ?&One
}
fn main() {
	a := Two{}
	println(a)
	println(Two{})
	dump(Two{})
}
```