### PR TITLE
cgen: fix return option call (fix #18848)

### DIFF
--- a/vlib/v/tests/return_option_call_test.v
+++ b/vlib/v/tests/return_option_call_test.v
@@ -1,0 +1,17 @@
+fn issue(data string) ?(int, string) {
+	if data.len == 0 {
+		return none
+	}
+	return data.len, data
+}
+
+fn wrapper(data string) ?(int, string) {
+	return issue(data)
+}
+
+fn test_return_option_call() {
+	dump(wrapper('issue'))
+	dump(wrapper('foobar'))
+	dump(wrapper(''))
+	assert true
+}


### PR DESCRIPTION
This PR fix return option call (fix #18848).

- Fix return option call.
- Add test.

```v
fn issue(data string) ?(int, string) {
	if data.len == 0 {
		return none
	}
	return data.len, data
}

fn wrapper(data string) ?(int, string) {
	return issue(data)
}

fn main() {
	dump(wrapper('issue'))
	dump(wrapper('foobar'))
	dump(wrapper(''))
	assert true
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:13] wrapper('issue'): Option((5, 'issue'))
[.\\tt1.v:14] wrapper('foobar'): Option((6, 'foobar'))
[.\\tt1.v:15] wrapper(''): Option(none)
```