### PR TITLE
parser: disallow `for i++; i < 10; i++ {`

### DIFF
--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -91,6 +91,9 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.close_scope()
 		return for_c_stmt
+	} else if p.tok.kind == .name
+		&& p.peek_tok.kind in [.inc, .dec, .plus_assign, .minus_assign, .mult_assign, .div_assign, .xor_assign, .mod_assign, .or_assign, .and_assign, .right_shift_assign, .left_shift_assign, .unsigned_right_shift_assign] {
+		return p.error('cannot use ${p.tok.lit}${p.peek_tok.kind} as initial value')
 	} else if p.peek_tok.kind in [.key_in, .comma]
 		|| (p.tok.kind == .key_mut && p.peek_token(2).kind in [.key_in, .comma]) {
 		// `for i in vals`, `for i in start .. end`, `for mut user in users`, `for i, mut user in users`

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -92,7 +92,8 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		p.close_scope()
 		return for_c_stmt
 	} else if p.tok.kind == .name
-		&& p.peek_tok.kind in [.inc, .dec, .plus_assign, .minus_assign, .mult_assign, .div_assign, .xor_assign, .mod_assign, .or_assign, .and_assign, .right_shift_assign, .left_shift_assign, .unsigned_right_shift_assign] {
+		&& p.peek_tok.kind in [.inc, .dec, .plus_assign, .minus_assign, .mult_assign, .div_assign, .xor_assign, .mod_assign, .or_assign, .and_assign, .right_shift_assign, .left_shift_assign, .unsigned_right_shift_assign]
+		&& !p.pref.translated {
 		return p.error('cannot use ${p.tok.lit}${p.peek_tok.kind} as initial value')
 	} else if p.peek_tok.kind in [.key_in, .comma]
 		|| (p.tok.kind == .key_mut && p.peek_token(2).kind in [.key_in, .comma]) {

--- a/vlib/v/parser/tests/for_loop_update_stmt_first_err.out
+++ b/vlib/v/parser/tests/for_loop_update_stmt_first_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/for_loop_update_stmt_first_err.vv:3:6: error: cannot use i++ as initial value
+    1 | fn main() {
+    2 |     i := 0
+    3 |     for i++; i < 10; i++ {
+      |         ^
+    4 |         println(i)
+    5 |     }

--- a/vlib/v/parser/tests/for_loop_update_stmt_first_err.vv
+++ b/vlib/v/parser/tests/for_loop_update_stmt_first_err.vv
@@ -1,0 +1,6 @@
+fn main() {
+	i := 0
+	for i++; i < 10; i++ {
+		println(i)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/18445
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8bef57</samp>

Add a new parser error for for loops that use an update statement as the initial value. Add test files for the new error case in `vlib/v/parser/tests`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8bef57</samp>

*  Add a new error case to the parser for for loops with update statements as initial values ([link](https://github.com/vlang/v/pull/18470/files?diff=unified&w=0#diff-1854c9c7273a9b6912efd8f44c2c0990203a79849b5e637ebdc4659fb50bd6a3R94-R96))
*  Add a new test file to the parser tests for the new error case ([link](https://github.com/vlang/v/pull/18470/files?diff=unified&w=0#diff-0511b224cb4a5ef9d71905156b8bafa118311163853b7d1dac582444cb8afefaR1-R7), [link](https://github.com/vlang/v/pull/18470/files?diff=unified&w=0#diff-fe18b73ec64081597507f20935eec5fce13645bbc1829d7d0b78bbf43e8e8ccfR1-R6))
