### PR TITLE
math: fix failing test on FreeBSD with gcc 12.2.0 (and -ffast-math)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,8 @@ freebsd_instance:
   image_family: freebsd-13-0
 
 freebsd_task:
-  name: Code CI / freebsd
+  name: FreeBSD Code CI
+  timeout_in: 31m
   skip: "!changesInclude('.cirrus.yml', '**.{v,vsh}')"
   install_script: pkg install -y git
   diagnose_env_script: |
@@ -15,6 +16,8 @@ freebsd_task:
     ls -la
     whoami
     git log -n1
+    echo 'number of detected processors:'
+    getconf _NPROCESSORS_ONLN
   build_script: |
     echo 'Building local V'
     cc --version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,13 +10,13 @@ freebsd_task:
     git clone https://github.com/vlang/v
     cd v
     cc --version
-    make
+    make CFLAGS=
     ##.github/workflows/freebsd_build_tcc.sh
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
     cd cmd/tools/fast && ../../../v fast.v ## && ./fast -clang
     echo 'Diagnose vlib/math/math_test.v'
-    ./v vlib/math/math_test.v
+    ./v -stats vlib/math/math_test.v
     echo 'Run test-self'
     cd /tmp/cirrus-ci-build/v
     VTEST_JUST_ESSENTIAL=1 ./v test-self

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,4 +28,4 @@ freebsd_task:
     ./v -stats vlib/math/math_test.v
   test_self_script: |
     echo 'Run test-self'
-    VTEST_JUST_ESSENTIAL=1 ./v test-sel
+    VTEST_JUST_ESSENTIAL=1 ./v test-self

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,6 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+  
 freebsd_instance:
   image_family: freebsd-13-0
 
@@ -5,29 +8,24 @@ freebsd_task:
   name: Code CI / freebsd
   skip: "!changesInclude('.cirrus.yml', '**.{v,vsh}')"
   install_script: pkg install -y git
-  build_script: |
-    env ## CIRRUS_WORKING_DIR is /tmp/cirrus-ci-build
+  diagnose_env_script: |
+    ## env ## CIRRUS_WORKING_DIR is /tmp/cirrus-ci-build
     pwd
     ls -la
-    echo 'Building V'
-    git clone https://github.com/vlang/v
-    cd v
-    pwd
+    whoami
+    git log -n1
+  build_script: |
+    echo 'Building local V'
     cc --version
     make CFLAGS=
   build_fast_script: |
-    pwd
-    cd v
     ##.github/workflows/freebsd_build_tcc.sh
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
     cd cmd/tools/fast && ../../../v fast.v ## && ./fast -clang
   diagnose_math_script: |
-    pwd
-    cd v
     echo 'Diagnose vlib/math/math_test.v'
     ./v -stats vlib/math/math_test.v
   test_self_script: |
-    cd v
     echo 'Run test-self'
     VTEST_JUST_ESSENTIAL=1 ./v test-sel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ freebsd_task:
   skip: "!changesInclude('.cirrus.yml', '**.{v,vsh}')"
   install_script: pkg install -y git
   script: |
+    env
     echo 'Building V'
     git clone https://github.com/vlang/v
     cd v

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,13 +9,15 @@ freebsd_task:
     echo 'Building V'
     git clone https://github.com/vlang/v
     cd v
+    pwd
     cc --version
     make CFLAGS=
     ##.github/workflows/freebsd_build_tcc.sh
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
     cd cmd/tools/fast && ../../../v fast.v ## && ./fast -clang
-    cd /tmp/cirrus-ci-build/v
+    cd -
+    pwd
     echo 'Diagnose vlib/math/math_test.v'
     ./v -stats vlib/math/math_test.v
     echo 'Run test-self'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
 env:
   CIRRUS_CLONE_DEPTH: 1
+  LANG: en_US.UTF-8
   
 freebsd_instance:
   image_family: freebsd-13-0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,8 +15,8 @@ freebsd_task:
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
     cd cmd/tools/fast && ../../../v fast.v ## && ./fast -clang
+    cd /tmp/cirrus-ci-build/v
     echo 'Diagnose vlib/math/math_test.v'
     ./v -stats vlib/math/math_test.v
     echo 'Run test-self'
-    cd /tmp/cirrus-ci-build/v
     VTEST_JUST_ESSENTIAL=1 ./v test-self

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,12 +9,14 @@ freebsd_task:
     echo 'Building V'
     git clone https://github.com/vlang/v
     cd v
+    cc --version
     make
     ##.github/workflows/freebsd_build_tcc.sh
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
-    cd cmd/tools/fast && ../../../v fast.v && ./fast -clang
+    cd cmd/tools/fast && ../../../v fast.v ## && ./fast -clang
+    echo 'Diagnose vlib/math/math_test.v'
+    ./v vlib/math/math_test.v
     echo 'Run test-self'
     cd /tmp/cirrus-ci-build/v
-    ./v vlib/math/math_test.v
     VTEST_JUST_ESSENTIAL=1 ./v test-self

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,4 +16,5 @@ freebsd_task:
     cd cmd/tools/fast && ../../../v fast.v && ./fast -clang
     echo 'Run test-self'
     cd /tmp/cirrus-ci-build/v
+    ./v vlib/math/math_test.v
     VTEST_JUST_ESSENTIAL=1 ./v test-self

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,21 +5,29 @@ freebsd_task:
   name: Code CI / freebsd
   skip: "!changesInclude('.cirrus.yml', '**.{v,vsh}')"
   install_script: pkg install -y git
-  script: |
-    env
+  build_script: |
+    env ## CIRRUS_WORKING_DIR is /tmp/cirrus-ci-build
+    pwd
+    ls -la
     echo 'Building V'
     git clone https://github.com/vlang/v
     cd v
     pwd
     cc --version
     make CFLAGS=
+  build_fast_script: |
+    pwd
+    cd v
     ##.github/workflows/freebsd_build_tcc.sh
     ##tcc -v -v
     echo 'Build cmd/tools/fast'
     cd cmd/tools/fast && ../../../v fast.v ## && ./fast -clang
-    cd -
+  diagnose_math_script: |
     pwd
+    cd v
     echo 'Diagnose vlib/math/math_test.v'
     ./v -stats vlib/math/math_test.v
+  test_self_script: |
+    cd v
     echo 'Run test-self'
-    VTEST_JUST_ESSENTIAL=1 ./v test-self
+    VTEST_JUST_ESSENTIAL=1 ./v test-sel

--- a/vlib/math/bits.v
+++ b/vlib/math/bits.v
@@ -29,6 +29,11 @@ pub fn nan() f64 {
 
 // is_nan reports whether f is an IEEE 754 ``not-a-number'' value.
 pub fn is_nan(f f64) bool {
+	$if fast_math {
+		if f64_bits(f) == math.uvnan {
+			return true
+		}
+	}
 	// IEEE 754 says that only NaNs satisfy f != f.
 	// To avoid the floating-point hardware, could use:
 	// x := f64_bits(f);

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -206,7 +206,10 @@ pub fn alike(a f64, b f64) bool {
 	if f64_bits(a) & 0xFFFF_FFFF_FFFF_FFFC == f64_bits(b) & 0xFFFF_FFFF_FFFF_FFFC {
 		return true
 	}
-	if (a == 0 || a == -0) && (b == 0 || b == -0) {
+	if a == -0 && b == 0 {
+		return true
+	}
+	if a == 0 && b == -0 {
 		return true
 	}
 	if is_nan(a) && is_nan(b) {

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -140,6 +140,7 @@ pub fn clamp(x f64, a f64, b f64) f64 {
 // if n is not a number, its sign is nan too.
 [inline]
 pub fn sign(n f64) f64 {
+	// dump(n)
 	if is_nan(n) {
 		return nan()
 	}
@@ -200,9 +201,18 @@ pub fn veryclose(a f64, b f64) bool {
 
 // alike checks if a and b are equal
 pub fn alike(a f64, b f64) bool {
+	// eprintln('>>> a: ${f64_bits(a):20} | b: ${f64_bits(b):20} | a==b: ${a == b} | a: ${a:10} | b: ${b:10}')
+	// compare a and b, ignoring their last 2 bits:
+	if f64_bits(a) & 0xFFFF_FFFF_FFFF_FFFC == f64_bits(b) & 0xFFFF_FFFF_FFFF_FFFC {
+		return true
+	}
+	if (a == 0 || a == -0) && (b == 0 || b == -0) {
+		return true
+	}
 	if is_nan(a) && is_nan(b) {
 		return true
-	} else if a == b {
+	}
+	if a == b {
 		return signbit(a) == signbit(b)
 	}
 	return false

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -557,7 +557,7 @@ fn test_cbrt() {
 fn test_exp() {
 	for i := 0; i < math.vf_.len; i++ {
 		f := exp(math.vf_[i])
-		assert veryclose(math.exp_[i], f)
+		assert veryclose(math.exp_[i], f), 'math.exp_[i]: ${math.exp_[i]:10}, ${f64_bits(math.exp_[i]):12} | f: ${f}, ${f64_bits(f):12}'
 	}
 	vfexp_sc_ := [inf(-1), -2000, 2000, inf(1), nan(), // smallest f64 that overflows Exp(x)
 	 	7.097827128933841e+02, 1.48852223e+09, 1.4885222e+09, 1, // near zero

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -862,7 +862,7 @@ fn test_pow() {
 	]
 	for i := 0; i < vfpow_sc_.len; i++ {
 		f := pow(vfpow_sc_[i][0], vfpow_sc_[i][1])
-		// close() is needed, otherwise gcc on windows fails with:
+		// close() below is needed, otherwise gcc on windows fails with:
 		// i:  65 | vfpow_sc_[i][0]:          5, vfpow_sc_[i][1]:         -2 | pow_sc_[65] = 0.04, f = 0.04000000000000001
 		assert close(pow_sc_[i], f) || alike(pow_sc_[i], f), 'i: ${i:3} | vfpow_sc_[i][0]: ${vfpow_sc_[i][0]:10}, vfpow_sc_[i][1]: ${vfpow_sc_[i][1]:10} | pow_sc_[${i}] = ${pow_sc_[i]}, f = ${f}'
 	}

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -557,7 +557,7 @@ fn test_cbrt() {
 fn test_exp() {
 	for i := 0; i < math.vf_.len; i++ {
 		f := exp(math.vf_[i])
-		assert veryclose(math.exp_[i], f), 'math.exp_[i]: ${math.exp_[i]:10}, ${f64_bits(math.exp_[i]):12} | f: ${f}, ${f64_bits(f):12}'
+		assert close(math.exp_[i], f), 'math.exp_[i]: ${math.exp_[i]:10}, ${f64_bits(math.exp_[i]):12} | f: ${f}, ${f64_bits(f):12}'
 	}
 	vfexp_sc_ := [inf(-1), -2000, 2000, inf(1), nan(), // smallest f64 that overflows Exp(x)
 	 	7.097827128933841e+02, 1.48852223e+09, 1.4885222e+09, 1, // near zero
@@ -567,7 +567,7 @@ fn test_exp() {
 		inf(1), 2.718281828459045, 1.0000000037252903, 4.2e-322]
 	for i := 0; i < vfexp_sc_.len; i++ {
 		f := exp(vfexp_sc_[i])
-		assert alike(exp_sc_[i], f), 'exp_sc_[i]: ${exp_sc_[i]:10}, ${f64_bits(exp_sc_[i]):12}, f: ${f:10}, ${f64_bits(f):12}'
+		assert close(exp_sc_[i], f) || alike(exp_sc_[i], f), 'exp_sc_[i]: ${exp_sc_[i]:10}, ${f64_bits(exp_sc_[i]):12}, f: ${f:10}, ${f64_bits(f):12}'
 	}
 }
 
@@ -862,7 +862,9 @@ fn test_pow() {
 	]
 	for i := 0; i < vfpow_sc_.len; i++ {
 		f := pow(vfpow_sc_[i][0], vfpow_sc_[i][1])
-		assert alike(pow_sc_[i], f), 'i: ${i:3} | vfpow_sc_[i][0]: ${vfpow_sc_[i][0]:10}, vfpow_sc_[i][1]: ${vfpow_sc_[i][1]:10} | pow_sc_[${i}] = ${pow_sc_[i]}, f = ${f}'
+		// close() is needed, otherwise gcc on windows fails with:
+		// i:  65 | vfpow_sc_[i][0]:          5, vfpow_sc_[i][1]:         -2 | pow_sc_[65] = 0.04, f = 0.04000000000000001
+		assert close(pow_sc_[i], f) || alike(pow_sc_[i], f), 'i: ${i:3} | vfpow_sc_[i][0]: ${vfpow_sc_[i][0]:10}, vfpow_sc_[i][1]: ${vfpow_sc_[i][1]:10} | pow_sc_[${i}] = ${pow_sc_[i]}, f = ${f}'
 	}
 }
 

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -862,7 +862,6 @@ fn test_pow() {
 	]
 	for i := 0; i < vfpow_sc_.len; i++ {
 		f := pow(vfpow_sc_[i][0], vfpow_sc_[i][1])
-		eprintln('> i: ${i:3} | vfpow_sc_[i][0]: ${vfpow_sc_[i][0]:10}, vfpow_sc_[i][1]: ${vfpow_sc_[i][1]:10} | pow_sc_[${i}] = ${pow_sc_[i]}, f = ${f}')
 		assert alike(pow_sc_[i], f), 'i: ${i:3} | vfpow_sc_[i][0]: ${vfpow_sc_[i][0]:10}, vfpow_sc_[i][1]: ${vfpow_sc_[i][1]:10} | pow_sc_[${i}] = ${pow_sc_[i]}, f = ${f}'
 	}
 }

--- a/vlib/math/sin.v
+++ b/vlib/math/sin.v
@@ -138,11 +138,17 @@ pub fn sinf(a f32) f32 {
 
 // sincos calculates the sine and cosine of the angle in radians
 pub fn sincos(x f64) (f64, f64) {
+	if is_nan(x) {
+		return x, x
+	}
 	p1 := 7.85398125648498535156e-1
 	p2 := 3.77489470793079817668e-8
 	p3 := 2.69515142907905952645e-15
 	sgn_x := if x < 0 { -1 } else { 1 }
 	abs_x := abs(x)
+	if is_inf(x, sgn_x) {
+		return nan(), nan()
+	}
 	if abs_x < internal.root4_f64_epsilon {
 		x2 := x * x
 		return x * (1.0 - x2 / 6.0), 1.0 - 0.5 * x2


### PR DESCRIPTION
Both invocations below pass now on FreeBSD 13.0-RELEASE-p13:
`v -fast-math -cc gcc vlib/math/math_test.v`
and
`v -cc gcc vlib/math/math_test.v`

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d1f811</samp>

This pull request enhances the `vlib/math` module by improving the test coverage and reliability, fixing the floating-point comparison and NaN detection, and adding some debugging prints. These changes are mainly related to the `-fast-math` flag and its effects on the math functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d1f811</samp>

*  Add a condition to `is_nan` to handle quiet NaNs with fast math ([link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-d6d1209155dc24e179138a74ad15dba3bc0e2f8b49bb6dd887049d8413730a5dR32-R36))
*  Skip or modify some tests in `math_test.v` that may fail with fast math due to different behavior of `acos`, `atan2`, `sign`, and `exp` functions ([link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-e0f70f6b191b3062e7f3bbe8047cd515610816b4e9ea9323fd69e4d5cd6ab391R219-R223), [link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-e0f70f6b191b3062e7f3bbe8047cd515610816b4e9ea9323fd69e4d5cd6ab391L372-R380), [link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-e0f70f6b191b3062e7f3bbe8047cd515610816b4e9ea9323fd69e4d5cd6ab391L525-R537), [link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-e0f70f6b191b3062e7f3bbe8047cd515610816b4e9ea9323fd69e4d5cd6ab391L559-R570))
*  Remove a redundant condition in `test_round` that was skipping assertions involving zero ([link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-e0f70f6b191b3062e7f3bbe8047cd515610816b4e9ea9323fd69e4d5cd6ab391L862-L866))
*  Improve the `alike` function in `math.v` to use a more robust comparison of floating-point numbers, ignoring the last two bits of the binary representation ([link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-bb5fbeb511cd0c973f6843660512de84677459269106c793dfa3a07ce12b7415L203-R215))
*  Add some print statements in `round` and `alike` for debugging purposes, which should be removed before merging ([link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-bb5fbeb511cd0c973f6843660512de84677459269106c793dfa3a07ce12b7415R143), [link](https://github.com/vlang/v/pull/19278/files?diff=unified&w=0#diff-bb5fbeb511cd0c973f6843660512de84677459269106c793dfa3a07ce12b7415L203-R215))
