### PR TITLE
native: inital support for aliased types

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1401,7 +1401,7 @@ fn (mut c Amd64) clear_reg(reg Amd64Register) {
 			c.g.write8(0xe4)
 		}
 		else {
-			c.g.n_error('unhandled mov ${reg}, ${reg}')
+			c.g.n_error('unhandled xor ${reg}, ${reg}')
 		}
 	}
 	c.g.println('xor ${reg}, ${reg}')

--- a/vlib/v/gen/native/arm64.v
+++ b/vlib/v/gen/native/arm64.v
@@ -320,6 +320,10 @@ pub fn (mut c Arm64) gen_arm64_exit(expr ast.Expr) {
 	c.svc()
 }
 
+fn (mut c Arm64) address_size() int {
+	return 8
+}
+
 fn (mut c Arm64) gen_print(s string, fd int) {
 	panic('Arm64.gen_print() is not implemented')
 }

--- a/vlib/v/gen/native/expr.v
+++ b/vlib/v/gen/native/expr.v
@@ -49,7 +49,7 @@ fn (mut g Gen) expr(node ast.Expr) {
 					} else if var.typ.is_pure_float() {
 						g.code_gen.load_fp_var(node as ast.Ident)
 					} else {
-						ts := g.table.sym(var.typ)
+						ts := g.table.sym(g.unwrap(var.typ))
 						match ts.info {
 							ast.Struct {
 								g.code_gen.lea_var_to_reg(g.code_gen.main_reg(), g.get_var_offset(node.name))

--- a/vlib/v/gen/native/stmt.v
+++ b/vlib/v/gen/native/stmt.v
@@ -93,6 +93,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.Import {} // do nothing here
 		ast.StructDecl {}
 		ast.EnumDecl {}
+		ast.TypeDecl {}
 		else {
 			eprintln('native.stmt(): bad node: ' + node.type_name())
 		}

--- a/vlib/v/gen/native/tests/struct.vv
+++ b/vlib/v/gen/native/tests/struct.vv
@@ -58,6 +58,52 @@ fn struct_test() {
 	assert e.a == 3
 }
 
+type AliasedStruct = Mutable
+type AliasedPointer = &Mutable
+
+fn alias_test() {
+	mut a := AliasedStruct{1}
+	a.a = 2
+	assert a.a == 2
+	mut b := &a
+	b.a = 3
+	assert a.a == 3
+
+	c := AliasedPointer{2}
+	assert c.a == 2
+}
+
+fn init_size28() Size28 {
+	return Size28{1, 2, 3, 4, 5, 6, 7}
+}
+type AliasedSize28 = Size28
+
+fn init_aliased() AliasedSize28 {
+	return AliasedSize28{1, 2, 3, 4, 5, 6, 7}
+}
+
+fn return_test() {
+	a := init_size28()
+	assert a.a == 1
+	assert a.b == 2
+	assert a.c == 3
+	assert a.d == 4
+	assert a.e == 5
+	assert a.f == 6
+	assert a.g == 7
+
+	b := init_aliased()
+	assert b.a == 1
+	assert b.b == 2
+	assert b.c == 3
+	assert b.d == 4
+	assert b.e == 5
+	assert b.f == 6
+	assert b.g == 7
+}
+
 fn main() {
 	struct_test()
+	return_test()
+	alias_test()
 }


### PR DESCRIPTION
This PR adds support for aliased data types. 

> **Note**
> There are probably still some places where a `g.unwrap(type)` call is needed, but we will discover them as we go.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 184156c</samp>

This pull request refactors the native code generator to support different architectures and handle type aliases more consistently and robustly. It introduces a new `unwrap` function and a new `address_size` method to simplify the code generation logic and error handling. It also adds some new test cases and error messages to improve the quality and coverage of the native backend.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 184156c</samp>

*  Add a new method `address_size` to the `CodeGen` interface and its implementations `Amd64` and `Arm64` to return the size of an address in bytes for the target architecture ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5R69), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cR97-R100), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-adbd41fc3b79a905013a0687dac2fa118ea4d8f000879c62dd3a785296ac56a9R323-R326))
* Introduce a new function `unwrap` that resolves any type aliases and returns the underlying type ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L618-R629))
  - `mov_reg_to_var` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL596-R639), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL688-R694))
  - `mov_var_to_reg` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL3780-R3790), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL3824-R3834), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-2c72949f2e9639a908055366823bfe6f73ef841f6c0e5f1f1bc15d8e72d73f66L52-R52))
  - `assign_var` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL2008-R2016), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL2017-R2026))
  - `gen_return` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL2364-R2373))
  - `gen_var_decl` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL3388-R3398), [link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL3417-R3432))
  - `get_field_offset` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L612-R613))
  - `get_type_align` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L702-R709))
  - `mov_reg_to_var` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL642-R648))
  - `assign_var` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL2026-R2035))
  - `gen_var_decl` ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cL3433-R3445))
* Simplify the `get_ident_var` method by removing the redundant `typ` variable and returning the `LocalVar` struct directly ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L240-R243))
* Add a new case for `ast.TypeDecl` in the `gen_stmt` method to handle type declarations in the native backend ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-3a07656e079e507a2d92b0d449fd0a69f87b102356e78c48e22a10152dfa9befR96))
* Add some new test cases to the `struct.vv` file to test the handling of type aliases, pointers, and return values in the native backend ([link](https://github.com/vlang/v/pull/18703/files?diff=unified&w=0#diff-af025e4a9f395ee43e02d32c0fad9e0715ef84044118e2cf31b5292a3b3268b3L61-R108))
