### PR TITLE
cgen: fix nested map of fn call (fix #18133)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -474,6 +474,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		}
 		tmp_opt := if gen_or { g.new_tmp_var() } else { '' }
 		tmp_opt_ptr := if gen_or { g.new_tmp_var() } else { '' }
+		mut is_fn_last_index_call := false
 		if gen_or {
 			g.write('${elem_type_str}* ${tmp_opt_ptr} = (${elem_type_str}*)(map_get_check(')
 		} else {
@@ -482,6 +483,8 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 					g.write('((')
 					g.write_fn_ptr_decl(&elem_sym.info, '')
 					g.write(')(*(voidptr*)map_get(')
+					is_fn_last_index_call = true
+					g.is_fn_index_call = false
 				}
 			} else {
 				g.write('(*(${elem_type_str}*)map_get(')
@@ -506,7 +509,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		g.write('}')
 		if gen_or {
 			g.write('))')
-		} else if g.is_fn_index_call {
+		} else if is_fn_last_index_call {
 			g.write(', &(voidptr[]){ ${zero} })))')
 		} else {
 			g.write(', &(${elem_type_str}[]){ ${zero} }))')

--- a/vlib/v/tests/nested_map_of_fn_call_test.v
+++ b/vlib/v/tests/nested_map_of_fn_call_test.v
@@ -1,0 +1,9 @@
+fn test_nested_map_of_fn_call() {
+	mut a := map[string]map[string]fn () int{}
+	a['a']['a'] = fn () int {
+		return 0
+	}
+	b := a['a']['a']()
+	println(b)
+	assert b == 0
+}


### PR DESCRIPTION
This PR fix nested map of fn call (fix #18133).

- Fix nested map of fn call.
- Add test.

```v
fn main() {
	mut a := map[string]map[string]fn () int{}
	a['a']['a'] = fn () int {
		return 0
	}
	b := a['a']['a']()
	println(b)
	assert b == 0
}

PS D:\Test\v\tt1> v run .
0
```