### PR TITLE
all: clean up with is_any_kind_of_pointer()

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2400,8 +2400,7 @@ pub fn (expr Expr) is_literal() bool {
 			return expr.expr.is_literal()
 		}
 		CastExpr {
-			return !expr.has_arg && expr.expr.is_literal()
-				&& (expr.typ.is_ptr() || expr.typ.is_pointer()
+			return !expr.has_arg && expr.expr.is_literal() && (expr.typ.is_any_kind_of_pointer()
 				|| expr.typ in [i8_type, i16_type, int_type, i64_type, u8_type, u16_type, u32_type, u64_type, f32_type, f64_type, char_type, bool_type, rune_type])
 		}
 		SizeOf, IsRefType {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -507,13 +507,12 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.error('cannot copy map: call `move` or `clone` method (or use a reference)',
 				right.pos())
 		}
-		left_is_ptr := left_type.is_ptr() || left_sym.is_pointer()
-		if left_is_ptr && !left.is_auto_deref_var() {
+		if left_type.is_any_kind_of_pointer() && !left.is_auto_deref_var() {
 			if !c.inside_unsafe && node.op !in [.assign, .decl_assign] {
 				// ptr op=
 				c.warn('pointer arithmetic is only allowed in `unsafe` blocks', node.pos)
 			}
-			right_is_ptr := right_type.is_ptr() || right_sym.is_pointer()
+			right_is_ptr := right_type.is_any_kind_of_pointer()
 			if !right_is_ptr && node.op == .assign && right_type_unwrapped.is_number() {
 				c.error('cannot assign to `${left}`: ' +
 					c.expected_msg(right_type_unwrapped, left_type_unwrapped), right.pos())
@@ -701,7 +700,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		}
 		if left_sym.kind == .interface_ {
 			if c.type_implements(right_type, left_type, right.pos()) {
-				if !right_type.is_ptr() && !right_type.is_pointer() && right_sym.kind != .interface_
+				if !right_type.is_any_kind_of_pointer() && right_sym.kind != .interface_
 					&& !c.inside_unsafe {
 					c.mark_as_referenced(mut &node.right[i], true)
 				}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -126,7 +126,7 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	if exp_idx == ast.voidptr_type_idx || exp_idx == ast.nil_type_idx
 		|| exp_idx == ast.byteptr_type_idx
 		|| (expected.is_ptr() && expected.deref().idx() == ast.u8_type_idx) {
-		if got.is_ptr() || got.is_pointer() {
+		if got.is_any_kind_of_pointer() {
 			return true
 		}
 	}
@@ -140,7 +140,7 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 	if got_idx == ast.voidptr_type_idx || got_idx == ast.nil_type_idx
 		|| got_idx == ast.byteptr_type_idx
 		|| (got_idx == ast.u8_type_idx && got.is_ptr()) {
-		if expected.is_ptr() || expected.is_pointer() {
+		if expected.is_any_kind_of_pointer() {
 			return true
 		}
 	}
@@ -375,7 +375,7 @@ fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 		}
 	}
 	if !unalias_got.is_ptr() && got_sym.kind == .array_fixed
-		&& (unalias_expected.is_pointer() || unalias_expected.is_ptr()) {
+		&& unalias_expected.is_any_kind_of_pointer() {
 		// fixed array needs to be a struct, not a pointer
 		return false
 	}
@@ -440,8 +440,8 @@ fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSymbol,
 		exp_arg := exp_fn.params[i]
 		exp_arg_typ := c.unwrap_generic(exp_arg.typ)
 		got_arg_typ := c.unwrap_generic(got_arg.typ)
-		exp_arg_is_ptr := exp_arg_typ.is_ptr() || exp_arg_typ.is_pointer()
-		got_arg_is_ptr := got_arg_typ.is_ptr() || got_arg_typ.is_pointer()
+		exp_arg_is_ptr := exp_arg_typ.is_any_kind_of_pointer()
+		got_arg_is_ptr := got_arg_typ.is_any_kind_of_pointer()
 		if exp_arg.is_mut && !got_arg.is_mut {
 			return false
 		}
@@ -671,13 +671,13 @@ fn (c &Checker) expected_msg(got ast.Type, expected ast.Type) string {
 fn (mut c Checker) symmetric_check(left ast.Type, right ast.Type) bool {
 	// allow direct int-literal assignment for pointers for now
 	// maybe in the future options should be used for that
-	if right.is_ptr() || right.is_pointer() {
+	if right.is_any_kind_of_pointer() {
 		if left == ast.int_literal_type {
 			return true
 		}
 	}
 	// allow direct int-literal assignment for pointers for now
-	if left.is_ptr() || left.is_pointer() {
+	if left.is_any_kind_of_pointer() {
 		if right == ast.int_literal_type {
 			return true
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2920,15 +2920,15 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			// TODO make this an error
 			c.warn('cannot cast voidptr to a struct outside `unsafe`', node.pos)
 		}
-		if !from_type.is_int() && final_from_sym.kind != .enum_ && !from_type.is_pointer()
-			&& !from_type.is_ptr() {
+		if !from_type.is_int() && final_from_sym.kind != .enum_
+			&& !from_type.is_any_kind_of_pointer() {
 			ft := c.table.type_to_str(from_type)
 			tt := c.table.type_to_str(to_type)
 			c.error('cannot cast `${ft}` to `${tt}`', node.pos)
 		}
 	} else if to_sym.kind == .interface_ {
 		if c.type_implements(from_type, to_type, node.pos) {
-			if !from_type.is_ptr() && !from_type.is_pointer() && from_sym.kind != .interface_
+			if !from_type.is_any_kind_of_pointer() && from_sym.kind != .interface_
 				&& !c.inside_unsafe {
 				c.mark_as_referenced(mut &node.expr, true)
 			}
@@ -2958,8 +2958,8 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			type_name := c.table.type_to_str(to_type)
 			c.error('cannot cast struct `${from_type_name}` to `${type_name}`', node.pos)
 		}
-	} else if to_sym.kind == .u8 && !final_from_sym.is_number() && !final_from_sym.is_pointer()
-		&& !from_type.is_ptr() && final_from_sym.kind !in [.char, .enum_, .bool] {
+	} else if to_sym.kind == .u8 && !final_from_sym.is_number()
+		&& !from_type.is_any_kind_of_pointer() && final_from_sym.kind !in [.char, .enum_, .bool] {
 		ft := c.table.type_to_str(from_type)
 		tt := c.table.type_to_str(to_type)
 		c.error('cannot cast type `${ft}` to `${tt}`', node.pos)

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -164,7 +164,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 					c.expected_type = elem_type
 					c.type_implements(typ, elem_type, expr.pos())
 				}
-				if !typ.is_ptr() && !typ.is_pointer() && !c.inside_unsafe {
+				if !typ.is_any_kind_of_pointer() && !c.inside_unsafe {
 					typ_sym := c.table.sym(typ)
 					if typ_sym.kind != .interface_ {
 						c.mark_as_referenced(mut &expr, true)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1153,7 +1153,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		// Handle expected interface
 		if final_param_sym.kind == .interface_ {
 			if c.type_implements(arg_typ, final_param_typ, call_arg.expr.pos()) {
-				if !arg_typ.is_ptr() && !arg_typ.is_pointer() && !c.inside_unsafe
+				if !arg_typ.is_any_kind_of_pointer() && !c.inside_unsafe
 					&& arg_typ_sym.kind != .interface_ {
 					c.mark_as_referenced(mut &call_arg.expr, true)
 				}
@@ -1306,7 +1306,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 					unwrap_sym := c.table.sym(unwrap_typ)
 					if unwrap_sym.kind == .interface_ {
 						if c.type_implements(utyp, unwrap_typ, call_arg.expr.pos()) {
-							if !utyp.is_ptr() && !utyp.is_pointer() && !c.inside_unsafe
+							if !utyp.is_any_kind_of_pointer() && !c.inside_unsafe
 								&& c.table.sym(utyp).kind != .interface_ {
 								c.mark_as_referenced(mut &call_arg.expr, true)
 							}
@@ -2030,7 +2030,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		// Handle expected interface
 		if final_arg_sym.kind == .interface_ {
 			if c.type_implements(got_arg_typ, final_arg_typ, arg.expr.pos()) {
-				if !got_arg_typ.is_ptr() && !got_arg_typ.is_pointer() && !c.inside_unsafe {
+				if !got_arg_typ.is_any_kind_of_pointer() && !c.inside_unsafe {
 					got_arg_typ_sym := c.table.sym(got_arg_typ)
 					if got_arg_typ_sym.kind != .interface_ {
 						c.mark_as_referenced(mut &arg.expr, true)

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -485,7 +485,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					if right_final_sym.kind != .array {
 						// []Animal << Cat
 						if c.type_implements(right_type, left_value_type, right_pos) {
-							if !right_type.is_ptr() && !right_type.is_pointer() && !c.inside_unsafe
+							if !right_type.is_any_kind_of_pointer() && !c.inside_unsafe
 								&& right_sym.kind != .interface_ {
 								c.mark_as_referenced(mut &node.right, true)
 							}

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -290,7 +290,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				// c.type_implements(expr_type, c.expected_type, expr.pos())
 				expr_pos := expr.pos()
 				if c.type_implements(expr_type, c.expected_type, expr_pos) {
-					if !expr_type.is_ptr() && !expr_type.is_pointer() && !c.inside_unsafe {
+					if !expr_type.is_any_kind_of_pointer() && !c.inside_unsafe {
 						if expr_type_sym.kind != .interface_ {
 							c.mark_as_referenced(mut &branch.exprs[k], true)
 						}

--- a/vlib/v/checker/postfix.v
+++ b/vlib/v/checker/postfix.v
@@ -5,7 +5,7 @@ import v.ast
 fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	typ := c.unwrap_generic(c.expr(node.expr))
 	typ_sym := c.table.sym(typ)
-	is_non_void_pointer := (typ.is_ptr() || typ.is_pointer()) && typ_sym.kind != .voidptr
+	is_non_void_pointer := typ.is_any_kind_of_pointer() && typ_sym.kind != .voidptr
 
 	if node.op in [.inc, .dec] && !node.expr.is_lvalue() {
 		op_kind, bin_op_alt := if node.op == .inc {

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -195,8 +195,8 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 			} else {
 				if exp_type_sym.kind == .interface_ {
 					if c.type_implements(got_type, exp_type, node.pos) {
-						if !got_type.is_ptr() && !got_type.is_pointer()
-							&& got_type_sym.kind != .interface_ && !c.inside_unsafe {
+						if !got_type.is_any_kind_of_pointer() && got_type_sym.kind != .interface_
+							&& !c.inside_unsafe {
 							c.mark_as_referenced(mut &node.exprs[expr_idxs[i]], true)
 						}
 					}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6824,7 +6824,7 @@ pub fn (mut g Gen) get_array_depth(el_typ ast.Type) int {
 // returns true if `t` includes any pointer(s) - during garbage collection heap regions
 // that contain no pointers do not have to be scanned
 pub fn (mut g Gen) contains_ptr(el_typ ast.Type) bool {
-	if el_typ.is_ptr() || el_typ.is_pointer() {
+	if el_typ.is_any_kind_of_pointer() {
 		return true
 	}
 	typ := g.unwrap_generic(el_typ)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2132,7 +2132,7 @@ fn (mut g Gen) keep_alive_call_pregen(node ast.CallExpr) int {
 fn (mut g Gen) keep_alive_call_postgen(node ast.CallExpr, tmp_cnt_save int) {
 	g.writeln('// keep_alive_call_postgen()')
 	for i, expected_type in node.expected_arg_types {
-		if expected_type.is_ptr() || expected_type.is_pointer() {
+		if expected_type.is_any_kind_of_pointer() {
 			g.writeln('GC_reachable_here(__tmp_arg_${tmp_cnt_save + i});')
 		}
 	}

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -549,8 +549,8 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 		} else {
 			if sfield.typ != ast.voidptr_type && sfield.typ != ast.nil_type
 				&& (sfield.expected_type.is_ptr() && !sfield.expected_type.has_flag(.shared_f))
-				&& !sfield.expected_type.has_flag(.option) && !(sfield.typ.is_ptr()
-				|| sfield.typ.is_pointer()) && !sfield.typ.is_number() {
+				&& !sfield.expected_type.has_flag(.option) && !sfield.typ.is_any_kind_of_pointer()
+				&& !sfield.typ.is_number() {
 				g.write('/* autoref */&')
 			}
 

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1138,7 +1138,7 @@ fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Pos) {
 		.sum_type] {
 		return
 	}
-	if typ.is_ptr() || typ.is_pointer() {
+	if typ.is_any_kind_of_pointer() {
 		return
 	}
 	if sym.kind == .alias {


### PR DESCRIPTION
This PR clean up with is_any_kind_of_pointer().

- Change `typ.is_ptr() || typ.is_pointer()` to `typ.is_any_kind_of_pointer()`.