### PR TITLE
all: remove any type future implementation reference

### DIFF
--- a/vlib/v/checker/tests/struct_field_with_any_type_err.out
+++ b/vlib/v/checker/tests/struct_field_with_any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use `any` type here, `any` will be implemented in V 0.4
+vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use `any` type here
     1 | struct My_type {
     2 |     fld any
       |         ~~~

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -648,9 +648,10 @@ fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_dot b
 						ret = ast.int_literal_type
 					}
 					'any' {
-						if !(p.file_backend_mode != .js && p.mod != 'builtin') {
-							ret = ast.any_type
+						if p.file_backend_mode != .js && p.mod != 'builtin' {
+							p.error('cannot use `any` type here')
 						}
+						ret = ast.any_type
 					}
 					else {
 						p.next()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -648,7 +648,7 @@ fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_dot b
 						ret = ast.int_literal_type
 					}
 					'any' {
-						if p.file_backend_mode == .js && p.mod == 'builtin' {
+						if !(p.file_backend_mode != .js && p.mod != 'builtin') {
 							ret = ast.any_type
 						}
 					}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -648,10 +648,9 @@ fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_dot b
 						ret = ast.int_literal_type
 					}
 					'any' {
-						if p.file_backend_mode != .js && p.mod != 'builtin' {
-							p.error('cannot use `any` type here, `any` will be implemented in V 0.4')
+						if p.file_backend_mode == .js && p.mod == 'builtin' {
+							ret = ast.any_type
 						}
-						ret = ast.any_type
 					}
 					else {
 						p.next()

--- a/vlib/v/parser/tests/cast_to_any_type_err.out
+++ b/vlib/v/parser/tests/cast_to_any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/cast_to_any_type_err.vv:2:7: error: cannot use `any` type here, `any` will be implemented in V 0.4
+vlib/v/parser/tests/cast_to_any_type_err.vv:2:7: error: cannot use `any` type here
     1 | fn main() {
     2 |     a := any(22)
       |          ~~~


### PR DESCRIPTION
Fix #18815

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80db818</samp>

Simplify the parser logic for the `any` type in `vlib/v/parser/parse_type.v`. Restrict the use of `any` to the `builtin` module in `js` mode.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80db818</samp>

*  Simplify the condition for using the `any` type in the parser ([link](https://github.com/vlang/v/pull/18822/files?diff=unified&w=0#diff-df4e07c6e98909e5d04fa219a5840be5ffb5d15033e4d64a111e12789479f3ffL651-R653))
