### PR TITLE
cgen: fix comptime ptr comparison generated code

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -100,7 +100,9 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 	is_none_check := node.left_type.has_flag(.option) && node.right is ast.None
 	if is_none_check {
 		g.gen_is_none_check(node)
-	} else if (left.typ.is_ptr() && right.typ.is_int()) || (right.typ.is_ptr() && left.typ.is_int()) {
+	} else if (left.typ.is_ptr() && right.typ.is_int())
+		|| (right.typ.is_ptr() && left.typ.is_int())
+		|| (left.typ.is_ptr() && right.typ == ast.nil_type) {
 		g.gen_plain_infix_expr(node)
 	} else if (left.typ.idx() == ast.string_type_idx || (!has_defined_eq_operator
 		&& left.unaliased.idx() == ast.string_type_idx)) && node.right is ast.StringLiteral

--- a/vlib/v/tests/comptime_indirection_check_test.v
+++ b/vlib/v/tests/comptime_indirection_check_test.v
@@ -1,0 +1,35 @@
+struct Encoder {}
+
+struct Writer {}
+
+struct StructTypePointer[T] {
+mut:
+	val &T
+}
+
+pub fn (e &Encoder) encode_value[T](val T, mut wr Writer) ! {
+	assert e.encode_struct[T](val, 1, mut wr)! == 'a'
+}
+
+fn (e &Encoder) encode_struct[U](val U, level int, mut wr Writer) !string {
+	$for field in U.fields {
+		if val.$(field.name) != unsafe { nil } {
+			$if field.indirections > 0 {
+				assert field.indirections == 1
+				return 'a'
+			} $else {
+				return 'b'
+			}
+		}
+	}
+	return 'z'
+}
+
+fn test_check() {
+	e := Encoder{}
+	mut sb := Writer{}
+
+	mut string_initialized_with_reference := 'ads'
+	e.encode_value(StructTypePointer[string]{ val: &string_initialized_with_reference }, mut
+		sb) or {}
+}


### PR DESCRIPTION
Fix #18028

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba34503</samp>

Fix pointer and nil comparison bug in C code generation. Add a condition to `vlib/v/gen/c/infix.v` to handle `nil` as a null pointer.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba34503</samp>

* Allow pointer and integer comparisons with `nil` ([link](https://github.com/vlang/v/pull/18048/files?diff=unified&w=0#diff-4194723712edfd7a1a69102329b9169cc79bc1d109393153e0537039c5ca1988L103-R105))
