### PR TITLE
checker: check error of implementing other module private interface (fix #19620)

### DIFF
--- a/vlib/crypto/cipher/cipher.v
+++ b/vlib/crypto/cipher/cipher.v
@@ -6,7 +6,7 @@ module cipher
 // using a given key. It provides the capability to encrypt
 // or decrypt individual blocks. The mode implementations
 // extend that capability to streams of blocks.
-interface Block {
+pub interface Block {
 	block_size int // block_size returns the cipher's block size.
 	encrypt(mut dst []u8, src []u8) // Encrypt encrypts the first block in src into dst.
 	// Dst and src must overlap entirely or not at all.
@@ -15,7 +15,7 @@ interface Block {
 }
 
 // A Stream represents a stream cipher.
-interface Stream {
+pub interface Stream {
 	// xor_key_stream XORs each byte in the given slice with a byte from the
 	// cipher's key stream. Dst and src must overlap entirely or not at all.
 	//
@@ -31,7 +31,7 @@ interface Stream {
 
 // A BlockMode represents a block cipher running in a block-based mode (CBC,
 // ECB etc).
-interface BlockMode {
+pub interface BlockMode {
 	block_size int // block_size returns the mode's block size.
 	crypt_blocks(mut dst []u8, src []u8) // crypt_blocks encrypts or decrypts a number of blocks. The length of
 	// src must be a multiple of the block size. Dst and src must overlap

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -18,7 +18,7 @@ pub enum ServerStatus {
 	stopped
 }
 
-interface Handler {
+pub interface Handler {
 mut:
 	handle(Request) Response
 }

--- a/vlib/v/checker/tests/modules/implement_private_interface.out
+++ b/vlib/v/checker/tests/modules/implement_private_interface.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/modules/implement_private_interface/main.v:6:16: error: `Bar` cannot implement private interface `baz.Foo` of other module
+    4 | fn main() {
+    5 |     b := Bar{10}
+    6 |     baz.print_foo(b) // prints 10
+      |                   ^
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/modules/implement_private_interface.out
+++ b/vlib/v/checker/tests/modules/implement_private_interface.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/modules/implement_private_interface/main.v:6:16: error: `Bar` cannot implement private interface `baz.Foo` of other module
-    4 | fn main() {
-    5 |     b := Bar{10}
-    6 |     baz.print_foo(b) // prints 10
+vlib/v/checker/tests/modules/implement_private_interface/main.v:7:16: error: `Bar` cannot implement private interface `baz.Foo` of other module
+    5 | fn main() {
+    6 |     b := Bar{10}
+    7 |     baz.print_foo(b) // prints 10
       |                   ^
-    7 | }
-    8 |
+    8 | }
+    9 |

--- a/vlib/v/checker/tests/modules/implement_private_interface/baz.v
+++ b/vlib/v/checker/tests/modules/implement_private_interface/baz.v
@@ -1,0 +1,10 @@
+// sub module
+module baz
+
+interface Foo {
+	a int
+}
+
+pub fn print_foo(f Foo) {
+	println(f.a)
+}

--- a/vlib/v/checker/tests/modules/implement_private_interface/main.v
+++ b/vlib/v/checker/tests/modules/implement_private_interface/main.v
@@ -1,4 +1,5 @@
 module main
+
 import baz
 
 fn main() {

--- a/vlib/v/checker/tests/modules/implement_private_interface/main.v
+++ b/vlib/v/checker/tests/modules/implement_private_interface/main.v
@@ -1,0 +1,11 @@
+module main
+import baz
+
+fn main() {
+	b := Bar{10}
+	baz.print_foo(b) // prints 10
+}
+
+struct Bar {
+	a int
+}

--- a/vlib/v/embed_file/decoder.v
+++ b/vlib/v/embed_file/decoder.v
@@ -1,7 +1,7 @@
 [has_globals]
 module embed_file
 
-interface Decoder {
+pub interface Decoder {
 	decompress([]u8) ![]u8
 }
 


### PR DESCRIPTION
This PR check error of implementing other module private interface (fix #19620).

- Check error of implementing other module private interface.
- Add test.
```v
// sub module
module baz

interface Foo {
	a int
}

pub fn print_foo(f Foo) {
	println(f.a)
}
```
```v
module main
import baz

fn main() {
	b := Bar{10}
	baz.print_foo(b) // prints 10
}

struct Bar {
	a int
}

PS D:\Test\v\tt1> v run .    
tt1.v:6:16: error: `Bar` cannot implement private interface `baz.Foo` of other module
    4 | fn main() {
    5 |     b := Bar{10}
    6 |     baz.print_foo(b) // prints 10
      |                   ^
    7 | }
    8 |
```