### PR TITLE
parser: disallow declaring static functions as method receivers

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -292,7 +292,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	}
 	mut name := ''
 	mut type_sym := p.table.sym(rec.typ)
-	name_pos := p.tok.pos()
+	mut name_pos := p.tok.pos()
 	if p.tok.kind == .name {
 		mut check_name := ''
 		// TODO high order fn
@@ -304,6 +304,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			p.check(.dot)
 			check_name = p.check_name()
 			name = type_name + '__static__' + check_name // "foo__bar"
+			name_pos = name_pos.extend(p.prev_tok.pos())
 		} else {
 			check_name = if language == .js { p.check_js_name() } else { p.check_name() }
 			name = check_name
@@ -451,6 +452,9 @@ run them via `v file.v` instead',
 					name_pos)
 			}
 		}
+	}
+	if is_method && is_static_type_method {
+		p.error_with_pos('cannot declare a static function as a receiver method', name_pos)
 	}
 	// Register
 	if is_method {

--- a/vlib/v/parser/tests/declare_static_fn_as_receiver_method_err.out
+++ b/vlib/v/parser/tests/declare_static_fn_as_receiver_method_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/declare_static_fn_as_receiver_method_err.vv:4:12: error: cannot declare a static function as a receiver method
+    2 | }
+    3 | 
+    4 | fn (y Foo) Foo.new() Foo {
+      |            ~~~~~~~
+    5 |     return Foo{}
+    6 | }

--- a/vlib/v/parser/tests/declare_static_fn_as_receiver_method_err.vv
+++ b/vlib/v/parser/tests/declare_static_fn_as_receiver_method_err.vv
@@ -1,0 +1,11 @@
+struct Foo {
+}
+
+fn (y Foo) Foo.new() Foo {
+	return Foo{}
+}
+
+fn main() {
+	x := Foo{}.new()
+	println(x)
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18959

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 666db30</samp>

This pull request fixes a parser bug that allowed `static` functions to be declared as receiver methods, which is not allowed in V. It also adds a test case for this error in `vlib/v/parser/tests`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 666db30</samp>

*  Declare and update `name_pos` variable to track the position of the function name in `parse_fn_decl` ([link](https://github.com/vlang/v/pull/19007/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL295-R295), [link](https://github.com/vlang/v/pull/19007/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eR307))
*  Add error check for declaring a static function as a receiver method in `parse_fn_decl` and report the `name_pos` as the error location ([link](https://github.com/vlang/v/pull/19007/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eR456-R458))
*  Add test file `declare_static_fn_as_receiver_method_err.vv` with an invalid function declaration and a main function ([link](https://github.com/vlang/v/pull/19007/files?diff=unified&w=0#diff-24feb3cb9b469b2e98f3cc818ea8f79143456cffec7cb27bed00523ae9dfed7dR1-R11))
*  Add test file `declare_static_fn_as_receiver_method_err.out` with the expected error output ([link](https://github.com/vlang/v/pull/19007/files?diff=unified&w=0#diff-f3beaa8515451d443cee77aca4fec725794934916cb5fcd4337be2e5135da314R1-R7))
