### PR TITLE
net.http: copy IANA's list of methods to Method

### DIFF
--- a/vlib/net/http/method.v
+++ b/vlib/net/http/method.v
@@ -50,6 +50,9 @@ pub enum Method { // as of 2023-06-20
 // str returns the string representation of the HTTP Method `m`.
 pub fn (m Method) str() string {
 	return match m {
+		.get { 'GET' }
+		.head { 'HEAD' }
+		.post { 'POST' }
 		.acl { 'ACL' }
 		.baseline_control { 'BASELINE-CONTROL' }
 		.bind { 'BIND' }
@@ -58,8 +61,6 @@ pub fn (m Method) str() string {
 		.connect { 'CONNECT' }
 		.copy { 'COPY' }
 		.delete { 'DELETE' }
-		.get { 'GET' }
-		.head { 'HEAD' }
 		.label { 'LABEL' }
 		.link { 'LINK' }
 		.@lock { 'LOCK' }
@@ -73,7 +74,6 @@ pub fn (m Method) str() string {
 		.options { 'OPTIONS' }
 		.orderpatch { 'ORDERPATCH' }
 		.patch { 'PATCH' }
-		.post { 'POST' }
 		.pri { 'PRI' }
 		.propfind { 'PROPFIND' }
 		.proppatch { 'PROPPATCH' }
@@ -98,6 +98,9 @@ pub fn (m Method) str() string {
 // Currently, the default value is Method.get for unsupported string value.
 pub fn method_from_str(m string) Method {
 	return match m {
+		'GET' { Method.get }
+		'HEAD' { Method.head }
+		'POST' { Method.post }
 		'ACL' { Method.acl }
 		'BASELINE-CONTROL' { Method.baseline_control }
 		'BIND' { Method.bind }
@@ -106,8 +109,6 @@ pub fn method_from_str(m string) Method {
 		'CONNECT' { Method.connect }
 		'COPY' { Method.copy }
 		'DELETE' { Method.delete }
-		'GET' { Method.get }
-		'HEAD' { Method.head }
 		'LABEL' { Method.label }
 		'LINK' { Method.link }
 		'LOCK' { Method.@lock }
@@ -121,7 +122,6 @@ pub fn method_from_str(m string) Method {
 		'OPTIONS' { Method.options }
 		'ORDERPATCH' { Method.orderpatch }
 		'PATCH' { Method.patch }
-		'POST' { Method.post }
 		'PRI' { Method.pri }
 		'PROPFIND' { Method.propfind }
 		'PROPPATCH' { Method.proppatch }

--- a/vlib/net/http/method.v
+++ b/vlib/net/http/method.v
@@ -3,33 +3,92 @@
 // that can be found in the LICENSE file.
 module http
 
-// The methods listed here are some of the most used ones, ordered by
-// commonality. A comprehensive list is available at:
+// The methods listed here are all of those on the list available at:
 // https://www.iana.org/assignments/http-methods/http-methods.xhtml
-pub enum Method {
-	get
-	post
-	put
-	head
-	delete
-	options
-	trace
+pub enum Method { // as of 2023-06-20
+	acl
+	baseline_control
+	bind
+	checkin
+	checkout
 	connect
+	copy
+	delete
+	get
+	head
+	label
+	link
+	@lock
+	merge
+	mkactivity
+	mkcalendar
+	mkcol
+	mkredirectref
+	mkworkspace
+	move
+	options
+	orderpatch
 	patch
+	post
+	pri
+	propfind
+	proppatch
+	put
+	rebind
+	report
+	search
+	trace
+	unbind
+	uncheckout
+	unlink
+	unlock
+	update
+	updateredirectref
+	version_control
 }
 
 // str returns the string representation of the HTTP Method `m`.
 pub fn (m Method) str() string {
 	return match m {
-		.get { 'GET' }
-		.post { 'POST' }
-		.put { 'PUT' }
-		.head { 'HEAD' }
-		.delete { 'DELETE' }
-		.options { 'OPTIONS' }
-		.trace { 'TRACE' }
+		.acl { 'ACL' }
+		.baseline_control { 'BASELINE-CONTROL' }
+		.bind { 'BIND' }
+		.checkin { 'CHECKIN' }
+		.checkout { 'CHECKOUT' }
 		.connect { 'CONNECT' }
+		.copy { 'COPY' }
+		.delete { 'DELETE' }
+		.get { 'GET' }
+		.head { 'HEAD' }
+		.label { 'LABEL' }
+		.link { 'LINK' }
+		.@lock { 'LOCK' }
+		.merge { 'MERGE' }
+		.mkactivity { 'MKACTIVITY' }
+		.mkcalendar { 'MKCALENDAR' }
+		.mkcol { 'MKCOL' }
+		.mkredirectref { 'MKREDIRECTREF' }
+		.mkworkspace { 'MKWORKSPACE' }
+		.move { 'MOVE' }
+		.options { 'OPTIONS' }
+		.orderpatch { 'ORDERPATCH' }
 		.patch { 'PATCH' }
+		.post { 'POST' }
+		.pri { 'PRI' }
+		.propfind { 'PROPFIND' }
+		.proppatch { 'PROPPATCH' }
+		.put { 'PUT' }
+		.rebind { 'REBIND' }
+		.report { 'REPORT' }
+		.search { 'SEARCH' }
+		.trace { 'TRACE' }
+		.unbind { 'UNBIND' }
+		.uncheckout { 'UNCHECKOUT' }
+		.unlink { 'UNLINK' }
+		.unlock { 'UNLOCK' }
+		.update { 'UPDATE' }
+		.updateredirectref { 'UPDATEREDIRECTREF' }
+		.version_control { 'VERSION-CONTROL' }
 	}
 }
 
@@ -39,15 +98,45 @@ pub fn (m Method) str() string {
 // Currently, the default value is Method.get for unsupported string value.
 pub fn method_from_str(m string) Method {
 	return match m {
-		'GET' { Method.get }
-		'POST' { Method.post }
-		'PUT' { Method.put }
-		'HEAD' { Method.head }
-		'DELETE' { Method.delete }
-		'OPTIONS' { Method.options }
-		'TRACE' { Method.trace }
+		'ACL' { Method.acl }
+		'BASELINE-CONTROL' { Method.baseline_control }
+		'BIND' { Method.bind }
+		'CHECKIN' { Method.checkin }
+		'CHECKOUT' { Method.checkout }
 		'CONNECT' { Method.connect }
+		'COPY' { Method.copy }
+		'DELETE' { Method.delete }
+		'GET' { Method.get }
+		'HEAD' { Method.head }
+		'LABEL' { Method.label }
+		'LINK' { Method.link }
+		'LOCK' { Method.@lock }
+		'MERGE' { Method.merge }
+		'MKACTIVITY' { Method.mkactivity }
+		'MKCALENDAR' { Method.mkcalendar }
+		'MKCOL' { Method.mkcol }
+		'MKREDIRECTREF' { Method.mkredirectref }
+		'MKWORKSPACE' { Method.mkworkspace }
+		'MOVE' { Method.move }
+		'OPTIONS' { Method.options }
+		'ORDERPATCH' { Method.orderpatch }
 		'PATCH' { Method.patch }
+		'POST' { Method.post }
+		'PRI' { Method.pri }
+		'PROPFIND' { Method.propfind }
+		'PROPPATCH' { Method.proppatch }
+		'PUT' { Method.put }
+		'REBIND' { Method.rebind }
+		'REPORT' { Method.report }
+		'SEARCH' { Method.search }
+		'TRACE' { Method.trace }
+		'UNBIND' { Method.unbind }
+		'UNCHECKOUT' { Method.uncheckout }
+		'UNLINK' { Method.unlink }
+		'UNLOCK' { Method.unlock }
+		'UPDATE' { Method.update }
+		'UPDATEREDIRECTREF' { Method.updateredirectref }
+		'VERSION-CONTROL' { Method.version_control }
 		else { Method.get } // should we default to GET?
 	}
 }


### PR DESCRIPTION
I'm writing a very basic WebDAV server for fun. WebDAV uses some weird request methods like `PROPFIND`. `net.http.Method` didn't have it in its list, so I had to add it. And I added the rest of the methods mentioned on IANA's page while I was at it.

I just thought you'd be interested.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55ec3d7</samp>

Improved HTTP module by adding and sorting all IANA-registered methods. Updated `Method` enum and related functions in `vlib/net/http/method.v` to handle the new methods.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55ec3d7</samp>

*  Add and sort all IANA-registered HTTP methods to the `Method` enum ([link](https://github.com/vlang/v/pull/18508/files?diff=unified&w=0#diff-2fb0df3e31ff305b2ad5596334d5ecde3221f4130441e7578149e4fa53fbe328L6-R47))
*  Update `str` method and `method_from_str` function to handle the new enum values ([link](https://github.com/vlang/v/pull/18508/files?diff=unified&w=0#diff-2fb0df3e31ff305b2ad5596334d5ecde3221f4130441e7578149e4fa53fbe328L24-R91), [link](https://github.com/vlang/v/pull/18508/files?diff=unified&w=0#diff-2fb0df3e31ff305b2ad5596334d5ecde3221f4130441e7578149e4fa53fbe328L42-R139))
