### PR TITLE
math.big: improve is_power_of_2

### DIFF
--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -1099,7 +1099,7 @@ fn (x Integer) is_odd() bool {
 }
 
 // is_power_of_2 returns true when the integer `x` satisfies `2^n`, where `n >= 0`
-[inline]
+[direct_array_access; inline]
 pub fn (x Integer) is_power_of_2() bool {
 	if x.signum == 0 {
 		return false

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -1101,7 +1101,18 @@ fn (x Integer) is_odd() bool {
 // is_power_of_2 returns true when the integer `x` satisfies `2^n`, where `n >= 0`
 [inline]
 pub fn (x Integer) is_power_of_2() bool {
-	return x.bitwise_and(x - one_int).bit_len() == 0
+	if x.signum == 0 {
+		return false
+	}
+
+	// check if all but the most significant digit are 0
+	for i := 0; i < x.digits.len - 1; i++ {
+		if x.digits[i] != 0 {
+			return false
+		}
+	}
+	n := u32(x.digits.last())
+	return n & (n - u32(1)) == 0
 }
 
 // bit_len returns the number of bits required to represent the integer `a`.


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR improves the `is_power_of_2` method by reducing unnecessary allocations/stack operations caused by the previous big.Integer bitwise AND and subtraction method. In this method the lower digits are checked to be zero and then the most significant digit is checked to be a power of 2, meaning the entire integer is a power of 2.

This allows a slight speedup on the method and reduces its memory usage.

Also a 0 check is added, where the previous method would return true for 0, this version correctly returns false since there is no `n` satisfying `2^n == 0`.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82c0b5e</samp>

Optimized `is_power_of_2` function in `vlib/math/big/integer.v` to use direct array access and bitwise operations, and fixed zero case.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82c0b5e</samp>

* Optimize `is_power_of_2` function to use direct array access and bitwise operations, and handle zero case ([link](https://github.com/vlang/v/pull/18914/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L1102-R1115))
