### PR TITLE
ci: delegate time zone testing into `time_ci.yml`

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -55,16 +55,6 @@ jobs:
         run: ./v test-self
       # - name: Self tests (-cstrict)
       #   run: V_CI_CSTRICT=1 ./v -cstrict test-self
-      - name: Test time functions in a timezone UTC-12
-        run: TZ=Etc/GMT+12 ./v test vlib/time/
-      - name: Test time functions in a timezone UTC-3
-        run: TZ=Etc/GMT+3 ./v test vlib/time/
-      - name: Test time functions in a timezone UTC+3
-        run: TZ=Etc/GMT-3 ./v test vlib/time/
-      - name: Test time functions in a timezone UTC+12
-        run: TZ=Etc/GMT-12 ./v test vlib/time/
-      - name: Test time functions in a timezone using daylight saving (Europe/Paris)
-        run: TZ=Europe/Paris ./v test vlib/time/
       - name: Build examples
         run: ./v -W build-examples
       - name: Build v tools

--- a/.github/workflows/time_ci.yml
+++ b/.github/workflows/time_ci.yml
@@ -1,0 +1,58 @@
+name: Time CI
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+      - '!**/time_ci.yml'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+      - '!**/time_ci.yml'
+
+concurrency:
+  group: time-ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  test-nix:
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: make -j4
+      - name: Test time functions in a timezone UTC-12
+        run: TZ=Etc/GMT+12 ./v test vlib/time/
+      - name: Test time functions in a timezone UTC-3
+        run: TZ=Etc/GMT+3 ./v test vlib/time/
+      - name: Test time functions in a timezone UTC+3
+        run: TZ=Etc/GMT-3 ./v test vlib/time/
+      - name: Test time functions in a timezone UTC+12
+        run: TZ=Etc/GMT-12 ./v test vlib/time/
+      - name: Test time functions in a timezone using daylight saving (Europe/Paris)
+        run: TZ=Europe/Paris ./v test vlib/time/
+
+  test-windows:
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: .\make.bat
+      - name: Test time functions in a timezone UTC-12
+        run: tzutil /s "Dateline Standard Time" && ./v test vlib/time/
+      - name: Test time functions in a timezone UTC-3
+        run: tzutil /s "Greenland Standard Time" && ./v test vlib/time/
+      - name: Test time functions in a timezone UTC+3
+        run: tzutil /s "Russian Standard Time" && ./v test vlib/time/
+      - name: Test time functions in a timezone UTC+12
+        run: tzutil /s "New Zealand Standard Time" && ./v test vlib/time/
+      - name: Test time functions in a timezone using daylight saving (Europe/Paris)
+        run: tzutil /s "W. Europe Standard Time" && ./v test vlib/time/

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -43,22 +43,6 @@ jobs:
       #   run: .\v.exe test-all
       - name: Build option_test.v with -autofree
         run: .\v.exe -autofree vlib/v/tests/option_test.v
-      - name: Test time functions in a timezone UTC-12
-        run: |
-          tzutil /s "Dateline Standard Time"
-          ./v test vlib/time/
-      - name: Test time functions in a timezone UTC-3
-        run: |
-          tzutil /s "Greenland Standard Time"
-          ./v test vlib/time/
-      - name: Test time functions in a timezone UTC+3
-        run: |
-          tzutil /s "Russian Standard Time"
-          ./v test vlib/time/
-      - name: Test time functions in a timezone UTC+12
-        run: |
-          tzutil /s "New Zealand Standard Time"
-          ./v test vlib/time/
       - name: Test v->js
         run: ./v -o hi.js examples/hello_v_js.v && node hi.js
       - name: Test v binaries


### PR DESCRIPTION
Uses dedicated workflow for time zone testing.
Adds time zone test on macOS, extends windows test to also include Europe.
Takes off about 3 minutes of current windows_ci runs:

![Screenshot_20231014_021654](https://github.com/vlang/v/assets/34311583/65dfee2d-d98d-4f8d-a6b5-9427cfb892bf)


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98a525f</samp>

The pull request refactors the GitHub Actions workflows for testing the time functions in different timezones. It creates a new workflow file `time_ci.yml` that runs the tests on both Linux and Windows platforms, and removes the redundant steps from `linux_ci.yml` and `windows_ci.yml`. This improves the modularity and efficiency of the testing process.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98a525f</samp>

*  Add a new workflow file `time_ci.yml` to run tests for time functions in different timezones on Linux and Windows ([link](https://github.com/vlang/v/pull/19563/files?diff=unified&w=0#diff-d05874baac413125f244537ff87f82f270c61a1fa9ac648e020a789bf643dbfcR1-R58))
* Remove the timezone tests from the existing workflow files `linux_ci.yml` and `windows_ci.yml` to avoid duplication and improve modularity ([link](https://github.com/vlang/v/pull/19563/files?diff=unified&w=0#diff-28752c3107c2643416798f1cca9a77ce5909e9cf98b4e4921ffce60e92b18d05L58-L67), [link](https://github.com/vlang/v/pull/19563/files?diff=unified&w=0#diff-51e29cc7ce6055cb886ed66ba289976529842254a5477e5edc392fa3de360b25L46-L61))
