### PR TITLE
checker: disallow ptr assign to option struct field

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -566,6 +566,9 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 							init_field.pos)
 					}
 				}
+				if exp_type.has_flag(.option) && got_type.is_ptr() {
+					c.error('cannot assign a pointer to option struct field', init_field.pos)
+				}
 				if exp_type_sym.kind == .voidptr && got_type_sym.kind == .struct_
 					&& !got_type.is_ptr() {
 					c.error('allocate on the heap for use in other functions', init_field.pos)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -566,7 +566,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 							init_field.pos)
 					}
 				}
-				if exp_type.has_flag(.option) && got_type.is_ptr() {
+				if exp_type.has_flag(.option) && got_type.is_ptr() && !(exp_type.is_ptr()
+					&& exp_type_sym.kind == .struct_) {
 					c.error('cannot assign a pointer to option struct field', init_field.pos)
 				}
 				if exp_type_sym.kind == .voidptr && got_type_sym.kind == .struct_

--- a/vlib/v/checker/tests/struct_option_field_assign_ptr_err.out
+++ b/vlib/v/checker/tests/struct_option_field_assign_ptr_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/struct_option_field_assign_ptr_err.vv:10:3: error: cannot assign a pointer to option struct field
+    8 |     name := 'Bilbo'
+    9 |     a := Abc{
+   10 |         age: &age
+      |         ~~~~~~
+   11 |     }
+   12 |     b := Abc{
+vlib/v/checker/tests/struct_option_field_assign_ptr_err.vv:13:3: error: cannot assign a pointer to option struct field
+   11 |     }
+   12 |     b := Abc{
+   13 |         name: &name
+      |         ~~~~~~~
+   14 |     }
+   15 |     dump(a)

--- a/vlib/v/checker/tests/struct_option_field_assign_ptr_err.vv
+++ b/vlib/v/checker/tests/struct_option_field_assign_ptr_err.vv
@@ -1,0 +1,17 @@
+struct Abc {
+	name ?string
+	age  ?int
+}
+
+fn main() {
+	age := 34
+	name := 'Bilbo'
+	a := Abc{
+		age: &age
+	}
+	b := Abc{
+		name: &name
+	}
+	dump(a)
+	dump(b)
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19378

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf41bf3</samp>

Prevent assigning pointers to struct option fields in the checker module and add a test case for this error. This fixes a potential memory corruption bug and improves the type safety of the language.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf41bf3</samp>

*  Add a check to prevent assigning pointers to struct option fields and emit an error message ([link](https://github.com/vlang/v/pull/19380/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88R569-R571))
*  Add a test case file with two struct literals that try to assign pointers to option fields and the expected compiler output ([link](https://github.com/vlang/v/pull/19380/files?diff=unified&w=0#diff-5dbc23cf8d9c9fe53aa10f561f31474a72165264edeffc6082a28bfdcde99a39R1-R14), [link](https://github.com/vlang/v/pull/19380/files?diff=unified&w=0#diff-e6b45d8115472bfc7857f9a339eec2223e7b485fcbc78e886e496660c03e9f70R1-R17))
*  Add the source code of the test case file in V using the `dump` function ([link](https://github.com/vlang/v/pull/19380/files?diff=unified&w=0#diff-e6b45d8115472bfc7857f9a339eec2223e7b485fcbc78e886e496660c03e9f70R1-R17))
