### PR TITLE
cgen: fix channel of interface (fix #19382)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2252,7 +2252,8 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					if atype.has_flag(.generic) {
 						atype = g.unwrap_generic(atype)
 					}
-					if atype.has_flag(.generic) || arg.expr is ast.StructInit {
+					if atype.has_flag(.generic) || arg.expr is ast.StructInit
+						|| arg_typ_sym.kind in [.sum_type, .interface_] {
 						g.write('(voidptr)&/*qq*/')
 					} else {
 						needs_closing = true

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2252,11 +2252,13 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					if atype.has_flag(.generic) {
 						atype = g.unwrap_generic(atype)
 					}
-					if atype.has_flag(.generic) || arg.expr is ast.StructInit
-						|| arg_typ_sym.kind in [.sum_type, .interface_] {
+					if atype.has_flag(.generic) || arg.expr is ast.StructInit {
 						g.write('(voidptr)&/*qq*/')
 					} else {
 						needs_closing = true
+						if arg_typ_sym.kind in [.sum_type, .interface_] {
+							atype = arg_typ
+						}
 						g.write('ADDR(${g.typ(atype)}/*qq*/, ')
 					}
 				}

--- a/vlib/v/tests/chan_interface_test.v
+++ b/vlib/v/tests/chan_interface_test.v
@@ -1,0 +1,17 @@
+interface TestInterface {
+	a int
+}
+
+struct TestStruct {
+	a int
+}
+
+fn test_chan_interface() {
+	c := chan TestInterface{cap: 1}
+
+	c.try_push(TestInterface(TestStruct{ a: 1 }))
+
+	m := <-c
+	println(m)
+	assert m.a == 1
+}


### PR DESCRIPTION
This PR fix channel of interface (fix #19382).

- Fix channel of interface.
- Add test.

```v
interface TestInterface {
	a int
}

struct TestStruct {
	a int
}

fn main() {
	c := chan TestInterface{cap: 1}

	c.try_push(TestInterface(TestStruct{ a: 1 }))

	m := <-c
	println(m)
	assert m.a == 1
}

PS D:\Test\v\tt1> v run .    
TestInterface(TestStruct{
    a: 1
})
```