### PR TITLE
parser: check generic fntype declaration without type name

### DIFF
--- a/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv
+++ b/vlib/v/checker/tests/generics_fn_called_fntype_arg_mismatch.vv
@@ -1,9 +1,9 @@
-pub type FnArrayInit = fn (idx int) T
+pub type FnArrayInit[T] = fn (idx int) T
 
 pub fn new_array[T](len int, initfn FnArrayInit[T]) []T {
 	mut res := []T{len: len}
 	for idx in 0 .. res.len {
-		res[idx] = initfn(idx)
+		res[idx] = initfn[T](idx)
 	}
 	return res
 }

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -230,6 +230,7 @@ pub fn (mut p Parser) parse_multi_return_type() ast.Type {
 
 // given anon name based off signature when `name` is blank
 pub fn (mut p Parser) parse_fn_type(name string, generic_types []ast.Type) ast.Type {
+	fn_type_pos := p.peek_token(-2).pos()
 	p.check(.key_fn)
 
 	for attr in p.attrs {
@@ -276,6 +277,10 @@ pub fn (mut p Parser) parse_fn_type(name string, generic_types []ast.Type) ast.T
 		generic_names: generic_types.map(p.table.sym(it).name)
 		is_method: false
 		attrs: p.attrs
+	}
+	if has_generic && generic_types.len == 0 && name.len > 0 {
+		p.error_with_pos('`${name}` type is generic fntype, must specify the generic type names, e.g. ${name}[T]',
+			fn_type_pos)
 	}
 	// MapFooFn typedefs are manually added in cheaders.v
 	// because typedefs get generated after the map struct is generated

--- a/vlib/v/parser/tests/generic_fn_type_decl_err.out
+++ b/vlib/v/parser/tests/generic_fn_type_decl_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/generic_fn_type_decl_err.vv:1:6: error: `Fn` type is generic fntype, must specify the generic type names, e.g. Fn[T]
+    1 | type Fn = fn (I) !(O, R)
+      |      ~~
+    2 |
+    3 | fn main() {

--- a/vlib/v/parser/tests/generic_fn_type_decl_err.vv
+++ b/vlib/v/parser/tests/generic_fn_type_decl_err.vv
@@ -1,0 +1,4 @@
+type Fn = fn (I) !(O, R)
+
+fn main() {
+}


### PR DESCRIPTION
This PR check generic fntype declaration without type name.

- Check generic fntype declaration without type name.
- Add test.

```v
type Fn = fn (I) !(O, R)

fn main() {
}

PS D:\Test\v\tt1> v run .
tt1.v:1:6: error: `Fn` type is generic fntype, must specify the generic type names, e.g. Fn[T]
    1 | type Fn = fn (I) !(O, R)
      |      ~~
    2 | 
    3 | fn main() {
```