### PR TITLE
cgen: fix map using option as value

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3989,6 +3989,8 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			}
 			if value_sym.kind == .sum_type {
 				g.expr_with_cast(expr, node.val_types[i], unwrap_val_typ)
+			} else if node.val_types[i].has_flag(.option) {
+				g.expr_with_opt(expr, node.val_types[i], unwrap_val_typ)
 			} else {
 				g.expr(expr)
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1888,7 +1888,11 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		g.writeln('${g.typ(ret_typ)} ${tmp_var};')
 		if ret_typ.has_flag(.option) {
 			if expr_typ.has_flag(.option) && expr in [ast.StructInit, ast.ArrayInit, ast.MapInit] {
-				g.write('_option_none(&(${styp}[]) { ')
+				if expr is ast.StructInit && (expr as ast.StructInit).init_fields.len > 0 {
+					g.write('_option_ok(&(${styp}[]) { ')
+				} else {
+					g.write('_option_none(&(${styp}[]) { ')
+				}
 			} else {
 				is_ptr_to_ptr_assign = (expr is ast.SelectorExpr
 					|| (expr is ast.Ident && !(expr as ast.Ident).is_auto_heap()))

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -397,7 +397,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		if g.inside_return {
 			g.typ(val_type)
 		} else {
-			g.typ(val_type.clear_flags(.option, .result))
+			g.typ(val_type.clear_flags(.result))
 		}
 	}
 	get_and_set_types := val_sym.kind in [.struct_, .map, .array]

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -990,7 +990,7 @@ fn (mut g Gen) infix_expr_and_or_op(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
-	if node.left in [ast.Ident, ast.SelectorExpr] {
+	if node.left in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
 		g.expr(node.left)

--- a/vlib/v/tests/option_map_init_test.v
+++ b/vlib/v/tests/option_map_init_test.v
@@ -1,0 +1,19 @@
+struct MyStruct {
+	field int
+}
+
+fn empty() map[string]?MyStruct {
+	return {
+		'key1': ?MyStruct(none)
+		'key2': ?MyStruct{
+			field: 10
+		}
+	}
+}
+
+fn test_main() {
+	a := dump(empty())
+
+	assert a['key1'] == none
+	assert a['key2'] == none
+}

--- a/vlib/v/tests/option_map_init_test.v
+++ b/vlib/v/tests/option_map_init_test.v
@@ -14,6 +14,12 @@ fn empty() map[string]?MyStruct {
 fn test_main() {
 	a := dump(empty())
 
+	b := dump(a['key2'])
+
+	assert b? == MyStruct{
+		field: 10
+	}
+
 	assert a['key1'] == none
-	assert a['key2'] == none
+	assert a['key2'] != none
 }


### PR DESCRIPTION
Fix #18530

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c68b754</samp>

This pull request improves the code generation and testing for option types in V. It fixes some bugs and adds support for tuple assignments, index expressions, and map initializations with option types.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c68b754</samp>

* Allow option types to be assigned to tuples and unwrapped or checked for `none` ([link](https://github.com/vlang/v/pull/18540/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR3992-R3993), [link](https://github.com/vlang/v/pull/18540/files?diff=unified&w=0#diff-b058bb59569048c240a2f2f23b2056f787c45090e2dbc97a8aaf00500734ded4L400-R400))
* Support `is` operator for index expressions that may return option types ([link](https://github.com/vlang/v/pull/18540/files?diff=unified&w=0#diff-4194723712edfd7a1a69102329b9169cc79bc1d109393153e0537039c5ca1988L993-R993))
* Add test file for initializing maps with option types (`vlib/v/tests/option_map_init_test.v`) ([link](https://github.com/vlang/v/pull/18540/files?diff=unified&w=0#diff-2eff1bcbd9ebf54136291963f88a59c708396948413f83475bc09c07ead50f3eR1-R19))
