### PR TITLE
builtin/string: correct small documentation mistake

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -633,9 +633,9 @@ pub fn (s string) u64() u64 {
 
 // parse_uint is like `parse_int` but for unsigned numbers
 //
-// This method directly exposes the `parse_int` function from `strconv`
+// This method directly exposes the `parse_uint` function from `strconv`
 // as a method on `string`. For more advanced features,
-// consider calling `strconv.common_parse_int` directly.
+// consider calling `strconv.common_parse_uint` directly.
 [inline]
 pub fn (s string) parse_uint(_base int, _bit_size int) !u64 {
 	return strconv.parse_uint(s, _base, _bit_size)
@@ -654,9 +654,9 @@ pub fn (s string) parse_uint(_base int, _bit_size int) !u64 {
 // correspond to int, int8, int16, int32, and int64.
 // If bitSize is below 0 or above 64, an error is returned.
 //
-// This method directly exposes the `parse_uint` function from `strconv`
+// This method directly exposes the `parse_int` function from `strconv`
 // as a method on `string`. For more advanced features,
-// consider calling `strconv.common_parse_uint` directly.
+// consider calling `strconv.common_parse_int` directly.
 [inline]
 pub fn (s string) parse_int(_base int, _bit_size int) !i64 {
 	return strconv.parse_int(s, _base, _bit_size)


### PR DESCRIPTION
In file [builtin/string.v](https://github.com/vlang/v/blob/master/vlib/builtin/string.v), the documentation inverts `common_parse_uint()` and `common_parse_int()` for `parse_uint()` and `parse_int()`: `parse_int` exposes `common_parse_int` but not `common_parse_uint` as mentionned, and vice versa.

(This pr doesn't affect any functionnal code)