### PR TITLE
vlib: remove methods deprecated before 2022-07-22

### DIFF
--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -354,22 +354,6 @@ pub fn (s string) trim_string_right(str string) string {
 	return s.clone()
 }
 
-// trim_prefix strips `str` from the start of the string.
-// Example: assert 'WorldHello V'.trim_prefix('World') == 'Hello V'
-[deprecated: 'use s.trim_string_left(x) instead']
-[deprecated_after: '2022-01-19']
-pub fn (s string) trim_prefix(str string) string {
-	return s.trim_string_left(str)
-}
-
-// trim_suffix strips `str` from the end of the string.
-// Example: assert 'Hello VWorld'.trim_suffix('World') == 'Hello V'
-[deprecated: 'use s.trim_string_right(x) instead']
-[deprecated_after: '2022-01-19']
-pub fn (s string) trim_suffix(str string) string {
-	return s.trim_string_right(str)
-}
-
 // compare_strings returns `-1` if `a < b`, `1` if `a > b` else `0`.
 pub fn compare_strings(a &string, b &string) int {
 	if a < b {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1677,22 +1677,6 @@ pub fn (s string) trim_string_right(str string) string {
 	return s.clone()
 }
 
-// trim_prefix strips `str` from the start of the string.
-// Example: assert 'WorldHello V'.trim_prefix('World') == 'Hello V'
-[deprecated: 'use s.trim_string_left(x) instead']
-[deprecated_after: '2022-01-19']
-pub fn (s string) trim_prefix(str string) string {
-	return s.trim_string_left(str)
-}
-
-// trim_suffix strips `str` from the end of the string.
-// Example: assert 'Hello VWorld'.trim_suffix('World') == 'Hello V'
-[deprecated: 'use s.trim_string_right(x) instead']
-[deprecated_after: '2022-01-19']
-pub fn (s string) trim_suffix(str string) string {
-	return s.trim_string_right(str)
-}
-
 // compare_strings returns `-1` if `a < b`, `1` if `a > b` else `0`.
 pub fn compare_strings(a &string, b &string) int {
 	if a < b {

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -66,19 +66,6 @@ pub fn utf32_decode_to_buffer(code u32, buf &u8) int {
 	return 0
 }
 
-// utf8_str_len returns the number of runes contained in the string.
-[deprecated: 'use `string.len_utf8()` instead']
-[deprecated_after: '2022-05-28']
-pub fn utf8_str_len(s string) int {
-	mut l := 0
-	mut i := 0
-	for i < s.len {
-		l++
-		i += ((0xe5000000 >> ((unsafe { s.str[i] } >> 3) & 0x1e)) & 3) + 1
-	}
-	return l
-}
-
 // Convert utf8 to utf32
 // the original implementation did not check for
 // valid utf8 in the string, and could result in

--- a/vlib/toml/input/input.v
+++ b/vlib/toml/input/input.v
@@ -13,27 +13,6 @@ pub:
 	file_path string // '/path/to/file.toml'
 }
 
-// auto_config returns an, automatic determined, input Config based on heuristics
-// found in `toml`
-// One example of several of why it's deprecated:
-// https://discord.com/channels/592103645835821068/592114487759470596/954101934988615721
-[deprecated: 'will be removed and not replaced due to flaky heuristics that leads to hard to find bugs']
-[deprecated_after: '2022-06-18']
-pub fn auto_config(toml string) !Config {
-	mut config := Config{}
-	if !toml.contains('\n') && os.is_file(toml) {
-		config = Config{
-			file_path: toml
-		}
-	} else {
-		config = Config{
-			text: toml
-		}
-	}
-	config.validate()!
-	return config
-}
-
 // validate returns an optional error if more than one of the fields
 // in `Config` has a non-default value (empty string).
 fn (c Config) validate() ! {

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -108,26 +108,6 @@ pub fn parse_text(text string) !Doc {
 	}
 }
 
-// parse parses the TOML document provided in `toml`.
-// parse automatically try to determine if the type of `toml` is a file or text.
-// For explicit parsing of input types see `parse_file` or `parse_text`.
-[deprecated: 'use parse_file or parse_text instead']
-[deprecated_after: '2022-06-18']
-pub fn parse(toml string) !Doc {
-	mut input_config := input.auto_config(toml)!
-	scanner_config := scanner.Config{
-		input: input_config
-	}
-	parser_config := parser.Config{
-		scanner: scanner.new_scanner(scanner_config)!
-	}
-	mut p := parser.new_parser(parser_config)
-	ast_ := p.parse()!
-	return Doc{
-		ast: ast_
-	}
-}
-
 // parse_dotted_key converts `key` string to an array of strings.
 // parse_dotted_key preserves strings delimited by both `"` and `'`.
 pub fn parse_dotted_key(key string) ![]string {


### PR DESCRIPTION
Before:
```
#0 14:11:46 ᛋ master /v/vnew❱rg deprecated_after|grep 2022
vlib/net/http/response.v:13:text         string [deprecated: 'use Response.body instead'; deprecated_after: '2022-10-03']
vlib/net/http/response.v:121:text    string  [deprecated: 'use ResponseConfig.body instead'; deprecated_after: '2022-10-03']
vlib/builtin/utf8.v:71:[deprecated_after: '2022-05-28']
vlib/time/chrono.v:21:[deprecated_after: '2022-11-23']
vlib/builtin/array.v:956:[deprecated_after: '2022-10-11']
vlib/builtin/js/string.js.v:360:[deprecated_after: '2022-01-19']
vlib/builtin/js/string.js.v:368:[deprecated_after: '2022-01-19']
vlib/builtin/string.v:1683:[deprecated_after: '2022-01-19']
vlib/builtin/string.v:1691:[deprecated_after: '2022-01-19']
vlib/toml/input/input.v:21:[deprecated_after: '2022-06-18']
vlib/toml/toml.v:115:[deprecated_after: '2022-06-18']
#0 14:11:57 ᛋ master /v/vnew❱
```

After:
```
#0 14:17:22 ᛋ cleanup_deprecated_methods /v/vnew❱rg deprecated_after|grep 2022
vlib/time/chrono.v:21:[deprecated_after: '2022-11-23']
vlib/net/http/response.v:13:text         string [deprecated: 'use Response.body instead'; deprecated_after: '2022-10-03']
vlib/net/http/response.v:121:text    string  [deprecated: 'use ResponseConfig.body instead'; deprecated_after: '2022-10-03']
vlib/builtin/array.v:956:[deprecated_after: '2022-10-11']
#0 14:18:57 ᛋ cleanup_deprecated_methods /v/vnew❱
```