### PR TITLE
fmt: fix formatting of `C.f(/*mut*/buff &char) i64` (fix #17195)

### DIFF
--- a/vlib/v/fmt/tests/c_fn_headers_with_comments_expected.vv
+++ b/vlib/v/fmt/tests/c_fn_headers_with_comments_expected.vv
@@ -1,0 +1,7 @@
+module main
+
+fn main() {
+	println('Hello World!')
+}
+
+fn C.f( /* mut */ buff &char) i64

--- a/vlib/v/fmt/tests/c_fn_headers_with_comments_input.vv
+++ b/vlib/v/fmt/tests/c_fn_headers_with_comments_input.vv
@@ -1,0 +1,7 @@
+module main
+
+fn main() {
+	println('Hello World!')
+}
+
+fn C.f(/*mut*/buff &char) i64

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -948,6 +948,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 				is_mut: is_mut
 				typ: param_type
 				type_pos: type_pos
+				comments: comments
 			}
 			param_no++
 			if param_no > 1024 {


### PR DESCRIPTION
This PR fix formatting of `C.f(/*mut*/buff &char) i64` (fix #17195).

- Fix formatting of `C.f(/*mut*/buff &char) i64`.
- Add test.

```v
module main

fn main() {
	println('Hello World!')
}

fn C.f(/*mut*/buff &char) i64
```
fmt to:
```v
module main

fn main() {
	println('Hello World!')
}

fn C.f( /* mut */ buff &char) i64
```