### PR TITLE
v: Fix concrete fn type that returns pair type as generic type

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2284,6 +2284,8 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 	}
 }
 
+// Extracts all type names from given types, notice that MultiReturn will be decompose 
+// and will not included in returned string
 pub fn (t &Table) get_generic_names(generic_types []Type) []string {
 	mut generic_names := []string{ cap: generic_types.len }
 	for typ in generic_types {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2284,6 +2284,28 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 	}
 }
 
+pub fn (t &Table) get_generic_names(generic_types []Type) []string {
+	mut generic_names := []string{ cap: generic_types.len }
+	for typ in generic_types {
+		if !typ.has_flag(.generic) {
+			continue
+		}
+
+		sym := t.sym(typ)
+		info := sym.info
+
+		match info {
+			MultiReturn {
+				generic_names << t.get_generic_names(info.types)
+			}
+			else {
+				generic_names << sym.name
+			}
+		}
+	}
+	return generic_names
+}
+
 pub fn (t &Table) is_comptime_type(x Type, y ComptimeType) bool {
 	x_kind := t.type_kind(x)
 	match y.kind {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2266,8 +2266,8 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 						}
 					}
 					if function.return_type.has_flag(.generic) {
-						if t_typ := t.resolve_generic_to_concrete(function.return_type, generic_names,
-							info.concrete_types)
+						if t_typ := t.resolve_generic_to_concrete(function.return_type,
+							generic_names, info.concrete_types)
 						{
 							function.return_type = t_typ
 						}
@@ -2285,10 +2285,10 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 	}
 }
 
-// Extracts all type names from given types, notice that MultiReturn will be decompose 
-com// and will not included in returned string
+// Extracts all type names from given types, notice that MultiReturn will be decompose
+// and will not included in returned string
 pub fn (t &Table) get_generic_names(generic_types []Type) []string {
-	mut generic_names := []string{ cap: generic_types.len }
+	mut generic_names := []string{cap: generic_types.len}
 	for typ in generic_types {
 		if !typ.has_flag(.generic) {
 			continue

--- a/vlib/v/tests/concrete_type_as_generic_type_test.v
+++ b/vlib/v/tests/concrete_type_as_generic_type_test.v
@@ -2,6 +2,8 @@ type Fn = fn (T)
 
 type FnReturn = fn (T) R
 
+type FnMultiReturn = fn (I) (O, R)
+
 fn func_fn_concrete() Fn[string] {
 	return fn (_s string) {}
 }
@@ -23,6 +25,12 @@ fn func_fn_return_dynamic[T, R]() FnReturn[T, R] {
 	}
 }
 
+fn func_fn_multi_return_concrete() FnMultiReturn[string, string, string] {
+	return fn (s string) (string, string) {
+		return s[..1], s[1..]
+	}
+}
+
 // vfmt will erase explicit generic type (bug)
 // vfmt off
 
@@ -31,6 +39,11 @@ fn test_concrete_function_type_as_generic_type() {
 	func_fn_dynamic[string]()('V')
 
 	assert func_fn_return_dynamic[string, int]()('100') == 100
+	
+	s1, s2 := func_fn_multi_return_concrete()('VLang')
+
+	assert s1 == 'V'
+	assert s2 == 'Lang'
 }
 
 // vfmt on

--- a/vlib/v/tests/concrete_type_as_generic_type_test.v
+++ b/vlib/v/tests/concrete_type_as_generic_type_test.v
@@ -31,7 +31,7 @@ fn func_fn_multi_return_concrete() FnMultiReturn[string, string, string] {
 	}
 }
 
-// vfmt will erase explicit generic type (bug)
+// vfmt will erase explicit generic type (bug reported in #17773)
 // vfmt off
 
 fn test_concrete_function_type_as_generic_type() {


### PR DESCRIPTION
- Fix #17778.
- Add tests

`concrete_type_as_generic_type_test.v`
```v
// ...

fn func_fn_multi_return_concrete() FnMultiReturn[string, string, string] {
	return fn (s string) (string, string) {
		return s[..1], s[1..]
	}
}

fn test_concrete_function_type_as_generic_type() {
	// ...
	s1, s2 := func_fn_multi_return_concrete()('VLang')

	assert s1 == 'V'
	assert s2 == 'Lang'
}
```