### PR TITLE
cgen: fix array of fns index call with direct_array_access mode (fix #19458)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -264,7 +264,11 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 				if elem_sym.info is ast.FnType {
 					g.write('((')
 					g.write_fn_ptr_decl(&elem_sym.info, '')
-					g.write(')(*(${elem_type_str}*)array_get(')
+					if is_direct_array_access {
+						g.write(')((${elem_type_str}*)')
+					} else {
+						g.write(')(*(${elem_type_str}*)array_get(')
+					}
 				}
 				if left_is_ptr && !node.left_type.has_flag(.shared_f) {
 					g.write('*')
@@ -296,6 +300,9 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			g.write('data)[')
 			g.expr(node.index)
 			g.write(']')
+			if g.is_fn_index_call {
+				g.write(')')
+			}
 		} else {
 			g.write(', ')
 			g.expr(node.index)

--- a/vlib/v/tests/array_of_fns_index_call_with_direct_array_access_test.v
+++ b/vlib/v/tests/array_of_fns_index_call_with_direct_array_access_test.v
@@ -1,0 +1,19 @@
+struct Bar {
+	f []fn (int) int
+}
+
+fn func(n int) int {
+	return n
+}
+
+[direct_array_access]
+fn (b Bar) foo() int {
+	return b.f[0](22)
+}
+
+fn test_array_of_fns_index_call_with_direct_array_acess() {
+	bar := Bar{[func]}
+	ret := bar.foo()
+	println(ret)
+	assert ret == 22
+}


### PR DESCRIPTION
This PR fix array of fns index call with direct_array_access mode (fix #19458).

- Fix array of fns index call with direct_array_access mode.
- Add test.

```v
struct Bar {
	f []fn (int) int
}

fn func(n int) int {
	return n
}

[direct_array_access]
fn (b Bar) foo() int {
	return b.f[0](22)
}

fn main() {
	bar := Bar{[func]}
	ret := bar.foo()
	println(ret)
	assert ret == 22
}

PS D:\Test\v\tt1> v run .
22
```