### PR TITLE
checker: disallow matching type with primitive vars

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -200,7 +200,8 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 			}
 			if mut expr is ast.TypeNode && cond_sym.is_primitive() {
 				type_str := c.table.type_to_str(expr.typ)
-				c.error('`match` by type can only be used for sum-types, `${node.cond}` is of type `${type_str}`', branch.pos)
+				c.error('`match` by type can only be used for sum-types, `${node.cond}` is of type `${type_str}`',
+					branch.pos)
 			}
 			if mut expr is ast.RangeExpr {
 				// Allow for `match enum_value { 4..5 { } }`, even though usually int and enum values,

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -199,8 +199,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 					branch.pos)
 			}
 			if mut expr is ast.TypeNode && cond_sym.is_primitive() {
-				type_str := c.table.type_to_str(expr.typ)
-				c.error('`match` by type can only be used for sum-types, `${node.cond}` is of type `${type_str}`',
+				c.error('matching by type can only be done for sum types, generics, interfaces, `${node.cond}` is none of those',
 					branch.pos)
 			}
 			if mut expr is ast.RangeExpr {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -198,6 +198,10 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				c.error('struct instances cannot be matched by type name, they can only be matched to other instances of the same struct type',
 					branch.pos)
 			}
+			if mut expr is ast.TypeNode && cond_sym.is_primitive() {
+				type_str := c.table.type_to_str(expr.typ)
+				c.error('cannot match ${type_str} with non sum type', branch.pos)
+			}
 			if mut expr is ast.RangeExpr {
 				// Allow for `match enum_value { 4..5 { } }`, even though usually int and enum values,
 				// are considered incompatible outside unsafe{}, and are not allowed to be compared directly

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -200,7 +200,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 			}
 			if mut expr is ast.TypeNode && cond_sym.is_primitive() {
 				type_str := c.table.type_to_str(expr.typ)
-				c.error('cannot match ${type_str} with non sum type', branch.pos)
+				c.error('`match` by type can only be used for sum-types, `${node.cond}` is of type `${type_str}`', branch.pos)
 			}
 			if mut expr is ast.RangeExpr {
 				// Allow for `match enum_value { 4..5 { } }`, even though usually int and enum values,

--- a/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.out
+++ b/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv:5:3: error: cannot match i64 with non sum type
+    3 |
+    4 |     match b {
+    5 |         i64 { println('i64') }
+      |         ~~~
+    6 |         100 { println(100) }
+    7 |         else {}

--- a/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.out
+++ b/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv:5:3: error: `match` by type can only be used for sum-types, `b` is of type `i64`
+vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv:5:3: error: matching by type can only be done for sum types, generics, interfaces, `b` is none of those
     3 |
     4 |     match b {
     5 |         i64 { println('i64') }

--- a/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.out
+++ b/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv:5:3: error: cannot match i64 with non sum type
+vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv:5:3: error: `match` by type can only be used for sum-types, `b` is of type `i64`
     3 |
     4 |     match b {
     5 |         i64 { println('i64') }

--- a/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv
+++ b/vlib/v/checker/tests/match_type_node_with_non_sum_type_err.vv
@@ -1,0 +1,9 @@
+fn main() {
+	b := i64(100)
+
+	match b {
+		i64 { println('i64') }
+		100 { println(100) }
+		else {}
+	}
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Fixes https://github.com/vlang/v/issues/17104

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcb2a9a</samp>

Add error checking for invalid match branches in `vlib/v/checker/match.v`. Prevent matching a primitive type with a non sum type, as part of fixing issue #10976.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcb2a9a</samp>

*  Add a check for invalid match branches with primitive types ([link](https://github.com/vlang/v/pull/18084/files?diff=unified&w=0#diff-b3e9e13d82c234e7953e95b8321dd2f6475a017c1985da21bb49dc46898962bfR201-R204))
