### PR TITLE
time, x.json2: Improve iso8601 decoding

### DIFF
--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -252,7 +252,7 @@ fn parse_iso8601_time(s string) !(int, int, int, int, i64, bool) {
 		microsecond_ = nanosecond_ / 1000
 	} else {
 		count = unsafe {
-			C.sscanf(&char(s.str), c'%2d:%2d:%2d.%6d%c%2d:%2d', &hour_, &minute_, &second_,
+			C.sscanf(&char(s.str), c'%2d:%2d:%2d.%9d%c%2d:%2d', &hour_, &minute_, &second_,
 				&microsecond_, &char(&plus_min_z), &offset_hour, &offset_minute)
 		}
 		// Missread microsecond ([Sec Hour Minute].len == 3 < 4)

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -117,10 +117,10 @@ pub fn decode[T](src string) !T {
 					typ.$(field.name) = res[json_name]!.str()
 				}
 			} $else $if field.typ is time.Time {
-				typ.$(field.name) = res[field.name]!.to_time()!
+				typ.$(field.name) = res[json_name]!.to_time()!
 			} $else $if field.typ is ?time.Time {
 				if json_name in res {
-					typ.$(field.name) = res[field.name]!.to_time()!
+					typ.$(field.name) = res[json_name]!.to_time()!
 				}
 			} $else $if field.is_array {
 				// typ.$(field.name) = res[field.name]!.arr()
@@ -393,8 +393,8 @@ pub fn (f Any) to_time() !time.Time {
 			return time.unix(f)
 		}
 		string {
-			if f.len == 10 && f[4] == `-` && f[7] == `-` {
-				// just a date in the format `2001-01-01`
+			is_iso8601 := f[4] == `-` && f[7] == `-`
+			if is_iso8601 {
 				return time.parse_iso8601(f)!
 			}
 			is_rfc3339 := f.len == 24 && f[23] == `Z` && f[10] == `T`


### PR DESCRIPTION
This PR fixes a couple of issues I found when trying to decode ISO 8601 timestamps in a JSON string (generated from a .NET app)

The changes are as follows:
Increased the maximum number of digits for milliseconds that can be parsed by `time.parse_iso8601()` from 6 to 9 (.NET generates 7, which caused an error)
Removed the length check in x.json2 for iso8601 dates to allow it to try and parse times as well. This check still isn't perfect, as it just checks if a string has a `-` at index 4 and 7, but a more comprehensive check may hurt performance.
made x.json2 use the `[json: 'name']` attribute for times like it does everything else