### PR TITLE
cgen: fix infix expr with promote number (fix #18905)

### DIFF
--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -118,7 +118,7 @@ pub fn (t Time) local() Time {
 		hour: st_local.hour
 		minute: st_local.minute
 		second: st_local.second // These are the same
-		microsecond: st_local.millisecond * 1000
+		microsecond: int(st_local.millisecond) * 1000
 		unix: st_local.unix_time()
 	}
 	return t_local
@@ -141,7 +141,7 @@ fn win_now() Time {
 		hour: st_local.hour
 		minute: st_local.minute
 		second: st_local.second
-		microsecond: st_local.millisecond * 1000
+		microsecond: int(st_local.millisecond) * 1000
 		unix: st_local.unix_time()
 		is_local: true
 	}
@@ -163,7 +163,7 @@ fn win_utc() Time {
 		hour: st_utc.hour
 		minute: st_utc.minute
 		second: st_utc.second
-		microsecond: st_utc.millisecond * 1000
+		microsecond: int(st_utc.millisecond) * 1000
 		unix: st_utc.unix_time()
 		is_local: false
 	}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1026,6 +1026,12 @@ fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
 // It handles auto dereferencing of variables, as well as automatic casting
 // (see Gen.expr_with_cast for more details)
 fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
+	needs_cast := node.left_type.is_number() && node.right_type.is_number()
+		&& node.op in [.plus, .minus, .mul, .div, .mod]
+	if needs_cast {
+		typ_str := g.typ(node.promoted_type)
+		g.write('(${typ_str})(')
+	}
 	if node.left_type.is_ptr() && node.left.is_auto_deref_var() {
 		g.write('*')
 	}
@@ -1036,6 +1042,9 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		g.expr(node.right)
 	} else {
 		g.expr_with_cast(node.right, node.right_type, node.left_type)
+	}
+	if needs_cast {
+		g.write(')')
 	}
 }
 

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1027,7 +1027,7 @@ fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
 // (see Gen.expr_with_cast for more details)
 fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 	needs_cast := node.left_type.is_number() && node.right_type.is_number()
-		&& node.op in [.plus, .minus, .mul, .div, .mod]
+		&& node.op in [.plus, .minus, .mul, .div, .mod] && node.left !is ast.InfixExpr
 	if needs_cast {
 		typ_str := g.typ(node.promoted_type)
 		g.write('(${typ_str})(')

--- a/vlib/v/tests/infix_expr_with_promote_number_test.v
+++ b/vlib/v/tests/infix_expr_with_promote_number_test.v
@@ -1,0 +1,14 @@
+fn test_infix_expr_with_promote_number() {
+	a := u8(255)
+	b := u8(1)
+	c := a + b
+
+	println(c)
+	assert c == 0
+
+	println(a + b)
+	assert a + b == 0
+
+	println(a + b < a)
+	assert a + b < a
+}

--- a/vlib/x/ttf/ttf.v
+++ b/vlib/x/ttf/ttf.v
@@ -169,10 +169,10 @@ pub fn (mut tf TTF_File) get_horizontal_metrics(glyph_index u16) (int, int) {
 		// dprintln("${glyph_index} aw:${advance_width} lsb:${left_side_bearing}")
 	} else {
 		// read the last entry of the hMetrics array
-		tf.pos = offset + (tf.num_of_long_hor_metrics - 1) * 4
+		tf.pos = offset + u32(tf.num_of_long_hor_metrics - 1) * 4
 		advance_width = tf.get_u16()
-		tf.pos = offset + tf.num_of_long_hor_metrics * 4 +
-			2 * (glyph_index - tf.num_of_long_hor_metrics)
+		tf.pos = offset + u32(tf.num_of_long_hor_metrics) * 4 +
+			2 * u32(glyph_index - tf.num_of_long_hor_metrics)
 		left_side_bearing = tf.get_fword()
 	}
 	tf.pos = old_pos


### PR DESCRIPTION
This PR fix infix expr with promote number (fix #18905).

- Fix infix expr with promote number.
- Fix time_windows.c.v.
- Add test.

```v
fn main() {
	a := u8(255)
	b := u8(1)
	c := a + b

	println(c)
	assert c == 0

	println(a + b)
	assert a + b == 0

	println(a + b < a)
	assert a + b < a
}

PS D:\Test\v\tt1> v run .
0
0
true
```