### PR TITLE
checker: fix autocast in complex if conditions 3

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -864,6 +864,9 @@ fn (mut c Checker) autocast_in_if_conds(mut right_ ast.Expr, from_expr ast.Expr,
 					}
 				}
 			}
+			if right.left !is ast.Ident {
+				c.autocast_in_if_conds(mut right.left, from_expr, from_type, to_type)
+			}
 			for mut arg in right.args {
 				c.autocast_in_if_conds(mut arg.expr, from_expr, from_type, to_type)
 			}

--- a/vlib/v/tests/autocast_in_if_conds_4_test.v
+++ b/vlib/v/tests/autocast_in_if_conds_4_test.v
@@ -1,0 +1,32 @@
+type MySumType = S1 | S2
+
+struct Info {
+	name string
+}
+
+struct S1 {
+	is_info bool
+	info    Info
+}
+
+struct S2 {
+	field2 string
+}
+
+fn get_name(s1 S1) string {
+	return s1.info.name
+}
+
+fn test_autocast_in_if_conds() {
+	s := MySumType(S1{
+		is_info: false
+		info: Info{'foo'}
+	})
+
+	if s is S1 && !s.is_info && get_name(s) == 'foo' {
+		println('ok')
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This PR fix autocast in complex if conditions 3.

- Fix autocast in complex if conditions 3.
- Add test.

```v
type MySumType = S1 | S2

struct Info {
	name string
}

struct S1 {
	is_info bool
	info    Info
}

struct S2 {
	field2 string
}

fn get_name(s1 S1) string {
	return s1.info.name
}

fn main() {
	s := MySumType(S1{
		is_info: false
		info: Info{'foo'}
	})

	if s is S1 && !s.is_info && get_name(s) == 'foo' {
		println('ok')
		assert true
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
ok
```