### PR TITLE
coroutines: use photon work_pool when nr_jobs > 0, and use photon libc fn wrappers

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -187,6 +187,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		// is only available on macos for now, and it is not yet trivial enough to
 		// build/install on the CI:
 		skip_files << 'examples/coroutines/simple_coroutines.v'
+		skip_files << 'examples/coroutines/coroutines_bench.v'
 		$if msvc {
 			skip_files << 'vlib/v/tests/const_comptime_eval_before_vinit_test.v' // _constructor used
 			skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.v'

--- a/examples/coroutines/coroutines_bench.v
+++ b/examples/coroutines/coroutines_bench.v
@@ -1,0 +1,37 @@
+// Build with (-gc none, until GC bug is fixed)
+// v -gc none -use-coroutines coroutine_benchs.v
+//
+import coroutines
+import time
+import net.http
+import sync
+
+const run_time = 10 * time.second
+
+fn request(mut mu sync.Mutex, count &int) {
+	for {
+		http.get('http://vlang.io/utc_now') or { panic(err) }
+		mu.@lock()
+		unsafe {
+			(*count)++
+		}
+		mu.unlock()
+	}
+}
+
+fn main() {
+	mut mu := sync.new_mutex()
+	mut count := 0
+
+	for _ in 0 .. 8 {
+		go request(mut mu, &count)
+	}
+	$if is_coroutine ? {
+		println('IS COROUTINE=true')
+		coroutines.sleep(run_time)
+	} $else {
+		println('IS COROUTINE=false')
+		time.sleep(run_time)
+	}
+	println('${count} requests made.')
+}

--- a/thirdparty/photon/photonwrapper.h
+++ b/thirdparty/photon/photonwrapper.h
@@ -2,6 +2,8 @@
 #define C_PHOTONWRAPPER_H_
 
 
+#include <sys/socket.h>
+
 #ifdef __cplusplus
 
 #include <fcntl.h>
@@ -12,22 +14,32 @@
 #include <photon/common/iovector.h>
 #include <photon/fs/localfs.h>
 #include <photon/net/socket.h>
-
+#include <photon/net/basic_socket.h>
 #include <iostream>
 
 extern "C" {
 #else
-
 #endif
 
 int photon_init_default();
 void photon_thread_create(void* (* f)(void*), void* arg);
 void photon_sleep_s(int n);
 void photon_sleep_ms(int n);
+
+// void* default_photon_thread_stack_alloc(void*, size_t size);
+// void default_photon_thread_stack_dealloc(void*, void* ptr, size_t size);
 void set_photon_thread_stack_allocator(
     void* (*alloc_func)(void*, size_t),
     void (*dealloc_func)(void*, void*, size_t)
 );
+
+int photon_socket(int domain, int type, int protocol);
+int photon_connect(int fd, const struct sockaddr *addr, socklen_t addrlen, uint64_t timeout);
+int photon_accept(int fd, struct sockaddr *addr, socklen_t *addrlen, uint64_t timeout);
+ssize_t photon_send(int fd, const void* buf, size_t len, int flags, uint64_t timeout);
+// ssize_t photon_sendmsg(int fd, const struct msghdr* msg, int flags, uint64_t timeout);
+ssize_t photon_recv(int fd, void* buf, size_t count, int flags, uint64_t timeout);
+// ssize_t photon_recvmsg(int fd, struct msghdr* msg, int flags, uint64_t timeout);
 
 #ifdef __cplusplus
 }

--- a/thirdparty/photon/photonwrapper.h
+++ b/thirdparty/photon/photonwrapper.h
@@ -1,8 +1,8 @@
 #ifndef C_PHOTONWRAPPER_H_
 #define C_PHOTONWRAPPER_H_
 
-
 #include <sys/socket.h>
+
 
 #ifdef __cplusplus
 
@@ -15,12 +15,21 @@
 #include <photon/fs/localfs.h>
 #include <photon/net/socket.h>
 #include <photon/net/basic_socket.h>
+#include <photon/thread/workerpool.h>
 #include <iostream>
 
 extern "C" {
+// using namespace photon;
+// WorkPool* work_pool;
+// WorkPool* new_photon_work_pool();
+photon::WorkPool* work_pool;
 #else
 #endif
 
+// custom v functions
+void init_photon_work_pool(size_t);
+void photon_thread_create_and_migrate_to_work_pool(void* (* f)(void*), void* arg);
+// direct wrappers to photon functions
 int photon_init_default();
 void photon_thread_create(void* (* f)(void*), void* arg);
 void photon_sleep_s(int n);

--- a/vlib/coroutines/coroutines.v
+++ b/vlib/coroutines/coroutines.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module coroutines
 
+import v.util
 import time
 
 #flag -I @VEXEROOT/thirdparty/photon
@@ -10,8 +11,13 @@ import time
 
 #include "photonwrapper.h"
 
-fn C.photon_init_default() int
+// struct C.WorkPool {}
+// fn C.new_photon_work_pool) C.WorkPool
+fn C.init_photon_work_pool(int)
+
+// fn C.photon_thread_create_and_migrate_to_work_pool(f voidptr, arg voidptr)
 fn C.photon_thread_create(f voidptr, arg voidptr)
+fn C.photon_init_default() int
 fn C.photon_sleep_s(n int)
 fn C.photon_sleep_ms(n int)
 fn C.set_photon_thread_stack_allocator(fn (voidptr, int) voidptr, fn (voidptr, voidptr, int))
@@ -41,6 +47,9 @@ fn init() {
 	}
 	C.set_photon_thread_stack_allocator(alloc, dealloc)
 	ret := C.photon_init_default()
+	if util.nr_jobs > 0 {
+		C.init_photon_work_pool(util.nr_jobs)
+	}
 	if ret < 0 {
 		panic('failed to initialize coroutines via photon (ret=${ret})')
 	}

--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -113,5 +113,11 @@ fn C.FD_ISSET(fd int, fdset &C.fd_set) int
 
 fn C.inet_pton(family AddrFamily, saddr &char, addr voidptr) int
 
+fn C.photon_socket(domain AddrFamily, typ SocketType, protocol int) int
+fn C.photon_connect(int, &Addr, u32, timeout u64) int
+fn C.photon_accept(int, voidptr, int, timeout u64) int
+fn C.photon_send(int, voidptr, int, int, timeout u64) int
+fn C.photon_recv(int, voidptr, int, int, timeout u64) int
+
 [typedef]
 pub struct C.fd_set {}

--- a/vlib/net/tcp.v
+++ b/vlib/net/tcp.v
@@ -543,13 +543,11 @@ const (
 
 fn (mut s TcpSocket) connect(a Addr) ! {
 	$if !net_blocking_sockets ? {
-		println('## CONNECT: before')
 		res := $if is_coroutine ? {
 			C.photon_connect(s.handle, voidptr(&a), a.len(), net.tcp_default_read_timeout)
 		} $else {
 			C.connect(s.handle, voidptr(&a), a.len())
 		}
-		println('## CONNECT: after')
 		if res == 0 {
 			return
 		}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -161,7 +161,11 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 		}
 	} else if is_go {
-		g.writeln('photon_thread_create((void*)${wrapper_fn_name}, &${arg_tmp_var});')
+		if util.nr_jobs > 0 {
+			g.writeln('photon_thread_create_and_migrate_to_work_pool((void*)${wrapper_fn_name}, &${arg_tmp_var});')
+		} else {
+			g.writeln('photon_thread_create((void*)${wrapper_fn_name}, &${arg_tmp_var});')
+		}
 	}
 	g.writeln('// end go')
 	if node.is_expr {


### PR DESCRIPTION
also the .so files in photonbin repo need to be rebuilt

I cant see an difference between using the `photon_` libc socket fn wrappers and the libc functions directly. Perhaps context switching wouldn't nor work properly (moving across photon vCPU's), this needs more testing.
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ca5621</samp>

This pull request integrates the photon library with the V net and coroutines modules, enabling sockets and coroutines to work together for concurrent and asynchronous network programming. It adds the necessary C declarations, imports, and conditional statements to use the photon functions for socket operations, timeouts, and parallelism. It modifies the files `thirdparty/photon/photonwrapper.h`, `vlib/coroutines/coroutines.v`, `vlib/net/tcp.v`, `vlib/net/aasocket.c.v`, and `vlib/v/gen/c/spawn_and_go.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ca5621</samp>

*  Add support for coroutines and timeouts in the net module using the photon library ( [link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-ce4fed8a80eef8878e2a509860a8d661a2553a277885837cbf2c9358036685fbR116-R121),  )
*  Add a photon work pool to manage a pool of worker threads for executing coroutines in parallel ([link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-a98f325ccc804db5d84bbbf7c58ba766b45bfcd70dad82ac68bdcb6601da3451L15-R39), [link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-0b5aae236eb24d44081b5c3c87836a80a8b0aa5c5fe9f299a779ab96e30a058eR6), [link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-0b5aae236eb24d44081b5c3c87836a80a8b0aa5c5fe9f299a779ab96e30a058eR49-R51), [link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-53fcf867649ba6d7e64468ab4d50597b4b76c6f972bd824f4b30f9dad726557fL164-R168))
*  Update the C declarations for the photon functions in the coroutines and net modules to match the photon wrapper header file ([link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-0b5aae236eb24d44081b5c3c87836a80a8b0aa5c5fe9f299a779ab96e30a058eL13-R19), [link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-ce4fed8a80eef8878e2a509860a8d661a2553a277885837cbf2c9358036685fbR116-R121))
*  Add an include directive for the sys/socket.h header file in the photon wrapper header file ([link](https://github.com/vlang/v/pull/19711/files?diff=unified&w=0#diff-a98f325ccc804db5d84bbbf7c58ba766b45bfcd70dad82ac68bdcb6601da3451L4-R6))
