### PR TITLE
time: fix loosing of is_local flag after adding duration

### DIFF
--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -116,6 +116,9 @@ pub fn (t Time) add(d Duration) Time {
 	microseconds := i64(t.unix) * 1_000_000 + t.microsecond + d.microseconds()
 	unix := microseconds / 1_000_000
 	micro := microseconds % 1_000_000
+	if t.is_local {
+		return unix2(unix, int(micro)).as_local()
+	}
 	return unix2(unix, int(micro))
 }
 

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -187,10 +187,15 @@ fn test_add() {
 	assert t2.second == t1.second + d_seconds
 	assert t2.microsecond == t1.microsecond + d_microseconds
 	assert t2.unix == t1.unix + d_seconds
+	assert t2.is_local == t1.is_local
 	t3 := time_to_test.add(-duration)
 	assert t3.second == t1.second - d_seconds
 	assert t3.microsecond == t1.microsecond - d_microseconds
 	assert t3.unix == t1.unix - d_seconds
+	assert t3.is_local == t1.is_local
+	t4 := time_to_test.as_local()
+	t5 := t4.add(duration)
+	assert t5.is_local == t4.is_local
 }
 
 fn test_add_days() {


### PR DESCRIPTION
Adding a duration/integer to a Time object via `.add()` or `.add_days()` or `add_seconds()` returns a new Time object that does not preserve the original state of `is_local` value.

The state should be preserved in order not to loose it which can lead to unexpected/strange results.