### PR TITLE
vdoc: make minor improvements to scrollspy and styles

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -450,12 +450,12 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 }
 
 fn html_tag_escape(str string) string {
-	excaped_string := str.replace_each(['<', '&lt;', '>', '&gt;'])
+	escaped_string := str.replace_each(['<', '&lt;', '>', '&gt;'])
 	mut re := regex.regex_opt(r'`.+[(&lt;)(&gt;)].+`') or { regex.RE{} }
-	if re.find_all_str(excaped_string).len > 0 {
+	if re.find_all_str(escaped_string).len > 0 {
 		return str
 	}
-	return excaped_string
+	return escaped_string
 }
 
 /*

--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -37,14 +37,7 @@
 	--attribute-deprecated-text-color: #92400e;
 	--attribute-text-color: #000000cf;
 }
-:root.dark .dark-icon {
-	display: none;
-}
-:root:not(.dark) .light-icon {
-	display: none;
-}
-
-.dark body {
+html.dark {
 	--background-color: #1a202c;
 	--text-color: #fff;
 	--link-color: #90cdf4;
@@ -80,6 +73,12 @@
 	--attribute-background-color: #ffffff20;
 	--attribute-text-color: #ffffffaf;
 	--attribute-deprecated-text-color: #fef3c7;
+}
+html.dark .dark-icon {
+	display: none;
+}
+html:not(.dark) .light-icon {
+	display: none;
 }
 html {
 	height: 100%;
@@ -731,9 +730,6 @@ pre {
 	.doc-node {
 		padding-top: 1rem !important;
 		margin-top: 0 !important;
-	}
-	.doc-toc {
-		top: 0;
 	}
 }
 

--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -233,7 +233,7 @@ body {
 	opacity: 0;
 }
 .doc-nav #search-keys kbd {
-	padding: 2.5px 3px;
+	padding: 2.5px 4px;
 	margin-left: 1px;
 	font-size: 11px;
 	background-color: var(--menu-background-color);

--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -361,6 +361,7 @@ body {
 /* Main content */
 .doc-scrollview {
 	height: 100%;
+	overflow-y: scroll;
 }
 .doc-container {
 	display: flex;
@@ -657,7 +658,6 @@ pre {
 		height: 100vh;
 		position: -webkit-sticky;
 		align-self: flex-start;
-		top: 56px;
 		min-width: 200px;
 		width: auto;
 		max-width: 300px;

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -212,7 +212,7 @@ function setupSearchKeymaps() {
 				ev.preventDefault();
 				if (!searchResults.length) break;
 				if (selectedIdx <= 0) {
-					// Cycle to last if first is selected (or select it if none is selcted yet)
+					// Cycle to last if first is selected (or select it if none is selected yet)
 					selectResult(searchResults, searchResults.length - 1);
 				} else {
 					// Select previous
@@ -232,9 +232,9 @@ function createSearchResult(data) {
 	a.href = data.link;
 	a.classList.add('link');
 	li.appendChild(a);
-	const defintion = document.createElement('div');
-	defintion.classList.add('definition');
-	a.appendChild(defintion);
+	const definition = document.createElement('div');
+	definition.classList.add('definition');
+	a.appendChild(definition);
 	if (data.description) {
 		const description = document.createElement('div');
 		description.classList.add('description');
@@ -244,11 +244,11 @@ function createSearchResult(data) {
 	const title = document.createElement('span');
 	title.classList.add('title');
 	title.textContent = data.title;
-	defintion.appendChild(title);
+	definition.appendChild(title);
 	const badge = document.createElement('badge');
 	badge.classList.add('badge');
 	badge.textContent = data.badge;
-	defintion.appendChild(badge);
+	definition.appendChild(badge);
 	return li;
 }
 

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -10,36 +10,35 @@
 })();
 
 function setupScrollSpy() {
-	const sections = document.querySelectorAll('section');
+	const mainContent = document.querySelector('#main-content');
+	mainContent.focus();
+	const toc = mainContent.querySelector('.doc-toc');
+	const sections = mainContent.querySelectorAll('section');
 	const sectionPositions = Array.from(sections).map((section) => section.offsetTop);
-	let scrollPos = 0;
-	window.addEventListener('scroll', () => {
-		const toc = document.querySelector('.doc-toc');
+	let lastScrollPos = 0;
+	mainContent.addEventListener('scroll', () => {
 		// Reset classes
 		toc.querySelectorAll('a[class="active"]').forEach((link) => link.classList.remove('active'));
-		// Set current menu link as active
-		let scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
+		let scrollPos = mainContent.scrollTop;
 		for (const [i, position] of sectionPositions.entries()) {
-			if (position >= scrollPosition) {
+			if (position >= scrollPos) {
 				const section = sections[i];
 				const link = toc.querySelector('a[href="#' + section.id + '"]');
 				if (link) {
+					// Set current menu link as active
 					link.classList.add('active');
 					const tocHeight = toc.clientHeight;
 					const scrollTop = toc.scrollTop;
-					if (
-						document.body.getBoundingClientRect().top < scrollPos &&
-						scrollTop < link.offsetTop - 10
-					) {
+					if (lastScrollPos < scrollPos && scrollTop < link.offsetTop) {
 						toc.scrollTop = link.clientHeight + link.offsetTop - tocHeight + 10;
-					} else if (scrollTop > link.offsetTop - 10) {
-						toc.scrollTop = link.offsetTop - 10;
+					} else if (scrollTop > link.offsetTop) {
+						toc.scrollTop = link.offsetTop - 16;
 					}
 				}
 				break;
 			}
 		}
-		scrollPos = document.body.getBoundingClientRect().top;
+		lastScrollPos = mainContent.scrollTop;
 	});
 }
 

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -29,8 +29,11 @@ function setupScrollSpy() {
 					link.classList.add('active');
 					const tocHeight = toc.clientHeight;
 					const scrollTop = toc.scrollTop;
+					const tocStart = toc.getBoundingClientRect().top + window.scrollY;
 					if (lastScrollPos < scrollPos && scrollTop < link.offsetTop) {
-						toc.scrollTop = link.clientHeight + link.offsetTop - tocHeight + 10;
+						toc.scrollTop = link.clientHeight + link.offsetTop - tocHeight + tocStart + 10;
+					} else if (link.offsetTop < tocStart) {
+						toc.scrollTop = 0;
 					} else if (scrollTop > link.offsetTop) {
 						toc.scrollTop = link.offsetTop - 16;
 					}

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -16,14 +16,16 @@ function setupScrollSpy() {
 	const toc = mainContent.querySelector('.doc-toc');
 	const sections = mainContent.querySelectorAll('section');
 	const sectionPositions = Array.from(sections).map((section) => section.offsetTop);
+	let lastActive = null;
 	let clickedScroll = false;
 	const handleScroll = debounce(() => {
 		if (clickedScroll) {
 			clickedScroll = false;
 			return;
 		}
-		// Reset classes
-		toc.querySelectorAll('a[class="active"]').forEach((link) => link.classList.remove('active'));
+		if (lastActive) {
+			lastActive.classList.remove('active');
+		}
 		for (const [i, position] of sectionPositions.entries()) {
 			if (position >= mainContent.scrollTop) {
 				const link = toc.querySelector('a[href="#' + sections[i].id + '"]');
@@ -42,6 +44,7 @@ function setupScrollSpy() {
 						toc.scrollTop = link.offsetTop - 10;
 					}
 				}
+				lastActive = link;
 				break;
 			}
 		}
@@ -49,8 +52,11 @@ function setupScrollSpy() {
 	mainContent.addEventListener('scroll', handleScroll);
 	toc.querySelectorAll('a').forEach((a) =>
 		a.addEventListener('click', () => {
-			toc.querySelectorAll('a[class="active"]').forEach((link) => link.classList.remove('active'));
+			if (lastActive) {
+				lastActive.classList.remove('active');
+			}
 			a.classList.add('active');
+			lastActive = a;
 			clickedScroll = true;
 		})
 	);

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -11,6 +11,7 @@
 
 function setupScrollSpy() {
 	const mainContent = document.querySelector('#main-content');
+	// Ensure initial keyboard navigability
 	mainContent.focus();
 	const toc = mainContent.querySelector('.doc-toc');
 	const sections = mainContent.querySelectorAll('section');
@@ -41,7 +42,7 @@ function setupScrollSpy() {
 				break;
 			}
 		}
-		lastScrollPos = mainContent.scrollTop;
+		lastScrollPos = scrollPos;
 	});
 }
 

--- a/cmd/tools/vdoc/theme/index.html
+++ b/cmd/tools/vdoc/theme/index.html
@@ -26,7 +26,7 @@
 	</head>
 
 	<body>
-		<div><a id="skip-to-content-link" tabindex="-1" href="#main-content">Skip to content</a></div>
+		<div><a id="skip-to-content-link" href="#main-content">Skip to content</a></div>
 		<div id="page">
 			<header class="doc-nav hidden">
 				<div class="heading-container">
@@ -58,7 +58,7 @@
 					</ul>
 				</nav>
 			</header>
-			<div class="doc-scrollview" id="main-content">
+			<div class="doc-scrollview" tabindex="-1" id="main-content">
 				<div class="doc-container">
 					<div class="doc-content">
 						{{ contents }}

--- a/cmd/tools/vdoc/theme/index.html
+++ b/cmd/tools/vdoc/theme/index.html
@@ -26,7 +26,7 @@
 	</head>
 
 	<body>
-		<div><a id="skip-to-content-link" href="#main-content">Skip to content</a></div>
+		<div><a id="skip-to-content-link" tabindex="-1" href="#main-content">Skip to content</a></div>
 		<div id="page">
 			<header class="doc-nav hidden">
 				<div class="heading-container">


### PR DESCRIPTION
This PR adds minor improvements to the sites generated with vodc.

1. It refines the scrollspy
   This includes a fix for the scroll position indicator at medium widths so it doesn't move out of the screen and become invisible.
   Also a headermenu style fix for medium widths, where it looked cutoff at  in chromium based browsers due to the scrollbar.
  ![Screenshot from 2023-08-12 22-27-21 (1)](https://github.com/vlang/v/assets/34311583/39f9a8c8-e97c-4f52-ab10-5f8f51aff7bd)
  ![Screenshot from 2023-08-12 22-27-21](https://github.com/vlang/v/assets/34311583/83f890d6-3b41-422c-88cc-41e034d93b7e)

   Should also fix potential little jumpiness at certain positions due to difference in toc padding and set scrollpostions.
   
2. It slightly increases the width of the kbd searchkey indicator.
   After having added the search menu shortcuts I looked more on mac screens at the modules page. The shortcut indicator with just the cmd mac symbol is a bit narrow, so I'm adding a px per side.

The changes are probably best compared live when adjusting the window with to ~768px-1024px and opening:
https://modules.vlang.io/
`v doc -m -f html vlib`
`v/vlib/_docs/index.html`


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28cab5d</samp>

This pull request enhances the documentation theme for vdoc by improving the style, functionality, and accessibility of the navigation bar, the scroll container, and the skip-to-content link. It modifies `doc.css`, `doc.js`, and `index.html` in the `cmd/tools/vdoc/theme` directory.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28cab5d</samp>

* Increase the padding of the search keys in the documentation navigation bar ([link](https://github.com/vlang/v/pull/19128/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL236-R236))
* Add a scroll bar to the documentation navigation bar and remove its fixed top position ([link](https://github.com/vlang/v/pull/19128/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cR364), [link](https://github.com/vlang/v/pull/19128/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL660))
* Modify the setupScrollSpy function in `doc.js` to use the main content element as the scroll container and adjust the scroll position of the table of contents ([link](https://github.com/vlang/v/pull/19128/files?diff=unified&w=0#diff-3fb25060e841bc44786d7d6ed02a91a4c6c44f16784bb57b6af7e7934f57eb0eL13-R35), [link](https://github.com/vlang/v/pull/19128/files?diff=unified&w=0#diff-3fb25060e841bc44786d7d6ed02a91a4c6c44f16784bb57b6af7e7934f57eb0eL42-R41))
* Add a tabindex attribute to the skip-to-content link in `index.html` to improve the keyboard navigation and accessibility ([link](https://github.com/vlang/v/pull/19128/files?diff=unified&w=0#diff-679db9dd884a96bcceba7a0182b1d52fde2e04ee8ca01bdc4a86b2a5c3a483edL29-R29))
