### PR TITLE
vweb: make controllers of struct Controller public  (fix #18148)

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -420,7 +420,7 @@ interface ControllerInterface {
 }
 
 pub struct Controller {
-mut:
+pub mut:
 	controllers []&ControllerPath
 }
 


### PR DESCRIPTION
This PR make controllers of struct Controller public  (fix #18148).

- Make controllers of struct Controller public.

```v
import vweb

pub struct CouldExist[T] {
pub:
	optional ?T
}

struct App {
	vweb.Context
	vweb.Controller
}

struct Admin {
	vweb.Context
}

struct Foo {
	vweb.Context
}

fn main() {
	mut app := &App{
		controllers: [
			vweb.controller('/admin', &Admin{}),
			vweb.controller('/foo', &Foo{}),
		]
	}
	vweb.run(app, 8080)
}

['/path']
pub fn (mut app Admin) path() vweb.Result {
	return app.text('Admin')
}

PS D:\Test\v\tt1> v run .
[Vweb] Running app on http://localhost:8080/
[Vweb] We have 3 workers
```