### PR TITLE
v.util: fix typo in module.v

### DIFF
--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -61,7 +61,7 @@ pub fn qualify_module(pref_ &pref.Preferences, mod string, file_path string) str
 	// TODO: find most stable solution & test with -usecache
 	//
 	// TODO 2022-01-30: Using os.getwd() here does not seem right *at all* imho.
-	// TODO 2022-01-30: That makes lookup dependent on fragile enviroment factors.
+	// TODO 2022-01-30: That makes lookup dependent on fragile environment factors.
 	// TODO 2022-01-30: The lookup should be relative to the folder, in which the current file is,
 	// TODO 2022-01-30: *NOT* to the working folder of the compiler, which can change easily.
 	if clean_file_path.replace(os.getwd() + os.path_separator, '') == mod {


### PR DESCRIPTION
enviroment -> environment



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f448bcd</samp>

Fixed a typo in a comment in `vlib/v/util/module.v`. The comment explains how the function `find_module_path` searches for modules in the environment.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f448bcd</samp>

* Fix spelling mistake of "environment" in comment of `find_module_path` function ([link](https://github.com/vlang/v/pull/19494/files?diff=unified&w=0#diff-5085b81c0cc4bc343efcddbb5910c8519cc6e49d4c0f081379d875990542d608L64-R64))
