### PR TITLE
examples: Update net_udp_server_and_client.v

### DIFF
--- a/examples/net_udp_server_and_client.v
+++ b/examples/net_udp_server_and_client.v
@@ -12,7 +12,7 @@ fn main() {
 	mut buf := []u8{len: 100}
 	if is_server {
 		println('UDP echo server, listening for udp packets on port: ${port}')
-			mut c := net.listen_udp('0.0.0.0:${port}')!
+		mut c := net.listen_udp('0.0.0.0:${port}')!
 		for {
 			read, addr := c.read(mut buf) or { continue }
 			println('received ${read} bytes from ${addr}')

--- a/examples/net_udp_server_and_client.v
+++ b/examples/net_udp_server_and_client.v
@@ -12,7 +12,7 @@ fn main() {
 	mut buf := []u8{len: 100}
 	if is_server {
 		println('UDP echo server, listening for udp packets on port: ${port}')
-		mut c := net.listen_udp(':${port}')!
+			mut c := net.listen_udp('0.0.0.0:${port}')!
 		for {
 			read, addr := c.read(mut buf) or { continue }
 			println('received ${read} bytes from ${addr}')
@@ -23,7 +23,7 @@ fn main() {
 		}
 	} else {
 		println('UDP client, sending packets to port: ${port}.\nType `exit` to exit.')
-		mut c := net.dial_udp('localhost:${port}')!
+		mut c := net.dial_udp('127.0.0.1:${port}')!
 		for {
 			mut line := os.input('client > ')
 			match line {


### PR DESCRIPTION
example didn't run in windows without explicit mention on ip and on windows v couldn't resolve localhost to 127.0.0.1



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ce02bb</samp>

Improved UDP examples by using explicit IP addresses. Changed `listen_udp` and `dial_udp` calls in `examples/net_udp_server_and_client.v` to avoid potential name resolution issues.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ce02bb</samp>

*  Make the UDP server listen on all interfaces and the UDP client use the loopback address ([link](https://github.com/vlang/v/pull/19564/files?diff=unified&w=0#diff-0279ccef1ed3b9ee024d567641eaa68e1b3bf5fe68606c88db3b556521fe12e8L15-R15), [link](https://github.com/vlang/v/pull/19564/files?diff=unified&w=0#diff-0279ccef1ed3b9ee024d567641eaa68e1b3bf5fe68606c88db3b556521fe12e8L26-R26))
