### PR TITLE
os: export SignalHandler

### DIFF
--- a/vlib/os/signal.v
+++ b/vlib/os/signal.v
@@ -40,4 +40,4 @@ pub enum Signal {
 	sys = 31
 }
 
-type SignalHandler = fn (Signal)
+pub type SignalHandler = fn (Signal)


### PR DESCRIPTION
The type `SignalHandler` is used in the function `os.signal_opt`. By exporting this type, it does appear in the documentation, and we do not have to read the source file to learn about the handler's signature.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11fd5bc</samp>

Make `SignalHandler` public for signal handling. This allows users to customize how their programs react to signals.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11fd5bc</samp>

* Make `SignalHandler` type public to allow custom signal handlers ([link](https://github.com/vlang/v/pull/18115/files?diff=unified&w=0#diff-88847626c60f4fef0692b23b2c5673bdd66e41f39aa60572ed715a018c21ca12L43-R43))
