### PR TITLE
parser: fix dump removes empty lines

### DIFF
--- a/vlib/v/fmt/tests/empty_lines_expected.vv
+++ b/vlib/v/fmt/tests/empty_lines_expected.vv
@@ -10,6 +10,8 @@ fn squash_multiple_empty_lines() {
 
 	println('b')
 
+	dump('c')
+
 	c := 0
 
 	d := 0

--- a/vlib/v/fmt/tests/empty_lines_input.vv
+++ b/vlib/v/fmt/tests/empty_lines_input.vv
@@ -8,6 +8,8 @@ fn squash_multiple_empty_lines() {
 
 	println('b')
 
+	dump('c')
+
 
 	c := 0
 

--- a/vlib/v/fmt/tests/empty_lines_keep.vv
+++ b/vlib/v/fmt/tests/empty_lines_keep.vv
@@ -33,12 +33,15 @@ fn keep_single_empty_line() {
 
 	println('c')
 
+	dump('d')
+
 	d := 0
 
 	if true {
 		println('e')
 	}
 
+	dump('f')
 	f := 0
 	arr << MyStruct{}
 

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -328,9 +328,11 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				p.next()
 			}
 			p.check(.rpar)
+			mut pos := p.tok.pos()
+			pos.update_last_line(p.prev_tok.line_nr)
 			node = ast.DumpExpr{
 				expr: expr
-				pos: spos.extend(p.tok.pos())
+				pos: spos.extend(pos)
 			}
 		}
 		.key_offsetof {


### PR DESCRIPTION
Currently, all emtpy lines will be removed after a dump expression:
```v
dump('a')

x := 3
```

will become this after formatting
```v
dump('a')
x := 3
```

After the PR, it will behave like e.g. `println`. Preserving one blank line and no blank line, multiple blank lines will be reduced to one blank line.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b527df8</samp>

Fix a bug in `v fmt` that affected `dump` expressions with multiple lines, and add tests for `v fmt` behavior with empty lines.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b527df8</samp>

* Fix a bug in `v fmt` that caused incorrect output for multi-line `dump` expressions ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL331-R335))
  - Use the previous token's position as the `pos` field of the `ast.DumpExpr` node in `parse_dump_expr` ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL331-R335))
  - Update the previous token's last line number to match the current token's line number ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL331-R335))
* Add tests for `v fmt` behavior on empty lines ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-7bbd8dd9e0944fb2f4739eb9f9a90072090be85be034d44f22a91ef44f81c065R13-R14), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-cc48cecc9155ca1927dfa147816cfb6c8d14d4ced5bae31391b6f53735f40279L11-R13), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-80df4e33c5918824be4b8d10dd7dffae7b63e32a12ac76ec67dba048ec1c130bR36-R37), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-80df4e33c5918824be4b8d10dd7dffae7b63e32a12ac76ec67dba048ec1c130bR44))
  - Test that `v fmt` preserves empty lines marked with `// @keep` in `empty_lines_input.vv` and `empty_lines_expected.vv` ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-7bbd8dd9e0944fb2f4739eb9f9a90072090be85be034d44f22a91ef44f81c065R13-R14), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-cc48cecc9155ca1927dfa147816cfb6c8d14d4ced5bae31391b6f53735f40279L11-R13))
  - Test that `v fmt` with the `-keep` flag preserves all empty lines in `empty_lines_keep.vv` ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-80df4e33c5918824be4b8d10dd7dffae7b63e32a12ac76ec67dba048ec1c130bR36-R37), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-80df4e33c5918824be4b8d10dd7dffae7b63e32a12ac76ec67dba048ec1c130bR44))
  - Add calls to `dump` in the test files to check the output of `v fmt` on multi-line `dump` expressions ([link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-7bbd8dd9e0944fb2f4739eb9f9a90072090be85be034d44f22a91ef44f81c065R13-R14), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-cc48cecc9155ca1927dfa147816cfb6c8d14d4ced5bae31391b6f53735f40279L11-R13), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-80df4e33c5918824be4b8d10dd7dffae7b63e32a12ac76ec67dba048ec1c130bR36-R37), [link](https://github.com/vlang/v/pull/18452/files?diff=unified&w=0#diff-80df4e33c5918824be4b8d10dd7dffae7b63e32a12ac76ec67dba048ec1c130bR44))
