### PR TITLE
builder: src folder for module can have subfolders

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -346,6 +346,12 @@ pub fn (b Builder) v_files_from_dir(dir string) []string {
 				println('v_files_from_dir ("${src_path}") (/src/)')
 			}
 			files = os.ls(src_path) or { panic(err) }
+			src_path_offset := src_path.split('/').len
+			for file in os.walk_ext(src_path, '.v').map(it.split('/')#[src_path_offset..].join('/')) {
+				if !files.contains(file) {
+					files << file
+				}
+			}
 			return b.pref.should_compile_filtered_files(src_path, files)
 		}
 	}


### PR DESCRIPTION
`src` folder for package is a convenient way to organise v files. Adding to `src` folder subfolders that contain v files in the same module, provides a better organisation of v files inside `src` folder of a v package. 
I have tested this feature in my dev repo for v ui and it works like a charm even in submodules (`ui/component/src`). 

```
➜  ui git:(devel51) ✗ ls -l src                                                     ((arm64))
total 0
drwxr-xr-x   4 xxxx xxxxx  128  1 aoû  2022 assets
drwxr-xr-x   6  xxxx xxxxx  192 29 mar 12:01 draw_device
drwxr-xr-x   8  xxxx xxxxx 256 29 mar 12:02 extra
drwxr-xr-x  18  xxxx xxxxx  576 29 mar 12:04 interfaces
drwxr-xr-x   9  xxxx xxxxx  288 29 mar 12:20 layouts
drwxr-xr-x  18  xxxx xxxxx  576 29 mar 12:19 styles
drwxr-xr-x  17  xxxx xxxxx  544 29 mar 12:08 tools
drwxr-xr-x   8  xxxx xxxxx  256 29 mar 12:18 ui
drwxr-xr-x  20  xxxx xxxxx  640 29 mar 11:59 widgets
drwxr-xr-x   4  xxxx xxxxx  128 29 mar 12:20 window
drwxr-xr-x   3  xxxx xxxxx   96 29 mar 12:20 wm
```
No more need to prefix files to indicate categories of files.