### PR TITLE
checker: warn about byte deprecation when used as fn param

### DIFF
--- a/vlib/builtin/cfns_wrapper.c.v
+++ b/vlib/builtin/cfns_wrapper.c.v
@@ -3,7 +3,7 @@ module builtin
 // vstrlen returns the V length of the C string `s` (0 terminator is not counted).
 // The C string is expected to be a &byte pointer.
 [inline; unsafe]
-pub fn vstrlen(s &byte) int {
+pub fn vstrlen(s &u8) int {
 	return unsafe { C.strlen(&char(s)) }
 }
 

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -64,7 +64,7 @@ pub fn (x StrIntpType) str() string {
 pub union StrIntpMem {
 pub mut:
 	d_c   u32
-	d_u8  byte
+	d_u8  u8
 	d_i8  i8
 	d_u16 u16
 	d_i16 i16
@@ -114,7 +114,7 @@ fn abs64(x i64) u64 {
 //---------------------------------------
 
 // convert from data format to compact u64
-pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch byte, in_base int, in_upper_case bool) u64 {
+pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u64 {
 	width := if in_width != 0 { abs64(in_width) } else { u64(0) }
 	allign := if in_width > 0 { u64(1 << 5) } else { u64(0) } // two bit 0 .left 1 .rigth, for now we use only one
 	upper_case := if in_upper_case { u64(1 << 7) } else { u64(0) }
@@ -131,7 +131,7 @@ pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision 
 }
 
 // convert from data format to compact u32
-pub fn get_str_intp_u32_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch byte, in_base int, in_upper_case bool) u32 {
+pub fn get_str_intp_u32_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u32 {
 	width := if in_width != 0 { abs64(in_width) } else { u32(0) }
 	allign := if in_width > 0 { u32(1 << 5) } else { u32(0) } // two bit 0 .left 1 .rigth, for now we use only one
 	upper_case := if in_upper_case { u32(1 << 7) } else { u32(0) }

--- a/vlib/crypto/internal/subtle/comparison.v
+++ b/vlib/crypto/internal/subtle/comparison.v
@@ -1,7 +1,7 @@
 module subtle
 
 // constant_time_byte_eq returns 1 when x == y.
-pub fn constant_time_byte_eq(x byte, y byte) int {
+pub fn constant_time_byte_eq(x u8, y u8) int {
 	return int((u32(x ^ y) - 1) >> 31)
 }
 

--- a/vlib/db/mysql/stmt.c.v
+++ b/vlib/db/mysql/stmt.c.v
@@ -188,7 +188,7 @@ pub fn (mut stmt Stmt) bind_bool(b &bool) {
 }
 
 // bind_byte binds a single byte value to the statement `stmt`
-pub fn (mut stmt Stmt) bind_byte(b &byte) {
+pub fn (mut stmt Stmt) bind_byte(b &u8) {
 	stmt.bind(mysql.mysql_type_tiny, b, 0)
 }
 

--- a/vlib/json/json_primitives.v
+++ b/vlib/json/json_primitives.v
@@ -194,8 +194,8 @@ fn encode_i64(val i64) &C.cJSON {
 
 // TODO: remove when `byte` is removed
 [markused]
-fn encode_byte(root byte) &C.cJSON {
-	return encode_u8(u8(root))
+fn encode_byte(root u8) &C.cJSON {
+	return encode_u8(root)
 }
 
 [markused]

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -70,7 +70,7 @@ pub fn (mut b Builder) write_u8(data u8) {
 }
 
 // write_byte appends a single `data` byte to the accumulated buffer
-pub fn (mut b Builder) write_byte(data byte) {
+pub fn (mut b Builder) write_byte(data u8) {
 	b << data
 }
 

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -18,7 +18,7 @@ pub fn new_builder(initial_size int) Builder {
 	return []u8{cap: initial_size}
 }
 
-pub fn (mut b Builder) write_byte(data byte) {
+pub fn (mut b Builder) write_byte(data u8) {
 	b << data
 }
 

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -271,6 +271,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			if c.check_import_sym_conflict(param.name) {
 				c.error('duplicate of an import symbol `${param.name}`', param.pos)
 			}
+			if arg_typ_sym.kind == .alias && arg_typ_sym.name == 'byte' {
+				c.warn('byte is deprecated, use u8 instead', param.type_pos)
+			}
 		}
 		if !node.is_method {
 			// Check if function name is already registered as imported module symbol

--- a/vlib/v/checker/tests/top_level_fn_builtin_decl_err.out
+++ b/vlib/v/checker/tests/top_level_fn_builtin_decl_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:3:12: warning: byte is deprecated, use u8 instead
+    1 | 
+    2 | [inline]
+    3 | fn char(ch byte) fn (string) !(byte, string) {
+      |            ~~~~
+    4 |     return fn [ch] (input string) !(byte, string) {
+    5 |         return if input[0] == ch {
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:3:1: error: top level declaration cannot shadow builtin type
     1 | 
     2 | [inline]


### PR DESCRIPTION
Currently the below won't inform about the byte deprecation
```v
fn do_byte_things(should_warn byte) {}
```
With the changes it will warn, as the next one does:
```v
b := byte(`b`)
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 841f403</samp>

Changed the type of several variables and parameters related to string manipulation from `byte` to `u8` in various modules. Added a warning to the checker module to inform the user that `byte` is deprecated and `u8` should be used instead. These changes are part of a larger effort to remove the `byte` alias and use `u8` consistently throughout the codebase.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 841f403</samp>

*  Replace the deprecated type alias `byte` with `u8` in several places to avoid confusion and improve consistency ([link](https://github.com/vlang/v/pull/19629/files?diff=unified&w=0#diff-72dfce88d13610339c2b4e5ab76096dddd27a09aca512d7dc900a83b8966c859L6-R6), [link](https://github.com/vlang/v/pull/19629/files?diff=unified&w=0#diff-d8e38509fb88f6dae47cd50bd7688c03755409ff826373e03eda59194364aa04L67-R67), [link](https://github.com/vlang/v/pull/19629/files?diff=unified&w=0#diff-d8e38509fb88f6dae47cd50bd7688c03755409ff826373e03eda59194364aa04L117-R117), [link](https://github.com/vlang/v/pull/19629/files?diff=unified&w=0#diff-d8e38509fb88f6dae47cd50bd7688c03755409ff826373e03eda59194364aa04L134-R134), [link](https://github.com/vlang/v/pull/19629/files?diff=unified&w=0#diff-ed970d96e6989f77b2c8664fdb155d4567979b1bc4f8e2271d2938b47615f479L73-R73))
*  Add a warning to the checker module when a function parameter has the type `byte`, advising the user to use `u8` instead ([link](https://github.com/vlang/v/pull/19629/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR274-R276))
