### PR TITLE
tools.vdoc: support toc for projects with single exposing module

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -261,7 +261,7 @@ fn (vd VDoc) gen_html(d doc.Doc) string {
 	} else {
 		symbols_toc_str
 	}).replace('{{ contents }}', contents.str()).replace('{{ right_content }}', if cfg.is_multi
-		&& vd.docs.len > 1 && d.head.name != 'README' {
+		&& d.head.name != 'README' {
 		'<div class="doc-toc"><ul>' + symbols_toc_str + '</ul></div>'
 	} else {
 		''


### PR DESCRIPTION
This extends the support for table of contents generation of `v doc`:

E.g. use-case: Create a file structure like:
```
my_lib
└── lib.v
```

```v
// lib.v
module my_lib

pub struct MyStruct {}

pub type MyType = voidptr

pub fn my_fn() {}

pub fn (t MyType) my_fn() {}
```

Generate the docs `v doc -m -f html ./my_lib`, and open `my_lib/_docs/my_lib.html`.
On the right side, there will be no toc for the module. With the PR a toc will be generated.

It's probably rather the module list in the sidebar on the left that becomes less necessary with a single module. But the sidebar contains other things so it shouldn't be omitted either.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba67f5a</samp>

Fix a bug in `vdoc` that prevents the right sidebar from showing up for single-file modules. Simplify the condition for displaying the symbols table of contents in `html.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba67f5a</samp>

* Fix a bug where the right sidebar would not show up for single-file modules that are not named README in the HTML documentation ([link](https://github.com/vlang/v/pull/19001/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L264-R264))
