### PR TITLE
checker: disallow `none` as value type in map

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -354,6 +354,9 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 			if info.value_type.has_flag(.result) {
 				c.error('cannot use Result type as map value type', node.pos)
 			}
+			if info.value_type == ast.none_type {
+				c.error('cannot use `none` as map value type', node.pos)
+			}
 			val_sym := c.table.sym(info.value_type)
 			if val_sym.kind == .struct_ {
 				val_info := val_sym.info as ast.Struct

--- a/vlib/v/checker/tests/map_none_value_type_err.out
+++ b/vlib/v/checker/tests/map_none_value_type_err.out
@@ -1,0 +1,3 @@
+vlib/v/checker/tests/map_none_value_type_err.vv:1:6: error: cannot use `none` as map value type
+    1 | _ := map[int]none{}
+      |      ~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/map_none_value_type_err.vv
+++ b/vlib/v/checker/tests/map_none_value_type_err.vv
@@ -1,0 +1,1 @@
+_ := map[int]none{}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6af324a</samp>

Prevent using `none` as a map value type in the checker module and add a test case for it. This fixes a potential compiler error or runtime crash when using invalid map literals.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6af324a</samp>

* Add a check to prevent using `none` as a map value type and emit an error message ([link](https://github.com/vlang/v/pull/19582/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR357-R359))
* Add a test case to verify the error message for using `none` as a map value type ([link](https://github.com/vlang/v/pull/19582/files?diff=unified&w=0#diff-b216b66342f8c1dc51a2ae02eb1881c30dd2cab8c27bcf804f508e9e4fc1c6d9R1-R3), [link](https://github.com/vlang/v/pull/19582/files?diff=unified&w=0#diff-a4b9e34f5953b5de57e742139fa0b888873853b6f00088344b8e78b313319360R1))
