### PR TITLE
tools.vpm: add support for env variable `VPM_FAIL_ON_PROMPT`, to prevent getting stuck in test scenarios with conflicting module dir names

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -233,6 +233,10 @@ fn (m Module) confirm_install() bool {
 	} else {
 		install_version := at_version(if m.version == '' { 'latest' } else { m.version })
 		println('Module `${m.name}${at_version(m.installed_version)}` is already installed at `${m.install_path_fmted}`.')
+		if settings.no_prompt {
+			vpm_error('VPM should not have entered a confirmation prompt.')
+			exit(1)
+		}
 		input := os.input('Replace it with `${m.name}${install_version}`? [Y/n]: ')
 		match input.to_lower() {
 			'', 'y' {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -233,7 +233,7 @@ fn (m Module) confirm_install() bool {
 	} else {
 		install_version := at_version(if m.version == '' { 'latest' } else { m.version })
 		println('Module `${m.name}${at_version(m.installed_version)}` is already installed at `${m.install_path_fmted}`.')
-		if settings.no_prompt {
+		if settings.fail_on_prompt {
 			vpm_error('VPM should not have entered a confirmation prompt.')
 			exit(1)
 		}

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -16,7 +16,7 @@ fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 	os.setenv('VPM_DEBUG', '', true)
 	os.setenv('VPM_NO_INCREMENT', '1', true)
-	os.setenv('VPM_NO_PROMPT', '1', true)
+	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -16,6 +16,7 @@ fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 	os.setenv('VPM_DEBUG', '', true)
 	os.setenv('VPM_NO_INCREMENT', '1', true)
+	os.setenv('VPM_NO_PROMPT', '1', true)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -14,6 +14,7 @@ fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 	os.setenv('VPM_DEBUG', '', true)
 	os.setenv('VPM_NO_INCREMENT', '1', true)
+	os.setenv('VPM_NO_PROMPT', '1', true)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -14,7 +14,7 @@ fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
 	os.setenv('VPM_DEBUG', '', true)
 	os.setenv('VPM_NO_INCREMENT', '1', true)
-	os.setenv('VPM_NO_PROMPT', '1', true)
+	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -14,8 +14,8 @@ mut:
 	vmodules_path         string
 	no_dl_count_increment bool
 	// To ensure that some test scenarios with conflicting module directory names do not get stuck in prompts.
-	// It is intended that VPM does not display a prompt when `VPM_NO_PROMPT` is set.
-	no_prompt bool
+	// It is intended that VPM does not display a prompt when `VPM_FAIL_ON_PROMPT` is set.
+	fail_on_prompt bool
 	// git is used by default. URL installations can specify `--hg`. For already installed modules
 	// and VPM modules that specify a different VCS in their `v.mod`, the VCS is validated separately.
 	vcs VCS
@@ -38,6 +38,6 @@ fn init_settings() VpmSettings {
 		vcs: supported_vcs[if '--hg' in opts { 'hg' } else { 'git' }]
 		vmodules_path: os.vmodules_dir()
 		no_dl_count_increment: os.getenv('CI') != '' || (no_inc_env != '' && no_inc_env != '0')
-		no_prompt: os.getenv('VPM_NO_PROMPT') != ''
+		fail_on_prompt: os.getenv('VPM_FAIL_ON_PROMPT') != ''
 	}
 }

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -13,6 +13,9 @@ mut:
 	server_urls           []string
 	vmodules_path         string
 	no_dl_count_increment bool
+	// To ensure that some test scenarios with conflicting module directory names do not get stuck in prompts.
+	// It is intended that VPM does not display a prompt when `VPM_NO_PROMPT` is set.
+	no_prompt bool
 	// git is used by default. URL installations can specify `--hg`. For already installed modules
 	// and VPM modules that specify a different VCS in their `v.mod`, the VCS is validated separately.
 	vcs VCS
@@ -35,5 +38,6 @@ fn init_settings() VpmSettings {
 		vcs: supported_vcs[if '--hg' in opts { 'hg' } else { 'git' }]
 		vmodules_path: os.vmodules_dir()
 		no_dl_count_increment: os.getenv('CI') != '' || (no_inc_env != '' && no_inc_env != '0')
+		no_prompt: os.getenv('VPM_NO_PROMPT') != ''
 	}
 }


### PR DESCRIPTION
Edit:

changed to `VPM_FAIL_ON_PROMPT`


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3e99c63</samp>

This pull request adds a `no_prompt` setting to `vpm` that allows the user to skip confirmation prompts when installing modules. It also updates the tests to use this setting and adds an error check for unexpected prompts. This fixes issue #11197.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3e99c63</samp>

*  Implement `no_prompt` setting in `vpm` to avoid prompts when installing modules ([link](https://github.com/vlang/v/pull/19960/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR16-R18), [link](https://github.com/vlang/v/pull/19960/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aR41), [link](https://github.com/vlang/v/pull/19960/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cR236-R239))
*  Set `VPM_NO_PROMPT` environment variable to `1` in tests to enable `no_prompt` setting and prevent failing tests due to prompts ([link](https://github.com/vlang/v/pull/19960/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58R19), [link](https://github.com/vlang/v/pull/19960/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38R17))
