### PR TITLE
checker: check error for result/option call in assert statement (fix #19199)

### DIFF
--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -130,6 +130,7 @@ fn setup_symlink_windows(vexe string) {
 			set_reg_value(reg_sys_env_handle, 'Path', new_sys_env_path) or {
 				C.RegCloseKey(reg_sys_env_handle)
 				warn_and_exit(err.msg())
+				return
 			}
 			println('Done.')
 		}
@@ -138,6 +139,7 @@ fn setup_symlink_windows(vexe string) {
 			eprintln(err)
 			C.RegCloseKey(reg_sys_env_handle)
 			warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
+			return
 		}
 		C.RegCloseKey(reg_sys_env_handle)
 		println('Done.')

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -328,11 +328,13 @@ fn main() {
 		testroot := vroot + os.path_separator
 		tsession.skip_files << test_js_files.map(it.replace(testroot, ''))
 	}
-	testing.find_started_process('mysqld') or {
+	if _ := testing.find_started_process('mysqld') {
+	} else {
 		tsession.skip_files << 'vlib/db/mysql/mysql_orm_test.v'
 		tsession.skip_files << 'vlib/db/mysql/mysql_test.v'
 	}
-	testing.find_started_process('postgres') or {
+	if _ := testing.find_started_process('postgres') {
+	} else {
 		tsession.skip_files << 'vlib/db/pg/pg_orm_test.v'
 	}
 

--- a/examples/custom_error.v
+++ b/examples/custom_error.v
@@ -1,8 +1,14 @@
 import semver
 
 fn main() {
-	semver.from('asd') or { check_error(err) }
-	semver.from('') or { check_error(err) }
+	semver.from('asd') or {
+		check_error(err)
+		return
+	}
+	semver.from('') or {
+		check_error(err)
+		return
+	}
 }
 
 fn check_error(err IError) {

--- a/examples/database/orm.v
+++ b/examples/database/orm.v
@@ -146,10 +146,10 @@ fn psql_array() ! {
 	eprintln('------------ ${@METHOD} -----------------')
 	mut db := pg.connect(host: pg_host, user: pg_user, password: pg_pass, dbname: pg_db)!
 	defer {
-		db.exec_one('drop table if exists "Parent", "Child"') or { eprintln(err) }
+		db.exec_one('drop table if exists "Parent", "Child"') or { panic(err) }
 		db.close()
 	}
-	db.exec_one('drop table if exists "Parent", "Child"') or { eprintln(err) }
+	db.exec_one('drop table if exists "Parent", "Child"') or { panic(err) }
 
 	sql db {
 		create table Parent
@@ -220,12 +220,12 @@ fn msql() ! {
 		dbname: mysql_db
 	)!
 	defer {
-		conn.query('DROP TABLE IF EXISTS Module') or { eprintln(err) }
-		conn.query('DROP TABLE IF EXISTS User') or { eprintln(err) }
+		conn.query('DROP TABLE IF EXISTS Module') or { panic(err) }
+		conn.query('DROP TABLE IF EXISTS User') or { panic(err) }
 		conn.close()
 	}
-	conn.query('DROP TABLE IF EXISTS Module') or { eprintln(err) }
-	conn.query('DROP TABLE IF EXISTS User') or { eprintln(err) }
+	conn.query('DROP TABLE IF EXISTS Module') or { panic(err) }
+	conn.query('DROP TABLE IF EXISTS User') or { panic(err) }
 
 	sql conn {
 		create table Module
@@ -255,10 +255,10 @@ fn psql() ! {
 	eprintln('------------ ${@METHOD} -----------------')
 	mut db := pg.connect(host: pg_host, user: pg_user, password: pg_pass, dbname: pg_db)!
 	defer {
-		db.exec_one('drop table if exists "modules", "User"') or { eprintln(err) }
+		db.exec_one('drop table if exists "modules", "User"') or { panic(err) }
 		db.close()
 	}
-	db.exec_one('drop table if exists "modules", "User"') or { eprintln(err) }
+	db.exec_one('drop table if exists "modules", "User"') or { panic(err) }
 	sql db {
 		create table Module
 		create table User

--- a/examples/errors.v
+++ b/examples/errors.v
@@ -1,8 +1,14 @@
 import semver
 
 fn main() {
-	semver.from('asd') or { check_error(err) }
-	semver.from('') or { check_error(err) }
+	semver.from('asd') or {
+		check_error(err)
+		return
+	}
+	semver.from('') or {
+		check_error(err)
+		return
+	}
 }
 
 fn check_error(err IError) {

--- a/examples/file_list.v
+++ b/examples/file_list.v
@@ -11,7 +11,10 @@ fn main() {
 	}
 	for file in files {
 		if os.is_file(file) {
-			f.write_string(file + '\r\n') or { println(err) }
+			f.write_string(file + '\r\n') or {
+				println(err)
+				return
+			}
 		}
 	}
 	f.close()

--- a/vlib/crypto/bcrypt/bcrypt_test.v
+++ b/vlib/crypto/bcrypt/bcrypt_test.v
@@ -7,6 +7,7 @@ fn test_crypto_bcrypt() {
 
 	bcrypt.compare_hash_and_password('password2'.bytes(), hash.bytes()) or {
 		assert err.msg() == 'mismatched hash and password'
+		return
 	}
 
 	hash2 := bcrypt.generate_from_password('bb'.bytes(), 10) or { panic(err) }
@@ -15,6 +16,7 @@ fn test_crypto_bcrypt() {
 	bcrypt.compare_hash_and_password('bbb'.bytes(), hash2.bytes()) or {
 		hash2_must_mismatch = true
 		assert err.msg() == 'mismatched hash and password'
+		return
 	}
 
 	assert hash2_must_mismatch

--- a/vlib/crypto/md5/md5_test.v
+++ b/vlib/crypto/md5/md5_test.v
@@ -9,20 +9,38 @@ fn test_crypto_md5() {
 
 fn test_crypto_md5_writer() {
 	mut digest := md5.new()
-	digest.write('this is a'.bytes()) or { assert false }
-	digest.write(' md5 checksum.'.bytes()) or { assert false }
+	digest.write('this is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' md5 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.sum([])
 	assert sum.hex() == '6fb421ff99036547655984da12973431'
 }
 
 fn test_crypto_md5_writer_reset() {
 	mut digest := md5.new()
-	digest.write('this is a'.bytes()) or { assert false }
-	digest.write(' md5 checksum.'.bytes()) or { assert false }
+	digest.write('this is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' md5 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	_ = digest.sum([])
 	digest.reset()
-	digest.write('this is a'.bytes()) or { assert false }
-	digest.write(' md5 checksum.'.bytes()) or { assert false }
+	digest.write('this is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' md5 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.sum([])
 	assert sum.hex() == '6fb421ff99036547655984da12973431'
 }

--- a/vlib/crypto/sha1/sha1_test.v
+++ b/vlib/crypto/sha1/sha1_test.v
@@ -9,20 +9,38 @@ fn test_crypto_sha1() {
 
 fn test_crypto_sha1_writer() {
 	mut digest := sha1.new()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha1 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha1 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.sum([])
 	assert sum.hex() == 'e100d74442faa5dcd59463b808983c810a8eb5a1'
 }
 
 fn test_crypto_sha1_writer_reset() {
 	mut digest := sha1.new()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha1 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha1 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	_ = digest.sum([])
 	digest.reset()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha1 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha1 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.sum([])
 	assert sum.hex() == 'e100d74442faa5dcd59463b808983c810a8eb5a1'
 }

--- a/vlib/crypto/sha256/sha256_test.v
+++ b/vlib/crypto/sha256/sha256_test.v
@@ -9,20 +9,38 @@ fn test_crypto_sha256() {
 
 fn test_crypto_sha256_writer() {
 	mut digest := sha256.new()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha256 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha256 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.sum([])
 	assert sum.hex() == 'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
 }
 
 fn test_crypto_sha256_writer_reset() {
 	mut digest := sha256.new()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha256 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha256 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	_ = digest.sum([])
 	digest.reset()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha256 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha256 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.sum([])
 	assert sum.hex() == 'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
 }

--- a/vlib/crypto/sha512/sha512_test.v
+++ b/vlib/crypto/sha512/sha512_test.v
@@ -9,20 +9,38 @@ fn test_crypto_sha512() {
 
 fn test_crypto_sha512_writer() {
 	mut digest := sha512.new_digest(.sha512)
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha512 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha512 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.checksum()
 	assert sum.hex() == '4143e55fcba7e39b20f62a1368e5eb28f64a8859458886117ac66027832e0f9f5263daec688c439d2d0fa07059334668d39e59543039703dbb7e03ec9da7f8d7'
 }
 
 fn test_crypto_sha512_writer_reset() {
 	mut digest := sha512.new_digest(.sha512)
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha512 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha512 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	_ = digest.checksum()
 	digest.reset()
-	digest.write('This is a'.bytes()) or { assert false }
-	digest.write(' sha512 checksum.'.bytes()) or { assert false }
+	digest.write('This is a'.bytes()) or {
+		assert false
+		return
+	}
+	digest.write(' sha512 checksum.'.bytes()) or {
+		assert false
+		return
+	}
 	sum := digest.checksum()
 	assert sum.hex() == '4143e55fcba7e39b20f62a1368e5eb28f64a8859458886117ac66027832e0f9f5263daec688c439d2d0fa07059334668d39e59543039703dbb7e03ec9da7f8d7'
 }

--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -594,10 +594,12 @@ fn (mut fs FlagParser) find_existing_flag(fname string) !Flag {
 fn (mut fs FlagParser) handle_builtin_options() {
 	mut show_version := false
 	mut show_help := false
-	fs.find_existing_flag('help') or {
+	if _ := fs.find_existing_flag('help') {
+	} else {
 		show_help = fs.bool('help', `h`, false, fs.default_help_label)
 	}
-	fs.find_existing_flag('version') or {
+	if _ := fs.find_existing_flag('version') {
+	} else {
 		show_version = fs.bool('version', 0, false, fs.default_version_label)
 	}
 	if show_help {

--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -81,7 +81,7 @@ fn test_logger_mutable_reference() {
 	println(@FN + ' end')
 }
 
-fn test_level_from_tag() ? {
+fn test_level_from_tag() {
 	assert level_from_tag('INFO')? == .info
 	assert level_from_tag('FATAL')? == .fatal
 	assert level_from_tag('WARN')? == .warn
@@ -92,7 +92,10 @@ fn test_level_from_tag() ? {
 
 	for value in invalid {
 		mut passed := false
-		level_from_tag(value) or { passed = true }
+		level_from_tag(value) or {
+			passed = true
+			continue
+		}
 		assert passed
 	}
 }
@@ -106,7 +109,10 @@ fn test_target_from_label() ? {
 
 	for value in invalid {
 		mut passed := false
-		target_from_label(value) or { passed = true }
+		target_from_label(value) or {
+			passed = true
+			continue
+		}
 		assert passed
 	}
 }

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -29,7 +29,10 @@ pub struct GetTagsOptions {
 [if debug_html ?]
 fn (mut dom DocumentObjectModel) print_debug(data string) {
 	if data.len > 0 {
-		dom.debug_file.writeln(data) or { eprintln(err) }
+		dom.debug_file.writeln(data) or {
+			eprintln(err)
+			return
+		}
 	}
 }
 

--- a/vlib/net/http/chunked/dechunk_test.v
+++ b/vlib/net/http/chunked/dechunk_test.v
@@ -4,7 +4,7 @@ fn test_invalid_chunk() {
 	mut is_failure := false
 
 	decode('eee') or {
-		is_failure = true 
+		is_failure = true
 		assert true
 		return
 	}

--- a/vlib/net/http/chunked/dechunk_test.v
+++ b/vlib/net/http/chunked/dechunk_test.v
@@ -3,9 +3,12 @@ module chunked
 fn test_invalid_chunk() {
 	mut is_failure := false
 
-	decode('eee') or { is_failure = true }
-
-	assert is_failure
+	decode('eee') or {
+		is_failure = true 
+		assert true
+		return
+	}
+	assert false
 }
 
 fn test_valid_chunk() {

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -145,9 +145,7 @@ fn (mut w HandlerWorker) process_requests() {
 
 fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 	defer {
-		conn.close() or {
-			panic('close() failed: ${err}')
-		}
+		conn.close() or { panic('close() failed: ${err}') }
 	}
 
 	mut reader := io.new_buffered_reader(reader: conn)

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -145,7 +145,9 @@ fn (mut w HandlerWorker) process_requests() {
 
 fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 	defer {
-		conn.close() or { eprintln('close() failed: ${err}') }
+		conn.close() or {
+			panic('close() failed: ${err}')
+		}
 	}
 
 	mut reader := io.new_buffered_reader(reader: conn)
@@ -175,7 +177,10 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 		resp.header.set(.content_length, '${resp.body.len}')
 	}
 
-	conn.write(resp.bytes()) or { eprintln('error sending response: ${err}') }
+	conn.write(resp.bytes()) or {
+		eprintln('error sending response: ${err}')
+		return
+	}
 }
 
 // DebugHandler implements the Handler interface by echoing the request

--- a/vlib/net/tcp_self_dial_from_many_clients_test.v
+++ b/vlib/net/tcp_self_dial_from_many_clients_test.v
@@ -89,7 +89,10 @@ fn start_client(i int, shared ctx Context) {
 		ctx.ok_client_dials++
 	}
 	elog('client [${i}]: conn is connected, con.sock.handle: ${tcp_con.sock.handle}')
-	tcp_con.write([u8(i)]) or { elog('client [${i}]: write failed, err: ${err}') }
+	tcp_con.write([u8(i)]) or {
+		elog('client [${i}]: write failed, err: ${err}')
+		return
+	}
 	time.sleep(1 * time.second)
 	elog('client [${i}]: closing connection...')
 	tcp_con.close() or {

--- a/vlib/net/tcp_simple_client_server_test.v
+++ b/vlib/net/tcp_simple_client_server_test.v
@@ -70,7 +70,10 @@ fn test_socket_write_and_read() {
 		cleanup(mut server, mut client, mut socket)
 	}
 	message1 := 'a message 1'
-	socket.write_string(message1) or { assert false }
+	socket.write_string(message1) or {
+		assert false
+		return
+	}
 	mut rbuf := []u8{len: message1.len}
 	client.read(mut rbuf) or {
 		assert false
@@ -88,7 +91,10 @@ fn test_socket_read_line() {
 	}
 	message1, message2 := 'message1', 'message2'
 	message := '${message1}\n${message2}\n'
-	socket.write_string(message) or { assert false }
+	socket.write_string(message) or {
+		assert false
+		return
+	}
 	assert true
 	//
 	line1 := reader.read_line() or {
@@ -126,6 +132,7 @@ fn test_socket_write_fail_without_panic() {
 		socket.write_string(message2) or {
 			println('write to a socket without a recipient should produce an option fail: ${err} | ${message2}')
 			assert true
+			continue
 		}
 	}
 }

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -325,7 +325,11 @@ fn test_read_raw_at_negative_pos() {
 	if _ := f.read_raw_at[Point](u64(-1)) {
 		assert false
 	}
-	f.read_raw_at[Point](u64(-1)) or { assert err.msg() == 'Invalid argument' }
+	f.read_raw_at[Point](u64(-1)) or {
+		assert err.msg() == 'Invalid argument'
+		f.close()
+		return
+	}
 	f.close()
 }
 

--- a/vlib/os/signal_test.v
+++ b/vlib/os/signal_test.v
@@ -11,7 +11,10 @@ fn default_handler(signal os.Signal) {
 }
 
 fn test_signal_opt() {
-	os.signal_opt(.int, default_handler) or { assert false }
+	os.signal_opt(.int, default_handler) or {
+		assert false
+		return
+	}
 }
 
 fn test_signal_opt_invalid_argument() {
@@ -22,6 +25,7 @@ fn test_signal_opt_invalid_argument() {
 	os.signal_opt(.kill, default_handler) or {
 		assert err.msg() == 'Invalid argument; code: 22'
 		assert err.code() == 22
+		return
 	}
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -71,6 +71,7 @@ pub mut:
 	inside_anon_fn             bool // true inside `fn() { ... }()`
 	inside_ref_lit             bool // true inside `a := &something`
 	inside_defer               bool // true inside `defer {}` blocks
+	inside_return              bool // true inside `return a`
 	inside_fn_arg              bool // `a`, `b` in `a.f(b)`
 	inside_ct_attr             bool // true inside `[if expr]`
 	inside_x_is_type           bool // true inside the Type expression of `if x is Type {`

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -545,6 +545,10 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	c.expected_or_type = node.return_type.clear_flag(.result)
 	c.stmts_ending_with_expression(mut node.or_block.stmts)
 	c.expected_or_type = ast.void_type
+	
+	if node.or_block.stmts.len > 0 && !c.inside_return {
+		c.check_expr_opt_call(node, node.return_type.clear_flags(.result, .option))
+	}
 
 	if !c.inside_const && c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_main
 		&& !c.table.cur_fn.is_test {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -545,7 +545,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	c.expected_or_type = node.return_type.clear_flag(.result)
 	c.stmts_ending_with_expression(mut node.or_block.stmts)
 	c.expected_or_type = ast.void_type
-	
+
 	if node.or_block.stmts.len > 0 && !c.inside_return {
 		c.check_expr_opt_call(node, node.return_type.clear_flags(.result, .option))
 	}

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -25,6 +25,11 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 	if c.table.cur_fn == unsafe { nil } {
 		return
 	}
+	old_inside_return := c.inside_return
+	c.inside_return = true
+	defer {
+		c.inside_return = old_inside_return
+	}
 	c.expected_type = c.table.cur_fn.return_type
 	mut expected_type := c.unwrap_generic(c.expected_type)
 	if expected_type != 0 && c.table.sym(expected_type).kind == .alias {

--- a/vlib/v/checker/tests/assert_result_inside_infix_expr_err.out
+++ b/vlib/v/checker/tests/assert_result_inside_infix_expr_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assert_result_inside_infix_expr_err.vv:53:27: error: wrong return type `IError` in the `or {}` block, expected `StopAfter`
+   51 |     assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
+   52 |     assert parse('10t')! == StopAfter{10, .tx}
+   53 |     assert parse('10x') or { err } == StopAfter{}
+      |                              ~~~
+   54 | }

--- a/vlib/v/checker/tests/assert_result_inside_infix_expr_err.vv
+++ b/vlib/v/checker/tests/assert_result_inside_infix_expr_err.vv
@@ -1,0 +1,54 @@
+import time
+
+enum StopAfterType {
+	time
+	tx
+}
+
+struct StopAfter {
+	t               f64
+	stop_after_type StopAfterType
+}
+
+pub fn parse(str string) !StopAfter {
+	time_format := [str[str.len - 1]].bytestr()
+	time_string := str[0..str.len - 1]
+	if time_string == '0' {
+		return StopAfter{}
+	}
+	timef64 := time_string.f64()
+	if timef64 == 0 {
+		return error('invalid string "${str}"')
+	}
+
+	match time_format {
+		's' {
+			return StopAfter{timef64 * time.second, .time}
+		}
+		'm' {
+			return StopAfter{timef64 * time.minute, .time}
+		}
+		'h' {
+			return StopAfter{timef64 * time.hour, .time}
+		}
+		'd' {
+			return StopAfter{timef64 * time.hour * 24, .time}
+		}
+		't' {
+			return StopAfter{timef64, .tx}
+		}
+		else {
+			return error('no match for "${time_format}" format')
+		}
+	}
+}
+
+fn main() {
+	assert parse('0s')! == StopAfter{}
+	assert parse('10s')! == StopAfter{10 * time.second, .time}
+	assert parse('10m')! == StopAfter{10 * time.minute, .time}
+	assert parse('10h')! == StopAfter{10 * time.hour, .time}
+	assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
+	assert parse('10t')! == StopAfter{10, .tx}
+	assert parse('10x') or { err } == StopAfter{}
+}

--- a/vlib/v/checker/tests/expression_should_return_an_option.out
+++ b/vlib/v/checker/tests/expression_should_return_an_option.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/expression_should_return_an_option.vv:26:10: error: expression should either return an Option or a Result
-   24 |     return_option(true) or { println(err) }
-   25 |     // should be an checker error:
-   26 |     if x := return_string() {
+vlib/v/checker/tests/expression_should_return_an_option.vv:29:10: error: expression should either return an Option or a Result
+   27 |     }
+   28 |     // should be an checker error:
+   29 |     if x := return_string() {
       |             ~~~~~~~~~~~~~~~
-   27 |         println('x: ${x}')
-   28 |     }
+   30 |         println('x: ${x}')
+   31 |     }

--- a/vlib/v/checker/tests/expression_should_return_an_option.vv
+++ b/vlib/v/checker/tests/expression_should_return_an_option.vv
@@ -21,7 +21,10 @@ fn main() {
 		println(err)
 	}
 	// works
-	return_option(true) or { println(err) }
+	return_option(true) or {
+		println(err)
+		return
+	}
 	// should be an checker error:
 	if x := return_string() {
 		println('x: ${x}')

--- a/vlib/v/checker/tests/option_or_block_mismatch.out
+++ b/vlib/v/checker/tests/option_or_block_mismatch.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/option_or_block_mismatch.vv:10:18: error: wrong return type
       |                     ~~~~~
    11 |     println(x)
    12 |
-vlib/v/checker/tests/option_or_block_mismatch.vv:13:13: error: the default expression type in the `or` block should be `&Bar`, instead you gave a value of type `Bar`
+vlib/v/checker/tests/option_or_block_mismatch.vv:13:13: error: wrong return type `Bar` in the `or {}` block, expected `&Bar`
    11 |     println(x)
    12 |
    13 |     foo() or { Bar{} }

--- a/vlib/v/checker/tests/option_or_block_returns_value_of_incompatible_type.out
+++ b/vlib/v/checker/tests/option_or_block_returns_value_of_incompatible_type.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/option_or_block_returns_value_of_incompatible_type.vv:13:3: error: the default expression type in the `or` block should be `string`, instead you gave a value of type `int literal`
+vlib/v/checker/tests/option_or_block_returns_value_of_incompatible_type.vv:13:3: error: wrong return type `int literal` in the `or {}` block, expected `string`
    11 |         // must be of the same type of the return
    12 |         // type of the `test_option` function
    13 |         123

--- a/vlib/v/checker/tests/return_duplicate_with_none_err_a.vv
+++ b/vlib/v/checker/tests/return_duplicate_with_none_err_a.vv
@@ -5,5 +5,6 @@ fn f() ?bool {
 fn main() {
 	f() or {
 		println('fail')
+		return
 	}
 }

--- a/vlib/v/checker/tests/return_duplicate_with_none_err_b.vv
+++ b/vlib/v/checker/tests/return_duplicate_with_none_err_b.vv
@@ -5,5 +5,6 @@ fn f() ?bool {
 fn main() {
 	f() or {
 		println('fail')
+		return
 	}
 }

--- a/vlib/v/pkgconfig/pkgconfig_test.v
+++ b/vlib/v/pkgconfig/pkgconfig_test.v
@@ -23,6 +23,7 @@ fn test_dependency_resolution_fails_correctly() {
 		pcname := os.file_name(pc).replace('.pc', '')
 		pkgconfig.load(pcname, use_default_paths: false, path: samples_dir) or {
 			errors << err.msg()
+			continue
 		}
 	}
 	assert errors.len < pc_files.len

--- a/vlib/v/tests/match_expr_with_assign_sumtype_test.v
+++ b/vlib/v/tests/match_expr_with_assign_sumtype_test.v
@@ -1,5 +1,8 @@
 fn test_match_expr_with_assign_sumtype() {
-	parse_args(['1', '+', '-', '*', '/', ' ']) or { println(err) }
+	parse_args(['1', '+', '-', '*', '/', ' ']) or {
+		println(err)
+		return
+	}
 }
 
 enum Operator {

--- a/vlib/v/tests/nested_option_call_test.v
+++ b/vlib/v/tests/nested_option_call_test.v
@@ -62,6 +62,10 @@ fn test_nested_propagation_method() {
 	mut x := St{
 		z: 2.25
 	}
-	x.aa_propagate() or { x.z = 13.0625 }
-	assert x.z == 13.0625
+	x.aa_propagate() or {
+		x.z = 13.0625
+		assert x.z == 13.0625
+		return
+	}
+	assert false
 }

--- a/vlib/v/tests/option_if_assign_and_fallthrough_test.v
+++ b/vlib/v/tests/option_if_assign_and_fallthrough_test.v
@@ -41,6 +41,7 @@ fn test_opt_with_fall_through() {
 		eprintln('  this *should* be an error: ${err}')
 		x++
 		assert true
+		return
 	}
 	assert x == 2
 }

--- a/vlib/v/tests/orm_stmt_wrong_return_checking_test.v
+++ b/vlib/v/tests/orm_stmt_wrong_return_checking_test.v
@@ -24,6 +24,9 @@ fn add_target(repo Target) !int {
 }
 
 fn test_main() {
-	add_target(Target{1, 'foo'}) or { println('>> ${err}') }
+	add_target(Target{1, 'foo'}) or {
+		println('>> ${err}')
+		return
+	}
 	assert true
 }

--- a/vlib/v/tests/results_test.v
+++ b/vlib/v/tests/results_test.v
@@ -17,7 +17,10 @@ fn test_return_err() {
 }
 
 fn test_return_err_var() {
-	foo_err() or { assert err.msg() == 'throw' }
+	foo_err() or {
+		assert err.msg() == 'throw'
+		return
+	}
 }
 
 fn test_str() {
@@ -31,7 +34,10 @@ fn result_void(err bool) ! {
 }
 
 fn test_result_void() {
-	result_void(false) or { assert false }
+	result_void(false) or {
+		assert false
+		return
+	}
 }
 
 fn test_result_void_err() {
@@ -39,6 +45,7 @@ fn test_result_void_err() {
 	result_void(true) or {
 		assert err.msg() == 'throw'
 		or_block = true
+		return
 	}
 	assert or_block
 }
@@ -48,7 +55,10 @@ fn propagate() ! {
 }
 
 fn test_propagation() {
-	propagate() or { assert false }
+	propagate() or {
+		assert false
+		return
+	}
 }
 
 fn function_that_can_return_error() !int {
@@ -61,7 +71,10 @@ fn util_error_propagation() ! {
 }
 
 fn test_return_on_error_propagation() {
-	util_error_propagation() or { assert err.msg() == 'abc' }
+	util_error_propagation() or {
+		assert err.msg() == 'abc'
+		return
+	}
 }
 
 fn unsafe_return_error() !int {
@@ -71,7 +84,10 @@ fn unsafe_return_error() !int {
 }
 
 fn test_unsafe_return_error() {
-	unsafe_return_error() or { assert err.msg() == 'abc' }
+	unsafe_return_error() or {
+		assert err.msg() == 'abc'
+		return
+	}
 }
 
 fn return_reference_type(path string) !&string {

--- a/vlib/v/tests/struct_test.v
+++ b/vlib/v/tests/struct_test.v
@@ -374,9 +374,15 @@ fn test_fields_anon_fn_with_option_void_return_type() {
 		}
 	}
 
-	foo.f() or { assert err.msg() == 'oops' }
+	foo.f() or {
+		assert err.msg() == 'oops'
+		return
+	}
 
-	foo.g() or { assert false }
+	foo.g() or {
+		assert false
+		return
+	}
 }
 
 struct Commands {

--- a/vlib/v/vcache/vcache_test.v
+++ b/vlib/v/vcache/vcache_test.v
@@ -54,25 +54,37 @@ fn test_different_options_should_produce_different_cache_entries_for_same_key_an
 
 fn test_exists() {
 	mut cm := vcache.new_cache_manager([])
-	cm.exists('.o', 'abc') or { assert true }
+	cm.exists('.o', 'abc') or {
+		assert true
+		return
+	}
 	//
 	x := cm.save('.x', 'abc', '') or {
 		assert false
 		''
 	}
-	cm.exists('.o', 'abc') or { assert true }
+	cm.exists('.o', 'abc') or {
+		assert true
+		return
+	}
 	//
 	y := cm.save('.o', 'zbc', '') or {
 		assert false
 		''
 	}
-	cm.exists('.o', 'abc') or { assert true }
+	cm.exists('.o', 'abc') or {
+		assert true
+		return
+	}
 	//
 	z := cm.save('.o', 'abc', '') or {
 		assert false
 		''
 	}
-	cm.exists('.o', 'abc') or { assert false }
+	cm.exists('.o', 'abc') or {
+		assert false
+		return
+	}
 	//
 	assert os.is_file(x)
 	assert os.is_file(y)

--- a/vlib/x/json2/json2_test.v
+++ b/vlib/x/json2/json2_test.v
@@ -126,6 +126,7 @@ fn test_maps() {
 	assert json.decode[map[string]string]('{"test":"abc"}') or {
 		dump(err)
 		assert false
+		return
 	} == {
 		'test': 'abc'
 	}


### PR DESCRIPTION
This PR check error for result/option call in assert statement (fix #19199).

- Check error for result/option call in assert statement.
- Add test.

```v
import time

enum StopAfterType {
	time
	tx
}

struct StopAfter {
	t               f64
	stop_after_type StopAfterType
}

pub fn parse(str string) !StopAfter {
	time_format := [str[str.len - 1]].bytestr()
	time_string := str[0..str.len - 1]
	if time_string == '0' {
		return StopAfter{}
	}
	timef64 := time_string.f64()
	if timef64 == 0 {
		return error('invalid string "${str}"')
	}

	match time_format {
		's' {
			return StopAfter{timef64 * time.second, .time}
		}
		'm' {
			return StopAfter{timef64 * time.minute, .time}
		}
		'h' {
			return StopAfter{timef64 * time.hour, .time}
		}
		'd' {
			return StopAfter{timef64 * time.hour * 24, .time}
		}
		't' {
			return StopAfter{timef64, .tx}
		}
		else {
			return error('no match for "${time_format}" format')
		}
	}
}

fn main() {
	assert parse('0s')! == StopAfter{}
	assert parse('10s')! == StopAfter{10 * time.second, .time}
	assert parse('10m')! == StopAfter{10 * time.minute, .time}
	assert parse('10h')! == StopAfter{10 * time.hour, .time}
	assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
	assert parse('10t')! == StopAfter{10, .tx}
	assert parse('10x') or { err } == StopAfter{}
}

PS D:\Test\v\tt1> v run .       
tt1.v:53:27: error: wrong return type `IError` in the `or {}` block, expected `StopAfter`
   51 |     assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
   52 |     assert parse('10t')! == StopAfter{10, .tx}
   53 |     assert parse('10x') or { err } == StopAfter{}
      |                              ~~~
   54 | }
```