### PR TITLE
cgen, orm: fix typo, and wrap the `fkey` attribute into quotes in errors.

### DIFF
--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -283,12 +283,12 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 					if attr.kind == .string {
 						f_key = attr.arg
 					} else {
-						verror("fkey attribute need be string. Try [fkey: '${attr.arg}'] instead of [fkey: ${attr.arg}]")
+						verror("`fkey` attribute need be string. Try [fkey: '${attr.arg}'] instead of [fkey: ${attr.arg}]")
 					}
 				}
 			}
 			if f_key == '' {
-				verror('a field which holds an array, needs a fkey defined ("${sym.name}")')
+				verror('a field which holds an array, needs a `fkey` defined ("${sym.name}")')
 			}
 			fkeys << f_key
 			info := sym.array_info()
@@ -905,13 +905,13 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, le
 						if attr.kind == .string {
 							fkey = attr.arg
 						} else {
-							verror("fkey attribute need be string. Try [fkey: '${attr.arg}'] instead of [fkey: ${attr.arg}]")
+							verror("`fkey` attribute need be string. Try [fkey: '${attr.arg}'] instead of [fkey: ${attr.arg}]")
 						}
 					}
 				}
 				// TODO: move to the ORM checker
 				if fkey == '' {
-					verror('fn field which holds an array, needs a `fkey` defined ("${sym.name}")')
+					verror('a field which holds an array, needs a `fkey` defined ("${sym.name}")')
 				}
 				info := sym.array_info()
 				arr_typ := info.elem_type


### PR DESCRIPTION
Fix the typo after c45c36cccec80b9a7388c5af678fb922bd00cb53.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa0e0d8</samp>

Improve error messages for ORM code generator in `vlib/v/gen/c/orm.v` by formatting code literals and fixing a typo.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa0e0d8</samp>

*  Add backticks around `fkey` attribute in error messages for clarity and consistency ([link](https://github.com/vlang/v/pull/18266/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L286-R291), [link](https://github.com/vlang/v/pull/18266/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L908-R908))
*  Correct typo in error message, changing "fn" to "a" ([link](https://github.com/vlang/v/pull/18266/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L914-R914))
