### PR TITLE
tools: fix `has_vmod` test in `install_test` interpreting wrong dir as install dir

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -105,8 +105,8 @@ fn parse_query(query []string) ([]Module, []Module) {
 }
 
 fn has_vmod(url string, install_path string) bool {
-	if os.exists((os.join_path(install_path, 'v.mod'))) {
-		// Safe time fetchting the repo when the module is already installed and has a `v.mod`.
+	if install_path != '' && os.exists((os.join_path(install_path, 'v.mod'))) {
+		// Skip fetching the repo when the module is already installed and has a `v.mod`.
 		return true
 	}
 	head_branch := os.execute_opt('git ls-remote --symref ${url} HEAD') or {


### PR DESCRIPTION
Fixes a failing unit test of `has_mod` in `install_test.v` after the recent `join_path` fix.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 678030e</samp>

Improved `vpm` error handling by checking install path before `v.mod` file. Updated comment in `cmd/tools/vpm/common.v` to match the new condition.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 678030e</samp>

* Modify the condition for checking if a module has a `v.mod` file to also check if the install path is not empty ([link](https://github.com/vlang/v/pull/19891/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L108-R109)). This prevents a potential error when the install path is not provided or is invalid. Update the comment to reflect the change. This improves the error handling and user feedback of the `vpm` tool in `cmd/tools/vpm/common.v`.
