### PR TITLE
crypto.pem: add decode_only and general improvements to decoding

### DIFF
--- a/vlib/crypto/pem/decode.v
+++ b/vlib/crypto/pem/decode.v
@@ -6,7 +6,7 @@ import encoding.base64
 //  when a header is expected, but not present or when a start of '-----BEGIN' or end of '-----END'
 // can't be found.
 //
-// use decode if you still need the unparsed rest of the string
+// use decode if you still need the unparsed rest of the string.
 [inline]
 pub fn decode_only(data string) ?Block {
 	block, _ := decode_internal(data)?
@@ -17,8 +17,8 @@ pub fn decode_only(data string) ?Block {
 // the string. `none` is returned when a header is expected, but not present
 // or when a start of '-----BEGIN' or end of '-----END' can't be found.
 //
-// use decode_only if you do not need the unparsed rest of the string
-[inline; direct_array_access]
+// use decode_only if you do not need the unparsed rest of the string.
+[direct_array_access; inline]
 pub fn decode(data string) ?(Block, string) {
 	block, rest := decode_internal(data)?
 	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)

--- a/vlib/crypto/pem/pem_test.v
+++ b/vlib/crypto/pem/pem_test.v
@@ -5,6 +5,7 @@ fn test_decode_rfc1421() {
 	for i in 0 .. pem.test_data_rfc1421.len {
 		decoded, rest := decode(pem.test_data_rfc1421[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results_rfc1421[i]
+		assert decoded == decode_only(pem.test_data_rfc1421[i]) or { Block{} }
 		assert rest == ''
 	}
 }
@@ -13,6 +14,7 @@ fn test_decode() {
 	for i in 0 .. pem.test_data.len {
 		decoded, rest := decode(pem.test_data[i]) or { Block{}, '' }
 		assert decoded == pem.expected_results[i]
+		assert decoded == decode_only(pem.test_data[i]) or { Block{} }
 		assert rest == pem.expected_rest[i]
 	}
 }
@@ -23,6 +25,7 @@ fn test_encode_rfc1421() {
 		decoded, rest := decode(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results_rfc1421[i]
+		assert decoded == decode_only(encoded) or { Block{} }
 	}
 }
 
@@ -32,6 +35,7 @@ fn test_encode() {
 		decoded, rest := decode(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
+		assert decoded == decode_only(encoded) or { Block{} }
 	}
 }
 
@@ -41,15 +45,17 @@ fn test_encode_config() {
 		decoded, rest := decode(encoded) or { Block{}, '' }
 		assert rest == ''
 		assert decoded == pem.expected_results[i]
+		assert decoded == decode_only(encoded) or { Block{} }
 	}
 }
 
 fn test_decode_no_pem() {
 	for test in pem.test_data_no_pem {
 		if _, _ := decode(test) {
-			assert false, 'Block.decode_partial should return `none` on input without PEM data'
-		} else {
-			assert true
+			assert false, 'decode should return `none` on input without PEM data'
+		}
+		if _ := decode_only(test) {
+			assert false, 'decode_only should return `none` on input without PEM data'
 		}
 	}
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR adds `direct_array_access` to functions with known not-OOB accesses and adds a function `decode_only` to allow callers to parse a block without performing extra operations on the rest of the string in `decode`. For this purpose `decode_internal` is added to allow the two decode functions to deal with the rest of the data as they will.

Plus adding `decode_only` to the test cases.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 930a89c</samp>

This pull request improves the `pem` module in the `crypto` library by refactoring the `decode` function and updating the tests. The new `decode` function allows more control over the output and avoids unnecessary allocations. The tests use a new `decode_only` function for simpler cases and check for error handling.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 930a89c</samp>

* Split `decode` function into `decode_only` and `decode` to allow users to choose the level of parsing they need ([link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-a8123bb5fadc7f6d6bf58adfa6e3d962677b53bf0b92e2c230da7047244766f2L5-R33))
* Extract common logic into `decode_internal` function and add `[inline]` and `[direct_array_access]` attributes for performance optimization ([link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-a8123bb5fadc7f6d6bf58adfa6e3d962677b53bf0b92e2c230da7047244766f2L5-R33), [link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-a8123bb5fadc7f6d6bf58adfa6e3d962677b53bf0b92e2c230da7047244766f2L15), [link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-a8123bb5fadc7f6d6bf58adfa6e3d962677b53bf0b92e2c230da7047244766f2L21-R48))
* Modify `assert` statements in `pem_test.v` to use `decode_only` function and handle `none` case with `or` blocks ([link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-253485bd38fef8d33f351f76e84629dc031b8b8211cee1f6f05630d14f05d614R8), [link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-253485bd38fef8d33f351f76e84629dc031b8b8211cee1f6f05630d14f05d614R17), [link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-253485bd38fef8d33f351f76e84629dc031b8b8211cee1f6f05630d14f05d614R28), [link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-253485bd38fef8d33f351f76e84629dc031b8b8211cee1f6f05630d14f05d614R38), [link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-253485bd38fef8d33f351f76e84629dc031b8b8211cee1f6f05630d14f05d614R48))
* Extend test case in `pem_test.v` to check `decode_only` function for inputs without PEM data ([link](https://github.com/vlang/v/pull/18908/files?diff=unified&w=0#diff-253485bd38fef8d33f351f76e84629dc031b8b8211cee1f6f05630d14f05d614L50-R59))
