### PR TITLE
fmt: align ternary expressions in const blocks

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -910,9 +910,17 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 				info.max = field.name.len
 			}
 			if !expr_is_single_line(field.expr) {
-				info.last_idx = i
-				align_infos << info
-				info = ValAlignInfo{}
+				is_ternary := field.expr is ast.IfExpr && field.expr.branches.len == 2
+					&& field.expr.has_else
+					&& branch_is_single_line((field.expr as ast.IfExpr).branches[0])
+					&& branch_is_single_line((field.expr as ast.IfExpr).branches[1])
+					&& (field.expr.is_expr || f.is_assign || f.inside_const
+					|| f.is_struct_init || f.single_line_fields)
+				if !is_ternary || field.name.len + field.expr.str().len > fmt.max_len.last() {
+					info.last_idx = i
+					align_infos << info
+					info = ValAlignInfo{}
+				}
 			}
 		}
 		info.last_idx = node.fields.len

--- a/vlib/v/fmt/tests/if_ternary_expected.vv
+++ b/vlib/v/fmt/tests/if_ternary_expected.vv
@@ -1,5 +1,6 @@
 const (
 	spacing_error = if true { true } else { false }
+	// Multiline result should not align with the next multiline result.
 	too_long_line = if b.no_cstep {
 		'TMP1/${b.nexpected_steps:1d}'
 	} else {
@@ -12,6 +13,12 @@ const (
 	} else {
 		false
 	}
+)
+
+const (
+	align                = if true { 'a' } else { 'b' }
+	some_longer_variable = 'foo'
+	another_var          = 'bar'
 )
 
 fn main() {

--- a/vlib/v/fmt/tests/if_ternary_input.vv
+++ b/vlib/v/fmt/tests/if_ternary_input.vv
@@ -1,7 +1,14 @@
 const (
 	spacing_error = if true {true}else{ false}
+	// Multiline result should not align with the next multiline result.
 	too_long_line = if b.no_cstep { 'TMP1/${b.nexpected_steps:1d}' } else { '${b.cstep:1d}/${b.nexpected_steps:1d}' }
 	too_many_branches = if true { true } else if true { true } else { false }
+)
+
+const (
+	align = if true { 'a' } else { 'b' }
+	some_longer_variable = 'foo'
+	another_var = 'bar'
 )
 
 fn main() {


### PR DESCRIPTION
Fixes v fmt not aligning a const ternary when it is the first element, but aligning it when it is the second.

Current formatted, different positions:
```v
const (
	spacing_error = if true { true } else { false }
	align = if true { 'a' } else { 'b' }  // <=
	quoted_vexe_path = os.quoted_path(@VEXE) // some longer variable
	vroot            = os.dir(quoted_vexe_path)
)

```
```v
const (
	spacing_error = if true { true } else { false }
	quoted_vexe_path = os.quoted_path(@VEXE) // some longer variable
	align            = if true { 'a' } else { 'b' } // <=
	vroot = os.dir(quoted_vexe_path)
)
```
```v
const (
	spacing_error = if true { true } else { false }
	quoted_vexe_path = os.quoted_path(@VEXE) // some longer variable
	vroot            = os.dir(quoted_vexe_path)
	align            = if true { 'a' } else { 'b' } // <=
)
```

Formatted with changes:
```v
const (
	spacing_error    = if true { true } else { false }
	align            = if true { 'a' } else { 'b' }
	quoted_vexe_path = os.quoted_path(@VEXE) // some longer variable
	vroot            = os.dir(quoted_vexe_path)
)
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68a23b3</samp>

This pull request improves the formatting of ternary if expressions in `v fmt`, especially for struct fields. It adds a new condition, a comment, and a test case to `vlib/v/fmt/fmt.v` and `vlib/v/fmt/tests/if_ternary_*.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68a23b3</samp>

* Improve formatting of ternary if expressions in struct fields ([link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL913-R923))
* Update and extend test cases for ternary if expressions in `vlib/v/fmt/tests/if_ternary_input.vv` and `vlib/v/fmt/tests/if_ternary_expected.vv` ([link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-bdcbb79172dc839607add83618a37df5832dfc838db96a088e962b8d6e1a97f6R3), [link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-bdcbb79172dc839607add83618a37df5832dfc838db96a088e962b8d6e1a97f6R18-R23), [link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-94e921cbc32b3a206681411135cea3f17de686452fd7ef08cb79409688c9a036L3-R13))
  - Add a comment to explain the expected formatting for multiline ternary if expressions ([link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-bdcbb79172dc839607add83618a37df5832dfc838db96a088e962b8d6e1a97f6R3))
  - Add a new test case with single-line ternary if expressions to check the alignment with other fields ([link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-bdcbb79172dc839607add83618a37df5832dfc838db96a088e962b8d6e1a97f6R18-R23), [link](https://github.com/vlang/v/pull/19721/files?diff=unified&w=0#diff-94e921cbc32b3a206681411135cea3f17de686452fd7ef08cb79409688c9a036L3-R13))
