### PR TITLE
vlib: rewrite `vlib/v/help`, fix `print_help_and_exit` for sub topics

### DIFF
--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -2,80 +2,52 @@ module help
 
 import os
 
-const (
-	unknown_topic = '`v help`: unknown help topic provided. Use `v help` for usage information.'
-)
+const help_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'help')
 
-// print_and_exit Prints the help topic and exits
+// print_and_exit prints the help topic and exits.
 pub fn print_and_exit(topic string) {
-	vexe := os.executable()
-	vroot := os.dir(vexe)
-	topicdir := os.join_path(vroot, 'vlib', 'v', 'help')
-
-	for b in topic {
-		if (b >= `a` && b <= `z`) || b == `-` || (b >= `0` && b <= `9`) {
-			continue
-		}
-		eprintln(help.unknown_topic)
-		exit(1)
-	}
-
-	mut path_to := topic
-	mut topics := os.walk_ext(topicdir, '.txt')
-	mut items := [][]string{}
-
-	mut item_rev := []string{}
-	mut delim := ''
-
-	// Getting the directory, splitting at `/`, trimming to only indexes 0 and 1,
-	// and reversing that into the items array
-	for mut item in topics {
-		$if windows {
-			delim = '\\'
-		} $else {
-			delim = '/'
-		}
-		item_rev = item.split(delim).reverse()
-		item_rev.trim(2)
-		items << item_rev.reverse()
-	}
-
-	// Getting the path to the help topic text file
-	for cmds in items {
-		if '${topic}.txt' in cmds {
-			path_to = '${cmds[0]}/${cmds[1].replace('.txt', '')}'
-			break
-		}
-	}
-
-	topic_dir := if topic == 'default' {
-		os.join_path(topicdir, 'default.txt')
-	} else {
-		os.join_path(topicdir, '${path_to}.txt')
-	}
-
 	if topic == 'topics' {
-		println(known_topics(topicdir))
+		print_known_topics()
 		exit(0)
 	}
 
-	content := os.read_file(topic_dir) or {
-		eprintln(help.unknown_topic)
-		eprintln(known_topics(topicdir))
+	for c in topic {
+		if !c.is_letter() && !c.is_digit() && c != `-` {
+			print_topic_unkown(topic)
+			exit(1)
+		}
+	}
+
+	mut topic_path := ''
+	for t in os.walk_ext(help.help_dir, '.txt') {
+		if topic == t.all_after_last(os.path_separator)#[..-4] {
+			topic_path = t
+			break
+		}
+	}
+	if topic_path == '' {
+		print_topic_unkown(topic)
+		print_known_topics()
 		exit(1)
 	}
-	println(content)
+
+	println(os.read_file(topic_path) or {
+		eprintln('error: failed reading topic file: ${err}')
+		exit(1)
+	})
 	exit(0)
 }
 
-// known_topics Getting topics known to V
-fn known_topics(topicdir string) string {
-	mut res := []string{}
-	res << 'Known help topics: '
+fn print_topic_unkown(topic string) {
+	eprintln('error: unknown help topic "${topic}". Use `v help` for usage information.')
+}
 
-	mut topics := os.walk_ext(topicdir, '.txt').map(os.file_name(it).replace('.txt', ''))
-	topics.sort()
-	res << topics.join(', ')
-	res << '.'
-	return res.join('').replace('default, ', '')
+fn print_known_topics() {
+	mut res := 'Known help topics: '
+	for t in os.walk_ext(help.help_dir, '.txt') {
+		if t != 'default.txt' {
+			res += os.file_name(t).replace('.txt', '') + ', '
+		}
+	}
+	println(res#[..-2] + '.')
 }

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -19,9 +19,9 @@ pub fn print_and_exit(topic string) {
 	}
 
 	mut topic_path := ''
-	for t in os.walk_ext(help.help_dir, '.txt') {
-		if topic == t.all_after_last(os.path_separator)#[..-4] {
-			topic_path = t
+	for path in os.walk_ext(help.help_dir, '.txt') {
+		if topic == os.file_name(path).all_before('.txt') {
+			topic_path = path
 			break
 		}
 	}
@@ -44,10 +44,12 @@ fn print_topic_unkown(topic string) {
 
 fn print_known_topics() {
 	mut res := 'Known help topics: '
-	for t in os.walk_ext(help.help_dir, '.txt') {
-		if t != 'default.txt' {
-			res += os.file_name(t).replace('.txt', '') + ', '
+	topic_paths := os.walk_ext(help.help_dir, '.txt')
+	for i, path in topic_paths {
+		topic := os.file_name(path).all_before('.txt')
+		if topic != 'default' {
+			res += topic + if i != topic_paths.len - 1 { ', ' } else { '.' }
 		}
 	}
-	println(res#[..-2] + '.')
+	println(res)
 }

--- a/vlib/v/help/help_test.v
+++ b/vlib/v/help/help_test.v
@@ -1,52 +1,44 @@
 import os
 
-const vexe = os.getenv('VEXE')
+const vexe = os.quoted_path(@VEXE)
 
 fn test_help() {
-	res := os.execute('${os.quoted_path(vexe)} help')
+	res := os.execute(vexe + ' help')
 	assert res.exit_code == 0
 	assert res.output.starts_with('V is a tool for managing V source code.')
 }
 
 fn test_help_as_short_option() {
-	res := os.execute('${os.quoted_path(vexe)} -h')
+	res := os.execute(vexe + ' -h')
 	assert res.exit_code == 0
 	assert res.output.starts_with('V is a tool for managing V source code.')
 }
 
 fn test_help_as_long_option() {
-	res := os.execute('${os.quoted_path(vexe)} --help')
+	res := os.execute(vexe + ' --help')
 	assert res.exit_code == 0
 	assert res.output.starts_with('V is a tool for managing V source code.')
 }
 
-fn test_all_help() {
-	vroot := os.dir(vexe)
-	topicdir := os.join_path(vroot, 'vlib', 'v', 'help')
-	mut topics := os.walk_ext(topicdir, '.txt')
-
-	mut items := []string{}
-	mut delim := ''
-
-	for mut item in topics {
-		$if windows {
-			delim = '\\'
-		} $else {
-			delim = '/'
-		}
-		mut item_rev := item.replace('.txt', '').split(delim).reverse()
-		item_rev.trim(2)
-		items << item_rev.reverse()
-	}
-
-	for topic in items {
-		res := os.execute('${os.quoted_path(vexe)} help ${topic}')
-
-		if topic == 'help' {
-			continue
-		}
-
-		assert res.exit_code == 0
+fn test_all_topics() {
+	help_dir := os.join_path(@VEXEROOT, 'vlib', 'v', 'help')
+	topic_paths := os.walk_ext(help_dir, '.txt')
+	topics := topic_paths.map(it.all_after_last(os.path_separator).replace('.txt', ''))
+	for t in topics {
+		res := os.execute(vexe + ' help ${t}')
+		assert res.exit_code == 0, res.output
 		assert res.output != ''
 	}
+}
+
+fn test_uknown_topic() {
+	res := os.execute(vexe + ' help abc')
+	assert res.exit_code == 1, res.output
+	assert res.output.starts_with('error: unknown help topic "abc".')
+}
+
+fn test_topic_sub_help() {
+	res := os.execute(vexe + ' fmt --help')
+	assert res.exit_code == 0, res.output
+	assert res.output != ''
 }

--- a/vlib/v/help/help_test.v
+++ b/vlib/v/help/help_test.v
@@ -23,7 +23,7 @@ fn test_help_as_long_option() {
 fn test_all_topics() {
 	help_dir := os.join_path(@VEXEROOT, 'vlib', 'v', 'help')
 	topic_paths := os.walk_ext(help_dir, '.txt')
-	topics := topic_paths.map(it.all_after_last(os.path_separator).replace('.txt', ''))
+	topics := topic_paths.map(os.file_name(it).replace('.txt', ''))
 	for t in topics {
 		res := os.execute(vexe + ' help ${t}')
 		assert res.exit_code == 0, res.output
@@ -35,6 +35,13 @@ fn test_uknown_topic() {
 	res := os.execute(vexe + ' help abc')
 	assert res.exit_code == 1, res.output
 	assert res.output.starts_with('error: unknown help topic "abc".')
+}
+
+fn test_topics_output() {
+	res := os.execute(vexe + ' help topics')
+	assert res.exit_code == 0, res.output
+	assert res.output != '', res.output
+	assert !res.output.contains('default')
 }
 
 fn test_topic_sub_help() {


### PR DESCRIPTION
Currently, when running `v fmt --help` it prints:
```
`v help`: unknown help topic provided. Use `v help` for usage information.
Known help topics: .
```
This is despite vfmt accepting a help flag and calling the print_help function:
https://github.com/vlang/v/blob/f7058978a5b347c97c2bd2fa2a48401e7f7bc6ee/cmd/tools/vfmt.v#L90-L91

This PR fixes it and extends the modules test coverage and better error information.
It is a small module so it was rewritten to improve the module's suboptimalities. 

As a note when testing the changes locally: it's required to re-run `v self` to include when checking out the branch.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a7a403</samp>

This pull request refactors and improves the `help` and `help_test` modules in the V standard library. It uses new compiler attributes to get the paths to the V executable and the help topics, simplifies the code logic and structure, and adds more test cases.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a7a403</samp>

*  Refactor the `print_and_exit` function to use the new attributes and helper functions ([link](https://github.com/vlang/v/pull/19672/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L5-R52))
*  Update the `help_test` module to use the new attributes and the `os.quoted_path` function ([link](https://github.com/vlang/v/pull/19672/files?diff=unified&w=0#diff-9d6d0e8636892545d97d7aeabeab023a432adfdc54db3ad4fee85a29ec29f882L3-R6), [link](https://github.com/vlang/v/pull/19672/files?diff=unified&w=0#diff-9d6d0e8636892545d97d7aeabeab023a432adfdc54db3ad4fee85a29ec29f882L12-R12))
*  Rename the `test_all_help` function to `test_all_topics` and add two new test functions ([link](https://github.com/vlang/v/pull/19672/files?diff=unified&w=0#diff-9d6d0e8636892545d97d7aeabeab023a432adfdc54db3ad4fee85a29ec29f882L18-R43))
*  Simplify the logic of getting the topic names from the file paths in `test_all_topics` ([link](https://github.com/vlang/v/pull/19672/files?diff=unified&w=0#diff-9d6d0e8636892545d97d7aeabeab023a432adfdc54db3ad4fee85a29ec29f882L18-R43))
