### PR TITLE
cgen: include float kind in struct field type defaults

### DIFF
--- a/vlib/json/json_omitempty_types_test.v
+++ b/vlib/json/json_omitempty_types_test.v
@@ -45,83 +45,83 @@ fn main() {
 }
 
 fn test_struct() {
-	test2 := OmitEmptyStruct{
+	test := OmitEmptyStruct{
 		bug: Struct{}
 	}
-	encoded2 := json.encode(test2)
-	dump(encoded2)
-	test := OmitEmptyStruct{
+	encoded := json.encode(test)
+	dump(encoded)
+	test2 := OmitEmptyStruct{
 		bug: Struct{
 			name: 'mybug'
 		}
 	}
-	encoded := json.encode(test)
-	dump(encoded)
+	encoded2 := json.encode(test2)
+	dump(encoded2)
 }
 
 fn test_fnum_struct() {
 	test := OmitEmptyFNumStruct{
 		bug: FNumStruct{}
 	}
-	encode := json.encode(test)
-	dump(encode)
+	encoded := json.encode(test)
+	dump(encoded)
 	test2 := OmitEmptyFNumStruct{
 		bug: FNumStruct{
 			f_num: 1.5
 		}
 	}
-	encoded := json.encode(test)
-	dump(encoded)
+	encoded2 := json.encode(test)
+	dump(encoded2)
 }
 
 fn test_alias() {
-	test3 := OmitEmptyAlias{
+	test := OmitEmptyAlias{
 		bug: ''
 	}
-	encoded3 := json.encode(test3)
-	dump(encoded3)
-	test4 := OmitEmptyAlias{
+	encoded := json.encode(test)
+	dump(encoded)
+	test2 := OmitEmptyAlias{
 		bug: 'foo'
 	}
-	encoded4 := json.encode(test4)
-	dump(encoded4)
+	encoded2 := json.encode(test2)
+	dump(encoded2)
 }
 
 fn test_map() {
-	test3 := OmitEmptyMap{
+	test := OmitEmptyMap{
 		bug: {}
 	}
-	encoded3 := json.encode(test3)
-	dump(encoded3)
-	test4 := OmitEmptyMap{
+	encoded := json.encode(test)
+	dump(encoded)
+	test2 := OmitEmptyMap{
 		bug: {
 			'foo': 'bar'
 		}
 	}
-	encoded4 := json.encode(test4)
-	dump(encoded4)
+	encoded2 := json.encode(test2)
+	dump(encoded2)
 }
 
 fn test_sumtype() {
-	test3 := OmitEmptySumType{}
-	encoded3 := json.encode(test3)
-	dump(encoded3)
-	test4 := OmitEmptySumType{
+	test := OmitEmptySumType{}
+	encoded := json.encode(test)
+	dump(encoded)
+	test2 := OmitEmptySumType{
 		bug: 1
 	}
-	encoded4 := json.encode(test4)
-	dump(encoded4)
+	encoded2 := json.encode(test2)
+	dump(encoded2)
 }
 
 fn test_array() {
-	test3 := OmitEmptyArray{
+	test := OmitEmptyArray{
 		bug: []
 	}
-	encoded3 := json.encode(test3)
-	dump(encoded3)
-	test4 := OmitEmptyArray{
+	encoded := json.encode(test)
+	dump(encoded)
+	test2 := OmitEmptyArray{
 		bug: ['1']
 	}
-	encoded4 := json.encode(test4)
-	dump(encoded4)
+	encoded2 := json.encode(test2)
+	dump(encoded2)
 }

--- a/vlib/json/json_omitempty_types_test.v
+++ b/vlib/json/json_omitempty_types_test.v
@@ -62,7 +62,7 @@ fn test_fnum_struct() {
 			f_num: 1.5
 		}
 	}
-	encoded2 := json.encode(test)
+	encoded2 := json.encode(test2)
 	dump(encoded2)
 }
 

--- a/vlib/json/json_omitempty_types_test.v
+++ b/vlib/json/json_omitempty_types_test.v
@@ -36,14 +36,6 @@ struct OmitEmptyFNumStruct {
 	bug FNumStruct [omitempty]
 }
 
-fn main() {
-	test_struct()
-	test_alias()
-	test_map()
-	test_sumtype()
-	test_array()
-}
-
 fn test_struct() {
 	test := OmitEmptyStruct{
 		bug: Struct{}

--- a/vlib/json/json_omitempty_types_test.v
+++ b/vlib/json/json_omitempty_types_test.v
@@ -28,6 +28,14 @@ struct OmitEmptySumType {
 	bug MySum [omitempty]
 }
 
+struct FNumStruct {
+	f_num f64
+}
+
+struct OmitEmptyFNumStruct {
+	bug FNumStruct [omitempty]
+}
+
 fn main() {
 	test_struct()
 	test_alias()
@@ -45,6 +53,21 @@ fn test_struct() {
 	test := OmitEmptyStruct{
 		bug: Struct{
 			name: 'mybug'
+		}
+	}
+	encoded := json.encode(test)
+	dump(encoded)
+}
+
+fn test_fnum_struct() {
+	test := OmitEmptyFNumStruct{
+		bug: FNumStruct{}
+	}
+	encode := json.encode(test)
+	dump(encode)
+	test2 := OmitEmptyFNumStruct{
+		bug: FNumStruct{
+			f_num: 1.5
 		}
 	}
 	encoded := json.encode(test)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6116,7 +6116,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 				for field in info.fields {
 					field_sym := g.table.sym(field.typ)
 					if field.has_default_expr
-						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .u8, .u16, .u32, .u64, .char, .voidptr, .byteptr, .charptr, .struct_, .chan] {
+						|| field_sym.kind in [.array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .u8, .u16, .u32, .u64, .f32, .f64, .char, .voidptr, .byteptr, .charptr, .struct_, .chan] {
 						field_name := c_name(field.name)
 						if field.has_default_expr {
 							mut expr_str := ''


### PR DESCRIPTION
The PR includes floats for the `type_default` of struct fields.

I encountered and was attempting to resolve this issue while working with json. So the path of least resistance was to include a test case that is in the json space.

The PR aims to resolve the following, which will result in a cgen error on master. The error occurs if the potentially-omitted-struct contains only float type fields. Another field that is e.g. of type string will prevent it.
```v
module main

import json

pub struct Dilution {
	cash_pos CashPosition [omitempty]
}

pub struct CashPosition {
	quaterly_burn f64
	// ticker        string // <- will prevent cerror
}

dil := Dilution{
	cash_pos: CashPosition{
		quaterly_burn: 1.5
	}
}

res := json.encode(dil)
println(res)

```
---

This PR also resolves #14428. Which instead of resulting in a c error, will throw:
```
src/test.v:2:9: error: cannot cast `int|f64` sum type value to `f64`, use `a as f64` instead
    1 | fn cast(a int|f64) f64 {
    2 |     return f64(a)
      |            ~~~~~~
    3 | }
    4 |
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e1b68f</samp>

This pull request adds support for the `omitempty` attribute of JSON encoding for floating point numbers. It updates the `cgen.v` file to initialize floating point fields with default values and adds a test case in `json_omitempty_types_test.v` to verify the correct behavior.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e1b68f</samp>

*  Add support for `omitempty` attribute for floating point numbers in JSON encoding ([link](https://github.com/vlang/v/pull/18228/files?diff=unified&w=0#diff-e4dc91f0b511f06c9a175969a0df54cf3a22bfeaa73a1ecb9c576c573db4225dR31-R38), [link](https://github.com/vlang/v/pull/18228/files?diff=unified&w=0#diff-e4dc91f0b511f06c9a175969a0df54cf3a22bfeaa73a1ecb9c576c573db4225dR62-R76), [link](https://github.com/vlang/v/pull/18228/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL6119-R6119))
  * Define two structs, `FNumStruct` and `OmitEmptyFNumStruct`, to test the `omitempty` behavior for `f32` and `f64` fields in `vlib/json/json_omitempty_types_test.v` ([link](https://github.com/vlang/v/pull/18228/files?diff=unified&w=0#diff-e4dc91f0b511f06c9a175969a0df54cf3a22bfeaa73a1ecb9c576c573db4225dR31-R38))
  * Add a test function, `test_fnum_struct`, that encodes two instances of `OmitEmptyFNumStruct` with different values for the `bug` field, which has the `omitempty` attribute, and checks the JSON output in `vlib/json/json_omitempty_types_test.v` ([link](https://github.com/vlang/v/pull/18228/files?diff=unified&w=0#diff-e4dc91f0b511f06c9a175969a0df54cf3a22bfeaa73a1ecb9c576c573db4225dR62-R76))
  * Modify the C code generation in `vlib/v/gen/c/cgen.v` to initialize floating point fields with their default values when creating a struct, to avoid garbage values that would interfere with the `omitempty` check ([link](https://github.com/vlang/v/pull/18228/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL6119-R6119))
