### PR TITLE
cgen: fix reference aliases of map/array/string (fix #19194)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4544,7 +4544,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 			g.expr_with_opt(node.expr, expr_type, (sym.info as ast.Alias).parent_type)
 		} else {
 			g.write('(${cast_label}(')
-			if sym.kind == .alias && g.table.final_sym(node.typ).kind == .string {
+			if sym.kind == .alias && g.table.final_sym(node.typ).kind in [.string, .map, .array] {
 				ptr_cnt := node.typ.nr_muls() - expr_type.nr_muls()
 				if ptr_cnt > 0 {
 					g.write('&'.repeat(ptr_cnt))

--- a/vlib/v/tests/ref_aliases_of_map_test.v
+++ b/vlib/v/tests/ref_aliases_of_map_test.v
@@ -3,22 +3,22 @@ type FooArr = []string
 type FooStr = string
 
 fn test_reference_aliases_of_map() {
-    addr1 := &FooMap(map[string]int{})
-	 println('${addr1:p}')
+	addr1 := &FooMap(map[string]int{})
+	println('${addr1:p}')
 
-	 assert true
+	assert true
 }
 
 fn test_reference_aliases_of_array() {
-	 addr2 := &FooArr([]string{})
-	 println('${addr2:p}')
+	addr2 := &FooArr([]string{})
+	println('${addr2:p}')
 
-	 assert true
+	assert true
 }
 
 fn test_reference_aliases_of_string() {
-	 addr3 := &FooStr('hello')
-	 println('${addr3:p}')
+	addr3 := &FooStr('hello')
+	println('${addr3:p}')
 
-	 assert true
+	assert true
 }

--- a/vlib/v/tests/ref_aliases_of_map_test.v
+++ b/vlib/v/tests/ref_aliases_of_map_test.v
@@ -1,0 +1,24 @@
+type FooMap = map[string]int
+type FooArr = []string
+type FooStr = string
+
+fn test_reference_aliases_of_map() {
+    addr1 := &FooMap(map[string]int{})
+	 println('${addr1:p}')
+
+	 assert true
+}
+
+fn test_reference_aliases_of_array() {
+	 addr2 := &FooArr([]string{})
+	 println('${addr2:p}')
+
+	 assert true
+}
+
+fn test_reference_aliases_of_string() {
+	 addr3 := &FooStr('hello')
+	 println('${addr3:p}')
+
+	 assert true
+}


### PR DESCRIPTION
This PR fix reference aliases of map/array/string (fix #19194).

- Fix reference aliases of map/array/string.
- Add test.

```v
type FooMap = map[string]int
type FooArr = []string
type FooStr = string

fn main() {
	addr1 := &FooMap(map[string]int{})
	println('${addr1:p}')

	addr2 := &FooArr([]string{})
	println('${addr2:p}')

	addr3 := &FooStr('hello')
	println('${addr3:p}')
}

PS D:\Test\v\tt1> v run .        
14dfde0
14dfd38
14dfca0
```