### PR TITLE
cgen: fix fixed array of option type default (related #19392)

### DIFF
--- a/vlib/v/tests/fixed_array_of_option_test.v
+++ b/vlib/v/tests/fixed_array_of_option_test.v
@@ -1,7 +1,12 @@
 fn test_fixed_array_of_option() {
-	mut a := [3]?int{init: ?int(1)}
-	a[0] = none
-	a[1] = 2
-	println(a)
-	assert '${a}' == '[Option(none), Option(2), Option(1)]'
+	mut a1 := [3]?int{init: ?int(1)}
+	a1[0] = none
+	a1[1] = 2
+	println(a1)
+	assert '${a1}' == '[Option(none), Option(2), Option(1)]'
+
+	mut a2 := [3]?int{}
+	a2[0] = 1
+	println(a2)
+	assert '${a2}' == '[Option(1), Option(none), Option(none)]'
 }


### PR DESCRIPTION
This PR fix fixed array of option type default (related #19392).

- Fix fixed array of option type default.
- Add test.

```v
fn main() {
	mut a1 := [3]?int{init: ?int(1)}
	a1[0] = none
	a1[1] = 2
	println(a1)
	assert '${a1}' == '[Option(none), Option(2), Option(1)]'

	mut a2 := [3]?int{}
	a2[0] = 1
	println(a2)
	assert '${a2}' == '[Option(1), Option(none), Option(none)]'
}

PS D:\Test\v\tt1> v run .    
[Option(none), Option(2), Option(1)]
[Option(1), Option(none), Option(none)]
```