### PR TITLE
checker: fix missing type mismatch with ptr types

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -7,9 +7,11 @@ import v.pref
 
 // TODO 600 line function
 fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
+	c.inside_assign = true
 	c.expected_type = ast.none_type // TODO a hack to make `x := if ... work`
 	defer {
 		c.expected_type = ast.void_type
+		c.inside_assign = false
 	}
 	is_decl := node.op == .decl_assign
 	right_first := node.right[0]

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -7,11 +7,12 @@ import v.pref
 
 // TODO 600 line function
 fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
+	prev_inside_assign := c.inside_assign
 	c.inside_assign = true
 	c.expected_type = ast.none_type // TODO a hack to make `x := if ... work`
 	defer {
 		c.expected_type = ast.void_type
-		c.inside_assign = false
+		c.inside_assign = prev_inside_assign
 	}
 	is_decl := node.op == .decl_assign
 	right_first := node.right[0]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -115,6 +115,7 @@ mut:
 	inside_println_arg               bool
 	inside_decl_rhs                  bool
 	inside_if_guard                  bool // true inside the guard condition of `if x := opt() {}`
+	inside_assign                    bool
 	is_index_assign                  bool
 	comptime_call_pos                int // needed for correctly checking use before decl for templates
 	goto_labels                      map[string]ast.GotoLabel // to check for unused goto labels

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -320,7 +320,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 							node.pos)
 					} else {
-						if stmt.typ.is_ptr() != node.typ.is_ptr() {
+						if c.inside_assign && stmt.typ.is_ptr() != node.typ.is_ptr() {
 							c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 								node.pos)
 						}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -319,6 +319,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						}
 						c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 							node.pos)
+					} else {
+						if stmt.typ.is_ptr() != node.typ.is_ptr() {
+							c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
+								node.pos)
+						}
 					}
 				} else if !node.is_comptime {
 					c.error('`${if_kind}` expression requires an expression as the last statement of every branch',

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -321,7 +321,8 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							node.pos)
 					} else {
 						if c.inside_assign && node.is_expr && !node.typ.has_flag(.shared_f)
-							&& stmt.typ.is_ptr() != node.typ.is_ptr() {
+							&& stmt.typ.is_ptr() != node.typ.is_ptr()
+							&& stmt.typ != ast.voidptr_type {
 							c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 								node.pos)
 						}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -320,7 +320,8 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 							node.pos)
 					} else {
-						if c.inside_assign && stmt.typ.is_ptr() != node.typ.is_ptr() {
+						if node.is_expr && !node.typ.has_flag(.shared_f)
+							&& stmt.typ.is_ptr() != node.typ.is_ptr() {
 							c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 								node.pos)
 						}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -320,7 +320,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 							node.pos)
 					} else {
-						if node.is_expr && !node.typ.has_flag(.shared_f)
+						if c.inside_assign && node.is_expr && !node.typ.has_flag(.shared_f)
 							&& stmt.typ.is_ptr() != node.typ.is_ptr() {
 							c.error('mismatched types `${c.table.type_to_str(node.typ)}` and `${c.table.type_to_str(stmt.typ)}`',
 								node.pos)

--- a/vlib/v/checker/tests/if_diff_expected_type_err.out
+++ b/vlib/v/checker/tests/if_diff_expected_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/if_diff_expected_type_err.vv:7:11: error: mismatched types `&[]rune` and `[]rune`
+    5 | 
+    6 | fn main() {
+    7 |     runes := if true { &some_runes } else { some_other_runes }
+      |              ~~
+    8 |     println(runes)
+    9 | }

--- a/vlib/v/checker/tests/if_diff_expected_type_err.vv
+++ b/vlib/v/checker/tests/if_diff_expected_type_err.vv
@@ -1,0 +1,9 @@
+const (
+	some_runes       = [`a`, `b`, `c`]
+	some_other_runes = [`c`, `b`, `a`]
+)
+
+fn main() {
+	runes := if true { &some_runes } else { some_other_runes }
+	println(runes)
+}


### PR DESCRIPTION
Fix #17687

```V
const (
	some_runes       = [`a`, `b`, `c`]
	some_other_runes = [`c`, `b`, `a`]
)

fn main() {
	runes := if true { &some_runes } else { some_other_runes }
	println(runes)
}
```