### PR TITLE
math: fix pure v math.pow

### DIFF
--- a/vlib/math/pow.v
+++ b/vlib/math/pow.v
@@ -145,7 +145,7 @@ pub fn pow(x f64, y f64) f64 {
 		if y > 0 {
 			return result
 		}
-		return copysign(1, x) / abs(result)
+		return 1 / result
 	}
 
 	// ans = a1 * 2**ae (= 1 for now).


### PR DESCRIPTION
I did an oopsie. See also #19274.

Seems like an oversight that the CI only tests the C backend for now, meaning pure V implementations don't get any test coverage currently.
Maybe we need an extra CI that ignores `.c.v`?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d476fd</samp>

Simplify the calculation of negative powers in `math/pow.v` by removing unnecessary sign manipulation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d476fd</samp>

*  Simplify reciprocal calculation for negative x and odd y in `pow` function ([link](https://github.com/vlang/v/pull/19287/files?diff=unified&w=0#diff-0d34693f54bc7d43b70adf4eec5917c18b6e8ee35464cb5000ea5c7b5aee7fadL148-R148))
