### PR TITLE
checker: check generic fn call argument type mismatch (fix #17018)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1792,7 +1792,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				c.error('literal argument cannot be passed as reference parameter `${c.table.type_to_str(param.typ)}`',
 					arg.pos)
 			}
-			c.check_expected_call_arg(got_arg_typ, exp_arg_typ, node.language, arg) or {
+			c.check_expected_call_arg(c.unwrap_generic(got_arg_typ), exp_arg_typ, node.language,
+				arg) or {
 				// str method, allow type with str method if fn arg is string
 				// Passing an int or a string array produces a c error here
 				// Deleting this condition results in propper V error messages

--- a/vlib/v/checker/tests/generic_fn_call_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/generic_fn_call_arg_mismatch_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generic_fn_call_arg_mismatch_err.vv:7:17: error: cannot use `int` as `string` in argument 1 to `strings.Builder.write_string`
+    5 |     var := T{}
+    6 |     ptr := &var
+    7 |     b.write_string(*ptr)
+      |                    ~~~~
+    8 | }
+    9 |

--- a/vlib/v/checker/tests/generic_fn_call_arg_mismatch_err.vv
+++ b/vlib/v/checker/tests/generic_fn_call_arg_mismatch_err.vv
@@ -1,0 +1,12 @@
+import strings
+
+fn my_fn[T]() {
+	mut b := strings.new_builder(16)
+	var := T{}
+	ptr := &var
+	b.write_string(*ptr)
+}
+
+fn main() {
+	my_fn[int]()
+}

--- a/vlib/v/token/keywords_matcher_trie.v
+++ b/vlib/v/token/keywords_matcher_trie.v
@@ -70,7 +70,7 @@ pub fn new_keywords_matcher_trie[T](kw_map map[string]T) KeywordsMatcherTrie {
 		km.nodes << &TrieNode(0)
 	}
 	for k, v in kw_map {
-		km.add_word(k, v)
+		km.add_word(k, int(v))
 	}
 	// dump(km.min_len)
 	// dump(km.max_len)

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -130,14 +130,14 @@ fn (e &Encoder) encode_value_with_level[T](val T, level int, mut wr io.Writer) !
 		e.encode_any(val, level, mut wr)!
 	} $else $if T is []Any {
 		e.encode_any(val, level, mut wr)!
-	} $else $if T in [Null, bool, $Float, $Int] {
-		e.encode_any(val, level, mut wr)!
 	} $else $if T is Encodable {
 		wr.write(val.json_str().bytes())!
 	} $else $if T is $Struct {
 		e.encode_struct(val, level, mut wr)!
 	} $else $if T is $Enum {
 		e.encode_any(Any(int(val)), level, mut wr)!
+	} $else $if T in [Null, bool, $Float, $Int] {
+		e.encode_any(val, level, mut wr)!
 	} $else {
 		// dump(val.str())
 		return error('cannot encode value with ${typeof(val).name} type')


### PR DESCRIPTION
This PR check generic fn call argument type mismatch (fix #17018).

- Check generic fn call argument type mismatch.
- Add test.
- Fix all the related errors.

```v
import strings

fn my_fn[T]() {
	mut b := strings.new_builder(16)
	var := T{}
	ptr := &var
	b.write_string(*ptr)
}

fn main() {
	my_fn[int]()
}

PS D:\Test\v\tt1> v run .
tt1.v:7:17: error: cannot use `int` as `string` in argument 1 to `strings.Builder.write_string`
    5 |     var := T{}
    6 |     ptr := &var
    7 |     b.write_string(*ptr)
      |                    ~~~~
    8 | }
    9 |
```