### PR TITLE
examples, orm: fix orm example; add `-d trace_orm` option to see all ORM generated queries

### DIFF
--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -1,6 +1,39 @@
+import os
 import db.sqlite
-import db.mysql as sql
+import db.mysql
 import db.pg
+
+// The goal of this example, is to show how you can connect to
+// several different databases in the same program, and use both
+// the ORM and the native connection wrapper, that each DB driver
+// provides, if you need to execute more complex SQL queries.
+//
+// You can use environment variables to pass your local DB connection
+// settings, without editing the code, like this:
+//
+//    MUSER='myuser' MPASS='abc' MDATABASE='vtestdb'  PGUSER='postgres' PGPASS='password' PGDATABASE='postgres'  ./v -g run examples/database/orm.v
+//
+// WARNING: this example will drop and re-create any tables named:
+//   * modules
+//   * User
+//   * Parent
+//   * Child
+// in the passed databases, so it is better to use empty DBs for it.
+
+const (
+	mysql_host = os.getenv_opt('MHOST') or { 'localhost' }
+	mysql_port = os.getenv_opt('MPORT') or { '3306' }.u32()
+	mysql_user = os.getenv_opt('MUSER') or { 'myuser' }
+	mysql_pass = os.getenv_opt('MPASS') or { 'abc' }
+	mysql_db   = os.getenv_opt('MDATABASE') or { 'test' }
+)
+
+const (
+	pg_host = os.getenv_opt('PGHOST') or { 'localhost' }
+	pg_user = os.getenv_opt('PGUSER') or { 'test' }
+	pg_pass = os.getenv_opt('PGPASS') or { 'abc' }
+	pg_db   = os.getenv_opt('PGDATABASE') or { 'test' }
+)
 
 [table: 'modules']
 struct Module {
@@ -13,7 +46,7 @@ struct Module {
 struct User {
 	id             int    [primary; sql: serial]
 	age            u32    [unique: 'user']
-	name           string [sql: 'username'; unique]
+	name           string [sql: 'username'; sql_type: 'VARCHAR(200)'; unique]
 	is_customer    bool   [sql: 'abc'; unique: 'user']
 	skipped_string string [skip]
 }
@@ -30,22 +63,23 @@ struct Child {
 	name      string
 }
 
-fn main() {
-	sqlite3_array()
-	mysql_array()
-	psql_array()
-
-	sqlite3()
-	mysql()
-	psql()
-}
-
-fn sqlite3_array() {
-	mut db := sqlite.connect(':memory:') or { panic(err) }
+fn sqlite3_array() ! {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		sql db {
+			drop table Parent
+			drop table Child
+		}
+		db.close() or {}
+	}
+	//
 	sql db {
 		create table Parent
 	}
-
+	sql db {
+		create table Child
+	}
 	par := Parent{
 		name: 'test'
 		children: [
@@ -57,36 +91,38 @@ fn sqlite3_array() {
 			},
 		]
 	}
-
 	sql db {
 		insert par into Parent
 	}
-
 	parent := sql db {
 		select from Parent where id == 1
 	}
-
-	sql db {
-		drop table Parent
-	}
-
 	eprintln(parent)
 }
 
-fn mysql_array() {
-	mut db := sql.Connection{
-		host: 'localhost'
-		port: 3306
-		username: 'root'
-		password: 'abc'
-		dbname: 'test'
+fn msql_array() ! {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut db := mysql.Connection{
+		host: mysql_host
+		port: mysql_port
+		username: mysql_user
+		password: mysql_pass
+		dbname: mysql_db
 	}
-	db.connect() or { panic(err) }
-
+	db.connect()!
+	defer {
+		sql db {
+			drop table Parent
+		}
+		db.close()
+	}
+	//
+	db.query('drop table if exists Parent')!
+	db.query('drop table if exists Child')!
 	sql db {
 		create table Parent
+		create table Child
 	}
-
 	par := Parent{
 		name: 'test'
 		children: [
@@ -98,33 +134,28 @@ fn mysql_array() {
 			},
 		]
 	}
-
 	sql db {
 		insert par into Parent
 	}
-
 	parent := sql db {
 		select from Parent where id == 1
 	}
-
 	eprintln(parent)
-
-	sql db {
-		drop table Parent
-	}
-
-	db.close()
 }
 
-fn psql_array() {
-	mut db := pg.connect(host: 'localhost', user: 'test', password: 'abc', dbname: 'test') or {
-		panic(err)
+fn psql_array() ! {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut db := pg.connect(host: pg_host, user: pg_user, password: pg_pass, dbname: pg_db)!
+	defer {
+		db.exec_one('drop table if exists "Parent", "Child"') or { eprintln(err) }
+		db.close()
 	}
-
+	db.exec_one('drop table if exists "Parent", "Child"') or { eprintln(err) }
+	//
 	sql db {
 		create table Parent
+		create table Child
 	}
-
 	par := Parent{
 		name: 'test'
 		children: [
@@ -136,30 +167,34 @@ fn psql_array() {
 			},
 		]
 	}
-
 	sql db {
 		insert par into Parent
 	}
-
 	parent := sql db {
 		select from Parent where id == 1
 	}
-
 	eprintln(parent)
-
-	sql db {
-		drop table Parent
-	}
-
-	db.close()
 }
 
-fn sqlite3() {
-	mut db := sqlite.connect(':memory:') or { panic(err) }
+fn sqlite3() ! {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		sql db {
+			drop table Module
+		}
+		sql db {
+			drop table User
+		}
+		db.close() or {}
+	}
+	//
 	sql db {
 		create table Module
 	}
-
+	sql db {
+		create table User
+	}
 	mod := Module{
 		name: 'test'
 		nr_downloads: 10
@@ -172,33 +207,36 @@ fn sqlite3() {
 	sql db {
 		insert mod into Module
 	}
-
 	modul := sql db {
 		select from Module where id == 1
 	}
-
-	sql db {
-		drop table Module
-	}
-
 	eprintln(modul)
-	db.close() or { panic(err) }
 }
 
-fn mysql() {
-	mut conn := sql.Connection{
-		host: 'localhost'
-		port: 3306
-		username: 'root'
-		password: 'abc'
-		dbname: 'test'
+fn msql() ! {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut conn := mysql.Connection{
+		host: mysql_host
+		port: mysql_port
+		username: mysql_user
+		password: mysql_pass
+		dbname: mysql_db
 	}
-	conn.connect() or { panic(err) }
-
+	conn.connect()!
+	defer {
+		conn.query('DROP TABLE IF EXISTS Module') or { eprintln(err) }
+		conn.query('DROP TABLE IF EXISTS User') or { eprintln(err) }
+		conn.close()
+	}
+	conn.query('DROP TABLE IF EXISTS Module') or { eprintln(err) }
+	conn.query('DROP TABLE IF EXISTS User') or { eprintln(err) }
+	//
 	sql conn {
 		create table Module
 	}
-
+	sql conn {
+		create table User
+	}
 	mod := Module{
 		name: 'test'
 		nr_downloads: 10
@@ -208,24 +246,27 @@ fn mysql() {
 			is_customer: true
 		}
 	}
-
 	sql conn {
 		insert mod into Module
 	}
-
 	m := sql conn {
 		select from Module where id == 1
 	}
-
 	eprintln(m)
-	conn.close()
 }
 
-fn psql() {
-	mut db := pg.connect(host: 'localhost', user: 'test', password: 'abc', dbname: 'test') or {
-		panic(err)
+fn psql() ! {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut db := pg.connect(host: pg_host, user: pg_user, password: pg_pass, dbname: pg_db)!
+	defer {
+		db.exec_one('drop table if exists "modules", "User"') or { eprintln(err) }
+		db.close()
 	}
-
+	db.exec_one('drop table if exists "modules", "User"') or { eprintln(err) }
+	sql db {
+		create table Module
+		create table User
+	}
 	mod := Module{
 		name: 'test'
 		nr_downloads: 10
@@ -235,23 +276,25 @@ fn psql() {
 			is_customer: true
 		}
 	}
-
-	sql db {
-		create table Module
-	}
-
 	sql db {
 		insert mod into Module
 	}
-
 	modul := sql db {
 		select from Module where id == 1
 	}
-
 	sql db {
 		drop table Module
 	}
-
 	eprintln(modul)
-	db.close()
+}
+
+fn main() {
+	eprintln('------------ ${@METHOD} -----------------')
+	sqlite3_array()!
+	msql_array()!
+	psql_array()!
+
+	sqlite3()!
+	msql()!
+	psql()!
 }

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -305,6 +305,12 @@ pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKin
 		}
 	}
 	str += ';'
+	$if trace_orm_stmt ? {
+		eprintln('> orm_stmt sql_dialect: ${sql_dialect} | table: ${table} | kind: ${kind} | query: ${str}')
+	}
+	$if trace_orm ? {
+		eprintln('> orm: ${str}')
+	}
 	return str, QueryData{
 		fields: data_fields
 		data: data_data
@@ -393,6 +399,12 @@ pub fn orm_select_gen(orm SelectConfig, q string, num bool, qm string, start_pos
 	}
 
 	str += ';'
+	$if trace_orm_query ? {
+		eprintln('> orm_query: ${str}')
+	}
+	$if trace_orm ? {
+		eprintln('> orm: ${str}')
+	}
 	return str
 }
 
@@ -515,6 +527,12 @@ pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, 
 	fs << unique_fields
 	str += fs.join(', ')
 	str += ');'
+	$if trace_orm_create ? {
+		eprintln('> orm_create table: ${table} | query: ${str}')
+	}
+	$if trace_orm ? {
+		eprintln('> orm: ${str}')
+	}
 	return str
 }
 


### PR DESCRIPTION
- orm: add tracing of the generated queries by the orm module, when a program is compiled with `-d trace_orm`
- examples: fix examples/database/orm.v, add comments, and ensure that the example can be run several times with no errors
