### PR TITLE
stbi: remove defaulting to 4 channels

### DIFF
--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -110,8 +110,15 @@ fn C.stbi_load(filename &char, x &int, y &int, channels_in_file &int, desired_ch
 fn C.stbi_load_from_file(f voidptr, x &int, y &int, channels_in_file &int, desired_channels int) &u8
 fn C.stbi_load_from_memory(buffer &u8, len int, x &int, y &int, channels_in_file &int, desired_channels int) &u8
 
+[params]
+pub struct LoadParams {
+	// the number of channels you expect the image to have.
+	// If set to 0 stbi will figure out the correct number of channels
+	desired_channels int = C.STBI_rgb_alpha
+}
+
 // load load an image from a path
-pub fn load(path string) !Image {
+pub fn load(path string, params LoadParams) !Image {
 	ext := path.all_after_last('.')
 	mut res := Image{
 		ok: true
@@ -119,7 +126,7 @@ pub fn load(path string) !Image {
 		data: 0
 	}
 	res.data = C.stbi_load(&char(path.str), &res.width, &res.height, &res.nr_channels,
-		0)
+		params.desired_channels)
 
 	if isnil(res.data) {
 		return error('stbi_image failed to load from "${path}"')

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -119,7 +119,7 @@ pub fn load(path string) !Image {
 		data: 0
 	}
 	res.data = C.stbi_load(&char(path.str), &res.width, &res.height, &res.nr_channels,
-		C.STBI_rgb_alpha)
+		0)
 
 	if isnil(res.data) {
 		return error('stbi_image failed to load from "${path}"')


### PR DESCRIPTION
In the current `stbi_load` implementation the number of channels will always be 4 (rgba). This produces wrong output if you load a jpg image which doesn't have an alpha channel.

This pull request removes that desired channels.

From the docs of `stb_image.h`
```
// Basic usage (see HDR discussion below for HDR usage):
//    int x,y,n;
//    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
//    // ... process data if not NULL ...
//    // ... x = width, y = height, n = # 8-bit components per pixel ...
//    // ... replace '0' with '1'..'4' to force that many components per pixel
//    // ... but 'n' will always be the number that it would have been if you said 0
```

png images will still have their alpha channel preserved if it existed on the loaded image.

`v-logo.jpg` after load and write with stbi

![out](https://github.com/vlang/v/assets/43839798/b4f5db85-a1e6-49df-a792-925d719f1e12)

EDIT: add desired channels as `[params]` struct with the default value being 4 for compatiblity with sokol_gl and android.

```v
stbi.load(path, desired_channels: 3) or { panic(err) }
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9264a27</samp>

Fix image loading bug by inferring channel count from image format. Change `C.stbi_load` flag from `C.STBI_rgb_alpha` to 0 in `vlib/stbi/stbi.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9264a27</samp>

* Fix image loading bug by inferring channel count from image format ([link](https://github.com/vlang/v/pull/18491/files?diff=unified&w=0#diff-3566edbb636a40b3c608bb8b51fb2403f57929e1626e96f39ccb7256f0573a99L122-R122))
