### PR TITLE
pref: fix unintended file extensions in default output names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ vls.log
 wasm.v
 TAGS
 tags
+vlib/builtin/js/*.js

--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -113,6 +113,12 @@ fn get_all_commands() []Command {
 		runcmd: .execute
 		expect: "['arg1', 'arg2']1.0"
 	}
+	res << Command{
+		line: '${vexe} -o calling_c.exe run examples/call_c_from_v/main.c.v'
+		okmsg: 'V can run main.c.v files'
+		runcmd: .execute
+		contains: 'V can call C functions like puts too.'
+	}
 	$if linux || macos {
 		res << Command{
 			line: '${vexe} run examples/hello_world.v'

--- a/examples/call_c_from_v/main.c.v
+++ b/examples/call_c_from_v/main.c.v
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+fn C.puts(&char) int
+
+fn main() {
+	C.puts(c'V can call C functions like `puts` too.')
+}

--- a/vlib/builtin/js/int.js.v
+++ b/vlib/builtin/js/int.js.v
@@ -108,9 +108,11 @@ pub fn (x u16) hex() string {
 }
 
 pub fn (x i8) hex() string {
-	res := ''
+	mut res := ''
 	#res.str = x.val.toString(16)
-
+	if res.len < 2 {
+		res = '0' + res
+	}
 	return res
 }
 
@@ -136,9 +138,11 @@ pub fn (x int_literal) hex() string {
 }
 
 pub fn (x u8) hex() string {
-	res := ''
+	mut res := ''
 	#res.str = x.val.toString(16)
-
+	if res.len < 2 {
+		res = '0' + res
+	}
 	return res
 }
 

--- a/vlib/builtin/js/int_test.js.v
+++ b/vlib/builtin/js/int_test.js.v
@@ -109,7 +109,7 @@ fn test_hex() {
 	// assert u64(-1).hex() == 'ffffffffffffffff'
 	// signed tests
 	// assert i8(-1).hex() == 'ff'
-	assert i8(12).hex() == 'c'
+	assert i8(12).hex() == '0c'
 	assert i16(32767).hex() == '7fff'
 	assert int(2147483647).hex() == '7fffffff'
 	assert i64(9223372036854775807).hex() == '7fffffffffffffff'
@@ -202,35 +202,35 @@ fn test_int_to_hex() {
 	st1 := [u8(0x41)].repeat(100)
 	assert st1.hex() == '41'.repeat(100)*/
 	// --- int to hex tests
-	c0 := 12
+	c := 12
 	// 8Bit
-	assert u8(0).hex() == '0'
-	assert u8(c0).hex() == 'c'
-	assert i8(c0).hex() == 'c'
+	assert u8(0).hex() == '00'
+	assert u8(c).hex() == '0c'
+	assert i8(c).hex() == '0c'
 	assert u8(127).hex() == '7f'
 	assert i8(127).hex() == '7f'
 	assert u8(255).hex() == 'ff'
 	// assert u8(-1).hex() == 'ff'
 	// 16bit
 	assert u16(0).hex() == '0'
-	assert i16(c0).hex() == 'c'
-	assert u16(c0).hex() == 'c'
+	assert i16(c).hex() == 'c'
+	assert u16(c).hex() == 'c'
 	assert i16(32767).hex() == '7fff'
 	assert u16(32767).hex() == '7fff'
 	// assert i16(-1).hex() == 'ffff'
 	assert u16(65535).hex() == 'ffff'
 	// 32bit
 	assert u32(0).hex() == '0'
-	assert c0.hex() == 'c'
-	assert u32(c0).hex() == 'c'
+	assert c.hex() == 'c'
+	assert u32(c).hex() == 'c'
 	assert 2147483647.hex() == '7fffffff'
 	assert u32(2147483647).hex() == '7fffffff'
 	// assert (-1).hex() == 'ffffffffffffffff'
 	// assert u32(4294967295).hex() == 'ffffffff'
 	// 64 bit
 	assert u64(0).hex() == '0'
-	assert i64(c0).hex() == 'c'
-	assert u64(c0).hex() == 'c'
+	assert i64(c).hex() == 'c'
+	assert u64(c).hex() == 'c'
 	assert i64(9223372036854775807).hex() == '7fffffffffffffff'
 	assert u64(9223372036854775807).hex() == '7fffffffffffffff'
 	// assert i64(-1).hex() == 'ffffffffffffffff'

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -62,7 +62,10 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	rpath := os.real_path(p.path)
 	if p.out_name == '' {
 		filename := os.file_name(rpath).trim_space()
-		mut base := filename.all_before_last('.').replace('.', '_')
+		mut base := filename.all_before_last('.')
+		if os.file_ext(base) in ['.c', '.js', '.wasm'] {
+			base = base.all_before_last('.')
+		}
 		if base == '' {
 			// The file name is just `.v` or `.vsh` or `.*`
 			base = filename

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -62,7 +62,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	rpath := os.real_path(p.path)
 	if p.out_name == '' {
 		filename := os.file_name(rpath).trim_space()
-		mut base := filename.all_before_last('.')
+		mut base := filename.all_before_last('.').replace('.', '_')
 		if base == '' {
 			// The file name is just `.v` or `.vsh` or `.*`
 			base = filename


### PR DESCRIPTION
Fixes #19727 


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdf35c8</samp>

Fix output file name generation for inputs with dots. Replace dots with underscores in the base name of the input file before adding the output extension.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fdf35c8</samp>

* Replace dots with underscores in input file base name to avoid output file extension conflicts ([link](https://github.com/vlang/v/pull/19745/files?diff=unified&w=0#diff-e178ddff137d18fe9589236ddc349d5eb75f844d32146886b33888241784e3c4L65-R65))
