### PR TITLE
vlib, tools: make minor improvements

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -217,10 +217,10 @@ fn (vd VDoc) gen_html(d doc.Doc) string {
 		mut used_submod_prefixes := map[string]bool{}
 		for dc in vd.docs {
 			submod_prefix := dc.head.name.all_before('.')
-			if used_submod_prefixex[submod_prefix] {
+			if used_submod_prefixes[submod_prefix] {
 				continue
 			}
-			used_submod_prefixex[submod_prefix] = true
+			used_submod_prefixes[submod_prefix] = true
 			mut href_name := './${dc.head.name}.html'
 			if (cfg.is_vlib && dc.head.name == 'builtin' && !cfg.include_readme)
 				|| dc.head.name == 'README' {

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -214,7 +214,7 @@ fn (vd VDoc) gen_html(d doc.Doc) string {
 	}
 	// write nav1
 	if cfg.is_multi || vd.docs.len > 1 {
-		mut used_submod_prefixex := map[string]bool{}
+		mut used_submod_prefixes := map[string]bool{}
 		for dc in vd.docs {
 			submod_prefix := dc.head.name.all_before('.')
 			if used_submod_prefixex[submod_prefix] {

--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -3,10 +3,6 @@ module main
 import strings
 import v.doc
 
-fn markdown_escape_script_tags(str string) string {
-	return str.replace_each(['<script>', '`', '</script>', '`'])
-}
-
 fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {
 	mut hw := strings.new_builder(200)
 	mut cw := strings.new_builder(200)

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -29,7 +29,10 @@ struct Options {
 	doc_private_fns_too bool
 }
 
-const term_colors = term.can_show_color_on_stderr()
+const (
+	term_colors = term.can_show_color_on_stderr()
+	clean_seq   = ['[', '', ']', '', ' ', '']
+)
 
 fn main() {
 	vet_options := cmdline.options_after(os.args, ['vet'])
@@ -140,7 +143,7 @@ fn (mut vt Vet) vet_fn_documentation(lines []string, line string, lnumber int) {
 	if lnumber > 0 {
 		collect_tags := fn (line string) []string {
 			mut cleaned := line.all_before('/')
-			cleaned = cleaned.replace_each(['[', '', ']', '', ' ', ''])
+			cleaned = cleaned.replace_each(clean_seq)
 			return cleaned.split(',')
 		}
 		ident_fn_name := fn (line string) string {

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -141,11 +141,9 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL) !Res
 	// println('fetch $method, $scheme, $host_name, $nport, $path ')
 	if scheme == 'https' && req.proxy == unsafe { nil } {
 		// println('ssl_do( $nport, $method, $host_name, $path )')
-		mut retries := 0
-		for {
+		for i in 0 .. req.max_retries {
 			res := req.ssl_do(nport, method, host_name, path) or {
-				retries++
-				if is_no_need_retry_error(err.code()) || retries >= req.max_retries {
+				if i == req.max_retries - 1 || is_no_need_retry_error(err.code()) {
 					return err
 				}
 				continue
@@ -154,11 +152,9 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL) !Res
 		}
 	} else if scheme == 'http' && req.proxy == unsafe { nil } {
 		// println('http_do( $nport, $method, $host_name, $path )')
-		mut retries := 0
-		for {
+		for i in 0 .. req.max_retries {
 			res := req.http_do('${host_name}:${nport}', method, path) or {
-				retries++
-				if is_no_need_retry_error(err.code()) || retries >= req.max_retries {
+				if i == req.max_retries - 1 || is_no_need_retry_error(err.code()) {
 					return err
 				}
 				continue
@@ -166,11 +162,9 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL) !Res
 			return res
 		}
 	} else if req.proxy != unsafe { nil } {
-		mut retries := 0
-		for {
+		for i in 0 .. req.max_retries {
 			res := req.proxy.http_do(url, method, path, req) or {
-				retries++
-				if is_no_need_retry_error(err.code()) || retries >= req.max_retries {
+				if i == req.max_retries - 1 || is_no_need_retry_error(err.code()) {
 					return err
 				}
 				continue

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -395,7 +395,7 @@ pub fn (mut c Checker) check_files(ast_files []&ast.File) {
 		}
 	}
 	// After the main checker run, run the line info check, print line info, and exit (if it's present)
-	if c.pref.line_info != '' && !c.pref.linfo.is_running { //'' && c.pref.linfo.line_nr == 0 {
+	if !c.pref.linfo.is_running && c.pref.line_info != '' { //'' && c.pref.linfo.line_nr == 0 {
 		// c.do_line_info(c.pref.line_info, ast_files)
 		println('setting is_running=true,  pref.path=${c.pref.linfo.path} curdir' + os.getwd())
 		c.pref.linfo.is_running = true
@@ -963,7 +963,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 	styp := c.table.type_to_str(utyp)
 	typ_sym := c.table.sym(utyp)
 	mut inter_sym := c.table.sym(interface_type)
-	if inter_sym.mod !in [typ_sym.mod, c.mod] && !inter_sym.is_pub && typ_sym.mod != 'builtin' {
+	if !inter_sym.is_pub && inter_sym.mod !in [typ_sym.mod, c.mod] && typ_sym.mod != 'builtin' {
 		c.error('`${styp}` cannot implement private interface `${inter_sym.name}` of other module',
 			pos)
 		return false
@@ -2321,7 +2321,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 			c.error('hash statements are only allowed in backend specific files such "x.js.v" and "x.go.v"',
 				node.pos)
 		}
-		if c.mod == 'main' && c.pref.backend != .golang {
+		if c.pref.backend != .golang && c.mod == 'main' {
 			c.error('hash statements are not allowed in the main module. Place them in a separate module.',
 				node.pos)
 		}
@@ -4600,7 +4600,7 @@ fn (c &Checker) check_struct_signature(from ast.Struct, to ast.Struct) bool {
 fn (mut c Checker) fetch_field_name(field ast.StructField) string {
 	mut name := field.name
 	for attr in field.attrs {
-		if attr.kind == .string && attr.name == 'sql' && attr.arg != '' {
+		if attr.kind == .string && attr.arg != '' && attr.name == 'sql' {
 			name = attr.arg
 			break
 		}

--- a/vlib/v/checker/errors.v
+++ b/vlib/v/checker/errors.v
@@ -160,10 +160,12 @@ fn (mut c Checker) deprecate(kind string, name string, attrs []ast.Attr, pos tok
 	now := time.now()
 	mut after_time := now
 	for attr in attrs {
-		if attr.name == 'deprecated' && attr.arg != '' {
-			deprecation_message = attr.arg
+		if attr.arg == '' {
+			continue
 		}
-		if attr.name == 'deprecated_after' && attr.arg != '' {
+		if attr.name == 'deprecated' {
+			deprecation_message = attr.arg
+		} else if attr.name == 'deprecated_after' {
 			after_time = time.parse_iso8601(attr.arg) or {
 				c.error('invalid time format', attr.pos)
 				now

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2572,7 +2572,10 @@ fn (mut c Checker) map_builtin_method_call(mut node ast.CallExpr, left_type ast.
 				c.table.find_or_register_array(info.value_type)
 			}
 			ret_type = ast.Type(typ)
-			if info.key_type.has_flag(.generic) {
+			if info.key_type.has_flag(.generic) && method_name == 'keys' {
+				ret_type = ret_type.set_flag(.generic)
+			}
+			if info.value_type.has_flag(.generic) && method_name == 'values' {
 				ret_type = ret_type.set_flag(.generic)
 			}
 		}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -48,7 +48,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			struct_sym.info.fields.sort_with_compare(minify_sort_fn)
 		}
 		for attr in node.attrs {
-			if attr.name == 'typedef' && node.language != .c {
+			if node.language != .c && attr.name == 'typedef' {
 				c.error('`typedef` attribute can only be used with C structs', node.pos)
 			}
 		}
@@ -827,7 +827,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 				}
 				*/
 				// Check for `[required]` struct attr
-				if field.attrs.contains('required') && !node.no_keys && !node.has_update_expr {
+				if !node.no_keys && !node.has_update_expr && field.attrs.contains('required') {
 					mut found := false
 					for init_field in node.init_fields {
 						if field.name == init_field.name {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -303,37 +303,43 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 	for_val := p.check_name()
 	mut kind := ast.ComptimeForKind.methods
 	p.open_scope()
-	if for_val == 'methods' {
-		p.scope.register(ast.Var{
-			name: val_var
-			typ: p.table.find_type_idx('FunctionData')
-			pos: var_pos
-		})
-	} else if for_val == 'values' {
-		p.scope.register(ast.Var{
-			name: val_var
-			typ: p.table.find_type_idx('EnumData')
-			pos: var_pos
-		})
-		kind = .values
-	} else if for_val == 'fields' {
-		p.scope.register(ast.Var{
-			name: val_var
-			typ: p.table.find_type_idx('FieldData')
-			pos: var_pos
-		})
-		kind = .fields
-	} else if for_val == 'attributes' {
-		p.scope.register(ast.Var{
-			name: val_var
-			typ: p.table.find_type_idx('StructAttribute')
-			pos: var_pos
-		})
-		kind = .attributes
-	} else {
-		p.error_with_pos('unknown kind `${for_val}`, available are: `methods`, `fields`, `values`, or `attributes`',
-			p.prev_tok.pos())
-		return ast.ComptimeFor{}
+	match for_val {
+		'methods' {
+			p.scope.register(ast.Var{
+				name: val_var
+				typ: p.table.find_type_idx('FunctionData')
+				pos: var_pos
+			})
+		}
+		'values' {
+			p.scope.register(ast.Var{
+				name: val_var
+				typ: p.table.find_type_idx('EnumData')
+				pos: var_pos
+			})
+			kind = .values
+		}
+		'fields' {
+			p.scope.register(ast.Var{
+				name: val_var
+				typ: p.table.find_type_idx('FieldData')
+				pos: var_pos
+			})
+			kind = .fields
+		}
+		'attributes' {
+			p.scope.register(ast.Var{
+				name: val_var
+				typ: p.table.find_type_idx('StructAttribute')
+				pos: var_pos
+			})
+			kind = .attributes
+		}
+		else {
+			p.error_with_pos('unknown kind `${for_val}`, available are: `methods`, `fields`, `values`, or `attributes`',
+				p.prev_tok.pos())
+			return ast.ComptimeFor{}
+		}
 	}
 	spos := p.tok.pos()
 	stmts := p.parse_block()

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -44,9 +44,9 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 			p.is_stmt_ident = is_stmt_ident
 		}
 		.name, .question {
-			if p.tok.lit == 'sql' && p.peek_tok.kind == .name {
+			if p.peek_tok.kind == .name && p.tok.lit == 'sql' {
 				node = p.sql_expr()
-			} else if p.tok.lit == 'map' && p.peek_tok.kind == .lcbr && !(p.builtin_mod
+			} else if p.peek_tok.kind == .lcbr && p.tok.lit == 'map' && !(p.builtin_mod
 				&& p.file_base in ['map.v', 'map_d_gcboehm_opt.v']) {
 				p.error_with_pos("deprecated map syntax, use syntax like `{'age': 20}`",
 					p.tok.pos())
@@ -296,7 +296,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 					|| p.tok.kind.is_start_of_type()
 					|| (p.tok.lit.len > 0 && p.tok.lit[0].is_capital())
 
-				if p.tok.lit in ['c', 'r'] && p.peek_tok.kind == .string {
+				if p.peek_tok.kind == .string && p.tok.lit in ['c', 'r'] {
 					is_known_var = false
 					is_type = false
 				}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -976,7 +976,7 @@ fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			return p.for_stmt()
 		}
 		.name {
-			if p.tok.lit == 'sql' && p.peek_tok.kind == .name {
+			if p.peek_tok.kind == .name && p.tok.lit == 'sql' {
 				return p.sql_stmt()
 			}
 			if p.peek_tok.kind == .colon {
@@ -2425,7 +2425,7 @@ fn (p &Parser) is_generic_call() bool {
 	}
 
 	if kind2 == .name {
-		if tok2.lit == 'map' && kind3 == .lsbr {
+		if kind3 == .lsbr && tok2.lit == 'map' {
 			// case 2
 			return true
 		}
@@ -2554,7 +2554,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 	// p.warn('resetting')
 	p.expr_mod = ''
 	// `map[string]int` initialization
-	if p.tok.lit == 'map' && p.peek_tok.kind == .lsbr {
+	if p.peek_tok.kind == .lsbr && p.tok.lit == 'map' {
 		mut pos := p.tok.pos()
 		mut map_type := p.parse_map_type()
 		if p.tok.kind == .lcbr {
@@ -2648,12 +2648,8 @@ fn (mut p Parser) name_expr() ast.Expr {
 	if p.peek_tok.kind == .dot && !known_var && (language != .v || p.known_import(p.tok.lit)
 		|| p.mod.all_after_last('.') == p.tok.lit) {
 		// p.tok.lit has been recognized as a module
-		if language == .c {
-			mod = 'C'
-		} else if language == .js {
-			mod = 'JS'
-		} else if language == .wasm {
-			mod = 'WASM'
+		if language in [.c, .js, .wasm] {
+			mod = language.str().to_upper()
 		} else {
 			if p.tok.lit in p.imports {
 				// mark the imported module as used


### PR DESCRIPTION
This PR contains some accumulated changes. Cleaning stashes, I thought they can be grouped in a PR with minor improvements. 
E.g., 
- preferring to do less expensive checks in if conditions first 
- using a const instead of re-assigning arrays with static data in often called fns
- preferring a match statement where it can promote readability
- using loops with a predefined end if the loop logic allows for it
 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa560c2</samp>

This pull request improves the code quality, performance, and readability of various modules in the v compiler and tools, such as `vdoc`, `vvet`, `checker`, `parser`, and `comptime`. It mainly involves reordering, simplifying, or removing some if statements, using match statements, and fixing typos and formatting issues. It also affects the html generation of `vdoc` by escaping script tags in markdown comments.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa560c2</samp>

*  Simplify and refactor the logic of escaping html tags in comments and collecting submodules prefixes for the navigation bar in `cmd/tools/vdoc/html.v` ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L16-R26), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L216-R223), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-c7c93e5e03a9193dc4ed1ba0c142dffb39f84f74fa679f4e44d33b10784a3bd5L427-R427))
* Remove the unused `markdown_escape_script_tags` function from `cmd/tools/vdoc/markdown.v` ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-2fb56b319e63887256ce7a3f2ce6d77fc71ae667ddefde479f35ae5e2500fdc8L6-L9))
* Move the `term_colors` constant from `cmd/tools/vvet/vvet.v` to `cmd/tools/vdoc/html.v` and add a new constant `clean_seq` to clean the tags from the comments ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-5d248836ed005ade6bda50382383c06d99919b725ce68583faa50bbd1415ccb9L32-R35), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-5d248836ed005ade6bda50382383c06d99919b725ce68583faa50bbd1415ccb9L143-R146))
* Simplify the retry logic for the `ssl_do`, `http_do`, and `proxy.http_do` methods in `vlib/net/http/request.v` by using range-based for loops instead of manual counters and while loops ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995L144-R146), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995L157-R157), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-f5e1c9c797b5f85a7a3c0cd779b067595885f947ab8ffbaa90ea12f7c37b5995L169-R167))
* Swap the order of the conditions in several if statements in `vlib/v/checker/checker.v`, `vlib/v/checker/errors.v`, `vlib/v/checker/fn.v`, `vlib/v/checker/struct.v`, `vlib/v/parser/comptime.v`, and `vlib/v/parser/expr.v` to make them more consistent and avoid unnecessary checks ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L398-R398), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L966-R966), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L2324-R2324), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L4603-R4603), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-0f827ae97276f7c8db76bb5ebca9417a7e99e8ecfad523a022fed947b276b5feL163-R170), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL339-R339), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL731-R731), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL804-R804), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL2575-R2577), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL2617-R2614), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaL2649-R2646), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L51-R51), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-5a78d6ef98b6b2c2d5acab77fadb4e8131186177da378b9160e407ee02720b88L830-R830), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-d2c9f636f3936dce5b9a5091134a09f3d93289d196779b56c1efa12ec04a59a5L306-R342), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL47-R49), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL299-R299), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L979-R979), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2428-R2428), [link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2557-R2557))
* Refactor the logic of registering the variables for the comptime for loop in `vlib/v/parser/comptime.v` by using a match statement instead of multiple if statements ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-d2c9f636f3936dce5b9a5091134a09f3d93289d196779b56c1efa12ec04a59a5L306-R342))
* Refactor the logic of setting the module name based on the language in `vlib/v/parser/parser.v` by using a match statement instead of multiple if statements ([link](https://github.com/vlang/v/pull/19950/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2651-R2652))
