### PR TITLE
tools: fix vcomplete for zsh

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -342,11 +342,19 @@ fn auto_complete(args []string) {
 				exit(0)
 			}
 			mut lines := []string{}
+			mut dirs := []string{}
+			mut files := []string{}
 			list := auto_complete_request(sub_args[1..])
 			for entry in list {
-				lines << 'compadd -U -S' + '""' + ' -- ' + "'${entry}';"
+				match true {
+					os.is_dir(entry) { dirs << entry }
+					os.is_file(entry) { files << entry }
+					else { lines << entry }
+				}
 			}
-			println(lines.join('\n'))
+			println('compadd -q -- ${lines.join(' ')}')
+			println('compadd -J "dirs" -X "directory" -d -- ${dirs.join(' ')}')
+			println('compadd -J "files" -X "file" -f -- ${files.join(' ')}')
 		}
 		'-h', '--help' {
 			println(help_text)


### PR DESCRIPTION
Having read in yesterdays discords help chat about vcomplete for zsh, I started using it. 

Experiencing some problems with it, this PR submits some fixes.

E.g. some current issues that get fixed: 
- Selecting a completing item adds a `--` suffix. E.g. selecting v `self` becomes `self--`, which is not recognized as a command by default and it's required to manually remove the suffix. For commands like `run--`(followed by a path arg) this also stops further suggestions of directories / files. 
- Commands / Files / Directories are not grouped.
![Screenshot from 2023-07-23 11-02-07](https://github.com/vlang/v/assets/34311583/48c65a94-f129-4b9b-98a3-159b38de3ec6)
  Comparison like it's done in go. It's similar for v after the change.
  ![go](https://github.com/vlang/v/assets/34311583/d95f5561-7047-4db0-8f71-162ab05848c6)
  
  
Below a short video. First it shows the above mentioned issues and then how it behaves with the changes:

https://github.com/vlang/v/assets/34311583/806a3f79-4ff9-406a-8c7e-3dc7584959a7

I found some more room for things that can be improved. E.g., when selecting a completing entry that is a directory it should optimally automatically show further suggestions for files and subdirs. But I think the PR makes things a lot better already and with time I would do a part 2 to submit such nitpicks and see if more things come up with extended usage.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eda08db</samp>

Improve zsh completion for v commands by using different `compadd` options for different types of candidates. Modify `cmd/tools/vcomplete.v` to separate the candidates by type and pass them to `compadd` accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eda08db</samp>

* Improve zsh completion for v commands by using different compadd options for directories, files, and other lines ([link](https://github.com/vlang/v/pull/18950/files?diff=unified&w=0#diff-23f795d87e7ad5c06cf7e08a78af246428e9184ae5fd450c8f1ac07a00e8aae9L345-R357))
