### PR TITLE
tools: use expansion character/string to format home paths in vpm output

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -156,7 +156,7 @@ fn vpm_install_from_vcs(modules []Module) {
 		final_path := os.real_path(os.join_path(settings.vmodules_path, manifest.name.replace('-',
 			'_').to_lower()))
 		if m.install_path != final_path {
-			verbose_println('Relocating `${m.name} (${m.install_path})` to `${manifest.name} (${final_path})`...')
+			verbose_println('Relocating `${m.name} (${m.install_path_fmted})` to `${manifest.name} (${final_path})`...')
 			if os.exists(final_path) {
 				println('Target directory for `${m.name} (${final_path})` already exists.')
 				input := os.input('Replace it with the module directory? [Y/n]: ')
@@ -233,7 +233,7 @@ fn (m Module) install(vcs &VCS) InstallResult {
 	cmd := '${vcs.cmd} ${install_arg} "${m.url}" "${m.install_path}"'
 	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
 	println('Installing `${m.name}`...')
-	verbose_println('  cloning from `${m.url}` to `${m.install_path}`')
+	verbose_println('  cloning from `${m.url}` to `${m.install_path_fmted}`')
 	res := os.execute_opt(cmd) or {
 		vpm_error('failed to install `${m.name}`.', details: err.msg())
 		return .failed
@@ -248,7 +248,7 @@ fn (m Module) confirm_install() bool {
 		return false
 	} else {
 		install_version := at_version(if m.version == '' { 'latest' } else { m.version })
-		println('Module `${m.name}${at_version(m.installed_version)}` is already installed at `${m.install_path}`.')
+		println('Module `${m.name}${at_version(m.installed_version)}` is already installed at `${m.install_path_fmted}`.')
 		input := os.input('Replace it with `${m.name}${install_version}`? [Y/n]: ')
 		match input.to_lower() {
 			'', 'y' {
@@ -263,7 +263,7 @@ fn (m Module) confirm_install() bool {
 }
 
 fn (m Module) remove() ! {
-	verbose_println('Removing `${m.name}` from `${m.install_path}`...')
+	verbose_println('Removing `${m.name}` from `${m.install_path_fmted}`...')
 	$if windows {
 		os.execute_opt('rd /s /q ${m.install_path}')!
 	} $else {

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -40,7 +40,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 	}
 	name := get_name_from_url(result.name) or { result.name }
 	result.final_path = get_path_of_existing_module(result.name) or { return result }
-	println('Updating module `${name}` in `${result.final_path}` ...')
+	println('Updating module `${name}` in `${fmt_mod_path(result.final_path)}` ...')
 	vcs := vcs_used_in_dir(result.final_path) or { return result }
 	vcs.is_executable() or {
 		result.has_err = true
@@ -67,7 +67,7 @@ fn vpm_update_verbose(modules []string) {
 	for mod in modules {
 		name := get_name_from_url(mod) or { mod }
 		install_path := get_path_of_existing_module(mod) or { continue }
-		println('Updating module `${name}` in `${install_path}` ...')
+		println('Updating module `${name}` in `${fmt_mod_path(install_path)}` ...')
 		vcs := vcs_used_in_dir(install_path) or { continue }
 		vcs.is_executable() or {
 			errors++


### PR DESCRIPTION
E.g.
```sh
# On Lin/mac
Updating `sdl` in `/home/username/.vmodules/sdl`
# would become
Updating `sdl` in `~/.vmodules/sdl`

# On Windows
Updating `sdl` in `C:\Users\username\.vmodules\sdl`
# would become
Updating `sdl` in `%USERPROFILE%\.vmodules\sdl`
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eca32a9</samp>

Improved the output and user experience of `vpm` by adding formatted paths, colors, alignment, and progress indicators. Modified the `Module` struct and several functions in `cmd/tools/vpm/common.v`, `cmd/tools/vpm/install.v`, and `cmd/tools/vpm/update.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eca32a9</samp>

*  Add a new field `install_path_fmted` to the `Module` struct to store a formatted version of the vmodules install path ([link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L19-R24), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R70), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L77-R87))
* Define a new constant `home_dir` to store the result of `os.home_dir()` function and avoid repeated calls ([link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R48-R49))
* Define a new function `fmt_mod_path` to format the vmodules install path by replacing the home directory with a tilde or an environment variable depending on the OS ([link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R423-R434))
* Use the `install_path_fmted` field instead of the `install_path` field in the output messages of the `relocate`, `install`, `remove`, and `update` functions in `install.v` and `update.v` to make the output more user-friendly and consistent ([link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL159-R159), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL236-R236), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL251-R251), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL266-R266), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L43-R43), [link](https://github.com/vlang/v/pull/19847/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L70-R70))
