### PR TITLE
all: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ accordingly in the steps below.)
       with the updated version of your changes.
 
 The point of doing the above steps, is to never directly push to the main V
-repository, _only to your own fork_. Since your local `master` branch tracks the
+repository, *only to your own fork*. Since your local `master` branch tracks the
 main V repository's master, then `git checkout master`, as well as
 `git pull --rebase origin master` will continue to work as expected
 (these are actually used by `v up`) and git can always do it cleanly.
@@ -204,7 +204,7 @@ command.
 
 ### Preparation:
 
-(steps 1..3 need to be done just _once_):
+(steps 1..3 need to be done just *once*):
 
 1. `hub clone vlang/v my_v`
 2. `cd my_v`
@@ -216,8 +216,8 @@ command.
    ```
 3. `hub fork --remote-name pullrequest`
 
-4. `git checkout -b my_cool_feature` # Step 4 is better done _once per each new
-   feature/bugfix_ that you make.
+4. `git checkout -b my_cool_feature` # Step 4 is better done *once per each new
+   feature/bugfix* that you make.
 
 ### Improve V by making commits:
 
@@ -257,22 +257,22 @@ V allows you to pass custom flags using `-d my_flag` that can then be checked
 at compile time (see the documentation about
 [compile-time if](https://github.com/vlang/v/blob/master/doc/docs.md#compile-time-if)).
 
-Since the compiler is _also_ an ordinary V program, there are numerous flags that can be
+Since the compiler is *also* an ordinary V program, there are numerous flags that can be
 passed when building the compiler itself with `v self`, or when creating a copy of the
 compiler, that will help you when debugging the compiler.
 
-Note: beware that the flags below must be passed, when building the compiler, _not the program_,
+Note: beware that the flags below must be passed, when building the compiler, *not the program*,
 so do for example:
 `./v -o w -d time_parsing cmd/v`
 or
 `./v -o w -d trace_checker self`
 ... then use `./w file.v`, instead of `./v file.v`, to compile your program.
 
-Note: some of the flags can make the compiler _very verbose_, so it is recommended to create
+Note: some of the flags can make the compiler *very verbose*, so it is recommended to create
 a copy of the compiler rather than replacing it with `v self`.
 
 | Flag                              | Usage                                                                                                               |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | `debugscanner`                    | Prints debug information during the scanning phase                                                                  |
 | `debug_codegen`                   | Prints automatically generated V code during the scanning phase                                                     |
 | `debug_interface_table`           | Prints generated interfaces during C generation                                                                     |
@@ -288,9 +288,9 @@ a copy of the compiler rather than replacing it with `v self`.
 |                                   |                                                                                                                     |
 | `trace_gen`                       | Prints all the strings written to the generated C file. Very verbose.                                               |
 | `trace_cgen_stmt`                 | Prints details about the statements that are being processed by cgen.                                               |
-|                                   | Use it for panics in cgen, to see the closest input V source line, that caused the panic.                           |
-|                                   | Note: you need `v -no-parallel -d trace_cgen_stmt -o w cmd/v` to make sense of the output of that,                  |
-|                                   | otherwise by default cgen uses several threads, and the lines that are printed are out of order.                    |
+|                                   |        Use it for panics in cgen, to see the closest input V source line, that caused the panic.                    |
+|                                   |        Note: you need `v -no-parallel -d trace_cgen_stmt -o w cmd/v` to make sense of the output of that,           |
+|                                   |        otherwise by default cgen uses several threads, and the lines that are printed are out of order.             |
 |                                   |                                                                                                                     |
 | `trace_autofree`                  | Prints details about how/when -autofree puts free() calls                                                           |
 | `trace_autostr`                   | Prints details about `.str()` method auto-generated by the compiler during C generation                             |
@@ -298,4 +298,4 @@ a copy of the compiler rather than replacing it with `v self`.
 | `trace_thirdparty_obj_files`      | Prints details about built thirdparty obj files                                                                     |
 | `trace_usecache`                  | Prints details when -usecache is used                                                                               |
 | `trace_embed_file`                | Prints details when $embed_file is used                                                                             |
-| `embed_only_metadata`             | Embed only the metadata for the file(s) with `$embed_file('somefile')`; faster; for development, _not_ distribution |
+| `embed_only_metadata`             | Embed only the metadata for the file(s) with `$embed_file('somefile')`; faster; for development, *not* distribution |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,11 @@ The main files are:
 
 1. `cmd/v/v.v` The entry point.
 
-    - V figures out the build mode.
-    - Constructs the compiler object (`struct V`).
-    - Creates a list of .v files that need to be parsed.
-    - Creates a parser object for each file and runs `parse()` on them.
-    - The correct backend is called (C, JS, native), and a binary is compiled.
+   - V figures out the build mode.
+   - Constructs the compiler object (`struct V`).
+   - Creates a list of .v files that need to be parsed.
+   - Creates a parser object for each file and runs `parse()` on them.
+   - The correct backend is called (C, JS, native), and a binary is compiled.
 
 2. `vlib/v/scanner` The scanner's job is to parse a list of characters and convert
    them to tokens.
@@ -84,9 +84,9 @@ accordingly in the steps below.)
    `https://github.com/YOUR_GITHUB_USERNAME/v` .
 2. Clone the main v repository https://github.com/vlang/v to a local folder on
    your computer, say named nv/ (`git clone https://github.com/vlang/v nv`)
-3. `cd nv`   
-3.1 (optional) Run these commands, which ensure that all your code will be 
-   automatically formatted, before commiting:
+3. `cd nv`
+   3.1 (optional) Run these commands, which ensure that all your code will be
+   automatically formatted, before committing:
    ```
    cp cmd/tools/git_pre_commit_hook.vsh .git/hooks/pre-commit
    chmod 755 .git/hooks/pre-commit
@@ -99,10 +99,9 @@ accordingly in the steps below.)
    `git pull` `git status` and so on.
 
 5. When finished with a feature/bugfix/change, you can:
-`git checkout -b fix_alabala`
+   `git checkout -b fix_alabala`
    - Don't forget to keep formatting standards, run `v fmt -w YOUR_MODIFIED_FILES`
-   before committing (if you have not run the commands from 3.1)
-   
+     before committing (if you have not run the commands from 3.1)
 6. `git push pullrequest` Note: The `pullrequest` remote was setup on step 4
 
 7. On GitHub's web interface, go to: https://github.com/vlang/v/pulls
@@ -118,13 +117,13 @@ accordingly in the steps below.)
 9. If there are merge conflicts, or a branch lags too much behind V's master,
    you can do the following:
 
-    1. `git pull --rebase origin master` # solve conflicts and do
-       `git rebase --continue`
-    2. `git push pullrequest -f` # this will overwrite your current remote branch
-       with the updated version of your changes.
+   1. `git pull --rebase origin master` # solve conflicts and do
+      `git rebase --continue`
+   2. `git push pullrequest -f` # this will overwrite your current remote branch
+      with the updated version of your changes.
 
 The point of doing the above steps, is to never directly push to the main V
-repository, *only to your own fork*. Since your local `master` branch tracks the
+repository, _only to your own fork_. Since your local `master` branch tracks the
 main V repository's master, then `git checkout master`, as well as
 `git pull --rebase origin master` will continue to work as expected
 (these are actually used by `v up`) and git can always do it cleanly.
@@ -135,10 +134,11 @@ information.
 
 ## Finding issues to contribute to
 
-If you're willing to contribute to V but don't know which issue to resolve 
+If you're willing to contribute to V but don't know which issue to resolve
+
 - you can go to [Issues](https://github.com/vlang/v/issues) tab
-in this repository. There you can see things logged by both users and developers
-that need to be discussed and/or resolved.
+  in this repository. There you can see things logged by both users and developers
+  that need to be discussed and/or resolved.
 
 It's recommended to filter issues by likes and labels to find an issue
 you are interested in.
@@ -168,22 +168,25 @@ You can examine the list of labels [here](https://github.com/vlang/v/labels).
 The most common labels are:
 
 By issue type:
+
 - `Bug`
 - `Feature Request`
 
 By OS:
+
 - `OS: Linux`
 - `OS: Windows`
 - `OS: Mac`
 
 By status:
+
 - `Status: Confirmed`
 
 To apply this filter, navigate to [Issues](https://github.com/vlang/v/issues)
 tab, then paste the following in the "Filter" field:
 
 ```
-is:open is:issue label:Bug label:"OS: Windows" label:"Status: Confirmed" 
+is:open is:issue label:Bug label:"OS: Windows" label:"Status: Confirmed"
 ```
 
 This filter will return all open issues with the labels `Bug`, `OS: Windows`,
@@ -201,20 +204,20 @@ command.
 
 ### Preparation:
 
-(steps 1..3 need to be done just *once*):
+(steps 1..3 need to be done just _once_):
 
 1. `hub clone vlang/v my_v`
 2. `cd my_v`
-2.1 (optional) Run these commands, which ensure that all your code will be 
-   automatically formatted, before commiting:
+   2.1 (optional) Run these commands, which ensure that all your code will be
+   automatically formatted, before committing:
    ```
    cp cmd/tools/git_pre_commit_hook.vsh .git/hooks/pre-commit
    chmod 755 .git/hooks/pre-commit
    ```
 3. `hub fork --remote-name pullrequest`
 
-4. `git checkout -b my_cool_feature` # Step 4 is better done *once per each new
-   feature/bugfix* that you make.
+4. `git checkout -b my_cool_feature` # Step 4 is better done _once per each new
+   feature/bugfix_ that you make.
 
 ### Improve V by making commits:
 
@@ -254,22 +257,22 @@ V allows you to pass custom flags using `-d my_flag` that can then be checked
 at compile time (see the documentation about
 [compile-time if](https://github.com/vlang/v/blob/master/doc/docs.md#compile-time-if)).
 
-Since the compiler is *also* an ordinary V program, there are numerous flags that can be
+Since the compiler is _also_ an ordinary V program, there are numerous flags that can be
 passed when building the compiler itself with `v self`, or when creating a copy of the
 compiler, that will help you when debugging the compiler.
 
-Note: beware that the flags below must be passed, when building the compiler, *not the program*,
+Note: beware that the flags below must be passed, when building the compiler, _not the program_,
 so do for example:
 `./v -o w -d time_parsing cmd/v`
 or
 `./v -o w -d trace_checker self`
 ... then use `./w file.v`, instead of `./v file.v`, to compile your program.
 
-Note: some of the flags can make the compiler *very verbose*, so it is recommended to create
+Note: some of the flags can make the compiler _very verbose_, so it is recommended to create
 a copy of the compiler rather than replacing it with `v self`.
 
 | Flag                              | Usage                                                                                                               |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `debugscanner`                    | Prints debug information during the scanning phase                                                                  |
 | `debug_codegen`                   | Prints automatically generated V code during the scanning phase                                                     |
 | `debug_interface_table`           | Prints generated interfaces during C generation                                                                     |
@@ -285,9 +288,9 @@ a copy of the compiler rather than replacing it with `v self`.
 |                                   |                                                                                                                     |
 | `trace_gen`                       | Prints all the strings written to the generated C file. Very verbose.                                               |
 | `trace_cgen_stmt`                 | Prints details about the statements that are being processed by cgen.                                               |
-|                                   |        Use it for panics in cgen, to see the closest input V source line, that caused the panic.                    |
-|                                   |        Note: you need `v -no-parallel -d trace_cgen_stmt -o w cmd/v` to make sense of the output of that,           |
-|                                   |        otherwise by default cgen uses several threads, and the lines that are printed are out of order.             |
+|                                   | Use it for panics in cgen, to see the closest input V source line, that caused the panic.                           |
+|                                   | Note: you need `v -no-parallel -d trace_cgen_stmt -o w cmd/v` to make sense of the output of that,                  |
+|                                   | otherwise by default cgen uses several threads, and the lines that are printed are out of order.                    |
 |                                   |                                                                                                                     |
 | `trace_autofree`                  | Prints details about how/when -autofree puts free() calls                                                           |
 | `trace_autostr`                   | Prints details about `.str()` method auto-generated by the compiler during C generation                             |
@@ -295,4 +298,4 @@ a copy of the compiler rather than replacing it with `v self`.
 | `trace_thirdparty_obj_files`      | Prints details about built thirdparty obj files                                                                     |
 | `trace_usecache`                  | Prints details when -usecache is used                                                                               |
 | `trace_embed_file`                | Prints details when $embed_file is used                                                                             |
-| `embed_only_metadata`             | Embed only the metadata for the file(s) with `$embed_file('somefile')`; faster; for development, *not* distribution |
+| `embed_only_metadata`             | Embed only the metadata for the file(s) with `$embed_file('somefile')`; faster; for development, _not_ distribution |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,5 @@
 ## [Version 0.3]
+
 - [x] gc option
 - [x] channels
 - [x] lock{}
@@ -50,7 +51,7 @@
 - [ ] Cross compilation of C
 - [ ] Big remaining bugs fixed
 - [ ] More powerful comptime
-- [ ] Constraits for generics
+- [ ] Constrains for generics
 - [ ] Coroutines on Windows
 - [ ] Autofree memory management option ready for production
 - [ ] C2V supporting entire C99 standard

--- a/bench/vectors/README.md
+++ b/bench/vectors/README.md
@@ -1,4 +1,5 @@
-# Running the C# program:
+Running the C# program:
+====================================
 
 ```
 dotnet run
@@ -15,7 +16,8 @@ The generated executable will be in
 Its size is ~64MB . After stripping, the executable shrinks to just 11MB,
 but unfortunately it also stops running after stripping :-| .
 
-## Compiling and running the V program:
+Compiling and running the V program:
+====================================
 
 ```
 v crun vectors.v
@@ -34,11 +36,12 @@ After stripping, the executable shrinks to 157KB. It can still run after
 stripping.
 
 Note: using `crun` will make sure that the compilation will happen just
-once at the start, and then the executable will be reused by the subsequent
-commands with identical options. It will also ensure that the compiled
-executable will not be removed, unlike `run` .
+once at the start, and then the executable will be just reused by the
+subsequent commands with identical options. It will also ensure that
+the compiled executable will not be removed, unlike `run` .
 
-## Some measurements and comparisons
+Some measurements and comparisons
+====================================
 
 Note: the following was done on Intel(R) Core(TM) i3-3225, 16GB RAM:
 

--- a/bench/vectors/README.md
+++ b/bench/vectors/README.md
@@ -1,10 +1,11 @@
-Running the C# program:
-====================================
+# Running the C# program:
+
 ```
 dotnet run
 ```
 
 Creating a release version of the C# program:
+
 ```
 dotnet publish -c Release -r ubuntu.20.04-x64
 ```
@@ -14,51 +15,52 @@ The generated executable will be in
 Its size is ~64MB . After stripping, the executable shrinks to just 11MB,
 but unfortunately it also stops running after stripping :-| .
 
-Compiling and running the V program:
-====================================
+## Compiling and running the V program:
+
 ```
 v crun vectors.v
 ```
-... produces and runs an executable `vectors` which is ~1.3MB in size.
 
+... produces and runs a `vectors` executable which is ~1.3MB in size.
 
 Compiling and running the V program, compiled with -prod:
+
 ```
 v -prod crun vectors.v
 ```
-... produces and runs an executable `vectors` which is ~176KB in size.
+
+... produces and runs a `vectors` executable which is ~176KB in size.
 After stripping, the executable shrinks to 157KB. It can still run after
 stripping.
 
-
 Note: using `crun` will make sure that the compilation will happen just
-once at the start, and then the executable will be just reused by the
-subsequent commands with identical options. It will also ensure that
-the compiled executable will not be removed, unlike `run` .
+once at the start, and then the executable will be reused by the subsequent
+commands with identical options. It will also ensure that the compiled
+executable will not be removed, unlike `run` .
 
+## Some measurements and comparisons
 
-Some measurements and comparisons
-====================================
-Note: the folowing was done on Intel(R) Core(TM) i3-3225, 16GB RAM:
+Note: the following was done on Intel(R) Core(TM) i3-3225, 16GB RAM:
+
 ```
 #0 13:41:35 ᛋ master /v/vnew/bench/vectors❱rm -rf vectors
 #0 13:41:49 ᛋ master /v/vnew/bench/vectors❱
-#0 13:41:49 ᛋ master /v/vnew/bench/vectors❱v -o vectors_development vectors.v 
-#0 13:42:14 ᛋ master /v/vnew/bench/vectors❱v -o vectors_production -prod vectors.v 
+#0 13:41:49 ᛋ master /v/vnew/bench/vectors❱v -o vectors_development vectors.v
+#0 13:42:14 ᛋ master /v/vnew/bench/vectors❱v -o vectors_production -prod vectors.v
 #0 13:42:28 ᛋ master /v/vnew/bench/vectors❱
 #0 13:42:29 ᛋ master /v/vnew/bench/vectors❱hyperfine ./bin/Release/net7.0/ubuntu.20.04-x64/publish/vectors ./vectors_development ./vectors_production
 Benchmark 1: ./bin/Release/net7.0/ubuntu.20.04-x64/publish/vectors
   Time (mean ± σ):     347.4 ms ±   7.4 ms    [User: 334.4 ms, System: 13.0 ms]
   Range (min … max):   340.2 ms … 361.7 ms    10 runs
- 
+
 Benchmark 2: ./vectors_development
   Time (mean ± σ):     882.6 ms ±  14.0 ms    [User: 880.3 ms, System: 2.3 ms]
   Range (min … max):   862.4 ms … 912.9 ms    10 runs
- 
+
 Benchmark 3: ./vectors_production
   Time (mean ± σ):     217.9 ms ±   9.4 ms    [User: 216.8 ms, System: 0.9 ms]
   Range (min … max):   206.4 ms … 241.3 ms    12 runs
- 
+
 Summary
   ./vectors_production ran
     1.59 ± 0.08 times faster than ./bin/Release/net7.0/ubuntu.20.04-x64/publish/vectors
@@ -69,8 +71,8 @@ Summary
 -rwxrwxr-x 1 1000 1000  1320764 Sep  6 13:42 ./vectors_development
 -rwxr-xr-x 1 1000 1000 66732821 Sep  6 13:40 ./bin/Release/net7.0/ubuntu.20.04-x64/publish/vectors
 #0 13:45:12 ᛋ master /v/vnew/bench/vectors❱
-#0 13:53:12 ᛋ master /v/vnew/bench/vectors❱alias xtime='/usr/bin/time -f "CPU: %Us\tReal: %es\tElapsed: %E\tRAM: %MKB\t%C"' 
-#0 13:53:42 ᛋ master /v/vnew/bench/vectors❱xtime ./vectors_development 
+#0 13:53:12 ᛋ master /v/vnew/bench/vectors❱alias xtime='/usr/bin/time -f "CPU: %Us\tReal: %es\tElapsed: %E\tRAM: %MKB\t%C"'
+#0 13:53:42 ᛋ master /v/vnew/bench/vectors❱xtime ./vectors_development
 5.0498380931718074e+07 - 5.0504723697762154e+07 - 5.040198063489048e+07
 0.0 - 0.0 - 0.0
 CPU: 0.87s      Real: 0.87s     Elapsed: 0:00.87        RAM: 4404KB     ./vectors_development
@@ -84,10 +86,10 @@ CPU: 0.20s      Real: 0.20s     Elapsed: 0:00.20        RAM: 3228KB     ./vector
 CPU: 0.33s      Real: 0.34s     Elapsed: 0:00.34        RAM: 30544KB    ./bin/Release/net7.0/ubuntu.20.04-x64/publish/vectors
 #0 13:54:02 ᛋ master /v/vnew/bench/vectors❱
 #0 14:01:33 ᛋ master /v/vnew/bench/vectors❱
-#0 14:01:35 ᛋ master /v/vnew/bench/vectors❱xtime v vectors.v 
+#0 14:01:35 ᛋ master /v/vnew/bench/vectors❱xtime v vectors.v
 CPU: 0.41s      Real: 0.36s     Elapsed: 0:00.36        RAM: 59412KB    v vectors.v
 #0 14:01:41 ᛋ master /v/vnew/bench/vectors❱
-#0 14:01:42 ᛋ master /v/vnew/bench/vectors❱xtime v -prod vectors.v 
+#0 14:01:42 ᛋ master /v/vnew/bench/vectors❱xtime v -prod vectors.v
 CPU: 4.97s      Real: 5.11s     Elapsed: 0:05.11        RAM: 80732KB    v -prod vectors.v
 #0 14:01:48 ᛋ master /v/vnew/bench/vectors❱
 #0 14:01:50 ᛋ master /v/vnew/bench/vectors❱xtime dotnet publish -c Release -r ubuntu.20.04-x64

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -260,7 +260,7 @@ fn test_bf_pos() {
 	 * set haystack size to 80
 	 * test different sizes of needle, from 1 to 80
 	 * test different positions of needle, from 0 to where it fits
-	 * all haystacks here contain exactly one instanse of needle,
+	 * all haystacks here contain exactly one instance of needle,
 	 * so search should return non-negative-values
 	*
 	*/

--- a/vlib/datatypes/bloom_filter.v
+++ b/vlib/datatypes/bloom_filter.v
@@ -38,7 +38,7 @@ fn (b &BloomFilter[T]) free() {
 	}
 }
 
-// new_bloom_filter_fast create a new bloom_filter. `table_size` is 16384 , and `num_functions` is 4
+// new_bloom_filter_fast creates a new bloom_filter. `table_size` is 16384, and `num_functions` is 4.
 pub fn new_bloom_filter_fast[T](hash_func fn (T) u32) &BloomFilter[T] {
 	return &BloomFilter[T]{
 		hash_func: hash_func
@@ -48,7 +48,7 @@ pub fn new_bloom_filter_fast[T](hash_func fn (T) u32) &BloomFilter[T] {
 	}
 }
 
-// new_bloom_filter create a new bloom_filter. `table_size` should greate than 0 , and `num_functions` should be 1~16
+// new_bloom_filter creates a new bloom_filter. `table_size` should be greater than 0, and `num_functions` should be 1~16.
 pub fn new_bloom_filter[T](hash_func fn (T) u32, table_size int, num_functions int) !&BloomFilter[T] {
 	if table_size <= 0 {
 		return error('table_size should great that 0')

--- a/vlib/datatypes/bloom_filter_test.v
+++ b/vlib/datatypes/bloom_filter_test.v
@@ -10,10 +10,10 @@ fn hash_func(s string) u32 {
 fn test_bloom_filter_fast() {
 	mut b := new_bloom_filter_fast[string](hash_func)
 	b.add('hello world')
-	b.add('v is awsome')
+	b.add('v is awesome')
 	b.add('power by v')
 	assert b.exists('hello world') == true
-	assert b.exists('v is awsome') == true
+	assert b.exists('v is awesome') == true
 	assert b.exists('power by v') == true
 	assert b.exists('my world') == false
 }
@@ -21,10 +21,10 @@ fn test_bloom_filter_fast() {
 fn test_bloom_filter_fast_normal() {
 	mut b := new_bloom_filter[string](hash_func, 65536, 16) or { panic(err) }
 	b.add('hello world')
-	b.add('v is awsome')
+	b.add('v is awesome')
 	b.add('power by v')
 	assert b.exists('hello world') == true
-	assert b.exists('v is awsome') == true
+	assert b.exists('v is awesome') == true
 	assert b.exists('power by v') == true
 	assert b.exists('my world') == false
 }
@@ -33,10 +33,10 @@ fn test_bloom_filter_false_positive() {
 	// every `add` will set 8 bits in the table(total length = 16), so overflow very quickly
 	mut b := new_bloom_filter[string](hash_func, 16, 8) or { panic(err) }
 	b.add('hello world')
-	b.add('v is awsome')
+	b.add('v is awesome')
 	b.add('power by v')
 	assert b.exists('hello world') == true
-	assert b.exists('v is awsome') == true
+	assert b.exists('v is awesome') == true
 	assert b.exists('power by v') == true
 	assert b.exists('my world') == true // false positive
 }
@@ -50,7 +50,7 @@ fn test_bloom_filter_fast_union_intersection() {
 	a.add('super rust')
 
 	b.add('hello world')
-	b.add('v is awsome')
+	b.add('v is awesome')
 	b.add('power by v')
 
 	assert a.exists('power by v') == true
@@ -59,7 +59,7 @@ fn test_bloom_filter_fast_union_intersection() {
 	assert a.exists('power c++') == false
 
 	assert b.exists('hello world') == true
-	assert b.exists('v is awsome') == true
+	assert b.exists('v is awesome') == true
 	assert b.exists('power by v') == true
 	assert b.exists('my world') == false
 
@@ -69,7 +69,7 @@ fn test_bloom_filter_fast_union_intersection() {
 	assert c.exists('super rust') == true
 	assert c.exists('power c++') == false
 	assert c.exists('hello world') == true
-	assert c.exists('v is awsome') == true
+	assert c.exists('v is awesome') == true
 	assert c.exists('power by v') == true
 	assert c.exists('my world') == false
 
@@ -79,7 +79,7 @@ fn test_bloom_filter_fast_union_intersection() {
 	assert d.exists('super rust') == false
 	assert d.exists('power c++') == false
 	assert d.exists('hello world') == false
-	assert d.exists('v is awsome') == false
+	assert d.exists('v is awesome') == false
 	assert d.exists('power by v') == true
 	assert d.exists('my world') == false
 }

--- a/vlib/datatypes/bstree.v
+++ b/vlib/datatypes/bstree.v
@@ -1,6 +1,6 @@
 module datatypes
 
-/// Internal rapresentation of the tree node
+/// Internal representation of the tree node
 [heap]
 struct BSTreeNode[T] {
 mut:
@@ -234,7 +234,7 @@ fn (bst &BSTree[T]) pre_order_traversal_helper(node &BSTreeNode[T], mut result [
 	bst.pre_order_traversal_helper(node.right, mut result)
 }
 
-// get_node is a helper method to ge the internal rapresentation of the node with the `value`.
+// get_node is a helper method to ge the internal representation of the node with the `value`.
 fn (bst &BSTree[T]) get_node(node &BSTreeNode[T], value T) &BSTreeNode[T] {
 	if unsafe { node == 0 } || !node.is_init {
 		return new_none_node[T](false)

--- a/vlib/datatypes/bstree_test.v
+++ b/vlib/datatypes/bstree_test.v
@@ -86,7 +86,7 @@ fn test_get_left_on_empty_bst() {
 }
 
 // Check the remove operation if it is able to remove
-// all elements required, and mantains the BST propriety.
+// all elements required, and maintains the BST propriety.
 fn test_remove_from_bst_one() {
 	mut bst := BSTree[int]{}
 	assert bst.insert(10)

--- a/vlib/db/mysql/mysql_orm_test.v
+++ b/vlib/db/mysql/mysql_orm_test.v
@@ -29,7 +29,7 @@ mut:
 	deleted_at time.Time
 }
 
-struct TestDefaultAtribute {
+struct TestDefaultAttribute {
 	id         string [primary; sql: serial]
 	name       string
 	created_at string [default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
@@ -205,13 +205,13 @@ fn test_mysql_orm() {
 	/** test default attribute
 	*/
 	sql db {
-		create table TestDefaultAtribute
+		create table TestDefaultAttribute
 	}!
 
 	mut result_defaults := db.query("
 		SELECT COLUMN_DEFAULT
 		FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_NAME = 'TestDefaultAtribute'
+		WHERE TABLE_NAME = 'TestDefaultAttribute'
 		ORDER BY ORDINAL_POSITION
 	") or {
 		println(err)
@@ -220,7 +220,7 @@ fn test_mysql_orm() {
 	mut information_schema_defaults_results := []string{}
 
 	sql db {
-		drop table TestDefaultAtribute
+		drop table TestDefaultAttribute
 	}!
 
 	information_schema_column_default_sql := [{

--- a/vlib/db/pg/pg_orm_test.v
+++ b/vlib/db/pg/pg_orm_test.v
@@ -29,7 +29,7 @@ mut:
 	deleted_at time.Time
 }
 
-struct TestDefaultAtribute {
+struct TestDefaultAttribute {
 	id         string [default: 'gen_random_uuid()'; primary; sql_type: 'uuid']
 	name       string
 	created_at string [default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
@@ -202,13 +202,13 @@ fn test_pg_orm() {
 	/** test default attribute
 	*/
 	sql db {
-		create table TestDefaultAtribute
+		create table TestDefaultAttribute
 	}!
 
 	mut result_defaults := db.exec("
 		SELECT column_default
 		FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_NAME = 'TestDefaultAtribute'
+		WHERE TABLE_NAME = 'TestDefaultAttribute'
 		ORDER BY ORDINAL_POSITION
 	") or {
 		println(err)
@@ -220,7 +220,7 @@ fn test_pg_orm() {
 		information_schema_defaults_results << defaults.vals[0]
 	}
 	sql db {
-		drop table TestDefaultAtribute
+		drop table TestDefaultAttribute
 	}!
 	assert ['gen_random_uuid()', '', 'CURRENT_TIMESTAMP'] == information_schema_defaults_results
 }

--- a/vlib/db/sqlite/sqlite_orm_test.v
+++ b/vlib/db/sqlite/sqlite_orm_test.v
@@ -13,7 +13,7 @@ struct TestCustomSqlType {
 	custom6 time.Time
 }
 
-struct TestDefaultAtribute {
+struct TestDefaultAttribute {
 	id          string  [primary; sql: serial]
 	name        string
 	created_at  ?string [default: 'CURRENT_TIME']
@@ -124,11 +124,11 @@ fn test_sqlite_orm() {
 	*/
 
 	sql db {
-		create table TestDefaultAtribute
+		create table TestDefaultAttribute
 	}!
 
 	mut result_default_sql := db.exec('
-			pragma table_info(TestDefaultAtribute);
+			pragma table_info(TestDefaultAttribute);
 		')!
 
 	mut information_schema_data_types_results := []string{}
@@ -139,29 +139,29 @@ fn test_sqlite_orm() {
 	}
 	assert information_schema_data_types_results == information_schema_default_sql
 
-	test_default_atribute := TestDefaultAtribute{
+	test_default_attribute := TestDefaultAttribute{
 		name: 'Hitalo'
 	}
 
 	sql db {
-		insert test_default_atribute into TestDefaultAtribute
+		insert test_default_attribute into TestDefaultAttribute
 	}!
 
-	test_default_atributes := sql db {
-		select from TestDefaultAtribute limit 1
+	test_default_attributes := sql db {
+		select from TestDefaultAttribute limit 1
 	}!
 
-	result_test_default_atribute := test_default_atributes.first()
-	assert result_test_default_atribute.name == 'Hitalo'
-	assert test_default_atribute.created_at or { '' } == ''
-	assert test_default_atribute.created_at1 or { '' } == ''
-	assert test_default_atribute.created_at2 or { '' } == ''
-	assert result_test_default_atribute.created_at or { '' }.len == 8 // HH:MM:SS
-	assert result_test_default_atribute.created_at1 or { '' }.len == 10 // YYYY-MM-DD
-	assert result_test_default_atribute.created_at2 or { '' }.len == 19 // YYYY-MM-DD HH:MM:SS
+	result_test_default_attribute := test_default_attributes.first()
+	assert result_test_default_attribute.name == 'Hitalo'
+	assert test_default_attribute.created_at or { '' } == ''
+	assert test_default_attribute.created_at1 or { '' } == ''
+	assert test_default_attribute.created_at2 or { '' } == ''
+	assert result_test_default_attribute.created_at or { '' }.len == 8 // HH:MM:SS
+	assert result_test_default_attribute.created_at1 or { '' }.len == 10 // YYYY-MM-DD
+	assert result_test_default_attribute.created_at2 or { '' }.len == 19 // YYYY-MM-DD HH:MM:SS
 
 	sql db {
-		drop table TestDefaultAtribute
+		drop table TestDefaultAttribute
 	}!
 }
 

--- a/vlib/gx/color_test.v
+++ b/vlib/gx/color_test.v
@@ -80,7 +80,7 @@ fn test_over() {
 	semi_r := gx.Color{255, 0, 0, 128}
 	semi_g := gx.Color{0, 255, 0, 128}
 	semi_b := gx.Color{0, 0, 255, 128}
-	// fully opaque colors, should be preserved when layed *over* any others:
+	// fully opaque colors, should be preserved when laid *over* any others:
 	assert b.over(g) == b
 	assert r.over(g) == r
 	assert y.over(r) == y

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -22,7 +22,7 @@ pub fn (l &Log) get_level() Level {
 	return l.level
 }
 
-// set_level sets the logging level to `level`. Messges for levels above it will skipped.
+// set_level sets the logging level to `level`. Messages for levels above it will skipped.
 // For example, after calling log.set_level(.info), log.debug('message') will produce nothing.
 // Call log.set_level(.disabled) to turn off the logging of all messages.
 pub fn (mut l Log) set_level(level Level) {

--- a/vlib/picoev/loop_freebsd.c.v
+++ b/vlib/picoev/loop_freebsd.c.v
@@ -4,7 +4,7 @@ module picoev
 #include <sys/types.h>
 #include <sys/event.h>
 
-fn C.kevent(int, changelist voidptr, nchanges int, eventlist voidptr, nevents int, timout &C.timespec) int
+fn C.kevent(int, changelist voidptr, nchanges int, eventlist voidptr, nevents int, timeout &C.timespec) int
 fn C.kqueue() int
 fn C.EV_SET(kev voidptr, ident int, filter i16, flags u16, fflags u32, data voidptr, udata voidptr)
 

--- a/vlib/picoev/loop_macos.c.v
+++ b/vlib/picoev/loop_macos.c.v
@@ -4,7 +4,7 @@ module picoev
 #include <sys/types.h>
 #include <sys/event.h>
 
-fn C.kevent(int, changelist voidptr, nchanges int, eventlist voidptr, nevents int, timout &C.timespec) int
+fn C.kevent(int, changelist voidptr, nchanges int, eventlist voidptr, nevents int, timeout &C.timespec) int
 fn C.kqueue() int
 fn C.EV_SET(kev voidptr, ident int, filter i16, flags u16, fflags u32, data voidptr, udata voidptr)
 

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -99,7 +99,7 @@ fn fatal_socket_error(fd int) bool {
 	return true
 }
 
-// listen creates a listening tcp socket and returns its file decriptor
+// listen creates a listening tcp socket and returns its file descriptor
 fn listen(config Config) int {
 	// not using the `net` modules sockets, because not all socket options are defined
 	fd := C.socket(net.AddrFamily.ip, net.SocketType.tcp, 0)

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -407,7 +407,7 @@ pub fn (mut rng PRNG) binomial(n int, p f64) !int {
 	return count
 }
 
-// exponential returns an exponentially distributed random number with the rate paremeter
+// exponential returns an exponentially distributed random number with the rate parameter
 // lambda. It is expected that lambda is positive.
 pub fn (mut rng PRNG) exponential(lambda f64) f64 {
 	if lambda <= 0 {
@@ -748,7 +748,7 @@ pub fn binomial(n int, p f64) !int {
 	return default_rng.binomial(n, p)
 }
 
-// exponential returns an exponentially distributed random number with the rate paremeter
+// exponential returns an exponentially distributed random number with the rate parameter
 // lambda. It is expected that lambda is positive.
 pub fn exponential(lambda f64) f64 {
 	return default_rng.exponential(lambda)

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -334,7 +334,7 @@ fn converter(mut pn PrepNumber) u64 {
 	*/
 
 	// C.printf(c"mantissa before rounding: %08x%08x%08x binexp: %d \n", s2,s1,s0,binexp)
-	// s1 => 0xFFFFFFxx only F are rapresented
+	// s1 => 0xFFFFFFxx only F are represented
 	nbit := 7
 	check_round_bit := u32(1) << u32(nbit)
 	check_round_mask := u32(0xFFFFFFFF) << u32(nbit)

--- a/vlib/term/term.js.v
+++ b/vlib/term/term.js.v
@@ -1,16 +1,16 @@
 module term
 
 #const $tty = require('tty');
-// get_terminal_size returns a number of colums and rows of terminal window.
+// get_terminal_size returns a number of columns and rows of terminal window.
 pub fn get_terminal_size() (int, int) {
 	$if js_node {
-		colums := 0
+		cols := 0
 		rows := 0
 		#let sizes = $tty.WriteStream(1).getWindowSize();
-		#colums.val = sizes[0];
+		#cols.val = sizes[0];
 		#rows.val = sizes[1];
 
-		return colums, rows
+		return cols, rows
 	} $else {
 		return default_columns_size, default_rows_size
 	}

--- a/vlib/term/term_nix.c.v
+++ b/vlib/term/term_nix.c.v
@@ -15,7 +15,7 @@ pub:
 
 fn C.ioctl(fd int, request u64, arg voidptr) int
 
-// get_terminal_size returns a number of colums and rows of terminal window.
+// get_terminal_size returns a number of columns and rows of terminal window.
 pub fn get_terminal_size() (int, int) {
 	if os.is_atty(1) <= 0 || os.getenv('TERM') == 'dumb' {
 		return default_columns_size, default_rows_size

--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -180,7 +180,7 @@ fn supports_truecolor() bool {
 	if os.getenv('COLORTERM') in ['truecolor', '24bit'] {
 		return true
 	}
-	// set the bg color to some arbirtrary value (#010203), assumed not to be the default
+	// set the bg color to some arbitrary value (#010203), assumed not to be the default
 	print('\x1b[48:2:1:2:3m')
 	flush_stdout()
 	// andquery the current color

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -490,7 +490,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 								if r is ast.Ident {
 									obj := r.obj
 									if obj is ast.Var && !obj.is_mut {
-										c.warn('cannot add a referenece to an immutable object to a mutable array',
+										c.warn('cannot add a reference to an immutable object to a mutable array',
 											elem_expr.pos)
 									}
 								}
@@ -553,7 +553,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 		if left_sym.kind == .function && right_sym.info is ast.FnType {
 			return_sym := c.table.sym(right_sym.info.func.return_type)
 			if return_sym.kind == .placeholder {
-				c.error('unkown return type: cannot assign `${right}` as a function variable',
+				c.error('unknown return type: cannot assign `${right}` as a function variable',
 					right.pos())
 			} else if (!right_sym.info.is_anon && return_sym.kind == .any)
 				|| (return_sym.info is ast.Struct && return_sym.info.is_generic) {

--- a/vlib/v/checker/tests/array_of_refs_mutability.out
+++ b/vlib/v/checker/tests/array_of_refs_mutability.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/array_of_refs_mutability.vv:11:14: warning: cannot add a referenece to an immutable object to a mutable array
+vlib/v/checker/tests/array_of_refs_mutability.vv:11:14: warning: cannot add a reference to an immutable object to a mutable array
     9 |     }
    10 | 
    11 |     mut arr := [&x]
       |                 ^
    12 |     arr[0].bar = 30
    13 |
-vlib/v/checker/tests/array_of_refs_mutability.vv:15:10: warning: cannot add a referenece to an immutable object to a mutable array
+vlib/v/checker/tests/array_of_refs_mutability.vv:15:10: warning: cannot add a reference to an immutable object to a mutable array
    13 | 
    14 |     mut arr2 := [&Foo{}]
    15 |     arr2 = [&x]

--- a/vlib/v/checker/tests/invalid_insert_references_test.out
+++ b/vlib/v/checker/tests/invalid_insert_references_test.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/invalid_insert_references_test.vv:4:12: warning: cannot add a referenece to an immutable object to a mutable array
+vlib/v/checker/tests/invalid_insert_references_test.vv:4:12: warning: cannot add a reference to an immutable object to a mutable array
     2 | fn test_invalid_insert_references() {
     3 |     b := 0
     4 |     mut a := [&b]

--- a/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
+++ b/vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.out
@@ -5,7 +5,7 @@ Did you mean `[2]fn (u32) UnknownThing`?
       |                         ~~~~~~~~~~~~
     3 | }
     4 |
-vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv:6:18: error: unkown return type: cannot assign `virt.fns[0]` as a function variable
+vlib/v/checker/tests/unknown_array_fn_type_in_struct_field.vv:6:18: error: unknown return type: cannot assign `virt.fns[0]` as a function variable
     4 | 
     5 | fn (virt Virt) caller() {
     6 |     func := virt.fns[0]

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -327,13 +327,13 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 			last_import_stmt_idx = sidx
 		}
 	}
-	mut preceeding_comments := []DocComment{}
+	mut preceding_comments := []DocComment{}
 	// mut imports_section := true
 	for sidx, mut stmt in file_ast.stmts {
 		if mut stmt is ast.ExprStmt {
 			// Collect comments
 			if mut stmt.expr is ast.Comment {
-				preceeding_comments << ast_comment_to_doc_comment(stmt.expr)
+				preceding_comments << ast_comment_to_doc_comment(stmt.expr)
 				continue
 			}
 		}
@@ -343,13 +343,13 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 				continue
 			}
 			// the previous comments were probably a copyright/license one
-			module_comment := merge_doc_comments(preceeding_comments)
-			preceeding_comments = []
+			module_comment := merge_doc_comments(preceding_comments)
+			preceding_comments = []
 			if !d.is_vlib && !module_comment.starts_with('Copyright (c)') {
 				if module_comment == '' {
 					continue
 				}
-				d.head.comments << preceeding_comments
+				d.head.comments << preceding_comments
 			}
 			continue
 		}
@@ -357,16 +357,16 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 			// the accumulated comments were interspersed before/between the imports;
 			// just add them all to the module comments:
 			if d.with_head {
-				d.head.comments << preceeding_comments
+				d.head.comments << preceding_comments
 			}
-			preceeding_comments = []
+			preceding_comments = []
 			// imports_section = false
 		}
 		if stmt is ast.Import {
 			continue
 		}
 		mut node := d.stmt(mut stmt, os.base(file_ast.path)) or {
-			preceeding_comments = []
+			preceding_comments = []
 			continue
 		}
 		if node.parent_name !in contents {
@@ -380,10 +380,10 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 				kind: parent_node_kind
 			}
 		}
-		if d.with_comments && preceeding_comments.len > 0 {
-			node.comments << preceeding_comments
+		if d.with_comments && preceding_comments.len > 0 {
+			node.comments << preceding_comments
 		}
-		preceeding_comments = []
+		preceding_comments = []
 		if node.parent_name.len > 0 {
 			parent_name := node.parent_name
 			if node.parent_name == 'Constants' {

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -276,7 +276,7 @@ pub fn (mut e Eval) register_symbol(stmt ast.Stmt, mod string, file string) {
 }
 
 fn (e Eval) error(msg string) {
-	eprintln('> V interpeter backtrace:')
+	eprintln('> V interpreter backtrace:')
 	e.print_backtrace()
 	util.verror('interpreter', msg)
 }

--- a/vlib/v/eval/stmt.v
+++ b/vlib/v/eval/stmt.v
@@ -52,7 +52,7 @@ pub fn (mut e Eval) stmt(stmt ast.Stmt) {
 					}
 				}
 				else {
-					e.error('unknown assign statment: ${stmt.op}')
+					e.error('unknown assign statement: ${stmt.op}')
 				}
 			}
 		}

--- a/vlib/v/eval/var.v
+++ b/vlib/v/eval/var.v
@@ -49,7 +49,7 @@ pub fn (mut e Eval) set(expr ast.Expr, val Object, init bool, typ ast.Type) {
 			// }
 		}
 		else {
-			panic('unknown left value to assign statment: ${expr.type_name()}')
+			panic('unknown left value to assign statement: ${expr.type_name()}')
 		}
 	}
 }
@@ -62,7 +62,7 @@ pub fn (mut e Eval) add(expr ast.Expr, val Object) {
 				.plus, e.local_vars[expr.name].typ)
 		}
 		else {
-			panic('unknown left value to add statment: ${expr.type_name()}')
+			panic('unknown left value to add statement: ${expr.type_name()}')
 		}
 	}
 }

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -191,8 +191,8 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					continue
 				}
 			}
-			if already_initalised_node_field_index := inited_fields[field.name] {
-				mut sfield := node.init_fields[already_initalised_node_field_index]
+			if already_inited_node_field_index := inited_fields[field.name] {
+				mut sfield := node.init_fields[already_inited_node_field_index]
 				if sfield.typ == 0 {
 					continue
 				}
@@ -231,7 +231,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 				if node.no_keys && sym.kind == .struct_ {
 					sym_info := sym.info as ast.Struct
 					if sym_info.fields.len == node.init_fields.len {
-						sfield.name = sym_info.fields[already_initalised_node_field_index].name
+						sfield.name = sym_info.fields[already_inited_node_field_index].name
 					}
 				}
 				g.struct_init_field(sfield, sym.language)

--- a/vlib/v/slow_tests/inout/panic_with_cg.out
+++ b/vlib/v/slow_tests/inout/panic_with_cg.out
@@ -1,5 +1,5 @@
 ================ V panic ================
    module: main
  function: buggy_function()
-  message: panicing...
+  message: panicking...
      file: vlib/v/slow_tests/inout/panic_with_cg.vv:2

--- a/vlib/v/slow_tests/inout/panic_with_cg.vv
+++ b/vlib/v/slow_tests/inout/panic_with_cg.vv
@@ -1,5 +1,5 @@
 fn buggy_function() {
-	panic('panicing...')
+	panic('panicking...')
 }
 
 fn main() {

--- a/vlib/v/tests/array_of_fns_index_call_with_direct_array_access_test.v
+++ b/vlib/v/tests/array_of_fns_index_call_with_direct_array_access_test.v
@@ -11,7 +11,7 @@ fn (b Bar) foo() int {
 	return b.f[0](22)
 }
 
-fn test_array_of_fns_index_call_with_direct_array_acess() {
+fn test_array_of_fns_index_call_with_direct_array_access() {
 	bar := Bar{[func]}
 	ret := bar.foo()
 	println(ret)

--- a/vlib/v/tests/array_of_map_with_default_test.v
+++ b/vlib/v/tests/array_of_map_with_default_test.v
@@ -11,10 +11,10 @@ fn init_b(n_rows int) []map[int]int {
 	return tally
 }
 
-pub fn tallys_in_array(indexs []int, values [][]int, init fn (int) []map[int]int) []map[int]int {
-	mut tally := init(indexs.len)
+pub fn tallys_in_array(indices []int, values [][]int, init fn (int) []map[int]int) []map[int]int {
+	mut tally := init(indices.len)
 	for row in 0 .. values.len {
-		for i, index in indexs {
+		for i, index in indices {
 			tally[i][values[row][index]]++
 		}
 	}
@@ -22,12 +22,12 @@ pub fn tallys_in_array(indexs []int, values [][]int, init fn (int) []map[int]int
 }
 
 fn test_array_of_map_with_default() {
-	indexs := [0, 1]
+	indices := [0, 1]
 	values := [[1, 201], [1, 3], [1, 201], [1, 3]]
 
-	out1 := tallys_in_array(indexs, values, init_a)
+	out1 := tallys_in_array(indices, values, init_a)
 	println(out1)
-	out2 := tallys_in_array(indexs, values, init_b)
+	out2 := tallys_in_array(indices, values, init_b)
 	println(out2)
 
 	mut maps := []map[int]int{}

--- a/vlib/v/tests/array_of_sumtype_init_test.v
+++ b/vlib/v/tests/array_of_sumtype_init_test.v
@@ -1,10 +1,10 @@
-pub type MenuItem = Action | Group | Separater
+pub type MenuItem = Action | Group | Separator
 
 pub struct Group {
 	children []MenuItem
 }
 
-pub struct Separater {}
+pub struct Separator {}
 
 pub struct Action {}
 
@@ -12,7 +12,7 @@ fn test_array_of_sumtype_init() {
 	g := Group{
 		children: [
 			Action{},
-			Separater{},
+			Separator{},
 			Group{
 				children: [
 					Action{},

--- a/vlib/v/tests/heap_interface_test.v
+++ b/vlib/v/tests/heap_interface_test.v
@@ -14,7 +14,7 @@ fn (x St) val() int {
 	return x.n
 }
 
-fn owerwrite_stack() f64 {
+fn overwrite_stack() f64 {
 	a := 12.5
 	b := 3.5
 	c := a + b
@@ -37,7 +37,7 @@ fn return_interface(x St) MyInterface {
 
 fn test_gen_interface() {
 	i1 := gen_interface()
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert i1.val() == -123
 	assert d == 16.0
 }
@@ -47,7 +47,7 @@ fn test_convert_to_interface() {
 		n: 5
 	}
 	i2 := return_interface(x)
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert i2.val() == 5
 	assert d == 16.0
 }

--- a/vlib/v/tests/heap_struct_test.v
+++ b/vlib/v/tests/heap_struct_test.v
@@ -45,7 +45,7 @@ fn get_ref_structs() (&Abc, &St, &Qwe) {
 	return aa, bb, xx
 }
 
-fn owerwrite_stack() f64 {
+fn overwrite_stack() f64 {
 	a := 12.5
 	b := 3.5
 	c := a + b
@@ -54,7 +54,7 @@ fn owerwrite_stack() f64 {
 
 fn test_ref_struct() {
 	u, v, w := get_ref_structs()
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert u.n == 3
 	assert v.n == 7
 	assert w.a.n == 23
@@ -74,7 +74,7 @@ fn test_value_ref_heap_struct() {
 	}
 	y := return_heap_obj_value_as_ref(x)
 	x.f = 22.0625
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert typeof(y).name == '&Qwe'
 	assert x.f == 22.0625
 	assert x.a.n == -129
@@ -98,7 +98,7 @@ fn test_value_ref_struct() {
 	}
 	y := return_struct_value_as_ref(x)
 	x.f = 91.0625
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert typeof(y).name == '&NotHeap'
 	assert y.f == -17.125
 	assert x.f == 91.0625
@@ -113,7 +113,7 @@ fn get_int_ref() &int {
 fn test_int_ref() {
 	iptr := get_int_ref()
 	assert typeof(iptr).name == '&int'
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert *iptr == 49154
 	assert d == 16.0
 }
@@ -127,7 +127,7 @@ fn test_value_as_ref() {
 	y := pass_f64_as_ref(x)
 	assert typeof(y).name == '&f64'
 	x = 23.0625
-	d := owerwrite_stack()
+	d := overwrite_stack()
 	assert x == 23.0625
 	assert *y == -31.75
 	assert d == 16.0

--- a/vlib/vweb/csrf/csrf_test.v
+++ b/vlib/vweb/csrf/csrf_test.v
@@ -225,12 +225,12 @@ pub fn (mut app App) middleware_auth() vweb.Result {
 // ======================================
 
 pub fn (mut app App) shutdown() vweb.Result {
-	spawn app.gracefull_exit()
+	spawn app.exit_gracefully()
 	return app.ok('good bye')
 }
 
-fn (mut app App) gracefull_exit() {
-	eprintln('>> webserver: gracefull_exit')
+fn (mut app App) exit_gracefully() {
+	eprintln('>> webserver: exit_gracefully')
 	time.sleep(100 * time.millisecond)
 	exit(0)
 }

--- a/vlib/vweb/tests/controller_test_server.v
+++ b/vlib/vweb/tests/controller_test_server.v
@@ -107,12 +107,12 @@ pub fn (mut app App) shutdown() vweb.Result {
 	if session_key != 'superman' {
 		return app.not_found()
 	}
-	spawn app.gracefull_exit()
+	spawn app.exit_gracefully()
 	return app.ok('good bye')
 }
 
-fn (mut app App) gracefull_exit() {
-	eprintln('>> webserver: gracefull_exit')
+fn (mut app App) exit_gracefully() {
+	eprintln('>> webserver: exit_gracefully')
 	time.sleep(100 * time.millisecond)
 	exit(0)
 }

--- a/vlib/vweb/tests/middleware_test.v
+++ b/vlib/vweb/tests/middleware_test.v
@@ -289,7 +289,7 @@ fn simple_tcp_client(config SimpleTcpClientConfig) !string {
 		break
 	}
 	if client == unsafe { nil } {
-		eprintln('coult not create a tcp client connection to ${localserver} after ${config.retries} retries')
+		eprintln('could not create a tcp client connection to ${localserver} after ${config.retries} retries')
 		exit(1)
 	}
 	client.set_read_timeout(tcp_r_timeout)
@@ -330,7 +330,7 @@ fn simple_tcp_client_post_json(config SimpleTcpClientConfig) !string {
 		break
 	}
 	if client == unsafe { nil } {
-		eprintln('coult not create a tcp client connection to ${localserver} after ${config.retries} retries')
+		eprintln('could not create a tcp client connection to ${localserver} after ${config.retries} retries')
 		exit(1)
 	}
 	client.set_read_timeout(tcp_r_timeout)

--- a/vlib/vweb/tests/middleware_test_server.v
+++ b/vlib/vweb/tests/middleware_test_server.v
@@ -275,12 +275,12 @@ pub fn (mut app App) shutdown() vweb.Result {
 	if session_key != 'superman' {
 		return app.not_found()
 	}
-	spawn app.gracefull_exit()
+	spawn app.exit_gracefully()
 	return app.ok('good bye')
 }
 
-fn (mut app App) gracefull_exit() {
-	eprintln('>> webserver: gracefull_exit')
+fn (mut app App) exit_gracefully() {
+	eprintln('>> webserver: exit_gracefully')
 	time.sleep(100 * time.millisecond)
 	exit(0)
 }

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -316,7 +316,7 @@ fn simple_tcp_client(config SimpleTcpClientConfig) !string {
 		break
 	}
 	if client == unsafe { nil } {
-		eprintln('coult not create a tcp client connection to ${localserver} after ${config.retries} retries')
+		eprintln('could not create a tcp client connection to ${localserver} after ${config.retries} retries')
 		exit(1)
 	}
 	client.set_read_timeout(tcp_r_timeout)

--- a/vlib/vweb/tests/vweb_test_server.v
+++ b/vlib/vweb/tests/vweb_test_server.v
@@ -135,12 +135,12 @@ pub fn (mut app App) shutdown() vweb.Result {
 	if session_key != 'superman' {
 		return app.not_found()
 	}
-	spawn app.gracefull_exit()
+	spawn app.exit_gracefully()
 	return app.ok('good bye')
 }
 
-fn (mut app App) gracefull_exit() {
-	eprintln('>> webserver: gracefull_exit')
+fn (mut app App) exit_gracefully() {
+	eprintln('>> webserver: exit_gracefully')
 	time.sleep(100 * time.millisecond)
 	exit(0)
 }


### PR DESCRIPTION
Changes that the formatter made whilst going through the related files where kept in the staged changes - like trimming trailing whitespace and aligment of markdown list points.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 761d052</samp>

This pull request fixes various spelling, punctuation, and formatting errors in the comments, documentation, and test files of the vlang/v repository. The changes improve the readability, clarity, and consistency of the code and the markdown rendering. The files affected include `bench/vectors/README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `vlib/datatypes/bloom_filter_test.v`, `vlib/datatypes/bloom_filter.v`, `vlib/datatypes/bstree.v`, `vlib/db/mysql/mysql_orm_test.v`, `vlib/db/pg/pg_orm_test.v`, `vlib/db/sqlite/sqlite_orm_test.v`, `vlib/rand/rand.v`, `vlib/bitfield/bitfield_test.v`, `vlib/datatypes/bstree_test.v`, `vlib/gx/color_test.v`, `vlib/log/log.v`, `vlib/picoev/loop_freebsd.c.v`, `vlib/picoev/loop_macos.c.v`, `vlib/picoev/socket_util.c.v`, `vlib/strconv/atof.c.v`, `vlib/term/term.js.v`, and `vlib/term/term_nix.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 761d052</samp>

*  Fix spelling errors in various files ([link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-8471e61c979e55512fdbcac4279daa0b6eb06c15ea0208f169ed174bda37561cL263-R263), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL13-R16), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL24-R27), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL36-R39), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL53-R53), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL62-R62), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL72-R72), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-199948d1d1f9c5195f54175053a32bab9be5648d1357177049d9689d3f8c19baL82-R82), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-c6fa02c99f2f20489cf3ad62896f9ad667929691abc550a1ff483ec1ede04f96L3-R3), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-c6fa02c99f2f20489cf3ad62896f9ad667929691abc550a1ff483ec1ede04f96L237-R237), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-a8608f99d416ffd5af7ac8a6bed1dd2d37632f0db50c44eec751570688741b67L89-R89), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-9d0249204b82fa4d6aa4628c76b1d0ee3a113fbc137f4b496a71009779f72455L32-R32), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-9d0249204b82fa4d6aa4628c76b1d0ee3a113fbc137f4b496a71009779f72455L208-R208), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-9d0249204b82fa4d6aa4628c76b1d0ee3a113fbc137f4b496a71009779f72455L214-R214), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-9d0249204b82fa4d6aa4628c76b1d0ee3a113fbc137f4b496a71009779f72455L223-R223), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-8bb2fdd37427cfcffd74624d73836fd538429391cb09cc77d81841c45b73b197L32-R32), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-8bb2fdd37427cfcffd74624d73836fd538429391cb09cc77d81841c45b73b197L205-R205), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-8bb2fdd37427cfcffd74624d73836fd538429391cb09cc77d81841c45b73b197L211-R211), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-8bb2fdd37427cfcffd74624d73836fd538429391cb09cc77d81841c45b73b197L223-R223), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-2047415fcf2c46ec3cac38c59a5587705edf5f4d178820dcbbbfce2d09f5ba32L16-R16), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-2047415fcf2c46ec3cac38c59a5587705edf5f4d178820dcbbbfce2d09f5ba32L127-R131), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-2047415fcf2c46ec3cac38c59a5587705edf5f4d178820dcbbbfce2d09f5ba32L142-R164), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-44aa38f516d569aaa9eb38dbdd1552ab0942adb5cfc0dc665d8b6b3482c87a60L83-R83), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-b1b4f998e69f626c035e84a2dd3fd9338ee2cda88f3f506ef019982fb2e9f210L25-R25), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-078149738c6e4dcdd9d40170cc7bffbf3c9614c6b678ec54ee4766eb9e6335a9L7-R7), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-226b444ed747871cc264899a74638df45a3bc212beda4fb93677656c61309c37L7-R7), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-426c0ee91a2a40157b09795860ad0cfa213ed59a2e6a2c63ba9e85c193bf18efL102-R102), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-3c14908b443d801f4726012f3289104b28d8e662eb14d4d7698a440afd446105L410-R410), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-3c14908b443d801f4726012f3289104b28d8e662eb14d4d7698a440afd446105L751-R751), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-f6392b54eb4e74029f7107a399686b534f540b3bfd7a2d33b03b7e2d136674e1L337-R337), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-fae6c4c31da0b4700ca3738f386f5e489810d067bd85f6edac9fb91d19a140a7L4-R13))
*  Add blank lines and headings to improve markdown rendering in `bench/vectors/README.md` ([link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-02002496eeb07838ceba4276f8ac72bf1b69931147c186ec50388a4051cb505bL1-R2), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-02002496eeb07838ceba4276f8ac72bf1b69931147c186ec50388a4051cb505bR8), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-02002496eeb07838ceba4276f8ac72bf1b69931147c186ec50388a4051cb505bL17-R49), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-02002496eeb07838ceba4276f8ac72bf1b69931147c186ec50388a4051cb505bL53-R63), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-02002496eeb07838ceba4276f8ac72bf1b69931147c186ec50388a4051cb505bL72-R75), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-02002496eeb07838ceba4276f8ac72bf1b69931147c186ec50388a4051cb505bL87-R92))
*  Fix indentation, punctuation, and formatting issues in `CONTRIBUTING.md` ([link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L31-R35), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L87-R89), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L102-R104), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L121-R126), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L138-R141), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L171-R176), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R182), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L186-R189), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L204-R212), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L216-R220), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L257-R264), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L268-R275), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L288-R293), [link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L298-R301))
*  Add a blank line before the section `[Version 0.3]` in `ROADMAP.md` ([link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R2))
*  Fix the spelling of `Constraints` in the section `[Version 1.0]` in `ROADMAP.md` ([link](https://github.com/vlang/v/pull/19693/files?diff=unified&w=0#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L53-R54))
