### PR TITLE
docs: create custom problemMatcher in VSCode task to V

### DIFF
--- a/doc/vscode.md
+++ b/doc/vscode.md
@@ -127,9 +127,20 @@ with a label named `build`.
             ],
             "group": "build",
             "presentation": {
-                "reveal": "silent"
+                "reveal": "never"
             },
-            "problemMatcher": "$gcc"
+            "problemMatcher": {
+                "owner": "v",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
Create a custom `problemMatcher` in `VSCode` task to match compiler problems. I change also `presentation` setting to never because now `problems` tab shows errors.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ac7c85</samp>

Improved the VS Code build task for V projects by hiding the terminal output and adding a custom problem matcher that integrates with the editor. Modified the file `doc/vscode.md` to reflect these changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ac7c85</samp>

*  Configure VS Code to show V compiler problems in the editor and the Problems panel ([link](https://github.com/vlang/v/pull/18047/files?diff=unified&w=0#diff-18b210667f6c06e8ade21fe0e530a1daaff82ab9514a98c2915b4cecdfbe64a6L130-R143))
