### PR TITLE
cgen: fix `it` variable casting on map call when arr is a comptime variable

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -484,6 +484,17 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 			g.write('${ret_elem_type} ti = ')
 			g.expr(node.args[0].expr)
 		}
+		ast.CastExpr {
+			// value.map(Type(it)) when `value` is a comptime var
+			if expr.expr is ast.Ident && node.left is ast.Ident && g.is_comptime_var(node.left) {
+				ctyp := g.get_comptime_var_type(node.left)
+				if ctyp != ast.void_type {
+					expr.expr_type = g.table.value_type(ctyp)
+				}
+			}
+			g.write('${ret_elem_type} ti = ')
+			g.expr(node.args[0].expr)
+		}
 		else {
 			if closure_var_decl != '' {
 				g.write('${closure_var_decl} = ')

--- a/vlib/v/tests/comptime_map_it_test.v
+++ b/vlib/v/tests/comptime_map_it_test.v
@@ -1,0 +1,30 @@
+type Any = []Any | f64 | int | map[string]Any | string
+
+struct Arr {
+	ints   []int
+	floats []f64
+	strs   []string
+}
+
+fn encode[T](typ T) map[string]Any {
+	mut mp := map[string]Any{}
+	$for field in T.fields {
+		value := typ.$(field.name)
+		$if field.is_enum {
+			mp[field.name] = Any(int(value))
+		} $else $if field.is_array {
+			mp[field.name] = value.map(Any(it))
+		} $else {
+			mp[field.name] = Any(value)
+		}
+	}
+	return mp
+}
+
+fn test_main() {
+	a := Arr{[5], [2.0], ['asdf']}
+	r := encode[Arr](a)
+	assert r['ints'] == Any([Any(5)])
+	assert r['floats'] == Any([Any(2.0)])
+	assert r['strs'] == Any([Any('asdf')])
+}


### PR DESCRIPTION
Fix #18069

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 609ee70</samp>

Fix comptime variable casting in array generation. Update `vlib/v/gen/c/array.v` to handle comptime variables with different types in cast expressions and write them correctly to C.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 609ee70</samp>

* Fix comptime variable type mapping with cast expressions ([link](https://github.com/vlang/v/pull/18083/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278R487-R497))
