### PR TITLE
checker: replace `as` cast with safer type check `is` smart cast

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1517,8 +1517,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		&& method_name in ['clone', 'keys', 'values', 'move', 'delete'] {
 		if left_sym.kind == .map {
 			return c.map_builtin_method_call(mut node, left_type, c.table.sym(left_type))
-		} else {
-			parent_type := (left_sym.info as ast.Alias).parent_type
+		} else if left_sym.info is ast.Alias {
+			parent_type := left_sym.info.parent_type
 			return c.map_builtin_method_call(mut node, parent_type, c.table.final_sym(left_type))
 		}
 	} else if left_sym.kind == .array && method_name in ['insert', 'prepend'] {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 62682ff</samp>

Fix checker panic on invalid map method calls in `vlib/v/checker/fn.v`. Add type check for left expression of map method calls to avoid invalid casts and memory errors.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 62682ff</samp>

* Fix bug where checker panics on map method call with non-map left expression ([link](https://github.com/vlang/v/pull/18286/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL1520-R1521))
