### PR TITLE
cgen: ensure that `<<` and `>>` has higher precedence, than `+` and `-` (diff between C and V precedences)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -35,7 +35,16 @@ fn (mut g Gen) infix_expr(node ast.InfixExpr) {
 			g.infix_expr_arithmetic_op(node)
 		}
 		.left_shift {
+			// `a << b` can mean many things in V ...
+			// TODO: disambiguate everything in the checker; cgen should not decide all this.
+			// Instead it should be as simple, as the branch for .right_shift is.
+			// `array << val` should have its own separate operation internally.
 			g.infix_expr_left_shift_op(node)
+		}
+		.right_shift {
+			g.write('(')
+			g.gen_plain_infix_expr(node)
+			g.write(')')
 		}
 		.and, .logical_or {
 			g.infix_expr_and_or_op(node)
@@ -846,7 +855,9 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			}
 		}
 	} else {
+		g.write('(')
 		g.gen_plain_infix_expr(node)
+		g.write(')')
 	}
 }
 

--- a/vlib/v/tests/shift_test.v
+++ b/vlib/v/tests/shift_test.v
@@ -1,5 +1,21 @@
 type MyInt = int
 
+fn test_shift_left_precedence() {
+	x := u32(20)
+	base := u32(1)
+	shift := u32(3)
+	assert x + base << shift == (x + (base << shift)), '<< should have higher precedence than +'
+	assert x - base << shift == (x - (base << shift)), '<< should have higher precedence than -'
+}
+
+fn test_shift_right_precedence() {
+	x := u32(20)
+	base := u32(100)
+	shift := u32(2)
+	assert x + base >> shift == (x + (base >> shift)), '>> should have higher precedence than +'
+	assert x - base >> shift == (x - (base >> shift)), '>> should have higher precedence than -'
+}
+
 fn test_shift_operators() {
 	// check that shift works with all integer types
 	// as the right-hand side operand


### PR DESCRIPTION
After this PR, this passes without failing the assertion:
```v
fn main() {
        x := u32(1)
        base := u32(2)
        shift := u32(3)
        dump(x + base << shift)
        dump(x + (base << shift))
        dump((x+base) << shift)
        assert x + base << shift == (x + (base << shift))
}
```
printing:
```
[file.v:5] x + base << shift: 17
[file.v:6] x + (base << shift): 17
[file.v:7] (x + base) << shift: 24
```