### PR TITLE
checker: fix generic struct init with update expr (fix #17824)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -295,7 +295,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 			}
 		}
 		if struct_sym.info.generic_types.len > 0 && struct_sym.info.concrete_types.len == 0
-			&& !node.is_short_syntax && c.table.cur_concrete_types.len != 0 {
+			&& !node.is_short_syntax && c.table.cur_concrete_types.len != 0
+			&& !is_field_zero_struct_init {
 			if node.generic_types.len == 0 {
 				c.error('generic struct init must specify type parameter, e.g. Foo[T]',
 					node.pos)
@@ -651,12 +652,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				if !node.has_update_expr && !field.has_default_expr && field.name !in inited_fields
 					&& !field.typ.is_ptr() && !field.typ.has_flag(.option)
 					&& c.table.final_sym(field.typ).kind == .struct_ {
-					mut generic_types := []ast.Type{}
-					if field.typ.has_flag(.generic) {
-						generic_types = node.generic_types.clone()
-					}
 					mut zero_struct_init := ast.StructInit{
-						generic_types: generic_types
 						pos: node.pos
 						typ: field.typ
 					}
@@ -664,12 +660,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				}
 			}
 			for embed in info.embeds {
-				mut generic_types := []ast.Type{}
-				if embed.has_flag(.generic) {
-					generic_types = node.generic_types.clone()
-				}
 				mut zero_struct_init := ast.StructInit{
-					generic_types: generic_types
 					pos: node.pos
 					typ: embed
 				}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -651,8 +651,12 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				if !node.has_update_expr && !field.has_default_expr && field.name !in inited_fields
 					&& !field.typ.is_ptr() && !field.typ.has_flag(.option)
 					&& c.table.final_sym(field.typ).kind == .struct_ {
+					mut generic_types := []ast.Type{}
+					if field.typ.has_flag(.generic) {
+						generic_types = node.generic_types.clone()
+					}
 					mut zero_struct_init := ast.StructInit{
-						generic_types: node.generic_types
+						generic_types: generic_types
 						pos: node.pos
 						typ: field.typ
 					}
@@ -660,8 +664,12 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				}
 			}
 			for embed in info.embeds {
+				mut generic_types := []ast.Type{}
+				if embed.has_flag(.generic) {
+					generic_types = node.generic_types.clone()
+				}
 				mut zero_struct_init := ast.StructInit{
-					generic_types: node.generic_types
+					generic_types: generic_types
 					pos: node.pos
 					typ: embed
 				}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -648,8 +648,9 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 							node.pos)
 					}
 				}
-				if !field.has_default_expr && field.name !in inited_fields && !field.typ.is_ptr()
-					&& !field.typ.has_flag(.option) && c.table.final_sym(field.typ).kind == .struct_ {
+				if !node.has_update_expr && !field.has_default_expr && field.name !in inited_fields
+					&& !field.typ.is_ptr() && !field.typ.has_flag(.option)
+					&& c.table.final_sym(field.typ).kind == .struct_ {
 					mut zero_struct_init := ast.StructInit{
 						pos: node.pos
 						typ: field.typ

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -652,6 +652,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					&& !field.typ.is_ptr() && !field.typ.has_flag(.option)
 					&& c.table.final_sym(field.typ).kind == .struct_ {
 					mut zero_struct_init := ast.StructInit{
+						generic_types: node.generic_types
 						pos: node.pos
 						typ: field.typ
 					}
@@ -660,6 +661,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 			}
 			for embed in info.embeds {
 				mut zero_struct_init := ast.StructInit{
+					generic_types: node.generic_types
 					pos: node.pos
 					typ: embed
 				}

--- a/vlib/v/tests/generic_struct_init_with_update_expr_test.v
+++ b/vlib/v/tests/generic_struct_init_with_update_expr_test.v
@@ -1,0 +1,31 @@
+pub struct Time[T] {
+pub mut:
+	start T
+	end   T
+}
+
+pub struct Transform[T] {
+pub mut:
+	time   Time[T]
+	before []T
+	after  []T
+}
+
+pub fn (t Transform[T]) clone() Transform[T] {
+	return Transform[T]{
+		...t
+	}
+}
+
+fn test_generic_struct_init_with_update_expr() {
+	a := Transform[f64]{
+		before: [0.0, 0.0]
+		after: [320.0, 240.0]
+	}
+
+	b := a.clone()
+
+	println(b)
+	assert b.before == a.before
+	assert b.after == a.after
+}

--- a/vlib/v/tests/generic_struct_init_with_update_expr_test.v
+++ b/vlib/v/tests/generic_struct_init_with_update_expr_test.v
@@ -17,6 +17,10 @@ pub fn (t Transform[T]) clone() Transform[T] {
 	}
 }
 
+pub fn (t Transform[T]) default() Transform[T] {
+	return Transform[T]{}
+}
+
 fn test_generic_struct_init_with_update_expr() {
 	a := Transform[f64]{
 		before: [0.0, 0.0]
@@ -24,8 +28,12 @@ fn test_generic_struct_init_with_update_expr() {
 	}
 
 	b := a.clone()
-
 	println(b)
 	assert b.before == a.before
 	assert b.after == a.after
+
+	c := a.default()
+	println(c)
+	assert c.before.len == 0
+	assert c.after.len == 0
 }


### PR DESCRIPTION
This PR fix generic struct init with update expr (fix #17824).

- Fix generic struct init with update expr.
- Add test.

```v
pub struct Time[T] {
pub mut:
	start T
	end   T
}

pub struct Transform[T] {
pub mut:
	time   Time[T]
	before []T
	after  []T
}

pub fn (t Transform[T]) clone() Transform[T] {
	return Transform[T]{
		...t
	}
}

pub fn (t Transform[T]) default() Transform[T] {
	return Transform[T]{}
}

fn main() {
	a := Transform[f64]{
		before: [0.0, 0.0]
		after: [320.0, 240.0]
	}

	b := a.clone()
	println(b)
	assert b.before == a.before
	assert b.after == a.after

	c := a.default()
	println(c)
	assert c.before.len == 0
	assert c.after.len == 0
}

PS D:\Test\v\tt1> v run .
Transform[f64]{
    time: Time[f64]{
        start: 0.0
        end: 0.0
    }
    before: [0.0, 0.0]
    after: [320.0, 240.0]
}
Transform[f64]{
    time: Time[f64]{
        start: 0.0
        end: 0.0
    }
    before: []
    after: []
}
```