### PR TITLE
cgen: fix comptime interpolation

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -698,8 +698,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
-		if left_sym.kind == .struct_ && !(left_sym.info as ast.Struct).is_anon
-			&& right is ast.StructInit && (right as ast.StructInit).is_anon {
+		if left_sym.kind == .struct_ && right is ast.StructInit && (right as ast.StructInit).is_anon {
 			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
 		}
 	}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -698,7 +698,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
-		if left_sym.kind == .struct_ && right is ast.StructInit && (right as ast.StructInit).is_anon {
+		if left_sym.kind == .struct_ && !(left_sym.info as ast.Struct).is_anon
+			&& right is ast.StructInit && (right as ast.StructInit).is_anon {
 			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
 		}
 	}

--- a/vlib/v/tests/comptime_println_test.v
+++ b/vlib/v/tests/comptime_println_test.v
@@ -1,0 +1,27 @@
+struct Foo {
+	a int
+	b f32
+	c string
+}
+
+fn print_struct[T](x &T) []string {
+	mut a := []string{}
+	$for field in T.fields {
+		typ := typeof((*x).$(field.name)).name
+		val := (*x).$(field.name)
+		a << '${field.name} (${typ}) = ${val}'
+	}
+	return a
+}
+
+fn test_main() {
+	foo := Foo{
+		a: 123
+		b: 4.56
+		c: 'hello'
+	}
+	out := print_struct(&foo)
+	assert out[0] == 'a (int) = 123'
+	assert out[1] == 'b (f32) = 4.56'
+	assert out[2] == 'c (string) = hello'
+}


### PR DESCRIPTION
Fix #10843

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5deb0bb</samp>

This pull request refactors the code generation for string interpolation literals, simplifies the checker logic for struct assignment, and adds a new test file for comptime reflection. The purpose of these changes is to improve the readability, performance and correctness of the compiler and the language.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5deb0bb</samp>

*  Simplify condition for checking anonymous struct assignment ([link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL701-R701))
*  Add `fmts` parameter to `str_format` and `str_val` functions to avoid accessing `node.fmts` field directly ([link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL49-R49), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL62-R62), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL162-R164), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL190-R190), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL206-R207), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL274-R275), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL280-R284))
*  Clone `node.fmts` field to a local variable `fmts` and pass it to `str_format` and `str_val` functions, allowing `get_default_fmt` to modify it if needed ([link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debR240), [link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-5b42d7124a6fddb94f4145738da8e3ad61015e0ac97872c8472c48ef21779debL252-R253))
*  Add test file `vlib/v/tests/comptime_println_test.v` to demonstrate and verify comptime reflection feature, using a generic function `print_struct` that prints struct fields and values ([link](https://github.com/vlang/v/pull/18281/files?diff=unified&w=0#diff-586f03a5ce323d7386b716cb8518243b2494644556ec6ee714f660be161178e6R1-R27))
