### PR TITLE
cgen, checker: fix comptime enumdata value property access

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1470,6 +1470,7 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	} else if c.inside_comptime_for_field && typ == c.enum_data_type && node.field_name == 'value' {
 		// for comp-time enum.values
 		node.expr_type = c.comptime_fields_type[c.comptime_for_field_var]
+		node.typ = typ
 		return node.expr_type
 	}
 	node.expr_type = typ

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3634,12 +3634,6 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 	}
-	if g.enum_data_type == node.typ {
-		g.expr(node.expr)
-		g.write('.')
-		g.write(node.field_name)
-		return
-	}
 	sym := g.table.sym(g.unwrap_generic(node.expr_type))
 	field_name := if sym.language == .v { c_name(node.field_name) } else { node.field_name }
 
@@ -3705,6 +3699,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		g.write('sync__Channel_${node.field_name}(')
 		g.expr(node.expr)
 		g.write(')')
+		return
+	} else if g.enum_data_type == node.typ {
+		g.expr(node.expr)
+		g.write('.')
+		g.write(node.field_name)
 		return
 	}
 	mut sum_type_deref_field := ''

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3634,7 +3634,12 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 	}
-
+	if g.enum_data_type == node.typ {
+		g.expr(node.expr)
+		g.write('.')
+		g.write(node.field_name)
+		return
+	}
 	sym := g.table.sym(g.unwrap_generic(node.expr_type))
 	field_name := if sym.language == .v { c_name(node.field_name) } else { node.field_name }
 

--- a/vlib/v/tests/comptime_enum_values_test.v
+++ b/vlib/v/tests/comptime_enum_values_test.v
@@ -1,0 +1,35 @@
+enum CharacterGroup {
+	chars
+	alphanumerics
+	numeric
+	special
+}
+
+fn (self CharacterGroup) value() string {
+	return match self {
+		.chars { 'first' }
+		.alphanumerics { 'second' }
+		.numeric { 'third' }
+		.special { 'fourth' }
+	}
+}
+
+fn CharacterGroup.values() []CharacterGroup {
+	mut res := []CharacterGroup{}
+	$for item in CharacterGroup.values {
+		res << CharacterGroup(item.value)
+	}
+	return res
+}
+
+fn test_main() {
+	values := CharacterGroup.values()
+	println('Char group values: ${values}')
+	println('For loop over the values')
+	for entry in CharacterGroup.values() {
+		println('Value: ${entry}  ${entry.value()}')
+	}
+
+	assert values == [CharacterGroup.chars, CharacterGroup.alphanumerics, CharacterGroup.numeric,
+		CharacterGroup.special]
+}


### PR DESCRIPTION
Fix #19489

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35934ed</samp>

Fix C backend issue with enum fields with custom types. Assign type to selector expression node in `checker.v` and generate simple dot notation in `cgen.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35934ed</samp>

*  Assign the type of the selector expression node to the node itself to preserve type information for enum fields ([link](https://github.com/vlang/v/pull/19768/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R1473))
*  Generate C code for enum fields with custom types by writing the expression and the field name with a dot, avoiding sym table lookup ([link](https://github.com/vlang/v/pull/19768/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL3637-R3642))
