### PR TITLE
v.util: make util.launch_tool/3 more robust, by recompiling V tools always in a known current working folder (vroot)

### DIFF
--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -180,9 +180,13 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 			println('Compiling ${tool_name} with: "${compilation_command}"')
 		}
 
+		current_work_dir := os.getwd()
 		retry_max_count := 3
 		for i in 0 .. retry_max_count {
+			// ensure a stable and known working folder, when compiling V's tools, to avoid module lookup problems:
+			os.chdir(vroot) or {}
 			tool_compilation := os.execute(compilation_command)
+			os.chdir(current_work_dir) or {}
 			if tool_compilation.exit_code == 0 {
 				break
 			} else {


### PR DESCRIPTION
Prevents module lookup problems when recompiling V tools in a current folder != the V project root one.

An example for such is: https://github.com/vlang/v/pull/18356 .