### PR TITLE
checker: fix an inappropriate variable name

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -499,8 +499,8 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 		}
 	}
 	// If the left expr has an or_block, it needs to be checked for legal or_block statement.
-	return_type := c.expr(mut node.left)
-	c.check_expr_opt_call(node.left, return_type)
+	left_type := c.expr(mut node.left)
+	c.check_expr_opt_call(node.left, left_type)
 	// TODO merge logic from method_call and fn_call
 	// First check everything that applies to both fns and methods
 	old_inside_fn_arg := c.inside_fn_arg


### PR DESCRIPTION
This PR fixed an inappropriate variable name.

```v
	// If the left expr has an or_block, it needs to be checked for legal or_block statement.
	return_type := c.expr(mut node.left)
	c.check_expr_opt_call(node.left, return_type)
```

==>

```v
	// If the left expr has an or_block, it needs to be checked for legal or_block statement.
	left_type := c.expr(mut node.left)
	c.check_expr_opt_call(node.left, left_type)
```