### PR TITLE
checker: fix infering generic array type in nested call (fix #18317)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -934,9 +934,9 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					typ = typ.set_nr_muls(0)
 				}
 			} else if param.typ.has_flag(.generic) {
-				arg_sym := c.table.final_sym(arg.typ)
+				arg_sym := c.table.final_sym(c.unwrap_generic(arg.typ))
 				if param.typ.has_flag(.variadic) {
-					typ = ast.mktyp(arg.typ)
+					typ = ast.mktyp(c.unwrap_generic(arg.typ))
 				} else if arg_sym.info is ast.Array && param_sym.info is ast.Array {
 					mut arg_elem_typ, mut param_elem_typ := arg_sym.info.elem_type, param_sym.info.elem_type
 					mut arg_elem_sym, mut param_elem_sym := c.table.sym(arg_elem_typ), c.table.sym(param_elem_typ)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -934,9 +934,14 @@ fn (mut c Checker) infer_fn_generic_types(func ast.Fn, mut node ast.CallExpr) {
 					typ = typ.set_nr_muls(0)
 				}
 			} else if param.typ.has_flag(.generic) {
-				arg_sym := c.table.final_sym(c.unwrap_generic(arg.typ))
+				arg_typ := if c.table.sym(arg.typ).kind == .any {
+					c.unwrap_generic(arg.typ)
+				} else {
+					arg.typ
+				}
+				arg_sym := c.table.final_sym(arg_typ)
 				if param.typ.has_flag(.variadic) {
-					typ = ast.mktyp(c.unwrap_generic(arg.typ))
+					typ = ast.mktyp(arg_typ)
 				} else if arg_sym.info is ast.Array && param_sym.info is ast.Array {
 					mut arg_elem_typ, mut param_elem_typ := arg_sym.info.elem_type, param_sym.info.elem_type
 					mut arg_elem_sym, mut param_elem_sym := c.table.sym(arg_elem_typ), c.table.sym(param_elem_typ)

--- a/vlib/v/tests/generics_fn_return_result_test.v
+++ b/vlib/v/tests/generics_fn_return_result_test.v
@@ -1,6 +1,6 @@
 fn make_2x3[T](mut res [][]T) ! {
 	mut a := []T{len: 6}
-	res = reshape(a, [2, 3])!
+	res = reshape[T](a, [2, 3])!
 }
 
 fn reshape[T](y []T, dims []int) ![][]T {

--- a/vlib/v/tests/infer_generic_array_type_in_nested_call_test.v
+++ b/vlib/v/tests/infer_generic_array_type_in_nested_call_test.v
@@ -1,0 +1,17 @@
+fn unmarshal_any[T]() T {
+	mut typ := T{}
+	$if T is $array {
+		unmarshal_array(mut typ)
+	}
+	return typ
+}
+
+fn unmarshal_array[T](mut typ []T) {
+	typ << 42
+}
+
+fn test_infer_generic_array_type_in_nested_call() {
+	ret := unmarshal_any[[]int]()
+	println(ret)
+	assert ret == [42]
+}


### PR DESCRIPTION
This PR fix infering generic array type in nested call (fix #18317).

- Fix infering generic array type in nested call.
- Add test.

```v
fn unmarshal_any[T]() T {
	mut typ := T{}
	$if T is $array {
		unmarshal_array(mut typ)
	}
	return typ
}

fn unmarshal_array[T](mut typ []T) {
	typ << 42
}

fn main() {
	ret := unmarshal_any[[]int]()
	println(ret)
	assert ret == [42]
}

PS D:\Test\v\tt1> v run .
[42]
```