### PR TITLE
wasm: fix building the wasm backend with the new `int` behaving like `isize`

### DIFF
--- a/examples/wasm_codegen/add.v
+++ b/examples/wasm_codegen/add.v
@@ -4,8 +4,8 @@ fn main() {
 	mut m := wasm.Module{}
 	mut func := m.new_function('add', [.i32_t, .i32_t], [.i32_t])
 	{
-		func.local_get(0)
-		func.local_get(1)
+		func.local_get(i32(0))
+		func.local_get(i32(1))
 		func.add(.i32_t)
 	}
 	m.commit(func, true) // `export: true`

--- a/examples/wasm_codegen/control_flow.v
+++ b/examples/wasm_codegen/control_flow.v
@@ -13,7 +13,7 @@ fn main() {
 		blk := bif.c_block([], [])
 		{
 			// if argument[0], break
-			bif.local_get(0)
+			bif.local_get(i32(0))
 			bif.c_br_if(blk)
 			// loc = i32.const 11
 			bif.i32_const(11)
@@ -27,7 +27,7 @@ fn main() {
 	m.commit(bif, true)
 	mut ifexpr := m.new_function('if_expr', [.i32_t], [.i64_t])
 	{
-		ifexpr.local_get(0)
+		ifexpr.local_get(i32(0))
 		if_blk := ifexpr.c_if([], [.i64_t])
 		{
 			ifexpr.i64_const(5000)

--- a/examples/wasm_codegen/factorial.v
+++ b/examples/wasm_codegen/factorial.v
@@ -4,7 +4,7 @@ fn main() {
 	mut m := wasm.Module{}
 	mut fac := m.new_function('fac', [.i64_t], [.i64_t])
 	{
-		fac.local_get(0)
+		fac.local_get(i32(0))
 		fac.eqz(.i64_t)
 		bif := fac.c_if([], [.i64_t])
 		{
@@ -13,10 +13,10 @@ fn main() {
 		fac.c_else(bif)
 		{
 			{
-				fac.local_get(0)
+				fac.local_get(i32(0))
 			}
 			{
-				fac.local_get(0)
+				fac.local_get(i32(0))
 				fac.i64_const(1)
 				fac.sub(.i64_t)
 				fac.call('fac')

--- a/examples/wasm_codegen/functions.v
+++ b/examples/wasm_codegen/functions.v
@@ -6,11 +6,11 @@ fn main() {
 		.f32_t,
 	])
 	{
-		pyth.local_get(0)
-		pyth.local_get(0)
+		pyth.local_get(i32(0))
+		pyth.local_get(i32(0))
 		pyth.mul(.f32_t)
-		pyth.local_get(1)
-		pyth.local_get(1)
+		pyth.local_get(i32(1))
+		pyth.local_get(i32(1))
 		pyth.mul(.f32_t)
 		pyth.add(.f32_t)
 		pyth.sqrt(.f32_t)
@@ -19,7 +19,7 @@ fn main() {
 	m.commit(pyth, true)
 	mut test := m.new_function('test', [.f32_t], [.f64_t])
 	{
-		test.local_get(0)
+		test.local_get(i32(0))
 		test.f32_const(10.0)
 		test.call('pythagoras')
 		test.cast(.f32_t, true, .f64_t)

--- a/examples/wasm_codegen/hello_wasi.v
+++ b/examples/wasm_codegen/hello_wasi.v
@@ -17,7 +17,7 @@ fn main() {
 		func.i32_const(1) // stdout
 		func.i32_const(0) // *iovs
 		func.i32_const(1) // 1 iov
-		func.i32_const(-1) // *retptrs
+		func.i32_const(i32(-1)) // *retptrs
 		func.call_import('wasi_unstable', 'fd_write')
 		func.drop()
 		func.i32_const(0)

--- a/examples/wasm_codegen/memory.v
+++ b/examples/wasm_codegen/memory.v
@@ -4,7 +4,7 @@ fn main() {
 	mut m := wasm.Module{}
 	mut mtest := m.new_function('mload', [.i32_t], [.i32_t])
 	{
-		mtest.local_get(0)
+		mtest.local_get(i32(0))
 		mtest.load(.i32_t, 2, 0)
 	}
 	m.commit(mtest, false)

--- a/vlib/v/gen/wasm/ops.v
+++ b/vlib/v/gen/wasm/ops.v
@@ -35,9 +35,9 @@ pub fn (mut g Gen) get_wasm_type(typ_ ast.Type) wasm.ValType {
 	}
 	if typ in ast.number_type_idxs {
 		return match typ {
-			ast.isize_type_idx, ast.usize_type_idx, ast.i8_type_idx, ast.u8_type_idx,
-			ast.char_type_idx, ast.rune_type_idx, ast.i16_type_idx, ast.u16_type_idx,
-			ast.int_type_idx, ast.u32_type_idx {
+			ast.isize_type_idx, ast.usize_type_idx, ast.char_type_idx, ast.rune_type_idx,
+			ast.i8_type_idx, ast.u8_type_idx, ast.i16_type_idx, ast.u16_type_idx, ast.i32_type_idx,
+			ast.u32_type_idx, ast.int_type_idx {
 				wasm.ValType.i32_t
 			}
 			ast.i64_type_idx, ast.u64_type_idx {

--- a/vlib/wasm/constant.v
+++ b/vlib/wasm/constant.v
@@ -12,6 +12,8 @@ pub fn constexpr_value[T](v T) ConstExpression {
 	$if T is i64 {
 		expr.i64_const(v)
 	} $else $if T is $int {
+		expr.i32_const(i32(v))
+	} $else $if T is i32 {
 		expr.i32_const(v)
 	} $else $if T is f32 {
 		expr.f32_const(v)
@@ -154,7 +156,7 @@ pub fn (mut expr ConstExpression) ref_func(name string) {
 	expr.code << 0xD2 // ref.func
 	expr.call_patches << FunctionCallPatch{
 		name: name
-		pos: expr.code.len
+		pos: i32(expr.code.len)
 	}
 }
 
@@ -166,6 +168,6 @@ pub fn (mut expr ConstExpression) ref_func_import(mod string, name string) {
 	expr.call_patches << ImportCallPatch{
 		mod: mod
 		name: name
-		pos: expr.code.len
+		pos: i32(expr.code.len)
 	}
 }

--- a/vlib/wasm/encoding.v
+++ b/vlib/wasm/encoding.v
@@ -63,20 +63,20 @@ fn push_f64(mut buf []u8, v f64) {
 	buf << u8(rv >> u32(56))
 }
 
-fn (mod &Module) get_function_idx(patch CallPatch) int {
-	mut idx := -1
+fn (mod &Module) get_function_idx(patch CallPatch) i32 {
+	mut idx := i32(-1)
 
 	match patch {
 		FunctionCallPatch {
 			ftt := mod.functions[patch.name] or {
 				panic('called function ${patch.name} does not exist')
 			}
-			idx = ftt.idx + mod.fn_imports.len
+			idx = ftt.idx + i32(mod.fn_imports.len)
 		}
 		ImportCallPatch {
 			for fnidx, c in mod.fn_imports {
 				if c.mod == patch.mod && c.name == patch.name {
-					idx = fnidx
+					idx = i32(fnidx)
 					break
 				}
 			}
@@ -93,18 +93,18 @@ fn (mut mod Module) patch(ft Function) {
 	mut ptr := 0
 
 	for patch in ft.patches {
-		mut idx := 0
+		mut idx := i32(0)
 		match patch {
 			CallPatch {
 				idx = mod.get_function_idx(patch)
 			}
 			FunctionGlobalPatch {
-				idx = mod.global_imports.len + patch.idx
+				idx = i32(mod.global_imports.len) + patch.idx
 			}
 		}
 		mod.buf << ft.code[ptr..patch.pos]
 		mod.u32(u32(idx))
-		ptr = patch.pos
+		ptr = int(patch.pos)
 	}
 
 	mod.buf << ft.code[ptr..]
@@ -215,7 +215,7 @@ pub fn (mut mod Module) compile() []u8 {
 
 						mod.buf << gt.init.code[ptr..patch.pos]
 						mod.u32(u32(idx))
-						ptr = patch.pos
+						ptr = int(patch.pos)
 					}
 					mod.buf << gt.init.code[ptr..]
 				}
@@ -238,7 +238,7 @@ pub fn (mut mod Module) compile() []u8 {
 				lsz++
 				mod.name(ft.export_name or { ft.name })
 				mod.buf << 0x00 // function
-				mod.u32(u32(ft.idx + mod.fn_imports.len))
+				mod.u32(u32(ft.idx + i32(mod.fn_imports.len)))
 			}
 			if memory := mod.memory {
 				if memory.export {
@@ -267,7 +267,7 @@ pub fn (mut mod Module) compile() []u8 {
 		ftt := mod.functions[start] or { panic('start function ${start} does not exist') }
 		tpatch := mod.start_section(.start_section)
 		{
-			mod.u32(u32(ftt.idx + mod.fn_imports.len))
+			mod.u32(u32(ftt.idx + i32(mod.fn_imports.len)))
 		}
 		mod.end_section(tpatch)
 	}

--- a/vlib/wasm/functions.v
+++ b/vlib/wasm/functions.v
@@ -7,13 +7,13 @@ struct ImportCallPatch {
 	mod  string
 	name string
 mut:
-	pos int
+	pos i32
 }
 
 struct FunctionCallPatch {
 	name string
 mut:
-	pos int
+	pos i32
 }
 
 type CallPatch = FunctionCallPatch | ImportCallPatch
@@ -21,7 +21,7 @@ type CallPatch = FunctionCallPatch | ImportCallPatch
 struct FunctionGlobalPatch {
 	idx GlobalIndex
 mut:
-	pos int
+	pos i32
 }
 
 type FunctionPatch = CallPatch | FunctionGlobalPatch
@@ -32,11 +32,11 @@ struct FunctionLocal {
 }
 
 pub struct Function {
-	tidx int
-	idx  int
+	tidx i32
+	idx  i32
 mut:
 	patches []FunctionPatch // sorted
-	label   int
+	label   i32
 	export  bool
 	mod     &Module = unsafe { nil }
 	code    []u8

--- a/vlib/wasm/instructions.v
+++ b/vlib/wasm/instructions.v
@@ -25,11 +25,11 @@ fn (mut func Function) blocktype(typ FuncType) {
 	func.code << leb128.encode_i32(tidx)
 }
 
-pub type PatchPos = int
+pub type PatchPos = i32
 
 // patch_pos returns a `PatchPos` for use with `patch`.
 pub fn (func Function) patch_pos() PatchPos {
-	return func.code.len
+	return i32(func.code.len)
 }
 
 // patch "patches" the code generated starting from the last `patch_pos` call in `begin` to `loc`.
@@ -54,14 +54,14 @@ pub fn (mut func Function) patch(loc PatchPos, begin PatchPos) {
 	assert loc < begin
 
 	v := func.code[begin..].clone()
-	func.code.trim(begin)
+	func.code.trim(int(begin))
 	func.code.insert(int(loc), v)
 
 	for mut patch in func.patches {
 		if patch.pos >= begin {
 			patch.pos -= begin - loc
 		} else if patch.pos >= loc {
-			patch.pos += func.code.len - begin
+			patch.pos += i32(func.code.len) - begin
 		}
 	}
 
@@ -92,7 +92,7 @@ pub fn (mut func Function) new_local(v ValType) LocalIndex {
 	func.locals << FunctionLocal{
 		typ: v
 	}
-	return ret
+	return i32(ret)
 }
 
 // new_local_named creates a function local with a name and returns it's index.
@@ -104,7 +104,7 @@ pub fn (mut func Function) new_local_named(v ValType, name string) LocalIndex {
 		typ: v
 		name: name
 	}
-	return ret
+	return i32(ret)
 }
 
 // i32_const places a constant i32 value on the stack.
@@ -166,7 +166,7 @@ pub fn (mut func Function) global_get(global GlobalIndices) {
 		GlobalIndex {
 			func.patches << FunctionGlobalPatch{
 				idx: global
-				pos: func.code.len
+				pos: i32(func.code.len)
 			}
 		}
 		GlobalImportIndex {
@@ -183,7 +183,7 @@ pub fn (mut func Function) global_set(global GlobalIndices) {
 		GlobalIndex {
 			func.patches << FunctionGlobalPatch{
 				idx: global
-				pos: func.code.len
+				pos: i32(func.code.len)
 			}
 		}
 		GlobalImportIndex {
@@ -884,7 +884,7 @@ pub fn (mut func Function) nop() {
 	func.code << 0x01
 }
 
-pub type LabelIndex = int
+pub type LabelIndex = i32
 
 // c_block creates a label that can later be branched out of with `c_br` and `c_br_if`.
 // Blocks are strongly typed, you must supply a list of types for `parameters` and `results`.
@@ -963,7 +963,7 @@ pub fn (mut func Function) call(name string) {
 	func.code << 0x10 // call
 	func.patches << CallPatch(FunctionCallPatch{
 		name: name
-		pos: func.code.len
+		pos: i32(func.code.len)
 	})
 }
 
@@ -975,13 +975,13 @@ pub fn (mut func Function) call_import(mod string, name string) {
 	func.patches << CallPatch(ImportCallPatch{
 		mod: mod
 		name: name
-		pos: func.code.len
+		pos: i32(func.code.len)
 	})
 }
 
 // load loads a value with type `typ` from memory.
 // WebAssembly instruction: `i32|i64|f32|f64.load`.
-pub fn (mut func Function) load(typ NumType, align int, offset int) {
+pub fn (mut func Function) load(typ NumType, align i32, offset i32) {
 	match typ {
 		.i32_t { func.code << 0x28 } // i32.load
 		.i64_t { func.code << 0x29 } // i64.load
@@ -994,7 +994,7 @@ pub fn (mut func Function) load(typ NumType, align int, offset int) {
 
 // load8 loads a 8-bit value with type `typ` with respect to `is_signed` from memory.
 // WebAssembly instructions: `i32|i64.load8_s`, `i32|i64.load8_u`.
-pub fn (mut func Function) load8(typ NumType, is_signed bool, align int, offset int) {
+pub fn (mut func Function) load8(typ NumType, is_signed bool, align i32, offset i32) {
 	assert typ in [.i32_t, .i64_t]
 
 	match typ {
@@ -1020,7 +1020,7 @@ pub fn (mut func Function) load8(typ NumType, is_signed bool, align int, offset 
 
 // load16 loads a 16-bit value with type `typ` with respect to `is_signed` from memory.
 // WebAssembly instructions: `i32|i64.load16_s`, `i32|i64.load16_u`.
-pub fn (mut func Function) load16(typ NumType, is_signed bool, align int, offset int) {
+pub fn (mut func Function) load16(typ NumType, is_signed bool, align i32, offset i32) {
 	assert typ in [.i32_t, .i64_t]
 
 	match typ {
@@ -1046,7 +1046,7 @@ pub fn (mut func Function) load16(typ NumType, is_signed bool, align int, offset
 
 // load32_i64 loads a 32-bit value of type i64 with respect to `is_signed` from memory.
 // WebAssembly instructions: `i64.load32_s`, `i64.load32_u`.
-pub fn (mut func Function) load32_i64(is_signed bool, align int, offset int) {
+pub fn (mut func Function) load32_i64(is_signed bool, align i32, offset i32) {
 	if is_signed {
 		func.code << 0x34 // i64.load32_s
 	} else {
@@ -1058,7 +1058,7 @@ pub fn (mut func Function) load32_i64(is_signed bool, align int, offset int) {
 
 // store stores a value with type `typ` into memory.
 // WebAssembly instruction: `i32|i64|f32|f64.store`.
-pub fn (mut func Function) store(typ NumType, align int, offset int) {
+pub fn (mut func Function) store(typ NumType, align i32, offset i32) {
 	match typ {
 		.i32_t { func.code << 0x36 } // i32.store
 		.i64_t { func.code << 0x37 } // i64.store
@@ -1071,7 +1071,7 @@ pub fn (mut func Function) store(typ NumType, align int, offset int) {
 
 // store8 stores a 8-bit value with type `typ` into memory.
 // WebAssembly instruction: `i32|i64.store8`.
-pub fn (mut func Function) store8(typ NumType, align int, offset int) {
+pub fn (mut func Function) store8(typ NumType, align i32, offset i32) {
 	assert typ in [.i32_t, .i64_t]
 
 	match typ {
@@ -1085,7 +1085,7 @@ pub fn (mut func Function) store8(typ NumType, align int, offset int) {
 
 // store16 stores a 16-bit value with type `typ` into memory.
 // WebAssembly instruction: `i32|i64.store16`.
-pub fn (mut func Function) store16(typ NumType, align int, offset int) {
+pub fn (mut func Function) store16(typ NumType, align i32, offset i32) {
 	assert typ in [.i32_t, .i64_t]
 
 	match typ {
@@ -1099,7 +1099,7 @@ pub fn (mut func Function) store16(typ NumType, align int, offset int) {
 
 // store16 stores a 32-bit value of type i64 into memory.
 // WebAssembly instruction: `i64.store32`.
-pub fn (mut func Function) store32_i64(align int, offset int) {
+pub fn (mut func Function) store32_i64(align i32, offset i32) {
 	func.code << 0x3E // i64.store32
 	func.u32(u32(align))
 	func.u32(u32(offset))
@@ -1170,7 +1170,7 @@ pub fn (mut func Function) ref_func(name string) {
 	func.code << 0xD2 // ref.func
 	func.patches << CallPatch(FunctionCallPatch{
 		name: name
-		pos: func.code.len
+		pos: i32(func.code.len)
 	})
 }
 
@@ -1182,6 +1182,6 @@ pub fn (mut func Function) ref_func_import(mod string, name string) {
 	func.patches << CallPatch(ImportCallPatch{
 		mod: mod
 		name: name
-		pos: func.code.len
+		pos: i32(func.code.len)
 	})
 }

--- a/vlib/wasm/module.v
+++ b/vlib/wasm/module.v
@@ -92,7 +92,7 @@ struct GlobalImport {
 struct FunctionImport {
 	mod  string
 	name string
-	tidx int
+	tidx i32
 }
 
 struct Memory {
@@ -103,15 +103,15 @@ struct Memory {
 }
 
 struct DataSegment {
-	idx  ?int
+	idx  ?i32
 	data []u8
 	name ?string
 }
 
-pub type LocalIndex = int
-pub type GlobalIndex = int
-pub type GlobalImportIndex = int
-pub type DataSegmentIndex = int
+pub type LocalIndex = i32
+pub type GlobalIndex = i32
+pub type GlobalImportIndex = i32
+pub type DataSegmentIndex = i32
 
 pub struct FuncType {
 pub:
@@ -120,7 +120,7 @@ pub:
 	name       ?string
 }
 
-fn (mut mod Module) new_functype(ft FuncType) int {
+fn (mut mod Module) new_functype(ft FuncType) i32 {
 	// interns existing types
 	mut idx := mod.functypes.index(ft)
 
@@ -129,14 +129,14 @@ fn (mut mod Module) new_functype(ft FuncType) int {
 		mod.functypes << ft
 	}
 
-	return idx
+	return i32(idx)
 }
 
 // new_function creates a function struct.
 pub fn (mut mod Module) new_function(name string, parameters []ValType, results []ValType) Function {
 	assert name !in mod.functions.keys()
 
-	idx := mod.functions.len
+	idx := i32(mod.functions.len)
 	tidx := mod.new_functype(FuncType{parameters, results, none})
 
 	return Function{
@@ -160,7 +160,7 @@ pub fn (mut mod Module) new_debug_function(name string, typ FuncType, argument_n
 	return Function{
 		name: name
 		tidx: tidx
-		idx: idx
+		idx: i32(idx)
 		mod: mod
 		locals: argument_names.map(FunctionLocal{ name: it }) // specifying it's ValType doesn't matter
 	}
@@ -225,14 +225,14 @@ pub fn (mut mod Module) commit(func Function, export bool) {
 
 // new_data_segment inserts a new data segment at the memory index `pos`.
 // `name` is optional, it is used for debug info.
-pub fn (mut mod Module) new_data_segment(name ?string, pos int, data []u8) DataSegmentIndex {
+pub fn (mut mod Module) new_data_segment(name ?string, pos i32, data []u8) DataSegmentIndex {
 	len := mod.segments.len
 	mod.segments << DataSegment{
-		idx: pos
+		idx: i32(pos)
 		data: data
 		name: name
 	}
-	return len
+	return i32(len)
 }
 
 // new_passive_data_segment inserts a new passive data segment.
@@ -255,7 +255,7 @@ pub fn (mut mod Module) new_global(name string, export bool, typ ValType, is_mut
 		export: export
 		init: init
 	}
-	return len
+	return i32(len)
 }
 
 // new_global_import imports a new global into the current module and returns it's index.
@@ -270,7 +270,7 @@ pub fn (mut mod Module) new_global_import(modn string, name string, typ ValType,
 		typ: typ
 		is_mut: is_mut
 	}
-	return len
+	return i32(len)
 }
 
 // assign_global_init assigns a global with the constant expression `init`.


### PR DESCRIPTION
Fixes:
`./v should-compile-all examples/wasm_codegen/` 
`./v -b wasm -os browser examples/wasm/mandelbrot/mandelbrot.v`
`./v -b wasm examples/wasm/hello_world.v`
`./v -b wasm examples/wasm/functions.v`