### PR TITLE
checker: fix logic of enum value overflow check

### DIFF
--- a/vlib/strconv/atoi.v
+++ b/vlib/strconv/atoi.v
@@ -193,8 +193,7 @@ pub fn common_parse_int(_s string, base int, _bit_size int, error_on_non_digit b
 	// TODO: check should u64(bit_size-1) be size of int (32)?
 	cutoff := u64(1) << u64(bit_size - 1)
 	if !neg && un >= cutoff {
-		// return error('parse_int: range error $s0')
-		return i64(cutoff - u64(1))
+		return error('common_parse_int: integer overflow ${s}')
 	}
 	if neg && un > cutoff {
 		// return error('parse_int: range error $s0')

--- a/vlib/v/checker/tests/enum_field_edge_values.vv
+++ b/vlib/v/checker/tests/enum_field_edge_values.vv
@@ -1,0 +1,14 @@
+enum MaxInt32 {
+	a
+	b = 2147483647
+}
+
+enum MinInt32 {
+	a = -2147483648
+	b = 0
+}
+
+enum MinMaxInt32 {
+    a = -2147483648
+    b = 2147483647
+}

--- a/vlib/v/checker/tests/enum_field_overflow.out
+++ b/vlib/v/checker/tests/enum_field_overflow.out
@@ -1,10 +1,3 @@
-vlib/v/checker/tests/enum_field_overflow.vv:3:10: error: enum value `2147483647` overflows the enum type `int`, values of which have to be in [-2147483648, 2147483647]
-    1 | enum Color {
-    2 |     red
-    3 |     green = 2147483647
-      |             ~~~~~~~~~~
-    4 |     blue
-    5 | }
 vlib/v/checker/tests/enum_field_overflow.vv:4:2: error: enum value overflows type `int`, which has a maximum value of 2147483647
     2 |     red
     3 |     green = 2147483647


### PR DESCRIPTION
Fix #19315 

This PR adds more mess to `checker.v` mess. It also fixes wrong logic (I have no idea why it was merged at all) in `atoi.v` - `parse_int`, but only for positive integers.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dad3bb7</samp>

This pull request improves the error handling and parsing of enum values in the V compiler. It updates the `common_parse_int` function to return a more informative error message, and the checker to use the `parse_int` and `parse_uint` methods for enum values. It also adds a new test file `enum_field_edge_values.vv` and removes an obsolete test file `enum_field_overflow.out`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dad3bb7</samp>

*  Modify error message for integer overflow to include input string ([link](https://github.com/vlang/v/pull/19321/files?diff=unified&w=0#diff-5ab5e17885914d1c0e2aa0ad9b25a2ac673fecb717d9102681a9b729c698f762L196-R196))
*  Use parsing methods for enum values instead of direct integer conversion ([link](https://github.com/vlang/v/pull/19321/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L1790-R1853))
*  Add test for enums with edge values of underlying integer type ([link](https://github.com/vlang/v/pull/19321/files?diff=unified&w=0#diff-5aaaab7e4bd94150e64710a6f341f573e8c5baa654c15018531fbdc57ca6d7b2R1-R14))
*  Remove test for enum value overflow that is covered by new test ([link](https://github.com/vlang/v/pull/19321/files?diff=unified&w=0#diff-ef38cf7e65fe368a6e9eff6fbca8abf1184044c32833d0989710ae9cec24658fL1-L7))
