### PR TITLE
checker: fix generic infix expr type mismatch error

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -734,6 +734,14 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 
 	// Dual sides check (compatibility check)
 	if node.left !is ast.ComptimeCall && node.right !is ast.ComptimeCall {
+		if left_type.has_flag(.generic) {
+			left_type = c.unwrap_generic(left_type)
+			left_sym = c.table.sym(left_type)
+		}
+		if right_type.has_flag(.generic) {
+			right_type = c.unwrap_generic(right_type)
+			right_sym = c.table.sym(right_type)
+		}
 		if !(c.symmetric_check(left_type, right_type) && c.symmetric_check(right_type, left_type))
 			&& !c.pref.translated && !c.file.is_translated && !node.left.is_auto_deref_var()
 			&& !node.right.is_auto_deref_var() {

--- a/vlib/v/checker/tests/generic_eq_wrong_type.err.out
+++ b/vlib/v/checker/tests/generic_eq_wrong_type.err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/generic_eq_wrong_type.err.vv:9:13: error: infix expr: cannot use `string` (right expression) as `rune`
+    7 |         if ztest == `\n` {
+    8 |             println('${z}: \\n')
+    9 |         } else if ztest == '\r' {
+      |                   ~~~~~~~~~~~~~
+   10 |             println('${z}: \\r')
+   11 |         } else {

--- a/vlib/v/checker/tests/generic_eq_wrong_type.err.vv
+++ b/vlib/v/checker/tests/generic_eq_wrong_type.err.vv
@@ -1,0 +1,24 @@
+struct Scanner[T] {
+	contents []T
+}
+
+pub fn (s Scanner[T]) tokenize() {
+	for z, ztest in s.contents {
+		if ztest == `\n` {
+			println('${z}: \\n')
+		} else if ztest == '\r' {
+			println('${z}: \\r')
+		} else {
+			println('${z}: ${ztest}')
+		}
+	}
+}
+
+pub fn new_scanner[T](contents []T) Scanner[T] {
+	return Scanner[T]{contents}
+}
+
+fn main() {
+	s := new_scanner([`\n`, `b`])
+	s.tokenize()
+}


### PR DESCRIPTION
Closes #14061

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10b4cbb</samp>

This pull request adds a checker for generic types in infix expressions and a test case for the error message when comparing generic values with wrong types. It modifies `vlib/v/checker/infix.v` and adds `vlib/v/checker/tests/generic_eq_wrong_type.err.out` and `vlib/v/checker/tests/generic_eq_wrong_type.err.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 10b4cbb</samp>

* Add a check for generic types in infix expressions and unwrap them to their underlying types ([link](https://github.com/vlang/v/pull/18706/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7R737-R744))
* Add a test case for the error message when comparing a generic value with a wrong type using a generic `Scanner` struct ([link](https://github.com/vlang/v/pull/18706/files?diff=unified&w=0#diff-651c20c68c7f3a0bae0fb4ff015c497c1148cae52ae7e577e5a580b4317625e2R1-R7), [link](https://github.com/vlang/v/pull/18706/files?diff=unified&w=0#diff-80b464b019fd185835d832dfd89717ecf38589d6c4c3cc05719d47740845ce15R1-R24))
* Add the source code for the test case in `vlib/v/checker/tests/generic_eq_wrong_type.err.vv` ([link](https://github.com/vlang/v/pull/18706/files?diff=unified&w=0#diff-80b464b019fd185835d832dfd89717ecf38589d6c4c3cc05719d47740845ce15R1-R24))
