### PR TITLE
checker, cgen: fix fixed array return on assigning, arg pass and dumping

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -32,9 +32,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 			right_type_sym := c.table.sym(right_type)
 			// fixed array returns an struct, but when assigning it must be the array type
-			if right_type_sym.kind == .array_fixed && (right_type_sym.info as ast.ArrayFixed).is_fn_ret {
+			if right_type_sym.kind == .array_fixed
+				&& (right_type_sym.info as ast.ArrayFixed).is_fn_ret {
 				info := right_type_sym.info as ast.ArrayFixed
-				right_type = c.table.find_or_register_array_fixed(info.elem_type, info.size, info.size_expr, false)
+				right_type = c.table.find_or_register_array_fixed(info.elem_type, info.size,
+					info.size_expr, false)
 			}
 			if i == 0 {
 				right_type0 = right_type

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -342,7 +342,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		right_sym := g.table.sym(unwrapped_val_type)
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
-			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr]
+			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr]
 			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit)
 			|| (val is ast.UnsafeExpr && (val as ast.UnsafeExpr).expr is ast.Ident))
 			&& !g.pref.translated
@@ -622,6 +622,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						&& (val as ast.CallExpr).or_block.kind == .propagate_option)
 						&& ((right_sym.info is ast.ArrayFixed
 						&& (right_sym.info as ast.ArrayFixed).is_fn_ret)
+						|| (val is ast.DumpExpr && right_sym.info is ast.ArrayFixed)
 						|| (val is ast.CallExpr
 						&& g.table.sym(g.unwrap_generic((val as ast.CallExpr).return_type)).kind == .array_fixed))
 					typ_str := g.typ(val_type).trim('*')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2441,6 +2441,9 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	}
 	// no cast
 	g.expr(expr)
+	if expr is ast.CallExpr && exp_sym.kind == .array_fixed {
+		g.write('.ret_arr')
+	}
 }
 
 fn write_octal_escape(mut b strings.Builder, c u8) {

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -105,7 +105,8 @@ fn (mut g Gen) dump_expr_definitions() {
 			g.go_back(str_tdef.len)
 			dump_typedefs['typedef ${str_tdef};'] = true
 			str_dumparg_ret_type = str_dumparg_type
-		} else if dump_sym.kind == .array_fixed {
+		} else if !typ.has_flag(.option) && dump_sym.kind == .array_fixed {
+			// fixed array returned from function
 			str_dumparg_ret_type = '_v_' + str_dumparg_type
 		} else {
 			str_dumparg_ret_type = str_dumparg_type
@@ -163,10 +164,10 @@ fn (mut g Gen) dump_expr_definitions() {
 		dump_fns.writeln('\tstrings__Builder_write_string(&sb, value);')
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, '\\n');")
 		surrounder.builder_write_afters(mut dump_fns)
-		if dump_sym.kind == .array_fixed {
+		if !typ.has_flag(.option) && dump_sym.kind == .array_fixed {
 			tmp_var := g.new_tmp_var()
-			dump_fns.writeln('${str_dumparg_ret_type} ${tmp_var} = {0};')
-			dump_fns.writeln('memcpy(${tmp_var}.ret_arr, dump_arg, sizeof(${str_dumparg_type}));')
+			dump_fns.writeln('\t${str_dumparg_ret_type} ${tmp_var} = {0};')
+			dump_fns.writeln('\tmemcpy(${tmp_var}.ret_arr, dump_arg, sizeof(${str_dumparg_type}));')
 			dump_fns.writeln('\treturn ${tmp_var};')
 		} else {
 			dump_fns.writeln('\treturn dump_arg;')

--- a/vlib/v/tests/fn_fixed_array_ret_test.v
+++ b/vlib/v/tests/fn_fixed_array_ret_test.v
@@ -107,3 +107,9 @@ fn test_arg_fixed() {
 	g(zzz)
 	g(f())
 }
+
+fn test_dump_ret() {
+	zzz := f()
+	a := dump(zzz)
+	b := dump(zzz[0])
+}

--- a/vlib/v/tests/fn_fixed_array_ret_test.v
+++ b/vlib/v/tests/fn_fixed_array_ret_test.v
@@ -98,3 +98,12 @@ fn test_simple_ret() {
 	dump(zzz)
 	dump(zzz[0])
 }
+
+fn g(a [4]int) {
+}
+
+fn test_arg_fixed() {
+	zzz := f()
+	g(zzz)
+	g(f())
+}

--- a/vlib/v/tests/fn_fixed_array_ret_test.v
+++ b/vlib/v/tests/fn_fixed_array_ret_test.v
@@ -88,3 +88,13 @@ fn test_inline() {
 	mut a := [1, 2, 3, 4]!
 	assert four(a)[1] == 2
 }
+
+fn f() [4]int {
+	return [1, 2, 3, 4]!
+}
+
+fn test_simple_ret() {
+	zzz := f()
+	dump(zzz)
+	dump(zzz[0])
+}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e00dd40</samp>

Fixed a checker bug and added a test for assigning fixed arrays returned by functions. The bug caused a type mismatch error in `vlib/v/checker/assign.v`, and the test is in `vlib/v/tests/fn_fixed_array_ret_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e00dd40</samp>

*  Make `right_type` mutable and handle fixed array return type in assignment ([link](https://github.com/vlang/v/pull/18216/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL29-R38))
*  Remove unused `right_type_sym` variable ([link](https://github.com/vlang/v/pull/18216/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL39))
*  Add test case for assigning fixed array returned by function to `vlib/v/tests/fn_fixed_array_ret_test.v` ([link](https://github.com/vlang/v/pull/18216/files?diff=unified&w=0#diff-caea9cbb8d10b19b53db81a10f83049076a53ff83c86f7e3279f27d25993a1e0R91-R100))
