### PR TITLE
math.big: add checked division methods

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -573,6 +573,11 @@ fn test_div_mod() {
 		assert q == eq
 		assert r == er
 	}
+
+	// an extra test for checked division by zero
+	if _, _ := div_mod_test_data[0].dividend.parse().div_mod_checked(TestInteger(0).parse()) {
+		assert false, 'Division by 0 should return an error'
+	}
 }
 
 fn test_comparison() {

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -372,6 +372,8 @@ pub fn (multiplicand Integer) * (multiplier Integer) Integer {
 // div_mod_internal is an entirely not zero-checked method for division.
 // This should only be used for internal calculations involving a definitive non-zero
 // divisor.
+//
+// DO NOT use this method if the divisor has any chance of being 0.
 fn (dividend Integer) div_mod_internal(divisor Integer) (Integer, Integer) {
 	$if debug {
 		assert divisor.signum != 0

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -428,11 +428,9 @@ pub fn (dividend Integer) div_mod(divisor Integer) (Integer, Integer) {
 // divided by `divisor`. An error is returned if `divisor == 0`.
 [inline]
 pub fn (dividend Integer) div_mod_checked(divisor Integer) !(Integer, Integer) {
-	// Quick exits
 	if _unlikely_(divisor.signum == 0) {
 		return error('math.big: Cannot divide by zero')
 	}
-
 	return dividend.div_mod_internal(divisor)
 }
 

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -369,7 +369,7 @@ pub fn (multiplicand Integer) * (multiplier Integer) Integer {
 	}
 }
 
-// div_mod_internal is an entirely not zero-checked method for division.
+// div_mod_internal is an entirely unchecked (in terms of division by zero) method for division.
 // This should only be used for internal calculations involving a definitive non-zero
 // divisor.
 //

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -446,8 +446,8 @@ pub fn (dividend Integer) / (divisor Integer) Integer {
 
 // % returns the remainder of `dividend` divided by `divisor`.
 //
-// WARNING: this method will panic if `divisor == 0`. For a modulation method that returns a Result
-// refer to `mod_checked`.
+// WARNING: this method will panic if `divisor == 0`. For a modular division method that
+// returns a Result refer to `mod_checked`.
 [inline]
 pub fn (dividend Integer) % (divisor Integer) Integer {
 	_, r := dividend.div_mod(divisor)

--- a/vlib/math/big/special_array_ops.v
+++ b/vlib/math/big/special_array_ops.v
@@ -228,7 +228,7 @@ fn toom3_multiply_digit_array(operand_a []u32, operand_b []u32, mut storage []u3
 	p2 := ((ptemp + a2).left_shift(1) - a0) * ((qtemp + b2).left_shift(1) - b0)
 	pinf := a2 * b2
 
-	mut t2 := (p2 - vm1) / three_int
+	mut t2, _ := (p2 - vm1).div_mod_internal(three_int)
 	mut tm1 := (p1 - vm1).right_shift(1)
 	mut t1 := p1 - p0
 	t2 = (t2 - t1).right_shift(1)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

# Checked and Unchecked Division

Adds `div_mod_checked`, `div_checked` and `mod_checked` as safe variants to `div_mod`, `/` and `%`. The checked methods return a Result type, where an error is returned only if division by 0 is attempted. `div_mod`, `/` and `%` result in a documented runtime panic for division by 0.

As most divisions by zero are found in the beginning of a larger development project, we use the `_unlikely_` compiler hint to mitigate most of the minor slow down the zero-check might cause on both the checked and unchecked methods.

Internal calculations are done with a known non-zero divisor and so we use the `div_mod_internal` method which does absolutely no zero-check.

### Additional

Passing zero as the radix to `radix_str` should not be allowed, so that is fixed. 

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af9737f</samp>

This pull request improves the division and modulo operations for big integers, by adding safe and checked methods, refactoring the internal div_mod method, and fixing a bug with zero radix. It also updates the tests and the special array operations to reflect the changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af9737f</samp>

*  Rename `div_mod` to `div_mod_internal` and add warning comment in `integer.v` ([link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L372-R381))
*  Replace calls to `div_mod` with `div_mod_internal` in `integer.v` and `special_array_ops.v` ([link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L385-R393), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L411-R443), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339R863-R865), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L818-R873), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L1037-R1093), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-0010dc8c24e1c6f4472542e9d3789895ab0a03ba518c0b065b322c64d5c1c9e3L231-R231))
*  Add new methods `div_mod`, `div_mod_checked`, `div_checked`, and `mod_checked` to `integer.v` with comments and inline attributes ([link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L411-R443), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339R459-R474))
*  Add comment and inline attribute to existing `/` and `%` methods in `integer.v` and warn about panic behavior ([link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L411-R443), [link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339R450-R453))
*  Add check for zero radix in `radix_str` method in `integer.v` and return '0' ([link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-03d80aeafad3ed636bb8e535115d3d1e47ecba70dd3ea483c62a79f0cb2e1339L794-R846))
*  Add test case for checked division by zero in `big_test.v` ([link](https://github.com/vlang/v/pull/18924/files?diff=unified&w=0#diff-1a2421de75c404a48cc287a36b69e158cc54faa177f66be4ac465cd74165877eR576-R580))
