### PR TITLE
fix: make CloseTagType public

### DIFF
--- a/vlib/net/html/tag.v
+++ b/vlib/net/html/tag.v
@@ -3,7 +3,7 @@ module html
 import strings
 import datatypes
 
-enum CloseTagType {
+pub enum CloseTagType {
 	in_name
 	new_tag
 }


### PR DESCRIPTION
It's public field of Tag struct, but type itself is private
