### PR TITLE
net.websocket: remove unnecessary free of static string

### DIFF
--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -150,9 +150,7 @@ pub fn (mut ws Client) listen() ! {
 		ws.debug_log('got message: ${msg.opcode}')
 		match msg.opcode {
 			.text_frame {
-				log_msg = 'read: text'
-				ws.debug_log(log_msg)
-				unsafe { log_msg.free() }
+				ws.debug_log('read: text')
 				ws.send_message_event(msg)
 				unsafe { msg.free() }
 			}
@@ -184,9 +182,7 @@ pub fn (mut ws Client) listen() ! {
 				}
 			}
 			.close {
-				log_msg = 'read: close'
-				ws.debug_log(log_msg)
-				unsafe { log_msg.free() }
+				ws.debug_log('read: close')
 				defer {
 					ws.manage_clean_close()
 				}


### PR DESCRIPTION
I find it odd that what look like statically allocated strings are being freed.  These code changes make the debug message handling of the .text_frame and .close cases match the way debug messages are done in the other cases of this match statement.

I am not sure if the freeing of the log_msg string on line 131 is appropriate as it is generated at run time due to the interpolation of ws.is_server into the string.  I am still new to v and I don't have a good mental model of how memory is handled in this situation.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41bc198</samp>

Optimize `websocket_client` module for memory and logging. Reduce string allocations and improve debug messages in `vlib/net/websocket/websocket_client.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41bc198</samp>

*  Eliminate unnecessary memory allocation and freeing of `log_msg` variable in `vlib/net/websocket/websocket_client.v` ([link](https://github.com/vlang/v/pull/19009/files?diff=unified&w=0#diff-ef727f3d4a51e0d66848c62505e7bc2e00b651a5e8681c329da842048813dd4fL153-R153), [link](https://github.com/vlang/v/pull/19009/files?diff=unified&w=0#diff-ef727f3d4a51e0d66848c62505e7bc2e00b651a5e8681c329da842048813dd4fL187-R185))
