### PR TITLE
fmt: respect range index expressions in match branches

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -33,8 +33,6 @@ pub mut:
 	single_line_if     bool
 	cur_mod            string
 	did_imports        bool
-	is_assign          bool
-	is_struct_init     bool
 	auto_imports       []string          // automatically inserted imports that the user forgot to specify
 	import_pos         int               // position of the imports in the resulting string for later autoimports insertion
 	used_imports       []string          // to remove unused imports
@@ -48,7 +46,10 @@ pub mut:
 	inside_const       bool
 	inside_unsafe      bool
 	inside_comptime_if bool
+	is_assign          bool
+	is_index_expr      bool
 	is_mbranch_expr    bool // match a { x...y { } }
+	is_struct_init     bool
 	fn_scope           &ast.Scope = unsafe { nil }
 	wsinfix_depth      int
 	format_state       FormatState
@@ -2334,6 +2335,7 @@ pub fn (mut f Fmt) index_expr(node ast.IndexExpr) {
 			f.write('#')
 		}
 	}
+	f.is_index_expr = true
 	f.write('[')
 	f.expr(node.index)
 	f.write(']')
@@ -2802,7 +2804,7 @@ pub fn (mut f Fmt) prefix_expr(node ast.PrefixExpr) {
 
 pub fn (mut f Fmt) range_expr(node ast.RangeExpr) {
 	f.expr(node.low)
-	if f.is_mbranch_expr {
+	if f.is_mbranch_expr && !f.is_index_expr {
 		f.write('...')
 	} else {
 		f.write('..')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2335,11 +2335,12 @@ pub fn (mut f Fmt) index_expr(node ast.IndexExpr) {
 			f.write('#')
 		}
 	}
+	last_index_expr_state := f.is_index_expr
 	f.is_index_expr = true
 	f.write('[')
 	f.expr(node.index)
 	f.write(']')
-	f.is_index_expr = false
+	f.is_index_expr = last_index_expr_state
 	if node.or_expr.kind != .absent {
 		f.or_expr(node.or_expr)
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2339,6 +2339,7 @@ pub fn (mut f Fmt) index_expr(node ast.IndexExpr) {
 	f.write('[')
 	f.expr(node.index)
 	f.write(']')
+	f.is_index_expr = false
 	if node.or_expr.kind != .absent {
 		f.or_expr(node.or_expr)
 	}

--- a/vlib/v/fmt/tests/match_expected.vv
+++ b/vlib/v/fmt/tests/match_expected.vv
@@ -48,3 +48,11 @@ fn match_branch_extra_comma() {
 		else {}
 	}
 }
+
+fn match_index_range_expr(var string) string {
+	return match true {
+		var.len < 3 { 'i#' + var }
+		var[1..2].contains('#') { var }
+		else { 'i#' + var }
+	}
+}

--- a/vlib/v/fmt/tests/match_input.vv
+++ b/vlib/v/fmt/tests/match_input.vv
@@ -46,3 +46,11 @@ fn match_branch_extra_comma() {
 		else {}
 	}
 }
+
+fn match_index_range_expr(var string) string{
+	return match true {
+			var.len< 3{ 'i#' + var }
+			var[1..2].contains('#') { var }
+			else { 'i#' + var }
+		}
+}

--- a/vlib/v/fmt/tests/match_range_expression_branches_keep.vv
+++ b/vlib/v/fmt/tests/match_range_expression_branches_keep.vv
@@ -13,3 +13,11 @@ pub fn str_escaped(b u8) string {
 	}
 	return str
 }
+
+fn match_index_range_expr(var string) {
+	println(match true {
+		var.len < 3 { 'i#' + var }
+		var[1..2].contains('#') { var }
+		else { 'i#' + var }
+	})
+}


### PR DESCRIPTION
Fixes #19680 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 282225f</samp>

Simplify `Fmt` struct and fix formatting bug for index expressions with range expressions in `vlib/v/fmt/fmt.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 282225f</samp>

* Remove unused fields `is_assign` and `is_struct_init` from `Fmt` struct ([link](https://github.com/vlang/v/pull/19684/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL36-L37))
* Add field `is_index_expr` to `Fmt` struct to track index expressions ([link](https://github.com/vlang/v/pull/19684/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eR49-R51))
* Set `is_index_expr` to true when formatting an index expression node ([link](https://github.com/vlang/v/pull/19684/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eR2338))
