### PR TITLE
cgen: fix fixed array of chan

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -201,6 +201,21 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 					elem_type: arr_info.elem_type
 				})
 			}
+		} else if elem_sym.kind == .chan {
+			// fixed array for chan -- [N]chan
+			info := array_type.unaliased_sym.info as ast.ArrayFixed
+			chan_info := elem_sym.chan_info()
+			g.expr(ast.ChanInit{
+				typ: node.elem_type
+				elem_type: chan_info.elem_type
+			})
+			for _ in 1 .. info.size {
+				g.write(', ')
+				g.expr(ast.ChanInit{
+					typ: node.elem_type
+					elem_type: chan_info.elem_type
+				})
+			}
 		} else {
 			g.write('0')
 		}

--- a/vlib/v/tests/fixed_array_chan_test.v
+++ b/vlib/v/tests/fixed_array_chan_test.v
@@ -1,0 +1,31 @@
+import time
+
+struct Struct {
+	ch chan int
+}
+
+fn listen(ch chan int) {
+	for {
+		t := <-ch or { break }
+		println(t)
+	}
+}
+
+fn sp_array() {
+	mut array := [3]chan int{}
+	for a in 0 .. 3 {
+		spawn listen(array[a])
+	}
+	for i, a in array {
+		a <- i
+	}
+	time.sleep(1000 * time.millisecond)
+	for c in array {
+		c.close()
+	}
+}
+
+fn test_main() {
+	sp_array()
+	assert true
+}


### PR DESCRIPTION
Fix #18433

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d082a8c</samp>

Add support for generating C code for fixed arrays of channels in V. Update `gen_array_init` function in `vlib/v/gen/c/array.v` to handle `[N]chan T` declarations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d082a8c</samp>

*  Add support for fixed arrays of channels in C code generation ([link](https://github.com/vlang/v/pull/18438/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278R204-R218))
