### PR TITLE
parser, fmt: fix formatting interface fields with pre-comments (fix #18980)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1292,11 +1292,13 @@ pub fn (mut f Fmt) interface_field(field ast.StructField) {
 	ft := f.no_cur_mod(f.table.type_to_str_using_aliases(field.typ, f.mod2alias))
 	end_pos := field.pos.pos + field.pos.len
 	before_comments := field.comments.filter(it.pos.pos < field.pos.pos)
-	between_comments := field.comments[before_comments.len..].filter(it.pos.pos < end_pos)
-	after_type_comments := field.comments[(before_comments.len + between_comments.len)..]
+	end_comments := field.comments.filter(it.pos.pos > field.pos.pos)
+	if before_comments.len > 0 {
+		f.comments(before_comments, level: .indent)
+	}
 	f.write('\t${field.name} ${ft}')
-	if after_type_comments.len > 0 {
-		f.comments(after_type_comments, level: .indent)
+	if end_comments.len > 0 {
+		f.comments(end_comments, level: .indent)
 	} else {
 		f.writeln('')
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1290,7 +1290,6 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 
 pub fn (mut f Fmt) interface_field(field ast.StructField) {
 	ft := f.no_cur_mod(f.table.type_to_str_using_aliases(field.typ, f.mod2alias))
-	end_pos := field.pos.pos + field.pos.len
 	before_comments := field.comments.filter(it.pos.pos < field.pos.pos)
 	end_comments := field.comments.filter(it.pos.pos > field.pos.pos)
 	if before_comments.len > 0 {

--- a/vlib/v/fmt/tests/interface_fields_with_pre_comments_keep.vv
+++ b/vlib/v/fmt/tests/interface_fields_with_pre_comments_keep.vv
@@ -1,0 +1,14 @@
+module main
+
+fn main() {
+}
+
+pub interface IOperateInfo {
+mut:
+	// title
+	title string
+	// msg
+	msg string
+	// id
+	id string
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -702,18 +702,13 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			info.methods << tmethod
 		} else {
 			// interface fields
+			mut comments := p.eat_comments()
 			field_pos := p.tok.pos()
 			field_name := p.check_name()
 			mut type_pos := p.tok.pos()
 			field_typ := p.parse_type()
 			type_pos = type_pos.extend(p.prev_tok.pos())
-			mut comments := []ast.Comment{}
-			for p.tok.kind == .comment {
-				comments << p.comment()
-				if p.tok.kind == .rcbr {
-					break
-				}
-			}
+			comments << p.eat_comments(same_line: true)
 			fields << ast.StructField{
 				name: field_name
 				pos: field_pos


### PR DESCRIPTION
This PR fix formatting interface fields with pre-comments (fix #18980, fix #18981).

- Fix formatting interface fields with pre-comments.
- Add test.

vlib\v\fmt\tests\interface_fields_with_pre_comments_keep.vv
```v
module main

fn main() {
}

pub interface IOperateInfo {
mut:
	// title
	title string
	// msg
	msg string
	// id
	id string
}
```