### PR TITLE
vweb: Make routes case sensitive

### DIFF
--- a/vlib/vweb/parse.v
+++ b/vlib/vweb/parse.v
@@ -55,8 +55,8 @@ fn parse_attrs(name string, attrs []string) !([]http.Method, string, string, str
 	if path == '' {
 		path = '/${name}'
 	}
-	// Make path and host lowercase for case-insensitive comparisons
-	return methods, path.to_lower(), middleware, host.to_lower()
+	// Make host lowercase for case-insensitive comparisons
+	return methods, path, middleware, host.to_lower()
 }
 
 fn parse_query_from_url(url urllib.URL) map[string]string {


### PR DESCRIPTION
This PR makes routes in vweb specified through attributes case sensitive (e.g. `['/index'] fn index() {...` is different to `['/Index'] fn index() {...`). This fixes #17960, and seemed to work great for me in my testing (including unit tests), however I'm still not sure about it, as this seemed to work a little too well and be too easy. Things in software are never just a one line fix with no side effects, so when someone finds that their project doesn't work anymore because of this, please let me know before it's merged (if it gets merged) :)

As discussed in #17960, this does seem to be the "correct" way of doing this, as URLs are case sensitive and therefore vweb should treat them as such, although it does beg the question of if there should be a config option somewhere to use case insensitive routes. (This might be implementable in middleware but I haven't tried.)