### PR TITLE
os: update TOCTOU example in readme

### DIFF
--- a/vlib/os/README.md
+++ b/vlib/os/README.md
@@ -23,28 +23,32 @@ so that <b>TOCTOU</b> is no longer possible.
 
 <table>
 <tr>
+<td>Possibility for TOCTOU attack</td>
+<td>TOCTOU not possible</td>
+</tr>
+<tr>
 <td>
-Possibility for TOCTOU attack
 
-```v ignore 
-if os.is_writable("file"){
+```v ignore
+if os.is_writable("file") {
+    // time to make a quick attack
+    // (e.g. symlink /etc/passwd to `file`)
 
-    // >> time to make a quick attack (e.g. symlink /etc/passwd to >file<) <<
-
-    mut f := os.create('path/to/file') ?
-        // <do something with file>
+    mut f := os.create('path/to/file')!
+    // do something with file
     f.close()
 }
 ```
 </td>
-<td>TOCTOU not possible
+<td>
 
 ```v ignore
 mut f := os.create('path/to/file') or {
     println("file not writable")
 }
 
-// >> do something with file; file is locked <<
+// file is locked
+// do something with file
 
 f.close()
 ```


### PR DESCRIPTION
Updates the examples in the os modules readme. 
The change is mainly concerned with improving support when viewing it in narrower windows. 

E.g. on https://modules.vlang.io/os.html up until a window width of about 1300-1400px, it's not visible that the example has a right part of how to do it correctly at all.

Hopefully, also improves general readability of the examples.

GH rendered preview:
current: https://github.com/vlang/v/blob/master/vlib/os/README.md
suggestion: https://github.com/ttytm/v/blob/os/update-readme/vlib/os/README.md