### PR TITLE
toml: fix scanner floating point detection

### DIFF
--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -589,12 +589,22 @@ fn (mut s Scanner) extract_number() !string {
 	}
 	s.pos++
 	s.col++
-	if u8(s.peek(1)).is_digit() && (s.peek(2) == `\n` || s.peek(2) == `,`) && s.is_left_of_assign {
-		s.pos++
-		s.col++
-	}
 	for s.pos < s.text.len {
 		c = s.at()
+		// Adjust scanner position to floating point numbers
+		mut i, mut float_precision := 1, 0
+		for c_ := u8(s.peek(i)); c_ != scanner.end_of_text && c_ != `\n`; c_ = u8(s.peek(i)) {
+			if !u8(c_).is_digit() && c_ != `.` && c_ != `,` {
+				float_precision = 0
+				break
+			}
+			if u8(c_).is_digit() && c == `.` {
+				float_precision++
+			}
+			i++
+		}
+		s.pos += float_precision
+		s.col += float_precision
 		// Handle signed exponent notation. I.e.: 3e2, 3E2, 3e-2, 3E+2, 3e0, 3.1e2, 3.1E2, -1E-1
 		if c in [`e`, `E`] && s.peek(1) in [`+`, `-`] && u8(s.peek(2)).is_digit() {
 			s.pos += 2

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -589,6 +589,10 @@ fn (mut s Scanner) extract_number() !string {
 	}
 	s.pos++
 	s.col++
+	if u8(s.peek(1)).is_digit() && s.peek(2) == 10 {
+		s.pos++
+		s.col++
+	}
 	for s.pos < s.text.len {
 		c = s.at()
 		// Handle signed exponent notation. I.e.: 3e2, 3E2, 3e-2, 3E+2, 3e0, 3.1e2, 3.1E2, -1E-1

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -594,11 +594,11 @@ fn (mut s Scanner) extract_number() !string {
 		// Adjust scanner position to floating point numbers
 		mut i, mut float_precision := 1, 0
 		for c_ := u8(s.peek(i)); c_ != scanner.end_of_text && c_ != `\n`; c_ = u8(s.peek(i)) {
-			if !u8(c_).is_digit() && c_ != `.` && c_ != `,` {
+			if !c_.is_digit() && c_ != `.` && c_ != `,` {
 				float_precision = 0
 				break
 			}
-			if u8(c_).is_digit() && c == `.` {
+			if c_.is_digit() && c == `.` {
 				float_precision++
 			}
 			i++

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -589,7 +589,7 @@ fn (mut s Scanner) extract_number() !string {
 	}
 	s.pos++
 	s.col++
-	if u8(s.peek(1)).is_digit() && s.peek(2) == 10 && s.is_left_of_assign {
+	if u8(s.peek(1)).is_digit() && (s.peek(2) == `\n` || s.peek(2) == `,`) && s.is_left_of_assign {
 		s.pos++
 		s.col++
 	}

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -589,7 +589,7 @@ fn (mut s Scanner) extract_number() !string {
 	}
 	s.pos++
 	s.col++
-	if u8(s.peek(1)).is_digit() && s.peek(2) == 10 {
+	if u8(s.peek(1)).is_digit() && s.peek(2) == 10 && s.is_left_of_assign {
 		s.pos++
 		s.col++
 	}

--- a/vlib/toml/tests/reflect_test.v
+++ b/vlib/toml/tests/reflect_test.v
@@ -18,6 +18,13 @@ bools = [true, false, true, true]
 
 floats = [0.0, 1.0, 2.0, 3.0]
 
+floats_br = [
+  0.0,
+  1.0,
+  2.0,
+  3.0
+]
+
 int_map = {"a" = 0, "b" = 1, "c" = 2, "d" = 3}
 
 [bio]
@@ -44,14 +51,15 @@ struct Bio {
 }
 
 struct User {
-	name     string
-	age      int
-	height   f64
-	birthday toml.Date
-	strings  []string
-	bools    []bool
-	floats   []f32
-	int_map  map[string]int
+	name      string
+	age       int
+	height    f64
+	birthday  toml.Date
+	strings   []string
+	bools     []bool
+	floats    []f32
+	floats_br []f32
+	int_map   map[string]int
 
 	config toml.Any
 mut:
@@ -73,6 +81,7 @@ fn test_reflect() {
 	assert user.strings == ['v matures', 'like rings', 'spread in the', 'water']
 	assert user.bools == [true, false, true, true]
 	assert user.floats == [f32(0.0), 1.0, 2.0, 3.0]
+	assert user.floats_br == [f32(0.0), 1.0, 2.0, 3.0]
 	assert user.int_map == {
 		'a': 0
 		'b': 1

--- a/vlib/toml/tests/reflect_test.v
+++ b/vlib/toml/tests/reflect_test.v
@@ -20,9 +20,9 @@ floats = [0.0, 1.0, 2.0, 3.0]
 
 floats_br = [
   0.0,
-  1.0,
-  2.0,
-  3.0
+  1.05,
+  2.025,
+  3.5001
 ]
 
 int_map = {"a" = 0, "b" = 1, "c" = 2, "d" = 3}
@@ -81,7 +81,7 @@ fn test_reflect() {
 	assert user.strings == ['v matures', 'like rings', 'spread in the', 'water']
 	assert user.bools == [true, false, true, true]
 	assert user.floats == [f32(0.0), 1.0, 2.0, 3.0]
-	assert user.floats_br == [f32(0.0), 1.0, 2.0, 3.0]
+	assert user.floats_br == [f32(0.0), 1.05, 2.025, 3.5001]
 	assert user.int_map == {
 		'a': 0
 		'b': 1


### PR DESCRIPTION
Closes #18058 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bff91b9</samp>

Fix TOML scanner bug with floats and newlines. Update `scanner.v` to handle leading zeros and adjust position and column.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bff91b9</samp>

* Fix a bug in the TOML scanner that caused an error when parsing a float with a leading zero and a newline ([link](https://github.com/vlang/v/pull/18062/files?diff=unified&w=0#diff-8a65223c95935b8ffeaccee61b280f7d5da77554634cd9174360ff584220438eR592-R595))
