### PR TITLE
net: correct a small documentation mistake

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -48,7 +48,7 @@ pub fn new_request(method Method, url_ string, data string) Request {
 	}
 }
 
-// get sends a GET HTTP request to the give `url`.
+// get sends a GET HTTP request to the given `url`.
 pub fn get(url string) !Response {
 	return fetch(method: .get, url: url)
 }


### PR DESCRIPTION
net/http/http.v contains a small typo on the ```get``` function. Doc string says ```get sends a GET HTTP request to the give `url`.``` but should say ```get sends a GET HTTP request to the given `url`.``` like the other doc strings appear