### PR TITLE
tools: extend vpm to support specifying git version tags when installing modules

### DIFF
--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -50,10 +50,10 @@ fn test_install_dependencies_in_module_dir() {
 	assert v_mod.dependencies == ['markdown', 'pcre', 'https://github.com/spytheman/vtray']
 	// Run `v install`
 	res := os.execute_or_exit('${v} install')
-	assert res.output.contains('Detected v.mod file inside the project directory. Using it...')
-	assert res.output.contains('Installing module `markdown`')
-	assert res.output.contains('Installing module `pcre`')
-	assert res.output.contains('Installing module `vtray`')
+	assert res.output.contains('Detected v.mod file inside the project directory. Using it...'), res.output
+	assert res.output.contains('Installing `markdown`'), res.output
+	assert res.output.contains('Installing `pcre`'), res.output
+	assert res.output.contains('Installing `vtray`'), res.output
 	assert get_mod_name(os.join_path(test_path, 'markdown', 'v.mod')) == 'markdown'
 	assert get_mod_name(os.join_path(test_path, 'pcre', 'v.mod')) == 'pcre'
 	assert get_mod_name(os.join_path(test_path, 'vtray', 'v.mod')) == 'vtray'
@@ -61,9 +61,9 @@ fn test_install_dependencies_in_module_dir() {
 
 fn test_resolve_external_dependencies_during_module_install() {
 	res := os.execute_or_exit('${v} install https://github.com/ttytm/emoji-mart-desktop')
-	assert res.output.contains('Resolving 2 dependencies')
-	assert res.output.contains('Installing module `webview`')
-	assert res.output.contains('Installing module `miniaudio`')
+	assert res.output.contains('Resolving 2 dependencies'), res.output
+	assert res.output.contains('Installing `webview`'), res.output
+	assert res.output.contains('Installing `miniaudio`'), res.output
 	// The external dependencies should have been installed to `<vmodules_dir>/<dependency_name>`
 	assert get_mod_name(os.join_path(test_path, 'webview', 'v.mod')) == 'webview'
 	assert get_mod_name(os.join_path(test_path, 'miniaudio', 'v.mod')) == 'miniaudio'

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -4,6 +4,12 @@ import os
 import v.vmod
 import v.help
 
+enum InstallResult {
+	installed
+	failed
+	skipped
+}
+
 fn vpm_install(query []string) {
 	if settings.is_help {
 		help.print_and_exit('vpm')
@@ -88,8 +94,8 @@ fn vpm_install_from_vpm(modules []Module) {
 		last_errors := errors
 		vcs := if m.vcs != '' {
 			supported_vcs[m.vcs] or {
-				errors++
 				vpm_error('skipping `${m.name}`, since it uses an unsupported version control system `${m.vcs}`.')
+				errors++
 				continue
 			}
 		} else {
@@ -100,18 +106,19 @@ fn vpm_install_from_vpm(modules []Module) {
 			errors++
 			continue
 		}
-		if os.exists(m.install_path) {
-			vpm_update([m.name])
-			continue
-		}
-		m.install(vcs) or {
-			errors++
-			vpm_error(err.msg())
-			continue
+		match m.install(vcs) {
+			.installed {}
+			.failed {
+				errors++
+				continue
+			}
+			.skipped {
+				continue
+			}
 		}
 		increment_module_download_count(m.name) or {
-			errors++
 			vpm_error('failed to increment the download count for `${m.name}`', details: err.msg())
+			errors++
 		}
 		if last_errors == errors {
 			println('Installed `${m.name}`.')
@@ -124,27 +131,27 @@ fn vpm_install_from_vpm(modules []Module) {
 }
 
 fn vpm_install_from_vcs(modules []Module) {
-	mut errors := 0
+	vpm_log(@FILE_LINE, @FN, 'modules: ${modules}')
 	vcs := supported_vcs[settings.vcs]
+	vcs.is_executable() or {
+		vpm_error(err.msg())
+		exit(1)
+	}
 	urls := modules.map(it.url)
+	mut errors := 0
 	for m in modules {
 		vpm_log(@FILE_LINE, @FN, 'module: ${m}')
 		last_errors := errors
-		if os.exists(m.install_path) {
-			vpm_update([m.name])
-			continue
+		match m.install(vcs) {
+			.installed {}
+			.failed {
+				errors++
+				continue
+			}
+			.skipped {
+				continue
+			}
 		}
-		vcs.is_executable() or {
-			vpm_error(err.msg())
-			errors++
-			continue
-		}
-		m.install(vcs) or {
-			errors++
-			vpm_error(err.msg())
-			continue
-		}
-		// Note: increment error count when v.mod becomes mandatory for external modules.
 		manifest := get_manifest(m.install_path) or { continue }
 		final_path := os.real_path(os.join_path(settings.vmodules_path, manifest.name.replace('-',
 			'_').to_lower()))
@@ -201,13 +208,57 @@ fn vpm_install_from_vcs(modules []Module) {
 	}
 }
 
-fn (m Module) install(vcs &VCS) ! {
-	cmd := '${vcs.cmd} ${vcs.args.install} "${m.url}" "${m.install_path}"'
+fn (m Module) install(vcs &VCS) InstallResult {
+	if m.is_installed {
+		// Case: installed, but not an explicit version. Update instead of continuing the installation.
+		if m.version == '' && m.installed_version == '' {
+			vpm_update([if m.is_external { m.url } else { m.name }])
+			return .skipped
+		}
+		// Case: installed, but conflicting. Confirmation or -[-f]orce flag required.
+		if settings.is_force || m.confirm_install() {
+			m.remove() or {
+				vpm_error('failed to remove `${m.name}`.', details: err.msg())
+				return .failed
+			}
+		} else {
+			return .skipped
+		}
+	}
+	install_arg := if m.version != '' {
+		'${vcs.args.install} --single-branch -b ${m.version}'
+	} else {
+		vcs.args.install
+	}
+	cmd := '${vcs.cmd} ${install_arg} "${m.url}" "${m.install_path}"'
 	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
-	println('Installing module `${m.name}` from `${m.url}` to `${m.install_path}` ...')
-	os.execute_opt(cmd) or {
-		vpm_log(@FILE_LINE, @FN, 'cmd output: ${err}')
-		return error('failed to install module `${m.name}` to `${m.install_path}`.')
+	println('Installing `${m.name}`...')
+	verbose_println('  cloning from `${m.url}` to `${m.install_path}`')
+	res := os.execute_opt(cmd) or {
+		vpm_error('failed to install `${m.name}`.', details: err.msg())
+		return .failed
+	}
+	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output}')
+	return .installed
+}
+
+fn (m Module) confirm_install() bool {
+	if m.installed_version == m.version {
+		println('Module `${m.name}${at_version(m.installed_version)}` is already installed, use --force to overwrite.')
+		return false
+	} else {
+		install_version := at_version(if m.version == '' { 'latest' } else { m.version })
+		println('Module `${m.name}${at_version(m.installed_version)}` is already installed at `${m.install_path}`.')
+		input := os.input('Replace it with `${m.name}${install_version}`? [Y/n]: ')
+		match input.to_lower() {
+			'', 'y' {
+				return true
+			}
+			else {
+				verbose_println('Skipping `${m.name}`.')
+				return false
+			}
+		}
 	}
 }
 
@@ -219,4 +270,8 @@ fn (m Module) remove() ! {
 		os.rmdir_all(m.install_path)!
 	}
 	verbose_println('Removed `${m.name}`.')
+}
+
+fn at_version(version string) string {
+	return if version != '' { '@${version}' } else { '' }
 }

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -24,7 +24,7 @@ fn testsuite_end() {
 
 fn test_install_from_vpm_ident() {
 	res := os.execute_or_exit('${v} install nedpals.args')
-	assert res.output.contains('Skipping download count increment for `nedpals.args`.')
+	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -45,7 +45,7 @@ fn test_install_from_vpm_short_ident() {
 
 fn test_install_from_git_url() {
 	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
-	assert res.output.contains('Installing module `markdown` from `https://github.com/vlang/markdown`')
+	assert res.output.contains('Installing `markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -86,7 +86,7 @@ fn test_install_once() {
 	install_cmd := '${@VEXE} install https://github.com/vlang/markdown https://github.com/vlang/pcre --once -v'
 	// Try installing two modules, one of which is already installed.
 	mut res := os.execute_or_exit(install_cmd)
-	assert res.output.contains("Already installed modules: ['markdown']")
+	assert res.output.contains("Already installed modules: ['markdown']"), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -99,7 +99,7 @@ fn test_install_once() {
 
 	// Try installing two modules that are both already installed.
 	res = os.execute_or_exit(install_cmd)
-	assert res.output.contains('All modules are already installed.')
+	assert res.output.contains('All modules are already installed.'), res.output
 	assert md_last_modified == os.file_last_mod_unix(os.join_path(test_path, 'markdown',
 		'v.mod'))
 }
@@ -108,13 +108,13 @@ fn test_missing_repo_name_in_url() {
 	incomplete_url := 'https://github.com/vlang'
 	res := os.execute('${v} install ${incomplete_url}')
 	assert res.exit_code == 1
-	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`')
+	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`'), res.output
 }
 
 fn test_missing_vmod_in_url() {
-	assert has_vmod('https://github.com/vlang/v') // head branch == `master`.
-	assert has_vmod('https://github.com/v-analyzer/v-analyzer') // head branch == `main`.
-	assert !has_vmod('https://github.com/octocat/octocat.github.io') // not a V module.
+	assert has_vmod('https://github.com/vlang/v', '') // head branch == `master`.
+	assert has_vmod('https://github.com/v-analyzer/v-analyzer', '') // head branch == `main`.
+	assert !has_vmod('https://github.com/octocat/octocat.github.io', '') // not a V module.
 	res := os.execute('${v} install https://github.com/octocat/octocat.github.io')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to find `v.mod` for `https://github.com/octocat/octocat.github.io`'), res.output

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -1,0 +1,95 @@
+// vtest flaky: true
+// vtest retry: 3
+module main
+
+import os
+import v.vmod
+
+const (
+	v         = os.quoted_path(@VEXE)
+	test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test')
+)
+
+fn testsuite_begin() {
+	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_DEBUG', '', true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
+fn get_mod_name_and_version(path string) (string, string) {
+	mod := vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
+		eprintln(err)
+		return '', ''
+	}
+	return mod.name, mod.version
+}
+
+fn test_install_from_vpm_with_git_version_tag() {
+	ident := 'ttytm.webview'
+	mut tag := 'v0.6.0'
+	mut res := os.execute_or_exit('${v} install ${ident}@${tag}')
+	assert res.output.contains('Installing `${ident}`'), res.output
+	assert res.output.contains('Installed `${ident}`'), res.output
+	mut name, mut version := get_mod_name_and_version(os.join_path('ttytm', 'webview'))
+	assert name == 'webview'
+	assert version == '0.6.0'
+	// Install same version without force flag.
+	res = os.execute_or_exit('${v} install ${ident}@${tag}')
+	assert res.output.contains('Module `${ident}@${tag}` is already installed, use --force to overwrite'), res.output
+	// Install another version, add force flag to surpass confirmation.
+	tag = 'v0.5.0'
+	res = os.execute_or_exit('${v} install -f ${ident}@${tag}')
+	assert res.output.contains('Installed `${ident}`'), res.output
+	name, version = get_mod_name_and_version(os.join_path('ttytm', 'webview'))
+	assert name == 'webview'
+	assert version == '0.5.0'
+	// Install invalid version.
+	tag = '6.0'
+	res = os.execute('${v} install -f ${ident}@${tag}')
+	assert res.exit_code == 1
+	assert res.output.contains('failed to install `${ident}`'), res.output
+	// Install invalid version verbose.
+	res = os.execute('${v} install -f -v ${ident}@${tag}')
+	assert res.exit_code == 1
+	assert res.output.contains('failed to install `${ident}`'), res.output
+	assert res.output.contains('Remote branch 6.0 not found in upstream origin'), res.output
+	// Install without version tag after a version was installed
+	res = os.execute_or_exit('${v} install -f ${ident}')
+	assert res.output.contains('Installing `${ident}`'), res.output
+	// Re-install latest version (without a tag). Should trigger an update, force should not be required.
+	res = os.execute_or_exit('${v} install ${ident}')
+	assert res.output.contains('Updating module `${ident}`'), res.output
+}
+
+fn test_install_from_url_with_git_version_tag() {
+	url := 'https://github.com/vlang/vsl'
+	mut tag := 'v0.1.50'
+	mut res := os.execute_or_exit('v install ${url}@${tag}')
+	assert res.output.contains('Installing `vsl`'), res.output
+	assert res.output.contains('Installed `vsl`'), res.output
+	mut name, mut version := get_mod_name_and_version('vsl')
+	assert name == 'vsl'
+	assert version == '0.1.50'
+	// Install same version without force flag.
+	res = os.execute_or_exit('${v} install ${url}@${tag}')
+	assert res.output.contains('Module `vsl@${tag}` is already installed, use --force to overwrite'), res.output
+	// Install another version, add force flag to surpass confirmation.
+	tag = 'v0.1.47'
+	res = os.execute_or_exit('${v} install -f ${url}@${tag}')
+	assert res.output.contains('Installed `vsl`'), res.output
+	name, version = get_mod_name_and_version('vsl')
+	assert name == 'vsl'
+	assert version == '0.1.47'
+	// Install invalid version.
+	tag = 'abc'
+	res = os.execute('${v} install -f ${url}@${tag}')
+	assert res.exit_code == 1
+	// Install invalid version verbose.
+	res = os.execute('${v} install -f -v ${url}@${tag}')
+	assert res.exit_code == 1
+	assert res.output.contains('Remote branch abc not found in upstream origin'), res.output
+}

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -9,6 +9,7 @@ mut:
 	is_help               bool
 	is_once               bool
 	is_verbose            bool
+	is_force              bool
 	server_urls           []string
 	vcs                   string
 	vmodules_path         string
@@ -26,6 +27,7 @@ fn init_settings() VpmSettings {
 		is_help: '-h' in opts || '--help' in opts || 'help' in cmds
 		is_once: '--once' in opts
 		is_verbose: '-v' in opts
+		is_force: '-f' in opts || '--force' in opts
 		vcs: if '--hg' in opts { 'hg' } else { 'git' }
 		server_urls: cmdline.options(args, '--server-urls')
 		vmodules_path: os.vmodules_dir()


### PR DESCRIPTION
The change updates and extends VPM to install module versions based on git tags.

E.g. when installing modules

```sh
# VPM modules
v install publisher.module@v0.4.0
# From URLs
v install https://github.com/publisher/repository@v1.0.0
```

And when specifying dependencies in a v.mod file

```v
Module {
	// ...
	dependencies: ['publisher.module@v0.6.0', 'https://github.com/publisher/repository@v1.0.0']
}
```

Will also create the base for some great followup features.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc08098</samp>

This pull request enhances the `vpm` tool with new features and tests for installing modules from various sources. It adds a new `is_force` option, a new `is_external` field, and a new `InstallResult` enum to improve the logic and user interface of the `v install` command. It also adds output assertions and version tag support to the existing and new test functions in `dependency_test.v`, `install_test.v`, and `install_version_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc08098</samp>

*  Add a new field `is_external` to the `Module` struct and use it to simplify the logic of installing modules from external URLs or VPM identifiers ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R22), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L51-R52), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L59-R59), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L66-R67), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L88-R89))
*  Add a new enum `InstallResult` and use it to handle different outcomes of installing a module, such as `installed`, `failed`, or `skipped` ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cR7-R12), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL103-R121), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL204-R264))
*  Add a new method `confirm_install` to the `Module` struct and a new function `at_version` to prompt the user to confirm the installation of a module if it is already installed with a different version ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cR274-R277))
*  Add a new field `is_force` to the `Settings` struct and use it to allow the user to overwrite the existing installation of a module without confirmation ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR12), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR30))
*  Modify the `has_vmod` function to take an `install_path` parameter and skip fetching the remote repository if the module is already installed and has a `v.mod` file ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L100-R105), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L111-R117))
*  Modify the `vpm_install_from_vcs` function to check the VCS executable once and print the modules array for debugging ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL127-R154))
*  Modify the `install` method of the `Module` struct to print more verbose messages and handle specifying the version tag ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL204-R264))
*  Modify the expected output of the `v install` command in the `test_install_from_git_url` function to reflect the changes in the `install` method of the `Module` struct ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L48-R48))
*  Add assertions to check the output of the `v install` command in various test functions ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L53-R56), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L64-R66), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L27-R27), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L89-R89), [link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L102-R102))
*  Add a new file `install_version_test.v` with two new test functions to test the functionality of installing modules with specific version tags from VPM identifiers or external URLs ([link](https://github.com/vlang/v/pull/19835/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38R1-R95))
