### PR TITLE
tools: use shared contexts to resolve dependencies during threaded module updates

### DIFF
--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -72,7 +72,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &UpdateResult {
 	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output.trim_space()}')
 	// Don't bail if the download count increment has failed.
 	increment_module_download_count(name) or { vpm_error(err.msg(), verbose: true) }
-	ctx := UpdateSession{pp.get_shared_context()}
+	ctx := unsafe { &UpdateSession(pp.get_shared_context()) }
 	resolve_dependencies(get_manifest(install_path), ctx.idents)
 	return result
 }


### PR DESCRIPTION
The change improves the performance and creates the base for further improvements by adding a shared context to the module update pool processor. 
It resolves the reason why dependencies were resolved outside of an update thread, namely because other module identifiers were not accessible. This makes it possible to handle the dependencies of a module that is being updated within its thread without changing the current behavior.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16775b5</samp>

Refactored the `vpm` module update process to use structs and a context for better readability and modularity. Improved the dependency resolution logic by moving it to the pool processor.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 16775b5</samp>

*  Replace `ModUpdateInfo` struct with `UpdateSession` and `UpdateResult` structs to simplify data flow and avoid duplication ([link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L7-R13))
* Rename `modules` to `idents` to clarify that they are module identifiers, not names ([link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L18-R20), [link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L104-R106))
* Move dependency resolution from main loop to callback function to improve concurrency and avoid race conditions ([link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L24-R38), [link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L42-R55), [link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L63-R82), [link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L104-R106))
* Remove unused and redundant fields from `UpdateResult` struct to save memory and allocations ([link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L42-R55))
* Change error handling for download count increment to not fail the update, as it is not critical ([link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L63-R82))
* Modify pool processor and callback function to use shared context to access `UpdateSession` ([link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L24-R38), [link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L42-R55), [link](https://github.com/vlang/v/pull/19878/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L63-R82))
