### PR TITLE
parser: fix assigning with in another module sumtypes (fix #19413)

### DIFF
--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -164,6 +164,7 @@ fn (mut p Parser) array_init(is_option bool) ast.ArrayInit {
 		}
 	}
 	pos := first_pos.extend_with_last_line(last_pos, p.prev_tok.line_nr)
+	p.expr_mod = ''
 	return ast.ArrayInit{
 		is_fixed: is_fixed
 		has_val: has_val

--- a/vlib/v/tests/assign_with_in_module_sumtype_test.v
+++ b/vlib/v/tests/assign_with_in_module_sumtype_test.v
@@ -1,0 +1,16 @@
+import aa
+
+fn test_assign_with_in_module_sumtype() {
+	node := aa.MySumType(aa.S1{})
+
+	cond := node in [aa.S1, aa.S2]
+	mut b := 'b'
+	mut c := 'c'
+
+	if cond {
+		println('${cond} --- ${b} --- ${c}')
+		assert '${cond} --- ${b} --- ${c}' == 'true --- b --- c'
+	} else {
+		assert false
+	}
+}

--- a/vlib/v/tests/modules/aa/aa.v
+++ b/vlib/v/tests/modules/aa/aa.v
@@ -1,0 +1,7 @@
+module aa
+
+pub type MySumType = S1 | S2
+
+pub struct S1 {}
+
+pub struct S2 {}


### PR DESCRIPTION
This PR fix assigning with in another module sumtypes (fix #19413).

- Fix assigning with in another module sumtypes.
- Add test.

aa/aa.v
```v
module aa

pub type MySumType = S1 | S2

pub struct S1 {}

pub struct S2 {}
```
tt1.v
```v
import aa

fn main() {
	node := aa.MySumType(aa.S1{})

	cond := node in [aa.S1, aa.S2]
	mut b := 'b'
	mut c := 'c'

	if cond {
		println('${cond} --- ${b} --- ${c}')
		assert '${cond} --- ${b} --- ${c}' == 'true --- b --- c'
	} else {
		assert false
	}
}

PS D:\Test\v\tt1> v run .
true --- b --- c
```