### PR TITLE
checker: add missing check for mismatch anon struct to typed struct

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -691,6 +691,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
+		if left_sym.kind == .struct_ && right is ast.StructInit && (right as ast.StructInit).is_anon {
+			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
+		}
 	}
 	// this needs to run after the assign stmt left exprs have been run through checker
 	// so that ident.obj is set

--- a/vlib/v/checker/tests/anon_struct_assign_err.out
+++ b/vlib/v/checker/tests/anon_struct_assign_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/anon_struct_assign_err.vv:9:12: error: cannot assign anonymous `struct` to a typed `struct`
+    7 | }
+    8 | println(y)
+    9 | y = struct {
+      |            ^
+   10 |     name: 'Def'
+   11 | }

--- a/vlib/v/checker/tests/anon_struct_assign_err.vv
+++ b/vlib/v/checker/tests/anon_struct_assign_err.vv
@@ -1,0 +1,12 @@
+struct Abc {
+	name string
+}
+
+mut y := Abc{
+	name: 'Abc'
+}
+println(y)
+y = struct {
+	name: 'Def'
+}
+println(y)


### PR DESCRIPTION
Fix #18239

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce8f7dc</samp>

This pull request adds a new error check and a test case for assigning an anonymous struct to a typed struct in `vlib/v/checker/assign.v`. This prevents a potential type mismatch and inconsistency in the V language.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce8f7dc</samp>

*  Add error check for assigning anonymous struct to typed struct ([link](https://github.com/vlang/v/pull/18250/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR694-R696))
*  Add expected output of the test case with file name, line and column numbers, and error message ([link](https://github.com/vlang/v/pull/18250/files?diff=unified&w=0#diff-1cfb21fd9766143f516087587c1ba8905d55d4f58e567627b7f9b6dc91369659R1-R7))
