### PR TITLE
v: implement aligned attr for struct

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6107,7 +6107,7 @@ sure that the access index will be valid.
 
 #### `[packed]`
 
-The `[packed]` attribute can be applied to a structure to create an unaligned memory layout,
+The `@[packed]` attribute can be applied to a structure to create an unaligned memory layout,
 which decreases the overall memory footprint of the structure. Using the `[packed]` attribute
 may negatively impact performance or even be prohibited on certain CPU architectures.
 
@@ -6124,10 +6124,9 @@ is needed.
 
 The `@[aligned]` attribute can be applied to a structure or union to specify a minimum alignment
 (in bytes) for variables of that type. Using the `@[aligned]` attribute you can only *increase*
-the default alignment. 
-Use `@[packed]` you want to *decrease* it. The alignment of any struct or union, should be at
-least a perfect multiple of the lowest common multiple of the alignments of all of the members
-of the struct or union.
+the default alignment. Use `@[packed]` if you want to *decrease* it. The alignment of any struct
+or union, should be at least a perfect multiple of the lowest common multiple of the alignments of
+all of the members of the struct or union.
 
 Example:
 ```v
@@ -6148,14 +6147,15 @@ specialised machine instructions, that do require a specific alignment to work.
 
 - On CPU architectures, that do not support unaligned memory access. If you are not working on
 performance critical algorithms, you do not really need it, since the proper minimum alignment
-is CPU specific.
+is CPU specific, and the compiler already usually will choose a good default for you.
 
-You can leave out the alignment factor, i.e. use just `@[aligned]`, in which case the compiler
-will align a type to the maximum useful alignment for the target machine you are compiling for,
-i.e. the alignment will be the largest alignment which is ever used for any data type on the
-target machine. Doing this can often make copy operations more efficient, because the compiler
-can choose whatever instructions copy the biggest chunks of memory, when performing copies to or
-from the variables which have types that you have aligned this way.
+> **Note**
+> You can leave out the alignment factor, i.e. use just `@[aligned]`, in which case the compiler
+> will align a type to the maximum useful alignment for the target machine you are compiling for,
+> i.e. the alignment will be the largest alignment which is ever used for any data type on the
+> target machine. Doing this can often make copy operations more efficient, because the compiler
+> can choose whatever instructions copy the biggest chunks of memory, when performing copies to or
+> from the variables which have types that you have aligned this way.
 
 See also ["What Every Programmer Should Know About Memory", by Ulrich Drepper](https://people.freebsd.org/~lstewart/articles/cpumemory.pdf) .
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6120,6 +6120,20 @@ may negatively impact performance or even be prohibited on certain CPU architect
 - On CPU architectures that do not support unaligned memory access or when high-speed memory access
 is needed.
 
+#### `[aligned]`
+
+The `[aligned]` attribute can be added to a structure to specify a minimum alignment (in bytes). 
+Using the `[aligned]` attribute you can increase the alignment, when using `[packed]` you can decrease it.
+
+**When to Use**
+
+- When memory usage is more critical than performance, e.g., in embedded systems.
+
+**When to Avoid**
+
+- On CPU architectures that do not support unaligned memory access or when high-speed memory access
+is needed.
+
 #### `[minify]`
 
 The `[minify]` attribute can be added to a struct, allowing the compiler to reorder the fields in

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6107,7 +6107,7 @@ sure that the access index will be valid.
 
 #### `[packed]`
 
-The `[packed]` attribute can be added to a structure to create an unaligned memory layout,
+The `[packed]` attribute can be applied to a structure to create an unaligned memory layout,
 which decreases the overall memory footprint of the structure. Using the `[packed]` attribute
 may negatively impact performance or even be prohibited on certain CPU architectures.
 
@@ -6122,18 +6122,42 @@ is needed.
 
 #### `[aligned]`
 
-The `[aligned]` attribute can be added to a structure to specify a minimum alignment (in bytes). 
-Using the `[aligned]` attribute you can increase the alignment, when using `[packed]` you can 
-decrease it.
+The `@[aligned]` attribute can be applied to a structure or union to specify a minimum alignment
+(in bytes) for variables of that type. Using the `@[aligned]` attribute you can only *increase*
+the default alignment. 
+Use `@[packed]` you want to *decrease* it. The alignment of any struct or union, should be at
+least a perfect multiple of the lowest common multiple of the alignments of all of the members
+of the struct or union.
 
+Example:
+```v
+// Each u16 in the `data` field below, takes 2 bytes, and we have 3 of them = 6 bytes.
+// The smallest power of 2, bigger than 6 is 8, i.e. with `@[aligned]`, the alignment
+// for the entire struct U16s, will be 8:
+@[aligned]
+struct U16s {
+	data [3]u16
+}
+```
 **When to Use**
 
-- When memory usage is more critical than performance, e.g., in embedded systems.
+- Only if the instances of your types, will be used in performance critical sections, or with
+specialised machine instructions, that do require a specific alignment to work.
 
 **When to Avoid**
 
-- On CPU architectures that do not support unaligned memory access or when high-speed memory access
-is needed.
+- On CPU architectures, that do not support unaligned memory access. If you are not working on
+performance critical algorithms, you do not really need it, since the proper minimum alignment
+is CPU specific.
+
+You can leave out the alignment factor, i.e. use just `@[aligned]`, in which case the compiler
+will align a type to the maximum useful alignment for the target machine you are compiling for,
+i.e. the alignment will be the largest alignment which is ever used for any data type on the
+target machine. Doing this can often make copy operations more efficient, because the compiler
+can choose whatever instructions copy the biggest chunks of memory, when performing copies to or
+from the variables which have types that you have aligned this way.
+
+See also ["What Every Programmer Should Know About Memory", by Ulrich Drepper](https://people.freebsd.org/~lstewart/articles/cpumemory.pdf) .
 
 #### `[minify]`
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6123,7 +6123,8 @@ is needed.
 #### `[aligned]`
 
 The `[aligned]` attribute can be added to a structure to specify a minimum alignment (in bytes). 
-Using the `[aligned]` attribute you can increase the alignment, when using `[packed]` you can decrease it.
+Using the `[aligned]` attribute you can increase the alignment, when using `[packed]` you can 
+decrease it.
 
 **When to Use**
 

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -573,7 +573,7 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 	}
 	g.type_definitions.write_string('}${ti_attrs}')
 	if !g.is_cc_msvc && aligned_attr != '' {
-		g.type_definitions.writeln(' ${aligned_attr}')
+		g.type_definitions.write_string(' ${aligned_attr}')
 	}
 	if !is_anon {
 		g.type_definitions.write_string(';')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -476,14 +476,16 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 		return
 	} else if s.is_union {
 		if g.is_cc_msvc && aligned_attr != '' {
-			g.type_definitions.writeln('${aligned_attr} ')
+			g.type_definitions.writeln('union ${aligned_attr} ${name} {')
+		} else {
+			g.type_definitions.writeln('union ${name} {')
 		}
-		g.type_definitions.writeln('union ${name} {')
 	} else {
 		if g.is_cc_msvc && aligned_attr != '' {
-			g.type_definitions.writeln('${aligned_attr} ')
+			g.type_definitions.writeln('struct ${aligned_attr} ${name} {')
+		} else {
+			g.type_definitions.writeln('struct ${name} {')
 		}
-		g.type_definitions.writeln('struct ${name} {')
 	}
 
 	if s.fields.len > 0 || s.embeds.len > 0 {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -549,10 +549,18 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 	} else {
 		g.type_definitions.writeln('\tEMPTY_STRUCT_DECLARATION;')
 	}
-	ti_attrs := if !g.is_cc_msvc && s.attrs.contains('packed') {
+	mut ti_attrs := if !g.is_cc_msvc && s.attrs.contains('packed') {
 		'__attribute__((__packed__))'
 	} else {
 		''
+	}
+	if attr := s.attrs.find_first('aligned') {
+		attr_arg := if attr.arg == '' { '' } else { ' (${attr.arg})' }
+		ti_attrs += if g.is_cc_msvc {
+			'__declspec(align(${attr_arg}))'
+		} else {
+			' __attribute__((aligned${attr_arg}))'
+		}
 	}
 	g.type_definitions.write_string('}${ti_attrs}')
 	if !is_anon {

--- a/vlib/v/gen/c/testdata/aligned_attr.c.must_have
+++ b/vlib/v/gen/c/testdata/aligned_attr.c.must_have
@@ -1,0 +1,9 @@
+struct main__Test {
+        int a;
+}  __attribute__((aligned))
+;
+
+struct main__Test2 {
+        int a;
+        int b;
+}  __attribute__((aligned (16)))

--- a/vlib/v/gen/c/testdata/aligned_attr.c.must_have
+++ b/vlib/v/gen/c/testdata/aligned_attr.c.must_have
@@ -1,9 +1,2 @@
-struct main__Test {
-        int a;
 }  __attribute__((aligned))
-;
-
-struct main__Test2 {
-        int a;
-        int b;
 }  __attribute__((aligned (16)))

--- a/vlib/v/gen/c/testdata/aligned_attr.vv
+++ b/vlib/v/gen/c/testdata/aligned_attr.vv
@@ -1,0 +1,10 @@
+@[aligned]
+struct Test {
+	a int
+}
+
+@[aligned:16]
+struct Test2 {
+	a int 
+	b int
+}

--- a/vlib/v/gen/c/testdata/aligned_attr_nix.c.must_have
+++ b/vlib/v/gen/c/testdata/aligned_attr_nix.c.must_have
@@ -1,2 +1,2 @@
-}  __attribute__((aligned))
+}  __attribute__((aligned (8)))
 }  __attribute__((aligned (16)))

--- a/vlib/v/gen/c/testdata/aligned_attr_nix.c.must_have
+++ b/vlib/v/gen/c/testdata/aligned_attr_nix.c.must_have
@@ -1,2 +1,3 @@
-}  __attribute__((aligned (8)))
+}  __attribute__((aligned))
 }  __attribute__((aligned (16)))
+}  __attribute__((aligned (8)))

--- a/vlib/v/gen/c/testdata/aligned_attr_nix.vv
+++ b/vlib/v/gen/c/testdata/aligned_attr_nix.vv
@@ -8,3 +8,9 @@ struct Test2 {
 	a int 
 	b int
 }
+
+@[aligned:8]
+enum Test3 {
+	a
+	b
+}

--- a/vlib/v/gen/c/testdata/aligned_attr_nix.vv
+++ b/vlib/v/gen/c/testdata/aligned_attr_nix.vv
@@ -10,7 +10,6 @@ struct Test2 {
 }
 
 @[aligned:8]
-enum Test3 {
-	a
-	b
+union Test3 {
+	a int
 }

--- a/vlib/v/gen/c/testdata/aligned_attr_windows.c.must_have
+++ b/vlib/v/gen/c/testdata/aligned_attr_windows.c.must_have
@@ -1,3 +1,3 @@
 struct __declspec(align (8)) main__Test {
 struct __declspec(align (16)) main__Test2 {
-enum __declspec(align (8)) main__Test3 {
+union __declspec(align (8)) main__Test3 {

--- a/vlib/v/gen/c/testdata/aligned_attr_windows.c.must_have
+++ b/vlib/v/gen/c/testdata/aligned_attr_windows.c.must_have
@@ -1,0 +1,3 @@
+struct __declspec(align (8)) main__Test {
+struct __declspec(align (16)) main__Test2 {
+enum __declspec(align (8)) main__Test3 {

--- a/vlib/v/gen/c/testdata/aligned_attr_windows.vv
+++ b/vlib/v/gen/c/testdata/aligned_attr_windows.vv
@@ -12,7 +12,6 @@ struct Test2 {
 }
 
 @[aligned:8]
-enum Test3 {
-	a
-	b
+union Test3 {
+	a int
 }

--- a/vlib/v/gen/c/testdata/aligned_attr_windows.vv
+++ b/vlib/v/gen/c/testdata/aligned_attr_windows.vv
@@ -1,0 +1,18 @@
+// vtest vflags: -cc msvc -os windows
+
+@[aligned:8]
+struct Test {
+	a int
+}
+
+@[aligned:16]
+struct Test2 {
+	a int 
+	b int
+}
+
+@[aligned:8]
+enum Test3 {
+	a
+	b
+}


### PR DESCRIPTION
Fix #19775

```V
@[aligned]
struct Test {
// ...
}

@[aligned:8]
struct Test2 {
// ...
}
```

It also works for MSVC.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a9b32f2</samp>

Add support for the `aligned` attribute for structs in C code generation. This allows specifying the memory alignment of structs and their fields for different compilers.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a9b32f2</samp>

*  Add support for the `aligned` attribute for structs ([link](https://github.com/vlang/v/pull/19915/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L549-R561),                             
