### PR TITLE
net.http:fix post error with https on windows

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -87,7 +87,7 @@ void vschannel_init(TlsContext *tls_ctx) {
 	tls_ctx->creds_initialized = TRUE;
 }
 
-INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, CHAR **out)
+INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, DWORD req_len, CHAR **out)
 {
 	SecBuffer  ExtraData;
 	SECURITY_STATUS Status;
@@ -149,7 +149,7 @@ INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, CHAR **out)
 	tls_ctx->p_pemote_cert_context = NULL;
 
 	// Request from server
-	if(https_make_request(tls_ctx, req, out, &resp_length)) {
+	if(https_make_request(tls_ctx, req, out, req_len, &resp_length)) {
 		vschannel_cleanup(tls_ctx);
 		return resp_length;
 	}
@@ -711,7 +711,7 @@ static SECURITY_STATUS client_handshake_loop(TlsContext *tls_ctx, BOOL fDoInitia
 }
 
 
-static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, CHAR **out, int *length) {
+static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD req_len, CHAR **out, int *length) {
 	SecPkgContext_StreamSizes Sizes;
 	SECURITY_STATUS scRet;
 	SecBufferDesc   Message;
@@ -757,10 +757,8 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, CHAR *
 
 	// Build HTTP request. Note that I'm assuming that this is less than
 	// the maximum message size. If it weren't, it would have to be broken up.
-	sprintf(pbMessage, "%s", req);
-
-	cbMessage = (DWORD)strlen(pbMessage);
-
+	memcpy(pbMessage, req, req_len);
+	cbMessage = req_len;
 
 	// Encrypt the HTTP request.
 	Buffers[0].pvBuffer     = pbIoBuffer;

--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -149,7 +149,7 @@ INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, DWORD req_le
 	tls_ctx->p_pemote_cert_context = NULL;
 
 	// Request from server
-	if(https_make_request(tls_ctx, req, out, req_len, &resp_length)) {
+	if(https_make_request(tls_ctx, req, req_len, out, &resp_length)) {
 		vschannel_cleanup(tls_ctx);
 		return resp_length;
 	}

--- a/thirdparty/vschannel/vschannel.h
+++ b/thirdparty/vschannel/vschannel.h
@@ -32,9 +32,9 @@ static void vschannel_init(TlsContext *tls_ctx);
 
 static void vschannel_cleanup(TlsContext *tls_ctx);
 
-static INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, CHAR **out);
+static INT request(TlsContext *tls_ctx, INT iport, LPWSTR host, CHAR *req, DWORD req_len, CHAR **out);
 
-static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, CHAR **out, int *length);
+static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD req_len, CHAR **out, int *length);
 
 static INT connect_to_server(TlsContext *tls_ctx, LPWSTR host, INT port_number);
 

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -370,7 +370,7 @@ fn C.closesocket(int) int
 
 fn C.vschannel_init(&C.TlsContext)
 
-fn C.request(&C.TlsContext, int, &u16, &u8, &&u8) int
+fn C.request(&C.TlsContext, int, &u16, &u8, u32, &&u8) int
 
 fn C.vschannel_cleanup(&C.TlsContext)
 

--- a/vlib/net/http/backend_windows.c.v
+++ b/vlib/net/http/backend_windows.c.v
@@ -22,7 +22,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 	$if trace_http_request ? {
 		eprintln('> ${sdata}')
 	}
-	length := C.request(&ctx, port, addr.to_wide(), sdata.str, &buff)
+	length := C.request(&ctx, port, addr.to_wide(), sdata.str, sdata.len, &buff)
 	C.vschannel_cleanup(&ctx)
 	response_text := unsafe { buff.vstring_with_len(length) }
 	if req.on_progress != unsafe { nil } {


### PR DESCRIPTION
net.http:fix post error with https on windows

the post data is treated as a string,so data will be truncated when post binary data that contains \0
