### PR TITLE
checker: cleanup type checking functions

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4542,10 +4542,9 @@ fn (mut c Checker) trace(fbase string, message string) {
 	}
 }
 
-fn (mut c Checker) ensure_generic_type_specify_type_names(typ ast.Type, pos token.Pos) ? {
+fn (mut c Checker) ensure_generic_type_specify_type_names(typ ast.Type, pos token.Pos) {
 	if typ == 0 {
 		c.error('unknown type', pos)
-		return none
 	}
 
 	c.ensure_generic_type_level++
@@ -4555,7 +4554,6 @@ fn (mut c Checker) ensure_generic_type_specify_type_names(typ ast.Type, pos toke
 	if c.ensure_generic_type_level > checker.expr_level_cutoff_limit {
 		c.error('checker: too many levels of Checker.ensure_generic_type_specify_type_names calls: ${c.ensure_generic_type_level} ',
 			pos)
-		return none
 	}
 
 	sym := c.table.final_sym(typ)
@@ -4568,23 +4566,23 @@ fn (mut c Checker) ensure_generic_type_specify_type_names(typ ast.Type, pos toke
 	match sym.kind {
 		.function {
 			fn_info := sym.info as ast.FnType
-			c.ensure_generic_type_specify_type_names(fn_info.func.return_type, fn_info.func.return_type_pos)?
+			c.ensure_generic_type_specify_type_names(fn_info.func.return_type, fn_info.func.return_type_pos)
 			for param in fn_info.func.params {
-				c.ensure_generic_type_specify_type_names(param.typ, param.type_pos)?
+				c.ensure_generic_type_specify_type_names(param.typ, param.type_pos)
 			}
 		}
 		.array {
 			c.ensure_generic_type_specify_type_names((sym.info as ast.Array).elem_type,
-				pos)?
+				pos)
 		}
 		.array_fixed {
 			c.ensure_generic_type_specify_type_names((sym.info as ast.ArrayFixed).elem_type,
-				pos)?
+				pos)
 		}
 		.map {
 			info := sym.info as ast.Map
-			c.ensure_generic_type_specify_type_names(info.key_type, pos)?
-			c.ensure_generic_type_specify_type_names(info.value_type, pos)?
+			c.ensure_generic_type_specify_type_names(info.key_type, pos)
+			c.ensure_generic_type_specify_type_names(info.value_type, pos)
 		}
 		.sum_type {
 			info := sym.info as ast.SumType

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4618,14 +4618,12 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) {
 	if !c.is_builtin_mod && sym.kind == .struct_ && !sym.is_pub && sym.mod != c.mod {
 		c.error('struct `${sym.name}` was declared as private to module `${sym.mod}`, so it can not be used inside module `${c.mod}`',
 			pos)
-		return
 	}
 	match sym.kind {
 		.placeholder {
 			if sym.language == .v && !sym.name.starts_with('C.') {
 				c.error(util.new_suggestion(sym.name, c.table.known_type_names()).say('unknown type `${sym.name}`'),
 					pos)
-				return
 			}
 		}
 		.int_literal, .float_literal {
@@ -4638,7 +4636,6 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) {
 					'unknown type `${sym.name}`.\nDid you mean `f64`?'
 				}
 				c.error(msg, pos)
-				return
 			}
 		}
 		.function {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -524,9 +524,7 @@ fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 		}
 		// The rest of the parent symbol kinds are also allowed, since they are either primitive types,
 		// that in turn do not allow recursion, or are abstract enough so that they can not be checked at comptime:
-		else {
-			// dump(parent_typ_sym.kind)
-		}
+		else {}
 		/*
 		.voidptr, .byteptr, .charptr {}
 		.char, .rune, .bool {}

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -92,7 +92,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				c.error('cannot use unwrapped Option as capacity', node.cap_expr.pos())
 			}
 		}
-		c.ensure_type_exists(node.elem_type, node.elem_type_pos) or {}
+		c.ensure_type_exists(node.elem_type, node.elem_type_pos)
 		if node.typ.has_flag(.generic) && c.table.cur_fn != unsafe { nil }
 			&& c.table.cur_fn.generic_names.len == 0 {
 			c.error('generic struct cannot be used in non-generic function', node.pos)
@@ -108,7 +108,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 
 	if node.is_fixed {
 		c.ensure_sumtype_array_has_default_value(node)
-		c.ensure_type_exists(node.elem_type, node.elem_type_pos) or {}
+		c.ensure_type_exists(node.elem_type, node.elem_type_pos)
 		if node.elem_type.is_any_kind_of_pointer() && !c.inside_unsafe && !c.is_builtin_mod {
 			c.warn('fixed arrays of references need to be initialized right away (unless inside `unsafe`)',
 				node.pos)
@@ -367,8 +367,8 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 				}
 			}
 		}
-		c.ensure_type_exists(info.key_type, node.pos) or {}
-		c.ensure_type_exists(info.value_type, node.pos) or {}
+		c.ensure_type_exists(info.key_type, node.pos)
+		c.ensure_type_exists(info.value_type, node.pos)
 		node.key_type = info.key_type
 		node.value_type = info.value_type
 		return node.typ

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -211,7 +211,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	if node.language == .v {
 		// Make sure all types are valid
 		for mut param in node.params {
-			c.ensure_type_exists(param.typ, param.type_pos) or { return }
+			c.ensure_type_exists(param.typ, param.type_pos)
 			if reserved_type_names_chk.matches(param.name) {
 				c.error('invalid use of reserved type `${param.name}` as a parameter name',
 					param.pos)
@@ -279,7 +279,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		c.error('top level declaration cannot shadow builtin type', node.pos)
 	}
 	if node.return_type != ast.Type(0) {
-		c.ensure_type_exists(node.return_type, node.return_type_pos) or { return }
+		c.ensure_type_exists(node.return_type, node.return_type_pos)
 		if node.language == .v && node.is_method && node.name == 'str' {
 			if node.return_type != ast.string_type {
 				c.error('.str() methods should return `string`', node.pos)
@@ -980,7 +980,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			node.concrete_list_pos)
 	}
 	for concrete_type in node.concrete_types {
-		c.ensure_type_exists(concrete_type, node.concrete_list_pos) or {}
+		c.ensure_type_exists(concrete_type, node.concrete_list_pos)
 	}
 	if func.generic_names.len > 0 && node.args.len == 0 && node.concrete_types.len == 0 {
 		c.error('no argument generic function must add concrete types, e.g. foo[int]()',
@@ -1851,7 +1851,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			node.concrete_list_pos)
 	}
 	for concrete_type in node.concrete_types {
-		c.ensure_type_exists(concrete_type, node.concrete_list_pos) or {}
+		c.ensure_type_exists(concrete_type, node.concrete_list_pos)
 	}
 	if method.return_type == ast.void_type && method.is_conditional
 		&& method.ctdefine_idx != ast.invalid_type_idx {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -196,7 +196,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					} else {
 						if mut node.right is ast.ArrayInit {
 							for i, typ in node.right.expr_types {
-								c.ensure_type_exists(typ, node.right.exprs[i].pos()) or {}
+								c.ensure_type_exists(typ, node.right.exprs[i].pos())
 							}
 						}
 					}

--- a/vlib/v/checker/interface.v
+++ b/vlib/v/checker/interface.v
@@ -118,7 +118,7 @@ fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			if node.language == .v {
 				c.check_valid_snake_case(method.name, 'method name', method.pos)
 			}
-			c.ensure_type_exists(method.return_type, method.return_type_pos) or { return }
+			c.ensure_type_exists(method.return_type, method.return_type_pos)
 			if is_js {
 				mtyp := c.table.sym(method.return_type)
 				if !mtyp.is_js_compatible() {
@@ -147,7 +147,7 @@ fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 				if param.typ.has_flag(.generic) {
 					has_generic_types = true
 				}
-				c.ensure_type_exists(param.typ, param.pos) or { return }
+				c.ensure_type_exists(param.typ, param.pos)
 				if reserved_type_names_chk.matches(param.name) {
 					c.error('invalid use of reserved type `${param.name}` as a parameter name',
 						param.pos)
@@ -190,7 +190,7 @@ fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 			if node.language == .v {
 				c.check_valid_snake_case(field.name, 'field name', field.pos)
 			}
-			c.ensure_type_exists(field.typ, field.pos) or { return }
+			c.ensure_type_exists(field.typ, field.pos)
 			if field.typ.has_flag(.generic) {
 				has_generic_types = true
 			}

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -26,7 +26,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 		|| (node.cond is ast.SelectorExpr && node.cond.is_mut) {
 		c.fail_if_immutable(node.cond)
 	}
-	c.ensure_type_exists(node.cond_type, node.pos) or { return ast.void_type }
+	c.ensure_type_exists(node.cond_type, node.pos)
 	c.check_expr_opt_call(node.cond, cond_type)
 	cond_type_sym := c.table.sym(cond_type)
 	cond_is_option := cond_type.has_flag(.option)

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -26,7 +26,7 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 
 	// To avoid panics while working with `table_expr`,
 	// it is necessary to check if its type exists.
-	c.ensure_type_exists(node.table_expr.typ, node.pos) or { return ast.void_type }
+	c.ensure_type_exists(node.table_expr.typ, node.pos)
 	table_sym := c.table.sym(node.table_expr.typ)
 
 	if !c.check_orm_table_expr_type(node.table_expr) {
@@ -175,7 +175,7 @@ fn (mut c Checker) sql_stmt_line(mut node ast.SqlStmtLine) ast.Type {
 
 	// To avoid panics while working with `table_expr`,
 	// it is necessary to check if its type exists.
-	c.ensure_type_exists(node.table_expr.typ, node.pos) or { return ast.void_type }
+	c.ensure_type_exists(node.table_expr.typ, node.pos)
 	table_sym := c.table.sym(node.table_expr.typ)
 
 	if !c.check_orm_table_expr_type(node.table_expr) {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -366,7 +366,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 		c.table.unwrap_generic_type(node.typ, c.table.cur_fn.generic_names, c.table.cur_concrete_types)
 	}
 	if !is_field_zero_struct_init {
-		c.ensure_type_exists(node.typ, node.pos) or {}
+		c.ensure_type_exists(node.typ, node.pos)
 	}
 	type_sym := c.table.sym(node.typ)
 	if !c.inside_unsafe && type_sym.kind == .sum_type {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -88,8 +88,8 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if field.typ.has_flag(.result) {
 				c.error('struct field does not support storing Result', field.option_pos)
 			}
-			c.ensure_type_exists(field.typ, field.type_pos) or { return }
-			c.ensure_generic_type_specify_type_names(field.typ, field.type_pos) or { return }
+			c.ensure_type_exists(field.typ, field.type_pos)
+			c.ensure_generic_type_specify_type_names(field.typ, field.type_pos)
 			if field.typ.has_flag(.generic) {
 				has_generic_types = true
 			}


### PR DESCRIPTION
This PR cleans up two type checking functions. Since they work the same without their current return type, it has been removed. This allows for less verbosity and might improve understanding and readability where the functions are called.

- `ensure_type_exists` never returned an option or a result. The predominant ways this function was called are `c.ensure_type_exists(info.key_type, pos)?` and `c.ensure_type_exists(info.key_type, pos) or {}`. In some cases the `or` block contained a value but it would never be reached, based on the functions returns.
- `ensure_generic_type_specify_type_names` returned `none` values, but only after `c.errors`. These return values can also be omitted as far as I could see.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4322b66</samp>

This pull request refactors and simplifies the code for checking types and generics in the checker module. It removes unnecessary error handling clauses from various functions and moves the logic from different files to `checker.v` for better modularity and readability. It also adds a debug statement for type aliases.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4322b66</samp>

*  Remove redundant and unnecessary `or { return }` clauses from calls to `c.ensure_type_exists` in various checker modules ([link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L463-R463), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L527-R529), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L555-R557), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L561-R563), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L573-R575), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L760-R762), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L2488-R2490), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L2495-R2497), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L2860-R2862), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL95-R95), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL111-R111), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL370-R371), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL214-R214), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL282-R282), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL983-R983), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL1854-R1854), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-7ce933b2084bee06da6fc5e405a242310fb98e1bdadc41c0748dd2c22a21b9c7L199-R199), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-07b3bf1741b262a87dcfb7d0ac1760aedf9337bf015c086ae9e6d2f88b83552aL121-R121), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-07b3bf1741b262a87dcfb7d0ac1760aedf9337bf015c086ae9e6d2f88b83552aL150-R150), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-07b3bf1741b262a87dcfb7d0ac1760aedf9337bf015c086ae9e6d2f88b83552aL193-R193), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-b3e9e13d82c234e7953e95b8321dd2f6475a017c1985da21bb49dc46898962bfL29-R29), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L29-R29), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L178-R178), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L91-R92), [link](https://github.com/vlang/v/pull/18727/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L369-R369)). The function `ensure_type_exists` already handles the error case and returns early, so there is no need to repeat the error handling in the caller.
