### PR TITLE
picoev: implement raw mode

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -39,7 +39,6 @@ pub:
 	max_headers  int     = 100
 	max_read     int     = 4096
 	max_write    int     = 8192
-	is_raw       bool
 }
 
 [heap]
@@ -49,7 +48,6 @@ pub struct Picoev {
 	raw_cb    fn (voidptr, int) = unsafe { nil }
 	user_data voidptr = unsafe { nil }
 
-	is_raw       bool
 	timeout_secs int
 	max_headers  int = 100
 	max_read     int = 4096
@@ -214,7 +212,7 @@ fn raw_callback(fd int, events int, context voidptr) {
 		return
 	} else if events & picoev.picoev_read != 0 {
 		pv.set_timeout(fd, pv.timeout_secs)
-		if pv.is_raw {
+		if !isnil(pv.raw_cb) {
 			pv.raw_cb(pv.user_data, fd)
 			return
 		}
@@ -297,10 +295,9 @@ pub fn new(config Config) &Picoev {
 		max_headers: config.max_headers
 		max_read: config.max_read
 		max_write: config.max_write
-		is_raw: config.is_raw
 	}
 
-	if !config.is_raw {
+	if isnil(pv.raw_cb) {
 		pv.buf = unsafe { malloc_noscan(picoev.max_fds * config.max_read + 1) }
 		pv.out = unsafe { malloc_noscan(picoev.max_fds * config.max_write + 1) }
 	}


### PR DESCRIPTION
Instead of invoking the HTTP parser, among other things, you can use raw mode to interact with file descriptors manually.

This was ripped and slightly changed from #19615 

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5fc70e6</samp>

Add raw event handling feature to `picoev` module. This allows users to access low-level system events and customize their behavior using a `raw_cb` callback function.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fc70e6</samp>

*  Add support for raw event handling in `picoev` ([link](https://github.com/vlang/v/pull/19771/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cR36), [link](https://github.com/vlang/v/pull/19771/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cR48), [link](https://github.com/vlang/v/pull/19771/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cR215-R218), [link](https://github.com/vlang/v/pull/19771/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cR292), [link](https://github.com/vlang/v/pull/19771/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL291-R304))
