### PR TITLE
checker: fix autocast in complex if condtions 2

### DIFF
--- a/vlib/v/tests/autocast_in_if_conds_3_test.v
+++ b/vlib/v/tests/autocast_in_if_conds_3_test.v
@@ -1,0 +1,45 @@
+type MySumType = S1 | S2
+
+struct Info {
+	name string
+}
+
+struct Node {
+	left MySumType
+}
+
+struct S1 {
+	is_info bool
+	info    Info
+}
+
+fn (s1 S1) is_info() bool {
+	return s1.is_info
+}
+
+struct S2 {
+	field2 string
+}
+
+fn get_name(name string) string {
+	return name
+}
+
+fn test_autocast_in_if_conds() {
+	node := Node{
+		left: MySumType(S1{
+			is_info: false
+			info: Info{'foo'}
+		})
+	}
+
+	a := 22
+
+	if a > 0 && node.left is S1 && !node.left.is_info && get_name(node.left.info.name) == 'foo'
+		&& !node.left.is_info() {
+		println('ok')
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix autocast in complex if condtions 2.

- Fix autocast in complex if condtions 2.
- Add test.

```v
type MySumType = S1 | S2

struct Info {
	name string
}

struct Node {
	left MySumType
}

struct S1 {
	is_info bool
	info    Info
}

fn (s1 S1) is_info() bool {
	return s1.is_info
}

struct S2 {
	field2 string
}

fn get_name(name string) string {
	return name
}

fn main() {
	node := Node{
		left: MySumType(S1{
			is_info: false
			info: Info{'foo'}
		})
	}

	a := 22

	if a > 0 && node.left is S1 && !node.left.is_info && get_name(node.left.info.name) == 'foo'
		&& !node.left.is_info() {
		println('ok')
	}
}

PS D:\Test\v\tt1> v run .
ok
```