### PR TITLE
ast: fix formatting struct declaration with nested struct (fix #19560)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1378,8 +1378,8 @@ pub fn (t &Table) has_deep_child_no_ref(ts &TypeSymbol, name string) bool {
 	if ts.info is Struct {
 		for field in ts.info.fields {
 			sym := t.sym(field.typ)
-			if !field.typ.is_ptr() && ((sym.name == name && !field.typ.has_flag(.option))
-				|| t.has_deep_child_no_ref(sym, name)) {
+			if !field.typ.is_ptr() && !field.typ.has_flag(.option)
+				&& (sym.name == name || t.has_deep_child_no_ref(sym, name)) {
 				return true
 			}
 		}

--- a/vlib/v/fmt/tests/struct_decl_with_nested_struct_keep.vv
+++ b/vlib/v/fmt/tests/struct_decl_with_nested_struct_keep.vv
@@ -1,0 +1,7 @@
+pub struct Node {
+	parent ?Node
+}
+
+pub struct NodeWrapper {
+	node Node
+}


### PR DESCRIPTION
This PR fix formatting struct declaration with nested struct (fix #19560).

- Fix formatting struct declaration with nested struct.
- Add test.

vlib\v\fmt\tests\struct_decl_with_nested_struct_keep.vv
```v
pub struct Node {
	parent ?Node
}

pub struct NodeWrapper {
	node Node
}
```
```v
pub struct Node {
	parent ?Node
}

pub struct NodeWrapper {
	node Node
}

fn main() {}

PS D:\Test\v\tt1> v run . 
tt1.v:1:1: error: recursive struct is only possible with optional pointer (e.g. ?&Node)
    1 | pub struct Node {
      | ~~~~~~~~~~~~~~~
    2 |     parent ?Node
    3 | }
```