### PR TITLE
tools.vpm: support again `http` installs when installing from an url (workaround)

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -52,13 +52,22 @@ fn parse_query(query []string) ([]Module, []Module) {
 	mut errors := 0
 	for m in query {
 		ident, version := m.rsplit_once('@') or { m, '' }
-		mut mod := if ident.starts_with('https://') || ident.starts_with('http://') {
-			name := get_name_from_url(ident) or {
+		is_http := if ident.starts_with('http://') {
+			vpm_warn('installing `${ident}` via http.
+${' '.repeat('warning: '.len)}`http` support is deprecated, switch to `https` to ensure future compatibility.')
+			true
+		} else {
+			false
+		}
+		mut mod := if is_http || ident.starts_with('https://') {
+			publisher, name := get_ident_from_url(ident) or {
 				vpm_error(err.msg())
 				errors++
 				continue
 			}
-			install_path := os.real_path(os.join_path(settings.vmodules_path, name))
+			base := if is_http { publisher } else { '' }
+			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
+				base, name)))
 			if !has_vmod(ident, install_path) {
 				errors++
 				continue
@@ -76,9 +85,9 @@ fn parse_query(query []string) ([]Module, []Module) {
 				errors++
 				continue
 			}
-			name_normalized := info.name.replace('-', '_').to_lower()
-			name_as_path := name_normalized.replace('.', os.path_separator)
-			install_path := os.real_path(os.join_path(settings.vmodules_path, name_as_path))
+			ident_as_path := info.name.replace('.', os.path_separator)
+			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
+				ident_as_path)))
 			Module{
 				name: info.name
 				url: info.url
@@ -198,14 +207,23 @@ fn get_mod_vpm_info(name string) !ModuleVpmInfo {
 	return error(errors.join_lines())
 }
 
-fn get_name_from_url(raw_url string) !string {
+fn get_ident_from_url(raw_url string) !(string, string) {
 	url := urllib.parse(raw_url) or { return error('failed to parse module URL `${raw_url}`.') }
-	owner, mut name := url.path.trim_left('/').rsplit_once('/') or {
+	publisher, mut name := url.path.trim_left('/').rsplit_once('/') or {
 		return error('failed to retrieve module name for `${url}`.')
 	}
-	vpm_log(@FILE_LINE, @FN, 'raw_url: ${raw_url}; owner: ${owner}; name: ${name}')
+	vpm_log(@FILE_LINE, @FN, 'raw_url: ${raw_url}; publisher: ${publisher}; name: ${name}')
 	name = if name.ends_with('.git') { name.replace('.git', '') } else { name }
-	return name.replace('-', '_').to_lower()
+	return publisher, name
+}
+
+fn get_name_from_url(raw_url string) !string {
+	_, name := get_ident_from_url(raw_url)!
+	return name
+}
+
+fn normalize_mod_path(path string) string {
+	return path.replace('-', '_').to_lower()
 }
 
 fn get_outdated() ![]string {
@@ -367,8 +385,7 @@ fn increment_module_download_count(name string) ! {
 
 fn get_manifest(path string) ?vmod.Manifest {
 	return vmod.from_file(os.join_path(path, 'v.mod')) or {
-		eprintln(term.ecolorize(term.yellow, 'warning: ') +
-			'failed to find v.mod file for `${path.all_after_last(os.path_separator)}`.')
+		vpm_warn('failed to find v.mod file for `${path.all_after_last(os.path_separator)}`.')
 		return none
 	}
 }
@@ -419,6 +436,10 @@ fn vpm_error(msg string, opts ErrorOptions) {
 			eprintln(term.ecolorize(term.blue, line))
 		}
 	}
+}
+
+fn vpm_warn(msg string) {
+	eprintln(term.ecolorize(term.yellow, 'warning: ') + msg)
 }
 
 // Formatted version of the vmodules install path. E.g. `/home/user/.vmodules` -> `~/.vmodules`

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -52,7 +52,7 @@ fn parse_query(query []string) ([]Module, []Module) {
 	mut errors := 0
 	for m in query {
 		ident, version := m.rsplit_once('@') or { m, '' }
-		mut mod := if ident.starts_with('https://') {
+		mut mod := if ident.starts_with('https://') || ident.starts_with('http://') {
 			name := get_name_from_url(ident) or {
 				vpm_error(err.msg())
 				errors++

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -52,13 +52,16 @@ fn test_install_from_git_url() {
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
-	res = os.execute_or_exit('${v} install https://github.com/vlang/vsl')
-	assert res.output.contains('Installing `vsl`'), res.output
-	mod = vmod.from_file(os.join_path(test_path, 'vsl', 'v.mod')) or {
+	res = os.execute_or_exit('${v} install http://github.com/Wertzui123/HashMap')
+	assert res.output.contains('Installing `HashMap`'), res.output
+	assert res.output.contains('`http` support is deprecated, switch to `https` to ensure future compatibility.'), res.output
+	mod = vmod.from_file(os.join_path(test_path, 'wertzui123', 'hashmap', 'v.mod')) or {
 		assert false, err.msg()
 		return
 	}
-	assert mod.name == 'vsl'
+	res = os.execute_or_exit('${v} install http://github.com/Wertzui123/HashMap')
+	assert res.output.contains('Updating module `wertzui123.hashmap`'), res.output
+	assert res.output.contains('`http` support is deprecated, switch to `https` to ensure future compatibility.'), res.output
 }
 
 fn test_install_already_existent() {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -44,14 +44,21 @@ fn test_install_from_vpm_short_ident() {
 }
 
 fn test_install_from_git_url() {
-	res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
+	mut res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
 	assert res.output.contains('Installing `markdown`'), res.output
-	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
+	mut mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
 		return
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
+	res = os.execute_or_exit('${v} install https://github.com/vlang/vsl')
+	assert res.output.contains('Installing `vsl`'), res.output
+	mod = vmod.from_file(os.join_path(test_path, 'vsl', 'v.mod')) or {
+		assert false, err.msg()
+		return
+	}
+	assert mod.name == 'vsl'
 }
 
 fn test_install_already_existent() {


### PR DESCRIPTION
Until we make a decision on eventual changes of the default install location of url installs this enables http installs to work like https installs.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 436b7c4</samp>

Improve `vpm` tool by refactoring tests, adding a new test case, and supporting both `https` and `http` URLs for module installation.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 436b7c4</samp>

* Enable `vpm` to install modules from `http` URLs ([link](https://github.com/vlang/v/pull/19914/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L55-R55))
* Move `test_install_from_git_url` to `common.v` to avoid duplication ([link](https://github.com/vlang/v/pull/19914/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L47-R49))
* Add test case for installing `vsl` from `https` URL ([link](https://github.com/vlang/v/pull/19914/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R55-R61))
