### PR TITLE
checker, fmt: fix static methods not recognized when imported from a module(fix #19127)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1876,8 +1876,8 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 			f.write('${node.name.after_char(`.`)}')
 		} else {
 			name := f.short_module(node.name)
-			f.mark_import_as_used(name)
 			if node.name.contains('__static__') {
+				f.mark_import_as_used(node.name.split('__static__')[0])
 				if name.contains('.') {
 					indx := name.index('.') or { -1 } + 1
 					f.write(name[0..indx] + name[indx..].replace('__static__', '.').capitalize())
@@ -1885,6 +1885,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 					f.write(name.replace('__static__', '.').capitalize())
 				}
 			} else {
+				f.mark_import_as_used(name)
 				f.write(name)
 			}
 		}

--- a/vlib/v/tests/modules/methods_struct_another_module/import_symbol_static_method_test.v
+++ b/vlib/v/tests/modules/methods_struct_another_module/import_symbol_static_method_test.v
@@ -1,0 +1,7 @@
+import time { Time, now }
+
+fn test_import_symbol_static_method() {
+	now := now()
+	now_2 := Time.new(now)
+	assert now == now_2
+}


### PR DESCRIPTION
1. Fix #19127 
2. Add tests.

```v
module main

import amod { SomeStruct }

fn main() {
	result := SomeStruct.new()
	println(result)
}
```

output:
```
amod.SomeStruct{}
```