### PR TITLE
cgen: fix concat with matchexpr + option string

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -722,11 +722,25 @@ fn (mut g Gen) infix_expr_arithmetic_op(node ast.InfixExpr) {
 			g.gen_plain_infix_expr(node)
 			return
 		}
+
+		mut right_var := ''
+		if node.right is ast.Ident && (node.right as ast.Ident).or_expr.kind != .absent {
+			cur_line := g.go_before_stmt(0).trim_space()
+			right_var = g.new_tmp_var()
+			g.write('${g.typ(right.typ)} ${right_var} = ')
+			g.op_arg(node.right, method.params[1].typ, right.typ)
+			g.writeln(';')
+			g.write(cur_line)
+		}
 		g.write(method_name)
 		g.write('(')
 		g.op_arg(node.left, method.params[0].typ, left.typ)
-		g.write(', ')
-		g.op_arg(node.right, method.params[1].typ, right.typ)
+		if right_var != '' {
+			g.write(', ${right_var}')
+		} else {
+			g.write(', ')
+			g.op_arg(node.right, method.params[1].typ, right.typ)
+		}
 		g.write(')')
 	}
 }

--- a/vlib/v/tests/option_concat_str_test.v
+++ b/vlib/v/tests/option_concat_str_test.v
@@ -1,0 +1,14 @@
+fn test_str_concat() {
+	opt := ?string(none)
+	x := match 1 {
+		0 { 'abc' }
+		else { 'def' }
+	} + opt or { '!!!' }
+	println(x)
+
+	y := opt or { '!!!' } + match 1 {
+		0 { 'abc' }
+		else { 'def' }
+	}
+	println(y)
+}


### PR DESCRIPTION
Fix #17941