### PR TITLE
.editorconfig: do not specify an indent size for tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ trim_trailing_whitespace = true
 
 [*.v]
 indent_style = tab
-indent_size = 4
 
 [*.{bat,cmd}]
 # BAT/CMD ~ DOS/Win requires BAT/CMD files to have CRLF EOLNs


### PR DESCRIPTION
The PRs brings a small improvement in accessibility.

Background:
The beauty of tab indentation is its increased accessibility for developers.

The preferred indent width can be used or dynamically adapted to a given situation, without making a change to the codebase. Unlike with spaces, specifying a width is not needed; one tab is always one indentation. Due to this, more modern linters that allow choosing between space or tab indentation offer an `indendation=int|"tab"` value.
Where `int` implies that space indentation is used, for tabs it is simply not needed. I.e.:
https://stylelint.io/user-guide/rules/indentation/#options

But I wouldn't submit this PR if removing the indentation width for tabs from the editorconfig didn't resolve a problem.

For example, working in VSCode:
Having a fixed indent width specified and changing the indent size while working in the Vlang codebase results in: Unfocusing and refocusing the editor window shifts the indent width back to 4 while the indent guides are not reset:

![Screenshot_20230528_230737](https://github.com/vlang/v/assets/34311583/3d15c259-57a9-46de-923c-06746f9ac5ab)

Removing the width for tabs preserves the users configuration.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a743a6</samp>

Removed `indent_size` from `.editorconfig` to avoid redundancy and conflicts. This is part of a code style improvement pull request.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a743a6</samp>

* Remove redundant `indent_size` setting from `.editorconfig` file ([link](https://github.com/vlang/v/pull/18297/files?diff=unified&w=0#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bL11))
