### PR TITLE
net.http: make listener public, and add addr in Server struct

### DIFF
--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -1,10 +1,9 @@
-module http
-
 import net
+import net.http
 import time
 
 fn test_server_stop() {
-	mut server := &Server{
+	mut server := &http.Server{
 		accept_timeout: 1 * time.second
 	}
 	t := spawn server.listen_and_serve()
@@ -18,7 +17,7 @@ fn test_server_stop() {
 }
 
 fn test_server_close() {
-	mut server := &Server{
+	mut server := &http.Server{
 		accept_timeout: 1 * time.second
 		handler: MyHttpHandler{}
 	}
@@ -34,7 +33,7 @@ fn test_server_close() {
 
 fn test_server_custom_listener() {
 	listener := net.listen_tcp(.ip6, ':8081')!
-	mut server := &Server{
+	mut server := &http.Server{
 		accept_timeout: 1 * time.second
 		listener: listener
 	}
@@ -55,10 +54,10 @@ mut:
 	not_founds int
 }
 
-fn (mut handler MyHttpHandler) handle(req Request) Response {
+fn (mut handler MyHttpHandler) handle(req http.Request) http.Response {
 	handler.counter++
 	// eprintln('$time.now() | counter: $handler.counter | $req.method $req.url\n$req.header\n$req.data - 200 OK\n')
-	mut r := Response{
+	mut r := http.Response{
 		body: req.data + ', ${req.url}'
 		header: req.header
 	}
@@ -80,28 +79,28 @@ const cport = 8198
 
 fn test_server_custom_handler() {
 	mut handler := MyHttpHandler{}
-	mut server := &Server{
+	mut server := &http.Server{
 		accept_timeout: 1 * time.second
 		handler: handler
-		port: http.cport
+		port: cport
 	}
 	t := spawn server.listen_and_serve()
 	for server.status() != .running {
 		time.sleep(10 * time.millisecond)
 	}
-	x := fetch(url: 'http://localhost:${http.cport}/endpoint?abc=xyz', data: 'my data')!
+	x := http.fetch(url: 'http://localhost:${cport}/endpoint?abc=xyz', data: 'my data')!
 	assert x.body == 'my data, /endpoint?abc=xyz'
 	assert x.status_code == 200
 	assert x.status_msg == 'OK'
 	assert x.http_version == '1.1'
-	y := fetch(url: 'http://localhost:${http.cport}/another/endpoint', data: 'abcde')!
+	y := http.fetch(url: 'http://localhost:${cport}/another/endpoint', data: 'abcde')!
 	assert y.body == 'abcde, /another/endpoint'
 	assert y.status_code == 200
 	assert x.status_msg == 'OK'
 	assert y.status() == .ok
 	assert y.http_version == '1.1'
 	//
-	fetch(url: 'http://localhost:${http.cport}/something/else')!
+	http.fetch(url: 'http://localhost:${cport}/something/else')!
 	server.stop()
 	t.wait()
 	assert handler.counter == 3

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -1,8 +1,10 @@
-import net.http
+module http
+
+import net
 import time
 
 fn test_server_stop() {
-	mut server := &http.Server{
+	mut server := &Server{
 		accept_timeout: 1 * time.second
 	}
 	t := spawn server.listen_and_serve()
@@ -16,9 +18,25 @@ fn test_server_stop() {
 }
 
 fn test_server_close() {
-	mut server := &http.Server{
+	mut server := &Server{
 		accept_timeout: 1 * time.second
 		handler: MyHttpHandler{}
+	}
+	t := spawn server.listen_and_serve()
+	time.sleep(250 * time.millisecond)
+	mut watch := time.new_stopwatch()
+	server.close()
+	assert server.status() == .closed
+	assert watch.elapsed() < 100 * time.millisecond
+	t.wait()
+	assert watch.elapsed() < 999 * time.millisecond
+}
+
+fn test_server_custom_listener() {
+	listener := net.listen_tcp(.ip6, ':8081')!
+	mut server := &Server{
+		accept_timeout: 1 * time.second
+		listener: listener
 	}
 	t := spawn server.listen_and_serve()
 	time.sleep(250 * time.millisecond)
@@ -37,10 +55,10 @@ mut:
 	not_founds int
 }
 
-fn (mut handler MyHttpHandler) handle(req http.Request) http.Response {
+fn (mut handler MyHttpHandler) handle(req Request) Response {
 	handler.counter++
 	// eprintln('$time.now() | counter: $handler.counter | $req.method $req.url\n$req.header\n$req.data - 200 OK\n')
-	mut r := http.Response{
+	mut r := Response{
 		body: req.data + ', ${req.url}'
 		header: req.header
 	}
@@ -62,28 +80,28 @@ const cport = 8198
 
 fn test_server_custom_handler() {
 	mut handler := MyHttpHandler{}
-	mut server := &http.Server{
+	mut server := &Server{
 		accept_timeout: 1 * time.second
 		handler: handler
-		port: cport
+		port: http.cport
 	}
 	t := spawn server.listen_and_serve()
 	for server.status() != .running {
 		time.sleep(10 * time.millisecond)
 	}
-	x := http.fetch(url: 'http://localhost:${cport}/endpoint?abc=xyz', data: 'my data')!
+	x := fetch(url: 'http://localhost:${http.cport}/endpoint?abc=xyz', data: 'my data')!
 	assert x.body == 'my data, /endpoint?abc=xyz'
 	assert x.status_code == 200
 	assert x.status_msg == 'OK'
 	assert x.http_version == '1.1'
-	y := http.fetch(url: 'http://localhost:${cport}/another/endpoint', data: 'abcde')!
+	y := fetch(url: 'http://localhost:${http.cport}/another/endpoint', data: 'abcde')!
 	assert y.body == 'abcde, /another/endpoint'
 	assert y.status_code == 200
 	assert x.status_msg == 'OK'
 	assert y.status() == .ok
 	assert y.http_version == '1.1'
 	//
-	http.fetch(url: 'http://localhost:${cport}/something/else')!
+	fetch(url: 'http://localhost:${http.cport}/something/else')!
 	server.stop()
 	t.wait()
 	assert handler.counter == 3


### PR DESCRIPTION
Set the `listener` public so we can set our own and also add `addr` to (eventually) replace `port` so we can specify which address to listen on as opposed to just `0.0.0.0`.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00c00ee</samp>

Moved the HTTP server test file to the `http` module and added a new test. Changed the `Server` struct and the `listen_and_serve` method to use a `string` `addr` field instead of an `int` `port` field.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00c00ee</samp>

*  Modify `Server` struct to use `addr` instead of `port` and add `listener` field ([link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-8d46659948d0307c5239ade1d5c80100c7558d707663bd21ff0e31cefcf10a82L28-R31),[link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-8d46659948d0307c5239ade1d5c80100c7558d707663bd21ff0e31cefcf10a82R38))
*  Update `listen_and_serve` method to use `addr` and `listener` fields and print the actual listening address ([link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-8d46659948d0307c5239ade1d5c80100c7558d707663bd21ff0e31cefcf10a82L46-R68),[link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-8d46659948d0307c5239ade1d5c80100c7558d707663bd21ff0e31cefcf10a82L61-R80))
*  Move `server_test.v` file to `http` module and remove import statement ([link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27L1-R7))
*  Prefix `http` module name to `Server`, `Request`, `Response`, `cport`, and `fetch` in `server_test.v` ([link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27L19-R21),[link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27L40-R61),[link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27L65-R86),[link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27L74-R97),[link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27L86-R104))
*  Add test function for using custom listener with server ([link](https://github.com/vlang/v/pull/18871/files?diff=unified&w=0#diff-b94e3550e2d6f70c1f33b3a6a70a0d20033bf3d0b8d2e02e01a3c03abbb97c27R35-R50))
