### PR TITLE
ast, checker, cgen: a minor cleanup

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1362,6 +1362,12 @@ pub fn (t &Table) is_sumtype_or_in_variant(parent Type, typ Type) bool {
 	return t.sumtype_has_variant(parent, typ, false)
 }
 
+[inline]
+pub fn (t &Table) is_interface_var(var ScopeObject) bool {
+	return var is Var && var.orig_type != 0 && t.sym(var.orig_type).kind == .interface_
+		&& t.sym(var.smartcasts.last()).kind != .interface_
+}
+
 // only used for debugging V compiler type bugs
 pub fn (t &Table) known_type_names() []string {
 	mut res := []string{cap: t.type_idxs.len}
@@ -2332,6 +2338,12 @@ pub fn (t &Table) is_comptime_type(x Type, y ComptimeType) bool {
 			return x.has_flag(.option)
 		}
 	}
+}
+
+[inline]
+pub fn (t &Table) is_comptime_var(node Expr) bool {
+	return node is Ident && node.info is IdentVar && node.obj is Var
+		&& (node.obj as Var).ct_type_var != .no_comptime
 }
 
 pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1562,7 +1562,8 @@ fn (mut c Checker) get_comptime_args(func ast.Fn, node_ ast.CallExpr, concrete_t
 						comptime_args[i] = comptime_args[i].set_nr_muls(0)
 					}
 				}
-			} else if call_arg.expr is ast.ComptimeSelector && c.is_comptime_var(call_arg.expr) {
+			} else if call_arg.expr is ast.ComptimeSelector
+				&& c.table.is_comptime_var(call_arg.expr) {
 				comptime_args[i] = c.get_comptime_var_type(call_arg.expr)
 			}
 		}

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -73,7 +73,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		node.scope.update_var_type(node.val_var, node.val_type)
 	} else {
 		mut is_comptime := false
-		if (node.cond is ast.Ident && c.is_comptime_var(node.cond))
+		if (node.cond is ast.Ident && c.table.is_comptime_var(node.cond))
 			|| node.cond is ast.ComptimeSelector {
 			ctyp := c.get_comptime_var_type(node.cond)
 			if ctyp != ast.void_type {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -76,12 +76,12 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 						ret_type = expr_type
 						if expr_type.is_ptr() {
 							if stmt.expr is ast.Ident && stmt.expr.obj is ast.Var
-								&& c.is_interface_var(stmt.expr.obj) {
+								&& c.table.is_interface_var(stmt.expr.obj) {
 								ret_type = expr_type.deref()
 							} else if mut stmt.expr is ast.PrefixExpr
 								&& stmt.expr.right is ast.Ident {
 								ident := stmt.expr.right as ast.Ident
-								if ident.obj is ast.Var && c.is_interface_var(ident.obj) {
+								if ident.obj is ast.Var && c.table.is_interface_var(ident.obj) {
 									ret_type = expr_type.deref()
 								}
 							}

--- a/vlib/v/checker/postfix.v
+++ b/vlib/v/checker/postfix.v
@@ -24,7 +24,7 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 	}
 	if !(typ_sym.is_number() || ((c.inside_unsafe || c.pref.translated) && is_non_void_pointer)) {
 		if c.inside_comptime_for_field {
-			if c.is_comptime_var(node.expr) || node.expr is ast.ComptimeSelector {
+			if c.table.is_comptime_var(node.expr) || node.expr is ast.ComptimeSelector {
 				node.typ = c.unwrap_generic(c.get_comptime_var_type(node.expr))
 				if node.op == .question {
 					node.typ = node.typ.clear_flag(.option)

--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -45,7 +45,7 @@ fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Type {
 	c.inside_casting_to_str = true
 	for i, mut expr in node.exprs {
 		mut ftyp := c.expr(mut expr)
-		if c.is_comptime_var(expr) {
+		if c.table.is_comptime_var(expr) {
 			ctyp := c.get_comptime_var_type(expr)
 			if ctyp != ast.void_type {
 				ftyp = ctyp
@@ -78,7 +78,8 @@ fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Type {
 					c.error('no known default format for type `${c.table.get_type_name(ftyp)}`',
 						node.fmt_poss[i])
 				}
-			} else if c.is_comptime_var(expr) && c.get_comptime_var_type(expr) != ast.void_type {
+			} else if c.table.is_comptime_var(expr)
+				&& c.get_comptime_var_type(expr) != ast.void_type {
 				// still `_` placeholder for comptime variable without specifier
 				node.need_fmts[i] = false
 			} else {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -538,7 +538,8 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 		}
 		ast.CastExpr {
 			// value.map(Type(it)) when `value` is a comptime var
-			if expr.expr is ast.Ident && node.left is ast.Ident && g.is_comptime_var(node.left) {
+			if expr.expr is ast.Ident && node.left is ast.Ident
+				&& g.table.is_comptime_var(node.left) {
 				ctyp := g.get_comptime_var_type(node.left)
 				if ctyp != ast.void_type {
 					expr.expr_type = g.table.value_type(ctyp)

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -235,7 +235,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				}
 			}
 			if mut left.obj is ast.Var {
-				if val is ast.Ident && g.is_comptime_var(val) {
+				if val is ast.Ident && g.table.is_comptime_var(val) {
 					ctyp := g.unwrap_generic(g.get_comptime_var_type(val))
 					if ctyp != ast.void_type {
 						var_type = ctyp

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3414,7 +3414,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				if mut node.expr is ast.ComptimeSelector && node.expr.left is ast.Ident {
 					// val.$(field.name)?
 					expr_str = '${node.expr.left.str()}.${g.comptime_for_field_value.name}'
-				} else if mut node.expr is ast.Ident && g.is_comptime_var(node.expr) {
+				} else if mut node.expr is ast.Ident && g.table.is_comptime_var(node.expr) {
 					// val?
 					expr_str = node.expr.name
 				}
@@ -4330,12 +4330,6 @@ pub fn (mut g Gen) is_generic_param_var(node ast.Expr) bool {
 		&& (node.obj as ast.Var).ct_type_var == .generic_param
 }
 
-[inline]
-pub fn (mut g Gen) is_comptime_var(node ast.Expr) bool {
-	return node is ast.Ident && node.info is ast.IdentVar && node.obj is ast.Var
-		&& (node.obj as ast.Var).ct_type_var != .no_comptime
-}
-
 fn (mut g Gen) get_const_name(node ast.Ident) string {
 	if g.pref.translated && !g.is_builtin_mod
 		&& !util.module_is_builtin(node.name.all_before_last('.')) {
@@ -4347,12 +4341,6 @@ fn (mut g Gen) get_const_name(node ast.Ident) string {
 	} else {
 		return '_const_' + g.get_ternary_name(c_name(node.name))
 	}
-}
-
-[inline]
-fn (mut g Gen) is_interface_var(var ast.ScopeObject) bool {
-	return var is ast.Var && var.orig_type != 0 && g.table.sym(var.orig_type).kind == .interface_
-		&& g.table.sym(var.smartcasts.last()).kind != .interface_
 }
 
 fn (mut g Gen) ident(node ast.Ident) {
@@ -4491,7 +4479,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 						g.write('(')
 						if obj_sym.kind == .sum_type && !is_auto_heap {
 							g.write('*')
-						} else if g.inside_casting_to_str && g.is_interface_var(node.obj) {
+						} else if g.inside_casting_to_str && g.table.is_interface_var(node.obj) {
 							g.write('*')
 						}
 					}
@@ -4572,7 +4560,8 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 	node_typ := g.unwrap_generic(node.typ)
 	mut expr_type := node.expr_type
 	sym := g.table.sym(node_typ)
-	if (node.expr is ast.Ident && g.is_comptime_var(node.expr)) || node.expr is ast.ComptimeSelector {
+	if (node.expr is ast.Ident && g.table.is_comptime_var(node.expr))
+		|| node.expr is ast.ComptimeSelector {
 		expr_type = g.unwrap_generic(g.get_comptime_var_type(node.expr))
 	}
 	if sym.kind in [.sum_type, .interface_] {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -788,7 +788,7 @@ fn (mut g Gen) get_comptime_var_type(node ast.Expr) ast.Type {
 }
 
 fn (mut g Gen) resolve_comptime_type(node ast.Expr, default_type ast.Type) ast.Type {
-	if (node is ast.Ident && g.is_comptime_var(node)) || node is ast.ComptimeSelector {
+	if (node is ast.Ident && g.table.is_comptime_var(node)) || node is ast.ComptimeSelector {
 		return g.get_comptime_var_type(node)
 	} else if node is ast.SelectorExpr && node.expr_type != 0 {
 		sym := g.table.sym(g.unwrap_generic(node.expr_type))

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -37,7 +37,8 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 				}
 			}
 		}
-	} else if node.expr is ast.Ident && g.inside_comptime_for_field && g.is_comptime_var(node.expr) {
+	} else if node.expr is ast.Ident && g.inside_comptime_for_field
+		&& g.table.is_comptime_var(node.expr) {
 		expr_type = g.get_comptime_var_type(node.expr)
 		name = g.typ(g.unwrap_generic(expr_type.clear_flags(.shared_f, .result))).replace('*',
 			'')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1657,13 +1657,14 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	// Handle `print(x)`
 	mut print_auto_str := false
 	if is_print && (node.args[0].typ != ast.string_type
-		|| g.comptime_for_method.len > 0 || g.is_comptime_var(node.args[0].expr)) {
+		|| g.comptime_for_method.len > 0
+		|| g.table.is_comptime_var(node.args[0].expr)) {
 		g.inside_casting_to_str = true
 		defer {
 			g.inside_casting_to_str = false
 		}
 		mut typ := node.args[0].typ
-		if g.is_comptime_var(node.args[0].expr) {
+		if g.table.is_comptime_var(node.args[0].expr) {
 			ctyp := g.get_comptime_var_type(node.args[0].expr)
 			if ctyp != ast.void_type {
 				typ = ctyp

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -141,7 +141,8 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 	mut node := unsafe { node_ }
 	mut is_comptime := false
 
-	if (node.cond is ast.Ident && g.is_comptime_var(node.cond)) || node.cond is ast.ComptimeSelector {
+	if (node.cond is ast.Ident && g.table.is_comptime_var(node.cond))
+		|| node.cond is ast.ComptimeSelector {
 		mut unwrapped_typ := g.unwrap_generic(node.cond_type)
 		ctyp := g.get_comptime_var_type(node.cond)
 		if ctyp != ast.void_type {
@@ -220,7 +221,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		mut val_sym := g.table.sym(node.val_type)
 		op_field := g.dot_or_ptr(node.cond_type)
 
-		if is_comptime && g.is_comptime_var(node.cond) {
+		if is_comptime && g.table.is_comptime_var(node.cond) {
 			mut unwrapped_typ := g.unwrap_generic(node.cond_type)
 			ctyp := g.unwrap_generic(g.get_comptime_var_type(node.cond))
 			if ctyp != ast.void_type {

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -235,11 +235,11 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 				mut stmt := branch.stmts.last()
 				if mut stmt is ast.ExprStmt {
 					if mut stmt.expr is ast.Ident && stmt.expr.obj is ast.Var
-						&& g.is_interface_var(stmt.expr.obj) {
+						&& g.table.is_interface_var(stmt.expr.obj) {
 						g.inside_casting_to_str = true
 					} else if mut stmt.expr is ast.PrefixExpr && stmt.expr.right is ast.Ident {
 						ident := stmt.expr.right as ast.Ident
-						if ident.obj is ast.Var && g.is_interface_var(ident.obj) {
+						if ident.obj is ast.Var && g.table.is_interface_var(ident.obj) {
 							g.inside_casting_to_str = true
 						}
 					}

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -244,7 +244,7 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 	mut node_ := unsafe { node }
 	mut fmts := node_.fmts.clone()
 	for i, mut expr in node_.exprs {
-		if g.is_comptime_var(expr) {
+		if g.table.is_comptime_var(expr) {
 			ctyp := g.get_comptime_var_type(expr)
 			if ctyp != ast.void_type {
 				node_.expr_types[i] = ctyp


### PR DESCRIPTION
A minor cleanup:

Extract is_interface_var(), is_comptime_var() methods from cgen, checker to ast.table