### PR TITLE
tools: require v.mod to install external urls via vpm

### DIFF
--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -112,8 +112,8 @@ fn test_missing_repo_name_in_url() {
 }
 
 fn test_missing_vmod_in_url() {
-	assert has_vmod('https://github.com/vlang/v') // main branch == `master`.
-	assert has_vmod('https://github.com/vlang/v') // main branch == `main`.
+	assert has_vmod('https://github.com/vlang/v') // head branch == `master`.
+	assert has_vmod('https://github.com/v-analyzer/v-analyzer') // head branch == `main`.
 	assert !has_vmod('https://github.com/octocat/octocat.github.io') // not a V module.
 	res := os.execute('${v} install https://github.com/octocat/octocat.github.io')
 	assert res.exit_code == 1

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -1,5 +1,7 @@
 // vtest flaky: true
 // vtest retry: 3
+module main
+
 import os
 import v.vmod
 
@@ -107,4 +109,13 @@ fn test_missing_repo_name_in_url() {
 	res := os.execute('${v} install ${incomplete_url}')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`')
+}
+
+fn test_missing_vmod_in_url() {
+	assert has_vmod('https://github.com/vlang/v') // main branch == `master`.
+	assert has_vmod('https://github.com/vlang/v') // main branch == `main`.
+	assert !has_vmod('https://github.com/octocat/octocat.github.io') // not a V module.
+	res := os.execute('${v} install https://github.com/octocat/octocat.github.io')
+	assert res.exit_code == 1
+	assert res.output.contains('failed to find `v.mod` for `https://github.com/octocat/octocat.github.io`'), res.output
 }


### PR DESCRIPTION
At current master, vpm will clone any git module into the vmodules dir when specifying it as URL after the `install` command.

E.g.
```sh
v install https://github.com/octocat/octocat.github.io
```

The change in this PR makes a `v.mod` file a requirement for projects that are installed via an URL.Just as a `Cargo.toml` is required for rust cargo and a go.mod for go modules, though less strict. 

I think it should also be a requirement for modules hosted on vpm.vlang.io. Because eventually it will help to have it, and it will be better to require it sooner than later. But for this it should become requirement when a module is submitted to vpm.vlang.io, and also it should not conflict anymore with commonly used modules. E.g., libsodium, which is installed via vpm in CI, does not have a v.mod file. 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ecbd984</samp>

This pull request improves the `vpm` tool by adding a check for `v.mod` files before installing modules from URLs. It also adds a test case for this feature in `install_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ecbd984</samp>

*  Add a check for `v.mod` file in module URLs ([link](https://github.com/vlang/v/pull/19825/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R59-R62))
*  Implement a new function `has_vmod` that queries the git repository and the manifest URL for a `v.mod` file ([link](https://github.com/vlang/v/pull/19825/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R100-R118))
*  Add the module declaration `module main` to the test file `install_test.v` ([link](https://github.com/vlang/v/pull/19825/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R3-R4))
*  Add a test case for `has_vmod` and `v install` with a URL that lacks a `v.mod` file ([link](https://github.com/vlang/v/pull/19825/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R113-R121))
