### PR TITLE
net, net.http: fixed some ssl library call return values judgment and handling

### DIFF
--- a/vlib/math/stats/stats.v
+++ b/vlib/math/stats/stats.v
@@ -470,7 +470,7 @@ pub fn skew_mean_stddev[T](data []T, mean T, sd T) T {
 }
 
 // quantile calculates quantile points
-// for more reference 
+// for more reference
 // https://en.wikipedia.org/wiki/Quantile
 pub fn quantile[T](sorted_data []T, f T) T {
 	if sorted_data.len == 0 {

--- a/vlib/net/http/backend_nix.c.v
+++ b/vlib/net/http/backend_nix.c.v
@@ -36,6 +36,9 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string)
 			eprintln(unsafe { tos(bp, len) })
 			eprintln('-'.repeat(20))
 		}
+		if len <= 0 {
+			break
+		}
 		unsafe { content.write_ptr(bp, len) }
 		if req.on_progress != unsafe { nil } {
 			req.on_progress(req, content[content.len - len..], u64(content.len))!

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -193,9 +193,11 @@ fn (req &Request) read_all_from_client_connection(r &net.TcpConn) ![]u8 {
 	mut read := i64(0)
 	mut b := []u8{len: 32768}
 	for {
-		r.wait_for_read()!
 		old_read := read
 		new_read := r.read(mut b[read..]) or { break }
+		if new_read <= 0 {
+			break
+		}
 		read += new_read
 		if req.on_progress != unsafe { nil } {
 			req.on_progress(req, b[old_read..read], u64(read))!

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -39,7 +39,7 @@ mut:
 	conf      C.mbedtls_ssl_config
 	certs     &SSLCerts = unsafe { nil }
 	handle    int
-	timeout   time.Duration
+	duration  time.Duration
 	opened    bool
 
 	owns_socket bool
@@ -349,7 +349,7 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 		return error('ssl connection already open')
 	}
 	s.handle = tcp_conn.sock.handle
-	s.timeout = 30 * time.second
+	s.duration = 30 * time.second
 
 	mut ret := C.mbedtls_ssl_set_hostname(&s.ssl, &char(hostname.str))
 	if ret != 0 {
@@ -378,7 +378,7 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	if s.opened {
 		return error('ssl connection already open')
 	}
-	s.timeout = 30 * time.second
+	s.duration = 30 * time.second
 
 	mut ret := C.mbedtls_ssl_set_hostname(&s.ssl, &char(hostname.str))
 	if ret != 0 {
@@ -421,7 +421,7 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 		}
 	}
 
-	deadline := time.now().add(s.timeout)
+	deadline := time.now().add(s.duration)
 	// s.wait_for_read(deadline - time.now())!
 	for {
 		res = C.mbedtls_ssl_read(&s.ssl, buf_ptr, len)
@@ -487,7 +487,7 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 		}
 	}
 
-	deadline := time.now().add(s.timeout)
+	deadline := time.now().add(s.duration)
 	unsafe {
 		mut ptr_base := bytes
 		for total_sent < len {

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -55,8 +55,8 @@ mut:
 	conf      C.mbedtls_ssl_config
 	certs     &SSLCerts = unsafe { nil }
 	opened    bool
-	// handle	  int
-	// timeout	  time.Duration
+	// handle		int
+	// duration	time.Duration
 }
 
 // create a new SSLListener binding to `saddr`

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -589,9 +589,9 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	return net.err_timed_out
 }
 
-// wait_common wraps the common wait code
-fn wait_common(handle int, test Select, timeout time.Duration) ! {
-	ready := @select(handle, test, timeout)!
+// wait_for wraps the common wait code
+fn wait_for(handle int, what Select, timeout time.Duration) ! {
+	ready := @select(handle, what, timeout)!
 	if ready {
 		return
 	}
@@ -600,11 +600,11 @@ fn wait_common(handle int, test Select, timeout time.Duration) ! {
 }
 
 // wait_for_write waits for a write io operation to be available
-pub fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
-	return wait_common(s.handle, .write, timeout)
+fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
+	return wait_for(s.handle, .write, timeout)
 }
 
 // wait_for_read waits for a read io operation to be available
-pub fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
-	return wait_common(s.handle, .read, timeout)
+fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
+	return wait_for(s.handle, .read, timeout)
 }

--- a/vlib/net/mbedtls/ssl_connection.v
+++ b/vlib/net/mbedtls/ssl_connection.v
@@ -589,8 +589,8 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	return net.err_timed_out
 }
 
-// wait_for_common wraps the common wait code
-fn wait_for_common(handle int, test Select, timeout time.Duration) ! {
+// wait_common wraps the common wait code
+fn wait_common(handle int, test Select, timeout time.Duration) ! {
 	ready := @select(handle, test, timeout)!
 	if ready {
 		return
@@ -601,10 +601,10 @@ fn wait_for_common(handle int, test Select, timeout time.Duration) ! {
 
 // wait_for_write waits for a write io operation to be available
 pub fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
-	return wait_for_common(s.handle, .write, timeout)
+	return wait_common(s.handle, .write, timeout)
 }
 
 // wait_for_read waits for a read io operation to be available
 pub fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
-	return wait_for_common(s.handle, .read, timeout)
+	return wait_common(s.handle, .read, timeout)
 }

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -429,9 +429,9 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	return net.err_timed_out
 }
 
-// wait_common wraps the common wait code
-fn wait_common(handle int, test Select, timeout time.Duration) ! {
-	ready := @select(handle, test, timeout)!
+// wait_for wraps the common wait code
+fn wait_for(handle int, what Select, timeout time.Duration) ! {
+	ready := @select(handle, what, timeout)!
 	if ready {
 		return
 	}
@@ -440,11 +440,11 @@ fn wait_common(handle int, test Select, timeout time.Duration) ! {
 }
 
 // wait_for_write waits for a write io operation to be available
-pub fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
-	return wait_common(s.handle, .write, timeout)
+fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
+	return wait_for(s.handle, .write, timeout)
 }
 
 // wait_for_read waits for a read io operation to be available
-pub fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
-	return wait_common(s.handle, .read, timeout)
+fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
+	return wait_for(s.handle, .read, timeout)
 }

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -429,8 +429,8 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	return net.err_timed_out
 }
 
-// wait_for_common wraps the common wait code
-fn wait_for_common(handle int, test Select, timeout time.Duration) ! {
+// wait_common wraps the common wait code
+fn wait_common(handle int, test Select, timeout time.Duration) ! {
 	ready := @select(handle, test, timeout)!
 	if ready {
 		return
@@ -441,10 +441,10 @@ fn wait_for_common(handle int, test Select, timeout time.Duration) ! {
 
 // wait_for_write waits for a write io operation to be available
 pub fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
-	return wait_for_common(s.handle, .write, timeout)
+	return wait_common(s.handle, .write, timeout)
 }
 
 // wait_for_read waits for a read io operation to be available
 pub fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
-	return wait_for_common(s.handle, .read, timeout)
+	return wait_common(s.handle, .read, timeout)
 }

--- a/vlib/net/openssl/ssl_connection.v
+++ b/vlib/net/openssl/ssl_connection.v
@@ -9,10 +9,10 @@ import os
 pub struct SSLConn {
 	config SSLConnectConfig
 mut:
-	sslctx   &C.SSL_CTX = unsafe { nil }
-	ssl      &C.SSL     = unsafe { nil }
-	handle   int
-	duration time.Duration
+	sslctx  &C.SSL_CTX = unsafe { nil }
+	ssl     &C.SSL     = unsafe { nil }
+	handle  int
+	timeout time.Duration
 
 	owns_socket bool
 }
@@ -54,49 +54,32 @@ pub fn (mut s SSLConn) shutdown() ! {
 	$if trace_ssl ? {
 		eprintln(@METHOD)
 	}
+
 	if s.ssl != 0 {
-		mut res := 0
+		deadline := time.now().add(s.timeout)
 		for {
-			res = C.SSL_shutdown(voidptr(s.ssl))
-			if res < 0 {
-				err_res := ssl_error(res, s.ssl) or {
-					break // We break to free rest of resources
-				}
-				if err_res == .ssl_error_want_read {
-					for {
-						ready := @select(s.handle, .read, s.duration)!
-						if ready {
-							break
-						}
-					}
-					continue
-				} else if err_res == .ssl_error_want_write {
-					for {
-						ready := @select(s.handle, .write, s.duration)!
-						if ready {
-							break
-						}
-					}
-					continue
-				} else {
-					unsafe { C.SSL_free(voidptr(s.ssl)) }
-					if s.sslctx != 0 {
-						C.SSL_CTX_free(s.sslctx)
-					}
-					return error('unexepedted ssl error ${err_res}')
-				}
-				if s.ssl != 0 {
-					unsafe { C.SSL_free(voidptr(s.ssl)) }
-				}
-				if s.sslctx != 0 {
-					C.SSL_CTX_free(s.sslctx)
-				}
-				return error('Could not connect using SSL. (${err_res}),err')
-			} else if res == 0 {
-				continue
-			} else if res == 1 {
+			mut res := C.SSL_shutdown(voidptr(s.ssl))
+			if res == 1 {
 				break
 			}
+
+			err_res := ssl_error(res, s.ssl) or {
+				break // We break to free rest of resources
+			}
+			if err_res == .ssl_error_want_read {
+				s.wait_for_read(deadline - time.now())!
+				continue
+			} else if err_res == .ssl_error_want_write {
+				s.wait_for_write(deadline - time.now())!
+				continue
+			}
+			if s.ssl != 0 {
+				unsafe { C.SSL_free(voidptr(s.ssl)) }
+			}
+			if s.sslctx != 0 {
+				C.SSL_CTX_free(s.sslctx)
+			}
+			return error('Could not connect using SSL. (${err_res}),err')
 		}
 		C.SSL_free(voidptr(s.ssl))
 	}
@@ -184,7 +167,7 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 		eprintln('${@METHOD} hostname: ${hostname}')
 	}
 	s.handle = tcp_conn.sock.handle
-	s.duration = tcp_conn.read_timeout()
+	s.timeout = tcp_conn.read_timeout()
 
 	mut res := C.SSL_set_tlsext_host_name(voidptr(s.ssl), voidptr(hostname.str))
 	if res != 1 {
@@ -205,9 +188,6 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	}
 	s.owns_socket = true
 	mut tcp_conn := net.dial_tcp('${hostname}:${port}') or { return err }
-	$if macos {
-		tcp_conn.set_blocking(true) or { return err }
-	}
 	s.connect(mut tcp_conn, hostname) or { return err }
 }
 
@@ -215,57 +195,42 @@ fn (mut s SSLConn) complete_connect() ! {
 	$if trace_ssl ? {
 		eprintln(@METHOD)
 	}
+
+	deadline := time.now().add(s.timeout)
 	for {
 		mut res := C.SSL_connect(voidptr(s.ssl))
-		if res != 1 {
-			err_res := ssl_error(res, s.ssl)!
-			if err_res == .ssl_error_want_read {
-				for {
-					ready := @select(s.handle, .read, s.duration)!
-					if ready {
-						break
-					}
-				}
-				continue
-			} else if err_res == .ssl_error_want_write {
-				for {
-					ready := @select(s.handle, .write, s.duration)!
-					if ready {
-						break
-					}
-				}
-				continue
-			}
-			return error('Could not connect using SSL. (${err_res}),err')
+		if res == 1 {
+			break
 		}
-		break
+
+		err_res := ssl_error(res, s.ssl)!
+		if err_res == .ssl_error_want_read {
+			s.wait_for_read(deadline - time.now())!
+			continue
+		}
+		if err_res == .ssl_error_want_write {
+			s.wait_for_write(deadline - time.now())!
+			continue
+		}
+		return error('Could not connect using SSL. (${err_res}),err')
 	}
 
 	if s.config.validate {
 		for {
 			mut res := C.SSL_do_handshake(voidptr(s.ssl))
-			if res != 1 {
-				err_res := ssl_error(res, s.ssl)!
-				if err_res == .ssl_error_want_read {
-					for {
-						ready := @select(s.handle, .read, s.duration)!
-						if ready {
-							break
-						}
-					}
-					continue
-				} else if err_res == .ssl_error_want_write {
-					for {
-						ready := @select(s.handle, .write, s.duration)!
-						if ready {
-							break
-						}
-					}
-					continue
-				}
-				return error('Could not validate SSL certificate. (${err_res}),err')
+			if res == 1 {
+				break
 			}
-			break
+
+			err_res := ssl_error(res, s.ssl)!
+			if err_res == .ssl_error_want_read {
+				s.wait_for_read(deadline - time.now())!
+				continue
+			} else if err_res == .ssl_error_want_write {
+				s.wait_for_write(deadline - time.now())!
+				continue
+			}
+			return error('Could not validate SSL certificate. (${err_res}),err')
 		}
 		pcert := C.SSL_get_peer_certificate(voidptr(s.ssl))
 		defer {
@@ -294,6 +259,9 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 			}
 		}
 	}
+
+	deadline := time.now().add(s.timeout)
+	// s.wait_for_read(deadline - time.now())!
 	for {
 		res = C.SSL_read(voidptr(s.ssl), buf_ptr, len)
 		if res > 0 {
@@ -307,21 +275,19 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 			err_res := ssl_error(res, s.ssl)!
 			match err_res {
 				.ssl_error_want_read {
-					ready := @select(s.handle, .read, s.duration)!
-					if !ready {
+					s.wait_for_read(deadline - time.now()) or {
 						$if trace_ssl ? {
-							eprintln('${@METHOD} ---> res: net.err_timed_out .ssl_error_want_read')
+							eprintln('${@METHOD} ---> res: ${err} .ssl_error_want_read')
 						}
-						return net.err_timed_out
+						return err
 					}
 				}
 				.ssl_error_want_write {
-					ready := @select(s.handle, .write, s.duration)!
-					if !ready {
+					s.wait_for_write(deadline - time.now()) or {
 						$if trace_ssl ? {
-							eprintln('${@METHOD} ---> res: net.err_timed_out .ssl_error_want_write')
+							eprintln('${@METHOD} ---> res: ${err} .ssl_error_want_write')
 						}
-						return net.err_timed_out
+						return err
 					}
 				}
 				.ssl_error_zero_return {
@@ -339,7 +305,9 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 			}
 		}
 	}
-	return res
+
+	// Dead code, for the compiler to pass
+	return error('Unknown error')
 }
 
 pub fn (mut s SSLConn) read(mut buffer []u8) !int {
@@ -357,6 +325,8 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 			eprintln('${@METHOD} total_sent: ${total_sent}, bytes: ${voidptr(bytes):x}, len: ${len}, hex: ${unsafe { bytes.vbytes(len).hex() }}, data:-=-=-=-\n${unsafe { bytes.vstring_with_len(len) }}\n-=-=-=-')
 		}
 	}
+
+	deadline := time.now().add(s.timeout)
 	unsafe {
 		mut ptr_base := bytes
 		for total_sent < len {
@@ -366,19 +336,10 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 			if sent <= 0 {
 				err_res := ssl_error(sent, s.ssl)!
 				if err_res == .ssl_error_want_read {
-					for {
-						ready := @select(s.handle, .read, s.duration)!
-						if ready {
-							break
-						}
-					}
+					s.wait_for_read(deadline - time.now())!
+					continue
 				} else if err_res == .ssl_error_want_write {
-					for {
-						ready := @select(s.handle, .write, s.duration)!
-						if ready {
-							break
-						}
-					}
+					s.wait_for_write(deadline - time.now())!
 					continue
 				} else if err_res == .ssl_error_zero_return {
 					$if trace_ssl ? {
@@ -466,4 +427,24 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 	}
 
 	return net.err_timed_out
+}
+
+// wait_for_common wraps the common wait code
+fn wait_for_common(handle int, test Select, timeout time.Duration) ! {
+	ready := @select(handle, test, timeout)!
+	if ready {
+		return
+	}
+
+	return net.err_timed_out
+}
+
+// wait_for_write waits for a write io operation to be available
+pub fn (mut s SSLConn) wait_for_write(timeout time.Duration) ! {
+	return wait_for_common(s.handle, .write, timeout)
+}
+
+// wait_for_read waits for a read io operation to be available
+pub fn (mut s SSLConn) wait_for_read(timeout time.Duration) ! {
+	return wait_for_common(s.handle, .read, timeout)
 }


### PR DESCRIPTION
This PR:
1. Fixed some ssl library call return values judgment and handling.
2. Fixed timeout handling for ssl/tls read and write operations.
3. Further reduced exception messages in issue #19580.

There are several more PR's for issue #19580, please keep it open, thanks, @spytheman 😄 