### PR TITLE
parser: fix generic fn call with fixed array argument (fix #19863)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2416,8 +2416,8 @@ fn (p &Parser) is_generic_call() bool {
 	}
 
 	if kind2 == .lsbr {
-		// case 1
-		return tok3.kind == .rsbr
+		// case 1 (array or fixed array type)
+		return tok3.kind == .rsbr || (tok4.kind == .rsbr && p.is_typename(tok5))
 	}
 
 	if kind2 == .name {

--- a/vlib/v/tests/generics_call_with_fixed_array_arg_test.v
+++ b/vlib/v/tests/generics_call_with_fixed_array_arg_test.v
@@ -1,0 +1,21 @@
+fn generic[T](t T) string {
+	return '${t}'
+}
+
+fn test_generic_call_with_fixed_array_arg() {
+	r1 := generic[[3]int]([1, 2, 3]!)
+	println(r1)
+	assert r1 == '[1, 2, 3]'
+
+	r2 := generic[[]int]([1, 2, 3])
+	println(r2)
+	assert r2 == '[1, 2, 3]'
+
+	r3 := generic[int](22)
+	println(r3)
+	assert r3 == '22'
+
+	r4 := generic[bool](true)
+	println(r4)
+	assert r4 == 'true'
+}


### PR DESCRIPTION
This PR fix generic fn call with fixed array argument (fix #19863).

- Fix generic fn call with fixed array argument.
- Add test.

```v
fn generic[T](t T) string {
	return '${t}'
}

fn main() {
	r1 := generic[[3]int]([1, 2, 3]!)
	println(r1)
	assert r1 == '[1, 2, 3]'

	r2 := generic[[]int]([1, 2, 3])
	println(r2)
	assert r2 == '[1, 2, 3]'

	r3 := generic[int](22)
	println(r3)
	assert r3 == '22'

	r4 := generic[bool](true)
	println(r4)
	assert r4 == 'true'
}

PS D:\Test\v\tt1> v run .
[1, 2, 3]
[1, 2, 3]
22
true
```