### PR TITLE
cgen: fix alias to option handling

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2857,6 +2857,12 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 
 	if to_sym.language != .c {
 		c.ensure_type_exists(to_type, node.pos) or {}
+
+		if to_sym.kind == .alias && (to_sym.info as ast.Alias).parent_type.has_flag(.option)
+			&& !to_type.has_flag(.option) {
+			c.error('alias to Option type requires to be used as Option type (?${to_sym.name}(...))',
+				node.pos)
+		}
 	}
 	if from_sym.kind == .u8 && from_type.is_ptr() && to_sym.kind == .string && !to_type.is_ptr() {
 		c.error('to convert a C string buffer pointer to a V string, use x.vstring() instead of string(x)',

--- a/vlib/v/checker/tests/alias_to_option_err.out
+++ b/vlib/v/checker/tests/alias_to_option_err.out
@@ -1,0 +1,42 @@
+vlib/v/checker/tests/alias_to_option_err.vv:11:7: error: alias to Option type requires to be used as Option type (?TestInt(...))
+    9 | 
+   10 | fn main() {
+   11 |     f := TestInt(1)
+      |          ~~~~~~~~~~
+   12 |     dump(f)
+   13 |     println(f)
+vlib/v/checker/tests/alias_to_option_err.vv:15:7: error: alias to Option type requires to be used as Option type (?TestString(...))
+   13 |     println(f)
+   14 | 
+   15 |     g := TestString('foo')
+      |          ~~~~~~~~~~~~~~~~~
+   16 |     dump(g)
+   17 |     println(g)
+vlib/v/checker/tests/alias_to_option_err.vv:19:7: error: alias to Option type requires to be used as Option type (?TestString(...))
+   17 |     println(g)
+   18 | 
+   19 |     h := TestString(none)
+      |          ~~~~~~~~~~~~~~~~
+   20 |     dump(h)
+   21 |
+vlib/v/checker/tests/alias_to_option_err.vv:22:7: error: alias to Option type requires to be used as Option type (?TestF64(...))
+   20 |     dump(h)
+   21 | 
+   22 |     i := TestF64(none)
+      |          ~~~~~~~~~~~~~
+   23 |     dump(i)
+   24 |
+vlib/v/checker/tests/alias_to_option_err.vv:25:7: error: alias to Option type requires to be used as Option type (?TestStruct(...))
+   23 |     dump(i)
+   24 | 
+   25 |     l := TestStruct(none)
+      |          ~~~~~~~~~~~~~~~~
+   26 |     dump(l)
+   27 |
+vlib/v/checker/tests/alias_to_option_err.vv:28:7: error: alias to Option type requires to be used as Option type (?TestStruct(...))
+   26 |     dump(l)
+   27 | 
+   28 |     k := TestStruct(Struct{})
+      |          ~~~~~~~~~~~~~~~~~~~~
+   29 |     dump(k)
+   30 | }

--- a/vlib/v/checker/tests/alias_to_option_err.vv
+++ b/vlib/v/checker/tests/alias_to_option_err.vv
@@ -1,0 +1,30 @@
+type TestInt = ?int
+type TestString = ?string
+type TestF64 = ?f64
+
+struct Struct {
+}
+
+type TestStruct = ?Struct
+
+fn main() {
+	f := TestInt(1)
+	dump(f)
+	println(f)
+
+	g := TestString('foo')
+	dump(g)
+	println(g)
+
+	h := TestString(none)
+	dump(h)
+
+	i := TestF64(none)
+	dump(i)
+
+	l := TestStruct(none)
+	dump(l)
+
+	k := TestStruct(Struct{})
+	dump(k)
+}


### PR DESCRIPTION
```V
type TestInt = ?int
type TestString = ?string
type TestF64 = ?f64

struct Struct {

}

type TestStruct = ?Struct

fn main() {
	a := ?string('foo')
	dump(a)
	println(a?)

	b := ?TestInt(1)
	dump(b)
	println(b)

	c := ?TestString('foo')
	dump(c)
	println(c?)

	d := ?TestF64(1.2)
	dump(d)
	println(d)

	e := ?TestInt(none)
	dump(e)

	m := ?TestStruct(Struct{})
	dump(m)
}
```

This PR also blocks alias to option without `?` prefix:

```
vlib/v/checker/tests/alias_to_option_err.vv:11:7: error: alias to Option type requires to be used as Option type (?TestInt(...))
    9 | 
   10 | fn main() {
   11 |     f := TestInt(1)
      |          ~~~~~~~~~~
```  

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a711cdc</samp>

This pull request enhances the support and error checking for aliases to Option types in the V compiler. It improves the code generation and adds a new check in the `checker` module to prevent invalid uses of aliases to Option types. It also adds a new test file to verify the compiler output.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a711cdc</samp>

*  Add error check for aliases to Option types in checker module ([link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R2860-R2865))
*  Add test file for checker module to verify error messages for aliases to Option types ([link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-431ee1034e71e61db109d8bbfe49236da4db12e2533357bab7c2610e1a3b0e8fR1-R42), [link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-d78796924d2b3740bed8f3d994336b5975335559c3ab7f0b029be726c5d34e0fR1-R30))
*  Modify code generation module to handle aliases to Option types correctly in different contexts ([link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4248-R4261), [link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4401-R4415), [link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4407-R4445))
   *  Add extra dereference and cast for accessing data of Option type ([link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4248-R4261))
   *  Avoid redundant and incorrect casting for Option type ([link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4401-R4415))
   *  Generate temporary variables and call `_option_ok` or `expr_with_opt` functions for checking and wrapping Option type ([link](https://github.com/vlang/v/pull/18490/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4407-R4445))
