### PR TITLE
parser: fix comptime_for in repl (script mode) (fix #5976)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -751,15 +751,20 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 				if p.peek_tok.kind == .eof {
 					return p.unexpected(got: 'eof')
 				}
-				if_expr := p.if_expr(true)
-				cur_stmt := ast.ExprStmt{
-					expr: if_expr
-					pos: if_expr.pos
-				}
-				if comptime_if_expr_contains_top_stmt(if_expr) {
-					return cur_stmt
-				} else {
-					return p.other_stmts(cur_stmt)
+				if p.peek_tok.kind == .key_if {
+					if_expr := p.if_expr(true)
+					cur_stmt := ast.ExprStmt{
+						expr: if_expr
+						pos: if_expr.pos
+					}
+					if comptime_if_expr_contains_top_stmt(if_expr) {
+						return cur_stmt
+					} else {
+						return p.other_stmts(cur_stmt)
+					}
+				} else if p.peek_tok.kind == .key_for {
+					comptime_for_stmt := p.comptime_for()
+					return p.other_stmts(comptime_for_stmt)
 				}
 			}
 			.hash {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -751,7 +751,10 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 				if p.peek_tok.kind == .eof {
 					return p.unexpected(got: 'eof')
 				}
-				if p.peek_tok.kind == .key_if {
+				if p.peek_tok.kind == .key_for {
+					comptime_for_stmt := p.comptime_for()
+					return p.other_stmts(comptime_for_stmt)
+				} else {
 					if_expr := p.if_expr(true)
 					cur_stmt := ast.ExprStmt{
 						expr: if_expr
@@ -762,9 +765,6 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 					} else {
 						return p.other_stmts(cur_stmt)
 					}
-				} else if p.peek_tok.kind == .key_for {
-					comptime_for_stmt := p.comptime_for()
-					return p.other_stmts(comptime_for_stmt)
 				}
 			}
 			.hash {

--- a/vlib/v/slow_tests/repl/comptime_for.repl
+++ b/vlib/v/slow_tests/repl/comptime_for.repl
@@ -1,0 +1,10 @@
+struct Person {
+	name string
+	age int
+}
+$for field in Person.fields {
+	println(field.name)
+}
+===output===
+name
+age


### PR DESCRIPTION
This PR fix comptime_for in repl (script mode) (fix #5976).

- Fix comptime_for in repl (script mode).
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.3.3 2179db3 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> struct Person {
... name string
... age int
... }
>>> $for field in Person.fields {
... println(field.name)
... }
name
age
>>>
```