### PR TITLE
checker: fix comptime evaluation is/!is operator with typenode

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -666,17 +666,6 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 						sym := c.table.sym(cond.right.typ)
 						if sym.kind != .interface_ {
 							c.expr(cond.left)
-							left_type := c.unwrap_generic((cond.left as ast.TypeNode).typ)
-							ret_val := if left_type == cond.right.typ {
-								ComptimeBranchSkipState.eval
-							} else {
-								ComptimeBranchSkipState.skip
-							}
-							if cond.op == .key_is {
-								return ret_val
-							} else {
-								return if ret_val == .eval { .skip } else { .eval }
-							}
 						}
 						return .unknown
 					} else if cond.left is ast.TypeNode && cond.right is ast.ComptimeType {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -666,7 +666,17 @@ fn (mut c Checker) comptime_if_branch(cond ast.Expr, pos token.Pos) ComptimeBran
 						sym := c.table.sym(cond.right.typ)
 						if sym.kind != .interface_ {
 							c.expr(cond.left)
-							// c.error('`$sym.name` is not an interface', cond.right.pos())
+							left_type := c.unwrap_generic((cond.left as ast.TypeNode).typ)
+							ret_val := if left_type == cond.right.typ {
+								ComptimeBranchSkipState.eval
+							} else {
+								ComptimeBranchSkipState.skip
+							}
+							if cond.op == .key_is {
+								return ret_val
+							} else {
+								return if ret_val == .eval { .skip } else { .eval }
+							}
 						}
 						return .unknown
 					} else if cond.left is ast.TypeNode && cond.right is ast.ComptimeType {

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -100,7 +100,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					is_comptime_type_is_expr = true
 				}
 			} else if mut branch.cond is ast.InfixExpr {
-				if branch.cond.op == .key_is {
+				if branch.cond.op in [.not_is, .key_is] {
 					left := branch.cond.left
 					right := branch.cond.right
 					if right !in [ast.TypeNode, ast.ComptimeType] {
@@ -170,7 +170,10 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							skip_state = c.check_compatible_types(checked_type, right as ast.TypeNode)
 						}
 					}
-				} else if branch.cond.op in [.eq, .ne] {
+					if branch.cond.op == .not_is && skip_state != .unknown {
+						skip_state = if skip_state == .eval { .skip } else { .eval }
+					}
+				} else if branch.cond.op in [.eq, .ne, .gt, .lt, .ge, .le] {
 					left := branch.cond.left
 					right := branch.cond.right
 					if left is ast.SelectorExpr && right is ast.IntegerLiteral {

--- a/vlib/v/tests/comptime_is_check_test.v
+++ b/vlib/v/tests/comptime_is_check_test.v
@@ -1,0 +1,15 @@
+fn test[T](val T) string {
+	$if T is u32 {
+		$compile_error('u32')
+		return ''
+	} $else $if T !is string {
+		$compile_error('not string')
+		return ''
+	} $else {
+		return val
+	}
+}
+
+fn test_main() {
+	assert test('str') == 'str'
+}


### PR DESCRIPTION
Fix #18769

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3634df7</samp>

This pull request adds support for the `.not_is` operator in comptime if statements, which allows checking if a generic type parameter is not a specific type. It also removes some redundant code and adds a test file for the new feature.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3634df7</samp>

*  Add support for `.not_is` operator in comptime if statements ([link](https://github.com/vlang/v/pull/18773/files?diff=unified&w=0#diff-92297a74e9e70557a4b47ca09faef734f8e4b97ac35dc69278794d134b2be211L103-R103), [link](https://github.com/vlang/v/pull/18773/files?diff=unified&w=0#diff-92297a74e9e70557a4b47ca09faef734f8e4b97ac35dc69278794d134b2be211L173-R176))
* Remove unused error message in `eval_comptime_if` function in `vlib/v/checker/comptime.v` ([link](https://github.com/vlang/v/pull/18773/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5L669))
* Add test file for comptime if statements with `.is` and `.not_is` operators in `vlib/v/tests/comptime_is_check_test.v` ([link](https://github.com/vlang/v/pull/18773/files?diff=unified&w=0#diff-7b2315b8aeb92d71ca214f615c711cd6d3dadf8aa452aa40c9e870f3da481475R1-R15))
