### PR TITLE
fmt: don't add line breaks after call_expr before params struct args

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1992,6 +1992,7 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 		}
 		if i == args.len - 1 && arg.expr is ast.StructInit {
 			if arg.expr.typ == ast.void_type {
+				f.single_line_fields = true
 				f.use_short_fn_args = true
 			}
 		}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1976,11 +1976,12 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 }
 
 pub fn (mut f Fmt) call_args(args []ast.CallArg) {
-	f.single_line_fields = true
+	old_single_line_fields_state := f.single_line_fields
 	old_short_arg_state := f.use_short_fn_args
+	f.single_line_fields = true
 	f.use_short_fn_args = false
 	defer {
-		f.single_line_fields = false
+		f.single_line_fields = old_single_line_fields_state
 		f.use_short_fn_args = old_short_arg_state
 	}
 	for i, arg in args {
@@ -1992,7 +1993,6 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 		}
 		if i == args.len - 1 && arg.expr is ast.StructInit {
 			if arg.expr.typ == ast.void_type {
-				f.single_line_fields = true
 				f.use_short_fn_args = true
 			}
 		}

--- a/vlib/v/fmt/tests/fn_call_with_call_expr_and_params_struct_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_call_with_call_expr_and_params_struct_args_keep.vv
@@ -1,0 +1,10 @@
+[params]
+struct Bar {
+	bar bool
+}
+
+fn foo(msg string, opts Bar) {
+	println(msg)
+}
+
+foo(123.str(), bar: true)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9db72b</samp>

Fix formatting issues with call expressions and params attributes in struct fields. Add a new test file to verify the correct formatting of function calls with call expressions and params struct arguments.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9db72b</samp>

*  Set `single_line_fields` flag to true in `fmt` module to fix formatting bug for struct fields with call expressions and params attributes ([link](https://github.com/vlang/v/pull/19795/files?diff=unified&w=0#diff-d0537f29a228ae27067d917150e3d42f8d45250dbdce1adfccf442c36ba7244eR1995))
*  Add test file `fn_call_with_call_expr_and_params_struct_args_keep.vv` to verify correct formatting of function calls with call expression and params struct argument ([link](https://github.com/vlang/v/pull/19795/files?diff=unified&w=0#diff-954b1b306f6b7b10df7a49ee0a1edcb02bae057a59a5e9c552665688bac1d0eeR1-R10))
