### PR TITLE
parser: fix enum attr with default value

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -481,7 +481,7 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				return node
 			}
 			p.is_stmt_ident = is_stmt_ident
-		} else if p.tok.kind in [.lsbr, .nilsbr] && (p.tok.line_nr == p.prev_tok.line_nr
+		} else if left !is ast.IntegerLiteral && p.tok.kind in [.lsbr, .nilsbr] && (p.tok.line_nr == p.prev_tok.line_nr
 			|| (p.prev_tok.kind == .string
 			&& p.tok.line_nr == p.prev_tok.line_nr + p.prev_tok.lit.count('\n'))) {
 			if p.tok.kind == .nilsbr {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -481,8 +481,8 @@ pub fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_iden
 				return node
 			}
 			p.is_stmt_ident = is_stmt_ident
-		} else if left !is ast.IntegerLiteral && p.tok.kind in [.lsbr, .nilsbr] && (p.tok.line_nr == p.prev_tok.line_nr
-			|| (p.prev_tok.kind == .string
+		} else if left !is ast.IntegerLiteral && p.tok.kind in [.lsbr, .nilsbr]
+			&& (p.tok.line_nr == p.prev_tok.line_nr || (p.prev_tok.kind == .string
 			&& p.tok.line_nr == p.prev_tok.line_nr + p.prev_tok.lit.count('\n'))) {
 			if p.tok.kind == .nilsbr {
 				node = p.index_expr(node, true)

--- a/vlib/v/tests/enum_attr_2_test.v
+++ b/vlib/v/tests/enum_attr_2_test.v
@@ -1,0 +1,14 @@
+enum Color {
+	red = 1 + 1  [json: 'Red']
+	blue = 10 / 2  [json: 'Blue']
+}
+
+fn test_main() {
+	$for e in Color.values {
+		if e.name == 'red' {
+			assert e.value == Color.red
+		} else if e.name == 'blue' {
+			assert e.value == Color.blue
+		}
+	}
+}


### PR DESCRIPTION
Fix #18242

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb552c1</samp>

Fix a parser bug with enum values as indexes and add a test for enum attributes with arithmetic expressions. The bug fix affects `vlib/v/parser/expr.v` and the test is in `vlib/v/tests/enum_attr_2_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb552c1</samp>

* Fix a parser bug that caused an incorrect error for enum values as array or map indices ([link](https://github.com/vlang/v/pull/18248/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL484-R485))
* Add a test case for enum attributes with arithmetic expressions as values ([link](https://github.com/vlang/v/pull/18248/files?diff=unified&w=0#diff-e543b3382f2268478e255b87129556e9f1fc8ff917134e647f0c3806398f0421R1-R14))
