### PR TITLE
time: add missing `custom_format` token

### DIFF
--- a/vlib/time/custom_format_test.v
+++ b/vlib/time/custom_format_test.v
@@ -5,7 +5,7 @@ fn test_custom_format() {
 	assert date.custom_format('YYYY-MM-DD HH:mm') == date.format()
 	assert date.custom_format('MMM') == date.smonth()
 
-	test_str := 'M MM MMM MMMM\nD DD DDD DDDD\nd dd ddd dddd\nYY YYYY a A\nH HH h hh k kk e\nm mm s ss Z ZZ ZZZ\nDo DDDo Q Qo QQ\nN NN w wo ww\nM/D/YYYY N-HH:mm:ss Qo?a'
+	test_str := 'M MM Mo MMM MMMM\nD DD DDD DDDD\nd dd ddd dddd\nYY YYYY a A\nH HH h hh k kk e\nm mm s ss Z ZZ ZZZ\nDo DDDo Q Qo QQ\nN NN w wo ww\nM/D/YYYY N-HH:mm:ss Qo?a'
 
 	println(date.custom_format(test_str))
 }

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -85,8 +85,8 @@ fn ordinal_suffix(n int) string {
 }
 
 const (
-	tokens_2 = ['MM', 'DD', 'Do', 'YY', 'ss', 'kk', 'NN', 'mm', 'hh', 'HH', 'ZZ', 'dd', 'Qo', 'QQ',
-		'wo', 'ww']
+	tokens_2 = ['MM', 'Mo', 'DD', 'Do', 'YY', 'ss', 'kk', 'NN', 'mm', 'hh', 'HH', 'ZZ', 'dd', 'Qo',
+		'QQ', 'wo', 'ww']
 	tokens_3 = ['MMM', 'DDD', 'ZZZ', 'ddd']
 	tokens_4 = ['MMMM', 'DDDD', 'DDDo', 'dddd', 'YYYY']
 )


### PR DESCRIPTION
This PR adds a missing `Mo` token that is used for the `custom_format` method.

Currently, a custom format call like the usage example in the methods doc comment results in wrong ordinal suffixes:
```v
// Usage:
// ```v
// println(time.now().custom_format('MMMM Mo YY N kk:mm:ss A')) // output like: January 1st 22 AD 13:45:33 PM
// ```
```
Instead of the described output we'll get e.g., `January 1o 22 AD 13:45:33 PM`.
Where `Mo` is formatted into `o` instead of `st`, `nd` ... `th`.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48e58b0</samp>

Added support for the 'Mo' token in `time.format` to format months as ordinal numbers. This improved the compatibility with Moment.js, a JavaScript library for date and time manipulation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 48e58b0</samp>

* Add 'Mo' token to `tokens_2` array to support month as ordinal number in `format` method of `Time` struct ([link](https://github.com/vlang/v/pull/18880/files?diff=unified&w=0#diff-890c2cc435153abe97e479d5bc29d9a0dbc47472b01c00fd3f3370fec6fc9a49L88-R89))
