### PR TITLE
fmt: fix formatting of the comptime call (fix #18942)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1977,7 +1977,11 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 				f.write("\$pkgconfig('${node.args_var}')")
 			}
 			node.method_name in ['compile_error', 'compile_warn'] {
-				f.write("\$${node.method_name}('${node.args_var}')")
+				if node.args_var.contains("'") {
+					f.write('\$${node.method_name}("${node.args_var}")')
+				} else {
+					f.write("\$${node.method_name}('${node.args_var}')")
+				}
 			}
 			node.method_name == 'res' {
 				if node.args_var != '' {

--- a/vlib/v/fmt/tests/comptime_call_keep.vv
+++ b/vlib/v/fmt/tests/comptime_call_keep.vv
@@ -1,0 +1,5 @@
+$if linux {
+	$compile_error("This won't be formatted correctly by v fmt :')")
+}
+
+fn main() {}


### PR DESCRIPTION
This PR fix formatting of the comptime call (fix #18942).

- Fix formatting of the comptime call.
- Add test.

```v
$if linux {
	$compile_error("This won't be formatted correctly by v fmt :')")
}

fn main() {}
```