### PR TITLE
json: fix raw decode to option string of complex data

### DIFF
--- a/vlib/json/json_option_raw_test.v
+++ b/vlib/json/json_option_raw_test.v
@@ -19,6 +19,7 @@ fn test_main() {
 	dto := json.decode(Dto, raw_json)!
 
 	println(dto)
+	assert dto.data? == '{"test":1}'
 }
 
 fn test_none() {
@@ -30,6 +31,8 @@ fn test_none() {
 	dto := json.decode(Dto, raw_json)!
 
 	println(dto)
+	assert dto.data == none
+	assert dto.optional? == '"test"'
 }
 
 fn test_null() {
@@ -43,6 +46,8 @@ fn test_null() {
 	dto := json.decode(Dto, raw_json)!
 
 	println(dto)
+	assert dto.key2 == 'null'
+	assert dto.data? == 'null'
 }
 
 fn test_not_set() {
@@ -52,4 +57,6 @@ fn test_not_set() {
 	dto := json.decode(Dto, raw_json)!
 
 	println(dto)
+	assert dto.data == none
+	assert dto.optional == none
 }

--- a/vlib/json/json_option_raw_test.v
+++ b/vlib/json/json_option_raw_test.v
@@ -1,0 +1,55 @@
+import json
+
+pub struct Dto {
+pub:
+	key      string  [raw]
+	key2     string  [raw]
+	data     ?string [raw]
+	optional ?string [raw]
+}
+
+fn test_main() {
+	raw_json := '{
+        "key": [1, 2, "test"],
+        "key2": { "test": 1 },
+        "data": { "test": 1 },
+        "optional": "test"
+    }'
+
+	dto := json.decode(Dto, raw_json)!
+
+	println(dto)
+}
+
+fn test_none() {
+	raw_json := '{
+        "key": [1, 2, "test"],
+        "optional": "test"
+    }'
+
+	dto := json.decode(Dto, raw_json)!
+
+	println(dto)
+}
+
+fn test_null() {
+	raw_json := '{
+        "key": [1, 2, "test"],
+       	"key2": null,
+        "data": null,
+        "optional": "test"
+    }'
+
+	dto := json.decode(Dto, raw_json)!
+
+	println(dto)
+}
+
+fn test_not_set() {
+	raw_json := '{
+    }'
+
+	dto := json.decode(Dto, raw_json)!
+
+	println(dto)
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -629,7 +629,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 			if field.typ.has_flag(.option) {
 				g.gen_json_for_type(field.typ)
 				base_typ := g.base_type(field.typ)
-				dec.writeln('\tif (!cJSON_IsString(js_get(root, "${name}")))')
+				dec.writeln('\tif (js_get(root, "${name}") == NULL)')
 				dec.writeln('\t\t_option_none(&(${base_typ}[]) { {0} }, &${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 				dec.writeln('\telse')
 				dec.writeln('\t\t_option_ok(&(${base_typ}[]) {  tos5(cJSON_PrintUnformatted(js_get(root, "${name}"))) }, &${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')


### PR DESCRIPTION
Fix #18895

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1afc9e8</samp>

This pull request adds a test file for the `[raw]` annotation in JSON decoding and fixes a bug in the code generation for optional `[raw]` fields. The bug caused some fields to be decoded as none instead of their actual JSON values.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1afc9e8</samp>

* Fix a bug in decoding optional `[raw]` fields in JSON ([link](https://github.com/vlang/v/pull/18902/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L632-R632))
* Add a new test file `vlib/json/json_option_raw_test.v` ([link](https://github.com/vlang/v/pull/18902/files?diff=unified&w=0#diff-203e5c13b14be61f4a0a1386b70b8ae54ccdd32d929a1692f27a04aacc35425cR1-R55))
