### PR TITLE
cgen: remove carriage return for consistency with all other line-breaks

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -364,7 +364,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 		expr_str := g.out.last_n(g.out.len - start_pos).trim_space()
 		if expr_str != '' {
 			if g.defer_ifdef != '' {
-				g.defer_ifdef += '\r\n' + '\t'.repeat(g.indent + 1)
+				g.defer_ifdef += '\n' + '\t'.repeat(g.indent + 1)
 			}
 			g.defer_ifdef += expr_str
 		}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

`defer` statements within comp-time if branches sometimes use `\r\n` for the line break, whereas the rest of cgen just uses `\n`. This PR makes sure the consistency is maintained.

[This commit](https://github.com/vlang/v/commit/b6bbbcf2e7ff2f0f80629d209a40dee84056e6f3) added the line with the carriage return, but it seems like there was no direct reason.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b663b8</samp>

Fix a comptime bug that caused wrong C code formatting with `#ifdef` directives. Replace `\r` with `\n` in `g.defer_ifdef` in `vlib/v/gen/c/comptime.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b663b8</samp>

* Fix indentation and formatting of generated C code for `#ifdef` directives ([link](https://github.com/vlang/v/pull/18962/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL367-R367),                             F0
