### PR TITLE
checker: missing mutability check for array.delete

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2535,6 +2535,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 			node.receiver_type = left_type
 		}
 	} else if method_name == 'delete' {
+		c.fail_if_immutable(node.left)
 		unwrapped_left_sym := c.table.sym(c.unwrap_generic(left_type))
 		if method := c.table.find_method(unwrapped_left_sym, method_name) {
 			node.receiver_type = method.receiver_type

--- a/vlib/v/checker/tests/array_delete_imut_err.out
+++ b/vlib/v/checker/tests/array_delete_imut_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_delete_imut_err.vv:5:2: error: `a` is immutable, declare it with `mut` to make it mutable
+    3 |     println(a)
+    4 | 
+    5 |     a.delete(1)
+      |     ^
+    6 |     println(a)
+    7 | }

--- a/vlib/v/checker/tests/array_delete_imut_err.vv
+++ b/vlib/v/checker/tests/array_delete_imut_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	a := [1, 2, 3, 4]
+	println(a)
+
+	a.delete(1)
+	println(a)
+}


### PR DESCRIPTION
Fix #18095

copilot:summary

copilot:walkthrough
