### PR TITLE
toml, semver: minor optimization of conditions

### DIFF
--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -34,12 +34,7 @@ struct InvalidComparatorFormatError {
 }
 
 fn (r Range) satisfies(ver Version) bool {
-	for set in r.comparator_sets {
-		if set.satisfies(ver) {
-			return true
-		}
-	}
-	return false
+	return r.comparator_sets.any(it.satisfies(ver))
 }
 
 fn (set ComparatorSet) satisfies(ver Version) bool {

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -34,7 +34,12 @@ struct InvalidComparatorFormatError {
 }
 
 fn (r Range) satisfies(ver Version) bool {
-	return true in r.comparator_sets.map(it.satisfies(ver))
+	for set in r.comparator_sets {
+		if set.satisfies(ver) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (set ComparatorSet) satisfies(ver Version) bool {

--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -592,16 +592,17 @@ fn (mut s Scanner) extract_number() !string {
 	for s.pos < s.text.len {
 		c = s.at()
 		// Adjust scanner position to floating point numbers
-		mut i, mut float_precision := 1, 0
-		for c_ := u8(s.peek(i)); c_ != scanner.end_of_text && c_ != `\n`; c_ = u8(s.peek(i)) {
-			if !c_.is_digit() && c_ != `.` && c_ != `,` {
-				float_precision = 0
-				break
-			}
-			if c_.is_digit() && c == `.` {
+		mut float_precision := 0
+		if c == `.` {
+			mut i := 1
+			for c_ := u8(s.peek(i)); c_ != scanner.end_of_text && c_ != `\n`; c_ = u8(s.peek(i)) {
+				if !c_.is_digit() && c_ != `,` {
+					float_precision = 0
+					break
+				}
 				float_precision++
+				i++
 			}
-			i++
 		}
 		s.pos += float_precision
 		s.col += float_precision


### PR DESCRIPTION
In retrospect of some of the recent submitted fixes, further improvements presented themselves.

Since those are not just stylistic changes, but also a bit cheaper in computation, I feel obliged to submit those refinements.

1. semver: the change submitted in the refactor resembled it's prior functionality, looping the whole array.

   ```diff
   -	mut final_result := false
   -	for set in r.comparator_sets {
   -		final_result = final_result || set.satisfies(ver)
   -	}
   -	return final_result
   +	return true in r.comparator_sets.map(it.satisfies(ver))
   ```

   But since `true || false` is always true. We can simply early return.

3. toml: the condition for the floating point detection can be checked before performing further computation.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ff1259</samp>

This pull request improves the performance and readability of the `satisfies` method in `vlib/semver/range.v`, and fixes a number parsing bug in `vlib/toml/scanner/scanner.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ff1259</samp>

*  Simplify logic of `satisfies` method for checking version-range compatibility ([link](https://github.com/vlang/v/pull/18299/files?diff=unified&w=0#diff-c88e753ca61a533631c8687d40bf217b8e5819b8a7e2e243b02feb0078236af2L37-R42))
*  Fix bug in `scan_number` method for parsing number literals in TOML documents ([link](https://github.com/vlang/v/pull/18299/files?diff=unified&w=0#diff-8a65223c95935b8ffeaccee61b280f7d5da77554634cd9174360ff584220438eL595-R605))
