### PR TITLE
checker: check element and its children for ref uninitialized fields(fix #19864)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -102,6 +102,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.warn('arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`)',
 				node.pos)
 		}
+		c.check_elements_ref_fields_initialized(node.elem_type, node.pos)
 		return node.typ
 	}
 
@@ -112,6 +113,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.warn('fixed arrays of references need to be initialized right away (unless inside `unsafe`)',
 				node.pos)
 		}
+		c.check_elements_ref_fields_initialized(node.elem_type, node.pos)
 	}
 	// `a = []`
 	if node.exprs.len == 0 {
@@ -400,6 +402,7 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		c.ensure_type_exists(info.value_type, node.pos)
 		node.key_type = info.key_type
 		node.value_type = info.value_type
+		c.check_elements_ref_fields_initialized(node.typ, node.pos)
 		return node.typ
 	}
 
@@ -498,4 +501,73 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		return map_type
 	}
 	return node.typ
+}
+
+// check the element, and its children for ref uninitialized fields
+fn (mut c Checker) check_elements_ref_fields_initialized(typ ast.Type, pos &token.Pos) {
+	if typ == 0 || c.inside_const {
+		return
+	}
+	sym := c.table.sym(typ)
+	mut checked_types := []ast.Type{}
+	c.do_check_elements_ref_fields_initialized(sym, mut checked_types, pos)
+}
+
+// Recursively check the element, and its children for ref uninitialized fields
+fn (mut c Checker) do_check_elements_ref_fields_initialized(sym &ast.TypeSymbol, mut checked_types []ast.Type, pos &token.Pos) {
+	if sym.info is ast.Struct {
+		linked_name := sym.name
+		// For now, let's call this method and give a notice instead of an error.
+		// After some time, we remove the check_ref_fields_initialized_note() method and
+		// simply call check_ref_fields_initialized()
+		c.check_ref_fields_initialized_note(sym, mut checked_types, linked_name, pos)
+		return
+	}
+	match sym.info {
+		ast.Array {
+			elem_type := sym.info.elem_type
+			if elem_type in checked_types {
+				return
+			}
+			checked_types << elem_type
+			elem_sym := c.table.sym(elem_type)
+			c.do_check_elements_ref_fields_initialized(elem_sym, mut checked_types, pos)
+		}
+		ast.ArrayFixed {
+			elem_type := sym.info.elem_type
+			if elem_type in checked_types {
+				return
+			}
+			checked_types << elem_type
+			elem_sym := c.table.sym(elem_type)
+			c.do_check_elements_ref_fields_initialized(elem_sym, mut checked_types, pos)
+		}
+		ast.Map {
+			key_type := sym.info.key_type
+			if key_type in checked_types {
+				return
+			}
+			checked_types << key_type
+			key_sym := c.table.sym(key_type)
+			c.do_check_elements_ref_fields_initialized(key_sym, mut checked_types, pos)
+			value_type := sym.info.value_type
+			if value_type in checked_types {
+				return
+			}
+			checked_types << value_type
+			value_sym := c.table.sym(value_type)
+			c.do_check_elements_ref_fields_initialized(value_sym, mut checked_types, pos)
+		}
+		ast.Alias {
+			parent_type := sym.info.parent_type
+			if parent_type in checked_types {
+				return
+			}
+			checked_types << parent_type
+			parent_sym := c.table.sym(parent_type)
+			c.do_check_elements_ref_fields_initialized(parent_sym, mut checked_types,
+				pos)
+		}
+		else {}
+	}
 }

--- a/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:8:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
+    6 | 
+    7 | fn main() {
+    8 |     _ = []Foo{}
+      |         ~~~~~~
+    9 |     _ = [1]Foo{}
+   10 |     _ = map[string]Foo{}
+vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:9:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
+    7 | fn main() {
+    8 |     _ = []Foo{}
+    9 |     _ = [1]Foo{}
+      |         ~~~~~~~~
+   10 |     _ = map[string]Foo{}
+   11 |     _ = map[string][]Foo{}
+vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:10:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
+    8 |     _ = []Foo{}
+    9 |     _ = [1]Foo{}
+   10 |     _ = map[string]Foo{}
+      |         ~~~~~~~~~~~~~~~~
+   11 |     _ = map[string][]Foo{}
+   12 |     _ = []AliasFoo{}
+vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:11:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
+    9 |     _ = [1]Foo{}
+   10 |     _ = map[string]Foo{}
+   11 |     _ = map[string][]Foo{}
+      |         ~~~~~~~~~~~~~~~~~~
+   12 |     _ = []AliasFoo{}
+   13 | }
+vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:12:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
+   10 |     _ = map[string]Foo{}
+   11 |     _ = map[string][]Foo{}
+   12 |     _ = []AliasFoo{}
+      |         ~~~~~~~~~~~
+   13 | }

--- a/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv
+++ b/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv
@@ -1,0 +1,13 @@
+struct Foo {
+	n &int
+}
+
+type AliasFoo = Foo
+
+fn main() {
+	_ = []Foo{}
+	_ = [1]Foo{}
+	_ = map[string]Foo{}
+	_ = map[string][]Foo{}
+	_ = []AliasFoo{}
+}

--- a/vlib/v/tests/const_fixed_array_containing_references_to_itself_test.v
+++ b/vlib/v/tests/const_fixed_array_containing_references_to_itself_test.v
@@ -1,5 +1,5 @@
 struct Abc {
-	prev &Abc
+	prev &Abc = unsafe { nil }
 }
 
 const a = [Abc{unsafe { nil }}, Abc{unsafe { &a[0] }}, Abc{unsafe { &a[1] }}]!

--- a/vlib/v/tests/str_circular_test.v
+++ b/vlib/v/tests/str_circular_test.v
@@ -6,7 +6,7 @@ mut:
 
 struct Bb {
 mut:
-	a &Aa
+	a &Aa = unsafe { nil }
 }
 
 fn test_circular() {


### PR DESCRIPTION
1. Fixed #19864 
2. Add tests.

```v
struct Foo {
	n &int
}

fn main() {
	_ = []Foo{}
	_ = [1]Foo{}
	_ = map[string]Foo{}
	_ = map[string][]Foo{}
}
```

outputs:

```
a.v:6:6: error: reference field `Foo.n` must be initialized (part of struct `Foo`)
    4 | 
    5 | fn main() {
    6 |     _ = []Foo{}
      |         ~~~~~~
    7 |     _ = [1]Foo{}
    8 |     _ = map[string]Foo{}
a.v:7:6: error: reference field `Foo.n` must be initialized (part of struct `Foo`)
    5 | fn main() {
    6 |     _ = []Foo{}
    7 |     _ = [1]Foo{}
      |         ~~~~~~~~
    8 |     _ = map[string]Foo{}
    9 |     _ = map[string][]Foo{}
a.v:8:6: error: reference field `Foo.n` must be initialized (part of struct `Foo`)
    6 |     _ = []Foo{}
    7 |     _ = [1]Foo{}
    8 |     _ = map[string]Foo{}
      |         ~~~~~~~~~~~~~~~~
    9 |     _ = map[string][]Foo{}
   10 | }
a.v:9:6: error: reference field `Foo.n` must be initialized (part of struct `Foo`)
    7 |     _ = [1]Foo{}
    8 |     _ = map[string]Foo{}
    9 |     _ = map[string][]Foo{}
      |         ~~~~~~~~~~~~~~~~~~
   10 | }
   11 |
```