### PR TITLE
all: implement `@VCURRENTHASH` to replace `C.V_CURRENT_COMMIT_HASH`

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5533,7 +5533,7 @@ that are substituted at compile time:
 - `@VEXEROOT`  => will be substituted with the *folder*,
   where the V executable is (as a string).
 - `@VHASH`  => replaced with the shortened commit hash of the V compiler (as a string).
-- `@VCURRENTHASH` => replaced with the shortened commot hash of the V compiler (as a string). This hash changes, when `./v self` is called.
+- `@VCURRENTHASH` => Similar to `@VHASH`, except this changes, when `./v self` is called.
 - `@VMOD_FILE` => replaced with the contents of the nearest v.mod file (as a string).
 - `@VMODROOT` => will be substituted with the *folder*,
   where the nearest v.mod file is (as a string).

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5533,7 +5533,9 @@ that are substituted at compile time:
 - `@VEXEROOT`  => will be substituted with the *folder*,
   where the V executable is (as a string).
 - `@VHASH`  => replaced with the shortened commit hash of the V compiler (as a string).
-- `@VCURRENTHASH` => Similar to `@VHASH`, except this changes, when `./v self` is called.
+- `@VCURRENTHASH` => Similar to `@VHASH`, but changes when the compiler is
+  recompiled on a different commit (after local modifications, or after 
+  using git bisect etc).
 - `@VMOD_FILE` => replaced with the contents of the nearest v.mod file (as a string).
 - `@VMODROOT` => will be substituted with the *folder*,
   where the nearest v.mod file is (as a string).

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5533,6 +5533,7 @@ that are substituted at compile time:
 - `@VEXEROOT`  => will be substituted with the *folder*,
   where the V executable is (as a string).
 - `@VHASH`  => replaced with the shortened commit hash of the V compiler (as a string).
+- `@VCURRENTHASH` => replaced with the shortened commot hash of the V compiler (as a string). This hash changes, when `./v self` is called.
 - `@VMOD_FILE` => replaced with the contents of the nearest v.mod file (as a string).
 - `@VMODROOT` => will be substituted with the *folder*,
   where the nearest v.mod file is (as a string).

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -50,7 +50,7 @@ fn panic_debug(line_no int, file string, mod string, fn_name string, s string) {
 		eprintln(' function: ${fn_name}()')
 		eprintln('  message: ${s}')
 		eprintln('     file: ${file}:${line_no}')
-		eprintln('   v hash: ${@VHASH}')
+		eprintln('   v hash: ${@VHASH}') // TODO: use @VCURRENTHASH when bootstrapped
 		eprintln('=========================================')
 		$if native {
 			C.exit(1) // TODO: native backtraces
@@ -104,7 +104,7 @@ pub fn panic(s string) {
 	} $else {
 		eprint('V panic: ')
 		eprintln(s)
-		eprintln('v hash: ${@VHASH}')
+		eprintln('v hash: ${@VHASH}') // TODO: use @VCURRENTHASH when bootstrapped
 		$if native {
 			C.exit(1) // TODO: native backtraces
 		} $else $if exit_after_panic_message ? {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -130,6 +130,8 @@ mut:
 	goto_labels       map[string]ast.GotoLabel // to check for unused goto labels
 	enum_data_type    ast.Type
 	fn_return_type    ast.Type
+
+	v_current_commit_hash string // same as V_CURRENT_COMMIT_HASH
 }
 
 pub fn new_checker(table &ast.Table, pref_ &pref.Preferences) &Checker {
@@ -142,6 +144,7 @@ pub fn new_checker(table &ast.Table, pref_ &pref.Preferences) &Checker {
 		pref: pref_
 		timers: util.new_timers(should_print: timers_should_print, label: 'checker')
 		match_exhaustive_cutoff_limit: pref_.checker_match_exhaustive_cutoff_limit
+		v_current_commit_hash: version.githash(pref_.building_v)
 	}
 }
 
@@ -3363,6 +3366,9 @@ fn (mut c Checker) at_expr(mut node ast.AtExpr) ast.Type {
 		}
 		.vhash {
 			node.val = version.vhash()
+		}
+		.v_current_hash {
+			node.val = c.v_current_commit_hash
 		}
 		.vmod_file {
 			// cache the vmod content, do not read it many times

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -282,8 +282,9 @@ fn (e Eval) error(msg string) {
 }
 
 fn (e Eval) panic(s string) {
+	commithash := unsafe { tos5(&char(C.V_CURRENT_COMMIT_HASH)) }
 	eprintln('V panic: ${s}')
-	eprintln('V hash: ${@VCURRENTHASH}')
+	eprintln('V hash: ${commithash}')
 	e.print_backtrace()
 	exit(1)
 }

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -282,9 +282,8 @@ fn (e Eval) error(msg string) {
 }
 
 fn (e Eval) panic(s string) {
-	commithash := unsafe { tos5(&char(C.V_CURRENT_COMMIT_HASH)) }
 	eprintln('V panic: ${s}')
-	eprintln('V hash: ${commithash}')
+	eprintln('V hash: ${@VCURRENTHASH}')
 	e.print_backtrace()
 	exit(1)
 }

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -247,7 +247,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) string 
 	// deps_resolved := graph.resolve()
 	// nodes := deps_resolved.nodes
 
-	mut out := g.definitions.str() + g.hashes()
+	mut out := g.definitions.str()
 	if !g.pref.output_es5 {
 		out += '\nlet wasmExportObject;\n'
 
@@ -489,12 +489,6 @@ pub fn (mut g JsGen) init() {
 	g.definitions.writeln('function BreakException() {}')
 	g.definitions.writeln('function ContinueException() {}')
 	g.definitions.writeln('function ReturnException(val) { this.val = val; }')
-}
-
-pub fn (g JsGen) hashes() string {
-	mut res := '// V_COMMIT_HASH ${version.vhash()}\n'
-	res += '// V_CURRENT_COMMIT_HASH ${version.githash(g.pref.building_v)}\n'
-	return res
 }
 
 [noreturn]

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -5,7 +5,6 @@ import v.ast
 import v.token
 import v.pref
 import v.util
-import v.util.version
 import v.depgraph
 import encoding.base64
 import v.gen.js.sourcemap

--- a/vlib/v/gen/native/expr.v
+++ b/vlib/v/gen/native/expr.v
@@ -8,6 +8,9 @@ import v.util
 
 fn (mut g Gen) expr(node ast.Expr) {
 	match node {
+		ast.AtExpr {
+			g.allocate_string(g.comptime_at(node), 3, .rel32)
+		}
 		ast.ParExpr {
 			g.expr(node.expr)
 		}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -352,6 +352,7 @@ fn (mut p Parser) at() ast.AtExpr {
 		'@FILE_LINE' { token.AtKind.file_path_line_nr }
 		'@LOCATION' { token.AtKind.location }
 		'@COLUMN' { token.AtKind.column_nr }
+		'@VCURRENTHASH' { token.AtKind.v_current_hash }
 		'@VHASH' { token.AtKind.vhash }
 		'@VMOD_FILE' { token.AtKind.vmod_file }
 		'@VEXE' { token.AtKind.vexe_path }

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -188,7 +188,8 @@ pub const (
 		.unsigned_right_shift_assign]
 
 	valid_at_tokens = ['@VROOT', '@VMODROOT', '@VEXEROOT', '@FN', '@METHOD', '@MOD', '@STRUCT',
-		'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@FILE_LINE', '@LOCATION']
+		'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@FILE_LINE',
+		'@LOCATION']
 
 	token_str       = build_token_str()
 

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -173,6 +173,7 @@ pub enum AtKind {
 	line_nr
 	column_nr
 	vhash
+	v_current_hash
 	vmod_file
 	vmodroot_path
 	vroot_path // obsolete
@@ -187,7 +188,7 @@ pub const (
 		.unsigned_right_shift_assign]
 
 	valid_at_tokens = ['@VROOT', '@VMODROOT', '@VEXEROOT', '@FN', '@METHOD', '@MOD', '@STRUCT',
-		'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VMOD_FILE', '@FILE_LINE', '@LOCATION']
+		'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@FILE_LINE', '@LOCATION']
 
 	token_str       = build_token_str()
 


### PR DESCRIPTION
This PR implements `@VCURRENTHASH` as a replacement of the `C.V_CURRENT_COMMITH_HASH` macro. This is necessary to use this functionality on other backends than `cgen`.

To finish this transition, the following changes have to be applied _after_ merging this PR to remove `V_CURRENT_COMMIT_HASH`:

```diff
diff --git a/vlib/builtin/builtin.c.v b/vlib/builtin/builtin.c.v
index a7107b415..28c370987 100644
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -50,7 +50,7 @@ fn panic_debug(line_no int, file string, mod string, fn_name string, s string) {
 		eprintln(' function: ${fn_name}()')
 		eprintln('  message: ${s}')
 		eprintln('     file: ${file}:${line_no}')
-		eprintln('   v hash: ${@VHASH}') // TODO: use @VCURRENTHASH when bootstrapped
+		eprintln('   v hash: ${@VCURRENTHASH}')
 		eprintln('=========================================')
 		$if native {
 			C.exit(1) // TODO: native backtraces
@@ -104,7 +104,7 @@ pub fn panic(s string) {
 	} $else {
 		eprint('V panic: ')
 		eprintln(s)
-		eprintln('v hash: ${@VHASH}') // TODO: use @VCURRENTHASH when bootstrapped
+		eprintln('v hash: ${@VCURRENTHASH}')
 		$if native {
 			C.exit(1) // TODO: native backtraces
 		} $else $if exit_after_panic_message ? {
diff --git a/vlib/v/gen/c/cgen.v b/vlib/v/gen/c/cgen.v
index f0c407b68..c6d8f20a5 100644
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -748,7 +748,6 @@ pub fn (mut g Gen) gen_file() {
 
 pub fn (g &Gen) hashes() string {
 	mut res := c_commit_hash_default.replace('@@@', version.vhash())
-	res += c_current_commit_hash_default.replace('@@@', version.githash(g.pref.building_v))
 	return res
 }
 
diff --git a/vlib/v/gen/c/cheaders.v b/vlib/v/gen/c/cheaders.v
index 47ca63cf5..8e582c3ac 100644
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -14,13 +14,6 @@ const c_commit_hash_default = '
 #endif
 '
 
-// V_CURRENT_COMMIT_HASH is updated, when V is rebuilt inside a git repo.
-const c_current_commit_hash_default = '
-#ifndef V_CURRENT_COMMIT_HASH
-	#define V_CURRENT_COMMIT_HASH "@@@"
-#endif
-'
-
 const c_concurrency_helpers = '
 typedef struct __shared_map __shared_map;
 struct __shared_map {
diff --git a/vlib/v/util/version/version.v b/vlib/v/util/version/version.v
index c4ff3fc6d..9cf736f58 100644
--- a/vlib/v/util/version/version.v
+++ b/vlib/v/util/version/version.v
@@ -75,11 +75,6 @@ pub fn githash(should_get_from_filesystem bool) string {
 		}
 		break
 	}
-	mut buf := [50]u8{}
-	buf[0] = 0
-	unsafe {
-		bp := &buf[0]
-		C.snprintf(&char(bp), 50, c'%s', C.V_CURRENT_COMMIT_HASH)
-		return tos_clone(bp)
-	}
+	
+	return @VCURRENTHASH
 }
diff --git a/vlib/v/eval/eval.v b/vlib/v/eval/eval.v
index 14ed1f348..c55abd9db 100644
--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -282,9 +282,8 @@ fn (e Eval) error(msg string) {
 }
 
 fn (e Eval) panic(s string) {
-	commithash := unsafe { tos5(&char(C.V_CURRENT_COMMIT_HASH)) }
 	eprintln('V panic: ${s}')
-	eprintln('V hash: ${commithash}')
+	eprintln('V hash: ${@VCURRENTHASH}')
 	e.print_backtrace()
 	exit(1)
 }
```