### PR TITLE
cgen: fix shared struct field initialization with default value

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -161,9 +161,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			g.is_shared = old_is_shared2
 		}
 		for mut field in info.fields {
-			if !field.typ.has_flag(.shared_f) {
-				g.is_shared = false
-			}
+			g.is_shared = field.typ.has_flag(.shared_f)
 			if mut sym.info is ast.Struct {
 				mut found_equal_fields := 0
 				for mut sifield in sym.info.fields {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -278,7 +278,6 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 				g.write(',')
 			}
 			initialized = true
-			g.is_shared = old_is_shared
 		}
 		g.is_shared = old_is_shared
 	}

--- a/vlib/v/tests/shared_struct_field_test.v
+++ b/vlib/v/tests/shared_struct_field_test.v
@@ -1,0 +1,13 @@
+module main
+
+struct StructA {
+	ints shared []int = [0]
+}
+
+fn test_main() {
+	a := StructA{}
+	rlock a.ints {
+		dump(a)
+		assert true
+	}
+}


### PR DESCRIPTION
Fix #18074

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a23d169</samp>

Simplify setting `g.is_shared` flag for struct fields in `vlib/v/gen/c/struct.v`. This is part of a pull request to improve struct and enum code generation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a23d169</samp>

*  Simplify the logic of setting the `g.is_shared` flag for a struct field by directly assigning the result of the `has_flag` method call ([link](https://github.com/vlang/v/pull/18075/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L164-R164))
