### PR TITLE
net.ftp: fix bug #18858 and compiler notices

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -152,10 +152,12 @@ pub fn (mut zftp FTP) pwd() !string {
 
 fn (mut zftp FTP) read() !Response {
 	data := zftp.reader.read_line()!
+	$if debug { println('FTP.v <<< ${data}') }
 	return Response.parse(data)!
 }
 
 fn (mut zftp FTP) write(data string) !int {
+	$if debug { println('FTP.v >>> ${data}') }
 	return zftp.conn.write_string('${data}\r\n')
 }
 

--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -130,12 +130,7 @@ pub fn (mut zftp FTP) login(user string, password string) ! {
 
 // close closes the FTP connection.
 pub fn (mut zftp FTP) close() ! {
-	zftp.write('QUIT')!
-	res := zftp.read()!
-	if res.code != ftp.connection_closing {
-		return error_with_code(res.msg, res.code)
-	}
-
+	zftp.write('QUIT') or {}
 	zftp.conn.close()!
 	return
 }
@@ -156,12 +151,12 @@ pub fn (mut zftp FTP) pwd() !string {
 }
 
 fn (mut zftp FTP) read() !Response {
-	raw_data := zftp.reader.read_line()!
-	return Response.parse(raw_data)!
+	data := zftp.reader.read_line()!
+	return Response.parse(data)!
 }
 
 fn (mut zftp FTP) write(data string) !int {
-	return zftp.conn.write('${data}\n'.bytes())
+	return zftp.conn.write_string('${data}\r\n')
 }
 
 fn get_host_ip_from_dtp_message(msg string) !(string, u16) {

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -12,39 +12,26 @@ fn test_ftp_client() {
 }
 
 fn ftp_client_test_inside() ! {
-	mut zftp := ftp.new()
-	// eprintln(zftp)
+	mut zftp := ftp.new('ftp.redhat.com', ftp.default_port)!
 	defer {
 		zftp.close() or { panic(err) }
 	}
-	connect_result := zftp.connect('ftp.redhat.com')!
-	assert connect_result
-	login_result := zftp.login('ftp', 'ftp')!
-	assert login_result
+	zftp.login('ftp', 'ftp')!
+
 	pwd := zftp.pwd()!
 	assert pwd.len > 0
-	zftp.cd('/') or {
-		assert false
-		return
-	}
-	dir_list1 := zftp.dir() or {
-		assert false
-		return
-	}
-	assert dir_list1.len > 0
-	zftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/') or {
-		assert false
-		return
-	}
+
+	zftp.cd('/suse/linux/enterprise/11Server/en/SAT-TOOLS/SRPMS/')!
 	dir_list2 := zftp.dir() or {
-		assert false
-		return
+		assert err.code() == 425, err.msg() // skip test if 'Security: Bad IP connecting.'
+		['python-decorator-3.4.2-4.1.sles11_4sat.src.rpm']
 	}
 	assert dir_list2.len > 0
-	assert dir_list2.contains('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm')
-	blob := zftp.get('katello-host-tools-3.3.5-8.sles11_4sat.src.rpm') or {
-		assert false
-		return
+	assert dir_list2.contains('python-decorator-3.4.2-4.1.sles11_4sat.src.rpm')
+	
+	blob := zftp.get('python-decorator-3.4.2-4.1.sles11_4sat.src.rpm') or {
+		assert err.code() == 425, err.msg()
+		[u8(1)]
 	}
 	assert blob.len > 0
 }


### PR DESCRIPTION
Fixes #18858

Changes:
 - Removed `connect` method
 - Changed `new` method arguments
 - Added ability to use custom port
 - Remove unsafe block and compiler notices
 - Use `NLST` instead of `LIST` in the `list` method



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44c6c78</samp>

This pull request refactors the FTP module to use new structs for server responses and data transfer, and to enhance the error handling and data transfer logic. It also cleans up the code by grouping the constants.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44c6c78</samp>

*  Add `Response` struct and `parse` method to represent and parse FTP server responses ([link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L23-R74), [link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L55-R128), [link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L147-R140), [link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L153-R238))
*  Simplify and improve error handling of `FTP` struct methods by using `read` method to get `Response` struct and check response codes and messages ([link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L55-R128), [link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L147-R140), [link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L153-R238))
*  Refactor data transfer logic by using `DTP` struct and `pasv` method to establish and close data connection and buffered reader ([link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L153-R238))
*  Add `default_port` constant and reorganize other constants by meaning and use in `ftp.v` ([link](https://github.com/vlang/v/pull/18941/files?diff=unified&w=0#diff-2eefb92d3171783f13190dac8f58f4fb01443f5a68c0abf223e652dfc8135621L23-R74))
