### PR TITLE
net/openssl: add flags for preferring openssl from the ports collection on FreeBSD

### DIFF
--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -7,6 +7,11 @@ module openssl
 // use the (older) system openssl.
 #flag linux -I/usr/local/include/openssl
 #flag linux -L/usr/local/lib
+// On FreeBSD, prefer openssl from the ports collection, because
+// it is much more likely for it to be newer, than the system
+// openssl.
+#flag freebsd -I/usr/local/include
+#flag freebsd -L/usr/local/lib
 $if $pkgconfig('openssl') {
 	#pkgconfig --cflags --libs openssl
 } $else {


### PR DESCRIPTION
As of FreeBSD 13.2, the version of openssl in the base system is 1.1.1t. 

The default version from the ports collection is 3.0.12.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3e12a31</samp>

Enable vlib/net/openssl to work with FreeBSD ports openssl. Add compiler flags for FreeBSD to use `ports/openssl` instead of `system/openssl` in `vlib/net/openssl/openssl.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3e12a31</samp>

* Enable openssl support for FreeBSD by adding compiler flags for the ports collection library ([link](https://github.com/vlang/v/pull/19904/files?diff=unified&w=0#diff-5ea0882828394df2ef8536592dae357e0e43177ba69d301152e7997d9291d0f9R10-R14))
