### PR TITLE
ast: check receivers of callexprs too in ast.Table.dependent_names_in_expr

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2342,6 +2342,9 @@ pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
 			names << t.dependent_names_in_expr(expr.init_expr)
 		}
 		CallExpr {
+			if expr.is_method {
+				names << t.dependent_names_in_expr(expr.left)
+			}
 			for arg in expr.args {
 				names << t.dependent_names_in_expr(arg.expr)
 			}

--- a/vlib/v/tests/const_init_order_test.v
+++ b/vlib/v/tests/const_init_order_test.v
@@ -1,3 +1,4 @@
+import os
 import rand
 
 const (
@@ -7,4 +8,19 @@ const (
 fn test_rand_is_initialized_before_main() {
 	eprintln('random letter: ${my_random_letter_const.str()} | ASCII code: ${my_random_letter_const}')
 	assert my_random_letter_const.is_capital()
+}
+
+//
+
+const (
+	last_constant = fn_that_calls_a_method_on_a_constant()
+	a_constant    = os.join_path(@VROOT, 'a')
+)
+
+fn fn_that_calls_a_method_on_a_constant() string {
+	return a_constant.replace('\\', '/')
+}
+
+fn test_consts_initialised_with_a_function_that_uses_other_consts_as_receivers_are_properly_ordered() {
+	assert last_constant != ''
 }


### PR DESCRIPTION
The method is used for finding the constants, that another constant depends on.