### PR TITLE
v.help: add `ExitOptions` params struct to `print_and_exit`

### DIFF
--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -4,17 +4,23 @@ import os
 
 const help_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'help')
 
+[params]
+struct ExitOptions {
+	success_code int // The exit code to use after the specified topic was printed successfully.
+	fail_code    int = 1 // The exit code to use after the specified topic could not be printed (e.g., if it is unknown).
+}
+
 // print_and_exit prints the help topic and exits.
-pub fn print_and_exit(topic string) {
+pub fn print_and_exit(topic string, exit_opts ExitOptions) {
 	if topic == 'topics' {
 		print_known_topics()
-		exit(0)
+		exit(exit_opts.success_code)
 	}
 
 	for c in topic {
 		if !c.is_letter() && !c.is_digit() && c != `-` {
 			print_topic_unkown(topic)
-			exit(1)
+			exit(exit_opts.fail_code)
 		}
 	}
 
@@ -28,14 +34,14 @@ pub fn print_and_exit(topic string) {
 	if topic_path == '' {
 		print_topic_unkown(topic)
 		print_known_topics()
-		exit(1)
+		exit(exit_opts.fail_code)
 	}
 
 	println(os.read_file(topic_path) or {
 		eprintln('error: failed reading topic file: ${err}')
-		exit(1)
+		exit(exit_opts.fail_code)
 	})
-	exit(0)
+	exit(exit_opts.success_code)
 }
 
 fn print_topic_unkown(topic string) {

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -5,7 +5,7 @@ import os
 const help_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'help')
 
 [params]
-struct ExitOptions {
+pub struct ExitOptions {
 	success_code int // The exit code to use after the specified topic was printed successfully.
 	fail_code    int = 1 // The exit code to use after the specified topic could not be printed (e.g., if it is unknown).
 }


### PR DESCRIPTION
Extends `help.print_and_exit` to accept additional params, without changing its current default behavior.

This will allow for a followup fix, as there are cases in the code base that specify an exit code after calling `print_help_and_exit` that is never returned. 

On of such is e.g., in the vpm module. It specifes an exit code 5 after calling print_and_exit that will currently not be returned.

https://github.com/vlang/v/blob/aa28efc0b18a031475840170862555ff8d838899/cmd/tools/vpm/vpm.v#L64-L67

The used `vpm_help()` here, just calls `print_and_exit`
https://github.com/vlang/v/blob/aa28efc0b18a031475840170862555ff8d838899/cmd/tools/vpm/vpm.v#L633-L635

```sh
# Provoke the block that contains exit(5) by running the file directly and not adding furhter params 
❯ v run cmd/tools/vpm/vpm.v 

# Prints help as expected
Package Management Utilities:

  install   Installs each PACKAGE.
  ...
  
  
# But checking the exit code, it currently is hard coded exit code 0
❯ echo $?
0
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a38cc84</samp>

Refactor `v help` command to use structured exit codes. Add `ExitOptions` struct to `vlib/v/help/help.v` to control exit behavior.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a38cc84</samp>

*  Modify `print_and_exit` function to accept an `ExitOptions` struct as a parameter ([link](https://github.com/vlang/v/pull/19698/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L7-R17))
*  Use the exit codes from the `ExitOptions` struct instead of hard-coded values in `print_and_exit` function ([link](https://github.com/vlang/v/pull/19698/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L17-R23), [link](https://github.com/vlang/v/pull/19698/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L31-R44))
*  Document the `ExitOptions` struct with the `[params]` attribute ([link](https://github.com/vlang/v/pull/19698/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L7-R17))
