### PR TITLE
runtime: cleanup free_memory comptime conditional

### DIFF
--- a/vlib/runtime/free_memory_impl_darwin.c.v
+++ b/vlib/runtime/free_memory_impl_darwin.c.v
@@ -19,16 +19,13 @@ fn C.host_page_size(host C.host_t, out_page_size &C.vm_size_t) int
 fn C.host_statistics64(host C.host_t, flavor int, host_info_out &int, host_info_outCnt &u32) int
 
 fn free_memory_impl() usize {
-	$if macos {
-		mut hs := C.vm_statistics64_data_t{}
-		mut vmsz := u32(C.HOST_VM_INFO64_COUNT)
-		mut hps := u32(0)
-		mut host := C.mach_host_self()
-		unsafe {
-			C.host_statistics64(host, C.HOST_VM_INFO64, &int(&hs), &vmsz)
-			C.host_page_size(host, &C.vm_size_t(&hps))
-		}
-		return usize(u64(hs.free_count) * u64(hps))
+	mut hs := C.vm_statistics64_data_t{}
+	mut vmsz := u32(C.HOST_VM_INFO64_COUNT)
+	mut hps := u32(0)
+	mut host := C.mach_host_self()
+	unsafe {
+		C.host_statistics64(host, C.HOST_VM_INFO64, &int(&hs), &vmsz)
+		C.host_page_size(host, &C.vm_size_t(&hps))
 	}
-	return 1
+	return usize(u64(hs.free_count) * u64(hps))
 }

--- a/vlib/runtime/free_memory_impl_linux.c.v
+++ b/vlib/runtime/free_memory_impl_linux.c.v
@@ -1,10 +1,7 @@
 module runtime
 
 fn free_memory_impl() usize {
-	$if linux {
-		page_size := usize(C.sysconf(C._SC_PAGESIZE))
-		av_phys_pages := usize(C.sysconf(C._SC_AVPHYS_PAGES))
-		return page_size * av_phys_pages
-	}
-	return 1
+	page_size := usize(C.sysconf(C._SC_PAGESIZE))
+	av_phys_pages := usize(C.sysconf(C._SC_AVPHYS_PAGES))
+	return page_size * av_phys_pages
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR cleans up `free_memory_impl_*.c.v` files to remove their redundant comptime conditionals resulting in cleaner C code.

Going from:
```c
VV_LOCAL_SYMBOL usize runtime__free_memory_impl(void) {
	usize page_size = ((usize)(sysconf(_SC_PAGESIZE)));
	usize av_phys_pages = ((usize)(sysconf(_SC_AVPHYS_PAGES)));
	usize _t1 = (usize)(page_size * av_phys_pages);
	return _t1;
	usize _t2 = 1;
	return _t2;
}
```
to
```c
VV_LOCAL_SYMBOL usize runtime__free_memory_impl(void) {
	usize page_size = ((usize)(sysconf(_SC_PAGESIZE)));
	usize av_phys_pages = ((usize)(sysconf(_SC_AVPHYS_PAGES)));
	usize _t1 = (usize)(page_size * av_phys_pages);
	return _t1;
}
```

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54df136</samp>

This pull request simplifies and unifies the implementation of the `free_memory_impl` function for the Darwin and Linux platforms, by removing unnecessary conditional compilation directives.

*  Simplify code by removing redundant `$if macos` directive ([link](https://github.com/vlang/v/pull/18968/files?diff=unified&w=0#diff-20d0e64a0930e6a80e2f51c9fea265bf6c254d22b36113870fff8dcbec080e99L22-R30))
