### PR TITLE
v.util.diff: accomodate differences in FreeBSD's diff command options

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -25,6 +25,12 @@ pub fn find_working_diff_command() !string {
 			}
 			continue
 		}
+		$if freebsd {
+			if diffcmd == 'diff' { // FreeBSD diff has no `--version` option
+				return diffcmd
+			}
+		}
+
 		p := os.execute('${diffcmd} --version')
 		if p.exit_code < 0 {
 			continue
@@ -61,7 +67,10 @@ fn opendiff_exists() bool {
 
 pub fn color_compare_files(diff_cmd string, file1 string, file2 string) string {
 	if diff_cmd != '' {
-		full_cmd := '${diff_cmd} --minimal --text --unified=2  --show-function-line="fn " ${os.quoted_path(file1)} ${os.quoted_path(file2)} '
+		mut full_cmd := '${diff_cmd} --minimal --text --unified=2  --show-function-line="fn " ${os.quoted_path(file1)} ${os.quoted_path(file2)} '
+		$if freebsd {
+			full_cmd = '${diff_cmd} --minimal --text --unified=2  ${os.quoted_path(file1)} ${os.quoted_path(file2)} '
+		}
 		x := os.execute(full_cmd)
 		if x.exit_code < 0 {
 			return 'comparison command: `${full_cmd}` not found'


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67f6de4</samp>

Fix `diff` module compatibility with FreeBSD. Use platform-specific `diff` command options in `vlib/v/util/diff/diff.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67f6de4</samp>

*  Add FreeBSD support for `diff` command ([link](https://github.com/vlang/v/pull/19923/files?diff=unified&w=0#diff-775f372d90aaeb197503b0c85a5c97a01fb4b53631dd66399d6e81fb82a482c5R28-R33), [link](https://github.com/vlang/v/pull/19923/files?diff=unified&w=0#diff-775f372d90aaeb197503b0c85a5c97a01fb4b53631dd66399d6e81fb82a482c5L64-R73))
   - Check if platform is FreeBSD and skip `--version` option ([link](https://github.com/vlang/v/pull/19923/files?diff=unified&w=0#diff-775f372d90aaeb197503b0c85a5c97a01fb4b53631dd66399d6e81fb82a482c5R28-R33))
   - Remove `--show-function-line` option from `full_cmd` on FreeBSD ([link](https://github.com/vlang/v/pull/19923/files?diff=unified&w=0#diff-775f372d90aaeb197503b0c85a5c97a01fb4b53631dd66399d6e81fb82a482c5L64-R73))
