### PR TITLE
checker: allow returning of alias of fixed array

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -129,8 +129,6 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 						node.return_type_pos)
 				}
 			}
-		} else if c.table.sym(node.return_type).kind == .alias && return_sym.kind == .array_fixed {
-			c.error('fixed array cannot be returned by function using alias', node.return_type_pos)
 		}
 		// Ensure each generic type of the parameter was declared in the function's definition
 		if node.return_type.has_flag(.generic) {

--- a/vlib/v/tests/alias_fixed_array_return_test.v
+++ b/vlib/v/tests/alias_fixed_array_return_test.v
@@ -1,0 +1,22 @@
+type U24 = [3]u8
+
+fn from_u32(val u32) U24 {
+	mut v := U24([3]u8{})
+	_ = v[2]
+	v[0] = u8((val >> 16) & 0xFF)
+	v[1] = u8((val >> 8) & 0xFF)
+	v[2] = u8(val & 0xFF)
+	return v
+}
+
+fn to_u32(v U24) u32 {
+	return u32(v[2]) | u32(v[1]) << u8(8) | u32(v[0]) << 16
+}
+
+fn test_alias_fixed_array_return() {
+	a := u32(1)
+	v := from_u32(a)
+	assert v == U24([u8(0), 0, 1]!)
+	assert '${v}' == 'U24([0, 0, 1])'
+	dump(v)
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18796

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 216b8cd</samp>

This pull request allows functions to return fixed arrays by alias types, and adds a test case for this feature. It removes an unnecessary error check in `vlib/v/checker/fn.v` and adds a new file `vlib/v/tests/alias_fixed_array_return_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 216b8cd</samp>

* Remove error check for returning fixed array by alias type ([link](https://github.com/vlang/v/pull/18798/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL132-L133))
* Add test case for converting between u32 and U24 alias type ([link](https://github.com/vlang/v/pull/18798/files?diff=unified&w=0#diff-ce489946961c5e922dd71b1c9aa5c77e297add1404746488b7a705160dc1e14bR1-R22))
