### PR TITLE
native, builtin: implement little improvements from #19498 and remove `vcommithash()` in favor of `@VHASH`

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -32,10 +32,6 @@ pub fn exit(code int) {
 	C.exit(code)
 }
 
-fn vcommithash() string {
-	return unsafe { tos5(&char(C.V_CURRENT_COMMIT_HASH)) }
-}
-
 // panic_debug private function that V uses for panics, -cg/-g is passed
 // recent versions of tcc print nicer backtraces automatically
 // Note: the duplication here is because tcc_backtrace should be called directly
@@ -54,7 +50,7 @@ fn panic_debug(line_no int, file string, mod string, fn_name string, s string) {
 		eprintln(' function: ${fn_name}()')
 		eprintln('  message: ${s}')
 		eprintln('     file: ${file}:${line_no}')
-		eprintln('   v hash: ${vcommithash()}')
+		eprintln('   v hash: ${@VHASH}')
 		eprintln('=========================================')
 		$if native {
 			C.exit(1) // TODO: native backtraces
@@ -108,7 +104,7 @@ pub fn panic(s string) {
 	} $else {
 		eprint('V panic: ')
 		eprintln(s)
-		eprintln('v hash: ${vcommithash()}')
+		eprintln('v hash: ${@VHASH}')
 		$if native {
 			C.exit(1) // TODO: native backtraces
 		} $else $if exit_after_panic_message ? {

--- a/vlib/builtin/float.c.v
+++ b/vlib/builtin/float.c.v
@@ -190,9 +190,9 @@ pub fn (a f32) eq_epsilon(b f32) bool {
 	delta := f32_abs(a - b)
 	$if native {
 		if hi > f32(1.0) {
-			return delta <= hi * (4 * 1e-5)
+			return delta <= hi * (4 * 1.19209290e-7)
 		} else {
-			return (1 / (4 * 1e-5)) * delta <= hi
+			return (1 / (4 * 1.19209290e-7)) * delta <= hi
 		}
 	} $else {
 		if hi > f32(1.0) {
@@ -212,9 +212,9 @@ pub fn (a f64) eq_epsilon(b f64) bool {
 	delta := f64_abs(a - b)
 	$if native {
 		if hi > 1.0 {
-			return delta <= hi * (4 * 1e-9)
+			return delta <= hi * (4 * 2.2204460492503131e-16)
 		} else {
-			return (1 / (4 * 1e-9)) * delta <= hi
+			return (1 / (4 * 2.2204460492503131e-16)) * delta <= hi
 		}
 	} $else {
 		if hi > 1.0 {

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -942,6 +942,13 @@ fn (mut c Amd64) call(addr int) i64 {
 	return c_addr
 }
 
+fn (mut c Amd64) patch_relative_jmp(pos int, addr i64) {
+	// Update jmp or cjmp address.
+	// The value is the relative address, difference between current position and the location
+	// after `jxx 00 00 00 00`
+	c.g.write32_at(pos, int(addr - pos - 4))
+}
+
 fn (mut c Amd64) extern_call(addr int) {
 	match c.g.pref.os {
 		.linux {

--- a/vlib/v/gen/native/arm64.v
+++ b/vlib/v/gen/native/arm64.v
@@ -530,3 +530,7 @@ pub fn (mut c Arm64) add(r Register, val int) {
 fn (mut c Arm64) mov_deref(reg Register, regptr Register, typ ast.Type) {
 	panic('Arm64.mov_deref() not implemented')
 }
+
+fn (mut c Arm64) patch_relative_jmp(pos int, addr i64) {
+	panic('Arm64.patch_relative_jmp() not implemented')
+}

--- a/vlib/v/gen/native/comptime.v
+++ b/vlib/v/gen/native/comptime.v
@@ -10,30 +10,12 @@ fn (mut g Gen) comptime_at(node ast.AtExpr) string {
 }
 
 fn (mut g Gen) comptime_conditional(node ast.IfExpr) ?ast.IfBranch {
-	if node.branches.len == 0 {
-		return none
-	}
-
-	for i, branch in node.branches {
-		// handle $else branch, which does not have a condition
-		if (node.has_else && i + 1 == node.branches.len) || g.comptime_is_truthy(branch.cond) {
-			return branch
-		}
-	}
-
-	return none
+	return node.branches.filter((node.has_else && it == node.branches.last())
+		|| g.comptime_is_truthy(it.cond))[0] or { return none }
 }
 
 fn (mut g Gen) should_emit_hash_stmt(node ast.HashStmt) bool {
-	if node.ct_conds.len == 0 {
-		return true
-	}
-
-	mut emit := true
-	for cond in node.ct_conds {
-		emit = emit && g.comptime_is_truthy(cond)
-	}
-	return emit
+	return node.ct_conds.all(g.comptime_is_truthy(it))
 }
 
 fn (mut g Gen) comptime_is_truthy(cond ast.Expr) bool {

--- a/vlib/v/gen/native/stmt.v
+++ b/vlib/v/gen/native/stmt.v
@@ -75,12 +75,11 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 
 			match node.kind {
 				'include', 'preinclude', 'define', 'insert' {
-					g.warning('#${node.kind} is not supported with the native backend',
+					g.v_error('#${node.kind} is not supported with the native backend',
 						node.pos)
-					// TODO: replace with error once issues with builtin are resolved
 				}
 				'flag' {
-					// flags are already handled when dispatching extern dependencies
+					// do nothing; flags are already handled when dispatching extern dependencies
 				}
 				else {
 					g.gen_native_hash_stmt(node)


### PR DESCRIPTION
Little PR that implements various stuff noted in #19498. In an effort to further reduce C macro usage, I removed `vcommithash()` from `builtin`, which was relying on `C.V_CURRENT_COMMIT_HASH`. `@VHASH` should provide a cross-backend alternative.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4183108</samp>

This pull request improves the native code generation module for the V compiler, by simplifying the code, increasing the precision of floating-point comparisons, adding support for windows linking, and raising errors for unsupported features. It also removes an unnecessary function from the builtin module and uses a constant instead. It adds a `patch_relative_jmp` function to the `Amd64` and `Arm64` structs, but only implements it for the former.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4183108</samp>

*  Remove `vcommithash` function and replace it with `@VHASH` constant in `builtin.c.v` ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL35-L38),[link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL57-R53),[link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL111-R107))
*  Update epsilon values for `f32_eq_delta` and `f64_eq_delta` functions in `float.c.v` to improve floating-point comparison accuracy ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-23b769ff3e67da4620ba0391000d349c38f4d17654364ac823e2e4d7e998146dL193-R195),[link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-23b769ff3e67da4620ba0391000d349c38f4d17654364ac823e2e4d7e998146dL215-R217))
*  Add `patch_relative_jmp` function to `Amd64` and `Arm64` structs in `amd64.v` and `arm64.v` to update jump addresses after code generation ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-058ff896cbdc6c11f12aa1310120c759dffdd567fa79c0c4ed7cfc3a7168f07cR945-R951),[link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-adbd41fc3b79a905013a0687dac2fa118ea4d8f000879c62dd3a785296ac56a9R533-R536))
*  Add `patch_relative_jmp` function to `CodeGen` interface in `gen.v` to make it consistent with native backends ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5R130))
*  Simplify and refactor `comptime_conditional` and `should_emit_hash_stmt` functions in `comptime.v` to use array methods `filter` and `all` ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-aa09e63336a304c7ae395076d6cbf4a9221bd11b162b272855d13689e6b5d61bL13-R18))
*  Move `ast_fetch_external_deps` function from `generate_header` to `generate` in `gen.v` to avoid calling it twice and make code more modular ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L431-R432))
*  Move `requires_linking` field from `generate_header` to `ast_fetch_external_deps` in `gen.v` to avoid setting it twice and make code more consistent ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L437-R442))
*  Remove conditional branching based on OS in `generate` in `gen.v` and call `link` unconditionally if `requires_linking` is true ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L485-R486))
*  Add conditional branching based on OS in `link` in `gen.v` and handle windows and macos cases separately ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5R522-R527))
*  Simplify and refactor `write` function in `gen.v` to use `<<` operator instead of loop ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L567-R568))
*  Replace code that updates jump address in `resolve_labels` in `gen.v` with call to `patch_relative_jmp` function ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-fb95eb5c46e6f4c50431d038e29002dc61d2e5ef6d9f8eca5af1c5e71b0aa8f5L1037-R1037))
*  Raise compiler error for unsupported hash statements in `stmt.v` instead of printing warning ([link](https://github.com/vlang/v/pull/19508/files?diff=unified&w=0#diff-3a07656e079e507a2d92b0d449fd0a69f87b102356e78c48e22a10152dfa9befL78-R82))
