### PR TITLE
checker: fix generate dump code for array fixed struct field

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -284,6 +284,14 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 				unwrapped_expr_type := c.unwrap_generic(field.typ)
 				tsym := c.table.sym(unwrapped_expr_type)
 				c.table.dumps[int(unwrapped_expr_type.clear_flags(.option, .result, .atomic_f))] = tsym.cname
+				if tsym.kind == .array_fixed {
+					info := tsym.info as ast.ArrayFixed
+					if !info.is_fn_ret {
+						// for dumping fixed array we must register the fixed array struct to return from function
+						c.table.find_or_register_array_fixed(info.elem_type, info.size,
+							info.size_expr, true)
+					}
+				}
 			}
 			c.comptime_for_field_var = ''
 			c.inside_comptime_for_field = false

--- a/vlib/v/tests/comptime_array_fixed_field_test.v
+++ b/vlib/v/tests/comptime_array_fixed_field_test.v
@@ -1,0 +1,11 @@
+struct Another {
+	a [3]int
+	b [4]u8
+	c [2]u32
+}
+
+fn test_main() {
+	$for f in Another.fields {
+	}
+	assert true
+}


### PR DESCRIPTION
Fix #19881

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c238d6</samp>

Enable comptime function return values for fixed arrays by registering their structs in the table. Update `vlib/v/checker/comptime.v` to handle fixed array type symbols.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c238d6</samp>

* Implement comptime function return values by generating and dumping a struct for each comptime function that has a non-void return type (F0
