### PR TITLE
cgen: fix mixed fixed array and array initializing (fix #19244)

### DIFF
--- a/vlib/v/tests/mixed_fixed_array_and_array_init_test.v
+++ b/vlib/v/tests/mixed_fixed_array_and_array_init_test.v
@@ -1,0 +1,24 @@
+fn test_mixed_fixed_array_and_array_init1() {
+	a := [0.312, 12.0213]!
+	b := [0.23, 2131.213]!
+	ab := [a, b]
+	println(ab)
+	assert '${ab}' == '[[0.312, 12.0213], [0.23, 2131.213]]'
+}
+
+fn test_mixed_fixed_array_and_array_init2() {
+	a := [0.312, 12.0213]!
+	b := [0.23, 2131.213]!
+	mut ab := [a]
+	ab << b
+	println(ab)
+	assert '${ab}' == '[[0.312, 12.0213], [0.23, 2131.213]]'
+}
+
+fn test_mixed_fixed_array_and_array_init3() {
+	a := [0.312, 12.0213]!
+	b := [0.23, 2131.213]!
+	mut ab := [a, b]!
+	println(ab)
+	assert '${ab}' == '[[0.312, 12.0213], [0.23, 2131.213]]'
+}


### PR DESCRIPTION
This PR fix mixed fixed array and array initializing (fix #19244).

- Fix mixed fixed array and array initializing.
- Add test.

```v
fn main(){
	a := [0.312, 12.0213]!
	b := [0.23, 2131.213]!
	ab := [a, b]
	println(ab)
}

PS D:\Test\v\tt1> v run .    
[[0.312, 12.0213], [0.23, 2131.213]]
```
```v
fn main(){
	a := [0.312, 12.0213]!
	b := [0.23, 2131.213]!
	mut ab := [a]
	ab << b
	println(ab)
}

PS D:\Test\v\tt1> v run .
[[0.312, 12.0213], [0.23, 2131.213]]
```
```v
fn main(){
	a := [0.312, 12.0213]!
	b := [0.23, 2131.213]!
	mut ab := [a,b]!
	println(ab)
}

PS D:\Test\v\tt1> v run .
[[0.312, 12.0213], [0.23, 2131.213]]
```