### PR TITLE
ast/fmt/parser: fix attribute alignment & remove unneeded code

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -324,7 +324,6 @@ pub:
 	comments         []Comment
 	i                int
 	has_default_expr bool
-	attrs_has_at     bool // TODO: remove in next stage
 	attrs            []Attr
 	is_pub           bool
 	default_val      string

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -145,8 +145,9 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 		f.mark_types_import_as_used(field.typ)
 		attrs_len := inline_attrs_len(field.attrs)
 		has_attrs := field.attrs.len > 0
+		has_at := if has_attrs { field.attrs[0].has_at } else { false }
 		// TODO: this will get removed in next stage
-		if has_attrs && !field.attrs_has_at {
+		if has_attrs && !has_at {
 			f.write(strings.repeat(` `, field_align.max_type_len - field_types[i].len))
 			f.single_line_attrs(field.attrs, same_line: true)
 		}
@@ -168,8 +169,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 				inc_indent = false
 			}
 		}
-		if has_attrs && field.attrs_has_at {
-			// TODO: calculate correct padding
+		if has_attrs && has_at {
+			f.write(strings.repeat(` `, field_align.max_type_len - field_types[i].len))
 			f.single_line_attrs(field.attrs, same_line: true)
 		}
 		// Handle comments after field type

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -295,9 +295,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					has_default_expr = true
 					comments << p.eat_comments()
 				}
-				mut has_at := false // TODO: remove in next stage
 				if p.tok.kind == .at {
-					has_at = true
 					p.inside_struct_attr_decl = true
 					// attrs are stored in `p.attrs`
 					p.attributes()
@@ -318,7 +316,6 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					i: i
 					default_expr: default_expr
 					has_default_expr: has_default_expr
-					attrs_has_at: has_at
 					attrs: p.attrs
 					is_pub: is_embed || is_field_pub
 					is_mut: is_embed || is_field_mut


### PR DESCRIPTION
more fixes on the mission to make the attribute migration (stage 3) PR pass CI 😄 

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e95f0ef</samp>

This pull request refactors the handling of struct fields and attributes in the V compiler. It removes the `attrs_has_at` field from the `Field` struct and uses the `has_at` field of the `Attr` struct instead. This improves the formatting, parsing, and representation of struct fields with attributes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e95f0ef</samp>

*  Remove `attrs_has_at` field from `Field` struct to simplify AST and avoid duplication of information ([link](https://github.com/vlang/v/pull/19826/files?diff=unified&w=0#diff-8e27648d38098f8fe63778c94c11aceb0a48e379121f676d189b04cb2cd8fc45L327), [link](https://github.com/vlang/v/pull/19826/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26L321))
*  Use `has_at` field of first attribute instead of `attrs_has_at` field of field to format struct fields and fix alignment bug ([link](https://github.com/vlang/v/pull/19826/files?diff=unified&w=0#diff-4d3237fc1e8650361e511e94248e3a9f5c7f590eca3dd3fbc845def22d31104bL148-R150), [link](https://github.com/vlang/v/pull/19826/files?diff=unified&w=0#diff-4d3237fc1e8650361e511e94248e3a9f5c7f590eca3dd3fbc845def22d31104bL171-R173))
*  Remove `has_at` variable from `parse_struct_fields` function to simplify parser and avoid duplication of information ([link](https://github.com/vlang/v/pull/19826/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26L298-R298))
