### PR TITLE
parser: fix for_c_stmt that init with var assign (fix #18999)

### DIFF
--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -31,8 +31,9 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		p.close_scope()
 		return for_stmt
 	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon]
-		|| p.tok.kind == .semicolon || (p.peek_tok.kind == .comma
-		&& p.peek_token(2).kind != .key_mut && p.peek_token(3).kind != .key_in) {
+		|| p.peek_tok.kind.is_assign() || p.tok.kind == .semicolon
+		|| (p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
+		&& p.peek_token(3).kind != .key_in) {
 		// `for i := 0; i < 10; i++ {` or `for a,b := 0,1; a < 10; a++ {`
 		if p.tok.kind == .key_mut {
 			return p.error('`mut` is not needed in `for ;;` loops: use `for i := 0; i < n; i ++ {`')
@@ -45,7 +46,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		mut has_inc := false
 		mut is_multi := p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
 			&& p.peek_token(3).kind != .key_in
-		if p.peek_tok.kind in [.assign, .decl_assign] || is_multi {
+		if p.peek_tok.kind in [.assign, .decl_assign] || p.peek_tok.kind.is_assign() || is_multi {
 			init = p.assign_stmt()
 			has_init = true
 		}

--- a/vlib/v/tests/for_c_init_with_var_assign_test.v
+++ b/vlib/v/tests/for_c_init_with_var_assign_test.v
@@ -1,0 +1,9 @@
+fn test_for_c_init_with_var_assign() {
+	mut v := 4
+	mut r := 0
+	for v >>= 1; v != 0; v >>= 1 {
+		r++
+	}
+	println(r)
+	assert r == 2
+}


### PR DESCRIPTION
This PR fix for_c_stmt that init with var assign (fix #18999).

- Fix for_c_stmt that init with var assign.
- Add test.

```v
fn main() {
	mut v := 4
	mut r := 0
	for v >>= 1; v != 0; v >>= 1 {
		r++
	}
	println(r)
	assert r == 2
}

PS D:\Test\v\tt1> v run .
2
```