### PR TITLE
tools: skip download count  increment when vpm runs in CI by default

### DIFF
--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -15,11 +15,7 @@ const (
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 	os.setenv('VPM_DEBUG', '', true)
-	// Skipping download count increment should be the default if vpm runs in CI.
-	// Don't set `VPM_NO_INCREMENT` to test this behavior. `CI` is always true in GH CI runs.
-	if os.getenv('CI') == '' {
-		os.setenv('VPM_NO_INCREMENT', '1', true)
-	}
+	os.setenv('VPM_NO_INCREMENT', '1', true)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -15,7 +15,11 @@ const (
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 	os.setenv('VPM_DEBUG', '', true)
-	os.setenv('VPM_NO_INCREMENT', '1', true)
+	// Skipping download count increment should be the default if vpm runs in CI.
+	// Don't set `VPM_NO_INCREMENT` to test this behavior. `CI` is always true in GH CI runs.
+	if os.getenv('CI') == '' {
+		os.setenv('VPM_NO_INCREMENT', '1', true)
+	}
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -23,6 +23,7 @@ fn init_settings() VpmSettings {
 	if os.getenv('VPM_DEBUG') != '' {
 		log.set_level(.debug)
 	}
+	no_inc_env := os.getenv('VPM_NO_INCREMENT')
 	return VpmSettings{
 		is_help: '-h' in opts || '--help' in opts || 'help' in cmds
 		is_once: '--once' in opts
@@ -31,6 +32,6 @@ fn init_settings() VpmSettings {
 		vcs: if '--hg' in opts { 'hg' } else { 'git' }
 		server_urls: cmdline.options(args, '--server-urls')
 		vmodules_path: os.vmodules_dir()
-		no_dl_count_increment: os.getenv('VPM_NO_INCREMENT') != ''
+		no_dl_count_increment: os.getenv('CI') != '' || (no_inc_env != '' && no_inc_env != '0')
 	}
 }


### PR DESCRIPTION
This PR would make VPM skip incrementing the download count of modules the deafult behavior when they are installed in CI.

To explicitly enable incrementing, `VPM_NO_INCREMENT=0` can be set. 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34bbfc2</samp>

This pull request enhances the vpm tool by adding a feature to prevent incrementing the download count of modules when vpm runs in a CI environment or when `VPM_NO_INCREMENT` is set. It also updates the `install_test.v` file to test this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34bbfc2</samp>

*  Implement logic to prevent vpm from incrementing download count of modules in CI environment or if `VPM_NO_INCREMENT` is set ([link](https://github.com/vlang/v/pull/19861/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L18-R22), [link](https://github.com/vlang/v/pull/19861/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR26), [link](https://github.com/vlang/v/pull/19861/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL34-R35))
  - Modify `install_test.v` to conditionally set `VPM_NO_INCREMENT` based on `CI` value ([link](https://github.com/vlang/v/pull/19861/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L18-R22))
  - Add `no_inc_env` variable to `settings.v` to store `VPM_NO_INCREMENT` value ([link](https://github.com/vlang/v/pull/19861/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR26))
  - Use `no_inc_env` and `CI` value to set `no_dl_count_increment` field in `Settings` struct ([link](https://github.com/vlang/v/pull/19861/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL34-R35))
