### PR TITLE
strings: simplify Builder.drain_builder; add test

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -87,7 +87,9 @@ pub fn (mut b Builder) write(data []u8) !int {
 // `other`, so that the `other` strings builder is ready to receive new content.
 [manualfree]
 pub fn (mut b Builder) drain_builder(mut other Builder, other_new_cap int) {
-	b.write(other) or { panic(err) }
+	if other.len > 0 {
+		b << *other
+	}
 	unsafe { other.free() }
 	other = new_builder(other_new_cap)
 }

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -129,3 +129,18 @@ fn test_ensure_cap() {
 	sb.ensure_cap(-1)
 	assert sb.cap == 15
 }
+
+fn test_drain_builder() {
+	mut sb := strings.new_builder(0)
+	mut target_sb := strings.new_builder(0)
+	assert sb.cap == 0
+	assert target_sb.cap == 0
+
+	sb.write_string('abc')
+	assert sb.len == 3
+
+	target_sb.drain_builder(mut sb, 0)
+	assert sb.len == 0
+	assert target_sb.len == 3
+	assert target_sb.str() == 'abc'
+}


### PR DESCRIPTION
Just a small cleanup of the strings.drain_builder method.
Reduces number of C warnings with latest clang on macos, in code using `strings` to 0.