### PR TITLE
vweb: avoid the controllers needs to be defined in specific order

### DIFF
--- a/vlib/vweb/tests/controller_test.v
+++ b/vlib/vweb/tests/controller_test.v
@@ -88,6 +88,16 @@ fn test_other_path() {
 	assert x.body == 'Other path'
 }
 
+fn test_other_hided_home() {
+	x := http.get('http://${localserver}/other/hide') or { panic(err) }
+	assert x.body == 'Other'
+}
+
+fn test_other_hided_path() {
+	x := http.get('http://${localserver}/other/hide/path') or { panic(err) }
+	assert x.body == 'Other path'
+}
+
 fn test_different_404() {
 	res_app := http.get('http://${localserver}/zxcnbnm') or { panic(err) }
 	assert res_app.status() == .not_found

--- a/vlib/vweb/tests/controller_test_server.v
+++ b/vlib/vweb/tests/controller_test_server.v
@@ -18,6 +18,10 @@ struct Other {
 	vweb.Context
 }
 
+struct OtherHidedByOther {
+	vweb.Context
+}
+
 fn exit_after_timeout(timeout_in_ms int) {
 	time.sleep(timeout_in_ms * time.millisecond)
 	println('>> webserver: pid: ${os.getpid()}, exiting ...')
@@ -38,6 +42,7 @@ fn main() {
 		controllers: [
 			vweb.controller('/admin', &Admin{}),
 			vweb.controller('/other', &Other{}),
+			vweb.controller('/other/hide', &OtherHidedByOther{}),
 		]
 	}
 
@@ -82,6 +87,16 @@ pub fn (mut app Other) other_home() vweb.Result {
 
 ['/path']
 pub fn (mut app Other) other_path() vweb.Result {
+	return app.text('Other path')
+}
+
+['/']
+pub fn (mut app OtherHidedByOther) other_home() vweb.Result {
+	return app.text('Other')
+}
+
+['/path']
+pub fn (mut app OtherHidedByOther) other_path() vweb.Result {
 	return app.text('Other path')
 }
 


### PR DESCRIPTION
This P/R allows the use of the controllers in VWeb without need to worry about the order in which you put them in the list. 

This should avoid user errors, and make it more easy to use VWeb controllers. 

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27c00f0</samp>

This pull request improves the vweb routing logic by fixing a bug and adding a new controller and test cases. It sorts the controllers by path length and checks for duplicate or conflicting paths. It also adds the `OtherHidedByOther` controller and tests it with the `/other/hide` and `/other/hide/path` routes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27c00f0</samp>

*  Fix a bug where controllers with longer paths could be shadowed by controllers with shorter paths that match a prefix of the longer path ([link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L525-R534),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R573),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L615-R622),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L683-R690),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L1080-R1089),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L1106-R1115))
* Add a new struct `OtherHidedByOther` to test the routing logic ([link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-0f564cbe4468a67876c25891075d15b6cf79140e2a07385f5611fe1e629274f2R21-R24),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-0f564cbe4468a67876c25891075d15b6cf79140e2a07385f5611fe1e629274f2R45),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-0f564cbe4468a67876c25891075d15b6cf79140e2a07385f5611fe1e629274f2R93-R102),[link](https://github.com/vlang/v/pull/19182/files?diff=unified&w=0#diff-41c157df4905c0f11c8ae76510bae2e74a0f95a266bd97196f0e5c415be691c2R91-R100))
