### PR TITLE
os: fix truncate() on windows

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -101,11 +101,10 @@ pub fn open_file(path string, mode string, options ...int) !File {
 		}
 	}
 	p := fix_windows_path(path)
-	mut fd := 0
-	$if windows {
-		fd = C._wopen(p.to_wide(), flags, permission)
+	fd := $if windows {
+		C._wopen(p.to_wide(), flags, permission)
 	} $else {
-		fd = C.open(&char(p.str), flags, permission)
+		C.open(&char(p.str), flags, permission)
 	}
 	if fd == -1 {
 		return error(posix_get_error_msg(C.errno))

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -447,5 +447,9 @@ fn test_open_file_on_chinese_windows() {
 		f1.close()
 
 		assert os.read_file('中文.txt')! == 'test'
+		assert os.file_size('中文.txt') == 4
+
+		os.truncate('中文.txt', 2)!
+		assert os.file_size('中文.txt') == 2
 	}
 }

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -147,12 +147,16 @@ pub fn read_file(path string) !string {
 // truncate changes the size of the file located in `path` to `len`.
 // Note that changing symbolic links on Windows only works as admin.
 pub fn truncate(path string, len u64) ! {
-	fp := C.open(&char(path.str), o_wronly | o_trunc, 0)
-	defer {
-		C.close(fp)
+	fp := $if windows {
+		C._wopen(path.to_wide(), o_wronly | o_trunc, 0)
+	} $else {
+		C.open(&char(path.str), o_wronly | o_trunc, 0)
 	}
 	if fp < 0 {
 		return error_with_code(posix_get_error_msg(C.errno), C.errno)
+	}
+	defer {
+		C.close(fp)
 	}
 	$if windows {
 		if C._chsize_s(fp, len) != 0 {


### PR DESCRIPTION
This PR fix truncate() on windows.

- Fix os.truncate() on windows with Chinese path name.
- Add test.

```v
import os

fn main() {
	mut f1 := os.open_file('中文.txt', 'w+', 0x666) or { panic(err) }
	f1.write_string('test')!
	f1.close()

	assert os.read_file('中文.txt')! == 'test'

	l1 := os.file_size('中文.txt')
	println(l1)
	os.truncate('中文.txt', 2)!

	l2 := os.file_size('中文.txt')
	println(l2)
}

PS D:\Test\v\tt1> v run .
4
2
```