### PR TITLE
transformer: `ast.IfExpr` reports correct `has_else` after transformation

### DIFF
--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -368,9 +368,13 @@ pub fn (mut t Transformer) expr_stmt_if_expr(mut node ast.IfExpr) ast.Expr {
 	if stop_index != -1 {
 		unreachable_branches = unreachable_branches.filter(it < stop_index)
 		node.branches = node.branches[..stop_index + 1]
+		node.has_else = false // if any matches true, else case cannot be reached
 	}
 	for unreachable_branches.len != 0 {
 		node.branches.delete(unreachable_branches.pop())
+	}
+	if node.branches.len == 1 {
+		node.has_else = false
 	}
 	/*
 	FIXME: optimization causes cgen error `g.expr(): unhandled EmptyExpr`


### PR DESCRIPTION
- In a constant `ast.IfExpr`, the transformer can wipe out branches.
- When it does and removes an else case, the field `has_else` has a chance to still be set.
- This PR fixes this bug in the transformer.

Take this code below,
```v
if true {
    a = 20
} else {
    a = 25
}
```
only a single `ast.IfBranch`, but has_else is still set!
```
ast.IfExpr{
    branches: [ast.IfBranch{
        // ...
    }]
    has_else: true
}
```

- I came across this bug when developing the WebAssembly backend, it relies the on `has_else` field.
- This specific feature would be hard to implement specific tests.

\- l-m