### PR TITLE
builtin, cgen: fix printing slice of fn call string (fix #19435)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -530,7 +530,7 @@ pub fn (mut a array) delete_last() {
 // Alternative: Slices can also be made with [start..end] notation
 // Alternative: `.slice_ni()` will always return an array.
 fn (a array) slice(start int, _end int) array {
-	mut end := _end
+	mut end := if _end == 2147483647 { a.len } else { _end } // max_int
 	$if !no_bounds_checking {
 		if start > end {
 			panic('array.slice: invalid slice index (${start} > ${end})')
@@ -565,7 +565,7 @@ fn (a array) slice(start int, _end int) array {
 // This function always return a valid array.
 fn (a array) slice_ni(_start int, _end int) array {
 	// a.flags.clear(.noslices)
-	mut end := _end
+	mut end := if _end == 2147483647 { a.len } else { _end } // max_int
 	mut start := _start
 
 	if start < 0 {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1037,7 +1037,8 @@ fn (s string) substr2(start int, _end int, end_max bool) string {
 // substr returns the string between index positions `start` and `end`.
 // Example: assert 'ABCD'.substr(1,3) == 'BC'
 [direct_array_access]
-pub fn (s string) substr(start int, end int) string {
+pub fn (s string) substr(start int, _end int) string {
+	end := if _end == 2147483647 { s.len } else { _end } // max_int
 	$if !no_bounds_checking {
 		if start > end || start > s.len || end > s.len || start < 0 || end < 0 {
 			panic('substr(${start}, ${end}) out of bounds (len=${s.len})')
@@ -1061,7 +1062,8 @@ pub fn (s string) substr(start int, end int) string {
 // version of `substr()` that is used in `a[start..end] or {`
 // return an error when the index is out of range
 [direct_array_access]
-pub fn (s string) substr_with_check(start int, end int) !string {
+pub fn (s string) substr_with_check(start int, _end int) !string {
+	end := if _end == 2147483647 { s.len } else { _end } // max_int
 	if start > end || start > s.len || end > s.len || start < 0 || end < 0 {
 		return error('substr(${start}, ${end}) out of bounds (len=${s.len})')
 	}
@@ -1085,7 +1087,7 @@ pub fn (s string) substr_with_check(start int, end int) !string {
 [direct_array_access]
 pub fn (s string) substr_ni(_start int, _end int) string {
 	mut start := _start
-	mut end := _end
+	mut end := if _end == 2147483647 { s.len } else { _end } // max_int
 
 	// borders math
 	if start < 0 {

--- a/vlib/v/slow_tests/inout/printing_slice_of_fn_call_string.out
+++ b/vlib/v/slow_tests/inout/printing_slice_of_fn_call_string.out
@@ -1,0 +1,2 @@
+Get called
+ello

--- a/vlib/v/slow_tests/inout/printing_slice_of_fn_call_string.vv
+++ b/vlib/v/slow_tests/inout/printing_slice_of_fn_call_string.vv
@@ -1,0 +1,15 @@
+struct Wrapper {
+	element string
+}
+
+fn (instance Wrapper) get() string {
+	println("Get called")
+	return instance.element
+}
+
+fn main() {
+	wrapper := Wrapper{
+		element: "Hello"
+	}
+	println(wrapper.get()[1..])
+}


### PR DESCRIPTION
This PR fix printing slice of fn call string (fix #19435).

- Fix printing slice of fn call string.
- Add test.

```v
struct Wrapper {
	element string
}

fn (instance Wrapper) get() string {
	println("Get called")
	return instance.element
}

fn main() {
	wrapper := Wrapper{
		element: "Hello"
	}
	println(wrapper.get()[1..])
}

PS D:\Test\v\tt1> v run .
Get called
ello
```