### PR TITLE
checker: add a separate error msg for `fail_if_immutable` for anon fns

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -685,8 +685,13 @@ fn (mut c Checker) fail_if_immutable(mut expr ast.Expr) (string, token.Pos) {
 			if mut expr.obj is ast.Var {
 				if !expr.obj.is_mut && !c.pref.translated && !c.file.is_translated
 					&& !c.inside_unsafe {
-					c.error('`${expr.name}` is immutable, declare it with `mut` to make it mutable',
-						expr.pos)
+					if c.inside_anon_fn {
+						c.error('the closure copy of `${expr.name}` is immutable, declare it with `mut` to make it mutable',
+							expr.pos)
+					} else {
+						c.error('`${expr.name}` is immutable, declare it with `mut` to make it mutable',
+							expr.pos)
+					}
 				}
 				expr.obj.is_changed = true
 				if expr.obj.typ.share() == .shared_t {

--- a/vlib/v/checker/tests/closure_copy_immutable_var_err.out
+++ b/vlib/v/checker/tests/closure_copy_immutable_var_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/closure_copy_immutable_var_err.vv:5:3: error: the closure copy of `name` is immutable, declare it with `mut` to make it mutable
+    3 | 
+    4 |     fn [name] () {
+    5 |         name = 'Ivan'
+      |         ~~~~
+    6 |         println(name)
+    7 |     }()

--- a/vlib/v/checker/tests/closure_copy_immutable_var_err.vv
+++ b/vlib/v/checker/tests/closure_copy_immutable_var_err.vv
@@ -1,0 +1,8 @@
+fn main() {
+	mut name := 'John'
+
+	fn [name] () {
+		name = 'Ivan'
+		println(name)
+	}()
+}

--- a/vlib/v/checker/tests/closure_immutable.out
+++ b/vlib/v/checker/tests/closure_immutable.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/closure_immutable.vv:4:3: error: `a` is immutable, declare it with `mut` to make it mutable
+vlib/v/checker/tests/closure_immutable.vv:4:3: error: the closure copy of `a` is immutable, declare it with `mut` to make it mutable
     2 |     a := 1
     3 |     f1 := fn [a] () {
     4 |         a++
@@ -12,7 +12,7 @@ vlib/v/checker/tests/closure_immutable.vv:7:16: error: original `a` is immutable
       |                   ^
     8 |         a++
     9 |         println(a)
-vlib/v/checker/tests/closure_immutable.vv:13:3: error: `b` is immutable, declare it with `mut` to make it mutable
+vlib/v/checker/tests/closure_immutable.vv:13:3: error: the closure copy of `b` is immutable, declare it with `mut` to make it mutable
    11 |     mut b := 2
    12 |     f3 := fn [b] () {
    13 |         b++


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18739

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85b4834</samp>

Improve error message for closures that modify immutable copies of variables. Add a test file for the new error message in `vlib/v/checker/tests`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85b4834</samp>

* Improve error message for closure copy of immutable variable ([link](https://github.com/vlang/v/pull/18854/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L688-R694))
* Add test file for the new error message ([link](https://github.com/vlang/v/pull/18854/files?diff=unified&w=0#diff-1475bf582705295adf5d6b03c12de7604a829a8e6bda310fd46d37043ebf3960R1-R7), [link](https://github.com/vlang/v/pull/18854/files?diff=unified&w=0#diff-41e2c46ec5f5df3bf656e6c6f79f4b1cfde8f919a4dddae9bc6f7c5b5a7c9db2R1-R8))
