### PR TITLE
cgen: fix alias of map clone() (fix #18384)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1277,7 +1277,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.get_free_method(rec_type)
 	}
 	mut has_cast := false
-	if left_sym.kind == .map && node.name in ['clone', 'move'] {
+	if final_left_sym.kind == .map && node.name in ['clone', 'move'] {
 		receiver_type_name = 'map'
 	}
 	if final_left_sym.kind == .array && !(left_sym.kind == .alias && left_sym.has_method(node.name))

--- a/vlib/v/tests/alias_map_clone_test.v
+++ b/vlib/v/tests/alias_map_clone_test.v
@@ -1,9 +1,13 @@
 type Fields = map[string]string
 
 fn test_alias_map_clone() {
-	f := Fields({'s': 'a'})
-	
+	f := Fields({
+		's': 'a'
+	})
+
 	s := f.clone()
 	println(s)
-	assert s == {'s': 'a'}
+	assert s == {
+		's': 'a'
+	}
 }

--- a/vlib/v/tests/alias_map_clone_test.v
+++ b/vlib/v/tests/alias_map_clone_test.v
@@ -1,0 +1,9 @@
+type Fields = map[string]string
+
+fn test_alias_map_clone() {
+	f := Fields({'s': 'a'})
+	
+	s := f.clone()
+	println(s)
+	assert s == {'s': 'a'}
+}


### PR DESCRIPTION
This PR fix alias of map clone() (fix #18384).

- Fix alias of map clone().
- Add test.

```v
type Fields = map[string]string

fn main() {
	f := Fields({'s': 'a'})
	
	s := f.clone()
	println(s)
	assert s == {'s': 'a'}
}

PS D:\Test\v\tt1> v run .
{'s': 'a'}
```