### PR TITLE
vpm.tools: use `VPM_NO_INCREMENT` env var to skip dl count increment when testing

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -239,6 +239,10 @@ fn ensure_vcs_is_installed(vcs &VCS) ! {
 }
 
 fn increment_module_download_count(name string) ! {
+	if no_dl_count_increment {
+		println('Skipping download count increment for "${name}".')
+		return
+	}
 	mut errors := []string{}
 
 	for server_url in vpm_server_urls {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -10,6 +10,7 @@ const (
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
 }
 
 fn testsuite_end() {
@@ -19,6 +20,7 @@ fn testsuite_end() {
 fn test_install_from_vpm_ident() {
 	res := os.execute('${v} install nedpals.args')
 	assert res.exit_code == 0, res.output
+	assert res.output.contains('Skipping download count increment for "nedpals.args".')
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.str()
 		return

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -27,6 +27,7 @@ struct VCS {
 
 const (
 	settings                = &VpmSettings{}
+	no_dl_count_increment   = os.getenv('VPM_NO_INCREMENT') == '1'
 	default_vpm_server_urls = ['https://vpm.vlang.io', 'https://vpm.url4e.com']
 	vpm_server_urls         = rand.shuffle_clone(default_vpm_server_urls) or { [] } // ensure that all queries are distributed fairly
 	valid_vpm_commands      = ['help', 'search', 'install', 'update', 'upgrade', 'outdated', 'list',


### PR DESCRIPTION




<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2663dc0</samp>

This pull request adds a `no_dl_count_increment` flag to `vpm` that allows skipping the increment of the download count of modules. This is useful for testing purposes, to avoid affecting the actual statistics of the VPM server. The flag can be set by using the `VPM_NO_INCREMENT` environment variable.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2663dc0</samp>

*  Add a flag to skip incrementing the download count of a module ([link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R242-R245), [link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R13), [link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545R30))
  - Check the flag in `increment_download_count` in `common.v` and return early if true ([link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R242-R245))
  - Set the flag to the value of the `VPM_NO_INCREMENT` environment variable in `vpm.v` ([link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545R30))
  - Set the environment variable to `1` in `install_test.v` to avoid affecting the actual download count in tests ([link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R13))
*  Add a test to verify that the flag works as expected ([link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R23))
  - Assert that the output of `vpm install` contains the expected message when the flag is true ([link](https://github.com/vlang/v/pull/19756/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R23))
