### PR TITLE
parser: change warn to error for const name with upper letter (fix #18838)

### DIFF
--- a/vlib/v/checker/tests/const_field_name_snake_case.out
+++ b/vlib/v/checker/tests/const_field_name_snake_case.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/const_field_name_snake_case.vv:2:2: warning: const names cannot contain uppercase letters, use snake_case instead
+vlib/v/checker/tests/const_field_name_snake_case.vv:2:2: error: const names cannot contain uppercase letters, use snake_case instead
     1 | const (
     2 |     Red = 1
       |     ~~~

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3689,7 +3689,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 		pos := p.tok.pos()
 		name := p.check_name()
 		end_comments << p.eat_comments()
-		if util.contains_capital(name) {
+		if !p.is_translated && util.contains_capital(name) {
 			p.error_with_pos('const names cannot contain uppercase letters, use snake_case instead',
 				pos)
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3689,7 +3689,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 		pos := p.tok.pos()
 		name := p.check_name()
 		end_comments << p.eat_comments()
-		if !p.is_translated && util.contains_capital(name) {
+		if !p.pref.translated && !p.is_translated && util.contains_capital(name) {
 			p.error_with_pos('const names cannot contain uppercase letters, use snake_case instead',
 				pos)
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3690,7 +3690,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 		name := p.check_name()
 		end_comments << p.eat_comments()
 		if util.contains_capital(name) {
-			p.warn_with_pos('const names cannot contain uppercase letters, use snake_case instead',
+			p.error_with_pos('const names cannot contain uppercase letters, use snake_case instead',
 				pos)
 		}
 		full_name := p.prepend_mod(name)


### PR DESCRIPTION
This PR change warn to error for const name with upper letter (fix #18838).

- Change warn to error for const name with upper letter.
- Modify the test.

```v
const CMB_CONJUNTO_QT_DE_BOLAS = 10

fn main() {
	qt_bolas_selecionadas := 1
	
	if qt_bolas_selecionadas == CMB_CONJUNTO_QT_DE_BOLAS {		
		for id := 0; id < 100; id += 1  {
			println("valor: ${id}")
		}
	}	

	if qt_bolas_selecionadas == CMB_CONJUNTO_QT_DE_BOLAS {
		for id := 0; id < 100; id += 1  {
			println("valor: ${id}")
		}
	}	
}

PS D:\Test\v\tt1> v run .
tt1.v:1:7: error: const names cannot contain uppercase letters, use snake_case instead
    1 | const CMB_CONJUNTO_QT_DE_BOLAS = 10
      |       ~~~~~~~~~~~~~~~~~~~~~~~~
    2 | 
    3 | fn main() {
```