### PR TITLE
net.http: fix chunked decoding of response body

### DIFF
--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -1,38 +1,72 @@
 module chunked
 
-import io
-
-const max_read_len = 8 * 1024
+import strings
+// See: https://en.wikipedia.org/wiki/Chunked_transfer_encoding
+// /////////////////////////////////////////////////////////////
+// The chunk size is transferred as a hexadecimal number
+// followed by \r\n as a line separator,
+// followed by a chunk of data of the given size.
+// The end is marked with a chunk with size 0.
 
 struct ChunkScanner {
-	text string
 mut:
-	pos int
+	pos  int
+	text string
 }
 
-fn (mut s ChunkScanner) read(mut buf []u8) !int {
-	if s.pos >= s.text.len {
-		return io.Eof{}
+fn (mut s ChunkScanner) read_chunk_size() u32 {
+	mut n := u32(0)
+	for {
+		if s.pos >= s.text.len {
+			break
+		}
+		c := s.text[s.pos]
+		if !c.is_hex_digit() {
+			break
+		}
+		n = n << 4
+		n += u32(unhex(c))
+		s.pos++
 	}
-	end := if s.pos + chunked.max_read_len >= s.text.len {
-		s.text.len
-	} else {
-		s.pos + chunked.max_read_len
-	}
-	n := copy(mut buf, s.text[s.pos..end].bytes())
-	s.pos += n
 	return n
 }
 
-fn reader(s string) &io.BufferedReader {
-	return io.new_buffered_reader(
-		reader: &ChunkScanner{
-			text: s
-		}
-	)
+fn unhex(c u8) u8 {
+	if `0` <= c && c <= `9` {
+		return c - `0`
+	} else if `a` <= c && c <= `f` {
+		return c - `a` + 10
+	} else if `A` <= c && c <= `F` {
+		return c - `A` + 10
+	}
+	return 0
+}
+
+fn (mut s ChunkScanner) skip_crlf() {
+	s.pos += 2
+}
+
+fn (mut s ChunkScanner) read_chunk(chunksize u32) string {
+	startpos := s.pos
+	s.pos += int(chunksize)
+	return s.text[startpos..s.pos]
 }
 
 pub fn decode(text string) string {
-	mut reader_ := reader(text)
-	return io.read_all(reader: reader_) or { ''.bytes() }.bytestr()
+	mut sb := strings.new_builder(100)
+	mut cscanner := ChunkScanner{
+		pos: 0
+		text: text
+	}
+	for {
+		csize := cscanner.read_chunk_size()
+		if 0 == csize {
+			break
+		}
+		cscanner.skip_crlf()
+		sb.write_string(cscanner.read_chunk(csize))
+		cscanner.skip_crlf()
+	}
+	cscanner.skip_crlf()
+	return sb.str()
 }

--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -9,9 +9,9 @@ import strings
 // The end is marked with a chunk with size 0.
 
 struct ChunkScanner {
-mut:
-	pos  int
 	text string
+mut:
+	pos int
 }
 
 fn (mut s ChunkScanner) read_chunk_size() u32 {
@@ -43,12 +43,17 @@ fn unhex(c u8) u8 {
 }
 
 fn (mut s ChunkScanner) skip_crlf() {
-	s.pos += 2
+	if s.pos + 2 <= s.text.len {
+		s.pos += 2
+	}
 }
 
 fn (mut s ChunkScanner) read_chunk(chunksize u32) string {
 	startpos := s.pos
-	s.pos += int(chunksize)
+	cs := int(chunksize)
+	if s.pos + cs <= s.text.len {
+		s.pos += cs
+	}
 	return s.text[startpos..s.pos]
 }
 

--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -1,6 +1,6 @@
 module chunked
 
-import strings
+import io
 // See: https://en.wikipedia.org/wiki/Chunked_transfer_encoding
 // /////////////////////////////////////////////////////////////
 // The chunk size is transferred as a hexadecimal number
@@ -9,64 +9,32 @@ import strings
 // The end is marked with a chunk with size 0.
 
 struct ChunkScanner {
-mut:
-	pos  int
 	text string
+mut:
+	pos int
 }
 
-fn (mut s ChunkScanner) read_chunk_size() u32 {
-	mut n := u32(0)
-	for {
-		if s.pos >= s.text.len {
-			break
-		}
-		c := s.text[s.pos]
-		if !c.is_hex_digit() {
-			break
-		}
-		n = n << 4
-		n += u32(unhex(c))
-		s.pos++
+fn (mut s ChunkScanner) read(mut buf []u8) !int {
+	if s.pos >= s.text.len {
+		return io.Eof{}
 	}
+	max_bytes := 100
+	end := if s.pos + max_bytes >= s.text.len { s.text.len } else { s.pos + max_bytes }
+	n := copy(mut buf, s.text[s.pos..end].bytes())
+	s.pos += n
 	return n
 }
 
-fn unhex(c u8) u8 {
-	if `0` <= c && c <= `9` {
-		return c - `0`
-	} else if `a` <= c && c <= `f` {
-		return c - `a` + 10
-	} else if `A` <= c && c <= `F` {
-		return c - `A` + 10
-	}
-	return 0
-}
-
-fn (mut s ChunkScanner) skip_crlf() {
-	s.pos += 2
-}
-
-fn (mut s ChunkScanner) read_chunk(chunksize u32) string {
-	startpos := s.pos
-	s.pos += int(chunksize)
-	return s.text[startpos..s.pos]
+fn reader(s string) &io.BufferedReader {
+	return io.new_buffered_reader(
+		reader: &ChunkScanner{
+			text: s
+		}
+	)
 }
 
 pub fn decode(text string) string {
-	mut sb := strings.new_builder(100)
-	mut cscanner := ChunkScanner{
-		pos: 0
-		text: text
-	}
-	for {
-		csize := cscanner.read_chunk_size()
-		if 0 == csize {
-			break
-		}
-		cscanner.skip_crlf()
-		sb.write_string(cscanner.read_chunk(csize))
-		cscanner.skip_crlf()
-	}
-	cscanner.skip_crlf()
-	return sb.str()
+	mut reader_ := reader(text)
+	sb := io.read_all(reader: reader_) or { ''.bytes() }
+	return sb.bytestr()
 }

--- a/vlib/v/doc/doc_test.v
+++ b/vlib/v/doc/doc_test.v
@@ -13,6 +13,6 @@ fn test_generate_from_mod() {
 	}
 	assert nested_mod_doc.head.name == nested_mod_name
 	assert nested_mod_doc.head.content == 'module ${nested_mod_name}'
-	assert nested_mod_doc.contents.len == 4
-	assert nested_mod_doc.contents['ChunkScanner'].children.len == 1
+	assert nested_mod_doc.contents.len == 3
+	assert nested_mod_doc.contents['ChunkScanner'].children.len == 3
 }

--- a/vlib/v/doc/doc_test.v
+++ b/vlib/v/doc/doc_test.v
@@ -13,6 +13,6 @@ fn test_generate_from_mod() {
 	}
 	assert nested_mod_doc.head.name == nested_mod_name
 	assert nested_mod_doc.head.content == 'module ${nested_mod_name}'
-	assert nested_mod_doc.contents.len == 3
-	assert nested_mod_doc.contents['ChunkScanner'].children.len == 3
+	assert nested_mod_doc.contents.len == 4
+	assert nested_mod_doc.contents['ChunkScanner'].children.len == 1
 }


### PR DESCRIPTION
fixes #18094

This PR adds a check that ensures position increments during chunked decoding are within text bounds. This should help resolve out-of-bounds errors that can occur when making concurrent requests. I'm experiencing this issue on Linux based systems but not on macOS. While this check is a way to deal with it, the root cause of the underlying problem with concurrent requests on Linux should be investigated further.