### PR TITLE
v/tests: fix byte tests and implicit clone in closure_generator_test.v

### DIFF
--- a/vlib/v/tests/closure_generator_test.v
+++ b/vlib/v/tests/closure_generator_test.v
@@ -80,12 +80,12 @@ fn test_closures_with_n_args() {
 	}
 	v_code.writeln('}')
 
-	for typ in ['byte', 'u16', 'int', 'i64', 'voidptr', 'string'] {
+	for typ in ['u8', 'u16', 'int', 'i64', 'voidptr', 'string'] {
 		for i in 0 .. max_params {
 			param_names := all_param_names[..i]
 			params := param_names.map('${it} ${typ}')
 
-			mut values := all_param_values[..i]
+			mut values := all_param_values[..i].clone()
 			if typ == 'string' {
 				values = values.map("'${it}'")
 			} else {


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c0c5586</samp>

Updated `closure_generator_test.v` to use `u8` type and clone array before mapping. This was part of a bug-fixing and testing improvement pull request for the closure generator module.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c0c5586</samp>

*  Rename `byte` to `u8` in closure generator module and tests ([link](https://github.com/vlang/v/pull/19922/files?diff=unified&w=0#diff-3553a6f56c60408694db7b27ca3fda7d4a30a82578bd709070c1440046d7c02eL83-R88),                             F
