### PR TITLE
checker: disallow casting string to enum

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3231,6 +3231,11 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				}
 			}
 		}
+		// don't allow casting `string` to `enum`, and suggest using `enum_name.type_to_string(str)` instead
+		if mut node.expr is ast.StringLiteral {
+			c.add_error_detail('use ${c.table.type_to_str(node.typ)}.from_string(\'${node.expr.val}\') instead')
+			c.error('cannot cast `string` to `enum`', node.pos)
+		}
 	}
 	node.typname = c.table.sym(node.typ).name
 	return node.typ

--- a/vlib/v/checker/tests/string_to_enum_cast_err.out
+++ b/vlib/v/checker/tests/string_to_enum_cast_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/string_to_enum_cast_err.vv:8:7: error: cannot cast `string` to `enum`
+    6 | 
+    7 | fn main() {
+    8 |     _ := Test('one')
+      |          ~~~~~~~~~~~
+    9 | }
+Details: use main.Test.from_string('one') instead

--- a/vlib/v/checker/tests/string_to_enum_cast_err.vv
+++ b/vlib/v/checker/tests/string_to_enum_cast_err.vv
@@ -1,0 +1,9 @@
+enum Test {
+	one
+	two
+	three
+}
+
+fn main() {
+	_ := Test('one')
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19258

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32b8e3e</samp>

This pull request fixes a bug that allowed casting string literals to enum types, which is not supported in V. It adds a check and an error message in the checker, and a test case with an expected output to verify the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32b8e3e</samp>

*  Add a check and an error message for casting a string literal to an enum type ([link](https://github.com/vlang/v/pull/19260/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R3234-R3238))
*  Add a test case and an expected output file to verify the check and the error message ([link](https://github.com/vlang/v/pull/19260/files?diff=unified&w=0#diff-92f4b654cf712b338672ec2c36a5ddb25eff2b3e0a52441684d572d6793e83c8R1-R7), [link](https://github.com/vlang/v/pull/19260/files?diff=unified&w=0#diff-863b8adf73ccce9059dc4495ce45c74392be5ba715955625c932ecd0a40b6fa9R1-R9))
