### PR TITLE
vcreate: fix init can set unallowed project name

### DIFF
--- a/cmd/tools/vcreate/tests/init_in_dir_with_invalid_mod_name.expect
+++ b/cmd/tools/vcreate/tests/init_in_dir_with_invalid_mod_name.expect
@@ -1,0 +1,16 @@
+#!/usr/bin/env expect
+
+set timeout 3
+
+# Pass v_root as arg, since we chdir into a temp directory during testing and create a project there.
+set v_root [lindex $argv 0]
+set project_dir_name [lindex $argv 1]
+set corrected_mod_name [lindex $argv 2]
+
+spawn $v_root/v init
+
+expect "The directory name `$project_dir_name` is invalid as module name. The module name in `v.mod` was set to `$corrected_mod_name`" {} timeout { exit 1 }
+expect "Change the description of your project in `v.mod`" {} timeout { exit 1 }
+expect "Complete!" {} timeout {} timeout { exit 1 }
+
+expect eof

--- a/cmd/tools/vcreate/tests/init_in_dir_with_invalid_mod_name.expect
+++ b/cmd/tools/vcreate/tests/init_in_dir_with_invalid_mod_name.expect
@@ -9,7 +9,7 @@ set corrected_mod_name [lindex $argv 2]
 
 spawn $v_root/v init
 
-expect "The directory name `$project_dir_name` is invalid as module name. The module name in `v.mod` was set to `$corrected_mod_name`" {} timeout { exit 1 }
+expect "The directory name `$project_dir_name` is invalid as a module name. The module name in `v.mod` was set to `$corrected_mod_name`" {} timeout { exit 1 }
 expect "Change the description of your project in `v.mod`" {} timeout { exit 1 }
 expect "Complete!" {} timeout {} timeout { exit 1 }
 

--- a/cmd/tools/vcreate/tests/new_with_model_arg.expect
+++ b/cmd/tools/vcreate/tests/new_with_model_arg.expect
@@ -13,6 +13,6 @@ expect "Input your project description: " { send "My Awesome V Project.\r" } tim
 expect "Input your project version: (0.0.0) " { send "0.0.1\r" } timeout { exit 1 }
 expect "Input your project license: (MIT) " { send "\r" } timeout { exit 1 }
 expect "Initialising ..." {} timeout { exit 1 }
-expect  "Complete!" {} timeout { exit 1 }
+expect "Complete!" {} timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vcreate/tests/new_with_name_arg.expect
+++ b/cmd/tools/vcreate/tests/new_with_name_arg.expect
@@ -12,6 +12,6 @@ expect "Input your project description: " { send "\r" } timeout { exit 1 }
 expect "Input your project version: (0.0.0) " { send "\r" } timeout { exit 1 }
 expect "Input your project license: (MIT) " { send "\r" } timeout { exit 1 }
 expect "Initialising ..." {} timeout { exit 1 }
-expect  "Complete!" {} timeout { exit 1 }
+expect "Complete!" {} timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vcreate/tests/new_with_no_arg.expect
+++ b/cmd/tools/vcreate/tests/new_with_no_arg.expect
@@ -13,6 +13,6 @@ expect "Input your project description: " { send "My Awesome V Project.\r" } tim
 expect "Input your project version: (0.0.0) " { send "0.1.0\r" } timeout { exit 1 }
 expect "Input your project license: (MIT) " { send "GPL\r" } timeout { exit 1 }
 expect "Initialising ..." {} timeout { exit 1 }
-expect  "Complete!" {} timeout { exit 1 }
+expect "Complete!" {} timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -129,7 +129,7 @@ fn new_project(args []string) {
 
 fn init_project() {
 	mut c := Create{}
-	c.name = check_name(os.file_name(os.getwd()))
+	c.name = check_name(os.file_name(os.getwd()).replace('-', '_'))
 	if !os.exists('v.mod') {
 		c.description = ''
 		c.write_vmod(false)

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -129,10 +129,15 @@ fn new_project(args []string) {
 
 fn init_project() {
 	mut c := Create{}
-	c.name = check_name(os.file_name(os.getwd()).replace('-', '_'))
+	dir_name := check_name(os.file_name(os.getwd()))
 	if !os.exists('v.mod') {
 		c.description = ''
+		mod_dir_has_hyphens := dir_name.contains('-')
+		c.name = if mod_dir_has_hyphens { dir_name.replace('-', '_') } else { dir_name }
 		c.write_vmod(false)
+		if mod_dir_has_hyphens {
+			println('The directory name `${dir_name}` is invalid as module name. The module name in `v.mod` was set to `${c.name}`')
+		}
 		println('Change the description of your project in `v.mod`')
 	}
 	if !os.exists('src/main.v') {

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -136,7 +136,7 @@ fn init_project() {
 		c.name = if mod_dir_has_hyphens { dir_name.replace('-', '_') } else { dir_name }
 		c.write_vmod(false)
 		if mod_dir_has_hyphens {
-			println('The directory name `${dir_name}` is invalid as module name. The module name in `v.mod` was set to `${c.name}`')
+			println('The directory name `${dir_name}` is invalid as a module name. The module name in `v.mod` was set to `${c.name}`')
 		}
 		println('Change the description of your project in `v.mod`')
 	}

--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -6,7 +6,7 @@ import v.vmod
 // avoid clashes with the postfix `_test.v`, that V uses for its own test files.
 const (
 	// Expect has to be installed for the test.
-	expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
+	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
 	})
@@ -31,8 +31,7 @@ fn prepare_test_path() ! {
 fn test_new_with_no_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_project'
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
-		'new_with_no_arg.expect')} ${@VMODROOT} ${project_name}')
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_no_arg.expect')} ${@VMODROOT} ${project_name}')
 	if res.exit_code != 0 {
 		assert false, res.output
 	}
@@ -53,8 +52,7 @@ fn test_new_with_no_arg_input() {
 fn test_new_with_name_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_other_project'
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
-		'new_with_name_arg.expect')} ${@VMODROOT} ${project_name}')
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_name_arg.expect')} ${@VMODROOT} ${project_name}')
 	if res.exit_code != 0 {
 		assert false, res.output
 	}
@@ -76,8 +74,7 @@ fn test_new_with_model_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_lib'
 	model := 'lib'
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
-		'new_with_model_arg.expect')} ${@VMODROOT} ${project_name} ${model}')
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_model_arg.expect')} ${@VMODROOT} ${project_name} ${model}')
 	if res.exit_code != 0 {
 		assert false, res.output
 	}
@@ -102,8 +99,7 @@ fn test_v_init_in_dir_with_invalid_mod_name() {
 	proj_path := os.join_path(os.vtmp_dir(), 'v', dir_name_with_invalid_mod_name)
 	os.mkdir_all(proj_path) or {}
 	os.chdir(proj_path)!
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
-		'init_in_dir_with_invalid_mod_name.expect')} ${@VMODROOT} ${dir_name_with_invalid_mod_name} ${corrected_mod_name}')
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'init_in_dir_with_invalid_mod_name.expect')} ${@VMODROOT} ${dir_name_with_invalid_mod_name} ${corrected_mod_name}')
 	if res.exit_code != 0 {
 		assert false, res.output
 	}

--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -6,10 +6,10 @@ import v.vmod
 // avoid clashes with the postfix `_test.v`, that V uses for its own test files.
 const (
 	// Expect has to be installed for the test.
-	expect_exe = os.find_abs_path_of_executable('expect') or {
+	expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
-	}
+	})
 	// Directory where the Expect scripts will create projects.
 	test_module_path  = os.join_path(os.vtmp_dir(), 'v', 'test_vcreate_input')
 	// Directory that contains the Expect scripts used in the test.
@@ -31,7 +31,7 @@ fn prepare_test_path() ! {
 fn test_new_with_no_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_project'
-	res := os.execute('${os.quoted_path(expect_exe)} ${os.join_path(expect_tests_path,
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
 		'new_with_no_arg.expect')} ${@VMODROOT} ${project_name}')
 	if res.exit_code != 0 {
 		assert false, res.output
@@ -53,7 +53,7 @@ fn test_new_with_no_arg_input() {
 fn test_new_with_name_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_other_project'
-	res := os.execute('${os.quoted_path(expect_exe)} ${os.join_path(expect_tests_path,
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
 		'new_with_name_arg.expect')} ${@VMODROOT} ${project_name}')
 	if res.exit_code != 0 {
 		assert false, res.output
@@ -76,7 +76,7 @@ fn test_new_with_model_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_lib'
 	model := 'lib'
-	res := os.execute('${os.quoted_path(expect_exe)} ${os.join_path(expect_tests_path,
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
 		'new_with_model_arg.expect')} ${@VMODROOT} ${project_name} ${model}')
 	if res.exit_code != 0 {
 		assert false, res.output
@@ -93,6 +93,30 @@ fn test_new_with_model_arg_input() {
 	assert mod.description == 'My Awesome V Project.'
 	assert mod.version == '0.0.1'
 	assert mod.license == 'MIT'
+}
+
+fn test_v_init_in_dir_with_invalid_mod_name() {
+	// A project with a directory name with hyphens, which is invalid for a module name.
+	dir_name_with_invalid_mod_name := 'my-proj'
+	corrected_mod_name := 'my_proj'
+	proj_path := os.join_path(os.vtmp_dir(), 'v', dir_name_with_invalid_mod_name)
+	os.mkdir_all(proj_path) or {}
+	os.chdir(proj_path)!
+	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path,
+		'init_in_dir_with_invalid_mod_name.expect')} ${@VMODROOT} ${dir_name_with_invalid_mod_name} ${corrected_mod_name}')
+	if res.exit_code != 0 {
+		assert false, res.output
+	}
+	// Assert mod data set in `new_with_model_arg.expect`.
+	mod := vmod.decode(os.read_file(os.join_path(proj_path, 'v.mod')) or {
+		assert false, 'Failed reading v.mod of ${proj_path}'
+		return
+	}) or {
+		assert false, err.str()
+		return
+	}
+	assert mod.name == corrected_mod_name
+	os.rmdir_all(proj_path) or {}
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -140,22 +140,6 @@ indent_style = tab
 	assert os.read_file('.editorconfig')! == editor_config_content
 }
 
-fn test_v_init_in_dir_with_invalid_name() {
-	// A project with a directory name with hyphens, which is invalid for a module name.
-	proj_path := os.join_path(os.vtmp_dir(), 'v', 'test-vcreate')
-	os.mkdir_all(proj_path) or {}
-	os.chdir(proj_path)!
-	os.execute_or_exit(os.quoted_path(@VEXE) + ' init')
-	mod := vmod.decode(os.read_file(os.join_path(proj_path, 'v.mod')) or {
-		assert false, 'Failed reading v.mod of ${proj_path}'
-		return
-	}) or {
-		assert false, err.str()
-		return
-	}
-	assert mod.name == 'test_vcreate'
-}
-
 fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -1,4 +1,5 @@
 import os
+import v.vmod
 
 // Note: the following uses `test_vcreate` and NOT `vcreate_test` deliberately,
 // to both avoid confusions with the name of the current test itself, and to
@@ -137,6 +138,22 @@ indent_style = tab
 
 	assert os.read_file('.gitattributes')! == git_attributes_content
 	assert os.read_file('.editorconfig')! == editor_config_content
+}
+
+fn test_v_init_in_dir_with_invalid_name() {
+	// A project with a directory name with hyphens, which is invalid for a module name.
+	proj_path := os.join_path(os.vtmp_dir(), 'v', 'test-vcreate')
+	os.mkdir_all(proj_path) or {}
+	os.chdir(proj_path)!
+	os.execute_or_exit(os.quoted_path(@VEXE) + ' init')
+	mod := vmod.decode(os.read_file(os.join_path(proj_path, 'v.mod')) or {
+		assert false, 'Failed reading v.mod of ${proj_path}'
+		return
+	}) or {
+		assert false, err.str()
+		return
+	}
+	assert mod.name == 'test_vcreate'
 }
 
 fn testsuite_end() {


### PR DESCRIPTION
Currently when running `v init` in a project dir like `my-proj`, the name in the `v.mod` file will be set to `my-proj`.

With `v new`, this is a prohibited name:
https://github.com/vlang/v/blob/48a1d6cc6c39e042000f37b4facff0515f0bea8c/cmd/tools/vcreate/vcreate.v#L74-L77

The change converts hyphens to underscores when using `v init` so we would get `my_proj` as name in the mod file.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 284e2f5</samp>

Replace hyphens with underscores in project name for `v create` command. This ensures that the project name is a valid V module name and avoids potential errors.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 284e2f5</samp>

* Replace hyphens with underscores in project name to ensure valid module name ([link](https://github.com/vlang/v/pull/19619/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL132-R132))
