### PR TITLE
tools.vpm: add warning when installing a vpm module without a manifest

### DIFF
--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -54,14 +54,14 @@ fn test_install_from_git_url() {
 	assert mod.dependencies == []string{}
 	res = os.execute_or_exit('${v} install http://github.com/Wertzui123/HashMap')
 	assert res.output.contains('Installing `HashMap`'), res.output
-	assert res.output.contains('`http` support is deprecated, switch to `https` to ensure future compatibility.'), res.output
+	assert res.output.contains('`http` is deprecated'), res.output
 	mod = vmod.from_file(os.join_path(test_path, 'wertzui123', 'hashmap', 'v.mod')) or {
 		assert false, err.msg()
 		return
 	}
 	res = os.execute_or_exit('${v} install http://github.com/Wertzui123/HashMap')
 	assert res.output.contains('Updating module `wertzui123.hashmap`'), res.output
-	assert res.output.contains('`http` support is deprecated, switch to `https` to ensure future compatibility.'), res.output
+	assert res.output.contains('`http` is deprecated'), res.output
 }
 
 fn test_install_already_existent() {
@@ -125,7 +125,11 @@ fn test_missing_vmod_in_url() {
 	assert has_vmod('https://github.com/vlang/v', '') // head branch == `master`.
 	assert has_vmod('https://github.com/v-analyzer/v-analyzer', '') // head branch == `main`.
 	assert !has_vmod('https://github.com/octocat/octocat.github.io', '') // not a V module.
-	res := os.execute('${v} install https://github.com/octocat/octocat.github.io')
+	mut res := os.execute('${v} install https://github.com/octocat/octocat.github.io')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to find `v.mod` for `https://github.com/octocat/octocat.github.io`'), res.output
+	// No error for vpm modules yet.
+	res = os.execute_or_exit('${v} install spytheman.regex')
+	assert res.output.contains('`spytheman.regex` is missing a manifest file'), res.output
+	assert res.output.contains('Installing `spytheman.regex`'), res.output
 }


### PR DESCRIPTION
The PR will add a warning when installing vpm-registered modules that are missing a manifest. Unlike for URL installs, the installation will for now continue without an error.

E.g.,
```
❯ v install spytheman.regex
warning: `spytheman.regex` is missing a manifest file.
Installing `spytheman.regex`
Installed `spytheman.regex` 
```

If the module has an active issues section, details will be added to the warning. Below, `sdl` serves just as an example; it is not actually missing a manifest file. 
The link would open a pre-filled issue.
```
❯ v install sdl
warning: `sdl` is missing a manifest file.
details: Help to ensure future-compatibility by adding a `v.mod` file or opening an issue at:
         `https://github.com/vlang/sdl/issues/new?title=Missing%20Manifest&body=sdl%20is%20missing%20a%20manifest,%20please%20consider%20adding%20a%20v.mod%20file%20with%20the%20modules%20metadta.`
```


This is part of an imho important effort to move more validation out of the final install and update process into a validation that is done beforehand (for the biggest part into the parsing step of the query). This will help to make vpm more robust and to address some issues. E.g. currently vpm can into a recursive loop when resolving dependencies when there are combinations of shared dependencies. This situation is atm not very likely, since there are not too many V modules with shared dependencies. But with a growing ecosystem, it will eventually become a problem. To fix this, dependencies can be evaluated in a validation step that is done beforehand.