### PR TITLE
rand: Fix edge case when bit length is 31 and 63. Add unit tests

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -55,7 +55,7 @@ pub fn (mut rng PRNG) u32n(max u32) !u32 {
 	// the closest power of two. Then we loop until we find
 	// an int in the required range
 	bit_len := bits.len_32(max)
-	if bit_len == 32 {
+	if _unlikely_(bit_len == 32) {
 		for {
 			value := rng.u32()
 			if value < max {
@@ -63,7 +63,11 @@ pub fn (mut rng PRNG) u32n(max u32) !u32 {
 			}
 		}
 	} else {
-		mask := (u32(1) << (bit_len + 1)) - 1
+		mask := if _unlikely_(bit_len == 31) {
+			u32(0x7FFFFFFF)
+		} else {
+			(u32(1) << (bit_len + 1)) - 1
+		}
 		for {
 			value := rng.u32() & mask
 			if value < max {
@@ -81,7 +85,7 @@ pub fn (mut rng PRNG) u64n(max u64) !u64 {
 		return error('max must be positive integer')
 	}
 	bit_len := bits.len_64(max)
-	if bit_len == 64 {
+	if _unlikely_(bit_len == 64) {
 		for {
 			value := rng.u64()
 			if value < max {
@@ -89,7 +93,11 @@ pub fn (mut rng PRNG) u64n(max u64) !u64 {
 			}
 		}
 	} else {
-		mask := (u64(1) << (bit_len + 1)) - 1
+		mask := if _unlikely_(bit_len == 63) {
+			u64(0x7FFFFFFFFFFFFFFF)
+		} else {
+			(u64(1) << (bit_len + 1)) - 1
+		}
 		for {
 			value := rng.u64() & mask
 			if value < max {

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -454,3 +454,17 @@ fn test_element2() {
 		assert 4 != e
 	}
 }
+
+fn test_proper_masking() {
+	a := []int{len: 10, init: index * 0 + rand.intn(1073741823)!}
+	assert a != [0].repeat(10)
+
+	b := []int{len: 10, init: index * 0 + rand.intn(1073741824)!}
+	assert b != [0].repeat(10)
+
+	c := []i64{len: 10, init: index * 0 + rand.i64n(i64(4611686018427387903))!}
+	assert c != [i64(0)].repeat(10)
+
+	d := []i64{len: 10, init: index * 0 + rand.i64n(i64(4611686018427387904))!}
+	assert d != [i64(0)].repeat(10)
+}

--- a/vlib/rand/random_numbers_test.v
+++ b/vlib/rand/random_numbers_test.v
@@ -456,15 +456,21 @@ fn test_element2() {
 }
 
 fn test_proper_masking() {
-	a := []int{len: 10, init: index * 0 + rand.intn(1073741823)!}
-	assert a != [0].repeat(10)
+	under32 := []int{len: 10, init: index * 0 + rand.intn(1073741823)!}
+	assert under32 != [0].repeat(10)
 
-	b := []int{len: 10, init: index * 0 + rand.intn(1073741824)!}
-	assert b != [0].repeat(10)
+	over32 := []int{len: 10, init: index * 0 + rand.intn(1073741824)!}
+	assert over32 != [0].repeat(10)
 
-	c := []i64{len: 10, init: index * 0 + rand.i64n(i64(4611686018427387903))!}
-	assert c != [i64(0)].repeat(10)
+	under64 := []i64{len: 10, init: index * 0 + rand.i64n(i64(4611686018427387903))!}
+	assert under64 != [i64(0)].repeat(10)
 
-	d := []i64{len: 10, init: index * 0 + rand.i64n(i64(4611686018427387904))!}
-	assert d != [i64(0)].repeat(10)
+	over64 := []i64{len: 10, init: index * 0 + rand.i64n(i64(4611686018427387904))!}
+	assert over64 != [i64(0)].repeat(10)
+
+	almost_full32 := []int{len: 10, init: index * 0 + rand.intn(2147483647)!}
+	assert almost_full32 != [0].repeat(10)
+
+	almost_full64 := []i64{len: 10, init: index * 0 + rand.i64n(i64(9223372036854775807))!}
+	assert almost_full64 != [i64(0)].repeat(10)
 }


### PR DESCRIPTION
Fixes #18712

The mask calculation in `u32n` overflows and produces 0 when the bit length is 31. This is a similar case for `u64n` when the bit length of the limit value is 63. We add a check with proper mask values for both these cases.

Unit tests are added to prevent regression.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c59415</samp>

Improved the performance and correctness of `rand.intn` and `rand.i64n` functions in `vlib/rand/rand.v` by optimizing mask calculations and adding a new test case.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c59415</samp>

*  Improve performance of `rand.intn` and `rand.i64n` by using `_unlikely_` macro and special cases for mask calculation ([link](https://github.com/vlang/v/pull/18714/files?diff=unified&w=0#diff-3c14908b443d801f4726012f3289104b28d8e662eb14d4d7698a440afd446105L58-R58), [link](https://github.com/vlang/v/pull/18714/files?diff=unified&w=0#diff-3c14908b443d801f4726012f3289104b28d8e662eb14d4d7698a440afd446105L66-R70), [link](https://github.com/vlang/v/pull/18714/files?diff=unified&w=0#diff-3c14908b443d801f4726012f3289104b28d8e662eb14d4d7698a440afd446105L84-R88), [link](https://github.com/vlang/v/pull/18714/files?diff=unified&w=0#diff-3c14908b443d801f4726012f3289104b28d8e662eb14d4d7698a440afd446105L92-R100)) in `vlib/rand/rand.v`
