### PR TITLE
test: supplement test cases in fixed_array_const_size_test.v (related #19269)

### DIFF
--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -50,12 +50,52 @@ const (
 	cols = 3
 )
 
-struct Matrix {
+struct Matrix1 {
 	data [rows * cols]int
 }
 
+struct Matrix2 {
+	data [rows * cols + 4]int
+}
+
+struct Matrix3 {
+	data [rows * 4 - 2 * cols]int
+}
+
+struct Matrix4 {
+	data [5 * rows - cols * 2]int
+}
+
+struct Matrix5 {
+	data [5 * rows / 2]int
+}
+
+struct Matrix6 {
+	data [5 * rows / 2 + 1]int
+}
+
 fn test_infix_const_expr_used_as_fixed_array_size() {
-	mat := Matrix{}
-	println(mat)
-	assert mat.data.len == 6
+	mat1 := Matrix1{}
+	println(mat1)
+	assert mat1.data.len == 6
+
+	mat2 := Matrix2{}
+	println(mat2)
+	assert mat2.data.len == 10
+
+	mat3 := Matrix3{}
+	println(mat3)
+	assert mat3.data.len == 2
+
+	mat4 := Matrix4{}
+	println(mat4)
+	assert mat4.data.len == 4
+
+	mat5 := Matrix5{}
+	println(mat5)
+	assert mat5.data.len == 5
+
+	mat6 := Matrix6{}
+	println(mat6)
+	assert mat6.data.len == 6
 }


### PR DESCRIPTION
This PR supplement test cases in fixed_array_const_size_test.v (related #19269).

```v
const (
	rows = 2
	cols = 3
)

struct Matrix1 {
	data [rows * cols]int
}

struct Matrix2 {
	data [rows * cols + 4]int
}

struct Matrix3 {
	data [rows * 4 - 2 * cols]int
}

struct Matrix4 {
	data [5 * rows - cols * 2]int
}

struct Matrix5 {
	data [5 * rows / 2]int
}

struct Matrix6 {
	data [5 * rows / 2 + 1]int
}

fn main() {
	mat1 := Matrix1{}
	println(mat1)
	assert mat1.data.len == 6

	mat2 := Matrix2{}
	println(mat2)
	assert mat2.data.len == 10

	mat3 := Matrix3{}
	println(mat3)
	assert mat3.data.len == 2

	mat4 := Matrix4{}
	println(mat4)
	assert mat4.data.len == 4

	mat5 := Matrix5{}
	println(mat5)
	assert mat5.data.len == 5

	mat6 := Matrix6{}
	println(mat6)
	assert mat6.data.len == 6
}

PS D:\Test\v\tt1> v run .
Matrix1{
    data: [0, 0, 0, 0, 0, 0]
}
Matrix2{
    data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
}
Matrix3{
    data: [0, 0]
}
Matrix4{
    data: [0, 0, 0, 0]
}
Matrix5{
    data: [0, 0, 0, 0, 0]
}
Matrix6{
    data: [0, 0, 0, 0, 0, 0]
}
```