### PR TITLE
cgen: fix generic array initialization 

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5247,7 +5247,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 					g.writeln('{0};')
 					if node.exprs[0] is ast.Ident {
 						g.write('memcpy(${tmpvar}.ret_arr, ${g.expr_string(node.exprs[0])}, sizeof(${g.typ(node.types[0])})) /*ret*/')
-					} else if node.exprs[0] is ast.ArrayInit {
+					} else if node.exprs[0] in [ast.ArrayInit, ast.StructInit] {
 						tmpvar2 := g.new_tmp_var()
 						g.write('${g.typ(node.types[0])} ${tmpvar2} = ')
 						g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -48,8 +48,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 	if mut sym.info is ast.Struct {
 		is_anon = sym.info.is_anon
 	}
+	is_array := sym.kind in [.array_fixed, .array]
 
-	if !g.inside_cinit && !is_anon {
+	if !g.inside_cinit && !is_anon && !is_array {
 		g.write('(')
 		defer {
 			g.write(')')
@@ -88,7 +89,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		if g.table.sym(node.typ).kind == .alias && g.table.unaliased_type(node.typ).is_ptr() {
 			g.write('&')
 		}
-		if is_multiline {
+		if is_array {
+			g.write('{')
+		} else if is_multiline {
 			g.writeln('(${styp}){')
 		} else {
 			g.write('(${styp}){')

--- a/vlib/v/tests/generics_fixed_array_assign_test.v
+++ b/vlib/v/tests/generics_fixed_array_assign_test.v
@@ -1,0 +1,8 @@
+fn init_type[T]() {
+	_ := T{}
+}
+
+fn test_main() {
+	init_type[[3]int]()
+	assert true
+}


### PR DESCRIPTION
Fix #19903

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4808151</samp>

Fix C code generation and syntax for arrays of structs. This improves compatibility and correctness of the generated C code for `vlib/v/gen/c/struct.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4808151</samp>

*  Fix C code generation for arrays of structs (#11176)
  - Skip cast to struct type when accessing array elements ([link](https://github.com/vlang/v/pull/19916/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L51-R53))
  - Use plain curly brace for array initialization ([link](https://github.com/vlang/v/pull/19916/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L91-R94))
