### PR TITLE
mysql: add the ability to commit transactions, some code improvements.

### DIFF
--- a/vlib/db/mysql/_cdefs.c.v
+++ b/vlib/db/mysql/_cdefs.c.v
@@ -80,7 +80,10 @@ fn C.mysql_num_fields(res &C.MYSQL_RES) int
 fn C.mysql_num_rows(res &C.MYSQL_RES) u64
 
 // C.mysql_autocommit sets autocommit mode on if `mode` is 1, off if `mode` is 0.
-fn C.mysql_autocommit(mysql &C.MYSQL, mode bool)
+fn C.mysql_autocommit(mysql &C.MYSQL, mode bool) int
+
+// C.mysql_commit commits the current transaction.
+fn C.mysql_commit(mysql &C.MYSQL) int
 
 // C.mysql_refresh flush tables or caches, or resets replication server information.
 fn C.mysql_refresh(mysql &C.MYSQL, options u32) int

--- a/vlib/db/mysql/mysql.v
+++ b/vlib/db/mysql/mysql.v
@@ -34,13 +34,13 @@ pub mut:
 }
 
 // connect attempts to establish a connection to a MySQL server.
-pub fn (mut conn Connection) connect() !bool {
-	instance := C.mysql_init(conn.conn)
-	conn.conn = C.mysql_real_connect(instance, conn.host.str, conn.username.str, conn.password.str,
-		conn.dbname.str, conn.port, 0, conn.flag)
+pub fn (mut c Connection) connect() !bool {
+	instance := C.mysql_init(c.conn)
+	c.conn = C.mysql_real_connect(instance, c.host.str, c.username.str, c.password.str,
+		c.dbname.str, c.port, 0, c.flag)
 
-	if isnil(conn.conn) {
-		return error_with_code(get_error_msg(instance), get_errno(instance))
+	if isnil(c.conn) {
+		c.throw_mysql_error()!
 	}
 
 	return true
@@ -49,12 +49,12 @@ pub fn (mut conn Connection) connect() !bool {
 // query executes the SQL statement pointed to by the string `q`.
 // It cannot be used for statements that contain binary data;
 // Use `real_query()` instead.
-pub fn (conn Connection) query(q string) !Result {
-	if C.mysql_query(conn.conn, q.str) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (c &Connection) query(q string) !Result {
+	if C.mysql_query(c.conn, q.str) != 0 {
+		c.throw_mysql_error()!
 	}
 
-	result := C.mysql_store_result(conn.conn)
+	result := C.mysql_store_result(c.conn)
 	return Result{result}
 }
 
@@ -66,8 +66,8 @@ pub fn (conn Connection) query(q string) !Result {
 // without storing it in a temporary table or local buffer,
 // mysql_use_result is faster and uses much less memory than C.mysql_store_result().
 // You must mysql_free_result() after you are done with the result set.
-pub fn (conn Connection) use_result() {
-	C.mysql_use_result(conn.conn)
+pub fn (c &Connection) use_result() {
+	C.mysql_use_result(c.conn)
 }
 
 // real_query makes an SQL query and receive the results.
@@ -75,20 +75,20 @@ pub fn (conn Connection) use_result() {
 // (Binary data may contain the `\0` character, which `query()`
 // interprets as the end of the statement string). In addition,
 // `real_query()` is faster than `query()`.
-pub fn (mut conn Connection) real_query(q string) !Result {
-	if C.mysql_real_query(conn.conn, q.str, q.len) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (mut c Connection) real_query(q string) !Result {
+	if C.mysql_real_query(c.conn, q.str, q.len) != 0 {
+		c.throw_mysql_error()!
 	}
 
-	result := C.mysql_store_result(conn.conn)
+	result := C.mysql_store_result(c.conn)
 	return Result{result}
 }
 
 // select_db causes the database specified by `db` to become
 // the default (current) database on the connection specified by mysql.
-pub fn (mut conn Connection) select_db(dbname string) !bool {
-	if C.mysql_select_db(conn.conn, dbname.str) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (mut c Connection) select_db(dbname string) !bool {
+	if C.mysql_select_db(c.conn, dbname.str) != 0 {
+		c.throw_mysql_error()!
 	}
 
 	return true
@@ -97,16 +97,16 @@ pub fn (mut conn Connection) select_db(dbname string) !bool {
 // change_user changes the mysql user for the connection.
 // Passing an empty string for the `dbname` parameter, resultsg in only changing
 // the user and not changing the default database for the connection.
-pub fn (mut conn Connection) change_user(username string, password string, dbname string) !bool {
+pub fn (mut c Connection) change_user(username string, password string, dbname string) !bool {
 	mut result := true
 
 	if dbname != '' {
-		result = C.mysql_change_user(conn.conn, username.str, password.str, dbname.str)
+		result = C.mysql_change_user(c.conn, username.str, password.str, dbname.str)
 	} else {
-		result = C.mysql_change_user(conn.conn, username.str, password.str, 0)
+		result = C.mysql_change_user(c.conn, username.str, password.str, 0)
 	}
 	if !result {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+		c.throw_mysql_error()!
 	}
 
 	return result
@@ -114,14 +114,29 @@ pub fn (mut conn Connection) change_user(username string, password string, dbnam
 
 // affected_rows returns the number of rows changed, deleted,
 // or inserted by the last statement if it was an `UPDATE`, `DELETE`, or `INSERT`.
-pub fn (conn &Connection) affected_rows() u64 {
-	return C.mysql_affected_rows(conn.conn)
+pub fn (c &Connection) affected_rows() u64 {
+	return C.mysql_affected_rows(c.conn)
 }
 
 // autocommit turns on/off the auto-committing mode for the connection.
 // When it is on, then each query is committed right away.
-pub fn (mut conn Connection) autocommit(mode bool) {
-	C.mysql_autocommit(conn.conn, mode)
+pub fn (mut c Connection) autocommit(mode bool) ! {
+	c.check_connection_is_established()!
+	result := C.mysql_autocommit(c.conn, mode)
+
+	if result != 0 {
+		c.throw_mysql_error()!
+	}
+}
+
+// commit commits the current transaction.
+pub fn (c &Connection) commit() ! {
+	c.check_connection_is_established()!
+	result := C.mysql_commit(c.conn)
+
+	if result != 0 {
+		c.throw_mysql_error()!
+	}
 }
 
 // tables returns a list of the names of the tables in the current database,
@@ -129,10 +144,10 @@ pub fn (mut conn Connection) autocommit(mode bool) {
 // The `wildcard` parameter may contain the wildcard characters `%` or `_`.
 // If an empty string is passed, it will return all tables.
 // Calling `tables()` is similar to executing query `SHOW TABLES [LIKE wildcard]`.
-pub fn (conn &Connection) tables(wildcard string) ![]string {
-	c_mysql_result := C.mysql_list_tables(conn.conn, wildcard.str)
+pub fn (c &Connection) tables(wildcard string) ![]string {
+	c_mysql_result := C.mysql_list_tables(c.conn, wildcard.str)
 	if isnil(c_mysql_result) {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+		c.throw_mysql_error()!
 	}
 
 	result := Result{c_mysql_result}
@@ -148,10 +163,10 @@ pub fn (conn &Connection) tables(wildcard string) ![]string {
 // escape_string creates a legal SQL string for use in an SQL statement.
 // The `s` argument is encoded to produce an escaped SQL string,
 // taking into account the current character set of the connection.
-pub fn (conn &Connection) escape_string(s string) string {
+pub fn (c &Connection) escape_string(s string) string {
 	unsafe {
 		to := malloc_noscan(2 * s.len + 1)
-		C.mysql_real_escape_string(conn.conn, to, s.str, s.len)
+		C.mysql_real_escape_string(c.conn, to, s.str, s.len)
 		return to.vstring()
 	}
 }
@@ -159,16 +174,16 @@ pub fn (conn &Connection) escape_string(s string) string {
 // set_option sets extra connect options that affect the behavior of
 // a connection. This function may be called multiple times to set several
 // options. To retrieve the current values for an option, use `get_option()`.
-pub fn (mut conn Connection) set_option(option_type int, val voidptr) {
-	C.mysql_options(conn.conn, option_type, val)
+pub fn (mut c Connection) set_option(option_type int, val voidptr) {
+	C.mysql_options(c.conn, option_type, val)
 }
 
 // get_option returns the value of an option, settable by `set_option`.
 // https://dev.mysql.com/doc/c-api/5.7/en/mysql-get-option.html
-pub fn (conn &Connection) get_option(option_type int) !voidptr {
+pub fn (c &Connection) get_option(option_type int) !voidptr {
 	mysql_option := unsafe { nil }
-	if C.mysql_get_option(conn.conn, option_type, &mysql_option) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+	if C.mysql_get_option(c.conn, option_type, &mysql_option) != 0 {
+		c.throw_mysql_error()!
 	}
 
 	return mysql_option
@@ -176,18 +191,18 @@ pub fn (conn &Connection) get_option(option_type int) !voidptr {
 
 // refresh flush the tables or caches, or resets replication server
 // information. The connected user must have the `RELOAD` privilege.
-pub fn (mut conn Connection) refresh(options u32) !bool {
-	if C.mysql_refresh(conn.conn, options) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (mut c Connection) refresh(options u32) !bool {
+	if C.mysql_refresh(c.conn, options) != 0 {
+		c.throw_mysql_error()!
 	}
 
 	return true
 }
 
 // reset resets the connection, and clear the session state.
-pub fn (mut conn Connection) reset() !bool {
-	if C.mysql_reset_connection(conn.conn) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (mut c Connection) reset() !bool {
+	if C.mysql_reset_connection(c.conn) != 0 {
+		c.throw_mysql_error()!
 	}
 
 	return true
@@ -195,50 +210,50 @@ pub fn (mut conn Connection) reset() !bool {
 
 // ping pings a server connection, or tries to reconnect if the connection
 // has gone down.
-pub fn (mut conn Connection) ping() !bool {
-	if C.mysql_ping(conn.conn) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (mut c Connection) ping() !bool {
+	if C.mysql_ping(c.conn) != 0 {
+		c.throw_mysql_error()!
 	}
 
 	return true
 }
 
 // close closes the connection.
-pub fn (mut conn Connection) close() {
-	C.mysql_close(conn.conn)
+pub fn (mut c Connection) close() {
+	C.mysql_close(c.conn)
 }
 
 // info returns information about the most recently executed query.
 // See more on https://dev.mysql.com/doc/c-api/8.0/en/mysql-info.html
-pub fn (conn &Connection) info() string {
-	return resolve_nil_str(C.mysql_info(conn.conn))
+pub fn (c &Connection) info() string {
+	return resolve_nil_str(C.mysql_info(c.conn))
 }
 
 // get_host_info returns a string describing the type of connection in use,
 // including the server host name.
-pub fn (conn &Connection) get_host_info() string {
-	return unsafe { C.mysql_get_host_info(conn.conn).vstring() }
+pub fn (c &Connection) get_host_info() string {
+	return unsafe { C.mysql_get_host_info(c.conn).vstring() }
 }
 
 // get_server_info returns a string representing the MySQL server version.
 // For example, `8.0.24`.
-pub fn (conn &Connection) get_server_info() string {
-	return unsafe { C.mysql_get_server_info(conn.conn).vstring() }
+pub fn (c &Connection) get_server_info() string {
+	return unsafe { C.mysql_get_server_info(c.conn).vstring() }
 }
 
 // get_server_version returns an integer, representing the MySQL server
 // version. The value has the format `XYYZZ` where `X` is the major version,
 // `YY` is the release level (or minor version), and `ZZ` is the sub-version
 // within the release level. For example, `8.0.24` is returned as `80024`.
-pub fn (conn &Connection) get_server_version() u64 {
-	return C.mysql_get_server_version(conn.conn)
+pub fn (c &Connection) get_server_version() u64 {
+	return C.mysql_get_server_version(c.conn)
 }
 
 // dump_debug_info instructs the server to write debugging information
 // to the error log. The connected user must have the `SUPER` privilege.
-pub fn (mut conn Connection) dump_debug_info() !bool {
-	if C.mysql_dump_debug_info(conn.conn) != 0 {
-		return error_with_code(get_error_msg(conn.conn), get_errno(conn.conn))
+pub fn (mut c Connection) dump_debug_info() !bool {
+	if C.mysql_dump_debug_info(c.conn) != 0 {
+		c.throw_mysql_error()!
 	}
 
 	return true
@@ -260,4 +275,16 @@ pub fn get_client_version() u64 {
 // See https://dev.mysql.com/doc/c-api/8.0/en/mysql-debug.html
 pub fn debug(debug string) {
 	C.mysql_debug(debug.str)
+}
+
+[inline]
+fn (c &Connection) throw_mysql_error() ! {
+	return error_with_code(get_error_msg(c.conn), get_errno(c.conn))
+}
+
+[inline]
+fn (c &Connection) check_connection_is_established() ! {
+	if isnil(c.conn) {
+		return error('No connection to a MySQL server, use `connect()` to connect to a database for working with it')
+	}
 }


### PR DESCRIPTION
Fixes #17771

Check if the connection is not null before using in commit methods to avoid segfaults. Improve the code to eliminate redundant code duplication in multiple places.

Example of usage:
```v
db.autocommit(false)!

sql db {
	create table Task
}!

task_model := Task{
	title: 'Commits'
}

sql db {
	insert task_model into Task
	insert task_model into Task
	insert task_model into Task
	insert task_model into Task
	insert task_model into Task
	insert task_model into Task
}!

db.commit()!
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c922a3</samp>

Refactored the MySQL module to use a separate file for C definitions and added support for transactions with `commit` and `mysql_autocommit` functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c922a3</samp>

*  Change the return type of `mysql_autocommit` to `int` and add `mysql_commit` function to expose the C API for transactions ([link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-cc0bddeb65a2708d9d0013fdf8bddbbaca429d8fb10e554e3fd3eb7ee1e6e049L83-R87))
* Move all the C functions from `vlib/db/mysql/mysql.v` to `vlib/db/mysql/_cdefs.c.v` and use `throw_mysql_error` and `check_connection_is_established` helpers for error handling and connection checking ([link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L37-R43), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L52-R57), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L69-R70), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L78-R83), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L89-R91), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L100-R109), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L117-R141), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L132-R150), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L151-R169), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L162-R186), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L179-R196), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L188-R205), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L198-R215), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L207-R241), [link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188L233-R256))
* Add `throw_mysql_error` and `check_connection_is_established` helpers to `vlib/db/mysql/mysql.v` to simplify the error handling and connection checking logic for the C functions ([link](https://github.com/vlang/v/pull/18268/files?diff=unified&w=0#diff-177365dcf53db17c17932ab512767f1e1d0baf48366481fe899bca229f243188R279-R290))
