### PR TITLE
docs: add undocumented behavior

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3465,7 +3465,9 @@ fn fn1(s Foo) {
 
 #### Casting an interface
 
-We can test the underlying type of an interface using dynamic cast operators:
+We can test the underlying type of an interface using dynamic cast operators.
+> **Note**
+> Dynamic cast converts variable `s` into a pointer inside the `if` statemnts in this example:
 
 ```v oksyntax
 // interface-example.3 (continued from interface-example.1)

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3152,7 +3152,7 @@ pub fn say_hi() {
 ```
 All items inside a module can be used between the files of a module regardless of whether or
 not they are prefaced with the `pub` keyword.
-```v
+```v failcompile
 // myfile2.v
 module mymodule
 
@@ -6849,7 +6849,6 @@ sizeof
 spawn
 static
 struct
-thread
 true
 type
 typeof

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3150,6 +3150,17 @@ pub fn say_hi() {
 	println('hello from mymodule!')
 }
 ```
+All items inside a module can be used between the files of a module regardless of whether or
+not they're prefaced with the `pub` keyword.
+```v
+// myfile2.v
+module mymodule
+
+pub fn say_hi_and_bye() {
+	say_hi() // from myfile.v
+	println('goodbye from mymodule')
+}
+```
 
 You can now use `mymodule` in your code:
 
@@ -3158,6 +3169,7 @@ import mymodule
 
 fn main() {
 	mymodule.say_hi()
+	mymodule.say_hi_and_bye()
 }
 ```
 
@@ -6835,6 +6847,7 @@ sizeof
 spawn
 static
 struct
+thread
 true
 type
 typeof

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3151,7 +3151,7 @@ pub fn say_hi() {
 }
 ```
 All items inside a module can be used between the files of a module regardless of whether or
-not they're prefaced with the `pub` keyword.
+not they are prefaced with the `pub` keyword.
 ```v
 // myfile2.v
 module mymodule


### PR DESCRIPTION
Added "thread" to the list of keywords in the appendix. Added documentation for the undocumented behavior mentioned in #18207 (interface dynamic cast converting value variable to pointer) and #18196 (files in module share functions, structs, interfaces, types, etc.).