### PR TITLE
checker: fix blank_ident as param of lambda exprs(fix #19853)

### DIFF
--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -129,8 +129,10 @@ pub fn (mut c Checker) lambda_expr_fix_type_of_param(mut node ast.LambdaExpr, mu
 			v.expr = ast.empty_expr
 		}
 	}
-	c.ident(mut pident)
-	pident.obj.typ = ptype
+	if pident.kind != .blank_ident {
+		c.ident(mut pident)
+		pident.obj.typ = ptype
+	}
 }
 
 pub fn (mut c Checker) support_lambda_expr_in_sort(param_type ast.Type, return_type ast.Type, mut expr ast.LambdaExpr) {

--- a/vlib/v/tests/lambda_expr_test.v
+++ b/vlib/v/tests/lambda_expr_test.v
@@ -45,3 +45,12 @@ fn test_fn_with_callback_called_with_lambda_expression() {
 	}) == 'a: 10, b: 20'
 	assert doit(100, 200, |a, b| 'a: ${a}, b: ${b}') == 'a: 100, b: 200'
 }
+
+// for test params has blank_ident
+fn f4(g fn (int) string) {
+	assert g(0) == 'hello'
+}
+
+fn test_params_has_blank_ident() {
+	f4(|_| 'hello')
+}


### PR DESCRIPTION
1. Fixed #19853 
2. Add tests.

```v
fn f(g fn (int) string) {
    println('function returned: ${g(42)}')
}

fn main() {
    f(|_| 'hello world')
}
```

outputs:
```
function returned: hello world