### PR TITLE
net.html: add `&Tag` get_tag methods to retrieve first found matching tag

### DIFF
--- a/vlib/net/html/tag.v
+++ b/vlib/net/html/tag.v
@@ -69,6 +69,19 @@ pub fn (tag &Tag) str() string {
 	return html_str.str()
 }
 
+// get_tag retrieves the first found child tag in the tag that has the given tag name.
+pub fn (tag &Tag) get_tag(name string) ?&Tag {
+	for child in tag.children {
+		if child.name == name {
+			return child
+		}
+		if c := child.get_tag(name) {
+			return c
+		}
+	}
+	return none
+}
+
 // get_tags retrieves all the child tags recursively in the tag that has the given tag name.
 pub fn (tag &Tag) get_tags(name string) []&Tag {
 	mut res := []&Tag{}
@@ -79,6 +92,20 @@ pub fn (tag &Tag) get_tags(name string) []&Tag {
 		res << child.get_tags(name)
 	}
 	return res
+}
+
+// get_tag_by_attribute retrieves the first found child tag in the tag that has the given attribute name.
+pub fn (tag &Tag) get_tag_by_attribute(name string) ?&Tag {
+	// mut res := &Tag{}
+	for child in tag.children {
+		if child.attributes[name] != '' {
+			return child
+		}
+		if c := child.get_tag_by_attribute(name) {
+			return c
+		}
+	}
+	return none
 }
 
 // get_tags_by_attribute retrieves all the child tags recursively in the tag that has the given attribute name.
@@ -93,6 +120,19 @@ pub fn (tag &Tag) get_tags_by_attribute(name string) []&Tag {
 	return res
 }
 
+// get_tag_by_attribute_value retrieves the first found child tag in the tag that has the given attribute name and value.
+pub fn (tag &Tag) get_tag_by_attribute_value(name string, value string) ?&Tag {
+	for child in tag.children {
+		if child.attributes[name] == value {
+			return child
+		}
+		if c := child.get_tag_by_attribute_value(name, value) {
+			return c
+		}
+	}
+	return none
+}
+
 // get_tags_by_attribute_value retrieves all the child tags recursively in the tag that has the given attribute name and value.
 pub fn (tag &Tag) get_tags_by_attribute_value(name string, value string) []&Tag {
 	mut res := []&Tag{}
@@ -103,6 +143,26 @@ pub fn (tag &Tag) get_tags_by_attribute_value(name string, value string) []&Tag 
 		res << child.get_tags_by_attribute_value(name, value)
 	}
 	return res
+}
+
+// get_tag_by_class_name retrieves the first found child tag in the tag that has the given class name(s).
+pub fn (tag &Tag) get_tag_by_class_name(names ...string) ?&Tag {
+	for child in tag.children {
+		mut matched := true
+		for name in names {
+			matched = child.class_set.exists(name)
+			if !matched {
+				break
+			}
+		}
+		if matched {
+			return child
+		}
+		if c := child.get_tag_by_class_name(...names) {
+			return c
+		}
+	}
+	return none
 }
 
 // get_tags_by_class_name retrieves all the child tags recursively in the tag that has the given class name(s).

--- a/vlib/net/html/tag_test.v
+++ b/vlib/net/html/tag_test.v
@@ -8,7 +8,7 @@ const (
 <head></head>
 <body>
   <div id="1st">
-    <div class="bar"></div>
+    <div class="foo bar"></div>
   </div>
   <div id="2nd">
     <div class="foo">
@@ -30,7 +30,17 @@ const (
 </html>'
 )
 
-fn test_search_by_tag_type() {
+fn test_search_tag_by_type() {
+	mut dom := parse(html.html)
+	tag := dom.get_tag('body')[0]
+	assert tag.get_tag('div') or { assert false }.attributes['id'] == '1st'
+	assert tag.get_tag_by_attribute('href') or { assert false }.content == 'V'
+	// TODO: update after improved parsing to not add trailing white space to attribute values
+	assert tag.get_tag_by_attribute_value('id', '3rd') or { assert false }.str() == '<div id="3rd" ></div>'
+	assert tag.get_tag_by_class_name('foo') or { assert false }.attributes['class'] == 'foo bar'
+}
+
+fn test_search_tags_by_type() {
 	mut dom := parse(html.html)
 	tag := dom.get_tag_by_attribute_value('id', '2nd')[0]
 	assert tag.get_tags('div').len == 5


### PR DESCRIPTION
This adds the feature to retrieve the first matching tag. It mirrors it's current equivalents `get_tags<...>` that retrieve all tags. Since this allows to early return, the use cases for this will benefit from an improved performance.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f079482</samp>

This pull request enhances the `net/html` module with new features for searching HTML tags. It adds four new methods to the `Tag` struct in `vlib/net/html/tag.v` and corresponding test cases in `vlib/net/html/tag_test.v`. It also improves the test HTML document and the naming of some test functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f079482</samp>

*  Add four new methods to the `Tag` struct for searching child tags by name, attribute, attribute value, or class name ([link](https://github.com/vlang/v/pull/18139/files?diff=unified&w=0#diff-3a8ec24ecdca8a9c84ad445d6317373df6f1d5cb218adcb46bf5b60b117cf147R72-R84), [link](https://github.com/vlang/v/pull/18139/files?diff=unified&w=0#diff-3a8ec24ecdca8a9c84ad445d6317373df6f1d5cb218adcb46bf5b60b117cf147R97-R110), [link](https://github.com/vlang/v/pull/18139/files?diff=unified&w=0#diff-3a8ec24ecdca8a9c84ad445d6317373df6f1d5cb218adcb46bf5b60b117cf147R123-R135), [link](https://github.com/vlang/v/pull/18139/files?diff=unified&w=0#diff-3a8ec24ecdca8a9c84ad445d6317373df6f1d5cb218adcb46bf5b60b117cf147R148-R167)) in `vlib/net/html/tag.v`
