### PR TITLE
arrays: fix examples for `find_first` and `find_last`

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -681,7 +681,7 @@ pub fn carray_to_varray[T](c_array_data voidptr, items int) []T {
 
 // find_first returns the first element that matches the given predicate
 // returns `none`, if there is no match found
-// Example: arrays.find_first([1, 2, 3, 4, 5], fn (arr int) bool { arr == 3}) // => 3
+// Example: arrays.find_first([1, 2, 3, 4, 5], fn (i int) bool { return i == 3 })? // => 3
 pub fn find_first[T](array []T, predicate fn (elem T) bool) ?T {
 	if array.len == 0 {
 		return none
@@ -696,7 +696,7 @@ pub fn find_first[T](array []T, predicate fn (elem T) bool) ?T {
 
 // find_last returns the last element that matches the given predicate
 // returns `none`, if there is no match found
-// Example: arrays.find_last([1, 2, 3, 4, 5], fn (arr int) bool { arr == 3}) // => 3
+// Example: arrays.find_last([1, 2, 3, 4, 5], fn (i int) bool { return i == 3})? // => 3
 pub fn find_last[T](array []T, predicate fn (elem T) bool) ?T {
 	if array.len == 0 {
 		return none


### PR DESCRIPTION
Fixes not working examples and suboptimal naming of array elements as `arr` in the two mentioned `arrays` module examples.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04d6f32</samp>

Improved the documentation of `arrays.find_first` and `arrays.find_last` by using better examples.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04d6f32</samp>

*  Update example code for `find_first` and `find_last` functions to use consistent and concise syntax ([link](https://github.com/vlang/v/pull/19153/files?diff=unified&w=0#diff-b7b2841a2601a108289f795e922710054cff56ff06212c11d40dd2a0346191dcL684-R684), [link](https://github.com/vlang/v/pull/19153/files?diff=unified&w=0#diff-b7b2841a2601a108289f795e922710054cff56ff06212c11d40dd2a0346191dcL699-R699))
