### PR TITLE
cgen: fix infix op when handling comptime selector

### DIFF
--- a/vlib/v/tests/comptime_eq_test.v
+++ b/vlib/v/tests/comptime_eq_test.v
@@ -1,0 +1,34 @@
+struct Abc {
+	id     int
+	name   string
+	letter string
+}
+
+fn join[T](mut old T, new T) {
+	$if T is $struct {
+		default := T{}
+		$for field in T.fields {
+			if new.$(field.name) != default.$(field.name) {
+				old.$(field.name) = new.$(field.name)
+			}
+		}
+	}
+}
+
+fn test_main() {
+	mut a := Abc{
+		name: 'Peter'
+		letter: 'a'
+	}
+	b := Abc{
+		id: 1
+		letter: 'b'
+	}
+	join(mut a, b)
+
+	assert a == Abc{
+		name: 'Peter'
+		id: 1
+		letter: 'b'
+	}
+}


### PR DESCRIPTION
Fix #19566

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c56dc79</samp>

This pull request enhances the V compiler and adds a test for comptime generics and equality. It fixes the code generation for infix expressions with comptime selectors and none checks in `vlib/v/gen/c/infix.v` and adds a new test case in `vlib/v/tests/comptime_eq_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c56dc79</samp>

*  Add logic to handle comptime selectors in infix expressions with `==` and `!=` operators ([link](https://github.com/vlang/v/pull/19691/files?diff=unified&w=0#diff-4194723712edfd7a1a69102329b9169cc79bc1d109393153e0537039c5ca1988L99-R110))
* Fix a minor bug to use the `left_type` variable instead of `node.left_type` in the `is_none_check` condition ([link](https://github.com/vlang/v/pull/19691/files?diff=unified&w=0#diff-4194723712edfd7a1a69102329b9169cc79bc1d109393153e0537039c5ca1988L113-R123))
* Add a test case for comptime generics with `==` operator in `vlib/v/tests/comptime_eq_test.v` ([link](https://github.com/vlang/v/pull/19691/files?diff=unified&w=0#diff-4a4b44ed266db08d80683afdd27a5e6e4b494c3e3511a0e071732dac9fe4c93bR1-R34))
