### PR TITLE
term: fix typo in term_windows.c.v

### DIFF
--- a/vlib/term/term_windows.c.v
+++ b/vlib/term/term_windows.c.v
@@ -55,7 +55,7 @@ fn C.SetConsoleCursorPosition(handle C.HANDLE, coord C.COORD) bool
 // ref - https://docs.microsoft.com/en-us/windows/console/scrollconsolescreenbuffer
 fn C.ScrollConsoleScreenBuffer(output C.HANDLE, scroll_rect &C.SMALL_RECT, clip_rect &C.SMALL_RECT, des C.COORD, fill &C.CHAR_INFO) bool
 
-// get_terminal_size returns a number of colums and rows of terminal window.
+// get_terminal_size returns a number of columns and rows of terminal window.
 pub fn get_terminal_size() (int, int) {
 	if os.is_atty(1) > 0 && os.getenv('TERM') != 'dumb' {
 		info := C.CONSOLE_SCREEN_BUFFER_INFO{}


### PR DESCRIPTION
colums -> columns



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 669468d</samp>

This pull request corrects a spelling error in a comment of the `term` module. It changes `colums` to `columns` in the file `vlib/term/term_windows.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 669468d</samp>

* Fix a typo in the comment of `get_terminal_size` ([link](https://github.com/vlang/v/pull/18745/files?diff=unified&w=0#diff-03cf093b214ee2a929799fc81756759528f683e3db7cc38bb3ff0030883b42e4L58-R58))
