### PR TITLE
net: fix handling of spurious wake-up signals lost when calling select() in mbedtls and openssl

### DIFF
--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -545,40 +545,54 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 		eprintln('${@METHOD} handle: ${handle}, timeout: ${timeout}')
 	}
 	set := C.fd_set{}
-
 	C.FD_ZERO(&set)
 	C.FD_SET(handle, &set)
 
-	seconds := timeout.milliseconds() / 1000
-	microseconds := timeout - (seconds * time.second)
-	mut tt := C.timeval{
-		tv_sec: u64(seconds)
-		tv_usec: u64(microseconds)
-	}
+	deadline := time.now().add(timeout)
+	mut remaining_time := timeout.milliseconds()
+	for remaining_time > 0 {
+		seconds := remaining_time / 1000
+		microseconds := (remaining_time % 1000) * 1000
 
-	mut timeval_timeout := &tt
-
-	// infinite timeout is signaled by passing null as the timeout to
-	// select
-	if timeout == net.infinite_timeout {
-		timeval_timeout = &C.timeval(unsafe { nil })
-	}
-
-	match test {
-		.read {
-			net.socket_error(C.@select(handle + 1, &set, C.NULL, C.NULL, timeval_timeout))!
+		tt := C.timeval{
+			tv_sec: u64(seconds)
+			tv_usec: u64(microseconds)
 		}
-		.write {
-			net.socket_error(C.@select(handle + 1, C.NULL, &set, C.NULL, timeval_timeout))!
+		timeval_timeout := if timeout < 0 {
+			&C.timeval(unsafe { nil })
+		} else {
+			&tt
 		}
-		.except {
-			net.socket_error(C.@select(handle + 1, C.NULL, C.NULL, &set, timeval_timeout))!
+
+		mut res := -1
+		match test {
+			.read {
+				res = net.socket_error(C.@select(handle + 1, &set, C.NULL, C.NULL, timeval_timeout))!
+			}
+			.write {
+				res = net.socket_error(C.@select(handle + 1, C.NULL, &set, C.NULL, timeval_timeout))!
+			}
+			.except {
+				res = net.socket_error(C.@select(handle + 1, C.NULL, C.NULL, &set, timeval_timeout))!
+			}
 		}
+		if res < 0 {
+			if C.errno == C.EINTR {
+				// errno is 4, Spurious wakeup from signal, keep waiting
+				remaining_time = (deadline - time.now()).milliseconds()
+				continue
+			}
+			return error_with_code('Select failed: ${res}', C.errno)
+		} else if res == 0 {
+			return net.err_timed_out
+		}
+
+		res = C.FD_ISSET(handle, &set)
+		$if trace_ssl ? {
+			eprintln('${@METHOD} ---> res: ${res}')
+		}
+		return res != 0
 	}
 
-	res := C.FD_ISSET(handle, &set)
-	$if trace_ssl ? {
-		eprintln('${@METHOD} ---> res: ${res}')
-	}
-	return res != 0
+	return net.err_timed_out
 }


### PR DESCRIPTION
1. This PR fixed handling of spurious wake-up signals lost when calling select() in mbedtls and openssl.
2. Significantly reduced issue #19580 exception response messages.
3. There are many reasons of issue #19580. I will continue to submit PR to solve other small problems. It also needs to be kept open.

```
Shoves-MacBook:temp shove$ v a.v
Shoves-MacBook:temp shove$ ./a
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
```