### PR TITLE
cgen: fix regression with unalised naming conflict with C interop

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -22,7 +22,12 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		g.empty_line = false
 		g.write(s)
 	}
-	styp := g.typ(g.table.unaliased_type(node.typ)).replace('*', '')
+	unalised_typ := g.table.unaliased_type(node.typ)
+	styp := if g.table.sym(unalised_typ).language == .v {
+		g.typ(unalised_typ).replace('*', '')
+	} else {
+		g.typ(node.typ)
+	}
 	mut shared_styp := '' // only needed for shared x := St{...
 	if styp in c.skip_struct_init {
 		// needed for c++ compilers

--- a/vlib/v/tests/modules/sub/foo.v
+++ b/vlib/v/tests/modules/sub/foo.v
@@ -1,0 +1,8 @@
+module sub
+
+import sub.foo.c
+
+[typedef]
+struct C.sub_foo {}
+
+pub type Foo = C.sub_foo

--- a/vlib/v/tests/modules/sub/foo.v
+++ b/vlib/v/tests/modules/sub/foo.v
@@ -3,6 +3,8 @@ module sub
 import sub.foo.c
 
 [typedef]
-struct C.sub_foo {}
+struct C.sub_foo {
+	a int
+}
 
 pub type Foo = C.sub_foo

--- a/vlib/v/tests/modules/sub/foo/c/foo.h
+++ b/vlib/v/tests/modules/sub/foo/c/foo.h
@@ -1,3 +1,5 @@
 typedef struct sub_foo sub_foo;
 
-struct sub_foo {};
+struct sub_foo {
+    int a;
+};

--- a/vlib/v/tests/modules/sub/foo/c/foo.h
+++ b/vlib/v/tests/modules/sub/foo/c/foo.h
@@ -1,0 +1,3 @@
+typedef struct sub_foo sub_foo;
+
+struct sub_foo {};

--- a/vlib/v/tests/modules/sub/foo/c/foo.v
+++ b/vlib/v/tests/modules/sub/foo/c/foo.v
@@ -1,0 +1,7 @@
+module c
+
+pub const used_import = 1
+
+#flag -I @VMODROOT
+
+#include "foo.h"

--- a/vlib/v/tests/modules/sub/sub_test.v
+++ b/vlib/v/tests/modules/sub/sub_test.v
@@ -1,0 +1,7 @@
+import sub
+
+fn test_vmain() {
+	sub_foo := &sub.Foo{}
+
+	dump(sub_foo)
+}


### PR DESCRIPTION
Fix #18743

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 548289f</samp>

Fix C struct initialization bug in `vlib/v/gen/c/struct.v`. Use the correct type name based on the language of the unaliased type.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 548289f</samp>

* Fix a bug where C structs were not initialized correctly with `:=` syntax ([link](https://github.com/vlang/v/pull/18752/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L25-R30))
