### PR TITLE
vdoc: add hr style

### DIFF
--- a/.github/workflows/module_docs_lint.yml
+++ b/.github/workflows/module_docs_lint.yml
@@ -12,8 +12,8 @@ jobs:
   lint-module-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Formatting
-        uses: actionsx/prettier@v2
+        uses: creyD/prettier_action@v4.3
         with:
-          args: --check cmd/tools/vdoc/theme
+          prettier_options: --check cmd/tools/vdoc/theme

--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -85,8 +85,17 @@ html {
 }
 body {
 	margin: 0;
-	font-family: Jost, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
-		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	font-family:
+		Jost,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji',
+		'Segoe UI Symbol';
 	background-color: #fff;
 	background-color: var(--background-color);
 	color: #000;
@@ -344,8 +353,17 @@ hr {
 	font-weight: 500;
 }
 .doc-nav > .search .result > .link > .description {
-	font-family: Jost, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
-		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	font-family:
+		Jost,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji',
+		'Segoe UI Symbol';
 	font-size: 0.75rem;
 	overflow: hidden;
 	white-space: nowrap;

--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -93,6 +93,13 @@ body {
 	color: var(--text-color);
 	height: 100%;
 }
+hr {
+	height: 0.25rem;
+	background-color: var(--title-bottom-line-color);
+	border: 0;
+	padding: 0;
+	margin: 1.2rem 0;
+}
 #page {
 	height: 100%;
 	padding-top: 56px;

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -56,7 +56,7 @@ function setupScrollSpy() {
 			a.classList.add('active');
 			lastActive = a;
 			clickedScroll = true;
-		})
+		}),
 	);
 }
 

--- a/cmd/tools/vdoc/theme/index.html
+++ b/cmd/tools/vdoc/theme/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />

--- a/cmd/tools/vdoc/theme/normalize.css
+++ b/cmd/tools/vdoc/theme/normalize.css
@@ -13,12 +13,6 @@ h1 {
 	margin: 0.67em 0;
 }
 
-hr {
-	box-sizing: content-box;
-	height: 0;
-	overflow: visible;
-}
-
 pre {
 	font-family: monospace, monospace;
 	font-size: 1em;


### PR DESCRIPTION
Adds style for the `hr` tag, updates prettier as format linter to v3, formats to conform changes in prettier3.

current

![curr_dark](https://github.com/vlang/v/assets/34311583/a70a4e96-7b74-4e4f-a25f-0d2802bf2324)
![curr_light](https://github.com/vlang/v/assets/34311583/ce7c261d-fd64-4ba1-a53a-afad98dba19c)

suggested

![sug_dark](https://github.com/vlang/v/assets/34311583/b57c6d41-0ec7-4236-9356-9fa5ca668d0e)
![sug_light](https://github.com/vlang/v/assets/34311583/6a97553e-156c-4c94-ac5f-f8d8418838df)


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d10109</samp>

This pull request updates the vdoc theme files to follow the prettier style guide and improve the documentation appearance. It changes the `doc.css`, `doc.js`, `index.html`, and `normalize.css` files, and also updates the GitHub workflow for linting the theme files.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d10109</samp>

*  Update the workflow and syntax for checking the formatting of the vdoc theme files ([link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-110a76eaf435e0a21f891ef811cc0b9385cb32d5944fe96a580c179052baf50aL15-R19))
*  Reformat the font-family properties in the doc.css file to use one line per font name ([link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL88-R98), [link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cL340-R366))
*  Add a new style rule for the horizontal rule element in the doc.css file, using a custom CSS variable for the color ([link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-f749a7a4292b3edebb60063394b8d54a45ad85bf51d4862da0e10999834e990cR105-R111))
*  Add a trailing comma to the array of anchor elements in the doc.js file ([link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-3fb25060e841bc44786d7d6ed02a91a4c6c44f16784bb57b6af7e7934f57eb0eL59-R59))
*  Change the doctype declaration in the index.html file to lowercase ([link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-679db9dd884a96bcceba7a0182b1d52fde2e04ee8ca01bdc4a86b2a5c3a483edL1-R1))
*  Remove the redundant style rule for the horizontal rule element in the normalize.css file ([link](https://github.com/vlang/v/pull/19628/files?diff=unified&w=0#diff-a4b59925f917c7fa7303f77a8e8f0f915c011c9824588c8db72278026a69f11dL16-L21))
