### PR TITLE
checker: fix anon fn initialization as struct-like

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -337,6 +337,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				node.pos)
 			return ast.void_type
 		}
+	} else if struct_sym.info is ast.FnType {
+		c.error('cannot create a function in this way', node.pos)
 	}
 	// register generic struct type when current fn is generic fn
 	if c.table.cur_fn != unsafe { nil } && c.table.cur_fn.generic_names.len > 0 {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -338,7 +338,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 			return ast.void_type
 		}
 	} else if struct_sym.info is ast.FnType {
-		c.error('cannot create a function in this way', node.pos)
+		c.error('functions must be defined, not instantiated like structs', node.pos)
 	}
 	// register generic struct type when current fn is generic fn
 	if c.table.cur_fn != unsafe { nil } && c.table.cur_fn.generic_names.len > 0 {

--- a/vlib/v/checker/tests/wrong_fn_init_err.out
+++ b/vlib/v/checker/tests/wrong_fn_init_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/wrong_fn_init_err.vv:4:7: error: cannot create a function in this way
+vlib/v/checker/tests/wrong_fn_init_err.vv:4:7: error: functions must be defined, not instantiated like structs
     2 | 
     3 | fn main() {
     4 |     a := MyCallback{}

--- a/vlib/v/checker/tests/wrong_fn_init_err.out
+++ b/vlib/v/checker/tests/wrong_fn_init_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/wrong_fn_init_err.vv:4:7: error: cannot create a function in this way
+    2 | 
+    3 | fn main() {
+    4 |     a := MyCallback{}
+      |          ~~~~~~~~~~~~
+    5 |     println(a)
+    6 | }

--- a/vlib/v/checker/tests/wrong_fn_init_err.vv
+++ b/vlib/v/checker/tests/wrong_fn_init_err.vv
@@ -1,0 +1,6 @@
+type MyCallback = fn () string
+
+fn main() {
+	a := MyCallback{}
+	println(a)
+}


### PR DESCRIPTION
Fix #17650

```V
type MyCallback = fn () string

fn main() {
	a := MyCallback{}
	println(a)
}
```