### PR TITLE
ast, fmt: simplify fmt.fn_decl()

### DIFF
--- a/vlib/v/fmt/tests/fn_headers_with_inline_comments_expected.vv
+++ b/vlib/v/fmt/tests/fn_headers_with_inline_comments_expected.vv
@@ -3,6 +3,6 @@ fn /* main */ main() {
 }
 
 fn // hi
- print_hi() {
+print_hi() {
 	println('hi')
 }


### PR DESCRIPTION
This PR simplify fmt.fn_decl().

- Remove fmt.fn_header().
- Avoid duplicate codes.