### PR TITLE
net, net.http: fix missing select calls when request is read from non-block socket(fix #19580)

### DIFF
--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -109,7 +109,7 @@ fn C.FD_ZERO(fdset &C.fd_set)
 
 fn C.FD_SET(fd int, fdset &C.fd_set)
 
-fn C.FD_ISSET(fd int, fdset &C.fd_set) bool
+fn C.FD_ISSET(fd int, fdset &C.fd_set) int
 
 fn C.inet_pton(family AddrFamily, saddr &char, addr voidptr) int
 

--- a/vlib/net/common.v
+++ b/vlib/net/common.v
@@ -85,7 +85,7 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 		}
 	}
 
-	return C.FD_ISSET(handle, &set)
+	return C.FD_ISSET(handle, &set) != 0
 }
 
 [inline]
@@ -108,7 +108,7 @@ fn select_deadline(handle int, test Select, deadline time.Time) !bool {
 	}
 
 	// Deadline elapsed
-	return false
+	return err_timed_out
 }
 
 // wait_for_common wraps the common wait code

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -193,6 +193,7 @@ fn (req &Request) read_all_from_client_connection(r &net.TcpConn) ![]u8 {
 	mut read := i64(0)
 	mut b := []u8{len: 32768}
 	for {
+		r.wait_for_read()!
 		old_read := read
 		new_read := r.read(mut b[read..]) or { break }
 		read += new_read

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -580,5 +580,5 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	$if trace_ssl ? {
 		eprintln('${@METHOD} ---> res: ${res}')
 	}
-	return res
+	return res != 0
 }

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -460,5 +460,5 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	$if trace_ssl ? {
 		eprintln('${@METHOD} ---> res: ${res}')
 	}
-	return res
+	return res != 0
 }

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -1,7 +1,6 @@
 module net
 
 import time
-import io
 import strings
 
 pub const (
@@ -147,12 +146,7 @@ pub fn (c TcpConn) read_ptr(buf_ptr &u8, len int) !int {
 }
 
 pub fn (c TcpConn) read(mut buf []u8) !int {
-	return c.read_ptr(buf.data, buf.len) or {
-		return io.NotExpected{
-			cause: 'unexpected error in `read_ptr` function'
-			code: -1
-		}
-	}
+	return c.read_ptr(buf.data, buf.len)!
 }
 
 pub fn (mut c TcpConn) read_deadline() !time.Time {

--- a/vlib/net/unix/common.v
+++ b/vlib/net/unix/common.v
@@ -57,7 +57,7 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 		}
 	}
 
-	return C.FD_ISSET(handle, &set)
+	return C.FD_ISSET(handle, &set) != 0
 }
 
 // wait_for_common wraps the common wait code

--- a/vlib/picoev/loop_default.c.v
+++ b/vlib/picoev/loop_default.c.v
@@ -74,9 +74,9 @@ fn (mut pv Picoev) poll_once(max_wait int) int {
 			if target.loop_id == pv.loop.id {
 				// vfmt off
 				read_events := (
-					(if C.FD_ISSET(target.fd, &readfds) { picoev_read } else { 0 })
+					(if C.FD_ISSET(target.fd, &readfds) != 0 { picoev_read } else { 0 })
 						|
-					(if C.FD_ISSET(target.fd, &writefds) { picoev_write } else { 0 })
+					(if C.FD_ISSET(target.fd, &writefds) != 0 { picoev_write } else { 0 })
 				)
 				// vfmt on
 				if read_events != 0 {


### PR DESCRIPTION
1. Fix #19580 
2. I don't know how to write test cases for net changes, For the use case of this issue, there is no written test case due to the result uncertainty  😄 

```v
module main

import net.http

fn main(){
	mut ch := chan string{}
	mut threads := []thread {}
	for _ in 1 .. 15 {
		threads << spawn  fn(ch chan string){
			for {
				m := <-ch or {
					break
				}
				res := http.get(m) or {
					println(err)
					continue
				}
				println(res.status_code)
			}
		}(ch)
	}
	for _ in 0..5 {
		s:= "http://ip.sb"
		ch <- s
	}
	ch.close()
	threads.wait()
}
```

outputs:
```
200
200
200
200
200
```
