### PR TITLE
v.scanner: fix scanner when quote is directly after '}'

### DIFF
--- a/vlib/v/tests/string_interpolation_string_args_test.v
+++ b/vlib/v/tests/string_interpolation_string_args_test.v
@@ -28,4 +28,6 @@ fn test_interpolation_string_args() {
 
 	assert '1_${show_more_info('aaa', '111')} 2_${show_more_info('bbb', '222')}' == '1_aaa111 2_bbb222'
 	assert '1_${show_more_info('aaa', '111')} 2_${show_more_info('bbb', '222')}' == '1_aaa111 2_bbb222'
+
+	assert '"${show_info('abc')}"' == '"abc"'
 }


### PR DESCRIPTION
Fix for #18888 

This pr adds a fix for the case where there is a quote directly after a string interpolation part.

```v
module main

fn url(path string) string {
	return '${path}.html'
}

fn main() {
	//                           v
	assert 'href="${url('/test')}"' == 'href="/test.html"'
}
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0b5f31</samp>

Fixed a scanner bug with string interpolation and added a test case. The bug caused syntax errors when parsing string literals with interpolation expressions that had string arguments. The test case is in `vlib/v/tests/string_interpolation_string_args_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0b5f31</samp>

*  Add a new field `just_closed_inter` to the `Scanner` struct to track the end of string interpolation expressions ([link](https://github.com/vlang/v/pull/18961/files?diff=unified&w=0#diff-1bb5cde15ef3f080d1dcd7d80688b8208c896fe5895103639dc3c10eb61cafadL49-R50))
*  Set `just_closed_inter` to true when closing a string interpolation expression with `}` ([link](https://github.com/vlang/v/pull/18961/files?diff=unified&w=0#diff-1bb5cde15ef3f080d1dcd7d80688b8208c896fe5895103639dc3c10eb61cafadR840))
*  Check `just_closed_inter` before treating a quote character as the start of a new string literal ([link](https://github.com/vlang/v/pull/18961/files?diff=unified&w=0#diff-1bb5cde15ef3f080d1dcd7d80688b8208c896fe5895103639dc3c10eb61cafadL1152-R1156))
*  Reset `just_closed_inter` to false after processing a quote character ([link](https://github.com/vlang/v/pull/18961/files?diff=unified&w=0#diff-1bb5cde15ef3f080d1dcd7d80688b8208c896fe5895103639dc3c10eb61cafadR1163))
*  Add a test case in `vlib/v/tests/string_interpolation_string_args_test.v` to verify the correct parsing of string interpolation with string arguments ([link](https://github.com/vlang/v/pull/18961/files?diff=unified&w=0#diff-e6e8363fbab75df107a9e73b47bb94b19c892c0af38bedf279dda643210c5445R31-R32))
