### PR TITLE
cgen: added circular reference limit to auto_str for interface 

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1007,7 +1007,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 			if field.typ in ast.charptr_types {
 				fn_body.write_string('tos4((byteptr)${func})')
 			} else {
-				if field.typ.is_ptr() && sym.kind == .struct_ {
+				if field.typ.is_ptr() && sym.kind in [.struct_, .interface_] {
 					funcprefix += '(indent_count > 25)? _SLIT("<probably circular>") : '
 				}
 				// eprintln('>>> caller_should_free: ${caller_should_free:6s} | funcprefix: $funcprefix | func: $func')

--- a/vlib/v/tests/option_ptr_iface_test.v
+++ b/vlib/v/tests/option_ptr_iface_test.v
@@ -1,0 +1,16 @@
+interface ITeste {
+mut:
+	teste ?&ITeste
+}
+
+struct Teste {
+pub mut:
+	teste ?&ITeste
+}
+
+fn test_main() {
+	mut t := Teste{}
+	t.teste = &t
+	dump(t)
+	assert t.teste? == &ITeste(t.teste?)
+}

--- a/vlib/v/tests/option_ptr_iface_test.v
+++ b/vlib/v/tests/option_ptr_iface_test.v
@@ -11,6 +11,8 @@ pub mut:
 fn test_main() {
 	mut t := Teste{}
 	t.teste = &t
+	z := &ITeste(t)
+	dump(z)
 	dump(t)
-	assert t.teste? == &ITeste(t.teste?)
+	assert voidptr(t.teste?) == voidptr(z.teste?)
 }


### PR DESCRIPTION
Fix #18328

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b35832</samp>

Fix and test a bug in the `str` method for structs and interfaces with circular references. The bug could cause a stack overflow when printing such types. The fix uses a special string to indicate the possible cycle. The test case defines and checks an example of such a type. The files affected are `vlib/v/gen/c/auto_str_methods.v` and `vlib/v/tests/option_ptr_iface_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b35832</samp>

* Fix bug in auto-generated `str` method for structs and interfaces with circular references ([link](https://github.com/vlang/v/pull/18340/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL1010-R1010))
* Add test case for `str` method with option pointer interface field ([link](https://github.com/vlang/v/pull/18340/files?diff=unified&w=0#diff-bdeaa97649075d155f77d3ca6c2b4710d244bc6f469d44fbc944739dfa48f0baR1-R16))
