### PR TITLE
ci: add `wasm` module test jobs for macos, linux and windows

### DIFF
--- a/.github/workflows/wasm_wabt_tests_ci.yml
+++ b/.github/workflows/wasm_wabt_tests_ci.yml
@@ -1,0 +1,73 @@
+name: wasm wabt validate tests CI
+
+on:
+  push:
+    paths:
+      - '!**'
+      - '!**.md'
+      - 'vlib/builtin/**.v'
+      - 'vlib/wasm/**.v'
+      - 'vlib/wasm/tests/**.v'
+  pull_request:
+    paths:
+      - '!**'
+      - '!**.md'
+      - 'vlib/builtin/**.v'
+      - 'vlib/wasm/**.v'
+      - 'vlib/wasm/tests/**.v'
+
+concurrency:
+  group: wasm-wabt-ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  wasm-backend-ubuntu:
+    runs-on: ubuntu-22.04
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    timeout-minutes: 31
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build V
+        run: make && ./v symlink -githubci
+
+      - name: Install wabt to get the wasm-validate executable
+        run: v cmd/tools/install_wabt.vsh
+
+      - name: Test the WASM backend
+        run: v test vlib/wasm/
+
+  wasm-backend-macos:
+    runs-on: macOS-12
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    timeout-minutes: 31
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build V
+        run: make && ./v symlink -githubci
+
+      - name: Install wabt to get the wasm-validate executable
+        run: v cmd/tools/install_wabt.vsh
+
+      - name: Test the WASM backend
+        run: v test vlib/wasm/
+        
+  wasm-backend-windows:
+    runs-on: windows-2022
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    timeout-minutes: 31
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build V
+        run: .\make.bat -msvc
+        
+      - name: Symlink V
+        run: .\v.exe symlink -githubci
+
+      - name: Install wabt to get the wasm-validate executable
+        run: v cmd/tools/install_wabt.vsh
+
+      - name: Test the WASM backend
+        run: v test vlib/wasm/

--- a/.github/workflows/wasm_wabt_tests_ci.yml
+++ b/.github/workflows/wasm_wabt_tests_ci.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wasm-backend-ubuntu:
+  wasm-wabt-ubuntu:
     runs-on: ubuntu-22.04
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
     timeout-minutes: 31
@@ -37,7 +37,7 @@ jobs:
       - name: Test the WASM backend
         run: v test vlib/wasm/
 
-  wasm-backend-macos:
+  wasm-wabt-macos:
     runs-on: macOS-12
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
     timeout-minutes: 31
@@ -52,8 +52,8 @@ jobs:
 
       - name: Test the WASM backend
         run: v test vlib/wasm/
-        
-  wasm-backend-windows:
+
+  wasm-wabt-windows:
     runs-on: windows-2022
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
     timeout-minutes: 31
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build V
         run: .\make.bat -msvc
-        
+
       - name: Symlink V
         run: .\v.exe symlink -githubci
 

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ flake.nix
 
 thirdparty/stdatomic/nix/cpp/*.h
 thirdparty/binaryen*
+thirdparty/wabt*
 
 # ignore VLS log
 vls.log

--- a/cmd/tools/install_wabt.vsh
+++ b/cmd/tools/install_wabt.vsh
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp
+
+import os
+import net.http
+
+const root = @VROOT
+
+fn main() {
+	os.chdir(root)! // make sure that the workfolder is stable
+
+	tloc := os.join_path(root, 'thirdparty')
+	loc := os.join_path(tloc, 'wabt')
+
+	if os.exists(loc) {
+		eprintln('thirdparty/wabt exists, will not overwrite')
+		eprintln('delete the folder, and execute again')
+		exit(1)
+	}
+	tag := '1.0.32'
+	fname := 'wabt-${tag}'
+	platform := $if windows {
+		'windows'
+	} $else $if macos {
+		'macos-12'
+	} $else $if linux {
+		'ubuntu'
+	} $else {
+		eprintln('A premade binary library is not available for your system.')
+		eprintln('Build it from source, following the documentation here: https://github.com/WebAssembly/wabt/')
+		exit(1)
+	}
+	url := 'https://github.com/WebAssembly/wabt/releases/download/${tag}/${fname}-${platform}.tar.gz'
+	saveloc := os.join_path(tloc, '${fname}.tar.gz')
+	if !os.exists(saveloc) {
+		println('Downloading archive: ${saveloc}, from url: ${url} ...')
+		http.download_file(url, saveloc)!
+		// defer { os.rm(saveloc) or {}! }
+	}
+
+	println('Extracting `${tloc}/${fname}` to `${tloc}/wabt` ...')
+	cmd := 'tar -xvf ${saveloc} --directory ${tloc}'
+	if os.system(cmd) != 0 {
+		eprintln('`${cmd}` exited with a non zero exit code')
+		exit(1)
+	}
+
+	println(cmd)
+	println('Moving `${tloc}/${fname}` to `${tloc}/wabt` ...')
+
+	os.rename_dir('${tloc}/${fname}', loc)!
+	println('Done. You can now use `v test vlib/wasm` .')
+}

--- a/vlib/wasm/tests/arith_test.v
+++ b/vlib/wasm/tests/arith_test.v
@@ -1,26 +1,6 @@
+module main
+
 import wasm
-import os
-
-const exe = os.find_abs_path_of_executable('wasm-validate') or { exit(0) }
-
-fn validate(mod []u8) ! {
-	mut proc := os.new_process(exe)
-	proc.set_args(['-'])
-	proc.set_redirect_stdio()
-	proc.run()
-	{
-		os.fd_write(proc.stdio_fd[0], mod.bytestr())
-		os.fd_close(proc.stdio_fd[0])
-	}
-	proc.wait()
-	if proc.status != .exited {
-		return error('wasm-validate exited abormally')
-	}
-	if proc.code != 0 {
-		return error('wasm-validate exited with a non zero exit code')
-	}
-	proc.close()
-}
 
 fn test_add() {
 	mut m := wasm.Module{}

--- a/vlib/wasm/tests/block_test.v
+++ b/vlib/wasm/tests/block_test.v
@@ -1,26 +1,6 @@
+module main
+
 import wasm
-import os
-
-const exe = os.find_abs_path_of_executable('wasm-validate') or { exit(0) }
-
-fn validate(mod []u8) ! {
-	mut proc := os.new_process(exe)
-	proc.set_args(['-'])
-	proc.set_redirect_stdio()
-	proc.run()
-	{
-		os.fd_write(proc.stdio_fd[0], mod.bytestr())
-		os.fd_close(proc.stdio_fd[0])
-	}
-	proc.wait()
-	if proc.status != .exited {
-		return error('wasm-validate exited abormally')
-	}
-	if proc.code != 0 {
-		return error('wasm-validate exited with a non zero exit code')
-	}
-	proc.close()
-}
 
 fn test_block() {
 	mut m := wasm.Module{}

--- a/vlib/wasm/tests/call_test.v
+++ b/vlib/wasm/tests/call_test.v
@@ -1,26 +1,6 @@
+module main
+
 import wasm
-import os
-
-const exe = os.find_abs_path_of_executable('wasm-validate') or { exit(0) }
-
-fn validate(mod []u8) ! {
-	mut proc := os.new_process(exe)
-	proc.set_args(['-'])
-	proc.set_redirect_stdio()
-	proc.run()
-	{
-		os.fd_write(proc.stdio_fd[0], mod.bytestr())
-		os.fd_close(proc.stdio_fd[0])
-	}
-	proc.wait()
-	if proc.status != .exited {
-		return error('wasm-validate exited abormally')
-	}
-	if proc.code != 0 {
-		return error('wasm-validate exited with a non zero exit code')
-	}
-	proc.close()
-}
 
 fn test_call() {
 	mut m := wasm.Module{}

--- a/vlib/wasm/tests/common.v
+++ b/vlib/wasm/tests/common.v
@@ -2,14 +2,30 @@ module main
 
 import os
 
-const wasm_validate_exe = os.find_abs_path_of_executable('wasm-validate') or {
-	println('skipping test, since wasm-validate could not be found')
+const pid = os.getpid()
+
+const wasm_validate_exe = find_wasm_validate() or {
+	println('>>> Skipping test, since wasm-validate could not be found, error: ${err}')
 	exit(0)
 }
 
-const pid = os.getpid()
+fn find_wasm_validate() !string {
+	// Prefer to find our own version first, if it was installed already
+	// through install_wabt.vsh, since it is more likely to be known, recent, and stable:
+	thirdpart_wasm_validate_folder := os.join_path(@VROOT, 'thirdparty', 'wabt', 'bin')
+	extension := $if windows { '.exe' } $else { '' }
+	wasm_validate_executable := os.join_path(thirdpart_wasm_validate_folder, 'wasm-validate${extension}')
+	if os.exists(wasm_validate_executable) {
+		return wasm_validate_executable
+	}
+	if path := os.find_abs_path_of_executable('wasm-validate') {
+		return path
+	}
+	return error('could not find wasm-validate executable in thirdparty/ as well, try first `v run cmd/tools/install_wabt.vsh`')
+}
 
 pub fn validate(code []u8) ! {
+	println('validating using: ${wasm_validate_exe}')
 	outfile := os.join_path(os.temp_dir(), 'code_${pid}.wasm')
 	os.write_file(outfile, code.bytestr())!
 	validation_cmd := '${os.quoted_path(wasm_validate_exe)} ${os.quoted_path(outfile)}'

--- a/vlib/wasm/tests/common.v
+++ b/vlib/wasm/tests/common.v
@@ -1,0 +1,27 @@
+module main
+
+import os
+
+const exe = os.find_abs_path_of_executable('wasm-validate') or {
+	println('skipping test, since wasm-validate could not be found')
+	exit(0)
+}
+
+pub fn validate(mod []u8) ! {
+	mut proc := os.new_process(exe)
+	proc.set_args(['-'])
+	proc.set_redirect_stdio()
+	proc.run()
+	{
+		os.fd_write(proc.stdio_fd[0], mod.bytestr())
+		os.fd_close(proc.stdio_fd[0])
+	}
+	proc.wait()
+	if proc.status != .exited {
+		return error('wasm-validate exited abormally')
+	}
+	if proc.code != 0 {
+		return error('wasm-validate exited with a non zero exit code')
+	}
+	proc.close()
+}

--- a/vlib/wasm/tests/var_test.v
+++ b/vlib/wasm/tests/var_test.v
@@ -1,26 +1,6 @@
+module main
+
 import wasm
-import os
-
-const exe = os.find_abs_path_of_executable('wasm-validate') or { exit(0) }
-
-fn validate(mod []u8) ! {
-	mut proc := os.new_process(exe)
-	proc.set_args(['-'])
-	proc.set_redirect_stdio()
-	proc.run()
-	{
-		os.fd_write(proc.stdio_fd[0], mod.bytestr())
-		os.fd_close(proc.stdio_fd[0])
-	}
-	proc.wait()
-	if proc.status != .exited {
-		return error('wasm-validate exited abormally')
-	}
-	if proc.code != 0 {
-		return error('wasm-validate exited with a non zero exit code')
-	}
-	proc.close()
-}
 
 fn test_globals() {
 	mut m := wasm.Module{}


### PR DESCRIPTION
- tests: extract the common code from wasm tests into a common.v file
- tests: make the wasm tests work on Windows too (use `wasm-validate file.wasm` instead of piping to `wasm-validate -`)
- tests: final cleanup of vlib/wasm tests and cmd/tools/install_wabt.vsh
