### PR TITLE
sync: make sync.Direction public

### DIFF
--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -26,7 +26,7 @@ mut:
 	nxt  &Subscription  = unsafe { nil }
 }
 
-enum Direction {
+pub enum Direction {
 	pop
 	push
 }


### PR DESCRIPTION
sync.Direction should be public to use with sync.channel_select(.., dir, ..)
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31db407</samp>

Made `Direction` enum public in `vlib/sync/channels.c.v` to enable bidirectional channel operations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31db407</samp>

* Make `Direction` enum public to allow specifying channel direction ([link](https://github.com/vlang/v/pull/19047/files?diff=unified&w=0#diff-41e9c9ec04088c737ec9fce6ed608506a2393f265a9335a3924e8f9716a40b22L29-R29))
