### PR TITLE
build-tools: don't copy directories

### DIFF
--- a/cmd/tools/vbuild-tools.v
+++ b/cmd/tools/vbuild-tools.v
@@ -64,6 +64,9 @@ fn main() {
 			os.mv_by_cp(tpath, os.join_path(tfolder, tname, texe)) or { panic(err) }
 			continue
 		}
+		if os.is_dir(tpath) {
+			continue
+		}
 		target_path := os.join_path(tfolder, texe)
 		os.mv_by_cp(tpath, target_path) or {
 			emsg := err.msg()


### PR DESCRIPTION
  - When trying to copy tools from temporary directory to cmd/tools/, don't copy directories.
  - Fixes vlang/v#17437

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86b34be</samp>

Skip copying subdirectories when building V tools. This improves the efficiency and robustness of `vbuild-tools.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86b34be</samp>

* Skip copying directories when building a V tool ([link](https://github.com/vlang/v/pull/18503/files?diff=unified&w=0#diff-eea3b1e2fe7a722b3844faf13b4a011ced56ef70a04d46931ffaeb776f5bac38R67-R69))
