### PR TITLE
checker, cgen: fix infering type for comptimeselector when using ptr type

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -896,6 +896,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 				} else if c.inside_comptime_for_field && sym.kind in [.struct_, .any]
 					&& arg.expr is ast.ComptimeSelector {
 					comptime_typ := c.get_comptime_selector_type(arg.expr, ast.void_type)
+
 					if comptime_typ != ast.void_type {
 						typ = comptime_typ
 						if func.return_type.has_flag(.generic)
@@ -905,7 +906,8 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					}
 				}
 
-				if arg.expr.is_auto_deref_var() {
+				if arg.expr.is_auto_deref_var() || (arg.expr is ast.ComptimeSelector
+					&& (arg.expr as ast.ComptimeSelector).left.is_auto_deref_var()) {
 					typ = typ.deref()
 				}
 				// resolve &T &&T ...

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -896,7 +896,6 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 				} else if c.inside_comptime_for_field && sym.kind in [.struct_, .any]
 					&& arg.expr is ast.ComptimeSelector {
 					comptime_typ := c.get_comptime_selector_type(arg.expr, ast.void_type)
-
 					if comptime_typ != ast.void_type {
 						typ = comptime_typ
 						if func.return_type.has_flag(.generic)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -586,9 +586,6 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			concrete_types << concrete_type
 		}
 	}
-	if node.concrete_types.len > 0 {
-		println('>>> ${c.table.type_to_str(concrete_types[0])}')
-	}
 	if c.table.cur_fn != unsafe { nil } && c.table.cur_concrete_types.len == 0 && has_generic {
 		c.error('generic fn using generic types cannot be called outside of generic fn',
 			node.pos)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -586,6 +586,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			concrete_types << concrete_type
 		}
 	}
+	if node.concrete_types.len > 0 {
+		println('>>> ${c.table.type_to_str(concrete_types[0])}')
+	}
 	if c.table.cur_fn != unsafe { nil } && c.table.cur_concrete_types.len == 0 && has_generic {
 		c.error('generic fn using generic types cannot be called outside of generic fn',
 			node.pos)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1027,6 +1027,7 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 			if !param.typ.has_flag(.generic) {
 				continue
 			}
+			param_typ := param.typ
 			if mut call_arg.expr is ast.Ident {
 				if mut call_arg.expr.obj is ast.Var {
 					node_.args[i].typ = call_arg.expr.obj.typ
@@ -1034,7 +1035,6 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 						mut ctyp := g.get_comptime_var_type(call_arg.expr)
 						if ctyp != ast.void_type {
 							arg_sym := g.table.sym(ctyp)
-							param_typ := param.typ
 							if arg_sym.kind == .array && param_typ.has_flag(.generic)
 								&& g.table.final_sym(param_typ).kind == .array {
 								ctyp = (arg_sym.info as ast.Array).elem_type
@@ -1044,10 +1044,8 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 					} else if call_arg.expr.obj.ct_type_var == .generic_param {
 						mut ctyp := g.get_comptime_var_type(call_arg.expr)
 						if ctyp != ast.void_type {
-							param_typ := param.typ
 							arg_sym := g.table.final_sym(call_arg.typ)
 							param_typ_sym := g.table.sym(param_typ)
-
 							if param_typ.has_flag(.variadic) {
 								ctyp = ast.mktyp(ctyp)
 								comptime_args[i] = ctyp
@@ -1098,6 +1096,12 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 				}
 			} else if mut call_arg.expr is ast.ComptimeSelector {
 				comptime_args[i] = g.comptime_for_field_type
+				if call_arg.expr.left.is_auto_deref_var() {
+					comptime_args[i] = comptime_args[i].deref()
+				}
+				if param_typ.nr_muls() > 0 && comptime_args[i].nr_muls() > 0 {
+					comptime_args[i] = comptime_args[i].set_nr_muls(0)
+				}
 			}
 		}
 	}

--- a/vlib/v/tests/comptime_selector_ptr_test.v
+++ b/vlib/v/tests/comptime_selector_ptr_test.v
@@ -1,0 +1,46 @@
+struct Encoder {}
+
+struct Writer {}
+
+struct APrice {}
+
+struct Association {
+	association &Association = unsafe { nil }
+	price       APrice
+}
+
+fn get_value_from_ref[T](val &T) T {
+	return *val
+}
+
+fn (e &Encoder) encode_struct[U](val U, mut wr Writer) ! {
+	$for field in U.fields {
+		$if field.typ is &Association {
+			assert get_value_from_ref(val.$(field.name)) == Association{
+				association: unsafe { nil }
+				price: APrice{}
+			}
+		}
+	}
+}
+
+fn test_main() {
+	e := Encoder{}
+	mut sb := Writer{}
+
+	value := Association{
+		association: &Association{
+			price: APrice{}
+		}
+		price: APrice{}
+	}
+
+	assert get_value_from_ref(&Association{
+		price: APrice{}
+	}) == Association{
+		association: unsafe { nil }
+		price: APrice{}
+	}
+
+	e.encode_struct(value, mut sb)!
+}


### PR DESCRIPTION
Fix #17991