### PR TITLE
mysql: allocate memory for each string and blob dynamically depending on its value length.

### DIFF
--- a/vlib/db/mysql/orm.v
+++ b/vlib/db/mysql/orm.v
@@ -47,10 +47,9 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 			.type_time, .type_date, .type_datetime, .type_time2, .type_datetime2 {
 				dataptr << unsafe { malloc(sizeof(C.MYSQL_TIME)) }
 			}
-			.type_string, .type_blob {
-				dataptr << unsafe { malloc(field.length) }
-			}
-			.type_var_string {
+			.type_string, .type_blob, .type_var_string {
+				// walkingdevel: maybe this solution will change while I'm working on this library,
+				// but the current solution addresses the issues reported.
 				dataptr << unsafe { malloc(field.length) }
 			}
 			else {

--- a/vlib/db/mysql/orm.v
+++ b/vlib/db/mysql/orm.v
@@ -103,19 +103,17 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 
 	for {
 		status = stmt.fetch_stmt()!
-		// Clone the `lengths` for the current iteration so that the nested loop
-		// with the `fetch_column` method call does not override the values we need.
-		cloned_lengths := lengths.clone()
 
 		if status == 1 || status == 100 {
 			break
 		}
 
 		for index, mut bind in string_binds_map {
-			string_length := cloned_lengths[index] + 1
+			string_length := lengths[index] + 1
 			dataptr[index] = unsafe { malloc(string_length) }
 			bind.buffer = dataptr[index]
 			bind.buffer_length = string_length
+			bind.length = unsafe { nil }
 
 			stmt.fetch_column(bind, index)!
 		}

--- a/vlib/db/mysql/orm.v
+++ b/vlib/db/mysql/orm.v
@@ -3,10 +3,6 @@ module mysql
 import orm
 import time
 
-type Prims = f32 | f64 | i16 | i64 | i8 | int | string | u16 | u32 | u64 | u8
-
-// sql expr
-
 // @select is used internally by V's ORM for processing `SELECT ` queries
 pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, where orm.QueryData) ![][]orm.Primitive {
 	query := orm.orm_select_gen(config, '`', false, '?', 0, where)
@@ -28,8 +24,8 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 	mut dataptr := []&u8{}
 
 	for i in 0 .. num_fields {
-		f := unsafe { fields[i] }
-		match unsafe { FieldType(f.@type) } {
+		field := unsafe { fields[i] }
+		match unsafe { FieldType(field.@type) } {
 			.type_tiny {
 				dataptr << unsafe { malloc(1) }
 			}
@@ -52,13 +48,13 @@ pub fn (db Connection) @select(config orm.SelectConfig, data orm.QueryData, wher
 				dataptr << unsafe { malloc(sizeof(C.MYSQL_TIME)) }
 			}
 			.type_string, .type_blob {
-				dataptr << unsafe { malloc(512) }
+				dataptr << unsafe { malloc(field.length) }
 			}
 			.type_var_string {
-				dataptr << unsafe { malloc(2) }
+				dataptr << unsafe { malloc(field.length) }
 			}
 			else {
-				return error('\'${unsafe { FieldType(f.@type) }}\' is not yet implemented. Please create a new issue at https://github.com/vlang/v/issues/new')
+				return error('\'${unsafe { FieldType(field.@type) }}\' is not yet implemented. Please create a new issue at https://github.com/vlang/v/issues/new')
 			}
 		}
 	}


### PR DESCRIPTION
Now a value of any length can be stored in a string column or in a blob, and getting this value will not allocate extra memory.

Fixes #15274 and #15917

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c47d8c8</samp>

Fix a bug and improve code quality in `vlib/db/mysql/orm.v`. The bug affected some field types in the ORM and could lead to data loss or corruption. The code quality improvements removed an unused alias and renamed a variable for clarity.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c47d8c8</samp>

* Fix bug with string, blob and var_string types by allocating enough space based on field length ([link](https://github.com/vlang/v/pull/18214/files?diff=unified&w=0#diff-4a4b7a536f16ac5999429ba69f91a8cf1f42ae1e1cac8ef7bae67bdc3a4e8064L54-R56))
* Rename variable `f` to `field` for clarity and consistency ([link](https://github.com/vlang/v/pull/18214/files?diff=unified&w=0#diff-4a4b7a536f16ac5999429ba69f91a8cf1f42ae1e1cac8ef7bae67bdc3a4e8064L31-R28))
* Remove unused and redundant type alias `Prims` ([link](https://github.com/vlang/v/pull/18214/files?diff=unified&w=0#diff-4a4b7a536f16ac5999429ba69f91a8cf1f42ae1e1cac8ef7bae67bdc3a4e8064L6-L9))
