### PR TITLE
time: new method year_day and the tests for it.

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -267,6 +267,12 @@ pub fn (t Time) day_of_week() int {
 	return day_of_week(t.year, t.month, t.day)
 }
 
+// day_of_year returns the current day of the year as an integer. 
+// See also #Time.custom_format .
+pub fn (t Time) day_of_year() int {
+	return t.day + days_before[t.month - 1] + int(is_leap_year(t.year))
+}
+
 // weekday_str returns the current day as a string 3 letter abbreviation.
 pub fn (t Time) weekday_str() string {
 	i := t.day_of_week() - 1

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -270,7 +270,7 @@ pub fn (t Time) day_of_week() int {
 // day_of_year returns the current day of the year as an integer. 
 // See also #Time.custom_format .
 pub fn (t Time) day_of_year() int {
-	return t.day + days_before[t.month - 1] + int(is_leap_year(t.year))
+	return t.day + time.days_before[t.month - 1] + int(is_leap_year(t.year))
 }
 
 // weekday_str returns the current day as a string 3 letter abbreviation.

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -267,11 +267,11 @@ pub fn (t Time) day_of_week() int {
 	return day_of_week(t.year, t.month, t.day)
 }
 
-// year_day returns the current day of the year as an integer. 
+// year_day returns the current day of the year as an integer.
 // See also #Time.custom_format .
 pub fn (t Time) year_day() int {
 	yday := t.day + time.days_before[t.month - 1]
-	if time.is_leap_year(t.year) && t.month > 2 {
+	if is_leap_year(t.year) && t.month > 2 {
 		return yday + 1
 	}
 	return yday

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -267,10 +267,14 @@ pub fn (t Time) day_of_week() int {
 	return day_of_week(t.year, t.month, t.day)
 }
 
-// day_of_year returns the current day of the year as an integer. 
+// year_day returns the current day of the year as an integer. 
 // See also #Time.custom_format .
-pub fn (t Time) day_of_year() int {
-	return t.day + time.days_before[t.month - 1] + int(is_leap_year(t.year))
+pub fn (t Time) year_day() int {
+	yday := t.day + time.days_before[t.month - 1]
+	if time.is_leap_year(t.year) && t.month > 2 {
+		return yday + 1
+	}
+	return yday
 }
 
 // weekday_str returns the current day as a string 3 letter abbreviation.

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -142,20 +142,23 @@ fn test_day_of_week() {
 	}
 }
 
-fn test_day_of_year() {
-	d31 := time.parse("2024-12-31 10:00:00") or {
-		eprintln('> date parsing failed | err: ${err}')
-		return
-	}
+fn test_year_day() {
 	// testing if December 31st in a leap year is numbered as 366
-	assert d31.day_of_year() == 366
+	assert time.parse('2024-12-31 20:00:00')!.year_day() == 366
 
-	nly := time.parse("2023-12-31 10:00:00") or {
-		eprintln('> date parsing failed | err: ${err}')
-		return
-	}
 	// testing December 31st's number in a non leap year
-	assert nly.day_of_year() == 365
+	assert time.parse('2025-12-31 20:00:00')!.year_day() == 365
+
+	assert time.parse('2024-02-28 20:00:00')!.year_day() == 59
+	assert time.parse('2024-02-29 20:00:00')!.year_day() == 60
+	assert time.parse('2024-03-01 20:00:00')!.year_day() == 61
+	assert time.parse('2024-03-02 20:00:00')!.year_day() == 62
+	
+	assert time.parse('2025-02-28 20:00:00')!.year_day() == 59
+	assert time.parse('2025-03-01 20:00:00')!.year_day() == 60
+
+	assert time.parse('2024-01-01 20:00:00')!.year_day() == 1
+	assert time.parse('2025-01-01 20:00:00')!.year_day() == 1
 }
 
 fn test_weekday_str() {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -142,6 +142,26 @@ fn test_day_of_week() {
 	}
 }
 
+fn test_day_of_year() {
+	mut day_of_month := 1
+	for i in 336 .. 367 {
+		// 2024 is a leap year, has 366 days
+		tt := time.Time{
+			year: 2024
+			month: 12
+			day: day_of_month
+			hour: 10
+			minute: 0
+			second: 0
+			unix: 0
+		}
+		day_of_month += 1
+		// testing if the December's days from 1st to 31st in 2024
+		// are numbered as 336 to 366
+		assert i == t.day_of_year()
+	}
+}
+
 fn test_weekday_str() {
 	day_names := ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 	for i, name in day_names {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -146,7 +146,7 @@ fn test_day_of_year() {
 	mut day_of_month := 1
 	for i in 336 .. 367 {
 		// 2024 is a leap year, has 366 days
-		tt := time.Time{
+		t := time.Time{
 			year: 2024
 			month: 12
 			day: day_of_month

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -143,23 +143,19 @@ fn test_day_of_week() {
 }
 
 fn test_day_of_year() {
-	mut day_of_month := 1
-	for i in 336 .. 367 {
-		// 2024 is a leap year, has 366 days
-		t := time.Time{
-			year: 2024
-			month: 12
-			day: day_of_month
-			hour: 10
-			minute: 0
-			second: 0
-			unix: 0
-		}
-		day_of_month += 1
-		// testing if the December's days from 1st to 31st in 2024
-		// are numbered as 336 to 366
-		assert i == t.day_of_year()
+	d31 := time.parse("2024-12-31 10:00:00") or {
+		eprintln('> date parsing failed | err: ${err}')
+		return
 	}
+	// testing if December 31st in a leap year is numbered as 366
+	assert d31.day_of_year() == 366
+
+	nly := time.parse("2023-12-31 10:00:00") or {
+		eprintln('> date parsing failed | err: ${err}')
+		return
+	}
+	// testing December 31st's number in a non leap year
+	assert nly.day_of_year() == 365
 }
 
 fn test_weekday_str() {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -153,7 +153,7 @@ fn test_year_day() {
 	assert time.parse('2024-02-29 20:00:00')!.year_day() == 60
 	assert time.parse('2024-03-01 20:00:00')!.year_day() == 61
 	assert time.parse('2024-03-02 20:00:00')!.year_day() == 62
-	
+
 	assert time.parse('2025-02-28 20:00:00')!.year_day() == 59
 	assert time.parse('2025-03-01 20:00:00')!.year_day() == 60
 


### PR DESCRIPTION
Needed a way to get the current day of the year as an integer from the Time struct. If I'm not alone in this, please consider this PR? Thank you 🙏

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca69f8b</samp>

This pull request adds a new `day_of_year` method to the `Time` struct in `vlib/time/time.v`, which returns the current day of the year as an integer. It also adds a test function for this method in `vlib/time/time_test.v`, which verifies its correctness for different dates, including leap years.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca69f8b</samp>

*  Add `day_of_year` method to Time struct, which returns the current day of the year as an integer, accounting for leap years ([link](https://github.com/vlang/v/pull/18107/files?diff=unified&w=0#diff-31c344f2cfe6fecdafedef24cc42ca595e29556e07d4efc67c5ab8115e199c88R270-R275))
*  Add test function `test_day_of_year` to `time_test.v`, which checks the correctness of `day_of_year` method for different days of December in a leap year ([link](https://github.com/vlang/v/pull/18107/files?diff=unified&w=0#diff-b56c81f693db672f625845374a4bd67074d4d60ba2180b658f6d5b63fc0106b7R145-R164))
