### PR TITLE
cgen: fix c struct with reserved field name (fix #17993)

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -185,6 +185,7 @@ const (
 		'vlib/v/slow_tests/profile/profile_test.v',
 		'vlib/gg/draw_fns_api_test.v',
 		'vlib/v/tests/skip_unused/gg_code.vv',
+		'vlib/v/tests/c_struct_with_reserved_field_name_test.v',
 	]
 	skip_on_ubuntu_musl           = [
 		'do_not_remove',

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -140,7 +140,8 @@ fn (mut g Gen) final_gen_str(typ StrType) {
 			g.gen_str_for_fn_type(sym.info, styp, str_fn_name)
 		}
 		ast.Struct {
-			g.gen_str_for_struct(sym.info, styp, g.table.type_to_str(typ.typ), str_fn_name)
+			g.gen_str_for_struct(sym.info, sym.language, styp, g.table.type_to_str(typ.typ),
+				str_fn_name)
 		}
 		ast.Map {
 			g.gen_str_for_map(sym.info, styp, str_fn_name)
@@ -830,7 +831,7 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 	return .si_i32
 }
 
-fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, str_fn_name string) {
+fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp string, typ_str string, str_fn_name string) {
 	$if trace_autostr ? {
 		eprintln('> gen_str_for_struct: ${info.parent_type.debug()} | ${styp} | ${str_fn_name}')
 	}
@@ -946,9 +947,10 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 		}
 
 		mut funcprefix := ''
-		mut func, mut caller_should_free := struct_auto_str_func(sym, field.typ, field_styp_fn_name,
-			field.name, sym_has_str_method, str_method_expects_ptr)
+		mut func, mut caller_should_free := struct_auto_str_func(sym, lang, field.typ,
+			field_styp_fn_name, field.name, sym_has_str_method, str_method_expects_ptr)
 		ftyp_nr_muls := field.typ.nr_muls()
+		field_name := if lang == .c { field.name } else { c_name(field.name) }
 		if ftyp_nr_muls > 1 || field.typ in ast.cptr_types {
 			if is_opt_field {
 			} else {
@@ -958,9 +960,9 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 		} else if ftyp_noshared.is_ptr() {
 			// reference types can be "nil"
 			if ftyp_noshared.has_flag(.option) {
-				funcprefix += 'isnil(&it.${c_name(field.name)})'
+				funcprefix += 'isnil(&it.${field_name})'
 			} else {
-				funcprefix += 'isnil(it.${c_name(field.name)})'
+				funcprefix += 'isnil(it.${field_name})'
 			}
 			funcprefix += ' ? _SLIT("nil") : '
 			// struct, floats and ints have a special case through the _str function
@@ -980,7 +982,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 		// handle circular ref type of struct to the struct itself
 		if styp == field_styp && !allow_circular {
 			if is_field_array {
-				fn_body.write_string('it.${c_name(field.name)}.len > 0 ? ${funcprefix}_SLIT("[<circular>]") : ${funcprefix}_SLIT("[]")')
+				fn_body.write_string('it.${field_name}.len > 0 ? ${funcprefix}_SLIT("[<circular>]") : ${funcprefix}_SLIT("[]")')
 			} else {
 				fn_body.write_string('${funcprefix}_SLIT("<circular>")')
 			}
@@ -1011,38 +1013,39 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, styp string, typ_str string, 
 	fn_body.writeln('\t}));')
 }
 
-fn struct_auto_str_func(sym &ast.TypeSymbol, _field_type ast.Type, fn_name string, field_name string, has_custom_str bool, expects_ptr bool) (string, bool) {
+fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.Type, fn_name string, field_name string, has_custom_str bool, expects_ptr bool) (string, bool) {
 	$if trace_autostr ? {
 		eprintln('> struct_auto_str_func: ${sym.name} | field_type.debug() | ${fn_name} | ${field_name} | ${has_custom_str} | ${expects_ptr}')
 	}
 	field_type := if _field_type.has_flag(.shared_f) { _field_type.deref() } else { _field_type }
 	sufix := if field_type.has_flag(.shared_f) { '->val' } else { '' }
 	deref, _ := deref_kind(expects_ptr, field_type.is_ptr(), field_type)
+	final_field_name := if lang == .c { field_name } else { c_name(field_name) }
 	if sym.kind == .enum_ {
-		return '${fn_name}(${deref}(it.${c_name(field_name)}))', true
+		return '${fn_name}(${deref}(it.${final_field_name}))', true
 	} else if _field_type.has_flag(.option) || should_use_indent_func(sym.kind) {
-		obj := '${deref}it.${c_name(field_name)}${sufix}'
+		obj := '${deref}it.${final_field_name}${sufix}'
 		if has_custom_str {
 			return '${fn_name}(${obj})', true
 		}
 		return 'indent_${fn_name}(${obj}, indent_count + 1)', true
 	} else if sym.kind in [.array, .array_fixed, .map, .sum_type] {
-		obj := '${deref}it.${c_name(field_name)}${sufix}'
+		obj := '${deref}it.${final_field_name}${sufix}'
 		if has_custom_str {
 			return '${fn_name}(${obj})', true
 		}
 		return 'indent_${fn_name}(${obj}, indent_count + 1)', true
 	} else if sym.kind == .function {
-		obj := '${deref}it.${c_name(field_name)}${sufix}'
+		obj := '${deref}it.${final_field_name}${sufix}'
 		return '${fn_name}(${obj})', true
 	} else if sym.kind == .chan {
-		return '${fn_name}(${deref}it.${c_name(field_name)}${sufix})', true
+		return '${fn_name}(${deref}it.${final_field_name}${sufix})', true
 	} else {
 		mut method_str := ''
 		if !field_type.is_ptr() && (field_type.has_flag(.option) || field_type.has_flag(.result)) {
-			method_str = '(*(${sym.name}*)it.${c_name(field_name)}.data)'
+			method_str = '(*(${sym.name}*)it.${final_field_name}.data)'
 		} else {
-			method_str = 'it.${c_name(field_name)}'
+			method_str = 'it.${final_field_name}'
 		}
 		if sym.kind == .bool {
 			return '${method_str} ? _SLIT("true") : _SLIT("false")', false

--- a/vlib/v/tests/c_struct_with_reserved_field_name_test.v
+++ b/vlib/v/tests/c_struct_with_reserved_field_name_test.v
@@ -1,0 +1,22 @@
+import gg
+import gx
+
+struct Game {
+mut:
+	gg ?gg.Context
+}
+
+fn test_c_struct_with_reserved_field_name() {
+	mut game := Game{
+		gg: none
+	}
+	mut cont := gg.new_context(
+		bg_color: gx.rgb(174, 198, 255)
+		width: 600
+		height: 400
+		window_title: 'Polygons'
+	)
+	game.gg = cont
+	println(game.gg)
+	assert true
+}


### PR DESCRIPTION
This PR fix c struct with reserved field name (fix #17993).

- Fix c struct with reserved field name.
- Add test.

```v
import gg
import gx

struct Game {
mut:
	gg ?gg.Context
}

fn main() {
	mut game := Game{
		gg: none
	}
	mut cont := gg.new_context(
		bg_color: gx.rgb(174, 198, 255)
		width: 600
		height: 400
		window_title: 'Polygons'
	)
	game.gg = cont
	println(game.gg)
	assert true
}

PS D:\Test\v\tt1> v run .
Option(gg.Context{
    render_text: true
    image_cache: []
    needs_refresh: false
    ticks: 0
    native_rendering: false
    scale: 0.0
    width: 0
    height: 0
    clear_pass:     sokol.gfx.PassAction(C.sg_pass_action{
    _start_canary: 0
    colors: [C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}, C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}, C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}, C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}]
    depth:     sokol.gfx.DepthAttachmentAction(C.sg_depth_attachment_action{
    action: _default
    value: 0.0
})
    stencil:     sokol.gfx.StencilAttachmentAction(C.sg_stencil_attachment_action{
    action: _default
    value: 0
})
    _end_canary: 0
})
    window:     sokol.sapp.Desc(C.sapp_desc{
    init_cb: fn ()
    frame_cb: fn ()
    cleanup_cb: fn ()
    event_cb: fn (sokol.sapp.Event)
    fail_cb: fn (u8)
    user_data: 0
    init_userdata_cb: fn (voidptr)
    frame_userdata_cb: fn (voidptr)
    cleanup_userdata_cb: fn (voidptr)
    event_userdata_cb: fn (sokol.sapp.Event, voidptr)
    fail_userdata_cb: fn (char, voidptr)
    width: 0
    height: 0
    sample_count: 0
    swap_interval: 0
    high_dpi: false
    fullscreen: false
    alpha: false
    window_title: &C""
    enable_clipboard: false
    clipboard_size: 0
    enable_dragndrop: false
    max_dropped_files: 0
    max_dropped_file_path_length: 0
    icon:     sokol.sapp.IconDesc(C.sapp_icon_desc{
    sokol_default: false
    images: [C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}]
})
    gl_force_gles2: false
    win32_console_utf8: false
    win32_console_create: false
    win32_console_attach: false
    html5_canvas_name: &C""
    html5_canvas_resize: false
    html5_preserve_drawing_buffer: false
    html5_premultiplied_alpha: false
    html5_ask_leave_site: false
    ios_keyboard_resizes_canvas: false
    __v_native_render: false
    allocator: C.sapp_allocator{
        alloc: fn (usize, voidptr) voidptr
        free: fn (voidptr, voidptr)
        user_data: 0
    }
    logger: C.sapp_logger{
        log_cb: fn (char, voidptr)
        user_data: 0
    }
})
    timage_pip:     sokol.sgl.Pipeline(C.sgl_pipeline{
    id: 0
})
    pipeline: &nil
    config: gg.Config{
        width: 0
        height: 0
        use_ortho: false
        retina: false
        resizable: false
        user_data: 0
        font_size: 0
        create_window: false
        window_title: ''
        borderless_window: false
        always_on_top: false
        bg_color: Color{0, 0, 0, 0}
        init_fn: fn (voidptr)
        frame_fn: fn (voidptr)
        native_frame_fn: fn (voidptr)
        cleanup_fn: fn (voidptr)
        fail_fn: fn (string, voidptr)
        event_fn: fn (gg.Event, voidptr)
        quit_fn: fn (gg.Event, voidptr)
        keydown_fn: fn (gg.KeyCode, gg.Modifier, voidptr)
        keyup_fn: fn (gg.KeyCode, gg.Modifier, voidptr)
        char_fn: fn (u32, voidptr)
        move_fn: fn (f32, f32, voidptr)
        click_fn: fn (f32, f32, gg.MouseButton, voidptr)
        unclick_fn: fn (f32, f32, gg.MouseButton, voidptr)
        leave_fn: fn (gg.Event, voidptr)
        enter_fn: fn (gg.Event, voidptr)
        resized_fn: fn (gg.Event, voidptr)
        scroll_fn: fn (gg.Event, voidptr)
        fullscreen: false
        scale: 0.0
        sample_count: 0
        swap_interval: 0
        font_path: ''
        custom_bold_font_path: ''
        ui_mode: false
        font_bytes_normal: []
        font_bytes_bold: []
        font_bytes_mono: []
        font_bytes_italic: []
        native_rendering: false
        enable_dragndrop: false
        max_dropped_files: 0
        max_dropped_file_path_length: 0
    }
    user_data: 0
    ft: &nil
    font_inited: false
    ui_mode: false
    frame: 0
    mbtn_mask: 0
    mouse_buttons: gg.MouseButtons{}
    mouse_pos_x: 0
    mouse_pos_y: 0
    mouse_dx: 0
    mouse_dy: 0
    scroll_x: 0
    scroll_y: 0
    key_modifiers: gg.Modifier{}
    key_repeat: false
    pressed_keys: [false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false]      
    pressed_keys_edge: [false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false] 
    fps: gg.FPSConfig{
        x: 0
        y: 0
        width: 0
        height: 0
        show: false
        text_config: gx.TextCfg{
            color: Color{0, 0, 0, 0}
            size: 0
            align: unknown enum value
            vertical_align: unknown enum value
            max_width: 0
            family: ''
            bold: false
            mono: false
            italic: false
        }
        background_color: Color{0, 0, 0, 0}
    }
})
```