### PR TITLE
log: use param name than differs from module name

### DIFF
--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -1,30 +1,30 @@
 module log
 
-fn log_mutable_statements(mut log Log) {
+fn log_mutable_statements(mut l Log) {
 	println(@FN + ' start')
-	log.info('info')
-	log.warn('warn')
-	log.error('error')
-	log.debug('no output for debug')
-	log.set_level(.debug)
-	log.debug('debug now')
-	log.set_level(level_from_tag('INFO') or { Level.disabled })
-	log.info('info again')
-	log.set_level(level_from_tag('') or { Level.disabled })
-	log.error('no output anymore')
+	l.info('info')
+	l.warn('warn')
+	l.error('error')
+	l.debug('no output for debug')
+	l.set_level(.debug)
+	l.debug('debug now')
+	l.set_level(level_from_tag('INFO') or { Level.disabled })
+	l.info('info again')
+	l.set_level(level_from_tag('') or { Level.disabled })
+	l.error('no output anymore')
 	println(@FN + ' end')
 }
 
-fn logger_mutable_statements(mut log Logger) {
+fn logger_mutable_statements(mut l Logger) {
 	println(@FN + ' start')
 	// the given logger instance could have a level to filter some levels used here
-	log.info('info')
-	log.warn('warn')
-	log.error('error')
-	log.debug('no output for debug')
-	log.set_level(.debug) // change logging level, now part of the Logger interface
-	log.debug('output for debug now')
-	log.info('output for info now')
+	l.info('info')
+	l.warn('warn')
+	l.error('error')
+	l.debug('no output for debug')
+	l.set_level(.debug) // change logging level, now part of the Logger interface
+	l.debug('output for debug now')
+	l.info('output for info now')
 	println(@FN + ' end')
 }
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78ca662</samp>

Improved code style in `vlib/log/log_test.v` by renaming `log` parameters to `l`. This avoids shadowing the `log` module name and clarifies the code.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 78ca662</samp>

* Rename parameter `log` to `l` in functions `test_log` and `test_log_with_level` to avoid shadowing module name `log` ([link](https://github.com/vlang/v/pull/19646/files?diff=unified&w=0#diff-4ff05d5b170e6045f6d902c527dfc1e97480a30ebcb196e116a83b558104d777L3-R27))
