### PR TITLE
checker, builder, pref: support `-dump-defines -` to help explore all the available user and system defines for a given program

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -149,6 +149,9 @@ pub fn (mut b Builder) middle_stages() ! {
 	if b.pref.show_callgraph {
 		callgraph.show(mut b.table, b.pref, b.parsed_files)
 	}
+	if b.pref.dump_defines != '' {
+		b.dump_defines()
+	}
 }
 
 pub fn (mut b Builder) front_and_middle_stages(v_files []string) ! {

--- a/vlib/v/builder/dump_lists.v
+++ b/vlib/v/builder/dump_lists.v
@@ -24,3 +24,14 @@ fn dump_list(file_path string, list []string) {
 		}
 	}
 }
+
+pub fn (b &Builder) dump_defines() {
+	mut res := []string{}
+	for k, v in b.checker.ct_system_defines {
+		res << 'system,${k},${v}'
+	}
+	for k, v in b.checker.ct_user_defines {
+		res << 'user,${k},${v}'
+	}
+	dump_list(b.pref.dump_defines, res)
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -93,6 +93,8 @@ pub mut:
 	smartcast_mut_pos          token.Pos // match mut foo, if mut foo is Foo
 	smartcast_cond_pos         token.Pos // match cond
 	ct_cond_stack              []ast.Expr
+	ct_user_defines            map[string]ComptimeBranchSkipState
+	ct_system_defines          map[string]ComptimeBranchSkipState
 mut:
 	stmt_level int // the nesting level inside each stmts list;
 	// .stmt_level is used to check for `evaluated but not used` ExprStmts like `1 << 1`

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -278,6 +278,17 @@ see also `v help build`.
       Write all used V file paths used by the program in `file.txt`, one module per line.
       If `file.txt` is `-`, write to stdout instead.
 
+   -dump-defines file.txt
+      Write all system and user defines, that V knows about for the current program, one per line.
+      If `file.txt` is `-`, write to stdout instead.
+      Example sample of the content of that file:
+          system,linux,eval
+          system,amd64,eval
+          system,solaris,skip		  
+          system,solaris,skip		  
+          user,gcboehm,eval
+          user,gg_record_trace,skip
+
    -no-rsp
       By default, V passes all C compiler options to the backend C compiler
       in so called "response files" (https://gcc.gnu.org/wiki/Response_Files).

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -151,8 +151,9 @@ pub mut:
 	show_callgraph         bool   // -show-callgraph, print the program callgraph, in a Graphviz DOT format to stdout
 	show_depgraph          bool   // -show-depgraph, print the program module dependency graph, in a Graphviz DOT format to stdout
 	dump_c_flags           string // `-dump-c-flags file.txt` - let V store all C flags, passed to the backend C compiler in `file.txt`, one C flag/value per line.
-	dump_modules           string // `-dump-modules modules.txt` - let V store all V modules, that were used by the compiled program in `modules.txt`, one module per line.
+	dump_modules           string // `-dump-modules modules.txt` - let V store all V modules, that were used by the compiled program in `modules.txt`, one module per line.	
 	dump_files             string // `-dump-files files.txt` - let V store all V or .template file paths, that were used by the compiled program in `files.txt`, one path per line.
+	dump_defines           string // `-dump-defines defines.txt` - let V store all the defines that affect the current program and their values, one define per line + `,` + its value.
 	use_cache              bool   // when set, use cached modules to speed up subsequent compilations, at the cost of slower initial ones (while the modules are cached)
 	retry_compilation      bool = true // retry the compilation with another C compiler, if tcc fails.
 	use_os_system_to_run   bool   // when set, use os.system() to run the produced executable, instead of os.new_process; works around segfaults on macos, that may happen when xcode is updated
@@ -669,6 +670,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-dump-files' {
 				res.dump_files = cmdline.option(current_args, arg, '-')
+				i++
+			}
+			'-dump-defines' {
+				res.dump_defines = cmdline.option(current_args, arg, '-')
 				i++
 			}
 			'-experimental' {


### PR DESCRIPTION
Here is an example:
```
#0 02:53:20 ᛋ feature_dump_defines /v/vnew❱./v -dump-defines - examples/2048/
system,no_bounds_checking,skip
system,prealloc,skip
system,freestanding,skip
system,native,unknown
system,tinyc,eval
system,macos,skip
system,freebsd,skip
system,openbsd,skip
system,netbsd,skip
system,linux,eval
system,android,skip
system,glibc,unknown
system,vinix,skip
system,ios,skip
system,termux,skip
system,prod,skip
system,debug,skip
system,amd64,eval
system,arm64,skip
system,i386,skip
system,arm32,skip
system,windows,skip
system,solaris,skip
system,fast_math,unknown
system,x64,unknown
system,x32,unknown
system,dragonfly,skip
system,haiku,skip
system,qnx,skip
system,serenity,skip
system,darwin,skip
user,debug_strconv,skip
user,nofloat,skip
user,no_backtrace,skip
user,use_libbacktrace,skip
user,exit_after_panic_message,skip
user,panics_break_into_debugger,skip
user,bultin_writeln_should_write_at_once,skip
user,bultin_write_buf_to_fd_should_use_c_write,skip
user,trace_malloc,skip
user,vplayground,skip
user,gcboehm,eval
user,debug_malloc,skip
user,gcboehm_opt,eval
user,trace_realloc,skip
user,debug_realloc,skip
user,trace_vcalloc,skip
user,gcboehm_leak,skip
user,trace_memdup,skip
user,dynamic_boehm,skip
user,trace_vmemcpy,skip
user,trace_vmemmove,skip
user,trace_vmemcmp,skip
user,trace_vmemset,skip
user,trace_error,skip
user,trace_stbi_allocations,skip
user,emscripten,skip
user,no_sokol_app,skip
user,trace_sokol_memory,skip
user,trace_sokol_memory_salloc_backtrace,skip
user,trace_sokol_memory_sfree_backtrace,skip
user,trace_find_abs_path_of_executable,skip
user,debug_font,skip
user,gg_record,skip
user,show_fps,skip
user,gg_record_trace,skip
user,showfps,skip
#0 02:53:29 ᛋ feature_dump_defines /v/vnew❱
```
Note from the above, that the compiler's checker, knows that for example:
`no_sokol_app` was not passed, so code that is inside `$if no_sokol_app ? {}` will be skipped.
Note also `system,native,unknown`, which is indicative of a bug or not fully implemented feature, since the checker should be able to determine that we have not passed `-b native`, i.e. code like this `$if native {}` should be also skipped fully.
Same with `$if fast_math {}` which should have been also a skip, or `$if x32 {}` (because the current system is a 64 bit linux).