### PR TITLE
vpm: increment vpm downloads, use new endpoints

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -222,7 +222,7 @@ fn vpm_install_from_vpm(module_names []string) {
 		println('Installing module "${name}" from "${mod.url}" to "${minfo.final_module_path}" ...')
 		increment_module_download_count(name) or {
 			errors++
-			eprintln('Errors while retrieving meta data for module ${name}:')
+			eprintln('Errors while incrementing the download count for ${name}:')
 		}
 		vcs_install_cmd := supported_vcs_install_cmds[vcs]
 		cmd := '${vcs_install_cmd} "${mod.url}" "${minfo.final_module_path}"'
@@ -410,6 +410,10 @@ fn vpm_update(m []string) {
 			continue
 		} else {
 			verbose_println('    ${vcs_res.output.trim_space()}')
+			increment_module_download_count(name) or {
+				errors++
+				eprintln('Errors while incrementing the download count for ${name}:')
+			}
 		}
 		resolve_dependencies(modulename, final_module_path, module_names)
 	}

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -223,7 +223,6 @@ fn vpm_install_from_vpm(module_names []string) {
 		increment_module_download_count(name) or {
 			errors++
 			eprintln('Errors while retrieving meta data for module ${name}:')
-			continue
 		}
 		vcs_install_cmd := supported_vcs_install_cmds[vcs]
 		cmd := '${vcs_install_cmd} "${mod.url}" "${minfo.final_module_path}"'

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -410,9 +410,9 @@ fn vpm_update(m []string) {
 			continue
 		} else {
 			verbose_println('    ${vcs_res.output.trim_space()}')
-			increment_module_download_count(name) or {
+			increment_module_download_count(zname) or {
 				errors++
-				eprintln('Errors while incrementing the download count for ${name}:')
+				eprintln('Errors while incrementing the download count for ${zname}:')
 			}
 		}
 		resolve_dependencies(modulename, final_module_path, module_names)

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -220,10 +220,9 @@ fn vpm_install_from_vpm(module_names []string) {
 			continue
 		}
 		println('Installing module "${name}" from "${mod.url}" to "${minfo.final_module_path}" ...')
-				increment_module_download_count(name) or {
+		increment_module_download_count(name) or {
 			errors++
 			eprintln('Errors while retrieving meta data for module ${name}:')
-			eprintln(err)
 			continue
 		}
 		vcs_install_cmd := supported_vcs_install_cmds[vcs]
@@ -780,12 +779,12 @@ fn get_module_meta_info(name string) !Mod {
 	return error(errors.join_lines())
 }
 
-fn increment_module_download_count(name string)! {
+fn increment_module_download_count(name string) ! {
 	mut errors := []string{}
 
 	for server_url in vpm_server_urls {
 		modurl := server_url + '/api/packages/${name}/incr_downloads'
-		r := http.post(modurl, "") or {
+		r := http.post(modurl, '') or {
 			errors << 'Http server did not respond to our request for "${modurl}" .'
 			errors << 'Error details: ${err}'
 			continue

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -220,6 +220,12 @@ fn vpm_install_from_vpm(module_names []string) {
 			continue
 		}
 		println('Installing module "${name}" from "${mod.url}" to "${minfo.final_module_path}" ...')
+				increment_module_download_count(name) or {
+			errors++
+			eprintln('Errors while retrieving meta data for module ${name}:')
+			eprintln(err)
+			continue
+		}
 		vcs_install_cmd := supported_vcs_install_cmds[vcs]
 		cmd := '${vcs_install_cmd} "${mod.url}" "${minfo.final_module_path}"'
 		verbose_println('      command: ${cmd}')
@@ -740,7 +746,7 @@ fn get_module_meta_info(name string) !Mod {
 	mut errors := []string{}
 
 	for server_url in vpm_server_urls {
-		modurl := server_url + '/jsmod/${name}'
+		modurl := server_url + '/api/packages/${name}'
 		verbose_println('Retrieving module metadata from: "${modurl}" ...')
 		r := http.get(modurl) or {
 			errors << 'Http server did not respond to our request for "${modurl}" .'
@@ -770,6 +776,25 @@ fn get_module_meta_info(name string) !Mod {
 			continue
 		}
 		return mod
+	}
+	return error(errors.join_lines())
+}
+
+fn increment_module_download_count(name string)! {
+	mut errors := []string{}
+
+	for server_url in vpm_server_urls {
+		modurl := server_url + '/api/packages/${name}/incr_downloads'
+		r := http.post(modurl, "") or {
+			errors << 'Http server did not respond to our request for "${modurl}" .'
+			errors << 'Error details: ${err}'
+			continue
+		}
+		if r.status_code != 200 {
+			errors << 'Failed to increment the download count for module "${name}", since "${server_url}" responded with ${r.status_code} http status code. Please try again later.'
+			continue
+		}
+		return
 	}
 	return error(errors.join_lines())
 }


### PR DESCRIPTION
## vpm: use new endpoints from https://github.com/vlang/vpm/pull/104

### What:
- Use new `/packages/:name` instead of `/jsmod/:name`
- Use `/packages/:name/incr_downloads` to increment the downloads on vpm when a package is installed with `v install`
- It increments the downloads if the package already exists or is being updated


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66f403b</samp>

This pull request enhances the `vpm` tool by tracking module downloads and using a better API endpoint. It modifies `cmd/tools/vpm.v` to implement these features.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66f403b</samp>

*  Add functionality to track and update the download count of modules on the vpm servers ([link](https://github.com/vlang/v/pull/18202/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R223-R227), [link](https://github.com/vlang/v/pull/18202/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R782-R800))
  - Call `increment_module_download_count` in `vpm_get_module_meta` to increment the count when a module is fetched ([link](https://github.com/vlang/v/pull/18202/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R223-R227))
  - Define `increment_module_download_count` in `vpm.v` to loop over the server URLs and send POST requests to the `/api/packages/${name}/incr_downloads` endpoint ([link](https://github.com/vlang/v/pull/18202/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R782-R800))
* Change the URL of the module metadata request to use the `/api/packages` endpoint instead of the `/jsmod` endpoint ([link](https://github.com/vlang/v/pull/18202/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L743-R748))
