### PR TITLE
cgen: fix fn voidptr param calling with nonpointer rvalue (fix #18424)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2204,7 +2204,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					if atype.has_flag(.generic) {
 						atype = g.unwrap_generic(atype)
 					}
-					if atype.has_flag(.generic) {
+					if atype.has_flag(.generic) || atype == ast.voidptr_type {
 						g.write('(voidptr)&/*qq*/')
 					} else {
 						needs_closing = true

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2204,7 +2204,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					if atype.has_flag(.generic) {
 						atype = g.unwrap_generic(atype)
 					}
-					if atype.has_flag(.generic) || atype == ast.voidptr_type {
+					if atype.has_flag(.generic) || arg.expr is ast.StructInit {
 						g.write('(voidptr)&/*qq*/')
 					} else {
 						needs_closing = true

--- a/vlib/v/tests/fn_voidptr_param_call_with_nonpointer_rvalue_test.v
+++ b/vlib/v/tests/fn_voidptr_param_call_with_nonpointer_rvalue_test.v
@@ -1,0 +1,23 @@
+import eventbus
+
+struct MyMessage {
+	msg string
+}
+
+fn test_fn_call_with_nonpointer_rvalue() {
+	eb := eventbus.new()
+	mut subscriber := eb.subscriber
+
+	subscriber.subscribe('my_publish', subscriber_method)
+
+	do_something(eb)
+	assert true
+}
+
+fn subscriber_method(receiver voidptr, ev &MyMessage, sender voidptr) {
+	println(ev)
+}
+
+fn do_something(eb &eventbus.EventBus) {
+	eb.publish('my_publish', eb, MyMessage{ msg: 'this is my message' })
+}


### PR DESCRIPTION
This PR fix fn voidptr param calling with nonpointer rvalue (fix #18424).

- Fix fn voidptr param calling with nonpointer rvalue.
- Add test.

```v
import eventbus

struct MyMessage {
	msg string
}

fn main() {
	eb := eventbus.new()
	mut subscriber := eb.subscriber

	subscriber.subscribe('my_publish', subscriber_method)

	do_something(eb)
	assert true
}

fn subscriber_method(receiver voidptr, ev &MyMessage, sender voidptr) {
	dump(ev)
}

fn do_something(eb &eventbus.EventBus) {
	eb.publish('my_publish', eb, MyMessage{ msg: 'this is my message' })
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:18] ev: &MyMessage{
    msg: 'this is my message'
}
```