### PR TITLE
v: allow none values on map initialization

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -409,6 +409,11 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		expecting_interface_map := map_value_sym.kind == .interface_
 		//
 		mut same_key_type := true
+
+		if node.keys.len == 1 && val0_type == ast.none_type {
+			c.error('map value cannot be only `none`', node.vals[0].pos())
+		}
+
 		for i, mut key in node.keys {
 			if i == 0 && !use_expected_type {
 				continue
@@ -444,6 +449,9 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 					msg := c.expected_msg(val_type, node.value_type)
 					c.error('invalid map value: ${msg}', val.pos())
 				}
+			}
+			if val_type == ast.none_type && val0_type.has_flag(.option) {
+				continue
 			}
 			if !c.check_types(val_type, val0_type)
 				|| val0_type.has_flag(.option) != val_type.has_flag(.option)

--- a/vlib/v/checker/tests/map_with_none_err.out
+++ b/vlib/v/checker/tests/map_with_none_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/map_with_none_err.vv:2:6: warning: unused variable: `a`
+    1 | fn main() {
+    2 |     mut a := {
+      |         ^
+    3 |         'bar': none
+    4 |     }
+vlib/v/checker/tests/map_with_none_err.vv:6:6: warning: unused variable: `b`
+    4 |     }
+    5 | 
+    6 |     mut b := {
+      |         ^
+    7 |         'foo': 1,
+    8 |         'bar': none
+vlib/v/checker/tests/map_with_none_err.vv:11:6: warning: unused variable: `c`
+    9 |     }
+   10 | 
+   11 |     mut c := {
+      |         ^
+   12 |         'foo': ?int(none),
+   13 |         'bar': none
+vlib/v/checker/tests/map_with_none_err.vv:3:10: error: map value cannot be only `none`
+    1 | fn main() {
+    2 |     mut a := {
+    3 |         'bar': none
+      |                ~~~~
+    4 |     }
+    5 |
+vlib/v/checker/tests/map_with_none_err.vv:8:10: error: invalid map value: expected `int`, not `none`
+    6 |     mut b := {
+    7 |         'foo': 1,
+    8 |         'bar': none
+      |                ~~~~
+    9 |     }
+   10 |

--- a/vlib/v/checker/tests/map_with_none_err.vv
+++ b/vlib/v/checker/tests/map_with_none_err.vv
@@ -1,0 +1,15 @@
+fn main() {
+	mut a := {
+		'bar': none
+	}
+
+	mut b := {
+		'foo': 1,
+		'bar': none
+	}
+
+	mut c := {
+		'foo': ?int(none),
+		'bar': none
+	}
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4018,7 +4018,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			}
 			if value_sym.kind == .sum_type {
 				g.expr_with_cast(expr, node.val_types[i], unwrap_val_typ)
-			} else if node.val_types[i].has_flag(.option) {
+			} else if node.val_types[i].has_flag(.option) || node.val_types[i] == ast.none_type {
 				g.expr_with_opt(expr, node.val_types[i], unwrap_val_typ)
 			} else {
 				g.expr(expr)

--- a/vlib/v/tests/option_map_none_test.v
+++ b/vlib/v/tests/option_map_none_test.v
@@ -1,0 +1,17 @@
+fn test_main() {
+	mut a := {
+		'foo': ?int(1)
+		'bar': none
+	}
+	a['foo'] = 1
+	assert dump(a) == a
+}
+
+fn test_none() {
+	mut a := {
+		'foo': ?int(1)
+		'bar': none
+	}
+	a['foo'] = none
+	assert dump(a) == a
+}


### PR DESCRIPTION
This PR allows to initialized a map with none values, when its value type is an option.

```V
fn test_main() {
	mut a := {
		'foo': ?int(1)
		'bar': none
	}
	a['foo'] = 1
	assert dump(a) == a
}

fn test_none() {
	mut a := {
		'foo': ?int(1)
		'bar': none
	}
	a['foo'] = none
	assert dump(a) == a
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bae8cf</samp>

This pull request fixes and tests map literals with `none` values in V. It improves the checker to report errors for invalid map values, and the C backend to generate correct code for option values. It adds test files for the checker and the map operations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1bae8cf</samp>

*  Add a check for invalid map values of `none` ([link](https://github.com/vlang/v/pull/18821/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR412-R416))
*  Skip type check for map values of `none` when the expected type is an option type ([link](https://github.com/vlang/v/pull/18821/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR453-R455))
*  Modify code generation for map literals with `none` or option values in the C backend ([link](https://github.com/vlang/v/pull/18821/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4021-R4021))
*  Add test files for map literals with `none` and option values ([link](https://github.com/vlang/v/pull/18821/files?diff=unified&w=0#diff-85e8782357a245da2fb7b443c9c4d069cf0d7baf26b0d90bc4b75201ed62eef7L1-R14), [link](https://github.com/vlang/v/pull/18821/files?diff=unified&w=0#diff-d03369db9b1d9ff5d529a12996d597a38431077491ad275128d13cb591d42075R1-R17))
*  Add expected output for the checker test file ([link](https://github.com/vlang/v/pull/18821/files?diff=unified&w=0#diff-95ea38b85cd22b5125af2493d04af9299db3539170ff05ca9fa11cfd1b70472dR1-R34))
