### PR TITLE
net.websocket: fix utils.v to use vlib

### DIFF
--- a/vlib/net/websocket/utils.v
+++ b/vlib/net/websocket/utils.v
@@ -3,27 +3,18 @@ module websocket
 import rand
 import crypto.sha1
 import encoding.base64
+import encoding.binary
 
 // htonl64 converts payload length to header bits
 fn htonl64(payload_len u64) []u8 {
 	mut ret := []u8{len: 8}
-	ret[0] = u8(((payload_len & (u64(0xff) << 56)) >> 56) & 0xff)
-	ret[1] = u8(((payload_len & (u64(0xff) << 48)) >> 48) & 0xff)
-	ret[2] = u8(((payload_len & (u64(0xff) << 40)) >> 40) & 0xff)
-	ret[3] = u8(((payload_len & (u64(0xff) << 32)) >> 32) & 0xff)
-	ret[4] = u8(((payload_len & (u64(0xff) << 24)) >> 24) & 0xff)
-	ret[5] = u8(((payload_len & (u64(0xff) << 16)) >> 16) & 0xff)
-	ret[6] = u8(((payload_len & (u64(0xff) << 8)) >> 8) & 0xff)
-	ret[7] = u8(((payload_len & (u64(0xff) << 0)) >> 0) & 0xff)
+	binary.big_endian_put_u64(mut ret, payload_len)
 	return ret
 }
 
 // create_masking_key returns a new masking key to use when masking websocket messages
 fn create_masking_key() []u8 {
-	mask_bit := rand.u8()
-	buf := []u8{len: 4, init: `0`}
-	unsafe { C.memcpy(buf.data, &mask_bit, 4) }
-	return buf
+	return rand.bytes(4) or {[0,0,0,0]}
 }
 
 // create_key_challenge_response creates a key challenge response from security key
@@ -45,10 +36,5 @@ fn create_key_challenge_response(seckey string) !string {
 
 // get_nonce creates a randomized array used in handshake process
 fn get_nonce(nonce_size int) string {
-	mut nonce := []u8{len: nonce_size, cap: nonce_size}
-	alphanum := '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz'
-	for i in 0 .. nonce_size {
-		nonce[i] = alphanum[rand.intn(alphanum.len) or { 0 }]
-	}
-	return unsafe { tos(nonce.data, nonce.len) }.clone()
+	return rand.string_from_set('0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz',nonce_size)
 }


### PR DESCRIPTION
1. fix `htonl64` to use `encoding.binary.big_endian_put_u64`
2. fix `create_masking_key` use `rand.bytes(4)`. There maybe a bug of origin code, which use `rand.u8` instead of `rand.u32`
3. fix `get_nonce` use `rand.string_from_set`
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

copilot:summary

copilot:walkthrough
