### PR TITLE
cgen: Fix result of typeof function returns result type

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -479,6 +479,8 @@ fn (mut g Gen) fn_decl_str(info ast.FnType) string {
 		x := util.strip_main_name(g.table.get_type_name(g.unwrap_generic(info.func.return_type)))
 		if info.func.return_type.has_flag(.option) {
 			fn_str += ' ?${x}'
+		} else if info.func.return_type.has_flag(.result) {
+			fn_str += ' !${x}'
 		} else {
 			fn_str += ' ${x}'
 		}

--- a/vlib/v/tests/typeof_type_test.v
+++ b/vlib/v/tests/typeof_type_test.v
@@ -1,5 +1,7 @@
 fn test_typeof_fn() {
 	assert typeof[fn (s string, x u32) (int, f32)]().name == 'fn (string, u32) (int, f32)'
+	assert typeof[fn (s string, x u32) ?(int, f32)]().name == 'fn (string, u32) ?(int, f32)'
+	assert typeof[fn (s string, x u32) !(int, f32)]().name == 'fn (string, u32) !(int, f32)'
 }
 
 fn test_typeof_int() {


### PR DESCRIPTION
- Fix #17847.
- Add assertion test:

`vlib\v\tests\typeof_type_test.v`:
```v
fn test_typeof_fn() {
    // ...
    assert typeof[fn (s string, x u32) ?(int, f32)]().name == 'fn (string, u32) ?(int, f32)'
    assert typeof[fn (s string, x u32) !(int, f32)]().name == 'fn (string, u32) !(int, f32)'
    // ...
}
```