### PR TITLE
changelog: mark `[json_as_number]` change as breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## V 0.3.4
 *30 Apr 2023*
+
+### Breaking Changes
+
+- `json`: enums are serialized as strings by default, `[json_as_number]` attribute can be used for the old behavior.
+
+  If you are serializing enums to JSON in your application, then you will need to add the 
+  `[json_as_number]` attribute to keep the old behavior!
+
+### Other Changes
+
 - **vweb now supports live page reloading**. The web app is instantly updated in the browser (no need to refresh the page) everytime a .v or a .html file is changed.
 - vweb is now significantly faster and more stable under load, due to a new multithreaded worker pool, which is much more efficient at spreading the workload among all threads equally.
 - Middleware support in vweb.
@@ -55,7 +65,6 @@
 - Generic struct inits no longer need explicit types provided: `struct Foo[T, U] { a T; b U } foo := Foo{a:2, b:'x'}`
 - `os.Process` now has a `create_no_window` option (Windows only).
 - `os.Process` now has a `set_work_folder()` method to set the initial working folder of the new child process.
-- `json`: enums are serialized as strings by default, `[json_as_number]` attribute can be used for the old behavior.
 - `net.http`: mime types have been updated to include all official types.
 - `gg`: `create_image()` now returns `!Image` instead of `Image`, allowing to handle errors.
 - sokol: errors during image creation no longer result in a panic, but can be handled by the programmer.


### PR DESCRIPTION
Breaking changes are understandable as the language is still evolving, however it **must be** described in the CHANGELOG so that users don't try to figure out why something that worked on the old version stopped working for them in new.

If I didn't know the change in this version, it would be quite difficult for me to understand why my program started to work incorrectly.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b28b633</samp>

This pull request modifies `CHANGELOG.md` to reflect a breaking change in JSON serialization of enums in version 0.3.4, and how to avoid it. It also fixes some minor errors in the changelog.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b28b633</samp>

* Implement and document the feature of serializing enums as strings or numbers in JSON ([link](https://github.com/vlang/v/pull/18108/files?diff=unified&w=0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R12),  7,                                         F1L
