### PR TITLE
net.http: check for `\r\n` line endings in header range

### DIFF
--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -144,7 +144,7 @@ fn find_headers_range(data string) !(int, int) {
 	start_idx := data.index('\n') or { return error('no start index found') } + 1
 	mut count := 0
 	for i := start_idx; i < data.len; i++ {
-		if data[i] == `\n` || (data[i] == `\r` && i + 1 < data.len && data[i + 1] == `\n`) {
+		if data[i] == `\n` || (data[i] == `\r` && data[i + 1] == `\n`) {
 			count++
 		} else if data[i] != `\r` {
 			count = 0

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -144,7 +144,7 @@ fn find_headers_range(data string) !(int, int) {
 	start_idx := data.index('\n') or { return error('no start index found') } + 1
 	mut count := 0
 	for i := start_idx; i < data.len; i++ {
-		if data[i] == `\n` {
+		if data[i] == `\n` || (data[i] == `\r` && i + 1 < data.len && data[i + 1] == `\n`) {
 			count++
 		} else if data[i] != `\r` {
 			count = 0


### PR DESCRIPTION
Depending a response header one might run into issues if it contains `\r\n` line endings. 
Therefore this PR adds `\r\n` into the condition.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 500eebb</samp>

Fix header parsing bug in `parse_headers` function of `net/http` module. The change handles both `\n` and `\r\n` line endings for headers.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 500eebb</samp>

* Fix header parsing bug in `parse_headers` function ([link](https://github.com/vlang/v/pull/18169/files?diff=unified&w=0#diff-75efcba8ed0029a97f653d4b42426c8a9fd3fbe58e54af92311fe791ddc5d0e9L147-R147))
