### PR TITLE
scanner: check invalid newline rune literal  (fix #19087)

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1472,17 +1472,23 @@ fn (mut s Scanner) ident_char() string {
 		u := c.runes()
 		if u.len != 1 {
 			if escaped_hex || escaped_unicode {
-				s.error('invalid character literal `${orig}` => `${c}` (${u}) (escape sequence did not refer to a singular rune)')
+				s.error_with_pos('invalid character literal `${orig}` => `${c}` (${u}) (escape sequence did not refer to a singular rune)',
+					lspos)
 			} else if u.len == 0 {
 				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
 					lspos)
-				s.error('invalid empty character literal `${orig}`')
+				s.error_with_pos('invalid empty character literal `${orig}`', lspos)
 			} else {
 				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
 					lspos)
-				s.error('invalid character literal `${orig}` => `${c}` (${u}) (more than one character)')
+				s.error_with_pos('invalid character literal `${orig}` => `${c}` (${u}) (more than one character)',
+					lspos)
 			}
 		}
+	} else if c == '\n' {
+		s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
+			lspos)
+		s.error_with_pos('invalid character literal, use \`\\n\` instead', lspos)
 	}
 	// Escapes a `'` character
 	if c == "'" {
@@ -1566,14 +1572,18 @@ fn (mut s Scanner) eat_details() string {
 }
 
 pub fn (mut s Scanner) warn(msg string) {
-	if s.pref.warns_are_errors {
-		s.error(msg)
-		return
-	}
 	pos := token.Pos{
 		line_nr: s.line_nr
 		pos: s.pos
 		col: s.current_column() - 1
+	}
+	s.warn_with_pos(msg, pos)
+}
+
+pub fn (mut s Scanner) warn_with_pos(msg string, pos token.Pos) {
+	if s.pref.warns_are_errors {
+		s.error_with_pos(msg, pos)
+		return
 	}
 	details := s.eat_details()
 	if s.pref.output_mode == .stdout && !s.pref.check_only {
@@ -1604,6 +1614,10 @@ pub fn (mut s Scanner) error(msg string) {
 		pos: s.pos
 		col: s.current_column() - 1
 	}
+	s.error_with_pos(msg, pos)
+}
+
+pub fn (mut s Scanner) error_with_pos(msg string, pos token.Pos) {
 	details := s.eat_details()
 	if s.pref.output_mode == .stdout && !s.pref.check_only {
 		util.show_compiler_message('error:',

--- a/vlib/v/scanner/tests/empty_character_literal_err.out
+++ b/vlib/v/scanner/tests/empty_character_literal_err.out
@@ -1,10 +1,10 @@
-vlib/v/scanner/tests/empty_character_literal_err.vv:2:8: error: invalid empty character literal ``
+vlib/v/scanner/tests/empty_character_literal_err.vv:2:7: error: invalid empty character literal ``
     1 | fn main() {
     2 |     a := ``
-      |           ^
+      |          ^
     3 |     println(a)
     4 | }
-Details: 
+Details:
 vlib/v/scanner/tests/empty_character_literal_err.vv:2:7: details: use quotes for strings, backticks for characters
     1 | fn main() {
     2 |     a := ``

--- a/vlib/v/scanner/tests/newline_character_literal_err.out
+++ b/vlib/v/scanner/tests/newline_character_literal_err.out
@@ -1,0 +1,13 @@
+vlib/v/scanner/tests/newline_character_literal_err.vv:2:7: error: invalid character literal, use `\n` instead
+    1 | fn main() {
+    2 |     a := `
+      |          ^
+    3 | `
+    4 |     println(a)
+Details:
+vlib/v/scanner/tests/newline_character_literal_err.vv:2:7: details: use quotes for strings, backticks for characters
+    1 | fn main() {
+    2 |     a := `
+      |          ^
+    3 | `
+    4 |     println(a)

--- a/vlib/v/scanner/tests/newline_character_literal_err.vv
+++ b/vlib/v/scanner/tests/newline_character_literal_err.vv
@@ -1,0 +1,5 @@
+fn main() {
+	a := `
+`
+	println(a)
+}


### PR DESCRIPTION
This PR check invalid newline rune literal  (fix #19087).

- Check invalid newline rune literal.
- Add error_with_pos() and warn_with_pos().
- Add test.

```v
fn md_skip_unicode_whitespace(label &MD_CHAR, off MD_OFFSET, size MD_SIZE) MD_OFFSET {
		if !md_is_unicode_whitespace__(codepoint) && !((((label [off] )) == (`
`) || ((label [off] )) == (`
`))) {}

fn md_build_attribute(ctx &MD_CTX, raw_text &MD_CHAR, raw_size MD_SIZE, flags u32, attr &MD_ATTRIBUTE, build &MD_ATTRIBUTE_BUILD) int {
	raw_off := MD_OFFSET{}
	off := MD_OFFSET{}

	is_trivial := 0
	ret := 0
	C.memset(build, 0, sizeof(MD_ATTRIBUTE_BUILD))
	is_trivial = 1
	for raw_off = 0 ; raw_off < raw_size ; raw_off ++ {
		if ((raw_text[raw_off] ) == `\` || (raw_text[raw_off] ) == `&` || (raw_text[raw_off] ) == `�`) {
			is_trivial = 0
			break

		}
	}
}

PS D:\Test\v\tt1> v -check-syntax tt1.v
tt1.v:2:72: error: invalid character literal, use `\n` instead
    1 | fn md_skip_unicode_whitespace(label &MD_CHAR, off MD_OFFSET, size MD_SIZE) MD_OFFSET {
    2 |         if !md_is_unicode_whitespace__(codepoint) && !((((label [off] )) == (`
      |                                                                              ^
    3 | `) || ((label [off] )) == (`
    4 | `))) {}
Details: 
tt1.v:2:72: details: use quotes for strings, backticks for characters
    1 | fn md_skip_unicode_whitespace(label &MD_CHAR, off MD_OFFSET, size MD_SIZE) MD_OFFSET {
    2 |         if !md_is_unicode_whitespace__(codepoint) && !((((label [off] )) == (`
      |                                                                              ^
    3 | `) || ((label [off] )) == (`
    4 | `))) {}
```