### PR TITLE
stbi: add params to `load_from_memory()`

### DIFF
--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -135,14 +135,13 @@ pub fn load(path string, params LoadParams) !Image {
 }
 
 // load_from_memory load an image from a memory buffer
-pub fn load_from_memory(buf &u8, bufsize int) !Image {
+pub fn load_from_memory(buf &u8, bufsize int, params LoadParams) !Image {
 	mut res := Image{
 		ok: true
 		data: 0
 	}
-	flag := C.STBI_rgb_alpha
 	res.data = C.stbi_load_from_memory(buf, bufsize, &res.width, &res.height, &res.nr_channels,
-		flag)
+		params.desired_channels)
 	if isnil(res.data) {
 		return error('stbi_image failed to load from memory')
 	}


### PR DESCRIPTION
Add `LoadParams` to `load_from_memory`

`LoadParams` are a parameter for `load()` but `load_from_memory()` defaults to `C.STBI_rgb_alpha` (4 channels)

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c91bc02</samp>

Modified `load_from_memory` to take a `LoadParams` struct for specifying image channels. This enables loading images with different formats in `stbi`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c91bc02</samp>

*  Add support for loading images with different channel formats ([link](https://github.com/vlang/v/pull/19268/files?diff=unified&w=0#diff-3566edbb636a40b3c608bb8b51fb2403f57929e1626e96f39ccb7256f0573a99L138-R144),                             
