### PR TITLE
cgen, checker: fix indexexpr with sumtype of array types

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -49,10 +49,18 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				}
 			}
 		} else {
-			g.expr(node.left)
-			g.write('[')
-			g.expr(node.index)
-			g.write(']')
+			if sym.kind == .aggregate
+				&& (sym.info as ast.Aggregate).types.filter(g.table.type_kind(it) !in [.array, .array_fixed, .string, .map]).len == 0 {
+				// treating sumtype of array types
+				unwrapped_got_type := (sym.info as ast.Aggregate).types[g.aggregate_type_idx]
+				value_type := g.table.value_type(unwrapped_got_type)
+				g.index_of_array(ast.IndexExpr{ ...node, left_type: value_type }, g.table.sym(unwrapped_got_type))
+			} else {
+				g.expr(node.left)
+				g.write('[')
+				g.expr(node.index)
+				g.write(']')
+			}
 		}
 	}
 }

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -53,7 +53,6 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				&& (sym.info as ast.Aggregate).types.filter(g.table.type_kind(it) !in [.array, .array_fixed, .string, .map]).len == 0 {
 				// treating sumtype of array types
 				unwrapped_got_type := (sym.info as ast.Aggregate).types[g.aggregate_type_idx]
-				value_type := g.table.value_type(unwrapped_got_type)
 				g.index_expr(ast.IndexExpr{ ...node, left_type: unwrapped_got_type })
 			} else {
 				g.expr(node.left)

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -54,7 +54,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				// treating sumtype of array types
 				unwrapped_got_type := (sym.info as ast.Aggregate).types[g.aggregate_type_idx]
 				value_type := g.table.value_type(unwrapped_got_type)
-				g.index_of_array(ast.IndexExpr{ ...node, left_type: value_type }, g.table.sym(unwrapped_got_type))
+				g.index_expr(ast.IndexExpr{ ...node, left_type: unwrapped_got_type })
 			} else {
 				g.expr(node.left)
 				g.write('[')

--- a/vlib/v/tests/match_sumtype_arr_test.v
+++ b/vlib/v/tests/match_sumtype_arr_test.v
@@ -1,0 +1,32 @@
+type MySumType = []MyStructA | []MyStructB
+
+struct ParentStruct {
+	parent_field string
+}
+
+struct MyStructA {
+	ParentStruct
+}
+
+struct MyStructB {
+	ParentStruct
+}
+
+fn check(mut t MySumType) {
+	match mut t {
+		[]MyStructA, []MyStructB {
+			println(t[0].parent_field)
+		}
+	}
+}
+
+fn test_main() {
+	s := MyStructA{
+		parent_field: 'common'
+	}
+
+	mut t := MySumType([s])
+
+	check(mut t)
+	assert true
+}

--- a/vlib/v/tests/match_sumtype_arr_test.v
+++ b/vlib/v/tests/match_sumtype_arr_test.v
@@ -1,4 +1,5 @@
 type MySumType = []MyStructA | []MyStructB
+type MySumTypePtr = []&MyStructA | []&MyStructB
 
 struct ParentStruct {
 	parent_field string
@@ -20,13 +21,23 @@ fn check(mut t MySumType) {
 	}
 }
 
+fn check2(mut t MySumTypePtr) {
+	match mut t {
+		[]&MyStructA, []&MyStructB {
+			println(t[0].parent_field)
+		}
+	}
+}
+
 fn test_main() {
 	s := MyStructA{
 		parent_field: 'common'
 	}
 
 	mut t := MySumType([s])
+	mut t2 := MySumTypePtr([&s])
 
 	check(mut t)
+	check2(mut t2)
 	assert true
 }


### PR DESCRIPTION
Fix #18504

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b284052</samp>

This pull request adds support for indexing expressions on sum types of array types in V. It updates the type checker and the C code generator, and adds a new test file to verify the functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b284052</samp>

* Enable indexing expressions on sum types of array types ([link](https://github.com/vlang/v/pull/18515/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L4105-R4115), [link](https://github.com/vlang/v/pull/18515/files?diff=unified&w=0#diff-b058bb59569048c240a2f2f23b2056f787c45090e2dbc97a8aaf00500734ded4L52-R63))
  - Check if the type is an aggregate of array types in `vlib/v/checker/checker.v` and set the element type accordingly ([link](https://github.com/vlang/v/pull/18515/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L4105-R4115))
  - Handle the aggregate case in the C code generator in `vlib/v/gen/c/index.v` by using the `aggregate_type_idx` field to unwrap the type ([link](https://github.com/vlang/v/pull/18515/files?diff=unified&w=0#diff-b058bb59569048c240a2f2f23b2056f787c45090e2dbc97a8aaf00500734ded4L52-R63))
* Add a test file in `vlib/v/tests/match_sumtype_arr_test.v` to verify the new feature ([link](https://github.com/vlang/v/pull/18515/files?diff=unified&w=0#diff-7315268e8145a999523e03c92ebf12705a51540e0d3bbbd9cb22b3b02744bc6cR1-R32))
* Move the declaration of `index_type_sym` inside the if block in `vlib/v/checker/checker.v` to avoid unnecessary calls to `c.table.sym` ([link](https://github.com/vlang/v/pull/18515/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L4038-R4039))
