### PR TITLE
time: add more detailed error explanation, add custom format parsing

### DIFF
--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -106,10 +106,13 @@ pub fn (s string) clone() string {
 	return string(s.str)
 }
 
+// contains returns `true` if the string contains `substr`.
+// See also: [`string.index`](#string.index)
 pub fn (s string) contains(substr string) bool {
 	return bool(s.str.includes(substr.str))
 }
 
+// contains_any returns `true` if the string contains any chars in `chars`.
 pub fn (s string) contains_any(chars string) bool {
 	sep := ''
 	res := chars.str.split(sep.str)
@@ -119,6 +122,26 @@ pub fn (s string) contains_any(chars string) bool {
 		}
 	}
 	return false
+}
+
+// contains_only returns `true`, if the string contains only the characters in `chars`.
+pub fn (s string) contains_only(chars string) bool {
+	if chars.len == 0 {
+		return false
+	}
+	for ch in s {
+		mut res := 0
+		for c in chars {
+			if ch == c {
+				res++
+				break
+			}
+		}
+		if res == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 pub fn (s string) contains_any_substr(chars []string) bool {

--- a/vlib/builtin/js/string_test.js.v
+++ b/vlib/builtin/js/string_test.js.v
@@ -404,6 +404,13 @@ fn test_contains_any() {
 	assert !''.contains_any('')
 }
 
+fn test_contains_only() {
+	assert '23885'.contains_only('0123456789')
+	assert '23gg885'.contains_only('01g23456789')
+	assert !'hello;'.contains_only('hello')
+	assert !''.contains_only('')
+}
+
 fn test_contains_any_substr() {
 	s := 'Some random text'
 	assert s.contains_any_substr(['false', 'not', 'rand'])

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -38,7 +38,7 @@ fn (mut p DateTimeParser) must_be_int(length int) !int {
 fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allow_leading_zero bool) !int {
 	mut length := max + 1 - min
 	mut val := ''
-	for i in 0 .. length {
+	for _ in 0 .. length {
 		maybe_int := p.peek(1) or { break }
 		if maybe_int == '0' || maybe_int == '1' || maybe_int == '2' || maybe_int == '4'
 			|| maybe_int == '5' || maybe_int == '6' || maybe_int == '7' || maybe_int == '8'

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -1,7 +1,5 @@
 module time
 
-
-
 struct DateTimeParser {
 	datetime string
 	format   string
@@ -29,33 +27,37 @@ fn (mut p DateTimeParser) peek(length int) !string {
 	if p.current_pos_datetime + length > p.datetime.len {
 		return error('end of string')
 	}
-	return p.datetime[p.current_pos_datetime..p.current_pos_datetime+length]
+	return p.datetime[p.current_pos_datetime..p.current_pos_datetime + length]
 }
 
 fn (mut p DateTimeParser) must_be_int(length int) !int {
 	val := p.next(length) or { return err }
 	return val.int()
 }
-fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int,allow_leading_zero bool) !int {		
-	mut length:=max+1-min
-	mut val:=""	
-	for i in 0..length{
-		maybe_int := p.peek(1) or { break }			
-		if  maybe_int == "0" || maybe_int == "1" || maybe_int == "2" || maybe_int == "4" || maybe_int == "5" || maybe_int == "6"  || maybe_int == "7" || maybe_int == "8" || maybe_int == "9"     {
+
+fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allow_leading_zero bool) !int {
+	mut length := max + 1 - min
+	mut val := ''
+	for i in 0 .. length {
+		maybe_int := p.peek(1) or { break }
+		if maybe_int == '0' || maybe_int == '1' || maybe_int == '2' || maybe_int == '4'
+			|| maybe_int == '5' || maybe_int == '6' || maybe_int == '7' || maybe_int == '8'
+			|| maybe_int == '9' {
 			p.next(1)!
-			val+=maybe_int
-		}else{
+			val += maybe_int
+		} else {
 			break
 		}
-	}	
-	if val.len<min{
-		return error("expected int with a minimum length of ${min}, found: ${val.len}")
 	}
-	if !allow_leading_zero && val.starts_with("0"){
-		return error("0 is not allowed for this format")
+	if val.len < min {
+		return error('expected int with a minimum length of ${min}, found: ${val.len}')
+	}
+	if !allow_leading_zero && val.starts_with('0') {
+		return error('0 is not allowed for this format')
 	}
 	return val.int()
 }
+
 fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
 	mut val := p.next(1) or { return err }
 	if val == '0' {
@@ -162,10 +164,10 @@ fn (mut p DateTimeParser) parse() !Time {
 				}
 			}
 			'M' {
-				month_ = p.must_be_int_with_minimum_length(1,2,false) or {
+				month_ = p.must_be_int_with_minimum_length(1, 2, false) or {
 					return error_invalid_time(0, 'end of string reached before the month was specified')
 				}
-				if month_<1 || month_>12 {
+				if month_ < 1 || month_ > 12 {
 					return error_invalid_time(0, 'month must be  between 1 and 12')
 				}
 			}
@@ -173,7 +175,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				month_ = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before the month was specified')
 				}
-				if month_<1 || month_>12 {
+				if month_ < 1 || month_ > 12 {
 					return error_invalid_time(0, 'month must be  between 01 and 12')
 				}
 			}
@@ -181,10 +183,10 @@ fn (mut p DateTimeParser) parse() !Time {
 				month_ = p.must_be_valid_month() or { return err }
 			}
 			'D' {
-				day_in_month = p.must_be_int_with_minimum_length(1,2,false) or {
+				day_in_month = p.must_be_int_with_minimum_length(1, 2, false) or {
 					return error_invalid_time(0, 'end of string reached before the day was specified')
 				}
-				if day_in_month<1 || day_in_month>31 {
+				if day_in_month < 1 || day_in_month > 31 {
 					return error_invalid_time(0, 'day must be  between 1 and 31')
 				}
 			}
@@ -192,15 +194,15 @@ fn (mut p DateTimeParser) parse() !Time {
 				day_in_month = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before the month was specified')
 				}
-				if day_in_month<1 || day_in_month>31 {
+				if day_in_month < 1 || day_in_month > 31 {
 					return error_invalid_time(0, 'day must be  between 01 and 31')
 				}
 			}
 			'H' {
-				hour_ = p.must_be_int_with_minimum_length(1,2,false) or {
+				hour_ = p.must_be_int_with_minimum_length(1, 2, false) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
-				if hour_<0 || hour_>23 {
+				if hour_ < 0 || hour_ > 23 {
 					return error_invalid_time(0, 'hour must be  between 0 and 23')
 				}
 			}
@@ -208,15 +210,15 @@ fn (mut p DateTimeParser) parse() !Time {
 				hour_ = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
-				if hour_<0 || hour_>23 {
+				if hour_ < 0 || hour_ > 23 {
 					return error_invalid_time(0, 'hour must be  between 00 and 23')
 				}
 			}
 			'h' {
-				hour_ = p.must_be_int_with_minimum_length(1,2,false) or {
+				hour_ = p.must_be_int_with_minimum_length(1, 2, false) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
-				if hour_<0 || hour_>23 {
+				if hour_ < 0 || hour_ > 23 {
 					return error_invalid_time(0, 'hour must be  between 0 and 23')
 				}
 			}
@@ -224,7 +226,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				hour_ = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
-				if hour_<0 || hour_>23 {
+				if hour_ < 0 || hour_ > 23 {
 					return error_invalid_time(0, 'hour must be  between 00 and 23')
 				}
 			}
@@ -232,7 +234,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				hour_ = p.must_be_int(1) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
-				if hour_<0 || hour_>23 {
+				if hour_ < 0 || hour_ > 23 {
 					return error_invalid_time(0, 'hour must be  between 0 and 23')
 				}
 			}
@@ -240,7 +242,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				hour_ = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
-				if hour_<0 || hour_>23 {
+				if hour_ < 0 || hour_ > 23 {
 					return error_invalid_time(0, 'hour must be  between 00 and 23')
 				}
 			}
@@ -248,7 +250,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				minute_ = p.must_be_int(1) or {
 					return error_invalid_time(0, 'end of string reached before minutes where specified')
 				}
-				if minute_<0 || minute_>59 {
+				if minute_ < 0 || minute_ > 59 {
 					return error_invalid_time(0, 'minute must be between 0 and 59')
 				}
 			}
@@ -256,7 +258,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				minute_ = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before minutes where specified')
 				}
-				if minute_<0 || minute_>59 {
+				if minute_ < 0 || minute_ > 59 {
 					return error_invalid_time(0, 'minute must be between 00 and 59')
 				}
 			}
@@ -264,7 +266,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				second_ = p.must_be_int(1) or {
 					return error_invalid_time(0, 'end of string reached before seconds where specified')
 				}
-				if second_<0 || second_>59 {
+				if second_ < 0 || second_ > 59 {
 					return error_invalid_time(0, 'second must be between 0 and 59')
 				}
 			}
@@ -272,7 +274,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				second_ = p.must_be_int(2) or {
 					return error_invalid_time(0, 'end of string reached before seconds where specified')
 				}
-				if second_<0 || second_>59 {
+				if second_ < 0 || second_ > 59 {
 					return error_invalid_time(0, 'second must be between 00 and 59')
 				}
 			}

--- a/vlib/time/datetime_parser.v
+++ b/vlib/time/datetime_parser.v
@@ -1,20 +1,20 @@
 module time
 
-pub struct DateTime_Parser {
+struct DateTime_Parser {
 	datetime string
 	format   string
 mut:
 	current_pos_datetime int
 }
 
-pub fn new_datetime_parser(datetime string, format string) DateTime_Parser {
+fn new_datetime_parser(datetime string, format string) DateTime_Parser {
 	return DateTime_Parser{
 		datetime: datetime
 		format: format
 	}
 }
 
-pub fn (mut p DateTime_Parser) next(length int) !string {
+fn (mut p DateTime_Parser) next(length int) !string {
 	if p.current_pos_datetime + length > p.datetime.len {
 		return error('end of string')
 	}
@@ -23,19 +23,19 @@ pub fn (mut p DateTime_Parser) next(length int) !string {
 	return val
 }
 
-pub fn (mut p DateTime_Parser) peek(length int) !string {
+fn (mut p DateTime_Parser) peek(length int) !string {
 	if p.current_pos_datetime + length > p.datetime.len {
 		return error('end of string')
 	}
 	return p.datetime[p.current_pos_datetime - length..p.current_pos_datetime]
 }
 
-pub fn (mut p DateTime_Parser) must_be_int(length int) !int {
+fn (mut p DateTime_Parser) must_be_int(length int) !int {
 	val := p.next(length) or { return err }
 	return val.int()
 }
 
-pub fn (mut p DateTime_Parser) must_be_single_int_with_optional_leading_zero() !int {
+fn (mut p DateTime_Parser) must_be_single_int_with_optional_leading_zero() !int {
 	mut val := p.next(1) or { return err }
 	if val == '0' {
 		val += p.next(1) or { return val.int() }
@@ -43,14 +43,14 @@ pub fn (mut p DateTime_Parser) must_be_single_int_with_optional_leading_zero() !
 	return val.int()
 }
 
-pub fn (mut p DateTime_Parser) must_be_string(must string) ! {
+fn (mut p DateTime_Parser) must_be_string(must string) ! {
 	val := p.next(must.len) or { return err }
 	if val != must {
 		return error('invalid string: "${val}"!="${must}"')
 	}
 }
 
-pub fn (mut p DateTime_Parser) must_be_string_one_of(oneof []string) !string {
+fn (mut p DateTime_Parser) must_be_string_one_of(oneof []string) !string {
 	for _, must in oneof {
 		val := p.peek(must.len) or { continue }
 		if val == must {
@@ -60,7 +60,7 @@ pub fn (mut p DateTime_Parser) must_be_string_one_of(oneof []string) !string {
 	return error('invalid string: must be one of ${oneof}, at ${p.current_pos_datetime}')
 }
 
-pub fn (mut p DateTime_Parser) must_be_valid_month() !int {
+fn (mut p DateTime_Parser) must_be_valid_month() !int {
 	for _, v in long_months {
 		if p.current_pos_datetime + v.len < p.datetime.len {
 			month_name := p.datetime[p.current_pos_datetime..p.current_pos_datetime + v.len]
@@ -73,7 +73,7 @@ pub fn (mut p DateTime_Parser) must_be_valid_month() !int {
 	return error_invalid_time(0, 'invalid month name')
 }
 
-pub fn (mut p DateTime_Parser) must_be_valid_week_day(letters int) !string {
+fn (mut p DateTime_Parser) must_be_valid_week_day(letters int) !string {
 	val := p.next(letters) or { return err }
 	for _, v in long_days {
 		if v[0..letters] == val {

--- a/vlib/time/datetime_parser.v
+++ b/vlib/time/datetime_parser.v
@@ -1,0 +1,212 @@
+module time
+
+pub struct DateTime_Parser {
+	datetime string
+	format   string
+mut:
+	current_pos_datetime int
+}
+
+pub fn new_datetime_parser(datetime string, format string) DateTime_Parser {
+	return DateTime_Parser{
+		datetime: datetime
+		format: format
+	}
+}
+
+pub fn (mut p DateTime_Parser) next(length int) !string {
+	if p.current_pos_datetime + length > p.datetime.len {
+		return error('end of string')
+	}
+	val := p.datetime[p.current_pos_datetime..p.current_pos_datetime + length]
+	p.current_pos_datetime += length
+	return val
+}
+
+pub fn (mut p DateTime_Parser) peek(length int) !string {
+	if p.current_pos_datetime + length > p.datetime.len {
+		return error('end of string')
+	}
+	return p.datetime[p.current_pos_datetime - length..p.current_pos_datetime]
+}
+
+pub fn (mut p DateTime_Parser) must_be_int(length int) !int {
+	val := p.next(length) or { return err }
+	return val.int()
+}
+
+pub fn (mut p DateTime_Parser) must_be_single_int_with_optional_leading_zero() !int {
+	mut val := p.next(1) or { return err }
+	if val == '0' {
+		val += p.next(1) or { return val.int() }
+	}
+	return val.int()
+}
+
+pub fn (mut p DateTime_Parser) must_be_string(must string) ! {
+	val := p.next(must.len) or { return err }
+	if val != must {
+		return error('invalid string: "${val}"!="${must}"')
+	}
+}
+
+pub fn (mut p DateTime_Parser) must_be_string_one_of(oneof []string) !string {
+	for _, must in oneof {
+		val := p.peek(must.len) or { continue }
+		if val == must {
+			return must
+		}
+	}
+	return error('invalid string: must be one of ${oneof}, at ${p.current_pos_datetime}')
+}
+
+pub fn (mut p DateTime_Parser) must_be_valid_month() !int {
+	for _, v in long_months {
+		if p.current_pos_datetime + v.len < p.datetime.len {
+			month_name := p.datetime[p.current_pos_datetime..p.current_pos_datetime + v.len]
+			if v == month_name {
+				p.current_pos_datetime += v.len
+				return long_months.index(month_name) + 1
+			}
+		}
+	}
+	return error_invalid_time(0, 'invalid month name')
+}
+
+pub fn (mut p DateTime_Parser) must_be_valid_week_day(letters int) !string {
+	val := p.next(letters) or { return err }
+	for _, v in long_days {
+		if v[0..letters] == val {
+			return v
+		}
+	}
+	return error_invalid_time(0, 'invalid month name')
+}
+
+fn extract_tokens(s string) ![]string {
+	mut tokens := []string{}
+	mut current := ''
+	for r in s {
+		if current.contains_only(r.ascii_str()) || current == '' {
+			current += r.ascii_str()
+		} else {
+			tokens << current
+			current = r.ascii_str()
+		}
+	}
+	if current != '' {
+		tokens << current
+	}
+	return tokens
+}
+
+fn (mut p DateTime_Parser) parse() !Time {
+	mut year_ := 0
+	mut month_ := 0
+	mut day_in_month := 0
+	mut hour_ := 0
+	mut minute_ := 0
+	mut second_ := 0
+	tokens := extract_tokens(p.format) or {
+		return error_invalid_time(0, 'malformed format string: ${err}')
+	}
+	for _, token in tokens {
+		match token {
+			'YYYY' {
+				year_ = p.must_be_int(4) or {
+					return error_invalid_time(0, 'end of string reached before the full year was specified')
+				}
+			}
+			'YY' {
+				year_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before the full year was specified')
+				}
+			}
+			'M' {
+				month_ = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before the month was specified')
+				}
+			}
+			'MM' {
+				month_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before the month was specified')
+				}
+			}
+			'MMMM' {
+				month_ = p.must_be_valid_month() or { return err }
+			}
+			'D' {
+				day_in_month = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before the month was specified')
+				}
+			}
+			'DD' {
+				day_in_month = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before the month was specified')
+				}
+			}
+			'H' {
+				hour_ = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before hours where specified')
+				}
+			}
+			'HH' {
+				hour_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before hours where specified')
+				}
+			}
+			'h' {
+				hour_ = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before hours where specified')
+				}
+			}
+			'hh' {
+				hour_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before hours where specified')
+				}
+			}
+			'k' {
+				hour_ = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before hours where specified')
+				}
+			}
+			'kk' {
+				hour_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before hours where specified')
+				}
+			}
+			'm' {
+				minute_ = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before minutes where specified')
+				}
+			}
+			'mm' {
+				minute_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before minutes where specified')
+				}
+			}
+			's' {
+				second_ = p.must_be_int(1) or {
+					return error_invalid_time(0, 'end of string reached before seconds where specified')
+				}
+			}
+			'ss' {
+				second_ = p.must_be_int(2) or {
+					return error_invalid_time(0, 'end of string reached before seconds where specified')
+				}
+			}
+			else {
+				p.must_be_string(token) or { return error_invalid_time(0, '${err}') }
+			}
+		}
+	}
+
+	return new_time(
+		year: year_
+		month: month_
+		day: day_in_month
+		hour: hour_
+		minute: minute_
+		second: second_
+	)
+}

--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -115,6 +115,24 @@ pub fn parse(s string) !Time {
 	return res
 }
 
+// parse_format parses the string `s`, as a custom `format`, containing the following specifiers:
+// YYYY - 4 digit year, 0000..9999
+// YY - 2 digit year, 00..99
+// M - month, 1..12
+// MM - month, 2 digits, 01..12
+// MMMM - name of month
+// D - day of the month, 1..31
+// DD - day of the month, 01..31
+// H - hour, 0..23
+// HH - hour, 00..23
+// h - hour, 0..23
+// hh - hour, 0..23
+// k - hour, 0..23
+// kk - hour, 0..23
+// m - minute, 0..59
+// mm - minute, 0..59
+// s - second, 0..59
+// ss - second, 0..59
 pub fn parse_format(s string, format string) !Time {
 	if s == '' {
 		return error_invalid_time(0, 'datetime string is empty')

--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -137,7 +137,7 @@ pub fn parse_format(s string, format string) !Time {
 	if s == '' {
 		return error_invalid_time(0, 'datetime string is empty')
 	}
-	mut p := new_datetime_parser(s, format)
+	mut p := new_date_time_parser(s, format)
 	return p.parse()
 }
 

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -6,16 +6,18 @@ module time
 // TimeParseError represents a time parsing error.
 pub struct TimeParseError {
 	Error
-	code int
+	code    int
+	message string
 }
 
 // msg implements the `IError.msg()` method for `TimeParseError`.
 pub fn (err TimeParseError) msg() string {
-	return 'Invalid time format code: ${err.code}'
+	return 'Invalid time format code: ${err.code}, error: ${err.message}'
 }
 
-fn error_invalid_time(code int) IError {
+fn error_invalid_time(code int, message string) IError {
 	return TimeParseError{
 		code: code
+		message: message
 	}
 }

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -230,4 +230,12 @@ fn test_parse_format() {
 	}
 	assert t.year == 2018 && t.month == 1 && t.day == 2 && t.hour == 1 && t.minute == 8
 		&& t.second == 2
+
+	//This should always fail, because we test if M and D allow for a 01 value which they shouldn't
+	s = '2018-01-02 1:8:2'
+	t = time.parse_format(s, 'YYYY-M-D H:m:s') or {				
+		return
+	}
+	eprintln('> failing for datetime: ${s}, the datetime string should not have passed the format "YYYY-M-D H:m:s"')	
+	assert false
 }

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -201,3 +201,33 @@ fn test_ad_second_to_parse_result_pre_2001() {
 	assert future_tm.str() == '2000-01-01 04:01:00'
 	assert now_tm.unix < future_tm.unix
 }
+
+fn test_parse_format() {
+	mut s := '2018-01-27 12:48:34'
+	mut t := time.parse_format(s, 'YYYY-MM-DD HH:mm:ss') or {
+		eprintln('> failing format: ${s} | err: ${err}')
+		assert false
+		return
+	}
+
+	assert t.year == 2018 && t.month == 1 && t.day == 27 && t.hour == 12 && t.minute == 48
+		&& t.second == 34
+
+	s = '2018-November-27 12:48:20'
+	t = time.parse_format(s, 'YYYY-MMMM-DD HH:mm:ss') or {
+		eprintln('> failing format: ${s} | err: ${err}')
+		assert false
+		return
+	}
+	assert t.year == 2018 && t.month == 11 && t.day == 27 && t.hour == 12 && t.minute == 48
+		&& t.second == 20
+
+	s = '2018-1-2 1:8:2'
+	t = time.parse_format(s, 'YYYY-M-D H:m:s') or {
+		eprintln('> failing format: ${s} | err: ${err}')
+		assert false
+		return
+	}
+	assert t.year == 2018 && t.month == 1 && t.day == 2 && t.hour == 1 && t.minute == 8
+		&& t.second == 2
+}

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -231,11 +231,9 @@ fn test_parse_format() {
 	assert t.year == 2018 && t.month == 1 && t.day == 2 && t.hour == 1 && t.minute == 8
 		&& t.second == 2
 
-	//This should always fail, because we test if M and D allow for a 01 value which they shouldn't
+	// This should always fail, because we test if M and D allow for a 01 value which they shouldn't
 	s = '2018-01-02 1:8:2'
-	t = time.parse_format(s, 'YYYY-M-D H:m:s') or {				
-		return
-	}
-	eprintln('> failing for datetime: ${s}, the datetime string should not have passed the format "YYYY-M-D H:m:s"')	
+	t = time.parse_format(s, 'YYYY-M-D H:m:s') or { return }
+	eprintln('> failing for datetime: ${s}, the datetime string should not have passed the format "YYYY-M-D H:m:s"')
 	assert false
 }

--- a/vlib/time/time.js.v
+++ b/vlib/time/time.js.v
@@ -43,6 +43,24 @@ pub fn sleep(dur Duration) {
 	#while (new Date().getTime() < now + Number(toWait)) {}
 }
 
+// new_time returns a time struct with calculated Unix time.
+pub fn new_time(t Time) Time {
+	if t.unix != 0 {
+		return t
+	}
+	mut res := Time{}
+	#res.year.val = t.year.val
+	#res.month.val = t.month.val
+	#res.day.val = t.day.val
+	#res.hour.val = t.hour.val
+	#res.minute.val = t.minute.val
+	#res.second.val = t.second.val
+	#res.microsecond.val = t.microsecond.val
+	#res.unix.val = t.unix.val
+
+	return res
+}
+
 pub fn ticks() i64 {
 	t := i64(0)
 	#t.val = BigInt(new Date().getTime())


### PR DESCRIPTION
Add an incomplete parser for the datetime string format used for the formatting of a time struct.
I'm not sure if this is alright for performance, but the parser is written to be easy to understand and reason about.

While adding the parser it was difficult for me to debug the generated errors without a detailed error message, so also added a message field to the time_error struct to better describe the error.
I also don't know if the error code I choose was right.

Running v test vlib/time succeds, but running v test-all fails with the following methods not found:
 str.contains_only, new_time.


<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b79228</samp>

This pull request refactors and improves the time parsing functionality in the `time` module by adding a new file `vlib/time/datetime_parser.v` that defines a struct and methods for parsing datetime strings with different formats, a new function `parse_format` that allows custom format strings, and more descriptive error messages for invalid input cases. It also adds a new test function `test_parse_format` in `vlib/time/parse_test.v` to ensure the correctness and quality of the new feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b79228</samp>

*  Add a new file `vlib/time/datetime_parser.v` that defines a struct and methods for parsing datetime strings with different formats ([link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-d836f01e54c1a4c57f9023b8940c07a4e5da7e5d367e63eec9abafc37e84bbc4R1-R212))
*  Add a new function `parse_format` in `vlib/time/datetime_parser.v` that allows parsing datetime strings with a custom format string ([link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bR118-R125))
*  Modify the `parse_rfc3339`, `parse_iso8601`, and `parse_rfc2822` functions in `vlib/time/datetime_parser.v` to include more descriptive error messages when the input string is empty, malformed, or has invalid or missing components ([link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL11-R11), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL57-R57), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL63-R76), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL88-R105), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL123-R138), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL160-R178), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL181-R202), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL237-R249), [link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL243-R258))
*  Modify the `TimeParseError` struct and the `error_invalid_time` function in `vlib/time/datetime_parser.v` to include a message field that stores the specific error message for each error code ([link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-68544ad8b77d2774101756528c5aac2fe327b270ff8c36eaf25b9ae086e1f31eL9-R21))
*  Add a new test function `test_parse_format` in `vlib/time/parse_test.v` that tests the functionality of the new `parse_format` function with different input and format strings ([link](https://github.com/vlang/v/pull/18257/files?diff=unified&w=0#diff-41cf851b04082ae4fa760e219eece2f84546b5d928d620b22593982693a7cc91R204-R233))
