### PR TITLE
cgen: fix array sort with fn call parameter (fix #19220)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -612,7 +612,7 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 		left_name := infix_expr.left.str()
 		if left_name.len > 1 {
 			compare_fn += '_by' +
-				left_name[1..].replace_each(['.', '_', '[', '_', ']', '_', "'", '_', '(', '', ')', '', ',', ''])
+				left_name[1..].replace_each(['.', '_', '[', '_', ']', '_', "'", '_', '"', '_', '(', '', ')', '', ',', ''])
 		}
 		// is_reverse is `true` for `.sort(a > b)` and `.sort(b < a)`
 		is_reverse := (left_name.starts_with('a') && infix_expr.op == .gt)

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -611,7 +611,8 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 		comparison_type = g.unwrap(infix_expr.left_type.set_nr_muls(0))
 		left_name := infix_expr.left.str()
 		if left_name.len > 1 {
-			compare_fn += '_by' + left_name[1..].replace_each(['.', '_', '[', '_', ']', '_'])
+			compare_fn += '_by' +
+				left_name[1..].replace_each(['.', '_', '[', '_', ']', '_', "'", '_', '(', '', ')', '', ',', ''])
 		}
 		// is_reverse is `true` for `.sort(a > b)` and `.sort(b < a)`
 		is_reverse := (left_name.starts_with('a') && infix_expr.op == .gt)

--- a/vlib/v/tests/array_sort_with_fn_call_test.v
+++ b/vlib/v/tests/array_sort_with_fn_call_test.v
@@ -1,0 +1,13 @@
+struct Info {
+mut:
+	fields []string
+}
+
+fn test_sort_with_fn_call() {
+	mut info := Info{
+		fields: ['aaa(', 'b(']
+	}
+	info.fields.sort(a.before('(').len < b.before('(').len)
+	println(info.fields)
+	assert info.fields == ['b(', 'aaa(']
+}


### PR DESCRIPTION
This PR fix array sort with fn call parameter (fix #19220).

- Fix array sort with fn call parameter.
- Add test.

```v
struct Info {
mut:
	fields []string
}

fn main() {
	mut info := Info{
		fields: ['aaa(', 'b(']
	}
	info.fields.sort(a.before('(').len < b.before('(').len)
	println(info.fields)
	assert info.fields == ['b(', 'aaa(']
}

PS D:\Test\v\tt1> v run .
['b(', 'aaa(']
```