### PR TITLE
checker: allow casted integeral types in match ranges

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -166,6 +166,11 @@ fn (mut c Checker) get_comptime_number_value(mut expr ast.Expr) ?i64 {
 	if mut expr is ast.IntegerLiteral {
 		return expr.val.i64()
 	}
+	if mut expr is ast.CastExpr {
+		if mut expr.expr is ast.IntegerLiteral {
+			return expr.expr.val.i64()
+		}
+	}
 	if mut expr is ast.Ident {
 		has_expr_mod_in_name := expr.name.contains('.')
 		expr_name := if has_expr_mod_in_name { expr.name } else { '${expr.mod}.${expr.name}' }

--- a/vlib/v/checker/tests/match_cast_cond_not_same_range_cast_type_err.out
+++ b/vlib/v/checker/tests/match_cast_cond_not_same_range_cast_type_err.out
@@ -1,0 +1,10 @@
+vlib/v/checker/tests/match_cast_cond_not_same_range_cast_type_err.vv:7:2: error: the range type and the match condition type should match
+    5 | c := u8(3)
+    6 | match c {
+    7 |     a...b { println('1...5') }
+      |     ~~~~~
+    8 |     else { println('not 1...5') }
+    9 | }
+Details: 
+match condition type: u8
+          range type: u16

--- a/vlib/v/checker/tests/match_cast_cond_not_same_range_cast_type_err.vv
+++ b/vlib/v/checker/tests/match_cast_cond_not_same_range_cast_type_err.vv
@@ -1,0 +1,9 @@
+const (
+	a = u16(1)
+	b = u16(5)
+)
+c := u8(3)
+match c {
+	a...b { println('1...5') }
+	else { println('not 1...5') }
+}

--- a/vlib/v/checker/tests/match_ranges_not_same_cast_err.out
+++ b/vlib/v/checker/tests/match_ranges_not_same_cast_err.out
@@ -1,0 +1,10 @@
+vlib/v/checker/tests/match_ranges_not_same_cast_err.vv:7:2: error: the low and high parts of a range expression, should have matching types
+    5 | c := u16(3)
+    6 | match c {
+    7 |     a...b { println('1...5') }
+      |     ~~~~~
+    8 |     else { println('not 1...5') }
+    9 | }
+Details: 
+ low part type: u16
+high part type: u8

--- a/vlib/v/checker/tests/match_ranges_not_same_cast_err.vv
+++ b/vlib/v/checker/tests/match_ranges_not_same_cast_err.vv
@@ -1,0 +1,9 @@
+const (
+	a = u16(1)
+	b = u8(5)
+)
+c := u16(3)
+match c {
+	a...b { println('1...5') }
+	else { println('not 1...5') }
+}

--- a/vlib/v/tests/match_const_range_test.v
+++ b/vlib/v/tests/match_const_range_test.v
@@ -1,13 +1,16 @@
 const (
-	start        = 1
-	start_2      = 4
-	end          = 3
-	end_2        = 8
+	start           = 1
+	start_2         = 4
+	end             = 3
+	end_2           = 8
 	//
-	start_rune   = `a`
-	start_2_rune = `d`
-	end_rune     = `c`
-	end_2_rune   = `i`
+	start_rune      = `a`
+	start_2_rune    = `d`
+	end_rune        = `c`
+	end_2_rune      = `i`
+	//
+	start_cast_expr = u16(1)
+	end_cast_expr   = u16(5)
 )
 
 fn test_match_int_const_ranges() {
@@ -62,4 +65,14 @@ fn test_match_expr_rune_const_ranges() {
 		results << result
 	}
 	assert results == [1, 1, 1, 2, 2, 3, 3, 3, 3, 4, 4]
+}
+
+fn test_match_expr_integer_cast_const_ranges() {
+	c := u16(3)
+	match c {
+		start_cast_expr...end_cast_expr {
+			assert c == u16(3)
+		}
+		else {}
+	}
 }


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19571

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5353936</samp>

This pull request adds support for matching integer literals with different types in match conditions, and improves the error messages for invalid range expressions. It also adds tests for these features in `vlib/v/checker/tests` and `vlib/v/tests`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5353936</samp>

*  Add special case for cast expressions in match conditions ([link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-b3e9e13d82c234e7953e95b8321dd2f6475a017c1985da21bb49dc46898962bfR169-R173))
*  Add test function for matching cast expressions in `match_const_range_test.v` ([link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-e7e66d42bd45d5b3566ea36ecca9699974bda9bb96f9c126a24ca50c014c4416R69-R78))
   * Use constants defined in the same file ([link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-e7e66d42bd45d5b3566ea36ecca9699974bda9bb96f9c126a24ca50c014c4416L2-R13))
*  Add test files for checking error messages when match condition type and range type do not match ([link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-39deb0ad8e3356d46be510a30195a08e68c37275f8db4ccca80358bf0f5d9e0bR1-R10), [link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-017de643b84bfb88e905f2c63207319274c6a0456381dd5dac37cec1fd02e7ccR1-R9))
*  Add test files for checking error messages when low and high parts of range expression have different types ([link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-063fe692226006f77569d5f999daf60f664cc5906cb47592e35f65338b4ecc90R1-R10), [link](https://github.com/vlang/v/pull/19572/files?diff=unified&w=0#diff-e2d36012aec8c690e98004b7c4c2b853f4ec9eac78c4d4dc614efb0044bea460R1-R9))
