### PR TITLE
vweb: use correct tag for `<head>` element

### DIFF
--- a/examples/vweb/server_sent_events/index.html
+++ b/examples/vweb/server_sent_events/index.html
@@ -1,9 +1,9 @@
 <html>
-    <header>
+    <head>
         <title>@title</title>
         <meta charset="utf-8"/>
 	    @css 'assets/site.css'
-    </header>
+    </head>
     <body>
         <h1>@title</h1>
         <button>Close the connection</button>

--- a/examples/vweb/vweb_assets/index.html
+++ b/examples/vweb/vweb_assets/index.html
@@ -1,9 +1,9 @@
 <html>
-<header>
+<head>
 	<title>@title</title>
 	<style>html{display:none}</style>
 	@css 'index.css'
-</header>
+</head>
 <body>
 	<h1>@title</h1>
 	<h2>@subtitle</h2>

--- a/tutorials/building_a_simple_web_blog_with_vweb/code/blog/index.html
+++ b/tutorials/building_a_simple_web_blog_with_vweb/code/blog/index.html
@@ -1,7 +1,7 @@
 <html>
-<header>
+<head>
 	<title>V Blog</title>
-</header>
+</head>
 <body>
     user id = @app.user_id <br>
 	@for article in articles

--- a/tutorials/building_a_simple_web_blog_with_vweb/code/blog/new.html
+++ b/tutorials/building_a_simple_web_blog_with_vweb/code/blog/new.html
@@ -1,7 +1,7 @@
 <html>
-<header>
+<head>
 	<title>V Blog</title>
-</header>
+</head>
 <body>
 	<form action='/new_article' method='post'>
 		<input type='text' placeholder='Title' name='title'> <br>

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -92,10 +92,10 @@ That means that the template automatically has access to that action's entire en
 
 ```html
 <html>
-  <header>
+  <head>
     <title>${page_title}</title>
     @css 'src/templates/page/home.css'
-  </header>
+  </head>
   <body>
     <h1 class="title">Hello, Vs.</h1>
     @for var in list_of_object


### PR DESCRIPTION
fixes a mix-up where `<header>` - a container for content/navigation elements - is used as `<head>` element, the container for metadata.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76557d2</samp>

Replace `<header>` tags with `<head>` tags in several HTML files and code snippets in the `vlang/v` repository. This change fixes the HTML syntax and avoids confusion with the semantic `<header>` element.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76557d2</samp>

* Replace `<header>` tag with `<head>` tag in HTML files to improve syntax and avoid conflicts ([link](https://github.com/vlang/v/pull/18516/files?diff=unified&w=0#diff-db72499b21abac0400b81c0a5927baba6e989d597d8a8db0e4d399476997b2cdL2-R6), [link](https://github.com/vlang/v/pull/18516/files?diff=unified&w=0#diff-0dfcf4c9ef2f886876bcd0e3a3d44cfd54b7f31ac286782674baf163d89764b1L2-R6), [link](https://github.com/vlang/v/pull/18516/files?diff=unified&w=0#diff-c7290762e14b9d37799cc33a53cc0abb0778d8239869193b617c3ddb7b15485bL2-R4), [link](https://github.com/vlang/v/pull/18516/files?diff=unified&w=0#diff-f5eab996e2404b6bae70ef0209fd90dfe09e7c6565d508fd13f156f0d746e31cL2-R4), [link](https://github.com/vlang/v/pull/18516/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L95-R98))
* Update HTML code snippet in `vweb` module's `README.md` file to reflect the correct tag usage ([link](https://github.com/vlang/v/pull/18516/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L95-R98))
