### PR TITLE
cgen, checker, parser: fix fixed array with channel

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -188,6 +188,15 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			} else if mut right is ast.PrefixExpr {
 				if right.op == .amp && right.right is ast.StructInit {
 					right_type = c.expr(right)
+				} else if right.op == .arrow {
+					right_type = c.expr(right)
+					right_type_sym := c.table.sym(right_type)
+					if right_type_sym.kind == .array_fixed
+						&& (right_type_sym.info as ast.ArrayFixed).is_fn_ret {
+						info := right_type_sym.info as ast.ArrayFixed
+						right_type = c.table.find_or_register_array_fixed(info.elem_type,
+							info.size, info.size_expr, false)
+					}
 				}
 			} else if mut right is ast.Ident {
 				if right.kind == .function {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -353,6 +353,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
 			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr]
 			|| (val is ast.CastExpr && (val as ast.CastExpr).expr !is ast.ArrayInit)
+			|| (val is ast.PrefixExpr && (val as ast.PrefixExpr).op == .arrow)
 			|| (val is ast.UnsafeExpr && (val as ast.UnsafeExpr).expr is ast.Ident))
 			&& !g.pref.translated
 		g.is_assign_lhs = true

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -73,7 +73,7 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 			p.error_with_pos('fixed size cannot be zero or negative', size_expr.pos())
 		}
 		idx := p.table.find_or_register_array_fixed(elem_type, fixed_size, size_expr,
-			!is_option && p.inside_fn_return)
+			!is_option && (p.inside_fn_return || p.inside_chan_decl))
 		if elem_type.has_flag(.generic) {
 			return ast.new_type(idx).set_flag(.generic)
 		}
@@ -162,8 +162,10 @@ fn (mut p Parser) parse_chan_type() ast.Type {
 	}
 	p.register_auto_import('sync')
 	p.next()
+	p.inside_chan_decl = true
 	is_mut := p.tok.kind == .key_mut
 	elem_type := p.parse_type()
+	p.inside_chan_decl = false
 	idx := p.table.find_or_register_chan(elem_type, is_mut)
 	if elem_type.has_flag(.generic) {
 		return ast.new_type(idx).set_flag(.generic)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -64,6 +64,7 @@ mut:
 	inside_struct_attr_decl   bool
 	inside_map_init           bool
 	inside_orm                bool
+	inside_chan_decl          bool
 	or_is_handled             bool       // ignore `or` in this expression
 	builtin_mod               bool       // are we in the `builtin` module?
 	mod                       string     // current module name


### PR DESCRIPTION
Fix #18311

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db7c0ef</samp>

This pull request fixes the parsing, checking, and code generation of fixed-size arrays inside channel types. It adds a flag to the parser, handles arrow expressions in assignments, and adjusts the types and arguments for channel operations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db7c0ef</samp>

*  Handle assignments of fixed-size arrays returned by functions ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR191-R199),[link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bR356))
  - Check the right-hand side type of the assignment for arrow expressions in the checker ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR191-R199))
  - Generate the code for accessing the return value of the function in the C generator ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bR356))
*  Support fixed-size arrays as elements of channels ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL1411-R1428),[link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffL76-R76),[link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffL165-R168),[link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R67))
  - Adjust the types and arguments for the popval and pushval functions in the C generator ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL1411-R1428))
  - Mark fixed-size arrays inside channels as function return types in the table ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffL76-R76))
  - Set and unset the inside_chan_decl flag of the parser when parsing channel types ([link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffL165-R168),[link](https://github.com/vlang/v/pull/18315/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R67))
