### PR TITLE
cgen: fix anon fn direct call with option (fix #18825)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -683,9 +683,12 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			tmp_var := g.new_tmp_var()
 			fn_type := g.fn_var_signature(node.left.decl.return_type, node.left.decl.params.map(it.typ),
 				tmp_var)
+			line := g.go_before_stmt(0).trim_space()
+			g.empty_line = true
 			g.write('${fn_type} = ')
 			g.expr(node.left)
 			g.writeln(';')
+			g.write(line)
 			g.write(tmp_var)
 		} else if node.or_block.kind == .absent {
 			g.expr(node.left)

--- a/vlib/v/tests/anon_fn_direct_call_with_option_test.v
+++ b/vlib/v/tests/anon_fn_direct_call_with_option_test.v
@@ -1,0 +1,17 @@
+fn test_anon_fn_direct_call_with_option() {
+	z := true
+	a := fn [z] () ?int {
+		match z {
+			true { return 1 }
+			else { return none }
+		}
+	}()
+	b := a or {
+		println('failed')
+		return
+	}
+
+	println('b: ${b}')
+	println(a)
+	assert b == 1
+}


### PR DESCRIPTION
This PR fix anon fn direct call with option (fix #18825).

- Fix anon fn direct call with option.
- Add test.

```v
fn main() {
	z := true
	a := fn [z] () ?int {
		match z {
			true { return 1 }
			else { return none }
		}
	}()
	b := a or {
		println('failed')
		return
	}

	println('b: ${b}')
	println(a)
	assert b == 1
}

PS D:\Test\v\tt1> v run .
b: 1
Option(1)
```