### PR TITLE
checker: fix interface param resolution

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1720,7 +1720,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					}
 					if c.table.sym(param.typ).kind == .interface_ {
 						// cannot hide interface expected type to make possible to pass its interface type automatically
-						earg_types << param.typ.set_nr_muls(targ.nr_muls())
+						earg_types << if targ.idx() != param.typ.idx() { param.typ } else { targ }
 					} else {
 						earg_types << targ
 					}

--- a/vlib/v/tests/iface_arg_test.v
+++ b/vlib/v/tests/iface_arg_test.v
@@ -13,8 +13,8 @@ fn (t Test) test(a ITest) {}
 
 fn test(a ITest) {}
 
-fn get() Test {
-	return Test{}
+fn get() &Test {
+	return &Test{}
 }
 
 fn test_main() {
@@ -23,6 +23,14 @@ fn test_main() {
 	a.call(Test{})
 	test(Test{})
 	Test{}.test(a)
+
+	assert true
+}
+
+fn test_ptr() {
+	mut a := Cmdable{}
+	a.call = test
+	a.call(get())
 
 	assert true
 }


### PR DESCRIPTION
Fix #18768

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09e630a</samp>

Fix interface to concrete type casting in function calls. Update `vlib/v/checker/fn.v` to use the parameter type instead of the target type when checking for type compatibility.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 09e630a</samp>

* Fix interface type mismatch errors when passing to functions ([link](https://github.com/vlang/v/pull/18780/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL1723-R1723))
