### PR TITLE
cgen: fix option sumtype auto deref

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4465,7 +4465,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			g.write('${name}.val')
 			return
 		}
-		is_option = node.info.is_option
+		is_option = node.info.is_option || node.obj.typ.has_flag(.option)
 		if node.obj is ast.Var {
 			is_auto_heap = node.obj.is_auto_heap
 				&& (!g.is_assign_lhs || g.assign_op != .decl_assign)
@@ -4479,6 +4479,10 @@ fn (mut g Gen) ident(node ast.Ident) {
 						g.write('(')
 						if obj_sym.kind == .sum_type && !is_auto_heap {
 							g.write('*')
+							if is_option {
+								styp := g.base_type(node.obj.typ)
+								g.write('(*(${styp}*)')
+							}
 						} else if g.inside_casting_to_str && g.table.is_interface_var(node.obj) {
 							g.write('*')
 						}
@@ -4504,6 +4508,9 @@ fn (mut g Gen) ident(node ast.Ident) {
 								sym := g.table.sym(cast_sym.info.types[g.aggregate_type_idx])
 								g.write('${dot}_${sym.cname}')
 							} else {
+								if is_option {
+									g.write('.data)')
+								}
 								g.write('${dot}_${cast_sym.cname}')
 							}
 						}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4465,7 +4465,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			g.write('${name}.val')
 			return
 		}
-		is_option = node.info.is_option || node.obj.typ.has_flag(.option)
+		is_option = node.info.is_option || (node.obj is ast.Var && node.obj.typ.has_flag(.option))
 		if node.obj is ast.Var {
 			is_auto_heap = node.obj.is_auto_heap
 				&& (!g.is_assign_lhs || g.assign_op != .decl_assign)

--- a/vlib/v/tests/option_sumtype_test.v
+++ b/vlib/v/tests/option_sumtype_test.v
@@ -1,0 +1,16 @@
+pub type TType = []int | string
+
+pub fn teste() ?TType {
+	return TType([1, 2])
+}
+
+fn test_main() {
+	x := teste()
+	if x is []int {
+		dump(x)
+		y := x as []int
+		assert y == [1, 2]
+		return
+	}
+	assert false
+}


### PR DESCRIPTION
Fix #19917

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f74c686</samp>

Improve C code generation for option types in assignment expressions. Fix generic option detection and add proper casts and field accesses in `vlib/v/gen/c/cgen.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f74c686</samp>

*  Handle option types in assignment expressions ([link](https://github.com/vlang/v/pull/19919/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4468-R4468), [link](https://github.com/vlang/v/pull/19919/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR4482-R4485), [link](https://github.com/vlang/v/pull/19919/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR4511-R4513))
