### PR TITLE
parser: fix generic function variable (fix #18369)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2140,7 +2140,13 @@ fn (mut p Parser) is_following_concrete_types() bool {
 		} else if cur_tok.kind == .rsbr {
 			break
 		} else if cur_tok.kind == .name {
-			if !(p.is_typename(cur_tok) && !(cur_tok.lit.len == 1 && !cur_tok.lit[0].is_capital())) {
+			if p.peek_token(i + 1).kind == .dot {
+				if p.is_typename(cur_tok) {
+					return false
+				}
+				i++
+			} else if !(p.is_typename(cur_tok) && !(cur_tok.lit.len == 1
+				&& !cur_tok.lit[0].is_capital())) {
 				return false
 			}
 		} else if cur_tok.kind != .comma {

--- a/vlib/v/tests/generics_fn_variable_3_test.v
+++ b/vlib/v/tests/generics_fn_variable_3_test.v
@@ -1,0 +1,36 @@
+import ecs
+
+struct Entity {
+	components []Component
+}
+
+interface Component {}
+
+fn two_components_filter_query[A, B](entity Entity) bool {
+	return check_if_entity_has_component[A](entity) && check_if_entity_has_component[B](entity)
+}
+
+pub fn check_if_entity_has_component[T](entity Entity) bool {
+	get_entity_component[T](entity) or { return false }
+
+	return true
+}
+
+pub fn get_entity_component[T](entity Entity) !&T {
+	for component in entity.components {
+		if component is T {
+			return component
+		}
+	}
+
+	return error('Entity with does not have a component of type ${T.name}')
+}
+
+fn component_interface_hack() []Component {
+	return [ecs.Position{}, ecs.Velocity{}]
+}
+
+fn test_generic_fn_variable() {
+	query := two_components_filter_query[ecs.Position, ecs.Velocity]
+	assert true
+}

--- a/vlib/v/tests/modules/ecs/ecs.v
+++ b/vlib/v/tests/modules/ecs/ecs.v
@@ -1,0 +1,11 @@
+module ecs
+
+pub struct Position {
+	x int
+	y int
+}
+
+pub struct Velocity {
+	x f64
+	y f64
+}


### PR DESCRIPTION
This PR fix generic function variable (fix #18369).

- Fix generic function variable.
- Add test.

```v
import ecs

struct Entity {
	components []Component
}

interface Component {}

fn two_components_filter_query[A, B](entity Entity) bool {
	return check_if_entity_has_component[A](entity) && check_if_entity_has_component[B](entity)
}

pub fn check_if_entity_has_component[T](entity Entity) bool {
	get_entity_component[T](entity) or { return false }

	return true
}

pub fn get_entity_component[T](entity Entity) !&T {
	for component in entity.components {
		if component is T {
			return component
		}
	}

	return error('Entity with does not have a component of type ${T.name}')
}

fn component_interface_hack() []Component {
	return [ecs.Position{}, ecs.Velocity{}]
}

fn main() {
	query := two_components_filter_query[ecs.Position, ecs.Velocity]
	assert true
}

PS D:\Test\v\tt1> v run .
tt1.v:34:2: warning: unused variable: `query`
   32 | 
   33 | fn main() {
   34 |     query := two_components_filter_query[ecs.Position, ecs.Velocity]
      |     ~~~~~
   35 |     assert true
   36 | }
```