### PR TITLE
checker, cgen: fix closure with inherited sumtype variable (fix #18869)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3650,6 +3650,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 			mut smartcasts := []ast.Type{}
 			mut is_already_casted := false
 			mut orig_type := 0
+			mut is_inherited := false
 			if mut expr.obj is ast.Var {
 				is_mut = expr.obj.is_mut
 				smartcasts << expr.obj.smartcasts
@@ -3657,6 +3658,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 				if orig_type == 0 {
 					orig_type = expr.obj.typ
 				}
+				is_inherited = expr.obj.is_inherited
 			}
 			// smartcast either if the value is immutable or if the mut argument is explicitly given
 			if (!is_mut || expr.is_mut) && !is_already_casted {
@@ -3667,6 +3669,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 					pos: expr.pos
 					is_used: true
 					is_mut: expr.is_mut
+					is_inherited: is_inherited
 					smartcasts: smartcasts
 					orig_type: orig_type
 				})

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4348,6 +4348,9 @@ fn (mut g Gen) ident(node ast.Ident) {
 						} else {
 							mut is_ptr := false
 							if i == 0 {
+								if node.obj.is_inherited {
+									g.write(closure_ctx + '->')
+								}
 								g.write(name)
 								if node.obj.orig_type.is_ptr() {
 									is_ptr = true

--- a/vlib/v/tests/closure_with_sumtype_var_test.v
+++ b/vlib/v/tests/closure_with_sumtype_var_test.v
@@ -1,0 +1,75 @@
+import encoding.binary
+import rand
+
+type DataType = int | string
+
+struct DataBuilder {
+mut:
+	func fn (mut []u8)
+	len  int
+}
+
+pub fn (mut d DataBuilder) add(v DataType) {
+	func := d.func
+	len := d.len
+	d.func = fn [v, len, func] (mut b []u8) {
+		if !isnil(func) {
+			func(mut b)
+		}
+		match v {
+			int {
+				binary.big_endian_put_u32_at(mut b, u32(v), len)
+			}
+			string {
+				binary.big_endian_put_u16_at(mut b, u16(v.len), len)
+				for i := 0; i < v.len; i++ {
+					b[len + 2 + i] = v[i]
+				}
+			}
+		}
+	}
+	d.len += match v {
+		int { 4 }
+		string { 2 + v.len }
+	}
+}
+
+pub fn (d &DataBuilder) build() []u8 {
+	mut b := []u8{len: d.len}
+	d.func(mut b)
+	binary.big_endian_put_u16(mut b, u16(d.len - 2))
+	unsafe {
+		d.func = nil
+		d.len = 2
+	}
+	return b
+}
+
+fn new_data_builder() DataBuilder {
+	return DataBuilder{
+		func: unsafe { nil }
+		len: 2
+	}
+}
+
+fn test_closure_with_sumtype_var() {
+	mut data := new_data_builder()
+	data.add(1)
+	data.add(2)
+	data.add(3)
+	data.add(4)
+	data.add(5)
+	data.add('1')
+	data.add('22')
+	data.add('334455')
+	data.add(rand.string(rand.int_in_range(10, 100)!))
+	data.add('5')
+	data.add(1)
+	data.add(2)
+	data.add(3)
+	data.add(4)
+	data.add(5)
+	ret := data.build()
+	dump(ret)
+	assert binary.big_endian_u16_at(ret, 0) == ret[2..].len
+}


### PR DESCRIPTION
This PR fix closure with inherited sumtype variable (fix #18869).

- Fix closure with inherited sumtype variable.
- Add test.

```v
import encoding.binary
import rand

type DataType = int | string

struct DataBuilder {
mut:
	func fn (mut []u8)
	len  int
}

pub fn (mut d DataBuilder) add(v DataType) {
	func := d.func
	len := d.len
	d.func = fn [v, len, func] (mut b []u8) {
		if !isnil(func) {
			func(mut b)
		}
		match v {
			int {
				binary.big_endian_put_u32_at(mut b, u32(v), len)
			}
			string {
				binary.big_endian_put_u16_at(mut b, u16(v.len), len)
				for i := 0; i < v.len; i++ {
					b[len + 2 + i] = v[i]
				}
			}
		}
	}
	d.len += match v {
		int { 4 }
		string { 2 + v.len }
	}
}

pub fn (d &DataBuilder) build() []u8 {
	mut b := []u8{len: d.len}
	d.func(mut b)
	binary.big_endian_put_u16(mut b, u16(d.len - 2))
	unsafe {
		d.func = nil
		d.len = 2
	}
	return b
}

fn new_data_builder() DataBuilder {
	return DataBuilder{
		func: unsafe { nil }
		len: 2
	}
}

fn main() {
	mut data := new_data_builder()
	data.add(1)
	data.add(2)
	data.add(3)
	data.add(4)
	data.add(5)
	data.add('1')
	data.add('22')
	data.add('334455')
	data.add(rand.string(rand.int_in_range(10, 100)!))
	data.add('5')
	data.add(1)
	data.add(2)
	data.add(3)
	data.add(4)
	data.add(5)
	ret := data.build()
	dump(ret)
	assert binary.big_endian_u16_at(ret, 0) == ret[2..].len
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:73] ret: [0, 143, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 1, 49, 0, 2, 50, 50, 0, 6, 51, 51, 52, 52, 53, 53, 0, 83, 86, 81, 87, 99, 84, 78, 107, 80, 109, 89, 107, 116, 107, 115, 82, 90, 102, 79, 69, 79, 76, 108, 74, 121, 117, 114, 97, 116, 74, 84, 68, 114, 78, 113, 80, 68, 122, 114, 105, 104, 99, 74, 81, 76, 88, 87, 84, 82, 81, 84, 120, 103, 67, 72, 115, 67, 112, 102, 83, 122, 65, 66, 104, 115, 82, 108, 74, 68, 120, 86, 82, 122, 70, 107, 75, 102, 120, 72, 100, 99, 90, 78, 76, 0, 1, 53, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5]
```