### PR TITLE
checker: check struct init with pointer field (fix #18485)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -545,8 +545,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						c.error('reference field must be initialized with reference',
 							field.pos)
 					} else if exp_type.is_pointer() && !got_type.is_any_kind_of_pointer()
-						&& field.expr.str() != '0' && !(field.expr is ast.Ident
-						&& (field.expr as ast.Ident).language == .c) {
+						&& field.expr.str() != '0' && !got_type.is_int()
+						&& !(field.expr is ast.Ident && (field.expr as ast.Ident).language == .c) {
 						got_typ_str := c.table.type_to_str(got_type)
 						exp_typ_str := c.table.type_to_str(exp_type)
 						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -544,6 +544,13 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						&& field.expr.str() != '0' && !exp_type.has_flag(.option) {
 						c.error('reference field must be initialized with reference',
 							field.pos)
+					} else if exp_type.is_pointer() && !got_type.is_any_kind_of_pointer()
+						&& field.expr.str() != '0' && !(field.expr is ast.Ident
+						&& (field.expr as ast.Ident).language == .c) {
+						got_typ_str := c.table.type_to_str(got_type)
+						exp_typ_str := c.table.type_to_str(exp_type)
+						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',
+							field.pos)
 					}
 				}
 				node.fields[i].typ = got_type

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -545,8 +545,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						c.error('reference field must be initialized with reference',
 							field.pos)
 					} else if exp_type.is_pointer() && !got_type.is_any_kind_of_pointer()
-						&& field.expr.str() != '0' && !got_type.is_int()
-						&& !(field.expr is ast.Ident && (field.expr as ast.Ident).language == .c) {
+						&& !got_type.is_int() {
 						got_typ_str := c.table.type_to_str(got_type)
 						exp_typ_str := c.table.type_to_str(exp_type)
 						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',

--- a/vlib/v/checker/tests/struct_voidptr_field_init_err.out
+++ b/vlib/v/checker/tests/struct_voidptr_field_init_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_voidptr_field_init_err.vv:7:3: error: cannot assign to field `example`: expected a pointer `voidptr`, but got `string`
+    5 | fn main() {
+    6 |     println(Example{
+    7 |         example: get()
+      |         ~~~~~~~~~~~~~~
+    8 |     })
+    9 | }

--- a/vlib/v/checker/tests/struct_voidptr_field_init_err.vv
+++ b/vlib/v/checker/tests/struct_voidptr_field_init_err.vv
@@ -1,0 +1,13 @@
+struct Example {
+	example voidptr
+}
+
+fn main() {
+	println(Example{
+		example: get()
+	})
+}
+
+fn get() string {
+	return 'hello'
+}


### PR DESCRIPTION
This PR check struct init with pointer field (fix #18485).

- Check struct init with pointer field.
- Add test.

```v
struct Example {
	example voidptr
}

fn main() {
	println(Example{
		example: get()
	})
}

fn get() string {
	return 'hello'
}

PS D:\Test\v\tt1> v run .
tt1.v:7:3: error: cannot assign to field `example`: expected a pointer `voidptr`, but got `string`
    5 | fn main() {
    6 |     println(Example{
    7 |         example: get()
      |         ~~~~~~~~~~~~~~
    8 |     })
    9 | }
```