### PR TITLE
parser, fmt: fix formatting interface method with pre-comments (related #18980)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1305,9 +1305,14 @@ pub fn (mut f Fmt) interface_field(field ast.StructField) {
 }
 
 pub fn (mut f Fmt) interface_method(method ast.FnDecl) {
+	before_comments := method.comments.filter(it.pos.pos < method.pos.pos)
+	end_comments := method.comments.filter(it.pos.pos > method.pos.pos)
+	if before_comments.len > 0 {
+		f.comments(before_comments, level: .indent)
+	}
 	f.write('\t')
 	f.write(method.stringify_fn_decl(f.table, f.cur_mod, f.mod2alias).all_after_first('fn '))
-	f.comments(method.comments, inline: true, has_nl: false, level: .indent)
+	f.comments(end_comments, inline: true, has_nl: false, level: .indent)
 	f.writeln('')
 	f.comments(method.next_comments, inline: false, has_nl: true, level: .indent)
 	for param in method.params {

--- a/vlib/v/fmt/tests/interface_method_with_pre_comments_keep.vv
+++ b/vlib/v/fmt/tests/interface_method_with_pre_comments_keep.vv
@@ -1,0 +1,16 @@
+module main
+
+fn main() {
+}
+
+pub interface IOperateResult {
+mut:
+	// is_success
+	is_success bool
+	// is_show_msg
+	is_show_msg bool
+	// msg
+	msg string
+	// comment before method def
+	set_msg(msg string) // comment after method def
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -646,6 +646,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				p.peek_tok.pos())
 			return ast.InterfaceDecl{}
 		}
+		mut comments := p.eat_comments()
 		if p.peek_tok.kind == .lpar {
 			method_start_pos := p.tok.pos()
 			line_nr := p.tok.line_nr
@@ -687,9 +688,9 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				method.return_type_pos = method.return_type_pos.extend(p.tok.pos())
 				method.pos = method.pos.extend(method.return_type_pos)
 			}
-			mcomments := p.eat_comments(same_line: true)
+			comments << p.eat_comments(same_line: true)
 			mnext_comments := p.eat_comments()
-			method.comments = mcomments
+			method.comments = comments
 			method.next_comments = mnext_comments
 			methods << method
 			tmethod := ast.Fn{
@@ -706,7 +707,6 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			info.methods << tmethod
 		} else {
 			// interface fields
-			mut comments := p.eat_comments()
 			field_pos := p.tok.pos()
 			field_name := p.check_name()
 			mut type_pos := p.tok.pos()


### PR DESCRIPTION
This PR fix formatting interface method with pre-comments (related #18980).

- Fix formatting interface method with pre-comments.
- Add test.

vlib\v\fmt\tests\interface_method_with_pre_comments_keep.vv
```v
module main

fn main() {
}

pub interface IOperateResult {
mut:
	// is_success
	is_success bool
	// is_show_msg
	is_show_msg bool
	// msg
	msg string
	// comment before method def
	set_msg(msg string) // comment after method def
}
```