### PR TITLE
parser: deprecate old attribute syntax & update remaining (missed) attributes

### DIFF
--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -24,7 +24,7 @@ pub mut:
 	method     Method  = .get
 	header     Header
 	host       string
-	cookies    map[string]string [deprecated: 'use req.cookie(name) and req.add_cookie(name) instead']
+	cookies    map[string]string @[deprecated: 'use req.cookie(name) and req.add_cookie(name) instead']
 	data       string
 	url        string
 	user_agent string = 'v.http'

--- a/vlib/v/checker/tests/generic_interface_missing_type_names_err.vv
+++ b/vlib/v/checker/tests/generic_interface_missing_type_names_err.vv
@@ -5,11 +5,11 @@ interface Output[T] {
 
 struct Coil {
   pub mut: val int
-  pub: name string [required]
+  pub: name string @[required]
 }
 struct Light {
   pub mut: val int
-  pub: name string [required]
+  pub: name string @[required]
 }
 
 fn main() {

--- a/vlib/v/checker/tests/struct_field_type_err.vv
+++ b/vlib/v/checker/tests/struct_field_type_err.vv
@@ -2,8 +2,8 @@ struct Data {
 mut:
 	n    int
 	b    bool
-	f1   fn (voidptr) [required]
-	f2   fn (...voidptr) [required]
+	f1   fn (voidptr) @[required]
+	f2   fn (...voidptr) @[required]
 	data &Data
 }
 

--- a/vlib/v/checker/tests/unknown_type_in_anon_fn.out
+++ b/vlib/v/checker/tests/unknown_type_in_anon_fn.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/unknown_type_in_anon_fn.vv:5:10: error: unknown type `Another`
     3 | struct Struc{
     4 | mut:
-    5 |     f fn (s Another, i int)? [required]
+    5 |     f fn (s Another, i int)? @[required]
       |             ~~~~~~~
     6 | }
     7 |

--- a/vlib/v/checker/tests/unknown_type_in_anon_fn.vv
+++ b/vlib/v/checker/tests/unknown_type_in_anon_fn.vv
@@ -2,7 +2,7 @@ module main
 
 struct Struc{
 mut:
-	f fn (s Another, i int)? [required]
+	f fn (s Another, i int)? @[required]
 }
 
 fn main() {}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -445,10 +445,13 @@ fn (mut p Parser) parse_type() ast.Type {
 
 	if is_option || is_result {
 		// maybe the '[' is the start of the field attribute
+		// TODO: remove once old syntax dropped
 		is_required_field := p.inside_struct_field_decl && p.tok.kind == .lsbr
 			&& p.peek_tok.kind == .name && p.peek_tok.lit == 'required'
+		is_attr := p.tok.kind == .at
 
-		if p.tok.line_nr > line_nr || p.tok.kind in [.comma, .rpar, .assign] || is_required_field {
+		if p.tok.line_nr > line_nr || p.tok.kind in [.comma, .rpar, .assign]
+			|| (is_attr || is_required_field) {
 			mut typ := ast.void_type
 			if is_option {
 				typ = typ.set_flag(.option)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1815,7 +1815,7 @@ fn (mut p Parser) attributes() {
 	start_pos := p.tok.pos()
 	mut is_at := false
 	if p.tok.kind == .lsbr {
-		p.warn('`[attr]` has been deprecated, use `@[attr]` instead')
+		p.note('`[attr]` has been deprecated, use `@[attr]` instead')
 		// [attr]
 		p.check(.lsbr)
 	} else if p.tok.kind == .at {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1812,6 +1812,7 @@ fn (mut p Parser) is_attributes() bool {
 
 // when is_top_stmt is true attrs are added to p.attrs
 fn (mut p Parser) attributes() {
+	start_pos := p.tok.pos()
 	mut is_at := false
 	if p.tok.kind == .lsbr {
 		p.warn('`[attr]` has been deprecated, use `@[attr]` instead')
@@ -1825,16 +1826,16 @@ fn (mut p Parser) attributes() {
 	}
 	mut has_ctdefine := false
 	for p.tok.kind != .rsbr {
-		start_pos := p.tok.pos()
+		attr_start_pos := p.tok.pos()
 		attr := p.parse_attr(is_at)
 		if p.attrs.contains(attr.name) && attr.name != 'wasm_export' {
-			p.error_with_pos('duplicate attribute `${attr.name}`', start_pos.extend(p.prev_tok.pos()))
+			p.error_with_pos('duplicate attribute `${attr.name}`', attr_start_pos.extend(p.prev_tok.pos()))
 			return
 		}
 		if attr.kind == .comptime_define {
 			if has_ctdefine {
 				p.error_with_pos('only one `[if flag]` may be applied at a time `${attr.name}`',
-					start_pos.extend(p.prev_tok.pos()))
+					attr_start_pos.extend(p.prev_tok.pos()))
 				return
 			} else {
 				has_ctdefine = true
@@ -1852,7 +1853,7 @@ fn (mut p Parser) attributes() {
 		p.next()
 	}
 	if p.attrs.len == 0 {
-		p.error_with_pos('attributes cannot be empty', p.prev_tok.pos().extend(p.tok.pos()))
+		p.error_with_pos('attributes cannot be empty', start_pos.extend(p.tok.pos()))
 		return
 	}
 	// TODO: remove when old attr syntax is removed

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1814,6 +1814,7 @@ fn (mut p Parser) is_attributes() bool {
 fn (mut p Parser) attributes() {
 	mut is_at := false
 	if p.tok.kind == .lsbr {
+		p.warn('`[attr]` has been deprecated, use `@[attr]` instead')
 		// [attr]
 		p.check(.lsbr)
 	} else if p.tok.kind == .at {

--- a/vlib/v/parser/tests/fn_attributes_empty_err.out
+++ b/vlib/v/parser/tests/fn_attributes_empty_err.out
@@ -1,5 +1,5 @@
 vlib/v/parser/tests/fn_attributes_empty_err.vv:1:1: error: attributes cannot be empty
-    1 | [] fn tt() {
-      | ~~
+    1 | @[] fn tt() {
+      | ~~~
     2 |     println('text')
     3 | }

--- a/vlib/v/parser/tests/fn_attributes_empty_err.vv
+++ b/vlib/v/parser/tests/fn_attributes_empty_err.vv
@@ -1,4 +1,4 @@
-[] fn tt() {
+@[] fn tt() {
 	println('text')
 }
 fn main() {

--- a/vlib/v/parser/tests/struct_field_required_fn_option_type.vv
+++ b/vlib/v/parser/tests/struct_field_required_fn_option_type.vv
@@ -1,5 +1,5 @@
 struct Foo {
-	foo fn () ? [required]
+	foo fn () ? @[required]
 }
 
 fn main() {

--- a/vlib/v/parser/tests/struct_field_required_fn_result_type.vv
+++ b/vlib/v/parser/tests/struct_field_required_fn_result_type.vv
@@ -1,5 +1,5 @@
 struct Foo {
-	foo fn() ! [required]
+	foo fn() ! @[required]
 }
 
 fn main() {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -1181,7 +1181,7 @@ fn (mut w Worker[T]) process_incoming_requests() {
 
 @[params]
 pub struct PoolParams[T] {
-	handler    fn () T [required] = unsafe { nil }
+	handler    fn () T = unsafe { nil } @[required]
 	nr_workers int = runtime.nr_jobs()
 }
 


### PR DESCRIPTION
Add a deprecation warning for the old attribute syntax. After a decided upon amount of time, support for the old syntax will then be completely removed.

Should this deprecation be a warning or an error? It would be nice to push for all code to be migrated, and the old syntax removed as soon as possible.
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f12abe9</samp>

Warn users about deprecated attribute syntax with square brackets in `vlib/v/parser/parser.v`. Suggest using the new syntax with at-signs instead.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f12abe9</samp>

* Add a warning message for deprecated attribute syntax using square brackets ([link](https://github.com/vlang/v/pull/19879/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R1817))
