### PR TITLE
math.signi : incorrect documentation, conflicts with function signature

### DIFF
--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -146,7 +146,7 @@ pub fn sign(n f64) f64 {
 	return copysign(1.0, n)
 }
 
-// signi returns the corresponding sign -1.0, 1.0 of the provided number.
+// signi returns the corresponding sign -1, 1 of the provided number.
 [inline]
 pub fn signi(n f64) int {
 	return int(copysign(1.0, n))


### PR DESCRIPTION
The online documentation for [math.signi](https://modules.vlang.io/math.html#signi) states:

> signi returns the corresponding sign -1.0, 1.0 of the provided number.

However the function signature, and code, return an integer, not a float.

```vlang
fn signi(n f64) int {
      ....
}
```

This PR just alters the `math.signi` documentation to imply that it returns an int, not a float:

> signi returns the corresponding sign -1, 1 of the provided number.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6df314f</samp>

Fixed a comment typo in the `signi` function of the `vlib/math/math.v` file. This improves the accuracy and consistency of the math module documentation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6df314f</samp>

* Update the comment for the `signi` function to match the return type of `int` ([link](https://github.com/vlang/v/pull/18872/files?diff=unified&w=0#diff-bb5fbeb511cd0c973f6843660512de84677459269106c793dfa3a07ce12b7415L149-R149)). This change improves the documentation and clarity of the `math.v` file.
