### PR TITLE
v: attr for enum fields (+ json encode/decode)

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -111,6 +111,7 @@ pub struct EnumData {
 pub:
 	name  string
 	value i64
+	attrs []string
 }
 
 // FieldData holds information about a field. Fields reside on structs.

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1296,6 +1296,7 @@ pub:
 	comments      []Comment // comment after Enumfield in the same line
 	next_comments []Comment // comments between current EnumField and next EnumField
 	has_expr      bool      // true, when .expr has a value
+	attrs         []Attr
 pub mut:
 	expr Expr // the value of current EnumField; 123 in `ename = 123`
 }

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -512,7 +512,7 @@ pub fn (x Expr) str() string {
 			return "'${x.val}'"
 		}
 		TypeNode {
-			return 'TypeNode(${x.typ})'
+			return 'TypeNode(${global_table.type_str(x.typ)})'
 		}
 		TypeOf {
 			if x.is_type {

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -193,6 +193,7 @@ pub:
 	is_multi_allowed bool
 	uses_exprs       bool
 	typ              Type
+	attrs            map[string][]Attr
 }
 
 [minify]

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -986,6 +986,10 @@ pub fn (mut f Fmt) enum_decl(node ast.EnumDecl) {
 			f.write(' = ')
 			f.expr(field.expr)
 		}
+		if field.attrs.len > 0 {
+			f.write(' ')
+			f.single_line_attrs(field.attrs, inline: true)
+		}
 		f.comments(field.comments, inline: true, has_nl: false, level: .indent)
 		f.writeln('')
 		f.comments(field.next_comments, inline: false, has_nl: true, level: .indent)

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -942,6 +942,15 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					} else {
 						g.writeln('${g.typ(g.comptime_for_field_type)}__${g.comptime_enum_field_value};')
 					}
+					enum_attrs := sym.info.attrs[val]
+					if enum_attrs.len == 0 {
+						g.writeln('\t${node.val_var}.attrs = __new_array_with_default(0, 0, sizeof(string), 0);')
+					} else {
+						attrs := cgen_attrs(enum_attrs)
+						g.writeln(
+							'\t${node.val_var}.attrs = new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
+							attrs.join(', ') + '}));\n')
+					}
 					g.stmts(node.stmts)
 					g.writeln('}')
 					i++

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -205,7 +205,15 @@ fn (mut g Gen) gen_enum_to_str(utyp ast.Type, sym ast.TypeSymbol, enum_var strin
 	enc.writeln('${ident}switch (${enum_var}) {')
 	for val in (sym.info as ast.Enum).vals {
 		enc.write_string('${ident}\tcase ${enum_prefix}${val}:\t')
-		enc.writeln('${result_var} = json__encode_string(_SLIT("${val}")); break;')
+		// read [json:] attr from the Enum value
+		attr := g.table.enum_decls[sym.name].fields.filter(it.name == val)[0].attrs.find_first('json') or {
+			ast.Attr{}
+		}
+		if attr.has_arg {
+			enc.writeln('${result_var} = json__encode_string(_SLIT("${attr.arg}")); break;')
+		} else {
+			enc.writeln('${result_var} = json__encode_string(_SLIT("${val}")); break;')
+		}
 	}
 	enc.writeln('${ident}}')
 }
@@ -215,11 +223,19 @@ fn (mut g Gen) gen_str_to_enum(utyp ast.Type, sym ast.TypeSymbol, val_var string
 	enum_prefix := g.gen_enum_prefix(utyp.clear_flag(.option))
 	is_option := utyp.has_flag(.option)
 	for k, val in (sym.info as ast.Enum).vals {
-		if k == 0 {
-			dec.write_string('${ident}if (string__eq(_SLIT("${val}"), ${val_var}))\t')
-		} else {
-			dec.write_string('${ident}else if (string__eq(_SLIT("${val}"), ${val_var}))\t')
+		// read [json:] attr from the Enum value
+		attr := g.table.enum_decls[sym.name].fields.filter(it.name == val)[0].attrs.find_first('json') or {
+			ast.Attr{}
 		}
+		if k == 0 {
+			dec.write_string('${ident}if (string__eq(_SLIT("${val}"), ${val_var})')
+		} else {
+			dec.write_string('${ident}else if (string__eq(_SLIT("${val}"), ${val_var})')
+		}
+		if attr.has_arg {
+			dec.write_string('|| string__eq(_SLIT("${attr.arg}"), ${val_var})')
+		}
+		dec.write_string(')\t')
 		if is_option {
 			base_typ := g.base_type(utyp)
 			dec.writeln('_option_ok(&(${base_typ}[]){ ${enum_prefix}${val} }, ${result_var}, sizeof(${base_typ}));')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -233,7 +233,7 @@ fn (mut g Gen) gen_str_to_enum(utyp ast.Type, sym ast.TypeSymbol, val_var string
 			dec.write_string('${ident}else if (string__eq(_SLIT("${val}"), ${val_var})')
 		}
 		if attr.has_arg {
-			dec.write_string('|| string__eq(_SLIT("${attr.arg}"), ${val_var})')
+			dec.write_string(' || string__eq(_SLIT("${attr.arg}"), ${val_var})')
 		}
 		dec.write_string(')\t')
 		if is_option {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3923,6 +3923,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			p.attributes()
 			attrs << p.attrs
 			enum_attrs[val] = attrs
+			p.attrs = []
 		}
 		fields << ast.EnumField{
 			name: val

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3904,6 +3904,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	// mut default_exprs := []ast.Expr{}
 	mut fields := []ast.EnumField{}
 	mut uses_exprs := false
+	mut enum_attrs := map[string][]ast.Attr{}
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
 		pos := p.tok.pos()
 		val := p.check_name()
@@ -3917,6 +3918,12 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			has_expr = true
 			uses_exprs = true
 		}
+		mut attrs := []ast.Attr{}
+		if p.tok.kind == .lsbr {
+			p.attributes()
+			attrs << p.attrs
+			enum_attrs[val] = attrs
+		}
 		fields << ast.EnumField{
 			name: val
 			pos: pos
@@ -3924,6 +3931,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			has_expr: has_expr
 			comments: p.eat_comments(same_line: true)
 			next_comments: p.eat_comments()
+			attrs: attrs
 		}
 	}
 	p.top_level_statement_end()
@@ -3965,6 +3973,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			is_multi_allowed: is_multi_allowed
 			uses_exprs: uses_exprs
 			typ: enum_type
+			attrs: enum_attrs
 		}
 		is_pub: is_pub
 	})

--- a/vlib/v/tests/enum_attr_test.v
+++ b/vlib/v/tests/enum_attr_test.v
@@ -1,8 +1,8 @@
 import json
 
 enum Foo {
-	yay
-	foo
+	yay  [json: 'A'; yay]
+	foo  [foo; json: 'B']
 }
 
 struct FooStruct {
@@ -17,8 +17,8 @@ fn test_comptime() {
 			assert f.attrs[1] == 'yay'
 		}
 		if f.value == Foo.foo {
-			assert f.attrs[0] == 'json: B'
-			assert f.attrs[1] == 'foo'
+			assert f.attrs[1] == 'json: B'
+			assert f.attrs[0] == 'foo'
 		}
 	}
 }

--- a/vlib/v/tests/enum_attr_test.v
+++ b/vlib/v/tests/enum_attr_test.v
@@ -1,0 +1,37 @@
+import json
+
+enum Foo {
+	yay
+	foo
+}
+
+struct FooStruct {
+	item Foo
+}
+
+fn test_comptime() {
+	$for f in Foo.values {
+		println(f)
+		if f.value == Foo.yay {
+			assert f.attrs[0] == 'json: A'
+			assert f.attrs[1] == 'yay'
+		}
+		if f.value == Foo.foo {
+			assert f.attrs[0] == 'json: B'
+			assert f.attrs[1] == 'foo'
+		}
+	}
+}
+
+fn test_json_encode() {
+	assert dump(json.encode(Foo.yay)) == '"A"'
+	assert dump(json.encode(Foo.foo)) == '"B"'
+
+	assert dump(json.encode(FooStruct{ item: Foo.yay })) == '{"item":"A"}'
+	assert dump(json.encode(FooStruct{ item: Foo.foo })) == '{"item":"B"}'
+}
+
+fn test_json_decode() {
+	dump(json.decode(FooStruct, '{"item": "A"}')!)
+	dump(json.decode(FooStruct, '{"item": "B"}')!)
+}


### PR DESCRIPTION
Fix #18151

This PR enables attributes to Enum values.

I've also changed the TypeNode dump whichs occurs when doing dump(json.decode(...)), it nows prints the symbol name (e.g. TypeNode(main.Struct), instead of TypeNode(Type(...=0xfffff)).

```V
import json

enum Foo {
	yay
	foo
}

struct FooStruct {
	item Foo
}

fn test_comptime() {
	$for f in Foo.values {
		println(f)
		if f.value == Foo.yay {
			assert f.attrs[0] == 'json: A'
			assert f.attrs[1] == 'yay'
		}
		if f.value == Foo.foo {
			assert f.attrs[0] == 'json: B'
			assert f.attrs[1] == 'foo'
		}
	}
}

fn test_json_encode() {
	assert dump(json.encode(Foo.yay)) == '"A"'
	assert dump(json.encode(Foo.foo)) == '"B"'

	assert dump(json.encode(FooStruct{ item: Foo.yay })) == '{"item":"A"}'
	assert dump(json.encode(FooStruct{ item: Foo.foo })) == '{"item":"B"}'
}

fn test_json_decode() {
	dump(json.decode(FooStruct, '{"item": "A"}')!)
	dump(json.decode(FooStruct, '{"item": "B"}')!)
}

```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f717ec3</samp>

This pull request adds support for customizing the JSON encoding and decoding of enum values using the `[json:]` attribute. It modifies the parser, the AST, the type system, and the C code generator to handle the attribute. It also adds tests for the new feature in `vlib/v/tests/enum_attr_test.v`.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f717ec3</samp>

*  Add support for enum attributes, such as `[json: A]`, to the V language and the JSON module. ([link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-7e458b1abaa6bf3fddcd706358679ea5cbd9575e2bbdc58bbe103a3e87de34e1R114), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-8e27648d38098f8fe63778c94c11aceb0a48e379121f676d189b04cb2cd8fc45R1299), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-b9cd311e4eb5925e472e2d7f062cd82f2974db9d695c97eccd6ad2d54c2910b1R196), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3907), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3921-R3927), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3935), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3977))
*  Modify the `str` method of the `TypeNode` enum to use the `global_table.type_str` function, which shows the attributes of the type. ([link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-7bc4f508f265a81569dbc37006a6626b7e205285be22b19ed323cb935ca9943eL515-R515))
*  Generate C code that initializes the `attrs` field of the `EnumVal` struct with an array of strings containing the attributes of the enum value. ([link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bR945-R953))
*  Modify the `gen_json_for_enum` method of the `Gen` struct to read the `[json:]` attribute from the enum value and use it for encoding and decoding, instead of the enum value name. ([link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L208-R216), [link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L218-R238))
*  Add tests for the new feature of enum attributes in `vlib/v/tests/enum_attr_test.v`, using the `json` module and the `Foo` enum. ([link](https://github.com/vlang/v/pull/18163/files?diff=unified&w=0#diff-c74ee0a9d16dee055a160a405117ee8fbc6c9c6178183557b2792a403dda56b1R1-R37))
