### PR TITLE
time: fix hour 0 parsing, remove unused function

### DIFF
--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -203,7 +203,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				}
 			}
 			'H' {
-				hour_ = p.must_be_int_with_minimum_length(1, 2, false) or {
+				hour_ = p.must_be_int_with_minimum_length(1, 2, true) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
 				if hour_ < 0 || hour_ > 23 {
@@ -219,7 +219,7 @@ fn (mut p DateTimeParser) parse() !Time {
 				}
 			}
 			'h' {
-				hour_ = p.must_be_int_with_minimum_length(1, 2, false) or {
+				hour_ = p.must_be_int_with_minimum_length(1, 2, true) or {
 					return error_invalid_time(0, 'end of string reached before hours where specified')
 				}
 				if hour_ < 0 || hour_ > 23 {

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -58,18 +58,6 @@ fn (mut p DateTimeParser) must_be_int_with_minimum_length(min int, max int, allo
 	return val.int()
 }
 
-fn (mut p DateTimeParser) must_be_single_int_with_optional_leading_zero() !int {
-	mut val := p.next(1)!
-	if val == '0' {
-		next := p.next(1) or { '' }
-		if !next.contains_only('0123456789') {
-			return error('expected int, found: ${next}')
-		}
-		val += next
-	}
-	return val.int()
-}
-
 fn (mut p DateTimeParser) must_be_string(must string) ! {
 	val := p.next(must.len)!
 	if val != must {

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -221,13 +221,13 @@ fn test_parse_format() {
 	assert t.year == 2018 && t.month == 11 && t.day == 27 && t.hour == 12 && t.minute == 48
 		&& t.second == 20
 
-	s = '18-1-2 1:8:2'
+	s = '18-1-2 0:8:2'
 	t = time.parse_format(s, 'YY-M-D H:m:s') or {
 		eprintln('> failing format: ${s} | err: ${err}')
 		assert false
 		return
 	}
-	assert t.year == 2018 && t.month == 1 && t.day == 2 && t.hour == 1 && t.minute == 8
+	assert t.year == 2018 && t.month == 1 && t.day == 2 && t.hour == 0 && t.minute == 8
 		&& t.second == 2
 
 	// This should always fail, because we test if M and D allow for a 01 value which they shouldn't


### PR DESCRIPTION
Sets zero allowance to true to fixes and issue where it's not possible to parse hour 0.
```v
println(time.parse_format('07/17/23 0:00', 'MM/DD/YY H:mm')!)
```

copilot:summary

copilot:walkthrough
