### PR TITLE
json: support for &ptr types

### DIFF
--- a/vlib/json/json_encode_with_ptr_test.v
+++ b/vlib/json/json_encode_with_ptr_test.v
@@ -1,5 +1,3 @@
-module main
-
 import json
 
 struct User {
@@ -12,7 +10,7 @@ struct MyStruct {
 	users2 map[string]&User
 }
 
-fn main() {
+fn test_json_encode_with_ptr() {
 	user := User{
 		name: 'foo'
 	}

--- a/vlib/json/json_encode_with_ptr_test.v
+++ b/vlib/json/json_encode_with_ptr_test.v
@@ -1,0 +1,30 @@
+module main
+
+import json
+
+struct User {
+	name string
+}
+
+struct MyStruct {
+	user   &User //
+	users  map[string]User
+	users2 map[string]&User
+}
+
+fn main() {
+	user := User{
+		name: 'foo'
+	}
+	data := MyStruct{
+		user: &user
+		users: {
+			'keyfoo': user
+		}
+		users2: {
+			'keyfoo': &user
+		}
+	}
+
+	assert json.encode(data) == '{"user":{"name":"foo"},"users":{"keyfoo":{"name":"foo"}},"users2":{"keyfoo":{"name":"foo"}}}'
+}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1339,9 +1339,6 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			g.empty_line = true
 			g.writeln('// json.encode')
 			g.write('cJSON* ${json_obj} = ${encode_name}(')
-			if node.args[0].typ.is_ptr() {
-				g.write('*')
-			}
 			g.call_args(node)
 			g.writeln(');')
 			tmp2 = g.new_tmp_var()


### PR DESCRIPTION
Fix #17610

```V
module main

import json

struct User {
	name string
}

struct MyStruct {
	user	&User //
	users	map[string]User 
	users2	map[string]&User 
}

fn main() {
	user := User{
		name: "foo"
	}
	data := MyStruct{
		user: &user
		users: { "keyfoo": user}
		users2: { "keyfoo": &user}
	}
	
	assert json.encode(data) == '{"user":{"name":"foo"},"users":{"keyfoo":{"name":"foo"}},"users2":{"keyfoo":{"name":"foo"}}}'
}
```