### PR TITLE
http: add support for stream connections, and custom .on_redirect, .on_progress, .on_finish callbacks to http.fetch() (#19184)

### DIFF
--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -45,3 +45,45 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	}
 	return parse_response(response_text)
 }
+
+fn (req &Request) ssl_do_stream(port int, method Method, host_name string, path string, cb StreamCallback) !Response {
+	mut ssl_conn := ssl.new_ssl_conn(
+		verify: req.verify
+		cert: req.cert
+		cert_key: req.cert_key
+		validate: req.validate
+		in_memory_verification: req.in_memory_verification
+	)!
+	ssl_conn.dial(host_name, port) or { return err }
+
+	req_headers := req.build_request_headers(method, host_name, path)
+	$if trace_http_request ? {
+		eprintln('> ${req_headers}')
+	}
+	// println(req_headers)
+	ssl_conn.write_string(req_headers) or { return err }
+
+	mut content := strings.new_builder(100)
+	mut buff := [bufsize]u8{}
+	bp := unsafe { &buff[0] }
+	mut readcounter := 0
+	for {
+		readcounter++
+		len := ssl_conn.socket_read_into_ptr(bp, bufsize) or { break }
+		$if debug_http ? {
+			eprintln('ssl_do, read ${readcounter:4d} | len: ${len}')
+			eprintln('-'.repeat(20))
+			eprintln(unsafe { tos(bp, len) })
+			eprintln('-'.repeat(20))
+		}
+		unsafe { content.write_ptr(bp, len) }
+		response_text := content.str()
+		cb(response_text)
+	}
+	ssl_conn.shutdown()!
+	response_text := content.str()
+	$if trace_http_response ? {
+		eprintln('< ${response_text}')
+	}
+	return parse_response(response_text)
+}

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -37,53 +37,17 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 			eprintln('-'.repeat(20))
 		}
 		unsafe { content.write_ptr(bp, len) }
-	}
-	ssl_conn.shutdown()!
-	response_text := content.str()
-	$if trace_http_response ? {
-		eprintln('< ${response_text}')
-	}
-	return parse_response(response_text)
-}
-
-fn (req &Request) ssl_do_stream(port int, method Method, host_name string, path string, cb StreamCallback) !Response {
-	mut ssl_conn := ssl.new_ssl_conn(
-		verify: req.verify
-		cert: req.cert
-		cert_key: req.cert_key
-		validate: req.validate
-		in_memory_verification: req.in_memory_verification
-	)!
-	ssl_conn.dial(host_name, port) or { return err }
-
-	req_headers := req.build_request_headers(method, host_name, path)
-	$if trace_http_request ? {
-		eprintln('> ${req_headers}')
-	}
-	// println(req_headers)
-	ssl_conn.write_string(req_headers) or { return err }
-
-	mut content := strings.new_builder(100)
-	mut buff := [bufsize]u8{}
-	bp := unsafe { &buff[0] }
-	mut readcounter := 0
-	for {
-		readcounter++
-		len := ssl_conn.socket_read_into_ptr(bp, bufsize) or { break }
-		$if debug_http ? {
-			eprintln('ssl_do, read ${readcounter:4d} | len: ${len}')
-			eprintln('-'.repeat(20))
-			eprintln(unsafe { tos(bp, len) })
-			eprintln('-'.repeat(20))
+		if req.on_progress != unsafe { nil } {
+			req.on_progress(req, content[content.len - len..], u64(content.len))
 		}
-		unsafe { content.write_ptr(bp, len) }
-		response_text := content.str()
-		cb(response_text)
 	}
 	ssl_conn.shutdown()!
 	response_text := content.str()
 	$if trace_http_response ? {
 		eprintln('< ${response_text}')
+	}
+	if req.on_finish != unsafe { nil } {
+		req.on_finish(req)
 	}
 	return parse_response(response_text)
 }

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -38,7 +38,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 		}
 		unsafe { content.write_ptr(bp, len) }
 		if req.on_progress != unsafe { nil } {
-			req.on_progress(req, content[content.len - len..], u64(content.len))
+			req.on_progress(req, content[content.len - len..], u64(content.len))!
 		}
 	}
 	ssl_conn.shutdown()!
@@ -47,7 +47,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 		eprintln('< ${response_text}')
 	}
 	if req.on_finish != unsafe { nil } {
-		req.on_finish(req, u64(response_text.len))
+		req.on_finish(req, u64(response_text.len))!
 	}
 	return parse_response(response_text)
 }

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -47,7 +47,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 		eprintln('< ${response_text}')
 	}
 	if req.on_finish != unsafe { nil } {
-		req.on_finish(req)
+		req.on_finish(req, u64(response_text.len))
 	}
 	return parse_response(response_text)
 }

--- a/vlib/net/http/backend_windows.c.v
+++ b/vlib/net/http/backend_windows.c.v
@@ -30,3 +30,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	}
 	return parse_response(response_text)
 }
+
+fn (req &Request) ssl_do_stream(port int, method Method, host_name string, path string, cb StreamCallback) !Response {
+	return error('https stream not supported on Windows')
+}

--- a/vlib/net/http/backend_windows.c.v
+++ b/vlib/net/http/backend_windows.c.v
@@ -32,7 +32,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 		eprintln('< ${response_text}')
 	}
 	if req.on_finish != unsafe { nil } {
-		req.on_finish(req)
+		req.on_finish(req, u64(response_text.len))
 	}
 	return parse_response(response_text)
 }

--- a/vlib/net/http/backend_windows.c.v
+++ b/vlib/net/http/backend_windows.c.v
@@ -26,13 +26,13 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	C.vschannel_cleanup(&ctx)
 	response_text := unsafe { buff.vstring_with_len(length) }
 	if req.on_progress != unsafe { nil } {
-		req.on_progress(req, unsafe { buff.vbytes(length) }, u64(length))
+		req.on_progress(req, unsafe { buff.vbytes(length) }, u64(length))!
 	}
 	$if trace_http_response ? {
 		eprintln('< ${response_text}')
 	}
 	if req.on_finish != unsafe { nil } {
-		req.on_finish(req, u64(response_text.len))
+		req.on_finish(req, u64(response_text.len))!
 	}
 	return parse_response(response_text)
 }

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -20,7 +20,8 @@ pub mut:
 	data       string
 	params     map[string]string
 	cookies    map[string]string
-	user_agent string = 'v.http'
+	user_agent string  = 'v.http'
+	user_ptr   voidptr = unsafe { nil }
 	verbose    bool
 	//
 	validate               bool   // set this to true, if you want to stop requests, when their certificates are found to be invalid
@@ -29,6 +30,10 @@ pub mut:
 	cert_key               string // the path to a key.pem file, containing private keys for the client certificate(s)
 	in_memory_verification bool   // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
+	// callbacks to allow custom reporting code to run, while the request is running
+	on_redirect RequestRedirectFn = unsafe { nil }
+	on_progress RequestProgressFn = unsafe { nil }
+	on_finish   RequestFinishFn   = unsafe { nil }
 }
 
 // new_request creates a new Request given the request `method`, `url_`, and
@@ -149,7 +154,7 @@ pub fn fetch(config FetchConfig) !Response {
 		header: config.header
 		cookies: config.cookies
 		user_agent: config.user_agent
-		user_ptr: 0
+		user_ptr: config.user_ptr
 		verbose: config.verbose
 		validate: config.validate
 		verify: config.verify
@@ -157,6 +162,9 @@ pub fn fetch(config FetchConfig) !Response {
 		cert_key: config.cert_key
 		in_memory_verification: config.in_memory_verification
 		allow_redirect: config.allow_redirect
+		on_progress: config.on_progress
+		on_redirect: config.on_redirect
+		on_finish: config.on_finish
 	}
 	res := req.do()!
 	return res

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -14,7 +14,7 @@ pub type RequestRedirectFn = fn (request &Request, nredirects int, new_url strin
 
 pub type RequestProgressFn = fn (request &Request, chunk []u8, read_so_far u64)
 
-pub type RequestFinishFn = fn (request &Request)
+pub type RequestFinishFn = fn (request &Request, final_size u64)
 
 // Request holds information about an HTTP request (either received by
 // a server or to be sent by a client)
@@ -184,7 +184,7 @@ fn (req &Request) http_do(host string, method Method, path string) !Response {
 		eprintln('< ${response_text}')
 	}
 	if req.on_finish != unsafe { nil } {
-		req.on_finish(req)
+		req.on_finish(req, u64(response_text.len))
 	}
 	return parse_response(response_text)
 }

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -127,14 +127,16 @@ fn test_server_custom_handler() {
 			progress_calls.chunks << chunk
 			progress_calls.reads << read_so_far
 		}
-		on_finish: fn [mut progress_calls] (req &http.Request) {
-			eprintln('>>>>>>>> on_finish, req.url: ${req.url}')
+		on_finish: fn [mut progress_calls] (req &http.Request, final_size u64) {
+			eprintln('>>>>>>>> on_finish, req.url: ${req.url}, final_size: ${final_size}')
 			progress_calls.finished_was_called = true
+			progress_calls.final_size = final_size
 		}
 	)!
 	assert z.status_code == 200
 	assert z.body.starts_with('xyz')
 	assert z.body.len > 10000
+	assert progress_calls.final_size > 80_000
 	assert progress_calls.finished_was_called
 	assert progress_calls.chunks.len > 1
 	assert progress_calls.reads.len > 1
@@ -158,4 +160,5 @@ mut:
 	reads               []u64
 	finished_was_called bool
 	redirected_to       []string
+	final_size          u64
 }

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -119,18 +119,18 @@ fn test_server_custom_handler() {
 	z := http.fetch(
 		url: big_url
 		user_ptr: progress_calls
-		on_redirect: fn (req &http.Request, nredirects int, new_url string) {
+		on_redirect: fn (req &http.Request, nredirects int, new_url string) ! {
 			mut progress_calls := unsafe { &ProgressCalls(req.user_ptr) }
 			eprintln('>>>>>>>> on_redirect, req.url: ${req.url} | new_url: ${new_url} | nredirects: ${nredirects}')
 			progress_calls.redirected_to << new_url
 		}
-		on_progress: fn (req &http.Request, chunk []u8, read_so_far u64) {
+		on_progress: fn (req &http.Request, chunk []u8, read_so_far u64) ! {
 			mut progress_calls := unsafe { &ProgressCalls(req.user_ptr) }
 			eprintln('>>>>>>>> on_progress, req.url: ${req.url} | got chunk.len: ${chunk.len:5}, read_so_far: ${read_so_far:8}, chunk: ${chunk#[0..30].bytestr()}')
 			progress_calls.chunks << chunk
 			progress_calls.reads << read_so_far
 		}
-		on_finish: fn (req &http.Request, final_size u64) {
+		on_finish: fn (req &http.Request, final_size u64) ! {
 			mut progress_calls := unsafe { &ProgressCalls(req.user_ptr) }
 			eprintln('>>>>>>>> on_finish, req.url: ${req.url}, final_size: ${final_size}')
 			progress_calls.finished_was_called = true

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -52,6 +52,7 @@ mut:
 	counter    int
 	oks        int
 	not_founds int
+	redirects  int
 }
 
 fn (mut handler MyHttpHandler) handle(req http.Request) http.Response {
@@ -63,6 +64,17 @@ fn (mut handler MyHttpHandler) handle(req http.Request) http.Response {
 	}
 	match req.url.all_before('?') {
 		'/endpoint', '/another/endpoint' {
+			r.set_status(.ok)
+			handler.oks++
+		}
+		'/redirect_to_big' {
+			r.header = http.new_header(key: .location, value: '/big')
+			r.status_msg = 'Moved permanently'
+			r.status_code = 301
+			handler.redirects++
+		}
+		'/big' {
+			r.body = 'xyz def '.repeat(10_000)
 			r.set_status(.ok)
 			handler.oks++
 		}
@@ -101,9 +113,49 @@ fn test_server_custom_handler() {
 	assert y.http_version == '1.1'
 	//
 	http.fetch(url: 'http://localhost:${cport}/something/else')!
+	//
+	big_url := 'http://localhost:${cport}/redirect_to_big'
+	mut progress_calls := &ProgressCalls{}
+	z := http.fetch(
+		url: big_url
+		on_redirect: fn [mut progress_calls] (req &http.Request, nredirects int, new_url string) {
+			eprintln('>>>>>>>> on_redirect, req.url: ${req.url} | new_url: ${new_url} | nredirects: ${nredirects}')
+			progress_calls.redirected_to << new_url
+		}
+		on_progress: fn [mut progress_calls] (req &http.Request, chunk []u8, read_so_far u64) {
+			eprintln('>>>>>>>> on_progress, req.url: ${req.url} | got chunk.len: ${chunk.len:5}, read_so_far: ${read_so_far:8}, chunk: ${chunk#[0..30].bytestr()}')
+			progress_calls.chunks << chunk
+			progress_calls.reads << read_so_far
+		}
+		on_finish: fn [mut progress_calls] (req &http.Request) {
+			eprintln('>>>>>>>> on_finish, req.url: ${req.url}')
+			progress_calls.finished_was_called = true
+		}
+	)!
+	assert z.status_code == 200
+	assert z.body.starts_with('xyz')
+	assert z.body.len > 10000
+	assert progress_calls.finished_was_called
+	assert progress_calls.chunks.len > 1
+	assert progress_calls.reads.len > 1
+	assert progress_calls.chunks[0].bytestr().starts_with('HTTP/1.1 301 Moved permanently')
+	assert progress_calls.chunks[1].bytestr().starts_with('HTTP/1.1 200 OK')
+	assert progress_calls.chunks.last().bytestr().contains('xyz def')
+	assert progress_calls.redirected_to == ['http://localhost:8198/big']
+	//
 	server.stop()
 	t.wait()
-	assert handler.counter == 3
-	assert handler.oks == 2
+	//
+	assert handler.counter == 5
+	assert handler.oks == 3
 	assert handler.not_founds == 1
+	assert handler.redirects == 1
+}
+
+struct ProgressCalls {
+mut:
+	chunks              [][]u8
+	reads               []u64
+	finished_was_called bool
+	redirected_to       []string
 }

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -118,16 +118,20 @@ fn test_server_custom_handler() {
 	mut progress_calls := &ProgressCalls{}
 	z := http.fetch(
 		url: big_url
-		on_redirect: fn [mut progress_calls] (req &http.Request, nredirects int, new_url string) {
+		user_ptr: progress_calls
+		on_redirect: fn (req &http.Request, nredirects int, new_url string) {
+			mut progress_calls := unsafe { &ProgressCalls(req.user_ptr) }
 			eprintln('>>>>>>>> on_redirect, req.url: ${req.url} | new_url: ${new_url} | nredirects: ${nredirects}')
 			progress_calls.redirected_to << new_url
 		}
-		on_progress: fn [mut progress_calls] (req &http.Request, chunk []u8, read_so_far u64) {
+		on_progress: fn (req &http.Request, chunk []u8, read_so_far u64) {
+			mut progress_calls := unsafe { &ProgressCalls(req.user_ptr) }
 			eprintln('>>>>>>>> on_progress, req.url: ${req.url} | got chunk.len: ${chunk.len:5}, read_so_far: ${read_so_far:8}, chunk: ${chunk#[0..30].bytestr()}')
 			progress_calls.chunks << chunk
 			progress_calls.reads << read_so_far
 		}
-		on_finish: fn [mut progress_calls] (req &http.Request, final_size u64) {
+		on_finish: fn (req &http.Request, final_size u64) {
+			mut progress_calls := unsafe { &ProgressCalls(req.user_ptr) }
 			eprintln('>>>>>>>> on_finish, req.url: ${req.url}, final_size: ${final_size}')
 			progress_calls.finished_was_called = true
 			progress_calls.final_size = final_size


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c8c583</samp>

This pull request adds a new feature to the `net.http` module, which allows performing HTTP requests with a streaming interface. It implements a new function `ssl_do_stream` for HTTPS requests on Unix-like systems, and a new method `do_stream` for the `Request` struct, which uses the callback function to process the response data in chunks. It also handles redirects and URL parsing.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c8c583</samp>

*  Add a streaming interface for HTTP requests ([link](https://github.com/vlang/v/pull/19184/files?diff=unified&w=0#diff-1bedbf658beb0fe9b71b58b1c0adeef51b63357521a405fb6e5718a02b92aa74R48-R91), [link](https://github.com/vlang/v/pull/19184/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995R92-R155))
   - Implement a new function `ssl_do_stream` in `backend_nix.c.v` that performs a HTTPS request using the `ssl` module and passes the response data in chunks to a callback function ([link](https://github.com/vlang/v/pull/19184/files?diff=unified&w=0#diff-1bedbf658beb0fe9b71b58b1c0adeef51b63357521a405fb6e5718a02b92aa74R48-R91))
   - Add a new method `do_stream` to the `Request` struct in `request.v` that performs a HTTP request using the `method` and `url` fields and calls the `method_and_url_to_stream` function to dispatch the request to either `ssl_do_stream` or `http_do` depending on the URL scheme ([link](https://github.com/vlang/v/pull/19184/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995R92-R155))
   - Handle redirects by following the `location` header of the response, up to a maximum number of redirects, in the `do_stream` method ([link](https://github.com/vlang/v/pull/19184/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995R92-R155))
