### PR TITLE
compress: deprecate function names that are module name duplicates

### DIFF
--- a/cmd/tools/vcompress.v
+++ b/cmd/tools/vcompress.v
@@ -29,7 +29,7 @@ fn main() {
 	}
 	compressed := match compression_type {
 		.zlib {
-			zlib.compress(content) or {
+			zlib.pack(content) or {
 				eprintln('compression error: ${err}')
 				exit(1)
 			}

--- a/vlib/compress/compress.v
+++ b/vlib/compress/compress.v
@@ -8,10 +8,10 @@ pub const max_size = u64(1 << 31)
 fn C.tdefl_compress_mem_to_heap(source_buf voidptr, source_buf_len usize, out_len &usize, flags int) voidptr
 fn C.tinfl_decompress_mem_to_heap(source_buf voidptr, source_buf_len usize, out_len &usize, flags int) voidptr
 
-// compresses an array of bytes based on providing flags and returns the compressed bytes in a new array
+// pack compresses an array of bytes based on the given flags and returns the result in a new array
 // NB: this is a low level api, a high level implementation like zlib/gzip should be preferred
 [manualfree]
-pub fn compress(data []u8, flags int) ![]u8 {
+pub fn pack(data []u8, flags int) ![]u8 {
 	if u64(data.len) > compress.max_size {
 		return error('data too large (${data.len} > ${compress.max_size})')
 	}
@@ -27,10 +27,10 @@ pub fn compress(data []u8, flags int) ![]u8 {
 	return unsafe { address.vbytes(int(out_len)) }
 }
 
-// decompresses an array of bytes based on providing flags and returns the decompressed bytes in a new array
+// unpack decompresses an array of bytes based on the given flags and returns the result in a new array
 // NB: this is a low level api, a high level implementation like zlib/gzip should be preferred
 [manualfree]
-pub fn decompress(data []u8, flags int) ![]u8 {
+pub fn unpack(data []u8, flags int) ![]u8 {
 	mut out_len := usize(0)
 
 	address := C.tinfl_decompress_mem_to_heap(data.data, data.len, &out_len, flags)
@@ -41,4 +41,16 @@ pub fn decompress(data []u8, flags int) ![]u8 {
 		return error('decompressed data is too large (${out_len} > ${compress.max_size})')
 	}
 	return unsafe { address.vbytes(int(out_len)) }
+}
+
+[deprecated: 'use pack() instead']
+[deprecated_after: '2023-10-31']
+pub fn compress(data []u8, flags int) ![]u8 {
+	return pack(data, flags)
+}
+
+[deprecated: 'use unpack() instead']
+[deprecated_after: '2023-10-31']
+pub fn decompress(data []u8, flags int) ![]u8 {
+	return unpack(data, flags)
 }

--- a/vlib/compress/compress.v
+++ b/vlib/compress/compress.v
@@ -43,12 +43,16 @@ pub fn unpack(data []u8, flags int) ![]u8 {
 	return unsafe { address.vbytes(int(out_len)) }
 }
 
+// compress compresses an array of bytes based on the given flags and returns the result in a new array
+// NB: this is a low level api, a high level implementation like zlib/gzip should be preferred
 [deprecated: 'use pack() instead']
 [deprecated_after: '2023-10-31']
 pub fn compress(data []u8, flags int) ![]u8 {
 	return pack(data, flags)
 }
 
+// decompress decompresses an array of bytes based on the given flags and returns the result in a new array
+// NB: this is a low level api, a high level implementation like zlib/gzip should be preferred
 [deprecated: 'use unpack() instead']
 [deprecated_after: '2023-10-31']
 pub fn decompress(data []u8, flags int) ![]u8 {

--- a/vlib/compress/deflate/README.md
+++ b/vlib/compress/deflate/README.md
@@ -11,8 +11,8 @@ import compress.deflate
 
 fn main() {
 	uncompressed := 'Hello world!'
-	compressed := deflate.compress(uncompressed.bytes())!
-	decompressed := deflate.decompress(compressed)!
+	compressed := deflate.pack(uncompressed.bytes())!
+	decompressed := deflate.unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 ```

--- a/vlib/compress/deflate/deflate.v
+++ b/vlib/compress/deflate/deflate.v
@@ -2,14 +2,26 @@ module deflate
 
 import compress as compr
 
-// compresses an array of bytes using deflate and returns the compressed bytes in a new array
+// pack compresses an array of bytes using deflate and returns the result in a new array
 // Example: compressed := deflate.compress(b)!
-pub fn compress(data []u8) ![]u8 {
-	return compr.compress(data, 0)
+pub fn pack(data []u8) ![]u8 {
+	return compr.pack(data, 0)
 }
 
-// decompresses an array of bytes using deflate and returns the decompressed bytes in a new array
+// unpack decompresses an array of bytes using deflate and returns the result in a new array
 // Example: decompressed := deflate.decompress(b)!
+pub fn unpack(data []u8) ![]u8 {
+	return compr.unpack(data, 0)
+}
+
+[deprecated: 'use pack() instead']
+[deprecated_after: '2023-10-31']
+pub fn compress(data []u8) ![]u8 {
+	return pack(data)
+}
+
+[deprecated: 'use unpack() instead']
+[deprecated_after: '2023-10-31']
 pub fn decompress(data []u8) ![]u8 {
-	return compr.decompress(data, 0)
+	return unpack(data)
 }

--- a/vlib/compress/deflate/deflate.v
+++ b/vlib/compress/deflate/deflate.v
@@ -3,23 +3,27 @@ module deflate
 import compress as compr
 
 // pack compresses an array of bytes using deflate and returns the result in a new array
-// Example: compressed := deflate.compress(b)!
+// Example: compressed := deflate.pack(b)!
 pub fn pack(data []u8) ![]u8 {
 	return compr.pack(data, 0)
 }
 
 // unpack decompresses an array of bytes using deflate and returns the result in a new array
-// Example: decompressed := deflate.decompress(b)!
+// Example: decompressed := deflate.unpack(b)!
 pub fn unpack(data []u8) ![]u8 {
 	return compr.unpack(data, 0)
 }
 
+// pack compresses an array of bytes using deflate and returns the result in a new array
+// Example: compressed := deflate.compress(b)!
 [deprecated: 'use pack() instead']
 [deprecated_after: '2023-10-31']
 pub fn compress(data []u8) ![]u8 {
 	return pack(data)
 }
 
+// decompress decompresses an array of bytes using deflate and returns the result in a new array
+// Example: decompressed := deflate.decompress(b)!
 [deprecated: 'use unpack() instead']
 [deprecated_after: '2023-10-31']
 pub fn decompress(data []u8) ![]u8 {

--- a/vlib/compress/deflate/deflate_test.v
+++ b/vlib/compress/deflate/deflate_test.v
@@ -4,9 +4,9 @@ const gzip_magic_numbers = [u8(0x1f), 0x8b]
 
 fn test_gzip() {
 	uncompressed := 'Hello world!'
-	compressed := compress(uncompressed.bytes())!
+	compressed := pack(uncompressed.bytes())!
 	first2 := compressed[0..2]
 	assert first2 != deflate.gzip_magic_numbers
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }

--- a/vlib/compress/gzip/README.md
+++ b/vlib/compress/gzip/README.md
@@ -11,8 +11,8 @@ import compress.gzip
 
 fn main() {
 	uncompressed := 'Hello world!'
-	compressed := gzip.compress(uncompressed.bytes())!
-	decompressed := gzip.decompress(compressed)!
+	compressed := gzip.pack(uncompressed.bytes())!
+	decompressed := gzip.unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 ```

--- a/vlib/compress/gzip/gzip.v
+++ b/vlib/compress/gzip/gzip.v
@@ -7,7 +7,7 @@ import compress as compr
 import hash.crc32
 
 // pack compresses an array of bytes using gzip and returns the result in a new array
-// Example: compressed := gzip.compress(b)!
+// Example: compressed := gzip.pack(b)!
 pub fn pack(data []u8) ![]u8 {
 	compressed := compr.pack(data, 0)!
 	// header
@@ -134,7 +134,7 @@ pub fn validate(data []u8, params DecompressParams) !GzipHeader {
 }
 
 // unpack decompresses an array of bytes using zlib and returns the result in a new array
-// Example: decompressed := gzip.decompress(b)!
+// Example: decompressed := gzip.unpack(b)!
 pub fn unpack(data []u8, params DecompressParams) ![]u8 {
 	gzip_header := validate(data, params)!
 	header_length := gzip_header.length
@@ -152,12 +152,16 @@ pub fn unpack(data []u8, params DecompressParams) ![]u8 {
 	return decompressed
 }
 
+// compress compresses an array of bytes using gzip and returns the result in a new array
+// Example: compressed := gzip.compress(b)!
 [deprecated: 'use pack() instead']
 [deprecated_after: '2023-10-31']
 pub fn compress(data []u8) ![]u8 {
 	return pack(data)
 }
 
+// decompress decompresses an array of bytes using zlib and returns the result in a new array
+// Example: decompressed := gzip.decompress(b)!
 [deprecated: 'use unpack() instead']
 [deprecated_after: '2023-10-31']
 pub fn decompress(data []u8, params DecompressParams) ![]u8 {

--- a/vlib/compress/gzip/gzip.v
+++ b/vlib/compress/gzip/gzip.v
@@ -6,10 +6,10 @@ module gzip
 import compress as compr
 import hash.crc32
 
-// compresses an array of bytes using gzip and returns the compressed bytes in a new array
+// pack compresses an array of bytes using gzip and returns the result in a new array
 // Example: compressed := gzip.compress(b)!
-pub fn compress(data []u8) ![]u8 {
-	compressed := compr.compress(data, 0)!
+pub fn pack(data []u8) ![]u8 {
+	compressed := compr.pack(data, 0)!
 	// header
 	mut result := [
 		u8(0x1f), // magic numbers (1F 8B)
@@ -133,13 +133,13 @@ pub fn validate(data []u8, params DecompressParams) !GzipHeader {
 	return header
 }
 
-// decompresses an array of bytes using zlib and returns the decompressed bytes in a new array
+// unpack decompresses an array of bytes using zlib and returns the result in a new array
 // Example: decompressed := gzip.decompress(b)!
-pub fn decompress(data []u8, params DecompressParams) ![]u8 {
+pub fn unpack(data []u8, params DecompressParams) ![]u8 {
 	gzip_header := validate(data, params)!
 	header_length := gzip_header.length
 
-	decompressed := compr.decompress(data[header_length..data.len - 8], 0)!
+	decompressed := compr.unpack(data[header_length..data.len - 8], 0)!
 	length_expected := (u32(data[data.len - 4]) << 24) | (u32(data[data.len - 3]) << 16) | (u32(data[data.len - 2]) << 8) | data[data.len - 1]
 	if params.verify_length && decompressed.len != length_expected {
 		return error('length verification failed, got ${decompressed.len}, expected ${length_expected}')
@@ -150,4 +150,16 @@ pub fn decompress(data []u8, params DecompressParams) ![]u8 {
 		return error('checksum verification failed')
 	}
 	return decompressed
+}
+
+[deprecated: 'use pack() instead']
+[deprecated_after: '2023-10-31']
+pub fn compress(data []u8) ![]u8 {
+	return pack(data)
+}
+
+[deprecated: 'use unpack() instead']
+[deprecated_after: '2023-10-31']
+pub fn decompress(data []u8, params DecompressParams) ![]u8 {
+	return unpack(data, params)
 }

--- a/vlib/compress/gzip/gzip_test.v
+++ b/vlib/compress/gzip/gzip_test.v
@@ -4,13 +4,13 @@ import hash.crc32
 
 fn test_gzip() {
 	uncompressed := 'Hello world!'
-	compressed := compress(uncompressed.bytes())!
-	decompressed := decompress(compressed)!
+	compressed := pack(uncompressed.bytes())!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn assert_decompress_error(data []u8, reason string) ! {
-	decompress(data) or {
+	unpack(data) or {
 		assert err.msg() == reason
 		return
 	}
@@ -34,37 +34,37 @@ fn test_gzip_invalid_compression() {
 
 fn test_gzip_with_ftext() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= ftext
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn test_gzip_with_fname() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= fname
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
 	compressed.insert(12, 0x00)
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn test_gzip_with_fcomment() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= fcomment
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
 	compressed.insert(12, 0x00)
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn test_gzip_with_fname_fcomment() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= (fname | fcomment)
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
@@ -72,37 +72,37 @@ fn test_gzip_with_fname_fcomment() {
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
 	compressed.insert(12, 0x00)
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn test_gzip_with_fextra() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= fextra
 	compressed.insert(10, 2)
 	compressed.insert(11, `h`)
 	compressed.insert(12, `i`)
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn test_gzip_with_hcrc() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= fhcrc
 	checksum := crc32.sum(compressed[..10])
 	compressed.insert(10, u8(checksum >> 24))
 	compressed.insert(11, u8(checksum >> 16))
 	compressed.insert(12, u8(checksum >> 8))
 	compressed.insert(13, u8(checksum))
-	decompressed := decompress(compressed)!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 
 fn test_gzip_with_invalid_hcrc() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= fhcrc
 	checksum := crc32.sum(compressed[..10])
 	compressed.insert(10, u8(checksum >> 24))
@@ -114,21 +114,21 @@ fn test_gzip_with_invalid_hcrc() {
 
 fn test_gzip_with_invalid_checksum() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[compressed.len - 5] += 1
 	assert_decompress_error(compressed, 'checksum verification failed')!
 }
 
 fn test_gzip_with_invalid_length() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[compressed.len - 1] += 1
 	assert_decompress_error(compressed, 'length verification failed, got 12, expected 13')!
 }
 
 fn test_gzip_with_invalid_flags() {
 	uncompressed := 'Hello world!'
-	mut compressed := compress(uncompressed.bytes())!
+	mut compressed := pack(uncompressed.bytes())!
 	compressed[3] |= 0b1000_0000
 	assert_decompress_error(compressed, 'reserved flags are set, unsupported field detected')!
 }

--- a/vlib/compress/zlib/README.md
+++ b/vlib/compress/zlib/README.md
@@ -10,8 +10,8 @@ import compress.zlib
 
 fn main() {
 	uncompressed := 'Hello world!'
-	compressed := zlib.compress(uncompressed.bytes())!
-	decompressed := zlib.decompress(compressed)!
+	compressed := zlib.pack(uncompressed.bytes())!
+	decompressed := zlib.unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
 ```

--- a/vlib/compress/zlib/zlib.v
+++ b/vlib/compress/zlib/zlib.v
@@ -3,25 +3,29 @@ module zlib
 import compress as compr
 
 // pack compresses an array of bytes using zlib and returns the result in a new array
-// Example: compressed := zlib.compress(b)!
+// Example: compressed := zlib.pack(b)!
 pub fn pack(data []u8) ![]u8 {
 	// flags = TDEFL_WRITE_ZLIB_HEADER (0x01000)
 	return compr.pack(data, 0x01000)
 }
 
 // unpack decompresses an array of bytes using zlib and returns the result in a new array
-// Example: decompressed := zlib.decompress(b)!
+// Example: decompressed := zlib.unpack(b)!
 pub fn unpack(data []u8) ![]u8 {
 	// flags = TINFL_FLAG_PARSE_ZLIB_HEADER (0x1)
 	return compr.unpack(data, 0x1)
 }
 
+// compress decompresses an array of bytes using zlib and returns the result in a new array
+// Example: decompressed := zlib.decompress(b)!
 [deprecated: 'use pack() instead']
 [deprecated_after: '2023-10-31']
 pub fn compress(data []u8) ![]u8 {
 	return pack(data)
 }
 
+// decompress decompresses an array of bytes using zlib and returns the result in a new array
+// Example: decompressed := zlib.decompress(b)!
 [deprecated: 'use unpack() instead']
 [deprecated_after: '2023-10-31']
 pub fn decompress(data []u8) ![]u8 {

--- a/vlib/compress/zlib/zlib.v
+++ b/vlib/compress/zlib/zlib.v
@@ -2,16 +2,28 @@ module zlib
 
 import compress as compr
 
-// compresses an array of bytes using zlib and returns the compressed bytes in a new array
+// pack compresses an array of bytes using zlib and returns the result in a new array
 // Example: compressed := zlib.compress(b)!
-pub fn compress(data []u8) ![]u8 {
+pub fn pack(data []u8) ![]u8 {
 	// flags = TDEFL_WRITE_ZLIB_HEADER (0x01000)
-	return compr.compress(data, 0x01000)
+	return compr.pack(data, 0x01000)
 }
 
-// decompresses an array of bytes using zlib and returns the decompressed bytes in a new array
+// unpack decompresses an array of bytes using zlib and returns the result in a new array
 // Example: decompressed := zlib.decompress(b)!
-pub fn decompress(data []u8) ![]u8 {
+pub fn unpack(data []u8) ![]u8 {
 	// flags = TINFL_FLAG_PARSE_ZLIB_HEADER (0x1)
-	return compr.decompress(data, 0x1)
+	return compr.unpack(data, 0x1)
+}
+
+[deprecated: 'use pack() instead']
+[deprecated_after: '2023-10-31']
+pub fn compress(data []u8) ![]u8 {
+	return pack(data)
+}
+
+[deprecated: 'use unpack() instead']
+[deprecated_after: '2023-10-31']
+pub fn decompress(data []u8) ![]u8 {
+	return unpack(data)
 }

--- a/vlib/compress/zlib/zlib_test.v
+++ b/vlib/compress/zlib/zlib_test.v
@@ -2,7 +2,7 @@ module zlib
 
 fn test_zlib() {
 	uncompressed := 'Hello world!'
-	compressed := compress(uncompressed.bytes())!
-	decompressed := decompress(compressed)!
+	compressed := pack(uncompressed.bytes())!
+	decompressed := unpack(compressed)!
 	assert decompressed == uncompressed.bytes()
 }

--- a/vlib/v/embed_file/decoder.v
+++ b/vlib/v/embed_file/decoder.v
@@ -2,7 +2,7 @@
 module embed_file
 
 interface Decoder {
-	decompress([]u8) ![]u8
+	unpack([]u8) ![]u8
 }
 
 struct EmbedFileDecoders {

--- a/vlib/v/embed_file/embed_file.v
+++ b/vlib/v/embed_file/embed_file.v
@@ -66,7 +66,7 @@ pub fn (mut ed EmbedFileData) data() &u8 {
 			panic('EmbedFileData error: unknown compression of "${ed.path}": "${ed.compression_type}"')
 		}
 		compressed := unsafe { ed.compressed.vbytes(ed.len) }
-		decompressed := decoder.decompress(compressed) or {
+		decompressed := decoder.unpack(compressed) or {
 			panic('EmbedFileData error: decompression of "${ed.path}" failed: ${err}')
 		}
 		unsafe {

--- a/vlib/v/fmt/tests/do_not_change_type_names_that_just_happen_to_have_the_module_as_a_substring_keep.vv
+++ b/vlib/v/fmt/tests/do_not_change_type_names_that_just_happen_to_have_the_module_as_a_substring_keep.vv
@@ -7,9 +7,9 @@ import compress as z
 import hash.crc32
 
 // compresses an array of bytes using gzip and returns the compressed bytes in a new array
-// Example: compressed := gzip.compress(b)?
-pub fn compress(data []u8) ![]u8 {
-	compressed := compress.compress(data, 0)!
+// Example: compressed := gzip.pack(b)?
+pub fn pack(data []u8) ![]u8 {
+	compressed := compress.pack(data, 0)!
 	// header
 	mut result := [
 		u8(0x1f), // magic numbers (1F 8B)
@@ -134,12 +134,12 @@ pub fn validate(data []u8, params DecompressParams) !GzipHeader {
 }
 
 // decompresses an array of bytes using zlib and returns the decompressed bytes in a new array
-// Example: decompressed := gzip.decompress(b)?
-pub fn decompress(data []u8, params DecompressParams) ![]u8 {
+// Example: decompressed := gzip.unpack(b)?
+pub fn unpack(data []u8, params DecompressParams) ![]u8 {
 	gzip_header := validate(data, params)!
 	header_length := gzip_header.length
 
-	decompressed := compress.decompress(data[header_length..data.len - 8], 0)!
+	decompressed := compress.unpack(data[header_length..data.len - 8], 0)!
 	length_expected := (u32(data[data.len - 4]) << 24) | (u32(data[data.len - 3]) << 16) | (u32(data[data.len - 2]) << 8) | data[data.len - 1]
 	if params.verify_length && decompressed.len != length_expected {
 		return error('length verification failed, got ${decompressed.len}, expected ${length_expected}')

--- a/vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.c.must_have
+++ b/vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.c.must_have
@@ -3,8 +3,8 @@
 {1, { .str=(byteptr)("embed.vv"), .len=8, .is_lit=1 }, { .str=(byteptr)("none"), .len=4, .is_lit=1 }, (byteptr)_v_embed_blob_1},
 
 VV_LOCAL_SYMBOL void v__preludes__embed_file__zlib__init(void);
-VV_LOCAL_SYMBOL _result_Array_u8 v__preludes__embed_file__zlib__ZLibDecoder_decompress(v__preludes__embed_file__zlib__ZLibDecoder _d1, Array_u8 data) {
-= compress__zlib__decompress(data);
+VV_LOCAL_SYMBOL _result_Array_u8 v__preludes__embed_file__zlib__ZLibDecoder_unpack(v__preludes__embed_file__zlib__ZLibDecoder _d1, Array_u8 data) {
+= compress__zlib__unpack(data);
 
 res.compressed = v__embed_file__find_index_entry_by_path((voidptr)_v_embed_file_index, _SLIT("embed.vv"), _SLIT("zlib"))->data;
 res.compression_type = _SLIT("zlib");

--- a/vlib/v/preludes/embed_file/zlib/embed_file_zlib.v
+++ b/vlib/v/preludes/embed_file/zlib/embed_file_zlib.v
@@ -5,8 +5,8 @@ import v.embed_file
 
 struct ZLibDecoder {}
 
-fn (_ ZLibDecoder) decompress(data []u8) ![]u8 {
-	return zlib.decompress(data)
+fn (_ ZLibDecoder) unpack(data []u8) ![]u8 {
+	return zlib.unpack(data)
 }
 
 fn init() {


### PR DESCRIPTION
related to #18118 
discussed in https://discord.com/channels/592103645835821068/592320321995014154/1140736295161827401

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a965412</samp>

Renamed the `compress` module and its functions to `pack` and `unpack` for clarity and consistency. Updated the `gzip`, `deflate`, `zlib`, and `embed_file` modules and tools to use the new names and functions. Deprecated the old names and functions and provided backward compatibility wrappers.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a965412</samp>

*  Rename `compress` and `decompress` functions to `pack` and `unpack` in all compression modules and update their usage in other modules ([link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-06166d09fb91cc2744f36e7938c9dd1bda623e8064ecf7c5c532821d1d3264ccL32-R32), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-f68812df11d4e1224a451282c9c06a08103ac9b388522d2d972c68f7049ebe45L11-R14), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-f68812df11d4e1224a451282c9c06a08103ac9b388522d2d972c68f7049ebe45L30-R33), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-2f778c51141908254356a83b645cd711cace35145a951a83289f02979b97e0abL5-R26), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-5db13b5a3b39ec893d2de3d3bc14c67c720bf92dc4851755a54d73d5bbebeb7bL9-R12), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-5db13b5a3b39ec893d2de3d3bc14c67c720bf92dc4851755a54d73d5bbebeb7bL136-R142), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-2eae69a2719162c13df4514eb45567ecfb4df67fc611fea7c59c73373cc1eeffL5-R29), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-48e63396098b4102f351d744fcf536c74f6c7dfa7074375b75bff357820d297aL5-R5), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-63ba0a62d2812ae6ef8e6b43cbd0555fdeae99d38dbda4bd137add2207f8086bL69-R69), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-133ac7defb824ac722c66208354da52a3247d304310a5eac34dc894792160ce4L8-R9))
*  Mark old `compress` and `decompress` functions as deprecated and implement them as wrappers for the new functions, with a warning message and a removal date of 2023-10-31 ([link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-f68812df11d4e1224a451282c9c06a08103ac9b388522d2d972c68f7049ebe45R45-R56), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-2f778c51141908254356a83b645cd711cace35145a951a83289f02979b97e0abL5-R26), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-5db13b5a3b39ec893d2de3d3bc14c67c720bf92dc4851755a54d73d5bbebeb7bR154-R165), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-2eae69a2719162c13df4514eb45567ecfb4df67fc611fea7c59c73373cc1eeffL5-R29))
*  Change the name of the low-level `compress` module to `pack` to avoid confusion with the high-level compression modules ([link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-f68812df11d4e1224a451282c9c06a08103ac9b388522d2d972c68f7049ebe45L11-R14), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-f68812df11d4e1224a451282c9c06a08103ac9b388522d2d972c68f7049ebe45L30-R33), [link](https://github.com/vlang/v/pull/19180/files?diff=unified&w=0#diff-f68812df11d4e1224a451282c9c06a08103ac9b388522d2d972c68f7049ebe45R45-R56))
