### PR TITLE
cgen: fix option ptr default struct initialization

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -321,7 +321,7 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 				}
 				g.write('.${field_name} = ')
 				if field.typ.has_flag(.option) {
-					if field.is_recursive {
+					if field.is_recursive || field.typ.is_ptr() {
 						g.expr_with_opt(ast.None{}, ast.none_type, field.typ)
 					} else {
 						tmp_var := g.new_tmp_var()

--- a/vlib/v/tests/option_ptr_init_test.v
+++ b/vlib/v/tests/option_ptr_init_test.v
@@ -1,0 +1,12 @@
+struct Queue {
+	head ?&Node
+}
+
+struct Node {
+	next ?&Node
+}
+
+fn test_main() {
+	q := Queue{}
+	assert q.head == none
+}


### PR DESCRIPTION
Fix #18129

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab080f6</samp>

Fix C code generation for optional pointer fields in structs and add a test case. The fix prevents segmentation faults when initializing such fields with `none` and the test case verifies the correct behavior.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab080f6</samp>

* Fix a bug in C code generation for optional pointer fields ([link](https://github.com/vlang/v/pull/18141/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L324-R324))
* Add a test case for the bug fix in `vlib/v/tests/option_ptr_init_test.v` ([link](https://github.com/vlang/v/pull/18141/files?diff=unified&w=0#diff-90097626dd8418807372c8fb5e3b43951915906127f6bc17675dfa8faf9874edR1-R12))
