### PR TITLE
parser, checker: fix generic struct init with field struct init (fix #18040)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -324,7 +324,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						continue
 					}
 					gtyp_name := c.table.sym(gtyp).name
-					if gtyp_name !in c.table.cur_fn.generic_names {
+					if gtyp_name.len == 1 && gtyp_name !in c.table.cur_fn.generic_names {
 						cur_generic_names := '(' + c.table.cur_fn.generic_names.join(',') + ')'
 						c.error('generic struct init type parameter `${gtyp_name}` must be within the parameters `${cur_generic_names}` of the current generic function',
 							node.pos)

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -398,6 +398,7 @@ fn (mut p Parser) struct_init(typ_str string, kind ast.StructInitKind, is_option
 	first_pos := (if kind == .short_syntax && p.prev_tok.kind == .lcbr { p.prev_tok } else { p.tok }).pos()
 	p.struct_init_generic_types = []ast.Type{}
 	mut typ := if kind == .short_syntax { ast.void_type } else { p.parse_type() }
+	struct_init_generic_types := p.struct_init_generic_types.clone()
 	if is_option {
 		typ = typ.set_flag(.option)
 	}
@@ -492,7 +493,7 @@ fn (mut p Parser) struct_init(typ_str string, kind ast.StructInitKind, is_option
 		is_short_syntax: kind == .short_syntax
 		is_anon: kind == .anon
 		pre_comments: pre_comments
-		generic_types: p.struct_init_generic_types
+		generic_types: struct_init_generic_types
 	}
 }
 

--- a/vlib/v/tests/generic_struct_init_with_field_struct_init_test.v
+++ b/vlib/v/tests/generic_struct_init_with_field_struct_init_test.v
@@ -1,0 +1,18 @@
+struct Child {
+}
+
+struct Test[T] {
+	child Child
+}
+
+fn new[T]() Test[T] {
+	return Test[T]{
+		child: Child{}
+	}
+}
+
+fn test_generic_struct_init_with_field_struct_init() {
+	t := new[int]()
+	println(t)
+	assert t.child == Child{}
+}


### PR DESCRIPTION
This PR fix generic struct init with field struct init (fix #18040).

- Fix generic struct init with field struct init.
- Add test.

```v
struct Child {
}

struct Test[T] {
	child Child
}

fn new[T]() Test[T] {
	return Test[T]{
		child: Child{}
	}
}

fn main() {
	t := new[int]()
	println(t)
	assert t.child == Child{}
}

PS D:\Test\v\tt1> v run .    
Test[int]{
    child: Child{}
}
```