### PR TITLE
cgen: fix embed struct with sumtype field (fix #17811)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3491,7 +3491,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	mut sum_type_deref_field := ''
 	mut sum_type_dot := '.'
-	if f := g.table.find_field(sym, node.field_name) {
+	if f := g.table.find_field_with_embeds(sym, node.field_name) {
 		field_sym := g.table.sym(f.typ)
 		if field_sym.kind in [.sum_type, .interface_] {
 			if !prevent_sum_type_unwrapping_once {

--- a/vlib/v/tests/embed_struct_with_sumtype_field_test.v
+++ b/vlib/v/tests/embed_struct_with_sumtype_field_test.v
@@ -1,0 +1,28 @@
+type Prefix = [2]string | string
+
+struct FooStruct {
+	prefix Prefix
+}
+
+struct BarStruct {
+	FooStruct
+}
+
+fn (b BarStruct) print_prefix() string {
+	if b.prefix is [2]string {
+		eprint(b.prefix[0])
+		return b.prefix[0]
+	} else if b.prefix is string {
+		eprint(b.prefix)
+		return b.prefix
+	}
+	return ''
+}
+
+fn test_embed_struct_with_sumtype_field() {
+	b := BarStruct{
+		prefix: ['abc', 'bcd']!
+	}
+	ret := b.print_prefix()
+	assert ret == 'abc'
+}


### PR DESCRIPTION
This PR fix embed struct with sumtype field (fix #17811).

- Fix embed struct with sumtype field.
- Add test.

```v
type Prefix = [2]string | string

struct FooStruct {
	prefix Prefix
}

struct BarStruct {
	FooStruct
}

fn (b BarStruct) print_prefix() string {
	if b.prefix is [2]string {
		eprint(b.prefix[0])
		return b.prefix[0]
	} else if b.prefix is string {
		eprint(b.prefix)
		return b.prefix
	}
	return ''
}

fn main() {
	b := BarStruct{
		prefix: ['abc', 'bcd']!
	}
	ret := b.print_prefix()
	assert ret == 'abc'
}

PS D:\Test\v\tt1> v run .
abc
```