### PR TITLE
tools.vpm: fix windows install of already existing module

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -184,10 +184,18 @@ fn vpm_install_from_vcs(modules []string, vcs &VCS) {
 				if os.exists(minfo.final_module_path) {
 					eprintln('Warning module "${minfo.final_module_path}" already exists!')
 					eprintln('Removing module "${minfo.final_module_path}" ...')
-					os.rmdir_all(minfo.final_module_path) or {
+					mut err_msg := ''
+					$if windows {
+						os.execute_opt('rd /s /q ${minfo.final_module_path}') or {
+							err_msg = err.msg()
+						}
+					} $else {
+						os.rmdir_all(minfo.final_module_path) or { err_msg = err.msg() }
+					}
+					if err_msg != '' {
 						errors++
 						eprintln('Errors while removing "${minfo.final_module_path}" :')
-						eprintln(err)
+						eprintln(err_msg)
 						continue
 					}
 				}

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -52,11 +52,6 @@ fn test_install_from_git_url() {
 }
 
 fn test_install_already_existent() {
-	// FIXME: Skip this for now on Windows, as `rmdir_all` results in permission
-	// errors when vpm tries to remove existing modules.
-	$if windows {
-		return
-	}
 	mut res := os.execute('${v} install https://github.com/vlang/markdown')
 	assert res.exit_code == 0, res.output
 	assert res.output.contains('already exists')


### PR DESCRIPTION
The permission issue with `rmdir` is actually a real problem on Windows. Currently, using `v install` for an already existent module can run into the permission issue not just during testing.

The issue causes that most contents of the directory of the module that should have been installed will be removed. In my tests, all except the `.git` directory - _With this discovery it looks like the permission issue with `rmdir_all` on Windows might be related to hidden files_. After this error it becomes impossible to install the module without manually removing it from the `.vmodules` directory, because vpm recognizes a `.git` directory and tries to unsuccessfully update it, which is also something that should be improved separately.

I think until the rmdir issue is fixed, this is an important workaround to make VPM work on Windows. That said, the rmdir issue should be addressed asap, because executing the system command for removal increases the likelihood of the V executable triggering Windows defender. 

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bccf63e</samp>

This pull request fixes a bug that prevented vpm from installing modules on Windows, and enables a previously skipped test for vpm install. The bug is fixed by using a different command to remove existing modules, and the test is updated to run on all platforms.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bccf63e</samp>

* Fix bug where existing modules cannot be removed on Windows ([link](https://github.com/vlang/v/pull/19761/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL187-R198))
* Enable test for module removal on Windows ([link](https://github.com/vlang/v/pull/19761/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L55-L59))
