### PR TITLE
json2: add support for nested structs (fix #19549)

### DIFF
--- a/vlib/x/json2/decode_struct_test.v
+++ b/vlib/x/json2/decode_struct_test.v
@@ -31,6 +31,10 @@ mut:
 	val T
 }
 
+struct StructTypeSub {
+	test string
+}
+
 struct StructTypeOption[T] {
 mut:
 	val ?T
@@ -92,6 +96,13 @@ fn test_types() {
 		assert false
 	} else {
 		// dump(err)
+		assert true
+	}
+
+	assert json.decode[StructType[StructTypeSub]]('{"val": {"test": "test"}}')!.val.test == 'test'
+	if x := json.decode[StructType[StructTypeSub]]('{"val": {"invalid_field": "test"}}') {
+		assert false
+	} else {
 		assert true
 	}
 }

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -20,8 +20,13 @@ pub fn fast_raw_decode(src string) !Any {
 
 // decode is a generic function that decodes a JSON string into the target type.
 pub fn decode[T](src string) !T {
-	mut typ := T{}
 	res := raw_decode(src)!.as_map()
+	return decode_struct[T](T{}, res)
+}
+
+// decode_struct is a generic function that decodes a JSON map into the struct T.
+fn decode_struct[T](_ T, res map[string]Any) !T {
+	mut typ := T{}
 	$if T is $struct {
 		$for field in T.fields {
 			mut json_name := field.name
@@ -123,8 +128,8 @@ pub fn decode[T](src string) !T {
 					typ.$(field.name) = res[json_name]!.to_time()!
 				}
 			} $else $if field.is_array {
-				// typ.$(field.name) = res[field.name]!.arr()
 			} $else $if field.is_struct {
+				typ.$(field.name) = decode_struct(typ.$(field.name), res[field.name]!.as_map())!
 			} $else $if field.is_alias {
 			} $else $if field.is_map {
 			} $else {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 830bde7</samp>

edit: fixes #19549
Enhance and refactor struct decoding in `json2` module. Add more tests for nested structs in `vlib/x/json2/decode_struct_test.v` and extract a reusable `decode_struct` function in `vlib/x/json2/json2.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 830bde7</samp>

*  Refactor `decode` function to use `decode_struct` helper for structs ([link](https://github.com/vlang/v/pull/19579/files?diff=unified&w=0#diff-e353018721c33071f81c18deb7168684f13845b44768a9eac6ffaa953ef1be6fL23-R29))
*  Implement `decode_struct` function to handle nested structs recursively ([link](https://github.com/vlang/v/pull/19579/files?diff=unified&w=0#diff-e353018721c33071f81c18deb7168684f13845b44768a9eac6ffaa953ef1be6fL126-R132))
*  Add `StructTypeSub` type and test cases for decoding nested structs in `vlib/x/json2/decode_struct_test.v` ([link](https://github.com/vlang/v/pull/19579/files?diff=unified&w=0#diff-d30b0a2b4550f3959f2318d90fda115159fcfd05f2536819d5fe1d009221c104R34-R37), [link](https://github.com/vlang/v/pull/19579/files?diff=unified&w=0#diff-d30b0a2b4550f3959f2318d90fda115159fcfd05f2536819d5fe1d009221c104R101-R107))
