### PR TITLE
docs: update the name of Twitter to X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -818,7 +818,7 @@ Final steps in making the Option type a first class type:
 - C to V translation via C2V: `v translate file.c`. (Demo video: [Translating DOOM from C to V, building it in under a second and running it!](https://www.youtube.com/watch?v=6oXrz3oRoEg))
 - Lots of bug fixes in V, cgen, and C interop to allow running translated DOOM.v.
 - Programs built with the V compiler no longer leak memory by default.
-- Closures. All operating systems are supported. ([Demo](https://twitter.com/v_language/status/1528710491882852352))
+- Closures. All operating systems are supported. ([Demo](https://x.com/v_language/status/1528710491882852352))
 - `Option` and `Result` are now separate types: `?Foo` and `!Foo` respectively. Old code will continue working for 1 year and will result in a warning/hint.
 - Hundreds of new checks in the type checker.
 - All V's backends have been split up into separate processes.  As the result, building V got 26% faster.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Sponsor][SponsorBadge]][SponsorUrl]
 [![Patreon][PatreonBadge]][PatreonUrl]
 [![Discord][DiscordBadge]][DiscordUrl]
-[![Twitter][TwitterBadge]][TwitterUrl]
+[![Twitter][XBadge]][XUrl]
 [![Modules][ModulesBadge]][ModulesUrl]
 </div>
 
@@ -367,12 +367,12 @@ section on our
 [DiscordBadge]: https://img.shields.io/discord/592103645835821068?label=Discord&logo=discord&logoColor=white
 [PatreonBadge]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Dvlang%26type%3Dpatrons&style=flat
 [SponsorBadge]: https://camo.githubusercontent.com/da8bc40db5ed31e4b12660245535b5db67aa03ce/68747470733a2f2f696d672e736869656c64732e696f2f7374617469632f76313f6c6162656c3d53706f6e736f72266d6573736167653d254532253944254134266c6f676f3d476974487562
-[TwitterBadge]: https://img.shields.io/badge/follow-%40v_language-1DA1F2?logo=twitter&style=flat&logoColor=white&color=1da1f2
+[XBadge]: https://img.shields.io/badge/follow-%40v_language-1DA1F2?logo=x&style=flat&logoColor=white&color=1da1f2
 [ModulesBadge]: https://img.shields.io/badge/modules-reference-027d9c?logo=v&logoColor=white&logoWidth=10
 
 [WorkflowUrl]: https://github.com/vlang/v/commits/master
 [DiscordUrl]: https://discord.gg/vlang
 [PatreonUrl]: https://patreon.com/vlang
 [SponsorUrl]: https://github.com/sponsors/medvednikov
-[TwitterUrl]: https://twitter.com/v_language
+[XUrl]: https://x.com/v_language
 [ModulesUrl]: https://modules.vlang.io

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Sponsor][SponsorBadge]][SponsorUrl]
 [![Patreon][PatreonBadge]][PatreonUrl]
 [![Discord][DiscordBadge]][DiscordUrl]
-[![Twitter][XBadge]][XUrl]
+[![X][XBadge]][XUrl]
 [![Modules][ModulesBadge]][ModulesUrl]
 </div>
 


### PR DESCRIPTION
I have updated the name of Twitter to X in all the documentation (Texts and Links) of this repo.

Everyone must be well aware by now that the legal name of Twitter has been formally changed to X. Therefore, I have updated the Readme and other files and corrected the name to X. Therefore, Wouldn't it be best to be updated with the latest?
