### PR TITLE
docs: fix location of `asm_test.amd64.v` file

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6664,7 +6664,7 @@ println('c: ${c}') // 120
 ```
 
 For more examples, see
-[github.com/vlang/v/tree/master/vlib/v/tests/assembly/asm_test.amd64.v](https://github.com/vlang/v/tree/master/vlib/v/tests/assembly/asm_test.amd64.v)
+[vlib/v/slow_tests/assembly/asm_test.amd64.v](https://github.com/vlang/v/tree/master/vlib/v/slow_tests/assembly/asm_test.amd64.v)
 
 ### Hot code reloading
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

self-explanatory

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10c5eea</samp>

Fixed a broken link in the documentation of V's assembly support. The link now points to the correct location of the assembly test file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 10c5eea</samp>

* Update the link to the assembly test file in `doc/docs.md` ([link](https://github.com/vlang/v/pull/18841/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L6667-R6667))
