### PR TITLE
cgen: fix printing fixed array of options (fix #19469)

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -678,27 +678,27 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 				g.auto_str_funcs.writeln('\t\tif ( 0 == a[i] ) {')
 				g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _SLIT("0"));')
 				g.auto_str_funcs.writeln('\t\t}else{')
-				g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}( ${deref} a[i]) );')
+				g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${deref}a[i]));')
 				g.auto_str_funcs.writeln('\t\t}')
 			} else {
-				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}( ${deref} a[i]) );')
+				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${deref}a[i]));')
 			}
-		} else if sym.kind in [.f32, .f64] {
+		} else if sym.kind in [.f32, .f64] && !typ.has_flag(.option) {
 			if sym.kind == .f32 {
 				field_str := str_intp_g32('a[i]')
-				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${field_str} );')
+				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${field_str});')
 			} else {
 				field_str := str_intp_g64('a[i]')
-				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${field_str} );')
+				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${field_str});')
 			}
-		} else if sym.kind == .string {
+		} else if sym.kind == .string && !typ.has_flag(.option) {
 			field_str := str_intp_sq('a[i]')
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${field_str});')
-		} else if sym.kind == .rune {
-			tmp_str := str_intp_rune('${elem_str_fn_name}(  ${deref} a[i])')
+		} else if sym.kind == .rune && !typ.has_flag(.option) {
+			tmp_str := str_intp_rune('${elem_str_fn_name}(${deref}a[i])')
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${tmp_str});')
 		} else {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}( ${deref} a[i]));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${deref}a[i]));')
 		}
 	}
 	g.auto_str_funcs.writeln('\t\tif (i < ${info.size - 1}) {')

--- a/vlib/v/slow_tests/inout/dump_fixed_array_of_option.out
+++ b/vlib/v/slow_tests/inout/dump_fixed_array_of_option.out
@@ -1,0 +1,4 @@
+[vlib/v/slow_tests/inout/dump_fixed_array_of_option.vv:3] a1: [Option('foo'), Option(none)]
+[vlib/v/slow_tests/inout/dump_fixed_array_of_option.vv:6] a2: [Option(22), Option(none)]
+[vlib/v/slow_tests/inout/dump_fixed_array_of_option.vv:9] a3: [Option(22.2), Option(none)]
+[vlib/v/slow_tests/inout/dump_fixed_array_of_option.vv:12] a4: [Option(true), Option(none)]

--- a/vlib/v/slow_tests/inout/dump_fixed_array_of_option.vv
+++ b/vlib/v/slow_tests/inout/dump_fixed_array_of_option.vv
@@ -1,0 +1,13 @@
+fn main() {
+	a1 := [?string('foo'), ?string(none)]!
+	dump(a1)
+
+	a2 := [?int(22), ?int(none)]!
+	dump(a2)
+
+	a3 := [?f64(22.2), ?f64(none)]!
+	dump(a3)
+
+	a4 := [?bool(true), ?bool(none)]!
+	dump(a4)
+}


### PR DESCRIPTION
This PR fix printing fixed array of options (fix #19469).

- Fix printing fixed array of options.
- Add test.

```v
fn main() {
	a1 := [?string('foo'), ?string(none)]!
	dump(a1)

	a2 := [?int(22), ?int(none)]!
	dump(a2)

	a3 := [?f64(22.2), ?f64(none)]!
	dump(a3)

	a4 := [?bool(true), ?bool(none)]!
	dump(a4)
}

PS D:\Test\v\tt1> v run .       
[.\\tt1.v:3] a1: [Option('foo'), Option(none)]
[.\\tt1.v:6] a2: [Option(22), Option(none)]
[.\\tt1.v:9] a3: [Option(22.2), Option(none)]
[.\\tt1.v:12] a4: [Option(true), Option(none)]
```