### PR TITLE
checker: fix wrong error message about missing `shared` on param signature

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1086,7 +1086,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 		} else {
 			if param.is_mut {
-				tok := call_arg.share.str()
+				tok := if param.typ.has_flag(.shared_f) { 'shared' } else { call_arg.share.str() }
 				c.error('function `${node.name}` parameter `${param.name}` is `${tok}`, so use `${tok} ${call_arg.expr}` instead',
 					call_arg.expr.pos())
 			} else {
@@ -1805,7 +1805,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				}
 			} else {
 				if param_is_mut {
-					tok := arg.share.str()
+					tok := if param.typ.has_flag(.shared_f) { 'shared' } else { arg.share.str() }
 					c.error('method `${node.name}` parameter `${param.name}` is `${tok}`, so use `${tok} ${arg.expr}` instead',
 						arg.expr.pos())
 				} else {
@@ -2056,7 +2056,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					}
 				} else {
 					if param.is_mut {
-						tok := arg.share.str()
+						tok := if param.typ.has_flag(.shared_f) { 'shared' } else { arg.share.str() }
 						c.error('method `${node.name}` parameter ${i + 1} is `${tok}`, so use `${tok} ${arg.expr}` instead',
 							arg.expr.pos())
 					} else {

--- a/vlib/v/checker/tests/shared_param_err.out
+++ b/vlib/v/checker/tests/shared_param_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/shared_param_err.vv:23:12: error: method `g` parameter `c` is `shared`, so use `shared a` instead
+   21 |         x: 10
+   22 |     }
+   23 |     spawn a.g(a)
+      |               ^
+   24 |     spawn foo(a)
+   25 |
+vlib/v/checker/tests/shared_param_err.vv:24:12: error: function `foo` parameter `b` is `shared`, so use `shared a` instead
+   22 |     }
+   23 |     spawn a.g(a)
+   24 |     spawn foo(a)
+      |               ^
+   25 | 
+   26 |     rlock a {

--- a/vlib/v/checker/tests/shared_param_err.vv
+++ b/vlib/v/checker/tests/shared_param_err.vv
@@ -1,0 +1,29 @@
+struct St {
+mut:
+	x int
+	// data to be shared
+}
+
+fn (shared b St) g(shared c St) {
+	lock b {
+		b.x = 100
+	}
+}
+
+fn foo(shared b St) {
+	lock b {
+		b.x = 101
+	}
+}
+
+fn main() {
+	shared a := St{
+		x: 10
+	}
+	spawn a.g(a)
+	spawn foo(a)
+
+	rlock a {
+		println(a.x)
+	}
+}


### PR DESCRIPTION
Fix #18087

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1db1fc7</samp>

Fix error messages for passing mutable parameters to shared functions. Use the `shared` keyword consistently in `vlib/v/checker/fn.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1db1fc7</samp>

* Fix error message for passing mutable parameter to function with shared parameter ([link](https://github.com/vlang/v/pull/18091/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL1089-R1089))
* Fix error message for passing mutable parameter to method with shared parameter ([link](https://github.com/vlang/v/pull/18091/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL1808-R1808))
* Fix error message for passing mutable parameter to variadic method with shared parameter ([link](https://github.com/vlang/v/pull/18091/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL2059-R2059))
