### PR TITLE
parser: fix wrong nodes generated for $something

### DIFF
--- a/vlib/v/checker/tests/invalid_comptime_test.out
+++ b/vlib/v/checker/tests/invalid_comptime_test.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/invalid_comptime_test.vv:1:1: error: unexpected token `$`
+    1 | $fn func(a int) int {
+      | ^
+    2 |     return a + a
+    3 | }

--- a/vlib/v/checker/tests/invalid_comptime_test.vv
+++ b/vlib/v/checker/tests/invalid_comptime_test.vv
@@ -1,0 +1,7 @@
+$fn func(a int) int {
+    return a + a
+}
+
+fn main() {
+    println(func(5))
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -754,7 +754,7 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 				if p.peek_tok.kind == .key_for {
 					comptime_for_stmt := p.comptime_for()
 					return p.other_stmts(comptime_for_stmt)
-				} else {
+				} else if p.peek_tok.kind == .key_if {
 					if_expr := p.if_expr(true)
 					cur_stmt := ast.ExprStmt{
 						expr: if_expr
@@ -765,6 +765,8 @@ pub fn (mut p Parser) top_stmt() ast.Stmt {
 					} else {
 						return p.other_stmts(cur_stmt)
 					}
+				} else {
+					return p.unexpected()
 				}
 			}
 			.hash {


### PR DESCRIPTION
Fix #17967

`$something` was generating `IfExpr` AST nodes.