### PR TITLE
cgen: fix array contains method with interface(fix #19670)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -979,7 +979,7 @@ fn (mut g Gen) gen_array_contains(left_type ast.Type, left ast.Expr, right_type 
 		g.write('->val')
 	}
 	g.write(', ')
-	if right.is_auto_deref_var() {
+	if right.is_auto_deref_var() || right_type.is_ptr() {
 		g.write('*')
 	}
 	left_sym := g.table.final_sym(left_type)

--- a/vlib/v/tests/array_methods_test.v
+++ b/vlib/v/tests/array_methods_test.v
@@ -39,3 +39,27 @@ fn test_any_called_with_opt_bool_fn() ? {
 	_ := [1, 2, 3].any(opt_bool_fn()?)
 	assert true
 }
+
+interface Args {}
+
+const some_strings = ['one', 'two', 'three']
+
+fn array_contains_method_with_interface(args ...Args) bool {
+	arg := args[0]
+	match arg {
+		string {
+			if arg in some_strings {
+				return true
+			} else {
+				return false
+			}
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn test_array_contains_method_with_interface() {
+	assert array_contains_method_with_interface('one')
+}


### PR DESCRIPTION
1. Fix #19670 
2. Add tests.

```v
interface Param {}

const some_strings = ['one', 'two', 'three']

fn test(params ...Param) {
	param := params[0]
	match param {
		string {
			if param in some_strings {
				println('in some_strings')
			}
		}
		else {
			panic('oops')
		}
	}
}

fn main() {
	test('three')
}
```

outputs:

```
in some_strings
```