### PR TITLE
checker: disallow `none` as parent type of type alias

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -526,6 +526,9 @@ fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 			// type Sum = int | Alias
 			// type Alias = Sum
 		}
+		.none_ {
+			c.error('cannot create a type alias of `none` as it is a value', node.type_pos)
+		}
 		// The rest of the parent symbol kinds are also allowed, since they are either primitive types,
 		// that in turn do not allow recursion, or are abstract enough so that they can not be checked at comptime:
 		else {}

--- a/vlib/v/checker/tests/type_alias_none_parent_type_err.out
+++ b/vlib/v/checker/tests/type_alias_none_parent_type_err.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/type_alias_none_parent_type_err.vv:1:13: error: cannot create a type alias of `none` as it is a value
+    1 | type None = none
+      |             ~~~~

--- a/vlib/v/checker/tests/type_alias_none_parent_type_err.vv
+++ b/vlib/v/checker/tests/type_alias_none_parent_type_err.vv
@@ -1,0 +1,1 @@
+type None = none


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9cb978d</samp>

This pull request fixes a bug in the checker module that allowed type aliases with `none` as the parent type. It adds a new error case and two test files to verify the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9cb978d</samp>

*  Add error handling for type aliases with `none` as the parent type ([link](https://github.com/vlang/v/pull/19078/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R529-R531))
   * Add a test case in `vlib/v/checker/tests/type_alias_none_parent_type_err.vv` that triggers the error ([link](https://github.com/vlang/v/pull/19078/files?diff=unified&w=0#diff-065790f935618a579e1745244f9d98892c8de5a99262db6f07a9a1f145a6498bR1))
   * Add the expected compiler output in `vlib/v/checker/tests/type_alias_none_parent_type_err.out` ([link](https://github.com/vlang/v/pull/19078/files?diff=unified&w=0#diff-d1d96fa2a451372322e0ceb1a1b24c3b64df4ef4fa7a02991e247ba1229983f8R1-R3))
