### PR TITLE
tools: improve version detection of installed modules

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -94,7 +94,7 @@ fn parse_query(query []string) ([]Module, []Module) {
 				mut details := ''
 				if resp := http.head('${info.url}/issues/new') {
 					if resp.status_code == 200 {
-						issue_tmpl_url := '${info.url}/issues/new?title=Missing%20Manifest&body=${info.name}%20is%20missing%20a%20manifest,%20please%20consider%20adding%20a%20v.mod%20file%20with%20the%20modules%20metadta.'
+						issue_tmpl_url := '${info.url}/issues/new?title=Missing%20Manifest&body=${info.name}%20is%20missing%20a%20manifest,%20please%20consider%20adding%20a%20v.mod%20file%20with%20the%20modules%20metadata.'
 						details = 'Help to ensure future-compatibility by adding a `v.mod` file or opening an issue at:\n`${issue_tmpl_url}`'
 					}
 				}

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -114,15 +114,17 @@ fn parse_query(query []string) ([]Module, []Module) {
 			// In case the head just temporarily matches a tag, make sure that there
 			// really is a version installation before adding it as `installed_version`.
 			// NOTE: can be refined for branch installations. E.g., for `sdl`.
-			tag := refs.output.all_after_last('refs/tags/').trim_space()
-			head := if refs.output.contains('refs/heads/') {
-				refs.output.all_after_last('refs/heads/').trim_space()
-			} else {
-				tag
-			}
-			vpm_log(@FILE_LINE, @FN, 'head: ${head}, tag: ${tag}')
-			if tag == head {
-				mod.installed_version = tag
+			if refs.output.contains('refs/tags/') {
+				tag := refs.output.all_after_last('refs/tags/').trim_space()
+				head := if refs.output.contains('refs/heads/') {
+					refs.output.all_after_last('refs/heads/').trim_space()
+				} else {
+					tag
+				}
+				vpm_log(@FILE_LINE, @FN, 'head: ${head}, tag: ${tag}')
+				if tag == head {
+					mod.installed_version = tag
+				}
 			}
 		}
 		if mod.is_external {


### PR DESCRIPTION
This PR adds a comparison of the head and the tag to improve detecting if an installed module was installed at a version. This helps to not interpret a module as "version-installed-module" whose latest commit-sha just temporarily matches a tag. But it can treat it as a module at its latest version.

Also fixes a typo made in the last PR.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d0b19a5</samp>

This pull request improves the vpm tool by fixing a typo in the issue template URL and using a more reliable method to detect the versions of installed modules.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d0b19a5</samp>

* Fix typo in issue template URL for modules missing a manifest ([link](https://github.com/vlang/v/pull/19933/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L97-R97))
* Improve module version detection by using `git ls-remote --refs` instead of `git ls-remote --tags` ([link](https://github.com/vlang/v/pull/19933/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L112-R126))
