### PR TITLE
vdoc: prevent main-content outline with certain devices / browsers

### DIFF
--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -358,6 +358,9 @@ body {
 }
 
 /* Main content */
+#main-content {
+	outline: none;
+}
 .doc-scrollview {
 	height: 100%;
 	overflow-y: scroll;


### PR DESCRIPTION
Just noticed this outline when entering modules.vlang.io on Vivaldi mobile. The change prevents it.

![Screenshot_20230907_174202](https://github.com/vlang/v/assets/34311583/589dec82-4367-46c5-b7eb-cfa02b6306cb)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29f0213</samp>

Improve vdoc theme accessibility and style. Remove outline from `main` element in `doc.css`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 29f0213</samp>

* Remove outline from main content element when focused ([link](https://github.com/vlang/v/pull/19304/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cR361-R363))
