### PR TITLE
native: replace abs() with mathutils.abs()

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -451,10 +451,6 @@ fn (mut c Amd64) cset(op Amd64SetOp) {
 	c.g.println('set${op} al')
 }
 
-fn abs(a i64) i64 {
-	return if a < 0 { -a } else { a }
-}
-
 fn (mut c Amd64) tmp_jle(addr i64) {
 	// Calculate the relative offset to jump to
 	// (`addr` is absolute address)

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -590,7 +590,7 @@ fn (mut g Gen) write_string_with_padding(s string, max int) {
 }
 
 fn (g &Gen) abs_to_rel_addr(addr i64) int {
-	return int(abs(addr - g.buf.len)) - 1
+	return int(mu.abs(addr - g.buf.len)) - 1
 }
 
 fn (mut g Gen) try_var_offset(var_name string) int {


### PR DESCRIPTION

Removed abs() in amd64.v and replaced it in gen.v with mu.abs() because it was not architecture dependant.
(I'm not sure if I made the pullrequest right since it's my first time)

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad562e7</samp>

Refactored native code generation for AMD64 by moving `abs` function to `mu.v` and using it in `gen.v`. This reduces code duplication and improves modularity.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad562e7</samp>

*  Move `abs` function from `amd64.v` to `mu.v` for common math utilities ([link](https://github.com/vlang/v/pull/18568/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL454-L457))
*  Update `abs_to_rel_addr` function in `gen.v` to use `mu.abs` instead of local `abs` ([link](https://github.com/vlang/v/pull/18568/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L593-R593))
