### PR TITLE
cgen: fix code generated for or-block for void result return function + code generated for indirection comptime checking for logical operators

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -717,18 +717,7 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 						if c.is_comptime_selector_field_name(cond.left as ast.SelectorExpr,
 							'indirections')
 						{
-							ret := match cond.op {
-								.gt { c.comptime_fields_default_type.nr_muls() > cond.right.val.i64() }
-								.lt { c.comptime_fields_default_type.nr_muls() < cond.right.val.i64() }
-								.ge { c.comptime_fields_default_type.nr_muls() >= cond.right.val.i64() }
-								.le { c.comptime_fields_default_type.nr_muls() <= cond.right.val.i64() }
-								else { false }
-							}
-							return if ret {
-								ComptimeBranchSkipState.eval
-							} else {
-								ComptimeBranchSkipState.skip
-							}
+							return .unknown
 						}
 					}
 					c.error('invalid `\$if` condition', cond.pos)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5823,6 +5823,14 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 					g.write('${cvar_name} = ')
 					g.gen_option_error(return_type, expr_stmt.expr)
 					g.writeln(';')
+				} else if return_type == ast.rvoid_type {
+					// fn returns !, do not fill var.data
+					old_inside_opt_data := g.inside_opt_data
+					g.inside_opt_data = true
+					g.expr(expr_stmt.expr)
+					g.inside_opt_data = old_inside_opt_data
+					g.writeln(';')
+					g.stmt_path_pos.delete_last()
 				} else {
 					if is_option {
 						g.write('*(${cast_typ}*) ${cvar_name}.data = ')

--- a/vlib/v/slow_tests/inout/or_block_with_rvoid.out
+++ b/vlib/v/slow_tests/inout/or_block_with_rvoid.out
@@ -1,0 +1,5 @@
+aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa

--- a/vlib/v/slow_tests/inout/or_block_with_rvoid.vv
+++ b/vlib/v/slow_tests/inout/or_block_with_rvoid.vv
@@ -1,0 +1,65 @@
+struct Encoder {}
+
+struct Writer {}
+
+struct StructTypePointer[T] {
+mut:
+	val &T
+}
+
+pub struct Null {
+	is_null bool = true
+}
+
+pub const null = Null{}
+
+pub fn (e &Encoder) encode_value[T](val T, mut wr Writer) ! {
+	e.encode_struct[T](val, 1, mut wr)!
+}
+
+fn (e &Encoder) encode_struct[U](val U, level int, mut wr Writer) ! {
+	$for field in U.fields {
+		$if field.indirections > 0 {
+			println('aaaaaaaaaaaaaaaaaaaa')
+		} $else {
+			println('bbbbbbbbbbbbbbbbbbbb')
+		}
+	}
+}
+
+fn main() {
+	e := Encoder{}
+
+	mut sb := Writer{}
+	mut string_initialized_with_reference := 'ads'
+
+	e.encode_value(StructTypePointer[string]{ val: &string_initialized_with_reference }, mut
+		sb) or {
+		println(err)
+		e.encode_value[Null](null, mut sb) or {}
+	}
+
+	e.encode_value(StructTypePointer[string]{ val: &string_initialized_with_reference }, mut
+		sb) or {
+		println(err)
+		e.encode_value[Null](null, mut sb) or {}
+	}
+
+	e.encode_value(StructTypePointer[string]{ val: &string_initialized_with_reference }, mut
+		sb) or {
+		println(err)
+		e.encode_value[Null](null, mut sb) or {}
+	}
+
+	e.encode_value(StructTypePointer[string]{ val: &string_initialized_with_reference }, mut
+		sb) or {
+		dump(err)
+		e.encode_value[Null](null, mut sb) or {}
+	}
+
+	e.encode_value(StructTypePointer[string]{ val: &string_initialized_with_reference }, mut
+		sb) or {
+		dump(err)
+		e.encode_value[Null](null, mut sb) or {}
+	}
+}


### PR DESCRIPTION
Fix #18027
Fix #17966

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1cb263</samp>

This pull request improves the comptime attribute system and the C code generation for error handling. It simplifies the comptime evaluation of `indirections` for struct fields and avoids invalid assignments and casts for `!void` functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1cb263</samp>

*  Simplify comptime evaluation of `indirections` attribute for struct fields ([link](https://github.com/vlang/v/pull/18066/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5L720-R720))
* Fix C code generation for functions that return `!void` ([link](https://github.com/vlang/v/pull/18066/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR5826-R5833))
