### PR TITLE
cgen: fix option handling with auto heap variable

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -962,6 +962,17 @@ pub mut:
 	concrete_types []Type
 }
 
+pub fn (i &Ident) is_auto_heap() bool {
+	match i.obj {
+		Var {
+			return i.obj.is_auto_heap
+		}
+		else {
+			return false
+		}
+	}
+}
+
 pub fn (i &Ident) is_mut() bool {
 	match i.obj {
 		Var {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -17,7 +17,7 @@ fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr
 		expr_var := if expr is ast.Ident && (expr as ast.Ident).is_auto_heap() {
 			'(*${expr.name})'
 		} else {
-			g.expr_string(expr)
+			'${expr}'
 		}
 		g.writeln('if (${expr_var}.state != 0) { // assign')
 		if expr is ast.Ident && (expr as ast.Ident).or_expr.kind == .propagate_option {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -697,12 +697,12 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					}
 				} else {
 					// var = &auto_heap_var
-					old_is_auto_heap := g.is_auto_heap
-					g.is_auto_heap = val is ast.PrefixExpr
+					old_is_auto_heap := g.is_option_auto_heap
+					g.is_option_auto_heap = val_type.has_flag(.option) && val is ast.PrefixExpr
 						&& (val as ast.PrefixExpr).right is ast.Ident
 						&& ((val as ast.PrefixExpr).right as ast.Ident).is_auto_heap()
 					defer {
-						g.is_auto_heap = old_is_auto_heap
+						g.is_option_auto_heap = old_is_auto_heap
 					}
 					if var_type.has_flag(.option) || gen_or {
 						g.expr_with_opt_or_block(val, val_type, left, var_type)

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -696,10 +696,16 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						}
 					}
 				} else {
+					// var = &auto_heap_var
+					old_is_auto_heap := g.is_auto_heap
+					g.is_auto_heap = val is ast.PrefixExpr
+						&& (val as ast.PrefixExpr).right is ast.Ident
+						&& ((val as ast.PrefixExpr).right as ast.Ident).is_auto_heap()
+					defer {
+						g.is_auto_heap = old_is_auto_heap
+					}
 					if var_type.has_flag(.option) || gen_or {
-						g.is_auto_heap = is_auto_heap
 						g.expr_with_opt_or_block(val, val_type, left, var_type)
-						g.is_auto_heap = false
 					} else if node.has_cross_var {
 						g.gen_cross_tmp_variable(node.left, val)
 					} else {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -15,9 +15,9 @@ fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr
 		g.expr_with_cast(expr, expr_typ, ret_typ)
 		g.writeln(';')
 		expr_var := if expr is ast.Ident && (expr as ast.Ident).is_auto_heap() {
-			'(*${expr})'
+			'(*${expr.name})'
 		} else {
-			'${expr}'
+			g.expr_string(expr)
 		}
 		g.writeln('if (${expr_var}.state != 0) { // assign')
 		if expr is ast.Ident && (expr as ast.Ident).or_expr.kind == .propagate_option {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -14,7 +14,12 @@ fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr
 		g.inside_opt_or_res = true
 		g.expr_with_cast(expr, expr_typ, ret_typ)
 		g.writeln(';')
-		g.writeln('if (${expr}.state != 0) {')
+		expr_var := if expr is ast.Ident && (expr as ast.Ident).is_auto_heap() {
+			'(*${expr})'
+		} else {
+			'${expr}'
+		}
+		g.writeln('if (${expr_var}.state != 0) { // assign')
 		if expr is ast.Ident && (expr as ast.Ident).or_expr.kind == .propagate_option {
 			g.writeln('\tpanic_option_not_set(_SLIT("none"));')
 		} else {
@@ -623,6 +628,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						g.inside_opt_or_res = old_inside_opt_or_res
 					}
 					g.inside_opt_or_res = true
+					if is_auto_heap && var_type.has_flag(.option) {
+						g.write('&')
+					}
 					tmp_var := g.new_tmp_var()
 					g.expr_with_tmp_var(val, val_type, var_type, tmp_var)
 				} else if is_fixed_array_var {
@@ -689,7 +697,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					}
 				} else {
 					if var_type.has_flag(.option) || gen_or {
+						g.is_auto_heap = is_auto_heap
 						g.expr_with_opt_or_block(val, val_type, left, var_type)
+						g.is_auto_heap = false
 					} else if node.has_cross_var {
 						g.gen_cross_tmp_variable(node.left, val)
 					} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -104,7 +104,7 @@ mut:
 	is_js_call                bool // for handling a special type arg #1 `json.decode(User, ...)`
 	is_fn_index_call          bool
 	is_cc_msvc                bool // g.pref.ccompiler == 'msvc'
-	is_auto_heap              bool
+	is_option_auto_heap       bool
 	vlines_path               string   // set to the proper path for generating #line directives
 	options_pos_forward       int      // insertion point to forward
 	options_forward           []string // to forward
@@ -3343,14 +3343,14 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					}
 				}
 			} else {
-				if g.is_auto_heap && node.right_type.has_flag(.option) {
+				if g.is_option_auto_heap {
 					g.write('(${g.base_type(node.right_type)}*)')
 				}
-				if !g.is_auto_heap && !(g.is_amp && node.right.is_auto_deref_var()) {
+				if !g.is_option_auto_heap && !(g.is_amp && node.right.is_auto_deref_var()) {
 					g.write(node.op.str())
 				}
 				g.expr(node.right)
-				if g.is_auto_heap {
+				if g.is_option_auto_heap {
 					g.write('.data')
 				}
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -103,7 +103,8 @@ mut:
 	is_json_fn                bool // inside json.encode()
 	is_js_call                bool // for handling a special type arg #1 `json.decode(User, ...)`
 	is_fn_index_call          bool
-	is_cc_msvc                bool     // g.pref.ccompiler == 'msvc'
+	is_cc_msvc                bool // g.pref.ccompiler == 'msvc'
+	is_auto_heap              bool
 	vlines_path               string   // set to the proper path for generating #line directives
 	options_pos_forward       int      // insertion point to forward
 	options_forward           []string // to forward
@@ -3342,7 +3343,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					}
 				}
 			} else {
-				if !(g.is_amp && node.right.is_auto_deref_var()) {
+				if !(g.is_auto_heap && g.is_amp && node.right.is_auto_deref_var()) {
 					g.write(node.op.str())
 				}
 				g.expr(node.right)
@@ -3560,8 +3561,10 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	mut sum_type_deref_field := ''
 	mut sum_type_dot := '.'
+	mut field_typ := ast.void_type
 	if f := g.table.find_field_with_embeds(sym, node.field_name) {
 		field_sym := g.table.sym(f.typ)
+		field_typ = f.typ
 		if field_sym.kind in [.sum_type, .interface_] {
 			if !prevent_sum_type_unwrapping_once {
 				// check first if field is sum type because scope searching is expensive
@@ -3660,6 +3663,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			return
 		}
 	}
+	field_is_opt := node.expr is ast.Ident && (node.expr as ast.Ident).is_auto_heap()
+		&& (node.expr as ast.Ident).or_expr.kind != .absent && field_typ.has_flag(.option)
+	if field_is_opt {
+		g.write('((${g.base_type(field_typ)})')
+	}
 	n_ptr := node.expr_type.nr_muls() - 1
 	if n_ptr > 0 {
 		g.write('(')
@@ -3668,6 +3676,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		g.write(')')
 	} else {
 		g.expr(node.expr)
+	}
+	if field_is_opt {
+		g.write(')')
 	}
 	if is_opt_or_res {
 		g.write('.data)')
@@ -3691,8 +3702,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		}
 	}
 	alias_to_ptr := sym.info is ast.Alias && (sym.info as ast.Alias).parent_type.is_ptr()
-	if (node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
-		&& node.from_embed_types.len == 0 {
+	if field_is_opt
+		|| ((node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
+		&& node.from_embed_types.len == 0) {
 		g.write('->')
 	} else {
 		g.write('.')
@@ -4158,6 +4170,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 		}
 	}
 	mut is_auto_heap := false
+	mut is_option := false
 	if node.info is ast.IdentVar {
 		if node.obj is ast.Var {
 			if !g.is_assign_lhs && node.obj.ct_type_var !in [.generic_param, .no_comptime] {
@@ -4177,7 +4190,8 @@ fn (mut g Gen) ident(node ast.Ident) {
 					&& !g.is_assign_lhs) {
 					stmt_str := g.go_before_stmt(0).trim_space()
 					g.empty_line = true
-					g.or_block(name, node.or_expr, comptime_type)
+					var_opt := if node.obj.is_auto_heap { '(*${name})' } else { name }
+					g.or_block(var_opt, node.or_expr, comptime_type)
 					g.writeln(stmt_str)
 				}
 				return
@@ -4199,7 +4213,12 @@ fn (mut g Gen) ident(node ast.Ident) {
 				&& !g.is_assign_lhs) {
 				stmt_str := g.go_before_stmt(0).trim_space()
 				g.empty_line = true
-				g.or_block(name, node.or_expr, node.info.typ)
+				var_opt := if node.obj is ast.Var && (node.obj as ast.Var).is_auto_heap {
+					'(*${name})'
+				} else {
+					name
+				}
+				g.or_block(var_opt, node.or_expr, node.info.typ)
 				g.write(stmt_str)
 			}
 			return
@@ -4208,6 +4227,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			g.write('${name}.val')
 			return
 		}
+		is_option = node.info.is_option
 		if node.obj is ast.Var {
 			is_auto_heap = node.obj.is_auto_heap
 				&& (!g.is_assign_lhs || g.assign_op != .decl_assign)
@@ -4280,6 +4300,16 @@ fn (mut g Gen) ident(node ast.Ident) {
 	g.write(g.get_ternary_name(name))
 	if is_auto_heap {
 		g.write('))')
+		if is_option {
+			g.write('.data')
+		}
+	}
+	if node.or_expr.kind != .absent && !(g.inside_opt_or_res && g.inside_assign && !g.is_assign_lhs) {
+		stmt_str := g.go_before_stmt(0).trim_space()
+		g.empty_line = true
+		var_opt := if is_auto_heap { '(*${name})' } else { name }
+		g.or_block(var_opt, node.or_expr, node.info.typ)
+		g.write(stmt_str)
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4183,19 +4183,18 @@ fn (mut g Gen) ident(node ast.Ident) {
 				comptime_type := g.get_comptime_var_type(node)
 				if comptime_type.has_flag(.option) {
 					if (g.inside_opt_or_res || g.left_is_opt) && node.or_expr.kind == .absent {
-						var_name := if !g.is_assign_lhs && is_auto_heap {
-							'(*${name})'
+						if !g.is_assign_lhs && is_auto_heap {
+							g.write('(*${name})')
 						} else {
-							name
+							g.write(name)
 						}
-						g.write('${var_name}')
 					} else {
 						g.write('/*opt*/')
 						styp := g.base_type(comptime_type)
 						g.write('(*(${styp}*)${name}.data)')
 					}
 				} else {
-					g.write('${name}')
+					g.write(name)
 				}
 				if node.or_expr.kind != .absent && !(g.inside_opt_or_res && g.inside_assign
 					&& !g.is_assign_lhs) {
@@ -4214,8 +4213,11 @@ fn (mut g Gen) ident(node ast.Ident) {
 		// `println(x)` => `println(*(int*)x.data)`
 		if node.info.is_option && !(g.is_assign_lhs && g.right_is_opt) {
 			if (g.inside_opt_or_res || g.left_is_opt) && node.or_expr.kind == .absent {
-				var_name := if !g.is_assign_lhs && is_auto_heap { '(*${name})' } else { name }
-				g.write('${var_name}')
+				if !g.is_assign_lhs && is_auto_heap {
+					g.write('(*${name})')
+				} else {
+					g.write(name)
+				}
 			} else {
 				g.write('/*opt*/')
 				styp := g.base_type(node.info.typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4191,7 +4191,11 @@ fn (mut g Gen) ident(node ast.Ident) {
 					} else {
 						g.write('/*opt*/')
 						styp := g.base_type(comptime_type)
-						g.write('(*(${styp}*)${name}.data)')
+						if is_auto_heap {
+							g.write('(*(${styp}*)${name}->data)')
+						} else {
+							g.write('(*(${styp}*)${name}.data)')
+						}
 					}
 				} else {
 					g.write(name)
@@ -4221,7 +4225,11 @@ fn (mut g Gen) ident(node ast.Ident) {
 			} else {
 				g.write('/*opt*/')
 				styp := g.base_type(node.info.typ)
-				g.write('(*(${styp}*)${name}.data)')
+				if is_auto_heap {
+					g.write('(*(${styp}*)${name}->data)')
+				} else {
+					g.write('(*(${styp}*)${name}.data)')
+				}
 			}
 			if node.or_expr.kind != .absent && !(g.inside_opt_or_res && g.inside_assign
 				&& !g.is_assign_lhs) {
@@ -4322,7 +4330,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 		stmt_str := g.go_before_stmt(0).trim_space()
 		g.empty_line = true
 		var_opt := if is_auto_heap { '(*${name})' } else { name }
-		g.or_block(var_opt, node.or_expr, node.info.typ)
+		g.or_block(var_opt, node.or_expr, node.obj.typ)
 		g.write(stmt_str)
 	}
 }

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -63,10 +63,6 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 	} else {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
-		if expr_type.has_flag(.option) && node.expr is ast.Ident
-			&& (node.expr as ast.Ident).is_auto_heap() {
-			g.write('*')
-		}
 		g.expr(node.expr)
 		g.inside_opt_or_res = old_inside_opt_or_res
 	}

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -63,6 +63,10 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 	} else {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
+		if expr_type.has_flag(.option) && node.expr is ast.Ident
+			&& (node.expr as ast.Ident).is_auto_heap() {
+			g.write('*')
+		}
 		g.expr(node.expr)
 		g.inside_opt_or_res = old_inside_opt_or_res
 	}

--- a/vlib/v/tests/option_auto_heap_test.v
+++ b/vlib/v/tests/option_auto_heap_test.v
@@ -1,0 +1,24 @@
+struct Teste {
+pub mut:
+	teste ?&Teste
+}
+
+fn test_main() {
+	mut a := Teste{}
+	a.teste = &a
+	dump(a) // circular
+
+	assert a.teste? == &a
+
+	mut t := ?Teste{}
+	w := dump(t) // Option(none)
+	assert w == none
+
+	mut z := ?Teste{}
+	z = Teste{}
+	z?.teste = &z
+	dump(z) // // circular
+
+	y := z?
+	assert y.teste? == &z?
+}


### PR DESCRIPTION
Fix #18329

```V
struct Teste {
pub mut:
	teste ?&Teste
}

mut a := Teste{}
a.teste = &a
dump(a) // circular


mut t := ?Teste{}
dump(t) // Option(none)

mut z := ?Teste{}
z = Teste{}
z?.teste = &z
dump(z) // circular
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 37c0fff</samp>

This pull request implements a feature that allows the compiler to infer the heap allocation of some variables and wrap them in option types. It modifies the `ast`, `cgen`, and `assign` modules to handle the new syntax and semantics of auto-heap variables. It also fixes some bugs in the code generation for assignment statements involving option types.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 37c0fff</samp>

*  Add a new method `is_auto_heap` to the `Ident` struct that checks if the identifier is an auto-heap variable with an option type ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-8e27648d38098f8fe63778c94c11aceb0a48e379121f676d189b04cb2cd8fc45R965-R975))
  * Introduce a new variable `expr_var` that holds the right-hand side expression of the assignment and dereference it if it is an auto-heap variable ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL17-R22))
  * Add a condition that takes the address of the right-hand side expression if the left-hand side variable is an auto-heap variable ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bR631-R633))
  * Add a block of code that sets and restores a new field `is_option_auto_heap` in the `Gen` struct to indicate if the right-hand side expression is an auto-heap variable ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bR699-R706))
  * Add a new field `is_option_auto_heap` to the `Gen` struct to store the state of the current expression ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL106-R107))
  * Add a condition that casts the right-hand side expression to the base type of the option type if it is an auto-heap variable in a binary expression with an assignment operator ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3345-R3355))
  * Add a new variable `field_typ` that holds the type of the field being accessed in a selector expression and initialize it with the result of the `find_field_with_embeds` method ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3563-R3573))
  * Add a condition that casts the field to the base type of the option type if it is an auto-heap variable in a selector expression ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR3672-R3676), [link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR3686-R3688))
  * Add a condition that dereferences the field with a `->` operator if it is an auto-heap variable in a selector expression, or uses a `.` operator otherwise ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3694-R3713))
  * Add two new variables `is_auto_heap` and `is_option` that store the result of the `is_auto_heap` method and the `is_option` field of the `IdentVar` struct in the case of an identifier expression ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4160-R4179), [link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR4242))
  * Add a condition that dereferences the identifier with a `(*${name})` expression if it is an auto-heap variable in an identifier expression with an option type or an option flag ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4167-R4191), [link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4180-R4205), [link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4192-R4218), [link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4202-R4233))
  * Add a condition that accesses the data field of the option type with a `.data` expression if the identifier is an auto-heap variable in an identifier expression ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4283-R4325))
  * Add a condition that generates the C code for the `or` block if the identifier has an `or` block and is not inside an option or result type or on the left-hand side of an assignment ([link](https://github.com/vlang/v/pull/18336/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4283-R4325))