### PR TITLE
cgen: fix closure with fixed array variable (fix #17700)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -487,12 +487,30 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 			if obj is ast.Var {
 				if obj.has_inherited {
 					has_inherited = true
-					g.writeln('.${var.name} = ${c.closure_ctx}->${var.name},')
+					var_sym := g.table.sym(var.typ)
+					if var_sym.info is ast.ArrayFixed {
+						g.write('.${var.name} = {')
+						for i in 0 .. var_sym.info.size {
+							g.write('${c.closure_ctx}->${var.name}[${i}],')
+						}
+						g.writeln('},')
+					} else {
+						g.writeln('.${var.name} = ${c.closure_ctx}->${var.name},')
+					}
 				}
 			}
 		}
 		if !has_inherited {
-			g.writeln('.${var.name} = ${var.name},')
+			var_sym := g.table.sym(var.typ)
+			if var_sym.info is ast.ArrayFixed {
+				g.write('.${var.name} = {')
+				for i in 0 .. var_sym.info.size {
+					g.write('${var.name}[${i}],')
+				}
+				g.writeln('},')
+			} else {
+				g.writeln('.${var.name} = ${var.name},')
+			}
 		}
 	}
 	g.indent--

--- a/vlib/v/tests/closure_with_fixed_array_var_test.v
+++ b/vlib/v/tests/closure_with_fixed_array_var_test.v
@@ -1,0 +1,16 @@
+struct Crasher {
+	value int
+}
+
+fn crash(c [1]Crasher) fn () int {
+	return fn [c] () int {
+		println(c[0].value)
+		return c[0].value
+	}
+}
+
+fn test_closure_with_fixed_array_var() {
+	crash_fn := crash([Crasher{1}]!)
+	ret := crash_fn()
+	assert ret == 1
+}


### PR DESCRIPTION
This PR fix closure with fixed array variable (fix #17700).

- Fix closure with fixed array variable.
- Add test.

```v
struct Crasher {
	value int
}

fn crash(c [1]Crasher) fn () int {
	return fn [c] () int {
		println(c[0].value)
		return c[0].value
	}
}

fn main() {
	crash_fn := crash([Crasher{1}]!)
	ret := crash_fn()
	assert ret == 1
}

PS D:\Test\v\tt1> v run .
1
```