### PR TITLE
net.conv: added rfc9000 variable unsigned integer encoding

### DIFF
--- a/vlib/net/conv/conv.v
+++ b/vlib/net/conv/conv.v
@@ -124,15 +124,15 @@ pub fn u64tovarint(n u64) ![]u8 {
 		}
 	}
 	len := 1 << msb
-	mut result := []u8{len: len, cap: len}
+	mut result := []u8{len: len}
 	mut tn := n
 	for i in 0 .. len {
-		result[i] = u8(tn % 256)
+		result[len - 1 - i] = u8(tn % 256)
 		tn /= 256
 	}
-	result[len - 1] |= msb << 6
+	result[0] |= msb << 6
 
-	return result.reverse()
+	return result
 }
 
 // varinttou64 parses a variable length number from the start of the

--- a/vlib/net/conv/conv.v
+++ b/vlib/net/conv/conv.v
@@ -106,8 +106,8 @@ pub fn ntoh16(net u16) u16 {
 // can represent 0..1<<62
 
 // takes a u64 where n < 2^62 and returns a byte array
-pub fn u64tovlu62(n u64) ![]u8 {
-	if n < 1 << 62 {
+pub fn u64tovarint(n u64) ![]u8 {
+	if n > u64(1) << 62 {
 		return error('cannnot encode more than 2^62-1')
 	}
 	msb := match true {
@@ -137,7 +137,7 @@ pub fn u64tovlu62(n u64) ![]u8 {
 }
 
 // parses a variable length uint from start of the byte array, returns the number and len in bytes
-pub fn vlu62tou64(b []u8) !(u64, u8) {
+pub fn varinttou64(b []u8) !(u64, u8) {
 	if b.len == 0 {
 		return error('cannot parse vluint from empty byte array')
 	}

--- a/vlib/net/conv/conv.v
+++ b/vlib/net/conv/conv.v
@@ -101,11 +101,10 @@ pub fn ntoh16(net u16) u16 {
 	return hton16(net)
 }
 
-// variable length unsigned integer encoding from rfc9000 sec.16
-// short version -> len in [1,2,4,8] and first two msbs encodes the log2(len) of n
-// can represent 0..1<<62
-
-// takes a u64 where n < 2^62 and returns a byte array
+// u64tovarint converts the given 64 bit number `n`, where n < 2^62 to a byte array,
+// using the variable length unsigned integer encoding from:
+// https://datatracker.ietf.org/doc/html/rfc9000#section-16 .
+// The returned array length .len, will be in [1,2,4,8] .
 pub fn u64tovarint(n u64) ![]u8 {
 	if n > u64(1) << 62 {
 		return error('cannnot encode more than 2^62-1')
@@ -136,7 +135,9 @@ pub fn u64tovarint(n u64) ![]u8 {
 	return result.reverse()
 }
 
-// parses a variable length uint from start of the byte array, returns the number and len in bytes
+// varinttou64 parses a variable length number from the start of the
+// given byte array `b`. If it succeeds, it returns the decoded number,
+// and the length of the parsed byte span.
 pub fn varinttou64(b []u8) !(u64, u8) {
 	if b.len == 0 {
 		return error('cannot parse vluint from empty byte array')

--- a/vlib/net/conv/conv_test.v
+++ b/vlib/net/conv/conv_test.v
@@ -44,9 +44,9 @@ fn test_hton16_ntoh16() {
 }
 
 fn test_varinttou64_u64tovarint() {
-	b0 := conv2.u64tovarint(0) or { panic(err) }
+	b0 := conv.u64tovarint(0) or { panic(err) }
 	assert b0 == [u8(0)]
-	b1 := conv2.u64tovarint(1) or { panic(err) }
+	b1 := conv.u64tovarint(1) or { panic(err) }
 	assert b1 == [u8(1)]
 	mp := {
 		u64(128):         [u8(0b01000000), 0b10000000]
@@ -56,9 +56,9 @@ fn test_varinttou64_u64tovarint() {
 	}
 	for k, v in mp {
 		println('${k:b}:${v}')
-		n, len := conv2.varinttou64(v) or { panic(err) }
+		n, len := conv.varinttou64(v) or { panic(err) }
 		assert n == k
-		rn := conv2.u64tovarint(k) or { panic(err) }
+		rn := conv.u64tovarint(k) or { panic(err) }
 		assert rn == v
 	}
 }

--- a/vlib/net/conv/conv_test.v
+++ b/vlib/net/conv/conv_test.v
@@ -42,3 +42,11 @@ fn test_hton16_ntoh16() {
 		check(conv.hton16, conv.ntoh16, x)
 	}
 }
+
+// TODO: write tests ! v cannot find the new functions when trying to run tests
+// fn test_u64tovlu62_vlu62tou64() {
+// 	assert [u8(0)] == conv.u64tovlu62(0)
+// 	assert [u8(1)] == conv.u64tovlu62(1)
+// 	assert (0, 1) == conv.vlu62tou64([u8(0)])
+// 	assert (1, 1) == conv.vlu62tou64([u8(1)])
+// }

--- a/vlib/net/conv/conv_test.v
+++ b/vlib/net/conv/conv_test.v
@@ -43,10 +43,22 @@ fn test_hton16_ntoh16() {
 	}
 }
 
-// TODO: write tests ! v cannot find the new functions when trying to run tests
-// fn test_u64tovlu62_vlu62tou64() {
-// 	assert [u8(0)] == conv.u64tovlu62(0)
-// 	assert [u8(1)] == conv.u64tovlu62(1)
-// 	assert (0, 1) == conv.vlu62tou64([u8(0)])
-// 	assert (1, 1) == conv.vlu62tou64([u8(1)])
-// }
+fn test_varinttou64_u64tovarint() {
+	b0 := conv2.u64tovarint(0) or { panic(err) }
+	assert b0 == [u8(0)]
+	b1 := conv2.u64tovarint(1) or { panic(err) }
+	assert b1 == [u8(1)]
+	mp := {
+		u64(128):         [u8(0b01000000), 0b10000000]
+		1024:             [u8(0b01000100), 0b00000000]
+		0xffff:           [u8(0b10000000), 0, 0xff, 0xff]
+		u64(1) << 62 - 1: [u8(0xff), 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+	}
+	for k, v in mp {
+		println('${k:b}:${v}')
+		n, len := conv2.varinttou64(v) or { panic(err) }
+		assert n == k
+		rn := conv2.u64tovarint(k) or { panic(err) }
+		assert rn == v
+	}
+}

--- a/vlib/net/conv/conv_test.v
+++ b/vlib/net/conv/conv_test.v
@@ -44,9 +44,9 @@ fn test_hton16_ntoh16() {
 }
 
 fn test_varinttou64_u64tovarint() {
-	b0 := conv.u64tovarint(0) or { panic(err) }
+	b0 := conv.u64tovarint(0)!
 	assert b0 == [u8(0)]
-	b1 := conv.u64tovarint(1) or { panic(err) }
+	b1 := conv.u64tovarint(1)!
 	assert b1 == [u8(1)]
 	mp := {
 		u64(128):         [u8(0b01000000), 0b10000000]
@@ -56,9 +56,9 @@ fn test_varinttou64_u64tovarint() {
 	}
 	for k, v in mp {
 		println('${k:b}:${v}')
-		n, len := conv.varinttou64(v) or { panic(err) }
+		n, len := conv.varinttou64(v)!
 		assert n == k
-		rn := conv.u64tovarint(k) or { panic(err) }
+		rn := conv.u64tovarint(k)!
 		assert rn == v
 	}
 }


### PR DESCRIPTION
[rfc9000 sec-16](https://www.rfc-editor.org/rfc/rfc9000.html#section-16)

planning to implement quic in v while learning v 
this is a start
need help testing right now when i do v vlib/net/conv/conv_test.v or v test vlib/net/conv i'll get an error saying the new functions i declared do not exist !

i don't know why but i guess that v thinks i want to import the original net.conv and not the new one i modified
couldn't find a way to import module from current directory

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abf1bac</samp>

Add `conv` functions for variable length integer encoding and decoding as used in QUIC. Add a test function for the new `conv` functions in `conv_test.v`, but comment it out until the compiler issue is resolved.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at abf1bac</samp>

*  Add variable length integer encoding and decoding functions `varint_encode` and `varint_decode` to `conv.v` ([link](https://github.com/vlang/v/pull/19568/files?diff=unified&w=0#diff-e8475fdf90d528db59faad4c82916fbe194109ab9088e5cc6e7579b234d64f34R103-R155))
*  Add error handling and comments to explain the logic and assumptions of the encoding and decoding functions ([link](https://github.com/vlang/v/pull/19568/files?diff=unified&w=0#diff-e8475fdf90d528db59faad4c82916fbe194109ab9088e5cc6e7579b234d64f34R103-R155))
*  Add a commented-out test function `test_varint` to `conv_test.v` that intends to test the encoding and decoding functions, but is not working yet due to a compiler issue ([link](https://github.com/vlang/v/pull/19568/files?diff=unified&w=0#diff-26b18062fa89a723fde5ac67eee759be9f0ed1df6e63a01ad865ff28b40f1d36R45-R52))
*  Mark the test function with a TODO comment to indicate that it needs further work and debugging ([link](https://github.com/vlang/v/pull/19568/files?diff=unified&w=0#diff-26b18062fa89a723fde5ac67eee759be9f0ed1df6e63a01ad865ff28b40f1d36R45-R52))
