### PR TITLE
math.big: fix inner deprecated binary_str use

### DIFF
--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -803,7 +803,7 @@ pub fn (integer Integer) radix_str(radix u32) string {
 	}
 	return match radix {
 		2 {
-			integer.binary_str()
+			integer.bin_str()
 		}
 		16 {
 			integer.hex()


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc7c127</samp>

Refactored the `big.integer` module to rename `binary_str` to `bin_str` and improve the consistency of the string conversion methods.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc7c127</samp>

* Rename `binary_str` method to `bin_str` for consistency with other base conversion methods ([link](https://github.com/vlang/v/pull/18911/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L806-R806))
