### PR TITLE
checker: fix const from multi branchs of if expr (fix #18933)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1626,18 +1626,11 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 		}
 		node.fields[i].typ = ast.mktyp(typ)
 		if mut field.expr is ast.IfExpr {
-			if field.expr.branches.len == 2 {
-				first_stmts := field.expr.branches[0].stmts
-				second_stmts := field.expr.branches[1].stmts
-				if first_stmts.len > 0 && first_stmts.last() is ast.ExprStmt
-					&& first_stmts.last().typ != ast.void_type {
+			for branch in field.expr.branches {
+				if branch.stmts.len > 0 && branch.stmts.last() is ast.ExprStmt
+					&& branch.stmts.last().typ != ast.void_type {
 					field.expr.is_expr = true
-					field.expr.typ = (first_stmts.last() as ast.ExprStmt).typ
-					field.typ = field.expr.typ
-				} else if second_stmts.len > 0 && second_stmts.last() is ast.ExprStmt
-					&& second_stmts.last().typ != ast.void_type {
-					field.expr.is_expr = true
-					field.expr.typ = (second_stmts.last() as ast.ExprStmt).typ
+					field.expr.typ = (branch.stmts.last() as ast.ExprStmt).typ
 					field.typ = field.expr.typ
 				}
 			}

--- a/vlib/v/tests/const_from_multi_branchs_of_if_expr_test.v
+++ b/vlib/v/tests/const_from_multi_branchs_of_if_expr_test.v
@@ -1,0 +1,14 @@
+import os
+
+const bin = $if linux {
+	os.join_path(@VMODROOT, 'bin_linux_64')
+} $else $if macos {
+	os.join_path(@VMODROOT, 'bin_macos')
+} $else {
+	''
+}
+
+fn test_const_from_mutli_branchs_of_if_expr() {
+	println('Hello')
+	assert true
+}


### PR DESCRIPTION
This PR fix const from multi branchs of if expr (fix #18933).

- Fix const from multi branchs of if expr.
- Add test.

```v
import os

const bin = $if linux {
	os.join_path(@VMODROOT, 'bin_linux_64')
} $else $if macos {
	os.join_path(@VMODROOT, 'bin_macos')
} $else {
	''
}

fn main() {
	println('Hello')
}

PS D:\Test\v\tt1> v run .
Hello
```