### PR TITLE
parser: fix missing sync auto import when only declaring shared type and not using it

### DIFF
--- a/vlib/v/checker/tests/sync_receiver_decl.vv
+++ b/vlib/v/checker/tests/sync_receiver_decl.vv
@@ -1,0 +1,4 @@
+struct St {}
+fn (shared b St) g() {}
+
+println('ok')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -623,6 +623,9 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	if rec.is_mut {
 		p.next() // `mut`
 	}
+	if is_shared {
+		p.register_auto_import('sync')
+	}
 	rec_start_pos := p.tok.pos()
 	rec.name = p.check_name()
 	if !rec.is_mut {


### PR DESCRIPTION
Fix #9281

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f38dc7</samp>

This pull request adds a new feature to the V language that allows declaring a receiver as `shared`, enabling concurrent access to the receiver's data. It also updates the parser and adds a test case for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f38dc7</samp>

*  Add support for declaring a receiver as `shared`, which allows concurrent access to the receiver by multiple threads ([link](https://github.com/vlang/v/pull/18255/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eR626-R628), [link](https://github.com/vlang/v/pull/18255/files?diff=unified&w=0#diff-06acaa991afe381403fc84650c328d590f2aba84914e0da887315cc5344b65baL1-R3))
  - Modify the parser to check for the `shared` keyword and register an auto import of the `sync` module, which provides synchronization primitives and utilities ([link](https://github.com/vlang/v/pull/18255/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eR626-R628))
  - Add a test case that defines a struct and a method with a shared receiver and prints `ok` to verify that the code compiles and runs without errors ([link](https://github.com/vlang/v/pull/18255/files?diff=unified&w=0#diff-06acaa991afe381403fc84650c328d590f2aba84914e0da887315cc5344b65baL1-R3))
