### PR TITLE
cgen: fix nested fixed array instantiation

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -172,6 +172,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 	} else {
 		elem_sym := g.table.final_sym(node.elem_type)
 		if elem_sym.kind == .map {
+			// fixed array for map -- [N]map[key_type]value_type
 			info := array_type.unaliased_sym.info as ast.ArrayFixed
 			map_info := elem_sym.map_info()
 			g.expr(ast.MapInit{
@@ -186,6 +187,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 				})
 			}
 		} else if elem_sym.kind == .array_fixed {
+			// nested fixed array -- [N][N]type
 			info := array_type.unaliased_sym.info as ast.ArrayFixed
 			arr_info := elem_sym.array_fixed_info()
 			g.expr(ast.ArrayInit{

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -185,6 +185,20 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 					value_type: map_info.value_type
 				})
 			}
+		} else if elem_sym.kind == .array_fixed {
+			info := array_type.unaliased_sym.info as ast.ArrayFixed
+			arr_info := elem_sym.array_fixed_info()
+			g.expr(ast.ArrayInit{
+				typ: node.elem_type
+				elem_type: arr_info.elem_type
+			})
+			for _ in 1 .. info.size {
+				g.write(', ')
+				g.expr(ast.ArrayInit{
+					typ: node.elem_type
+					elem_type: arr_info.elem_type
+				})
+			}
 		} else {
 			g.write('0')
 		}

--- a/vlib/v/tests/multiple_arr_fixed_test.v
+++ b/vlib/v/tests/multiple_arr_fixed_test.v
@@ -1,0 +1,8 @@
+fn test_main() {
+	mut arr := [2][3][2]map[string]string{}
+	arr[0][0][1]['key'] = 'value'
+	dump(arr)
+	assert arr[0][0][1] == {
+		'key': 'value'
+	}
+}


### PR DESCRIPTION
Fix #18355

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4307d31</samp>

This pull request implements a new syntax for multiple fixed-size arrays in V. It updates the C code generator to handle nested array initializers, and adds a test file to check the correctness of the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4307d31</samp>

*  Add support for multiple fixed-size arrays ([link](https://github.com/vlang/v/pull/18357/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278R188-R201))
*  Test new syntax for multiple fixed-size arrays ([link](https://github.com/vlang/v/pull/18357/files?diff=unified&w=0#diff-20c04355667922da376aa3d5ecda648e54f66c9417b16afc94599f7dc691d944R1-R8))
