### PR TITLE
os: remove the meaningless [noinit] attribute of the os.notifier

### DIFF
--- a/vlib/os/notify/backend_darwin.c.v
+++ b/vlib/os/notify/backend_darwin.c.v
@@ -21,14 +21,12 @@ fn C.EV_SET(voidptr, u32, i16, u16, u32, int, voidptr)
 
 // KqueueNotifier provides methods that implement FdNotifier using the
 // kqueue I/O event notification facility (macos, freeBSD, xxxBSD...unix only)
-[noinit]
 struct KqueueNotifier {
 	kqueue_fd int
 }
 
 // KqueueEvent describes an event that occurred for a file descriptor in
 // the watch list
-[noinit]
 struct KqueueEvent {
 pub:
 	fd   int

--- a/vlib/os/notify/backend_linux.c.v
+++ b/vlib/os/notify/backend_linux.c.v
@@ -26,14 +26,12 @@ fn C.epoll_wait(int, &C.epoll_event, int, int) int
 
 // EpollNotifier provides methods that implement FdNotifier using the
 // epoll I/O event notification facility (linux only)
-[noinit]
 struct EpollNotifier {
 	epoll_fd int
 }
 
 // EpollEvent describes an event that occurred for a file descriptor in
 // the watch list
-[noinit]
 struct EpollEvent {
 pub:
 	fd   int


### PR DESCRIPTION
This PR remove the meaningless [noinit] attribute of the os.notifier.  😄 