### PR TITLE
encoding.xml: fix parsing for self closing empty tags.

### DIFF
--- a/vlib/encoding/xml/parser.v
+++ b/vlib/encoding/xml/parser.v
@@ -562,7 +562,7 @@ pub fn parse_single_node(first_char u8, mut reader io.Reader) !XMLNode {
 	tag_contents := contents.str().trim_space()
 
 	parts := tag_contents.split_any(' \t\n')
-	name := parts[0]
+	name := parts[0].trim_right('/')
 
 	// Check if it is a self-closing tag
 	if tag_contents.ends_with('/') {

--- a/vlib/encoding/xml/parser_test.v
+++ b/vlib/encoding/xml/parser_test.v
@@ -7,6 +7,7 @@ const (
 	<c id="c2">
 		Sample Text
 	</c>
+	<empty/>
 	<c id="c3"/>
 	<abc id="c4"/>
 	<xyz id="c5"/>
@@ -33,6 +34,10 @@ const (
 			children: [
 				'Sample Text',
 			]
+		},
+		XMLNode{
+			name: 'empty'
+			attributes: {}
 		},
 		XMLNode{
 			name: 'c'


### PR DESCRIPTION
An edge case for empty self-closing tags like `<single/>` was causing errors during parsing. This PR fixes it and adds a test for it.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6094bb5</samp>

This pull request fixes a bug in the `encoding/xml` module that incorrectly parsed self-closing tags. It also adds a test case to verify the correct behavior of the XML parser.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6094bb5</samp>

* Fix a bug in the XML parser that caused self-closing tags to have a slash in their name ([link](https://github.com/vlang/v/pull/19907/files?diff=unified&w=0#diff-8c01226584bbc4a113c727c616317c4b98a725c0b2f1b7ec8b3776618771a261L565-R565))
* Add a test case for the XML parser that contains a self-closing tag ([link](https://github.com/vlang/v/pull/19907/files?diff=unified&w=0#diff-4383c2d5aa4c256686f50beb0ed5d9a5faa1214cb9617d313ea79046d81702c2R10),[link](https://github.com/vlang/v/pull/19907/files?diff=unified&w=0#diff-4383c2d5aa4c256686f50beb0ed5d9a5faa1214cb9617d313ea79046d81702c2R39-R42))
