### PR TITLE
checker: fix struct field fntype value call (fix #19063)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1779,7 +1779,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 						// cannot hide interface expected type to make possible to pass its interface type automatically
 						earg_types << if targ.idx() != param.typ.idx() { param.typ } else { targ }
 					} else {
-						earg_types << targ
+						earg_types << param.typ
 					}
 					param_share := param.typ.share()
 					if param_share == .shared_t

--- a/vlib/v/tests/struct_field_fn_call_test.v
+++ b/vlib/v/tests/struct_field_fn_call_test.v
@@ -1,0 +1,18 @@
+struct Foo {
+	f fn (Foo) int = dummy
+}
+
+fn dummy(s Foo) int {
+	return 22
+}
+
+fn (mut s Foo) fun() int {
+	return s.f(s)
+}
+
+fn test_struct_field_fn_call() {
+	mut s := Foo{}
+	ret := s.fun()
+	println(ret)
+	assert ret == 22
+}


### PR DESCRIPTION
This PR fix struct field fntype value call (fix #19063).

- Fix struct field fntype value call.
- Add test.

```v
struct Foo {
	f fn (Foo) int = dummy
}

fn dummy(s Foo) int {
	return 22
}

fn (mut s Foo) fun() int {
	return s.f(s)
}

fn main() {
	mut s := Foo{}
	ret := s.fun()
	println(ret)
	assert ret == 22
}

PS D:\Test\v\tt1> v run .
22
```