### PR TITLE
checker: Warn instead of error for unnecessary brackets on if/match

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -52,7 +52,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 	for i in 0 .. node.branches.len {
 		mut branch := node.branches[i]
 		if branch.cond is ast.ParExpr && !c.pref.translated && !c.file.is_translated {
-			c.error('unnecessary `()` in `${if_kind}` condition, use `${if_kind} expr {` instead of `${if_kind} (expr) {`.',
+			c.warn('unnecessary `()` in `${if_kind}` condition, use `${if_kind} expr {` instead of `${if_kind} (expr) {`.',
 				branch.pos)
 		}
 		if !node.has_else || i < node.branches.len - 1 {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -9,7 +9,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	node.is_expr = c.expected_type != ast.void_type
 	node.expected_type = c.expected_type
 	if mut node.cond is ast.ParExpr && !c.pref.translated && !c.file.is_translated {
-		c.error('unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.',
+		c.warn('unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.',
 			node.cond.pos)
 	}
 	if node.is_expr {

--- a/vlib/v/checker/tests/match_cond_with_parenthesis_err.out
+++ b/vlib/v/checker/tests/match_cond_with_parenthesis_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/match_cond_with_parenthesis_err.vv:14:15: error: unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.
+vlib/v/checker/tests/match_cond_with_parenthesis_err.vv:14:15: warning: unnecessary `()` in `match` condition, use `match expr {` instead of `match (expr) {`.
    12 | 
    13 | fn bar() bool {
    14 |     return match (foo()) {

--- a/vlib/v/checker/tests/unnecessary_parenthesis.out
+++ b/vlib/v/checker/tests/unnecessary_parenthesis.out
@@ -1,17 +1,17 @@
-vlib/v/checker/tests/unnecessary_parenthesis.vv:2:2: error: unnecessary `()` in `if` condition, use `if expr {` instead of `if (expr) {`.
+vlib/v/checker/tests/unnecessary_parenthesis.vv:2:2: warning: unnecessary `()` in `if` condition, use `if expr {` instead of `if (expr) {`.
     1 | fn main() {
     2 |     if (1 == 1) {
       |     ~~~~~~~~~~~
     3 |         println('yeay')
     4 |     } else if (1 == 2) {
-vlib/v/checker/tests/unnecessary_parenthesis.vv:4:4: error: unnecessary `()` in `if` condition, use `if expr {` instead of `if (expr) {`.
+vlib/v/checker/tests/unnecessary_parenthesis.vv:4:4: warning: unnecessary `()` in `if` condition, use `if expr {` instead of `if (expr) {`.
     2 |     if (1 == 1) {
     3 |         println('yeay')
     4 |     } else if (1 == 2) {
       |       ~~~~~~~~~~~~~~~~
     5 |         println("oh no :'(")
     6 |     } else if (1 == 3) {
-vlib/v/checker/tests/unnecessary_parenthesis.vv:6:4: error: unnecessary `()` in `if` condition, use `if expr {` instead of `if (expr) {`.
+vlib/v/checker/tests/unnecessary_parenthesis.vv:6:4: warning: unnecessary `()` in `if` condition, use `if expr {` instead of `if (expr) {`.
     4 |     } else if (1 == 2) {
     5 |         println("oh no :'(")
     6 |     } else if (1 == 3) {


### PR DESCRIPTION
This PR changes the error given by using brackets around an if or match statement into a warning.

When writing an if statement in v, if the programmer uses brackets around the expression as is common in other languages the compiler will alert them that this is not necessary, in the form of an error. This is a bit extreme as the code will still operate just fine with the brackets, it is just simply not v's preferred coding style. This PR changes this error to a warning, so debug builds can still be compiled with these statements, for example if a programmer was just trying to make a feature work and not considering the style of their code, or even was using multiple brackets to separate conditions and removed one without removing the brackets from the other, they can still build and test their code in debug mode without having to to back and change it, slowing down their work, but will be required to clean up when making a production build as all warnings become errors.

This also brings it into line with other similar warnings, like unused variables and redundant parentheses, which only warn rather than giving an error.