### PR TITLE
fmt: fix fn with short arguments (fix #18398)

### DIFF
--- a/examples/pendulum-simulation/modules/sim/anim/app.v
+++ b/examples/pendulum-simulation/modules/sim/anim/app.v
@@ -47,7 +47,8 @@ pub fn new_app(args simargs.ParallelArgs) &App {
 
 fn init(mut app App) {
 	app.iidx = app.gg.new_streaming_image(app.args.grid.width, app.args.grid.height, 4,
-		pixel_format: .rgba8)
+		pixel_format: .rgba8
+	)
 	spawn pixels_worker(mut app)
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1885,7 +1885,7 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 		if arg.is_mut {
 			f.write(arg.share.str() + ' ')
 		}
-		if i > 0 && !f.single_line_if {
+		if i > 0 && !f.single_line_if && !f.use_short_fn_args {
 			f.wrap_long_line(3, true)
 		}
 		f.expr(arg.expr)

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -43,7 +43,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 			if comment.pos.pos >= end_pos {
 				if comment.pos.line_nr == field.pos.line_nr {
 					comment_aligns.add_info(attrs_len, field_types[i].len, comment.pos.line_nr,
-						use_threshold: true)
+						use_threshold: true
+					)
 				}
 				continue
 			}
@@ -54,7 +55,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 		field_aligns.add_info(comments_len + field.name.len, ft.len, field.pos.line_nr)
 		if field.has_default_expr {
 			default_expr_aligns.add_info(attrs_len, field_types[i].len, field.pos.line_nr,
-				use_threshold: true)
+				use_threshold: true
+			)
 		}
 	}
 	f.writeln(' {')

--- a/vlib/v/fmt/tests/fn_with_short_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_short_args_keep.vv
@@ -1,0 +1,22 @@
+struct Config {
+	name string
+	age  int
+}
+
+fn get_info(a int, b string, c Config) string {
+	return b + '-' + c.name + '-${a}'
+}
+
+fn main() {
+	ret1 := get_info(11, 'aaaaabbbbb',
+		name: 'john'
+		age: 11
+	)
+	println(ret1)
+
+	ret2 := get_info(22, 'aaaaabbbbbcccccdddddeeeeefffffggggghhhhhiiiiijjjjjkkkkklllllmmmmm',
+		name: 'bob'
+		age: 22
+	)
+	println(ret2)
+}

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -2049,24 +2049,20 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 										if size >= 8 {
 											for offset in 0 .. size / 8 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: offset * 8
 													typ: ast.i64_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: offset * 8
 													typ: ast.i64_type_idx
 												)
 											}
 											if size % 8 != 0 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: size - 8
 													typ: ast.i64_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: size - 8
 													typ: ast.i64_type_idx
 												)
@@ -2074,11 +2070,9 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 										} else {
 											mut left_size := if size >= 4 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													typ: ast.int_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													typ: ast.int_type_idx
 												)
 												size - 4
@@ -2087,12 +2081,10 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 											}
 											if left_size >= 2 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: size - left_size
 													typ: ast.i16_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: size - left_size
 													typ: ast.i16_type_idx
 												)
@@ -2100,12 +2092,10 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 											}
 											if left_size == 1 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: size - left_size
 													typ: ast.i8_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: size - left_size
 													typ: ast.i8_type_idx
 												)
@@ -2141,24 +2131,20 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 										if size >= 8 {
 											for offset in 0 .. size / 8 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: offset * 8
 													typ: ast.i64_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: offset * 8
 													typ: ast.i64_type_idx
 												)
 											}
 											if size % 8 != 0 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: size - 8
 													typ: ast.i64_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: size - 8
 													typ: ast.i64_type_idx
 												)
@@ -2166,11 +2152,9 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 										} else {
 											mut left_size := if size >= 4 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													typ: ast.int_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													typ: ast.int_type_idx
 												)
 												size - 4
@@ -2179,12 +2163,10 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 											}
 											if left_size >= 2 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: size - left_size
 													typ: ast.i16_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: size - left_size
 													typ: ast.i16_type_idx
 												)
@@ -2192,12 +2174,10 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i int, right ast.Expr, n
 											}
 											if left_size == 1 {
 												c.mov_var_to_reg(Amd64Register.rax, right_var,
-													
 													offset: size - left_size
 													typ: ast.i8_type_idx
 												)
 												c.mov_reg_to_var(var, Amd64Register.rax,
-													
 													offset: size - left_size
 													typ: ast.i8_type_idx
 												)

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -1449,7 +1449,6 @@ fn (mut g Gen) expr(node ast.Expr) {
 							}
 							ast.Enum {
 								g.code_gen.mov_var_to_reg(g.code_gen.main_reg(), node as ast.Ident,
-									
 									typ: ast.int_type_idx
 								)
 							}


### PR DESCRIPTION
This PR fix fn with short arguments (fix #18398).

- Fix fmt of fn with short arguments.
- Add test.

fn_with_short_args_keep.vv
```v
struct Config {
	name string
	age  int
}

fn get_info(a int, b string, c Config) string {
	return b + '-' + c.name + '-${a}'
}

fn main() {
	ret1 := get_info(11, 'aaaaabbbbb',
		name: 'john'
		age: 11
	)
	println(ret1)

	ret2 := get_info(22, 'aaaaabbbbbcccccdddddeeeeefffffggggghhhhhiiiiijjjjjkkkkklllllmmmmm',
		name: 'bob'
		age: 22
	)
	println(ret2)
}
```