### PR TITLE
vdoc: update html escape test to cover more cases

### DIFF
--- a/cmd/tools/vdoc/html_tag_escape_test.v
+++ b/cmd/tools/vdoc/html_tag_escape_test.v
@@ -1,6 +1,6 @@
 module main
 
 fn test_html_tag_escape() {
-	assert html_tag_escape('assert <abc> 123') == 'assert &lt;abc&gt; 123'
-	assert html_tag_escape('`assert <abc> 123`') == '`assert <abc> 123`'
+	assert html_tag_escape('abc <b>bold</b> 123') == 'abc &lt;b&gt;bold&lt;/b&gt; 123'
+	assert html_tag_escape('`abc <b>bold</b> 123`') == '`abc <b>bold</b> 123`'
 }

--- a/cmd/tools/vdoc/html_tag_escape_test.v
+++ b/cmd/tools/vdoc/html_tag_escape_test.v
@@ -1,6 +1,6 @@
 module main
 
 fn test_html_tag_escape() {
-	assert html_tag_escape('<abc>') == '&lt;abc&gt;'
-	assert html_tag_escape('`<abc>`') == '`<abc>`'
+	assert html_tag_escape('assert <abc> 123') == 'assert &lt;abc&gt; 123'
+	assert html_tag_escape('`assert <abc> 123`') == '`assert <abc> 123`'
 }


### PR DESCRIPTION

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ec1f5b</samp>

Improved the test cases for the `html_tag_escape` function in `cmd/tools/vdoc/html_tag_escape_test.v`. This function is used to escape HTML tags in code blocks for documentation generation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ec1f5b</samp>

* Escape HTML tags in code blocks when generating documentation with `vdoc` ([link](https://github.com/vlang/v/pull/19272/files?diff=unified&w=0#diff-849d255b72543e64cebf7df17cd2de1a827acb0da04b84c349aeeca8a05bf4ebL4-R5),F
