### PR TITLE
ast, checker: change `check(file_ &ast.File)` to `check(mut file ast.File)`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1850,13 +1850,13 @@ pub:
 	scope        &Scope = unsafe { nil }
 	left         Expr
 	is_vweb      bool
-	vweb_tmpl    File
 	is_embed     bool
 	is_env       bool
 	env_pos      token.Pos
 	is_pkgconfig bool
 	or_block     OrExpr
 pub mut:
+	vweb_tmpl   File
 	left_type   Type
 	result_type Type
 	env_value   string

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -166,8 +166,7 @@ fn (mut c Checker) reset_checker_state_at_start_of_new_file() {
 	c.inside_if_guard = false
 }
 
-pub fn (mut c Checker) check(ast_file_ &ast.File) {
-	mut ast_file := unsafe { ast_file_ }
+pub fn (mut c Checker) check(mut ast_file ast.File) {
 	c.reset_checker_state_at_start_of_new_file()
 	c.change_current_file(ast_file)
 	for i, ast_import in ast_file.imports {
@@ -266,7 +265,7 @@ pub fn (mut c Checker) check_scope_vars(sc &ast.Scope) {
 }
 
 // not used right now
-pub fn (mut c Checker) check2(ast_file &ast.File) []errors.Error {
+pub fn (mut c Checker) check2(mut ast_file ast.File) []errors.Error {
 	c.change_current_file(ast_file)
 	for stmt in ast_file.stmts {
 		c.stmt(stmt)
@@ -290,7 +289,7 @@ pub fn (mut c Checker) check_files(ast_files []&ast.File) {
 		for i in 0 .. ast_files.len {
 			mut file := ast_files[i]
 			c.timers.start('checker_check ${file.path}')
-			c.check(file)
+			c.check(mut file)
 			if file.mod.name == 'main' {
 				files_from_main_module << file
 				has_main_mod_file = true

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -126,7 +126,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 		}
 		mut c2 := new_checker(c.table, pref2)
 		c2.comptime_call_pos = node.pos.pos
-		c2.check(node.vweb_tmpl)
+		c2.check(mut node.vweb_tmpl)
 		c.warnings << c2.warnings
 		c.errors << c2.errors
 		c.notices << c2.notices

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -446,15 +446,15 @@ pub fn (mut d Doc) generate() ! {
 		}
 		file_asts << parser.parse_file(file_path, d.table, comments_mode, d.prefs)
 	}
-	return d.file_asts(file_asts)
+	return d.file_asts(mut file_asts)
 }
 
 // file_asts has the same function as the `file_ast` function but
 // accepts an array of `ast.File` and throws an error if necessary.
-pub fn (mut d Doc) file_asts(file_asts []ast.File) ! {
+pub fn (mut d Doc) file_asts(mut file_asts []ast.File) ! {
 	mut fname_has_set := false
 	d.orig_mod_name = file_asts[0].mod.name
-	for i, file_ast in file_asts {
+	for i, mut file_ast in file_asts {
 		if d.filename.len > 0 && file_ast.path.contains(d.filename) && !fname_has_set {
 			d.filename = file_ast.path
 			fname_has_set = true
@@ -473,7 +473,7 @@ pub fn (mut d Doc) file_asts(file_asts []ast.File) ! {
 			continue
 		}
 		if file_ast.path == d.filename {
-			d.checker.check(file_ast)
+			d.checker.check(mut file_ast)
 			d.scoped_contents = d.file_ast_with_pos(file_ast, d.pos)
 		}
 		contents := d.file_ast(file_ast)

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -76,9 +76,9 @@ x := 10
 '
 	table := ast.new_table()
 	vpref := &pref.Preferences{}
-	prog := parse_file(s, table, .skip_comments, vpref)
+	mut prog := parse_file(s, table, .skip_comments, vpref)
 	mut checker_ := checker.new_checker(table, vpref)
-	checker_.check(prog)
+	checker_.check(mut prog)
 	res, _, _, _ := c.gen([prog], table, vpref)
 	println(res)
 }
@@ -100,13 +100,13 @@ fn test_one() {
 	for line in input {
 		e << parse_stmt(line, table, scope)
 	}
-	program := &ast.File{
+	mut program := &ast.File{
 		stmts: e
 		scope: scope
 		global_scope: scope
 	}
 	mut checker_ := checker.new_checker(table, vpref)
-	checker_.check(program)
+	checker_.check(mut program)
 	mut res, _, _, _ := c.gen([program], table, vpref)
 	res = res.replace('\n', '').trim_space().after('#endif')
 	println(res)
@@ -143,12 +143,12 @@ fn test_parse_expr() {
 		println('\n\nst="${s}"')
 		e << parse_stmt(s, table, scope)
 	}
-	program := &ast.File{
+	mut program := &ast.File{
 		stmts: e
 		scope: scope
 		global_scope: scope
 	}
-	chk.check(program)
+	chk.check(mut program)
 	mut res, _, _, _ := c.gen([program], table, vpref)
 	res = res.after('#endif')
 	println('========')


### PR DESCRIPTION
This PR change `check(file_ &ast.File)` to `check(mut file ast.File)`.

- Avoid `mut file := unsafe { file_ }`.