### PR TITLE
leb128: decoding returns number of bytes used for decoding

### DIFF
--- a/vlib/encoding/leb128/leb128.v
+++ b/vlib/encoding/leb128/leb128.v
@@ -66,8 +66,8 @@ pub fn encode_u32(value u32) []u8 {
 	return result
 }
 
-// decode_i32 decodes an i32 from the given leb128 encoded array `value`
-pub fn decode_i32(value []u8) i32 {
+// decode_i32 decodes an i32 and returns the number of bytes used from the given leb128 encoded array `value`
+pub fn decode_i32(value []u8) (i32, int) {
 	mut result := int(0)
 	mut shift := 0
 	for b in value {
@@ -80,11 +80,11 @@ pub fn decode_i32(value []u8) i32 {
 			break
 		}
 	}
-	return result
+	return result, shift / 7
 }
 
-// decode_i64 decodes an i64 from the given leb128 encoded array `value`
-pub fn decode_i64(value []u8) i64 {
+// decode_i64 decodes an i64 and returns the number of bytes used from the given leb128 encoded array `value`
+pub fn decode_i64(value []u8) (i64, int) {
 	mut result := u64(0)
 	mut shift := 0
 	for b in value {
@@ -97,11 +97,11 @@ pub fn decode_i64(value []u8) i64 {
 			break
 		}
 	}
-	return i64(result)
+	return i64(result), shift / 7
 }
 
-// decode_u64 decodes an u64 from the given leb128 encoded array `value`
-pub fn decode_u64(value []u8) u64 {
+// decode_u64 decodes an u64 and returns the number of bytes used from the given leb128 encoded array `value`
+pub fn decode_u64(value []u8) (u64, int) {
 	mut result := u64(0)
 	mut shift := 0
 	for b in value {
@@ -111,11 +111,11 @@ pub fn decode_u64(value []u8) u64 {
 		}
 		shift += 7
 	}
-	return result
+	return result, shift / 7 + 1
 }
 
-// decode_u32 decodes an u32 from the given leb128 encoded array `value`
-pub fn decode_u32(value []u8) u32 {
+// decode_u32 decodes an u32 and returns the number of bytes used from the given leb128 encoded array `value`
+pub fn decode_u32(value []u8) (u32, int) {
 	mut result := u32(0)
 	mut shift := 0
 	for b in value {
@@ -125,5 +125,5 @@ pub fn decode_u32(value []u8) u32 {
 		}
 		shift += 7
 	}
-	return result
+	return result, shift / 7 + 1
 }

--- a/vlib/encoding/leb128/leb128_test.v
+++ b/vlib/encoding/leb128/leb128_test.v
@@ -13,9 +13,13 @@ struct PairI {
 
 fn test_basic() {
 	assert leb128.encode_u64(624485) == [u8(0xe5), 0x8e, 0x26]
-	assert leb128.decode_u64([u8(0xe5), 0x8e, 0x26]) == 624485
+	uval, ulen := leb128.decode_u64([u8(0xe5), 0x8e, 0x26])
+	assert uval == 624485, 'val, _ := leb128.decode_u64([u8(0xe5), 0x8e, 0x26]) == 624486'
+	assert ulen == 3, '_, len := leb128.decode_u64([u8(0xe5), 0x8e, 0x26]) == 3'
 	assert leb128.encode_i64(-123456) == [u8(0xc0), 0xbb, 0x78]
-	assert leb128.decode_i64([u8(0xc0), 0xbb, 0x78]) == -123456
+	sval, slen := leb128.decode_i64([u8(0xc0), 0xbb, 0x78])
+	assert sval == -123456, 'val, _ := leb128.decode_i64([u8(0xc0), 0xbb, 0x78]) == -123456'
+	assert slen == 3, '_, len := leb128.decode_i64([u8(0xc0), 0xbb, 0x78]) == 3'
 }
 
 fn test_unsigned_data() {
@@ -23,7 +27,9 @@ fn test_unsigned_data() {
 		assert leb128.encode_u64(x.value).hex() == x.encoded, 'leb128.encode_u64( ${x.value} )  == ${x.encoded}'
 		bytes := hex.decode(x.encoded)!
 		// eprintln('>> bytes: ${bytes} | pair: ${x}')
-		assert leb128.decode_u64(bytes) == x.value, 'leb128.decode_u64( ${x.encoded} ) == ${x.value}'
+		val, len := leb128.decode_u64(bytes)
+		assert val == x.value, 'val, _ := leb128.decode_u64( ${x.encoded} ) == ${x.value}'
+		assert len == bytes.len, '_, len := leb128.decode_u64( ${x.encoded} ) = ${bytes.len}'
 	}
 }
 
@@ -32,7 +38,9 @@ fn test_signed_data() {
 		assert leb128.encode_i64(x.value).hex() == x.encoded, 'k: ${x.value} | v: ${x.encoded}'
 		bytes := hex.decode(x.encoded)!
 		// eprintln('>> bytes: ${bytes} | pair: ${x}')
-		assert leb128.decode_i64(bytes) == x.value, 'leb128.decode_i64( ${x.encoded} ) == ${x.value}'
+		val, len := leb128.decode_i64(bytes)
+		assert val == x.value, 'val, _ := leb128.decode_i64( ${x.encoded} ) == ${x.value}'
+		assert len == bytes.len, '_, len := leb128.decode_i64( ${x.encoded} ) == ${x.value}'
 	}
 }
 


### PR DESCRIPTION
The decoding functions in the module `encoding.leb128` returns the number of bytes used.

Leb128 allows to encode and decode values with variable length. The program won't know the length until the value has been decoded. Decoding the value and not knowing how long the encoded value was may not always(never) be helpful.

For example I have to `u64` values `34` and `69` encoded as leb128 in my `u8` array `[0x22, 0x45]`. After decoding the first value I still don't know where the encoded first value ends with the previous decoding function. But now I also have that information and can use it as offset to decode the second value too without knowing the encoded sizes of the values beforehand.