### PR TITLE
vlib: fix logic around the definition of VNORETURN and VUNREACHABLE

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -447,7 +447,7 @@ const c_common_macros = '
 	#if defined(__GNUC__) && !defined(__clang__)
 		#define V_GCC_VERSION  (__GNUC__ * 10000L + __GNUC_MINOR__ * 100L + __GNUC_PATCHLEVEL__)
 		#if (V_GCC_VERSION >= 40500L) && !defined(__TINYC__)
-                	#define VUNREACHABLE()  do { __builtin_unreachable(); } while (0)
+			#define VUNREACHABLE()  do { __builtin_unreachable(); } while (0)
 		#endif
 	#endif
 	#if defined(__clang__) && defined(__has_builtin) && !defined(__TINYC__)

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -435,7 +435,7 @@ const c_common_macros = '
 	#endif
 	# if !defined(__TINYC__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 	#  define VNORETURN _Noreturn
-	# elif defined(__GNUC__) && __GNUC__ >= 2
+	# elif !defined(VNORETURN) && defined(__GNUC__) && __GNUC__ >= 2
 	#  define VNORETURN __attribute__((noreturn))
 	# endif
 	#ifndef VNORETURN
@@ -446,19 +446,16 @@ const c_common_macros = '
 #if !defined(VUNREACHABLE)
 	#if defined(__GNUC__) && !defined(__clang__)
 		#define V_GCC_VERSION  (__GNUC__ * 10000L + __GNUC_MINOR__ * 100L + __GNUC_PATCHLEVEL__)
-		#if (V_GCC_VERSION >= 40500L)
-			#define VUNREACHABLE()  do { __builtin_unreachable(); } while (0)
+		#if (V_GCC_VERSION >= 40500L) && !defined(__TINYC__)
+                	#define VUNREACHABLE()  do { __builtin_unreachable(); } while (0)
 		#endif
 	#endif
-	#if defined(__clang__) && defined(__has_builtin)
+	#if defined(__clang__) && defined(__has_builtin) && !defined(__TINYC__)
 		#if __has_builtin(__builtin_unreachable)
 			#define VUNREACHABLE()  do { __builtin_unreachable(); } while (0)
 		#endif
 	#endif
 	#ifndef VUNREACHABLE
-		#define VUNREACHABLE() do { } while (0)
-	#endif
-	#if defined(__FreeBSD__) && defined(__TINYC__)
 		#define VUNREACHABLE() do { } while (0)
 	#endif
 #endif


### PR DESCRIPTION
In certain situations these values would be defined and then later re-defined, causing warning messages that would make some tests fail.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9163f8b</samp>

This pull request enhances the `VNORETURN` and `VUNREACHABLE` macros in `vlib/v/gen/c/cheaders.v` to work better with various C compilers and platforms. It fixes potential issues with redefinition, feature support, and backend consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9163f8b</samp>

*  Add checks for `VNORETURN` and `__TINYC__` macros to avoid redefining or using unsupported features ([link](https://github.com/vlang/v/pull/19316/files?diff=unified&w=0#diff-9f4960eeea6c8145477b33c711e42120d2877a4eb7cc16a93e00bd32b21281b2L438-R438), [link](https://github.com/vlang/v/pull/19316/files?diff=unified&w=0#diff-9f4960eeea6c8145477b33c711e42120d2877a4eb7cc16a93e00bd32b21281b2L449-R453), [link](https://github.com/vlang/v/pull/19316/files?diff=unified&w=0#diff-9f4960eeea6c8145477b33c711e42120d2877a4eb7cc16a93e00bd32b21281b2L461-L463))
