### PR TITLE
checker, cgen: fix fixed array of option with default value (related #19405)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -304,7 +304,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			node.typ = ast.new_type(idx)
 		}
 		if node.has_default {
-			c.expr(mut node.default_expr)
+			node.default_type = c.expr(mut node.default_expr)
 		}
 	}
 	return node.typ

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -126,7 +126,11 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		g.indent++
 		g.writeln('int it = index;') // FIXME: Remove this line when it is fully forbidden
 		g.write('*pelem = ')
-		g.expr(node.default_expr)
+		if node.elem_type.has_flag(.option) {
+			g.expr_with_opt(node.default_expr, node.default_type, node.elem_type)
+		} else {
+			g.expr_with_cast(node.default_expr, node.default_type, node.elem_type)
+		}
 		g.writeln(';')
 		g.indent--
 		g.writeln('}')
@@ -167,7 +171,11 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 	} else if node.has_default {
 		info := array_type.unaliased_sym.info as ast.ArrayFixed
 		for i in 0 .. info.size {
-			g.expr(node.default_expr)
+			if info.elem_type.has_flag(.option) {
+				g.expr_with_opt(node.default_expr, node.default_type, info.elem_type)
+			} else {
+				g.expr_with_cast(node.default_expr, node.default_type, info.elem_type)
+			}
 			if i != info.size - 1 {
 				g.write(', ')
 			}
@@ -334,7 +342,11 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.indent++
 		g.writeln('int it = index;') // FIXME: Remove this line when it is fully forbidden
 		g.write('*pelem = ')
-		g.expr(node.default_expr)
+		if node.elem_type.has_flag(.option) {
+			g.expr_with_opt(node.default_expr, node.default_type, node.elem_type)
+		} else {
+			g.expr_with_cast(node.default_expr, node.default_type, node.elem_type)
+		}
 		g.writeln(';')
 		g.indent--
 		g.writeln('}')

--- a/vlib/v/tests/fixed_array_of_option_test.v
+++ b/vlib/v/tests/fixed_array_of_option_test.v
@@ -5,6 +5,12 @@ fn test_fixed_array_of_option() {
 	println(a1)
 	assert '${a1}' == '[Option(none), Option(2), Option(1)]'
 
+	mut a11 := [3]?int{init: 1}
+	a11[0] = none
+	a11[1] = 2
+	println(a11)
+	assert '${a11}' == '[Option(none), Option(2), Option(1)]'
+
 	mut a2 := [3]?int{}
 	a2[0] = 1
 	println(a2)
@@ -13,4 +19,8 @@ fn test_fixed_array_of_option() {
 	a3 := [3]?int{init: ?int(index * 2)}
 	println(a3)
 	assert '${a3}' == '[Option(0), Option(2), Option(4)]'
+
+	a33 := [3]?int{init: index * 2}
+	println(a33)
+	assert '${a33}' == '[Option(0), Option(2), Option(4)]'
 }


### PR DESCRIPTION
This PR fix fixed array of option with default value (related #19405).

- Fix fixed array of option with default value.
- Add test.

```v
fn main() {
	mut a1 := [3]?int{init: ?int(1)}
	a1[0] = none
	a1[1] = 2
	println(a1)
	assert '${a1}' == '[Option(none), Option(2), Option(1)]'

	mut a11 := [3]?int{init: 1}
	a11[0] = none
	a11[1] = 2
	println(a11)
	assert '${a11}' == '[Option(none), Option(2), Option(1)]'

	mut a2 := [3]?int{}
	a2[0] = 1
	println(a2)
	assert '${a2}' == '[Option(1), Option(none), Option(none)]'

	a3 := [3]?int{init: ?int(index * 2)}
	println(a3)
	assert '${a3}' == '[Option(0), Option(2), Option(4)]'

	a33 := [3]?int{init: index * 2}
	println(a33)
	assert '${a33}' == '[Option(0), Option(2), Option(4)]'
}

PS D:\Test\v\tt1> v run .
[Option(none), Option(2), Option(1)]
[Option(none), Option(2), Option(1)]
[Option(1), Option(none), Option(none)]
[Option(0), Option(2), Option(4)]
[Option(0), Option(2), Option(4)]
```