### PR TITLE
cgen: fix auto_str for fn type

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -189,6 +189,8 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 		g.auto_str_funcs.writeln('\t\tres = ${str_intp_sq(tmp_res)};')
 	} else if should_use_indent_func(sym.kind) && !sym_has_str_method {
 		g.auto_str_funcs.writeln('\t\tres = indent_${parent_str_fn_name}(*(${sym.cname}*)it.data, indent_count);')
+	} else if sym.kind == .function {
+		g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}();')
 	} else {
 		g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}(*(${sym.cname}*)it.data);')
 	}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -162,7 +162,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				g.write('*')
 			}
 			g.expr_with_cast(expr, typ, typ)
-		} else {
+		} else if typ.has_flag(.option) {
+			// only Option fn receive argument
 			g.expr_with_cast(expr, typ, typ)
 		}
 		g.write(')')

--- a/vlib/v/tests/print_fn_test.v
+++ b/vlib/v/tests/print_fn_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+mut:
+	f ?fn (int)
+}
+
+fn test_print_fn() {
+	a := fn (a string) int {
+		return 1
+	}
+	println(a)
+
+	foo := Foo{}
+	println(foo.f)
+	assert foo.f == none
+}


### PR DESCRIPTION
Fix #17914

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e21e9cc</samp>

This pull request improves the `str` method for function types and option types in V. It fixes a bug in the C code generation for option expressions and adds a test case to verify the functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e21e9cc</samp>

*  Add support for `str` method of option function types ([link](https://github.com/vlang/v/pull/17988/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bR192-R193), [link](https://github.com/vlang/v/pull/17988/files?diff=unified&w=0#diff-59fdbcf7230093246f7aa61fbb8b95b95cfec3d9e28994295354a23db89a0367L165-R166))
  - Generate C code to call `str` function of parent type for function fields in `gen_auto_str_methods` ([link](https://github.com/vlang/v/pull/17988/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bR192-R193))
  - Cast expression to option type before passing to `str` function in `gen_str_for_expr` ([link](https://github.com/vlang/v/pull/17988/files?diff=unified&w=0#diff-59fdbcf7230093246f7aa61fbb8b95b95cfec3d9e28994295354a23db89a0367L165-R166))
* Add test case for printing option function types in `print_fn_test.v` ([link](https://github.com/vlang/v/pull/17988/files?diff=unified&w=0#diff-b434fe10a6852c87c50ade492e993ef3c8444504f8676afe78151dc64f8ad10fR1-R15))