### PR TITLE
wasm: add -wasm-stack-top flag to compiler

### DIFF
--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -1321,7 +1321,7 @@ pub fn (mut g Gen) calculate_enum_fields() {
 }
 
 pub fn gen(files []&ast.File, table &ast.Table, out_name string, w_pref &pref.Preferences) {
-	stack_top := 1024 + (16 * 1024)
+	stack_top := w_pref.wasm_stack_top
 	mut g := &Gen{
 		table: table
 		pref: w_pref

--- a/vlib/v/help/build/build-wasm.txt
+++ b/vlib/v/help/build/build-wasm.txt
@@ -12,6 +12,10 @@ For more general build help, see also `v help build`.
       After compiling the WebAssembly module, execute wasm-validate to validate the module.
       Useful for debugging the compiler.
 
+   -wasm-stack-top
+      Overrides the default stack_top value used by the WebAssembly compiler.
+      Useful for some platforms with unusual memory requirements.
+
    -os <browser|wasi>, -target-os <browser|wasi>
       Change the target WebAssembly execution environment that V compiles for.
 

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -230,6 +230,7 @@ pub mut:
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 12
 	thread_stack_size                     int = 8388608 // Change with `-thread-stack-size 4194304`. Note: on macos it was 524288, which is too small for more complex programs with many nested callexprs.
+	wasm_stack_top                        int = 1024 + (16 * 1024) // stack size for webassembly backend
 	wasm_validate                         bool // validate webassembly code, by calling `wasm-validate`
 }
 
@@ -308,6 +309,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 		match arg {
 			'-wasm-validate' {
 				res.wasm_validate = true
+			}
+			'-wasm-stack-top' {
+				res.wasm_stack_top = cmdline.option(current_args, arg, res.wasm_stack_top.str()).int()
+				i++
 			}
 			'-apk' {
 				res.is_apk = true


### PR DESCRIPTION
This PR adds a new flag to the compiler that allows overriding the value used for the wasm stack_top. This fixes compatibility with some platforms such as [TIC-80](https://tic80.com/), as they have very specific memory layout requirements and by default V writes into reserved memory. If a compiler flag isn't the best way to do this please let me know, but I couldn't think of a better place to put it.