### PR TITLE
cgen: fix selector code to use interface method table on closure when needed

### DIFF
--- a/vlib/v/tests/interface_closure_test.v
+++ b/vlib/v/tests/interface_closure_test.v
@@ -1,0 +1,30 @@
+interface ITest {
+mut:
+	caller(a Test) !
+}
+
+struct Test {
+}
+
+struct Test2 {
+}
+
+fn (t2 Test2) with_reader(func fn (a Test) !) ! {
+	return func(Test{})
+}
+
+fn (t Test) caller(a Test) ! {
+	println('ok')
+}
+
+fn get() ITest {
+	return Test{}
+}
+
+fn test_main() {
+	mut a := get()
+
+	b := Test2{}
+	b.with_reader(a.caller)!
+	assert true
+}


### PR DESCRIPTION
Fix #18709

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00d25c9</samp>

Refactor and improve code generation for interface and sum type methods. Enable dynamic dispatch for interface methods.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00d25c9</samp>

*  Implement dynamic dispatch for interface methods by using a name table lookup based on the receiver type ([link](https://github.com/vlang/v/pull/18736/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3678-R3686))
*  Simplify code generation for methods on interface and sum type receivers by removing unnecessary dereferencing ([link](https://github.com/vlang/v/pull/18736/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3582-L3584), [link](https://github.com/vlang/v/pull/18736/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR3601-R3603), [link](https://github.com/vlang/v/pull/18736/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR3714-R3717))
