### PR TITLE
cgen: fix interface with option field (fix #19419)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3633,7 +3633,22 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			g.write('*(')
 		}
 		g.expr(node.expr)
-		if node.expr_type.is_ptr() {
+		for i, embed in node.from_embed_types {
+			embed_sym := g.table.sym(embed)
+			embed_name := embed_sym.embed_name()
+			is_left_ptr := if i == 0 {
+				node.expr_type.is_ptr()
+			} else {
+				node.from_embed_types[i - 1].is_ptr()
+			}
+			if is_left_ptr {
+				g.write('->')
+			} else {
+				g.write('.')
+			}
+			g.write(embed_name)
+		}
+		if node.expr_type.is_ptr() && node.from_embed_types.len == 0 {
 			g.write('->')
 		} else {
 			g.write('.')

--- a/vlib/v/tests/interface_with_option_field_test.v
+++ b/vlib/v/tests/interface_with_option_field_test.v
@@ -1,0 +1,32 @@
+import time
+
+interface InterfaceObject {
+mut:
+	duration ?time.Duration
+	update()
+}
+
+struct Object {
+mut:
+	duration ?time.Duration
+}
+
+fn (mut obj Object) update() {
+	duration := obj.duration or { time.second }
+	println(duration)
+}
+
+struct FooObject {
+	Object
+}
+
+fn (mut obj FooObject) update() {
+	duration := obj.duration or { time.millisecond * 500 }
+	println(duration)
+}
+
+fn test_interface_with_option_field() {
+	mut object := InterfaceObject(FooObject{})
+	println(object)
+	assert '${object.duration}' == 'Option(none)'
+}


### PR DESCRIPTION
This PR fix interface with option field (fix #19419).

- Fix interface with option field.
- Add test.

```v
import time

interface InterfaceObject {
mut:
	duration ?time.Duration
	update()
}

struct Object {
mut:
	duration ?time.Duration
}

fn (mut obj Object) update() {
	duration := obj.duration or { time.second }
	println(duration)
}

struct FooObject {
	Object
}

fn (mut obj FooObject) update() {
	duration := obj.duration or { time.millisecond * 500 }
	println(duration)
}

fn main() {
	mut object := InterfaceObject(FooObject{})
	println(object)
	assert '${object.duration}' == 'Option(none)'
}

PS D:\Test\v\tt1> v run .    
InterfaceObject(FooObject{
    Object: Object{
        duration: Option(none)
    }
})
```