### PR TITLE
strings: cleanup builder.c.v

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -108,10 +108,6 @@ pub fn (mut b Builder) write_string(s string) {
 		return
 	}
 	unsafe { b.push_many(s.str, s.len) }
-	// for c in s {
-	// b.buf << c
-	// }
-	// b.buf << []u8(s)  // TODO
 }
 
 // go_back discards the last `n` bytes from the buffer
@@ -194,28 +190,6 @@ pub fn (mut b Builder) str() string {
 	s := unsafe { bcopy.vstring_with_len(b.len - 1) }
 	b.trim(0)
 	return s
-}
-
-// ensure_cap ensures that the buffer has enough space for at least `n` bytes by growing the buffer if necessary
-pub fn (mut b Builder) ensure_cap(n int) {
-	// code adapted from vlib/builtin/array.v
-	if n <= b.cap {
-		return
-	}
-
-	new_data := vcalloc(n * b.element_size)
-	if b.data != unsafe { nil } {
-		unsafe { vmemcpy(new_data, b.data, b.len * b.element_size) }
-		// TODO: the old data may be leaked when no GC is used (ref-counting?)
-		if b.flags.has(.noslices) {
-			unsafe { free(b.data) }
-		}
-	}
-	unsafe {
-		b.data = new_data
-		b.offset = 0
-		b.cap = n
-	}
 }
 
 // free frees the memory block, used for the buffer.

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -115,21 +115,6 @@ fn test_write_runes() {
 	assert x == 'hello world'
 }
 
-fn test_ensure_cap() {
-	mut sb := strings.new_builder(0)
-	assert sb.cap == 0
-	sb.ensure_cap(10)
-	assert sb.cap == 10
-	sb.ensure_cap(10)
-	assert sb.cap == 10
-	sb.ensure_cap(15)
-	assert sb.cap == 15
-	sb.ensure_cap(10)
-	assert sb.cap == 15
-	sb.ensure_cap(-1)
-	assert sb.cap == 15
-}
-
 fn test_drain_builder() {
 	mut sb := strings.new_builder(0)
 	mut target_sb := strings.new_builder(0)


### PR DESCRIPTION
This PR cleanup builder.c.v.

- Remove unused private function `ensure_cap()`.