### PR TITLE
all: add support for `@LOCATION`, for more convenient logging/tracing, without needing to combine `@FILE`, `@LINE` at runtime

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2455,8 +2455,9 @@ user := User.new()
 This is an alternative to factory functions like `fn new_user() User {}` and should be used
 instead.
 
-Note, that these are not constructors, but simple functions. V doesn't have constructors or
-classes.
+> **Note**
+> Note, that these are not constructors, but simple functions. V doesn't have constructors or
+> classes.
 
 ### `[noinit]` structs
 
@@ -5524,9 +5525,10 @@ that are substituted at compile time:
 - `@MOD` => replaced with the name of the current V module
 - `@STRUCT` => replaced with the name of the current V struct
 - `@FILE` => replaced with the absolute path of the V source file
-- `@LINE` => replaced with the V line number where it appears (as a string).
+- `@LINE` => replaced with the V line number where it appears (as a string)
 - `@FILE_LINE` => like `@FILE:@LINE`, but the file part is a relative path
-- `@COLUMN` => replaced with the column where it appears (as a string).
+- `@LOCATION` => file, line and name of the current type + method; suitable for logging
+- `@COLUMN` => replaced with the column where it appears (as a string)
 - `@VEXE` => replaced with the path to the V compiler
 - `@VEXEROOT`  => will be substituted with the *folder*,
   where the V executable is (as a string).
@@ -5538,7 +5540,7 @@ that are substituted at compile time:
 That allows you to do the following example, useful while debugging/logging/tracing your code:
 
 ```v
-eprintln('file: ' + @FILE + ' | line: ' + @LINE + ' | fn: ' + @MOD + '.' + @FN)
+eprintln(@LOCATION)
 ```
 
 Another example, is if you want to embed the version/name from v.mod *inside* your executable:
@@ -5548,6 +5550,18 @@ import v.vmod
 vm := vmod.decode( @VMOD_FILE ) or { panic(err) }
 eprintln('${vm.name} ${vm.version}\n ${vm.description}')
 ```
+
+A program that prints its own source code (a quine):
+```v
+print($embed_file(@FILE).to_string())
+```
+
+> **Note**
+> you can have arbitrary source code in the file, without problems, since the full file
+> will be embeded into the executable, produced by compiling it. Also note that printing
+> is done with `print` and not `println`, to not add another new line, missing in the
+> source code.
+
 
 ### Compile time reflection
 

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -430,7 +430,7 @@ pub fn (x Expr) str() string {
 			return '${x.expr.str()} as ${global_table.type_to_str(x.typ)}'
 		}
 		AtExpr {
-			return '${x.val}'
+			return '${x.name}'
 		}
 		CTempVar {
 			return x.orig.str()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3346,6 +3346,21 @@ fn (mut c Checker) at_expr(mut node ast.AtExpr) ast.Type {
 		.column_nr {
 			node.val = (node.pos.col + 1).str()
 		}
+		.location {
+			mut mname := 'unknown'
+			if c.table.cur_fn != unsafe { nil } {
+				if c.table.cur_fn.is_method {
+					mname = c.table.type_to_str(c.table.cur_fn.receiver.typ) + '{}.' +
+						c.table.cur_fn.name.all_after_last('.')
+				} else {
+					mname = c.table.cur_fn.name
+				}
+				if c.table.cur_fn.is_static_type_method {
+					mname = mname.replace('__static__', '.') + ' (static)'
+				}
+			}
+			node.val = c.file.path + ':' + (node.pos.line_nr + 1).str() + ', ${mname}'
+		}
 		.vhash {
 			node.val = version.vhash()
 		}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -350,6 +350,7 @@ fn (mut p Parser) at() ast.AtExpr {
 		'@FILE' { token.AtKind.file_path }
 		'@LINE' { token.AtKind.line_nr }
 		'@FILE_LINE' { token.AtKind.file_path_line_nr }
+		'@LOCATION' { token.AtKind.location }
 		'@COLUMN' { token.AtKind.column_nr }
 		'@VHASH' { token.AtKind.vhash }
 		'@VMOD_FILE' { token.AtKind.vmod_file }

--- a/vlib/v/tests/comptime_at_test.v
+++ b/vlib/v/tests/comptime_at_test.v
@@ -157,12 +157,12 @@ fn MyStruct.new() MyStruct {
 
 fn (s MyStruct) mymethod() {
 	assert @LOCATION.contains('comptime_at_test.v:')
-	assert @LOCATION.contains('main.MyStruct{}.mymethod')
+	assert @LOCATION.ends_with('main.MyStruct{}.mymethod')
 }
 
 fn test_at_location() {
 	abc()
 	MyStruct.new().mymethod()
-	assert @LOCATION.contains('main.test_at_location')
-	assert @LOCATION.contains('main.test_at_location')
+	assert @LOCATION.contains('comptime_at_test.v:')
+	assert @LOCATION.ends_with('main.test_at_location')
 }

--- a/vlib/v/tests/comptime_at_test.v
+++ b/vlib/v/tests/comptime_at_test.v
@@ -141,3 +141,28 @@ fn test_line_number_last_token() {
 	assert line1 == line2
 	assert line1 == line3
 }
+
+fn abc() {
+	assert @LOCATION.contains('comptime_at_test.v:')
+	assert @LOCATION.ends_with(', main.abc')
+}
+
+struct MyStruct {
+}
+
+fn MyStruct.new() MyStruct {
+	assert @LOCATION.ends_with('main.MyStruct.new (static)')
+	return MyStruct{}
+}
+
+fn (s MyStruct) mymethod() {
+	assert @LOCATION.contains('comptime_at_test.v:')
+	assert @LOCATION.contains('main.MyStruct{}.mymethod')
+}
+
+fn test_at_location() {
+	abc()
+	MyStruct.new().mymethod()
+	assert @LOCATION.contains('main.test_at_location')
+	assert @LOCATION.contains('main.test_at_location')
+}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -178,6 +178,7 @@ pub enum AtKind {
 	vroot_path // obsolete
 	vexeroot_path
 	file_path_line_nr
+	location
 }
 
 pub const (
@@ -186,7 +187,7 @@ pub const (
 		.unsigned_right_shift_assign]
 
 	valid_at_tokens = ['@VROOT', '@VMODROOT', '@VEXEROOT', '@FN', '@METHOD', '@MOD', '@STRUCT',
-		'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VMOD_FILE', '@FILE_LINE']
+		'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VMOD_FILE', '@FILE_LINE', '@LOCATION']
 
 	token_str       = build_token_str()
 


### PR DESCRIPTION
```v
// abc
// def

fn abc() {
	eprintln(@LOCATION)
}

struct MyStruct {
}

fn MyStruct.new() MyStruct {
	eprintln(@LOCATION)
	return MyStruct{}
}

fn (s MyStruct) mymethod() {
	eprintln(@LOCATION)
}

eprintln(@LOCATION)
abc()
MyStruct.new().mymethod()
eprintln(@LOCATION)
```
produces:
```
/Users/delyanangelov/code/misc/2023_10_01__19/loc.v:20, main.main
/Users/delyanangelov/code/misc/2023_10_01__19/loc.v:5, main.abc
/Users/delyanangelov/code/misc/2023_10_01__19/loc.v:12, main.MyStruct.new (static)
/Users/delyanangelov/code/misc/2023_10_01__19/loc.v:17, main.MyStruct{}.mymethod
/Users/delyanangelov/code/misc/2023_10_01__19/loc.v:23, main.main
```