### PR TITLE
v.help: add `[noreturn]` attribute to `print_and_exit`

### DIFF
--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -44,7 +44,6 @@ fn (v1 CheckResult) + (v2 CheckResult) CheckResult {
 fn main() {
 	if non_option_args.len == 0 || '-help' in os.args {
 		help.print_and_exit('check-md')
-		exit(0)
 	}
 	if '-all' in os.args {
 		println('´-all´ flag is deprecated. Please use ´v check-md .´ instead.')

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -89,7 +89,6 @@ fn main() {
 	}
 	if files.len == 0 || '-help' in args || '--help' in args {
 		help.print_and_exit('fmt')
-		exit(0)
 	}
 	mut cli_args_no_files := []string{}
 	for idx, a in os.args {

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -62,8 +62,7 @@ fn main() {
 	options := cmdline.only_options(os.args[1..])
 	verbose_println('cli params: ${params}')
 	if params.len < 1 {
-		vpm_help()
-		exit(5)
+		help.print_and_exit('vpm', exit_code: 5)
 	}
 	vpm_command := params[0]
 	mut module_names := params[1..].clone()
@@ -71,7 +70,7 @@ fn main() {
 	// println('module names: ') println(module_names)
 	match vpm_command {
 		'help' {
-			vpm_help()
+			help.print_and_exit('vpm')
 		}
 		'search' {
 			vpm_search(module_names)
@@ -141,7 +140,6 @@ fn vpm_search(keywords []string) {
 	search_keys := keywords.map(it.replace('_', '-'))
 	if settings.is_help {
 		help.print_and_exit('search')
-		exit(0)
 	}
 	if search_keys.len == 0 {
 		eprintln('´v search´ requires *at least one* keyword.')
@@ -365,7 +363,6 @@ fn vpm_once_filter(module_names []string) []string {
 fn vpm_install(module_names []string, source Source) {
 	if settings.is_help {
 		help.print_and_exit('install')
-		exit(0)
 	}
 	if module_names.len == 0 {
 		eprintln('´v install´ requires *at least one* module name.')
@@ -427,7 +424,6 @@ fn vpm_update(m []string) {
 	mut module_names := m.clone()
 	if settings.is_help {
 		help.print_and_exit('update')
-		exit(0)
 	}
 	if module_names.len == 0 {
 		module_names = get_installed_modules()
@@ -574,7 +570,6 @@ fn vpm_list() {
 fn vpm_remove(module_names []string) {
 	if settings.is_help {
 		help.print_and_exit('remove')
-		exit(0)
 	}
 	if module_names.len == 0 {
 		eprintln('´v remove´ requires *at least one* module name.')
@@ -625,10 +620,6 @@ fn ensure_vmodules_dir_exist() {
 		println('Creating "${settings.vmodules_path}/" ...')
 		os.mkdir(settings.vmodules_path) or { panic(err) }
 	}
-}
-
-fn vpm_help() {
-	help.print_and_exit('vpm')
 }
 
 fn vcs_used_in_dir(dir string) ?[]string {

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -6,24 +6,23 @@ const help_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'help')
 
 [params]
 pub struct ExitOptions {
-	success_code int // The exit code to use after the specified topic was printed successfully.
-	fail_code    int = 1 // The exit code to use after the specified topic could not be printed (e.g., if it is unknown).
+	exit_code int
 }
 
 // print_and_exit prints the help topic and exits.
-pub fn print_and_exit(topic string, exit_opts ExitOptions) {
+[noreturn]
+pub fn print_and_exit(topic string, opts ExitOptions) {
 	if topic == 'topics' {
 		print_known_topics()
-		exit(exit_opts.success_code)
+		exit(opts.exit_code)
 	}
-
+	fail_code := if opts.exit_code != 0 { opts.exit_code } else { 1 }
 	for c in topic {
 		if !c.is_letter() && !c.is_digit() && c != `-` {
 			print_topic_unkown(topic)
-			exit(exit_opts.fail_code)
+			exit(fail_code)
 		}
 	}
-
 	mut topic_path := ''
 	for path in os.walk_ext(help.help_dir, '.txt') {
 		if topic == os.file_name(path).all_before('.txt') {
@@ -34,14 +33,13 @@ pub fn print_and_exit(topic string, exit_opts ExitOptions) {
 	if topic_path == '' {
 		print_topic_unkown(topic)
 		print_known_topics()
-		exit(exit_opts.fail_code)
+		exit(fail_code)
 	}
-
 	println(os.read_file(topic_path) or {
 		eprintln('error: failed reading topic file: ${err}')
-		exit(exit_opts.fail_code)
+		exit(fail_code)
 	})
-	exit(exit_opts.success_code)
+	exit(opts.exit_code)
 }
 
 fn print_topic_unkown(topic string) {


### PR DESCRIPTION
Marks `print_and_exit` as a no_return function.
Simplifies the recently added opts struct to accept one exit code. This should still cover all cases and is less confusing. If there is a need to extend it can still be done until then imho this is more sensible.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e94b82</samp>

Refactor and simplify the `vpm`, `help`, `vcheck-md`, and `vfmt` tools to use the `help.print_and_exit` function and to avoid unnecessary `exit(0)` statements. This improves the consistency, simplicity, and code quality of the tools and the help system.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e94b82</samp>

*  Simplify and unify the help system for V tools by using the `help` module ([link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L65-R65), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L74-R73), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L630-L633), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L9-R25), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L37-R42))
*  Remove unnecessary `exit(0)` statements from `vcheck-md`, `vfmt`, and `vpm` tools and let the main function handle the exit code ([link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-ff8302fd8e3a46aa8560774702d6426e12ba0d34a1fa99794c9952c43318ef21L47), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-cb9752e214f74997fbf39c438f9486d1457f3ecdf4531e4da32a2c977bbd20b9L92), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L144), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L368), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L430), [link](https://github.com/vlang/v/pull/19706/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L577))
