### PR TITLE
cgen: minor cleanup in ref_or_deref_arg()

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2173,7 +2173,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 				g.expr(arg.expr)
 				return
 			} else if arg_sym.kind == .interface_ && exp_sym.kind == .interface_
-				&& (arg.expr is ast.Ident || arg.expr is ast.SelectorExpr) {
+				&& arg.expr in [ast.Ident, ast.SelectorExpr] {
 				g.write('&/*iface*/')
 				g.expr(arg.expr)
 				return


### PR DESCRIPTION
This PR makes a minor cleanup in ref_or_deref_arg().

- `arg.expr is ast.Ident || arg.expr is ast.SelectorExpr` -> `arg.expr in [ast.Ident, ast.SelectorExpr]`