### PR TITLE
cgen: fix fixed array of map type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2530,6 +2530,12 @@ pub fn (mut c Checker) expr(node_ ast.Expr) ast.Type {
 
 			unwrapped_expr_type := c.unwrap_generic(node.expr_type)
 			tsym := c.table.sym(unwrapped_expr_type)
+			if tsym.kind == .array_fixed {
+				info := tsym.info as ast.ArrayFixed
+				// for dumping fixed array we must registed the fixed array struct to return from function
+				c.table.find_or_register_array_fixed(info.elem_type, info.size, info.size_expr,
+					true)
+			}
 			type_cname := if node.expr_type.has_flag(.option) {
 				'_option_${tsym.cname}'
 			} else {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -170,7 +170,24 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			g.expr(node.default_expr)
 		}
 	} else {
-		g.write('0')
+		elem_sym := g.table.final_sym(node.elem_type)
+		if elem_sym.kind == .map {
+			info := array_type.unaliased_sym.info as ast.ArrayFixed
+			map_info := elem_sym.map_info()
+			g.expr(ast.MapInit{
+				key_type: map_info.key_type
+				value_type: map_info.value_type
+			})
+			for _ in 1 .. info.size {
+				g.write(', ')
+				g.expr(ast.MapInit{
+					key_type: map_info.key_type
+					value_type: map_info.value_type
+				})
+			}
+		} else {
+			g.write('0')
+		}
 	}
 	g.write('}')
 	if need_tmp_var {

--- a/vlib/v/tests/fixed_array_map_test.v
+++ b/vlib/v/tests/fixed_array_map_test.v
@@ -1,0 +1,13 @@
+fn test_main() {
+	mut arr := [22]map[string]string{}
+	arr[0]['key'] = 'value'
+	arr[1]['key2'] = 'value2'
+	dump(arr[0])
+	assert dump(arr[0]) == {
+		'key': 'value'
+	}
+	assert dump(arr[1]) == {
+		'key2': 'value2'
+	}
+	assert dump(arr).len == 22
+}


### PR DESCRIPTION
Fix #18342

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5920e41</samp>

This pull request adds support for fixed arrays of maps in the V language. It modifies the `checker.v` and `array.v` files to handle the type checking and code generation for this feature, and adds a test file `fixed_array_map_test.v` to verify its functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5920e41</samp>

*  Add support for fixed arrays of maps in the checker and the C backend ([link](https://github.com/vlang/v/pull/18347/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R2533-R2538), [link](https://github.com/vlang/v/pull/18347/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278L173-R190))
  - Check if the type symbol of a variable is a fixed array and register it in the table (`checker.v`, [link](https://github.com/vlang/v/pull/18347/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R2533-R2538))
  - Generate C code for initializing each map element of a fixed array with an empty map (`array.v`, [link](https://github.com/vlang/v/pull/18347/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278L173-R190))
* Add a test function for fixed arrays of maps (`fixed_array_map_test.v`, [link](https://github.com/vlang/v/pull/18347/files?diff=unified&w=0#diff-3461fdd206b548ece75875dbe8847bd33ad5713ce04267ce37c5dfd1f9668b63R1-R13))
