### PR TITLE
cgen: fix isize/usize dumping

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -838,9 +838,9 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 		return .si_i32
 	} else if sym.kind == .u32 {
 		return .si_u32
-	} else if sym.kind == .u64 {
+	} else if sym.kind in [.u64, .usize] {
 		return .si_u64
-	} else if sym.kind == .i64 {
+	} else if sym.kind in [.i64, .isize] {
 		return .si_i64
 	}
 	return .si_i32


### PR DESCRIPTION
Fix #18411

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a1818a</samp>

Add `usize` and `isize` support to string interpolation code generation. Simplify the type checking logic in `cgen.auto_str_methods_for_type` by using the `in` operator.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a1818a</samp>

*  Add support for `usize` and `isize` types in string interpolation methods ([link](https://github.com/vlang/v/pull/18417/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL841-R843))
