### PR TITLE
vls: fix official repository source

### DIFF
--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -249,7 +249,7 @@ fn (upd VlsUpdater) compile_from_source() ! {
 
 	if !os.exists(vls_src_folder) {
 		upd.log('Cloning VLS repo...')
-		clone_result := os.execute('${git} clone https://github.com/nedpals/vls ${vls_src_folder}')
+		clone_result := os.execute('${git} clone https://github.com/vlang/vls ${vls_src_folder}')
 		if clone_result.exit_code != 0 {
 			return error('Failed to build VLS from source. Reason: ${clone_result.output}')
 		}


### PR DESCRIPTION
`v ls --install` downloads a prebuilt release from the projects _official_ repository.
However, when compiling from source the _original_ repository is being cloned.

This PR fixes that.

:information_source:  I encountered this due to [a recent compilation issue](https://github.com/vlang/vls/pull/442) that is fixed in the official repository only.
```
$ v ls --update --source
> Cloning VLS repo...
> Compiling VLS from source...
v ls error: Cannot compile VLS from source: jsonrpc/jsonrpc.v:7:8: error: cannot import `jsonrpc` into a module with the same name
    5 |
    6 | import json
    7 | import jsonrpc
      |        ~~~~~~~
    8 | import strings
    9 | import io
> Building VLS...
v -g -o /home/werkzeug/.vls/src/bin/vls -gc boehm -cc cc -d use_libbacktrace cmd/vls
Failed building VLS
``` 
