### PR TITLE
parser, fmt: fix match with multi-commmented branchs (fix #19880)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2696,12 +2696,12 @@ fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
 				f.writeln('')
 			}
 			f.write(estr)
+			if j < branch.exprs.len - 1 {
+				f.write(', ')
+			}
 			if j < branch.ecmnts.len && branch.ecmnts[j].len > 0 {
 				f.write(' ')
 				f.comments(branch.ecmnts[j])
-			}
-			if j < branch.exprs.len - 1 {
-				f.write(', ')
 			}
 		}
 		f.is_mbranch_expr = false
@@ -2714,6 +2714,8 @@ fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
 	} else {
 		if single_line {
 			f.write(' { ')
+		} else if branch.ecmnts.len > 0 && branch.ecmnts.last().len > 0 {
+			f.writeln('{')
 		} else {
 			f.writeln(' {')
 		}

--- a/vlib/v/fmt/tests/match_with_multi_commented_branches_keep.vv
+++ b/vlib/v/fmt/tests/match_with_multi_commented_branches_keep.vv
@@ -1,0 +1,40 @@
+import strings
+
+fn escape_string(s string) string {
+	mut res := strings.new_builder(s.len * 2)
+	for ch in s {
+		match ch {
+			0 // NUL (null)
+			{
+				res.write_u8(92) // \
+				res.write_u8(48) // 0
+			}
+			10 { // LF (line feed)
+				res.write_u8(92) // \
+				res.write_u8(110) // n
+			}
+			13 { // CR (carriage return)
+				res.write_u8(92) // \
+				res.write_u8(114) // r
+			}
+			26 { // SUB (substitute)
+				res.write_u8(92) // \
+				res.write_u8(90) // Z
+			}
+			34,  // "
+			39,  // '
+			92 // \
+			{
+				res.write_u8(92) // \
+				res.write_u8(ch)
+			}
+			else {
+				res.write_u8(ch)
+			}
+		}
+	}
+	return res.bytestr()
+}
+
+fn main() {
+}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -258,13 +258,13 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			for {
 				// Sum type match
 				parsed_type := p.parse_type()
-				ecmnts << p.eat_comments()
 				types << parsed_type
 				exprs << ast.TypeNode{
 					typ: parsed_type
 					pos: p.prev_tok.pos()
 				}
 				if p.tok.kind != .comma {
+					ecmnts << p.eat_comments()
 					break
 				}
 				p.check(.comma)
@@ -275,6 +275,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 					for p.tok.kind == .comma {
 						p.next()
 					}
+					ecmnts << p.eat_comments()
 				}
 			}
 			is_sum_type = true
@@ -284,7 +285,6 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 				p.inside_match_case = true
 				mut range_pos := p.tok.pos()
 				expr := p.expr(0)
-				ecmnts << p.eat_comments()
 				p.inside_match_case = false
 				if p.tok.kind == .dotdot {
 					p.error_with_pos('match only supports inclusive (`...`) ranges, not exclusive (`..`)',
@@ -306,6 +306,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 					exprs << expr
 				}
 				if p.tok.kind != .comma {
+					ecmnts << p.eat_comments()
 					break
 				}
 
@@ -317,6 +318,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 					for p.tok.kind == .comma {
 						p.next()
 					}
+					ecmnts << p.eat_comments()
 				}
 			}
 		}


### PR DESCRIPTION
This PR fix match with multi-commmented branchs (fix #19880).

- Fix match with multi-commmented branchs.
- Add test.

vlib\v\fmt\tests\match_with_multi_commented_branches_keep.vv
```v
import strings

fn escape_string(s string) string {
	mut res := strings.new_builder(s.len * 2)
	for ch in s {
		match ch {
			0 // NUL (null)
			{
				res.write_u8(92) // \
				res.write_u8(48) // 0
			}
			10 { // LF (line feed)
				res.write_u8(92) // \
				res.write_u8(110) // n
			}
			13 { // CR (carriage return)
				res.write_u8(92) // \
				res.write_u8(114) // r
			}
			26 { // SUB (substitute)
				res.write_u8(92) // \
				res.write_u8(90) // Z
			}
			34,  // "
			39,  // '
			92 // \
			{
				res.write_u8(92) // \
				res.write_u8(ch)
			}
			else {
				res.write_u8(ch)
			}
		}
	}
	return res.bytestr()
}

fn main() {
}
```