### PR TITLE
checker, cgen: implement fixed array of threads wait() (fix #19016)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1067,6 +1067,18 @@ fn (mut g Gen) gen_array_wait(node ast.CallExpr) {
 	g.write(')')
 }
 
+fn (mut g Gen) gen_fixed_array_wait(node ast.CallExpr) {
+	arr := g.table.sym(g.unwrap_generic(node.receiver_type))
+	thread_type := arr.array_fixed_info().elem_type
+	thread_sym := g.table.sym(thread_type)
+	thread_ret_type := thread_sym.thread_info().return_type
+	eltyp := g.table.sym(thread_ret_type).cname
+	fn_name := g.register_thread_fixed_array_wait_call(node, eltyp)
+	g.write('${fn_name}(')
+	g.expr(node.left)
+	g.write(')')
+}
+
 fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	tmp := g.new_tmp_var()
 	mut s := g.go_before_stmt(0)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1250,6 +1250,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if g.gen_array_method_call(node, left_type) {
 			return
 		}
+	} else if left_sym.kind == .array_fixed && node.name == 'wait' {
+		g.gen_fixed_array_wait(node)
+		return
 	}
 
 	if final_left_sym.kind == .map {

--- a/vlib/v/tests/fixed_array_of_threads_wait_test.v
+++ b/vlib/v/tests/fixed_array_of_threads_wait_test.v
@@ -1,0 +1,15 @@
+fn foo() bool {
+	return true
+}
+
+fn test_fixed_array_of_threads_wait() {
+	threads := [
+		spawn foo(),
+		spawn foo(),
+	]!
+
+	results := threads.wait()
+
+	println(results)
+	assert results == [true, true]
+}


### PR DESCRIPTION
This PR implement fixed array of threads wait() (fix #19016).

- Implement fixed array of threads wait().
- Add test.

```v
fn test() bool {
	return true
}

fn main() {
	threads := [
		spawn test(),
		spawn test(),
	]!

	results := threads.wait()

	println(results)
	assert results == [true, true]
}

PS D:\Test\v\tt1> v run .
[true, true]
```