### PR TITLE
scanner: fix string interpolation with match expr (fix #18963)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -808,7 +808,7 @@ fn (mut s Scanner) text_scan() token.Token {
 			}
 			`{` {
 				// Skip { in `${` in strings
-				if s.is_inside_string {
+				if s.is_inside_string || s.is_enclosed_inter {
 					if s.text[s.pos - 1] == `$` {
 						continue
 					} else {

--- a/vlib/v/tests/string_interpolation_match_expr_test.v
+++ b/vlib/v/tests/string_interpolation_match_expr_test.v
@@ -1,0 +1,15 @@
+fn test_string_interpolation_match_expr() {
+	x := 0
+
+	println('Hello ${match x {
+		0 { 'John' }
+		1 { 'George' }
+		else { 'Others' }
+	}}')
+
+	assert '${match x {
+		0 { 'John' }
+		1 { 'George' }
+		else { 'Others' }
+	}}' == 'John'
+}


### PR DESCRIPTION
This PR fix string interpolation with match expr (fix #18963).

- Fix string interpolation with match expr.
- Add test.

```v
fn main() {
	x := 0

	println('Hello ${match x {
		0 { 'John' }
		1 { 'George' }
		else { 'Others' }
	}}')

	assert '${match x {
		0 { 'John' }
		1 { 'George' }
		else { 'Others' }
	}}' == 'John'
}

PS D:\Test\v\tt1> v run .
Hello John
```