### PR TITLE
orm: add enums

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -139,6 +139,7 @@ const (
 		'vlib/db/sqlite/sqlite_test.v',
 		'vlib/db/sqlite/sqlite_orm_test.v',
 		'vlib/db/sqlite/sqlite_vfs_lowlevel_test.v',
+		'vlib/v/tests/orm_enum_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_joined_tables_select_test.v',
@@ -165,6 +166,7 @@ const (
 		'vlib/orm/orm_insert_reserved_name_test.v',
 		'vlib/orm/orm_references_test.v',
 		'vlib/v/tests/websocket_logger_interface_should_compile_test.v',
+		'vlib/v/tests/orm_enum_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
 	]
@@ -174,6 +176,7 @@ const (
 		'vlib/orm/orm_insert_test.v',
 		'vlib/orm/orm_insert_reserved_name_test.v',
 		'vlib/orm/orm_references_test.v',
+		'vlib/v/tests/orm_enum_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
 		'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v', // fails compilation with: undefined reference to vtable for __cxxabiv1::__function_type_info'
@@ -219,6 +222,7 @@ const (
 		'vlib/orm/orm_custom_operators_test.v',
 		'vlib/orm/orm_fk_test.v',
 		'vlib/orm/orm_references_test.v',
+		'vlib/v/tests/orm_enum_test.v',
 		'vlib/v/tests/orm_sub_struct_test.v',
 		'vlib/v/tests/orm_sub_array_struct_test.v',
 		'vlib/v/tests/orm_joined_tables_select_test.v',

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -139,6 +139,7 @@ pub:
 	is_time     bool
 	default_val string
 	is_arr      bool
+	is_enum     bool
 	attrs       []StructAttribute
 }
 
@@ -608,6 +609,8 @@ fn sql_field_type(field TableField) int {
 	mut typ := field.typ
 	if field.is_time {
 		return -2
+	} else if field.is_enum {
+		return typeof[i64]().idx
 	}
 	for attr in field.attrs {
 		if attr.kind == .plain && attr.name == 'sql' && attr.arg != '' {

--- a/vlib/v/tests/orm_enum_test.v
+++ b/vlib/v/tests/orm_enum_test.v
@@ -1,0 +1,45 @@
+import db.sqlite
+
+enum Number {
+	zero
+	one
+	two
+	four = 4
+	five
+}
+
+struct Counter {
+	id     int    [primary; sql: serial]
+	number Number
+}
+
+fn test_orm_enum() {
+	db := sqlite.connect(':memory:') or { panic(err) }
+	sql db {
+		create table Counter
+	}!
+
+	counter1 := Counter{
+		number: .two
+	}
+	sql db {
+		insert counter1 into Counter
+	}!
+
+	mut counters := sql db {
+		select from Counter
+	}!
+
+	assert counters.first().number == counter1.number
+
+	// test short enum syntax
+	sql db {
+		update Counter set number = .five where number == .two
+	}!
+
+	counters = sql db {
+		select from Counter
+	}!
+
+	assert counters.first().number == .five
+}


### PR DESCRIPTION
orm: add support for enum fields

This pr adds the ability to have enum field types in V's orm.  Enums can be any int type, that is why they are stored as `i64` in SQL.


**Example:**
```v
module main

import db.sqlite

enum Numbers {
	zero
	one
	two
	four = 4
	five
}

struct Counter {
	id     int     [primary; sql: serial]
	number Numbers 
}

fn main() {
	db := sqlite.connect(':memory:')!
	sql db {
		create table Counter
	}!

	c := Counter{
		number: .two
	}
	c2 := Counter{
		number: .five
	}
	
	sql db {
		insert c into Counter
		insert c2 into Counter
	}!

	mut rows := sql db {
		select from Counter
	}!
	println(rows)
}
```
```
[Counter{
    id: 1
    number: two
}, Counter{
    id: 2
    number: five
}]
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a238053</samp>

This pull request adds support for enum types in the ORM module. It modifies the `orm__Field` struct, the checker, the C code generator, and the runtime functions to handle enum values in the database. It also adds a new test file `vlib/v/tests/orm_enum_test.v` to verify the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a238053</samp>

*  Add support for enum fields in ORM operations ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R142), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L321-R327), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R393), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L397-R404), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R142), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R372-R374), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R465-R467), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R709-R711), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R788-R790), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R995-R998))
  * Add a new field `is_enum` to the `orm__Field` struct to indicate whether the field is an enum type ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R142), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R142))
  * Return the index of the `i64` type in the `orm__Field.typeof` method if the field is an enum type ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837R612-R613))
  * Check the validity of the update expression if it is an enum value and set the expected type to the field type in the `orm_update` method ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L321-R327))
  * Include enum fields in the ORM operations by setting and checking the `is_enum` variable in the `orm_select` method ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672R393), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-93527b637b060eae115caa95bec79b56c8c13188e92dfc876c36e59524e3e672L397-R404))
  * Convert enum values to `i64` values and write them to the insert and update statements in the `gen_orm_insert` and `write_orm_primitive` methods ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R372-R374), [link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R465-R467))
  * Collect and append enum values from the select statement in the `orm__get_data` function ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R709-R711))
  * Collect and append the index of the `i64` type for enum fields in the `orm__get_types` function ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R788-R790))
  * Cast `i64` values from the database to enum values and assign them to the object fields in the `gen_orm_select` method ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48R995-R998))
* Add a test case for the ORM enum feature in `vlib/v/tests/orm_enum_test.v` ([link](https://github.com/vlang/v/pull/19374/files?diff=unified&w=0#diff-28c2a285408e62f898ee3672d8a12d6b129dceeda9a805b3aae9215b5899a34fR1-R45))
