### PR TITLE
checker: fix fn call with option call argument in autofree mode (fix #19495)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -531,7 +531,8 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 			if arg.typ != ast.string_type {
 				continue
 			}
-			if arg.expr in [ast.Ident, ast.StringLiteral, ast.SelectorExpr] {
+			if arg.expr in [ast.Ident, ast.StringLiteral, ast.SelectorExpr]
+				|| (arg.expr is ast.CallExpr && arg.expr.or_block.kind != .absent) {
 				// Simple expressions like variables, string literals, selector expressions
 				// (`x.field`) can't result in allocations and don't need to be assigned to
 				// temporary vars.


### PR DESCRIPTION
This PR fix fn call with option call argument in autofree mode (fix #19495).

```v
import os

fn maybe_error() !string {
	return 'string'
}

fn return_string_result() ! {
	os.write_file('./test.txt', maybe_error()!)!
}

fn main() {
	return_string_result() or {
		println(err.msg())
		exit(1)
	}
}

PS D:\Test\v\tt1> v -autofree run .

```