### PR TITLE
vdoc: support for highlighting code in README's

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -523,7 +523,7 @@ fn no_quotes(s string) string {
 struct MdHtmlCodeHighlighter {
 mut:
 	language string
-	table &ast.Table
+	table    &ast.Table
 }
 
 fn (f &MdHtmlCodeHighlighter) transform_attribute(p markdown.ParentType, name string, value string) string {


### PR DESCRIPTION
Hi everyone. It's been a while. Just checking in to see how V was doing lately and it turns out there's no code highlighting yet for README's in vdoc (*shocked face*). Good thing I'm on a break right now so I have time to fix this.

This just utilizes the things that I have implemented in the `markdown` library (see PRs below) as well as the good ol' `html_highlight` function already available in vdoc so there's few code added here.

Requires vlang/markdown#15 and vlang/markdown#16 to be merged.

Just to show the power of code highlighting changes things, here's a side-by-side comparison:
|Before|After|
|--|--|
|![image](https://github.com/vlang/v/assets/7358345/ed5f2ee6-da7e-41b0-9e8c-bb23e6d83a38)|![image](https://github.com/vlang/v/assets/7358345/2708b187-c3cc-41b3-92ce-6ab79990d619)|

More power to everyone who makes the vision of V possible.