### PR TITLE
cgen: fix strings builder shift array.reverse() (fix #17948)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -741,8 +741,9 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 		tmp_var := g.new_tmp_var()
 		array_info := left.unaliased_sym.info as ast.Array
 		noscan := g.check_noscan(array_info.elem_type)
-		if right.unaliased_sym.kind == .array && array_info.elem_type != right.typ
-			&& !(right.sym.kind == .alias
+		if (right.unaliased_sym.kind == .array
+			|| (right.unaliased_sym.kind == .struct_ && right.unaliased_sym.name == 'array'))
+			&& array_info.elem_type != right.typ && !(right.sym.kind == .alias
 			&& g.table.sumtype_has_variant(array_info.elem_type, node.right_type, false)) {
 			// push an array => PUSH_MANY, but not if pushing an array to 2d array (`[][]int << []int`)
 			g.write('_PUSH_MANY${noscan}(')

--- a/vlib/v/tests/strings_builder_shift_array_reverse_test.v
+++ b/vlib/v/tests/strings_builder_shift_array_reverse_test.v
@@ -1,0 +1,12 @@
+import rand
+import strings
+
+fn test_strings_builder_shift_array_reverse() {
+	mut a := strings.new_builder(0)
+	mut b := strings.new_builder(0)
+	b << rand.ascii(5).bytes()
+	a << b.reverse()
+	ret := a.str()
+	println(ret)
+	assert ret.len == 5
+}


### PR DESCRIPTION
This PR fix strings builder shift array.reverse() (fix #17948).

- Fix strings builder shift array.reverse().
- Add test.

```v
import rand
import strings

fn main() {
	mut a := strings.new_builder(0)
	mut b := strings.new_builder(0)
	b << rand.ascii(5).bytes()
	a << b.reverse()
	ret := a.str()
	println(ret)
	assert ret.len == 5
}

PS D:\Test\v\tt1> v run .       
cw\-}
```