### PR TITLE
builtin: fix typo in string.v

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -329,7 +329,7 @@ pub fn (a string) clone() string {
 	return b
 }
 
-// replace_once replaces the first occurence of `rep` with the string passed in `with`.
+// replace_once replaces the first occurrence of `rep` with the string passed in `with`.
 pub fn (s string) replace_once(rep string, with string) string {
 	idx := s.index_(rep)
 	if idx == -1 {
@@ -338,7 +338,7 @@ pub fn (s string) replace_once(rep string, with string) string {
 	return s.substr(0, idx) + with + s.substr(idx + rep.len, s.len)
 }
 
-// replace replaces all occurences of `rep` with the string passed in `with`.
+// replace replaces all occurrences of `rep` with the string passed in `with`.
 [direct_array_access]
 pub fn (s string) replace(rep string, with string) string {
 	if s.len == 0 || rep.len == 0 || rep.len > s.len {
@@ -406,7 +406,7 @@ struct RepIndex {
 	val_idx int
 }
 
-// replace_each replaces all occurences of the string pairs given in `vals`.
+// replace_each replaces all occurrences of the string pairs given in `vals`.
 // Example: assert 'ABCD'.replace_each(['B','C/','C','D','D','C']) == 'AC/DC'
 [direct_array_access]
 pub fn (s string) replace_each(vals []string) string {
@@ -496,7 +496,7 @@ pub fn (s string) replace_each(vals []string) string {
 	}
 }
 
-// replace_char replaces all occurences of the character `rep` multiple occurences of the character passed in `with` with respect to `repeat`.
+// replace_char replaces all occurrences of the character `rep` multiple occurrences of the character passed in `with` with respect to `repeat`.
 // Example: assert '\tHello!'.replace_char(`\t`,` `,8) == '        Hello!'
 [direct_array_access]
 pub fn (s string) replace_char(rep u8, with u8, repeat int) string {
@@ -900,7 +900,7 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 		}
 		else {
 			mut start := 0
-			// Take the left part for each delimiter occurence
+			// Take the left part for each delimiter occurrence
 			for i <= s.len {
 				is_delim := i + delim.len <= s.len && s.substr(i, i + delim.len) == delim
 				if is_delim {
@@ -1204,7 +1204,7 @@ pub fn (s string) index_any(chars string) int {
 	return -1
 }
 
-// last_index returns the position of the last occurence of the input string.
+// last_index returns the position of the last occurrence of the input string.
 [direct_array_access]
 fn (s string) last_index_(p string) int {
 	if p.len > s.len || p.len == 0 {
@@ -1224,7 +1224,7 @@ fn (s string) last_index_(p string) int {
 	return -1
 }
 
-// last_index returns the position of the last occurence of the input string.
+// last_index returns the position of the last occurrence of the input string.
 pub fn (s string) last_index(p string) ?int {
 	idx := s.last_index_(p)
 	if idx == -1 {
@@ -1274,7 +1274,7 @@ pub fn (s string) index_u8(c u8) int {
 	return -1
 }
 
-// last_index_byte returns the index of the last occurence of byte `c` if found in the string.
+// last_index_byte returns the index of the last occurrence of byte `c` if found in the string.
 // last_index_byte returns -1 if the byte is not found.
 [direct_array_access]
 pub fn (s string) last_index_u8(c u8) int {
@@ -1853,7 +1853,7 @@ pub fn (s string) all_before(sub string) string {
 	return s[..pos]
 }
 
-// all_before_last returns the contents before the last occurence of `sub` in the string.
+// all_before_last returns the contents before the last occurrence of `sub` in the string.
 // If the substring is not found, it returns the full input string.
 // Example: assert '23:34:45.234'.all_before_last(':') == '23:34'
 // Example: assert 'abcd'.all_before_last('.') == 'abcd'
@@ -1877,7 +1877,7 @@ pub fn (s string) all_after(sub string) string {
 	return s[pos + sub.len..]
 }
 
-// all_after_last returns the contents after the last occurence of `sub` in the string.
+// all_after_last returns the contents after the last occurrence of `sub` in the string.
 // If the substring is not found, it returns the full input string.
 // Example: assert '23:34:45.234'.all_after_last(':') == '45.234'
 // Example: assert 'abcd'.all_after_last('z') == 'abcd'
@@ -1889,7 +1889,7 @@ pub fn (s string) all_after_last(sub string) string {
 	return s[pos + sub.len..]
 }
 
-// all_after_first returns the contents after the first occurence of `sub` in the string.
+// all_after_first returns the contents after the first occurrence of `sub` in the string.
 // If the substring is not found, it returns the full input string.
 // Example: assert '23:34:45.234'.all_after_first(':') == '34:45.234'
 // Example: assert 'abcd'.all_after_first('z') == 'abcd'
@@ -1901,7 +1901,7 @@ pub fn (s string) all_after_first(sub string) string {
 	return s[pos + sub.len..]
 }
 
-// after returns the contents after the last occurence of `sub` in the string.
+// after returns the contents after the last occurrence of `sub` in the string.
 // If the substring is not found, it returns the full input string.
 // Example: assert '23:34:45.234'.after(':') == '45.234'
 // Example: assert 'abcd'.after('z') == 'abcd'
@@ -1911,7 +1911,7 @@ pub fn (s string) after(sub string) string {
 	return s.all_after_last(sub)
 }
 
-// after_char returns the contents after the first occurence of `sub` character in the string.
+// after_char returns the contents after the first occurrence of `sub` character in the string.
 // If the substring is not found, it returns the full input string.
 // Example: assert '23:34:45.234'.after_char(`:`) == '34:45.234'
 // Example: assert 'abcd'.after_char(`:`) == 'abcd'


### PR DESCRIPTION
occurence -> occurrence



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25edc4e</samp>

This pull request corrects spelling errors in the comments of `vlib/builtin/string.v`. It replaces `occurence` with `occurrence` in the documentation of several string functions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25edc4e</samp>

* Fix typos in the comments of various string functions that use the word `occurrence` ([link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L332-R332), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L341-R341), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L409-R409), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L499-R499), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L903-R903), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1207-R1207), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1227-R1227), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1277-R1277), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1856-R1856), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1880-R1880), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1892-R1892), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1904-R1904), [link](https://github.com/vlang/v/pull/19431/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L1914-R1914)) in `vlib/builtin/string.v`
