### PR TITLE
net: use char types that resemble C API of mbedtls more closely

### DIFF
--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -144,6 +144,15 @@ pub struct C.mbedtls_ssl_context {}
 [typedef]
 pub struct C.mbedtls_ssl_config {}
 
+[typedef]
+pub struct C.mbedtls_ssl_send_t {}
+
+[typedef]
+pub struct C.mbedtls_ssl_recv_t {}
+
+[typedef]
+pub struct C.mbedtls_ssl_recv_timeout_t {}
+
 fn C.mbedtls_net_init(&C.mbedtls_net_context)
 fn C.mbedtls_ssl_init(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_config_init(&C.mbedtls_ssl_config)
@@ -151,7 +160,8 @@ fn C.mbedtls_pk_init(&C.mbedtls_pk_context)
 fn C.mbedtls_x509_crt_init(&C.mbedtls_x509_crt)
 fn C.mbedtls_ctr_drbg_init(&C.mbedtls_ctr_drbg_context)
 fn C.mbedtls_entropy_init(&C.mbedtls_entropy_context)
-fn C.mbedtls_ctr_drbg_seed(&C.mbedtls_ctr_drbg_context, voidptr, &C.mbedtls_entropy_context, &char, int) int
+fn C.mbedtls_entropy_func(voidptr, &u8, usize)
+fn C.mbedtls_ctr_drbg_seed(&C.mbedtls_ctr_drbg_context, fn (voidptr, &u8, usize), voidptr, &u8, usize) int
 
 fn C.mbedtls_net_free(&C.mbedtls_net_context)
 fn C.mbedtls_ssl_free(&C.mbedtls_ssl_context)
@@ -163,33 +173,34 @@ fn C.mbedtls_entropy_free(&C.mbedtls_entropy_context)
 
 fn C.mbedtls_ssl_config_defaults(&C.mbedtls_ssl_config, int, int, int) int
 
-fn C.mbedtls_x509_crt_parse(&C.mbedtls_x509_crt, &u8, int) int
-fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, int, &char, int, voidptr, voidptr) int
+fn C.mbedtls_x509_crt_parse(&C.mbedtls_x509_crt, &u8, usize) int
+fn C.mbedtls_ctr_drbg_random(voidptr, &u8, usize) int
+fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, usize, &u8, usize, fn (voidptr, &u8, usize) int, voidptr) int
 fn C.mbedtls_x509_crt_parse_file(&C.mbedtls_x509_crt, &char) int
-fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, voidptr, voidptr) int
+fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, fn (voidptr, &u8, usize) int, voidptr) int
 
 fn C.mbedtls_net_connect(&C.mbedtls_net_context, &char, &char, int) int
 
-fn C.mbedtls_net_bind(&C.mbedtls_net_context, voidptr, &char, int) int
-fn C.mbedtls_net_accept(&C.mbedtls_net_context, &C.mbedtls_net_context, voidptr, int, voidptr) int
+fn C.mbedtls_net_bind(&C.mbedtls_net_context, &char, &char, int) int
+fn C.mbedtls_net_accept(&C.mbedtls_net_context, &C.mbedtls_net_context, voidptr, usize, &usize) int
 fn C.mbedtls_ssl_session_reset(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
 
 fn C.mbedtls_ssl_conf_own_cert(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_pk_context) int
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
 fn C.mbedtls_ssl_conf_ca_chain(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_x509_crl)
-fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, voidptr, &C.mbedtls_ctr_drbg_context)
+fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, fn(voidptr, &u8, usize) int, &C.mbedtls_ctr_drbg_context)
 
 fn C.mbedtls_ssl_setup(&C.mbedtls_ssl_context, &C.mbedtls_ssl_config) int
 
 fn C.mbedtls_ssl_set_hostname(&C.mbedtls_ssl_context, &char) int
 
-fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, voidptr, voidptr, voidptr)
+fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, &C.mbedtls_ssl_send_t, &C.mbedtls_ssl_recv_t, &C.mbedtls_ssl_recv_timeout_t)
 
 fn C.mbedtls_ssl_handshake(&C.mbedtls_ssl_context) int
 
-fn C.mbedtls_ssl_read(&C.mbedtls_ssl_context, &u8, int) int
-fn C.mbedtls_ssl_write(&C.mbedtls_ssl_context, &u8, int) int
+fn C.mbedtls_ssl_read(&C.mbedtls_ssl_context, &u8, usize) int
+fn C.mbedtls_ssl_write(&C.mbedtls_ssl_context, &u8, usize) int
 
 fn C.mbedtls_high_level_strerr(int) &char
 

--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -163,7 +163,7 @@ fn C.mbedtls_ssl_init(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_setup(&C.mbedtls_ssl_context, &C.mbedtls_ssl_config) int
 fn C.mbedtls_ssl_session_reset(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
-fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, fn(voidptr, &u8, usize) int, &C.mbedtls_ctr_drbg_context)
+fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, fn (voidptr, &u8, usize) int, &C.mbedtls_ctr_drbg_context)
 fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, &C.mbedtls_ssl_send_t, &C.mbedtls_ssl_recv_t, &C.mbedtls_ssl_recv_timeout_t)
 fn C.mbedtls_ssl_conf_own_cert(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_pk_context) int
 fn C.mbedtls_ssl_conf_ca_chain(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_x509_crl)

--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -163,14 +163,14 @@ fn C.mbedtls_entropy_free(&C.mbedtls_entropy_context)
 
 fn C.mbedtls_ssl_config_defaults(&C.mbedtls_ssl_config, int, int, int) int
 
-fn C.mbedtls_x509_crt_parse(&C.mbedtls_x509_crt, &char, int) int
-fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &char, int, &char, int, voidptr, voidptr) int
+fn C.mbedtls_x509_crt_parse(&C.mbedtls_x509_crt, &u8, int) int
+fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, int, &char, int, voidptr, voidptr) int
 fn C.mbedtls_x509_crt_parse_file(&C.mbedtls_x509_crt, &char) int
 fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, voidptr, voidptr) int
 
-fn C.mbedtls_net_connect(&C.mbedtls_net_context, &u8, &u8, int) int
+fn C.mbedtls_net_connect(&C.mbedtls_net_context, &char, &char, int) int
 
-fn C.mbedtls_net_bind(&C.mbedtls_net_context, voidptr, &u8, int) int
+fn C.mbedtls_net_bind(&C.mbedtls_net_context, voidptr, &char, int) int
 fn C.mbedtls_net_accept(&C.mbedtls_net_context, &C.mbedtls_net_context, voidptr, int, voidptr) int
 fn C.mbedtls_ssl_session_reset(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
@@ -188,8 +188,8 @@ fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, voidptr
 
 fn C.mbedtls_ssl_handshake(&C.mbedtls_ssl_context) int
 
-fn C.mbedtls_ssl_read(&C.mbedtls_ssl_context, &char, int) int
-fn C.mbedtls_ssl_write(&C.mbedtls_ssl_context, &char, int) int
+fn C.mbedtls_ssl_read(&C.mbedtls_ssl_context, &u8, int) int
+fn C.mbedtls_ssl_write(&C.mbedtls_ssl_context, &u8, int) int
 
 fn C.mbedtls_high_level_strerr(int) &char
 

--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -124,21 +124,6 @@ mut:
 }
 
 [typedef]
-pub struct C.mbedtls_x509_crt {}
-
-[typedef]
-pub struct C.mbedtls_x509_crl {}
-
-[typedef]
-pub struct C.mbedtls_pk_context {}
-
-[typedef]
-pub struct C.mbedtls_entropy_context {}
-
-[typedef]
-pub struct C.mbedtls_ctr_drbg_context {}
-
-[typedef]
 pub struct C.mbedtls_ssl_context {}
 
 [typedef]
@@ -153,54 +138,62 @@ pub struct C.mbedtls_ssl_recv_t {}
 [typedef]
 pub struct C.mbedtls_ssl_recv_timeout_t {}
 
+[typedef]
+pub struct C.mbedtls_pk_context {}
+
+[typedef]
+pub struct C.mbedtls_ctr_drbg_context {}
+
+[typedef]
+pub struct C.mbedtls_entropy_context {}
+
+[typedef]
+pub struct C.mbedtls_x509_crt {}
+
+[typedef]
+pub struct C.mbedtls_x509_crl {}
+
 fn C.mbedtls_net_init(&C.mbedtls_net_context)
-fn C.mbedtls_ssl_init(&C.mbedtls_ssl_context)
-fn C.mbedtls_ssl_config_init(&C.mbedtls_ssl_config)
-fn C.mbedtls_pk_init(&C.mbedtls_pk_context)
-fn C.mbedtls_x509_crt_init(&C.mbedtls_x509_crt)
-fn C.mbedtls_ctr_drbg_init(&C.mbedtls_ctr_drbg_context)
-fn C.mbedtls_entropy_init(&C.mbedtls_entropy_context)
-fn C.mbedtls_entropy_func(voidptr, &u8, usize)
-fn C.mbedtls_ctr_drbg_seed(&C.mbedtls_ctr_drbg_context, fn (voidptr, &u8, usize), voidptr, &u8, usize) int
-
-fn C.mbedtls_net_free(&C.mbedtls_net_context)
-fn C.mbedtls_ssl_free(&C.mbedtls_ssl_context)
-fn C.mbedtls_ssl_config_free(&C.mbedtls_ssl_config)
-fn C.mbedtls_pk_free(&C.mbedtls_pk_context)
-fn C.mbedtls_x509_crt_free(&C.mbedtls_x509_crt)
-fn C.mbedtls_ctr_drbg_free(&C.mbedtls_ctr_drbg_context)
-fn C.mbedtls_entropy_free(&C.mbedtls_entropy_context)
-
-fn C.mbedtls_ssl_config_defaults(&C.mbedtls_ssl_config, int, int, int) int
-
-fn C.mbedtls_x509_crt_parse(&C.mbedtls_x509_crt, &u8, usize) int
-fn C.mbedtls_ctr_drbg_random(voidptr, &u8, usize) int
-fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, usize, &u8, usize, fn (voidptr, &u8, usize) int, voidptr) int
-fn C.mbedtls_x509_crt_parse_file(&C.mbedtls_x509_crt, &char) int
-fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, fn (voidptr, &u8, usize) int, voidptr) int
-
 fn C.mbedtls_net_connect(&C.mbedtls_net_context, &char, &char, int) int
-
 fn C.mbedtls_net_bind(&C.mbedtls_net_context, &char, &char, int) int
 fn C.mbedtls_net_accept(&C.mbedtls_net_context, &C.mbedtls_net_context, voidptr, usize, &usize) int
+fn C.mbedtls_net_free(&C.mbedtls_net_context)
+
+fn C.mbedtls_ssl_init(&C.mbedtls_ssl_context)
+fn C.mbedtls_ssl_setup(&C.mbedtls_ssl_context, &C.mbedtls_ssl_config) int
 fn C.mbedtls_ssl_session_reset(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
-
-fn C.mbedtls_ssl_conf_own_cert(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_pk_context) int
-fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
-fn C.mbedtls_ssl_conf_ca_chain(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_x509_crl)
 fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, fn(voidptr, &u8, usize) int, &C.mbedtls_ctr_drbg_context)
-
-fn C.mbedtls_ssl_setup(&C.mbedtls_ssl_context, &C.mbedtls_ssl_config) int
-
-fn C.mbedtls_ssl_set_hostname(&C.mbedtls_ssl_context, &char) int
-
 fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, &C.mbedtls_ssl_send_t, &C.mbedtls_ssl_recv_t, &C.mbedtls_ssl_recv_timeout_t)
-
+fn C.mbedtls_ssl_conf_own_cert(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_pk_context) int
+fn C.mbedtls_ssl_conf_ca_chain(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_x509_crl)
+fn C.mbedtls_ssl_set_hostname(&C.mbedtls_ssl_context, &char) int
 fn C.mbedtls_ssl_handshake(&C.mbedtls_ssl_context) int
-
 fn C.mbedtls_ssl_read(&C.mbedtls_ssl_context, &u8, usize) int
 fn C.mbedtls_ssl_write(&C.mbedtls_ssl_context, &u8, usize) int
+fn C.mbedtls_ssl_free(&C.mbedtls_ssl_context)
+fn C.mbedtls_ssl_config_init(&C.mbedtls_ssl_config)
+fn C.mbedtls_ssl_config_defaults(&C.mbedtls_ssl_config, int, int, int) int
+fn C.mbedtls_ssl_config_free(&C.mbedtls_ssl_config)
+
+fn C.mbedtls_pk_init(&C.mbedtls_pk_context)
+fn C.mbedtls_pk_free(&C.mbedtls_pk_context)
+fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, usize, &u8, usize, fn (voidptr, &u8, usize) int, voidptr) int
+fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, fn (voidptr, &u8, usize) int, voidptr) int
+
+fn C.mbedtls_ctr_drbg_init(&C.mbedtls_ctr_drbg_context)
+fn C.mbedtls_ctr_drbg_seed(&C.mbedtls_ctr_drbg_context, fn (voidptr, &u8, usize), voidptr, &u8, usize) int
+fn C.mbedtls_ctr_drbg_free(&C.mbedtls_ctr_drbg_context)
+fn C.mbedtls_ctr_drbg_random(voidptr, &u8, usize) int
+
+fn C.mbedtls_entropy_init(&C.mbedtls_entropy_context)
+fn C.mbedtls_entropy_free(&C.mbedtls_entropy_context)
+fn C.mbedtls_entropy_func(voidptr, &u8, usize)
+
+fn C.mbedtls_x509_crt_init(&C.mbedtls_x509_crt)
+fn C.mbedtls_x509_crt_free(&C.mbedtls_x509_crt)
+fn C.mbedtls_x509_crt_parse(&C.mbedtls_x509_crt, &u8, usize) int
+fn C.mbedtls_x509_crt_parse_file(&C.mbedtls_x509_crt, &char) int
 
 fn C.mbedtls_high_level_strerr(int) &char
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 707357f</samp>

Updated the net/mbedtls module to use `&u8` instead of `&char` for byte parameters. This avoids unnecessary casting and aligns with V's byte type.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 707357f</samp>

* Change the function signatures of `mbedtls_x509_crt_parse`, `mbedtls_pk_parse_key`, `mbedtls_net_connect`, `mbedtls_ssl_read`, and `mbedtls_ssl_write` to use `&u8` instead of `&char` for byte array parameters ([link](https://github.com/vlang/v/pull/19837/files?diff=unified&w=0#diff-6828a7c399d5b4ebf8e0aac08553a8d209eb79f527e80163bc0095880e38b0daL166-R173), [link](https://github.com/vlang/v/pull/19837/files?diff=unified&w=0#diff-6828a7c399d5b4ebf8e0aac08553a8d209eb79f527e80163bc0095880e38b0daL191-R192)). This improves the compatibility and correctness of the V bindings for the mbedtls C library in `vlib/net/mbedtls/mbedtls.c.v`.
