### PR TITLE
vpm: add parse_query

### DIFF
--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -44,7 +44,6 @@ fn test_install_from_vpm_short_ident() {
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
 	assert res.output.contains('Installing module `markdown` from `https://github.com/vlang/markdown`')
-	assert res.output.contains('Relocating module from `vlang/markdown` to `markdown`')
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -55,7 +54,7 @@ fn test_install_from_git_url() {
 
 fn test_install_already_existent() {
 	mut res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('already exists')
+	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -64,7 +63,7 @@ fn test_install_already_existent() {
 	assert mod.dependencies == []string{}
 	// The same module but with the `.git` extension added.
 	os.execute_or_exit('${v} install https://github.com/vlang/markdown.git')
-	assert res.output.contains('already exists')
+	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 }
 
 fn test_install_once() {

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -140,7 +140,7 @@ fn vpm_remove(module_names []string) {
 		exit(2)
 	}
 	for name in module_names {
-		final_module_path := valid_final_path_of_existing_module(name) or { continue }
+		final_module_path := get_path_of_existing_module(name) or { continue }
 		println('Removing module "${name}" ...')
 		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
 		os.rmdir_all(final_module_path) or { vpm_error(err.msg(),
@@ -161,21 +161,20 @@ fn vpm_remove(module_names []string) {
 	}
 }
 
-fn vpm_show(module_names []string) {
+fn vpm_show(modules []string) {
 	installed_modules := get_installed_modules()
-	for module_name in module_names {
-		if module_name !in installed_modules {
-			module_meta_info := get_module_meta_info(module_name) or { continue }
-			print('
-Name: ${module_meta_info.name}
-Homepage: ${module_meta_info.url}
-Downloads: ${module_meta_info.nr_downloads}
+	for m in modules {
+		if m !in installed_modules {
+			info := get_mod_vpm_info(m) or { continue }
+			print('Name: ${info.name}
+Homepage: ${info.url}
+Downloads: ${info.nr_downloads}
 Installed: False
 --------
 ')
 			continue
 		}
-		path := os.join_path(os.vmodules_dir(), module_name.replace('.', os.path_separator))
+		path := os.join_path(os.vmodules_dir(), m.replace('.', os.path_separator))
 		mod := vmod.from_file(os.join_path(path, 'v.mod')) or { continue }
 		print('Name: ${mod.name}
 Version: ${mod.version}


### PR DESCRIPTION
Based on the end result of #19813 we can make it a 3 or 4 part change which can be better monitored. 

This PRs main change:

- Add a parse_query step - to evaluate the requested modules (and versions to use in a followup PR) at the beginning and use []Module arrays that store all data that is needed instead of working with []string arrays for the whole process.

