### PR TITLE
math.big: fix min i32 value bug

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -198,6 +198,11 @@ fn test_integer_from_string() {
 		y := big.integer_from_int(int_values[index])
 		assert x == y
 	}
+
+	imin := big.integer_from_string('-2147483648') or {
+		panic('Minimum signed 32-bit int test fails.')
+	}
+	assert imin.int() == -2147483648
 }
 
 fn test_integer_from_powers_of_2() {
@@ -412,7 +417,7 @@ fn test_get_bit() {
 		'0000000000000000000000000000000000000000010000', '1110010', '0001001']
 	for value in values {
 		a := big.integer_from_radix(value, 2) or { panic('Could not read binary') }
-		bits := []bool{len: value.len, init: value[value.len - 1 - it] == `1`}
+		bits := []bool{len: value.len, init: value[value.len - 1 - index] == `1`}
 		for i in 0 .. value.len {
 			assert a.get_bit(i) == bits[i]
 		}
@@ -441,7 +446,7 @@ fn test_bit_len() ? {
 
 	assert big.one_int.lshift(1239).bit_len() == 1240
 
-	mut num := big.integer_from_string('4338476092346017364013796407961305761039463198075691378460917856')?
+	mut num := big.integer_from_string('4338476092346017364013796407961305761039463198075691378460917856')!
 	assert num.bit_len() == 212
 	for num.bit_len() > 0 {
 		num = num.rshift(8)

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -203,6 +203,11 @@ fn test_integer_from_string() {
 		panic('Minimum signed 32-bit int test fails.')
 	}
 	assert imin.int() == -2147483648
+
+	imax := big.integer_from_string('2147483647') or {
+		panic('Maximum signed 32-bit int test fails.')
+	}
+	assert imax.int() == 2147483647
 }
 
 fn test_integer_from_powers_of_2() {

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -801,9 +801,10 @@ pub fn (a Integer) int() int {
 		return 0
 	}
 	// Check for minimum value int
-	if a.digits[0] == u32(-2147483648) {
+	if a.digits[0] == 2147483648 && a.signum == -1 {
 		return -2147483648
 	}
+	// Rest of the values should be fine
 	value := int(a.digits[0] & 0x7fffffff)
 	return value * a.signum
 }

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -801,7 +801,7 @@ pub fn (a Integer) int() int {
 		return 0
 	}
 	// Check for minimum value int
-	if a.digits[0] == -2147483648 {
+	if a.digits[0] == u32(-2147483648) {
 		return -2147483648
 	}
 	value := int(a.digits[0] & 0x7fffffff)

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -800,6 +800,10 @@ pub fn (a Integer) int() int {
 	if a.signum == 0 {
 		return 0
 	}
+	// Check for minimum value int
+	if a.digits[0] == -2147483648 {
+		return -2147483648
+	}
 	value := int(a.digits[0] & 0x7fffffff)
 	return value * a.signum
 }


### PR DESCRIPTION
- Add a special case for the minimum 32-bit signed integer value to fix #17637
- Update syntax