### PR TITLE
checker: fix typeof of typeof.name

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -795,7 +795,7 @@ fn (mut g Gen) get_comptime_var_type(node ast.Expr) ast.Type {
 fn (mut g Gen) resolve_comptime_type(node ast.Expr, default_type ast.Type) ast.Type {
 	if (node is ast.Ident && g.is_comptime_var(node)) || node is ast.ComptimeSelector {
 		return g.get_comptime_var_type(node)
-	} else if node is ast.SelectorExpr {
+	} else if node is ast.SelectorExpr && node.expr_type != 0 {
 		sym := g.table.sym(g.unwrap_generic(node.expr_type))
 		if f := g.table.find_field_with_embeds(sym, node.field_name) {
 			return f.typ

--- a/vlib/v/tests/typeof_name_test.v
+++ b/vlib/v/tests/typeof_name_test.v
@@ -1,0 +1,6 @@
+fn test_main() {
+	pi := 3.14
+	type_ := typeof(pi).name
+	assert typeof(type_).name == 'string'
+	assert typeof(typeof(pi).name).name == 'string'
+}


### PR DESCRIPTION
Fix #19168

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e99fe26</samp>

This pull request fixes a compiler bug with selector expressions and adds a test case for the `typeof` builtin function. It modifies `vlib/v/gen/c/comptime.v` and `vlib/v/tests/typeof_name_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e99fe26</samp>

* Fix compiler crash for invalid selector expression type ([link](https://github.com/vlang/v/pull/19323/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL798-R798))
* Add test case for `typeof` builtin function ([link](https://github.com/vlang/v/pull/19323/files?diff=unified&w=0#diff-8c90c7219119c1859199626511c6ac66e02ce99a4c4198d7eb83e060429da514R1-R6))
