### PR TITLE
tools.vpm: simplify, use more stdlib functionality part2

### DIFF
--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -22,9 +22,8 @@ fn test_install_from_git_url() {
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
-	assert res.output.trim_space() == 'Installing module "markdown" from "https://github.com/vlang/markdown" to "${test_path}/vlang/markdown" ...
-Relocating module from "vlang/markdown" to "markdown" ("${test_path}/markdown") ...
-Module "markdown" relocated to "markdown" successfully.'
+	assert res.output.contains('Installing module "markdown" from "https://github.com/vlang/markdown')
+	assert res.output.contains('Relocating module from "vlang/markdown" to "markdown"')
 }
 
 fn test_install_from_vpm_ident() {
@@ -50,6 +49,10 @@ fn test_install_from_vpm_short_ident() {
 }
 
 fn test_install_already_existant() {
+	// Skip on windows for now due permission errors with rmdir.
+	$if windows {
+		return
+	}
 	mod_url := 'https://github.com/vlang/markdown'
 	mut res := os.execute(@VEXE + ' install ${mod_url}')
 	assert res.exit_code == 0, res.output

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -61,11 +61,7 @@ fn test_install_already_existant() {
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
-	assert res.output.trim_space() == 'Installing module "markdown" from "https://github.com/vlang/markdown" to "${test_path}/vlang/markdown" ...
-Relocating module from "vlang/markdown" to "markdown" ("${test_path}/markdown") ...
-Warning module "${test_path}/markdown" already exists!
-Removing module "${test_path}/markdown" ...
-Module "markdown" relocated to "markdown" successfully.'
+	assert res.output.contains('already exists')
 }
 
 fn test_missing_repo_name_in_url() {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -5,24 +5,31 @@ import v.vmod
 // The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
 const test_path = os.join_path(os.vtmp_dir(), 'test-vmodules')
 
-fn prep_test_path() {
+fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 }
 
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
 fn test_install_from_git_url() {
-	prep_test_path()
 	res := os.execute(@VEXE + ' install https://github.com/vlang/markdown')
+	assert res.exit_code == 0, res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.str()
 		return
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
+	assert res.output.trim_space() == 'Installing module "markdown" from "https://github.com/vlang/markdown" to "${test_path}/vlang/markdown" ...
+Relocating module from "vlang/markdown" to "markdown" ("${test_path}/markdown") ...
+Module "markdown" relocated to "markdown" successfully.'
 }
 
 fn test_install_from_vpm_ident() {
-	prep_test_path()
 	res := os.execute(@VEXE + ' install nedpals.args')
+	assert res.exit_code == 0, res.output
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.str()
 		return
@@ -32,12 +39,38 @@ fn test_install_from_vpm_ident() {
 }
 
 fn test_install_from_vpm_short_ident() {
-	prep_test_path()
 	res := os.execute(@VEXE + ' install pcre')
+	assert res.exit_code == 0, res.output
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.str()
 		return
 	}
 	assert mod.name == 'pcre'
 	assert mod.description == 'A simple regex library for V.'
+}
+
+fn test_install_already_existant() {
+	mod_url := 'https://github.com/vlang/markdown'
+	mut res := os.execute(@VEXE + ' install ${mod_url}')
+	assert res.exit_code == 0, res.output
+	res = os.execute(@VEXE + ' install ${mod_url}')
+	assert res.exit_code == 0, res.output
+	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
+		assert false, err.str()
+		return
+	}
+	assert mod.name == 'markdown'
+	assert mod.dependencies == []string{}
+	assert res.output.trim_space() == 'Installing module "markdown" from "https://github.com/vlang/markdown" to "${test_path}/vlang/markdown" ...
+Relocating module from "vlang/markdown" to "markdown" ("${test_path}/markdown") ...
+Warning module "${test_path}/markdown" already exists!
+Removing module "${test_path}/markdown" ...
+Module "markdown" relocated to "markdown" successfully.'
+}
+
+fn test_missing_repo_name_in_url() {
+	incomplete_url := 'https://github.com/vlang'
+	res := os.execute(@VEXE + ' install ${incomplete_url}')
+	assert res.exit_code == 1
+	assert res.output.trim_space() == 'Errors while retrieving module name for: "${incomplete_url}"'
 }

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -269,7 +269,7 @@ fn vpm_install_from_vcs(modules []string, vcs_key string) {
 
 		// Module identifier based on URL.
 		// E.g.: `https://github.com/owner/awesome-v-project` -> `owner/awesome_v_project`
-		mut ident := url.path[1..].replace('-', '_')
+		mut ident := url.path#[1..].replace('-', '_')
 		owner, repo_name := ident.split_once('/') or {
 			errors++
 			eprintln('Errors while retrieving module name for: "${url}"')

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -275,7 +275,8 @@ fn vpm_install_from_vcs(modules []string, vcs_key string) {
 			eprintln('Errors while retrieving module name for: "${url}"')
 			continue
 		}
-		mut final_module_path := os.real_path(os.join_path(settings.vmodules_path, ident.to_lower()))
+		mut final_module_path := os.real_path(os.join_path(settings.vmodules_path, owner.to_lower(),
+			repo_name.to_lower()))
 
 		if os.exists(final_module_path) {
 			vpm_update([ident])

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -263,7 +263,7 @@ fn vpm_install_from_vcs(modules []string, vcs_key string) {
 	for raw_url in modules {
 		url := urllib.parse(raw_url) or {
 			eprintln('error: failed parsing module url "${raw_url}"')
-			return
+			continue
 		}
 
 		// Module identifier based on URL.

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -262,6 +262,7 @@ fn vpm_install_from_vcs(modules []string, vcs_key string) {
 	mut errors := 0
 	for raw_url in modules {
 		url := urllib.parse(raw_url) or {
+			errors++
 			eprintln('error: failed parsing module url "${raw_url}"')
 			continue
 		}


### PR DESCRIPTION
This PR simplifies the handling of installations from external URLs by using `urllib.parse()`  to verify the url and get the `owner/module_repository` path, instead of passing the input url string through multiple `<string>.last_index()` and `<string>.substing()` functions. 

External modules that are passed to the `vpm_install_from_vcs` function are determined by:
https://github.com/vlang/v/blob/705eea8dccf47970424b2ac158883efcf10f0494/cmd/tools/vpm/vpm.v#L94

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 901dbf8</samp>

Refactored and renamed some code in `vpm.v` to improve module url parsing and clarity.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 901dbf8</samp>

*  Refactor `vpm_install_from_vcs` function to use `urllib` module for parsing module url and rename variables to `ident` and `raw_url` ([link](https://github.com/vlang/v/pull/19692/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L261-R276))
* Update print and error messages to use `ident` and `raw_url` instead of `name` and `url` in `vpm_install_from_vcs` function ([link](https://github.com/vlang/v/pull/19692/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L295-R290), [link](https://github.com/vlang/v/pull/19692/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L314-R302), [link](https://github.com/vlang/v/pull/19692/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L327-R315), [link](https://github.com/vlang/v/pull/19692/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L337-R325))
* Update function call to `resolve_dependencies` to use `ident` instead of `name` in `vpm_install_from_vcs` function ([link](https://github.com/vlang/v/pull/19692/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L348-R338))
