### PR TITLE
checker: fix comptime dumping var

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -135,6 +135,7 @@ mut:
 	comptime_call_pos int // needed for correctly checking use before decl for templates
 	goto_labels       map[string]ast.GotoLabel // to check for unused goto labels
 	enum_data_type    ast.Type
+	field_data_type   ast.Type
 	fn_return_type    ast.Type
 	orm_table_fields  map[string][]ast.StructField // known table structs
 	//
@@ -1470,7 +1471,7 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		return ast.void_type
 	} else if c.inside_comptime_for_field && typ == c.enum_data_type && node.field_name == 'value' {
 		// for comp-time enum.values
-		node.expr_type = c.comptime_fields_type[c.comptime_for_field_var]
+		node.expr_type = c.comptime_fields_type['${c.comptime_for_field_var}.typ']
 		node.typ = typ
 		return node.expr_type
 	}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -275,9 +275,13 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 			}
 			c.inside_comptime_for_field = true
 			for field in fields {
+				if c.field_data_type == 0 {
+					c.field_data_type = ast.Type(c.table.find_type_idx('FieldData'))
+				}
 				c.comptime_for_field_value = field
 				c.comptime_for_field_var = node.val_var
-				c.comptime_fields_type[node.val_var] = node.typ
+				c.comptime_fields_type[node.val_var] = c.field_data_type
+				c.comptime_fields_type['${node.val_var}.typ'] = node.typ
 				c.comptime_fields_default_type = field.typ
 				c.stmts(mut node.stmts)
 
@@ -302,7 +306,8 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 			for field in sym_info.vals {
 				c.comptime_enum_field_value = field
 				c.comptime_for_field_var = node.val_var
-				c.comptime_fields_type[node.val_var] = node.typ
+				c.comptime_fields_type[node.val_var] = c.enum_data_type
+				c.comptime_fields_type['${node.val_var}.typ'] = node.typ
 				c.stmts(mut node.stmts)
 			}
 		} else {

--- a/vlib/v/tests/comptime_dump_test.v
+++ b/vlib/v/tests/comptime_dump_test.v
@@ -1,0 +1,48 @@
+@[abc]
+struct Another {
+	a []int
+	b u8
+	c u32
+}
+
+fn (f Another) test() {}
+
+enum Abc {
+	a
+	b
+	c
+}
+
+fn test_main() {
+	mut c := 0
+	$for f in Abc.values {
+		dump(f)
+		dump(f.value)
+		c += 1
+		assert typeof(f).name == 'EnumData'
+	}
+	assert c == 3
+
+	$for f in Another.fields {
+		dump(f)
+		dump(f.name)
+		c += 1
+	}
+	assert c == 6
+
+	$for f in Another.methods {
+		dump(f)
+		dump(f.name)
+		c += 1
+		assert typeof(f).name == 'FunctionData'
+	}
+	assert c == 7
+
+	$for f in Another.attributes {
+		dump(f)
+		dump(f.name)
+		c += 1
+		assert typeof(f).name == 'StructAttribute'
+	}
+	assert c == 8
+}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ff1f4e</samp>

This pull request enhances the comp-time reflection capabilities of V for struct fields and enum values. It fixes a bug in the checker module, refactors the comptime logic for `for` loops, and adds a new test file `vlib/v/tests/comptime_dump_test.v` to verify the reflection features.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ff1f4e</samp>

*  Add a new field `field_data_type` to the `Checker` struct to store the type of the `FieldData` struct for comp-time reflection of struct fields ([link](https://github.com/vlang/v/pull/19887/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R138))
*  Fix a bug in the `Checker.expr_dot` method where the expression type of a comp-time enum value was incorrectly set to the enum type instead of the underlying type ([link](https://github.com/vlang/v/pull/19887/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L1473-R1474))
*  Refactor the comptime logic for handling the comp-time `for` loops over struct fields and enum values, and set the `comptime_fields_type` map with both the wrapper type and the original type for the comp-time field variable ([link](https://github.com/vlang/v/pull/19887/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5L278-R284), [link](https://github.com/vlang/v/pull/19887/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5L305-R310))
*  Add a new test file `vlib/v/tests/comptime_dump_test.v` to test the comp-time reflection of struct fields, enum values, methods, and attributes, using the `dump` function and assertions ([link](https://github.com/vlang/v/pull/19887/files?diff=unified&w=0#diff-f10a7619bc58a15665f9e181137a70857c8f3866c34fd9773e3396d8d8d979ffR1-R48))
