### PR TITLE
checker: fix closure in if guard (fix #19748)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -486,7 +486,11 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 			c.error('original `${parent_var.name}` is immutable, declare it with `mut` to make it mutable',
 				var.pos)
 		}
-		var.typ = parent_var.typ
+		if parent_var.expr is ast.IfGuardExpr {
+			var.typ = parent_var.expr.expr_type.clear_flags(.option, .result)
+		} else {
+			var.typ = parent_var.typ
+		}
 		if var.typ.has_flag(.generic) {
 			has_generic = true
 		}

--- a/vlib/v/tests/closure_in_if_guard_test.v
+++ b/vlib/v/tests/closure_in_if_guard_test.v
@@ -1,0 +1,16 @@
+struct Foo {
+	optional ?int
+}
+
+fn test_closure_in_if_guard() {
+	f := Foo{45}
+	mut ret := ''
+	if v := f.optional {
+		func := fn [v] () string {
+			println(v)
+			return '${v}'
+		}
+		ret = func()
+	}
+	assert ret == '45'
+}


### PR DESCRIPTION
This PR fix closure in if guard (fix #19748).

- Fix closure in if guard.
- Add test.

```v
struct Foo {
	optional ?int
}

fn main() {
	f := Foo{45}
	mut ret := ''
	if v := f.optional {
		func := fn [v] () string {
			println(v)
			return '${v}'
		}
		ret = func()
	}
	assert ret == '45'
}

PS D:\Test\v\tt1> v run .
45
```