### PR TITLE
parser: fix vet `bad top level statement` error for one file programs

### DIFF
--- a/cmd/tools/vvet/tests/prog_without_main_fn.out
+++ b/cmd/tools/vvet/tests/prog_without_main_fn.out
@@ -1,0 +1,1 @@
+cmd/tools/vvet/tests/prog_without_main_fn.vv:1: notice: use a fixed array, instead of a dynamic one

--- a/cmd/tools/vvet/tests/prog_without_main_fn.vv
+++ b/cmd/tools/vvet/tests/prog_without_main_fn.vv
@@ -1,0 +1,3 @@
+const x = [1, 2, 3]
+
+println(x)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -873,7 +873,7 @@ fn (mut p Parser) other_stmts(cur_stmt ast.Stmt) ast.Stmt {
 			scope: p.scope
 			label_names: p.label_names
 		}
-	} else if p.pref.is_fmt {
+	} else if p.pref.is_fmt || p.pref.is_vet {
 		return p.stmt(false)
 	} else {
 		return p.error('bad top level statement ' + p.tok.str())


### PR DESCRIPTION
Fixes an issue where it's not possible to run `v vet` over one-file programs or over dirs that contain such files (the latter is probably the more common problem. E.g., for example files in libraries).

E.g.:
```v
// vet_me.v
const x = [1, 2, 3]

println(x)
```
```
v vet vet_me.v
```
Would currently throw:
```
vet_me.v:3:1: error: bad top level statement name `println`
    1 | const x = [1, 2, 3]
    2 | 
    3 | println(x)
      | ~~~~~~~
```

With the suggestion added it'll throw:
```
vet_me.v:1: notice: use a fixed array, instead of a dynamic one
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eec7c51</samp>

Added vet mode support to the statement parser in `vlib/v/parser/parser.v`. This allows the V compiler to check V code for errors and style issues with a vet command.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eec7c51</samp>

* Extend the condition for parsing a statement to include vet mode ([link](https://github.com/vlang/v/pull/19613/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L876-R876)). This allows the parser to check for errors and style issues in blocks of code when the vet command is used.
