### PR TITLE
cgen: fix code generation for array clear

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1281,7 +1281,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		receiver_type_name = 'map'
 	}
 	if final_left_sym.kind == .array && !(left_sym.kind == .alias && left_sym.has_method(node.name))
-		&& node.name in ['repeat', 'sort_with_compare', 'free', 'push_many', 'trim', 'first', 'last', 'pop', 'clone', 'reverse', 'slice', 'pointers'] {
+		&& node.name in ['clear', 'repeat', 'sort_with_compare', 'free', 'push_many', 'trim', 'first', 'last', 'pop', 'clone', 'reverse', 'slice', 'pointers'] {
 		if !(left_sym.info is ast.Alias && typ_sym.has_method(node.name)) {
 			// `array_Xyz_clone` => `array_clone`
 			receiver_type_name = 'array'

--- a/vlib/v/tests/array_clear_test.v
+++ b/vlib/v/tests/array_clear_test.v
@@ -1,0 +1,29 @@
+struct Registry[T] {
+mut:
+	events []EventHandler[T]
+}
+
+struct EventHandler[T] {
+	name T
+}
+
+fn (mut r Registry[T]) test() {
+	mut events := []EventHandler[string]{}
+	r.events << EventHandler[string]{
+		name: 'test'
+	}
+	assert 1 == r.events.len
+
+	r.events.clear()
+	events.clear()
+
+	assert events.len == r.events.len
+}
+
+fn test_main() {
+	mut registry := &Registry[string]{
+		events: []
+	}
+	registry.test()
+	assert dump(registry.events).len == 0
+}


### PR DESCRIPTION
Fix #18572

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7a8a23</samp>

Implement and test the `array.clear()` method for generic arrays. Add C code generation for the `clear` array method and a test file `array_clear_test.v` that checks the functionality and memory management of the method.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7a8a23</samp>

* Implement array.clear() method for generic arrays ([link](https://github.com/vlang/v/pull/18792/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L1284-R1284), [link](https://github.com/vlang/v/pull/18792/files?diff=unified&w=0#diff-9711ea2fc527233cc3157b952c074196ac96555b9a1c1bf6283b5f29366454c2R1-R29))
  - Add 'clear' to the list of array methods handled by C generator in `vlib/v/gen/c/fn.v` ([link](https://github.com/vlang/v/pull/18792/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L1284-R1284))
  - Add test file `vlib/v/tests/array_clear_test.v` that defines a generic struct Registry with a field of type []EventHandler[T] and tests the clear() method on it and a local variable of type []EventHandler[string] ([link](https://github.com/vlang/v/pull/18792/files?diff=unified&w=0#diff-9711ea2fc527233cc3157b952c074196ac96555b9a1c1bf6283b5f29366454c2R1-R29))
