### PR TITLE
tools: cleanup and simplify vcreate for upcoming fixes and features

### DIFF
--- a/cmd/tools/vcreate/project_model_bin.v
+++ b/cmd/tools/vcreate/project_model_bin.v
@@ -1,8 +1,8 @@
 module main
 
-fn (mut c Create) set_bin_project_files(new bool) {
+fn (mut c Create) set_bin_project_files() {
 	c.files << ProjectFiles{
-		path: if new { '${c.name}/src/main.v' } else { 'src/main.v' }
+		path: if c.new_dir { '${c.name}/src/main.v' } else { 'src/main.v' }
 		content: "module main
 
 fn main() {

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -52,7 +52,7 @@ fn main() {
 			new_project(os.args[2..])
 		}
 		'init' {
-			init_project()
+			init_project(os.args[2..])
 		}
 		else {
 			cerror('unknown command: ${cmd}')
@@ -65,25 +65,7 @@ fn main() {
 fn new_project(args []string) {
 	mut c := Create{}
 	c.new_dir = true
-
-	c.name = check_name(if args.len > 0 { args[0] } else { os.input('Input your project name: ') })
-
-	if c.name == '' {
-		cerror('project name cannot be empty')
-		exit(1)
-	}
-
-	if c.name.contains('-') {
-		cerror('"${c.name}" should not contain hyphens')
-		exit(1)
-	}
-
-	if os.is_dir(c.name) {
-		cerror('${c.name} folder already exists')
-		exit(3)
-	}
-
-	c.prompt()
+	c.prompt(args)
 
 	println('Initialising ...')
 	if args.len == 2 {
@@ -117,13 +99,13 @@ fn new_project(args []string) {
 	c.create_git_repo(c.name)
 }
 
-fn init_project() {
+fn init_project(args []string) {
 	mut c := Create{}
 	dir_name := check_name(os.file_name(os.getwd()))
 	if !os.exists('v.mod') {
 		mod_dir_has_hyphens := dir_name.contains('-')
 		c.name = if mod_dir_has_hyphens { dir_name.replace('-', '_') } else { dir_name }
-		c.prompt()
+		c.prompt(args)
 		c.write_vmod()
 		if mod_dir_has_hyphens {
 			println('The directory name `${dir_name}` is invalid as a module name. The module name in `v.mod` was set to `${c.name}`')
@@ -138,7 +120,22 @@ fn init_project() {
 	c.create_git_repo('.')
 }
 
-fn (mut c Create) prompt() {
+fn (mut c Create) prompt(args []string) {
+	if c.name == '' {
+		c.name = check_name(args[0] or { os.input('Input your project name: ') })
+		if c.name == '' {
+			cerror('project name cannot be empty')
+			exit(1)
+		}
+		if c.name.contains('-') {
+			cerror('"${c.name}" should not contain hyphens')
+			exit(1)
+		}
+		if os.is_dir(c.name) {
+			cerror('${c.name} folder already exists')
+			exit(3)
+		}
+	}
 	c.description = os.input('Input your project description: ')
 	default_version := '0.0.0'
 	c.version = os.input('Input your project version: (${default_version}) ')

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -23,6 +23,7 @@ mut:
 	version     string
 	license     string
 	files       []ProjectFiles
+	new_dir     bool
 }
 
 struct ProjectFiles {
@@ -63,6 +64,7 @@ fn main() {
 
 fn new_project(args []string) {
 	mut c := Create{}
+	c.new_dir = true
 
 	c.name = check_name(if args.len > 0 { args[0] } else { os.input('Input your project name: ') })
 
@@ -88,7 +90,7 @@ fn new_project(args []string) {
 		// E.g.: `v new my_project lib`
 		match os.args.last() {
 			'bin' {
-				c.set_bin_project_files(true)
+				c.set_bin_project_files()
 			}
 			'lib' {
 				c.set_lib_project_files()
@@ -103,15 +105,15 @@ fn new_project(args []string) {
 		}
 	} else {
 		// E.g.: `v new my_project`
-		c.set_bin_project_files(true)
+		c.set_bin_project_files()
 	}
 
 	// gen project based in the `Create.files` info
 	c.create_files_and_directories()
 
-	c.write_vmod(true)
-	c.write_gitattributes(true)
-	c.write_editorconfig(true)
+	c.write_vmod()
+	c.write_gitattributes()
+	c.write_editorconfig()
 	c.create_git_repo(c.name)
 }
 
@@ -122,17 +124,17 @@ fn init_project() {
 		mod_dir_has_hyphens := dir_name.contains('-')
 		c.name = if mod_dir_has_hyphens { dir_name.replace('-', '_') } else { dir_name }
 		c.prompt()
-		c.write_vmod(false)
+		c.write_vmod()
 		if mod_dir_has_hyphens {
 			println('The directory name `${dir_name}` is invalid as a module name. The module name in `v.mod` was set to `${c.name}`')
 		}
 	}
 	if !os.exists('src/main.v') {
-		c.set_bin_project_files(false)
+		c.set_bin_project_files()
 	}
 	c.create_files_and_directories()
-	c.write_gitattributes(false)
-	c.write_editorconfig(false)
+	c.write_gitattributes()
+	c.write_editorconfig()
 	c.create_git_repo('.')
 }
 
@@ -237,22 +239,22 @@ indent_style = tab
 '
 }
 
-fn (c &Create) write_vmod(new bool) {
-	vmod_path := if new { '${c.name}/v.mod' } else { 'v.mod' }
+fn (c &Create) write_vmod() {
+	vmod_path := if c.new_dir { '${c.name}/v.mod' } else { 'v.mod' }
 	os.write_file(vmod_path, vmod_content(c)) or { panic(err) }
 }
 
-fn (c &Create) write_gitattributes(new bool) {
-	gitattributes_path := if new { '${c.name}/.gitattributes' } else { '.gitattributes' }
-	if !new && os.exists(gitattributes_path) {
+fn (c &Create) write_gitattributes() {
+	gitattributes_path := if c.new_dir { '${c.name}/.gitattributes' } else { '.gitattributes' }
+	if !c.new_dir && os.exists(gitattributes_path) {
 		return
 	}
 	os.write_file(gitattributes_path, gitattributes_content()) or { panic(err) }
 }
 
-fn (c &Create) write_editorconfig(new bool) {
-	editorconfig_path := if new { '${c.name}/.editorconfig' } else { '.editorconfig' }
-	if !new && os.exists(editorconfig_path) {
+fn (c &Create) write_editorconfig() {
+	editorconfig_path := if c.new_dir { '${c.name}/.editorconfig' } else { '.editorconfig' }
+	if !c.new_dir && os.exists(editorconfig_path) {
 		return
 	}
 	os.write_file(editorconfig_path, editorconfig_content()) or { panic(err) }


### PR DESCRIPTION
This PR should clean up vcreate and prepare it to fix issues and extend it as described here: https://github.com/vlang/v/pull/19619#issuecomment-1778320090.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e20b8c0</samp>

This pull request improves the `vcreate` tool by simplifying the code, allowing the user to specify the project name, and writing the project files directly to the disk. It also refactors the `project_model_bin.v` file to use a more consistent function signature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e20b8c0</samp>

*  Simplify and refactor the project creation logic for binary projects
  * Add a `new_dir` field to the `Create` struct to store whether the project is created in a new directory or not ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eR26))
  * Use the `new_dir` field instead of a `new` parameter in the `set_bin_project_files` function and other functions that write project files ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-04e0bd4b8647bb6e9f4e48476b1f9f992abd017105833bd850c11cedac5a0011L3-R5), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL178-R179), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL187-R195), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL226-R211), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL270-R261))
  * Move the `write_vmod`, `write_gitattributes`, and `write_editorconfig` functions from `vcreate.v` to `project_model_bin.v` and write the file contents directly instead of returning strings ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL238-R222), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-04e0bd4b8647bb6e9f4e48476b1f9f992abd017105833bd850c11cedac5a0011L3-R5))
  * Refactor the `new_project` function to remove the redundant code for checking the project name and directory, and delegate the prompting logic to the `prompt` function ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL66-R69))
  * Modify the `prompt` function to accept an `args` parameter, which is a slice of strings containing the command-line arguments for the project initialization, and use it to assign or validate the project name ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL131-R138), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL124-R109))
  * Modify the `init_project` function to accept an `args` parameter and pass it to the `prompt` function ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL54-R55), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL112-R102))
  * Update the function calls to remove the `new` argument or pass the `args` parameter as needed ([link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL91-R75), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL106-R90), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL112-R102), [link](https://github.com/vlang/v/pull/19794/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL124-R109))
