### PR TITLE
gg: Android specific asset load in `create_image` function

### DIFF
--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -26,58 +26,59 @@ pub mut:
 
 // create_image creates an `Image` from `file`.
 pub fn (mut ctx Context) create_image(file string) !Image {
-	$if android {
-		image_data := os.read_apk_asset(file)!
-		mut image := ctx.create_image_from_byte_array(image_data)!
+	if !os.exists(file) {
+		$if android {
+			image_data := os.read_apk_asset(file)!
+			mut image := ctx.create_image_from_byte_array(image_data)!
 
-		image.path = file
+			image.path = file
 
-		return image
-	} $else {
-		if !os.exists(file) {
+			return image
+		} $else {
 			return error('image file "${file}" not found')
 		}
+	}
 
-		$if macos {
-			if ctx.native_rendering {
-				// return C.darwin_create_image(file)
-				mut img := C.darwin_create_image(file)
-				// println('created macos image: $img.path w=$img.width')
-				// C.printf('p = %p\n', img.data)
-				img.id = ctx.image_cache.len
-				unsafe {
-					ctx.image_cache << img
-				}
-				return img
-			}
-		}
+	$if macos {
+		if ctx.native_rendering {
+			// return C.darwin_create_image(file)
+			mut img := C.darwin_create_image(file)
 
-		if !gfx.is_valid() {
-			// Sokol is not initialized yet, add stbi object to a queue/cache
-			// ctx.image_queue << file
-			stb_img := stbi.load(file)!
-			img := Image{
-				width: stb_img.width
-				height: stb_img.height
-				nr_channels: stb_img.nr_channels
-				ok: false
-				data: stb_img.data
-				ext: stb_img.ext
-				path: file
-				id: ctx.image_cache.len
-			}
+			// println('created macos image: $img.path w=$img.width')
+			// C.printf('p = %p\n', img.data)
+			img.id = ctx.image_cache.len
 			unsafe {
 				ctx.image_cache << img
 			}
 			return img
 		}
-		mut img := create_image(file)
-		img.id = ctx.image_cache.len
+	}
+
+	if !gfx.is_valid() {
+		// Sokol is not initialized yet, add stbi object to a queue/cache
+		// ctx.image_queue << file
+		stb_img := stbi.load(file)!
+		img := Image{
+			width: stb_img.width
+			height: stb_img.height
+			nr_channels: stb_img.nr_channels
+			ok: false
+			data: stb_img.data
+			ext: stb_img.ext
+			path: file
+			id: ctx.image_cache.len
+		}
 		unsafe {
 			ctx.image_cache << img
 		}
 		return img
 	}
+	mut img := create_image(file)
+	img.id = ctx.image_cache.len
+	unsafe {
+		ctx.image_cache << img
+	}
+	return img
 }
 
 // init_sokol_image initializes this `Image` for use with the


### PR DESCRIPTION
Before, loading an image on Android must be handled separately from the `create_image` function, and the created image doesn't contain a `path` value.

This PR unifies the `create_image` function to automatically handle the loading of images on Android (with the same code that was used manually) and implements setup of `path` value for images loaded on Android.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0bca41</samp>

This pull request improves the image loading functionality of the `gg` module for android platforms. It adds support for reading images from apk assets using the `android_asset` prefix, and streamlines the logic for initializing the Sokol backend in `vlib/gg/image.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0bca41</samp>

*  Add support for loading images from apk assets on android ([link](https://github.com/vlang/v/pull/19015/files?diff=unified&w=0#diff-f21f6656c2db38887c087f60a867a24de8bf28fda97ad295a07fd18eecfbdefbL28-R68))
* Refactor the code for handling Sokol initialization ([link](https://github.com/vlang/v/pull/19015/files?diff=unified&w=0#diff-f21f6656c2db38887c087f60a867a24de8bf28fda97ad295a07fd18eecfbdefbL45-R75), [link](https://github.com/vlang/v/pull/19015/files?diff=unified&w=0#diff-f21f6656c2db38887c087f60a867a24de8bf28fda97ad295a07fd18eecfbdefbL65-L70))
