### PR TITLE
db.pg: Allow postgres connection using service definitions

### DIFF
--- a/vlib/db/pg/pg.v
+++ b/vlib/db/pg/pg.v
@@ -55,6 +55,11 @@ pub:
 	dbname   string
 }
 
+pub struct Service {
+pub:
+	name string
+}
+
 //
 
 struct C.pg_result {}
@@ -144,6 +149,23 @@ fn C.PQfinish(conn &C.PGconn)
 // a connection error when something goes wrong
 pub fn connect(config Config) !DB {
 	conninfo := 'host=${config.host} port=${config.port} user=${config.user} dbname=${config.dbname} password=${config.password}'
+
+	return do_connect(conninfo)!
+}
+
+// connect makes a new connection to the database server using
+// the parameters from the `Config` structure, returning
+// a connection error when something goes wrong
+pub fn connect_with_service(service Service) !DB {
+	conninfo := 'service=${service.name}'
+
+	return do_connect(conninfo)!
+}
+
+// do_connect makes a new connection to the database server using
+// the `conninfo` connection string, returning
+// a connection error when something goes wrong
+fn do_connect(conninfo string) !DB {
 	conn := C.PQconnectdb(&char(conninfo.str))
 	if conn == 0 {
 		return error('libpq memory allocation error')

--- a/vlib/db/pg/pg.v
+++ b/vlib/db/pg/pg.v
@@ -153,8 +153,9 @@ pub fn connect(config Config) !DB {
 	return do_connect(conninfo)!
 }
 
-// connect makes a new connection to the database server using
-// the parameters from the `Config` structure, returning
+// connect_with_service makes a new connection to the database server using
+// the parameters from the service definition in `pg_service.conf` matching the name
+// in the `Service` structure, returning
 // a connection error when something goes wrong
 pub fn connect_with_service(service Service) !DB {
 	conninfo := 'service=${service.name}'

--- a/vlib/db/pg/pg.v
+++ b/vlib/db/pg/pg.v
@@ -55,11 +55,6 @@ pub:
 	dbname   string
 }
 
-pub struct Service {
-pub:
-	name string
-}
-
 //
 
 struct C.pg_result {}
@@ -150,23 +145,13 @@ fn C.PQfinish(conn &C.PGconn)
 pub fn connect(config Config) !DB {
 	conninfo := 'host=${config.host} port=${config.port} user=${config.user} dbname=${config.dbname} password=${config.password}'
 
-	return do_connect(conninfo)!
+	return connect_with_conninfo(conninfo)!
 }
 
-// connect_with_service makes a new connection to the database server using
-// the parameters from the service definition in `pg_service.conf` matching the name
-// in the `Service` structure, returning
-// a connection error when something goes wrong
-pub fn connect_with_service(service Service) !DB {
-	conninfo := 'service=${service.name}'
-
-	return do_connect(conninfo)!
-}
-
-// do_connect makes a new connection to the database server using
+// connect_with_conninfo makes a new connection to the database server using
 // the `conninfo` connection string, returning
 // a connection error when something goes wrong
-fn do_connect(conninfo string) !DB {
+pub fn connect_with_conninfo(conninfo string) !DB {
 	conn := C.PQconnectdb(&char(conninfo.str))
 	if conn == 0 {
 		return error('libpq memory allocation error')


### PR DESCRIPTION
Support making the pg connection using service names that can be defined in `~/.pg_service.conf` ([docs](https://www.postgresql.org/docs/current/libpq-pgservice.html)). This immediately adds implicit support for [all connection parameters](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) the server supports, without adding fields to `pg.Config` or needing to manually parse files.

This is my first contribution and I'm new to vlang, so I'm not sure about best practices. Here are some considerations:

1. I didn't add a test case since this will require everyone to have a local `~/.pg_service.conf` file set up. I'm happy to add this test if required, though.
2. I added a `Service` struct that will be accepted by `connect_with_service()` but I could just let it accept a `string` instead.
3. I can also, instead, add `service string` to `Config` and have it take precedence over all other attributes if it is non-empty.

 

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b93449</samp>

Added support for PostgreSQL service names in `pg` module. Refactored connection logic into a separate function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b93449</samp>

* Add a `Service` struct to represent a PostgreSQL service name ([link](https://github.com/vlang/v/pull/19288/files?diff=unified&w=0#diff-8a8a6bd5b4a42fb2ec9cbdee23699a814793c004f2ddf263224f141337b42af0R58-R62))
* Implement a `connect_with_service` function to make a new connection using a service name ([link](https://github.com/vlang/v/pull/19288/files?diff=unified&w=0#diff-8a8a6bd5b4a42fb2ec9cbdee23699a814793c004f2ddf263224f141337b42af0R152-R168))
* Implement a `do_connect` function to make a new connection using a connection string ([link](https://github.com/vlang/v/pull/19288/files?diff=unified&w=0#diff-8a8a6bd5b4a42fb2ec9cbdee23699a814793c004f2ddf263224f141337b42af0R152-R168))
