### PR TITLE
checker: fix embedded struct field with default value (fix #17758)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -118,17 +118,15 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 
 			if field.has_default_expr {
 				c.expected_type = field.typ
-				default_expr_type := c.expr(field.default_expr)
 				if !field.typ.has_flag(.option) && !field.typ.has_flag(.result) {
-					c.check_expr_opt_call(field.default_expr, default_expr_type)
+					c.check_expr_opt_call(field.default_expr, field.default_expr_typ)
 				}
-				struct_sym.info.fields[i].default_expr_typ = default_expr_type
 				interface_implemented := sym.kind == .interface_
-					&& c.type_implements(default_expr_type, field.typ, field.pos)
-				c.check_expected(default_expr_type, field.typ) or {
+					&& c.type_implements(field.default_expr_typ, field.typ, field.pos)
+				c.check_expected(field.default_expr_typ, field.typ) or {
 					if sym.kind == .interface_ && interface_implemented {
-						if !c.inside_unsafe && !default_expr_type.is_real_pointer() {
-							if c.table.sym(default_expr_type).kind != .interface_ {
+						if !c.inside_unsafe && !field.default_expr_typ.is_real_pointer() {
+							if c.table.sym(field.default_expr_typ).kind != .interface_ {
 								c.mark_as_referenced(mut &node.fields[i].default_expr,
 									true)
 							}

--- a/vlib/v/tests/embed_struct_field_default_value_test.v
+++ b/vlib/v/tests/embed_struct_field_default_value_test.v
@@ -1,0 +1,37 @@
+struct Papa {
+	fam_name string
+}
+
+pub struct Child {
+	Papa
+pub mut:
+	activity Activity = Fun.roll
+	age      u8       = 2
+}
+
+type Activity = Fun | Other
+
+pub enum Fun {
+	run
+	roll
+	jump
+}
+
+pub struct Other {}
+
+// Same struct without embedding just works.
+pub struct Human {
+	fam_name string
+pub mut:
+	activity Activity = Fun.roll
+	age      u8       = 2
+}
+
+fn test_embed_struct_field_default_value() {
+	c := Child{}
+	println(c.activity)
+	assert c.activity == Activity(Fun.roll)
+	h := Human{}
+	println(h.activity)
+	assert h.activity == Activity(Fun.roll)
+}


### PR DESCRIPTION
This PR fix embedded struct field with default value (fix #17758).

- Fix embedded struct field with default value.
- Add test.

```v
struct Papa {
	fam_name string
}

pub struct Child {
	Papa
pub mut:
	activity Activity = Fun.roll
	age      u8       = 2
}

type Activity = Fun | Other

pub enum Fun {
	run
	roll
	jump
}

pub struct Other {}

// Same struct without embedding just works.
pub struct Human {
	fam_name string
pub mut:
	activity Activity = Fun.roll
	age      u8       = 2
}

fn main() {
	c := Child{}
	println(c.activity)
	assert c.activity == Activity(Fun.roll)
	h := Human{}
	println(h.activity)
	assert h.activity == Activity(Fun.roll)
}

PS D:\Test\v\tt1> v run .
Activity(roll)
Activity(roll)
```