### PR TITLE
vdoc: fix invisible scrollspy and initial keyboard navigability

### DIFF
--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -98,7 +98,6 @@ body {
   height: 100%;
   padding-top: 56px;
   box-sizing: border-box;
-  overflow: hidden;
 }
 
 /** Reset for menus */
@@ -349,7 +348,6 @@ body {
 /* Main content */
 .doc-scrollview {
   height: 100%;
-  overflow-y: scroll;
 }
 .doc-container {
   display: flex;
@@ -649,8 +647,6 @@ pre {
     position: -webkit-sticky;
     align-self: flex-start;
     top: 56px;
-    height: auto;
-    height: 100vh;
     min-width: 200px;
     width: auto;
     max-width: 300px;


### PR DESCRIPTION
This PR add some simple style changes to fix the scrollspy(in the toc on the right of vdoc sites) being invisible and not scrolling with the content.

During testing I've also noticed that vdoc sites are currently not initially accessible for keyboard navigation keys like arrows, page up, page down etc. by default. The content would have to be clicked once. When using e.g. vimium there is no issue. But testing it without extension initial keyboard movements didn't work in chromium based and firefox browsers.

Below a quick snippet - first showing the problems then the behavior with the changes.

https://github.com/vlang/v/assets/34311583/037bdce9-ee90-471e-9fec-c9c3f66b6424

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

copilot:summary

copilot:walkthrough
