### PR TITLE
toml: add generic de- and encoding of simple structs when they don't implement custom methods

### DIFF
--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -1,18 +1,40 @@
 import toml
 
-enum JobTitle {
-	manager
-	executive
-	worker
+enum Rank {
+	low
+	medium
+	high
+}
+
+struct Planet {
+	name       string
+	population u64
+	size       f64
+	avg_temp   int
+	has_water  bool
+	rank       Rank
 }
 
 struct Employee {
-pub mut:
+mut:
 	name     string
 	age      int
 	salary   f32
 	is_human bool
-	title    JobTitle
+	rank     Rank
+}
+
+fn test_encode_and_decode() {
+	p := Planet{'Mars', 0, 144.8, -81, true, .high}
+	s := 'name = "Mars"
+population = 0
+size = 144.8
+avg_temp = -81
+has_water = true
+rank = 2'
+
+	assert toml.encode[Planet](p) == s
+	assert toml.decode[Planet](s)! == p
 }
 
 pub fn (e Employee) to_toml() string {
@@ -21,7 +43,7 @@ pub fn (e Employee) to_toml() string {
 	mp['age'] = toml.Any(e.age)
 	mp['salary'] = toml.Any(e.salary)
 	mp['is_human'] = toml.Any(e.is_human)
-	mp['title'] = toml.Any(int(e.title))
+	mp['rank'] = toml.Any(int(e.rank))
 	return mp.to_toml()
 }
 
@@ -31,18 +53,18 @@ pub fn (mut e Employee) from_toml(any toml.Any) {
 	e.age = mp['age'] or { toml.Any(0) }.int()
 	e.salary = mp['salary'] or { toml.Any(0) }.f32()
 	e.is_human = mp['is_human'] or { toml.Any(false) }.bool()
-	e.title = unsafe { JobTitle(mp['title'] or { toml.Any(0) }.int()) }
+	e.rank = unsafe { Rank(mp['rank'] or { toml.Any(0) }.int()) }
 }
 
-fn test_encode_and_decode() {
-	x := Employee{'Peter', 28, 95000.5, true, .worker}
+fn test_custom_encode_and_decode() {
+	x := Employee{'Peter', 28, 95000.5, true, .medium}
 	s := toml.encode[Employee](x)
 	eprintln('Employee x: ${s}')
 	assert s == r'name = "Peter"
 age = 28
 salary = 95000.5
 is_human = true
-title = 2'
+rank = 1'
 
 	y := toml.decode[Employee](s) or {
 		println(err)
@@ -54,5 +76,5 @@ title = 2'
 	assert y.age == 28
 	assert y.salary == 95000.5
 	assert y.is_human == true
-	assert y.title == .worker
+	assert y.rank == .medium
 }

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -104,8 +104,8 @@ fn test_custom_encode_and_decode() {
 	eprintln('Employee x: ${s}')
 	assert s == r'name = "Peter"
 age = 28
-salary = 100000.5
 is_human = true
+salary = 100000.5
 title = 2'
 
 	y := toml.decode[Employee](s) or {

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -41,9 +41,9 @@ pub fn (e Employee) to_toml() string {
 	mut mp := map[string]toml.Any{}
 	mp['name'] = toml.Any(e.name)
 	mp['age'] = toml.Any(e.age)
-	mp['salary'] = toml.Any(e.salary)
+	mp['salary'] = toml.Any(f32(e.salary) + 5000.0)
 	mp['is_human'] = toml.Any(e.is_human)
-	mp['rank'] = toml.Any(int(e.rank))
+	mp['rank'] = toml.Any(int(e.rank) + 1)
 	return mp.to_toml()
 }
 
@@ -51,9 +51,9 @@ pub fn (mut e Employee) from_toml(any toml.Any) {
 	mp := any.as_map()
 	e.name = mp['name'] or { toml.Any('') }.string()
 	e.age = mp['age'] or { toml.Any(0) }.int()
-	e.salary = mp['salary'] or { toml.Any(0) }.f32()
+	e.salary = mp['salary'] or { toml.Any(0) }.f32() - 15000.0
 	e.is_human = mp['is_human'] or { toml.Any(false) }.bool()
-	e.rank = unsafe { Rank(mp['rank'] or { toml.Any(0) }.int()) }
+	e.rank = unsafe { Rank(mp['rank'] or { toml.Any(0) }.int() - 2) }
 }
 
 fn test_custom_encode_and_decode() {
@@ -62,9 +62,9 @@ fn test_custom_encode_and_decode() {
 	eprintln('Employee x: ${s}')
 	assert s == r'name = "Peter"
 age = 28
-salary = 95000.5
+salary = 100000.5
 is_human = true
-rank = 1'
+rank = 2'
 
 	y := toml.decode[Employee](s) or {
 		println(err)
@@ -74,7 +74,7 @@ rank = 1'
 	eprintln('Employee y: ${y}')
 	assert y.name == 'Peter'
 	assert y.age == 28
-	assert y.salary == 95000.5
+	assert y.salary == 85000.5
 	assert y.is_human == true
-	assert y.rank == .medium
+	assert y.rank == .low
 }

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -81,8 +81,9 @@ pub fn (e Employee) to_toml() string {
 	mut mp := map[string]toml.Any{}
 	mp['name'] = toml.Any(e.name)
 	mp['age'] = toml.Any(e.age)
-	mp['salary'] = toml.Any(f32(e.salary) + 5000.0)
 	mp['is_human'] = toml.Any(e.is_human)
+	// Change some values to assert that the structs method is used instead of generic decoding.
+	mp['salary'] = toml.Any(f32(e.salary) + 5000.0)
 	mp['title'] = toml.Any(int(e.title) + 1)
 	return mp.to_toml()
 }

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -77,8 +77,9 @@ pub fn (mut e Employee) from_toml(any toml.Any) {
 	mp := any.as_map()
 	e.name = mp['name'] or { toml.Any('') }.string()
 	e.age = mp['age'] or { toml.Any(0) }.int()
-	e.salary = mp['salary'] or { toml.Any(0) }.f32() - 15000.0
 	e.is_human = mp['is_human'] or { toml.Any(false) }.bool()
+	// Change some values to assert that the structs method is used instead of generic decoding.
+	e.salary = mp['salary'] or { toml.Any(0) }.f32() - 15000.0
 	e.title = unsafe { JobTitle(mp['title'] or { toml.Any(0) }.int() - 2) }
 }
 

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -15,12 +15,23 @@ struct Pet {
 	has_furr  bool
 	title     JobTitle
 	address   Address
+	// *¹ Currently it is only possible to decode a single nested struct generically.
+	// As soon as we decode another nested struct (e.g. within this struct, like `contact` below)
+	// or only one nested struct within another struct, it results in wrong values or errors.
+	// Related issue: https://github.com/vlang/v/issues/18110
+	// contact Contact
 }
 
 struct Address {
 	street string
 	city   string
 }
+
+// *¹
+/*
+struct Contact {
+	phone string
+}*/
 
 struct Employee {
 mut:
@@ -45,6 +56,8 @@ struct Arrs {
 }
 
 fn test_encode_and_decode() {
+	// *¹
+	// p := Pet{'Mr. Scratchy McEvilPaws', ['Freddy', 'Fred', 'Charles'], 8, -1, 0.8, true, .manager, Address{'1428 Elm Street', 'Springwood'}, Contact{'123-456-7890'}}
 	p := Pet{'Mr. Scratchy McEvilPaws', ['Freddy', 'Fred', 'Charles'], 8, -1, 0.8, true, .manager, Address{'1428 Elm Street', 'Springwood'}}
 	s := 'name = "Mr. Scratchy McEvilPaws"
 nicknames = [
@@ -58,6 +71,7 @@ height = 0.8
 has_furr = true
 title = 2
 address = { street = "1428 Elm Street", city = "Springwood" }'
+	// contact = { phone = "123-456-7890" }' // *¹
 
 	assert toml.encode[Pet](p) == s
 	assert toml.decode[Pet](s)! == p

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -82,7 +82,7 @@ pub fn (e Employee) to_toml() string {
 	mp['name'] = toml.Any(e.name)
 	mp['age'] = toml.Any(e.age)
 	mp['is_human'] = toml.Any(e.is_human)
-	// Change some values to assert that the structs method is used instead of generic decoding.
+	// Change some values to assert that the custom method is used instead of generic encoding.
 	mp['salary'] = toml.Any(f32(e.salary) + 5000.0)
 	mp['title'] = toml.Any(int(e.title) + 1)
 	return mp.to_toml()
@@ -93,7 +93,7 @@ pub fn (mut e Employee) from_toml(any toml.Any) {
 	e.name = mp['name'] or { toml.Any('') }.string()
 	e.age = mp['age'] or { toml.Any(0) }.int()
 	e.is_human = mp['is_human'] or { toml.Any(false) }.bool()
-	// Change some values to assert that the structs method is used instead of generic decoding.
+	// Change some values to assert that the custom method is used instead of generic decoding.
 	e.salary = mp['salary'] or { toml.Any(0) }.f32() - 15000.0
 	e.title = unsafe { JobTitle(mp['title'] or { toml.Any(0) }.int() - 2) }
 }

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -13,7 +13,7 @@ pub struct Null {
 }
 
 // decode decodes a TOML `string` into the target type `T`.
-// `T` can have a custom `.from_toml()` method that will be used in decode.
+// If `T` has a custom `.from_toml()` method, it will be used instead of the default.
 pub fn decode[T](toml_txt string) !T {
 	doc := parse_text(toml_txt)!
 	mut typ := T{}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -76,7 +76,7 @@ fn decode_struct[T](doc Any, mut typ T) {
 }
 
 // encode encodes the type `T` into a TOML string.
-// `T` can have a custom `.to_toml()` method that will be used in encode.
+// If `T` has a custom `.to_toml()` method, it will be used instead of the default.
 pub fn encode[T](typ T) string {
 	$for method in T.methods {
 		$if method.name == 'to_toml' {

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -46,6 +46,12 @@ fn decode_struct[T](doc Any, mut typ T) {
 			typ.$(field.name) = value.f32()
 		} $else $if field.typ is f64 {
 			typ.$(field.name) = value.f64()
+		} $else $if field.typ is DateTime {
+			typ.$(field.name) = value.datetime()
+		} $else $if field.typ is Date {
+			typ.$(field.name) = value.date()
+		} $else $if field.typ is Time {
+			typ.$(field.name) = value.time()
 		} $else $if field.is_array {
 			arr := value.array()
 			match typeof(typ.$(field.name)).name {
@@ -62,22 +68,9 @@ fn decode_struct[T](doc Any, mut typ T) {
 				else {}
 			}
 		} $else $if field.is_struct {
-			match typeof(typ.$(field.name)).name {
-				'toml.DateTime' {
-					// typ.$(field.name) = DateTime{value.string()}
-				}
-				'toml.Date' {
-					// typ.$(field.name) = Date{value.string()}
-				}
-				'toml.Time' {
-					// typ.$(field.name) = Time{value.string()}
-				}
-				else {
-					mut s := typ.$(field.name)
-					decode_struct(value, mut s)
-					typ.$(field.name) = s
-				}
-			}
+			mut s := typ.$(field.name)
+			decode_struct(value, mut s)
+			typ.$(field.name) = s
 		}
 	}
 }

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -17,6 +17,12 @@ pub struct Null {
 pub fn decode[T](toml_txt string) !T {
 	doc := parse_text(toml_txt)!
 	mut typ := T{}
+	$for method in T.methods {
+		$if method.name == 'from_toml' {
+			typ.from_toml(doc.to_any())
+			return typ
+		}
+	}
 	$for field in T.fields {
 		$if field.is_enum {
 			typ.$(field.name) = doc.value(field.name).int()
@@ -45,6 +51,11 @@ pub fn decode[T](toml_txt string) !T {
 // encode encodes the type `T` into a TOML string.
 // Currently encode expects the method `.to_toml()` exists on `T`.
 pub fn encode[T](typ T) string {
+	$for method in T.methods {
+		$if method.name == 'to_toml' {
+			return typ.to_toml()
+		}
+	}
 	mut mp := map[string]Any{}
 	$if T is $struct {
 		$for field in T.fields {

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -14,12 +14,13 @@ pub struct Null {
 }
 
 // decode decodes a TOML `string` into the target type `T`.
+// `T` can have a custom `.from_toml()` method to be used for decoding.
 pub fn decode[T](toml_txt string) !T {
 	doc := parse_text(toml_txt)!
 	mut typ := T{}
 	$for method in T.methods {
 		$if method.name == 'from_toml' {
-			typ.from_toml(doc.to_any())
+			typ.$method(doc.to_any())
 			return typ
 		}
 	}
@@ -49,11 +50,11 @@ pub fn decode[T](toml_txt string) !T {
 }
 
 // encode encodes the type `T` into a TOML string.
-// Currently encode expects the method `.to_toml()` exists on `T`.
+// `T` can have a custom `.to_toml()` method to be used for decoding.
 pub fn encode[T](typ T) string {
 	$for method in T.methods {
 		$if method.name == 'to_toml' {
-			return typ.to_toml()
+			return typ.$method()
 		}
 	}
 	mut mp := map[string]Any{}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -14,7 +14,7 @@ pub struct Null {
 }
 
 // decode decodes a TOML `string` into the target type `T`.
-// `T` can have a custom `.from_toml()` method to be used for decoding.
+// `T` can have a custom `.from_toml()` method that will be used in decode.
 pub fn decode[T](toml_txt string) !T {
 	doc := parse_text(toml_txt)!
 	mut typ := T{}
@@ -50,7 +50,7 @@ pub fn decode[T](toml_txt string) !T {
 }
 
 // encode encodes the type `T` into a TOML string.
-// `T` can have a custom `.to_toml()` method to be used for decoding.
+// `T` can have a custom `.to_toml()` method that will be used in encode.
 pub fn encode[T](typ T) string {
 	$for method in T.methods {
 		$if method.name == 'to_toml' {

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -17,7 +17,14 @@ pub struct Null {
 // `T` can have a custom `.from_toml()` method that will be used in decode.
 pub fn decode[T](toml_txt string) !T {
 	doc := parse_text(toml_txt)!
-	typ := decode_struct[T](doc.to_any())
+	mut typ := T{}
+	$for method in T.methods {
+		$if method.name == 'from_toml' {
+			typ.$method(doc.to_any())
+			return typ
+		}
+	}
+	typ = decode_struct[T](doc.to_any())
 	return typ
 }
 

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -19,8 +19,7 @@ pub fn decode[T](toml_txt string) !T {
 	mut typ := T{}
 	$for field in T.fields {
 		$if field.is_enum {
-			// TODO: check enums
-			doc.value(field.name).int()
+			typ.$(field.name) = doc.value(field.name).int()
 		} $else $if field.typ is string {
 			typ.$(field.name) = doc.value(field.name).string()
 		} $else $if field.typ is bool {
@@ -51,7 +50,7 @@ pub fn encode[T](typ T) string {
 		$for field in T.fields {
 			value := typ.$(field.name)
 			$if field.is_enum {
-				mp[field.name] = Any(value.str())
+				mp[field.name] = Any(int(value))
 			} $else {
 				mp[field.name] = Any(value)
 			}


### PR DESCRIPTION
PR adds direct encoding and decoding in toml.

Let me know about considerations and nitpicks to make this good as it should be. 