### PR TITLE
ast, checker, cgen: fix interface embeded methods call(fix #16496)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1762,6 +1762,10 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if m := c.table.find_method(left_sym, method_name) {
 		method = m
 		has_method = true
+		if left_sym.kind == .interface_ && m.from_embeded_type != 0 {
+			is_method_from_embed = true
+			node.from_embed_types = [m.from_embeded_type]
+		}
 	} else {
 		if final_left_sym.kind in [.struct_, .sum_type, .interface_, .alias, .array] {
 			mut parent_type := ast.void_type

--- a/vlib/v/tests/interface_embedding_call_test.v
+++ b/vlib/v/tests/interface_embedding_call_test.v
@@ -22,3 +22,31 @@ interface ParentGreeter {
 interface Greeter {
 	greet() string
 }
+
+// for issue 16496
+interface Foo {
+	a_method()
+}
+
+fn (f Foo) foo_method() int {
+	return 0
+}
+
+interface Bar {
+	Foo
+}
+
+fn (b Bar) bar_method() int {
+	// The test calls the method of the embedded interface in the interface method
+	return b.foo_method()
+}
+
+struct Derived {}
+
+fn (d &Derived) a_method() {
+}
+
+fn test_embedding_method_call_cgen() {
+	bar := Bar(Derived{})
+	assert bar.bar_method() == 0
+}


### PR DESCRIPTION
1. Fixed #16496 
2. Add tests.

```v
interface Foo {
    a_method()
}

fn (f Foo) foo_method() int {
    return 0
}

interface Bar {
    Foo
}

fn (b Bar) bar_method() int {
    return b.foo_method()
}

struct Derived {}

fn (d &Derived) a_method() {
}

fn main() {
    bar := Bar(Derived{})
    println(bar.bar_method())
}
```

outputs:

```
0
```

This problem occurs when calls the method of the embedded interface in the interface method, because the transformation mechanism of the interface embedded method is currently missing.  This PR implements the same mechanism in the interface by calling the method of the embedded struct from the struct