### PR TITLE
parser: fix assigning with in another module sumtypes 2 (related #19414)

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -286,6 +286,7 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr, left_comments []ast.Comme
 		}
 	}
 	pos.update_last_line(p.prev_tok.line_nr)
+	p.expr_mod = ''
 	return ast.AssignStmt{
 		op: op
 		left: left

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -164,7 +164,6 @@ fn (mut p Parser) array_init(is_option bool) ast.ArrayInit {
 		}
 	}
 	pos := first_pos.extend_with_last_line(last_pos, p.prev_tok.line_nr)
-	p.expr_mod = ''
 	return ast.ArrayInit{
 		is_fixed: is_fixed
 		has_val: has_val


### PR DESCRIPTION
This PR fix assigning with in another module sumtypes 2.

- #19414 couldn't resolve assign_stmt(), and this PR can work.