### PR TITLE
cgen: fix cross assign with generic fn call (fix #18042)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -985,7 +985,10 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			g.write(')')
 		}
 		ast.CallExpr {
-			fn_name := val.name.replace('.', '__')
+			mut fn_name := val.name.replace('.', '__')
+			if val.concrete_types.len > 0 {
+				fn_name = g.generic_fn_name(val.concrete_types, fn_name)
+			}
 			g.write('${fn_name}(')
 			for i, arg in val.args {
 				g.gen_cross_tmp_variable(left, arg.expr)

--- a/vlib/v/tests/cross_assign_with_generic_fn_call_test.v
+++ b/vlib/v/tests/cross_assign_with_generic_fn_call_test.v
@@ -1,0 +1,10 @@
+import math
+
+fn test_cross_assign_with_generic_fn_call() {
+	mut x := -1
+	mut y := -2
+	x, y = y, math.abs(x)
+	println('${x} | ${y}')
+	assert x == -2
+	assert y == 1
+}


### PR DESCRIPTION
This PR fix cross assign with generic fn call (fix #18042).

- Fix cross assign with generic fn call.
- Add test.

```v
import math

fn main() {
	mut x := -1
	mut y := -2
	x, y = y, math.abs(x)
	println('${x} | ${y}')
	assert x == -2
	assert y == 1
}

PS D:\Test\v\tt1> v run .
-2 | 1
```