### PR TITLE
tools.vpm: improve handling of urls that end with .git

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -43,7 +43,7 @@ fn vpm_install(requested_modules []string, opts []string) {
 					eprintln('Errors while parsing module url "${raw_url}" : ${err}')
 					continue
 				}
-				mod_name := url.path.all_after_last('/')
+				mod_name := url.path.all_after_last('/').replace('.git', '')
 				if mod_name in installed_modules {
 					already_installed << mod_name
 					i_deleted << i
@@ -150,7 +150,7 @@ fn vpm_install_from_vcs(modules []string, vcs &VCS) {
 		}
 		// Module identifier based on URL.
 		// E.g.: `https://github.com/owner/awesome-v-project` -> `owner/awesome_v_project`
-		mut ident := url.path#[1..].replace('-', '_')
+		mut ident := url.path#[1..].replace('-', '_').replace('.git', '')
 		owner, repo_name := ident.split_once('/') or {
 			errors++
 			eprintln('Errors while retrieving module name for: "${url}"')

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -66,6 +66,9 @@ fn test_install_already_existent() {
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
+	// The same module but with the `.git` extension added.
+	os.execute_or_exit('${v} install https://github.com/vlang/markdown.git')
+	assert res.output.contains('already exists')
 }
 
 fn test_install_once() {


### PR DESCRIPTION
Uniformizes module handling when it's installed from a git url, either with or without the `.git` extension added.

- Install paths
  ```sh
  ❯ v install https://github.com/vlang/markdown.git
  ```

  ```diff
  - Installing module "markdown" from "https://github.com/vlang/markdown.git" to "/home/t/.vmodules/vlang/markdown.git" ...
  - Relocating module from "vlang/markdown.git" to "markdown" ("/home/t/.vmodules/markdown") ...
  + Installing module "markdown" from "https://github.com/vlang/markdown.git" to "/home/t/.vmodules/vlang/markdown" ...
  + Relocating module from "vlang/markdown" to "markdown" ("/home/t/.vmodules/markdown") ...
  ```

- Recognizing a module as already installed when a specified url has a `.git` extension.

  ```sh
  ❯ v install -v --once https://github.com/vlang/markdown.git
  ```
  ```sh
  # Current
  Installing module "markdown.git" from "https://github.com/vlang/markdown.git" to 
  "/home/t/.vmodules/vlang/markdown.git" ...
  Relocating module from "vlang/markdown.git" to "markdown" ("/home/t/.vmodules/markdown") ...
  Warning module "/home/t/.vmodules/markdown" already exists!
  Removing module "/home/t/.vmodules/markdown" ...
  Module "markdown.git" relocated to "markdown" successfully.
  
  # Changed
  Already installed modules: ['markdown']
  All modules are already installed.
  ```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a0f572</samp>

Fix vpm module installation and add a test case for `.git` extension. The fix removes the `.git` suffix from module names and identifiers when using `v install`, while the test case verifies that the installation works correctly with URLs that have the `.git` extension.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a0f572</samp>

*  Strip `.git` extension from module URLs to avoid duplication and inconsistency ([link](https://github.com/vlang/v/pull/19758/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL46-R46), [link](https://github.com/vlang/v/pull/19758/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL153-R153))
* Add a test case for installing modules with `.git` extension ([link](https://github.com/vlang/v/pull/19758/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R69-R71))
