### PR TITLE
checker: check fn call argument mismatch for array struct type (fix #18967)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -350,7 +350,8 @@ fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 		return true
 	}
 	// TODO: use sym so it can be absorbed into below [.voidptr, .any] logic
-	if expected.idx() == ast.array_type_idx || got.idx() == ast.array_type_idx {
+	if (expected.idx() == ast.array_type_idx && c.table.final_sym(got).kind == .array)
+		|| (got.idx() == ast.array_type_idx && c.table.final_sym(expected).kind == .array) {
 		return true
 	}
 	got_sym, exp_sym := c.table.sym(got), c.table.sym(expected)

--- a/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv:9:36: error: cannot use `string` as `array` in argument 2 to `os.write_file_array`
+    7 |
+    8 | fn main() {
+    9 |     os.write_file_array(service_path, service_file) or {
+      |                                       ~~~~~~~~~~~~
+   10 |         eprintln('Error: write file service')
+   11 |         exit(1)

--- a/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv
@@ -1,0 +1,13 @@
+import os
+
+const (
+	service_file = '[Unit]'
+	service_path = 'dockerman.service'
+)
+
+fn main() {
+	os.write_file_array(service_path, service_file) or {
+		eprintln('Error: write file service')
+		exit(1)
+	}
+}


### PR DESCRIPTION
This PR check fn call argument mismatch for array struct type (fix #18967).

- Check fn call argument mismatch for array struct type.
- Add test.

```v
import os

const (
	service_file = '[Unit]'
	service_path = 'dockerman.service'
)

fn main() {
	os.write_file_array(service_path, service_file) or {
		eprintln('Error: write file service')
		exit(1)
	}
}

PS D:\Test\v\tt1> v run .
tt1.v:9:36: error: cannot use `string` as `array` in argument 2 to `os.write_file_array`
    7 | 
    8 | fn main() {
    9 |     os.write_file_array(service_path, service_file) or {
      |                                       ~~~~~~~~~~~~
   10 |         eprintln('Error: write file service')
   11 |         exit(1)
```