### PR TITLE
checker: turn warning for var and param module name duplicates into error

### DIFF
--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -46,18 +46,18 @@ pub fn new_log_as_logger() &Logger {
 
 fn test_log_mutable() {
 	println(@FN + ' start')
-	mut log := Log{}
-	log.set_level(.info)
-	log_mutable_statements(mut log)
+	mut l := Log{}
+	l.set_level(.info)
+	log_mutable_statements(mut l)
 	assert true
 	println(@FN + ' end')
 }
 
 fn test_log_mutable_reference() {
 	println(@FN + ' start')
-	mut log := new_log()
-	assert typeof(log).name == '&log.Log'
-	t := spawn log_mutable_statements(mut log)
+	mut l := new_log()
+	assert typeof(l).name == '&log.Log'
+	t := spawn log_mutable_statements(mut l)
 	t.wait()
 	assert true
 	println(@FN + ' end')

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -375,8 +375,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							}
 						}
 						if left.name == left.mod && left.name != 'main' {
-							c.add_error_detail('Module name duplicates will become errors after 2023/10/31.')
-							c.note('duplicate of a module name `${left.name}`', left.pos)
+							c.error('duplicate of a module name `${left.name}`', left.pos)
 						}
 						// Check if variable name is already registered as imported module symbol
 						if c.check_import_sym_conflict(left.name) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1687,8 +1687,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 				...field.pos
 				len: util.no_cur_mod(field.name, c.mod).len
 			}
-			c.add_error_detail('Module name duplicates will become errors after 2023/10/31.')
-			c.note('duplicate of a module name `${field.name}`', name_pos)
+			c.error('duplicate of a module name `${field.name}`', name_pos)
 		}
 		c.const_names << field.name
 	}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -264,8 +264,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 			}
 			if param.name == node.mod && param.name != 'main' {
-				c.add_error_detail('Module name duplicates will become errors after 2023/10/31.')
-				c.note('duplicate of a module name `${param.name}`', param.pos)
+				c.error('duplicate of a module name `${param.name}`', param.pos)
 			}
 			// Check if parameter name is already registered as imported module symbol
 			if c.check_import_sym_conflict(param.name) {

--- a/vlib/v/checker/tests/mod_name_duplicate_const_err.out
+++ b/vlib/v/checker/tests/mod_name_duplicate_const_err.out
@@ -1,9 +1,8 @@
-vlib/v/checker/tests/mod_name_duplicate_const_err.vv:3:7: notice: duplicate of a module name `foo.foo`
+vlib/v/checker/tests/mod_name_duplicate_const_err.vv:3:7: error: duplicate of a module name `foo.foo`
     1 | module foo
     2 | 
     3 | const foo = 'bar'
       |       ~~~
-Details: Module name duplicates will become errors after 2023/10/31.
 vlib/v/checker/tests/mod_name_duplicate_const_err.vv:1:1: error: project must include a `main` module or be a shared library (compile with `v -shared`)
     1 | module foo
       | ^

--- a/vlib/v/checker/tests/mod_name_duplicate_param_err.out
+++ b/vlib/v/checker/tests/mod_name_duplicate_param_err.out
@@ -1,11 +1,10 @@
-vlib/v/checker/tests/mod_name_duplicate_param_err.vv:3:8: notice: duplicate of a module name `foo`
+vlib/v/checker/tests/mod_name_duplicate_param_err.vv:3:8: error: duplicate of a module name `foo`
     1 | module foo
     2 | 
     3 | fn bar(foo string) {
       |        ~~~
     4 |     println(foo)
     5 | }
-Details: Module name duplicates will become errors after 2023/10/31.
 vlib/v/checker/tests/mod_name_duplicate_param_err.vv:1:1: error: project must include a `main` module or be a shared library (compile with `v -shared`)
     1 | module foo
       | ^

--- a/vlib/v/checker/tests/mod_name_duplicate_var_err.out
+++ b/vlib/v/checker/tests/mod_name_duplicate_var_err.out
@@ -1,11 +1,10 @@
-vlib/v/checker/tests/mod_name_duplicate_var_err.vv:4:2: notice: duplicate of a module name `foo`
+vlib/v/checker/tests/mod_name_duplicate_var_err.vv:4:2: error: duplicate of a module name `foo`
     2 | 
     3 | fn bar() {
     4 |     foo := 'bar'
       |     ~~~
     5 |     println(foo)
     6 | }
-Details: Module name duplicates will become errors after 2023/10/31.
 vlib/v/checker/tests/mod_name_duplicate_var_err.vv:1:1: error: project must include a `main` module or be a shared library (compile with `v -shared`)
     1 | module foo
       | ^


### PR DESCRIPTION
> **Important**
> Wait with merge until deprecation date 2023/10/31 has passed.

