### PR TITLE
cgen: fix printing struct with thread field (fix #19282)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -846,7 +846,7 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 	if typ.is_int_valptr() || typ.is_float_valptr() {
 		return .si_s
 	} else if sym.kind in [.struct_, .array, .array_fixed, .map, .bool, .enum_, .interface_,
-		.sum_type, .function, .alias, .chan] {
+		.sum_type, .function, .alias, .chan, .thread] {
 		return .si_s
 	} else if sym.kind == .string {
 		return .si_s
@@ -1082,6 +1082,8 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 		return '${fn_name}(${obj})', true
 	} else if sym.kind == .chan {
 		return '${fn_name}(${deref}it.${final_field_name}${sufix})', true
+	} else if sym.kind == .thread {
+		return '${fn_name}(${deref}it.${final_field_name}${sufix})', false
 	} else {
 		mut method_str := ''
 		if !field_type.is_ptr() && (field_type.has_flag(.option) || field_type.has_flag(.result)) {

--- a/vlib/v/slow_tests/inout/printing_struct_with_thread_field.out
+++ b/vlib/v/slow_tests/inout/printing_struct_with_thread_field.out
@@ -1,0 +1,7 @@
+Video{
+    path: '/path/to/some/mp4'
+    tmp_dir: '/tmp'
+    frame_count: 0
+    frame_format: bmp
+    extract_frames_thread: thread(string)
+}

--- a/vlib/v/slow_tests/inout/printing_struct_with_thread_field.vv
+++ b/vlib/v/slow_tests/inout/printing_struct_with_thread_field.vv
@@ -1,0 +1,40 @@
+// Video is the object containing all the information needed for
+// conversion to ascii.
+struct Video {
+pub:
+	// path may be URL or path on local file system.
+	path         string
+	tmp_dir      string
+	frame_count  int
+	frame_format FrameFormat
+pub mut:
+	// TODO: once V fixes bug #19281 replace the type here
+	// with `thread !`. And the return type on the corresponding
+	// function that is spawned.
+	extract_frames_thread thread string
+}
+
+enum FrameFormat {
+	bmp
+	jpg
+}
+
+fn (video Video) extract_frames() string {
+	// try to extract frames os.execute()
+	// if os.execute() returns with an exit
+	// code other than 0, return an error.
+	if true {
+		return 'Failed to extract frames: os.execute() cmd output'
+	}
+	// do something else
+	return ''
+}
+
+fn main() {
+	mut video := Video{
+		path: '/path/to/some/mp4'
+		tmp_dir: '/tmp'
+	}
+	video.extract_frames_thread = spawn video.extract_frames()
+	println(video)
+}


### PR DESCRIPTION
This PR fix printing struct with thread field (fix #19282).

- Fix printing struct with thread field.
- Add test.

```v
// Video is the object containing all the information needed for
// conversion to ascii.
struct Video {
pub:
	// path may be URL or path on local file system.
	path         string
	tmp_dir      string
	frame_count  int
	frame_format FrameFormat
pub mut:
	// TODO: once V fixes bug #19281 replace the type here
	// with `thread !`. And the return type on the corresponding
	// function that is spawned.
	extract_frames_thread thread string
}

enum FrameFormat {
	bmp
	jpg
}

fn (video Video) extract_frames() string {
	// try to extract frames os.execute()
	// if os.execute() returns with an exit
	// code other than 0, return an error.
	if true {
		return 'Failed to extract frames: os.execute() cmd output'
	}
	// do something else
	return ''
}

fn main() {
	mut video := Video{
		path: '/path/to/some/mp4'
		tmp_dir: '/tmp'
	}
	video.extract_frames_thread = spawn video.extract_frames()
	println(video)
}

PS D:\Test\v\tt1> v run .
Video{
    path: '/path/to/some/mp4'
    tmp_dir: '/tmp'
    frame_count: 0
    frame_format: bmp
    extract_frames_thread: thread(string)
}
```