### PR TITLE
tools.vpm: fix installing of modules with conflicting names, extend tests

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -45,7 +45,7 @@ struct ErrorOptions {
 }
 
 const (
-	vexe     = os.quoted_path(@VEXE)
+	vexe     = os.getenv('VEXE')
 	home_dir = os.home_dir()
 )
 

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -43,7 +43,10 @@ struct ErrorOptions {
 	verbose bool // is used to only output the error message if the verbose setting is enabled.
 }
 
-const home_dir = os.home_dir()
+const (
+	vexe     = os.quoted_path(@VEXE)
+	home_dir = os.home_dir()
+)
 
 fn parse_query(query []string) ([]Module, []Module) {
 	mut vpm_modules, mut external_modules := []Module{}, []Module{}

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -45,7 +45,7 @@ struct ErrorOptions {
 }
 
 const (
-	vexe     = os.getenv('VEXE')
+	vexe     = os.quoted_path(os.getenv('VEXE'))
 	home_dir = os.home_dir()
 )
 

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -20,6 +20,7 @@ mut:
 	is_installed       bool
 	is_external        bool
 	vcs                ?VCS
+	manifest           vmod.Manifest
 }
 
 struct ModuleVpmInfo {
@@ -64,26 +65,30 @@ fn parse_query(query []string) ([]Module, []Module) {
 			false
 		}
 		mut mod := if is_http || ident.starts_with('https://') {
-			// External module.
+			// External module. The idenifier is an URL.
 			publisher, name := get_ident_from_url(ident) or {
 				vpm_error(err.msg())
 				errors++
 				continue
 			}
-			// Resolve path, verify existence of manifest.
-			base := if is_http { publisher } else { '' }
-			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
-				base, name)))
-			if is_git_setting && !has_vmod(ident, install_path) {
-				vpm_error('failed to find `v.mod` for `${ident}`.')
+			// Fetch manifest.
+			manifest := fetch_manifest(name, ident, version, is_git_setting) or {
+				vpm_error('failed to find `v.mod` for `${ident}${at_version(version)}`.',
+					details: err.msg()
+				)
 				errors++
 				continue
 			}
+			// Resolve path.
+			base := if is_http { publisher } else { '' }
+			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
+				base, manifest.name)))
 			Module{
-				name: name
+				name: manifest.name
 				url: ident
 				install_path: install_path
 				is_external: true
+				manifest: manifest
 			}
 		} else {
 			// VPM registered module.
@@ -115,11 +120,9 @@ fn parse_query(query []string) ([]Module, []Module) {
 				errors++
 				continue
 			}
-			// Resolve path, verify existence of manifest.
-			ident_as_path := info.name.replace('.', os.path_separator)
-			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
-				ident_as_path)))
-			if is_git_module && !has_vmod(info.url, install_path) {
+			// Fetch manifest.
+			manifest := fetch_manifest(info.name, info.url, version, is_git_module) or {
+				// Add link with issue template requesting to add a manifest.
 				mut details := ''
 				if resp := http.head('${info.url}/issues/new') {
 					if resp.status_code == 200 {
@@ -128,12 +131,19 @@ fn parse_query(query []string) ([]Module, []Module) {
 					}
 				}
 				vpm_warn('`${info.name}` is missing a manifest file.', details: details)
+				vpm_log(@FILE_LINE, @FN, 'vpm manifest detection error: ${err}')
+				vmod.Manifest{}
 			}
+			// Resolve path.
+			ident_as_path := info.name.replace('.', os.path_separator)
+			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
+				ident_as_path)))
 			Module{
 				name: info.name
 				url: info.url
 				vcs: vcs
 				install_path: install_path
+				manifest: manifest
 			}
 		}
 		mod.version = version
@@ -177,23 +187,38 @@ fn (mut m Module) get_installed() {
 	}
 }
 
-fn has_vmod(url string, install_path string) bool {
-	if install_path != '' && os.exists((os.join_path(install_path, 'v.mod'))) {
-		// Skip fetching the repo when the module is already installed and has a `v.mod`.
-		return true
+fn fetch_manifest(name string, url string, version string, is_git bool) !vmod.Manifest {
+	if !is_git {
+		// TODO: fetch manifest for mercurial repositories
+		return vmod.Manifest{
+			name: name
+		}
 	}
-	head_branch := os.execute_opt('git ls-remote --symref ${url} HEAD') or {
-		vpm_error('failed to find git HEAD for `${url}`.', details: err.msg())
-		return false
-	}.output.all_after_last('/').all_before(' ').all_before('\t')
+	v := if version != '' {
+		version
+	} else {
+		head_branch := os.execute_opt('git ls-remote --symref ${url} HEAD') or {
+			return error('failed to find git HEAD. ${err}')
+		}
+		head_branch.output.all_after_last('/').all_before(' ').all_before('\t')
+	}
 	url_ := if url.ends_with('.git') { url.replace('.git', '') } else { url }
-	manifest_url := '${url_}/blob/${head_branch}/v.mod'
-	vpm_log(@FILE_LINE, @FN, 'manifest_url: ${manifest_url}')
-	has_vmod := http.head(manifest_url) or {
-		vpm_error('failed to retrieve module data for `${url}`.')
-		return false
-	}.status_code == 200
-	return has_vmod
+	// Scan both URLS. E.g.:
+	// https://github.com/publisher/module/raw/v0.7.0/v.mod
+	// https://gitlab.com/publisher/module/-/raw/main/v.mod
+	raw_paths := ['raw/', '/-/raw/']
+	for i, raw_p in raw_paths {
+		manifest_url := '${url_}/${raw_p}/${v}/v.mod'
+		vpm_log(@FILE_LINE, @FN, 'manifest_url ${i}: ${manifest_url}')
+		raw_manifest_resp := http.get(manifest_url) or { continue }
+		if raw_manifest_resp.status_code != 200 {
+			return error('unsuccessful response status `${raw_manifest_resp.status_code}`.')
+		}
+		return vmod.decode(raw_manifest_resp.body) or {
+			return error('failed to decode manifest `${raw_manifest_resp.body}`. ${err}')
+		}
+	}
+	return error('failed to retrieve manifest.')
 }
 
 fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModuleDateInfo {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -130,54 +130,8 @@ fn vpm_install_from_vcs(modules []Module) {
 				continue
 			}
 		}
-		manifest := get_manifest(m.install_path) or { continue }
-		final_path := os.join_path(m.install_path.all_before_last(os.path_separator),
-			normalize_mod_path(manifest.name))
-		if m.install_path != final_path {
-			verbose_println('Relocating `${m.name} (${m.install_path_fmted})` to `${manifest.name} (${final_path})`...')
-			if os.exists(final_path) {
-				println('Target directory for `${m.name} (${final_path})` already exists.')
-				input := os.input('Replace it with the module directory? [Y/n]: ')
-				match input.to_lower() {
-					'', 'y' {
-						m.remove() or {
-							vpm_error('failed to remove `${final_path}`.', details: err.msg())
-							errors++
-							continue
-						}
-					}
-					else {
-						verbose_println('Skipping `${m.name}`.')
-						continue
-					}
-				}
-			}
-			// When the module should be relocated into a subdirectory we need to make sure
-			// it exists to not run into permission errors.
-			if m.install_path.count(os.path_separator) < final_path.count(os.path_separator)
-				&& !os.exists(final_path) {
-				os.mkdir_all(final_path) or {
-					vpm_error('failed to create directory for `${manifest.name}`.',
-						details: err.msg()
-					)
-					errors++
-					continue
-				}
-			}
-			os.mv(m.install_path, final_path) or {
-				errors++
-				vpm_error('failed to relocate module `${m.name}`.', details: err.msg())
-				os.rmdir_all(m.install_path) or {
-					vpm_error('failed to remove `${m.install_path}`.', details: err.msg())
-					errors++
-					continue
-				}
-				continue
-			}
-			verbose_println('Relocated `${m.name}` to `${manifest.name}`.')
-		}
 		println('Installed `${m.name}`.')
-		resolve_dependencies(manifest, urls)
+		resolve_dependencies(m.manifest, urls)
 	}
 	if errors > 0 {
 		exit(1)

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -92,7 +92,6 @@ fn vpm_install_from_vpm(modules []Module) {
 	mut errors := 0
 	for m in modules {
 		vpm_log(@FILE_LINE, @FN, 'module: ${m}')
-		last_errors := errors
 		match m.install() {
 			.installed {}
 			.failed {
@@ -107,9 +106,7 @@ fn vpm_install_from_vpm(modules []Module) {
 			vpm_error('failed to increment the download count for `${m.name}`', details: err.msg())
 			errors++
 		}
-		if last_errors == errors {
-			println('Installed `${m.name}`.')
-		}
+		println('Installed `${m.name}`.')
 		resolve_dependencies(get_manifest(m.install_path), idents)
 	}
 	if errors > 0 {
@@ -123,7 +120,6 @@ fn vpm_install_from_vcs(modules []Module) {
 	mut errors := 0
 	for m in modules {
 		vpm_log(@FILE_LINE, @FN, 'module: ${m}')
-		last_errors := errors
 		match m.install() {
 			.installed {}
 			.failed {
@@ -180,9 +176,7 @@ fn vpm_install_from_vcs(modules []Module) {
 			}
 			verbose_println('Relocated `${m.name}` to `${manifest.name}`.')
 		}
-		if last_errors == errors {
-			println('Installed `${m.name}`.')
-		}
+		println('Installed `${m.name}`.')
 		resolve_dependencies(manifest, urls)
 	}
 	if errors > 0 {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -59,6 +59,8 @@ fn test_install_from_git_url() {
 	res = os.execute_or_exit('${vexe} install http://github.com/Wertzui123/HashMap')
 	assert res.output.contains('Updating module `wertzui123.hashmap`'), res.output
 	assert res.output.contains('`http` is deprecated'), res.output
+	res = os.execute_or_exit('${vexe} install https://gitlab.com/tobealive/webview')
+	assert res.output.contains('Installed `webview`'), res.output
 }
 
 fn test_install_already_existent() {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -5,12 +5,9 @@ module main
 import os
 import v.vmod
 
-const (
-	v         = os.quoted_path(@VEXE)
-	// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
-	// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
-	test_path = os.join_path(os.vtmp_dir(), 'vpm_install_test')
-)
+// Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
+// The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_test')
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
@@ -23,7 +20,7 @@ fn testsuite_end() {
 }
 
 fn test_install_from_vpm_ident() {
-	res := os.execute_or_exit('${v} install nedpals.args')
+	res := os.execute_or_exit('${vexe} install nedpals.args')
 	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.msg()
@@ -34,7 +31,7 @@ fn test_install_from_vpm_ident() {
 }
 
 fn test_install_from_vpm_short_ident() {
-	os.execute_or_exit('${v} install pcre')
+	os.execute_or_exit('${vexe} install pcre')
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -44,7 +41,7 @@ fn test_install_from_vpm_short_ident() {
 }
 
 fn test_install_from_git_url() {
-	mut res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
+	mut res := os.execute_or_exit('${vexe} install https://github.com/vlang/markdown')
 	assert res.output.contains('Installing `markdown`'), res.output
 	mut mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
@@ -52,20 +49,20 @@ fn test_install_from_git_url() {
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
-	res = os.execute_or_exit('${v} install http://github.com/Wertzui123/HashMap')
+	res = os.execute_or_exit('${vexe} install http://github.com/Wertzui123/HashMap')
 	assert res.output.contains('Installing `HashMap`'), res.output
 	assert res.output.contains('`http` is deprecated'), res.output
 	mod = vmod.from_file(os.join_path(test_path, 'wertzui123', 'hashmap', 'v.mod')) or {
 		assert false, err.msg()
 		return
 	}
-	res = os.execute_or_exit('${v} install http://github.com/Wertzui123/HashMap')
+	res = os.execute_or_exit('${vexe} install http://github.com/Wertzui123/HashMap')
 	assert res.output.contains('Updating module `wertzui123.hashmap`'), res.output
 	assert res.output.contains('`http` is deprecated'), res.output
 }
 
 fn test_install_already_existent() {
-	mut res := os.execute_or_exit('${v} install https://github.com/vlang/markdown')
+	mut res := os.execute_or_exit('${vexe} install https://github.com/vlang/markdown')
 	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
@@ -74,7 +71,7 @@ fn test_install_already_existent() {
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
 	// The same module but with the `.git` extension added.
-	os.execute_or_exit('${v} install https://github.com/vlang/markdown.git')
+	os.execute_or_exit('${vexe} install https://github.com/vlang/markdown.git')
 	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 }
 
@@ -89,7 +86,7 @@ fn test_install_once() {
 	os.mkdir_all(test_path) or {}
 
 	// Install markdown module.
-	os.execute_or_exit('${v} install markdown')
+	os.execute_or_exit('${vexe} install markdown')
 	// Keep track of the last modified state of the v.mod file of the installed markdown module.
 	md_last_modified := os.file_last_mod_unix(os.join_path(test_path, 'markdown', 'v.mod'))
 
@@ -116,7 +113,7 @@ fn test_install_once() {
 
 fn test_missing_repo_name_in_url() {
 	incomplete_url := 'https://github.com/vlang'
-	res := os.execute('${v} install ${incomplete_url}')
+	res := os.execute('${vexe} install ${incomplete_url}')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to retrieve module name for `${incomplete_url}`'), res.output
 }
@@ -125,11 +122,11 @@ fn test_missing_vmod_in_url() {
 	assert has_vmod('https://github.com/vlang/v', '') // head branch == `master`.
 	assert has_vmod('https://github.com/v-analyzer/v-analyzer', '') // head branch == `main`.
 	assert !has_vmod('https://github.com/octocat/octocat.github.io', '') // not a V module.
-	mut res := os.execute('${v} install https://github.com/octocat/octocat.github.io')
+	mut res := os.execute('${vexe} install https://github.com/octocat/octocat.github.io')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to find `v.mod` for `https://github.com/octocat/octocat.github.io`'), res.output
 	// No error for vpm modules yet.
-	res = os.execute_or_exit('${v} install spytheman.regex')
+	res = os.execute_or_exit('${vexe} install spytheman.regex')
 	assert res.output.contains('`spytheman.regex` is missing a manifest file'), res.output
 	assert res.output.contains('Installing `spytheman.regex`'), res.output
 }

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -5,10 +5,7 @@ module main
 import os
 import v.vmod
 
-const (
-	v         = os.quoted_path(@VEXE)
-	test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test')
-)
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test')
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
@@ -31,37 +28,37 @@ fn get_mod_name_and_version(path string) (string, string) {
 fn test_install_from_vpm_with_git_version_tag() {
 	ident := 'ttytm.webview'
 	mut tag := 'v0.6.0'
-	mut res := os.execute_or_exit('${v} install ${ident}@${tag}')
+	mut res := os.execute_or_exit('${vexe} install ${ident}@${tag}')
 	assert res.output.contains('Installing `${ident}`'), res.output
 	assert res.output.contains('Installed `${ident}`'), res.output
 	mut name, mut version := get_mod_name_and_version(os.join_path('ttytm', 'webview'))
 	assert name == 'webview'
 	assert version == '0.6.0'
 	// Install same version without force flag.
-	res = os.execute_or_exit('${v} install ${ident}@${tag}')
+	res = os.execute_or_exit('${vexe} install ${ident}@${tag}')
 	assert res.output.contains('Module `${ident}@${tag}` is already installed, use --force to overwrite'), res.output
 	// Install another version, add force flag to surpass confirmation.
 	tag = 'v0.5.0'
-	res = os.execute_or_exit('${v} install -f ${ident}@${tag}')
+	res = os.execute_or_exit('${vexe} install -f ${ident}@${tag}')
 	assert res.output.contains('Installed `${ident}`'), res.output
 	name, version = get_mod_name_and_version(os.join_path('ttytm', 'webview'))
 	assert name == 'webview'
 	assert version == '0.5.0'
 	// Install invalid version.
 	tag = '6.0'
-	res = os.execute('${v} install -f ${ident}@${tag}')
+	res = os.execute('${vexe} install -f ${ident}@${tag}')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to install `${ident}`'), res.output
 	// Install invalid version verbose.
-	res = os.execute('${v} install -f -v ${ident}@${tag}')
+	res = os.execute('${vexe} install -f -v ${ident}@${tag}')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to install `${ident}`'), res.output
 	assert res.output.contains('Remote branch 6.0 not found in upstream origin'), res.output
 	// Install without version tag after a version was installed
-	res = os.execute_or_exit('${v} install -f ${ident}')
+	res = os.execute_or_exit('${vexe} install -f ${ident}')
 	assert res.output.contains('Installing `${ident}`'), res.output
 	// Re-install latest version (without a tag). Should trigger an update, force should not be required.
-	res = os.execute_or_exit('${v} install ${ident}')
+	res = os.execute_or_exit('${vexe} install ${ident}')
 	assert res.output.contains('Updating module `${ident}`'), res.output
 }
 
@@ -75,21 +72,21 @@ fn test_install_from_url_with_git_version_tag() {
 	assert name == 'vsl'
 	assert version == '0.1.50'
 	// Install same version without force flag.
-	res = os.execute_or_exit('${v} install ${url}@${tag}')
+	res = os.execute_or_exit('${vexe} install ${url}@${tag}')
 	assert res.output.contains('Module `vsl@${tag}` is already installed, use --force to overwrite'), res.output
 	// Install another version, add force flag to surpass confirmation.
 	tag = 'v0.1.47'
-	res = os.execute_or_exit('${v} install -f ${url}@${tag}')
+	res = os.execute_or_exit('${vexe} install -f ${url}@${tag}')
 	assert res.output.contains('Installed `vsl`'), res.output
 	name, version = get_mod_name_and_version('vsl')
 	assert name == 'vsl'
 	assert version == '0.1.47'
 	// Install invalid version.
 	tag = 'abc'
-	res = os.execute('${v} install -f ${url}@${tag}')
+	res = os.execute('${vexe} install -f ${url}@${tag}')
 	assert res.exit_code == 1
 	// Install invalid version verbose.
-	res = os.execute('${v} install -f -v ${url}@${tag}')
+	res = os.execute('${vexe} install -f -v ${url}@${tag}')
 	assert res.exit_code == 1
 	assert res.output.contains('Remote branch abc not found in upstream origin'), res.output
 }

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -63,7 +63,7 @@ fn test_install_from_vpm_with_git_version_tag() {
 }
 
 fn test_install_from_url_with_git_version_tag() {
-	url := 'https://github.com/vlang/vsl'
+	mut url := 'https://github.com/vlang/vsl'
 	mut tag := 'v0.1.50'
 	mut res := os.execute_or_exit('v install ${url}@${tag}')
 	assert res.output.contains('Installing `vsl`'), res.output
@@ -89,4 +89,12 @@ fn test_install_from_url_with_git_version_tag() {
 	res = os.execute('${vexe} install -f -v ${url}@${tag}')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to find `v.mod` for `${url}@${tag}`'), res.output
+	// GitLab
+	url = 'https://gitlab.com/tobealive/webview'
+	tag = 'v0.6.0'
+	res = os.execute_or_exit('${vexe} install ${url}@${tag}')
+	assert res.output.contains('Installed `webview`'), res.output
+	name, version = get_mod_name_and_version('webview')
+	assert name == 'webview'
+	assert version == '0.6.0'
 }

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -88,5 +88,5 @@ fn test_install_from_url_with_git_version_tag() {
 	// Install invalid version verbose.
 	res = os.execute('${vexe} install -f -v ${url}@${tag}')
 	assert res.exit_code == 1
-	assert res.output.contains('Remote branch abc not found in upstream origin'), res.output
+	assert res.output.contains('failed to find `v.mod` for `${url}@${tag}`'), res.output
 }

--- a/cmd/tools/vpm/search.v
+++ b/cmd/tools/vpm/search.v
@@ -39,7 +39,6 @@ fn vpm_search(keywords []string) {
 		}
 	}
 	if index == 0 {
-		vexe := os.getenv('VEXE')
 		vroot := os.real_path(os.dir(vexe))
 		mut messages := ['No module(s) found for `${joined}` .']
 		for vlibmod in search_keys {


### PR DESCRIPTION
fixes: https://discord.com/channels/592103645835821068/618363736503353374/1176466062682882058

This includes validating module data  running the actual install. This is also a major step to improve dependency resolution.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9025e7a</samp>

This pull request refactors and tests the `vpm` tool for managing modules in V. It uses the `vmod.Manifest` struct for module metadata, improves the handling of module identifiers and statuses, and removes unused or redundant code. It also adds or updates tests for the `fetch_manifest` function and the installation of modules.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9025e7a</samp>

*  Add a new field `manifest` to the `Module` struct to store the parsed data from the `v.mod` file of a module ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55R23))
*  Add a new constant `vexe` to hold the quoted path of the V executable and use it instead of the `VEXE` environment variable in the tests and the source code ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L46-R50), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L8-R10), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L26-R23), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L37-R34), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L47-R44), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L55-R52), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L62-R59), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L68-R65), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L77-R74), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L92-R89), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L8-R8), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L34-R31), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L41-R42), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L52-R61), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L78-R79), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L89-R91), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-96549a827e85ce50a5777165ed054e7bcdaefc5a6b6f2950a24ebb8b4a4d5c3dL42))
*  Add a new function `fetch_manifest` to download and decode the manifest from the module URL, handle different cases of branch names, URL formats, and missing or invalid manifests, and relocate the module based on the manifest name ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L70-R91), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L115-R125), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L174-R223), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL137-R134), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L119-R167))
*  Add a new method `get_installed` to the `Module` struct to check the installation status and version of a module using the `git ls-remote` command and set the `is_installed` and `installed_version` fields accordingly ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L134-R150))
*  Move the code for installing a module from the `install.v` file to the `common.v` file as part of the `install_modules` function, which is shared by both the `install.v` and the `update.v` files ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL95), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL110-R109), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL126))
*  Add a comment to clarify that the identifier of an external module is an URL, not a name ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L64-R68))
*  Resolve the path of the module based on the manifest name, instead of the identifier name, to ensure the correct installation directory ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L128-R140))
*  Remove the unused variable `last_errors`, which was used to compare the number of errors before and after installing a module ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL95), [link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL126))
*  Remove the unused variable `vexe`, which was used to get the path of the V executable from the `VEXE` environment variable ([link](https://github.com/vlang/v/pull/19961/files?diff=unified&w=0#diff-96549a827e85ce50a5777165ed054e7bcdaefc5a6b6f2950a24ebb8b4a4d5c3dL42))
