### PR TITLE
cgen: fix opt ptr argument passing with and without heap usage

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -7,12 +7,15 @@ import v.ast
 import v.util
 import v.token
 
-fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr ast.Expr, ret_typ ast.Type) {
+fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr ast.Expr, ret_typ ast.Type, in_heap bool) {
 	gen_or := expr is ast.Ident && (expr as ast.Ident).or_expr.kind != .absent
 	if gen_or {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
 		g.expr_with_cast(expr, expr_typ, ret_typ)
+		if in_heap {
+			g.write('))')
+		}
 		g.writeln(';')
 		expr_var := if expr is ast.Ident && (expr as ast.Ident).is_auto_heap() {
 			'(*${expr.name})'
@@ -575,8 +578,8 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 								g.write('${styp} ')
 							}
 						}
-						if is_auto_heap {
-							g.write('*')
+						if is_auto_heap && !(val_type.is_ptr() && val_type.has_flag(.option)) {
+							g.write('*/*aqui*/')
 						}
 					}
 				}
@@ -588,7 +591,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						g.op_arg(left, op_expected_left, var_type)
 					} else {
 						if !is_decl && left.is_auto_deref_var() {
-							g.write('*')
+							g.write('*/*aqui2*/')
 						}
 						g.expr(left)
 						if !is_decl && var_type.has_flag(.shared_f) {
@@ -665,15 +668,18 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							g.write('{0}')
 						}
 					} else {
+						is_option_unwrapped := (val is ast.Ident
+							&& (val as ast.Ident).or_expr.kind != .absent)
+						is_option_auto_heap := is_auto_heap && is_option_unwrapped
 						if is_auto_heap {
 							g.write('HEAP(${styp}, (')
 						}
-						if val.is_auto_deref_var() {
+						if val.is_auto_deref_var() && !is_option_unwrapped {
 							g.write('*')
 						}
 						if (var_type.has_flag(.option) && val !in [ast.Ident, ast.SelectorExpr])
 							|| gen_or {
-							g.expr_with_opt_or_block(val, val_type, left, var_type)
+							g.expr_with_opt_or_block(val, val_type, left, var_type, is_option_auto_heap)
 						} else if val is ast.ArrayInit {
 							g.array_init(val, c_name(ident.name))
 						} else if val_type.has_flag(.shared_f) {
@@ -681,7 +687,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						} else {
 							g.expr(val)
 						}
-						if is_auto_heap {
+						if is_auto_heap && !is_option_auto_heap {
 							g.write('))')
 						}
 					}
@@ -695,7 +701,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						g.is_option_auto_heap = old_is_auto_heap
 					}
 					if var_type.has_flag(.option) || gen_or {
-						g.expr_with_opt_or_block(val, val_type, left, var_type)
+						g.expr_with_opt_or_block(val, val_type, left, var_type, false)
 					} else if node.has_cross_var {
 						g.gen_cross_tmp_variable(node.left, val)
 					} else {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -579,7 +579,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							}
 						}
 						if is_auto_heap && !(val_type.is_ptr() && val_type.has_flag(.option)) {
-							g.write('*/*aqui*/')
+							g.write('*')
 						}
 					}
 				}
@@ -591,7 +591,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						g.op_arg(left, op_expected_left, var_type)
 					} else {
 						if !is_decl && left.is_auto_deref_var() {
-							g.write('*/*aqui2*/')
+							g.write('*')
 						}
 						g.expr(left)
 						if !is_decl && var_type.has_flag(.shared_f) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2453,7 +2453,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		deref_will_match := expected_type in [got_type, got_deref_type, deref_sym.parent_idx]
 		got_is_opt_or_res := got_type.has_flag(.option) || got_type.has_flag(.result)
 		if deref_will_match || got_is_opt_or_res || expr.is_auto_deref_var() {
-			g.write('*/*c*/')
+			g.write('*')
 		}
 	}
 	if expr is ast.IntegerLiteral {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1898,6 +1898,9 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				} else {
 					g.write('_option_ok(&(${styp}[]) { ')
 				}
+				if !expr_typ.is_ptr() && ret_typ.is_ptr() {
+					g.write('&/*ref*/')
+				}
 			}
 		} else {
 			g.write('_result_ok(&(${styp}[]) { ')
@@ -2450,7 +2453,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		deref_will_match := expected_type in [got_type, got_deref_type, deref_sym.parent_idx]
 		got_is_opt_or_res := got_type.has_flag(.option) || got_type.has_flag(.result)
 		if deref_will_match || got_is_opt_or_res || expr.is_auto_deref_var() {
-			g.write('*')
+			g.write('*/*c*/')
 		}
 	}
 	if expr is ast.IntegerLiteral {
@@ -4271,7 +4274,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					for _ in node.obj.smartcasts {
 						g.write('(')
 						if obj_sym.kind == .sum_type && !is_auto_heap {
-							g.write('*')
+							g.write('*/*d*/')
 						}
 					}
 					for i, typ in node.obj.smartcasts {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4274,7 +4274,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					for _ in node.obj.smartcasts {
 						g.write('(')
 						if obj_sym.kind == .sum_type && !is_auto_heap {
-							g.write('*/*d*/')
+							g.write('*')
 						}
 					}
 					for i, typ in node.obj.smartcasts {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2193,7 +2193,12 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 			if arg_typ_sym.kind != .function && deref_sym.kind !in [.sum_type, .interface_]
 				&& lang != .c {
 				if arg.expr.is_lvalue() {
-					g.write('(voidptr)&/*qq*/')
+					if expected_type.has_flag(.option) {
+						g.expr_with_opt(arg.expr, arg_typ, expected_type)
+						return
+					} else {
+						g.write('(voidptr)&/*qq*/')
+					}
 				} else {
 					mut atype := expected_deref_type
 					if atype.has_flag(.generic) {

--- a/vlib/v/tests/option_ptr_arg_heap_test.v
+++ b/vlib/v/tests/option_ptr_arg_heap_test.v
@@ -1,0 +1,25 @@
+module main
+
+[heap]
+struct Node[T] {
+mut:
+	value T
+	next  ?&Node[T]
+}
+
+fn print_t1(node ?&Node[int]) {
+	println(node)
+}
+
+fn print_t2(mut node ?&Node[int]) {
+	n := node or { return }
+	println(n)
+}
+
+fn test_main() {
+	mut n := Node[int]{
+		value: 5
+	}
+	print_t1(n)
+	print_t2(mut n.next)
+}

--- a/vlib/v/tests/option_ptr_arg_test.v
+++ b/vlib/v/tests/option_ptr_arg_test.v
@@ -1,0 +1,24 @@
+module main
+
+struct Node[T] {
+mut:
+	value T
+	next  ?&Node[T]
+}
+
+fn print_t1(node ?&Node[int]) {
+	println(node)
+}
+
+fn print_t2(mut node ?&Node[int]) {
+	n := node or { return }
+	println(n)
+}
+
+fn test_main() {
+	mut n := Node[int]{
+		value: 5
+	}
+	print_t1(n)
+	print_t2(mut n.next)
+}


### PR DESCRIPTION
Fix #18418

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ae4668</samp>

This pull request improves the C code generation for optional pointers and adds tests to verify the correctness. It handles different cases of optional expressions and pointers, whether they are on the stack or the heap, and whether they are passed as arguments to functions that expect void pointers or not. It also adds reference and dereference operators to expressions in C code generation to handle pointer types correctly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ae4668</samp>

*  Add a parameter `in_heap` to `expr_with_opt_or_block` to handle optional expressions on the heap ([link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL10-R10), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bR16-R18), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL668-R682), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL698-R704))
*  Avoid double dereferencing and memory errors when assigning optional pointers ([link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL578-R582), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL591-R594), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL684-R690))
*  Insert reference operator for non-pointer expressions passed to pointer parameters ([link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR1901-R1903))
*  Call `expr_with_opt` for optional pointers passed to void pointers ([link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L2196-R2201))
*  Add comments for debugging and clarity where pointers are dereferenced ([link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL591-R594), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL2453-R2456), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4274-R4277))
*  Add test files `option_ptr_arg_heap_test.v` and `option_ptr_arg_test.v` to check the correctness of the changes for `Node` struct and `print_t1` and `print_t2` functions ([link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-7cc4a9886b0354ef2796ce787755a832b5b1ca3ccaebc1ca443441dacd4589fcR1-R25), [link](https://github.com/vlang/v/pull/18423/files?diff=unified&w=0#diff-e47198be257ac54368905fb88dfa00af668a18b66a554ae7dd9491bf95afc036R1-R24))
