### PR TITLE
ci: extend vinix ci to include utils

### DIFF
--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -1,4 +1,4 @@
-name: Build Vinix kernel
+name: Build Vinix
 
 on:
   pull_request:

--- a/.github/workflows/vinix_kernel_ci.yml
+++ b/.github/workflows/vinix_kernel_ci.yml
@@ -14,6 +14,7 @@ jobs:
   vinix-build:
     runs-on: ubuntu-20.04
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    timeout-minutes: 3
     env:
       VFLAGS: -gc none
     steps:
@@ -35,3 +36,9 @@ jobs:
 
       - name: Attempt to build the Vinix kernel (prod)
         run: cd vinix/kernel && make PROD=true CFLAGS="-D__vinix__ -O2 -g -pipe" V="../../v" && make clean
+
+      - name: Attempt to build the util-vinix (debug)
+        run: cd vinix/util-vinix && make PROD=false V="$(realpath ../../v)" VFLAGS="-os vinix -gc none" CFLAGS="-D__vinix__ -O2 -g -pipe" && make clean
+
+      - name: Attempt to build the util-vinix (prod)
+        run: cd vinix/util-vinix && make PROD=true V="$(realpath ../../v)" VFLAGS="-os vinix -gc none" CFLAGS="-D__vinix__ -O2 -g -pipe" && make clean


### PR DESCRIPTION
This proposal updates the vinix ci to include building of vinix utils.

E.g. the introduction of the termios module into the stdlib in March resulted in the utils build to run infinitely until it was fixed recently in e3b0dfbfddf1813be8b4b04bf911a8e731e94628. The CI would make such friction points immediately visible, rather than when pushing to the vinix repository at a later point in time.

The vinix CI usually runs in about a minute. Including the `util-vinix` Makefile adds about 20-30 seconds. If changes will lead to infinite runs, as in the issue mentioned above, we could add the timeout of 3 minutes or so for the job.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ccb3f97</samp>

Improved the GitHub workflow for Vinix development. The `.github/workflows/vinix_ci.yml` file now builds and tests both the kernel and the userland utilities in different modes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ccb3f97</samp>

* Rename the workflow to "Build Vinix" to reflect the inclusion of userland utilities ([link](https://github.com/vlang/v/pull/19123/files?diff=unified&w=0#diff-76e47dfa0477c8c6b6071d0dd86f03d3724103fbb57a174f35a2b5b6e9c2a9a3L1-R1))
* Add timeout-minutes parameter to limit the kernel build duration to 3 minutes ([link](https://github.com/vlang/v/pull/19123/files?diff=unified&w=0#diff-76e47dfa0477c8c6b6071d0dd86f03d3724103fbb57a174f35a2b5b6e9c2a9a3R17))
* Add two steps to build the `util-vinix` userland utilities in debug and production modes, using the V and C compilers with Vinix-specific flags ([link](https://github.com/vlang/v/pull/19123/files?diff=unified&w=0#diff-76e47dfa0477c8c6b6071d0dd86f03d3724103fbb57a174f35a2b5b6e9c2a9a3R39-R44))
* Clean up the build artifacts after each userland utility build ([link](https://github.com/vlang/v/pull/19123/files?diff=unified&w=0#diff-76e47dfa0477c8c6b6071d0dd86f03d3724103fbb57a174f35a2b5b6e9c2a9a3R39-R44))
