### PR TITLE
cgen: fix match with comptime if expr in branch (fix #19166)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -7,7 +7,8 @@ import v.ast
 
 fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
 	if node.is_expr && g.inside_ternary == 0 {
-		if g.is_autofree || node.typ.has_flag(.option) || node.typ.has_flag(.result) {
+		if g.is_autofree || node.typ.has_flag(.option) || node.typ.has_flag(.result)
+			|| node.is_comptime {
 			return true
 		}
 		for branch in node.branches {

--- a/vlib/v/tests/match_with_comptime_if_expr_in_branch_test.v
+++ b/vlib/v/tests/match_with_comptime_if_expr_in_branch_test.v
@@ -1,0 +1,19 @@
+fn test_match_with_comptime_if_expr_in_branch() {
+	x := match 'green' {
+		'red' {
+			'color is red'
+		}
+		'green' {
+			$if windows {
+				'color is green windows'
+			} $else {
+				'color is green unix'
+			}
+		}
+		else {
+			'nothing to say'
+		}
+	}
+	println(x)
+	assert true
+}


### PR DESCRIPTION
This PR fix match with comptime if expr in branch (fix #19166).

- Fix match with comptime if expr in branch.
- Add test.

```v
fn main() {
	x := match 'green' {
		'red' {
			'color is red'
		}
		'green' {
			$if windows {
				'color is green windows'
			} $else {
				'color is green unix'
			}
		}
		else {
			'nothing to say'
		}
	}
	println(x)
}

PS D:\Test\v\tt1> v run .       
color is green windows
```