### PR TITLE
checker: change `smartcast(expr_ ast.Expr,..)` to `smartcast(mut expr ast.Expr,..)`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3572,14 +3572,13 @@ fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 }
 
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
-fn (mut c Checker) smartcast(expr_ ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
+fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
 	sym := c.table.sym(cur_type)
 	to_type := if sym.kind == .interface_ && c.table.sym(to_type_).kind != .interface_ {
 		to_type_.ref()
 	} else {
 		to_type_
 	}
-	mut expr := unsafe { expr_ }
 	match mut expr {
 		ast.SelectorExpr {
 			mut is_mut := false

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -290,7 +290,7 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 		if node.cond.op == .key_is {
 			if node.cond.right is ast.TypeNode && node.cond.left in [ast.Ident, ast.SelectorExpr] {
 				if c.table.type_kind(node.cond.left_type) in [.sum_type, .interface_] {
-					c.smartcast(node.cond.left, node.cond.left_type, node.cond.right_type, mut
+					c.smartcast(mut node.cond.left, node.cond.left_type, node.cond.right_type, mut
 						node.scope)
 				}
 			}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -307,7 +307,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			}
 		} else {
 			// smartcast sumtypes and interfaces when using `is`
-			c.smartcast_if_conds(branch.cond, mut branch.scope)
+			c.smartcast_if_conds(mut branch.cond, mut branch.scope)
 			if node_is_expr {
 				c.stmts_ending_with_expression(mut branch.stmts)
 			} else {
@@ -462,11 +462,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 	return node.typ
 }
 
-fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
-	if node is ast.InfixExpr {
+fn (mut c Checker) smartcast_if_conds(mut node ast.Expr, mut scope ast.Scope) {
+	if mut node is ast.InfixExpr {
 		if node.op == .and {
-			c.smartcast_if_conds(node.left, mut scope)
-			c.smartcast_if_conds(node.right, mut scope)
+			c.smartcast_if_conds(mut node.left, mut scope)
+			c.smartcast_if_conds(mut node.right, mut scope)
 		} else if node.op == .key_is {
 			right_expr := node.right
 			right_type := match right_expr {
@@ -498,7 +498,7 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 					c.error('cannot use type `${expect_str}` as type `${expr_str}`', node.pos)
 				}
 				if node.left in [ast.Ident, ast.SelectorExpr] && node.right is ast.TypeNode {
-					is_variable := if node.left is ast.Ident {
+					is_variable := if mut node.left is ast.Ident {
 						node.left.kind == .variable
 					} else {
 						true
@@ -509,7 +509,7 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 							c.fail_if_immutable(node.left)
 						}
 						// TODO: Add check for sum types in a way that it doesn't break a lot of compiler code
-						if node.left is ast.Ident
+						if mut node.left is ast.Ident
 							&& (left_sym.kind == .interface_ && right_sym.kind != .interface_) {
 							v := scope.find_var(node.left.name) or { &ast.Var{} }
 							if v.is_mut && !node.left.is_mut {
@@ -518,14 +518,15 @@ fn (mut c Checker) smartcast_if_conds(node ast.Expr, mut scope ast.Scope) {
 							}
 						}
 						if left_sym.kind in [.interface_, .sum_type] {
-							c.smartcast(node.left, node.left_type, right_type, mut scope)
+							c.smartcast(mut node.left, node.left_type, right_type, mut
+								scope)
 						}
 					}
 				}
 			}
 		}
-	} else if node is ast.Likely {
-		c.smartcast_if_conds(node.expr, mut scope)
+	} else if mut node is ast.Likely {
+		c.smartcast_if_conds(mut node.expr, mut scope)
 	}
 }
 

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -357,7 +357,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 					expr_type = expr_types[0].typ
 				}
 
-				c.smartcast(node.cond, node.cond_type, expr_type, mut branch.scope)
+				c.smartcast(mut node.cond, node.cond_type, expr_type, mut branch.scope)
 			}
 		}
 	}


### PR DESCRIPTION
This PR change `smartcast(expr_ ast.Expr,..)` to `smartcast(mut expr ast.Expr,..)`.

- Avoid `mut expr := unsafe { expr_ }`.