### PR TITLE
cgen: fix shared variable assign generic structs(fix #19798)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -570,11 +570,18 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							if val_sym.info.generic_types.len > 0 {
 								if val is ast.StructInit {
 									var_styp := g.typ(val.typ)
-									g.write('${var_styp} ')
+									if var_type.has_flag(.shared_f) {
+										g.write('__shared__${var_styp}* ')
+									} else {
+										g.write('${var_styp} ')
+									}
 									is_used_var_styp = true
 								} else if val is ast.PrefixExpr {
 									if val.op == .amp && val.right is ast.StructInit {
 										var_styp := g.typ(val.right.typ.ref())
+										if var_type.has_flag(.shared_f) {
+											g.write('__shared__')
+										}
 										g.write('${var_styp} ')
 										is_used_var_styp = true
 									}

--- a/vlib/v/tests/shared_generic_test.v
+++ b/vlib/v/tests/shared_generic_test.v
@@ -1,0 +1,14 @@
+struct Foo[T] {
+	a T
+}
+
+fn test_shared_struct_has_generics() {
+	shared foo := Foo[int]{1}
+	lock foo {
+		assert foo.a == 1
+	}
+	shared bar := &Foo[int]{1}
+	lock bar {
+		assert bar.a == 1
+	}
+}


### PR DESCRIPTION
1. Fixed #19798
2. Add tests.

```v
import datatypes

shared test := datatypes.Queue[int]{}
lock test {
	println(test)
}
```

outputs:

```
[]
```