### PR TITLE
cmd/tools: Add support for skiping lines in "v bump"

### DIFF
--- a/cmd/tools/vbump.v
+++ b/cmd/tools/vbump.v
@@ -21,10 +21,10 @@ const (
     version: \'0.2.42\'
     VERSION = "1.23.8"
 
-	If certain lines need to be skipped, use the --skip option. For instance,
-	the following command will skip lines containing "tool-version":
+  If certain lines need to be skipped, use the --skip option. For instance,
+  the following command will skip lines containing "tool-version":
 
-		v bump --patch --skip "tool-version" [files...]
+    v bump --patch --skip "tool-version" [files...]
 
 Examples:
   Bump the patch version in v.mod if it exists

--- a/cmd/tools/vbump.v
+++ b/cmd/tools/vbump.v
@@ -24,7 +24,7 @@ const (
 	If certain lines need to be skipped, use the --skip option. For instance,
 	the following command will skip lines containing "tool-version":
 
-		v bump --patch --skip "tool-version"
+		v bump --patch --skip "tool-version" [files...]
 
 Examples:
   Bump the patch version in v.mod if it exists

--- a/cmd/tools/vbump.v
+++ b/cmd/tools/vbump.v
@@ -148,7 +148,7 @@ Try ${tool_name} -h for more help...')
 		patch: fp.bool('patch', `p`, false, 'Bump the patch version.')
 		minor: fp.bool('minor', `n`, false, 'Bump the minor version.')
 		major: fp.bool('major', `m`, false, 'Bump the major version.')
-		skip: fp.string('skip', `s`, '', 'Skip lines matching this pattern.').trim_space()
+		skip: fp.string('skip', `s`, '', 'Skip lines matching this substring.').trim_space()
 	}
 
 	remaining := fp.finalize() or {

--- a/vlib/v/help/other/bump.txt
+++ b/vlib/v/help/other/bump.txt
@@ -11,7 +11,12 @@ recognized by the heuristic:
 tool_version = '1.2.1'
 version: '0.2.42'
 VERSION = "1.23.8"
-  
+
+If certain lines need to be skipped, use the --skip option. For instance,
+the following command will skip lines containing "tool-version":
+
+  v bump --patch --skip "tool-version" [files...]
+
 Examples:
   Bump the patch version in v.mod if it exists
     v bump --patch

--- a/vlib/v/help/other/bump.txt
+++ b/vlib/v/help/other/bump.txt
@@ -27,7 +27,8 @@ Examples:
 
 
 Options:
-  -h, --help   Show this help text.
-  -m, --major  Bump the major version.
-  -n, --minor  Bump the minor version.
-  -p, --patch  Bump the patch version.
+  -h, --help           Show this help text.
+  -m, --major          Bump the major version.
+  -n, --minor          Bump the minor version.
+  -p, --patch          Bump the patch version.
+  -s, --skip <string>  Skip lines matching this substring.


### PR DESCRIPTION
- Adds a `--skip` option to allow skipping lines that should not be affected.
- Uses `fp.finalize` to obtain the list of files.
- Updates the version of the `v bump` tool.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8ca99e</samp>

Added a new feature and improved testing for the `vbump` tool. The `--skip` option lets users exclude lines from version bumping based on a pattern. The error handling and test cases for `vbump` were also enhanced.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8ca99e</samp>

*  Update the tool version and description constants to reflect the new `--skip` feature ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aL12-R12), [link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aR24-R28))
* Add the `skip` field to the `Options` struct to store the value of the `--skip` option ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aR45))
* Modify the `bump_version` function to check the `skip` option and the line content before replacing the version string ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aL88-R95))
* Add the `--skip` option to the flag parser and assign the `files` variable to the remaining arguments after parsing the options ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aL144-R158), [link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aL153-R166))
* Add a new struct `SkipTestCase` and a new constant `skip_test_cases` to store the data for testing the `--skip` option in `cmd/tools/vbump_test.v` ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcR102-R163))
* Add a new function `run_skip_test` to run a single `SkipTestCase` by creating a temporary file, bumping the version with the `--skip` option, and asserting the expected results ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcR102-R163))
* Add a new function `test_all_skip_bump_cases` to iterate over the `skip_test_cases` array and run each case using the `run_skip_test` function ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcR102-R163))
* Add the `!` operator to the `os` calls in the test functions to propagate the errors if any ([link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcL81-R81), [link](https://github.com/vlang/v/pull/19064/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcL93-R93))
