### PR TITLE
disallow assigning struct fielld assign voidptr to fn ptr

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -557,8 +557,9 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 						&& init_field.expr.str() != '0' && !exp_type.has_flag(.option) {
 						c.error('reference field must be initialized with reference',
 							init_field.pos)
-					} else if exp_type.is_pointer() && !got_type.is_any_kind_of_pointer()
-						&& !got_type.is_int() {
+					} else if (exp_type.is_pointer() && !got_type.is_any_kind_of_pointer()
+						&& !got_type.is_int())
+						|| (got_type_sym.kind == .function && exp_type.is_pointer()) {
 						got_typ_str := c.table.type_to_str(got_type)
 						exp_typ_str := c.table.type_to_str(exp_type)
 						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',

--- a/vlib/v/checker/tests/voidptr_struct_assign_fn_ptr_err.out
+++ b/vlib/v/checker/tests/voidptr_struct_assign_fn_ptr_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/voidptr_struct_assign_fn_ptr_err.vv:15:3: error: cannot assign to field `func`: expected a pointer `voidptr`, but got `&fn ()`
+   13 | 
+   14 |     _ := &StructVoidptr{
+   15 |         func: &fun
+      |         ~~~~~~~
+   16 |     }
+   17 | }

--- a/vlib/v/checker/tests/voidptr_struct_assign_fn_ptr_err.vv
+++ b/vlib/v/checker/tests/voidptr_struct_assign_fn_ptr_err.vv
@@ -1,0 +1,17 @@
+module main
+
+struct StructVoidptr {
+	func voidptr
+}
+
+fn function() {
+	println('Function!')
+}
+
+fn main() {
+	fun := function
+
+	_ := &StructVoidptr{
+		func: &fun
+	}
+}


### PR DESCRIPTION
Closes https://github.com/vlang/v/issues/12347
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b5bfcc</samp>

Fix a bug that allowed assigning function pointers to void pointer fields in structs. Add a check in the checker and a test case to verify the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b5bfcc</samp>

* Fix a bug where assigning a function pointer to a void pointer field was allowed by the compiler, but caused a segmentation fault at runtime ([link](https://github.com/vlang/v/pull/18949/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L560-R562))
* Add a test case to demonstrate the bug and the fix ([link](https://github.com/vlang/v/pull/18949/files?diff=unified&w=0#diff-4e194cc0d78f759bce05c865347a8a116512d507dc41769ed696256b16625c6aR1-R7), [link](https://github.com/vlang/v/pull/18949/files?diff=unified&w=0#diff-b860a9ac6825f04f1a7672f30c34b66f809b09b0fbe15371c46395d70ea0456aR1-R17))
