### PR TITLE
checker: no notice for `interface` field initialized struct with `...other` syntax

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -636,7 +636,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				}
 				if field.typ.is_ptr() && !field.typ.has_flag(.shared_f)
 					&& !field.typ.has_flag(.option) && !node.has_update_expr && !c.pref.translated
-					&& !c.file.is_translated && node.fields.len != 0 {
+					&& !c.file.is_translated {
 					c.warn('reference field `${type_sym.name}.${field.name}` must be initialized',
 						node.pos)
 					continue
@@ -660,7 +660,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					}
 				}
 				if !field.typ.has_flag(.option) && sym.kind == .interface_
-					&& (!has_noinit && sym.language != .js) {
+					&& (!has_noinit && sym.language != .js) && !node.has_update_expr {
 					// TODO: should be an error instead, but first `ui` needs updating.
 					c.note('interface field `${type_sym.name}.${field.name}` must be initialized',
 						node.pos)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -636,7 +636,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				}
 				if field.typ.is_ptr() && !field.typ.has_flag(.shared_f)
 					&& !field.typ.has_flag(.option) && !node.has_update_expr && !c.pref.translated
-					&& !c.file.is_translated {
+					&& !c.file.is_translated && node.fields.len != 0 {
 					c.warn('reference field `${type_sym.name}.${field.name}` must be initialized',
 						node.pos)
 					continue

--- a/vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.out
+++ b/vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.out
@@ -1,4 +1,4 @@
-Outer{
+[vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.vv:20] o: Outer{
     a: Foo(FooImpl{
         prop: 0
     })

--- a/vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.out
+++ b/vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.out
@@ -1,0 +1,5 @@
+Outer{
+    a: Foo(FooImpl{
+        prop: 0
+    })
+}

--- a/vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.vv
+++ b/vlib/v/slow_tests/inout/interface_field_initialised_struct_update_expr.vv
@@ -1,0 +1,21 @@
+interface Foo {
+	prop int
+}
+
+struct FooImpl {
+	prop int
+}
+
+struct Outer {
+	a Foo
+}
+
+fn main() {
+	other := Outer{
+		a: FooImpl{}
+	}
+	o := Outer{
+		...other
+	}
+	dump(o)
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/18407
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c2be9f</samp>

Fix false positive warning for reference fields of structs. Check if the node has fields before reporting an uninitialized reference field in `vlib/v/checker/struct.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c2be9f</samp>

* Add an extra condition to avoid false positive warnings for reference fields of structs with default initialization ([link](https://github.com/vlang/v/pull/18405/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L639-R639))
