### PR TITLE
crypto.sha: fix calculating hash values again for sha1/256/512(fix #19696)

### DIFF
--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -64,6 +64,14 @@ pub fn (mut d Digest) reset() {
 	d.len = 0
 }
 
+fn (d &Digest) clone() &Digest {
+	return &Digest{
+		...d
+		h: d.h.clone()
+		x: d.x.clone()
+	}
+}
+
 // new returns a new Digest (implementing hash.Hash) computing the SHA1 checksum.
 pub fn new() &Digest {
 	mut d := &Digest{}
@@ -110,7 +118,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 // sum returns a copy of the generated sum of the bytes in `b_in`.
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
-	mut d0 := *d
+	mut d0 := d.clone()
 	hash := d0.checksum()
 	mut b_out := b_in.clone()
 	for b in hash {

--- a/vlib/crypto/sha1/sha1_test.v
+++ b/vlib/crypto/sha1/sha1_test.v
@@ -11,7 +11,9 @@ fn test_crypto_sha1_writer() {
 	mut digest := sha1.new()
 	digest.write('This is a'.bytes()) or { assert false }
 	digest.write(' sha1 checksum.'.bytes()) or { assert false }
-	sum := digest.sum([])
+	mut sum := digest.sum([])
+	assert sum.hex() == 'e100d74442faa5dcd59463b808983c810a8eb5a1'
+	sum = digest.sum([])
 	assert sum.hex() == 'e100d74442faa5dcd59463b808983c810a8eb5a1'
 }
 

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -91,6 +91,14 @@ pub fn (mut d Digest) reset() {
 	d.len = 0
 }
 
+fn (d &Digest) clone() &Digest {
+	return &Digest{
+		...d
+		h: d.h.clone()
+		x: d.x.clone()
+	}
+}
+
 // new returns a new Digest (implementing hash.Hash) computing the SHA256 checksum.
 pub fn new() &Digest {
 	mut d := &Digest{}
@@ -144,7 +152,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 // sum returns the SHA256 or SHA224 checksum of digest with the data.
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
-	mut d0 := *d
+	mut d0 := d.clone()
 	hash := d0.checksum()
 	mut b_out := b_in.clone()
 	if d0.is224 {

--- a/vlib/crypto/sha256/sha256_test.v
+++ b/vlib/crypto/sha256/sha256_test.v
@@ -11,7 +11,9 @@ fn test_crypto_sha256_writer() {
 	mut digest := sha256.new()
 	digest.write('This is a'.bytes()) or { assert false }
 	digest.write(' sha256 checksum.'.bytes()) or { assert false }
-	sum := digest.sum([])
+	mut sum := digest.sum([])
+	assert sum.hex() == 'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
+	sum = digest.sum([])
 	assert sum.hex() == 'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
 }
 

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -136,6 +136,14 @@ pub fn (mut d Digest) reset() {
 	d.len = 0
 }
 
+fn (d &Digest) clone() &Digest {
+	return &Digest{
+		...d
+		h: d.h.clone()
+		x: d.x.clone()
+	}
+}
+
 // internal
 fn new_digest(hash crypto.Hash) &Digest {
 	mut d := &Digest{
@@ -203,7 +211,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 // sum returns the SHA512 or SHA384 checksum of digest with the data bytes in `b_in`
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
-	mut d0 := *d
+	mut d0 := d.clone()
 	hash := d0.checksum()
 	mut b_out := b_in.clone()
 	match d0.function {

--- a/vlib/crypto/sha512/sha512_test.v
+++ b/vlib/crypto/sha512/sha512_test.v
@@ -11,8 +11,12 @@ fn test_crypto_sha512_writer() {
 	mut digest := sha512.new_digest(.sha512)
 	digest.write('This is a'.bytes()) or { assert false }
 	digest.write(' sha512 checksum.'.bytes()) or { assert false }
-	sum := digest.checksum()
+	mut sum := digest.checksum()
 	assert sum.hex() == '4143e55fcba7e39b20f62a1368e5eb28f64a8859458886117ac66027832e0f9f5263daec688c439d2d0fa07059334668d39e59543039703dbb7e03ec9da7f8d7'
+	sum = digest.sum([])
+	assert sum.hex() == '64922a82583d4e364010e574ca5ce6a15686e0d268bd41ac1003dda924356d3552e276b7baedacd85a6884e744943a92d931cebca4738510b4568c5fb5a49723'
+	sum = digest.sum([])
+	assert sum.hex() == '64922a82583d4e364010e574ca5ce6a15686e0d268bd41ac1003dda924356d3552e276b7baedacd85a6884e744943a92d931cebca4738510b4568c5fb5a49723'
 }
 
 fn test_crypto_sha512_writer_reset() {


### PR DESCRIPTION
1. Fixed #19696 
2. Add tests.

```v
import crypto.sha256

fn main() {
	s := 'sha256 this string'.bytes()
	dump(s.hex())

	mut d1 := sha256.new()
	o1 := d1.sum(s)
	dump(o1.hex())

	mut d2 := sha256.new()
	n := d2.write(s)!
	dump(n)

	o2 := d2.sum([]u8{})
	o3 := d2.sum([]u8{})
	dump(o2.hex())
	dump(o3.hex())
}
```

outputs:

```
Shoves-MacBook:temp shove$ ./a
[a.v:6] s.hex(): 736861323536207468697320737472696e67
[a.v:10] o1.hex(): 736861323536207468697320737472696e67e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
[a.v:14] n: 18
[a.v:18] o2.hex(): 1af1dfa857bf1d8814fe1af8983c18080019922e557f15a8a0d3db739d77aacb
[a.v:19] o3.hex(): 1af1dfa857bf1d8814fe1af8983c18080019922e557f15a8a0d3db739d77aacb
```