### PR TITLE
net.ssl: implement SSLConn.peer_addr()

### DIFF
--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -4,7 +4,7 @@ import io.util
 import net.conv
 import os
 
-pub union AddrData {
+union AddrData {
 	Unix
 	Ip
 	Ip6

--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -4,7 +4,7 @@ import io.util
 import net.conv
 import os
 
-union AddrData {
+pub union AddrData {
 	Unix
 	Ip
 	Ip6

--- a/vlib/net/address.v
+++ b/vlib/net/address.v
@@ -294,14 +294,24 @@ pub fn (a Addr) str() string {
 
 // addr_from_socket_handle returns an address, based on the given integer socket `handle`
 pub fn addr_from_socket_handle(handle int) Addr {
-	addr := Addr{
+	mut addr := Addr{
 		addr: AddrData{
 			Ip6: Ip6{}
 		}
 	}
-	size := sizeof(addr)
-
+	mut size := sizeof(addr)
 	C.getsockname(handle, voidptr(&addr), &size)
+	return addr
+}
 
+// peer_addr_from_socket_handle retrieves the ip address and port number, given a socket handle
+pub fn peer_addr_from_socket_handle(handle int) !Addr {
+	mut addr := Addr{
+		addr: AddrData{
+			Ip6: Ip6{}
+		}
+	}
+	mut size := sizeof(Addr)
+	socket_error_message(C.getpeername(handle, voidptr(&addr), &size), 'peer_addr_from_socket_handle failed')!
 	return addr
 }

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -405,17 +405,9 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	s.opened = true
 }
 
-// retrieve the ip address and port number used by the peer
-pub fn (mut s SSLConn) peer_addr() !net.Addr {
-	socket := net.TcpSocket{
-		handle: s.handle
-	}
-	tc := &net.TcpConn{
-		sock: socket
-		read_timeout: net.tcp_default_read_timeout
-		write_timeout: net.tcp_default_write_timeout
-	}
-	return tc.peer_addr()
+// peer_addr retrieves the ip address and port number used by the peer
+pub fn (s &SSLConn) peer_addr() !net.Addr {
+	return net.peer_addr_from_socket_handle(s.handle)
 }
 
 // socket_read_into_ptr reads `len` bytes into `buf`

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -405,15 +405,17 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	s.opened = true
 }
 
+// retrieve the ip address and port number used by the peer
 pub fn (mut s SSLConn) peer_addr() !net.Addr {
-	mut addr := net.Addr{
-		addr: net.AddrData{
-			Ip6: net.Ip6{}
-		}
+	socket := net.TcpSocket{
+		handle: s.handle
 	}
-	mut size := sizeof(net.Addr)
-	net.socket_error_message(C.getpeername(s.handle, voidptr(&addr), &size), 'peer_addr failed')!
-	return addr
+	tc := &net.TcpConn{
+		sock: socket
+		read_timeout: net.tcp_default_read_timeout
+		write_timeout: net.tcp_default_write_timeout
+	}
+	return tc.peer_addr()
 }
 
 // socket_read_into_ptr reads `len` bytes into `buf`

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -405,6 +405,17 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	s.opened = true
 }
 
+pub fn (mut s SSLConn) peer_addr() !net.Addr {
+	mut addr := net.Addr{
+		addr: net.AddrData{
+			Ip6: net.Ip6{}
+		}
+	}
+	mut size := sizeof(net.Addr)
+	net.socket_error_message(C.getpeername(s.handle, voidptr(&addr), &size), 'peer_addr failed')!
+	return addr
+}
+
 // socket_read_into_ptr reads `len` bytes into `buf`
 pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 	mut res := 0

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -280,6 +280,11 @@ fn (mut s SSLConn) complete_connect() ! {
 	}
 }
 
+// peer_addr retrieves the ip address and port number used by the peer
+pub fn (s &SSLConn) peer_addr() !net.Addr {
+	return net.peer_addr_from_socket_handle(s.handle)
+}
+
 pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 	mut res := 0
 	$if trace_ssl ? {

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -252,18 +252,12 @@ pub fn (mut c TcpConn) set_sock() ! {
 	}
 }
 
-// retrieve the ip address and port number used by the peer
+// peer_addr retrieves the ip address and port number used by the peer
 pub fn (c &TcpConn) peer_addr() !Addr {
-	mut addr := Addr{
-		addr: AddrData{
-			Ip6: Ip6{}
-		}
-	}
-	mut size := sizeof(Addr)
-	socket_error_message(C.getpeername(c.sock.handle, voidptr(&addr), &size), 'peer_addr failed')!
-	return addr
+	return peer_addr_from_socket_handle(c.sock.handle)
 }
 
+// peer_ip retrieves the ip address used by the peer, and returns it as a string
 pub fn (c &TcpConn) peer_ip() !string {
 	return c.peer_addr()!.str()
 }

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -4,7 +4,7 @@ import time
 import io
 import strings
 
-const (
+pub const (
 	tcp_default_read_timeout  = 30 * time.second
 	tcp_default_write_timeout = 30 * time.second
 )
@@ -252,6 +252,7 @@ pub fn (mut c TcpConn) set_sock() ! {
 	}
 }
 
+// retrieve the ip address and port number used by the peer
 pub fn (c &TcpConn) peer_addr() !Addr {
 	mut addr := Addr{
 		addr: AddrData{
@@ -385,7 +386,7 @@ pub fn (c &TcpListener) addr() !Addr {
 	return c.sock.address()
 }
 
-struct TcpSocket {
+pub struct TcpSocket {
 	Socket
 }
 

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -380,7 +380,7 @@ pub fn (c &TcpListener) addr() !Addr {
 	return c.sock.address()
 }
 
-pub struct TcpSocket {
+struct TcpSocket {
 	Socket
 }
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 400ac66</samp>

Made `AddrData` union public and added `peer_addr` method to `SSLConn`. These changes improve the net module's API and enable secure applications to access the remote address of the connection.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 400ac66</samp>

* Make `AddrData` union public to allow other modules to access address fields ([link](https://github.com/vlang/v/pull/19333/files?diff=unified&w=0#diff-ac93d4f5773c25b0d6d22917ae41271fe50380347d0a79dbfa76b0c7adc3e7faL7-R7))
* Add `peer_addr` method to `SSLConn` struct to return the remote address of the secure connection ([link](https://github.com/vlang/v/pull/19333/files?diff=unified&w=0#diff-326ce84590d0e746b2d0332784bdb803c464769d8a77fe8100d7bd48a374b78dR408-R418))
