### PR TITLE
checker: fix printing interface variable in smartcast (fix #18886)

### DIFF
--- a/vlib/context/empty_test.v
+++ b/vlib/context/empty_test.v
@@ -2,7 +2,7 @@ module context
 
 fn test_background() {
 	ctx := background()
-	assert '&context.Background' == ctx.str()
+	assert 'context.Background' == ctx.str()
 	if _ := ctx.value('') {
 		panic('This should never happen')
 	}
@@ -10,7 +10,7 @@ fn test_background() {
 
 fn test_todo() {
 	ctx := todo()
-	assert '&context.TODO' == ctx.str()
+	assert 'context.TODO' == ctx.str()
 	if _ := ctx.value('') {
 		panic('This should never happen')
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1441,7 +1441,10 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	if node.expr.is_auto_deref_var() {
 		if mut node.expr is ast.Ident {
 			if mut node.expr.obj is ast.Var {
-				typ = node.expr.obj.typ
+				if node.expr.obj.orig_type == 0 || (node.expr.obj.orig_type != 0
+					&& c.table.sym(node.expr.obj.orig_type).kind != .interface_) {
+					typ = node.expr.obj.typ
+				}
 			}
 		}
 	}
@@ -3798,6 +3801,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 					is_used: true
 					is_mut: expr.is_mut
 					is_inherited: is_inherited
+					is_auto_deref: sym.kind == .interface_
 					smartcasts: smartcasts
 					orig_type: orig_type
 				})

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1441,8 +1441,8 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	if node.expr.is_auto_deref_var() {
 		if mut node.expr is ast.Ident {
 			if mut node.expr.obj is ast.Var {
-				if node.expr.obj.orig_type == 0 || (node.expr.obj.orig_type != 0
-					&& c.table.sym(node.expr.obj.orig_type).kind != .interface_) {
+				if node.expr.obj.orig_type == 0
+					|| c.table.sym(node.expr.obj.orig_type).kind != .interface_ {
 					typ = node.expr.obj.typ
 				}
 			}
@@ -3801,7 +3801,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 					is_used: true
 					is_mut: expr.is_mut
 					is_inherited: is_inherited
-					is_auto_deref: sym.kind == .interface_
+					is_auto_deref: sym.kind == .interface_ && to_type.is_ptr()
 					smartcasts: smartcasts
 					orig_type: orig_type
 				})

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -729,7 +729,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						if op_overloaded {
 							g.op_arg(val, op_expected_right, val_type)
 						} else {
-							exp_type := if left.is_auto_deref_var() || var_type.has_flag(.shared_f) {
+							exp_type := if
+								(left.is_auto_deref_var() || var_type.has_flag(.shared_f))
+								&& var_type.is_ptr() {
 								var_type.deref()
 							} else {
 								var_type

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5019,7 +5019,14 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			}
 			g.write('.arg${arg_idx}=')
 			if expr.is_auto_deref_var() {
-				g.write('*')
+				if expr is ast.Ident {
+					if expr.obj is ast.Var {
+						if expr.obj.orig_type == 0
+							|| g.table.sym(expr.obj.orig_type).kind != .interface_ {
+							g.write('*')
+						}
+					}
+				}
 			}
 			if g.table.sym(mr_info.types[i]).kind in [.sum_type, .interface_] {
 				g.expr_with_cast(expr, node.types[i], mr_info.types[i])

--- a/vlib/v/tests/empty_interface_test.v
+++ b/vlib/v/tests/empty_interface_test.v
@@ -10,5 +10,5 @@ fn print_out(x Any) string {
 
 fn test_empty_interface() {
 	ret := print_out('12345')
-	assert ret == '&12345'
+	assert ret == '12345'
 }

--- a/vlib/v/tests/print_interface_variable_in_smartcast_test.v
+++ b/vlib/v/tests/print_interface_variable_in_smartcast_test.v
@@ -1,0 +1,25 @@
+interface Any {}
+
+fn do(v Any) string {
+	match v {
+		int {
+			println('> integer answer: ${2 * v}')
+			return '${2 * v}'
+		}
+		string {
+			println('> string answer: ${v}, len: ${v.len}')
+			return '${v}'
+		}
+		else {
+			return ''
+		}
+	}
+}
+
+fn test_printing_interface_variable_in_smartcast() {
+	s1 := do(123)
+	assert s1 == '246'
+
+	s2 := do('abc')
+	assert s2 == 'abc'
+}


### PR DESCRIPTION
This PR fix printing interface variable in smartcast (fix #18886).

- Fix printing interface variable in smartcast.
- Add test.

```v
interface Any {}

fn do(v Any) string {
	match v {
		int {
			println('> integer answer: ${2 * v}')
			return '${2 * v}'
		}
		string {
			println('> string answer: ${v}, len: ${v.len}')
			return '${v}'
		}
		else {
			return ''
		}
	}
}

fn main() {
	s1 := do(123)
	assert s1 == '246'

	s2 := do('abc')
	assert s2 == 'abc'
}

PS D:\Test\v\tt1> v run .    
> integer answer: 246
> string answer: abc, len: 3
```