### PR TITLE
strconv: fix v_sprintf with '%%' (fix #17638)

### DIFF
--- a/vlib/strconv/format_test.v
+++ b/vlib/strconv/format_test.v
@@ -113,3 +113,9 @@ fn test_sprintf_does_not_double_free_on_g() {
 	x := 3.141516
 	assert strconv.v_sprintf('aaa %G', x) == 'aaa 3.141516'
 }
+
+fn test_sprintf_with_escape() {
+	n := 69
+	s := strconv.v_sprintf('%d is 100%% awesome', n)
+	assert s == '69 is 100% awesome'
+}

--- a/vlib/strconv/vprintf.c.v
+++ b/vlib/strconv/vprintf.c.v
@@ -75,6 +75,12 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 			i++
 			continue
 		}
+		if ch == `%` && status == .field_char {
+			status = .norm_char
+			res.write_u8(ch)
+			i++
+			continue
+		}
 		if ch == `%` && status == .norm_char {
 			status = .field_char
 			i++


### PR DESCRIPTION
This PR fix v_sprintf with '%%' (fix #17638).

- Fix v_sprintf with '%%'.
- Add test.

```v
import strconv

fn main() {
	n := 69
	s := strconv.v_sprintf('%d is 100%% awesome', n)
	println(s)
	assert s == '69 is 100% awesome'
}

PS D:\Test\v\tt1> v run .
69 is 100% awesome
```