### PR TITLE
fmt: recognize or blocks in call args

### DIFF
--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -6,7 +6,7 @@ import v.vmod
 // avoid clashes with the postfix `_test.v`, that V uses for its own test files.
 const (
 	// Expect has to be installed for the test.
-	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
+	expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
 	})

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -788,7 +788,8 @@ fn expr_is_single_line(expr ast.Expr) bool {
 			}
 		}
 		ast.CallExpr {
-			if expr.or_block.stmts.len > 1 {
+			if expr.or_block.stmts.len > 1 || expr.args.any(it.expr is ast.CallExpr
+				&& it.expr.or_block.stmts.len > 1) {
 				return false
 			}
 		}

--- a/vlib/v/fmt/tests/consts_with_or_block_keep.vv
+++ b/vlib/v/fmt/tests/consts_with_or_block_keep.vv
@@ -1,0 +1,13 @@
+import os
+
+const (
+	exe = os.find_abs_path_of_executable('my_exe') or {
+		eprintln('skipping test, since `my_exe` is missing')
+		exit(0)
+	}
+	exe_quoted = os.quoted_path(os.find_abs_path_of_executable('my_exe') or {
+		eprintln('skipping test, since `my_exe` is missing')
+		exit(0)
+	})
+	single_line_test_path = os.join_path(os.vtmp_dir(), 'my_test_path')
+)


### PR DESCRIPTION
This PR should fix un-uniform behavior where or-blocks are not recognized in call arguments.

Current:
```v
import os

const (
	// v fmt doesn't alling since it isn't singleline / has an or block.
	exe = os.find_abs_path_of_executable('my_exe') or {
		eprintln('skipping test, since `my_exe` is missing')
		exit(0)
	}
	// same expr as above but wrapped in a function as an argument.
	// v fmt aligns despite the or block.
	exe_quoted            = os.quoted_path(os.find_abs_path_of_executable('my_exe') or {
		eprintln('skipping test, since `my_exe` is missing')
		exit(0)
	})
	single_line_test_path = os.join_path(os.vtmp_dir(), 'my_test_path')
)
```

Changed:
```v
import os

const (
	exe = os.find_abs_path_of_executable('my_exe') or {
		eprintln('skipping test, since `my_exe` is missing')
		exit(0)
	}
	// Now detects or block in call arg.
	exe_quoted = os.quoted_path(os.find_abs_path_of_executable('my_exe') or {
		eprintln('skipping test, since `my_exe` is missing')
		exit(0)
	})
	single_line_test_path = os.join_path(os.vtmp_dir(), 'my_test_path')
)
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08b020b</samp>

Improve the formatting of call expressions with or blocks and add a test file to verify it. Fix issue #11197 by modifying `expr_is_single_line` in `vlib/v/fmt/fmt.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08b020b</samp>

* Fix formatting of call expressions with or blocks ([link](https://github.com/vlang/v/pull/19690/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL791-R791))
* Add test cases for formatting of call expressions with or blocks as constants ([link](https://github.com/vlang/v/pull/19690/files?diff=unified&w=0#diff-ecb9a001367d1e6784699f72d380b52a561adf03e310aca0185211e680c32bcaR1-R13))
