### PR TITLE
ci: update c2v workflow, translate doom on macOS

### DIFF
--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -3,63 +3,64 @@ name: C2V apps
 on:
   push:
     paths-ignore:
-      - "**.md"
-      - "**.yml"
-      - "doc/**"
-      - "examples/**"
-      - "tutorials/**"
+      - '**.md'
+      - '**.yml'
+      - '!**/c2v_ci.yml'
+      - 'doc/**'
+      - 'examples/**'
+      - 'tutorials/**'
   pull_request:
     paths-ignore:
-      - "**.md"
-      - "**.yml"
-      - "doc/**"
-      - "examples/**"
-      - "tutorials/**"
+      - '**.md'
+      - '**.yml'
+      - '!**/c2v_ci.yml'
+      - 'doc/**'
+      - 'examples/**'
+      - 'tutorials/**'
 
 concurrency:
   group: build-c2v-apps-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  doom-compiles:
-    runs-on: ubuntu-20.04
+  build-doom:
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
-    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build V
         run: make && ./v symlink -githubci
-
-      - name: Build C2V
+      - name: Install C2V
         run: |
-          echo "Clone C2V"
-          mkdir -p ~/code/
-          git clone --depth 1 https://github.com/vlang/c2v ~/code/c2v
-          ln -s ~/code/c2v ~/.vmodules/c2v
-          v -g ~/.vmodules/c2v/
-          ~/.vmodules/c2v/c2v || true
-
-      - name: Install Doom Dependencies
+          v install --git https://github.com/vlang/c2v
+          v -g ~/.vmodules/c2v/ || true
+      - name: Install dependencies
         run: |
-          sudo apt-get update -y -qq
-          sudo apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
-
+          if [ "${{ runner.os }}" == "Linux" ]; then
+            sudo apt update -y -qq
+            sudo apt install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
+          else
+            brew install sdl2 sdl2_mixer sdl2_net libpng libsamplerate
+          fi
       - name: Build original Chocolate Doom
         run: |
           git clone --quiet --depth 1 https://github.com/vlang/doom ~/code/doom
           cd ~/code/doom/chocolate-doom
           cmake -DCMAKE_BUILD_TYPE=Debug .
           make chocolate-doom
-
       - name: Translate the whole game in project/folder mode and compile it
         run: |
-          cd ~/code/doom
           touch ~/DOOM1.WAD
           WAD_FILE=~/DOOM1.WAD ~/code/doom/build_whole_project.sh
 
-  doom-regressions:
-    runs-on: ubuntu-20.04
+  test-regression:
     if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:
       VFLAGS: -cc tcc
@@ -67,56 +68,42 @@ jobs:
       LIBGL_ALWAYS_SOFTWARE: true
       VTMP: /tmp
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build V
         run: make && ./v symlink -githubci
-
-      - name: Setup dependencies
+      - name: Install C2V
         run: |
-          sudo apt-get update -y -qq
-
+          v install --git https://github.com/vlang/c2v
+          v -g ~/.vmodules/c2v/ || true
+      - name: Install dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
           # c2v / DOOM dependencies
-          sudo apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
-
           # vgret dependencies
           # imagemagick              : convert, mogrify, import
           # xvfb                     : For starting X11 Virtual FrameBuffers
           # openimageio-tools        : idiff
           # libgl1-mesa-dri          : For headless rendering / software DRI driver (LIBGL_ALWAYS_SOFTWARE=true)
           # freeglut3-dev            : Fixes graphic apps compilation with tcc
-          sudo apt-get install imagemagick openimageio-tools freeglut3-dev libgl1-mesa-dri xvfb xsel xclip
-
+          sudo apt install imagemagick openimageio-tools freeglut3-dev libgl1-mesa-dri xvfb xsel xclip
+      - name: Setup test tools
+        run: |
           # Fetch the free ~4MB DOOM1.WAD from the link at https://doomwiki.org/wiki/DOOM1.WAD
           wget https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad -O ~/doom1.wad
-
           # Get imgur upload script
           wget https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
           chmod +x ./imgur.sh
-
           # Get regression images to test against
           git clone https://github.com/Larpon/doom-regression-images
-
-      - name: Build C2V
-        run: |
-          echo "Clone C2V"
-          mkdir -p ~/code/
-          git clone --depth 1 https://github.com/vlang/c2v ~/code/c2v
-          ln -s ~/code/c2v ~/.vmodules/c2v
-          v -g ~/.vmodules/c2v/
-          ~/.vmodules/c2v/c2v || true
-
       - name: Build original Chocolate Doom
         run: |
           git clone --quiet --depth 1 https://github.com/vlang/doom ~/code/doom
           cd ~/code/doom/chocolate-doom
           cmake -DCMAKE_BUILD_TYPE=Debug .
           make chocolate-doom
-
       - name: Translate the whole game in project/folder mode
-        run: |
-          cd ~/code/doom
-          WAD_FILE=~/doom1.wad ~/code/doom/build_whole_project.sh
-
+        run: WAD_FILE=~/doom1.wad ~/code/doom/build_whole_project.sh
       - name: Sample and compare with vgret
         id: compare
         continue-on-error: true
@@ -124,7 +111,6 @@ jobs:
           Xvfb $DISPLAY -screen 0 800x600x24 -fbdir /var/tmp/ &
           sleep 1; while [ ! -f /var/tmp/Xvfb_screen0 ]; do sleep 0.5; done # give xvfb time to start, even on slow CI runs
           sleep 1; v gret -r ~/code/doom -t ./doom-regression-images/vgret.doom.toml -v ./doom-sample_images ./doom-regression-images
-
       - name: Upload regression to imgur
         if: steps.compare.outcome != 'success'
         run: |

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -73,14 +73,6 @@ jobs:
           ../v -autofree .
           ../v -prod .
           cd ..
-      # - name: Test c2v
-      #   run: |
-      #     git clone --depth 1 https://github.com/vlang/c2v
-      #     cd c2v && ../v -o c2v .
-      #     ../v .
-      #     ../v run tests/run_tests.vsh
-      #     ../v -experimental -w c2v_test.v
-      #     cd ..
       - name: Build V UI examples
         run: |
           git clone --depth 1 https://github.com/vlang/ui


### PR DESCRIPTION
Adds doom building on macos to c2v workflow. 
Removes commented out c2v test step from `macos_ci.yml`. 
Makes minor cleanups.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfddc5b</samp>

This pull request refactors and optimizes the GitHub Actions workflows for testing the `c2v` module and the V compiler on macOS. It separates the `c2v` tests into a dedicated workflow file, `c2v_ci.yml`, and adds cross-platform support for it. It also removes the redundant `c2v` test step from the `macos_ci.yml` workflow file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfddc5b</samp>

*  Rename and update build and test jobs for c2v in `.github/workflows/c2v_ci.yml` ([link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L6-R19), [link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L24-R47), [link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L53-R60), [link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L70-R79), [link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L114-R103))
* Remove test c2v step from `.github/workflows/macos_ci.yml` ([link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-0d0e3285f3847a9675e66e29e83eec87ffa82aa20b21000dc96db6c14b739bafL76-L83))
* Update checkout action to v4 in `.github/workflows/c2v_ci.yml` ([link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L70-R79))
* Remove empty line in `.github/workflows/c2v_ci.yml` ([link](https://github.com/vlang/v/pull/19562/files?diff=unified&w=0#diff-a2524e92d4f9a8ac5a55396d42c4aa22afbe2d610bf79c832eae366bd9148c86L127))
