### PR TITLE
checker, cgen: make comptime field.indirections working with logical operators

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -563,13 +563,17 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 							}
 						} else if cond.right is ast.IntegerLiteral {
 							if g.is_comptime_selector_field_name(cond.left, 'indirections') {
-								ret := match cond.op {
+								is_true := match cond.op {
 									.eq { g.comptime_for_field_type.nr_muls() == cond.right.val.i64() }
 									.ne { g.comptime_for_field_type.nr_muls() != cond.right.val.i64() }
 									else { false }
 								}
-								g.write(if ret { '1' } else { '0' })
-								return ret, true
+								if is_true {
+									g.write('1')
+								} else {
+									g.write('0')
+								}
+								return is_true, true
 							}
 						}
 					}
@@ -627,15 +631,19 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 						if g.is_comptime_selector_field_name(cond.left as ast.SelectorExpr,
 							'indirections')
 						{
-							ret := match cond.op {
+							is_true := match cond.op {
 								.gt { g.comptime_for_field_type.nr_muls() > cond.right.val.i64() }
 								.lt { g.comptime_for_field_type.nr_muls() < cond.right.val.i64() }
 								.ge { g.comptime_for_field_type.nr_muls() >= cond.right.val.i64() }
 								.le { g.comptime_for_field_type.nr_muls() <= cond.right.val.i64() }
 								else { false }
 							}
-							g.write(if ret { '1' } else { '0' })
-							return ret, true
+							if is_true {
+								g.write('1')
+							} else {
+								g.write('0')
+							}
+							return is_true, true
 						} else {
 							return true, false
 						}

--- a/vlib/v/tests/comptime_field_indirections_test.v
+++ b/vlib/v/tests/comptime_field_indirections_test.v
@@ -1,0 +1,33 @@
+struct Encoder {}
+
+struct Writer {}
+
+struct StructType[T] {
+mut:
+	val  &T
+	val2 T
+}
+
+fn (e &Encoder) encode_struct[U](val U, mut wr Writer) ! {
+	$for field in U.fields {
+		if field.indirections == 1 {
+			assert field.indirections == 1
+			value := val.$(field.name)
+			// broken
+			$if field.indirections == 1 {
+				assert *value == 'ads'
+			} $else {
+				assert false
+			}
+		} else {
+			assert field.name == 'val2'
+		}
+	}
+}
+
+fn test_indirection_checking() {
+	e := Encoder{}
+	mut sb := Writer{}
+	mut string_pointer := 'ads'
+	e.encode_struct(StructType[string]{ val: &string_pointer }, mut sb)!
+}

--- a/vlib/v/tests/comptime_field_indirections_test.v
+++ b/vlib/v/tests/comptime_field_indirections_test.v
@@ -13,7 +13,6 @@ fn (e &Encoder) encode_struct[U](val U, mut wr Writer) ! {
 		if field.indirections == 1 {
 			assert field.indirections == 1
 			value := val.$(field.name)
-			// broken
 			$if field.indirections == 1 {
 				assert *value == 'ads'
 			} $else {


### PR DESCRIPTION
Fix #17989

Makes possible to check indirection on compile time:

```V
$if field.indirections == 1 {
				assert *value == 'ads'
```


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09e5639</samp>

This pull request enhances the compile-time evaluation and code generation of conditional branches that depend on the `indirections` field of fields accessed by `$for` variables. It adds new cases and refactors some functions in the `vlib/v/checker/comptime.v` and `vlib/v/gen/c/comptime.v` modules. It also adds a new test file `vlib/v/tests/comptime_field_indirections_test.v` to verify the functionality and correctness of the changes.