### PR TITLE
cgen: fix comptime assign with generic result return type

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -804,7 +804,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 				unwrapped_typ = unaliased_type.clear_flags(.option, .result)
 			}
 		}
-		unwrapped_styp := g.typ(unwrapped_typ)
+		mut unwrapped_styp := g.typ(unwrapped_typ)
 		if g.infix_left_var_name.len > 0 {
 			g.indent--
 			g.writeln('}')
@@ -814,6 +814,11 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.write('\n ${cur_line}')
 		} else if !g.inside_curry_call {
 			if !g.inside_const_opt_or_res {
+				if g.assign_ct_type != 0
+					&& node.or_block.kind in [.propagate_option, .propagate_result] {
+					unwrapped_styp = g.typ(g.assign_ct_type.derive(node.return_type).clear_flags(.option,
+						.result))
+				}
 				g.write('\n ${cur_line} (*(${unwrapped_styp}*)${tmp_opt}.data)')
 			} else {
 				g.write('\n ${cur_line} ${tmp_opt}')

--- a/vlib/v/tests/comptime_generic_ret_test.v
+++ b/vlib/v/tests/comptime_generic_ret_test.v
@@ -1,0 +1,48 @@
+struct Parent {
+pub mut:
+	id    int
+	name  string
+	child Child
+	other Other
+}
+
+struct Child {
+pub mut:
+	id  int
+	age int
+}
+
+struct Other {
+pub mut:
+	id   int
+	name string
+}
+
+interface IdInterface {
+mut:
+	id int
+}
+
+fn insert_ids[T](val T) !T {
+	mut clone := val
+
+	$for field in T.fields {
+		$if field.typ is $struct {
+			clone.$(field.name) = insert_ids(val.$(field.name))!
+		}
+	}
+	$if T is IdInterface {
+		clone.id = 1
+	} $else {
+		return error('${T.name} does not have an id field!')
+	}
+	return clone
+}
+
+fn test_main() {
+	inserted := insert_ids(Parent{
+		name: 'test'
+	})!
+	assert inserted.child.id == 1
+	assert inserted.other.id == 1
+}


### PR DESCRIPTION
Fix #19191

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08057ca</samp>

Added support for comptime generic return types with or blocks in C code generation and added a test case for it. Modified `vlib/v/gen/c/fn.v` to handle the type consistency and error handling of this feature and `vlib/v/tests/comptime_generic_ret_test.v` to define and test some structs and an interface with an `id` field.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08057ca</samp>

* Make `unwrapped_styp` mutable to handle comptime generic return types ([link](https://github.com/vlang/v/pull/19192/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L807-R807))
* Reassign `unwrapped_styp` to derived type of `g.assign_ct_type` for or blocks with propagate or result kinds ([link](https://github.com/vlang/v/pull/19192/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9R817-R821))
* Add test case for `insert_ids` function with comptime generic return type in `vlib/v/tests/comptime_generic_ret_test.v` ([link](https://github.com/vlang/v/pull/19192/files?diff=unified&w=0#diff-04775622db39be358c0eb020890632138b75ef5d692f9baa23e96ce42a97484cR1-R48))
