### PR TITLE
testing: add temporary file hash to prevent accidental collisions with test file binaries

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -61,6 +61,7 @@ pub mut:
 	nmessage_idx  int // currently printed message index
 	failed_cmds   shared []string
 	reporter      Reporter = Reporter(NormalReporter{})
+	hash          string // used during testing in temporary directory and file names to prevent collisions when files and directories are created in a test file.
 }
 
 pub fn (mut ts TestSession) add_failed_cmd(cmd string) {
@@ -274,7 +275,8 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 	vargs := _vargs.replace('-progress', '')
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
-	new_vtmp_dir := setup_new_vtmp_folder()
+	hash := '${sync.thread_id().hex()}_${time.sys_mono_now()}'
+	new_vtmp_dir := setup_new_vtmp_folder(hash)
 	if term.can_show_color_on_stderr() {
 		os.setenv('VCOLORS', 'always', true)
 	}
@@ -286,6 +288,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		show_stats: '-stats' in vargs.split(' ')
 		vargs: vargs
 		vtmp_dir: new_vtmp_dir
+		hash: hash
 		silent_mode: _vargs.contains('-silent')
 		progress_mode: _vargs.contains('-progress')
 	}
@@ -400,7 +403,6 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 			return pool.no_result
 		}
 	}
-	tmpd := ts.vtmp_dir
 	// tls_bench is used to format the step messages/timings
 	mut tls_bench := unsafe { &benchmark.Benchmark(p.get_thread_context(idx)) }
 	if isnil(tls_bench) {
@@ -441,13 +443,13 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	// Remove them after a test passes/fails.
 	fname := os.file_name(file)
 	generated_binary_fname := if os.user_os() == 'windows' && !run_js {
-		fname.replace('.v', '.exe')
+		'${fname.all_before_last('.v')}_${ts.hash}.exe'
 	} else if !run_js {
-		fname.replace('.v', '')
+		'${fname.all_before_last('.v')}_${ts.hash}'
 	} else {
-		fname.replace('.v', '')
+		'${fname.all_before_last('.v')}_${ts.hash}'
 	}
-	generated_binary_fpath := os.join_path_single(tmpd, generated_binary_fname)
+	generated_binary_fpath := os.join_path_single(ts.vtmp_dir, generated_binary_fname)
 	if produces_file_output {
 		if ts.rm_binaries {
 			os.rm(generated_binary_fpath) or {}
@@ -455,7 +457,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 
 		cmd_options << ' -o ${os.quoted_path(generated_binary_fpath)}'
 	}
-	cmd := '${os.quoted_path(ts.vexe)} ' + cmd_options.join(' ') + ' ${os.quoted_path(file)}'
+	cmd := '${os.quoted_path(ts.vexe)} ${cmd_options.join(' ')} ${os.quoted_path(file)}'
 	ts.benchmark.step()
 	tls_bench.step()
 	if relative_file.replace('\\', '/') in ts.skip_files {
@@ -712,9 +714,8 @@ pub fn building_any_v_binaries_failed() bool {
 // setup_new_vtmp_folder creates a new nested folder inside VTMP, then resets VTMP to it,
 // so that V programs/tests will write their temporary files to new location.
 // The new nested folder, and its contents, will get removed after all tests/programs succeed.
-pub fn setup_new_vtmp_folder() string {
-	now := time.sys_mono_now()
-	new_vtmp_dir := os.join_path(os.vtmp_dir(), 'tsession_${sync.thread_id().hex()}_${now}')
+pub fn setup_new_vtmp_folder(hash string) string {
+	new_vtmp_dir := os.join_path(os.vtmp_dir(), 'tsession_${hash}')
 	os.mkdir_all(new_vtmp_dir) or { panic(err) }
 	os.setenv('VTMP', new_vtmp_dir, true)
 	return new_vtmp_dir

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -444,8 +444,6 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	fname := os.file_name(file)
 	generated_binary_fname := if os.user_os() == 'windows' && !run_js {
 		'${fname.all_before_last('.v')}_${ts.hash}.exe'
-	} else if !run_js {
-		'${fname.all_before_last('.v')}_${ts.hash}'
 	} else {
 		'${fname.all_before_last('.v')}_${ts.hash}'
 	}

--- a/cmd/tools/vcreate/vcreate_input_test.v
+++ b/cmd/tools/vcreate/vcreate_input_test.v
@@ -11,8 +11,6 @@ const (
 	expect_tests_path = os.join_path(@VMODROOT, 'cmd', 'tools', 'vcreate', 'tests')
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_vcreate_input/`.
-	// Note: The following uses `test_vcreate_input` deliberately and NOT `vcreate_input_test`.
-	// This avoids clashes with the `_test` postfix, which V also uses for test file binaries.
 	test_module_path  = os.join_path(os.vtmp_dir(), 'test_vcreate_input')
 )
 

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -4,8 +4,6 @@ const (
 	test_project_dir_name = 'test_project'
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_project/`.
-	// Note: The following uses `test_vcreate` deliberately and NOT `vcreate_test`.
-	// This avoids clashes with the `_test` postfix, which V also uses for test file binaries.
 	test_path             = os.join_path(os.vtmp_dir(), test_project_dir_name)
 )
 


### PR DESCRIPTION
Wants to fix failing tests due to collisions with binary names of test files that are compiled when running a test. When encountering such an issue it might be not obvious immediately what is wrong. Also, I run into it at two places now. So I thought it's worth a fix.

The PR does it by utilizing the hash that is generated for a tsessions temporary directory name also in the output file names.

Now, if a file or directory `vcreate_input_test` is created when executing a test and the test is also named `vcreate_input_test`, a collision won't happen anymore.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f8a549</samp>

This pull request improves the testing module by adding a hash-based mechanism to avoid file and folder collisions when running multiple test sessions. It also removes some outdated comments from the `vcreate` tool tests.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f8a549</samp>

*  Add a `hash` field to the `TestSession` struct to create unique identifiers for each test session ([link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cR64), [link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cR291))
*  Use the `hash` value to generate temporary directories and files for each test session, avoiding collisions and conflicts ([link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cL277-R279), [link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cL403), [link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cL444-R452), [link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cL715-R718))
*  Remove unnecessary or redundant comments, variables, and quotes in the test files and commands ([link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cL458-R460), [link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-5b7f64c53dd651dede186bcecc3482b94b62487616e673b51f23e23feecab667L14-L15), [link](https://github.com/vlang/v/pull/19710/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL7-L8))
