### PR TITLE
fmt: fix formatting of fn with argument comments (fix #15354)

### DIFF
--- a/vlib/v/fmt/tests/fn_with_args_comments_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_args_comments_keep.vv
@@ -1,0 +1,9 @@
+fn main() {
+	filtered_links := text_processing.filter_links(links, /* unwanted_domains = */ [
+		'www.kickstarter.com',
+		'www.pepper.pl',
+		'tenor.com',
+		'www.wykop.pl',
+		'giphy.com',
+	])
+}


### PR DESCRIPTION
This PR fix formatting of fn with argument comments (fix #15354).

- Add test.

vlib\v\fmt\tests\fn_with_args_comments_keep.vv
```v
fn main() {
	filtered_links := text_processing.filter_links(links, /* unwanted_domains = */ [
		'www.kickstarter.com',
		'www.pepper.pl',
		'tenor.com',
		'www.wykop.pl',
		'giphy.com',
	])
}
```