### PR TITLE
vdoc: fix toc height

### DIFF
--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -644,6 +644,7 @@ pre {
     position: relative;
     /* IE11 */
     position: sticky;
+    height: 100vh;
     position: -webkit-sticky;
     align-self: flex-start;
     top: 56px;


### PR DESCRIPTION
This hunk went into the last commit. I didn't had this change locally so I don't know how I accomplished this. Only the redundant height should have been removed.

```diff
- height: auto;
- height: 100vh;
```
should be
```diff
- height: auto;
height: 100vh;
```

The fix can be tested re-adding the property to the `<div class="doc-toc">` element on https://modules.vlang.io/ in the browsers DevTools.

Sorry for the noise on this one.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae08d32</samp>

Fix sidebar overflow and improve responsiveness of vdoc theme. Change the height of `.doc-container` in `cmd/tools/vdoc/theme/doc.css` and make other layout adjustments.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae08d32</samp>

* Fix sidebar overflow bug by setting `.doc-container` height to 100% of viewport height ([link](https://github.com/vlang/v/pull/19023/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cR647))
