### PR TITLE
checker, cgen: fix asserting if guard expr (fix #17743)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1903,6 +1903,7 @@ fn (mut c Checker) stmt(node_ ast.Stmt) {
 
 fn (mut c Checker) assert_stmt(node ast.AssertStmt) {
 	cur_exp_typ := c.expected_type
+	c.expected_type = ast.bool_type
 	assert_type := c.check_expr_opt_call(node.expr, c.expr(node.expr))
 	if assert_type != ast.bool_type_idx {
 		atype_name := c.table.sym(assert_type).name

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -22,7 +22,10 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 	g.inside_ternary++
 	if g.pref.is_test {
 		g.write('if (')
+		prev_inside_ternary := g.inside_ternary
+		g.inside_ternary = 0
 		g.expr(node.expr)
+		g.inside_ternary = prev_inside_ternary
 		g.write(')')
 		g.decrement_inside_ternary()
 		g.writeln(' {')
@@ -35,7 +38,10 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 		g.writeln('}')
 	} else {
 		g.write('if (!(')
+		prev_inside_ternary := g.inside_ternary
+		g.inside_ternary = 0
 		g.expr(node.expr)
+		g.inside_ternary = prev_inside_ternary
 		g.write('))')
 		g.decrement_inside_ternary()
 		g.writeln(' {')

--- a/vlib/v/tests/assert_if_guard_expr_test.v
+++ b/vlib/v/tests/assert_if_guard_expr_test.v
@@ -1,0 +1,11 @@
+fn foo() !int {
+	return error('error')
+}
+
+fn test_assert_if_guard_expr() {
+	assert if _ := foo() {
+		false
+	} else {
+		true
+	}
+}


### PR DESCRIPTION
This PR fix asserting if guard expr (fix #17743).

- Fix asserting if guard expr.
- Add test.

```v
fn foo() !int {
	return error('error')
}

fn main() {
	assert if _ := foo() {
		false
	} else {
		true
	}
}

PS D:\Test\v\tt1> v run .
```