### PR TITLE
parser: disallow multi `else` branches in match

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -213,6 +213,7 @@ fn (mut p Parser) is_only_array_type() bool {
 
 fn (mut p Parser) match_expr() ast.MatchExpr {
 	match_first_pos := p.tok.pos()
+	mut else_count := 0
 	p.inside_match = true
 	p.check(.key_match)
 	mut is_sum_type := false
@@ -233,6 +234,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		mut is_else := false
 		if p.tok.kind == .key_else {
 			is_else = true
+			else_count += 1
 			p.next()
 		} else if (p.tok.kind == .name && !(p.tok.lit == 'C' && p.peek_tok.kind == .dot)
 			&& (((ast.builtin_type_names_matcher.matches(p.tok.lit) || p.tok.lit[0].is_capital())
@@ -327,6 +329,9 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 		}
 		if is_else && branches.len == 1 {
 			p.error_with_pos('`match` must have at least one non `else` branch', pos)
+		}
+		if else_count > 1 {
+			p.error_with_pos('`match` can have only one `else` branch', pos)
 		}
 		if p.tok.kind == .rcbr || (is_else && no_lcbr) {
 			break

--- a/vlib/v/parser/tests/match_multi_else_branch_err.out
+++ b/vlib/v/parser/tests/match_multi_else_branch_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/match_multi_else_branch_err.vv:5:3: error: `match` can have only one `else` branch
+    3 |         true { 1 }
+    4 |         else { 3 }
+    5 |         else { 5 }
+      |         ~~~~
+    6 |     }
+    7 | }

--- a/vlib/v/parser/tests/match_multi_else_branch_err.vv
+++ b/vlib/v/parser/tests/match_multi_else_branch_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	_ := match true {
+		true { 1 }
+		else { 3 }
+		else { 5 }
+	}
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18521

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03e9a9f</samp>

Added error checking and testing for `match` expressions with multiple `else` branches. This improves the parser's robustness and usability.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03e9a9f</samp>

* Enforce the rule that a match expression can have only one else branch ([link](https://github.com/vlang/v/pull/18526/files?diff=unified&w=0#diff-0185db9758da469bd38f53e5be2cfd9af3104f31dc749d51f967041be8f253b9R216), [link](https://github.com/vlang/v/pull/18526/files?diff=unified&w=0#diff-0185db9758da469bd38f53e5be2cfd9af3104f31dc749d51f967041be8f253b9R237), [link](https://github.com/vlang/v/pull/18526/files?diff=unified&w=0#diff-0185db9758da469bd38f53e5be2cfd9af3104f31dc749d51f967041be8f253b9R333-R335))
* Add test files to check the error message for a match expression with multiple else branches ([link](https://github.com/vlang/v/pull/18526/files?diff=unified&w=0#diff-9a12825d7df52d645c17ebc529a024cef421caa7c7f97fc10363257491b8edaeR1-R7), [link](https://github.com/vlang/v/pull/18526/files?diff=unified&w=0#diff-68abb4cb634a7f8f19dc0fa2f7ed13aad3f8d116b874cffc86f6d42948ff9993R1-R7))
