### PR TITLE
parser, cgen: fix `for i++; i<10; i++ {` (fix #18445)

### DIFF
--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -17,6 +17,9 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		g.indent++
 		if node.has_init {
 			g.stmt(node.init)
+			if node.init is ast.ExprStmt {
+				g.write('; ')
+			}
 		}
 		g.writeln('bool _is_first = true;')
 		g.writeln('while (true) {')
@@ -58,6 +61,9 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 			g.write('; ')
 		} else {
 			g.stmt(node.init)
+			if node.init is ast.ExprStmt {
+				g.write('; ')
+			}
 			// Remove excess return and add space
 			if g.out.last_n(1) == '\n' {
 				g.go_back(1)

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -30,7 +30,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.close_scope()
 		return for_stmt
-	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon]
+	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon, .inc, .dec]
 		|| p.peek_tok.kind.is_assign() || p.tok.kind == .semicolon
 		|| (p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
 		&& p.peek_token(3).kind != .key_in) {
@@ -48,6 +48,9 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 			&& p.peek_token(3).kind != .key_in
 		if p.peek_tok.kind in [.assign, .decl_assign] || p.peek_tok.kind.is_assign() || is_multi {
 			init = p.assign_stmt()
+			has_init = true
+		} else if p.peek_tok.kind in [.inc, .dec] {
+			init = p.stmt(false)
 			has_init = true
 		}
 		comments << p.eat_comments()

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -30,7 +30,8 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.close_scope()
 		return for_stmt
-	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon, .inc, .dec]
+	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon]
+		|| (p.peek_tok.kind in [.inc, .dec] && p.peek_token(2).kind in [.semicolon, .comma])
 		|| p.peek_tok.kind.is_assign() || p.tok.kind == .semicolon
 		|| (p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
 		&& p.peek_token(3).kind != .key_in) {

--- a/vlib/v/tests/for_c_init_with_var_inc_test.v
+++ b/vlib/v/tests/for_c_init_with_var_inc_test.v
@@ -1,0 +1,9 @@
+fn test_for_c_init_with_var_inc() {
+	mut results := []int{}
+	mut i := 0
+	for i++; i < 10; i++ {
+		println(i)
+		results << i
+	}
+	assert results == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+}


### PR DESCRIPTION
This PR fix `for i++; i<10; i++ {` (fix #18445).

- Fix for_c_stmt that init is `i++`.
- Add test.

```v
fn main() {
	mut results := []int{}
	mut i := 0
	for i++; i < 10; i++ {
		println(i)
		results << i
	}
	assert results == [1, 2, 3, 4, 5, 6, 7, 8, 9]
}

PS D:\Test\v\tt1> v run .
1
2
3
4
5
6
7
8
9
```