### PR TITLE
math.big: fix incorrect division with negative numbers(fix #19585)

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -221,6 +221,21 @@ const div_mod_test_data = [
 ]
 // vfmt on
 
+struct DivTest {
+	dividend  TestInteger
+	divisor   TestInteger
+	quotient  TestInteger
+}
+
+// vfmt off
+const div_test_data = [
+	DivTest{1234, 10, 123},
+	DivTest{-1234, 10, -123},
+	DivTest{1234, -10, -123},
+	DivTest{-1234, -10, 123},
+]
+// vfmt on
+
 enum Comparison {
 	less    = -1
 	equal   = 0
@@ -552,6 +567,9 @@ fn test_mul() {
 
 fn test_div() {
 	for t in div_mod_test_data {
+		assert t.dividend.parse() / t.divisor.parse() == t.quotient.parse()
+	}
+	for t in div_test_data {
 		assert t.dividend.parse() / t.divisor.parse() == t.quotient.parse()
 	}
 }

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -222,9 +222,9 @@ const div_mod_test_data = [
 // vfmt on
 
 struct DivTest {
-	dividend  TestInteger
-	divisor   TestInteger
-	quotient  TestInteger
+	dividend TestInteger
+	divisor  TestInteger
+	quotient TestInteger
 }
 
 // vfmt off

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -440,6 +440,10 @@ pub fn (dividend Integer) div_mod_checked(divisor Integer) !(Integer, Integer) {
 // refer to `div_checked`.
 [inline]
 pub fn (dividend Integer) / (divisor Integer) Integer {
+	if dividend.signum == -1 {
+		q, _ := dividend.neg().div_mod(divisor)
+		return q.neg()
+	}
 	q, _ := dividend.div_mod(divisor)
 	return q
 }


### PR DESCRIPTION
1. Fix #19585 
2. Add tests.

```v
fn main() {
	println(big.integer_from_int(1234) / big.integer_from_int(10))
	println(big.integer_from_int(-1234) / big.integer_from_int(10))
	println(big.integer_from_int(1234) / big.integer_from_int(-10))
	println(big.integer_from_int(-1234) / big.integer_from_int(-10))
}
```

output:
```
123
-123
-123
123
```