### PR TITLE
benchmark: extend time measure

### DIFF
--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -129,8 +129,12 @@ pub fn (mut b Benchmark) measure(label string) i64 {
 	return res
 }
 
-// step_measure pushes the current time spent doing `label` to `measured_steps`, since the benchmark was started, or since its last call
-pub fn (mut b Benchmark) step_measure(label string) i64 {
+// record_measure stores the current time doing `label`, since the benchmark 
+// was started, or since the last call to `b.record_measure`.
+// It is similar to `b.measure`, but unlike it, will not print the measurement
+// immediately, just record it for later. You can call `b.all_recorded_measures` 
+// to retrieve all measures stored by `b.record_measure` calls.
+pub fn (mut b Benchmark) record_measure(label string) i64 {
 	b.ok()
 	res := b.step_timer.elapsed().microseconds()
 	b.measured_steps << b.step_message_with_label(benchmark.b_spent, 'in ${label}')
@@ -223,8 +227,9 @@ pub fn (b &Benchmark) total_message(msg string) string {
 	return tmsg
 }
 
-// total_measured_message returns a string with all the recorded measures with step_measure
-pub fn (b &Benchmark) total_measured_message() string {
+// all_recorded_measures returns a string, that contains all the recorded 
+// measure messages, done by individual calls to `b.record_measure`.
+pub fn (b &Benchmark) all_recorded_measures() string {
 	return b.measured_steps.join_lines()
 }
 

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -25,6 +25,7 @@ pub mut:
 	cstep           int
 	bok             string
 	bfail           string
+	measured_steps  []string
 }
 
 // new_benchmark returns a `Benchmark` instance on the stack.
@@ -128,6 +129,15 @@ pub fn (mut b Benchmark) measure(label string) i64 {
 	return res
 }
 
+// step_measure pushes the current time spent doing `label` to `measured_steps`, since the benchmark was started, or since its last call
+pub fn (mut b Benchmark) step_measure(label string) i64 {
+	b.ok()
+	res := b.step_timer.elapsed().microseconds()
+	b.measured_steps << b.step_message_with_label(benchmark.b_spent, 'in ${label}')
+	b.step()
+	return res
+}
+
 // step_message_with_label_and_duration returns a string describing the current step.
 pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg string, sduration time.Duration) string {
 	timed_line := b.tdiff_in_ms(msg, sduration.microseconds())
@@ -211,6 +221,11 @@ pub fn (b &Benchmark) total_message(msg string) string {
 	}
 	tmsg += '${b.ntotal} total. ${term.colorize(term.bold, 'Runtime:')} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.\n'
 	return tmsg
+}
+
+// total_measured_message returns a string with all the recorded measures with step_measure
+pub fn (b &Benchmark) total_measured_message() string {
+	return b.measured_steps.join_lines()
 }
 
 // total_duration returns the duration in ms.

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -129,10 +129,10 @@ pub fn (mut b Benchmark) measure(label string) i64 {
 	return res
 }
 
-// record_measure stores the current time doing `label`, since the benchmark 
+// record_measure stores the current time doing `label`, since the benchmark
 // was started, or since the last call to `b.record_measure`.
 // It is similar to `b.measure`, but unlike it, will not print the measurement
-// immediately, just record it for later. You can call `b.all_recorded_measures` 
+// immediately, just record it for later. You can call `b.all_recorded_measures`
 // to retrieve all measures stored by `b.record_measure` calls.
 pub fn (mut b Benchmark) record_measure(label string) i64 {
 	b.ok()
@@ -227,7 +227,7 @@ pub fn (b &Benchmark) total_message(msg string) string {
 	return tmsg
 }
 
-// all_recorded_measures returns a string, that contains all the recorded 
+// all_recorded_measures returns a string, that contains all the recorded
 // measure messages, done by individual calls to `b.record_measure`.
 pub fn (b &Benchmark) all_recorded_measures() string {
 	return b.measured_steps.join_lines()

--- a/vlib/benchmark/benchmark_test.v
+++ b/vlib/benchmark/benchmark_test.v
@@ -7,7 +7,7 @@ fn test_measure() {
 	x := b.measure('sleeping') // returns microseconds
 	flush_stdout()
 	assert x > 150_000
-	assert x < 300_000
+	// assert x < 800_000 // this can be much longer on a slow CI runner
 }
 
 fn test_record_measure() {
@@ -17,7 +17,7 @@ fn test_record_measure() {
 	time.sleep(100 * time.millisecond)
 	x := b.record_measure('sleeping 1')
 	assert x > 50_000
-	assert x < 200_000
+	// assert x < 200_000
 	flush_stdout()
 	//
 	println('step 2')
@@ -25,7 +25,7 @@ fn test_record_measure() {
 	time.sleep(150 * time.millisecond)
 	y := b.record_measure('sleeping 2')
 	assert y > 100_000
-	assert y < 200_000
+	// assert y < 200_000
 	flush_stdout()
 	//
 	res := b.all_recorded_measures()

--- a/vlib/benchmark/benchmark_test.v
+++ b/vlib/benchmark/benchmark_test.v
@@ -1,0 +1,38 @@
+import time
+import benchmark
+
+fn test_measure() {
+	mut b := benchmark.start()
+	time.sleep(200 * time.millisecond)
+	x := b.measure('sleeping') // returns microseconds
+	flush_stdout()
+	assert x > 150_000
+	assert x < 300_000
+}
+
+fn test_record_measure() {
+	mut b := benchmark.start()
+	println('step 1')
+	flush_stdout()
+	time.sleep(100 * time.millisecond)
+	x := b.record_measure('sleeping 1')
+	assert x > 50_000
+	assert x < 200_000
+	flush_stdout()
+	//
+	println('step 2')
+	flush_stdout()
+	time.sleep(150 * time.millisecond)
+	y := b.record_measure('sleeping 2')
+	assert y > 100_000
+	assert y < 200_000
+	flush_stdout()
+	//
+	res := b.all_recorded_measures()
+	println('All recorded measurements:')
+	println(res)
+	flush_stdout()
+	assert res.contains('ms in sleeping 1')
+	assert res.contains('ms in sleeping 1')
+	assert res.contains('SPENT')
+}


### PR DESCRIPTION
## Done:

The current implementation of `benchmark::measure` always prints on call, but in some cases, the user may want to print the summary at the end of all calls to `benchmark::measure` 

#### Example:

```v
fn main() {
      mut b := benchmark.start()
      time.sleep(1500 * time.millisecond)
      println('Doing job')
      b.measure('Job')
      println('Another')
      time.sleep(500 * time.millisecond)
      b.measure('Another')
}
```

The example above returns the following output:
```
Doing job
 SPENT  1500.158 ms in Job
Another
 SPENT   500.123 ms in Another
```

The PR implements two new functions:
- **step_measure:** same as `measure`, but stores the time spent message in `Benchmark::measure_steps`
- **total_measured_message:** generates a string with all the measured messages stored in `Benchmark::measure_steps`

#### Example:

```v
module main

import time
import benchmark

fn main() {
	mut b := benchmark.start()
	time.sleep(1500 * time.millisecond)
	println('Doing job')
	b.step_measure('Job')
	println('Another')
	time.sleep(500 * time.millisecond)
	b.step_measure('Another')
	println(b.total_measured_message())
}

```

The example above returns the following output:
```
Doing job
Another
 SPENT  1500.176 ms in Job
 SPENT   500.127 ms in Another
```