### PR TITLE
tools.vpm: simplify `update.v`, add update result info

### DIFF
--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -36,6 +36,9 @@ fn test_update_idents() {
 	res = os.execute_or_exit('${v} update nedpals.args vtray')
 	assert res.output.contains('Updating module `vtray`'), res.output
 	assert res.output.contains('Updating module `nedpals.args`'), res.output
+	// Update installed module using its url.
+	res = os.execute('${v} update https://github.com/spytheman/vtray')
+	assert res.output.contains('Updating module `vtray`'), res.output
 	// Try update not installed.
 	res = os.execute('${v} update vsl')
 	assert res.exit_code == 1


### PR DESCRIPTION
- Adds info about the update result like `Updated module ...`, or `Skipped module...` when the module is already up to date.
- Doesn't use a separate function for `v update --verbose` anymore which became obsolete with the recent changes. This enables to use the verbose setting for updating and improves maintainability.
- Adds debug logging, comments, and adds a test.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6fb74a5</samp>

Improved vpm update functionality and added a test case. The `UpdateResult` struct and the `update_module` function in `cmd/tools/vpm/update.v` were simplified and refactored. A new test in `cmd/tools/vpm/update_test.v` checks that `v update` can update a module by url.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6fb74a5</samp>

*  Simplify the `UpdateResult` struct to use a `success` field instead of a `has_err` field ([link](https://github.com/vlang/v/pull/19892/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L13-R13))
*  Refactor the `update_module` function in `cmd/tools/vpm/update.v` to simplify the error handling, avoid unnecessary mutability, and improve the output messages ([link](https://github.com/vlang/v/pull/19892/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L35-R31),[link](https://github.com/vlang/v/pull/19892/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L46-R76))
*  Remove the redundant `vpm_update_verbose` function from `cmd/tools/vpm/update.v` ([link](https://github.com/vlang/v/pull/19892/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L25-L28))
*  Add a test case to `cmd/tools/vpm/update_test.v` to check that the `v update` command can update an installed module using its url as an argument ([link](https://github.com/vlang/v/pull/19892/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeR39-R41))
