### PR TITLE
toml: Fix toml encoding of complex types

### DIFF
--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -181,6 +181,15 @@ fn test_map_encode_of_complex_struct() {
 	assert toml.encode(Example5{ mp: mp }) == 'mp = { key_one = "a problem", key_two = "a problem" }'
 }
 
+struct Example6 {
+	ptr voidptr
+	r   rune
+}
+
+fn test_encode_for_exotic_types() {
+	assert toml.encode(Example6{ ptr: &voidptr(0), r: `🚀` }) == 'ptr = "0x0"\nr = "🚀"'
+}
+
 fn test_array_encode_decode() {
 	a := Arrs{
 		strs: ['foo', 'bar']

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -149,6 +149,38 @@ fn test_custom_encode_of_complex_struct() {
 ]'
 }
 
+struct Example3 {
+	arr_arr [][]Problem
+}
+
+struct Example4 {
+	mp map[string]Problem
+}
+
+pub fn (example Example3) to_toml() string {
+	return '[This is Valid]'
+}
+
+pub fn (example Example4) to_toml() string {
+	return '[This is Valid]'
+}
+
+fn test_custom_encode_of_nested_complex_struct() {
+	assert toml.encode(Example3{}) == '[This is Valid]'
+	assert toml.encode(Example4{}) == '[This is Valid]'
+}
+
+struct Example5 {
+	mp map[string]Problem
+}
+
+fn test_map_encode_of_complex_struct() {
+	mut mp := map[string]Problem{}
+	mp['key_one'] = Problem{}
+	mp['key_two'] = Problem{}
+	assert toml.encode(Example5{ mp: mp }) == 'mp = { key_one = "a problem", key_two = "a problem" }'
+}
+
 fn test_array_encode_decode() {
 	a := Arrs{
 		strs: ['foo', 'bar']

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -135,7 +135,7 @@ fn to_any[T](value T) Any {
 	} $else $if T is $map {
 		mut mmap := map[string]Any{}
 		for key, val in value {
-			mmap[encode(key)] = to_any(val)
+			mmap['${key}'] = to_any(val)
 		}
 		return mmap
 	} $else {


### PR DESCRIPTION
As outlined in issue #19300 the default *toml* encoder caused compile time errors when encoding more complex structs. 
#19338 attempted to solve this issue by adding additional logic that covers the edge cases mentioned within the issue. However, other edge cases exist that bypass the fix and lead to compile time errors again. Examples are defined within the new test cases in this PR and include:

```v
struct Example3 {
	arr_arr [][]Problem
}

struct Example4 {
	mp map[string]Problem
}
```

This PR extends the `encode_struct` function of the *toml* module by adding handling of currently missing types (e.g. `$map`, which fixes `Example4` from above) and by applying encoding recursively (fixes `Example3` from above). This should catch quite some more edge cases, although I'm not sure whether it catches all.

The changes were tested against all defined *toml* test cases and seem to work. Concerning the implementation I'm not sure whether it is optimized. E.g. I expected that stuff like:

```v
	} $else $if T is i64 {
		return Any(value)
	} $else $if T is int {
		return Any(value)
	} $else $if T is u64 {
		return Any(value)
	}
```

could be written as:

```v
	} $else $if T in [i64, int, u64] {
		return Any(value)
	}
```

But this somehow did not work and led to unexpected results :shrug: 