### PR TITLE
checker: disallow non-ptr elem in init ptr array

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -216,7 +216,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				c.expected_type = elem_type
 				continue
 			} else {
-				if !typ.is_ptr() && is_first_elem_ptr {
+				if !typ.is_real_pointer() && !typ.is_int() && is_first_elem_ptr {
 					c.error('cannot have non-pointer of type `${c.table.type_to_str(typ)}` in a pointer array of type `${c.table.type_to_str(elem_type)}`',
 						expr.pos())
 				}

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -210,7 +210,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				} else {
 					elem_type = ast.mktyp(typ)
 				}
-				if typ.is_ptr() {
+				if typ.is_ptr() && c.in_for_count == 0 {
 					is_first_elem_ptr = true
 				}
 				c.expected_type = elem_type

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -151,6 +151,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		mut expected_value_type := ast.void_type
 		mut expecting_interface_array := false
 		mut expecting_sumtype_array := false
+		mut is_first_elem_ptr := false
 		if c.expected_type != 0 {
 			expected_value_type = c.table.value_type(c.expected_type)
 			expected_value_sym := c.table.sym(expected_value_type)
@@ -209,8 +210,16 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				} else {
 					elem_type = ast.mktyp(typ)
 				}
+				if typ.is_ptr() {
+					is_first_elem_ptr = true
+				}
 				c.expected_type = elem_type
 				continue
+			} else {
+				if !typ.is_ptr() && is_first_elem_ptr {
+					c.error('cannot have non-pointer of type `${c.table.type_to_str(typ)}` in a pointer array of type `${c.table.type_to_str(elem_type)}`',
+						expr.pos())
+				}
 			}
 			if expr !is ast.TypeNode {
 				if c.table.type_kind(elem_type) == .interface_ {

--- a/vlib/v/checker/tests/array_init_ptr_non_ptr_elem_err.out
+++ b/vlib/v/checker/tests/array_init_ptr_non_ptr_elem_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_init_ptr_non_ptr_elem_err.vv:13:23: error: cannot have non-pointer of type `Chunk` in a pointer array of type `&Chunk`
+   11 |     chunk1 := Chunk{1}
+   12 |     w := World{
+   13 |         chunks: [&Chunk{0}, chunk1]
+      |                             ~~~~~~
+   14 |     }
+   15 |

--- a/vlib/v/checker/tests/array_init_ptr_non_ptr_elem_err.vv
+++ b/vlib/v/checker/tests/array_init_ptr_non_ptr_elem_err.vv
@@ -1,0 +1,17 @@
+struct World {
+	chunks []&Chunk
+}
+
+struct Chunk {
+	id int
+	// Big data here
+}
+
+fn main() {
+	chunk1 := Chunk{1}
+	w := World{
+		chunks: [&Chunk{0}, chunk1]
+	}
+
+	println(w)
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/9535

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7342d5c</samp>

Add a check for pointer consistency in array literals and a test case for it. This prevents the compiler from allowing invalid array initializations that would cause runtime errors.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7342d5c</samp>

* Fix a bug that allowed initializing an array of pointers with a mix of pointer and non-pointer elements ([link](https://github.com/vlang/v/pull/18161/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR154),[link](https://github.com/vlang/v/pull/18161/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL212-R222))
  - Declare and initialize a variable `is_first_elem_ptr` to track the type of the first array element ([link](https://github.com/vlang/v/pull/18161/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR154))
  - Check if the current element is not a pointer and `is_first_elem_ptr` is true, and report an error if so ([link](https://github.com/vlang/v/pull/18161/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL212-R222))
* Add a test file `array_init_ptr_non_ptr_elem_err.vv` to demonstrate the bug and the expected error message ([link](https://github.com/vlang/v/pull/18161/files?diff=unified&w=0#diff-c45223209cf4a02c69d781da45e135744fe42d4b985bf16084a8e21ebbac9e82R1-R17))
* Add a test file `array_init_ptr_non_ptr_elem_err.out` to contain the expected output of the compiler when checking the test file ([link](https://github.com/vlang/v/pull/18161/files?diff=unified&w=0#diff-af9577939ff64503b2f0e80bce35e51a0f8de660c0a477f0f50ca7bce4200494R1-R7))
