### PR TITLE
checker: fix error assigning generic function variable with generic struct return, break out of execution halt from invalid generic fn variables

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -514,7 +514,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					right.pos())
 			} else if (!right_sym.info.is_anon && return_sym.kind == .any)
 				|| (return_sym.info is ast.Struct && (return_sym.info as ast.Struct).is_generic) {
-				panic('cannot assign `${right}` as a generic function variable')
+				c.error('cannot assign `${right}` as a generic function variable', right.pos())
 			}
 		}
 		if left_type.is_any_kind_of_pointer() && !left.is_auto_deref_var() {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -507,6 +507,15 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.error('cannot copy map: call `move` or `clone` method (or use a reference)',
 				right.pos())
 		}
+		if left_sym.kind == .function && right_sym.info is ast.FnType {
+			return_sym := c.table.sym(right_sym.info.func.return_type)
+			if return_sym.kind == .placeholder {
+				c.error('cannot assign function `${right_sym.name}` to variable', right.pos())
+			} else if (!right_sym.info.is_anon && return_sym.kind == .any)
+				|| (return_sym.info is ast.Struct && (return_sym.info as ast.Struct).is_generic) {
+				panic('cannot assign function `${right_sym.name}` with generic return type `${return_sym.name}` to a variable')
+			}
+		}
 		if left_type.is_any_kind_of_pointer() && !left.is_auto_deref_var() {
 			if !c.inside_unsafe && node.op !in [.assign, .decl_assign] {
 				// ptr op=

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -510,10 +510,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left_sym.kind == .function && right_sym.info is ast.FnType {
 			return_sym := c.table.sym(right_sym.info.func.return_type)
 			if return_sym.kind == .placeholder {
-				c.error('cannot assign function `${right_sym.name}` to variable', right.pos())
+				c.error('unkown return type: cannot assign `${right}` as a function variable',
+					right.pos())
 			} else if (!right_sym.info.is_anon && return_sym.kind == .any)
 				|| (return_sym.info is ast.Struct && (return_sym.info as ast.Struct).is_generic) {
-				panic('cannot assign function `${right_sym.name}` with generic return type `${return_sym.name}` to a variable')
+				panic('cannot assign `${right}` as a generic function variable')
 			}
 		}
 		if left_type.is_any_kind_of_pointer() && !left.is_auto_deref_var() {

--- a/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
+++ b/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
@@ -5,6 +5,13 @@ vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:2: warning: unused 
       |     ~~~
     7 |     // ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
     8 | }
+vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:9: error: cannot assign `f1` as a generic function variable
+    4 | 
+    5 | fn main() {
+    6 |     ff1 := f1 // <-- missing e.g. `[int]`
+      |            ~~
+    7 |     // ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
+    8 | }
 vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:1:1: error: generic function visited more than 10000 times
     1 | fn f1[T](x T, i int) T {
       | ~~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
+++ b/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
@@ -5,3 +5,10 @@ Did you mean `[2]fn (u32) UnknownThing`?
       |                         ~~~~~~~~~~~~
     3 | }
     4 |
+vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv:6:18: error: cannot assign function `fn (u32) UnknownThing` to variable
+    4 | 
+    5 | fn (virt Virt) caller() {
+    6 |     func := virt.fns[0]
+      |                     ~~~
+    7 |     func(5)
+    8 | }

--- a/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
+++ b/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
@@ -5,7 +5,7 @@ Did you mean `[2]fn (u32) UnknownThing`?
       |                         ~~~~~~~~~~~~
     3 | }
     4 |
-vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv:6:18: error: cannot assign function `fn (u32) UnknownThing` to variable
+vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv:6:18: error: unkown return type: cannot assign `virt.fns[0]` as a function variable
     4 | 
     5 | fn (virt Virt) caller() {
     6 |     func := virt.fns[0]


### PR DESCRIPTION
Closes #18469 

This PR deals with two problems. 

1. The code in the related issue declares a generic struct as return type of a generic function. Instead of resulting in a C error when assigning it to a function variable it will now throw:

   ```
   return.v:12:9: error: unkown return type: cannot assign `new_arr` as a function variable
      10 | 
      11 | fn main() {
      12 |     arr := new_arr[int]
         |            ~~~~~~~
      13 |     println('Hello')
      14 | }
   ```

2. ~~All execution being halted when assigning a generic function variable without type specifications.~~ 
   Resolved in: #18477

   ```v
   fn f1[T](x T, i int) T {
   	return x
   }
   
   fn main() {
   	ff1 := f1 // <-- missing e.g. `[int]`
   	// ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
   }
   ```


   ~~I couldn't find a way to even call `c.error`, it's just not getting executed. Therefore `panic` is used, since it felt like better error handling than manually needing to break out of a program that stopped execution and might hang for indefinite since it might not be noticed in some scenarios.~~

<br>

~~Tests were not added yet.~~ The reason why the error in the related issue is triggered, is that the return type of a genric-struct-return remains unknown when it is used like that. Extending support for this might be something for a separate issue - that's what someone with more extensive knowledge of V's generic type system and road-plan would need to tell me. ~~I'd also like to know what you think about relying on a `panic` call. There are some places it is used in the checker code. But I'm not quite sure it's the best fit here. Maybe it's a good enough solution until something better comes up.~~

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20b77a4</samp>

Prevent assigning anonymous functions to variables or fields in `vlib/v/checker/assign.v`. This fixes some function-related bugs and improves type safety.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 20b77a4</samp>

*  Prevent assigning anonymous functions to variables or fields ([link](https://github.com/vlang/v/pull/18472/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR225-R230))
