### PR TITLE
reflection: fix an error when reflecting ref types(fix #19595)

### DIFF
--- a/vlib/v/reflection/reflection.v
+++ b/vlib/v/reflection/reflection.v
@@ -242,7 +242,7 @@ pub fn get_string_by_idx(idx int) string {
 
 // type_of returns the type info of the passed value
 pub fn type_of[T](val T) Type {
-	return g_reflection.types.filter(it.idx == typeof[T]().idx)[0]
+	return g_reflection.types.filter(it.idx == typeof[T]().idx & 0xff00ffff)[0]
 }
 
 // get_modules returns the module name built with V source

--- a/vlib/v/tests/reflection_test.v
+++ b/vlib/v/tests/reflection_test.v
@@ -86,3 +86,10 @@ fn test_get_string_by_idx() {
 	file_idx := reflection.get_funcs().filter(it.name == 'all_after_last')[0].file_idx
 	assert reflection.get_string_by_idx(file_idx).ends_with('string.v')
 }
+
+fn test_ref() {
+	cstr := c'abc' // &u8
+	assert reflection.type_of(cstr).str().contains("name: 'u8'")
+	ptr_user := &User{}
+	assert reflection.type_of(ptr_user).str().contains("name: 'User'")
+}


### PR DESCRIPTION
1. Fix #19595 
2. Add tests.

```v
import v.reflection

fn main() {
    s := c'abc'
    println(reflection.type_of(s))
}
```
outputs:
```
reflection.Type{
    name: 'u8'
    idx: 11
    sym: reflection.TypeSymbol{
        name: 'u8'
        idx: 11
        parent_idx: 0
        language: v
        kind: u8
        info: reflection.TypeInfo(reflection.None{
            parent_idx: 0
        })
        methods: [reflection.Function{
            mod_name: 'builtin'
            name: 'vbytes'
            args: [reflection.FunctionArg{
                name: 'data'
......
```

```v
import v.reflection

struct User {
	name string
}

fn main() {
    s := &User{}
    println(reflection.type_of(s))
}
```

outputs:

```
reflection.Type{
    name: 'User'
    idx: 95
    sym: reflection.TypeSymbol{
        name: 'main.User'
        idx: 95
        parent_idx: 0
        language: v
        kind: struct_
        info: reflection.TypeInfo(reflection.Struct{
            parent_idx: 0
            attrs: []
            fields: [reflection.StructField{
                name: 'name'
                typ: VType(0x15 = 21)
                attrs: []
......
```