### PR TITLE
checker: add mutability check for comptime assignments

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -643,6 +643,9 @@ fn (mut c Checker) fail_if_immutable(expr_ ast.Expr) (string, token.Pos) {
 			return '', expr.pos
 		}
 		ast.ComptimeSelector {
+			if expr.left is ast.Ident {
+				c.fail_if_immutable(expr.left)
+			}
 			return '', expr.pos
 		}
 		ast.Ident {

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -215,7 +215,8 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut wr io.Writer) ! {
 					|| field.typ is ?i8 || field.typ is ?i16 || field.typ is ?int
 					|| field.typ is ?i64 || field.typ is ?u8 || field.typ is ?u16
 					|| field.typ is ?u32 || field.typ is ?u64 {
-					wr.write(val.$(field.name) ?.str().bytes())!
+					mut opt := val.$(field.name)
+					wr.write(opt ?.str().bytes())!
 				} $else $if field.typ is ?time.Time {
 					option_value := val.$(field.name) as ?time.Time
 					parsed_time := option_value as time.Time


### PR DESCRIPTION
Currently, it's possible to assign values to an immutable variable at comptime within the block of it's assignment.

Requiring to declare it as mutable is nice to semantically follow that it should be mutated later on. Since it already was the common pattern in the code-base to declare variables as mutable in such scenarios it is just a small change.

The following works on current master:

```v
import toml

struct Person {
	name string
}

fn decode[T](toml_str string) !T {
	res := T{} // <- immutable
	doc := toml.parse_text(toml_str)!.to_any()
	$for field in T.fields {
		val := doc.value(field.name)
		$if field.typ is string {
			res.$(field.name) = val.string()
		}
	}
	return res
}

p_str := 'name = "John"'

dump(decode[Person](p_str)!)
```

After the PR it would throw:
```
error: `res` is immutable, declare it with `mut` to make it mutable
   11 |         val := doc.value(field.name)
   12 |         $if field.typ is string {
   13 |             res.$(field.name) = val.string()
      |             ~~~
   14 |         }
   15 |     }
```

Will work:
```v
import toml

struct Person {
	name string
}

fn decode[T](toml_str string) !T {
	mut res := T{}
	doc := toml.parse_text(toml_str)!.to_any()
	$for field in T.fields {
		val := doc.value(field.name)
		$if field.typ is string {
			res.$(field.name) = val.string()
		}
	}
	return res
}

p_str := 'name = "John"'

dump(decode[Person](p_str)!)
```

copilot:summary

copilot:walkthrough
