### PR TITLE
transformer: keep the symbolic expressions inside dump(expr) from being optimised out, even when they could be, when composed of literals known at comptime

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1779,9 +1779,6 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 						useen << uval
 					}
 				}
-				ast.PrefixExpr {
-					dump(field.expr)
-				}
 				ast.InfixExpr {
 					// Handle `enum Foo { x = 1 + 2 }`
 					c.infix_expr(mut field.expr)

--- a/vlib/v/slow_tests/inout/dump_expressions_with_literals.out
+++ b/vlib/v/slow_tests/inout/dump_expressions_with_literals.out
@@ -1,0 +1,7 @@
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:5] 2 + 2: 4
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:6] 2 * 3 + 50 / 5: 16
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:7] 3.14 + 0.1: 3.24
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:8] 'abc' + 'a': abca
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:9] 'a' + 'b' + 'c': abc
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:10] true || (false && true): true
+[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:11] 2 == 4: false

--- a/vlib/v/slow_tests/inout/dump_expressions_with_literals.vv
+++ b/vlib/v/slow_tests/inout/dump_expressions_with_literals.vv
@@ -1,0 +1,12 @@
+// Note: dump expressions should not get optimised out by the transformer stage,
+// even though they could normally, when they are composed of literals, i.e.
+// the value of the expression is known at compile time.
+fn main() {
+	dump(2 + 2)
+	dump(2 * 3 + 50 / 5)
+	dump(3.14 + 0.1)
+	dump('abc' + 'a')
+	dump('a' + 'b' + 'c')
+	dump(true || (false && true))
+	dump(2 == 4)
+}

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -10,7 +10,8 @@ pub mut:
 	index &IndexState
 	table &ast.Table = unsafe { nil }
 mut:
-	is_assert bool
+	is_assert   bool
+	inside_dump bool
 }
 
 pub fn new_transformer(pref_ &pref.Preferences) &Transformer {
@@ -513,6 +514,9 @@ pub fn (mut t Transformer) interface_decl(mut node ast.InterfaceDecl) ast.Stmt {
 }
 
 pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
+	if t.inside_dump {
+		return node
+	}
 	match mut node {
 		ast.AnonFn {
 			node.decl = t.stmt(mut node.decl) as ast.FnDecl
@@ -563,6 +567,11 @@ pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
 			}
 		}
 		ast.DumpExpr {
+			old_inside_dump := t.inside_dump
+			defer {
+				t.inside_dump = old_inside_dump
+			}
+			t.inside_dump = true
 			node.expr = t.expr(mut node.expr)
 		}
 		ast.GoExpr {

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -568,11 +568,9 @@ pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
 		}
 		ast.DumpExpr {
 			old_inside_dump := t.inside_dump
-			defer {
-				t.inside_dump = old_inside_dump
-			}
 			t.inside_dump = true
 			node.expr = t.expr(mut node.expr)
+			t.inside_dump = old_inside_dump
 		}
 		ast.GoExpr {
 			node.call_expr = t.expr(mut node.call_expr) as ast.CallExpr


### PR DESCRIPTION
Before:
```
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:5] 4: 4
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:6] 16: 16
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:7] 3.24: 3.24
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:8] 'abca': abca
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:9] 'abc': abc
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:10] true || (false): true
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:11] false: false
```

After:
```
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:5] 2 + 2: 4
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:6] 2 * 3 + 50 / 5: 16
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:7] 3.14 + 0.1: 3.24
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:8] 'abc' + 'a': abca
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:9] 'a' + 'b' + 'c': abc
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:10] true || (false && true): true
[vlib/v/slow_tests/inout/dump_expressions_with_literals.vv:11] 2 == 4: false
```