### PR TITLE
checker: implement autocast in if conditions `if n is Ident && n.is_mut { ... }`

### DIFF
--- a/vlib/v/tests/autocast_in_if_conds_test.v
+++ b/vlib/v/tests/autocast_in_if_conds_test.v
@@ -1,0 +1,24 @@
+type MySumType = S1 | S2
+
+struct S1 {
+	is_name bool
+	name    string
+}
+
+struct S2 {
+	field2 bool
+}
+
+fn test_autocast_in_if_conds() {
+	s := MySumType(S1{
+		is_name: true
+		name: 'bob'
+	})
+
+	if s is S1 && s.is_name && s.name == 'bob' {
+		println('ok')
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR implement autocast in if conditions `if n is Ident && n.is_mut { ... }`.

- Implement autocast in if conditions `if n is Ident && n.is_mut { ... }`.
- Add test.

```v
type MySumType = S1 | S2

struct S1 {
	is_name bool
	name    string
}

struct S2 {
	field2 bool
}

fn main() {
	s := MySumType(S1{
		is_name: true
		name: 'bob'
	})

	if s is S1 && s.is_name && s.name == 'bob' {
		println('ok')
		assert true
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
ok
```