### PR TITLE
wasm module: globals, constant expressions and function reference types

### DIFF
--- a/vlib/wasm/constant.v
+++ b/vlib/wasm/constant.v
@@ -1,0 +1,140 @@
+module wasm
+
+import encoding.leb128
+
+// constexpr_value returns a constant expression that evaluates to a single value.
+pub fn constexpr_value[T](v T) ConstExpression {
+	mut expr := ConstExpression{}
+	
+	$if T is i64 {
+		expr.i64_const(v)
+	} $else $if T is $int {
+		expr.i32_const(v)
+	} $else $if T is f32 {
+		expr.f32_const(v)
+	} $else $if T is f64 {
+		expr.f64_const(v)
+	} $else {
+		$compile_error("values can only be int, i32, i64, f32, f64")
+	}
+
+	return expr
+}
+
+// constexpr_ref_null returns a constant expression that evaluates to a null reference.
+pub fn constexpr_ref_null(rt RefType) ConstExpression {
+	mut expr := ConstExpression{}
+	
+	expr.ref_null(rt)
+
+	return expr
+}
+
+// WebAssembly constant expressions are permitted to use a subset of valid instructions.
+pub struct ConstExpression {
+mut:
+	call_patches []CallPatch
+	code         []u8
+}
+
+// i32_const places a constant i32 value on the stack.
+// WebAssembly instruction: `i32.const`.
+pub fn (mut expr ConstExpression) i32_const(v i32) {
+	expr.code << 0x41 // i32.const
+	expr.code << leb128.encode_i32(v)
+}
+
+// i64_const places a constant i64 value on the stack.
+// WebAssembly instruction: `i64.const`.
+pub fn (mut expr ConstExpression) i64_const(v i64) {
+	expr.code << 0x42 // i64.const
+	expr.code << leb128.encode_i64(v)
+}
+
+// f32_const places a constant f32 value on the stack.
+// WebAssembly instruction: `f32.const`.
+pub fn (mut expr ConstExpression) f32_const(v f32) {
+	expr.code << 0x43 // f32.const
+	push_f32(mut expr.code, v)
+}
+
+// f64_const places a constant f64 value on the stack.
+// WebAssembly instruction: `f64.const`.
+pub fn (mut expr ConstExpression) f64_const(v f64) {
+	expr.code << 0x44 // f64.const
+	push_f64(mut expr.code, v)
+}
+
+// add adds two values on the stack with type `typ`.
+// WebAssembly instructions: `i32|i64.add`.
+pub fn (mut expr ConstExpression) add(typ NumType) {
+	assert typ in [.i32_t, .i64_t]
+
+	match typ {
+		.i32_t { expr.code << 0x6A } // i32.add
+		.i64_t { expr.code << 0x7C } // i64.add
+		else {}
+	}
+}
+
+// sub subtracts two values on the stack with type `typ`.
+// WebAssembly instructions: `i32|i64.sub`.
+pub fn (mut expr ConstExpression) sub(typ NumType) {
+	assert typ in [.i32_t, .i64_t]
+
+	match typ {
+		.i32_t { expr.code << 0x6B } // i32.sub
+		.i64_t { expr.code << 0x7D } // i64.sub
+		else {}
+	}
+}
+
+// mul multiplies two values on the stack with type `typ`.
+// WebAssembly instructions: `i32|i64.mul`.
+pub fn (mut expr ConstExpression) mul(typ NumType) {
+	assert typ in [.i32_t, .i64_t]
+
+	match typ {
+		.i32_t { expr.code << 0x6C } // i32.mul
+		.i64_t { expr.code << 0x7E } // i64.mul
+		else {}
+	}
+}
+
+// global_get places the value of the global at the index `global` on the stack.
+// Constant expressions are only allowed to refer to imported globals.
+// WebAssembly instruction: `global.get`.
+pub fn (mut expr ConstExpression) global_get(global GlobalImportIndex) {
+	expr.code << 0x23 // global.get
+	expr.code << leb128.encode_u32(u32(global))
+}
+
+// ref_null places a null reference on the stack.
+// WebAssembly instruction: `ref.null`.
+pub fn (mut expr ConstExpression) ref_null(rt RefType) {
+	expr.code << 0xD0 // ref.null
+	expr.code << u8(rt)
+}
+
+// ref_func places a reference to a function with `name` on the stack.
+// If this function does not exist when calling `compile` on the module, it will panic.
+// WebAssembly instruction: `ref.func`.
+pub fn (mut expr ConstExpression) ref_func(name string) {
+	expr.code << 0xD2 // ref.func
+	expr.call_patches << FunctionCallPatch{
+		name: name
+		pos: expr.code.len
+	}
+}
+
+// ref_func places a reference to an imported function with `name` on the stack.
+// If the imported function does not exist when calling `compile` on the module, it will panic.
+// WebAssembly instruction: `ref.func`.
+pub fn (mut expr ConstExpression) ref_func_import(mod string, name string) {
+	expr.code << 0xD2 // ref.func
+	expr.call_patches << ImportCallPatch{
+		mod: mod
+		name: name
+		pos: expr.code.len
+	}
+}

--- a/vlib/wasm/constant.v
+++ b/vlib/wasm/constant.v
@@ -5,7 +5,7 @@ import encoding.leb128
 // constexpr_value returns a constant expression that evaluates to a single value.
 pub fn constexpr_value[T](v T) ConstExpression {
 	mut expr := ConstExpression{}
-	
+
 	$if T is i64 {
 		expr.i64_const(v)
 	} $else $if T is $int {
@@ -15,7 +15,7 @@ pub fn constexpr_value[T](v T) ConstExpression {
 	} $else $if T is f64 {
 		expr.f64_const(v)
 	} $else {
-		$compile_error("values can only be int, i32, i64, f32, f64")
+		$compile_error('values can only be int, i32, i64, f32, f64')
 	}
 
 	return expr
@@ -24,7 +24,7 @@ pub fn constexpr_value[T](v T) ConstExpression {
 // constexpr_ref_null returns a constant expression that evaluates to a null reference.
 pub fn constexpr_ref_null(rt RefType) ConstExpression {
 	mut expr := ConstExpression{}
-	
+
 	expr.ref_null(rt)
 
 	return expr

--- a/vlib/wasm/functions.v
+++ b/vlib/wasm/functions.v
@@ -13,16 +13,22 @@ struct FunctionCallPatch {
 
 type CallPatch = FunctionCallPatch | ImportCallPatch
 
-struct Function {
+struct FunctionGlobalPatch {
+	idx GlobalIndex
+	pos int
+}
+
+pub struct Function {
 	tidx int
 	idx  int
 mut:
-	call_patches []CallPatch
-	label        int
-	export       bool
-	mod          &Module
-	code         []u8
-	locals       []ValType
+	call_patches   []CallPatch
+	global_patches []FunctionGlobalPatch
+	label          int
+	export         bool
+	mod            &Module = unsafe { nil }
+	code           []u8
+	locals         []ValType
 pub:
 	name string
 }

--- a/vlib/wasm/tests/block_test.v
+++ b/vlib/wasm/tests/block_test.v
@@ -22,7 +22,7 @@ fn validate(mod []u8) ! {
 	proc.close()
 }
 
-fn test_add() {
+fn test_block() {
 	mut m := wasm.Module{}
 	mut a1 := m.new_function('param', [], [.i32_t])
 	{

--- a/vlib/wasm/tests/call_test.v
+++ b/vlib/wasm/tests/call_test.v
@@ -22,7 +22,7 @@ fn validate(mod []u8) ! {
 	proc.close()
 }
 
-fn test_add() {
+fn test_call() {
 	mut m := wasm.Module{}
 	mut a1 := m.new_function('const-i32', [], [.i32_t])
 	{

--- a/vlib/wasm/tests/var_test.v
+++ b/vlib/wasm/tests/var_test.v
@@ -25,7 +25,7 @@ fn validate(mod []u8) ! {
 fn test_globals() {
 	mut m := wasm.Module{}
 
-	vsp := m.new_global("__vsp", .i32_t, true, wasm.constexpr_value(10))
+	vsp := m.new_global('__vsp', .i32_t, true, wasm.constexpr_value(10))
 	mut func := m.new_function('vsp', [], [.i32_t])
 	{
 		func.global_get(vsp)
@@ -35,8 +35,8 @@ fn test_globals() {
 		func.global_get(vsp)
 	}
 	m.commit(func, true)
-	
-	fref := m.new_global("__ref", .funcref_t, true, wasm.constexpr_ref_null(.funcref_t))
+
+	fref := m.new_global('__ref', .funcref_t, true, wasm.constexpr_ref_null(.funcref_t))
 	mut func1 := m.new_function('ref', [], [])
 	{
 		func1.ref_func('vsp')
@@ -44,7 +44,7 @@ fn test_globals() {
 	}
 	m.commit(func1, true)
 
-	gimport := m.new_global_import("env", "__import", .f64_t, false)
+	gimport := m.new_global_import('env', '__import', .f64_t, false)
 	mut func2 := m.new_function('import', [], [.f64_t])
 	{
 		func2.global_get(gimport)

--- a/vlib/wasm/tests/var_test.v
+++ b/vlib/wasm/tests/var_test.v
@@ -1,0 +1,55 @@
+import wasm
+import os
+
+const exe = os.find_abs_path_of_executable('wasm-validate') or { exit(0) }
+
+fn validate(mod []u8) ! {
+	mut proc := os.new_process(exe)
+	proc.set_args(['-'])
+	proc.set_redirect_stdio()
+	proc.run()
+	{
+		os.fd_write(proc.stdio_fd[0], mod.bytestr())
+		os.fd_close(proc.stdio_fd[0])
+	}
+	proc.wait()
+	if proc.status != .exited {
+		return error('wasm-validate exited abormally')
+	}
+	if proc.code != 0 {
+		return error('wasm-validate exited with a non zero exit code')
+	}
+	proc.close()
+}
+
+fn test_globals() {
+	mut m := wasm.Module{}
+
+	vsp := m.new_global("__vsp", .i32_t, true, wasm.constexpr_value(10))
+	mut func := m.new_function('vsp', [], [.i32_t])
+	{
+		func.global_get(vsp)
+		func.i32_const(20)
+		func.add(.i32_t)
+		func.global_set(vsp)
+		func.global_get(vsp)
+	}
+	m.commit(func, true)
+	
+	fref := m.new_global("__ref", .funcref_t, true, wasm.constexpr_ref_null(.funcref_t))
+	mut func1 := m.new_function('ref', [], [])
+	{
+		func1.ref_func('vsp')
+		func1.global_set(fref)
+	}
+	m.commit(func1, true)
+
+	gimport := m.new_global_import("env", "__import", .f64_t, false)
+	mut func2 := m.new_function('import', [], [.f64_t])
+	{
+		func2.global_get(gimport)
+	}
+	m.commit(func2, true)
+
+	validate(m.compile()) or { panic(err) }
+}


### PR DESCRIPTION
Implement global variables, and initialisation with constant expressions. Also implemented function reference types and cleaned up the code.

As I have mentioned before, if the tests pass on my PC they will pass on others. The V CI also does not contain special CI for testing the wasm module. Skipping CI would be preferrable.

```v
import wasm

fn main() {
	mut m := wasm.Module{}

	// global, export: "__vsp", type: i32, mutable: true, init: i32.const 10
	vsp := m.new_global("__vsp", .i32_t, true, wasm.constexpr_value(10))
	mut func := m.new_function('vsp', [], [.i32_t])
	{
		func.global_get(vsp)
		func.i32_const(20)
		func.add(.i32_t)
		func.global_set(vsp)
		func.global_get(vsp)
	}
	m.commit(func, true)
}
````

\- l-m