### PR TITLE
parser, checker: allow lambdas anywhere anonymous functions are expected

### DIFF
--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -7,11 +7,6 @@ pub fn (mut c Checker) lambda_expr(mut node ast.LambdaExpr, exp_typ ast.Type) as
 	if node.is_checked {
 		return node.typ
 	}
-	if !c.inside_fn_arg {
-		c.error('lambda expressions are allowed only inside function or method callsites',
-			node.pos)
-		return ast.void_type
-	}
 	if exp_typ == 0 {
 		c.error('lambda expressions are allowed only in places expecting function callbacks',
 			node.pos)

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -837,8 +837,6 @@ fn (mut p Parser) process_custom_orm_operators() {
 }
 
 fn (mut p Parser) lambda_expr() ?ast.LambdaExpr {
-	
-
 	// a) `f(||expr)` for a callback lambda expression with 0 arguments
 	// b) `f(|a_1,...,a_n| expr_with_a_1_etc_till_a_n)` for a callback with several arguments
 	if !(p.tok.kind == .logical_or

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -837,9 +837,7 @@ fn (mut p Parser) process_custom_orm_operators() {
 }
 
 fn (mut p Parser) lambda_expr() ?ast.LambdaExpr {
-	if !p.inside_call_args {
-		return none
-	}
+	
 
 	// a) `f(||expr)` for a callback lambda expression with 0 arguments
 	// b) `f(|a_1,...,a_n| expr_with_a_1_etc_till_a_n)` for a callback with several arguments

--- a/vlib/v/tests/lambda_as_struct_field_value_test.v
+++ b/vlib/v/tests/lambda_as_struct_field_value_test.v
@@ -1,5 +1,5 @@
 struct Foo {
-	sum fn(int, int) int
+	sum fn (int, int) int
 }
 
 fn test_lambda_as_struct_field_value() {

--- a/vlib/v/tests/lambda_as_struct_field_value_test.v
+++ b/vlib/v/tests/lambda_as_struct_field_value_test.v
@@ -1,0 +1,10 @@
+struct Foo {
+	sum fn(int, int) int
+}
+
+fn test_lambda_as_struct_field_value() {
+	foo := Foo{
+		sum: |x, y| x + y
+	}
+	assert foo.sum(6, 6) == 12
+}


### PR DESCRIPTION
This fixes #19428 as well as allowing lambdas anywhere an anonymous function is expected.