### PR TITLE
net.html: Add documentation note to parse and parse_file

### DIFF
--- a/vlib/net/html/html.v
+++ b/vlib/net/html/html.v
@@ -3,6 +3,8 @@ module html
 import os
 
 // parse parses and returns the DOM from the given text.
+// Note: this function will parse all tags to lowercase.
+// E.g. <MyTag>content<MyTag/> is converted to <mytag>content<mytag>
 pub fn parse(text string) DocumentObjectModel {
 	mut parser := Parser{}
 	parser.parse_html(text)
@@ -10,6 +12,8 @@ pub fn parse(text string) DocumentObjectModel {
 }
 
 // parse_file parses and returns the DOM from the contents of a file.
+// Note: this function will parse all tags to lowercase.
+// E.g. <MyTag>content<MyTag/> is converted to <mytag>content<mytag>
 pub fn parse_file(filename string) DocumentObjectModel {
 	content := os.read_file(filename) or { return DocumentObjectModel{
 		root: &Tag{}


### PR DESCRIPTION
### Problem:

- `net.html::parse` turns all tags to lowercase without expressing it in any of the docs **I found**, unless you check the actual implementation.

Example:

```XML
<MyTag></MyTag>
```

If we call `get_tags` with `MyTag` it fails, since the parser parses all tags to lowercase. This is a problem because the end user asks what he can see in the `XML` data.

### Possible solutions and what was done:

I had two ideas:

1. Set all input to `get_tag` or `get_tags` to lowercase.
2. Add a note to both `parse` and `parse_file` to inform the user that he should search for lowercase tags.

I decided to use the second solution since most of the web uses lowercase tags, and being able to parse `XML` with `net.html` is only a side-effect of the DOM using the XML format, even though nowadays the usage of custom tags is big and most of them follow the `PascalCase` format.
