### PR TITLE
builtin: fix typo in string.js.v

### DIFF
--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -595,7 +595,7 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 		}
 		else {
 			mut start := 0
-			// Take the left part for each delimiter occurence
+			// Take the left part for each delimiter occurrence
 			for i <= s.len {
 				is_delim := i + delim.len <= s.len && s[i..i + delim.len] == delim
 				if is_delim {
@@ -625,7 +625,7 @@ struct RepIndex {
 	val_idx int
 }
 
-// replace_each replaces all occurences of the string pairs given in `vals`.
+// replace_each replaces all occurrences of the string pairs given in `vals`.
 // Example: assert 'ABCD'.replace_each(['B','C/','C','D','D','C']) == 'AC/DC'
 [direct_array_access]
 pub fn (s string) replace_each(vals []string) string {
@@ -722,7 +722,7 @@ pub fn (s string) replace_each(vals []string) string {
 	return b
 }
 
-// last_index returns the position of the last occurence of the input string.
+// last_index returns the position of the last occurrence of the input string.
 fn (s string) last_index_(p string) int {
 	if p.len > s.len || p.len == 0 {
 		return -1
@@ -741,7 +741,7 @@ fn (s string) last_index_(p string) int {
 	return -1
 }
 
-// last_index returns the position of the last occurence of the input string.
+// last_index returns the position of the last occurrence of the input string.
 pub fn (s string) last_index(p string) ?int {
 	idx := s.last_index_(p)
 	if idx == -1 {
@@ -800,7 +800,7 @@ pub fn (s string) split_into_lines() []string {
 	return res
 }
 
-// replace_once replaces the first occurence of `rep` with the string passed in `with`.
+// replace_once replaces the first occurrence of `rep` with the string passed in `with`.
 pub fn (s string) replace_once(rep string, with_ string) string {
 	s2 := ''
 	#s2.val = s.str.replace(rep.str,with_.str)


### PR DESCRIPTION
occurence -> occurrence



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22ae548</samp>

Fix spelling errors in comments of `vlib/builtin/js/string.js.v`. Improve readability and consistency of the code documentation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22ae548</samp>

* Fix typos in comments of `vlib/builtin/js/string.js.v` ([link](https://github.com/vlang/v/pull/18213/files?diff=unified&w=0#diff-20e0115676d4adf0c8e085d4e04c7ac22ae2cae25351f67c1eec08dc339a588eL598-R598), [link](https://github.com/vlang/v/pull/18213/files?diff=unified&w=0#diff-20e0115676d4adf0c8e085d4e04c7ac22ae2cae25351f67c1eec08dc339a588eL628-R628), [link](https://github.com/vlang/v/pull/18213/files?diff=unified&w=0#diff-20e0115676d4adf0c8e085d4e04c7ac22ae2cae25351f67c1eec08dc339a588eL725-R725), [link](https://github.com/vlang/v/pull/18213/files?diff=unified&w=0#diff-20e0115676d4adf0c8e085d4e04c7ac22ae2cae25351f67c1eec08dc339a588eL744-R744), [link](https://github.com/vlang/v/pull/18213/files?diff=unified&w=0#diff-20e0115676d4adf0c8e085d4e04c7ac22ae2cae25351f67c1eec08dc339a588eL803-R803))
