### PR TITLE
checker: allow using ! and ~ on aliased bool and integral types

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4182,12 +4182,10 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 			}
 		}
 	}
-	if node.op == .bit_not && !c.unwrap_generic(right_type).is_int() && !c.pref.translated
-		&& !c.file.is_translated {
+	if node.op == .bit_not && !right_sym.is_int() && !c.pref.translated && !c.file.is_translated {
 		c.type_error_for_operator('~', 'integer', right_sym.name, node.pos)
 	}
-	if node.op == .not && right_type != ast.bool_type_idx && !c.pref.translated
-		&& !c.file.is_translated {
+	if node.op == .not && right_sym.kind != .bool && !c.pref.translated && !c.file.is_translated {
 		c.type_error_for_operator('!', 'bool', right_sym.name, node.pos)
 	}
 	// FIXME

--- a/vlib/v/tests/alias_bool_not_op_test.v
+++ b/vlib/v/tests/alias_bool_not_op_test.v
@@ -1,0 +1,7 @@
+type JBoolean = bool
+
+fn test_alias_not_op() {
+	a := JBoolean(false)
+	b := !a
+	assert b == true
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19400

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a3239f</samp>

Refactor and optimize the type checking for `~` and `!` operators in `checker.v` and add a test case for using `!` on a type alias of `bool` in `alias_bool_not_op_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a3239f</samp>

*  Simplify type checking for `~` and `!` operators by using `Symbol` properties ([link](https://github.com/vlang/v/pull/19403/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L4185-R4188))
*  Add test case for using `!` on a type alias of `bool` ([link](https://github.com/vlang/v/pull/19403/files?diff=unified&w=0#diff-b8f43f3c45f8df81fe99a41c9f35966729ece5b719dfbb5c7f50f2c7bd67dbe0R1-R7))
