### PR TITLE
vweb: add host option to controller

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -1003,7 +1003,7 @@ pub fn (u &URL) port() string {
 // split_host_port separates host and port. If the port is not valid, it returns
 // the entire input as host, and it doesn't check the validity of the host.
 // Per RFC 3986, it requires ports to be numeric.
-fn split_host_port(hostport string) (string, string) {
+pub fn split_host_port(hostport string) (string, string) {
 	mut host := hostport
 	mut port := ''
 	colon := host.last_index_u8(`:`)

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -267,7 +267,16 @@ pub fn (mut app App) hello_web() vweb.Result {
 pub fn (mut app App) hello_api() vweb.Result {
 	return app.text('Hello API')
 }
+
+// define the handler without a host attribute last if you have conflicting paths.
+['/']
+pub fn (mut app App) hello_others() vweb.Result {
+	return app.text('Hello Others')
+}
 ```
+
+You can also [create a controller](#hosts) to handle all requests from a specific
+host in one app.
 
 ### Middleware
 
@@ -678,6 +687,43 @@ pub fn (mut app App) admin_path vweb.Result {
 ```
 There will be an error, because the controller `Admin` handles all routes starting with
 `"/admin"`; the method `admin_path` is unreachable.
+
+#### Hosts
+You can also set a host for a controller. All requests coming from that host will be handled
+by the controller.
+
+**Example:**
+```v
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	vweb.Controller
+}
+
+pub fn (mut app App) index() vweb.Result {
+	return app.text('App')
+}
+
+struct Example {
+	vweb.Context
+}
+
+// You can only access this route at example.com: http://example.com/
+pub fn (mut app Example) index() vweb.Result {
+	return app.text('Example')
+}
+
+fn main() {
+	vweb.run(&App{
+		controllers: [
+			vweb.controller_host('example.com', '/', &Example{}),
+		]
+	}, 8080)
+}
+```
 
 #### Databases and `[vweb_global]` in controllers
 

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -253,7 +253,8 @@ pub fn (mut app App) controller_get_user_by_id() vweb.Result {
 ```
 #### - Host
 To restrict an endpoint to a specific host, you can use the `host` attribute
-followed by a colon `:` and the host name.
+followed by a colon `:` and the host name. You can test the Host feature locally 
+by adding a host to the "hosts" file of your device.
 
 **Example:**
 

--- a/vlib/vweb/tests/controller_test.v
+++ b/vlib/vweb/tests/controller_test.v
@@ -137,9 +137,9 @@ fn test_duplicate_route() {
 	$if windows {
 		task := spawn os.execute(server_exec_cmd)
 		res := task.wait()
-		assert res.output.contains('V panic: method "duplicate" with route "/admin/duplicate" should be handled by the Controller of "/admin"')
+		assert res.output.contains('V panic: conflicting paths')
 	} $else {
 		res := os.execute(server_exec_cmd)
-		assert res.output.contains('V panic: method "duplicate" with route "/admin/duplicate" should be handled by the Controller of "/admin"')
+		assert res.output.contains('V panic: conflicting paths')
 	}
 }

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -238,6 +238,20 @@ fn test_http_client_multipart_form_data() {
 	assert x.body == files[0].data
 }
 
+fn test_host() {
+	mut req := http.Request{
+		url: 'http://${localserver}/with_host'
+		method: .get
+	}
+
+	mut x := req.do()!
+	assert x.status() == .not_found
+
+	req.add_header(.host, 'example.com')
+	x = req.do()!
+	assert x.status() == .ok
+}
+
 fn test_http_client_shutdown_does_not_work_without_a_cookie() {
 	x := http.get('http://${localserver}/shutdown') or {
 		assert err.msg() == ''

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -119,6 +119,12 @@ pub fn (mut app App) not_found() vweb.Result {
 	return app.html('404 on "${app.req.url}"')
 }
 
+[host: 'example.com']
+['/with_host']
+pub fn (mut app App) with_host() vweb.Result {
+	return app.ok('')
+}
+
 pub fn (mut app App) shutdown() vweb.Result {
 	session_key := app.get_cookie('skey') or { return app.not_found() }
 	if session_key != 'superman' {


### PR DESCRIPTION
Add a host option to a vweb Controller so it is possible to handle all requests from one host by a controller without having to use the `host` attribute.

- Fix: remove port from hostname

## Usage

```v
module main
import vweb
struct App {
	vweb.Context
	vweb.Controller
}
pub fn (mut app App) index() vweb.Result {
	return app.text('App')
}
struct Example {
	vweb.Context
}
// You can only access this route at example.com: http://example.com/
pub fn (mut app Example) index() vweb.Result {
	return app.text('Example')
}
fn main() {
	vweb.run(&App{
		controllers: [
			vweb.controller_host('example.com', '/', &Example{}),
		]
	}, 8080)
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc52029</samp>

This pull request adds host-based routing to the `vweb` module, allowing different handlers to be associated with different host names. It also updates the documentation, the error message, and the test cases to reflect this new feature. It uses the `split_host_port` function from `vlib/net/urllib/urllib.v` to parse the host and port from the request.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dc52029</samp>

*  Make `split_host_port` function public in `urllib.v` to parse host and port from URL or header ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-c68c83cfd274d96f5c5f442f56cbdad148925f59faa3b7902fece8e18d22b149L1006-R1006))
*  Add `host` attribute to `ControllerPath` struct and `controller_host` function in `vweb.v` to create controllers for specific hosts ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L420-R424), [link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R454-R460))
*  Change validation logic for routes and controllers in `vweb.v` to check for conflicting paths only among controllers without a host attribute and use new error message ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L490-R507))
*  Change logic for extracting host from request header and matching it with controller host in `vweb.v` to use `split_host_port` function and remove port from host name ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L625-R639), [link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R654-R657))
*  Update documentation for `host` attribute in `README.md` to include note on testing locally, example of handler without host attribute, and new section on creating host controllers ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L256-R257), [link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L270-R281), [link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R692-R728))
*  Add test case for host feature in `vweb_test.v` and `vweb_test_server.v` to check that handler with host attribute only responds to requests from that host and returns 404 otherwise ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-e2b4ca574c1f1cb6c8d8bf504cd731684504a071b7613a1be57ef663dc16a9dbR241-R254), [link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-104a4ef4fe245864051c9a884f32da33db53a1789de9a362d19c8cdebef0a2c9R122-R127))
*  Update test case for controller validation in `controller_test.v` to reflect new error message for conflicting paths ([link](https://github.com/vlang/v/pull/18303/files?diff=unified&w=0#diff-41c157df4905c0f11c8ae76510bae2e74a0f95a266bd97196f0e5c415be691c2L140-R143))
