### PR TITLE
orm: fix for NULL binding in Postfix

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -65,8 +65,8 @@ pub enum OperationKind {
 	ge // >=
 	le // <=
 	orm_like // LIKE
-	@is // is
-	is_not // !is
+	is_null // IS NULL
+	is_not_null // IS NOT NULL
 }
 
 pub enum MathOperationKind {
@@ -101,10 +101,14 @@ fn (kind OperationKind) to_str() string {
 		.ge { '>=' }
 		.le { '<=' }
 		.orm_like { 'LIKE' }
-		.@is { 'IS' }
-		.is_not { 'IS NOT' }
+		.is_null { 'IS NULL' }
+		.is_not_null { 'IS NOT NULL' }
 	}
 	return str
+}
+
+fn (kind OperationKind) is_unary() bool {
+	return kind in [.is_null, .is_not_null]
 }
 
 fn (kind OrderType) to_str() string {
@@ -396,10 +400,13 @@ fn gen_where_clause(where QueryData, q string, qm string, num bool, mut c &int) 
 		if pre_par {
 			str += '('
 		}
-		str += '${q}${field}${q} ${where.kinds[i].to_str()} ${qm}'
-		if num {
-			str += '${c}'
-			c++
+		str += '${q}${field}${q} ${where.kinds[i].to_str()}'
+		if !where.kinds[i].is_unary() {
+			str += ' ${qm}'
+			if num {
+				str += '${c}'
+				c++
+			}
 		}
 		if post_par {
 			str += ')'

--- a/vlib/orm/orm_null_test.v
+++ b/vlib/orm/orm_null_test.v
@@ -123,11 +123,10 @@ fn test_option_struct_fields_and_none() {
 	_ := sql db {
 		select from Foo where e > 5 && c is none && c !is none && h == 2
 	}!
-	assert db.st.last == 'SELECT `id`, `a`, `c`, `d`, `e`, `g`, `h` FROM `foo` WHERE `e` > ? AND `c` IS ? AND `c` IS NOT ? AND `h` = ?;'
+	assert db.st.last == 'SELECT `id`, `a`, `c`, `d`, `e`, `g`, `h` FROM `foo` WHERE `e` > ? AND `c` IS NULL AND `c` IS NOT NULL AND `h` = ?;'
 	assert db.st.data.len == 0
-	assert db.st.where.len == 4
-	assert db.st.where == [orm.Primitive(int(5)), orm.Null{},
-		orm.Null{}, orm.Primitive(int(2))]
+	assert db.st.where.len == 2
+	assert db.st.where == [orm.Primitive(int(5)), orm.Primitive(int(2))]
 
 	foo := Foo{}
 	sql db {

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -699,10 +699,10 @@ fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut pare
 					'orm__OperationKind__orm_like'
 				}
 				.key_is {
-					'orm__OperationKind__is'
+					'orm__OperationKind__is_null'
 				}
 				.not_is {
-					'orm__OperationKind__is_not'
+					'orm__OperationKind__is_not_null'
 				}
 				else {
 					''
@@ -720,9 +720,11 @@ fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut pare
 			if expr.left !is ast.InfixExpr && expr.right !is ast.InfixExpr && kind != '' {
 				kinds << kind
 			}
-			g.sql_side = .right
-			g.write_orm_where_expr(expr.right, mut fields, mut parentheses, mut kinds, mut
-				data, mut is_and)
+			if expr.op !in [.key_is, .not_is] { // ignore rhs for unary ops
+				g.sql_side = .right
+				g.write_orm_where_expr(expr.right, mut fields, mut parentheses, mut kinds, mut
+					data, mut is_and)
+			}
 		}
 		ast.ParExpr {
 			mut par := [fields.len]


### PR DESCRIPTION
On Postgres, you can not bind NULL in a where clause. E.g.
```SQL
SELECT * FROM `foo` WHERE `bar` IS $1
```
Postgres complains that "IS $1" is invalid because it treats "IS NULL" and "IS NOT NULL" as unary operations.

This PR:
* changes the ORM ops `is`/`not_is` to `is_null`/`is_not_null`
* does not bind a value in where clauses for unary ops (i.e., `is_null` and `is_not_null`)
* ignores the right-hand side of the AST when generating where clause data

This makes `is_null` and `is_not_null` unary ops in V's ORM as well, which should be more efficient anyway.

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c729a58</samp>

This pull request enhances the ORM module in V by adding null checks for query conditions. It modifies the `orm.v` and `c/orm.v` files to support the `is_null` and `is_not_null` operations and their SQL and C code generation. It also updates the `orm_null_test.v` file to test the new functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c729a58</samp>

*  Add support for unary SQL operations `IS NULL` and `IS NOT NULL` in ORM queries ([link](https://github.com/vlang/v/pull/19635/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837L68-R69), [link](https://github.com/vlang/v/pull/19635/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837L104-R113), [link](https://github.com/vlang/v/pull/19635/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L702-R705))
*  Modify `Builder` struct to generate valid SQL syntax and values for unary operations in `where_str` method ([link](https://github.com/vlang/v/pull/19635/files?diff=unified&w=0#diff-22d3495bac6fa5bffad6f985dd99c7fba9c9c0ce82f54ae3a350e1ba13065837L399-R409))
*  Update C code generation for unary operations in ORM where expressions in `vlib/v/gen/c/orm.v` ([link](https://github.com/vlang/v/pull/19635/files?diff=unified&w=0#diff-d61f37de415d677c8926b4b1e082a5399b02ef168498c8f0883e0113e6a92b48L723-R727))
*  Update test case in `vlib/orm/orm_null_test.v` to use new syntax and behavior of unary operations ([link](https://github.com/vlang/v/pull/19635/files?diff=unified&w=0#diff-73783208972135ca646b81178a00e9ebcd76c18da831d806d58cdbff8c430baaL126-R129))
