### PR TITLE
readline: remove new line \n character from readline output

### DIFF
--- a/vlib/readline/readline_nix.c.v
+++ b/vlib/readline/readline_nix.c.v
@@ -472,6 +472,7 @@ fn (mut r Readline) commit_line() bool {
 		r.refresh_line()
 		println('')
 	}
+	r.current.pop()
 	return true
 }
 

--- a/vlib/readline/readline_nix.c.v
+++ b/vlib/readline/readline_nix.c.v
@@ -133,6 +133,10 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ![]rune {
 	r.disable_raw_mode()
 	if r.current.len == 0 {
 		return error('empty line')
+	} else {
+		if r.current.last() == `\n` {
+			r.current.pop()
+		}
 	}
 	return r.current
 }
@@ -472,7 +476,6 @@ fn (mut r Readline) commit_line() bool {
 		r.refresh_line()
 		println('')
 	}
-	r.current.pop()
 	return true
 }
 


### PR DESCRIPTION
currently the output of `readline` includes the new line character at the end of the string which it shouldn't. 

problem: 
```v
input := read_line('> ')!
// type <hello> and press enter
print(input.len) // output is 6 but should be 5
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->
