### PR TITLE
token: add inline next_to() and cleanup related calls

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2761,7 +2761,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 		return p.struct_init(p.mod + '.' + p.tok.lit, .normal, is_option) // short_syntax: false
 	} else if p.peek_tok.kind == .lcbr
 		&& ((p.inside_if && lit0_is_capital && p.tok.lit.len > 1 && !known_var && language == .v)
-		|| (p.inside_match_case && p.tok.kind == .name && p.peek_tok.pos - p.tok.pos == p.tok.len)) {
+		|| (p.inside_match_case && p.tok.kind == .name && p.peek_tok.next_to(p.tok))) {
 		// `if a == Foo{} {...}` or `match foo { Foo{} {...} }`
 		return p.struct_init(p.mod + '.' + p.tok.lit, .normal, is_option)
 	} else if p.peek_tok.kind == .dot && (lit0_is_capital && !known_var && language == .v) {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -586,7 +586,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		if p.tok.kind == .name && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 			&& (p.peek_tok.line_nr != p.tok.line_nr
 			|| p.peek_tok.kind !in [.name, .amp, .lsbr, .lpar]
-			|| (p.peek_tok.kind == .lsbr && p.peek_tok.pos - p.tok.pos == p.tok.len)) {
+			|| (p.peek_tok.kind == .lsbr && p.peek_tok.next_to(p.tok))) {
 			iface_pos := p.tok.pos()
 			mut iface_name := p.tok.lit
 			iface_type := p.parse_type()
@@ -641,7 +641,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			is_mut = true
 			mut_pos = fields.len
 		}
-		if p.peek_tok.kind in [.lt, .lsbr] && p.peek_tok.pos - p.tok.pos == p.tok.len {
+		if p.peek_tok.kind in [.lt, .lsbr] && p.peek_tok.next_to(p.tok) {
 			p.error_with_pos("no need to add generic type names in generic interface's method",
 				p.peek_tok.pos())
 			return ast.InterfaceDecl{}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -371,6 +371,11 @@ pub fn (t Kind) str() string {
 	return token.token_str[idx]
 }
 
+[inline]
+pub fn (t Token) next_to(pre_token Token) bool {
+	return t.pos - pre_token.pos == pre_token.len
+}
+
 pub fn (t Token) str() string {
 	mut s := t.kind.str()
 	if s.len == 0 {


### PR DESCRIPTION
This PR add inline next_to() and clean up related calls.