### PR TITLE
checker: fix: missing check when assignment statement lvalue is ParExpr(fix #19819)

### DIFF
--- a/examples/path_tracing.v
+++ b/examples/path_tracing.v
@@ -556,7 +556,9 @@ fn ray_trace(w int, h int, samps int, file_name string, scene_id int) Image {
 							d.mult_s(140.0), d.norm()}, 0, scene_id).mult_s(samps1)
 					}
 					tmp_vec := Vec{clamp(r.x), clamp(r.y), clamp(r.z)}.mult_s(.25)
-					(*ivec) = *ivec + tmp_vec
+					unsafe {
+						(*ivec) = *ivec + tmp_vec
+					}
 				}
 			}
 		}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -266,6 +266,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			}
 		}
 		node.left_types << left_type
+		for left is ast.ParExpr {
+			left = (left as ast.ParExpr).expr
+		}
 		match mut left {
 			ast.Ident {
 				if (is_decl || left.kind == .blank_ident) && left_type.is_ptr()

--- a/vlib/v/checker/tests/invalid_literal_assign_err.out
+++ b/vlib/v/checker/tests/invalid_literal_assign_err.out
@@ -54,9 +54,9 @@ vlib/v/checker/tests/invalid_literal_assign_err.vv:11:2: error: non-name literal
       |     ~~~~~
    12 |     (3 + 3.5) = 4 + 6.4
    13 | }
-vlib/v/checker/tests/invalid_literal_assign_err.vv:12:2: error: non-name literal value `(3 + 3.5)` on left side of `=`
+vlib/v/checker/tests/invalid_literal_assign_err.vv:12:3: error: non-name literal value `3 + 3.5` on left side of `=`
    10 |     true = false
    11 |     3 + 5 = 3 & 4
    12 |     (3 + 3.5) = 4 + 6.4
-      |     ~~~~~~~~~
+      |      ~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/prefix_expr_decl_assign_err.out
+++ b/vlib/v/checker/tests/prefix_expr_decl_assign_err.out
@@ -10,9 +10,15 @@ vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:2:5: error: non-name on the 
       |     ^
     3 |     (*d) := 14
     4 | }
-vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:3:5: error: non-name `(*d)` on left side of `:=`
+vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:3:10: error: modifying variables via dereferencing can only be done in `unsafe` blocks
     1 | fn main() {
     2 |     &a := 12
     3 |     (*d) := 14
-      |     ~~~~
+      |          ~~
+    4 | }
+vlib/v/checker/tests/prefix_expr_decl_assign_err.vv:3:6: error: non-name on the left side of `:=`
+    1 | fn main() {
+    2 |     &a := 12
+    3 |     (*d) := 14
+      |      ^
     4 | }

--- a/vlib/v/checker/tests/unsafe_deref_assign_err.out
+++ b/vlib/v/checker/tests/unsafe_deref_assign_err.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/unsafe_deref_assign_err.vv:4:7: error: modifying variables via dereferencing can only be done in `unsafe` blocks
+    2 | cref := &c
+    3 | 
+    4 | *cref = 1
+      |       ^
+    5 | (*cref) = 1
+vlib/v/checker/tests/unsafe_deref_assign_err.vv:5:9: error: modifying variables via dereferencing can only be done in `unsafe` blocks
+    3 | 
+    4 | *cref = 1
+    5 | (*cref) = 1
+      |         ^

--- a/vlib/v/checker/tests/unsafe_deref_assign_err.vv
+++ b/vlib/v/checker/tests/unsafe_deref_assign_err.vv
@@ -1,0 +1,5 @@
+c := 0
+cref := &c
+
+*cref = 1
+(*cref) = 1

--- a/vlib/v/tests/assign_bitops_with_type_aliases_test.v
+++ b/vlib/v/tests/assign_bitops_with_type_aliases_test.v
@@ -7,8 +7,10 @@ const (
 type SteamId = u64
 
 fn (mut s SteamId) set_id(i u32) {
-	(*s) &= ~steamid_id_mask
-	(*s) |= ((u64(i) << steamid_id_shift) & steamid_id_mask)
+	unsafe {
+		(*s) &= ~steamid_id_mask
+		(*s) |= ((u64(i) << steamid_id_shift) & steamid_id_mask)
+	}
 }
 
 fn test_bitops_work_with_type_aliases() {

--- a/vlib/v/tests/mut_test.v
+++ b/vlib/v/tests/mut_test.v
@@ -25,7 +25,9 @@ fn test_mut() {
 	n := 1
 	mut b := (&n)
 	//
-	(*b) = 10
+	unsafe {
+		(*b) = 10
+	}
 	// mut b := mut a
 	// b = 10
 }


### PR DESCRIPTION
1. Fixed #19819 
2. Add tests.
3. Fixed related tests.

```v
c := 0
cref := &c

*cref = 1
(*cref) = 1
```

outputs:

```
a.v:4:7: error: modifying variables via dereferencing can only be done in `unsafe` blocks
    2 | cref := &c
    3 | 
    4 | *cref = 1
      |       ^
    5 | (*cref) = 1
    6 |
a.v:5:9: error: modifying variables via dereferencing can only be done in `unsafe` blocks
    3 | 
    4 | *cref = 1
    5 | (*cref) = 1
      |         ^
    6 | 
    7 |
```