### PR TITLE
json: fix recursive pointer encoding

### DIFF
--- a/vlib/json/json_encode_recursive_ptr_test.v
+++ b/vlib/json/json_encode_recursive_ptr_test.v
@@ -1,0 +1,19 @@
+import json
+
+struct PostTag {
+	id         string
+	parent     ?&PostTag
+	visibility string
+	created_at string    [json: 'createdAt']
+	metadata   string    [raw]
+}
+
+fn test_main() {
+	new_post_tag := PostTag{}
+	assert json.encode(new_post_tag) == '{"id":"","visibility":"","createdAt":"","metadata":""}'
+
+	new_post_tag2 := PostTag{
+		parent: new_post_tag
+	}
+	assert json.encode(new_post_tag2) == '{"id":"","parent":{"id":"","visibility":"","createdAt":"","metadata":""},"visibility":"","createdAt":"","metadata":""}'
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -58,7 +58,7 @@ fn (mut g Gen) gen_jsons() {
 
 		mut init_styp := '${styp} res'
 		if utyp.has_flag(.option) {
-			if sym.kind == .struct_ {
+			if sym.kind == .struct_ && !utyp.is_ptr() {
 				init_styp += ' = '
 				g.set_current_pos_as_last_stmt_pos()
 				pos := g.out.len
@@ -634,7 +634,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				dec.writeln('\telse')
 				dec.writeln('\t\t_option_ok(&(${base_typ}[]) {  tos5(cJSON_PrintUnformatted(js_get(root, "${name}"))) }, &${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 			} else {
-				dec.writeln('\tres${op}${c_name(field.name)} = tos5(cJSON_PrintUnformatted(' +
+				dec.writeln(
+					'\t${prefix}${op}${c_name(field.name)} = tos5(cJSON_PrintUnformatted(' +
 					'js_get(root, "${name}")));')
 			}
 		} else {


### PR DESCRIPTION
Fix #19812

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fff005f</samp>

This pull request fixes and tests the JSON encoding and decoding of structs with optional and recursive pointer fields in `vlib/v/gen/c/json.v` and `vlib/json`. It adds a type check, removes a variable prefix, and creates a new test file `vlib/json/json_encode_recursive_ptr_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fff005f</samp>

*  Fix JSON encoding and decoding of structs with recursive pointer fields ([link](https://github.com/vlang/v/pull/19840/files?diff=unified&w=0#diff-0f8fe5f54791bb459ff936012aecd924a0a95158ee885a2a1684324814b09ff7R1-R19), [link](https://github.com/vlang/v/pull/19840/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L61-R61), [link](https://github.com/vlang/v/pull/19840/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L637-R638))
  - Add a test file `vlib/json/json_encode_recursive_ptr_test.v` that checks the JSON encoding of a struct with a recursive pointer field of type `?&PostTag` ([link](https://github.com/vlang/v/pull/19840/files?diff=unified&w=0#diff-0f8fe5f54791bb459ff936012aecd924a0a95158ee885a2a1684324814b09ff7R1-R19))
  - Modify the code generation in `vlib/v/gen/c/json.v` to handle optional fields with pointer types differently from non-pointer types ([link](https://github.com/vlang/v/pull/19840/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L61-R61))
  - Refactor the code generation in `vlib/v/gen/c/json.v` to remove the unnecessary `res` prefix from the variable name that holds the decoded value of the optional field ([link](https://github.com/vlang/v/pull/19840/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L637-R638))
