### PR TITLE
net.mbedtls: have shutdown close accepted connections too

### DIFF
--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -180,7 +180,6 @@ pub fn (mut l SSLListener) accept() !&SSLConn {
 	mut conn := &SSLConn{
 		config: l.config
 		opened: true
-		owns_socket: false
 	}
 
 	// TODO: save the client's IP address somewhere (maybe add a field to SSLConn ?)
@@ -189,6 +188,8 @@ pub fn (mut l SSLListener) accept() !&SSLConn {
 	if ret != 0 {
 		return error_with_code("can't accept connection", ret)
 	}
+	conn.handle = conn.server_fd.fd
+	conn.owns_socket = true
 
 	C.mbedtls_ssl_init(&conn.ssl)
 	C.mbedtls_ssl_config_init(&conn.conf)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

This PR changes `(SSLListener) accept()` in vlib/net/mbedtls/ssl_connection.v so that the client connection socket it creates will be closed by `(SSLConn) shutdown()`.

Without this change, `shutdown()` does not close connections created by `accept()` and clients that are designed to keep receiving (or sending) data until the server closes the connection will be left to time out. This makes it difficult to implement the Gemini protocol, for example.