### PR TITLE
os: fix open_file() on windows (fix #18245)

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -101,7 +101,12 @@ pub fn open_file(path string, mode string, options ...int) !File {
 		}
 	}
 	p := fix_windows_path(path)
-	fd := C.open(&char(p.str), flags, permission)
+	mut fd := 0
+	$if windows {
+		fd = C._wopen(p.to_wide(), flags, permission)
+	} $else {
+		fd = C.open(&char(p.str), flags, permission)
+	}
 	if fd == -1 {
 		return error(posix_get_error_msg(C.errno))
 	}

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -418,7 +418,7 @@ fn test_open_file_wb_ab() {
 	mut afile := os.open_file('text.txt', 'ab', 0o666)!
 	afile.write_string('hello')!
 	afile.close()
-	assert os.read_file('text.txt')? == 'hellohello'
+	assert os.read_file('text.txt')! == 'hellohello'
 }
 
 fn test_open_append() {
@@ -437,4 +437,13 @@ fn test_open_append() {
 	f3.write_string('def\n')!
 	f3.close()
 	assert os.read_lines(tfile)! == ['abc', 'abc', 'def']
+}
+
+fn test_open_file_on_chinese_windows() {
+	os.rm('中文.txt') or {}
+	mut f1 := os.open_file('中文.txt', 'w+', 0x666) or { panic(err) }
+	f1.write_string('test')!
+	f1.close()
+
+	assert os.read_file('中文.txt')! == 'test'
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -440,10 +440,12 @@ fn test_open_append() {
 }
 
 fn test_open_file_on_chinese_windows() {
-	os.rm('中文.txt') or {}
-	mut f1 := os.open_file('中文.txt', 'w+', 0x666) or { panic(err) }
-	f1.write_string('test')!
-	f1.close()
+	$if windows {
+		os.rm('中文.txt') or {}
+		mut f1 := os.open_file('中文.txt', 'w+', 0x666) or { panic(err) }
+		f1.write_string('test')!
+		f1.close()
 
-	assert os.read_file('中文.txt')! == 'test'
+		assert os.read_file('中文.txt')! == 'test'
+	}
 }

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -19,6 +19,8 @@ fn C.sigaction(int, voidptr, int) int
 
 fn C.open(&char, int, ...int) int
 
+fn C._wopen(&u16, int, ...int) int
+
 fn C.fdopen(fd int, mode &char) &C.FILE
 
 fn C.ferror(stream &C.FILE) int


### PR DESCRIPTION
This PR fix open_file() on windows (fix #18245).

- Fix open_file() on windows.
- Add test.

```v
import os

fn main() {
	mut result := os.open_file('中文.txt', 'w+', 0x666) or { panic(err) }
	result.write_string('中文，test') or { panic(err) }
}

PS D:\Test\v\tt1> v run .
```
generated:
`中文.txt`
```v
中文，test
```