### PR TITLE
cgen: fix nested or expr call (fix #18803)

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -152,6 +152,7 @@ const (
 		'vlib/net/smtp/smtp_test.v',
 		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
 		'vlib/v/tests/fn_literal_type_test.v',
+		'vlib/v/tests/nested_or_expr_call_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'do_not_remove',
@@ -187,6 +188,7 @@ const (
 		'vlib/gg/draw_fns_api_test.v',
 		'vlib/v/tests/skip_unused/gg_code.vv',
 		'vlib/v/tests/c_struct_with_reserved_field_name_test.v',
+		'vlib/v/tests/nested_or_expr_call_test.v',
 	]
 	skip_on_ubuntu_musl           = [
 		'do_not_remove',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -152,7 +152,6 @@ const (
 		'vlib/net/smtp/smtp_test.v',
 		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
 		'vlib/v/tests/fn_literal_type_test.v',
-		'vlib/v/tests/nested_or_expr_call_test.v',
 	]
 	skip_with_fsanitize_address   = [
 		'do_not_remove',
@@ -188,7 +187,6 @@ const (
 		'vlib/gg/draw_fns_api_test.v',
 		'vlib/v/tests/skip_unused/gg_code.vv',
 		'vlib/v/tests/c_struct_with_reserved_field_name_test.v',
-		'vlib/v/tests/nested_or_expr_call_test.v',
 	]
 	skip_on_ubuntu_musl           = [
 		'do_not_remove',

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6115,11 +6115,8 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 	}
 	if or_block.kind == .block {
 		g.or_expr_return_type = return_type.clear_flags(.option, .result)
-		if g.inside_or_block {
-			g.writeln('\terr = ${cvar_name}.err;')
-		} else {
-			g.writeln('\tIError err = ${cvar_name}.err;')
-		}
+		g.writeln('\tIError err = ${cvar_name}.err;')
+
 		g.inside_or_block = true
 		defer {
 			g.inside_or_block = false

--- a/vlib/v/tests/nested_or_expr_call_test.v
+++ b/vlib/v/tests/nested_or_expr_call_test.v
@@ -1,0 +1,37 @@
+import db.sqlite
+
+// sets a custom table name. Default is struct name (case-sensitive)
+[table: 'customers']
+struct Customer {
+	id   int    [primary; sql: serial] // a field named `id` of integer type must be the first field
+	name string
+}
+
+fn test_nested_or_expr_call() {
+	db := sqlite.connect(':memory:')!
+
+	sql db {
+		create table Customer
+	}!
+
+	uid_map := map[int]string{}
+	uid := 2
+	username := if uid <= 0 {
+		'unknown'
+	} else {
+		uid_map[uid] or {
+			users := sql db {
+				select from Customer where id == uid
+			} or {
+				[Customer{
+					id: uid
+					name: 'unknown'
+				}]
+			}
+			name := if users.len == 1 { users[0].name } else { 'unknown' }
+			name
+		}
+	}
+	println('${uid} is ${username}')
+	assert username == 'unknown'
+}

--- a/vlib/v/tests/nested_or_expr_call_test.v
+++ b/vlib/v/tests/nested_or_expr_call_test.v
@@ -1,37 +1,19 @@
-import db.sqlite
-
-// sets a custom table name. Default is struct name (case-sensitive)
-[table: 'customers']
-struct Customer {
-	id   int    [primary; sql: serial] // a field named `id` of integer type must be the first field
-	name string
+fn get_name() !string {
+	return error('failed')
 }
 
 fn test_nested_or_expr_call() {
-	db := sqlite.connect(':memory:')!
-
-	sql db {
-		create table Customer
-	}!
-
 	uid_map := map[int]string{}
 	uid := 2
 	username := if uid <= 0 {
 		'unknown'
 	} else {
 		uid_map[uid] or {
-			users := sql db {
-				select from Customer where id == uid
-			} or {
-				[Customer{
-					id: uid
-					name: 'unknown'
-				}]
+			name := get_name() or {
+				'unknown'
 			}
-			name := if users.len == 1 { users[0].name } else { 'unknown' }
 			name
 		}
 	}
 	println('${uid} is ${username}')
-	assert username == 'unknown'
 }

--- a/vlib/v/tests/nested_or_expr_call_test.v
+++ b/vlib/v/tests/nested_or_expr_call_test.v
@@ -9,11 +9,10 @@ fn test_nested_or_expr_call() {
 		'unknown'
 	} else {
 		uid_map[uid] or {
-			name := get_name() or {
-				'unknown'
-			}
+			name := get_name() or { 'unknown' }
 			name
 		}
 	}
+	assert username == 'unknown'
 	println('${uid} is ${username}')
 }


### PR DESCRIPTION
This PR fix nested or expr call (fix #18803).

- Fix nested or expr call.
- Add test.

```v
import db.sqlite

// sets a custom table name. Default is struct name (case-sensitive)
[table: 'customers']
struct Customer {
	id   int    [primary; sql: serial] // a field named `id` of integer type must be the first field
	name string
}

fn main() {
	db := sqlite.connect(':memory:')!

	sql db {
		create table Customer
	}!

	uid_map := map[int]string{}
	uid := 2
	username := if uid <= 0 {
		'unknown'
	} else {
		uid_map[uid] or {
			users := sql db {
				select from Customer where id == uid
			} or {
				[Customer{
					id: uid
					name: 'unknown'
				}]
			}
			name := if users.len == 1 { users[0].name } else { 'unknown' }
			name
		}
	}
	println('${uid} is ${username}')
}

PS D:\Test\v\tt1> v run .
2 is unknown
```