### PR TITLE
cgen: fix map of complex array (fix #17646)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -123,6 +123,7 @@ mut:
 	inside_map_infix          bool // inside map<</+=/-= infix expr
 	inside_assign             bool
 	inside_map_index          bool
+	inside_array_index        bool
 	inside_opt_or_res         bool
 	inside_opt_data           bool
 	inside_if_option          bool

--- a/vlib/v/tests/map_complex_array_test.v
+++ b/vlib/v/tests/map_complex_array_test.v
@@ -1,0 +1,19 @@
+struct Instr {
+mut:
+	a int
+	b int
+}
+
+fn test_map_complex_array() {
+	mut map1 := map[string][]&Instr{}
+	instr := &Instr{
+		a: 1
+		b: 2
+	}
+	arr := [instr]
+	map1['Hello'] = arr
+	map1['Hello'][0].a = 2
+	println(map1['Hello'][0].a)
+	assert map1['Hello'][0].a == 2
+	assert map1['Hello'][0].b == 2
+}


### PR DESCRIPTION
This PR fix map of complex array (fix #17646).

- Fix map of complex array.
- Add test.

```v
struct Instr {
mut:
	a int
	b int
}

fn main() {
	mut map1 := map[string][]&Instr{}
	instr := &Instr{
		a: 1
		b: 2
	}
	arr := [instr]
	map1['Hello'] = arr
	map1['Hello'][0].a = 2
	println(map1['Hello'][0].a)
	assert map1['Hello'][0].a == 2
	assert map1['Hello'][0].b == 2
}

PS D:\Test\v\tt1> v run .
2
```