### PR TITLE
builtin: fix split_nth() and rsplit_nth() on an empty delimeter

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -865,7 +865,7 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 			i = 1
 			for ch in s {
 				if nth > 0 && i >= nth {
-					res << s[i..]
+					res << s[i-1..]
 					break
 				}
 				res << ch.ascii_str()
@@ -938,7 +938,7 @@ pub fn (s string) rsplit_nth(delim string, nth int) []string {
 		0 {
 			for i >= 0 {
 				if nth > 0 && res.len == nth - 1 {
-					res << s[..i]
+					res << s[..i+1]
 					break
 				}
 				res << s[i].ascii_str()

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -865,7 +865,7 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 			i = 1
 			for ch in s {
 				if nth > 0 && i >= nth {
-					res << s[i-1..]
+					res << s[i - 1..]
 					break
 				}
 				res << ch.ascii_str()
@@ -938,7 +938,7 @@ pub fn (s string) rsplit_nth(delim string, nth int) []string {
 		0 {
 			for i >= 0 {
 				if nth > 0 && res.len == nth - 1 {
-					res << s[..i+1]
+					res << s[..i + 1]
 					break
 				}
 				res << s[i].ascii_str()

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -188,9 +188,9 @@ fn test_split_nth() {
 	assert f.rsplit_nth(':', 2) == ['3', '1:2']
 	g := '123'
 	assert g.split_nth('', 2) == ['1', '23']
-	assert g.rsplit_nth('', 2)    == ['3', '12']
+	assert g.rsplit_nth('', 2) == ['3', '12']
 	h := ''
-	assert h.split_nth('', 2)  == []
+	assert h.split_nth('', 2) == []
 	assert h.rsplit_nth('', 2) == []
 }
 

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -183,6 +183,15 @@ fn test_split_nth() {
 	assert e.split_nth(',,', 3).len == 3
 	assert e.split_nth(',', -1).len == 12
 	assert e.split_nth(',', 3).len == 3
+	f := '1:2:3'
+	assert f.split_nth(':', 2) == ['1', '2:3']
+	assert f.rsplit_nth(':', 2) == ['3', '1:2']
+	g := '123'
+	assert g.split_nth('', 2) == ['1', '23']
+	assert g.rsplit_nth('', 2)    == ['3', '12']
+	h := ''
+	assert h.split_nth('', 2)  == []
+	assert h.rsplit_nth('', 2) == []
 }
 
 fn test_rsplit_nth() {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

### Test:
```v
module man

fn main() {
	assert '1:2:3'.split_nth(':', 2) == ['1', '2:3']
	assert '123'.split_nth('', 2)    == ['1', '23']

	assert '1:2:3'.rsplit_nth(':', 2) == ['3', '1:2']
	assert '123'.rsplit_nth('', 2)    == ['3', '12']

	assert ''.split_nth('', 2)  == []
	assert ''.rsplit_nth('', 2) == []

	println('success')
}
```

Fix bugs in `string.split_nth` and `string.rsplit_nth` with empty delimiters. Preserve the delimiter characters in the output substrings. (#18997)

