### PR TITLE
json2: fix: encode maps with maps like map[string]map[string]int

### DIFF
--- a/vlib/x/json2/encode_struct_test.v
+++ b/vlib/x/json2/encode_struct_test.v
@@ -265,11 +265,11 @@ fn test_maps() {
 			'1': 1
 		}
 	}) == '{"val":{"1":1}}'
-	// assert json.encode(StructType[map[string]map[string]int]{
-	// 	val: {
-	// 		'a': {
-	// 			'1': 1
-	// 		}
-	// 	}
-	// }) == '{"val":{"a":{"1":1}}}'
+	assert json.encode(StructType[map[string]map[string]int]{
+		val: {
+			'a': {
+				'1': 1
+			}
+		}
+	}) == '{"val":{"a":{"1":1}}}'
 }


### PR DESCRIPTION
```v
	assert json.encode(StructType[map[string]map[string]int]{
		val: {
			'a': {
				'1': 1
			}
		}
	}) == '{"val":{"a":{"1":1}}}'
```