### PR TITLE
vpm: fix installation of mixed modules

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -100,15 +100,19 @@ fn main() {
 			external_module_names := module_names.filter(it.starts_with('https://'))
 			vpm_module_names := module_names.filter(it !in external_module_names)
 
-			vpm_install(vpm_module_names, Source.vpm)
-
-			mut external_source := Source.git
-
-			if '--hg' in options {
-				external_source = Source.hg
+			if vpm_module_names.len > 0 {
+				vpm_install(vpm_module_names, Source.vpm)
 			}
 
-			vpm_install(external_module_names, external_source)
+			if external_module_names.len > 0 {
+				mut external_source := Source.git
+
+				if '--hg' in options {
+					external_source = Source.hg
+				}
+
+				vpm_install(external_module_names, external_source)
+			}
 		}
 		'update' {
 			vpm_update(module_names)

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -88,24 +88,27 @@ fn main() {
 				manifest := vmod.from_file('./v.mod') or { panic(err) }
 				module_names = manifest.dependencies.clone()
 			}
-			mut source := Source.vpm
-			if module_names.all(it.starts_with('https://')) {
-				source = Source.git
-			}
+
 			if '--once' in options {
 				module_names = vpm_once_filter(module_names)
+
 				if module_names.len == 0 {
 					return
 				}
 			}
-			if '--git' in options {
-				source = Source.git
-			}
+
+			external_module_names := module_names.filter(it.starts_with('https://'))
+			vpm_module_names := module_names.filter(it !in external_module_names)
+
+			vpm_install(vpm_module_names, Source.vpm)
+
+			mut external_source := Source.git
+
 			if '--hg' in options {
-				source = Source.hg
+				external_source = Source.hg
 			}
 
-			vpm_install(module_names, source)
+			vpm_install(external_module_names, external_source)
 		}
 		'update' {
 			vpm_update(module_names)


### PR DESCRIPTION
This PR fixes a way that `vpm` uses to install external (`git` and `hg`) modules when they are combined with VPM modules in `v.mod` file. Before, modules were installed as external only when all modules that need to be installed were external. With these changes, VPM modules will be installed separately from external modules.

These changes fix `Errors while incrementing the download count for` errors for external modules when they are mixed with VPM modules.

This PR also removes the handling of `--git` flag. With these changes, external modules will be treated as `git` modules and only will be treated as `hg` when `--hg` flag is present.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d90c5ae</samp>

Refactor `vpm.v` to handle external and vpm modules separately and fix '--git' option bug. This improves the vpm command and supports different sources for modules.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d90c5ae</samp>

* Refactor module name parsing and installation logic ([link](https://github.com/vlang/v/pull/18545/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L91-R111))
