### PR TITLE
parser: change `fn_args()` to `fn_params()`

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -258,9 +258,9 @@ fn (mut p Parser) parse_fn_type(name string, generic_types []ast.Type) ast.Type 
 
 	mut has_generic := false
 	line_nr := p.tok.line_nr
-	args, _, is_variadic := p.fn_args()
-	for arg in args {
-		if arg.typ.has_flag(.generic) {
+	params, _, is_variadic := p.fn_params()
+	for param in params {
+		if param.typ.has_flag(.generic) {
 			has_generic = true
 			break
 		}
@@ -277,7 +277,7 @@ fn (mut p Parser) parse_fn_type(name string, generic_types []ast.Type) ast.Type 
 	}
 	func := ast.Fn{
 		name: name
-		params: args
+		params: params
 		is_variadic: is_variadic
 		return_type: return_type
 		return_type_pos: return_type_pos

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -660,8 +660,8 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				p.error_with_pos('duplicate method `${name}`', method_start_pos)
 				return ast.InterfaceDecl{}
 			}
-			args2, _, is_variadic := p.fn_args() // TODO merge ast.Param and ast.Arg to avoid this
-			mut args := [
+			params_t, _, is_variadic := p.fn_params() // TODO merge ast.Param and ast.Arg to avoid this
+			mut params := [
 				ast.Param{
 					name: 'x'
 					is_mut: is_mut
@@ -669,12 +669,12 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 					is_hidden: true
 				},
 			]
-			args << args2
+			params << params_t
 			mut method := ast.FnDecl{
 				name: name
 				short_name: name
 				mod: p.mod
-				params: args
+				params: params
 				file: p.file_name
 				return_type: ast.void_type
 				is_variadic: is_variadic
@@ -695,7 +695,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			methods << method
 			tmethod := ast.Fn{
 				name: name
-				params: args
+				params: params
 				pos: method.pos
 				return_type: method.return_type
 				is_variadic: is_variadic


### PR DESCRIPTION
This PR change `fn_args()` to `fn_params()` and cleanup all the related calls.