### PR TITLE
fmt: fix parens around reference module prefix expressions

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2629,9 +2629,9 @@ pub fn (mut f Fmt) postfix_expr(node ast.PostfixExpr) {
 }
 
 pub fn (mut f Fmt) prefix_expr(node ast.PrefixExpr) {
-	// !(a in b) => a !in b, !(a is b) => a !is b
-	if node.op == .not && node.right is ast.ParExpr {
-		if node.right.expr is ast.InfixExpr {
+	if node.right is ast.ParExpr {
+		if node.op == .not && node.right.expr is ast.InfixExpr {
+			// !(a in b) => a !in b, !(a is b) => a !is b
 			if node.right.expr.op in [.key_in, .not_in, .key_is, .not_is]
 				&& node.right.expr.right !is ast.InfixExpr {
 				f.expr(node.right.expr.left)
@@ -2645,6 +2645,14 @@ pub fn (mut f Fmt) prefix_expr(node ast.PrefixExpr) {
 				f.expr(node.right.expr.right)
 				return
 			}
+		} else if node.op == .amp && node.right.expr is ast.Ident {
+			// Reference prefix ParExpr. E.g.: `a := &(modname.constname)`
+			f.write(node.op.str())
+			f.write('(')
+			f.expr(node.right)
+			f.or_expr(node.or_block)
+			f.write(')')
+			return
 		}
 	}
 	f.write(node.op.str())

--- a/vlib/v/fmt/tests/module_ref_type_keep.vv
+++ b/vlib/v/fmt/tests/module_ref_type_keep.vv
@@ -1,0 +1,13 @@
+module ast
+
+struct MyChar {
+	c string
+}
+
+const a_char = MyChar{
+	c: 'a'
+}
+
+fn foo() {
+	mut b := &(ast.a_char)
+}


### PR DESCRIPTION
fixes #18414 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cad62ad</samp>

Improve formatting of prefix expressions with parentheses in `vlib/v/fmt/fmt.v`. Handle `amp` operator and constants from other modules better.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cad62ad</samp>

* Reorder condition checks in `prefix_expr` to simplify logic and avoid unnecessary checks ([link](https://github.com/vlang/v/pull/18416/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL2632-R2634))
* Add case for `amp` operator with `ParExpr` on the right to support referencing constants from other modules ([link](https://github.com/vlang/v/pull/18416/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eR2648-R2655))
