### PR TITLE
fmt: simplify formatting struct field comments

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -38,7 +38,6 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 		field_types << ft
 		attrs_len := inline_attrs_len(field.attrs)
 		end_pos := field.pos.pos + field.pos.len
-		mut comments_len := 0 // Length of comments between field name and type
 		for comment in field.comments {
 			if comment.pos.pos >= end_pos {
 				if comment.pos.line_nr == field.pos.line_nr {
@@ -48,11 +47,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 				}
 				continue
 			}
-			if comment.pos.pos > field.pos.pos {
-				comments_len += '/* ${comment.text.trim_left('\x01')} */ '.len
-			}
 		}
-		field_aligns.add_info(comments_len + field.name.len, ft.len, field.pos.line_nr)
+		field_aligns.add_info(field.name.len, ft.len, field.pos.line_nr)
 		if field.has_default_expr {
 			default_expr_aligns.add_info(attrs_len, field_types[i].len, field.pos.line_nr,
 				use_threshold: true


### PR DESCRIPTION
This PR simplify formatting struct field comments.

- Remove inline comments between field name and field type.