### PR TITLE
cgen: fix memleak for [][]T{len: x}, or []Struct{len: x}

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -316,8 +316,8 @@ pub fn malloc(n isize) &u8 {
 		C.fprintf(C.stderr, c'_v_malloc %6d total %10d\n', n, total_m)
 		// print_backtrace()
 	}
-	if n <= 0 {
-		panic('malloc(${n} <= 0)')
+	if n < 0 {
+		panic('malloc(${n} < 0)')
 	}
 	$if vplayground ? {
 		if n > 10000 {
@@ -359,8 +359,8 @@ pub fn malloc_noscan(n isize) &u8 {
 		C.fprintf(C.stderr, c'malloc_noscan %6d total %10d\n', n, total_m)
 		// print_backtrace()
 	}
-	if n <= 0 {
-		panic('malloc_noscan(${n} <= 0)')
+	if n < 0 {
+		panic('malloc_noscan(${n} < 0)')
 	}
 	$if vplayground ? {
 		if n > 10000 {
@@ -418,8 +418,8 @@ pub fn malloc_uncollectable(n isize) &u8 {
 		C.fprintf(C.stderr, c'malloc_uncollectable %6d total %10d\n', n, total_m)
 		// print_backtrace()
 	}
-	if n <= 0 {
-		panic('malloc_uncollectable(${n} <= 0)')
+	if n < 0 {
+		panic('malloc_uncollectable(${n} < 0)')
 	}
 	$if vplayground ? {
 		if n > 10000 {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -388,7 +388,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		tmp := g.new_tmp_var()
 		line := g.go_before_stmt(0).trim_space()
 		g.empty_line = true
-		g.write('${elem_styp}* ${tmp} = _v_malloc((')
+		g.write('${elem_styp}* ${tmp} = (${elem_styp}*) _v_malloc((')
 		g.expr(node.len_expr)
 		g.writeln(') * sizeof(${elem_styp}));')
 		ind := g.new_tmp_var()

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -388,7 +388,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		tmp := g.new_tmp_var()
 		line := g.go_before_stmt(0).trim_space()
 		g.empty_line = true
-		g.write('${elem_styp}* ${tmp} = malloc((')
+		g.write('${elem_styp}* ${tmp} = _v_malloc((')
 		g.expr(node.len_expr)
 		g.writeln(') * sizeof(${elem_styp}));')
 		ind := g.new_tmp_var()

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -79,7 +79,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	wrapper_fn_name := name + '_thread_wrapper'
 	arg_tmp_var := 'arg_' + tmp
 	if is_spawn {
-		g.writeln('${wrapper_struct_name} *${arg_tmp_var} = _v_malloc(sizeof(thread_arg_${name}));')
+		g.writeln('${wrapper_struct_name} *${arg_tmp_var} = (${wrapper_struct_name} *) _v_malloc(sizeof(thread_arg_${name}));')
 	} else if is_go {
 		g.writeln('${wrapper_struct_name} ${arg_tmp_var};')
 	}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -106,7 +106,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	}
 	s_ret_typ := g.typ(node.call_expr.return_type)
 	if g.pref.os == .windows && node.call_expr.return_type != ast.void_type {
-		g.writeln('${arg_tmp_var}->ret_ptr = malloc(sizeof(${s_ret_typ}));')
+		g.writeln('${arg_tmp_var}->ret_ptr = (void *) _v_malloc(sizeof(${s_ret_typ}));')
 	}
 	is_opt := node.call_expr.return_type.has_flag(.option)
 	is_res := node.call_expr.return_type.has_flag(.result)
@@ -201,7 +201,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 			if node.call_expr.return_type != ast.void_type {
 				g.gowrappers.writeln('\t${s_ret_typ} ret = *ret_ptr;')
-				g.gowrappers.writeln('\tfree(ret_ptr);')
+				g.gowrappers.writeln('\t_v_free(ret_ptr);')
 				g.gowrappers.writeln('\treturn ret;')
 			}
 			g.gowrappers.writeln('}')
@@ -278,7 +278,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			if g.pref.os == .windows {
 				g.gowrappers.write_string('\t*((${s_ret_typ}*)(arg->ret_ptr)) = ')
 			} else {
-				g.gowrappers.writeln('\t${s_ret_typ}* ret_ptr = malloc(sizeof(${s_ret_typ}));')
+				g.gowrappers.writeln('\t${s_ret_typ}* ret_ptr = (${s_ret_typ}*) _v_malloc(sizeof(${s_ret_typ}));')
 				g.gowrappers.write_string('\t*ret_ptr = ')
 			}
 		} else {
@@ -359,7 +359,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 		}
 		g.gowrappers.writeln(');')
-		g.gowrappers.writeln('\tfree(arg);')
+		g.gowrappers.writeln('\t_v_free(arg);')
 		if g.pref.os != .windows && node.call_expr.return_type != ast.void_type {
 			g.gowrappers.writeln('\treturn ret_ptr;')
 		} else {

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -79,7 +79,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	wrapper_fn_name := name + '_thread_wrapper'
 	arg_tmp_var := 'arg_' + tmp
 	if is_spawn {
-		g.writeln('${wrapper_struct_name} *${arg_tmp_var} = malloc(sizeof(thread_arg_${name}));')
+		g.writeln('${wrapper_struct_name} *${arg_tmp_var} = _v_malloc(sizeof(thread_arg_${name}));')
 	} else if is_go {
 		g.writeln('${wrapper_struct_name} ${arg_tmp_var};')
 	}


### PR DESCRIPTION
- cgen: fix memleak for `[]T{len: x}`
- use _v_malloc, in the wrapper generated by `spawn f()` as well

Test program:
```v
import os

const mypid = os.getpid()

fn abc(k int, m int) [][]int {
	mut z := [][]int{len: k}
	z[0] = []int{len: m}
	z[0][0] = 9999
	z[0][m/2] = 9999
	z[0][m-1] = 9999
	return z
}

fn f() bool {
	x := abc(10_000, 1000)
	return x[0][0] == 0
}

fn main() {
	mut i := u64(0)        
	for {
		f()
		i++
		if i % 1_000 == 0 {
			eprintln('> i: $i')
		}
	}
}
```
(run the above on linux, after executing `ulimit -v 1000000` in the same shell, to limit the amount of available memory to that process to 1GB)

On master, it will fail with:
```
#0 21:46:16 ᛋ master /v/vnew❱xtime ./v run bb.v 
> i: 0
> i: 1000
> i: 2000
> i: 3000
7f3e3e03cbcb : at ???: RUNTIME ERROR: invalid memory access
/tmp/v_1000/bb.6641612626006065282.tmp.c:17781: by main__f
/tmp/v_1000/bb.6641612626006065282.tmp.c:17788: by main__main
/tmp/v_1000/bb.6641612626006065282.tmp.c:18184: by main
Command exited with non-zero status 255
CPU: 3.39s      Real: 3.04s     Elapsed: 0:03.04        RAM: 974352KB   ./v run bb.v
#255 21:46:20 ᛋ master /v/vnew❱
```

With this PR, the above program has a more or less constant RAM usage of ~7MB.