### PR TITLE
builtin: add support for `-d bultin_writeln_should_write_at_once` and `-d bultin_write_buf_to_fd_should_use_c_write`

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -262,6 +262,12 @@ pub fn println(s string) {
 
 [manualfree]
 fn _writeln_to_fd(fd int, s string) {
+	$if !bultin_writeln_should_write_at_once ? {
+		buf := u8(`\n`)
+		_write_buf_to_fd(fd, s.str, s.len)
+		_write_buf_to_fd(fd, &buf, 1)
+		return
+	}
 	unsafe {
 		buf_len := s.len + 1 // space for \n
 		mut buf := malloc(buf_len)
@@ -282,7 +288,7 @@ fn _write_buf_to_fd(fd int, buf &u8, buf_len int) {
 	mut ptr := unsafe { buf }
 	mut remaining_bytes := isize(buf_len)
 	mut x := isize(0)
-	$if freestanding || vinix {
+	$if freestanding || vinix || bultin_write_buf_to_fd_should_use_c_write ? {
 		unsafe {
 			for remaining_bytes > 0 {
 				x = C.write(fd, ptr, remaining_bytes)

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -263,9 +263,9 @@ pub fn println(s string) {
 [manualfree]
 fn _writeln_to_fd(fd int, s string) {
 	$if !bultin_writeln_should_write_at_once ? {
-		buf := u8(`\n`)
+		lf := u8(`\n`)
 		_write_buf_to_fd(fd, s.str, s.len)
-		_write_buf_to_fd(fd, &buf, 1)
+		_write_buf_to_fd(fd, &lf, 1)
 		return
 	}
 	unsafe {


### PR DESCRIPTION
Do less allocations for println/eprintln by default.
The old mode where println and eprintln form the final string in memory is still available with `-d bultin_writeln_should_write_at_once` .

Also add the ability to use the vinix/freestanding output mode (i.e. C.write, instead of C.fwrite) directly with `-d bultin_write_buf_to_fd_should_use_c_write` .