### PR TITLE
math: fix division with negative numbers (fix #19585)

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -783,3 +783,21 @@ fn test_set_bit() {
 	a.set_bit(100, false)
 	assert a == b
 }
+
+fn test_div_with_neg_num() {
+	r1 := big.integer_from_int(1234) / big.integer_from_int(10)
+	println(r1)
+	assert '${r1}' == '123'
+
+	r2 := big.integer_from_int(-1234) / big.integer_from_int(10)
+	println(r2)
+	assert '${r2}' == '-123'
+
+	r3 := big.integer_from_int(1234) / big.integer_from_int(-10)
+	println(r3)
+	assert '${r3}' == '-123'
+
+	r4 := big.integer_from_int(-1234) / big.integer_from_int(-10)
+	println(r4)
+	assert '${r4}' == '123'
+}

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -391,11 +391,7 @@ fn (dividend Integer) div_mod_internal(divisor Integer) (Integer, Integer) {
 	}
 	if dividend.signum == -1 {
 		q, r := dividend.neg().div_mod_internal(divisor)
-		if r.signum == 0 {
-			return q.neg(), zero_int
-		} else {
-			return q.neg() - one_int, divisor - r
-		}
+		return q.neg(), r
 	}
 	// Division for positive integers
 	mut q := []u32{cap: dividend.digits.len - divisor.digits.len + 1}


### PR DESCRIPTION
This PR fix division with negative numbers (fix #19585).

- Fix division with negative numbers.
- Add test.

```v
import math.big

fn main() {
	// Correct: 123
	r1 := big.integer_from_int(1234) / big.integer_from_int(10)
	println(r1)
	assert '${r1}' == '123'

	// Incorrect: -124
	r2 := big.integer_from_int(-1234) / big.integer_from_int(10)
	println(r2)
	assert '${r2}' == '-123'

	// Correct: -123
	r3 := big.integer_from_int(1234) / big.integer_from_int(-10)
	println(r3)
	assert '${r3}' == '-123'

	// Incorrect: 124
	r4 := big.integer_from_int(-1234) / big.integer_from_int(-10)
	println(r4)
	assert '${r4}' == '123'
}

PS D:\Test\v\tt1> v run .
123
-123
-123
123
```