### PR TITLE
tools.vpm: add installs from git version tags

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -1,199 +1,14 @@
 module main
 
-import json
 import os
-import v.vmod
-import sync.pool
 import net.http
-import net.urllib
 import term
 import log
-
-struct ModuleVpmInfo {
-	// id           int
-	name         string
-	url          string
-	nr_downloads int
-	vcs          string
-}
-
-pub struct ModDateInfo {
-	name string
-mut:
-	outdated bool
-	exec_err bool
-}
 
 [params]
 struct ErrorOptions {
 	details string
 	verbose bool // is used to only output the error message if the verbose setting is enabled.
-}
-
-fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModDateInfo {
-	mut result := &ModDateInfo{
-		name: pp.get_item[string](idx)
-	}
-	final_module_path := valid_final_path_of_existing_module(result.name) or { return result }
-	vcs := vcs_used_in_dir(final_module_path) or { return result }
-	is_hg := vcs.cmd == 'hg'
-	mut outputs := []string{}
-	for step in vcs.args.outdated {
-		cmd := '${vcs.cmd} ${vcs.args.path} "${final_module_path}" ${step}'
-		res := os.execute(cmd)
-		if res.exit_code < 0 {
-			verbose_println('Error command: ${cmd}')
-			verbose_println('Error details:\n${res.output}')
-			result.exec_err = true
-			return result
-		}
-		if is_hg && res.exit_code == 1 {
-			result.outdated = true
-			return result
-		}
-		outputs << res.output
-	}
-	// vcs.cmd == 'git'
-	if !is_hg && outputs[1] != outputs[2] {
-		result.outdated = true
-	}
-	return result
-}
-
-fn get_mod_vpm_info(name string) !ModuleVpmInfo {
-	if name.len < 2 || (!name[0].is_digit() && !name[0].is_letter()) {
-		return error('invalid module name `${name}`.')
-	}
-	mut errors := []string{}
-	for server_url in vpm_server_urls {
-		modurl := server_url + '/api/packages/${name}'
-		verbose_println('Retrieving module metadata from `${modurl}` ...')
-		r := http.get(modurl) or {
-			errors << 'Http server did not respond to our request for `${modurl}`.'
-			errors << 'Error details: ${err}'
-			continue
-		}
-		if r.status_code == 404 || r.body.trim_space() == '404' {
-			errors << 'Skipping module `${name}`, since `${server_url}` reported that `${name}` does not exist.'
-			continue
-		}
-		if r.status_code != 200 {
-			errors << 'Skipping module `${name}`, since `${server_url}` responded with ${r.status_code} http status code. Please try again later.'
-			continue
-		}
-		s := r.body
-		if s.len > 0 && s[0] != `{` {
-			errors << 'Invalid json data'
-			errors << s.trim_space().limit(100) + ' ...'
-			continue
-		}
-		mod := json.decode(ModuleVpmInfo, s) or {
-			errors << 'Skipping module `${name}`, since its information is not in json format.'
-			continue
-		}
-		if '' == mod.url || '' == mod.name {
-			errors << 'Skipping module `${name}`, since it is missing name or url information.'
-			continue
-		}
-		vpm_log(@FILE_LINE, @FN, 'name: ${name}; mod: ${mod}')
-		return mod
-	}
-	return error(errors.join_lines())
-}
-
-fn get_name_from_url(raw_url string) !string {
-	url := urllib.parse(raw_url) or { return error('failed to parse module URL `${raw_url}`.') }
-	owner, mut name := url.path.trim_left('/').rsplit_once('/') or {
-		return error('failed to retrieve module name for `${url}`.')
-	}
-	vpm_log(@FILE_LINE, @FN, 'raw_url: ${raw_url}; owner: ${owner}; name: ${name}')
-	name = if name.ends_with('.git') { name.replace('.git', '') } else { name }.to_lower()
-	return name
-}
-
-fn get_outdated() ![]string {
-	module_names := get_installed_modules()
-	mut outdated := []string{}
-	mut pp := pool.new_pool_processor(callback: get_mod_date_info)
-	pp.work_on_items(module_names)
-	for res in pp.get_results[ModDateInfo]() {
-		if res.exec_err {
-			return error('failed to check the latest commits for `${res.name}`.')
-		}
-		if res.outdated {
-			outdated << res.name
-		}
-	}
-	return outdated
-}
-
-fn get_all_modules() []string {
-	url := get_working_server_url()
-	r := http.get(url) or {
-		vpm_error(err.msg(),
-			verbose: true
-		)
-		exit(1)
-	}
-	if r.status_code != 200 {
-		vpm_error('failed to search vpm.vlang.io.', details: 'Status code: ${r.status_code}')
-		exit(1)
-	}
-	s := r.body
-	mut read_len := 0
-	mut modules := []string{}
-	for read_len < s.len {
-		mut start_token := "<a href='/mod"
-		end_token := '</a>'
-		// get the start index of the module entry
-		mut start_index := s.index_after(start_token, read_len)
-		if start_index == -1 {
-			start_token = '<a href="/mod'
-			start_index = s.index_after(start_token, read_len)
-			if start_index == -1 {
-				break
-			}
-		}
-		// get the index of the end of anchor (a) opening tag
-		// we use the previous start_index to make sure we are getting a module and not just a random 'a' tag
-		start_token = '>'
-		start_index = s.index_after(start_token, start_index) + start_token.len
-
-		// get the index of the end of module entry
-		end_index := s.index_after(end_token, start_index)
-		if end_index == -1 {
-			break
-		}
-		modules << s[start_index..end_index]
-		read_len = end_index
-		if read_len >= s.len {
-			break
-		}
-	}
-	return modules
-}
-
-fn get_installed_modules() []string {
-	dirs := os.ls(settings.vmodules_path) or { return [] }
-	mut modules := []string{}
-	for dir in dirs {
-		adir := os.join_path(settings.vmodules_path, dir)
-		if dir in excluded_dirs || !os.is_dir(adir) {
-			continue
-		}
-		if os.exists(os.join_path(adir, 'v.mod')) && os.exists(os.join_path(adir, '.git', 'config')) {
-			// an official vlang module with a short module name, like `vsl`, `ui` or `markdown`
-			modules << dir
-			continue
-		}
-		author := dir
-		mods := os.ls(adir) or { continue }
-		for m in mods {
-			vcs_used_in_dir(os.join_path(adir, m)) or { continue }
-			modules << '${author}.${m}'
-		}
-	}
-	return modules
 }
 
 fn get_working_server_url() string {
@@ -231,50 +46,6 @@ fn (vcs &VCS) is_executable() ! {
 	}
 }
 
-fn increment_module_download_count(name string) ! {
-	if settings.no_dl_count_increment {
-		println('Skipping download count increment for `${name}`.')
-		return
-	}
-	mut errors := []string{}
-
-	for server_url in vpm_server_urls {
-		modurl := server_url + '/api/packages/${name}/incr_downloads'
-		r := http.post(modurl, '') or {
-			errors << 'Http server did not respond to our request for `${modurl}`.'
-			errors << 'Error details: ${err}'
-			continue
-		}
-		if r.status_code != 200 {
-			errors << 'Failed to increment the download count for module `${name}`, since `${server_url}` responded with ${r.status_code} http status code. Please try again later.'
-			continue
-		}
-		return
-	}
-	return error(errors.join_lines())
-}
-
-fn resolve_dependencies(name string, module_path string, module_names []string) {
-	vmod_path := os.join_path(module_path, 'v.mod')
-	if !os.exists(vmod_path) {
-		return
-	}
-	manifest := vmod.from_file(vmod_path) or {
-		vpm_error(err.msg(),
-			verbose: true
-		)
-		return
-	}
-	// Filter out modules that are both contained in the input query and listed as
-	// dependencies in the mod file of the module that is supposed to be installed.
-	deps := manifest.dependencies.filter(it !in module_names)
-	if deps.len > 0 {
-		println('Resolving ${deps.len} dependencies for module `${name}` ...')
-		verbose_println('Found dependencies: ${deps}')
-		vpm_install(deps)
-	}
-}
-
 fn vcs_used_in_dir(dir string) ?VCS {
 	for vcs in supported_vcs.values() {
 		if os.is_dir(os.real_path(os.join_path(dir, vcs.dir))) {
@@ -284,30 +55,9 @@ fn vcs_used_in_dir(dir string) ?VCS {
 	return none
 }
 
-fn valid_final_path_of_existing_module(mod_name string) ?string {
-	mut name := get_name_from_url(mod_name) or { mod_name }
-	name_normalised := if name.ends_with('.git') { name.replace('.git', '') } else { name }.replace('-',
-		'_').to_lower()
-	path := os.real_path(os.join_path(settings.vmodules_path, name_normalised.replace('.',
-		os.path_separator)))
-	if !os.exists(path) {
-		vpm_error('failed to find a module with name `${name_normalised}` at `${path}`.')
-		return none
-	}
-	if !os.is_dir(path) {
-		vpm_error('skipping `${path}`, since it is not a directory.')
-		return none
-	}
-	vcs_used_in_dir(path) or {
-		vpm_error('skipping `${path}`, since it uses an unsupported version control system.')
-		return none
-	}
-	return path
-}
-
-fn verbose_println(s string) {
+fn verbose_println(msg string) {
 	if settings.is_verbose {
-		println(s)
+		println(msg)
 	}
 }
 

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -32,9 +32,7 @@ fn ensure_vmodules_dir_exist() {
 	if !os.is_dir(settings.vmodules_path) {
 		println('Creating `${settings.vmodules_path}` ...')
 		os.mkdir(settings.vmodules_path) or {
-			vpm_error(err.msg(),
-				verbose: true
-			)
+			vpm_error(err.msg(), verbose: true)
 			exit(1)
 		}
 	}

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -50,10 +50,10 @@ fn test_install_dependencies_in_module_dir() {
 	assert v_mod.dependencies == ['markdown', 'pcre', 'https://github.com/spytheman/vtray']
 	// Run `v install`
 	res := os.execute_or_exit('${v} install')
-	assert res.output.contains('Detected v.mod file inside the project directory. Using it...')
-	assert res.output.contains('Installing module `markdown`')
-	assert res.output.contains('Installing module `pcre`')
-	assert res.output.contains('Installing module `vtray`')
+	assert res.output.contains('Detected v.mod file inside the project directory. Using it...'), res.output
+	assert res.output.contains('Installing module `markdown`'), res.output
+	assert res.output.contains('Installing module `pcre`'), res.output
+	assert res.output.contains('Installing module `vtray`'), res.output
 	assert get_mod_name(os.join_path(test_path, 'markdown', 'v.mod')) == 'markdown'
 	assert get_mod_name(os.join_path(test_path, 'pcre', 'v.mod')) == 'pcre'
 	assert get_mod_name(os.join_path(test_path, 'vtray', 'v.mod')) == 'vtray'
@@ -61,9 +61,9 @@ fn test_install_dependencies_in_module_dir() {
 
 fn test_resolve_external_dependencies_during_module_install() {
 	res := os.execute_or_exit('${v} install https://github.com/ttytm/emoji-mart-desktop')
-	assert res.output.contains('Resolving 2 dependencies')
-	assert res.output.contains('Installing module `webview`')
-	assert res.output.contains('Installing module `miniaudio`')
+	assert res.output.contains('Resolving 2 dependencies'), res.output
+	assert res.output.contains('Installing module `webview`'), res.output
+	assert res.output.contains('Installing module `miniaudio`'), res.output
 	// The external dependencies should have been installed to `<vmodules_dir>/<dependency_name>`
 	assert get_mod_name(os.join_path(test_path, 'webview', 'v.mod')) == 'webview'
 	assert get_mod_name(os.join_path(test_path, 'miniaudio', 'v.mod')) == 'miniaudio'

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -18,8 +18,9 @@ fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }
 
+// path relative to `test_path`
 fn get_mod_name(path string) string {
-	mod := vmod.from_file(path) or {
+	mod := vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
 		eprintln(err)
 		return ''
 	}
@@ -51,20 +52,20 @@ fn test_install_dependencies_in_module_dir() {
 	// Run `v install`
 	res := os.execute_or_exit('${v} install')
 	assert res.output.contains('Detected v.mod file inside the project directory. Using it...'), res.output
-	assert res.output.contains('Installing module `markdown`'), res.output
-	assert res.output.contains('Installing module `pcre`'), res.output
-	assert res.output.contains('Installing module `vtray`'), res.output
-	assert get_mod_name(os.join_path(test_path, 'markdown', 'v.mod')) == 'markdown'
-	assert get_mod_name(os.join_path(test_path, 'pcre', 'v.mod')) == 'pcre'
-	assert get_mod_name(os.join_path(test_path, 'vtray', 'v.mod')) == 'vtray'
+	assert res.output.contains('Installing `markdown`'), res.output
+	assert res.output.contains('Installing `pcre`'), res.output
+	assert res.output.contains('Installing `vtray`'), res.output
+	assert get_mod_name('markdown') == 'markdown'
+	assert get_mod_name('pcre') == 'pcre'
+	assert get_mod_name('vtray') == 'vtray'
 }
 
 fn test_resolve_external_dependencies_during_module_install() {
 	res := os.execute_or_exit('${v} install https://github.com/ttytm/emoji-mart-desktop')
 	assert res.output.contains('Resolving 2 dependencies'), res.output
-	assert res.output.contains('Installing module `webview`'), res.output
-	assert res.output.contains('Installing module `miniaudio`'), res.output
+	assert res.output.contains('Installing `webview`'), res.output
+	assert res.output.contains('Installing `miniaudio`'), res.output
 	// The external dependencies should have been installed to `<vmodules_dir>/<dependency_name>`
-	assert get_mod_name(os.join_path(test_path, 'webview', 'v.mod')) == 'webview'
-	assert get_mod_name(os.join_path(test_path, 'miniaudio', 'v.mod')) == 'miniaudio'
+	assert get_mod_name('webview') == 'webview'
+	assert get_mod_name('miniaudio') == 'miniaudio'
 }

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -123,8 +123,11 @@ fn vpm_install_from_vpm(modules []Module) {
 			errors++
 		}
 		manifest := vmod.from_file(os.join_path(m.install_path, 'v.mod')) or {
-			vpm_error(err.msg())
-			errors++
+			vpm_error('Module `${m.name}` is lacking a v.mod file.',
+				details: err.msg()
+				verbose: true
+			)
+			println('Installed `${m.name}`.')
 			continue
 		}
 		if last_errors == errors {
@@ -160,8 +163,11 @@ fn vpm_install_from_vcs(modules []Module) {
 			}
 		}
 		manifest := vmod.from_file(os.join_path(m.install_path, 'v.mod')) or {
-			vpm_error(err.msg())
-			errors++
+			vpm_error('Module `${m.name}` is lacking a v.mod file.',
+				details: err.msg()
+				verbose: true
+			)
+			println('Installed `${m.name}`.')
 			continue
 		}
 		vpm_log(@FILE_LINE, @FN, 'manifest: ${manifest}')

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -35,11 +35,9 @@ fn vpm_install(requested_modules []string) {
 			exit(2)
 		}
 	} else {
-		requested_modules.clone()
+		requested_modules
 	})
 
-	mut vpm_modules := modules.filter(!it.is_external)
-	mut external_modules := modules.filter(it.is_external)
 	installed_modules := get_installed_modules()
 
 	vpm_log(@FILE_LINE, @FN, 'VPM modules: ${vpm_modules}')
@@ -74,7 +72,7 @@ fn vpm_install(requested_modules []string) {
 		}
 		if already_installed.len > 0 {
 			verbose_println('Already installed modules: ${already_installed}')
-			if already_installed.len == modules.len {
+			if already_installed.len == requested_modules.len {
 				println('All modules are already installed.')
 				exit(0)
 			}

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -170,8 +170,8 @@ fn vpm_install_from_vcs(modules []Module) {
 			println('Installed `${m.name}`.')
 			continue
 		}
-		vpm_log(@FILE_LINE, @FN, 'manifest: ${manifest}')
-		final_path := os.real_path(os.join_path(settings.vmodules_path, manifest.name))
+		final_path := os.real_path(os.join_path(settings.vmodules_path, manifest.name.replace('-',
+			'_').to_lower()))
 		if m.install_path != final_path {
 			verbose_println('Relocating `${m.name} (${m.install_path})` to `${manifest.name} (${final_path})`...')
 			if os.exists(final_path) {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -3,17 +3,72 @@ module main
 import os
 import v.vmod
 import v.help
-import net.urllib
+
+struct Module {
+mut:
+	// Can be populated via via VPM API.
+	name string
+	url  string
+	vcs  string
+	// Based on input / environment.
+	version      string
+	install_path string
+	external     bool
+}
+
+fn parse_query(query []string) []Module {
+	mut modules := []Module{}
+	mut errors := 0
+	for mod in query {
+		ident, version := mod.rsplit_once('@') or { mod, '' }
+		if ident.starts_with('https://') {
+			name := get_name_from_url(ident) or {
+				vpm_error(err.msg())
+				errors++
+				continue
+			}
+			name_normalized := name.replace('-', '_').to_lower()
+			modules << Module{
+				name: name
+				url: ident
+				version: version
+				install_path: os.real_path(os.join_path(settings.vmodules_path, name_normalized))
+				external: true
+			}
+		} else {
+			info := get_mod_vpm_info(ident) or {
+				vpm_error(err.msg())
+				errors++
+				continue
+			}
+			name_normalized := info.name.replace('-', '_').to_lower()
+			modules << Module{
+				name: info.name
+				url: info.url
+				vcs: info.vcs
+				version: version
+				install_path: os.real_path(os.join_path(settings.vmodules_path, name_normalized.replace('.',
+					os.path_separator)))
+			}
+		}
+	}
+	if errors > 0 && errors == query.len {
+		exit(1)
+	}
+	return modules
+}
 
 fn vpm_install(requested_modules []string) {
+	vpm_log(@FILE_LINE, @FN, 'requested_modules: ${requested_modules}')
+
 	if settings.is_help {
 		help.print_and_exit('vpm')
 	}
 
-	modules := if requested_modules.len == 0 {
-		// Run `v install` in a directory of another V module without passing modules as arguments
-		// to install its dependencies.
+	mut vpm_modules, mut external_modules := parse_query(if requested_modules.len == 0 {
 		if os.exists('./v.mod') {
+			// Case: `v install` was run in a directory of another V-module to install its dependencies
+			// - without additional module arguments.
 			println('Detected v.mod file inside the project directory. Using it...')
 			manifest := vmod.from_file('./v.mod') or { panic(err) }
 			if manifest.dependencies.len == 0 {
@@ -29,24 +84,23 @@ fn vpm_install(requested_modules []string) {
 		}
 	} else {
 		requested_modules.clone()
-	}
+	})
 
-	mut external_modules := modules.filter(it.starts_with('https://'))
-	mut vpm_modules := modules.filter(it !in external_modules)
+	mut vpm_modules := modules.filter(!it.external)
+	mut external_modules := modules.filter(it.external)
 	installed_modules := get_installed_modules()
+
+	vpm_log(@FILE_LINE, @FN, 'VPM modules: ${vpm_modules}')
+	vpm_log(@FILE_LINE, @FN, 'External modules: ${external_modules}')
+	vpm_log(@FILE_LINE, @FN, 'Installed modules: ${installed_modules}')
 
 	if installed_modules.len > 0 && settings.is_once {
 		mut already_installed := []string{}
 		if external_modules.len > 0 {
 			mut i_deleted := []int{}
-			for i, raw_url in external_modules {
-				url := urllib.parse(raw_url) or {
-					vpm_error('failed to parse module url `${raw_url}`.', details: err.msg())
-					continue
-				}
-				mod_name := url.path.all_after_last('/').replace('.git', '')
-				if mod_name in installed_modules {
-					already_installed << mod_name
+			for i, m in external_modules {
+				if m.name in installed_modules {
+					already_installed << m.name
 					i_deleted << i
 				}
 			}
@@ -56,11 +110,10 @@ fn vpm_install(requested_modules []string) {
 		}
 		if vpm_modules.len > 0 {
 			mut i_deleted := []int{}
-			for i, mod_name in vpm_modules {
-				if mod_name in installed_modules {
-					already_installed << mod_name
+			for i, m in vpm_modules {
+				if m.name in installed_modules {
+					already_installed << m.name
 					i_deleted << i
-					continue
 				}
 			}
 			for i in i_deleted.reverse() {
@@ -84,145 +137,155 @@ fn vpm_install(requested_modules []string) {
 	}
 }
 
-fn install_module(vcs &VCS, name string, url string, final_module_path string) ! {
-	cmd := '${vcs.cmd} ${vcs.args.install} "${url}" "${final_module_path}"'
-	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
-	println('Installing module `${name}` from `${url}` to `${final_module_path}` ...')
-	os.execute_opt(cmd) or {
-		vpm_log(@FILE_LINE, @FN, 'cmd output: ${err}')
-		return error('failed to install module `${name}` to `${final_module_path}`.')
-	}
-}
-
-fn vpm_install_from_vpm(module_names []string) {
+fn vpm_install_from_vpm(modules []Module) {
+	vpm_log(@FILE_LINE, @FN, 'modules: ${modules}')
 	mut errors := 0
-	for n in module_names {
-		name := n.trim_space().replace('_', '-')
-		mod := get_module_meta_info(name) or {
-			errors++
-			vpm_error('failed to retrieve meta data for module `${name}`.', details: err.msg())
-			continue
-		}
+	idents := modules.map(it.name)
+	for mod in modules {
+		vpm_log(@FILE_LINE, @FN, 'mod: ${mod}')
 		vcs := if mod.vcs != '' {
 			supported_vcs[mod.vcs] or {
 				errors++
-				vpm_error('skipping `${name}`, since it uses an unsupported version control system `${mod.vcs}`.')
+				vpm_error('skipping `${mod.name}`, since it uses an unsupported version control system `${mod.vcs}`.')
 				continue
 			}
 		} else {
 			supported_vcs['git']
 		}
-		ensure_vcs_is_installed(vcs) or {
+		vcs.is_executable() or {
 			errors++
 			vpm_error(err.msg())
 			continue
 		}
-		minfo := get_mod_name_info(mod.name)
-		if os.exists(minfo.final_module_path) {
-			vpm_update([name])
+		if os.exists(mod.install_path) {
+			vpm_log(@FILE_LINE, @FN, 'exists: ${mod.install_path}')
+			vpm_update([mod.name])
 			continue
 		}
-		install_module(vcs, name, mod.url, minfo.final_module_path) or {
+		mod.install(vcs) or {
 			errors++
 			vpm_error(err.msg())
 			continue
 		}
-		increment_module_download_count(name) or {
+		increment_module_download_count(mod.name) or {
 			errors++
-			vpm_error('failed to increment the download count for `${name}`', details: err.msg())
+			vpm_error('failed to increment the download count for `${mod.name}`', details: err.msg())
 		}
-		resolve_dependencies(name, minfo.final_module_path, module_names)
+		manifest := vmod.from_file(os.join_path(mod.install_path, 'v.mod')) or {
+			vpm_error(err.msg())
+			return
+		}
+		deps := manifest.dependencies.filter(it !in idents)
+		vpm_log(@FILE_LINE, @FN, 'manifest: ${manifest}; deps: ${deps}')
+		install_dependencies(mod.name, deps)
 	}
 	if errors > 0 {
 		exit(1)
 	}
 }
 
-fn vpm_install_from_vcs(modules []string, vcs &VCS) {
+// TODO: if requested version differs and the current install is a version install,
+// overwrite with -force or prompt + print(updating `module` to version `version`).
+fn vpm_install_from_vcs(modules []Module, vcs &VCS) {
+	vpm_log(@FILE_LINE, @FN, 'modules: ${modules}')
 	mut errors := 0
-	for raw_url in modules {
-		url := urllib.parse(raw_url) or {
-			errors++
-			vpm_error('failed to parse module url `${raw_url}`.', details: err.msg())
-			continue
-		}
-		// Module identifier based on URL.
-		// E.g.: `https://github.com/owner/awesome-v-project` -> `owner/awesome_v_project`
-		mut ident := url.path#[1..].replace('-', '_').replace('.git', '')
-		owner, repo_name := ident.split_once('/') or {
-			errors++
-			vpm_error('failed to retrieve module name for `${url}`.', details: err.msg())
-			continue
-		}
-		mut final_module_path := os.real_path(os.join_path(settings.vmodules_path, owner.to_lower(),
-			repo_name.to_lower()))
-		if os.exists(final_module_path) {
-			vpm_update([ident])
-			continue
-		}
-		ensure_vcs_is_installed(vcs) or {
+	urls := modules.map(it.url)
+	for mod in modules {
+		vcs.is_executable() or {
 			errors++
 			vpm_error(err.msg())
 			continue
 		}
-		install_module(vcs, repo_name, url.str(), final_module_path) or {
+		if os.exists(mod.install_path) {
+			vpm_update([mod.name])
+			continue
+		}
+		mod.install(vcs) or {
 			errors++
 			vpm_error(err.msg())
 			continue
 		}
-		vmod_path := os.join_path(final_module_path, 'v.mod')
-		if os.exists(vmod_path) {
-			manifest := vmod.from_file(vmod_path) or {
-				vpm_error(err.msg(),
-					verbose: true
-				)
-				return
-			}
-			minfo := get_mod_name_info(manifest.name)
-			if final_module_path != minfo.final_module_path {
-				println('Relocating module from `${ident}` to `${manifest.name}` (`${minfo.final_module_path}`) ...')
-				if os.exists(minfo.final_module_path) {
-					eprintln('Warning module `${minfo.final_module_path}` already exists!')
-					eprintln('Removing module `${minfo.final_module_path}` ...')
-					mut err_msg := ''
-					$if windows {
-						os.execute_opt('rd /s /q ${minfo.final_module_path}') or {
-							err_msg = err.msg()
-						}
-					} $else {
-						os.rmdir_all(minfo.final_module_path) or { err_msg = err.msg() }
-					}
-					if err_msg != '' {
-						errors++
-						vpm_error('failed to remove `${minfo.final_module_path}`', details: err_msg)
-						continue
-					}
+		manifest := vmod.from_file(os.join_path(mod.install_path, 'v.mod')) or {
+			vpm_error(err.msg())
+			return
+		}
+		final_path := os.real_path(os.join_path(settings.vmodules_path, manifest.name))
+		if mod.install_path != final_path {
+			println('Relocating module from `${mod.name}` to `${manifest.name}` (`${final_path}`) ...')
+			if os.exists(final_path) {
+				// TODO: detect updatability
+				// TODO: either require force flag or prompt for replace if a different module with the same name is already installed.
+				// TODO: check for local changes, don't overwrite by default
+				// vpm_update([manifest.name])
+				println('Warning module `${final_path}` already exists!')
+				println('Removing module `${final_path}` ...')
+				mut err_msg := ''
+				$if windows {
+					os.execute_opt('rd /s /q ${final_path}') or { err_msg = err.msg() }
+				} $else {
+					os.rmdir_all(final_path) or { err_msg = err.msg() }
 				}
-				os.mv(final_module_path, minfo.final_module_path) or {
+				if err_msg != '' {
 					errors++
-					vpm_error('failed to relocate module `${repo_name}`.', details: err.msg())
-					os.rmdir_all(final_module_path) or {
-						errors++
-						vpm_error('failed to remove `${final_module_path}`.', details: err.msg())
-						continue
-					}
+					vpm_error('failed to remove `${final_path}`.', details: err_msg)
 					continue
 				}
-				println('Module `${repo_name}` relocated to `${manifest.name}` successfully.')
-				publisher_dir := os.dir(final_module_path)
-				if os.is_dir_empty(publisher_dir) {
-					os.rmdir(publisher_dir) or {
-						errors++
-						vpm_error('failed to remove `${publisher_dir}`.', details: err.msg())
-					}
-				}
-				final_module_path = minfo.final_module_path
 			}
-			ident = manifest.name
+			// When the module should be relocated into a subdirectory we need to make sure
+			// it exists to not into permission errors.
+			if mod.install_path.count(os.path_separator) < final_path.count(os.path_separator)
+				&& !os.exists(final_path) {
+				os.mkdir_all(final_path) or {
+					errors++
+					vpm_error('failed to create directory for `${manifest.name}` — ${err}')
+					continue
+				}
+			}
+			vpm_log(@FILE_LINE, @FN, 'mv `${mod.install_path}` to `${final_path}`')
+			os.mv(mod.install_path, final_path) or {
+				errors++
+				vpm_error('failed to relocate module `${mod.name}`.', details: err.msg())
+				os.rmdir_all(mod.install_path) or {
+					errors++
+					vpm_error('failed to remove `${mod.install_path}`.', details: err.msg())
+					continue
+				}
+				continue
+			}
+			verbose_println('Relocated `${mod.name}` to `${manifest.name}`.')
 		}
-		resolve_dependencies(ident, final_module_path, modules)
+		// Filter out modules that are both contained in the input query and listed as
+		// dependencies in the mod file of the module that is supposed to be installed.
+		deps := manifest.dependencies.filter(it !in urls)
+		vpm_log(@FILE_LINE, @FN, 'manifest: ${manifest}; deps: ${deps}')
+		install_dependencies(manifest.name, deps)
 	}
 	if errors > 0 {
 		exit(1)
+	}
+}
+
+fn (m Module) install(vcs &VCS) ! {
+	install_arg := if m.version != '' {
+		'${vcs.args.install} --single-branch -b ${m.version}'
+	} else {
+		vcs.args.install
+	}
+	cmd := '${vcs.cmd} ${install_arg} "${m.url}" "${m.install_path}"'
+	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
+	println('Installing module `${m.name}` from `${m.url}` to `${m.install_path}` ...')
+	res := os.execute_opt(cmd) or {
+		vpm_log(@FILE_LINE, @FN, 'cmd output: ${err}')
+		return error('failed to install module `${m.name}`.')
+	}
+	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output}')
+}
+
+// TODO: check for merging possiblity with resolve_dependencies after progressing with `update` functions
+fn install_dependencies(name string, deps []string) {
+	if deps.len > 0 {
+		println('Resolving ${deps.len} dependencies for module `${name}` ...')
+		verbose_println('Found dependencies: ${deps}')
+		vpm_install(deps)
 	}
 }

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -122,7 +122,7 @@ fn vpm_install_from_vpm(modules []Module) {
 			errors++
 			continue
 		}
-		install_dependencies(manifest.name, manifest.dependencies, idents)
+		resolve_dependencies(manifest.name, manifest.dependencies, idents)
 	}
 	if errors > 0 {
 		exit(1)
@@ -204,7 +204,7 @@ fn vpm_install_from_vcs(modules []Module, vcs &VCS) {
 			}
 			verbose_println('Relocated `${mod.name}` to `${manifest.name}`.')
 		}
-		install_dependencies(manifest.name, manifest.dependencies, urls)
+		resolve_dependencies(manifest.name, manifest.dependencies, urls)
 	}
 	if errors > 0 {
 		exit(1)
@@ -225,15 +225,4 @@ fn (m Module) install(vcs &VCS) ! {
 		return error('failed to install module `${m.name}`.')
 	}
 	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output}')
-}
-
-fn install_dependencies(name string, dependencies []string, modules []string) {
-	// Filter out modules that are both contained in the input query and listed as
-	// dependencies in the mod file of the module that is supposed to be installed.
-	deps := dependencies.filter(it !in modules)
-	if deps.len > 0 {
-		println('Resolving ${deps.len} dependencies for module `${name}` ...')
-		verbose_println('Found dependencies: ${deps}')
-		vpm_install(deps)
-	}
 }

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -266,7 +266,8 @@ fn (m Module) install(vcs &VCS) ! {
 	}
 	cmd := '${vcs.cmd} ${install_arg} "${m.url}" "${m.install_path}"'
 	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
-	println('Installing `${m.name}` from `${m.url}` to `${m.install_path}`...')
+	println('Installing `${m.name}`...')
+	verbose_println('  cloning from `${m.url}` to `${m.install_path}`')
 	res := os.execute_opt(cmd) or {
 		vpm_log(@FILE_LINE, @FN, 'cmd output: ${err}')
 		return error('failed to install module `${m.name}`.')

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -22,7 +22,7 @@ fn testsuite_end() {
 
 fn test_install_from_vpm_ident() {
 	res := os.execute_or_exit('${v} install nedpals.args')
-	assert res.output.contains('Skipping download count increment for `nedpals.args`.')
+	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -43,8 +43,7 @@ fn test_install_from_vpm_short_ident() {
 
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('Installing module `markdown` from `https://github.com/vlang/markdown`')
-	assert res.output.contains('Relocating module from `vlang/markdown` to `markdown`')
+	assert res.output.contains('Installing module `markdown` from `https://github.com/vlang/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -55,7 +54,7 @@ fn test_install_from_git_url() {
 
 fn test_install_already_existent() {
 	mut res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('already exists')
+	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -64,7 +63,7 @@ fn test_install_already_existent() {
 	assert mod.dependencies == []string{}
 	// The same module but with the `.git` extension added.
 	os.execute_or_exit('${v} install https://github.com/vlang/markdown.git')
-	assert res.output.contains('already exists')
+	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 }
 
 fn test_install_once() {
@@ -85,7 +84,7 @@ fn test_install_once() {
 	install_cmd := '${@VEXE} install https://github.com/vlang/markdown https://github.com/vlang/pcre --once -v'
 	// Try installing two modules, one of which is already installed.
 	mut res := os.execute_or_exit(install_cmd)
-	assert res.output.contains("Already installed modules: ['markdown']")
+	assert res.output.contains("Already installed modules: ['markdown']"), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -98,7 +97,7 @@ fn test_install_once() {
 
 	// Try installing two modules that are both already installed.
 	res = os.execute_or_exit(install_cmd)
-	assert res.output.contains('All modules are already installed.')
+	assert res.output.contains('All modules are already installed.'), res.output
 	assert md_last_modified == os.file_last_mod_unix(os.join_path(test_path, 'markdown',
 		'v.mod'))
 }
@@ -107,5 +106,5 @@ fn test_missing_repo_name_in_url() {
 	incomplete_url := 'https://github.com/vlang'
 	res := os.execute('${v} install ${incomplete_url}')
 	assert res.exit_code == 1
-	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`')
+	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`'), res.output
 }

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -44,6 +44,7 @@ fn test_install_from_vpm_short_ident() {
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
 	assert res.output.contains('Installing `markdown`'), res.output
+	assert res.output.contains('Installed `markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -43,7 +43,7 @@ fn test_install_from_vpm_short_ident() {
 
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('Installing `markdown` from `https://github.com/vlang/markdown`'), res.output
+	assert res.output.contains('Installing `markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -109,3 +109,71 @@ fn test_missing_repo_name_in_url() {
 	assert res.exit_code == 1
 	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`'), res.output
 }
+
+fn test_install_from_vpm_with_git_version_tag() {
+	ident := 'ttytm.webview'
+	mut tag := 'v0.6.0'
+	mut res := os.execute_or_exit('${v} install ${ident}@${tag}')
+	assert res.output.contains('Installing `${ident}`'), res.output
+	assert res.output.contains('Installed `${ident}`'), res.output
+	mut name, mut version := get_mod_name_and_version(os.join_path('ttytm', 'webview'))
+	assert name == 'webview'
+	assert version == '0.6.0'
+	// Install same version without force flag.
+	res = os.execute_or_exit('${v} install ${ident}@${tag}')
+	assert res.output.contains('Module `${ident}@${tag}` is already installed, use --force to overwrite'), res.output
+	// Install another version, add force flag to surpass confirmation.
+	tag = 'v0.5.0'
+	res = os.execute_or_exit('${v} install -f ${ident}@${tag}')
+	assert res.output.contains('Installed `${ident}`'), res.output
+	name, version = get_mod_name_and_version(os.join_path('ttytm', 'webview'))
+	assert name == 'webview'
+	assert version == '0.5.0'
+	// Install invalid version.
+	tag = '6.0'
+	res = os.execute('${v} install -f ${ident}@${tag}')
+	assert res.exit_code == 1
+	assert res.output.contains('failed to install `${ident}`'), res.output
+	// Install invalid version verbose.
+	res = os.execute('${v} install -f -v ${ident}@${tag}')
+	assert res.exit_code == 1
+	assert res.output.contains('failed to install `${ident}`'), res.output
+	assert res.output.contains('Remote branch 6.0 not found in upstream origin'), res.output
+}
+
+fn test_install_from_url_with_git_version_tag() {
+	url := 'https://github.com/vlang/vsl'
+	mut tag := 'v0.1.50'
+	mut res := os.execute_or_exit('v install ${url}@${tag}')
+	assert res.output.contains('Installing `vsl`'), res.output
+	assert res.output.contains('Installed `vsl`'), res.output
+	mut name, mut version := get_mod_name_and_version('vsl')
+	assert name == 'vsl'
+	assert version == '0.1.50'
+	// Install same version without force flag.
+	res = os.execute_or_exit('${v} install ${url}@${tag}')
+	assert res.output.contains('Module `vsl@${tag}` is already installed, use --force to overwrite'), res.output
+	// Install another version, add force flag to surpass confirmation.
+	tag = 'v0.1.47'
+	res = os.execute_or_exit('${v} install -f ${url}@${tag}')
+	assert res.output.contains('Installed `vsl`'), res.output
+	name, version = get_mod_name_and_version('vsl')
+	assert name == 'vsl'
+	assert version == '0.1.47'
+	// Install invalid version.
+	tag = 'abc'
+	res = os.execute('${v} install -f ${url}@${tag}')
+	assert res.exit_code == 1
+	// Install invalid version verbose.
+	res = os.execute('${v} install -f -v ${url}@${tag}')
+	assert res.exit_code == 1
+	assert res.output.contains('Remote branch abc not found in upstream origin'), res.output
+}
+
+fn get_mod_name_and_version(path string) (string, string) {
+	mod := vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
+		eprintln(err)
+		return '', ''
+	}
+	return mod.name, mod.version
+}

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -43,7 +43,7 @@ fn test_install_from_vpm_short_ident() {
 
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('Installing module `markdown` from `https://github.com/vlang/markdown`'), res.output
+	assert res.output.contains('Installing `markdown` from `https://github.com/vlang/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -54,7 +54,7 @@ fn test_install_from_git_url() {
 
 fn test_install_already_existent() {
 	mut res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
+	assert res.output.contains('Updating `markdown` in `${test_path}/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -63,7 +63,7 @@ fn test_install_already_existent() {
 	assert mod.dependencies == []string{}
 	// The same module but with the `.git` extension added.
 	os.execute_or_exit('${v} install https://github.com/vlang/markdown.git')
-	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
+	assert res.output.contains('Updating `markdown` in `${test_path}/markdown`'), res.output
 }
 
 fn test_install_once() {

--- a/cmd/tools/vpm/mod_info.v
+++ b/cmd/tools/vpm/mod_info.v
@@ -16,7 +16,8 @@ mut:
 	version           string // specifies the requested version.
 	install_path      string
 	is_external       bool
-	installed_version ?string
+	is_installed      bool
+	installed_version string
 }
 
 struct ModuleVpmInfo {
@@ -67,6 +68,7 @@ fn parse_query(query []string) []Module {
 		}
 		mod.version = version
 		if v := os.execute_opt('git ls-remote --tags ${mod.install_path}') {
+			mod.is_installed = true
 			mod.installed_version = v.output.all_after_last('/').trim_space()
 		}
 		modules << mod

--- a/cmd/tools/vpm/mod_info.v
+++ b/cmd/tools/vpm/mod_info.v
@@ -1,0 +1,282 @@
+module main
+
+import os
+import json
+import sync.pool
+import net.http
+import net.urllib
+
+struct Module {
+mut:
+	// Can be populated via VPM API.
+	name string
+	url  string
+	vcs  string
+	// Based on input / environment.
+	version      string
+	install_path string
+	external     bool
+}
+
+struct ModuleVpmInfo {
+	// id           int
+	name         string
+	url          string
+	vcs          string
+	nr_downloads int
+}
+
+pub struct ModuleDateInfo {
+	name string
+mut:
+	outdated bool
+	exec_err bool
+}
+
+fn parse_query(query []string) []Module {
+	mut modules := []Module{}
+	mut errors := 0
+	for mod in query {
+		ident, version := mod.rsplit_once('@') or { mod, '' }
+		if ident.starts_with('https://') {
+			name := get_name_from_url(ident) or {
+				vpm_error(err.msg())
+				errors++
+				continue
+			}
+			name_normalized := name.replace('-', '_').to_lower()
+			modules << Module{
+				name: name
+				url: ident
+				version: version
+				install_path: os.real_path(os.join_path(settings.vmodules_path, name_normalized))
+				external: true
+			}
+		} else {
+			info := get_mod_vpm_info(ident) or {
+				vpm_error('failed to retrieve metadata for `${ident}`.', details: err.msg())
+				errors++
+				continue
+			}
+			name_normalized := info.name.replace('-', '_').to_lower()
+			modules << Module{
+				name: info.name
+				url: info.url
+				vcs: info.vcs
+				version: version
+				install_path: os.real_path(os.join_path(settings.vmodules_path, name_normalized.replace('.',
+					os.path_separator)))
+			}
+		}
+	}
+	if errors > 0 && errors == query.len {
+		exit(1)
+	}
+	return modules
+}
+
+fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModuleDateInfo {
+	mut result := &ModuleDateInfo{
+		name: pp.get_item[string](idx)
+	}
+	path := get_path_of_existing_module(result.name) or { return result }
+	vcs := vcs_used_in_dir(path) or { return result }
+	is_hg := vcs.cmd == 'hg'
+	mut outputs := []string{}
+	for step in vcs.args.outdated {
+		cmd := '${vcs.cmd} ${vcs.args.path} "${path}" ${step}'
+		res := os.execute(cmd)
+		if res.exit_code < 0 {
+			verbose_println('Error command: ${cmd}')
+			verbose_println('Error details:\n${res.output}')
+			result.exec_err = true
+			return result
+		}
+		if is_hg && res.exit_code == 1 {
+			result.outdated = true
+			return result
+		}
+		outputs << res.output
+	}
+	// vcs.cmd == 'git'
+	if !is_hg && outputs[1] != outputs[2] {
+		result.outdated = true
+	}
+	return result
+}
+
+fn get_mod_vpm_info(name string) !ModuleVpmInfo {
+	if name.len < 2 || (!name[0].is_digit() && !name[0].is_letter()) {
+		return error('invalid module name `${name}`.')
+	}
+	mut errors := []string{}
+	for server_url in vpm_server_urls {
+		modurl := server_url + '/api/packages/${name}'
+		verbose_println('Retrieving metadata for `${name}` from `${modurl}`...')
+		r := http.get(modurl) or {
+			errors << 'Http server did not respond to our request for `${modurl}`.'
+			errors << 'Error details: ${err}'
+			continue
+		}
+		if r.status_code == 404 || r.body.trim_space() == '404' {
+			errors << 'Skipping module `${name}`, since `${server_url}` reported that `${name}` does not exist.'
+			continue
+		}
+		if r.status_code != 200 {
+			errors << 'Skipping module `${name}`, since `${server_url}` responded with ${r.status_code} http status code. Please try again later.'
+			continue
+		}
+		s := r.body
+		if s.len > 0 && s[0] != `{` {
+			errors << 'Invalid json data'
+			errors << s.trim_space().limit(100) + '...'
+			continue
+		}
+		mod := json.decode(ModuleVpmInfo, s) or {
+			errors << 'Skipping module `${name}`, since its information is not in json format.'
+			continue
+		}
+		if '' == mod.url || '' == mod.name {
+			errors << 'Skipping module `${name}`, since it is missing name or url information.'
+			continue
+		}
+		vpm_log(@FILE_LINE, @FN, 'name: ${name}; mod: ${mod}')
+		return mod
+	}
+	return error(errors.join_lines())
+}
+
+fn get_name_from_url(raw_url string) !string {
+	url := urllib.parse(raw_url) or { return error('failed to parse module URL `${raw_url}`.') }
+	owner, mut name := url.path.trim_left('/').rsplit_once('/') or {
+		return error('failed to retrieve module name for `${url}`.')
+	}
+	vpm_log(@FILE_LINE, @FN, 'raw_url: ${raw_url}; owner: ${owner}; name: ${name}')
+	name = if name.ends_with('.git') { name.replace('.git', '') } else { name }.to_lower()
+	return name
+}
+
+fn get_outdated() ![]string {
+	modules := get_installed_modules()
+	mut outdated := []string{}
+	mut pp := pool.new_pool_processor(callback: get_mod_date_info)
+	pp.work_on_items(modules)
+	for res in pp.get_results[ModuleDateInfo]() {
+		if res.exec_err {
+			return error('failed to check the latest commits for `${res.name}`.')
+		}
+		if res.outdated {
+			outdated << res.name
+		}
+	}
+	return outdated
+}
+
+fn get_all_modules() []string {
+	url := get_working_server_url()
+	r := http.get(url) or {
+		vpm_error(err.msg(),
+			verbose: true
+		)
+		exit(1)
+	}
+	if r.status_code != 200 {
+		vpm_error('failed to search vpm.vlang.io.', details: 'Status code: ${r.status_code}')
+		exit(1)
+	}
+	s := r.body
+	mut read_len := 0
+	mut modules := []string{}
+	for read_len < s.len {
+		mut start_token := "<a href='/mod"
+		end_token := '</a>'
+		// get the start index of the module entry
+		mut start_index := s.index_after(start_token, read_len)
+		if start_index == -1 {
+			start_token = '<a href="/mod'
+			start_index = s.index_after(start_token, read_len)
+			if start_index == -1 {
+				break
+			}
+		}
+		// get the index of the end of anchor (a) opening tag
+		// we use the previous start_index to make sure we are getting a module and not just a random 'a' tag
+		start_token = '>'
+		start_index = s.index_after(start_token, start_index) + start_token.len
+
+		// get the index of the end of module entry
+		end_index := s.index_after(end_token, start_index)
+		if end_index == -1 {
+			break
+		}
+		modules << s[start_index..end_index]
+		read_len = end_index
+		if read_len >= s.len {
+			break
+		}
+	}
+	return modules
+}
+
+fn get_installed_modules() []string {
+	dirs := os.ls(settings.vmodules_path) or { return [] }
+	mut modules := []string{}
+	for dir in dirs {
+		adir := os.join_path(settings.vmodules_path, dir)
+		if dir in excluded_dirs || !os.is_dir(adir) {
+			continue
+		}
+		if os.exists(os.join_path(adir, 'v.mod')) && os.exists(os.join_path(adir, '.git', 'config')) {
+			// an official vlang module with a short module name, like `vsl`, `ui` or `markdown`
+			modules << dir
+			continue
+		}
+		author := dir
+		mods := os.ls(adir) or { continue }
+		for m in mods {
+			vcs_used_in_dir(os.join_path(adir, m)) or { continue }
+			modules << '${author}.${m}'
+		}
+	}
+	return modules
+}
+
+fn get_path_of_existing_module(mod_name string) ?string {
+	name := get_name_from_url(mod_name) or { mod_name.replace('-', '_').to_lower() }
+	path := os.real_path(os.join_path(settings.vmodules_path, name.replace('.', os.path_separator)))
+	if !os.exists(path) {
+		vpm_error('failed to find `${name}` at `${path}`.')
+		return none
+	}
+	if !os.is_dir(path) {
+		vpm_error('skipping `${path}`, since it is not a directory.')
+		return none
+	}
+	vcs_used_in_dir(path) or {
+		vpm_error('skipping `${path}`, since it uses an unsupported version control system.')
+		return none
+	}
+	return path
+}
+
+fn increment_module_download_count(name string) ! {
+	if settings.no_dl_count_increment {
+		println('Skipping download count increment for `${name}`.')
+		return
+	}
+	mut errors := []string{}
+	for server_url in vpm_server_urls {
+		modurl := server_url + '/api/packages/${name}/incr_downloads'
+		r := http.post(modurl, '') or {
+			errors << 'Http server did not respond to our request for `${modurl}`.'
+			errors << 'Error details: ${err}'
+			continue
+		}
+		if r.status_code != 200 {
+			errors << 'Failed to increment the download count for module `${name}`, since `${server_url}` responded with ${r.status_code} http status code. Please try again later.'
+			continue
+		}
+		return
+	}
+	return error(errors.join_lines())
+}

--- a/cmd/tools/vpm/mod_info.v
+++ b/cmd/tools/vpm/mod_info.v
@@ -280,3 +280,14 @@ fn increment_module_download_count(name string) ! {
 	}
 	return error(errors.join_lines())
 }
+
+fn resolve_dependencies(name string, dependencies []string, modules []string) {
+	// Filter out modules that are both contained in the input query and listed as
+	// dependencies in the mod file of the module that is supposed to be installed.
+	deps := dependencies.filter(it !in modules)
+	if deps.len > 0 {
+		println('Resolving ${deps.len} dependencies for module `${name}` ...')
+		verbose_println('Found dependencies: ${deps}')
+		vpm_install(deps)
+	}
+}

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -9,6 +9,7 @@ mut:
 	is_help               bool
 	is_once               bool
 	is_verbose            bool
+	is_force              bool
 	server_urls           []string
 	vcs                   string
 	vmodules_path         string
@@ -26,6 +27,7 @@ fn init_settings() VpmSettings {
 		is_help: '-h' in opts || '--help' in opts || 'help' in cmds
 		is_once: '--once' in opts
 		is_verbose: '-v' in opts
+		is_force: '-f' in opts || '--force' in opts
 		vcs: if '--hg' in opts { 'hg' } else { 'git' }
 		server_urls: cmdline.options(args, '--server-urls')
 		vmodules_path: os.vmodules_dir()

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -34,7 +34,10 @@ fn vpm_update(modules []string) {
 			exit(1)
 		}
 		manifest := vmod.from_file(os.join_path(res.install_path, 'v.mod')) or {
-			vpm_error(err.msg())
+			vpm_error('Module `${res.name}` is lacking a v.mod file.',
+				details: err.msg()
+				verbose: true
+			)
 			continue
 		}
 		resolve_dependencies(manifest.name, manifest.dependencies, modules)
@@ -99,8 +102,7 @@ fn vpm_update_verbose(modules []string) {
 			vpm_error(err.msg(), verbose: true)
 		}
 		manifest := vmod.from_file(os.join_path(install_path, 'v.mod')) or {
-			errors++
-			vpm_error(err.msg(), verbose: true)
+			vpm_error('Module `${mod}` is lacking a v.mod file.', details: err.msg(), verbose: true)
 			continue
 		}
 		resolve_dependencies(manifest.name, manifest.dependencies, modules)

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -66,9 +66,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModuleUpdateInfo 
 	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output.trim_space()}')
 	increment_module_download_count(name) or {
 		result.has_err = true
-		vpm_error(err.msg(),
-			verbose: true
-		)
+		vpm_error(err.msg(), verbose: true)
 	}
 	return result
 }
@@ -98,15 +96,11 @@ fn vpm_update_verbose(modules []string) {
 		vpm_log(@FILE_LINE, @FN, 'cmd: ${res.output.trim_space()}')
 		increment_module_download_count(name) or {
 			errors++
-			vpm_error(err.msg(),
-				verbose: true
-			)
+			vpm_error(err.msg(), verbose: true)
 		}
 		manifest := vmod.from_file(os.join_path(install_path, 'v.mod')) or {
 			errors++
-			vpm_error(err.msg(),
-				verbose: true
-			)
+			vpm_error(err.msg(), verbose: true)
 			continue
 		}
 		resolve_dependencies(manifest.name, manifest.dependencies, modules)

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -15,11 +15,11 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 	mut result := &ModUpdateInfo{
 		name: pp.get_item[string](idx)
 	}
-	zname := url_to_module_name(result.name)
+	zname := get_name_from_url(result.name) or { result.name }
 	result.final_path = valid_final_path_of_existing_module(result.name) or { return result }
 	println('Updating module `${zname}` in `${result.final_path}` ...')
 	vcs := vcs_used_in_dir(result.final_path) or { return result }
-	ensure_vcs_is_installed(vcs) or {
+	vcs.is_executable() or {
 		result.has_err = true
 		vpm_error(err.msg())
 		return result
@@ -68,11 +68,11 @@ fn vpm_update(m []string) {
 fn vpm_update_verbose(module_names []string) {
 	mut errors := 0
 	for name in module_names {
-		zname := url_to_module_name(name)
+		zname := get_name_from_url(name) or { name }
 		final_module_path := valid_final_path_of_existing_module(name) or { continue }
 		println('Updating module `${zname}` in `${final_module_path}` ...')
 		vcs := vcs_used_in_dir(final_module_path) or { continue }
-		ensure_vcs_is_installed(vcs) or {
+		vcs.is_executable() or {
 			errors++
 			vpm_error(err.msg())
 			continue

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -102,7 +102,14 @@ fn vpm_update_verbose(modules []string) {
 				verbose: true
 			)
 		}
-		resolve_dependencies(mod, install_path, modules)
+		manifest := vmod.from_file(os.join_path(install_path, 'v.mod')) or {
+			errors++
+			vpm_error(err.msg(),
+				verbose: true
+			)
+			continue
+		}
+		resolve_dependencies(manifest.name, manifest.dependencies, modules)
 	}
 	if errors > 0 {
 		exit(1)

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -97,7 +97,6 @@ fn main() {
 			help.print_and_exit('vpm', exit_code: 3)
 		}
 	}
-	println('Completed.')
 }
 
 fn vpm_upgrade() {

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -144,9 +144,7 @@ fn vpm_remove(module_names []string) {
 		final_module_path := get_path_of_existing_module(name) or { continue }
 		println('Removing module "${name}" ...')
 		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
-		os.rmdir_all(final_module_path) or { vpm_error(err.msg(),
-			verbose: true
-		) }
+		os.rmdir_all(final_module_path) or { vpm_error(err.msg(), verbose: true) }
 		// Delete author directory if it is empty.
 		author := name.split('.')[0]
 		author_dir := os.real_path(os.join_path(settings.vmodules_path, author))
@@ -155,9 +153,7 @@ fn vpm_remove(module_names []string) {
 		}
 		if os.is_dir_empty(author_dir) {
 			verbose_println('Removing author folder ${author_dir}')
-			os.rmdir(author_dir) or { vpm_error(err.msg(),
-				verbose: true
-			) }
+			os.rmdir(author_dir) or { vpm_error(err.msg(), verbose: true) }
 		}
 	}
 }

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -140,7 +140,7 @@ fn vpm_remove(module_names []string) {
 		exit(2)
 	}
 	for name in module_names {
-		final_module_path := valid_final_path_of_existing_module(name) or { continue }
+		final_module_path := get_path_of_existing_module(name) or { continue }
 		println('Removing module "${name}" ...')
 		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
 		os.rmdir_all(final_module_path) or { vpm_error(err.msg(),
@@ -161,21 +161,20 @@ fn vpm_remove(module_names []string) {
 	}
 }
 
-fn vpm_show(module_names []string) {
+fn vpm_show(modules []string) {
 	installed_modules := get_installed_modules()
-	for module_name in module_names {
-		if module_name !in installed_modules {
-			module_meta_info := get_module_meta_info(module_name) or { continue }
-			print('
-Name: ${module_meta_info.name}
-Homepage: ${module_meta_info.url}
-Downloads: ${module_meta_info.nr_downloads}
+	for m in modules {
+		if m !in installed_modules {
+			info := get_mod_vpm_info(m) or { continue }
+			print('Name: ${info.name}
+Homepage: ${info.url}
+Downloads: ${info.nr_downloads}
 Installed: False
 --------
 ')
 			continue
 		}
-		path := os.join_path(os.vmodules_dir(), module_name.replace('.', os.path_separator))
+		path := os.join_path(os.vmodules_dir(), m.replace('.', os.path_separator))
 		mod := vmod.from_file(os.join_path(path, 'v.mod')) or { continue }
 		print('Name: ${mod.name}
 Version: ${mod.version}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -97,6 +97,7 @@ fn main() {
 			help.print_and_exit('vpm', exit_code: 3)
 		}
 	}
+	println('Completed.')
 }
 
 fn vpm_upgrade() {


### PR DESCRIPTION
The change updates and extends VPM to install module versions based on git tags.

E.g. when installing modules

```sh
# VPM modules
v install publisher.module@v0.4.0
# From URLs
v install https://github.com/publisher/repository@v1.0.0
```

And when specifying dependencies in a v.mod file

```v
Module {
	// ...
	dependencies: ['publisher.module@v0.6.0', 'https://github.com/publisher/repository@v1.0.0']
}
```

In its current state, the VPM module lacked the foundation for such feature. The PR therefore makes some fundamental updates that also come with additional fixes and performance improvements. The recently added tests and updates can certainly make it easier to wave through a big change like this, but this PR is still a chunk thrown at you as a reviewer.

I suggest it this way because going small steps on the current code would be extremely time-consuming for me as a programmer - to keep things working at every step while trying to make fundamental changes -, it would lead to a flood of PRs and would - bottom line - probably also take up more of your time. So please bare with me.

A short overview of what comes with the changes in this PR.

- parse_query step - used to evaluate the requested modules at the beginning and use `[]Module` arrays that store all data that is needed instead of working with `[]string` arrays for the whole process. This allows to remove some highly coupled parts of code and to reduce redundancy where the same module data was requested from different functions at different stages.
- general cleanups
- fixes vpm can confuse the source of already installed modules, not allowing to install an external module when a vpm version of a module is installed.
- better detects if a module is already installed. This allows to update it in case it is installed and fix unwanted removals.
- extends tests

I still carry a long list of things how vpm can be further improved to achieve a high-quality and tailored product. But none that would require an extensive change like this one, and I would like to continue working on them separately after proposed changes have been resolved.

On further changes that are not as extensive in terms of code changes for the VPM module but also fundamental: I think we should require a `v.mod` file for vpm installations. Just as a `Cargo.toml` is required for rust cargo and a `go.mod` for go modules. At current master it's possible to fetch any git repo with `v install <url>`.