### PR TITLE
map: add docstring for map.move()

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -286,6 +286,9 @@ fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_
 	return out
 }
 
+// move moves the map to a new location in memory.
+// It does this by copying to a new location, then setting the
+// old location to all `0` with `vmemset`
 pub fn (mut m map) move() map {
 	r := *m
 	unsafe {


### PR DESCRIPTION
Based on [this discussion](https://github.com/vlang/v/discussions/17705) and #7047 I found that [map.move](https://modules.vlang.io/index.html#map.move) didn't have a docstring, so I added one. Please let me know if I misunderstood the code.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d2e500</samp>

Add a comment to `map.move` method in `vlib/builtin/map.v` to document its functionality and rationale. This method helps avoid memory leaks when transferring map ownership.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d2e500</samp>

* Add a comment to explain the `move` method for maps ([link](https://github.com/vlang/v/pull/18430/files?diff=unified&w=0#diff-c639b6a25595ff12a0acfa40b019df49c89647406a1a436a77c593841c156258R289-R291))
