### PR TITLE
math.big: allow bitwise operations on negative signums

### DIFF
--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -590,16 +590,9 @@ pub fn (a Integer) < (b Integer) bool {
 	return if signum < 0 { cmp > 0 } else { cmp < 0 }
 }
 
-fn check_sign(a Integer) {
-	if a.signum < 0 {
-		panic('Bitwise operations are only supported for nonnegative integers')
-	}
-}
-
 // get_bit checks whether the bit at the given index is set.
 [direct_array_access]
 pub fn (a Integer) get_bit(i u32) bool {
-	check_sign(a)
 	target_index := i / 32
 	offset := i % 32
 	if target_index >= a.digits.len {
@@ -610,7 +603,6 @@ pub fn (a Integer) get_bit(i u32) bool {
 
 // set_bit sets the bit at the given index to the given value.
 pub fn (mut a Integer) set_bit(i u32, value bool) {
-	check_sign(a)
 	target_index := i / 32
 	offset := i % 32
 
@@ -635,10 +627,10 @@ pub fn (mut a Integer) set_bit(i u32, value bool) {
 	}
 }
 
-// bitwise_or returns the "bitwise or" of the integers `a` and `b`.
+// bitwise_or returns the "bitwise or" of the integers `|a|` and `|b|`.
+//
+// Note: both operands are treated as absolute values.
 pub fn (a Integer) bitwise_or(b Integer) Integer {
-	check_sign(a)
-	check_sign(b)
 	mut result := []u32{len: imax(a.digits.len, b.digits.len)}
 	bitwise_or_digit_array(a.digits, b.digits, mut result)
 	return Integer{
@@ -647,10 +639,10 @@ pub fn (a Integer) bitwise_or(b Integer) Integer {
 	}
 }
 
-// bitwise_and returns the "bitwise and" of the integers `a` and `b`.
+// bitwise_and returns the "bitwise and" of the integers `|a|` and `|b|`.
+//
+// Note: both operands are treated as absolute values.
 pub fn (a Integer) bitwise_and(b Integer) Integer {
-	check_sign(a)
-	check_sign(b)
 	mut result := []u32{len: imax(a.digits.len, b.digits.len)}
 	bitwise_and_digit_array(a.digits, b.digits, mut result)
 	return Integer{
@@ -659,9 +651,10 @@ pub fn (a Integer) bitwise_and(b Integer) Integer {
 	}
 }
 
-// bitwise_not returns the "bitwise not" of the integer `a`.
+// bitwise_not returns the "bitwise not" of the integer `|a|`.
+//
+// Note: the integer is treated as an absolute value.
 pub fn (a Integer) bitwise_not() Integer {
-	check_sign(a)
 	mut result := []u32{len: a.digits.len}
 	bitwise_not_digit_array(a.digits, mut result)
 	return Integer{
@@ -670,10 +663,10 @@ pub fn (a Integer) bitwise_not() Integer {
 	}
 }
 
-// bitwise_xor returns the "bitwise exclusive or" of the integers `a` and `b`.
+// bitwise_xor returns the "bitwise exclusive or" of the integers `|a|` and `|b|`.
+//
+// Note: both operands are treated as absolute values.
 pub fn (a Integer) bitwise_xor(b Integer) Integer {
-	check_sign(a)
-	check_sign(b)
 	mut result := []u32{len: imax(a.digits.len, b.digits.len)}
 	bitwise_xor_digit_array(a.digits, b.digits, mut result)
 	return Integer{


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR simply removes the `check_sign` function which panics on negative operands to bitwise operations. Instead, Haldar and I figured it'd make most sense to treat the operands only by their magnitude, therefore as absolute values.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7441edf</samp>

Simplified bitwise operations on `big.integer` by ignoring sign and using absolute values. Updated documentation in `vlib/math/big/integer.v` accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7441edf</samp>

*  Remove unnecessary `check_sign` function calls from bitwise operations methods on `Integer` struct ([link](https://github.com/vlang/v/pull/18912/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L593-R595), [link](https://github.com/vlang/v/pull/18912/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L613), [link](https://github.com/vlang/v/pull/18912/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L638-R633), [link](https://github.com/vlang/v/pull/18912/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L650-R645), [link](https://github.com/vlang/v/pull/18912/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L662-R657), [link](https://github.com/vlang/v/pull/18912/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L673-R669)) in `vlib/math/big/integer.v`
