### PR TITLE
checker: missing string/bool invalid operation validation as concrete type

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -16,7 +16,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	if node.op == .key_is {
 		c.inside_x_is_type = true
 	}
-	mut right_type := c.expr(node.right)
+	mut right_type := c.unwrap_generic(c.expr(node.right))
 	if node.op == .key_is {
 		c.inside_x_is_type = false
 	}

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -9,14 +9,14 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	defer {
 		c.expected_type = former_expected_type
 	}
-	mut left_type := c.unwrap_generic(c.expr(node.left))
+	mut left_type := c.expr(node.left)
 	node.left_type = left_type
 	c.expected_type = left_type
 
 	if node.op == .key_is {
 		c.inside_x_is_type = true
 	}
-	mut right_type := c.unwrap_generic(c.expr(node.right))
+	mut right_type := c.expr(node.right)
 	if node.op == .key_is {
 		c.inside_x_is_type = false
 	}
@@ -649,10 +649,11 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		else {}
 	}
 	// TODO: Absorb this block into the above single side check block to accelerate.
-	if left_type == ast.bool_type && node.op !in [.eq, .ne, .logical_or, .and] {
+	if c.unwrap_generic(left_type) == ast.bool_type && node.op !in [.eq, .ne, .logical_or, .and] {
 		c.error('bool types only have the following operators defined: `==`, `!=`, `||`, and `&&`',
 			node.pos)
-	} else if left_type == ast.string_type && node.op !in [.plus, .eq, .ne, .lt, .gt, .le, .ge] {
+	} else if c.unwrap_generic(left_type) == ast.string_type
+		&& node.op !in [.plus, .eq, .ne, .lt, .gt, .le, .ge] {
 		// TODO broken !in
 		c.error('string types only have the following operators defined: `==`, `!=`, `<`, `>`, `<=`, `>=`, and `+`',
 			node.pos)

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -9,7 +9,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	defer {
 		c.expected_type = former_expected_type
 	}
-	mut left_type := c.expr(node.left)
+	mut left_type := c.unwrap_generic(c.expr(node.left))
 	node.left_type = left_type
 	c.expected_type = left_type
 
@@ -283,8 +283,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 
-			if !c.pref.translated
-				&& left_sym.kind in [.string, .array, .array_fixed, .map, .struct_] {
+			if !c.pref.translated && left_sym.kind in [.array, .array_fixed, .map, .struct_] {
 				if left_sym.has_method_with_generic_parent(node.op.str()) {
 					if method := left_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type
@@ -302,8 +301,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 							left_right_pos)
 					}
 				}
-			} else if !c.pref.translated
-				&& right_sym.kind in [.string, .array, .array_fixed, .map, .struct_] {
+			} else if !c.pref.translated && right_sym.kind in [.array, .array_fixed, .map, .struct_] {
 				if right_sym.has_method_with_generic_parent(node.op.str()) {
 					if method := right_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -283,7 +283,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 
-			if !c.pref.translated && left_sym.kind in [.array, .array_fixed, .map, .struct_] {
+			if !c.pref.translated
+				&& left_sym.kind in [.string, .array, .array_fixed, .map, .struct_] {
 				if left_sym.has_method_with_generic_parent(node.op.str()) {
 					if method := left_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type
@@ -301,7 +302,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 							left_right_pos)
 					}
 				}
-			} else if !c.pref.translated && right_sym.kind in [.array, .array_fixed, .map, .struct_] {
+			} else if !c.pref.translated
+				&& right_sym.kind in [.string, .array, .array_fixed, .map, .struct_] {
 				if right_sym.has_method_with_generic_parent(node.op.str()) {
 					if method := right_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type


### PR DESCRIPTION
Fix #18007 (first issue)

```V
struct Wrapped[T] {
	value T
}

fn (w Wrapped[T]) double() Wrapped[T] {
	return Wrapped[T]{w.value * 2}
}

fn make_wrapped[T](value T) Wrapped[T] {
	return Wrapped[T]{value}
}

fn main() {
	println(make_wrapped('str'))
}
```