### PR TITLE
ci: remove obsolete node setup

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -11,9 +11,6 @@ jobs:
       VFLAGS: -cc msvc
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Build
         run: |
           echo %VFLAGS%

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -168,9 +168,6 @@ jobs:
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -275,9 +272,6 @@ jobs:
       VFLAGS: -cc clang
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -382,9 +376,6 @@ jobs:
 #       V_CI_MUSL: 1
 #     steps:
 #     - uses: actions/checkout@v3
-#     - uses: actions/setup-node@v3
-#       with:
-#         node-version: 16
 #     - name: Install dependencies
 #       run: |
 #          sudo apt-get install --quiet -y musl musl-tools libssl-dev sqlite3 libsqlite3-dev valgrind

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -24,9 +24,6 @@ jobs:
       PKG_CONFIG_PATH: /usr/local/opt/pkgconfig:/usr/local/opt/libpq/lib/pkgconfig:/usr/local/opt/openssl@3/lib/pkgconfig:/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/libpq/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           echo "PKG_CONFIG_PATH is '$PKG_CONFIG_PATH'"

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -84,9 +84,6 @@ jobs:
       VTEST_SHOW_START: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -112,9 +109,6 @@ jobs:
       VTEST_SHOW_START: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt update
@@ -139,9 +133,6 @@ jobs:
       VTEST_SHOW_START: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt update
@@ -171,9 +162,6 @@ jobs:
       VTEST_SHOW_START: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Build
         run: |
           echo %VFLAGS%
@@ -203,9 +191,6 @@ jobs:
       VTEST_SHOW_START: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt update
@@ -235,9 +220,6 @@ jobs:
       VTEST_SHOW_START: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -24,9 +24,6 @@ jobs:
       VERBOSE_MAKE: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Build
         run: |
           gcc --version
@@ -89,9 +86,6 @@ jobs:
       VERBOSE_MAKE: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Build
         run: |
           echo %VFLAGS%
@@ -139,9 +133,6 @@ jobs:
       VERBOSE_MAKE: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Build with make.bat -tcc
         run: |
           .\make.bat -tcc


### PR DESCRIPTION
This PR suggestion includes a cleanup of CI runs. It removes an obsolete Node setup, since it became a default on Github-runners. 

Ref.: https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/#:~:text=The%20GitHub%20Blog-,GitHub%20Actions%3A%20GitHub%2Dhosted%20runners%20now%20run%20Node.,js%2016%20by%20default&text=In%20the%20latest%20update%20to,the%20default%20version%20of%20npm%20.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cdfbd6</samp>

This pull request removes the `setup-node` action from several GitHub workflows that do not use node.js. This simplifies the workflows and improves their performance.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1cdfbd6</samp>

* Remove unnecessary setup-node actions from all workflows ([link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-22ec448956849a92b29ee757943a6d9f51b5fbf9ae7cabbe309d2a5acc560ca4L14-L16), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-28752c3107c2643416798f1cca9a77ce5909e9cf98b4e4921ffce60e92b18d05L171-L173), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-28752c3107c2643416798f1cca9a77ce5909e9cf98b4e4921ffce60e92b18d05L277-L280), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-28752c3107c2643416798f1cca9a77ce5909e9cf98b4e4921ffce60e92b18d05L385-L387), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-0d0e3285f3847a9675e66e29e83eec87ffa82aa20b21000dc96db6c14b739bafL27-L29), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-c78cb59fa36318d82d895a969e44f65b9ec928cac8109601b9bde67a0c369479L87-L89), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-c78cb59fa36318d82d895a969e44f65b9ec928cac8109601b9bde67a0c369479L115-L117), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-c78cb59fa36318d82d895a969e44f65b9ec928cac8109601b9bde67a0c369479L142-L144), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-c78cb59fa36318d82d895a969e44f65b9ec928cac8109601b9bde67a0c369479L174-L176), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-c78cb59fa36318d82d895a969e44f65b9ec928cac8109601b9bde67a0c369479L206-L208), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-c78cb59fa36318d82d895a969e44f65b9ec928cac8109601b9bde67a0c369479L238-L240), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-51e29cc7ce6055cb886ed66ba289976529842254a5477e5edc392fa3de360b25L27-L29), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-51e29cc7ce6055cb886ed66ba289976529842254a5477e5edc392fa3de360b25L92-L94), [link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-51e29cc7ce6055cb886ed66ba289976529842254a5477e5edc392fa3de360b25L142-L144))
* ~~Simplify `linux_ci` workflow by removing redundant checkout and setup-node actions from `build_v` step ([link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-28752c3107c2643416798f1cca9a77ce5909e9cf98b4e4921ffce60e92b18d05L277-L280))~~
* Clean up commented out code from `linux_ci` workflow ([link](https://github.com/vlang/v/pull/18986/files?diff=unified&w=0#diff-28752c3107c2643416798f1cca9a77ce5909e9cf98b4e4921ffce60e92b18d05L385-L387))
