### PR TITLE
checker: avoid nil assign to option var

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -383,6 +383,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							c.error('duplicate of an import symbol `${left.name}`', left.pos)
 						}
 					}
+					if node.op == .assign && left_type.has_flag(.option) && right is ast.UnsafeExpr {
+						c.error('cannot assign `nil` to option value', right.pos())
+					}
 				}
 			}
 			ast.PrefixExpr {
@@ -421,7 +424,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						}
 					}
 				}
-				if left_type.has_flag(.option) && right is ast.UnsafeExpr {
+				if left_type.has_flag(.option) && right is ast.UnsafeExpr && right.expr.is_nil() {
 					c.error('cannot assign `nil` to option value', right.pos())
 				}
 			}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -383,7 +383,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							c.error('duplicate of an import symbol `${left.name}`', left.pos)
 						}
 					}
-					if node.op == .assign && left_type.has_flag(.option) && right is ast.UnsafeExpr {
+					if node.op == .assign && left_type.has_flag(.option) && right is ast.UnsafeExpr
+						&& right.expr.is_nil() {
 						c.error('cannot assign `nil` to option value', right.pos())
 					}
 				}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -421,6 +421,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						}
 					}
 				}
+				if left_type.has_flag(.option) && right is ast.UnsafeExpr {
+					c.error('cannot assign `nil` to option value', right.pos())
+				}
 			}
 			else {
 				if mut left is ast.IndexExpr {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -206,8 +206,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 							field.default_expr.pos)
 					}
 					if field.typ.has_flag(.option) && field.default_expr.is_nil() {
-						c.error('cannot assign `nil` to option value',
-							field.default_expr.pos())
+						c.error('cannot assign `nil` to option value', field.default_expr.pos())
 					}
 					continue
 				}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -205,6 +205,10 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 						c.warn('unnecessary default value of `none`: struct fields are zeroed by default',
 							field.default_expr.pos)
 					}
+					if field.typ.has_flag(.option) && field.default_expr.is_nil() {
+						c.error('cannot assign `nil` to option value',
+							field.default_expr.pos())
+					}
 					continue
 				}
 				if field.typ in ast.unsigned_integer_type_idxs {

--- a/vlib/v/checker/tests/nil_to_option_err.out
+++ b/vlib/v/checker/tests/nil_to_option_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/nil_to_option_err.vv:8:7: warning: cannot assign a reference to a value (this will be an error soon) left=int false right=nil true ptr=false
+    6 | fn main() {
+    7 |     mut a := ?int(none)
+    8 |     a = unsafe { nil }
+      |       ^
+    9 | 
+   10 |     mut b := Test{}
+vlib/v/checker/tests/nil_to_option_err.vv:7:9: warning: unused variable: `a`
+    5 | 
+    6 | fn main() {
+    7 |     mut a := ?int(none)
+      |         ^
+    8 |     a = unsafe { nil }
+    9 |
+vlib/v/checker/tests/nil_to_option_err.vv:3:7: error: cannot assign `nil` to a non-pointer field
+    1 | struct Test {
+    2 | mut:
+    3 |     a ?int = unsafe { nil }
+      |       ~~~~
+    4 | }
+    5 |
+vlib/v/checker/tests/nil_to_option_err.vv:8:9: error: cannot assign `nil` to option value
+    6 | fn main() {
+    7 |     mut a := ?int(none)
+    8 |     a = unsafe { nil }
+      |         ~~~~~~
+    9 | 
+   10 |     mut b := Test{}
+vlib/v/checker/tests/nil_to_option_err.vv:11:11: error: cannot assign `nil` to option value
+    9 | 
+   10 |     mut b := Test{}
+   11 |     b.a = unsafe { nil }
+      |           ~~~~~~
+   12 | }

--- a/vlib/v/checker/tests/nil_to_option_err.vv
+++ b/vlib/v/checker/tests/nil_to_option_err.vv
@@ -1,0 +1,12 @@
+struct Test {
+mut:
+    a ?int = unsafe { nil }
+}
+
+fn main() {
+    mut a := ?int(none)
+    a = unsafe { nil }
+
+    mut b := Test{}
+    b.a = unsafe { nil }
+}

--- a/vlib/v/tests/comptime_for_in_fields_FieldData_test.v
+++ b/vlib/v/tests/comptime_for_in_fields_FieldData_test.v
@@ -33,9 +33,9 @@ struct Complex {
 	o_ch_i     ?chan int = chan int{cap: 10}
 	o_my_alias ?MyInt    = 123
 	// o_atomic_i ?atomic int // TODO: cgen error, but should be probably a checker one, since option atomics do not make sense
-	o_pointer1_i ?&int   = unsafe { nil }
-	o_pointer2_i ?&&int  = unsafe { nil }
-	o_pointer3_i ?&&&int = unsafe { nil }
+	o_pointer1_i ?&int
+	o_pointer2_i ?&&int
+	o_pointer3_i ?&&&int
 	//
 	o_array_i          ?[]int
 	o_map_i            ?map[int]int


### PR DESCRIPTION
Fix #19538

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fde202</samp>

Add error checks for assigning `nil` to option values in unsafe expressions and struct fields. This prevents invalid option values and improves type safety.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7fde202</samp>

*  Prevent assigning `nil` to option values in unsafe expressions and struct fields ([link](https://github.com/vlang/v/pull/19746/files?diff=unified&w=0#diff-980126e1a0f05a7144fc13bfc1a7c22ef0da4c1879b3ed947045ea458d94905dR424-R426), [link](https://github.com/vlang/v/pull/19746/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88R208-R211))
