### PR TITLE
checker: unalias arg_typ byte to u8

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1136,6 +1136,10 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			c.error('literal argument cannot be passed as reference parameter `${c.table.type_to_str(param.typ)}`',
 				call_arg.pos)
 		}
+		// TODO: remove once deprecation period for byte has ended
+		if param_typ_sym.kind == .u8 && arg_typ_sym.info is ast.Alias && arg_typ_sym.name == 'byte' {
+			arg_typ = arg_typ_sym.info.parent_type
+		}
 		c.check_expected_call_arg(arg_typ, c.unwrap_generic(param.typ), node.language,
 			call_arg) or {
 			if param.typ.has_flag(.generic) {


### PR DESCRIPTION
part1 of #18198 

I'm not certain about the string comparison, but it was the best alternative I've found here. Please roast me as much as necessary to make this fix as good as possible and to allow approaching further work with V with more knowledge.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e50154b</samp>

Allow `byte` as an alias for `u8` in function arguments as a temporary workaround. This is part of improving the type system and error messages of V.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e50154b</samp>

* Allow `byte` as an alias for `u8` in function arguments as a temporary workaround ([link](https://github.com/vlang/v/pull/18289/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR1139-R1142))
