### PR TITLE
checker: allow no return in compile_error else block

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -303,6 +303,10 @@ fn has_top_return(stmts []ast.Stmt) bool {
 						|| (stmt.expr.is_method == false && stmt.expr.name == 'panic') {
 						return true
 					}
+				} else if stmt.expr is ast.ComptimeCall {
+					if stmt.expr.method_name == 'compile_error' {
+						return true
+					}
 				}
 			}
 			else {}

--- a/vlib/v/checker/tests/comptime_else_compile_error_no_return.out
+++ b/vlib/v/checker/tests/comptime_else_compile_error_no_return.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/comptime_else_compile_error_no_return.vv:5:3: error: not an int
+    3 |         return val
+    4 |     } $else {
+    5 |         $compile_error('not an int')
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    6 |     }
+    7 | }

--- a/vlib/v/checker/tests/comptime_else_compile_error_no_return.vv
+++ b/vlib/v/checker/tests/comptime_else_compile_error_no_return.vv
@@ -1,0 +1,12 @@
+fn onlyint[T](val T) T {
+	$if val is $int {
+		return val
+	} $else {
+		$compile_error('not an int')
+	}
+}
+
+fn main() {
+	onlyint(7)
+	onlyint([]int{})
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Closes #18757

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ad0b20</samp>

Allow `$compile_error` macro in branches that do not return a value. Add a test case and a test output file for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0ad0b20</samp>

*  Add a special case for comptime function calls with `$compile_error` macro ([link](https://github.com/vlang/v/pull/18758/files?diff=unified&w=0#diff-2106e54001315d8484198ab86f15bc5212b4cbbea1264d563c217efaf7c9c93dR306-R309))
*  Add a test case and output for the comptime function call with `$compile_error` macro ([link](https://github.com/vlang/v/pull/18758/files?diff=unified&w=0#diff-78578fbc43b738f4f2e7631b63afe5f1f38eb54c7f7132e8b3dab3900cfc3a46R1-R12), [link](https://github.com/vlang/v/pull/18758/files?diff=unified&w=0#diff-f6b8077b21e90c0cca3ae37e11271e98afc0de3a5dea20f303aca8a581a2b950L1-R6))
