### PR TITLE
tests add  test runner  extended

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -83,25 +83,21 @@ mut:
 	flow_id string
 }
 
-fn (mut ts TestSession) append_message(kind MessageKind, msg string, mtc MessageThreadContext) {
+fn (mut ts TestSession) append(mtc MessageThreadContext, lm LogMessage) {
 	ts.nmessages <- LogMessage{
+		...lm
 		file: mtc.file
 		flow_id: mtc.flow_id
-		message: msg
-		kind: kind
 		when: time.now()
 	}
 }
 
+fn (mut ts TestSession) append_message(kind MessageKind, msg string, mtc MessageThreadContext) {
+	ts.append(mtc, message: msg, kind: kind)
+}
+
 fn (mut ts TestSession) append_message_with_duration(kind MessageKind, msg string, d time.Duration, mtc MessageThreadContext) {
-	ts.nmessages <- LogMessage{
-		file: mtc.file
-		flow_id: mtc.flow_id
-		message: msg
-		kind: kind
-		when: time.now()
-		took: d
-	}
+	ts.append(mtc, message: msg, kind: kind, took: d)
 }
 
 pub fn (mut ts TestSession) session_start(message string) {

--- a/cmd/tools/modules/testing/output.v
+++ b/cmd/tools/modules/testing/output.v
@@ -6,6 +6,12 @@ pub enum MessageKind {
 	cmd_begin // sent right before *each* _test.v file execution, the resulting status is not known yet, but the _test.v file itself is
 	cmd_end // sent right after *each* _test.v file execution, the message contains the output of that execution
 	//
+	compilation_begin // sent right before *each* compilation of a _test.v file; the result of it is not known yet
+	compilation_end // sent right after *each* compilation of a _test.v file; the compilation result is known
+	//
+	run_begin // sent right before *each* run of a _test.v file; the result of the run is not known yet
+	run_end // sent right after *each* run of a _test.v file; the result of the run is known
+	//
 	ok // success of a _test.v file
 	fail // failed _test.v file, one or more assertions failed
 	skip // the _test.v file was skipped for some reason
@@ -16,6 +22,7 @@ pub enum MessageKind {
 	sentinel // send just once after all executions are done; it signals that the reporting/printing thread should stop the loop and exit
 }
 
+[heap]
 pub struct LogMessage {
 pub:
 	kind    MessageKind   // see the MessageKind declaration above
@@ -33,14 +40,14 @@ mut:
 	worker_threads_start(files []string, mut ts TestSession) // called once per test session, in the main thread, right before all the worker threads start
 	worker_threads_finish(mut ts TestSession) // called once per test session, in the main thread, right after all the worker threads finish
 	//
-	report(index int, log_msg LogMessage) // called once per each message, that will be shown (ok/fail/skip etc), only in the reporting thread.
+	report(index int, log_msg &LogMessage) // called once per each message, that will be shown (ok/fail/skip etc), only in the reporting thread.
 	report_stop() // called just once after all messages are processed, only in the reporting thread, but before stop_session.
 	//
 	// TODO: reconsider, whether the next methods, should be kept for all reporters, or just moved inside the normal reporter, to simplify the interface
-	progress(index int, message string)
-	update_last_line(index int, message string)
-	update_last_line_and_move_to_next(index int, message string)
-	message(index int, message string)
+	progress(index int, message string, log_msg &LogMessage)
+	update_last_line(index int, message string, log_msg &LogMessage)
+	update_last_line_and_move_to_next(index int, message string, log_msg &LogMessage)
+	message(index int, message string, log_msg &LogMessage)
 	divider() // called to show a long ---------- horizontal line; can be safely ignored in most reporters; used in the main thread.
 	list_of_failed_commands(cmds []string) // called after all testing is done, to produce a small summary that only lists the failed commands, so that they can be retried manually if needed, without forcing the user to scroll and find them.
 }

--- a/cmd/tools/modules/testing/output.v
+++ b/cmd/tools/modules/testing/output.v
@@ -22,7 +22,7 @@ pub enum MessageKind {
 	sentinel // send just once after all executions are done; it signals that the reporting/printing thread should stop the loop and exit
 }
 
-[heap]
+[heap; params]
 pub struct LogMessage {
 pub:
 	kind    MessageKind   // see the MessageKind declaration above
@@ -31,6 +31,8 @@ pub:
 	flow_id string        // the messages of each thread, producing LogMessage, will have all the same unique flowid. Messages by other threads will have other flowid. If you use VJOBS=1 to serialise the execution, then all messages will have the same flowid.
 	took    time.Duration // the duration of the event, that this message describes
 	message string        // the actual message text; the result of the event, that the message describes; most reporters could ignore this, since it could be reconstructed by the other fields
+	//
+	meta map[string]string // meta information about the message
 }
 
 pub interface Reporter {

--- a/cmd/tools/modules/testing/output_dump.v
+++ b/cmd/tools/modules/testing/output_dump.v
@@ -31,7 +31,7 @@ pub fn (r DumpReporter) session_stop(message string, mut ts TestSession) {
 
 //
 
-pub fn (r DumpReporter) report(index int, message LogMessage) {
+pub fn (r DumpReporter) report(index int, message &LogMessage) {
 	eprintln('> ${@METHOD} | index: ${index} | message: ${message}')
 }
 
@@ -39,19 +39,19 @@ pub fn (r DumpReporter) report_stop() {
 	eprintln('> ${@METHOD}')
 }
 
-pub fn (r DumpReporter) progress(index int, message string) {
+pub fn (r DumpReporter) progress(index int, message string, log_message &LogMessage) {
 	eprintln('> ${@METHOD} | index: ${index} | message: ${message}')
 }
 
-pub fn (r DumpReporter) update_last_line(index int, message string) {
+pub fn (r DumpReporter) update_last_line(index int, message string, log_message &LogMessage) {
 	eprintln('> ${@METHOD} | index: ${index} | message: ${message}')
 }
 
-pub fn (r DumpReporter) update_last_line_and_move_to_next(index int, message string) {
+pub fn (r DumpReporter) update_last_line_and_move_to_next(index int, message string, log_message &LogMessage) {
 	eprintln('> ${@METHOD} | index: ${index} | message: ${message}')
 }
 
-pub fn (r DumpReporter) message(index int, message string) {
+pub fn (r DumpReporter) message(index int, message string, log_message &LogMessage) {
 	eprintln('> ${@METHOD} | index: ${index} | message: ${message}')
 }
 

--- a/cmd/tools/modules/testing/output_extended.v
+++ b/cmd/tools/modules/testing/output_extended.v
@@ -10,6 +10,7 @@ pub struct ExtendedReporter {
 mut:
 	compilation_duration map[string]time.Duration
 	run_duration         map[string]time.Duration
+	file_size            map[string]string
 }
 
 pub fn (r ExtendedReporter) session_start(message string, mut ts TestSession) {
@@ -26,6 +27,7 @@ pub fn (r ExtendedReporter) session_stop(message string, mut ts TestSession) {
 pub fn (mut r ExtendedReporter) report(index int, message &LogMessage) {
 	if message.kind == .compilation_end {
 		r.compilation_duration[message.file] = message.took
+		r.file_size[message.file] = message.meta['exe_size']
 	}
 	if message.kind == .run_end {
 		r.run_duration[message.file] = message.took
@@ -61,7 +63,7 @@ pub fn (r ExtendedReporter) message(index int, message string, log_message &LogM
 	cdur := r.compilation_duration[log_message.file]
 	rdur := r.run_duration[log_message.file]
 	// diff := time.Duration(log_message.took - (cdur + rdur))
-	nmessage := message.replace('] ', '] ${f64(cdur.microseconds()) / 1000.0:9} ms c.   ${f64(rdur.microseconds()) / 1000.0:8} ms r.  ')
+	nmessage := message.replace_each([' ms ', ' ms, ', ' [', ', [']).replace('] ', '], ${r.file_size[log_message.file]:8} B, ${f64(cdur.microseconds()) / 1000.0:9} ms c,   ${f64(rdur.microseconds()) / 1000.0:8} ms r, ')
 	eprintln(nmessage)
 }
 

--- a/cmd/tools/modules/testing/output_extended.v
+++ b/cmd/tools/modules/testing/output_extended.v
@@ -1,0 +1,86 @@
+module testing
+
+import term
+import time
+
+// ExtendedReporter implements the interface testing.Reporter.
+// It is used by default by `v test .`
+// It was extracted by the original non customiseable output implementation directly in cmd/tools/modules/testing/common.v
+pub struct ExtendedReporter {
+mut:
+	compilation_duration map[string]time.Duration
+	run_duration         map[string]time.Duration
+}
+
+pub fn (r ExtendedReporter) session_start(message string, mut ts TestSession) {
+	header(message)
+	///	eprintln('Status           Compilation        Runtime      Total    File')
+}
+
+pub fn (r ExtendedReporter) session_stop(message string, mut ts TestSession) {
+	println(ts.benchmark.total_message(message))
+}
+
+// the most general form; it may be useful for other reporters
+// in the normal one, it currently does nothing
+pub fn (mut r ExtendedReporter) report(index int, message &LogMessage) {
+	if message.kind == .compilation_end {
+		r.compilation_duration[message.file] = message.took
+	}
+	if message.kind == .run_end {
+		r.run_duration[message.file] = message.took
+	}
+	// eprintln('> ${@METHOD} index: $index | message: $message')
+}
+
+pub fn (r ExtendedReporter) report_stop() {
+	// eprintln('> ${@METHOD}')
+	eprintln('')
+}
+
+//// TODO: reconsider if these should be public:
+
+pub fn (r ExtendedReporter) progress(index int, message string, log_message &LogMessage) {
+	eprintln(message)
+}
+
+// in progress mode, the last line will be rewritten many times, and does not end with \n
+// the \n will be printed just once when some progress has been made.
+pub fn (r ExtendedReporter) update_last_line(index int, message string, log_message &LogMessage) {
+	print('\r${empty}\r${message}')
+	flush_stdout()
+}
+
+pub fn (r ExtendedReporter) update_last_line_and_move_to_next(index int, message string, log_message &LogMessage) {
+	// the last \n is needed, so SKIP/FAIL messages
+	// will not get overwritten by the OK ones
+	eprint('\r${empty}\r${message}\n')
+}
+
+pub fn (r ExtendedReporter) message(index int, message string, log_message &LogMessage) {
+	cdur := r.compilation_duration[log_message.file]
+	rdur := r.run_duration[log_message.file]
+	// diff := time.Duration(log_message.took - (cdur + rdur))
+	nmessage := message.replace('] ', '] ${f64(cdur.microseconds()) / 1000.0:9} ms c.   ${f64(rdur.microseconds()) / 1000.0:8} ms r.  ')
+	eprintln(nmessage)
+}
+
+pub fn (r ExtendedReporter) divider() {
+	eprintln(term.h_divider('-'))
+}
+
+//
+
+pub fn (r ExtendedReporter) worker_threads_start(files []string, mut ts TestSession) {
+	// eprintln('> ${@METHOD}')
+}
+
+pub fn (r ExtendedReporter) worker_threads_finish(mut ts TestSession) {
+	// eprintln('> ${@METHOD}')
+}
+
+pub fn (r ExtendedReporter) list_of_failed_commands(failed_cmds []string) {
+	for i, cmd in failed_cmds {
+		eprintln(term.failed('Failed command ${i + 1}:') + '    ${cmd}')
+	}
+}

--- a/cmd/tools/modules/testing/output_normal.v
+++ b/cmd/tools/modules/testing/output_normal.v
@@ -1,22 +1,15 @@
 module testing
 
 import term
-import time
-
-pub const empty = term.header(' ', ' ')
 
 // NormalReporter implements the interface testing.Reporter.
 // It is used by default by `v test .`
 // It was extracted by the original non customiseable output implementation directly in cmd/tools/modules/testing/common.v
 pub struct NormalReporter {
-mut:
-	compilation_duration map[string]time.Duration
-	run_duration         map[string]time.Duration
 }
 
 pub fn (r NormalReporter) session_start(message string, mut ts TestSession) {
 	header(message)
-	eprintln('Status             Total       Compilation        Runtime                 Test file')
 }
 
 pub fn (r NormalReporter) session_stop(message string, mut ts TestSession) {
@@ -26,12 +19,6 @@ pub fn (r NormalReporter) session_stop(message string, mut ts TestSession) {
 // the most general form; it may be useful for other reporters
 // in the normal one, it currently does nothing
 pub fn (mut r NormalReporter) report(index int, message &LogMessage) {
-	if message.kind == .compilation_end {
-		r.compilation_duration[message.file] = message.took
-	}
-	if message.kind == .run_end {
-		r.run_duration[message.file] = message.took
-	}
 	// eprintln('> ${@METHOD} index: $index | message: $message')
 }
 
@@ -49,21 +36,18 @@ pub fn (r NormalReporter) progress(index int, message string, log_message &LogMe
 // in progress mode, the last line will be rewritten many times, and does not end with \n
 // the \n will be printed just once when some progress has been made.
 pub fn (r NormalReporter) update_last_line(index int, message string, log_message &LogMessage) {
-	print('\r${testing.empty}\r${message}')
+	print('\r${empty}\r${message}')
 	flush_stdout()
 }
 
 pub fn (r NormalReporter) update_last_line_and_move_to_next(index int, message string, log_message &LogMessage) {
 	// the last \n is needed, so SKIP/FAIL messages
 	// will not get overwritten by the OK ones
-	eprint('\r${testing.empty}\r${message}\n')
+	eprint('\r${empty}\r${message}\n')
 }
 
 pub fn (r NormalReporter) message(index int, message string, log_message &LogMessage) {
-	cdur := r.compilation_duration[log_message.file]
-	rdur := r.run_duration[log_message.file]
-	nmessage := message.replace(' ms ', ' ms ~ ${cdur:10}   +   ${rdur:10}   ')
-	eprintln(nmessage)
+	eprintln(message)
 }
 
 pub fn (r NormalReporter) divider() {

--- a/cmd/tools/modules/testing/output_normal.v
+++ b/cmd/tools/modules/testing/output_normal.v
@@ -1,6 +1,7 @@
 module testing
 
 import term
+import time
 
 pub const empty = term.header(' ', ' ')
 
@@ -8,10 +9,14 @@ pub const empty = term.header(' ', ' ')
 // It is used by default by `v test .`
 // It was extracted by the original non customiseable output implementation directly in cmd/tools/modules/testing/common.v
 pub struct NormalReporter {
+mut:
+	compilation_duration map[string]time.Duration
+	run_duration         map[string]time.Duration
 }
 
 pub fn (r NormalReporter) session_start(message string, mut ts TestSession) {
 	header(message)
+	eprintln('Status             Total       Compilation        Runtime                 Test file')
 }
 
 pub fn (r NormalReporter) session_stop(message string, mut ts TestSession) {
@@ -20,7 +25,13 @@ pub fn (r NormalReporter) session_stop(message string, mut ts TestSession) {
 
 // the most general form; it may be useful for other reporters
 // in the normal one, it currently does nothing
-pub fn (r NormalReporter) report(index int, message LogMessage) {
+pub fn (mut r NormalReporter) report(index int, message &LogMessage) {
+	if message.kind == .compilation_end {
+		r.compilation_duration[message.file] = message.took
+	}
+	if message.kind == .run_end {
+		r.run_duration[message.file] = message.took
+	}
 	// eprintln('> ${@METHOD} index: $index | message: $message')
 }
 
@@ -31,25 +42,28 @@ pub fn (r NormalReporter) report_stop() {
 
 //// TODO: reconsider if these should be public:
 
-pub fn (r NormalReporter) progress(index int, message string) {
+pub fn (r NormalReporter) progress(index int, message string, log_message &LogMessage) {
 	eprintln(message)
 }
 
 // in progress mode, the last line will be rewritten many times, and does not end with \n
 // the \n will be printed just once when some progress has been made.
-pub fn (r NormalReporter) update_last_line(index int, message string) {
+pub fn (r NormalReporter) update_last_line(index int, message string, log_message &LogMessage) {
 	print('\r${testing.empty}\r${message}')
 	flush_stdout()
 }
 
-pub fn (r NormalReporter) update_last_line_and_move_to_next(index int, message string) {
+pub fn (r NormalReporter) update_last_line_and_move_to_next(index int, message string, log_message &LogMessage) {
 	// the last \n is needed, so SKIP/FAIL messages
 	// will not get overwritten by the OK ones
 	eprint('\r${testing.empty}\r${message}\n')
 }
 
-pub fn (r NormalReporter) message(index int, message string) {
-	eprintln(message)
+pub fn (r NormalReporter) message(index int, message string, log_message &LogMessage) {
+	cdur := r.compilation_duration[log_message.file]
+	rdur := r.run_duration[log_message.file]
+	nmessage := message.replace(' ms ', ' ms ~ ${cdur:10}   +   ${rdur:10}   ')
+	eprintln(nmessage)
 }
 
 pub fn (r NormalReporter) divider() {

--- a/cmd/tools/modules/testing/output_teamcity.v
+++ b/cmd/tools/modules/testing/output_teamcity.v
@@ -11,7 +11,7 @@ pub fn (r TeamcityReporter) session_start(message string, mut ts TestSession) {
 pub fn (r TeamcityReporter) session_stop(message string, mut ts TestSession) {
 }
 
-pub fn (r TeamcityReporter) report(index int, message LogMessage) {
+pub fn (r TeamcityReporter) report(index int, message &LogMessage) {
 	name := r.get_test_suite_name_by_file(message.file)
 	match message.kind {
 		.cmd_begin {
@@ -35,16 +35,16 @@ pub fn (r TeamcityReporter) get_test_suite_name_by_file(path string) string {
 pub fn (r TeamcityReporter) report_stop() {
 }
 
-pub fn (r TeamcityReporter) progress(index int, message string) {
+pub fn (r TeamcityReporter) progress(index int, message string, log_message &LogMessage) {
 }
 
-pub fn (r TeamcityReporter) update_last_line(index int, message string) {
+pub fn (r TeamcityReporter) update_last_line(index int, message string, log_message &LogMessage) {
 }
 
-pub fn (r TeamcityReporter) update_last_line_and_move_to_next(index int, message string) {
+pub fn (r TeamcityReporter) update_last_line_and_move_to_next(index int, message string, log_message &LogMessage) {
 }
 
-pub fn (r TeamcityReporter) message(index int, message string) {
+pub fn (r TeamcityReporter) message(index int, message string, log_message &LogMessage) {
 }
 
 pub fn (r TeamcityReporter) divider() {

--- a/cmd/tools/modules/testing/test_command.v
+++ b/cmd/tools/modules/testing/test_command.v
@@ -1,0 +1,103 @@
+module testing
+
+import os
+import time
+
+struct TestCommand {
+mut:
+	vexe    string
+	options string
+	file    string
+	run_js  bool
+	//
+	compile_cmd string
+	executable  string
+	//
+	already_compiled bool
+	compile_result   os.Result
+	//
+	exit_code int
+	output    string
+	//
+	total_duration   time.Duration
+	compile_duration time.Duration
+	run_duration     time.Duration
+	ts               &TestSession = unsafe { nil }
+	mtc              &MessageThreadContext = unsafe { nil }
+}
+
+fn TestCommand.new(vexe string, options []string, file string, generated_binary_fpath string, run_js bool, ts &TestSession, mtc &MessageThreadContext) TestCommand {
+	noptions := options.filter(it != '').join(' ')
+	compile_cmd := '${os.quoted_path(vexe)} ${noptions} ${os.quoted_path(file)}'
+	executable := if run_js {
+		compile_cmd
+	} else {
+		generated_binary_fpath
+	}
+	// eprintln('>>>> vexe: ${vexe} | noptions: `${noptions}` | file: ${file} | generated_binary_fpath: ${generated_binary_fpath} | run_js: ${run_js} | compile_cmd: ${compile_cmd}')
+	return TestCommand{
+		vexe: vexe
+		options: noptions
+		file: file
+		compile_cmd: compile_cmd
+		executable: executable
+		run_js: run_js
+		ts: ts
+		mtc: mtc
+	}
+}
+
+fn (tc TestCommand) str() string {
+	return tc.compile_cmd
+}
+
+fn (mut tc TestCommand) compile() {
+	if tc.already_compiled {
+		return
+	}
+	tc.ts.append_message(.compilation_begin, '', tc.mtc)
+	sw := time.new_stopwatch()
+	cres := os.execute(tc.compile_cmd)
+	tc.compile_duration = sw.elapsed()
+	tc.total_duration = tc.compile_duration
+	tc.already_compiled = true
+	tc.exit_code = cres.exit_code
+	tc.output = cres.output
+	tc.compile_result = cres
+	tc.ts.append_message_with_duration(.compilation_end, '', tc.compile_duration, tc.mtc)
+}
+
+//
+
+fn (mut tc TestCommand) execute() os.Result {
+	if !tc.run_js {
+		tc.compile()
+		if tc.compile_result.exit_code != 0 {
+			return tc.compile_result
+		}
+	}
+	tc.ts.append_message(.run_begin, '', tc.mtc)
+	sw := time.new_stopwatch()
+	rres := os.execute(tc.executable)
+	tc.run_duration = sw.elapsed()
+	tc.total_duration += tc.run_duration
+	tc.ts.append_message_with_duration(.run_end, '', tc.run_duration, tc.mtc)
+	return os.Result{
+		...rres
+		output: '${tc.compile_result.output}\n${rres.output}'
+	}
+}
+
+fn (mut tc TestCommand) system() int {
+	if !tc.run_js {
+		tc.compile()
+		if tc.compile_result.exit_code != 0 {
+			return tc.compile_result.exit_code
+		}
+	}
+	sw := time.new_stopwatch()
+	res := os.system(tc.executable)
+	tc.run_duration = sw.elapsed()
+	tc.total_duration += tc.run_duration
+	return res
+}

--- a/cmd/tools/modules/testing/test_command.v
+++ b/cmd/tools/modules/testing/test_command.v
@@ -64,7 +64,15 @@ fn (mut tc TestCommand) compile() {
 	tc.exit_code = cres.exit_code
 	tc.output = cres.output
 	tc.compile_result = cres
-	tc.ts.append_message_with_duration(.compilation_end, '', tc.compile_duration, tc.mtc)
+	exe_size := os.file_size(tc.executable)
+	tc.ts.append(tc.mtc,
+		kind: .compilation_end
+		message: ''
+		took: tc.compile_duration
+		meta: {
+			'exe_size': exe_size.str()
+		}
+	)
 }
 
 //

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -62,6 +62,8 @@ fn (b &Builder) exit_on_invalid_syntax() {
 	}
 }
 
+const vtest_just_compile = os.getenv('VTEST_JUST_COMPILE') != ''
+
 fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.backend == .interpret {
 		// the interpreted code has already ran
@@ -79,7 +81,8 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.os == .ios {
 		panic('Running iOS apps is not supported yet.')
 	}
-	if !(b.pref.is_test || b.pref.is_run || b.pref.is_crun) {
+	if (builder.vtest_just_compile && b.pref.is_test) || !(b.pref.is_test
+		|| b.pref.is_run || b.pref.is_crun) {
 		exit(0)
 	}
 	mut compiled_file := b.pref.out_name

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -62,8 +62,6 @@ fn (b &Builder) exit_on_invalid_syntax() {
 	}
 }
 
-const vtest_just_compile = os.getenv('VTEST_JUST_COMPILE') != ''
-
 fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.backend == .interpret {
 		// the interpreted code has already ran
@@ -81,8 +79,10 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.os == .ios {
 		panic('Running iOS apps is not supported yet.')
 	}
-	if (builder.vtest_just_compile && b.pref.is_test) || !(b.pref.is_test
-		|| b.pref.is_run || b.pref.is_crun) {
+	if b.pref.is_test && b.pref.is_just_compile {
+		exit(0)
+	}
+	if !(b.pref.is_test || b.pref.is_run || b.pref.is_crun) {
 		exit(0)
 	}
 	mut compiled_file := b.pref.out_name

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -92,7 +92,7 @@ pub enum Arch {
 pub const list_of_flags_with_param = ['b', 'd', 'e', 'o', 'define', 'backend', 'cc', 'os', 'cflags',
 	'ldflags', 'path', 'arch']
 
-pub const supported_test_runners = ['normal', 'simple', 'tap', 'dump', 'teamcity']
+pub const supported_test_runners = ['normal', 'extended', 'simple', 'tap', 'dump', 'teamcity']
 
 [heap; minify]
 pub struct Preferences {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -132,6 +132,7 @@ pub mut:
 	is_apk             bool     // build as Android .apk format
 	is_help            bool     // -h, -help or --help was passed
 	is_cstrict         bool     // turn on more C warnings; slightly slower
+	is_just_compile    bool     // Used by `v test .`; The test runner uses `v -just-compile file_test.v` to compile each _test.v file, *without* running it first.
 	eval_argument      string   // `println(2+2)` on `v -e "println(2+2)"`. Note that this souce code, will be evaluated in vsh mode, so 'v -e 'println(ls(".")!)' is valid.
 	test_runner        string   // can be 'simple' (fastest, but much less detailed), 'tap', 'normal'
 	profile_file       string   // the profile results will be stored inside profile_file
@@ -795,6 +796,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-is_o' {
 				res.is_o = true
+			}
+			'-just-compile' {
+				res.is_just_compile = true
 			}
 			'-b', '-backend' {
 				sbackend := cmdline.option(current_args, arg, 'c')

--- a/vlib/v/preludes/embed_file/embed_file.v
+++ b/vlib/v/preludes/embed_file/embed_file.v
@@ -4,6 +4,4 @@ module embed_file
 // in both the main executable, and in the shared library.
 import v.embed_file
 
-const (
-	no_warning_embed_file_is_used = embed_file.is_used
-)
+const no_warning_embed_file_is_used = embed_file.is_used

--- a/vlib/v/preludes/embed_file/zlib/embed_file_zlib.v
+++ b/vlib/v/preludes/embed_file/zlib/embed_file_zlib.v
@@ -5,6 +5,7 @@ import v.embed_file
 
 struct ZLibDecoder {}
 
+[markused]
 fn (_ ZLibDecoder) decompress(data []u8) ![]u8 {
 	return zlib.decompress(data)
 }

--- a/vlib/v/preludes/test_runner.v
+++ b/vlib/v/preludes/test_runner.v
@@ -1,6 +1,7 @@
 [has_globals]
 module main
 
+[markused]
 __global test_runner TestRunner
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -43,6 +44,7 @@ struct VTestFileMetaInfo {
 
 // vtest_new_filemetainfo will be called right before .start(ntests),
 // to fill in the .file_test_info field of the runner interface.
+[markused]
 fn vtest_new_filemetainfo(file string, tests int) VTestFileMetaInfo {
 	return VTestFileMetaInfo{
 		file: file
@@ -67,6 +69,7 @@ struct VTestFnMetaInfo {
 }
 
 // vtest_new_metainfo will be called once per each test function.
+[markused]
 fn vtest_new_metainfo(name string, mod string, file string, line_nr int) VTestFnMetaInfo {
 	return VTestFnMetaInfo{
 		name: name
@@ -76,7 +79,7 @@ fn vtest_new_metainfo(name string, mod string, file string, line_nr int) VTestFn
 	}
 }
 
-[unsafe]
+[markused; unsafe]
 fn (i &VTestFnMetaInfo) free() {
 	unsafe {
 		i.name.free()
@@ -96,7 +99,7 @@ mut:
 // change_test_runner should be called by preludes that implement the
 // the TestRunner interface, in their vtest_init fn (see below), to
 // customize the way that V shows test results
-[manualfree]
+[manualfree; markused]
 pub fn change_test_runner(x &TestRunner) {
 	pobj := unsafe { &C.main__TestRunner(&test_runner)._object }
 	if pobj != 0 {

--- a/vlib/v/preludes/test_runner_extended.v
+++ b/vlib/v/preludes/test_runner_extended.v
@@ -1,0 +1,171 @@
+module main
+
+import os
+import term
+
+///////////////////////////////////////////////////////////
+// This file gets compiled as part of the main program, for
+// each _test.v file. It implements the default/normal test
+// output for `v run file_test.v`
+// See also test_runner.v .
+///////////////////////////////////////////////////////////
+
+fn vtest_init() {
+	change_test_runner(&TestRunner(new_normal_test_runner()))
+}
+
+struct NormalTestRunner {
+pub mut:
+	fname              string
+	use_color          bool
+	use_relative_paths bool
+	all_assertsions    []&VAssertMetaInfo
+	//
+mut:
+	file_test_info   VTestFileMetaInfo
+	fn_test_info     VTestFnMetaInfo
+	fn_assert_passes u64
+	fn_passes        u64
+	fn_fails         u64
+	//
+	total_assert_passes u64
+	total_assert_fails  u64
+}
+
+fn new_normal_test_runner() &TestRunner {
+	unsafe {
+		mut tr := &NormalTestRunner{}
+		tr.use_color = term.can_show_color_on_stderr()
+		tr.use_relative_paths = match os.getenv('VERROR_PATHS') {
+			'absolute' { false }
+			else { true }
+		}
+		return tr
+	}
+}
+
+fn (mut runner NormalTestRunner) free() {
+	unsafe {
+		runner.all_assertsions.free()
+		runner.fname.free()
+		runner.fn_test_info.free()
+		runner.file_test_info.free()
+	}
+}
+
+fn normalise_fname(name string) string {
+	return 'fn ' + name.replace('__', '.').replace('main.', '')
+}
+
+fn (mut runner NormalTestRunner) start(ntests int) {
+	unsafe {
+		runner.all_assertsions = []&VAssertMetaInfo{cap: 1000}
+	}
+}
+
+fn (mut runner NormalTestRunner) finish() {
+}
+
+fn (mut runner NormalTestRunner) exit_code() int {
+	if runner.fn_fails > 0 {
+		return 1
+	}
+	if runner.total_assert_fails > 0 {
+		return 2
+	}
+	return 0
+}
+
+fn (mut runner NormalTestRunner) fn_start() bool {
+	runner.fn_assert_passes = 0
+	runner.fname = normalise_fname(runner.fn_test_info.name)
+	return true
+}
+
+fn (mut runner NormalTestRunner) fn_pass() {
+	runner.fn_passes++
+}
+
+fn (mut runner NormalTestRunner) fn_fail() {
+	runner.fn_fails++
+}
+
+fn (mut runner NormalTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+	filepath := if runner.use_relative_paths { file.clone() } else { os.real_path(file) }
+	mut final_filepath := filepath + ':${line_nr}:'
+	if runner.use_color {
+		final_filepath = term.gray(final_filepath)
+	}
+	mut final_funcname := 'fn ' + fn_name.replace('main.', '').replace('__', '.')
+	if runner.use_color {
+		final_funcname = term.red('✗ ' + final_funcname)
+	}
+	final_msg := if runner.use_color { term.dim(errmsg) } else { errmsg.clone() }
+	eprintln('${final_filepath} ${final_funcname} failed propagation with error: ${final_msg}')
+	if os.is_file(file) {
+		source_lines := os.read_lines(file) or { []string{len: line_nr + 1} }
+		eprintln('${line_nr:5} | ${source_lines[line_nr - 1]}')
+	}
+}
+
+fn (mut runner NormalTestRunner) assert_pass(i &VAssertMetaInfo) {
+	runner.total_assert_passes++
+	runner.fn_assert_passes++
+	runner.all_assertsions << i
+}
+
+fn (mut runner NormalTestRunner) assert_fail(i &VAssertMetaInfo) {
+	runner.total_assert_fails++
+	filepath := if runner.use_relative_paths { i.fpath.clone() } else { os.real_path(i.fpath) }
+	mut final_filepath := filepath + ':${i.line_nr + 1}:'
+	if runner.use_color {
+		final_filepath = term.gray(final_filepath)
+	}
+	mut final_funcname := 'fn ' + i.fn_name.replace('main.', '').replace('__', '.')
+	if runner.use_color {
+		final_funcname = term.red('✗ ' + final_funcname)
+	}
+	final_src := if runner.use_color {
+		term.dim('assert ${term.bold(i.src)}')
+	} else {
+		'assert ' + i.src
+	}
+	eprintln('${final_filepath} ${final_funcname}')
+	if i.op.len > 0 && i.op != 'call' {
+		mut lvtitle := '    Left value:'
+		mut rvtitle := '    Right value:'
+		mut slvalue := '${i.lvalue}'
+		mut srvalue := '${i.rvalue}'
+		if runner.use_color {
+			slvalue = term.yellow(slvalue)
+			srvalue = term.yellow(srvalue)
+			lvtitle = term.gray(lvtitle)
+			rvtitle = term.gray(rvtitle)
+		}
+		cutoff_limit := 30
+		if slvalue.len > cutoff_limit || srvalue.len > cutoff_limit {
+			eprintln('  > ${final_src}')
+			eprintln(lvtitle)
+			eprintln('      ${slvalue}')
+			eprintln(rvtitle)
+			eprintln('      ${srvalue}')
+		} else {
+			eprintln('   > ${final_src}')
+			eprintln(' ${lvtitle} ${slvalue}')
+			eprintln('${rvtitle} ${srvalue}')
+		}
+	} else {
+		eprintln('    ${final_src}')
+	}
+	if i.has_msg {
+		mut mtitle := '        Message:'
+		mut mvalue := '${i.message}'
+		if runner.use_color {
+			mvalue = term.yellow(mvalue)
+			mtitle = term.gray(mtitle)
+		}
+		eprintln('${mtitle} ${mvalue}')
+	}
+	eprintln('')
+	runner.all_assertsions << i
+}

--- a/vlib/v/preludes/test_runner_extended.v
+++ b/vlib/v/preludes/test_runner_extended.v
@@ -5,16 +5,16 @@ import term
 
 ///////////////////////////////////////////////////////////
 // This file gets compiled as part of the main program, for
-// each _test.v file. It implements the default/normal test
+// each _test.v file. It implements the extended test
 // output for `v run file_test.v`
 // See also test_runner.v .
 ///////////////////////////////////////////////////////////
 
 fn vtest_init() {
-	change_test_runner(&TestRunner(new_normal_test_runner()))
+	change_test_runner(&TestRunner(ExtendedTestRunner.new()))
 }
 
-struct NormalTestRunner {
+struct ExtendedTestRunner {
 pub mut:
 	fname              string
 	use_color          bool
@@ -32,9 +32,9 @@ mut:
 	total_assert_fails  u64
 }
 
-fn new_normal_test_runner() &TestRunner {
+fn ExtendedTestRunner.new() &TestRunner {
 	unsafe {
-		mut tr := &NormalTestRunner{}
+		mut tr := &ExtendedTestRunner{}
 		tr.use_color = term.can_show_color_on_stderr()
 		tr.use_relative_paths = match os.getenv('VERROR_PATHS') {
 			'absolute' { false }
@@ -44,7 +44,7 @@ fn new_normal_test_runner() &TestRunner {
 	}
 }
 
-fn (mut runner NormalTestRunner) free() {
+fn (mut runner ExtendedTestRunner) free() {
 	unsafe {
 		runner.all_assertsions.free()
 		runner.fname.free()
@@ -57,16 +57,16 @@ fn normalise_fname(name string) string {
 	return 'fn ' + name.replace('__', '.').replace('main.', '')
 }
 
-fn (mut runner NormalTestRunner) start(ntests int) {
+fn (mut runner ExtendedTestRunner) start(ntests int) {
 	unsafe {
 		runner.all_assertsions = []&VAssertMetaInfo{cap: 1000}
 	}
 }
 
-fn (mut runner NormalTestRunner) finish() {
+fn (mut runner ExtendedTestRunner) finish() {
 }
 
-fn (mut runner NormalTestRunner) exit_code() int {
+fn (mut runner ExtendedTestRunner) exit_code() int {
 	if runner.fn_fails > 0 {
 		return 1
 	}
@@ -76,21 +76,21 @@ fn (mut runner NormalTestRunner) exit_code() int {
 	return 0
 }
 
-fn (mut runner NormalTestRunner) fn_start() bool {
+fn (mut runner ExtendedTestRunner) fn_start() bool {
 	runner.fn_assert_passes = 0
 	runner.fname = normalise_fname(runner.fn_test_info.name)
 	return true
 }
 
-fn (mut runner NormalTestRunner) fn_pass() {
+fn (mut runner ExtendedTestRunner) fn_pass() {
 	runner.fn_passes++
 }
 
-fn (mut runner NormalTestRunner) fn_fail() {
+fn (mut runner ExtendedTestRunner) fn_fail() {
 	runner.fn_fails++
 }
 
-fn (mut runner NormalTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn (mut runner ExtendedTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
 	filepath := if runner.use_relative_paths { file.clone() } else { os.real_path(file) }
 	mut final_filepath := filepath + ':${line_nr}:'
 	if runner.use_color {
@@ -108,13 +108,13 @@ fn (mut runner NormalTestRunner) fn_error(line_nr int, file string, mod string, 
 	}
 }
 
-fn (mut runner NormalTestRunner) assert_pass(i &VAssertMetaInfo) {
+fn (mut runner ExtendedTestRunner) assert_pass(i &VAssertMetaInfo) {
 	runner.total_assert_passes++
 	runner.fn_assert_passes++
 	runner.all_assertsions << i
 }
 
-fn (mut runner NormalTestRunner) assert_fail(i &VAssertMetaInfo) {
+fn (mut runner ExtendedTestRunner) assert_fail(i &VAssertMetaInfo) {
 	runner.total_assert_fails++
 	filepath := if runner.use_relative_paths { i.fpath.clone() } else { os.real_path(i.fpath) }
 	mut final_filepath := filepath + ':${i.line_nr + 1}:'

--- a/vlib/v/preludes/tests_with_stats.v
+++ b/vlib/v/preludes/tests_with_stats.v
@@ -10,9 +10,7 @@ module main
 import os
 import benchmark
 
-const (
-	inner_indent = '     '
-)
+const inner_indent = '     '
 
 struct BenchedTests {
 mut:
@@ -26,6 +24,7 @@ mut:
 
 // ///////////////////////////////////////////////////////////////////
 // Called at the start of the test program produced by `v -stats file_test.v`
+[markused]
 fn start_testing(total_number_of_tests int, vfilename string) BenchedTests {
 	mut benched_tests_res := BenchedTests{
 		bench: benchmark.new_benchmark()
@@ -37,6 +36,7 @@ fn start_testing(total_number_of_tests int, vfilename string) BenchedTests {
 }
 
 // Called before each test_ function, defined in file_test.v
+[markused]
 fn (mut b BenchedTests) testing_step_start(stepfunc string) {
 	b.step_func_name = stepfunc.replace('main.', '').replace('__', '.')
 	b.oks = test_runner.total_assert_passes
@@ -46,6 +46,7 @@ fn (mut b BenchedTests) testing_step_start(stepfunc string) {
 }
 
 // Called after each test_ function, defined in file_test.v
+[markused]
 fn (mut b BenchedTests) testing_step_end() {
 	ok_diff := int(test_runner.total_assert_passes - b.oks)
 	fail_diff := int(test_runner.total_assert_fails - b.fails)
@@ -76,11 +77,13 @@ fn (mut b BenchedTests) testing_step_end() {
 	}
 }
 
+[markused]
 fn (b &BenchedTests) fn_name() string {
 	return b.step_func_name + '()'
 }
 
 // Called at the end of the test program produced by `v -stats file_test.v`
+[markused]
 fn (mut b BenchedTests) end_testing() {
 	b.bench.stop()
 	fname := os.file_name(b.test_suit_file)


### PR DESCRIPTION
- v.builder: support VTEST_JUST_COMPILE, so `v file_test.v` can just compile a test file to an executable and stop
- tests: show compilation time and run time separately in the normal output of `v test .`
- pref: support `v -just-compile file_test.v`, instead of `VTEST_JUST_COMPILE=1 v file_test.v` (more predictable with nested testing)
- pref: support `v -test-runner extended test .`
- preludes: fix `./v -stats -show-timings -just-compile vlib/builtin/byte_test.v`
- tests: show the test executable size too as a column in the output of `./v -test-runner extended test vlib/term/`
- cleanup vlib/v/preludes/test_runner_extended.v
