### PR TITLE
scanner: fix string interpolation string literal with fmt (fix #17865)

### DIFF
--- a/vlib/v/tests/string_interpolation_string_lit_with_fmt_test.v
+++ b/vlib/v/tests/string_interpolation_string_lit_with_fmt_test.v
@@ -1,0 +1,6 @@
+fn test_string_interpolation_string_lit_with_fmt() {
+	println('${'hello':-12s}')
+	assert '${'hello':-12s}' == 'hello       '
+	println('${'hello':12s}')
+	assert '${'hello':12s}' == '       hello'
+}


### PR DESCRIPTION
This PR fix string interpolation string literal with fmt (fix #17865).

- Fix string interpolation string literal with fmt.
- Add test.

```v
fn main() {
	println('${'hello':-12s}')
	assert '${'hello':-12s}' == 'hello       '
	println('${'hello':12s}')
	assert '${'hello':12s}' == '       hello'
}

PS D:\Test\v\tt1> v run .
hello
       hello
```