### PR TITLE
parser: fix fixed array with eval const size (fix #19265)

### DIFF
--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -44,3 +44,18 @@ fn test_int_const_used_as_fixed_array_size() {
 	dump(bb.len)
 	assert aa.len == 10_000
 }
+
+const (
+	rows = 4
+	cols = 4
+)
+
+struct Matrix {
+	data [rows * cols]int
+}
+
+fn test_infix_const_expr_used_as_fixed_array_size() {
+	mat := Matrix{}
+	println(mat)
+	assert mat.data.len == 16
+}


### PR DESCRIPTION
This PR fix fixed array with eval const size (fix #19265).

- Fix fixed array with eval const size.
- Add test.

```v
const (
	rows = 4
	cols = 4
)

struct Matrix {
	data [rows * cols]int
}

fn main() {
	mat := Matrix{}
	println(mat)
	assert mat.data.len == 16
}

PS D:\Test\v\tt1> v run .
Matrix{
    data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
}
```