### PR TITLE
checker: fix generic argument resolution when mixed order on next call

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -848,6 +848,7 @@ fn (g Checker) get_generic_array_fixed_element_type(array ast.ArrayFixed) ast.Ty
 
 fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 	mut inferred_types := []ast.Type{}
+	mut arg_inferred := []int{}
 	for gi, gt_name in func.generic_names {
 		// skip known types
 		if gi < node.concrete_types.len {
@@ -1027,7 +1028,7 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					}
 				} else if arg_sym.kind == .any && c.table.cur_fn.generic_names.len > 0
 					&& c.table.cur_fn.params.len > 0 && func.generic_names.len > 0
-					&& arg.expr is ast.Ident {
+					&& arg.expr is ast.Ident && arg_i !in arg_inferred {
 					var_name := (arg.expr as ast.Ident).name
 					for k, cur_param in c.table.cur_fn.params {
 						if !cur_param.typ.has_flag(.generic) || k < gi || cur_param.name != var_name {
@@ -1044,6 +1045,9 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 						break
 					}
 				}
+			}
+			if typ != ast.void_type {
+				arg_inferred << arg_i
 			}
 		}
 		if typ == ast.void_type {

--- a/vlib/v/tests/generic_call_mixing_args_test.v
+++ b/vlib/v/tests/generic_call_mixing_args_test.v
@@ -1,0 +1,21 @@
+struct MyStruct {
+	text string
+}
+
+struct App {}
+
+fn pre_send[T, N](app T, params N) {
+	send(params, app)
+}
+
+fn send[T, N](params T, app N) { // app now is second argument
+	println(params)
+}
+
+fn test_main() {
+	params := MyStruct{'hello'}
+	app := App{}
+
+	pre_send(app, params)
+	assert true
+}


### PR DESCRIPTION
Fix #18190

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e81d37</samp>

This pull request fixes a type inference bug in generic function arguments and adds a new test case to demonstrate the fix. The changes affect the file `vlib/v/checker/check_types.v` and the new file `vlib/v/tests/generic_call_mixing_args_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e81d37</samp>

*  Fix type inference bug for generic function arguments ([link](https://github.com/vlang/v/pull/18192/files?diff=unified&w=0#diff-b3f19dfb0ba250009a75b2ee6915a97dab4450f6e7c32f37c01edc69491875c2R851), [link](https://github.com/vlang/v/pull/18192/files?diff=unified&w=0#diff-b3f19dfb0ba250009a75b2ee6915a97dab4450f6e7c32f37c01edc69491875c2L1030-R1031), [link](https://github.com/vlang/v/pull/18192/files?diff=unified&w=0#diff-b3f19dfb0ba250009a75b2ee6915a97dab4450f6e7c32f37c01edc69491875c2R1049-R1051))
* Add a test case to verify the fix and prevent regressions ([link](https://github.com/vlang/v/pull/18192/files?diff=unified&w=0#diff-b13684d297d3294118175e7f7a461384dfd7e77588cbbd34bfe6aeb3d3451332R1-R21))
