### PR TITLE
builtin: cleanup in string.v and array.v

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -530,7 +530,7 @@ pub fn (mut a array) delete_last() {
 // Alternative: Slices can also be made with [start..end] notation
 // Alternative: `.slice_ni()` will always return an array.
 fn (a array) slice(start int, _end int) array {
-	mut end := if _end == 2147483647 { a.len } else { _end } // max_int
+	end := if _end == 2147483647 { a.len } else { _end } // max_int
 	$if !no_bounds_checking {
 		if start > end {
 			panic('array.slice: invalid slice index (${start} > ${end})')
@@ -607,12 +607,6 @@ fn (a array) slice_ni(_start int, _end int) array {
 		cap: l
 	}
 	return res
-}
-
-// used internally for [2..4]
-fn (a array) slice2(start int, _end int, end_max bool) array {
-	end := if end_max { a.len } else { _end }
-	return a.slice(start, end)
 }
 
 // clone_static_to_depth() returns an independent copy of a given array.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1027,13 +1027,6 @@ pub fn (s string) split_into_lines() []string {
 	return res
 }
 
-// used internally for [2..4]
-[inline]
-fn (s string) substr2(start int, _end int, end_max bool) string {
-	end := if end_max { s.len } else { _end }
-	return s.substr(start, end)
-}
-
 // substr returns the string between index positions `start` and `end`.
 // Example: assert 'ABCD'.substr(1,3) == 'BC'
 [direct_array_access]

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -99,7 +99,6 @@ pub fn mark_used(mut table ast.Table, pref_ &pref.Preferences, ast_files []&ast.
 			'22.repeat_to_depth',
 			'22.slice',
 			'22.slice_ni',
-			'22.slice2',
 			'61.get',
 			'61.set',
 			'65558.last',


### PR DESCRIPTION
This PR cleanup in string.v and array.v.

- Remove unused internal fn `string.substr2(start int, end int, end_max bool)`.
- Remove unused internal fn `array.slice2(start int, end int, end_max bool)`.