### PR TITLE
checker: add warn about non-option function

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -553,6 +553,9 @@ fn (mut c Checker) fn_type_decl(node ast.FnTypeDecl) {
 	if ret_sym.kind == .placeholder {
 		c.error('unknown type `${ret_sym.name}`', fn_info.return_type_pos)
 	}
+	if !node.typ.has_flag(.option) {
+		c.warn('you should declare it as Option instead', node.type_pos)
+	}
 	for arg in fn_info.params {
 		c.ensure_type_exists(arg.typ, arg.type_pos) or { return }
 		arg_sym := c.table.sym(arg.typ)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -135,6 +135,13 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 					c.error('cannot use Result type as map value type', field.type_pos)
 				}
 			}
+			if sym.kind == .function {
+				fn_info := sym.info as ast.FnType
+				if !field.typ.has_flag(.option) && fn_info.is_anon {
+					c.warn('direct function declaration is not recommended, use Option instead (?fn ...)',
+						field.type_pos)
+				}
+			}
 
 			if field.has_default_expr {
 				c.expected_type = field.typ

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -137,9 +137,13 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			}
 			if sym.kind == .function {
 				fn_info := sym.info as ast.FnType
-				if !field.typ.has_flag(.option) && fn_info.is_anon {
-					c.warn('direct function declaration is not recommended, use Option instead (?fn ...)',
-						field.type_pos)
+				if !field.typ.has_flag(.option) {
+					if fn_info.is_anon {
+						c.warn('you should declare it as Option instead (?fn ...)', field.type_pos)
+					} else {
+						c.warn('this is not recommended, you should use Option function instead',
+							field.type_pos)
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR is about the ROADMAP item "Handle function pointers safely, remove if function == 0 {".

```V

type MapFunc = fn () 

struct Test {
	a fn (int) // warn
	b ?fn () // ok
	c MapFunc // warn
	d ?MapFunc // ok
}

fn main() {
	t := Test{b: fn () {
		println('cool')
	}}
	z := t.b?
	z()
	dump(t)
}
```

```
$ v run bug.v
bug.v:2:16: warning: you should declare it as Option instead
    1 | 
    2 | type MapFunc = fn () 
      |                ~~~~~~
    3 | 
    4 | struct Test {
bug.v:5:4: warning: you should declare it as Option instead (?fn ...)
    3 | 
    4 | struct Test {
    5 |     a fn (int) // warn
      |       ~~~~~~~~
    6 |     b ?fn () // ok
    7 |     c MapFunc // warn
bug.v:7:4: warning: this is not recommended, you should use Option function instead
    5 |     a fn (int) // warn
    6 |     b ?fn () // ok
    7 |     c MapFunc // warn
      |       ~~~~~~~
    8 |     d ?MapFunc // ok
    9 | }
cool
[bug.v:17] t: Test{
    a: fn (int)
    b: Option(fn ())
    c: fn ()
    d: Option(none)
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 100f441</samp>

Warn about direct function types in struct fields. The change modifies `vlib/v/checker/struct.v` to emit a warning when a struct field is declared as a direct function type without the option flag, as this can cause memory issues. The change is part of a pull request to improve function type safety in V.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 100f441</samp>

* Add a warning message for direct function types in struct fields ([link](https://github.com/vlang/v/pull/18560/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88R138-R144))
