### PR TITLE
parser: disallow having builtin type as type names for `enum`, `sum type` and `alias`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4011,7 +4011,8 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		}
 		is_pub: is_pub
 	})
-	if idx == -1 {
+	if idx in [ast.invalid_type_idx, ast.string_type_idx, ast.rune_type_idx, ast.array_type_idx,
+		ast.map_type_idx] {
 		p.error_with_pos('cannot register enum `${name}`, another type with this name exists',
 			end_pos)
 	}
@@ -4109,7 +4110,8 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 			}
 			is_pub: is_pub
 		})
-		if typ == ast.invalid_type_idx {
+		if typ in [ast.invalid_type_idx, ast.string_type_idx, ast.rune_type_idx, ast.array_type_idx,
+			ast.map_type_idx] {
 			p.error_with_pos('cannot register sum type `${name}`, another type with this name exists',
 				name_pos)
 			return ast.SumTypeDecl{}
@@ -4149,7 +4151,8 @@ fn (mut p Parser) type_decl() ast.TypeDecl {
 		is_pub: is_pub
 	})
 	type_end_pos := p.prev_tok.pos()
-	if idx == ast.invalid_type_idx {
+	if idx in [ast.invalid_type_idx, ast.string_type_idx, ast.rune_type_idx, ast.array_type_idx,
+		ast.map_type_idx] {
 		p.error_with_pos('cannot register alias `${name}`, another type with this name exists',
 			name_pos)
 		return ast.AliasTypeDecl{}

--- a/vlib/v/parser/tests/builtin_alias_type_name_err.out
+++ b/vlib/v/parser/tests/builtin_alias_type_name_err.out
@@ -1,0 +1,3 @@
+vlib/v/parser/tests/builtin_alias_type_name_err.vv:1:6: error: cannot register alias `string`, another type with this name exists
+    1 | type string = int
+      |      ~~~~~~

--- a/vlib/v/parser/tests/builtin_alias_type_name_err.vv
+++ b/vlib/v/parser/tests/builtin_alias_type_name_err.vv
@@ -1,0 +1,1 @@
+type string = int

--- a/vlib/v/parser/tests/builtin_enum_type_name_err.out
+++ b/vlib/v/parser/tests/builtin_enum_type_name_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/builtin_enum_type_name_err.vv:1:6: error: cannot register enum `rune`, another type with this name exists
+    1 | enum rune {
+      |      ~~~~
+    2 |     a
+    3 |     b

--- a/vlib/v/parser/tests/builtin_enum_type_name_err.vv
+++ b/vlib/v/parser/tests/builtin_enum_type_name_err.vv
@@ -1,0 +1,5 @@
+enum rune {
+	a
+	b
+	c
+}

--- a/vlib/v/parser/tests/builtin_sum_type_type_name_err.out
+++ b/vlib/v/parser/tests/builtin_sum_type_type_name_err.out
@@ -1,0 +1,3 @@
+vlib/v/parser/tests/builtin_sum_type_type_name_err.vv:1:6: error: cannot register sum type `map`, another type with this name exists
+    1 | type map = int | u64
+      |      ~~~

--- a/vlib/v/parser/tests/builtin_sum_type_type_name_err.vv
+++ b/vlib/v/parser/tests/builtin_sum_type_type_name_err.vv
@@ -1,0 +1,1 @@
+type map = int | u64


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18957

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39926c5</samp>

This pull request enhances the parser's validation of user-defined type names and adds tests for error messages. It prevents name collisions with built-in types for `enum`, `sum type`, and `type alias` declarations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39926c5</samp>

*  Prevent name collisions between user-defined types and built-in types by adding more invalid type indices to the parser checks ([link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4014-R4015), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4112-R4114), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4152-R4155))
* Add test files and source code for the error messages when a type alias, an enum, or a sum type name conflicts with a built-in type name, such as `string`, `rune`, or `map` ([link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-763dd16e6d4bbcf1901a90abac71b018b4acc82ced638c9c083cd0d5fe2f5110R1-R3), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-8978fac722281abca3ec7af88547ecc15b02ad43dc68b8994719bcbaee3599b7R1), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-8aa07d2f8f8579383277e2549e27ae8f0e9bb624ed469d8cbd5448f5755b97e5R1-R5), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-9e194dcb5ac019307806f1f8690de90ecf4711246ddbd7c7fd071458b22ef980R1-R5), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-a35054dab86936c64a7fd03e390b8335e7125429bf4a6d5b96275c783c43c15bR1-R3), [link](https://github.com/vlang/v/pull/19043/files?diff=unified&w=0#diff-4e6ccd97a3530b2797a01deac0cd3894271b261f2eb4d17da66005115119bd11R1))
