### PR TITLE
scanner: fix checking comments not terminated (fix #17842)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1063,8 +1063,7 @@ fn (mut s Scanner) text_scan() token.Token {
 					// Skip comment
 					for nest_count > 0 && s.pos < s.text.len - 1 {
 						s.pos++
-						if s.pos >= s.text.len {
-							s.line_nr--
+						if s.pos >= s.text.len - 1 {
 							s.error('comment not terminated')
 						}
 						if s.text[s.pos] == scanner.b_lf {

--- a/vlib/v/scanner/tests/comments_not_terminated_err.out
+++ b/vlib/v/scanner/tests/comments_not_terminated_err.out
@@ -1,0 +1,5 @@
+vlib/v/scanner/tests/comments_not_terminated_err.vv:7:2: error: comment not terminated
+    5 | /*
+    6 | fn tt() {
+    7 | }
+      |  ^

--- a/vlib/v/scanner/tests/comments_not_terminated_err.vv
+++ b/vlib/v/scanner/tests/comments_not_terminated_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	println('hello, world')
+}
+
+/*
+fn tt() {
+}


### PR DESCRIPTION
This PR fix checking comments not terminated (fix #17842).

- Fix checking comments not terminated.
- Add test.

```v

fn main() {
	println('hello, world')
}

/*
fn tt() {
}

PS D:\Test\v\tt1> v run .
tt1.v:8:2: error: comment not terminated
    6 | /*
    7 | fn tt() {
    8 | }
      |  ^
```