### PR TITLE
checker: adjust fix for struct anon assigning to typed struct

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -698,7 +698,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
-		if left_sym.kind == .struct_ && right is ast.StructInit && (right as ast.StructInit).is_anon {
+		if left_sym.kind == .struct_ && !(left_sym.info as ast.Struct).is_anon
+			&& right is ast.StructInit && (right as ast.StructInit).is_anon {
 			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
 		}
 	}

--- a/vlib/v/tests/anon_struct_assign_test.v
+++ b/vlib/v/tests/anon_struct_assign_test.v
@@ -1,0 +1,14 @@
+struct Parent {
+mut:
+	val   string
+	child struct {
+	mut:
+		val string
+	}
+}
+
+fn test_main() {
+	mut p := Parent{}
+	p.child = struct {'abc'}
+	assert p.child == struct {'abc'}
+}


### PR DESCRIPTION
Fix #18261

copilot:summary

copilot:walkthrough
