### PR TITLE
parser: fix formatting comptime if expr script (fix #15073)

### DIFF
--- a/vlib/v/fmt/tests/comptime_if_expr_script_keep.vv
+++ b/vlib/v/fmt/tests/comptime_if_expr_script_keep.vv
@@ -1,0 +1,6 @@
+mut pre_built_str := ''
+$if prebuilt ? {
+	the_date := if $env('DATE') != '' { $env('DATE') } else { '##DATE##' }
+	pre_built_str = '[pre-built binary release (${the_date})]\n'
+}
+dump(pre_built_str)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -764,7 +764,7 @@ fn (mut p Parser) top_stmt() ast.Stmt {
 						expr: if_expr
 						pos: if_expr.pos
 					}
-					if comptime_if_expr_contains_top_stmt(if_expr) {
+					if p.pref.is_fmt || comptime_if_expr_contains_top_stmt(if_expr) {
 						return cur_stmt
 					} else {
 						return p.other_stmts(cur_stmt)


### PR DESCRIPTION
This PR fix formatting comptime if expr script (fix #15073).

- Fix formatting comptime if expr script.
- Add test.

vlib\v\fmt\tests\comptime_if_expr_script_keep.vv
```v
mut pre_built_str := ''
$if prebuilt ? {
	the_date := if $env('DATE') != '' { $env('DATE') } else { '##DATE##' }
	pre_built_str = '[pre-built binary release (${the_date})]\n'
}
dump(pre_built_str)
```