### PR TITLE
os: update doc comment for `input_opt` return

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -276,7 +276,7 @@ pub fn file_name(opath string) string {
 }
 
 // input_opt returns a one-line string from stdin, after printing a prompt.
-// In the event of error (end of input), it returns `none`.
+// Returns `none` in case of an error (end of input).
 pub fn input_opt(prompt string) ?string {
 	print(prompt)
 	flush()


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 609fe5b</samp>

Improved the comment for the `input_opt` function in `vlib/os/os.v`. This was part of a larger effort to enhance the documentation and readability of the `os` module.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 609fe5b</samp>

* Rephrase the comment for the `input_opt` function to avoid repetition and improve clarity ([link](https://github.com/vlang/v/pull/19223/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09L279-R279))
