### PR TITLE
CONTRIBUTING: quick link to likes filter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,9 @@ you are interested in.
 Filtering by likes helps you identify high-impact issues.
 More likes mean more community interest.
 
-To apply this filter, navigate to [Issues](https://github.com/vlang/v/issues)
+To quickly use this filter, click [there](https://github.com/vlang/v/issues?q=is%3Aopen+is%3Aissue+sort%3Areactions-%2B1-desc).
+
+To manually apply this filter, navigate to [Issues](https://github.com/vlang/v/issues)
 tab, then paste the following in the "Filter" field:
 
 ```


### PR DESCRIPTION
This PR adds a quick link to the likes filter, as proposed by [here](https://github.com/vlang/v/discussions/19440#discussioncomment-7105425).

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe0944a</samp>

Added a link to the issues filtered by likes in `CONTRIBUTING.md`. This change aims to make it easier for contributors to find and engage with popular issues.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe0944a</samp>

* Add a link to the filtered issues by likes in `CONTRIBUTING.md` ([link](https://github.com/vlang/v/pull/19442/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L151-R153))
