### PR TITLE
vlib/strconv/format: fix byte type to u8 type in documented examples

### DIFF
--- a/vlib/strconv/format.md
+++ b/vlib/strconv/format.md
@@ -66,7 +66,7 @@ The Length field can be omitted or be any of:
 
 | Character | Description                                                                |
 | --------- | -------------------------------------------------------------------------- |
-| `hh`      | For integer types, causes `printf` to expect an `byte` or `i8` argument.   |
+| `hh`      | For integer types, causes `printf` to expect an `i8` or `u8` argument.     |
 | `h`       | For integer types, causes `printf` to expect an `int16` or `u16` argument. |
 | `l`       | For integer types, causes `printf` to expect an `i64` or `u64` argument.   |
 | `ll`      | For integer types, causes `printf` to expect an `i64` or `u64` argument.   |
@@ -99,7 +99,7 @@ import strconv
 
 a0 := u32(10)
 b0 := 200
-c0 := byte(12)
+c0 := u8(12)
 s0 := 'ciAo'
 ch0 := `B`
 f0 := 0.312345
@@ -118,7 +118,7 @@ integer
 ```v
 import strconv
 
-a := byte(12)
+a := u8(12)
 b := i16(13)
 c := 14
 d := i64(15)
@@ -136,7 +136,7 @@ unsigned integer
 ```v
 import strconv
 
-a1 := byte(0xff)
+a1 := u8(0xff)
 b1 := u16(0xffff)
 c1 := u32(0xffffffff)
 d1 := u64(-1)
@@ -154,7 +154,7 @@ hexadecimal
 ```v
 import strconv
 
-a1 := byte(0xff)
+a1 := u8(0xff)
 b1 := i16(0xffff)
 c1 := u32(0xffffffff)
 d1 := u64(-1)
@@ -239,7 +239,7 @@ The format module also has some utility functions:
 ```v oksyntax nofmt
 // calling struct
 struct BF_param {
-  pad_ch       byte       = ` `     // padding char
+  pad_ch       u8         = ` `     // padding char
   len0         int        = -1      // default len for whole the number or string
   len1         int        = 6       // number of decimal digits, if needed
   positive     bool       = true    // mandatory: the sign of the number passed


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a6e976c</samp>

Updated `strconv.format` documentation to use `u8` type. This reflects the latest V syntax and avoids using the deprecated `byte` type.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a6e976c</samp>

* Replace `byte` with `u8` in documentation of `strconv.format` module ([link](https://github.com/vlang/v/pull/19952/files?diff=unified&w=0#diff-15072a5b2c53bbad97e5867165e92e160a42a9ca0ad20269dd04bda5121316d8L69-R69), [link](https://github.com/vlang/v/pull/19952/files?diff=unified&w=0#diff-15072a5b2c53bbad97e5867165e92e160a42a9ca0ad20269dd04bda5121316d8L102-R102), [link](https://github.com/vlang/v/pull/19952/files?diff=unified&w=0#diff-15072a5b2c53bbad97e5867165e92e160a42a9ca0ad20269dd04bda5121316d8L121-R121), [link](https://github.com/vlang/v/pull/19952/files?diff=unified&w=0#diff-15072a5b2c53bbad97e5867165e92e160a42a9ca0ad20269dd04bda5121316d8L139-R139), [link](https://github.com/vlang/v/pull/19952/files?diff=unified&w=0#diff-15072a5b2c53bbad97e5867165e92e160a42a9ca0ad20269dd04bda5121316d8L157-R157), [link](https://github.com/vlang/v/pull/19952/files?diff=unified&w=0#diff-15072a5b2c53bbad97e5867165e92e160a42a9ca0ad20269dd04bda5121316d8L242-R242))
