### PR TITLE
checker, orm: don't insert an uninitialized struct in the related table.

### DIFF
--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -64,7 +64,7 @@ fn test_does_not_insert_uninitialized_field() {
 		select from User
 	}!
 
-	// users must be empty because the package doesn't have an initialized user structure.
+	// users must be empty because the package doesn't have an initialized `User` structure.
 	assert users.len == 0
 }
 

--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -25,14 +25,75 @@ struct Account {
 	id int [primary; sql: serial]
 }
 
+struct Package {
+	id     int    [primary; sql: serial]
+	name   string [unique]
+	author User   [fkey: 'id']
+}
+
+struct User {
+pub mut:
+	id       int    [primary; sql: serial]
+	username string [unique]
+}
+
 pub fn insert_parent(db sqlite.DB, mut parent Parent) ! {
 	sql db {
 		insert parent into Parent
 	}!
 }
 
+fn test_does_not_insert_uninitialized_field() {
+	db := sqlite.connect(':memory:')!
+
+	sql db {
+		create table User
+		create table Package
+	}!
+
+	package := Package{
+		name: 'xml'
+		// author
+	}
+
+	sql db {
+		insert package into Package
+	}!
+
+	users := sql db {
+		select from User
+	}!
+
+	// users must be empty because the package doesn't have an initialized user structure.
+	assert users.len == 0
+}
+
+fn test_insert_empty_field() {
+	db := sqlite.connect(':memory:')!
+
+	sql db {
+		create table User
+		create table Package
+	}!
+
+	package := Package{
+		name: 'xml'
+		author: User{}
+	}
+
+	sql db {
+		insert package into Package
+	}!
+
+	users := sql db {
+		select from User
+	}!
+
+	assert users.len == 1
+}
+
 fn test_insert_empty_object() {
-	db := sqlite.connect(':memory:') or { panic(err) }
+	db := sqlite.connect(':memory:')!
 
 	account := Account{}
 
@@ -49,7 +110,7 @@ fn test_insert_empty_object() {
 }
 
 fn test_orm_insert_mut_object() {
-	db := sqlite.connect(':memory:') or { panic(err) }
+	db := sqlite.connect(':memory:')!
 
 	sql db {
 		create table Parent
@@ -71,7 +132,7 @@ fn test_orm_insert_mut_object() {
 }
 
 fn test_orm_insert_with_multiple_child_elements() {
-	mut db := sqlite.connect(':memory:') or { panic(err) }
+	mut db := sqlite.connect(':memory:')!
 
 	sql db {
 		create table Parent

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -182,9 +182,9 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 	defer {
 		c.cur_orm_ts = old_ts
 	}
+	inserting_object_name := node.object_var_name
 
 	if node.kind == .insert && !node.is_generated {
-		inserting_object_name := node.object_var_name
 		inserting_object := node.scope.find(inserting_object_name) or {
 			c.error('undefined ident: `${inserting_object_name}`', node.pos)
 			return ast.void_type
@@ -210,12 +210,19 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 	}
 
 	info := table_sym.info as ast.Struct
-	fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, table_sym.name)
+	mut fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, table_sym.name)
 	mut sub_structs := map[int]ast.SqlStmtLine{}
 	for f in fields.filter((c.table.type_symbols[int(it.typ)].kind == .struct_
 		|| (c.table.sym(it.typ).kind == .array
 		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
 		&& c.table.get_type_name(it.typ) != 'time.Time') {
+		// Delete an uninitialized struct from fields and skip adding the current field
+		// to sub structs to skip inserting an empty struct in the related table.
+		if c.check_field_of_inserting_structure_is_uninitialized(node, f.name) {
+			fields.delete(fields.index(f))
+			continue
+		}
+
 		c.check_orm_struct_field_attributes(f)
 
 		typ := if c.table.sym(f.typ).kind == .struct_ {
@@ -528,4 +535,19 @@ fn (mut c Checker) check_db_expr(db_expr &ast.Expr) bool {
 	}
 
 	return true
+}
+
+fn (_ &Checker) check_field_of_inserting_structure_is_uninitialized(node &ast.SqlStmtLine, field_name string) bool {
+	mut found := false
+	struct_scope := node.scope.find_var(node.object_var_name) or { return false }
+
+	if struct_scope.expr is ast.StructInit {
+		for field in struct_scope.expr.fields {
+			if field.name == field_name {
+				found = true
+			}
+		}
+	}
+
+	return !found
 }

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -218,7 +218,7 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 		&& c.table.get_type_name(it.typ) != 'time.Time') {
 		// Delete an uninitialized struct from fields and skip adding the current field
 		// to sub structs to skip inserting an empty struct in the related table.
-		if c.check_field_of_inserting_structure_is_uninitialized(node, f.name) {
+		if c.check_field_of_inserting_struct_is_uninitialized(node, f.name) {
 			fields.delete(fields.index(f))
 			continue
 		}
@@ -537,7 +537,7 @@ fn (mut c Checker) check_db_expr(db_expr &ast.Expr) bool {
 	return true
 }
 
-fn (_ &Checker) check_field_of_inserting_structure_is_uninitialized(node &ast.SqlStmtLine, field_name string) bool {
+fn (_ &Checker) check_field_of_inserting_struct_is_uninitialized(node &ast.SqlStmtLine, field_name string) bool {
 	struct_scope := node.scope.find_var(node.object_var_name) or { return false }
 
 	if struct_scope.expr is ast.StructInit {

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -538,16 +538,11 @@ fn (mut c Checker) check_db_expr(db_expr &ast.Expr) bool {
 }
 
 fn (_ &Checker) check_field_of_inserting_structure_is_uninitialized(node &ast.SqlStmtLine, field_name string) bool {
-	mut found := false
 	struct_scope := node.scope.find_var(node.object_var_name) or { return false }
 
 	if struct_scope.expr is ast.StructInit {
-		for field in struct_scope.expr.fields {
-			if field.name == field_name {
-				found = true
-			}
-		}
+		return struct_scope.expr.fields.filter(it.name == field_name).len == 0
 	}
 
-	return !found
+	return false
 }


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db036c6</samp>

This pull request enhances the ORM module and its tests. It adds support for inserting objects with foreign key relations and uninitialized structs, and refactors some error handling and variable assignments. It also updates the `orm_insert_test.v` file to cover these cases.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db036c6</samp>

*  Add two new structs `Package` and `User` to test foreign key relations and uninitialized fields in the ORM module ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-b75950eb24d45e1ac6411ea661868c97e93e073f7e5f72bac11c251065bd2922R28-R39))
*  Modify `test_insert_empty_object` and add `test_does_not_insert_uninitialized_field` and `test_insert_empty_field` to test the insertion of objects with empty or uninitialized fields in the ORM module ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-b75950eb24d45e1ac6411ea661868c97e93e073f7e5f72bac11c251065bd2922L34-R96))
*  Refactor error handling for `sqlite.connect` calls in `test_orm_insert_mut_object` and `test_orm_insert_with_multiple_child_elements` to use the `!` operator for unwrapping optionals ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-b75950eb24d45e1ac6411ea661868c97e93e073f7e5f72bac11c251065bd2922L52-R113), [link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-b75950eb24d45e1ac6411ea661868c97e93e073f7e5f72bac11c251065bd2922L74-R135))
*  Move the assignment of `inserting_object_name` outside of the `if` block in `check_sql_stmt_line` to avoid repetition and make it available for the new function `check_field_of_inserting_struct_is_uninitialized` ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L185-R187))
*  Add the `mut` keyword to the `fields` variable in `check_sql_stmt_line` to allow the deletion of fields that have uninitialized structs ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L213-R213))
*  Add a new `if` block in `check_sql_stmt_line` to check if the current field of the inserting object is an uninitialized struct using `check_field_of_inserting_struct_is_uninitialized` and delete it from the `fields` list and skip adding it to the `sub_structs` map ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R219-R225))
*  Add a new function `check_field_of_inserting_struct_is_uninitialized` to the `orm.v` file that takes a `SqlStmtLine` node and a field name and returns a boolean value indicating whether the field of the inserting object is an uninitialized struct ([link](https://github.com/vlang/v/pull/18093/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R539-R548))
