### PR TITLE
time: check if a day is a valid day of its month

### DIFF
--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -276,8 +276,16 @@ fn (mut p DateTimeParser) parse() !Time {
 		}
 	}
 
-	if !is_leap_year(year_) && month_ == 2 && day_in_month == 29 {
-		return error_invalid_time(0, '${year_}-${month_}-${day_in_month} is only valid in a leap year')
+	if month_ == 2 {
+		feb_days_in_year := if is_leap_year(year_) { 29 } else { 28 }
+		if day_in_month > feb_days_in_year {
+			return error_invalid_time(0, 'February has only 28 days in the given year')
+		}
+	} else if day_in_month == 31 && month_ !in [1, 3, 5, 7, 8, 10, 12] {
+		month_name := Time{
+			month: month_
+		}.custom_format('MMMM')
+		return error_invalid_time(0, '${month_name} has only 30 days')
 	}
 
 	return new_time(

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -276,6 +276,10 @@ fn (mut p DateTimeParser) parse() !Time {
 		}
 	}
 
+	if !is_leap_year(year_) && month_ == 2 && day_in_month == 29 {
+		return error_invalid_time(0, '${year_}-${month_}-${day_in_month} is only valid in a leap year')
+	}
+
 	return new_time(
 		year: year_
 		month: month_


### PR DESCRIPTION
Closes #19230

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b56aa7</samp>

Improved date validation in `time` module by adding leap year check in `date_time_parser.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b56aa7</samp>

*  Add a new variable `needs_leap_year` to track if the parsed date requires a leap year or not ([link](https://github.com/vlang/v/pull/19232/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5R143))
*  Assign `needs_leap_year` to true if the parsed month is February and the parsed day is 0 or 29, otherwise false, for different date formats ([link](https://github.com/vlang/v/pull/19232/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5R166-R170), [link](https://github.com/vlang/v/pull/19232/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5R179-R183), [link](https://github.com/vlang/v/pull/19232/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5R203-R207))
*  Return an invalid time error if `needs_leap_year` is true but the parsed year is not a leap year, to prevent invalid dates ([link](https://github.com/vlang/v/pull/19232/files?diff=unified&w=0#diff-8786731737afd46ad1e0b033406b21dd95d9557bcf1e139adb8bcaa9367b27d5R295-R298))
