### PR TITLE
parser: fix new attribute syntax in struct dec (stage 2)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1,7 +1,7 @@
 // Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-@[has_globals]
+[has_globals]
 module parser
 
 import v.scanner
@@ -14,7 +14,7 @@ import v.errors
 import os
 import hash.fnv1a
 
-@[minify]
+[minify]
 pub struct Parser {
 	pref &pref.Preferences = unsafe { nil }
 mut:
@@ -175,12 +175,12 @@ pub fn parse_text(text string, path string, table &ast.Table, comments_mode scan
 	return res
 }
 
-@[unsafe]
+[unsafe]
 pub fn (mut p Parser) free() {
 	unsafe { p.free_scanner() }
 }
 
-@[unsafe]
+[unsafe]
 fn (mut p Parser) free_scanner() {
 	unsafe {
 		if p.scanner != 0 {
@@ -480,7 +480,7 @@ fn (mut p Parser) read_first_token() {
 	p.next()
 }
 
-@[inline]
+[inline]
 fn (p &Parser) peek_token(n int) token.Token {
 	return p.scanner.peek_token(n - 2)
 }
@@ -633,7 +633,7 @@ fn (mut p Parser) check(expected token.Kind) {
 	}
 }
 
-@[params]
+[params]
 struct ParamsForUnexpected {
 	got            string
 	expecting      string
@@ -696,7 +696,7 @@ fn (mut p Parser) check_name() string {
 	return name
 }
 
-@[if trace_parser ?]
+[if trace_parser ?]
 fn (p &Parser) trace_parser(label string) {
 	eprintln('parsing: ${p.file_name:-30}|tok.pos: ${p.tok.pos().line_str():-39}|tok.kind: ${p.tok.kind:-10}|tok.lit: ${p.tok.lit:-10}|${label}')
 }
@@ -735,7 +735,7 @@ fn (mut p Parser) top_stmt() ast.Stmt {
 					p.attributes()
 					continue
 				} else {
-					return p.error('@[attr] expected')
+					return p.error('[attr] expected')
 				}
 			}
 			.lsbr {
@@ -915,7 +915,7 @@ fn (mut p Parser) comment_stmt() ast.ExprStmt {
 	}
 }
 
-@[params]
+[params]
 struct EatCommentsConfig {
 	same_line bool // Only eat comments on the same line as the previous token
 	follow_up bool // Comments directly below the previous token as long as there is no empty line
@@ -1797,9 +1797,9 @@ fn (mut p Parser) attributes() {
 	if p.tok.kind == .lsbr {
 		// [attr]
 		p.check(.lsbr)
-		p.warn('`[attr] attributes are deprecated, please migrate to `@[attr]`')
+		p.warn('`[attr] attributes are deprecated, please migrate to `[attr]`')
 	} else if p.tok.kind == .at {
-		// @[attr]
+		// [attr]
 		p.check(.at)
 		p.check(.lsbr)
 		is_at = true
@@ -2317,7 +2317,7 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 	}
 }
 
-@[direct_array_access]
+[direct_array_access]
 fn (p &Parser) is_generic_struct_init() bool {
 	lit0_is_capital := p.tok.kind != .eof && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 	if !lit0_is_capital || p.peek_tok.kind !in [.lt, .lsbr] {
@@ -2352,7 +2352,7 @@ fn (p &Parser) is_generic_struct_init() bool {
 	return false
 }
 
-@[direct_array_access; inline]
+[direct_array_access; inline]
 fn (p &Parser) is_typename(t token.Token) bool {
 	return t.kind == .name && (t.lit[0].is_capital() || p.table.known_type(t.lit))
 }
@@ -2369,7 +2369,7 @@ fn (p &Parser) is_typename(t token.Token) bool {
 // 8. if there is a &, ignore the & and see if it is a type
 // 9. otherwise, it's not generic
 // see also test_generic_detection in vlib/v/tests/generics_test.v
-@[direct_array_access]
+[direct_array_access]
 fn (p &Parser) is_generic_call() bool {
 	lit0_is_capital := p.tok.kind != .eof && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 	if lit0_is_capital || p.peek_tok.kind !in [.lt, .lsbr] {
@@ -2483,7 +2483,7 @@ fn (mut p Parser) is_generic_cast() bool {
 	return false
 }
 
-@[direct_array_access]
+[direct_array_access]
 fn (mut p Parser) name_expr() ast.Expr {
 	prev_tok_kind := p.prev_tok.kind
 	mut node := ast.empty_expr
@@ -4067,12 +4067,12 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		pubfn := if p.mod == 'main' { 'fn' } else { 'pub fn' }
 		p.codegen('
 //
-@[inline] ${pubfn} (    e &${enum_name}) is_empty() bool           { return  ${senum_type}(*e) == 0 }
-@[inline] ${pubfn} (    e &${enum_name}) has(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) != 0 }
-@[inline] ${pubfn} (    e &${enum_name}) all(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) == ${senum_type}(flag) }
-@[inline] ${pubfn} (mut e  ${enum_name}) set(flag ${enum_name})      { unsafe{ *e = ${enum_name}(${senum_type}(*e) |  (${senum_type}(flag))) } }
-@[inline] ${pubfn} (mut e  ${enum_name}) clear(flag ${enum_name})    { unsafe{ *e = ${enum_name}(${senum_type}(*e) & ~(${senum_type}(flag))) } }
-@[inline] ${pubfn} (mut e  ${enum_name}) toggle(flag ${enum_name})   { unsafe{ *e = ${enum_name}(${senum_type}(*e) ^  (${senum_type}(flag))) } }
+[inline] ${pubfn} (    e &${enum_name}) is_empty() bool           { return  ${senum_type}(*e) == 0 }
+[inline] ${pubfn} (    e &${enum_name}) has(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) != 0 }
+[inline] ${pubfn} (    e &${enum_name}) all(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) == ${senum_type}(flag) }
+[inline] ${pubfn} (mut e  ${enum_name}) set(flag ${enum_name})      { unsafe{ *e = ${enum_name}(${senum_type}(*e) |  (${senum_type}(flag))) } }
+[inline] ${pubfn} (mut e  ${enum_name}) clear(flag ${enum_name})    { unsafe{ *e = ${enum_name}(${senum_type}(*e) & ~(${senum_type}(flag))) } }
+[inline] ${pubfn} (mut e  ${enum_name}) toggle(flag ${enum_name})   { unsafe{ *e = ${enum_name}(${senum_type}(*e) ^  (${senum_type}(flag))) } }
 //
 ')
 	}
@@ -4302,7 +4302,7 @@ fn (p &Parser) new_true_expr() ast.Expr {
 	}
 }
 
-@[noreturn]
+[noreturn]
 fn verror(s string) {
 	util.verror('parser error', s)
 }
@@ -4444,7 +4444,7 @@ fn (mut p Parser) trace[T](fbase string, x &T) {
 	}
 }
 
-@[params]
+[params]
 struct ParserShowParams {
 	msg   string
 	reach int = 3

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1,7 +1,7 @@
 // Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-[has_globals]
+@[has_globals]
 module parser
 
 import v.scanner
@@ -14,7 +14,7 @@ import v.errors
 import os
 import hash.fnv1a
 
-[minify]
+@[minify]
 pub struct Parser {
 	pref &pref.Preferences = unsafe { nil }
 mut:
@@ -175,12 +175,12 @@ pub fn parse_text(text string, path string, table &ast.Table, comments_mode scan
 	return res
 }
 
-[unsafe]
+@[unsafe]
 pub fn (mut p Parser) free() {
 	unsafe { p.free_scanner() }
 }
 
-[unsafe]
+@[unsafe]
 fn (mut p Parser) free_scanner() {
 	unsafe {
 		if p.scanner != 0 {
@@ -480,7 +480,7 @@ fn (mut p Parser) read_first_token() {
 	p.next()
 }
 
-[inline]
+@[inline]
 fn (p &Parser) peek_token(n int) token.Token {
 	return p.scanner.peek_token(n - 2)
 }
@@ -633,7 +633,7 @@ fn (mut p Parser) check(expected token.Kind) {
 	}
 }
 
-[params]
+@[params]
 struct ParamsForUnexpected {
 	got            string
 	expecting      string
@@ -696,7 +696,7 @@ fn (mut p Parser) check_name() string {
 	return name
 }
 
-[if trace_parser ?]
+@[if trace_parser ?]
 fn (p &Parser) trace_parser(label string) {
 	eprintln('parsing: ${p.file_name:-30}|tok.pos: ${p.tok.pos().line_str():-39}|tok.kind: ${p.tok.kind:-10}|tok.lit: ${p.tok.lit:-10}|${label}')
 }
@@ -915,7 +915,7 @@ fn (mut p Parser) comment_stmt() ast.ExprStmt {
 	}
 }
 
-[params]
+@[params]
 struct EatCommentsConfig {
 	same_line bool // Only eat comments on the same line as the previous token
 	follow_up bool // Comments directly below the previous token as long as there is no empty line
@@ -1797,6 +1797,7 @@ fn (mut p Parser) attributes() {
 	if p.tok.kind == .lsbr {
 		// [attr]
 		p.check(.lsbr)
+		p.warn('`[attr] attributes are deprecated, please migrate to `@[attr]`')
 	} else if p.tok.kind == .at {
 		// @[attr]
 		p.check(.at)
@@ -2316,7 +2317,7 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 	}
 }
 
-[direct_array_access]
+@[direct_array_access]
 fn (p &Parser) is_generic_struct_init() bool {
 	lit0_is_capital := p.tok.kind != .eof && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 	if !lit0_is_capital || p.peek_tok.kind !in [.lt, .lsbr] {
@@ -2351,7 +2352,7 @@ fn (p &Parser) is_generic_struct_init() bool {
 	return false
 }
 
-[direct_array_access; inline]
+@[direct_array_access; inline]
 fn (p &Parser) is_typename(t token.Token) bool {
 	return t.kind == .name && (t.lit[0].is_capital() || p.table.known_type(t.lit))
 }
@@ -2368,7 +2369,7 @@ fn (p &Parser) is_typename(t token.Token) bool {
 // 8. if there is a &, ignore the & and see if it is a type
 // 9. otherwise, it's not generic
 // see also test_generic_detection in vlib/v/tests/generics_test.v
-[direct_array_access]
+@[direct_array_access]
 fn (p &Parser) is_generic_call() bool {
 	lit0_is_capital := p.tok.kind != .eof && p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 	if lit0_is_capital || p.peek_tok.kind !in [.lt, .lsbr] {
@@ -2482,7 +2483,7 @@ fn (mut p Parser) is_generic_cast() bool {
 	return false
 }
 
-[direct_array_access]
+@[direct_array_access]
 fn (mut p Parser) name_expr() ast.Expr {
 	prev_tok_kind := p.prev_tok.kind
 	mut node := ast.empty_expr
@@ -4066,12 +4067,12 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		pubfn := if p.mod == 'main' { 'fn' } else { 'pub fn' }
 		p.codegen('
 //
-[inline] ${pubfn} (    e &${enum_name}) is_empty() bool           { return  ${senum_type}(*e) == 0 }
-[inline] ${pubfn} (    e &${enum_name}) has(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) != 0 }
-[inline] ${pubfn} (    e &${enum_name}) all(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) == ${senum_type}(flag) }
-[inline] ${pubfn} (mut e  ${enum_name}) set(flag ${enum_name})      { unsafe{ *e = ${enum_name}(${senum_type}(*e) |  (${senum_type}(flag))) } }
-[inline] ${pubfn} (mut e  ${enum_name}) clear(flag ${enum_name})    { unsafe{ *e = ${enum_name}(${senum_type}(*e) & ~(${senum_type}(flag))) } }
-[inline] ${pubfn} (mut e  ${enum_name}) toggle(flag ${enum_name})   { unsafe{ *e = ${enum_name}(${senum_type}(*e) ^  (${senum_type}(flag))) } }
+@[inline] ${pubfn} (    e &${enum_name}) is_empty() bool           { return  ${senum_type}(*e) == 0 }
+@[inline] ${pubfn} (    e &${enum_name}) has(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) != 0 }
+@[inline] ${pubfn} (    e &${enum_name}) all(flag ${enum_name}) bool { return  (${senum_type}(*e) &  (${senum_type}(flag))) == ${senum_type}(flag) }
+@[inline] ${pubfn} (mut e  ${enum_name}) set(flag ${enum_name})      { unsafe{ *e = ${enum_name}(${senum_type}(*e) |  (${senum_type}(flag))) } }
+@[inline] ${pubfn} (mut e  ${enum_name}) clear(flag ${enum_name})    { unsafe{ *e = ${enum_name}(${senum_type}(*e) & ~(${senum_type}(flag))) } }
+@[inline] ${pubfn} (mut e  ${enum_name}) toggle(flag ${enum_name})   { unsafe{ *e = ${enum_name}(${senum_type}(*e) ^  (${senum_type}(flag))) } }
 //
 ')
 	}
@@ -4301,7 +4302,7 @@ fn (p &Parser) new_true_expr() ast.Expr {
 	}
 }
 
-[noreturn]
+@[noreturn]
 fn verror(s string) {
 	util.verror('parser error', s)
 }
@@ -4443,7 +4444,7 @@ fn (mut p Parser) trace[T](fbase string, x &T) {
 	}
 }
 
-[params]
+@[params]
 struct ParserShowParams {
 	msg   string
 	reach int = 3

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -267,7 +267,8 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 			// Comments after type (same line)
 			prev_attrs := p.attrs
 			p.attrs = []
-			if p.tok.kind == .lsbr || p.tok.kind == .at {
+			// TODO: remove once old syntax is no longer supported
+			if p.tok.kind == .lsbr {
 				p.inside_struct_attr_decl = true
 				// attrs are stored in `p.attrs`
 				p.attributes()
@@ -293,6 +294,17 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					}
 					has_default_expr = true
 					comments << p.eat_comments()
+				}
+				if p.tok.kind == .at {
+					p.inside_struct_attr_decl = true
+					// attrs are stored in `p.attrs`
+					p.attributes()
+					for fa in p.attrs {
+						if fa.name == 'deprecated' {
+							is_field_deprecated = true
+						}
+					}
+					p.inside_struct_attr_decl = false
 				}
 				ast_fields << ast.StructField{
 					name: field_name


### PR DESCRIPTION
this PR is stage 1 which fixes parsing of the new attribute syntax in struct decl fields, and adds a deprecation warning.
stage 2 is in a seperate PR which updates all uses of the syntax.
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8d3bb4</samp>

This pull request changes the attribute syntax in the V language from `[attr]` to `@[attr]` to avoid ambiguity with array literals. It also adds a warning for the old syntax, updates the parser and struct modules to use the new syntax, and refactors the struct parsing logic to a separate file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8d3bb4</samp>

*  Update the attribute syntax from `[attr]` to `@[attr]` in various places to avoid confusion with array literals ([link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4-R4), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L17-R17), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L178-R183), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L483-R483), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L636-R636), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L699-R699), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L918-R918), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2319-R2320), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2354-R2355), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2371-R2372), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2485-R2486), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4069-R4075), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4304-R4305), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L4446-R4447), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26L270-R271), [link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26R298-R308))
* Add a warning message to inform the user that the old attribute syntax is deprecated and should be migrated to the new one ([link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R1800))
* Add a loop that checks if a struct field has a `deprecated` attribute and sets a flag accordingly in the `vlib/v/parser/struct.v` file ([link](https://github.com/vlang/v/pull/19679/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26R298-R308))
