### PR TITLE
math/fractions: replace deprecated math.fractions.Fraction.equals with == in approximations_test.v

### DIFF
--- a/vlib/math/fractions/approximations_test.v
+++ b/vlib/math/fractions/approximations_test.v
@@ -7,19 +7,19 @@ import math
 fn test_half() {
 	float_val := 0.5
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(1, 2))
+	assert fract_val == fractions.fraction(1, 2)
 }
 
 fn test_third() {
 	float_val := 1.0 / 3.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(1, 3))
+	assert fract_val == fractions.fraction(1, 3)
 }
 
 fn test_minus_one_twelfth() {
 	float_val := -1.0 / 12.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(-1, 12))
+	assert fract_val == fractions.fraction(-1, 12)
 }
 
 fn test_zero() {
@@ -27,37 +27,37 @@ fn test_zero() {
 	println('Pre')
 	fract_val := fractions.approximate(float_val)
 	println('Post')
-	assert fract_val.equals(fractions.fraction(0, 1))
+	assert fract_val == fractions.fraction(0, 1)
 }
 
 fn test_minus_one() {
 	float_val := -1.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(-1, 1))
+	assert fract_val == fractions.fraction(-1, 1)
 }
 
 fn test_thirty_three() {
 	float_val := 33.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(33, 1))
+	assert fract_val == fractions.fraction(33, 1)
 }
 
 fn test_millionth() {
 	float_val := 1.0 / 1000000.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(1, 1000000))
+	assert fract_val == fractions.fraction(1, 1000000)
 }
 
 fn test_minus_27_by_57() {
 	float_val := -27.0 / 57.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(-27, 57))
+	assert fract_val == fractions.fraction(-27, 57)
 }
 
 fn test_29_by_104() {
 	float_val := 29.0 / 104.0
 	fract_val := fractions.approximate(float_val)
-	assert fract_val.equals(fractions.fraction(29, 104))
+	assert fract_val == fractions.fraction(29, 104)
 }
 
 fn test_140710_232() {
@@ -69,121 +69,118 @@ fn test_140710_232() {
 }
 
 fn test_pi_1_digit() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-2).equals(fractions.fraction(22,
-		7))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-2) == fractions.fraction(22, 7)
 }
 
 fn test_pi_2_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-3).equals(fractions.fraction(22,
-		7))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-3) == fractions.fraction(22, 7)
 }
 
 fn test_pi_3_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-4).equals(fractions.fraction(333,
-		106))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-4) == fractions.fraction(333,
+		106)
 }
 
 fn test_pi_4_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-5).equals(fractions.fraction(355,
-		113))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-5) == fractions.fraction(355,
+		113)
 }
 
 fn test_pi_5_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-6).equals(fractions.fraction(355,
-		113))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-6) == fractions.fraction(355,
+		113)
 }
 
 fn test_pi_6_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-7).equals(fractions.fraction(355,
-		113))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-7) == fractions.fraction(355,
+		113)
 }
 
 fn test_pi_7_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-8).equals(fractions.fraction(103993,
-		33102))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-8) == fractions.fraction(103993,
+		33102)
 }
 
 fn test_pi_8_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-9).equals(fractions.fraction(103993,
-		33102))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-9) == fractions.fraction(103993,
+		33102)
 }
 
 fn test_pi_9_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-10).equals(fractions.fraction(104348,
-		33215))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-10) == fractions.fraction(104348,
+		33215)
 }
 
 fn test_pi_10_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-11).equals(fractions.fraction(312689,
-		99532))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-11) == fractions.fraction(312689,
+		99532)
 }
 
 fn test_pi_11_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-12).equals(fractions.fraction(1146408,
-		364913))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-12) == fractions.fraction(1146408,
+		364913)
 }
 
 fn test_pi_12_digits() {
-	assert fractions.approximate_with_eps(math.pi, 5.0e-13).equals(fractions.fraction(4272943,
-		1360120))
+	assert fractions.approximate_with_eps(math.pi, 5.0e-13) == fractions.fraction(4272943,
+		1360120)
 }
 
 fn test_phi_1_digit() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-2).equals(fractions.fraction(5,
-		3))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-2) == fractions.fraction(5, 3)
 }
 
 fn test_phi_2_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-3).equals(fractions.fraction(21,
-		13))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-3) == fractions.fraction(21,
+		13)
 }
 
 fn test_phi_3_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-4).equals(fractions.fraction(55,
-		34))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-4) == fractions.fraction(55,
+		34)
 }
 
 fn test_phi_4_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-5).equals(fractions.fraction(233,
-		144))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-5) == fractions.fraction(233,
+		144)
 }
 
 fn test_phi_5_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-6).equals(fractions.fraction(610,
-		377))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-6) == fractions.fraction(610,
+		377)
 }
 
 fn test_phi_6_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-7).equals(fractions.fraction(1597,
-		987))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-7) == fractions.fraction(1597,
+		987)
 }
 
 fn test_phi_7_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-8).equals(fractions.fraction(6765,
-		4181))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-8) == fractions.fraction(6765,
+		4181)
 }
 
 fn test_phi_8_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-9).equals(fractions.fraction(17711,
-		10946))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-9) == fractions.fraction(17711,
+		10946)
 }
 
 fn test_phi_9_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-10).equals(fractions.fraction(75025,
-		46368))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-10) == fractions.fraction(75025,
+		46368)
 }
 
 fn test_phi_10_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-11).equals(fractions.fraction(196418,
-		121393))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-11) == fractions.fraction(196418,
+		121393)
 }
 
 fn test_phi_11_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-12).equals(fractions.fraction(514229,
-		317811))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-12) == fractions.fraction(514229,
+		317811)
 }
 
 fn test_phi_12_digits() {
-	assert fractions.approximate_with_eps(math.phi, 5.0e-13).equals(fractions.fraction(2178309,
-		1346269))
+	assert fractions.approximate_with_eps(math.phi, 5.0e-13) == fractions.fraction(2178309,
+		1346269)
 }


### PR DESCRIPTION
I believe these substitutions accomplish the original intent of the tests.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 12b4f70</samp>

Updated the test file for fraction approximations to use the `==` operator instead of the `equals` method. This improves the readability and consistency of the code.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 12b4f70</samp>

*  Replace `equals` method with `==` operator for `fraction` struct in `vlib/math/fractions/approximations_test.v` ([link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL10-R10), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL16-R16), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL22-R22), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL30-R30), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL36-R36), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL42-R42), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL48-R48), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL54-R54), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL60-R60), [link](https://github.com/vlang/v/pull/19906/files?diff=unified&w=0#diff-65c51ce437d1619dbfa690ade0b3bdbd4e1b44cb2a1963b63bfcbec2facc00eeL72-R185))
