### PR TITLE
cgen: make comptime call works with or-block

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1002,6 +1002,7 @@ fn (t Tree) comptime_call(node ast.ComptimeCall) &Node {
 	obj.add_terse('env_value', t.string_node(node.env_value))
 	obj.add('pos', t.pos(node.pos))
 	obj.add_terse('args', t.array_node_call_arg(node.args))
+	obj.add_terse('or_block', t.or_expr(node.or_block))
 	return obj
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1845,6 +1845,7 @@ pub:
 	is_env       bool
 	env_pos      token.Pos
 	is_pkgconfig bool
+	or_block     OrExpr
 pub mut:
 	left_type   Type
 	result_type Type

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -141,6 +141,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 			// check each arg expression
 			node.args[i].typ = c.expr(arg.expr)
 		}
+		c.stmts_ending_with_expression(node.or_block.stmts)
 		// assume string for now
 		return ast.string_type
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1954,6 +1954,7 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 			}
 			f.expr(node.left)
 			f.write('.$${method_expr}')
+			f.or_expr(node.or_block)
 		}
 	}
 }

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -227,7 +227,8 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			&& (m.return_type.has_flag(.option) || m.return_type.has_flag(.result)) {
 			g.write('.data)')
 		}
-		if node.or_block.kind != .absent {
+		if node.or_block.kind != .absent
+			&& (m.return_type.has_flag(.option) || m.return_type.has_flag(.result)) {
 			if !g.inside_assign {
 				cur_line := g.go_before_stmt(0)
 				tmp_var := g.new_tmp_var()

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -234,8 +234,6 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				g.write('${g.typ(m.return_type)} ${tmp_var} = ')
 				g.write(cur_line)
 				g.or_block(tmp_var, node.or_block, m.return_type)
-			} else {
-				g.or_block('', node.or_block, m.return_type)
 			}
 		}
 		return

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -161,7 +161,8 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			}
 		}
 
-		if !g.inside_call && (m.return_type.has_flag(.option) || m.return_type.has_flag(.result)) {
+		if !g.inside_call && node.or_block.kind != .block
+			&& (m.return_type.has_flag(.option) || m.return_type.has_flag(.result)) {
 			g.write('(*(${g.base_type(m.return_type)}*)')
 		}
 		// TODO: check argument types
@@ -222,8 +223,20 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			}
 		}
 		g.write(')')
-		if !g.inside_call && (m.return_type.has_flag(.option) || m.return_type.has_flag(.result)) {
+		if !g.inside_call && node.or_block.kind != .block
+			&& (m.return_type.has_flag(.option) || m.return_type.has_flag(.result)) {
 			g.write('.data)')
+		}
+		if node.or_block.kind != .absent {
+			if !g.inside_assign {
+				cur_line := g.go_before_stmt(0)
+				tmp_var := g.new_tmp_var()
+				g.write('${g.typ(m.return_type)} ${tmp_var} = ')
+				g.write(cur_line)
+				g.or_block(tmp_var, node.or_block, m.return_type)
+			} else {
+				g.or_block('', node.or_block, m.return_type)
+			}
 		}
 		return
 	}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -357,9 +357,13 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 		p.check(.lpar)
 		args := p.call_args()
 		p.check(.rpar)
+		mut or_kind := ast.OrKind.absent
+		mut or_pos := p.tok.pos()
+		mut or_stmts := []ast.Stmt{}
 		if p.tok.kind == .key_orelse {
-			p.next()
-			p.check(.lcbr)
+			// `$method() or {}``
+			or_kind = .block
+			or_stmts, or_pos = p.or_block(.with_err_var)
 		}
 		return ast.ComptimeCall{
 			left: left
@@ -369,6 +373,11 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 			args_var: ''
 			args: args
 			pos: start_pos.extend(p.prev_tok.pos())
+			or_block: ast.OrExpr{
+				stmts: or_stmts
+				kind: or_kind
+				pos: or_pos
+			}
 		}
 	}
 	mut has_parens := false

--- a/vlib/v/tests/comptime_call_or_block_test.v
+++ b/vlib/v/tests/comptime_call_or_block_test.v
@@ -10,7 +10,7 @@ fn test_main() {
 	mut ret2 := ''
 	$for method in App.methods {
 		$if method.is_pub {
-			app.$method()
+			app.$method() or { ret2 = err.msg() }
 			dump(ret2)
 		}
 	}

--- a/vlib/v/tests/comptime_call_or_block_test.v
+++ b/vlib/v/tests/comptime_call_or_block_test.v
@@ -5,6 +5,9 @@ pub fn (mut app App) app_index() ! {
 	return error('hhh')
 }
 
+pub fn (mut app App) no_error() {
+}
+
 fn test_main() {
 	mut app := App{}
 	mut ret2 := ''

--- a/vlib/v/tests/comptime_call_or_block_test.v
+++ b/vlib/v/tests/comptime_call_or_block_test.v
@@ -1,0 +1,18 @@
+pub struct App {
+}
+
+pub fn (mut app App) app_index() ! {
+	return error('hhh')
+}
+
+fn test_main() {
+	mut app := App{}
+	mut ret2 := ''
+	$for method in App.methods {
+		$if method.is_pub {
+			app.$method()
+			dump(ret2)
+		}
+	}
+	assert ret2 == 'hhh'
+}


### PR DESCRIPTION
Fix #18200

Enable `or-block` with `app.$method()` call.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f34124</samp>

This pull request adds support for `or` blocks after comptime function calls in the V language. It updates the parser, the checker, the C code generator, and the AST to handle this new syntax. It also adds a test file to verify the functionality and correctness of the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f34124</samp>

*  Add support for `or` block after comptime function call ([link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-8e27648d38098f8fe63778c94c11aceb0a48e379121f676d189b04cb2cd8fc45R1848), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R144), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL164-R165), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL225-R240), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-d2c9f636f3936dce5b9a5091134a09f3d93289d196779b56c1efa12ec04a59a5L360-R366), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-d2c9f636f3936dce5b9a5091134a09f3d93289d196779b56c1efa12ec04a59a5R376-R380), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-5e26b9212af4880a25413056cff2dd36c0bd4e2884b542ac8deef8dc18f3bdd4R1-R18))
  * Add a new field `or_block` to the `ComptimeCall` struct in `ast.v` to store the optional `or` block ([link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-8e27648d38098f8fe63778c94c11aceb0a48e379121f676d189b04cb2cd8fc45R1848))
  * Parse the `or` block in `parse_comptime_call` in `comptime.v` and assign it to the `or_block` field ([link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-d2c9f636f3936dce5b9a5091134a09f3d93289d196779b56c1efa12ec04a59a5L360-R366), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-d2c9f636f3936dce5b9a5091134a09f3d93289d196779b56c1efa12ec04a59a5R376-R380))
  * Check the type and scope of the `or` block in `check_comptime_call` in `comptime.v` and ensure the last statement matches the expected return type ([link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R144))
  * Generate C code for the `or` block in `gen_comptime_call` in `comptime.v` and handle the cases when the `or` block is a single expression or a block of statements ([link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL164-R165), [link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL225-R240))
  * Add a test file `comptime_call_or_block_test.v` that tests the functionality of the `or` block with various comptime function calls ([link](https://github.com/vlang/v/pull/18215/files?diff=unified&w=0#diff-5e26b9212af4880a25413056cff2dd36c0bd4e2884b542ac8deef8dc18f3bdd4R1-R18))
