### PR TITLE
tools: remove residues that specify size for tab indents

### DIFF
--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -238,7 +238,6 @@ trim_trailing_whitespace = true
 
 [*.v]
 indent_style = tab
-indent_size = 4
 '
 }
 

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -91,7 +91,6 @@ fn init_and_check() ! {
 		'',
 		'[*.v]',
 		'indent_style = tab',
-		'indent_size = 4',
 		'',
 	].join_lines()
 }
@@ -130,7 +129,6 @@ trim_trailing_whitespace = true
 
 [*.v]
 indent_style = tab
-indent_size = 4
 '
 	prepare_test_path()!
 	os.write_file('.gitattributes', git_attributes_content)!

--- a/examples/vweb_fullstack/.editorconfig
+++ b/examples/vweb_fullstack/.editorconfig
@@ -6,4 +6,3 @@ trim_trailing_whitespace = true
 
 [*.v]
 indent_style = tab
-indent_size = 4

--- a/examples/vweb_orm_jwt/.editorconfig
+++ b/examples/vweb_orm_jwt/.editorconfig
@@ -6,4 +6,3 @@ trim_trailing_whitespace = true
 
 [*.v]
 indent_style = tab
-indent_size = 4


### PR DESCRIPTION
Part2 of #18297.  

The PR fixes the issue mentioned in the related PR for the changed `.editorconfig`s and prevents newly created projects from being prone to it.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a2f334</samp>

Removed `indent_size` from various files to ensure consistent and automatic indentation of V code. This simplifies the code formatting and avoids conflicts between the `fmt` tool and the `.editorconfig` file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a2f334</samp>

*  Remove unused and redundant `indent_size` variable from `vcreate.v` ([link](https://github.com/vlang/v/pull/18426/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL241)) and its tests in `vcreate_test.v` ([link](https://github.com/vlang/v/pull/18426/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL94), [link](https://github.com/vlang/v/pull/18426/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL133))
*  Remove `indent_size` line from `.editorconfig` files in `examples/vweb_fullstack` and `examples/vweb_orm_jwt` to match the default indentation size of 2 spaces for V code ([link](https://github.com/vlang/v/pull/18426/files?diff=unified&w=0#diff-435ee1c7f537c59a739afafa9c2c9c3cac444902a6c377a9dd12486006b31466L9), [link](https://github.com/vlang/v/pull/18426/files?diff=unified&w=0#diff-b0bfff57a27ae8aa158472b2e2d8444923c999166584f5bb32f74f7be0660656L9))
