### PR TITLE
json.decode: add check for shared variable

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -635,6 +635,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 		}
 		panic('unreachable')
+	} else if node.args.len > 0 && fn_name == 'json.encode' && node.args[0].typ.has_flag(.shared_f) {
+		c.error('json.encode cannot handle shared data', node.pos)
+		return ast.void_type
 	} else if node.args.len > 0 && fn_name == 'json.decode' {
 		if node.args.len != 2 {
 			c.error("json.decode expects 2 arguments, a type and a string (e.g `json.decode(T, '')`)",

--- a/vlib/v/checker/tests/json_decode_shared_err.out
+++ b/vlib/v/checker/tests/json_decode_shared_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/json_decode_shared_err.vv:6:22: error: json.encode cannot handle shared data
+vlib/v/checker/tests/json_decode_shared_err.vv:6:16: error: json.encode cannot handle shared data
     4 |     shared data := [1, 2, 3]
     5 |     rlock data {
     6 |         println(json.encode(data))

--- a/vlib/v/checker/tests/json_decode_shared_err.out
+++ b/vlib/v/checker/tests/json_decode_shared_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/json_decode_shared_err.vv:6:22: error: json.encode cannot handle shared data
+    4 |     shared data := [1, 2, 3]
+    5 |     rlock data {
+    6 |         println(json.encode(data))
+      |                      ~~~~~~~~~~~~
+    7 |     }
+    8 | }

--- a/vlib/v/checker/tests/json_decode_shared_err.vv
+++ b/vlib/v/checker/tests/json_decode_shared_err.vv
@@ -1,0 +1,8 @@
+import json
+
+fn main() {
+	shared data := [1, 2, 3]
+	rlock data {
+		println(json.encode(data))
+	}
+}


### PR DESCRIPTION
Fix #11551

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19e5ec8</samp>

Add a checker error for calling `json.encode` with a shared argument. Add a test case for this error in `vlib/v/checker/tests`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19e5ec8</samp>

* Add a check for unsupported shared arguments to `json.encode` ([link](https://github.com/vlang/v/pull/18237/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR638-R640))
* Emit an error message and return a void type if the check fails ([link](https://github.com/vlang/v/pull/18237/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR638-R640))
* Test the check with a shared array of integers inside a read lock ([link](https://github.com/vlang/v/pull/18237/files?diff=unified&w=0#diff-60ddedbf66ca3618d1f34abfc0e1aa00406a31d40cbba0782229f0a2b335e6a9R1-R8), [link](https://github.com/vlang/v/pull/18237/files?diff=unified&w=0#diff-2ab080fbc2e02747ea838424cb1ee05db3890de2a3f895aabc004d89e8e92ab6R1-R7))
* Use the files `vlib/v/checker/tests/json_decode_shared_err.vv` and `vlib/v/checker/tests/json_decode_shared_err.out` for the test case ([link](https://github.com/vlang/v/pull/18237/files?diff=unified&w=0#diff-60ddedbf66ca3618d1f34abfc0e1aa00406a31d40cbba0782229f0a2b335e6a9R1-R8), [link](https://github.com/vlang/v/pull/18237/files?diff=unified&w=0#diff-2ab080fbc2e02747ea838424cb1ee05db3890de2a3f895aabc004d89e8e92ab6R1-R7))
