### PR TITLE
checker: fix enum max value validation

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1668,6 +1668,7 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 					mut overflows := false
 					mut uval := u64(0)
 					mut ival := i64(0)
+
 					if signed {
 						val := field.expr.val.i64()
 						ival = val
@@ -1679,11 +1680,23 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 					} else {
 						val := field.expr.val.u64()
 						uval = val
-						if uval > enum_umax
-							|| (uval == enum_umax && field.expr.val.str() != uval.str()) {
-							c.error('enum value `${field.expr.val}` overflows the enum type `${senum_type}`, values of which have to be in [${enum_umin}, ${enum_umax}]',
-								field.expr.pos)
+						if val >= enum_umax {
 							overflows = true
+							if val == enum_umax {
+								is_bin := field.expr.val.starts_with('0b')
+								is_oct := field.expr.val.starts_with('0o')
+								is_hex := field.expr.val.starts_with('0x')
+
+								if is_hex {
+									overflows = val.hex() != enum_umax.hex()
+								} else if !is_bin && !is_oct && !is_hex {
+									overflows = field.expr.val.str() != enum_umax.str()
+								}
+							}
+							if overflows {
+								c.error('enum value `${field.expr.val}` overflows the enum type `${senum_type}`, values of which have to be in [${enum_umin}, ${enum_umax}]',
+									field.expr.pos)
+							}
 						}
 					}
 					if !overflows && !c.pref.translated && !c.file.is_translated

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1679,7 +1679,8 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 					} else {
 						val := field.expr.val.u64()
 						uval = val
-						if val > enum_umax {
+						if uval > enum_umax
+							|| (uval == enum_umax && field.expr.val.str() != uval.str()) {
 							c.error('enum value `${field.expr.val}` overflows the enum type `${senum_type}`, values of which have to be in [${enum_umin}, ${enum_umax}]',
 								field.expr.pos)
 							overflows = true

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1679,7 +1679,7 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 					} else {
 						val := field.expr.val.u64()
 						uval = val
-						if val >= enum_umax {
+						if val > enum_umax {
 							c.error('enum value `${field.expr.val}` overflows the enum type `${senum_type}`, values of which have to be in [${enum_umin}, ${enum_umax}]',
 								field.expr.pos)
 							overflows = true

--- a/vlib/v/tests/enum_max_test.v
+++ b/vlib/v/tests/enum_max_test.v
@@ -4,9 +4,24 @@ enum Nums as u8 {
 	three = 0xff
 }
 
+enum Nums2 as u32 {
+	one
+	two
+	three = 0xFFFFFFFF
+}
+
+enum Nums3 as u64 {
+	one
+	two
+	three = 0xFFFFFFFFFFFFFFFF
+}
+
 fn test_main() {
 	mut a := Nums.one
 	assert a == Nums.one
 	assert int(Nums.three) == 0xff
 	assert Nums.three == unsafe { Nums(255) }
+
+	assert u64(Nums2.three) == 0xFFFFFFFF
+	assert u64(Nums3.three) == 0xFFFFFFFFFFFFFFFF
 }

--- a/vlib/v/tests/enum_max_test.v
+++ b/vlib/v/tests/enum_max_test.v
@@ -1,0 +1,12 @@
+enum Nums as u8 {
+	one
+	two
+	three = 0xff
+}
+
+fn test_main() {
+	mut a := Nums.one
+	assert a == Nums.one
+	assert int(Nums.three) == 0xff
+	assert Nums.three == unsafe { Nums(255) }
+}


### PR DESCRIPTION
Fix #18421
Fix #16994

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8237d23</samp>

Fix a bug in the checker that caused overflow errors for enum values equal to the maximum value of their underlying type. Add a test case in `enum_max_test.v` to verify the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8237d23</samp>

* Fix checker bug that prevented enum values from being equal to the maximum value of their underlying type ([link](https://github.com/vlang/v/pull/18446/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L1682-R1682))
* Add test case to verify that enum values can be compared and casted correctly with the maximum value of their underlying type ([link](https://github.com/vlang/v/pull/18446/files?diff=unified&w=0#diff-d552720d7155f98a24ffd78eb79bd1554b758e2e47943e25b9ca187af88f061fR1-R12))
