### PR TITLE
parser: check struct embed with wrong position (fix #19241)

### DIFF
--- a/vlib/v/fmt/tests/structs_input.vv
+++ b/vlib/v/fmt/tests/structs_input.vv
@@ -8,8 +8,8 @@ struct User {
 }
 
 struct FamousUser {
-pub:
 	User
+pub:
 	aka string
 }
 

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -197,7 +197,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				&& (p.peek_tok.line_nr != p.tok.line_nr || p.peek_tok.kind !in [.name, .amp])
 				&& (p.peek_tok.kind != .lsbr || p.peek_token(2).kind != .rsbr))
 				|| p.peek_tok.kind == .dot) && language == .v && p.peek_tok.kind != .key_fn
-			is_on_top := ast_fields.len == 0 && !(is_field_mut || is_field_global)
+			is_on_top := ast_fields.len == 0 && !(is_field_pub || is_field_mut || is_field_global)
 			mut field_name := ''
 			mut typ := ast.Type(0)
 			mut type_pos := token.Pos{}

--- a/vlib/v/parser/tests/struct_embed_wrong_pos_in_pub_err.out
+++ b/vlib/v/parser/tests/struct_embed_wrong_pos_in_pub_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/struct_embed_wrong_pos_in_pub_err.vv:6:5: error: struct embedding must be declared at the beginning of the struct body
+    4 | pub struct ThreadSafeLog {
+    5 | pub:
+    6 |     Log
+      |     ~~~
+    7 | pub mut:
+    8 |     mu Xyz

--- a/vlib/v/parser/tests/struct_embed_wrong_pos_in_pub_err.vv
+++ b/vlib/v/parser/tests/struct_embed_wrong_pos_in_pub_err.vv
@@ -1,0 +1,11 @@
+struct Log {}
+struct Xyz {}
+
+pub struct ThreadSafeLog {
+pub:
+    Log
+pub mut:
+    mu Xyz
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check struct embed with wrong position (fix #19241).

- Check struct embed with wrong position.
- Add test.

```v
struct Log {}
struct Xyz {}

pub struct ThreadSafeLog {
pub:
    Log
pub mut:
    mu Xyz
}

fn main() {}

PS D:\Test\v\tt1> v run .
tt1.v:6:5: error: struct embedding must be declared at the beginning of the struct body
    4 | pub struct ThreadSafeLog {
    5 | pub:
    6 |     Log
      |     ~~~
    7 | pub mut:
    8 |     mu Xyz

PS D:\Test\v\tt1> v fmt -w tt1.v   
tt1.v:6:5: error: struct embedding must be declared at the beginning of the struct body
    4 | pub struct ThreadSafeLog {
    5 | pub:
    6 |     Log
      |     ~~~
    7 | pub mut:
    8 |     mu Xyz

Internal vfmt error while formatting file: tt1.v.
Encountered a total of: 1 errors.
```