### PR TITLE
docs: add compile time types

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -171,6 +171,7 @@ by using any of the following commands in a terminal:
         * [Compile time pseudo variables](#compile-time-pseudo-variables)
         * [Compile time reflection](#compile-time-reflection)
         * [Compile time code](#compile-time-code)
+        * [Compile time types](#compile-time-types)
         * [Environment specific files](#environment-specific-files)
     * [Memory-unsafe code](#memory-unsafe-code)
     * [Structs with reference fields](#structs-with-reference-fields)
@@ -5505,7 +5506,7 @@ eprintln('${vm.name} ${vm.version}\n ${vm.description}')
 
 ### Compile time reflection
 
-`$` is used as a prefix for compile time operations.
+`$` is used as a prefix for compile time (also referred to as 'comptime') operations.
 
 Having built-in JSON support is nice, but V also allows you to create efficient
 serializers for any data format. V has compile time `if` and `for` constructs:
@@ -5727,18 +5728,18 @@ the `.len` attribute in arrays.
 
 V supports the following compile time types:
 
-- `$map` => matches [Maps](#maps).
+- `$alias` => matches [Type aliases](#type-aliases).
+- `$array` => matches [Arrays](#arrays) and [Fixed Size Arrays](#fixed-size-arrays).
+- `$enum` => matches [Enums](#enums).
+- `$float` => matches `f32`, `f64` and float literals.
+- `$function` => matches [Function Types](#function-types).
 - `$int` => matches `int`, `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `isize`, `usize`
   and integer literals.
-- `$float` => matches `f32`, `f64` and float literals.
-- `$struct` => matches [Structs](#structs).
 - `$interface` => matches [Interfaces](#interfaces).
-- `$array` => matches [Arrays](#arrays) and [Fixed Size Arrays](#fixed-size-arrays).
-- `$sumtype` => matches [Sum Types](#sum-types).
-- `$enum` => matches [Enums](#enums).
-- `$alias` => matches [Type aliases](#type-aliases).
-- `$function` => matches [Function Types](#function-types).
+- `$map` => matches [Maps](#maps).
 - `$option` => matches [Option Types](#optionresult-types-and-error-handling).
+- `$struct` => matches [Structs](#structs).
+- `$sumtype` => matches [Sum Types](#sum-types).
 
 ### Environment specific files
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -169,7 +169,7 @@ by using any of the following commands in a terminal:
     * [Attributes](#attributes)
     * [Conditional compilation](#conditional-compilation)
         * [Compile time pseudo variables](#compile-time-pseudo-variables)
-        * [Compile-time reflection](#compile-time-reflection)
+        * [Compile time reflection](#compile-time-reflection)
         * [Compile time code](#compile-time-code)
         * [Environment specific files](#environment-specific-files)
     * [Memory-unsafe code](#memory-unsafe-code)
@@ -2957,7 +2957,7 @@ const (
 		g: 0
 		b: 0
 	}
-	// evaluate function call at compile-time*
+	// evaluate function call at compile time*
 	blue = rgb(0, 0, 255)
 )
 
@@ -5503,10 +5503,12 @@ vm := vmod.decode( @VMOD_FILE ) or { panic(err) }
 eprintln('${vm.name} ${vm.version}\n ${vm.description}')
 ```
 
-### Compile-time reflection
+### Compile time reflection
+
+`$` is used as a prefix for compile time operations.
 
 Having built-in JSON support is nice, but V also allows you to create efficient
-serializers for any data format. V has compile-time `if` and `for` constructs:
+serializers for any data format. V has compile time `if` and `for` constructs:
 
 ```v
 struct User {
@@ -5530,8 +5532,6 @@ See [`examples/compiletime/reflection.v`](/examples/compiletime/reflection.v)
 for a more complete example.
 
 ### Compile time code
-
-`$` is used as a prefix for compile-time operations.
 
 #### `$if` condition
 
@@ -5718,6 +5718,27 @@ x.v:4:5: error: Linux is not supported
     5 | }
     6 |
 ```
+
+### Compile time types
+
+Compile time types group multiple types into a general higher-level type. This is useful in
+functions with generic parameters, where the input type must have a specific property, for example
+the `.len` attribute in arrays.
+
+V supports the following compile time types:
+
+- `$map` => matches [Maps](#maps).
+- `$int` => matches `int`, `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `isize`, `usize`
+  and integer literals.
+- `$float` => matches `f32`, `f64` and float literals.
+- `$struct` => matches [Structs](#structs).
+- `$interface` => matches [Interfaces](#interfaces).
+- `$array` => matches [Arrays](#arrays) and [Fixed Size Arrays](#fixed-size-arrays).
+- `$sumtype` => matches [Sum Types](#sum-types).
+- `$enum` => matches [Enums](#enums).
+- `$alias` => matches [Type aliases](#type-aliases).
+- `$function` => matches [Function Types](#function-types).
+- `$option` => matches [Option Types](#optionresult-types-and-error-handling).
 
 ### Environment specific files
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR adds `Compile time types` to the V documentation and improves consistency of using the term "compile time" (the hyphenated version is also correct, but it's better to be consistent).

The line "`$` is used as a prefix for compile time operations." is also moved up to the beginning of the compile time reflection section as that is also the first time the prefix is used.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1194805</samp>

This pull request improves the documentation of compile time features in `doc/docs.md`. It clarifies the usage and syntax of `$`, compile time reflection, and compile time types with more examples and descriptions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1194805</samp>

* Fix typos in `doc/docs.md` by adding hyphens to "compile-time" ([link](https://github.com/vlang/v/pull/18761/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L172-R172), [link](https://github.com/vlang/v/pull/18761/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L2960-R2960))
* Add a sentence to introduce the `$` prefix for compile time operations in `doc/docs.md` ([link](https://github.com/vlang/v/pull/18761/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L5506-R5511))
* Remove a redundant sentence that was already added by the previous change in `doc/docs.md` ([link](https://github.com/vlang/v/pull/18761/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L5534-L5535))
* Document the compile time types feature in a new subsection in `doc/docs.md`, with examples and explanations ([link](https://github.com/vlang/v/pull/18761/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8R5722-R5742))
