### PR TITLE
vet: allow vetting files with global variables

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3788,8 +3788,9 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 		}
 	}
 
-	if !p.has_globals && !p.pref.enable_globals && !p.pref.is_fmt && !p.pref.translated
-		&& !p.is_translated && !p.pref.is_livemain && !p.pref.building_v && !p.builtin_mod {
+	if !p.has_globals && !p.pref.enable_globals && !p.pref.is_fmt && !p.pref.is_vet
+		&& !p.pref.translated && !p.is_translated && !p.pref.is_livemain && !p.pref.building_v
+		&& !p.builtin_mod {
 		p.error('use `v -enable-globals ...` to enable globals')
 		return ast.GlobalDecl{}
 	}


### PR DESCRIPTION
Closes #18187 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd993b9</samp>

Allow globals in vet mode by changing the error condition in `vlib/v/parser/parser.v`. This is part of a pull request that adds the vet tool as a subcommand of the V compiler.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd993b9</samp>

* Allow globals in vet mode by checking `is_vet` flag in parser ([link](https://github.com/vlang/v/pull/18195/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L3792-R3793))
