### PR TITLE
docs: update deprecated attr syntax

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2344,7 +2344,7 @@ V doesn't have default function arguments or named arguments, for that trailing 
 literal syntax can be used instead:
 
 ```v
-[params]
+@[params]
 struct ButtonConfig {
 	text        string
 	is_disabled bool
@@ -2470,7 +2470,7 @@ For an example, consider the following source in a directory `sample`:
 ```v oksyntax
 module sample
 
-[noinit]
+@[noinit]
 pub struct Information {
 pub:
 	data string
@@ -4488,7 +4488,7 @@ be achieved by tagging your assert containing functions with an `[assert_continu
 tag, for example running this program:
 
 ```v
-[assert_continues]
+@[assert_continues]
 fn abc(ii int) {
 	assert ii == 2
 }
@@ -4640,7 +4640,7 @@ data types:
 ```v
 struct MyType {}
 
-[unsafe]
+@[unsafe]
 fn (data &MyType) free() {
 	// ...
 }
@@ -4813,7 +4813,7 @@ mut:
 }
 
 // see discussion below
-[heap]
+@[heap]
 struct MyStruct {
 	n int
 }
@@ -4974,7 +4974,7 @@ V's ORM provides a number of benefits:
 import db.sqlite
 
 // sets a custom table name. Default is struct name (case-sensitive)
-[table: 'customers']
+@[table: 'customers']
 struct Customer {
 	id        int    [primary; sql: serial] // a field named `id` of integer type must be the first field
 	name      string [nonull]
@@ -5353,7 +5353,7 @@ function/struct/enum declaration and applies only to the following declaration.
 ```v
 // [flag] enables Enum types to be used as bitfields
 
-[flag]
+@[flag]
 enum BitField {
 	read
 	write
@@ -5395,13 +5395,13 @@ Function/method deprecations:
 ```v
 // Calling this function will result in a deprecation warning
 
-[deprecated]
+@[deprecated]
 fn old_function() {
 }
 
 // It can also display a custom deprecation message
 
-[deprecated: 'use new_function() instead']
+@[deprecated: 'use new_function() instead']
 fn legacy_function() {}
 
 // You can also specify a date, after which the function will be
@@ -5413,19 +5413,19 @@ fn legacy_function() {}
 // 6 months after the deprecation date, calls will be hard
 // compiler errors.
 
-[deprecated: 'use new_function2() instead']
-[deprecated_after: '2021-05-27']
+@[deprecated: 'use new_function2() instead']
+@[deprecated_after: '2021-05-27']
 fn legacy_function2() {}
 ```
 
 ```v nofmt
 // This function's calls will be inlined.
-[inline]
+@[inline]
 fn inlined_function() {
 }
 
 // This function's calls will NOT be inlined.
-[noinline]
+@[noinline]
 fn function() {
 }
 
@@ -5434,7 +5434,7 @@ fn function() {
 // just like exit/1 or panic/1. Such functions can not
 // have return types, and should end either in for{}, or
 // by calling other `[noreturn]` functions.
-[noreturn]
+@[noreturn]
 fn forever() {
 	for {}
 }
@@ -5442,13 +5442,13 @@ fn forever() {
 // The following struct must be allocated on the heap. Therefore, it can only be used as a
 // reference (`&Window`) or inside another reference (`&OuterStruct{ Window{...} }`).
 // See section "Stack and Heap"
-[heap]
+@[heap]
 struct Window {
 }
 
 // V will not generate this function and all its calls if the provided flag is false.
 // To use a flag, use `v -d flag`
-[if debug]
+@[if debug]
 fn foo() {
 }
 
@@ -5458,7 +5458,7 @@ fn bar() {
 
 // The memory pointed to by the pointer arguments of this function will not be
 // freed by the garbage collector (if in use) before the function returns
-[keep_args_alive]
+@[keep_args_alive]
 fn C.my_external_function(voidptr, int, voidptr) int
 
 // Calls to following function must be in unsafe{} blocks.
@@ -5467,7 +5467,7 @@ fn C.my_external_function(voidptr, int, voidptr) int
 // This is useful, when you want to have an `[unsafe]` function that
 // has checks before/after a certain unsafe operation, that will still
 // benefit from V's safety features.
-[unsafe]
+@[unsafe]
 fn risky_business() {
 	// code that will be checked, perhaps checking pre conditions
 	unsafe {
@@ -5483,22 +5483,22 @@ fn risky_business() {
 
 // V's autofree engine will not take care of memory management in this function.
 // You will have the responsibility to free memory manually yourself in it.
-[manualfree]
+@[manualfree]
 fn custom_allocations() {
 }
 
 // For C interop only, tells V that the following struct is defined with `typedef struct` in C
-[typedef]
+@[typedef]
 pub struct C.Foo {
 }
 
 // Used to add a custom calling convention to a function, available calling convention: stdcall, fastcall and cdecl.
 // This list also applies for type aliases (see below).
-[callconv: "stdcall"]
+@[callconv: "stdcall"]
 fn C.DefWindowProc(hwnd int, msg int, lparam int, wparam int)
 
 // Used to add a custom calling convention to a function type aliases.
-[callconv: "fastcall"]
+@[callconv: "fastcall"]
 type FastFn = fn (int) bool
 
 // Windows only:
@@ -5508,7 +5508,7 @@ type FastFn = fn (int) bool
 // (e)println output can be seen.
 // Use it to force-open a terminal to view output in, even if the app is started from Explorer.
 // Valid before main() only.
-[console]
+@[console]
 fn main() {
 }
 ```
@@ -6776,7 +6776,7 @@ For example, `fn foo() {}` in module `bar` will result in `bar__foo()`.
 To use a custom export name, use the `[export]` attribute:
 
 ```
-[export: 'my_custom_c_name']
+@[export: 'my_custom_c_name']
 fn foo() {
 }
 ```
@@ -6902,7 +6902,7 @@ module main
 
 import time
 
-[live]
+@[live]
 fn print_message() {
 	println('Hello! Modify this message while the program is running.')
 }

--- a/examples/js_dom_cube/README.md
+++ b/examples/js_dom_cube/README.md
@@ -140,7 +140,7 @@ fn new_app() &App {
 	return app
 }
 
-['/'; get]
+@['/'; get]
 pub fn (mut app App) controller_get_all_task() vweb.Result {
 	file := os.read_file('./index.html') or { panic(err) }
 	return app.html(file)

--- a/examples/js_dom_draw/README.md
+++ b/examples/js_dom_draw/README.md
@@ -142,7 +142,7 @@ fn new_app() &App {
 	return app
 }
 
-['/'; get]
+@['/'; get]
 pub fn (mut app App) controller_get_all_task() vweb.Result {
 	file := os.read_file('./index.html') or { panic(err) }
 	return app.html(file)

--- a/examples/js_dom_draw_bechmark_chart/README.md
+++ b/examples/js_dom_draw_bechmark_chart/README.md
@@ -54,7 +54,7 @@ exit
 In `v_vweb_orm/src/main.v`, create a route that returns a `Response` struct.
 
 ```v ignore
-['/sqlite-memory/:count']
+@['/sqlite-memory/:count']
 pub fn (mut app App) sqlite_memory(count int) vweb.Result {
 	mut insert_stopwatchs := []int{}
 	mut select_stopwatchs := []int{}

--- a/examples/js_dom_draw_bechmark_chart/chart/README.md
+++ b/examples/js_dom_draw_bechmark_chart/chart/README.md
@@ -19,7 +19,7 @@ In `examples/js_dom_draw_bechmark_chart/v_vweb_orm/src/main.v` path
 Create a route returning a `Response` struct like:
 
 ```v ignore
-['/sqlite-memory/:count']
+@['/sqlite-memory/:count']
 pub fn (mut app App) sqlite_memory(count int) vweb.Result {
 	mut insert_stopwatchs := []int{}
 	mut select_stopwatchs := []int{}

--- a/tutorials/C2V_translating_simple_programs_and_DOOM/README.md
+++ b/tutorials/C2V_translating_simple_programs_and_DOOM/README.md
@@ -49,7 +49,7 @@ It will create `primes.v` with the following contents:
 
 
 ```v
-[translated]
+@[translated]
 module main
 
 fn is_prime(x int) bool {

--- a/tutorials/building_a_simple_web_blog_with_vweb/README.md
+++ b/tutorials/building_a_simple_web_blog_with_vweb/README.md
@@ -69,7 +69,7 @@ fn main() {
 	vweb.run(app, 8081)
 }
 
-['/index']
+@['/index']
 pub fn (mut app App) index() vweb.Result {
 	return app.text('Hello world from vweb!')
 }
@@ -336,7 +336,7 @@ Create `new.html`:
 // article.v
 import vweb
 
-[post]
+@[post]
 pub fn (mut app App) new_article(title string, text string) vweb.Result {
 	if title == '' || text == '' {
 		return app.text('Empty text/title')
@@ -368,7 +368,7 @@ We need to update `index.html` to add a link to the "new article" page:
 Next we need to add the HTML endpoint to our code like we did with `index.html`:
 
 ```v ignore
-['/new']
+@['/new']
 pub fn (mut app App) new() vweb.Result {
 	return $vweb.html()
 }
@@ -386,7 +386,7 @@ in V is very simple:
 // article.v
 import vweb
 
-['/articles'; get]
+@['/articles'; get]
 pub fn (mut app App) articles() vweb.Result {
 	articles := app.find_all_articles()
 	return app.json(articles)

--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -30,7 +30,7 @@ non-option fields are defied as NOT NULL when creating tables.
 ```v ignore
 import time
 
-[table: 'foos']
+@[table: 'foos']
 struct Foo {
     id          int         [primary; sql: serial]
     name        string

--- a/vlib/sokol/README.md
+++ b/vlib/sokol/README.md
@@ -21,7 +21,7 @@ const (
 	sw_start_ms = sw.elapsed().milliseconds()
 )
 
-[inline]
+@[inline]
 fn sintone(periods int, frame int, num_frames int) f32 {
 	return math.sinf(f32(periods) * (2 * math.pi) * f32(frame) / f32(num_frames))
 }

--- a/vlib/v/fmt/tests/fn_call_with_call_expr_and_params_struct_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_call_with_call_expr_and_params_struct_args_keep.vv
@@ -1,4 +1,4 @@
-[params]
+@[params]
 struct Bar {
 	bar bool
 }

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -67,7 +67,7 @@ fn new_app() &App {
 	return app
 }
 
-['/']
+@['/']
 pub fn (mut app App) page_home() vweb.Result {
 	// all this constants can be accessed by src/templates/page/home.html file.
 	page_title := 'V is the new V'
@@ -182,7 +182,7 @@ fn (mut app App) hello() vweb.Result {
 }
 
 // This endpoint can be accessed via http://localhost:port/foo
-["/foo"]
+@["/foo"]
 fn (mut app App) world() vweb.Result {
 	return app.text('World')
 }
@@ -197,12 +197,12 @@ you can simply add the attribute before the function definition.
 **Example:**
 
 ```v ignore
-[post]
+@[post]
 fn (mut app App) world() vweb.Result {
 	return app.text('World')
 }
 
-['/product/create'; post]
+@['/product/create'; post]
 fn (mut app App) create_product() vweb.Result {
 	return app.text('product')
 }
@@ -220,7 +220,7 @@ After it is defined in the attribute, you have to add it as a function parameter
 
 ```v ignore
           vvvv
-['/hello/:user']            vvvv
+@['/hello/:user']            vvvv
 fn (mut app App) hello_user(user string) vweb.Result {
 	return app.text('Hello $user')
 }
@@ -245,7 +245,7 @@ This will match all routes after `'/'`. For example the url `/path/to/test` woul
 
 ```v ignore
         vvv
-['/:path...']             vvvv
+@['/:path...']             vvvv
 fn (mut app App) wildcard(path string) vweb.Result {
 	return app.text('URL path = "${path}"')
 }
@@ -269,7 +269,7 @@ fn main() {
 	vweb.run(&App{}, 8081)
 }
 
-['/user'; get]
+@['/user'; get]
 pub fn (mut app App) controller_get_user_by_id() vweb.Result {
 	// http://localhost:3000/user?q=vpm&order_by=desc => { 'q': 'vpm', 'order_by': 'desc' }
 	return app.text(app.query.str())
@@ -283,18 +283,18 @@ by adding a host to the "hosts" file of your device.
 **Example:**
 
 ```v ignore
-['/'; host: 'example.com']
+@['/'; host: 'example.com']
 pub fn (mut app App) hello_web() vweb.Result {
 	return app.text('Hello World')
 }
 
-['/'; host: 'api.example.org']
+@['/'; host: 'api.example.org']
 pub fn (mut app App) hello_api() vweb.Result {
 	return app.text('Hello API')
 }
 
 // define the handler without a host attribute last if you have conflicting paths.
-['/']
+@['/']
 pub fn (mut app App) hello_others() vweb.Result {
 	return app.text('Hello Others')
 }
@@ -376,8 +376,8 @@ Middleware can also be added to route specific functions via attributes.
 
 **Example:**
 ```v ignore
-[middleware: check_auth]
-['/admin/data']
+@[middleware: check_auth]
+@['/admin/data']
 pub fn (mut app App) admin() vweb.Result {
 	// ...
 }
@@ -489,7 +489,7 @@ pub fn (mut app App) before_request() {
 ```
 
 ```v ignore
-['/articles'; get]
+@['/articles'; get]
 pub fn (mut app App) articles() vweb.Result {
 	if !app.token {
 		app.redirect('/login')
@@ -503,14 +503,14 @@ You can also combine middleware and redirect.
 **Example:**
 
 ```v ignore
-[middleware: with_auth]
-['/admin/secret']
+@[middleware: with_auth]
+@['/admin/secret']
 pub fn (mut app App) admin_secret() vweb.Result {
 	// this code should never be reached
 	return app.text('secret')
 }
 
-['/redirect']
+@['/redirect']
 pub fn (mut app App) with_auth() bool {
 	app.redirect('/auth/login')
 	return false
@@ -767,7 +767,7 @@ will simply be ignored.
 Any route inside a controller struct is treated as a relative route to its controller namespace.
 
 ```v ignore
-['/path']
+@['/path']
 pub fn (mut app Admin) path vweb.Result {
     return app.text('Admin')
 }
@@ -780,7 +780,7 @@ Vweb doesn't support fallback routes or duplicate routes, so if we add the follo
 route to the example the code will produce an error.
 
 ```v ignore
-['/admin/path']
+@['/admin/path']
 pub fn (mut app App) admin_path vweb.Result {
     return app.text('Admin overwrite')
 }
@@ -916,7 +916,7 @@ Sets the response status
 **Example:**
 
 ```v ignore
-['/user/get_all'; get]
+@['/user/get_all'; get]
 pub fn (mut app App) controller_get_all_user() vweb.Result {
     token := app.get_header('token')
 
@@ -961,7 +961,7 @@ Response HTTP_OK with payload with content-type `application/json`
 **Examples:**
 
 ```v ignore
-['/articles'; get]
+@['/articles'; get]
 pub fn (mut app App) articles() vweb.Result {
     articles := app.find_all_articles()
     json_result := json.encode(articles)
@@ -970,7 +970,7 @@ pub fn (mut app App) articles() vweb.Result {
 ```
 
 ```v ignore
-['/user/create'; post]
+@['/user/create'; post]
 pub fn (mut app App) controller_create_user() vweb.Result {
     body := json.decode(User, app.req.data) or {
         app.set_status(400, '')
@@ -1009,7 +1009,7 @@ Response HTTP_OK with payload
 **Example:**
 
 ```v ignore
-['/form_echo'; post]
+@['/form_echo'; post]
 pub fn (mut app App) form_echo() vweb.Result {
     app.set_content_type(app.req.header.get(.content_type) or { '' })
     return app.ok(app.form['foo'])
@@ -1033,7 +1033,7 @@ Response HTTP_NOT_FOUND with payload
 **Example:**
 
 ```v ignore
-['/:user/:repo/settings']
+@['/:user/:repo/settings']
 pub fn (mut app App) user_repo_settings(username string, repository string) vweb.Result {
     if username !in known_users {
         return app.not_found()
@@ -1050,7 +1050,7 @@ Returns the header data from the key
 **Example:**
 
 ```v ignore
-['/user/get_all'; get]
+@['/user/get_all'; get]
 pub fn (mut app App) controller_get_all_user() vweb.Result {
     token := app.get_header('token')
     return app.text(token)
@@ -1074,7 +1074,7 @@ Adds an header to the response with key and val
 **Example:**
 
 ```v ignore
-['/upload'; post]
+@['/upload'; post]
 pub fn (mut app App) upload() vweb.Result {
     fdata := app.files['upfile']
 
@@ -1132,7 +1132,7 @@ Sets the response content type
 **Example:**
 
 ```v ignore
-['/form_echo'; post]
+@['/form_echo'; post]
 pub fn (mut app App) form_echo() vweb.Result {
     app.set_content_type(app.req.header.get(.content_type) or { '' })
     return app.ok(app.form['foo'])


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8aa2666</samp>

This pull request replaces the old bracket syntax for various attributes in V with the new `@` syntax. This affects the documentation, the tutorials, the examples, and some libraries and tests. The purpose of this change is to make the code more consistent and readable.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8aa2666</samp>

*  Update the syntax for various attributes in the documentation and example code to use `@` instead of `[` and `]` ([link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L2347-R2347)-[link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-e0f1f79ad24bb0fe6681f0cfc37ddc05ff9d4ba204b82a693ec0a2fe1db3def8L6905-R6905), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-11aa131d69a6bd3b74813a8491aa8e62c697157c3f65d1996b6b9714e3ee6252L143-R143), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-87ee4435420a0def4ee0804ab87756589945eb83670f2626923d2eda5ed6b6dcL145-R145), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-18aa6fe8043f1ae74500893a63cb703b6605f4008ff0c8bad64bcb2bd47cb187L57-R57), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-7664593f6ab536c426acaa2efcbcd0d734c08e687883bdd3b840855ad4af3321L22-R22), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-223f93c3dd4746d42252c02e7321f6dd78f0a83fe16cb0289ae07d6c59ce5e4fL52-R52), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-1943859407147a5d9a13245de5c67b28e86eea35e89564f2467440724d76e57dL72-R72), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-1943859407147a5d9a13245de5c67b28e86eea35e89564f2467440724d76e57dL339-R339), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-1943859407147a5d9a13245de5c67b28e86eea35e89564f2467440724d76e57dL371-R371), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-1943859407147a5d9a13245de5c67b28e86eea35e89564f2467440724d76e57dL389-R389), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-caf52246f0bcc9ee35344c0f5999fe028ac174a778aefedde2f1cfd7f27d6af5L33-R33), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-74ea4aaa4609d2184805a7b46a56cbcd6d9b8030385301b29a4ee53aff11854eL24-R24), [link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L70-R70)-[link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-0363f38173fe973cfa73ea26ebe6ed582a470e86ad0ef0b249acde5755c22f80L1135-R1135))
* Update the syntax for the `[params]` attribute in the test code for the V formatter to use `@` instead of `[` and `]` ([link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-954b1b306f6b7b10df7a49ee0a1edcb02bae057a59a5e9c552665688bac1d0eeL1-R1))
* Remove a trailing whitespace in the documentation for the C to V translation ([link](https://github.com/vlang/v/pull/19908/files?diff=unified&w=0#diff-223f93c3dd4746d42252c02e7321f6dd78f0a83fe16cb0289ae07d6c59ce5e4fL338-R338))
