### PR TITLE
checker, cgen: fix comptime method and field name checking

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -220,6 +220,30 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 								}
 							}
 						}
+					} else if branch.cond.op in [.eq, .ne] && left is ast.SelectorExpr
+						&& right is ast.StringLiteral {
+						if left.expr.str() == c.comptime_for_field_var {
+							if left.field_name == 'name' {
+								is_comptime_type_is_expr = true
+								match branch.cond.op {
+									.eq {
+										skip_state = if c.comptime_for_field_value.name == right.val.str() {
+											ComptimeBranchSkipState.eval
+										} else {
+											ComptimeBranchSkipState.skip
+										}
+									}
+									.ne {
+										skip_state = if c.comptime_for_field_value.name == right.val.str() {
+											ComptimeBranchSkipState.skip
+										} else {
+											ComptimeBranchSkipState.eval
+										}
+									}
+									else {}
+								}
+							}
+						}
 					}
 				}
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -558,7 +558,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 									mut is_true := if cond.op == .eq {
 										g.comptime_for_method == cond.right.val
 									} else {
-										g.comptime_for_method == cond.right.val
+										g.comptime_for_method != cond.right.val
 									}
 									if is_true {
 										g.write('1')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -555,22 +555,30 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 							if selector.expr is ast.Ident && selector.field_name == 'name' {
 								if g.comptime_for_method_var.len > 0
 									&& (selector.expr as ast.Ident).name == g.comptime_for_method_var {
-									is_equal := g.comptime_for_method == cond.right.val
-									if is_equal {
+									mut is_true := if cond.op == .eq {
+										g.comptime_for_method == cond.right.val
+									} else {
+										g.comptime_for_method == cond.right.val
+									}
+									if is_true {
 										g.write('1')
 									} else {
 										g.write('0')
 									}
-									return is_equal, true
+									return is_true, true
 								} else if g.comptime_for_field_var.len > 0
 									&& (selector.expr as ast.Ident).name == g.comptime_for_field_var {
-									is_equal := g.comptime_for_field_value.name == cond.right.val
-									if is_equal {
+									mut is_true := if cond.op == .eq {
+										g.comptime_for_field_value.name == cond.right.val
+									} else {
+										g.comptime_for_field_value.name != cond.right.val
+									}
+									if is_true {
 										g.write('1')
 									} else {
 										g.write('0')
 									}
-									return is_equal, true
+									return is_true, true
 								}
 							}
 						} else if cond.right is ast.IntegerLiteral {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -555,7 +555,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 							if selector.expr is ast.Ident && selector.field_name == 'name' {
 								if g.comptime_for_method_var.len > 0
 									&& (selector.expr as ast.Ident).name == g.comptime_for_method_var {
-									mut is_true := if cond.op == .eq {
+									is_true := if cond.op == .eq {
 										g.comptime_for_method == cond.right.val
 									} else {
 										g.comptime_for_method != cond.right.val
@@ -568,7 +568,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 									return is_true, true
 								} else if g.comptime_for_field_var.len > 0
 									&& (selector.expr as ast.Ident).name == g.comptime_for_field_var {
-									mut is_true := if cond.op == .eq {
+									is_true := if cond.op == .eq {
 										g.comptime_for_field_value.name == cond.right.val
 									} else {
 										g.comptime_for_field_value.name != cond.right.val

--- a/vlib/v/tests/comptime_field_name_check_test.v
+++ b/vlib/v/tests/comptime_field_name_check_test.v
@@ -1,0 +1,22 @@
+struct Struct {
+	a     int
+	txt   string
+	array []string
+}
+
+fn get_string[T](s T) string {
+	$for field in T.fields {
+		$if field.name == 'txt' {
+			println(field.name)
+			return s.$(field.name)
+		}
+	}
+	return ''
+}
+
+fn test_main() {
+	s := Struct{
+		txt: 'hello'
+	}
+	assert get_string(s) == 'hello'
+}


### PR DESCRIPTION
Fix #18400

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbf4112</samp>

This pull request adds support for checking the field name of a generic type at compile time using the `$if field.name == 'txt'` syntax. It modifies the `Checker.check_if` method to handle this case, the `Gen.comptime_gen_eq` method to generate the correct C code, and adds a new test file `vlib/v/tests/comptime_field_name_check_test.v` to verify the functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fbf4112</samp>

*  Add a new branch to handle comptime field name checks in `if` conditions ([link](https://github.com/vlang/v/pull/18402/files?diff=unified&w=0#diff-92297a74e9e70557a4b47ca09faef734f8e4b97ac35dc69278794d134b2be211R223-R246))
*  Modify C code generation for comptime equality checks to handle negation ([link](https://github.com/vlang/v/pull/18402/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL558-R581))
*  Add a test file `vlib/v/tests/comptime_field_name_check_test.v` to verify the new feature and prevent regressions ([link](https://github.com/vlang/v/pull/18402/files?diff=unified&w=0#diff-fa26a4b9bab49d287ab444ca1bc6c699f07a1e4e17003d79da55e8fe6377a903R1-R22))
