### PR TITLE
toml: check if supported type was passed for decoding when it has no method

### DIFF
--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -177,3 +177,13 @@ times = [
 	assert toml.encode[Arrs](a) == s
 	assert toml.decode[Arrs](s)! == a
 }
+
+fn test_unsupported_type() {
+	s := 'name = "Peter"'
+	err_msg := 'toml.decode: expected struct, found '
+	toml.decode[string](s) or { assert err.msg() == err_msg + 'string' }
+	toml.decode[[]string](s) or { assert err.msg() == err_msg + '[]string' }
+	toml.decode[int](s) or { assert err.msg() == err_msg + 'int' }
+	toml.decode[[]f32](s) or { assert err.msg() == err_msg + '[]f32' }
+	// ...
+}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -23,6 +23,9 @@ pub fn decode[T](toml_txt string) !T {
 			return typ
 		}
 	}
+	$if T !is $struct {
+		return error('toml.decode: expected struct, found ${T.name}')
+	}
 	decode_struct[T](doc.to_any(), mut typ)
 	return typ
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5931238</samp>

This pull request improves the error handling of the `toml.decode` function by adding a compile-time check for the generic type parameter and a test case for it. It ensures that the function only accepts structs as the type parameter and returns a clear error message otherwise.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5931238</samp>

*  Add compile-time check for struct type in `toml.decode` function ([link](https://github.com/vlang/v/pull/19317/files?diff=unified&w=0#diff-b8f13704e3af95d0fd433384853091d3fc14632a773fd45d2303b3f7d806cee9R26-R28))
*  Add test cases for `toml.decode` function with non-struct types ([link](https://github.com/vlang/v/pull/19317/files?diff=unified&w=0#diff-e21671b503fde62549e7f85e6544ac5ea616eb6dd5eec935b44cd85edda451b9R180-R189))
*  Assert that `toml.decode` function returns an error with the expected type name for non-struct types ([link](https://github.com/vlang/v/pull/19317/files?diff=unified&w=0#diff-e21671b503fde62549e7f85e6544ac5ea616eb6dd5eec935b44cd85edda451b9R180-R189))
