### PR TITLE
fmt: temp - fix formatting of struct field with default value and new attr syntax (stage 2)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -324,6 +324,7 @@ pub:
 	comments         []Comment
 	i                int
 	has_default_expr bool
+	attrs_has_at     bool // TODO: remove in next stage
 	attrs            []Attr
 	is_pub           bool
 	default_val      string

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -145,7 +145,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 		f.mark_types_import_as_used(field.typ)
 		attrs_len := inline_attrs_len(field.attrs)
 		has_attrs := field.attrs.len > 0
-		if has_attrs {
+		// TODO: this will get removed in next stage
+		if has_attrs && !field.attrs_has_at {
 			f.write(strings.repeat(` `, field_align.max_type_len - field_types[i].len))
 			f.single_line_attrs(field.attrs, same_line: true)
 		}
@@ -166,6 +167,10 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 				f.indent--
 				inc_indent = false
 			}
+		}
+		if has_attrs && field.attrs_has_at {
+			// TODO: calculate correct padding
+			f.single_line_attrs(field.attrs, same_line: true)
 		}
 		// Handle comments after field type
 		if after_type_comments.len > 0 {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -295,7 +295,9 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					has_default_expr = true
 					comments << p.eat_comments()
 				}
+				mut has_at := false // TODO: remove in next stage
 				if p.tok.kind == .at {
+					has_at = true
 					p.inside_struct_attr_decl = true
 					// attrs are stored in `p.attrs`
 					p.attributes()
@@ -316,6 +318,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					i: i
 					default_expr: default_expr
 					has_default_expr: has_default_expr
+					attrs_has_at: has_at
 					attrs: p.attrs
 					is_pub: is_embed || is_field_pub
 					is_mut: is_embed || is_field_mut


### PR DESCRIPTION
stage 2 of updating attribute syntax
need some fixed to calculate correct padding.
most of the code added here will get removed after the next stage
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3caa4d</samp>

Fix and improve the formatting of struct fields with `@` symbols in their attributes. Add a new flag to the parser, the AST, and the `fmt_struct_field` function to handle this case.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3caa4d</samp>

*  Add a new field `attrs_has_at` to the `Field` struct in `ast.v` to store whether the field attributes have an `@` symbol or not ([link](https://github.com/vlang/v/pull/19683/files?diff=unified&w=0#diff-8e27648d38098f8fe63778c94c11aceb0a48e379121f676d189b04cb2cd8fc45R327))
*  Modify the `fmt_struct_field` function in `fmt/struct.v` to check the `attrs_has_at` flag and write the inline attributes accordingly ([link](https://github.com/vlang/v/pull/19683/files?diff=unified&w=0#diff-4d3237fc1e8650361e511e94248e3a9f5c7f590eca3dd3fbc845def22d31104bL148-R149), [link](https://github.com/vlang/v/pull/19683/files?diff=unified&w=0#diff-4d3237fc1e8650361e511e94248e3a9f5c7f590eca3dd3fbc845def22d31104bR171-R174))
*  Modify the `parse_struct_field` function in `parser/struct.v` to set the `attrs_has_at` flag based on the parser input ([link](https://github.com/vlang/v/pull/19683/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26L298-R300), [link](https://github.com/vlang/v/pull/19683/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26R321))
