### PR TITLE
checker: fix missing check for option value on non-optional struct field assignment

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -490,6 +490,10 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				}
 				if !field_info.typ.has_flag(.option) && !field.typ.has_flag(.result) {
 					expr_type = c.check_expr_opt_call(field.expr, expr_type)
+					if expr_type.has_flag(.option) {
+						c.error('cannot assign an Option value to a non-option struct field',
+							field.pos)
+					}
 				}
 				expr_type_sym := c.table.sym(expr_type)
 				if field_type_sym.kind == .voidptr && expr_type_sym.kind == .struct_

--- a/vlib/v/checker/tests/option_fn_err.out
+++ b/vlib/v/checker/tests/option_fn_err.out
@@ -1,10 +1,17 @@
 vlib/v/checker/tests/option_fn_err.vv:40:9: error: assert can be used only with `bool` expressions, but found `bool` instead
-   38 | 
+   38 |
    39 |     // assert
    40 |     assert bar(true)
       |            ~~~~~~~~~
-   41 | 
+   41 |
    42 |     // struct
+vlib/v/checker/tests/option_fn_err.vv:45:3: error: cannot assign an Option value to a non-option struct field
+   43 |     mut v := Data{
+   44 |         f: fn (_ int) {}
+   45 |         value: bar(0)
+      |         ~~~~~~~~~~~~~
+   46 |         opt: bar(0)
+   47 |     }
 vlib/v/checker/tests/option_fn_err.vv:60:13: error: cannot use Option or Result as index (array type `[]int`)
    58 |     _ := [1]int{init: bar(0)}
    59 |     // index
@@ -31,5 +38,5 @@ vlib/v/checker/tests/option_fn_err.vv:69:18: error: type mismatch, `bar` must re
    68 |     println(arr.any(bar(true)))
    69 |     println(arr.all(bar(true)))
       |                     ~~~~~~~~~
-   70 | 
+   70 |
    71 |     match bar(0) {


### PR DESCRIPTION
This should fix #17781 

I hope I did not break anything and this is the right place for the check. 
This is my first try on a compiler related fix.