### PR TITLE
cgen: fix option unwrap from ovoid function

### DIFF
--- a/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
+++ b/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
@@ -1,12 +1,10 @@
 import db.sqlite
 import rand
 
-const (
-	max_file_name_len = 256
-)
+const max_file_name_len = 256
 
 fn test_vfs_register() {
-	org_default_vfs := sqlite.get_default_vfs()?
+	org_default_vfs := sqlite.get_default_vfs()!
 
 	assert org_default_vfs.zName != 0
 
@@ -22,9 +20,9 @@ fn test_vfs_register() {
 
 	vfs_descr.register_as_nondefault() or { panic('vfs register failed ${err}') }
 
-	sqlite.get_vfs(vfs_name)?
+	sqlite.get_vfs(vfs_name)!
 
-	now_default_vfs := sqlite.get_default_vfs()?
+	now_default_vfs := sqlite.get_default_vfs()!
 
 	assert now_default_vfs.zName == org_default_vfs.zName
 
@@ -37,7 +35,7 @@ fn test_vfs_register() {
 
 // minimal vfs based on example https://www.sqlite.org/src/doc/trunk/src/test_demovfs.c
 fn test_verify_vfs_is_actually_used() {
-	wrapped := sqlite.get_default_vfs()?
+	wrapped := sqlite.get_default_vfs()!
 
 	vfs_name := 'sometest'
 	mut vfs_state := &ExampleVfsState{
@@ -64,7 +62,7 @@ fn test_verify_vfs_is_actually_used() {
 		xCurrentTimeInt64: wrapped.xCurrentTimeInt64
 	}
 
-	vfs_descr.register_as_nondefault()?
+	vfs_descr.register_as_nondefault()!
 
 	// normally this would be written to disk
 	mut db := sqlite.connect_full('foo.db', [.readwrite, .create], vfs_name)!

--- a/vlib/db/sqlite/vfs_lowlevel.v
+++ b/vlib/db/sqlite/vfs_lowlevel.v
@@ -87,51 +87,40 @@ fn C.sqlite3_vfs_unregister(&C.sqlite3_vfs) int
 
 // get_vfs Requests sqlite to return instance of VFS with given name.
 // when such vfs is not known, `none` is returned
-pub fn get_vfs(name string) ?&Sqlite3_vfs {
+pub fn get_vfs(name string) !&Sqlite3_vfs {
 	res := C.sqlite3_vfs_find(name.str)
-
-	unsafe {
-		if res == nil {
-			return none
-		} else {
-			return res
-		}
+	if res != unsafe { nil } {
+		return res
 	}
+	return error('sqlite3_vfs_find returned 0')
 }
 
 // get_default_vfs Asks sqlite for default VFS instance
-pub fn get_default_vfs() ?&Sqlite3_vfs {
-	unsafe {
-		res := C.sqlite3_vfs_find(nil)
-		if res == nil {
-			return none
-		} else {
-			return res
-		}
+pub fn get_default_vfs() !&Sqlite3_vfs {
+	res := C.sqlite3_vfs_find(unsafe { nil })
+	if res != unsafe { nil } {
+		return res
 	}
+	return error('sqlite3_vfs_find(0) returned 0')
 }
 
 // register_as_nondefault Asks sqlite to register VFS passed in receiver argument as the known VFS.
 // more info about VFS: https://www.sqlite.org/c3ref/vfs.html
 // 'not TODOs' to prevent corruption: https://sqlite.org/howtocorrupt.html
 // example VFS: https://www.sqlite.org/src/doc/trunk/src/test_demovfs.c
-pub fn (mut v Sqlite3_vfs) register_as_nondefault() ? {
+pub fn (mut v Sqlite3_vfs) register_as_nondefault() ! {
 	res := C.sqlite3_vfs_register(v, 0)
-
-	if sqlite_ok == res {
-		return
+	if sqlite_ok != res {
+		return error('sqlite3_vfs_register returned ${res}')
 	}
-	error('sqlite3_vfs_register returned ${res}')
 }
 
 // unregister Requests sqlite to stop using VFS as passed in receiver argument
-pub fn (mut v Sqlite3_vfs) unregister() ? {
+pub fn (mut v Sqlite3_vfs) unregister() ! {
 	res := C.sqlite3_vfs_unregister(v)
-
-	if sqlite_ok == res {
-		return
+	if sqlite_ok != res {
+		return error('sqlite3_vfs_unregister returned ${res}')
 	}
-	error('sqlite3_vfs_unregister returned ${res}')
 }
 
 // https://www.sqlite.org/c3ref/open.html

--- a/vlib/db/sqlite/vfs_lowlevel.v
+++ b/vlib/db/sqlite/vfs_lowlevel.v
@@ -7,14 +7,14 @@ type Sig2 = fn (&Sqlite3_file, &int) int // https://github.com/vlang/v/issues/16
 pub type Sqlite3_file = C.sqlite3_file
 
 // https://www.sqlite.org/c3ref/file.html
-struct C.sqlite3_file {
+pub struct C.sqlite3_file {
 pub mut:
 	pMethods &C.sqlite3_io_methods // Methods for an open file
 }
 
 // https://www.sqlite.org/c3ref/io_methods.html
 [heap]
-struct C.sqlite3_io_methods {
+pub struct C.sqlite3_io_methods {
 mut:
 	// version 1 and later fields
 	iVersion int

--- a/vlib/db/sqlite/vfs_lowlevel.v
+++ b/vlib/db/sqlite/vfs_lowlevel.v
@@ -118,14 +118,20 @@ pub fn get_default_vfs() ?&Sqlite3_vfs {
 pub fn (mut v Sqlite3_vfs) register_as_nondefault() ? {
 	res := C.sqlite3_vfs_register(v, 0)
 
-	return if sqlite_ok == res { none } else { error('sqlite3_vfs_register returned ${res}') }
+	if sqlite_ok == res {
+		return
+	}
+	error('sqlite3_vfs_register returned ${res}')
 }
 
 // unregister Requests sqlite to stop using VFS as passed in receiver argument
 pub fn (mut v Sqlite3_vfs) unregister() ? {
 	res := C.sqlite3_vfs_unregister(v)
 
-	return if sqlite_ok == res { none } else { error('sqlite3_vfs_unregister returned ${res}') }
+	if sqlite_ok == res {
+		return
+	}
+	error('sqlite3_vfs_unregister returned ${res}')
 }
 
 // https://www.sqlite.org/c3ref/open.html

--- a/vlib/sqlite/vfs_lowlevel.v
+++ b/vlib/sqlite/vfs_lowlevel.v
@@ -118,14 +118,20 @@ pub fn get_default_vfs() ?&Sqlite3_vfs {
 pub fn (mut v Sqlite3_vfs) register_as_nondefault() ? {
 	res := C.sqlite3_vfs_register(v, 0)
 
-	return if sqlite_ok == res { none } else { error('sqlite3_vfs_register returned ${res}') }
+	if sqlite_ok == res {
+		return
+	}
+	error('sqlite3_vfs_register returned ${res}')
 }
 
 // unregister Requests sqlite to stop using VFS as passed in receiver argument
 pub fn (mut v Sqlite3_vfs) unregister() ? {
 	res := C.sqlite3_vfs_unregister(v)
 
-	return if sqlite_ok == res { none } else { error('sqlite3_vfs_unregister returned ${res}') }
+	return if sqlite_ok == res {
+		return
+	}
+	error('sqlite3_vfs_unregister returned ${res}')
 }
 
 // https://www.sqlite.org/c3ref/open.html

--- a/vlib/sqlite/vfs_lowlevel.v
+++ b/vlib/sqlite/vfs_lowlevel.v
@@ -87,51 +87,40 @@ fn C.sqlite3_vfs_unregister(&C.sqlite3_vfs) int
 
 // get_vfs Requests sqlite to return instance of VFS with given name.
 // when such vfs is not known, `none` is returned
-pub fn get_vfs(name string) ?&Sqlite3_vfs {
+pub fn get_vfs(name string) !&Sqlite3_vfs {
 	res := C.sqlite3_vfs_find(name.str)
-
-	unsafe {
-		if res == nil {
-			return none
-		} else {
-			return res
-		}
+	if res != unsafe { nil } {
+		return res
 	}
+	return error('sqlite3_vfs_find returned 0')
 }
 
 // get_default_vfs Asks sqlite for default VFS instance
-pub fn get_default_vfs() ?&Sqlite3_vfs {
-	unsafe {
-		res := C.sqlite3_vfs_find(nil)
-		if res == nil {
-			return none
-		} else {
-			return res
-		}
+pub fn get_default_vfs() !&Sqlite3_vfs {
+	res := C.sqlite3_vfs_find(unsafe { nil })
+	if res != unsafe { nil } {
+		return res
 	}
+	return error('sqlite3_vfs_find(0) returned 0')
 }
 
 // register_as_nondefault Asks sqlite to register VFS passed in receiver argument as the known VFS.
 // more info about VFS: https://www.sqlite.org/c3ref/vfs.html
 // 'not TODOs' to prevent corruption: https://sqlite.org/howtocorrupt.html
 // example VFS: https://www.sqlite.org/src/doc/trunk/src/test_demovfs.c
-pub fn (mut v Sqlite3_vfs) register_as_nondefault() ? {
+pub fn (mut v Sqlite3_vfs) register_as_nondefault() ! {
 	res := C.sqlite3_vfs_register(v, 0)
-
-	if sqlite_ok == res {
-		return
+	if sqlite_ok != res {
+		return error('sqlite3_vfs_register returned ${res}')
 	}
-	error('sqlite3_vfs_register returned ${res}')
 }
 
 // unregister Requests sqlite to stop using VFS as passed in receiver argument
-pub fn (mut v Sqlite3_vfs) unregister() ? {
+pub fn (mut v Sqlite3_vfs) unregister() ! {
 	res := C.sqlite3_vfs_unregister(v)
-
-	return if sqlite_ok == res {
-		return
+	if sqlite_ok != res {
+		return error('sqlite3_vfs_unregister returned ${res}')
 	}
-	error('sqlite3_vfs_unregister returned ${res}')
 }
 
 // https://www.sqlite.org/c3ref/open.html

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5889,7 +5889,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 	is_none_ok := return_type == ast.ovoid_type
 	g.writeln(';')
 	if is_none_ok {
-		g.writeln('if (${cvar_name}.state != 0 && ${cvar_name}.err._typ != _IError_None___index) {')
+		g.writeln('if (${cvar_name}.state != 0) {')
 	} else {
 		if return_type != 0 && g.table.sym(return_type).kind == .function {
 			mr_styp = 'voidptr'

--- a/vlib/v/slow_tests/inout/option_unwrap_err.out
+++ b/vlib/v/slow_tests/inout/option_unwrap_err.out
@@ -1,0 +1,14 @@
+1234
+1
+ok
+1234
+================ V panic ================
+   module: main
+ function: main()
+  message: 
+     file: vlib/v/slow_tests/inout/option_unwrap_err.vv:12
+   v hash: 814d682
+=========================================
+/tmp/v_1000/option_unwrap_err.14515441765423791889.tmp.c:6768: at panic_debug: Backtrace
+/tmp/v_1000/option_unwrap_err.14515441765423791889.tmp.c:12525: by main__main
+/tmp/v_1000/option_unwrap_err.14515441765423791889.tmp.c:12902: by main

--- a/vlib/v/slow_tests/inout/option_unwrap_err.out
+++ b/vlib/v/slow_tests/inout/option_unwrap_err.out
@@ -2,13 +2,3 @@
 1
 ok
 1234
-================ V panic ================
-   module: main
- function: main()
-  message: 
-     file: vlib/v/slow_tests/inout/option_unwrap_err.vv:12
-   v hash: 814d682
-=========================================
-/tmp/v_1000/option_unwrap_err.14515441765423791889.tmp.c:6768: at panic_debug: Backtrace
-/tmp/v_1000/option_unwrap_err.14515441765423791889.tmp.c:12525: by main__main
-/tmp/v_1000/option_unwrap_err.14515441765423791889.tmp.c:12902: by main

--- a/vlib/v/slow_tests/inout/option_unwrap_err.vv
+++ b/vlib/v/slow_tests/inout/option_unwrap_err.vv
@@ -9,6 +9,6 @@ fn main() {
 	t() or { println(1) }
 	println('ok')
 
-	t()?
+	t() or { return }
 	println('ok')
 }

--- a/vlib/v/slow_tests/inout/option_unwrap_err.vv
+++ b/vlib/v/slow_tests/inout/option_unwrap_err.vv
@@ -1,0 +1,14 @@
+fn t() ? {
+	a := ?int(1234)
+	println(a?)
+	b := ?int(none)
+	println(b?)
+}
+
+fn main() {
+	t() or { println(1) }
+	println('ok')
+
+	t()?
+	println('ok')
+}


### PR DESCRIPTION
Fix #18170

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9de0be3</samp>

Fix a bug in C code generation for option types and add a test case for it. The bug caused incorrect error checking for option values. The test case `option_unwrap_err.vv` shows how to use the option type and the `?` operator in V.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9de0be3</samp>

* Fix bug in C code generation for option types ([link](https://github.com/vlang/v/pull/18173/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL5892-R5892))
* Add new test case for option type and `?` operator ([link](https://github.com/vlang/v/pull/18173/files?diff=unified&w=0#diff-21b2928c9f6a026431f3626f0029d988623a3b98c317433187ba05fddc15933dL1-R13),[link](https://github.com/vlang/v/pull/18173/files?diff=unified&w=0#diff-572ae3eac9ba84b9fe4f58aaa16f19e65a2c4e0019c59605c559d6239064dfb5R1-R14))
