### PR TITLE
tools: add output when scanning module in an install query

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -52,6 +52,7 @@ fn parse_query(query []string) ([]Module, []Module) {
 	mut errors := 0
 	for m in query {
 		ident, version := m.rsplit_once('@') or { m, '' }
+		println('Scanning `${ident}`...')
 		is_http := if ident.starts_with('http://') {
 			vpm_warn('installing `${ident}` via http.',
 				details: 'Support for `http` is deprecated, use `https` to ensure future compatibility.'


### PR DESCRIPTION
Since more validation logic is moved out of the final install and update process, it can take longer for a user to get an initial feedback from vpm - it's not an instant `Installing ...` anymore, because the validation is done beforehand. Also, there are cases that don't reach the `Installing <moname>` print  already. This PR adds `Scanning <modname>` print when parsing and validating the install-query to give a user a quicker feedback that the request is being processed and at what state it is.

For now, I would continue to keep the outputs simple. After most of the teething problems are fixed, I'm planning to propose color-coded outputs for VPM - probably similar cargo, but we can then discuss on Discord which style is appropriate for V.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1dc786e</samp>

Improve `vpm` output by showing scan progress for module identifiers. Add a print statement to `cmd/tools/vpm/common.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1dc786e</samp>

*  Add a `scan_module_identifier` function to parse a module identifier from a string and return a struct with the name, version, and source ([link](https://github.com/vlang/v/pull/19934/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R55),                           F0
