### PR TITLE
os: add fast path to mkdir_all

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -699,7 +699,7 @@ pub fn mkdir_all(opath string, params MkdirParams) ! {
 		if is_dir(opath) {
 			return
 		}
-		return error('folder: ${opath}, error: File exists')
+		return error('path `${opath}` already exists, and is not a folder')
 	}
 	other_separator := if path_separator == '/' { '\\' } else { '/' }
 	path := opath.replace(other_separator, path_separator)

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -695,6 +695,12 @@ pub struct MkdirParams {
 
 // mkdir_all will create a valid full path of all directories given in `path`.
 pub fn mkdir_all(opath string, params MkdirParams) ! {
+	if exists(opath) {
+		if is_dir(opath) {
+			return
+		}
+		return error('folder: ${opath}, error: File exists')
+	}
 	other_separator := if path_separator == '/' { '\\' } else { '/' }
 	path := opath.replace(other_separator, path_separator)
 	mut p := if path.starts_with(path_separator) { path_separator } else { '' }

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -1021,7 +1021,7 @@ fn test_mkdir_at_file_dst() {
 	f3 := os.join_path('myfolder', 'f1', 'f2', 'f3')
 	os.mkdir_all(f3)!
 	assert os.is_dir(f3)
-	path := os.join_path('myfolder', 'f1', 'f2', 'f3', 'no_ext_doc')
+	path := os.join_path(f3, 'no_ext_doc')
 	os.write_file(path, '')!
 	assert os.exists(path) && os.is_file(path)
 	os.mkdir_all(path) or {

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -1016,3 +1016,17 @@ fn test_mv_across_partitions() {
 fn test_page_size() {
 	assert os.page_size() >= 4096 // this is normal and assumed.
 }
+
+fn test_mkdir_at_file_dst() {
+	f3 := os.join_path('myfolder', 'f1', 'f2', 'f3')
+	os.mkdir_all(f3)!
+	assert os.is_dir(f3)
+	path := os.join_path('myfolder', 'f1', 'f2', 'f3', 'no_ext_doc')
+	os.write_file(path, '')!
+	assert os.exists(path) && os.is_file(path)
+	os.mkdir_all(path) or {
+		assert err.msg() == 'path `${path}` already exists, and is not a folder', err.msg()
+		return
+	}
+	assert false
+}


### PR DESCRIPTION
`mkdir_all` is used at many places to ensure a destination directory exists - even when it's likely that it already does. Often it is not wrapped in an `os.exists(<dst_dir>)` condition. When it is, it should imho not be necessary to add the condition. 

This PR increases the performance of `mkdir_all` when it is called outside a conditional block like mentioned above and the destition dir is already present. It does it by using an early return fast path. The performance increase is more than 300%.

It's the way go does it:
https://github.com/golang/go/blob/dd88f23a2006307f835f42063b5168ec56c2c428/src/os/path.go#L18-L24

The error is kept the same that would be thrown further down the function.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e11c57e</samp>

Improve `os.create_folder` function by checking output path validity. Prevent file overwriting and nested folder creation.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e11c57e</samp>

* Add a check for the output path existence and type before creating a folder ([link](https://github.com/vlang/v/pull/19869/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09R698-R703)). This prevents overwriting an existing file or creating a nested folder in `os.create_folder`.
