### PR TITLE
net.html: fix semantic inconsistencies of tag retrieving functions

### DIFF
--- a/examples/web_crawler/web_crawler.v
+++ b/examples/web_crawler/web_crawler.v
@@ -12,8 +12,8 @@ fn main() {
 	}
 	// html.parse() parses and returns the DOM from the given text.
 	mut doc := html.parse(resp.body)
-	// html.DocumentObjectModel.get_tag_by_attribute_value() retrieves all the tags in the document that has the given attribute name and value.
-	tags := doc.get_tag_by_attribute_value('class', 'list_article_item')
+	// html.DocumentObjectModel.get_tags_by_attribute_value() retrieves all tags in the document that have the given attribute name and value.
+	tags := doc.get_tags_by_attribute_value('class', 'list_article_item')
 	for tag in tags {
 		el := tag.children[1].children[0].children[0].children[0]
 		href := el.attributes['href'] or { panic('key not found') }

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -21,6 +21,11 @@ mut:
 	debug_file     os.File
 }
 
+[params]
+pub struct GetTagsOptions {
+	name string
+}
+
 [if debug_html ?]
 fn (mut dom DocumentObjectModel) print_debug(data string) {
 	if data.len > 0 {
@@ -174,9 +179,12 @@ pub fn (dom DocumentObjectModel) get_tag(name string) []&Tag {
 	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
 }
 
-// get_tags retrieves all tags in the document that have the given tag name.
-pub fn (dom DocumentObjectModel) get_tags(name string) []&Tag {
-	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
+// get_tags returns all tags stored in the document.
+pub fn (dom DocumentObjectModel) get_tags(options GetTagsOptions) []&Tag {
+	if options.name != '' {
+		return if options.name in dom.tag_type { dom.tag_type[options.name] } else { []&Tag{} }
+	}
+	return dom.all_tags
 }
 
 // get_tags_by_class_name retrieves all tags recursively in the document root that have the given class name(s).
@@ -214,9 +222,4 @@ pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, val
 	} else {
 		[]&Tag{}
 	}
-}
-
-// get_tags returns all tags stored in the document.
-pub fn (dom DocumentObjectModel) get_all_tags() []&Tag {
-	return dom.all_tags
 }

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -163,25 +163,9 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 	dom.root = tag_list[0]
 }
 
-// get_tag_by_attribute_value retrieves all tags in the document that have the given attribute name and value.
-[deprecated: 'use get_tags_by_attribute_value instead']
-pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, value string) []&Tag {
-	location := dom.where_is(value, name)
-	return if dom.tag_attributes[name].len > location {
-		dom.tag_attributes[name][location]
-	} else {
-		[]&Tag{}
-	}
-}
-
-// get_tags_by_attribute_value retrieves all tags in the document that have the given attribute name and value.
-pub fn (mut dom DocumentObjectModel) get_tags_by_attribute_value(name string, value string) []&Tag {
-	location := dom.where_is(value, name)
-	return if dom.tag_attributes[name].len > location {
-		dom.tag_attributes[name][location]
-	} else {
-		[]&Tag{}
-	}
+// get_root returns the root of the document.
+pub fn (dom DocumentObjectModel) get_root() &Tag {
+	return dom.root
 }
 
 // get_tag retrieves all tags in the document that have the given tag name.
@@ -195,6 +179,11 @@ pub fn (dom DocumentObjectModel) get_tags(name string) []&Tag {
 	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
 }
 
+// get_tags_by_class_name retrieves all tags recursively in the document root that have the given class name(s).
+pub fn (dom DocumentObjectModel) get_tags_by_class_name(names ...string) []&Tag {
+	return dom.root.get_tags_by_class_name(...names)
+}
+
 // get_tag_by_attribute retrieves all tags in the document that have the given attribute name.
 [deprecated: 'use get_tags_by_attribute instead']
 pub fn (dom DocumentObjectModel) get_tag_by_attribute(name string) []&Tag {
@@ -206,17 +195,28 @@ pub fn (dom DocumentObjectModel) get_tags_by_attribute(name string) []&Tag {
 	return if name in dom.all_attributes { dom.all_attributes[name] } else { []&Tag{} }
 }
 
-// get_root returns the root of the document.
-pub fn (dom DocumentObjectModel) get_root() &Tag {
-	return dom.root
+// get_tags_by_attribute_value retrieves all tags in the document that have the given attribute name and value.
+pub fn (mut dom DocumentObjectModel) get_tags_by_attribute_value(name string, value string) []&Tag {
+	location := dom.where_is(value, name)
+	return if dom.tag_attributes[name].len > location {
+		dom.tag_attributes[name][location]
+	} else {
+		[]&Tag{}
+	}
+}
+
+// get_tag_by_attribute_value retrieves all tags in the document that have the given attribute name and value.
+[deprecated: 'use get_tags_by_attribute_value instead']
+pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, value string) []&Tag {
+	location := dom.where_is(value, name)
+	return if dom.tag_attributes[name].len > location {
+		dom.tag_attributes[name][location]
+	} else {
+		[]&Tag{}
+	}
 }
 
 // get_tags returns all tags stored in the document.
 pub fn (dom DocumentObjectModel) get_all_tags() []&Tag {
 	return dom.all_tags
-}
-
-// get_tags_by_class_name retrieves all tags recursively in the document root that have the given class name(s).
-pub fn (dom DocumentObjectModel) get_tags_by_class_name(names ...string) []&Tag {
-	return dom.root.get_tags_by_class_name(...names)
 }

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -164,6 +164,7 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 }
 
 // get_tag_by_attribute_value retrieves all the tags in the document that has the given attribute name and value.
+[deprecated: 'use get_tags_by_attribute_value instead']
 pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, value string) []&Tag {
 	location := dom.where_is(value, name)
 	return if dom.tag_attributes[name].len > location {
@@ -173,13 +174,35 @@ pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, val
 	}
 }
 
+// get_tags_by_attribute_value retrieves all the tags in the document that has the given attribute name and value.
+pub fn (mut dom DocumentObjectModel) get_tags_by_attribute_value(name string, value string) []&Tag {
+	location := dom.where_is(value, name)
+	return if dom.tag_attributes[name].len > location {
+		dom.tag_attributes[name][location]
+	} else {
+		[]&Tag{}
+	}
+}
+
 // get_tag retrieves all the tags in the document that has the given tag name.
+[deprecated: 'use get_tags instead']
 pub fn (dom DocumentObjectModel) get_tag(name string) []&Tag {
 	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
 }
 
+// get_tags retrieves all the tags in the document that has the given tag name.
+pub fn (dom DocumentObjectModel) get_tags(name string) []&Tag {
+	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
+}
+
 // get_tag_by_attribute retrieves all the tags in the document that has the given attribute name.
+[deprecated: 'use get_tags_by_attribute instead']
 pub fn (dom DocumentObjectModel) get_tag_by_attribute(name string) []&Tag {
+	return if name in dom.all_attributes { dom.all_attributes[name] } else { []&Tag{} }
+}
+
+// get_tags_by_attribute retrieves all the tags in the document that has the given attribute name.
+pub fn (dom DocumentObjectModel) get_tags_by_attribute(name string) []&Tag {
 	return if name in dom.all_attributes { dom.all_attributes[name] } else { []&Tag{} }
 }
 
@@ -189,7 +212,7 @@ pub fn (dom DocumentObjectModel) get_root() &Tag {
 }
 
 // get_tags returns all of the tags stored in the document.
-pub fn (dom DocumentObjectModel) get_tags() []&Tag {
+pub fn (dom DocumentObjectModel) get_all_tags() []&Tag {
 	return dom.all_tags
 }
 

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -163,7 +163,7 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 	dom.root = tag_list[0]
 }
 
-// get_tag_by_attribute_value retrieves all the tags in the document that has the given attribute name and value.
+// get_tag_by_attribute_value retrieves all tags in the document that have the given attribute name and value.
 [deprecated: 'use get_tags_by_attribute_value instead']
 pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, value string) []&Tag {
 	location := dom.where_is(value, name)
@@ -174,7 +174,7 @@ pub fn (mut dom DocumentObjectModel) get_tag_by_attribute_value(name string, val
 	}
 }
 
-// get_tags_by_attribute_value retrieves all the tags in the document that has the given attribute name and value.
+// get_tags_by_attribute_value retrieves all tags in the document that have the given attribute name and value.
 pub fn (mut dom DocumentObjectModel) get_tags_by_attribute_value(name string, value string) []&Tag {
 	location := dom.where_is(value, name)
 	return if dom.tag_attributes[name].len > location {
@@ -184,24 +184,24 @@ pub fn (mut dom DocumentObjectModel) get_tags_by_attribute_value(name string, va
 	}
 }
 
-// get_tag retrieves all the tags in the document that has the given tag name.
+// get_tag retrieves all tags in the document that have the given tag name.
 [deprecated: 'use get_tags instead']
 pub fn (dom DocumentObjectModel) get_tag(name string) []&Tag {
 	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
 }
 
-// get_tags retrieves all the tags in the document that has the given tag name.
+// get_tags retrieves all tags in the document that have the given tag name.
 pub fn (dom DocumentObjectModel) get_tags(name string) []&Tag {
 	return if name in dom.tag_type { dom.tag_type[name] } else { []&Tag{} }
 }
 
-// get_tag_by_attribute retrieves all the tags in the document that has the given attribute name.
+// get_tag_by_attribute retrieves all tags in the document that have the given attribute name.
 [deprecated: 'use get_tags_by_attribute instead']
 pub fn (dom DocumentObjectModel) get_tag_by_attribute(name string) []&Tag {
 	return if name in dom.all_attributes { dom.all_attributes[name] } else { []&Tag{} }
 }
 
-// get_tags_by_attribute retrieves all the tags in the document that has the given attribute name.
+// get_tags_by_attribute retrieves all tags in the document that have the given attribute name.
 pub fn (dom DocumentObjectModel) get_tags_by_attribute(name string) []&Tag {
 	return if name in dom.all_attributes { dom.all_attributes[name] } else { []&Tag{} }
 }
@@ -211,12 +211,12 @@ pub fn (dom DocumentObjectModel) get_root() &Tag {
 	return dom.root
 }
 
-// get_tags returns all of the tags stored in the document.
+// get_tags returns all tags stored in the document.
 pub fn (dom DocumentObjectModel) get_all_tags() []&Tag {
 	return dom.all_tags
 }
 
-// get_tags_by_class_name retrieves all the tags recursively in the document that has the given class name(s).
+// get_tags_by_class_name retrieves all tags recursively in the document root that have the given class name(s).
 pub fn (dom DocumentObjectModel) get_tags_by_class_name(names ...string) []&Tag {
 	return dom.root.get_tags_by_class_name(...names)
 }

--- a/vlib/net/html/dom_test.v
+++ b/vlib/net/html/dom_test.v
@@ -15,9 +15,9 @@ fn generate_temp_html() string {
 
 fn test_search_by_tag_type() {
 	dom := parse(generate_temp_html())
-	assert dom.get_tags('div').len == 4
-	assert dom.get_tags('head').len == 1
-	assert dom.get_tags('body').len == 1
+	assert dom.get_tags(name: 'div').len == 4
+	assert dom.get_tags(name: 'head').len == 1
+	assert dom.get_tags(name: 'body').len == 1
 }
 
 fn test_search_by_attribute_value() {
@@ -30,7 +30,7 @@ fn test_search_by_attribute_value() {
 
 fn test_access_parent() {
 	mut dom := parse(generate_temp_html())
-	div_tags := dom.get_tags('div')
+	div_tags := dom.get_tags(name: 'div')
 	parent := div_tags[0].parent
 	assert unsafe { parent != 0 }
 	for div_tag in div_tags {
@@ -45,7 +45,7 @@ fn test_search_by_attributes() {
 
 fn test_tags_used() {
 	dom := parse(generate_temp_html())
-	assert dom.get_all_tags().len == 9
+	assert dom.get_tags().len == 9
 }
 
 fn test_access_tag_fields() {

--- a/vlib/net/html/dom_test.v
+++ b/vlib/net/html/dom_test.v
@@ -15,22 +15,22 @@ fn generate_temp_html() string {
 
 fn test_search_by_tag_type() {
 	dom := parse(generate_temp_html())
-	assert dom.get_tag('div').len == 4
-	assert dom.get_tag('head').len == 1
-	assert dom.get_tag('body').len == 1
+	assert dom.get_tags('div').len == 4
+	assert dom.get_tags('head').len == 1
+	assert dom.get_tags('body').len == 1
 }
 
 fn test_search_by_attribute_value() {
 	mut dom := parse(generate_temp_html())
 	// println(temp_html)
 	print('Amount ')
-	println(dom.get_tag_by_attribute_value('id', 'name_0'))
-	assert dom.get_tag_by_attribute_value('id', 'name_0').len == 1
+	println(dom.get_tags_by_attribute_value('id', 'name_0'))
+	assert dom.get_tags_by_attribute_value('id', 'name_0').len == 1
 }
 
 fn test_access_parent() {
 	mut dom := parse(generate_temp_html())
-	div_tags := dom.get_tag('div')
+	div_tags := dom.get_tags('div')
 	parent := div_tags[0].parent
 	assert unsafe { parent != 0 }
 	for div_tag in div_tags {
@@ -40,17 +40,17 @@ fn test_access_parent() {
 
 fn test_search_by_attributes() {
 	dom := parse(generate_temp_html())
-	assert dom.get_tag_by_attribute('id').len == 4
+	assert dom.get_tags_by_attribute('id').len == 4
 }
 
 fn test_tags_used() {
 	dom := parse(generate_temp_html())
-	assert dom.get_tags().len == 9
+	assert dom.get_all_tags().len == 9
 }
 
 fn test_access_tag_fields() {
 	dom := parse(generate_temp_html())
-	id_tags := dom.get_tag_by_attribute('id')
+	id_tags := dom.get_tags_by_attribute('id')
 	assert id_tags[0].name == 'div'
 	assert id_tags[1].attributes['class'] == 'several-1'
 }

--- a/vlib/net/html/tag.v
+++ b/vlib/net/html/tag.v
@@ -82,7 +82,7 @@ pub fn (tag &Tag) get_tag(name string) ?&Tag {
 	return none
 }
 
-// get_tags retrieves all the child tags recursively in the tag that has the given tag name.
+// get_tags retrieves all child tags recursively in the tag that have the given tag name.
 pub fn (tag &Tag) get_tags(name string) []&Tag {
 	mut res := []&Tag{}
 	for child in tag.children {
@@ -107,7 +107,7 @@ pub fn (tag &Tag) get_tag_by_attribute(name string) ?&Tag {
 	return none
 }
 
-// get_tags_by_attribute retrieves all the child tags recursively in the tag that has the given attribute name.
+// get_tags_by_attribute retrieves all child tags recursively in the tag that have the given attribute name.
 pub fn (tag &Tag) get_tags_by_attribute(name string) []&Tag {
 	mut res := []&Tag{}
 	for child in tag.children {
@@ -132,7 +132,7 @@ pub fn (tag &Tag) get_tag_by_attribute_value(name string, value string) ?&Tag {
 	return none
 }
 
-// get_tags_by_attribute_value retrieves all the child tags recursively in the tag that has the given attribute name and value.
+// get_tags_by_attribute_value retrieves all child tags recursively in the tag that have the given attribute name and value.
 pub fn (tag &Tag) get_tags_by_attribute_value(name string, value string) []&Tag {
 	mut res := []&Tag{}
 	for child in tag.children {
@@ -164,7 +164,7 @@ pub fn (tag &Tag) get_tag_by_class_name(names ...string) ?&Tag {
 	return none
 }
 
-// get_tags_by_class_name retrieves all the child tags recursively in the tag that has the given class name(s).
+// get_tags_by_class_name retrieves all child tags recursively in the tag that have the given class name(s).
 pub fn (tag &Tag) get_tags_by_class_name(names ...string) []&Tag {
 	mut res := []&Tag{}
 	for child in tag.children {


### PR DESCRIPTION
This PR addresses semantic inconsistencies in the html module.

The main change is about consistent usage of "tag" and "tag**s**".
In `html/dom.v` we currently have functions such as `get_tag_by_attribute` and `get_tags_by_class_name`, both of which return an array of tags. While in `html/tag.v` all functions that return an array of tags are named `get_tags_...` and functions returning a single ?&Tag are named `get_tag_...`.

To achieve consistency the `get_tag_...` functions returning arrays of tags were marked as deprecated and refer to their added `get_tags_...` equivalents.
~~This includes a small breaking change for `get_tags`, which currently retrieves all the tags in the document without taking additional arguments. It was renamed to `get_all_tags`, allowing to use `get_tags(name string)` like it is done in `html/tag.v`~~

The other changes fix phrasing in the doc comments of the tag retrieving functions and sort the functions in `html/dom.v`. 

~~Since it includes a breaking change,~~ I'm not making this PR suggestion with high expectations of it being merged. Imho was just was easier and more practical to provide a potential result to review and work with, rather than starting a theoretical explanation of the problem. Trying to write this short theoretical description with it's consecutive explanations of slightly differing things and aiming not to be confusing just reinforced the practial approach for me. So the changes are hopefully clear when looking at them per commit or as a whole.