### PR TITLE
checker: extend check assigning mut reference to immutable var in nested parens

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -733,7 +733,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.inside_ref_lit = old_inside_ref_lit
 			if right_node.op == .amp {
 				expr := if right_node.right is ast.ParExpr {
-					right_node.right.expr
+					mut expr_ := right_node.right.expr
+					for mut expr_ is ast.ParExpr {
+						expr_ = expr_.expr
+					}
+					expr_
 				} else {
 					right_node.right
 				}

--- a/vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.out
+++ b/vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.out
@@ -1,7 +1,77 @@
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:11:12: warning: redundant parentheses are used
+    9 | fn foo() {
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+      |               ~~~~~~~~~~
+   12 |     mut c := &((((a_char))))
+   13 |     println(a)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:11:12: warning: redundant parentheses are used
+    9 | fn foo() {
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+      |               ~~~~~~~~~~
+   12 |     mut c := &((((a_char))))
+   13 |     println(a)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:12: warning: redundant parentheses are used
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |               ~~~~~~~~~~~~~~
+   13 |     println(a)
+   14 |     println(b)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:13: warning: redundant parentheses are used
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |                ~~~~~~~~~~~~
+   13 |     println(a)
+   14 |     println(b)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:14: warning: redundant parentheses are used
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |                 ~~~~~~~~~~
+   13 |     println(a)
+   14 |     println(b)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:12: warning: redundant parentheses are used
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |               ~~~~~~~~~~~~~~
+   13 |     println(a)
+   14 |     println(b)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:13: warning: redundant parentheses are used
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |                ~~~~~~~~~~~~
+   13 |     println(a)
+   14 |     println(b)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:14: warning: redundant parentheses are used
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |                 ~~~~~~~~~~
+   13 |     println(a)
+   14 |     println(b)
 vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:10:11: error: `a_char` is immutable, cannot have a mutable reference to it
     8 | 
     9 | fn foo() {
-   10 |     mut c := &(a_char)
+   10 |     mut a := &(a_char)
       |              ^
-   11 |     println(c)
-   12 | }
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:11:11: error: `a_char` is immutable, cannot have a mutable reference to it
+    9 | fn foo() {
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+      |              ^
+   12 |     mut c := &((((a_char))))
+   13 |     println(a)
+vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv:12:11: error: `a_char` is immutable, cannot have a mutable reference to it
+   10 |     mut a := &(a_char)
+   11 |     mut b := &((a_char))
+   12 |     mut c := &((((a_char))))
+      |              ^
+   13 |     println(a)
+   14 |     println(b)

--- a/vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv
+++ b/vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.vv
@@ -7,6 +7,10 @@ const a_char = MyChar{
 }
 
 fn foo() {
-	mut c := &(a_char)
+	mut a := &(a_char)
+	mut b := &((a_char))
+	mut c := &((((a_char))))
+	println(a)
+	println(b)
 	println(c)
 }


### PR DESCRIPTION
Checker part of #18439

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd7bc7d</samp>

This pull request fixes a checker bug that caused incorrect type and mutability checks for expressions with parentheses. It also adds more test cases and warnings for redundant parentheses. The files affected are `vlib/v/checker/assign.v` and `vlib/v/checker/tests/assign_immutable_reference_var_with_parenthesis_err.*`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd7bc7d</samp>

* Fix checker bug for nested parentheses in expressions ([link](https://github.com/vlang/v/pull/18442/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL736-R740))
* Update and modify test case `assign_immutable_reference_var_with_parenthesis_err` ([link](https://github.com/vlang/v/pull/18442/files?diff=unified&w=0#diff-f494234455eccb0d1407e50a75d8669e11e68a8f1fa8998acd33764e2c524b5cL1-R77), [link](https://github.com/vlang/v/pull/18442/files?diff=unified&w=0#diff-69a327572d275dcde5af5a99e96aa348f8d68285da643504284cac0afac9b1dcL10-R14))
