### PR TITLE
vweb: add parameter arrays documentation

### DIFF
--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -234,6 +234,23 @@ header you want example. `app.req.header.get(.content_type)`. See `struct Header
 for all available methods (`v doc net.http Header`).
 It has, too, fields for the `query`, `form`, `files`.
 
+#### - Parameter Arrays
+
+If you want multiple parameters in your route and if you want to parse the parameters 
+yourself, or you want a wildcard route, you can add `...`  after the `:` and name,
+e.g. `['/:path...']`.
+
+This will match all routes after `'/'`. For example the url `/path/to/test` would give
+`path = '/path/to/test'`.
+
+```v ignore
+        vvv
+['/:path...']             vvvv
+fn (mut app App) wildcard(path string) vweb.Result {
+	return app.text('URL path = "${path}"')
+}
+```
+
 #### - Query
 To handle the query context, you just need use the  `query` field
 

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -517,9 +517,9 @@ pub fn (mut app App) with_auth() bool {
 }
 ```
 
-### Fallback route
-You can implement a fallback `not_found` route that is called when a request is made and no
-matching route is found.
+### Cusom not found page
+You can implement a `not_found` route that is called when a request is made and no
+matching route is found to replace the default HTTP 404 not found page.
 
 **Example:**
 

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -517,7 +517,7 @@ pub fn (mut app App) with_auth() bool {
 }
 ```
 
-### Cusom not found page
+### Custom not found page
 You can implement a `not_found` route that is called when a request is made and no
 matching route is found to replace the default HTTP 404 not found page.
 


### PR DESCRIPTION
vweb: add documentation for the usage of "parameter arrays", or wildcard routes.

This feature is undocumented, but already exists in vweb and has tests.

The `not_found` method should be used for custom 404 pages. Parameters arrays should be used for a "fallback" or wildcard route.

## Usage

Catch all routes by adding `...` after the parameter name.

```v ignore
['/:path...']            
fn (mut app App) wildcard(path string) vweb.Result {
	return app.text('URL path = "${path}"')
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5692d09</samp>

This pull request improves the documentation of the vweb module in `vlib/vweb/README.md`. It explains how to use parameter arrays and the `not_found` route in vweb applications.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5692d09</samp>

*  Add a subsection to document parameter arrays in vweb routes ([link](https://github.com/vlang/v/pull/18903/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80R237-R253))
*  Modify the subsection title and description of the `not_found` route feature ([link](https://github.com/vlang/v/pull/18903/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L503-R522))
