### PR TITLE
szip: update `CompressionLevel` fields to use their named C values

### DIFF
--- a/vlib/szip/szip.c.v
+++ b/vlib/szip/szip.c.v
@@ -55,14 +55,13 @@ fn cb_zip_extract(filename &&char, arg &&char) int {
 	return 0
 }
 
-// CompressionLevel lists compression levels, see in "thirdparty/zip/miniz.h"
 pub enum CompressionLevel {
-	no_compression      = 0
-	best_speed          = 1
-	best_compression    = 9
-	uber_compression    = 10
-	default_level       = 6
-	default_compression = -1
+	no_compression      = C.MZ_NO_COMPRESSION
+	best_speed          = C.MZ_BEST_SPEED
+	best_compression    = C.MZ_BEST_COMPRESSION
+	uber_compression    = C.MZ_UBER_COMPRESSION
+	default_level       = C.MZ_DEFAULT_LEVEL
+	default_compression = C.MZ_DEFAULT_COMPRESSION
 }
 
 // OpenMode lists the opening modes


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1001c63</samp>

Use `miniz.h` constants for `CompressionLevel` enum values in `szip.c.v`. This improves code quality and avoids potential errors.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1001c63</samp>

* Replace hard-coded numeric values for `CompressionLevel` enum with constants from `miniz.h` header file ([link](https://github.com/vlang/v/pull/19957/files?diff=unified&w=0#diff-f74f8fd0df88b76ac5b797673978f5a645f727b5a6a6bcb490fd8b541bc78b14L58-R64))
