### PR TITLE
net.openssl: use actual C values for SSLError enum, remove inexistent value

### DIFF
--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -156,9 +156,7 @@ fn init() {
 	}
 }
 
-pub const (
-	is_used = 1
-)
+pub const is_used = true
 
 // ssl_error returns non error ssl code or error if unrecoverable and we should panic
 fn ssl_error(ret int, ssl voidptr) !SSLError {
@@ -180,16 +178,15 @@ fn ssl_error(ret int, ssl voidptr) !SSLError {
 }
 
 enum SSLError {
-	ssl_error_none             = 0 // SSL_ERROR_NONE
-	ssl_error_ssl              = 1 // SSL_ERROR_SSL
-	ssl_error_want_read        = 2 // SSL_ERROR_WANT_READ
-	ssl_error_want_write       = 3 // SSL_ERROR_WANT_WRITE
-	ssl_error_want_x509_lookup = 4 // SSL_ERROR_WANT_X509_LOOKUP
-	ssl_error_syscall          = 5 // SSL_ERROR_SYSCALL
-	ssl_error_zero_return      = 6 // SSL_ERROR_ZERO_RETURN
-	ssl_error_want_connect     = 7 // SSL_ERROR_WANT_CONNECT
-	ssl_error_want_accept      = 8 // SSL_ERROR_WANT_ACCEPT
-	ssl_error_want_async       = 9 // SSL_ERROR_WANT_ASYNC
-	ssl_error_want_async_job   = 10 // SSL_ERROR_WANT_ASYNC_JOB
-	ssl_error_want_early       = 11 // SSL_ERROR_WANT_EARLY
+	ssl_error_none             = C.SSL_ERROR_NONE
+	ssl_error_ssl              = C.SSL_ERROR_SSL
+	ssl_error_want_read        = C.SSL_ERROR_WANT_READ
+	ssl_error_want_write       = C.SSL_ERROR_WANT_WRITE
+	ssl_error_want_x509_lookup = C.SSL_ERROR_WANT_X509_LOOKUP
+	ssl_error_syscall          = C.SSL_ERROR_SYSCALL
+	ssl_error_zero_return      = C.SSL_ERROR_ZERO_RETURN
+	ssl_error_want_connect     = C.SSL_ERROR_WANT_CONNECT
+	ssl_error_want_accept      = C.SSL_ERROR_WANT_ACCEPT
+	ssl_error_want_async       = C.SSL_ERROR_WANT_ASYNC
+	ssl_error_want_async_job   = C.SSL_ERROR_WANT_ASYNC_JOB
 }

--- a/vlib/net/openssl/openssl_compiles_test.c.v
+++ b/vlib/net/openssl/openssl_compiles_test.c.v
@@ -12,6 +12,6 @@ fn test_printing_struct_with_reference_field_of_type_ssl_ctx() {
 }
 
 fn test_openssl_compiles() {
-	assert openssl.is_used == 1
+	assert openssl.is_used
 	assert true
 }


### PR DESCRIPTION
Updates the decl to be less susceptible to changes and to differences in sorting.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6f2f847</samp>

Improved `net/openssl` module by using more appropriate types and constants, and updated the corresponding test file.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6f2f847</samp>

* Change `is_used` constant to boolean type to match V convention and avoid casting (`[link](https://github.com/vlang/v/pull/19945/files?diff=unified&w=0#diff-5ea0882828394df2ef8536592dae357e0e43177ba69d301152e7997d9291d0f9L159-R159)`, `[link](https://github.com/vlang/v/pull/19945/files?diff=unified&w=0#diff-c578cb12af336cdbf445d67cc7cc7651d4f8db769ece3c93f1688b488a4caf0bL15-R15)`)
