### PR TITLE
cgen: fix printing struct with thread field (fix #19283)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6302,7 +6302,7 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 		.string {
 			return '(string){.str=(byteptr)"", .is_lit=1}'
 		}
-		.interface_, .sum_type, .array_fixed, .multi_return {
+		.interface_, .sum_type, .array_fixed, .multi_return, .thread {
 			return '{0}'
 		}
 		.alias {

--- a/vlib/v/slow_tests/inout/printing_struct_with_thread_field.out
+++ b/vlib/v/slow_tests/inout/printing_struct_with_thread_field.out
@@ -4,4 +4,6 @@ Video{
     frame_count: 0
     frame_format: bmp
     extract_frames_thread: thread(string)
+    frames: []
+    framerate: 24.0
 }

--- a/vlib/v/slow_tests/inout/printing_struct_with_thread_field.vv
+++ b/vlib/v/slow_tests/inout/printing_struct_with_thread_field.vv
@@ -12,6 +12,8 @@ pub mut:
 	// with `thread !`. And the return type on the corresponding
 	// function that is spawned.
 	extract_frames_thread thread string
+	frames                [][]u8
+	framerate             f64 = 24.0
 }
 
 enum FrameFormat {


### PR DESCRIPTION
This PR fix printing struct with thread field (fix #19283).

- Fix printing struct with thread field.
- Add test.

```v
// Video is the object containing all the information needed for
// conversion to ascii.
struct Video {
pub:
	// path may be URL or path on local file system.
	path         string
	tmp_dir      string
	frame_count  int
	frame_format FrameFormat
pub mut:
	// TODO: once V fixes bug #19281 replace the type here
	// with `thread !`. And the return type on the corresponding
	// function that is spawned.
	extract_frames_thread thread string
	frames                [][]u8
	framerate             f64 = 24.0
}

enum FrameFormat {
	bmp
	jpg
}

fn (video Video) extract_frames() string {
	// try to extract frames os.execute()
	// if os.execute() returns with an exit
	// code other than 0, return an error.
	if true {
		return 'Failed to extract frames: os.execute() cmd output'
	}
	// do something else
	return ''
}

fn main() {
	mut video := Video{
		path: '/path/to/some/mp4'
		tmp_dir: '/tmp'
	}
	video.extract_frames_thread = spawn video.extract_frames()
	println(video)
}

PS D:\Test\v\tt1> v run .
Video{
    path: '/path/to/some/mp4'
    tmp_dir: '/tmp'
    frame_count: 0
    frame_format: bmp
    extract_frames_thread: thread(string)
    frames: []
    framerate: 24.0
}
```