### PR TITLE
ast, cgen: fix generic closures with different generic types (fix #17829)

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -581,7 +581,11 @@ fn (t Tree) anon_fn(node ast.AnonFn) &Node {
 	obj.add_terse('decl', t.fn_decl(node.decl))
 	obj.add('inherited_vars', t.array_node_arg(node.inherited_vars))
 	obj.add_terse('typ', t.type_node(node.typ))
-	obj.add('has_gen', t.bool_node(node.has_gen))
+	symbol_obj := new_object()
+	for key, val in node.has_gen {
+		symbol_obj.add_terse(key.str(), t.bool_node(val))
+	}
+	obj.add_terse('has_gen', symbol_obj)
 	return obj
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -508,7 +508,7 @@ pub mut:
 	decl           FnDecl
 	inherited_vars []Param
 	typ            Type // the type of anonymous fn. Both .typ and .decl.name are auto generated
-	has_gen        bool // has been generated
+	has_gen        map[string]bool // has been generated
 }
 
 // function or method declaration

--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -766,10 +766,14 @@ fn (mut g JsGen) fn_args(args []ast.Param, is_variadic bool) {
 }
 
 fn (mut g JsGen) gen_anon_fn(mut fun ast.AnonFn) {
-	if fun.has_gen {
+	mut fn_name := fun.decl.name
+	if fun.decl.generic_names.len > 0 {
+		fn_name = g.generic_fn_name(g.cur_concrete_types, fn_name)
+	}
+	if fun.has_gen[fn_name] {
 		return
 	}
-	fun.has_gen = true
+	fun.has_gen[fn_name] = true
 	it := fun.decl
 	cur_fn_decl := g.fn_decl
 	unsafe {

--- a/vlib/v/tests/generics_closures_with_different_generic_types_test.v
+++ b/vlib/v/tests/generics_closures_with_different_generic_types_test.v
@@ -1,0 +1,17 @@
+fn abc[T](x T) fn (p T) T {
+	return fn [x] [T](p T) T {
+		return p * x
+	}
+}
+
+fn test_generic_closures_with_different_generic_types() {
+	f := abc[int](12345)
+	a := f(2)
+	dump(a)
+	assert a == 24690
+
+	g := abc[u8](5)
+	b := g(2)
+	dump(b)
+	assert b == 10
+}


### PR DESCRIPTION
This PR fix generic closures with different generic types (fix #17829).

- Fix generic closures with different generic types.
- Add test.

```v
fn abc[T](x T) fn (p T) T {
	return fn [x] [T](p T) T {
		return p * x
	}
}

fn main() {
	f := abc[int](12345)
	a := f(2)
	dump(a)
	assert a == 24690

	g := abc[u8](5)
	b := g(2)
	dump(b)
	assert b == 10
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:10] a: 24690
[.\\tt1.v:15] b: 10
```