### PR TITLE
checker: fix [noinit] attr checking with multiple attr

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -398,7 +398,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 	}
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
-		if info.attrs.len > 0 && info.attrs[0].name == 'noinit' && type_sym.mod != c.mod {
+		if info.attrs.len > 0 && info.attrs.contains('noinit') && type_sym.mod != c.mod {
 			c.error('struct `${type_sym.name}` is declared with a `[noinit]` attribute, so ' +
 				'it cannot be initialized with `${type_sym.name}{}`', node.pos)
 		}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6819ed</samp>

Fixed a bug in the checker module that caused structs with multiple attributes to be incorrectly initialized. Changed the condition for detecting the `[noinit]` attribute in `vlib/v/checker/struct.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6819ed</samp>

*  Fix bug where structs with multiple attributes were not detected as having the `[noinit]` attribute by changing the condition for checking the attribute from using the first element of the `attrs` array to using the `contains` method ([link](https://github.com/vlang/v/pull/18079/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L401-R401))
