### PR TITLE
checker: check struct field init with result value (fix #18511)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -509,10 +509,13 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				if got_type == ast.void_type {
 					c.error('`${init_field.expr}` (no value) used as value', init_field.pos)
 				}
-				if !exp_type.has_flag(.option) && !got_type.has_flag(.result) {
+				if !exp_type.has_flag(.option) {
 					got_type = c.check_expr_opt_call(init_field.expr, got_type)
 					if got_type.has_flag(.option) {
 						c.error('cannot assign an Option value to a non-option struct field',
+							init_field.pos)
+					} else if got_type.has_flag(.result) {
+						c.error('cannot assign a Result value to a non-option struct field',
 							init_field.pos)
 					}
 				}

--- a/vlib/v/checker/tests/struct_field_init_with_result_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_result_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/struct_field_init_with_result_err.vv:10:18: error: example() returns a Result, so it should have either an `or {}` block, or `!` at the end
+    8 |
+    9 | fn main() {
+   10 |     println(Example{example()})
+      |                     ~~~~~~~~~
+   11 | }

--- a/vlib/v/checker/tests/struct_field_init_with_result_err.vv
+++ b/vlib/v/checker/tests/struct_field_init_with_result_err.vv
@@ -1,0 +1,11 @@
+fn example() !int {
+	return 0
+}
+
+struct Example {
+	example int
+}
+
+fn main() {
+	println(Example{example()})
+}


### PR DESCRIPTION
This PR check struct field init with result value (fix #18511).

- Check struct field init with result value.
- Add test.

```v
fn example() !int {
	return 0
}

struct Example {
	example int
}

fn main() {
	println(Example{example()})
}

PS D:\Test\v\tt1> v run .
tt1.v:10:18: error: example() returns a Result, so it should have either an `or {}` block, or `!` at the end
    8 | 
    9 | fn main() {
   10 |     println(Example{example()})
      |                     ~~~~~~~~~
   11 | }
```