### PR TITLE
checker/orm: disallow unsupported data types

### DIFF
--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -636,6 +636,10 @@ fn (c &Checker) orm_get_field_pos(expr &ast.Expr) token.Pos {
 		} else {
 			pos = expr.left.pos()
 		}
+	} else if expr is ast.ParExpr {
+		pos = c.orm_get_field_pos(expr.expr)
+	} else if expr is ast.PrefixExpr {
+		pos = c.orm_get_field_pos(expr.right)
 	} else {
 		pos = expr.pos()
 	}

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -632,7 +632,7 @@ fn (c &Checker) orm_get_field_pos(expr &ast.Expr) token.Pos {
 			pos = expr.left.pos
 		} else if expr.left is ast.InfixExpr || expr.left is ast.ParExpr
 			|| expr.left is ast.PrefixExpr {
-			pos = c.get_field_pos(expr.left)
+			pos = c.orm_get_field_pos(expr.left)
 		} else {
 			pos = expr.left.pos()
 		}

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
@@ -8,11 +8,11 @@ vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:15:29: erro
 Details:
  field name: `example`
  data type: `[]u8`
-vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:18:33: error: V ORM: does not support array of primitive types
+vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:18:34: error: V ORM: does not support array of primitive types
    16 |     }!
    17 |     f := sql db {
    18 |             select from Example where (example == bytes)
-      |                                       ~~~~~~~~~~~~~~~~~~
+      |                                        ~~~~~~~
    19 |         }!
    20 |     print(e)
 Details:

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
@@ -1,7 +1,20 @@
-vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:15:29: error: V ORM: select: field `example` has unsupported data type `[]u8`
+vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:15:29: error: V ORM: does not support array of primitive types
    13 |     bytes := [u8(0)]
    14 |     e := sql db {
    15 |         select from Example where example == bytes
       |                                   ~~~~~~~
    16 |     }!
-   17 |     print(e)
+   17 |     f := sql db {
+Details:
+ field name: `example`
+ data type: `[]u8`
+vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:18:33: error: V ORM: does not support array of primitive types
+   16 |     }!
+   17 |     f := sql db {
+   18 |             select from Example where (example == bytes)
+      |                                       ~~~~~~~~~~~~~~~~~~
+   19 |         }!
+   20 |     print(e)
+Details:
+ field name: `example`
+ data type: `[]u8`

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:15:29: error: V ORM: select: field `example` has unsupported data type `[]u8`
+   13 |     bytes := [u8(0)]
+   14 |     e := sql db {
+   15 |         select from Example where example == bytes
+      |                                   ~~~~~~~
+   16 |     }!
+   17 |     print(e)

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv
@@ -14,5 +14,9 @@ fn main() {
 	e := sql db {
 		select from Example where example == bytes
 	}!
+	f := sql db {
+    		select from Example where (example == bytes)
+    	}!
 	print(e)
+	print(f)
 }

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv
@@ -1,0 +1,18 @@
+module main
+
+import db.pg
+
+[table: 'example']
+pub struct Example {
+	id      int  [primary; sql: serial]
+	example []u8 [sql_type: 'bytea'; unique]
+}
+
+fn main() {
+	db := pg.connect(pg.Config{}) or { exit(0) }
+	bytes := [u8(0)]
+	e := sql db {
+		select from Example where example == bytes
+	}!
+	print(e)
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->
Closes https://github.com/vlang/v/issues/18316

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f87e666</samp>

This pull request adds a new feature and a test case for the ORM module. It allows specifying a SQL expression for the table and the where clause in the `fetch_and_verify_orm_fields` function. It also checks and reports errors for unsupported field types in the where clause, such as arrays.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f87e666</samp>

*  Add a parameter `sql_expr` of type `ast.SqlExpr` to the function `fetch_and_verify_orm_fields` to pass the SQL expression that contains the table name and the where clause ([link](https://github.com/vlang/v/pull/18537/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L43-R44), [link](https://github.com/vlang/v/pull/18537/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L218-R220), [link](https://github.com/vlang/v/pull/18537/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L330-R332))
*  Check the data types of the fields used in the where clause and report errors if they are not supported by the ORM, such as array types of primitive elements ([link](https://github.com/vlang/v/pull/18537/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R349-R361))
*  Add a test case `orm_where_clause_unsupported_field_types_err.vv` that shows an example of a SQL expression that uses an unsupported field type in the where clause, and the expected compiler output in `orm_where_clause_unsupported_field_types_err.out` ([link](https://github.com/vlang/v/pull/18537/files?diff=unified&w=0#diff-5e2d457102f84e6310d82c2f9162f13f2113905f270b9f584ca253c91a19788bR1-R7), [link](https://github.com/vlang/v/pull/18537/files?diff=unified&w=0#diff-01a450eaeea07083654b56b5577222b6253907712b69fca898853ce71c5f9484R1-R18))
