### PR TITLE
all: minor cleanup for ast.clear_flags()

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3935,7 +3935,7 @@ fn (mut g Gen) unlock_locks() {
 
 fn (mut g Gen) map_init(node ast.MapInit) {
 	unwrap_key_typ := g.unwrap_generic(node.key_type)
-	unwrap_val_typ := g.unwrap_generic(node.value_type).clear_flags(.result)
+	unwrap_val_typ := g.unwrap_generic(node.value_type).clear_flag(.result)
 	key_typ_str := g.typ(unwrap_key_typ)
 	value_typ_str := g.typ(unwrap_val_typ)
 	value_sym := g.table.sym(unwrap_val_typ)

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -404,7 +404,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		if g.inside_return {
 			g.typ(val_type)
 		} else {
-			g.typ(val_type.clear_flags(.result))
+			g.typ(val_type.clear_flag(.result))
 		}
 	}
 	get_and_set_types := val_sym.kind in [.struct_, .map, .array]


### PR DESCRIPTION
This PR makes a minor cleanup for ast.clear_flags().

- Using `clear_flag(.result)` instead of `clear_flags(.result)` .