### PR TITLE
checker: disallow ptr assignments to consts with int literal vals

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -264,15 +264,15 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		node.left_types << left_type
 		match mut left {
 			ast.Ident {
-				if is_decl || left.kind == .blank_ident {
-					if left_type.is_ptr() && mut right is ast.PrefixExpr
-						&& right.right_type == ast.int_literal_type_idx {
-						if mut right.right is ast.Ident && right.right.obj is ast.ConstField {
-							c.error('cannot assign a pointer to a constant with an integer literal value',
-								right.right.pos)
-							c.add_error_detail('Specify the type for the constant value. Example:')
-							c.add_error_detail('         `const ${right.right.name.all_after_last('.')} = int(${(right.right.obj as ast.ConstField).expr})`')
-						}
+				if (is_decl || left.kind == .blank_ident) && left_type.is_ptr()
+					&& mut right is ast.PrefixExpr && right.right_type == ast.int_literal_type_idx {
+					if mut right.right is ast.Ident && right.right.obj is ast.ConstField {
+						const_name := right.right.name.all_after_last('.')
+						const_val := (right.right.obj as ast.ConstField).expr
+						c.error('cannot assign a pointer to a constant with an integer literal value',
+							right.right.pos)
+						c.add_error_detail('Specify the type for the constant value. Example:')
+						c.add_error_detail('         `const ${const_name} = int(${const_val})`')
 					}
 				}
 				if left.kind == .blank_ident {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -269,13 +269,12 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					if mut right.right is ast.Ident && right.right.obj is ast.ConstField {
 						const_name := right.right.name.all_after_last('.')
 						const_val := (right.right.obj as ast.ConstField).expr
-						c.error('cannot assign a pointer to a constant with an integer literal value',
-							right.right.pos)
 						c.add_error_detail('Specify the type for the constant value. Example:')
 						c.add_error_detail('         `const ${const_name} = int(${const_val})`')
+						c.error('cannot assign a pointer to a constant with an integer literal value',
+							right.right.pos)
 					}
-				}
-				if left.kind == .blank_ident {
+				} else if left.kind == .blank_ident {
 					left_type = right_type
 					node.left_types[i] = right_type
 					if node.op !in [.assign, .decl_assign] {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -289,6 +289,15 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							c.error('use of untyped nil in assignment (use `unsafe` | ${c.inside_unsafe})',
 								right.pos())
 						}
+						if mut right is ast.PrefixExpr && left_type.is_ptr()
+							&& right.right_type == ast.int_literal_type_idx {
+							if mut right.right is ast.Ident && right.right.obj is ast.ConstField {
+								c.error('cannot assign a pointer to a constant with an integer literal value',
+									right.right.pos)
+								c.add_error_detail('Specify the type for the constant value. Example:')
+								c.add_error_detail('         `const ${right.right.name.all_after_last('.')} = int(${(right.right.obj as ast.ConstField).expr})`')
+							}
+						}
 					}
 					mut ident_var_info := left.info as ast.IdentVar
 					if ident_var_info.share == .shared_t {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -264,6 +264,17 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		node.left_types << left_type
 		match mut left {
 			ast.Ident {
+				if is_decl || left.kind == .blank_ident {
+					if left_type.is_ptr() && mut right is ast.PrefixExpr
+						&& right.right_type == ast.int_literal_type_idx {
+						if mut right.right is ast.Ident && right.right.obj is ast.ConstField {
+							c.error('cannot assign a pointer to a constant with an integer literal value',
+								right.right.pos)
+							c.add_error_detail('Specify the type for the constant value. Example:')
+							c.add_error_detail('         `const ${right.right.name.all_after_last('.')} = int(${(right.right.obj as ast.ConstField).expr})`')
+						}
+					}
+				}
 				if left.kind == .blank_ident {
 					left_type = right_type
 					node.left_types[i] = right_type
@@ -288,15 +299,6 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							// }`
 							c.error('use of untyped nil in assignment (use `unsafe` | ${c.inside_unsafe})',
 								right.pos())
-						}
-						if mut right is ast.PrefixExpr && left_type.is_ptr()
-							&& right.right_type == ast.int_literal_type_idx {
-							if mut right.right is ast.Ident && right.right.obj is ast.ConstField {
-								c.error('cannot assign a pointer to a constant with an integer literal value',
-									right.right.pos)
-								c.add_error_detail('Specify the type for the constant value. Example:')
-								c.add_error_detail('         `const ${right.right.name.all_after_last('.')} = int(${(right.right.obj as ast.ConstField).expr})`')
-							}
 						}
 					}
 					mut ident_var_info := left.info as ast.IdentVar

--- a/vlib/v/checker/tests/assign_const_ptr_int_literal_err.out
+++ b/vlib/v/checker/tests/assign_const_ptr_int_literal_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv:4:2: warning: unused variable: `b`
+    2 |
+    3 | fn main() {
+    4 |     b := &a
+      |     ^
+    5 | }
+Details: Specify the type for the constant value. Example:
+         `const a = int(3)`
+vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv:4:8: error: cannot assign a pointer to a constant with an integer literal value
+    2 |
+    3 | fn main() {
+    4 |     b := &a
+      |           ^
+    5 | }

--- a/vlib/v/checker/tests/assign_const_ptr_int_literal_err.out
+++ b/vlib/v/checker/tests/assign_const_ptr_int_literal_err.out
@@ -1,14 +1,9 @@
-vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv:4:2: warning: unused variable: `b`
-    2 |
-    3 | fn main() {
-    4 |     b := &a
-      |     ^
-    5 | }
-Details: Specify the type for the constant value. Example:
-         `const a = int(3)`
 vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv:4:8: error: cannot assign a pointer to a constant with an integer literal value
-    2 |
+    2 | 
     3 | fn main() {
     4 |     b := &a
       |           ^
-    5 | }
+    5 |     dump(b)
+    6 | }
+Details: Specify the type for the constant value. Example:
+         `const a = int(3)`

--- a/vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv
+++ b/vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv
@@ -1,0 +1,5 @@
+const a = 3
+
+fn main() {
+	b := &a
+}

--- a/vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv
+++ b/vlib/v/checker/tests/assign_const_ptr_int_literal_err.vv
@@ -2,4 +2,5 @@ const a = 3
 
 fn main() {
 	b := &a
+	dump(b)
 }

--- a/vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.out
+++ b/vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.out
@@ -4,3 +4,5 @@ vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.vv:4:8: error: cannot
     4 |     _ := &a
       |           ^
     5 | }
+Details: Specify the type for the constant value. Example:
+         `const a = int(3)`

--- a/vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.out
+++ b/vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.vv:4:8: error: cannot assign a pointer to a constant with an integer literal value
+    2 | 
+    3 | fn main() {
+    4 |     _ := &a
+      |           ^
+    5 | }

--- a/vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.vv
+++ b/vlib/v/checker/tests/blank_ident_const_ptr_int_literal_err.vv
@@ -1,0 +1,5 @@
+const a = 3
+
+fn main() {
+	_ := &a
+}


### PR DESCRIPTION
fixes #19146 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c04366</samp>

Prevent assigning pointers to integer constants in the V compiler. Improve error message and suggestion for constant declarations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c04366</samp>

* Add a check to prevent assigning a pointer to a constant integer literal ([link](https://github.com/vlang/v/pull/19160/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR292-R300))
* Provide an error message and a suggestion to specify the type for the constant value ([link](https://github.com/vlang/v/pull/19160/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR292-R300))
