### PR TITLE
cgen: fix struct init with multi option fn type (fix #19478)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1981,6 +1981,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		} else {
 			g.writeln(' }, (${c.result_name}*)(&${tmp_var}), sizeof(${styp}));')
 		}
+		g.set_current_pos_as_last_stmt_pos()
 	}
 
 	g.write(stmt_str)

--- a/vlib/v/tests/struct_init_with_multi_option_fn_type_test.v
+++ b/vlib/v/tests/struct_init_with_multi_option_fn_type_test.v
@@ -1,0 +1,43 @@
+// CycleMenuItem is a menu item that can be cycled through by pressing a button.
+pub struct CycleMenuItem {
+mut:
+	label  string
+	values []string
+	on     CycleMenuItemEvents
+}
+
+// CycleMenuItemEvents is a set of events that can be invoked by a
+// `CycleMenuItem`.
+[params]
+pub struct CycleMenuItemEvents {
+__global:
+	click ?fn (string) bool
+	cycle ?fn (string) bool
+}
+
+// CycleMenuItem.new creates a new `CycleMenuItem` with the given label, values,
+// and function to invoke when the item is selected.
+[inline]
+pub fn CycleMenuItem.new(label string, values []string, events CycleMenuItemEvents) CycleMenuItem {
+	return CycleMenuItem{
+		label: label
+		values: values
+		on: events
+	}
+}
+
+fn test_struct_init_with_multi_option_fn_type() {
+	item := CycleMenuItem.new('FPS', ['30', '60', '90', '120', '144', '165', 'unlimited'],
+		click: fn (value string) bool {
+			if value == 'unlimited' {
+				return true
+			} else {
+				return false
+			}
+		}
+	)
+	func := item.on.click?
+	ret := func('unlimited')
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR fix struct init with multi option fn type (fix #19478).

- Fix struct init with multi option fn type.
- Add test.

```v
// CycleMenuItem is a menu item that can be cycled through by pressing a button.
pub struct CycleMenuItem {
mut:
	label  string
	values []string
	on     CycleMenuItemEvents
}

// CycleMenuItemEvents is a set of events that can be invoked by a
// `CycleMenuItem`.
[params]
pub struct CycleMenuItemEvents {
__global:
	click ?fn (string) bool
	cycle ?fn (string) bool
}

// CycleMenuItem.new creates a new `CycleMenuItem` with the given label, values,
// and function to invoke when the item is selected.
[inline]
pub fn CycleMenuItem.new(label string, values []string, events CycleMenuItemEvents) CycleMenuItem {
	return CycleMenuItem{
		label: label
		values: values
		on: events
	}
}

fn main() {
	item := CycleMenuItem.new('FPS', ['30', '60', '90', '120', '144', '165', 'unlimited'],
		click: fn (value string) bool {
			if value == 'unlimited' {
				return true
			} else {
				return false
			}
		}
	)
	func := item.on.click?
	ret := func('unlimited')
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
true
```