### PR TITLE
checker: check error for sumtype in array (fix #19170)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -190,6 +190,12 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 							for i, typ in node.right.expr_types {
 								c.ensure_type_exists(typ, node.right.exprs[i].pos())
 							}
+						} else {
+							elem_type := right_final_sym.array_info().elem_type
+							c.check_expected(left_type, elem_type) or {
+								c.error('left operand to `${node.op}` does not match the array element type: ${err.msg()}',
+									left_right_pos)
+							}
 						}
 					}
 				}

--- a/vlib/v/checker/tests/infix_sumtype_in_array_err.out
+++ b/vlib/v/checker/tests/infix_sumtype_in_array_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/infix_sumtype_in_array_err.vv:15:7: error: left operand to `in` does not match the array element type: expected `rune`, not `RuneAliasOrOtherType`
+   13 |     match x {
+   14 |         RuneAlias {
+   15 |             if x in whitespace {
+      |                ~~~~~~~~~~~~~~~
+   16 |                 // doing `if x as RuneAlias in whitepsace` here
+   17 |                 // works but it should be doing that automatically

--- a/vlib/v/checker/tests/infix_sumtype_in_array_err.vv
+++ b/vlib/v/checker/tests/infix_sumtype_in_array_err.vv
@@ -1,0 +1,25 @@
+struct OtherType {
+	foo string
+	bar string
+}
+
+type RuneAlias = rune
+type RuneAliasOrOtherType = OtherType | RuneAlias
+
+const whitespace = [rune(0x0009), 0x000a, 0x000c, 0x000d, 0x0020]
+
+fn main() {
+	mut x := RuneAliasOrOtherType(RuneAlias(rune(`!`)))
+	match x {
+		RuneAlias {
+			if x in whitespace {
+				// doing `if x as RuneAlias in whitepsace` here
+				// works but it should be doing that automatically
+				// since I'm inside the RuneAlias match condition.
+			}
+		}
+		else {
+			// do something else
+		}
+	}
+}


### PR DESCRIPTION
This PR check error for sumtype in array (fix #19170).

- Check error for sumtype in array.
- Add test.

```v
struct OtherType {
	foo string
	bar string
}

type RuneAlias = rune
type RuneAliasOrOtherType = OtherType | RuneAlias

const whitespace = [rune(0x0009), 0x000a, 0x000c, 0x000d, 0x0020]

fn main() {
	mut x := RuneAliasOrOtherType(RuneAlias(rune(`!`)))
	match x {
		RuneAlias {
			if x in whitespace {
				// doing `if x as RuneAlias in whitepsace` here
				// works but it should be doing that automatically
				// since I'm inside the RuneAlias match condition.
			}
		}
		else {
			// do something else
		}
	}
}

PS D:\Test\v\tt1> v run .       
tt1.v:15:7: error: left operand to `in` does not match the array element type: expected `rune`, not `RuneAliasOrOtherType`
   13 |     match x {
   14 |         RuneAlias {
   15 |             if x in whitespace {
      |                ~~~~~~~~~~~~~~~
   16 |                 // doing `if x as RuneAlias in whitepsace` here
   17 |                 // works but it should be doing that automatically
```