### PR TITLE
cgen: don't subtract null ptr in `__offsetof`

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -360,7 +360,7 @@ const c_common_macros = '
 
 // for __offset_of
 #ifndef __offsetof
-	#define __offsetof(PTYPE,FIELDNAME) ((size_t)((char *)&((PTYPE *)0)->FIELDNAME - (char *)0))
+	#define __offsetof(PTYPE,FIELDNAME) ((size_t)(&((PTYPE *)0)->FIELDNAME))
 #endif
 
 #define OPTION_CAST(x) (x)


### PR DESCRIPTION
The suggestion would fix e.g. #19222

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9f7a0a</samp>

Simplified the `__offsetof` macro in `vlib/v/gen/c/cheaders.v` to avoid undefined behavior and improve portability and readability of the generated C code.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9f7a0a</samp>

*  Simplify `__offsetof` macro to use address-of operator instead of null pointer subtraction ([link](https://github.com/vlang/v/pull/19520/files?diff=unified&w=0#diff-9f4960eeea6c8145477b33c711e42120d2877a4eb7cc16a93e00bd32b21281b2L363-R363)). This avoids potential undefined behavior and improves portability and readability of the generated C code.
