### PR TITLE
docs: update deprecated function results

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4551,9 +4551,9 @@ If a test function has an error return type, any propagated errors will fail the
 ```v
 import strconv
 
-fn test_atoi() ? {
-	assert strconv.atoi('1')? == 1
-	assert strconv.atoi('one')? == 1 // test will fail
+fn test_atoi() ! {
+	assert strconv.atoi('1')! == 1
+	assert strconv.atoi('one')! == 1 // test will fail
 }
 ```
 
@@ -6738,7 +6738,7 @@ fn sh(cmd string) {
 rmdir_all('build') or {}
 
 // Create build/, never fails as build/ does not exist
-mkdir('build')?
+mkdir('build')!
 
 // Move *.v files to build/
 result := execute('mv *.v build/')
@@ -6749,7 +6749,7 @@ if result.exit_code != 0 {
 sh('ls')
 
 // Similar to:
-// files := ls('.')?
+// files := ls('.')!
 // mut count := 0
 // if files.len > 0 {
 //     for file in files {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f96273</samp>

Updated the documentation to use the `!` operator for testing and scripting. This reflects the latest syntax and best practices for vlang.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6f96273</samp>

*  Replace `?` operator with `!` operator in test function and shell script examples ([link](https://github.com/vlang/v/pull/18850/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L4554-R4556), [link](https://github.com/vlang/v/pull/18850/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L6741-R6741), [link](https://github.com/vlang/v/pull/18850/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L6752-R6752))
