### PR TITLE
cgen: fix shared map ptr type default value

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6338,7 +6338,8 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 			}
 			init_str := 'new_map${noscan}(sizeof(${g.typ(info.key_type)}), sizeof(${g.typ(info.value_type)}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})'
 			if typ.has_flag(.shared_f) {
-				mtyp := '__shared__Map_${key_typ.cname}_${g.table.sym(info.value_type).cname}'
+				mtyp := '__shared__Map_${key_typ.cname}_${g.typ(info.value_type).replace('*',
+					'_ptr')}'
 				return '(${mtyp}*)__dup_shared_map(&(${mtyp}){.mtx = {0}, .val =${init_str}}, sizeof(${mtyp}))'
 			} else {
 				return init_str


### PR DESCRIPTION
Fix #19111

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 486a958</samp>

Fix C code generation for shared maps with pointer values in `vlib/v/gen/c/cgen.v`. Use a consistent type name that avoids compilation errors.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 486a958</samp>

* Fix bug in C code generation for shared maps with pointer values ([link](https://github.com/vlang/v/pull/19113/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL6341-R6342))
