### PR TITLE
checker: missing check for Result as map value type

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -349,6 +349,9 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 	if node.typ != 0 {
 		info := c.table.sym(node.typ).map_info()
 		if info.value_type != 0 {
+			if info.value_type.has_flag(.result) {
+				c.error('cannot use Result type as map value type', node.pos)
+			}
 			val_sym := c.table.sym(info.value_type)
 			if val_sym.kind == .struct_ {
 				val_info := val_sym.info as ast.Struct

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -129,6 +129,12 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if sym.kind == .none_ {
 				c.error('cannot use `none` as field type', field.type_pos)
 			}
+			if sym.kind == .map {
+				info := sym.map_info()
+				if info.value_type.has_flag(.result) {
+					c.error('cannot use Result type as map value type', field.type_pos)
+				}
+			}
 
 			if field.has_default_expr {
 				c.expected_type = field.typ

--- a/vlib/v/checker/tests/map_with_result_value_err.out
+++ b/vlib/v/checker/tests/map_with_result_value_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/map_with_result_value_err.vv:2:8: error: cannot use Result type as map value type
+    1 | fn main() {
+    2 |   dump(map[string]!string{})
+      |        ~~~~~~~~~~~~~~~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/map_with_result_value_err.out
+++ b/vlib/v/checker/tests/map_with_result_value_err.out
@@ -1,5 +1,19 @@
-vlib/v/checker/tests/map_with_result_value_err.vv:2:8: error: cannot use Result type as map value type
-    1 | fn main() {
-    2 |   dump(map[string]!string{})
-      |        ~~~~~~~~~~~~~~~~~~~~
+vlib/v/checker/tests/map_with_result_value_err.vv:2:7: error: cannot use Result type as map value type
+    1 | struct Foo {
+    2 |     map1 map[string]!string
+      |          ~~~~~~~~~~~~~~~~~~
     3 | }
+    4 |
+vlib/v/checker/tests/map_with_result_value_err.vv:6:8: error: cannot use Result type as map value type
+    4 | 
+    5 | fn main() {
+    6 |   _ := map[string]!string{}
+      |        ~~~~~~~~~~~~~~~~~~~~
+    7 | 
+    8 |   dump(map[string]!string{})
+vlib/v/checker/tests/map_with_result_value_err.vv:8:8: error: cannot use Result type as map value type
+    6 |   _ := map[string]!string{}
+    7 | 
+    8 |   dump(map[string]!string{})
+      |        ~~~~~~~~~~~~~~~~~~~~
+    9 | }

--- a/vlib/v/checker/tests/map_with_result_value_err.vv
+++ b/vlib/v/checker/tests/map_with_result_value_err.vv
@@ -1,3 +1,9 @@
+struct Foo {
+	map1 map[string]!string
+}
+
 fn main() {
+  _ := map[string]!string{}
+
   dump(map[string]!string{})
 }

--- a/vlib/v/checker/tests/map_with_result_value_err.vv
+++ b/vlib/v/checker/tests/map_with_result_value_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+  dump(map[string]!string{})
+}

--- a/vlib/v/tests/map_value_with_option_result_test.v
+++ b/vlib/v/tests/map_value_with_option_result_test.v
@@ -15,13 +15,11 @@ fn foo(arg map[string]?string) ?string {
 }
 
 struct Foo {
-	map1 map[string]!string
 	map2 map[string]?string
 }
 
 fn bar() {
 	map1 := map[string]?string{}
-	map2 := map[string]!string{}
 }
 
 fn baz(arg map[string]?string) ?string {


### PR DESCRIPTION
Fix #18542

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ceb93d</samp>

Prevent using `Result` types as map values in the checker module. Add a test case and an output file for the new check.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ceb93d</samp>

* Add a check to prevent using Result types as map values ([link](https://github.com/vlang/v/pull/18543/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR352-R354))
* Emit an error message with the node position if the check fails ([link](https://github.com/vlang/v/pull/18543/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR352-R354))
* Add a test source file `map_with_result_value_err.vv` with an example of the invalid usage ([link](https://github.com/vlang/v/pull/18543/files?diff=unified&w=0#diff-c3ed5515e288eafa50d1daa90c53b6fdd49ffe29a90b7e8b6d37d4c794cb7825L1-R2))
* Add a test output file `map_with_result_value_err.out` with the expected error message and line number ([link](https://github.com/vlang/v/pull/18543/files?diff=unified&w=0#diff-afcd42a3465cfd1b59b02a601c13065562b4dbbea769892d1c8c8c64ab442106R1-R5))
