### PR TITLE
builtin: implement string_from_wide/1 and string_from_wide2/2 on *nix too

### DIFF
--- a/vlib/builtin/utf8.c.v
+++ b/vlib/builtin/utf8.c.v
@@ -44,17 +44,11 @@ pub fn string_from_wide(_wstr &u16) string {
 			return string_from_wide2(_wstr, wstr_len)
 		}
 	} $else {
-		mut len := 0
 		mut i := 0
-		for {
-			r := rune(unsafe { _wstr[i] })
-			if r == 0 {
-				break
-			}
-			len += r.length_in_bytes()
+		for unsafe { _wstr[i] } != 0 {
 			i++
 		}
-		return unsafe { string_from_wide2(_wstr, len) }
+		return unsafe { string_from_wide2(_wstr, i) }
 	}
 }
 

--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -54,3 +54,18 @@ fn test_to_wide_cyrillic() {
 		assert w[5] == 0
 	}
 }
+
+const wide_serial_number = [u8(67), 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48, 0,
+	54, 0, 52, 0, 57, 0, 0, 0, 0]
+
+const swide_serial_number = 'CL46I1A00649'
+
+fn test_string_from_wide() {
+	z := unsafe { string_from_wide(wide_serial_number.data) }
+	assert z == swide_serial_number
+}
+
+fn test_string_from_wide2() {
+	z := unsafe { string_from_wide2(wide_serial_number.data, 12) }
+	assert z == swide_serial_number
+}

--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -69,3 +69,9 @@ fn test_string_from_wide2() {
 	z := unsafe { string_from_wide2(wide_serial_number.data, 12) }
 	assert z == swide_serial_number
 }
+
+fn test_reverse_cyrillic_with_string_from_wide() {
+	s := 'Проба'
+	z := unsafe { string_from_wide(s.to_wide()) }
+	assert z == s
+}


### PR DESCRIPTION
The following now works on both windows and !windows:
```v
a := [u8(67), 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48, 0,
	54, 0, 52, 0, 57, 0, 0, 0, 0]
assert unsafe{ string_from_wide(a.data) } == 'CL46I1A00649'
```