### PR TITLE
checker, cgen: fix type alias of pointer (fix #17860)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -219,8 +219,9 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 					pos)
 			}
 		}
-		if (got_typ.is_ptr() || got_typ.is_pointer())
-			&& (!exp_type.is_ptr() && !exp_type.is_pointer()) {
+		unaliased_exp_typ := c.table.unaliased_type(exp_type)
+		if got_typ.is_real_pointer() && !exp_type.is_real_pointer()
+			&& !unaliased_exp_typ.is_real_pointer() {
 			pos := node.exprs[expr_idxs[i]].pos()
 			if node.exprs[expr_idxs[i]].is_auto_deref_var() {
 				continue
@@ -230,7 +231,7 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				pos)
 		}
 		unaliased_got_typ := c.table.unaliased_type(got_typ)
-		if (exp_type.is_ptr() || exp_type.is_pointer()) && !got_typ.is_real_pointer()
+		if exp_type.is_real_pointer() && !got_typ.is_real_pointer()
 			&& !unaliased_got_typ.is_real_pointer() && got_typ != ast.int_literal_type
 			&& !c.pref.translated && !c.file.is_translated {
 			pos := node.exprs[expr_idxs[i]].pos()

--- a/vlib/v/tests/type_alias_of_pointer_types_test.v
+++ b/vlib/v/tests/type_alias_of_pointer_types_test.v
@@ -72,3 +72,24 @@ fn mut_alias(mut ps PZZMyStructInt) int {
 	//	dump(ptr_str(voidptr(ps)))
 	return 123
 }
+
+type HANDLE = voidptr
+
+fn example(arg voidptr) {
+	println('Handle value in function is: ${arg}')
+	assert '${arg}' == '0'
+}
+
+fn test_alias_of_pointer() {
+	handle := get_handle()
+
+	println('Actual handle value is: ${handle}')
+	println('Memory address of handle is: ${&handle}')
+
+	example(handle)
+	assert '${handle}' == '0'
+}
+
+fn get_handle() HANDLE {
+	return unsafe { nil }
+}


### PR DESCRIPTION
This PR fix type alias of pointer (fix #17860).

- Fix type alias of pointer.
- Add test.

```v
type HANDLE = voidptr

fn example(arg voidptr) {
	println('Handle value in function is: ${arg}')
	assert '${arg}' == '0'
}

fn main() {
	handle := get_handle()

	println('Actual handle value is: ${handle}')
	println('Memory address of handle is: ${&handle}')

	example(handle)
	assert '${handle}' == '0'
}

fn get_handle() HANDLE {
	return unsafe { nil }
}

PS D:\Test\v\tt1> v run .
Actual handle value is: 0
Memory address of handle is: 14efe58
Handle value in function is: 0
```