### PR TITLE
cgen: fix generics array of threads with multiple types (fix #18136)

### DIFF
--- a/vlib/v/tests/generics_array_of_threads_test.v
+++ b/vlib/v/tests/generics_array_of_threads_test.v
@@ -7,10 +7,17 @@ fn async_map[T](arr []T, func fn (T) T) []T {
 }
 
 fn test_generic_array_of_threads() {
-	arr := [1, 2, 3, 4]
-	results := async_map(arr, fn (a int) int {
+	arr1 := [1, 2, 3, 4]
+	results1 := async_map(arr1, fn (a int) int {
 		return -a
 	})
-	println(results)
-	assert results == [-1, -2, -3, -4]
+	println(results1)
+	assert results1 == [-1, -2, -3, -4]
+
+	arr2 := [1.0, 2.0, 3.0, 4.0]
+	results2 := async_map(arr2, fn (a f64) f64 {
+		return -a
+	})
+	println(results2)
+	assert results2 == [-1.0, -2.0, -3.0, -4.0]
 }


### PR DESCRIPTION
This PR fix generics array of threads with multiple types (fix #18136).

- Fix generics array of threads with multiple types.
- Add test.

```v
fn async_map[T](arr []T, func fn (T) T) []T {
	mut threads := []thread T{}
	for element in arr {
		threads << spawn func(element)
	}
	return threads.wait()
}

fn main() {
	arr1 := [1, 2, 3, 4]
	results1 := async_map(arr1, fn (a int) int {
		return -a
	})
	println(results1)
	assert results1 == [-1, -2, -3, -4]

	arr2 := [1.0, 2.0, 3.0, 4.0]
	results2 := async_map(arr2, fn (a f64) f64 {
		return -a
	})
	println(results2)
	assert results2 == [-1.0, -2.0, -3.0, -4.0]
}

PS D:\Test\v\tt1> v run .
[-1, -2, -3, -4]
[-1.0, -2.0, -3.0, -4.0]
```