### PR TITLE
json: fix option state

### DIFF
--- a/vlib/json/json_option_none_test.v
+++ b/vlib/json/json_option_none_test.v
@@ -1,0 +1,46 @@
+import json
+
+struct Struct {
+	a int
+}
+
+struct Test {
+	a ?int
+	b ?string
+	c ?Struct
+}
+
+fn test_main() {
+	a := json.decode(Test, '{"a": 1, "b": "foo"}')!
+	dump(a)
+
+	assert a.a != none
+	assert a.b != none
+
+	b := json.decode(Test, '{"a": 1}')!
+	dump(b)
+	assert b.a != none
+	assert b.b == none
+
+	c := json.decode(Test, '{"a": 1, "b": null}')!
+	dump(b)
+	assert c.a != none
+	assert c.b == none
+
+	d := json.decode(Test, '{"a": null, "b": null}')!
+	dump(d)
+	assert d.a == none
+	assert d.b == none
+
+	e := json.decode(Test, '{"a": null, "b": null, "c": null}')!
+	dump(e)
+	assert e.a == none
+	assert e.b == none
+	assert e.c == none
+
+	f := json.decode(Test, '{"a": null, "b": null, "c": {"a":1}}')!
+	dump(f)
+	assert f.a == none
+	assert f.b == none
+	assert f.c != none
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -65,6 +65,9 @@ fn (mut g Gen) gen_jsons() {
 				g.expr_with_tmp_var(ast.Expr(ast.StructInit{ typ: utyp, typ_str: styp }),
 					utyp, utyp, 'res')
 				init_styp = g.out.cut_to(pos).trim_space()
+			} else {
+				none_str := g.expr_string(ast.None{})
+				init_styp += ' = (${styp}){ .state=2, .err=${none_str}, .data={EMPTY_STRUCT_INITIALIZATION} }'
 			}
 		} else {
 			if sym.kind == .struct_ {


### PR DESCRIPTION
This PR fixes the option state created from json module.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42fe8e6</samp>

This pull request enhances the JSON support in V by fixing and improving the C code generation for optional fields and elements. It also adds a new test file `vlib/json/json_option_none_test.v` to verify the correct decoding of JSON objects with optional fields.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42fe8e6</samp>

*  Add a condition to check the result state before setting the option value for JSON objects with optional fields ([link](https://github.com/vlang/v/pull/18802/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L193-R195)). This fixes a bug where the option value could be set to a garbage value when the field is missing or invalid.
