### PR TITLE
orm: support different foreign key types

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -210,17 +210,11 @@ pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKin
 					// Allow the database to insert an automatically generated primary key
 					// under the hood if it is not passed by the user.
 					tidx := data.data[i].type_idx()
-					if is_primary_column
-						&& (tidx in orm.nums || tidx in orm.num64 || tidx == orm.type_string) {
+					if is_primary_column && (tidx in orm.nums || tidx in orm.num64) {
 						x := data.data[i]
 						match x {
 							i8, i16, int, i64, u8, u16, u32, u64 {
 								if i64(x) == 0 {
-									continue
-								}
-							}
-							string {
-								if x.str() == '' {
 									continue
 								}
 							}

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -98,7 +98,7 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 				scope: c.fn_scope
 				obj: ast.Var{}
 				mod: 'main'
-				name: pkey_field.name
+				name: 'id'
 				is_mut: false
 				kind: .unresolved
 				info: ast.IdentVar{}
@@ -111,13 +111,24 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 				is_mut: false
 				scope: c.fn_scope
 				info: ast.IdentVar{
-					typ: pkey_field.typ
+					typ: ast.int_type
 				}
 			}
-			left_type: pkey_field.typ
-			right_type: pkey_field.typ
+			left_type: ast.int_type
+			right_type: ast.int_type
 			auto_locked: ''
 			or_block: ast.OrExpr{}
+		}
+
+		if c.table.sym(field.typ).kind == .array {
+			mut where_expr := subquery_expr.where_expr as ast.InfixExpr
+			mut left := where_expr.left as ast.Ident
+			mut right := where_expr.right as ast.Ident
+
+			left.name = pkey_field.name
+			right.info.typ = pkey_field.typ
+			where_expr.left_type = pkey_field.typ
+			where_expr.right_type = pkey_field.typ
 		}
 
 		sub_structs[int(typ)] = subquery_expr

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -121,14 +121,24 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 		}
 
 		if c.table.sym(field.typ).kind == .array {
-			mut where_expr := subquery_expr.where_expr as ast.InfixExpr
-			mut left := where_expr.left as ast.Ident
-			mut right := where_expr.right as ast.Ident
+			mut where_expr := subquery_expr.where_expr
+			if mut where_expr is ast.InfixExpr {
+				where_expr.left_type = pkey_field.typ
+				where_expr.right_type = pkey_field.typ
 
-			left.name = pkey_field.name
-			right.info.typ = pkey_field.typ
-			where_expr.left_type = pkey_field.typ
-			where_expr.right_type = pkey_field.typ
+				mut left := where_expr.left
+				if mut left is ast.Ident {
+					left.name = pkey_field.name
+				}
+
+				mut right := where_expr.right
+				if mut right is ast.Ident {
+					mut right_info := right.info
+					if mut right_info is ast.IdentVar {
+						right_info.typ = pkey_field.typ
+					}
+				}
+			}
 		}
 
 		sub_structs[int(typ)] = subquery_expr

--- a/vlib/v/checker/tests/orm_fkey_has_pkey.out
+++ b/vlib/v/checker/tests/orm_fkey_has_pkey.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_fkey_has_pkey.vv:5:2: error: V ORM: a struct that has a field that holds an array must have a primary key
+    3 | struct Person {
+    4 |     id    int
+    5 |     child []Child [fkey: 'person_id']
+      |     ~~~~~~~~~~~~~
+    6 | }
+    7 |

--- a/vlib/v/checker/tests/orm_fkey_has_pkey.vv
+++ b/vlib/v/checker/tests/orm_fkey_has_pkey.vv
@@ -1,0 +1,18 @@
+import db.sqlite
+
+struct Person {
+	id    int
+	child []Child [fkey: 'person_id']
+}
+
+struct Child {
+	id        int [primary; sql: serial]
+	person_id int
+}
+
+fn main() {
+	db := sqlite.connect(':memory:')!
+	_ := sql db {
+		select from Person
+	}!
+}

--- a/vlib/v/checker/tests/orm_multiple_pkeys.out
+++ b/vlib/v/checker/tests/orm_multiple_pkeys.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_multiple_pkeys.vv:5:2: error: V ORM: a struct can only have one primary key
+    3 | struct Person {
+    4 |     id   int    [primary]
+    5 |     name string [primary]
+      |     ~~~~~~~~~~~
+    6 | }
+    7 |

--- a/vlib/v/checker/tests/orm_multiple_pkeys.vv
+++ b/vlib/v/checker/tests/orm_multiple_pkeys.vv
@@ -1,0 +1,13 @@
+import db.sqlite
+
+struct Person {
+	id   int    [primary]
+	name string [primary]
+}
+
+fn main() {
+	db := sqlite.connect(':memory:')!
+	_ := sql db {
+		select from Person
+	}!
+}

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -302,7 +302,15 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	}
 
 	fields := node.fields.filter(g.table.sym(it.typ).kind != .array)
-	primary_field_name := g.get_orm_struct_primary_field_name(fields) or { '' }
+	primary_field := g.get_orm_struct_primary_field(fields) or { ast.StructField{} }
+
+	mut is_serial := false
+	for attr in primary_field.attrs {
+		if attr.kind == .plain && attr.name == 'sql' && attr.arg.to_lower() == 'serial' {
+			is_serial = true
+		}
+	}
+	is_serial = is_serial && primary_field.typ == ast.int_type
 
 	for sub in subs {
 		g.sql_stmt_line(sub, connection_var_name, or_expr)
@@ -350,7 +358,9 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 		g.write('_MOV((orm__Primitive[${fields.len}]){ ')
 		mut structs := 0
 		for field in fields {
-			if field.name == fkey {
+			// use last_insert_id if parent struct has `id int [primary; sql: serial]`
+			// else get the foreign key from the fetched rows
+			if field.name == fkey && pid != '' {
 				g.write('${pid}, ')
 				continue
 			}
@@ -374,7 +384,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	g.indent--
 	g.writeln('),')
 	g.writeln('.types = __new_array_with_default_noscan(0, 0, sizeof(int), 0),')
-	g.writeln('.primary_column_name = _SLIT("${primary_field_name}"),')
+	g.writeln('.primary_column_name = _SLIT("${primary_field.name}"),')
 	g.writeln('.kinds = __new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
 	g.writeln('.is_and = __new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
 	g.indent--
@@ -383,8 +393,13 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	g.writeln(');')
 
 	if arrs.len > 0 {
-		mut id_name := g.new_tmp_var()
-		g.writeln('orm__Primitive ${id_name} = orm__int_to_primitive(orm__Connection_name_table[${connection_var_name}._typ]._method_last_id(${connection_var_name}._object));')
+		mut id_name := ''
+		// only use last_insert_id if current struct has `id int [primary; sql: serial]`
+		if is_serial {
+			id_name = g.new_tmp_var()
+			g.writeln('orm__Primitive ${id_name} = orm__int_to_primitive(orm__Connection_name_table[${connection_var_name}._typ]._method_last_id(${connection_var_name}._object));')
+		}
+
 		for i, mut arr in arrs {
 			c_field_name := c_name(field_names[i])
 			idx := g.new_tmp_var()
@@ -656,7 +671,10 @@ fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut pare
 		}
 		ast.Ident {
 			if g.sql_side == .left {
-				fields << g.get_orm_column_name_from_struct_field(g.get_orm_current_table_field(expr.name))
+				field := g.get_orm_current_table_field(expr.name) or {
+					verror('field "${expr.name}" does not exist on "${g.sql_table_name}"')
+				}
+				fields << g.get_orm_column_name_from_struct_field(field)
 			} else {
 				data << expr
 			}
@@ -686,7 +704,7 @@ fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut pare
 // write_orm_select writes C code that calls ORM functions for selecting rows.
 fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, left_expr_string string, or_expr ast.OrExpr) {
 	mut fields := []ast.StructField{}
-	mut primary_field_name := g.get_orm_struct_primary_field_name(node.fields) or { '' }
+	mut primary_field := g.get_orm_struct_primary_field(node.fields) or { ast.StructField{} }
 
 	for field in node.fields {
 		mut skip := false
@@ -732,8 +750,8 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, le
 	g.writeln('.has_limit = ${node.has_limit},')
 	g.writeln('.has_offset = ${node.has_offset},')
 
-	if primary_field_name != '' {
-		g.writeln('.primary = _SLIT("${primary_field_name}"),')
+	if primary_field.name != '' {
+		g.writeln('.primary = _SLIT("${primary_field.name}"),')
 	}
 
 	select_fields := fields.filter(g.table.sym(it.typ).kind != .array)
@@ -927,11 +945,11 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, le
 				where_expr.left = left_where_expr
 				where_expr.right = ast.SelectorExpr{
 					pos: right_where_expr.pos
-					field_name: primary_field_name
+					field_name: primary_field.name
 					is_mut: false
 					expr: right_where_expr
 					expr_type: (right_where_expr.info as ast.IdentVar).typ
-					typ: ast.int_type
+					typ: (right_where_expr.info as ast.IdentVar).typ
 					scope: 0
 				}
 				mut sql_expr_select_array := ast.SqlExpr{
@@ -1040,7 +1058,7 @@ fn (g &Gen) get_table_name_by_struct_type(typ ast.Type) string {
 }
 
 // get_orm_current_table_field returns the current processing table's struct field by name.
-fn (g &Gen) get_orm_current_table_field(name string) ast.StructField {
+fn (g &Gen) get_orm_current_table_field(name string) ?ast.StructField {
 	info := g.table.sym(g.table.type_idxs[g.sql_table_name]).struct_info()
 
 	for field in info.fields {
@@ -1049,7 +1067,7 @@ fn (g &Gen) get_orm_current_table_field(name string) ast.StructField {
 		}
 	}
 
-	return ast.StructField{}
+	return none
 }
 
 // get_orm_column_name_from_struct_field converts the struct field to a table column name.
@@ -1071,12 +1089,12 @@ fn (g &Gen) get_orm_column_name_from_struct_field(field ast.StructField) string 
 	return name
 }
 
-// get_orm_struct_primary_field_name returns the table's primary column name.
-fn (_ &Gen) get_orm_struct_primary_field_name(fields []ast.StructField) ?string {
+// get_orm_struct_primary_field returns the table's primary column field.
+fn (_ &Gen) get_orm_struct_primary_field(fields []ast.StructField) ?ast.StructField {
 	for field in fields {
 		for attr in field.attrs {
 			if attr.name == 'primary' {
-				return field.name
+				return field
 			}
 		}
 	}

--- a/vlib/v/tests/orm_sub_array_struct_test.v
+++ b/vlib/v/tests/orm_sub_array_struct_test.v
@@ -13,6 +13,18 @@ mut:
 	name      string
 }
 
+struct ParentString {
+	name     string        [primary]
+	children []ChildString [fkey: 'parent_name']
+}
+
+struct ChildString {
+mut:
+	id          int    [primary; sql: serial]
+	parent_name string
+	name        string
+}
+
 fn test_orm_array() {
 	mut db := sqlite.connect(':memory:') or { panic(err) }
 	sql db {
@@ -44,6 +56,45 @@ fn test_orm_array() {
 
 	sql db {
 		drop table Parent
+	}!
+
+	parent := parents.first()
+	assert parent.name == new_parent.name
+	assert parent.children.len == new_parent.children.len
+	assert parent.children[0].name == 'abc'
+	assert parent.children[1].name == 'def'
+}
+
+fn test_orm_array_different_pkey_type() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	sql db {
+		create table ParentString
+		create table ChildString
+	}!
+
+	new_parent := ParentString{
+		name: 'test'
+		children: [
+			ChildString{
+				name: 'abc'
+			},
+			ChildString{
+				name: 'def'
+			},
+		]
+	}
+
+	sql db {
+		insert new_parent into ParentString
+	}!
+
+	parents := sql db {
+		select from ParentString where name == 'test'
+	}!
+
+	sql db {
+		drop table ParentString
+		drop table ChildString
 	}!
 
 	parent := parents.first()
@@ -115,6 +166,73 @@ fn test_orm_relationship() {
 
 	children = sql db {
 		select from Child
+	}!
+
+	assert children.len == 2
+}
+
+fn test_orm_relationship_different_pkey_type() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	sql db {
+		create table ParentString
+		create table ChildString
+	}!
+
+	mut child := ChildString{
+		name: 'abc'
+	}
+
+	new_parent := ParentString{
+		name: 'test'
+		children: []
+	}
+	sql db {
+		insert new_parent into ParentString
+	}!
+
+	mut parents := sql db {
+		select from ParentString where name == 'test'
+	}!
+
+	mut parent := parents.first()
+	child.parent_name = parent.name
+	child.name = 'atum'
+
+	sql db {
+		insert child into ChildString
+	}!
+
+	child.name = 'bacon'
+
+	sql db {
+		insert child into ChildString
+	}!
+
+	assert parent.name == new_parent.name
+	assert parent.children.len == 0
+
+	parents = sql db {
+		select from ParentString where name == 'test'
+	}!
+
+	parent = parents.first()
+	assert parent.name == new_parent.name
+	assert parent.children.len == 2
+	assert parent.children[0].name == 'atum'
+	assert parent.children[1].name == 'bacon'
+
+	mut children := sql db {
+		select from ChildString
+	}!
+
+	assert children.len == 2
+
+	sql db {
+		drop table ParentString
+	}!
+
+	children = sql db {
+		select from ChildString
 	}!
 
 	assert children.len == 2


### PR DESCRIPTION
Fix #18844

This pr adds the ability to have other V types as foreign keys, intead of only ints and improves checker errors.

For example it is now possible to have a primary field of type `string`:
```v
[table: 'stations']
struct Station {
	id           string        [primary]
	name         string
	observations []Observation [fkey: 'station_id']
}

[table: 'observations']
struct Observation {
	ts              time.Time [sql_type: 'DATETIME']
	station_id      string    [sql: 'stationid']
	air_temperature f64       [sql: 'airTemperature']
}
```

At this moment it is hardcoded in the orm code that a sub struct must have a field `id` of type `int` which is used to join the two tables. This pr removes this restriction for arrays and joins the two tables on the primary key, so for the previous example it would evaluate to something like this:
```
SELECT FROM observations WHERE station_id == [value of Station.id]
```

Consequently, when a struct with struct arrays is inserted the last insert id is only fetched if the parent struct has a sql serial field: `int [primary; sql: serial]`, else the value of the primary field from the parent struct is passed to the array values.


**Example to clarify:**
```v
module main

import db.sqlite
import time

[table: 'stations']
struct Station {
	id           string        [primary]
	name         string
	observations []Observation [fkey: 'station_id']
}

[table: 'observations']
struct Observation {
	ts              time.Time [sql_type: 'DATETIME']
	station_id      string    [sql: 'stationid']
	air_temperature f64       [sql: 'airTemperature']
}

fn main() {
	db := sqlite.connect(':memory:')!
	sql db {
		create table Observation
		create table Station
	}!
	s := Station{
		id: 'AMS'
		name: 'amsterdam'
		observations: [
			Observation{
				ts: time.now()
				air_temperature: 20.5
			},
			Observation{
				ts: time.now()
				air_temperature: 23.2
			},
		]
	}
	sql db {
		insert s into Station
	}!
	result := sql db {
		select from Station
	}!
	println('Result: ${result}')
}
```
```
Result: [Station{
    id: 'AMS'
    name: 'amsterdam'
    observations: [Observation{
        ts: 2023-09-12 22:59:51
        station_id: 'AMS'
        air_temperature: 20.5
    }, Observation{
        ts: 2023-09-12 22:59:51
        station_id: 'AMS'
        air_temperature: 23.2
    }]
}]
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80499d2</samp>

This pull request enhances the ORM module to support custom primary keys of different types and names for structs, and fixes some bugs and errors related to foreign keys and array fields. It also adds new tests and checks for the ORM features and queries in the `vlib/v/tests` and `vlib/v/checker/tests` directories.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80499d2</samp>

*  Add support for different types and names of primary keys in ORM ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R456), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837L469-R470), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R482), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R12), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L50-R72), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R123-R133), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L377-R394), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L387-R416), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L689-R721), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L735-R768), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L927-R966), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L1070-R1111), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-fe9275ad5d03e00ff8db91b8ec953591711dc2f3e98df03aaa4ca3ce80bc2be8R16-R27), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-fe9275ad5d03e00ff8db91b8ec953591711dc2f3e98df03aaa4ca3ce80bc2be8R68-R106), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-fe9275ad5d03e00ff8db91b8ec953591711dc2f3e98df03aaa4ca3ce80bc2be8R173-R239))
  * Declare and use a new variable `primary_typ` in `orm.v` to store the type of the primary key field of a struct ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R456), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837L469-R470))
  * Assign the type of the current field to `primary_typ` if the field has the `primary` attribute in `orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R482))
  * Add a new constant `pkey_attr_name` in `orm.v` to store the name of the `primary` attribute for struct fields ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R12))
  * Declare and use two new variables `has_pkey_attr` and `pkey_field` in `orm.v` to track whether the struct has a primary key field and what that field is ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L50-R72), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R123-R133))
  * Use the `pkey_field` instead of a hardcoded `id` field in the `where_expr` of the subquery for array fields in `orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R123-R133))
  * Use the `primary_field` variable instead of the `primary_field_name` variable to access the name, type, and attributes of the primary key field in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L377-R394), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L735-R768), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L927-R966))
  * Add a new variable `is_serial` in `c/orm.v` to store whether the primary key field has the `sql: serial` attribute, which means that the SQL table will generate the primary key value automatically ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L387-R416))
  * Modify the logic for getting the primary key value for array fields depending on the value of `is_serial` in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L689-R721))
  * Modify the name and return type of the `get_orm_struct_primary_field_name` function to `get_orm_struct_primary_field` and `?ast.StructField`, respectively, in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L1070-R1111))
  * Add two new structs `ParentString` and `ChildString` to the test file `orm_sub_array_struct_test.v` to test the case where the primary key field is a `string` instead of an `int`, and the foreign key field has a different name than the primary key field ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-fe9275ad5d03e00ff8db91b8ec953591711dc2f3e98df03aaa4ca3ce80bc2be8R16-R27))
  * Add two new test functions `test_orm_array_different_pkey_type` and `test_orm_relationship_different_pkey_type` to the test file `orm_sub_array_struct_test.v` to test the insert and select queries and the relationship between the structs `ParentString` and `ChildString` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-fe9275ad5d03e00ff8db91b8ec953591711dc2f3e98df03aaa4ca3ce80bc2be8R68-R106), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-fe9275ad5d03e00ff8db91b8ec953591711dc2f3e98df03aaa4ca3ce80bc2be8R173-R239))
* Add error checks for missing or multiple primary keys in ORM ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L50-R72), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L659-R691), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L1039-R1075), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L1048-R1084), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-99a74167fc1d6ac6cf57ac7f891ef708290045ae205f05bf861b3330f0492897R1-R7), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-68de6a135f773895c26977d56db515225c46ee1a67910e07e61a035bfd98497fR1-R18), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-122361e3062352d0a3000b11940e600c9c7bac64c79c24b7bd1d3b5cbf35909bR1-R7), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-7bc039313ad9d82ddee7865d936cdd5f367b995031845abeb91eb191d45e646dR1-R13))
  * Add a check for the existence of the struct field with the given name in the current table, and return an error if not found, in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L659-R691))
  * Modify the return type of the `get_orm_current_table_field` function to be an optional `ast.StructField` instead of a default `ast.StructField`, and use the `none` keyword instead of an empty struct field, to indicate the absence of a value, in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L1039-R1075), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L1048-R1084))
  * Add a check for the existence and uniqueness of the primary key field in the struct, and return an error if not found or multiple, in `orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L50-R72))
  * Add two new test files `orm_fkey_has_pkey.out` and `orm_fkey_has_pkey.vv` to check the error message when a struct has an array field with a foreign key but no primary key ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-99a74167fc1d6ac6cf57ac7f891ef708290045ae205f05bf861b3330f0492897R1-R7), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-68de6a135f773895c26977d56db515225c46ee1a67910e07e61a035bfd98497fR1-R18))
  * Add two new test files `orm_multiple_pkeys.out` and `orm_multiple_pkeys.vv` to check the error message when a struct has more than one primary key field ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-122361e3062352d0a3000b11940e600c9c7bac64c79c24b7bd1d3b5cbf35909bR1-R7), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-7bc039313ad9d82ddee7865d936cdd5f367b995031845abeb91eb191d45e646dR1-R13))
* Improve the code readability and consistency for accessing struct fields in ORM ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L304-R338), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L334-L345), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R934), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R994))
  * Declare and use a new variable `member_access_type` in `c/orm.v` to store the operator for accessing struct fields, either `.` or `->` depending on whether the struct is a pointer or not ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L304-R338), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L334-L345), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L689-R721))
  * Move the declaration and initialization of the `member_access_type` variable to a later point, after the `arrs` variable is declared, in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L334-L345))
  * Declare and use a new variable `selected_fields_idx` in `c/orm.v` to store the index of the selected fields in the SQL query result, and increment it after each non-array and array field is processed, in `c/orm.v` ([link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L879-R914), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R934), [link](https://github.com/vlang/v/pull/19337/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R994))
