### PR TITLE
parser: fix shared generic struct as fn parameters(fix #19804)

### DIFF
--- a/vlib/v/checker/tests/option_ref_init_err.out
+++ b/vlib/v/checker/tests/option_ref_init_err.out
@@ -1,18 +1,32 @@
 vlib/v/checker/tests/option_ref_init_err.vv:9:18: warning: unnecessary default value of `none`: struct fields are zeroed by default
     7 | mut:
-    8 |     a0 ?&Viewport 
+    8 |     a0 ?&Viewport
     9 |     a1 ?&Viewport = none
       |                     ~~~~
    10 |     a2 ?&Viewport = none
    11 |     a3 ?&Viewport = unsafe { nil }
 vlib/v/checker/tests/option_ref_init_err.vv:10:18: warning: unnecessary default value of `none`: struct fields are zeroed by default
-    8 |     a0 ?&Viewport 
+    8 |     a0 ?&Viewport
     9 |     a1 ?&Viewport = none
    10 |     a2 ?&Viewport = none
       |                     ~~~~
    11 |     a3 ?&Viewport = unsafe { nil }
    12 |     a4 ?&Viewport = nil
 vlib/v/checker/tests/option_ref_init_err.vv:12:18: error: `nil` is only allowed in `unsafe` code
+   10 |     a2 ?&Viewport = none
+   11 |     a3 ?&Viewport = unsafe { nil }
+   12 |     a4 ?&Viewport = nil
+      |                     ~~~
+   13 | }
+   14 |
+vlib/v/checker/tests/option_ref_init_err.vv:11:18: error: cannot assign `nil` to option value
+    9 |     a1 ?&Viewport = none
+   10 |     a2 ?&Viewport = none
+   11 |     a3 ?&Viewport = unsafe { nil }
+      |                     ~~~~~~
+   12 |     a4 ?&Viewport = nil
+   13 | }
+vlib/v/checker/tests/option_ref_init_err.vv:12:18: error: cannot assign `nil` to option value
    10 |     a2 ?&Viewport = none
    11 |     a3 ?&Viewport = unsafe { nil }
    12 |     a4 ?&Viewport = nil

--- a/vlib/v/checker/tests/option_ref_init_err.vv
+++ b/vlib/v/checker/tests/option_ref_init_err.vv
@@ -5,7 +5,7 @@ mut:
 
 pub struct Window {
 mut:
-	a0 ?&Viewport 
+	a0 ?&Viewport
 	a1 ?&Viewport = none
 	a2 ?&Viewport = none
 	a3 ?&Viewport = unsafe { nil }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1198,8 +1198,12 @@ fn (mut p Parser) check_fn_mutable_arguments(typ ast.Type, pos token.Pos) {
 }
 
 fn (mut p Parser) check_fn_shared_arguments(typ ast.Type, pos token.Pos) {
-	sym := p.table.sym(typ)
+	mut sym := p.table.sym(typ)
+	if sym.kind == .generic_inst {
+		sym = p.table.type_symbols[(sym.info as ast.GenericInst).parent_idx]
+	}
 	if sym.kind !in [.array, .struct_, .map, .placeholder] && !typ.is_ptr() {
+		println(sym.info)
 		p.error_with_pos('shared arguments are only allowed for arrays, maps, and structs\n',
 			pos)
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1203,7 +1203,6 @@ fn (mut p Parser) check_fn_shared_arguments(typ ast.Type, pos token.Pos) {
 		sym = p.table.type_symbols[(sym.info as ast.GenericInst).parent_idx]
 	}
 	if sym.kind !in [.array, .struct_, .map, .placeholder] && !typ.is_ptr() {
-		println(sym.info)
 		p.error_with_pos('shared arguments are only allowed for arrays, maps, and structs\n',
 			pos)
 	}

--- a/vlib/v/tests/shared_generic_test.v
+++ b/vlib/v/tests/shared_generic_test.v
@@ -12,3 +12,14 @@ fn test_shared_struct_has_generics() {
 		assert bar.a == 1
 	}
 }
+
+fn generic_struct_as_parameters(shared arg Foo[int]) {
+	rlock arg {
+		assert arg.a == 1
+	}
+}
+
+fn test_generic_struct_as_parameters() {
+	shared foo := Foo[int]{1}
+	generic_struct_as_parameters(shared foo)
+}


### PR DESCRIPTION
1. Fixed #19804 
2. Add tests.

```v
struct Test[T] {
	value T
}

fn do_something(shared stuff Test[int]) {
	rlock stuff {
		println(stuff.value)
	}
}

shared test := Test[int]{}

do_something(shared test)
```

outputs:

```
0
```