### PR TITLE
checker: fix const from comptime if expr (fix #19169)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1648,6 +1648,13 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 					field.expr.is_expr = true
 					field.expr.typ = (branch.stmts.last() as ast.ExprStmt).typ
 					field.typ = field.expr.typ
+					// update ConstField object's type in table
+					if mut obj := c.file.global_scope.find(field.name) {
+						if mut obj is ast.ConstField {
+							obj.typ = field.typ
+						}
+					}
+					break
 				}
 			}
 		}

--- a/vlib/v/tests/const_from_comptime_if_expr_test.v
+++ b/vlib/v/tests/const_from_comptime_if_expr_test.v
@@ -1,0 +1,20 @@
+import term
+
+const (
+	color = $if windows {
+		term.bright_cyan('WINDOWS')
+	} $else {
+		term.bright_green('UNIX')
+	}
+)
+
+fn test_const_from_comptime_if_expr() {
+	salutation := 'hello'
+	val := match salutation {
+		'hello' { color + ' some text' }
+		'goodbyte' { color + ' some other text' }
+		else { 'invalid' }
+	}
+	println(val)
+	assert true
+}


### PR DESCRIPTION
This PR fix const from comptime if expr (fix #19169).

- Fix const from comptime if expr.
- Add test.

```v
import term

const (
	color = $if windows {
		term.bright_cyan('WINDOWS')
	} $else {
		term.bright_green('UNIX')
	}
)

fn main() {
	salutation := 'hello'
	// works if you add `'' +` before 'color'
	val := match salutation {
		'hello' { color + ' some text' }
		'goodbyte' { color + ' some other text' }
		else { 'invalid' }
	}
	println(val)
	assert true
}

PS D:\Test\v\tt1> v run .
WINDOWS some text
```