### PR TITLE
encoding.xml: make tag name and attribute parsing more robust and cleaner

### DIFF
--- a/vlib/encoding/xml/test/local/18_single_letter_tag/shared.xml
+++ b/vlib/encoding/xml/test/local/18_single_letter_tag/shared.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sst count="5" uniqueCount="5">
   <si>
-    <t>Item 1</t>
+    <t a="1">Item 1</t>
   </si>
   <si>
     <t>Item 2</t>

--- a/vlib/encoding/xml/test/local/18_single_letter_tag/shared_test.v
+++ b/vlib/encoding/xml/test/local/18_single_letter_tag/shared_test.v
@@ -19,6 +19,9 @@ fn test_valid_parsing() {
 					children: [
 						xml.XMLNode{
 							name: 't'
+							attributes: {
+								'a': '1'
+							}
 							children: ['Item 1']
 						},
 					]


### PR DESCRIPTION
Previously, the first character was treated separately during processing the opening of a tag and its optional attributes. Now, we just add it to the buffer directly and work on it. This simplifies the code _and_ takes care of edge cases.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5582a1d</samp>

This pull request improves the parsing of XML nodes and attributes in `vlib/encoding/xml/parser.v` and adds a test case to verify the correctness of the attribute parsing. It also updates the test XML file to include an attribute in a single-letter node.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5582a1d</samp>

*  Simplify and fix node parsing logic in `parser.v` ([link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L530-R535), [link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L553-R545), [link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L564-R556))
  - Append first character to contents builder and loop until `>` ([link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L530-R535))
  - Use first part of tag contents as name without repeating first character ([link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L553-R545))
  - Use name length as starting index of attribute string without subtracting one ([link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L564-R556))
* Add attribute to `<t>` node in `shared.xml` and update expected map in `shared_test.v` ([link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-36a2b6699865b60d2f2b59e60a2ad0f3b10ff77e2fb1566cf0ce738f7665427aL4-R4), [link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-c6ace94a767f22b9aa374305e241222012713526e19b0c19e9d41cd3563230feR22-R24))
  - Test attribute parsing in single-letter nodes ([link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-36a2b6699865b60d2f2b59e60a2ad0f3b10ff77e2fb1566cf0ce738f7665427aL4-R4), [link](https://github.com/vlang/v/pull/19828/files?diff=unified&w=0#diff-c6ace94a767f22b9aa374305e241222012713526e19b0c19e9d41cd3563230feR22-R24))
