### PR TITLE
vweb: implement database pool

### DIFF
--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -6,7 +6,7 @@ The [gitly](https://gitly.org/) site is based on vweb.
 
 **_Some features may not be complete, and have some bugs._**
 
-## Getting start
+## Quick Start
 Just run **`v new <name> web`** in your terminal
 
 ## Features
@@ -16,6 +16,7 @@ Just run **`v new <name> web`** in your terminal
 - **Easy to deploy** just one binary file that also includes all templates. No need to install any
   dependencies.
 - **Templates are precompiled** all errors are visible at compilation time, not at runtime.
+- **Multithreaded** by default
 
 ### Examples
 
@@ -391,6 +392,96 @@ pub fn (mut app App) not_found() vweb.Result {
 }
 ```
 
+### Databases
+The `db` field in a vweb app is reserved for database connections. The connection is 
+copied to each new request.
+
+**Example:**
+
+```v
+module main
+
+import vweb
+import db.sqlite
+
+struct App {
+	vweb.Context
+mut:
+	db sqlite.DB
+}
+
+fn main() {
+	// create the database connection
+	mut db := sqlite.connect('db')!
+
+	vweb.run(&App{
+		db: db
+	}, 8080)
+}
+```
+
+### Multithreading
+By default, a vweb app is multithreaded, that means that multiple requests can
+be handled in parallel by using multiple CPU's: a worker pool. You can 
+change the number of workers (maximum allowed threads) by altering the `nr_workers`
+option. The default behaviour is to use the maximum number of jobs (cores in most cases).
+
+**Example:**
+```v ignore
+fn main() {
+	// assign a maximum of 4 workers
+	vweb.run_at(&App{}, nr_workers: 4)
+}
+```
+
+#### Database Pool
+A single connection database works fine if you run your app with 1 worker, of if
+you access a file-based database like a sqlite file.
+
+This approach will fail when using a non-file based database connection like a mysql
+connection to another server somewhere on the internet. Multiple threads would need to access
+the same connection at the same time.
+
+To resolve this issue, you can use the vweb's built-in database pool. The database pool
+will keep a number of connections open when the app is started and each worker is
+assigned its own connection.
+
+Let's look how we can improve our previous example with database pooling and using a 
+postgresql server instead.
+
+**Example:**
+```v
+module main
+
+import vweb
+import db.pg
+
+struct App {
+	vweb.Context
+	db_handle vweb.DatabasePool[pg.DB]
+mut:
+	db pg.DB
+}
+
+fn get_database_connection() pg.DB {
+	// insert your own credentials
+	return pg.connect(user: 'user', password: 'password', dbname: 'database') or { panic(err) }
+}
+
+fn main() {
+	// create the database pool and pass our `get_database_connection` function as handler
+	pool := vweb.database_pool(handler: get_database_connection)
+
+	// no need to set the `db` field
+	vweb.run(&App{
+		db_handle: pool
+	}, 8080)
+}
+```
+
+If you don't use the default number of workers (`nr_workers`) you have to change 
+it to the same number in `vweb.run_at` as in `vweb.database_pool`
+
 ### Controllers
 Controllers can be used to split up app logic so you are able to have one struct 
 per `"/"`.  E.g. a struct `Admin` for urls starting with `"/admin"` and a struct `Foo`
@@ -458,7 +549,8 @@ There will be an error, because the controller `Admin` handles all routes starti
 
 #### Databases and `[vweb_global]` in controllers
 
-Fields with `[vweb_global]` like a database have to passed to each controller individually.
+Fields with `[vweb_global]` have to passed to each controller individually.
+The `db` field is unique and will be treated as a `vweb_global` field at all times.
 
 **Example:**
 ```v
@@ -470,14 +562,14 @@ import db.sqlite
 struct App {
 	vweb.Context
 	vweb.Controller
-pub mut:
-	db sqlite.DB [vweb_global]
+mut:
+	db sqlite.DB
 }
 
 struct Admin {
 	vweb.Context
-pub mut:
-	db sqlite.DB [vweb_global]
+mut:
+	db sqlite.DB
 }
 
 fn main() {
@@ -488,6 +580,50 @@ fn main() {
 		controllers: [
 			vweb.controller('/admin', &Admin{
 				db: db
+			}),
+		]
+	}
+}
+```
+
+#### Using a database pool
+
+**Example:**
+```v
+module main
+
+import vweb
+import db.pg
+
+struct App {
+	vweb.Context
+	vweb.Controller
+	db_handle vweb.DatabasePool[pg.DB]
+mut:
+	db pg.DB
+}
+
+struct Admin {
+	vweb.Context
+	db_handle vweb.DatabasePool[pg.DB]
+mut:
+	db pg.DB
+}
+
+fn get_database_connection() pg.DB {
+	// insert your own credentials
+	return pg.connect(user: 'user', password: 'password', dbname: 'database') or { panic(err) }
+}
+
+fn main() {
+	// create the database pool and pass our `get_database_connection` function as handler
+	pool := vweb.database_pool(handler: get_database_connection)
+
+	mut app := &App{
+		db_handle: pool
+		controllers: [
+			vweb.controller('/admin', &Admin{
+				db_handle: pool
 			}),
 		]
 	}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -12,6 +12,7 @@ import net.urllib
 import time
 import json
 import encoding.html
+import db.pg
 
 // A type which don't get filtered inside templates
 pub type RawHtml = string
@@ -377,6 +378,16 @@ mut:
 	db T
 }
 
+interface DbPoolInterface[T] {
+	DatabaseInterface
+}
+
+interface DatabaseInterface[T] {
+	get_connection fn (tid int) T
+mut:
+	db T
+}
+
 interface DbInterface {
 	db voidptr
 }
@@ -531,7 +542,7 @@ fn new_request_app[T](global_app &T, ctx Context, tid int) &T {
 	$if T is DbInterface {
 		// copy a database to a app without multithreading
 		request_app.db = global_app.db
-	} $else {
+	} $else $if T is DbPoolInterface[pg.DB] {
 		// get database connection from the connection pool
 		request_app.db = global_app.Database.get_connection(tid)
 	}


### PR DESCRIPTION
At this moment it is only possible to have 1 ongoing datbase connection for an entire vweb application. Problems arise when multiple workers need to access that same database connection over multiple threads, see #18006.

This pullrequest adds the option to have a pool of database connections. 

## Usage
Example with postgres as database.

```v
module main

import vweb
import db.pg

struct App {
	vweb.Context
	db_handle vweb.DatabasePool[pg.DB]
mut:
	db pg.DB
}

fn get_database_connection() pg.DB {
	return pg.connect(user: 'dev', password: 'password', dbname: 'database') or { panic(err) }
}

fn main() {
	pool := vweb.database_pool(handler: get_database_connection, nr_workers: 20)

	vweb.run_at(&App{
		db_handle: pool
	},
		port: 8080
		nr_workers: 20
	)!
}
```

In this example there are 20 workers and there must be 1 database connection for each worker (thread).

The default nr of workers is the same as for a default app:
```v
[params]
pub struct PoolParams[T] {
	handler    fn () T [required]
	nr_workers int = runtime.nr_jobs()
}
```

## DIfferent databases
The above example configured for mysql:
```v
module main

import vweb
import db.mysql

struct App {
	vweb.Context
	vweb.Controller
	db_handle vweb.DatabasePool[mysql.Connection]
mut:
	db mysql.Connection
}

fn get_database_connection() mysql.Connection {
	mut connection := mysql.Connection{
		// host: ''
		// port: 3306
		username: 'root'
		// password: ''
		dbname: 'mysql'
	}
	connection.connect() or { panic(err) }
	return connection
}

fn main() {
	pool := vweb.database_pool(handler: get_database_connection, nr_workers: 20)

	vweb.run_at(&App{
		db_handle: pool
	},
		port: 8080
		nr_workers: 20
	)!
}
```

Only the types in the `App` struct need to be changed and the implementation of the pool handler.

## Compatibility
All older vweb applications with a single db connection will still work so no breaking changes.

## Performance
Test script `run.sh`:
```sh
#!/bin/bash

sleep 1
wrk -t 4 -c 20 -d10s http://127.0.0.1:8080/ &
wrk -t 4 -c 20 -d10s http://127.0.0.1:8080/other &
```
Output:
```
Running 10s test @ http://127.0.0.1:8080/
Running 10s test @ http://127.0.0.1:8080/other
  4 threads and 20 connections
  4 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.15ms  642.50us  16.56ms   80.83%
    Req/Sec     0.91k   413.37     1.64k    68.00%
  36058 requests in 10.01s, 3.61MB read
Requests/sec:   3603.88
Transfer/sec:    369.54KB
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.14ms  639.29us  12.51ms   81.35%
    Req/Sec     0.96k    36.87     1.08k    76.50%
  38082 requests in 10.01s, 3.81MB read
Requests/sec:   3804.78
Transfer/sec:    390.14KB
```
Tested on intel i9 12900K with 24 threads (23 workers).

The test was perfomed with [this](https://gist.github.com/Casper64/6b37ab26265be5f5240e2f4c963b1162) script.
The load is equally distributed in the app averaging at $3604+ 3805 = 7409$ request per second.


