### PR TITLE
picoev.v:  initial value for struct members

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -23,7 +23,7 @@ pub mut:
 	fd      int
 	loop_id int = -1
 	events  u32
-	cb      fn (int, int, voidptr)
+	cb      fn (int, int, voidptr) = unsafe { nil }
 	// used internally by the kqueue implementation
 	backend int
 }
@@ -31,7 +31,7 @@ pub mut:
 pub struct Config {
 pub:
 	port         int = 8080
-	cb           fn (voidptr, picohttpparser.Request, mut picohttpparser.Response)
+	cb           fn (voidptr, picohttpparser.Request, mut picohttpparser.Response) = unsafe { nil }
 	err_cb       fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError) = default_err_cb
 	user_data    voidptr = unsafe { nil }
 	timeout_secs int     = 8
@@ -42,7 +42,7 @@ pub:
 
 [heap]
 pub struct Picoev {
-	cb        fn (voidptr, picohttpparser.Request, mut picohttpparser.Response)
+	cb        fn (voidptr, picohttpparser.Request, mut picohttpparser.Response) = unsafe { nil }
 	err_cb    fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError) = default_err_cb
 	user_data voidptr = unsafe { nil }
 


### PR DESCRIPTION
The PR adds missing initial values for callback fields in pico.

`v examples/pico/pico.v`, on master produces:
```
vlib/picoev/picoev.v:26:2: notice: uninitialized `fn` struct fields are not allowed, since they can result in segfaults; use `?fn` or initialize the field with `=` (if you absolutely want to have unsafe function pointers, use `= unsafe { nil }`)
```

With this PR, `v examples/pico/pico.v` compiles cleanly with **no** notices.


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9331c0e</samp>

*  Initialize `cb` fields of `picoev_watcher`, `PicoevConfig`, and `Picoev` structs to `unsafe { nil }` to avoid compiler notices ([link](https://github.com/vlang/v/pull/19065/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL26-R26), [link](https://github.com/vlang/v/pull/19065/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL34-R34), [link](https://github.com/vlang/v/pull/19065/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL45-R45) in `vlib/picoev/picoev.v`). These fields are function pointers that are set by the user later, so they are safe to initialize to `nil` as long as they are not called before being assigned a valid function.
