### PR TITLE
x.vweb: picoev based event loop for vweb

### DIFF
--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -1,0 +1,1239 @@
+# vweb - the V Web Server
+
+A simple yet powerful web server with built-in routing, parameter handling, templating, and other
+features.
+The [gitly](https://gitly.org/) site is based on vweb.
+
+**_Some features may not be complete, and have some bugs._**
+
+## Quick Start
+Just run **`v new <name> web`** in your terminal.
+
+Run your vweb app with a live reload via `v -d vweb_livereload watch run .`
+
+Now modifying any file in your web app (whether it's a .v file with the backend logic
+or a compiled .html template file) will result in an instant refresh of your app
+in the browser. No need to quit the app, rebuild it, and refresh the page in the browser!
+
+
+## Features
+
+- **Very fast** performance of C on the web.
+- **Small binary** hello world website is <100 KB.
+- **Easy to deploy** just one binary file that also includes all templates. No need to install any
+  dependencies.
+- **Templates are precompiled** all errors are visible at compilation time, not at runtime.
+- **Multithreaded** by default
+
+### Examples
+
+There are some examples
+that can be explored [here](https://github.com/vlang/v/tree/master/examples/vweb).
+
+And others like:
+
+- [vweb_orm_jwt](https://github.com/vlang/v/tree/master/examples/vweb_orm_jwt) (back-end)
+- [vorum](https://github.com/vlang/vorum) (front-end)
+- [gitly](https://github.com/vlang/gitly) (full-stack)
+
+**Front-end getting start example**
+`src/main.v`
+
+```v ignore
+module main
+
+import vweb
+import os
+
+struct App {
+	vweb.Context
+}
+
+struct Object {
+	title       string
+	description string
+}
+
+fn main() {
+	vweb.run_at(new_app(), vweb.RunParams{
+		port: 8081
+	}) or { panic(err) }
+}
+
+fn new_app() &App {
+	mut app := &App{}
+	// makes all static files available.
+	app.mount_static_folder_at(os.resource_abs_path('.'), '/')
+	return app
+}
+
+['/']
+pub fn (mut app App) page_home() vweb.Result {
+	// all this constants can be accessed by src/templates/page/home.html file.
+	page_title := 'V is the new V'
+	v_url := 'https://github.com/vlang/v'
+
+	list_of_object := [
+		Object{
+			title: 'One good title'
+			description: 'this is the first'
+		},
+		Object{
+			title: 'Other good title'
+			description: 'more one'
+		},
+	]
+	// $vweb.html() in `<folder>_<name> vweb.Result ()` like this
+	// render the `<name>.html` in folder `./templates/<folder>`
+	return $vweb.html()
+}
+
+```
+
+`$vweb.html()` compiles an HTML template into V during compilation, and embeds the resulting code
+into the current action.
+
+That means that the template automatically has access to that action's entire environment.
+
+`src/templates/page/home.html`
+
+```html
+<html>
+  <head>
+    <title>${page_title}</title>
+    @css 'src/templates/page/home.css'
+  </head>
+  <body>
+    <h1 class="title">Hello, Vs.</h1>
+    @for var in list_of_object
+    <div>
+      <a href="${v_url}">${var.title}</a>
+      <span>${var.description}</span>
+    </div>
+    @end
+    <div>@include 'component.html'</div>
+  </body>
+</html>
+```
+
+`src/templates/page/component.html`
+
+```html
+<div>This is a component</div>
+```
+
+`src/templates/page/home.css`
+
+```css
+h1.title {
+  font-family: Arial, Helvetica, sans-serif;
+  color: #3b7bbf;
+}
+```
+
+V supports [Template directives](/vlib/v/TEMPLATES.md) like
+`@css`, `@js` for static files in \<path\>
+`@if`, `@for` for conditional and loop
+and
+`@include` to include html components.
+
+## Deploying vweb apps
+
+Everything, including HTML templates, is in one binary file. That's all you need to deploy.
+
+## Getting Started
+
+To start with vweb, you have to import the module `vweb` and define a struct to hold vweb.Context
+(and any other variables your program will need).
+The web server can be started by calling `vweb.run(&App{}, port)` or `vweb.run(&App{}, RunParams)`
+
+**Example:**
+
+```v ignore
+import vweb
+
+struct App {
+    vweb.Context
+}
+
+fn main() {
+	vweb.run(&App{}, 8080)
+	// // or
+	// vweb.run_at(new_app(), vweb.RunParams{
+	// 	host: 'localhost'
+	// 	port: 8099
+	// 	family: .ip
+	// }) or { panic(err) }
+}
+```
+
+### Defining endpoints
+
+To add endpoints to your web server, you have to extend the `App` struct.
+For routing you can either use auto-mapping of function names or specify the path as an attribute.
+The function expects a response of the type `vweb.Result`.
+
+**Example:**
+
+```v ignore
+// This endpoint can be accessed via http://localhost:port/hello
+fn (mut app App) hello() vweb.Result {
+	return app.text('Hello')
+}
+
+// This endpoint can be accessed via http://localhost:port/foo
+["/foo"]
+fn (mut app App) world() vweb.Result {
+	return app.text('World')
+}
+```
+
+#### - HTTP verbs
+
+To use any HTTP verbs (or methods, as they are properly called),
+such as `[post]`, `[get]`, `[put]`, `[patch]` or `[delete]`
+you can simply add the attribute before the function definition.
+
+**Example:**
+
+```v ignore
+[post]
+fn (mut app App) world() vweb.Result {
+	return app.text('World')
+}
+
+['/product/create'; post]
+fn (mut app App) create_product() vweb.Result {
+	return app.text('product')
+}
+```
+
+#### - Parameters
+
+Parameters are passed directly in endpoint route using colon sign `:` and received using the same
+name at function
+To pass a parameter to an endpoint, you simply define it inside an attribute, e. g.
+`['/hello/:user]`.
+After it is defined in the attribute, you have to add it as a function parameter.
+
+**Example:**
+
+```v ignore
+          vvvv
+['/hello/:user']            vvvv
+fn (mut app App) hello_user(user string) vweb.Result {
+	return app.text('Hello $user')
+}
+```
+
+You have access to the raw request data such as headers
+or the request body by accessing `app` (which is `vweb.Context`).
+If you want to read the request body, you can do that by calling `app.req.data`.
+To read the request headers, you just call `app.req.header` and access the
+header you want example. `app.req.header.get(.content_type)`. See `struct Header`
+for all available methods (`v doc net.http Header`).
+It has, too, fields for the `query`, `form`, `files`.
+
+#### - Parameter Arrays
+
+If you want multiple parameters in your route and if you want to parse the parameters 
+yourself, or you want a wildcard route, you can add `...`  after the `:` and name,
+e.g. `['/:path...']`.
+
+This will match all routes after `'/'`. For example the url `/path/to/test` would give
+`path = '/path/to/test'`.
+
+```v ignore
+        vvv
+['/:path...']             vvvv
+fn (mut app App) wildcard(path string) vweb.Result {
+	return app.text('URL path = "${path}"')
+}
+```
+
+#### - Query
+To handle the query context, you just need use the  `query` field
+
+**Example:**
+
+```v
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+}
+
+fn main() {
+	vweb.run(&App{}, 8081)
+}
+
+['/user'; get]
+pub fn (mut app App) controller_get_user_by_id() vweb.Result {
+	// http://localhost:3000/user?q=vpm&order_by=desc => { 'q': 'vpm', 'order_by': 'desc' }
+	return app.text(app.query.str())
+}
+```
+#### - Host
+To restrict an endpoint to a specific host, you can use the `host` attribute
+followed by a colon `:` and the host name. You can test the Host feature locally
+by adding a host to the "hosts" file of your device.
+
+**Example:**
+
+```v ignore
+['/'; host: 'example.com']
+pub fn (mut app App) hello_web() vweb.Result {
+	return app.text('Hello World')
+}
+
+['/'; host: 'api.example.org']
+pub fn (mut app App) hello_api() vweb.Result {
+	return app.text('Hello API')
+}
+
+// define the handler without a host attribute last if you have conflicting paths.
+['/']
+pub fn (mut app App) hello_others() vweb.Result {
+	return app.text('Hello Others')
+}
+```
+
+You can also [create a controller](#hosts) to handle all requests from a specific
+host in one app.
+
+### Middleware
+
+Vweb has different kinds of middleware.
+The `before_request()` method is always called before every request before any
+other middleware is processed. You could use it to check user session cookies or to add a header.
+
+**Example:**
+
+```v ignore
+pub fn (mut app App) before_request() {
+    app.user_id = app.get_cookie('id') or { '0' }
+}
+```
+
+Middleware functions can be passed directly when creating an App instance and is
+executed when the url starts with the defined key.
+
+In the following example, if a user navigates to `/path/to/test` the middleware
+is executed in the following order: `middleware_func`, `other_func`, `global_middleware`.
+The middleware is executed in the same order as they are defined and if any function in
+the chain returns `false` the propogation is stopped.
+
+**Example:**
+```v
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	middlewares map[string][]vweb.Middleware
+}
+
+fn new_app() &App {
+	mut app := &App{
+		middlewares: {
+			// chaining is allowed, middleware will be evaluated in order
+			'/path/to/': [middleware_func, other_func]
+			'/':         [global_middleware]
+		}
+	}
+
+	// do stuff with app
+	// ...
+	return app
+}
+
+fn middleware_func(mut ctx vweb.Context) bool {
+	// ...
+	return true
+}
+
+fn other_func(mut ctx vweb.Context) bool {
+	// ...
+	return true
+}
+
+fn global_middleware(mut ctx vweb.Context) bool {
+	// ...
+	return true
+}
+```
+
+Middleware functions will be of type `vweb.Middleware` and are not methods of App,
+so they could also be imported from other modules.
+```v ignore
+pub type Middleware = fn (mut Context) bool
+```
+
+Middleware can also be added to route specific functions via attributes.
+
+**Example:**
+```v ignore
+[middleware: check_auth]
+['/admin/data']
+pub fn (mut app App) admin() vweb.Result {
+	// ...
+}
+
+// check_auth is a method of App, so we don't need to pass the context as parameter.
+pub fn (mut app App) check_auth () bool {
+	// ...
+	return true
+}
+```
+You can only add 1 middleware to a route specific function via attributes.
+
+#### Middleware evaluation order
+The middleware is executed in the following order:
+
+1. `before_request`
+2. The middleware in `app.middlewares`
+3. The middleware in the `[middleware]` attribute
+
+If any function of step 2 or 3 returns `false` the middleware functions that would
+come after it are not executed and the app handler will also not be executed. You
+can think of it as a chain.
+
+### Context values
+
+You can store a value pair in vweb's context. It is especially useful for passing variables
+from a middleware function to the route handler.
+
+**Example**:
+```v oksyntax
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	middlewares map[string][]vweb.Middleware
+}
+
+pub fn (mut app App) index() vweb.Result {
+	// get the user or return HTTP 401
+	user := app.get_value[User]('user') or {
+		app.set_status(401, '')
+		return app.text('HTTP 401: Unauthorized')
+	}
+
+	return app.text('welcome ${user.name}')
+}
+
+fn main() {
+	vweb.run(&App{
+		middlewares: {
+			'/': [get_session]
+		}
+	}, 8080)
+}
+
+struct User {
+	session_id string
+	name       string
+}
+
+fn get_session(mut ctx vweb.Context) bool {
+	// impelement your own logic to get the user
+	user := User{
+		session_id: '123456'
+		name: 'Vweb'
+	}
+
+	// set the user
+	ctx.set_value('user', user)
+	return true
+}
+```
+
+When you visit the index page the middleware function `get_session` will run first
+This function sets a `User` value to a key `'user'`.
+We get this key in `index` and display it to the user if the `'user'` key exists.
+
+#### Changing Context values
+
+By default context values are immutable when retrieved with `get_value`. If you want to
+change the value later you have to set it again with `set_value`.
+
+**Example:**
+```v ignore
+fn change_user(mut ctx vweb.Context) bool {
+	user := User{
+		session_id: '654321'
+		name: 'tester'
+	}
+
+	// set the user
+	ctx.set_value('user', user)
+	return true
+}
+```
+
+### Redirect
+
+Used when you want be redirected to an url
+
+**Examples:**
+
+```v ignore
+pub fn (mut app App) before_request() {
+	app.user_id = app.get_cookie('id') or { app.redirect('/') }
+}
+```
+
+```v ignore
+['/articles'; get]
+pub fn (mut app App) articles() vweb.Result {
+	if !app.token {
+		app.redirect('/login')
+	}
+	return app.text('patatoes')
+}
+```
+
+You can also combine middleware and redirect.
+
+**Example:**
+
+```v ignore
+[middleware: with_auth]
+['/admin/secret']
+pub fn (mut app App) admin_secret() vweb.Result {
+	// this code should never be reached
+	return app.text('secret')
+}
+
+['/redirect']
+pub fn (mut app App) with_auth() bool {
+	app.redirect('/auth/login')
+	return false
+}
+```
+
+### Custom not found page
+You can implement a `not_found` route that is called when a request is made and no
+matching route is found to replace the default HTTP 404 not found page.
+
+**Example:**
+
+``` v ignore
+pub fn (mut app App) not_found() vweb.Result {
+	app.set_status(404, 'Not Found')
+	return app.html('<h1>Page not found</h1>')
+}
+```
+
+### Databases
+The `db` field in a vweb app is reserved for database connections. The connection is
+copied to each new request.
+
+**Example:**
+
+```v
+module main
+
+import vweb
+import db.sqlite
+
+struct App {
+	vweb.Context
+mut:
+	db sqlite.DB
+}
+
+fn main() {
+	// create the database connection
+	mut db := sqlite.connect('db')!
+
+	vweb.run(&App{
+		db: db
+	}, 8080)
+}
+```
+
+### Multithreading
+By default, a vweb app is multithreaded, that means that multiple requests can
+be handled in parallel by using multiple CPU's: a worker pool. You can
+change the number of workers (maximum allowed threads) by altering the `nr_workers`
+option. The default behaviour is to use the maximum number of jobs (cores in most cases).
+
+**Example:**
+```v ignore
+fn main() {
+	// assign a maximum of 4 workers
+	vweb.run_at(&App{}, nr_workers: 4)
+}
+```
+
+#### Database Pool
+A single connection database works fine if you run your app with 1 worker, of if
+you access a file-based database like a sqlite file.
+
+This approach will fail when using a non-file based database connection like a mysql
+connection to another server somewhere on the internet. Multiple threads would need to access
+the same connection at the same time.
+
+To resolve this issue, you can use the vweb's built-in database pool. The database pool
+will keep a number of connections open when the app is started and each worker is
+assigned its own connection.
+
+Let's look how we can improve our previous example with database pooling and using a
+postgresql server instead.
+
+**Example:**
+```v
+module main
+
+import vweb
+import db.pg
+
+struct App {
+	vweb.Context
+	db_handle vweb.DatabasePool[pg.DB]
+mut:
+	db pg.DB
+}
+
+fn get_database_connection() pg.DB {
+	// insert your own credentials
+	return pg.connect(user: 'user', password: 'password', dbname: 'database') or { panic(err) }
+}
+
+fn main() {
+	// create the database pool and pass our `get_database_connection` function as handler
+	pool := vweb.database_pool(handler: get_database_connection)
+
+	// no need to set the `db` field
+	vweb.run(&App{
+		db_handle: pool
+	}, 8080)
+}
+```
+
+If you don't use the default number of workers (`nr_workers`) you have to change
+it to the same number in `vweb.run_at` as in `vweb.database_pool`
+
+### Extending the App struct with `[vweb_global]`
+You can change your `App` struct however you like, but there are some things you
+have to keep in mind. Under the hood at each request a new instance of `App` is
+constructed, and all fields are re-initialized with their default type values,
+except for the `db` field.
+
+This behaviour ensures that each request is treated equally and in the same context, but
+problems arise when we want to provide more context than just the default `vweb.Context`.
+
+Let's view the following example where we want to provide a secret token to our app:
+
+```v
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	secret string
+}
+
+fn main() {
+	vweb.run(&App{
+		secret: 'my secret'
+	}, 8080)
+}
+
+fn (mut app App) index() vweb.Result {
+	return app.text('My secret is: ${app.secret}')
+}
+```
+
+When you visit `localhost:8080/` you would expect to see the text
+`"My secret is: my secret"`, but instead there is only the text
+`"My secret is: "`. This is because of the way vweb works. We can override the default
+behaviour by adding the attribute `[vweb_global]` to the `secret` field.
+
+**Example:**
+```v ignore
+struct App {
+	vweb.Context
+	secret string [vweb_global]
+}
+```
+
+Now if you visit `localhost:8080/` you see the text `"My secret is: my secret"`.
+> **Note**: the value of `secret` gets initialized with the provided value when creating
+> `App`. If you would modify `secret` in one request the value won't be changed in the
+> next request. You can use shared fields for this.
+
+### Shared Objects across requests
+We saw in the previous section that we can persist data across multiple requests,
+but what if we want to be able to mutate the data? Since vweb works with threads,
+we have to use `shared` fields.
+
+Let's see how we can add a visitor counter to our `App`.
+
+**Example:**
+```v
+module main
+
+import vweb
+
+struct Counter {
+pub mut:
+	count int
+}
+
+struct App {
+	vweb.Context
+mut:
+	counter shared Counter // shared fields can only be structs, arrays or maps.
+}
+
+fn main() {
+	// initialize the shared object
+	shared counter := Counter{
+		count: 0
+	}
+
+	vweb.run(&App{
+		counter: counter
+	}, 8080)
+}
+
+fn (mut app App) index() vweb.Result {
+	mut count := 0
+	// lock the counter so we can modify it
+	lock app.counter {
+		app.counter.count += 1
+		count = app.counter.count
+	}
+	return app.text('Total visitors: ${count}')
+}
+```
+
+#### Drawback of Shared Objects
+The drawback of using shared objects is that it affects performance. In the previous example
+`App.counter` needs to be locked each time the page is loaded if there are simultaneous
+requests the next requests will have to wait for the lock to be released.
+
+It is best practice to limit the use of shared objects as much as possible.
+
+### Controllers
+Controllers can be used to split up app logic so you are able to have one struct
+per `"/"`.  E.g. a struct `Admin` for urls starting with `"/admin"` and a struct `Foo`
+for urls starting with `"/foo"`
+
+**Example:**
+```v
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	vweb.Controller
+}
+
+struct Admin {
+	vweb.Context
+}
+
+struct Foo {
+	vweb.Context
+}
+
+fn main() {
+	mut app := &App{
+		controllers: [
+			vweb.controller('/admin', &Admin{}),
+			vweb.controller('/foo', &Foo{}),
+		]
+	}
+	vweb.run(app, 8080)
+}
+```
+
+You can do everything with a controller struct as with a regular `App` struct.
+The only difference being is that only the main app that is being passed to `vweb.run`
+is able to have controllers. If you add `vweb.Controller` on a controller struct it
+will simply be ignored.
+
+#### Routing
+Any route inside a controller struct is treated as a relative route to its controller namespace.
+
+```v ignore
+['/path']
+pub fn (mut app Admin) path vweb.Result {
+    return app.text('Admin')
+}
+```
+When we created the controller with `vweb.controller('/admin', &Admin{})` we told
+vweb that the namespace of that controller is `"/admin"` so in this example we would
+see the text `"Admin"` if we navigate to the url `"/admin/path"`.
+
+Vweb doesn't support fallback routes or duplicate routes, so if we add the following
+route to the example the code will produce an error.
+
+```v ignore
+['/admin/path']
+pub fn (mut app App) admin_path vweb.Result {
+    return app.text('Admin overwrite')
+}
+```
+There will be an error, because the controller `Admin` handles all routes starting with
+`"/admin"`; the method `admin_path` is unreachable.
+
+#### Hosts
+You can also set a host for a controller. All requests coming from that host will be handled
+by the controller.
+
+**Example:**
+```v
+module main
+
+import vweb
+
+struct App {
+	vweb.Context
+	vweb.Controller
+}
+
+pub fn (mut app App) index() vweb.Result {
+	return app.text('App')
+}
+
+struct Example {
+	vweb.Context
+}
+
+// You can only access this route at example.com: http://example.com/
+pub fn (mut app Example) index() vweb.Result {
+	return app.text('Example')
+}
+
+fn main() {
+	vweb.run(&App{
+		controllers: [
+			vweb.controller_host('example.com', '/', &Example{}),
+		]
+	}, 8080)
+}
+```
+
+#### Databases and `[vweb_global]` in controllers
+
+Fields with `[vweb_global]` have to passed to each controller individually.
+The `db` field is unique and will be treated as a `vweb_global` field at all times.
+
+**Example:**
+```v
+module main
+
+import vweb
+import db.sqlite
+
+struct App {
+	vweb.Context
+	vweb.Controller
+mut:
+	db sqlite.DB
+}
+
+struct Admin {
+	vweb.Context
+mut:
+	db sqlite.DB
+}
+
+fn main() {
+	mut db := sqlite.connect('db')!
+
+	mut app := &App{
+		db: db
+		controllers: [
+			vweb.controller('/admin', &Admin{
+				db: db
+			}),
+		]
+	}
+}
+```
+
+#### Using a database pool
+
+**Example:**
+```v
+module main
+
+import vweb
+import db.pg
+
+struct App {
+	vweb.Context
+	vweb.Controller
+	db_handle vweb.DatabasePool[pg.DB]
+mut:
+	db pg.DB
+}
+
+struct Admin {
+	vweb.Context
+	db_handle vweb.DatabasePool[pg.DB]
+mut:
+	db pg.DB
+}
+
+fn get_database_connection() pg.DB {
+	// insert your own credentials
+	return pg.connect(user: 'user', password: 'password', dbname: 'database') or { panic(err) }
+}
+
+fn main() {
+	// create the database pool and pass our `get_database_connection` function as handler
+	pool := vweb.database_pool(handler: get_database_connection)
+
+	mut app := &App{
+		db_handle: pool
+		controllers: [
+			vweb.controller('/admin', &Admin{
+				db_handle: pool
+			}),
+		]
+	}
+}
+```
+
+### Responses
+
+#### - set_status
+
+Sets the response status
+**Example:**
+
+```v ignore
+['/user/get_all'; get]
+pub fn (mut app App) controller_get_all_user() vweb.Result {
+    token := app.get_header('token')
+
+    if !token {
+        app.set_status(401, '')
+        return app.text('Not valid token')
+    }
+
+    response := app.service_get_all_user() or {
+        app.set_status(400, '')
+        return app.text('$err')
+    }
+    return app.json(response)
+}
+```
+
+#### - html
+
+Response HTTP_OK with payload with content-type `text/html`
+**Example:**
+
+```v ignore
+pub fn (mut app App) html_page() vweb.Result {
+    return app.html('<h1>ok</h1>')
+}
+```
+
+#### - text
+
+Response HTTP_OK with payload with content-type `text/plain`
+**Example:**
+
+```v ignore
+pub fn (mut app App) simple() vweb.Result {
+    return app.text('A simple result')
+}
+```
+
+#### - json
+
+Response HTTP_OK with payload with content-type `application/json`
+**Examples:**
+
+```v ignore
+['/articles'; get]
+pub fn (mut app App) articles() vweb.Result {
+    articles := app.find_all_articles()
+    json_result := json.encode(articles)
+    return app.json(json_result)
+}
+```
+
+```v ignore
+['/user/create'; post]
+pub fn (mut app App) controller_create_user() vweb.Result {
+    body := json.decode(User, app.req.data) or {
+        app.set_status(400, '')
+        return app.text('Failed to decode json, error: $err')
+	}
+
+    response := app.service_add_user(body.username, body.password) or {
+        app.set_status(400, '')
+        return app.text('error: $err')
+    }
+
+    return app.json(response)
+}
+```
+
+#### - json_pretty
+
+Response HTTP_OK with a pretty-printed JSON result
+**Example:**
+
+```v ignore
+fn (mut app App) time_json_pretty() {
+    app.json_pretty({
+        'time': time.now().format()
+    })
+}
+```
+
+#### - file
+
+Response HTTP_OK with file as payload
+
+#### - ok
+
+Response HTTP_OK with payload
+**Example:**
+
+```v ignore
+['/form_echo'; post]
+pub fn (mut app App) form_echo() vweb.Result {
+    app.set_content_type(app.req.header.get(.content_type) or { '' })
+    return app.ok(app.form['foo'])
+}
+```
+
+#### - server_error
+
+Response a server error
+**Example:**
+
+```v ignore
+fn (mut app App) sse() vweb.Result {
+    return app.server_error(501)
+}
+```
+
+#### - not_found
+
+Response HTTP_NOT_FOUND with payload
+**Example:**
+
+```v ignore
+['/:user/:repo/settings']
+pub fn (mut app App) user_repo_settings(username string, repository string) vweb.Result {
+    if username !in known_users {
+        return app.not_found()
+    }
+    return app.html('username: $username | repository: $repository')
+}
+```
+
+### Requests
+
+#### - get_header
+
+Returns the header data from the key
+**Example:**
+
+```v ignore
+['/user/get_all'; get]
+pub fn (mut app App) controller_get_all_user() vweb.Result {
+    token := app.get_header('token')
+    return app.text(token)
+}
+```
+
+#### - get_cookie
+
+Sets a cookie
+**Example:**
+
+```v ignore
+pub fn (mut app App) before_request() {
+    app.user_id = app.get_cookie('id') or { '0' }
+}
+```
+
+#### - add_header
+
+Adds an header to the response with key and val
+**Example:**
+
+```v ignore
+['/upload'; post]
+pub fn (mut app App) upload() vweb.Result {
+    fdata := app.files['upfile']
+
+    data_rows := fdata[0].data.split('\n')
+
+    mut output_data := ''
+
+    for elem in data_rows {
+        delim_row := elem.split('\t')
+        output_data += '${delim_row[0]}\t${delim_row[1]}\t'
+        output_data += '${delim_row[0].int() + delim_row[1].int()}\n'
+	}
+
+    output_data = output_data.all_before_last('\n')
+
+    app.add_header('Content-Disposition', 'attachment; filename=results.txt')
+    app.send_response_to_client('application/octet-stream', output_data)
+
+    return $vweb.html()
+}
+```
+
+#### - set_cookie
+
+Sets a cookie
+**Example:**
+
+```v ignore
+pub fn (mut app App) cookie() vweb.Result {
+    app.set_cookie(name: 'cookie', value: 'test')
+    return app.text('Response Headers\n$app.header')
+}
+```
+
+#### - set_cookie_with_expire_date
+
+Sets a cookie with a `expire_data`
+**Example:**
+
+```v ignore
+pub fn (mut app App) cookie() vweb.Result {
+    key := 'cookie'
+    value := 'test'
+    duration := time.Duration(2 * time.minute ) // add 2 minutes
+    expire_date := time.now().add(duration)
+
+    app.set_cookie_with_expire_date(key, value, expire_date)
+    return app.text('Response Headers\n$app.header')
+}
+```
+
+#### - set_content_type
+
+Sets the response content type
+**Example:**
+
+```v ignore
+['/form_echo'; post]
+pub fn (mut app App) form_echo() vweb.Result {
+    app.set_content_type(app.req.header.get(.content_type) or { '' })
+    return app.ok(app.form['foo'])
+}
+```
+
+### Template
+
+#### -handle_static
+
+handle_static is used to mark a folder (relative to the current working folder) as one that
+contains only static resources (css files, images etc).\
+host_handle_static can be used to limit the static resources to a specific host.
+
+If `root` is set the mount path for the dir will be in '/'
+
+**Example:**
+
+```v ignore
+fn main() {
+    mut app := &App{}
+    app.serve_static('/favicon.ico', 'favicon.ico')
+    // app.host_serve_static('localhost', '/favicon.ico', 'favicon.ico')
+    // Automatically make available known static mime types found in given directory.
+    os.chdir(os.dir(os.executable()))?
+    app.handle_static('assets', true)
+    vweb.run(app, port)
+}
+```
+
+#### -mount_static_folder_at
+
+makes all static files in `directory_path` and inside it, available at http://server/mount_path.
+
+For example: suppose you have called .mount_static_folder_at('/var/share/myassets', '/assets'),
+and you have a file /var/share/myassets/main.css .
+=> That file will be available at URL: http://server/assets/main.css .
+
+mount_static_folder_at can be used to limit the static resources to a specific host.
+
+#### -serve_static
+
+Serves a file static.
+`url` is the access path on the site, `file_path` is the real path to the file, `mime_type` is the
+file type
+
+host_serve_static can be used to limit the static resources to a specific host.
+
+**Example:**
+
+```v ignore
+fn main() {
+    mut app := &App{}
+    app.serve_static('/favicon.ico', 'favicon.ico')
+    // app.host_serve_static('localhost', /favicon.ico', 'favicon.ico')
+    app.mount_static_folder_at(os.resource_abs_path('.'), '/')
+    vweb.run(app, 8081)
+}
+```
+
+### Others
+
+#### -user_agent
+
+Returns the user-agent from the current user
+
+**Example:**
+
+```v ignore
+pub fn (mut app App) user_agent() vweb.Result {
+    ua := app.user_agent()
+    return app.text('User-Agent: $ua')
+}
+```
+
+#### -ip
+
+Returns the ip address from the current user
+
+**Example:**
+
+```v ignore
+pub fn (mut app App) ip() vweb.Result {
+    ip := app.ip()
+    return app.text('ip: $ip')
+}
+```
+
+#### -error
+
+Set a string to the form error
+
+**Example:**
+
+```v ignore
+pub fn (mut app App) error() vweb.Result {
+    app.error('here as an error')
+    println(app.form_error) //'vweb error: here as an error'
+}
+```
+# Cross-Site Request Forgery (CSRF) protection
+
+Vweb has built-in csrf protection. Go to the [csrf module](csrf/) to learn how
+you can protect your app against CSRF.

--- a/vlib/x/vweb/assets/assets.v
+++ b/vlib/x/vweb/assets/assets.v
@@ -1,0 +1,235 @@
+module assets
+
+// this module provides an AssetManager for combining
+// and caching javascript & css.
+import os
+import time
+import crypto.md5
+
+const (
+	unknown_asset_type_error = 'vweb.assets: unknown asset type'
+)
+
+pub struct AssetManager {
+mut:
+	css []Asset
+	js  []Asset
+pub mut:
+	// when true assets will be minified
+	minify bool
+	// the directory to store the cached/combined files
+	cache_dir string
+}
+
+struct Asset {
+	file_path     string
+	last_modified time.Time
+mut:
+	include_name string
+}
+
+// new_manager returns a new AssetManager
+pub fn new_manager() &AssetManager {
+	return &AssetManager{}
+}
+
+// add_css adds a css asset
+pub fn (mut am AssetManager) add_css(file string) bool {
+	return am.add('css', file)
+}
+
+// add_css_as adds a css asset with a custom href
+pub fn (mut am AssetManager) add_css_as(file string, href string) bool {
+	if am.add('css', file) {
+		// set name of added asset
+		am.css.last().include_name = href
+		return true
+	} else {
+		return false
+	}
+}
+
+// add_js adds a js asset
+pub fn (mut am AssetManager) add_js(file string) bool {
+	return am.add('js', file)
+}
+
+// add_js_as adds a js asset with a custom src
+pub fn (mut am AssetManager) add_js_as(file string, src string) bool {
+	if am.add('js', file) {
+		// set name of added asset
+		am.js.last().include_name = src
+		return true
+	} else {
+		return false
+	}
+}
+
+// combine_css returns the combined css as a string when to_file is false
+// when to_file is true it combines the css to disk and returns the path of the file
+pub fn (am AssetManager) combine_css(to_file bool) string {
+	return am.combine('css', to_file)
+}
+
+// combine_js returns the combined js as a string when to_file is false
+// when to_file is true it combines the css to disk and returns the path of the file
+pub fn (am AssetManager) combine_js(to_file bool) string {
+	return am.combine('js', to_file)
+}
+
+// include_css returns the html <link> tag(s) for including the css files in a page.
+// when combine is true the files are combined.
+pub fn (am AssetManager) include_css(combine bool) string {
+	return am.include('css', combine)
+}
+
+// include_js returns the html <script> tag(s) for including the js files in a page.
+// when combine is true the files are combined.
+pub fn (am AssetManager) include_js(combine bool) string {
+	return am.include('js', combine)
+}
+
+fn (am AssetManager) combine(asset_type string, to_file bool) string {
+	if am.cache_dir == '' {
+		panic('vweb.assets: you must set a cache dir.')
+	}
+	cache_key := am.get_cache_key(asset_type)
+	out_file := '${am.cache_dir}/${cache_key}.${asset_type}'
+	mut out := ''
+	// use cache
+	if os.exists(out_file) {
+		if to_file {
+			return out_file
+		}
+		cached := os.read_file(out_file) or { return '' }
+		return cached
+	}
+	// rebuild
+	for asset in am.get_assets(asset_type) {
+		data := os.read_file(asset.file_path) or { return '' }
+		out += data
+	}
+	if am.minify {
+		if asset_type == 'css' {
+			out = minify_css(out)
+		} else {
+			out = minify_js(out)
+		}
+	}
+	if !to_file {
+		return out
+	}
+	if !os.is_dir(am.cache_dir) {
+		os.mkdir(am.cache_dir) or { panic(err) }
+	}
+	mut file := os.create(out_file) or { panic(err) }
+	file.write(out.bytes()) or { panic(err) }
+	file.close()
+	return out_file
+}
+
+fn (am AssetManager) get_cache_key(asset_type string) string {
+	mut files_salt := ''
+	mut latest_modified := i64(0)
+	for asset in am.get_assets(asset_type) {
+		files_salt += asset.file_path
+		if asset.last_modified.unix > latest_modified {
+			latest_modified = asset.last_modified.unix
+		}
+	}
+	hash := md5.sum(files_salt.bytes()).hex()
+	return '${hash}-${latest_modified}'
+}
+
+fn (am AssetManager) include(asset_type string, combine bool) string {
+	assets := am.get_assets(asset_type)
+	mut out := ''
+	if asset_type == 'css' {
+		if combine {
+			file := am.combine(asset_type, true)
+			return '<link rel="stylesheet" href="${file}">\n'
+		}
+		for asset in assets {
+			mut href := asset.file_path
+			if asset.include_name.len > 0 {
+				href = asset.include_name
+			}
+
+			out += '<link rel="stylesheet" href="${href}">\n'
+		}
+	}
+	if asset_type == 'js' {
+		if combine {
+			file := am.combine(asset_type, true)
+			return '<script type="text/javascript" src="${file}"></script>\n'
+		}
+		for asset in assets {
+			mut src := asset.file_path
+			if asset.include_name.len > 0 {
+				src = asset.include_name
+			}
+
+			out += '<script type="text/javascript" src="${src}"></script>\n'
+		}
+	}
+	return out
+}
+
+// dont return option until size limit is removed
+// fn (mut am AssetManager) add(asset_type, file string) ?bool {
+pub fn (mut am AssetManager) add(asset_type string, file string) bool {
+	if !os.exists(file) {
+		// return error('vweb.assets: cannot add asset $file, it does not exist')
+		return false
+	}
+	asset := Asset{
+		file_path: file
+		last_modified: time.Time{
+			unix: os.file_last_mod_unix(file)
+		}
+	}
+	if asset_type == 'css' {
+		am.css << asset
+	} else if asset_type == 'js' {
+		am.js << asset
+	} else {
+		panic('${assets.unknown_asset_type_error} (${asset_type}).')
+	}
+	return true
+}
+
+fn (am AssetManager) exists(asset_type string, file string) bool {
+	assets := am.get_assets(asset_type)
+	for asset in assets {
+		if asset.file_path == file {
+			return true
+		}
+	}
+	return false
+}
+
+fn (am AssetManager) get_assets(asset_type string) []Asset {
+	if asset_type != 'css' && asset_type != 'js' {
+		panic('${assets.unknown_asset_type_error} (${asset_type}).')
+	}
+	assets := if asset_type == 'css' { am.css } else { am.js }
+	return assets
+}
+
+// todo: implement proper minification
+pub fn minify_css(css string) string {
+	mut lines := css.split('\n')
+	for i, _ in lines {
+		lines[i] = lines[i].trim_space()
+	}
+	return lines.join(' ')
+}
+
+// todo: implement proper minification
+pub fn minify_js(js string) string {
+	mut lines := js.split('\n')
+	for i, _ in lines {
+		lines[i] = lines[i].trim_space()
+	}
+	return lines.join(' ')
+}

--- a/vlib/x/vweb/assets/assets_test.v
+++ b/vlib/x/vweb/assets/assets_test.v
@@ -1,0 +1,199 @@
+import vweb.assets
+import os
+
+const base_cache_dir = os.join_path(os.vtmp_dir(), 'v', 'assets_test_cache')
+
+fn testsuite_begin() {
+	os.mkdir_all(base_cache_dir) or {}
+}
+
+fn testsuite_end() {
+	os.rmdir_all(base_cache_dir) or {}
+}
+
+// clean_cache_dir used before and after tests that write to a cache directory.
+// Because of parallel compilation and therefore test running,
+// unique cache dirs are needed per test function.
+fn clean_cache_dir(dir string) {
+	os.rmdir_all(dir) or {}
+}
+
+fn cache_dir(test_name string) string {
+	return os.join_path(base_cache_dir, test_name)
+}
+
+fn get_test_file_path(file string) string {
+	path := os.join_path(base_cache_dir, file)
+	os.rm(path) or {}
+	os.write_file(path, get_test_file_contents(file)) or { panic(err) }
+	return path
+}
+
+fn get_test_file_contents(file string) string {
+	contents := match file {
+		'test1.js' { '{"one": 1}\n' }
+		'test2.js' { '{"two": 2}\n' }
+		'test1.css' { '.one {\n\tcolor: #336699;\n}\n' }
+		'test2.css' { '.two {\n\tcolor: #996633;\n}\n' }
+		else { 'wibble\n' }
+	}
+	return contents
+}
+
+fn test_set_cache() {
+	mut am := assets.new_manager()
+	am.cache_dir = 'cache'
+}
+
+fn test_set_minify() {
+	mut am := assets.new_manager()
+	am.minify = true
+}
+
+fn test_add() {
+	mut am := assets.new_manager()
+	assert am.add('css', 'testx.css') == false
+	assert am.add('css', get_test_file_path('test1.css')) == true
+	assert am.add('js', get_test_file_path('test1.js')) == true
+	// assert am.add('css', get_test_file_path('test2.js')) == false // TODO: test extension on add
+}
+
+fn test_add_css() {
+	mut am := assets.new_manager()
+	assert am.add_css('testx.css') == false
+	assert am.add_css(get_test_file_path('test1.css')) == true
+	// assert am.add_css(get_test_file_path('test1.js')) == false // TODO: test extension on add
+}
+
+fn test_add_css_as() {
+	mut am := assets.new_manager()
+	file_name := '/custom/path/test1.css'
+	assert am.add_css_as(get_test_file_path('test1.css'), file_name) == true
+
+	expected := '<link rel="stylesheet" href="${file_name}">\n'
+	actual := am.include_css(false)
+	assert actual == expected
+}
+
+fn test_add_js() {
+	mut am := assets.new_manager()
+	assert am.add_js('testx.js') == false
+	assert am.add_css(get_test_file_path('test1.js')) == true
+	// assert am.add_css(get_test_file_path('test1.css')) == false // TODO: test extension on add
+}
+
+fn test_add_js_as() {
+	mut am := assets.new_manager()
+	file_name := '/custom/path/test1.js'
+	assert am.add_js_as(get_test_file_path('test1.js'), file_name) == true
+
+	expected := '<script type="text/javascript" src="${file_name}"></script>\n'
+	actual := am.include_js(false)
+	assert expected == actual
+}
+
+fn test_combine_css() {
+	mut am := assets.new_manager()
+	am.cache_dir = cache_dir('test_combine_css')
+	clean_cache_dir(am.cache_dir)
+	am.add_css(get_test_file_path('test1.css'))
+	am.add_css(get_test_file_path('test2.css'))
+	// TODO: How do I test non-minified, is there a "here doc" format that keeps formatting?
+	am.minify = true
+	expected := '.one { color: #336699; } .two { color: #996633; } '
+	actual := am.combine_css(false)
+	assert actual == expected
+	assert actual.contains(expected)
+	// Test cache path doesn't change when input files and minify setting do not.
+	path1 := am.combine_css(true)
+	clean_cache_dir(am.cache_dir)
+	path2 := am.combine_css(true)
+	assert path1 == path2
+	clean_cache_dir(am.cache_dir)
+}
+
+fn test_combine_js() {
+	mut am := assets.new_manager()
+	am.cache_dir = cache_dir('test_combine_js')
+	clean_cache_dir(am.cache_dir)
+	am.add_js(get_test_file_path('test1.js'))
+	am.add_js(get_test_file_path('test2.js'))
+	expected1 := '{"one": 1}'
+	expected2 := '{"two": 2}'
+	expected := expected1 + '\n' + expected2 + '\n'
+	actual := am.combine_js(false)
+	assert actual == expected
+	assert actual.contains(expected)
+	assert actual.contains(expected1)
+	assert actual.contains(expected2)
+	am.minify = true
+	clean_cache_dir(am.cache_dir)
+	expected3 := expected1 + ' ' + expected2 + ' '
+	actual2 := am.combine_js(false)
+	assert actual2 == expected3
+	assert actual2.contains(expected3)
+	// Test cache path doesn't change when input files and minify setting do not.
+	path1 := am.combine_js(true)
+	clean_cache_dir(am.cache_dir)
+	path2 := am.combine_js(true)
+	assert path1 == path2
+	clean_cache_dir(am.cache_dir)
+}
+
+fn test_include_css() {
+	mut am := assets.new_manager()
+	file1 := get_test_file_path('test1.css')
+	am.add_css(file1)
+	expected := '<link rel="stylesheet" href="${file1}">\n'
+	actual := am.include_css(false)
+	assert actual == expected
+	assert actual.contains(expected)
+	// Two lines of output.
+	file2 := get_test_file_path('test2.css')
+	am.add_css(file2)
+	am.cache_dir = cache_dir('test_include_css')
+	clean_cache_dir(am.cache_dir)
+	expected2 := expected + '<link rel="stylesheet" href="${file2}">\n'
+	actual2 := am.include_css(false)
+	assert actual2 == expected2
+	assert actual2.contains(expected2)
+	// Combined output.
+	clean_cache_dir(am.cache_dir)
+	actual3 := am.include_css(true)
+	assert actual3.contains(expected2) == false
+	assert actual3.starts_with('<link rel="stylesheet" href="${am.cache_dir}/') == true
+	// Test cache path doesn't change when input files and minify setting do not.
+	clean_cache_dir(am.cache_dir)
+	actual4 := am.include_css(true)
+	assert actual4 == actual3
+	clean_cache_dir(am.cache_dir)
+}
+
+fn test_include_js() {
+	mut am := assets.new_manager()
+	file1 := get_test_file_path('test1.js')
+	am.add_js(file1)
+	expected := '<script type="text/javascript" src="${file1}"></script>\n'
+	actual := am.include_js(false)
+	assert actual == expected
+	assert actual.contains(expected)
+	// Two lines of output.
+	file2 := get_test_file_path('test2.js')
+	am.add_js(file2)
+	am.cache_dir = cache_dir('test_include_js')
+	clean_cache_dir(am.cache_dir)
+	expected2 := expected + '<script type="text/javascript" src="${file2}"></script>\n'
+	actual2 := am.include_js(false)
+	assert actual2 == expected2
+	assert actual2.contains(expected2)
+	// Combined output.
+	clean_cache_dir(am.cache_dir)
+	actual3 := am.include_js(true)
+	assert actual3.contains(expected2) == false
+	assert actual3.starts_with('<script type="text/javascript" src="${am.cache_dir}/')
+	// Test cache path doesn't change when input files and minify setting do not.
+	clean_cache_dir(am.cache_dir)
+	actual4 := am.include_js(true)
+	assert actual4 == actual3
+	clean_cache_dir(am.cache_dir)
+}

--- a/vlib/x/vweb/csrf/README.md
+++ b/vlib/x/vweb/csrf/README.md
@@ -1,0 +1,237 @@
+# Cross-Site Request Forgery (CSRF) protection
+
+This module implements the [double submit cookie][owasp] technique to protect routes 
+from CSRF attacks.
+
+CSRF is a type of attack that occurs when a malicious program/website (and others) causes
+a user's web browser to perform an action without them knowing. A web browser automatically sends
+cookies to a website when it performs a request, including session cookies. So if a user is
+authenticated on your website the website can not distinguish a forged request by a legitimate
+request.
+
+## When to not add CSRF-protection
+If you are creating a service that is intended to be used by other servers e.g. an API,
+you probably don't want CSRF-protection. An alternative would be to send an Authorization
+token in, and only in, an HTTP-header (like JSON Web Tokens). If you do that your website
+isn't vulnerable to CSRF-attacks.
+
+## Usage
+
+You can add `CsrfApp` to your own `App` struct to have the functions available 
+in your app's context, or you can use it with the middleware of vweb. 
+
+The advantage of the middleware approach is that you have to define
+the configuration separate from your `App`. This makes it possible to share the 
+configuration between modules or controllers.
+
+### Usage with the CsrfApp
+
+Change `secret` and `allowed_hosts` when creating the `CsrfApp`.
+
+**Example**:
+```v ignore
+module main
+
+import net.http
+import vweb
+import vweb.csrf
+
+struct App {
+	vweb.Context
+pub mut:
+	csrf csrf.CsrfApp [vweb_global]
+}
+
+fn main() {
+	app := &App{
+		csrf: csrf.CsrfApp{
+			// change the secret
+			secret: 'my-64bytes-secret'
+			// change to which domains you want to allow
+			allowed_hosts: ['*']
+		}
+	}
+	vweb.run(app, 8080)
+}
+
+pub fn (mut app App) index() vweb.Result {
+	// this line sets `app.token` and the cookie
+	app.csrf.set_token(mut app.Context)
+	return $vweb.html()
+}
+
+[post]
+pub fn (mut app App) auth() vweb.Result {
+	// this line protects the route against CSRF
+	app.csrf.protect(mut app.Context)
+	return app.text('authenticated!')
+}
+```
+
+index.html
+```html
+<form action="/auth" method="post">
+    <input type="hidden" name="@app.csrf.token_name" value="@app.csrf.token"/>
+    <label for="password">Your password:</label>
+    <input type="text" id="password" name="password" placeholder="Your password" />
+</form>
+```
+
+### Usage without CsrfApp
+If you use `vweb.Middleware` you can protect multiple routes at once.
+
+**Example**:
+```v ignore
+module main
+
+import net.http
+import vweb
+import vweb.csrf
+
+const (
+	// the configuration moved here
+	csrf_config = csrf.CsrfConfig{
+		// change the secret
+		secret: 'my-64bytes-secret'
+		// change to which domains you want to allow
+		allowed_hosts: ['*']
+	}
+)
+
+struct App {
+	vweb.Context
+pub mut:
+	middlewares map[string][]vweb.Middleware
+}
+
+fn main() {
+	app := &App{
+		middlewares: {
+			// protect all routes starting with the url '/auth'
+			'/auth': [csrf.middleware(csrf_config)]
+		}
+	}
+	vweb.run(app, 8080)
+}
+
+pub fn (mut app App) index() vweb.Result {
+	// get the token and set the cookie
+	csrftoken := csrf.set_token(mut app.Context, csrf_config)
+	return $vweb.html()
+}
+
+[post]
+pub fn (mut app App) auth() vweb.Result {
+	return app.text('authenticated!')
+}
+
+[post]
+pub fn (mut app App) register() vweb.Result {
+	// protect an individual route with the following line
+	csrf.protect(mut app.Context, csrf_config)
+	// ...
+}
+```
+
+index.html (the hidden input has changed)
+```html
+<form action="/auth" method="post">
+    <input type="hidden" name="@csrf_config.token_name" value="@csrftoken"/>
+    <label for="password">Your password:</label>
+    <input type="text" id="password" name="password" placeholder="Your password" />
+</form>
+```
+
+### Protect all routes
+It is possible to protect all routes against CSRF-attacks. Every request that is not 
+defined as a [safe method](#safe-methods) (`GET`, `OPTIONS`, `HEAD` by default)
+will have CSRF-protection.
+
+**Example**:
+```v ignore
+pub fn (mut app App) before_request() {
+	app.csrf.protect(mut app.Context)
+	// or if you don't use `CsrfApp`:
+	// csrf.protect(mut app.Context, csrf_config)
+}
+```
+
+## How it works
+This module implements the [double submit cookie][owasp] technique: a random token 
+is generated, the CSRF-token. The hmac of this token and the secret key is stored in a cookie.
+
+When a request is made, the CSRF-token should be placed inside a HTML form element. 
+The CSRF-token the hmac of the CSRF-token in the formdata is compared to the cookie.
+If the values match, the request is accepted.
+
+This approach has the advantage of being stateless: there is no need to store tokens on the server
+side and validate them. The token and cookie are bound cryptographically to each other so
+an attacker would need to know both values in order to make a CSRF-attack succeed. That
+is why is it important to **not leak the CSRF-token** via an url, or some other way.
+See [client side CSRF][client-side-csrf] for more information.
+
+This is a high level overview of the implementation.
+
+## Security Considerations
+
+### The secret key
+The secret key should be a random string that is not easily guessable. 
+The recommended size is 64 bytes.
+
+### Sessions
+If your app supports some kind of user sessions, it is recommended to cryptographically
+bind the CSRF-token to the users' session. You can do that by providing the name
+of the session ID cookie. If an attacker changes the session ID in the cookie, in the
+token or both the hmac will be different adn the request will be rejected.
+
+**Example**:
+```v ignore
+csrf_config = csrf.CsrfConfig{
+	// ...
+	session_cookie: 'my_session_id_cookie_name'
+}
+```
+
+### Safe Methods
+The HTTP methods `GET`, `OPTIONS`, `HEAD` are considered 
+[safe methods][mozilla-safe-methods] meaning they should not alter the state of
+an application. If a request with a "safe method" is made, the csrf protection will be skipped.
+
+You can change which methods are considered safe by changing `CsrfConfig.safe_methods`.
+
+### Allowed Hosts
+
+By default, both the http Origin and Referer headers are checked and matched strictly
+to the values in `allowed_hosts`. That means that you need to include each subdomain.
+
+If the value of `allowed_hosts` contains the wildcard: `'*'` the headers will not be checked.
+
+#### Domain name matching
+The following configuration will not allow requests made from `test.example.com`,
+only from `example.com`.
+
+**Example**
+```v ignore
+config := csrf.CsrfConfig{
+    secret: '...'
+    allowed_hosts: ['example.com']
+}
+```
+
+#### Referer, Origin header check
+In some cases (like if your server is behind a proxy), the Origin or Referer header will 
+not be present. If that is your case you can set `check_origin_and_referer` to `false`. 
+Request will now be accepted when the Origin *or* Referer header is valid.
+
+### Share csrf cookie with subdomains
+If you need to share the CSRF-token cookie with subdomains, you can set 
+`same_site` to `.same_site_lax_mode`.
+
+## Configuration
+
+All configuration options are defined in `CsrfConfig`.
+
+[//]: # (Sources)
+[owasp]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+[client-side-csrf]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#client-side-csrf
+[mozilla-safe-methods]: https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP

--- a/vlib/x/vweb/csrf/csrf.v
+++ b/vlib/x/vweb/csrf/csrf.v
@@ -1,0 +1,205 @@
+module csrf
+
+import crypto.hmac
+import crypto.sha256
+import encoding.base64
+import net.http
+import net.urllib
+import rand
+import time
+import vweb
+
+[params]
+pub struct CsrfConfig {
+pub:
+	secret string
+	// how long the random part of the csrf-token should be
+	nonce_length int = 64
+	// HTTP "safe" methods meaning they shouldn't alter state.
+	// If a request with any of these methods is made, `protect` will always return true
+	// https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1
+	safe_methods []http.Method = [.get, .head, .options]
+	// which hosts are allowed, enforced by checking the Origin and Referer header
+	// if allowed_hosts contains '*' the check will be skipped.
+	// Subdomains need to be included separately: a request from `"sub.example.com"`
+	//  will be rejected when `allowed_host = ['example.com']`.
+	allowed_hosts []string
+	// if set to true both the Referer and Origin headers must match `allowed_hosts`
+	// else if either one is valid the request is accepted
+	check_origin_and_referer bool = true
+	// the name of the csrf-token in the hidden html input
+	token_name string = 'csrftoken'
+	// the name of the cookie that contains the session id
+	session_cookie string
+	// cookie options
+	cookie_name string        = 'csrftoken'
+	same_site   http.SameSite = .same_site_strict_mode
+	cookie_path string        = '/'
+	// how long the cookie stays valid in seconds. Default is 30 days
+	max_age       int = 60 * 60 * 24 * 30
+	cookie_domain string
+}
+
+pub struct CsrfApp {
+	CsrfConfig
+pub mut:
+	// the csrftoken that should be placed in an html form
+	token string
+}
+
+// set_token is the app wrapper for `set_token`
+pub fn (mut app CsrfApp) set_token(mut ctx vweb.Context) {
+	app.token = set_token(mut ctx, app.CsrfConfig)
+}
+
+// protect is the app wrapper for `protect`
+pub fn (mut app CsrfApp) protect(mut ctx vweb.Context) bool {
+	return protect(mut ctx, app.CsrfConfig)
+}
+
+// check_origin_and_referer is the app wrapper for `check_origin_and_referer`
+fn (app &CsrfApp) check_origin_and_referer(ctx vweb.Context) bool {
+	return check_origin_and_referer(ctx, app.CsrfConfig)
+}
+
+// middleware returns a function that you can use in `app.middlewares`
+pub fn middleware(config &CsrfConfig) vweb.Middleware {
+	return fn [config] (mut ctx vweb.Context) bool {
+		return protect(mut ctx, config)
+	}
+}
+
+// set_token returns the csrftoken and sets an encrypted cookie with the hmac of
+// `config.get_secret` and the csrftoken
+pub fn set_token(mut ctx vweb.Context, config &CsrfConfig) string {
+	expire_time := time.now().add_seconds(config.max_age)
+	session_id := ctx.get_cookie(config.session_cookie) or { '' }
+
+	token := generate_token(expire_time.unix_time(), session_id, config.nonce_length)
+	cookie := generate_cookie(expire_time.unix_time(), token, config.secret)
+
+	// the hmac key is set as a cookie and later validated with `app.token` that must
+	// be in an html form
+	ctx.set_cookie(http.Cookie{
+		name: config.cookie_name
+		value: cookie
+		same_site: config.same_site
+		http_only: true
+		secure: true
+		path: config.cookie_path
+		expires: expire_time
+		max_age: config.max_age
+	})
+
+	return token
+}
+
+// protect returns false and sends an http 401 response when the csrf verification
+// fails. protect will always return true if the current request method is in
+// `config.safe_methods`.
+pub fn protect(mut ctx vweb.Context, config &CsrfConfig) bool {
+	// if the request method is a "safe" method we allow the request
+	if ctx.req.method in config.safe_methods {
+		return true
+	}
+
+	// check origin and referer header
+	if check_origin_and_referer(ctx, config) == false {
+		request_is_invalid(mut ctx)
+		return false
+	}
+
+	// use the session id from the cookie, not from the csrftoken
+	session_id := ctx.get_cookie(config.session_cookie) or { '' }
+
+	actual_token := ctx.form[config.token_name] or {
+		request_is_invalid(mut ctx)
+		return false
+	}
+	// retrieve timestamp and nonce from csrftoken
+	data := base64.url_decode_str(actual_token).split('.')
+	if data.len < 3 {
+		request_is_invalid(mut ctx)
+		return false
+	}
+
+	// check the timestamp from the csrftoken against the current time
+	// if an attacker would change the timestamp on the cookie, the token or both the
+	// hmac would also change.
+	now := time.now().unix_time()
+	expire_timestamp := data[0].i64()
+	if expire_timestamp < now {
+		// token has expired
+		request_is_invalid(mut ctx)
+		return false
+	}
+
+	nonce := data.last()
+	expected_token := base64.url_encode_str('${expire_timestamp}.${session_id}.${nonce}')
+
+	actual_hash := ctx.get_cookie(config.cookie_name) or {
+		request_is_invalid(mut ctx)
+		return false
+	}
+	// generate new hmac based on information in the http request
+	expected_hash := generate_cookie(expire_timestamp, expected_token, config.secret)
+
+	// if the new hmac matches the cookie value the request is legit
+	if actual_hash != expected_hash {
+		request_is_invalid(mut ctx)
+		return false
+	}
+
+	return true
+}
+
+// check_origin_and_referer validates the `Origin` and `Referer` headers.
+fn check_origin_and_referer(ctx vweb.Context, config &CsrfConfig) bool {
+	// wildcard allow all hosts NOT SAFE!
+	if '*' in config.allowed_hosts {
+		return true
+	}
+
+	// only match host and match the full domain name
+	// because lets say `allowed_host` = `['example.com']`.
+	// Attackers shouldn't be able to bypass this check with the domain `example.com.attacker.com`
+
+	origin := ctx.get_header('Origin')
+	origin_url := urllib.parse(origin) or { urllib.URL{} }
+
+	valid_origin := origin_url.hostname() in config.allowed_hosts
+
+	referer := ctx.get_header('Referer')
+	referer_url := urllib.parse(referer) or { urllib.URL{} }
+
+	valid_referer := referer_url.hostname() in config.allowed_hosts
+
+	if config.check_origin_and_referer {
+		return valid_origin && valid_referer
+	} else {
+		return valid_origin || valid_referer
+	}
+}
+
+// request_is_invalid sends an http 403 response
+fn request_is_invalid(mut ctx vweb.Context) {
+	ctx.set_status(403, '')
+	ctx.text('Forbidden: Invalid or missing CSRF token')
+}
+
+fn generate_token(expire_time i64, session_id string, nonce_length int) string {
+	nonce := rand.string_from_set('0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz',
+		nonce_length)
+	token := '${expire_time}.${session_id}.${nonce}'
+
+	return base64.url_encode_str(token)
+}
+
+// generate_cookie converts secret key based on the request context and a random
+// token into an hmac key
+fn generate_cookie(expire_time i64, token string, secret string) string {
+	hash := base64.url_encode(hmac.new(secret.bytes(), token.bytes(), sha256.sum, sha256.block_size))
+	cookie := '${expire_time}.${hash}'
+
+	return cookie
+}

--- a/vlib/x/vweb/csrf/csrf_test.v
+++ b/vlib/x/vweb/csrf/csrf_test.v
@@ -1,0 +1,377 @@
+import time
+import net.http
+import net.html
+import vweb
+import vweb.csrf
+import os
+
+const (
+	sport                  = 12385
+	localserver            = '127.0.0.1:${sport}'
+	exit_after_time        = 12000 // milliseconds
+
+	session_id_cookie_name = 'session_id'
+	csrf_config            = &csrf.CsrfConfig{
+		secret: 'my-256bit-secret'
+		allowed_hosts: ['*']
+		session_cookie: session_id_cookie_name
+	}
+
+	allowed_origin         = 'example.com'
+	csrf_config_origin     = &csrf.CsrfConfig{
+		secret: 'my-256bit-secret'
+		allowed_hosts: [allowed_origin]
+		session_cookie: session_id_cookie_name
+	}
+)
+
+// 			Test CSRF functions
+// =====================================
+
+fn test_set_token() {
+	mut ctx := vweb.Context{}
+
+	token := csrf.set_token(mut ctx, csrf_config)
+
+	cookie := ctx.header.get(.set_cookie) or { '' }
+	assert cookie.len != 0
+	assert cookie.starts_with('${csrf_config.cookie_name}=')
+}
+
+fn test_protect() {
+	mut ctx := vweb.Context{}
+
+	token := csrf.set_token(mut ctx, csrf_config)
+
+	mut cookie := ctx.header.get(.set_cookie) or { '' }
+	// get cookie value from "name=value;"
+	cookie = cookie.split(' ')[0].all_after('=').replace(';', '')
+
+	form := {
+		csrf_config.token_name: token
+	}
+	cookie_map := {
+		csrf_config.cookie_name: cookie
+	}
+	ctx = vweb.Context{
+		form: form
+		req: http.Request{
+			method: .post
+			cookies: cookie_map
+		}
+	}
+	valid := csrf.protect(mut ctx, csrf_config)
+
+	assert valid == true
+}
+
+fn test_timeout() {
+	timeout := 1
+	short_time_config := &csrf.CsrfConfig{
+		secret: 'my-256bit-secret'
+		allowed_hosts: ['*']
+		session_cookie: session_id_cookie_name
+		max_age: timeout
+	}
+
+	mut ctx := vweb.Context{}
+
+	token := csrf.set_token(mut ctx, short_time_config)
+
+	// after 2 seconds the cookie should expire (maxage)
+	time.sleep(2 * time.second)
+	mut cookie := ctx.header.get(.set_cookie) or { '' }
+	// get cookie value from "name=value;"
+	cookie = cookie.split(' ')[0].all_after('=').replace(';', '')
+
+	form := {
+		short_time_config.token_name: token
+	}
+	cookie_map := {
+		short_time_config.cookie_name: cookie
+	}
+	ctx = vweb.Context{
+		form: form
+		req: http.Request{
+			method: .post
+			cookies: cookie_map
+		}
+	}
+
+	valid := csrf.protect(mut ctx, short_time_config)
+
+	assert valid == false
+}
+
+fn test_valid_origin() {
+	// valid because both Origin and Referer headers are present
+	token, cookie := get_token_cookie('')
+
+	form := {
+		csrf_config.token_name: token
+	}
+	cookie_map := {
+		csrf_config.cookie_name: cookie
+	}
+
+	mut req := http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	req.add_header(.origin, 'http://${allowed_origin}')
+	req.add_header(.referer, 'http://${allowed_origin}/test')
+	mut ctx := vweb.Context{
+		form: form
+		req: req
+	}
+
+	mut valid := csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == true
+}
+
+fn test_invalid_origin() {
+	// invalid because either the Origin, Referer or neither are present
+	token, cookie := get_token_cookie('')
+
+	form := {
+		csrf_config.token_name: token
+	}
+	cookie_map := {
+		csrf_config.cookie_name: cookie
+	}
+
+	mut req := http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	req.add_header(.origin, 'http://${allowed_origin}')
+	mut ctx := vweb.Context{
+		form: form
+		req: req
+	}
+
+	mut valid := csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == false
+
+	req = http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	req.add_header(.referer, 'http://${allowed_origin}/test')
+	ctx = vweb.Context{
+		form: form
+		req: req
+	}
+
+	valid = csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == false
+
+	req = http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	ctx = vweb.Context{
+		form: form
+		req: req
+	}
+
+	valid = csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == false
+}
+
+// 			Testing App
+// ================================
+
+struct App {
+	vweb.Context
+pub mut:
+	csrf        csrf.CsrfApp                 [vweb_global]
+	middlewares map[string][]vweb.Middleware
+}
+
+pub fn (mut app App) index() vweb.Result {
+	app.csrf.set_token(mut app.Context)
+
+	return app.html('<form action="/auth" method="post">
+    <input type="hidden" name="${app.csrf.token_name}" value="${app.csrf.token}"/>
+    <label for="password">Your password:</label>
+    <input type="text"  id="password" name="password" placeholder="Your password" />
+</form>')
+}
+
+[post]
+pub fn (mut app App) auth() vweb.Result {
+	app.csrf.protect(mut app.Context)
+
+	return app.ok('authenticated')
+}
+
+pub fn (mut app App) middleware_index() vweb.Result {
+	csrftoken := csrf.set_token(mut app.Context, csrf_config)
+
+	return app.html('<form action="/auth" method="post">
+    <input type="hidden" name="${csrf_config.token_name}" value="${csrftoken}"/>
+    <label for="password">Your password:</label>
+    <input type="text"  id="password" name="password" placeholder="Your password" />
+</form>')
+}
+
+[post]
+pub fn (mut app App) middleware_auth() vweb.Result {
+	return app.ok('middleware authenticated')
+}
+
+// 			App cleanup function
+// ======================================
+
+pub fn (mut app App) shutdown() vweb.Result {
+	spawn app.gracefull_exit()
+	return app.ok('good bye')
+}
+
+fn (mut app App) gracefull_exit() {
+	eprintln('>> webserver: gracefull_exit')
+	time.sleep(100 * time.millisecond)
+	exit(0)
+}
+
+fn exit_after_timeout[T](mut app T, timeout_in_ms int) {
+	time.sleep(timeout_in_ms * time.millisecond)
+	eprintln('>> webserver: pid: ${os.getpid()}, exiting ...')
+	app.shutdown()
+
+	eprintln('App timed out!')
+	assert true == false
+}
+
+// 			Tests for the App
+// ======================================
+
+fn test_run_app_in_background() {
+	mut app := &App{
+		csrf: csrf.CsrfApp{
+			secret: 'my-256bit-secret'
+			allowed_hosts: [allowed_origin]
+			session_cookie: session_id_cookie_name
+		}
+		middlewares: {
+			'/middleware_auth': [csrf.middleware(csrf_config)]
+		}
+	}
+	spawn vweb.run_at(app, port: sport, family: .ip)
+	spawn exit_after_timeout(mut app, exit_after_time)
+
+	time.sleep(500 * time.millisecond)
+}
+
+fn test_token_with_app() {
+	res := http.get('http://${localserver}/') or { panic(err) }
+
+	mut doc := html.parse(res.body)
+	inputs := doc.get_tags_by_attribute_value('type', 'hidden')
+	assert inputs.len == 1
+	assert csrf_config.token_name == inputs[0].attributes['name']
+}
+
+fn test_token_with_middleware() {
+	res := http.get('http://${localserver}/middleware_index') or { panic(err) }
+
+	mut doc := html.parse(res.body)
+	inputs := doc.get_tags_by_attribute_value('type', 'hidden')
+	assert inputs.len == 1
+	assert csrf_config.token_name == inputs[0].attributes['name']
+}
+
+// utility function to check whether the route at `path` is protected against csrf
+fn protect_route_util(path string) {
+	mut req := http.Request{
+		method: .post
+		url: 'http://${localserver}/${path}'
+	}
+	mut res := req.do() or { panic(err) }
+	assert res.status() == .forbidden
+
+	// A valid request with CSRF protection should have a cookie session id,
+	// csrftoken in `app.form` and the hmac of that token in a cookie
+	session_id := 'user_session_id'
+	token, cookie := get_token_cookie(session_id)
+
+	header := http.new_header_from_map({
+		http.CommonHeader.origin:  'http://${allowed_origin}'
+		http.CommonHeader.referer: 'http://${allowed_origin}/route'
+	})
+
+	formdata := http.url_encode_form_data({
+		csrf_config.token_name: token
+	})
+
+	// session id is altered: test if session hijacking is possible
+	// if the session id the csrftoken changes so the cookie can't be validated
+	mut cookies := {
+		csrf_config.cookie_name: cookie
+		session_id_cookie_name:  'altered'
+	}
+
+	req = http.Request{
+		method: .post
+		url: 'http://${localserver}/${path}'
+		data: formdata
+		cookies: cookies
+		header: header
+	}
+
+	res = req.do() or { panic(err) }
+	assert res.status() == .forbidden
+
+	// Everything is valid now and the request should succeed
+	cookies[session_id_cookie_name] = session_id
+
+	req = http.Request{
+		method: .post
+		url: 'http://${localserver}/${path}'
+		data: formdata
+		cookies: cookies
+		header: header
+	}
+
+	res = req.do() or { panic(err) }
+	assert res.status() == .ok
+}
+
+fn test_protect_with_app() {
+	protect_route_util('/auth')
+}
+
+fn test_protect_with_middleware() {
+	protect_route_util('middleware_auth')
+}
+
+fn testsuite_end() {
+	// This test is guaranteed to be called last.
+	// It sends a request to the server to shutdown.
+	x := http.get('http://${localserver}/shutdown') or {
+		assert err.msg() == ''
+		return
+	}
+	assert x.status() == .ok
+	assert x.body == 'good bye'
+}
+
+// Utility functions
+
+fn get_token_cookie(session_id string) (string, string) {
+	mut ctx := vweb.Context{
+		req: http.Request{
+			cookies: {
+				session_id_cookie_name: session_id
+			}
+		}
+	}
+
+	token := csrf.set_token(mut ctx, csrf_config_origin)
+
+	mut cookie := ctx.header.get(.set_cookie) or { '' }
+	// get cookie value from "name=value;"
+	cookie = cookie.split(' ')[0].all_after('=').replace(';', '')
+	return token, cookie
+}

--- a/vlib/x/vweb/parse.v
+++ b/vlib/x/vweb/parse.v
@@ -1,0 +1,91 @@
+module vweb
+
+import net.urllib
+import net.http
+
+// Parsing function attributes for methods and path.
+fn parse_attrs(name string, attrs []string) !([]http.Method, string, string, string) {
+	if attrs.len == 0 {
+		return [http.Method.get], '/${name}', '', ''
+	}
+
+	mut x := attrs.clone()
+	mut methods := []http.Method{}
+	mut middleware := ''
+	mut path := ''
+	mut host := ''
+
+	for i := 0; i < x.len; {
+		attr := x[i]
+		attru := attr.to_upper()
+		m := http.method_from_str(attru)
+		if attru == 'GET' || m != .get {
+			methods << m
+			x.delete(i)
+			continue
+		}
+		if attr.starts_with('/') {
+			if path != '' {
+				return http.MultiplePathAttributesError{}
+			}
+			path = attr
+			x.delete(i)
+			continue
+		}
+		if attr.starts_with('middleware:') {
+			middleware = attr.all_after('middleware:').trim_space()
+			x.delete(i)
+			continue
+		}
+		if attr.starts_with('host:') {
+			host = attr.all_after('host:').trim_space()
+			x.delete(i)
+			continue
+		}
+		i++
+	}
+	if x.len > 0 {
+		return http.UnexpectedExtraAttributeError{
+			attributes: x
+		}
+	}
+	if methods.len == 0 {
+		methods = [http.Method.get]
+	}
+	if path == '' {
+		path = '/${name}'
+	}
+	// Make host lowercase for case-insensitive comparisons
+	return methods, path, middleware, host.to_lower()
+}
+
+fn parse_query_from_url(url urllib.URL) map[string]string {
+	mut query := map[string]string{}
+	for qvalue in url.query().data {
+		query[qvalue.key] = qvalue.value
+	}
+	return query
+}
+
+const boundary_start = 'boundary='
+
+fn parse_form_from_request(request http.Request) !(map[string]string, map[string][]http.FileData) {
+	if request.method !in [http.Method.post, .put, .patch] {
+		return map[string]string{}, map[string][]http.FileData{}
+	}
+	ct := request.header.get(.content_type) or { '' }.split(';').map(it.trim_left(' \t'))
+	if 'multipart/form-data' in ct {
+		boundaries := ct.filter(it.starts_with(vweb.boundary_start))
+		if boundaries.len != 1 {
+			return error('detected more that one form-data boundary')
+		}
+		boundary := boundaries[0].all_after(vweb.boundary_start)
+		if boundary.len > 0 && boundary[0] == `"` {
+			// quotes are send by our http.post_multipart_form/2:
+			return http.parse_multipart_form(request.data, boundary.trim('"'))
+		}
+		// Firefox and other browsers, do not use quotes around the boundary:
+		return http.parse_multipart_form(request.data, boundary)
+	}
+	return http.parse_form(request.data), map[string][]http.FileData{}
+}

--- a/vlib/x/vweb/route_test.v
+++ b/vlib/x/vweb/route_test.v
@@ -1,0 +1,282 @@
+module vweb
+
+struct RoutePair {
+	url   string
+	route string
+}
+
+fn (rp RoutePair) test() ?[]string {
+	url := rp.url.split('/').filter(it != '')
+	route := rp.route.split('/').filter(it != '')
+	return route_matches(url, route)
+}
+
+fn (rp RoutePair) test_match() {
+	rp.test() or { panic('should match: ${rp}') }
+}
+
+fn (rp RoutePair) test_no_match() {
+	rp.test() or { return }
+	panic('should not match: ${rp}')
+}
+
+fn (rp RoutePair) test_param(expected []string) {
+	res := rp.test() or { panic('should match: ${rp}') }
+	assert res == expected
+}
+
+fn test_route_no_match() {
+	tests := [
+		RoutePair{
+			url: '/a'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/b'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/b/'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/c/b'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/c/b/'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/b/c/d'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/b/c'
+			route: '/'
+		},
+	]
+	for test in tests {
+		test.test_no_match()
+	}
+}
+
+fn test_route_exact_match() {
+	tests := [
+		RoutePair{
+			url: '/a/b/c'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a/b/c/'
+			route: '/a/b/c'
+		},
+		RoutePair{
+			url: '/a'
+			route: '/a'
+		},
+		RoutePair{
+			url: '/'
+			route: '/'
+		},
+	]
+	for test in tests {
+		test.test_match()
+	}
+}
+
+fn test_route_params_match() {
+	RoutePair{
+		url: '/a/b/c'
+		route: '/:a/b/c'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b/c'
+		route: '/a/:b/c'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b/c'
+		route: '/a/b/:c'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b/c'
+		route: '/:a/b/:c'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b/c'
+		route: '/:a/:b/:c'
+	}.test_match()
+
+	RoutePair{
+		url: '/one/two/three'
+		route: '/:a/:b/:c'
+	}.test_match()
+
+	RoutePair{
+		url: '/one/b/c'
+		route: '/:a/b/c'
+	}.test_match()
+
+	RoutePair{
+		url: '/one/two/three'
+		route: '/:a/b/c'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/one/two/three'
+		route: '/:a/:b/c'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/one/two/three'
+		route: '/:a/b/:c'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/a/b/c/d'
+		route: '/:a/:b/:c'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/1/2/3/4'
+		route: '/:a/:b/:c'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/a/b'
+		route: '/:a/:b/:c'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/1/2'
+		route: '/:a/:b/:c'
+	}.test_no_match()
+}
+
+fn test_route_params() {
+	RoutePair{
+		url: '/a/b/c'
+		route: '/:a/b/c'
+	}.test_param(['a'])
+
+	RoutePair{
+		url: '/one/b/c'
+		route: '/:a/b/c'
+	}.test_param(['one'])
+
+	RoutePair{
+		url: '/one/two/c'
+		route: '/:a/:b/c'
+	}.test_param(['one', 'two'])
+
+	RoutePair{
+		url: '/one/two/three'
+		route: '/:a/:b/:c'
+	}.test_param(['one', 'two', 'three'])
+
+	RoutePair{
+		url: '/one/b/three'
+		route: '/:a/b/:c'
+	}.test_param(['one', 'three'])
+}
+
+fn test_route_params_array_match() {
+	// array can only be used on the last word (TODO: add parsing / tests to ensure this)
+
+	RoutePair{
+		url: '/a/b/c'
+		route: '/a/b/:c...'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b/c/d'
+		route: '/a/b/:c...'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b/c/d/e'
+		route: '/a/b/:c...'
+	}.test_match()
+
+	RoutePair{
+		url: '/one/b/c/d/e'
+		route: '/:a/b/:c...'
+	}.test_match()
+
+	RoutePair{
+		url: '/one/two/c/d/e'
+		route: '/:a/:b/:c...'
+	}.test_match()
+
+	RoutePair{
+		url: '/one/two/three/four/five'
+		route: '/:a/:b/:c...'
+	}.test_match()
+
+	RoutePair{
+		url: '/a/b'
+		route: '/:a/:b/:c...'
+	}.test_no_match()
+
+	RoutePair{
+		url: '/a/b/'
+		route: '/:a/:b/:c...'
+	}.test_no_match()
+}
+
+fn test_route_params_array() {
+	RoutePair{
+		url: '/a/b/c'
+		route: '/a/b/:c...'
+	}.test_param(['c'])
+
+	RoutePair{
+		url: '/a/b/c/d'
+		route: '/a/b/:c...'
+	}.test_param(['c/d'])
+
+	RoutePair{
+		url: '/a/b/c/d/'
+		route: '/a/b/:c...'
+	}.test_param(['c/d'])
+
+	RoutePair{
+		url: '/a/b/c/d/e'
+		route: '/a/b/:c...'
+	}.test_param(['c/d/e'])
+
+	RoutePair{
+		url: '/one/b/c/d/e'
+		route: '/:a/b/:c...'
+	}.test_param(['one', 'c/d/e'])
+
+	RoutePair{
+		url: '/one/two/c/d/e'
+		route: '/:a/:b/:c...'
+	}.test_param(['one', 'two', 'c/d/e'])
+
+	RoutePair{
+		url: '/one/two/three/d/e'
+		route: '/:a/:b/:c...'
+	}.test_param(['one', 'two', 'three/d/e'])
+}
+
+fn test_route_index_path() {
+	RoutePair{
+		url: '/'
+		route: '/:path...'
+	}.test_param(['/'])
+
+	RoutePair{
+		url: '/foo/bar'
+		route: '/:path...'
+	}.test_param(['/foo/bar'])
+}

--- a/vlib/x/vweb/sse/sse.v
+++ b/vlib/x/vweb/sse/sse.v
@@ -1,0 +1,77 @@
+module sse
+
+import net
+import time
+import strings
+
+// This module implements the server side of `Server Sent Events`.
+// See https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+// as well as https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
+// for detailed description of the protocol, and a simple web browser client example.
+//
+// > Event stream format
+// > The event stream is a simple stream of text data which must be encoded using UTF-8.
+// > Messages in the event stream are separated by a pair of newline characters.
+// > A colon as the first character of a line is in essence a comment, and is ignored.
+// > Note: The comment line can be used to prevent connections from timing out;
+// > a server can send a comment periodically to keep the connection alive.
+// >
+// > Each message consists of one or more lines of text listing the fields for that message.
+// > Each field is represented by the field name, followed by a colon, followed by the text
+// > data for that field's value.
+
+[heap]
+pub struct SSEConnection {
+pub mut:
+	headers       map[string]string
+	conn          &net.TcpConn  = unsafe { nil }
+	write_timeout time.Duration = 600 * time.second
+}
+
+pub struct SSEMessage {
+	id    string
+	event string
+	data  string
+	retry int
+}
+
+pub fn new_connection(conn &net.TcpConn) &SSEConnection {
+	return &SSEConnection{
+		conn: unsafe { conn }
+	}
+}
+
+// sse_start is used to send the start of a Server Side Event response.
+pub fn (mut sse SSEConnection) start() ! {
+	sse.conn.set_write_timeout(sse.write_timeout)
+	mut start_sb := strings.new_builder(512)
+	start_sb.write_string('HTTP/1.1 200')
+	start_sb.write_string('\r\nConnection: keep-alive')
+	start_sb.write_string('\r\nCache-Control: no-cache')
+	start_sb.write_string('\r\nContent-Type: text/event-stream')
+	for k, v in sse.headers {
+		start_sb.write_string('\r\n${k}: ${v}')
+	}
+	start_sb.write_string('\r\n')
+	sse.conn.write(start_sb) or { return error('could not start sse response') }
+}
+
+// send_message sends a single message to the http client that listens for SSE.
+// It does not close the connection, so you can use it many times in a loop.
+pub fn (mut sse SSEConnection) send_message(message SSEMessage) ! {
+	mut sb := strings.new_builder(512)
+	if message.id != '' {
+		sb.write_string('id: ${message.id}\n')
+	}
+	if message.event != '' {
+		sb.write_string('event: ${message.event}\n')
+	}
+	if message.data != '' {
+		sb.write_string('data: ${message.data}\n')
+	}
+	if message.retry != 0 {
+		sb.write_string('retry: ${message.retry}\n')
+	}
+	sb.write_string('\n')
+	sse.conn.write(sb)!
+}

--- a/vlib/x/vweb/tests/controller_duplicate_server.v
+++ b/vlib/x/vweb/tests/controller_duplicate_server.v
@@ -1,0 +1,41 @@
+module main
+
+import vweb
+import time
+import os
+
+struct App {
+	vweb.Context
+	vweb.Controller
+}
+
+struct Admin {
+	vweb.Context
+}
+
+['/admin/duplicate']
+pub fn (mut app App) duplicate() vweb.Result {
+	return app.text('duplicate')
+}
+
+fn exit_after_timeout(timeout_in_ms int) {
+	time.sleep(timeout_in_ms * time.millisecond)
+	println('>> webserver: pid: ${os.getpid()}, exiting ...')
+	exit(0)
+}
+
+fn main() {
+	if os.args.len != 3 {
+		panic('Usage: `controller_test_server.exe PORT TIMEOUT_IN_MILLISECONDS`')
+	}
+	http_port := os.args[1].int()
+	assert http_port > 0
+	timeout := os.args[2].int()
+	mut app_dup := &App{
+		controllers: [
+			vweb.controller('/admin', &Admin{}),
+		]
+	}
+
+	vweb.run_at(app_dup, host: 'localhost', port: http_port, family: .ip) or { panic(err) }
+}

--- a/vlib/x/vweb/tests/controller_test.v
+++ b/vlib/x/vweb/tests/controller_test.v
@@ -1,0 +1,155 @@
+import os
+import time
+import net.http
+
+const (
+	sport           = 12382
+	sport2          = 12383
+	localserver     = '127.0.0.1:${sport}'
+	exit_after_time = 12000 // milliseconds
+	vexe            = os.getenv('VEXE')
+	vweb_logfile    = os.getenv('VWEB_LOGFILE')
+	vroot           = os.dir(vexe)
+	serverexe       = os.join_path(os.cache_dir(), 'controller_test_server.exe')
+	tcp_r_timeout   = 30 * time.second
+	tcp_w_timeout   = 30 * time.second
+)
+
+// setup of vweb webserver
+fn testsuite_begin() {
+	os.chdir(vroot) or {}
+	if os.exists(serverexe) {
+		os.rm(serverexe) or {}
+	}
+}
+
+fn test_middleware_vweb_app_can_be_compiled() {
+	// did_server_compile := os.system('${os.quoted_path(vexe)} -g -o ${os.quoted_path(serverexe)} vlib/vweb/tests/controller_test_server.vv')
+	// TODO: find out why it does not compile with -usecache and -g
+	did_server_compile := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(serverexe)} vlib/vweb/tests/controller_test_server.v')
+	assert did_server_compile == 0
+	assert os.exists(serverexe)
+}
+
+fn test_middleware_vweb_app_runs_in_the_background() {
+	mut suffix := ''
+	$if !windows {
+		suffix = ' > /dev/null &'
+	}
+	if vweb_logfile != '' {
+		suffix = ' 2>> ${os.quoted_path(vweb_logfile)} >> ${os.quoted_path(vweb_logfile)} &'
+	}
+	server_exec_cmd := '${os.quoted_path(serverexe)} ${sport} ${exit_after_time} ${suffix}'
+	$if debug_net_socket_client ? {
+		eprintln('running:\n${server_exec_cmd}')
+	}
+	$if windows {
+		spawn os.system(server_exec_cmd)
+	} $else {
+		res := os.system(server_exec_cmd)
+		assert res == 0
+	}
+	$if macos {
+		time.sleep(1000 * time.millisecond)
+	} $else {
+		time.sleep(100 * time.millisecond)
+	}
+}
+
+// test functions:
+
+fn test_app_home() {
+	x := http.get('http://${localserver}/') or { panic(err) }
+	assert x.body == 'App'
+}
+
+fn test_app_path() {
+	x := http.get('http://${localserver}/path') or { panic(err) }
+	assert x.body == 'App path'
+}
+
+fn test_admin_home() {
+	x := http.get('http://${localserver}/admin/') or { panic(err) }
+	assert x.body == 'Admin'
+}
+
+fn test_admin_path() {
+	x := http.get('http://${localserver}/admin/path') or { panic(err) }
+	assert x.body == 'Admin path'
+}
+
+fn test_other_home() {
+	x := http.get('http://${localserver}/other/') or { panic(err) }
+	assert x.body == 'Other'
+}
+
+fn test_other_path() {
+	x := http.get('http://${localserver}/other/path') or { panic(err) }
+	assert x.body == 'Other path'
+}
+
+fn test_other_hided_home() {
+	x := http.get('http://${localserver}/other/hide') or { panic(err) }
+	assert x.body == 'Other'
+}
+
+fn test_other_hided_path() {
+	x := http.get('http://${localserver}/other/hide/path') or { panic(err) }
+	assert x.body == 'Other path'
+}
+
+fn test_different_404() {
+	res_app := http.get('http://${localserver}/zxcnbnm') or { panic(err) }
+	assert res_app.status() == .not_found
+	assert res_app.body == '404 From App'
+
+	res_admin := http.get('http://${localserver}/admin/JHKAJA') or { panic(err) }
+	assert res_admin.status() == .not_found
+	assert res_admin.body == '404 From Admin'
+
+	// Other doesn't have a custom 404 so the vweb.Context's not_found is expected
+	res_other := http.get('http://${localserver}/other/unknown') or { panic(err) }
+	assert res_other.status() == .not_found
+	assert res_other.body == '404 Not Found'
+}
+
+fn test_shutdown() {
+	// This test is guaranteed to be called last.
+	// It sends a request to the server to shutdown.
+	x := http.fetch(
+		url: 'http://${localserver}/shutdown'
+		method: .get
+		cookies: {
+			'skey': 'superman'
+		}
+	) or {
+		assert err.msg() == ''
+		return
+	}
+	assert x.status() == .ok
+	assert x.body == 'good bye'
+}
+
+fn test_duplicate_route() {
+	did_server_compile := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(serverexe)} vlib/vweb/tests/controller_duplicate_server.v')
+	assert did_server_compile == 0
+	assert os.exists(serverexe)
+
+	mut suffix := ''
+
+	if vweb_logfile != '' {
+		suffix = ' 2>> ${os.quoted_path(vweb_logfile)} >> ${os.quoted_path(vweb_logfile)} &'
+	}
+	server_exec_cmd := '${os.quoted_path(serverexe)} ${sport2} ${exit_after_time} ${suffix}'
+	$if debug_net_socket_client ? {
+		eprintln('running:\n${server_exec_cmd}')
+	}
+	$if windows {
+		task := spawn os.execute(server_exec_cmd)
+		res := task.wait()
+		assert res.output.contains('V panic: conflicting paths')
+	} $else {
+		res := os.execute(server_exec_cmd)
+		assert res.output.contains('V panic: conflicting paths')
+	}
+}

--- a/vlib/x/vweb/tests/controller_test_server.v
+++ b/vlib/x/vweb/tests/controller_test_server.v
@@ -1,0 +1,118 @@
+module main
+
+import vweb
+import time
+import os
+
+struct App {
+	vweb.Context
+	vweb.Controller
+	timeout int
+}
+
+struct Admin {
+	vweb.Context
+}
+
+struct Other {
+	vweb.Context
+}
+
+struct OtherHidedByOther {
+	vweb.Context
+}
+
+fn exit_after_timeout(timeout_in_ms int) {
+	time.sleep(timeout_in_ms * time.millisecond)
+	println('>> webserver: pid: ${os.getpid()}, exiting ...')
+	exit(0)
+}
+
+fn main() {
+	if os.args.len != 3 {
+		panic('Usage: `controller_test_server.exe PORT TIMEOUT_IN_MILLISECONDS`')
+	}
+	http_port := os.args[1].int()
+	assert http_port > 0
+	timeout := os.args[2].int()
+	spawn exit_after_timeout(timeout)
+
+	mut app := &App{
+		timeout: timeout
+		controllers: [
+			vweb.controller('/admin', &Admin{}),
+			vweb.controller('/other', &Other{}),
+			vweb.controller('/other/hide', &OtherHidedByOther{}),
+		]
+	}
+
+	eprintln('>> webserver: pid: ${os.getpid()}, started on http://localhost:${http_port}/ , with maximum runtime of ${app.timeout} milliseconds.')
+	vweb.run_at(app, host: 'localhost', port: http_port, family: .ip)!
+}
+
+['/']
+pub fn (mut app App) home() vweb.Result {
+	return app.text('App')
+}
+
+['/path']
+pub fn (mut app App) app_path() vweb.Result {
+	return app.text('App path')
+}
+
+pub fn (mut app App) not_found() vweb.Result {
+	app.set_status(404, 'Not Found')
+	return app.text('404 From App')
+}
+
+['/']
+pub fn (mut app Admin) admin_home() vweb.Result {
+	return app.text('Admin')
+}
+
+['/path']
+pub fn (mut app Admin) admin_path() vweb.Result {
+	return app.text('Admin path')
+}
+
+pub fn (mut app Admin) not_found() vweb.Result {
+	app.set_status(404, 'Not Found')
+	return app.text('404 From Admin')
+}
+
+['/']
+pub fn (mut app Other) other_home() vweb.Result {
+	return app.text('Other')
+}
+
+['/path']
+pub fn (mut app Other) other_path() vweb.Result {
+	return app.text('Other path')
+}
+
+['/']
+pub fn (mut app OtherHidedByOther) other_home() vweb.Result {
+	return app.text('Other')
+}
+
+['/path']
+pub fn (mut app OtherHidedByOther) other_path() vweb.Result {
+	return app.text('Other path')
+}
+
+// utility functions:
+
+pub fn (mut app App) shutdown() vweb.Result {
+	session_key := app.get_cookie('skey') or { return app.not_found() }
+	if session_key != 'superman' {
+		return app.not_found()
+	}
+	spawn app.gracefull_exit()
+	return app.ok('good bye')
+}
+
+fn (mut app App) gracefull_exit() {
+	eprintln('>> webserver: gracefull_exit')
+	time.sleep(100 * time.millisecond)
+	exit(0)
+}

--- a/vlib/x/vweb/tests/middleware_test.v
+++ b/vlib/x/vweb/tests/middleware_test.v
@@ -1,0 +1,357 @@
+import os
+import time
+import json
+import net
+import net.http
+import io
+
+const (
+	sport           = 12381
+	localserver     = '127.0.0.1:${sport}'
+	exit_after_time = 12000 // milliseconds
+	vexe            = os.getenv('VEXE')
+	vweb_logfile    = os.getenv('VWEB_LOGFILE')
+	vroot           = os.dir(vexe)
+	serverexe       = os.join_path(os.cache_dir(), 'middleware_test_server.exe')
+	tcp_r_timeout   = 30 * time.second
+	tcp_w_timeout   = 30 * time.second
+)
+
+// setup of vweb webserver
+fn testsuite_begin() {
+	os.chdir(vroot) or {}
+	if os.exists(serverexe) {
+		os.rm(serverexe) or {}
+	}
+}
+
+fn test_middleware_vweb_app_can_be_compiled() {
+	// did_server_compile := os.system('${os.quoted_path(vexe)} -g -o ${os.quoted_path(serverexe)} vlib/vweb/tests/middleware_test_server.vv')
+	// TODO: find out why it does not compile with -usecache and -g
+	did_server_compile := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(serverexe)} vlib/vweb/tests/middleware_test_server.v')
+	assert did_server_compile == 0
+	assert os.exists(serverexe)
+}
+
+fn test_middleware_vweb_app_runs_in_the_background() {
+	mut suffix := ''
+	$if !windows {
+		suffix = ' > /dev/null &'
+	}
+	if vweb_logfile != '' {
+		suffix = ' 2>> ${os.quoted_path(vweb_logfile)} >> ${os.quoted_path(vweb_logfile)} &'
+	}
+	server_exec_cmd := '${os.quoted_path(serverexe)} ${sport} ${exit_after_time} ${suffix}'
+	$if debug_net_socket_client ? {
+		eprintln('running:\n${server_exec_cmd}')
+	}
+	$if windows {
+		spawn os.system(server_exec_cmd)
+	} $else {
+		res := os.system(server_exec_cmd)
+		assert res == 0
+	}
+	$if macos {
+		time.sleep(1000 * time.millisecond)
+	} $else {
+		time.sleep(100 * time.millisecond)
+	}
+}
+
+// normal routes:
+
+fn test_app_middleware() {
+	x := http.get('http://${localserver}/') or { panic(err) }
+	assert x.body == '0app_middlewareindex'
+}
+
+fn test_single_middleware() {
+	received := simple_tcp_client(path: '/single') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1HTTP/')
+	assert received.ends_with('0single')
+}
+
+fn test_multiple_middleware() {
+	received := simple_tcp_client(path: '/multiple') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1m2HTTP/')
+	assert received.ends_with('0multiple')
+}
+
+fn test_combined_middleware() {
+	received := simple_tcp_client(path: '/combined') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1m2HTTP/')
+	assert received.ends_with('0app_middlewarecombined')
+}
+
+fn test_nested_middleware() {
+	received := simple_tcp_client(path: '/admin/nested') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1HTTP/')
+	assert received.ends_with('0nested')
+}
+
+// above routes + post
+
+struct Post {
+	msg string
+}
+
+fn test_app_post_middleware() {
+	test_object := Post{
+		msg: 'HI'
+	}
+	json_test := json.encode(test_object)
+	mut x := http.post_json('http://${localserver}/index_post', json_test) or { panic(err) }
+	assert x.body == '0app_middlewareindex_post:${json_test}'
+}
+
+fn test_single_post_middleware() {
+	test_object := Post{
+		msg: 'HI'
+	}
+	json_test := json.encode(test_object)
+
+	received := simple_tcp_client_post_json(
+		path: '/single_post'
+		headers: 'Content-Length: ${json_test.len}\r\n'
+		content: json_test
+	) or {
+		assert err.msg() == ''
+		return
+	}
+
+	assert received.starts_with('m1')
+	assert received.ends_with('0single_post:${json_test}')
+}
+
+fn test_multiple_post_middleware() {
+	test_object := Post{
+		msg: 'HI'
+	}
+	json_test := json.encode(test_object)
+
+	received := simple_tcp_client_post_json(
+		path: '/multiple_post'
+		headers: 'Content-Length: ${json_test.len}\r\n'
+		content: json_test
+	) or {
+		assert err.msg() == ''
+		return
+	}
+
+	assert received.starts_with('m1m2')
+	assert received.ends_with('0multiple_post:${json_test}')
+}
+
+fn test_combined_post_middleware() {
+	test_object := Post{
+		msg: 'HI'
+	}
+	json_test := json.encode(test_object)
+
+	received := simple_tcp_client_post_json(
+		path: '/combined_post'
+		headers: 'Content-Length: ${json_test.len}\r\n'
+		content: json_test
+	) or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1m2')
+	assert received.ends_with('0app_middlewarecombined_post:${json_test}')
+}
+
+fn test_nested_post_middleware() {
+	test_object := Post{
+		msg: 'HI'
+	}
+	json_test := json.encode(test_object)
+
+	received := simple_tcp_client_post_json(
+		path: '/admin/nested_post'
+		headers: 'Content-Length: ${json_test.len}\r\n'
+		content: json_test
+	) or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1')
+	assert received.ends_with('0nested_post:${json_test}')
+}
+
+// dynamic routes:
+
+fn test_dynamic_middleware() {
+	dynamic_path := 'test'
+	received := simple_tcp_client(path: '/admin/${dynamic_path}') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1HTTP/')
+	assert received.ends_with('0admin_dynamic:${dynamic_path}')
+}
+
+fn test_combined_dynamic_middleware() {
+	dynamic_path := 'test'
+	received := simple_tcp_client(path: '/other/${dynamic_path}') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('m1m2HTTP/')
+	assert received.ends_with('0app_middlewarecombined_dynamic:${dynamic_path}')
+}
+
+// redirect routes:
+
+fn test_app_redirect_middleware() {
+	x := http.get('http://${localserver}/app_redirect') or { panic(err) }
+	x_home := http.get('http://${localserver}/') or { panic(err) }
+	assert x.body == x_home.body
+
+	received := simple_tcp_client(path: '/app_redirect') or {
+		assert err.msg() == ''
+		return
+	}
+	assert received.starts_with('HTTP/1.1 302 Found')
+	assert received.ends_with('302 Found')
+}
+
+fn test_redirect_middleware() {
+	received := simple_tcp_client(path: '/redirect') or {
+		assert err.msg() == ''
+		return
+	}
+	println(received)
+
+	assert received.starts_with('m_redirect')
+	assert received.contains('HTTP/1.1 302 Found')
+	assert received.ends_with('302 Found')
+}
+
+// Context's
+
+fn test_middleware_with_context() {
+	x := http.get('http://${localserver}/with-context') or { panic(err) }
+	assert x.body == 'b'
+}
+
+fn testsuite_end() {
+	// This test is guaranteed to be called last.
+	// It sends a request to the server to shutdown.
+	x := http.fetch(
+		url: 'http://${localserver}/shutdown'
+		method: .get
+		cookies: {
+			'skey': 'superman'
+		}
+	) or {
+		assert err.msg() == ''
+		return
+	}
+	assert x.status() == .ok
+	assert x.body == 'good bye'
+}
+
+// utility code:
+struct SimpleTcpClientConfig {
+	retries int    = 20
+	host    string = 'static.dev'
+	path    string = '/'
+	agent   string = 'v/net.tcp.v'
+	headers string = '\r\n'
+	content string
+}
+
+fn simple_tcp_client(config SimpleTcpClientConfig) !string {
+	mut client := &net.TcpConn(unsafe { nil })
+	mut tries := 0
+	for tries < config.retries {
+		tries++
+		eprintln('> client retries: ${tries}')
+		client = net.dial_tcp(localserver) or {
+			if tries > config.retries {
+				return err
+			}
+			time.sleep(100 * time.millisecond)
+			continue
+		}
+		break
+	}
+	if client == unsafe { nil } {
+		eprintln('coult not create a tcp client connection to ${localserver} after ${config.retries} retries')
+		exit(1)
+	}
+	client.set_read_timeout(tcp_r_timeout)
+	client.set_write_timeout(tcp_w_timeout)
+	defer {
+		client.close() or {}
+	}
+	message := 'GET ${config.path} HTTP/1.1
+Host: ${config.host}
+User-Agent: ${config.agent}
+Accept: */*
+${config.headers}
+${config.content}'
+	$if debug_net_socket_client ? {
+		eprintln('sending:\n${message}')
+	}
+	client.write(message.bytes())!
+	read := io.read_all(reader: client)!
+	$if debug_net_socket_client ? {
+		eprintln('received:\n${read}')
+	}
+	return read.bytestr()
+}
+
+fn simple_tcp_client_post_json(config SimpleTcpClientConfig) !string {
+	mut client := &net.TcpConn(unsafe { nil })
+	mut tries := 0
+	for tries < config.retries {
+		tries++
+		eprintln('> client retries: ${tries}')
+		client = net.dial_tcp(localserver) or {
+			if tries > config.retries {
+				return err
+			}
+			time.sleep(100 * time.millisecond)
+			continue
+		}
+		break
+	}
+	if client == unsafe { nil } {
+		eprintln('coult not create a tcp client connection to ${localserver} after ${config.retries} retries')
+		exit(1)
+	}
+	client.set_read_timeout(tcp_r_timeout)
+	client.set_write_timeout(tcp_w_timeout)
+	defer {
+		client.close() or {}
+	}
+	message := 'POST ${config.path} HTTP/1.1
+Host: ${config.host}
+User-Agent: ${config.agent}
+Accept: */*
+Content-Type: application/json
+${config.headers}
+${config.content}'
+	$if debug_net_socket_client ? {
+		eprintln('sending:\n${message}')
+	}
+	client.write(message.bytes())!
+	read := io.read_all(reader: client)!
+	$if debug_net_socket_client ? {
+		eprintln('received:\n${read}')
+	}
+	return read.bytestr()
+}

--- a/vlib/x/vweb/tests/middleware_test_server.v
+++ b/vlib/x/vweb/tests/middleware_test_server.v
@@ -1,0 +1,286 @@
+module main
+
+import vweb
+import time
+import os
+
+struct App {
+	vweb.Context
+	timeout       int
+	global_config shared Config
+	middlewares   map[string][]vweb.Middleware
+}
+
+struct Config {
+pub mut:
+	middleware_text string
+}
+
+fn exit_after_timeout(timeout_in_ms int) {
+	time.sleep(timeout_in_ms * time.millisecond)
+	println('>> webserver: pid: ${os.getpid()}, exiting ...')
+	exit(0)
+}
+
+fn main() {
+	if os.args.len != 3 {
+		panic('Usage: `vweb_test_server.exe PORT TIMEOUT_IN_MILLISECONDS`')
+	}
+	http_port := os.args[1].int()
+	assert http_port > 0
+	timeout := os.args[2].int()
+	spawn exit_after_timeout(timeout)
+
+	shared config := &Config{}
+
+	app := &App{
+		timeout: timeout
+		global_config: config
+		middlewares: {
+			'/single':        [middleware1]
+			'/single_post':   [middleware1]
+			'/multiple':      [middleware1, middleware2]
+			'/multiple_post': [middleware1, middleware2]
+			'/combined':      [middleware1, middleware2]
+			'/combined_post': [middleware1, middleware2]
+			'/admin/':        [middleware1]
+			'/other/':        [middleware1, middleware2]
+			'/redirect':      [middleware_redirect]
+			'/with-context':  [context1]
+		}
+	}
+	eprintln('>> webserver: pid: ${os.getpid()}, started on http://localhost:${http_port}/ , with maximum runtime of ${app.timeout} milliseconds.')
+	vweb.run_at(app, host: 'localhost', port: http_port, family: .ip)!
+}
+
+// normal routes:
+
+[middleware: app_middleware]
+['/']
+pub fn (mut app App) index() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}index')
+}
+
+['/single']
+pub fn (mut app App) single() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}single')
+}
+
+['/multiple']
+pub fn (mut app App) multiple() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}multiple')
+}
+
+[middleware: app_middleware]
+['/combined']
+pub fn (mut app App) combined() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}combined')
+}
+
+['/admin/nested']
+pub fn (mut app App) nested() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}nested')
+}
+
+// above routes + post
+
+[middleware: app_middleware]
+['/index_post'; post]
+pub fn (mut app App) index_post() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}index_post:${app.req.data}')
+}
+
+['/single_post'; post]
+pub fn (mut app App) single_post() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}single_post:${app.req.data}')
+}
+
+['/multiple_post'; post]
+pub fn (mut app App) multiple_post() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}multiple_post:${app.req.data}')
+}
+
+[middleware: app_middleware]
+['/combined_post'; post]
+pub fn (mut app App) combined_post() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}combined_post:${app.req.data}')
+}
+
+['/admin/nested_post'; post]
+pub fn (mut app App) nested_post() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}nested_post:${app.req.data}')
+}
+
+// dynamic routes
+
+['/admin/:dynamic']
+pub fn (mut app App) admin_dynamic(dynamic string) vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}admin_dynamic:${dynamic}')
+}
+
+[middleware: app_middleware]
+['/other/:dynamic']
+pub fn (mut app App) combined_dynamic(dynamic string) vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}combined_dynamic:${dynamic}')
+}
+
+// redirect routes:
+
+[middleware: app_redirect]
+['/app_redirect']
+pub fn (mut app App) app_redirect_route() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}should_never_reach!')
+}
+
+['/redirect']
+pub fn (mut app App) redirect_route() vweb.Result {
+	mut result := ''
+
+	rlock app.global_config {
+		result = app.global_config.middleware_text
+	}
+
+	return app.text('${result}should_never_reach!')
+}
+
+['/with-context']
+pub fn (mut app App) with_context() vweb.Result {
+	a := app.get_value[string]('a') or { 'none' }
+	return app.text(a)
+}
+
+// middleware functions:
+
+pub fn (mut app App) before_request() {
+	lock app.global_config {
+		app.global_config.middleware_text = '0'
+	}
+}
+
+pub fn (mut app App) app_middleware() bool {
+	lock app.global_config {
+		app.global_config.middleware_text += 'app_middleware'
+	}
+	return true
+}
+
+pub fn (mut app App) app_redirect() bool {
+	app.redirect('/')
+	return false
+}
+
+fn middleware1(mut ctx vweb.Context) bool {
+	ctx.conn.write_string('m1') or { panic(err) }
+	return true
+}
+
+fn middleware2(mut ctx vweb.Context) bool {
+	ctx.conn.write_string('m2') or { panic(err) }
+	return true
+}
+
+fn middleware_redirect(mut ctx vweb.Context) bool {
+	ctx.conn.write_string('m_redirect') or { panic(err) }
+	ctx.redirect('/')
+	return false
+}
+
+fn context1(mut ctx vweb.Context) bool {
+	ctx.set_value('a', 'b')
+	return true
+}
+
+// utility functions:
+
+pub fn (mut app App) shutdown() vweb.Result {
+	session_key := app.get_cookie('skey') or { return app.not_found() }
+	if session_key != 'superman' {
+		return app.not_found()
+	}
+	spawn app.gracefull_exit()
+	return app.ok('good bye')
+}
+
+fn (mut app App) gracefull_exit() {
+	eprintln('>> webserver: gracefull_exit')
+	time.sleep(100 * time.millisecond)
+	exit(0)
+}

--- a/vlib/x/vweb/tests/vweb_test.v
+++ b/vlib/x/vweb/tests/vweb_test.v
@@ -1,0 +1,342 @@
+import os
+import time
+import json
+import net
+import net.http
+import io
+
+const (
+	sport           = 12380
+	localserver     = '127.0.0.1:${sport}'
+	exit_after_time = 12000 // milliseconds
+	vexe            = os.getenv('VEXE')
+	vweb_logfile    = os.getenv('VWEB_LOGFILE')
+	vroot           = os.dir(vexe)
+	serverexe       = os.join_path(os.cache_dir(), 'vweb_test_server.exe')
+	tcp_r_timeout   = 30 * time.second
+	tcp_w_timeout   = 30 * time.second
+)
+
+// setup of vweb webserver
+fn testsuite_begin() {
+	os.chdir(vroot) or {}
+	if os.exists(serverexe) {
+		os.rm(serverexe) or {}
+	}
+}
+
+fn test_a_simple_vweb_app_can_be_compiled() {
+	// did_server_compile := os.system('${os.quoted_path(vexe)} -g -o ${os.quoted_path(serverexe)} vlib/vweb/tests/vweb_test_server.v')
+	// TODO: find out why it does not compile with -usecache and -g
+	did_server_compile := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(serverexe)} vlib/vweb/tests/vweb_test_server.v')
+	assert did_server_compile == 0
+	assert os.exists(serverexe)
+}
+
+fn test_a_simple_vweb_app_runs_in_the_background() {
+	mut suffix := ''
+	$if !windows {
+		suffix = ' > /dev/null &'
+	}
+	if vweb_logfile != '' {
+		suffix = ' 2>> ${os.quoted_path(vweb_logfile)} >> ${os.quoted_path(vweb_logfile)} &'
+	}
+	server_exec_cmd := '${os.quoted_path(serverexe)} ${sport} ${exit_after_time} ${suffix}'
+	$if debug_net_socket_client ? {
+		eprintln('running:\n${server_exec_cmd}')
+	}
+	$if windows {
+		spawn os.system(server_exec_cmd)
+	} $else {
+		res := os.system(server_exec_cmd)
+		assert res == 0
+	}
+	$if macos {
+		time.sleep(1000 * time.millisecond)
+	} $else {
+		time.sleep(100 * time.millisecond)
+	}
+}
+
+// web client tests follow
+fn assert_common_headers(received string) {
+	assert received.starts_with('HTTP/1.1 200 OK\r\n')
+	assert received.contains('Server: VWeb\r\n')
+	assert received.contains('Content-Length:')
+	assert received.contains('Connection: close\r\n')
+}
+
+fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
+	received := simple_tcp_client(path: '/') or {
+		assert err.msg() == ''
+		return
+	}
+	assert_common_headers(received)
+	assert received.contains('Content-Type: text/plain')
+	assert received.contains('Content-Length: 15')
+	assert received.ends_with('Welcome to VWeb')
+}
+
+fn test_a_simple_tcp_client_simple_route() {
+	received := simple_tcp_client(path: '/simple') or {
+		assert err.msg() == ''
+		return
+	}
+	assert_common_headers(received)
+	assert received.contains('Content-Type: text/plain')
+	assert received.contains('Content-Length: 15')
+	assert received.ends_with('A simple result')
+}
+
+fn test_a_simple_tcp_client_zero_content_length() {
+	// tests that sending a content-length header of 0 doesn't hang on a read timeout
+	watch := time.new_stopwatch(auto_start: true)
+	simple_tcp_client(path: '/', headers: 'Content-Length: 0\r\n\r\n') or {
+		assert err.msg() == ''
+		return
+	}
+	assert watch.elapsed() < 1 * time.second
+}
+
+fn test_a_simple_tcp_client_html_page() {
+	received := simple_tcp_client(path: '/html_page') or {
+		assert err.msg() == ''
+		return
+	}
+	assert_common_headers(received)
+	assert received.contains('Content-Type: text/html')
+	assert received.ends_with('<h1>ok</h1>')
+}
+
+// net.http client based tests follow:
+fn assert_common_http_headers(x http.Response) ! {
+	assert x.status() == .ok
+	assert x.header.get(.server)! == 'VWeb'
+	assert x.header.get(.content_length)!.int() > 0
+	assert x.header.get(.connection)! == 'close'
+}
+
+fn test_http_client_index() {
+	x := http.get('http://${localserver}/') or { panic(err) }
+	assert_common_http_headers(x)!
+	assert x.header.get(.content_type)! == 'text/plain'
+	assert x.body == 'Welcome to VWeb'
+}
+
+fn test_http_client_404() {
+	server := 'http://${localserver}'
+	url_404_list := [
+		'/zxcnbnm',
+		'/JHKAJA',
+		'/unknown',
+	]
+	for url in url_404_list {
+		res := http.get('${server}${url}') or { panic(err) }
+		assert res.status() == .not_found
+		assert res.body == '404 on "${url}"'
+	}
+}
+
+fn test_http_client_simple() {
+	x := http.get('http://${localserver}/simple') or { panic(err) }
+	assert_common_http_headers(x)!
+	assert x.header.get(.content_type)! == 'text/plain'
+	assert x.body == 'A simple result'
+}
+
+fn test_http_client_html_page() {
+	x := http.get('http://${localserver}/html_page') or { panic(err) }
+	assert_common_http_headers(x)!
+	assert x.header.get(.content_type)! == 'text/html'
+	assert x.body == '<h1>ok</h1>'
+}
+
+fn test_http_client_settings_page() {
+	x := http.get('http://${localserver}/bilbo/settings') or { panic(err) }
+	assert_common_http_headers(x)!
+	assert x.body == 'username: bilbo'
+	//
+	y := http.get('http://${localserver}/kent/settings') or { panic(err) }
+	assert_common_http_headers(y)!
+	assert y.body == 'username: kent'
+}
+
+fn test_http_client_user_repo_settings_page() {
+	x := http.get('http://${localserver}/bilbo/gostamp/settings') or { panic(err) }
+	assert_common_http_headers(x)!
+	assert x.body == 'username: bilbo | repository: gostamp'
+	//
+	y := http.get('http://${localserver}/kent/golang/settings') or { panic(err) }
+	assert_common_http_headers(y)!
+	assert y.body == 'username: kent | repository: golang'
+	//
+	z := http.get('http://${localserver}/missing/golang/settings') or { panic(err) }
+	assert z.status() == .not_found
+}
+
+struct User {
+	name string
+	age  int
+}
+
+fn test_http_client_json_post() {
+	ouser := User{
+		name: 'Bilbo'
+		age: 123
+	}
+	json_for_ouser := json.encode(ouser)
+	mut x := http.post_json('http://${localserver}/json_echo', json_for_ouser) or { panic(err) }
+	$if debug_net_socket_client ? {
+		eprintln('/json_echo endpoint response: ${x}')
+	}
+	assert x.header.get(.content_type)! == 'application/json'
+	assert x.body == json_for_ouser
+	nuser := json.decode(User, x.body) or { User{} }
+	assert '${ouser}' == '${nuser}'
+	//
+	x = http.post_json('http://${localserver}/json', json_for_ouser) or { panic(err) }
+	$if debug_net_socket_client ? {
+		eprintln('/json endpoint response: ${x}')
+	}
+	assert x.header.get(.content_type)! == 'application/json'
+	assert x.body == json_for_ouser
+	nuser2 := json.decode(User, x.body) or { User{} }
+	assert '${ouser}' == '${nuser2}'
+}
+
+fn test_http_client_multipart_form_data() {
+	mut form_config := http.PostMultipartFormConfig{
+		form: {
+			'foo': 'baz buzz'
+		}
+	}
+
+	mut x := http.post_multipart_form('http://${localserver}/form_echo', form_config)!
+
+	$if debug_net_socket_client ? {
+		eprintln('/form_echo endpoint response: ${x}')
+	}
+	assert x.body == form_config.form['foo']
+
+	mut files := []http.FileData{}
+	files << http.FileData{
+		filename: 'vweb'
+		content_type: 'text'
+		data: '"vweb test"'
+	}
+
+	mut form_config_files := http.PostMultipartFormConfig{
+		files: {
+			'file': files
+		}
+	}
+
+	x = http.post_multipart_form('http://${localserver}/file_echo', form_config_files)!
+	$if debug_net_socket_client ? {
+		eprintln('/form_echo endpoint response: ${x}')
+	}
+	assert x.body == files[0].data
+}
+
+fn test_login_with_multipart_form_data_send_by_fetch() {
+	mut form_config := http.PostMultipartFormConfig{
+		form: {
+			'username': 'myusername'
+			'password': 'mypassword123'
+		}
+	}
+	x := http.post_multipart_form('http://${localserver}/login', form_config)!
+	assert x.status_code == 200
+	assert x.status_msg == 'OK'
+	assert x.body == 'username: xmyusernamex | password: xmypassword123x'
+}
+
+fn test_host() {
+	mut req := http.Request{
+		url: 'http://${localserver}/with_host'
+		method: .get
+	}
+
+	mut x := req.do()!
+	assert x.status() == .not_found
+
+	req.add_header(.host, 'example.com')
+	x = req.do()!
+	assert x.status() == .ok
+}
+
+fn test_http_client_shutdown_does_not_work_without_a_cookie() {
+	x := http.get('http://${localserver}/shutdown') or {
+		assert err.msg() == ''
+		return
+	}
+	assert x.status() == .not_found
+}
+
+fn testsuite_end() {
+	// This test is guaranteed to be called last.
+	// It sends a request to the server to shutdown.
+	x := http.fetch(
+		url: 'http://${localserver}/shutdown'
+		method: .get
+		cookies: {
+			'skey': 'superman'
+		}
+	) or {
+		assert err.msg() == ''
+		return
+	}
+	assert x.status() == .ok
+	assert x.body == 'good bye'
+}
+
+// utility code:
+struct SimpleTcpClientConfig {
+	retries int    = 20
+	host    string = 'static.dev'
+	path    string = '/'
+	agent   string = 'v/net.tcp.v'
+	headers string = '\r\n'
+	content string
+}
+
+fn simple_tcp_client(config SimpleTcpClientConfig) !string {
+	mut client := &net.TcpConn(unsafe { nil })
+	mut tries := 0
+	for tries < config.retries {
+		tries++
+		eprintln('> client retries: ${tries}')
+		client = net.dial_tcp(localserver) or {
+			if tries > config.retries {
+				return err
+			}
+			time.sleep(100 * time.millisecond)
+			continue
+		}
+		break
+	}
+	if client == unsafe { nil } {
+		eprintln('coult not create a tcp client connection to ${localserver} after ${config.retries} retries')
+		exit(1)
+	}
+	client.set_read_timeout(tcp_r_timeout)
+	client.set_write_timeout(tcp_w_timeout)
+	defer {
+		client.close() or {}
+	}
+	message := 'GET ${config.path} HTTP/1.1
+Host: ${config.host}
+User-Agent: ${config.agent}
+Accept: */*
+${config.headers}
+${config.content}'
+	$if debug_net_socket_client ? {
+		eprintln('sending:\n${message}')
+	}
+	client.write(message.bytes())!
+	read := io.read_all(reader: client)!
+	$if debug_net_socket_client ? {
+		eprintln('received:\n${read}')
+	}
+	return read.bytestr()
+}

--- a/vlib/x/vweb/tests/vweb_test_server.v
+++ b/vlib/x/vweb/tests/vweb_test_server.v
@@ -1,0 +1,146 @@
+module main
+
+import os
+import vweb
+import time
+
+const (
+	known_users = ['bilbo', 'kent']
+)
+
+struct App {
+	vweb.Context
+	port          int
+	timeout       int
+	global_config shared Config
+}
+
+struct Config {
+	max_ping int
+}
+
+fn exit_after_timeout(timeout_in_ms int) {
+	time.sleep(timeout_in_ms * time.millisecond)
+	println('>> webserver: pid: ${os.getpid()}, exiting ...')
+	exit(0)
+}
+
+fn main() {
+	if os.args.len != 3 {
+		panic('Usage: `vweb_test_server.exe PORT TIMEOUT_IN_MILLISECONDS`')
+	}
+	http_port := os.args[1].int()
+	assert http_port > 0
+	timeout := os.args[2].int()
+	assert timeout > 0
+	spawn exit_after_timeout(timeout)
+	//
+	shared config := &Config{
+		max_ping: 50
+	}
+	app := &App{
+		port: http_port
+		timeout: timeout
+		global_config: config
+	}
+	eprintln('>> webserver: pid: ${os.getpid()}, started on http://localhost:${app.port}/ , with maximum runtime of ${app.timeout} milliseconds.')
+	vweb.run_at(app, host: 'localhost', port: http_port, family: .ip)!
+}
+
+// pub fn (mut app App) init_server() {
+//}
+
+pub fn (mut app App) index() vweb.Result {
+	rlock app.global_config {
+		assert app.global_config.max_ping == 50
+	}
+	return app.text('Welcome to VWeb')
+}
+
+pub fn (mut app App) simple() vweb.Result {
+	return app.text('A simple result')
+}
+
+pub fn (mut app App) html_page() vweb.Result {
+	return app.html('<h1>ok</h1>')
+}
+
+// the following serve custom routes
+['/:user/settings']
+pub fn (mut app App) settings(username string) vweb.Result {
+	if username !in known_users {
+		return app.not_found()
+	}
+	return app.html('username: ${username}')
+}
+
+['/:user/:repo/settings']
+pub fn (mut app App) user_repo_settings(username string, repository string) vweb.Result {
+	if username !in known_users {
+		return app.not_found()
+	}
+	return app.html('username: ${username} | repository: ${repository}')
+}
+
+['/json_echo'; post]
+pub fn (mut app App) json_echo() vweb.Result {
+	// eprintln('>>>>> received http request at /json_echo is: $app.req')
+	app.set_content_type(app.req.header.get(.content_type) or { '' })
+	return app.ok(app.req.data)
+}
+
+['/login'; post]
+pub fn (mut app App) login_form(username string, password string) vweb.Result {
+	return app.html('username: x${username}x | password: x${password}x')
+}
+
+['/form_echo'; post]
+pub fn (mut app App) form_echo() vweb.Result {
+	app.set_content_type(app.req.header.get(.content_type) or { '' })
+	return app.ok(app.form['foo'])
+}
+
+['/file_echo'; post]
+pub fn (mut app App) file_echo() vweb.Result {
+	if 'file' !in app.files {
+		app.set_status(500, '')
+		return app.text('no file')
+	}
+
+	return app.text(app.files['file'][0].data)
+}
+
+// Make sure [post] works without the path
+[post]
+pub fn (mut app App) json() vweb.Result {
+	// eprintln('>>>>> received http request at /json is: $app.req')
+	app.set_content_type(app.req.header.get(.content_type) or { '' })
+	return app.ok(app.req.data)
+}
+
+// Custom 404 page
+pub fn (mut app App) not_found() vweb.Result {
+	app.set_status(404, 'Not Found')
+	return app.html('404 on "${app.req.url}"')
+}
+
+[host: 'example.com']
+['/with_host']
+pub fn (mut app App) with_host() vweb.Result {
+	return app.ok('')
+}
+
+pub fn (mut app App) shutdown() vweb.Result {
+	session_key := app.get_cookie('skey') or { return app.not_found() }
+	if session_key != 'superman' {
+		return app.not_found()
+	}
+	spawn app.gracefull_exit()
+	return app.ok('good bye')
+}
+
+fn (mut app App) gracefull_exit() {
+	eprintln('>> webserver: gracefull_exit')
+	time.sleep(100 * time.millisecond)
+	exit(0)
+}

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -1,0 +1,1104 @@
+// Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module vweb
+
+import os
+import io
+import runtime
+import net
+import net.http
+import net.urllib
+import time
+import json
+import encoding.html
+import context
+import picoev
+
+// A type which don't get filtered inside templates
+pub type RawHtml = string
+
+// A dummy structure that returns from routes to indicate that you actually sent something to a user
+[noinit]
+pub struct Result {}
+
+pub const (
+	methods_with_form = [http.Method.post, .put, .patch]
+	headers_close     = http.new_custom_header_from_map({
+		'Server':                           'VWeb'
+		http.CommonHeader.connection.str(): 'close'
+	}) or { panic('should never fail') }
+
+	http_302          = http.new_response(
+		status: .found
+		body: '302 Found'
+		header: headers_close
+	)
+	http_400          = http.new_response(
+		status: .bad_request
+		body: '400 Bad Request'
+		header: http.new_header(
+			key: .content_type
+			value: 'text/plain'
+		).join(headers_close)
+	)
+	http_404          = http.new_response(
+		status: .not_found
+		body: '404 Not Found'
+		header: http.new_header(
+			key: .content_type
+			value: 'text/plain'
+		).join(headers_close)
+	)
+	http_500          = http.new_response(
+		status: .internal_server_error
+		body: '500 Internal Server Error'
+		header: http.new_header(
+			key: .content_type
+			value: 'text/plain'
+		).join(headers_close)
+	)
+	mime_types        = {
+		'.aac':    'audio/aac'
+		'.abw':    'application/x-abiword'
+		'.arc':    'application/x-freearc'
+		'.avi':    'video/x-msvideo'
+		'.azw':    'application/vnd.amazon.ebook'
+		'.bin':    'application/octet-stream'
+		'.bmp':    'image/bmp'
+		'.bz':     'application/x-bzip'
+		'.bz2':    'application/x-bzip2'
+		'.cda':    'application/x-cdf'
+		'.csh':    'application/x-csh'
+		'.css':    'text/css'
+		'.csv':    'text/csv'
+		'.doc':    'application/msword'
+		'.docx':   'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+		'.eot':    'application/vnd.ms-fontobject'
+		'.epub':   'application/epub+zip'
+		'.gz':     'application/gzip'
+		'.gif':    'image/gif'
+		'.htm':    'text/html'
+		'.html':   'text/html'
+		'.ico':    'image/vnd.microsoft.icon'
+		'.ics':    'text/calendar'
+		'.jar':    'application/java-archive'
+		'.jpeg':   'image/jpeg'
+		'.jpg':    'image/jpeg'
+		'.js':     'text/javascript'
+		'.json':   'application/json'
+		'.jsonld': 'application/ld+json'
+		'.md':     'text/markdown'
+		'.mid':    'audio/midi audio/x-midi'
+		'.midi':   'audio/midi audio/x-midi'
+		'.mjs':    'text/javascript'
+		'.mp3':    'audio/mpeg'
+		'.mp4':    'video/mp4'
+		'.mpeg':   'video/mpeg'
+		'.mpkg':   'application/vnd.apple.installer+xml'
+		'.odp':    'application/vnd.oasis.opendocument.presentation'
+		'.ods':    'application/vnd.oasis.opendocument.spreadsheet'
+		'.odt':    'application/vnd.oasis.opendocument.text'
+		'.oga':    'audio/ogg'
+		'.ogv':    'video/ogg'
+		'.ogx':    'application/ogg'
+		'.opus':   'audio/opus'
+		'.otf':    'font/otf'
+		'.png':    'image/png'
+		'.pdf':    'application/pdf'
+		'.php':    'application/x-httpd-php'
+		'.ppt':    'application/vnd.ms-powerpoint'
+		'.pptx':   'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+		'.rar':    'application/vnd.rar'
+		'.rtf':    'application/rtf'
+		'.sh':     'application/x-sh'
+		'.svg':    'image/svg+xml'
+		'.swf':    'application/x-shockwave-flash'
+		'.tar':    'application/x-tar'
+		'.tif':    'image/tiff'
+		'.tiff':   'image/tiff'
+		'.ts':     'video/mp2t'
+		'.ttf':    'font/ttf'
+		'.txt':    'text/plain'
+		'.vsd':    'application/vnd.visio'
+		'.wasm':   'application/wasm'
+		'.wav':    'audio/wav'
+		'.weba':   'audio/webm'
+		'.webm':   'video/webm'
+		'.webp':   'image/webp'
+		'.woff':   'font/woff'
+		'.woff2':  'font/woff2'
+		'.xhtml':  'application/xhtml+xml'
+		'.xls':    'application/vnd.ms-excel'
+		'.xlsx':   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+		'.xml':    'application/xml'
+		'.xul':    'application/vnd.mozilla.xul+xml'
+		'.zip':    'application/zip'
+		'.3gp':    'video/3gpp'
+		'.3g2':    'video/3gpp2'
+		'.7z':     'application/x-7z-compressed'
+	}
+	max_http_post_size = 1024 * 1024
+	default_port       = 8080
+)
+
+// The Context struct represents the Context which hold the HTTP request and response.
+// It has fields for the query, form, files.
+pub struct Context {
+mut:
+	content_type string = 'text/plain'
+	status       string = '200 OK'
+	ctx          context.Context = context.EmptyContext{}
+pub:
+	// HTTP Request
+	req http.Request
+	// TODO Response
+pub mut:
+	done bool
+	// time.ticks() from start of vweb connection handle.
+	// You can use it to determine how much time is spent on your request.
+	page_gen_start i64
+	// TCP connection to client.
+	// But beware, do not store it for further use, after request processing vweb will close connection.
+	conn              &net.TcpConn = unsafe { nil }
+	static_files      map[string]string
+	static_mime_types map[string]string
+	static_hosts      map[string]string
+	// Map containing query params for the route.
+	// http://localhost:3000/index?q=vpm&order_by=desc => { 'q': 'vpm', 'order_by': 'desc' }
+	query map[string]string
+	// Multipart-form fields.
+	form map[string]string
+	// Files from multipart-form.
+	files map[string][]http.FileData
+
+	header http.Header // response headers
+	// ? It doesn't seem to be used anywhere
+	form_error                  string
+	livereload_poll_interval_ms int = 250
+}
+
+struct FileData {
+pub:
+	filename     string
+	content_type string
+	data         string
+}
+
+struct Route {
+	methods    []http.Method
+	path       string
+	middleware string
+	host       string
+}
+
+// Defining this method is optional.
+// This method called at server start.
+// You can use it for initializing globals.
+pub fn (ctx Context) init_server() {
+	eprintln('init_server() has been deprecated, please init your web app in `fn main()`')
+}
+
+// Defining this method is optional.
+// This method is called before every request (aka middleware).
+// You can use it for checking user session cookies or to add headers.
+pub fn (ctx Context) before_request() {}
+
+// TODO - test
+// vweb intern function
+[manualfree]
+pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bool {
+	if ctx.done {
+		return false
+	}
+	ctx.done = true
+	//
+	mut resp := http.Response{
+		body: res
+	}
+	$if vweb_livereload ? {
+		if mimetype == 'text/html' {
+			resp.body = res.replace('</html>', '<script src="/vweb_livereload/${vweb_livereload_server_start}/script.js"></script>\n</html>')
+		}
+	}
+	// build the header after the potential modification of resp.body from above
+	header := http.new_header_from_map({
+		http.CommonHeader.content_type:   mimetype
+		http.CommonHeader.content_length: resp.body.len.str()
+	}).join(ctx.header)
+	resp.header = header.join(vweb.headers_close)
+	//
+	resp.set_version(.v1_1)
+	resp.set_status(http.status_from_int(ctx.status.int()))
+	send_string(mut ctx.conn, resp.bytestr()) or { return false }
+	return true
+}
+
+// Response HTTP_OK with s as payload with content-type `text/html`
+pub fn (mut ctx Context) html(s string) Result {
+	ctx.send_response_to_client('text/html', s)
+	return Result{}
+}
+
+// Response HTTP_OK with s as payload with content-type `text/plain`
+pub fn (mut ctx Context) text(s string) Result {
+	ctx.send_response_to_client('text/plain', s)
+	return Result{}
+}
+
+// Response HTTP_OK with json_s as payload with content-type `application/json`
+pub fn (mut ctx Context) json[T](j T) Result {
+	json_s := json.encode(j)
+	ctx.send_response_to_client('application/json', json_s)
+	return Result{}
+}
+
+// Response HTTP_OK with a pretty-printed JSON result
+pub fn (mut ctx Context) json_pretty[T](j T) Result {
+	json_s := json.encode_pretty(j)
+	ctx.send_response_to_client('application/json', json_s)
+	return Result{}
+}
+
+// TODO - test
+// Response HTTP_OK with file as payload
+pub fn (mut ctx Context) file(f_path string) Result {
+	if !os.exists(f_path) {
+		eprintln('[vweb] file ${f_path} does not exist')
+		return ctx.not_found()
+	}
+	ext := os.file_ext(f_path)
+	data := os.read_file(f_path) or {
+		eprint(err.msg())
+		ctx.server_error(500)
+		return Result{}
+	}
+	content_type := vweb.mime_types[ext]
+	if content_type.len == 0 {
+		eprintln('[vweb] no MIME type found for extension ${ext}')
+		ctx.server_error(500)
+	} else {
+		ctx.send_response_to_client(content_type, data)
+	}
+	return Result{}
+}
+
+// Response HTTP_OK with s as payload
+pub fn (mut ctx Context) ok(s string) Result {
+	ctx.send_response_to_client(ctx.content_type, s)
+	return Result{}
+}
+
+// TODO - test
+// Response a server error
+pub fn (mut ctx Context) server_error(ecode int) Result {
+	$if debug {
+		eprintln('> ctx.server_error ecode: ${ecode}')
+	}
+	if ctx.done {
+		return Result{}
+	}
+	send_string(mut ctx.conn, vweb.http_500.bytestr()) or {}
+	return Result{}
+}
+
+// Redirect to an url
+pub fn (mut ctx Context) redirect(url string) Result {
+	if ctx.done {
+		return Result{}
+	}
+	ctx.done = true
+	mut resp := vweb.http_302
+	resp.header = resp.header.join(ctx.header)
+	resp.header.add(.location, url)
+	send_string(mut ctx.conn, resp.bytestr()) or { return Result{} }
+	return Result{}
+}
+
+// Send an not_found response
+pub fn (mut ctx Context) not_found() Result {
+	// TODO add a [must_be_returned] attribute, so that the caller is forced to use `return app.not_found()`
+	if ctx.done {
+		return Result{}
+	}
+	ctx.done = true
+	send_string(mut ctx.conn, vweb.http_404.bytestr()) or {}
+	return Result{}
+}
+
+// TODO - test
+// Sets a cookie
+pub fn (mut ctx Context) set_cookie(cookie http.Cookie) {
+	cookie_raw := cookie.str()
+	if cookie_raw == '' {
+		eprintln('[vweb] error setting cookie: name of cookie is invalid')
+		return
+	}
+	ctx.add_header('Set-Cookie', cookie_raw)
+}
+
+// Sets the response content type
+pub fn (mut ctx Context) set_content_type(typ string) {
+	ctx.content_type = typ
+}
+
+// TODO - test
+// Sets a cookie with a `expire_date`
+pub fn (mut ctx Context) set_cookie_with_expire_date(key string, val string, expire_date time.Time) {
+	cookie := http.Cookie{
+		name: key
+		value: val
+		expires: expire_date
+	}
+	ctx.set_cookie(cookie)
+}
+
+// Gets a cookie by a key
+pub fn (ctx &Context) get_cookie(key string) !string {
+	if value := ctx.req.cookies[key] {
+		return value
+	}
+	return error('Cookie not found')
+}
+
+// TODO - test
+// Sets the response status
+pub fn (mut ctx Context) set_status(code int, desc string) {
+	if code < 100 || code > 599 {
+		ctx.status = '500 Internal Server Error'
+	} else {
+		ctx.status = '${code} ${desc}'
+	}
+}
+
+// TODO - test
+// Adds an header to the response with key and val
+pub fn (mut ctx Context) add_header(key string, val string) {
+	ctx.header.add_custom(key, val) or {}
+}
+
+// TODO - test
+// Returns the header data from the key
+pub fn (ctx &Context) get_header(key string) string {
+	return ctx.req.header.get_custom(key) or { '' }
+}
+
+// set_value sets a value on the context
+pub fn (mut ctx Context) set_value(key context.Key, value context.Any) {
+	ctx.ctx = context.with_value(ctx.ctx, key, value)
+}
+
+// get_value gets a value from the context
+pub fn (ctx &Context) get_value[T](key context.Key) ?T {
+	if val := ctx.ctx.value(key) {
+		match val {
+			T {
+				// `context.value()` always returns a reference
+				// if we send back `val` the returntype becomes `?&T` and this can be problematic
+				// for end users since they won't be able to do something like
+				// `app.get_value[string]('a') or { '' }
+				// since V expects the value in the or block to be of type `&string`.
+				// And if a reference was allowed it would enable mutating the context directly
+				return *val
+			}
+			else {}
+		}
+	}
+	return none
+}
+
+pub type DatabasePool[T] = fn (tid int) T
+
+interface DbPoolInterface {
+	db_handle voidptr
+mut:
+	db voidptr
+}
+
+interface DbInterface {
+mut:
+	db voidptr
+}
+
+pub type Middleware = fn (mut Context) bool
+
+interface MiddlewareInterface {
+	middlewares map[string][]Middleware
+}
+
+// Generate route structs for an app
+fn generate_routes[T](app &T) !map[string]Route {
+	// Parsing methods attributes
+	mut routes := map[string]Route{}
+	$for method in T.methods {
+		http_methods, route_path, middleware, host := parse_attrs(method.name, method.attrs) or {
+			return error('error parsing method attributes: ${err}')
+		}
+
+		routes[method.name] = Route{
+			methods: http_methods
+			path: route_path
+			middleware: middleware
+			host: host
+		}
+	}
+	return routes
+}
+
+type ControllerHandler = fn (ctx Context, mut url urllib.URL, host string)
+
+pub struct ControllerPath {
+pub:
+	path    string
+	handler ControllerHandler = unsafe { nil }
+pub mut:
+	host string
+}
+
+interface ControllerInterface {
+	controllers []&ControllerPath
+}
+
+pub struct Controller {
+pub mut:
+	controllers []&ControllerPath
+}
+
+// controller generates a new Controller for the main app
+pub fn controller[T](path string, global_app &T) &ControllerPath {
+	routes := generate_routes(global_app) or { panic(err.msg()) }
+
+	// generate struct with closure so the generic type is encapsulated in the closure
+	// no need to type `ControllerHandler` as generic since it's not needed for closures
+	return &ControllerPath{
+		path: path
+		handler: fn [global_app, path, routes] [T](ctx Context, mut url urllib.URL, host string) {
+			// request_app is freed in `handle_route`
+			mut request_app := new_request_app[T](global_app, ctx)
+			// transform the url
+			url.path = url.path.all_after_first(path)
+			handle_route[T](mut request_app, url, host, &routes)
+		}
+	}
+}
+
+// controller_host generates a controller which only handles incoming requests from the `host` domain
+pub fn controller_host[T](host string, path string, global_app &T) &ControllerPath {
+	mut ctrl := controller(path, global_app)
+	ctrl.host = host
+	return ctrl
+}
+
+// run - start a new VWeb server, listening to all available addresses, at the specified `port`
+pub fn run[T](global_app &T, port int) {
+	run_at[T](global_app, port: port) or { panic(err.msg()) }
+}
+
+[params]
+pub struct RunParams {
+	port                 int  = 8080
+	show_startup_message bool = true
+}
+
+// EV context
+struct RequestParams {
+	global_app  voidptr
+	controllers []&ControllerPath
+	routes      &map[string]Route
+}
+
+// run_at - start a new VWeb server, listening only on a specific address `host`, at the specified `port`
+// Example: vweb.run_at(new_app(), vweb.RunParams{ host: 'localhost' port: 8099 family: .ip }) or { panic(err) }
+[manualfree]
+pub fn run_at[T](global_app &T, params RunParams) ! {
+	if params.port <= 0 || params.port > 65535 {
+		return error('invalid port number `${params.port}`, it should be between 1 and 65535')
+	}
+
+	routes := generate_routes(global_app)!
+	controllers_sorted := check_duplicate_routes_in_controllers[T](global_app, routes)!
+
+	if params.show_startup_message {
+		println('[Vweb] Running app on http://localhost:${params.port}/')
+	}
+	flush_stdout()
+
+	pico_context := &RequestParams{
+		global_app: unsafe { global_app }
+		controllers: controllers_sorted
+		routes: &routes
+	}
+
+	// is_raw: true, raw_cb: ...
+	mut pico := picoev.new(
+		port: params.port
+		is_raw: true
+		raw_cb: ev_callback[T]
+		user_data: pico_context
+	)
+	pico.serve()
+}
+
+fn check_duplicate_routes_in_controllers[T](global_app &T, routes map[string]Route) ![]&ControllerPath {
+	mut controllers_sorted := []&ControllerPath{}
+	$if T is ControllerInterface {
+		mut paths := []string{}
+		controllers_sorted = global_app.controllers.clone()
+		controllers_sorted.sort(a.path.len > b.path.len)
+		for controller in controllers_sorted {
+			if controller.host == '' {
+				if controller.path in paths {
+					return error('conflicting paths: duplicate controller handling the route "${controller.path}"')
+				}
+				paths << controller.path
+			}
+		}
+		for method_name, route in routes {
+			for controller_path in paths {
+				if route.path.starts_with(controller_path) {
+					return error('conflicting paths: method "${method_name}" with route "${route.path}" should be handled by the Controller of path "${controller_path}"')
+				}
+			}
+		}
+	}
+	return controllers_sorted
+}
+
+fn new_request_app[T](global_app &T, ctx Context) &T {
+	// Create a new app object for each connection, copy global data like db connections
+	mut request_app := &T{}
+	$if T is MiddlewareInterface {
+		request_app = &T{
+			middlewares: global_app.middlewares.clone()
+		}
+	}
+
+	$if T is DbPoolInterface {
+		// get database connection from the connection pool
+		request_app.db = global_app.db_handle(tid)
+	} $else $if T is DbInterface {
+		// copy a database to a app without pooling
+		request_app.db = global_app.db
+	}
+
+	$for field in T.fields {
+		if field.is_shared {
+			unsafe {
+				// TODO: remove this horrible hack, when copying a shared field at comptime works properly!!!
+				raptr := &voidptr(&request_app.$(field.name))
+				gaptr := &voidptr(&global_app.$(field.name))
+				*raptr = *gaptr
+				_ = raptr // TODO: v produces a warning that `raptr` is unused otherwise, even though it was on the previous line
+			}
+		} else {
+			if 'vweb_global' in field.attrs {
+				request_app.$(field.name) = global_app.$(field.name)
+			}
+		}
+	}
+	request_app.Context = ctx // copy request data such as form and query etc
+
+	// copy static files
+	request_app.Context.static_files = global_app.static_files.clone()
+	request_app.Context.static_mime_types = global_app.static_mime_types.clone()
+	request_app.Context.static_hosts = global_app.static_hosts.clone()
+
+	return request_app
+}
+
+fn ev_callback[T](data voidptr, fd int) {
+	mut params := unsafe { &RequestParams(data) }
+	$if vweb_trace_worker_scan ? {
+		eprintln('[vweb] received request')
+	}
+	handle_conn[T](fd, params.global_app, params.controllers, params.routes)
+}
+
+[manualfree]
+fn handle_conn[T](fd int, global_app &T, controllers []&ControllerPath, routes &map[string]Route) {
+	mut conn := &net.TcpConn{
+		sock: net.tcp_socket_from_handle_raw(fd)
+		handle: fd
+		is_blocking: false
+	}
+	defer {
+		conn.close() or {}
+	}
+
+	mut reader := io.new_buffered_reader(reader: conn)
+	defer {
+		unsafe {
+			reader.free()
+		}
+	}
+
+	page_gen_start := time.ticks()
+
+	// Request parse
+	req := http.parse_request(mut reader) or {
+		// Prevents errors from being thrown when BufferedReader is empty
+		if '${err}' != 'none' {
+			eprintln('[vweb] error parsing request: ${err}')
+		}
+		return
+	}
+	$if trace_request ? {
+		dump(req)
+	}
+	$if trace_request_url ? {
+		dump(req.url)
+	}
+	// URL Parse
+	mut url := urllib.parse(req.url) or {
+		eprintln('[vweb] error parsing path: ${err}')
+		return
+	}
+
+	// Query parse
+	query := parse_query_from_url(url)
+
+	// Form parse
+	form, files := parse_form_from_request(req) or {
+		// Bad request
+		conn.write(vweb.http_400.bytes()) or {}
+		return
+	}
+
+	// remove the port from the HTTP Host header
+	host_with_port := req.header.get(.host) or { '' }
+	host, _ := urllib.split_host_port(host_with_port)
+
+	// Create Context with request data
+	ctx := Context{
+		ctx: context.background()
+		req: req
+		page_gen_start: page_gen_start
+		conn: conn
+		query: query
+		form: form
+		files: files
+	}
+
+	// match controller paths
+	$if T is ControllerInterface {
+		for controller in controllers {
+			// skip controller if the hosts don't match
+			if controller.host != '' && host != controller.host {
+				continue
+			}
+			if url.path.len >= controller.path.len && url.path.starts_with(controller.path) {
+				// pass route handling to the controller
+				controller.handler(ctx, mut url, host)
+				return
+			}
+		}
+	}
+
+	mut request_app := new_request_app(global_app, ctx)
+	handle_route(mut request_app, url, host, routes)
+}
+
+[manualfree]
+fn handle_route[T](mut app T, url urllib.URL, host string, routes &map[string]Route) {
+	defer {
+		unsafe {
+			free(app)
+		}
+	}
+
+	url_words := url.path.split('/').filter(it != '')
+
+	// Calling middleware...
+	app.before_request()
+
+	$if vweb_livereload ? {
+		if url.path.starts_with('/vweb_livereload/') {
+			if url.path.ends_with('current') {
+				app.handle_vweb_livereload_current()
+				return
+			}
+			if url.path.ends_with('script.js') {
+				app.handle_vweb_livereload_script()
+				return
+			}
+		}
+	}
+
+	// Static handling
+	if serve_if_static[T](mut app, url, host) {
+		// successfully served a static file
+		return
+	}
+
+	// Route matching
+	$for method in T.methods {
+		$if method.return_type is Result {
+			route := (*routes)[method.name] or {
+				eprintln('[vweb] parsed attributes for the `${method.name}` are not found, skipping...')
+				Route{}
+			}
+
+			// Skip if the HTTP request method does not match the attributes
+			if app.req.method in route.methods {
+				// Used for route matching
+				route_words := route.path.split('/').filter(it != '')
+
+				// Skip if the host does not match or is empty
+				if route.host == '' || route.host == host {
+					// Route immediate matches first
+					// For example URL `/register` matches route `/:user`, but `fn register()`
+					// should be called first.
+					if !route.path.contains('/:') && url_words == route_words {
+						// We found a match
+						$if T is MiddlewareInterface {
+							if validate_middleware(mut app, url.path) == false {
+								return
+							}
+						}
+
+						if app.req.method == .post && method.args.len > 0 {
+							// Populate method args with form values
+							mut args := []string{cap: method.args.len}
+							for param in method.args {
+								args << app.form[param.name]
+							}
+
+							if route.middleware == '' {
+								app.$method(args)
+							} else if validate_app_middleware(mut app, route.middleware,
+								method.name)
+							{
+								app.$method(args)
+							}
+						} else {
+							if route.middleware == '' {
+								app.$method()
+							} else if validate_app_middleware(mut app, route.middleware,
+								method.name)
+							{
+								app.$method()
+							}
+						}
+						return
+					}
+
+					if url_words.len == 0 && route_words == ['index'] && method.name == 'index' {
+						$if T is MiddlewareInterface {
+							if validate_middleware(mut app, url.path) == false {
+								return
+							}
+						}
+						if route.middleware == '' {
+							app.$method()
+						} else if validate_app_middleware(mut app, route.middleware, method.name) {
+							app.$method()
+						}
+						return
+					}
+
+					if params := route_matches(url_words, route_words) {
+						method_args := params.clone()
+						if method_args.len != method.args.len {
+							eprintln('[vweb] warning: uneven parameters count (${method.args.len}) in `${method.name}`, compared to the vweb route `${method.attrs}` (${method_args.len})')
+						}
+
+						$if T is MiddlewareInterface {
+							if validate_middleware(mut app, url.path) == false {
+								return
+							}
+						}
+						if route.middleware == '' {
+							app.$method(method_args)
+						} else if validate_app_middleware(mut app, route.middleware, method.name) {
+							app.$method(method_args)
+						}
+						return
+					}
+				}
+			}
+		}
+	}
+	// Route not found
+	app.not_found()
+}
+
+// validate_middleware validates and fires all middlewares that are defined in the global app instance
+fn validate_middleware[T](mut app T, full_path string) bool {
+	for path, middleware_chain in app.middlewares {
+		// only execute middleware if route.path starts with `path`
+		if full_path.len >= path.len && full_path.starts_with(path) {
+			// there is middleware for this route
+			for func in middleware_chain {
+				if func(mut app.Context) == false {
+					return false
+				}
+			}
+		}
+	}
+	// passed all middleware checks
+	return true
+}
+
+// validate_app_middleware validates all middlewares as a method of `app`
+fn validate_app_middleware[T](mut app T, middleware string, method_name string) bool {
+	// then the middleware that is defined for this route specifically
+	valid := fire_app_middleware(mut app, middleware) or {
+		eprintln('[vweb] warning: middleware `${middleware}` for the `${method_name}` are not found')
+		true
+	}
+	return valid
+}
+
+// fire_app_middleware fires all middlewares that are defined as a method of `app`
+fn fire_app_middleware[T](mut app T, method_name string) ?bool {
+	$for method in T.methods {
+		if method_name == method.name {
+			$if method.return_type is bool {
+				return app.$method()
+			} $else {
+				eprintln('[vweb] error in `${method.name}, middleware functions must return bool')
+				return none
+			}
+		}
+	}
+	// no middleware function found
+	return none
+}
+
+fn route_matches(url_words []string, route_words []string) ?[]string {
+	// URL path should be at least as long as the route path
+	// except for the catchall route (`/:path...`)
+	if route_words.len == 1 && route_words[0].starts_with(':') && route_words[0].ends_with('...') {
+		return ['/' + url_words.join('/')]
+	}
+	if url_words.len < route_words.len {
+		return none
+	}
+
+	mut params := []string{cap: url_words.len}
+	if url_words.len == route_words.len {
+		for i in 0 .. url_words.len {
+			if route_words[i].starts_with(':') {
+				// We found a path paramater
+				params << url_words[i]
+			} else if route_words[i] != url_words[i] {
+				// This url does not match the route
+				return none
+			}
+		}
+		return params
+	}
+
+	// The last route can end with ... indicating an array
+	if route_words.len == 0 || !route_words[route_words.len - 1].ends_with('...') {
+		return none
+	}
+
+	for i in 0 .. route_words.len - 1 {
+		if route_words[i].starts_with(':') {
+			// We found a path paramater
+			params << url_words[i]
+		} else if route_words[i] != url_words[i] {
+			// This url does not match the route
+			return none
+		}
+	}
+	params << url_words[route_words.len - 1..url_words.len].join('/')
+	return params
+}
+
+// check if request is for a static file and serves it
+// returns true if we served a static file, false otherwise
+[manualfree]
+fn serve_if_static[T](mut app T, url urllib.URL, host string) bool {
+	// TODO: handle url parameters properly - for now, ignore them
+	static_file := app.static_files[url.path] or { return false }
+	mime_type := app.static_mime_types[url.path] or { return false }
+	static_host := app.static_hosts[url.path] or { '' }
+	if static_file == '' || mime_type == '' {
+		return false
+	}
+	if static_host != '' && static_host != host {
+		return false
+	}
+	data := os.read_file(static_file) or {
+		send_string(mut app.conn, vweb.http_404.bytestr()) or {}
+		return true
+	}
+	app.send_response_to_client(mime_type, data)
+	unsafe { data.free() }
+	return true
+}
+
+fn (mut ctx Context) scan_static_directory(directory_path string, mount_path string, host string) {
+	files := os.ls(directory_path) or { panic(err) }
+	if files.len > 0 {
+		for file in files {
+			full_path := os.join_path(directory_path, file)
+			if os.is_dir(full_path) {
+				ctx.scan_static_directory(full_path, mount_path.trim_right('/') + '/' + file,
+					host)
+			} else if file.contains('.') && !file.starts_with('.') && !file.ends_with('.') {
+				ext := os.file_ext(file)
+				// Rudimentary guard against adding files not in mime_types.
+				// Use host_serve_static directly to add non-standard mime types.
+				if ext in vweb.mime_types {
+					ctx.host_serve_static(host, mount_path.trim_right('/') + '/' + file,
+						full_path)
+				}
+			}
+		}
+	}
+}
+
+// handle_static is used to mark a folder (relative to the current working folder)
+// as one that contains only static resources (css files, images etc).
+// If `root` is set the mount path for the dir will be in '/'
+// Usage:
+// ```v
+// os.chdir( os.executable() )?
+// app.handle_static('assets', true)
+// ```
+pub fn (mut ctx Context) handle_static(directory_path string, root bool) bool {
+	return ctx.host_handle_static('', directory_path, root)
+}
+
+// host_handle_static is used to mark a folder (relative to the current working folder)
+// as one that contains only static resources (css files, images etc).
+// If `root` is set the mount path for the dir will be in '/'
+// Usage:
+// ```v
+// os.chdir( os.executable() )?
+// app.host_handle_static('localhost', 'assets', true)
+// ```
+pub fn (mut ctx Context) host_handle_static(host string, directory_path string, root bool) bool {
+	if ctx.done || !os.exists(directory_path) {
+		return false
+	}
+	dir_path := directory_path.trim_space().trim_right('/')
+	mut mount_path := ''
+	if dir_path != '.' && os.is_dir(dir_path) && !root {
+		// Mount point hygene, "./assets" => "/assets".
+		mount_path = '/' + dir_path.trim_left('.').trim('/')
+	}
+	ctx.scan_static_directory(dir_path, mount_path, host)
+	return true
+}
+
+// TODO - test
+// mount_static_folder_at - makes all static files in `directory_path` and inside it, available at http://server/mount_path
+// For example: suppose you have called .mount_static_folder_at('/var/share/myassets', '/assets'),
+// and you have a file /var/share/myassets/main.css .
+// => That file will be available at URL: http://server/assets/main.css .
+pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_path string) bool {
+	return ctx.host_mount_static_folder_at('', directory_path, mount_path)
+}
+
+// TODO - test
+// host_mount_static_folder_at - makes all static files in `directory_path` and inside it, available at http://host/mount_path
+// For example: suppose you have called .host_mount_static_folder_at('localhost', '/var/share/myassets', '/assets'),
+// and you have a file /var/share/myassets/main.css .
+// => That file will be available at URL: http://localhost/assets/main.css .
+pub fn (mut ctx Context) host_mount_static_folder_at(host string, directory_path string, mount_path string) bool {
+	if ctx.done || mount_path.len < 1 || mount_path[0] != `/` || !os.exists(directory_path) {
+		return false
+	}
+	dir_path := directory_path.trim_right('/')
+
+	trim_mount_path := mount_path.trim_left('/').trim_right('/')
+	ctx.scan_static_directory(dir_path, '/${trim_mount_path}', host)
+	return true
+}
+
+// TODO - test
+// Serves a file static
+// `url` is the access path on the site, `file_path` is the real path to the file, `mime_type` is the file type
+pub fn (mut ctx Context) serve_static(url string, file_path string) {
+	ctx.host_serve_static('', url, file_path)
+}
+
+// TODO - test
+// Serves a file static
+// `url` is the access path on the site, `file_path` is the real path to the file
+// `mime_type` is the file type, `host` is the host to serve the file from
+pub fn (mut ctx Context) host_serve_static(host string, url string, file_path string) {
+	ctx.static_files[url] = file_path
+	// ctx.static_mime_types[url] = mime_type
+	ext := os.file_ext(file_path)
+	ctx.static_mime_types[url] = vweb.mime_types[ext]
+	ctx.static_hosts[url] = host
+}
+
+// user_agent returns the user-agent header for the current client
+pub fn (ctx &Context) user_agent() string {
+	return ctx.req.header.get(.user_agent) or { '' }
+}
+
+// Returns the ip address from the current user
+pub fn (ctx &Context) ip() string {
+	mut ip := ctx.req.header.get(.x_forwarded_for) or { '' }
+	if ip == '' {
+		ip = ctx.req.header.get_custom('X-Real-Ip') or { '' }
+	}
+
+	if ip.contains(',') {
+		ip = ip.all_before(',')
+	}
+	if ip == '' {
+		ip = ctx.conn.peer_ip() or { '' }
+	}
+	return ip
+}
+
+// Set s to the form error
+pub fn (mut ctx Context) error(s string) {
+	eprintln('[vweb] Context.error: ${s}')
+	ctx.form_error = s
+}
+
+// Returns an empty result
+pub fn not_found() Result {
+	return Result{}
+}
+
+fn send_string(mut conn net.TcpConn, s string) ! {
+	$if trace_send_string_conn ? {
+		eprintln('> send_string: conn: ${ptr_str(conn)}')
+	}
+	$if trace_response ? {
+		eprintln('> send_string:\n${s}\n')
+	}
+	if voidptr(conn) == unsafe { nil } {
+		return error('connection was closed before send_string')
+	}
+	conn.write_string(s)!
+}
+
+// Do not delete.
+// It used by `vlib/v/gen/c/str_intp.v:130` for string interpolation inside vweb templates
+// TODO: move it to template render
+fn filter(s string) string {
+	return html.escape(s)
+}
+
+[params]
+pub struct PoolParams[T] {
+	handler    fn () T [required] = unsafe { nil }
+	nr_workers int = runtime.nr_jobs()
+}
+
+// database_pool creates a pool of database connections
+pub fn database_pool[T](params PoolParams[T]) DatabasePool[T] {
+	mut connections := []T{}
+	// create a database connection for each worker
+	for _ in 0 .. params.nr_workers {
+		connections << params.handler()
+	}
+
+	return fn [connections] [T](tid int) T {
+		$if vweb_trace_worker_scan ? {
+			eprintln('[vweb] worker ${tid} received database connection')
+		}
+		return connections[tid]
+	}
+}

--- a/vlib/x/vweb/vweb_app_test.v
+++ b/vlib/x/vweb/vweb_app_test.v
@@ -1,0 +1,108 @@
+module main
+
+import vweb
+import time
+import db.sqlite
+
+struct App {
+	vweb.Context
+pub mut:
+	db      sqlite.DB
+	user_id string
+}
+
+struct Article {
+	id    int
+	title string
+	text  string
+}
+
+fn test_a_vweb_application_compiles() {
+	spawn fn () {
+		time.sleep(2 * time.second)
+		exit(0)
+	}()
+	vweb.run(&App{}, 18081)
+}
+
+pub fn (mut app App) before_request() {
+	app.user_id = app.get_cookie('id') or { '0' }
+}
+
+['/new_article'; post]
+pub fn (mut app App) new_article() vweb.Result {
+	title := app.form['title']
+	text := app.form['text']
+	if title == '' || text == '' {
+		return app.text('Empty text/title')
+	}
+	article := Article{
+		title: title
+		text: text
+	}
+	println('posting article')
+	println(article)
+	sql app.db {
+		insert article into Article
+	} or {}
+
+	return app.redirect('/')
+}
+
+fn (mut app App) time() {
+	app.text(time.now().format())
+}
+
+fn (mut app App) time_json() {
+	app.json({
+		'time': time.now().format()
+	})
+}
+
+fn (mut app App) time_json_pretty() {
+	app.json_pretty({
+		'time': time.now().format()
+	})
+}
+
+struct ApiSuccessResponse[T] {
+	success bool
+	result  T
+}
+
+fn (mut app App) json_success[T](result T) vweb.Result {
+	response := ApiSuccessResponse[T]{
+		success: true
+		result: result
+	}
+
+	return app.json(response)
+}
+
+// should compile, this is a helper method, not exposed as a route
+fn (mut app App) some_helper[T](result T) ApiSuccessResponse[T] {
+	response := ApiSuccessResponse[T]{
+		success: true
+		result: result
+	}
+	return response
+}
+
+// should compile, the route method itself is not generic
+fn (mut app App) ok() vweb.Result {
+	return app.json(app.some_helper(123))
+}
+
+struct ExampleStruct {
+	example int
+}
+
+fn (mut app App) request_raw_2() vweb.Result {
+	stuff := []ExampleStruct{}
+	return app.request_raw(stuff)
+}
+
+// should compile, this is a helper method, not exposed as a route
+fn (mut app App) request_raw(foo []ExampleStruct) vweb.Result {
+	return app.text('Hello world')
+}

--- a/vlib/x/vweb/vweb_livereload.v
+++ b/vlib/x/vweb/vweb_livereload.v
@@ -1,0 +1,48 @@
+module vweb
+
+import time
+
+// Note: to use live reloading while developing, the suggested workflow is doing:
+// `v -d vweb_livereload watch --keep run your_vweb_server_project.v`
+// in one shell, then open the start page of your vweb app in a browser.
+//
+// While developing, just open your files and edit them, then just save your
+// changes. Once you save, the watch command from above, will restart your server,
+// and your HTML pages will detect that shortly, then they will refresh themselves
+// automatically.
+
+// vweb_livereload_server_start records, when the vweb server process started.
+// That is later used by the /script.js and /current endpoints, which are active,
+// if you have compiled your vweb project with `-d vweb_livereload`, to detect
+// whether the web server has been restarted.
+const vweb_livereload_server_start = time.ticks().str()
+
+// handle_vweb_livereload_current serves a small text file, containing the
+// timestamp/ticks corresponding to when the vweb server process was started
+[if vweb_livereload ?]
+fn (mut ctx Context) handle_vweb_livereload_current() {
+	ctx.send_response_to_client('text/plain', vweb.vweb_livereload_server_start)
+}
+
+// handle_vweb_livereload_script serves a small dynamically generated .js file,
+// that contains code for polling the vweb server, and reloading the page, if it
+// detects that the vweb server is newer than the vweb server, that served the
+// .js file originally.
+[if vweb_livereload ?]
+fn (mut ctx Context) handle_vweb_livereload_script() {
+	res := '"use strict";
+function vweb_livereload_checker_fn(started_at) {
+    fetch("/vweb_livereload/" + started_at + "/current", { cache: "no-cache" })
+        .then(response=>response.text())
+        .then(function(current_at) {
+            // console.log(started_at); console.log(current_at);
+            if(started_at !== current_at){
+                // the app was restarted on the server:
+                window.location.reload();
+            }
+        });
+}
+const vweb_livereload_checker = setInterval(vweb_livereload_checker_fn, ${ctx.livereload_poll_interval_ms}, "${vweb.vweb_livereload_server_start}");
+'
+	ctx.send_response_to_client('text/javascript', res)
+}


### PR DESCRIPTION
Creates `x.vweb`
- Replace the internal workers from `vweb` with a single threaded event loop from `picoev`.

Edits `picoev`
- Implement "raw" mode for `picoev`.
- Raw mode will disallow `cb` and `err_cb` replacing it with `raw_cb` passing the raw file descriptor instead.