### PR TITLE
checker: fix missing check for [export] attr without parameter

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -95,6 +95,13 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	if node.name == 'main.main' {
 		c.main_fn_decl_node = *node
 	}
+	if node.language == .v && node.attrs.len > 0 {
+		if attr_export := node.attrs.find_first('export') {
+			if attr_export.arg == '' {
+				c.error('missing argument for [export] attribute', attr_export.pos)
+			}
+		}
+	}
 	if node.return_type != ast.void_type {
 		if ct_attr_idx := node.attrs.find_comptime_define() {
 			sexpr := node.attrs[ct_attr_idx].ct_expr.str()

--- a/vlib/v/checker/tests/missing_export_attr_arg_err.out
+++ b/vlib/v/checker/tests/missing_export_attr_arg_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/missing_export_attr_arg_err.vv:1:1: error: missing argument for [export] attribute
+    1 | [export]
+      | ~~~~~~~~
+    2 | fn foo() string{
+    3 |     return "foo"

--- a/vlib/v/checker/tests/missing_export_attr_arg_err.vv
+++ b/vlib/v/checker/tests/missing_export_attr_arg_err.vv
@@ -1,0 +1,4 @@
+[export]
+fn foo() string{
+	return "foo"
+}


### PR DESCRIPTION
Fix #17625

```V
vlib/v/checker/tests/missing_export_attr_arg_err.vv:1:1: error: missing argument for [export] attribute
    1 | [export]
      | ~~~~~~~~
    2 | fn foo() string{
    3 |     return "foo"
```