### PR TITLE
json: fix ptr field access

### DIFF
--- a/vlib/json/json_encode_with_mut_test.v
+++ b/vlib/json/json_encode_with_mut_test.v
@@ -1,0 +1,42 @@
+module main
+
+import json
+
+pub enum PlatformType {
+	unknown
+	osx
+	ubuntu
+	alpine
+}
+
+pub enum CPUType {
+	unknown
+	intel
+	arm
+	intel32
+	arm32
+}
+
+[heap]
+pub struct Node {
+pub:
+	name string = 'mymachine'
+pub mut:
+	platform    PlatformType
+	cputype     CPUType
+	done        map[string]string
+	environment map[string]string
+}
+
+pub fn (mut node Node) save() ! {
+	data := json.encode(node)
+	dump(data)
+}
+
+fn test_encode_with_mut_struct() {
+	mut n := Node{
+		platform: .osx
+		cputype: .unknown
+	}
+	n.save() or { panic(err) }
+}


### PR DESCRIPTION
Fix #17689

```V
module main

import json

pub enum PlatformType {
	unknown
	osx
	ubuntu
	alpine
}

pub enum CPUType {
	unknown
	intel
	arm
	intel32
	arm32
}

[heap]
pub struct Node {
pub:
	name string = 'mymachine'
pub mut:
	platform    PlatformType
	cputype     CPUType
	done        map[string]string
	environment map[string]string
}

pub fn (mut node Node) save() ! {
	data :=  json.encode(node)
	println(data)
}

fn main() {
	mut n := Node {
		platform: .osx
		cputype: .unknown
	}
	n.save() or {
		panic(err)
	}
}
```