### PR TITLE
transformer: fix using a constant, instead of a fn parameter, with the same name (fix #19766)

### DIFF
--- a/vlib/v/tests/const_with_fn_param_with_the_same_name_test.v
+++ b/vlib/v/tests/const_with_fn_param_with_the_same_name_test.v
@@ -1,0 +1,32 @@
+const zoom_factor = 1.1
+
+fn abc(zoom_factor f64) {
+	assert zoom_factor != 1.1, 'zoom_factor here is the parameter name, not the constant from above'
+	assert zoom_factor * 10 < 2
+	assert zoom_factor * 10 > 0.9
+	dump(zoom_factor)
+	a := if zoom_factor < 1 { 1 } else { -1 }
+	assert a == 1
+}
+
+fn def(zfactor f64) {
+	assert zfactor != zoom_factor, 'zfactor is different than zoom_factor in both name and value'
+	dump(zfactor)
+	a := if zfactor < 1 { 1 } else { -1 }
+	assert a == 1
+}
+
+fn xyz(zfactor f64) {
+	assert zfactor != zoom_factor, 'both zfactor and the const zoom_factor should be available, and have different values'
+	dump(zfactor)
+	z := if zoom_factor < 1 { 1 } else { -1 }
+	assert z == -1
+	dump(zoom_factor)
+	assert zoom_factor * 10 > 10.0
+}
+
+fn test_a_const_should_not_be_used_inside_fn_that_have_parameters_with_the_same_name() {
+	abc(0.1)
+	def(0.1)
+	xyz(0.1)
+}

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -712,6 +712,10 @@ pub fn (mut t Transformer) call_expr(mut node ast.CallExpr) ast.Expr {
 fn (mut t Transformer) trans_const_value_to_literal(mut expr ast.Expr) {
 	mut expr_ := expr
 	if mut expr_ is ast.Ident {
+		// if there is a local variable or a fn parameter, that has the same name as the constant, do not do the substitution:
+		if _ := expr_.scope.find_var(expr_.name) {
+			return
+		}
 		if mut obj := t.table.global_scope.find_const(expr_.mod + '.' + expr_.name) {
 			if mut obj.expr is ast.BoolLiteral {
 				expr = obj.expr
@@ -740,10 +744,10 @@ fn (mut t Transformer) trans_const_value_to_literal(mut expr ast.Expr) {
 pub fn (mut t Transformer) infix_expr(mut node ast.InfixExpr) ast.Expr {
 	node.left = t.expr(mut node.left)
 	node.right = t.expr(mut node.right)
-	// if !t.pref.translated {
-	// 	t.trans_const_value_to_literal(mut node.left)
-	// 	t.trans_const_value_to_literal(mut node.right)
-	// }
+	if !t.pref.translated {
+		t.trans_const_value_to_literal(mut node.left)
+		t.trans_const_value_to_literal(mut node.right)
+	}
 
 	mut pos := node.left.pos()
 	pos.extend(node.pos)

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -696,8 +696,7 @@ pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
 				}
 				else {}
 			}
-		}
-		*/
+		}*/
 		else {}
 	}
 	return node
@@ -741,10 +740,10 @@ fn (mut t Transformer) trans_const_value_to_literal(mut expr ast.Expr) {
 pub fn (mut t Transformer) infix_expr(mut node ast.InfixExpr) ast.Expr {
 	node.left = t.expr(mut node.left)
 	node.right = t.expr(mut node.right)
-	if !t.pref.translated {
-		t.trans_const_value_to_literal(mut node.left)
-		t.trans_const_value_to_literal(mut node.right)
-	}
+	// if !t.pref.translated {
+	// 	t.trans_const_value_to_literal(mut node.left)
+	// 	t.trans_const_value_to_literal(mut node.right)
+	// }
 
 	mut pos := node.left.pos()
 	pos.extend(node.pos)


### PR DESCRIPTION
Fix #19766.
Discovered by partially reverting commit 055e113af37017a5bbc9173b17cecbe556b79b39 in https://discord.com/channels/592103645835821068/592294828432424960/1170655326526242837 .

