### PR TITLE
cgen: fix alias to struct ptr on structinit

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -259,7 +259,8 @@ fn (mut g Gen) gen_str_for_alias(info ast.Alias, styp string, str_fn_name string
 	if str_method_expects_ptr {
 		g.auto_str_funcs.writeln('\tstring tmp_ds = ${parent_str_fn_name}(&it);')
 	} else {
-		g.auto_str_funcs.writeln('\tstring tmp_ds = ${parent_str_fn_name}(it);')
+		deref, _ := deref_kind(str_method_expects_ptr, info.parent_type.is_ptr(), info.parent_type)
+		g.auto_str_funcs.writeln('\tstring tmp_ds = ${parent_str_fn_name}(${deref}it);')
 	}
 	g.auto_str_funcs.writeln('\tstring res = str_intp(3, _MOV((StrIntpData[]){
 		{_SLIT0, ${c.si_s_code}, {.d_s = indents }},

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -22,7 +22,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		g.empty_line = false
 		g.write(s)
 	}
-	styp := g.typ(node.typ)
+	styp := g.typ(g.table.unaliased_type(node.typ)).replace('*', '')
 	mut shared_styp := '' // only needed for shared x := St{...
 	if styp in c.skip_struct_init {
 		// needed for c++ compilers
@@ -71,6 +71,10 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			g.write('{')
 		}
 	} else {
+		// alias to pointer type
+		if g.table.sym(node.typ).kind == .alias && g.table.unaliased_type(node.typ).is_ptr() {
+			g.write('&')
+		}
 		if is_multiline {
 			g.writeln('(${styp}){')
 		} else {

--- a/vlib/v/tests/alias_to_ptr_arg_test.v
+++ b/vlib/v/tests/alias_to_ptr_arg_test.v
@@ -1,0 +1,16 @@
+struct Foo {
+	name string
+	age  int
+}
+
+type Boo = &Foo
+
+fn foo(f Boo) {
+	println(f)
+	dump(f)
+}
+
+fn test_main() {
+	foo(name: '')
+	assert true
+}


### PR DESCRIPTION
Fix #17448

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c9504e</samp>

Fix C code generation and auto_str methods for structs with pointer aliases. Add a test case in `alias_to_ptr_arg_test.v` to verify the fixes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c9504e</samp>

* Fix bug in generating auto_str methods for structs with pointer alias parents ([link](https://github.com/vlang/v/pull/18571/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL262-R263))
* Fix bug in generating struct initialization code for structs with pointer alias types ([link](https://github.com/vlang/v/pull/18571/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L25-R25), [link](https://github.com/vlang/v/pull/18571/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82R74-R77))
  - Remove pointer symbol from type name when getting C type ([link](https://github.com/vlang/v/pull/18571/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L25-R25))
  - Add ampersand before struct literal to indicate pointer ([link](https://github.com/vlang/v/pull/18571/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82R74-R77))
* Add test case for alias to pointer type argument in `vlib/v/tests/alias_to_ptr_arg_test.v` ([link](https://github.com/vlang/v/pull/18571/files?diff=unified&w=0#diff-2ee5fac16092a2588266f90f7ebd5d959046b947019a0ba5f4e5564ad9f8d32fR1-R16))
