### PR TITLE
checker: disallow voidptr cast to struct

### DIFF
--- a/vlib/term/ui/README.md
+++ b/vlib/term/ui/README.md
@@ -19,7 +19,7 @@ fn event(e &tui.Event, x voidptr) {
 }
 
 fn frame(x voidptr) {
-	mut app := &App(x)
+	mut app := unsafe { &App(x) }
 
 	app.tui.clear()
 	app.tui.set_bg_color(r: 63, g: 81, b: 181)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2943,7 +2943,8 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				else {}
 			}
 		}
-		if from_type == ast.voidptr_type_idx && !c.inside_unsafe && !c.file.is_translated {
+		if from_type == ast.voidptr_type_idx && !c.inside_unsafe && !c.pref.translated
+			&& !c.file.is_translated {
 			c.error('cannot cast voidptr to a struct outside `unsafe`', node.pos)
 		}
 		if !from_type.is_int() && final_from_sym.kind != .enum_

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2944,8 +2944,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			}
 		}
 		if from_type == ast.voidptr_type_idx && !c.inside_unsafe {
-			// TODO make this an error
-			c.warn('cannot cast voidptr to a struct outside `unsafe`', node.pos)
+			c.error('cannot cast voidptr to a struct outside `unsafe`', node.pos)
 		}
 		if !from_type.is_int() && final_from_sym.kind != .enum_
 			&& !from_type.is_any_kind_of_pointer() {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2943,7 +2943,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				else {}
 			}
 		}
-		if from_type == ast.voidptr_type_idx && !c.inside_unsafe {
+		if from_type == ast.voidptr_type_idx && !c.inside_unsafe && !c.file.is_translated {
 			c.error('cannot cast voidptr to a struct outside `unsafe`', node.pos)
 		}
 		if !from_type.is_int() && final_from_sym.kind != .enum_

--- a/vlib/v/checker/tests/voidptr_cast_to_struct_err.out
+++ b/vlib/v/checker/tests/voidptr_cast_to_struct_err.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/voidptr_cast_to_struct_err.vv:4:7: error: cannot cast `voidptr` to struct
     2 | 
     3 | fn main() {
-    4 |     a := Foo(voidptr(0))
-      |          ~~~~~~~~~~~~~~~
+    4 |     a := Foo(unsafe { nil })
+      |          ~~~~~~~~~~~~~~~~~~~
     5 |     println(a)
     6 | }

--- a/vlib/v/checker/tests/voidptr_cast_to_struct_err.out
+++ b/vlib/v/checker/tests/voidptr_cast_to_struct_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/voidptr_cast_to_struct_err.vv:4:7: error: cannot cast `voidptr` to struct
+    2 | 
+    3 | fn main() {
+    4 |     a := Foo(voidptr(0))
+      |          ~~~~~~~~~~~~~~~
+    5 |     println(a)
+    6 | }

--- a/vlib/v/checker/tests/voidptr_cast_to_struct_err.vv
+++ b/vlib/v/checker/tests/voidptr_cast_to_struct_err.vv
@@ -1,0 +1,6 @@
+struct Foo {}
+
+fn main() {
+	a := Foo(voidptr(0))
+	println(a)
+}

--- a/vlib/v/checker/tests/voidptr_cast_to_struct_err.vv
+++ b/vlib/v/checker/tests/voidptr_cast_to_struct_err.vv
@@ -1,6 +1,6 @@
 struct Foo {}
 
 fn main() {
-	a := Foo(voidptr(0))
+	a := Foo(unsafe { nil })
 	println(a)
 }

--- a/vlib/v/tests/option_generic_ptr_return_test.v
+++ b/vlib/v/tests/option_generic_ptr_return_test.v
@@ -8,7 +8,7 @@ struct ABCD {}
 pub fn cast_object_desc[H](desc &ObjectDesc) ?H {
 	$if H is &ABCD {
 		if desc.typ == 12 { // desc == ABCD
-			return &ABCD(desc.ptr)
+			return unsafe { &ABCD(desc.ptr) }
 		}
 	}
 	return none

--- a/vlib/v/tests/option_ptr_cast_test.v
+++ b/vlib/v/tests/option_ptr_cast_test.v
@@ -14,7 +14,7 @@ pub fn cast_object_desc[H](desc &ObjectDesc) ?H {
 			return &ABCD(desc.ptr)
 		}*/
 		if desc.typ == 12 { // desc == ABCD
-			return ?&ABCD(&ABCD(desc.ptr))
+			return ?&ABCD(unsafe { &ABCD(desc.ptr) })
 		}
 	}
 	return none

--- a/vlib/v/tests/pointers_multilevel_casts_test.v
+++ b/vlib/v/tests/pointers_multilevel_casts_test.v
@@ -49,10 +49,10 @@ fn test_struct_pointer_casts_with_field_selectors() {
 	}
 	dump(ss)
 	pss := voidptr(ss)
-	if &Struct(pss).name == 'abc' {
+	if unsafe { &Struct(pss).name } == 'abc' {
 		assert true
 	}
-	if &Struct(pss).x == 123 {
+	if unsafe { &Struct(pss).x } == 123 {
 		// &Struct cast and selecting .x
 		assert true
 	}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f790d0d</samp>

Enforce the rule that `voidptr` cannot be cast to a struct outside an `unsafe` block. Modify the `check_cast` method in `checker.v` and add a test case and an expected output file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f790d0d</samp>

*  Enforce error for casting `voidptr` to struct outside `unsafe` block ([link](https://github.com/vlang/v/pull/18845/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L2947-R2947))
*  Add test case for invalid `voidptr` to struct cast ([link](https://github.com/vlang/v/pull/18845/files?diff=unified&w=0#diff-f5c1f8e519364f9d208ed84fe3adb69663b0208ba41562166ba4369ff4497d38R1-R6), [link](https://github.com/vlang/v/pull/18845/files?diff=unified&w=0#diff-b8df28e5202d96738605c4351875ad85a4d380a443c7251110ade2d3422eec36R1-R7))
