### PR TITLE
net.html: fix parsing of nested quoted strings in code tags

### DIFF
--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -111,30 +111,29 @@ fn (mut parser Parser) generate_tag() {
 pub fn (mut parser Parser) split_parse(data string) {
 	parser.init()
 	for chr in data {
-		// returns true if byte is a " or '
 		is_quote := chr == `"` || chr == `'`
 		string_code := match chr {
-			`"` { 1 } // "
-			`'` { 2 } // '
+			`"` { 1 }
+			`'` { 2 }
 			else { 0 }
 		}
-		if parser.lexical_attributes.open_code { // here will verify all needed to know if open_code finishes and string in code
+		if parser.lexical_attributes.open_code { // verify if open_code is complete and handle string code
 			parser.lexical_attributes.lexeme_builder.write_u8(chr)
 			if parser.lexical_attributes.open_string > 0
 				&& parser.lexical_attributes.open_string == string_code {
 				parser.lexical_attributes.open_string = 0
-			} else if chr == `>` { // only execute verification if is a > // here will verify < to know if code tag is finished
+			} else if chr == `>` { // code tag is finished
 				name_close_tag := '</${parser.lexical_attributes.opened_code_type}>'
 				if parser.builder_str().to_lower().ends_with(name_close_tag) {
 					parser.lexical_attributes.open_code = false
-					// need to modify lexeme_builder to add script text as a content in next loop (not gave error in dom)
+					// modify lexeme_builder to include script text as content in the next loop
 					parser.lexical_attributes.lexeme_builder.go_back(name_close_tag.len)
 					parser.lexical_attributes.current_tag.closed = true
 					parser.lexical_attributes.current_tag.close_type = .new_tag
 				}
 			}
 		} else if parser.lexical_attributes.open_comment {
-			if chr == `>` && parser.verify_end_comment(false) { // close tag '>'
+			if chr == `>` && parser.verify_end_comment(false) {
 				// parser.print_debug(parser.builder_str() + " >> " + parser.lexical_attributes.line_count.str())
 				parser.lexical_attributes.lexeme_builder.go_back_to(0)
 				parser.lexical_attributes.open_comment = false
@@ -172,10 +171,10 @@ pub fn (mut parser Parser) split_parse(data string) {
 			if parser.lexical_attributes.lexeme_builder.len == 0 && is_quote {
 				parser.lexical_attributes.open_string = string_code
 				parser.lexical_attributes.lexeme_builder.write_u8(chr)
-			} else if chr == `>` { // close tag >
+			} else if chr == `>` {
 				complete_lexeme := parser.builder_str().to_lower()
 				parser.lexical_attributes.current_tag.closed = (complete_lexeme.len > 0
-					&& complete_lexeme[complete_lexeme.len - 1] == `/`) // if equals to /
+					&& complete_lexeme[complete_lexeme.len - 1] == `/`)
 				if complete_lexeme.len > 0 && complete_lexeme[0] == `/` {
 					parser.dom.close_tags[complete_lexeme] = true
 				}
@@ -205,7 +204,7 @@ pub fn (mut parser Parser) split_parse(data string) {
 				} else {
 					parser.lexical_attributes.current_tag.attributes[complete_lexeme] = ''
 					parser.lexical_attributes.current_tag.last_attribute = ''
-					if chr == `=` { // if was a =
+					if chr == `=` {
 						parser.lexical_attributes.current_tag.last_attribute = complete_lexeme
 					}
 				}
@@ -214,7 +213,7 @@ pub fn (mut parser Parser) split_parse(data string) {
 			if parser.builder_str() == '!--' {
 				parser.lexical_attributes.open_comment = true
 			}
-		} else if chr == `<` { // open tag '<'
+		} else if chr == `<` {
 			temp_string := parser.builder_str()
 			if parser.lexical_attributes.lexeme_builder.len >= 1 {
 				if parser.lexical_attributes.current_tag.name.len > 1

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -123,8 +123,6 @@ pub fn (mut parser Parser) split_parse(data string) {
 			if parser.lexical_attributes.open_string > 0
 				&& parser.lexical_attributes.open_string == string_code {
 				parser.lexical_attributes.open_string = 0
-			} else if is_quote {
-				parser.lexical_attributes.open_string = string_code
 			} else if chr == `>` { // only execute verification if is a > // here will verify < to know if code tag is finished
 				name_close_tag := '</${parser.lexical_attributes.opened_code_type}>'
 				if parser.builder_str().to_lower().ends_with(name_close_tag) {

--- a/vlib/net/html/parser_test.v
+++ b/vlib/net/html/parser_test.v
@@ -62,7 +62,7 @@ fn test_giant_string() {
 
 fn test_script_tag() {
 	mut parser := Parser{}
-	script_content := "\nvar googletag = googletag || {};\ngoogletag.cmd = googletag.cmd || [];if(3 > 5) {console.log('Birl');}\n"
+	script_content := '\nvar googletag = googletag || {};\ngoogletag.cmd = googletag.cmd || [];if(3 > 5) {console.log("Quoted \'message\'");}\n'
 	temp_html := '<html><body><script>${script_content}</script></body></html>'
 	parser.parse_html(temp_html)
 	assert parser.tags[2].content.len == script_content.len


### PR DESCRIPTION
Fixes an issue where nested quoted strings break parsing.

I.e. the following code results in missing content in the script tag and following tags not parsed correctly.

```v
import net.html

html_str := '<body><script>console.log("Quoted message \'message\'")</script><h1>Heading</h1></body>'
println(html.parse(html_str))
```

<details><summary>Resulting in:</summary>
Current state (pre PR)

```
html.DocumentObjectModel{
    root: &<body><script></script></body>
    constructed: true
    btree: html.BTree{
        all_tags: [<body></body>, <script></script>]
        node_pointer: 0
        childrens: [[1]]
        parents: [0, 0]
    }
    all_tags: [<body><script></script></body>, <script></script>]
    all_attributes: {}
    close_tags: {'/!document': true}
    attributes: {}
    tag_attributes: {}
    tag_type: {'script': [<script></script>]}
    debug_file: os.File{
        cfile: 0
        fd: 0
        is_opened: false
    }
}
```

Current state without nested quotes `console.log("Quoted message message'")`:
```
html.DocumentObjectModel{
    root: &<body><script>console.log("Quoted message message")</script><h1>Heading</h1></body>
    constructed: true
    btree: html.BTree{
        all_tags: [<body></body>, <script>console.log("Quoted message message")</script>, <h1>Heading</h1>]
        node_pointer: 0
        childrens: [[1, 2]]
        parents: [0, 0, 0]
    }
    all_tags: [<body><script>console.log("Quoted message message")</script><h1>Heading</h1></body>, <script>console.log("Quoted message message")</script>, <h1>Heading</h1>]
    all_attributes: {}
    close_tags: {'/!document': true, '/h1': true, '/body': true}
    attributes: {}
    tag_attributes: {}
    tag_type: {'script': [<script>console.log("Quoted message message")</script>], 'h1': [<h1>Heading</h1>]}
    debug_file: os.File{
        cfile: 0
        fd: 0
        is_opened: false
    }
}
```

With nested quotes after PR:
```
html.DocumentObjectModel{
    root: &<body><script>console.log("Quoted message 'message'")</script><h1>Heading</h1></body>
    constructed: true
    btree: html.BTree{
        all_tags: [<body></body>, <script>console.log("Quoted message 'message'")</script>, <h1>Heading</h1>]
        node_pointer: 0
        childrens: [[1, 2]]
        parents: [0, 0, 0]
    }
    all_tags: [<body><script>console.log("Quoted message 'message'")</script><h1>Heading</h1></body>, <script>console.log("Quoted message 'message'")</script>, <h1>Heading</h1>]
    all_attributes: {}
    close_tags: {'/!document': true, '/h1': true, '/body': true}
    attributes: {}
    tag_attributes: {}
    tag_type: {'script': [<script>console.log("Quoted message 'message'")</script>], 'h1': [<h1>Heading</h1>]}
    debug_file: os.File{
        cfile: 0
        fd: 0
        is_opened: false
    }
}
```
</details>

Fixes #10576

Furthermore , the script test were extended to check for this case. And to improve further maintainability, I'm cleaning up some comments by refining phrasing, and removing redundant descriptions of conditional statements that make the code imo harder to read.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd7bf5a</samp>

This pull request improves the `net/html` module by cleaning up the `parser.v` file and adding a new test case for the `parser_test.v` file. The changes enhance the code quality and the test coverage of the HTML parser.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd7bf5a</samp>

*  Simplify and clean up the logic of parsing string code inside open code tags ([link](https://github.com/vlang/v/pull/18123/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724L114-R129))
* Remove unnecessary comments and debug print statements from the parser code ([link](https://github.com/vlang/v/pull/18123/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724L139-R136), [link](https://github.com/vlang/v/pull/18123/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724L177-R177), [link](https://github.com/vlang/v/pull/18123/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724L210-R207), [link](https://github.com/vlang/v/pull/18123/files?diff=unified&w=0#diff-ccb255c02eb759f48240eb5686b03d3044dacf5bd04acd527220d7160030a724L219-R216))
* Add a test case for parsing a quoted string with an escaped single quote inside a script tag in `vlib/net/html/parser_test.v` ([link](https://github.com/vlang/v/pull/18123/files?diff=unified&w=0#diff-4902e81415c8e92e33c4fa9fc0640ed6724d2b4d683e46dea5d4138686919778L65-R65))
