### PR TITLE
checker: fix embedded structure initialization warnings (fix #18376)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -586,6 +586,16 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 							field.expr.pos)
 					}
 				}
+
+				// all the fields of initialized embedded struct are ignored, they are considered initialized
+				sym := c.table.sym(field.typ)
+				if field.name.len > 0 && field.name[0].is_capital() && sym.kind == .struct_
+					&& sym.language == .v {
+					struct_fields := c.table.struct_fields(sym)
+					for struct_field in struct_fields {
+						inited_fields << struct_field.name
+					}
+				}
 			}
 			// Check uninitialized refs/sum types
 			// The variable `fields` contains two parts, the first part is the same as info.fields,

--- a/vlib/v/slow_tests/inout/struct_with_embed_field_init.out
+++ b/vlib/v/slow_tests/inout/struct_with_embed_field_init.out
@@ -1,0 +1,5 @@
+Outer{
+    Embedded: Embedded{
+        a: &nil
+    }
+}

--- a/vlib/v/slow_tests/inout/struct_with_embed_field_init.vv
+++ b/vlib/v/slow_tests/inout/struct_with_embed_field_init.vv
@@ -1,0 +1,20 @@
+struct Embedded {
+	a &int
+}
+
+fn new_embedded() Embedded {
+	return Embedded{
+		a: unsafe { nil }
+	}
+}
+
+struct Outer {
+	Embedded
+}
+
+fn main() {
+	o := Outer{
+		Embedded: new_embedded()
+	}
+	println(o)
+}


### PR DESCRIPTION
This PR fix embedded structure initialization warnings (fix #18376).

- Fix embedded structure initialization warnings.
- Add test.

```v
struct Embedded {
	a &int
}

fn new_embedded() Embedded {
	return Embedded{
		a: unsafe { nil }
	}
}

struct Outer {
	Embedded
}

fn main() {
	o := Outer{
		Embedded: new_embedded()
	}
	println(o)
}

PS D:\Test\v\tt1> v run .
Outer{
    Embedded: Embedded{
        a: &nil
    }
}
```