### PR TITLE
checker, cgen: fix match branches return type ref mismatch, when return type exists interface or sumtype(fix #16203)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3564,9 +3564,7 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 							typ = c.expr(mut obj.expr)
 						}
 					}
-					if c.inside_casting_to_str && obj.orig_type != 0
-						&& c.table.sym(obj.orig_type).kind == .interface_
-						&& c.table.sym(obj.smartcasts.last()).kind != .interface_ {
+					if c.inside_casting_to_str && c.is_interface_var(obj) {
 						typ = typ.deref()
 					}
 					is_option := typ.has_flag(.option) || typ.has_flag(.result)
@@ -4026,6 +4024,12 @@ fn (c &Checker) has_return(stmts []ast.Stmt) ?bool {
 pub fn (mut c Checker) is_comptime_var(node ast.Expr) bool {
 	return node is ast.Ident && node.info is ast.IdentVar && node.kind == .variable
 		&& (node.obj as ast.Var).ct_type_var != .no_comptime
+}
+
+[inline]
+fn (mut c Checker) is_interface_var(var ast.ScopeObject) bool {
+	return var is ast.Var && var.orig_type != 0 && c.table.sym(var.orig_type).kind == .interface_
+		&& c.table.sym(var.smartcasts.last()).kind != .interface_
 }
 
 fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) {

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.out
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.out
@@ -5,3 +5,31 @@ vlib/v/checker/tests/match_return_mismatch_type_err.vv:4:10: error: return type 
       |                ~~
     5 |     }
     6 |     println(a)
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:18:10: error: return type mismatch, it should be `&string`
+   16 |     _ = match any {
+   17 |         string { &any }
+   18 |         else { variable }
+      |                ~~~~~~~~
+   19 |     }
+   20 |
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:23:10: error: return type mismatch, it should be `string`
+   21 |     _ = match any {
+   22 |         string { any }
+   23 |         else { &variable }
+      |                ^
+   24 |     }
+   25 | }
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:36:10: error: return type mismatch, it should be `&string`
+   34 |     _ = match any {
+   35 |         string { &any }
+   36 |         else { variable }
+      |                ~~~~~~~~
+   37 |     }
+   38 |
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:41:10: error: return type mismatch, it should be `string`
+   39 |     _ = match any {
+   40 |         string { any }
+   41 |         else { &variable }
+      |                ^
+   42 |     }
+   43 | }

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.out
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:27:6: warning: cannot assign a reference to a value (this will be an error soon) left=string false right=string true ptr=true
+   25 | 
+   26 |     mut res := ''
+   27 |     res = match any {
+      |         ^
+   28 |         string { &any }
+   29 |         else { &variable }
 vlib/v/checker/tests/match_return_mismatch_type_err.vv:4:10: error: return type mismatch, it should be `string`
     2 |     a := match 1 {
     3 |         1 { 'aa' }
@@ -18,18 +25,18 @@ vlib/v/checker/tests/match_return_mismatch_type_err.vv:23:10: error: return type
    23 |         else { &variable }
       |                ^
    24 |     }
-   25 | }
-vlib/v/checker/tests/match_return_mismatch_type_err.vv:36:10: error: return type mismatch, it should be `&string`
-   34 |     _ = match any {
-   35 |         string { &any }
-   36 |         else { variable }
+   25 |
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:43:10: error: return type mismatch, it should be `&string`
+   41 |     _ = match any {
+   42 |         string { &any }
+   43 |         else { variable }
       |                ~~~~~~~~
-   37 |     }
-   38 |
-vlib/v/checker/tests/match_return_mismatch_type_err.vv:41:10: error: return type mismatch, it should be `string`
-   39 |     _ = match any {
-   40 |         string { any }
-   41 |         else { &variable }
+   44 |     }
+   45 |
+vlib/v/checker/tests/match_return_mismatch_type_err.vv:48:10: error: return type mismatch, it should be `string`
+   46 |     _ = match any {
+   47 |         string { any }
+   48 |         else { &variable }
       |                ^
-   42 |     }
-   43 | }
+   49 |     }
+   50 | }

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.vv
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.vv
@@ -5,3 +5,39 @@ fn main() {
 	}
 	println(a)
 }
+
+// for test the returns both interface or non-interface
+interface IAny {}
+
+fn returns_both_interface_and_non_interface() {
+	any := IAny('abc')
+	variable := ''
+
+	_ = match any {
+		string { &any }
+		else { variable }
+	}
+
+	_ = match any {
+		string { any }
+		else { &variable }
+	}
+}
+
+// for test the returns both sumtype or non-sumtype
+type SAny = int | string
+
+fn returns_both_sumtype_and_non_sumtype() {
+	any := SAny('abc')
+	variable := ''
+
+	_ = match any {
+		string { &any }
+		else { variable }
+	}
+
+	_ = match any {
+		string { any }
+		else { &variable }
+	}
+}

--- a/vlib/v/checker/tests/match_return_mismatch_type_err.vv
+++ b/vlib/v/checker/tests/match_return_mismatch_type_err.vv
@@ -22,6 +22,13 @@ fn returns_both_interface_and_non_interface() {
 		string { any }
 		else { &variable }
 	}
+
+	mut res := ''
+	res = match any {
+		string { &any }
+		else { &variable }
+	}
+	println(res)
 }
 
 // for test the returns both sumtype or non-sumtype

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4349,6 +4349,12 @@ fn (mut g Gen) get_const_name(node ast.Ident) string {
 	}
 }
 
+[inline]
+fn (mut g Gen) is_interface_var(var ast.ScopeObject) bool {
+	return var is ast.Var && var.orig_type != 0 && g.table.sym(var.orig_type).kind == .interface_
+		&& g.table.sym(var.smartcasts.last()).kind != .interface_
+}
+
 fn (mut g Gen) ident(node ast.Ident) {
 	prevent_sum_type_unwrapping_once := g.prevent_sum_type_unwrapping_once
 	g.prevent_sum_type_unwrapping_once = false
@@ -4485,9 +4491,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 						g.write('(')
 						if obj_sym.kind == .sum_type && !is_auto_heap {
 							g.write('*')
-						} else if g.inside_casting_to_str && node.obj.orig_type != 0
-							&& g.table.sym(node.obj.orig_type).kind == .interface_
-							&& g.table.sym(node.obj.smartcasts.last()).kind != .interface_ {
+						} else if g.inside_casting_to_str && g.is_interface_var(node.obj) {
 							g.write('*')
 						}
 					}

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -237,6 +237,11 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 					if mut stmt.expr is ast.Ident && stmt.expr.obj is ast.Var
 						&& g.is_interface_var(stmt.expr.obj) {
 						g.inside_casting_to_str = true
+					} else if mut stmt.expr is ast.PrefixExpr && stmt.expr.right is ast.Ident {
+						ident := stmt.expr.right as ast.Ident
+						if ident.obj is ast.Var && g.is_interface_var(ident.obj) {
+							g.inside_casting_to_str = true
+						}
 					}
 				}
 			}

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -230,7 +230,18 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 			if is_expr && tmp_var.len > 0 && g.table.sym(node.return_type).kind == .sum_type {
 				g.expected_cast_type = node.return_type
 			}
+			inside_casting_to_str_old := g.inside_casting_to_str
+			if is_expr && branch.stmts.len > 0 {
+				mut stmt := branch.stmts.last()
+				if mut stmt is ast.ExprStmt {
+					if mut stmt.expr is ast.Ident && stmt.expr.obj is ast.Var
+						&& g.is_interface_var(stmt.expr.obj) {
+						g.inside_casting_to_str = true
+					}
+				}
+			}
 			g.stmts_with_tmp_var(branch.stmts, tmp_var)
+			g.inside_casting_to_str = inside_casting_to_str_old
 			g.expected_cast_type = 0
 			if g.inside_ternary == 0 {
 				g.writeln('}')

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -301,3 +301,23 @@ fn test_noreturn() {
 		}
 	}
 }
+
+// for test the returns both interface and non-interface
+interface Any {}
+
+fn test_returns_both_interface_and_non_interface() {
+	any := Any('abc')
+
+	mut res := match any {
+		string { any }
+		else { 'literal' }
+	}
+	assert res == 'abc'
+
+	variable := ''
+	res = match any {
+		string { any }
+		else { variable }
+	}
+	assert res == 'abc'
+}


### PR DESCRIPTION
1. Fixed #16203
2. Add tests.

Because smartcast adds one level of ref to the interface type, special handling is required in the return type of the match expr branch.




```v
interface Any {}

fn (any Any) echo() {
	r := match any {
		string { any }
		else { 'unsupported' }
	}
	println(r)
}

Any('hallo').echo()
```

outputs:

```
hallo
```