### PR TITLE
vdoc: highlight comments with gray color

### DIFF
--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -163,9 +163,9 @@ fn color_highlight(code string, tb &ast.Table) string {
 			}
 			.comment {
 				lit = if tok.lit != '' && tok.lit[0] == 1 {
-					'//${tok.lit[1..]}'
+					term.gray('//${tok.lit[1..]}')
 				} else {
-					'//${tok.lit}'
+					term.gray('//${tok.lit}')
 				}
 			}
 			.keyword {


### PR DESCRIPTION
This PR highlight comments with gray color in vdoc.

![image](https://github.com/vlang/v/assets/6949593/01def7a0-45a5-469a-9027-d6cb22ab5039)
