### PR TITLE
tools: improve error messages, add color coding and debug logging

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -248,7 +248,9 @@ fn ensure_vmodules_dir_exist() {
 }
 
 fn ensure_vcs_is_installed(vcs &VCS) ! {
-	os.find_abs_path_of_executable(vcs.cmd) or { return error('failed to execute `${vcs}`.') }
+	os.find_abs_path_of_executable(vcs.cmd) or {
+		return error('VPM needs `${vcs.cmd}` to be installed.')
+	}
 }
 
 fn increment_module_download_count(name string) ! {
@@ -316,7 +318,7 @@ fn valid_final_path_of_existing_module(modulename string) ?string {
 	name := if mod := get_mod_by_url(modulename) { mod.name } else { modulename }
 	minfo := get_mod_name_info(name)
 	if !os.exists(minfo.final_module_path) {
-		vpm_error('failed to find a module with name `${minfo.mname_normalised}` exists at ${minfo.final_module_path}')
+		vpm_error('failed to find a module with name `${minfo.mname_normalised}` at `${minfo.final_module_path}`')
 		return none
 	}
 	if !os.is_dir(minfo.final_module_path) {
@@ -324,7 +326,7 @@ fn valid_final_path_of_existing_module(modulename string) ?string {
 		return none
 	}
 	vcs_used_in_dir(minfo.final_module_path) or {
-		vpm_error('skipping `${minfo.final_module_path}`, since it specifiecs an unsupported version control system.')
+		vpm_error('skipping `${minfo.final_module_path}`, since it specifics an unsupported version control system.')
 		return none
 	}
 	return minfo.final_module_path
@@ -347,9 +349,10 @@ fn vpm_error(msg string, opts ErrorOptions) {
 	eprintln(term.ecolorize(term.red, 'error: ') + msg)
 	if opts.details.len > 0 && settings.is_verbose {
 		eprint(term.ecolorize(term.blue, 'details: '))
+		padding := ' '.repeat('details: '.len)
 		for i, line in opts.details.split_into_lines() {
 			if i > 0 {
-				eprint(' '.repeat('details: '.len))
+				eprint(padding)
 			}
 			eprintln(term.ecolorize(term.blue, line))
 		}

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -6,6 +6,8 @@ import v.vmod
 import sync.pool
 import net.http
 import net.urllib
+import term
+import log
 
 struct Mod {
 	id           int
@@ -30,6 +32,12 @@ mut:
 	final_module_path string // ~/.vmodules/the_user/the_mod
 }
 
+[params]
+struct ErrorOptions {
+	details string
+	verbose bool // is used to only output the error message if the verbose setting is enabled.
+}
+
 fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	mut result := &ModDateInfo{
 		name: pp.get_item[string](idx)
@@ -40,7 +48,7 @@ fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
 	mut outputs := []string{}
 	for step in vcs.args.outdated {
 		cmd := '${vcs.cmd} ${vcs.args.path} "${final_module_path}" ${step}'
-		res := os.execute('${cmd}')
+		res := os.execute(cmd)
 		if res.exit_code < 0 {
 			verbose_println('Error command: ${cmd}')
 			verbose_println('Error details:\n${res.output}')
@@ -73,22 +81,24 @@ fn get_module_meta_info(name string) !Mod {
 	if mod := get_mod_by_url(name) {
 		return mod
 	}
+	if name.len < 2 || (!name[0].is_digit() && !name[0].is_letter()) {
+		return error('invalid module name `${name}`.')
+	}
 	mut errors := []string{}
-
 	for server_url in vpm_server_urls {
 		modurl := server_url + '/api/packages/${name}'
-		verbose_println('Retrieving module metadata from: "${modurl}" ...')
+		verbose_println('Retrieving module metadata from `${modurl}` ...')
 		r := http.get(modurl) or {
-			errors << 'Http server did not respond to our request for "${modurl}" .'
+			errors << 'Http server did not respond to our request for `${modurl}`.'
 			errors << 'Error details: ${err}'
 			continue
 		}
 		if r.status_code == 404 || r.body.trim_space() == '404' {
-			errors << 'Skipping module "${name}", since "${server_url}" reported that "${name}" does not exist.'
+			errors << 'Skipping module `${name}`, since `${server_url}` reported that `${name}` does not exist.'
 			continue
 		}
 		if r.status_code != 200 {
-			errors << 'Skipping module "${name}", since "${server_url}" responded with ${r.status_code} http status code. Please try again later.'
+			errors << 'Skipping module `${name}`, since `${server_url}` responded with ${r.status_code} http status code. Please try again later.'
 			continue
 		}
 		s := r.body
@@ -98,11 +108,11 @@ fn get_module_meta_info(name string) !Mod {
 			continue
 		}
 		mod := json.decode(Mod, s) or {
-			errors << 'Skipping module "${name}", since its information is not in json format.'
+			errors << 'Skipping module `${name}`, since its information is not in json format.'
 			continue
 		}
 		if '' == mod.url || '' == mod.name {
-			errors << 'Skipping module "${name}", since it is missing name or url information.'
+			errors << 'Skipping module `${name}`, since it is missing name or url information.'
 			continue
 		}
 		return mod
@@ -130,7 +140,7 @@ fn get_outdated() ![]string {
 	pp.work_on_items(module_names)
 	for res in pp.get_results[ModDateInfo]() {
 		if res.exec_err {
-			return error('Error while checking latest commits for "${res.name}" .')
+			return error('failed to check the latest commits for `${res.name}`.')
 		}
 		if res.outdated {
 			outdated << res.name
@@ -141,9 +151,14 @@ fn get_outdated() ![]string {
 
 fn get_all_modules() []string {
 	url := get_working_server_url()
-	r := http.get(url) or { panic(err) }
+	r := http.get(url) or {
+		vpm_error(err.msg(),
+			verbose: true
+		)
+		exit(1)
+	}
 	if r.status_code != 200 {
-		eprintln('Failed to search vpm.vlang.io. Status code: ${r.status_code}')
+		vpm_error('failed to search vpm.vlang.io.', details: 'Status code: ${r.status_code}')
 		exit(1)
 	}
 	s := r.body
@@ -222,20 +237,23 @@ fn get_working_server_url() string {
 
 fn ensure_vmodules_dir_exist() {
 	if !os.is_dir(settings.vmodules_path) {
-		println('Creating "${settings.vmodules_path}/" ...')
-		os.mkdir(settings.vmodules_path) or { panic(err) }
+		println('Creating `${settings.vmodules_path}` ...')
+		os.mkdir(settings.vmodules_path) or {
+			vpm_error(err.msg(),
+				verbose: true
+			)
+			exit(1)
+		}
 	}
 }
 
 fn ensure_vcs_is_installed(vcs &VCS) ! {
-	os.find_abs_path_of_executable(vcs.cmd) or {
-		return error('VPM needs `${vcs}` to be installed.')
-	}
+	os.find_abs_path_of_executable(vcs.cmd) or { return error('failed to execute `${vcs}`.') }
 }
 
 fn increment_module_download_count(name string) ! {
 	if settings.no_dl_count_increment {
-		println('Skipping download count increment for "${name}".')
+		println('Skipping download count increment for `${name}`.')
 		return
 	}
 	mut errors := []string{}
@@ -243,12 +261,12 @@ fn increment_module_download_count(name string) ! {
 	for server_url in vpm_server_urls {
 		modurl := server_url + '/api/packages/${name}/incr_downloads'
 		r := http.post(modurl, '') or {
-			errors << 'Http server did not respond to our request for "${modurl}" .'
+			errors << 'Http server did not respond to our request for `${modurl}`.'
 			errors << 'Error details: ${err}'
 			continue
 		}
 		if r.status_code != 200 {
-			errors << 'Failed to increment the download count for module "${name}", since "${server_url}" responded with ${r.status_code} http status code. Please try again later.'
+			errors << 'Failed to increment the download count for module `${name}`, since `${server_url}` responded with ${r.status_code} http status code. Please try again later.'
 			continue
 		}
 		return
@@ -262,14 +280,16 @@ fn resolve_dependencies(name string, module_path string, module_names []string) 
 		return
 	}
 	manifest := vmod.from_file(vmod_path) or {
-		eprintln(err)
+		vpm_error(err.msg(),
+			verbose: true
+		)
 		return
 	}
 	// Filter out modules that are both contained in the input query and listed as
 	// dependencies in the mod file of the module that is supposed to be installed.
 	deps := manifest.dependencies.filter(it !in module_names)
 	if deps.len > 0 {
-		println('Resolving ${deps.len} dependencies for module "${name}" ...')
+		println('Resolving ${deps.len} dependencies for module `${name}` ...')
 		verbose_println('Found dependencies: ${deps}')
 		vpm_install(deps)
 	}
@@ -296,15 +316,15 @@ fn valid_final_path_of_existing_module(modulename string) ?string {
 	name := if mod := get_mod_by_url(modulename) { mod.name } else { modulename }
 	minfo := get_mod_name_info(name)
 	if !os.exists(minfo.final_module_path) {
-		eprintln('No module with name "${minfo.mname_normalised}" exists at ${minfo.final_module_path}')
+		vpm_error('failed to find a module with name `${minfo.mname_normalised}` exists at ${minfo.final_module_path}')
 		return none
 	}
 	if !os.is_dir(minfo.final_module_path) {
-		eprintln('Skipping "${minfo.final_module_path}", since it is not a folder.')
+		vpm_error('skipping `${minfo.final_module_path}`, since it is not a directory.')
 		return none
 	}
 	vcs_used_in_dir(minfo.final_module_path) or {
-		eprintln('Skipping "${minfo.final_module_path}", since it does not use a supported vcs.')
+		vpm_error('skipping `${minfo.final_module_path}`, since it specifiecs an unsupported version control system.')
 		return none
 	}
 	return minfo.final_module_path
@@ -313,5 +333,25 @@ fn valid_final_path_of_existing_module(modulename string) ?string {
 fn verbose_println(s string) {
 	if settings.is_verbose {
 		println(s)
+	}
+}
+
+fn vpm_log(line string, func string, msg string) {
+	log.debug('${line} | (${func}) ${msg}')
+}
+
+fn vpm_error(msg string, opts ErrorOptions) {
+	if opts.verbose && !settings.is_verbose {
+		return
+	}
+	eprintln(term.ecolorize(term.red, 'error: ') + msg)
+	if opts.details.len > 0 && settings.is_verbose {
+		eprint(term.ecolorize(term.blue, 'details: '))
+		for i, line in opts.details.split_into_lines() {
+			if i > 0 {
+				eprint(' '.repeat('details: '.len))
+			}
+			eprintln(term.ecolorize(term.blue, line))
+		}
 	}
 }

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -326,7 +326,7 @@ fn valid_final_path_of_existing_module(modulename string) ?string {
 		return none
 	}
 	vcs_used_in_dir(minfo.final_module_path) or {
-		vpm_error('skipping `${minfo.final_module_path}`, since it specifics an unsupported version control system.')
+		vpm_error('skipping `${minfo.final_module_path}`, since it uses an unsupported version control system.')
 		return none
 	}
 	return minfo.final_module_path

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -8,6 +8,7 @@ const (
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_DEBUG', '', true)
 	os.setenv('VPM_NO_INCREMENT', '1', true)
 }
 

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -48,9 +48,9 @@ fn test_install_dependencies_in_module_dir() {
 	// Run `v install`
 	res := os.execute_or_exit('${v} install')
 	assert res.output.contains('Detected v.mod file inside the project directory. Using it...')
-	assert res.output.contains('Installing module "markdown"')
-	assert res.output.contains('Installing module "pcre"')
-	assert res.output.contains('Installing module "vtray"')
+	assert res.output.contains('Installing module `markdown`')
+	assert res.output.contains('Installing module `pcre`')
+	assert res.output.contains('Installing module `vtray`')
 	assert get_mod_name(os.join_path(test_path, 'markdown', 'v.mod')) == 'markdown'
 	assert get_mod_name(os.join_path(test_path, 'pcre', 'v.mod')) == 'pcre'
 	assert get_mod_name(os.join_path(test_path, 'vtray', 'v.mod')) == 'vtray'
@@ -59,8 +59,8 @@ fn test_install_dependencies_in_module_dir() {
 fn test_resolve_external_dependencies_during_module_install() {
 	res := os.execute_or_exit('${v} install https://github.com/ttytm/emoji-mart-desktop')
 	assert res.output.contains('Resolving 2 dependencies')
-	assert res.output.contains('Installing module "webview"')
-	assert res.output.contains('Installing module "miniaudio"')
+	assert res.output.contains('Installing module `webview`')
+	assert res.output.contains('Installing module `miniaudio`')
 	// The external dependencies should have been installed to `<vmodules_dir>/<dependency_name>`
 	assert get_mod_name(os.join_path(test_path, 'webview', 'v.mod')) == 'webview'
 	assert get_mod_name(os.join_path(test_path, 'miniaudio', 'v.mod')) == 'miniaudio'

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -106,7 +106,7 @@ fn vpm_install_from_vpm(module_names []string) {
 		vcs := if mod.vcs != '' {
 			supported_vcs[mod.vcs] or {
 				errors++
-				vpm_error('skipping `${name}`, since it specifics an unsupported version control system `${mod.vcs}`.')
+				vpm_error('skipping `${name}`, since it uses an unsupported version control system `${mod.vcs}`.')
 				continue
 			}
 		} else {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -106,7 +106,7 @@ fn vpm_install_from_vpm(module_names []string) {
 		vcs := if mod.vcs != '' {
 			supported_vcs[mod.vcs] or {
 				errors++
-				vpm_error('skipping `${name}`, since it specifiecs an unsupported version control system `${mod.vcs}`.')
+				vpm_error('skipping `${name}`, since it specifics an unsupported version control system `${mod.vcs}`.')
 				continue
 			}
 		} else {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -11,6 +11,7 @@ const (
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_DEBUG', '', true)
 	os.setenv('VPM_NO_INCREMENT', '1', true)
 }
 

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -1,5 +1,6 @@
 import os
 import v.vmod
+import term
 
 const (
 	v         = os.quoted_path(@VEXE)
@@ -19,7 +20,7 @@ fn testsuite_end() {
 
 fn test_install_from_vpm_ident() {
 	res := os.execute_or_exit('${v} install nedpals.args')
-	assert res.output.contains('Skipping download count increment for "nedpals.args".')
+	assert res.output.contains('Skipping download count increment for `nedpals.args`.')
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -40,8 +41,8 @@ fn test_install_from_vpm_short_ident() {
 
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('Installing module "markdown" from "https://github.com/vlang/markdown')
-	assert res.output.contains('Relocating module from "vlang/markdown" to "markdown"')
+	assert res.output.contains('Installing module `markdown` from `https://github.com/vlang/markdown`')
+	assert res.output.contains('Relocating module from `vlang/markdown` to `markdown`')
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -104,5 +105,5 @@ fn test_missing_repo_name_in_url() {
 	incomplete_url := 'https://github.com/vlang'
 	res := os.execute('${v} install ${incomplete_url}')
 	assert res.exit_code == 1
-	assert res.output.trim_space() == 'Errors while retrieving module name for: "${incomplete_url}"'
+	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`')
 }

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -1,6 +1,5 @@
 import os
 import v.vmod
-import term
 
 const (
 	v         = os.quoted_path(@VEXE)

--- a/cmd/tools/vpm/search.v
+++ b/cmd/tools/vpm/search.v
@@ -9,7 +9,7 @@ fn vpm_search(keywords []string) {
 		help.print_and_exit('search')
 	}
 	if search_keys.len == 0 {
-		eprintln('´v search´ requires *at least one* keyword.')
+		vpm_error('specify at least one keyword to search for.')
 		exit(2)
 	}
 	modules := get_all_modules()
@@ -22,7 +22,7 @@ fn vpm_search(keywords []string) {
 				continue
 			}
 			if index == 0 {
-				println('Search results for "${joined}":\n')
+				println('Search results for `${joined}`:\n')
 			}
 			index++
 			mut parts := mod.split('.')
@@ -44,13 +44,13 @@ fn vpm_search(keywords []string) {
 		mut messages := ['No module(s) found for `${joined}` .']
 		for vlibmod in search_keys {
 			if os.is_dir(os.join_path(vroot, 'vlib', vlibmod)) {
-				messages << 'There is already an existing "${vlibmod}" module in vlib, so you can just `import ${vlibmod}` .'
+				messages << 'There is already an existing `${vlibmod}` module in vlib, so you can just `import ${vlibmod}` .'
 			}
 		}
 		for m in messages {
 			println(m)
 		}
 	} else {
-		eprintln('\nUse "v install author_name.module_name" to install the module.')
+		eprintln('\nUse `v install author_name.module_name` to install the module.')
 	}
 }

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -2,6 +2,7 @@ module main
 
 import os
 import os.cmdline
+import log
 
 struct VpmSettings {
 mut:
@@ -18,6 +19,9 @@ fn init_settings() VpmSettings {
 	args := os.args[1..]
 	opts := cmdline.only_options(args)
 	cmds := cmdline.only_non_options(args)
+	if os.getenv('VPM_DEBUG') != '' {
+		log.set_level(.debug)
+	}
 	return VpmSettings{
 		is_help: '-h' in opts || '--help' in opts || 'help' in cmds
 		is_once: '--once' in opts
@@ -25,6 +29,6 @@ fn init_settings() VpmSettings {
 		vcs: if '--hg' in opts { 'hg' } else { 'git' }
 		server_urls: cmdline.options(args, '--server-urls')
 		vmodules_path: os.vmodules_dir()
-		no_dl_count_increment: os.getenv('VPM_NO_INCREMENT') == '1'
+		no_dl_count_increment: os.getenv('VPM_NO_INCREMENT') != ''
 	}
 }

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -17,25 +17,28 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 	}
 	zname := url_to_module_name(result.name)
 	result.final_path = valid_final_path_of_existing_module(result.name) or { return result }
-	println('Updating module "${zname}" in "${result.final_path}" ...')
+	println('Updating module `${zname}` in `${result.final_path}` ...')
 	vcs := vcs_used_in_dir(result.final_path) or { return result }
 	ensure_vcs_is_installed(vcs) or {
 		result.has_err = true
-		eprintln(err)
+		vpm_error(err.msg())
 		return result
 	}
 	cmd := '${vcs.cmd} ${vcs.args.path} "${result.final_path}" ${vcs.args.update}'
-	verbose_println('    command: ${cmd}')
-	res := os.execute_opt('${cmd}') or {
+	vpm_log(@FILE_LINE, @FN, 'cmd: ${cmd}')
+	res := os.execute_opt(cmd) or {
 		result.has_err = true
-		println('Failed updating module "${zname}" in "${result.final_path}".')
-		verbose_println('      command output: ${err}')
+		vpm_error('failed to update module `${zname}` in `${result.final_path}`.',
+			details: err.msg()
+		)
 		return result
 	}
-	verbose_println('    ${res.output.trim_space()}')
+	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output.trim_space()}')
 	increment_module_download_count(zname) or {
 		result.has_err = true
-		eprintln('Errors while incrementing the download count for ${zname}:')
+		vpm_error(err.msg(),
+			verbose: true
+		)
 	}
 	return result
 }
@@ -67,25 +70,28 @@ fn vpm_update_verbose(module_names []string) {
 	for name in module_names {
 		zname := url_to_module_name(name)
 		final_module_path := valid_final_path_of_existing_module(name) or { continue }
-		println('Updating module "${zname}" in "${final_module_path}" ...')
+		println('Updating module `${zname}` in `${final_module_path}` ...')
 		vcs := vcs_used_in_dir(final_module_path) or { continue }
 		ensure_vcs_is_installed(vcs) or {
 			errors++
-			eprintln(err)
+			vpm_error(err.msg())
 			continue
 		}
 		cmd := '${vcs.cmd} ${vcs.args.path} "${final_module_path}" ${vcs.args.update}'
-		verbose_println('    command: ${cmd}')
-		res := os.execute_opt('${cmd}') or {
+		vpm_log(@FILE_LINE, @FN, 'cmd: ${cmd}')
+		res := os.execute_opt(cmd) or {
 			errors++
-			println('Failed updating module "${zname}" in "${final_module_path}" .')
-			verbose_println('      command output: ${err}')
+			vpm_error('failed to update module `${zname}` in `${final_module_path}`.',
+				details: err.msg()
+			)
 			continue
 		}
-		verbose_println('    ${res.output.trim_space()}')
+		vpm_log(@FILE_LINE, @FN, 'cmd: ${res.output.trim_space()}')
 		increment_module_download_count(zname) or {
 			errors++
-			eprintln('Errors while incrementing the download count for ${zname}:')
+			vpm_error(err.msg(),
+				verbose: true
+			)
 		}
 		resolve_dependencies(name, final_module_path, module_names)
 	}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -56,7 +56,7 @@ fn main() {
 	// which provides the path to V inside os.getenv('VEXE')
 	// args are: vpm [options] SUBCOMMAND module names
 	params := cmdline.only_non_options(os.args[1..])
-	// dump(params)
+	vpm_log(@FILE_LINE, @FN, 'params: ${params}')
 	if params.len < 1 {
 		help.print_and_exit('vpm', exit_code: 5)
 	}
@@ -92,12 +92,9 @@ fn main() {
 			vpm_show(requested_modules)
 		}
 		else {
-			eprintln('Error: you tried to run "v ${vpm_command}"')
-			eprintln('... but the v package management tool vpm only knows about these commands:')
-			for validcmd in valid_vpm_commands {
-				eprintln('    v ${validcmd}')
-			}
-			exit(3)
+			// Unreachable in regular usage. V will catch unkown commands beforehand.
+			vpm_error('unkown command "${vpm_command}"')
+			help.print_and_exit('vpm', exit_code: 3)
 		}
 	}
 }
@@ -114,9 +111,9 @@ fn vpm_upgrade() {
 fn vpm_outdated() {
 	outdated := get_outdated() or { exit(1) }
 	if outdated.len > 0 {
-		eprintln('Outdated modules:')
+		println('Outdated modules:')
 		for m in outdated {
-			eprintln('  ${m}')
+			println('  ${m}')
 		}
 	} else {
 		println('Modules are up to date.')
@@ -126,7 +123,7 @@ fn vpm_outdated() {
 fn vpm_list() {
 	module_names := get_installed_modules()
 	if module_names.len == 0 {
-		eprintln('You have no modules installed.')
+		println('You have no modules installed.')
 		exit(0)
 	}
 	for mod in module_names {
@@ -139,27 +136,27 @@ fn vpm_remove(module_names []string) {
 		help.print_and_exit('remove')
 	}
 	if module_names.len == 0 {
-		eprintln('´v remove´ requires *at least one* module name.')
+		vpm_error('specify at least one module name for removal.')
 		exit(2)
 	}
 	for name in module_names {
 		final_module_path := valid_final_path_of_existing_module(name) or { continue }
-		eprintln('Removing module "${name}" ...')
-		verbose_println('removing folder ${final_module_path}')
-		os.rmdir_all(final_module_path) or {
-			verbose_println('error while removing "${final_module_path}": ${err.msg()}')
-		}
-		// delete author directory if it is empty
+		println('Removing module "${name}" ...')
+		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
+		os.rmdir_all(final_module_path) or { vpm_error(err.msg(),
+			verbose: true
+		) }
+		// Delete author directory if it is empty.
 		author := name.split('.')[0]
 		author_dir := os.real_path(os.join_path(settings.vmodules_path, author))
 		if !os.exists(author_dir) {
 			continue
 		}
 		if os.is_dir_empty(author_dir) {
-			verbose_println('removing author folder ${author_dir}')
-			os.rmdir(author_dir) or {
-				verbose_println('error while removing "${author_dir}": ${err.msg()}')
-			}
+			verbose_println('Removing author folder ${author_dir}')
+			os.rmdir(author_dir) or { vpm_error(err.msg(),
+				verbose: true
+			) }
 		}
 	}
 }

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -14,7 +14,7 @@ struct VCS {
 	cmd  string
 	args struct {
 		install  string
-		path     string // the flag used to specify a path. E.g., used to explictly work on a path during multithreaded updating.
+		path     string // the flag used to specify a path. E.g., used to explicitly work on a path during multithreaded updating.
 		update   string
 		outdated []string
 	}
@@ -92,8 +92,8 @@ fn main() {
 			vpm_show(requested_modules)
 		}
 		else {
-			// Unreachable in regular usage. V will catch unkown commands beforehand.
-			vpm_error('unkown command "${vpm_command}"')
+			// Unreachable in regular usage. V will catch unknown commands beforehand.
+			vpm_error('unknown command "${vpm_command}"')
 			help.print_and_exit('vpm', exit_code: 3)
 		}
 	}


### PR DESCRIPTION
This PR updates errors (e.g., also the error stated in yesterday's discord chat) and makes them uniform. It adds some color coding (similar to our regular V errors or cargo) and replaces verbose prints where they were solely used for debugging with debug logs that will be printed when run with the `VPM_DEBUG` env var.

- Errors:
  Current
  ![Screenshot_20231106_091326](https://github.com/vlang/v/assets/34311583/e102d6ac-4c4e-4d31-a3d7-94d3b48e362f)

  New
  ![Screenshot_20231106_091830](https://github.com/vlang/v/assets/34311583/bbf08db7-1867-4a4c-b47d-65cedf51b7e1)
  
- Logs:

  ![Screenshot_20231106_084729](https://github.com/vlang/v/assets/34311583/e8e667fe-665a-408d-87b0-e8a965553ecc)
  
Ofc. colors differ from the screenshots based on terminal configuration.

Also, the work on VPM implements new errors or extends existing ones. Updating them allows working with the new errors already, instead of creating ones that match the old ones, only to update them later.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8b9e99</samp>

This pull request improves the error handling, logging, and output formatting of the `vpm` tool, using the `log` and `term` modules and some new helper functions. It also fixes some bugs and validations in the module metadata and dependency resolution features. It updates the test files to match the new output and error messages.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a8b9e99</samp>

*  Add new error handling and logging functions `vpm_error` and `vpm_log` to `common.v`, and use them to replace `eprintln`, `panic`, and `verbose_println` in various places, respecting the verbosity settings and providing more details if needed ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R9-R10),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L133-R143),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R338-R357),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L51-R53),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L62-R63),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL25-R28),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL43-R44),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL88-R93),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL102-R103),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL109-R109),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL117-R117),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL127-R132),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL146-R146),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL154-R154),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL165-R170),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL176-R186),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL195-R197),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL202-R216),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R3),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L22-R23),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L43-R45),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L107-R108),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-96549a827e85ce50a5777165ed054e7bcdaefc5a6b6f2950a24ebb8b4a4d5c3dL12-R12),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L20-R41),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L70-R94),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L59-R59),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L95-R97),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L117-R116),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L129-R126),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L142-R149),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L159-R159))
* Add a new struct `ErrorOptions` to `common.v`, and use it to pass optional details and verbosity settings to the `vpm_error` function, allowing more flexibility and control over how errors are displayed to the user ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R35-R40))
* Fix a bug in the `get_module_meta_info` function in `common.v`, where the `cmd` variable was interpolated twice, causing an invalid command to be executed ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L43-R51))
* Add a validation check for the module name in the `get_module_meta_info` function in `common.v`, where it returns an error if the name is less than two characters long or does not start with a digit or a letter ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L76-R101))
* Remove the redundant quotation marks around the module name and url in the `get_module_meta_info` and `resolve_dependencies` functions in `common.v`, where they are already interpolated with the `${}` syntax ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L101-R115),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L272-R292))
* Replace the `eprintln` function with the `vpm_error` function in the `get_mod_date_info`, `get_all_modules`, `ensure_vmodules_dir_exist`, `increment_module_download_count`, and `resolve_dependencies` functions in `common.v`, where they report various errors related to the retrieval, creation, and parsing of module data ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L133-R143),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L144-R161),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L225-R256),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L246-R269),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L265-R285))
* Replace the `eprintln` function with the `vpm_error` function in the `valid_final_path_of_existing_module` function in `common.v`, where it reports various errors if the module name or path is invalid or unsupported, and make the error messages more consistent and informative ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L299-R327))
* Replace the quotation marks with backticks around the module names and url in the `test_install_from_vmod`, `test_install_from_git_url`, `test_install_from_incomplete_url` functions in `install_test.v`, and the `test_install_from_vmod` and `test_install_from_git_url` functions in `dependency_test.v`, where they assert that the output of the `v install` command contains the expected messages, and make the test output more consistent with the actual output of the vpm tool ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L51-R53),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L62-R63),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L22-R23),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L43-R45),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L107-R108))
* Replace the exact string comparison with a substring check in the `test_install_from_incomplete_url` function in `install_test.v`, where it asserts that the output of the `v install` command contains the expected error message, and make the test more robust and flexible ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L107-R108))
* Remove the redundant quotation marks around the joined keywords in the `vpm_search` function in `search.v`, where they are already interpolated with the `${}` syntax ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-96549a827e85ce50a5777165ed054e7bcdaefc5a6b6f2950a24ebb8b4a4d5c3dL25-R25))
* Remove the redundant quotation marks around the vlib module name in the `vpm_search` function in `search.v`, where they are already interpolated with the `${}` syntax ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-96549a827e85ce50a5777165ed054e7bcdaefc5a6b6f2950a24ebb8b4a4d5c3dL47-R47))
* Replace the quotation marks with backticks around the module name in the `vpm_search` function in `search.v`, where it prints a suggestion on how to install the module, and make the output more consistent with the actual output of the vpm tool ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-96549a827e85ce50a5777165ed054e7bcdaefc5a6b6f2950a24ebb8b4a4d5c3dL54-R54))
* Add an import to the `log` module in `settings.v`, and use it for the new `vpm_log` function that uses the `log` module to output debug messages ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR5))
* Add a check for the `VPM_DEBUG` environment variable in the `get_settings` function in `settings.v`, where it sets the log level to debug if the variable is not empty ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR22-R24))
* Change the condition for the `no_dl_count_increment` field in the `get_settings` function in `settings.v`, where it checks if the `VPM_NO_INCREMENT` environment variable is not empty instead of equal to `1` ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL28-R32))
* Add a call to the `vpm_log` function in the `main` function in `vpm.v`, where it logs the parameters passed to the vpm tool, and provide more debug information for the vpm tool ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L59-R59))
* Replace the `eprintln` function with the `println` function in the `main` function in `vpm.v`, where it prints the list of outdated or installed modules, and avoid printing the list as an error ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L117-R116),[link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L129-R126))
* Replace the `help.print_and_exit` function with the `vpm_error` function and the `help.print_and_exit` function in the `main` function in `vpm.v`, where it reports an error and prints the help message if an unknown command is passed to the vpm tool, and make the code more consistent and concise ([link](https://github.com/vlang/v/pull/19781/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L95-R97))
