### PR TITLE
cgen: fix code generation for generic unions

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -393,7 +393,11 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 		return
 	}
 	if name.contains('_T_') {
-		g.typedefs.writeln('typedef struct ${name} ${name};')
+		if s.is_union {
+			g.typedefs.writeln('typedef union ${name} ${name};')
+		} else {
+			g.typedefs.writeln('typedef struct ${name} ${name};')
+		}
 	}
 	// TODO avoid buffer manip
 	start_pos := g.type_definitions.len

--- a/vlib/v/tests/generics_union_dump_test.v
+++ b/vlib/v/tests/generics_union_dump_test.v
@@ -14,15 +14,15 @@ fn test_conversion_works() {
 
 fn test_dumping_of_a_generic_union_value() {
 	dump(Convertor[u8]{
-		value: 123
+		bytes: [u8(210), 4, 0, 0, 5, 0, 0, 0]!
 	})
 	dump(Convertor[i16]{
-		value: 1234
+		bytes: [u8(210), 4, 0, 0, 5, 0, 0, 0]!
 	})
 	dump(Convertor[int]{
-		value: 1234
+		bytes: [u8(210), 4, 0, 0, 5, 0, 0, 0]!
 	})
 	dump(Convertor[i64]{
-		value: 1234
+		bytes: [u8(210), 4, 0, 0, 5, 0, 0, 0]!
 	})
 }

--- a/vlib/v/tests/generics_union_dump_test.v
+++ b/vlib/v/tests/generics_union_dump_test.v
@@ -1,0 +1,28 @@
+union Convertor[T] {
+	value T
+	bytes [8]u8
+}
+
+fn test_conversion_works() {
+	a := Convertor[i64]{
+		value: 21474837714
+	}
+	$if little_endian {
+		assert unsafe { a.bytes } == [u8(210), 4, 0, 0, 5, 0, 0, 0]!
+	}
+}
+
+fn test_dumping_of_a_generic_union_value() {
+	dump(Convertor[u8]{
+		value: 123
+	})
+	dump(Convertor[i16]{
+		value: 1234
+	})
+	dump(Convertor[int]{
+		value: 1234
+	})
+	dump(Convertor[i64]{
+		value: 1234
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/18512 .

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3123abc</samp>

This pull request fixes a bug in the C code generation of generic unions and adds a test file to verify their functionality. It changes the file `vlib/v/gen/c/struct.v` to use the correct keyword for generic unions and adds the file `vlib/v/tests/generics_union_dump_test.v` to demonstrate how to use and dump generic unions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3123abc</samp>

* Fix a bug where generic unions were not generated correctly in C by using the `union` keyword instead of the `struct` keyword in the typedef declaration ([link](https://github.com/vlang/v/pull/18513/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L396-R400))
* Add a new test file `generics_union_dump_test.v` to verify the functionality of generic unions ([link](https://github.com/vlang/v/pull/18513/files?diff=unified&w=0#diff-b42f7b734d0336dba51dba3f6a5bb27083b8208448b873601baee66da16467b5R1-R28))