### PR TITLE
checker, cgen: fix array of interfaces contains()

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2509,6 +2509,9 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 				c.error('${err.msg()} in argument 1 to `.contains()`', node.args[0].pos)
 			}
 		}
+		for i, arg in node.args {
+			node.args[i].typ = c.expr(arg.expr)
+		}
 		node.return_type = ast.bool_type
 	} else if method_name == 'index' {
 		if node.args.len != 1 {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -891,7 +891,7 @@ fn (mut g Gen) gen_array_method_call(node ast.CallExpr, left_type ast.Type) bool
 			return true
 		}
 		'contains' {
-			g.gen_array_contains(left_type, node.left, node.args[0].expr)
+			g.gen_array_contains(left_type, node.left, node.args[0].typ, node.args[0].expr)
 			return true
 		}
 		'index' {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -488,12 +488,21 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 						expr: node.left
 						expr_type: ast.mktyp(node.left_type)
 					}
-					g.gen_array_contains(node.right_type, node.right, new_node_left)
+					g.gen_array_contains(node.right_type, node.right, elem_type, new_node_left)
 					return
 				}
+			} else if elem_type_.sym.kind == .interface_ {
+				new_node_left := ast.CastExpr{
+					arg: ast.empty_expr
+					typ: elem_type
+					expr: node.left
+					expr_type: ast.mktyp(node.left_type)
+				}
+				g.gen_array_contains(node.right_type, node.right, elem_type, new_node_left)
+				return
 			}
 		}
-		g.gen_array_contains(node.right_type, node.right, node.left)
+		g.gen_array_contains(node.right_type, node.right, node.left_type, node.left)
 	} else if right.unaliased_sym.kind == .map {
 		g.write('_IN_MAP(')
 		if !left.typ.is_ptr() {
@@ -558,12 +567,12 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 						expr: node.left
 						expr_type: ast.mktyp(node.left_type)
 					}
-					g.gen_array_contains(node.right_type, node.right, new_node_left)
+					g.gen_array_contains(node.right_type, node.right, elem_type, new_node_left)
 					return
 				}
 			}
 		}
-		g.gen_array_contains(node.right_type, node.right, node.left)
+		g.gen_array_contains(node.right_type, node.right, node.left_type, node.left)
 	} else if right.unaliased_sym.kind == .string {
 		g.write('string_contains(')
 		g.expr(node.right)

--- a/vlib/v/tests/array_of_interfaces_builtin_method_test.v
+++ b/vlib/v/tests/array_of_interfaces_builtin_method_test.v
@@ -24,8 +24,12 @@ fn get_component[T](entity Entity) !&T {
 
 fn test_array_of_interfaces_index() {
 	entity := Entity{1, [IsControlledByPlayerTag{}]}
-	id := entity.components.index(*get_component[IsControlledByPlayerTag](entity)!)
 
+	id := entity.components.index(*get_component[IsControlledByPlayerTag](entity)!)
 	println('id = ${id}')
 	assert id == 0
+
+	ret := entity.components.contains(*get_component[IsControlledByPlayerTag](entity)!)
+	println(ret)
+	assert ret
 }


### PR DESCRIPTION
This PR fix array of interfaces contains().

- Fix array of interfaces contains().
- Add test.

```v
struct Entity {
	id u64
mut:
	components []IComponent
}

interface IComponent {
	hollow bool
}

struct IsControlledByPlayerTag {
	hollow bool
}

fn get_component[T](entity Entity) !&T {
	for component in entity.components {
		if component is T {
			return component
		}
	}

	return error('Entity does not have component')
}

fn main() {
	entity := Entity{1, [IsControlledByPlayerTag{}]}
	id := entity.components.index(*get_component[IsControlledByPlayerTag](entity)!)

	println('id = ${id}')
	assert id == 0

	ret := entity.components.contains(*get_component[IsControlledByPlayerTag](entity)!)
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
id = 0
true
```