### PR TITLE
tools: support `--verbose` in vpm, as an alternative to `-v`, to enable verbose output

### DIFF
--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -26,7 +26,7 @@ fn init_settings() VpmSettings {
 	return VpmSettings{
 		is_help: '-h' in opts || '--help' in opts || 'help' in cmds
 		is_once: '--once' in opts
-		is_verbose: '-v' in opts
+		is_verbose: '-v' in opts || '--verbose' in opts
 		is_force: '-f' in opts || '--force' in opts
 		vcs: if '--hg' in opts { 'hg' } else { 'git' }
 		server_urls: cmdline.options(args, '--server-urls')


### PR DESCRIPTION



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28235e3</samp>

Improved the verbose option of `vpm` by allowing both short and long forms. Updated the `is_verbose` field of the `Settings` struct in `cmd/tools/vpm/settings.v` to reflect this change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28235e3</samp>

* Allow both `-v` and `--verbose` as valid options for enabling verbose output in vpm ([link](https://github.com/vlang/v/pull/19848/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL29-R29))
