### PR TITLE
tools: fix typo in vbuild-tools.v

### DIFF
--- a/cmd/tools/vbuild-tools.v
+++ b/cmd/tools/vbuild-tools.v
@@ -15,7 +15,7 @@ const tools_in_subfolders = ['vast', 'vcreate', 'vdoc', 'vpm', 'vvet', 'vwhere']
 
 // non_packaged_tools are tools that should not be packaged with
 // prebuild versions of V, to keep the size smaller.
-// They are mainly usefull for the V project itself, not to end users.
+// They are mainly useful for the V project itself, not to end users.
 const non_packaged_tools = ['gen1m', 'gen_vc', 'fast', 'wyhash']
 
 fn main() {


### PR DESCRIPTION
usefull -> useful



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38d1af7</samp>

Fix a typo in a comment in `cmd/tools/vbuild-tools.v`. The comment describes a constant that controls which tools are packaged with V.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38d1af7</samp>

* Fix a typo in the comment for `non_packaged_tools` ([link](https://github.com/vlang/v/pull/19797/files?diff=unified&w=0#diff-eea3b1e2fe7a722b3844faf13b4a011ced56ef70a04d46931ffaeb776f5bac38L18-R18))
