### PR TITLE
tools.vpm: improve VCS handling part2

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -38,9 +38,8 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	vcs := vcs_used_in_dir(final_module_path) or { return result }
 	is_hg := vcs.cmd == 'hg'
 	mut outputs := []string{}
-	for step in vcs.outdated_steps {
-		path_flag := if is_hg { '-R' } else { '-C' }
-		cmd := '${vcs.cmd} ${path_flag} "${final_module_path}" ${step}'
+	for step in vcs.args.outdated {
+		cmd := '${vcs.cmd} ${vcs.args.path} "${final_module_path}" ${step}'
 		res := os.execute('${cmd}')
 		if res.exit_code < 0 {
 			verbose_println('Error command: ${cmd}')
@@ -229,7 +228,7 @@ fn ensure_vmodules_dir_exist() {
 }
 
 fn ensure_vcs_is_installed(vcs &VCS) ! {
-	cmd := '${vcs.cmd} --version'
+	cmd := '${vcs.cmd} ${vcs.args.version}'
 	verbose_println('      command: ${cmd}')
 	res := os.execute(cmd)
 	if res.exit_code != 0 {

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -228,11 +228,7 @@ fn ensure_vmodules_dir_exist() {
 }
 
 fn ensure_vcs_is_installed(vcs &VCS) ! {
-	cmd := '${vcs.cmd} ${vcs.args.version}'
-	verbose_println('      command: ${cmd}')
-	res := os.execute(cmd)
-	if res.exit_code != 0 {
-		verbose_println('      command output: ${res.output}')
+	os.find_abs_path_of_executable(vcs.cmd) or {
 		return error('VPM needs `${vcs}` to be installed.')
 	}
 }

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -79,13 +79,13 @@ fn vpm_install(requested_modules []string, opts []string) {
 		vpm_install_from_vpm(vpm_modules)
 	}
 	if external_modules.len > 0 {
-		vcs := if '--hg' in opts { supported_vcs['hd'] } else { supported_vcs['git'] }
+		vcs := if '--hg' in opts { supported_vcs['hg'] } else { supported_vcs['git'] }
 		vpm_install_from_vcs(external_modules, vcs)
 	}
 }
 
 fn install_module(vcs &VCS, name string, url string, final_module_path string) ! {
-	cmd := '${vcs.cmd} ${vcs.install_arg} "${url}" "${final_module_path}"'
+	cmd := '${vcs.cmd} ${vcs.args.install} "${url}" "${final_module_path}"'
 	verbose_println('      command: ${cmd}')
 	println('Installing module "${name}" from "${url}" to "${final_module_path}" ...')
 	res := os.execute(cmd)

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -24,8 +24,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 		eprintln(err)
 		return result
 	}
-	path_flag := if vcs.cmd == 'hg' { '-R' } else { '-C' }
-	cmd := '${vcs.cmd} ${path_flag} "${result.final_path}" ${vcs.update_arg}'
+	cmd := '${vcs.cmd} ${vcs.args.path} "${result.final_path}" ${vcs.args.update}'
 	verbose_println('    command: ${cmd}')
 	res := os.execute('${cmd}')
 	if res.exit_code != 0 {
@@ -76,8 +75,7 @@ fn vpm_update_verbose(module_names []string) {
 			eprintln(err)
 			continue
 		}
-		path_flag := if vcs.cmd == 'hg' { '-R' } else { '-C' }
-		cmd := '${vcs.cmd} ${path_flag} "${final_module_path}" ${vcs.update_arg}'
+		cmd := '${vcs.cmd} ${vcs.args.path} "${final_module_path}" ${vcs.args.update}'
 		verbose_println('    command: ${cmd}')
 		res := os.execute('${cmd}')
 		if res.exit_code != 0 {

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -18,11 +18,15 @@ mut:
 }
 
 struct VCS {
-	cmd            string
-	dir            string
-	update_arg     string
-	install_arg    string
-	outdated_steps []string
+	dir  string
+	cmd  string
+	args struct {
+		install  string
+		path     string // the flag used to specify a path. E.g., used to explictly work on a path during multithreaded updating.
+		update   string
+		outdated []string
+		version  string
+	}
 }
 
 const (
@@ -34,18 +38,26 @@ const (
 	excluded_dirs           = ['cache', 'vlib']
 	supported_vcs           = {
 		'git': VCS{
-			cmd: 'git'
 			dir: '.git'
-			update_arg: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts, when the upstream is more than 1 commit newer
-			install_arg: 'clone --depth=1 --recursive --shallow-submodules'
-			outdated_steps: ['fetch', 'rev-parse @', 'rev-parse @{u}']
+			cmd: 'git'
+			args: struct {
+				install: 'clone --depth=1 --recursive --shallow-submodules'
+				update: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts, when the upstream is more than 1 commit newer
+				path: '-C'
+				outdated: ['fetch', 'rev-parse @', 'rev-parse @{u}']
+				version: '--version'
+			}
 		}
 		'hg':  VCS{
-			cmd: 'hg'
 			dir: '.hg'
-			update_arg: 'pull --update'
-			install_arg: 'clone'
-			outdated_steps: ['incoming']
+			cmd: 'hg'
+			args: struct {
+				install: 'clone'
+				update: 'pull --update'
+				path: '-R'
+				version: '--version'
+				outdated: ['incoming']
+			}
 		}
 	}
 )

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -25,7 +25,6 @@ struct VCS {
 		path     string // the flag used to specify a path. E.g., used to explictly work on a path during multithreaded updating.
 		update   string
 		outdated []string
-		version  string
 	}
 }
 
@@ -45,7 +44,6 @@ const (
 				update: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts, when the upstream is more than 1 commit newer
 				path: '-C'
 				outdated: ['fetch', 'rev-parse @', 'rev-parse @{u}']
-				version: '--version'
 			}
 		}
 		'hg':  VCS{
@@ -55,7 +53,6 @@ const (
 				install: 'clone'
 				update: 'pull --update'
 				path: '-R'
-				version: '--version'
 				outdated: ['incoming']
 			}
 		}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 380a28a</samp>

This pull request improves the vpm tool by fixing a bug with Mercurial modules, and by refactoring the `VCS` struct to use a nested `args` struct for version control system commands. This makes the code more readable, flexible, and consistent across different files.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 380a28a</samp>

*  Refactor the code to use a new `args` field in the `VCS` struct, which holds the specific arguments for each version control system command ([link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L41-R42), [link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L232-R231), [link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL88-R88), [link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L27-R27), [link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L79-R78), [link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L21-R29), [link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L37-R60))
* Fix a typo in the `supported_vcs` map, where the key for Mercurial was `'hd'` instead of `'hg'` ([link](https://github.com/vlang/v/pull/19754/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL82-R82))
