### PR TITLE
checker: check if guard returning non-propagate option or result (fix #17742)

### DIFF
--- a/examples/tcp_notify_echo_server.v
+++ b/examples/tcp_notify_echo_server.v
@@ -37,11 +37,11 @@ fn main() {
 					// someone is trying to connect
 					eprint('trying to connect.. ')
 					if conn := listener.accept() {
-						if _ := notifier.add(conn.sock.handle, .read | .peer_hangup) {
-							eprintln('connected')
-						} else {
+						notifier.add(conn.sock.handle, .read | .peer_hangup) or {
 							eprintln('error adding to notifier: ${err}')
+							return
 						}
+						eprintln('connected')
 					} else {
 						eprintln('unable to accept: ${err}')
 					}
@@ -57,11 +57,11 @@ fn main() {
 				else {
 					// remote connection
 					if event.kind.has(.peer_hangup) {
-						if _ := notifier.remove(event.fd) {
-							eprintln('remote disconnected')
-						} else {
+						notifier.remove(event.fd) or {
 							eprintln('error removing from notifier: ${err}')
+							return
 						}
+						eprintln('remote disconnected')
 					} else {
 						s, _ := os.fd_read(event.fd, 10)
 						os.fd_write(event.fd, s)

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -267,9 +267,6 @@ fn test_write_raw_at() {
 
 fn test_write_raw_at_negative_pos() {
 	mut f := os.open_file(tfile, 'w')!
-	if _ := f.write_raw_at(another_point, u64(-1)) {
-		assert false
-	}
 	f.write_raw_at(another_point, u64(-1)) or { assert err.msg() == 'Invalid argument' }
 	f.close()
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -267,6 +267,9 @@ fn test_write_raw_at() {
 
 fn test_write_raw_at_negative_pos() {
 	mut f := os.open_file(tfile, 'w')!
+	if _ := f.write_raw_at(another_point, u64(-1)) {
+		assert false
+	}
 	f.write_raw_at(another_point, u64(-1)) or { assert err.msg() == 'Invalid argument' }
 	f.close()
 }

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -71,6 +71,10 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			}
 		}
 		if mut branch.cond is ast.IfGuardExpr {
+			if branch.cond.expr_type.clear_flag(.option).clear_flag(.result) == ast.void_type {
+				c.error('if guard expects non-propagate option or result', branch.pos)
+				continue
+			}
 			sym := c.table.sym(branch.cond.expr_type)
 			if sym.kind == .multi_return {
 				mr_info := sym.info as ast.MultiReturn

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -71,7 +71,8 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			}
 		}
 		if mut branch.cond is ast.IfGuardExpr {
-			if branch.cond.expr_type.clear_flag(.option).clear_flag(.result) == ast.void_type {
+			if branch.cond.expr_type.clear_flag(.option).clear_flag(.result) == ast.void_type
+				&& !(branch.cond.vars.len == 1 && branch.cond.vars[0].name == '_') {
 				c.error('if guard expects non-propagate option or result', branch.pos)
 				continue
 			}

--- a/vlib/v/checker/tests/if_guard_expr_err.out
+++ b/vlib/v/checker/tests/if_guard_expr_err.out
@@ -1,14 +1,7 @@
-vlib/v/checker/tests/if_guard_expr_err.vv:6:10: warning: unused variable: `r`
-    4 |
-    5 | fn main() {
-    6 |     a := if r := foo() {
-      |             ^
-    7 |         true
-    8 |     } else {
 vlib/v/checker/tests/if_guard_expr_err.vv:6:7: error: if guard expects non-propagate option or result
     4 |
     5 | fn main() {
     6 |     a := if r := foo() {
       |          ~~~~~~~~~~~~~
-    7 |         true
-    8 |     } else {
+    7 |         println(r)
+    8 |         true

--- a/vlib/v/checker/tests/if_guard_expr_err.out
+++ b/vlib/v/checker/tests/if_guard_expr_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/if_guard_expr_err.vv:6:10: warning: unused variable: `r`
+    4 |
+    5 | fn main() {
+    6 |     a := if r := foo() {
+      |             ^
+    7 |         true
+    8 |     } else {
+vlib/v/checker/tests/if_guard_expr_err.vv:6:7: error: if guard expects non-propagate option or result
+    4 |
+    5 | fn main() {
+    6 |     a := if r := foo() {
+      |          ~~~~~~~~~~~~~
+    7 |         true
+    8 |     } else {

--- a/vlib/v/checker/tests/if_guard_expr_err.vv
+++ b/vlib/v/checker/tests/if_guard_expr_err.vv
@@ -4,6 +4,7 @@ fn foo() ! {
 
 fn main() {
 	a := if r := foo() {
+		println(r)
 		true
 	} else {
 		false

--- a/vlib/v/checker/tests/if_guard_expr_err.vv
+++ b/vlib/v/checker/tests/if_guard_expr_err.vv
@@ -1,0 +1,13 @@
+fn foo() ! {
+	return error("error")
+}
+
+fn main() {
+	a := if r := foo() {
+		true
+	} else {
+		false
+	}
+	
+	println(a)
+}


### PR DESCRIPTION
This PR check if guard returning non-propagate option or result (fix #17742).

- Check if guard returning non-propagate option or result.
- Add test.

```v
fn foo() ! {
	return error("error")
}

fn main() {
	a := if r := foo() {
		true
	} else {
		false
	}
	
	println(a)
}

PS D:\Test\v\tt1> v run .
tt1.v:6:10: warning: unused variable: `r`
    4 |
    5 | fn main() {
    6 |     a := if r := foo() {
      |             ^
    7 |         true
    8 |     } else {
tt1.v:6:7: error: if guard expects non-propagate option or result
    4 |
    5 | fn main() {
    6 |     a := if r := foo() {
      |          ~~~~~~~~~~~~~
    7 |         true
    8 |     } else {
```