### PR TITLE
net: fix typos

### DIFF
--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -53,7 +53,7 @@ fn C.ntohl(net u32) u32
 fn C.ntohs(net u16) u16
 
 // fn C.bind(sockfd int, addr &C.sockaddr, addrlen C.socklen_t) int
-// use voidptr for arg 2 becasue sockaddr is a generic descriptor for any kind of socket operation,
+// use voidptr for arg 2 because sockaddr is a generic descriptor for any kind of socket operation,
 // it can also take sockaddr_in depending on the type of socket used in arg 1
 fn C.bind(sockfd int, addr &Addr, addrlen u32) int
 

--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -201,7 +201,7 @@ fn (mut zftp FTP) pasv() !&DTP {
 		println('pass: ${data}')
 	}
 	if code != ftp.passive_mode {
-		return error('pasive mode not allowed')
+		return error('passive mode not allowed')
 	}
 	dtp := new_dtp(data)!
 	return dtp

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -1,6 +1,6 @@
 import net.ftp
 
-fn test_ftp_cleint() {
+fn test_ftp_client() {
 	$if !network ? {
 		return
 	}

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -52,7 +52,7 @@ pub fn (mut req Request) add_custom_header(key string, val string) ! {
 	return req.header.add_custom(key, val)
 }
 
-// do will send the HTTP request and returns `http.Response` as soon as the response is recevied
+// do will send the HTTP request and returns `http.Response` as soon as the response is received
 pub fn (req &Request) do() !Response {
 	mut url := urllib.parse(req.url) or { return error('http.Request.do: invalid url ${req.url}') }
 	mut rurl := url

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -76,7 +76,7 @@ pub fn (mut s Server) stop() {
 	s.state = .stopped
 }
 
-// close immediatly closes the port and signals the server that it has been closed.
+// close immediately closes the port and signals the server that it has been closed.
 [inline]
 pub fn (mut s Server) close() {
 	s.state = .closed

--- a/vlib/net/openssl/c.v
+++ b/vlib/net/openssl/c.v
@@ -1,6 +1,6 @@
 module openssl
 
-// On Linux, prefer a localy built openssl, because it is
+// On Linux, prefer a locally built openssl, because it is
 // much more likely for it to be newer, than the system
 // openssl from libssl-dev. If there is no local openssl,
 // the next #pkgconfig flag is harmless, since it will still

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -162,7 +162,7 @@ fn (mut c Client) expect_reply(expected ReplyCode) ! {
 			return error('Received unexpected status code ${status}, expecting ${expected}')
 		}
 	} else {
-		return error('Recieved unexpected SMTP data: ${str}')
+		return error('Received unexpected SMTP data: ${str}')
 	}
 }
 

--- a/vlib/net/socket_options.c.v
+++ b/vlib/net/socket_options.c.v
@@ -1,7 +1,7 @@
 module net
 
 pub enum SocketOption {
-	// TODO: SO_ACCEPT_CONN is not here because windows doesnt support it
+	// TODO: SO_ACCEPT_CONN is not here because windows doesn't support it
 	// and there is no easy way to define it
 	broadcast = C.SO_BROADCAST
 	debug = C.SO_DEBUG

--- a/vlib/net/socket_options.c.v
+++ b/vlib/net/socket_options.c.v
@@ -11,9 +11,9 @@ pub enum SocketOption {
 	linger = C.SO_LINGER
 	oob_inline = C.SO_OOBINLINE
 	reuse_addr = C.SO_REUSEADDR
-	recieve_buf_size = C.SO_RCVBUF
-	recieve_low_size = C.SO_RCVLOWAT
-	recieve_timeout = C.SO_RCVTIMEO
+	receive_buf_size = C.SO_RCVBUF
+	receive_low_size = C.SO_RCVLOWAT
+	receive_timeout = C.SO_RCVTIMEO
 	send_buf_size = C.SO_SNDBUF
 	send_low_size = C.SO_SNDLOWAT
 	send_timeout = C.SO_SNDTIMEO
@@ -24,9 +24,9 @@ pub enum SocketOption {
 const (
 	opts_bool    = [SocketOption.broadcast, .debug, .dont_route, .error, .keep_alive, .oob_inline]
 	opts_int     = [
-		.recieve_buf_size,
-		.recieve_low_size,
-		.recieve_timeout,
+		.receive_buf_size,
+		.receive_low_size,
+		.receive_timeout,
 		.send_buf_size,
 		.send_low_size,
 		.send_timeout,
@@ -39,9 +39,9 @@ const (
 		.keep_alive,
 		.linger,
 		.oob_inline,
-		.recieve_buf_size,
-		.recieve_low_size,
-		.recieve_timeout,
+		.receive_buf_size,
+		.receive_low_size,
+		.receive_timeout,
 		.send_buf_size,
 		.send_low_size,
 		.send_timeout,

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -415,7 +415,7 @@ fn get_scheme(rawurl string) !string {
 	return split[0]
 }
 
-// split slices s into two substrings separated by the first occurence of
+// split slices s into two substrings separated by the first occurrence of
 // sep. If cutc is true then sep is included with the second substring.
 // If sep does not occur in s then s and the empty string is returned.
 fn split(s string, sep u8, cutc bool) (string, string) {

--- a/vlib/net/websocket/message.v
+++ b/vlib/net/websocket/message.v
@@ -231,7 +231,7 @@ pub fn (mut ws Client) parse_frame_header() !Frame {
 			frame.opcode = unsafe { OPCode(int(buffer[0] & 0x7F)) }
 			frame.has_mask = (buffer[1] & 0x80) == 0x80
 			frame.payload_len = buffer[1] & 0x7F
-			// if has mask set the byte postilion where mask ends
+			// if has mask, set the byte position where the mask ends
 			if frame.has_mask {
 				mask_end_byte = if frame.payload_len < 126 {
 					websocket.header_len_offset + 4

--- a/vlib/net/websocket/message.v
+++ b/vlib/net/websocket/message.v
@@ -231,7 +231,7 @@ pub fn (mut ws Client) parse_frame_header() !Frame {
 			frame.opcode = unsafe { OPCode(int(buffer[0] & 0x7F)) }
 			frame.has_mask = (buffer[1] & 0x80) == 0x80
 			frame.payload_len = buffer[1] & 0x7F
-			// if has mask, set the byte position where the mask ends
+			// if the frame has a mask, set the byte position where the mask ends
 			if frame.has_mask {
 				mask_end_byte = if frame.payload_len < 126 {
 					websocket.header_len_offset + 4

--- a/vlib/net/websocket/message.v
+++ b/vlib/net/websocket/message.v
@@ -112,7 +112,7 @@ fn (mut ws Client) read_payload(frame &Frame) ![]u8 {
 fn (mut ws Client) validate_utf_8(opcode OPCode, payload []u8) ! {
 	if opcode in [.text_frame, .close] && !utf8.validate(payload.data, payload.len) {
 		ws.logger.error('malformed utf8 payload, payload len: (${payload.len})')
-		ws.send_error_event('Recieved malformed utf8.')
+		ws.send_error_event('Received malformed utf8.')
 		ws.close(1007, 'malformed utf8 payload')!
 		return error('malformed utf8 payload')
 	}
@@ -180,7 +180,7 @@ pub fn (mut ws Client) read_next_message() !Message {
 	return error('none')
 }
 
-// payload_from_fragments returs the whole paylaod from fragmented message
+// payload_from_fragments returns the whole paylaod from fragmented message
 fn (ws Client) payload_from_fragments(fin_payload []u8) ![]u8 {
 	mut total_size := 0
 	for f in ws.fragments {
@@ -231,7 +231,7 @@ pub fn (mut ws Client) parse_frame_header() !Frame {
 			frame.opcode = unsafe { OPCode(int(buffer[0] & 0x7F)) }
 			frame.has_mask = (buffer[1] & 0x80) == 0x80
 			frame.payload_len = buffer[1] & 0x7F
-			// if has mask set the byte postition where mask ends
+			// if has mask set the byte postilion where mask ends
 			if frame.has_mask {
 				mask_end_byte = if frame.payload_len < 126 {
 					websocket.header_len_offset + 4

--- a/vlib/net/websocket/utils.v
+++ b/vlib/net/websocket/utils.v
@@ -18,7 +18,7 @@ fn htonl64(payload_len u64) []u8 {
 	return ret
 }
 
-// create_masking_key returs a new masking key to use when masking websocket messages
+// create_masking_key returns a new masking key to use when masking websocket messages
 fn create_masking_key() []u8 {
 	mask_bit := rand.u8()
 	buf := []u8{len: 4, init: `0`}
@@ -26,10 +26,10 @@ fn create_masking_key() []u8 {
 	return buf
 }
 
-// create_key_challenge_response creates a key challange response from security key
+// create_key_challenge_response creates a key challenge response from security key
 fn create_key_challenge_response(seckey string) !string {
 	if seckey.len == 0 {
-		return error('unexpected seckey lengt zero')
+		return error('unexpected seckey length zero')
 	}
 	guid := '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
 	sha1buf := seckey + guid

--- a/vlib/net/websocket/websocket_test.v
+++ b/vlib/net/websocket/websocket_test.v
@@ -10,7 +10,7 @@ pub mut:
 	nr_closes        int
 }
 
-// Do not run these tests everytime, since they are flaky.
+// Do not run these tests every time, since they are flaky.
 // They have their own specialized CI runner.
 const github_job = os.getenv('GITHUB_JOB')
 
@@ -129,10 +129,10 @@ fn ws_test(family net.AddrFamily, uri string) ! {
 		client.write(msg.bytes(), .text_frame) or {
 			panic('fail to write to websocket, err: ${err}')
 		}
-		// sleep to give time to recieve response before send a new one
+		// sleep to give time to receive response before send a new one
 		time.sleep(100 * time.millisecond)
 	}
-	// sleep to give time to recieve response before asserts
+	// sleep to give time to receive response before asserts
 	time.sleep(1500 * time.millisecond)
 	// We expect at least 2 pongs, one sent directly and one indirectly
 	assert test_results.nr_pong_received >= 2


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fc2a86</samp>

This pull request fixes various spelling errors in the `vlib/net` module, mainly in comments, error messages, and enum values. These changes improve the readability, consistency, and clarity of the code and the documentation. No functional changes are introduced by this pull request.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6fc2a86</samp>

* Fix typos in comments, error messages, function names, and enum values ([link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-ce4fed8a80eef8878e2a509860a8d661a2553a277885837cbf2c9358036685fbL56-R56), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L204-R204), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-d7b79f8e529d174627955a8bb63d014714e18bc3ab81d6e93d09f4c82f970a00L3-R3), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995L55-R55), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-8d46659948d0307c5239ade1d5c80100c7558d707663bd21ff0e31cefcf10a82L79-R79), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-e9e8ddf0891865eaedba8fed6f27c9a7fdcf52766727c7e0bfbea6cde3456205L3-R3), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-1d4ed741b6d730ebf09d584b8f1e2c8efb7b783a1d653a1e776b034d639f9516L165-R165), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-f82441f59b8c0ecb9203c642af8017b34df4ff1734a3a9fc463009f4d8017b2dL4-R4), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-f82441f59b8c0ecb9203c642af8017b34df4ff1734a3a9fc463009f4d8017b2dL14-R16), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-f82441f59b8c0ecb9203c642af8017b34df4ff1734a3a9fc463009f4d8017b2dL27-R29), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-f82441f59b8c0ecb9203c642af8017b34df4ff1734a3a9fc463009f4d8017b2dL42-R44), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-c68c83cfd274d96f5c5f442f56cbdad148925f59faa3b7902fece8e18d22b149L418-R418), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-3315e72936f08aef217bd678f4f3cdece558e89a608a948e7275d5d165db54d5L115-R115), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-3315e72936f08aef217bd678f4f3cdece558e89a608a948e7275d5d165db54d5L183-R183), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-3315e72936f08aef217bd678f4f3cdece558e89a608a948e7275d5d165db54d5L234-R234), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-cf71c396bfc7697aa774d593fbaaaa095c79092a3efaa0c516b4bc278946deaeL21-R21), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-cf71c396bfc7697aa774d593fbaaaa095c79092a3efaa0c516b4bc278946deaeL29-R32), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-a85a938295d82aedab694edfeb772e0bb185966f12c05749c614a06a199b4b29L13-R13), [link](https://github.com/vlang/v/pull/18164/files?diff=unified&w=0#diff-a85a938295d82aedab694edfeb772e0bb185966f12c05749c614a06a199b4b29L132-R135))
