### PR TITLE
net.http: support passing on_running, on_stopped, on_closed callback functions to http.Server{}, as well as show_startup_message: false.

### DIFF
--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -160,7 +160,7 @@ pub:
 // (when the server is running in another thread).
 // It returns an error, after params.max_retries * params.retry_period_ms
 // milliseconds have passed, without that expected server transition.
-pub fn (mut s Server) wait_till_running(params WaitTillRunningParams) ! {
+pub fn (mut s Server) wait_till_running(params WaitTillRunningParams) !int {
 	mut i := 0
 	for s.status() != .running && i < params.max_retries {
 		time.sleep(params.retry_period_ms * time.millisecond)
@@ -169,6 +169,8 @@ pub fn (mut s Server) wait_till_running(params WaitTillRunningParams) ! {
 	if i >= params.max_retries {
 		return error('maximum retries reached')
 	}
+	time.sleep(params.retry_period_ms)
+	return i
 }
 
 struct HandlerWorker {

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -8,14 +8,14 @@ import net
 import time
 import runtime
 // ServerStatus is the current status of the server.
-// .running means that the server is active and serving.
-// .stopped means that the server is not active but still listening.
-// .closed means that the server is completely inactive.
+// .closed means that the server is completely inactive (the default on creation, and after calling .close()).
+// .running means that the server is active and serving (after .listen_and_serve()).
+// .stopped means that the server is not active but still listening (after .stop() ).
 
 pub enum ServerStatus {
+	closed
 	running
 	stopped
-	closed
 }
 
 interface Handler {
@@ -36,6 +36,12 @@ pub mut:
 	pool_channel_slots int = 1024
 	worker_num         int = runtime.nr_jobs()
 	listener           net.TcpListener
+	//
+	on_running fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .running state.
+	on_stopped fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .stopped state.
+	on_closed  fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .closed state.
+	//
+	show_startup_message bool = true // set to false, to remove the default `Listening on ...` message.
 }
 
 // listen_and_serve listens on the server port `s.port` over TCP network and
@@ -78,9 +84,15 @@ pub fn (mut s Server) listen_and_serve() {
 		ws << new_handler_worker(wid, ch, s.handler)
 	}
 
-	println('Listening on http://${listening_address}/')
-	flush_stdout()
+	if s.show_startup_message {
+		println('Listening on http://${s.addr}/')
+		flush_stdout()
+	}
+
 	s.state = .running
+	if s.on_running != unsafe { nil } {
+		s.on_running(mut s)
+	}
 	for {
 		// break if we have a stop signal
 		if s.state != .running {
@@ -107,6 +119,9 @@ pub fn (mut s Server) listen_and_serve() {
 [inline]
 pub fn (mut s Server) stop() {
 	s.state = .stopped
+	if s.on_stopped != unsafe { nil } {
+		s.on_stopped(mut s)
+	}
 }
 
 // close immediately closes the port and signals the server that it has been closed.
@@ -114,12 +129,23 @@ pub fn (mut s Server) stop() {
 pub fn (mut s Server) close() {
 	s.state = .closed
 	s.listener.close() or { return }
+	if s.on_closed != unsafe { nil } {
+		s.on_closed(mut s)
+	}
 }
 
 // status indicates whether the server is running, stopped, or closed.
 [inline]
 pub fn (s &Server) status() ServerStatus {
 	return s.state
+}
+
+// wait_till_running allows you to synchronise your calling (main) thread, with the state of the server
+// (when the server is running in another thread).
+pub fn (mut s Server) wait_till_running() {
+	for s.status() != .running {
+		time.sleep(10 * time.millisecond)
+	}
 }
 
 struct HandlerWorker {

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -61,9 +61,16 @@ pub fn (mut s Server) listen_and_serve() {
 		eprintln('Failed getting listener address, err: ${err}')
 		return
 	}
-	listening_address := s.addr.clone()
+	mut listening_address := s.addr.clone()
 	if l.family() == net.AddrFamily.unspec {
-		s.listener = net.listen_tcp(.ip6, listening_address) or {
+		if listening_address == ':0' {
+			listening_address = 'localhost:0'
+		}
+		mut listen_family := net.AddrFamily.ip
+		//		$if !windows {
+		//			listen_family = net.AddrFamily.ip6
+		//		}
+		s.listener = net.listen_tcp(listen_family, listening_address) or {
 			eprintln('Listening on ${s.addr} failed, err: ${err}')
 			return
 		}

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -3,7 +3,7 @@ import net
 import net.http
 import time
 
-const atimeout = 200 * time.millisecond
+const atimeout = 500 * time.millisecond
 
 fn testsuite_begin() {
 	log.info(@FN)

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -18,7 +18,7 @@ fn test_server_stop() {
 		accept_timeout: atimeout
 	}
 	t := spawn server.listen_and_serve()
-	server.wait_till_running()
+	server.wait_till_running()!
 	mut watch := time.new_stopwatch()
 	server.stop()
 	assert server.status() == .stopped
@@ -34,7 +34,7 @@ fn test_server_close() {
 		show_startup_message: false
 	}
 	t := spawn server.listen_and_serve()
-	server.wait_till_running()
+	server.wait_till_running()!
 	mut watch := time.new_stopwatch()
 	server.close()
 	assert server.status() == .closed
@@ -51,7 +51,7 @@ fn test_server_custom_listener() {
 		show_startup_message: false
 	}
 	t := spawn server.listen_and_serve()
-	server.wait_till_running()
+	server.wait_till_running()!
 	mut watch := time.new_stopwatch()
 	server.close()
 	assert server.status() == .closed
@@ -111,7 +111,7 @@ fn test_server_custom_handler() {
 		show_startup_message: false
 	}
 	t := spawn server.listen_and_serve()
-	server.wait_till_running()
+	server.wait_till_running()!
 	x := http.fetch(url: 'http://localhost:${cport}/endpoint?abc=xyz', data: 'my data')!
 	assert x.body == 'my data, /endpoint?abc=xyz'
 	assert x.status_code == 200

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -100,7 +100,7 @@ fn (mut handler MyHttpHandler) handle(req http.Request) http.Response {
 	return r
 }
 
-const cport = 8198
+const cport = 18197
 
 fn test_server_custom_handler() {
 	mut handler := MyHttpHandler{}
@@ -159,7 +159,7 @@ fn test_server_custom_handler() {
 	assert progress_calls.chunks[0].bytestr().starts_with('HTTP/1.1 301 Moved permanently')
 	assert progress_calls.chunks[1].bytestr().starts_with('HTTP/1.1 200 OK')
 	assert progress_calls.chunks.last().bytestr().contains('xyz def')
-	assert progress_calls.redirected_to == ['http://localhost:8198/big']
+	assert progress_calls.redirected_to == ['http://localhost:${cport}/big']
 	//
 	server.stop()
 	t.wait()

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -22,7 +22,17 @@ mut:
 	is_blocking    bool
 }
 
-pub fn dial_tcp(address string) !&TcpConn {
+pub fn dial_tcp(oaddress string) !&TcpConn {
+	mut address := oaddress
+	$if windows {
+		// resolving 0.0.0.0 to localhost, works on linux and macos, but not on windows, so try to emulate it:
+		if address.starts_with(':::') {
+			address = address.replace_once(':::', 'localhost:')
+		}
+		if address.starts_with('0.0.0.0:') {
+			address = address.replace_once('0.0.0.0:', 'localhost:')
+		}
+	}
 	addrs := resolve_addrs_fuzzy(address, .tcp) or {
 		return error('${err.msg()}; could not resolve address ${address} in dial_tcp')
 	}


### PR DESCRIPTION
Improves the ergonomics of `http.Server` from the module `net.http` .