### PR TITLE
checker: fix wrong ref field uninitialized

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -727,14 +727,16 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 						node.pos)
 					continue
 				}
-				if sym.kind == .struct_ {
-					c.check_ref_fields_initialized(sym, mut checked_types, '${type_sym.name}.${field.name}',
-						node)
-				} else if sym.kind == .alias {
-					parent_sym := c.table.sym((sym.info as ast.Alias).parent_type)
-					if parent_sym.kind == .struct_ {
-						c.check_ref_fields_initialized(parent_sym, mut checked_types,
-							'${type_sym.name}.${field.name}', node)
+				if !field.typ.has_flag(.option) {
+					if sym.kind == .struct_ {
+						c.check_ref_fields_initialized(sym, mut checked_types, '${type_sym.name}.${field.name}',
+							node)
+					} else if sym.kind == .alias {
+						parent_sym := c.table.sym((sym.info as ast.Alias).parent_type)
+						if parent_sym.kind == .struct_ {
+							c.check_ref_fields_initialized(parent_sym, mut checked_types,
+								'${type_sym.name}.${field.name}', node)
+						}
 					}
 				}
 				// Do not allow empty uninitialized interfaces

--- a/vlib/v/checker/tests/option_ref_init_err.out
+++ b/vlib/v/checker/tests/option_ref_init_err.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/option_ref_init_err.vv:9:18: warning: unnecessary default value of `none`: struct fields are zeroed by default
+    7 | mut:
+    8 |     a0 ?&Viewport 
+    9 |     a1 ?&Viewport = none
+      |                     ~~~~
+   10 |     a2 ?&Viewport = none
+   11 |     a3 ?&Viewport = unsafe { nil }
+vlib/v/checker/tests/option_ref_init_err.vv:10:18: warning: unnecessary default value of `none`: struct fields are zeroed by default
+    8 |     a0 ?&Viewport 
+    9 |     a1 ?&Viewport = none
+   10 |     a2 ?&Viewport = none
+      |                     ~~~~
+   11 |     a3 ?&Viewport = unsafe { nil }
+   12 |     a4 ?&Viewport = nil
+vlib/v/checker/tests/option_ref_init_err.vv:12:18: error: `nil` is only allowed in `unsafe` code
+   10 |     a2 ?&Viewport = none
+   11 |     a3 ?&Viewport = unsafe { nil }
+   12 |     a4 ?&Viewport = nil
+      |                     ~~~
+   13 | }
+   14 |

--- a/vlib/v/checker/tests/option_ref_init_err.vv
+++ b/vlib/v/checker/tests/option_ref_init_err.vv
@@ -1,0 +1,17 @@
+struct Viewport {
+mut:
+	parent &Window
+}
+
+pub struct Window {
+mut:
+	a0 ?&Viewport 
+	a1 ?&Viewport = none
+	a2 ?&Viewport = none
+	a3 ?&Viewport = unsafe { nil }
+	a4 ?&Viewport = nil
+}
+
+fn main() {
+	_ := &Window{}
+}


### PR DESCRIPTION
Fix #19559

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a78776</samp>

Fix struct initialization bug with optional fields. Skip checking ref fields for option types in `vlib/v/checker/struct.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a78776</samp>

* Fix a bug related to struct initialization with optional fields ([link](https://github.com/vlang/v/pull/19786/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L730-R739))
