### PR TITLE
speed improvement for is_odd_int()

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -209,8 +209,7 @@ pub fn alike(a f64, b f64) bool {
 }
 
 fn is_odd_int(x f64) bool {
-	xi, xf := modf(x)
-	return xf == 0 && (i64(xi) & 1) == 1
+	return math.fmod(x, 2) == 0
 }
 
 fn is_neg_int(x f64) bool {


### PR DESCRIPTION
I found that my version of the function is faster than the default. I ran some time trials, and with numbers 1.0 - 10.0 (floats), my function runs at around 190μs, while the original runs at around 230μs. Small but possibly necessary optimization.