### PR TITLE
os: add `execute_opt` function

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -881,6 +881,14 @@ pub fn execute_or_exit(cmd string) Result {
 	return res
 }
 
+pub fn execute_opt(cmd string) !Result {
+	res := execute(cmd)
+	if res.exit_code != 0 {
+		return error(res.output)
+	}
+	return res
+}
+
 // quoted path - return a quoted version of the path, depending on the platform.
 pub fn quoted_path(path string) string {
 	$if windows {

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -881,6 +881,7 @@ pub fn execute_or_exit(cmd string) Result {
 	return res
 }
 
+// execute_opt returns the os.Result of executing `cmd`, or an error on failure.
 pub fn execute_opt(cmd string) !Result {
 	res := execute(cmd)
 	if res.exit_code != 0 {


### PR DESCRIPTION
Add `execute_opt` function to simplify error handling. Would allow to use or-blocks with `return`s / `continue`s, passing errors as values from subfunctions etc.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02d7673</samp>

Add `execute_opt` function to `vlib/os/os.v` to run commands and handle errors with `Result`. This enables parallel testing support.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02d7673</samp>

*  Add `execute_opt` function to simplify error handling when running external commands ([link](https://github.com/vlang/v/pull/19723/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09R884-R891))
