### PR TITLE
test: missing shared map test

### DIFF
--- a/vlib/v/tests/shared_map_ptr_test.v
+++ b/vlib/v/tests/shared_map_ptr_test.v
@@ -1,0 +1,23 @@
+struct Abc {
+	f shared map[string]&Abc
+}
+
+fn test_main() {
+	c := Abc{}
+	b := Abc{}
+	a := Abc{
+		f: b.f
+	}
+
+	lock a.f, b.f {
+		a.f['a'] = &c
+	}
+	lock b.f {
+		b.f['b'] = &c
+	}
+
+	dump(b.f)
+	rlock b.f {
+		assert b.f.len == 2
+	}
+}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 982528c</samp>

Added a new test case for the shared map pointer feature in `vlib/v/tests/shared_map_ptr_test.v`. The test demonstrates how to use shared maps with lock and rlock statements, and how to check and print their contents.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 982528c</samp>

* Add a test case for the shared map pointer feature ([link](https://github.com/vlang/v/pull/19322/files?diff=unified&w=0#diff-8cbb7118d3a35501011c3d31ee7792175500b80c726ea3646b765a7cd023fc1aR1-R23))
