### PR TITLE
cgen: fix assign the spawn or go expr to the []thread(fix #19365)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3269,16 +3269,22 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			}
 		}
 		ast.SpawnExpr {
+			old_is_arraymap_set := g.is_arraymap_set
+			g.is_arraymap_set = false
 			g.spawn_and_go_expr(node, .spawn_)
+			g.is_arraymap_set = old_is_arraymap_set
 		}
 		ast.GoExpr {
 			// XTODO this results in a cgen bug, order of fields is broken
 			// g.spawn_and_go_expr(ast.SpawnExpr{node.pos, node.call_expr, node.is_expr},
+			old_is_arraymap_set := g.is_arraymap_set
+			g.is_arraymap_set = false
 			g.spawn_and_go_expr(ast.SpawnExpr{
 				pos: node.pos
 				call_expr: node.call_expr
 				is_expr: node.is_expr
 			}, .go_)
+			g.is_arraymap_set = old_is_arraymap_set
 		}
 		ast.Ident {
 			g.ident(node)

--- a/vlib/v/tests/thread_array_test.v
+++ b/vlib/v/tests/thread_array_test.v
@@ -1,0 +1,11 @@
+fn test_assign_spawn_to_element() {
+	mut threads := []thread{len: 1}
+
+	threads[0] = spawn fn () {
+		a := 1
+		dump(a)
+		assert true
+	}()
+
+	threads.wait()
+}


### PR DESCRIPTION
1. Fix #19365 
2. Add tests.

```v
fn main() {
	mut threads := []thread{len: 1}

	threads[0] = spawn fn () {
		a := 1
		dump(a)
		assert true
	}()

	threads.wait()
}
```

output:

```
[a.v:6] a: 1
```
