### PR TITLE
cgen: fix code for enum comptime selector enum.name

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3430,8 +3430,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	} else {
 		// for comp-time enum value evaluation
 		if node.expr_type == g.enum_data_type && node.expr is ast.Ident
-			&& (node.expr as ast.Ident).name == 'value' {
-			g.write(node.str())
+			&& node.field_name in ['name', 'value'] {
+			g.expr(node.expr)
+			g.write('.${node.field_name}')
 			return
 		}
 	}

--- a/vlib/v/tests/comptime_enum_test.v
+++ b/vlib/v/tests/comptime_enum_test.v
@@ -3,6 +3,12 @@ enum Test {
 	bar
 }
 
+enum Test2 {
+	alpha
+	bravo
+	charlie
+}
+
 fn test_main() {
 	$for item in Test.values {
 		assert item.name in ['foo', 'bar']
@@ -23,5 +29,12 @@ fn test_main() {
 			println('foo>> item: ${item.name}')
 			assert item.value == .bar
 		}
+	}
+}
+
+fn test_selectors() {
+	$for value in Test2.values {
+		println(value.name)
+		assert dump(value.value) == value.value
 	}
 }


### PR DESCRIPTION
Fix #17745