### PR TITLE
vdoc: escape tags in highlighted html

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -533,10 +533,10 @@ fn (f &MdHtmlCodeHighlighter) transform_attribute(p markdown.ParentType, name st
 fn (f &MdHtmlCodeHighlighter) transform_content(parent markdown.ParentType, text string) string {
 	if parent is markdown.MD_BLOCKTYPE && parent == .md_block_code {
 		if f.language == 'v' || f.language == 'vlang' {
-			return html_highlight(text, f.table)
+			return html_highlight(html_tag_escape(text), f.table)
 		}
 	}
-	return markdown.default_html_transformer.transform_content(parent, text)
+	return markdown.default_html_transformer.transform_content(parent, html_tag_escape(text))
 }
 
 fn (mut f MdHtmlCodeHighlighter) config_set(key string, val string) {


### PR DESCRIPTION
Fixes #19730 

![Screenshot_20231101_235220](https://github.com/vlang/v/assets/34311583/b4e946eb-60d7-46eb-a93c-7842bff34fcb)

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6f936d</samp>

Escape HTML tags in code blocks and other content in `vdoc` HTML output. This improves security and formatting of the generated documentation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6f936d</samp>

*  Escape HTML tags in code blocks and other content to prevent injection or rendering issues ([link](https://github.com/vlang/v/pull/19731/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L536-R539),                             F
