### PR TITLE
checker: fix missing check for taking address of literal value member

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3906,6 +3906,9 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 				c.error('unexpected `&`, expecting expression', node.right.pos)
 			}
 		} else if mut node.right is ast.SelectorExpr {
+			if node.right.expr.is_literal() {
+				c.error('cannot take the address of a literal value', node.pos.extend(node.right.pos))
+			}
 			right_sym := c.table.sym(right_type)
 			expr_sym := c.table.sym(node.right.expr_type)
 			if expr_sym.kind == .struct_ && (expr_sym.info as ast.Struct).is_minify

--- a/vlib/v/checker/tests/prefix_addr_err.out
+++ b/vlib/v/checker/tests/prefix_addr_err.out
@@ -1,0 +1,10 @@
+vlib/v/checker/tests/prefix_addr_err.vv:2:2: warning: unused variable: `b`
+    1 | fn main() {
+    2 |     b := &'foo'.len
+      |     ^
+    3 | }
+vlib/v/checker/tests/prefix_addr_err.vv:2:7: error: cannot take the address of a literal value
+    1 | fn main() {
+    2 |     b := &'foo'.len
+      |          ~~~~~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/prefix_addr_err.vv
+++ b/vlib/v/checker/tests/prefix_addr_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	b := &'foo'.len
+}


### PR DESCRIPTION
Fix #14979

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 720f11e</samp>

Add a new error check and test case for taking the address of literals. Update the `checker` module and the `vlib/v/checker/tests` directory with the relevant files.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 720f11e</samp>

* Add a check for invalid address of operator on literals ([link](https://github.com/vlang/v/pull/18570/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R3909-R3911))
* Add a test case for the new error ([link](https://github.com/vlang/v/pull/18570/files?diff=unified&w=0#diff-8d9598fff2cbae3983af6c3ec094f4dd9ceca744b202c78cde38f02b3bd9eeaeR1-R10), [link](https://github.com/vlang/v/pull/18570/files?diff=unified&w=0#diff-852491441d50fa69d2c95b07e68ba504ee6395e55f12c1e5da721e7ee2dbdcd2R1-R3))
