### PR TITLE
vweb: change: return 404 on file not found

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -256,6 +256,10 @@ pub fn (mut ctx Context) json_pretty[T](j T) Result {
 // TODO - test
 // Response HTTP_OK with file as payload
 pub fn (mut ctx Context) file(f_path string) Result {
+	if !os.exists(f_path) {
+		eprintln('[vweb] file ${f_path} does not exist')
+		return ctx.not_found()
+	}
 	ext := os.file_ext(f_path)
 	data := os.read_file(f_path) or {
 		eprint(err.msg())


### PR DESCRIPTION
vweb respons with a 500 internal server error status when a file is not found, which can lead to confusion when debugging requests
This PR changes the response to 404 File not found
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df0742a</samp>

Improve error handling for static file requests in `vweb`. Add a file existence check in `serve_static` and return 404 if not found.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at df0742a</samp>

* Add a check for file existence before serving static files ([link](https://github.com/vlang/v/pull/18219/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R259-R262)). Return a 404 response if the file is not found, instead of panicking.
