### PR TITLE
time: fix and cleanup int validity checks

### DIFF
--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -1,7 +1,5 @@
 module time
 
-import strconv
-
 struct DateTimeParser {
 	datetime string
 	format   string
@@ -34,7 +32,10 @@ fn (mut p DateTimeParser) peek(length int) !string {
 
 fn (mut p DateTimeParser) must_be_int(length int) !int {
 	val := p.next(length)!
-	return strconv.atoi(val)!
+	if !val.contains_only('0123456789') {
+		return error('expected int, found: ${val}')
+	}
+	return val.int()
 }
 
 fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allow_leading_zero bool) !int {
@@ -57,15 +58,19 @@ fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allo
 	if !allow_leading_zero && val.starts_with('0') {
 		return error('0 is not allowed for this format')
 	}
-	return strconv.atoi(val)!
+	return val.int()
 }
 
 fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
 	mut val := p.next(1)!
 	if val == '0' {
-		val += p.next(1) or { '' }
+		next := p.next(1) or { '' }
+		if !next.contains_only('0123456789') {
+			return error('expected int, found: ${next}')
+		}
+		val += next
 	}
-	return strconv.atoi(val)!
+	return val.int()
 }
 
 fn (mut p DateTimeParser) must_be_string(must string) ! {

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -42,15 +42,12 @@ fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allo
 	mut length := max + 1 - min
 	mut val := ''
 	for _ in 0 .. length {
-		maybe_int := p.peek(1) or { break }
-		if maybe_int == '0' || maybe_int == '1' || maybe_int == '2' || maybe_int == '4'
-			|| maybe_int == '5' || maybe_int == '6' || maybe_int == '7' || maybe_int == '8'
-			|| maybe_int == '9' {
-			p.next(1)!
-			val += maybe_int
-		} else {
+		tok := p.peek(1) or { break }
+		if !tok.contains_only('0123456789') {
 			break
 		}
+		p.next(1)!
+		val += tok
 	}
 	if val.len < min {
 		return error('expected int with a minimum length of ${min}, found: ${val.len}')

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -1,5 +1,7 @@
 module time
 
+import strconv
+
 struct DateTimeParser {
 	datetime string
 	format   string
@@ -32,7 +34,7 @@ fn (mut p DateTimeParser) peek(length int) !string {
 
 fn (mut p DateTimeParser) must_be_int(length int) !int {
 	val := p.next(length) or { return err }
-	return val.int()
+	return strconv.atoi(val)!
 }
 
 fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allow_leading_zero bool) !int {
@@ -55,7 +57,7 @@ fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allo
 	if !allow_leading_zero && val.starts_with('0') {
 		return error('0 is not allowed for this format')
 	}
-	return val.int()
+	return strconv.atoi(val)!
 }
 
 fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
@@ -63,7 +65,7 @@ fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
 	if val == '0' {
 		val += p.next(1) or { '' }
 	}
-	return val.int()
+	return strconv.atoi(val)!
 }
 
 fn (mut p DateTimeParser) must_be_string(must string) ! {

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -33,7 +33,7 @@ fn (mut p DateTimeParser) peek(length int) !string {
 }
 
 fn (mut p DateTimeParser) must_be_int(length int) !int {
-	val := p.next(length) or { return err }
+	val := p.next(length)!
 	return strconv.atoi(val)!
 }
 
@@ -61,7 +61,7 @@ fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allo
 }
 
 fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
-	mut val := p.next(1) or { return err }
+	mut val := p.next(1)!
 	if val == '0' {
 		val += p.next(1) or { '' }
 	}
@@ -69,7 +69,7 @@ fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
 }
 
 fn (mut p DateTimeParser) must_be_string(must string) ! {
-	val := p.next(must.len) or { return err }
+	val := p.next(must.len)!
 	if val != must {
 		return error('invalid string: "${val}"!="${must}" at: ${p.current_pos_datetime}')
 	}
@@ -99,7 +99,7 @@ fn (mut p DateTimeParser) must_be_valid_month() !int {
 }
 
 fn (mut p DateTimeParser) must_be_valid_week_day(letters int) !string {
-	val := p.next(letters) or { return err }
+	val := p.next(letters)!
 	for _, v in long_days {
 		if v[0..letters] == val {
 			return v

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -81,7 +81,7 @@ fn (mut p DateTimeParser) must_be_string(must string) ! {
 }
 
 fn (mut p DateTimeParser) must_be_string_one_of(oneof []string) !string {
-	for _, must in oneof {
+	for must in oneof {
 		val := p.peek(must.len) or { continue }
 		if val == must {
 			return must
@@ -91,7 +91,7 @@ fn (mut p DateTimeParser) must_be_string_one_of(oneof []string) !string {
 }
 
 fn (mut p DateTimeParser) must_be_valid_month() !int {
-	for _, v in long_months {
+	for v in long_months {
 		if p.current_pos_datetime + v.len < p.datetime.len {
 			month_name := p.datetime[p.current_pos_datetime..p.current_pos_datetime + v.len]
 			if v == month_name {
@@ -105,7 +105,7 @@ fn (mut p DateTimeParser) must_be_valid_month() !int {
 
 fn (mut p DateTimeParser) must_be_valid_week_day(letters int) !string {
 	val := p.next(letters)!
-	for _, v in long_days {
+	for v in long_days {
 		if v[0..letters] == val {
 			return v
 		}
@@ -158,7 +158,7 @@ fn (mut p DateTimeParser) parse() !Time {
 	tokens := extract_tokens(p.format) or {
 		return error_invalid_time(0, 'malformed format string: ${err}')
 	}
-	for _, token in tokens {
+	for token in tokens {
 		match token {
 			'YYYY' {
 				year_ = p.must_be_int(4) or {

--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module time
 
+import strconv
+
 // parse_rfc3339 returns time from a date string in RFC 3339 datetime format.
 // See also https://ijmacd.github.io/rfc3339-iso8601/ for a visual reference of
 // the differences between ISO-8601 and RFC 3339.
@@ -79,12 +81,25 @@ pub fn parse(s string) !Time {
 	minute_ := hms[1]
 	second_ := hms[2]
 	//
-	iyear := ymd[0].int()
-	imonth := ymd[1].int()
-	iday := ymd[2].int()
-	ihour := hour_.int()
-	iminute := minute_.int()
-	isecond := second_.int()
+	iyear := strconv.atoi(ymd[0]) or {
+		return error_invalid_time(0, 'invalid year format: ${ymd[0]}')
+	}
+	imonth := strconv.atoi(ymd[1]) or {
+		return error_invalid_time(0, 'invalid month format: ${ymd[1]}')
+	}
+	iday := strconv.atoi(ymd[2]) or {
+		return error_invalid_time(0, 'invalid day format: ${ymd[2]}')
+	}
+	ihour := strconv.atoi(hour_) or {
+		return error_invalid_time(0, 'invalid hour format: ${hour_}')
+	}
+	iminute := strconv.atoi(minute_) or {
+		return error_invalid_time(0, 'invalid minute format: ${minute_}')
+	}
+	isecond := strconv.atoi(second_) or {
+		return error_invalid_time(0, 'invalid second format: ${second_}')
+	}
+
 	// eprintln('>> iyear: $iyear | imonth: $imonth | iday: $iday | ihour: $ihour | iminute: $iminute | isecond: $isecond')
 	if iyear > 9999 || iyear < -9999 {
 		return error_invalid_time(3, 'year must be between -10000 and 10000')


### PR DESCRIPTION
This PR makes use of `strconv.atoi` in the time module to check validity of passed ints when using `time.parse` and `time.parse_format`.

This fixes an issue where invalid strings won't get catched.

- Using `time.parse`:
  ```v
  dt_str := '20as-01-14 17:10:39'
  println(time.parse(dt_str) or {
  	eprintln(err)
  	return
  })
  
  // Won't error, but give us:
  // 0020-01-14 17:10:39 
  //
  // Starting with a string for a date part, e.g.: 'as20-01-14 17:10:39':
  // 0000-01-14 17:10:39
  ```
  
  With the PR we'll get:
  ```
  time.TimeParseError: Invalid time format code: 0, error: invalid year format: 20as
  ```
  
  The implemented error messages are based off: 
https://github.com/vlang/v/blob/63867d4ce0122aaae60c26c3333a8047f0c42d90/vlib/time/date_time_parser.v#L106
https://github.com/vlang/v/blob/63867d4ce0122aaae60c26c3333a8047f0c42d90/vlib/time/date_time_parser.v#L152
  
- Using `time.parse_format` 

  ```v
  dt_str := '07/17/as23 6:00 AM'
  println(time.parse_format(dt_str, 'MM/DD/YYYY h:mm A') or {
  	eprintln(err)
  	return
  })
  
  // Will give us now:
  // 0000-07-17 06:00:00
  ```
  With the PR it will throw the default Year parsing error:
  ```
  time.TimeParseError: Invalid time format code: 0, error: end of string reached before the full year was specified
  ```
  https://github.com/vlang/v/blob/63867d4ce0122aaae60c26c3333a8047f0c42d90/vlib/time/date_time_parser.v#L158
  
  
---

I'd like to update handling of `parse_format` errors to provide more error details in a followup PR if you also think that could make sense.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7d93db</samp>

This pull request enhances the error handling of the `time` module by using the `strconv` module and the `!` operator to parse date and time strings in various formats. It also refactors the `parse_iso8601` function and moves it to `parse.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7d93db</samp>

* Import the `strconv` module and use the `atoi` function to handle errors when parsing integers from strings in the `DateTimeParser` struct methods ([link](https://github.com/vlang/v/pull/18885/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5R3-R4), [link](https://github.com/vlang/v/pull/18885/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5L34-R37), [link](https://github.com/vlang/v/pull/18885/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5L58-R72), [link](https://github.com/vlang/v/pull/18885/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bR6-R7), [link](https://github.com/vlang/v/pull/18885/files?diff=unified&w=0#diff-1f9ff41c1017eb614d3c67a516617a18d0f18a83f2d3b9cceaddddd0ccf7053bL82-R102)).
