### PR TITLE
parser: fix assigning static method to anon fn (fix #19484)

### DIFF
--- a/vlib/v/tests/assign_static_method_to_anon_fn_test.v
+++ b/vlib/v/tests/assign_static_method_to_anon_fn_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+}
+
+fn Foo.bar() string {
+	println('bar')
+	return 'bar'
+}
+
+fn test_assign_static_method_to_anon_fn() {
+	// vfmt off
+	anon_fn := Foo.bar
+	// vfmt on
+	ret := anon_fn()
+	assert ret == 'bar'
+}


### PR DESCRIPTION
This PR fix assigning static method to anon fn (fix #19484).

- Fix assigning static method to anon fn.
- Add test.

```v
struct Foo {
}

fn Foo.bar() string {
	println('bar')
	return 'bar'
}

fn main() {
	anon_fn := Foo.bar
	ret := anon_fn()
	assert ret == 'bar'
}

PS D:\Test\v\tt1> v run .
bar
```