### PR TITLE
cgen: fix g.obf_table data missing(fix #19695)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -680,6 +680,7 @@ fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) &Gen {
 		done_options: global_g.done_options
 		done_results: global_g.done_results
 		is_autofree: global_g.pref.autofree
+		obf_table: global_g.obf_table
 		referenced_fns: global_g.referenced_fns
 		is_cc_msvc: global_g.is_cc_msvc
 		use_segfault_handler: global_g.use_segfault_handler


### PR DESCRIPTION
This PR fixed g.obf_table data missing(fix #19695)

```v
fn add(a int, b int) int {
	return a + b
}

fn main() {
	println(add(1, 3))
}
```

```c
/* obf: main.add */
VV_LOCAL_SYMBOL int _f0(int a, int b) {
	int _t1 = (int)(a + b);
	return _t1;
}

VV_LOCAL_SYMBOL void main__main(void) {
	println(int_str(/* obf call: main.add */_f0(1, 3)));
}
```

```
v -obf run a.v
```
outputs:
```
4
```