### PR TITLE
cgen: fix generic comptimeselector array resolution

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1115,6 +1115,12 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 				}
 			} else if mut call_arg.expr is ast.ComptimeSelector {
 				comptime_args[i] = g.comptime_for_field_type
+				arg_sym := g.table.final_sym(call_arg.typ)
+				param_typ_sym := g.table.sym(param_typ)
+				if arg_sym.kind == .array && param_typ.has_flag(.generic)
+					&& param_typ_sym.kind == .array {
+					comptime_args[i] = g.get_generic_array_element_type(arg_sym.info as ast.Array)
+				}
 				if call_arg.expr.left.is_auto_deref_var() {
 					comptime_args[i] = comptime_args[i].deref()
 				}

--- a/vlib/v/tests/generic_comptime_test.v
+++ b/vlib/v/tests/generic_comptime_test.v
@@ -1,0 +1,26 @@
+struct EmptyStruct {
+	b []int = [1, 2, 3]
+}
+
+fn encode_array[T](val []T) []int {
+	return val
+}
+
+fn encode_struct[T](val T) []int {
+	$if T is $struct {
+		$for field in T.fields {
+			$if field.is_array {
+				return encode_array(val.$(field.name))
+			}
+		}
+	}
+	return [0]
+}
+
+fn encoder() []int {
+	return encode_struct(EmptyStruct{})
+}
+
+fn test_main() {
+	assert encoder() == [1, 2, 3]
+}


### PR DESCRIPTION
Fix #18292

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 714fc46</samp>

Fix a segfault bug when passing generic arrays as comptime arguments. Add a test case for the bug fix using a struct and an encoder function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 714fc46</samp>

* Fix a segmentation fault when passing a generic array as a comptime argument to a function ([link](https://github.com/vlang/v/pull/18296/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9R1118-R1123))
* Add a test case for the bug fix in `vlib/v/tests/generic_comptime_test.v` ([link](https://github.com/vlang/v/pull/18296/files?diff=unified&w=0#diff-c227c57252ba3c5cef294a818e632160521a4b465534559471e2aa5115a61671R1-R26))
