### PR TITLE
cgen: fix struct field of fixed array init (fix #19483)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -386,6 +386,19 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 		tmp_var := g.new_tmp_var()
 		g.expr_with_tmp_var(ast.None{}, ast.none_type, field.typ, tmp_var)
 		return true
+	} else if sym.info is ast.ArrayFixed {
+		g.write('{')
+		for i in 0 .. sym.info.size {
+			if sym.info.elem_type.has_flag(.option) {
+				g.expr_with_opt(ast.None{}, ast.none_type, sym.info.elem_type)
+			} else {
+				g.write(g.type_default(sym.info.elem_type))
+			}
+			if i != sym.info.size - 1 {
+				g.write(', ')
+			}
+		}
+		g.write('}')
 	} else {
 		g.write(g.type_default(field.typ))
 	}

--- a/vlib/v/tests/array_elements_with_option_test.v
+++ b/vlib/v/tests/array_elements_with_option_test.v
@@ -38,7 +38,7 @@ fn get_no_option() int {
 }
 
 fn test_option_non_fixed() {
-	x := get_has_option() or { 0 }
+	x := get_has_option()?
 	assert x == 0
 	assert get_no_option() == 0
 }

--- a/vlib/v/tests/array_elements_with_option_test.v
+++ b/vlib/v/tests/array_elements_with_option_test.v
@@ -13,8 +13,8 @@ fn get_no_option_fixed() int {
 	return foo.arr2[0]
 }
 
-fn test_option_fixed() ? {
-	x := get_has_option_fixed()?
+fn test_option_fixed() {
+	x := get_has_option_fixed() or { 0 }
 	assert x == 0
 	assert get_no_option_fixed() == 0
 }
@@ -37,8 +37,8 @@ fn get_no_option() int {
 	return foo.arr2[0]
 }
 
-fn test_option_non_fixed() ? {
-	x := get_has_option()?
+fn test_option_non_fixed() {
+	x := get_has_option() or { 0 }
 	assert x == 0
 	assert get_no_option() == 0
 }

--- a/vlib/v/tests/struct_field_fixed_array_init_test.v
+++ b/vlib/v/tests/struct_field_fixed_array_init_test.v
@@ -1,0 +1,10 @@
+struct Foo {
+mut:
+	bar [2]string
+}
+
+fn test_struct_field_fixed_array_init() {
+	foo := Foo{}
+	println(foo.bar[0])
+	assert foo.bar[0] == ''
+}


### PR DESCRIPTION
This PR fix struct field of fixed array init (fix #19483).

- Fix struct field of fixed array init.
- Add test.

```v 
struct Foo {
mut:
	bar [2]string
}

fn main() {
	foo := Foo{}
	println(foo.bar[0])
	assert foo.bar[0] == ''
}

PS D:\Test\v\tt1> v run .

```