### PR TITLE
all: finish bootstrapping of `@VCURRENTHASH`

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -50,7 +50,7 @@ fn panic_debug(line_no int, file string, mod string, fn_name string, s string) {
 		eprintln(' function: ${fn_name}()')
 		eprintln('  message: ${s}')
 		eprintln('     file: ${file}:${line_no}')
-		eprintln('   v hash: ${@VHASH}') // TODO: use @VCURRENTHASH when bootstrapped
+		eprintln('   v hash: ${@VCURRENTHASH}')
 		eprintln('=========================================')
 		$if native {
 			C.exit(1) // TODO: native backtraces
@@ -104,7 +104,7 @@ pub fn panic(s string) {
 	} $else {
 		eprint('V panic: ')
 		eprintln(s)
-		eprintln('v hash: ${@VHASH}') // TODO: use @VCURRENTHASH when bootstrapped
+		eprintln('v hash: ${@VCURRENTHASH}')
 		$if native {
 			C.exit(1) // TODO: native backtraces
 		} $else $if exit_after_panic_message ? {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -135,7 +135,7 @@ mut:
 	fn_return_type    ast.Type
 	orm_table_fields  map[string][]ast.StructField // known table structs
 	//
-	v_current_commit_hash string // same as V_CURRENT_COMMIT_HASH
+	v_current_commit_hash string // same as old C.V_CURRENT_COMMIT_HASH
 }
 
 pub fn new_checker(table &ast.Table, pref_ &pref.Preferences) &Checker {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -748,7 +748,6 @@ pub fn (mut g Gen) gen_file() {
 
 pub fn (g &Gen) hashes() string {
 	mut res := c_commit_hash_default.replace('@@@', version.vhash())
-	res += c_current_commit_hash_default.replace('@@@', version.githash(g.pref.building_v))
 	return res
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -747,8 +747,7 @@ pub fn (mut g Gen) gen_file() {
 }
 
 pub fn (g &Gen) hashes() string {
-	mut res := c_commit_hash_default.replace('@@@', version.vhash())
-	return res
+	return c_commit_hash_default.replace('@@@', version.vhash())
 }
 
 pub fn (mut g Gen) init() {

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -14,13 +14,6 @@ const c_commit_hash_default = '
 #endif
 '
 
-// V_CURRENT_COMMIT_HASH is updated, when V is rebuilt inside a git repo.
-const c_current_commit_hash_default = '
-#ifndef V_CURRENT_COMMIT_HASH
-	#define V_CURRENT_COMMIT_HASH "@@@"
-#endif
-'
-
 const c_concurrency_helpers = '
 typedef struct __shared_map __shared_map;
 struct __shared_map {

--- a/vlib/v/util/version/version.v
+++ b/vlib/v/util/version/version.v
@@ -75,11 +75,6 @@ pub fn githash(should_get_from_filesystem bool) string {
 		}
 		break
 	}
-	mut buf := [50]u8{}
-	buf[0] = 0
-	unsafe {
-		bp := &buf[0]
-		C.snprintf(&char(bp), 50, c'%s', C.V_CURRENT_COMMIT_HASH)
-		return tos_clone(bp)
-	}
+
+	return @VCURRENTHASH
 }


### PR DESCRIPTION
This PR finishes the bootstrapping process of `@VCURRENTHASH` as described in #19514
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa0334d</samp>

Replaced the C macro `@VHASH` with the V builtin constant `@VCURRENTHASH` to get the current V commit hash. This affects the files `vlib/builtin/builtin.c.v`, `vlib/v/checker/checker.v`, `vlib/v/gen/c/cgen.v`, `vlib/v/gen/c/cheaders.v`, and `vlib/v/util/version/version.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa0334d</samp>

*  Replace the `@VHASH` macro with the `@VCURRENTHASH` constant that holds the current V commit hash ([link](https://github.com/vlang/v/pull/19517/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL53-R53), [link](https://github.com/vlang/v/pull/19517/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL107-R107), [link](https://github.com/vlang/v/pull/19517/files?diff=unified&w=0#diff-34bca265fd348cec97ab74a486d0da428446a3ea2ec43fe5415ec341fe8bcc16L78-R79))
*  Remove the unused C macro and the code that generated it in the C header ([link](https://github.com/vlang/v/pull/19517/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL751), [link](https://github.com/vlang/v/pull/19517/files?diff=unified&w=0#diff-9f4960eeea6c8145477b33c711e42120d2877a4eb7cc16a93e00bd32b21281b2L17-L23))
*  Rename the `v_current_commit_hash` field of the `Checker` struct and update the comment ([link](https://github.com/vlang/v/pull/19517/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L138-R138))
