### PR TITLE
checker: add hint to sumtype cannot hold reference types error

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -567,7 +567,9 @@ fn (mut c Checker) sum_type_decl(node ast.SumTypeDecl) {
 	mut names_used := []string{}
 	for variant in node.variants {
 		if variant.typ.is_ptr() {
-			c.error('sum type cannot hold a reference type', variant.pos)
+			c.error('sum type cannot hold a reference type,
+use non-references types and a reference to the sum type instead `&${node.name}`',
+				variant.pos)
 		}
 		c.ensure_type_exists(variant.typ, variant.pos) or {}
 		sym := c.table.sym(variant.typ)

--- a/vlib/v/checker/tests/sum_type_ref_variant_err.out
+++ b/vlib/v/checker/tests/sum_type_ref_variant_err.out
@@ -1,17 +1,20 @@
-vlib/v/checker/tests/sum_type_ref_variant_err.vv:7:33: error: sum type cannot hold a reference type
+vlib/v/checker/tests/sum_type_ref_variant_err.vv:7:33: error: sum type cannot hold a reference type,
+use non-references types and a reference to the sum type instead `&Alphabet1`
     5 |     foo string
     6 | }
     7 | type Alphabet1 = Abc | string | &Xyz
       |                                 ~~~~
     8 | type Alphabet2 = Abc | &Xyz | string
     9 | type Alphabet3 = &Xyz | Abc | string
-vlib/v/checker/tests/sum_type_ref_variant_err.vv:8:24: error: sum type cannot hold a reference type
+vlib/v/checker/tests/sum_type_ref_variant_err.vv:8:24: error: sum type cannot hold a reference type,
+use non-references types and a reference to the sum type instead `&Alphabet2`
     6 | }
     7 | type Alphabet1 = Abc | string | &Xyz
     8 | type Alphabet2 = Abc | &Xyz | string
       |                        ~~~~
     9 | type Alphabet3 = &Xyz | Abc | string
-vlib/v/checker/tests/sum_type_ref_variant_err.vv:9:18: error: sum type cannot hold a reference type
+vlib/v/checker/tests/sum_type_ref_variant_err.vv:9:18: error: sum type cannot hold a reference type,
+use non-references types and a reference to the sum type instead `&Alphabet3`
     7 | type Alphabet1 = Abc | string | &Xyz
     8 | type Alphabet2 = Abc | &Xyz | string
     9 | type Alphabet3 = &Xyz | Abc | string


### PR DESCRIPTION
I thought adding a hint - similar to as it is used in some other errors - might also fit here. This would make the compiler a better friend when the brain is not at full capacity or someone is learning these things.

copilot:summary

copilot:walkthrough
