### PR TITLE
cgen: fix option map with fn type value (fix #18786)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1065,9 +1065,12 @@ fn (mut g Gen) expr_string_surround(prepend string, expr ast.Expr, append string
 // all unified in one place so that it doesnt break
 // if one location changes
 fn (mut g Gen) option_type_name(t ast.Type) (string, string) {
-	base := g.base_type(t)
+	mut base := g.base_type(t)
 	mut styp := ''
 	sym := g.table.sym(t)
+	if sym.info is ast.FnType {
+		base = 'anon_fn_${g.table.fn_type_signature(sym.info.func)}'
+	}
 	if sym.language == .c && sym.kind == .struct_ {
 		styp = '${c.option_name}_${base.replace(' ', '_')}'
 	} else {
@@ -1087,6 +1090,9 @@ fn (mut g Gen) result_type_name(t ast.Type) (string, string) {
 	}
 	mut styp := ''
 	sym := g.table.sym(t)
+	if sym.info is ast.FnType {
+		base = 'anon_fn_${g.table.fn_type_signature(sym.info.func)}'
+	}
 	if sym.language == .c && sym.kind == .struct_ {
 		styp = '${c.result_name}_${base.replace(' ', '_')}'
 	} else {

--- a/vlib/v/tests/option_map_fn_type_value_test.v
+++ b/vlib/v/tests/option_map_fn_type_value_test.v
@@ -1,0 +1,13 @@
+const mouse_action_to_function_map = {
+	1: handle_mouse_down_signal
+}
+
+fn handle_mouse_down_signal() string {
+	return 'hello'
+}
+
+fn test_option_map_fn_type_value() {
+	t := mouse_action_to_function_map[1] or { return }
+	println(t())
+	assert t() == 'hello'
+}


### PR DESCRIPTION
This PR fix option map with fn type value (fix #18786).

- Fix option map with fn type value.
- Add test.

```v
const mouse_action_to_function_map = {
	1: handle_mouse_down_signal
}

fn handle_mouse_down_signal() string {
	return 'hello'
}

fn main() {
	t := mouse_action_to_function_map[1] or { return }
	println(t())
	assert t() == 'hello'
}

PS D:\Test\v\tt1> v run .
hello
```