### PR TITLE
builtin: minor cleanup in sorted_map.v

### DIFF
--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -60,7 +60,7 @@ fn new_sorted_map_init(n int, value_bytes int, keys &string, values voidptr) Sor
 // each insertion.
 fn new_node() &mapnode {
 	return &mapnode{
-		children: 0
+		children: unsafe { nil }
 		len: 0
 	}
 }


### PR DESCRIPTION
This PR makes a minor cleanup in sorted_map.v.

- Change `0` to `unsafe { nil }`.