### PR TITLE
cgen: fix selector option casting

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -93,7 +93,7 @@ fn (mut g Gen) expr_with_opt(expr ast.Expr, expr_typ ast.Type, ret_typ ast.Type)
 		g.inside_opt_or_res = old_inside_opt_or_res
 	}
 	if expr_typ.has_flag(.option) && ret_typ.has_flag(.option)
-		&& expr in [ast.DumpExpr, ast.Ident, ast.ComptimeSelector, ast.AsCast, ast.CallExpr, ast.MatchExpr, ast.IfExpr, ast.IndexExpr, ast.UnsafeExpr, ast.CastExpr] {
+		&& expr in [ast.SelectorExpr, ast.DumpExpr, ast.Ident, ast.ComptimeSelector, ast.AsCast, ast.CallExpr, ast.MatchExpr, ast.IfExpr, ast.IndexExpr, ast.UnsafeExpr, ast.CastExpr] {
 		if expr in [ast.Ident, ast.CastExpr] {
 			if expr_typ.idx() != ret_typ.idx() {
 				return g.expr_opt_with_cast(expr, expr_typ, ret_typ)

--- a/vlib/v/tests/option_selector_cast_test.v
+++ b/vlib/v/tests/option_selector_cast_test.v
@@ -1,0 +1,15 @@
+[params]
+struct ConnectParams {
+	password ?string
+}
+
+pub fn connect(params ConnectParams) ? {
+	password2 := ?string(params.password)
+	assert password2? == 'foo'
+}
+
+fn test_main() {
+	connect(ConnectParams{
+		password: 'foo'
+	})
+}


### PR DESCRIPTION
Fix #18332

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83babde</samp>

This pull request adds support for casting optional struct fields to non-optional types using the `?` operator. It fixes a bug in the C code generator and adds a test case in `option_selector_cast_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83babde</samp>

* Add option selector cast feature to allow using `?` operator on optional struct fields ([link](https://github.com/vlang/v/pull/18395/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL96-R96))
* Add test case for option selector cast feature in `option_selector_cast_test.v` ([link](https://github.com/vlang/v/pull/18395/files?diff=unified&w=0#diff-0aadf41b79ba9a96c3a7f770627681f3b80e9a11b1b298893328f5acf09b7f59R1-R15))
