### PR TITLE
wasm: Add support for [export]ed functions

### DIFF
--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -309,11 +309,17 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 	for idx := paraml.len; idx < g.local_temporaries.len; idx++ {
 		temporaries << g.local_temporaries[idx].typ
 	}
+
+	mut fn_name := name.str
+	if cattr := node.attrs.find_first('export') {
+		fn_name = cattr.arg.str
+	}
+
 	function := binaryen.addfunction(g.mod, name.str, params_type, return_type, temporaries.data,
 		temporaries.len, wasm_expr)
 	//&& g.pref.os == .browser
 	if node.is_pub && node.mod == 'main' {
-		binaryen.addfunctionexport(g.mod, name.str, name.str)
+		binaryen.addfunctionexport(g.mod, name.str, fn_name)
 	}
 	if g.pref.is_debug {
 		binaryen.functionsetdebuglocation(function, wasm_expr, g.file_path_idx, node.pos.line_nr,

--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -310,16 +310,16 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 		temporaries << g.local_temporaries[idx].typ
 	}
 
-	mut fn_name := name.str
-	if cattr := node.attrs.find_first('export') {
-		fn_name = cattr.arg.str
-	}
-
 	function := binaryen.addfunction(g.mod, name.str, params_type, return_type, temporaries.data,
 		temporaries.len, wasm_expr)
+	
+	mut export_name := name.str
+	if cattr := node.attrs.find_first('export') {
+		export_name = cattr.arg.str
+	}
 	//&& g.pref.os == .browser
 	if node.is_pub && node.mod == 'main' {
-		binaryen.addfunctionexport(g.mod, name.str, fn_name)
+		binaryen.addfunctionexport(g.mod, name.str, export_name)
 	}
 	if g.pref.is_debug {
 		binaryen.functionsetdebuglocation(function, wasm_expr, g.file_path_idx, node.pos.line_nr,

--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -312,7 +312,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 
 	function := binaryen.addfunction(g.mod, name.str, params_type, return_type, temporaries.data,
 		temporaries.len, wasm_expr)
-	
+
 	mut export_name := name.str
 	if cattr := node.attrs.find_first('export') {
 		export_name = cattr.arg.str


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR adds a check in the new wasm backend that takes the `[export: 'name']` attribute into account when exporting functions for wasm modules. It doesn't alter the behavior otherwise (e.g. functions still need to be marked `pub` and need to be part of the `main` module), however it now uses the name specified in the `[export]` attribute (if applied) rather than the actual function name).

Partially addresses #17621