### PR TITLE
tools.vpm: fix resolving external dependencies, add test for dependencies

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -265,12 +265,13 @@ fn resolve_dependencies(name string, module_path string, module_names []string) 
 		eprintln(err)
 		return
 	}
-	// filter out dependencies that were already specified by the user
+	// Filter out modules that are both contained in the input query and listed as
+	// dependencies in the mod file of the module that is supposed to be installed.
 	deps := manifest.dependencies.filter(it !in module_names)
 	if deps.len > 0 {
 		println('Resolving ${deps.len} dependencies for module "${name}" ...')
 		verbose_println('Found dependencies: ${deps}')
-		vpm_install_from_vpm(deps)
+		vpm_install(deps)
 	}
 }
 

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -1,0 +1,67 @@
+import os
+import v.vmod
+
+const (
+	v         = os.quoted_path(@VEXE)
+	test_path = os.join_path(os.vtmp_dir(), 'vpm_dependency_test')
+)
+
+fn testsuite_begin() {
+	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
+fn get_mod_name(path string) string {
+	mod := vmod.from_file(path) or {
+		eprintln(err)
+		return ''
+	}
+	return mod.name
+}
+
+// Case: running `v install` without specifying modules in a V project directory.
+fn test_install_dependencies_in_module_dir() {
+	os.mkdir_all(test_path) or {}
+	mod := 'my_module'
+	mod_path := os.join_path(test_path, mod)
+	os.mkdir(mod_path)!
+	os.chdir(mod_path)!
+	// Create a v.mod file that lists dependencies.
+	vmod_path := os.join_path(mod_path, 'v.mod')
+	vmod_contents := "Module {
+	name: '${mod}'
+	description: ''
+	version: '0.0.0'
+	license: 'MIT'
+	dependencies: ['markdown', 'pcre', 'https://github.com/spytheman/vtray']
+}"
+	os.write_file(vmod_path, vmod_contents)!
+	v_mod := vmod.from_file(vmod_path) or {
+		assert false, err.msg()
+		return
+	}
+	assert v_mod.dependencies == ['markdown', 'pcre', 'https://github.com/spytheman/vtray']
+	// Run `v install`
+	res := os.execute_or_exit('${v} install')
+	assert res.output.contains('Detected v.mod file inside the project directory. Using it...')
+	assert res.output.contains('Installing module "markdown"')
+	assert res.output.contains('Installing module "pcre"')
+	assert res.output.contains('Installing module "vtray"')
+	assert get_mod_name(os.join_path(test_path, 'markdown', 'v.mod')) == 'markdown'
+	assert get_mod_name(os.join_path(test_path, 'pcre', 'v.mod')) == 'pcre'
+	assert get_mod_name(os.join_path(test_path, 'vtray', 'v.mod')) == 'vtray'
+}
+
+fn test_resolve_external_dependencies_during_module_install() {
+	res := os.execute_or_exit('${v} install https://github.com/ttytm/emoji-mart-desktop')
+	assert res.output.contains('Resolving 2 dependencies')
+	assert res.output.contains('Installing module "webview"')
+	assert res.output.contains('Installing module "miniaudio"')
+	// The external dependencies should have been installed to `<vmodules_dir>/<dependency_name>`
+	assert get_mod_name(os.join_path(test_path, 'webview', 'v.mod')) == 'webview'
+	assert get_mod_name(os.join_path(test_path, 'miniaudio', 'v.mod')) == 'miniaudio'
+}

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -5,7 +5,7 @@ const (
 	v         = os.quoted_path(@VEXE)
 	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
-	test_path = os.join_path(os.vtmp_dir(), 'test-vmodules')
+	test_path = os.join_path(os.vtmp_dir(), 'vpm_install_test')
 )
 
 fn testsuite_begin() {


### PR DESCRIPTION
Fixes resolving of external dependencies, add `dependency_test.v`.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 027dd6c</samp>

This pull request adds a new test file `cmd/tools/vpm/dependency_test.v` to check the dependency resolution and installation features of vpm. It also updates the comment and function call in `cmd/tools/vpm/common.v` and renames a variable in `cmd/tools/vpm/install_test.v` for clarity and consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 027dd6c</samp>

*  Rename `test-vmodules` to `vpm_install_test` for clarity ([link](https://github.com/vlang/v/pull/19772/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L8-R8))
*  Update comment and function call in `filter_out_user_specified_modules` to reflect the logic and functionality of installing dependencies from local and remote sources ([link](https://github.com/vlang/v/pull/19772/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L268-R274))
*  Add `dependency_test.v` file to test resolving and installing dependencies from v.mod files and external URLs ([link](https://github.com/vlang/v/pull/19772/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63R1-R67))
