### PR TITLE
ast: fix for in iterator of generic struct (fix #18339)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1905,7 +1905,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 			mut info := ts.info
 			info.is_generic = false
 			info.concrete_types = final_concrete_types
-			info.parent_type = typ
+			info.parent_type = typ.set_flag(.generic)
 			info.fields = fields
 			new_idx := t.register_sym(
 				kind: .struct_
@@ -1940,7 +1940,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 			mut info := ts.info
 			info.is_generic = false
 			info.concrete_types = final_concrete_types
-			info.parent_type = typ
+			info.parent_type = typ.set_flag(.generic)
 			info.fields = fields
 			info.variants = variants
 			new_idx := t.register_sym(
@@ -1984,7 +1984,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 			mut info := ts.info
 			info.is_generic = false
 			info.concrete_types = final_concrete_types
-			info.parent_type = typ
+			info.parent_type = typ.set_flag(.generic)
 			info.fields = fields
 			info.methods = imethods
 			new_idx := t.register_sym(

--- a/vlib/v/tests/for_in_iterator_of_generic_struct_3_test.v
+++ b/vlib/v/tests/for_in_iterator_of_generic_struct_3_test.v
@@ -1,0 +1,28 @@
+struct MyGenericArray[T] {
+	arr []T
+mut:
+	idx int
+}
+
+fn (mut self MyGenericArray[T]) next() ?T {
+	if self.arr.len <= self.idx {
+		return none
+	} else {
+		defer {
+			self.idx++
+		}
+		return self.arr[self.idx]
+	}
+}
+
+fn test_for_in_iterator_of_generic_struct() {
+	mut a := MyGenericArray{[4, 5, 6], 1}
+	mut ret := []int{}
+	for i in a {
+		println(i)
+		ret << i
+	}
+	assert ret.len == 2
+	assert ret[0] == 5
+	assert ret[1] == 6
+}


### PR DESCRIPTION
This PR fix for in iterator of generic struct (fix #18339).

- Fix for in iterator of generic struct.
- Add test.

```v
struct MyGenericArray[T] {
	arr []T
mut:
	idx int
}

fn (mut self MyGenericArray[T]) next() ?T {
	if self.arr.len <= self.idx {
		return none
	} else {
		defer {
			self.idx++
		}
		return self.arr[self.idx]
	}
}

fn main() {
	mut a := MyGenericArray{[4, 5, 6], 1}
	mut ret := []int{}
	for i in a {
		println(i)
		ret << i
	}
	assert ret.len == 2
	assert ret[0] == 5
	assert ret[1] == 6
}

PS D:\Test\v\tt1> v run .
5
6
```