### PR TITLE
checker: add byte deprecation warning

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -703,7 +703,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
 		}
 		if right_sym.kind == .alias && right_sym.name == 'byte' {
-			c.warn('byte s deprecated, use u8 instead', right.pos())
+			c.warn('byte is deprecated, use u8 instead', right.pos())
 		}
 	}
 	// this needs to run after the assign stmt left exprs have been run through checker

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -702,6 +702,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			&& right is ast.StructInit && (right as ast.StructInit).is_anon {
 			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
 		}
+		if right_sym.kind == .alias && right_sym.name == 'byte' {
+			c.warn('byte s deprecated, use u8 instead', right.pos())
+		}
 	}
 	// this needs to run after the assign stmt left exprs have been run through checker
 	// so that ident.obj is set

--- a/vlib/v/checker/tests/struct_type_cast_err.out
+++ b/vlib/v/checker/tests/struct_type_cast_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_type_cast_err.vv:10:7: warning: byte s deprecated, use u8 instead
+vlib/v/checker/tests/struct_type_cast_err.vv:10:7: warning: byte is deprecated, use u8 instead
     8 |     _ := u32(foo)
     9 |     _ := rune(foo)
    10 |     _ := byte(foo)

--- a/vlib/v/checker/tests/struct_type_cast_err.out
+++ b/vlib/v/checker/tests/struct_type_cast_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/struct_type_cast_err.vv:10:7: warning: byte s deprecated, use u8 instead
+    8 |     _ := u32(foo)
+    9 |     _ := rune(foo)
+   10 |     _ := byte(foo)
+      |          ~~~~~~~~~
+   11 |     _ := i8(foo)
+   12 |     _ := i64(foo)
 vlib/v/checker/tests/struct_type_cast_err.vv:5:7: error: cannot cast struct `Foo` to `string`
     3 | fn main() {
     4 |     foo := Foo{}


### PR DESCRIPTION
part2 of #18198 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b9ab84</samp>

Warn users about deprecated `byte` type in assignments. Update `vlib/v/checker/assign.v` to emit a warning when a `byte` value is assigned to a variable, and suggest using `u8` instead.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b9ab84</samp>

* Warn about using `byte` type in assignments ([link](https://github.com/vlang/v/pull/18287/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR705-R707))
