### PR TITLE
cgen: fix closure variable in smartcast (fix #19616)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1777,7 +1777,11 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 								cast_sym := g.table.sym(g.unwrap_generic(typ))
 								mut is_ptr := false
 								if i == 0 {
-									g.write(node.name)
+									if obj.is_inherited {
+										g.write(c.closure_ctx + '->' + node.name)
+									} else {
+										g.write(node.name)
+									}
 									if obj.orig_type.is_ptr() {
 										is_ptr = true
 									}

--- a/vlib/v/tests/closure_variable_in_smartcast_test.v
+++ b/vlib/v/tests/closure_variable_in_smartcast_test.v
@@ -1,0 +1,25 @@
+pub type MyCallback = fn () | fn (ctx voidptr)
+
+fn my_lower_level_func(func fn (ctx voidptr), ctx voidptr) {
+	println('Bar')
+}
+
+fn my_func(cb MyCallback, ctx voidptr) {
+	my_lower_level_func(fn [cb] (ctx voidptr) {
+		match cb {
+			fn () {
+				cb()
+			}
+			fn (ctx voidptr) {
+				cb(ctx)
+			}
+		}
+	}, ctx)
+}
+
+fn test_closure_variable_in_smartcast() {
+	my_func(fn () {
+		println('Foo')
+	}, unsafe { nil })
+	assert true
+}


### PR DESCRIPTION
This PR fix closure variable in smartcast (fix #19616).

- Fix closure variable in smartcast.
- Add test.

```v
pub type MyCallback = fn () | fn (ctx voidptr)

fn my_lower_level_func(func fn (ctx voidptr), ctx voidptr) {
	println('Bar')
}

fn my_func(cb MyCallback, ctx voidptr) {
	my_lower_level_func(fn [cb] (ctx voidptr) {
		match cb {
			fn () {
				cb()
			}
			fn (ctx voidptr) {
				cb(ctx)
			}
		}
	}, ctx)
}

fn main() {
	my_func(fn () {
		println('Foo')
	}, unsafe { nil })
	assert true
}

PS D:\Test\v\tt1> v run .    
Bar
```