### PR TITLE
tools: handle paths in vcreate more gracefully

### DIFF
--- a/cmd/tools/vcreate/project_model_bin.v
+++ b/cmd/tools/vcreate/project_model_bin.v
@@ -1,8 +1,11 @@
 module main
 
+import os
+
 fn (mut c Create) set_bin_project_files() {
+	main_path := os.join_path('src', 'main.v')
 	c.files << ProjectFiles{
-		path: if c.new_dir { '${c.name}/src/main.v' } else { 'src/main.v' }
+		path: if c.new_dir { os.join_path(c.name, main_path) } else { main_path }
 		content: "module main
 
 fn main() {

--- a/cmd/tools/vcreate/project_model_lib.v
+++ b/cmd/tools/vcreate/project_model_lib.v
@@ -1,8 +1,10 @@
 module main
 
+import os
+
 fn (mut c Create) set_lib_project_files() {
 	c.files << ProjectFiles{
-		path: '${c.name}/src/${c.name}.v'
+		path: os.join_path(c.name, 'src', c.name + '.v')
 		content: 'module ${c.name}
 
 // square calculates the second power of `x`
@@ -12,7 +14,7 @@ pub fn square(x int) int {
 '
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/tests/square_test.v'
+		path: os.join_path(c.name, 'tests', 'square_test.v')
 		content: 'import ${c.name}
 
 fn test_square() {

--- a/cmd/tools/vcreate/project_model_web.v
+++ b/cmd/tools/vcreate/project_model_web.v
@@ -1,8 +1,10 @@
 module main
 
+import os { join_path }
+
 fn (mut c Create) set_web_project_files() {
 	c.files << ProjectFiles{
-		path: '${c.name}/src/databases/config_databases_sqlite.v'
+		path: join_path(c.name, 'src', 'databases', 'config_databases_sqlite.v')
 		content: "module databases
 
 import db.sqlite // can change to 'db.mysql', 'db.pg'
@@ -14,7 +16,7 @@ pub fn create_db_connection() !sqlite.DB {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/templates/header_component.html'
+		path: join_path(c.name, 'src', 'templates', 'header_component.html')
 		content: "<nav>
 	<div class='nav-wrapper'>
 		<a href='javascript:window.history.back();' class='left'>
@@ -33,7 +35,7 @@ pub fn create_db_connection() !sqlite.DB {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/templates/products.css'
+		path: join_path(c.name, 'src', 'templates', 'products.css')
 		content: 'h1.title {
 	font-family: Arial, Helvetica, sans-serif;
 	color: #3b7bbf;
@@ -47,7 +49,7 @@ div.products-table {
 }'
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/templates/products.html'
+		path: join_path(c.name, 'src', 'templates', 'products.html')
 		content: "<!DOCTYPE html>
 <html>
 <head>
@@ -144,7 +146,7 @@ div.products-table {
 </html>"
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/auth_controllers.v'
+		path: join_path(c.name, 'src', 'auth_controllers.v')
 		content: "module main
 
 import vweb
@@ -161,7 +163,7 @@ pub fn (mut app App) controller_auth(username string, password string) vweb.Resu
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/auth_dto.v'
+		path: join_path(c.name, 'src', 'auth_dto.v')
 		content: 'module main
 
 struct AuthRequestDto {
@@ -171,7 +173,7 @@ struct AuthRequestDto {
 '
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/auth_services.v'
+		path: join_path(c.name, 'src', 'auth_services.v')
 		content: "module main
 
 import crypto.hmac
@@ -266,7 +268,7 @@ fn auth_verify(token string) bool {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/index.html'
+		path: join_path(c.name, 'src', 'index.html')
 		content: "<!DOCTYPE html>
 <html>
 <head>
@@ -345,7 +347,7 @@ fn auth_verify(token string) bool {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/main.v'
+		path: join_path(c.name, 'src', 'main.v')
 		content: "module main
 
 import vweb
@@ -390,7 +392,7 @@ pub fn (mut app App) index() vweb.Result {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/product_controller.v'
+		path: join_path(c.name, 'src', 'product_controller.v')
 		content: "module main
 
 import vweb
@@ -456,7 +458,7 @@ pub fn (mut app App) controller_create_product(product_name string) vweb.Result 
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/product_entities.v'
+		path: join_path(c.name, 'src', 'product_entities.v')
 		content: "module main
 
 [table: 'products']
@@ -469,7 +471,7 @@ struct Product {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/product_service.v'
+		path: join_path(c.name, 'src', 'product_service.v')
 		content: "module main
 
 import databases
@@ -516,7 +518,7 @@ fn (mut app App) service_get_all_products_from(user_id int) ![]Product {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/product_view_api.v'
+		path: join_path(c.name, 'src', 'product_view_api.v')
 		content: "module main
 
 import json
@@ -555,7 +557,7 @@ pub fn get_product(token string) ![]User {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/product_view.v'
+		path: join_path(c.name, 'src', 'product_view.v')
 		content: "module main
 
 import vweb
@@ -577,7 +579,7 @@ pub fn (mut app App) products() !vweb.Result {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/user_controllers.v'
+		path: join_path(c.name, 'src', 'user_controllers.v')
 		content: "module main
 
 import vweb
@@ -647,7 +649,7 @@ pub fn (mut app App) controller_create_user(username string, password string) vw
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/user_entities.v'
+		path: join_path(c.name, 'src', 'user_entities.v')
 		content: "module main
 
 [table: 'users']
@@ -662,7 +664,7 @@ mut:
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/user_services.v'
+		path: join_path(c.name, 'src', 'user_services.v')
 		content: "module main
 
 import crypto.bcrypt
@@ -731,7 +733,7 @@ fn (mut app App) service_get_user(id int) !User {
 "
 	}
 	c.files << ProjectFiles{
-		path: '${c.name}/src/user_view_api.v'
+		path: join_path(c.name, 'src', 'user_view_api.v')
 		content: "module main
 
 import json

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -263,10 +263,7 @@ bin/
 
 fn (mut c Create) create_files_and_directories() {
 	for file in c.files {
-		// get dir and convert path separator
-		dir := file.path.split('/')#[..-1].join(os.path_separator)
-		// create all directories, if not exist
-		os.mkdir_all(dir) or { panic(err) }
+		os.mkdir_all(os.dir(file.path)) or { panic(err) }
 		os.write_file(file.path, file.content) or { panic(err) }
 	}
 }


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d36c787</samp>

This pull request improves the cross-platform compatibility of the `vcreate` tool by using the `os` module for path manipulation. It refactors the code for creating different types of projects (library, web, and binary) and uses the `os.join_path` and `os.dir` functions instead of string interpolation or manual splitting and joining of path components. This makes the code more portable, reliable, and readable.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d36c787</samp>

* Imported `os` module and used `os.join_path` function to join path components in a cross-platform way ([link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-04e0bd4b8647bb6e9f4e48476b1f9f992abd017105833bd850c11cedac5a0011L3-R8), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-90064538845bcfd034de22b9b9ddc747bc598596fed677d58156c69f9a3d52e2L3-R7), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-90064538845bcfd034de22b9b9ddc747bc598596fed677d58156c69f9a3d52e2L15-R17), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L3-R7), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L17-R19), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L36-R38), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L50-R52), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L147-R149), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L164-R166), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L174-R176), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L269-R271), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L348-R350), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L393-R395), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L459-R461), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L472-R474), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L519-R521), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L558-R560), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L580-R582), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L650-R652), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L665-R667), [link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-b600e098365b59505f7c64ed708eab88c17bfd1cb3df3969474b208af90adfc8L734-R736))
* Used `os.dir` function to get the directory of the file path instead of manual splitting and joining in `vcreate.v` ([link](https://github.com/vlang/v/pull/19870/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL266-R266))
