### PR TITLE
ci: add macos arm64 binary release

### DIFF
--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -38,13 +38,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: linux
-          path: v_linux.zip
+          path: ${{ env.ZIPNAME }}
 
-  build-macos:
+  build-macos-x86_64:
     runs-on: macos-latest
     env:
       CC: clang
-      ZIPNAME: v_macos.zip
+      ZIPNAME: v_macos_x86_64.zip
     steps:
       - uses: actions/checkout@v1
       - name: Compile
@@ -70,7 +70,40 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: macos
-          path: v_macos.zip
+          path: ${{ env.ZIPNAME }}
+  
+  build-macos-arm64:
+    runs-on: macos-latest
+    env:
+      CC: clang
+      CFLAGS: -target arm64-apple-darwin
+      ZIPNAME: v_macos_arm64.zip
+    steps:
+      - uses: actions/checkout@v1
+      - name: Compile
+        run: |
+          make
+          ./v -skip-unused -cc $CC -cflags "$CFLAGS" -prod -o v cmd/v
+          ./v -skip-unused -cc $CC -cflags "$CFLAGS" -prod cmd/tools/vup.v
+          ./v -skip-unused -cc $CC -cflags "$CFLAGS" -prod cmd/tools/vdoctor.v
+      - name: Remove excluded
+        run: |
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+      - name: Create ZIP archive
+        run: |
+           cd ..
+           zip -r9 --symlinks $ZIPNAME v/
+           mv $ZIPNAME v/
+           cd v/
+      - name: Create artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos
+          path: ${{ env.ZIPNAME }}
 
   build-windows:
     runs-on: windows-latest
@@ -110,11 +143,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: windows
-          path: v_windows.zip
+          path: ${{ env.ZIPNAME }}
 
   release:
     name: Create Github Release
-    needs: [build-linux, build-windows, build-macos]
+    needs: [build-linux, build-windows, build-macos-x86_64, build-macos-arm64]
     runs-on: ubuntu-20.04
     steps:
       - name: Get short tag name

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -24,7 +24,7 @@ jobs:
         cd v
         ./v run examples/hello_world.v
 
-  macos:
+  macos-x86_64:
     runs-on: macOS-latest
     timeout-minutes: 5
     steps:
@@ -36,14 +36,18 @@ jobs:
     - name: Download V
       run: |
         tag=${GITHUB_REF##*/}
-        wget https://github.com/vlang/v/releases/download/$tag/v_macos.zip
-        unzip v_macos.zip
+        wget https://github.com/vlang/v/releases/download/$tag/v_macos_x86_64.zip
+        unzip v_macos_x86_64.zip
         cd v
         ./v -version
     - name: Test V
       run: |
         cd v
         ./v run examples/hello_world.v
+
+  # NOTE: we cannot currently test the macos arm64 build without a apple silicon runner
+  # the arm64 release is cross compiled from intel. the apple silicon hosted runner is
+  # only currently available on the macos-latest-xlarge plan, not on the free plans.
 
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fa4d23</samp>

Added support for Apple Silicon in the V binary release process. Refactored and renamed some GitHub Actions workflows and jobs to use consistent zip file names for different macOS architectures.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fa4d23</samp>

*  Rename `build-macos` job to `build-macos-x86_64` and introduce `ZIPNAME` variable to avoid hardcoding zip file names ([link](https://github.com/vlang/v/pull/19823/files?diff=unified&w=0#diff-c92b092593dc68f83b1b0464a99b407491daf14f52639418ad39aeccaee172c1L41-R47))
*  Add `build-macos-arm64` job to cross-compile V binary for Apple Silicon architecture and set `ZIPNAME` to `v_macos_arm64.zip` ([link](https://github.com/vlang/v/pull/19823/files?diff=unified&w=0#diff-c92b092593dc68f83b1b0464a99b407491daf14f52639418ad39aeccaee172c1L73-R106))
*  Update `release` job to depend on `build-macos-arm64` job and use `ZIPNAME` variable for upload-artifact action ([link](https://github.com/vlang/v/pull/19823/files?diff=unified&w=0#diff-c92b092593dc68f83b1b0464a99b407491daf14f52639418ad39aeccaee172c1L113-R150))
*  Rename `macos` job to `macos-x86_64` in `prebuilt.yml` workflow and use `v_macos_x86_64.zip` file name for wget and unzip commands ([link](https://github.com/vlang/v/pull/19823/files?diff=unified&w=0#diff-61facb7ed1e53a51badc3d960214934bb418410b0b7fffcc0d4dfc5172671fdaL27-R27), [link](https://github.com/vlang/v/pull/19823/files?diff=unified&w=0#diff-61facb7ed1e53a51badc3d960214934bb418410b0b7fffcc0d4dfc5172671fdaL39-R40))
*  Add comment to explain why `macos-arm64` job is not included in `prebuilt.yml` workflow ([link](https://github.com/vlang/v/pull/19823/files?diff=unified&w=0#diff-61facb7ed1e53a51badc3d960214934bb418410b0b7fffcc0d4dfc5172671fdaR48-R51))
