### PR TITLE
checker: check error for or_expr inside infix expression (fix #19199)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -147,6 +147,12 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	match node.op {
 		// .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .dot, .key_as, .right_shift {}
 		.eq, .ne {
+			if node.left is ast.CallExpr && node.left.or_block.stmts.len > 0 {
+				c.check_expr_opt_call(node.left, left_type)
+			}
+			if node.right is ast.CallExpr && node.right.or_block.stmts.len > 0 {
+				c.check_expr_opt_call(node.right, right_type)
+			}
 			if left_type in ast.integer_type_idxs && right_type in ast.integer_type_idxs {
 				is_left_type_signed := left_type in ast.signed_integer_type_idxs
 				is_right_type_signed := right_type in ast.signed_integer_type_idxs

--- a/vlib/v/checker/tests/result_call_inside_infix_expr_err.out
+++ b/vlib/v/checker/tests/result_call_inside_infix_expr_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/result_call_inside_infix_expr_err.vv:53:27: error: wrong return type `IError` in the `or {}` block, expected `StopAfter`
+   51 |     assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
+   52 |     assert parse('10t')! == StopAfter{10, .tx}
+   53 |     assert parse('10x') or { err } == StopAfter{}
+      |                              ~~~
+   54 |     assert StopAfter{} == parse('10x') or { err }
+   55 | }
+vlib/v/checker/tests/result_call_inside_infix_expr_err.vv:54:42: error: wrong return type `IError` in the `or {}` block, expected `StopAfter`
+   52 |     assert parse('10t')! == StopAfter{10, .tx}
+   53 |     assert parse('10x') or { err } == StopAfter{}
+   54 |     assert StopAfter{} == parse('10x') or { err }
+      |                                             ~~~
+   55 | }

--- a/vlib/v/checker/tests/result_call_inside_infix_expr_err.vv
+++ b/vlib/v/checker/tests/result_call_inside_infix_expr_err.vv
@@ -1,0 +1,55 @@
+import time
+
+enum StopAfterType {
+	time
+	tx
+}
+
+struct StopAfter {
+	t               f64
+	stop_after_type StopAfterType
+}
+
+pub fn parse(str string) !StopAfter {
+	time_format := [str[str.len - 1]].bytestr()
+	time_string := str[0..str.len - 1]
+	if time_string == '0' {
+		return StopAfter{}
+	}
+	timef64 := time_string.f64()
+	if timef64 == 0 {
+		return error('invalid string "${str}"')
+	}
+
+	match time_format {
+		's' {
+			return StopAfter{timef64 * time.second, .time}
+		}
+		'm' {
+			return StopAfter{timef64 * time.minute, .time}
+		}
+		'h' {
+			return StopAfter{timef64 * time.hour, .time}
+		}
+		'd' {
+			return StopAfter{timef64 * time.hour * 24, .time}
+		}
+		't' {
+			return StopAfter{timef64, .tx}
+		}
+		else {
+			return error('no match for "${time_format}" format')
+		}
+	}
+}
+
+fn main() {
+	assert parse('0s')! == StopAfter{}
+	assert parse('10s')! == StopAfter{10 * time.second, .time}
+	assert parse('10m')! == StopAfter{10 * time.minute, .time}
+	assert parse('10h')! == StopAfter{10 * time.hour, .time}
+	assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
+	assert parse('10t')! == StopAfter{10, .tx}
+	assert parse('10x') or { err } == StopAfter{}
+	assert StopAfter{} == parse('10x') or { err }
+}

--- a/vlib/x/json2/json2_test.v
+++ b/vlib/x/json2/json2_test.v
@@ -123,10 +123,7 @@ fn test_struct_with_struct_to_map() {
 }
 
 fn test_maps() {
-	assert json.decode[map[string]string]('{"test":"abc"}') or {
-		dump(err)
-		assert false
-	} == {
+	assert json.decode[map[string]string]('{"test":"abc"}')! == {
 		'test': 'abc'
 	}
 


### PR DESCRIPTION
This PR check error for or_expr inside infix expression (fix #19199).

- Check error for or_expr inside infix expression.
- Add test.

```v
import time

enum StopAfterType {
	time
	tx
}

struct StopAfter {
	t               f64
	stop_after_type StopAfterType
}

pub fn parse(str string) !StopAfter {
	time_format := [str[str.len - 1]].bytestr()
	time_string := str[0..str.len - 1]
	if time_string == '0' {
		return StopAfter{}
	}
	timef64 := time_string.f64()
	if timef64 == 0 {
		return error('invalid string "${str}"')
	}

	match time_format {
		's' {
			return StopAfter{timef64 * time.second, .time}
		}
		'm' {
			return StopAfter{timef64 * time.minute, .time}
		}
		'h' {
			return StopAfter{timef64 * time.hour, .time}
		}
		'd' {
			return StopAfter{timef64 * time.hour * 24, .time}
		}
		't' {
			return StopAfter{timef64, .tx}
		}
		else {
			return error('no match for "${time_format}" format')
		}
	}
}

fn main() {
	assert parse('0s')! == StopAfter{}
	assert parse('10s')! == StopAfter{10 * time.second, .time}
	assert parse('10m')! == StopAfter{10 * time.minute, .time}
	assert parse('10h')! == StopAfter{10 * time.hour, .time}
	assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
	assert parse('10t')! == StopAfter{10, .tx}
	assert parse('10x') or { err } == StopAfter{}
	assert StopAfter{} == parse('10x') or { err }
}

PS D:\Test\v\tt1> v run .
tt1.v:53:27: error: wrong return type `IError` in the `or {}` block, expected `StopAfter`
   51 |     assert parse('10d')! == StopAfter{10 * time.hour * 24, .time}
   52 |     assert parse('10t')! == StopAfter{10, .tx}
   53 |     assert parse('10x') or { err } == StopAfter{}
      |                              ~~~
   54 |     assert StopAfter{} == parse('10x') or { err }
   55 | }
tt1.v:54:42: error: wrong return type `IError` in the `or {}` block, expected `StopAfter`
   52 |     assert parse('10t')! == StopAfter{10, .tx}
   53 |     assert parse('10x') or { err } == StopAfter{}
   54 |     assert StopAfter{} == parse('10x') or { err }
      |                                             ~~~
   55 | }
```