### PR TITLE
vweb: add .wasm to mime_types

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -119,6 +119,7 @@ pub const (
 		'.ttf':    'font/ttf'
 		'.txt':    'text/plain'
 		'.vsd':    'application/vnd.visio'
+		'.wasm':   'application/wasm'
 		'.wav':    'audio/wav'
 		'.weba':   'audio/webm'
 		'.webm':   'video/webm'


### PR DESCRIPTION
`vweb.mime_types` is of type `pub const`. Added support for files with `.wasm` extension