### PR TITLE
Update ROADMAP.md for solving #18754

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,7 @@
 - [x] Lambdas: `a.sort(|a, b| a > b)`
 - [ ] Custom attributes.
 - [ ] `arr.first() or { }` like `arr[0] or { }`
+- [ ]  64/32 bit int depending on arch (will remove array.len limitation on 64 bit systems)
 
 ## [Version 1.0]
 


### PR DESCRIPTION
 Adding a 64/32 bit integer selection depending on the system's architecture can help address the issue of map size limitations on 32-bit systems while providing better support for 64-bit systems. This approach allows your software to adapt to the available system resources, potentially improving its scalability and performance. Make sure to document this change in your roadmap.md file for transparency and communication with your development team.

