### PR TITLE
test improve incorrect_name_sum_type

### DIFF
--- a/vlib/v/checker/tests/incorrect_name_sum_type.out
+++ b/vlib/v/checker/tests/incorrect_name_sum_type.out
@@ -3,16 +3,16 @@ vlib/v/checker/tests/incorrect_name_sum_type.vv:1:1: error: sum type `integer` m
       | ~~~~~~~~~~~~
     2 | type Integer = i16 | i64 | i8 | int
     3 |
-vlib/v/checker/tests/incorrect_name_sum_type.v:4:1: error: method overrides built-in sum type method
+vlib/v/checker/tests/incorrect_name_sum_type.vv:4:1: error: method overrides built-in sum type method
     2 | type Integer = i16 | i64 | i8 | int
-    3 |
+    3 | 
     4 | fn (i Integer) type_idx() {
       | ~~~~~~~~~~~~~~~~~~~~~~~~~
     5 | }
     6 |
-vlib/v/checker/tests/incorrect_name_sum_type.v:7:1: error: method overrides built-in sum type method
+vlib/v/checker/tests/incorrect_name_sum_type.vv:7:1: error: method overrides built-in sum type method
     5 | }
-    6 |
+    6 | 
     7 | fn (i Integer) type_name() {
       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
     8 | }

--- a/vlib/v/checker/tests/incorrect_name_sum_type.out
+++ b/vlib/v/checker/tests/incorrect_name_sum_type.out
@@ -1,12 +1,18 @@
 vlib/v/checker/tests/incorrect_name_sum_type.vv:1:1: error: sum type `integer` must begin with capital letter
-    1 | type integer = i8 | i16 | int | i64
+    1 | type integer = i16 | i64 | i8 | int
       | ~~~~~~~~~~~~
-    2 | type Integer = i8 | i16 | int | i64
+    2 | type Integer = i16 | i64 | i8 | int
     3 |
-vlib/v/checker/tests/incorrect_name_sum_type.vv:4:1: error: method overrides built-in sum type method
-    2 | type Integer = i8 | i16 | int | i64
-    3 | 
-    4 | fn (i Integer) type_name() {
-      | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+vlib/v/checker/tests/incorrect_name_sum_type.v:4:1: error: method overrides built-in sum type method
+    2 | type Integer = i16 | i64 | i8 | int
+    3 |
+    4 | fn (i Integer) type_idx() {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~
     5 | }
     6 |
+vlib/v/checker/tests/incorrect_name_sum_type.v:7:1: error: method overrides built-in sum type method
+    5 | }
+    6 |
+    7 | fn (i Integer) type_name() {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    8 | }

--- a/vlib/v/checker/tests/incorrect_name_sum_type.vv
+++ b/vlib/v/checker/tests/incorrect_name_sum_type.vv
@@ -1,6 +1,8 @@
-type integer = i8 | i16 | int | i64
-type Integer = i8 | i16 | int | i64
+type integer = i16 | i64 | i8 | int
+type Integer = i16 | i64 | i8 | int
+
+fn (i Integer) type_idx() {
+}
 
 fn (i Integer) type_name() {
 }
-


### PR DESCRIPTION
fmt code and add `type_idx` method on test

```bash
vlib/v/checker/tests/incorrect_name_sum_type.vv:1:1: error: sum type `integer` must begin with capital letter
    1 | type integer = i16 | i64 | i8 | int
      | ~~~~~~~~~~~~
    2 | type Integer = i16 | i64 | i8 | int
    3 |
vlib/v/checker/tests/incorrect_name_sum_type.v:4:1: error: method overrides built-in sum type method
    2 | type Integer = i16 | i64 | i8 | int
    3 |
    4 | fn (i Integer) type_idx() {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | }
    6 |
vlib/v/checker/tests/incorrect_name_sum_type.v:7:1: error: method overrides built-in sum type method
    5 | }
    6 |
    7 | fn (i Integer) type_name() {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~
    8 | }
```