### PR TITLE
checker: fix missing check for unwrapped shift operation

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -457,7 +457,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			} else if node.left !in [ast.Ident, ast.SelectorExpr, ast.ComptimeSelector]
 				&& (left_type.has_flag(.option) || right_type.has_flag(.option)) {
 				opt_comp_pos := if left_type.has_flag(.option) { left_pos } else { right_pos }
-				c.error('unwrapped option cannot be compared in an infix expression',
+				c.error('unwrapped Option cannot be compared in an infix expression',
 					opt_comp_pos)
 			}
 		}
@@ -470,6 +470,11 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			if left_final_sym.kind == .array {
 				if !node.is_stmt {
 					c.error('array append cannot be used in an expression', node.pos)
+				}
+				if left_type.has_flag(.option) && node.left is ast.Ident
+					&& (node.left as ast.Ident).or_expr.kind == .absent {
+					c.error('unwrapped Option cannot be used in an infix expression',
+						node.pos)
 				}
 				// `array << elm`
 				c.check_expr_opt_call(node.right, right_type)
@@ -695,7 +700,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		opt_infix_pos := if left_is_option { left_pos } else { right_pos }
 		if (node.left !in [ast.Ident, ast.SelectorExpr, ast.ComptimeSelector]
 			|| node.op in [.eq, .ne, .lt, .gt, .le, .ge]) && right_sym.kind != .none_ {
-			c.error('unwrapped option cannot be used in an infix expression', opt_infix_pos)
+			c.error('unwrapped Option cannot be used in an infix expression', opt_infix_pos)
 		}
 	}
 
@@ -703,7 +708,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	right_is_result := right_type.has_flag(.result)
 	if left_is_result || right_is_result {
 		opt_infix_pos := if left_is_result { left_pos } else { right_pos }
-		c.error('unwrapped result cannot be used in an infix expression', opt_infix_pos)
+		c.error('unwrapped Result cannot be used in an infix expression', opt_infix_pos)
 	}
 
 	// Dual sides check (compatibility check)

--- a/vlib/v/checker/tests/infix_compare_option_err.out
+++ b/vlib/v/checker/tests/infix_compare_option_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/infix_compare_option_err.vv:6:5: error: unwrapped option cannot be compared in an infix expression
-    4 |
+vlib/v/checker/tests/infix_compare_option_err.vv:6:5: error: unwrapped Option cannot be compared in an infix expression
+    4 | 
     5 | fn main() {
     6 |     if foo() > foo() {
       |        ~~~~~

--- a/vlib/v/checker/tests/infix_err.out
+++ b/vlib/v/checker/tests/infix_err.out
@@ -17,17 +17,17 @@ vlib/v/checker/tests/infix_err.vv:9:9: error: `+` cannot be used with `?string`
     8 | _ = f() + ''
     9 | _ = f() + f()
       |         ^
-   10 |
+   10 | 
    11 | _ = 4 + g()
 vlib/v/checker/tests/infix_err.vv:11:7: error: `+` cannot be used with `?int`
     9 | _ = f() + f()
-   10 |
+   10 | 
    11 | _ = 4 + g()
       |       ^
    12 | _ = int(0) + g() // FIXME not detected
    13 | _ = g() + int(3)
-vlib/v/checker/tests/infix_err.vv:12:14: error: unwrapped option cannot be used in an infix expression
-   10 |
+vlib/v/checker/tests/infix_err.vv:12:14: error: unwrapped Option cannot be used in an infix expression
+   10 | 
    11 | _ = 4 + g()
    12 | _ = int(0) + g() // FIXME not detected
       |              ~~~
@@ -45,10 +45,10 @@ vlib/v/checker/tests/infix_err.vv:14:9: error: `+` cannot be used with `?int`
    13 | _ = g() + int(3)
    14 | _ = g() + 3
       |         ^
-   15 |
+   15 | 
    16 | // binary operands
 vlib/v/checker/tests/infix_err.vv:17:5: error: left operand for `&&` is not a boolean
-   15 |
+   15 | 
    16 | // binary operands
    17 | _ = 1 && 2
       |     ^
@@ -59,10 +59,10 @@ vlib/v/checker/tests/infix_err.vv:18:13: error: right operand for `||` is not a 
    17 | _ = 1 && 2
    18 | _ = true || 2
       |             ^
-   19 |
+   19 | 
    20 | // boolean expressions
 vlib/v/checker/tests/infix_err.vv:21:22: error: ambiguous boolean expression. use `()` to ensure correct order of operations
-   19 |
+   19 | 
    20 | // boolean expressions
    21 | _ = 1 == 1 && 2 == 2 || 3 == 3
       |                      ~~

--- a/vlib/v/checker/tests/option_wrapped_cmp_op_err.out
+++ b/vlib/v/checker/tests/option_wrapped_cmp_op_err.out
@@ -1,25 +1,25 @@
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:3:10: error: unwrapped option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:3:10: error: unwrapped Option cannot be used in an infix expression
     1 | fn main() {
     2 |     a := ?string("hi")
     3 |     println(a == 'hi')
       |             ^
     4 |     println('hi' == a)
     5 |     println(a != 'hi')
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:4:18: error: unwrapped option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:4:18: error: unwrapped Option cannot be used in an infix expression
     2 |     a := ?string("hi")
     3 |     println(a == 'hi')
     4 |     println('hi' == a)
       |                     ^
     5 |     println(a != 'hi')
     6 |     println('hi' != a)
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:5:10: error: unwrapped option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:5:10: error: unwrapped Option cannot be used in an infix expression
     3 |     println(a == 'hi')
     4 |     println('hi' == a)
     5 |     println(a != 'hi')
       |             ^
     6 |     println('hi' != a)
     7 | }
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:6:18: error: unwrapped option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:6:18: error: unwrapped Option cannot be used in an infix expression
     4 |     println('hi' == a)
     5 |     println(a != 'hi')
     6 |     println('hi' != a)

--- a/vlib/v/checker/tests/unwrapped_option_infix.out
+++ b/vlib/v/checker/tests/unwrapped_option_infix.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/unwrapped_option_infix.vv:5:9: error: unwrapped option cannot be used in an infix expression
+vlib/v/checker/tests/unwrapped_option_infix.vv:5:9: error: unwrapped Option cannot be used in an infix expression
     3 | }
-    4 |
+    4 | 
     5 | println(test() == '')
       |         ~~~~~~

--- a/vlib/v/checker/tests/unwrapped_result_infix_err.out
+++ b/vlib/v/checker/tests/unwrapped_result_infix_err.out
@@ -1,8 +1,7 @@
-vlib/v/checker/tests/unwrapped_result_infix_err.vv:7:9: error: unwrapped result cannot be used in an infix expression
+vlib/v/checker/tests/unwrapped_result_infix_err.vv:7:9: error: unwrapped Result cannot be used in an infix expression
     5 | fn g() ! {
     6 |     assert f('1')! == true
     7 |     assert f('1') == true
       |            ~~~~~~
     8 | }
     9 |
-

--- a/vlib/v/checker/tests/wrong_shift_left_option_err.out
+++ b/vlib/v/checker/tests/wrong_shift_left_option_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/wrong_shift_left_option_err.vv:7:4: error: unwrapped Option cannot be used in an infix expression
+    5 | fn main() {
+    6 |     mut a := ?[]SomeStruct([SomeStruct{}, SomeStruct{}]) // struct type
+    7 |     a << []SomeStruct{len: 20}
+      |       ~~
+    8 |     mut b := ?[]int([2, 8]) // primitive type
+    9 |     b << [1, 3, 4]
+vlib/v/checker/tests/wrong_shift_left_option_err.vv:9:4: error: unwrapped Option cannot be used in an infix expression
+    7 |     a << []SomeStruct{len: 20}
+    8 |     mut b := ?[]int([2, 8]) // primitive type
+    9 |     b << [1, 3, 4]
+      |       ~~
+   10 |     dump(a?.len)
+   11 |     dump(b)

--- a/vlib/v/checker/tests/wrong_shift_left_option_err.vv
+++ b/vlib/v/checker/tests/wrong_shift_left_option_err.vv
@@ -1,0 +1,12 @@
+pub struct SomeStruct {
+	i int
+}
+
+fn main() {
+	mut a := ?[]SomeStruct([SomeStruct{}, SomeStruct{}]) // struct type
+	a << []SomeStruct{len: 20}
+	mut b := ?[]int([2, 8]) // primitive type
+	b << [1, 3, 4]
+	dump(a?.len)
+	dump(b)
+}


### PR DESCRIPTION
Fix #18449

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 080df8e</samp>

Improved error handling for options and results in infix expressions. Added a new test file `wrong_shift_left_option_err.vv` and its output `wrong_shift_left_option_err.out` to check the error messages.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 080df8e</samp>

* Change error messages for unwrapped options and results in infix expressions to use capitalized type names ([link](https://github.com/vlang/v/pull/18451/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7L460-R460), [link](https://github.com/vlang/v/pull/18451/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7L698-R703), [link](https://github.com/vlang/v/pull/18451/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7L706-R711))
* Add check for unwrapped option in infix expression with missing `or` expression on left operand ([link](https://github.com/vlang/v/pull/18451/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7R474-R478))
* Add test file `wrong_shift_left_option_err.vv` and its output file `wrong_shift_left_option_err.out` to verify the error messages and the new check ([link](https://github.com/vlang/v/pull/18451/files?diff=unified&w=0#diff-cd0ffd198743d4555c97e3da7c1a65e5aeaa3b0abdcdb5de37151660a784baf7R1-R14), [link](https://github.com/vlang/v/pull/18451/files?diff=unified&w=0#diff-9c246196eddb61e3b9899dd43f0d016bf3c86cafa5b4e234f6bd050bae9e9bbeR1-R12))
