### PR TITLE
fmt: keep anon struct decl fields in interfaces

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1385,6 +1385,8 @@ pub fn (mut f Fmt) interface_field(field ast.StructField) {
 		if sym.info.is_anon {
 			f.write('\t${field.name} ')
 			f.write_anon_struct_field_decl(field.typ, ast.StructDecl{ fields: sym.info.fields })
+		} else {
+			f.write('\t${field.name} ${ft}')
 		}
 	} else {
 		f.write('\t${field.name} ${ft}')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1380,7 +1380,15 @@ pub fn (mut f Fmt) interface_field(field ast.StructField) {
 	if before_comments.len > 0 {
 		f.comments(before_comments, level: .indent)
 	}
-	f.write('\t${field.name} ${ft}')
+	sym := f.table.sym(field.typ)
+	if sym.info is ast.Struct {
+		if sym.info.is_anon {
+			f.write('\t${field.name} ')
+			f.write_anon_struct_field_decl(field.typ, ast.StructDecl{ fields: sym.info.fields })
+		}
+	} else {
+		f.write('\t${field.name} ${ft}')
+	}
 	if end_comments.len > 0 {
 		f.comments(end_comments, level: .indent)
 	} else {

--- a/vlib/v/fmt/tests/interface_anon_struct_decl_keep.vv
+++ b/vlib/v/fmt/tests/interface_anon_struct_decl_keep.vv
@@ -1,0 +1,5 @@
+interface Foo {
+	field struct {
+		bar int
+	}
+}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19459

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7fe90f</samp>

Add support for anonymous structs inside interfaces in the V language. Modify `vlib/v/fmt/fmt.v` to format such declarations correctly and add a test file `vlib/v/fmt/tests/interface_anon_struct_decl_keep.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d7fe90f</samp>

*  Add support for anonymous structs inside interfaces ([link](https://github.com/vlang/v/pull/19461/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL1383-R1391), [link](https://github.com/vlang/v/pull/19461/files?diff=unified&w=0#diff-b43f57f789d3f8f8481bc08da0f768470e4896915467ab469918b8d48b259862R1-R5))
   - Modify `write_struct_decl` method of `Fmt` struct in `vlib/v/fmt/fmt.v` to check for anonymous struct fields and write them using `write_anon_struct_field_decl` method ([link](https://github.com/vlang/v/pull/19461/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL1383-R1391))
   - Add `write_anon_struct_field_decl` method to `Fmt` struct in `vlib/v/fmt/fmt.v` to write the field name and the struct declaration for anonymous struct fields ([link](https://github.com/vlang/v/pull/19461/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL1383-R1391))
   - Add test file `vlib/v/fmt/tests/interface_anon_struct_decl_keep.vv` to define an interface with an anonymous struct field and check that the formatter keeps the struct declaration as it is ([link](https://github.com/vlang/v/pull/19461/files?diff=unified&w=0#diff-b43f57f789d3f8f8481bc08da0f768470e4896915467ab469918b8d48b259862R1-R5))
