### PR TITLE
os: mention that `execute_opt` error contains commands output

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -881,7 +881,7 @@ pub fn execute_or_exit(cmd string) Result {
 	return res
 }
 
-// execute_opt returns the os.Result of executing `cmd`, or an error on failure.
+// execute_opt returns the os.Result of executing `cmd`, or an error with its output on failure.
 pub fn execute_opt(cmd string) !Result {
 	res := execute(cmd)
 	if res.exit_code != 0 {


### PR DESCRIPTION
Wants to add an info to the doc comment that can be of value.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff44f5f</samp>

Improved the comment for the `os.execute_opt` function to match its error handling. Updated the documentation in `vlib/os/os.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff44f5f</samp>

* Clarify the error message of `execute_opt` to include the command output ([link](https://github.com/vlang/v/pull/19742/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09L884-R884))
