### PR TITLE
cgen: fix using custom enum static from_string() (fix #19165)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1720,7 +1720,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			g.write('panic_debug(${paline}, tos3("${pafile}"), tos3("${pamod}"), tos3("${pafn}"),  ')
 			g.call_args(node)
 			g.write(')')
-		} else if node.name.ends_with('__static__from_string') {
+		} else if node.name.ends_with('__static__from_string') && !g.table.known_fn(node.name) {
 			if node.name !in g.str_fn_names {
 				g.gen_enum_static_from_string(node.name)
 				g.str_fn_names << node.name

--- a/vlib/v/tests/enum_custom_static_from_string_test.v
+++ b/vlib/v/tests/enum_custom_static_from_string_test.v
@@ -1,0 +1,14 @@
+enum Color {
+	red
+	green
+	blue
+}
+
+fn Color.from_string(x string) Color {
+	return Color.red
+}
+
+fn test_enum_custom_static_from_string() {
+	ret := Color.from_string('abc')
+	assert ret == Color.red
+}


### PR DESCRIPTION
This PR fix using custom enum static from_string() (fix #19165).

- Fix using custom enum static from_string().
- Add test.

```v
enum Color {
	red
	green
	blue
}

fn Color.from_string(x string) Color {
	return Color.red
}

fn main() {
	ret := Color.from_string('abc')
	println(ret)
	assert ret == Color.red
}

PS D:\Test\v\tt1> v run .
red
```