### PR TITLE
cgen, checker: allow none assignment to array of option

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -522,6 +522,9 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				} else if c.check_types(unwrapped_right_type, c.unwrap_generic(left_type)) {
 					return ast.void_type
 				}
+				if left_value_type.has_flag(.option) && right_type == ast.none_type {
+					return ast.void_type
+				}
 				c.error('cannot append `${right_sym.name}` to `${left_sym.name}`', right_pos)
 				return ast.void_type
 			} else {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -578,10 +578,14 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 				deref, deref_label := deref_kind(str_method_expects_ptr, is_elem_ptr,
 					typ)
 				g.auto_str_funcs.writeln('\t\tstring x = _SLIT("nil");')
-				g.auto_str_funcs.writeln('\t\tif (it != 0) {')
+				if !typ.has_flag(.option) {
+					g.auto_str_funcs.writeln('\t\tif (it != 0) {')
+				}
 				g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT("${deref_label}"));')
 				g.auto_str_funcs.writeln('\t\t\tx = ${elem_str_fn_name}(${deref}it);')
-				g.auto_str_funcs.writeln('\t\t}')
+				if !typ.has_flag(.option) {
+					g.auto_str_funcs.writeln('\t\t}')
+				}
 			} else {
 				g.auto_str_funcs.writeln('\t\tstring x = indent_${elem_str_fn_name}(it, indent_count);')
 			}
@@ -610,10 +614,14 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 			deref, deref_label := deref_kind(str_method_expects_ptr, is_elem_ptr, typ)
 			if is_elem_ptr {
 				g.auto_str_funcs.writeln('\t\tstring x = _SLIT("nil");')
-				g.auto_str_funcs.writeln('\t\tif (it != 0) {')
+				if !typ.has_flag(.option) {
+					g.auto_str_funcs.writeln('\t\tif (it != 0) {')
+				}
 				g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT("${deref_label}"));')
 				g.auto_str_funcs.writeln('\t\t\tx = ${elem_str_fn_name}(${deref}it);')
-				g.auto_str_funcs.writeln('\t\t}')
+				if !typ.has_flag(.option) {
+					g.auto_str_funcs.writeln('\t\t}')
+				}
 			} else {
 				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, _SLIT("${deref_label}"));')
 				g.auto_str_funcs.writeln('\t\tstring x = ${elem_str_fn_name}(${deref}it);')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -990,7 +990,7 @@ fn (mut g Gen) infix_expr_and_or_op(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
-	if node.left in [ast.Ident, ast.SelectorExpr] {
+	if node.left in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
 		g.expr(node.left)

--- a/vlib/v/tests/option_assign_none_test.v
+++ b/vlib/v/tests/option_assign_none_test.v
@@ -1,0 +1,11 @@
+fn test_main() {
+	mut a := []?&int{}
+	a << ?&int(none)
+	a << none
+	dump(a[0])
+	dump(a[1])
+	println(a)
+
+	assert a[0] == none
+	assert a[1] == none
+}


### PR DESCRIPTION
Fix #18523
Fix #18524

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c2bcc3</samp>

Fix a compiler error when using `none` with optional types in infix expressions and arrays. Add a check for `void` result type in the checker, and handle index expressions in the C generator. Add a test case in `option_assign_none_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c2bcc3</samp>

*  Add a check for optional types with `none` in infix expressions ([link](https://github.com/vlang/v/pull/18539/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7R525-R527), [link](https://github.com/vlang/v/pull/18539/files?diff=unified&w=0#diff-4194723712edfd7a1a69102329b9169cc79bc1d109393153e0537039c5ca1988L993-R993))
*  Skip `if (it != 0)` checks for optional types in array `str` methods ([link](https://github.com/vlang/v/pull/18539/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL581-R588), [link](https://github.com/vlang/v/pull/18539/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL613-R624))
*  Add a test case for optional types with `none` in `vlib/v/tests/option_assign_none_test.v` ([link](https://github.com/vlang/v/pull/18539/files?diff=unified&w=0#diff-dc5745031c98de8963c60cb69a1255987c354c4d76ead2b8befcd668c6282ad6R1-R11))
