### PR TITLE
term.ui, vweb, v: update deprecated functions

### DIFF
--- a/examples/term.ui/cursor_chaser.v
+++ b/examples/term.ui/cursor_chaser.v
@@ -92,5 +92,5 @@ fn main() {
 		event_fn: event
 		hide_cursor: true
 	)
-	app.tui.run()?
+	app.tui.run()!
 }

--- a/examples/term.ui/event_viewer.v
+++ b/examples/term.ui/event_viewer.v
@@ -42,5 +42,5 @@ fn main() {
 		use_alternate_buffer: false
 	)
 	println('V term.ui event viewer (press `esc` to exit)\n\n')
-	app.tui.run()?
+	app.tui.run()!
 }

--- a/examples/term.ui/pong.v
+++ b/examples/term.ui/pong.v
@@ -493,5 +493,5 @@ fn main() {
 		hide_cursor: true
 		frame_rate: 60
 	)
-	app.tui.run()?
+	app.tui.run()!
 }

--- a/examples/term.ui/rectangles.v
+++ b/examples/term.ui/rectangles.v
@@ -91,5 +91,5 @@ fn main() {
 		hide_cursor: true
 		frame_rate: 60
 	)
-	app.tui.run()?
+	app.tui.run()!
 }

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -125,7 +125,7 @@ fn main() {
 	app.mouse_pos.x = 40
 	app.mouse_pos.y = 15
 	app.ui.clear()
-	app.ui.run()?
+	app.ui.run()!
 }
 
 fn frame(mut app App) {

--- a/examples/term.ui/text_editor.v
+++ b/examples/term.ui/text_editor.v
@@ -646,5 +646,5 @@ fn main() {
 		event_fn: event
 		capture_events: true
 	)
-	a.tui.run()?
+	a.tui.run()!
 }

--- a/examples/term.ui/vyper.v
+++ b/examples/term.ui/vyper.v
@@ -468,5 +468,5 @@ fn main() {
 		hide_cursor: true
 		frame_rate: 10
 	)
-	app.termui.run()?
+	app.termui.run()!
 }

--- a/vlib/term/ui/README.md
+++ b/vlib/term/ui/README.md
@@ -39,7 +39,7 @@ fn main() {
 		frame_fn: frame
 		hide_cursor: true
 	)
-	app.tui.run()?
+	app.tui.run()!
 }
 ```
 

--- a/vlib/term/ui/input_nix.c.v
+++ b/vlib/term/ui/input_nix.c.v
@@ -44,7 +44,7 @@ fn load_title() {
 }
 
 // run sets up and starts the terminal.
-pub fn (mut ctx Context) run() ? {
+pub fn (mut ctx Context) run() ! {
 	if ctx.cfg.use_x11 {
 		ctx.fail('error: x11 backend not implemented yet')
 		exit(1)

--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -101,7 +101,7 @@ pub fn init(cfg Config) &Context {
 }
 
 // run starts the windows console or restarts if it was paused.
-pub fn (mut ctx Context) run() ? {
+pub fn (mut ctx Context) run() ! {
 	frame_time := 1_000_000 / ctx.cfg.frame_rate
 	mut init_called := false
 	mut sw := time.new_stopwatch(auto_start: false)

--- a/vlib/v/eval/interpret_test.v
+++ b/vlib/v/eval/interpret_test.v
@@ -8,9 +8,9 @@ fn test_interpret() {
 	mut bench := benchmark.new_benchmark()
 	vexe := os.getenv('VEXE')
 	vroot := os.dir(vexe)
-	os.chdir(vroot)?
+	os.chdir(vroot)!
 	dir := os.join_path(vroot, 'vlib/v/eval/testdata')
-	files := os.ls(dir)?
+	files := os.ls(dir)!
 	//
 	tests := files.filter(it.ends_with('.vv'))
 	if tests.len == 0 {
@@ -35,7 +35,7 @@ fn test_interpret() {
 			eprintln(res.output)
 			continue
 		}
-		mut expected := os.read_file('${dir}/${test_name_without_postfix}.out')?
+		mut expected := os.read_file('${dir}/${test_name_without_postfix}.out')!
 		expected = normalise_line_endings(expected)
 		mut found := normalise_line_endings(res.output)
 		found = found.trim_space()

--- a/vlib/v/gen/js/program_test.v
+++ b/vlib/v/gen/js/program_test.v
@@ -40,7 +40,7 @@ fn test_running_programs_compiled_with_the_js_backend() {
 	os.chdir(vroot) or {}
 	test_dir := 'vlib/v/gen/js/tests/testdata'
 	main_files := get_main_files_in_dir(test_dir)
-	fails := check_path(test_dir, main_files)?
+	fails := check_path(test_dir, main_files)!
 	assert fails == 0
 }
 

--- a/vlib/v/tests/generics_with_nested_external_generics_fn_test.v
+++ b/vlib/v/tests/generics_with_nested_external_generics_fn_test.v
@@ -1,10 +1,10 @@
 import rand
 
-pub fn sample[T](arr []T, k int) ?[]T {
+pub fn sample[T](arr []T, k int) ![]T {
 	mut result := arr.clone()
 
 	rand.seed([u32(1), 2]) // set seed to produce same results in order
-	rand.shuffle[T](mut result)?
+	rand.shuffle[T](mut result)!
 
 	return result[0..k]
 }

--- a/vlib/v/tests/match_aliases_test.v
+++ b/vlib/v/tests/match_aliases_test.v
@@ -1,5 +1,5 @@
 fn test_match_aliases() {
-	a := byte(97)
+	a := u8(97)
 	ret := match a {
 		`0`...`9`, `a`...`f` { 'OK' }
 		else { 'NOT OK' }

--- a/vlib/v/tests/match_expr_with_assign_sumtype_test.v
+++ b/vlib/v/tests/match_expr_with_assign_sumtype_test.v
@@ -23,7 +23,7 @@ enum State {
 	parse_operator
 }
 
-fn tokenise(args string) ?[]Value {
+fn tokenise(args string) ![]Value {
 	mut rv := []Value{}
 
 	mut state := State.expecting
@@ -34,7 +34,7 @@ fn tokenise(args string) ?[]Value {
 				match i {
 					`0`...`9` {
 						state = .parse_num
-						cur_value = int(i.str().parse_uint(10, 8)?)
+						cur_value = int(i.str().parse_uint(10, 8)!)
 					}
 					`+`, `-`, `*`, `/` {
 						state = .parse_operator
@@ -67,7 +67,7 @@ fn tokenise(args string) ?[]Value {
 			.parse_num {
 				match i {
 					`0`...`9` {
-						cur_value = 10 + int(i.str().parse_uint(10, 8)?)
+						cur_value = 10 + int(i.str().parse_uint(10, 8)!)
 					}
 					`+`, `-`, `*`, `/` {
 						state = .parse_operator
@@ -94,7 +94,7 @@ fn tokenise(args string) ?[]Value {
 					`0`...`9` {
 						state = .parse_num
 						rv << cur_value
-						cur_value = int(i.str().parse_uint(10, 8)?)
+						cur_value = int(i.str().parse_uint(10, 8)!)
 					}
 					` ` {
 						state = .expecting
@@ -111,11 +111,11 @@ fn tokenise(args string) ?[]Value {
 	return rv
 }
 
-fn parse_args(argv []string) ?Expression {
+fn parse_args(argv []string) !Expression {
 	rv := Expression{
 		val: 1
 	}
-	tokens := tokenise(argv.join(' '))?
+	tokens := tokenise(argv.join(' '))!
 
 	println(tokens)
 	assert '${tokens}' == '[Value(1), Value(add), Value(subtract), Value(multiply), Value(divide)]'

--- a/vlib/v/tests/shared_array_sort_test.v
+++ b/vlib/v/tests/shared_array_sort_test.v
@@ -16,11 +16,11 @@ fn test_sorting_shared_arrays() {
 	alarms := Alarms{}
 	utc := time.utc()
 	alarms.add(utc)
-	alarms.add(time.parse_iso8601('2022-03-01')?)
-	alarms.add(time.parse_iso8601('3001-03-01')?)
-	alarms.add(time.parse_iso8601('2002-03-01')?)
-	alarms.add(time.parse_iso8601('3002-03-01')?)
-	alarms.add(time.parse_iso8601('2021-03-01')?)
+	alarms.add(time.parse_iso8601('2022-03-01')!)
+	alarms.add(time.parse_iso8601('3001-03-01')!)
+	alarms.add(time.parse_iso8601('2002-03-01')!)
+	alarms.add(time.parse_iso8601('3002-03-01')!)
+	alarms.add(time.parse_iso8601('2021-03-01')!)
 	println(alarms)
 	lock alarms.times {
 		assert alarms.times.len == 6

--- a/vlib/v/vmod/parser_test.v
+++ b/vlib/v/vmod/parser_test.v
@@ -15,7 +15,7 @@ fn test_ok() {
 }"
 	for s in [ok_source, ok_source.replace(apos, quote), ok_source.replace('\n', '\r\n'),
 		ok_source.replace('\n', '\r\n '), ok_source.replace('\n', '\n ')] {
-		content := vmod.decode(s)?
+		content := vmod.decode(s)!
 		assert content.name == 'V'
 		assert content.description == 'The V programming language.'
 		assert content.version == '0.3.4'
@@ -24,7 +24,7 @@ fn test_ok() {
 		assert content.dependencies == []
 		assert content.unknown == {}
 	}
-	e := vmod.decode('Module{}')?
+	e := vmod.decode('Module{}')!
 	assert e.name == ''
 	assert e.description == ''
 	assert e.version == ''

--- a/vlib/vweb/csrf/csrf_test.v
+++ b/vlib/vweb/csrf/csrf_test.v
@@ -268,7 +268,7 @@ fn test_token_with_app() {
 	res := http.get('http://${localserver}/') or { panic(err) }
 
 	mut doc := html.parse(res.body)
-	inputs := doc.get_tag_by_attribute_value('type', 'hidden')
+	inputs := doc.get_tags_by_attribute_value('type', 'hidden')
 	assert inputs.len == 1
 	assert csrf_config.token_name == inputs[0].attributes['name']
 }
@@ -277,7 +277,7 @@ fn test_token_with_middleware() {
 	res := http.get('http://${localserver}/middleware_index') or { panic(err) }
 
 	mut doc := html.parse(res.body)
-	inputs := doc.get_tag_by_attribute_value('type', 'hidden')
+	inputs := doc.get_tags_by_attribute_value('type', 'hidden')
 	assert inputs.len == 1
 	assert csrf_config.token_name == inputs[0].attributes['name']
 }


### PR DESCRIPTION
This PR updates some deprecated functions.

- The `run` command for V's term ui has been updated to return a `!` result type since it does not return an actual option type.
- Tests and library code for functions that used a deprecated option return have been updated (those that ensure the option return still works have been omitted).
- vweb's occurrences of `get_tag_` functions have been updated to the recently added `get_tags_` functions.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3af2b3f</samp>

This pull request refactors and updates various parts of the V codebase to improve readability, consistency, and test coverage. It removes the use of `?` and `byte` in some files, changes some functions to use sum types instead of optionals, fixes some test failures caused by API changes, and updates the documentation and examples accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3af2b3f</samp>

*  Replace `?` operator with `!` operator in term.ui examples and related functions to panic on errors instead of propagating them ([link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-c639c88fcfb439e0f4c90ba806d3fae29a4efd1883fde6a53225c69107879486L95-R95), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-c388b7386b1efbf61d74cfc1f365e6dec2b749d390cb39fe80a9a1b0576d38f4L45-R45), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-1759ed31d6b16e573b362c8a5302fc564dad79d2169ee131e91a3b55db778ec0L496-R496), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-feed2f24620cf2f12bd35eda3332e2b6bbf36e565c9fa79fd8b6f835aaff7d1fL94-R94), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-b38e4d51f3cce385601cac4150006e8a378a45648820ad17f4c5850f511c6b91L128-R128), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-02de6676eda0d00c410aabea3270fb8a5ef3bc499032705292f20d857da9d633L649-R649), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-e80c5e3349c0cf6ea9055491624708cee4c1d8f4fc18a65de513ac9883668859L471-R471), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-ba45c8f75d8b5d00c14380e1eb3acc36ec12687228b0491ee0e0cb9fdd1d1284L47-R47))
* Update `term.ui/README.md` to reflect the code changes in the examples ([link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-0ca2c6984739147f95f495199938eb26294f396f92aa03e20c794697f10c74ecL42-R42))
* Replace `?` operator with `!` operator in test functions to fail on errors instead of propagating them ([link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-c32b290aa29c6526cc8eff84c223031621b52deeacc6a516d7408a6ae4e42408L11-R13), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-c32b290aa29c6526cc8eff84c223031621b52deeacc6a516d7408a6ae4e42408L38-R38), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-cb6f37d5b9183c071dc82215e05efb958f4d1cd987ec5b13abf956915430a737L43-R43), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-d0150629d7d0e0e9eac918145308d9269387ce4d9ee3a928905b990e0764c995L3-R7), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-d3947bfa8a1d86d74f216c70eacb63ad27e5b99e444f05f6ca5fee1c3c67e4dcL26-R26), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-d3947bfa8a1d86d74f216c70eacb63ad27e5b99e444f05f6ca5fee1c3c67e4dcL37-R37), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-d3947bfa8a1d86d74f216c70eacb63ad27e5b99e444f05f6ca5fee1c3c67e4dcL70-R70), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-d3947bfa8a1d86d74f216c70eacb63ad27e5b99e444f05f6ca5fee1c3c67e4dcL97-R97), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-d3947bfa8a1d86d74f216c70eacb63ad27e5b99e444f05f6ca5fee1c3c67e4dcL114-R118), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-4e2dfbc75cd4ce0a631760a38857adf47e7e7725c8c1e389e511cdab7636524dL19-R23), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-c4037576901bceaa4092eb1a1cf0867a40a588c2c9eb7b54b330a548fe7be358L18-R18), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-c4037576901bceaa4092eb1a1cf0867a40a588c2c9eb7b54b330a548fe7be358L27-R27))
* Replace `byte` type with `u8` type in `match_aliases_test.v` to be consistent with the rest of the V language and the `match` expression syntax ([link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-87fd16e9dfb292020f7a78a25f261598f758f4755a2103dc73d1de3521162b60L2-R2))
* Replace `get_tag_by_attribute_value` method with `get_tags_by_attribute_value` method in `csrf_test.v` to match the renamed method in the `html` module that returns a list of tags ([link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-1c14a2e50cdfb7495af0ad92a6a09486a5d4861e58fe730079c54264ad45ee37L271-R271), [link](https://github.com/vlang/v/pull/18726/files?diff=unified&w=0#diff-1c14a2e50cdfb7495af0ad92a6a09486a5d4861e58fe730079c54264ad45ee37L280-R280))
