### PR TITLE
cgen: fix stringification of usize struct fields (before, they were treated as 32 bit *signed* numbers)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -555,7 +555,7 @@ pub fn (typ Type) is_number() bool {
 
 [inline]
 pub fn (typ Type) is_string() bool {
-	return typ.idx() in ast.string_type_idxs
+	return typ.idx() == ast.string_type_idx
 }
 
 [inline]
@@ -618,7 +618,6 @@ pub const (
 		char_type_idx, u16_type_idx, u32_type_idx, u64_type_idx, isize_type_idx, usize_type_idx,
 		f32_type_idx, f64_type_idx, int_literal_type_idx, float_literal_type_idx, rune_type_idx]
 	pointer_type_idxs          = [voidptr_type_idx, byteptr_type_idx, charptr_type_idx, nil_type_idx]
-	string_type_idxs           = [string_type_idx]
 )
 
 pub const (

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -842,6 +842,10 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 		return .si_u64
 	} else if sym.kind == .i64 {
 		return .si_i64
+	} else if sym.kind == .usize {
+		return .si_u64
+	} else if sym.kind == .isize {
+		return .si_i64
 	}
 	return .si_i32
 }
@@ -1076,9 +1080,12 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 				return 'str_intp(1, _MOV((StrIntpData[]){
 					{_SLIT0, ${si_g64_code}, {.d_f64 = *${method_str} }}
 				}))', true
-			} else if sym.kind == .u64 {
+			} else if sym.kind in [.u64, .usize] {
 				fmt_type := StrIntpType.si_u64
 				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_u64 = *${method_str} }}}))', true
+			} else if sym.kind in [.i64, .isize] {
+				fmt_type := StrIntpType.si_i64
+				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i64 = *${method_str} }}}))', true
 			}
 			fmt_type := StrIntpType.si_i32
 			return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i32 = *${method_str} }}}))', true

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -680,6 +680,10 @@ fn (g &JsGen) type_to_fmt(typ ast.Type) StrIntpType {
 		return .si_u64
 	} else if sym.kind == .i64 {
 		return .si_i64
+	} else if sym.kind == .usize {
+		return .si_u64
+	} else if sym.kind == .isize {
+		return .si_i64
 	}
 	return .si_i32
 }
@@ -819,9 +823,12 @@ fn struct_auto_str_func(mut g JsGen, sym &ast.TypeSymbol, field_type ast.Type, f
 				return 'str_intp(1, _MOV((StrIntpData[]){
 					{_SLIT0, ${si_g64_code}, {.d_f64 = *${method_str} }}
 				}))'
-			} else if sym.kind == .u64 {
+			} else if sym.kind in [.u64, .usize] {
 				fmt_type := StrIntpType.si_u64
 				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_u64 = *${method_str} }}}))'
+			} else if sym.kind in [.i64, .isize] {
+				fmt_type := StrIntpType.si_u64
+				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i64 = *${method_str} }}}))'
 			}
 			fmt_type := StrIntpType.si_i32
 			return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i32 = *${method_str} }}}))'

--- a/vlib/v/tests/string_interpolation_struct_with_usize_field_test.v
+++ b/vlib/v/tests/string_interpolation_struct_with_usize_field_test.v
@@ -1,0 +1,32 @@
+struct StructWithUsizeField {
+	f_usize usize
+	f_u64   u64
+	f_u32   u32
+	//
+	f_isize isize
+	f_i64   i64
+	f_i32   i32
+}
+
+fn test_stringified_usize_field_should_be_always_positive() {
+	a := StructWithUsizeField{
+		f_usize: usize(-1)
+		f_isize: isize(-1)
+		f_u64: u64(-1)
+		f_i64: i64(-1)
+		f_u32: u32(-1)
+		f_i32: i32(-1)
+	}
+	// dump(a)
+	sa := a.str()
+	assert sa.contains('f_isize: -1')
+	assert sa.contains('f_i64: -1')
+	assert sa.contains('f_i32:     i32(-1)')
+	i := sa.split_into_lines().filter(it.contains('isize'))[0]
+	assert i.contains('-'), 'all `i` fields should be negative, but ${i} != ${a.f_isize}'
+	//
+	assert sa.contains('f_u64: 18446744073709551615')
+	assert sa.contains('f_u32: 4294967295')
+	u := sa.split_into_lines().filter(it.contains('usize'))[0]
+	assert !u.contains('-'), 'all `u` fields should be positive, but ${u} != ${a.f_usize}'
+}


### PR DESCRIPTION
Consider:
```v
struct StructWithUsizeField {
	f_usize usize
	f_u64   u64
	f_u32   u32
	//
	f_isize isize
	f_i64   i64
	f_i32   i32
}

fn main() {
	a := StructWithUsizeField{
		f_usize: usize(-1)
		f_isize: isize(-1)
		f_u64: u64(-1)
		f_i64: i64(-1)
		f_u32: u32(-1)
		f_i32: i32(-1)
	}
	dump(a)
}
```

On master, it prints:
```
[x.v:20] a: StructWithUsizeField{
    f_usize: -1
    f_u64: 18446744073709551615
    f_u32: 4294967295
    f_isize: -1
    f_i64: -1
    f_i32:     i32(-1)
}
```
Notice that `f_usize: -1`, which is wrong. That is because on master, `usize` fields are stringified as i32, which loses information on 64bit platforms, and changes the sign.

With this PR:
```
[x.v:20] a: StructWithUsizeField{
    f_usize: 18446744073709551615
    f_u64: 18446744073709551615
    f_u32: 4294967295
    f_isize: -1
    f_i64: -1
    f_i32:     i32(-1)
}
```