### PR TITLE
checker: minor cleanup of `fn_decl`

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -272,24 +272,24 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('duplicate of an import symbol `${param.name}`', param.pos)
 			}
 		}
-		// Check if function name is already registered as imported module symbol
-		if !node.is_method && c.check_import_sym_conflict(node.short_name) {
-			c.error('duplicate of an import symbol `${node.short_name}`', node.pos)
+		if !node.is_method {
+			// Check if function name is already registered as imported module symbol
+			if c.check_import_sym_conflict(node.short_name) {
+				c.error('duplicate of an import symbol `${node.short_name}`', node.pos)
+			}
+			if node.params.len == 0 && node.name.after_char(`.`) == 'init' {
+				if node.is_pub {
+					c.error('fn `init` must not be public', node.pos)
+				}
+				if node.return_type != ast.void_type {
+					c.error('fn `init` cannot have a return type', node.pos)
+				}
+			}
+			if !c.is_builtin_mod && node.mod == 'main'
+				&& node.name.after_char(`.`) in reserved_type_names {
+				c.error('top level declaration cannot shadow builtin type', node.pos)
+			}
 		}
-	}
-	if node.language == .v && node.name.after_char(`.`) == 'init' && !node.is_method
-		&& node.params.len == 0 {
-		if node.is_pub {
-			c.error('fn `init` must not be public', node.pos)
-		}
-		if node.return_type != ast.void_type {
-			c.error('fn `init` cannot have a return type', node.pos)
-		}
-	}
-
-	if node.language == .v && node.mod == 'main' && node.name.after_char(`.`) in reserved_type_names
-		&& !node.is_method && !c.is_builtin_mod {
-		c.error('top level declaration cannot shadow builtin type', node.pos)
 	}
 	if node.return_type != ast.Type(0) {
 		if !c.ensure_type_exists(node.return_type, node.return_type_pos) {


### PR DESCRIPTION
Merges some redunant checks, checks less taxing conditions first.

Not as relevant for comptime things. Still, tcc compiled it's 1500%+ for e.g.:
```v
b := false
a := 'abcde'
for _ in 0 .. 1_000_000 {
	if a == 'abcde' && b {
		// println('true')
	}
}
```
vs
```diff
- if a == 'abcde' && b {
+ if b && a == 'abcde' {
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2d5fa6</samp>

Refactor and simplify function checking code in `vlib/v/checker/fn.v`. Move some checks inside a more specific condition and remove unnecessary ones.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2d5fa6</samp>

*  Refactor function checking logic to reduce nesting and simplify conditions ([link](https://github.com/vlang/v/pull/19627/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL275-R293))
