### PR TITLE
checker: fix array of sumtype appending array of sumtype (fix #18197)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -190,7 +190,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				continue
 			} else if expecting_sumtype_array {
 				if i == 0 {
-					if c.table.is_sumtype_or_in_variant(expected_value_type, typ) {
+					if c.table.is_sumtype_or_in_variant(expected_value_type, ast.mktyp(typ)) {
 						elem_type = expected_value_type
 					} else {
 						if expr.is_auto_deref_var() {

--- a/vlib/v/tests/array_of_sumtype_append_array_of_sumtype_test.v
+++ b/vlib/v/tests/array_of_sumtype_append_array_of_sumtype_test.v
@@ -1,0 +1,8 @@
+type IntStr = int | string
+
+fn test_array_of_sumtype_append_array_of_sumtype() {
+	mut a := [IntStr(1), 2, 'a']
+	a << [3, 4, 'dsafa']
+	println(a)
+	assert '${a}' == "[IntStr(1), IntStr(2), IntStr('a'), IntStr(3), IntStr(4), IntStr('dsafa')]"
+}


### PR DESCRIPTION
This PR fix array of sumtype appending array of sumtype (fix #18197).

- Fix array of sumtype appending array of sumtype.
- Add test.

```v
type IntStr = int | string

fn main() {
	mut a := [IntStr(1), 2, 'a']
	a << [3, 4, 'dsafa']
	println(a)
	assert '${a}' == "[IntStr(1), IntStr(2), IntStr('a'), IntStr(3), IntStr(4), IntStr('dsafa')]"
}

PS D:\Test\v\tt1> v run .
[IntStr(1), IntStr(2), IntStr('a'), IntStr(3), IntStr(4), IntStr('dsafa')]
```