### PR TITLE
github: update issue template presets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Report a bug
 title: (bug report summary)
-labels: Bug
+labels: [Bug]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: 🐛 Bug Report
 description: Report a bug
-title: (bug report summary)
 labels: [Bug]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: 🚀 Feature Request
 description: Suggest an idea for this project
-title: (feature request summary)
 labels: [Feature Request]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: 🚀 Feature Request
 description: Suggest an idea for this project
 title: (feature request summary)
-labels: Feature Request
+labels: [Feature Request]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
This suggestion includes an update the presets of the issue templates.

- It uses an array for the `labels` value to resolve a language server type complaint.
  (Technically it already works as it is. It is just the array type that is used in the docs and the LS will get satisfied.)
- It removes the pre-filled titles. In the short time I know about V I've seen a few issues that were submitted with just the preset `(bug report summary)`. Often it's updated afterwards by a user or moderator, but there are still a few(see below). As it's not possible to submit an issue without a title this should make it mandatory for a user to think about and write a title for an issue. 
  
![Screenshot from 2023-07-27 17-57-53](https://github.com/vlang/v/assets/34311583/65392406-f136-4382-9c4a-3bb09c73e4a8)
![Screenshot from 2023-07-27 17-58-21](https://github.com/vlang/v/assets/34311583/90929e03-83b9-4851-9301-76262f1aaa0f)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3d2c4f</samp>

Removed `title` field from bug report template and changed `labels` field to use list syntax. Renamed and reorganized issue templates.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3d2c4f</samp>

*  Rename and reorganize issue templates ([link](https://github.com/vlang/v/pull/19026/files?diff=unified&w=0#diff-a18ac139672d9f557f950ebe7df3f057ba19abe40d02ac2c81f72bcf44257b68L3-R3), [link](https://github.com/vlang/v/pull/19026/files?diff=unified&w=0#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335cL3-R3))
