### PR TITLE
cgen: fix none initialization to struct member

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -163,6 +163,10 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 								field.default_expr.pos)
 						}
 					}
+					if field.typ.has_flag(.option) && field.default_expr is ast.None {
+						c.warn('unnecessary default value of `none`: struct fields are zeroed by default',
+							field.default_expr.pos)
+					}
 					continue
 				}
 				if field.typ in ast.unsigned_integer_type_idxs {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -346,7 +346,11 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 			return true
 		}
 
-		if field.typ.has_flag(.option) {
+		if field.default_expr is ast.None {
+			tmp_var := g.new_tmp_var()
+			g.expr_with_tmp_var(ast.None{}, ast.none_type, field.typ, tmp_var)
+			return true
+		} else if field.typ.has_flag(.option) {
 			tmp_var := g.new_tmp_var()
 			g.expr_with_tmp_var(field.default_expr, field.default_expr_typ, field.typ,
 				tmp_var)

--- a/vlib/v/tests/generic_struct_recursive_test.v
+++ b/vlib/v/tests/generic_struct_recursive_test.v
@@ -1,0 +1,20 @@
+struct Node[T] {
+mut:
+	value T
+	next  ?&Node[T] = none
+}
+
+fn test_main() {
+	mut n := Node[int]{
+		value: 1
+	}
+	mut m := Node[int]{
+		value: 2
+	}
+	n.next = &m
+	a := n.next or { return }
+	dump(a)
+	dump(m)
+	dump(n)
+	assert a.value == 2
+}


### PR DESCRIPTION
This PR fixes none initialization.

```V
struct Node[T] {
mut:
	value T
	next ?&Node[T] = none
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7649841</samp>

This pull request fixes a C code generation bug for generic structs with optional fields and adds a test case for generic structs with recursive references. The bug fix prevents segmentation faults when using `none` as a default value, and the test case verifies the correct handling of recursive generic structs.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7649841</samp>

* Fix bug in C code generation for generic structs with optional fields ([link](https://github.com/vlang/v/pull/18295/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L349-R354))
* Add test case for generic structs with recursive references ([link](https://github.com/vlang/v/pull/18295/files?diff=unified&w=0#diff-ad93add5bb6bd9468a1eaa1e33ce1ae3da797d94959e0b0fd1bb30e1d70580a9R1-R20))
