### PR TITLE
fix(stdlib docs): use square brackets for generics

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -3,8 +3,8 @@ module arrays
 import strings
 
 // Common arrays functions:
-// - min / max - return the value of the minumum / maximum
-// - idx_min / idx_max - return the index of the first minumum / maximum
+// - min / max - return the value of the minimum / maximum
+// - idx_min / idx_max - return the index of the first minimum / maximum
 // - merge - combine two sorted arrays and maintain sorted order
 // - chunk - chunk array to arrays with n elements
 // - window - get snapshots of the window of the given size sliding along array with the given step, where each snapshot is an array
@@ -312,7 +312,7 @@ pub fn fold_indexed[T, R](array []T, init R, fold_op fn (idx int, acc R, elem T)
 }
 
 // flatten flattens n + 1 dimensional array into n dimensional array
-// Example: arrays.flatten<int>([[1, 2, 3], [4, 5]]) // => [1, 2, 3, 4, 5]
+// Example: arrays.flatten[int]([[1, 2, 3], [4, 5]]) // => [1, 2, 3, 4, 5]
 pub fn flatten[T](array [][]T) []T {
 	// calculate required capacity
 	mut required_size := 0

--- a/vlib/sync/pool/pool.v
+++ b/vlib/sync/pool/pool.v
@@ -37,7 +37,7 @@ pub struct PoolProcessorConfig {
 //      thread in the pool will run for each item.
 //      The callback function will receive as parameters:
 //      1) the PoolProcessor instance, so it can call
-//            p.get_item<int>(idx) to get the actual item at index idx
+//            p.get_item[int](idx) to get the actual item at index idx
 //      2) idx - the index of the currently processed item
 //      3) task_id - the index of the worker thread in which the callback
 //            function is running.


### PR DESCRIPTION
Found two instances in the user facing docs of the stdlib using the old `<T>`, instead of the new `[T]` syntax for generics. Corrected a couple of typos.

This PR is restricted to user visible documentation and _not_ general comments



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1ec655</samp>

This pull request fixes some documentation errors in the `arrays` and `pool` modules, mainly related to generic types and functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1ec655</samp>

* Fix typos and update syntax in comments of `arrays` and `pool` modules ([link](https://github.com/vlang/v/pull/18943/files?diff=unified&w=0#diff-b7b2841a2601a108289f795e922710054cff56ff06212c11d40dd2a0346191dcL6-R7), [link](https://github.com/vlang/v/pull/18943/files?diff=unified&w=0#diff-b7b2841a2601a108289f795e922710054cff56ff06212c11d40dd2a0346191dcL315-R315), [link](https://github.com/vlang/v/pull/18943/files?diff=unified&w=0#diff-d29cc82ff0aab2e8f42ad5d93856fd7b0063248920bbe44465ab0a1cac1e0ad7L40-R40))
