### PR TITLE
net.websocket: Fix ws client/server concurrent

### DIFF
--- a/examples/websocket/client-server/server.v
+++ b/examples/websocket/client-server/server.v
@@ -22,7 +22,9 @@ fn start_server() ! {
 		}
 	}
 	// Make that in execution test time give time to execute at least one time
-	s.ping_interval = 100
+	lock s.server_state {
+		s.server_state.ping_interval = 100
+	}
 	s.on_connect(fn (mut s websocket.ServerClient) !bool {
 		slog('s.on_connect')
 		// Here you can look att the client info and accept or not accept
@@ -37,8 +39,12 @@ fn start_server() ! {
 	s.on_message_ref(fn (mut ws websocket.Client, msg &websocket.Message, mut m websocket.Server) ! {
 		slog('s.on_message_ref')
 		// for _, cli in m.clients {
-		for i, _ in m.clients {
-			mut c := m.clients[i] or { continue }
+		for i, _ in rlock m.server_state {
+			m.server_state.clients
+		} {
+			mut c := rlock m.server_state {
+				m.server_state.clients[i] or { continue }
+			}
 			if c.client.state == .open && c.client.id != ws.id {
 				c.client.write(msg.payload, websocket.OPCode.text_frame) or { panic(err) }
 			}

--- a/examples/websocket/client-server/server.v
+++ b/examples/websocket/client-server/server.v
@@ -22,9 +22,7 @@ fn start_server() ! {
 		}
 	}
 	// Make that in execution test time give time to execute at least one time
-	lock s.server_state {
-		s.server_state.ping_interval = 100
-	}
+	s.set_ping_interval(100)
 	s.on_connect(fn (mut s websocket.ServerClient) !bool {
 		slog('s.on_connect')
 		// Here you can look att the client info and accept or not accept
@@ -45,7 +43,7 @@ fn start_server() ! {
 			mut c := rlock m.server_state {
 				m.server_state.clients[i] or { continue }
 			}
-			if c.client.state == .open && c.client.id != ws.id {
+			if c.client.get_state() == .open && c.client.id != ws.id {
 				c.client.write(msg.payload, websocket.OPCode.text_frame) or { panic(err) }
 			}
 		}

--- a/examples/websocket/ping.v
+++ b/examples/websocket/ping.v
@@ -32,9 +32,7 @@ fn start_server() ! {
 		}
 	}
 	// Make that in execution test time give time to execute at least one time
-	lock s.server_state {
-		s.server_state.ping_interval = 100
-	}
+	s.set_ping_interval(100)
 	s.on_connect(fn (mut s websocket.ServerClient) !bool {
 		slog('ws.on_connect, s.client_key: ${s.client_key}')
 		// Here you can look att the client info and accept or not accept

--- a/examples/websocket/ping.v
+++ b/examples/websocket/ping.v
@@ -32,7 +32,9 @@ fn start_server() ! {
 		}
 	}
 	// Make that in execution test time give time to execute at least one time
-	s.ping_interval = 100
+	lock s.server_state {
+		s.server_state.ping_interval = 100
+	}
 	s.on_connect(fn (mut s websocket.ServerClient) !bool {
 		slog('ws.on_connect, s.client_key: ${s.client_key}')
 		// Here you can look att the client info and accept or not accept

--- a/vlib/net/websocket/io.v
+++ b/vlib/net/websocket/io.v
@@ -5,7 +5,7 @@ import net
 // socket_read reads from socket into the provided buffer
 fn (mut ws Client) socket_read(mut buffer []u8) !int {
 	lock {
-		if ws.state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
+		if ws.get_state() in [.closed, .closing] || ws.conn.sock.handle <= 1 {
 			return error('socket_read: trying to read a closed socket')
 		}
 		if ws.is_ssl {
@@ -22,7 +22,7 @@ fn (mut ws Client) socket_read(mut buffer []u8) !int {
 // socket_read reads from socket into the provided byte pointer and length
 fn (mut ws Client) socket_read_ptr(buf_ptr &u8, len int) !int {
 	lock {
-		if ws.state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
+		if ws.get_state() in [.closed, .closing] || ws.conn.sock.handle <= 1 {
 			return error('socket_read_ptr: trying to read a closed socket')
 		}
 		if ws.is_ssl {
@@ -39,7 +39,7 @@ fn (mut ws Client) socket_read_ptr(buf_ptr &u8, len int) !int {
 // socket_write writes the provided byte array to the socket
 fn (mut ws Client) socket_write(bytes []u8) !int {
 	lock {
-		if ws.state == .closed || ws.conn.sock.handle <= 1 {
+		if ws.get_state() == .closed || ws.conn.sock.handle <= 1 {
 			ws.debug_log('socket_write: Socket already closed')
 			return error('socket_write: trying to write on a closed socket')
 		}

--- a/vlib/net/websocket/message.v
+++ b/vlib/net/websocket/message.v
@@ -214,7 +214,7 @@ pub fn (mut ws Client) parse_frame_header() !Frame {
 	mut frame := Frame{}
 	mut rbuff := [1]u8{}
 	mut mask_end_byte := 0
-	for ws.state == .open {
+	for ws.get_state() == .open {
 		read_bytes := ws.socket_read_ptr(&rbuff[0], 1)!
 		if read_bytes == 0 {
 			// this is probably a timeout or close

--- a/vlib/net/websocket/utils.v
+++ b/vlib/net/websocket/utils.v
@@ -3,27 +3,18 @@ module websocket
 import rand
 import crypto.sha1
 import encoding.base64
+import encoding.binary
 
 // htonl64 converts payload length to header bits
 fn htonl64(payload_len u64) []u8 {
 	mut ret := []u8{len: 8}
-	ret[0] = u8(((payload_len & (u64(0xff) << 56)) >> 56) & 0xff)
-	ret[1] = u8(((payload_len & (u64(0xff) << 48)) >> 48) & 0xff)
-	ret[2] = u8(((payload_len & (u64(0xff) << 40)) >> 40) & 0xff)
-	ret[3] = u8(((payload_len & (u64(0xff) << 32)) >> 32) & 0xff)
-	ret[4] = u8(((payload_len & (u64(0xff) << 24)) >> 24) & 0xff)
-	ret[5] = u8(((payload_len & (u64(0xff) << 16)) >> 16) & 0xff)
-	ret[6] = u8(((payload_len & (u64(0xff) << 8)) >> 8) & 0xff)
-	ret[7] = u8(((payload_len & (u64(0xff) << 0)) >> 0) & 0xff)
+	binary.big_endian_put_u64(mut ret, payload_len)
 	return ret
 }
 
 // create_masking_key returns a new masking key to use when masking websocket messages
 fn create_masking_key() []u8 {
-	mask_bit := rand.u8()
-	buf := []u8{len: 4, init: `0`}
-	unsafe { C.memcpy(buf.data, &mask_bit, 4) }
-	return buf
+	return rand.bytes(4) or {[0,0,0,0]}
 }
 
 // create_key_challenge_response creates a key challenge response from security key
@@ -45,10 +36,5 @@ fn create_key_challenge_response(seckey string) !string {
 
 // get_nonce creates a randomized array used in handshake process
 fn get_nonce(nonce_size int) string {
-	mut nonce := []u8{len: nonce_size, cap: nonce_size}
-	alphanum := '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz'
-	for i in 0 .. nonce_size {
-		nonce[i] = alphanum[rand.intn(alphanum.len) or { 0 }]
-	}
-	return unsafe { tos(nonce.data, nonce.len) }.clone()
+	return rand.string_from_set('0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz',nonce_size)
 }

--- a/vlib/net/websocket/utils.v
+++ b/vlib/net/websocket/utils.v
@@ -14,7 +14,7 @@ fn htonl64(payload_len u64) []u8 {
 
 // create_masking_key returns a new masking key to use when masking websocket messages
 fn create_masking_key() []u8 {
-	return rand.bytes(4) or {[0,0,0,0]}
+	return rand.bytes(4) or { [0, 0, 0, 0] }
 }
 
 // create_key_challenge_response creates a key challenge response from security key
@@ -36,5 +36,6 @@ fn create_key_challenge_response(seckey string) !string {
 
 // get_nonce creates a randomized array used in handshake process
 fn get_nonce(nonce_size int) string {
-	return rand.string_from_set('0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz',nonce_size)
+	return rand.string_from_set('0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz',
+		nonce_size)
 }

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -15,6 +15,11 @@ const (
 	empty_bytearr = []u8{} // used as empty response to avoid allocation
 )
 
+pub struct ClientState {
+mut:
+	state State = .closed // current state of connection
+}
+
 // Client represents websocket client
 pub struct Client {
 	is_server bool
@@ -36,8 +41,8 @@ pub mut:
 	header            http.Header  // headers that will be passed when connecting
 	conn              &net.TcpConn = unsafe { nil } // underlying TCP socket connection
 	nonce_size        int = 16 // size of nounce used for masking
-	panic_on_callback bool  // set to true of callbacks can panic
-	state             State // current state of connection
+	panic_on_callback bool // set to true of callbacks can panic
+	client_state      shared ClientState // current state of connection
 	// logger used to log messages
 	logger &log.Logger = &log.Logger(&log.Log{
 	level: .info
@@ -97,7 +102,9 @@ pub fn new_client(address string, opt ClientOpt) !&Client {
 		is_ssl: address.starts_with('wss')
 		logger: opt.logger
 		uri: uri
-		state: .closed
+		client_state: ClientState{
+			state: .closed
+		}
 		id: rand.uuid_v4()
 		header: http.new_header()
 		read_timeout: opt.read_timeout
@@ -124,20 +131,20 @@ pub fn (mut ws Client) listen() ! {
 	unsafe { log_msg.free() }
 	defer {
 		ws.logger.info('Quit client listener, server(${ws.is_server})...')
-		if ws.state == .open {
+		if ws.get_state() == .open {
 			ws.close(1000, 'closed by client') or {}
 		}
 	}
-	for ws.state == .open {
+	for ws.get_state() == .open {
 		msg := ws.read_next_message() or {
-			if ws.state in [.closed, .closing] {
+			if ws.get_state() in [.closed, .closing] {
 				return
 			}
 			ws.debug_log('failed to read next message: ${err}')
 			ws.send_error_event('failed to read next message: ${err}')
 			return err
 		}
-		if ws.state in [.closed, .closing] {
+		if ws.get_state() in [.closed, .closing] {
 			return
 		}
 		ws.debug_log('got message: ${msg.opcode}')
@@ -197,7 +204,7 @@ pub fn (mut ws Client) listen() ! {
 					if reason.len > 0 {
 						ws.validate_utf_8(.close, reason)!
 					}
-					if ws.state !in [.closing, .closed] {
+					if ws.get_state() !in [.closing, .closed] {
 						// sending close back according to spec
 						ws.debug_log('close with reason, code: ${code}, reason: ${reason}')
 						r := reason.bytestr()
@@ -205,7 +212,7 @@ pub fn (mut ws Client) listen() ! {
 					}
 					unsafe { msg.free() }
 				} else {
-					if ws.state !in [.closing, .closed] {
+					if ws.get_state() !in [.closing, .closed] {
 						ws.debug_log('close with reason, no code')
 						// sending close back according to spec
 						ws.close(1000, 'normal')!
@@ -242,7 +249,7 @@ pub fn (mut ws Client) pong() ! {
 // write_ptr writes len bytes provided a byteptr with a websocket messagetype
 pub fn (mut ws Client) write_ptr(bytes &u8, payload_len int, code OPCode) !int {
 	// ws.debug_log('write_ptr code: $code')
-	if ws.state != .open || ws.conn.sock.handle < 1 {
+	if ws.get_state() != .open || ws.conn.sock.handle < 1 {
 		// todo: send error here later
 		return error('trying to write on a closed socket!')
 	}
@@ -329,8 +336,9 @@ pub fn (mut ws Client) write_string(str string) !int {
 // close closes the websocket connection
 pub fn (mut ws Client) close(code int, message string) ! {
 	ws.debug_log('sending close, ${code}, ${message}')
-	if ws.state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
-		ws.debug_log('close: Websocket already closed (${ws.state}), ${message}, ${code} handle(${ws.conn.sock.handle})')
+	ws_state := ws.get_state()
+	if ws_state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
+		ws.debug_log('close: Websocket already closed (${ws_state}), ${message}, ${code} handle(${ws.conn.sock.handle})')
 		err_msg := 'Socket already closed: ${code}'
 		return error(err_msg)
 	}
@@ -362,7 +370,7 @@ pub fn (mut ws Client) close(code int, message string) ! {
 // send_control_frame sends a control frame to the server
 fn (mut ws Client) send_control_frame(code OPCode, frame_typ string, payload []u8) ! {
 	ws.debug_log('send control frame ${code}, frame_type: ${frame_typ}')
-	if ws.state !in [.open, .closing] && ws.conn.sock.handle > 1 {
+	if ws.get_state() !in [.open, .closing] && ws.conn.sock.handle > 1 {
 		return error('socket is not connected')
 	}
 	header_len := if ws.is_server { 2 } else { 6 }
@@ -446,15 +454,22 @@ fn parse_uri(url string) !&Uri {
 }
 
 // set_state sets current state of the websocket connection
-fn (mut ws Client) set_state(state State) {
-	lock {
-		ws.state = state
+pub fn (mut ws Client) set_state(state State) {
+	lock ws.client_state {
+		ws.client_state.state = state
+	}
+}
+
+// get_state return the current state of the websocket connection
+pub fn (ws Client) get_state() State {
+	return rlock ws.client_state {
+		ws.client_state.state
 	}
 }
 
 // assert_not_connected returns error if the connection is not connected
 fn (ws Client) assert_not_connected() ! {
-	match ws.state {
+	match ws.get_state() {
 		.connecting { return error('connect: websocket is connecting') }
 		.open { return error('connect: websocket already open') }
 		.closing { return error('connect: reconnect on closing websocket not supported, please use new client') }
@@ -463,9 +478,9 @@ fn (ws Client) assert_not_connected() ! {
 }
 
 // reset_state resets the websocket and initialize default settings
-fn (mut ws Client) reset_state() ! {
-	lock {
-		ws.state = .closed
+pub fn (mut ws Client) reset_state() ! {
+	lock ws.client_state {
+		ws.client_state.state = .closed
 		ws.ssl_conn = ssl.new_ssl_conn()!
 		ws.flags = []
 		ws.fragments = []

--- a/vlib/net/websocket/websocket_test.v
+++ b/vlib/net/websocket/websocket_test.v
@@ -50,9 +50,7 @@ fn start_server(family net.AddrFamily, listen_port int) ! {
 	eprintln('> start_server family:${family} | listen_port: ${listen_port}')
 	mut s := websocket.new_server(family, listen_port, '')
 	// make that in execution test time give time to execute at least one time
-	lock s.server_state {
-		s.server_state.ping_interval = 1
-	}
+	s.set_ping_interval(1)
 
 	s.on_connect(fn (mut s websocket.ServerClient) !bool {
 		// here you can look att the client info and accept or not accept
@@ -82,9 +80,7 @@ fn start_server_in_thread_and_wait_till_it_is_ready_to_accept_connections(mut ws
 	spawn fn [mut ws] () {
 		ws.listen() or { panic('websocket server could not listen, err: ${err}') }
 	}()
-	for rlock ws.server_state {
-		ws.server_state.state
-	} != .open {
+	for ws.get_state() != .open {
 		time.sleep(10 * time.millisecond)
 	}
 	eprintln('-----------------------------------------------------------------------------')


### PR DESCRIPTION
Make websocket server thread safe.
Introducing a pub struct `ServerState`, and make it `shared`.
The server spawn some processes, such as `handle_ping` and `serve_client`, and access server state may cause race condition.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27f1f70</samp>

This pull request improves the code quality and concurrency safety of the `net/websocket` module. It simplifies some functions in `utils.v` by using existing V modules, refactors the `Server` struct in `websocket_server.v` to use a shared state struct with locks, and adds locks to the `test_websocket_server` function in `websocket_test.v` to prevent data races.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27f1f70</samp>

*  Introduce a `shared ServerState` struct to store the state of the server and its clients in a thread-safe way ([link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46R9-R15))
*  Replace the fields of the `Server` struct that are part of the `ServerState` struct with a single `server_state` field of type `shared ServerState` ([link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L24-R31), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L53))
*  Use the `lock` and `rlock` keywords to access and modify the fields of the `server_state` field in the methods of the `Server` struct, such as `set_ping_interval`, `handle_ping`, `listen`, `setup_callbacks`, `set_state`, and `free` ([link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L59-R65), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L83-R100), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L96-R112), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L104-R121), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L127-R144), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L162-R177), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L185-R200), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L192-R212))
*  Update the `test_websocket_server` function in the `websocket_test.v` file to use the `lock` and `rlock` keywords to access and modify the fields of the `server_state` field of the `Server` instance ([link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-a85a938295d82aedab694edfeb772e0bb185966f12c05749c614a06a199b4b29L53-R55), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-a85a938295d82aedab694edfeb772e0bb185966f12c05749c614a06a199b4b29L83-R87))
*  Simplify the `htonl64`, `create_masking_key`, and `get_nonce` functions in the `utils.v` file by using the functions from the `encoding.binary` and `rand` modules ([link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-cf71c396bfc7697aa774d593fbaaaa095c79092a3efaa0c516b4bc278946deaeL6-R11), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-cf71c396bfc7697aa774d593fbaaaa095c79092a3efaa0c516b4bc278946deaeL23-R17), [link](https://github.com/vlang/v/pull/18179/files?diff=unified&w=0#diff-cf71c396bfc7697aa774d593fbaaaa095c79092a3efaa0c516b4bc278946deaeL48-R40))
