### PR TITLE
cgen: allow constant as enum value

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1818,8 +1818,11 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 						if field.expr.language == .c {
 							continue
 						}
-						if field.expr.kind in [.constant, .unresolved] {
+						if field.expr.kind == .unresolved {
 							c.ident(mut field.expr)
+						}
+						if field.expr.kind == .constant && field.expr.obj.typ.is_int() {
+							/* accepts int constants as enum value */
 							continue
 						}
 					}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1818,6 +1818,10 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 						if field.expr.language == .c {
 							continue
 						}
+						if field.expr.kind in [.constant, .unresolved] {
+							c.ident(mut field.expr)
+							continue
+						}
 					}
 					mut pos := field.expr.pos()
 					if pos.pos == 0 {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3875,7 +3875,16 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 		if field.has_expr {
 			g.enum_typedefs.write_string(' = ')
 			expr_str := g.expr_string(field.expr)
-			g.enum_typedefs.write_string(expr_str)
+			if field.expr is ast.Ident && field.expr.kind == .constant {
+				const_def := g.global_const_defs[util.no_dots(field.expr.name)]
+				if const_def.def.starts_with('#define') {
+					g.enum_typedefs.write_string(const_def.def.all_after_last(' '))
+				} else {
+					g.enum_typedefs.write_string(expr_str)
+				}
+			} else {
+				g.enum_typedefs.write_string(expr_str)
+			}
 			cur_enum_expr = expr_str
 			cur_enum_offset = 0
 		} else if is_flag {

--- a/vlib/v/tests/const_as_enum_value_test.v
+++ b/vlib/v/tests/const_as_enum_value_test.v
@@ -1,0 +1,15 @@
+const (
+	first_const  = 1000
+	second_const = 2000
+)
+
+enum Test {
+	example = first_const
+}
+
+fn test_main() {
+	a := Test.example
+	dump(Test.example)
+	assert a == unsafe { Test(1000) }
+	assert Test.example == unsafe { Test(1000) }
+}


### PR DESCRIPTION
Fix #19115

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 065e34e</samp>

Fix issue #11176 with enum fields with constant expressions. Resolve the expressions in the checker and use the correct values in the code generation.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 065e34e</samp>

* Fix issue #11176 with enum fields with constant expressions ([link](https://github.com/vlang/v/pull/19193/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R1821-R1824), [link](https://github.com/vlang/v/pull/19193/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3878-R3887))
  * Resolve the expression of the enum field in `checker.v` if it is a constant or unresolved ([link](https://github.com/vlang/v/pull/19193/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R1821-R1824))
  * Use the value of the constant definition in `cgen.v` if the expression is an identifier from a C header file ([link](https://github.com/vlang/v/pull/19193/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3878-R3887))
