### PR TITLE
cgen: fix generic method on nested struct (fix #17929)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1157,6 +1157,10 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			typ_sym = g.table.sym(unwrapped_rec_type)
 		}
 	}
+	if node.from_embed_types.len > 0 && !typ_sym.has_method(node.name) {
+		unwrapped_rec_type = node.from_embed_types.last()
+		typ_sym = g.table.sym(unwrapped_rec_type)
+	}
 	rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 	mut receiver_type_name := util.no_dots(rec_cc_type)
 	if typ_sym.kind == .interface_ && (typ_sym.info as ast.Interface).defines_method(node.name) {

--- a/vlib/v/tests/generics_method_on_nested_struct3_test.v
+++ b/vlib/v/tests/generics_method_on_nested_struct3_test.v
@@ -1,0 +1,32 @@
+struct Context {}
+
+pub fn (mut ctx Context) default_route() string {
+	println('from Context')
+	return 'from Context'
+}
+
+struct App {
+	Context
+}
+
+struct Other {
+	Context
+}
+
+pub fn (mut app Other) default_route() string {
+	println('from Other')
+	return 'from Other'
+}
+
+fn test_generic_method_on_nested_struct() {
+	mut app := &App{}
+	ret1 := call_generic(mut app)
+	assert ret1 == 'from Context'
+	mut other := &Other{}
+	ret2 := call_generic(mut other)
+	assert ret2 == 'from Other'
+}
+
+fn call_generic[T](mut app T) string {
+	return app.default_route()
+}


### PR DESCRIPTION
This PR fix generic method on nested struct (fix #17929).

- Fix generic method on nested struct.
- Add test.

```v
struct Context {}

pub fn (mut ctx Context) default_route() string {
	println('from Context')
	return 'from Context'
}

struct App {
	Context
}

struct Other {
	Context
}

pub fn (mut app Other) default_route() string {
	println('from Other')
	return 'from Other'
}

fn main() {
	mut app := &App{}
	ret1 := call_generic(mut app)
	assert ret1 == 'from Context'
	mut other := &Other{}
	ret2 := call_generic(mut other)
	assert ret2 == 'from Other'
}

fn call_generic[T](mut app T) string {
	return app.default_route()
}

PS D:\Test\v\tt1> v run .
from Context
from Other
```