### PR TITLE
json: replaced depricated type byte with u8

### DIFF
--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -131,8 +131,8 @@ struct User {
 	age           int
 	nums          []int
 	last_name     string @[json: lastName]
-	is_registered bool @[json: IsRegistered]
-	typ           int @[json: 'type']
+	is_registered bool   @[json: IsRegistered]
+	typ           int    @[json: 'type']
 	pets          string @[json: 'pet_animals'; raw]
 }
 
@@ -449,7 +449,7 @@ fn test_pretty() {
 
 struct Foo3 {
 	name string
-	age  int @[omitempty]
+	age  int    @[omitempty]
 }
 
 fn test_omit_empty() {

--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -131,8 +131,8 @@ struct User {
 	age           int
 	nums          []int
 	last_name     string @[json: lastName]
-	is_registered bool   @[json: IsRegistered]
-	typ           int    @[json: 'type']
+	is_registered bool @[json: IsRegistered]
+	typ           int @[json: 'type']
 	pets          string @[json: 'pet_animals'; raw]
 }
 
@@ -449,7 +449,7 @@ fn test_pretty() {
 
 struct Foo3 {
 	name string
-	age  int    @[omitempty]
+	age  int @[omitempty]
 }
 
 fn test_omit_empty() {
@@ -486,11 +486,11 @@ fn test_encode_sumtype_defined_ahead() {
 }
 
 struct StByteArray {
-	ba []byte
+	ba []u8
 }
 
 fn test_byte_array() {
-	assert json.encode(StByteArray{ ba: [byte(1), 2, 3, 4, 5] }) == '{"ba":[1,2,3,4,5]}'
+	assert json.encode(StByteArray{ ba: [u8(1), 2, 3, 4, 5] }) == '{"ba":[1,2,3,4,5]}'
 }
 
 struct Aa {


### PR DESCRIPTION
This change allows vlib/json/json_test.v to successfully run.

I also ran the file through the v formatter which changed a few lines.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dadd79f</samp>

Improve code style and compatibility of `json_test.v`. Use u8 instead of byte and adjust casts and assertions accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dadd79f</samp>

*  Replace `byte` with `u8` for unsigned 8-bit integers in `vlib/json/json_test.v` ([link](https://github.com/vlang/v/pull/19905/files?diff=unified&w=0#diff-4d11da0425239d414e169678642a1969ccd1718bd3c6985366bc1d6415044f0eL489-R493))
*  Remove extra spaces before attributes in `vlib/json/json_test.v` for consistency and readability ([link](https://github.com/vlang/v/pull/19905/files?diff=unified&w=0#diff-4d11da0425239d414e169678642a1969ccd1718bd3c6985366bc1d6415044f0eL134-R135), [link](https://github.com/vlang/v/pull/19905/files?diff=unified&w=0#diff-4d11da0425239d414e169678642a1969ccd1718bd3c6985366bc1d6415044f0eL452-R452))
