### PR TITLE
checker: infer map array values based on first value of map

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -457,12 +457,14 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 			if expecting_array_map && !use_expected_type {
 				arr_value := map_value_sym.info as ast.Array
 				if val_type_sym.kind == .array {
-					mut next_arr_value := val_type_sym.info as ast.Array
-					next_arr_value = ast.Array{
-						...next_arr_value
-						elem_type: arr_value.elem_type
+					if val_type_sym.info is ast.Array {
+						mut next_arr_value := val_type_sym.info as ast.Array
+						next_arr_value = ast.Array{
+							...next_arr_value
+							elem_type: arr_value.elem_type
+						}
+						val_type_sym.info = next_arr_value
 					}
-					val_type_sym.info = next_arr_value
 				} else {
 					msg := c.expected_msg(val_type, node.value_type)
 					c.error('invalid map value: ${msg}', val.pos())

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -454,14 +454,15 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 			if val_type == ast.none_type && val0_type.has_flag(.option) {
 				continue
 			}
-			if expecting_array_map {
+			if expecting_array_map && !use_expected_type {
 				arr_value := map_value_sym.info as ast.Array
 				if val_type_sym.kind == .array {
-					mut arr_value_2 := val_type_sym.info as ast.Array
-					arr_value_2 = ast.Array{
+					mut next_arr_value := val_type_sym.info as ast.Array
+					next_arr_value = ast.Array{
+						...next_arr_value
 						elem_type: arr_value.elem_type
 					}
-					val_type_sym.info = arr_value_2
+					val_type_sym.info = next_arr_value
 				} else {
 					msg := c.expected_msg(val_type, node.value_type)
 					c.error('invalid map value: ${msg}', val.pos())

--- a/vlib/v/tests/map_array_cast_value_acc_first_test.v
+++ b/vlib/v/tests/map_array_cast_value_acc_first_test.v
@@ -1,0 +1,18 @@
+const m = {
+	'foo': [u8(0xf0), 0x00]
+	'bar': [0xba, 0xaa]
+	'foobar': [12, 45]
+}
+
+fn test_check_arr_elem_type() {
+	assert typeof(m['foo']).name == '[]u8'
+	assert typeof(m['bar']).name == '[]u8'
+	assert typeof(m['foobar']).name == '[]u8'
+}
+
+fn test_get_elem() {
+	assert '${m['foo']}' == '[240, 0]'
+	assert '${m['bar']}' == '[186, 170]'
+	assert '${m['foobar']}' == '[12, 45]'
+}
+

--- a/vlib/v/tests/map_array_cast_value_acc_first_test.v
+++ b/vlib/v/tests/map_array_cast_value_acc_first_test.v
@@ -1,6 +1,6 @@
 const m = {
-	'foo': [u8(0xf0), 0x00]
-	'bar': [0xba, 0xaa]
+	'foo':    [u8(0xf0), 0x00]
+	'bar':    [0xba, 0xaa]
 	'foobar': [12, 45]
 }
 
@@ -15,4 +15,3 @@ fn test_get_elem() {
 	assert '${m['bar']}' == '[186, 170]'
 	assert '${m['foobar']}' == '[12, 45]'
 }
-


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19253

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b8ac2a</samp>

This pull request enhances the type checking and casting of maps with array values in V. It modifies `vlib/v/checker/containers.v` and adds a new test file `vlib/v/tests/map_array_cast_value_acc_first_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b8ac2a</samp>

*  Add a variable `expecting_array_map` to check if the map value type is an array ([link](https://github.com/vlang/v/pull/19411/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR410))
*  Make `val_type_sym` mutable to allow modifying the map value type if it is an array ([link](https://github.com/vlang/v/pull/19411/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL427-R428))
*  Handle the case of casting map values to arrays of the same element type as the first value ([link](https://github.com/vlang/v/pull/19411/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR457-R469))
*  Add a test file `map_array_cast_value_acc_first_test.v` to verify the functionality of the new feature ([link](https://github.com/vlang/v/pull/19411/files?diff=unified&w=0#diff-cea71058e7680c390a300f9c2cf1682f12ba918fb4afb49300711d3df89108c2R1-R18))
