### PR TITLE
cgen: remove `mut mut_table := unsafe { &ast.Table(g.table) }`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -49,7 +49,6 @@ pub struct Gen {
 	enum_data_type      ast.Type // cache her to avoid map lookups
 	module_built        string
 	timers_should_print bool
-	table               &ast.Table = unsafe { nil }
 mut:
 	out                       strings.Builder
 	cheaders                  strings.Builder
@@ -81,7 +80,8 @@ mut:
 	sql_buf                   strings.Builder // for writing exprs to args via `sqlite3_bind_int()` etc
 	global_const_defs         map[string]GlobalConstDef
 	sorted_global_const_names []string
-	file                      &ast.File = unsafe { nil }
+	file                      &ast.File  = unsafe { nil }
+	table                     &ast.Table = unsafe { nil }
 	unique_file_path_hash     u64 // a hash of file.path, used for making auxilary fn generation unique (like `compare_xyz`)
 	fn_decl                   &ast.FnDecl = unsafe { nil } // pointer to the FnDecl we are currently inside otherwise 0
 	last_fn_c_name            string

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -184,7 +184,6 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					continue
 				}
 				if sfield.expected_type.has_flag(.generic) && g.cur_fn != unsafe { nil } {
-					mut mut_table := unsafe { &ast.Table(g.table) }
 					mut t_generic_names := g.table.cur_fn.generic_names.clone()
 					mut t_concrete_types := g.cur_concrete_types.clone()
 					ts := g.table.sym(node.typ)
@@ -202,15 +201,15 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 									t_concrete_types << g.cur_concrete_types[index]
 								}
 							} else {
-								if tt := mut_table.resolve_generic_to_concrete(t_typ,
-									g.table.cur_fn.generic_names, g.cur_concrete_types)
+								if tt := g.table.resolve_generic_to_concrete(t_typ, g.table.cur_fn.generic_names,
+									g.cur_concrete_types)
 								{
 									t_concrete_types << tt
 								}
 							}
 						}
 					}
-					if tt := mut_table.resolve_generic_to_concrete(sfield.expected_type,
+					if tt := g.table.resolve_generic_to_concrete(sfield.expected_type,
 						t_generic_names, t_concrete_types)
 					{
 						sfield.expected_type = tt

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -15,9 +15,8 @@ fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 		// This should have already happened in the checker, since it also calls
 		// `resolve_generic_to_concrete`. `g.table` is made non-mut to make sure
 		// no one else can accidentally mutates the table.
-		mut mut_table := unsafe { &ast.Table(g.table) }
 		if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0 {
-			if t_typ := mut_table.resolve_generic_to_concrete(typ, g.cur_fn.generic_names,
+			if t_typ := g.table.resolve_generic_to_concrete(typ, g.cur_fn.generic_names,
 				g.cur_concrete_types)
 			{
 				return t_typ
@@ -28,7 +27,7 @@ fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 				if sym.info is ast.Struct {
 					if sym.info.generic_types.len > 0 {
 						generic_names := sym.info.generic_types.map(g.table.sym(it).name)
-						if t_typ := mut_table.resolve_generic_to_concrete(typ, generic_names,
+						if t_typ := g.table.resolve_generic_to_concrete(typ, generic_names,
 							sym.info.concrete_types)
 						{
 							return t_typ
@@ -42,13 +41,13 @@ fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 			if sym.info is ast.Struct {
 				if sym.info.generic_types.len > 0 {
 					generic_names := sym.info.generic_types.map(g.table.sym(it).name)
-					if t_typ := mut_table.resolve_generic_to_concrete(typ, generic_names,
+					if t_typ := g.table.resolve_generic_to_concrete(typ, generic_names,
 						sym.info.concrete_types)
 					{
 						return t_typ
 					}
 
-					if t_typ := mut_table.resolve_generic_to_concrete(typ, generic_names,
+					if t_typ := g.table.resolve_generic_to_concrete(typ, generic_names,
 						g.cur_concrete_types)
 					{
 						return t_typ


### PR DESCRIPTION
This PR remove `mut mut_table := unsafe { &ast.Table(g.table) }`.

- Make `Gen.table` mutable.