### PR TITLE
parser, checker, cgen: fix fn return alias of fixed array

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -118,9 +118,17 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 			}
 		}
-		return_sym := c.table.final_sym(node.return_type)
-		if return_sym.info is ast.MultiReturn {
-			for multi_type in return_sym.info.types {
+		return_sym := c.table.sym(node.return_type)
+		if return_sym.info is ast.Alias {
+			parent_sym := c.table.sym(return_sym.info.parent_type)
+			if parent_sym.info is ast.ArrayFixed {
+				c.table.find_or_register_array_fixed(parent_sym.info.elem_type, parent_sym.info.size,
+					parent_sym.info.size_expr, true)
+			}
+		}
+		final_return_sym := c.table.final_sym(node.return_type)
+		if final_return_sym.info is ast.MultiReturn {
+			for multi_type in final_return_sym.info.types {
 				if multi_type == ast.error_type {
 					c.error('type `IError` cannot be used in multi-return, return an Option instead',
 						node.return_type_pos)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1491,7 +1491,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	g.write(')')
 	if node.return_type != 0 && !node.return_type.has_flag(.option)
-		&& g.table.sym(node.return_type).kind == .array_fixed {
+		&& g.table.final_sym(node.return_type).kind == .array_fixed {
 		// it's non-option fixed array, requires accessing .ret_arr member to get the array
 		g.write('.ret_arr')
 	}
@@ -1798,7 +1798,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				g.write(')')
 			}
 			if node.return_type != 0 && !node.return_type.has_flag(.option)
-				&& g.table.sym(node.return_type).kind == .array_fixed {
+				&& g.table.final_sym(node.return_type).kind == .array_fixed {
 				// it's non-option fixed array, requires accessing .ret_arr member to get the array
 				g.write('.ret_arr')
 			}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -718,16 +718,6 @@ fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Languag
 					typ = ast.new_type(idx)
 				}
 			}
-			ast.Alias {
-				if p.inside_fn_return {
-					parent_sym := p.table.sym(sym.info.parent_type)
-					if parent_sym.kind == .array_fixed {
-						info := parent_sym.array_fixed_info()
-						typ = p.table.find_or_register_array_fixed(info.elem_type, info.size,
-							info.size_expr, p.inside_fn_return)
-					}
-				}
-			}
 			else {}
 		}
 		return typ

--- a/vlib/v/tests/return_aliases_of_fixed_array_test.v
+++ b/vlib/v/tests/return_aliases_of_fixed_array_test.v
@@ -7,7 +7,6 @@ fn test_main() {
 	assert z == [[1, 2]!, [3, 4]!]!
 }
 
-// vfmt off
 fn (v Mat) foo() Mat {
 	return v
 }
@@ -15,4 +14,3 @@ fn (v Mat) foo() Mat {
 fn bar() Mat {
 	return Mat([[1, 2]!, [3, 4]!]!)
 }
-// vfmt on

--- a/vlib/v/tests/return_fixed_array_test.v
+++ b/vlib/v/tests/return_fixed_array_test.v
@@ -8,11 +8,9 @@ fn return_fixed_array_in_multi_return() ([3]int, [3]int) {
 	return [1, 2, 3]!, [4, 5, 6]!
 }
 
-// vfmt off
 fn return_fixed_array_with_alias() Abc {
 	return [1, 2, 3]!
 }
-// vfmt on
 
 fn test_with_alias() {
 	a := return_fixed_array_with_alias()


### PR DESCRIPTION
This PR fix fn return alias of fixed array.

- Don't change return type from alias type to fixed array type in parser chase.
- Fmt is correct.
- Change the related tests.

```v
type Mat = [2][2]int

fn main() {
	a := Mat([[1, 2]!, [3, 4]!]!)
	println(a.foo())
	z := a.foo()
	assert z == [[1, 2]!, [3, 4]!]!
}

fn (v Mat) foo() Mat {
	return v
}

fn bar() Mat {
	return Mat([[1, 2]!, [3, 4]!]!)
}

PS D:\Test\v\tt1> v run .
Mat([[1, 2], [3, 4]])
```
Fmt is correct.