### PR TITLE
checker: fix missing check for mixing multi-return with other types

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -82,6 +82,9 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 		// Unpack multi return types
 		sym := c.table.sym(typ)
 		if sym.kind == .multi_return {
+			if i > 0 || i != node.exprs.len - 1 {
+				c.error('cannot use multi-return with other return types', expr.pos())
+			}
 			for t in sym.mr_info().types {
 				got_types << t
 				expr_idxs << i

--- a/vlib/v/checker/tests/multireturn_mix_err.out
+++ b/vlib/v/checker/tests/multireturn_mix_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/multireturn_mix_err.vv:6:9: error: cannot use multi-return with other return types
+    4 | 
+    5 | fn foo() (string, int, bool) {
+    6 |     return goo(), true
+      |            ~~~~~
+    7 | }

--- a/vlib/v/checker/tests/multireturn_mix_err.vv
+++ b/vlib/v/checker/tests/multireturn_mix_err.vv
@@ -1,0 +1,7 @@
+fn goo() (string, int) {
+	return '', 100
+}
+
+fn foo() (string, int, bool) {
+	return goo(), true
+}


### PR DESCRIPTION
Fix #17501

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60e3db6</samp>

Add checker rule for multi-return expressions. This rule disallows mixing multi-return values with other types in a function's return statement, as in `return a, b, c, 0`. The change affects the file `vlib/v/checker/return.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60e3db6</samp>

* Add a check to prevent using multi-return expressions with other return types in a function ([link](https://github.com/vlang/v/pull/18067/files?diff=unified&w=0#diff-2106e54001315d8484198ab86f15bc5212b4cbbea1264d563c217efaf7c9c93dR85-R87))
* Add tests for the new check in `vlib/v/checker/tests/return_multi_expr_err.vv` ([link](https://github.com/vlang/v/pull/18067/files?diff=unified&w=0#diff-2106e54001315d8484198ab86f15bc5212b4cbbea1264d563c217efaf7c9c93dR85-R87))
