### PR TITLE
Builder: fixed compile code when importing modules in both `src/modules` and `modules`.

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -214,11 +214,14 @@ pub fn (mut v Builder) set_module_lookup_paths() {
 	if v.pref.is_verbose {
 		println('x: "${x}"')
 	}
+
 	if os.exists(os.join_path(v.compiled_dir, 'src/modules')) {
 		v.module_search_paths << os.join_path(v.compiled_dir, 'src/modules')
-	} else {
+	}
+	if os.exists(os.join_path(v.compiled_dir, 'modules')) {
 		v.module_search_paths << os.join_path(v.compiled_dir, 'modules')
 	}
+
 	v.module_search_paths << v.pref.lookup_path
 	if v.pref.is_verbose {
 		v.log('v.module_search_paths:')

--- a/vlib/v/tests/projects_that_should_compile_test.v
+++ b/vlib/v/tests/projects_that_should_compile_test.v
@@ -27,5 +27,5 @@ fn test_projects_should_run() {
 	assert res.trim_space() == 'v0'
 
 	res2 := vrun_ok('run', vroot_path('vlib/v/tests/testdata/modules_in_src/'))
-	assert res2.trim_space() == 'somemodule'
+	assert res2.trim_space() == 'somemodule somemoduletwo'
 }

--- a/vlib/v/tests/testdata/modules_in_src/modules/somemoduletwo/somemoduletwo.v
+++ b/vlib/v/tests/testdata/modules_in_src/modules/somemoduletwo/somemoduletwo.v
@@ -1,0 +1,7 @@
+module somemoduletwo
+
+const name = 'somemoduletwo'
+
+pub fn name() string {
+	return somemoduletwo.name
+}

--- a/vlib/v/tests/testdata/modules_in_src/src/main.v
+++ b/vlib/v/tests/testdata/modules_in_src/src/main.v
@@ -1,7 +1,8 @@
 module main
 
 import somemodule
+import somemoduletwo
 
 fn main() {
-	println(somemodule.name())
+	println('${somemodule.name()} ${somemoduletwo.name()}')
 }


### PR DESCRIPTION
Fixed problem with 'modules' not being recognized when `src/modules` and `modules` exist