### PR TITLE
tools.vpm: improve prints for install command

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -69,7 +69,7 @@ fn vpm_install(requested_modules []string, opts []string) {
 		if already_installed.len > 0 {
 			verbose_println('Already installed modules: ${already_installed}')
 			if already_installed.len == modules.len {
-				verbose_println('All modules are already installed.')
+				println('All modules are already installed.')
 				exit(0)
 			}
 		}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -57,14 +57,13 @@ fn main() {
 	// args are: vpm [options] SUBCOMMAND module names
 	params := cmdline.only_non_options(os.args[1..])
 	options := cmdline.only_options(os.args[1..])
-	verbose_println('cli params: ${params}')
+	// dump(params)
 	if params.len < 1 {
 		help.print_and_exit('vpm', exit_code: 5)
 	}
 	vpm_command := params[0]
 	mut requested_modules := params[1..].clone()
 	ensure_vmodules_dir_exist()
-	// println('module names: ') println(requested_modules)
 	match vpm_command {
 		'help' {
 			help.print_and_exit('vpm')


### PR DESCRIPTION
- Improves the feedback messages that are printed during installation.

  E.g. currently all this is printed in non-verbose mode, when installing a module.
  ```
  ❯ v install https://github.com/vlang/markdow
  Installing module "markdown" from "https://github.com/vlang/markdown" to "/home/t/.vmodules/vlang/markdown" ...
  Relocating module from "vlang/markdown" to "markdown" ("/home/t/.vmodules/markdown") ...
  Warning module "/home/t/.vmodules/markdown" already exists!
  Removing module "/home/t/.vmodules/markdown" ...
  Module "markdown" relocated to "markdown" successfully.
  ```
  But when using `--once`, the already installed info would only be printed with the verbose flag added. Without it, the install command would immediately finish, without printing any info.
  ```
  ❯ v install -v --once https://github.com/vlang/markdown.git
  Already installed modules: ['markdown']
  All modules are already installed.
  ╭─ ~/Dev/vlang/v
  ╰─❯ ▌
  
  # Current no verbose (no feedback)
  ❯ v install --once https://github.com/vlang/markdown.git
  ╭─ ~/Dev/vlang/v
  ╰─❯ ▌
  
  
  # PR no verbose
  ❯ v install --once https://github.com/vlang/markdown.git
  All modules are already installed.
  ╭─ ~/Dev/vlang/v
  ╰─❯ ▌
  ```
  With the PR the the `All modules are already installed.` info is printed also in non-verbose mode. I think giving the short feedback to the users is useful also here to confirm that their request was processed. 


- Removes some info from verbose mode that is imho only relevant for debugging and not for the user. E.g.
  ```diff
  ❯ v install --once -v https://github.com/vlang/markdown.git
  - cli params: ['install', 'https://github.com/vlang/markdown.git']
  -      command: git --version
  -      command: git clone --depth=1 --recursive --shallow-submodules "https://github.com/vlang/markdown.git" "/home/t/.vmodules/vlang/markdown.git"
  ...
  ```


