### PR TITLE
checker: fix generic fn with nested generic fn call (fix #18285)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1355,11 +1355,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 			return node.return_type
 		} else if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
-			concrete_types)
+			node.concrete_types)
 		{
-			if typ.has_flag(.generic) {
-				node.return_type = typ
-			}
+			node.return_type = typ
 			return typ
 		}
 	}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1354,11 +1354,23 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				}
 			}
 			return node.return_type
-		} else if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
-			node.concrete_types)
-		{
-			node.return_type = typ
-			return typ
+		} else {
+			if node.concrete_types.len > 0 && !node.concrete_types.any(it.has_flag(.generic)) {
+				if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
+					node.concrete_types)
+				{
+					node.return_type = typ
+					return typ
+				}
+			}
+			if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
+				concrete_types)
+			{
+				if typ.has_flag(.generic) {
+					node.return_type = typ
+				}
+				return typ
+			}
 		}
 	}
 	return func.return_type

--- a/vlib/v/tests/generic_fn_with_nested_generic_fn_call_test.v
+++ b/vlib/v/tests/generic_fn_with_nested_generic_fn_call_test.v
@@ -1,0 +1,14 @@
+struct Test {}
+
+fn unmarshal[T]() ! {
+	get_number[int]()!
+}
+
+fn get_number[T]() !T {
+	return T(42)
+}
+
+fn test_generic_fn_with_nested_generic_fn_call() {
+	unmarshal[Test]()!
+	assert true
+}


### PR DESCRIPTION
This PR fix generic fn with nested generic fn call (fix #18285).

- Fix generic fn with nested generic fn call.
- Add test.

```v
struct Test {}

fn unmarshal[T]() ! {
	get_number[int]()!
}

fn get_number[T]() !T {
	return T(42)
}

fn main() {
	unmarshal[Test]()!
	assert true
}

PS D:\Test\v\tt1> v run .
```