### PR TITLE
fmt: add single-line ternary expr support for constants

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2225,7 +2225,8 @@ pub fn (mut f Fmt) if_expr(node ast.IfExpr) {
 	f.inside_comptime_if = node.is_comptime
 	mut is_ternary := node.branches.len == 2 && node.has_else
 		&& branch_is_single_line(node.branches[0]) && branch_is_single_line(node.branches[1])
-		&& (node.is_expr || f.is_assign || f.is_struct_init || f.single_line_fields)
+		&& (node.is_expr || f.is_assign || f.inside_const || f.is_struct_init
+		|| f.single_line_fields)
 	f.single_line_if = is_ternary
 	start_pos := f.out.len
 	start_len := f.line_len

--- a/vlib/v/fmt/tests/comptime_if_expr_script_keep.vv
+++ b/vlib/v/fmt/tests/comptime_if_expr_script_keep.vv
@@ -1,3 +1,5 @@
+const enable_debug = $if debug { true } $else { false }
+
 mut pre_built_str := ''
 $if prebuilt ? {
 	the_date := if $env('DATE') != '' { $env('DATE') } else { '##DATE##' }

--- a/vlib/v/fmt/tests/if_ternary_expected.vv
+++ b/vlib/v/fmt/tests/if_ternary_expected.vv
@@ -1,5 +1,6 @@
 const (
-	too_long_ling = if b.no_cstep {
+	spacing_error = if true { true } else { false }
+	too_long_line = if b.no_cstep {
 		'TMP1/${b.nexpected_steps:1d}'
 	} else {
 		'${b.cstep:1d}/${b.nexpected_steps:1d}'

--- a/vlib/v/fmt/tests/if_ternary_expected.vv
+++ b/vlib/v/fmt/tests/if_ternary_expected.vv
@@ -1,3 +1,18 @@
+const (
+	too_long_ling = if b.no_cstep {
+		'TMP1/${b.nexpected_steps:1d}'
+	} else {
+		'${b.cstep:1d}/${b.nexpected_steps:1d}'
+	}
+	too_many_branches = if true {
+		true
+	} else if true {
+		true
+	} else {
+		false
+	}
+)
+
 fn main() {
 	// This line is too long
 	sprogress := if b.no_cstep {

--- a/vlib/v/fmt/tests/if_ternary_input.vv
+++ b/vlib/v/fmt/tests/if_ternary_input.vv
@@ -1,3 +1,8 @@
+const (
+	too_long_ling = if b.no_cstep { 'TMP1/${b.nexpected_steps:1d}' } else { '${b.cstep:1d}/${b.nexpected_steps:1d}' }
+	too_many_branches = if true { true } else if true { true } else { false }
+)
+
 fn main() {
 	// This line is too long
 	sprogress := if b.no_cstep { 'TMP1/${b.nexpected_steps:1d}' } else { '${b.cstep:1d}/${b.nexpected_steps:1d}' }

--- a/vlib/v/fmt/tests/if_ternary_input.vv
+++ b/vlib/v/fmt/tests/if_ternary_input.vv
@@ -1,5 +1,6 @@
 const (
-	too_long_ling = if b.no_cstep { 'TMP1/${b.nexpected_steps:1d}' } else { '${b.cstep:1d}/${b.nexpected_steps:1d}' }
+	spacing_error = if true {true}else{ false}
+	too_long_line = if b.no_cstep { 'TMP1/${b.nexpected_steps:1d}' } else { '${b.cstep:1d}/${b.nexpected_steps:1d}' }
 	too_many_branches = if true { true } else if true { true } else { false }
 )
 

--- a/vlib/v/fmt/tests/if_ternary_keep.vv
+++ b/vlib/v/fmt/tests/if_ternary_keep.vv
@@ -1,3 +1,7 @@
+import os
+
+const exe_extension = if os.user_os() == 'windows' { '.exe' } else { '' }
+
 struct Foo {
 	n int
 	s string


### PR DESCRIPTION
This PR wants to make single line ternary expressions behave uniformly for  constants and variable declarations.

Currently:
```v
// Running vfmt on:
const ternary = if true { 1 } else { 0 }
// Fmt result:
const ternary = if true {
	1
} else {
	0
}

// While it is kept here:
ternary := if true { 1 } else { 0 }
// Fmt result:
ternary := if true { 1 } else { 0 }
```

After the PR we can also keep the single line formatting for short, two-branch expressions in constants if they were written on a single line.
```v
// v fmt keeps:
const (
	ternary = if true { 1 } else { 0 }
	my_custom_flag = $if my_custom_flag ? { true } $else { false }
)

// instead of:
const (
	ternary = if true {
		1
	} else {
		0
	}
	my_custom_flag = $if my_custom_flag ? {
		true
	} $else {
		false
	}
)
```


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 528101b</samp>

This pull request fixes a bug in the formatter that caused incorrect formatting of comptime if expressions inside const blocks. It also adds several test cases for the formatter's handling of if expressions that can be formatted as ternary operators.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 528101b</samp>

* Fix a bug in the formatter that caused incorrect formatting of comptime if expressions inside const blocks ([link](https://github.com/vlang/v/pull/19681/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL2228-R2229))
* Add a test case for the comptime if expression bug using the `$if` and `$else` syntax in `comptime_if_expr_script_keep.vv` ([link](https://github.com/vlang/v/pull/19681/files?diff=unified&w=0#diff-1cdc844dd6fce1b3148742fc7a51f083ab86a2bf15b3f4ab6ca881205a005debR1-R2))
* Add test cases for the formatter's handling of if expressions that can be formatted as ternary operators in `if_ternary_input.vv` and `if_ternary_expected.vv` ([link](https://github.com/vlang/v/pull/19681/files?diff=unified&w=0#diff-bdcbb79172dc839607add83618a37df5832dfc838db96a088e962b8d6e1a97f6R1-R15), [link](https://github.com/vlang/v/pull/19681/files?diff=unified&w=0#diff-94e921cbc32b3a206681411135cea3f17de686452fd7ef08cb79409688c9a036R1-R5))
* Add a test case for the keep option of the formatter that preserves the original formatting of if expressions in `if_ternary_keep.vv` ([link](https://github.com/vlang/v/pull/19681/files?diff=unified&w=0#diff-264806a03ebe1222987b877d3b1f9bba0edb57d71a3832e9348e304f327eb931R1-R4))
