### PR TITLE
checker: check enum static from_string arguments errors (fix #19158)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -865,6 +865,15 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 			idx := c.table.type_idxs[full_enum_name]
 			ret_typ := ast.Type(idx).set_flag(.option)
+			if node.args.len != 1 {
+				c.error('expected 1 argument, but got ${node.args.len}', node.pos)
+			} else {
+				node.args[0].typ = c.expr(mut node.args[0].expr)
+				if node.args[0].typ != ast.string_type {
+					styp := c.table.type_to_str(node.args[0].typ)
+					c.error('expected `string` argument, but got `${styp}`', node.pos)
+				}
+			}
 			node.return_type = ret_typ
 			return ret_typ
 		}

--- a/vlib/v/checker/tests/enum_from_string_args_err.out
+++ b/vlib/v/checker/tests/enum_from_string_args_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/enum_from_string_args_err.vv:8:2: error: expected 1 argument, but got 0
+    6 |
+    7 | fn main() {
+    8 |     Color.from_string()
+      |     ~~~~~~~~~~~~~~~~~~~
+    9 |     Color.from_string('red', 'blue')
+   10 |     Color.from_string(22)
+vlib/v/checker/tests/enum_from_string_args_err.vv:9:2: error: expected 1 argument, but got 2
+    7 | fn main() {
+    8 |     Color.from_string()
+    9 |     Color.from_string('red', 'blue')
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   10 |     Color.from_string(22)
+   11 |     Color.from_string(22.22)
+vlib/v/checker/tests/enum_from_string_args_err.vv:10:2: error: expected `string` argument, but got `int literal`
+    8 |     Color.from_string()
+    9 |     Color.from_string('red', 'blue')
+   10 |     Color.from_string(22)
+      |     ~~~~~~~~~~~~~~~~~~~~~
+   11 |     Color.from_string(22.22)
+   12 |     Color.from_string(true)
+vlib/v/checker/tests/enum_from_string_args_err.vv:11:2: error: expected `string` argument, but got `float literal`
+    9 |     Color.from_string('red', 'blue')
+   10 |     Color.from_string(22)
+   11 |     Color.from_string(22.22)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+   12 |     Color.from_string(true)
+   13 | }
+vlib/v/checker/tests/enum_from_string_args_err.vv:12:2: error: expected `string` argument, but got `bool`
+   10 |     Color.from_string(22)
+   11 |     Color.from_string(22.22)
+   12 |     Color.from_string(true)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+   13 | }

--- a/vlib/v/checker/tests/enum_from_string_args_err.vv
+++ b/vlib/v/checker/tests/enum_from_string_args_err.vv
@@ -1,0 +1,13 @@
+enum Color {
+	red
+	green
+	blue
+}
+
+fn main() {
+	Color.from_string()
+	Color.from_string('red', 'blue')
+	Color.from_string(22)
+	Color.from_string(22.22)
+	Color.from_string(true)
+}


### PR DESCRIPTION
This PR check enum static from_string arguments errors (fix #19158).

- Check enum static from_string arguments errors.
- Add test.

```v
enum Color {
	red
	green
	blue
}

fn main() {
	Color.from_string()
	Color.from_string('red', 'blue')
	Color.from_string(22)
	Color.from_string(22.22)
	Color.from_string(true)
}

PS D:\Test\v\tt1> v run .
tt1.v:8:2: error: expected 1 argument, but got 0
    6 |
    7 | fn main() {
    8 |     Color.from_string()
      |     ~~~~~~~~~~~~~~~~~~~
    9 |     Color.from_string('red', 'blue')
   10 |     Color.from_string(22)
tt1.v:9:2: error: expected 1 argument, but got 2
    7 | fn main() {
    8 |     Color.from_string()
    9 |     Color.from_string('red', 'blue')
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   10 |     Color.from_string(22)
   11 |     Color.from_string(22.22)
tt1.v:10:2: error: expected `string` argument, but got `int literal`
    8 |     Color.from_string()
    9 |     Color.from_string('red', 'blue')
   10 |     Color.from_string(22)
      |     ~~~~~~~~~~~~~~~~~~~~~
   11 |     Color.from_string(22.22)
   12 |     Color.from_string(true)
tt1.v:11:2: error: expected `string` argument, but got `float literal`
    9 |     Color.from_string('red', 'blue')
   10 |     Color.from_string(22)
   11 |     Color.from_string(22.22)
      |     ~~~~~~~~~~~~~~~~~~~~~~~~
   12 |     Color.from_string(true)
   13 | }
tt1.v:12:2: error: expected `string` argument, but got `bool`
   10 |     Color.from_string(22)
   11 |     Color.from_string(22.22)
   12 |     Color.from_string(true)
      |     ~~~~~~~~~~~~~~~~~~~~~~~
   13 | }
```