### PR TITLE
tools: fix `v build-tools`, make `v test` more robust

### DIFF
--- a/cmd/tools/vbuild-tools.v
+++ b/cmd/tools/vbuild-tools.v
@@ -36,6 +36,7 @@ fn main() {
 	buildopts := args_string.all_before('build-tools')
 	mut session := testing.prepare_test_session(buildopts, folder, skips, main_label)
 	session.rm_binaries = false
+	session.build_tools = true
 	for stool in tools_in_subfolders {
 		session.add(os.join_path(tfolder, stool))
 	}


### PR DESCRIPTION
- tests: ensure that each _test.v file runs in its own unique folder, to prevent naming conflicts as much as possible
- tools: fix `v build-tools` (move all tools back inside cmd/tools, to make packaging V easier)
