### PR TITLE
ast: clean up ast.StructInit

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1567,7 +1567,6 @@ fn (t Tree) struct_init(node ast.StructInit) &Node {
 	obj.add('name_pos', t.pos(node.name_pos))
 	obj.add('update_expr_comments', t.array_node_comment(node.update_expr_comments))
 	obj.add_terse('fields', t.array_node_struct_init_field(node.fields))
-	obj.add_terse('embeds', t.array_node_struct_init_embed(node.embeds))
 	obj.add('pre_comments', t.array_node_comment(node.pre_comments))
 	return obj
 }
@@ -1584,19 +1583,6 @@ fn (t Tree) struct_init_field(node ast.StructInitField) &Node {
 	obj.add('next_comments', t.array_node_comment(node.next_comments))
 	obj.add('pos', t.pos(node.pos))
 	obj.add('name_pos', t.pos(node.name_pos))
-	return obj
-}
-
-fn (t Tree) struct_init_embed(node ast.StructInitEmbed) &Node {
-	mut obj := new_object()
-	obj.add_terse('ast_type', t.string_node('StructInitEmbed'))
-	obj.add_terse('name', t.string_node(node.name))
-	obj.add_terse('expr', t.expr(node.expr))
-	obj.add_terse('typ', t.type_node(node.typ))
-	obj.add_terse('expected_type', t.type_node(node.expected_type))
-	obj.add('comments', t.array_node_comment(node.comments))
-	obj.add('next_comments', t.array_node_comment(node.next_comments))
-	obj.add('pos', t.pos(node.pos))
 	return obj
 }
 
@@ -2302,14 +2288,6 @@ fn (t Tree) array_node_if_guard_var(nodes []ast.IfGuardVar) &Node {
 	mut arr := new_array()
 	for node in nodes {
 		arr.add_item(t.if_guard_var(node))
-	}
-	return arr
-}
-
-fn (t Tree) array_node_struct_init_embed(nodes []ast.StructInitEmbed) &Node {
-	mut arr := new_array()
-	for node in nodes {
-		arr.add_item(t.struct_init_embed(node))
 	}
 	return arr
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -437,18 +437,6 @@ pub mut:
 	parent_type   Type
 }
 
-pub struct StructInitEmbed {
-pub:
-	pos           token.Pos
-	comments      []Comment
-	next_comments []Comment
-pub mut:
-	expr          Expr
-	name          string
-	typ           Type
-	expected_type Type
-}
-
 // `s := Foo{
 //    ...a
 //    field1: 'hello'
@@ -473,7 +461,6 @@ pub mut:
 	is_update_embed      bool
 	has_update_expr      bool // has `...a`
 	fields               []StructInitField
-	embeds               []StructInitEmbed
 	generic_types        []Type
 }
 

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -418,9 +418,6 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 			for sif in node.fields {
 				w.expr(sif.expr)
 			}
-			for sie in node.embeds {
-				w.expr(sie.expr)
-			}
 		}
 		ast.TypeOf {
 			w.expr(node.expr)

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -662,9 +662,6 @@ pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
 			for mut field in node.fields {
 				field.expr = t.expr(mut field.expr)
 			}
-			for mut embed in node.embeds {
-				embed.expr = t.expr(mut embed.expr)
-			}
 		}
 		ast.UnsafeExpr {
 			node.expr = t.expr(mut node.expr)


### PR DESCRIPTION
This PR clean up ast.StructInit.

- Remove unused field `embeds`.