### PR TITLE
checker: fix missing check for diff type on map value declaration

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -440,8 +440,10 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 					c.error('invalid map value: ${msg}', val.pos())
 				}
 			}
-			if !c.check_types(val_type, val0_type) || (i == 0 && val_type.is_number()
-				&& val0_type.is_number() && val0_type != ast.mktyp(val_type)) {
+			if !c.check_types(val_type, val0_type)
+				|| val0_type.has_flag(.option) != val_type.has_flag(.option)
+				|| (i == 0 && val_type.is_number() && val0_type.is_number()
+				&& val0_type != ast.mktyp(val_type)) {
 				msg := c.expected_msg(val_type, val0_type)
 				c.error('invalid map value: ${msg}', val.pos())
 			}

--- a/vlib/v/checker/tests/diff_type_map_value_err.out
+++ b/vlib/v/checker/tests/diff_type_map_value_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/diff_type_map_value_err.vv:10:44: error: invalid map value: expected `?MyStruct`, not `MyStruct`
+    8 | 
+    9 | fn empty() map[string]?MyStruct {
+   10 |   return {'key1': ?MyStruct(none), 'key2': MyStruct{field: 10}}
+      |                                            ~~~~~~~~~~~~~~~~~~~
+   11 | }
+   12 |

--- a/vlib/v/checker/tests/diff_type_map_value_err.vv
+++ b/vlib/v/checker/tests/diff_type_map_value_err.vv
@@ -1,0 +1,16 @@
+struct MyStruct {
+    field int
+}
+
+struct MyStruct2 {
+    field int
+}
+
+fn empty() map[string]?MyStruct {
+  return {'key1': ?MyStruct(none), 'key2': MyStruct{field: 10}}
+}
+
+fn test_empty() {
+    expected := {'key': ?MyStruct(none)}
+    assert empty() == expected
+}


### PR DESCRIPTION
Fix #18519

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68ec823</samp>

Fix a bug that allowed creating maps with incompatible value types. Add a checker condition and a test case to verify the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68ec823</samp>

*  Prevent mixing optional and non-optional map values ([link](https://github.com/vlang/v/pull/18522/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL443-R446))
* Add a test case for the error ([link](https://github.com/vlang/v/pull/18522/files?diff=unified&w=0#diff-f1ccf4d6cd99db7823da18a184cd5411fe8151093b42da732de3bae2ce64e6d2R1-R7), [link](https://github.com/vlang/v/pull/18522/files?diff=unified&w=0#diff-7899a56a02571c288060374c2615bcf0c35b8264d58cddbbcd09c64eeacb2a7bL1-R15))
