### PR TITLE
parser, transformer: fix transformer.infix_expr() and cleanup parse_types.v (related #19269)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -38,7 +38,8 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 							} else {
 								if mut const_field.expr is ast.InfixExpr {
 									// QUESTION: this should most likely no be done in the parser, right?
-									mut t := transformer.new_transformer(p.pref)
+									mut t := transformer.new_transformer_with_table(p.table,
+										p.pref)
 									folded_expr := t.infix_expr(mut const_field.expr)
 
 									if folded_expr is ast.IntegerLiteral {
@@ -62,7 +63,7 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 						fixed_size = 1
 						show_non_const_error = false
 					} else {
-						mut t := transformer.new_transformer(p.pref)
+						mut t := transformer.new_transformer_with_table(p.table, p.pref)
 						folded_expr := t.infix_expr(mut size_expr)
 
 						if folded_expr is ast.IntegerLiteral {
@@ -71,18 +72,13 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 						}
 					}
 					if show_non_const_error {
-						p.error_with_pos('non-constant array bound `${size_expr}`', size_expr.pos)
+						p.error_with_pos('fixed array size cannot use non-constant eval value',
+							size_expr.pos)
 					}
 				}
 				else {
-					if p.pref.is_fmt {
-						// for vfmt purposes, pretend the constant does exist
-						// it may have been defined in another .v file:
-						fixed_size = 1
-					} else {
-						p.error_with_pos('fixed array size cannot use non-constant value',
-							size_expr.pos())
-					}
+					p.error_with_pos('fixed array size cannot use non-constant value',
+						size_expr.pos())
 				}
 			}
 		}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -71,13 +71,18 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 						}
 					}
 					if show_non_const_error {
-						p.error_with_pos('fixed array size cannot use non-constant value',
-							size_expr.pos)
+						p.error_with_pos('non-constant array bound `${size_expr}`', size_expr.pos)
 					}
 				}
 				else {
-					p.error_with_pos('fixed array size cannot use non-constant value',
-						size_expr.pos())
+					if p.pref.is_fmt {
+						// for vfmt purposes, pretend the constant does exist
+						// it may have been defined in another .v file:
+						fixed_size = 1
+					} else {
+						p.error_with_pos('fixed array size cannot use non-constant value',
+							size_expr.pos())
+					}
 				}
 			}
 		}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -65,7 +65,13 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 					if folded_expr is ast.IntegerLiteral {
 						fixed_size = folded_expr.val.int()
 					} else {
-						show_non_const_error = true
+						if p.pref.is_fmt {
+							// for vfmt purposes, pretend the constant does exist
+							// it may have been defined in another .v file:
+							fixed_size = 1
+						} else {
+							show_non_const_error = true
+						}
 					}
 					if show_non_const_error {
 						p.error_with_pos('fixed array size cannot use non-constant value',

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -39,15 +39,15 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 					} else {
 						show_non_const_error = true
 					}
-				}
-			} else {
-				if p.pref.is_fmt {
+				} else if p.pref.is_fmt {
 					// for vfmt purposes, pretend the constant does exist
 					// it may have been defined in another .v file:
 					fixed_size = 1
 				} else {
 					show_non_const_error = true
 				}
+			} else {
+				show_non_const_error = true
 			}
 
 			if show_non_const_error {

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -25,29 +25,29 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 				}
 				ast.Ident {
 					mut show_non_const_error := true
-					if p.pref.is_fmt {
-						// for vfmt purposes, pretend the constant does exist
-						// it may have been defined in another .v file:
-						fixed_size = 1
-						show_non_const_error = false
-					} else {
-						if mut const_field := p.table.global_scope.find_const('${p.mod}.${size_expr.name}') {
-							if mut const_field.expr is ast.IntegerLiteral {
-								fixed_size = const_field.expr.val.int()
-								show_non_const_error = false
-							} else {
-								if mut const_field.expr is ast.InfixExpr {
-									// QUESTION: this should most likely no be done in the parser, right?
-									mut t := transformer.new_transformer_with_table(p.table,
-										p.pref)
-									folded_expr := t.infix_expr(mut const_field.expr)
+					if mut const_field := p.table.global_scope.find_const('${p.mod}.${size_expr.name}') {
+						if mut const_field.expr is ast.IntegerLiteral {
+							fixed_size = const_field.expr.val.int()
+							show_non_const_error = false
+						} else {
+							if mut const_field.expr is ast.InfixExpr {
+								// QUESTION: this should most likely no be done in the parser, right?
+								mut t := transformer.new_transformer_with_table(p.table,
+									p.pref)
+								folded_expr := t.infix_expr(mut const_field.expr)
 
-									if folded_expr is ast.IntegerLiteral {
-										fixed_size = folded_expr.val.int()
-										show_non_const_error = false
-									}
+								if folded_expr is ast.IntegerLiteral {
+									fixed_size = folded_expr.val.int()
+									show_non_const_error = false
 								}
 							}
+						}
+					} else {
+						if p.pref.is_fmt {
+							// for vfmt purposes, pretend the constant does exist
+							// it may have been defined in another .v file:
+							fixed_size = 1
+							show_non_const_error = false
 						}
 					}
 					if show_non_const_error {
@@ -57,19 +57,12 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 				}
 				ast.InfixExpr {
 					mut show_non_const_error := true
-					if p.pref.is_fmt {
-						// for vfmt purposes, pretend the constant does exist
-						// it may have been defined in another .v file:
-						fixed_size = 1
-						show_non_const_error = false
-					} else {
-						mut t := transformer.new_transformer_with_table(p.table, p.pref)
-						folded_expr := t.infix_expr(mut size_expr)
+					mut t := transformer.new_transformer_with_table(p.table, p.pref)
+					folded_expr := t.infix_expr(mut size_expr)
 
-						if folded_expr is ast.IntegerLiteral {
-							fixed_size = folded_expr.val.int()
-							show_non_const_error = false
-						}
+					if folded_expr is ast.IntegerLiteral {
+						fixed_size = folded_expr.val.int()
+						show_non_const_error = false
 					}
 					if show_non_const_error {
 						p.error_with_pos('fixed array size cannot use non-constant eval value',

--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -46,16 +46,16 @@ fn test_int_const_used_as_fixed_array_size() {
 }
 
 const (
-	rows = 4
-	cols = 4
+	rows = 2
+	cols = 3
 )
 
 struct Matrix {
-	data [rows * cols]int
+	data [rows * cols + 1]int
 }
 
 fn test_infix_const_expr_used_as_fixed_array_size() {
 	mat := Matrix{}
 	println(mat)
-	assert mat.data.len == 16
+	assert mat.data.len == 7
 }

--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -51,11 +51,11 @@ const (
 )
 
 struct Matrix {
-	data [rows * cols + 1]int
+	data [rows * cols]int
 }
 
 fn test_infix_const_expr_used_as_fixed_array_size() {
 	mat := Matrix{}
 	println(mat)
-	assert mat.data.len == 7
+	assert mat.data.len == 6
 }

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -712,7 +712,7 @@ pub fn (mut t Transformer) call_expr(mut node ast.CallExpr) ast.Expr {
 fn (mut t Transformer) trans_const_value_to_literal(mut expr ast.Expr) {
 	mut expr_ := expr
 	if mut expr_ is ast.Ident {
-		if mut obj := expr_.scope.find_const(expr_.mod + '.' + expr_.name) {
+		if mut obj := t.table.global_scope.find_const(expr_.mod + '.' + expr_.name) {
 			if mut obj.expr is ast.BoolLiteral {
 				expr = obj.expr
 			} else if mut obj.expr is ast.IntegerLiteral {

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -695,7 +695,8 @@ pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
 				}
 				else {}
 			}
-		}*/
+		}
+		*/
 		else {}
 	}
 	return node
@@ -708,9 +709,39 @@ pub fn (mut t Transformer) call_expr(mut node ast.CallExpr) ast.Expr {
 	return node
 }
 
+fn (mut t Transformer) trans_const_value_to_literal(mut expr ast.Expr) {
+	mut expr_ := expr
+	if mut expr_ is ast.Ident {
+		if mut obj := expr_.scope.find_const(expr_.mod + '.' + expr_.name) {
+			if mut obj.expr is ast.BoolLiteral {
+				expr = obj.expr
+			} else if mut obj.expr is ast.IntegerLiteral {
+				expr = obj.expr
+			} else if mut obj.expr is ast.FloatLiteral {
+				expr = obj.expr
+			} else if mut obj.expr is ast.StringLiteral {
+				expr = obj.expr
+			} else if mut obj.expr is ast.InfixExpr {
+				folded_expr := t.infix_expr(mut obj.expr)
+				if folded_expr is ast.BoolLiteral {
+					expr = folded_expr
+				} else if folded_expr is ast.IntegerLiteral {
+					expr = folded_expr
+				} else if folded_expr is ast.FloatLiteral {
+					expr = folded_expr
+				} else if folded_expr is ast.StringLiteral {
+					expr = folded_expr
+				}
+			}
+		}
+	}
+}
+
 pub fn (mut t Transformer) infix_expr(mut node ast.InfixExpr) ast.Expr {
 	node.left = t.expr(mut node.left)
+	t.trans_const_value_to_literal(mut node.left)
 	node.right = t.expr(mut node.right)
+	t.trans_const_value_to_literal(mut node.right)
 
 	mut pos := node.left.pos()
 	pos.extend(node.pos)

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -739,9 +739,11 @@ fn (mut t Transformer) trans_const_value_to_literal(mut expr ast.Expr) {
 
 pub fn (mut t Transformer) infix_expr(mut node ast.InfixExpr) ast.Expr {
 	node.left = t.expr(mut node.left)
-	t.trans_const_value_to_literal(mut node.left)
 	node.right = t.expr(mut node.right)
-	t.trans_const_value_to_literal(mut node.right)
+	if !t.pref.translated {
+		t.trans_const_value_to_literal(mut node.left)
+		t.trans_const_value_to_literal(mut node.right)
+	}
 
 	mut pos := node.left.pos()
 	pos.extend(node.pos)


### PR DESCRIPTION
This PR fix transformer.infix_expr() and cleanup parse_types.v (related #19269).

- Fix transformer.infix_expr() and cleanup parse_types.v.
- Add test.

```v
const (
	rows = 2
	cols = 3
)

struct Matrix {
	data [rows * cols + 1]int
}

fn main() {
	mat := Matrix{}
	println(mat)
}

PS D:\Test\v\tt1> v run .
Matrix{
    data: [0, 0, 0, 0, 0, 0, 0]
}
```