### PR TITLE
cgen: fix array contains method with interface(fix #19670)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -979,14 +979,17 @@ fn (mut g Gen) gen_array_contains(left_type ast.Type, left ast.Expr, right_type 
 		g.write('->val')
 	}
 	g.write(', ')
-	if right.is_auto_deref_var() {
-		g.write('*')
-	}
 	left_sym := g.table.final_sym(left_type)
 	elem_typ := if left_sym.kind == .array {
 		left_sym.array_info().elem_type
 	} else {
 		left_sym.array_fixed_info().elem_type
+	}
+	if right.is_auto_deref_var()
+		|| (g.table.sym(elem_typ).kind !in [.interface_, .sum_type, .struct_] && right is ast.Ident
+		&& right.info is ast.IdentVar
+		&& g.table.sym(right.obj.typ).kind in [.interface_, .sum_type]) {
+		g.write('*')
 	}
 	if g.table.sym(elem_typ).kind in [.interface_, .sum_type] {
 		g.expr_with_cast(right, right_type, elem_typ)

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -612,6 +612,10 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 			.string, .alias, .sum_type, .map, .interface_, .array, .struct_ {
 				if elem_sym.kind == .string {
 					g.write('string__eq(')
+					if left.is_auto_deref_var() || (left is ast.Ident && left.info is ast.IdentVar
+						&& g.table.sym(left.obj.typ).kind in [.interface_, .sum_type]) {
+						g.write('*')
+					}
 				} else {
 					ptr_typ := g.equality_fn(right.elem_type)
 					if elem_sym.kind == .alias {

--- a/vlib/v/tests/array_methods_test.v
+++ b/vlib/v/tests/array_methods_test.v
@@ -39,3 +39,44 @@ fn test_any_called_with_opt_bool_fn() ? {
 	_ := [1, 2, 3].any(opt_bool_fn()?)
 	assert true
 }
+
+interface Args {}
+
+const some_strings = ['one', 'two', 'three']
+
+// For test `gen array contains method`
+// When `arg` comes from arguments, cgen generates code by `array contains event`
+fn array_contains_method_with_interface(args ...Args) {
+	arg := args[0]
+	match arg {
+		string {
+			if arg in some_strings {
+				assert true
+				return
+			}
+		}
+		else {}
+	}
+	assert false
+}
+
+// For test `gen string_eq method`
+// The cgen of static arrays containing events is optimized, which involves the string_eq event.
+fn string_eq_method_with_interface() {
+	arg := Args('three')
+	match arg {
+		string {
+			if arg in some_strings {
+				assert true
+				return
+			}
+		}
+		else {}
+	}
+	assert false
+}
+
+fn test_array_contains_method_with_interface() {
+	array_contains_method_with_interface('one')
+	string_eq_method_with_interface()
+}

--- a/vlib/v/tests/array_methods_test.v
+++ b/vlib/v/tests/array_methods_test.v
@@ -45,9 +45,8 @@ interface Args {}
 const some_strings = ['one', 'two', 'three']
 
 // For test `gen array contains method`
-// When `arg` comes from arguments, cgen generates code by `array contains event`
-fn array_contains_method_with_interface(args ...Args) {
-	arg := args[0]
+fn test_array_contains_method_with_interface() {
+	arg := Args('one')
 	match arg {
 		string {
 			if arg in some_strings {
@@ -61,12 +60,11 @@ fn array_contains_method_with_interface(args ...Args) {
 }
 
 // For test `gen string_eq method`
-// The cgen of static arrays containing events is optimized, which involves the string_eq event.
-fn string_eq_method_with_interface() {
+fn test_string_eq_method_with_interface() {
 	arg := Args('three')
 	match arg {
 		string {
-			if arg in some_strings {
+			if arg in ['one', 'two', 'three'] {
 				assert true
 				return
 			}
@@ -74,9 +72,4 @@ fn string_eq_method_with_interface() {
 		else {}
 	}
 	assert false
-}
-
-fn test_array_contains_method_with_interface() {
-	array_contains_method_with_interface('one')
-	string_eq_method_with_interface()
 }


### PR DESCRIPTION
1. Fix #19670 
2. Add tests.

```v
interface Param {}

const some_strings = ['one', 'two', 'three']

fn test(params ...Param) {
	param := params[0]
	match param {
		string {
			if param in some_strings {
				println('in some_strings')
			}
		}
		else {
			panic('oops')
		}
	}
}

fn main() {
	test('three')
}
```

outputs:

```
in some_strings
```