### PR TITLE
parser: detect wrong usage of Option as concrete type

### DIFF
--- a/vlib/v/checker/tests/option_concrete_type_err.out
+++ b/vlib/v/checker/tests/option_concrete_type_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/option_concrete_type_err.vv:5:8: error: cannot use Option type name as concrete type
+    3 | }
+    4 | 
+    5 | r := f[?int]()
+      |        ^

--- a/vlib/v/checker/tests/option_concrete_type_err.vv
+++ b/vlib/v/checker/tests/option_concrete_type_err.vv
@@ -1,0 +1,5 @@
+fn f[T]() T {
+	return none
+}
+
+r := f[?int]()

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -485,7 +485,10 @@ fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bo
 		} else if left !is ast.IntegerLiteral && p.tok.kind in [.lsbr, .nilsbr]
 			&& (p.tok.line_nr == p.prev_tok.line_nr || (p.prev_tok.kind == .string
 			&& p.tok.line_nr == p.prev_tok.line_nr + p.prev_tok.lit.count('\n'))) {
-			if p.tok.kind == .nilsbr {
+			if p.peek_tok.kind == .question && p.peek_token(2).kind == .name {
+				p.next()
+				p.error_with_pos('cannot use Option type name as concrete type', p.tok.pos())
+			} else if p.tok.kind == .nilsbr {
 				node = p.index_expr(node, true)
 			} else {
 				node = p.index_expr(node, false)


### PR DESCRIPTION
Fix #18331

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9d2c6a</samp>

This pull request adds a new checker test case and a parser error for using an Option type name as a concrete type for a generic function call. This is an invalid syntax that should be reported by the compiler.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9d2c6a</samp>

*  Report syntax error when using Option type name as concrete type for generic function call ([link](https://github.com/vlang/v/pull/18334/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL488-R491))
* Add test case for invalid syntax of Option type name as concrete type ([link](https://github.com/vlang/v/pull/18334/files?diff=unified&w=0#diff-206e938aefe51351594bf9a2af3866875e2419f3123f770bda7495ec8a57d592R1-R5), [link](https://github.com/vlang/v/pull/18334/files?diff=unified&w=0#diff-0f2dae0c091ffdca78a053e900f30da929153640580df003fc75939855c6388dR1-R5))
