### PR TITLE
builtin: fix doc comments of string split methods

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -795,7 +795,7 @@ pub fn (s string) rsplit_any(delim string) []string {
 	return res
 }
 
-// split splits a string into an array of strings at the given delimiter.
+// split splits the string into an array of strings at the given delimiter.
 // Example: assert 'A B C'.split(' ') == ['A','B','C']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.split('') == ['D','E','F']
@@ -804,7 +804,7 @@ pub fn (s string) split(delim string) []string {
 	return s.split_nth(delim, 0)
 }
 
-// rsplit splits a string into an array of strings at the given delimiter, starting from the right.
+// rsplit splits the string into an array of strings at the given delimiter, starting from the right.
 // Example: assert 'A B C'.rsplit(' ') == ['C','B','A']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.rsplit('') == ['F','E','D']
@@ -813,7 +813,7 @@ pub fn (s string) rsplit(delim string) []string {
 	return s.rsplit_nth(delim, 0)
 }
 
-// split_once splits a string into a pair of strings at the given delimiter.
+// split_once splits the string into a pair of strings at the given delimiter.
 // Example:
 // ```v
 // path, ext := 'file.ts.dts'.split_once('.')?
@@ -829,7 +829,7 @@ pub fn (s string) split_once(delim string) ?(string, string) {
 	return result[0], result[1]
 }
 
-// rsplit_once splits a string into a pair of strings at the given delimiter, starting from the right.
+// rsplit_once splits the string into a pair of strings at the given delimiter, starting from the right.
 // Example:
 // ```v
 // path, ext := 'file.ts.dts'.rsplit_once('.')?

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -836,7 +836,7 @@ pub fn (s string) split_once(delim string) ?(string, string) {
 // assert path == 'file.ts'
 // assert ext == 'dts'
 // ```
-// Note that rsplit_once returns remaining string as first part of pair.
+// NOTE: rsplit_once returns the string at the left side of the delimiter as first part of the pair.
 pub fn (s string) rsplit_once(delim string) ?(string, string) {
 	result := s.rsplit_nth(delim, 2)
 

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -795,7 +795,7 @@ pub fn (s string) rsplit_any(delim string) []string {
 	return res
 }
 
-// split splits the string to an array by `delim`.
+// split splits a string into an array of strings at the given delimiter.
 // Example: assert 'A B C'.split(' ') == ['A','B','C']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.split('') == ['D','E','F']
@@ -804,7 +804,7 @@ pub fn (s string) split(delim string) []string {
 	return s.split_nth(delim, 0)
 }
 
-// rsplit splits the string to an array by `delim` in reverse order.
+// rsplit splits a string into an array of strings at the given delimiter starting from the right.
 // Example: assert 'A B C'.rsplit(' ') == ['C','B','A']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.rsplit('') == ['F','E','D']
@@ -813,15 +813,12 @@ pub fn (s string) rsplit(delim string) []string {
 	return s.rsplit_nth(delim, 0)
 }
 
-// split_once divides string into pair of string by `delim`.
+// split_once splits a string into a pair of strings at the given delimiter.
 // Example:
 // ```v
-// path, ext := 'file.ts.dts'.splice_once('.')?
+// path, ext := 'file.ts.dts'.split_once('.')?
 // assert path == 'file'
 // assert ext == 'ts.dts'
-// ```
-// Note that rsplit_once returns splitted string string as first part of pair,
-// and returns remaining as second part of pair.
 pub fn (s string) split_once(delim string) ?(string, string) {
 	result := s.split_nth(delim, 2)
 
@@ -832,15 +829,14 @@ pub fn (s string) split_once(delim string) ?(string, string) {
 	return result[0], result[1]
 }
 
-// rsplit_once divides string into pair of string by `delim`.
+// rsplit_once splits a string into a pair of strings at the given delimiter starting from the right.
 // Example:
 // ```v
-// path, ext := 'file.ts.dts'.splice_once('.')?
+// path, ext := 'file.ts.dts'.rsplit_once('.')?
 // assert path == 'file.ts'
 // assert ext == 'dts'
 // ```
-// Note that rsplit_once returns remaining string as first part of pair,
-// and returns splitted string as second part of pair.
+// Note that rsplit_once returns remaining string as first part of pair.
 pub fn (s string) rsplit_once(delim string) ?(string, string) {
 	result := s.rsplit_nth(delim, 2)
 

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -804,7 +804,7 @@ pub fn (s string) split(delim string) []string {
 	return s.split_nth(delim, 0)
 }
 
-// rsplit splits a string into an array of strings at the given delimiter starting from the right.
+// rsplit splits a string into an array of strings at the given delimiter, starting from the right.
 // Example: assert 'A B C'.rsplit(' ') == ['C','B','A']
 // If `delim` is empty the string is split by it's characters.
 // Example: assert 'DEF'.rsplit('') == ['F','E','D']
@@ -829,7 +829,7 @@ pub fn (s string) split_once(delim string) ?(string, string) {
 	return result[0], result[1]
 }
 
-// rsplit_once splits a string into a pair of strings at the given delimiter starting from the right.
+// rsplit_once splits a string into a pair of strings at the given delimiter, starting from the right.
 // Example:
 // ```v
 // path, ext := 'file.ts.dts'.rsplit_once('.')?


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eda2c22</samp>

Improve and fix the documentation of four string splitting functions in `vlib/builtin/string.v`. Make the documentation more accurate, clear, and consistent.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eda2c22</samp>

* Improve the documentation of the `split` and `rsplit` functions by using more precise and consistent terms and clarifying the direction of splitting ([link](https://github.com/vlang/v/pull/19643/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L798-R798), [link](https://github.com/vlang/v/pull/19643/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L807-R807))
* Fix typos in the documentation and example code of the `split_once` and `rsplit_once` functions in `vlib/builtin/string.v` ([link](https://github.com/vlang/v/pull/19643/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L816-R821), [link](https://github.com/vlang/v/pull/19643/files?diff=unified&w=0#diff-6b49d6b4f39ff58ebe55368feb180324b8e82e51a16006f9ac6952c0b899a335L835-R839))
