### PR TITLE
tools.vpm: validate VCS during parsing

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -100,6 +100,8 @@ fn parse_query(query []string) ([]Module, []Module) {
 				is_git_module = info.vcs == 'git'
 				if !is_git_module && version != '' {
 					vpm_error('skipping `${info.name}`, version installs are currently only supported for projects using `git`.')
+					errors++
+					continue
 				}
 				info_vcs
 			} else {

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -11,17 +11,15 @@ import log
 
 struct Module {
 mut:
-	// Fields determined by the url or the info received from the VPM API.
-	name string
-	url  string
-	vcs  string
-	// Fields based on preference / environment.
+	name               string
+	url                string
 	version            string // specifies the requested version.
 	install_path       string
 	install_path_fmted string
+	installed_version  string
 	is_installed       bool
 	is_external        bool
-	installed_version  string
+	vcs                ?VCS
 }
 
 struct ModuleVpmInfo {
@@ -50,6 +48,7 @@ const home_dir = os.home_dir()
 fn parse_query(query []string) ([]Module, []Module) {
 	mut vpm_modules, mut external_modules := []Module{}, []Module{}
 	mut errors := 0
+	is_git_setting := settings.vcs.cmd == 'git'
 	for m in query {
 		ident, version := m.rsplit_once('@') or { m, '' }
 		println('Scanning `${ident}`...')
@@ -62,15 +61,17 @@ fn parse_query(query []string) ([]Module, []Module) {
 			false
 		}
 		mut mod := if is_http || ident.starts_with('https://') {
+			// External module.
 			publisher, name := get_ident_from_url(ident) or {
 				vpm_error(err.msg())
 				errors++
 				continue
 			}
+			// Resolve path, verify existence of manifest.
 			base := if is_http { publisher } else { '' }
 			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
 				base, name)))
-			if !has_vmod(ident, install_path) {
+			if is_git_setting && !has_vmod(ident, install_path) {
 				vpm_error('failed to find `v.mod` for `${ident}`.')
 				errors++
 				continue
@@ -79,19 +80,41 @@ fn parse_query(query []string) ([]Module, []Module) {
 				name: name
 				url: ident
 				install_path: install_path
-				install_path_fmted: fmt_mod_path(install_path)
 				is_external: true
 			}
 		} else {
+			// VPM registered module.
 			info := get_mod_vpm_info(ident) or {
 				vpm_error('failed to retrieve metadata for `${ident}`.', details: err.msg())
 				errors++
 				continue
 			}
+			// Verify VCS.
+			mut is_git_module := true
+			vcs := if info.vcs != '' {
+				info_vcs := supported_vcs[info.vcs] or {
+					vpm_error('skipping `${info.name}`, since it uses an unsupported version control system `${info.vcs}`.')
+					errors++
+					continue
+				}
+				is_git_module = info.vcs == 'git'
+				if !is_git_module && version != '' {
+					vpm_error('skipping `${info.name}`, version installs are currently only supported for projects using `git`.')
+				}
+				info_vcs
+			} else {
+				supported_vcs['git']
+			}
+			vcs.is_executable() or {
+				vpm_error(err.msg())
+				errors++
+				continue
+			}
+			// Resolve path, verify existence of manifest.
 			ident_as_path := info.name.replace('.', os.path_separator)
 			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
 				ident_as_path)))
-			if !has_vmod(info.url, install_path) {
+			if is_git_module && !has_vmod(info.url, install_path) {
 				mut details := ''
 				if resp := http.head('${info.url}/issues/new') {
 					if resp.status_code == 200 {
@@ -104,12 +127,12 @@ fn parse_query(query []string) ([]Module, []Module) {
 			Module{
 				name: info.name
 				url: info.url
-				vcs: info.vcs
+				vcs: vcs
 				install_path: install_path
-				install_path_fmted: fmt_mod_path(install_path)
 			}
 		}
 		mod.version = version
+		mod.install_path_fmted = fmt_mod_path(mod.install_path)
 		if refs := os.execute_opt('git ls-remote --refs ${mod.install_path}') {
 			mod.is_installed = true
 			// In case the head just temporarily matches a tag, make sure that there
@@ -136,6 +159,12 @@ fn parse_query(query []string) ([]Module, []Module) {
 	}
 	if errors > 0 && errors == query.len {
 		exit(1)
+	}
+	if external_modules.len > 0 {
+		settings.vcs.is_executable() or {
+			vpm_error(err.msg())
+			exit(1)
+		}
 	}
 	return vpm_modules, external_modules
 }

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -11,9 +11,11 @@ mut:
 	is_verbose            bool
 	is_force              bool
 	server_urls           []string
-	vcs                   string
 	vmodules_path         string
 	no_dl_count_increment bool
+	// git is used by default. URL installations can specify `--hg`. For already installed modules
+	// and VPM modules that specify a different VCS in their `v.mod`, the VCS is validated separately.
+	vcs VCS
 }
 
 fn init_settings() VpmSettings {
@@ -29,8 +31,8 @@ fn init_settings() VpmSettings {
 		is_once: '--once' in opts
 		is_verbose: '-v' in opts || '--verbose' in opts
 		is_force: '-f' in opts || '--force' in opts
-		vcs: if '--hg' in opts { 'hg' } else { 'git' }
 		server_urls: cmdline.options(args, '--server-urls')
+		vcs: supported_vcs[if '--hg' in opts { 'hg' } else { 'git' }]
 		vmodules_path: os.vmodules_dir()
 		no_dl_count_increment: os.getenv('CI') != '' || (no_inc_env != '' && no_inc_env != '0')
 	}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -10,13 +10,14 @@ import v.help
 import v.vmod
 
 struct VCS {
-	dir  string
-	cmd  string
+	dir  string        @[required]
+	cmd  string        @[required]
 	args struct {
-		install  string
-		path     string // the flag used to specify a path. E.g., used to explicitly work on a path during multithreaded updating.
-		update   string
-		outdated []string
+		install  string   @[required]
+		version  string   @[required] // flag to specify a version, added to install.
+		path     string   @[required] // flag to specify a path. E.g., used to explicitly work on a path during multithreaded updating.
+		update   string   @[required]
+		outdated []string @[required]
 	}
 }
 
@@ -33,7 +34,8 @@ const (
 			cmd: 'git'
 			args: struct {
 				install: 'clone --depth=1 --recursive --shallow-submodules'
-				update: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts, when the upstream is more than 1 commit newer
+				version: '--single-branch -b'
+				update: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts when the upstream has more than 1 new commits.
 				path: '-C'
 				outdated: ['fetch', 'rev-parse @', 'rev-parse @{u}']
 			}
@@ -43,6 +45,7 @@ const (
 			cmd: 'hg'
 			args: struct {
 				install: 'clone'
+				version: '' // not supported yet.
 				update: 'pull --update'
 				path: '-R'
 				outdated: ['incoming']


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4143aa7</samp>

This pull request enhances the V package manager (VPM) to support different version control systems (VCS) for V modules, such as `git` and `hg`. It also adds the ability to install specific versions of `git` modules with flags. It refactors and reorganizes some code to improve readability and maintainability.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4143aa7</samp>

*  Change the `vcs` field of the `Module` and `Settings` structs from a string to a `VCS` type, which represents a version control system with its command and arguments ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L14-R22), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL14-R18), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL32-R35), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L107-R135), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL212-R193), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL234-R217))
*  Add a `version` field to the `VCS` struct, which specifies the flag to use for installing a specific version of a module ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L36-R38), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545R48), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL234-R217))
*  Move the `VCS` struct and the `install` function of the `Module` struct from the `vpm.v` and `install.v` files to the `common.v` file, since they are used by both the `install` and `update` commands ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L13-R20), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL96-R96), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL212-R193))
*  Add a local variable `is_git_setting` to check if the global `settings.vcs` is `git`, which is the default and most common VCS used for V modules ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R51))
*  Add comments to clarify the cases of external and VPM registered modules in the `resolve_modules` function ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R64), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L82-R86))
*  Add a condition to check if the `is_git_setting` variable is true before calling the `has_vmod` function, which verifies the existence of a `v.mod` file in the module's repository ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L70-R74))
*  Add a block of code to verify the VCS of the VPM registered module, and assign it to a local variable `vcs` in the `resolve_modules` function ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L91-R117))
*  Add a block of code to check if there are any external modules in the `modules` array, and if so, verify that the global `settings.vcs` is executable in the `resolve_modules` function ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R163-R168))
*  Remove the `vcs` argument from the `install` function of the `Module` struct, and use the `vcs` field of the struct instead ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL96-R96), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL146-R127), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL212-R193), [link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL234-R217))
*  Remove a block of code from the `install_modules` function, which checked if the global `settings.vcs` was executable, since this check was moved to the `resolve_modules` function ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL136-L140))
*  Assign the `is_installed` field of the `Module` struct the value of a `git` command output, which checks if the module's repository has any remote references, only if the module uses `git` as its VCS ([link](https://github.com/vlang/v/pull/19943/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L107-R135))
