### PR TITLE
ast: reduce expense in repetitively called functions by using constants

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -75,7 +75,11 @@ pub fn (mut t Table) free() {
 	}
 }
 
-pub const invalid_type_idx = -1
+pub const (
+	invalid_type_idx     = -1
+	fn_type_escape_seq   = [' ', '', '(', '_', ')', '']
+	map_cname_escape_seq = ['[', '_T_', ', ', '_', ']', '']
+)
 
 pub type FnPanicHandler = fn (&Table, string)
 
@@ -862,7 +866,7 @@ pub fn (t &Table) array_cname(elem_type Type) string {
 	opt := if elem_type.has_flag(.option) { '_option_' } else { '' }
 	res := if elem_type.has_flag(.result) { '_result_' } else { '' }
 	if elem_type_sym.cname.contains('[') {
-		type_name := elem_type_sym.cname.replace_each(['[', '_T_', ', ', '_', ']', ''])
+		type_name := elem_type_sym.cname.replace_each(ast.map_cname_escape_seq)
 		return 'Array_${opt}${res}${type_name}${suffix}'
 	} else {
 		return 'Array_${opt}${res}${elem_type_sym.cname}${suffix}'
@@ -892,7 +896,7 @@ pub fn (t &Table) array_fixed_cname(elem_type Type, size int) string {
 	opt := if elem_type.has_flag(.option) { '_option_' } else { '' }
 	res := if elem_type.has_flag(.result) { '_result_' } else { '' }
 	if elem_type_sym.cname.contains('[') {
-		type_name := elem_type_sym.cname.replace_each(['[', '_T_', ', ', '_', ']', ''])
+		type_name := elem_type_sym.cname.replace_each(ast.map_cname_escape_seq)
 		return 'Array_fixed_${opt}${res}${type_name}${suffix}_${size}'
 	} else {
 		return 'Array_fixed_${opt}${res}${elem_type_sym.cname}${suffix}_${size}'
@@ -999,7 +1003,7 @@ pub fn (t &Table) map_cname(key_type Type, value_type Type) string {
 	opt := if value_type.has_flag(.option) { '_option_' } else { '' }
 	res := if value_type.has_flag(.result) { '_result_' } else { '' }
 	if value_type_sym.cname.contains('[') {
-		type_name := value_type_sym.cname.replace_each(['[', '_T_', ', ', '_', ']', ''])
+		type_name := value_type_sym.cname.replace_each(ast.map_cname_escape_seq)
 		return 'Map_${key_type_sym.cname}_${opt}${res}${type_name}${suffix}'
 	} else {
 		return 'Map_${key_type_sym.cname}_${opt}${res}${value_type_sym.cname}${suffix}'
@@ -1187,7 +1191,7 @@ pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon bool, has_decl bool)
 	cname := if f.name.len == 0 {
 		'anon_fn_${t.fn_type_signature(f)}'
 	} else {
-		util.no_dots(f.name.clone()).replace_each([' ', '', '(', '_', ')', ''])
+		util.no_dots(f.name.clone()).replace_each(ast.fn_type_escape_seq)
 	}
 	anon := f.name.len == 0 || is_anon
 	existing_idx := t.type_idxs[name]


### PR DESCRIPTION
Those functions can be called quite often since they check types.

Using a constant declaration for the arrays with static data, instead of re-defining them per call, makes them a little cheaper.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d712f3</samp>

Refactor C name generation methods in `Table` struct. Use `ast` constants to replace invalid characters in V types.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d712f3</samp>

*  Define constants for character replacement in C names of function and map types (`vlib/v/ast/table.v` [link](https://github.com/vlang/v/pull/19733/files?diff=unified&w=0#diff-cfd5d819278aed172646f4254f098c98ee8bb62abdd0fd839359f6376c913614L78-R82))
* Use `map_cname_escape_seq` constant to replace brackets and commas in array element type names (`vlib/v/ast/table.v` [link](https://github.com/vlang/v/pull/19733/files?diff=unified&w=0#diff-cfd5d819278aed172646f4254f098c98ee8bb62abdd0fd839359f6376c913614L865-R869), [link](https://github.com/vlang/v/pull/19733/files?diff=unified&w=0#diff-cfd5d819278aed172646f4254f098c98ee8bb62abdd0fd839359f6376c913614L895-R899), [link](https://github.com/vlang/v/pull/19733/files?diff=unified&w=0#diff-cfd5d819278aed172646f4254f098c98ee8bb62abdd0fd839359f6376c913614L1002-R1006))
* Use `fn_type_escape_seq` constant to replace spaces and parentheses in function names (`vlib/v/ast/table.v` [link](https://github.com/vlang/v/pull/19733/files?diff=unified&w=0#diff-cfd5d819278aed172646f4254f098c98ee8bb62abdd0fd839359f6376c913614L1190-R1194))
