### PR TITLE
fmt: fix formatting imported static type methods

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1828,7 +1828,12 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			name := f.short_module(node.name)
 			f.mark_import_as_used(name)
 			if node.name.contains('__static__') {
-				f.write(name.replace('__static__', '.').capitalize())
+				if name.contains('.') {
+					indx := name.index('.') or { -1 } + 1
+					f.write(name[0..indx] + name[indx..].replace('__static__', '.').capitalize())
+				} else {
+					f.write(name.replace('__static__', '.').capitalize())
+				}
 			} else {
 				f.write(name)
 			}

--- a/vlib/v/fmt/tests/static_methods_keep.vv
+++ b/vlib/v/fmt/tests/static_methods_keep.vv
@@ -1,0 +1,7 @@
+module module_fmt
+
+import mod
+
+fn main() {
+	mod.Foo.new()
+}


### PR DESCRIPTION
During formatting of static type methods from imported modules, the module name would be capitalized instead of the static method, resulting in an invalid output. This commit corrects this by formatting the static method name correctly. 



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27ba87e</samp>

Fix formatting of static methods in imported modules. Update `vlib/v/fmt/fmt.v` to correctly capitalize and replace `__static__` with a dot in module names.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27ba87e</samp>

* Fix formatting of static methods in imported modules ([link](https://github.com/vlang/v/pull/18720/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL1831-R1836))
