### PR TITLE
vcreate: re-prompt on invalid project name instead of exiting

### DIFF
--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -69,17 +69,17 @@ fn new_project(args []string) {
 
 	if c.name == '' {
 		cerror('project name cannot be empty')
-		exit(1)
+		c.name = os.input('Input your project name: ')
 	}
 
 	if c.name.contains('-') {
 		cerror('"${c.name}" should not contain hyphens')
-		exit(1)
+		c.name = os.input('Input your project name: ')
 	}
 
 	if os.is_dir(c.name) {
 		cerror('${c.name} folder already exists')
-		exit(3)
+		c.name = os.input('Input your project name: ')
 	}
 
 	c.description = if args.len > 1 { args[1] } else { os.input('Input your project description: ') }

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -62,24 +62,28 @@ fn main() {
 	println('Complete!')
 }
 
+fn ask_for_project_name() string {
+	return check_name(os.input('Input your project name: '))
+}
+
 fn new_project(args []string) {
 	mut c := Create{}
 
-	c.name = check_name(if args.len > 0 { args[0] } else { os.input('Input your project name: ') })
+	c.name = if args.len > 0 { check_name(args[0]) } else { ask_for_project_name() }
 
 	if c.name == '' {
 		cerror('project name cannot be empty')
-		c.name = os.input('Input your project name: ')
+		c.name = ask_for_project_name()
 	}
 
 	if c.name.contains('-') {
 		cerror('"${c.name}" should not contain hyphens')
-		c.name = os.input('Input your project name: ')
+		c.name = ask_for_project_name()
 	}
 
 	if os.is_dir(c.name) {
 		cerror('${c.name} folder already exists')
-		c.name = os.input('Input your project name: ')
+		c.name = ask_for_project_name()
 	}
 
 	c.description = if args.len > 1 { args[1] } else { os.input('Input your project description: ') }


### PR DESCRIPTION
Assuming that someone still wants to create a V project after entering an invalid project, this change still prints the error but re-prompts for a project name input instead of exiting the project creating process. This spares executing the `v new` command again.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46d8053</samp>

Make `vcreate` more interactive by prompting for a new project name if the input is invalid or existing. Update `vcreate.v` to implement this behavior.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46d8053</samp>

* Add interactive prompts for project name and description to `vcreate` command ([link](https://github.com/vlang/v/pull/19438/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL72-R82),                             F0
