### PR TITLE
parser, checker: fix static method naming and generic call

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -571,7 +571,7 @@ pub fn (f &FnDecl) get_name() string {
 }
 
 pub fn (f &CallExpr) get_name() string {
-	if f.name.is_capital() && f.name.contains('__static__') {
+	if f.name[0].is_capital() && f.name.contains('__static__') {
 		return f.name.replace('__static__', '.')
 	} else {
 		return f.name

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -562,6 +562,22 @@ pub mut:
 	pos         token.Pos // function declaration position
 }
 
+pub fn (f &FnDecl) get_name() string {
+	if f.is_static_type_method {
+		return f.name.all_after_last('__static__')
+	} else {
+		return f.name
+	}
+}
+
+pub fn (f &CallExpr) get_name() string {
+	if f.name.is_capital() && f.name.contains('__static__') {
+		return f.name.replace('__static__', '.')
+	} else {
+		return f.name
+	}
+}
+
 pub fn (f &FnDecl) new_method_with_receiver_type(new_type Type) FnDecl {
 	unsafe {
 		mut new_method := f

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -562,24 +562,6 @@ pub mut:
 	pos         token.Pos // function declaration position
 }
 
-// get_name returns the real name for the function declaration
-pub fn (f &FnDecl) get_name() string {
-	if f.is_static_type_method {
-		return f.name.all_after_last('__static__')
-	} else {
-		return f.name
-	}
-}
-
-// get_name returns the real name for the function calling
-pub fn (f &CallExpr) get_name() string {
-	if f.name.all_after_last('.')[0].is_capital() && f.name.contains('__static__') {
-		return f.name.replace('__static__', '.')
-	} else {
-		return f.name
-	}
-}
-
 pub fn (f &FnDecl) new_method_with_receiver_type(new_type Type) FnDecl {
 	unsafe {
 		mut new_method := f

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -562,6 +562,7 @@ pub mut:
 	pos         token.Pos // function declaration position
 }
 
+// get_name returns the real name for the function declaration
 pub fn (f &FnDecl) get_name() string {
 	if f.is_static_type_method {
 		return f.name.all_after_last('__static__')
@@ -570,8 +571,9 @@ pub fn (f &FnDecl) get_name() string {
 	}
 }
 
+// get_name returns the real name for the function calling
 pub fn (f &CallExpr) get_name() string {
-	if f.name.contains('__static__') {
+	if f.name.all_after_last('.')[0].is_capital() && f.name.contains('__static__') {
 		return f.name.replace('__static__', '.')
 	} else {
 		return f.name

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -571,7 +571,7 @@ pub fn (f &FnDecl) get_name() string {
 }
 
 pub fn (f &CallExpr) get_name() string {
-	if f.name[0].is_capital() && f.name.contains('__static__') {
+	if f.name.contains('__static__') {
 		return f.name.replace('__static__', '.')
 	} else {
 		return f.name

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -6,6 +6,24 @@ module ast
 import v.util
 import strings
 
+// get_name returns the real name for the function declaration
+pub fn (f &FnDecl) get_name() string {
+	if f.is_static_type_method {
+		return f.name.all_after_last('__static__')
+	} else {
+		return f.name
+	}
+}
+
+// get_name returns the real name for the function calling
+pub fn (f &CallExpr) get_name() string {
+	if f.name.all_after_last('.')[0].is_capital() && f.name.contains('__static__') {
+		return f.name.replace('__static__', '.')
+	} else {
+		return f.name
+	}
+}
+
 pub fn (node &FnDecl) modname() string {
 	if node.mod != '' {
 		return node.mod
@@ -373,18 +391,18 @@ pub fn (x Expr) str() string {
 				return '${x.left.str()}.${x.name}(${sargs})${propagate_suffix}'
 			}
 			if x.name.starts_with('${x.mod}.') {
-				return util.strip_main_name('${x.name}(${sargs})${propagate_suffix}')
+				return util.strip_main_name('${x.get_name()}(${sargs})${propagate_suffix}')
 			}
 			if x.mod == '' && x.name == '' {
 				return x.left.str() + '(${sargs})${propagate_suffix}'
 			}
 			if x.name.contains('.') {
-				return '${x.name}(${sargs})${propagate_suffix}'
+				return '${x.get_name()}(${sargs})${propagate_suffix}'
 			}
 			if x.name.contains('__static__') {
-				return '${x.mod}.${x.name}(${sargs})${propagate_suffix}'
+				return '${x.mod}.${x.get_name()}(${sargs})${propagate_suffix}'
 			}
-			return '${x.mod}.${x.name}(${sargs})${propagate_suffix}'
+			return '${x.mod}.${x.get_name()}(${sargs})${propagate_suffix}'
 		}
 		CharLiteral {
 			return '`${x.val}`'

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -17,7 +17,7 @@ pub fn (f &FnDecl) get_name() string {
 
 // get_name returns the real name for the function calling
 pub fn (f &CallExpr) get_name() string {
-	if f.name.all_after_last('.')[0].is_capital() && f.name.contains('__static__') {
+	if f.name != '' && f.name.all_after_last('.')[0].is_capital() && f.name.contains('__static__') {
 		return f.name.replace('__static__', '.')
 	} else {
 		return f.name

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -87,14 +87,14 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				// If it's a void type, it's an unknown variable, already had an error earlier.
 				return
 			}
-			c.error('assignment mismatch: ${node.left.len} variable(s) but `${right_first.name}()` returns ${right_len} value(s)',
+			c.error('assignment mismatch: ${node.left.len} variable(s) but `${right_first.get_name()}()` returns ${right_len} value(s)',
 				node.pos)
 		} else if right_first is ast.ParExpr {
 			mut right_next := right_first
 			for {
 				if mut right_next.expr is ast.CallExpr {
 					if right_next.expr.return_type == ast.void_type {
-						c.error('assignment mismatch: expected ${node.left.len} value(s) but `${right_next.expr.name}()` returns ${right_len} value(s)',
+						c.error('assignment mismatch: expected ${node.left.len} value(s) but `${right_next.expr.get_name()}()` returns ${right_len} value(s)',
 							node.pos)
 					}
 					break

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -87,7 +87,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 	}
 	if node.language == .v && !c.is_builtin_mod && !node.is_anon {
-		c.check_valid_snake_case(node.name, 'function name', node.pos)
+		c.check_valid_snake_case(node.get_name(), 'function name', node.pos)
 		if !node.is_method && node.mod == 'main' && node.short_name in c.table.builtin_pub_fns {
 			c.error('cannot redefine builtin public function `${node.short_name}`', node.pos)
 		}
@@ -944,7 +944,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				return ast.void_type
 			}
 		}
-		c.error('unknown function: ${fn_name}', node.pos)
+		c.error('unknown function: ${node.get_name()}', node.pos)
 		return ast.void_type
 	}
 	node.is_file_translated = func.is_file_translated

--- a/vlib/v/checker/tests/func_with_static_keyword_err.out
+++ b/vlib/v/checker/tests/func_with_static_keyword_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/func_with_static_keyword_err.vv:6:2: warning: unused variable: `a`
+    4 | 
+    5 | fn main() {
+    6 |     a := a__static__b()
+      |     ^
+    7 | }
+vlib/v/checker/tests/func_with_static_keyword_err.vv:6:4: error: assignment mismatch: 1 variable(s) but `a__static__b()` returns 2 value(s)
+    4 | 
+    5 | fn main() {
+    6 |     a := a__static__b()
+      |       ~~
+    7 | }

--- a/vlib/v/checker/tests/func_with_static_keyword_err.vv
+++ b/vlib/v/checker/tests/func_with_static_keyword_err.vv
@@ -1,0 +1,7 @@
+fn a__static__b() (int,int) {
+	return 1,2
+}
+
+fn main() {
+	a := a__static__b()
+}

--- a/vlib/v/checker/tests/static_method_multi_return_err.out
+++ b/vlib/v/checker/tests/static_method_multi_return_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/static_method_multi_return_err.vv:10:6: error: assignment mismatch: 1 variable(s) but `SomeStruct.static_method()` returns 2 1value(s)
+vlib/v/checker/tests/static_method_multi_return_err.vv:10:6: error: assignment mismatch: 1 variable(s) but `SomeStruct.static_method()` returns 2 value(s)
     8 | 
     9 | fn main() {
    10 |     val := SomeStruct.static_method()

--- a/vlib/v/checker/tests/static_method_multi_return_err.out
+++ b/vlib/v/checker/tests/static_method_multi_return_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/static_method_multi_return_err.vv:10:6: error: assignment mismatch: 1 variable(s) but `SomeStruct.static_method()` returns 2 1value(s)
+    8 | 
+    9 | fn main() {
+   10 |     val := SomeStruct.static_method()
+      |         ~~
+   11 |     println(val)
+   12 | }

--- a/vlib/v/checker/tests/static_method_multi_return_err.vv
+++ b/vlib/v/checker/tests/static_method_multi_return_err.vv
@@ -1,0 +1,12 @@
+struct SomeStruct {
+	name string
+}
+
+fn SomeStruct.static_method() (string, int) {
+	return 'hello', 100
+}
+
+fn main() {
+	val := SomeStruct.static_method()
+	println(val)
+}

--- a/vlib/v/checker/tests/static_method_not_found_err.out
+++ b/vlib/v/checker/tests/static_method_not_found_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/static_method_not_found_err.vv:10:9: error: unknown function: TestStruct.static_method
+    8 | 
+    9 | fn main() {
+   10 |     val := TestStruct.static_method()
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   11 |     println(val)
+   12 | }
+vlib/v/checker/tests/static_method_not_found_err.vv:11:2: error: `println` can not print void expressions
+    9 | fn main() {
+   10 |     val := TestStruct.static_method()
+   11 |     println(val)
+      |     ~~~~~~~~~~~~
+   12 | }

--- a/vlib/v/checker/tests/static_method_not_found_err.vv
+++ b/vlib/v/checker/tests/static_method_not_found_err.vv
@@ -1,0 +1,12 @@
+struct TestStruct {
+	name string
+}
+
+fn (f TestStruct) static_method() string {
+	return 'hello'
+}
+
+fn main() {
+	val := TestStruct.static_method()
+	println(val)
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2630,9 +2630,10 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
-		if p.peek_tok.kind == .lpar && (is_mod_cast || is_c_pointer_cast
-			|| is_c_type_cast || is_js_cast || is_generic_cast || (language == .v && name.len > 0
-			&& (name[0].is_capital() || (!known_var && (name in p.table.type_idxs
+		if (is_option || p.peek_tok.kind == .lpar) && (is_mod_cast
+			|| is_c_pointer_cast || is_c_type_cast || is_js_cast || is_generic_cast
+			|| (language == .v && name.len > 0 && (name[0].is_capital()
+			|| (!known_var && (name in p.table.type_idxs
 			|| name_w_mod in p.table.type_idxs))
 			|| name.all_after_last('.')[0].is_capital()))) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2630,11 +2630,11 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
-		if is_mod_cast || is_c_pointer_cast || is_c_type_cast || is_js_cast
-			|| is_generic_cast || (language == .v && name.len > 0 && (name[0].is_capital()
-			|| (!known_var && (name in p.table.type_idxs
+		if p.peek_tok.kind == .lpar && (is_mod_cast || is_c_pointer_cast
+			|| is_c_type_cast || is_js_cast || is_generic_cast || (language == .v && name.len > 0
+			&& (name[0].is_capital() || (!known_var && (name in p.table.type_idxs
 			|| name_w_mod in p.table.type_idxs))
-			|| name.all_after_last('.')[0].is_capital())) {
+			|| name.all_after_last('.')[0].is_capital()))) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`
 			// TODO handle C.stat()
 			start_pos := p.tok.pos()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2630,7 +2630,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
-		if (is_option || p.peek_tok.kind == .lpar) && (is_mod_cast
+		if (is_option || p.peek_tok.kind in [.lsbr, .lpar]) && (is_mod_cast
 			|| is_c_pointer_cast || is_c_type_cast || is_js_cast || is_generic_cast
 			|| (language == .v && name.len > 0 && (name[0].is_capital()
 			|| (!known_var && (name in p.table.type_idxs

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2630,7 +2630,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// type cast. TODO: finish
 		// if name in ast.builtin_type_names_to_idx {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
-		if (is_option || p.peek_tok.kind in [.lsbr, .lpar]) && (is_mod_cast
+		if (is_option || p.peek_tok.kind in [.lsbr, .lt, .lpar]) && (is_mod_cast
 			|| is_c_pointer_cast || is_c_type_cast || is_js_cast || is_generic_cast
 			|| (language == .v && name.len > 0 && (name[0].is_capital()
 			|| (!known_var && (name in p.table.type_idxs

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2674,7 +2674,6 @@ fn (mut p Parser) name_expr() ast.Expr {
 			p.expr_mod = ''
 			return node
 		} else {
-			// fn call
 			// fn_call
 			if is_option {
 				p.unexpected_with_pos(p.prev_tok.pos(),

--- a/vlib/v/parser/tests/method_call_receiver_err.out
+++ b/vlib/v/parser/tests/method_call_receiver_err.out
@@ -1,19 +1,19 @@
 vlib/v/parser/tests/method_call_receiver_err.vv:6:2: warning: unused variable: `s1`
-    4 |
+    4 | 
     5 | fn main() {
     6 |     s1 := S1{}
       |     ~~
-    7 |
+    7 | 
     8 |     $for method in S1.methods {
 vlib/v/parser/tests/method_call_receiver_err.vv:8:7: warning: unused variable: `method`
     6 |     s1 := S1{}
-    7 |
+    7 | 
     8 |     $for method in S1.methods {
       |          ~~~~~~
     9 |         println(S1.method_hello('yo'))
    10 |     }
-vlib/v/parser/tests/method_call_receiver_err.vv:9:11: error: unknown function: s1__static__method_hello
-    7 |
+vlib/v/parser/tests/method_call_receiver_err.vv:9:11: error: unknown function: S1.method_hello
+    7 | 
     8 |     $for method in S1.methods {
     9 |         println(S1.method_hello('yo'))
       |                 ~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/tests/generic_static_method_test.v
+++ b/vlib/v/tests/generic_static_method_test.v
@@ -1,0 +1,12 @@
+struct SomeStruct {
+	name string
+}
+
+fn SomeStruct.static_method[T]() string {
+	return 'hello'
+}
+
+fn test_main() {
+	val := SomeStruct.static_method[string]()
+	assert val == 'hello'
+}


### PR DESCRIPTION
Fix #18578
Fix #18577
Fix #18575
Fix #18576


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 392d1e1</samp>

This pull request adds support for generic static methods in V, which are methods that can be called on types without creating instances. It also fixes some bugs and improves some error messages related to static methods. It modifies the `ast`, `checker`, and `parser` modules, and adds or updates several test files.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 392d1e1</samp>

*  Add two new methods to `FnDecl` and `CallExpr` to return the real name of the function without the `__static__` prefix ([link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-7bc4f508f265a81569dbc37006a6626b7e205285be22b19ed323cb935ca9943eR9-R26))
*  Use the new methods instead of the `name` field when generating string representations and error messages for functions and expressions ([link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-7bc4f508f265a81569dbc37006a6626b7e205285be22b19ed323cb935ca9943eL376-R394), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-7bc4f508f265a81569dbc37006a6626b7e205285be22b19ed323cb935ca9943eL382-R405), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL90-R90), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL97-R97), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL90-R90), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL947-R947), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-442712a5a08d747202f6db3a939716c11dfa10471f05bb0795ace125c9d9f95cL2-R16))
*  Remove the `to_lower` call on the type name when constructing the `name` field for static methods, to preserve the original case ([link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL17-R17))
*  Use a separate variable to store the name of the function that is checked for validity and snake case, without the `__static__` prefix or the type name ([link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eR297), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL304-R312))
*  Fix a bug where some expressions that are not casts, such as static methods, are parsed as casts, by adding a new condition to the `if` statement ([link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2633-R2638))
*  Add new test files to check the error handling and the functionality of static methods, especially generic ones ([link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-1ea23f2e26705d8fb8bf19dbbf677d6b6b1aff5c819e46fd05aafb2f62e7f41cR1-R12), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-56e465671c93da22c062cb73336915971162e9e321985a7a9adc86a9c18351f5L1-R6), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-72a81cd0168269cc5d447fb80c306a8009bc7e140e712f715fde2a6caaa7d0d2R1-R7), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-bdb9f736e06c69ed64107869f36f8aa159e3f44b12549ff44a20bb742607c116L1-R11), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-94d1f6fadaee092d977157d87e640bc9fb8a3ffe3ce82d53bdd4d4087a8badd8R1-R13), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-7f9d12a70a08dc30ae4651c24f06ad4b923fd498c5ce54eaa2c5d0ebf97f4e2fL1-R11), [link](https://github.com/vlang/v/pull/18694/files?diff=unified&w=0#diff-a1354b78be8da052f4541ea863bcdccfcd1fc951f7bca5e4afdecdea8fe671d9R1-R12))
