### PR TITLE
orm: quote table and field name in `[references]`

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -572,7 +572,7 @@ pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, 
 			unique_fields << f
 		}
 		if references_table != '' {
-			stmt += ' REFERENCES ${references_table} (${references_field})'
+			stmt += ' REFERENCES ${q}${references_table}${q}(${q}${references_field}${q})'
 		}
 		fs << stmt
 	}


### PR DESCRIPTION
Provides sql appropriate quotes around the table name and field name when utilizing `[references]`.
Should have been done initially