### PR TITLE
orm: fix inserting sequential values (id=0), in tables with an i64 primary field

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -209,9 +209,16 @@ pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKin
 				if data.data.len > 0 {
 					// Allow the database to insert an automatically generated primary key
 					// under the hood if it is not passed by the user.
-					if is_primary_column && data.data[i].type_idx() in orm.nums {
-						if (data.data[i] as int) == 0 {
-							continue
+					tidx := data.data[i].type_idx()
+					if is_primary_column && (tidx in orm.nums || tidx in orm.num64) {
+						x := data.data[i]
+						match x {
+							i8, i16, int, i64, u8, u16, u32, u64 {
+								if i64(x) == 0 {
+									continue
+								}
+							}
+							else {}
 						}
 					}
 

--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -287,3 +287,29 @@ fn test_orm_insert_with_multiple_child_elements() {
 	assert parent.notes[1].text == 'Second note'
 	assert parent.notes[2].text == 'Third note'
 }
+
+[table: 'customers']
+struct Customer {
+	id   i64    [primary; sql: serial]
+	name string
+}
+
+fn test_i64_primary_field_works_with_insertions_of_id_0() {
+	db := sqlite.connect(':memory:')!
+	sql db {
+		create table Customer
+	}!
+	for i in ['Bob', 'Charlie'] {
+		new_customer := Customer{
+			name: i
+		}
+		sql db {
+			insert new_customer into Customer
+		}!
+	}
+	users := sql db {
+		select from Customer
+	}!
+	assert users.len == 2
+	// println("${users}")
+}


### PR DESCRIPTION
Previously this code:
```v
import db.sqlite

// sets a custom table name. Default is struct name (case-sensitive)
[table: 'customers']
struct Customer {
        id        i64 [primary; sql: serial] // a field named `id` of integer type must be the first field
        name      string
}

fn main() {
        db := sqlite.connect('abc.db')!

        sql db {
                create table Customer
        }!

        for i in ["Bob", "Charlie"] {
                // insert a new customer
                new_customer := Customer{
                        name: i
                }
                sql db {
                        insert new_customer into Customer
                }!
        }
        users:= sql db {
                select from Customer
        }!
        println("${users}")
}
```
produced this:
```
#148 21:17:44 ᛋ fix_18779 /v/vnew❱v -g -d trace_orm run zz_i64.v 
> orm: CREATE TABLE IF NOT EXISTS `customers` (`id` INTEGER, `name` TEXT, PRIMARY KEY(`id`));
> orm: INSERT INTO `customers` (`id`, `name`) VALUES (?1, ?2);
================ V panic ================
   module: main
 function: main()
  message: UNIQUE constraint failed: customers.id (19) (INSERT INTO `customers` (`id`, `name`) VALUES (?1, ?2);); code: 19
     file: zz_i64.v:24
   v hash: ef26672
=========================================
/tmp/v_1000/../../../../../../v/vnew/vlib/builtin/builtin.c.v:68: at panic_debug: Backtrace
```

The same, but with `int` instead of `i64` worked without runtime errors.