### PR TITLE
cgen, checker: fix comptime assigning to sumtype or indexexpr

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -336,7 +336,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									}
 								}
 								if right is ast.ComptimeSelector {
-									if c.table.sym(left_type).kind != .sum_type {
+									if is_decl {
 										left.obj.ct_type_var = .field_var
 										left.obj.typ = c.comptime_fields_default_type
 									}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -336,8 +336,10 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									}
 								}
 								if right is ast.ComptimeSelector {
-									left.obj.ct_type_var = .field_var
-									left.obj.typ = c.comptime_fields_default_type
+									if c.table.sym(left_type).kind != .sum_type {
+										left.obj.ct_type_var = .field_var
+										left.obj.typ = c.comptime_fields_default_type
+									}
 								} else if right is ast.Ident
 									&& (right as ast.Ident).obj is ast.Var && (right as ast.Ident).or_expr.kind == .absent {
 									if ((right as ast.Ident).obj as ast.Var).ct_type_var != .no_comptime {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -238,9 +238,13 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				} else if val is ast.ComptimeSelector {
 					key_str := g.get_comptime_selector_key_type(val)
 					if key_str != '' {
-						var_type = g.comptime_var_type_map[key_str] or { var_type }
-						val_type = var_type
-						left.obj.typ = var_type
+						if g.table.sym(var_type).kind != .sum_type {
+							var_type = g.comptime_var_type_map[key_str] or { var_type }
+							val_type = var_type
+							left.obj.typ = var_type
+						} else {
+							val_type = g.comptime_var_type_map[key_str] or { var_type }
+						}
 					}
 				} else if val is ast.ComptimeCall {
 					key_str := '${val.method_name}.return_type'

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -238,7 +238,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				} else if val is ast.ComptimeSelector {
 					key_str := g.get_comptime_selector_key_type(val)
 					if key_str != '' {
-						if g.table.sym(var_type).kind != .sum_type {
+						if is_decl {
 							var_type = g.comptime_var_type_map[key_str] or { var_type }
 							val_type = var_type
 							left.obj.typ = var_type
@@ -286,6 +286,11 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				if key_str_right != '' {
 					val_type = g.comptime_var_type_map[key_str_right] or { var_type }
 				}
+			}
+		} else if mut left is ast.IndexExpr && val is ast.ComptimeSelector {
+			key_str := g.get_comptime_selector_key_type(val)
+			if key_str != '' {
+				val_type = g.comptime_var_type_map[key_str] or { var_type }
 			}
 		}
 		mut styp := g.typ(var_type)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4263,7 +4263,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 	node_typ := g.unwrap_generic(node.typ)
 	mut expr_type := node.expr_type
 	sym := g.table.sym(node_typ)
-	if node.expr is ast.Ident && g.is_comptime_var(node.expr) {
+	if (node.expr is ast.Ident && g.is_comptime_var(node.expr)) || node.expr is ast.ComptimeSelector {
 		expr_type = g.unwrap_generic(g.get_comptime_var_type(node.expr))
 	}
 	if sym.kind in [.sum_type, .interface_] {

--- a/vlib/v/tests/comptime_sumtype_cast_2_test.v
+++ b/vlib/v/tests/comptime_sumtype_cast_2_test.v
@@ -1,0 +1,38 @@
+pub type Any = bool | int | map[string]Any | string
+
+struct StructType[T] {
+mut:
+	val T
+}
+
+fn map_from[T](t T) Any {
+	mut value := Any{}
+	$if T is $struct {
+		$for field in T.fields {
+			println(t.$(field.name))
+			value = t.$(field.name)
+			value = Any(t.$(field.name))
+		}
+	}
+	return value
+}
+
+fn test_generic_struct_with_sumtype() {
+	struct_type := StructType[string]{
+		val: 'true'
+	}
+	struct_type2 := StructType[int]{
+		val: 1
+	}
+	array_of_struct := [struct_type, struct_type]
+
+	for variable in array_of_struct {
+		assert map_from(variable) == Any('true')
+	}
+
+	array_of_struct2 := [struct_type2, struct_type2]
+
+	for variable in array_of_struct2 {
+		assert map_from(variable) == Any(1)
+	}
+}

--- a/vlib/v/tests/comptime_sumtype_cast_3_test.v
+++ b/vlib/v/tests/comptime_sumtype_cast_3_test.v
@@ -1,0 +1,61 @@
+pub type Any = bool | int | map[string]Any | string
+
+struct StructType[T] {
+mut:
+	val T
+}
+
+fn map_from[T](t T) map[string]Any {
+	mut m := map[string]Any{}
+	$if T is $struct {
+		$for field in T.fields {
+			key := field.name
+			m[key] = t.$(field.name)
+		}
+	}
+	return m
+}
+
+fn test_struct_to_map_string() {
+	array_of_struct := [StructType[string]{
+		val: 'true'
+	}, StructType[string]{
+		val: 'false'
+	}]
+
+	mut array_of_map := []Any{}
+
+	for variable in array_of_struct {
+		array_of_map << map_from(variable)
+	}
+
+	println(array_of_map)
+	assert array_of_map[0] == Any({
+		'val': Any('true')
+	})
+	assert array_of_map[1] == Any({
+		'val': Any('false')
+	})
+}
+
+fn test_struct_to_map_bool() {
+	array_of_struct := [StructType[bool]{
+		val: true
+	}, StructType[bool]{
+		val: false
+	}]
+
+	mut array_of_map := []Any{}
+
+	for variable in array_of_struct {
+		array_of_map << map_from(variable)
+	}
+
+	println(array_of_map)
+	assert array_of_map[0] == Any({
+		'val': Any(true)
+	})
+	assert array_of_map[1] == Any({
+		'val': Any(false)
+	})
+}


### PR DESCRIPTION
Fix #16869
Fix #16799

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c199bf</samp>

Fix a bug where assigning a comptime field to a sum type variable would change the sum type's tag and cause a runtime error. Update the checker and the C code generator modules to handle comptime selectors correctly. Add a new test file for generic structs with sum type fields.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c199bf</samp>

* Fix a bug where assigning a comptime field to a sum type variable would change the sum type's tag and cause a runtime error ([link](https://github.com/vlang/v/pull/18240/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL339-R342), [link](https://github.com/vlang/v/pull/18240/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL241-R247))
* Use the comptime var type instead of the node type when generating C code for comptime selectors, to handle the case where they are used as function or method arguments ([link](https://github.com/vlang/v/pull/18240/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4266-R4266))
* Add a new test file `vlib/v/tests/comptime_sumtype_cast_2_test.v` to verify the behavior of generic structs with sum type fields, using comptime reflection to create a map from any struct type ([link](https://github.com/vlang/v/pull/18240/files?diff=unified&w=0#diff-cd9e6db20e236208c02d4170f731ab8b6969d6b86e7dee1bf171237dabbd2ef6R1-R38))
