### PR TITLE
v/parser: fix reference output for method_call_receiver_err

### DIFF
--- a/vlib/v/parser/tests/method_call_receiver_err.out
+++ b/vlib/v/parser/tests/method_call_receiver_err.out
@@ -1,17 +1,3 @@
-vlib/v/parser/tests/method_call_receiver_err.vv:6:2: warning: unused variable: `s1`
-    4 | 
-    5 | fn main() {
-    6 |     s1 := S1{}
-      |     ~~
-    7 | 
-    8 |     $for method in S1.methods {
-vlib/v/parser/tests/method_call_receiver_err.vv:8:7: warning: unused variable: `method`
-    6 |     s1 := S1{}
-    7 | 
-    8 |     $for method in S1.methods {
-      |          ~~~~~~
-    9 |         println(S1.method_hello('yo'))
-   10 |     }
 vlib/v/parser/tests/method_call_receiver_err.vv:9:11: error: unknown function: S1.method_hello
     7 | 
     8 |     $for method in S1.methods {
@@ -26,3 +12,17 @@ vlib/v/parser/tests/method_call_receiver_err.vv:9:3: error: `println` can not pr
       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    10 |     }
    11 | }
+vlib/v/parser/tests/method_call_receiver_err.vv:6:2: error: unused variable: `s1`
+    4 | 
+    5 | fn main() {
+    6 |     s1 := S1{}
+      |     ~~
+    7 | 
+    8 |     $for method in S1.methods {
+vlib/v/parser/tests/method_call_receiver_err.vv:8:7: error: unused variable: `method`
+    6 |     s1 := S1{}
+    7 | 
+    8 |     $for method in S1.methods {
+      |          ~~~~~~
+    9 |         println(S1.method_hello('yo'))
+   10 |     }


### PR DESCRIPTION
I notice a large number of these problems when running test-all.  Should I be making pull requests for all of these or are other people responsible.  I don't want to step on anybody's work.

It looks like there are a lot of differences in the expected output dues to warnings now showing up as errors and the order or error messages are different.  If I should continue cleaning these up, should I do a pull request per file or should I batch them up so that there aren't too many pull requests but no one pull request is too big?

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 33de50c</samp>

This pull request fixes a test case for the compiler's error handling of unused variables. It updates the expected output file `method_call_receiver_err.out` to match the new error messages.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 33de50c</samp>

*  Change the compiler to treat unused variables as errors instead of warnings (                                           
