### PR TITLE
parser: fix `for select` parsing

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -474,6 +474,7 @@ fn (mut p Parser) select_expr() ast.SelectExpr {
 		}
 		branch_last_pos := p.tok.pos()
 		p.inside_match_body = true
+		p.inside_for = false
 		stmts := p.parse_block_no_scope(false)
 		p.close_scope()
 		p.inside_match_body = false

--- a/vlib/v/tests/for_select_test.v
+++ b/vlib/v/tests/for_select_test.v
@@ -1,0 +1,27 @@
+import time
+
+fn test_main() {
+	ch := chan int{}
+	go do_send(ch)
+	mut a := 0
+	for select {
+		x := <-ch {
+			a += x
+			check(x)
+		}
+	} {
+	}
+	assert a == 45
+	time.sleep(500 * time.millisecond)
+}
+
+fn do_send(ch chan int) {
+	for i in 0 .. 10 {
+		ch <- i
+	}
+	ch.close()
+}
+
+fn check(a int) {
+	println(a)
+}


### PR DESCRIPTION
This PR fixes parsing of `for select {` block, where `CallExpr` were being sets incorrectyl to is_expr=true.

Fix #13505

copilot:summary

copilot:walkthrough
