### PR TITLE
checker: disallow alias ptr cast on map

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3177,6 +3177,10 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.error('casting a function value from one function signature, to another function signature, should be done inside `unsafe{}` blocks',
 			node.pos)
 	}
+	if to_type.is_ptr() && to_sym.kind == .alias && from_sym.kind == .map {
+		c.error('cannot cast to alias pointer `${c.table.type_to_str(to_type)}` because `${c.table.type_to_str(from_type)}` is a value',
+			node.pos)
+	}
 
 	if to_type == ast.string_type {
 		if from_type in [ast.u8_type, ast.bool_type] {
@@ -3281,7 +3285,6 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 				}
 			}
 		}
-		// don't allow casting `string` to `enum`, and suggest using `enum_name.type_to_string(str)` instead
 		if mut node.expr is ast.StringLiteral {
 			c.add_error_detail('use ${c.table.type_to_str(node.typ)}.from_string(\'${node.expr.val}\') instead')
 			c.error('cannot cast `string` to `enum`', node.pos)

--- a/vlib/v/checker/tests/invalid_alias_ptr_cast_on_map_err.out
+++ b/vlib/v/checker/tests/invalid_alias_ptr_cast_on_map_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/invalid_alias_ptr_cast_on_map_err.vv:4:7: error: cannot cast to alias pointer `&FooMap` because `map[string]int` is a value
+    2 | 
+    3 | fn main() {
+    4 |     _ := &FooMap(map[string]int{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/invalid_alias_ptr_cast_on_map_err.vv
+++ b/vlib/v/checker/tests/invalid_alias_ptr_cast_on_map_err.vv
@@ -1,0 +1,5 @@
+type FooMap = map[string]int
+
+fn main() {
+	_ := &FooMap(map[string]int{})
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19194

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3922441</samp>

This pull request enhances the V compiler's error checking for casting expressions involving maps and alias pointers. It adds a new check and a new test case (`invalid_alias_ptr_cast_on_map_err`) with corresponding source and output files.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3922441</samp>

* Add a new error check for invalid alias pointer casts on map values ([link](https://github.com/vlang/v/pull/19336/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R3180-R3183))
* Remove an outdated comment about string to enum casts ([link](https://github.com/vlang/v/pull/19336/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L3284))
* Add a new test case for the error check ([link](https://github.com/vlang/v/pull/19336/files?diff=unified&w=0#diff-f5b7f44f1ea668ea79259831d94d800c880fbffbaf535aab7efde9c8654ad29eR1-R6), [link](https://github.com/vlang/v/pull/19336/files?diff=unified&w=0#diff-c136bbd36bcc4c32a8382e28b564fe4b2bfcbfd52f48aecf189d88c8f04d4353R1-R5))
