### PR TITLE
parser: fix parsing cast array syntax from another module

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2551,14 +2551,22 @@ pub fn (mut p Parser) name_expr() ast.Expr {
 			}
 		}
 	} else if p.peek_tok.kind == .lpar || is_generic_call || is_generic_cast
-		|| (p.tok.kind == .lsbr && p.peek_tok.kind == .rsbr && p.peek_token(3).kind == .lpar)
-		|| (p.tok.kind == .lsbr && p.peek_tok.kind == .number && p.peek_token(2).kind == .rsbr
-		&& p.peek_token(4).kind == .lpar) {
+		|| (p.tok.kind == .lsbr && p.peek_tok.kind == .rsbr && (p.peek_token(3).kind == .lpar
+		|| p.peek_token(5).kind == .lpar)) || (p.tok.kind == .lsbr && p.peek_tok.kind == .number
+		&& p.peek_token(2).kind == .rsbr && (p.peek_token(4).kind == .lpar
+		|| p.peek_token(6).kind == .lpar)) {
 		// ?[]foo(), ?[1]foo, foo(), foo<int>() or type() cast
 		mut name := if is_array {
 			p.peek_token(if is_fixed_array { 3 } else { 2 }).lit
 		} else {
 			p.tok.lit
+		}
+		if is_fixed_array && p.peek_token(4).kind == .dot {
+			mod = name
+			name = p.peek_token(5).lit
+		} else if is_array && p.peek_token(3).kind == .dot {
+			mod = name
+			name = p.peek_token(4).lit
 		}
 		if mod.len > 0 {
 			name = '${mod}.${name}'

--- a/vlib/v/tests/option_array_submodule_test.v
+++ b/vlib/v/tests/option_array_submodule_test.v
@@ -8,4 +8,12 @@ fn test_submodule_array_instance() {
 	y := ?amodule.SomeStruct(none)
 	dump(y)
 	assert y == none
+
+	w := ?[]amodule.SomeStruct(none)
+	dump(w)
+	assert w == none
+
+	z := ?[2]amodule.SomeStruct(none)
+	dump(z)
+	assert z == none
 }


### PR DESCRIPTION
Fix #17704