### PR TITLE
Added create_no_window parameter to Process

### DIFF
--- a/vlib/os/process.v
+++ b/vlib/os/process.v
@@ -25,15 +25,15 @@ pub mut:
 	// the exit code of the process, != -1 *only* when status is .exited *and* the process was not aborted
 	status ProcessState = .not_started
 	// the current status of the process
-	err           string   // if the process fails, contains the reason why
-	args          []string // the arguments that the command takes
-	env_is_custom bool     // true, when the environment was customized with .set_environment
-	env           []string // the environment with which the process was started  (list of 'var=val')
-	use_stdio_ctl bool     // when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
-	use_pgroup    bool     // when true, the process will create a new process group, enabling .signal_pgkill()
-	stdio_fd      [3]int   // the stdio file descriptors for the child process, used only by the nix implementation
-	wdata         voidptr  // the WProcess; used only by the windows implementation
-	create_no_window bool  // sets a value indicating whether to start the process in a new window, The default is false; used only by the windows implementation
+	err              string   // if the process fails, contains the reason why
+	args             []string // the arguments that the command takes
+	env_is_custom    bool     // true, when the environment was customized with .set_environment
+	env              []string // the environment with which the process was started  (list of 'var=val')
+	use_stdio_ctl    bool     // when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
+	use_pgroup       bool     // when true, the process will create a new process group, enabling .signal_pgkill()
+	stdio_fd         [3]int   // the stdio file descriptors for the child process, used only by the nix implementation
+	wdata            voidptr  // the WProcess; used only by the windows implementation
+	create_no_window bool     // sets a value indicating whether to start the process in a new window, The default is false; used only by the windows implementation
 }
 
 // new_process - create a new process descriptor

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -97,7 +97,11 @@ fn (mut p Process) win_spawn_process() int {
 	cmd := '${p.filename} ' + p.args.join(' ')
 	C.ExpandEnvironmentStringsW(cmd.to_wide(), voidptr(&wdata.command_line[0]), 32768)
 
-	mut creation_flags := if p.create_no_window { int(C.CREATE_NO_WINDOW) } else { int(C.NORMAL_PRIORITY_CLASS) }
+	mut creation_flags := if p.create_no_window {
+		int(C.CREATE_NO_WINDOW)
+	} else {
+		int(C.NORMAL_PRIORITY_CLASS)
+	}
 	if p.use_pgroup {
 		creation_flags |= C.CREATE_NEW_PROCESS_GROUP
 	}


### PR DESCRIPTION
Sets a value that indicates whether the process should start in a new window.

`true` for the process to start without creating a new window containing it; otherwise, `false`. The default is `false`.

This avoids the undesirable behavior of the console (cmd) opening and closing when running a task in windows

```v
import os

fn main() {
	lines := exec_cmd(['netstat']) // using netstat as an example
	for line in lines {
		println(line)
	}
	os.system('pause')
}


fn exec_cmd(args []string) []string {
	mut pro := os.new_process('cmd')
	pro.create_no_window = true // <--- HERE
	mut argsa := ['/min', '/c', args.join(' ')]
	pro.set_args(argsa)

	pro.set_redirect_stdio()
	pro.run()

	mut content := []string{}
	for pro.is_alive() {
		mut out := pro.stdout_read()
		if out.len > 0 {
			//println(out)
			for line in out.split_into_lines() {
				content << line.trim_space()
			}
		}		
	}
	pro.close()
	return content
}

```

