### PR TITLE
cgen: fix multi return assignment with option

### DIFF
--- a/vlib/v/tests/option_multi_ret_test.v
+++ b/vlib/v/tests/option_multi_ret_test.v
@@ -6,46 +6,36 @@ mut:
 }
 
 fn mr_1() (?int, string, []int) {
-	return 0, 'foo', [1]
+	return 456, 'foo', [1]
 }
 
 fn mr_2() (?int, string, []int) {
-	return none, 'foo', [1]
+	return none, 'zoo', [99]
 }
 
 fn mr_3() ([]?int, ?int) {
-	a := ?int(0)
-	return [a], none
+	return [?int(456)], none
 }
 
 fn test_mr_first_option() {
 	mut t := Test{}
 	t.a, t.b, t.c = mr_1()
-
-	a := dump(t.a)
-	b := dump(t.b)
-	c := dump(t.c)
-	assert a? == t.a?
-	assert b? == t.b?
-	assert c? == t.c?
+	assert t.a? == 456
+	assert t.b? == 'foo'
+	assert t.c? == [1]
 }
 
 fn test_mr_first_option_none() {
 	mut t := Test{}
 	t.a, t.b, t.c = mr_2()
-
-	a := dump(t.a)
-	b := dump(t.b)
-	c := dump(t.c)
-	assert a == none
-	assert b? == t.b?
-	assert c? == t.c?
+	assert t.a == none
+	assert t.b? == 'zoo'
+	assert t.c? == [99]
 }
 
 fn test_mr_first_option_array() {
 	a, b := mr_3()
-
 	t := a[0]
-	assert t? == 0
+	assert t? == 456
 	assert b == none
 }

--- a/vlib/v/tests/option_multi_ret_test.v
+++ b/vlib/v/tests/option_multi_ret_test.v
@@ -1,0 +1,51 @@
+struct Test {
+mut:
+	a ?int
+	b ?string
+	c ?[]int
+}
+
+fn mr_1() (?int, string, []int) {
+	return 0, 'foo', [1]
+}
+
+fn mr_2() (?int, string, []int) {
+	return none, 'foo', [1]
+}
+
+fn mr_3() ([]?int, ?int) {
+	a := ?int(0)
+	return [a], none
+}
+
+fn test_mr_first_option() {
+	mut t := Test{}
+	t.a, t.b, t.c = mr_1()
+
+	a := dump(t.a)
+	b := dump(t.b)
+	c := dump(t.c)
+	assert a? == t.a?
+	assert b? == t.b?
+	assert c? == t.c?
+}
+
+fn test_mr_first_option_none() {
+	mut t := Test{}
+	t.a, t.b, t.c = mr_2()
+
+	a := dump(t.a)
+	b := dump(t.b)
+	c := dump(t.c)
+	assert a == none
+	assert b? == t.b?
+	assert c? == t.c?
+}
+
+fn test_mr_first_option_array() {
+	a, b := mr_3()
+
+	t := a[0]
+	assert t? == 0
+	assert b == none
+}


### PR DESCRIPTION
Fix #17672

```V
struct Test {
mut:
	a ?int
	b ?string
	c ?[]int
}

fn mr_1() (?int, string, []int) {
	return 0, 'foo', [1]
}

fn mr_2() (?int, string, []int) {
	return none, 'foo', [1]
}

fn mr_3() ([]?int, ?int) {
	a := ?int(0)
	return [a], none
}

fn test_mr_first_option() {
	mut t := Test{}
	t.a, t.b, t.c = mr_1()

	a := dump(t.a)
	b := dump(t.b)
	c := dump(t.c)
	assert a? == t.a?
	assert b? == t.b?
	assert c? == t.c?
}

fn test_mr_first_option_none() {
	mut t := Test{}
	t.a, t.b, t.c = mr_2()

	a := dump(t.a)
	b := dump(t.b)
	c := dump(t.c)
	assert a == none
	assert b? == t.b?
	assert c? == t.c?
}

fn test_mr_first_option_array() {
	a, b := mr_3()

	t := a[0]
	assert t? == 0
	assert b == none
}
```