### PR TITLE
picoev: freebsd bugfix

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -84,8 +84,14 @@ fn setup_sock(fd int) ! {
 	if C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_NODELAY, &flag, sizeof(int)) < 0 {
 		return error('setup_sock.setup_sock failed')
 	}
-	if C.fcntl(fd, C.F_SETFL, C.O_NONBLOCK) != 0 {
-		return error('fcntl failed')
+	$if freebsd {
+		if C.fcntl(fd, C.F_SETFL, C.SOCK_NONBLOCK) != 0 {
+			return error('fcntl failed')
+		}
+	} $else {
+		if C.fcntl(fd, C.F_SETFL, C.O_NONBLOCK) != 0 {
+			return error('fcntl failed')
+		}
 	}
 }
 


### PR DESCRIPTION
https://man.freebsd.org/cgi/man.cgi?query=fcntl&sektion=2

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63bc3c2</samp>

Use `SOCK_NONBLOCK` flag for sockets on FreeBSD in `picoev.v`. This fixes a bug that prevented the picoev library from working correctly on FreeBSD systems.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63bc3c2</samp>

*  Add conditional compilation blocks for different operating systems ([link](https://github.com/vlang/v/pull/18492/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL87-R94),                              F
