### PR TITLE
docs: fix #19249

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1231,7 +1231,7 @@ The behaviour depends on the parent's capacity and is predictable:
 
 ```v
 mut a := []int{len: 5, cap: 6, init: 2}
-mut b := a[1..4]
+mut b := unsafe { a[1..4] }
 a << 3
 // no reallocation - fits in `cap`
 b[2] = 13 // `a[3]` is modified


### PR DESCRIPTION
`a[1..4]` should have `unsafe { a[1..4] }` or `a[1..4].clone()`



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->
