### PR TITLE
cgen: fix fixed array ret with anon fn

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -755,7 +755,9 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	if same_line {
 		if (p.tok.kind.is_start_of_type() && (same_line || p.tok.kind != .lsbr))
 			|| (same_line && p.tok.kind == .key_fn) {
+			p.inside_fn_return = true
 			return_type = p.parse_type()
+			p.inside_fn_return = false
 			return_type_pos = return_type_pos.extend(p.tok.pos())
 		} else if p.tok.kind != .lcbr {
 			p.error_with_pos('expected return type, not ${p.tok} for anonymous function',

--- a/vlib/v/tests/anon_fn_fixed_arr_test.v
+++ b/vlib/v/tests/anon_fn_fixed_arr_test.v
@@ -1,0 +1,38 @@
+struct Struct {
+	f fn () ?[2]int
+	g fn () [2]int
+}
+
+fn test_struct_member() {
+	s := Struct{
+		f: fn () ?[2]int {
+			return [1, 2]!
+		}
+		g: fn () [2]int {
+			return [1, 2]!
+		}
+	}
+
+	mut a := s.f()
+	println(s.f())
+	dump(a)
+	mut b := s.g()
+	println(s.g())
+	dump(b)
+}
+
+fn test_fn_var() {
+	mut h := fn () [2]int {
+		return [1, 2]!
+	}
+	mut i := fn () ?[2]int {
+		return [1, 2]!
+	}
+
+	mut c := h()
+	println(h())
+	dump(c)
+	mut d := i()
+	println(i())
+	dump(d)
+}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f01059</samp>

Fix bugs and enforce rules for using fixed size arrays in function pointers and return values. Add a test file to check the functionality of `vlib/v/gen/c/cgen.v` and `vlib/v/parser/fn.v` for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f01059</samp>

*  Fix C code generation for function pointers and calls that return fixed size arrays ([link](https://github.com/vlang/v/pull/18279/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL1565-R1568), [link](https://github.com/vlang/v/pull/18279/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL2444-R2448))
* Enforce that fixed size arrays can only be returned by value, not by reference, in the parser and the checker ([link](https://github.com/vlang/v/pull/18279/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL758-R760))
* Add a test file to verify the functionality and correctness of the above changes ([link](https://github.com/vlang/v/pull/18279/files?diff=unified&w=0#diff-bfa7c59fd267416582f4968a6fefd114224e521d56eb72386404726ee36b7389R1-R38))
