### PR TITLE
checker: fix generic fn infering map argument (fix #18337)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -344,7 +344,8 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		mut key0_type := ast.void_type
 		mut val0_type := ast.void_type
 		use_expected_type := c.expected_type != ast.void_type && !c.inside_const
-			&& c.table.sym(c.expected_type).kind == .map
+			&& c.table.sym(c.expected_type).kind == .map && !(c.inside_fn_arg
+			&& c.expected_type.has_flag(.generic))
 		if use_expected_type {
 			sym := c.table.sym(c.expected_type)
 			info := sym.map_info()

--- a/vlib/v/tests/generic_fn_infer_map_argument_test.v
+++ b/vlib/v/tests/generic_fn_infer_map_argument_test.v
@@ -1,0 +1,17 @@
+fn f[T](src map[string]T) T {
+	return src['a']
+}
+
+fn test_generic_fn_infer_map_arg() {
+	r1 := f({
+		'a': 1
+	})
+	println(r1)
+	assert r1 == 1
+
+	r2 := f({
+		'a': 'hello'
+	})
+	println(r2)
+	assert r2 == 'hello'
+}


### PR DESCRIPTION
This PR fix generic fn infering map argument (fix #18337).

- Fix generic fn infering map argument.
- Add test.

```v
fn f[T](src map[string]T) T {
	return src['a']
}

fn main() {
	r1 := f({
		'a': 1
	})
	println(r1)
	assert r1 == 1

	r2 := f({
		'a': 'hello'
	})
	println(r2)
	assert r2 == 'hello'
}

PS D:\Test\v\tt1> v run .
1
hello
```