### PR TITLE
cgen: fix an error when interpo a ptr and specifier is p(fix #19048)

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -167,13 +167,13 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int, fmts []u8) {
 	if typ == ast.string_type && g.comptime_for_method.len == 0 {
 		if g.inside_vweb_tmpl {
 			g.write('vweb__filter(')
-			if expr.is_auto_deref_var() {
+			if expr.is_auto_deref_var() && fmt != `p` {
 				g.write('*')
 			}
 			g.expr(expr)
 			g.write(')')
 		} else {
-			if expr.is_auto_deref_var() {
+			if expr.is_auto_deref_var() && fmt != `p` {
 				g.write('*')
 			}
 			g.expr(expr)
@@ -221,13 +221,13 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int, fmts []u8) {
 			g.expr(expr)
 			g.write(')')
 		} else {
-			if expr.is_auto_deref_var() {
+			if expr.is_auto_deref_var() && fmt != `p` {
 				g.write('*')
 			}
 			g.expr(expr)
 		}
 	} else {
-		if expr.is_auto_deref_var() {
+		if expr.is_auto_deref_var() && fmt != `p` {
 			g.write('*')
 		}
 		g.expr(expr)

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -201,3 +201,19 @@ fn test_call() {
 	s := '${f(4)}'
 	assert s == '4'
 }
+
+// for issue: 19048
+struct Foo {
+}
+
+fn (mut f Foo) intp_pointer() string {
+	return '${f:p}'
+}
+
+fn test_intp_pointer_specifier_p() {
+	mut foo := Foo{}
+	str1 := foo.intp_pointer()
+
+	str2 := '${&foo:p}'
+	assert str1 == str2
+}


### PR DESCRIPTION
1. Fix #19048 
2. Add test.

```v
struct Foo {
}

fn (mut f Foo) intp_pointer() string {
	return '${f:p}'
}

fn main() {
	mut foo := Foo{}
	str1 := foo.intp_pointer()

	str2 := '${&foo:p}'
	assert str1 == str2
}
```

```
passed
```