### PR TITLE
cgen: reduce expense in repetitively called functions by using consts

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -7,6 +7,8 @@ import strings
 import v.ast
 import v.util
 
+const c_fn_name_escape_seq = ['[', '_T_', ']', '']
+
 fn (mut g Gen) is_used_by_main(node ast.FnDecl) bool {
 	mut is_used_by_main := true
 	if g.pref.skip_unused {
@@ -449,7 +451,7 @@ fn (mut g Gen) c_fn_name(node &ast.FnDecl) string {
 		unwrapped_rec_typ := g.unwrap_generic(node.receiver.typ)
 		name = g.cc_type(unwrapped_rec_typ, false) + '_' + name
 		if g.table.sym(unwrapped_rec_typ).kind == .placeholder {
-			name = name.replace_each(['[', '_T_', ']', ''])
+			name = name.replace_each(c.c_fn_name_escape_seq)
 		}
 	}
 	if node.language == .c {
@@ -613,7 +615,7 @@ fn (mut g Gen) fn_decl_params(params []ast.Param, scope &ast.Scope, is_variadic 
 			typ = g.table.sym(typ).array_info().elem_type.set_flag(.variadic)
 		}
 		param_type_sym := g.table.sym(typ)
-		mut param_type_name := g.typ(typ).replace_each(['[', '_T_', ']', ''])
+		mut param_type_name := g.typ(typ).replace_each(c.c_fn_name_escape_seq)
 		if param_type_sym.kind == .function && !typ.has_flag(.option) {
 			info := param_type_sym.info as ast.FnType
 			func := info.func


### PR DESCRIPTION
Those functions can be called quite often since the check nodes.

Using a constant declaration for the arrays with static data, instead of re-defining them per call, makes them a little cheaper.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d659fa</samp>

Refactor C code generation for generic functions and methods in `vlib/v/gen/c/fn.v` by using a constant to escape generic brackets.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d659fa</samp>

*  Define a constant `c_fn_name_escape_seq` to hold the characters to be replaced in generic function names ([link](https://github.com/vlang/v/pull/19732/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9R10-R11))
* Use `c_fn_name_escape_seq` instead of literal arrays to replace generic brackets in receiver and parameter type names of methods and functions ([link](https://github.com/vlang/v/pull/19732/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L452-R454), [link](https://github.com/vlang/v/pull/19732/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L616-R618))
