### PR TITLE
picoev: bugfixes and UB mitigation

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -149,14 +149,19 @@ fn (mut pv Picoev) set_timeout(fd int, secs int) {
 // timeout event
 [direct_array_access; inline]
 fn (mut pv Picoev) handle_timeout() {
+	mut to_remove := []int{}
+
 	for fd, timeout in pv.timeouts {
 		if timeout <= pv.loop.now {
-			target := pv.file_descriptors[fd]
-			assert target.loop_id == pv.loop.id
-
-			pv.timeouts.delete(fd)
-			unsafe { target.cb(fd, picoev.picoev_timeout, &pv) }
+			to_remove << fd
 		}
+	}
+
+	for fd in to_remove {
+		target := pv.file_descriptors[fd]
+		assert target.loop_id == pv.loop.id
+		pv.timeouts.delete(fd)
+		unsafe { target.cb(fd, picoev.picoev_timeout, &pv) }
 	}
 }
 

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -106,8 +106,6 @@ fn (mut pv Picoev) del(fd int) int {
 	}
 
 	if pv.update_events(fd, picoev.picoev_del) != 0 {
-		target.loop_id = -1
-		target.fd = 0
 		return -1
 	}
 


### PR DESCRIPTION
Applying fix suggestions from @Casper64. Small changes, they're self explanatory.

Ignore the last message from Copilot, it's generating junk.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2193444</samp>

This pull request improves the picoev library by fixing a bug with event reuse and optimizing timeout handling. It changes how the `picoev.v` file resets and iterates over some fields and data structures.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2193444</samp>

* Fix a bug that caused event targets to be reused after being closed by a timeout callback ([link](https://github.com/vlang/v/pull/18991/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL109-L110)). This bug was reported in issue #11276 and could lead to unexpected behavior and crashes.
