### PR TITLE
cgen: fix sumtype alias fntype smartcast

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4196,9 +4196,19 @@ fn (mut g Gen) ident(node ast.Ident) {
 			if node.obj.smartcasts.len > 0 {
 				obj_sym := g.table.sym(node.obj.typ)
 				if !prevent_sum_type_unwrapping_once {
-					for _ in node.obj.smartcasts {
+					outer: for _, typ in node.obj.smartcasts {
 						g.write('(')
 						if obj_sym.kind == .sum_type && !is_auto_heap {
+							if g.sumtype_casting_fns.len > 0 {
+								typ_kind := g.table.sym(g.unwrap_generic(typ)).kind
+								if typ_kind == .function {
+									for f in g.sumtype_casting_fns {
+										if f.got == typ {
+											break outer
+										}
+									}
+								}
+							}
 							g.write('*')
 						}
 					}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3256,7 +3256,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				mut expr_str := ''
 				if mut node.expr is ast.ComptimeSelector
 					&& (node.expr as ast.ComptimeSelector).left is ast.Ident {
-					// val.$(field.name)?					
+					// val.$(field.name)?
 					expr_str = '${node.expr.left.str()}.${g.comptime_for_field_value.name}'
 				} else if mut node.expr is ast.Ident && g.is_comptime_var(node.expr) {
 					// val?

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4204,7 +4204,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 								if typ_kind == .function {
 									for f in g.sumtype_casting_fns {
 										if f.got == typ {
-											break outer
+											continue outer
 										}
 									}
 								}

--- a/vlib/v/tests/sumtype_with_alias_fntype_smartcst_test.v
+++ b/vlib/v/tests/sumtype_with_alias_fntype_smartcst_test.v
@@ -1,0 +1,17 @@
+type FunString = FnAlias | string
+
+type FnAlias = fn () string
+
+fn foo_bar(foo FnAlias) string {
+	return foo()
+}
+
+fn test_sumtype_with_alias_fntype_smartcast() {
+	fs := FunString(FnAlias(fn () string {
+		return 'bar'
+	}))
+
+	if fs is FnAlias {
+		println(foo_bar(fs))
+	}
+}


### PR DESCRIPTION
fixes #17799 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06852c9</samp>

Fix a bug in C code generation for sum types with function aliases and add a test case. The bug caused a segmentation fault when smartcasting and calling a sum type as a function alias. The fix avoids invalid pointer arithmetic in the generated C code.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06852c9</samp>

* Fix bug in C code generation for sum types with function aliases ([link](https://github.com/vlang/v/pull/18298/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4199-R4211))
* Add test case for sum type with function alias smartcasting ([link](https://github.com/vlang/v/pull/18298/files?diff=unified&w=0#diff-d9592de27b8b832f06914140fbe65c6c097518ddf2c1392a22aab0dd084825d3R1-R17))
