### PR TITLE
Checker: change `more than 1000 possibilities in match range` to notice

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -281,7 +281,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				if both_low_and_high_are_known {
 					high_low_cutoff := 1000
 					if high - low > high_low_cutoff {
-						c.warn('more than ${high_low_cutoff} possibilities (${low} ... ${high}) in match range',
+						c.note('more than ${high_low_cutoff} possibilities (${low} ... ${high}) in match range may affect compile time',
 							branch.pos)
 					}
 					for i in low .. high + 1 {


### PR DESCRIPTION
because it is not user's fault but compiler's. it shouldn't be an error with `-prod`



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6eca41</samp>

Changed the warning level and wording of a match range message in `vlib/v/checker/match.v` to better inform the user about the compile time impact of large ranges.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e6eca41</samp>

* Change the warning message for a large match range to a note message, and clarify the impact on compile time ([link](https://github.com/vlang/v/pull/19862/files?diff=unified&w=0#diff-b3e9e13d82c234e7953e95b8321dd2f6475a017c1985da21bb49dc46898962bfL284-R284))
