### PR TITLE
tools.vpm: fix `install --once` for external modules, add already installed info, add test

### DIFF
--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -75,7 +75,7 @@ fn test_install_once() {
 	md_last_modified := os.file_last_mod_unix(os.join_path(test_path, 'markdown', 'v.mod'))
 
 	install_cmd := '${@VEXE} install https://github.com/vlang/markdown https://github.com/vlang/pcre --once -v'
-	// Try install two modules, where one is already installed.
+	// Try installing two modules, one of which is already installed.
 	res = os.execute(install_cmd)
 	assert res.exit_code == 0, res.output
 	assert res.output.contains("Already installed modules: ['markdown']")
@@ -89,7 +89,7 @@ fn test_install_once() {
 	assert md_last_modified == os.file_last_mod_unix(os.join_path(test_path, 'markdown',
 		'v.mod'))
 
-	// Try install two modules, where both are already installed.
+	// Try installing two modules that are both already installed.
 	res = os.execute(install_cmd)
 	assert res.exit_code == 0, res.output
 	assert res.output.contains('All modules are already installed.')

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -1,9 +1,12 @@
 import os
 import v.vmod
 
-// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
-// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
-const test_path = os.join_path(os.vtmp_dir(), 'test-vmodules')
+const (
+	v         = os.quoted_path(@VEXE)
+	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
+	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
+	test_path = os.join_path(os.vtmp_dir(), 'test-vmodules')
+)
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
@@ -14,7 +17,7 @@ fn testsuite_end() {
 }
 
 fn test_install_from_vpm_ident() {
-	res := os.execute(@VEXE + ' install nedpals.args')
+	res := os.execute('${v} install nedpals.args')
 	assert res.exit_code == 0, res.output
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.str()
@@ -25,7 +28,7 @@ fn test_install_from_vpm_ident() {
 }
 
 fn test_install_from_vpm_short_ident() {
-	res := os.execute(@VEXE + ' install pcre')
+	res := os.execute('${v} install pcre')
 	assert res.exit_code == 0, res.output
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.str()
@@ -36,7 +39,7 @@ fn test_install_from_vpm_short_ident() {
 }
 
 fn test_install_from_git_url() {
-	res := os.execute(@VEXE + ' install https://github.com/vlang/markdown')
+	res := os.execute('${v} install https://github.com/vlang/markdown')
 	assert res.exit_code == 0, res.output
 	assert res.output.contains('Installing module "markdown" from "https://github.com/vlang/markdown')
 	assert res.output.contains('Relocating module from "vlang/markdown" to "markdown"')
@@ -54,7 +57,7 @@ fn test_install_already_existent() {
 	$if windows {
 		return
 	}
-	mut res := os.execute(@VEXE + ' install https://github.com/vlang/markdown')
+	mut res := os.execute('${v} install https://github.com/vlang/markdown')
 	assert res.exit_code == 0, res.output
 	assert res.output.contains('already exists')
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
@@ -76,7 +79,7 @@ fn test_install_once() {
 	os.mkdir_all(test_path) or {}
 
 	// Install markdown module.
-	mut res := os.execute(@VEXE + ' install markdown')
+	mut res := os.execute('${v} install markdown')
 	assert res.exit_code == 0, res.output
 	// Keep track of the last modified state of the v.mod file of the installed markdown module.
 	md_last_modified := os.file_last_mod_unix(os.join_path(test_path, 'markdown', 'v.mod'))
@@ -106,7 +109,7 @@ fn test_install_once() {
 
 fn test_missing_repo_name_in_url() {
 	incomplete_url := 'https://github.com/vlang'
-	res := os.execute(@VEXE + ' install ${incomplete_url}')
+	res := os.execute('${v} install ${incomplete_url}')
 	assert res.exit_code == 1
 	assert res.output.trim_space() == 'Errors while retrieving module name for: "${incomplete_url}"'
 }

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -48,8 +48,9 @@ fn test_install_from_git_url() {
 	assert mod.dependencies == []string{}
 }
 
-fn test_install_already_existant() {
-	// Skip on windows for now due permission errors with rmdir.
+fn test_install_already_existent() {
+	// FIXME: Skip this for now on Windows, as `rmdir_all` results in permission
+	// errors when vpm tries to remove existing modules.
 	$if windows {
 		return
 	}
@@ -66,8 +67,14 @@ fn test_install_already_existant() {
 
 fn test_install_once() {
 	// Start with a clean test path.
-	os.rmdir_all(test_path) or {}
+	$if windows {
+		// FIXME: Workaround for failing `rmdir` commands on Windows.
+		os.system('rd /s /q ${test_path}')
+	} $else {
+		os.rmdir_all(test_path) or {}
+	}
 	os.mkdir_all(test_path) or {}
+
 	// Install markdown module.
 	mut res := os.execute(@VEXE + ' install markdown')
 	assert res.exit_code == 0, res.output

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -139,34 +139,33 @@ fn vpm_install_(requested_modules []string, opts []string) {
 	if installed_modules.len > 0 && '--once' in opts {
 		mut already_installed := []string{}
 		if external_modules.len > 0 {
-			// Clone required, since we delete already installed modules from `external_modules` in the loop.
-			mut i := 0
-			for raw_url in external_modules.clone() {
+			mut i_deleted := []int{}
+			for i, raw_url in external_modules {
 				url := urllib.parse(raw_url) or {
 					eprintln('Errors while parsing module url "${raw_url}" : ${err}')
-					i++
 					continue
 				}
 				mod_name := url.path.all_after_last('/')
 				if mod_name in installed_modules {
 					already_installed << mod_name
-					external_modules.delete(i)
-					// Don't increment `i` because we deleted an element and the array lost length.
-					// Otherwise, other modules that are already installed might get skipped.
-					continue
+					i_deleted << i
 				}
-				i++
+			}
+			for i in i_deleted.reverse() {
+				external_modules.delete(i)
 			}
 		}
 		if vpm_modules.len > 0 {
-			mut i := 0
-			for mod_name in vpm_modules.clone() {
+			mut i_deleted := []int{}
+			for i, mod_name in vpm_modules {
 				if mod_name in installed_modules {
 					already_installed << mod_name
-					vpm_modules.delete(i)
+					i_deleted << i
 					continue
 				}
-				i++
+			}
+			for i in i_deleted.reverse() {
+				vpm_modules.delete(i)
 			}
 		}
 		if already_installed.len > 0 {


### PR DESCRIPTION
- Fixes `v install --once` for modules that are installed from external URLs. Currently, they would be overwritten despite the flag.
- If modules are already installed, running in verbose-mode will now contain a little info with the names of already installed modules and an info if all modules are already installed.
- Adds a test.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8bb01a</samp>

This pull request improves the `vpm` tool by adding more test coverage, refactoring the code, and using the `help` module. It affects the files `cmd/tools/vpm/install_test.v` and `cmd/tools/vpm/vpm.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8bb01a</samp>

*  Refactor `vpm` function to extract `install` command logic into `vpm_install_` function ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L65-R82))
*  Implement `vpm_install_` function to handle dependencies, `--once` option, and different sources for modules ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545R110-R182))
*  Remove `vpm_once_filter` function as it is no longer needed ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L354-R397))
*  Remove `vpm_help` function and use `help` module instead ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L630-L633))
*  Update `remove` and `show` commands to use `requested_modules` variable instead of `module_names` ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L124-R97))
*  Remove redundant test case for installing from git URL in `cmd/tools/vpm/install_test.v` ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L16-L28))
*  Add test case for installing from git URL with `--once` and `-v` options and check last modified time of `v.mod` file ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R38-R50))
*  Modify test case for installing from git URL twice to check for "already exists" message ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L56-R58))
*  Add test case for `--once` option with two modules, one already installed and one new, and check output ([link](https://github.com/vlang/v/pull/19702/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L67-R99))
