### PR TITLE
tools.vpm: cleanup VCS handling and make it more robust

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -36,12 +36,11 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	}
 	final_module_path := valid_final_path_of_existing_module(result.name) or { return result }
 	vcs := vcs_used_in_dir(final_module_path) or { return result }
-	is_hg := vcs[0] == 'hg'
-	vcs_cmd_steps := supported_vcs_outdated_steps[vcs[0]]
+	is_hg := vcs.cmd == 'hg'
 	mut outputs := []string{}
-	for step in vcs_cmd_steps {
+	for step in vcs.outdated_steps {
 		path_flag := if is_hg { '-R' } else { '-C' }
-		cmd := '${vcs[0]} ${path_flag} "${final_module_path}" ${step}'
+		cmd := '${vcs.cmd} ${path_flag} "${final_module_path}" ${step}'
 		res := os.execute('${cmd}')
 		if res.exit_code < 0 {
 			verbose_println('Error command: ${cmd}')
@@ -55,7 +54,7 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 		}
 		outputs << res.output
 	}
-	// vcs[0] == 'git'
+	// vcs.cmd == 'git'
 	if !is_hg && outputs[1] != outputs[2] {
 		result.outdated = true
 	}
@@ -229,8 +228,8 @@ fn ensure_vmodules_dir_exist() {
 	}
 }
 
-fn ensure_vcs_is_installed(vcs string) ! {
-	cmd := '${vcs} ${supported_vcs_version_cmds[vcs]}'
+fn ensure_vcs_is_installed(vcs &VCS) ! {
+	cmd := '${vcs.cmd} --version'
 	verbose_println('      command: ${cmd}')
 	res := os.execute(cmd)
 	if res.exit_code != 0 {
@@ -284,18 +283,13 @@ fn url_to_module_name(modulename string) string {
 	return res
 }
 
-fn vcs_used_in_dir(dir string) ?[]string {
-	mut vcs := []string{}
-	for repo_subfolder in supported_vcs_folders {
-		checked_folder := os.real_path(os.join_path(dir, repo_subfolder))
-		if os.is_dir(checked_folder) {
-			vcs << repo_subfolder.replace('.', '')
+fn vcs_used_in_dir(dir string) ?VCS {
+	for vcs in supported_vcs.values() {
+		if os.is_dir(os.real_path(os.join_path(dir, vcs.dir))) {
+			return vcs
 		}
 	}
-	if vcs.len == 0 {
-		return none
-	}
-	return vcs
+	return none
 }
 
 fn valid_final_path_of_existing_module(modulename string) ?string {

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -18,14 +18,14 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 	zname := url_to_module_name(result.name)
 	result.final_path = valid_final_path_of_existing_module(result.name) or { return result }
 	println('Updating module "${zname}" in "${result.final_path}" ...')
-	vcs := vcs_used_in_dir(result.final_path) or { return result }[0]
+	vcs := vcs_used_in_dir(result.final_path) or { return result }
 	ensure_vcs_is_installed(vcs) or {
 		result.has_err = true
 		eprintln(err)
 		return result
 	}
-	path_flag := if vcs == 'hg' { '-R' } else { '-C' }
-	cmd := '${vcs} ${path_flag} "${result.final_path}" ${supported_vcs_update_cmds[vcs]}'
+	path_flag := if vcs.cmd == 'hg' { '-R' } else { '-C' }
+	cmd := '${vcs.cmd} ${path_flag} "${result.final_path}" ${vcs.update_arg}'
 	verbose_println('    command: ${cmd}')
 	res := os.execute('${cmd}')
 	if res.exit_code != 0 {
@@ -70,14 +70,14 @@ fn vpm_update_verbose(module_names []string) {
 		zname := url_to_module_name(name)
 		final_module_path := valid_final_path_of_existing_module(name) or { continue }
 		println('Updating module "${zname}" in "${final_module_path}" ...')
-		vcs := vcs_used_in_dir(final_module_path) or { continue }[0]
+		vcs := vcs_used_in_dir(final_module_path) or { continue }
 		ensure_vcs_is_installed(vcs) or {
 			errors++
 			eprintln(err)
 			continue
 		}
-		path_flag := if vcs == 'hg' { '-R' } else { '-C' }
-		cmd := '${vcs} ${path_flag} "${final_module_path}" ${supported_vcs_update_cmds[vcs]}'
+		path_flag := if vcs.cmd == 'hg' { '-R' } else { '-C' }
+		cmd := '${vcs.cmd} ${path_flag} "${final_module_path}" ${vcs.update_arg}'
 		verbose_println('    command: ${cmd}')
 		res := os.execute('${cmd}')
 		if res.exit_code != 0 {

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -17,36 +17,36 @@ mut:
 	vmodules_path string
 }
 
-enum Source {
-	git
-	hg
-	vpm
+struct VCS {
+	cmd            string
+	dir            string
+	update_arg     string
+	install_arg    string
+	outdated_steps []string
 }
 
 const (
-	settings                  = &VpmSettings{}
-	default_vpm_server_urls   = ['https://vpm.vlang.io', 'https://vpm.url4e.com']
-	vpm_server_urls           = rand.shuffle_clone(default_vpm_server_urls) or { [] } // ensure that all queries are distributed fairly
-	valid_vpm_commands        = ['help', 'search', 'install', 'update', 'upgrade', 'outdated',
-		'list', 'remove', 'show']
-	excluded_dirs             = ['cache', 'vlib']
-	supported_vcs_systems     = ['git', 'hg']
-	supported_vcs_folders     = ['.git', '.hg']
-	supported_vcs_update_cmds = {
-		'git': 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts, when the upstream is more than 1 commit newer
-		'hg':  'pull --update'
-	}
-	supported_vcs_install_cmds = {
-		'git': 'clone --depth=1 --recursive --shallow-submodules'
-		'hg':  'clone'
-	}
-	supported_vcs_outdated_steps = {
-		'git': ['fetch', 'rev-parse @', 'rev-parse @{u}']
-		'hg':  ['incoming']
-	}
-	supported_vcs_version_cmds = {
-		'git': 'version'
-		'hg':  'version'
+	settings                = &VpmSettings{}
+	default_vpm_server_urls = ['https://vpm.vlang.io', 'https://vpm.url4e.com']
+	vpm_server_urls         = rand.shuffle_clone(default_vpm_server_urls) or { [] } // ensure that all queries are distributed fairly
+	valid_vpm_commands      = ['help', 'search', 'install', 'update', 'upgrade', 'outdated', 'list',
+		'remove', 'show']
+	excluded_dirs           = ['cache', 'vlib']
+	supported_vcs           = {
+		'git': VCS{
+			cmd: 'git'
+			dir: '.git'
+			update_arg: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts, when the upstream is more than 1 commit newer
+			install_arg: 'clone --depth=1 --recursive --shallow-submodules'
+			outdated_steps: ['fetch', 'rev-parse @', 'rev-parse @{u}']
+		}
+		'hg':  VCS{
+			cmd: 'hg'
+			dir: '.hg'
+			update_arg: 'pull --update'
+			install_arg: 'clone'
+			outdated_steps: ['incoming']
+		}
 	}
 )
 


### PR DESCRIPTION
The next part of the recent install / update cleanup. It wants to solidify the base for a versioning implementation in of one the followup PRs.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a75e981</samp>

This pull request refactors and simplifies the vpm code for handling different version control systems (vcs) by using a common `vcs` struct and moving some functions to `common.v`. This improves the readability, maintainability, and performance of the vpm tool.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a75e981</samp>

*  Refactor the vcs handling to use a struct instead of a string array ([link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L39-R43), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L58-R57), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L232-R232), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L287-R292), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL82-R88), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL108-R116), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL143-R143), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L21-R21), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L27-R28), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L73-R73), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L79-R80), [link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L20-R50))
* Move the `install_module` function from `install.v` to `common.v` since it is used by both `install.v` and `update.v` ([link](https://github.com/vlang/v/pull/19740/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL82-R88))
