### PR TITLE
checker, cgen: fix for c stmt with option or result calls (fix #19630)

### DIFF
--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -19,15 +19,6 @@ fn (mut c Checker) for_c_stmt(mut node ast.ForCStmt) {
 			if assign.op == .decl_assign {
 				c.error('for loop post statement cannot be a variable declaration', assign.pos)
 			}
-
-			for right in assign.right {
-				if right is ast.CallExpr {
-					if right.or_block.stmts.len > 0 {
-						c.error('options are not allowed in `for statement increment` (yet)',
-							right.pos)
-					}
-				}
-			}
 		}
 		c.stmt(mut node.inc)
 	}

--- a/vlib/v/checker/tests/for_c_stmt_with_option_call.out
+++ b/vlib/v/checker/tests/for_c_stmt_with_option_call.out
@@ -1,7 +1,0 @@
-vlib/v/checker/tests/for_c_stmt_with_option_call.vv:15:31: error: options are not allowed in `for statement increment` (yet)
-   13 |     for t := 0; t < tests; t++ {
-   14 |         mut v := []bool{len: nmax, init: false}
-   15 |         for x := 0; !v[x]; x = rand.intn(n) or { 0 } {
-      |                                     ~~~~~~~
-   16 |             v[x] = true
-   17 |             sum++

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -56,6 +56,8 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		if node.label.len > 0 {
 			g.writeln('${node.label}:')
 		}
+		g.set_current_pos_as_last_stmt_pos()
+		g.skip_stmt_pos = true
 		g.write('for (')
 		if !node.has_init {
 			g.write('; ')
@@ -93,6 +95,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 			}
 		}
 		g.writeln(') {')
+		g.skip_stmt_pos = false
 		g.is_vlines_enabled = true
 		g.inside_for_c_stmt = false
 		g.stmts(node.stmts)

--- a/vlib/v/tests/for_c_stmt_with_option_call_test.v
+++ b/vlib/v/tests/for_c_stmt_with_option_call_test.v
@@ -20,7 +20,7 @@ fn avg(n int) f64 {
 	return f64(sum) / tests
 }
 
-fn main() {
+fn test_for_c_stmt_with_option_call() {
 	println(' N   average   analytical   (error)')
 	println('=== ========= ============ =========')
 	for n in 1 .. nmax + 1 {
@@ -28,4 +28,5 @@ fn main() {
 		b := ana(n)
 		println('${n:3} ${a:9.4f} ${b:12.4f} (${(abs(a - b) / b * 100):6.2f}%)')
 	}
+	assert true
 }

--- a/vlib/v/tests/for_c_stmt_with_result_call_test.v
+++ b/vlib/v/tests/for_c_stmt_with_result_call_test.v
@@ -1,0 +1,19 @@
+module main
+
+fn foo() !int {
+	return 5
+}
+
+fn test_for_c_stmt_with_result_call() {
+	mut pos := 0
+
+	for ; pos > 10; pos = foo()! {
+		println(pos)
+	}
+
+	for pos = foo()!; pos > 10; {
+		println(pos)
+	}
+
+	assert true
+}


### PR DESCRIPTION
This PR fix for c stmt with option or result calls (fix #19630).

- Fix for c stmt with option or result calls.
- Add test.

```v
module main

fn foo() !int {
	return 5
}

fn main() {
	mut pos := 0

	for ; pos > 10; pos = foo()! {
		println(pos)
	}

	for pos = foo()!; pos > 10; {
		println(pos)
	}

	assert true
}

PS D:\Test\v\tt1> v run .  
```
```v
import rand
import math { abs }

const nmax = 20

fn ana(n int) f64 {
	return 1.0 // haven't started
}

fn avg(n int) f64 {
	tests := 1e4
	mut sum := 0
	for t := 0; t < tests; t++ {
		mut v := []bool{len: nmax, init: false}
		for x := 0; !v[x]; x = rand.intn(n) or { 0 } {
			v[x] = true
			sum++
		}
	}
	return f64(sum) / tests
}

fn main() {
	println(' N   average   analytical   (error)')
	println('=== ========= ============ =========')
	for n in 1 .. nmax + 1 {
		a := avg(n)
		b := ana(n)
		println('${n:3} ${a:9.4f} ${b:12.4f} (${(abs(a - b) / b * 100):6.2f}%)')
	}
	assert true
}

PS D:\Test\v\tt1> v run .
 N   average   analytical   (error)
=== ========= ============ =========
  1    1.0000       1.0000 (  0.00%)
  2    1.5047       1.0000 ( 50.47%)
  3    1.6645       1.0000 ( 66.45%)
  4    1.7550       1.0000 ( 75.50%)
  5    1.7972       1.0000 ( 79.72%)
  6    1.8323       1.0000 ( 83.23%)
  7    1.8565       1.0000 ( 85.65%)
  8    1.8808       1.0000 ( 88.08%)
  9    1.8890       1.0000 ( 88.90%)
 10    1.8931       1.0000 ( 89.31%)
 11    1.9026       1.0000 ( 90.26%)
 12    1.9171       1.0000 ( 91.71%)
 13    1.9179       1.0000 ( 91.79%)
 14    1.9242       1.0000 ( 92.42%)
 15    1.9329       1.0000 ( 93.29%)
 16    1.9389       1.0000 ( 93.89%)
 17    1.9399       1.0000 ( 93.99%)
 18    1.9449       1.0000 ( 94.49%)
 19    1.9498       1.0000 ( 94.98%)
 20    1.9534       1.0000 ( 95.34%)
```