### PR TITLE
ci: use VJOBS=1 for alpine docker format check

### DIFF
--- a/.github/workflows/containers_ci.yml
+++ b/.github/workflows/containers_ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: CC=gcc make
 
       - name: All code is formatted
-        run: ./v test-cleancode
+        run: VJOBS=1 ./v test-cleancode
 
       - name: Run only essential tests
         run: VTEST_JUST_ESSENTIAL=1 ./v test-self


### PR DESCRIPTION
Should fix the formatting CI that is failing a lot recently on alpine docker.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 617a7ad</samp>

Added `VJOBS=1` to `test-cleancode` command in `.github/workflows/containers_ci.yml` to prevent memory errors on GitHub Actions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 617a7ad</samp>

* Limit the number of parallel jobs for the `test-cleancode` command to one by setting the `VJOBS=1` environment variable ([link](https://github.com/vlang/v/pull/19762/files?diff=unified&w=0#diff-bc07a69d77e9280722faa7da45e9a6e22ef4dc52cb5d352762f7d02f5a1d26e6L53-R53)). This avoids out-of-memory errors on GitHub Actions for the `.github/workflows/containers_ci.yml` workflow.
