### PR TITLE
checker: remove check for option being initialized

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -645,7 +645,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						break
 					}
 				}
-				if sym.kind == .interface_ && (!has_noinit && sym.language != .js) {
+				if !field.typ.has_flag(.option) && sym.kind == .interface_
+					&& (!has_noinit && sym.language != .js) {
 					// TODO: should be an error instead, but first `ui` needs updating.
 					c.note('interface field `${type_sym.name}.${field.name}` must be initialized',
 						node.pos)


### PR DESCRIPTION
Fix #18277

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31c306f</samp>

Fix option type and interface field initialization in `vlib/v/checker/struct.v`. Prevent nil values in interface fields that can cause runtime errors.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31c306f</samp>

*  Prevent uninitialized nil values in interface fields by checking if the field type is not an option type ([link](https://github.com/vlang/v/pull/18280/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L648-R649))
