### PR TITLE
net: ignore the SIGNPIPE signal at the socket level on macos

### DIFF
--- a/vlib/net/net_nix.c.v
+++ b/vlib/net/net_nix.c.v
@@ -7,6 +7,7 @@ module net
 #include <netdb.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <netinet/tcp.h>
 
 #flag solaris -lsocket
 

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -401,19 +401,7 @@ fn new_tcp_socket(family AddrFamily) !TcpSocket {
 	// we shouldn't be using ioctlsocket in the 21st century
 	// use the non-blocking socket option instead please :)
 
-	// TODO(emily):
-	// Move this to its own function on the socket
-	s.set_option_int(.reuse_addr, 1)!
-
-	// At the socket level to ignore the exception signal (usually SIGNPIPE).
-	// In Linux, instead of using set_option(), specify the C.MSG_NOSIGNAL flag in c.send().
-	// In Windows, there is no need to process this signal.
-	$if macos {
-		s.set_option(C.SOL_SOCKET, C.SO_NOSIGPIPE, 1)!
-	}
-
-	// Enable the NODELAY option by default.
-	s.set_option(C.IPPROTO_TCP, C.TCP_NODELAY, 1)!
+	s.set_default_options()!
 
 	$if !net_blocking_sockets ? {
 		$if windows {
@@ -433,21 +421,11 @@ fn tcp_socket_from_handle(sockfd int) !TcpSocket {
 	$if trace_tcp ? {
 		eprintln('    tcp_socket_from_handle | s.handle: ${s.handle:6}')
 	}
-	// s.set_option_bool(.reuse_addr, true)?
-	s.set_option_int(.reuse_addr, 1)!
+
 	s.set_dualstack(true) or {
 		// Not ipv6, we dont care
 	}
-
-	// At the socket level to ignore the exception signal (usually SIGNPIPE).
-	// In Linux, instead of using set_option(), specify the C.MSG_NOSIGNAL flag in c.send().
-	// In Windows, there is no need to process this signal.
-	$if macos {
-		s.set_option(C.SOL_SOCKET, C.SO_NOSIGPIPE, 1)!
-	}
-
-	// Enable the NODELAY option by default.
-	s.set_option(C.IPPROTO_TCP, C.TCP_NODELAY, 1)!
+	s.set_default_options()!
 
 	$if !net_blocking_sockets ? {
 		$if windows {
@@ -494,6 +472,20 @@ pub fn (mut s TcpSocket) set_option_int(opt SocketOption, value int) ! {
 pub fn (mut s TcpSocket) set_dualstack(on bool) ! {
 	x := int(!on)
 	s.set_option(C.IPPROTO_IPV6, int(SocketOption.ipv6_only), &x)!
+}
+
+fn (mut s TcpSocket) set_default_options() ! {
+	s.set_option_int(.reuse_addr, 1)!
+
+	// At the socket level to ignore the exception signal (usually SIGNPIPE).
+	// In Linux, instead of using set_option(), specify the C.MSG_NOSIGNAL flag in c.send().
+	// In Windows, there is no need to process this signal.
+	$if macos {
+		s.set_option(C.SOL_SOCKET, C.SO_NOSIGPIPE, 1)!
+	}
+
+	// Enable the NODELAY option by default.
+	s.set_option(C.IPPROTO_TCP, C.TCP_NODELAY, 1)!
 }
 
 // bind a local rddress for TcpSocket


### PR DESCRIPTION
This PR:
1. At the socket level to ignore the exception signal (SIGNPIPE).
2. Enable the NODELAY option by default.

Related to http.get()