### PR TITLE
add a reopen method to log

### DIFF
--- a/vlib/log/file_log_test.v
+++ b/vlib/log/file_log_test.v
@@ -1,0 +1,37 @@
+import os
+import log
+import rand
+
+fn test_reopen() {
+	lfolder := os.join_path(os.vtmp_dir(), rand.ulid())
+	lpath1 := os.join_path(lfolder, 'current.log')
+	lpath2 := os.join_path(lfolder, 'current.log.2')
+	os.mkdir_all(lfolder)!
+
+	dump(lfolder)
+	mut l := log.new_thread_safe_log()
+	l.set_full_logpath(lpath1)
+	l.warn('one warning')
+	l.error('one error')
+	os.mv(lpath1, lpath2)!
+	l.warn('another warning')
+	l.flush()
+	l.reopen()!
+	l.warn('third warning')
+	l.flush()
+	// os.system('ls -la $lpath1 $lpath2')
+	l.close()
+	lcontent1 := os.read_file(lpath1)!
+	lcontent2 := os.read_file(lpath2)!
+	assert lcontent1.len > 0
+	assert lcontent2.len > 0
+	// the rotated log should have all messages before the l.reopen() call:
+	assert lcontent2.contains('one warning')
+	assert lcontent2.contains('one error')
+	assert lcontent2.contains('another warning')
+	// the log file that was reopened, should have only the new message:
+	assert lcontent1.contains('third warning')
+	assert !lcontent1.contains('one warning')
+
+	os.rmdir_all(lfolder) or {}
+}

--- a/vlib/log/file_log_test.v
+++ b/vlib/log/file_log_test.v
@@ -13,14 +13,15 @@ fn test_reopen() {
 	l.set_full_logpath(lpath1)
 	l.warn('one warning')
 	l.error('one error')
+	// simulate a log rotation, by moving the log file
 	os.mv(lpath1, lpath2)!
 	l.warn('another warning')
-	l.flush()
+	// call reopen, note that the message from above, should be in the new file lpath2:
 	l.reopen()!
 	l.warn('third warning')
 	l.flush()
-	// os.system('ls -la $lpath1 $lpath2')
 	l.close()
+	// os.system('ls -la $lpath1 $lpath2')
 	lcontent1 := os.read_file(lpath1)!
 	lcontent2 := os.read_file(lpath2)!
 	assert lcontent1.len > 0

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -83,6 +83,7 @@ pub fn (mut l Log) close() {
 // reopen reopens the log file.  Useful for log rotation.
 // This does nothing if you are only writing to the console.
 pub fn (mut l Log) reopen() ! {
+	l.flush()
 	if l.output_target == .file || l.output_target == .both {
 		l.ofile.reopen(l.output_file_name, 'ab') or {
 			return error_with_code('re-opening log file `${l.output_file_name}` for appending failed',

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -82,10 +82,11 @@ pub fn (mut l Log) close() {
 
 // reopen reopens the log file.  Useful for log rotation.
 // This does nothing if you are only writing to the console.
-pub fn (mut l Log) reopen() {
+pub fn (mut l Log) reopen() ! {
 	if l.output_target == .file || l.output_target == .both {
 		l.ofile.reopen(l.output_file_name, 'ab') or {
-			panic('error while re-opening log file ${l.output_file_name} for appending')
+			return error_with_code('re-opening log file `${l.output_file_name}` for appending failed',
+				1)
 		}
 	}
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -80,6 +80,16 @@ pub fn (mut l Log) close() {
 	l.ofile.close()
 }
 
+// reopen reopens the log file.  Useful for log rotation.
+// This does nothing if you are only writing to the console.
+pub fn (mut l Log) reopen() {
+	if l.output_target == .file || l.output_target == .both {
+		l.ofile.reopen(l.output_file_name, 'ab') or {
+			panic('error while re-opening log file ${l.output_file_name} for appending')
+		}
+	}
+}
+
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
 	timestamp := time.now().format_ss_micro()

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -80,7 +80,7 @@ pub fn (mut l Log) close() {
 	l.ofile.close()
 }
 
-// reopen reopens the log file.  Useful for log rotation.
+// reopen reopens the log file. Useful for log rotation.
 // This does nothing if you are only writing to the console.
 pub fn (mut l Log) reopen() ! {
 	l.flush()


### PR DESCRIPTION
log: add a reopen method to the Log structure.

When rotating log files, one common procedure is to rename the existing log file and then send a HUP signal to the program generating the log.  The signal handler then re-opens the log file causing new log records to go to the newly reopened file.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7745b43</samp>

Add `reopen` method to `Log` struct to support log rotation for file output. This method allows the log file to be renamed and archived without losing any log messages.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7745b43</samp>

* Add a `reopen` method to the `Log` struct to support log rotation ([link](https://github.com/vlang/v/pull/19854/files?diff=unified&w=0#diff-b1b4f998e69f626c035e84a2dd3fd9338ee2cda88f3f506ef019982fb2e9f210R83-R92))
