### PR TITLE
http: increase max redirects

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -6,7 +6,7 @@ module http
 import net.urllib
 
 const (
-	max_redirects        = 4
+	max_redirects        = 16 // safari max - other browsers allow up to 20
 	content_type_default = 'text/plain'
 	bufsize              = 1536
 )


### PR DESCRIPTION
Most browsers allow up to 20 redirects.  Safari is one of the lowest, at 16 (IE8 was 10).

Increase max redirects to 16 to match lowest current browser use.