### PR TITLE
orm: fix cgen inserting wrong array index

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -134,6 +134,7 @@ const (
 		'vlib/orm/orm_mut_db_test.v',
 		'vlib/orm/orm_result_test.v',
 		'vlib/orm/orm_custom_operators_test.v',
+		'vlib/orm/orm_fk_test.v',
 		'vlib/db/sqlite/sqlite_test.v',
 		'vlib/db/sqlite/sqlite_orm_test.v',
 		'vlib/db/sqlite/sqlite_vfs_lowlevel_test.v',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -214,6 +214,7 @@ const (
 		'vlib/orm/orm_mut_db_test.v',
 		'vlib/orm/orm_result_test.v',
 		'vlib/orm/orm_custom_operators_test.v',
+		'vlib/orm/orm_fk_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_joined_tables_select_test.v',

--- a/vlib/orm/orm_fk_test.v
+++ b/vlib/orm/orm_fk_test.v
@@ -1,0 +1,57 @@
+import db.sqlite
+
+struct Person {
+	id                int       [primary; sql: serial]
+	age               int
+	brothers          []Brother [fkey: 'person_id']
+	sisters           []Sister  [fkey: 'person_id']
+	field_after_fkeys string
+}
+
+struct Brother {
+	id        int    [primary; sql: serial]
+	person_id int
+	name      string
+}
+
+struct Sister {
+	id        int    [primary; sql: serial]
+	person_id int
+	name      string
+}
+
+fn test_field_after_fkeys() {
+	db := sqlite.connect(':memory:') or { panic(err) }
+
+	sql db {
+		create table Brother
+		create table Sister
+		create table Person
+	}!
+
+	person := Person{
+		age: 21
+		brothers: [Brother{
+			name: 'aaa'
+		}, Brother{
+			name: 'bbb'
+		}]
+		sisters: [Sister{
+			name: 'ccc'
+		}, Sister{
+			name: 'ddd'
+		}]
+		field_after_fkeys: 'eee'
+	}
+
+	sql db {
+		insert person into Person
+	}!
+
+	persons := sql db {
+		select from Person
+	}!
+
+	assert persons[0].age == 21
+	assert persons[0].field_after_fkeys == 'eee'
+}


### PR DESCRIPTION
Fix #19042

The cgen of orm inserts the wrong index of fields from the result array of a SELECT query.
Array fields aren't present in the result array, but their index is still counted which can result in an index out of range.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a10281</samp>

Fix selected fields indexing in ORM queries. Use a separate index variable to access the `result` array in `vlib/v/gen/c/orm.v` to avoid mismatches with the `fields` array.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a10281</samp>

*  Introduce and increment `selected_fields_idx` variable to track the index of selected fields in query result ([link](https://github.com/vlang/v/pull/19324/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L879-R882), [link](https://github.com/vlang/v/pull/19324/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R902), [link](https://github.com/vlang/v/pull/19324/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R962))
