### PR TITLE
parser: fix improper token advancement when parsing the types of struct thread type fields(fix #19029)

### DIFF
--- a/vlib/v/tests/parse_thread_type_test.v
+++ b/vlib/v/tests/parse_thread_type_test.v
@@ -1,0 +1,30 @@
+struct Foo1 {
+	before_1 int
+	thr      thread
+	after_1  int
+	after_2  int
+	after_3  int
+}
+
+struct Foo2 {
+	thr thread
+	a   ?int
+}
+
+struct Foo3 {
+	thrs []thread
+	a    []int
+}
+
+struct Foo4 {
+	thrs []thread int
+	a    []int
+}
+
+fn test_parse_thread_type() {
+	_ = &Foo1{}
+	_ = &Foo2{}
+	_ = &Foo3{}
+	_ = &Foo4{}
+	assert true
+}


### PR DESCRIPTION
Fixed: #19029 

```v
struct Foo1 {
	before_1 int
	thr      thread
	after_1  int
	after_2  int
	after_3  int
}

struct Foo2 {
	thr thread
	a   ?int
}

struct Foo3 {
	thrs []thread
	a    []int
}

struct Foo4 {
	thrs []thread int
	a    []int
}

fn test_parse_thread_type() {
	_ = &Foo1{}
	_ = &Foo2{}
	_ = &Foo3{}
	_ = &Foo4{}
	assert true
}

```

```
passed.
```