### PR TITLE
Properly include utime.h and set defines for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ freebsd_instance:
 freebsd_task:
   name: FreeBSD Code CI
   timeout_in: 31m
-  skip: "!changesInclude('.cirrus.yml', '**.{v,vsh}')"
+  skip: "!changesInclude('.cirrus.yml', '**.{v,vsh}', '**.c', '**.h')"
   install_script: pkg install -y git
   diagnose_env_script: |
     ## env ## CIRRUS_WORKING_DIR is /tmp/cirrus-ci-build
@@ -30,6 +30,9 @@ freebsd_task:
   diagnose_math_script: |
     echo 'Diagnose vlib/math/math_test.v'
     ./v -stats vlib/math/math_test.v
+  test_zip_modules: |
+    echo 'Test modules using thirdparty/zip'
+    ./v test vlib/compress/ vlib/szip/
   test_self_script: |
     echo 'Run test-self'
     VTEST_JUST_ESSENTIAL=1 ./v test-self

--- a/thirdparty/zip/miniz.h
+++ b/thirdparty/zip/miniz.h
@@ -4926,6 +4926,24 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_DELETE_FILE remove
 #define MZ_MKDIR(d) _mkdir(d)
 
+#elif defined(__FreeBSD__)
+#ifndef MINIZ_NO_TIME
+#include <utime.h>
+#endif
+
+#define MZ_FOPEN(f, m) fopen(f, m)
+#define MZ_FCLOSE fclose
+#define MZ_FREAD fread
+#define MZ_FWRITE fwrite
+#define MZ_FTELL64 ftello
+#define MZ_FSEEK64 fseeko
+#define MZ_FILE_STAT_STRUCT stat
+#define MZ_FILE_STAT stat
+#define MZ_FFLUSH fflush
+#define MZ_FREOPEN(p, m, s) freopen(p, m, s)
+#define MZ_DELETE_FILE remove
+#define MZ_MKDIR(d) mkdir(d, 0755)
+
 #elif defined(__TINYC__)
 #ifndef MINIZ_NO_TIME
 #include <sys/utime.h>


### PR DESCRIPTION
thirdparty/zip: when compiling on FreeBSD, include <utime.h> and set defines for various file operations.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 025a246</samp>

Add FreeBSD file I/O support to `miniz.h` library. This enables vlang/v to use zip compression and decompression on FreeBSD platform.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 025a246</samp>

*  Add support for FreeBSD platform by defining file I/O macros and functions for miniz library ([link](https://github.com/vlang/v/pull/19285/files?diff=unified&w=0#diff-a2b0f859805806ae1d32cacd80a726010b7b8d1a51f61a2d2121642c85f165afR4929-R4946))
