### PR TITLE
datatypes queue clear

### DIFF
--- a/vlib/datatypes/queue.v
+++ b/vlib/datatypes/queue.v
@@ -49,3 +49,8 @@ pub fn (queue Queue[T]) str() string {
 pub fn (queue Queue[T]) array() []T {
 	return queue.elements.array()
 }
+
+// clear clears all items in the queue
+pub fn (queue Queue[T]) clear() {
+	queue.elements.clear()
+}

--- a/vlib/datatypes/queue_test.v
+++ b/vlib/datatypes/queue_test.v
@@ -76,3 +76,12 @@ fn test_array() {
 	queue.push(2)
 	assert queue.array() == [1, 2]
 }
+
+fn test_clear() {
+	mut queue := Queue[int]{}
+	queue.push(1)
+	queue.push(2)
+	queue.push(3)
+	queue.clear()
+	assert queue.len() == 0
+}


### PR DESCRIPTION
Missing clear() functionality in queue datatype