### PR TITLE
checker: avoid &Type as generic concrete type on usage

### DIFF
--- a/vlib/v/checker/tests/wrong_ref_type_as_concrete_err.out
+++ b/vlib/v/checker/tests/wrong_ref_type_as_concrete_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/wrong_ref_type_as_concrete_err.vv:9:39: error: cannot use &Type as generic concrete type, declare the function parameter as &T instead
+    7 | 
+    8 | fn main() {
+    9 |     mut dl := datatypes.DoublyLinkedList[&User]{}
+      |                                          ^
+   10 |     println(dl)
+   11 | }

--- a/vlib/v/checker/tests/wrong_ref_type_as_concrete_err.out
+++ b/vlib/v/checker/tests/wrong_ref_type_as_concrete_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/wrong_ref_type_as_concrete_err.vv:9:39: error: cannot use &Type as generic concrete type, declare the function parameter as &T instead
+vlib/v/checker/tests/wrong_ref_type_as_concrete_err.vv:9:39: error: cannot use &Type as generic concrete type, declare the function parameter or struct member as &T instead
     7 | 
     8 | fn main() {
     9 |     mut dl := datatypes.DoublyLinkedList[&User]{}

--- a/vlib/v/checker/tests/wrong_ref_type_as_concrete_err.vv
+++ b/vlib/v/checker/tests/wrong_ref_type_as_concrete_err.vv
@@ -1,0 +1,11 @@
+import datatypes
+
+[heap]
+struct User {
+	name string
+}
+
+fn main() {
+	mut dl := datatypes.DoublyLinkedList[&User]{}
+	println(dl)
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -742,7 +742,7 @@ fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	for p.tok.kind != .eof {
 		mut type_pos := p.tok.pos()
 		if p.tok.kind == .amp {
-			p.error_with_pos('cannot use &Type as generic concrete type, declare the function parameter as &T instead',
+			p.error_with_pos('cannot use &Type as generic concrete type, declare the function parameter or struct member as &T instead',
 				type_pos)
 		}
 		gt := p.parse_type()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -741,6 +741,10 @@ fn (mut p Parser) parse_generic_inst_type(name string) ast.Type {
 	mut is_instance := true
 	for p.tok.kind != .eof {
 		mut type_pos := p.tok.pos()
+		if p.tok.kind == .amp {
+			p.error_with_pos('cannot use &Type as generic concrete type, declare the function parameter as &T instead',
+				type_pos)
+		}
 		gt := p.parse_type()
 		type_pos = type_pos.extend(p.prev_tok.pos())
 		if gt.has_flag(.generic) {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3223,6 +3223,9 @@ fn (mut p Parser) parse_concrete_types() []ast.Type {
 		if first_done {
 			p.check(.comma)
 		}
+		if p.tok.kind == .amp {
+			p.error('cannot use &Type as generic concrete type')
+		}
 		types << p.parse_type()
 		first_done = true
 	}


### PR DESCRIPTION
Fix #18440
Fix #18367

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6065ce</samp>

Prevent using reference types as generic concrete types in the compiler. Add a test case and an error message for this scenario.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6065ce</samp>

*  Report and test error when using reference type as generic concrete type ([link](https://github.com/vlang/v/pull/18447/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffR744-R747), [link](https://github.com/vlang/v/pull/18447/files?diff=unified&w=0#diff-709f9ef602072837fe0a8da72abbe02e77b77e9df425d8872b9fc3b00fc0cb6fR1-R7), [link](https://github.com/vlang/v/pull/18447/files?diff=unified&w=0#diff-94ef78a0886d62190846f5ae3736909bcf193954eefcde50eb0bd64015cffc42R1-R11))
  - Check for ampersand token after opening bracket in `parse_type.v` and call `error_with_pos` with message and position ([link](https://github.com/vlang/v/pull/18447/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffR744-R747))
  - Add expected compiler error message in `wrong_ref_type_as_concrete_err.out` suggesting to use generic type parameter instead ([link](https://github.com/vlang/v/pull/18447/files?diff=unified&w=0#diff-709f9ef602072837fe0a8da72abbe02e77b77e9df425d8872b9fc3b00fc0cb6fR1-R7))
  - Add test case in `wrong_ref_type_as_concrete_err.vv` that imports `datatypes` module, defines heap-allocated struct `User`, and tries to create doubly linked list of references to `User` ([link](https://github.com/vlang/v/pull/18447/files?diff=unified&w=0#diff-94ef78a0886d62190846f5ae3736909bcf193954eefcde50eb0bd64015cffc42R1-R11))
