### PR TITLE
vweb.assets: add option for custom href and src attribute values

### DIFF
--- a/vlib/vweb/assets/assets.v
+++ b/vlib/vweb/assets/assets.v
@@ -24,6 +24,8 @@ pub mut:
 struct Asset {
 	file_path     string
 	last_modified time.Time
+mut:
+	include_name string
 }
 
 // new_manager returns a new AssetManager
@@ -36,9 +38,31 @@ pub fn (mut am AssetManager) add_css(file string) bool {
 	return am.add('css', file)
 }
 
+// add_css_as adds a css asset with a custom href
+pub fn (mut am AssetManager) add_css_as(file string, href string) bool {
+	if am.add('css', file) {
+		// set name of added asset
+		am.css.last().include_name = href
+		return true
+	} else {
+		return false
+	}
+}
+
 // add_js adds a js asset
 pub fn (mut am AssetManager) add_js(file string) bool {
 	return am.add('js', file)
+}
+
+// add_js_as adds a js asset with a custom src
+pub fn (mut am AssetManager) add_js_as(file string, src string) bool {
+	if am.add('js', file) {
+		// set name of added asset
+		am.js.last().include_name = src
+		return true
+	} else {
+		return false
+	}
 }
 
 // combine_css returns the combined css as a string when to_file is false
@@ -126,7 +150,12 @@ fn (am AssetManager) include(asset_type string, combine bool) string {
 			return '<link rel="stylesheet" href="${file}">\n'
 		}
 		for asset in assets {
-			out += '<link rel="stylesheet" href="${asset.file_path}">\n'
+			mut href := asset.file_path
+			if asset.include_name.len > 0 {
+				href = asset.include_name
+			}
+
+			out += '<link rel="stylesheet" href="${href}">\n'
 		}
 	}
 	if asset_type == 'js' {
@@ -135,7 +164,12 @@ fn (am AssetManager) include(asset_type string, combine bool) string {
 			return '<script type="text/javascript" src="${file}"></script>\n'
 		}
 		for asset in assets {
-			out += '<script type="text/javascript" src="${asset.file_path}"></script>\n'
+			mut src := asset.file_path
+			if asset.include_name.len > 0 {
+				src = asset.include_name
+			}
+
+			out += '<script type="text/javascript" src="${src}"></script>\n'
 		}
 	}
 	return out

--- a/vlib/vweb/assets/assets_test.v
+++ b/vlib/vweb/assets/assets_test.v
@@ -85,7 +85,7 @@ fn test_add_js() {
 fn test_add_js_as() {
 	mut am := assets.new_manager()
 	file_name := '/custom/path/test1.js'
-	assert am.add_js_as(get_test_file_path('test1.js'), '/custom/path/test1.js') == true
+	assert am.add_js_as(get_test_file_path('test1.js'), file_name) == true
 
 	expected := '<script type="text/javascript" src="${file_name}"></script>\n'
 	actual := am.include_js(false)

--- a/vlib/vweb/assets/assets_test.v
+++ b/vlib/vweb/assets/assets_test.v
@@ -65,11 +65,31 @@ fn test_add_css() {
 	// assert am.add_css(get_test_file_path('test1.js')) == false // TODO: test extension on add
 }
 
+fn test_add_css_as() {
+	mut am := assets.new_manager()
+	file_name := '/custom/path/test1.css'
+	assert am.add_css_as(get_test_file_path('test1.css'), file_name) == true
+
+	expected := '<link rel="stylesheet" href="${file_name}">\n'
+	actual := am.include_css(false)
+	assert actual == expected
+}
+
 fn test_add_js() {
 	mut am := assets.new_manager()
 	assert am.add_js('testx.js') == false
 	assert am.add_css(get_test_file_path('test1.js')) == true
 	// assert am.add_css(get_test_file_path('test1.css')) == false // TODO: test extension on add
+}
+
+fn test_add_js_as() {
+	mut am := assets.new_manager()
+	file_name := '/custom/path/test1.js'
+	assert am.add_js_as(get_test_file_path('test1.js'), '/custom/path/test1.js') == true
+
+	expected := '<script type="text/javascript" src="${file_name}"></script>\n'
+	actual := am.include_js(false)
+	assert expected == actual
 }
 
 fn test_combine_css() {


### PR DESCRIPTION

When using the asset manager the `href` and `src` values will always be the filename. This doesn't work when you are mounting a static directory under another name. 

For example let's say you have vweb application with a static folder mounted at the root. And you have a css file in "static/css/main.css".
```v
app.handle_static('static', true)
```

The `href` and `src` values are relative: "static/css/main.css" becomes `href="static/css/main.css"`. If you are at a subpath let's say "/auth/login" the browser will look for the css file in "/auth/static/css/main.css"

With `add_css_as` you can make sure the href will always be correct.
```v
mut am := assets.new_manager()
am.add_css_as('static/css/main.css', '/css/main.css')
css_links := am.include_css(false)
```
Now the href will just be "/css/main.css" and the browser can find the file in the mounted static directory.
This solution gives the user more flexibility with their file system and is better than manual replacing the static path e.g.
```v
css_links = css_links.replace('static/', '/')
```

The same applies for js `add_js_as`, but with `src` instead of `href`.
