### PR TITLE
checker: fix generic array append

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2057,7 +2057,8 @@ fn (mut c Checker) stmt(mut node ast.Stmt) {
 				if mut node.expr is ast.InfixExpr {
 					if node.expr.op == .left_shift {
 						left_sym := c.table.final_sym(node.expr.left_type)
-						if left_sym.kind != .array {
+						if left_sym.kind != .array
+							&& c.table.final_sym(c.unwrap_generic(node.expr.left_type)).kind != .array {
 							c.error('unused expression', node.pos)
 						}
 					}

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -514,7 +514,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			return c.check_like_operator(node)
 		}
 		.left_shift {
-			if left_final_sym.kind == .array {
+			if left_final_sym.kind == .array
+				|| c.table.sym(c.unwrap_generic(left_type)).kind == .array {
 				if !node.is_stmt {
 					c.error('array append cannot be used in an expression', node.pos)
 				}

--- a/vlib/v/tests/generics_array_append_test.v
+++ b/vlib/v/tests/generics_array_append_test.v
@@ -8,4 +8,17 @@ fn test_generic_array_append() {
 	g([1, 2, 3])
 	g([1.1, 2.2, 3.3])
 	g(['aa', 'bb', 'cc'])
+	gs[[]string]()!
+}
+
+fn gs[T]() !T {
+	mut typ := T{
+		cap: 10
+	}
+	if T.name == '[]string' {
+		typ << 'strings'
+	} else {
+		return error('only string arrays are supported')
+	}
+	return typ
 }


### PR DESCRIPTION
- Resolve #19608, fix generic array append when generic type is known and the value type is matched.
- Add test code.

`v/tests/generics_array_append_test.v`
```v
fn g[T](arr []T) {
	mut r := []T{}
	r << arr
	assert arr.len > 0
}

fn test_generic_array_append() {
	g([1, 2, 3])
	g([1.1, 2.2, 3.3])
	g(['aa', 'bb', 'cc'])
	gs[[]string]()!
}

fn gs[T]() !T {
	mut typ := T{
		cap: 10
	}
	if T.name == '[]string' {
		typ << 'strings'
	} else {
		return error('only string arrays are supported')
	}
	return typ
}
```