### PR TITLE
vlib: update doc comments

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -679,8 +679,8 @@ pub fn carray_to_varray[T](c_array_data voidptr, items int) []T {
 	return v_array
 }
 
-// find_first returns the first element that matches the given predicate
-// returns `none`, if there is no match found
+// find_first returns the first element that matches the given predicate.
+// Returns `none` if no match is found.
 // Example: arrays.find_first([1, 2, 3, 4, 5], fn (i int) bool { return i == 3 })? // => 3
 pub fn find_first[T](array []T, predicate fn (elem T) bool) ?T {
 	if array.len == 0 {
@@ -694,8 +694,8 @@ pub fn find_first[T](array []T, predicate fn (elem T) bool) ?T {
 	return none
 }
 
-// find_last returns the last element that matches the given predicate
-// returns `none`, if there is no match found
+// find_last returns the last element that matches the given predicate.
+// Returns `none` if no match is found.
 // Example: arrays.find_last([1, 2, 3, 4, 5], fn (i int) bool { return i == 3})? // => 3
 pub fn find_last[T](array []T, predicate fn (elem T) bool) ?T {
 	if array.len == 0 {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -578,7 +578,7 @@ fn (mut d DenseArray) delete(i int) {
 	}
 }
 
-// Removes the mapping of a particular key from the map.
+// delete removes the mapping of a particular key from the map.
 [unsafe]
 pub fn (mut m map) delete(key voidptr) {
 	mut index, mut meta := m.key_to_index(key)
@@ -618,7 +618,7 @@ pub fn (mut m map) delete(key voidptr) {
 	}
 }
 
-// Returns all keys in the map.
+// keys returns all keys in the map.
 pub fn (m &map) keys() array {
 	mut keys := __new_array(m.len, 0, m.key_bytes)
 	mut item := unsafe { &u8(keys.data) }
@@ -645,7 +645,7 @@ pub fn (m &map) keys() array {
 	return keys
 }
 
-// Returns all values in the map.
+// values returns all values in the map.
 pub fn (m &map) values() array {
 	mut values := __new_array(m.len, 0, m.value_bytes)
 	mut item := unsafe { &u8(values.data) }

--- a/vlib/dl/dl.v
+++ b/vlib/dl/dl.v
@@ -26,8 +26,7 @@ pub fn get_libname(libname string) string {
 	return '${libname}${dl.dl_ext}'
 }
 
-// open_opt - loads the dynamic shared object.
-// Unlike open, open_opt return an option.
+// open_opt tries to load a given dynamic shared object.
 pub fn open_opt(filename string, flags int) !voidptr {
 	shared_object_handle := open(filename, flags)
 	if shared_object_handle == 0 {

--- a/vlib/dl/dl_nix.c.v
+++ b/vlib/dl/dl_nix.c.v
@@ -23,7 +23,7 @@ fn C.dlclose(handle voidptr) int
 
 fn C.dlerror() &char
 
-// open loads the dynamic shared object.
+// open loads a given dynamic shared object.
 pub fn open(filename string, flags int) voidptr {
 	return C.dlopen(&char(filename.str), flags)
 }

--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -105,7 +105,7 @@ pub fn read_cookies(h map[string][]string, filter string) []&Cookie {
 	return cookies
 }
 
-// Returns the serialization of the cookie for use in a Cookie header
+// str returns the serialization of the cookie for use in a Cookie header
 // (if only Name and Value are set) or a Set-Cookie response
 // header (if other fields are set).
 //

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -444,7 +444,7 @@ pub fn parse_multipart_form(body string, boundary string) (map[string]string, ma
 	return form, files
 }
 
-// parse_disposition parses the Content-Disposition header of a multipart form
+// parse_disposition parses the Content-Disposition header of a multipart form.
 // Returns a map of the key="value" pairs
 // Example: assert parse_disposition('Content-Disposition: form-data; name="a"; filename="b"') == {'name': 'a', 'filename': 'b'}
 fn parse_disposition(line string) map[string]string {

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -16,8 +16,8 @@ pub fn getenv(key string) string {
 	return getenv_opt(key) or { '' }
 }
 
-// `getenv_opt` returns the value of the environment variable named by the key
-// If there is not one found, it returns `none`.
+// `getenv_opt` returns the value a given environment variable.
+// Returns `none` if the environment variable does not exist.
 [manualfree]
 pub fn getenv_opt(key string) ?string {
 	unsafe {

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -16,7 +16,7 @@ pub fn getenv(key string) string {
 	return getenv_opt(key) or { '' }
 }
 
-// `getenv_opt` returns the value a given environment variable.
+// `getenv_opt` returns the value of a given environment variable.
 // Returns `none` if the environment variable does not exist.
 [manualfree]
 pub fn getenv_opt(key string) ?string {

--- a/vlib/os/environment.js.v
+++ b/vlib/os/environment.js.v
@@ -21,7 +21,7 @@ pub fn getenv(key string) string {
 	return res
 }
 
-// `getenv_opt` returns the value a given environment variable.
+// `getenv_opt` returns the value of a given environment variable.
 // Returns `none` if the environment variable does not exist.
 pub fn getenv_opt(key string) ?string {
 	#if (!$ENV[key]) return none__;

--- a/vlib/os/environment.js.v
+++ b/vlib/os/environment.js.v
@@ -21,8 +21,8 @@ pub fn getenv(key string) string {
 	return res
 }
 
-// `getenv_opt` returns the value of the environment variable named by the key.
-// If such an environment variable does not exist, then it returns `none`.
+// `getenv_opt` returns the value a given environment variable.
+// Returns `none` if the environment variable does not exist.
 pub fn getenv_opt(key string) ?string {
 	#if (!$ENV[key]) return none__;
 

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -52,7 +52,6 @@ fn fix_windows_path(path string) string {
 }
 
 // open_file tries to open or create a file with custom flags and permissions.
-// If successful, it returns a `File` object.
 pub fn open_file(path string, mode string, options ...int) !File {
 	mut flags := 0
 	mut seek_to_end := false
@@ -131,7 +130,6 @@ pub fn open_file(path string, mode string, options ...int) !File {
 }
 
 // open tries to open a file from a given path for reading.
-// If successful, it returns a read-only `File` object.
 pub fn open(path string) !File {
 	/*
 	$if linux {

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -51,7 +51,8 @@ fn fix_windows_path(path string) string {
 	return p
 }
 
-// open_file can be used to open or create a file with custom flags and permissions and returns a `File` object.
+// open_file tries to open or create a file with custom flags and permissions.
+// If successful, it returns a `File` object.
 pub fn open_file(path string, mode string, options ...int) !File {
 	mut flags := 0
 	mut seek_to_end := false
@@ -129,7 +130,8 @@ pub fn open_file(path string, mode string, options ...int) !File {
 	}
 }
 
-// open tries to open a file for reading and returns back a read-only `File` object.
+// open tries to open a file from a given path for reading.
+// If successful, it returns a read-only `File` object.
 pub fn open(path string) !File {
 	/*
 	$if linux {

--- a/vlib/os/open_uri_default.c.v
+++ b/vlib/os/open_uri_default.c.v
@@ -1,5 +1,6 @@
 module os
 
+// open_uri opens a given uri.
 pub fn open_uri(uri string) ! {
 	mut vopen_uri_cmd := getenv('VOPEN_URI_CMD')
 	if vopen_uri_cmd == '' {

--- a/vlib/os/open_uri_windows.c.v
+++ b/vlib/os/open_uri_windows.c.v
@@ -4,6 +4,7 @@ import dl
 
 type ShellExecuteWin = fn (voidptr, &u16, &u16, &u16, &u16, int)
 
+// open_uri opens a given uri.
 pub fn open_uri(uri string) ! {
 	mut vopen_uri_cmd := getenv('VOPEN_URI_CMD')
 	if vopen_uri_cmd != '' {

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -1001,7 +1001,8 @@ pub fn chown(path string, owner int, group int) ! {
 	}
 }
 
-// open_append opens `path` file for appending.
+// open_append tries to open a file from a given path.
+// If successfull, it and returns a `File` for appending.
 pub fn open_append(path string) !File {
 	mut file := File{}
 	$if windows {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -288,7 +288,7 @@ pub fn input_opt(prompt string) ?string {
 }
 
 // input returns a one-line string from stdin, after printing a prompt.
-// In the event of error (end of input), it returns '<EOF>'.
+// Returns '<EOF>' in case of an error (end of input).
 pub fn input(prompt string) string {
 	res := input_opt(prompt) or { return '<EOF>' }
 	return res


### PR DESCRIPTION
Updates some doc comments based on common conventions used in vlib doc comments.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d45521f</samp>

This pull request fixes and improves various comments in the `vlib` modules, mainly for the functions that deal with opening files, maps, arrays, and environment variables. It also adds missing comments for the `open_uri` function in different OS-specific files. These changes enhance the documentation style, clarity, and consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d45521f</samp>

*  Fix comment locations and wording for `delete`, `keys`, and `values` functions in `vlib/builtin/map.v` ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-c639b6a25595ff12a0acfa40b019df49c89647406a1a436a77c593841c156258L581-R581), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-c639b6a25595ff12a0acfa40b019df49c89647406a1a436a77c593841c156258L621-R621), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-c639b6a25595ff12a0acfa40b019df49c89647406a1a436a77c593841c156258L648-R648))
*  Add periods and capitalize "Returns" in comments for `find_first` and `find_last` functions in `vlib/arrays/arrays.v` ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-b7b2841a2601a108289f795e922710054cff56ff06212c11d40dd2a0346191dcL682-R683), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-b7b2841a2601a108289f795e922710054cff56ff06212c11d40dd2a0346191dcL697-R698))
*  Rephrase comments for `open_opt`, `getenv_opt`, `open_file`, `open`, and `open_append` functions to use "tries" and avoid confusion or repetition ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-f66d8f25356ffd054d00fbce7af2f5d3e9b8c1700f1a9aa31d8afd9ea16bbd04L29-R29), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-491e2325bbefc3d3da124c846a549be35bfb118648bdf3166971aec57cf53d0fL19-R20), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-ec48ce21e577b8cddc8acc4a281f617df5d5e53fd19462445c206f4a03a64e7dL24-R25), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-597fc688845d0467fe270baf2e65a64eb533ac785f634b0d954a817fc3001db6L54-R55), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-597fc688845d0467fe270baf2e65a64eb533ac785f634b0d954a817fc3001db6L132-R134), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-4d8978da445d7babd96c096c86416b20ed658ebb83dca96f12c5c43f16cc3d61L1004-R1005))
*  Add "str" to comment for `str` method of `Cookie` struct in `vlib/net/http/cookie.v` ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-518d796e26587dedb98e07d3cbcde97ae310558dd10b573652632ebffe415960L108-R108))
*  Add period to comment for `parse_disposition` function in `vlib/net/http/request.v` ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995L447-R447))
*  Add comments for `open_uri` functions in `vlib/os/open_uri_default.c.v` and `vlib/os/open_uri_windows.c.v` ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-eb0877f6b88b35072e4427f4ebb1b92d78f87b1a17e04d9eba8ec918aed8a1d2R3), [link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-4e14ca683e3c4d080047bc6be6e9cc486ee484a1ff12b684a88467d46b6357feR7))
*  Rephrase comment for `input` function in `vlib/os/os.v` to avoid "error" ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09L291-R291))
*  Capitalize "Returns" in comment for `open` function in `vlib/dl/dl_nix.c.v` ([link](https://github.com/vlang/v/pull/19231/files?diff=unified&w=0#diff-a44c5e5ae5b2dfabc564c2adaff2fdd92575ba8378d7e6a29e5cd0612f5eadabL26-R26))
