### PR TITLE
checker, cgen: fix generic fn returning fixed array (fix #19872)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -34,6 +34,10 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 		}
 	}
 	expected_type_sym := c.table.sym(expected_type)
+	if expected_type_sym.info is ast.ArrayFixed {
+		c.table.find_or_register_array_fixed(expected_type_sym.info.elem_type, expected_type_sym.info.size,
+			expected_type_sym.info.size_expr, true)
+	}
 	if node.exprs.len > 0 && c.table.cur_fn.return_type == ast.void_type {
 		c.error('unexpected argument, current function does not return anything', node.exprs[0].pos())
 		return

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4896,7 +4896,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 
 	// got to do a correct check for multireturn
-	sym := g.table.sym(g.fn_decl.return_type)
+	sym := g.table.sym(g.unwrap_generic(g.fn_decl.return_type))
 	mut fn_ret_type := g.fn_decl.return_type
 	if sym.kind == .alias {
 		unaliased_type := g.table.unaliased_type(fn_ret_type)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -227,7 +227,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	mut name := g.c_fn_name(node)
 	mut type_name := g.typ(g.unwrap_generic(node.return_type))
 
-	ret_sym := g.table.sym(node.return_type)
+	ret_sym := g.table.sym(g.unwrap_generic(node.return_type))
 	if node.return_type.has_flag(.generic) && ret_sym.kind == .array_fixed {
 		type_name = '_v_${type_name}'
 	} else if ret_sym.kind == .alias && !node.return_type.has_flag(.option) {

--- a/vlib/v/tests/generics_return_fixed_array_test.v
+++ b/vlib/v/tests/generics_return_fixed_array_test.v
@@ -1,0 +1,9 @@
+fn init_type[T]() T {
+	return T{}
+}
+
+fn test_generics_return_fixed_array() {
+	r1 := init_type[[3]int]()
+	println(r1)
+	assert '${r1}' == '[0, 0, 0]'
+}


### PR DESCRIPTION
This PR fix generic fn returning fixed array (fix #19872).

- Fix generic fn returning fixed array.
- Add test.

```v
module main

fn init_type[T]() T {
	return T{}
}

fn main() {
	r1 := init_type[[3]int]()
	println(r1)
	assert '${r1}' == '[0, 0, 0]'
}

PS D:\Test\v\tt1> v run .
[0, 0, 0]
```