### PR TITLE
parser: fix fixed array of option values (fix #19385)

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -65,7 +65,8 @@ fn (mut p Parser) array_init(is_option bool) ast.ArrayInit {
 		last_pos = p.tok.pos()
 		p.check(.rsbr)
 		if exprs.len == 1 && p.tok.line_nr == line_nr
-			&& (p.tok.kind in [.name, .amp] || (p.tok.kind == .lsbr && p.is_array_type())) {
+			&& (p.tok.kind in [.name, .amp, .question, .key_shared]
+			|| (p.tok.kind == .lsbr && p.is_array_type())) {
 			// [100]u8
 			elem_type = p.parse_type()
 			if p.table.sym(elem_type).name == 'byte' {

--- a/vlib/v/tests/fixed_array_of_option_test.v
+++ b/vlib/v/tests/fixed_array_of_option_test.v
@@ -1,0 +1,7 @@
+fn test_fixed_array_of_option() {
+	mut a := [3]?int{init: ?int(1)}
+	a[0] = none
+	a[1] = 2
+	println(a)
+	assert '${a}' == '[Option(none), Option(2), Option(1)]'
+}


### PR DESCRIPTION
This PR fix fixed array of option values (fix #19385).

- Fix fixed array of option values.
- Add test.

```v
module main

fn main() {
	mut a := [3]?int{init: ?int(1)}
	a[0] = none
	a[1] = 2
	println(a)
	assert '${a}' == '[Option(none), Option(2), Option(1)]'
}

PS D:\Test\v\tt1> v run .       
[Option(none), Option(2), Option(1)]
```