### PR TITLE
cgen: fix alias eq method + map init with option

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -230,7 +230,7 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 	mut fn_builder := strings.new_builder(512)
 	fn_builder.writeln('static bool ${ptr_styp}_alias_eq(${ptr_styp} a, ${ptr_styp} b) {')
 
-	is_option := info.parent_type.has_flag(.option) || left.typ.has_flag(.option)
+	is_option := left.typ.has_flag(.option)
 
 	left_var := if is_option { '*' + g.read_opt(info.parent_type, 'a') } else { 'a' }
 	right_var := if is_option { '*' + g.read_opt(info.parent_type, 'b') } else { 'b' }

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -232,12 +232,14 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 
 	is_option := left.typ.has_flag(.option)
 
-	left_var := if is_option { '*' + g.read_opt(info.parent_type, 'a') } else { 'a' }
-	right_var := if is_option { '*' + g.read_opt(info.parent_type, 'b') } else { 'b' }
+	mut left_var := if is_option { '*' + g.read_opt(info.parent_type, 'a') } else { 'a' }
+	mut right_var := if is_option { '*' + g.read_opt(info.parent_type, 'b') } else { 'b' }
 
 	sym := g.table.sym(info.parent_type)
 	if sym.kind == .string {
-		if is_option {
+		if info.parent_type.has_flag(.option) {
+			left_var = '*' + g.read_opt(info.parent_type, 'a')
+			right_var = '*' + g.read_opt(info.parent_type, 'b')
 			fn_builder.writeln('\treturn ((${left_var}).len == (${right_var}).len && (${left_var}).len == 0) || string__eq(${left_var}, ${right_var});')
 		} else {
 			fn_builder.writeln('\treturn string__eq(a, b);')

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -464,7 +464,11 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 			fn_builder.writeln('\t\tif (*(voidptr*)map_get(&b, k, &(voidptr[]){ 0 }) != v) {')
 		}
 		else {
-			fn_builder.writeln('\t\tif (*(${ptr_value_styp}*)map_get(&b, k, &(${ptr_value_styp}[]){ 0 }) != v) {')
+			if value.typ.has_flag(.option) {
+				fn_builder.writeln('\t\tif (memcmp(v.data, ((${ptr_value_styp}*)map_get(&b, k, &(${ptr_value_styp}[]){ 0 }))->data, sizeof(${g.base_type(value.typ)})) != 0) {')
+			} else {
+				fn_builder.writeln('\t\tif (*(${ptr_value_styp}*)map_get(&b, k, &(${ptr_value_styp}[]){ 0 }) != v) {')
+			}
 		}
 	}
 	fn_builder.writeln('\t\t\treturn false;')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3923,7 +3923,7 @@ fn (mut g Gen) unlock_locks() {
 
 fn (mut g Gen) map_init(node ast.MapInit) {
 	unwrap_key_typ := g.unwrap_generic(node.key_type)
-	unwrap_val_typ := g.unwrap_generic(node.value_type).clear_flags(.option, .result)
+	unwrap_val_typ := g.unwrap_generic(node.value_type).clear_flags(.result)
 	key_typ_str := g.typ(unwrap_key_typ)
 	value_typ_str := g.typ(unwrap_val_typ)
 	value_sym := g.table.sym(unwrap_val_typ)

--- a/vlib/v/tests/option_alias_eq_test.v
+++ b/vlib/v/tests/option_alias_eq_test.v
@@ -10,9 +10,9 @@ fn empty() map[string]MyOpt {
 
 fn test_empty() {
 	expected := {
-		'key': MyOpt(none)
+		'key': ?MyOpt(none)
 	}
 	assert dump(expected) == {
-		'key': MyOpt(none)
+		'key': ?MyOpt(none)
 	}
 }

--- a/vlib/v/tests/option_alias_eq_test.v
+++ b/vlib/v/tests/option_alias_eq_test.v
@@ -1,0 +1,18 @@
+struct MyStruct {
+	field int
+}
+
+pub type MyOpt = ?MyStruct
+
+fn empty() map[string]MyOpt {
+	return {}
+}
+
+fn test_empty() {
+	expected := {
+		'key': MyOpt(none)
+	}
+	assert dump(expected) == {
+		'key': MyOpt(none)
+	}
+}


### PR DESCRIPTION
Fix #18475

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83cf1c0</samp>

Fix a bug in auto-generated equality methods for alias options and add a test case. The bug caused a segmentation fault when comparing empty maps of alias options in `vlib/v/gen/c/auto_eq_methods.v`. The test case is in `vlib/v/tests/option_alias_eq_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83cf1c0</samp>

* Fix bug in auto-generated equality methods for alias options ([link](https://github.com/vlang/v/pull/18483/files?diff=unified&w=0#diff-52d15de15ee5e3cdb07ec151f66074a96f12360be904b00f50f2f2aba6548640L233-R233))
* Add test case for alias option equality bug ([link](https://github.com/vlang/v/pull/18483/files?diff=unified&w=0#diff-73e1f5023dfe5f8af2eb1d449c47a7dbb03c75b325352c4300cad6f32169a33dR1-R18))
