### PR TITLE
checker: allow size of fixed array to be integral casts

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -272,6 +272,13 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 								fixed_size = comptime_value.i64() or { fixed_size }
 							}
 						}
+						if init_expr.obj.expr.expr is ast.InfixExpr {
+							if comptime_value := c.eval_comptime_const_expr(init_expr.obj.expr.expr,
+								0)
+							{
+								fixed_size = comptime_value.i64() or { fixed_size }
+							}
+						}
 					}
 					if comptime_value := c.eval_comptime_const_expr(init_expr.obj.expr,
 						0)

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -265,6 +265,13 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 						if !init_expr.obj.expr.typ.is_pure_int() {
 							c.error('only integer types are allowed', init_expr.pos)
 						}
+						if init_expr.obj.expr.expr is ast.IntegerLiteral {
+							if comptime_value := c.eval_comptime_const_expr(init_expr.obj.expr.expr,
+								0)
+							{
+								fixed_size = comptime_value.i64() or { fixed_size }
+							}
+						}
 					}
 					if comptime_value := c.eval_comptime_const_expr(init_expr.obj.expr,
 						0)

--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -1,8 +1,8 @@
 const (
-	size     = 5
-	u64_size = u64(5)
-	int_size = int(1)
-	infix_cast_size = int(100/50)
+	size            = 5
+	u64_size        = u64(5)
+	int_size        = int(1)
+	infix_cast_size = int(100 / 50)
 )
 
 struct Foo {

--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -2,6 +2,7 @@ const (
 	size     = 5
 	u64_size = u64(5)
 	int_size = int(1)
+	infix_cast_size = int(100/50)
 )
 
 struct Foo {
@@ -18,6 +19,10 @@ fn test_fixed_array_const_size() {
 	b := [int_size]int{}
 	assert b.len == 1
 	assert b == [0]!
+
+	c := [infix_cast_size]int{}
+	assert c.len == 2
+	assert c == [0, 0]!
 }
 
 fn test_fixed_array_const_u64_size() {

--- a/vlib/v/tests/fixed_array_const_size_test.v
+++ b/vlib/v/tests/fixed_array_const_size_test.v
@@ -1,6 +1,7 @@
 const (
 	size     = 5
 	u64_size = u64(5)
+	int_size = int(1)
 )
 
 struct Foo {
@@ -13,6 +14,10 @@ fn test_fixed_array_const_size() {
 	assert a == Foo{
 		bar: [u8(0), 0, 0, 0, 0]!
 	}
+
+	b := [int_size]int{}
+	assert b.len == 1
+	assert b == [0]!
 }
 
 fn test_fixed_array_const_u64_size() {


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

Closes https://github.com/vlang/v/issues/19661

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 080580b</samp>

Add support for constants as the size of fixed arrays. Add a test case and a checker rule for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 080580b</samp>

*  Add a check for integer literals as the size of fixed arrays in the checker ([link](https://github.com/vlang/v/pull/19663/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cR268-R274))
* Add a test case for using a constant as the size of fixed arrays ([link](https://github.com/vlang/v/pull/19663/files?diff=unified&w=0#diff-a8aac9d1005c238f0839227177e0930fa3f4d5fec51afe03f32eca8ebec0e448R4), [link](https://github.com/vlang/v/pull/19663/files?diff=unified&w=0#diff-a8aac9d1005c238f0839227177e0930fa3f4d5fec51afe03f32eca8ebec0e448R17-R20))
