### PR TITLE
checker: fix fn returning alias of pointer (fix #17861)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -229,9 +229,11 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 			c.error('fn `${c.table.cur_fn.name}` expects you to return a non reference type `${c.table.type_to_str(exp_type)}`, but you are returning `${c.table.type_to_str(got_typ)}` instead',
 				pos)
 		}
+		unaliased_got_typ := c.table.unaliased_type(got_typ)
 		if (exp_type.is_ptr() || exp_type.is_pointer())
-			&& (!got_typ.is_ptr() && !got_typ.is_pointer()) && got_typ != ast.int_literal_type
-			&& !c.pref.translated && !c.file.is_translated {
+			&& (!got_typ.is_ptr() && !got_typ.is_pointer())
+			&& (!unaliased_got_typ.is_ptr() && !unaliased_got_typ.is_pointer())
+			&& got_typ != ast.int_literal_type && !c.pref.translated && !c.file.is_translated {
 			pos := node.exprs[expr_idxs[i]].pos()
 			if node.exprs[expr_idxs[i]].is_auto_deref_var() {
 				continue

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -230,10 +230,9 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				pos)
 		}
 		unaliased_got_typ := c.table.unaliased_type(got_typ)
-		if (exp_type.is_ptr() || exp_type.is_pointer())
-			&& (!got_typ.is_ptr() && !got_typ.is_pointer())
-			&& (!unaliased_got_typ.is_ptr() && !unaliased_got_typ.is_pointer())
-			&& got_typ != ast.int_literal_type && !c.pref.translated && !c.file.is_translated {
+		if (exp_type.is_ptr() || exp_type.is_pointer()) && !got_typ.is_real_pointer()
+			&& !unaliased_got_typ.is_real_pointer() && got_typ != ast.int_literal_type
+			&& !c.pref.translated && !c.file.is_translated {
 			pos := node.exprs[expr_idxs[i]].pos()
 			if node.exprs[expr_idxs[i]].is_auto_deref_var() {
 				continue

--- a/vlib/v/tests/fn_return_alias_of_ptr_test.v
+++ b/vlib/v/tests/fn_return_alias_of_ptr_test.v
@@ -1,0 +1,16 @@
+type HANDLE = voidptr
+
+struct ExampleStruct {
+	handle HANDLE
+}
+
+fn get_ptr(arg ExampleStruct) voidptr {
+	return arg.handle
+}
+
+fn test_fn_return_alias_of_ptr() {
+	h := ExampleStruct{}
+	r := get_ptr(h)
+	println(r)
+	assert r == unsafe { nil }
+}


### PR DESCRIPTION
This PR fix fn returning alias of pointer (fix #17861).

- Fix fn returning alias of pointer.
- Add test.

```v
type HANDLE = voidptr

struct ExampleStruct {
	handle HANDLE
}

fn get_ptr(arg ExampleStruct) voidptr {
	return arg.handle
}

fn main() {
	h := ExampleStruct{}
	r := get_ptr(h)
	println(r)
	assert r == unsafe { nil }
}

PS D:\Test\v\tt1> v run .
0x0
```