### PR TITLE
cgen: do not generate the stringified values for `assert x in y`, for the `pass` case

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -5,6 +5,12 @@ module c
 
 import v.ast
 
+enum AssertMetainfoKind {
+	pass
+	fail
+	panic
+}
+
 fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 	if !original_assert_statement.is_used {
 		return
@@ -29,10 +35,10 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 		g.write(')')
 		g.decrement_inside_ternary()
 		g.writeln(' {')
-		metaname_ok := g.gen_assert_metainfo(node)
+		metaname_ok := g.gen_assert_metainfo(node, .pass)
 		g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_assert_pass(test_runner._object, &${metaname_ok});')
 		g.writeln('} else {')
-		metaname_fail := g.gen_assert_metainfo(node)
+		metaname_fail := g.gen_assert_metainfo(node, .fail)
 		g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_assert_fail(test_runner._object, &${metaname_fail});')
 		g.gen_assert_postfailure_mode(node)
 		g.writeln('}')
@@ -45,7 +51,7 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 		g.write('))')
 		g.decrement_inside_ternary()
 		g.writeln(' {')
-		metaname_panic := g.gen_assert_metainfo(node)
+		metaname_panic := g.gen_assert_metainfo(node, .panic)
 		g.writeln('\t__print_assert_failure(&${metaname_panic});')
 		g.gen_assert_postfailure_mode(node)
 		g.writeln('}')
@@ -107,7 +113,7 @@ fn (mut g Gen) gen_assert_postfailure_mode(node ast.AssertStmt) {
 	}
 }
 
-fn (mut g Gen) gen_assert_metainfo(node ast.AssertStmt) string {
+fn (mut g Gen) gen_assert_metainfo(node ast.AssertStmt, kind AssertMetainfoKind) string {
 	mod_path := cestring(g.file.path)
 	fn_name := g.fn_decl.name
 	line_nr := node.pos.line_nr
@@ -131,12 +137,14 @@ fn (mut g Gen) gen_assert_metainfo(node ast.AssertStmt) string {
 			g.writeln('\t${metaname}.op = ${expr_op_str};')
 			g.writeln('\t${metaname}.llabel = ${expr_left_str};')
 			g.writeln('\t${metaname}.rlabel = ${expr_right_str};')
-			g.write('\t${metaname}.lvalue = ')
-			g.gen_assert_single_expr(node.expr.left, node.expr.left_type)
-			g.writeln(';')
-			g.write('\t${metaname}.rvalue = ')
-			g.gen_assert_single_expr(node.expr.right, node.expr.right_type)
-			g.writeln(';')
+			if kind != .pass {
+				g.write('\t${metaname}.lvalue = ')
+				g.gen_assert_single_expr(node.expr.left, node.expr.left_type)
+				g.writeln(';')
+				g.write('\t${metaname}.rvalue = ')
+				g.gen_assert_single_expr(node.expr.right, node.expr.right_type)
+				g.writeln(';')
+			}
 		}
 		ast.CallExpr {
 			g.writeln('\t${metaname}.op = _SLIT("call");')


### PR DESCRIPTION
The string values were not used in the test runner callbacks, and generating them may have non trivial costs, if your values are more deeply nested.

Also see: https://discord.com/channels/592103645835821068/592320321995014154/1094223536320696352 .