### PR TITLE
encoding.html: improve hex unescaping, add test

### DIFF
--- a/vlib/encoding/html/escape_test.v
+++ b/vlib/encoding/html/escape_test.v
@@ -48,7 +48,7 @@ fn test_unescape_html() {
 fn test_unescape_all_html() {
 	// Test different formats
 	assert html.unescape('&#39;&#x27;&apos;', all: true) == "'''"
-	assert html.unescape('&#10836; = &#x02a54; = &#X02A54; = &Or;', all: true) == "⩔ = ⩔ = ⩔ = ⩔"
+	assert html.unescape('&#10836; = &#x02a54; = &#X02A54; = &Or;', all: true) == '⩔ = ⩔ = ⩔ = ⩔'
 	// Converse escape tests
 	assert html.unescape('&lt;&gt;&amp;', all: true) == '<>&'
 	assert html.unescape('No change', all: true) == 'No change'

--- a/vlib/encoding/html/escape_test.v
+++ b/vlib/encoding/html/escape_test.v
@@ -48,6 +48,7 @@ fn test_unescape_html() {
 fn test_unescape_all_html() {
 	// Test different formats
 	assert html.unescape('&#39;&#x27;&apos;', all: true) == "'''"
+	assert html.unescape('&#10836; = &#x02a54; = &#X02A54; = &Or;', all: true) == "⩔ = ⩔ = ⩔ = ⩔"
 	// Converse escape tests
 	assert html.unescape('&lt;&gt;&amp;', all: true) == '<>&'
 	assert html.unescape('No change', all: true) == 'No change'


### PR DESCRIPTION


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64c84e2</samp>

Fix a bug in `html.unescape` that caused incorrect decoding of hexadecimal escape sequences. Add a test case for `html.unescape` using the lambda character as an example.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64c84e2</samp>

* Fix bug in `html.unescape` that did not handle hexadecimal escape sequences with uppercase `X` ([link](https://github.com/vlang/v/pull/19279/files?diff=unified&w=0#diff-2d44634831d925adee58f6c78937bcfb295faf81b450eab99ff76893afeee1e6L63-R75))
* Simplify conversion of hexadecimal bytes to runes in `html.unescape` by using arithmetic operations instead of string concatenation and decoding ([link](https://github.com/vlang/v/pull/19279/files?diff=unified&w=0#diff-2d44634831d925adee58f6c78937bcfb295faf81b450eab99ff76893afeee1e6L63-R75))
* Add test case for `html.unescape` to verify that it can handle different cases of hexadecimal escape sequences using the Greek letter lambda as an example ([link](https://github.com/vlang/v/pull/19279/files?diff=unified&w=0#diff-250bfb2602ad7aca917da49342b07d41a28a75ba0d339219c108d54acb34b04eR51))
