### PR TITLE
cgen: fix cross assign with aliased array (fix #18828)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -889,7 +889,7 @@ fn (mut g Gen) gen_cross_var_assign(node &ast.AssignStmt) {
 				}
 			}
 			ast.IndexExpr {
-				sym := g.table.sym(left.left_type)
+				sym := g.table.sym(g.table.unaliased_type(left.left_type))
 				if sym.kind == .array {
 					info := sym.info as ast.Array
 					elem_typ := g.table.sym(info.elem_type)

--- a/vlib/v/tests/cross_assign_aliased_array_test.v
+++ b/vlib/v/tests/cross_assign_aliased_array_test.v
@@ -1,0 +1,13 @@
+pub type IntSlice = []int
+
+pub fn (mut x IntSlice) swap(i int, j int) {
+	x[i], x[j] = x[j], x[i]
+}
+
+fn test_cross_assign_aliased_array() {
+	mut x := IntSlice([11, 22])
+	println(x)
+	x.swap(0, 1)
+	println(x)
+	assert x == IntSlice([22, 11])
+}


### PR DESCRIPTION
This PR fix cross assign with aliased array (fix #18828).

- Fix cross assign with aliased array.
- Add test.

```v
pub type IntSlice = []int

pub fn (mut x IntSlice) swap(i int, j int) {
	x[i], x[j] = x[j], x[i]
}

fn main() {
	mut x := IntSlice([11, 22])
	println(x)
	x.swap(0, 1)
	println(x)
	assert x == IntSlice([22, 11])
}

PS D:\Test\v\tt1> v run .
IntSlice([11, 22])
IntSlice([22, 11])
```