### PR TITLE
cgen: define enum default value standard

### DIFF
--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -32,6 +32,7 @@ pub mut:
 //
 // See https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00 for details.
 pub enum SameSite {
+	same_site_not_set
 	same_site_default_mode = 1
 	same_site_lax_mode
 	same_site_strict_mode
@@ -162,6 +163,7 @@ pub fn (c &Cookie) str() string {
 		b.write_string('; Secure')
 	}
 	match c.same_site {
+		.same_site_not_set {}
 		.same_site_default_mode {
 			b.write_string('; SameSite')
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6254,6 +6254,18 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 				return init_str
 			}
 		}
+		.enum_ {
+			// returns the enum's first value
+			if enum_decl := g.table.enum_decls[sym.name] {
+				return if enum_decl.fields[0].expr is ast.EmptyExpr {
+					'0'
+				} else {
+					g.expr_string(enum_decl.fields[0].expr)
+				}
+			} else {
+				return '0'
+			}
+		}
 		else {
 			return '0'
 		}

--- a/vlib/v/tests/enum_default_test.v
+++ b/vlib/v/tests/enum_default_test.v
@@ -1,0 +1,28 @@
+enum TestEnum {
+	two = 1
+	one
+}
+
+struct Test {
+	a TestEnum
+	b TestEnum = .one
+}
+
+fn test_main() {
+	assert dump(Test{}) == Test{
+		a: .two
+		b: .one
+	}
+	assert dump(Test{}) == Test{}
+
+	assert dump(Test{
+		a: .one
+	}) == Test{
+		a: .one
+	}
+	assert dump(Test{
+		b: .two
+	}) == Test{
+		b: .two
+	}
+}


### PR DESCRIPTION
Fix #18365

This PR makes Enum default value to be set to its first declared field.

```V
pub enum TestEnum {
	second = 2
	first = 1
}

pub struct TestStruct {
	test TestEnum
}
fn main() {
	println(TestStruct{})
}
```

```
TestStruct{
    test: second
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18c15d0</samp>

Add support for default initialization of enums with explicit values in C code generation. Update `vlib/v/gen/c/cgen.v` to handle enum types in `default_init` method.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18c15d0</samp>

*  Add a new case for enum types in the default_init method of the cgen struct ([link](https://github.com/vlang/v/pull/18388/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR6244-R6255))
