### PR TITLE
ast, cgen: fix generic struct with inconsistent generic types (fix #18254)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1152,7 +1152,7 @@ pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 	ph_type := TypeSymbol{
 		kind: .placeholder
 		name: name
-		cname: util.no_dots(name)
+		cname: util.no_dots(name).replace_each(['[', '_T_', ']', ''])
 		language: language
 		mod: modname
 	}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1152,7 +1152,7 @@ pub fn (mut t Table) add_placeholder_type(name string, language Language) int {
 	ph_type := TypeSymbol{
 		kind: .placeholder
 		name: name
-		cname: util.no_dots(name).replace_each(['[', '_T_', ']', ''])
+		cname: util.no_dots(name)
 		language: language
 		mod: modname
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -222,7 +222,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		eprintln('INFO: compile with `v -live ${g.pref.path} `, if you want to use the [live] function ${node.name} .')
 	}
 
-	mut name := g.c_fn_name(node) or { return }
+	mut name := g.c_fn_name(node)
 	mut type_name := g.typ(g.unwrap_generic(node.return_type))
 
 	if node.return_type.has_flag(.generic) && g.table.sym(node.return_type).kind == .array_fixed {
@@ -432,17 +432,17 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 }
 
-fn (mut g Gen) c_fn_name(node &ast.FnDecl) !string {
+fn (mut g Gen) c_fn_name(node &ast.FnDecl) string {
 	mut name := node.name
 	if name in ['+', '-', '*', '/', '%', '<', '=='] {
 		name = util.replace_op(name)
 	}
 	if node.is_method {
-		unwrapped_rec_sym := g.table.sym(g.unwrap_generic(node.receiver.typ))
-		if unwrapped_rec_sym.kind == .placeholder {
-			return error('none')
+		unwrapped_rec_typ := g.unwrap_generic(node.receiver.typ)
+		name = g.cc_type(unwrapped_rec_typ, false) + '_' + name
+		if g.table.sym(unwrapped_rec_typ).kind == .placeholder {
+			name = name.replace_each(['[', '_T_', ']', ''])
 		}
-		name = g.cc_type(node.receiver.typ, false) + '_' + name
 	}
 	if node.language == .c {
 		name = util.no_dots(name)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -439,11 +439,12 @@ fn (mut g Gen) c_fn_name(node &ast.FnDecl) ?string {
 	}
 	if node.is_method {
 		unwrapped_rec_typ := g.unwrap_generic(node.receiver.typ)
-		if g.table.sym(unwrapped_rec_typ).kind == .placeholder
-			&& unwrapped_rec_typ.has_flag(.generic) {
+		name = g.cc_type(unwrapped_rec_typ, false) + '_' + name
+		unwrapped_rec_sym := g.table.sym(unwrapped_rec_typ)
+		if unwrapped_rec_sym.kind == .placeholder
+			&& unwrapped_rec_sym.cname.all_after_last('_').len == 1 {
 			return none
 		}
-		name = g.cc_type(unwrapped_rec_typ, false) + '_' + name
 	}
 	if node.language == .c {
 		name = util.no_dots(name)

--- a/vlib/v/tests/generics_struct_with_inconsistent_generic_types_1_test.v
+++ b/vlib/v/tests/generics_struct_with_inconsistent_generic_types_1_test.v
@@ -1,0 +1,26 @@
+pub struct Generic[D] {
+pub mut:
+	field D
+}
+
+pub fn (j Generic[D]) foo() D {
+	return j.field
+}
+
+pub fn new_generic[T](field T) Generic[T] {
+	return Generic[T]{
+		field: field
+	}
+}
+
+fn test_generic_struct_with_inconsistent_generic_types() {
+	my_generic1 := new_generic[int](2)
+	r1 := my_generic1.foo()
+	println(r1)
+	assert r1 == 2
+
+	my_generic2 := new_generic[string]('hello')
+	r2 := my_generic2.foo()
+	println(r2)
+	assert r2 == 'hello'
+}


### PR DESCRIPTION
This PR fix generic struct with inconsistent generic types (fix #18254).

- Fix generic struct with inconsistent generic types.
- Add test.

```v
pub struct Generic[D] {
pub mut:
	field D
}

pub fn (j Generic[D]) foo() D {
	return j.field
}

pub fn new_generic[T](field T) Generic[T] {
	return Generic[T]{
		field: field
	}
}

fn main() {
	my_generic1 := new_generic[int](2)
	r1 := my_generic1.foo()
	println(r1)
	assert r1 == 2

	my_generic2 := new_generic[string]('hello')
	r2 := my_generic2.foo()
	println(r2)
	assert r2 == 'hello'
}

PS D:\Test\v\tt1> v run .
2
hello
```