### PR TITLE
os: fix signal ignore platform differences

### DIFF
--- a/vlib/os/signal_linux.c.v
+++ b/vlib/os/signal_linux.c.v
@@ -16,6 +16,18 @@ pub fn is_main_thread() bool {
 	return g_main_thread_id == u64(C.pthread_self())
 }
 
-// Not supported yet
+[typedef]
+struct C.sigset_t {}
+
+fn C.sigaddset(set &C.sigset_t, signum int) int
+fn C.sigemptyset(set &C.sigset_t)
+fn C.sigprocmask(how int, set &C.sigset_t, oldset &C.sigset_t) int
+
 fn signal_ignore_internal(args ...Signal) {
+	mask1 := C.sigset_t{}
+	C.sigemptyset(&mask1)
+	for arg in args {
+		C.sigaddset(&mask1, int(arg))
+	}
+	C.sigprocmask(C.SIG_BLOCK, &mask1, unsafe { nil })
 }


### PR DESCRIPTION
Fixed "signal ignore" platform differences.  😄 

The definition of "sigset_t" varies greatly from platform to platform, so let's support to Linux and MacOS for now.

Linux:
```c
typedef struct {
    unsigned long int __val[(1024 / (8 * sizeof(unsigned long int)))];
} sigset_t;
```
MacOS:
```c
typedef unsigned int sigset_t;
```
BSD:
```c
typedef unsigned long sigset_t;
```
FreeBSD:
```c
typedef struct {
    unsigned long __bits[4];
} sigset_t;
```
OpenBSD:
```c
typedef __uint32_t sigset_t;
```
NetBSD:
```c
typedef unsigned long sigset_t;
```
Unix (AIX、HP-UX、Solaris...):
```c
typedef struct {
    int __bits[32];
} sigset_t;
```
...