### PR TITLE
checker: disallow invalid prefix on left side of assign stmt

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -393,7 +393,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						}
 					}
 				} else if left.op == .amp {
-					c.error('cannot deference on the left side of `${node.op}`', left.pos)
+					c.error('cannot use a reference on the left side of `${node.op}`', left.pos)
 				} else {
 					c.error('cannot use `${left.op}` on the left of `${node.op}`', left.pos)
 				}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -393,7 +393,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						}
 					}
 				} else if left.op == .amp {
-					c.error('cannot use a reference on the left side of `${node.op}`', left.pos)
+					c.error('cannot use a reference on the left side of `${node.op}`',
+						left.pos)
 				} else {
 					c.error('cannot use `${left.op}` on the left of `${node.op}`', left.pos)
 				}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -392,6 +392,10 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							left.right.obj.is_used = true
 						}
 					}
+				} else if left.op == .amp {
+					c.error('cannot deference on the left side of `${node.op}`', left.pos)
+				} else {
+					c.error('cannot use `${left.op}` on the left of `${node.op}`', left.pos)
 				}
 				if is_decl {
 					c.error('non-name on the left side of `:=`', left.pos)

--- a/vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.out
+++ b/vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv:3:2: error: can
       |     ^
     4 |     &x = unsafe { nil }
     5 |     println(x)
-vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv:4:2: error: cannot deference on the left side of `=`
+vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv:4:2: error: cannot use a reference on the left side of `=`
     2 |     mut x := 0
     3 |     ~x = 34
     4 |     &x = unsafe { nil }

--- a/vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.out
+++ b/vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv:3:2: error: cannot use `~` on the left of `=`
+    1 | fn main() {
+    2 |     mut x := 0
+    3 |     ~x = 34
+      |     ^
+    4 |     &x = unsafe { nil }
+    5 |     println(x)
+vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv:4:2: error: cannot deference on the left side of `=`
+    2 |     mut x := 0
+    3 |     ~x = 34
+    4 |     &x = unsafe { nil }
+      |     ^
+    5 |     println(x)
+    6 | }

--- a/vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv
+++ b/vlib/v/checker/tests/invalid_prefix_left_side_assign_stmt_err.vv
@@ -1,0 +1,6 @@
+fn main() {
+	mut x := 0
+	~x = 34
+	&x = unsafe { nil }
+	println(x)
+}

--- a/vlib/v/checker/tests/prefix_expr_decl_assign_err.out
+++ b/vlib/v/checker/tests/prefix_expr_decl_assign_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:2:5: error: non-name on the left side of `:=`
+vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:2:5: error: cannot use a reference on the left side of `:=`
     1 | fn main() {
     2 |     &a := 12
       |     ^


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18748

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1833385</samp>

Add checker errors for invalid left-hand sides of assignment statements. Add test files and expected outputs for `vlib/v/checker/assign.v` and `vlib/v/checker/tests`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1833385</samp>

*  Add error cases for invalid left-hand sides of assignment statements in the checker ([link](https://github.com/vlang/v/pull/18750/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR395-R398))
*  Add test file with examples of invalid left-hand sides of assignment statements (`invalid_prefix_left_side_assign_stmt_err.vv`) ([link](https://github.com/vlang/v/pull/18750/files?diff=unified&w=0#diff-640f84fdbd8eac6346c834f4641ad5b7a3e119a09f3949b306683264383e6e2dR1-R6))
*  Add expected output of the checker for the test file (`invalid_prefix_left_side_assign_stmt_err.out`) ([link](https://github.com/vlang/v/pull/18750/files?diff=unified&w=0#diff-3d68c747ac288483545d383b161d0a4fd9cf883dc12d739d907f8959acab0aefR1-R14))
