### PR TITLE
toml: fix custom `to_toml` for complex structs

### DIFF
--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -121,20 +121,32 @@ title = 2'
 	assert y.title == .worker
 }
 
-struct Example {
-	array []Problem
+struct Example1 {
+	arr []Problem
+}
+
+struct Example2 {
+	arr []Problem
 }
 
 struct Problem {
+	x int
 }
 
-pub fn (example Example) to_toml() string {
+pub fn (example Example1) to_toml() string {
 	return '[This is Valid]'
 }
 
+pub fn (problem Problem) to_toml() string {
+	return 'a problem'
+}
+
 fn test_custom_encode_of_complex_struct() {
-	example := Example{}
-	assert toml.encode(example) == '[This is Valid]'
+	assert toml.encode(Example1{}) == '[This is Valid]'
+	assert toml.encode(Example2{[Problem{}, Problem{}]}) == 'arr = [
+  "a problem",
+  "a problem"
+]'
 }
 
 fn test_array_encode_decode() {

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -121,6 +121,22 @@ title = 2'
 	assert y.title == .worker
 }
 
+struct Example {
+	array []Problem
+}
+
+struct Problem {
+}
+
+pub fn (example Example) to_toml() string {
+	return '[This is Valid]'
+}
+
+fn test_custom_encode_of_complex_struct() {
+	example := Example{}
+	assert toml.encode(example) == '[This is Valid]'
+}
+
 fn test_array_encode_decode() {
 	a := Arrs{
 		strs: ['foo', 'bar']

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -108,7 +108,7 @@ fn encode_struct[T](typ T) map[string]Any {
 				} $else $if v is DateTime {
 					arr << Any(v)
 				} $else $if v is $struct {
-					arr << Any(encode_struct(v))
+					arr << Any(encode(v))
 				} $else {
 					arr << Any(v)
 				}

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -101,7 +101,19 @@ fn encode_struct[T](typ T) map[string]Any {
 		} $else $if field.is_array {
 			mut arr := []Any{}
 			for v in value {
-				arr << Any(v)
+				$if v is $struct {
+					$if v is Date {
+						arr << Any(v)
+					} $else $if v is Time {
+						arr << Any(v)
+					} $else $if v is DateTime {
+						arr << Any(v)
+					} $else {
+						arr << Any(encode_struct(v))
+					}
+				} $else {
+					arr << Any(v)
+				}
 			}
 			mp[field.name] = arr
 		} $else {

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -101,16 +101,14 @@ fn encode_struct[T](typ T) map[string]Any {
 		} $else $if field.is_array {
 			mut arr := []Any{}
 			for v in value {
-				$if v is $struct {
-					$if v is Date {
-						arr << Any(v)
-					} $else $if v is Time {
-						arr << Any(v)
-					} $else $if v is DateTime {
-						arr << Any(v)
-					} $else {
-						arr << Any(encode_struct(v))
-					}
+				$if v is Date {
+					arr << Any(v)
+				} $else $if v is Time {
+					arr << Any(v)
+				} $else $if v is DateTime {
+					arr << Any(v)
+				} $else $if v is $struct {
+					arr << Any(encode_struct(v))
 				} $else {
 					arr << Any(v)
 				}


### PR DESCRIPTION
Quickfix for #19300 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83c267e</samp>

This pull request enhances the `toml` module to support custom encoding of complex structs using the `to_toml` method. It also fixes the encoding of nested structs in arrays, and adds a test case for the new functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83c267e</samp>

*  Add support for custom encoding of complex structs using the `to_toml` method ([link](https://github.com/vlang/v/pull/19338/files?diff=unified&w=0#diff-e21671b503fde62549e7f85e6544ac5ea616eb6dd5eec935b44cd85edda451b9R124-R139), [link](https://github.com/vlang/v/pull/19338/files?diff=unified&w=0#diff-b8f13704e3af95d0fd433384853091d3fc14632a773fd45d2303b3f7d806cee9L104-R116))
  - Implement the `to_toml` method for the `Example` struct in `vlib/toml/tests/encode_and_decode_test.v` and assert that it matches the output of `toml.encode` ([link](https://github.com/vlang/v/pull/19338/files?diff=unified&w=0#diff-e21671b503fde62549e7f85e6544ac5ea616eb6dd5eec935b44cd85edda451b9R124-R139))
  - Modify the `encode_struct` function in `vlib/toml/toml.v` to check for nested structs in arrays and use the `to_toml` method if available, or the `encode_struct` function otherwise ([link](https://github.com/vlang/v/pull/19338/files?diff=unified&w=0#diff-b8f13704e3af95d0fd433384853091d3fc14632a773fd45d2303b3f7d806cee9L104-R116))
  - Handle the special cases of `Date`, `Time`, and `DateTime` structs, which are already encoded by the `toml` module ([link](https://github.com/vlang/v/pull/19338/files?diff=unified&w=0#diff-b8f13704e3af95d0fd433384853091d3fc14632a773fd45d2303b3f7d806cee9L104-R116))
