### PR TITLE
cmd: Update `v share` to work with the playground redesign

### DIFF
--- a/cmd/tools/vshare.v
+++ b/cmd/tools/vshare.v
@@ -6,7 +6,7 @@ import clipboard
 import json
 
 struct Response {
-	hash string
+	hash  string
 	error string
 }
 
@@ -38,7 +38,7 @@ fn main() {
 	share := http.post_form('https://play.vlang.io/share', {
 		'code': content
 	})!
-	
+
 	response := json.decode(Response, share.body)!
 	url := 'https://play.vlang.io/p/${response.hash}'
 

--- a/cmd/tools/vshare.v
+++ b/cmd/tools/vshare.v
@@ -3,6 +3,12 @@ module main
 import net.http
 import os
 import clipboard
+import json
+
+struct Response {
+	hash string
+	error string
+}
 
 fn main() {
 	mut cb := clipboard.new()
@@ -32,7 +38,9 @@ fn main() {
 	share := http.post_form('https://play.vlang.io/share', {
 		'code': content
 	})!
-	url := 'https://play.vlang.io/p/${share.body}'
+	
+	response := json.decode(Response, share.body)!
+	url := 'https://play.vlang.io/p/${response.hash}'
 
 	cb.copy(url)
 	println(url)


### PR DESCRIPTION
The new playground has a different response compared to the previous one, so the response has to be parsed as JSON now.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4227b2</samp>

Fixed vshare tool bug and improved server response parsing. Used `json` module and `Response` struct to handle `cmd/tools/vshare.v` output.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4227b2</samp>

* Fix URL generation for shared code by decoding JSON response and using hash field ([link](https://github.com/vlang/v/pull/18090/files?diff=unified&w=0#diff-ab33a60abb0cbbbb2138eddc157d3e3fb95f22bda76515ed0e73b34cdebf3b5dL6-R12), [link](https://github.com/vlang/v/pull/18090/files?diff=unified&w=0#diff-ab33a60abb0cbbbb2138eddc157d3e3fb95f22bda76515ed0e73b34cdebf3b5dL35-R43))
* Import and define `json` module and `Response` struct to handle JSON decoding ([link](https://github.com/vlang/v/pull/18090/files?diff=unified&w=0#diff-ab33a60abb0cbbbb2138eddc157d3e3fb95f22bda76515ed0e73b34cdebf3b5dL6-R12))
