### PR TITLE
vcreate: don't use template names as project descriptions

### DIFF
--- a/cmd/tools/vcreate/tests/new_with_model_arg.expect
+++ b/cmd/tools/vcreate/tests/new_with_model_arg.expect
@@ -9,6 +9,7 @@ set model [lindex $argv 2]
 
 spawn $v_root/v new $project_name $model
 
+expect "Input your project description: " { send "My Awesome V Project.\r" } timeout { exit 1 }
 expect "Input your project version: (0.0.0) " { send "0.0.1\r" } timeout { exit 1 }
 expect "Input your project license: (MIT) " { send "\r" } timeout { exit 1 }
 expect "Initialising ..." {} timeout { exit 1 }

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -81,7 +81,7 @@ fn new_project(args []string) {
 		exit(3)
 	}
 
-	c.description = if args.len > 1 { args[1] } else { os.input('Input your project description: ') }
+	c.description = os.input('Input your project description: ')
 
 	default_version := '0.0.0'
 	c.version = os.input('Input your project version: (${default_version}) ')

--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -81,7 +81,7 @@ fn test_new_with_model_arg_input() {
 		return
 	}
 	assert mod.name == project_name
-	assert mod.description == model
+	assert mod.description == 'My Awesome V Project.'
 	assert mod.version == '0.0.1'
 	assert mod.license == 'MIT'
 }


### PR DESCRIPTION
This removes usage of the second template arg as description. So when a template is used for creating a project, the description in the v.mod would not be set silently. 

E.g. the description when using `v new my_web_project web` would not become `web` as in the example below:
```
Module {
	name: 'my_web_project'
	description: 'web'
	version: '0.0.0'
	license: 'MIT'
	dependencies: []
}
```

Instead, the description prompt `Input your project description: ` would appear also when using a template.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 558616d</samp>

Refactor `vcreate` tool to use `cli` module and simplify description input. The change always asks the user for a project description instead of relying on a second argument.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 558616d</samp>

* Refactor the vcreate tool to use the new cli module ([link](https://github.com/vlang/v/pull/19439/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL85-R85),                             F0L112
