### PR TITLE
fmt: fix #14400 `modname.constname` becomes `constname` in modules excluding main module

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2155,6 +2155,12 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 				}
 			}
 		}
+		if !is_local && node.mod != 'main' {
+			// Do not shorten `modname.constname` to `constname` unless inside the main module.
+			name := '${node.mod}.${node.name}'
+			f.write(name)
+			return
+		}
 		name := f.short_module(node.name)
 		f.write(name)
 		if node.concrete_types.len > 0 {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2155,7 +2155,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 				}
 			}
 		}
-		if !is_local && node.mod != 'main' {
+		if !is_local && node.mod != 'main' && !node.comptime {
 			// Do not shorten `modname.constname` to `constname` unless inside the main module.
 			name := '${node.mod}.${node.name}'
 			f.write(name)

--- a/vlib/v/fmt/tests/consts_outisde_of_file_keep.vv
+++ b/vlib/v/fmt/tests/consts_outisde_of_file_keep.vv
@@ -1,0 +1,6 @@
+module test
+
+const foo = 'foo'
+
+dump(test.foo)
+dump(test.bar)


### PR DESCRIPTION
Fixed the issue described in #14400. In modules other than `main`, `modname.constname` was being converted to `constname` by `v fmt`. This behavior is unexpected: [require module prefix docs](https://github.com/vlang/v/blob/master/doc/docs.md#required-module-prefix).