### PR TITLE
docs: note about threads

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4040,13 +4040,6 @@ println(compare(1.1, 1.2)) //         -1
 V's model of concurrency is going to be very similar to Go's.
 For now, `spawn foo()` runs `foo()` concurrently in a different thread:
 
-> **Note**
-> Threads relies on running machine's CPU (number of cores/threads).
-> Be aware that OS threads spawned with `spawn`
-> have limitations in regard to concurrency, 
-> including resource overhead and scalability issues, 
-> and might affect performance in cases of high thread count.
-
 ```v
 import math
 
@@ -4065,6 +4058,13 @@ fn main() {
 	// }(3, 4)
 }
 ```
+
+> **Note**
+> Threads rely on the machine's CPU (number of cores/threads).
+> Be aware that OS threads spawned with `spawn`
+> have limitations in regard to concurrency, 
+> including resource overhead and scalability issues, 
+> and might affect performance in cases of high thread count.
 
 There's also a `go` keyword. Right now `go foo()` will be automatically renamed via vfmt
 to `spawn foo()`, and there will be a way to launch a coroutine with `go` (a lightweight

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4039,6 +4039,7 @@ println(compare(1.1, 1.2)) //         -1
 
 V's model of concurrency is going to be very similar to Go's.
 For now, `spawn foo()` runs `foo()` concurrently in a different thread:
+> **Note** Threads relies on running machine's CPU (number of cores/threads), so keep in mind that OS threads spawned with `spawn` have limitations in regard to concurrency, including resource overhead and scalability issues, and might affect performance in cases of high thread count.
 
 ```v
 import math

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4039,7 +4039,13 @@ println(compare(1.1, 1.2)) //         -1
 
 V's model of concurrency is going to be very similar to Go's.
 For now, `spawn foo()` runs `foo()` concurrently in a different thread:
-> **Note** Threads relies on running machine's CPU (number of cores/threads), so keep in mind that OS threads spawned with `spawn` have limitations in regard to concurrency, including resource overhead and scalability issues, and might affect performance in cases of high thread count.
+
+> **Note**
+> Threads relies on running machine's CPU (number of cores/threads).
+> Be aware that OS threads spawned with `spawn`
+> have limitations in regard to concurrency, 
+> including resource overhead and scalability issues, 
+> and might affect performance in cases of high thread count.
 
 ```v
 import math


### PR DESCRIPTION
As for myself, I didn't know from the start the difference between threads, coroutines and how it is in the V language at the moment, and I think it might be honest to note it at least somewhere in docs. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 264c082</samp>

Update the documentation of `spawn` in `doc/docs.md` to include a note about the limitations and drawbacks of OS threads. This change aims to educate the reader about the concurrency options and trade-offs in V.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 264c082</samp>

* Add a note about the limitations and drawbacks of OS threads for concurrency to the documentation of the `spawn` keyword ([link](https://github.com/vlang/v/pull/19225/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8R4042))
