### PR TITLE
toml: implement decode method for `Doc`

### DIFF
--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -178,12 +178,50 @@ times = [
 	assert toml.decode[Arrs](s)! == a
 }
 
+fn test_decode_doc() {
+	doc := toml.parse_text('name = "Peter"
+age = 28
+is_human = true
+salary = 100000.5
+title = 2')!
+	e := doc.decode[Employee]()!
+	assert e.name == 'Peter'
+	assert e.age == 28
+	assert e.salary == 100000.5
+	assert e.is_human == true
+	assert e.title == .manager
+}
+
 fn test_unsupported_type() {
 	s := 'name = "Peter"'
 	err_msg := 'toml.decode: expected struct, found '
-	toml.decode[string](s) or { assert err.msg() == err_msg + 'string' }
-	toml.decode[[]string](s) or { assert err.msg() == err_msg + '[]string' }
-	toml.decode[int](s) or { assert err.msg() == err_msg + 'int' }
-	toml.decode[[]f32](s) or { assert err.msg() == err_msg + '[]f32' }
+	if _ := toml.decode[string](s) {
+		assert false
+	} else {
+		assert err.msg() == err_msg + 'string'
+	}
+	if _ := toml.decode[[]string](s) {
+		assert false
+	} else {
+		assert err.msg() == err_msg + '[]string'
+	}
+	if _ := toml.decode[int](s) {
+		assert false
+	} else {
+		assert err.msg() == err_msg + 'int'
+	}
+	if _ := toml.decode[[]f32](s) {
+		assert false
+	} else {
+		assert err.msg() == err_msg + '[]f32'
+	}
 	// ...
+
+	doc := toml.parse_text('name = "Peter"')!
+	assert doc.value('name').string() == 'Peter'
+	if _ := doc.decode[string]() {
+		assert false
+	} else {
+		assert err.msg() == 'Doc.decode: expected struct, found string'
+	}
 }

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -252,6 +252,16 @@ fn parse_array_key(key string) (string, int) {
 	return k, index
 }
 
+// decode decodes a TOML `string` into the target struct type `T`.
+pub fn (d Doc) decode[T]() !T {
+	$if T !is $struct {
+		return error('Doc.decode: expected struct, found ${T.name}')
+	}
+	mut typ := T{}
+	decode_struct(d.to_any(), mut typ)
+	return typ
+}
+
 // to_any converts the `Doc` to toml.Any type.
 pub fn (d Doc) to_any() Any {
 	return ast_to_any(d.ast.table)


### PR DESCRIPTION
I.e. `toml.parse_file` returns a `Doc`. So it probably makes sense to implement a `decode` method for it to simplify the decoding process.

It's includes #19317, which is a separate change, I would rebase it after it is resolved.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dacfe18</samp>

This pull request adds a new feature and tests to the `toml` module. The feature allows decoding TOML documents into custom structs with compile-time type checking. The tests cover the new feature and the error handling of the `decode` function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dacfe18</samp>

*  Add a compile-time check to `decode` function of `toml` module to ensure struct type argument ([link](https://github.com/vlang/v/pull/19318/files?diff=unified&w=0#diff-b8f13704e3af95d0fd433384853091d3fc14632a773fd45d2303b3f7d806cee9R26-R28))
*  Add a `decode` method to `Doc` struct to allow decoding a parsed TOML document into a custom struct type ([link](https://github.com/vlang/v/pull/19318/files?diff=unified&w=0#diff-b8f13704e3af95d0fd433384853091d3fc14632a773fd45d2303b3f7d806cee9R255-R264))
*  Add two test functions to `vlib/toml/tests/encode_and_decode_test.v` to test the new `decode` method of `Doc` struct and the error handling of `decode` function of `toml` module ([link](https://github.com/vlang/v/pull/19318/files?diff=unified&w=0#diff-e21671b503fde62549e7f85e6544ac5ea616eb6dd5eec935b44cd85edda451b9R180-R207))
*  Add an enum type `Title` and a struct type `Employee` to `vlib/toml/tests/encode_and_decode_test.v` to use as target types for decoding ([link](https://github.com/vlang/v/pull/19318/files?diff=unified&w=0#diff-e21671b503fde62549e7f85e6544ac5ea616eb6dd5eec935b44cd85edda451b9R180-R207))
