### PR TITLE
fmt: fix blank line inserts between enum attribute comments

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -423,6 +423,11 @@ fn (f Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) 
 				return false
 			}
 		}
+		if stmt is ast.EnumDecl {
+			if stmt.attrs.len > 0 && stmt.attrs[0].pos.line_nr - prev_line_nr <= 1 {
+				return false
+			}
+		}
 		if stmt is ast.FnDecl {
 			if stmt.attrs.len > 0 && stmt.attrs[0].pos.line_nr - prev_line_nr <= 1 {
 				return false

--- a/vlib/v/fmt/tests/enum_attributes_keep.vv
+++ b/vlib/v/fmt/tests/enum_attributes_keep.vv
@@ -1,0 +1,16 @@
+// CollisionType is an enum that categorizes entities for the purpose of collision detection, used in Collider ECS component.
+// The flag attribute allows for multiple EntityType values to be combined, enabling entities to be categorized as multiple types.
+[flag]
+pub enum CollisionType {
+	obstacle
+	chicken
+	egg
+}
+
+// Another descriptive comment with a linebreak separated from the next enum decl.
+
+[flag]
+pub enum Direction {
+	left
+	right
+}


### PR DESCRIPTION
fixes #18359 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b4d879</samp>

Fix `v fmt` removing linebreaks between enum declarations and comments or attributes. Add a test case for this fix in `vlib/v/fmt/tests/enum_attributes_keep.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b4d879</samp>

* Fix issue #11176 by preventing `v fmt` from removing linebreaks between enum declarations and their comments or attributes ([link](https://github.com/vlang/v/pull/18361/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eR426-R430))
* Add a test case to verify that the fix works as expected on two enum declarations with attributes and comments in `vlib/v/fmt/tests/enum_attributes_keep.vv` ([link](https://github.com/vlang/v/pull/18361/files?diff=unified&w=0#diff-08312f4db2f8c3c6859a465e4b2d048de017cee43ae797eb1346c8f524db20f6R1-R16))
