### PR TITLE
cgen: fix casting to interface with struct field default expr (fix #19497)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -323,6 +323,11 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 }
 
 fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
+	old_inside_cast_in_heap := g.inside_cast_in_heap
+	g.inside_cast_in_heap = 0
+	defer {
+		g.inside_cast_in_heap = old_inside_cast_in_heap
+	}
 	sym := g.table.sym(field.typ)
 	field_name := if sym.language == .v { c_name(field.name) } else { field.name }
 	if sym.info is ast.Struct {

--- a/vlib/v/tests/cast_to_interface_with_struct_field_default_test.v
+++ b/vlib/v/tests/cast_to_interface_with_struct_field_default_test.v
@@ -1,0 +1,19 @@
+import time
+
+interface Cursor {
+mut:
+	blink time.StopWatch
+}
+
+struct LineCursor {
+__global:
+	blink time.StopWatch = time.new_stopwatch(auto_start: true)
+}
+
+fn test_cast_to_interface_with_struct_field_default() {
+	c := Cursor(LineCursor{})
+	time.sleep(2 * time.millisecond)
+	duration := c.blink.elapsed().milliseconds()
+	println(duration)
+	assert duration > 0
+}


### PR DESCRIPTION
This PR fix casting to interface with struct field default expr (fix #19497).

- Fix casting to interface with struct field default expr.
- Add test.

```v
import time

interface Cursor {
mut:
	blink time.StopWatch
}

struct LineCursor {
__global:
	blink time.StopWatch = time.new_stopwatch(auto_start: true)
}

fn main() {
	c := Cursor(LineCursor{})
	time.sleep(2 * time.millisecond)
	duration := c.blink.elapsed().milliseconds()
	println(duration)
	assert duration > 0
}

PS D:\Test\v\tt1> v run .       
12
```