### PR TITLE
checker: extend byte deprecation warning to array init types

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -15,42 +15,49 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			if node.typ.has_flag(.option) && (node.has_cap || node.has_len) {
 				c.error('Option array `${elem_sym.name}` cannot have initializers', node.pos)
 			}
-			if elem_sym.kind == .struct_ {
-				elem_info := elem_sym.info as ast.Struct
-				if elem_info.generic_types.len > 0 && elem_info.concrete_types.len == 0
-					&& !node.elem_type.has_flag(.generic) {
-					if c.table.cur_concrete_types.len == 0 {
-						c.error('generic struct `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[int]',
-							node.elem_type_pos)
-					} else {
-						c.error('generic struct `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[T]',
-							node.elem_type_pos)
+			match elem_sym.info {
+				ast.Struct {
+					if elem_sym.info.generic_types.len > 0 && elem_sym.info.concrete_types.len == 0
+						&& !node.elem_type.has_flag(.generic) {
+						if c.table.cur_concrete_types.len == 0 {
+							c.error('generic struct `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[int]',
+								node.elem_type_pos)
+						} else {
+							c.error('generic struct `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[T]',
+								node.elem_type_pos)
+						}
 					}
 				}
-			} else if elem_sym.kind == .interface_ {
-				elem_info := elem_sym.info as ast.Interface
-				if elem_info.generic_types.len > 0 && elem_info.concrete_types.len == 0
-					&& !node.elem_type.has_flag(.generic) {
-					if c.table.cur_concrete_types.len == 0 {
-						c.error('generic interface `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[int]',
-							node.elem_type_pos)
-					} else {
-						c.error('generic interface `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[T]',
-							node.elem_type_pos)
+				ast.Interface {
+					if elem_sym.info.generic_types.len > 0 && elem_sym.info.concrete_types.len == 0
+						&& !node.elem_type.has_flag(.generic) {
+						if c.table.cur_concrete_types.len == 0 {
+							c.error('generic interface `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[int]',
+								node.elem_type_pos)
+						} else {
+							c.error('generic interface `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[T]',
+								node.elem_type_pos)
+						}
 					}
 				}
-			} else if elem_sym.kind == .sum_type {
-				elem_info := elem_sym.info as ast.SumType
-				if elem_info.generic_types.len > 0 && elem_info.concrete_types.len == 0
-					&& !node.elem_type.has_flag(.generic) {
-					if c.table.cur_concrete_types.len == 0 {
-						c.error('generic sumtype `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[int]',
-							node.elem_type_pos)
-					} else {
-						c.error('generic sumtype `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[T]',
-							node.elem_type_pos)
+				ast.SumType {
+					if elem_sym.info.generic_types.len > 0 && elem_sym.info.concrete_types.len == 0
+						&& !node.elem_type.has_flag(.generic) {
+						if c.table.cur_concrete_types.len == 0 {
+							c.error('generic sumtype `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[int]',
+								node.elem_type_pos)
+						} else {
+							c.error('generic sumtype `${elem_sym.name}` must specify type parameter, e.g. ${elem_sym.name}[T]',
+								node.elem_type_pos)
+						}
 					}
 				}
+				ast.Alias {
+					if elem_sym.name == 'byte' {
+						c.warn('byte is deprecated, use u8 instead', node.elem_type_pos)
+					}
+				}
+				else {}
 			}
 		}
 		if node.exprs.len == 0 {

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -238,7 +238,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut wr io.Writer) ! {
 						typeof[u16]().idx, typeof[u32]().idx, typeof[u64]().idx {
 							wr.write(value.str().bytes())!
 						}
-						typeof[[]byte]().idx, typeof[[]int]().idx {
+						typeof[[]int]().idx {
 							// FIXME - error: could not infer generic type `U` in call to `encode_array`
 							// e.encode_array(value, level, mut wr)!
 						}


### PR DESCRIPTION
Includes a small updated of the related code block as incremental refactor to improve readability and do less variable declarations and `as` casts.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d1a731</samp>

Refactor `vlib/v/checker/containers.v` to use `match` and handle `byte` deprecation. Simplify `vlib/x/json2/encoder.v` by removing redundant case for `[]byte`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d1a731</samp>

* Refactor the element symbol check for array types to use a `match` statement and handle `ast.Alias` ([link](https://github.com/vlang/v/pull/19671/files?diff=unified&w=0#diff-3a150553db91ada683e7bb70efe0d6d61a0c497bfdcd7c608d7f3f77282ae82cL18-R60))
* Remove the redundant case for `[]byte` in the JSON encoder `match` statement ([link](https://github.com/vlang/v/pull/19671/files?diff=unified&w=0#diff-b86e02046fdedcd445b233e5eabc730131f2e20d205de20bdfbb42d8edef0b21L241-R241))
