### PR TITLE
cgen: fix fixed array of string item concatenation

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -419,10 +419,16 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 			mut op_expected_left := ast.Type(0)
 			mut op_expected_right := ast.Type(0)
 			if node.op == .plus_assign && unaliased_right_sym.kind == .string {
-				if left is ast.IndexExpr {
-					// a[0] += str => `array_set(&a, 0, &(string[]) {string__plus(...))})`
-					g.expr(left)
-					g.write('string__plus(')
+				if mut left is ast.IndexExpr {
+					if g.table.sym(left.left_type).kind == .array_fixed {
+						// strs[0] += str2 => `strs[0] = string__plus(strs[0], str2)`
+						g.expr(left)
+						g.write(' = string__plus(')
+					} else {
+						// a[0] += str => `array_set(&a, 0, &(string[]) {string__plus(...))})`
+						g.expr(left)
+						g.write('string__plus(')
+					}
 				} else {
 					// str += str2 => `str = string__plus(str, str2)`
 					g.expr(left)

--- a/vlib/v/tests/array_string_test.v
+++ b/vlib/v/tests/array_string_test.v
@@ -1,0 +1,11 @@
+fn test_array() {
+	mut strs := ['abc', 'cde']!
+	strs[0] += 'def'
+	assert strs[0] == 'abcdef'
+}
+
+fn test_fixed_array() {
+	mut strs := ['abc', 'cde']
+	strs[0] += 'def'
+	assert strs[0] == 'abcdef'
+}


### PR DESCRIPTION
Fix #17797 