### PR TITLE
checker: allow `i32` enum type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1627,8 +1627,12 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 			signed, enum_umin, enum_umax = false, 0, 0xFFFF_FFFF_FFFF_FFFF
 		}
 		else {
-			c.error('`${senum_type}` is not one of `i8`,`i16`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`',
-				node.typ_pos)
+			if senum_type == 'i32' {
+				signed, enum_imin, enum_imax = true, -2_147_483_648, 0x7FFF_FFFF
+			} else {
+				c.error('`${senum_type}` is not one of `i8`,`i16`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`',
+					node.typ_pos)
+			}
 		}
 	}
 	if enum_imin > 0 {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1630,7 +1630,7 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 			if senum_type == 'i32' {
 				signed, enum_imin, enum_imax = true, -2_147_483_648, 0x7FFF_FFFF
 			} else {
-				c.error('`${senum_type}` is not one of `i8`,`i16`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`',
+				c.error('`${senum_type}` is not one of `i8`,`i16`,`i32`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`',
 					node.typ_pos)
 			}
 		}

--- a/vlib/v/checker/tests/enum_field_value_overflow.out
+++ b/vlib/v/checker/tests/enum_field_value_overflow.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/enum_field_value_overflow.vv:3:10: error: enum value `21474
       |             ~~~~~~~~~~
     4 |     blue
     5 | }
-vlib/v/checker/tests/enum_field_value_overflow.vv:7:21: error: `string` is not one of `i8`,`i16`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`
+vlib/v/checker/tests/enum_field_value_overflow.vv:7:21: error: `string` is not one of `i8`,`i16`,`i32`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`
     5 | }
     6 |
     7 | enum ColorString as string {

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -94,13 +94,13 @@ enum Number as i32 {
 	c = 300
 	d = 400
 }
+
 fn test_enum_as_i32() {
 	assert int(Number.a) == 100
 	assert int(Number.b) == 200
 	assert int(Number.c) == 300
 	assert int(Number.d) == 400
 }
-
 
 /*
 enum Expr {

--- a/vlib/v/tests/enum_test.v
+++ b/vlib/v/tests/enum_test.v
@@ -88,6 +88,20 @@ fn test_nums() {
 	assert d == unsafe { Foo(-10) }
 }
 
+enum Number as i32 {
+	a = 100
+	b = 200
+	c = 300
+	d = 400
+}
+fn test_enum_as_i32() {
+	assert int(Number.a) == 100
+	assert int(Number.b) == 200
+	assert int(Number.c) == 300
+	assert int(Number.d) == 400
+}
+
+
 /*
 enum Expr {
 	BoolExpr(bool)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18171

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e111ed</samp>

This pull request adds support for `i32` as a valid underlying type for enums in V. It modifies the checker to handle `i32` enums and adds a test case in `enum_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e111ed</samp>

* Add support for `i32` as a valid underlying type for enums ([link](https://github.com/vlang/v/pull/18172/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L1630-R1635))
* Add a test case for the `enum as i32` feature in `vlib/v/tests/enum_test.v` ([link](https://github.com/vlang/v/pull/18172/files?diff=unified&w=0#diff-3cec753ccee99bddf81cbb964a12361bb15e122a7d60ccf35a26fa8280518f10R91-R104))
