### PR TITLE
parser: fix failures found with fuzzing

### DIFF
--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -96,8 +96,9 @@ jobs:
       - name: V self compilation with g++ and -std=c++20
         run: ./v -cc g++-11 -no-std -cflags -std=c++20 -o v2 cmd/v && ./v2 -cc g++-11 -no-std -cflags -std=c++20 -o v3 cmd/v
 
+      # NB: this does not mean it runs, but at least keeps it from regressing
       - name: Ensure V can be compiled with -autofree
-        run: ./v -autofree -o v2 cmd/v # NB: this does not mean it runs, but at least keeps it from regressing
+        run: ./v -autofree -o v2 cmd/v
 
       - name: Shader examples can be built
         run: |
@@ -126,17 +127,17 @@ jobs:
       - name: Build local v
         run: |
           make -j4
-          ./v -g cmd/tools/vtest-parser.v
+          ./v -g -d trace_parse_stmt cmd/tools/vtest-parser.v
       - name: Run test-parser
         run: |
-          ./v test-parser -S examples/hello_world.v
-          ./v test-parser -S examples/hanoi.v
-          ./v test-parser -S examples/fibonacci.v
-          ./v test-parser -S examples/cli.v
-          ./v test-parser -S examples/json.v
-          ./v test-parser -S examples/vmod.v
-          ./v test-parser -S examples/regex/regex_example.v
-          ./v test-parser -S examples/2048/2048.v
+          ./v test-parser --show_source --linear examples/hello_world.v
+          ./v test-parser --show_source --linear examples/hanoi.v
+          ./v test-parser --show_source --linear examples/fibonacci.v
+          ./v test-parser --show_source --linear examples/cli.v
+          ./v test-parser --show_source --linear examples/json.v
+          ./v test-parser --show_source --linear examples/vmod.v
+          ./v test-parser --show_source --linear examples/regex/regex_example.v
+          ./v test-parser --show_source --linear examples/2048/2048.v
 
       - name: Run test-parser over fuzzed files
         run: |
@@ -148,8 +149,11 @@ jobs:
           zzuf -R '\x00-\x20\x7f-\xff' -r0.01 < examples/vmod.v > examples/vmod_fuzz.v
           zzuf -R '\x00-\x20\x7f-\xff' -r0.01 < examples/regex/regex_example.v > examples/regex_example_fuzz.v
           zzuf -R '\x00-\x20\x7f-\xff' -r0.01 < examples/2048/2048.v > examples/2048/2048_fuzz.v
-          ./v test-parser -S examples/hello_world_fuzz.v
-          ./v test-parser -S examples/hanoi_fuzz.v
-          ./v test-parser -S examples/cli_fuzz.v
-          ./v test-parser -S examples/regex_example_fuzz.v
-          ./v test-parser -S examples/2048/2048_fuzz.v
+          ./v test-parser --show_source --linear examples/hello_world_fuzz.v
+          ./v test-parser --show_source --linear examples/fibonacci_fuzz.v
+          ./v test-parser --show_source --linear examples/hanoi_fuzz.v
+          ./v test-parser --show_source --linear examples/cli_fuzz.v
+          ./v test-parser --show_source --linear examples/json_fuzz.v
+          ./v test-parser --show_source --linear examples/vmod_fuzz.v
+          ./v test-parser --show_source --linear examples/regex_example_fuzz.v
+          ./v test-parser --show_source --linear examples/2048/2048_fuzz.v

--- a/cmd/tools/vtest-parser.v
+++ b/cmd/tools/vtest-parser.v
@@ -35,7 +35,6 @@ mut:
 	max_index  int      // the maximum index (equivalent to the file content length)
 	// parser context in the worker processes:
 	table      ast.Table
-	scope      ast.Scope
 	pref       &pref.Preferences = unsafe { nil }
 	period_ms  int  // print periodic progress
 	stop_print bool // stop printing the periodic progress
@@ -49,9 +48,6 @@ fn main() {
 		// A worker's process job is to try to parse a single given file in context.path.
 		// It can crash/panic freely.
 		context.table = ast.new_table()
-		context.scope = &ast.Scope{
-			parent: 0
-		}
 		context.pref = &pref.Preferences{
 			output_mode: .silent
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -384,7 +384,11 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		sym := p.table.sym(rec.typ)
 		if sym.info is ast.Struct {
 			fn_generic_names := generic_names.clone()
-			generic_names = sym.info.generic_types.map(p.table.sym(it).name)
+			generic_names = p.types_to_names(sym.info.generic_types, p.tok.pos(), 'sym.info.generic_types') or {
+				return ast.FnDecl{
+					scope: 0
+				}
+			}
 			for gname in fn_generic_names {
 				if gname !in generic_names {
 					generic_names << gname

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2030,10 +2030,12 @@ fn (mut p Parser) error_with_pos(s string, pos token.Pos) ast.NodeError {
 		// To avoid getting stuck after an error, the parser
 		// will proceed to the next token.
 		if p.pref.check_only || p.pref.only_check_syntax {
-			p.next()
+			if p.tok.kind != .eof {
+				p.next()
+			}
 		}
 	}
-	if p.pref.output_mode == .silent {
+	if p.pref.output_mode == .silent && p.tok.kind != .eof {
 		// Normally, parser errors mean that the parser exits immediately, so there can be only 1 parser error.
 		// In the silent mode however, the parser continues to run, even though it would have stopped. Some
 		// of the parser logic does not expect that, and may loop forever.

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -563,6 +563,12 @@ fn (mut s Scanner) end_of_file() token.Token {
 	s.eofs++
 	if s.eofs > 50 {
 		s.line_nr--
+		if s.file_path == scanner.internally_generated_v_code {
+			// show a bit more context for that case, since the source may not be easily visible by just inspecting a source file on the filesystem
+			dump(s.text#[0..50])
+			dump(s.text#[-50..])
+			dump(s.text.len)
+		}
 		panic(
 			'the end of file `${s.file_path}` has been reached 50 times already, the v parser is probably stuck.\n' +
 			'This should not happen. Please report the bug here, and include the last 2-3 lines of your source code:\n' +


### PR DESCRIPTION
- parser: make the parser a bit more robust for fuzzed source code, and show more context on scanner fails for source code without backing .v files
- parser: make the parser more robust for fuzzed source code
