### PR TITLE
README: remove wrong claim about backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,6 @@
 - C and JavaScript backends
 - Great for writing low-level software ([Vinix OS](https://github.com/vlang/vinix))
 
-## Stability guarantee and future changes
-
-Despite being at an early development stage, the V language is relatively stable and has
-backwards compatibility guarantee, meaning that the code you write today is guaranteed
-to work a month, a year, or five years from now.
-
-There still may be minor syntax changes before the 1.0 release, but they will be handled
-automatically via `vfmt`, as has been done in the past.
-
-The V core APIs (primarily the `os` module) will still have minor changes until
-they are stabilized in V 1.0. Of course the APIs will grow after that, but without breaking
-existing code.
-
-Unlike many other languages, V is not going to be always changing, with new features
-being introduced and old features modified. It is always going to be a small and simple
-language, very similar to the way it is right now.
-
 ## Installing V from source
 
 --> **_(this is the preferred method)_**


### PR DESCRIPTION
I have requested this change several times in the discord already. The response was always something like "those changes are handled automatically" or "V is not mature enough to not break things yet" - and while I agree with the latter, the statement that `v fmt` handles breaking changes is simply wrong (partially because it doesn't make any sense to automate that process in some situations).

One recent example of this is 11337e7621eade026a916afacc88caab16c62410; this commit forbids variables called `thread` to be declared and is not handled by `v fmt`.

Another case from half a year ago is 404a9aa44240468c0155eb82d34d49f85735fd1c.

Here's one more: 46f32fc10cca328f95dba09d60d15eb2d9d7c3c4; this only introduced a warning, but since warnings are errors in `-prod` mode, it also broke my code.

To make it clear, I very much think that those changes make sense and that V **should break things** from time to time, but I just don't like the claim.

Let's discuss this topic in this PR as I think we might want to introduce some kind of BC compatibility promise, but the current one is unrealistic and simply wrong.