### PR TITLE
scanner: fix nested multiline comments (fix #17841)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1071,7 +1071,7 @@ fn (mut s Scanner) text_scan() token.Token {
 							s.inc_line_number()
 							continue
 						}
-						if s.expect('/*', s.pos) {
+						if s.expect('/*', s.pos) && s.text[s.pos + 2] != `/` {
 							nest_count++
 							continue
 						}

--- a/vlib/v/tests/nested_multiline_comments_test.v
+++ b/vlib/v/tests/nested_multiline_comments_test.v
@@ -1,5 +1,19 @@
-fn test_nested_multiline_comments() {
+fn test_nested_multiline_comments_1() {
 	/*//println(os.args)
 	*/
 	assert true
+}
+
+fn test_nested_multiline_comments_2() {
+	tt()
+	assert true
+}
+
+/*
+fn tt() {
+}
+//*/
+
+fn tt() {
+	println('hello, world')
 }


### PR DESCRIPTION
This PR fix nested multiline comments (fix #17841).

- Fix nested multiline comments.
- Add test.

```v

fn main() {
	tt()
	assert true
}

/*
fn tt() {
}
//*/

fn tt() {
	println('hello, world')
}

PS D:\Test\v\tt1> v run .
hello, world
```