### PR TITLE
coroutines: add macOS amd64 support, panic on wget errors.

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -802,21 +802,22 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-use-coroutines' {
 				res.use_coroutines = true
-				$if macos && arm64 {
+				$if macos {
+					os_arch := $if arm64 { 'arm64' } $else { 'amd64' }
 					vexe := vexe_path()
 					vroot := os.dir(vexe)
 					so_path := os.join_path(vroot, 'thirdparty', 'photon', 'photonwrapper.so')
-					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_macos_arm64.so'
+					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_macos_${os_arch}.so'
 					if !os.exists(so_path) {
 						println('coroutines .so not found, downloading...')
 						// http.download_file(so_url, so_path) or { panic(err) }
-						os.system('wget -O "${so_path}" "${so_url}"')
+						os.execute_or_panic('wget -O "${so_path}" "${so_url}"')
 						println('done!')
 					}
 					res.compile_defines << 'is_coroutine'
 					res.compile_defines_all << 'is_coroutine'
 				} $else {
-					println('coroutines only work on arm64 macos for now')
+					println('coroutines only work on macos for now')
 				}
 			}
 			else {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -803,11 +803,11 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-use-coroutines' {
 				res.use_coroutines = true
 				$if macos {
-					os_arch := $if arm64 { 'arm64' } $else { 'amd64' }
+					arch := $if arm64 { 'arm64' } $else { 'amd64' }
 					vexe := vexe_path()
 					vroot := os.dir(vexe)
 					so_path := os.join_path(vroot, 'thirdparty', 'photon', 'photonwrapper.so')
-					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_macos_${os_arch}.so'
+					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_macos_${arch}.so'
 					if !os.exists(so_path) {
 						println('coroutines .so not found, downloading...')
 						// http.download_file(so_url, so_path) or { panic(err) }


### PR DESCRIPTION
Photonlib PR: https://github.com/vlang/photonbin/pull/1

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd51b6e</samp>

This pull request adds support for coroutines on macos amd64 and enhances the user experience for the coroutine library. It modifies `vlib/v/pref/pref.v` to handle the platform detection, error reporting, and downloading logic.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd51b6e</samp>

* Add support for coroutines on macos amd64 ([link](https://github.com/vlang/v/pull/18360/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3L805-R814))
* Update error message for coroutines on macos ([link](https://github.com/vlang/v/pull/18360/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3L819-R820))
