### PR TITLE
toml: fix multiline array bool scanner, add test

### DIFF
--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -142,7 +142,7 @@ pub fn (mut s Scanner) scan() !token.Token {
 
 		if util.is_key_char(byte_c) {
 			key := s.extract_key()
-			if !s.is_left_of_assign && (key == 'true' || key == 'false') {
+			if u8(s.peek(1)) != `=` && (key == 'true' || key == 'false') {
 				util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'identified a boolean "${key}" (${key.len})')
 				return s.new_token(.boolean, key, key.len)
 			}

--- a/vlib/toml/tests/reflect_test.v
+++ b/vlib/toml/tests/reflect_test.v
@@ -16,6 +16,13 @@ strings = [
 
 bools = [true, false, true, true]
 
+bools_br = [
+  true,
+  false,
+  true,
+  true
+]
+
 floats = [0.0, 1.0, 2.0, 3.0]
 
 floats_br = [
@@ -57,6 +64,7 @@ struct User {
 	birthday  toml.Date
 	strings   []string
 	bools     []bool
+	bools_br  []bool
 	floats    []f32
 	floats_br []f32
 	int_map   map[string]int
@@ -80,6 +88,7 @@ fn test_reflect() {
 	assert user.birthday.str() == '1980-04-23'
 	assert user.strings == ['v matures', 'like rings', 'spread in the', 'water']
 	assert user.bools == [true, false, true, true]
+	assert user.bools_br == [true, false, true, true]
 	assert user.floats == [f32(0.0), 1.0, 2.0, 3.0]
 	assert user.floats_br == [f32(0.0), 1.05, 2.025, 3.5001]
 	assert user.int_map == {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25b8aca</samp>

Refactor the scanner logic for identifying boolean tokens in `vlib/toml/scanner/scanner.v`. Use `peek(1)` instead of `is_left_of_assign` to avoid false positives.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25b8aca</samp>

* Refactor the scanner to simplify the logic and fix some bugs ([link](https://github.com/vlang/v/pull/18068/files?diff=unified&w=0#diff-8a65223c95935b8ffeaccee61b280f7d5da77554634cd9174360ff584220438eL145-R145),                             F0L172
