### PR TITLE
cgen: fix msvc packed attr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3798,7 +3798,11 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 		g.enum_typedefs.writeln(', // ${cur_value}')
 		cur_enum_offset++
 	}
-	packed_attribute := if node.typ != ast.int_type { '__attribute__((packed))' } else { '' }
+	packed_attribute := if !g.is_cc_msvc && node.typ != ast.int_type {
+		'__attribute__((packed))'
+	} else {
+		''
+	}
 	g.enum_typedefs.writeln('} ${packed_attribute} ${enum_name};')
 	if node.typ != ast.int_type {
 		g.enum_typedefs.writeln('#pragma pack(pop)\n')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -507,7 +507,7 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 	}
 	// g.type_definitions.writeln('} $name;\n')
 	//
-	ti_attrs := if s.attrs.contains('packed') {
+	ti_attrs := if !g.is_cc_msvc && s.attrs.contains('packed') {
 		'__attribute__((__packed__))'
 	} else {
 		''


### PR DESCRIPTION
Fix #18435

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9356dd5</samp>

Fix MSVC compilation error for enums with `__attribute__((packed))`. Skip this attribute for MSVC in `vlib/v/gen/c/cgen.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9356dd5</samp>

* Fix MSVC compatibility issues for V by applying conditional compilation and using alternative syntax for some features ([link](https://github.com/vlang/v/pull/18437/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3801-R3805),                      F0L
