### PR TITLE
fmt: respect raw strings in comptime expressions

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2074,10 +2074,8 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 		match true {
 			node.is_embed {
 				f.write('\$embed_file(')
-				if node.embed_file.compression_type == 'none' {
-					f.expr(node.args[0].expr)
-				} else {
-					f.expr(node.args[0].expr)
+				f.expr(node.args[0].expr)
+				if node.embed_file.compression_type != 'none' {
 					f.write(', .${node.embed_file.compression_type}')
 				}
 				f.write(')')

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2066,7 +2066,7 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 		if node.method_name == 'html' {
 			f.write('\$vweb.html()')
 		} else {
-			f.write('\$tmpl($')
+			f.write('\$tmpl(')
 			f.expr(node.args[0].expr)
 			f.write(')')
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2066,16 +2066,21 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 		if node.method_name == 'html' {
 			f.write('\$vweb.html()')
 		} else {
-			f.write('\$tmpl(${node.args[0].expr})')
+			f.write('\$tmpl($')
+			f.expr(node.args[0].expr)
+			f.write(')')
 		}
 	} else {
 		match true {
 			node.is_embed {
+				f.write('\$embed_file(')
 				if node.embed_file.compression_type == 'none' {
-					f.write('\$embed_file(${node.args[0].expr})')
+					f.expr(node.args[0].expr)
 				} else {
-					f.write('\$embed_file(${node.args[0].expr}, .${node.embed_file.compression_type})')
+					f.expr(node.args[0].expr)
+					f.write(', .${node.embed_file.compression_type}')
 				}
+				f.write(')')
 			}
 			node.is_env {
 				f.write("\$env('${node.args_var}')")

--- a/vlib/v/fmt/tests/comptime_keep.vv
+++ b/vlib/v/fmt/tests/comptime_keep.vv
@@ -1,5 +1,7 @@
 import vweb
 
+const embedded_file = $embed_file(r'C:\Users\user\path\to\file')
+
 struct App {
 	a string
 	b string


### PR DESCRIPTION
Currently, fmt breaks raw strings in some comptime expressions.

```v
const embedded_file = $embed_file(r'C:\Users\user\path\to\file')
```
`v fmt` will result in
```v
const embedded_file = $embed_file('C:\Users\user\path\to\file')
```

Which will cause an Unkown escape sequence panic when later using the formatted file.

```
V panic: result not set (C:/Users/user/.../abc.v:1:39: error: `U` unknown escape sequence
    1 | const embedded_file = $embed_file('C:\Users\user\...'),
      |                                       ^
```

This PR makes sure the raw string is kept.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64ac79e</samp>

Fix formatting bug for template and embed file expressions in `vlib/v/fmt/fmt.v`. Add test case for embed file expressions with Windows path in `vlib/v/fmt/tests/comptime_keep.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64ac79e</samp>

* Fix formatting of template and embed file expressions ([link](https://github.com/vlang/v/pull/19753/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eL2069-R2083))
* Add test case for embed file expressions with Windows path ([link](https://github.com/vlang/v/pull/19753/files?diff=unified&w=0#diff-5ecdf3df19ac68ea98ef63702045c76565eec8ab97c7e04d71d03a1f9e5d6b2fR3-R4))
