### PR TITLE
cgen: fix dump of map with option value

### DIFF
--- a/vlib/v/tests/option_map_value_test.v
+++ b/vlib/v/tests/option_map_value_test.v
@@ -1,0 +1,41 @@
+struct Struct {
+	a int
+}
+
+fn test_str() {
+	mut data := map[string]?string{}
+	data = {
+		'name': ?string('andre')
+		'age':  ?string('')
+	}
+	dump(data)
+}
+
+fn test_complex() {
+	mut data := map[string]?Struct{}
+	data = {
+		'a': ?Struct{
+			a: 1
+		}
+		'b': ?Struct{}
+	}
+	dump(data)
+}
+
+fn test_int() {
+	mut data := map[string]?int{}
+	data = {
+		'a': ?int(0)
+		'b': ?int(none)
+	}
+	dump(data)
+}
+
+fn test_f64() {
+	mut data := map[string]?f64{}
+	data = {
+		'a': ?f64(0)
+		'b': ?f64(none)
+	}
+	dump(data)
+}


### PR DESCRIPTION
Fix #18806

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3887054</samp>

This pull request adds support for `auto_str` methods for maps with optional values in V. It modifies the code generator in `vlib/v/gen/c/auto_str_methods.v` and adds a test file in `vlib/v/tests/option_map_value_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3887054</samp>

*  Add support for auto str methods for maps with optional values ([link](https://github.com/vlang/v/pull/18813/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL786-R792), [link](https://github.com/vlang/v/pull/18813/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL793-R805), [link](https://github.com/vlang/v/pull/18813/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bL803-R816))
*  Add tests for auto str methods for maps with optional values in `vlib/v/tests/option_map_value_test.v` ([link](https://github.com/vlang/v/pull/18813/files?diff=unified&w=0#diff-69a29749457acacc413dcbb56fe0105d37a2e7e12ddbcda381630a7e8b20b1c9R1-R41))
