### PR TITLE
cgen: fix `println(value.name)` inside `$for value in Test.values{`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3427,13 +3427,6 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				g.error('unknown generic field', node.pos)
 			}
 		}
-	} else {
-		// for comp-time enum value evaluation
-		if node.expr_type == g.enum_data_type && node.expr is ast.Ident
-			&& (node.expr as ast.Ident).name == 'value' {
-			g.write(node.str())
-			return
-		}
 	}
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)

--- a/vlib/v/tests/comptime_concrete_type_register_test.v
+++ b/vlib/v/tests/comptime_concrete_type_register_test.v
@@ -7,7 +7,7 @@ mut:
 
 fn encode_struct[U](val U) ! {
 	$for field in U.fields {
-		$if field.typ is $Map {
+		$if field.typ is $map {
 			for _, v in val.$(field.name) {
 				encode_value_with_level(v)!
 			}
@@ -16,10 +16,10 @@ fn encode_struct[U](val U) ! {
 }
 
 fn encode_value_with_level[T](val T) ! {
-	$if T is $Struct {
+	$if T is $struct {
 		dump(val)
 		println(encode_struct(val)!)
-	} $else $if T is $Map {
+	} $else $if T is $map {
 		dump(val)
 	} $else $if T is string {
 		dump(val)
@@ -28,7 +28,7 @@ fn encode_value_with_level[T](val T) ! {
 
 fn (e &Encoder) encode_struct[U](val U) ! {
 	$for field in U.fields {
-		$if field.typ is $Map {
+		$if field.typ is $map {
 			for _, v in val.$(field.name) {
 				e.encode_value_with_level(v)!
 			}
@@ -37,10 +37,10 @@ fn (e &Encoder) encode_struct[U](val U) ! {
 }
 
 fn (e &Encoder) encode_value_with_level[T](val T) ! {
-	$if T is $Struct {
+	$if T is $struct {
 		dump(val)
 		println(e.encode_struct(val)!)
-	} $else $if T is $Map {
+	} $else $if T is $map {
 		dump(val)
 	} $else $if T is string {
 		dump(val)

--- a/vlib/v/tests/comptime_enum_test.v
+++ b/vlib/v/tests/comptime_enum_test.v
@@ -3,7 +3,26 @@ enum Test {
 	bar
 }
 
-fn test_main() {
+fn test_print_value_name() {
+	$for value in Test.values {
+		println(value.name)
+	}
+}
+
+fn test_print_value_value() {
+	$for value in Test.values {
+		println(value.value)
+	}
+}
+
+fn test_print_both() {
+	$for values in Test.values {
+		println(values.name)
+		println(values.value)
+	}
+}
+
+fn test_comptime_for_in_enum_values() {
 	$for item in Test.values {
 		assert item.name in ['foo', 'bar']
 		match item.value {


### PR DESCRIPTION
Fix #17745 .
```v
enum Test{
    alpha
    bravo
    charlie
}

fn main(){
    $for value in Test.values{
        println(value.name)
    }
}
```
will work after this PR.