### PR TITLE
cgen: only generate free in wrapper for spawn and not go

### DIFF
--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -371,7 +371,9 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 		}
 		g.gowrappers.writeln(');')
-		g.gowrappers.writeln('\t_v_free(arg);')
+		if is_spawn {
+			g.gowrappers.writeln('\t_v_free(arg);')
+		}
 		if g.pref.os != .windows && node.call_expr.return_type != ast.void_type {
 			g.gowrappers.writeln('\treturn ret_ptr;')
 		} else {


### PR DESCRIPTION
fixes bug where free was called pointer not allocated with malloc

```
pointer being freed was not allocated
```

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b09e5b</samp>

Fix double free bug when using go with struct arguments. Add a condition to `vlib/v/gen/c/spawn_and_go.v` to only free argument pointers for spawn expressions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b09e5b</samp>

* Fix double free error when using go with a struct argument ([link](https://github.com/vlang/v/pull/19780/files?diff=unified&w=0#diff-53fcf867649ba6d7e64468ab4d50597b4b76c6f972bd824f4b30f9dad726557fL374-R376))
