### PR TITLE
Update slice creating description

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1208,48 +1208,18 @@ array_2 << array_1[..3]
 println(array_2) // `[0, 1, 3, 5, 4]`
 ```
 
-A slice is always created with the smallest possible capacity `cap == len` (see
-[`cap` above](#array-initialization)) no matter what the capacity or length
-of the parent array is. As a result it is immediately reallocated and copied to another
-memory location when the size increases thus becoming independent from the
-parent array (*copy on grow*). In particular pushing elements to a slice
-does not alter the parent:
+A slice is always created, reallocated and copied to another
+memory location(see [`clone` above](#array-initialization)) : 
 
 ```v
 mut a := [0, 1, 2, 3, 4, 5]
-mut b := a[2..4]
-b[0] = 7 // `b[0]` is referring to `a[2]`
-println(a) // `[0, 1, 7, 3, 4, 5]`
+// an implicit clone of the slice was done here
+mut b := a[2..4] // same as "mut b = a[2..4].clone()"
+b[0] = 7 
+println(a) // `[0, 1, 2, 3, 4, 5]` - no change
 b << 9
-// `b` has been reallocated and is now independent from `a`
-println(a) // `[0, 1, 7, 3, 4, 5]` - no change
+println(a) // `[0, 1, 2, 3, 4, 5]` - no change
 println(b) // `[7, 3, 9]`
-```
-
-Appending to the parent array may or may not make it independent from its child slices.
-The behaviour depends on the parent's capacity and is predictable:
-
-```v
-mut a := []int{len: 5, cap: 6, init: 2}
-mut b := unsafe { a[1..4] }
-a << 3
-// no reallocation - fits in `cap`
-b[2] = 13 // `a[3]` is modified
-a << 4
-// a has been reallocated and is now independent from `b` (`cap` was exceeded)
-b[1] = 3 // no change in `a`
-println(a) // `[2, 2, 2, 13, 2, 3, 4]`
-println(b) // `[2, 3, 13]`
-```
-
-You can call .clone() on the slice, if you do want to have an independent copy right away:
-
-```v
-mut a := [0, 1, 2, 3, 4, 5]
-mut b := a[2..4].clone()
-b[0] = 7 // Note: `b[0]` is NOT referring to `a[2]`, as it would have been, without the .clone()
-println(a) // [0, 1, 2, 3, 4, 5]
-println(b) // [7, 3]
 ```
 
 ##### Slices with negative indexes


### PR DESCRIPTION
It is an implicit clone of original array



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4ae4cc</samp>

Updated the documentation on array slices in `doc/docs.md` to match the new cloning behavior of V 0.2.4. Added a cross-reference to the array initialization section.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4ae4cc</samp>

*  Update array slice documentation to match V 0.2.4 behavior ([link](https://github.com/vlang/v/pull/19482/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L1211-R1224))
