### PR TITLE
vpm: implement multithreading

### DIFF
--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -417,7 +417,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 	}
 	path_flag := if vcs[0] == 'hg' { '-R' } else { '-C' }
 	vcs_cmd := '${vcs[0]} ${path_flag} "${result.final_path}" ${supported_vcs_update_cmds[vcs[0]]}'
-	// verbose_println('    command: ${vcs_cmd}')
+	verbose_println('    command: ${vcs_cmd}')
 	vcs_res := os.execute('${vcs_cmd}')
 	if vcs_res.exit_code != 0 {
 		result.has_err = true
@@ -425,7 +425,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 		print_failed_cmd(vcs_cmd, vcs_res)
 		return result
 	} else {
-		// verbose_println('    ${vcs_res.output.trim_space()}')
+		verbose_println('    ${vcs_res.output.trim_space()}')
 		increment_module_download_count(zname) or {
 			result.has_err = true
 			eprintln('Errors while incrementing the download count for ${zname}:')

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -405,7 +405,6 @@ mut:
 fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 	mut result := ModUpdateInfo{
 		name: pp.get_item[string](idx)
-		has_err: false
 	}
 	zname := url_to_module_name(result.name)
 	result.final_path = valid_final_path_of_existing_module(result.name) or { return &result }
@@ -503,8 +502,6 @@ mut:
 fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	mut result := ModDateInfo{
 		name: pp.get_item[string](idx)
-		outdated: false
-		exec_err: false
 	}
 	final_module_path := valid_final_path_of_existing_module(result.name) or { return &result }
 	vcs := vcs_used_in_dir(final_module_path) or { return &result }

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -403,17 +403,17 @@ mut:
 }
 
 fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
-	mut result := ModUpdateInfo{
+	mut result := &ModUpdateInfo{
 		name: pp.get_item[string](idx)
 	}
 	zname := url_to_module_name(result.name)
-	result.final_path = valid_final_path_of_existing_module(result.name) or { return &result }
+	result.final_path = valid_final_path_of_existing_module(result.name) or { return result }
 	println('Updating module "${zname}" in "${result.final_path}" ...')
-	vcs := vcs_used_in_dir(result.final_path) or { return &result }
+	vcs := vcs_used_in_dir(result.final_path) or { return result }
 	if !ensure_vcs_is_installed(vcs[0]) {
 		result.has_err = true
 		println('VPM needs `${vcs}` to be installed.')
-		return &result
+		return result
 	}
 	path_flag := if vcs[0] == 'hg' { '-R' } else { '-C' }
 	vcs_cmd := '${vcs[0]} ${path_flag} "${result.final_path}" ${supported_vcs_update_cmds[vcs[0]]}'
@@ -423,7 +423,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 		result.has_err = true
 		println('Failed updating module "${zname}" in "${result.final_path}".')
 		print_failed_cmd(vcs_cmd, vcs_res)
-		return &result
+		return result
 	} else {
 		// verbose_println('    ${vcs_res.output.trim_space()}')
 		increment_module_download_count(zname) or {
@@ -431,7 +431,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 			eprintln('Errors while incrementing the download count for ${zname}:')
 		}
 	}
-	return &result
+	return result
 }
 
 fn vpm_update(m []string) {
@@ -500,11 +500,11 @@ mut:
 }
 
 fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
-	mut result := ModDateInfo{
+	mut result := &ModDateInfo{
 		name: pp.get_item[string](idx)
 	}
-	final_module_path := valid_final_path_of_existing_module(result.name) or { return &result }
-	vcs := vcs_used_in_dir(final_module_path) or { return &result }
+	final_module_path := valid_final_path_of_existing_module(result.name) or { return result }
+	vcs := vcs_used_in_dir(final_module_path) or { return result }
 	vcs_cmd_steps := supported_vcs_outdated_steps[vcs[0]]
 	mut outputs := []string{}
 	for step in vcs_cmd_steps {
@@ -515,12 +515,12 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 			verbose_println('Error command: ${cmd}')
 			verbose_println('Error details:\n${res.output}')
 			result.exec_err = true
-			return &result
+			return result
 		}
 		if vcs[0] == 'hg' {
 			if res.exit_code == 1 {
 				result.outdated = true
-				return &result
+				return result
 			}
 		} else {
 			outputs << res.output
@@ -529,7 +529,7 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	if vcs[0] == 'git' && outputs[1] != outputs[2] {
 		result.outdated = true
 	}
-	return &result
+	return result
 }
 
 fn get_outdated() ![]string {

--- a/cmd/tools/vpm.v
+++ b/cmd/tools/vpm.v
@@ -505,10 +505,11 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	}
 	final_module_path := valid_final_path_of_existing_module(result.name) or { return result }
 	vcs := vcs_used_in_dir(final_module_path) or { return result }
+	is_hg := vcs[0] == 'hg'
 	vcs_cmd_steps := supported_vcs_outdated_steps[vcs[0]]
 	mut outputs := []string{}
 	for step in vcs_cmd_steps {
-		path_flag := if vcs[0] == 'hg' { '-R' } else { '-C' }
+		path_flag := if is_hg { '-R' } else { '-C' }
 		cmd := '${vcs[0]} ${path_flag} "${final_module_path}" ${step}'
 		res := os.execute('${cmd}')
 		if res.exit_code < 0 {
@@ -517,7 +518,7 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 			result.exec_err = true
 			return result
 		}
-		if vcs[0] == 'hg' {
+		if is_hg {
 			if res.exit_code == 1 {
 				result.outdated = true
 				return result
@@ -526,7 +527,8 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 			outputs << res.output
 		}
 	}
-	if vcs[0] == 'git' && outputs[1] != outputs[2] {
+	// vcs[0] == 'git'
+	if !is_hg && outputs[1] != outputs[2] {
 		result.outdated = true
 	}
 	return result


### PR DESCRIPTION
Currently, it takes quite a while to scan for outdated modules and to update them.
The PR introduces a multi threaded approach that makes this procedure distinctively faster.

Verbose updates `v update -v` will remain as they are for now, since their printing needs special handling or even more so a re-imagining of this part of the vmp cli tool. I would like to suggest a hopefully nice approach for this separately at a later point. 

On master, a verbose update has the same execution time as the a regular update. So you can compare the difference on the PR branch without back and forth branch switches.
```
v update
v update -v
```
The outdated command would need to be compared on the separate branches.
```
v outdated
```


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0b22c0</samp>

This pull request enhances the vpm tool by parallelizing vcs operations, simplifying maps, and adding new structs for module data. These changes aim to improve the speed and reliability of vpm.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0b22c0</samp>

*  Import `sync.pool` module to enable parallel tasks ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R14))
*  Simplify vcs command maps by removing redundant vcs name ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L24-R38), [link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L234-R235), [link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L258-R259), [link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L418-R474))
*  Add vcs name and path flag to vcs commands to avoid changing working directory ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L234-R235), [link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L258-R259), [link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L418-R474))
*  Add `ModUpdateInfo` struct and `update_module` function to handle module updates in parallel ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166R398-R437))
*  Modify `vpm_update` function to use pool processor and `update_module` function, unless verbose flag is set ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L406-R465))
*  Add `ModDateInfo` struct and `get_mod_date_info` function to check module dates in parallel ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L440-R548))
*  Modify `get_outdated` function to use pool processor and `get_mod_date_info` function ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L440-R548))
*  Rename `modulename` variable to `name` for consistency ([link](https://github.com/vlang/v/pull/19208/files?diff=unified&w=0#diff-b809b4a6a7a38f515fae8531646fc8087d20dc360abac7b16f0f7627846cd166L433-R489))
