### PR TITLE
builtin: on FreeBSD, threaded version of libgc is named libgc-threaded

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -25,7 +25,11 @@ $if dynamic_boehm ? {
 				#flag -I/usr/local/include
 				#flag -L/usr/local/lib
 			}
-			#flag -lgc
+			$if freebsd {
+				#flag -lgc-threaded
+			} else {
+				#flag -lgc
+			}
 		}
 	}
 } $else {
@@ -53,8 +57,8 @@ $if dynamic_boehm ? {
 		}
 		$if tinyc {
 			#flag -I/usr/local/include
-			#flag $first_existing("/usr/local/lib/libgc.a", "/usr/lib/libgc.a")
-			#flag -lgc
+			#flag $first_existing("/usr/local/lib/libgc-threaded.a", "/usr/lib/libgc-threaded.a")
+			#flag -lgc-threaded
 		}
 		#flag -lpthread
 	} $else $if openbsd {

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -27,7 +27,7 @@ $if dynamic_boehm ? {
 			}
 			$if freebsd {
 				#flag -lgc-threaded
-			} else {
+			} $else {
 				#flag -lgc
 			}
 		}


### PR DESCRIPTION
This fixes the name of the threaded version of the boehm gc library on FreeBSD.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f62156</samp>

This pull request enables concurrent garbage collection on freebsd and tinyc by linking to `libgc-threaded` instead of `libgc` in `vlib/builtin/builtin_d_gcboehm.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f62156</samp>

*  Link with libgc-threaded library on freebsd to enable concurrency support for Boehm garbage collector ([link](https://github.com/vlang/v/pull/19294/files?diff=unified&w=0#diff-14d382816b2ffad1e7aa7c20c823217c79f6867823d557e891d8fcb3370c98faL28-R32), [link](https://github.com/vlang/v/pull/19294/files?diff=unified&w=0#diff-14d382816b2ffad1e7aa7c20c823217c79f6867823d557e891d8fcb3370c98faL56-R61))
