### PR TITLE
parser: fix multiple embedded external module interface (fix #18527)

### DIFF
--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -578,6 +578,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 	mut is_mut := false
 	mut mut_pos := -1
 	for p.tok.kind != .rcbr && p.tok.kind != .eof {
+		// check embedded interface from internal module
 		if p.tok.kind == .name && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 			&& (p.peek_tok.line_nr != p.tok.line_nr
 			|| p.peek_tok.kind !in [.name, .amp, .lsbr, .lpar]
@@ -600,8 +601,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			}
 			continue
 		}
-
-		// Check embedded interface from external module
+		// check embedded interface from external module
 		if p.tok.kind == .name && p.peek_tok.kind == .dot {
 			if p.tok.lit !in p.imports {
 				p.error_with_pos('mod `${p.tok.lit}` not imported', p.tok.pos())
@@ -624,6 +624,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			if p.tok.kind == .rcbr {
 				break
 			}
+			continue
 		}
 
 		if p.tok.kind == .key_mut {
@@ -654,7 +655,6 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				p.error_with_pos('duplicate method `${name}`', method_start_pos)
 				return ast.InterfaceDecl{}
 			}
-			// field_names << name
 			args2, _, is_variadic := p.fn_args() // TODO merge ast.Param and ast.Arg to avoid this
 			mut args := [
 				ast.Param{
@@ -688,7 +688,6 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			method.comments = mcomments
 			method.next_comments = mnext_comments
 			methods << method
-			// println('register method $name')
 			tmethod := ast.Fn{
 				name: name
 				params: args

--- a/vlib/v/tests/modules/module_a/module_a.v
+++ b/vlib/v/tests/modules/module_a/module_a.v
@@ -1,0 +1,5 @@
+module module_a
+
+pub interface Writer {
+	write(name string) string
+}

--- a/vlib/v/tests/modules/module_b/module_b.v
+++ b/vlib/v/tests/modules/module_b/module_b.v
@@ -1,0 +1,5 @@
+module module_b
+
+pub interface Reader {
+	read(name string) string
+}

--- a/vlib/v/tests/multiple_embed_external_interface_test.v
+++ b/vlib/v/tests/multiple_embed_external_interface_test.v
@@ -1,0 +1,12 @@
+import module_a
+import module_b
+
+pub interface MyInterface {
+	module_a.Writer
+	module_b.Reader
+}
+
+fn test_multiple_embed_external_interface() {
+	println('abc')
+	assert true
+}


### PR DESCRIPTION
This PR fix multiple embedded external module interface (fix #18527).

- Fix multiple embedded external module interfaces.
- Add test.

```v
import module_a
import module_b

pub interface MyInterface {
	module_a.Writer
	module_b.Reader
}

fn main() {
	println('abc')
}

PS D:\Test\v\tt1> v run .
abc
```