### PR TITLE
toml: fix trailing comma in inline toml

### DIFF
--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -232,10 +232,12 @@ pub fn (m map[string]Any) to_toml() string {
 // as an inline table encoded TOML `string`.
 pub fn (m map[string]Any) to_inline_toml() string {
 	mut toml_text := '{'
+	mut i := 1
 	for k, v in m {
 		key := if k.contains(' ') { '"${k}"' } else { k }
 		delimeter := if i < m.len { ',' } else { '' }
-		toml_text += ' ${key} = ${v.to_toml()},'
+		toml_text += ' ${key} = ${v.to_toml()}${delimeter}'
+		i++
 	}
 	return toml_text + ' }'
 }

--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -221,11 +221,8 @@ pub fn (m map[string]Any) as_strings() map[string]string {
 pub fn (m map[string]Any) to_toml() string {
 	mut toml_text := ''
 	for k, v in m {
-		mut key := k
-		if key.contains(' ') {
-			key = '"${key}"'
-		}
-		toml_text += '${key} = ' + v.to_toml() + '\n'
+		key := if k.contains(' ') { '"${k}"' } else { k }
+		toml_text += '${key} = ${v.to_toml()}\n'
 	}
 	toml_text = toml_text.trim_right('\n')
 	return toml_text
@@ -236,11 +233,9 @@ pub fn (m map[string]Any) to_toml() string {
 pub fn (m map[string]Any) to_inline_toml() string {
 	mut toml_text := '{'
 	for k, v in m {
-		mut key := k
-		if key.contains(' ') {
-			key = '"${key}"'
-		}
-		toml_text += ' ${key} = ' + v.to_toml() + ','
+		key := if k.contains(' ') { '"${k}"' } else { k }
+		delimeter := if i < m.len { ',' } else { '' }
+		toml_text += ' ${key} = ${v.to_toml()},'
 	}
 	return toml_text + ' }'
 }

--- a/vlib/toml/tests/inline_test.v
+++ b/vlib/toml/tests/inline_test.v
@@ -1,0 +1,16 @@
+import toml
+
+struct Address {
+	street string
+	city   string
+}
+
+fn test_inline() {
+	a := Address{'Elm Street', 'Springwood'}
+
+	mut mp := map[string]toml.Any{}
+	mp['street'] = toml.Any(a.street)
+	mp['city'] = toml.Any(a.city)
+
+	assert mp.to_inline_toml() == '{ street = "Elm Street", city = "Springwood" }'
+}


### PR DESCRIPTION
Serializing a nested struct like the following to toml:
```v
struct Person {
	name string
	address Address
}

struct Address {
	street string
	city   string
}

p := Person{
	name: 'John'
	address: Address{'Elm Street', 'Springwood'}
}
```

currently results in:
```
name = "John"
address = { street = "Elm Street", city = "Springwood", }
```

trying to deserialize it again with `doc := toml.parse_text(toml_txt) or { panic(err) }` will cause:
> V panic: toml.parser.Parser.inline_table unexpected "rcbr" "}" at this (excerpt): "...ngwood", }..."


This PR will cause serialization without a trailing comma on last items of inline tables to prevent this.
It also includes a little incremental refactor of variable assignments.

Edit: sorry about the spelling issue in the commit message. I think since PRs are usually squashed I'll leave it like this instead of force push fixing it.

Also, I'm realize that manually, user added trailing commas in config files should be handled.