### PR TITLE
cgen: fix printing array of recursive reference struct (fix #17858)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -980,7 +980,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 		// handle circular ref type of struct to the struct itself
 		if styp == field_styp && !allow_circular {
 			if is_field_array {
-				fn_body.write_string('${funcprefix}_SLIT("[<circular>]")')
+				fn_body.write_string('it.${c_name(field.name)}.len > 0 ? ${funcprefix}_SLIT("[<circular>]") : ${funcprefix}_SLIT("[]")')
 			} else {
 				fn_body.write_string('${funcprefix}_SLIT("<circular>")')
 			}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -969,9 +969,21 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 				funcprefix += '*'
 			}
 		}
+		mut is_field_array := false
+		if sym.info is ast.Array {
+			field_styp = g.typ(sym.info.elem_type).trim('*')
+			is_field_array = true
+		} else if sym.info is ast.ArrayFixed {
+			field_styp = g.typ(sym.info.elem_type).trim('*')
+			is_field_array = true
+		}
 		// handle circular ref type of struct to the struct itself
 		if styp == field_styp && !allow_circular {
-			fn_body.write_string('${funcprefix}_SLIT("<circular>")')
+			if is_field_array {
+				fn_body.write_string('${funcprefix}_SLIT("[<circular>]")')
+			} else {
+				fn_body.write_string('${funcprefix}_SLIT("<circular>")')
+			}
 		} else {
 			// manage C charptr
 			if field.typ in ast.charptr_types {

--- a/vlib/v/slow_tests/inout/printing_recursive_array_of_reference_struct.out
+++ b/vlib/v/slow_tests/inout/printing_recursive_array_of_reference_struct.out
@@ -1,0 +1,5 @@
+&Person{
+    name: 'John'
+    relatives: [<circular>]
+}
+Success

--- a/vlib/v/slow_tests/inout/printing_recursive_array_of_reference_struct.vv
+++ b/vlib/v/slow_tests/inout/printing_recursive_array_of_reference_struct.vv
@@ -1,0 +1,18 @@
+struct Person {
+	name string
+mut:
+	relatives []&Person
+}
+
+fn main() {
+	mut father := &Person{
+		name: 'John'
+	}
+	mut mother := &Person{
+		name: 'Jane'
+		relatives: [father]
+	}
+	father.relatives = [mother]
+	println(father)
+	println('Success')
+}


### PR DESCRIPTION
This PR fix printing array of recursive reference struct (fix #17858).

- Fix printing array of recursive reference struct.
- Add test.

```v
struct Person {
	name string
mut:
	relatives []&Person
}

fn main() {
	mut father := &Person{
		name: 'John'
	}
	mut mother := &Person{
		name: 'Jane'
		relatives: [father]
	}
	father.relatives = [mother]
	println(father)
	println('Success')
}

PS D:\Test\v\tt1> v run .
&Person{
    name: 'John'
    relatives: [<circular>]
}
Success
```