### PR TITLE
parser: fix compiler error when match returns reference (#18728)

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -240,7 +240,8 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			&& (((ast.builtin_type_names_matcher.matches(p.tok.lit) || p.tok.lit[0].is_capital())
 			&& p.peek_tok.kind != .lpar) || (p.peek_tok.kind == .dot && p.peek_token(2).lit.len > 0
 			&& p.peek_token(2).lit[0].is_capital()))) || p.is_only_array_type()
-			|| p.tok.kind == .key_fn || p.peek_token(2).kind == .amp {
+			|| p.tok.kind == .key_fn
+			|| (p.tok.kind == .lsbr && p.peek_token(2).kind == .amp) {
 			mut types := []ast.Type{}
 			for {
 				// Sum type match

--- a/vlib/v/tests/match_return_reference_test.v
+++ b/vlib/v/tests/match_return_reference_test.v
@@ -1,0 +1,29 @@
+struct Foo {}
+
+fn test_assign_ref_from_match() {
+	var := match 0 {
+		0 {
+			&Foo{}
+		}
+		else {
+			unsafe { nil }
+		}
+	}
+	assert var != unsafe { nil }
+}
+
+fn return_ref_from_match() &Foo {
+	return match 0 {
+		0 {
+			&Foo{}
+		}
+		else {
+			unsafe { nil }
+		}
+	}
+}
+
+fn test_return_ref_from_match() {
+	var := return_ref_from_match()
+	assert var != unsafe { nil }
+}


### PR DESCRIPTION
Fixes: #18782 
```v
fn main() {
	var := match 0 {
		0 {
			&Foo{}
		}
		else {
			unsafe { nil }
		}
	}
	assert(var != unsafe { nil })
}

struct Foo{}

fn foo() &Foo {
	return match 0 {
		0 {
			&Foo{}
		}
		else {
			&Foo{}
		}
	}
}

```

compile: pass.

