### PR TITLE
cgen: fix spawn call fn struct field(fix #18862)

### DIFF
--- a/vlib/v/gen/c/testdata/spawn_call_fn_struct_field.out
+++ b/vlib/v/gen/c/testdata/spawn_call_fn_struct_field.out
@@ -1,0 +1,2 @@
+hello
+hello

--- a/vlib/v/gen/c/testdata/spawn_call_fn_struct_field.vv
+++ b/vlib/v/gen/c/testdata/spawn_call_fn_struct_field.vv
@@ -1,0 +1,18 @@
+struct Foo {
+mut:
+	func1 fn (int) = unsafe { nil }
+	func2 fn (int) = do
+}
+
+fn do(a int) {
+	println('hello')
+}
+
+mut foo := Foo{}
+
+foo.func1 = do
+mut p := spawn foo.func1(1)
+p.wait()
+
+p = spawn foo.func2(1)
+p.wait()


### PR DESCRIPTION
1. Fix #18862 
2. Add test.

```v
struct Foo {
mut:
	func1 fn (int) = unsafe { nil }
	func2 fn (int) = do
}

fn do(a int) {
	println('hello')
}

mut foo := Foo{}

foo.func1 = do
mut p := spawn foo.func1(1)
p.wait()

p = spawn foo.func2(1)
p.wait()
```

output:
```
hello
hello
```

