### PR TITLE
vpm: don't keep empty dirs for git installs

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -342,6 +342,18 @@ fn vpm_install_from_vcs(module_names []string, vcs_key string) {
 					continue
 				}
 				println('Module "${name}" relocated to "${vmod_.name}" successfully.')
+				publisher_dir := final_module_path.all_before_last(os.path_separator)
+				if os.ls(publisher_dir) or {
+					errors++
+					println('Errors while getting info about "${publisher_dir}" :')
+					println(err)
+				}.len == 0 {
+					os.rmdir(publisher_dir) or {
+						errors++
+						println('Errors while removing "${publisher_dir}" :')
+						println(err)
+					}
+				}
 				final_module_path = minfo.final_module_path
 			}
 			name = vmod_.name

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -324,8 +324,8 @@ fn vpm_install_from_vcs(module_names []string, vcs_key string) {
 					eprintln('Removing module "${minfo.final_module_path}" ...')
 					os.rmdir_all(minfo.final_module_path) or {
 						errors++
-						println('Errors while removing "${minfo.final_module_path}" :')
-						println(err)
+						eprintln('Errors while removing "${minfo.final_module_path}" :')
+						eprintln(err)
 						continue
 					}
 				}
@@ -345,13 +345,13 @@ fn vpm_install_from_vcs(module_names []string, vcs_key string) {
 				publisher_dir := final_module_path.all_before_last(os.path_separator)
 				if os.ls(publisher_dir) or {
 					errors++
-					println('Errors while getting info about "${publisher_dir}" :')
-					println(err)
+					eprintln('Errors while getting info about "${publisher_dir}" :')
+					eprintln(err)
 				}.len == 0 {
 					os.rmdir(publisher_dir) or {
 						errors++
-						println('Errors while removing "${publisher_dir}" :')
-						println(err)
+						eprintln('Errors while removing "${publisher_dir}" :')
+						eprintln(err)
 					}
 				}
 				final_module_path = minfo.final_module_path

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -343,11 +343,7 @@ fn vpm_install_from_vcs(module_names []string, vcs_key string) {
 				}
 				println('Module "${name}" relocated to "${vmod_.name}" successfully.')
 				publisher_dir := final_module_path.all_before_last(os.path_separator)
-				if os.ls(publisher_dir) or {
-					errors++
-					eprintln('Errors while getting info about "${publisher_dir}" :')
-					eprintln(err)
-				}.len == 0 {
+				if os.is_dir_empty(publisher_dir) {
 					os.rmdir(publisher_dir) or {
 						errors++
 						eprintln('Errors while removing "${publisher_dir}" :')


### PR DESCRIPTION
This PR prevents creation of empty directories when installing a vmodule form it's git source.

E.g. if you install a module like:
```
v install --git https://github.com/ttytm/webview
```
And there are no vpm modules from this publisher installed, it will keep an empty directory with the publishers name. I think it should only be kept when there are already present installations in this directory.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbc1cfe</samp>

Add code to `vpm.v` to remove empty publisher directories after uninstalling modules. This improves the `vpm uninstall` command and avoids leaving unused directories on the system.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fbc1cfe</samp>

* Implement `vpm uninstall` command to remove installed modules ([link](https://github.com/vlang/v/pull/19070/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R345-R356),                             F0L343R
