### PR TITLE
ast, parser, fmt: fix formatting struct declaration with comments (fix #18982)

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5339,8 +5339,8 @@ module abc
 pub struct Xyz {
 pub mut:
 	a int
-	// the tags will produce a notice, since the deprecation date is in the far future
 	d int [deprecated: 'use Xyz.a instead'; deprecated_after: '2999-03-01']
+	// the tags above, will produce a notice, since the deprecation date is in the far future
 }
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5339,8 +5339,8 @@ module abc
 pub struct Xyz {
 pub mut:
 	a int
+	// the tags will produce a notice, since the deprecation date is in the far future
 	d int [deprecated: 'use Xyz.a instead'; deprecated_after: '2999-03-01']
-	// the tags above, will produce a notice, since the deprecation date is in the far future
 }
 ```
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -381,6 +381,7 @@ pub:
 	language     Language
 	is_union     bool
 	attrs        []Attr
+	pre_comments []Comment
 	end_comments []Comment
 	embeds       []Embed
 pub mut:

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -60,6 +60,9 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 		}
 	}
 	f.writeln(' {')
+	if node.pre_comments.len > 0 {
+		f.comments_before_field(node.pre_comments)
+	}
 	for embed in node.embeds {
 		f.mark_types_import_as_used(embed.typ)
 		styp := f.table.type_to_str_using_aliases(embed.typ, f.mod2alias)
@@ -188,11 +191,13 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 			f.writeln('')
 		}
 	}
-	f.comments_after_last_field(node.end_comments)
-	if is_anon {
+	if is_anon || node.end_comments.len > 0 {
 		f.write('}')
 	} else {
-		f.writeln('}\n')
+		f.writeln('}')
+	}
+	if node.end_comments.len > 0 {
+		f.comments(node.end_comments, inline: true)
 	}
 }
 

--- a/vlib/v/fmt/tests/struct_decl_with_comments_keep.vv
+++ b/vlib/v/fmt/tests/struct_decl_with_comments_keep.vv
@@ -1,0 +1,13 @@
+module main
+
+fn main() {
+}
+
+pub struct OperateInfo { // implements IperateInfo
+pub mut:
+	title string // title
+	// msg
+	msg string
+	// id
+	id string
+} // operate info

--- a/vlib/v/fmt/tests/structs_expected.vv
+++ b/vlib/v/fmt/tests/structs_expected.vv
@@ -37,8 +37,8 @@ fn new_user() User {
 }
 
 struct SomeStruct {
-mut:
 	// 1
+mut:
 	// 2
 	// 3
 	somefield /* 4 */ /* 5 */ int // 6

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -267,7 +267,6 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				}
 			}
 			// Comments after type (same line)
-			comments << p.eat_comments()
 			prev_attrs := p.attrs
 			p.attrs = []
 			if p.tok.kind == .lsbr {
@@ -281,6 +280,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				}
 				p.inside_struct_attr_decl = false
 			}
+			comments << p.eat_comments()
 			mut default_expr := ast.empty_expr
 			mut has_default_expr := false
 			if !is_embed {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -105,9 +105,11 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	mut is_field_pub := false
 	mut is_field_global := false
 	mut last_line := p.prev_tok.pos().line_nr + 1
+	mut pre_comments := []ast.Comment{}
 	mut end_comments := []ast.Comment{}
 	if !no_body {
 		p.check(.lcbr)
+		pre_comments = p.eat_comments()
 		mut i := 0
 		for p.tok.kind != .rcbr {
 			mut comments := []ast.Comment{}
@@ -118,7 +120,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				}
 			}
 			if p.tok.kind == .rcbr {
-				end_comments = comments.clone()
+				end_comments = p.eat_comments(same_line: true)
 				break
 			}
 			if p.tok.kind == .key_pub {
@@ -338,6 +340,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 		p.top_level_statement_end()
 		last_line = p.tok.line_nr
 		p.check(.rcbr)
+		end_comments = p.eat_comments(same_line: true)
 	}
 	is_minify := attrs.contains('minify')
 	mut sym := ast.TypeSymbol{
@@ -388,6 +391,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 		language: language
 		is_union: is_union
 		attrs: if is_anon { []ast.Attr{} } else { attrs } // anon structs can't have attributes
+		pre_comments: pre_comments
 		end_comments: end_comments
 		generic_types: generic_types
 		embeds: embeds


### PR DESCRIPTION
This PR fix formatting struct declaration with comments (fix #18982).

- Fix formatting struct declaration with comments.
- Add test.

vlib\v\fmt\tests\struct_decl_with_comments_keep.vv
```v
module main

fn main() {
}

pub struct OperateInfo { // implements IperateInfo
pub mut:
	title string // title
	// msg
	msg string
	// id
	id string
} // operate info
```