### PR TITLE
vcreate: cleanup tests

### DIFF
--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -1,19 +1,17 @@
 import os
 import v.vmod
 
-// Note: the following uses `test_vcreate` and NOT `vcreate_input_test` deliberately,
-// to both avoid confusions with the name of the current test itself, and to
-// avoid clashes with the postfix `_test.v`, that V uses for its own test files.
 const (
 	// Expect has to be installed for the test.
 	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
 	})
-	// Directory where the Expect scripts will create projects.
-	test_module_path  = os.join_path(os.vtmp_dir(), 'v', 'test_vcreate_input')
 	// Directory that contains the Expect scripts used in the test.
 	expect_tests_path = os.join_path(@VMODROOT, 'cmd', 'tools', 'vcreate', 'tests')
+	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
+	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_vcreate_input/`.
+	test_module_path  = os.join_path(os.vtmp_dir(), 'test_vcreate_input')
 )
 
 fn testsuite_begin() {
@@ -36,10 +34,7 @@ fn test_new_with_no_arg_input() {
 		assert false, res.output
 	}
 	// Assert mod data set in `new_no_arg.expect`.
-	mod := vmod.decode(os.read_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
-		assert false, 'Failed reading v.mod of ${project_name}'
-		return
-	}) or {
+	mod := vmod.from_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
 		assert false, err.str()
 		return
 	}
@@ -57,10 +52,7 @@ fn test_new_with_name_arg_input() {
 		assert false, res.output
 	}
 	// Assert mod data set in `new_with_name_arg.expect`.
-	mod := vmod.decode(os.read_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
-		assert false, 'Failed reading v.mod of ${project_name}'
-		return
-	}) or {
+	mod := vmod.from_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
 		assert false, err.str()
 		return
 	}
@@ -79,10 +71,7 @@ fn test_new_with_model_arg_input() {
 		assert false, res.output
 	}
 	// Assert mod data set in `new_with_model_arg.expect`.
-	mod := vmod.decode(os.read_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
-		assert false, 'Failed reading v.mod of ${project_name}'
-		return
-	}) or {
+	mod := vmod.from_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
 		assert false, err.str()
 		return
 	}
@@ -96,7 +85,7 @@ fn test_v_init_in_dir_with_invalid_mod_name() {
 	// A project with a directory name with hyphens, which is invalid for a module name.
 	dir_name_with_invalid_mod_name := 'my-proj'
 	corrected_mod_name := 'my_proj'
-	proj_path := os.join_path(os.vtmp_dir(), 'v', dir_name_with_invalid_mod_name)
+	proj_path := os.join_path(os.vtmp_dir(), dir_name_with_invalid_mod_name)
 	os.mkdir_all(proj_path) or {}
 	os.chdir(proj_path)!
 	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'init_in_dir_with_invalid_mod_name.expect')} ${@VMODROOT} ${dir_name_with_invalid_mod_name} ${corrected_mod_name}')
@@ -104,17 +93,9 @@ fn test_v_init_in_dir_with_invalid_mod_name() {
 		assert false, res.output
 	}
 	// Assert mod data set in `new_with_model_arg.expect`.
-	mod := vmod.decode(os.read_file(os.join_path(proj_path, 'v.mod')) or {
-		assert false, 'Failed reading v.mod of ${proj_path}'
-		return
-	}) or {
+	mod := vmod.from_file(os.join_path(proj_path, 'v.mod')) or {
 		assert false, err.str()
 		return
 	}
 	assert mod.name == corrected_mod_name
-	os.rmdir_all(proj_path) or {}
-}
-
-fn testsuite_end() {
-	os.rmdir_all(test_module_path) or {}
 }

--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -11,6 +11,8 @@ const (
 	expect_tests_path = os.join_path(@VMODROOT, 'cmd', 'tools', 'vcreate', 'tests')
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_vcreate_input/`.
+	// Note: The following uses `test_vcreate_input` deliberately and NOT `vcreate_input_test`.
+	// This avoids clashes with the `_test` postfix, which V also uses for test file binaries.
 	test_module_path  = os.join_path(os.vtmp_dir(), 'test_vcreate_input')
 )
 
@@ -18,6 +20,10 @@ fn testsuite_begin() {
 	dump(expect_exe)
 	dump(test_module_path)
 	dump(expect_tests_path)
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_module_path) or {}
 }
 
 fn prepare_test_path() ! {

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -4,8 +4,14 @@ const (
 	test_project_dir_name = 'test_project'
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_project/`.
+	// Note: The following uses `test_vcreate` deliberately and NOT `vcreate_test`.
+	// This avoids clashes with the `_test` postfix, which V also uses for test file binaries.
 	test_path             = os.join_path(os.vtmp_dir(), test_project_dir_name)
 )
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
 
 fn init_and_check() ! {
 	os.chdir(test_path)!

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -1,10 +1,11 @@
 import os
-import v.vmod
 
-// Note: the following uses `test_vcreate` and NOT `vcreate_test` deliberately,
-// to both avoid confusions with the name of the current test itself, and to
-// avoid clashes with the postfix `_test.v`, that V uses for its own test files.
-const test_path = os.join_path(os.vtmp_dir(), 'v', 'test_vcreate')
+const (
+	test_project_dir_name = 'test_project'
+	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
+	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_project/`.
+	test_path             = os.join_path(os.vtmp_dir(), test_project_dir_name)
+)
 
 fn init_and_check() ! {
 	os.chdir(test_path)!
@@ -35,7 +36,7 @@ fn init_and_check() ! {
 
 	assert os.read_file('v.mod')! == [
 		'Module {',
-		"	name: 'test_vcreate'",
+		"	name: '${test_project_dir_name}'",
 		"	description: ''",
 		"	version: ''",
 		"	license: ''",
@@ -47,7 +48,7 @@ fn init_and_check() ! {
 	assert os.read_file('.gitignore')! == [
 		'# Binaries for programs and plugins',
 		'main',
-		'test_vcreate',
+		'${test_project_dir_name}',
 		'*.exe',
 		'*.exe~',
 		'*.so',
@@ -138,8 +139,4 @@ indent_style = tab
 
 	assert os.read_file('.gitattributes')! == git_attributes_content
 	assert os.read_file('.editorconfig')! == editor_config_content
-}
-
-fn testsuite_end() {
-	os.rmdir_all(test_path) or {}
 }


### PR DESCRIPTION
The PR wants to cleanup and simplify.

It includes an update of old code regarding the temporary test path, which can be simplified because its handling has changed since its integration. The change is explained in the following.

Using a temp path that additionally appends `'v'`, is a relic from before `vtmp_dir` was integrated when temporary paths for V where set via the regular `temp_dir` function. It was introduced in this pull #15774 and isn't used anymore.

- **Code at time of the PR** - 2022/09
  Temp path for a test 
 https://github.com/vlang/v/blob/f922ed09418d26f499aca4507e07951b3f59b6d1/cmd/tools/vbump_test.v#L5
  So that it could be cleaned with wipe-cache
  https://github.com/vlang/v/blob/f922ed09418d26f499aca4507e07951b3f59b6d1/cmd/tools/vwipe-cache.v#L10
  
- **Nowadays, the reason this was integrated isn't used anymore in wipe-cache.**
  Wipe-cache at current master
  https://github.com/vlang/v/blob/c09b66b00bdee962dc6d2f8048c182fa81ceff5d/cmd/tools/vwipe-cache.v#L8
  vcreate_test at current master
  https://github.com/vlang/v/blob/c09b66b00bdee962dc6d2f8048c182fa81ceff5d/cmd/tools/vcreate/vcreate_test.v#L7

  When using vtmp in test a temporary test_session_path is created that is automatically cleaned up after the test. It's not necessary to add `'v'` or to clean the path manually after a test.  
   
I would further clean up those relics in other places in a followup to reduce and simplify related code if that's okay.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1460795</samp>

This pull request improves the tests for the `vcreate` tool by refactoring, simplifying, and fixing some code. It uses built-in functions to handle temporary files and directories, and renames and reorganizes the test files for clarity and consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1460795</samp>

*  Rename test file from `vcreate_test.v` to `vcreate_input_test.v` and update imports and constants ([link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL2-R8), [link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L4-L6), [link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L13-R14))
*  Use `vmod.from_file` function to simplify reading and decoding `v.mod` files ([link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L39-R37), [link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L60-R55), [link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L82-R74))
*  Fix bug in test case for correcting invalid module names by using correct project path ([link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L99-R88))
*  Remove unnecessary removal of project directories and `testsuite_end` function ([link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L107-R101), [link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL142-L145))
*  Update assertions of module name in `v.mod` and `.gitignore` files to use new constant ([link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL38-R39), [link](https://github.com/vlang/v/pull/19666/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL50-R51))
