### PR TITLE
picoev: improve raw mode

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -209,6 +209,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		$if solaris {
 			skip_files << 'examples/gg/gg2.v'
 			skip_files << 'examples/pico/pico.v'
+			skip_files << 'examples/pico/raw_callback.v'
 			skip_files << 'examples/sokol/fonts.v'
 			skip_files << 'examples/sokol/drawing.v'
 		}

--- a/examples/pico/raw_callback.v
+++ b/examples/pico/raw_callback.v
@@ -17,7 +17,7 @@ fn main() {
 	pico.serve()
 }
 
-fn handle_conn(data voidptr, fd int, remove_from_loop fn ()) {
+fn handle_conn(mut pv picoev.Picoev, fd int) {
 	// setup a nonblocking tcp connection
 	mut conn := &net.TcpConn{
 		sock: net.tcp_socket_from_handle_raw(fd)
@@ -34,7 +34,6 @@ fn handle_conn(data voidptr, fd int, remove_from_loop fn ()) {
 
 	conn.write(http_response.bytes()) or { eprintln('could not write response') }
 
-	// remove the socket from picoev's event loop first before closing the connection
-	remove_from_loop()
-	conn.close() or { eprintln('could not close connection') }
+	// remove the socket from picoev's event loop and close the connection
+	pv.close_conn(fd)
 }

--- a/examples/pico/raw_callback.v
+++ b/examples/pico/raw_callback.v
@@ -1,0 +1,40 @@
+module main
+
+import net
+import picoev
+
+const (
+	port          = 8080
+	http_response = 'HTTP/1.1 200 OK\r\nContent-type: text/html\r\nContent-length: 18\r\n\r\nHello from Picoev!'
+)
+
+fn main() {
+	println('Starting webserver on http://localhost:${port}/ ...')
+	mut pico := picoev.new(
+		port: port
+		raw_cb: handle_conn
+	)
+	pico.serve()
+}
+
+fn handle_conn(data voidptr, fd int, remove_from_loop fn ()) {
+	// setup a nonblocking tcp connection
+	mut conn := &net.TcpConn{
+		sock: net.tcp_socket_from_handle_raw(fd)
+		handle: fd
+		is_blocking: false
+	}
+
+	mut buf := []u8{len: 4096}
+	// read data from the tcp connection
+	conn.read(mut buf) or { eprintln('could not read data from socket') }
+
+	println('received data:')
+	println(buf.bytestr())
+
+	conn.write(http_response.bytes()) or { eprintln('could not write response') }
+
+	// remove the socket from picoev's event loop first before closing the connection
+	remove_from_loop()
+	conn.close() or { eprintln('could not close connection') }
+}

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -30,12 +30,10 @@ pub mut:
 
 pub struct Config {
 pub:
-	port   int = 8080
-	cb     fn (voidptr, picohttpparser.Request, mut picohttpparser.Response) = unsafe { nil }
-	err_cb fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError) = default_err_cb
-	// the last argument is a function that removes the current file descriptor
-	// from the event loop
-	raw_cb       fn (voidptr, int, fn ()) = unsafe { nil }
+	port         int = 8080
+	cb           fn (voidptr, picohttpparser.Request, mut picohttpparser.Response) = unsafe { nil }
+	err_cb       fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError) = default_err_cb
+	raw_cb       fn (mut Picoev, int) = unsafe { nil }
 	user_data    voidptr = unsafe { nil }
 	timeout_secs int     = 8
 	max_headers  int     = 100
@@ -45,10 +43,9 @@ pub:
 
 [heap]
 pub struct Picoev {
-	cb        fn (voidptr, picohttpparser.Request, mut picohttpparser.Response) = unsafe { nil }
-	err_cb    fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError) = default_err_cb
-	raw_cb    fn (voidptr, int, fn ()) = unsafe { nil }
-	user_data voidptr = unsafe { nil }
+	cb     fn (voidptr, picohttpparser.Request, mut picohttpparser.Response) = unsafe { nil }
+	err_cb fn (voidptr, picohttpparser.Request, mut picohttpparser.Response, IError) = default_err_cb
+	raw_cb fn (mut Picoev, int) = unsafe { nil }
 
 	timeout_secs int
 	max_headers  int = 100
@@ -65,6 +62,8 @@ mut:
 	out &u8 = unsafe { nil }
 
 	date string
+pub:
+	user_data voidptr = unsafe { nil }
 }
 
 // init fills the `file_descriptors` array
@@ -215,9 +214,7 @@ fn raw_callback(fd int, events int, context voidptr) {
 	} else if events & picoev.picoev_read != 0 {
 		pv.set_timeout(fd, pv.timeout_secs)
 		if !isnil(pv.raw_cb) {
-			pv.raw_cb(pv.user_data, fd, fn [mut pv, fd] () {
-				pv.del(fd)
-			})
+			pv.raw_cb(mut pv, fd)
 			return
 		}
 


### PR DESCRIPTION
Add callback function to picoev's raw callback mode that removes the file descriptor from the event loop. 

Currently if you use the raw mode in picoev the file descriptor only gets removed from the event loop when a timeout occurs.
This pr also adds an example for picoev's raw mode.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e57956</samp>

This pull request enhances the `picoev` module with a new option to remove file descriptors from the event loop. It also adds an example file to demonstrate the usage of this option and updates the testing module to skip this file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e57956</samp>

*  Add a new example file `examples/pico/raw_callback.v` that shows how to use the `raw_cb` option of the `picoev` module ([link](https://github.com/vlang/v/pull/19817/files?diff=unified&w=0#diff-69ca80ab788f0eac0d77a5a1d3385590b955287e63c23c4956b18f5dab07d281R1-R40), [link](https://github.com/vlang/v/pull/19817/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cR212))
*  Modify the `Config` struct of the `picoev` module to include a remove function as a third argument to the `raw_cb` function type, allowing the user to control when to close the connection and free the resources ([link](https://github.com/vlang/v/pull/19817/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL33-R38), [link](https://github.com/vlang/v/pull/19817/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL48-R50))
*  Pass the remove function as a closure to the `raw_cb` function in the `accept_cb` function of the `picoev` module, using the `del` method of the `picoev` instance ([link](https://github.com/vlang/v/pull/19817/files?diff=unified&w=0#diff-adc0159bf9f9b9fb9b3a6cbbd0e026447828931e20d52c58fcc10bcc0daa3b1cL216-R220))
