### PR TITLE
checker: fix if cond with alias (fix #17818)

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -62,7 +62,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			} else {
 				// check condition type is boolean
 				c.expected_type = ast.bool_type
-				cond_typ := c.unwrap_generic(c.expr(branch.cond))
+				cond_typ := c.table.unaliased_type(c.unwrap_generic(c.expr(branch.cond)))
 				if (cond_typ.idx() != ast.bool_type_idx || cond_typ.has_flag(.option)
 					|| cond_typ.has_flag(.result)) && !c.pref.translated && !c.file.is_translated {
 					c.error('non-bool type `${c.table.type_to_str(cond_typ)}` used as if condition',

--- a/vlib/v/tests/if_cond_with_alias_test.v
+++ b/vlib/v/tests/if_cond_with_alias_test.v
@@ -1,0 +1,14 @@
+type BOOL = bool
+
+fn example() BOOL {
+	return true
+}
+
+fn test_if_cond_with_alias() {
+	if example() {
+		println('Should work, or not?')
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix if cond with alias (fix #17818).

- Fix if cond with alias.
- Add test.

```v
type BOOL = bool

fn example() BOOL {
	return true
}

fn main() {
	if example() {
		println('Should work, or not?')
		assert true
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
Should work, or not?
```