### PR TITLE
v.help: fix typos

### DIFF
--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -57,9 +57,9 @@ see also `v help build`.
       Use with `-freestanding`. This specifies the directory to the
       implementation of some basic builtin functions. The list is as follows:
          bare_print(buf &byte, len u64)
-            Print len charecters from the buffer pointed to by buf to stdout.
+            Print len characters from the buffer pointed to by buf to stdout.
          bare_eprint(buf &byte, len u64)
-            Print len charecters from the buffer pointed to by buf to stderr.
+            Print len characters from the buffer pointed to by buf to stderr.
          bare_panic(msg string)
             Print "V panic: " + msg, along with an optional backtrace and/or the V commit hash, and then exit.
          [export: 'malloc']

--- a/vlib/v/help/build/build-js.txt
+++ b/vlib/v/help/build/build-js.txt
@@ -27,7 +27,7 @@ For more general build help, see also `v help build`.
                            (currently default,
                            external source map files not implemented)
 
-   -sourcemap-src-include  Include the orginal V source files into the
+   -sourcemap-src-include  Include the original V source files into the
                            generated source map
    (default false, all files in the source map are currently referenced by
    their absolute system file path)

--- a/vlib/v/help/build/build-wasm.txt
+++ b/vlib/v/help/build/build-wasm.txt
@@ -15,7 +15,7 @@ For more general build help, see also `v help build`.
    -os <browser|wasi>, -target-os <browser|wasi>
       Change the target WebAssembly execution environment that V compiles for.
 
-      The `wasi` target is the default execution enviroment.
+      The `wasi` target is the default execution environment.
         When targeting WASI, the generated WebAssembly module can be run in a variety of environments that support the WASI specification.
         WASI provides a standardized interface to interact with the host operating system, allowing WebAssembly modules to perform tasks like file I/O, networking, and more.
         The specific version of the WASI specification targeted by V is 'wasi_snapshot_preview1'.

--- a/vlib/v/help/build/build.txt
+++ b/vlib/v/help/build/build.txt
@@ -161,7 +161,7 @@ NB: the build flags are shared with the run command too:
         ... will generate a TAGS file, that emacs can then use to jump
     to the definition of functions used by v itself. For vim:
       ./v -print-v-files cmd/v | ctags -L -
-        ... will generate a simillar tags file, that vi compatible editors can use.
+        ... will generate a similar tags file, that vi compatible editors can use.
     NB: an useful, although not entirely accurate regexp based Universal Ctags options file
       for V is located in `.ctags.d/v.ctags` . If you use https://ctags.io/ , it will be used
       up automatically, or you can specify it explicitly with --options=.ctags.d/v.ctags .

--- a/vlib/v/help/common/watch.txt
+++ b/vlib/v/help/common/watch.txt
@@ -36,5 +36,5 @@ Options:
                          Example: --after 'rm -rf /tmp/v/'
 
 You can also customise the timeout, after `v watch` will re-start a monitored
-program automatically, even if it was not changed by setting the enviroment
+program automatically, even if it was not changed by setting the environment
 variable VWATCH_TIMEOUT (in seconds). By default, it is 5 min. (300 seconds).

--- a/vlib/v/help/other/bug.txt
+++ b/vlib/v/help/other/bug.txt
@@ -5,4 +5,4 @@ Usage:
 
 Options:
   -v  Enable verbosity while gathering various information
-  -y  Force the submission of the issue, even if an error occured
+  -y  Force the submission of the issue, even if an error occurred

--- a/vlib/v/help/other/other.txt
+++ b/vlib/v/help/other/other.txt
@@ -40,6 +40,6 @@ Other less frequently used commands supported by V include:
                    Mainly useful as a parser bug finder for the V Language Server project.
 
   test-self        Test if V is working properly by running all tests, including the compiler ones.
-                   NB: this can 1-2 minutes to run.
+                   NB: this can take 1-2 minutes to run.
 
   wipe-cache       Remove the V cache folder. Useful for cleaning the cache, and guaranteeing a clean build.


### PR DESCRIPTION


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a66361</samp>

This pull request fixes several typos and improves the readability of the documentation files for various `v` commands and backends. It affects the files `build-c.txt`, `build-wasm.txt`, `build.txt`, `build-js.txt`, `watch.txt`, `bug.txt`, and `other.txt` in the `vlib/v/help` directory.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a66361</samp>

* Fix typos in the documentation of various options and commands for the V compiler ([link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-ef676953c6088198ce5fd76325ccfb00ed05b1d43529262402d17c74bdcdfca6L60-R62), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-d61d7394ef4db2e6b21608eb62a2d2784c666419b2344979cf0b2e41451678b1L30-R34), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-eea1c2f8af79cdbe161485e54e17edfac9b347818077ea22f09312f601d0e48eL18-R18), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-2071dce05db2b57b27362bb1b18079010f8b6db790f90828e32d303c7b18e0f1L164-R164), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-0f581ae9c221258f2649f32483018b44f7909f2b983aec7d8e4b66f5b8cb7babL39-R39), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-8281c79b048f7b771dedb8bee3e1001b302f086d07bfae280c831e4012e06397L8-L7))
* Add missing words and punctuation in the documentation of the stack size option for the C backend, the browser target for the WASM backend, and the test-self command for the V compiler ([link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-ef676953c6088198ce5fd76325ccfb00ed05b1d43529262402d17c74bdcdfca6L312-L311), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-eea1c2f8af79cdbe161485e54e17edfac9b347818077ea22f09312f601d0e48eL25-L24), [link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-fcf3d7de2a9bb0b172981a1b939ff847fc201f6e85a2c7658966af23fabc49d7L43-L42))
* Add missing blank line before the "See also" section in the documentation of the build command for the V compiler ([link](https://github.com/vlang/v/pull/18987/files?diff=unified&w=0#diff-2071dce05db2b57b27362bb1b18079010f8b6db790f90828e32d303c7b18e0f1L216-L215))
