### PR TITLE
builder,pref: Allow thirdparty objects compilation with CPP compiler

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -187,6 +187,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		skip_files << 'examples/coroutines/simple_coroutines.v'
 		$if msvc {
 			skip_files << 'vlib/v/tests/const_comptime_eval_before_vinit_test.v' // _constructor used
+			skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v'
 		}
 		$if solaris {
 			skip_files << 'examples/gg/gg2.v'

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -170,6 +170,7 @@ const (
 		'vlib/orm/orm_insert_reserved_name_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
+		'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v', // fails compilation with: undefined reference to vtable for __cxxabiv1::__function_type_info'
 	]
 	skip_with_werror              = [
 		'do_not_remove',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -334,6 +334,7 @@ fn main() {
 	}
 
 	if github_job == 'windows-tcc' {
+		tsession.skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v'
 		// TODO: fix these ASAP
 		tsession.skip_files << 'vlib/net/tcp_test.v'
 		tsession.skip_files << 'vlib/net/udp_test.v'

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -243,6 +243,7 @@ const (
 		'vlib/v/tests/const_fixed_array_containing_references_to_itself_test.v', // error C2099: initializer is not a constant
 		'vlib/v/tests/const_and_global_with_same_name_test.v', // error C2099: initializer is not a constant
 		'vlib/v/tests/sumtype_as_cast_test.v', // error: cannot support compound statement expression ({expr; expr; expr;})
+		'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v', // TODO
 	]
 	skip_on_windows               = [
 		'do_not_remove',

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -248,6 +248,10 @@ pub fn (mut p Preferences) default_c_compiler() {
 }
 
 pub fn (mut p Preferences) default_cpp_compiler() {
+	if p.ccompiler.contains('clang') {
+		p.cppcompiler = 'clang++'
+		return
+	}
 	p.cppcompiler = 'c++'
 }
 

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -119,6 +119,9 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	if p.ccompiler == '' {
 		p.default_c_compiler()
 	}
+	if p.cppcompiler == '' {
+		p.default_cpp_compiler()
+	}
 	p.find_cc_if_cross_compiling()
 	p.ccompiler_type = cc_from_string(p.ccompiler)
 	p.is_test = p.path.ends_with('_test.v') || p.path.ends_with('_test.vv')
@@ -242,6 +245,10 @@ pub fn (mut p Preferences) default_c_compiler() {
 	}
 	p.ccompiler = 'cc'
 	return
+}
+
+pub fn (mut p Preferences) default_cpp_compiler() {
+	p.cppcompiler = 'c++'
 }
 
 pub fn vexe_path() string {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -163,6 +163,7 @@ pub mut:
 	m64                bool         // true = generate 64-bit code, defaults to x64
 	ccompiler          string       // the name of the C compiler used
 	ccompiler_type     CompilerType // the type of the C compiler used
+	cppcompiler        string       // the name of the CPP compiler used
 	third_party_option string
 	building_v         bool
 	no_bounds_checking bool // `-no-bounds-checking` turns off *all* bounds checks for all functions at runtime, as if they all had been tagged with `[direct_array_access]`
@@ -736,6 +737,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-cc' {
 				res.ccompiler = cmdline.option(current_args, '-cc', 'cc')
 				res.build_options << '${arg} "${res.ccompiler}"'
+				i++
+			}
+			'-c++' {
+				res.cppcompiler = cmdline.option(current_args, '-c++', 'c++')
 				i++
 			}
 			'-checker-match-exhaustive-cutoff-limit' {

--- a/vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v
+++ b/vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v
@@ -1,0 +1,16 @@
+module main
+
+#flag @VMODROOT/implementation.o
+
+fn C.sizeof_char() int
+
+fn test_the_implementation_object_file_was_compiled_with_a_c_plus_plus_compiler() {
+	res := C.sizeof_char()
+	dump(res)
+	if res == 4 {
+		eprintln('implementation.o was compiled with a C compiler. Fail.')
+	} else if res == 1 {
+		println('implementation.o was compiled with a C++ compiler. Good.')
+	}
+	assert res == 1 // valid for C++ compilers
+}

--- a/vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v
+++ b/vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v
@@ -7,10 +7,12 @@ fn C.sizeof_char() int
 fn test_the_implementation_object_file_was_compiled_with_a_c_plus_plus_compiler() {
 	res := C.sizeof_char()
 	dump(res)
-	if res == 4 {
+	if res == sizeof(int) {
 		eprintln('implementation.o was compiled with a C compiler. Fail.')
-	} else if res == 1 {
+	} else if res == sizeof(char) {
 		println('implementation.o was compiled with a C++ compiler. Good.')
+	} else {
+		eprintln('¯\_(ツ)_/¯ ... unknown C/C++ compiler')
 	}
-	assert res == 1 // valid for C++ compilers
+	assert res == sizeof(char)
 }

--- a/vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v
+++ b/vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v
@@ -1,6 +1,7 @@
 module main
 
 #flag @VMODROOT/implementation.o
+#include "@VMODROOT/implementation.h"
 
 fn C.sizeof_char() int
 
@@ -12,7 +13,7 @@ fn test_the_implementation_object_file_was_compiled_with_a_c_plus_plus_compiler(
 	} else if res == sizeof(char) {
 		println('implementation.o was compiled with a C++ compiler. Good.')
 	} else {
-		eprintln('¯\_(ツ)_/¯ ... unknown C/C++ compiler')
+		eprintln('¯\\_(ツ)_/¯ ... unknown C/C++ compiler')
 	}
 	assert res == sizeof(char)
 }

--- a/vlib/v/tests/project_with_cpp_code/implementation.cpp
+++ b/vlib/v/tests/project_with_cpp_code/implementation.cpp
@@ -1,9 +1,9 @@
 // This file should be compiled with a C++ compiler:
 extern "C" {
-	int sizeof_char();
+	int sizeof_char(void);
 }
 
-int sizeof_char() {
+int sizeof_char(void) {
    // see https://stackoverflow.com/a/12887719/1023403
    return sizeof('a'); // 4 for C compilers, 1 for C++ compilers
 }

--- a/vlib/v/tests/project_with_cpp_code/implementation.cpp
+++ b/vlib/v/tests/project_with_cpp_code/implementation.cpp
@@ -1,0 +1,9 @@
+// This file should be compiled with a C++ compiler:
+extern "C" {
+	int sizeof_char();
+}
+
+int sizeof_char() {
+   // see https://stackoverflow.com/a/12887719/1023403
+   return sizeof('a'); // 4 for C compilers, 1 for C++ compilers
+}

--- a/vlib/v/tests/project_with_cpp_code/implementation.h
+++ b/vlib/v/tests/project_with_cpp_code/implementation.h
@@ -1,0 +1,1 @@
+int sizeof_char(void);

--- a/vlib/v/tests/project_with_cpp_code/v.mod
+++ b/vlib/v/tests/project_with_cpp_code/v.mod
@@ -1,0 +1,5 @@
+Module {
+	name: 'project_with_c_code_3',
+	description: 'A simple project, containing C code.',
+	dependencies: []
+}

--- a/vlib/v/tests/project_with_cpp_code/v.mod
+++ b/vlib/v/tests/project_with_cpp_code/v.mod
@@ -1,5 +1,5 @@
 Module {
-	name: 'project_with_c_code_3',
-	description: 'A simple project, containing C code.',
+	name: 'project_with_cpp_code',
+	description: 'A simple project, containing a .cpp file with C++ code, that has to be compiled with a C++ compiler.',
 	dependencies: []
 }


### PR DESCRIPTION
Hi,

As I was working on a binding for an external CPP library, I was hit by:

- not finding CPP files to compile
- standard C compilations flags that depends on wether we are compiling a C file or a CPP one

This PR enable one to bind and build such binding, by keeping the `#flag @VEXEROOT/thirdparty/path/to/object.o` compatibilty.

Kind regards,

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 231859a</samp>

This pull request adds support for custom C++ compilers in V and enables compiling third party modules that use C++ code. It modifies the `Preferences` struct, the `cc.v` and `pref.v` files, and adds a `-c++` flag to choose the compiler.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 231859a</samp>

*  Add support for C++ files in third party modules ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3R13-R19), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L134-L140), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3R346-R353), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L399-R407), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L440-R467), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L891-R923), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L921-R963), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e178ddff137d18fe9589236ddc349d5eb75f844d32146886b33888241784e3c4R122-R124), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e178ddff137d18fe9589236ddc349d5eb75f844d32146886b33888241784e3c4R250-R253), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3R166), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3R742-R745))
  - Define constants for C and C++ standards in `vlib/v/builder/cc.v` ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3R13-R19))
  - Remove hard-coded C standard flags from C compiler options ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L134-L140))
  - Add C standard flags to source-specific arguments based on OS and `no_std` preference ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3R346-R353))
  - Pass file type argument to `thirdparty_object_args` function ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L399-R407), [link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L921-R963))
  - Add C or C++ standard flags to `thirdparty_object_args` function based on OS, `no_std` preference, and file type ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L440-R467))
  - Check if guessed C file exists and set file type flag accordingly in `build_thirdparty_obj_file` function ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L891-R923))
  - Switch to C++ compiler if file type is C++ in `build_thirdparty_obj_file` function ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-96aa475f49c10ef1e0246fffcd5cf86463e164a6cb77065733ab3ef92e895fc3L921-R963))
  - Set default C++ compiler if not specified by user in `default_ccompiler` function in `vlib/v/pref/default.v` ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e178ddff137d18fe9589236ddc349d5eb75f844d32146886b33888241784e3c4R122-R124))
  - Add `default_cpp_compiler` function to `Preferences` struct in `vlib/v/pref/default.v` ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e178ddff137d18fe9589236ddc349d5eb75f844d32146886b33888241784e3c4R250-R253))
  - Add `cppcompiler` field to `Preferences` struct in `vlib/v/pref/pref.v` ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3R166))
  - Add `-c++` option to command line parser in `vlib/v/pref/pref.v` ([link](https://github.com/vlang/v/pull/19124/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3R742-R745))
