### PR TITLE
tools.vdoc: include project root when searching for readme of `src/`

### DIFF
--- a/cmd/tools/vdoc/tests/testdata/readme_in_project_root/README.md
+++ b/cmd/tools/vdoc/tests/testdata/readme_in_project_root/README.md
@@ -1,0 +1,1 @@
+hello from readme

--- a/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.comments.out
@@ -1,0 +1,3 @@
+module foo
+
+fn bar()

--- a/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.readme.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.readme.comments.out
@@ -1,0 +1,4 @@
+hello from readme
+module foo
+
+fn bar()

--- a/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.v
+++ b/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.v
@@ -1,0 +1,3 @@
+module foo
+
+pub fn bar() {}

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -52,6 +52,11 @@ fn check_path(vexe string, dir string, tests []string) int {
 			cmd: '${os.quoted_path(vexe)} doc -comments ${os.quoted_path(program)}'
 			out_filename: 'main.comments.out'
 		)
+		fails += check_output(
+			program: program
+			cmd: '${os.quoted_path(vexe)} doc -readme -comments ${os.quoted_path(program)}'
+			out_filename: 'main.readme.comments.out'
+		)
 		total_fails += fails
 		if fails == 0 {
 			println(term.green('OK'))

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -233,6 +233,9 @@ fn (vd VDoc) get_readme(path string) string {
 		}
 	}
 	if fname == '' {
+		if path == './src' {
+			return vd.get_readme('.')
+		}
 		return ''
 	}
 	readme_path := os.join_path(path, '${fname}.md')

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -233,8 +233,8 @@ fn (vd VDoc) get_readme(path string) string {
 		}
 	}
 	if fname == '' {
-		if path == './src' {
-			return vd.get_readme('.')
+		if path.all_after_last(os.path_separator) == 'src' {
+			return vd.get_readme(path.all_before_last(os.path_separator))
 		}
 		return ''
 	}


### PR DESCRIPTION
This PR does:
If the `src/` directory doesn't have a `README.md` it will make `v doc` check for and use the `README.md` in a projects root directory for the `src/` directory.

To add some more context: When creating a v project with `v new` thats the default project structure:
```
├── src
│   └── main.v
└── v.mod
```

Extending it to this is a common pattern:
```
├── src
│   └── main.v
├── LICENSE
├── README.md
└── v.mod
```

When using vdoc to generate documentation for the example above, it currently won't include the README.md in the generated documentation. It would have to be placed in the `src/` dir to be included. 

This is also my current personal use case. To solve it, I would now write a script for the doc generation. It would copy things into the required file structure (with README.md in `./src`) then run the `v doc -m -f html` command and clean things up. 

But I think we can consider to support such a default structure out of the box.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ea0782</samp>

Fix `v doc ./src` command to show README.md instead of module documentation. Handle the special case of './src' path argument in `vdoc.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ea0782</samp>

* Fix `v doc ./src` error by returning README.md if path is './src' ([link](https://github.com/vlang/v/pull/19000/files?diff=unified&w=0#diff-03bd8fff4fb425549163bcbb5f6dba4874b83d5fd8b7993915e040975800d24cR236-R238))
