### PR TITLE
Fixed typo in flag.v

### DIFF
--- a/vlib/cli/flag.v
+++ b/vlib/cli/flag.v
@@ -21,11 +21,11 @@ pub mut:
 	name string
 	// Like short option
 	abbrev string
-	// Desciption of flag
+	// Description of flag
 	description string
 	// If the flag is added to this command and to all subcommands
 	global bool
-	// If flag is requierd
+	// If flag is required
 	required bool
 	// Default value if no value provide by command line
 	default_value []string = []


### PR DESCRIPTION
`cli: fix the typo in flag.v`

This PR fixes the typo in `cli` module docs i.e.
cli/flag.v:24: Desciption -> Description
cli/flag.v:28: requierd -> required

Fixes issue #19531

