### PR TITLE
builtin!: fix confusion with string `rsplit_once()`

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -835,12 +835,10 @@ pub fn (s string) split_once(delim string) ?(string, string) {
 // rsplit_once divides string into pair of string by `delim`.
 // Example:
 // ```v
-// path, ext := 'file.ts.dts'.splice_once('.')?
-// assert path == 'file.ts'
+// ext, path := 'file.ts.dts'.rsplit_once('.')?
 // assert ext == 'dts'
+// assert path == 'file.ts'
 // ```
-// Note that rsplit_once returns remaining string as first part of pair,
-// and returns splitted string as second part of pair.
 pub fn (s string) rsplit_once(delim string) ?(string, string) {
 	result := s.rsplit_nth(delim, 2)
 
@@ -848,7 +846,7 @@ pub fn (s string) rsplit_once(delim string) ?(string, string) {
 		return none
 	}
 
-	return result[1], result[0]
+	return result[0], result[1]
 }
 
 // split_nth splits the string based on the passed `delim` substring.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -414,15 +414,15 @@ fn test_split_once() ? {
 }
 
 fn test_rsplit_once() ? {
-	path1, ext1 := 'home/dir/lang.zip'.rsplit_once('.')?
-	assert path1 == 'home/dir/lang'
+	ext1, path1 := 'home/dir/lang.zip'.rsplit_once('.')?
 	assert ext1 == 'zip'
-	path2, ext2 := 'home/dir/lang.ts.dts'.rsplit_once('.')?
-	assert path2 == 'home/dir/lang.ts'
+	assert path1 == 'home/dir/lang'
+	ext2, path2 := 'home/dir/lang.ts.dts'.rsplit_once('.')?
 	assert ext2 == 'dts'
-	path3, ext3 := 'home/dir'.rsplit_once('.') or { '', '' }
-	assert path3 == ''
+	assert path2 == 'home/dir/lang.ts'
+	ext3, path3 := 'home/dir'.rsplit_once('.') or { '', '' }
 	assert ext3 == ''
+	assert path3 == ''
 }
 
 fn test_trim_space() {


### PR DESCRIPTION
The PR wants to remove confusion of the `rsplit_once` method. The current one breaks with the behaviour of the regular rsplit method and imho with intuitive thinking. 

Doc comment would be fixed in #19643 to
```diff
- // rsplit_once divides string into pair of string by `delim`.
+ // rsplit_once splits a string into a pair of strings at the given delimiter starting from the right.
```
 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

copilot:summary

copilot:walkthrough
