### PR TITLE
tools: don't interrupt resolving deps when a module failed updating, improve detecting invalid, add update_test

### DIFF
--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -26,11 +26,16 @@ fn vpm_update(query []string) {
 	}
 	mut pp := pool.new_pool_processor(callback: update_module)
 	pp.work_on_items(modules)
+	mut errors := 0
 	for res in pp.get_results[ModUpdateInfo]() {
 		if res.has_err {
-			exit(1)
+			errors++
+			continue
 		}
 		resolve_dependencies(get_manifest(res.final_path), modules)
+	}
+	if errors > 0 {
+		exit(1)
 	}
 }
 

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -44,9 +44,17 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &ModUpdateInfo {
 		name: pp.get_item[string](idx)
 	}
 	name := get_name_from_url(result.name) or { result.name }
-	result.final_path = get_path_of_existing_module(result.name) or { return result }
+	result.final_path = get_path_of_existing_module(result.name) or {
+		vpm_error('failed to find path for `${name}`.', verbose: true)
+		result.has_err = true
+		return result
+	}
 	println('Updating module `${name}` in `${fmt_mod_path(result.final_path)}` ...')
-	vcs := vcs_used_in_dir(result.final_path) or { return result }
+	vcs := vcs_used_in_dir(result.final_path) or {
+		vpm_error('failed to find version control system for `${name}`.', verbose: true)
+		result.has_err = true
+		return result
+	}
 	vcs.is_executable() or {
 		result.has_err = true
 		vpm_error(err.msg())

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -1,0 +1,46 @@
+import os
+
+const (
+	v         = os.quoted_path(@VEXE)
+	test_path = os.join_path(os.vtmp_dir(), 'vpm_update_test')
+)
+
+fn testsuite_begin() {
+	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_DEBUG', '', true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
+// Tests if `v update` detects installed modules and runs successfully.
+fn test_update() {
+	os.execute_or_exit('${v} install pcre')
+	os.execute_or_exit('${v} install nedpals.args')
+	os.execute_or_exit('${v} install https://github.com/spytheman/vtray')
+	res := os.execute_opt('${v} update') or { panic(err) }
+	assert res.output.contains('Updating module `pcre`'), res.output
+	assert res.output.contains('Updating module `nedpals.args`'), res.output
+	assert res.output.contains('Updating module `vtray`'), res.output
+	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
+	assert res.output.contains('Skipping download count increment for `pcre`.'), res.output
+}
+
+fn test_update_idents() {
+	mut res := os.execute_or_exit('${v} update pcre')
+	assert res.output.contains('Updating module `pcre`'), res.output
+	res = os.execute_or_exit('${v} update nedpals.args vtray')
+	assert res.output.contains('Updating module `vtray`'), res.output
+	assert res.output.contains('Updating module `nedpals.args`'), res.output
+	// Try update not installed.
+	res = os.execute('${v} update vsl')
+	assert res.exit_code == 1
+	assert res.output.contains('failed to find `vsl`'), res.output
+	// Try update mixed.
+	res = os.execute('${v} update pcre vsl')
+	assert res.exit_code == 1
+	assert res.output.contains('Updating module `pcre`'), res.output
+	assert res.output.contains('failed to find `vsl`'), res.output
+}

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -1,3 +1,5 @@
+// vtest flaky: true
+// vtest retry: 3
 import os
 
 const (


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e0c077</samp>

This pull request enhances the `vpm` tool by improving its error handling and feedback for updating modules, and by adding unit tests for the `update` function in `cmd/tools/vpm/update_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e0c077</samp>

* Add unit tests for the `update` function in `cmd/tools/vpm/update_test.v` ([link](https://github.com/vlang/v/pull/19867/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeR1-R46))
* Improve error handling and reporting in the `update` function ([link](https://github.com/vlang/v/pull/19867/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L29-R39), [link](https://github.com/vlang/v/pull/19867/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L42-R57))
  - Count errors and exit with code 1 only if any ([link](https://github.com/vlang/v/pull/19867/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L29-R39))
  - Display error messages and set `has_err` flag when `update_module` fails to find module path or vcs ([link](https://github.com/vlang/v/pull/19867/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L42-R57))
* Use temporary directory and disable download count increment for testing ([link](https://github.com/vlang/v/pull/19867/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeR1-R46))
