### PR TITLE
checker: include import aliases when checking for import duplicates

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -183,7 +183,7 @@ pub fn (mut c Checker) check(ast_file_ &ast.File) {
 				c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
 					ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
 			} else if ast_import.alias == ast_file.imports[j].alias {
-				c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
+				c.error('`${ast_file.imports[j].mod}` was already imported on line ${
 					ast_file.imports[j].alias_pos.line_nr + 1}', ast_import.alias_pos)
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -179,6 +179,9 @@ pub fn (mut c Checker) check(ast_file_ &ast.File) {
 			if ast_import.mod == ast_file.imports[j].mod {
 				c.error('`${ast_import.mod}` was already imported on line ${
 					ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
+			} else if ast_import.mod == ast_file.imports[j].alias {
+				c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
+					ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
 			}
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -182,6 +182,9 @@ pub fn (mut c Checker) check(ast_file_ &ast.File) {
 			} else if ast_import.mod == ast_file.imports[j].alias {
 				c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
 					ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
+			} else if ast_import.alias == ast_file.imports[j].alias {
+				c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
+					ast_file.imports[j].alias_pos.line_nr + 1}', ast_import.alias_pos)
 			}
 		}
 	}

--- a/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:2:19: error: `json` was already imported as `json` on line 1
+    1 | import json
+    2 | import x.json2 as json
+      |                   ~~~~
+    3 | 
+    4 | numbers := {

--- a/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:2:19: error: `json` was already imported as `json` on line 1
+vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:2:19: error: `json` was already imported on line 1
     1 | import json
     2 | import x.json2 as json
       |                   ~~~~

--- a/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv
+++ b/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv
@@ -1,0 +1,12 @@
+import json
+import x.json2 as json
+
+numbers := {
+	'one':   1
+	'two':   2
+	'three': 3
+	'four':  4
+}
+
+out := json.encode(numbers)
+println(out)

--- a/vlib/v/checker/tests/import_mod_as_import_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_duplicate_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv:2:8: error: `x.json2` was already imported as `json` on line 1
+    1 | import x.json2 as json
+    2 | import json
+      |        ~~~~
+    3 | 
+    4 | numbers := {

--- a/vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv
+++ b/vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv
@@ -1,0 +1,12 @@
+import x.json2 as json
+import json
+
+numbers := {
+	'one':   1
+	'two':   2
+	'three': 3
+	'four':  4
+}
+
+out := json.encode(numbers)
+println(out)


### PR DESCRIPTION
Currently, it's possible to use an import alias as duplicate of another import and an import as duplicate of another import alias.

```v
import json
import x.json2 as json
```

```v
import x.json2 as json
import json
```


With the changes in this PR it will result in:
```
error: `json` was already imported on line 1
    1 | import json
    2 | import x.json2 as json
      |                   ~~~~
```

```
error: `x.json2` was already imported as `json` on line 1
    1 | import x.json2 as json
    2 | import json
      |        ~~~~
```



<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb05497</samp>

Add error checks to the checker module to prevent importing modules with duplicate names or aliases. Add test files to verify the new checks.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb05497</samp>

*  Add error checks for importing modules with duplicate names or aliases ([link](https://github.com/vlang/v/pull/18450/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R182-R187))
   * Create V files with `.vv` extension that import modules with conflicting names or aliases ([link](https://github.com/vlang/v/pull/18450/files?diff=unified&w=0#diff-70715a9fba11acfb426426e0d08b778cfa8a22e5fdfb58a26b373ed4f25c3c35R1-R12), [link](https://github.com/vlang/v/pull/18450/files?diff=unified&w=0#diff-7d190962952c316c04a9f247f61d8332b908766abf8c81d043c498ecfee877caR1-R12))
   * Create output files with `.out` extension that match the V file names and contain the expected error messages and positions ([link](https://github.com/vlang/v/pull/18450/files?diff=unified&w=0#diff-94c790b6ba5423308fa53eb87cff121c736389088f7a4fc0898bd4216d552a24R1-R6), [link](https://github.com/vlang/v/pull/18450/files?diff=unified&w=0#diff-62b240db902c364573126ca75a8bd414607c444d984a777a270fcc645b9c38f5L1-R5))
