### PR TITLE
vlib: replace macros that resolve to __builtin_bswapnn calls

### DIFF
--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -1,6 +1,7 @@
 module net
 
 import io.util
+import net.conv
 import os
 
 union AddrData {
@@ -16,11 +17,17 @@ const (
 
 // new_ip6 creates a new Addr from the IP6 address family, based on the given port and addr
 pub fn new_ip6(port u16, addr [16]u8) Addr {
+	n_port := $if tinyc {
+		conv.hton16(port)
+	} $else {
+		u16(C.htons(port))
+	}
+
 	a := Addr{
 		f: u8(AddrFamily.ip6)
 		addr: AddrData{
 			Ip6: Ip6{
-				port: u16(C.htons(port))
+				port: n_port
 			}
 		}
 	}
@@ -32,11 +39,17 @@ pub fn new_ip6(port u16, addr [16]u8) Addr {
 
 // new_ip creates a new Addr from the IPv4 address family, based on the given port and addr
 pub fn new_ip(port u16, addr [4]u8) Addr {
+	n_port := $if tinyc {
+		conv.hton16(port)
+	} $else {
+		u16(C.htons(port))
+	}
+
 	a := Addr{
 		f: u8(AddrFamily.ip)
 		addr: AddrData{
 			Ip: Ip{
-				port: u16(C.htons(port))
+				port: n_port
 			}
 		}
 	}
@@ -79,7 +92,11 @@ pub fn (a Ip) str() string {
 	}
 
 	saddr := unsafe { cstring_to_vstring(&buf[0]) }
-	port := C.ntohs(a.port)
+	port := $if tinyc {
+		conv.hton16(a.port)
+	} $else {
+		C.ntohs(a.port)
+	}
 
 	return '${saddr}:${port}'
 }
@@ -95,7 +112,11 @@ pub fn (a Ip6) str() string {
 	}
 
 	saddr := unsafe { cstring_to_vstring(&buf[0]) }
-	port := C.ntohs(a.port)
+	port := $if tinyc {
+		conv.hton16(a.port)
+	} $else {
+		C.ntohs(a.port)
+	}
 
 	return '[${saddr}]:${port}'
 }

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -4,6 +4,7 @@
 module websocket
 
 import net
+import net.conv
 import net.http
 import net.ssl
 import net.urllib
@@ -261,7 +262,12 @@ pub fn (mut ws Client) write_ptr(bytes &u8, payload_len int, code OPCode) !int {
 		if payload_len <= 125 {
 			header[1] = u8(payload_len)
 		} else if payload_len > 125 && payload_len <= 0xffff {
-			len16 := C.htons(payload_len)
+			len16 := $if tinyc {
+				conv.hton16(u16(payload_len))
+			} $else {
+				C.htons(payload_len)
+			}
+
 			header[1] = 126
 			unsafe { C.memcpy(&header[2], &len16, 2) }
 		} else if payload_len > 0xffff && payload_len <= 0x7fffffff {
@@ -277,7 +283,11 @@ pub fn (mut ws Client) write_ptr(bytes &u8, payload_len int, code OPCode) !int {
 			header[4] = masking_key[2]
 			header[5] = masking_key[3]
 		} else if payload_len > 125 && payload_len <= 0xffff {
-			len16 := C.htons(payload_len)
+			len16 := $if tinyc {
+				conv.hton16(u16(payload_len))
+			} $else {
+				C.htons(payload_len)
+			}
 			header[1] = (126 | 0x80)
 			unsafe { C.memcpy(&header[2], &len16, 2) }
 			header[4] = masking_key[0]
@@ -346,7 +356,11 @@ pub fn (mut ws Client) close(code int, message string) ! {
 	ws.set_state(.closing)
 	// mut code32 := 0
 	if code > 0 {
-		code_ := C.htons(code)
+		code_ := $if tinyc {
+			conv.hton16(u16(code))
+		} $else {
+			C.htons(code)
+		}
 		message_len := message.len + 2
 		mut close_frame := []u8{len: message_len}
 		close_frame[0] = u8(code_ & 0xFF)

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -1,6 +1,7 @@
 module picoev
 
 import net
+import net.conv
 import picohttpparser
 
 #include <errno.h>
@@ -123,10 +124,23 @@ fn listen(config Config) int {
 	}
 
 	// addr settings
+
+	sin_port := $if tinyc {
+		conv.hton16(u16(config.port))
+	} $else {
+		C.htons(config.port)
+	}
+
+	sin_addr := $if tinyc {
+		conv.hton32(u32(C.INADDR_ANY))
+	} $else {
+		C.htonl(C.INADDR_ANY)
+	}
+
 	mut addr := C.sockaddr_in{
 		sin_family: u8(C.AF_INET)
-		sin_port: C.htons(config.port)
-		sin_addr: C.htonl(C.INADDR_ANY)
+		sin_port: sin_port
+		sin_addr: sin_addr
 	}
 	size := sizeof(C.sockaddr_in)
 	bind_res := C.bind(fd, voidptr(unsafe { &net.Addr(&addr) }), size)

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -803,7 +803,7 @@ static inline uint64_t _wymix(uint64_t A, uint64_t B){ _wymum(&A,&B); return A^B
 #if (WYHASH_LITTLE_ENDIAN)
 	static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return v;}
 	static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return v;}
-#elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+#elif !defined(__TINYC__) && (defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__))
 	static inline uint64_t _wyr8(const uint8_t *p) { uint64_t v; memcpy(&v, p, 8); return __builtin_bswap64(v);}
 	static inline uint64_t _wyr4(const uint8_t *p) { uint32_t v; memcpy(&v, p, 4); return __builtin_bswap32(v);}
 #elif defined(_MSC_VER)


### PR DESCRIPTION
The tcc compiler does not have __builtin_bswap64, __builtin_bswap32, and __builtin_bswap16 functions.  The various hton and ntoh macros resolve down to these functions.  When compiling with tcc, we should be using the analogous functions from net.conv.



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8bc3663</samp>

This pull request improves the compatibility and portability of the `v` language and its standard library with the `tinyc` compiler, which is a minimal C compiler. It does so by using the `net.conv` module to handle the network byte order conversions of various data types, and by adding a compiler-specific condition to the `wyhash` function. The affected files are `vlib/net/address.v`, `vlib/net/websocket/websocket_client.v`, `vlib/picoev/socket_util.c.v`, and `vlib/v/gen/c/cheaders.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8bc3663</samp>

*  Import `net.conv` module to use byte order conversion functions for `tinyc` compatibility ([link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ac93d4f5773c25b0d6d22917ae41271fe50380347d0a79dbfa76b0c7adc3e7faR4), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ef727f3d4a51e0d66848c62505e7bc2e00b651a5e8681c329da842048813dd4fR7), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-426c0ee91a2a40157b09795860ad0cfa213ed59a2e6a2c63ba9e85c193bf18efR4))
*  Replace `C.htons` and `C.htonl` macros with conditional expressions that call `conv.hton16` and `conv.hton32` functions for `tinyc` compiler ([link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ac93d4f5773c25b0d6d22917ae41271fe50380347d0a79dbfa76b0c7adc3e7faL19-R30), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ac93d4f5773c25b0d6d22917ae41271fe50380347d0a79dbfa76b0c7adc3e7faL35-R52), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ac93d4f5773c25b0d6d22917ae41271fe50380347d0a79dbfa76b0c7adc3e7faL82-R99), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ac93d4f5773c25b0d6d22917ae41271fe50380347d0a79dbfa76b0c7adc3e7faL98-R119), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ef727f3d4a51e0d66848c62505e7bc2e00b651a5e8681c329da842048813dd4fL264-R270), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ef727f3d4a51e0d66848c62505e7bc2e00b651a5e8681c329da842048813dd4fL280-R290), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-ef727f3d4a51e0d66848c62505e7bc2e00b651a5e8681c329da842048813dd4fL349-R363), [link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-426c0ee91a2a40157b09795860ad0cfa213ed59a2e6a2c63ba9e85c193bf18efL126-R143))
*  Add condition to use `__builtin_bswap64` and `__builtin_bswap32` functions for byte order swapping in `wyhash` function in `cheaders.v` file ([link](https://github.com/vlang/v/pull/19305/files?diff=unified&w=0#diff-9f4960eeea6c8145477b33c711e42120d2877a4eb7cc16a93e00bd32b21281b2L806-R806))
