### PR TITLE
checker: disallow multiple return values in const declarations

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1519,7 +1519,6 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	if node.fields.len == 0 {
 		c.warn('const block must have at least 1 declaration', node.pos)
 	}
-
 	for field in node.fields {
 		if checker.reserved_type_names_chk.matches(util.no_cur_mod(field.name, c.mod)) {
 			c.error('invalid use of reserved type `${field.name}` as a const name', field.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1519,6 +1519,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	if node.fields.len == 0 {
 		c.warn('const block must have at least 1 declaration', node.pos)
 	}
+
 	for field in node.fields {
 		if checker.reserved_type_names_chk.matches(util.no_cur_mod(field.name, c.mod)) {
 			c.error('invalid use of reserved type `${field.name}` as a const name', field.pos)
@@ -1530,6 +1531,13 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 				len: util.no_cur_mod(field.name, c.mod).len
 			}
 			c.error('duplicate const `${field.name}`', name_pos)
+		}
+		if field.expr is ast.CallExpr {
+			sym := c.table.sym(c.check_expr_opt_call(field.expr, c.expr(field.expr)))
+			if sym.kind == .multi_return {
+				c.error('const declarations do not support multiple return values yet',
+					field.expr.pos)
+			}
 		}
 		c.const_names << field.name
 	}

--- a/vlib/v/checker/tests/const_decl_multi_return_err.out
+++ b/vlib/v/checker/tests/const_decl_multi_return_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/const_decl_err.vv:6:6: error: const declarations do not support multiple return values yet
+    4 |
+    5 | const (
+    6 |     a = foo()
+      |         ~~~~~
+    7 | )
+    8 |

--- a/vlib/v/checker/tests/const_decl_multi_return_err.out
+++ b/vlib/v/checker/tests/const_decl_multi_return_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/const_decl_err.vv:6:6: error: const declarations do not support multiple return values yet
+vlib/v/checker/tests/const_decl_multi_return_err.vv:6:6: error: const declarations do not support multiple return values yet
     4 |
     5 | const (
     6 |     a = foo()

--- a/vlib/v/checker/tests/const_decl_multi_return_err.vv
+++ b/vlib/v/checker/tests/const_decl_multi_return_err.vv
@@ -1,0 +1,12 @@
+fn foo() (int, int, int) {
+	return 1, 2, 3
+}
+
+const (
+	a = foo()
+)
+
+
+fn main() {
+	println("$a")
+}


### PR DESCRIPTION
resolves #17399

Since multiple assignments are not supported for consts, disallowing multiple returns is probably what should be done until multiple assignments are supported.

---

As a potential addition to the PR:
The error message for the related multi assign has a phrasing issue. 

https://github.com/vlang/v/blob/8a856cc36d1a8d2e4d97a11a7ba1992303e313cc/vlib/v/parser/parser.v#L3683

If it fits here we could update the error message. I.e. to:
```diff
-			p.error_with_pos('const declaration do not support multiple assign yet', p.tok.pos())
+			p.error_with_pos('const declarations do not support multiple assignments yet', p.tok.pos())
```

---

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 398746f</samp>

Improve const checking and formatting in `vlib/v/checker/checker.v`. Add a check for invalid const declarations with multiple return values from function calls.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 398746f</samp>

*  Emit an error for const declarations that use function calls with multiple return values, as this is not supported by the compiler yet ([link](https://github.com/vlang/v/pull/18273/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R1535-R1541))
