### PR TITLE
examples: smtp/mail fix reader notice

### DIFF
--- a/examples/smtp/mail.v
+++ b/examples/smtp/mail.v
@@ -24,7 +24,6 @@ fn main() {
 		port: mailport
 		username: username
 		password: password
-		reader: unsafe { nil }
 	}
 	send_cfg := smtp.Mail{
 		to: to
@@ -32,6 +31,6 @@ fn main() {
 		body_type: .html
 		body: body
 	}
-	mut client := smtp.new_client(client_cfg) or { panic('Error configuring smtp') }
-	client.send(send_cfg) or { panic('Error resolving email address') }
+	mut client := smtp.new_client(client_cfg) or { panic('Error with configuring smtp: ${err}') }
+	client.send(send_cfg) or { panic('Error resolving email address: ${err}') }
 }

--- a/examples/smtp/mail.v
+++ b/examples/smtp/mail.v
@@ -24,6 +24,7 @@ fn main() {
 		port: mailport
 		username: username
 		password: password
+		reader: unsafe { nil }
 	}
 	send_cfg := smtp.Mail{
 		to: to

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -33,7 +33,7 @@ pub struct Client {
 mut:
 	conn     net.TcpConn
 	ssl_conn &ssl.SSLConn = unsafe { nil }
-	reader   io.BufferedReader
+	reader   ?&io.BufferedReader
 pub:
 	server   string
 	port     int = 25
@@ -139,7 +139,7 @@ fn (mut c Client) connect_ssl() ! {
 fn (mut c Client) expect_reply(expected ReplyCode) ! {
 	mut str := ''
 	for {
-		str = c.reader.read_line()!
+		str = c.reader or { return error('the Client.reader field is not set') }.read_line()!
 		if str.len < 4 {
 			return error('Invalid SMTP response: ${str}')
 		}


### PR DESCRIPTION
Executing `v examples/smtp/mail.v` outputs this notice:
```bash
examples/smtp/mail.v:21:21: notice: interface field `io.BufferedReader.reader` must be initialized
   19 |     subject := os.input('Subject: ')
   20 |     body := os.input('Body: ')
   21 |     client_cfg := smtp.Client{
      |                        ~~~~~~~
   22 |         server: mailserver
   23 |         from: from
```

@spytheman suggested this small fix/workaround (`reader: unsafe { nil }`) on Discord.
https://discord.com/channels/592103645835821068/592294828432424960/1098252925727416340

