### PR TITLE
vdoc: implement keyboard shortcuts for search navigation

### DIFF
--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -197,9 +197,14 @@ body {
 	width: 1.2rem;
 	height: 1.2rem;
 }
-.doc-nav > .heading-container > .heading > #search {
+.doc-nav #search {
+	position: relative;
 	margin: 0.6rem 1.2rem 1rem 1.2rem;
+	display: flex;
+}
+.doc-nav #search input {
 	border: none;
+	width: 100%;
 	border-radius: 0.2rem;
 	padding: 0.5rem 1rem;
 	outline: none;
@@ -208,17 +213,32 @@ body {
 	color: #fff;
 	color: var(--menu-search-text-color);
 }
-.doc-nav > .heading-container > .heading > #search::placeholder {
+.doc-nav #search input::placeholder {
 	color: #edf2f7;
 	text-transform: uppercase;
 	font-size: 12px;
 	font-weight: 600;
 }
-.doc-nav > .heading-container > .heading > #search:-ms-input-placeholder {
-	color: #edf2f7;
-	text-transform: uppercase;
-	font-size: 12px;
-	font-weight: 600;
+.doc-nav #search-keys {
+	position: absolute;
+	height: 100%;
+	align-items: center;
+	display: flex;
+	top: 0;
+	right: 0.75rem;
+	opacity: 0.33;
+	transition: opacity 0.1s;
+}
+.doc-nav #search-keys.hide {
+	opacity: 0;
+}
+.doc-nav #search-keys kbd {
+	padding: 2.5px 3px;
+	margin-left: 1px;
+	font-size: 11px;
+	background-color: var(--menu-background-color);
+	border: 1px solid #ffffff44;
+	border-radius: 3px;
 }
 .doc-nav > .content {
 	padding: 0 2rem 2rem 2rem;
@@ -278,7 +298,8 @@ body {
 .doc-nav .search li {
 	line-height: 1.5;
 }
-.doc-nav > .search .result:hover {
+.doc-nav > .search .result:hover,
+.doc-nav > .search .result.selected {
 	background-color: #00000021;
 	background-color: var(--menu-search-result-background-hover-color);
 }

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -49,7 +49,6 @@ function setupMobileToggle() {
 		const isHidden = docNav.classList.contains('hidden');
 		docNav.classList.toggle('hidden');
 		const search = docNav.querySelector('.search');
-		// console.log(search);
 		const searchHasResults = search.classList.contains('has-results');
 		if (isHidden && searchHasResults) {
 			search.classList.remove('mobile-hidden');

--- a/cmd/tools/vdoc/theme/index.html
+++ b/cmd/tools/vdoc/theme/index.html
@@ -46,7 +46,9 @@
 							</div>
 							{{ menu_icon }}
 						</div>
-						<input type="text" id="search" placeholder="Search... (beta)" autocomplete="off" />
+						<div id="search">
+							<input type="text" placeholder="Search... (beta)" autocomplete="off" />
+						</div>
 					</div>
 				</div>
 				<nav class="search hidden"></nav>


### PR DESCRIPTION
The PR implements keymaps for the search field and results.

- Escape: unfocus the search field
- Arrow Keys: cycle through search results
- Enter: navigate towards selected result
- Ctrl(Cmd on mac)-k: select search input field

It also adds a little shortcut indicator if the search field is not selected.
I hope the subtle version of the indicator is suitable. It was kind of hard to settle for an aesthetically satisfying color for the indicator, so suggestions are welcome.

https://github.com/vlang/v/assets/34311583/23996917-78e5-40f3-b7c3-581a5a5a5159

`v doc -m -f html vlib`
`v/vlib/_docs/index.html`

For a life test: https://ttytm.github.io/webview/.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 235adf3</samp>

This pull request enhances the search feature in the `vdoc` tool by adding a keyboard shortcut indicator and a selection highlight to the search input element. It also refactors the HTML, CSS, and JavaScript files to support the new functionality and improve the code readability.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 235adf3</samp>

*  Wrap the search input element in a div with id `search` and add flexbox properties to align it with the menu icon in `doc.css` ([link](https://github.com/vlang/v/pull/19088/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL200-R207))
*  Update the CSS selectors for the search input element and its placeholder text to match the new div wrapper and remove the redundant border property in `doc.css` ([link](https://github.com/vlang/v/pull/19088/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL211-R216))
*  Add the CSS rules for the keyboard shortcut indicator, which is a div with id `search-keys` that contains two kbd elements, and position it inside the search div in `doc.css` ([link](https://github.com/vlang/v/pull/19088/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL217-R242))
*  Add a CSS rule for the `.selected` class, which is applied to the search result that is currently selected by the keyboard navigation, and use the same background color as the hover state in `doc.css` ([link](https://github.com/vlang/v/pull/19088/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL281-R302))
*  Add a new function `setupSearchKeymaps` in `doc.js` that registers the keyboard shortcuts for the search functionality and toggles the visibility of the indicator ([link](https://github.com/vlang/v/pull/19088/files?diff=unified&w=0#diff-3fb25060e841bc44786d7d6ed02a91a4c6c44f16784bb57b6af7e7934f57eb0eL148-R211))
*  Update the HTML template for the documentation sidebar to use the new div wrapper for the search input element in `index.html` ([link](https://github.com/vlang/v/pull/19088/files?diff=unified&w=0#diff-679db9dd884a96bcceba7a0182b1d52fde2e04ee8ca01bdc4a86b2a5c3a483edL49-R51))
