### PR TITLE
ast, parser, checker, cgen, fmt: implement generic fn variable (fix #14937)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -935,14 +935,15 @@ pub:
 	mut_pos  token.Pos
 	comptime bool
 pub mut:
-	scope   &Scope = unsafe { nil }
-	obj     ScopeObject
-	mod     string
-	name    string
-	kind    IdentKind
-	info    IdentInfo
-	is_mut  bool // if mut *token* is before name. Use `is_mut()` to lookup mut variable
-	or_expr OrExpr
+	scope          &Scope = unsafe { nil }
+	obj            ScopeObject
+	mod            string
+	name           string
+	kind           IdentKind
+	info           IdentInfo
+	is_mut         bool // if mut *token* is before name. Use `is_mut()` to lookup mut variable
+	or_expr        OrExpr
+	concrete_types []Type
 }
 
 pub fn (i &Ident) is_mut() bool {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -744,7 +744,7 @@ pub fn (mut t Table) register_anon_struct(name string, sym_idx int) {
 }
 
 pub fn (t &Table) known_type(name string) bool {
-	return t.find_type_idx(name) != 0 || t.parsing_type == name
+	return t.find_type_idx(name) != 0 || t.parsing_type == name || name in ['i32', 'byte']
 }
 
 // start_parsing_type open the scope during the parsing of a type

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3387,7 +3387,16 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		}
 		// Non-anon-function object (not a call), e.g. `onclick(my_click)`
 		if func := c.table.find_fn(name) {
-			fn_type := ast.new_type(c.table.find_or_register_fn_type(func, false, true))
+			mut fn_type := ast.new_type(c.table.find_or_register_fn_type(func, false,
+				true))
+			if func.generic_names.len > 0 {
+				if typ_ := c.table.resolve_generic_to_concrete(fn_type, func.generic_names,
+					node.concrete_types)
+				{
+					fn_type = typ_
+					c.table.register_fn_concrete_types(func.fkey(), node.concrete_types)
+				}
+			}
 			node.name = name
 			node.kind = .function
 			node.info = ast.IdentFn{

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2018,6 +2018,17 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 		}
 		name := f.short_module(node.name)
 		f.write(name)
+		if node.concrete_types.len > 0 {
+			f.write('[')
+			for i, concrete_type in node.concrete_types {
+				typ_name := f.table.type_to_str_using_aliases(concrete_type, f.mod2alias)
+				f.write(typ_name)
+				if i != node.concrete_types.len - 1 {
+					f.write(', ')
+				}
+			}
+			f.write(']')
+		}
 		if node.or_expr.kind == .propagate_option {
 			f.write('?')
 		} else if node.or_expr.kind == .block {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4211,6 +4211,8 @@ fn (mut g Gen) ident(node ast.Ident) {
 				if cattr := func.attrs.find_first('c') {
 					name = cattr.arg
 				}
+			} else if node.concrete_types.len > 0 {
+				name = g.generic_fn_name(node.concrete_types, name)
 			}
 		}
 

--- a/vlib/v/tests/generics_fn_variable_test.v
+++ b/vlib/v/tests/generics_fn_variable_test.v
@@ -1,0 +1,20 @@
+type Fn[T] = fn (x T, i int) T
+
+fn func[T](x T, i int, f_ Fn[T]) T {
+	return f_(x, i)
+}
+
+fn f[T](x T, i int) T {
+	return x
+}
+
+fn test_generic_fn_variable() {
+	ff := f[int]
+	ret := ff(1, 11)
+	println(ret)
+	assert ret == 1
+
+	x := func[f64](2.0, 3, f[f64])
+	println(x)
+	assert x == 2.0
+}


### PR DESCRIPTION
This PR implement generic fn variable (fix #14937).

- Implement generic fn variable.
- Add test.

```v
type Fn[T] = fn (x T, i int) T

fn func[T](x T, i int, f_ Fn[T]) T {
	return f_(x, i)
}

fn f[T](x T, i int) T {
	return x
}

fn main() {
	ff := f[int]
	ret := ff(1, 11)
	println(ret)
	assert ret == 1

	x := func[f64](2.0, 3, f[f64])
	println(x)
	assert x == 2.0
}

PS D:\Test\v\tt1> v run .
1
2.0
```