### PR TITLE
checker: check option propogation in multi return types

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -530,7 +530,7 @@ pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, 
 							return error("references attribute needs to be in the format [references], [references: 'tablename'], or [references: 'tablename(field_id)']")
 						}
 						if attr.arg.contains('(') {
-							ref_table, ref_field := attr.arg.split_once('(')
+							ref_table, ref_field := attr.arg.split_once('(')?
 							if !ref_field.ends_with(')') {
 								return error("explicit references attribute should be written as [references: 'tablename(field_id)']")
 							}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -47,6 +47,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				}
 				node.right_types = right_type_sym.mr_info().types
 				right_len = node.right_types.len
+				if mut right is ast.CallExpr {
+					if right.or_block.kind == .absent && right_type.has_flag(.option) {
+						c.error("cannot multi assign as Option isn't propagated", right.pos)
+					}
+				}
 			} else if right_type == ast.void_type {
 				right_len = 0
 			}

--- a/vlib/v/checker/tests/multi_return_option_not_set_err.out
+++ b/vlib/v/checker/tests/multi_return_option_not_set_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/multi_return_option_not_set_err.vv:1:19: error: cannot multi assign as Option isn't propagated
+    1 | a, b := 'fdf:df:'.split_once(',')
+      |                   ~~~~~~~~~~~~~~~
+    2 | println(a)
+    3 | println(b)

--- a/vlib/v/checker/tests/multi_return_option_not_set_err.vv
+++ b/vlib/v/checker/tests/multi_return_option_not_set_err.vv
@@ -1,0 +1,3 @@
+a, b := 'fdf:df:'.split_once(',')
+println(a)
+println(b)


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/18566

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f90c01d</samp>

This pull request adds a checker error for multi-assignment with optional values that are not handled or propagated. It also adds a test case for the error using the `split_once` method from the `strings` module.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f90c01d</samp>

* Add a check for multi-assignment with optional values ([link](https://github.com/vlang/v/pull/19443/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR50-R54))
  - Report an error if the optional value is not handled or propagated ([link](https://github.com/vlang/v/pull/19443/files?diff=unified&w=0#diff-977168d734147fc147fe4029274165b1208c7dd327d861e85ea79b603f6b80d7R1-R5), [link](https://github.com/vlang/v/pull/19443/files?diff=unified&w=0#diff-1e89399ba88539bcc06f786fa3d7295f865f027188f3380935aa8fa07e2795a6R1-R3))
