### PR TITLE
Update 0.4.md

### DIFF
--- a/changelogs0.x/0.4.md
+++ b/changelogs0.x/0.4.md
@@ -32,7 +32,7 @@
 - `none` fixes: no longer allowed to be used as a separate type, `dump()` support,
   not allowed inside `unsafe`.
 - Const functions: `const y = term.yellow`, then `println(y('abc'))`.
-- Builtin type names can no longer be used as identifiers.
+- Built-in type names can no longer be used as identifiers.
 - Generic `typeof[T]()`, `sizeof[T]()`, `isreftype[T]()` functions.
 - Deprecated `-error-limit` in favour of the documented `-message-limit` option.
 - Maps now support aliased keys.


### PR DESCRIPTION
Fixes #19712 .

Fixes typo error.