### PR TITLE
tests: cleanup legacy temp paths

### DIFF
--- a/cmd/tools/test_if_v_test_system_works.v
+++ b/cmd/tools/test_if_v_test_system_works.v
@@ -26,7 +26,7 @@ fn get_vexe_path() string {
 }
 
 fn new_tdir() string {
-	dir := os.join_path(os.vtmp_dir(), 'v', rand.ulid())
+	dir := os.join_path(os.vtmp_dir(), rand.ulid())
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
 	C.atexit(cleanup_tdir)

--- a/cmd/tools/vbump_test.v
+++ b/cmd/tools/vbump_test.v
@@ -1,8 +1,9 @@
 import os
 
-const vexe = @VEXE
-
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'vbump')
+const (
+	vexe    = @VEXE
+	tfolder = os.join_path(os.vtmp_dir(), 'vbump')
+)
 
 fn testsuite_begin() {
 	os.mkdir_all(tfolder) or {}

--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -21,7 +21,7 @@ const (
 	show_progress                  = os.getenv('GITHUB_JOB') == '' && '-silent' !in os.args
 	non_option_args                = cmdline.only_non_options(os.args[2..])
 	is_verbose                     = os.getenv('VERBOSE') != ''
-	vcheckfolder                   = os.join_path(os.vtmp_dir(), 'v', 'vcheck_${os.getuid()}')
+	vcheckfolder                   = os.join_path(os.vtmp_dir(), 'vcheck_${os.getuid()}')
 	should_autofix                 = os.getenv('VAUTOFIX') != ''
 	vexe                           = @VEXE
 )

--- a/cmd/tools/vcomplete_test.v
+++ b/cmd/tools/vcomplete_test.v
@@ -1,8 +1,9 @@
 import os
 
-const vexe = @VEXE
-
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'vcomplete_test')
+const (
+	vexe    = @VEXE
+	tfolder = os.join_path(os.vtmp_dir(), 'vcomplete_test')
+)
 
 enum Shell {
 	bash

--- a/cmd/tools/vgret.v
+++ b/cmd/tools/vgret.v
@@ -58,7 +58,7 @@ Examples:
   Compare screenshots in `/tmp/src` to existing screenshots in `/tmp/dst`
     v gret --compare-only /tmp/src /tmp/dst
 '
-	tmp_dir    = os.join_path(os.vtmp_dir(), 'v', tool_name)
+	tmp_dir    = os.join_path(os.vtmp_dir(), tool_name)
 	runtime_os = os.user_os()
 	v_root     = os.real_path(@VMODROOT)
 )

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -35,7 +35,7 @@ const (
 	is_stdin_a_pipe = os.is_atty(0) == 0
 	vexe            = os.getenv('VEXE')
 	vstartup        = os.getenv('VSTARTUP')
-	repl_folder     = os.join_path(os.vtmp_dir(), 'v', 'repl')
+	repl_folder     = os.join_path(os.vtmp_dir(), 'repl')
 )
 
 enum FnType {

--- a/vlib/io/util/util_test.v
+++ b/vlib/io/util/util_test.v
@@ -5,7 +5,7 @@ const (
 	// tfolder will contain all the temporary files/subfolders made by
 	// the different tests. It would be removed in testsuite_end(), so
 	// individual os tests do not need to clean up after themselves.
-	tfolder = os.join_path(os.vtmp_dir(), 'v', 'tests', 'io_util_test')
+	tfolder = os.join_path(os.vtmp_dir(), 'tests', 'io_util_test')
 )
 
 fn testsuite_begin() {

--- a/vlib/net/unix/unix_test.v
+++ b/vlib/net/unix/unix_test.v
@@ -1,9 +1,10 @@
 import os
 import net.unix
 
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'unix_test')
-
-const test_port = os.join_path(tfolder, 'unix_domain_socket')
+const (
+	tfolder   = os.join_path(os.vtmp_dir(), 'unix_test')
+	test_port = os.join_path(tfolder, 'unix_domain_socket')
+)
 
 fn testsuite_begin() {
 	os.mkdir_all(tfolder) or {}

--- a/vlib/net/unix/use_net_and_net_unix_together_test.v
+++ b/vlib/net/unix/use_net_and_net_unix_together_test.v
@@ -2,12 +2,11 @@ import os
 import net.unix
 import net
 
-// ensure that `net` is used, i.e. no warnings
-const use_net = net.no_timeout
-
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'net_and_unix_together')
-
-const test_port = os.join_path(tfolder, 'unix_domain_socket')
+const (
+	use_net   = net.no_timeout // ensure that `net` is used, i.e. no warnings
+	tfolder   = os.join_path(os.vtmp_dir(), 'net_and_unix_together')
+	test_port = os.join_path(tfolder, 'unix_domain_socket')
+)
 
 fn testsuite_begin() {
 	os.mkdir_all(tfolder) or {}

--- a/vlib/orm/orm_sql_or_blocks_test.v
+++ b/vlib/orm/orm_sql_or_blocks_test.v
@@ -6,9 +6,10 @@ struct User {
 	name string [unique]
 }
 
-const db_folder = os.join_path(os.vtmp_dir(), 'v', 'orm_sql')
-
-const db_path = os.join_path(db_folder, 'sql_statement_or_blocks.db')
+const (
+	db_folder = os.join_path(os.vtmp_dir(), 'orm_sql')
+	db_path   = os.join_path(db_folder, 'sql_statement_or_blocks.db')
+)
 
 fn testsuite_begin() {
 	os.mkdir_all(db_folder) or {}

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -1,8 +1,9 @@
 import os
 
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'tests', 'os_file_test')
-
-const tfile = os.join_path_single(tfolder, 'test_file')
+const (
+	tfolder = os.join_path(os.vtmp_dir(), 'tests', 'os_file_test')
+	tfile   = os.join_path_single(tfolder, 'test_file')
+)
 
 fn testsuite_begin() {
 	os.rmdir_all(tfolder) or {}

--- a/vlib/os/find_abs_path_of_executable_test.v
+++ b/vlib/os/find_abs_path_of_executable_test.v
@@ -1,7 +1,7 @@
 import os
 
 fn test_find_abs_path_of_executable() {
-	tfolder := os.join_path(os.vtmp_dir(), 'v', 'tests', 'filepath_test')
+	tfolder := os.join_path(os.vtmp_dir(), 'tests', 'filepath_test')
 	os.rmdir_all(tfolder) or {}
 	assert !os.is_dir(tfolder)
 	os.mkdir_all(tfolder)!

--- a/vlib/os/inode_test.v
+++ b/vlib/os/inode_test.v
@@ -4,7 +4,7 @@ const (
 	// tfolder will contain all the temporary files/subfolders made by
 	// the different tests. It would be removed in testsuite_end(), so
 	// individual os tests do not need to clean up after themselves.
-	tfolder = os.join_path(os.vtmp_dir(), 'v', 'tests', 'inode_test')
+	tfolder = os.join_path(os.vtmp_dir(), 'tests', 'inode_test')
 )
 
 fn testsuite_begin() {

--- a/vlib/os/os_test.v
+++ b/vlib/os/os_test.v
@@ -5,7 +5,7 @@ const (
 	// tfolder will contain all the temporary files/subfolders made by
 	// the different tests. It would be removed in testsuite_end(), so
 	// individual os tests do not need to clean up after themselves.
-	tfolder = os.join_path(os.vtmp_dir(), 'v', 'tests', 'os_test')
+	tfolder = os.join_path(os.vtmp_dir(), 'tests', 'os_test')
 )
 
 // os.args has to be *already initialized* with the program's argc/argv at this point

--- a/vlib/os/process_test.v
+++ b/vlib/os/process_test.v
@@ -6,7 +6,7 @@ import time
 const (
 	vexe                   = os.getenv('VEXE')
 	vroot                  = os.dir(vexe)
-	tfolder                = os.join_path(os.vtmp_dir(), 'v', 'tests', 'os_process')
+	tfolder                = os.join_path(os.vtmp_dir(), 'tests', 'os_process')
 	test_os_process        = os.join_path(tfolder, 'test_os_process.exe')
 	test_os_process_source = os.join_path(vroot, 'cmd/tools/test_os_process.v')
 )

--- a/vlib/stbi/stbi_test.v
+++ b/vlib/stbi/stbi_test.v
@@ -1,7 +1,7 @@
 import os
 import stbi
 
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'stbi')
+const tfolder = os.join_path(os.vtmp_dir(), 'stbi')
 
 fn testsuite_begin() {
 	os.mkdir_all(tfolder) or {}

--- a/vlib/toml/tests/alexcrichton_toml_rs_test.v
+++ b/vlib/toml/tests/alexcrichton_toml_rs_test.v
@@ -37,7 +37,7 @@ const (
 	]
 	tests_folder           = os.join_path('test-suite', 'tests')
 	jq                     = os.find_abs_path_of_executable('jq') or { '' }
-	compare_work_dir_root  = os.join_path(os.vtmp_dir(), 'v', 'toml', 'alexcrichton')
+	compare_work_dir_root  = os.join_path(os.vtmp_dir(), 'toml', 'alexcrichton')
 	// From: https://stackoverflow.com/a/38266731/1904615
 	jq_normalize           = r'# Apply f to composite entities recursively using keys[], and to atoms
 def sorted_walk(f):

--- a/vlib/toml/tests/burntsushi_toml_test.v
+++ b/vlib/toml/tests/burntsushi_toml_test.v
@@ -27,7 +27,7 @@ const (
 	//'integer/long.toml', // TODO https://github.com/vlang/v/issues/9507
 
 	jq                     = os.find_abs_path_of_executable('jq') or { '' }
-	compare_work_dir_root  = os.join_path(os.vtmp_dir(), 'v', 'toml', 'burntsushi')
+	compare_work_dir_root  = os.join_path(os.vtmp_dir(), 'toml', 'burntsushi')
 	// From: https://stackoverflow.com/a/38266731/1904615
 	jq_normalize           = r'# Apply f to composite entities recursively using keys[], and to atoms
 def sorted_walk(f):

--- a/vlib/toml/tests/iarna_toml_spec_test.v
+++ b/vlib/toml/tests/iarna_toml_spec_test.v
@@ -43,7 +43,7 @@ const (
 
 	jq                     = os.find_abs_path_of_executable('jq') or { '' }
 	python                 = os.find_abs_path_of_executable('python') or { '' }
-	compare_work_dir_root  = os.join_path(os.vtmp_dir(), 'v', 'toml', 'iarna')
+	compare_work_dir_root  = os.join_path(os.vtmp_dir(), 'toml', 'iarna')
 	// From: https://stackoverflow.com/a/38266731/1904615
 	jq_normalize           = r'# Apply f to composite entities recursively using keys[], and to atoms
 def sorted_walk(f):

--- a/vlib/toml/tests/toml_test.v
+++ b/vlib/toml/tests/toml_test.v
@@ -68,7 +68,7 @@ fn test_toml() {
 }
 
 fn test_toml_file() {
-	out_path := os.join_path(os.vtmp_dir(), 'v', 'toml_tests')
+	out_path := os.join_path(os.vtmp_dir(), 'toml_tests')
 	test_file := os.join_path(out_path, 'toml_example.toml')
 	os.mkdir_all(out_path) or { assert false }
 	defer {

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -2,9 +2,10 @@ module main
 
 import os
 
-const test_path = os.join_path(os.vtmp_dir(), 'v', 'run_check')
-
-const vexe = @VEXE
+const (
+	vexe      = @VEXE
+	test_path = os.join_path(os.vtmp_dir(), 'run_check')
+)
 
 fn testsuite_begin() {
 	os.mkdir_all(test_path) or {}

--- a/vlib/v/builder/interpreterbuilder/v_interpret_test.v
+++ b/vlib/v/builder/interpreterbuilder/v_interpret_test.v
@@ -9,7 +9,7 @@ fn interpreter_wrap(a string) string {
 }
 
 fn interp_test(expression string, expected string) ! {
-	tmpdir := os.join_path(os.vtmp_dir(), 'v', 'interpret_test_${rand.ulid()}')
+	tmpdir := os.join_path(os.vtmp_dir(), 'interpret_test_${rand.ulid()}')
 	os.mkdir_all(tmpdir) or {}
 	defer {
 		os.rmdir_all(tmpdir) or {}

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -23,7 +23,7 @@ fn mm(s string) string {
 fn test_out_files() {
 	println(term.colorize(term.green, '> testing whether .out files match:'))
 	os.chdir(vroot) or {}
-	output_path := os.join_path(os.vtmp_dir(), 'v', 'coutput', 'out')
+	output_path := os.join_path(os.vtmp_dir(), 'coutput', 'out')
 	os.mkdir_all(output_path)!
 	defer {
 		os.rmdir_all(output_path) or {}
@@ -97,7 +97,7 @@ fn test_out_files() {
 fn test_c_must_have_files() {
 	println(term.colorize(term.green, '> testing whether `.c.must_have` files match:'))
 	os.chdir(vroot) or {}
-	output_path := os.join_path(os.vtmp_dir(), 'v', 'coutput', 'c_must_have')
+	output_path := os.join_path(os.vtmp_dir(), 'coutput', 'c_must_have')
 	os.mkdir_all(output_path)!
 	defer {
 		os.rmdir_all(output_path) or {}

--- a/vlib/v/gen/golang/tests/golang_test.v
+++ b/vlib/v/gen/golang/tests/golang_test.v
@@ -19,7 +19,7 @@ fn test_golang() {
 	dir := os.join_path(vroot, 'vlib/v/gen/golang/tests')
 	files := os.ls(dir) or { panic(err) }
 	//
-	wrkdir := os.join_path(os.vtmp_dir(), 'v', 'tests', 'golang')
+	wrkdir := os.join_path(os.vtmp_dir(), 'tests', 'golang')
 	os.mkdir_all(wrkdir) or { panic(err) }
 	defer {
 		os.rmdir_all(wrkdir) or {}

--- a/vlib/v/gen/js/jsgen_test.v
+++ b/vlib/v/gen/js/jsgen_test.v
@@ -2,7 +2,7 @@ import os
 
 const (
 	test_dir     = os.join_path('vlib', 'v', 'gen', 'js', 'tests')
-	output_dir   = os.join_path(os.vtmp_dir(), 'v', '_js_tests/')
+	output_dir   = os.join_path(os.vtmp_dir(), '_js_tests/')
 	v_options    = '-b js -w'
 	node_options = ''
 )

--- a/vlib/v/gen/native/tests/native_test.v
+++ b/vlib/v/gen/native/tests/native_test.v
@@ -21,7 +21,7 @@ fn test_native() {
 	dir := os.join_path(vroot, 'vlib', 'v', 'gen', 'native', 'tests')
 	files := os.ls(dir) or { panic(err) }
 	//
-	wrkdir := os.join_path(os.vtmp_dir(), 'v', 'tests', 'native')
+	wrkdir := os.join_path(os.vtmp_dir(), 'tests', 'native')
 	os.mkdir_all(wrkdir) or { panic(err) }
 	defer {
 		os.rmdir_all(wrkdir) or {}

--- a/vlib/v/gen/wasm/tests/wasm_test.v
+++ b/vlib/v/gen/wasm/tests/wasm_test.v
@@ -29,7 +29,7 @@ fn test_wasm() {
 	dir := os.join_path(vroot, 'vlib/v/gen/wasm/tests')
 	files := os.ls(dir) or { panic(err) }
 	//
-	wrkdir := os.join_path(os.vtmp_dir(), 'v', 'tests', 'wasm')
+	wrkdir := os.join_path(os.vtmp_dir(), 'tests', 'wasm')
 	os.mkdir_all(wrkdir) or { panic(err) }
 	defer {
 		os.rmdir_all(wrkdir) or {}

--- a/vlib/v/live/live_test.v
+++ b/vlib/v/live/live_test.v
@@ -33,7 +33,7 @@ TODO: Cleanup this when/if v has better process control/communication primitives
 */
 const (
 	vexe                = os.getenv('VEXE')
-	vtmp_folder         = os.join_path(os.vtmp_dir(), 'v', 'tests', 'live')
+	vtmp_folder         = os.join_path(os.vtmp_dir(), 'tests', 'live')
 	main_source_file    = os.join_path(vtmp_folder, 'main.v')
 	tmp_file            = os.join_path(vtmp_folder, 'mymodule', 'generated_live_module.tmp')
 	source_file         = os.join_path(vtmp_folder, 'mymodule', 'mymodule.v')

--- a/vlib/v/pref/options_test.v
+++ b/vlib/v/pref/options_test.v
@@ -3,9 +3,10 @@
 import os
 import time
 
-const vexe = @VEXE
-
-const tfolder = os.join_path(os.vtmp_dir(), 'v', 'custom_compile')
+const (
+	vexe    = @VEXE
+	tfolder = os.join_path(os.vtmp_dir(), 'custom_compile')
+)
 
 fn testsuite_begin() {
 	os.mkdir_all(tfolder) or {}

--- a/vlib/v/slow_tests/crun_mode/crun_test.v
+++ b/vlib/v/slow_tests/crun_mode/crun_test.v
@@ -1,11 +1,11 @@
 import os
 import time
 
-const crun_folder = os.join_path(os.vtmp_dir(), 'v', 'crun_folder')
-
-const vprogram_file = os.join_path(crun_folder, 'vprogram.vv')
-
-const vexe = os.getenv('VEXE')
+const (
+	vexe          = os.getenv('VEXE')
+	crun_folder   = os.join_path(os.vtmp_dir(), 'crun_folder')
+	vprogram_file = os.join_path(crun_folder, 'vprogram.vv')
+)
 
 fn testsuite_begin() {
 	os.setenv('VCACHE', crun_folder, true)

--- a/vlib/v/slow_tests/valgrind/valgrind_test.v
+++ b/vlib/v/slow_tests/valgrind/valgrind_test.v
@@ -67,7 +67,7 @@ fn test_all() {
 	mut files := os.ls(dir) or { panic(err) }
 	files.sort()
 	//
-	wrkdir := os.join_path(os.vtmp_dir(), 'v', 'tests', 'valgrind')
+	wrkdir := os.join_path(os.vtmp_dir(), 'tests', 'valgrind')
 	os.mkdir_all(wrkdir) or { panic(err) }
 	os.chdir(wrkdir) or {}
 	//

--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -170,7 +170,7 @@ fn test_closure_return_${styp}_${i}() ! {
 
 	code := v_code.str()
 	println('Compiling V code (${code.count('\n')} lines) ...')
-	wrkdir := os.join_path(os.vtmp_dir(), 'v', 'tests', 'closures')
+	wrkdir := os.join_path(os.vtmp_dir(), 'tests', 'closures')
 	os.mkdir_all(wrkdir)!
 	os.chdir(wrkdir)!
 	full_path_to_target := os.join_path(wrkdir, 'closure_return_test.v')

--- a/vlib/v/tests/run_v_code_from_stdin_test.v
+++ b/vlib/v/tests/run_v_code_from_stdin_test.v
@@ -1,10 +1,10 @@
 import os
 
-const vexe = os.getenv('VEXE')
-
-const turn_off_vcolors = os.setenv('VCOLORS', 'never', true)
-
-const vtmp_folder = os.join_path(os.vtmp_dir(), 'v', 'tests', 'run_v_code')
+const (
+	vexe             = os.getenv('VEXE')
+	turn_off_vcolors = os.setenv('VCOLORS', 'never', true)
+	vtmp_folder      = os.join_path(os.vtmp_dir(), 'tests', 'run_v_code')
+)
 
 fn test_vexe_is_set() {
 	assert vexe != ''

--- a/vlib/v/vcache/vcache_test.v
+++ b/vlib/v/vcache/vcache_test.v
@@ -1,9 +1,7 @@
 import os
 import v.vcache
 
-const (
-	vcache_folder = os.join_path(os.vtmp_dir(), 'v', 'cache_folder')
-)
+const vcache_folder = os.join_path(os.vtmp_dir(), 'cache_folder')
 
 fn check_cache_entry_fpath_invariants(x string, extension string) {
 	a := x.replace(vcache_folder + os.path_separator, '').split(os.path_separator)

--- a/vlib/vweb/assets/assets_test.v
+++ b/vlib/vweb/assets/assets_test.v
@@ -1,7 +1,7 @@
 import vweb.assets
 import os
 
-const base_cache_dir = os.join_path(os.vtmp_dir(), 'v', 'assets_test_cache')
+const base_cache_dir = os.join_path(os.vtmp_dir(), 'assets_test_cache')
 
 fn testsuite_begin() {
 	os.mkdir_all(base_cache_dir) or {}


### PR DESCRIPTION
Wants to update some the test paths from a time before `vtemp_dir` was integrated. THe second minor change is grouping of constant declarations in the related scope when appropriate.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a1a714</samp>

This pull request refactors and cleans up several test files in the vlang/v repository. It removes the redundant 'v' subdirectory from the temporary directory paths, uses const blocks to declare constants, and renames some test files to avoid name clashes with tools. These changes make the code more consistent, concise, and readable.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a1a714</samp>

*  Simplify temporary directory paths by removing unused 'v' subdirectory ([link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-3f32d9dd9a4acbefa06dd909e4c35de09d192b867b1f98dec122192f2825a41bL29-R29), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-ff8302fd8e3a46aa8560774702d6426e12ba0d34a1fa99794c9952c43318ef21L24-R24), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-8182313c83bb74ff9a16cdfcb845e86d1deb3c915baaee4f50a0da3048ae2d6cL61-R61), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-f018bd97a2f57fb8f2eca1f10fe94f293f04a962284facda13126da1cc913644L38-R38), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-6ae6eb3f588d7a08549ba548b18fc814b395452e259d37950d5fcb32e5a25c15L8-R8), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-064ba74ae2bc3b8138d36d9554cfdd4fae77ba7f7140362a373ff64a2d692e91L4-R4), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-52c012ca53e1703779e6aaacdd9f87b6caba759070778906b126deda5f2fa290L7-R7), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-db2ed44d3850507c8e5766d5bb6dd606072c43a48d393e4d3a6a93b9fc9df2b8L8-R8), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-a1461f7853d962963f76a154b9bc24748768faf6bcc95339696fc0f1f04d9db4L9-R9), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-d30afa08be4677e284969f84e76ef5f3a62ab7320be41337b87ef4e9683b21f8L4-R4), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-f03ffbca72155fd5a1edbd50cb0ffc01280ad9b4182df17df1cf081532d052d4L40-R40), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-f9064af73feafbb4524b21cbe010c047f97e8ef25823d26d6e7c4a08a902bd34L30-R30), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-f9e436e6d2d57cf88c41f996f2c4be49302cc0559cd810f254cc7fcb7536bae1L46-R46), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-5123c6cf5830b54af6950a907316a571e5381ac9e05cabc3a86dd14c0da2e6d7L71-R71))
* Refactor test files to use const blocks for declaring constants and avoid name clashes with tools ([link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcL3-R7), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-8e528eda66e365d90a3b1d0a48e3b70c304c8ed69d7de5193fb70fa908c0260dL3-R7), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-029fe2d91cedc0de4340e3851e3abdb62659d1e69293932216b3def65236fb17L4-R8), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-65c2ec8baa38ced4394def68b275ed3b9469ede5df9a4640431a56d00998506cL5-R10), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-816dad9be24f4df6b8335b9115cdb3e21587e3ef5500799d67a785161fff1284L9-R13), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-085798d5d8e26e8963c7ee340043ea7839ae9d946d453b939a2b3b85df8aea30L3-R7))
* Rename `vbump_test.v` and `vcomplete_test.v` to `test_if_v_test_system_works.v` to make their purpose clearer ([link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-b31157f9520c9a9a85dae46e062f3d37bc67cbf7ec6463d4885fa44059b9eebcL3-R7), [link](https://github.com/vlang/v/pull/19716/files?diff=unified&w=0#diff-8e528eda66e365d90a3b1d0a48e3b70c304c8ed69d7de5193fb70fa908c0260dL3-R7))
