### PR TITLE
repl: don't add extra newlines on default imports

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -145,7 +145,7 @@ fn (r &Repl) import_to_source_code() []string {
 		if mod in r.alias {
 			import_str += ' as ${r.alias[mod]}'
 		}
-		imports_line << endline_if_missed(import_str)
+		imports_line << import_str
 	}
 	return imports_line
 }


### PR DESCRIPTION
I was tracing the contents of the source file generated by the repl and find out the first lines look like the following:

```
import os

import time

import math

...
```

This patch removes the unnecessary newlines