### PR TITLE
flag: fix finalize with multiple shortargs (fix #18536)

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -307,6 +307,7 @@ fn (mut fs FlagParser) parse_bool_value(longhand string, shorthand u8) !string {
 			}
 			if arg.len > 1 && arg[0] == `-` && arg[1] != `-` && arg.index_u8(shorthand) != -1 {
 				// -abc is equivalent to -a -b -c
+				fs.args[i] = arg.replace(shorthand.ascii_str(), '') // -abc -> -bc
 				return 'true'
 			}
 		}

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -410,3 +410,16 @@ fn test_empty_string_with_flag() {
 	mut fp := flag.new_flag_parser([''])
 	s := fp.string('something', `s`, 'default', 'Hey parse me')
 }
+
+fn test_finalize_with_multi_shortargs() {
+	mut fp := flag.new_flag_parser(['-ab', '-c'])
+	a_bool := fp.bool('a_bool', `a`, false, '')
+	assert a_bool
+	b_bool := fp.bool('b_bool', `b`, false, '')
+	assert b_bool
+	c_bool := fp.bool('c_bool', `c`, false, '')
+	assert c_bool
+	additional_args := fp.finalize()!
+	println(additional_args.join_lines())
+	assert additional_args == []
+}


### PR DESCRIPTION
This PR fix finalize with multiple shortargs (fix #18536).

- Fix finalize with multiple shortargs.
- Add test.

```v
import os
import flag

fn main() {
	mut fp := flag.new_flag_parser(os.args)
	fp.skip_executable()
	a_bool := fp.bool('a_bool', `a`, false, '')
	println(a_bool)
	b_bool := fp.bool('b_bool', `b`, false, '')
	println(b_bool)
	c_bool := fp.bool('c_bool', `c`, false, '')
	println(c_bool)
	additional_args := fp.finalize()!
	println(additional_args.join_lines())
}

PS D:\Test\v\tt1> v run . -ab -c
true
true
true

```