### PR TITLE
pref: fix typo in pref.v

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -227,7 +227,7 @@ pub mut:
 	skip_unused       bool // skip generating C code for functions, that are not used
 	//
 	use_color           ColorOutput // whether the warnings/errors should use ANSI color escapes.
-	cleanup_files       []string    // list of temporary *.tmp.c and *.tmp.c.rsp files. Cleaned up on successfull builds.
+	cleanup_files       []string    // list of temporary *.tmp.c and *.tmp.c.rsp files. Cleaned up on successful builds.
 	build_options       []string    // list of options, that should be passed down to `build-module`, if needed for -usecache
 	cache_manager       vcache.CacheManager
 	gc_mode             GarbageCollectionMode = .unknown // .no_gc, .boehm, .boehm_leak, ...


### PR DESCRIPTION
successfull -> successful



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c36274d</samp>

Fix a typo in a comment in `vlib/v/pref/pref.v`. This improves the code documentation quality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c36274d</samp>

* Fix a typo in the comment for the `cleanup_files` field of the `Preferences` struct ([link](https://github.com/vlang/v/pull/19624/files?diff=unified&w=0#diff-e706d00d8dda53e89b46391f9de496dc45f5efc1fb9776c3d230fc708aba8aa3L230-R230))
