### PR TITLE
cgen: fix gen_str_for_map() (fix #17854)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -740,8 +740,10 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	g.auto_str_funcs.writeln('static string indent_${str_fn_name}(${styp} m, int indent_count) { /* gen_str_for_map */')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(m.key_values.len*10);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("{"));')
+	g.auto_str_funcs.writeln('\tbool is_first = true;')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < m.key_values.len; ++i) {')
 	g.auto_str_funcs.writeln('\t\tif (!DenseArray_has_index(&m.key_values, i)) { continue; }')
+	g.auto_str_funcs.writeln('\t\telse if (!is_first) { strings__Builder_write_string(&sb, _SLIT(", ")); }')
 
 	if key_sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstring key = *(string*)DenseArray_key(&m.key_values, i);')
@@ -779,9 +781,7 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		ptr_str := '*'.repeat(if receiver_is_ptr { val_typ.nr_muls() - 1 } else { val_typ.nr_muls() })
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*${ptr_str}(${val_styp}*)DenseArray_value(&m.key_values, i)));')
 	}
-	g.auto_str_funcs.writeln('\t\tif (i != m.key_values.len-1) {')
-	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT(", "));')
-	g.auto_str_funcs.writeln('\t\t}')
+	g.auto_str_funcs.writeln('\t\tis_first = false;')
 	g.auto_str_funcs.writeln('\t}')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("}"));')
 	g.auto_str_funcs.writeln('\tstring res = strings__Builder_str(&sb);')

--- a/vlib/v/tests/map_to_string_test.v
+++ b/vlib/v/tests/map_to_string_test.v
@@ -47,3 +47,19 @@ fn test_interpolation_map_to_string() {
 	}
 	assert '${f}' == "{'hello': [1, 2, 3]}"
 }
+
+fn test_interpolation_map_to_string_with_delete() {
+	mut m1 := map[string]int{}
+	m1['one'] = 1
+	m1['two'] = 2
+	m1.delete('two')
+	println(m1)
+	assert '${m1}' == "{'one': 1}"
+
+	mut m2 := map[string]int{}
+	m2['one'] = 1
+	m2['two'] = 2
+	m2.delete('one')
+	println(m2)
+	assert '${m2}' == "{'two': 2}"
+}


### PR DESCRIPTION
This PR fix gen_str_for_map() (fix #17854).

- Fix gen_str_for_map().
- Add test.

```v
fn main() {
	mut m1 := map[string]int{}
	m1['one'] = 1
	m1['two'] = 2
	m1.delete('two')
	println(m1)
	assert '${m1}' == "{'one': 1}"

	mut m2 := map[string]int{}
	m2['one'] = 1
	m2['two'] = 2
	m2.delete('one')
	println(m2)
	assert '${m2}' == "{'two': 2}"
}

PS D:\Test\v\tt1> v run .       
{'one': 1}
{'two': 2}
```