### PR TITLE
checker: disallow deferencing a `nil` pointer

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3876,6 +3876,17 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 		if right_type.is_voidptr() {
 			c.error('cannot dereference to void', node.pos)
 		}
+		if mut node.right is ast.Ident {
+			if mut var := node.right.scope.find_var('${node.right.name}') {
+				// Workaround for unused variable warning
+				_ = var
+				if mut var.expr is ast.UnsafeExpr {
+					if mut var.expr.expr is ast.Nil {
+						c.error('cannot deference a `nil` pointer', node.right.pos)
+					}
+				}
+			}
+		}
 	}
 	if node.op == .bit_not && !c.unwrap_generic(right_type).is_int() && !c.pref.translated
 		&& !c.file.is_translated {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3877,11 +3877,9 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 			c.error('cannot dereference to void', node.pos)
 		}
 		if mut node.right is ast.Ident {
-			if mut var := node.right.scope.find_var('${node.right.name}') {
-				// Workaround for unused variable warning
-				_ = var
-				if mut var.expr is ast.UnsafeExpr {
-					if mut var.expr.expr is ast.Nil {
+			if var := node.right.scope.find_var('${node.right.name}') {
+				if var.expr is ast.UnsafeExpr {
+					if var.expr.expr is ast.Nil {
 						c.error('cannot deference a `nil` pointer', node.right.pos)
 					}
 				}

--- a/vlib/v/checker/tests/deference_nil_ptr_err.out
+++ b/vlib/v/checker/tests/deference_nil_ptr_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/deference_nil_ptr_err.vv:3:10: error: cannot deference a `nil` pointer
+    1 | foo_ptr := unsafe { nil }
+    2 |
+    3 | println(*foo_ptr)
+      |          ~~~~~~~

--- a/vlib/v/checker/tests/deference_nil_ptr_err.vv
+++ b/vlib/v/checker/tests/deference_nil_ptr_err.vv
@@ -1,0 +1,3 @@
+foo_ptr := unsafe { nil }
+
+println(*foo_ptr)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 262c192</samp>

Add a checker error and a test case for dereferencing a nil pointer. This improves the compiler's ability to detect unsafe code that could cause a segmentation fault.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 262c192</samp>

*  Add a check for dereferencing a nil pointer in the checker module ([link](https://github.com/vlang/v/pull/18038/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R3879-R3889))
*  Add a test case for the nil pointer dereference check ([link](https://github.com/vlang/v/pull/18038/files?diff=unified&w=0#diff-d2907434d3970e418ae2497200d165ed8f3c9f9ade46e110553b338c58758984R1-R5), [link](https://github.com/vlang/v/pull/18038/files?diff=unified&w=0#diff-9ef21ca233e113f27854d9747a7fde170df5f211695e96d1abd4f315d3147f64R1-R3))

Fixes https://github.com/vlang/v/issues/18034
