### PR TITLE
vweb: Add support for host specific static files

### DIFF
--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -1045,7 +1045,8 @@ pub fn (mut app App) form_echo() vweb.Result {
 #### -handle_static
 
 handle_static is used to mark a folder (relative to the current working folder) as one that
-contains only static resources (css files, images etc).
+contains only static resources (css files, images etc).\
+host_handle_static can be used to limit the static resources to a specific host.
 
 If `root` is set the mount path for the dir will be in '/'
 
@@ -1055,6 +1056,7 @@ If `root` is set the mount path for the dir will be in '/'
 fn main() {
     mut app := &App{}
     app.serve_static('/favicon.ico', 'favicon.ico')
+    // app.host_serve_static('localhost', '/favicon.ico', 'favicon.ico')
     // Automatically make available known static mime types found in given directory.
     os.chdir(os.dir(os.executable()))?
     app.handle_static('assets', true)
@@ -1070,11 +1072,15 @@ For example: suppose you have called .mount_static_folder_at('/var/share/myasset
 and you have a file /var/share/myassets/main.css .
 => That file will be available at URL: http://server/assets/main.css .
 
+mount_static_folder_at can be used to limit the static resources to a specific host.
+
 #### -serve_static
 
 Serves a file static.
 `url` is the access path on the site, `file_path` is the real path to the file, `mime_type` is the
 file type
+
+host_serve_static can be used to limit the static resources to a specific host.
 
 **Example:**
 
@@ -1082,6 +1088,7 @@ file type
 fn main() {
     mut app := &App{}
     app.serve_static('/favicon.ico', 'favicon.ico')
+    // app.host_serve_static('localhost', /favicon.ico', 'favicon.ico')
     app.mount_static_folder_at(os.resource_abs_path('.'), '/')
     vweb.run(app, 8081)
 }


### PR DESCRIPTION
Add support for host specific static files.
Methods added:
 - host_handle_static
 - host_mount_static_folder_at
 - host_serve_static

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d7adcf</samp>

This pull request enhances the vweb module with the ability to serve static resources from different hosts. It updates the `vlib/vweb/README.md` file to document the new feature and adds new functions and fields to the `vlib/vweb/vweb.v` file to implement it. This feature can be useful for serving favicon.ico files or other static assets from different domains.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d7adcf</samp>

*  Add new feature to serve static resources from specific hosts in the vweb module ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L1048-R1049), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1059), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1075-R1076), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1083-R1084), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1091), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R161), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R582), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L697-R699), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L882-R894), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L898-R904), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L904-R918), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R934-R945), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L935-R955), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R965-R973), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L951-R980), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L959-R1000))
  * Add `static_hosts` field to the `Context` struct to store the host information for each static file ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R161))
  * Assign `static_hosts` field of the `request_app.Context` to a clone of the `global_app.static_hosts` in the `handle_conn` function ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R582))
  * Modify `serve_if_static` function to take an additional parameter `host` and check the host name of the request against the host information of the static file ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L697-R699))
  * Modify `handle` function to pass the host name of the request to the `serve_if_static` function ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L882-R894))
  * Modify `scan_static_directory` function to take an additional parameter `host` and add the host information to the context ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L898-R904), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L904-R918))
  * Add `host_handle_static` function to mark a folder as one that contains only static resources for a specific host and call the `scan_static_directory` function with the host name ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R934-R945))
  * Modify `handle_static` function to call the `host_handle_static` function with an empty host name ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L935-R955))
  * Add `host_mount_static_folder_at` function to serve static resources from a specific host and a specific mount path and call the `scan_static_directory` function with the host name and the mount path ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R965-R973))
  * Modify `mount_static_folder_at` function to call the `host_mount_static_folder_at` function with an empty host name ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L951-R980))
  * Add `host_serve_static` function to serve a single static file from a specific host and a specific url and add the file path, the mime type, and the host name to the context ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L959-R1000))
  * Modify `serve_static` function to call the `host_serve_static` function with an empty host name ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L959-R1000))
  * Update the README.md file of the vweb module to document the new feature and provide examples of using the new functions ([link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L1048-R1049), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1059), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1075-R1076), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1083-R1084), [link](https://github.com/vlang/v/pull/18322/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R1091))
