### PR TITLE
tools.vcreate: prompt for meta data on init

### DIFF
--- a/cmd/tools/vcreate/tests/init.expect
+++ b/cmd/tools/vcreate/tests/init.expect
@@ -4,15 +4,12 @@ set timeout 3
 
 # Pass v_root as arg, since we chdir into a temp directory during testing and create a project there.
 set v_root [lindex $argv 0]
-set project_dir_name [lindex $argv 1]
-set corrected_mod_name [lindex $argv 2]
 
 spawn $v_root/v init
 
 expect "Input your project description: " { send "\r" } timeout { exit 1 }
 expect "Input your project version: (0.0.0) " { send "\r" } timeout { exit 1 }
 expect "Input your project license: (MIT) " { send "\r" } timeout { exit 1 }
-expect "The directory name `$project_dir_name` is invalid as a module name. The module name in `v.mod` was set to `$corrected_mod_name`" {} timeout { exit 1 }
 expect "Complete!" {} timeout {} timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -81,19 +81,7 @@ fn new_project(args []string) {
 		exit(3)
 	}
 
-	c.description = os.input('Input your project description: ')
-
-	default_version := '0.0.0'
-	c.version = os.input('Input your project version: (${default_version}) ')
-	if c.version == '' {
-		c.version = default_version
-	}
-
-	default_license := os.getenv_opt('VLICENSE') or { 'MIT' }
-	c.license = os.input('Input your project license: (${default_license}) ')
-	if c.license == '' {
-		c.license = default_license
-	}
+	c.prompt()
 
 	println('Initialising ...')
 	if args.len == 2 {
@@ -131,14 +119,13 @@ fn init_project() {
 	mut c := Create{}
 	dir_name := check_name(os.file_name(os.getwd()))
 	if !os.exists('v.mod') {
-		c.description = ''
 		mod_dir_has_hyphens := dir_name.contains('-')
 		c.name = if mod_dir_has_hyphens { dir_name.replace('-', '_') } else { dir_name }
+		c.prompt()
 		c.write_vmod(false)
 		if mod_dir_has_hyphens {
 			println('The directory name `${dir_name}` is invalid as a module name. The module name in `v.mod` was set to `${c.name}`')
 		}
-		println('Change the description of your project in `v.mod`')
 	}
 	if !os.exists('src/main.v') {
 		c.set_bin_project_files(false)
@@ -147,6 +134,20 @@ fn init_project() {
 	c.write_gitattributes(false)
 	c.write_editorconfig(false)
 	c.create_git_repo('.')
+}
+
+fn (mut c Create) prompt() {
+	c.description = os.input('Input your project description: ')
+	default_version := '0.0.0'
+	c.version = os.input('Input your project version: (${default_version}) ')
+	if c.version == '' {
+		c.version = default_version
+	}
+	default_license := 'MIT'
+	c.license = os.input('Input your project license: (${default_license}) ')
+	if c.license == '' {
+		c.license = default_license
+	}
 }
 
 fn cerror(e string) {

--- a/cmd/tools/vcreate/vcreate_init_test.v
+++ b/cmd/tools/vcreate/vcreate_init_test.v
@@ -10,7 +10,7 @@ const (
 		exit(0)
 	})
 	// Directory that contains the Expect scripts used in the test.
-	expect_tests_path     = os.join_path(vroot, 'cmd', 'tools', 'vcreate', 'tests')
+	expect_tests_path     = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vcreate', 'tests')
 	test_project_dir_name = 'test_project'
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_project/`.

--- a/cmd/tools/vcreate/vcreate_init_test.v
+++ b/cmd/tools/vcreate/vcreate_init_test.v
@@ -34,7 +34,7 @@ fn init_and_check() ! {
 	x := os.execute_or_exit('${vexe} run .')
 	assert x.output.trim_space() == 'Hello World!'
 
-	if main_exists == true {
+	if main_exists {
 		assert main_last_modified == os.file_last_mod_unix('src/main.v')
 	} else {
 		assert os.read_file('src/main.v')! == [

--- a/cmd/tools/vcreate/vcreate_init_test.v
+++ b/cmd/tools/vcreate/vcreate_init_test.v
@@ -1,6 +1,16 @@
 import os
+import v.vmod
 
 const (
+	vroot      = os.quoted_path(@VEXEROOT)
+	vexe       = os.quoted_path(@VEXE)
+	// Expect has to be installed for the test.
+	expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
+		eprintln('skipping test, since expect is missing')
+		exit(0)
+	})
+	// Directory that contains the Expect scripts used in the test.
+	expect_tests_path     = os.join_path(vroot, 'cmd', 'tools', 'vcreate', 'tests')
 	test_project_dir_name = 'test_project'
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_project/`.
@@ -14,20 +24,18 @@ fn testsuite_end() {
 fn init_and_check() ! {
 	os.chdir(test_path)!
 
-	// if main file already exist we should not tamper it
-	mut main_last_modified_time := i64(0)
-	is_main_file_preexisting := os.exists('src/main.v')
-	if is_main_file_preexisting == true {
-		main_last_modified_time = os.file_last_mod_unix('src/main.v')
-	}
-	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
+	// Keep track of the last modified time of the main file to ensure it is not modifed if it already exists.
+	main_exists := os.exists('src/main.v')
+	main_last_modified := if main_exists { os.file_last_mod_unix('src/main.v') } else { 0 }
 
-	x := os.execute_or_exit('${os.quoted_path(@VEXE)} run .')
-	assert x.exit_code == 0
+	// Initilize project.
+	os.execute_or_exit('${expect_exe} ${os.join_path(expect_tests_path, 'init.expect')} ${vroot}')
+
+	x := os.execute_or_exit('${vexe} run .')
 	assert x.output.trim_space() == 'Hello World!'
 
-	if is_main_file_preexisting == true {
-		assert main_last_modified_time == os.file_last_mod_unix('src/main.v')
+	if main_exists == true {
+		assert main_last_modified == os.file_last_mod_unix('src/main.v')
 	} else {
 		assert os.read_file('src/main.v')! == [
 			'module main\n',
@@ -42,8 +50,8 @@ fn init_and_check() ! {
 		'Module {',
 		"	name: '${test_project_dir_name}'",
 		"	description: ''",
-		"	version: ''",
-		"	license: ''",
+		"	version: '0.0.0'",
+		"	license: 'MIT'",
 		'	dependencies: []',
 		'}',
 		'',
@@ -120,9 +128,9 @@ fn test_v_init_in_git_dir() {
 
 fn test_v_init_no_overwrite_gitignore() {
 	prepare_test_path()!
-	os.write_file('.gitignore', 'blah')!
-	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
-	assert os.read_file('.gitignore')! == 'blah'
+	os.write_file('.gitignore', 'foo')!
+	os.execute_or_exit('${expect_exe} ${os.join_path(expect_tests_path, 'init.expect')} ${vroot}')
+	assert os.read_file('.gitignore')! == 'foo'
 }
 
 fn test_v_init_no_overwrite_gitattributes_and_editorconfig() {
@@ -139,8 +147,24 @@ indent_style = tab
 	prepare_test_path()!
 	os.write_file('.gitattributes', git_attributes_content)!
 	os.write_file('.editorconfig', editor_config_content)!
-	os.execute_or_exit('${os.quoted_path(@VEXE)} init')
+	os.execute_or_exit('${expect_exe} ${os.join_path(expect_tests_path, 'init.expect')} ${vroot}')
 
 	assert os.read_file('.gitattributes')! == git_attributes_content
 	assert os.read_file('.editorconfig')! == editor_config_content
+}
+
+fn test_v_init_in_dir_with_invalid_mod_name() {
+	// A project with a directory name with hyphens, which is invalid for a module name.
+	dir_name_with_invalid_mod_name := 'my-proj'
+	corrected_mod_name := 'my_proj'
+	proj_path := os.join_path(os.vtmp_dir(), dir_name_with_invalid_mod_name)
+	os.mkdir_all(proj_path) or {}
+	os.chdir(proj_path)!
+	os.execute_or_exit('${expect_exe} ${os.join_path(expect_tests_path, 'init_in_dir_with_invalid_mod_name.expect')} ${vroot} ${dir_name_with_invalid_mod_name} ${corrected_mod_name}')
+	// Assert mod data set in `new_with_model_arg.expect`.
+	mod := vmod.from_file(os.join_path(proj_path, 'v.mod')) or {
+		assert false, err.str()
+		return
+	}
+	assert mod.name == corrected_mod_name
 }

--- a/cmd/tools/vcreate/vcreate_new_test.v
+++ b/cmd/tools/vcreate/vcreate_new_test.v
@@ -1,9 +1,8 @@
 import os
 import v.vmod
 
-
 const (
-	vroot = @VEXEROOT
+	vroot      = @VEXEROOT
 	// Expect has to be installed for the test.
 	expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')

--- a/cmd/tools/vcreate/vcreate_new_test.v
+++ b/cmd/tools/vcreate/vcreate_new_test.v
@@ -9,7 +9,7 @@ const (
 		exit(0)
 	})
 	// Directory that contains the Expect scripts used in the test.
-	expect_tests_path = os.join_path(vroot, 'cmd', 'tools', 'vcreate', 'tests')
+	expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vcreate', 'tests')
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_vcreate_input/`.
 	test_module_path  = os.join_path(os.vtmp_dir(), 'test_vcreate_input')

--- a/cmd/tools/vcreate/vcreate_new_test.v
+++ b/cmd/tools/vcreate/vcreate_new_test.v
@@ -1,14 +1,16 @@
 import os
 import v.vmod
 
+
 const (
+	vroot = @VEXEROOT
 	// Expect has to be installed for the test.
 	expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
 	})
 	// Directory that contains the Expect scripts used in the test.
-	expect_tests_path = os.join_path(@VMODROOT, 'cmd', 'tools', 'vcreate', 'tests')
+	expect_tests_path = os.join_path(vroot, 'cmd', 'tools', 'vcreate', 'tests')
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test_vcreate_input/`.
 	test_module_path  = os.join_path(os.vtmp_dir(), 'test_vcreate_input')
@@ -33,9 +35,8 @@ fn prepare_test_path() ! {
 fn test_new_with_no_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_project'
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_no_arg.expect')} ${@VMODROOT} ${project_name}')
-	if res.exit_code != 0 {
-		assert false, res.output
+	os.execute_opt('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_no_arg.expect')} ${vroot} ${project_name}') or {
+		assert false, err.msg()
 	}
 	// Assert mod data set in `new_no_arg.expect`.
 	mod := vmod.from_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
@@ -51,9 +52,8 @@ fn test_new_with_no_arg_input() {
 fn test_new_with_name_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_other_project'
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_name_arg.expect')} ${@VMODROOT} ${project_name}')
-	if res.exit_code != 0 {
-		assert false, res.output
+	os.execute_opt('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_name_arg.expect')} ${vroot} ${project_name}') or {
+		assert false, err.msg()
 	}
 	// Assert mod data set in `new_with_name_arg.expect`.
 	mod := vmod.from_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
@@ -70,9 +70,8 @@ fn test_new_with_model_arg_input() {
 	prepare_test_path()!
 	project_name := 'my_lib'
 	model := 'lib'
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_model_arg.expect')} ${@VMODROOT} ${project_name} ${model}')
-	if res.exit_code != 0 {
-		assert false, res.output
+	os.execute_opt('${expect_exe} ${os.join_path(expect_tests_path, 'new_with_model_arg.expect')} ${vroot} ${project_name} ${model}') or {
+		assert false, err.msg()
 	}
 	// Assert mod data set in `new_with_model_arg.expect`.
 	mod := vmod.from_file(os.join_path(test_module_path, project_name, 'v.mod')) or {
@@ -83,23 +82,4 @@ fn test_new_with_model_arg_input() {
 	assert mod.description == 'My Awesome V Project.'
 	assert mod.version == '0.0.1'
 	assert mod.license == 'MIT'
-}
-
-fn test_v_init_in_dir_with_invalid_mod_name() {
-	// A project with a directory name with hyphens, which is invalid for a module name.
-	dir_name_with_invalid_mod_name := 'my-proj'
-	corrected_mod_name := 'my_proj'
-	proj_path := os.join_path(os.vtmp_dir(), dir_name_with_invalid_mod_name)
-	os.mkdir_all(proj_path) or {}
-	os.chdir(proj_path)!
-	res := os.execute('${expect_exe} ${os.join_path(expect_tests_path, 'init_in_dir_with_invalid_mod_name.expect')} ${@VMODROOT} ${dir_name_with_invalid_mod_name} ${corrected_mod_name}')
-	if res.exit_code != 0 {
-		assert false, res.output
-	}
-	// Assert mod data set in `new_with_model_arg.expect`.
-	mod := vmod.from_file(os.join_path(proj_path, 'v.mod')) or {
-		assert false, err.str()
-		return
-	}
-	assert mod.name == corrected_mod_name
 }


### PR DESCRIPTION
The PR wants to add the feature of allowing to add project information when using `v init` to initialize a project, instead of just printing ``Change the description of your project in `v.mod`"``. Just like we do with `v new`, but with a shorter prompt that uses the name of the current directory instead of asking for the project name. 

It also updates and extends tests. Using dedicated tests for the commands with `vcreate_init_test.v` and `vcreate_new_test.v`.