### PR TITLE
parser: remove hardcoded check for function calls for `C.stat`, `C.sigaction`, etc

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -232,10 +232,10 @@ pub:
 
 type VectoredExceptionHandler = fn (&ExceptionPointers) int
 
-fn C.AddVectoredExceptionHandler(int, C.PVECTORED_EXCEPTION_HANDLER)
+fn C.AddVectoredExceptionHandler(int, voidptr)
 
 fn add_vectored_exception_handler(handler VectoredExceptionHandler) {
-	C.AddVectoredExceptionHandler(1, C.PVECTORED_EXCEPTION_HANDLER(handler))
+	C.AddVectoredExceptionHandler(1, voidptr(handler))
 }
 
 [callconv: stdcall]

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -255,7 +255,7 @@ fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlag
 
 fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
 
-fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead C.LPDWORD, lpOverlapped voidptr) bool
+fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead &u32, lpOverlapped voidptr) bool
 
 fn C.GetFileAttributesW(lpFileName &u8) u32
 

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -558,7 +558,7 @@ pub fn get_raw_line() string {
 			mut offset := 0
 			for {
 				pos := buf + offset
-				res := C.ReadFile(h_input, pos, 1, C.LPDWORD(&bytes_read), 0)
+				res := C.ReadFile(h_input, pos, 1, &u32(&bytes_read), 0)
 				if !res && offset == 0 {
 					return tos(buf, 0)
 				}
@@ -600,7 +600,7 @@ pub fn get_raw_stdin() []u8 {
 			mut offset := 0
 			for {
 				pos := buf + offset
-				res := C.ReadFile(h_input, pos, block_bytes, C.LPDWORD(&bytes_read), 0)
+				res := C.ReadFile(h_input, pos, block_bytes, &u32(&bytes_read), 0)
 				offset += bytes_read
 				if !res {
 					break

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -449,7 +449,7 @@ pub type VectoredExceptionHandler = fn (&ExceptionPointers) u32
 // duplicate definitions from displeasing the compiler
 // fn C.AddVectoredExceptionHandler(u32, VectoredExceptionHandler)
 pub fn add_vectored_exception_handler(first bool, handler VectoredExceptionHandler) {
-	C.AddVectoredExceptionHandler(u32(first), C.PVECTORED_EXCEPTION_HANDLER(handler))
+	C.AddVectoredExceptionHandler(u32(first), voidptr(handler))
 }
 
 // uname returns information about the platform on which the program is running.

--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -18,7 +18,7 @@ fn C.time(t &C.time_t) C.time_t
 
 fn C.gmtime(t &C.time_t) &C.tm
 fn C.gmtime_r(t &C.time_t, res &C.tm) &C.tm
-fn C.strftime(buf &C.char, maxsize C.size_t, fmt &C.char, tm &C.tm) C.size_t
+fn C.strftime(buf &char, maxsize usize, const_format &char, const_tm &C.tm) usize
 
 // now returns current local time.
 pub fn now() Time {
@@ -129,8 +129,8 @@ pub fn (t Time) strftime(fmt string) string {
 	} $else {
 		C.gmtime_r(voidptr(&t.unix), tm)
 	}
-	mut buf := [1024]C.char{}
-	fmt_c := unsafe { &C.char(fmt.str) }
-	C.strftime(&buf[0], C.size_t(sizeof(buf)), fmt_c, tm)
+	mut buf := [1024]char{}
+	fmt_c := unsafe { &char(fmt.str) }
+	C.strftime(&buf[0], usize(sizeof(buf)), fmt_c, tm)
 	return unsafe { cstring_to_vstring(&char(&buf[0])) }
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2622,12 +2622,13 @@ fn (mut p Parser) name_expr() ast.Expr {
 		}
 		name_w_mod := p.prepend_mod(name)
 		is_c_pointer_cast := language == .c && prev_tok_kind == .amp // `&C.abc(x)` is *always* a cast
+		is_c_type_cast := language == .c && name in ['C.intptr_t', 'C.uintptr_t']
 		is_js_cast := language == .js && name.all_after_last('.')[0].is_capital()
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
-		if is_mod_cast || is_c_pointer_cast || is_js_cast || is_generic_cast
-			|| (language == .v && name.len > 0 && (name[0].is_capital()
+		if is_mod_cast || is_c_pointer_cast || is_c_type_cast || is_js_cast
+			|| is_generic_cast || (language == .v && name.len > 0 && (name[0].is_capital()
 			|| (!known_var && (name in p.table.type_idxs
 			|| name_w_mod in p.table.type_idxs))
 			|| name.all_after_last('.')[0].is_capital())) {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2621,11 +2621,13 @@ fn (mut p Parser) name_expr() ast.Expr {
 			name = '${mod}.${name}'
 		}
 		name_w_mod := p.prepend_mod(name)
+		is_c_pointer_cast := language == .c && prev_tok_kind == .amp // `&C.abc(x)` is *always* a cast
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
-		if (!known_var && (name in p.table.type_idxs || name_w_mod in p.table.type_idxs)
-			&& name !in ['C.statvfs', 'C.stat', 'C.sigaction']) || is_mod_cast
-			|| is_generic_cast || (language == .v && name.len > 0 && (name[0].is_capital()
+		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
+		if is_mod_cast || is_c_pointer_cast || is_generic_cast || (language == .v && name.len > 0
+			&& (name[0].is_capital() || (!known_var && (name in p.table.type_idxs
+			|| name_w_mod in p.table.type_idxs))
 			|| name.all_after_last('.')[0].is_capital())) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`
 			// TODO handle C.stat()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2622,11 +2622,13 @@ fn (mut p Parser) name_expr() ast.Expr {
 		}
 		name_w_mod := p.prepend_mod(name)
 		is_c_pointer_cast := language == .c && prev_tok_kind == .amp // `&C.abc(x)` is *always* a cast
+		is_js_cast := language == .js && name.all_after_last('.')[0].is_capital()
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
-		if is_mod_cast || is_c_pointer_cast || is_generic_cast || (language == .v && name.len > 0
-			&& (name[0].is_capital() || (!known_var && (name in p.table.type_idxs
+		if is_mod_cast || is_c_pointer_cast || is_js_cast || is_generic_cast
+			|| (language == .v && name.len > 0 && (name[0].is_capital()
+			|| (!known_var && (name in p.table.type_idxs
 			|| name_w_mod in p.table.type_idxs))
 			|| name.all_after_last('.')[0].is_capital())) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`


### PR DESCRIPTION
- parser: remove the hardcoded list of `C.statvfs`, `C.stat`, `C.sigaction`, for the known C struct names, that are C function names as well
- fix for `./v -b js_browser examples/tetris/tetris.js.v`
- fix `v vlib/v/gen/c/coutput_test.v`
