### PR TITLE
cgen: fix generic struct with option fn field (fix #19202)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3603,7 +3603,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.or_block.kind != .absent && !g.is_assign_lhs && g.table.sym(node.typ).kind != .chan {
 		is_ptr := sym.kind in [.interface_, .sum_type]
 		stmt_str := g.go_before_stmt(0).trim_space()
-		styp := g.typ(node.typ)
+		styp := g.typ(g.unwrap_generic(node.typ))
 		g.empty_line = true
 		tmp_var := g.new_tmp_var()
 		g.write('${styp} ${tmp_var} = ')

--- a/vlib/v/tests/generics_struct_with_option_fn_test.v
+++ b/vlib/v/tests/generics_struct_with_option_fn_test.v
@@ -1,0 +1,14 @@
+struct Cmp[K] {
+	cmp ?fn (K, K) bool
+}
+
+fn (c Cmp[K]) compare(a K, b K) bool {
+	cmp := c.cmp or { return a < b }
+	return cmp(a, b)
+}
+
+fn test_generic_struct_with_option_fn() {
+	c := Cmp[int]{}
+	print(c.compare(1, 2))
+	assert c.compare(1, 2)
+}


### PR DESCRIPTION
This PR fix generic struct with option fn field (fix #19202).

- Fix generic struct with option fn field.
- Add test.

```v
struct Cmp[K] {
	cmp ?fn (K, K) bool
}

fn (c Cmp[K]) compare(a K, b K) bool {
	cmp := c.cmp or { return a < b }
	return cmp(a, b)
}

fn main() {
	c := Cmp[int]{}
	print(c.compare(1, 2))
	assert c.compare(1, 2)
}

PS D:\Test\v\tt1> v run .
true
```