### PR TITLE
checker: fix autocast in complex if condtions 5

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -857,6 +857,11 @@ fn (mut c Checker) autocast_in_if_conds(mut right ast.Expr, from_expr ast.Expr, 
 		ast.ParExpr {
 			c.autocast_in_if_conds(mut right.expr, from_expr, from_type, to_type)
 		}
+		ast.AsCast {
+			if right.typ != to_type {
+				c.autocast_in_if_conds(mut right.expr, from_expr, from_type, to_type)
+			}
+		}
 		ast.PrefixExpr {
 			c.autocast_in_if_conds(mut right.right, from_expr, from_type, to_type)
 		}


### PR DESCRIPTION
This PR fix autocast in complex if condtions 5.

```v
	return node is ast.Ident && node.info is ast.IdentVar && node.kind == .variable
		&& ((node as ast.Ident).obj as ast.Var).ct_type_var != .no_comptime
```
to
```v
	return node is ast.Ident && node.info is ast.IdentVar && node.kind == .variable
		&& (node.obj as ast.Var).ct_type_var != .no_comptime
```