### PR TITLE
orm, checker: refactor, comments, simplify.

### DIFF
--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -7,8 +7,8 @@ import v.token
 import v.util
 
 const (
-	fkey_attr_name            = 'fkey'
 	v_orm_prefix              = 'V ORM'
+	fkey_attr_name            = 'fkey'
 	connection_interface_name = 'orm.Connection'
 )
 
@@ -23,35 +23,31 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 	if !c.check_db_expr(node.db_expr) {
 		return ast.void_type
 	}
+
+	// To avoid panics while working with `table_expr`,
+	// it is necessary to check if its type exists.
 	c.ensure_type_exists(node.table_expr.typ, node.pos) or { return ast.void_type }
-	sym := c.table.sym(node.table_expr.typ)
+	table_sym := c.table.sym(node.table_expr.typ)
+
+	if !c.check_orm_table_expr_type(node.table_expr) {
+		return ast.void_type
+	}
 
 	old_ts := c.cur_orm_ts
-	c.cur_orm_ts = *sym
+	c.cur_orm_ts = *table_sym
 	defer {
 		c.cur_orm_ts = old_ts
 	}
-	if sym.info !is ast.Struct {
-		c.orm_error('the table symbol `${sym.name}` has to be a struct', node.table_expr.pos)
-		return ast.void_type
-	}
-	info := sym.info as ast.Struct
-	mut fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, sym.name)
+
+	info := table_sym.info as ast.Struct
+	mut fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, table_sym.name)
+	non_primitive_fields := c.get_orm_non_primitive_fields(fields)
 	mut sub_structs := map[int]ast.SqlExpr{}
 
-	for f in fields.filter((c.table.type_symbols[int(it.typ)].kind == .struct_
-		|| (c.table.sym(it.typ).kind == .array
-		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
-		&& c.table.get_type_name(it.typ) != 'time.Time') {
-		typ := if c.table.sym(f.typ).kind == .struct_ {
-			f.typ
-		} else if c.table.sym(f.typ).kind == .array {
-			c.table.sym(f.typ).array_info().elem_type
-		} else {
-			ast.Type(0)
-		}
+	for field in non_primitive_fields {
+		typ := c.get_type_of_field_with_related_table(field)
 
-		mut n := ast.SqlExpr{
+		mut subquery_expr := ast.SqlExpr{
 			pos: node.pos
 			has_where: true
 			where_expr: ast.None{}
@@ -65,12 +61,12 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 		}
 
 		tmp_inside_sql := c.inside_sql
-		c.sql_expr(mut n)
+		c.sql_expr(mut subquery_expr)
 		c.inside_sql = tmp_inside_sql
 
-		n.where_expr = ast.InfixExpr{
+		subquery_expr.where_expr = ast.InfixExpr{
 			op: .eq
-			pos: n.pos
+			pos: subquery_expr.pos
 			left: ast.Ident{
 				language: .v
 				tok_kind: .eq
@@ -99,7 +95,7 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 			or_block: ast.OrExpr{}
 		}
 
-		sub_structs[int(typ)] = n
+		sub_structs[int(typ)] = subquery_expr
 	}
 
 	if node.is_count {
@@ -117,20 +113,20 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 	if node.has_where {
 		c.expr(node.where_expr)
 		c.check_expr_has_no_fn_calls_with_non_orm_return_type(&node.where_expr)
-		c.check_where_expr_has_no_pointless_exprs(sym, field_names, &node.where_expr)
+		c.check_where_expr_has_no_pointless_exprs(table_sym, field_names, &node.where_expr)
 	}
 
 	if node.has_order {
 		if mut node.order_expr is ast.Ident {
 			order_ident_name := node.order_expr.name
 
-			if !sym.has_field(order_ident_name) {
-				c.orm_error(util.new_suggestion(order_ident_name, field_names).say('`${sym.name}` structure has no field with name `${order_ident_name}`'),
+			if !table_sym.has_field(order_ident_name) {
+				c.orm_error(util.new_suggestion(order_ident_name, field_names).say('`${table_sym.name}` structure has no field with name `${order_ident_name}`'),
 					node.order_expr.pos)
 				return ast.void_type
 			}
 		} else {
-			c.orm_error("expected `${sym.name}` structure's field", node.order_expr.pos())
+			c.orm_error("expected `${table_sym.name}` structure's field", node.order_expr.pos())
 			return ast.void_type
 		}
 
@@ -175,13 +171,22 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 	defer {
 		c.inside_sql = false
 	}
+
+	// To avoid panics while working with `table_expr`,
+	// it is necessary to check if its type exists.
 	c.ensure_type_exists(node.table_expr.typ, node.pos) or { return ast.void_type }
 	table_sym := c.table.sym(node.table_expr.typ)
+
+	if !c.check_orm_table_expr_type(node.table_expr) {
+		return ast.void_type
+	}
+
 	old_ts := c.cur_orm_ts
 	c.cur_orm_ts = *table_sym
 	defer {
 		c.cur_orm_ts = old_ts
 	}
+
 	inserting_object_name := node.object_var_name
 
 	if node.kind == .insert && !node.is_generated {
@@ -212,33 +217,26 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 	info := table_sym.info as ast.Struct
 	mut fields := c.fetch_and_verify_orm_fields(info, node.table_expr.pos, table_sym.name)
 	mut sub_structs := map[int]ast.SqlStmtLine{}
+	non_primitive_fields := c.get_orm_non_primitive_fields(fields)
 
-	for f in fields.filter((c.table.type_symbols[int(it.typ)].kind == .struct_
-		|| (c.table.sym(it.typ).kind == .array
-		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
-		&& c.table.get_type_name(it.typ) != 'time.Time') {
+	for field in non_primitive_fields {
 		// Delete an uninitialized struct from fields and skip adding the current field
 		// to sub structs to skip inserting an empty struct in the related table.
-		if c.check_field_of_inserting_struct_is_uninitialized(node, f.name) {
-			fields.delete(fields.index(f))
+		if c.check_field_of_inserting_struct_is_uninitialized(node, field.name) {
+			fields.delete(fields.index(field))
 			continue
 		}
 
-		c.check_orm_struct_field_attributes(f)
+		c.check_orm_struct_field_attributes(field)
 
-		typ := if c.table.sym(f.typ).kind == .struct_ {
-			f.typ
-		} else if c.table.sym(f.typ).kind == .array {
-			c.table.sym(f.typ).array_info().elem_type
-		} else {
-			ast.Type(0)
-		}
+		typ := c.get_type_of_field_with_related_table(field)
 
-		mut object_var_name := '${node.object_var_name}.${f.name}'
-		if typ != f.typ {
+		mut object_var_name := '${node.object_var_name}.${field.name}'
+		if typ != field.typ {
 			object_var_name = node.object_var_name
 		}
-		mut n := ast.SqlStmtLine{
+
+		mut subquery_expr := ast.SqlStmtLine{
 			pos: node.pos
 			kind: node.kind
 			table_expr: ast.TypeNode{
@@ -248,27 +246,34 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 			object_var_name: object_var_name
 			is_generated: true
 		}
+
 		tmp_inside_sql := c.inside_sql
-		c.sql_stmt_line(mut n)
+		c.sql_stmt_line(mut subquery_expr)
 		c.inside_sql = tmp_inside_sql
-		sub_structs[typ] = n
+		sub_structs[typ] = subquery_expr
 	}
+
 	node.fields = fields
 	node.sub_structs = sub_structs.move()
+
 	for i, column in node.updated_columns {
-		x := node.fields.filter(it.name == column)
-		if x.len == 0 {
+		updated_fields := node.fields.filter(it.name == column)
+
+		if updated_fields.len == 0 {
 			c.orm_error('type `${table_sym.name}` has no field named `${column}`', node.pos)
 			continue
 		}
-		field := x[0]
+
+		field := updated_fields.first()
 		node.updated_columns[i] = c.fetch_field_name(field)
 	}
+
 	if node.kind == .update {
 		for expr in node.update_exprs {
 			c.expr(expr)
 		}
 	}
+
 	if node.where_expr !is ast.EmptyExpr {
 		c.expr(node.where_expr)
 	}
@@ -323,12 +328,17 @@ fn (mut c Checker) check_orm_struct_field_attributes(field ast.StructField) {
 }
 
 fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, table_name string) []ast.StructField {
-	fields := info.fields.filter(
-		(it.typ in [ast.string_type, ast.bool_type] || int(it.typ) in ast.number_type_idxs
-		|| c.table.type_symbols[int(it.typ)].kind == .struct_
-		|| (c.table.sym(it.typ).kind == .array
-		&& c.table.sym(c.table.sym(it.typ).array_info().elem_type).kind == .struct_))
-		&& !it.attrs.contains('skip'))
+	fields := info.fields.filter(fn [mut c] (field ast.StructField) bool {
+		is_primitive := field.typ.is_string() || field.typ.is_bool() || field.typ.is_number()
+		is_struct := c.table.type_symbols[int(field.typ)].kind == .struct_
+		is_array := c.table.sym(field.typ).kind == .array
+		is_array_with_struct_elements := is_array
+			&& c.table.sym(c.table.sym(field.typ).array_info().elem_type).kind == .struct_
+		has_no_skip_attr := !field.attrs.contains('skip')
+
+		return (is_primitive || is_struct || is_array_with_struct_elements) && has_no_skip_attr
+	})
+
 	if fields.len == 0 {
 		c.orm_error('select: empty fields in `${table_name}`', pos)
 		return []ast.StructField{}
@@ -512,6 +522,7 @@ fn (mut c Checker) check_orm_or_expr(expr ORMExpr) {
 	}
 }
 
+// check_db_expr checks the `db_expr` implements `orm.Connection` and has no `option` flag.
 fn (mut c Checker) check_db_expr(db_expr &ast.Expr) bool {
 	connection_type_index := c.table.find_type_idx(checker.connection_interface_name)
 	connection_typ := ast.Type(connection_type_index)
@@ -534,6 +545,46 @@ fn (mut c Checker) check_db_expr(db_expr &ast.Expr) bool {
 	}
 
 	return true
+}
+
+fn (mut c Checker) check_orm_table_expr_type(type_node &ast.TypeNode) bool {
+	table_sym := c.table.sym(type_node.typ)
+
+	if table_sym.info !is ast.Struct {
+		c.orm_error('the table symbol `${table_sym.name}` has to be a struct', type_node.pos)
+
+		return false
+	}
+
+	return true
+}
+
+// get_type_of_field_with_related_table gets the type of table in which
+// the primary key is used as the foreign key in the current table.
+// For example, if you are using `[]Child`, the related table type would be `Child`.
+fn (c &Checker) get_type_of_field_with_related_table(table_field &ast.StructField) ast.Type {
+	if c.table.sym(table_field.typ).kind == .struct_ {
+		return table_field.typ
+	} else if c.table.sym(table_field.typ).kind == .array {
+		return c.table.sym(table_field.typ).array_info().elem_type
+	} else {
+		return ast.Type(0)
+	}
+}
+
+// get_orm_non_primitive_fields filters the table fields by selecting only
+// non-primitive fields such as arrays and structs.
+fn (c &Checker) get_orm_non_primitive_fields(fields []ast.StructField) []ast.StructField {
+	return fields.filter(fn [c] (field ast.StructField) bool {
+		type_with_no_option_flag := field.typ.clear_flag(.option)
+		is_struct := c.table.type_symbols[int(type_with_no_option_flag)].kind == .struct_
+		is_array := c.table.sym(type_with_no_option_flag).kind == .array
+		is_array_with_struct_elements := is_array
+			&& c.table.sym(c.table.sym(type_with_no_option_flag).array_info().elem_type).kind == .struct_
+		is_time := c.table.get_type_name(type_with_no_option_flag) == 'time.Time'
+
+		return (is_struct || is_array_with_struct_elements) && !is_time
+	})
 }
 
 // walkingdevel: Now I don't think it's a good solution


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db2b266</samp>

Refactored the ORM checker module `vlib/v/checker/orm.v` to make the code more clear and consistent.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db2b266</samp>

*  Refactor variable names and extract methods to improve clarity and maintainability of the ORM checker code ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L26-R50), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L68-R69), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L102-R98), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L120-R116), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L127-R129), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L215-R239), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L251-R270), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R550-R589))
*  Introduce `check_orm_table_expr_type` method to check if the `table_expr` is a struct type and call `ensure_type_exists` before accessing the `table_expr` field in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L178-R183), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R550-R589))
*  Introduce `get_type_of_field_with_related_table` method to get the type of table in which the primary key is used as the foreign key in the current table in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L215-R239), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R550-R589))
*  Introduce `get_orm_non_primitive_fields` method to filter the table fields by selecting only non-primitive fields such as arrays and structs in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L215-R239), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R550-R589))
*  Extract the logic of filtering the table fields by selecting only primitive or struct or array with struct elements fields and without the `skip` attribute into a separate function that takes a closure as an argument in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L326-R341))
*  Add comments to explain the purpose of the `check_db_expr` method and why the `ensure_type_exists` method is called before accessing the `table_expr` field in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L178-R183), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R525))
*  Add blank lines to separate the logic of checking the `table_expr` type from the logic of setting the `cur_orm_ts` field and the logic of setting the `sub_structs` field from the logic of checking the `update_exprs` field in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R189), [link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R276))
*  Reorder the constants to match the alphabetical order of their names in `vlib/v/checker/orm.v` ([link](https://github.com/vlang/v/pull/18203/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L10-R11))
