### PR TITLE
cgen: Fix wrong indent generation in anon fn decl

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -379,6 +379,11 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 	prev_inside_ternary := g.inside_ternary
 	g.inside_ternary = 0
+	prev_indent := g.indent
+	g.indent = 0
+	defer {
+		g.indent = prev_indent
+	}
 	g.stmts(node.stmts)
 	g.inside_ternary = prev_inside_ternary
 	if node.is_noreturn {
@@ -530,11 +535,6 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	}
 	if node.has_gen[fn_name] {
 		return
-	}
-	prev_indent := g.indent
-	g.indent = 0
-	defer {
-		g.indent = prev_indent
 	}
 	node.has_gen[fn_name] = true
 	mut builder := strings.new_builder(256)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -531,6 +531,11 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	if node.has_gen[fn_name] {
 		return
 	}
+	prev_indent := g.indent
+	g.indent = 0
+	defer {
+		g.indent = prev_indent
+	}
 	node.has_gen[fn_name] = true
 	mut builder := strings.new_builder(256)
 	builder.writeln('/*F*/')


### PR DESCRIPTION
- Fix #17878.

**`Example 1`**
`Before`:
![image](https://user-images.githubusercontent.com/43753315/229870766-2b9340c0-1178-4436-805c-1ed7452b19e7.png)

`After`:
![image](https://user-images.githubusercontent.com/43753315/229870901-4472765d-b413-42cc-b8e6-3ff008b901c3.png)

**`Example 2`**
`Before`:
![image](https://user-images.githubusercontent.com/43753315/229872352-8ac346a8-4fda-4439-91fb-0ca094f68901.png)

`After`:
![image](https://user-images.githubusercontent.com/43753315/229872442-5b1fd6ec-86ff-42f7-ad0c-9d0774c1e47c.png)
