### PR TITLE
parser: fix comments parsing on map init

### DIFF
--- a/vlib/v/fmt/tests/map_init_comments_keep.vv
+++ b/vlib/v/fmt/tests/map_init_comments_keep.vv
@@ -1,0 +1,9 @@
+enum HttpHeader {
+	user_agent
+	referer
+}
+
+headers := {
+	HttpHeader.user_agent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36' // content_length: '17' // <-- will be deleted
+	.referer:              'wwww.google.com' // content_length: '17' // <-- won't be deleted
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -456,7 +456,8 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 		p.if_cond_comments << p.eat_comments()
 	}
 	if p.pref.is_fmt && p.tok.kind == .comment && p.peek_tok.kind.is_infix() && !p.inside_infix
-		&& !(p.peek_tok.kind == .mul && p.peek_tok.pos().line_nr != p.tok.pos().line_nr) {
+		&& !p.inside_map_init && !(p.peek_tok.kind == .mul
+		&& p.peek_tok.pos().line_nr != p.tok.pos().line_nr) {
 		p.left_comments = p.eat_comments()
 	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)


### PR DESCRIPTION
Fix #18362

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afb82d0</samp>

This pull request fixes a bug in the parser and the formatter that caused comments inside map initialization expressions to be deleted. It also adds a test case in `vlib/v/fmt/tests/map_init_comments_keep.vv` to verify the correct behavior.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afb82d0</samp>

* Preserve comments inside map initialization expressions in the parser and formatter ([link](https://github.com/vlang/v/pull/18389/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL459-R460), [link](https://github.com/vlang/v/pull/18389/files?diff=unified&w=0#diff-7838fe617efac467b7255250a79ea980bc880de1bc36ed8e20d77aafa1469378R1-R9))
  - Check `p.inside_map_init` flag before eating comments in `p.expr()` ([link](https://github.com/vlang/v/pull/18389/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL459-R460))
  - Add a test case in `vlib/v/fmt/tests/map_init_comments_keep.vv` to show that comments after the colon are kept, but comments after the comma are deleted ([link](https://github.com/vlang/v/pull/18389/files?diff=unified&w=0#diff-7838fe617efac467b7255250a79ea980bc880de1bc36ed8e20d77aafa1469378R1-R9))
