### PR TITLE
net.conv: improve byte swapping on x86

### DIFF
--- a/vlib/net/conv/conv.v
+++ b/vlib/net/conv/conv.v
@@ -5,9 +5,9 @@ pub fn htn64(host u64) u64 {
 	$if little_endian {
 		$if amd64 {
 			mut r := host
-			asm amd64 {
+			asm volatile amd64 {
 				bswap a
-				; =r (r) as a
+				; +r (r) as a
 			}
 			return r
 		} $else {
@@ -36,7 +36,7 @@ pub fn htn32(host u32) u32 {
 			mut r := host
 			asm amd64 {
 				bswap a
-				; =r (r) as a
+				; +r (r) as a
 			}
 			return r
 		} $else {
@@ -61,7 +61,7 @@ pub fn htn16(host u16) u16 {
 			mut r := host
 			asm amd64 {
 				rol a, 8
-				; =r (r) as a
+				; +r (r) as a
 			}
 			return r
 		} $else {

--- a/vlib/net/conv/conv.v
+++ b/vlib/net/conv/conv.v
@@ -3,18 +3,27 @@ module conv
 // htn64 converts a the 64 bit value `host` to the net format (htonll)
 pub fn htn64(host u64) u64 {
 	$if little_endian {
-		// vfmt off
-		return (
-			((host >> 56) & 0x00000000_000000FF) | 
-			((host >> 40) & 0x00000000_0000FF00) | 
-			((host >> 24) & 0x00000000_00FF0000) | 
-			((host >> 8)  & 0x00000000_FF000000) |
-			((host << 8)  & 0x000000FF_00000000) | 
-			((host << 24) & 0x0000FF00_00000000) | 
-			((host << 40) & 0x00FF0000_00000000) | 
-			((host << 56) & 0xFF000000_00000000)
-		)
-		// vfmt on
+		$if amd64 {
+			mut r := host
+			asm amd64 {
+				bswap a
+				; =r (r) as a
+			}
+			return r
+		} $else {
+			// vfmt off
+			return (
+				((host >> 56) & 0x00000000_000000FF) |
+				((host >> 40) & 0x00000000_0000FF00) |
+				((host >> 24) & 0x00000000_00FF0000) |
+				((host >> 8)  & 0x00000000_FF000000) |
+				((host << 8)  & 0x000000FF_00000000) |
+				((host << 24) & 0x0000FF00_00000000) |
+				((host << 40) & 0x00FF0000_00000000) |
+				((host << 56) & 0xFF000000_00000000)
+			)
+			// vfmt on
+		}
 	} $else {
 		return host
 	}
@@ -23,14 +32,23 @@ pub fn htn64(host u64) u64 {
 // htn32 converts the 32 bit value `host` to the net format (htonl)
 pub fn htn32(host u32) u32 {
 	$if little_endian {
-		// vfmt off
-		return (
-			((host >> 24) & 0x0000_00FF) | 
-			((host >> 8)  & 0x0000_FF00) | 
-			((host << 8)  & 0x00FF_0000) | 
-			((host << 24) & 0xFF00_0000)
-		)
-		// vfmt on
+		$if amd64 || i386 {
+			mut r := host
+			asm amd64 {
+				bswap a
+				; =r (r) as a
+			}
+			return r
+		} $else {
+			// vfmt off
+			return (
+				((host >> 24) & 0x0000_00FF) |
+				((host >> 8)  & 0x0000_FF00) |
+				((host << 8)  & 0x00FF_0000) |
+				((host << 24) & 0xFF00_0000)
+			)
+			// vfmt on
+		}
 	} $else {
 		return host
 	}
@@ -39,12 +57,21 @@ pub fn htn32(host u32) u32 {
 // htn16 converts the 16 bit value `host` to the net format (htons)
 pub fn htn16(host u16) u16 {
 	$if little_endian {
-		// vfmt off
-		return (
-			((host >> 8) & 0x00FF) | 
-			((host << 8) & 0xFF00)
-		)
-		// vfmt on
+		$if amd64 || i386 {
+			mut r := host
+			asm amd64 {
+				rol a, 8
+				; =r (r) as a
+			}
+			return r
+		} $else {
+			// vfmt off
+			return (
+				((host >> 8) & 0x00FF) |
+				((host << 8) & 0xFF00)
+			)
+			// vfmt on
+		}
 	} $else {
 		return host
 	}

--- a/vlib/net/conv/conv.v
+++ b/vlib/net/conv/conv.v
@@ -3,7 +3,7 @@ module conv
 // htn64 converts a the 64 bit value `host` to the net format (htonll)
 pub fn htn64(host u64) u64 {
 	$if little_endian {
-		$if amd64 {
+		$if amd64 && !tinyc {
 			mut r := host
 			asm volatile amd64 {
 				bswap a
@@ -32,7 +32,7 @@ pub fn htn64(host u64) u64 {
 // htn32 converts the 32 bit value `host` to the net format (htonl)
 pub fn htn32(host u32) u32 {
 	$if little_endian {
-		$if amd64 || i386 {
+		$if !tinyc && (amd64 || i386) {
 			mut r := host
 			asm amd64 {
 				bswap a
@@ -57,7 +57,7 @@ pub fn htn32(host u32) u32 {
 // htn16 converts the 16 bit value `host` to the net format (htons)
 pub fn htn16(host u16) u16 {
 	$if little_endian {
-		$if amd64 || i386 {
+		$if !tinyc && (amd64 || i386) {
 			mut r := host
 			asm amd64 {
 				rol a, 8


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Make use of the x86 `bswap` instruction for efficient byte swapping (see [intel docs for the bswap](https://www.felixcloutier.com/x86/bswap)). 16-bit byte swapping is done with a bit-rotation.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebc19c2</samp>

Improve the performance of `net.conv` module by using assembly byte swapping on some platforms. Add compile-time checks for platform compatibility and fallback to pure V code otherwise.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebc19c2</samp>

* Optimize byte order conversion functions for 64-bit, 32-bit, and 16-bit unsigned integers by using assembly instructions on amd64 and i386 platforms ([link](https://github.com/vlang/v/pull/18931/files?diff=unified&w=0#diff-e8475fdf90d528db59faad4c82916fbe194109ab9088e5cc6e7579b234d64f34L6-R26), [link](https://github.com/vlang/v/pull/18931/files?diff=unified&w=0#diff-e8475fdf90d528db59faad4c82916fbe194109ab9088e5cc6e7579b234d64f34L26-R51), [link](https://github.com/vlang/v/pull/18931/files?diff=unified&w=0#diff-e8475fdf90d528db59faad4c82916fbe194109ab9088e5cc6e7579b234d64f34L42-R74) in `vlib/net/conv/conv.v`)
