### PR TITLE
context, vweb: add ability to set and get values on vweb.Context

### DIFF
--- a/vlib/context/context.v
+++ b/vlib/context/context.v
@@ -70,7 +70,8 @@ mut:
 	err() IError
 }
 
-pub fn (ctx Context) str() string {
+// str returns the `str` method of the corresponding Context struct
+pub fn (ctx &Context) str() string {
 	// since `Context` is an interface we have to manually match every possible
 	// type that implements `Context` if we want to use a `Context` as a field in a struct
 	// since the `Context` interface has to implement its own `str` method.

--- a/vlib/context/context.v
+++ b/vlib/context/context.v
@@ -65,10 +65,38 @@ pub interface Any {}
 pub interface Context {
 	deadline() ?time.Time
 	value(key Key) ?Any
-	str() string
 mut:
 	done() chan int
 	err() IError
+}
+
+pub fn (ctx Context) str() string {
+	// since `Context` is an interface we have to manually match every possible
+	// type that implements `Context` if we want to use a `Context` as a field in a struct
+	// since the `Context` interface has to implement its own `str` method.
+	match ctx {
+		BackgroundContext {
+			return ctx.str()
+		}
+		EmptyContext {
+			return ctx.str()
+		}
+		TodoContext {
+			return ctx.str()
+		}
+		CancelContext {
+			return ctx.str()
+		}
+		TimerContext {
+			return ctx.str()
+		}
+		ValueContext {
+			return ctx.str()
+		}
+		else {
+			return context_name(ctx)
+		}
+	}
 }
 
 fn context_name(ctx Context) string {

--- a/vlib/context/empty_test.v
+++ b/vlib/context/empty_test.v
@@ -2,7 +2,7 @@ module context
 
 fn test_background() {
 	ctx := background()
-	assert 'context.Background' == ctx.str()
+	assert '&context.Background' == ctx.str()
 	if _ := ctx.value('') {
 		panic('This should never happen')
 	}
@@ -10,7 +10,7 @@ fn test_background() {
 
 fn test_todo() {
 	ctx := todo()
-	assert 'context.TODO' == ctx.str()
+	assert '&context.TODO' == ctx.str()
 	if _ := ctx.value('') {
 		panic('This should never happen')
 	}

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -377,6 +377,63 @@ If any function of step 2 or 3 returns `false` the middleware functions that wou
 come after it are not executed and the app handler will also not be executed. You 
 can think of it as a chain.
 
+### Context values
+
+You can store a value pair in vweb's context. It is especially usefull for passing variables
+from a middleware function to the route handler.
+
+**Example**:
+```v oksyntax
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	middlewares map[string][]vweb.Middleware
+}
+
+pub fn (mut app App) index() vweb.Result {
+	// get the user or return HTTP 401
+	user := app.get_value[User]('user') or {
+		app.set_status(401, '')
+		return app.text('HTTP 401: Unauthorized')
+	}
+
+	return app.text('welcome ${user.name}')
+}
+
+fn main() {
+	vweb.run(&App{
+		middlewares: {
+			'/': [get_session]
+		}
+	}, 8080)
+}
+
+struct User {
+	session_id string
+	name       string
+}
+
+fn get_session(mut ctx vweb.Context) bool {
+	// impelement your own logic to get the user
+	user := User{
+		session_id: '123456'
+		name: 'Vweb'
+	}
+
+	// set the user
+	ctx.set_value('user', user)
+	return true
+}
+```
+
+When you visit the index page the middleware function `get_session` will run first
+This function sets a `User` value to a key `'user'`.
+We get this key in `index` and display it to the user if the `'user'` key exists.
+
+
 ### Redirect
 
 Used when you want be redirected to an url

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -433,6 +433,24 @@ When you visit the index page the middleware function `get_session` will run fir
 This function sets a `User` value to a key `'user'`.
 We get this key in `index` and display it to the user if the `'user'` key exists.
 
+#### Changing Context values
+
+By default context values are immutable when retrieved with `get_value`. If you want to 
+change the value later you have to set it again with `set_value`.
+
+**Example:**
+```v ignore
+fn change_user(mut ctx vweb.Context) bool {
+	user := User{
+		session_id: '654321'
+		name: 'tester'
+	}
+
+	// set the user
+	ctx.set_value('user', user)
+	return true
+}
+```
 
 ### Redirect
 

--- a/vlib/vweb/tests/middleware_test.v
+++ b/vlib/vweb/tests/middleware_test.v
@@ -239,6 +239,13 @@ fn test_redirect_middleware() {
 	assert received.ends_with('302 Found')
 }
 
+// Context's
+
+fn test_middleware_with_context() {
+	x := http.get('http://${localserver}/with-context') or { panic(err) }
+	assert x.body == 'b'
+}
+
 fn testsuite_end() {
 	// This test is guaranteed to be called last.
 	// It sends a request to the server to shutdown.

--- a/vlib/vweb/tests/middleware_test_server.v
+++ b/vlib/vweb/tests/middleware_test_server.v
@@ -46,6 +46,7 @@ fn main() {
 			'/admin/':        [middleware1]
 			'/other/':        [middleware1, middleware2]
 			'/redirect':      [middleware_redirect]
+			'/with-context':  [context1]
 		}
 	}
 	eprintln('>> webserver: pid: ${os.getpid()}, started on http://localhost:${http_port}/ , with maximum runtime of ${app.timeout} milliseconds.')
@@ -220,6 +221,12 @@ pub fn (mut app App) redirect_route() vweb.Result {
 	return app.text('${result}should_never_reach!')
 }
 
+['/with-context']
+pub fn (mut app App) with_context() vweb.Result {
+	a := app.get_value[string]('a') or { 'none' }
+	return app.text(a)
+}
+
 // middleware functions:
 
 pub fn (mut app App) before_request() {
@@ -254,6 +261,11 @@ fn middleware_redirect(mut ctx vweb.Context) bool {
 	ctx.conn.write_string('m_redirect') or { panic(err) }
 	ctx.redirect('/')
 	return false
+}
+
+fn context1(mut ctx vweb.Context) bool {
+	ctx.set_value('a', 'b')
+	return true
 }
 
 // utility functions:


### PR DESCRIPTION
Add the ability to add and get custom values from `vweb.Contex` using the `context` module, so it is easier to pass values between middleware and app route handlers.

In order to use the `context.Context` interface as a struct field the `str` method has to be implemented. This pr fixes this by matching the interface and returning the corresponding `str` method.

## Usage

```v
module main

import vweb

struct App {
	vweb.Context
	middlewares map[string][]vweb.Middleware
}

pub fn (mut app App) index() vweb.Result {
	// get the user or return HTTP 401
	user := app.get_value[User]('user') or {
		app.set_status(401, '')
		return app.text('HTTP 401: Unauthorized')
	}

	return app.text('welcome ${user.name}')
}

fn main() {
	vweb.run(&App{
		middlewares: {
			'/': [get_session]
		}
	}, 8080)
}

struct User {
	session_id string
	name       string
}

fn get_session(mut ctx vweb.Context) bool {
	// impelement your own logic to get the user
	user := User{
		session_id: '123456'
		name: 'Vweb'
	}

	// set the user
	ctx.set_value('user', user)
	return true
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70c11de</samp>

This pull request adds support for the `context` module in the `vweb` module, allowing web handlers and middleware functions to store and access values in a context-aware way. It also fixes a cyclic dependency error in the `context` module by changing the `str` method of the `Context` interface to a function. It updates the test cases and the documentation accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70c11de</samp>

*  Remove `str` method from `Context` interface to avoid cyclic dependency error ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-7907997ce7064274e9bf8e42246bbb56d3f86550eb209e025afb120c8b03f5f2L68))
*  Add `str` function for `Context` type to implement custom string representation for different context implementations ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-7907997ce7064274e9bf8e42246bbb56d3f86550eb209e025afb120c8b03f5f2R73-R101))
*  Update test cases for `background` and `todo` functions to reflect new `str` function for `Context` type ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-498e9c22f442b92f90b77750567add75d255bc3e2b2c4a007024c6fb32299d28L5-R5), [link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-498e9c22f442b92f90b77750567add75d255bc3e2b2c4a007024c6fb32299d28L13-R13))
*  Add `ctx` field of type `context.Context` to `vweb.Context` struct to store underlying context implementation ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R148))
*  Add `set_value` and `get_value` methods to `vweb.Context` type to provide convenient way to set and get values in context ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R382-R405))
*  Initialize `ctx` field of `vweb.Context` type with `context.background` function in `vweb.run` function to provide default context implementation ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R671))
*  Document how to use `set_value` and `get_value` methods of `vweb.Context` type in `vlib/vweb/README.md` file ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R380-R454))
*  Add route `/with-context` to `middlewares` map of `App` struct to associate middleware function `context1` with route handler `with_context` ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-610a68b85d482e140cdeaedffea77b82e0085ad1ac193f9a5be1e9686796953dR49))
*  Add route handler `with_context` to `App` struct to implement logic for `/with-context` route using `get_value` method of `vweb.Context` type ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-610a68b85d482e140cdeaedffea77b82e0085ad1ac193f9a5be1e9686796953dR224-R229))
*  Add middleware function `context1` to set value in context using `set_value` method of `vweb.Context` type ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-610a68b85d482e140cdeaedffea77b82e0085ad1ac193f9a5be1e9686796953dR266-R270))
*  Add test case `test_middleware_with_context` to test functionality of `set_value` and `get_value` methods of `vweb.Context` type ([link](https://github.com/vlang/v/pull/18564/files?diff=unified&w=0#diff-e129095332e697c754b2bc173c702b8c3fd9fb7aa4757f58b4ba08c5d9254482R242-R248))
