### PR TITLE
os!: update functions that wrap execute to return result output

### DIFF
--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -35,7 +35,7 @@ fn lsystem(cmd string) int {
 
 fn lexec(cmd string) string {
 	elog('  lexec: ${cmd}')
-	return os.execute_or_exit(cmd).output.trim_right('\r\n')
+	return os.execute_or_exit(cmd).trim_right('\r\n')
 }
 
 fn main() {
@@ -217,7 +217,7 @@ fn measure_steps_one_sample(vdir string) (int, int, int, int, int, string) {
 	resp := os.execute_or_exit(cmd)
 
 	mut scan, mut parse, mut check, mut cgen, mut vlines := 0, 0, 0, 0, 0
-	lines := resp.output.split_into_lines()
+	lines := resp.split_into_lines()
 	if lines.len == 3 {
 		parse = lines[0].before('.').int()
 		check = lines[1].before('.').int()

--- a/cmd/tools/vcreate/vcreate_test.v
+++ b/cmd/tools/vcreate/vcreate_test.v
@@ -23,8 +23,7 @@ fn init_and_check() ! {
 	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
 
 	x := os.execute_or_exit('${os.quoted_path(@VEXE)} run .')
-	assert x.exit_code == 0
-	assert x.output.trim_space() == 'Hello World!'
+	assert x.trim_space() == 'Hello World!'
 
 	if is_main_file_preexisting == true {
 		assert main_last_modified_time == os.file_last_mod_unix('src/main.v')

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -54,12 +54,8 @@ fn main() {
 
 fn compile(vroot string, cmd string) {
 	result := os.execute_or_exit(cmd)
-	if result.exit_code != 0 {
-		eprintln('cannot compile to `${vroot}`: \n${result.output}')
-		exit(1)
-	}
-	if result.output.len > 0 {
-		println(result.output.trim_space())
+	if result.len > 0 {
+		println(result.trim_space())
 	}
 }
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6958,7 +6958,7 @@ An example `deploy.vsh`:
 // print command then execute it
 fn sh(cmd string) {
 	println('❯ ${cmd}')
-	print(execute_or_exit(cmd).output)
+	print(execute_or_exit(cmd))
 }
 
 // Remove if build/ exits, ignore any errors if it doesn't

--- a/examples/dynamic_library_loader/use_test.v
+++ b/examples/dynamic_library_loader/use_test.v
@@ -61,7 +61,7 @@ fn test_can_compile_and_use_library_with_skip_unused_location1_dir() {
 fn v_compile(vopts string) os.Result {
 	cmd := '${os.quoted_path(vexe)} -showcc ${vopts}'
 	// dump(cmd)
-	res := os.execute_or_exit(cmd)
+	res := os.execute(cmd)
 	// dump(res)
 	assert res.exit_code == 0
 	return res

--- a/vlib/builtin/linux_bare/old/syscallwrapper_test.v
+++ b/vlib/builtin/linux_bare/old/syscallwrapper_test.v
@@ -16,9 +16,8 @@ fn test_syscallwrappers() {
 				checks_v := 'checks.v'
 				assert os.exists(checks_v)
 				rc := os.execute_or_exit('v run ${checks_v}')
-				assert rc.exit_code == 0
-				assert !rc.output.contains('V panic: An assertion failed.')
-				assert !rc.output.contains('failed')
+				assert !rc.contains('V panic: An assertion failed.')
+				assert !rc.contains('failed')
 			} else {
 				panic("Can't find test directory")
 			}

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -860,34 +860,41 @@ pub mut:
 	machine  string
 }
 
-pub fn execute_or_panic(cmd string) Result {
+[params]
+pub struct ExitOptions {
+	exit_code ?int
+}
+
+// execute_or_exit executes the given `cmd` and returns it's output, or exits on failure.
+pub fn execute_or_exit(cmd string, opts ExitOptions) string {
+	res := execute(cmd)
+	if res.exit_code != 0 {
+		eprintln('failed    cmd: ${cmd}')
+		eprintln('failed   code: ${res.exit_code}')
+		eprintln(res.output)
+		exit(opts.exit_code or { res.exit_code })
+	}
+	return res.output
+}
+
+// execute_or_panic executes the given `cmd` and returns it's output, or panics on failure.
+pub fn execute_or_panic(cmd string) string {
 	res := execute(cmd)
 	if res.exit_code != 0 {
 		eprintln('failed    cmd: ${cmd}')
 		eprintln('failed   code: ${res.exit_code}')
 		panic(res.output)
 	}
-	return res
+	return res.output
 }
 
-pub fn execute_or_exit(cmd string) Result {
-	res := execute(cmd)
-	if res.exit_code != 0 {
-		eprintln('failed    cmd: ${cmd}')
-		eprintln('failed   code: ${res.exit_code}')
-		eprintln(res.output)
-		exit(1)
-	}
-	return res
-}
-
-// execute_opt returns the os.Result of executing `cmd`, or an error on failure.
-pub fn execute_opt(cmd string) !Result {
+// execute_opt executes the given `cmd` and returns it's output, or an error on failure.
+pub fn execute_opt(cmd string) !string {
 	res := execute(cmd)
 	if res.exit_code != 0 {
 		return error(res.output)
 	}
-	return res
+	return res.output
 }
 
 // quoted path - return a quoted version of the path, depending on the platform.

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -248,7 +248,7 @@ pub fn (mut p Preferences) default_c_compiler() {
 		$if !ios {
 			ios_sdk := if p.is_ios_simulator { 'iphonesimulator' } else { 'iphoneos' }
 			ios_sdk_path_res := os.execute_or_exit('xcrun --sdk ${ios_sdk} --show-sdk-path')
-			mut isysroot := ios_sdk_path_res.output.replace('\n', '')
+			mut isysroot := ios_sdk_path_res.replace('\n', '')
 			arch := if p.is_ios_simulator {
 				'-arch x86_64 -arch arm64'
 			} else {

--- a/vlib/v/slow_tests/repl/repl_test.v
+++ b/vlib/v/slow_tests/repl/repl_test.v
@@ -12,8 +12,10 @@ fn test_the_v_compiler_can_be_invoked() {
 	println('vexecutable: ${vexec}')
 	assert vexec != ''
 	vcmd := '${os.quoted_path(vexec)} -version'
-	r := os.execute_or_exit(vcmd)
-	assert r.exit_code == 0
+	r := os.execute_opt(vcmd) or {
+		assert false, err.str()
+		return
+	}
 	// println('"$vcmd" exit_code: $r.exit_code | output: $r.output')
 	vcmd_error := '${os.quoted_path(vexec)} nonexisting.v'
 	r_error := os.execute(vcmd_error)


### PR DESCRIPTION
This PR wants to update the functions that wrap `os.execute` to return the output of the given command.

This is for the reason that - if we look at `os.Result` - it is the only relevant data they can return.

https://github.com/vlang/v/blob/cc1193f3313818301cb2accc7ab23ff28fdd867a/vlib/os/os.v#L20-L25

If they don't fail the exit code is already always `0`. And when the `stderr string TODO` in `os.Result` will be implemented, it is also only relevant for the error handling and not in the return of the wrapping functions.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e8140c</samp>

This pull request simplifies the usage and implementation of the `os` module functions for executing external commands. It makes them return a string instead of a struct, and adds an optional parameter for custom exit codes. It also updates the code and tests that use these functions to remove unnecessary field accesses and error checks.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e8140c</samp>

*  Refactor `os` module to return strings from `execute_or_exit`, `execute_or_panic`, and `execute_opt` functions, and add optional `exit_code` parameter to `execute_or_exit` ([link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09L863-R897))
* Simplify `lexec` function in `cmd/tools/fast/fast.v` by removing redundant `.output` field access from `os.execute_or_exit` result ([link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-5a23e924c283ba49089dd296b6466b39bce8b9a8b81b3b198e8feebe89cdfc76L38-R38), [link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-5a23e924c283ba49089dd296b6466b39bce8b9a8b81b3b198e8feebe89cdfc76L220-R220))
* Simplify `compile` function in `cmd/tools/vself.v` by removing unnecessary exit code check and `.output` field access from `os.execute_or_exit` result ([link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-5b3c979bed17bd7a991645efd1958bd54b3e5a68d8a646e44dd98360b0b4898bL57-R59))
* Update test code for `vcreate` tool, dynamic library loader, Linux bare syscall wrapper, and REPL to use new `os` functions and remove `.output` and `.exit_code` field accesses ([link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-495941a97c5f6db38489f3903e16aaee611ca7e8fd7ffad958265d969bef56faL26-R26), [link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-a70840d28724bb82b79b3f8cbc56ba334821afe7a6b21cf8a3b74f0a076ccc73L64-R64), [link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-e35017ae00f5a62165bbcfc269dca09827e9984ed863ea0a3698afb9a337d9b6L19-R20), [link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-ac0246eb90424ddd37032ebadd3b982174162f85e22d12468cb311e1841ffda6L15-R18))
* Update documentation example for cross-platform shell scripts in V to use new `os.execute_or_exit` function and remove `.output` field access and `print` function call ([link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L6961-R6961))
* Modify code for default preferences to use new `os.execute_or_exit` function and remove `.output` field access ([link](https://github.com/vlang/v/pull/19728/files?diff=unified&w=0#diff-e178ddff137d18fe9589236ddc349d5eb75f844d32146886b33888241784e3c4L251-R251))
