### PR TITLE
builtin: string performance improvements with `vmemcpy` instead of `for` loop, part 2

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1057,12 +1057,8 @@ pub fn (s string) substr(start int, end int) string {
 		str: unsafe { malloc_noscan(len + 1) }
 		len: len
 	}
-	for i in 0 .. len {
-		unsafe {
-			res.str[i] = s.str[start + i]
-		}
-	}
 	unsafe {
+		vmemcpy(res.str, s.str + start, len)
 		res.str[len] = 0
 	}
 	return res
@@ -1083,12 +1079,8 @@ pub fn (s string) substr_with_check(start int, end int) !string {
 		str: unsafe { malloc_noscan(len + 1) }
 		len: len
 	}
-	for i in 0 .. len {
-		unsafe {
-			res.str[i] = s.str[start + i]
-		}
-	}
 	unsafe {
+		vmemcpy(res.str, s.str + start, len)
 		res.str[len] = 0
 	}
 	return res
@@ -1120,14 +1112,7 @@ pub fn (s string) substr_ni(_start int, _end int) string {
 	}
 
 	if start > s.len || end < start {
-		mut res := string{
-			str: unsafe { malloc_noscan(1) }
-			len: 0
-		}
-		unsafe {
-			res.str[0] = 0
-		}
-		return res
+		return ''
 	}
 
 	len := end - start
@@ -1137,12 +1122,8 @@ pub fn (s string) substr_ni(_start int, _end int) string {
 		str: unsafe { malloc_noscan(len + 1) }
 		len: len
 	}
-	for i in 0 .. len {
-		unsafe {
-			res.str[i] = s.str[start + i]
-		}
-	}
 	unsafe {
+		vmemcpy(res.str, s.str + start, len)
 		res.str[len] = 0
 	}
 	return res


### PR DESCRIPTION
Second part of string optimization.
First one: https://github.com/vlang/v/pull/18206

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22985ad</samp>

Optimize `substr` functions in `string.v` by using `vmemcpy` and literals. Improve performance and readability of string slicing operations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22985ad</samp>

* Improve performance of `substr`, `substr2`, and `substr3` functions by using `vmemcpy` instead of for loops ([link](https://github.com/vlang/v/pull/18211/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1060-R1061), [link](https://github.com/vlang/v/pull/18211/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1086-R1083), [link](https://github.com/vlang/v/pull/18211/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1140-R1126)) in `vlib/builtin/string.v`
