### PR TITLE
checker: check `db` type implements `orm.Connection` and isn't an `Option`.

### DIFF
--- a/vlib/v/checker/tests/like_operator_with_non_string_type_error.out
+++ b/vlib/v/checker/tests/like_operator_with_non_string_type_error.out
@@ -1,14 +1,14 @@
-vlib/v/checker/tests/like_operator_with_non_string_type_error.vv:10:36: error: the right operand of the `like` operator must be a string type
-    8 | 
-    9 |     println(sql db {
-   10 |         select from User where name like 10
+vlib/v/checker/tests/like_operator_with_non_string_type_error.vv:12:36: error: the right operand of the `like` operator must be a string type
+   10 | 
+   11 |     println(sql db {
+   12 |         select from User where name like 10
       |                                          ~~
-   11 |     }!)
-   12 |
-vlib/v/checker/tests/like_operator_with_non_string_type_error.vv:14:26: error: the left operand of the `like` operator must be an identifier with a string type
-   12 | 
-   13 |     println(sql db {
-   14 |         select from User where 10 like true
+   13 |     }!)
+   14 |
+vlib/v/checker/tests/like_operator_with_non_string_type_error.vv:16:26: error: the left operand of the `like` operator must be an identifier with a string type
+   14 | 
+   15 |     println(sql db {
+   16 |         select from User where 10 like true
       |                                ~~
-   15 |     }!)
-   16 | }
+   17 |     }!)
+   18 | }

--- a/vlib/v/checker/tests/like_operator_with_non_string_type_error.vv
+++ b/vlib/v/checker/tests/like_operator_with_non_string_type_error.vv
@@ -1,10 +1,12 @@
+import db.sqlite
+
 struct User {
 	id   int    [primary]
 	name string
 }
 
 fn main() {
-	db := ''
+	db := sqlite.connect(':memory:')!
 
 	println(sql db {
 		select from User where name like 10

--- a/vlib/v/checker/tests/orm_db_expr_option_error.out
+++ b/vlib/v/checker/tests/orm_db_expr_option_error.out
@@ -1,0 +1,28 @@
+vlib/v/checker/tests/orm_db_expr_option_error.vv:16:11: error: expected `sqlite.DB`, not `?sqlite.DB`
+   14 |     db_option := connect_option()
+   15 | 
+   16 |     _ := sql db_option {
+      |              ~~~~~~~~~
+   17 |         select from Account
+   18 |     }!
+vlib/v/checker/tests/orm_db_expr_option_error.vv:22:11: error: `Account` doesn't implement method `select` of interface `orm.Connection`
+   20 |     account := Account{}
+   21 | 
+   22 |     _ := sql account {
+      |              ~~~~~~~
+   23 |         select from Account
+   24 |     }!
+vlib/v/checker/tests/orm_db_expr_option_error.vv:26:6: error: `Account` doesn't implement method `select` of interface `orm.Connection`
+   24 |     }!
+   25 | 
+   26 |     sql account {
+      |         ~~~~~~~
+   27 |         insert account into Account
+   28 |     }!
+vlib/v/checker/tests/orm_db_expr_option_error.vv:30:6: error: expected `sqlite.DB`, not `?sqlite.DB`
+   28 |     }!
+   29 | 
+   30 |     sql db_option {
+      |         ~~~~~~~~~
+   31 |         insert account into Account
+   32 |     }!

--- a/vlib/v/checker/tests/orm_db_expr_option_error.vv
+++ b/vlib/v/checker/tests/orm_db_expr_option_error.vv
@@ -1,0 +1,33 @@
+module main
+
+import db.sqlite
+
+struct Account {
+	id int [primary]
+}
+
+fn connect_option() ?sqlite.DB {
+	return sqlite.connect(':memory:') or { return none }
+}
+
+fn main() {
+	db_option := connect_option()
+
+	_ := sql db_option {
+		select from Account
+	}!
+
+	account := Account{}
+
+	_ := sql account {
+		select from Account
+	}!
+
+	sql account {
+		insert account into Account
+	}!
+
+	sql db_option {
+		insert account into Account
+	}!
+}

--- a/vlib/v/parser/tests/orm_no_error_handler.out
+++ b/vlib/v/parser/tests/orm_no_error_handler.out
@@ -1,7 +1,7 @@
-vlib/v/parser/tests/orm_no_error_handler.vv:8:7: error: V ORM returns a result, so it should have either an `or {}` block, or `!` at the end
-    6 |     db := true
-    7 | 
-    8 |     _ := sql db {
+vlib/v/parser/tests/orm_no_error_handler.vv:10:7: error: V ORM returns a result, so it should have either an `or {}` block, or `!` at the end
+    8 |     db := sqlite.connect(':memory:')!
+    9 | 
+   10 |     _ := sql db {
       |          ~~~~~~~~
-    9 |         select from User
-   10 |     }
+   11 |         select from User
+   12 |     }

--- a/vlib/v/parser/tests/orm_no_error_handler.vv
+++ b/vlib/v/parser/tests/orm_no_error_handler.vv
@@ -1,9 +1,11 @@
+import db.sqlite
+
 struct User {
 	id int
 }
 
 fn main() {
-	db := true
+	db := sqlite.connect(':memory:')!
 
 	_ := sql db {
 		select from User


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c21a910</samp>

This pull request enhances the ORM module by adding a new function `check_db_expr` that validates database expressions and their interface. It also improves the error handling and type checking of ORM queries in `check_orm_select`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c21a910</samp>

*  Add a function `check_db_expr` to `vlib/v/checker/orm.v` that validates database expressions and checks if they implement the `orm.Connection` interface ([link](https://github.com/vlang/v/pull/18078/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R509-R520))
* Call `check_db_expr` before getting the symbol of the table expression in the `check_orm_select` function, for both type and variable expressions ([link](https://github.com/vlang/v/pull/18078/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L21-R28), [link](https://github.com/vlang/v/pull/18078/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R159-R162))
