### PR TITLE
scanner: fix indent error for line comment generated by vdoc

### DIFF
--- a/vlib/net/http/cookie_test.v
+++ b/vlib/net/http/cookie_test.v
@@ -416,7 +416,7 @@ const (
 				value: ','
 				raw: 'special-8=","'
 			}]
-		}
+		},
 		// TODO(bradfitz): users have reported seeing this in the
 		// wild, but do browsers handle it? RFC 6265 just says "don't
 		// do that" (section 3) and then never mentions header folding

--- a/vlib/strconv/tables.v
+++ b/vlib/strconv/tables.v
@@ -24,7 +24,7 @@ const (
 		u64(1e14),
 		u64(1e15),
 		u64(1e16),
-		u64(1e17)
+		u64(1e17),
 		// We only need to find the length of at most 17 digit numbers.
 	]
 

--- a/vlib/v/fmt/tests/array_init_comment_ending_keep.vv
+++ b/vlib/v/fmt/tests/array_init_comment_ending_keep.vv
@@ -11,7 +11,7 @@ const (
 				value: ','
 				raw: 'special-8=","'
 			}]
-		}
+		},
 		// (bradfitz): users have reported seeing this in the
 		// wild, but do browsers handle it? RFC 6265 just says "don't
 		// do that" (section 3) and then never mentions header folding

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1053,7 +1053,7 @@ fn (mut s Scanner) text_scan() token.Token {
 							//     that are on a separate line
 							comment = '\x01' + comment
 						}
-						return s.new_token(.comment, comment, comment.len + 2)
+						return s.new_token(.comment, comment, s.line_comment.len + 2)
 					}
 					// Skip the comment (return the next token)
 					continue


### PR DESCRIPTION
This PR fix indent error for line comment generated by vdoc.

before:
```v
yuyi@yuyi-PC:~$ v doc time
module time

const (
        days_string        = 'MonTueWedThuFriSatSun'
        long_days          = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
                'Sunday']
        month_days         = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
        months_string      = 'JanFebMarAprMayJunJulAugSepOctNovDec'
        long_months        = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
                'September', 'October', 'November', 'December']
// The unsigned zero year for internal calculations.
// Must be 1 mod 400, and times before it will not compute correctly,
// but otherwise can be changed at will.
        absolute_zero_year = i64(-292277022399)
        seconds_per_minute = 60
        seconds_per_hour   = 60 * seconds_per_minute
        seconds_per_day    = 24 * seconds_per_hour
        seconds_per_week   = 7 * seconds_per_day
        days_per_400_years = days_in_year * 400 + 97
        days_per_100_years = days_in_year * 100 + 24
        days_per_4_years   = days_in_year * 4 + 1
        days_in_year       = 365
...
```
now:
```v
PS D:\Vlang\v> v doc time
module time

const (
        days_string        = 'MonTueWedThuFriSatSun'
        long_days          = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
                'Sunday']
        month_days         = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
        months_string      = 'JanFebMarAprMayJunJulAugSepOctNovDec'
        long_months        = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
                'September', 'October', 'November', 'December']
        // The unsigned zero year for internal calculations.
        // Must be 1 mod 400, and times before it will not compute correctly,
        // but otherwise can be changed at will.
        absolute_zero_year = i64(-292277022399)
        seconds_per_minute = 60
        seconds_per_hour   = 60 * seconds_per_minute
        seconds_per_day    = 24 * seconds_per_hour
        seconds_per_week   = 7 * seconds_per_day
        days_per_400_years = days_in_year * 400 + 97
        days_per_100_years = days_in_year * 100 + 24
        days_per_4_years   = days_in_year * 4 + 1
        days_in_year       = 365
        days_before        = [
```