### PR TITLE
crypto.pem: make static method `Block.new` to replace `new`

### DIFF
--- a/vlib/crypto/pem/decode.v
+++ b/vlib/crypto/pem/decode.v
@@ -6,18 +6,18 @@ import encoding.base64
 // the string
 // `none` is returned when a header is expected, but not present
 // or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
-[deprecated: 'use decode_partial or Block.decode instead']
+[deprecated: 'use Block.decode_partial or Block.decode instead']
 [inline]
 pub fn decode(data string) ?(Block, string) {
-	block, rest := decode_partial(data)?
+	block, rest := Block.decode_partial(data)?
 	return block, rest
 }
 
-// decode_partial reads `data` and returns the first parsed PEM Block along with the rest
+// Block.decode_partial reads `data` and returns the first parsed PEM Block along with the rest
 // of the string
 // `none` is returned when a header is expected, but not present
 // or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
-pub fn decode_partial(data string) ?(Block, string) {
+pub fn Block.decode_partial(data string) ?(Block, string) {
 	block, rest := decode_internal(data)?
 	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)
 }

--- a/vlib/crypto/pem/decode.v
+++ b/vlib/crypto/pem/decode.v
@@ -5,11 +5,10 @@ import encoding.base64
 // `decode` reads `data` and returns the first parsed PEM Block along with the rest of
 // the string. `none` is returned when a header is expected, but not present
 // or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
+[direct_array_access]
 pub fn decode(data string) ?(Block, string) {
 	mut rest := data[data.index(pem_begin)?..]
-	mut block := Block{
-		block_type: rest[pem_begin.len..].all_before(pem_eol)
-	}
+	mut block := Block.new(rest[pem_begin.len..].all_before(pem_eol))
 	block.headers, rest = parse_headers(rest[pem_begin.len..].all_after(pem_eol).trim_left(' \n\t\v\f\r'))?
 
 	block_end_index := rest.index(pem_end)?
@@ -23,6 +22,7 @@ pub fn decode(data string) ?(Block, string) {
 	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)
 }
 
+[direct_array_access]
 fn parse_headers(block string) ?(map[string][]string, string) {
 	headers_str := block.all_before(pem_end).all_before('\n\n')
 

--- a/vlib/crypto/pem/decode.v
+++ b/vlib/crypto/pem/decode.v
@@ -2,7 +2,10 @@ module pem
 
 import encoding.base64
 
-// see `decode_partial` or `Block.decode`
+// decode reads `data` and returns the first parsed PEM block along with the rest of
+// the string
+// `none` is returned when a header is expected, but not present
+// or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
 [deprecated: 'use decode_partial or Block.decode instead']
 [inline]
 pub fn decode(data string) ?(Block, string) {
@@ -10,7 +13,7 @@ pub fn decode(data string) ?(Block, string) {
 	return block, rest
 }
 
-// `decode` reads `data` and returns the first parsed PEM Block along with the rest
+// decode_partial reads `data` and returns the first parsed PEM Block along with the rest
 // of the string
 // `none` is returned when a header is expected, but not present
 // or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
@@ -19,7 +22,7 @@ pub fn decode_partial(data string) ?(Block, string) {
 	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)
 }
 
-// `decode` reads `data` and returns the first parsed PEM Block
+// Block.decode reads `data` and returns the first parsed PEM Block
 // `none` is returned when a header is expected, but not present
 // or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
 pub fn Block.decode(data string) ?Block {
@@ -27,7 +30,7 @@ pub fn Block.decode(data string) ?Block {
 	return block
 }
 
-// an internal function to allow `decode` variations to deal with the rest of the data as
+// decode_internal allows `decode` variations to deal with the rest of the data as
 // they want to. for example Block.decode could have hindered performance with the final
 // indexing into `rest` that `decode_partial` does.
 [direct_array_access]

--- a/vlib/crypto/pem/decode.v
+++ b/vlib/crypto/pem/decode.v
@@ -2,11 +2,36 @@ module pem
 
 import encoding.base64
 
-// `decode` reads `data` and returns the first parsed PEM Block along with the rest of
-// the string. `none` is returned when a header is expected, but not present
-// or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
-[direct_array_access]
+// see `decode_partial` or `Block.decode`
+[deprecated: 'use decode_partial or Block.decode instead']
+[inline]
 pub fn decode(data string) ?(Block, string) {
+	block, rest := decode_partial(data)?
+	return block, rest
+}
+
+// `decode` reads `data` and returns the first parsed PEM Block along with the rest
+// of the string
+// `none` is returned when a header is expected, but not present
+// or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
+pub fn decode_partial(data string) ?(Block, string) {
+	block, rest := decode_internal(data)?
+	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)
+}
+
+// `decode` reads `data` and returns the first parsed PEM Block
+// `none` is returned when a header is expected, but not present
+// or when a start of '-----BEGIN' or end of '-----END' can't be found in `data`
+pub fn Block.decode(data string) ?Block {
+	block, _ := decode_internal(data)?
+	return block
+}
+
+// an internal function to allow `decode` variations to deal with the rest of the data as
+// they want to. for example Block.decode could have hindered performance with the final
+// indexing into `rest` that `decode_partial` does.
+[direct_array_access]
+fn decode_internal(data string) ?(Block, string) {
 	mut rest := data[data.index(pem_begin)?..]
 	mut block := Block.new(rest[pem_begin.len..].all_before(pem_eol))
 	block.headers, rest = parse_headers(rest[pem_begin.len..].all_after(pem_eol).trim_left(' \n\t\v\f\r'))?
@@ -19,7 +44,7 @@ pub fn decode(data string) ?(Block, string) {
 	decoded_len := base64.decode_in_buffer(&b64_data, &block.data[0])
 	block.data = block.data[..decoded_len]
 
-	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)
+	return block, rest
 }
 
 [direct_array_access]

--- a/vlib/crypto/pem/encode.v
+++ b/vlib/crypto/pem/encode.v
@@ -3,7 +3,7 @@ module pem
 import encoding.base64
 import arrays
 
-// `encode_config` encodes the given block into a
+// encode encodes the given block into a
 // string using the EncodeConfig. It returns an error if `block_type` is undefined
 // or if a value in `headers` contains an invalid character ':'
 //

--- a/vlib/crypto/pem/pem.v
+++ b/vlib/crypto/pem/pem.v
@@ -9,7 +9,7 @@ const (
 	colon     = ':'
 )
 
-// returns a new `Block` with the specified block_type
+// new returns a new `Block` with the specified block_type
 [deprecated: 'use Block.new instead']
 [inline]
 pub fn new(block_type string) Block {
@@ -69,7 +69,7 @@ pub mut:
 	data []u8
 }
 
-// returns a new `Block` with the specified block_type
+// Block.new returns a new `Block` with the specified block_type
 [inline]
 pub fn Block.new(block_type string) Block {
 	return Block{
@@ -90,7 +90,7 @@ pub fn (mut block Block) free() {
 	}
 }
 
-// returns the selected key using the Header enum
+// header_by_key returns the selected key using the Header enum
 //
 // same as `block.headers[key.str()]`
 [inline]

--- a/vlib/crypto/pem/pem.v
+++ b/vlib/crypto/pem/pem.v
@@ -41,7 +41,7 @@ pub enum Header {
 	crl
 }
 
-// `str` returns the string representation of the header
+// str returns the string representation of the header
 pub fn (header Header) str() string {
 	return match header {
 		.proctype { 'Proc-Type' }

--- a/vlib/crypto/pem/pem.v
+++ b/vlib/crypto/pem/pem.v
@@ -9,6 +9,13 @@ const (
 	colon     = ':'
 )
 
+// returns a new `Block` with the specified block_type
+[deprecated: 'use Block.new instead']
+[inline]
+pub fn new(block_type string) Block {
+	return Block.new(block_type)
+}
+
 [params]
 pub struct EncodeConfig {
 pub mut:
@@ -62,6 +69,14 @@ pub mut:
 	data []u8
 }
 
+// returns a new `Block` with the specified block_type
+[inline]
+pub fn Block.new(block_type string) Block {
+	return Block{
+		block_type: block_type
+	}
+}
+
 // free the resources taken by the Block `block`
 [unsafe]
 pub fn (mut block Block) free() {
@@ -72,14 +87,6 @@ pub fn (mut block Block) free() {
 		block.block_type.free()
 		block.headers.free()
 		block.data.free()
-	}
-}
-
-// returns a new `Block` with the specified block_type
-[inline]
-pub fn new(block_type string) Block {
-	return Block{
-		block_type: block_type
 	}
 }
 

--- a/vlib/crypto/pem/pem_test.v
+++ b/vlib/crypto/pem/pem_test.v
@@ -3,7 +3,7 @@ module pem
 // example PEM structures from the RFC
 fn test_decode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
-		decoded, rest := Block.decode_partial(pem.test_data_rfc1421[i]) or { Block{}, '' }
+		decoded, rest := decode(pem.test_data_rfc1421[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results_rfc1421[i]
 		assert rest == ''
 	}
@@ -11,9 +11,8 @@ fn test_decode_rfc1421() {
 
 fn test_decode() {
 	for i in 0 .. pem.test_data.len {
-		decoded, rest := Block.decode_partial(pem.test_data[i]) or { Block{}, '' }
+		decoded, rest := decode(pem.test_data[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results[i]
-		assert decoded == Block.decode(pem.test_data[i]) or { Block{} }
 		assert rest == pem.expected_rest[i]
 	}
 }
@@ -21,43 +20,34 @@ fn test_decode() {
 fn test_encode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
 		encoded := pem.expected_results_rfc1421[i].encode() or { '' }
-		decoded, rest := Block.decode_partial(encoded) or { Block{}, '' }
+		decoded, rest := decode(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results_rfc1421[i]
-		assert decoded == Block.decode(encoded) or { Block{} }
 	}
 }
 
 fn test_encode() {
 	for i in 0 .. pem.test_data.len {
 		encoded := pem.expected_results[i].encode() or { '' }
-		decoded, rest := Block.decode_partial(encoded) or { Block{}, '' }
+		decoded, rest := decode(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
-		assert decoded == Block.decode(pem.test_data[i]) or { Block{} }
 	}
 }
 
 fn test_encode_config() {
 	for i in 0 .. pem.test_data.len {
 		encoded := pem.expected_results[i].encode(EncodeConfig{31, '\r\n'}) or { '' }
-		decoded, rest := Block.decode_partial(encoded) or { Block{}, '' }
+		decoded, rest := decode(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
-		assert decoded == Block.decode(encoded) or { Block{} }
 	}
 }
 
 fn test_decode_no_pem() {
 	for test in pem.test_data_no_pem {
-		if _, _ := Block.decode_partial(test) {
+		if _, _ := decode(test) {
 			assert false, 'Block.decode_partial should return `none` on input without PEM data'
-		} else {
-			assert true
-		}
-
-		if _ := Block.decode(test) {
-			assert false, 'Block.decode should return `none` on input without PEM data'
 		} else {
 			assert true
 		}

--- a/vlib/crypto/pem/pem_test.v
+++ b/vlib/crypto/pem/pem_test.v
@@ -3,7 +3,7 @@ module pem
 // example PEM structures from the RFC
 fn test_decode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
-		decoded, rest := decode_partial(pem.test_data_rfc1421[i]) or { Block{}, '' }
+		decoded, rest := Block.decode_partial(pem.test_data_rfc1421[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results_rfc1421[i]
 		assert rest == ''
 	}
@@ -11,7 +11,7 @@ fn test_decode_rfc1421() {
 
 fn test_decode() {
 	for i in 0 .. pem.test_data.len {
-		decoded, rest := decode_partial(pem.test_data[i]) or { Block{}, '' }
+		decoded, rest := Block.decode_partial(pem.test_data[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results[i]
 		assert decoded == Block.decode(pem.test_data[i]) or { Block{} }
 		assert rest == pem.expected_rest[i]
@@ -21,7 +21,7 @@ fn test_decode() {
 fn test_encode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
 		encoded := pem.expected_results_rfc1421[i].encode() or { '' }
-		decoded, rest := decode_partial(encoded) or { Block{}, '' }
+		decoded, rest := Block.decode_partial(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results_rfc1421[i]
 		assert decoded == Block.decode(encoded) or { Block{} }
@@ -31,7 +31,7 @@ fn test_encode_rfc1421() {
 fn test_encode() {
 	for i in 0 .. pem.test_data.len {
 		encoded := pem.expected_results[i].encode() or { '' }
-		decoded, rest := decode_partial(encoded) or { Block{}, '' }
+		decoded, rest := Block.decode_partial(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
 		assert decoded == Block.decode(pem.test_data[i]) or { Block{} }
@@ -41,7 +41,7 @@ fn test_encode() {
 fn test_encode_config() {
 	for i in 0 .. pem.test_data.len {
 		encoded := pem.expected_results[i].encode(EncodeConfig{31, '\r\n'}) or { '' }
-		decoded, rest := decode_partial(encoded) or { Block{}, '' }
+		decoded, rest := Block.decode_partial(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
 		assert decoded == Block.decode(encoded) or { Block{} }
@@ -50,8 +50,8 @@ fn test_encode_config() {
 
 fn test_decode_no_pem() {
 	for test in pem.test_data_no_pem {
-		if _, _ := decode_partial(test) {
-			assert false, 'decode_partial should return `none` on input without PEM data'
+		if _, _ := Block.decode_partial(test) {
+			assert false, 'Block.decode_partial should return `none` on input without PEM data'
 		} else {
 			assert true
 		}

--- a/vlib/crypto/pem/pem_test.v
+++ b/vlib/crypto/pem/pem_test.v
@@ -44,6 +44,23 @@ fn test_encode_config() {
 	}
 }
 
+fn test_decode_no_pem() {
+	for test in pem.test_data_no_pem {
+		if decoded, rest := decode(test) {
+			assert false, 'decode should return `none` on input without PEM data'
+		} else {
+			assert true
+		}
+	}
+}
+
+const test_data_no_pem = [
+	'',
+	'-----BEGIN',
+	'-----BEGIN -----',
+	'-----END',
+]
+
 // https://datatracker.ietf.org/doc/html/rfc7468#section-4
 const test_data_rfc1421 = [
 	'-----BEGIN PRIVACY-ENHANCED MESSAGE-----
@@ -305,8 +322,8 @@ BEGIN BEGIN BEGIN
 -----END RSA PRIVATE KEY
 : fkalsdjflkasdjf
 private key: fsaddf",
-	'Mollitia magnam ullam ipsam voluptas ipsa 
-rerum debitis. Vel nulla ipsum enim perspiciatis adipisci quam. Nihil incidunt ipsum 
+	'Mollitia magnam ullam ipsam voluptas ipsa
+rerum debitis. Vel nulla ipsum enim perspiciatis adipisci quam. Nihil incidunt ipsum
 --- --BEGIN
 
 
@@ -327,46 +344,46 @@ xph0pSfsfFsTKM4RhTWD2v4fgk+xZiKd1p0+L4hTtpwnEw0uXRVd0ki6muwV5y/P
 BQUAA4GBAJiDAAtY0mQQeuxWdzLRzXmjvdSuL9GoyT3BF/jSnpxz5/58dba8pWen
 v3pj4P3w5DoOso0rzkZy2jEsEitlVM2mLSbQpMM+MUVQCQoiG6W9xuCFuxSrwPIS
 pAqEAuV4DNoxQKKWmhVv+J0ptMWD25Pnpxeq5sXzghfJnslJlQND
------END CERTIFICATE----- 
+-----END CERTIFICATE-----
 fdsjaf888888888888
 -----
 
 -----END
 -----BEGIN',
 	'Lorem ipsum dolor sit amet
-, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore 
-et dolore magna aliqua. Massa id neque aliquam vestibulum 
-morbi blandit cursus risus. Elit at imperdiet dui accumsan sit amet nulla. Pulvinar pellentesque habitant 
+, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Massa id neque aliquam vestibulum
+morbi blandit cursus risus. Elit at imperdiet dui accumsan sit amet nulla. Pulvinar pellentesque habitant
 
 
-morbi tristique senectus. Vulputate 
-dignissim suspendisse in est ante in. Egestas dui id ornare arcu. Ultrices mi tempus imperdiet 
-nulla malesuada. Elementum nisi quis eleifend quam adipiscing. 
-Mi in nulla posuere sollicitudin aliquam ultrices. Elit at imperdiet dui accumsan sit amet nulla facilisi. In hac 
-habitasse platea dictumst quisque sagittis. Vestibulum 
-lectus mauris ultrices eros in cursus. Blandit volutpat maecenas volutpat blandit. Sed nisi 
-lacus sed viverra tellus in hac habitasse platea. 
-Nulla facilisi etiam dignissim diam. Donec et odio pellentesque diam volutpat 
-commodo sed egestas. Eleifend quam adipiscing 
+morbi tristique senectus. Vulputate
+dignissim suspendisse in est ante in. Egestas dui id ornare arcu. Ultrices mi tempus imperdiet
+nulla malesuada. Elementum nisi quis eleifend quam adipiscing.
+Mi in nulla posuere sollicitudin aliquam ultrices. Elit at imperdiet dui accumsan sit amet nulla facilisi. In hac
+habitasse platea dictumst quisque sagittis. Vestibulum
+lectus mauris ultrices eros in cursus. Blandit volutpat maecenas volutpat blandit. Sed nisi
+lacus sed viverra tellus in hac habitasse platea.
+Nulla facilisi etiam dignissim diam. Donec et odio pellentesque diam volutpat
+commodo sed egestas. Eleifend quam adipiscing
 vitae proin sagittis nisl.
 
-Pharetra et ultrices neque ornare aenean euismod elementum nisi. Sit amet consectetur sed id semper risus in. 
+Pharetra et ultrices neque ornare aenean euismod elementum nisi. Sit amet consectetur sed id semper risus in.
 Eget nullam non nisi est. A diam maecenas sed enim. Enim nec dui nunc mattis. Lectus quam id leo in vitae turpis massa sed
 . In eu mi bibendum neque egestas congue. Dui faucibus in ornare quam viverra orci j
 sagittis. Lectus sit amet est placerat in egestas erat imperdiet.
 
-Suspendisse potenti nullam ac tortor. Iaculis nunc sed augue lacus viverra vitae congue eu consequat. 
-Lacus vestibulum sed arcu 
+Suspendisse potenti nullam ac tortor. Iaculis nunc sed augue lacus viverra vitae congue eu consequat.
+Lacus vestibulum sed arcu
 non odio euismod. Massa sed elementum tempus egestas sed. Nulla facilisi etiam dignissim diam quis enim
-. Ac ut consequat semper viverra. Eleifend quam adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus. Nunc consequat interdum varius sit amet mattis vulputate enim. 
-Orci nulla pellentesque dignissim enim sit amet. Sed vulputate mi sit amet. 
-Sagittis vitae et leo duis ut diam. Orci a scelerisque purus semper eget duis 
+. Ac ut consequat semper viverra. Eleifend quam adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus. Nunc consequat interdum varius sit amet mattis vulputate enim.
+Orci nulla pellentesque dignissim enim sit amet. Sed vulputate mi sit amet.
+Sagittis vitae et leo duis ut diam. Orci a scelerisque purus semper eget duis
 at tellus at. In hac habitasse platea dictumst vestibulum rhoncus est
-. Fames 
-ac turpis egestas integer. Mattis enim ut 
-tellus elementum sagittis vitae. Pellentesque pulvinar pellentesque habitant morbi tristique senectus et netus 
-et. Id semper risus in hendrerit. 
-Et sollicitudin ac orci phasellus egestas. Sem integer vitae justo eget 
+. Fames
+ac turpis egestas integer. Mattis enim ut
+tellus elementum sagittis vitae. Pellentesque pulvinar pellentesque habitant morbi tristique senectus et netus
+et. Id semper risus in hendrerit.
+Et sollicitudin ac orci phasellus egestas. Sem integer vitae justo eget
 magna. Et ligula ullamcorper malesuada proin libero nunc consequat.-----BEGIN CERTIFICATE-----
 MIICMzCCAZygAwIBAgIJALiPnVsvq8dsMA0GCSqGSIb3DQEBBQUAMFMxCzAJBgNV
 BAYTAlVTMQwwCgYDVQQIEwNmb28xDDAKBgNVBAcTA2ZvbzEMMAoGA1UEChMDZm9v
@@ -662,7 +679,7 @@ BEGIN BEGIN BEGIN
 -----END RSA PRIVATE KEY
 : fkalsdjflkasdjf
 private key: fsaddf',
-	' 
+	'
 fdsjaf888888888888
 -----
 

--- a/vlib/crypto/pem/pem_test.v
+++ b/vlib/crypto/pem/pem_test.v
@@ -3,7 +3,7 @@ module pem
 // example PEM structures from the RFC
 fn test_decode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
-		decoded, rest := decode(pem.test_data_rfc1421[i]) or { Block{}, '' }
+		decoded, rest := decode_partial(pem.test_data_rfc1421[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results_rfc1421[i]
 		assert rest == ''
 	}
@@ -11,8 +11,9 @@ fn test_decode_rfc1421() {
 
 fn test_decode() {
 	for i in 0 .. pem.test_data.len {
-		decoded, rest := decode(pem.test_data[i]) or { Block{}, '' }
+		decoded, rest := decode_partial(pem.test_data[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results[i]
+		assert decoded == Block.decode(pem.test_data[i]) or { Block{} }
 		assert rest == pem.expected_rest[i]
 	}
 }
@@ -20,34 +21,43 @@ fn test_decode() {
 fn test_encode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
 		encoded := pem.expected_results_rfc1421[i].encode() or { '' }
-		decoded, rest := decode(encoded) or { Block{}, '' }
+		decoded, rest := decode_partial(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results_rfc1421[i]
+		assert decoded == Block.decode(encoded) or { Block{} }
 	}
 }
 
 fn test_encode() {
 	for i in 0 .. pem.test_data.len {
 		encoded := pem.expected_results[i].encode() or { '' }
-		decoded, rest := decode(encoded) or { Block{}, '' }
+		decoded, rest := decode_partial(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
+		assert decoded == Block.decode(pem.test_data[i]) or { Block{} }
 	}
 }
 
 fn test_encode_config() {
 	for i in 0 .. pem.test_data.len {
 		encoded := pem.expected_results[i].encode(EncodeConfig{31, '\r\n'}) or { '' }
-		decoded, rest := decode(encoded) or { Block{}, '' }
+		decoded, rest := decode_partial(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
+		assert decoded == Block.decode(encoded) or { Block{} }
 	}
 }
 
 fn test_decode_no_pem() {
 	for test in pem.test_data_no_pem {
-		if decoded, rest := decode(test) {
-			assert false, 'decode should return `none` on input without PEM data'
+		if _, _ := decode_partial(test) {
+			assert false, 'decode_partial should return `none` on input without PEM data'
+		} else {
+			assert true
+		}
+
+		if _ := Block.decode(test) {
+			assert false, 'Block.decode should return `none` on input without PEM data'
 		} else {
 			assert true
 		}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR deprecates the `new` function in favour of the new static methods and adds test cases for input data that doesn't contain complete PEM data.

Would it be good to make `decode` a static method as well or would we be getting into territory of making everything a static method making it a messy?

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->