### PR TITLE
ast, fmt: fix formatting type decl with anon struct 2 (related #19356)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1507,7 +1507,7 @@ pub fn (mut f Fmt) alias_type_decl(node ast.AliasTypeDecl) {
 	if sym.info is ast.Struct {
 		if sym.info.is_anon {
 			f.write('type ${node.name} = ')
-			f.write_anon_struct_field_decl(node.parent_type, ast.StructDecl{ fields: sym.info.fields })
+			f.struct_decl(ast.StructDecl{ fields: sym.info.fields }, true)
 			f.comments(node.comments, has_nl: false)
 			f.mark_types_import_as_used(node.parent_type)
 			return

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1502,7 +1502,7 @@ pub fn (mut f Fmt) alias_type_decl(node ast.AliasTypeDecl) {
 	if node.is_pub {
 		f.write('pub ')
 	}
-	// aliases of anon struct: `type foo = struct {}`
+	// aliases of anon struct: `type Foo = struct {}`
 	sym := f.table.sym(node.parent_type)
 	if sym.info is ast.Struct {
 		if sym.info.is_anon {

--- a/vlib/v/fmt/tests/type_decl_with_anon_struct_keep.vv
+++ b/vlib/v/fmt/tests/type_decl_with_anon_struct_keep.vv
@@ -1,9 +1,9 @@
 pub type Unit1 = struct {}
 
 pub type Unit2 = struct {
-		name string
-		age  int
-	}
+	name string
+	age  int
+}
 
 pub const unit1 = Unit1{}
 


### PR DESCRIPTION
This PR fix formatting type decl with anon struct 2 (related #19356).

- Fix formatting type decl with anon struct 2.
- Change test.

vlib\v\fmt\tests\type_decl_with_anon_struct_keep.vv
```v
pub type Unit1 = struct {}

pub type Unit2 = struct {
	name string
	age  int
}

pub const unit1 = Unit1{}

pub const unit2 = Unit2{'bob', 22}

fn main() {
	println(unit1)
	println(unit2)
}
```