### PR TITLE
orm: add OR in where on update and delete

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -321,7 +321,11 @@ pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKin
 				str += ')'
 			}
 			if i < where.fields.len - 1 {
-				str += ' AND '
+				if where.is_and[i] {
+					str += ' AND '
+				} else {
+					str += ' OR '
+				}
 			}
 		}
 	}

--- a/vlib/orm/orm_fn_test.v
+++ b/vlib/orm/orm_fn_test.v
@@ -1,7 +1,7 @@
 import orm
 
 fn test_orm_stmt_gen_update() {
-	query, _ := orm.orm_stmt_gen(.default, 'Test', "'", .update, true, '?', 0, orm.QueryData{
+	query_and, _ := orm.orm_stmt_gen(.default, 'Test', "'", .update, true, '?', 0, orm.QueryData{
 		fields: ['test', 'a']
 		data: []
 		types: []
@@ -13,7 +13,21 @@ fn test_orm_stmt_gen_update() {
 		kinds: [.ge, .eq]
 		is_and: [true]
 	})
-	assert query == "UPDATE 'Test' SET 'test' = ?0, 'a' = ?1 WHERE 'id' >= ?2 AND 'name' = ?3;"
+	assert query_and == "UPDATE 'Test' SET 'test' = ?0, 'a' = ?1 WHERE 'id' >= ?2 AND 'name' = ?3;"
+
+	query_or, _ := orm.orm_stmt_gen(.default, 'Test', "'", .update, true, '?', 0, orm.QueryData{
+		fields: ['test', 'a']
+		data: []
+		types: []
+		kinds: []
+	}, orm.QueryData{
+		fields: ['id', 'name']
+		data: []
+		types: []
+		kinds: [.ge, .eq]
+		is_and: [false]
+	})
+	assert query_or == "UPDATE 'Test' SET 'test' = ?0, 'a' = ?1 WHERE 'id' >= ?2 OR 'name' = ?3;"
 }
 
 fn test_orm_stmt_gen_insert() {
@@ -27,7 +41,7 @@ fn test_orm_stmt_gen_insert() {
 }
 
 fn test_orm_stmt_gen_delete() {
-	query, _ := orm.orm_stmt_gen(.default, 'Test', "'", .delete, true, '?', 0, orm.QueryData{
+	query_and, _ := orm.orm_stmt_gen(.default, 'Test', "'", .delete, true, '?', 0, orm.QueryData{
 		fields: ['test', 'a']
 		data: []
 		types: []
@@ -39,7 +53,21 @@ fn test_orm_stmt_gen_delete() {
 		kinds: [.ge, .eq]
 		is_and: [true]
 	})
-	assert query == "DELETE FROM 'Test' WHERE 'id' >= ?0 AND 'name' = ?1;"
+	assert query_and == "DELETE FROM 'Test' WHERE 'id' >= ?0 AND 'name' = ?1;"
+
+	query_or, _ := orm.orm_stmt_gen(.default, 'Test', "'", .delete, true, '?', 0, orm.QueryData{
+		fields: ['test', 'a']
+		data: []
+		types: []
+		kinds: []
+	}, orm.QueryData{
+		fields: ['id', 'name']
+		data: []
+		types: []
+		kinds: [.ge, .eq]
+		is_and: [false]
+	})
+	assert query_or == "DELETE FROM 'Test' WHERE 'id' >= ?0 OR 'name' = ?1;"
 }
 
 fn get_select_fields() []string {

--- a/vlib/orm/orm_fn_test.v
+++ b/vlib/orm/orm_fn_test.v
@@ -11,6 +11,7 @@ fn test_orm_stmt_gen_update() {
 		data: []
 		types: []
 		kinds: [.ge, .eq]
+		is_and: [true]
 	})
 	assert query == "UPDATE 'Test' SET 'test' = ?0, 'a' = ?1 WHERE 'id' >= ?2 AND 'name' = ?3;"
 }
@@ -36,6 +37,7 @@ fn test_orm_stmt_gen_delete() {
 		data: []
 		types: []
 		kinds: [.ge, .eq]
+		is_and: [true]
 	})
 	assert query == "DELETE FROM 'Test' WHERE 'id' >= ?0 AND 'name' = ?1;"
 }


### PR DESCRIPTION
orm: fix missing generation of OR operator in update and delete queries

It seems that the OR operator was not included in the where statements of update and delete queries on the orm rewrite 2 years ago.

By default all statements in WHERE where coupled with AND operators. If any existing code with the orm was written it will need to be adjusted like I did in the tests.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a01d2ed</samp>

This pull request enhances the `orm` module by allowing OR conditions in the where clause of queries. It also adds tests for this feature in `vlib/orm/orm_fn_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a01d2ed</samp>

*  Add support for OR conditions in the where clause of the orm query builder by checking the `is_and` array of the `where` struct ([link](https://github.com/vlang/v/pull/19172/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837L324-R328))
*  Add test cases for the OR condition in the `where` clause using different combinations of the `is_and` array in `orm_fn_test.v` ([link](https://github.com/vlang/v/pull/19172/files?diff=unified&w=0#diff-fbdfd1a0bc25a6e0a86658f0251a091cffe65b8f485b1e5b3ea02f75eaf045d6R14), [link](https://github.com/vlang/v/pull/19172/files?diff=unified&w=0#diff-fbdfd1a0bc25a6e0a86658f0251a091cffe65b8f485b1e5b3ea02f75eaf045d6R40))
