### PR TITLE
builtin: pub fn println, add missing flush on stdout

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -223,7 +223,7 @@ pub fn flush_stderr() {
 	}
 }
 
-// print prints a message to stdout. Unlike `println` stdout is not automatically flushed.
+// print prints a message to stdout. Note that unlike `eprint`, stdout is not automatically flushed.
 [manualfree]
 pub fn print(s string) {
 	$if android && !termux {
@@ -238,7 +238,7 @@ pub fn print(s string) {
 	}
 }
 
-// println prints a message with a line end, to stdout. stdout is flushed.
+// println prints a message with a line end, to stdout. Note that unlike `eprintln`, stdout is not automatically flushed.
 [manualfree]
 pub fn println(s string) {
 	if s.str == 0 {
@@ -257,7 +257,6 @@ pub fn println(s string) {
 		return
 	} $else {
 		_writeln_to_fd(1, s)
-		C.fflush(C.stdout)
 	}
 }
 

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -257,6 +257,7 @@ pub fn println(s string) {
 		return
 	} $else {
 		_writeln_to_fd(1, s)
+		C.fflush(C.stdout)
 	}
 }
 


### PR DESCRIPTION
The comment on the println function mentions the flush on stdout.  In addition, the comment on the print function mentions that it doesn't flush stdout unlike println.

I am assuming that since this flush is mentioned in 2 separate comments, that it is actually meant to be there.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ffad7e</samp>

Flush stdout after `println` and `print` in `builtin.c.v`. This improves output visibility and interactivity for V programs.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ffad7e</samp>

* Flush standard output buffer after printing values with `println` or `print` ([link](https://github.com/vlang/v/pull/18927/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eR260))
