### PR TITLE
github: remove unintended line break in issue voting note

### DIFF
--- a/.github/workflows/add-voting-info.yml
+++ b/.github/workflows/add-voting-info.yml
@@ -17,8 +17,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             > [!NOTE]
-            > You can vote for this issue using the 👍 reaction. More votes increase the issue's priority
-            for developers.
+            > You can vote for this issue using the 👍 reaction. More votes increase the issue's priority for developers.
             >
             > Take into account that only the 👍 reaction counts as a vote.
             > Only reactions to the issue itself will be counted as votes, not comments.


### PR DESCRIPTION
Removes a stubborn linebreak that was intended to be removed in https://github.com/vlang/v/pull/19448.

I hope a PR for the simple change is okay.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90b9161</samp>

Add a workflow to comment on new issues with voting information and fix a line break in the comment body. The workflow file is `.github/workflows/add-voting-info.yml`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90b9161</samp>

* Add a new workflow to comment on new issues with voting information (`.github/workflows/add-voting-info.yml`)
  - Remove the line break in the comment body for better readability ([link](https://github.com/vlang/v/pull/19455/files?diff=unified&w=0#diff-b4cf7e8509e8e8675e7ab2187a4fa52593e91c89ebced25e6f32a84edba2ba3aL20-R20))
