### PR TITLE
checker: fix type checker on auto deref var

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2013,6 +2013,17 @@ pub fn (expr Expr) is_expr() bool {
 	}
 }
 
+pub fn (expr Expr) get_pure_type() Type {
+	match expr {
+		BoolLiteral { return bool_type }
+		CharLiteral { return char_type }
+		FloatLiteral { return f64_type }
+		StringLiteral { return string_type }
+		IntegerLiteral { return i64_type }
+		else { return void_type }
+	}
+}
+
 pub fn (expr Expr) is_pure_literal() bool {
 	return match expr {
 		BoolLiteral, CharLiteral, FloatLiteral, StringLiteral, IntegerLiteral { true }

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -668,6 +668,10 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			&& !right_type.has_flag(.generic) && !left_type.has_flag(.generic) {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
+				// allow literal values to auto deref var (e.g.`for mut v in values { v = 1.0 }`)
+				if left.is_auto_deref_var() && right.is_literal() {
+					continue
+				}
 				// allow for ptr += 2
 				if left_type_unwrapped.is_ptr() && right_type_unwrapped.is_int()
 					&& node.op in [.plus_assign, .minus_assign] {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -670,13 +670,19 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
 				// allow literal values to auto deref var (e.g.`for mut v in values { v = 1.0 }`)
 				if left.is_auto_deref_var() || right.is_auto_deref_var() {
-					left_val := if left.is_auto_deref_var() { left_type.deref() } else { left_type }
-					right_val := if right.is_auto_deref_var() {
+					left_deref := if left.is_auto_deref_var() {
+						left_type.deref()
+					} else {
+						left_type
+					}
+					right_deref := if right.is_literal() {
+						right.get_pure_type()
+					} else if right.is_auto_deref_var() {
 						right_type.deref()
 					} else {
 						right_type
 					}
-					if c.check_types(left_val, right_val) {
+					if c.check_types(left_deref, right_deref) {
 						continue
 					}
 				}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -669,8 +669,12 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
 				// allow literal values to auto deref var (e.g.`for mut v in values { v = 1.0 }`)
-				if left.is_auto_deref_var() && right.is_literal() {
-					continue
+				if left.is_auto_deref_var() {
+					if left_type.is_int_valptr() && right_type.is_int() {
+						continue
+					} else if left_type.is_float_valptr() && right_type.is_float() {
+						continue
+					}
 				}
 				// allow for ptr += 2
 				if left_type_unwrapped.is_ptr() && right_type_unwrapped.is_int()

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -664,8 +664,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
-		if !is_blank_ident && !left.is_auto_deref_var() && !right.is_auto_deref_var()
-			&& right_sym.kind != .placeholder && left_sym.kind != .interface_
+		// println('>>>> ${left} ${left.is_auto_deref_var()} ${right.is_auto_deref_var()}' )
+		// && !left.is_auto_deref_var() && !right.is_auto_deref_var()
+		if !is_blank_ident && right_sym.kind != .placeholder && left_sym.kind != .interface_
 			&& !right_type.has_flag(.generic) && !left_type.has_flag(.generic) {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -675,7 +675,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					} else {
 						left_type
 					}
-					right_deref := if right.is_literal() {
+					right_deref := if right.is_pure_literal() {
 						right.get_pure_type()
 					} else if right.is_auto_deref_var() {
 						right_type.deref()

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -664,8 +664,6 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 			}
 		}
-		// println('>>>> ${left} ${left.is_auto_deref_var()} ${right.is_auto_deref_var()}' )
-		// && !left.is_auto_deref_var() && !right.is_auto_deref_var()
 		if !is_blank_ident && right_sym.kind != .placeholder && left_sym.kind != .interface_
 			&& !right_type.has_flag(.generic) && !left_type.has_flag(.generic) {
 			// Dual sides check (compatibility check)

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -669,10 +669,14 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
 				// allow literal values to auto deref var (e.g.`for mut v in values { v = 1.0 }`)
-				if left.is_auto_deref_var() {
-					if left_type.is_int_valptr() && right_type.is_int() {
-						continue
-					} else if left_type.is_float_valptr() && right_type.is_float() {
+				if left.is_auto_deref_var() || right.is_auto_deref_var() {
+					left_val := if left.is_auto_deref_var() { left_type.deref() } else { left_type }
+					right_val := if right.is_auto_deref_var() {
+						right_type.deref()
+					} else {
+						right_type
+					}
+					if c.check_types(left_val, right_val) {
 						continue
 					}
 				}

--- a/vlib/v/checker/tests/auto_deref_assign_err.out
+++ b/vlib/v/checker/tests/auto_deref_assign_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/auto_deref_assign_err.vv:10:6: error: cannot assign to `o`: expected `&int`, not `string`
+    8 | fn sub( mut o &int ) {
+    9 |     println( 'in function got: ' + o.str() )
+   10 |     o = "mutate int as string??"
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~
+   11 | }

--- a/vlib/v/checker/tests/auto_deref_assign_err.vv
+++ b/vlib/v/checker/tests/auto_deref_assign_err.vv
@@ -1,0 +1,11 @@
+fn main() {
+	mut a := 42
+	println( 'before sub: ' + a.str() )
+	sub( mut a )
+	println( 'after sub: ' + a.str() )
+}
+
+fn sub( mut o &int ) {
+	println( 'in function got: ' + o.str() )
+	o = "mutate int as string??"
+}


### PR DESCRIPTION
Fix #18816

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efbdd63</samp>

Fix a bug in the checker that prevented assigning pointers to struct fields. Remove an extra condition from `vlib/v/checker/assign.v` that caused the error.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efbdd63</samp>

* Remove unnecessary condition for pointer assignments ([link](https://github.com/vlang/v/pull/18842/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dL667-R667))
