### PR TITLE
builtin: heap memory usage api

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -643,21 +643,24 @@ pub fn memdup_uncollectable(src voidptr, sz int) voidptr {
 	}
 }
 
-// gc_heap_size returns the number of bytes in the heap
-pub fn gc_heap_size() usize {
-	$if gcboehm ? {
-		return C.GC_get_heap_size()
-	} $else {
-		return 0
-	}
+pub struct GCHeapUsage {
+pub:
+	heap_size      usize
+	free_bytes     usize
+	total_bytes    usize
+	unmapped_bytes usize
+	bytes_since_gc usize
 }
 
-// gc_free_bytes returns a lower bound on the number of free bytes in the heap
-pub fn gc_free_bytes() usize {
+// gc_heap_usage returns the info about heap usage
+pub fn gc_heap_usage() GCHeapUsage {
 	$if gcboehm ? {
-		return C.GC_get_free_bytes()
+		mut res := GCHeapUsage{}
+		C.GC_get_heap_usage_safe(&res.heap_size, &res.free_bytes, &res.unmapped_bytes,
+			&res.bytes_since_gc, &res.total_bytes)
+		return res
 	} $else {
-		return 0
+		return GCHeapUsage{}
 	}
 }
 
@@ -665,15 +668,6 @@ pub fn gc_free_bytes() usize {
 pub fn gc_memory_use() usize {
 	$if gcboehm ? {
 		return C.GC_get_memory_use()
-	} $else {
-		return 0
-	}
-}
-
-// gc_total_bytes returns the total number of bytes allocated in this process
-pub fn gc_total_bytes() usize {
-	$if gcboehm ? {
-		return C.GC_get_total_bytes()
 	} $else {
 		return 0
 	}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -643,6 +643,42 @@ pub fn memdup_uncollectable(src voidptr, sz int) voidptr {
 	}
 }
 
+// gc_heap_size returns the number of bytes in the heap
+pub fn gc_heap_size() usize {
+	$if gcboehm ? {
+		return C.GC_get_heap_size()
+	} $else {
+		return 0
+	}
+}
+
+// gc_free_bytes returns a lower bound on the number of free bytes in the heap
+pub fn gc_free_bytes() usize {
+	$if gcboehm ? {
+		return C.GC_get_free_bytes()
+	} $else {
+		return 0
+	}
+}
+
+// gc_memory_use returns the total memory use in bytes by all allocated blocks
+pub fn gc_memory_use() usize {
+	$if gcboehm ? {
+		return C.GC_get_memory_use()
+	} $else {
+		return 0
+	}
+}
+
+// gc_total_bytes returns the total number of bytes allocated in this process
+pub fn gc_total_bytes() usize {
+	$if gcboehm ? {
+		return C.GC_get_total_bytes()
+	} $else {
+		return 0
+	}
+}
+
 [inline]
 fn v_fixed_index(i int, len int) int {
 	$if !no_bounds_checking {

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -135,6 +135,5 @@ pub fn gc_check_leaks() {
 
 fn C.GC_get_heap_size() usize
 fn C.GC_get_free_bytes() usize
-fn C.GC_get_bytes_since_gc() usize
 fn C.GC_get_memory_use() usize
 fn C.GC_get_total_bytes() usize

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -133,7 +133,5 @@ pub fn gc_check_leaks() {
 	}
 }
 
-fn C.GC_get_heap_size() usize
-fn C.GC_get_free_bytes() usize
+fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_bytes &usize, pbytes_since_gc &usize, ptotal_bytes &usize)
 fn C.GC_get_memory_use() usize
-fn C.GC_get_total_bytes() usize

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -132,3 +132,9 @@ pub fn gc_check_leaks() {
 		C.GC_gcollect()
 	}
 }
+
+fn C.GC_get_heap_size() usize
+fn C.GC_get_free_bytes() usize
+fn C.GC_get_bytes_since_gc() usize
+fn C.GC_get_memory_use() usize
+fn C.GC_get_total_bytes() usize

--- a/vlib/builtin/builtin_notd_gcboehm.c.v
+++ b/vlib/builtin/builtin_notd_gcboehm.c.v
@@ -14,6 +14,11 @@ fn C.GC_REALLOC(ptr voidptr, n usize) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 
+fn C.GC_get_heap_size() usize
+fn C.GC_get_free_bytes() usize
+fn C.GC_get_memory_use() usize
+fn C.GC_get_total_bytes() usize
+
 // provide an empty function when manual memory management is used
 // to simplify leak detection
 //

--- a/vlib/builtin/builtin_notd_gcboehm.c.v
+++ b/vlib/builtin/builtin_notd_gcboehm.c.v
@@ -14,10 +14,9 @@ fn C.GC_REALLOC(ptr voidptr, n usize) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 
-fn C.GC_get_heap_size() usize
-fn C.GC_get_free_bytes() usize
+fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_bytes &usize, pbytes_since_gc &usize, ptotal_bytes &usize)
+
 fn C.GC_get_memory_use() usize
-fn C.GC_get_total_bytes() usize
 
 // provide an empty function when manual memory management is used
 // to simplify leak detection


### PR DESCRIPTION
Expose gcboehm's API to get memory usage:

- `gc_memory_use()` _returns the total memory use in bytes by all allocated blocks_
- `gc_heap_usage()` _returns the heap usage info_

```V
import time

[heap]
struct Test {
	a []int
}

fn stats() {
	s := gc_heap_usage()
	eprintln('gc_memory_use: ${gc_memory_use():7} | heap_size: ${s.heap_size:7} | free_bytes: ${s.free_bytes:7} | total_bytes: ${s.total_bytes:7} | bytes_since_gc: ${s.bytes_since_gc:7}')
}

fn main() {
	stats()
	for {
		a := Test{
			a: [1].repeat(10)
		}
		b := Test{
			a: [1].repeat(20)
		}
		c := Test{
			a: [1].repeat(30)
		}
		_ := 'a:${a} | b:${b} | c:${c}'
		stats()
		time.sleep(10 * time.millisecond)
	}
}
```

```
gc_memory_use:  192512 | heap_size:  131072 | free_bytes:   45056 | total_bytes:   18400 | bytes_since_gc:   18400
gc_memory_use:  229376 | heap_size:  131072 | free_bytes:    8192 | total_bytes:   23168 | bytes_since_gc:   23168
gc_memory_use:  229376 | heap_size:  131072 | free_bytes:    8192 | total_bytes:   27936 | bytes_since_gc:   27936
gc_memory_use:  233472 | heap_size:  131072 | free_bytes:    4096 | total_bytes:   32704 | bytes_since_gc:   32704
gc_memory_use:  233472 | heap_size:  131072 | free_bytes:    4096 | total_bytes:   37472 | bytes_since_gc:   37472
gc_memory_use:  237568 | heap_size:  131072 | free_bytes:       0 | total_bytes:   42240 | bytes_since_gc:   42240
```