### PR TITLE
cgen: fix printing sort with compare (fix #19575)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -147,6 +147,7 @@ mut:
 	inside_lambda             bool
 	inside_cinit              bool
 	inside_casting_to_str     bool
+	inside_casting_to_int     bool
 	last_tmp_call_var         []string
 	loop_depth                int
 	ternary_names             map[string]string
@@ -4637,7 +4638,13 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 					g.write('&'.repeat(ptr_cnt))
 				}
 			}
-			g.expr(node.expr)
+			if g.table.unaliased_type(node.typ).is_int() {
+				g.inside_casting_to_int = true
+				g.expr(node.expr)
+				g.inside_casting_to_int = false
+			} else {
+				g.expr(node.expr)
+			}
 			if node.expr is ast.IntegerLiteral {
 				if node_typ in [ast.u64_type, ast.u32_type, ast.u16_type] {
 					if !node.expr.val.starts_with('-') {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1032,9 +1032,9 @@ fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
 // It handles auto dereferencing of variables, as well as automatic casting
 // (see Gen.expr_with_cast for more details)
 fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
-	needs_cast := node.left_type.is_number() && node.right_type.is_number() && !g.inside_return
-		&& node.op in [.plus, .minus, .mul, .div, .mod] && !(g.pref.translated
-		|| g.file.is_translated)
+	needs_cast := node.left_type.is_number() && node.right_type.is_number() && !(g.inside_return
+		|| g.inside_casting_to_int) && node.op in [.plus, .minus, .mul, .div, .mod]
+		&& !(g.pref.translated || g.file.is_translated)
 	if needs_cast {
 		typ_str := g.typ(node.promoted_type)
 		g.write('(${typ_str})(')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1032,7 +1032,7 @@ fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
 // It handles auto dereferencing of variables, as well as automatic casting
 // (see Gen.expr_with_cast for more details)
 fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
-	needs_cast := node.left_type.is_number() && node.right_type.is_number()
+	needs_cast := node.left_type.is_number() && node.right_type.is_number() && !g.inside_return
 		&& node.op in [.plus, .minus, .mul, .div, .mod] && !(g.pref.translated
 		|| g.file.is_translated)
 	if needs_cast {

--- a/vlib/v/slow_tests/inout/printing_sort_with_compare.out
+++ b/vlib/v/slow_tests/inout/printing_sort_with_compare.out
@@ -1,3 +1,6 @@
 A B 
 A B 
 A B C 
+A B 
+A B 
+A B C 

--- a/vlib/v/slow_tests/inout/printing_sort_with_compare.out
+++ b/vlib/v/slow_tests/inout/printing_sort_with_compare.out
@@ -1,0 +1,3 @@
+A B 
+A B 
+A B C 

--- a/vlib/v/slow_tests/inout/printing_sort_with_compare.vv
+++ b/vlib/v/slow_tests/inout/printing_sort_with_compare.vv
@@ -4,13 +4,29 @@ pub struct PageObject {
 	key []u8
 }
 
-fn compare_bytes(a []u8, b []u8) int {
+fn compare_bytes1(a []u8, b []u8) int {
 	return a[0] - b[0]
 }
 
-fn sort_and_print(mut objects []PageObject) {
+fn compare_bytes2(a []u8, b []u8) int {
+	x := int(a[0] - b[0])
+	return x
+}
+
+fn sort_and_print1(mut objects []PageObject) {
 	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
-		return compare_bytes(a.key, b.key)
+		return compare_bytes1(a.key, b.key)
+	})
+
+	for object in objects {
+		print('${object.key.bytestr()} ')
+	}
+	println('')
+}
+
+fn sort_and_print2(mut objects []PageObject) {
+	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
+		return compare_bytes2(a.key, b.key)
 	})
 
 	for object in objects {
@@ -30,15 +46,22 @@ fn main() {
 		key: 'C'.bytes()
 	}
 
-	// CORRECT: (A, B)
-	mut objects1 := [b, a]
-	sort_and_print(mut objects1)
+	mut objects11 := [b, a]
+	sort_and_print1(mut objects11)
 
-	// INCORRECT: (B, A)
-	mut objects2 := [a, b]
-	sort_and_print(mut objects2)
+	mut objects12 := [a, b]
+	sort_and_print1(mut objects12)
 
-	// INCORRECT: (C, B, A)
-	mut objects3 := [a, b, c]
-	sort_and_print(mut objects3)
+	mut objects13 := [a, b, c]
+	sort_and_print1(mut objects13)
+
+	mut objects21 := [b, a]
+	sort_and_print2(mut objects21)
+
+	mut objects22 := [a, b]
+	sort_and_print2(mut objects22)
+
+	mut objects23 := [a, b, c]
+	sort_and_print2(mut objects23)
+
 }

--- a/vlib/v/slow_tests/inout/printing_sort_with_compare.vv
+++ b/vlib/v/slow_tests/inout/printing_sort_with_compare.vv
@@ -1,0 +1,44 @@
+module main
+
+pub struct PageObject {
+	key []u8
+}
+
+fn compare_bytes(a []u8, b []u8) int {
+	return a[0] - b[0]
+}
+
+fn sort_and_print(mut objects []PageObject) {
+	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
+		return compare_bytes(a.key, b.key)
+	})
+
+	for object in objects {
+		print('${object.key.bytestr()} ')
+	}
+	println('')
+}
+
+fn main() {
+	a := PageObject{
+		key: 'A'.bytes()
+	}
+	b := PageObject{
+		key: 'B'.bytes()
+	}
+	c := PageObject{
+		key: 'C'.bytes()
+	}
+
+	// CORRECT: (A, B)
+	mut objects1 := [b, a]
+	sort_and_print(mut objects1)
+
+	// INCORRECT: (B, A)
+	mut objects2 := [a, b]
+	sort_and_print(mut objects2)
+
+	// INCORRECT: (C, B, A)
+	mut objects3 := [a, b, c]
+	sort_and_print(mut objects3)
+}


### PR DESCRIPTION
This PR fix printing sort with compare (fix #19575).

- Fix printing sort with compare.
- Add test.

```v
module main

pub struct PageObject {
	key []u8
}

fn compare_bytes1(a []u8, b []u8) int {
	return a[0] - b[0]
}

fn compare_bytes2(a []u8, b []u8) int {
	x := int(a[0] - b[0])
	return x
}

fn sort_and_print1(mut objects []PageObject) {
	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
		return compare_bytes1(a.key, b.key)
	})

	for object in objects {
		print('${object.key.bytestr()} ')
	}
	println('')
}

fn sort_and_print2(mut objects []PageObject) {
	objects.sort_with_compare(fn (a &PageObject, b &PageObject) int {
		return compare_bytes2(a.key, b.key)
	})

	for object in objects {
		print('${object.key.bytestr()} ')
	}
	println('')
}

fn main() {
	a := PageObject{
		key: 'A'.bytes()
	}
	b := PageObject{
		key: 'B'.bytes()
	}
	c := PageObject{
		key: 'C'.bytes()
	}

	mut objects11 := [b, a]
	sort_and_print1(mut objects11)

	mut objects12 := [a, b]
	sort_and_print1(mut objects12)

	mut objects13 := [a, b, c]
	sort_and_print1(mut objects13)

	mut objects21 := [b, a]
	sort_and_print2(mut objects21)

	mut objects22 := [a, b]
	sort_and_print2(mut objects22)

	mut objects23 := [a, b, c]
	sort_and_print2(mut objects23)
}

PS D:\Test\v\tt1> v run .
A B 
A B 
A B C 
A B 
A B 
A B C 
```