### PR TITLE
fmt: fix formating of fn decl with end comments (fix #18176)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1001,7 +1001,7 @@ pub fn (mut f Fmt) fn_decl(node ast.FnDecl) {
 	f.attrs(node.attrs)
 	f.write(node.stringify(f.table, f.cur_mod, f.mod2alias)) // `Expr` instead of `ast.Expr` in mod ast
 	// Handle trailing comments after fn header declarations
-	if node.end_comments.len > 0 {
+	if node.no_body && node.end_comments.len > 0 {
 		first_comment := node.end_comments[0]
 		if first_comment.text.contains('\n') {
 			f.writeln('\n')
@@ -1045,6 +1045,25 @@ fn (mut f Fmt) fn_body(node ast.FnDecl) {
 				f.stmts(node.stmts)
 			}
 			f.write('}')
+			if node.end_comments.len > 0 {
+				first_comment := node.end_comments[0]
+				if first_comment.text.contains('\n') {
+					f.writeln('\n')
+				} else {
+					f.write(' ')
+				}
+				f.comment(first_comment)
+				if node.end_comments.len > 1 {
+					f.writeln('\n')
+					comments := node.end_comments[1..]
+					for i, comment in comments {
+						f.comment(comment)
+						if i != comments.len - 1 {
+							f.writeln('\n')
+						}
+					}
+				}
+			}
 		}
 		if !node.is_anon {
 			f.writeln('')

--- a/vlib/v/fmt/tests/fn_with_end_comments_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_end_comments_keep.vv
@@ -1,0 +1,9 @@
+fn (c Color) is_blue() bool {
+	return c == .blue
+} // method of enum
+
+fn (c Color) show_int() int {
+	return int(c)
+} // method of enum
+
+fn main() {}


### PR DESCRIPTION
This PR fix formating of fn decl with end comments (fix #18176).

- Fix formating of fn decl with end comments.
- Add test.

`fn_with_end_comments_keep.vv`
```v
fn (c Color) is_blue() bool {
	return c == .blue
} // method of enum

fn (c Color) show_int() int {
	return int(c)
} // method of enum

fn main() {}
```