### PR TITLE
scanner: fix string interpolation with nested string interpolation in inner quotes (fix #19081)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -648,7 +648,7 @@ fn (mut s Scanner) text_scan() token.Token {
 		}
 		// End of $var, start next string
 		if s.is_inter_end {
-			if s.text[s.pos] == s.quote || s.text[s.pos] == s.inter_quote {
+			if s.text[s.pos] == s.quote || (s.text[s.pos] == s.inter_quote && s.is_enclosed_inter) {
 				s.is_inter_end = false
 				return s.new_token(.string, '', 1)
 			}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -648,7 +648,7 @@ fn (mut s Scanner) text_scan() token.Token {
 		}
 		// End of $var, start next string
 		if s.is_inter_end {
-			if s.text[s.pos] == s.quote {
+			if s.text[s.pos] == s.quote || s.text[s.pos] == s.inter_quote {
 				s.is_inter_end = false
 				return s.new_token(.string, '', 1)
 			}

--- a/vlib/v/tests/string_interpolation_with_inner_quotes_test.v
+++ b/vlib/v/tests/string_interpolation_with_inner_quotes_test.v
@@ -1,0 +1,32 @@
+fn f(x int, s string) string {
+	return 'label ${s}: ${x}'
+}
+
+// vfmt off
+fn test_string_interp_with_inner_quotes() {
+	x := 'hi'
+	println('abc ${f(123, 'def')} xyz')
+	assert 'abc ${f(123, 'def')} xyz' == 'abc label def: 123 xyz'
+
+	println('abc ${f(123, "def")} xyz')
+	assert 'abc ${f(123, "def")} xyz' == 'abc label def: 123 xyz'
+
+	println("abc ${f(123, 'def')} xyz")
+	assert "abc ${f(123, 'def')} xyz" == 'abc label def: 123 xyz'
+
+	println("abc ${f(123, "def")} xyz")
+	assert "abc ${f(123, "def")} xyz" == 'abc label def: 123 xyz'
+	
+	println("abc ${f(123, "$x $x")} xyz")
+	assert "abc ${f(123, "$x $x")} xyz" == 'abc label hi hi: 123 xyz'
+
+	println('abc ${f(123, '$x $x')} xyz')
+	assert 'abc ${f(123, '$x $x')} xyz' == 'abc label hi hi: 123 xyz'
+
+	println('abc ${f(123, "$x $x")} xyz')
+	assert 'abc ${f(123, "$x $x")} xyz' == 'abc label hi hi: 123 xyz'
+
+	println("abc ${f(123, '$x $x')} xyz")
+	assert "abc ${f(123, '$x $x')} xyz" == 'abc label hi hi: 123 xyz'
+}
+// vfmt on


### PR DESCRIPTION
This PR fix string interpolation with nested string interpolation in inner quotes (fix #19081 partial).

- Fix string interpolation with nested string interpolation in inner quotes.
- Add test.

```v
fn f(x int, s string) string {
	return 'label ${s}: ${x}'
}

// vfmt off
fn main() {
	x := 'hi'
	println('abc ${f(123, 'def')} xyz')
	assert 'abc ${f(123, 'def')} xyz' == 'abc label def: 123 xyz'

	println('abc ${f(123, "def")} xyz')
	assert 'abc ${f(123, "def")} xyz' == 'abc label def: 123 xyz'

	println("abc ${f(123, 'def')} xyz")
	assert "abc ${f(123, 'def')} xyz" == 'abc label def: 123 xyz'

	println("abc ${f(123, "def")} xyz")
	assert "abc ${f(123, "def")} xyz" == 'abc label def: 123 xyz'
	
	println("abc ${f(123, "$x $x")} xyz")
	assert "abc ${f(123, "$x $x")} xyz" == 'abc label hi hi: 123 xyz'

	println('abc ${f(123, '$x $x')} xyz')
	assert 'abc ${f(123, '$x $x')} xyz' == 'abc label hi hi: 123 xyz'

	println('abc ${f(123, "$x $x")} xyz')
	assert 'abc ${f(123, "$x $x")} xyz' == 'abc label hi hi: 123 xyz'

	println("abc ${f(123, '$x $x')} xyz")
	assert "abc ${f(123, '$x $x')} xyz" == 'abc label hi hi: 123 xyz'
}
// vfmt on

PS D:\Test\v\tt1> v run .
abc label def: 123 xyz
abc label def: 123 xyz
abc label def: 123 xyz
abc label def: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
```