### PR TITLE
table: fix enum flag value evaluation

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -410,7 +410,7 @@ pub fn (t &Table) find_enum_field_val(name string, field_ string) ?i64 {
 			}
 		}
 	}
-	return val
+	return if enum_decl.is_flag { u64(1) << val } else { val }
 }
 
 pub fn (t &Table) get_enum_field_names(name string) []string {

--- a/vlib/v/tests/enum_flag_test.v
+++ b/vlib/v/tests/enum_flag_test.v
@@ -1,0 +1,18 @@
+@[flag]
+enum Foo {
+	a
+	b
+	c
+}
+
+const a = Foo.a
+
+const ab = Foo.a | Foo.b
+
+const abc = Foo.a | Foo.b | Foo.c
+
+fn test_main() {
+	assert dump(a) == Foo.a
+	assert dump(ab) == Foo.a | Foo.b
+	assert dump(abc) == Foo.a | Foo.b | Foo.c
+}


### PR DESCRIPTION
Fix #19925

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6030e05</samp>

Fix flag enum value calculation in `Table.enum_val`. Use bitwise shift for flag enums and return normal value for regular enums.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6030e05</samp>

* Fix flag enum value calculation in `Table.enum_val` method ([link](https://github.com/vlang/v/pull/19939/files?diff=unified&w=0#diff-cfd5d819278aed172646f4254f098c98ee8bb62abdd0fd839359f6376c913614L413-R413))
