### PR TITLE
checker, cgen: allow comptime ident is array of types

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -746,7 +746,8 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 					if cond.left is ast.Ident {
 						c.expr(cond.left)
 					}
-					if cond.left in [ast.TypeNode, ast.SelectorExpr, ast.Ident] && cond.right is ast.ArrayInit {
+					if cond.left in [ast.TypeNode, ast.SelectorExpr, ast.Ident]
+						&& cond.right is ast.ArrayInit {
 						for expr in cond.right.exprs {
 							if expr !in [ast.ComptimeType, ast.TypeNode] {
 								c.error('invalid `\$if` condition, only types are allowed',

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -743,7 +743,10 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 					}
 				}
 				.key_in, .not_in {
-					if cond.left in [ast.SelectorExpr, ast.TypeNode] && cond.right is ast.ArrayInit {
+					if cond.left is ast.Ident {
+						c.expr(cond.left)
+					}
+					if cond.left in [ast.TypeNode, ast.SelectorExpr, ast.Ident] && cond.right is ast.ArrayInit {
 						for expr in cond.right.exprs {
 							if expr !in [ast.ComptimeType, ast.TypeNode] {
 								c.error('invalid `\$if` condition, only types are allowed',

--- a/vlib/v/checker/tests/run/comptime_ident_in_typearray.run.out
+++ b/vlib/v/checker/tests/run/comptime_ident_in_typearray.run.out
@@ -1,0 +1,4 @@
+str
+this is an else block
+32-bit number
+32-bit number

--- a/vlib/v/checker/tests/run/comptime_ident_in_typearray.vv
+++ b/vlib/v/checker/tests/run/comptime_ident_in_typearray.vv
@@ -1,0 +1,16 @@
+fn test[T](val T) string {
+	$if val is string {
+		return val
+	} $else $if val in [i32, u32] {
+		return '32-bit number'
+	} $else {
+		return 'this is an else block'
+	}
+}
+
+fn main() {
+	println(test('str'))
+	println(test(7))
+	println(test(u32(7)))
+	println(test(i32(7)))
+}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -617,7 +617,8 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 					}
 				}
 				.key_in, .not_in {
-					if cond.left in [ast.TypeNode, ast.SelectorExpr, ast.Ident] && cond.right is ast.ArrayInit {
+					if cond.left in [ast.TypeNode, ast.SelectorExpr, ast.Ident]
+						&& cond.right is ast.ArrayInit {
 						checked_type := g.get_expr_type(cond.left)
 
 						for expr in cond.right.exprs {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -617,7 +617,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 					}
 				}
 				.key_in, .not_in {
-					if cond.left in [ast.TypeNode, ast.SelectorExpr] && cond.right is ast.ArrayInit {
+					if cond.left in [ast.TypeNode, ast.SelectorExpr, ast.Ident] && cond.right is ast.ArrayInit {
 						checked_type := g.get_expr_type(cond.left)
 
 						for expr in cond.right.exprs {
@@ -632,9 +632,8 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 								}
 							} else if expr is ast.TypeNode {
 								got_type := g.unwrap_generic(expr.typ)
-								is_true := checked_type.idx() == got_type.idx()
-									&& checked_type.has_flag(.option) == got_type.has_flag(.option)
-								if is_true {
+								if checked_type.idx() == got_type.idx()
+									&& checked_type.has_flag(.option) == got_type.has_flag(.option) {
 									if cond.op == .key_in {
 										g.write('1')
 									} else {
@@ -650,9 +649,6 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 							g.write('0')
 						}
 						return cond.op == .not_in, true
-					} else {
-						g.write('1')
-						return true, true
 					}
 				}
 				.gt, .lt, .ge, .le {


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Closes #18764

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1c4148</samp>

This pull request adds support for comptime evaluation of `key_in` and `not_in` operators with identifiers and type arrays. It also improves the code generator and adds tests for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1c4148</samp>

*  Add comptime support for `key_in` and `not_in` operators with identifiers and type arrays ([link](https://github.com/vlang/v/pull/18765/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5L746-R749), [link](https://github.com/vlang/v/pull/18765/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL620-R620))
* Simplify and optimize the code generator for `key_in` and `not_in` operators ([link](https://github.com/vlang/v/pull/18765/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL635-R636), [link](https://github.com/vlang/v/pull/18765/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL653-L655))
* Add test cases for the new feature in `vlib/v/checker/tests/run` ([link](https://github.com/vlang/v/pull/18765/files?diff=unified&w=0#diff-e7d3656794cdc040aea443b55360a099a3d157e5c937ecce72ae4a023b5ba94eL1-R3), [link](https://github.com/vlang/v/pull/18765/files?diff=unified&w=0#diff-dbd7ff18099c1a57b530fca2dc8b0e671f5e0536b1cce2634fdf4d7641c75b53R1-R16))
