### PR TITLE
cgen: fix match with option type

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -60,9 +60,8 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 				}
 				expr_type := c.expr(stmt.expr)
 				if !branch.is_else && cond_is_option && branch.exprs[0] !is ast.None {
-					println(c.table.type_to_str(expr_type))
 					c.error('`match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`',
-						stmt.pos)
+						branch.pos)
 				}
 				stmt.typ = expr_type
 				if first_iteration {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -59,7 +59,8 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					c.expected_type = node.expected_type
 				}
 				expr_type := c.expr(stmt.expr)
-				if !branch.is_else && cond_is_option && !expr_type.has_flag(.option) {
+				if !branch.is_else && cond_is_option && branch.exprs[0] !is ast.None {
+					println(c.table.type_to_str(expr_type))
 					c.error('`match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`',
 						stmt.pos)
 				}

--- a/vlib/v/checker/tests/match_cond_with_parenthesis_err.out
+++ b/vlib/v/checker/tests/match_cond_with_parenthesis_err.out
@@ -1,7 +1,21 @@
 vlib/v/checker/tests/match_cond_with_parenthesis_err.vv:14:15: error: unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.
-   12 |
+   12 | 
    13 | fn bar() bool {
    14 |     return match (foo()) {
       |                  ~~~~~~~
    15 |         .a { true }
    16 |         .b, .c { false }
+vlib/v/checker/tests/match_cond_with_parenthesis_err.vv:15:3: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
+   13 | fn bar() bool {
+   14 |     return match (foo()) {
+   15 |         .a { true }
+      |         ~~
+   16 |         .b, .c { false }
+   17 |     }
+vlib/v/checker/tests/match_cond_with_parenthesis_err.vv:16:3: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
+   14 |     return match (foo()) {
+   15 |         .a { true }
+   16 |         .b, .c { false }
+      |         ~~~~~~
+   17 |     }
+   18 | }

--- a/vlib/v/checker/tests/option_with_match_err.out
+++ b/vlib/v/checker/tests/option_with_match_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/option_with_match_err.vv:4:8: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
+    2 |     mut a := ?int(12)
+    3 |     match a {
+    4 |         12 { println(a) }
+      |              ~~~~~~~~~~
+    5 |         else { println('else') }
+    6 |     }

--- a/vlib/v/checker/tests/option_with_match_err.out
+++ b/vlib/v/checker/tests/option_with_match_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/option_with_match_err.vv:4:8: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
+vlib/v/checker/tests/option_with_match_err.vv:4:3: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
     2 |     mut a := ?int(12)
     3 |     match a {
     4 |         12 { println(a) }
-      |              ~~~~~~~~~~
+      |         ~~
     5 |         else { println('else') }
     6 |     }

--- a/vlib/v/checker/tests/option_with_match_err.vv
+++ b/vlib/v/checker/tests/option_with_match_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	mut a := ?int(12)
+	match a {
+		12 { println(a) }
+		else { println('else') }
+	}
+}

--- a/vlib/v/tests/option_match_test.v
+++ b/vlib/v/tests/option_match_test.v
@@ -1,0 +1,66 @@
+fn test_simple_match_expr() {
+	mut a := ?int(12)
+	match a? {
+		12 {
+			println(a)
+		}
+		else {
+			println('else')
+			assert false
+		}
+	}
+
+	match a {
+		none {
+			println('none')
+			assert false
+		}
+		else {
+			println('else')
+		}
+	}
+
+	a = none
+
+	match a {
+		none {
+			println('none')
+		}
+		else {
+			println('else')
+			assert false
+		}
+	}
+
+	mut b := ?string('aaa')
+	match b? {
+		'aaa' {
+			println(b)
+		}
+		else {
+			println('else')
+			assert false
+		}
+	}
+
+	match b {
+		none {
+			println('none')
+			assert false
+		}
+		else {
+			println('else')
+		}
+	}
+
+	b = none
+	match b {
+		none {
+			println('none')
+		}
+		else {
+			println('else')
+			assert false
+		}
+	}
+}


### PR DESCRIPTION
Fix #17711

```V
fn main() {
	mut a := ?int(12)
	match a? {
		12 { println(a) }
		//none { println('none') }
		else { println('else') }
	}

	match a {
		none { println('none') }
		else { println('else') }
	}
	
	a = none

	match a {
		none { println('none') }
		else { println('else') }
	}

	mut b := ?string('aaa')
	match b? {
		'aaa' { println(b) }
		else { println('else') }
	}

	match b {
		none { println('none') }
		else { println('else') }
	}

	b = none
	match b {
		none { println('none') }
		else { println('else') }
	}
}
```

Added error when using option type without unwrap to check against value different of `none`:

```V
bug.v:4:8: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
    2 |     mut a := ?int(12)
    3 |     match a {
    4 |         12 { println(a) }
      |              ~~~~~~~~~~
    5 |         else { println('else') }
    6 |     }
 ```