### PR TITLE
vweb: host attribute

### DIFF
--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -256,7 +256,7 @@ To restrict an endpoint to a specific host, you can use the `host` attribute fol
 
 **Example:**
 
-```v
+```v ignore
 ['/'; host: 'example.com']
 pub fn (mut app App) hello_web() vweb.Result {
 	return app.text('Hello World')

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -251,6 +251,23 @@ pub fn (mut app App) controller_get_user_by_id() vweb.Result {
 	return app.text(app.query.str())
 }
 ```
+#### - Host
+To restrict an endpoint to a specific host, you can use the `host` attribute followed by a colon `:` and the host name.
+
+**Example:**
+
+```v
+['/'; host: 'example.com']
+pub fn (mut app App) hello_web() vweb.Result {
+	return app.text('Hello World')
+}
+
+['/'; host: 'api.example.org']
+pub fn (mut app App) hello_api() vweb.Result {
+	return app.text('Hello API')
+}
+```
+
 ### Middleware
 
 Vweb has different kinds of middleware.

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -252,7 +252,8 @@ pub fn (mut app App) controller_get_user_by_id() vweb.Result {
 }
 ```
 #### - Host
-To restrict an endpoint to a specific host, you can use the `host` attribute followed by a colon `:` and the host name.
+To restrict an endpoint to a specific host, you can use the `host` attribute
+followed by a colon `:` and the host name.
 
 **Example:**
 

--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -4,15 +4,16 @@ import net.urllib
 import net.http
 
 // Parsing function attributes for methods and path.
-fn parse_attrs(name string, attrs []string) !([]http.Method, string, string) {
+fn parse_attrs(name string, attrs []string) !([]http.Method, string, string, string) {
 	if attrs.len == 0 {
-		return [http.Method.get], '/${name}', ''
+		return [http.Method.get], '/${name}', '', ''
 	}
 
 	mut x := attrs.clone()
 	mut methods := []http.Method{}
 	mut middleware := ''
 	mut path := ''
+	mut host := ''
 
 	for i := 0; i < x.len; {
 		attr := x[i]
@@ -36,6 +37,11 @@ fn parse_attrs(name string, attrs []string) !([]http.Method, string, string) {
 			x.delete(i)
 			continue
 		}
+		if attr.starts_with('host:') {
+			host = attr.all_after('host:').trim_space()
+			x.delete(i)
+			continue
+		}
 		i++
 	}
 	if x.len > 0 {
@@ -49,8 +55,8 @@ fn parse_attrs(name string, attrs []string) !([]http.Method, string, string) {
 	if path == '' {
 		path = '/${name}'
 	}
-	// Make path lowercase for case-insensitive comparisons
-	return methods, path.to_lower(), middleware
+	// Make path and host lowercase for case-insensitive comparisons
+	return methods, path.to_lower(), middleware, host.to_lower()
 }
 
 fn parse_query_from_url(url urllib.URL) map[string]string {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -414,7 +414,7 @@ fn generate_routes[T](app &T) !map[string]Route {
 	return routes
 }
 
-type ControllerHandler = fn (ctx Context, mut url urllib.URL, tid int)
+type ControllerHandler = fn (ctx Context, mut url urllib.URL, host string, tid int)
 
 pub struct ControllerPath {
 	path    string

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -183,6 +183,7 @@ struct Route {
 	methods    []http.Method
 	path       string
 	middleware string
+	host       string
 }
 
 // Defining this method is optional.
@@ -399,7 +400,7 @@ fn generate_routes[T](app &T) !map[string]Route {
 	// Parsing methods attributes
 	mut routes := map[string]Route{}
 	$for method in T.methods {
-		http_methods, route_path, middleware := parse_attrs(method.name, method.attrs) or {
+		http_methods, route_path, middleware, host := parse_attrs(method.name, method.attrs) or {
 			return error('error parsing method attributes: ${err}')
 		}
 
@@ -407,6 +408,7 @@ fn generate_routes[T](app &T) !map[string]Route {
 			methods: http_methods
 			path: route_path
 			middleware: middleware
+			host: host
 		}
 	}
 	return routes
@@ -436,12 +438,12 @@ pub fn controller[T](path string, global_app &T) &ControllerPath {
 	// no need to type `ControllerHandler` as generic since it's not needed for closures
 	return &ControllerPath{
 		path: path
-		handler: fn [global_app, path, routes] [T](ctx Context, mut url urllib.URL, tid int) {
+		handler: fn [global_app, path, routes] [T](ctx Context, mut url urllib.URL, host string, tid int) {
 			// request_app is freed in `handle_route`
 			mut request_app := new_request_app[T](global_app, ctx, tid)
 			// transform the url
 			url.path = url.path.all_after_first(path)
-			handle_route[T](mut request_app, url, &routes, tid)
+			handle_route[T](mut request_app, url, host, &routes, tid)
 		}
 	}
 }
@@ -620,6 +622,8 @@ fn handle_conn[T](mut conn net.TcpConn, global_app &T, routes &map[string]Route,
 		return
 	}
 
+	host := req.header.get(http.CommonHeader.host) or { '' }.to_lower()
+
 	// Create Context with request data
 	ctx := Context{
 		req: req
@@ -635,18 +639,18 @@ fn handle_conn[T](mut conn net.TcpConn, global_app &T, routes &map[string]Route,
 		for controller in global_app.controllers {
 			if url.path.len >= controller.path.len && url.path.starts_with(controller.path) {
 				// pass route handling to the controller
-				controller.handler(ctx, mut url, tid)
+				controller.handler(ctx, mut url, host, tid)
 				return
 			}
 		}
 	}
 
 	mut request_app := new_request_app(global_app, ctx, tid)
-	handle_route(mut request_app, url, routes, tid)
+	handle_route(mut request_app, url, host, routes, tid)
 }
 
 [manualfree]
-fn handle_route[T](mut app T, url urllib.URL, routes &map[string]Route, tid int) {
+fn handle_route[T](mut app T, url urllib.URL, host string, routes &map[string]Route, tid int) {
 	defer {
 		unsafe {
 			free(app)
@@ -690,70 +694,77 @@ fn handle_route[T](mut app T, url urllib.URL, routes &map[string]Route, tid int)
 				// Used for route matching
 				route_words := route.path.split('/').filter(it != '')
 
-				// Route immediate matches first
-				// For example URL `/register` matches route `/:user`, but `fn register()`
-				// should be called first.
-				if !route.path.contains('/:') && url_words == route_words {
-					// We found a match
-					$if T is MiddlewareInterface {
-						if validate_middleware(mut app, url.path) == false {
-							return
+				// Skip if the host does not match or is empty
+				if route.host == '' || route.host == host {
+					// Route immediate matches first
+					// For example URL `/register` matches route `/:user`, but `fn register()`
+					// should be called first.
+					if !route.path.contains('/:') && url_words == route_words {
+						// We found a match
+						$if T is MiddlewareInterface {
+							if validate_middleware(mut app, url.path) == false {
+								return
+							}
 						}
+
+						if app.req.method == .post && method.args.len > 0 {
+							// Populate method args with form values
+							mut args := []string{cap: method.args.len}
+							for param in method.args {
+								args << app.form[param.name]
+							}
+
+							if route.middleware == '' {
+								app.$method(args)
+							} else if validate_app_middleware(mut app, route.middleware,
+								method.name)
+							{
+								app.$method(args)
+							}
+						} else {
+							if route.middleware == '' {
+								app.$method()
+							} else if validate_app_middleware(mut app, route.middleware,
+								method.name)
+							{
+								app.$method()
+							}
+						}
+						return
 					}
 
-					if app.req.method == .post && method.args.len > 0 {
-						// Populate method args with form values
-						mut args := []string{cap: method.args.len}
-						for param in method.args {
-							args << app.form[param.name]
+					if url_words.len == 0 && route_words == ['index'] && method.name == 'index' {
+						$if T is MiddlewareInterface {
+							if validate_middleware(mut app, url.path) == false {
+								return
+							}
 						}
-
-						if route.middleware == '' {
-							app.$method(args)
-						} else if validate_app_middleware(mut app, route.middleware, method.name) {
-							app.$method(args)
-						}
-					} else {
 						if route.middleware == '' {
 							app.$method()
 						} else if validate_app_middleware(mut app, route.middleware, method.name) {
 							app.$method()
 						}
+						return
 					}
-					return
-				}
 
-				if url_words.len == 0 && route_words == ['index'] && method.name == 'index' {
-					$if T is MiddlewareInterface {
-						if validate_middleware(mut app, url.path) == false {
-							return
+					if params := route_matches(url_words, route_words) {
+						method_args := params.clone()
+						if method_args.len != method.args.len {
+							eprintln('[vweb] tid: ${tid:03d}, warning: uneven parameters count (${method.args.len}) in `${method.name}`, compared to the vweb route `${method.attrs}` (${method_args.len})')
 						}
-					}
-					if route.middleware == '' {
-						app.$method()
-					} else if validate_app_middleware(mut app, route.middleware, method.name) {
-						app.$method()
-					}
-					return
-				}
 
-				if params := route_matches(url_words, route_words) {
-					method_args := params.clone()
-					if method_args.len != method.args.len {
-						eprintln('[vweb] tid: ${tid:03d}, warning: uneven parameters count (${method.args.len}) in `${method.name}`, compared to the vweb route `${method.attrs}` (${method_args.len})')
-					}
-
-					$if T is MiddlewareInterface {
-						if validate_middleware(mut app, url.path) == false {
-							return
+						$if T is MiddlewareInterface {
+							if validate_middleware(mut app, url.path) == false {
+								return
+							}
 						}
+						if route.middleware == '' {
+							app.$method(method_args)
+						} else if validate_app_middleware(mut app, route.middleware, method.name) {
+							app.$method(method_args)
+						}
+						return
 					}
-					if route.middleware == '' {
-						app.$method(method_args)
-					} else if validate_app_middleware(mut app, route.middleware, method.name) {
-						app.$method(method_args)
-					}
-					return
 				}
 			}
 		}


### PR DESCRIPTION
Add support for a [host: 'example.org'] attribute in vweb.
This allows having host specific endpoints when using multiple domains (subdomains) for a page.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e14dfa7</samp>

This pull request adds a new feature to the `vweb` module that allows defining host-based routes for web endpoints. It modifies the `vweb` module's code and documentation to support and explain this feature. It affects the files `vlib/vweb/parse.v`, `vlib/vweb/vweb.v`, and `vlib/vweb/README.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e14dfa7</samp>

*  Add host-based routing feature to vweb module ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afL7-R9), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afR16), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afR40-R44), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afL52-R59), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R186), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L402-R403), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R411), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L415-R417), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L439-R446), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R625-R626), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L638-R642), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L645-R653), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L693-R741), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L722-R767))
  * Modify `parse_attrs` function in `vlib/vweb/parse.v` to return host name as fourth value ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afL7-R9), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afR16), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afR40-R44), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-825536522629231585c41f7252c76ecba1ad4acada7d07dfe8aae1678aad54afL52-R59))
  * Add `host` field to `Route` struct and assign it in `vweb.init` method ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R186), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L402-R403), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R411))
  * Add `host` parameter to `ControllerHandler` type alias and pass it in `vweb.controller` and `vweb.handle_conn` methods ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L415-R417), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L439-R446), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L638-R642))
  * Add `host` parameter to `handle_route` function and check it against route host name before matching ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L645-R653), [link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L693-R741))
  * Extract host name from request `Host` header in `vweb.handle_conn` method ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R625-R626))
  * Add missing `return` statement after route handler call in `handle_route` function ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L722-R767))
* Update README.md file of vweb module to explain how to use `host` attribute ([link](https://github.com/vlang/v/pull/18288/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R254-R270))
