### PR TITLE
math: add missing docstrings for math.log_gamma_sign and for the complex.complex constructor function

### DIFF
--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -12,7 +12,7 @@ pub mut:
 	im f64
 }
 
-// complex returns a Complex Struct with the given `re` and `im`
+// complex returns a complex struct with the given `re` and `im`
 pub fn complex(re f64, im f64) Complex {
 	return Complex{re, im}
 }

--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -31,6 +31,8 @@ pub fn (c Complex) abs() f64 {
 	return math.hypot(c.re, c.im)
 }
 
+// Returns the modulus value of the complex number
+// mod(x + iy) = √( x^2 + y^2 )
 pub fn (c Complex) mod() f64 {
 	return c.abs()
 }

--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -12,7 +12,7 @@ pub mut:
 	im f64
 }
 
-// Return a Complex Struct with re and im
+// complex returns a Complex Struct with the given `re` and `im`
 pub fn complex(re f64, im f64) Complex {
 	return Complex{re, im}
 }
@@ -31,8 +31,7 @@ pub fn (c Complex) abs() f64 {
 	return math.hypot(c.re, c.im)
 }
 
-// Returns the modulus value of the complex number
-// mod(x + iy) = √( x^2 + y^2 )
+// mod returns the modulus value of `c`
 pub fn (c Complex) mod() f64 {
 	return c.abs()
 }

--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -12,6 +12,7 @@ pub mut:
 	im f64
 }
 
+// Return a Complex Struct with re and im
 pub fn complex(re f64, im f64) Complex {
 	return Complex{re, im}
 }

--- a/vlib/math/gamma.v
+++ b/vlib/math/gamma.v
@@ -134,11 +134,13 @@ pub fn gamma(a f64) f64 {
 // log_gamma(-integer) = +inf
 // log_gamma(-inf) = -inf
 // log_gamma(nan) = nan
+// uses log_gamma_sign internally
 pub fn log_gamma(x f64) f64 {
 	y, _ := log_gamma_sign(x)
 	return y
 }
 
+// log_gamma_sign returns the natural logarithm and sign (-1 or +1) of Gamma(x)
 pub fn log_gamma_sign(a f64) (f64, int) {
 	mut x := a
 	ymin := 1.461632144968362245

--- a/vlib/math/gamma.v
+++ b/vlib/math/gamma.v
@@ -134,7 +134,6 @@ pub fn gamma(a f64) f64 {
 // log_gamma(-integer) = +inf
 // log_gamma(-inf) = -inf
 // log_gamma(nan) = nan
-// uses log_gamma_sign internally
 pub fn log_gamma(x f64) f64 {
 	y, _ := log_gamma_sign(x)
 	return y


### PR DESCRIPTION
Part of #7047 