### PR TITLE
vdoc: use `markdown.default_html_transformer` underneath, remove `html_tag_escape`

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -4,7 +4,6 @@ import os
 import net.urllib
 import strings
 import markdown
-import net.html
 import v.scanner
 import v.ast
 import v.token

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -530,7 +530,8 @@ fn (f &MdHtmlCodeHighlighter) transform_attribute(p markdown.ParentType, name st
 
 fn (f &MdHtmlCodeHighlighter) transform_content(parent markdown.ParentType, text string) string {
 	// NOTE: markdown.default_html_transformer uses html.escape internally.
-	initial_transformed_text := markdown.default_html_transformer.transform_content(parent, text)
+	initial_transformed_text := markdown.default_html_transformer.transform_content(parent,
+		text)
 	if parent is markdown.MD_BLOCKTYPE && parent == .md_block_code {
 		if f.language == 'v' || f.language == 'vlang' {
 			return html_highlight(initial_transformed_text, f.table)

--- a/cmd/tools/vdoc/html_tag_escape_test.v
+++ b/cmd/tools/vdoc/html_tag_escape_test.v
@@ -1,6 +1,0 @@
-module main
-
-fn test_html_tag_escape() {
-	assert html_tag_escape('abc <b>bold</b> 123') == 'abc &lt;b&gt;bold&lt;/b&gt; 123'
-	assert html_tag_escape('`abc <b>bold</b> 123`') == '`abc <b>bold</b> 123`'
-}

--- a/cmd/tools/vdoc/tests/testdata/output_formats/README.md
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/README.md
@@ -5,6 +5,10 @@ documentation in a project or module.
 
 This is a [link](https://vlang.io/) to the main V site.
 
+This is a <b>bold text</b>.
+
+This is a script <script>console.log('hi from README.md');</script> .
+
 ## Examples:
 
 ### Processing command line args:

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
@@ -2,6 +2,8 @@ Description:
 This is an example of a an .md file, used for adding more rich text
 documentation in a project or module.
 This is a link to the main V site.
+This is a bold text.
+This is a script console.log('hi from README.md'); .
 Examples:
 Processing command line args:
 import os
@@ -64,6 +66,10 @@ fn auth_verify(secret string, token string) bool {
     This is an example of a an .md file, used for adding more rich text documentation in a project or module.
     
     This is a [link](https://vlang.io/) to the main V site.
+    
+    This is a <b>bold text</b>.
+    
+    This is a script <script>console.log('hi from README.md');</script> .
     
     ## Examples:
     

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
@@ -135,7 +135,7 @@ fn auth_verify(secret string, token string) bool {
 [94mfn[39m [36mdef[39m()
     def - should be first
 [94mfn[39m [36mxyz[39m()
-    xyz - should be in the middle
+    xyz - should be in the middle a small script <script>console.log('hello');</script> bold text <b>bold</b> end underlined text <u>underline</u> end a link [main v repo](https://github.com/vlang/v)
 [94mfn[39m [32mMyXMLDocument[39m.[36mabc[39m(text [32mstring[39m) ?([32mstring[39m, [32mint[39m)
     MyXMLDocument.abc does something too... I just do not know what.
 [94mfn[39m [32mMyXMLDocument[39m.[36mfrom_file[39m(path [32mstring[39m) ![32mMyXMLDocument[39m

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.html
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.html
@@ -1,5 +1,5 @@
 <section id="readme_main" class="doc-node">
-			<div class="title"><h1> main <a href="#readme_main">#</a></h1></div><h2>Description:</h2><p>This is an example of a an .md file, used for adding more rich text documentation in a project or module.</p><p>This is a <a href="https://vlang.io/">link</a> to the main V site.</p><h2>Examples:</h2><h3>Processing command line args:</h3><pre><code class="language-v"><span class="token keyword">import</span> os
+			<div class="title"><h1> main <a href="#readme_main">#</a></h1></div><h2>Description:</h2><p>This is an example of a an .md file, used for adding more rich text documentation in a project or module.</p><p>This is a <a href="https://vlang.io/">link</a> to the main V site.</p><p>This is a <b>bold text</b>.</p><p>This is a script <code>console.log('hi from README.md');</code> .</p><h2>Examples:</h2><h3>Processing command line args:</h3><pre><code class="language-v"><span class="token keyword">import</span> os
 
 <span class="token keyword">fn</span> <span class="token function">main</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
 <span class="token keyword">dump</span><span class="token punctuation">(</span>os<span class="token punctuation">.</span>args<span class="token punctuation">)</span>

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.html
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.html
@@ -84,7 +84,7 @@ return hmac.equal(signature_from_token, signature_mirror)
 </section>
 		<section id="xyz" class="doc-node">
 			<div class="title"><h2>fn xyz <a href="#xyz">#</a></h2></div><pre class="signature"><code><span class="token keyword">fn</span> <span class="token function">xyz</span><span class="token punctuation">(</span><span class="token punctuation">)</span></code></pre>
-<p>xyz - should be in the middle</p>
+<p>xyz - should be in the middle a small script <script>console.log('hello');</script> bold text <b>bold</b> end underlined text <u>underline</u> end a link <a href="https://github.com/vlang/v">main v repo</a></p>
 
 </section>
 		<section id="MyXMLDocument.abc" class="doc-node">

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.text
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.text
@@ -76,7 +76,7 @@ fn abc()
 fn def()
     def - should be first
 fn xyz()
-    xyz - should be in the middle
+    xyz - should be in the middle a small script <script>console.log('hello');</script> bold text <b>bold</b> end underlined text <u>underline</u> end a link [main v repo](https://github.com/vlang/v)
 fn MyXMLDocument.abc(text string) ?(string, int)
     MyXMLDocument.abc does something too... I just do not know what.
 fn MyXMLDocument.from_file(path string) !MyXMLDocument

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.text
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.text
@@ -6,6 +6,10 @@ module main
     
     This is a [link](https://vlang.io/) to the main V site.
     
+    This is a <b>bold text</b>.
+    
+    This is a script <script>console.log('hi from README.md');</script> .
+    
     ## Examples:
     
     ### Processing command line args:

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.v
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.v
@@ -10,6 +10,10 @@ pub fn def() {
 }
 
 // xyz - should be in the middle
+// a small script <script>console.log('hello');</script>
+// bold text <b>bold</b> end
+// underlined text <u>underline</u> end
+// a link [main v repo](https://github.com/vlang/v)
 pub fn xyz() {
 	println(2)
 }


### PR DESCRIPTION
This PR improves upon the work done in PR #19731 by using `markdown.default_html_transformer` before highlighting the code with `html_highlight`. 

The said HTML transformer uses `encoding/html`'s [encode](https://modules.vlang.io/encoding.html.html#escape) function underneath so it makes sense to just use this over the regex-based `html_tag_escape` function. It also removes the wrapping of comments with `html_tag_escape` to avoid "over-escaping" and let the Markdown HTML renderer do it's own thing.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ec61f7</samp>

Refactored the HTML generation and escaping logic in `vdoc` tool. Removed unused and redundant code and tests.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ec61f7</samp>

*  Remove unused `regex` module import ([link](https://github.com/vlang/v/pull/19785/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L7))
*  Delete redundant `html_tag_escape` function and related variables ([link](https://github.com/vlang/v/pull/19785/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L23-L25), [link](https://github.com/vlang/v/pull/19785/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L461-L469))
*  Replace `html_tag_escape` function calls with original strings, as escaping is done by `markdown.default_html_transformer` ([link](https://github.com/vlang/v/pull/19785/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L395-R391))
*  Use `markdown.default_html_transformer` to escape HTML tags in `transform_content` method before highlighting V code ([link](https://github.com/vlang/v/pull/19785/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L535-R529))
*  Delete `html_tag_escape_test.v` file as it is no longer relevant ([link](https://github.com/vlang/v/pull/19785/files?diff=unified&w=0#diff-849d255b72543e64cebf7df17cd2de1a827acb0da04b84c349aeeca8a05bf4eb))
