### PR TITLE
net.html: fix text parsing for inline tags

### DIFF
--- a/vlib/net/html/html_test.v
+++ b/vlib/net/html/html_test.v
@@ -13,3 +13,20 @@ fn test_parse() {
 	assert h1_tag.str() == '<h1 class="title" >Hello world!</h1>'
 	// assert h1_tag.str() == '<h1 class="title">Hello world!</h1>'
 }
+
+fn test_parse_inline_tags() {
+	doc := parse('<html><body><p>before <span>in between</span> after</p></body></html>')
+	tags := doc.get_tag('span')
+	assert tags.len == 1
+
+	span_tag := tags[0]
+	assert span_tag.str() == '<span>in between</span>'
+
+	p_tags := doc.get_tag('p')
+	assert p_tags.len == 1
+
+	p_tag := p_tags[0]
+	assert p_tag.str() == '<p>before <span>in between</span><text> after</text></p>'
+
+	assert p_tag.text() == 'before in between after'
+}

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -14,6 +14,7 @@ mut:
 	opened_code_type string
 	line_count       int
 	outside_tag      bool
+	text_after_tag   bool
 	lexeme_builder   strings.Builder = strings.new_builder(100)
 	code_tags        map[string]bool = {
 		'script': true
@@ -221,10 +222,7 @@ pub fn (mut parser Parser) split_parse(data string) {
 				if parser.lexical_attributes.current_tag.name.len > 1
 					&& parser.lexical_attributes.current_tag.name[0] == 47
 					&& !blank_string(temp_string) {
-					parser.tags << &Tag{
-						name: 'text'
-						content: temp_string
-					}
+					parser.lexical_attributes.text_after_tag = true
 				} else {
 					parser.lexical_attributes.current_tag.content = temp_string // verify later who has this content
 				}
@@ -234,6 +232,14 @@ pub fn (mut parser Parser) split_parse(data string) {
 			parser.generate_tag()
 			parser.lexical_attributes.open_tag = true
 			parser.lexical_attributes.outside_tag = false
+
+			if parser.lexical_attributes.text_after_tag == true {
+				parser.tags << &Tag{
+					name: 'text'
+					content: temp_string
+				}
+				parser.lexical_attributes.text_after_tag = false
+			}
 		} else {
 			parser.lexical_attributes.lexeme_builder.write_u8(chr)
 		}


### PR DESCRIPTION
Fix issue where text that that comes after a tag is closed is added to the closed tag instead of the outer tag.

For example when parsing html with an inline tag:
```html
<html>
	<body>
		<p>before <span>in between</span> after</p>
	</body>
</html>
```

The `span` tag contains the text `"after"`
```v
doc := html.parse('<html><body><p>before <span>in between</span> after</p></body></html>')
tags := doc.get_tag('span')
span_tag := tags[0]
assert span_tag.str() == '<span>in between</span>' // fails
```
result: 
```
assert span_tag.str() == '<span>in between</span>'
    Left value:
      <span>in between<text> after</text></span>
    Right value:
      <span>in between</span>
```

Successfull test case after fix:
```v
fn test_parse_inline_tags() {
	doc := parse('<html><body><p>before <span>in between</span> after</p></body></html>')
	tags := doc.get_tag('span')
	assert tags.len == 1

	span_tag := tags[0]
	assert span_tag.str() == '<span>in between</span>'

	p_tags := doc.get_tag('p')
	assert p_tags.len == 1

	p_tag := p_tags[0]
	assert p_tag.str() == '<p>before <span>in between</span><text> after</text></p>'

	assert p_tag.text() == 'before in between after'
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dafca78</samp>

This pull request enhances the HTML parser in `vlib/net/html/parser.v` to handle text content more accurately and consistently. It also adds a test case in `vlib/net/html/html_test.v` to verify the parsing of inline tags.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dafca78</samp>

*  Add a new field `text_after_tag` to the `Parser` struct to handle text content after a closing tag ([link](https://github.com/vlang/v/pull/18085/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724R17))
*  Update the `parse` function to set `text_after_tag` to true when a closing tag is followed by non-blank text ([link](https://github.com/vlang/v/pull/18085/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724L224-R225))
*  Update the `parse` function to create and append a new text tag with the content after a closing tag when `text_after_tag` is true ([link](https://github.com/vlang/v/pull/18085/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724R235-R242))
*  Add a test function to `html_test.v` to check the parsing of inline tags within a parent tag and the text content after a closing tag ([link](https://github.com/vlang/v/pull/18085/files?diff=unified&w=0#diff-548800994428c49ebdbb652682e69a6f3d3cd0fa184b370eb833008e04ef5a4bR16-R32))
