### PR TITLE
checker: allow u8 ptr only with byte ptr and itself

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -224,6 +224,15 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 			&& got == ast.int_type_idx {
 			return
 		}
+	} else {
+		exp_sym_idx := c.table.sym(expected).idx
+		got_sym_idx := c.table.sym(got).idx
+		if expected.is_ptr() && got.is_ptr() && exp_sym_idx != got_sym_idx
+			&& exp_sym_idx in [ast.u8_type_idx, ast.byteptr_type_idx]
+			&& got_sym_idx !in [ast.u8_type_idx, ast.byteptr_type_idx] {
+			got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
+			return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
+		}
 	}
 	// check int signed/unsigned mismatch
 	if got == ast.int_literal_type_idx && expected in ast.unsigned_integer_type_idxs

--- a/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.out
+++ b/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.vv:9:28: error: cannot use `&[]int` as `&u8` in argument 1 to `accept_only_u8_references`
+    7 | fn test_main() {
+    8 |     a := [1, 2, 3]
+    9 |     accept_only_u8_references(&a)
+      |                               ~~
+   10 | }

--- a/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.vv
+++ b/vlib/v/checker/tests/fn_call_ref_incompatible_u8_test.vv
@@ -1,0 +1,10 @@
+module main
+
+fn accept_only_u8_references(x &u8) {
+	println(ptr_str(x))
+}
+
+fn test_main() {
+	a := [1, 2, 3]
+	accept_only_u8_references(&a)
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Fixes https://github.com/vlang/v/issues/16354

Overtakes https://github.com/vlang/v/pull/16783

Permission taken from @felipensp 

copilot:summary

copilot:walkthrough
