### PR TITLE
cgen: format generated c codes of sorted structs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5868,7 +5868,6 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 					}
 				}
 				g.type_definitions.writeln('};')
-				g.type_definitions.writeln('')
 			}
 			ast.ArrayFixed {
 				elem_sym := g.table.sym(sym.info.elem_type)

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -517,8 +517,6 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 	} else {
 		g.type_definitions.writeln('\tEMPTY_STRUCT_DECLARATION;')
 	}
-	// g.type_definitions.writeln('} $name;\n')
-	//
 	ti_attrs := if !g.is_cc_msvc && s.attrs.contains('packed') {
 		'__attribute__((__packed__))'
 	} else {
@@ -528,8 +526,10 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 	if !is_anon {
 		g.type_definitions.write_string(';')
 	}
-	g.type_definitions.writeln('\n')
-	g.type_definitions.writeln(post_pragma)
+	g.type_definitions.writeln('')
+	if post_pragma.len > 0 {
+		g.type_definitions.writeln(post_pragma)
+	}
 }
 
 fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Language) {


### PR DESCRIPTION
This PR format generated c codes of sorted structs.

before:
```v
// #start sorted_symbols
struct none {
	EMPTY_STRUCT_DECLARATION;
};

struct ContextRecord {
	EMPTY_STRUCT_DECLARATION;
};



struct ExceptionPointers {
	ExceptionRecord* exception_record;
	ContextRecord* context_record;
};



struct None__ {
	Error Error;
};



struct StrIntpCgenData {
	string str;
	string fmt;
	string d;
};



struct GCHeapUsage {
	usize heap_size;
	usize free_bytes;
	usize total_bytes;
	usize unmapped_bytes;
	usize bytes_since_gc;
};



struct VCastTypeIndexName {
	int tindex;
	string tname;
};



struct VAssertMetaInfo {
	string fpath;
	int line_nr;
	string fn_name;
	string src;
	string op;
	string llabel;
	string rlabel;
	string lvalue;
	string rvalue;
	string message;
	bool has_msg;
};



struct MethodArgs {
	int typ;
	string name;
};



struct FunctionData {
	string name;
	Array_string attrs;
	Array_MethodArgs args;
	int return_type;
	int typ;
};



struct EnumData {
	string name;
	i64 value;
	Array_string attrs;
};



struct FieldData {
	string name;
	int typ;
	int unaliased_typ;
	Array_string attrs;
	bool is_pub;
	bool is_mut;
	bool is_shared;
	bool is_atomic;
	bool is_option;
	bool is_array;
	bool is_map;
	bool is_chan;
	bool is_enum;
	bool is_struct;
	bool is_alias;
	u8 indirections;
};



struct StructAttribute {
	string name;
	bool has_arg;
	string arg;
	AttributeKind kind;
};



struct Line64 {
	u32 f_size_of_struct;
	voidptr f_key;
	u32 f_line_number;
	u8* f_file_name;
	u64 f_address;
};



struct ExceptionRecord {
	u32 code;
	u32 flags;
	ExceptionRecord* record;
	voidptr address;
	u32 param_count;
};



union strconv__Float64u {
	f64 f;
	u64 u;
};



union strconv__Float32u {
	f32 f;
	u32 u;
};



struct MessageError {
	string msg;
	int code;
};



struct Option {
	u8 state;
	IError err;
};



struct SortedMap {
	int value_bytes;
	mapnode* root;
	int len;
};



struct RepIndex {
	int idx;
	int val_idx;
};



union StrIntpMem {
	u32 d_c;
	byte d_u8;
	i8 d_i8;
	u16 d_u16;
	i16 d_i16;
	u32 d_u32;
	int d_i32;
	u64 d_u64;
	i64 d_i64;
	f32 d_f32;
	f64 d_f64;
	string d_s;
	voidptr d_p;
	voidptr d_vp;
};



struct strconv__BF_param {
	u8 pad_ch;
	int len0;
	int len1;
	bool positive;
	bool sign_flag;
	strconv__Align_text allign;
	bool rm_tail_zero;
};



struct strconv__PrepNumber {
	bool negative;
	int exponent;
	u64 mantissa;
};



struct strconv__Dec32 {
	u32 m;
	int e;
};



union strconv__Uf32 {
	f32 f;
	u32 u;
};



struct strconv__Dec64 {
	u64 m;
	int e;
};



union strconv__Uf64 {
	f64 f;
	u64 u;
};



struct strconv__Uint128 {
	u64 lo;
	u64 hi;
};



struct SymbolInfo {
	u32 f_size_of_struct;
	u32 f_type_index;
	Array_fixed_u64_2 f_reserved;
	u32 f_index;
	u32 f_size;
	u64 f_mod_base;
	u32 f_flags;
	u64 f_value;
	u64 f_address;
	u32 f_register;
	u32 f_scope;
	u32 f_tag;
	u32 f_name_len;
	u32 f_max_name_len;
	u8 f_name;
};



struct mapnode {
	voidptr* children;
	int len;
	Array_fixed_string_11 keys;
	Array_fixed_voidptr_11 values;
};



struct StrIntpData {
	string str;
	u32 fmt;
	StrIntpMem d;
};



struct SymbolInfoContainer {
	SymbolInfo syminfo;
	Array_fixed_char_254 f_name_rest;
};


// #end sorted_symbols
```
now:
```v
// #start sorted_symbols
struct none {
	EMPTY_STRUCT_DECLARATION;
};

struct ContextRecord {
	EMPTY_STRUCT_DECLARATION;
};

struct ExceptionPointers {
	ExceptionRecord* exception_record;
	ContextRecord* context_record;
};

struct None__ {
	Error Error;
};

struct StrIntpCgenData {
	string str;
	string fmt;
	string d;
};

struct GCHeapUsage {
	usize heap_size;
	usize free_bytes;
	usize total_bytes;
	usize unmapped_bytes;
	usize bytes_since_gc;
};

struct VCastTypeIndexName {
	int tindex;
	string tname;
};

struct VAssertMetaInfo {
	string fpath;
	int line_nr;
	string fn_name;
	string src;
	string op;
	string llabel;
	string rlabel;
	string lvalue;
	string rvalue;
	string message;
	bool has_msg;
};

struct MethodArgs {
	int typ;
	string name;
};

struct FunctionData {
	string name;
	Array_string attrs;
	Array_MethodArgs args;
	int return_type;
	int typ;
};

struct EnumData {
	string name;
	i64 value;
	Array_string attrs;
};

struct FieldData {
	string name;
	int typ;
	int unaliased_typ;
	Array_string attrs;
	bool is_pub;
	bool is_mut;
	bool is_shared;
	bool is_atomic;
	bool is_option;
	bool is_array;
	bool is_map;
	bool is_chan;
	bool is_enum;
	bool is_struct;
	bool is_alias;
	u8 indirections;
};

struct StructAttribute {
	string name;
	bool has_arg;
	string arg;
	AttributeKind kind;
};

struct Line64 {
	u32 f_size_of_struct;
	voidptr f_key;
	u32 f_line_number;
	u8* f_file_name;
	u64 f_address;
};

struct ExceptionRecord {
	u32 code;
	u32 flags;
	ExceptionRecord* record;
	voidptr address;
	u32 param_count;
};

union strconv__Float64u {
	f64 f;
	u64 u;
};

union strconv__Float32u {
	f32 f;
	u32 u;
};

struct MessageError {
	string msg;
	int code;
};

struct Option {
	u8 state;
	IError err;
};

struct SortedMap {
	int value_bytes;
	mapnode* root;
	int len;
};

struct RepIndex {
	int idx;
	int val_idx;
};

union StrIntpMem {
	u32 d_c;
	byte d_u8;
	i8 d_i8;
	u16 d_u16;
	i16 d_i16;
	u32 d_u32;
	int d_i32;
	u64 d_u64;
	i64 d_i64;
	f32 d_f32;
	f64 d_f64;
	string d_s;
	voidptr d_p;
	voidptr d_vp;
};

struct strconv__BF_param {
	u8 pad_ch;
	int len0;
	int len1;
	bool positive;
	bool sign_flag;
	strconv__Align_text allign;
	bool rm_tail_zero;
};

struct strconv__PrepNumber {
	bool negative;
	int exponent;
	u64 mantissa;
};

struct strconv__Dec32 {
	u32 m;
	int e;
};

union strconv__Uf32 {
	f32 f;
	u32 u;
};

struct strconv__Dec64 {
	u64 m;
	int e;
};

union strconv__Uf64 {
	f64 f;
	u64 u;
};

struct strconv__Uint128 {
	u64 lo;
	u64 hi;
};

struct SymbolInfo {
	u32 f_size_of_struct;
	u32 f_type_index;
	Array_fixed_u64_2 f_reserved;
	u32 f_index;
	u32 f_size;
	u64 f_mod_base;
	u32 f_flags;
	u64 f_value;
	u64 f_address;
	u32 f_register;
	u32 f_scope;
	u32 f_tag;
	u32 f_name_len;
	u32 f_max_name_len;
	u8 f_name;
};

struct mapnode {
	voidptr* children;
	int len;
	Array_fixed_string_11 keys;
	Array_fixed_voidptr_11 values;
};

struct StrIntpData {
	string str;
	u32 fmt;
	StrIntpMem d;
};

struct SymbolInfoContainer {
	SymbolInfo syminfo;
	Array_fixed_char_254 f_name_rest;
};
// #end sorted_symbols
```