### PR TITLE
parser: cleanup enum_decl() in parser.v

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4056,13 +4056,15 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			enum_attrs[val] = attrs
 			p.attrs = []
 		}
+		comments := p.eat_comments(same_line: true)
+		next_comments := p.eat_comments()
 		fields << ast.EnumField{
 			name: val
 			pos: pos
 			expr: expr
 			has_expr: has_expr
-			comments: p.eat_comments(same_line: true)
-			next_comments: p.eat_comments()
+			comments: comments
+			next_comments: next_comments
 			attrs: attrs
 		}
 	}


### PR DESCRIPTION
This PR cleanup enum_decl() in parser.v, formatting errors have occurred in the VUI occasionally.

- Direct calling of eat _ comments() in the field initialization of the constructs may cause errors due to a different initialization order,  so we should call in sequence before.