### PR TITLE
type: fix embed name with enum as generic struct type

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1492,14 +1492,14 @@ pub fn (t &TypeSymbol) symbol_name_except_generic() string {
 }
 
 pub fn (t &TypeSymbol) embed_name() string {
-	// main.Abc[int] => Abc[int]
-	mut embed_name := t.name.split('.').last()
-	// remove generic part from name
-	// Abc[int] => Abc
-	if embed_name.contains('[') {
-		embed_name = embed_name.split('[')[0]
+	if t.name.contains('[') {
+		// Abc[int] => Abc
+		// main.Abc[main.Enum] => Abc
+		return t.name.split('[')[0].split('.').last()
+	} else {
+		// main.Abc => Abc
+		return t.name.split('.').last()
 	}
-	return embed_name
 }
 
 pub fn (t &TypeSymbol) has_method(name string) bool {

--- a/vlib/v/tests/embed_struct_name_test.v
+++ b/vlib/v/tests/embed_struct_name_test.v
@@ -1,0 +1,27 @@
+struct MyTemplate[T] {
+	data T
+}
+
+enum MyEnum as u8 {
+	client
+	server
+}
+
+struct Embed {
+	a int
+}
+
+struct MyStructure {
+	Embed
+	MyTemplate[MyEnum]
+}
+
+fn test_embed_name_with_enum() {
+	t := MyStructure{
+		a: 10
+		data: .server
+	}
+	dump(t)
+	assert t.a == 10
+	assert t.data == .server
+}


### PR DESCRIPTION
Fix #17721

`MyTemplate[MyEnum]` was generating wrong code on struct declaration.