### PR TITLE
cgen, checker: fix opt const

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3588,6 +3588,13 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 					}
 					obj.typ = typ
 					node.obj = obj
+
+					if node.or_expr.kind != .absent {
+						unwrapped_typ := typ.clear_flags(.option, .result)
+						c.expected_or_type = unwrapped_typ
+						c.stmts_ending_with_expression(mut node.or_expr.stmts)
+						c.check_or_expr(node.or_expr, typ, c.expected_or_type, node)
+					}
 					return typ
 				}
 				else {}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2133,13 +2133,15 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 					const_name := vals.last()
 					if mod_prefix == 'main' {
 						f.write(const_name)
-						return
 					} else {
 						short := mod_prefix + '.' + const_name
 						f.write(short)
 						f.mark_import_as_used(short)
-						return
 					}
+					if node.or_expr.kind == .block {
+						f.or_expr(node.or_expr)
+					}
+					return
 				}
 			}
 		}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -17,7 +17,9 @@ fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr
 			g.write('))')
 		}
 		g.writeln(';')
-		expr_var := if expr is ast.Ident && expr.is_auto_heap() {
+		expr_var := if expr is ast.Ident && expr.kind == .constant {
+			g.get_const_name(expr)
+		} else if expr is ast.Ident && expr.is_auto_heap() {
 			'(*${expr.name})'
 		} else {
 			'${expr}'

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4270,6 +4270,19 @@ pub fn (mut g Gen) is_comptime_var(node ast.Expr) bool {
 		&& (node.obj as ast.Var).ct_type_var != .no_comptime
 }
 
+fn (mut g Gen) get_const_name(node ast.Ident) string {
+	if g.pref.translated && !g.is_builtin_mod
+		&& !util.module_is_builtin(node.name.all_before_last('.')) {
+		mut x := util.no_dots(node.name)
+		if x.starts_with('main__') {
+			x = x['main__'.len..]
+		}
+		return x
+	} else {
+		return '_const_' + g.get_ternary_name(c_name(node.name))
+	}
+}
+
 fn (mut g Gen) ident(node ast.Ident) {
 	prevent_sum_type_unwrapping_once := g.prevent_sum_type_unwrapping_once
 	g.prevent_sum_type_unwrapping_once = false
@@ -4293,6 +4306,14 @@ fn (mut g Gen) ident(node ast.Ident) {
 			g.write(x)
 			return
 		} else {
+			if g.inside_opt_or_res && node.or_expr.kind != .absent && node.obj.typ.has_flag(.option) {
+				styp := g.base_type(node.obj.typ)
+				g.write('(*(${styp}*)')
+
+				defer {
+					g.write('.data)')
+				}
+			}
 			// TODO globals hack
 			g.write('_const_')
 		}

--- a/vlib/v/tests/option_const_test.v
+++ b/vlib/v/tests/option_const_test.v
@@ -5,6 +5,6 @@ fn get_var() ?string {
 }
 
 fn test_main() {
-	a := var
+	a := var or { 'default' }
 	assert dump(a) == 'default'
 }

--- a/vlib/v/tests/option_const_test.v
+++ b/vlib/v/tests/option_const_test.v
@@ -1,0 +1,10 @@
+const var = get_var()
+
+fn get_var() ?string {
+	return none
+}
+
+fn test_main() {
+	a := var
+	assert dump(a) == 'default'
+}


### PR DESCRIPTION
Fix #19280

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a2bfb2</samp>

This pull request enhances the handling of constants and optional or result expressions in V. It fixes a bug in the C code generation, adds a checker rule for or blocks, and adds a test file for the new feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a2bfb2</samp>

*  Add check for or block after optional or result expression in checker ([link](https://github.com/vlang/v/pull/19314/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R3591-R3597))
*  Modify code generation for assignments involving constants to use helper function ([link](https://github.com/vlang/v/pull/19314/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL20-R22))
*  Add helper function `get_const_name` to C generator to handle different names of constants ([link](https://github.com/vlang/v/pull/19314/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR4273-R4285))
*  Modify code generation for accessing fields of optional or result expressions inside or blocks to cast to base type and access data field ([link](https://github.com/vlang/v/pull/19314/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR4309-R4316))
*  Add test file `option_const_test.v` to verify the new feature of allowing constants to be assigned from optional or result expressions ([link](https://github.com/vlang/v/pull/19314/files?diff=unified&w=0#diff-b5c59e284966ad981592c4e230f54ddef2b99573ad85c628371d5a49619dd77fR1-R10))
