### PR TITLE
cgen: fix temporary var name conflicts between const definitions with or_block in different files(fix #19149)

### DIFF
--- a/vlib/v/tests/modules/consts_with_or_blocks_in_different_files/config.v
+++ b/vlib/v/tests/modules/consts_with_or_blocks_in_different_files/config.v
@@ -1,0 +1,5 @@
+module consts_with_or_blocks_in_different_files
+
+import os
+
+const a_const = os.config_dir() or { panic(err) } + '/a'

--- a/vlib/v/tests/modules/consts_with_or_blocks_in_different_files/consts_should_not_conflict_test.v
+++ b/vlib/v/tests/modules/consts_with_or_blocks_in_different_files/consts_should_not_conflict_test.v
@@ -1,0 +1,10 @@
+module consts_with_or_blocks_in_different_files
+
+import os
+
+const b_const = os.config_dir() or { panic(err) } + '/b'
+
+// Just to test the two files in this folder are compiled normally
+fn test_consts_with_or_blocks_in_different_files() {
+	assert true
+}


### PR DESCRIPTION
1. Fixed #19149 
2. Add tests.
