### PR TITLE
vdoc: improve html tag escape

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -12,16 +12,16 @@ import v.pref
 import v.util { tabs }
 
 const (
-	css_js_assets           = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
-	default_theme           = os.resource_abs_path('theme')
-	link_svg                = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
+	css_js_assets                 = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
+	default_theme                 = os.resource_abs_path('theme')
+	link_svg                      = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 
-	single_quote            = "'"
-	double_quote            = '"'
-	no_quotes_replacement   = [single_quote, '', double_quote, '']
+	single_quote                  = "'"
+	double_quote                  = '"'
+	no_quotes_replacement         = [single_quote, '', double_quote, '']
 
-	html_tag_escape         = ['<', '&lt;', '>', '&gt;']
-	html_tag_quote_unescape = ['`&lt;', '`<', '&gt;`', '>`']
+	html_tag_escape_replacement   = ['<', '&lt;', '>', '&gt;']
+	html_tag_unescape_replacement = ['`&lt;', '`<', '&gt;`', '>`']
 )
 
 enum HighlightTokenTyp {
@@ -452,7 +452,7 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 }
 
 fn html_tag_escape(str string) string {
-	return str.replace_each(html_tag_escape).replace_each(html_tag_quote_unescape)
+	return str.replace_each(html_tag_escape_replacement).replace_each(html_tag_unescape_replacement)
 }
 
 /*

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -4,6 +4,7 @@ import os
 import net.urllib
 import strings
 import markdown
+import regex
 import v.scanner
 import v.ast
 import v.token
@@ -12,16 +13,15 @@ import v.pref
 import v.util { tabs }
 
 const (
-	css_js_assets                 = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
-	default_theme                 = os.resource_abs_path('theme')
-	link_svg                      = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
+	css_js_assets               = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
+	default_theme               = os.resource_abs_path('theme')
+	link_svg                    = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 
-	single_quote                  = "'"
-	double_quote                  = '"'
-	no_quotes_replacement         = [single_quote, '', double_quote, '']
+	single_quote                = "'"
+	double_quote                = '"'
+	no_quotes_replacement       = [single_quote, '', double_quote, '']
 
-	html_tag_escape_replacement   = ['<', '&lt;', '>', '&gt;']
-	html_tag_unescape_replacement = ['`&lt;', '`<', '&gt;`', '>`']
+	html_tag_escape_replacement = ['<', '&lt;', '>', '&gt;']
 )
 
 enum HighlightTokenTyp {
@@ -452,7 +452,12 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 }
 
 fn html_tag_escape(str string) string {
-	return str.replace_each(html_tag_escape_replacement).replace_each(html_tag_unescape_replacement)
+	escaped_string := str.replace_each(html_tag_escape_replacement)
+	mut re := regex.regex_opt(r'`.+[(&lt;)(&gt;)].+`') or { regex.RE{} }
+	if re.find_all_str(escaped_string).len > 0 {
+		return str
+	}
+	return escaped_string
 }
 
 /*

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -4,7 +4,6 @@ import os
 import net.urllib
 import strings
 import markdown
-import regex
 import v.scanner
 import v.ast
 import v.token
@@ -13,13 +12,16 @@ import v.pref
 import v.util { tabs }
 
 const (
-	css_js_assets         = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
-	default_theme         = os.resource_abs_path('theme')
-	link_svg              = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
+	css_js_assets           = ['doc.css', 'normalize.css', 'doc.js', 'dark-mode.js']
+	default_theme           = os.resource_abs_path('theme')
+	link_svg                = '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 
-	single_quote          = "'"
-	double_quote          = '"'
-	no_quotes_replacement = [single_quote, '', double_quote, '']
+	single_quote            = "'"
+	double_quote            = '"'
+	no_quotes_replacement   = [single_quote, '', double_quote, '']
+
+	html_tag_escape         = ['<', '&lt;', '>', '&gt;']
+	html_tag_quote_unescape = ['`&lt;', '`<', '&gt;`', '>`']
 )
 
 enum HighlightTokenTyp {
@@ -450,12 +452,7 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 }
 
 fn html_tag_escape(str string) string {
-	escaped_string := str.replace_each(['<', '&lt;', '>', '&gt;'])
-	mut re := regex.regex_opt(r'`.+[(&lt;)(&gt;)].+`') or { regex.RE{} }
-	if re.find_all_str(escaped_string).len > 0 {
-		return str
-	}
-	return escaped_string
+	return str.replace_each(html_tag_escape).replace_each(html_tag_quote_unescape)
 }
 
 /*

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -22,6 +22,7 @@ const (
 	no_quotes_replacement       = [single_quote, '', double_quote, '']
 
 	html_tag_escape_replacement = ['<', '&lt;', '>', '&gt;']
+	html_tag_escape_re          = regex.regex_opt(r'`.+[(&lt;)(&gt;)].+`') or { panic(err) }
 )
 
 enum HighlightTokenTyp {
@@ -453,7 +454,7 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 
 fn html_tag_escape(str string) string {
 	escaped_string := str.replace_each(html_tag_escape_replacement)
-	mut re := regex.regex_opt(r'`.+[(&lt;)(&gt;)].+`') or { regex.RE{} }
+	mut re := html_tag_escape_re
 	if re.find_all_str(escaped_string).len > 0 {
 		return str
 	}


### PR DESCRIPTION
current tag escape with regex: `536.382ms`
tag escape new: `79.732ms` (`50.160ms` when using constants)

There are not too many `replace_each` occurrences in the code base. If they don't use consts, should we replace the array arguments with constants for all functions that are called often internally and for potentially often called pub fns?