### PR TITLE
checker: fix generic comparison for conditional assignment (fix #19398)

### DIFF
--- a/vlib/v/tests/generic_comparison_for_conditional_assign_test.v
+++ b/vlib/v/tests/generic_comparison_for_conditional_assign_test.v
@@ -1,0 +1,21 @@
+fn clip[N](x []N, min N, max N) []N {
+	mut result := []N{cap: x.len}
+	for value in x {
+		result << if value < min {
+			min
+		} else if value > max {
+			max
+		} else {
+			value
+		}
+	}
+	return result
+}
+
+fn test_generic_comparison_for_conditional_assign() {
+	a := [1, 2, 3, 4, 5]
+	dump(a)
+	b := clip(a, 2, 4)
+	dump(b)
+	assert b == [2, 2, 3, 4, 4]
+}


### PR DESCRIPTION
This PR fix generic comparison for conditional assignment (fix #19398).

- Fix generic comparison for conditional assignment.
- Add test.

```v
fn clip[N](x []N, min N, max N) []N {
	mut result := []N{cap: x.len}
	for value in x {
		result << if value < min {
			min
		} else if value > max {
			max
		} else {
			value
		}
	}
	return result
}

fn main() {
	a := [1, 2, 3, 4, 5]
	dump(a)
	b := clip(a, 2, 4)
	dump(b)
	assert b == [2, 2, 3, 4, 4]
}

PS D:\Test\v\tt1> v run .    
[.\\tt1.v:17] a: [1, 2, 3, 4, 5]
[.\\tt1.v:19] b: [2, 2, 3, 4, 4]
```