### PR TITLE
cgen: fix struct field option type with default value init (fix #19418)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -359,8 +359,7 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 	if field.has_default_expr {
 		if sym.kind in [.sum_type, .interface_] {
 			if field.typ.has_flag(.option) {
-				g.expr_opt_with_cast(field.default_expr, field.default_expr_typ.set_flag(.option),
-					field.typ)
+				g.expr_with_opt(field.default_expr, field.default_expr_typ, field.typ)
 			} else {
 				g.expr_with_cast(field.default_expr, field.default_expr_typ, field.typ)
 			}

--- a/vlib/v/tests/struct_field_option_type_with_default_value_init_test.v
+++ b/vlib/v/tests/struct_field_option_type_with_default_value_init_test.v
@@ -1,0 +1,13 @@
+type SomeType = SomeStruct | string
+
+struct SomeStruct {}
+
+struct AnotherStruct {
+	field ?SomeType = 'default_string'
+}
+
+fn test_struct_field_option_type_with_default_value() {
+	s := AnotherStruct{}
+	println(s.field)
+	assert '${s.field}' == "Option(SomeType('default_string'))"
+}


### PR DESCRIPTION
This PR fix struct field option type with default value init (fix #19418).

- Fix struct field option type with default value init.
- Add test.

```v
type SomeType = SomeStruct | string

struct SomeStruct {}

struct AnotherStruct {
	field ?SomeType = 'default_string'
}

fn main() {
	s := AnotherStruct{}
	println(s.field)
	assert '${s.field}' == "Option(SomeType('default_string'))"
}

PS D:\Test\v\tt1> v run .
Option(SomeType('default_string'))
```