### PR TITLE
make.bat: use uniform indentation throughout file

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -41,29 +41,29 @@ if ["%~1"] == [""] goto :init
 
 REM Target options
 if !shift_counter! LSS 1 (
-    if "%~1" == "help" (
-        if not ["%~2"] == [""] set subcmd=%~2& shift& set /a shift_counter+=1
-    )
-    for %%z in (build clean cleanall check help rebuild) do (
-        if "%~1" == "%%z" set target=%1& shift& set /a shift_counter+=1& goto :verifyopt
-    )
+	if "%~1" == "help" (
+		if not ["%~2"] == [""] set subcmd=%~2& shift& set /a shift_counter+=1
+	)
+	for %%z in (build clean cleanall check help rebuild) do (
+		if "%~1" == "%%z" set target=%1& shift& set /a shift_counter+=1& goto :verifyopt
+	)
 )
 
 REM Compiler option
 for %%g in (-gcc -msvc -tcc -tcc32 -clang) do (
-    if "%~1" == "%%g" set compiler=%~1& set compiler=!compiler:~1!& shift& set /a shift_counter+=1& goto :verifyopt
+	if "%~1" == "%%g" set compiler=%~1& set compiler=!compiler:~1!& shift& set /a shift_counter+=1& goto :verifyopt
 )
 
 REM Standard options
 if "%~1" == "--local" (
-    if !flag_local! NEQ 0 (
-        echo The flag %~1 has already been specified. 1>&2
-        exit /b 2
-    )
-    set /a flag_local=1
-    set /a shift_counter+=1
-    shift
-    goto :verifyopt
+	if !flag_local! NEQ 0 (
+		echo The flag %~1 has already been specified. 1>&2
+		exit /b 2
+	)
+	set /a flag_local=1
+	set /a shift_counter+=1
+	shift
+	goto :verifyopt
 )
 
 echo Undefined option: %~1
@@ -104,26 +104,26 @@ goto :build
 
 :help
 if [!subcmd!] == [] (
-    call :usage
+	call :usage
 ) else (
-    call :help_!subcmd!
+	call :help_!subcmd!
 )
 if %ERRORLEVEL% NEQ 0 echo Invalid subcommand: !subcmd!
 exit /b %ERRORLEVEL%
 
 :build
 if !flag_local! NEQ 1 (
-    call :download_tcc
-    if %ERRORLEVEL% NEQ 0 goto :error
-    pushd "%vc_dir%" && (
-        echo Updating vc...
-        echo  ^> Sync with remote !vc_url!
-        cd %vc_dir%
-        git pull --quiet
-        cd ..
-        popd
-    ) || call :cloning_vc
-    echo.
+	call :download_tcc
+	if %ERRORLEVEL% NEQ 0 goto :error
+	pushd "%vc_dir%" && (
+		echo Updating vc...
+		echo  ^> Sync with remote !vc_url!
+		cd %vc_dir%
+		git pull --quiet
+		cd ..
+		popd
+	) || call :cloning_vc
+	echo.
 )
 
 echo Building V...
@@ -216,9 +216,9 @@ set ObjFile=.v.c.obj
 echo  ^> Attempting to build "%V_BOOTSTRAP%" (from v_win.c) with MSVC
 cl.exe /volatile:ms /Fo%ObjFile% /W0 /MD /D_VBOOTSTRAP "vc/v_win.c" user32.lib kernel32.lib advapi32.lib shell32.lib /link /nologo /out:"%V_BOOTSTRAP%" /incremental:no
 if %ERRORLEVEL% NEQ 0 (
-    echo In some cases, compile errors happen because of the MSVC compiler version
-    cl.exe
-    goto :compile_error
+	echo In some cases, compile errors happen because of the MSVC compiler version
+	cl.exe
+	goto :compile_error
 )
 
 echo  ^> Compiling "%V_EXE%" with "%V_BOOTSTRAP%"
@@ -230,10 +230,10 @@ goto :success
 
 :download_tcc
 pushd "%tcc_dir%" && (
-    echo Updating TCC
-    echo  ^> Syncing TCC from !tcc_url!
-    git pull --quiet
-    popd
+	echo Updating TCC
+	echo  ^> Syncing TCC from !tcc_url!
+	git pull --quiet
+	popd
 ) || call :bootstrap_tcc
 
 if [!tcc_exe!] == [] echo  ^> TCC not found, even after cloning& goto :error


### PR DESCRIPTION
Makes the `make.bat` file use one uniform indentation style, currently it's a bit mixed up.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efc87a1</samp>

Fix indentation of `make.bat` script. Use tabs instead of spaces to match the project's code style. Improve readability and consistency of the script.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efc87a1</samp>

* Standardize indentation to use tabs instead of spaces in `make.bat` ([link](https://github.com/vlang/v/pull/19612/files?diff=unified&w=0#diff-fdb01b5af0ae147e0e3aa673b80401463571d9d1d51f88b834df205f8c8e34b0L44-R66), [link](https://github.com/vlang/v/pull/19612/files?diff=unified&w=0#diff-fdb01b5af0ae147e0e3aa673b80401463571d9d1d51f88b834df205f8c8e34b0L107-R109), [link](https://github.com/vlang/v/pull/19612/files?diff=unified&w=0#diff-fdb01b5af0ae147e0e3aa673b80401463571d9d1d51f88b834df205f8c8e34b0L116-R126), [link](https://github.com/vlang/v/pull/19612/files?diff=unified&w=0#diff-fdb01b5af0ae147e0e3aa673b80401463571d9d1d51f88b834df205f8c8e34b0L219-R221), [link](https://github.com/vlang/v/pull/19612/files?diff=unified&w=0#diff-fdb01b5af0ae147e0e3aa673b80401463571d9d1d51f88b834df205f8c8e34b0L233-R236))
