### PR TITLE
crypto: eliminate deprecating notifications from internal calls to checksum()

### DIFF
--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -112,7 +112,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := d.clone()
-	hash := d0.checksum()
+	hash := d0.checksum_internal()
 	mut b_out := b_in.clone()
 	for b in hash {
 		b_out << b
@@ -120,11 +120,9 @@ pub fn (d &Digest) sum(b_in []u8) []u8 {
 	return b_out
 }
 
-// checksum returns the byte checksum of the `Digest`,
-// it is an internal method and is not recommended because its results are not idempotent.
-[deprecated: 'checksum() will be changed to a private method, use sum() instead']
-[deprecated_after: '2024-04-30']
-pub fn (mut d Digest) checksum() []u8 {
+// TODO:
+// When the deprecated "checksum()" is finally removed, restore this function name as: "checksum()"
+fn (mut d Digest) checksum_internal() []u8 {
 	// Append 0x80 to the end of the message and then append zeros
 	// until the length is a multiple of 56 bytes. Finally append
 	// 8 bytes representing the message length in bits.
@@ -149,11 +147,19 @@ pub fn (mut d Digest) checksum() []u8 {
 	return digest
 }
 
+// checksum returns the byte checksum of the `Digest`,
+// it is an internal method and is not recommended because its results are not idempotent.
+[deprecated: 'checksum() will be changed to a private method, use sum() instead']
+[deprecated_after: '2024-04-30']
+pub fn (mut d Digest) checksum() []u8 {
+	return d.checksum_internal()
+}
+
 // sum returns the MD5 checksum of the data.
 pub fn sum(data []u8) []u8 {
 	mut d := new()
 	d.write(data) or { panic(err) }
-	return d.checksum()
+	return d.checksum_internal()
 }
 
 fn block(mut dig Digest, p []u8) {

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -119,7 +119,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := d.clone()
-	hash := d0.checksum()
+	hash := d0.checksum_internal()
 	mut b_out := b_in.clone()
 	for b in hash {
 		b_out << b
@@ -127,11 +127,9 @@ pub fn (d &Digest) sum(b_in []u8) []u8 {
 	return b_out
 }
 
-// checksum returns the current byte checksum of the `Digest`,
-// it is an internal method and is not recommended because its results are not idempotent.
-[deprecated: 'checksum() will be changed to a private method, use sum() instead']
-[deprecated_after: '2024-04-30']
-pub fn (mut d Digest) checksum() []u8 {
+// TODO:
+// When the deprecated "checksum()" is finally removed, restore this function name as: "checksum()"
+fn (mut d Digest) checksum_internal() []u8 {
 	mut len := d.len
 	// Padding.  Add a 1 bit and 0 bits until 56 bytes mod 64.
 	mut tmp := []u8{len: (64)}
@@ -154,11 +152,19 @@ pub fn (mut d Digest) checksum() []u8 {
 	return digest
 }
 
+// checksum returns the current byte checksum of the `Digest`,
+// it is an internal method and is not recommended because its results are not idempotent.
+[deprecated: 'checksum() will be changed to a private method, use sum() instead']
+[deprecated_after: '2024-04-30']
+pub fn (mut d Digest) checksum() []u8 {
+	return d.checksum_internal()
+}
+
 // sum returns the SHA-1 checksum of the bytes passed in `data`.
 pub fn sum(data []u8) []u8 {
 	mut d := new()
 	d.write(data) or { panic(err) }
-	return d.checksum()
+	return d.checksum_internal()
 }
 
 fn block(mut dig Digest, p []u8) {

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -153,7 +153,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := d.clone()
-	hash := d0.checksum()
+	hash := d0.checksum_internal()
 	mut b_out := b_in.clone()
 	if d0.is224 {
 		for b in hash[..sha256.size224] {
@@ -167,11 +167,9 @@ pub fn (d &Digest) sum(b_in []u8) []u8 {
 	return b_out
 }
 
-// checksum returns the current byte checksum of the Digest,
-// it is an internal method and is not recommended because its results are not idempotent.
-[deprecated: 'checksum() will be changed to a private method, use sum() instead']
-[deprecated_after: '2024-04-30']
-pub fn (mut d Digest) checksum() []u8 {
+// TODO:
+// When the deprecated "checksum()" is finally removed, restore this function name as: "checksum()"
+fn (mut d Digest) checksum_internal() []u8 {
 	mut len := d.len
 	// Padding. Add a 1 bit and 0 bits until 56 bytes mod 64.
 	mut tmp := []u8{len: (64)}
@@ -202,6 +200,14 @@ pub fn (mut d Digest) checksum() []u8 {
 	return digest
 }
 
+// checksum returns the current byte checksum of the Digest,
+// it is an internal method and is not recommended because its results are not idempotent.
+[deprecated: 'checksum() will be changed to a private method, use sum() instead']
+[deprecated_after: '2024-04-30']
+pub fn (mut d Digest) checksum() []u8 {
+	return d.checksum_internal()
+}
+
 // sum returns the SHA256 checksum of the bytes in `data`.
 // Example: assert sha256.sum('V'.bytes()).len > 0 == true
 pub fn sum(data []u8) []u8 {
@@ -212,14 +218,14 @@ pub fn sum(data []u8) []u8 {
 pub fn sum256(data []u8) []u8 {
 	mut d := new()
 	d.write(data) or { panic(err) }
-	return d.checksum()
+	return d.checksum_internal()
 }
 
 // sum224 returns the SHA224 checksum of the data.
 pub fn sum224(data []u8) []u8 {
 	mut d := new224()
 	d.write(data) or { panic(err) }
-	sum := d.checksum()
+	sum := d.checksum_internal()
 	mut sum224 := []u8{len: sha256.size224}
 	copy(mut sum224, sum[..sha256.size224])
 	return sum224

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -212,7 +212,7 @@ pub fn (mut d Digest) write(p_ []u8) !int {
 pub fn (d &Digest) sum(b_in []u8) []u8 {
 	// Make a copy of d so that caller can keep writing and summing.
 	mut d0 := d.clone()
-	hash := d0.checksum()
+	hash := d0.checksum_internal()
 	mut b_out := b_in.clone()
 	match d0.function {
 		.sha384 {
@@ -239,11 +239,9 @@ pub fn (d &Digest) sum(b_in []u8) []u8 {
 	return b_out
 }
 
-// checksum returns the current byte checksum of the Digest,
-// it is an internal method and is not recommended because its results are not idempotent.
-[deprecated: 'checksum() will be changed to a private method, use sum() instead']
-[deprecated_after: '2024-04-30']
-pub fn (mut d Digest) checksum() []u8 {
+// TODO:
+// When the deprecated "checksum()" is finally removed, restore this function name as: "checksum()"
+fn (mut d Digest) checksum_internal() []u8 {
 	// Padding. Add a 1 bit and 0 bits until 112 bytes mod 128.
 	mut len := d.len
 	mut tmp := []u8{len: (128)}
@@ -275,18 +273,26 @@ pub fn (mut d Digest) checksum() []u8 {
 	return digest
 }
 
+// checksum returns the current byte checksum of the Digest,
+// it is an internal method and is not recommended because its results are not idempotent.
+[deprecated: 'checksum() will be changed to a private method, use sum() instead']
+[deprecated_after: '2024-04-30']
+pub fn (mut d Digest) checksum() []u8 {
+	return d.checksum_internal()
+}
+
 // sum512 returns the SHA512 checksum of the data.
 pub fn sum512(data []u8) []u8 {
 	mut d := new_digest(.sha512)
 	d.write(data) or { panic(err) }
-	return d.checksum()
+	return d.checksum_internal()
 }
 
 // sum384 returns the SHA384 checksum of the data.
 pub fn sum384(data []u8) []u8 {
 	mut d := new_digest(.sha384)
 	d.write(data) or { panic(err) }
-	sum := d.checksum()
+	sum := d.checksum_internal()
 	mut sum384 := []u8{len: sha512.size384}
 	copy(mut sum384, sum[..sha512.size384])
 	return sum384
@@ -296,7 +302,7 @@ pub fn sum384(data []u8) []u8 {
 pub fn sum512_224(data []u8) []u8 {
 	mut d := new_digest(.sha512_224)
 	d.write(data) or { panic(err) }
-	sum := d.checksum()
+	sum := d.checksum_internal()
 	mut sum224 := []u8{len: sha512.size224}
 	copy(mut sum224, sum[..sha512.size224])
 	return sum224
@@ -306,7 +312,7 @@ pub fn sum512_224(data []u8) []u8 {
 pub fn sum512_256(data []u8) []u8 {
 	mut d := new_digest(.sha512_256)
 	d.write(data) or { panic(err) }
-	sum := d.checksum()
+	sum := d.checksum_internal()
 	mut sum256 := []u8{len: sha512.size256}
 	copy(mut sum256, sum[..sha512.size256])
 	return sum256


### PR DESCRIPTION
@spytheman , I'm so sorry :(

In the last PR, I didn't notice that calling from inside the library would also get deprecation notification, so I modified it. Do you think this is OK?