### PR TITLE
sync: add destroy

### DIFF
--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -66,22 +66,26 @@ pub struct Semaphore {
 	sem C.sem_t
 }
 
+// `new_mutex` create and init a new mutex object. You should not call `init` again.
 pub fn new_mutex() &Mutex {
 	mut m := &Mutex{}
 	m.init()
 	return m
 }
 
+// `init` the mutex object.
 pub fn (mut m Mutex) init() {
 	C.pthread_mutex_init(&m.mutex, C.NULL)
 }
 
+// `new_rwmutex` create and init a new rwmutex object. You should not call `init` again.
 pub fn new_rwmutex() &RwMutex {
 	mut m := &RwMutex{}
 	m.init()
 	return m
 }
 
+// `init` the rwmutex object.
 pub fn (mut m RwMutex) init() {
 	a := RwMutexAttr{}
 	C.pthread_rwlockattr_init(&a.attr)
@@ -92,15 +96,17 @@ pub fn (mut m RwMutex) init() {
 	C.pthread_rwlockattr_destroy(&a.attr) // destroy the attr when done
 }
 
-// @lock(), for *manual* mutex handling, since `lock` is a keyword
+// `@lock` the mutex, wait and return after got the mutex lock.
 pub fn (mut m Mutex) @lock() {
 	C.pthread_mutex_lock(&m.mutex)
 }
 
+// `unlock` the mutex. The mutex is released.
 pub fn (mut m Mutex) unlock() {
 	C.pthread_mutex_unlock(&m.mutex)
 }
 
+// `destroy` the mutex object.
 pub fn (mut m Mutex) destroy() {
 	res := C.pthread_mutex_destroy(&m.mutex)
 	if res == 0 {
@@ -109,15 +115,17 @@ pub fn (mut m Mutex) destroy() {
 	panic(unsafe { tos_clone(&u8(C.strerror(res))) })
 }
 
-// RwMutex has separate read- and write locks
+// `@rlock` read-lock the rwmutex, wait and return after got read access.
 pub fn (mut m RwMutex) @rlock() {
 	C.pthread_rwlock_rdlock(&m.mutex)
 }
 
+// `@lock` read & write-lock the rwmutex, wait and return after got read & write access.
 pub fn (mut m RwMutex) @lock() {
 	C.pthread_rwlock_wrlock(&m.mutex)
 }
 
+// `destroy` the rwmutex object.
 pub fn (mut m RwMutex) destroy() {
 	res := C.pthread_rwlock_destroy(&m.mutex)
 	if res == 0 {
@@ -132,29 +140,35 @@ pub fn (mut m RwMutex) runlock() {
 	C.pthread_rwlock_unlock(&m.mutex)
 }
 
+// `unlock` the rwmutex object. The rwmutex is released.
 pub fn (mut m RwMutex) unlock() {
 	C.pthread_rwlock_unlock(&m.mutex)
 }
 
+// `new_semaphore` create a new semaphore, with zero initial value.
 [inline]
 pub fn new_semaphore() &Semaphore {
 	return new_semaphore_init(0)
 }
 
+// `new_semaphore_init` create a semaphore, with `n` initial value.
 pub fn new_semaphore_init(n u32) &Semaphore {
 	mut sem := &Semaphore{}
 	sem.init(n)
 	return sem
 }
 
+// `init` the semaphore, with `n` initial value.
 pub fn (mut sem Semaphore) init(n u32) {
 	C.sem_init(&sem.sem, 0, n)
 }
 
+// `post` increase the semaphore's value by 1.
 pub fn (mut sem Semaphore) post() {
 	C.sem_post(&sem.sem)
 }
 
+// `wait` decrease the semaphore's value by 1. If semaphore's original value is zero, then wait.
 pub fn (mut sem Semaphore) wait() {
 	for {
 		if C.sem_wait(&sem.sem) == 0 {
@@ -193,6 +207,8 @@ pub fn (mut sem Semaphore) try_wait() bool {
 	}
 }
 
+// `timed_wait` decrease the semaphore's value by 1. If semaphore's original
+// value is zero, then wait. If `timeout` return false.
 pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 	$if macos {
 		time.sleep(timeout)
@@ -221,6 +237,7 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 	return false
 }
 
+// `destroy` the semaphore object.
 pub fn (mut sem Semaphore) destroy() {
 	res := C.sem_destroy(&sem.sem)
 	if res == 0 {

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -66,26 +66,26 @@ pub struct Semaphore {
 	sem C.sem_t
 }
 
-// `new_mutex` create and init a new mutex object. You should not call `init` again.
+// new_mutex create and init a new mutex object. You should not call `init` again.
 pub fn new_mutex() &Mutex {
 	mut m := &Mutex{}
 	m.init()
 	return m
 }
 
-// `init` the mutex object.
+// init the mutex object.
 pub fn (mut m Mutex) init() {
 	C.pthread_mutex_init(&m.mutex, C.NULL)
 }
 
-// `new_rwmutex` create and init a new rwmutex object. You should not call `init` again.
+// new_rwmutex create and init a new rwmutex object. You should not call `init` again.
 pub fn new_rwmutex() &RwMutex {
 	mut m := &RwMutex{}
 	m.init()
 	return m
 }
 
-// `init` the rwmutex object.
+// init the rwmutex object.
 pub fn (mut m RwMutex) init() {
 	a := RwMutexAttr{}
 	C.pthread_rwlockattr_init(&a.attr)
@@ -96,17 +96,17 @@ pub fn (mut m RwMutex) init() {
 	C.pthread_rwlockattr_destroy(&a.attr) // destroy the attr when done
 }
 
-// `@lock` the mutex, wait and return after got the mutex lock.
+// @lock the mutex, wait and return after got the mutex lock.
 pub fn (mut m Mutex) @lock() {
 	C.pthread_mutex_lock(&m.mutex)
 }
 
-// `unlock` the mutex. The mutex is released.
+// unlock the mutex. The mutex is released.
 pub fn (mut m Mutex) unlock() {
 	C.pthread_mutex_unlock(&m.mutex)
 }
 
-// `destroy` the mutex object.
+// destroy the mutex object.
 pub fn (mut m Mutex) destroy() {
 	res := C.pthread_mutex_destroy(&m.mutex)
 	if res == 0 {
@@ -115,17 +115,17 @@ pub fn (mut m Mutex) destroy() {
 	panic(unsafe { tos_clone(&u8(C.strerror(res))) })
 }
 
-// `@rlock` read-lock the rwmutex, wait and return after got read access.
+// @rlock read-lock the rwmutex, wait and return after got read access.
 pub fn (mut m RwMutex) @rlock() {
 	C.pthread_rwlock_rdlock(&m.mutex)
 }
 
-// `@lock` read & write-lock the rwmutex, wait and return after got read & write access.
+// @lock read & write-lock the rwmutex, wait and return after got read & write access.
 pub fn (mut m RwMutex) @lock() {
 	C.pthread_rwlock_wrlock(&m.mutex)
 }
 
-// `destroy` the rwmutex object.
+// destroy the rwmutex object.
 pub fn (mut m RwMutex) destroy() {
 	res := C.pthread_rwlock_destroy(&m.mutex)
 	if res == 0 {
@@ -140,35 +140,35 @@ pub fn (mut m RwMutex) runlock() {
 	C.pthread_rwlock_unlock(&m.mutex)
 }
 
-// `unlock` the rwmutex object. The rwmutex is released.
+// unlock the rwmutex object. The rwmutex is released.
 pub fn (mut m RwMutex) unlock() {
 	C.pthread_rwlock_unlock(&m.mutex)
 }
 
-// `new_semaphore` create a new semaphore, with zero initial value.
+// new_semaphore create a new semaphore, with zero initial value.
 [inline]
 pub fn new_semaphore() &Semaphore {
 	return new_semaphore_init(0)
 }
 
-// `new_semaphore_init` create a semaphore, with `n` initial value.
+// new_semaphore_init create a semaphore, with `n` initial value.
 pub fn new_semaphore_init(n u32) &Semaphore {
 	mut sem := &Semaphore{}
 	sem.init(n)
 	return sem
 }
 
-// `init` the semaphore, with `n` initial value.
+// init the semaphore, with `n` initial value.
 pub fn (mut sem Semaphore) init(n u32) {
 	C.sem_init(&sem.sem, 0, n)
 }
 
-// `post` increase the semaphore's value by 1.
+// post increase the semaphore's value by 1.
 pub fn (mut sem Semaphore) post() {
 	C.sem_post(&sem.sem)
 }
 
-// `wait` decrease the semaphore's value by 1. If semaphore's original value is zero, then wait.
+// wait decrease the semaphore's value by 1. If semaphore's original value is zero, then wait.
 pub fn (mut sem Semaphore) wait() {
 	for {
 		if C.sem_wait(&sem.sem) == 0 {
@@ -186,7 +186,7 @@ pub fn (mut sem Semaphore) wait() {
 	}
 }
 
-// `try_wait()` should return as fast as possible so error handling is only
+// try_wait should return as fast as possible so error handling is only
 // done when debugging
 pub fn (mut sem Semaphore) try_wait() bool {
 	$if !debug {
@@ -207,7 +207,7 @@ pub fn (mut sem Semaphore) try_wait() bool {
 	}
 }
 
-// `timed_wait` decrease the semaphore's value by 1. If semaphore's original
+// timed_wait decrease the semaphore's value by 1. If semaphore's original
 // value is zero, then wait. If `timeout` return false.
 pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 	$if macos {
@@ -237,7 +237,7 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 	return false
 }
 
-// `destroy` the semaphore object.
+// destroy the semaphore object.
 pub fn (mut sem Semaphore) destroy() {
 	res := C.sem_destroy(&sem.sem)
 	if res == 0 {

--- a/vlib/v/slow_tests/valgrind/sync.v
+++ b/vlib/v/slow_tests/valgrind/sync.v
@@ -1,0 +1,20 @@
+import sync
+
+fn main() {
+	mut mutex := sync.new_mutex()
+	mutex.@lock()
+	mutex.unlock()
+	mutex.destroy()
+
+	mut rwmutex := sync.new_rwmutex()
+	rwmutex.@rlock()
+	rwmutex.unlock()
+	rwmutex.@lock()
+	rwmutex.unlock()
+	rwmutex.destroy()
+
+	mut sem := sync.new_semaphore()
+	sem.post()
+	sem.wait()
+	sem.destroy()
+}


### PR DESCRIPTION
sync: add destroy functions for Mutex, RwMutex.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c93d00</samp>

Added `destroy` methods to `sync` structs and a Valgrind test file. This fixes a memory leak and ensures proper resource management for the `sync` module.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c93d00</samp>

*  Add `destroy` methods to `Mutex` and `RwMutex` structs to free resources and avoid memory leaks ([link](https://github.com/vlang/v/pull/18351/files?diff=unified&w=0#diff-60365d617031f02fcf17685b4fce03d9e7c9f094f9aba23d049d83e8598e5eb2R104-R111), [link](https://github.com/vlang/v/pull/18351/files?diff=unified&w=0#diff-60365d617031f02fcf17685b4fce03d9e7c9f094f9aba23d049d83e8598e5eb2R121-R128))
*  Call `pthread_rwlockattr_destroy` after initializing `RwMutex` to destroy attribute object ([link](https://github.com/vlang/v/pull/18351/files?diff=unified&w=0#diff-60365d617031f02fcf17685b4fce03d9e7c9f094f9aba23d049d83e8598e5eb2R92))
*  Wrap C functions `pthread_rwlockattr_destroy` and `pthread_rwlock_destroy` in V module `sync` ([link](https://github.com/vlang/v/pull/18351/files?diff=unified&w=0#diff-60365d617031f02fcf17685b4fce03d9e7c9f094f9aba23d049d83e8598e5eb2L24-R29))
*  Change `destroy` method of `Semaphore` to take mutable reference for consistency and safety ([link](https://github.com/vlang/v/pull/18351/files?diff=unified&w=0#diff-60365d617031f02fcf17685b4fce03d9e7c9f094f9aba23d049d83e8598e5eb2L205-R224))
*  Add test file `sync.v` to check memory leaks using Valgrind for `destroy` methods of `Mutex`, `RwMutex`, and `Semaphore` ([link](https://github.com/vlang/v/pull/18351/files?diff=unified&w=0#diff-9163d599c3928001043d75d2eec411e50bce31be16ee74f895e271644cf22127R1-R20))
