### PR TITLE
server: replace use of .eq method with == in semver_test

### DIFF
--- a/vlib/semver/semver_test.v
+++ b/vlib/semver/semver_test.v
@@ -171,7 +171,7 @@ fn test_coerce() {
 			assert false
 			return
 		}
-		assert fixed.eq(valid)
+		assert fixed == valid
 	}
 }
 


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0419c22</samp>

Use `==` operator for `SemVer` struct in tests. This improves readability and aligns with the operator implementation for the struct.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0419c22</samp>

*  Implement `==` operator for `SemVer` struct to compare two versions for equality ()
