### PR TITLE
scanner: fix string interpolation with nested string interpolation (fix #19081)

### DIFF
--- a/vlib/v/tests/string_interpolation_with_inner_quotes_test.v
+++ b/vlib/v/tests/string_interpolation_with_inner_quotes_test.v
@@ -28,5 +28,11 @@ fn test_string_interp_with_inner_quotes() {
 
 	println("abc ${f(123, '$x $x')} xyz")
 	assert "abc ${f(123, '$x $x')} xyz" == 'abc label hi hi: 123 xyz'
+
+	println("abc ${f(123, "${x} ${x}")} xyz")
+	assert "abc ${f(123, "${x} ${x}")} xyz" == 'abc label hi hi: 123 xyz'
+
+	println('abc ${f(123, '${x} ${x}')} xyz')
+	assert 'abc ${f(123, '${x} ${x}')} xyz' == 'abc label hi hi: 123 xyz'
 }
 // vfmt on


### PR DESCRIPTION
This PR fix string interpolation with nested string interpolation (fix #19081).

- Fix string interpolation with nested string interpolation.
- Add test.

```v
fn f(x int, s string) string {
	return 'label ${s}: ${x}'
}

// vfmt off
fn main() {
	x := 'hi'
	println('abc ${f(123, 'def')} xyz')
	assert 'abc ${f(123, 'def')} xyz' == 'abc label def: 123 xyz'

	println('abc ${f(123, "def")} xyz')
	assert 'abc ${f(123, "def")} xyz' == 'abc label def: 123 xyz'

	println("abc ${f(123, 'def')} xyz")
	assert "abc ${f(123, 'def')} xyz" == 'abc label def: 123 xyz'

	println("abc ${f(123, "def")} xyz")
	assert "abc ${f(123, "def")} xyz" == 'abc label def: 123 xyz'
	
	println("abc ${f(123, "$x $x")} xyz")
	assert "abc ${f(123, "$x $x")} xyz" == 'abc label hi hi: 123 xyz'

	println('abc ${f(123, '$x $x')} xyz')
	assert 'abc ${f(123, '$x $x')} xyz' == 'abc label hi hi: 123 xyz'

	println('abc ${f(123, "$x $x")} xyz')
	assert 'abc ${f(123, "$x $x")} xyz' == 'abc label hi hi: 123 xyz'

	println("abc ${f(123, '$x $x')} xyz")
	assert "abc ${f(123, '$x $x')} xyz" == 'abc label hi hi: 123 xyz'

	println("abc ${f(123, "${x} ${x}")} xyz")
	assert "abc ${f(123, "${x} ${x}")} xyz" == 'abc label hi hi: 123 xyz'

	println('abc ${f(123, '${x} ${x}')} xyz')
	assert 'abc ${f(123, '${x} ${x}')} xyz' == 'abc label hi hi: 123 xyz'
}
// vfmt on

PS D:\Test\v\tt1> v run .
abc label def: 123 xyz
abc label def: 123 xyz
abc label def: 123 xyz
abc label def: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
abc label hi hi: 123 xyz
```