### PR TITLE
Un-define MBEDTLS_HAVE_X86_64 when compiling with tcc

### DIFF
--- a/thirdparty/mbedtls/library/aesni.h
+++ b/thirdparty/mbedtls/library/aesni.h
@@ -34,13 +34,9 @@
 
 #if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) &&  \
     ( defined(__amd64__) || defined(__x86_64__) )   &&  \
-    ! defined(MBEDTLS_HAVE_X86_64)
+    ! defined(MBEDTLS_HAVE_X86_64) && \
+    ! defined(__TINYC__)
 #define MBEDTLS_HAVE_X86_64
-#endif
-
-#if defined(__TINYC__)
-// TCC does not support the assembly instructions in aesni.c
-#undef MBEDTLS_HAVE_X86_64
 #endif
 
 #if defined(MBEDTLS_HAVE_X86_64)

--- a/thirdparty/mbedtls/library/aesni.h
+++ b/thirdparty/mbedtls/library/aesni.h
@@ -38,6 +38,11 @@
 #define MBEDTLS_HAVE_X86_64
 #endif
 
+#if defined(__TINYC__)
+// TCC does not support the assembly instructions in aesni.c
+#undef MBEDTLS_HAVE_X86_64
+#endif
+
 #if defined(MBEDTLS_HAVE_X86_64)
 
 #ifdef __cplusplus


### PR DESCRIPTION
thirdparty/mbedtls: Do not use hand-written assembly language when compiling with tcc.

While the tcc compiler does support some of the SSE instructions, it does not support all of them.  And, in particular, it doesn't support movdqu which is used in the assembly language instructions in aesni.c.

Looking at the assembler in tcc, it dos not appear to be trivial to add support for the missing SSE instructions needed by aesni.c.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e03d002</samp>

Disable AES-NI assembly instructions for TCC in `aesni.h`. This allows V to compile with TCC as a backend option.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e03d002</samp>

* Disable AES-NI assembly instructions for TCC compiler ([link](https://github.com/vlang/v/pull/19273/files?diff=unified&w=0#diff-53566f2fef73f277b1770dfce967b823919b8a3e9c254b64a706cc793403192aR41-R45))
