### PR TITLE
checker: fix generic argument resolution for multiple generic args

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1014,8 +1014,8 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					&& c.table.cur_fn.params.len > 0 && func.generic_names.len > 0
 					&& arg.expr is ast.Ident {
 					var_name := (arg.expr as ast.Ident).name
-					for cur_param in c.table.cur_fn.params {
-						if !cur_param.typ.has_flag(.generic) || cur_param.name != var_name {
+					for k, cur_param in c.table.cur_fn.params {
+						if !cur_param.typ.has_flag(.generic) || k < gi || cur_param.name != var_name {
 							continue
 						}
 						typ = cur_param.typ

--- a/vlib/v/tests/multiple_generic_resolve_test.v
+++ b/vlib/v/tests/multiple_generic_resolve_test.v
@@ -1,0 +1,24 @@
+struct App {
+}
+
+struct Config[T] {
+	val T
+}
+
+fn pre_start[T, R](app T, config R) string {
+	return start(app, config.val)
+}
+
+fn start[T, R](app T, otherthing R) R {
+	println(otherthing)
+	return otherthing
+}
+
+fn test_main() {
+	app := App{}
+	testval := 'hello'
+	config := Config[string]{
+		val: testval
+	}
+	assert pre_start(app, config) == 'hello'
+}


### PR DESCRIPTION
Fix #18072

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 092d56a</samp>

Fix type inference bug for generic functions in `vlib/v/checker/check_types.v`. Ensure that only the last argument with a generic name is used to infer the generic type.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 092d56a</samp>

* Fix type inference bug for generic functions ([link](https://github.com/vlang/v/pull/18073/files?diff=unified&w=0#diff-b3f19dfb0ba250009a75b2ee6915a97dab4450f6e7c32f37c01edc69491875c2L1017-R1018))
