### PR TITLE
encoding.xml: fix parsing of single letter tag names

### DIFF
--- a/vlib/encoding/xml/parser.v
+++ b/vlib/encoding/xml/parser.v
@@ -534,9 +534,12 @@ fn parse_single_node(first_char u8, mut reader io.Reader) !XMLNode {
 	if ch == `/` {
 		return error('XML node cannot start with "</".')
 	}
-	contents.write_u8(ch)
 
-	for {
+	if ch != `>` {
+		contents.write_u8(ch)
+	}
+
+	for ch != `>` {
 		ch = next_char(mut reader, mut local_buf)!
 		if ch == `>` {
 			break
@@ -547,7 +550,7 @@ fn parse_single_node(first_char u8, mut reader io.Reader) !XMLNode {
 	tag_contents := contents.str().trim_space()
 
 	parts := tag_contents.split_any(' \t\n')
-	name := first_char.ascii_str() + parts[0]
+	name := if parts.len > 0 { first_char.ascii_str() + parts[0] } else { first_char.ascii_str() }
 
 	// Check if it is a self-closing tag
 	if tag_contents.ends_with('/') {

--- a/vlib/encoding/xml/test/local/18_single_letter_tag/shared.xml
+++ b/vlib/encoding/xml/test/local/18_single_letter_tag/shared.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst count="5" uniqueCount="5">
+  <si>
+    <t>Item 1</t>
+  </si>
+  <si>
+    <t>Item 2</t>
+  </si>
+  <si>
+    <t>Item 3</t>
+  </si>
+  <si>
+    <t>Item 4</t>
+  </si>
+  <si>
+    <t>Item 5</t>
+  </si>
+</sst>

--- a/vlib/encoding/xml/test/local/18_single_letter_tag/shared_test.v
+++ b/vlib/encoding/xml/test/local/18_single_letter_tag/shared_test.v
@@ -1,0 +1,68 @@
+module main
+
+import os
+import encoding.xml
+
+fn test_valid_parsing() {
+	path := os.join_path(os.dir(@FILE), 'shared.xml')
+
+	expected := xml.XMLDocument{
+		root: xml.XMLNode{
+			name: 'sst'
+			attributes: {
+				'count':       '5'
+				'uniqueCount': '5'
+			}
+			children: [
+				xml.XMLNode{
+					name: 'si'
+					children: [
+						xml.XMLNode{
+							name: 't'
+							children: ['Item 1']
+						},
+					]
+				},
+				xml.XMLNode{
+					name: 'si'
+					children: [
+						xml.XMLNode{
+							name: 't'
+							children: ['Item 2']
+						},
+					]
+				},
+				xml.XMLNode{
+					name: 'si'
+					children: [
+						xml.XMLNode{
+							name: 't'
+							children: ['Item 3']
+						},
+					]
+				},
+				xml.XMLNode{
+					name: 'si'
+					children: [
+						xml.XMLNode{
+							name: 't'
+							children: ['Item 4']
+						},
+					]
+				},
+				xml.XMLNode{
+					name: 'si'
+					children: [
+						xml.XMLNode{
+							name: 't'
+							children: ['Item 5']
+						},
+					]
+				},
+			]
+		}
+	}
+	actual := xml.XMLDocument.from_file(path)!
+
+	assert expected == actual, 'Parsed XML document should be equal to expected XML document'
+}


### PR DESCRIPTION
If there are single-letter tag names (uncommon, but used in Excel files for example) then the current implementation crashes. This PR fixes this issue and adds a test for it.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f90e769</samp>

This pull request fixes two bugs in the `encoding/xml` module that caused errors when parsing XML tags with single-letter names. It also adds a test function and a test file to verify that the XML parser works correctly with such tags.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f90e769</samp>

* Fix a bug in the XML parser that caused an error when parsing single-letter tag names ([link](https://github.com/vlang/v/pull/19815/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L537-R542), [link](https://github.com/vlang/v/pull/19815/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L550-R553))
* Add a test function that verifies the validity of the XML parser for single-letter tag names ([link](https://github.com/vlang/v/pull/19815/files?diff=unified&w=0#diff-c6ace94a767f22b9aa374305e241222012713526e19b0c19e9d41cd3563230feR1-R68))
* Add a test XML file that contains a single-letter tag name and some nested elements ([link](https://github.com/vlang/v/pull/19815/files?diff=unified&w=0#diff-36a2b6699865b60d2f2b59e60a2ad0f3b10ff77e2fb1566cf0ce738f7665427aR1-R18))
