### PR TITLE
native: fix the file path used for warning messages

### DIFF
--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -43,6 +43,7 @@ mut:
 	stack_var_pos        int
 	stack_depth          int
 	debug_pos            int
+	current_file         &ast.File
 	errors               []errors.Error
 	warnings             []errors.Warning
 	syms                 []Symbol
@@ -346,6 +347,7 @@ pub fn gen(files []&ast.File, table &ast.Table, out_name string, pref_ &pref.Pre
 			eprintln('warning: ${file.warnings[0]}')
 		}
 		*/
+		g.current_file = file
 		if file.errors.len > 0 {
 			g.n_error(file.errors[0].str())
 		}
@@ -1055,10 +1057,10 @@ pub fn (mut g Gen) n_error(s string) {
 
 pub fn (mut g Gen) warning(s string, pos token.Pos) {
 	if g.pref.output_mode == .stdout {
-		util.show_compiler_message('warning:', pos: pos, file_path: g.pref.path, message: s)
+		util.show_compiler_message('warning:', pos: pos, file_path: g.current_file.path, message: s)
 	} else {
 		g.warnings << errors.Warning{
-			file_path: g.pref.path
+			file_path: g.current_file.path
 			pos: pos
 			reporter: .gen
 			message: s

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -43,7 +43,7 @@ mut:
 	stack_var_pos        int
 	stack_depth          int
 	debug_pos            int
-	current_file         &ast.File
+	current_file         &ast.File = unsafe { nil }
 	errors               []errors.Error
 	warnings             []errors.Warning
 	syms                 []Symbol


### PR DESCRIPTION
Changing the way warning messages get the file path. That also added (unintended) the description of the warning, like the underlining etc.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca76c5f</samp>

This pull request improves the warning messages for native code generation by using the correct file path for each AST file. It also adds a new field to the `Gen` struct to keep track of the current file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca76c5f</samp>

* Add a new field `current_file` to the `Gen` struct to track the current AST file being generated ([link](https://github.com/vlang/v/pull/18948/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5R46))
* Assign the `current_file` field the value of the `file` parameter in the `gen_file` method for each file processed by the generator ([link](https://github.com/vlang/v/pull/18948/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5R350))
* Use the `current_file.path` instead of the `pref.path` for the `file_path` argument of the warning functions to show the correct source file location ([link](https://github.com/vlang/v/pull/18948/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L1058-R1063))
