### PR TITLE
picohttpparser: make `u64toa` public

### DIFF
--- a/vlib/picohttpparser/misc.v
+++ b/vlib/picohttpparser/misc.v
@@ -19,8 +19,8 @@ const (
 
 // u64toa converts `value` to an ascii string and stores it at `buf_start`
 // then it returns the length of the ascii string (branch lookup table implementation)
-[direct_array_access; inline]
-fn u64toa(buf_start &u8, value u64) !int {
+[direct_array_access; unsafe]
+pub fn u64toa(buf_start &u8, value u64) !int {
 	mut buf := unsafe { buf_start }
 	// set maximum length to 100MB
 	if value >= 100_000_000 {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13356e4</samp>

Made `u64toa` public and unsafe in `picohttpparser/misc.v` to enable reuse and optimize memory.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13356e4</samp>

* Make `u64toa` function public and unsafe to allow other modules to use it and indicate manual memory management ([link](https://github.com/vlang/v/pull/18861/files?diff=unified&w=0#diff-7c06573bd122599196875d95075a529ac0ea2e68eb89925ead1eebf611e9a2c4L22-R23))
