### PR TITLE
checker: fix compiler panic for passing an extra decompose parameter to a function (fix: 18995)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2304,7 +2304,7 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 		has_decompose := node.args.filter(it.expr is ast.ArrayDecompose).len > 0
 		if has_decompose {
 			// if call(...args) is present
-			min_required_params = nr_args
+			min_required_params = nr_args - 1
 		}
 	}
 	if min_required_params < 0 {

--- a/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err_c.out
+++ b/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err_c.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err_c.vv:2:6: error: expected 0 arguments, but got 1
+    1 | fn main() {
+    2 |     foo(...args)
+      |         ~~~~~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err_c.vv
+++ b/vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err_c.vv
@@ -1,0 +1,6 @@
+fn main() {
+	foo(...args)
+}
+
+fn foo() {
+}


### PR DESCRIPTION
Fixed: #18995 

```v
fn main() {
	foo(...args)
}

fn foo() {
}
```

```
vlib/v/checker/tests/fn_array_decompose_arg_mismatch_err_c.vv:2:6: error: expected 0 arguments, but got 1
    1 | fn main() {
    2 |     foo(...args)
      |         ~~~~~~~
    3 | }
    4 |
```
