### PR TITLE
checker,orm: skip compile-time error msg for fields tagged with `[skip]` and `[sql: '-']`

### DIFF
--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -24,6 +24,7 @@ struct User {
 	is_customer     bool
 	skipped_string  string [skip]
 	skipped_string2 string [sql: '-']
+	skipped_array	[]string [skip]
 }
 
 struct Foo {
@@ -50,6 +51,7 @@ fn test_use_struct_field_as_limit() {
 		age: 29
 		name: 'Sam'
 		skipped_string2: 'this should be ignored'
+		skipped_array: ['ignored', 'array']
 	}
 
 	sql db {
@@ -65,6 +67,7 @@ fn test_use_struct_field_as_limit() {
 	assert users[0].age == 29
 	assert users[0].skipped_string == ''
 	assert users[0].skipped_string2 == ''
+	assert users[0].skipped_array == []
 }
 
 fn test_orm() {

--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -25,6 +25,7 @@ struct User {
 	skipped_string  string   [skip]
 	skipped_string2 string   [sql: '-']
 	skipped_array   []string [skip]
+	skipped_array2  []string [sql: '-']
 }
 
 struct Foo {
@@ -52,6 +53,7 @@ fn test_use_struct_field_as_limit() {
 		name: 'Sam'
 		skipped_string2: 'this should be ignored'
 		skipped_array: ['ignored', 'array']
+		skipped_array2: ['another', 'ignored', 'array']
 	}
 
 	sql db {
@@ -67,7 +69,8 @@ fn test_use_struct_field_as_limit() {
 	assert users[0].age == 29
 	assert users[0].skipped_string == ''
 	assert users[0].skipped_string2 == ''
-	assert users[0].skipped_array == []
+	assert users[0].skipped_array == [], 'skipped because of the [skip] tag, used for both sql and json'
+	assert users[0].skipped_array2 == [], "should be skipped, because of the sql specific [sql: '-'] tag"
 }
 
 fn test_orm() {

--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -18,13 +18,13 @@ struct Module {
 
 [table: 'userlist']
 struct User {
-	id              int    [primary; sql: serial]
+	id              int      [primary; sql: serial]
 	age             int
-	name            string [sql: 'username']
+	name            string   [sql: 'username']
 	is_customer     bool
-	skipped_string  string [skip]
-	skipped_string2 string [sql: '-']
-	skipped_array	[]string [skip]
+	skipped_string  string   [skip]
+	skipped_string2 string   [sql: '-']
+	skipped_array   []string [skip]
 }
 
 struct Foo {

--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -54,6 +54,10 @@ pub fn (attrs []Attr) contains(str string) bool {
 	return attrs.any(it.name == str)
 }
 
+pub fn (attrs []Attr) contains_arg(str string, arg string) bool {
+	return attrs.any(it.has_arg && it.name == str && it.arg == arg)
+}
+
 [direct_array_access]
 pub fn (attrs []Attr) find_first(aname string) ?Attr {
 	for a in attrs {

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -334,10 +334,11 @@ fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, t
 	mut fields := []ast.StructField{}
 	for field in info.fields {
 		is_primitive := field.typ.is_string() || field.typ.is_bool() || field.typ.is_number()
-		is_struct := c.table.type_symbols[int(field.typ)].kind == .struct_
-		is_array := c.table.sym(field.typ).kind == .array
+		fsym := c.table.sym(field.typ)
+		is_struct := fsym.kind == .struct_
+		is_array := fsym.kind == .array
 		elem_sym := if is_array {
-			c.table.sym(c.table.sym(field.typ).array_info().elem_type)
+			c.table.sym(fsym.array_info().elem_type)
 		} else {
 			ast.invalid_type_symbol
 		}

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -347,8 +347,8 @@ fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, t
 	}
 
 	field_pos := c.orm_get_field_pos(sql_expr.where_expr)
-	for field in fields {
-		if c.table.sym(field.typ).kind == .array
+	for field in info.fields {
+		if c.table.sym(field.typ).kind == .array && !field.attrs.contains('skip')
 			&& c.table.sym(c.table.sym(field.typ).array_info().elem_type).is_primitive() {
 			c.add_error_detail('')
 			c.add_error_detail(' field name: `${field.name}`')

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -347,7 +347,7 @@ fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, t
 	}
 
 	field_pos := c.orm_get_field_pos(sql_expr.where_expr)
-	for field in info.fields {
+	for field in fields {
 		if c.table.sym(field.typ).kind == .array
 			&& c.table.sym(c.table.sym(field.typ).array_info().elem_type).is_primitive() {
 			c.add_error_detail('')

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -330,26 +330,26 @@ fn (mut c Checker) check_orm_struct_field_attributes(field ast.StructField) {
 }
 
 fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, table_name string, sql_expr ast.SqlExpr) []ast.StructField {
-	fields := info.fields.filter(fn [mut c] (field ast.StructField) bool {
+	field_pos := c.orm_get_field_pos(sql_expr.where_expr)
+	mut fields := []ast.StructField{}
+	for field in info.fields {
 		is_primitive := field.typ.is_string() || field.typ.is_bool() || field.typ.is_number()
 		is_struct := c.table.type_symbols[int(field.typ)].kind == .struct_
 		is_array := c.table.sym(field.typ).kind == .array
-		is_array_with_struct_elements := is_array
-			&& c.table.sym(c.table.sym(field.typ).array_info().elem_type).kind == .struct_
-		has_no_skip_attr := !field.attrs.contains('skip')
-
-		return (is_primitive || is_struct || is_array_with_struct_elements) && has_no_skip_attr
-	})
-
-	if fields.len == 0 {
-		c.orm_error('select: empty fields in `${table_name}`', pos)
-		return []ast.StructField{}
-	}
-
-	field_pos := c.orm_get_field_pos(sql_expr.where_expr)
-	for field in info.fields {
-		if c.table.sym(field.typ).kind == .array && !field.attrs.contains('skip')
-			&& c.table.sym(c.table.sym(field.typ).array_info().elem_type).is_primitive() {
+		elem_sym := if is_array {
+			c.table.sym(c.table.sym(field.typ).array_info().elem_type)
+		} else {
+			ast.invalid_type_symbol
+		}
+		is_array_with_struct_elements := is_array && elem_sym.kind == .struct_
+		has_skip_attr := field.attrs.contains('skip') || field.attrs.contains_arg('sql', '-')
+		if has_skip_attr {
+			continue
+		}
+		if is_primitive || is_struct || is_array_with_struct_elements {
+			fields << field
+		}
+		if is_array && elem_sym.is_primitive() {
 			c.add_error_detail('')
 			c.add_error_detail(' field name: `${field.name}`')
 			c.add_error_detail(' data type: `${c.table.type_to_str(field.typ)}`')
@@ -357,7 +357,9 @@ fn (mut c Checker) fetch_and_verify_orm_fields(info ast.Struct, pos token.Pos, t
 			return []ast.StructField{}
 		}
 	}
-
+	if fields.len == 0 {
+		c.orm_error('select: empty fields in `${table_name}`', pos)
+	}
 	return fields
 }
 

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.out
@@ -5,16 +5,16 @@ vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:15:29: erro
       |                                   ~~~~~~~
    16 |     }!
    17 |     f := sql db {
-Details:
+Details: 
  field name: `example`
  data type: `[]u8`
-vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:18:34: error: V ORM: does not support array of primitive types
+vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv:18:30: error: V ORM: does not support array of primitive types
    16 |     }!
    17 |     f := sql db {
-   18 |             select from Example where (example == bytes)
-      |                                        ~~~~~~~
-   19 |         }!
+   18 |         select from Example where (example == bytes)
+      |                                    ~~~~~~~
+   19 |     }!
    20 |     print(e)
-Details:
+Details: 
  field name: `example`
  data type: `[]u8`

--- a/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv
+++ b/vlib/v/checker/tests/orm_where_clause_unsupported_field_types_err.vv
@@ -15,8 +15,8 @@ fn main() {
 		select from Example where example == bytes
 	}!
 	f := sql db {
-    		select from Example where (example == bytes)
-    	}!
+		select from Example where (example == bytes)
+	}!
 	print(e)
 	print(f)
 }


### PR DESCRIPTION
small fix to check for unsupported field data only for relevant fields
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 554a778</samp>

Fixed a bug in the ORM module that caused incorrect array type checking in SQL expressions. Renamed a variable in `orm_check_sql_expr` to avoid confusion.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 554a778</samp>

* Fix bug where wrong fields were used to check array types in SQL expressions ([link](https://github.com/vlang/v/pull/18700/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L350-R350))
