### PR TITLE
checker: check generic struct types infering error

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -793,6 +793,9 @@ fn (mut c Checker) infer_struct_generic_types(typ ast.Type, node ast.StructInit)
 					}
 				}
 			}
+			c.error('could not infer generic type `${gt_name}` in generic struct `${sym.name}[${generic_names.join(', ')}]`',
+				node.pos)
+			return concrete_types
 		}
 	}
 	return concrete_types

--- a/vlib/v/checker/tests/generic_interface_err.out
+++ b/vlib/v/checker/tests/generic_interface_err.out
@@ -3,6 +3,12 @@ vlib/v/checker/tests/generic_interface_err.vv:10:1: warning: unused variable: `i
     9 | s := Struct{7}
    10 | i := Interface(s)
       | ^
+vlib/v/checker/tests/generic_interface_err.vv:9:6: error: could not infer generic type `T` in generic struct `Struct[T]`
+    7 | }
+    8 |
+    9 | s := Struct{7}
+      |      ~~~~~~~~~
+   10 | i := Interface(s)
 vlib/v/checker/tests/generic_interface_err.vv:10:6: error: can not find method `method` on `Struct`, needed for interface: `Interface`
     8 |
     9 | s := Struct{7}

--- a/vlib/v/checker/tests/generics_struct_infer_err.out
+++ b/vlib/v/checker/tests/generics_struct_infer_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generics_struct_infer_err.vv:7:10: error: could not infer generic type `U` in generic struct `Foo[T, U]`
+    5 |
+    6 | fn main() {
+    7 |     st11 := Foo{
+      |             ~~~~
+    8 |         a: 'two'
+    9 |     }

--- a/vlib/v/checker/tests/generics_struct_infer_err.vv
+++ b/vlib/v/checker/tests/generics_struct_infer_err.vv
@@ -1,0 +1,11 @@
+struct Foo[T, U] {
+	a T
+	b U
+}
+
+fn main() {
+	st11 := Foo{
+		a: 'two'
+	}
+	println(st11)
+}

--- a/vlib/v/checker/tests/generics_struct_init_err.out
+++ b/vlib/v/checker/tests/generics_struct_init_err.out
@@ -1,8 +1,8 @@
-vlib/v/checker/tests/generics_struct_init_err.vv:67:23: error: could not infer generic type `T` in call to `call`
+vlib/v/checker/tests/generics_struct_init_err.vv:67:8: error: could not infer generic type `T` in generic struct `FnHolder2[T]`
    65 |     ret = holder_call_22(neg, 5)
    66 |     assert ret == -5
    67 |     ret = FnHolder2{neg}.call(6)
-      |                          ~~~~~~~
+      |           ~~~~~~~~~~~~~~
    68 |     assert ret == -6
    69 | }
 vlib/v/checker/tests/generics_struct_init_err.vv:22:7: error: generic struct init must specify type parameter, e.g. Foo[T]

--- a/vlib/v/checker/tests/interface_generic_err.out
+++ b/vlib/v/checker/tests/interface_generic_err.out
@@ -3,6 +3,12 @@ vlib/v/checker/tests/interface_generic_err.vv:8:1: warning: unused variable: `wh
     7 | what := What{}
     8 | why := Why(what)
       | ~~~
+vlib/v/checker/tests/interface_generic_err.vv:7:9: error: could not infer generic type `T` in generic struct `What[T]`
+    5 |
+    6 | // no segfault without generic
+    7 | what := What{}
+      |         ~~~~~~
+    8 | why := Why(what)
 vlib/v/checker/tests/interface_generic_err.vv:8:8: error: could not infer generic type `T` in interface `Why`
     6 | // no segfault without generic
     7 | what := What{}


### PR DESCRIPTION
This PR check generic struct types infering error.

- Check generic struct types infering error.
- Add test.

```v
struct Foo[T, U] {
	a T
	b U
}

fn main() {
	st11 := Foo{
		a: 'two'
	}
	println(st11)
}

PS D:\Test\v\tt1> v run .
tt1.v:7:10: error: could not infer generic type `U` in generic struct `Foo[T, U]`
    5 | 
    6 | fn main() {
    7 |     st11 := Foo{
      |             ~~~~
    8 |         a: 'two'
    9 |     }
```