### PR TITLE
Revert libc.h include, exits(), void main

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -553,14 +553,9 @@ voidptr memdup(voidptr src, int sz);
 	#error Cygwin is not supported, please use MinGW or Visual Studio.
 #endif
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__vinix__) || defined(__serenity__) || defined(__sun)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__vinix__) || defined(__serenity__) || defined(__sun) || defined(__plan9__)
 	#include <sys/types.h>
 	#include <sys/wait.h> // os__wait uses wait on nix
-#endif
-
-#if defined(__plan9__)
-	#include <u.h>
-	#include <libc.h>
 #endif
 
 #ifdef __OpenBSD__


### PR DESCRIPTION
I'm working on getting the plan 9 compilation working on ape/psh environment, and to do that it probably needs to be as close to normal ANSI C as possible, so I am changing the C headers to be more linux-ey.
This may change in the future, but I'm eliminating variables.