### PR TITLE
cgen: fix alias of array method call(fix #19125)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1436,8 +1436,13 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		arg_name := '_arg_expr_${fn_name}_0_${node.pos.pos}'
 		g.write('/*af receiver arg*/' + arg_name)
 	} else {
-		if left_sym.kind == .array && node.left.is_auto_deref_var()
-			&& is_array_method_first_last_repeat {
+		mut is_array := left_sym.kind == .array
+		if !is_array && left_sym.kind == .alias {
+			unaliased_type := g.table.unaliased_type(left_type)
+			unaliased_sym := g.table.sym(unaliased_type)
+			is_array = unaliased_sym.kind == .array
+		}
+		if is_array && node.left.is_auto_deref_var() && is_array_method_first_last_repeat {
 			g.write('*')
 		}
 		if node.left is ast.MapInit {

--- a/vlib/v/gen/c/testdata/alias_of_array_method_call.out
+++ b/vlib/v/gen/c/testdata/alias_of_array_method_call.out
@@ -1,0 +1,1 @@
+&Option(Element{})

--- a/vlib/v/gen/c/testdata/alias_of_array_method_call.vv
+++ b/vlib/v/gen/c/testdata/alias_of_array_method_call.vv
@@ -1,0 +1,20 @@
+struct Element {}
+
+type ElementStack = []&Element
+
+fn (mut stack ElementStack) pop_front() ?&Element {
+	return if stack.len > 0 {
+		val := stack.first()
+		stack.delete(0)
+		val
+	} else {
+		none
+	}
+}
+
+fn main() {
+	mut stack := ElementStack([]&Element{})
+	stack << &Element{}
+	a := stack.pop_front()
+	println(a)
+}


### PR DESCRIPTION
1. Fix #19125 
2. Add tests.

```v
struct Element {}

type ElementStack = []&Element

fn (mut stack ElementStack) pop_front() ?&Element {
	return if stack.len > 0 {
		val := stack.first()
		stack.delete(0)
		val
	} else {
		none
	}
}

fn main() {
	mut stack := ElementStack([]&Element{})
	stack << &Element{}
	a := stack.pop_front()
	println(a)
}
```

output:
```
&Option(Element{})
```