### PR TITLE
repl: fix comparison operator treated as statement

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -423,7 +423,8 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				' as ',
 			]
 			mut is_statement := false
-			if filter_line.count('=') % 2 == 1 {
+			if filter_line.count('=') % 2 == 1
+				&& filter_line.count('>=') + filter_line.count('<=') == 0 {
 				is_statement = true
 			} else {
 				for pattern in possible_statement_patterns {

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -424,7 +424,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			]
 			mut is_statement := false
 			if filter_line.count('=') % 2 == 1
-				&& filter_line.count('>=') + filter_line.count('<=') == 0 {
+				&& (filter_line.count('!=') + filter_line.count('>=') + filter_line.count('<=')) == 0 {
 				is_statement = true
 			} else {
 				for pattern in possible_statement_patterns {


### PR DESCRIPTION
Fix #18302

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f2df70</samp>

Fix a bug in the V REPL that caused comparison expressions to be treated as assignments. Update the `cmd/tools/vrepl.v` file to refine the statement detection logic.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f2df70</samp>

* Fix bug in V REPL statement detection by excluding lines with comparison operators from assignment check ([link](https://github.com/vlang/v/pull/18304/files?diff=unified&w=0#diff-f018bd97a2f57fb8f2eca1f10fe94f293f04a962284facda13126da1cc913644L426-R427))
