### PR TITLE
parser: fix invalid warning 'unused' for mut var in if/match cond(fix#19539)

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -37,6 +37,9 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 		.key_mut, .key_shared, .key_atomic, .key_static, .key_volatile {
 			ident := p.ident(ast.Language.v)
 			node = ident
+			if p.peek_tok.kind != .assign && (p.inside_if_cond || p.inside_match) {
+				p.mark_var_as_used(ident.name)
+			}
 			p.add_defer_var(ident)
 			p.is_stmt_ident = is_stmt_ident
 		}


### PR DESCRIPTION
Fixed #19539 

```v
struct Foo {
	value int = 0xf00
}

struct Bar {}

type FooBar = Bar | Foo

fn main() {
	mut foobar := FooBar(Bar{})
	match mut foobar {
		Foo {
			println('foo')
		}
		else {
			println('bar')
		}
	}
}
```
```v
struct Foo {
	value int = 0xf00
}

struct Bar {}

type FooBar = Bar | Foo

fn main() {
	mut foobar := FooBar(Bar{})
	if mut foobar is Foo {
		println('foo')
	} else {
		println('bar')
	}
}
``` 
Invalid warnings have been removed.