### PR TITLE
net.http: add a retry mechanism to http.fetch() when the socket inevitably errors

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -31,6 +31,7 @@ pub mut:
 	cert_key               string // the path to a key.pem file, containing private keys for the client certificate(s)
 	in_memory_verification bool   // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
+	max_retries            int  = 5 // maximum number of retries required when an underlying socket error occurs
 	// callbacks to allow custom reporting code to run, while the request is running
 	on_redirect RequestRedirectFn = unsafe { nil }
 	on_progress RequestProgressFn = unsafe { nil }
@@ -164,6 +165,7 @@ pub fn fetch(config FetchConfig) !Response {
 		cert_key: config.cert_key
 		in_memory_verification: config.in_memory_verification
 		allow_redirect: config.allow_redirect
+		max_retries: config.max_retries
 		on_progress: config.on_progress
 		on_redirect: config.on_redirect
 		on_finish: config.on_finish


### PR DESCRIPTION
1. Add a retry mechanism to http.fetch()
2. This PR is an ongoing follow-up on the stability of http.get()
3. After testing, it is much more stable now.  😄 
