### PR TITLE
builtin: zero out internal map/array pointers on m.free(), to reduce the work for the GC mark phase for non escaping maps/arrays, used in hot loops

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -750,6 +750,9 @@ pub fn (a &array) free() {
 	}
 	mblock_ptr := &u8(u64(a.data) - u64(a.offset))
 	unsafe { free(mblock_ptr) }
+	unsafe {
+		a.data = nil
+	}
 }
 
 // Some of the following functions have no implementation in V and exist here
@@ -867,12 +870,12 @@ pub fn (a array) contains(value voidptr) bool
 // or `-1` if the value is not found.
 pub fn (a array) index(value voidptr) int
 
-[unsafe]
+[direct_array_access; unsafe]
 pub fn (mut a []string) free() {
 	$if prealloc {
 		return
 	}
-	for s in a {
+	for mut s in a {
 		unsafe { s.free() }
 	}
 	unsafe { (&array(&a)).free() }
@@ -883,7 +886,7 @@ pub fn (mut a []string) free() {
 
 // str returns a string representation of an array of strings
 // Example: ['a', 'b', 'c'].str() // => "['a', 'b', 'c']".
-[manualfree]
+[direct_array_access; manualfree]
 pub fn (a []string) str() string {
 	mut sb_len := 4 // 2x" + 1x, + 1xspace
 	if a.len > 0 {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -728,11 +728,15 @@ pub fn (m &map) clone() map {
 [unsafe]
 pub fn (m &map) free() {
 	unsafe { free(m.metas) }
+	unsafe {
+		m.metas = nil
+	}
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {
 			unsafe {
 				pkey := m.key_values.key(i)
 				m.free_fn(pkey)
+				vmemset(pkey, 0, m.key_bytes)
 			}
 		}
 	} else {
@@ -743,12 +747,28 @@ pub fn (m &map) free() {
 			unsafe {
 				pkey := m.key_values.key(i)
 				m.free_fn(pkey)
+				vmemset(pkey, 0, m.key_bytes)
 			}
 		}
-		unsafe { free(m.key_values.all_deleted) }
 	}
 	unsafe {
-		free(m.key_values.keys)
-		free(m.key_values.values)
+		if m.key_values.all_deleted != nil {
+			free(m.key_values.all_deleted)
+			m.key_values.all_deleted = nil
+		}
+		if m.key_values.keys != nil {
+			free(m.key_values.keys)
+			m.key_values.keys = nil
+		}
+		if m.key_values.values != nil {
+			free(m.key_values.values)
+			m.key_values.values = nil
+		}
+		// TODO: the next lines assume that callback functions are static and independent from each particular
+		// map instance. Closures may invalidate that assumption, so revisit when RC for closures works.
+		m.hash_fn = nil
+		m.key_eq_fn = nil
+		m.clone_fn = nil
+		m.free_fn = nil
 	}
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1838,6 +1838,7 @@ pub fn (s &string) free() {
 	unsafe {
 		// C.printf(c's: %x %s\n', s.str, s.str)
 		free(s.str)
+		s.str = nil
 	}
 	s.is_lit = -98761234
 }


### PR DESCRIPTION
Note the maximum RAM usage for the following program. It is significantly lower with this PR (1611608KB vs 1918948KB):

Program:
```v
fn work_with_map() {
	mut m := map[string]int{}
	for i in 0 .. 4_000_000 {
		m['k_${i}'] = i
	}
	eprintln('   > m.len: ${m.len:10}')
	unsafe { m.free() }
}

fn main() {
	eprintln('start')
	for k in 0 .. 10 {
		work_with_map()
		eprintln('k: ${k:10}')
	}
	eprintln('stop')
}
```

On master:
```
#0 17:19:41 ᛋ master /v/vnew❱xtime ./m_old
start
   > m.len:    4000000
k:          0
GC Warning: Repeated allocation of very large block (appr. size 67112960):
        May lead to memory leak and poor performance
   > m.len:    4000000
k:          1
   > m.len:    4000000
k:          2
   > m.len:    4000000
k:          3
   > m.len:    4000000
k:          4
GC Warning: Repeated allocation of very large block (appr. size 17362944):
        May lead to memory leak and poor performance
   > m.len:    4000000
k:          5
   > m.len:    4000000
k:          6
   > m.len:    4000000
k:          7
   > m.len:    4000000
k:          8
GC Warning: Repeated allocation of very large block (appr. size 63430656):
        May lead to memory leak and poor performance
   > m.len:    4000000
k:          9
stop
CPU: 41.41s     Real: 39.06s    Elapsed: 0:39.06        RAM: 1918948KB  ./m_old
#0 17:20:27 ᛋ master /v/vnew❱
```

With this PR:
```
#0 17:20:33 ᛋ builtin_make_gc_mark_more_efficient_for_freed_v_maps_and_arrays /v/vnew❱xtime ./m_new
start
GC Warning: Repeated allocation of very large block (appr. size 39600128):
        May lead to memory leak and poor performance
GC Warning: Repeated allocation of very large block (appr. size 63430656):
        May lead to memory leak and poor performance
   > m.len:    4000000
k:          0
   > m.len:    4000000
k:          1
   > m.len:    4000000
k:          2
GC Warning: Repeated allocation of very large block (appr. size 71360512):
        May lead to memory leak and poor performance
   > m.len:    4000000
k:          3
   > m.len:    4000000
k:          4
   > m.len:    4000000
k:          5
   > m.len:    4000000
k:          6
   > m.len:    4000000
k:          7
   > m.len:    4000000
k:          8
   > m.len:    4000000
k:          9
stop
CPU: 42.96s     Real: 39.42s    Elapsed: 0:39.42        RAM: 1611608KB  ./m_new
#0 17:21:18 ᛋ builtin_make_gc_mark_more_efficient_for_freed_v_maps_and_arrays /v/vnew❱
```