### PR TITLE
net.http.chunked: return `!string` on decode

### DIFF
--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -67,7 +67,8 @@ pub fn decode(text string) !string {
 			break
 		}
 		cscanner.skip_crlf()
-		sb.write_string(cscanner.read_chunk(csize)!)
+		ch := cscanner.read_chunk(csize)!
+		sb.write_string(ch)
 		cscanner.skip_crlf()
 	}
 	cscanner.skip_crlf()

--- a/vlib/net/http/chunked/dechunk.v
+++ b/vlib/net/http/chunked/dechunk.v
@@ -46,13 +46,16 @@ fn (mut s ChunkScanner) skip_crlf() {
 	s.pos += 2
 }
 
-fn (mut s ChunkScanner) read_chunk(chunksize u32) string {
+fn (mut s ChunkScanner) read_chunk(chunksize u32) !string {
 	startpos := s.pos
 	s.pos += int(chunksize)
+	if s.pos > s.text.len {
+		return error('invalid chunksize')
+	}
 	return s.text[startpos..s.pos]
 }
 
-pub fn decode(text string) string {
+pub fn decode(text string) !string {
 	mut sb := strings.new_builder(100)
 	mut cscanner := ChunkScanner{
 		pos: 0
@@ -64,7 +67,7 @@ pub fn decode(text string) string {
 			break
 		}
 		cscanner.skip_crlf()
-		sb.write_string(cscanner.read_chunk(csize))
+		sb.write_string(cscanner.read_chunk(csize)!)
 		cscanner.skip_crlf()
 	}
 	cscanner.skip_crlf()

--- a/vlib/net/http/chunked/dechunk_test.v
+++ b/vlib/net/http/chunked/dechunk_test.v
@@ -1,0 +1,16 @@
+module chunked
+
+fn test_invalid_chunk() {
+	mut is_failure := false
+
+	decode('eee') or { is_failure = true }
+
+	assert is_failure
+}
+
+fn test_valid_chunk() {
+	chunks := '4\r\nWiki\r\n7\r\npedia i\r\nB\r\nn \r\nchunks.\r\n0\r\n\r\n'
+	str := decode(chunks) or { panic('uh oh') }
+
+	assert str == 'Wikipedia in \r\nchunks.'
+}

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -42,7 +42,7 @@ pub fn parse_response(resp string) !Response {
 	header := parse_headers(resp.substr(start_idx, end_idx))!
 	mut body := resp.substr(end_idx, resp.len)
 	if header.get(.transfer_encoding) or { '' } == 'chunked' {
-		body = chunked.decode(body)
+		body = chunked.decode(body)!
 	}
 	return Response{
 		http_version: version


### PR DESCRIPTION
"Never trust the internet" - Hosts can cut the request short and so chunked content decoding may fail, causing a runtime panic. Refactor to return `!string` instead of `string. Add tests too.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c83f4bd</samp>

Improved error handling in the `chunked` module and its usage in `response.v`. Made the functions return optional strings and propagate errors with the `!` operator instead of silently failing or returning empty values.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c83f4bd</samp>

*  Make `chunked.decode` and `read_chunk` return optional strings to handle invalid chunk sizes ([link](https://github.com/vlang/v/pull/18928/files?diff=unified&w=0#diff-9cdb97082d99da7d1495778fa72ce8a40368a31df08c267509d5cfb989917dd1L49-R58), [link](https://github.com/vlang/v/pull/18928/files?diff=unified&w=0#diff-9cdb97082d99da7d1495778fa72ce8a40368a31df08c267509d5cfb989917dd1L67-R70), [link](https://github.com/vlang/v/pull/18928/files?diff=unified&w=0#diff-75efcba8ed0029a97f653d4b42426c8a9fd3fbe58e54af92311fe791ddc5d0e9L45-R45))
