### PR TITLE
ast, checker, fmt: fix compiler internal formatting failed

### DIFF
--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -4,7 +4,6 @@
 module ast
 
 import v.cflag
-import v.checker.constants
 
 // check if cflag is in table
 pub fn (t &Table) has_cflag(flag cflag.CFlag) bool {
@@ -27,7 +26,7 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 	}
 	mut fos := ''
 	mut allowed_os_overrides := []string{}
-	allowed_os_overrides << constants.valid_comptime_not_user_defined
+	allowed_os_overrides << valid_comptime_not_user_defined
 	allowed_os_overrides << ctimedefines
 	for os_override in allowed_os_overrides {
 		if !flag.starts_with(os_override) {

--- a/vlib/v/ast/comptime_valid_idents.v
+++ b/vlib/v/ast/comptime_valid_idents.v
@@ -1,4 +1,4 @@
-module constants
+module ast
 
 pub const (
 	valid_comptime_if_os             = ['windows', 'ios', 'macos', 'mach', 'darwin', 'hpux', 'gnu',
@@ -16,10 +16,10 @@ pub const (
 
 fn all_valid_comptime_idents() []string {
 	mut res := []string{}
-	res << constants.valid_comptime_if_os
-	res << constants.valid_comptime_if_compilers
-	res << constants.valid_comptime_if_platforms
-	res << constants.valid_comptime_if_cpu_features
-	res << constants.valid_comptime_if_other
+	res << ast.valid_comptime_if_os
+	res << ast.valid_comptime_if_compilers
+	res << ast.valid_comptime_if_platforms
+	res << ast.valid_comptime_if_cpu_features
+	res << ast.valid_comptime_if_other
 	return res
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -12,7 +12,6 @@ import v.util
 import v.util.version
 import v.errors
 import v.pkgconfig
-import v.checker.constants
 
 const (
 	int_min                  = int(0x80000000)
@@ -1822,7 +1821,7 @@ fn (mut c Checker) stmt(node_ ast.Stmt) {
 			for i, ident in node.defer_vars {
 				mut id := ident
 				if mut id.info is ast.IdentVar {
-					if id.comptime && id.name in constants.valid_comptime_not_user_defined {
+					if id.comptime && id.name in ast.valid_comptime_not_user_defined {
 						node.defer_vars[i] = ast.Ident{
 							scope: 0
 							name: ''

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -7,7 +7,6 @@ import strings
 import v.ast
 import v.util
 import v.pref
-import v.checker.constants
 
 const (
 	bs      = '\\'
@@ -2009,7 +2008,7 @@ pub fn (mut f Fmt) enum_val(node ast.EnumVal) {
 
 pub fn (mut f Fmt) ident(node ast.Ident) {
 	if node.info is ast.IdentVar {
-		if node.comptime && node.name in constants.valid_comptime_not_user_defined {
+		if node.comptime && node.name in ast.valid_comptime_not_user_defined {
 			f.write(node.name)
 			return
 		}


### PR DESCRIPTION
This PR fix compiler internal formatting failed.

error:
```v
PS D:\Vlang\v\vlib\v\checker> v fmt -w check_types.v
cannot compile `D:\Vlang\v\cmd\tools\vfmt.v`: 
D:/Vlang/v/vlib/v/ast/cflags.v:30:36: error: undefined ident: `v.checker.constants.valid_comptime_not_user_defined`
   28 |     mut fos := ''
   29 |     mut allowed_os_overrides := []string{}
   30 |     allowed_os_overrides << constants.valid_comptime_not_user_defined
      |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   31 |     allowed_os_overrides << ctimedefines
   32 |     for os_override in allowed_os_overrides {
D:/Vlang/v/vlib/v/fmt/fmt.v:2012:46: error: undefined ident: `v.checker.constants.valid_comptime_not_user_defined`
 2010 | pub fn (mut f Fmt) ident(node ast.Ident) {
 2011 |     if node.info is ast.IdentVar {
 2012 |         if node.comptime && node.name in constants.valid_comptime_not_user_defined {
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2013 |             f.write(node.name)
 2014 |             return
```
solution:
- Move `comptime_valid_idents` from `v.checker.constants` to `ast`.