### PR TITLE
checker: disallow assigning `nil` to internal type struct fields

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -596,6 +596,13 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						inited_fields << struct_field.name
 					}
 				}
+				expected_type_sym := c.table.final_sym(init_field.expected_type)
+				if expected_type_sym.kind in [.string, .array, .map, .array_fixed, .chan]
+					&& init_field.expr.is_nil() && !init_field.expected_type.is_ptr()
+					&& mut init_field.expr is ast.UnsafeExpr {
+					c.error('cannot assign `nil` to struct field `${init_field.name}` with type `${expected_type_sym.name}`',
+						init_field.expr.pos.extend(init_field.expr.expr.pos()))
+				}
 			}
 			// Check uninitialized refs/sum types
 			// The variable `fields` contains two parts, the first part is the same as info.fields,

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -597,7 +597,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					}
 				}
 				expected_type_sym := c.table.final_sym(init_field.expected_type)
-				if expected_type_sym.kind in [.string, .array, .map, .array_fixed, .chan]
+				if expected_type_sym.kind in [.string, .array, .map, .array_fixed, .chan, .struct_]
 					&& init_field.expr.is_nil() && !init_field.expected_type.is_ptr()
 					&& mut init_field.expr is ast.UnsafeExpr {
 					c.error('cannot assign `nil` to struct field `${init_field.name}` with type `${expected_type_sym.name}`',

--- a/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.out
+++ b/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.out
@@ -1,0 +1,36 @@
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:12:8: error: cannot assign `nil` to struct field `name` with type `string`
+   10 |
+   11 | a := &Foo{
+   12 |     name: unsafe { nil }
+      |           ~~~~~~~~~~~~
+   13 |     name2: unsafe { nil }
+   14 |     arr: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:13:9: error: cannot assign `nil` to struct field `name2` with type `string`
+   11 | a := &Foo{
+   12 |     name: unsafe { nil }
+   13 |     name2: unsafe { nil }
+      |            ~~~~~~~~~~~~
+   14 |     arr: unsafe { nil }
+   15 |     mp: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:14:7: error: cannot assign `nil` to struct field `arr` with type `[]int`
+   12 |     name: unsafe { nil }
+   13 |     name2: unsafe { nil }
+   14 |     arr: unsafe { nil }
+      |          ~~~~~~~~~~~~
+   15 |     mp: unsafe { nil }
+   16 |     arr_fix: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:15:6: error: cannot assign `nil` to struct field `mp` with type `map[string]string`
+   13 |     name2: unsafe { nil }
+   14 |     arr: unsafe { nil }
+   15 |     mp: unsafe { nil }
+      |         ~~~~~~~~~~~~
+   16 |     arr_fix: unsafe { nil }
+   17 | }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:16:11: error: cannot assign `nil` to struct field `arr_fix` with type `[3]int`
+   14 |     arr: unsafe { nil }
+   15 |     mp: unsafe { nil }
+   16 |     arr_fix: unsafe { nil }
+      |              ~~~~~~~~~~~~
+   17 | }
+   18 | println(a)
+

--- a/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.out
+++ b/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.out
@@ -1,36 +1,42 @@
-vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:12:8: error: cannot assign `nil` to struct field `name` with type `string`
-   10 |
-   11 | a := &Foo{
-   12 |     name: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:15:8: error: cannot assign `nil` to struct field `name` with type `string`
+   13 |
+   14 | a := &Foo{
+   15 |     name: unsafe { nil }
       |           ~~~~~~~~~~~~
-   13 |     name2: unsafe { nil }
-   14 |     arr: unsafe { nil }
-vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:13:9: error: cannot assign `nil` to struct field `name2` with type `string`
-   11 | a := &Foo{
-   12 |     name: unsafe { nil }
-   13 |     name2: unsafe { nil }
-      |            ~~~~~~~~~~~~
-   14 |     arr: unsafe { nil }
-   15 |     mp: unsafe { nil }
-vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:14:7: error: cannot assign `nil` to struct field `arr` with type `[]int`
-   12 |     name: unsafe { nil }
-   13 |     name2: unsafe { nil }
-   14 |     arr: unsafe { nil }
+   16 |     bar: unsafe { nil }
+   17 |     name2: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:16:7: error: cannot assign `nil` to struct field `bar` with type `Bar`
+   14 | a := &Foo{
+   15 |     name: unsafe { nil }
+   16 |     bar: unsafe { nil }
       |          ~~~~~~~~~~~~
-   15 |     mp: unsafe { nil }
-   16 |     arr_fix: unsafe { nil }
-vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:15:6: error: cannot assign `nil` to struct field `mp` with type `map[string]string`
-   13 |     name2: unsafe { nil }
-   14 |     arr: unsafe { nil }
-   15 |     mp: unsafe { nil }
+   17 |     name2: unsafe { nil }
+   18 |     arr: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:17:9: error: cannot assign `nil` to struct field `name2` with type `string`
+   15 |     name: unsafe { nil }
+   16 |     bar: unsafe { nil }
+   17 |     name2: unsafe { nil }
+      |            ~~~~~~~~~~~~
+   18 |     arr: unsafe { nil }
+   19 |     mp: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:18:7: error: cannot assign `nil` to struct field `arr` with type `[]int`
+   16 |     bar: unsafe { nil }
+   17 |     name2: unsafe { nil }
+   18 |     arr: unsafe { nil }
+      |          ~~~~~~~~~~~~
+   19 |     mp: unsafe { nil }
+   20 |     arr_fix: unsafe { nil }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:19:6: error: cannot assign `nil` to struct field `mp` with type `map[string]string`
+   17 |     name2: unsafe { nil }
+   18 |     arr: unsafe { nil }
+   19 |     mp: unsafe { nil }
       |         ~~~~~~~~~~~~
-   16 |     arr_fix: unsafe { nil }
-   17 | }
-vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:16:11: error: cannot assign `nil` to struct field `arr_fix` with type `[3]int`
-   14 |     arr: unsafe { nil }
-   15 |     mp: unsafe { nil }
-   16 |     arr_fix: unsafe { nil }
+   20 |     arr_fix: unsafe { nil }
+   21 | }
+vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv:20:11: error: cannot assign `nil` to struct field `arr_fix` with type `[3]int`
+   18 |     arr: unsafe { nil }
+   19 |     mp: unsafe { nil }
+   20 |     arr_fix: unsafe { nil }
       |              ~~~~~~~~~~~~
-   17 | }
-   18 | println(a)
-
+   21 | }
+   22 | println(a)

--- a/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv
+++ b/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv
@@ -1,0 +1,18 @@
+type String = string
+
+struct Foo {
+	name    string
+	name2   String
+	arr     []int
+	mp      map[string]string
+	arr_fix [3]int
+}
+
+a := &Foo{
+	name: unsafe { nil }
+	name2: unsafe { nil }
+	arr: unsafe { nil }
+	mp: unsafe { nil }
+	arr_fix: unsafe { nil }
+}
+println(a)

--- a/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv
+++ b/vlib/v/checker/tests/struct_field_assign_internal_types_nil_err.vv
@@ -1,7 +1,10 @@
 type String = string
 
+struct Bar {}
+
 struct Foo {
 	name    string
+	bar 	Bar
 	name2   String
 	arr     []int
 	mp      map[string]string
@@ -10,6 +13,7 @@ struct Foo {
 
 a := &Foo{
 	name: unsafe { nil }
+	bar: unsafe { nil }
 	name2: unsafe { nil }
 	arr: unsafe { nil }
 	mp: unsafe { nil }


### PR DESCRIPTION

Closes https://github.com/vlang/v/issues/18719

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 259f65b</samp>

Add a check for assigning `nil` to struct fields with internal types and a test for it. This prevents potential memory corruption or undefined behavior.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 259f65b</samp>

*  Add a check for assigning `nil` to struct fields with internal types ([link](https://github.com/vlang/v/pull/18725/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88R599-R605))
*  Add a test source file for the new check ([link](https://github.com/vlang/v/pull/18725/files?diff=unified&w=0#diff-fbc16a466d4132daf5d4f801cad715f8a5708fdaa1077d8d061e42541ca33f67R1-R18))
*  Add a test output file for the new check ([link](https://github.com/vlang/v/pull/18725/files?diff=unified&w=0#diff-98766ab3b98fa9d6be64f189e38cf1855a90e3647886becd78bc0fe342659765R1-R36))
