### PR TITLE
builder: fix compiling code, importing a module located in `src/modules`

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -206,7 +206,11 @@ pub fn (mut v Builder) set_module_lookup_paths() {
 	if v.pref.is_verbose {
 		println('x: "${x}"')
 	}
-	v.module_search_paths << os.join_path(v.compiled_dir, 'modules')
+	if os.exists(os.join_path(v.compiled_dir, 'src/modules')) {
+		v.module_search_paths << os.join_path(v.compiled_dir, 'src/modules')
+	} else {
+		v.module_search_paths << os.join_path(v.compiled_dir, 'modules')
+	}
 	v.module_search_paths << v.pref.lookup_path
 	if v.pref.is_verbose {
 		v.log('v.module_search_paths:')

--- a/vlib/v/tests/projects_that_should_compile_test.v
+++ b/vlib/v/tests/projects_that_should_compile_test.v
@@ -25,4 +25,7 @@ fn test_projects_should_run() {
 	}
 	res := vrun_ok('run', vroot_path('vlib/v/tests/testdata/enum_in_builtin') + os.path_separator)
 	assert res.trim_space() == 'v0'
+
+	res2 := vrun_ok('run', vroot_path('vlib/v/tests/testdata/modules_in_src/'))
+	assert res2.trim_space() == 'somemodule'
 }

--- a/vlib/v/tests/testdata/modules_in_src/src/main.v
+++ b/vlib/v/tests/testdata/modules_in_src/src/main.v
@@ -1,0 +1,7 @@
+module main
+
+import somemodule
+
+fn main() {
+	println(somemodule.name())
+}

--- a/vlib/v/tests/testdata/modules_in_src/src/modules/somemodule/somemodule.v
+++ b/vlib/v/tests/testdata/modules_in_src/src/modules/somemodule/somemodule.v
@@ -1,0 +1,7 @@
+module somemodule
+
+const name = "somemodule"
+
+pub fn name() string {
+	return name
+}

--- a/vlib/v/tests/testdata/modules_in_src/src/modules/somemodule/somemodule.v
+++ b/vlib/v/tests/testdata/modules_in_src/src/modules/somemodule/somemodule.v
@@ -1,7 +1,7 @@
 module somemodule
 
-const name = "somemodule"
+const name = 'somemodule'
 
 pub fn name() string {
-	return name
+	return somemodule.name
 }

--- a/vlib/v/tests/testdata/modules_in_src/v.mod
+++ b/vlib/v/tests/testdata/modules_in_src/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'somemodule'
+	description: ''
+	version: ''
+	license: ''
+	dependencies: []
+}


### PR DESCRIPTION
Fixed a problem where modules in src were not recognized.