### PR TITLE
fmt: fix alias type stripped comments

### DIFF
--- a/vlib/v/fmt/tests/type_decl_comments_keep.vv
+++ b/vlib/v/fmt/tests/type_decl_comments_keep.vv
@@ -1,0 +1,4 @@
+const a = 1 // foo
+
+pub type Keycode = int // foo
+type Keycode2 = f64 | int // foo

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4118,7 +4118,7 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		p.error_with_pos('a type alias can not refer to itself: ${name}', decl_pos.extend(type_alias_pos))
 		return ast.AliasTypeDecl{}
 	}
-	comments = p.eat_comments(same_line: true)
+	comments = sum_variants[0].end_comments.clone()
 	return ast.AliasTypeDecl{
 		name: name
 		is_pub: is_pub


### PR DESCRIPTION
Fix #18343

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c772ce</samp>

This pull request improves the handling of comments in type declarations, both in the parser and the formatter. It fixes a bug that dropped comments after sum type variants in `vlib/v/parser/parser.v` and adds some tests for the type declaration formatting with comments in `vlib/v/fmt/tests/type_decl_comments_keep.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c772ce</samp>

* Fix a bug in the parser that caused comments after sum type variants to be lost ([link](https://github.com/vlang/v/pull/18346/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4121-R4121))
* Add test cases for type declaration formatting with comments in `vlib/v/fmt/tests/type_decl_comments_keep.vv` ([link](https://github.com/vlang/v/pull/18346/files?diff=unified&w=0#diff-0bef509aab87383761a29710e84f371b9b43fa5ef22c1d4c4b60827d925d4767R1-R4))
