### PR TITLE
os, v.builder: show more details, when a program ran by `v run file.v`, exits by a signal (fix #19412)

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -430,9 +430,9 @@ pub fn system(cmd string) int {
 	$if !windows {
 		pret, is_signaled := posix_wait4_to_exit_status(ret)
 		if is_signaled {
-			println('Terminated by signal ${ret:2d} (' + sigint_to_signal_name(pret) + ')')
+			eprintln('Terminated by signal ${pret:2d} (' + sigint_to_signal_name(pret) + ')')
 		}
-		ret = pret
+		ret = pret + 128
 	}
 	return ret
 }
@@ -541,7 +541,7 @@ pub fn rmdir(path string) ! {
 fn print_c_errno() {
 	e := C.errno
 	se := unsafe { tos_clone(&u8(C.strerror(e))) }
-	println('errno=${e} err=${se}')
+	eprintln('errno=${e} err=${se}')
 }
 
 // get_raw_line returns a one-line string from stdin along with '\n' if there is any.

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -429,10 +429,11 @@ pub fn system(cmd string) int {
 	}
 	$if !windows {
 		pret, is_signaled := posix_wait4_to_exit_status(ret)
+		ret = pret
 		if is_signaled {
 			eprintln('Terminated by signal ${pret:2d} (' + sigint_to_signal_name(pret) + ')')
+			ret = pret + 128
 		}
-		ret = pret + 128
 	}
 	return ret
 }

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -161,7 +161,7 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 		}
 		ret = run_process.code
 		if run_process.err != '' {
-			eprintln('> V run program error: ${run_process.err}')
+			eprintln(run_process.err)
 		}
 		run_process.close()
 	}

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -160,6 +160,9 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 			os.signal_opt(.quit, prev_quit_handler) or { serror('restore .quit', err) }
 		}
 		ret = run_process.code
+		if run_process.err != '' {
+			eprintln('> V run program error: ${run_process.err}')
+		}
 		run_process.close()
 	}
 	b.cleanup_run_executable_after_exit(compiled_file)


### PR DESCRIPTION
Fix #19412 .