### PR TITLE
checker, cgen: fix arrays alias built-in methods call(fix #19896)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -468,8 +468,8 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	}
 
 	ret_typ := g.typ(node.return_type)
-	ret_sym := g.table.sym(node.return_type)
-	inp_sym := g.table.sym(node.receiver_type)
+	ret_sym := g.table.final_sym(node.return_type)
+	inp_sym := g.table.final_sym(node.receiver_type)
 	ret_info := ret_sym.info as ast.Array
 	mut ret_elem_type := g.typ(ret_info.elem_type)
 	inp_info := inp_sym.info as ast.Array
@@ -581,7 +581,7 @@ fn (mut g Gen) gen_array_sorted(node ast.CallExpr) {
 		g.past_tmp_var_done(past)
 	}
 	atype := g.typ(node.return_type)
-	sym := g.table.sym(node.return_type)
+	sym := g.table.final_sym(node.return_type)
 	info := sym.info as ast.Array
 	depth := g.get_array_depth(info.elem_type)
 
@@ -601,7 +601,7 @@ fn (mut g Gen) gen_array_sorted(node ast.CallExpr) {
 // `users.sort(a.age < b.age)`
 fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	// println('filter s="$s"')
-	rec_sym := g.table.sym(node.receiver_type)
+	rec_sym := g.table.final_sym(node.receiver_type)
 	if rec_sym.kind != .array {
 		println(node.name)
 		println(g.typ(node.receiver_type))
@@ -724,7 +724,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 		g.past_tmp_var_done(past)
 	}
 
-	sym := g.table.sym(node.return_type)
+	sym := g.table.final_sym(node.return_type)
 	if sym.kind != .array {
 		verror('filter() requires an array')
 	}
@@ -1121,7 +1121,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 		g.past_tmp_var_done(past)
 	}
 
-	sym := g.table.sym(node.left_type)
+	sym := g.table.final_sym(node.left_type)
 	info := sym.info as ast.Array
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)
@@ -1200,7 +1200,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 		g.past_tmp_var_done(past)
 	}
 
-	sym := g.table.sym(node.left_type)
+	sym := g.table.final_sym(node.left_type)
 	info := sym.info as ast.Array
 	// styp := g.typ(node.return_type)
 	elem_type_str := g.typ(info.elem_type)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1257,7 +1257,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	left_sym := g.table.sym(left_type)
 	final_left_sym := g.table.final_sym(left_type)
-	if left_sym.kind == .array {
+	if left_sym.kind == .array || (final_left_sym.kind == .array
+		&& node.name in ['filter', 'map', 'sort', 'sorted', 'contains', 'any', 'all']) {
 		if g.gen_array_method_call(node, left_type) {
 			return
 		}

--- a/vlib/v/tests/alias_array_built_in_methods_test.v
+++ b/vlib/v/tests/alias_array_built_in_methods_test.v
@@ -1,0 +1,25 @@
+type IntArray = []int
+
+fn test_alias_array_method() {
+	mut arr := IntArray([0, 1, 2, 3])
+	res := arr.filter(it > 0)
+	assert res == IntArray([1, 2, 3])
+
+	assert arr.first() == 0
+	assert arr.last() == 3
+	arr.pop()
+	assert arr == IntArray([0, 1, 2])
+
+	arr2 := arr.map(it)
+	assert arr2 == [0, 1, 2]
+
+	assert arr.any(it > 0)
+	assert !arr.all(it > 0)
+
+	arr.sort(a > b)
+	assert arr == IntArray([2, 1, 0])
+	arr.sort()
+	assert arr == IntArray([0, 1, 2])
+
+	assert arr.contains(1)
+}


### PR DESCRIPTION
1. Fixed #19896 
2. Fixed built-in methods: filter, map, any, all, sort, sorted, contains.
3. Add tests.

```v
enum MsgType {
	null  = 0
	text  = 1
	ctrl  = 2
	frame = 3
}

struct Msg {
	msg_type MsgType
	payload  []u8
}

type Msgs = []Msg

fn main() {
	msgs0 := [Msg{
		msg_type: .null
	}, Msg{
		msg_type: .text
	}, Msg{
		msg_type: .null
	}, Msg{
		msg_type: .frame
	}]

	// it works without aliased msg
	msgs1 := msgs0.clone()
	null_msgs1 := msgs1.filter(it.msg_type == .null)
	dump(null_msgs1)

	// with aliased array
	msgs2 := Msgs(msgs0)
	null_msgs2 := msgs2.filter(it.msg_type == .null)
	dump(null_msgs2)
}
```

outputs:

```
[a.v:29] null_msgs1: [Msg{
    msg_type: null
    payload: []
}, Msg{
    msg_type: null
    payload: []
}]
[a.v:34] null_msgs2: Msgs([Msg{
    msg_type: null
    payload: []
}, Msg{
    msg_type: null
    payload: []
}])
```