### PR TITLE
semver: refactor, simplify, fix typo

### DIFF
--- a/vlib/semver/compare.v
+++ b/vlib/semver/compare.v
@@ -3,7 +3,8 @@ module semver
 // * Private functions.
 [inline]
 fn version_satisfies(ver Version, input string) bool {
-	return parse_range(input) or { return false }.satisfies(ver)
+	range := parse_range(input) or { return false }
+	return range.satisfies(ver)
 }
 
 fn compare_eq(v1 Version, v2 Version) bool {

--- a/vlib/semver/compare.v
+++ b/vlib/semver/compare.v
@@ -3,8 +3,7 @@ module semver
 // * Private functions.
 [inline]
 fn version_satisfies(ver Version, input string) bool {
-	range := parse_range(input) or { return false }
-	return range.satisfies(ver)
+	return parse_range(input) or { return false }.satisfies(ver)
 }
 
 fn compare_eq(v1 Version, v2 Version) bool {
@@ -13,47 +12,29 @@ fn compare_eq(v1 Version, v2 Version) bool {
 }
 
 fn compare_gt(v1 Version, v2 Version) bool {
-	if v1.major < v2.major {
-		return false
+	return match true {
+		v1.major < v2.major { false }
+		v1.major > v2.major { true }
+		v1.minor < v2.minor { false }
+		v1.minor > v2.minor { true }
+		else { v1.patch > v2.patch }
 	}
-	if v1.major > v2.major {
-		return true
-	}
-	if v1.minor < v2.minor {
-		return false
-	}
-	if v1.minor > v2.minor {
-		return true
-	}
-	return v1.patch > v2.patch
 }
 
 fn compare_lt(v1 Version, v2 Version) bool {
-	if v1.major > v2.major {
-		return false
+	return match true {
+		v1.major > v2.major { false }
+		v1.major < v2.major { true }
+		v1.minor > v2.minor { false }
+		v1.minor < v2.minor { true }
+		else { v1.patch < v2.patch }
 	}
-	if v1.major < v2.major {
-		return true
-	}
-	if v1.minor > v2.minor {
-		return false
-	}
-	if v1.minor < v2.minor {
-		return true
-	}
-	return v1.patch < v2.patch
 }
 
 fn compare_ge(v1 Version, v2 Version) bool {
-	if compare_eq(v1, v2) {
-		return true
-	}
-	return compare_gt(v1, v2)
+	return if compare_eq(v1, v2) { true } else { compare_gt(v1, v2) }
 }
 
 fn compare_le(v1 Version, v2 Version) bool {
-	if compare_eq(v1, v2) {
-		return true
-	}
-	return compare_lt(v1, v2)
+	return if compare_eq(v1, v2) { true } else { compare_lt(v1, v2) }
 }

--- a/vlib/semver/parse.v
+++ b/vlib/semver/parse.v
@@ -74,7 +74,10 @@ fn (raw_ver RawVersion) complete() RawVersion {
 }
 
 fn (raw_ver RawVersion) validate() ?Version {
-	return if !raw_ver.is_valid() { none } else { raw_ver.to_version() }
+	if !raw_ver.is_valid() {
+		return none
+	}
+	return raw_ver.to_version()
 }
 
 fn (raw_ver RawVersion) to_version() Version {

--- a/vlib/semver/parse.v
+++ b/vlib/semver/parse.v
@@ -74,10 +74,7 @@ fn (raw_ver RawVersion) complete() RawVersion {
 }
 
 fn (raw_ver RawVersion) validate() ?Version {
-	if !raw_ver.is_valid() {
-		return none
-	}
-	return raw_ver.to_version()
+	return if !raw_ver.is_valid() { none } else { raw_ver.to_version() }
 }
 
 fn (raw_ver RawVersion) to_version() Version {

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -142,7 +142,10 @@ fn parse_xrange(input string) ?Version {
 			else {}
 		}
 	}
-	return if !raw_ver.is_valid() { none } else { raw_ver.to_version() }
+	if !raw_ver.is_valid() {
+		return none
+	}
+	return raw_ver.to_version()
 }
 
 fn can_expand(input string) bool {

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -34,11 +34,7 @@ struct InvalidComparatorFormatError {
 }
 
 fn (r Range) satisfies(ver Version) bool {
-	mut final_result := false
-	for set in r.comparator_sets {
-		final_result = final_result || set.satisfies(ver)
-	}
-	return final_result
+	return true in r.comparator_sets.map(it.satisfies(ver))
 }
 
 fn (set ComparatorSet) satisfies(ver Version) bool {
@@ -51,22 +47,13 @@ fn (set ComparatorSet) satisfies(ver Version) bool {
 }
 
 fn (c Comparator) satisfies(ver Version) bool {
-	if c.op == .gt {
-		return ver.gt(c.ver)
+	return match c.op {
+		.gt { ver.gt(c.ver) }
+		.lt { ver.lt(c.ver) }
+		.ge { ver.ge(c.ver) }
+		.le { ver.le(c.ver) }
+		.eq { ver.eq(c.ver) }
 	}
-	if c.op == .lt {
-		return ver.lt(c.ver)
-	}
-	if c.op == .ge {
-		return ver.ge(c.ver)
-	}
-	if c.op == .le {
-		return ver.le(c.ver)
-	}
-	if c.op == .eq {
-		return ver.eq(c.ver)
-	}
-	return false
 }
 
 fn parse_range(input string) !Range {
@@ -105,23 +92,29 @@ fn parse_comparator_set(input string) !ComparatorSet {
 
 fn parse_comparator(input string) ?Comparator {
 	mut op := Operator.eq
-	mut raw_version := ''
-	if input.starts_with('>=') {
-		op = .ge
-		raw_version = input[2..]
-	} else if input.starts_with('<=') {
-		op = .le
-		raw_version = input[2..]
-	} else if input.starts_with('>') {
-		op = .gt
-		raw_version = input[1..]
-	} else if input.starts_with('<') {
-		op = .lt
-		raw_version = input[1..]
-	} else if input.starts_with('=') {
-		raw_version = input[1..]
-	} else {
-		raw_version = input
+	raw_version := match true {
+		input.starts_with('>=') {
+			op = .ge
+			input[2..]
+		}
+		input.starts_with('<=') {
+			op = .le
+			input[2..]
+		}
+		input.starts_with('>') {
+			op = .gt
+			input[1..]
+		}
+		input.starts_with('<') {
+			op = .lt
+			input[1..]
+		}
+		input.starts_with('=') {
+			input[1..]
+		}
+		else {
+			input
+		}
 	}
 	version := coerce_version(raw_version) or { return none }
 	return Comparator{version, op}
@@ -149,10 +142,7 @@ fn parse_xrange(input string) ?Version {
 			else {}
 		}
 	}
-	if !raw_ver.is_valid() {
-		return none
-	}
-	return raw_ver.to_version()
+	return if !raw_ver.is_valid() { none } else { raw_ver.to_version() }
 }
 
 fn can_expand(input string) bool {
@@ -174,22 +164,20 @@ fn expand_comparator_set(input string) ?ComparatorSet {
 
 fn expand_tilda(raw_version string) ?ComparatorSet {
 	min_ver := coerce_version(raw_version) or { return none }
-	mut max_ver := min_ver
-	if min_ver.minor == 0 && min_ver.patch == 0 {
-		max_ver = min_ver.increment(.major)
+	max_ver := if min_ver.minor == 0 && min_ver.patch == 0 {
+		min_ver.increment(.major)
 	} else {
-		max_ver = min_ver.increment(.minor)
+		min_ver.increment(.minor)
 	}
 	return make_comparator_set_ge_lt(min_ver, max_ver)
 }
 
 fn expand_caret(raw_version string) ?ComparatorSet {
 	min_ver := coerce_version(raw_version) or { return none }
-	mut max_ver := min_ver
-	if min_ver.major == 0 {
-		max_ver = min_ver.increment(.minor)
+	max_ver := if min_ver.major == 0 {
+		min_ver.increment(.minor)
 	} else {
-		max_ver = min_ver.increment(.major)
+		min_ver.increment(.major)
 	}
 	return make_comparator_set_ge_lt(min_ver, max_ver)
 }
@@ -204,43 +192,37 @@ fn expand_hyphen(raw_range string) ?ComparatorSet {
 	if raw_max_ver.is_missing(ver_major) {
 		return none
 	}
-	mut max_ver := raw_max_ver.coerce() or { return none }
 	if raw_max_ver.is_missing(ver_minor) {
-		max_ver = max_ver.increment(.minor)
+		max_ver := raw_max_ver.coerce() or { return none }.increment(.minor)
 		return make_comparator_set_ge_lt(min_ver, max_ver)
 	}
+	max_ver := raw_max_ver.coerce() or { return none }
 	return make_comparator_set_ge_le(min_ver, max_ver)
 }
 
 fn expand_xrange(raw_range string) ?ComparatorSet {
 	min_ver := parse_xrange(raw_range) or { return none }
 	if min_ver.major == 0 {
-		comparators := [
-			Comparator{min_ver, Operator.ge},
-		]
-		return ComparatorSet{comparators}
+		return ComparatorSet{[Comparator{min_ver, Operator.ge}]}
 	}
-	mut max_ver := min_ver
-	if min_ver.minor == 0 {
-		max_ver = min_ver.increment(.major)
+	max_ver := if min_ver.minor == 0 {
+		min_ver.increment(.major)
 	} else {
-		max_ver = min_ver.increment(.minor)
+		min_ver.increment(.minor)
 	}
 	return make_comparator_set_ge_lt(min_ver, max_ver)
 }
 
 fn make_comparator_set_ge_lt(min Version, max Version) ComparatorSet {
-	comparators := [
+	return ComparatorSet{[
 		Comparator{min, Operator.ge},
 		Comparator{max, Operator.lt},
-	]
-	return ComparatorSet{comparators}
+	]}
 }
 
 fn make_comparator_set_ge_le(min Version, max Version) ComparatorSet {
-	comparators := [
+	return ComparatorSet{[
 		Comparator{min, Operator.ge},
 		Comparator{max, Operator.le},
-	]
-	return ComparatorSet{comparators}
+	]}
 }

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -142,10 +142,7 @@ fn parse_xrange(input string) ?Version {
 			else {}
 		}
 	}
-	if !raw_ver.is_valid() {
-		return none
-	}
-	return raw_ver.to_version()
+	return raw_ver.validate()
 }
 
 fn can_expand(input string) bool {

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -104,7 +104,7 @@ pub fn (ver Version) str() string {
 	return '${common_string}${prerelease_string}${metadata_string}'
 }
 
-// * Utilites.
+// * Utilities.
 // coerce converts the `input` version to a `Version` struct.
 // coerce will strip any contents *after* the parsed version string:
 /*

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -43,10 +43,9 @@ pub fn from(input string) !Version {
 		return &EmptyInputError{}
 	}
 	raw_version := parse(input)
-	version := raw_version.validate() or { return &InvalidVersionFormatError{
+	return raw_version.validate() or { return &InvalidVersionFormatError{
 		input: input
 	} }
-	return version
 }
 
 // build returns a `Version` structure with given `major`, `minor` and `patch` versions.

--- a/vlib/semver/util.v
+++ b/vlib/semver/util.v
@@ -10,8 +10,7 @@ fn is_version_valid(input string) bool {
 [inline]
 fn coerce_version(input string) !Version {
 	raw_ver := parse(input)
-	ver := raw_ver.coerce() or { return error('Invalid version for input "${input}"') }
-	return ver
+	return raw_ver.coerce() or { return error('Invalid version for input "${input}"') }
 }
 
 [inline]


### PR DESCRIPTION
Utilizes the sugar vlang has to offer clean up the module. Removes mutability and assignments where not strictly or semantically necessary.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a86b87d</samp>

This pull request refactors and improves the `semver` module by using more idiomatic and concise V features, removing unnecessary operations, simplifying functions, and fixing a typo. The changes affect the files `compare.v`, `parse.v`, `range.v`, `semver.v`, and `util.v` in the `vlib/semver` directory.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a86b87d</samp>

*  Simplify `version_satisfies` and `parse_version` functions by using single return statements with chained method calls ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-17d81874fcaeeb6ffa2e9e951e04527813eda2413c94cf088fd64d823330ea0cL6-R6), [link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-94760a53c45df3a811653ad4e173cfea3467e5024f9935bd09df12900e873753L46-R48))
* Refactor `compare_gt`, `compare_lt`, `compare_ge`, and `compare_le` functions in `vlib/semver/compare.v` by using `match` expressions instead of multiple if statements ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-17d81874fcaeeb6ffa2e9e951e04527813eda2413c94cf088fd64d823330ea0cL16-R39))
* Simplify `satisfies` method of `Range` struct in `vlib/semver/range.v` by using `in` operator and `map` method instead of a for loop and a temporary variable ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L37-R37))
* Refactor `satisfies` method of `Comparator` struct and `parse_comparator` function in `vlib/semver/range.v` by using `match` expressions instead of multiple if statements ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L54-R56), [link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L108-R117))
* Simplify `validate` and `coerce` methods of `RawVersion` struct in `vlib/semver/parse.v` and `vlib/semver/range.v` by using single return statements with if expressions instead of if statements and two return statements ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-96642c1c431ed33d4e8ea578613d097c50a2fb163efac4608e240278a2ee686fL77-R77), [link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L152-R145))
* Remove unnecessary `.clone()` call on `raw_ints` field of `RawVersion` struct in `vlib/semver/parse.v` ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-96642c1c431ed33d4e8ea578613d097c50a2fb163efac4608e240278a2ee686fL65-R65))
* Simplify `expand_tilda`, `expand_caret`, `expand_hyphen`, and `expand_xrange` functions in `vlib/semver/range.v` by using if expressions instead of temporary variables and if-else statements, and avoid unnecessary array creation and method calls ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L177-R170), [link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L188-R180), [link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L207-R199), [link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L218-R211))
* Simplify `make_comparator_set_ge_lt` and `make_comparator_set_ge_le` functions in `vlib/semver/range.v` by using array literals instead of temporary variables for the `comparators` field of the `ComparatorSet` struct ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L233-R227))
* Simplify `coerce_version` function in `vlib/semver/util.v` by using a single return statement with a chained method call instead of a temporary variable and an if statement ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-82c96765c34069ae2258d752bbb6d3d58201a85154fe6247df451a8ccbd8ce7cL13-R13))
* Fix typo in comment of `coerce` function in `vlib/semver/semver.v` ([link](https://github.com/vlang/v/pull/18272/files?diff=unified&w=0#diff-94760a53c45df3a811653ad4e173cfea3467e5024f9935bd09df12900e873753L108-R107))
