### PR TITLE
gg, sokol.sapp: fix typo (.files_droped -> .files_dropped)

### DIFF
--- a/examples/gg/drag_n_drop.v
+++ b/examples/gg/drag_n_drop.v
@@ -41,7 +41,7 @@ fn main() {
 
 fn my_event_manager(mut ev gg.Event, mut app App) {
 	// drag&drop event
-	if ev.typ == .files_droped {
+	if ev.typ == .files_dropped {
 		num_dropped := sapp.get_num_dropped_files()
 		app.dropped_file_list.clear()
 		for i in 0 .. num_dropped {

--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -730,7 +730,7 @@ fn my_event_manager(mut ev gg.Event, mut app App) {
 	}
 
 	// drag&drop
-	if ev.typ == .files_droped {
+	if ev.typ == .files_dropped {
 		app.state = .scanning
 		// set logo texture during scanning
 		show_logo(mut app)

--- a/vlib/gg/gg.js.v
+++ b/vlib/gg/gg.js.v
@@ -28,7 +28,7 @@ pub enum DOMEventType {
 	update_cursor
 	quit_requested
 	clipboard_pasted
-	files_droped
+	files_dropped
 	num
 }
 

--- a/vlib/gg/gg.js.v
+++ b/vlib/gg/gg.js.v
@@ -30,6 +30,7 @@ pub enum DOMEventType {
 	clipboard_pasted
 	files_dropped
 	num
+	files_droped  [deprecated: 'use files_dropped instead'; deprecated_after: '2023-08-21']
 }
 
 pub struct Event {

--- a/vlib/sokol/sapp/enums.c.v
+++ b/vlib/sokol/sapp/enums.c.v
@@ -26,6 +26,7 @@ pub enum EventType {
 	clipboard_pasted
 	files_dropped
 	num
+	files_droped  [deprecated: 'use files_dropped instead'; deprecated_after: '2023-08-21']
 }
 
 pub enum MouseButton {

--- a/vlib/sokol/sapp/enums.c.v
+++ b/vlib/sokol/sapp/enums.c.v
@@ -24,7 +24,7 @@ pub enum EventType {
 	resumed
 	quit_requested
 	clipboard_pasted
-	files_droped
+	files_dropped
 	num
 }
 

--- a/vlib/sokol/sapp/sapp_funcs.c.v
+++ b/vlib/sokol/sapp/sapp_funcs.c.v
@@ -89,10 +89,10 @@ fn C.sapp_set_window_title(&char)
 // /* set the window icon (only on Windows and Linux) */
 // SOKOL_APP_API_DECL void sapp_set_icon(const sapp_icon_desc* icon_desc);
 
-// Get number of droped files
+// Get number of dropped files
 fn C.sapp_get_num_dropped_files() int
 
-// Get the file path of the droped file
+// Get the file path of the dropped file
 fn C.sapp_get_dropped_file_path(int) &u8
 
 // special run-function for SOKOL_NO_ENTRY (in standard mode this is an empty stub)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba2a689</samp>

This pull request fixes a spelling mistake in the event type name `files_dropped` across the `gg` and `sokol` modules and their examples. This improves the code consistency and compatibility with the sokol API.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba2a689</samp>

* Fix typo in event type name from `files_droped` to `files_dropped` in `gg` and `sapp` modules and examples ([link](https://github.com/vlang/v/pull/19190/files?diff=unified&w=0#diff-df737f19e552893434508161a989511772a5c04c959b3c794d3bf322d8ceee83L44-R44), [link](https://github.com/vlang/v/pull/19190/files?diff=unified&w=0#diff-13621febf1fb28bd64d26a2fa5e0434e670e432b7107e4f6896d531f4ee985c3L733-R733), [link](https://github.com/vlang/v/pull/19190/files?diff=unified&w=0#diff-1698b5d5fcb6bdb82d4d7b22e7d87b939b57964f5e9bb6e52ec4e5e01cbe1f9dL31-R31), [link](https://github.com/vlang/v/pull/19190/files?diff=unified&w=0#diff-75ecd1d1851c1f336a85e8e997c3e196c2dec9bbe27909bbc0dc1297439ad2e8L27-R27))
* Update comments of sokol API function declarations in `sapp_funcs.c.v` to match the corrected spelling ([link](https://github.com/vlang/v/pull/19190/files?diff=unified&w=0#diff-27b640b84ce2bb5563b1000984e88331ba5ff42f0b8571999b2735ae71c84c04L92-R95))
