### PR TITLE
checker: make `undefined ident` error for closures more friendly.

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3446,7 +3446,7 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 					found_var := c.fn_scope.find_var(node.name)
 
 					if found_var != none {
-						c.error('variable `${node.name}` from the outer scope not added to the capturing list of the closure',
+						c.error('`${node.name}` must be added to the capture list for the closure to be used inside',
 							node.pos)
 						return ast.void_type
 					}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3440,6 +3440,18 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 				c.error(util.new_suggestion(node.name, const_names_in_mod).say('undefined ident: `${node.name}`'),
 					node.pos)
 			} else {
+				// If a variable is not found in the scope of an anonymous function
+				// but is in an external scope, then we can suggest the user add it to the capturing list.
+				if c.inside_anon_fn {
+					found_var := c.fn_scope.find_var(node.name)
+
+					if found_var != none {
+						c.error('variable `${node.name}` from the outer scope not added to the capturing list of the closure',
+							node.pos)
+						return ast.void_type
+					}
+				}
+
 				c.error('undefined ident: `${node.name}`', node.pos)
 			}
 		}

--- a/vlib/v/checker/tests/anon_fn_arg_type_err.out
+++ b/vlib/v/checker/tests/anon_fn_arg_type_err.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/anon_fn_arg_type_err.vv:6:14: error: use `_` to name an unu
       |                 ^
     7 |         return i
     8 |     }
-vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: variable `i` from the outer scope not added to the capturing list of the closure
+vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: `i` must be added to the capture list for the closure to be used inside
     5 | 
     6 |     func := fn (i) int {
     7 |         return i

--- a/vlib/v/checker/tests/anon_fn_arg_type_err.out
+++ b/vlib/v/checker/tests/anon_fn_arg_type_err.out
@@ -1,12 +1,12 @@
 vlib/v/checker/tests/anon_fn_arg_type_err.vv:6:14: error: use `_` to name an unused parameter
     4 |     mut i := 1
-    5 |
+    5 | 
     6 |     func := fn (i) int {
       |                 ^
     7 |         return i
     8 |     }
-vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: undefined ident: `i`
-    5 |
+vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: variable `i` from the outer scope not added to the capturing list of the closure
+    5 | 
     6 |     func := fn (i) int {
     7 |         return i
       |                ^
@@ -14,7 +14,7 @@ vlib/v/checker/tests/anon_fn_arg_type_err.vv:7:10: error: undefined ident: `i`
     9 |
 vlib/v/checker/tests/anon_fn_arg_type_err.vv:10:15: error: cannot use `int` as `i` in argument 1 to `func`
     8 |     }
-    9 |
+    9 | 
    10 |     println(func(i) == 1)
       |                  ^
    11 | }

--- a/vlib/v/parser/tests/closure_not_declared.out
+++ b/vlib/v/parser/tests/closure_not_declared.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/closure_not_declared.vv:4:9: error: undefined ident: `a`
+vlib/v/parser/tests/closure_not_declared.vv:4:9: error: variable `a` from the outer scope not added to the capturing list of the closure
     2 |     a := 1
     3 |     f := fn () {
     4 |         print(a)

--- a/vlib/v/parser/tests/closure_not_declared.out
+++ b/vlib/v/parser/tests/closure_not_declared.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/closure_not_declared.vv:4:9: error: variable `a` from the outer scope not added to the capturing list of the closure
+vlib/v/parser/tests/closure_not_declared.vv:4:9: error: `a` must be added to the capture list for the closure to be used inside
     2 |     a := 1
     3 |     f := fn () {
     4 |         print(a)


### PR DESCRIPTION
Fixes #16135 

<img width="802" alt="after" src="https://user-images.githubusercontent.com/104449470/235775753-1cc0ba98-3146-4205-9740-18e9804f2301.png">

<!--


Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2232d8</samp>

Improve error message for closures that access external variables. Check for missing variables in the capture list and suggest adding them in `vlib/v/checker/checker.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e2232d8</samp>

*  Add a new error message for unresolved variables in closures ([link](https://github.com/vlang/v/pull/18100/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R3443-R3454))
