### PR TITLE
tests: clean up c_struct_with_reserved_field_name_test.v

### DIFF
--- a/vlib/v/tests/c_struct_with_reserved_field_name_test.v
+++ b/vlib/v/tests/c_struct_with_reserved_field_name_test.v
@@ -17,6 +17,6 @@ fn test_c_struct_with_reserved_field_name() {
 		window_title: 'Polygons'
 	)
 	game.gg = cont
-	println(game.gg)
+	game.gg.str()
 	assert true
 }


### PR DESCRIPTION
This PR clean up c_struct_with_reserved_field_name_test.v.

- Avoid printing out large amounts of structure information.

```v
 OK    [ 489/1416]   346.828 ms vlib/v/tests/c_function_mut_param/option_args_test.v
 OK    [ 490/1416]   369.833 ms vlib/v/tests/c_struct_free/c_struct_free_property_test.v
 OK    [ 491/1416]   367.251 ms vlib/v/tests/call_on_anon_test.v
 OK    [ 492/1416]   353.942 ms vlib/v/tests/call_to_str_on_option_test.v
Option(gg.Context{
    render_text: true
    image_cache: []
    needs_refresh: false
    ticks: 0
    native_rendering: false
    scale: 0.0
    width: 0
    height: 0
    clear_pass:     sokol.gfx.PassAction(C.sg_pass_action{
    _start_canary: 0
    colors: [C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}, C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}, C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}, C.sg_color_attachment_action{
    action: _default
    value:     sokol.gfx.Color(C.sg_color{
    r: 0.0
    g: 0.0
    b: 0.0
    a: 0.0
})
}]
    depth:     sokol.gfx.DepthAttachmentAction(C.sg_depth_attachment_action{
    action: _default
    value: 0.0
})
    stencil:     sokol.gfx.StencilAttachmentAction(C.sg_stencil_attachment_action{
    action: _default
    value: 0
})
    _end_canary: 0
})
    window:     sokol.sapp.Desc(C.sapp_desc{
    init_cb: fn ()
    frame_cb: fn ()
    cleanup_cb: fn ()
    event_cb: fn (sokol.sapp.Event)
    fail_cb: fn (u8)
    user_data: 0
    init_userdata_cb: fn (voidptr)
    frame_userdata_cb: fn (voidptr)
    cleanup_userdata_cb: fn (voidptr)
    event_userdata_cb: fn (sokol.sapp.Event, voidptr)
    fail_userdata_cb: fn (char, voidptr)
    width: 0
    height: 0
    sample_count: 0
    swap_interval: 0
    high_dpi: false
    fullscreen: false
    alpha: false
    window_title: &C""
    enable_clipboard: false
    clipboard_size: 0
    enable_dragndrop: false
    max_dropped_files: 0
    max_dropped_file_path_length: 0
    icon:     sokol.sapp.IconDesc(C.sapp_icon_desc{
    sokol_default: false
    images: [C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}, C.sapp_image_desc{
    width: 0
    height: 0
    pixels:     sokol.sapp.Range(C.sapp_range{
    ptr: 0
    size: 0
})
}]
})
    gl_force_gles2: false
    win32_console_utf8: false
    win32_console_create: false
    win32_console_attach: false
    html5_canvas_name: &C""
    html5_canvas_resize: false
    html5_preserve_drawing_buffer: false
    html5_premultiplied_alpha: false
    html5_ask_leave_site: false
    ios_keyboard_resizes_canvas: false
    __v_native_render: false
    allocator: C.sapp_allocator{
        alloc: fn (usize, voidptr) voidptr
        free: fn (voidptr, voidptr)
        user_data: 0
    }
    logger: C.sapp_logger{
        log_cb: fn (char, voidptr)
        user_data: 0
    }
})
    timage_pip:     sokol.sgl.Pipeline(C.sgl_pipeline{
    id: 0
})
    pipeline: &nil
    config: gg.Config{
        width: 0
        height: 0
        use_ortho: false
        retina: false
        resizable: false
        user_data: 0
        font_size: 0
        create_window: false
        window_title: ''
        borderless_window: false
        always_on_top: false
        bg_color: Color{0, 0, 0, 0}
        init_fn: fn (voidptr)
        frame_fn: fn (voidptr)
        native_frame_fn: fn (voidptr)
        cleanup_fn: fn (voidptr)
        fail_fn: fn (string, voidptr)
        event_fn: fn (gg.Event, voidptr)
        quit_fn: fn (gg.Event, voidptr)
        keydown_fn: fn (gg.KeyCode, gg.Modifier, voidptr)
        keyup_fn: fn (gg.KeyCode, gg.Modifier, voidptr)
        char_fn: fn (u32, voidptr)
        move_fn: fn (f32, f32, voidptr)
        click_fn: fn (f32, f32, gg.MouseButton, voidptr)
        unclick_fn: fn (f32, f32, gg.MouseButton, voidptr)
        leave_fn: fn (gg.Event, voidptr)
        enter_fn: fn (gg.Event, voidptr)
        resized_fn: fn (gg.Event, voidptr)
        scroll_fn: fn (gg.Event, voidptr)
        fullscreen: false
        scale: 0.0
        sample_count: 0
        swap_interval: 0
        font_path: ''
        custom_bold_font_path: ''
        ui_mode: false
        font_bytes_normal: []
        font_bytes_bold: []
        font_bytes_mono: []
        font_bytes_italic: []
        native_rendering: false
        enable_dragndrop: false
        max_dropped_files: 0
        max_dropped_file_path_length: 0
    }
    user_data: 0
    ft: &nil
    font_inited: false
    ui_mode: false
    frame: 0
    mbtn_mask: 0
    mouse_buttons: gg.MouseButtons{}
    mouse_pos_x: 0
    mouse_pos_y: 0
    mouse_dx: 0
    mouse_dy: 0
    scroll_x: 0
    scroll_y: 0
    key_modifiers: gg.Modifier{}
    key_repeat: false
    pressed_keys: [false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false]
    pressed_keys_edge: [false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false]
    fps: gg.FPSConfig{
        x: 0
        y: 0
        width: 0
        height: 0
        show: false
        text_config: gx.TextCfg{
            color: Color{0, 0, 0, 0}
            size: 0
            align: unknown enum value
            vertical_align: unknown enum value
            max_width: 0
            family: ''
            bold: false
            mono: false
            italic: false
        }
        background_color: Color{0, 0, 0, 0}
    }
})
 OK    [ 493/1416]   613.516 ms vlib/v/tests/c_struct_with_reserved_field_name_test.v
 OK    [ 494/1416]   336.708 ms vlib/v/tests/calling_module_functions_with_maps_of_arrays_test.v
 OK    [ 495/1416]   361.195 ms vlib/v/tests/cast_bool_to_int_test.v
 OK    [ 496/1416]   369.328 ms vlib/v/tests/cast_comptime_test.v
```