### PR TITLE
parser: fix struct field fn type with default value (fix #19099)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -424,7 +424,7 @@ fn (mut p Parser) parse_type() ast.Type {
 		is_required_field := p.inside_struct_field_decl && p.tok.kind == .lsbr
 			&& p.peek_tok.kind == .name && p.peek_tok.lit == 'required'
 
-		if p.tok.line_nr > line_nr || p.tok.kind in [.comma, .rpar] || is_required_field {
+		if p.tok.line_nr > line_nr || p.tok.kind in [.comma, .rpar, .assign] || is_required_field {
 			mut typ := ast.void_type
 			if is_option {
 				typ = typ.set_flag(.option)

--- a/vlib/v/tests/struct_field_default_fn_type_value_init_test.v
+++ b/vlib/v/tests/struct_field_default_fn_type_value_init_test.v
@@ -1,5 +1,5 @@
 struct Flip {
-	name    string = 'NULL'
+	name    string  = 'NULL'
 	execute fn () ! = unsafe { nil }
 }
 
@@ -7,7 +7,7 @@ fn (flip Flip) exec() ! {
 	if isnil(flip.execute) {
 		return
 	}
-	
+
 	println('Executing ${flip.name}')
 	flip.execute()!
 }
@@ -19,7 +19,7 @@ fn test_struct_field_default_fn_type_value() {
 			println('Hello, World!')
 		}
 	}
-	
+
 	fl.exec()!
 	assert true
 }

--- a/vlib/v/tests/struct_field_default_fn_type_value_init_test.v
+++ b/vlib/v/tests/struct_field_default_fn_type_value_init_test.v
@@ -1,0 +1,25 @@
+struct Flip {
+	name    string = 'NULL'
+	execute fn () ! = unsafe { nil }
+}
+
+fn (flip Flip) exec() ! {
+	if isnil(flip.execute) {
+		return
+	}
+	
+	println('Executing ${flip.name}')
+	flip.execute()!
+}
+
+fn test_struct_field_default_fn_type_value() {
+	fl := Flip{
+		name: 'a function'
+		execute: fn () ! {
+			println('Hello, World!')
+		}
+	}
+	
+	fl.exec()!
+	assert true
+}


### PR DESCRIPTION
This PR fix struct field fn type with default value (fix #19099).

- Fix struct field fn type with default value.
- Add test.

```v
struct Flip {
	name    string = 'NULL'
	execute fn () ! = unsafe { nil }
}

fn (flip Flip) exec() ! {
	if isnil(flip.execute) {
		return
	}
	
	println('Executing ${flip.name}')
	flip.execute()!
}

fn main() {
	fl := Flip{
		name: 'a function'
		execute: fn () ! {
			println('Hello, World!')
		}
	}
	
	fl.exec()!
}

PS D:\Test\v\tt1> v run .
Executing a function
Hello, World!
```