### PR TITLE
vweb: fix multipart_form parsing

### DIFF
--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -71,7 +71,9 @@ fn parse_form_from_request(request http.Request) !(map[string]string, map[string
 			if boundary.len != 1 {
 				return error('detected more that one form-data boundary')
 			}
-			form, files = http.parse_multipart_form(request.data, boundary[0][9..])
+			// omit 'boundary="' and the last '"'
+			boundary_str := boundary[0].substr(10, boundary[0].len - 1)
+			form, files = http.parse_multipart_form(request.data, boundary_str)
 		} else {
 			form = http.parse_form(request.data)
 		}

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -205,29 +205,39 @@ fn test_http_client_json_post() {
 }
 
 fn test_http_client_multipart_form_data() {
-	boundary := '6844a625b1f0b299'
-	name := 'foo'
-	ct := 'multipart/form-data; boundary=${boundary}'
-	contents := 'baz buzz'
-	data := '--${boundary}\r
-Content-Disposition: form-data; name="${name}"\r
-\r
-${contents}\r
---${boundary}--\r
-'
-	mut x := http.fetch(
-		url: 'http://${localserver}/form_echo'
-		method: .post
-		header: http.new_header(
-			key: .content_type
-			value: ct
-		)
-		data: data
-	)!
+	mut form_config := http.PostMultipartFormConfig{
+		form: {
+			'foo': 'baz buzz'
+		}
+	}
+	println(form_config.header)
+
+	mut x := http.post_multipart_form('http://${localserver}/form_echo', form_config)!
+	println(form_config.header)
+
 	$if debug_net_socket_client ? {
 		eprintln('/form_echo endpoint response: ${x}')
 	}
-	assert x.body == contents
+	assert x.body == form_config.form['foo']
+
+	mut files := []http.FileData{}
+	files << http.FileData{
+		filename: 'vweb'
+		content_type: 'text'
+		data: '"vweb test"'
+	}
+
+	mut form_config_files := http.PostMultipartFormConfig{
+		files: {
+			'file': files
+		}
+	}
+
+	x = http.post_multipart_form('http://${localserver}/file_echo', form_config_files)!
+	$if debug_net_socket_client ? {
+		eprintln('/form_echo endpoint response: ${x}')
+	}
+	assert x.body == files[0].data
 }
 
 fn test_http_client_shutdown_does_not_work_without_a_cookie() {

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -210,10 +210,8 @@ fn test_http_client_multipart_form_data() {
 			'foo': 'baz buzz'
 		}
 	}
-	println(form_config.header)
 
 	mut x := http.post_multipart_form('http://${localserver}/form_echo', form_config)!
-	println(form_config.header)
 
 	$if debug_net_socket_client ? {
 		eprintln('/form_echo endpoint response: ${x}')

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -95,6 +95,16 @@ pub fn (mut app App) form_echo() vweb.Result {
 	return app.ok(app.form['foo'])
 }
 
+['/file_echo'; post]
+pub fn (mut app App) file_echo() vweb.Result {
+	if 'file' !in app.files {
+		app.set_status(500, '')
+		return app.text('no file')
+	}
+
+	return app.text(app.files['file'][0].data)
+}
+
 // Make sure [post] works without the path
 [post]
 pub fn (mut app App) json() vweb.Result {


### PR DESCRIPTION
vweb fix multipart form parsing.

The boundary argument was passed as string `"boundary"` in `parse.v`, but `parse_multipart_form` expects only the string `boundary` without quotes. I updated the boundary to be correct. and changed the tests to use the `net.http.post_multipart_form` function instead of passing the data raw.
