### PR TITLE
json: fix option alias support

### DIFF
--- a/vlib/json/json_option_alias_test.v
+++ b/vlib/json/json_option_alias_test.v
@@ -16,6 +16,7 @@ fn test_empty() {
 	test := Test{}
 	encoded := json.encode(test)
 	assert dump(encoded) == '{}'
+	assert json.decode(Test, '{}')! == test
 }
 
 fn test_value() {
@@ -24,6 +25,7 @@ fn test_value() {
 	}
 	encoded := json.encode(test)
 	assert dump(encoded) == '{"optional_alias":1}'
+	assert json.decode(Test, '{"optional_alias":1}')! == test
 }
 
 fn test_value_2() {
@@ -35,4 +37,5 @@ fn test_value_2() {
 	}
 	encoded := json.encode(test)
 	assert dump(encoded) == '{"optional_alias":1,"optional_struct":{"a":1}}'
+	assert json.decode(Test, '{"optional_alias":1,"optional_struct":{"a":1}}')! == test
 }

--- a/vlib/json/json_option_alias_test.v
+++ b/vlib/json/json_option_alias_test.v
@@ -1,0 +1,38 @@
+import json
+
+struct Test {
+	optional_alias  ?MyAlias  // primitive
+	optional_struct ?MyAlias2 // complex
+}
+
+struct Complex {
+	a int = 3
+}
+
+type MyAlias = int
+type MyAlias2 = Complex
+
+fn test_empty() {
+	test := Test{}
+	encoded := json.encode(test)
+	assert dump(encoded) == '{}'
+}
+
+fn test_value() {
+	test := Test{
+		optional_alias: 1
+	}
+	encoded := json.encode(test)
+	assert dump(encoded) == '{"optional_alias":1}'
+}
+
+fn test_value_2() {
+	test := Test{
+		optional_alias: 1
+		optional_struct: Complex{
+			a: 1
+		}
+	}
+	encoded := json.encode(test)
+	assert dump(encoded) == '{"optional_alias":1,"optional_struct":{"a":1}}'
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -145,7 +145,7 @@ ${enc_fn_dec} {
 			enc.writeln(g.encode_map(utyp, m.key_type, m.value_type))
 		} else if sym.kind == .alias {
 			a := sym.info as ast.Alias
-			mut parent_typ := a.parent_type
+			parent_typ := a.parent_type
 			psym := g.table.sym(parent_typ)
 			if is_js_prim(g.typ(parent_typ)) {
 				if utyp.has_flag(.option) {

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -145,11 +145,16 @@ ${enc_fn_dec} {
 			enc.writeln(g.encode_map(utyp, m.key_type, m.value_type))
 		} else if sym.kind == .alias {
 			a := sym.info as ast.Alias
-			parent_typ := a.parent_type
+			mut parent_typ := a.parent_type
 			psym := g.table.sym(parent_typ)
 			if is_js_prim(g.typ(parent_typ)) {
-				g.gen_json_for_type(parent_typ)
-				g.gen_prim_enc_dec(parent_typ, mut enc, mut dec)
+				if utyp.has_flag(.option) {
+					g.gen_json_for_type(parent_typ.set_flag(.option))
+					g.gen_option_enc_dec(parent_typ.set_flag(.option), mut enc, mut dec)
+				} else {
+					g.gen_json_for_type(parent_typ)
+					g.gen_prim_enc_dec(parent_typ, mut enc, mut dec)
+				}
 			} else if psym.info is ast.Struct {
 				enc.writeln('\to = cJSON_CreateObject();')
 				g.gen_struct_enc_dec(utyp, psym.info, ret_styp, mut enc, mut dec)
@@ -163,6 +168,8 @@ ${enc_fn_dec} {
 				g.gen_json_for_type(m.value_type)
 				dec.writeln(g.decode_map(utyp, m.key_type, m.value_type, ret_styp))
 				enc.writeln(g.encode_map(utyp, m.key_type, m.value_type))
+			} else if utyp.has_flag(.option) {
+				g.gen_option_enc_dec(utyp, mut enc, mut dec)
 			} else {
 				verror('json: ${sym.name} is not struct')
 			}
@@ -684,9 +691,14 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				dec.writeln('\t}')
 			} else if field_sym.kind == .alias {
 				alias := field_sym.info as ast.Alias
-				parent_type := g.typ(alias.parent_type)
-				parent_dec_name := js_dec_name(parent_type)
-				if is_js_prim(parent_type) {
+				parent_type := if field.typ.has_flag(.option) {
+					alias.parent_type.set_flag(.option)
+				} else {
+					alias.parent_type
+				}
+				sparent_type := g.typ(parent_type)
+				parent_dec_name := js_dec_name(sparent_type)
+				if is_js_prim(sparent_type) {
 					tmp := g.new_tmp_var()
 					gen_js_get(styp, tmp, name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
@@ -697,7 +709,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					}
 					dec.writeln('\t}')
 				} else {
-					g.gen_json_for_type(alias.parent_type)
+					g.gen_json_for_type(parent_type)
 					tmp := g.new_tmp_var()
 					gen_js_get_opt(dec_name, field_type, styp, tmp, name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
@@ -772,7 +784,11 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 		if !is_js_prim(field_type) {
 			if field_sym.kind == .alias {
 				ainfo := field_sym.info as ast.Alias
-				enc_name = js_enc_name(g.typ(ainfo.parent_type))
+				if field.typ.has_flag(.option) {
+					enc_name = js_enc_name(g.typ(ainfo.parent_type.set_flag(.option)))
+				} else {
+					enc_name = js_enc_name(g.typ(ainfo.parent_type))
+				}
 			}
 		}
 		if field_sym.kind == .enum_ {
@@ -806,7 +822,12 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", json__encode_u64(${prefix_enc}${op}${c_name(field.name)}._v_unix));')
 			} else {
 				if !field.typ.is_any_kind_of_pointer() {
-					enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", ${enc_name}(${prefix_enc}${op}${c_name(field.name)})); /*A*/')
+					if field_sym.kind == .alias && field.typ.has_flag(.option) {
+						parent_type := g.table.unaliased_type(field.typ).set_flag(.option)
+						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", ${enc_name}(*(${g.typ(parent_type)}*)&${prefix_enc}${op}${c_name(field.name)})); /*?A*/')
+					} else {
+						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", ${enc_name}(${prefix_enc}${op}${c_name(field.name)})); /*A*/')
+					}
 				} else {
 					arg_prefix := if field.typ.is_ptr() { '' } else { '*' }
 					sptr_value := '${prefix_enc}${op}${c_name(field.name)}'


### PR DESCRIPTION
Fix #18775

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72f8aab</samp>

This pull request enhances the JSON support for optional alias types in V. It fixes the code generation for encoding and decoding such types in `vlib/v/gen/c/json.v` and adds a new test file `json_option_alias_test.v` to verify the functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72f8aab</samp>

*  Add support for encoding and decoding optional alias types in JSON ([link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L148-R157), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48R171-R172), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L687-R701), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L700-R712), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L775-R791), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L809-R830))
  * Modify `gen_json_for_type` to handle alias types with the `.option` flag by calling `gen_option_enc_dec` with the parent type also having the `.option` flag ([link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L148-R157))
  * Add a new case to `gen_json_for_type` to handle non-alias types with the `.option` flag by calling `gen_option_enc_dec` with the given type ([link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48R171-R172))
  * Modify `gen_struct_dec` to set the parent type of an alias field with the `.option` flag to also have the `.option` flag, and use it for casting and unwrapping the optional value ([link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L687-R701), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L700-R712))
  * Modify `gen_struct_enc` to set the parent type of an alias field with the `.option` flag to also have the `.option` flag, and use it for wrapping and casting the optional value. Add a special case for non-pointer optional alias types by dereferencing and casting the field value ([link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L775-R791), [link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L809-R830))
* Add a new test file `json_option_alias_test.v` to test the JSON output for different cases of empty or present optional alias values ([link](https://github.com/vlang/v/pull/18801/files?diff=unified&w=0#diff-3560ff4b61d5aed6e2dbb36ca276fa8a5831eb8c6f61c58d044058c3fb786906R1-R38))
