### PR TITLE
v2: initial move of tinyv (auto_semi branch) code to main repo

### DIFF
--- a/cmd/v2/v2.v
+++ b/cmd/v2/v2.v
@@ -1,0 +1,28 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module main
+
+import os
+import os.cmdline
+import v2.pref
+import v2.builder
+
+fn main() {
+	args := os.args[1..]
+
+	options := cmdline.only_options(args)
+	prefs := pref.new_preferences_using_options(options)
+
+	files := cmdline.only_non_options(args)
+	if files.len == 0 {
+		eprintln('At least 1 .v file expected')
+		exit(1)
+	}
+	$if debug {
+		eprintln('v files: ${files}')
+	}
+
+	mut b := builder.new_builder(prefs)
+	b.build(files)
+}

--- a/vlib/v2/ast/ast.v
+++ b/vlib/v2/ast/ast.v
@@ -1,0 +1,906 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module ast
+
+import v2.token
+
+pub const (
+	empty_expr = Expr(EmptyExpr(0))
+	empty_stmt = Stmt(EmptyStmt(0))
+)
+
+type EmptyExpr = u8
+type EmptyStmt = u8
+
+pub type Expr = ArrayInitExpr
+	| AsCastExpr
+	| AssocExpr
+	| BasicLiteral
+	| CallExpr
+	| CallOrCastExpr
+	| CastExpr
+	| ComptimeExpr
+	| EmptyExpr
+	| FieldInit
+	| FnLiteral
+	| GenericArgOrIndexExpr
+	| GenericArgs
+	| Ident
+	| IfExpr
+	| IfGuardExpr
+	| IndexExpr
+	| InfixExpr
+	| InitExpr
+	| Keyword
+	| KeywordOperator
+	| LambdaExpr
+	| LockExpr
+	| MapInitExpr
+	| MatchExpr
+	| ModifierExpr
+	| OrExpr
+	| ParenExpr
+	| PostfixExpr
+	| PrefixExpr
+	| RangeExpr
+	| SelectExpr
+	| SelectorExpr
+	| SqlExpr
+	| StringInterLiteral
+	| StringLiteral
+	| Tuple
+	| Type
+	| UnsafeExpr
+
+// TODO: decide if this going to be done like this (FieldInit)
+
+pub type Stmt = AsmStmt
+	| AssertStmt
+	| AssignStmt
+	| BlockStmt
+	| ComptimeStmt
+	| ConstDecl
+	| DeferStmt
+	| Directive
+	| EmptyStmt
+	| EnumDecl
+	| ExprStmt
+	| FlowControlStmt
+	| FnDecl
+	| ForInStmt
+	| ForStmt
+	| GlobalDecl
+	| ImportStmt
+	| InterfaceDecl
+	| LabelStmt
+	| ModuleStmt
+	| ReturnStmt
+	| StructDecl
+	| TypeDecl
+	| []Attribute
+
+// pub type Decl = ConstDecl | EnumDecl | FnDecl | GlobalDecl
+// 	| InterfaceDecl | StructDecl | TypeDecl
+
+// TOOD: (re)implement nested sumtype like TS (was removed from v)
+// currently need to cast to type in parser.type. Should I leave like
+// this or add these directly to Expr until nesting is implemented?
+pub type Type = AnonStructType
+	| ArrayFixedType
+	| ArrayType
+	| ChannelType
+	| FnType
+	| GenericType
+	| MapType
+	| NilType
+	| NoneType
+	| OptionType
+	| ResultType
+	| ThreadType
+	| TupleType
+
+pub fn (exprs []Expr) name_list() string {
+	mut name_list := ''
+	for i, expr in exprs {
+		name_list += expr.name()
+		if i < exprs.len - 1 {
+			name_list += ','
+		}
+	}
+	return name_list
+}
+
+pub fn (t Type) name() string {
+	return match t {
+		GenericType {
+			'${t.name.name()}[${t.params.name_list()}]'
+		}
+		else {
+			panic('Type.name(): unsupported expr `${t.type_name()}`, currently only supports `ast.Ident` & `ast.SelectorExpr`')
+			// expr.str()
+		}
+	}
+}
+
+// TODO: fix this, shouldbe only what is needed
+pub fn (expr Expr) name() string {
+	return match expr {
+		AsCastExpr {
+			'${expr.expr.name()} as ${expr.typ.name()}'
+		}
+		BasicLiteral {
+			expr.value
+		}
+		CallExpr {
+			// TODO:
+			'${expr.lhs.name()}()'
+		}
+		CallOrCastExpr {
+			'${expr.lhs.name()}(${expr.expr.name()})'
+		}
+		EmptyExpr {
+			// TODO:
+			'EmptyExpr'
+		}
+		GenericArgs {
+			'${expr.lhs.name()}[${expr.args.name_list()}]'
+		}
+		Ident {
+			expr.name
+		}
+		IndexExpr {
+			'${expr.lhs.name()}[${expr.expr.name()}]'
+		}
+		InfixExpr {
+			'${expr.lhs.name()} ${expr.op} ${expr.rhs.name()}'
+		}
+		Keyword {
+			expr.tok.str()
+		}
+		ModifierExpr {
+			'${expr.kind} ${expr.expr.name()}'
+		}
+		ParenExpr {
+			'(${expr.expr.name()})'
+		}
+		PrefixExpr {
+			'${expr.op}${expr.expr.name()}'
+		}
+		SelectorExpr {
+			expr.name()
+		}
+		StringLiteral {
+			"'${expr.value}'"
+		}
+		Type {
+			expr.name()
+		}
+		UnsafeExpr {
+			// TODO:
+			'UnsafeExpr'
+		}
+		else {
+			panic('Expr.name(): unsupported expr `${expr.type_name()}`, add it?')
+			// expr.str()
+		}
+	}
+}
+
+pub fn (expr Expr) pos() token.Pos {
+	return match expr {
+		Ident {
+			expr.pos
+		}
+		SelectorExpr {
+			expr.pos
+			// NOTE: should we remove `pos` from `SelectorExpr` and use `expr.lhs.pos()` instead?
+			// which would always get the position of the left most part of the `SelectorExpr`
+			// expr.lhs.pos()
+		}
+		else {
+			panic('Expr.pos(): TODO: add ${expr.type_name()}')
+		}
+	}
+}
+
+// File (AST container)
+pub struct File {
+pub:
+	attributes []Attribute
+	mod        string
+	name       string
+	stmts      []Stmt
+	imports    []ImportStmt
+}
+
+pub enum Language {
+	v
+	c
+	js
+}
+
+pub fn (lang Language) str() string {
+	return match lang {
+		.v { 'V' }
+		.c { 'C' }
+		.js { 'JS' }
+	}
+}
+
+// Expressions
+pub struct ArrayInitExpr {
+pub:
+	typ   Expr = ast.empty_expr
+	exprs []Expr
+	init  Expr = ast.empty_expr
+	cap   Expr = ast.empty_expr
+	len   Expr = ast.empty_expr
+	pos   token.Pos
+}
+
+pub struct AsCastExpr {
+pub:
+	expr Expr
+	typ  Expr
+	pos  token.Pos
+}
+
+pub struct AssocExpr {
+pub:
+	typ    Expr
+	expr   Expr
+	fields []FieldInit
+}
+
+pub struct BasicLiteral {
+pub:
+	kind  token.Token
+	value string
+}
+
+pub struct CallExpr {
+pub:
+	lhs  Expr
+	args []Expr
+	pos  token.Pos
+}
+
+pub struct CallOrCastExpr {
+pub:
+	lhs  Expr
+	expr Expr
+	pos  token.Pos
+}
+
+pub struct CastExpr {
+pub:
+	typ  Expr
+	expr Expr
+	pos  token.Pos
+}
+
+pub struct ComptimeExpr {
+pub:
+	expr Expr
+	pos  token.Pos
+}
+
+pub struct FieldDecl {
+pub:
+	name       string
+	typ        Expr = ast.empty_expr // can be empty as used for const (unless we use something else)
+	value      Expr = ast.empty_expr
+	attributes []Attribute
+}
+
+pub struct FieldInit {
+pub:
+	name  string
+	value Expr
+}
+
+// anon fn / closure
+pub struct FnLiteral {
+pub:
+	typ           FnType
+	captured_vars []Expr
+	stmts         []Stmt
+}
+
+pub struct GenericArgs {
+pub:
+	lhs  Expr
+	args []Expr // concrete types
+}
+
+pub struct GenericArgOrIndexExpr {
+pub:
+	lhs  Expr
+	expr Expr
+}
+
+pub struct Ident {
+pub:
+	pos  token.Pos
+	name string
+}
+
+pub struct IfExpr {
+pub:
+	cond      Expr = ast.empty_expr
+	else_expr Expr = ast.empty_expr
+	stmts     []Stmt
+}
+
+pub struct IfGuardExpr {
+pub:
+	stmt AssignStmt
+}
+
+pub struct InfixExpr {
+pub:
+	op  token.Token
+	lhs Expr
+	rhs Expr
+	pos token.Pos
+}
+
+pub struct IndexExpr {
+pub:
+	lhs      Expr
+	expr     Expr
+	is_gated bool
+}
+
+pub struct InitExpr {
+pub:
+	typ    Expr
+	fields []FieldInit
+}
+
+pub struct Keyword {
+pub:
+	tok token.Token
+}
+
+pub struct KeywordOperator {
+pub:
+	op    token.Token
+	exprs []Expr
+}
+
+pub struct Tuple {
+pub:
+	exprs []Expr
+}
+
+pub struct LambdaExpr {
+pub:
+	args []Ident
+	expr Expr
+}
+
+pub struct LockExpr {
+pub:
+	lock_exprs  []Expr
+	rlock_exprs []Expr
+	stmts       []Stmt
+}
+
+pub struct MapInitExpr {
+pub:
+	typ  Expr = ast.empty_expr
+	keys []Expr
+	vals []Expr
+	pos  token.Pos
+}
+
+pub struct MatchBranch {
+pub:
+	cond  []Expr
+	stmts []Stmt
+	pos   token.Pos
+}
+
+pub struct MatchExpr {
+pub:
+	expr     Expr
+	branches []MatchBranch
+	pos      token.Pos
+}
+
+// TODO: possibly merge modifiers into a bitfield where
+// multiple modifiers are used. this could also be used
+// for struct decl `mut:`, `pub mut:` etc. consider this
+// [flag]
+// pub enum Modifier {
+// 	.atomic
+// 	.global
+// 	.mutable
+// 	.public
+// 	.shared
+// 	.static
+// 	.volatile
+// }
+
+pub struct ModifierExpr {
+pub:
+	kind token.Token
+	expr Expr
+}
+
+// pub fn (expr ModifierExpr) unwrap() Expr {
+// 	return expr.expr
+// }
+
+pub struct OrExpr {
+pub:
+	expr  Expr
+	stmts []Stmt
+	pos   token.Pos
+}
+
+pub struct Parameter {
+pub:
+	name   string
+	typ    Expr
+	is_mut bool
+	pos    token.Pos
+}
+
+pub struct ParenExpr {
+pub:
+	expr Expr
+}
+
+pub struct PostfixExpr {
+pub:
+	op   token.Token
+	expr Expr
+}
+
+pub struct PrefixExpr {
+pub:
+	op   token.Token
+	expr Expr
+	pos  token.Pos
+}
+
+pub struct RangeExpr {
+pub:
+	op    token.Token // `..` exclusive | `...` inclusive
+	start Expr
+	end   Expr
+}
+
+pub struct SelectExpr {
+pub:
+	pos   token.Pos
+	stmt  Stmt
+	stmts []Stmt
+	next  Expr = ast.empty_expr
+}
+
+pub struct SelectorExpr {
+pub:
+	lhs Expr
+	rhs Ident
+	pos token.Pos
+}
+
+pub fn (se SelectorExpr) leftmost() Expr {
+	if se.lhs is SelectorExpr {
+		return se.lhs.leftmost()
+	}
+	return se.lhs
+}
+
+// pub fn (expr Expr) str() string {
+// 	return 'Expr.str() - $expr.type_name()'
+// }
+
+pub fn (se SelectorExpr) name() string {
+	return se.lhs.name() + '.' + se.rhs.name
+}
+
+pub enum StringLiteralKind {
+	c
+	js
+	raw
+	v
+}
+
+pub fn (s StringLiteralKind) str() string {
+	return match s {
+		.c { 'c' }
+		.js { 'js' }
+		.raw { 'r' }
+		.v { 'v' }
+	}
+}
+
+// TODO: allow overriding this method in main v compiler
+// that is why this method was renamed from `from_string`
+@[direct_array_access]
+pub fn StringLiteralKind.from_string_tinyv(s string) !StringLiteralKind {
+	match s[0] {
+		`c` {
+			return .c
+		}
+		`j` {
+			if s[1] == `s` {
+				return .js
+			}
+		}
+		`r` {
+			return .raw
+		}
+		else {}
+	}
+	return error('invalid string prefix `${s}`')
+}
+
+// NOTE: I'm using two nodes StringLiteral & StringInterLiteral
+// to avoid the extra array allocations when not needed.
+pub struct StringLiteral {
+pub:
+	kind  StringLiteralKind
+	value string
+}
+
+pub struct StringInterLiteral {
+pub:
+	kind   StringLiteralKind
+	values []string
+	inters []StringInter
+}
+
+pub struct StringInter {
+pub:
+	format    StringInterFormat
+	width     int
+	precision int
+	expr      Expr
+	// TEMP: prob removed once individual
+	// fields are set, precision etc
+	format_expr Expr = ast.empty_expr
+}
+
+pub enum StringInterFormat {
+	unformatted
+	binary
+	character
+	decimal
+	exponent
+	exponent_short
+	float
+	hex
+	octal
+	pointer_address
+	string
+}
+
+pub fn StringInterFormat.from_u8(c u8) !StringInterFormat {
+	return match c {
+		`b` { .binary }
+		`c` { .character }
+		`d` { .decimal }
+		`e`, `E` { .exponent }
+		`g`, `G` { .exponent_short }
+		`f`, `F` { .float }
+		`x`, `X` { .hex }
+		`o` { .octal }
+		`p` { .pointer_address }
+		`s` { .string }
+		else { error('unknown formatter `${c.ascii_str()}`') }
+	}
+}
+
+pub fn (sif StringInterFormat) str() string {
+	return match sif {
+		.unformatted { '' }
+		.binary { 'b' }
+		.character { 'c' }
+		.decimal { 'd' }
+		.exponent { 'e' }
+		.exponent_short { 'g' }
+		.float { 'f' }
+		.hex { 'x' }
+		.octal { 'o' }
+		.pointer_address { 'p' }
+		.string { 's' }
+	}
+}
+
+pub struct SqlExpr {
+pub:
+	expr Expr
+}
+
+pub struct UnsafeExpr {
+pub:
+	stmts []Stmt
+}
+
+// Statements
+pub struct AsmStmt {
+pub:
+	arch string
+}
+
+pub struct AssertStmt {
+pub:
+	expr  Expr
+	extra Expr = ast.empty_expr
+}
+
+pub struct AssignStmt {
+pub:
+	op  token.Token
+	lhs []Expr
+	rhs []Expr
+	pos token.Pos
+}
+
+pub fn (attributes []Attribute) has(name string) bool {
+	for attribute in attributes {
+		if attribute.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+pub struct Attribute {
+pub:
+	name          string
+	value         Expr
+	comptime_cond Expr
+}
+
+pub struct BlockStmt {
+pub:
+	stmts []Stmt
+}
+
+pub struct ComptimeStmt {
+pub:
+	stmt Stmt
+}
+
+pub struct ConstDecl {
+pub:
+	is_public bool
+	fields    []FieldInit
+}
+
+pub struct DeferStmt {
+pub:
+	stmts []Stmt
+}
+
+// #flag / #include
+pub struct Directive {
+pub:
+	name  string
+	value string
+}
+
+pub struct EnumDecl {
+pub:
+	attributes []Attribute
+	is_public  bool
+	name       string
+	as_type    Expr = ast.empty_expr
+	fields     []FieldDecl
+}
+
+pub struct ExprStmt {
+pub:
+	expr Expr
+}
+
+pub struct FlowControlStmt {
+pub:
+	op    token.Token
+	label string
+}
+
+// enum FnArributes {
+// 	method
+// 	static
+// }
+
+pub struct FnDecl {
+pub:
+	attributes []Attribute
+	is_public  bool
+	is_method  bool
+	is_static  bool
+	receiver   Parameter
+	language   Language = .v
+	name       string
+	typ        FnType
+	stmts      []Stmt
+	pos        token.Pos
+}
+
+pub struct ForStmt {
+pub:
+	init  Stmt = ast.empty_stmt // initialization
+	cond  Expr = ast.empty_expr // condition
+	post  Stmt = ast.empty_stmt // post iteration (afterthought)
+	stmts []Stmt
+}
+
+// NOTE: used as the initializer for ForStmt
+pub struct ForInStmt {
+pub:
+	// key   		 string
+	// value 		 string
+	// value_is_mut bool
+	// expr	     Expr
+	// TODO:
+	key   Expr = ast.empty_expr
+	value Expr
+	expr  Expr
+}
+
+pub struct GlobalDecl {
+pub:
+	attributes []Attribute
+	fields     []FieldDecl
+}
+
+pub struct ImportStmt {
+pub:
+	name       string
+	alias      string
+	is_aliased bool
+	symbols    []Expr
+}
+
+pub struct InterfaceDecl {
+pub:
+	is_public      bool
+	attributes     []Attribute
+	name           string
+	generic_params []Expr
+	embedded       []Expr
+	fields         []FieldDecl
+}
+
+pub struct LabelStmt {
+pub:
+	name string
+	stmt Stmt = ast.empty_stmt
+}
+
+pub struct ModuleStmt {
+pub:
+	name string
+}
+
+pub struct ReturnStmt {
+pub:
+	exprs []Expr
+}
+
+pub struct StructDecl {
+pub:
+	attributes     []Attribute
+	is_public      bool
+	embedded       []Expr
+	language       Language = .v
+	name           string
+	generic_params []Expr
+	fields         []FieldDecl
+	pos            token.Pos
+}
+
+pub struct TypeDecl {
+pub:
+	is_public      bool
+	language       Language
+	name           string
+	generic_params []Expr
+	base_type      Expr = ast.empty_expr
+	variants       []Expr
+}
+
+// Type Nodes
+pub struct ArrayType {
+pub:
+	elem_type Expr
+}
+
+pub struct ArrayFixedType {
+pub:
+	len       Expr
+	elem_type Expr
+}
+
+pub struct ChannelType {
+pub:
+	cap       Expr
+	elem_type Expr
+}
+
+pub struct ThreadType {
+pub:
+	elem_type Expr = ast.empty_expr
+}
+
+pub struct FnType {
+pub:
+	generic_params []Expr
+	params         []Parameter
+	return_type    Expr = ast.empty_expr
+}
+
+pub fn (ft &FnType) str() string {
+	mut s := 'fn('
+	for param in ft.params {
+		s += param.name + param.typ.str()
+	}
+	s += ') ' + ft.return_type.str()
+	return s
+}
+
+pub fn (ident &Ident) str() string {
+	return ident.name.clone()
+}
+
+// pub fn (expr Expr) str() string {
+// 	return match expr {
+// 		Ident {
+// 			expr.name
+// 		}
+// 		SelectorExpr {
+// 			expr.lhs.str() + '.' + expr.rhs.name
+// 		}
+// 		else {
+// 			'missing Expr.str() for ${expr.type_name()}'
+// 			// expr.str()
+// 		}
+// 	}
+// }
+
+pub struct AnonStructType {
+pub:
+	generic_params []Expr
+	embedded       []Expr
+	fields         []FieldDecl
+}
+
+pub struct GenericType {
+pub:
+	name   Expr
+	params []Expr
+}
+
+pub struct MapType {
+pub:
+	key_type   Expr
+	value_type Expr
+}
+
+pub struct NilType {}
+
+pub struct NoneType {}
+
+pub struct OptionType {
+pub:
+	base_type Expr = ast.empty_expr
+}
+
+pub struct ResultType {
+pub:
+	base_type Expr = ast.empty_expr
+}
+
+pub struct TupleType {
+pub:
+	types []Expr
+}

--- a/vlib/v2/ast/desugar.v
+++ b/vlib/v2/ast/desugar.v
@@ -1,0 +1,86 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module ast
+
+import v2.token
+
+// NOTE: this is just a very naive example of how it could possibly work.
+// actual implementation may work during AST -> IR (or not). it may also
+// need type information which we don't have here. as I said, just an example.
+pub fn (match_expr &MatchExpr) desugar() Expr {
+	mut if_expr := IfExpr{}
+	for i, branch in match_expr.branches {
+		mut branch_cond := empty_expr
+		for cond in branch.cond {
+			op := if cond in [Ident, SelectorExpr] { token.Token.key_is } else { token.Token.eq }
+			c := InfixExpr{
+				lhs: match_expr.expr
+				op: op
+				rhs: cond
+			}
+			if branch_cond !is EmptyExpr {
+				branch_cond = InfixExpr{
+					lhs: branch_cond
+					op: .logical_or
+					rhs: c
+				}
+			} else {
+				branch_cond = c
+			}
+		}
+		if_expr2 := IfExpr{
+			cond: branch_cond
+			stmts: branch.stmts
+		}
+		if i == 0 {
+			if_expr = if_expr2
+		} else {
+			if_expr = IfExpr{
+				...if_expr
+				else_expr: if_expr2
+			}
+		}
+	}
+	return if_expr
+}
+
+pub fn (or_expr &OrExpr) desugar() Expr {
+	if or_expr.expr is IndexExpr {
+		return IfExpr{
+			// has index fn call
+			// cond: CallExpr{
+			// 	lhs: Ident{name: 'array_has_index'},
+			// 	args: [or_expr.expr.lhs, or_expr.expr.expr]
+			// }
+			// array.len
+			cond: InfixExpr{
+				lhs: SelectorExpr{
+					lhs: or_expr.expr.lhs
+					rhs: Ident{
+						name: 'len'
+					}
+				}
+				op: .gt
+				rhs: or_expr.expr.expr
+			}
+			stmts: [ExprStmt{
+				expr: or_expr.expr
+			}]
+			else_expr: IfExpr{
+				stmts: or_expr.stmts
+			}
+		}
+	} else {
+		return IfExpr{
+			cond: InfixExpr{
+				lhs: or_expr.expr
+				op: .eq
+				rhs: BasicLiteral{
+					kind: .key_true
+				}
+			}
+			stmts: or_expr.stmts
+		}
+	}
+}

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -1,0 +1,71 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module builder
+
+import v2.ast
+import v2.gen.v as gen_v
+import v2.pref
+import v2.token
+// import v2.types
+// import v2.util
+// import v2.ir.ssa
+import time
+
+struct Builder {
+	pref &pref.Preferences
+mut:
+	files    []ast.File
+	file_set &token.FileSet = token.FileSet.new()
+}
+
+pub fn new_builder(prefs &pref.Preferences) &Builder {
+	unsafe {
+		return &Builder{
+			pref: prefs
+		}
+	}
+}
+
+pub fn (mut b Builder) build(files []string) {
+	mut sw := time.new_stopwatch()
+	// TODO: build here, or pass into Parser and add there?
+	// mut file_set := &token.FileSet{}
+	b.files = if b.pref.no_parallel {
+		b.parse_files(files)
+	} else {
+		b.parse_files_parallel(files)
+	}
+	parse_time := sw.elapsed()
+	// b.type_check_files()
+	type_check_time := time.Duration(sw.elapsed() - parse_time)
+	if !b.pref.skip_genv {
+		b.gen_v_files()
+	}
+	gen_v_time := time.Duration(sw.elapsed() - parse_time - type_check_time)
+	total_time := sw.elapsed()
+	print_time('Scan & Parse', parse_time)
+	print_time('Type Check', type_check_time)
+	print_time('Gen (v)', gen_v_time)
+	print_time('Total', total_time)
+
+	// for file in b.files {
+	// 	mut ssa_builder := ssa.new_builder(b.pref)
+	// 	program := ssa_builder.build_file(file)
+	// 	println(program)
+	// }
+}
+
+fn (mut b Builder) gen_v_files() {
+	mut gen := gen_v.new_gen(b.pref)
+	for file in b.files {
+		gen.gen(file)
+		if b.pref.debug {
+			gen.print_output()
+		}
+	}
+}
+
+fn print_time(title string, time_d time.Duration) {
+	println(' * ${title}: ${time_d.milliseconds()}ms (${time_d.microseconds()}us)')
+}

--- a/vlib/v2/builder/parse.v
+++ b/vlib/v2/builder/parse.v
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module builder
+
+import v2.ast
+import v2.parser
+
+fn (mut b Builder) parse_files(files []string) []ast.File {
+	mut parser_reused := parser.Parser.new(b.pref)
+	mut ast_files := []ast.File{}
+	// parse builtin
+	if !b.pref.skip_builtin {
+		ast_files << parser_reused.parse_files(get_v_files_from_dir(b.pref.get_vlib_module_path('builtin')), mut
+			b.file_set)
+		// ast_files << parser_reused.parse_files(get_v_files_from_dir(b.pref.get_vlib_module_path('sync')), mut b.file_set)
+	}
+	// parse user files
+	ast_files << parser_reused.parse_files(files, mut b.file_set)
+	if b.pref.skip_imports {
+		return ast_files
+	}
+	// parse imports
+	mut parsed_imports := []string{}
+	for afi := 0; afi < ast_files.len; afi++ {
+		ast_file := ast_files[afi]
+		for mod in ast_file.imports {
+			if mod.name in parsed_imports {
+				continue
+			}
+			mod_path := b.pref.get_module_path(mod.name, ast_file.name)
+			ast_files << parser_reused.parse_files(get_v_files_from_dir(mod_path), mut
+				b.file_set)
+			parsed_imports << mod.name
+		}
+	}
+	return ast_files
+}

--- a/vlib/v2/builder/parse_parallel.v
+++ b/vlib/v2/builder/parse_parallel.v
@@ -1,0 +1,74 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module builder
+
+import v2.ast
+import v2.pref
+import v2.parser
+import v2.token
+import v2.util
+import runtime
+
+struct ParsingSharedState {
+mut:
+	file_set       &token.FileSet
+	parsed_modules shared []string
+}
+
+fn (mut pstate ParsingSharedState) mark_module_as_parsed(name string) {
+	lock pstate.parsed_modules {
+		pstate.parsed_modules << name
+	}
+}
+
+fn (mut pstate ParsingSharedState) already_parsed_module(name string) bool {
+	rlock pstate.parsed_modules {
+		if name in pstate.parsed_modules {
+			return true
+		}
+	}
+	return false
+}
+
+fn worker(mut wp util.WorkerPool[string, ast.File], mut pstate ParsingSharedState, prefs &pref.Preferences) {
+	// eprintln('>> ${@METHOD}')
+	mut p := parser.Parser.new(prefs)
+	for {
+		filename := wp.get_job() or { break }
+		ast_file := p.parse_file(filename, mut pstate.file_set)
+		if !prefs.skip_imports {
+			for mod in ast_file.imports {
+				if pstate.already_parsed_module(mod.name) {
+					continue
+				}
+				pstate.mark_module_as_parsed(mod.name)
+				mod_path := prefs.get_module_path(mod.name, ast_file.name)
+				wp.queue_jobs(get_v_files_from_dir(mod_path))
+			}
+		}
+		// eprintln('>> ${@METHOD} fully parsed file: $filename')
+		wp.push_result(ast_file)
+	}
+}
+
+fn (mut b Builder) parse_files_parallel(files []string) []ast.File {
+	mut pstate := &ParsingSharedState{
+		file_set: b.file_set
+	}
+
+	// mut worker_pool := util.WorkerPool.new[string, ast.File](mut ch_in, mut ch_out)
+	mut worker_pool := util.WorkerPool.new[string, ast.File]()
+	// spawn workers
+	for _ in 0 .. runtime.nr_jobs() {
+		worker_pool.add_worker(spawn worker(mut worker_pool, mut pstate, b.pref))
+	}
+	// parse builtin
+	if !b.pref.skip_builtin {
+		worker_pool.queue_jobs(get_v_files_from_dir(b.pref.get_vlib_module_path('builtin')))
+	}
+	// parse user files
+	worker_pool.queue_jobs(files)
+
+	return worker_pool.wait_for_results()
+}

--- a/vlib/v2/builder/type_check.v
+++ b/vlib/v2/builder/type_check.v
@@ -1,0 +1,26 @@
+module builder
+
+import v2.ast
+import v2.types
+// import v2.util
+// import runtime
+
+fn type_check_worker(ch_in chan []ast.File, ch_out chan string) {
+	for {
+		// ast_files := <- ch_in or { break }
+	}
+}
+
+fn (mut b Builder) type_check_files() {
+	// mod := types.new_module('main', '')
+	env := types.Environment.new()
+	mut checker := types.Checker.new(b.pref, b.file_set, env)
+	checker.check_files(b.files)
+
+	// mut ch_in := chan []ast.File{cap: 1000}
+	// mut ch_out := chan string{cap: 1000}
+	// mut worker_pool := util.WorkerPool.new[[]ast.File, string](mut ch_in, mut ch_out)	
+	// for _ in 0..runtime.nr_jobs() {
+	// 	worker_pool.workers << spawn type_check_worker(ch_in, ch_out)
+	// }
+}

--- a/vlib/v2/builder/util.v
+++ b/vlib/v2/builder/util.v
@@ -1,0 +1,18 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module builder
+
+import os
+
+fn get_v_files_from_dir(dir string) []string {
+	mod_files := os.ls(dir) or { panic('error getting ls from ${dir}') }
+	mut v_files := []string{}
+	for file in mod_files {
+		if !file.ends_with('.v') || file.ends_with('.js.v') || file.ends_with('_test.v') {
+			continue
+		}
+		v_files << os.join_path(dir, file)
+	}
+	return v_files
+}

--- a/vlib/v2/errors/details.v
+++ b/vlib/v2/errors/details.v
@@ -1,0 +1,44 @@
+module errors
+
+import os
+import v2.token
+
+// loads the source file and generates the error message including the source
+// line and column. offending token is highlighted in the snipped of source code.
+// since this is used on errors, loading the source file isnt an issue.
+// TODO: probably needs a better name
+pub fn details(file &token.File, pos token.Position, row_padding int) string {
+	src := os.read_file(file.name) or {
+		// TODO: error util
+		panic('error reading ${file.name}')
+	}
+	line_start := if pos.line - row_padding - 1 > 0 {
+		file.line_start(pos.line - row_padding)
+	} else {
+		0
+	}
+	mut line_end := pos.offset + 1
+	for i := 0; line_end < src.len; {
+		if src[line_end] == `\n` {
+			i++
+			if i == row_padding + 1 {
+				break
+			}
+		}
+		line_end++
+	}
+	lines_src := src[line_start..line_end].split('\n')
+	line_no_start, _ := file.find_line_and_column(line_start)
+	mut lines_src_formatted := []string{}
+	for i in 0 .. lines_src.len {
+		line_no := line_no_start + i
+		line_src := lines_src[i]
+		line_spaces := line_src.replace('\t', '    ')
+		lines_src_formatted << '${line_no:5d} | ' + line_spaces
+		if line_no == pos.line {
+			space_diff := line_spaces.len - line_src.len
+			lines_src_formatted << '        ' + ' '.repeat(space_diff + pos.column - 1) + '^'
+		}
+	}
+	return lines_src_formatted.join('\n')
+}

--- a/vlib/v2/errors/error.v
+++ b/vlib/v2/errors/error.v
@@ -1,0 +1,32 @@
+module errors
+
+import v2.token
+
+pub enum Reporter {
+	scanner
+	parser
+	checker
+	builder
+	gen
+}
+
+pub struct CompilerMessage {
+pub:
+	message   string
+	details   string
+	file_path string
+	pos       token.Pos
+	reporter  Reporter
+}
+
+pub struct Error {
+	CompilerMessage
+}
+
+pub struct Warning {
+	CompilerMessage
+}
+
+pub struct Notice {
+	CompilerMessage
+}

--- a/vlib/v2/errors/util.v
+++ b/vlib/v2/errors/util.v
@@ -1,0 +1,33 @@
+module errors
+
+import v2.token
+import term
+
+pub enum Kind {
+	warning
+	notice
+	error
+}
+
+pub fn (e Kind) str() string {
+	return match e {
+		.warning { 'warning' }
+		.notice { 'notice' }
+		.error { 'error' }
+	}
+}
+
+pub fn (e Kind) color(s string) string {
+	return match e {
+		.warning { term.yellow(s) }
+		.notice { term.blue(s) }
+		.error { term.red(s) }
+	}
+}
+
+pub fn error(msg string, details string, kind Kind, pos token.Position) {
+	eprintln(pos.str() + ' -> ' + term.bold(kind.color(kind.str())) + ': ' + msg)
+	if details.len > 0 {
+		eprintln(details)
+	}
+}

--- a/vlib/v2/gen/v/gen.v
+++ b/vlib/v2/gen/v/gen.v
@@ -1,0 +1,1013 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module v
+
+import v2.ast
+import v2.pref
+import strings
+import time
+
+const (
+	// tabs = build_tabs(16)
+	tabs = build_tabs(24)
+)
+
+struct Gen {
+	pref &pref.Preferences
+mut:
+	file       ast.File
+	out        strings.Builder
+	indent     int
+	on_newline bool
+	in_init    bool
+}
+
+fn build_tabs(tabs_len int) []string {
+	mut tabs_arr := []string{len: tabs_len, cap: tabs_len}
+	mut indent := ''
+	for i in 1 .. tabs_len {
+		indent += '\t'
+		tabs_arr[i] = indent
+	}
+	return tabs_arr
+}
+
+pub fn new_gen(prefs &pref.Preferences) &Gen {
+	unsafe {
+		return &Gen{
+			pref: prefs
+			out: strings.new_builder(1000)
+			indent: -1
+		}
+	}
+}
+
+pub fn (mut g Gen) reset() {
+	g.out.go_back_to(0)
+	g.indent = -1
+	g.on_newline = false
+}
+
+pub fn (mut g Gen) gen(file ast.File) {
+	// clear in case we are reusing gen instance
+	if g.out.len > 1 {
+		g.reset()
+	}
+	if !g.pref.verbose {
+		unsafe {
+			goto start_no_time
+		}
+	}
+	mut sw := time.new_stopwatch()
+	start_no_time:
+	g.file = file
+	g.stmt_list(g.file.stmts)
+	if g.pref.verbose {
+		gen_time := sw.elapsed()
+		println('gen (v) ${file.name}: ${gen_time.milliseconds()}ms (${gen_time.microseconds()}us)')
+	}
+}
+
+fn (mut g Gen) stmt_list(stmts []ast.Stmt) {
+	for stmt in stmts {
+		g.indent++
+		g.stmt(stmt)
+		g.indent--
+	}
+}
+
+fn (mut g Gen) stmt(stmt ast.Stmt) {
+	match stmt {
+		ast.AsmStmt {
+			g.writeln('asm ${stmt.arch} {')
+			g.writeln('}')
+		}
+		ast.AssertStmt {
+			g.write('assert ')
+			g.expr(stmt.expr)
+			if stmt.extra !is ast.EmptyExpr {
+				g.write(', ')
+				g.expr(stmt.extra)
+			}
+			g.writeln('')
+		}
+		ast.AssignStmt {
+			g.expr_list(stmt.lhs, ', ')
+			g.write(' ${stmt.op} ')
+			g.expr_list(stmt.rhs, ', ')
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		[]ast.Attribute {
+			g.attributes(stmt)
+		}
+		ast.BlockStmt {
+			g.writeln('{')
+			g.stmt_list(stmt.stmts)
+			g.writeln('}')
+		}
+		ast.ConstDecl {
+			if stmt.is_public {
+				g.write('pub ')
+			}
+			g.writeln('const (')
+			g.indent++
+			for field in stmt.fields {
+				g.write(field.name)
+				g.write(' = ')
+				g.expr(field.value)
+				g.writeln('')
+			}
+			g.indent--
+			g.writeln(')')
+		}
+		ast.ComptimeStmt {
+			g.write('$')
+			g.stmt(stmt.stmt)
+		}
+		ast.DeferStmt {
+			g.write('defer {')
+			g.stmt_list(stmt.stmts)
+			g.writeln('}')
+		}
+		ast.Directive {
+			g.write('#')
+			g.write(stmt.name)
+			g.write(' ')
+			g.writeln(stmt.value)
+		}
+		ast.EmptyStmt {}
+		ast.EnumDecl {
+			if stmt.attributes.len > 0 {
+				g.attributes(stmt.attributes)
+				g.writeln('')
+			}
+			if stmt.is_public {
+				g.write('pub ')
+			}
+			g.write('enum ')
+			g.write(stmt.name)
+			if stmt.as_type !is ast.EmptyExpr {
+				g.write(' as ')
+				g.expr(stmt.as_type)
+			}
+			g.writeln(' {')
+			g.indent++
+			for field in stmt.fields {
+				g.write('${field.name}')
+				g.expr(field.typ)
+				if field.value !is ast.EmptyExpr {
+					g.write(' = ')
+					g.expr(field.value)
+				}
+				if field.attributes.len > 0 {
+					g.write(' ')
+					g.attributes(field.attributes)
+				}
+				g.writeln('')
+			}
+			g.indent--
+			g.writeln('}')
+		}
+		ast.ExprStmt {
+			g.expr(stmt.expr)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		ast.FlowControlStmt {
+			if stmt.label.len > 0 {
+				g.write(stmt.op.str())
+				g.write(' ')
+				g.writeln(stmt.label)
+			} else {
+				g.writeln(stmt.op.str())
+			}
+		}
+		ast.FnDecl {
+			if stmt.attributes.len > 0 {
+				g.attributes(stmt.attributes)
+				g.writeln('')
+			}
+			if stmt.is_public {
+				g.write('pub ')
+			}
+			g.write('fn ')
+			if stmt.is_method {
+				if !stmt.is_static {
+					g.write('(')
+					g.write(stmt.receiver.name)
+					g.write(' ')
+					g.expr(stmt.receiver.typ)
+					g.write(') ')
+				} else {
+					g.expr(stmt.receiver.typ)
+					g.write('.')
+				}
+			}
+			if stmt.language != .v {
+				g.write(stmt.language.str())
+				g.write('.')
+			}
+			g.write(stmt.name)
+			g.fn_type(stmt.typ)
+			// C fn definition |
+			// v fns with compiler implementations eg. `pub fn (a array) filter(predicate fn (voidptr) bool) array`
+			// NOTE: can we use generics for these fns, also make sure we parser error for normal fns without a body
+			// TODO: is it the correct way to handle those cases (the fn definitions, not this code)?
+			// if stmt.language == .c && stmt.stmts.len == 0 {
+			if stmt.stmts.len == 0 {
+				g.writeln('')
+			}
+			// normal v function
+			else {
+				g.writeln(' {')
+				g.stmt_list(stmt.stmts)
+				g.writeln('}')
+			}
+		}
+		ast.ForStmt {
+			g.write('for ')
+			in_init := g.in_init
+			g.in_init = true
+			mut is_plain := true
+			mut has_init := stmt.init !is ast.EmptyStmt
+			if has_init && stmt.init is ast.ForInStmt {
+				is_plain = false
+				g.write('/* ForIn */')
+				g.stmt(stmt.init)
+			} else {
+				mut has_post := stmt.post !is ast.EmptyStmt
+				if has_init {
+					is_plain = false
+					g.stmt(stmt.init)
+					g.write('; ')
+				}
+				if stmt.cond !is ast.EmptyExpr {
+					is_plain = false
+					g.write('/* cond: ${stmt.cond.type_name()} */')
+					g.expr(stmt.cond)
+				}
+				if has_init || has_post {
+					g.write('; ')
+				}
+				if has_post {
+					is_plain = false
+					g.stmt(stmt.post)
+				}
+			}
+			g.in_init = in_init
+			g.writeln(if is_plain { '{' } else { ' {' })
+			g.stmt_list(stmt.stmts)
+			g.writeln('}')
+		}
+		ast.ForInStmt {
+			// if stmt.key.len > 0 {
+			// 	g.write(stmt.key)
+			// 	g.write(', ')
+			// }
+			// if stmt.value_is_mut {
+			// 	g.write('mut ')
+			// }
+			// g.write(stmt.value)
+			if stmt.key !is ast.EmptyExpr {
+				g.expr(stmt.key)
+				g.write(', ')
+			}
+			g.expr(stmt.value)
+			g.write(' in ')
+			g.expr(stmt.expr)
+		}
+		ast.GlobalDecl {
+			g.writeln('__global (')
+			g.indent++
+			for field in stmt.fields {
+				// TODO
+				g.write(field.name)
+				// if field.value != none {
+				if field.value !is ast.EmptyExpr {
+					g.write(' = ')
+					g.expr(field.value)
+				} else {
+					g.write(' ')
+					g.expr(field.typ)
+				}
+				g.writeln('')
+			}
+			g.indent--
+			g.writeln(')')
+		}
+		ast.InterfaceDecl {
+			if stmt.is_public {
+				g.write('pub ')
+			}
+			g.write('interface ')
+			g.write(stmt.name)
+			if stmt.generic_params.len > 0 {
+				g.generic_list(stmt.generic_params)
+			}
+			g.writeln(' {')
+			g.indent++
+			for embed in stmt.embedded {
+				g.expr(embed)
+				g.writeln('')
+			}
+			for field in stmt.fields {
+				g.write(field.name)
+				g.write(' ')
+				g.expr(field.typ)
+				// if field.typ is ast.Type {
+				// 	if field.typ is ast.FnType {
+				// 		g.fn_type(field.typ)
+				// 	} else {
+				// 		g.write(' ')
+				// 		g.expr(field.typ)
+				// 	}
+				// }
+				// // TODO/FIXME: because p.typ() is returning ident & selector currently
+				// else {
+				// 	g.write(' ')
+				// 	g.expr(field.typ)
+				// }
+				g.writeln('')
+			}
+			g.indent--
+			g.writeln('}')
+		}
+		ast.ImportStmt {
+			g.write('import ')
+			g.write(stmt.name)
+			if stmt.is_aliased {
+				g.write(' as ')
+				g.write(stmt.alias)
+			}
+			if stmt.symbols.len > 0 {
+				g.write(' { ')
+				g.expr_list(stmt.symbols, ', ')
+				g.write(' }')
+			}
+			g.writeln('')
+		}
+		ast.LabelStmt {
+			g.write(stmt.name)
+			g.writeln(':')
+			if stmt.stmt != ast.empty_stmt {
+				g.stmt(stmt.stmt)
+			}
+		}
+		ast.ModuleStmt {
+			g.write('module ')
+			g.writeln(stmt.name)
+		}
+		ast.ReturnStmt {
+			g.write('return ')
+			g.expr_list(stmt.exprs, ', ')
+			g.writeln('')
+		}
+		ast.StructDecl {
+			g.struct_decl(stmt)
+		}
+		ast.TypeDecl {
+			g.write('type ')
+			if stmt.language != .v {
+				g.write(stmt.language.str())
+				g.write('.')
+			}
+			g.write(stmt.name)
+			if stmt.generic_params.len > 0 {
+				g.generic_list(stmt.generic_params)
+			}
+			if stmt.variants.len > 0 {
+				g.write(' = ')
+				g.expr_list(stmt.variants, ' | ')
+			} else {
+				g.write(' ')
+				g.expr(stmt.base_type)
+			}
+			g.writeln('')
+		}
+	}
+	// g.writeln('')
+}
+
+fn (mut g Gen) expr(expr ast.Expr) {
+	match expr {
+		ast.ArrayInitExpr {
+			if expr.exprs.len > 0 {
+				g.write('[')
+				g.expr_list(expr.exprs, ', ')
+				g.write(']')
+				// TODO: better way to handle this
+				if expr.len !is ast.EmptyExpr {
+					g.write('!')
+				}
+			} else {
+				has_init := expr.init !is ast.EmptyExpr
+				has_len := expr.len !is ast.EmptyExpr
+				has_cap := expr.cap !is ast.EmptyExpr
+				g.expr(expr.typ)
+				g.write('{')
+				// if expr.init != none {
+				if has_init {
+					g.write('init: ')
+					g.expr(expr.init)
+					if has_len || has_cap {
+						g.write(', ')
+					}
+				}
+				// if expr.len != none {
+				if has_len {
+					g.write('len: ')
+					g.expr(expr.len)
+					if has_cap {
+						g.write(', ')
+					}
+				}
+				// if expr.cap != none {
+				if has_cap {
+					g.write('cap: ')
+					g.expr(expr.cap)
+				}
+				g.write('}')
+			}
+		}
+		ast.AsCastExpr {
+			g.expr(expr.expr)
+			g.write(' as ')
+			g.expr(expr.typ)
+		}
+		ast.AssocExpr {
+			g.expr(expr.typ)
+			g.writeln('{')
+			g.indent++
+			g.write('...')
+			g.expr(expr.expr)
+			g.writeln('')
+			for field in expr.fields {
+				g.write(field.name)
+				g.write(': ')
+				g.expr(field.value)
+				g.writeln('')
+			}
+			g.indent--
+			g.write('}')
+		}
+		ast.BasicLiteral {
+			if expr.kind == .char {
+				g.write('`')
+				g.write(expr.value)
+				g.write('`')
+			} else {
+				g.write(expr.value)
+			}
+		}
+		ast.CallExpr {
+			g.expr(expr.lhs)
+			g.write('(')
+			g.expr_list(expr.args, ', ')
+			g.write(')')
+		}
+		ast.CallOrCastExpr {
+			g.expr(expr.lhs)
+			g.write('(')
+			g.expr(expr.expr)
+			g.write(')')
+		}
+		ast.CastExpr {
+			g.expr(expr.typ)
+			g.write('(')
+			g.expr(expr.expr)
+			g.write(')')
+		}
+		ast.ComptimeExpr {
+			g.write('$')
+			g.expr(expr.expr)
+		}
+		ast.EmptyExpr {}
+		// TODO: should this be handled like this
+		ast.FieldInit {
+			g.write(expr.name)
+			g.write(': ')
+			g.expr(expr.value)
+		}
+		ast.FnLiteral {
+			g.write('fn')
+			if expr.captured_vars.len > 0 {
+				g.write(' [')
+				g.expr_list(expr.captured_vars, ', ')
+				g.write('] ')
+			}
+			g.fn_type(expr.typ)
+			g.writeln(' {')
+			g.stmt_list(expr.stmts)
+			g.write('}')
+		}
+		ast.GenericArgs {
+			// g.write('/* ast.GenericArgs */')
+			g.expr(expr.lhs)
+			g.generic_list(expr.args)
+		}
+		ast.GenericArgOrIndexExpr {
+			// g.write('/* ast.GenericArgOrIndexExpr */')
+			g.expr(expr.lhs)
+			g.generic_list([expr.expr])
+		}
+		ast.Ident {
+			g.write(expr.name)
+		}
+		ast.IfExpr {
+			g.if_expr(expr)
+		}
+		ast.IfGuardExpr {
+			g.stmt(expr.stmt)
+		}
+		ast.IndexExpr {
+			g.expr(expr.lhs)
+			g.write('[')
+			g.expr(expr.expr)
+			g.write(']')
+		}
+		ast.InfixExpr {
+			g.expr(expr.lhs)
+			g.write(' ')
+			g.write(expr.op.str())
+			g.write(' ')
+			g.expr(expr.rhs)
+		}
+		ast.InitExpr {
+			g.expr(expr.typ)
+			// with field names
+			if expr.fields.len > 0 && expr.fields[0].name.len > 0 {
+				g.writeln('{')
+				in_init := g.in_init
+				g.in_init = true
+				g.indent++
+				for i, field in expr.fields {
+					g.write(field.name)
+					g.write(': ')
+					g.expr(field.value)
+					if i < expr.fields.len - 1 {
+						g.writeln(',')
+					} else {
+						g.writeln('')
+					}
+				}
+				g.indent--
+				g.in_init = in_init
+			}
+			// without field names, or empty init `Struct{}`
+			else {
+				g.write('{')
+				for i, field in expr.fields {
+					g.expr(field.value)
+					if i < expr.fields.len - 1 {
+						g.write(', ')
+					}
+				}
+			}
+			g.write('}')
+		}
+		ast.Keyword {
+			g.write(expr.tok.str())
+		}
+		ast.KeywordOperator {
+			g.write(expr.op.str())
+			if expr.op in [.key_go, .key_spawn] {
+				g.expr(expr.exprs[0])
+			} else {
+				g.write('(')
+				g.expr_list(expr.exprs, ', ')
+				g.write(')')
+			}
+		}
+		ast.LambdaExpr {
+			g.write('|')
+			for i, arg in expr.args {
+				g.write(arg.name)
+				if i < expr.args.len - 1 {
+					g.write(', ')
+				}
+			}
+			g.write('| ')
+			g.expr(expr.expr)
+		}
+		ast.LockExpr {
+			has_lock_exprs := expr.lock_exprs.len > 0
+			has_rlock_exprs := expr.rlock_exprs.len > 0
+			if !has_lock_exprs && !has_rlock_exprs {
+				g.write('lock')
+			} else {
+				if has_lock_exprs {
+					g.write('lock ')
+					g.expr_list(expr.lock_exprs, ', ')
+					if has_rlock_exprs {
+						g.write('; ')
+					}
+				}
+				if has_rlock_exprs {
+					g.write('rlock ')
+					g.expr_list(expr.rlock_exprs, ', ')
+				}
+			}
+			g.writeln(' {')
+			g.stmt_list(expr.stmts)
+			g.writeln('}')
+		}
+		ast.MapInitExpr {
+			// long syntax
+			if expr.typ !is ast.EmptyExpr {
+				g.expr(expr.typ)
+				g.write('{}')
+			}
+			// shorthand syntax
+			else if expr.keys.len > 0 {
+				g.write('{')
+				for i, key in expr.keys {
+					val := expr.vals[i]
+					g.expr(key)
+					g.write(': ')
+					g.expr(val)
+					if i < expr.keys.len - 1 {
+						g.write(', ')
+					}
+				}
+				g.write('}')
+			}
+			// empty {}
+			else {
+				g.write('{}')
+			}
+		}
+		ast.MatchExpr {
+			g.write('match ')
+			g.expr(expr.expr)
+			g.writeln(' {')
+			g.indent++
+			for branch in expr.branches {
+				if branch.cond.len > 0 {
+					g.expr_list(branch.cond, ', ')
+				} else {
+					g.write('else')
+				}
+				g.writeln(' {')
+				g.stmt_list(branch.stmts)
+				g.writeln('}')
+			}
+			g.indent--
+			g.write('}')
+			// g.writeln(' ==== DeSugared MatchExpr  ==== ')
+			// g.expr(expr.desugar())
+		}
+		ast.ModifierExpr {
+			g.write(expr.kind.str())
+			g.write(' ')
+			g.expr(expr.expr)
+		}
+		ast.OrExpr {
+			g.expr(expr.expr)
+			g.writeln(' or {')
+			g.stmt_list(expr.stmts)
+			g.writeln('}')
+			// g.writeln('==== DeSugared OrExpr ====')
+			// g.expr(expr.desugar())
+		}
+		ast.ParenExpr {
+			g.write('(')
+			g.expr(expr.expr)
+			g.write(')')
+		}
+		ast.PostfixExpr {
+			g.expr(expr.expr)
+			g.write(expr.op.str())
+		}
+		ast.PrefixExpr {
+			g.write(expr.op.str())
+			g.expr(expr.expr)
+		}
+		ast.RangeExpr {
+			g.write('RangeExpr[ ')
+			g.expr(expr.start)
+			// g.write(' ')
+			g.write(expr.op.str())
+			// g.write(' ')
+			g.expr(expr.end)
+			g.write(' ]')
+		}
+		ast.SelectExpr {
+			g.writeln('select {')
+			g.indent++
+			g.select_expr(expr)
+			g.indent--
+			g.write('}')
+		}
+		ast.SelectorExpr {
+			g.expr(expr.lhs)
+			g.write('.')
+			g.expr(expr.rhs)
+		}
+		ast.StringInterLiteral {
+			if expr.kind != .v {
+				g.write(expr.kind.str())
+			}
+			// TODO: smart quote
+			// quote_str := "'"
+			// g.write(quote_str)
+			for i, value in expr.values {
+				g.write(value)
+				if inter := expr.inters[i] {
+					g.write('\${')
+					g.expr(inter.expr)
+					if inter.format != .unformatted {
+						g.write(':')
+						g.expr(inter.format_expr)
+						g.write(inter.format.str())
+					}
+					g.write('}')
+				}
+			}
+			// g.write(quote_str)
+		}
+		ast.StringLiteral {
+			if expr.kind != .v {
+				g.write(expr.kind.str())
+			}
+			// TODO: smart quote
+			// quote_str := "'"
+			// g.write(quote_str)
+			g.write(expr.value)
+			// g.write(quote_str)
+		}
+		ast.SqlExpr {
+			g.write('sql ')
+			g.expr(expr.expr)
+			g.writeln(' {')
+			g.write('}')
+		}
+		ast.Tuple {
+			g.expr_list(expr.exprs, ', ')
+		}
+		ast.UnsafeExpr {
+			one_liner := g.in_init || expr.stmts.len == 1
+			if one_liner {
+				g.write('unsafe { ')
+			} else {
+				g.writeln('unsafe {')
+			}
+			in_init := g.in_init
+			g.in_init = one_liner
+			g.stmt_list(expr.stmts)
+			g.in_init = in_init
+			if one_liner {
+				g.write(' }')
+			} else {
+				g.write('}')
+			}
+		}
+		// Type Nodes
+		// TODO: I really would like to allow matching the nested sumtypes like TS
+		ast.Type {
+			match expr {
+				ast.AnonStructType {
+					g.write('struct')
+					if expr.generic_params.len > 0 {
+						g.generic_list(expr.generic_params)
+					}
+					g.struct_decl_fields(expr.embedded, expr.fields)
+				}
+				ast.ArrayType {
+					g.write('[]')
+					g.expr(expr.elem_type)
+				}
+				ast.ArrayFixedType {
+					g.write('[')
+					if expr.len !is ast.EmptyExpr {
+						g.expr(expr.len)
+					}
+					g.write(']')
+					g.expr(expr.elem_type)
+				}
+				ast.ChannelType {
+					g.write('chan ')
+					g.expr(expr.elem_type)
+				}
+				ast.FnType {
+					g.write('fn')
+					g.fn_type(expr)
+				}
+				ast.GenericType {
+					g.expr(expr.name)
+					g.generic_list(expr.params)
+				}
+				ast.MapType {
+					g.write('map[')
+					g.expr(expr.key_type)
+					g.write(']')
+					g.expr(expr.value_type)
+				}
+				ast.NilType {
+					g.write('nil')
+				}
+				ast.NoneType {
+					g.write('none')
+				}
+				ast.OptionType {
+					g.write('?')
+					if expr.base_type !is ast.EmptyExpr {
+						g.expr(expr.base_type)
+					}
+				}
+				ast.ResultType {
+					g.write('!')
+					if expr.base_type !is ast.EmptyExpr {
+						g.expr(expr.base_type)
+					}
+				}
+				ast.ThreadType {
+					g.write('thread')
+					if expr.elem_type !is ast.EmptyExpr {
+						g.write(' ')
+						g.expr(expr.elem_type)
+					}
+				}
+				ast.TupleType {
+					g.write('(')
+					g.expr_list(expr.types, ', ')
+					g.write(')')
+				}
+				// TODO: v bug since all variants are accounted for
+				// this should not be required?
+				// ast.Type {}
+			}
+		}
+	}
+}
+
+// NOTE: I purposefully left out `$` from every branch of comptime if
+// Hopefully this will be removed from the syntax. if not ill add it.
+fn (mut g Gen) if_expr(expr ast.IfExpr) {
+	if expr.cond !is ast.EmptyExpr {
+		g.write('if ')
+		in_init := g.in_init
+		g.in_init = true
+		g.expr(expr.cond)
+		g.in_init = in_init
+		g.write(' ')
+	}
+	g.writeln('{')
+	g.stmt_list(expr.stmts)
+	g.write('}')
+	if expr.else_expr is ast.IfExpr {
+		g.write(' else ')
+		g.if_expr(expr.else_expr)
+	}
+}
+
+fn (mut g Gen) select_expr(expr ast.SelectExpr) {
+	// TODO: fix missing writeln after block due to `p.in_init`
+	in_init := g.in_init
+	g.in_init = true
+	g.stmt(expr.stmt)
+	g.in_init = in_init
+	if expr.stmts.len > 0 {
+		g.writeln(' {')
+		g.stmt_list(expr.stmts)
+		g.write('}')
+	}
+	g.writeln('')
+	if expr.next is ast.SelectExpr {
+		g.select_expr(expr.next)
+	}
+}
+
+fn (mut g Gen) attributes(attributes []ast.Attribute) {
+	g.write('@[')
+	for i, attribute in attributes {
+		if attribute.comptime_cond !is ast.EmptyExpr {
+			g.write('if ')
+			g.expr(attribute.comptime_cond)
+		} else {
+			if attribute.name.len > 0 {
+				g.write(attribute.name)
+				g.write(': ')
+			}
+			g.expr(attribute.value)
+			if i < attributes.len - 1 {
+				g.write('; ')
+			}
+		}
+	}
+	g.write(']')
+}
+
+fn (mut g Gen) fn_type(typ ast.FnType) {
+	if typ.generic_params.len > 0 {
+		g.generic_list(typ.generic_params)
+	}
+	g.write('(')
+	for i, param in typ.params {
+		if param.name.len > 0 {
+			g.write(param.name)
+			g.write(' ')
+		}
+		g.expr(param.typ)
+		if i < typ.params.len - 1 {
+			g.write(', ')
+		}
+	}
+	g.write(')')
+	if typ.return_type !is ast.EmptyExpr {
+		g.write(' ')
+		g.expr(typ.return_type)
+	}
+}
+
+fn (mut g Gen) struct_decl(stmt ast.StructDecl) {
+	if stmt.attributes.len > 0 {
+		g.attributes(stmt.attributes)
+		g.writeln('')
+	}
+	if stmt.is_public {
+		g.write('pub ')
+	}
+	g.write('struct ')
+	if stmt.language != .v {
+		g.write(stmt.language.str())
+		g.write('.')
+	}
+	g.write(stmt.name)
+	if stmt.generic_params.len > 0 {
+		g.generic_list(stmt.generic_params)
+	}
+	g.struct_decl_fields(stmt.embedded, stmt.fields)
+}
+
+fn (mut g Gen) struct_decl_fields(embedded []ast.Expr, fields []ast.FieldDecl) {
+	if fields.len > 0 {
+		g.writeln(' {')
+	} else {
+		g.write(' {')
+	}
+	g.indent++
+	for embed in embedded {
+		g.expr(embed)
+		g.writeln('')
+	}
+	for field in fields {
+		g.write(field.name)
+		g.write(' ')
+		g.expr(field.typ)
+		// if field.value != none {
+		if field.value !is ast.EmptyExpr {
+			g.write(' = ')
+			g.expr(field.value)
+		}
+		if field.attributes.len > 0 {
+			g.write(' ')
+			g.attributes(field.attributes)
+		}
+		g.writeln('')
+	}
+	g.indent--
+	g.writeln('}')
+}
+
+@[inline]
+fn (mut g Gen) expr_list(exprs []ast.Expr, separator string) {
+	for i, expr in exprs {
+		g.expr(expr)
+		if i < exprs.len - 1 {
+			g.write(separator)
+		}
+	}
+}
+
+@[inline]
+fn (mut g Gen) generic_list(exprs []ast.Expr) {
+	g.write('[')
+	g.expr_list(exprs, ', ')
+	g.write(']')
+}
+
+@[inline]
+fn (mut g Gen) write(str string) {
+	if g.on_newline {
+		g.out.write_string(v.tabs[g.indent])
+	}
+	g.out.write_string(str)
+	g.on_newline = false
+}
+
+@[inline]
+fn (mut g Gen) writeln(str string) {
+	if g.on_newline {
+		g.out.write_string(v.tabs[g.indent])
+	}
+	g.out.writeln(str)
+	g.on_newline = true
+}
+
+pub fn (g &Gen) print_output() {
+	println(g.out)
+}

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -1,0 +1,2456 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module parser
+
+import os
+import time
+import v2.ast
+import v2.errors
+import v2.pref
+import v2.scanner
+import v2.token
+
+pub struct Parser {
+	pref &pref.Preferences
+mut:
+	file    &token.File = &token.File{}
+	scanner &scanner.Scanner
+	// track state
+	exp_lcbr bool // expecting `{` parsing `x` in `for|if|match x {` etc
+	exp_pt   bool // expecting (p)ossible (t)ype from `p.expr()`
+	// token info : start
+	line      int
+	lit       string
+	pos       token.Pos
+	tok       token.Token = .unknown
+	tok_next_ token.Token = .unknown // DO NOT access directly, use `p.peek()`
+	// token info : end
+}
+
+pub fn Parser.new(prefs &pref.Preferences) &Parser {
+	return &Parser{
+		pref: unsafe { prefs }
+		scanner: scanner.new_scanner(prefs, .normal)
+		// scanner: scanner.new_scanner(prefs, .skip_interpolation)
+	}
+}
+
+fn (mut p Parser) init(filename string, src string, mut file_set token.FileSet) {
+	// reset since parser instance may be reused
+	p.line = 0
+	p.lit = ''
+	p.pos = 0
+	p.tok = .unknown
+	p.tok_next_ = .unknown
+	// init
+	// TODO: consider another way to pass in file set?
+	p.file = file_set.add_file(filename, -1, src.len)
+	p.scanner.init(p.file, src)
+}
+
+pub fn (mut p Parser) parse_files(files []string, mut file_set token.FileSet) []ast.File {
+	mut ast_files := []ast.File{}
+	for file in files {
+		ast_files << p.parse_file(file, mut file_set)
+	}
+	return ast_files
+}
+
+pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) ast.File {
+	if !p.pref.verbose {
+		unsafe {
+			goto start_no_time
+		}
+	}
+	mut sw := time.new_stopwatch()
+	start_no_time:
+	src := os.read_file(filename) or { p.error('error reading ${filename}') }
+	p.init(filename, src, mut file_set)
+	// start
+	p.next()
+	mut top_stmts := []ast.Stmt{}
+	// mut decls := []ast.Decl{}
+	mut imports := []ast.ImportStmt{}
+	mut mod := 'main'
+	// file level attributes
+	// or we are missing a stmt which supports attributes in this match
+	mut attributes := []ast.Attribute{}
+	if p.tok in [.attribute, .lsbr] {
+		attribute_stmt := p.attribute_stmt()
+		top_stmts << attribute_stmt
+		if attribute_stmt is []ast.Attribute {
+			attributes = attribute_stmt.clone()
+			for attribute in attributes {
+				if attribute.value is ast.Ident {
+					if attribute.value.name !in ['has_globals', 'generated', 'manualfree',
+						'translated'] {
+						p.warn('invalid file level attribute `${attribute.name}` (or should `${p.tok}` support attributes)')
+					}
+				}
+			}
+		}
+	}
+	// TODO: script mode support?
+	// I really hope it gets dropped.
+	if p.tok == .key_module {
+		p.next()
+		module_stmt := ast.ModuleStmt{
+			name: p.expect_name()
+		}
+		p.expect(.semicolon)
+		top_stmts << module_stmt
+		mod = module_stmt.name
+	} else {
+		// TODO: set is_test somewhre, probably work it out in builder
+		// and pass it to parser, or in prefs. (check current v)
+		// if !p.file.name.contains('_test.') {
+		// 	p.error('expectng module')
+		// }
+		// NOTE: allowing no moule for now
+		// need to verify rules
+	}
+	for p.tok == .key_import {
+		import_stmt := p.import_stmt()
+		p.expect(.semicolon)
+		imports << import_stmt
+		top_stmts << import_stmt
+	}
+	for p.tok != .eof {
+		top_stmt := p.top_stmt()
+		// if top_stmt is ast.Decl {
+		// 	decls << top_stmt
+		// }
+		top_stmts << top_stmt
+	}
+	if p.pref.verbose {
+		parse_time := sw.elapsed()
+		println('scan & parse ${filename} (${p.file.line_count()} LOC): ${parse_time.milliseconds()}ms (${parse_time.microseconds()}us)')
+	}
+	return ast.File{
+		attributes: attributes
+		mod: mod
+		name: filename
+		imports: imports
+		// decls: decls
+		stmts: top_stmts
+	}
+}
+
+fn (mut p Parser) top_stmt() ast.Stmt {
+	match p.tok {
+		.dollar {
+			return p.comptime_stmt()
+		}
+		.hash {
+			return p.directive()
+		}
+		.key_asm {
+			return p.asm_stmt()
+		}
+		.key_const {
+			return p.const_decl(false)
+		}
+		.key_enum {
+			return p.enum_decl(false, [])
+		}
+		.key_fn {
+			return p.fn_decl(false, [])
+		}
+		.key_global {
+			return p.global_decl([])
+		}
+		// NOTE: handling moved to parse_file
+		// .key_import {
+		// 	return p.import_stmt()
+		// }
+		.key_interface {
+			return p.interface_decl(false, [])
+		}
+		// NOTE: handling moved to parse_file
+		// .key_module {
+		// 	p.next()
+		// 	name := p.expect_name()
+		// 	p.expect(.semicolon)
+		// 	return ast.ModuleStmt{
+		// 		name: name
+		// 	}
+		// }
+		.key_pub {
+			p.next()
+			match p.tok {
+				.key_const { return p.const_decl(true) }
+				.key_enum { return p.enum_decl(true, []) }
+				.key_fn { return p.fn_decl(true, []) }
+				.key_interface { return p.interface_decl(true, []) }
+				.key_struct, .key_union { return p.struct_decl(true, []) }
+				.key_type { return p.type_decl(true) }
+				else { p.error('not implemented: pub ${p.tok}') }
+			}
+		}
+		.key_struct, .key_union {
+			return p.struct_decl(false, [])
+		}
+		.key_type {
+			return p.type_decl(false)
+		}
+		.attribute, .lsbr {
+			return p.attribute_stmt()
+		}
+		else {
+			p.error('unknown top stmt: ${p.tok} - ${p.file.name}:${p.line}')
+		}
+	}
+}
+
+fn (mut p Parser) stmt() ast.Stmt {
+	// p.log('STMT: $p.tok - $p.file.name:$p.line')
+	match p.tok {
+		.dollar {
+			return p.comptime_stmt()
+		}
+		.hash {
+			return p.directive()
+		}
+		.key_asm {
+			return p.asm_stmt()
+		}
+		.key_assert {
+			p.next()
+			expr := p.expr(.lowest)
+			stmt := ast.AssertStmt{
+				expr: expr
+				extra: if p.tok == .comma {
+					p.next()
+					p.expr(.lowest)
+				} else {
+					ast.empty_expr
+				}
+			}
+			p.expect_semi()
+			return stmt
+		}
+		.key_break, .key_continue, .key_goto {
+			op := p.tok()
+			if p.tok == .name {
+				label := p.lit()
+				p.expect_semi()
+				return ast.FlowControlStmt{
+					op: op
+					label: label
+				}
+			} else {
+				p.expect_semi()
+				return ast.FlowControlStmt{
+					op: op
+				}
+			}
+		}
+		.key_defer {
+			p.next()
+			stmts := p.block()
+			p.expect(.semicolon)
+			return ast.DeferStmt{
+				stmts: stmts
+			}
+		}
+		.key_for {
+			return p.for_stmt()
+		}
+		.key_return {
+			// p.log('ast.ReturnStmt')
+			p.next()
+			// TODO: clean up semi stuff (use expr list)
+			if p.tok == .semicolon {
+				p.next()
+				return ast.ReturnStmt{}
+			}
+			rs := ast.ReturnStmt{
+				exprs: p.expr_list()
+			}
+			p.expect_semi()
+			if p.tok != .rcbr {
+				p.error_expected(.rcbr, p.tok)
+			}
+			return rs
+		}
+		.lcbr {
+			// anonymous / scoped block `{ a := 1 }`
+			stmts := p.block()
+			p.expect_semi()
+			return ast.BlockStmt{
+				stmts: stmts
+			}
+		}
+		else {
+			expr := p.expr(.lowest)
+			// label `start:`
+			if p.tok == .colon {
+				name := match expr {
+					ast.Ident { expr.name }
+					else { p.error('expecting identifier') }
+				}
+				p.next()
+				return ast.LabelStmt{
+					name: name
+					stmt: if p.tok == .key_for { p.for_stmt() } else { ast.empty_stmt }
+				}
+			}
+			return p.complete_simple_stmt(expr, false)
+		}
+	}
+	p.error('unknown stmt: ${p.tok}')
+}
+
+fn (mut p Parser) attribute_stmt() ast.Stmt {
+	// NOTE: could also return AttributeStmt{attributes: attributes, stmt: stmt}
+	attributes := p.attributes()
+	mut is_pub := false
+	if p.tok == .key_pub {
+		p.next()
+		is_pub = true
+	}
+	match p.tok {
+		.key_enum {
+			return p.enum_decl(is_pub, attributes)
+		}
+		.key_fn {
+			return p.fn_decl(is_pub, attributes)
+		}
+		.key_global {
+			return p.global_decl(attributes)
+		}
+		.key_interface {
+			return p.interface_decl(is_pub, attributes)
+		}
+		.key_struct, .key_union {
+			return p.struct_decl(is_pub, attributes)
+		}
+		else {
+			return attributes
+		}
+	}
+}
+
+@[inline]
+fn (mut p Parser) simple_stmt() ast.Stmt {
+	return p.complete_simple_stmt(p.expr(.lowest), false)
+}
+
+fn (mut p Parser) complete_simple_stmt(expr ast.Expr, expecting_semi bool) ast.Stmt {
+	// stand alone expression in a statement list
+	// eg: `if x == 1 {`, `x++`, `mut x := 1`, `a,`b := 1,2`
+	// multi assign from match/if `a, b := if x == 1 { 1,2 } else { 3,4 }
+	if p.tok == .comma {
+		p.next()
+		// a little extra code, but also a little more efficient
+		mut exprs := [expr]
+		exprs << p.expr(.lowest)
+		for p.tok == .comma {
+			p.next()
+			exprs << p.expr(.lowest)
+		}
+		// TODO: can we get rid of this dupe code?
+		if p.tok.is_assignment() {
+			assign_stmt := p.assign_stmt(exprs)
+			// TODO: best way? decide if we will force them
+			// NOTE: allow multiple exprs on single line without `;` should be removed
+			if p.tok == .semicolon && !expecting_semi {
+				p.next()
+			}
+			return assign_stmt
+		}
+		// multi return values (last statement, no return keyword)
+		return ast.ExprStmt{ast.Tuple{
+			exprs: exprs
+		}}
+	} else if p.tok.is_assignment() {
+		assign_stmt := p.assign_stmt([expr])
+		// TODO: best way? decide if we will force them
+		// NOTE: allow multiple exprs on single line without `;` should be removed
+		if p.tok == .semicolon && !expecting_semi {
+			p.next()
+		}
+		return assign_stmt
+	}
+	// TODO: best way? decide if we will force them
+	// NOTE: allow multiple exprs on single line without `;` should be removed
+	if p.tok == .semicolon && !expecting_semi {
+		p.next()
+	}
+	// TODO: add check for all ExprStmt eg.
+	// if expr is ast.ArrayInitExpr {
+	// 	p.error('UNUSED')
+	// }
+	return ast.ExprStmt{
+		expr: expr
+	}
+}
+
+fn (mut p Parser) expr(min_bp token.BindingPower) ast.Expr {
+	// p.log('EXPR: $p.tok - $p.line')
+	mut lhs := ast.empty_expr
+	match p.tok {
+		.char, .key_false, .key_true, .number {
+			lhs = ast.BasicLiteral{
+				kind: p.tok
+				value: p.lit()
+			}
+		}
+		.string {
+			lhs = p.string_literal(.v)
+		}
+		.key_fn {
+			p.next()
+			// TODO: closure variable capture syntax is the same as generic param syntax. IMO This should change.
+			// If we have both a capture list and generic params, we can always assume that the capture list comes
+			// first. However if we only have one or the other we will need to work out what we have. the only way
+			// to currently do this is to check for an ident where the name's first char is a capital, this is not
+			// great at all, and would be the only place in the parser where a capital letter is relied upon, or even
+			// the name at all is relied upon. imo this is context the parser should not need, and we should either
+			// change the varibale capture syntax, or move the position of the capture list, for example:
+			// change syntax: `fn <var_a, var_b> [T] () { ... }`, move position: `fn [T] () { ... } [var_a, var_b]`
+			// personally I think `fn <var_a, var_b> [T] () { ... }` is a great option.
+			mut captured_vars := []ast.Expr{}
+			mut generic_params := []ast.Expr{}
+			if p.tok == .lsbr {
+				p.next()
+				captured_vars = p.expr_list()
+				p.expect(.rsbr)
+			}
+			// we have generic params after capture list
+			if p.tok == .lsbr {
+				generic_params = p.generic_list()
+			}
+			// if we had one or the other determine what it is
+			else if captured_vars.len > 0 {
+				expr_0 := captured_vars[0]
+				if expr_0 is ast.Ident {
+					if expr_0.name[0].is_capital() {
+						generic_params = captured_vars.clone()
+						captured_vars = []
+					}
+				}
+			}
+			mut typ := p.fn_type()
+			// if we had generic params update the fn type / sig (params are stored here)
+			if generic_params.len > 0 {
+				typ = ast.FnType{
+					...typ
+					generic_params: generic_params
+				}
+			}
+			if p.exp_pt && (p.tok != .lcbr || p.exp_lcbr) {
+				return ast.Type(typ)
+			}
+			lhs = ast.FnLiteral{
+				typ: typ
+				stmts: p.block()
+				captured_vars: captured_vars
+			}
+		}
+		.key_if {
+			lhs = p.if_expr(false)
+		}
+		// NOTE: I would much rather dump, likely, and unlikely were
+		// some type of comptime fn/macro's which come as part of the
+		// v stdlib, as apposed to being language keywords.
+		// TODO: should these be replaced with something
+		// like `CallExpr{lhs: KeywordOperator}` ?
+		.key_isreftype, .key_sizeof, .key_typeof {
+			op := p.tok()
+			// p.expect(.lpar)
+			if p.tok == .lpar {
+				p.next()
+				lhs = ast.KeywordOperator{
+					op: op
+					exprs: [p.expr_or_type(.lowest)]
+				}
+				p.expect(.rpar)
+			} else {
+				// TODO: is this the best way to handle this? (prob not :D)
+				// this allows `typeof[type]()` to work
+				lhs = ast.Ident{
+					name: op.str()
+				}
+			}
+		}
+		.key_dump, .key_likely, .key_unlikely {
+			op := p.tok()
+			p.expect(.lpar)
+			lhs = ast.KeywordOperator{
+				op: op
+				exprs: [p.expr(.lowest)]
+			}
+			p.expect(.rpar)
+		}
+		.key_offsetof {
+			op := p.tok()
+			p.expect(.lpar)
+			expr := p.expr(.lowest)
+			p.expect(.comma)
+			lhs = ast.KeywordOperator{
+				op: op
+				exprs: [expr, p.expr(.lowest)]
+			}
+			p.expect(.rpar)
+		}
+		.key_go, .key_spawn {
+			op := p.tok()
+			lhs = ast.KeywordOperator{
+				op: op
+				exprs: [p.expr(.lowest)]
+			}
+		}
+		.key_nil {
+			p.next()
+			return ast.Type(ast.NilType{})
+		}
+		.key_none {
+			p.next()
+			return ast.Type(ast.NoneType{})
+		}
+		.key_lock, .key_rlock {
+			mut kind := p.tok()
+			// `lock { stmts... }`
+			if p.tok == .lcbr {
+				return ast.LockExpr{
+					stmts: p.block()
+				}
+			}
+			mut lock_exprs := []ast.Expr{}
+			mut rlock_exprs := []ast.Expr{}
+			exp_lcbr := p.exp_lcbr
+			p.exp_lcbr = true
+			// `r?lock exprs { stmts... }`
+			// NOTE/TODO: `lock a; rlock c; lock b; rlock d {` will become
+			// `lock a, b; rlock c, d` unlike in the main parser, where it remains
+			// the same. this may need to be changed to match the current behaviour.
+			for p.tok != .lcbr {
+				if kind == .key_lock {
+					lock_exprs << p.expr_list()
+				} else if kind == .key_rlock {
+					rlock_exprs << p.expr_list()
+				}
+				if p.tok != .semicolon {
+					break
+				}
+				p.next()
+				kind = p.tok()
+			}
+			p.exp_lcbr = exp_lcbr
+			return ast.LockExpr{
+				lock_exprs: lock_exprs
+				rlock_exprs: rlock_exprs
+				stmts: p.block()
+			}
+		}
+		.key_struct {
+			p.next()
+			typ := ast.Keyword{
+				tok: .key_struct
+			}
+			if p.exp_pt && p.tok != .lcbr {
+				return typ
+			}
+			lhs = p.assoc_or_init_expr(typ)
+		}
+		.key_select {
+			p.next()
+			p.expect(.lcbr)
+			se := p.select_expr()
+			p.expect(.rcbr)
+			return se
+		}
+		.dollar {
+			p.next()
+			return p.comptime_expr()
+		}
+		// enum value `.green`
+		// TODO: use ast.EnumValue{} or stick with SelectorExpr?
+		// .dot {}
+		.lpar {
+			p.next()
+			exp_lcbr := p.exp_lcbr
+			p.exp_lcbr = false
+			// p.log('ast.ParenExpr:')
+			lhs = ast.ParenExpr{
+				expr: p.expr(.lowest)
+			}
+			p.exp_lcbr = exp_lcbr
+			p.expect(.rpar)
+		}
+		.lcbr {
+			// if p.exp_lcbr {
+			// 	p.error('unexpected `{`')
+			// }
+			// shorthand map / struct init
+			// NOTE: config syntax handled in `p.fn_arguments()`
+			// which afaik is the only place it's supported
+			// lhs = p.struct_init()
+			p.next()
+			if p.tok == .ellipsis {
+				p.error('this assoc syntax is no longer supported `{...`. You must explicitly specify a type `MyType{...`')
+			}
+			// empty map init `{}`
+			if p.tok == .rcbr {
+				p.next()
+				return ast.MapInitExpr{
+					pos: p.pos
+				}
+			}
+			// map init
+			pos := p.pos
+			mut keys := []ast.Expr{}
+			mut vals := []ast.Expr{}
+			for p.tok != .rcbr {
+				key := p.expr(.lowest)
+				if key is ast.InfixExpr {
+					if key.op == .pipe {
+						p.error('this assoc syntax is no longer supported `{MyType|`. Use `MyType{...` instead')
+					}
+				}
+				keys << key
+				p.expect(.colon)
+				val := p.expr(.lowest)
+				vals << val
+				// if p.tok == .comma {
+				if p.tok in [.comma, .semicolon] {
+					p.next()
+				}
+			}
+			p.next()
+			lhs = ast.MapInitExpr{
+				keys: keys
+				vals: vals
+				pos: pos
+			}
+		}
+		.lsbr {
+			// ArrayInitExpr: `[1,2,3,4]` | `[]type{}` | `[]type{len: 4}` | `[2]type{init: 0}` etc...
+			// ArrayInitExpr->IndexExpr: `[1,2,3,4][0]` handled here for reasons listed in comment below
+			// ArrayType in CastExpr: `[]type` in `[]type(x)` set lhs to type, cast handled later
+			pos := p.pos
+			p.next()
+			// exprs in first `[]` eg. (`1,2,3,4` in `[1,2,3,4]) | (`2` in `[2]int{}`)
+			mut exprs := []ast.Expr{}
+			for p.tok != .rsbr {
+				exprs << p.expr(.lowest)
+				if p.tok == .comma {
+					p.next()
+				}
+				// `[
+				//    1,
+				//    2
+				//  ]`
+				// TODO: move to `p.expr_list()` and use that?
+				else if p.tok == .semicolon {
+					// NOTE: this is missing trailing `,`, we can skip this if we want
+					p.error('missing `,` ?')
+					// p.next()
+					// break
+				}
+			}
+			p.next()
+			// (`[2]type{}` | `[2][2]type{}` | `[2][]type{}`) | `[1,2,3,4][0]` | `[2]type`
+			// NOTE: it's tricky to differentiate between a fixed array of fixed array(s)
+			// and an index directly after initialization. for example, the following:
+			// a) fixed array of fixed array(s): `[2][2]type{}` | `[2][2][2]type{}`
+			// b) index directly after init: `[1][0]` | `[x][2][2]` <- vs (a) above
+			// only in this case collect exprs in following `[x][x]` then decide what to do
+			if exprs.len > 0 && p.tok == .lsbr {
+				// collect exprs in all the following `[x][x]`
+				mut exprs_arr := [exprs]
+				// NOTE: checking line here for this case:
+				// `pub const const_a = ['a', 'b', 'c', 'd']`
+				// '[attribute_a; attribute_b]''
+				for p.tok == .lsbr {
+					p.next()
+					mut exprs2 := []ast.Expr{}
+					for p.tok != .rsbr {
+						exprs2 << p.range_expr(p.expr(.lowest))
+						if p.tok == .comma {
+							p.next()
+						}
+					}
+					p.next()
+					exprs_arr << exprs2
+				}
+				// (`[2]type{}` | `[2][]type{}` | `[2]&type{init: Foo{}}`) | `[2]type`
+				if p.tok in [.amp, .name] {
+					elem_type := p.expect_type()
+					for i := exprs_arr.len - 1; i >= 0; i-- {
+						exprs2 := exprs_arr[i]
+						if exprs2.len == 0 {
+							lhs = ast.Type(ast.ArrayType{
+								elem_type: elem_type
+							})
+						} else if exprs2.len == 1 {
+							lhs = ast.Type(ast.ArrayFixedType{
+								elem_type: elem_type
+								len: exprs2[0]
+							})
+						} else {
+							// TODO: use same error message as typ() `expect(.rsbr)`
+							p.error('expecting single expr for fixed array length')
+						}
+					}
+					// `[2]type{}`
+					if p.tok == .lcbr && !p.exp_lcbr {
+						p.next()
+						mut init := ast.empty_expr
+						if p.tok != .rcbr {
+							key := p.expect_name()
+							p.expect(.colon)
+							match key {
+								'init' { init = p.expr(.lowest) }
+								else { p.error('expecting `init`, got `${key}`') }
+							}
+						}
+						p.next()
+						lhs = ast.ArrayInitExpr{
+							typ: lhs
+							init: init
+							pos: pos
+						}
+					}
+					// `[2]type`
+					// casts are completed in expr loop
+					else if p.tok != .lpar {
+						if !p.exp_pt {
+							p.error('unexpected type')
+						}
+						// no need to chain here
+						return lhs
+					}
+				}
+				// `[1][0]` | `[1,2,3,4][0]` | `[[1,2,3,4]][0][1]` <-- index directly after init
+				else {
+					lhs = ast.ArrayInitExpr{
+						exprs: exprs
+						pos: pos
+					}
+					for i := 1; i < exprs_arr.len; i++ {
+						exprs2 := exprs_arr[i]
+						if exprs2.len != 1 {
+							// TODO: use same error message as IndexExpr in expr loop `expect(.rsbr)`
+							p.error('invalid index expr')
+						}
+						lhs = ast.IndexExpr{
+							lhs: lhs
+							expr: exprs2[0]
+						}
+					}
+				}
+			}
+			// (`[]type{}` | `[][]type{}` | `[]&type{len: 2}`) | `[]type`
+			else if p.tok in [.amp, .lsbr, .name] {
+				lhs = ast.Type(ast.ArrayType{
+					elem_type: p.expect_type()
+				})
+				// `[]type{}`
+				if p.tok == .lcbr && !p.exp_lcbr {
+					p.next()
+					mut cap, mut init, mut len := ast.empty_expr, ast.empty_expr, ast.empty_expr
+					for p.tok != .rcbr {
+						key := p.expect_name()
+						p.expect(.colon)
+						match key {
+							'cap' { cap = p.expr(.lowest) }
+							'init' { init = p.expr(.lowest) }
+							'len' { len = p.expr(.lowest) }
+							else { p.error('expecting one of `cap, init, len`, got `${key}`') }
+						}
+						if p.tok == .comma {
+							p.next()
+						}
+					}
+					p.next()
+					lhs = ast.ArrayInitExpr{
+						typ: lhs
+						init: init
+						cap: cap
+						len: len
+						pos: pos
+					}
+				}
+				// `[]type`
+				// casts are completed in expr loop
+				else if p.tok != .lpar {
+					if !p.exp_pt {
+						p.error('unexpected type')
+					}
+					// no need to chain here
+					return lhs
+				}
+			}
+			// `[1,2,3,4]!`
+			else if p.tok == .not {
+				if exprs.len == 0 {
+					p.error('expecting at least one initialization expr: `[expr, expr2]!`')
+				}
+				p.next()
+				lhs = ast.ArrayInitExpr{
+					exprs: exprs
+					// NOTE: indicates fixed `!`
+					len: ast.PostfixExpr{
+						op: .not
+						expr: ast.empty_expr
+					}
+					pos: pos
+				}
+				// `[]` | `[1,2,3,4]`
+			} else {
+				lhs = ast.ArrayInitExpr{
+					exprs: exprs
+					pos: pos
+				}
+			}
+		}
+		.key_match {
+			match_pos := p.pos
+			p.next()
+			mut exp_lcbr := p.exp_lcbr
+			p.exp_lcbr = true
+			expr := p.expr(.lowest)
+			p.exp_lcbr = exp_lcbr
+			p.expect(.lcbr)
+			mut branches := []ast.MatchBranch{}
+			for p.tok != .rcbr {
+				exp_lcbr = p.exp_lcbr
+				branch_pos := p.pos
+				p.exp_lcbr = true
+				mut cond := [p.range_expr(p.expr_or_type(.lowest))]
+				for p.tok == .comma {
+					p.next()
+					cond << p.range_expr(p.expr_or_type(.lowest))
+				}
+				p.exp_lcbr = exp_lcbr
+				branches << ast.MatchBranch{
+					cond: cond
+					stmts: p.block()
+					pos: branch_pos
+				}
+				p.expect_semi()
+				if p.tok == .key_else {
+					p.next()
+					branches << ast.MatchBranch{
+						stmts: p.block()
+						pos: branch_pos
+					}
+					p.expect_semi()
+				}
+			}
+			// rcbr
+			p.next()
+			lhs = ast.MatchExpr{
+				expr: expr
+				branches: branches
+				pos: match_pos
+			}
+		}
+		.key_atomic, .key_mut, .key_shared, .key_static, .key_volatile {
+			lhs = ast.ModifierExpr{
+				kind: p.tok()
+				expr: p.expr(.highest)
+			}
+		}
+		.key_unsafe {
+			// p.log('ast.UnsafeExpr')
+			p.next()
+			// exp_lcbr := p.exp_lcbr
+			// p.exp_lcbr = false
+			lhs = ast.UnsafeExpr{
+				stmts: p.block()
+			}
+			// p.exp_lcbr = exp_lcbr
+		}
+		.name {
+			lit := p.lit
+			lhs = p.ident_or_named_type()
+			// `sql x {}` otherwise ident named `sql`
+			if lit == 'sql' && p.tok == .name {
+				exp_lcbr := p.exp_lcbr
+				p.exp_lcbr = true
+				expr := p.expr(.lowest)
+				p.exp_lcbr = exp_lcbr
+				p.expect(.lcbr)
+				// TODO:
+				for p.tok != .rcbr {
+					// otherwise we will break on `}` from `${x}`
+					if p.tok == .string {
+						p.string_literal(.v)
+					} else {
+						p.next()
+					}
+				}
+				p.expect(.rcbr)
+				lhs = ast.SqlExpr{
+					expr: expr
+				}
+			}
+			// raw/c/js string: `r'hello'`
+			else if p.tok == .string {
+				lhs = p.string_literal(ast.StringLiteralKind.from_string_tinyv(lit) or {
+					p.error(err.msg())
+				})
+			}
+			// `ident{}`
+			else if p.tok == .lcbr && !p.exp_lcbr {
+				// TODO: move inits to expr loop? currently just handled where needed
+				// since this is not very many places. consider if it should be moved
+				// TODO: consider the following (tricky to parse)
+				// `if err == IError(Eof{}) {`
+				// `if Foo{} == Foo{} {`
+				lhs = p.assoc_or_init_expr(lhs)
+			}
+		}
+		// native optionals `x := ?mod_a.StructA{}`
+		// could also simply be handled by `Token.is_prefix()` below
+		.question {
+			lhs = p.expect_type()
+			// only handle where actually needed instead of expr loop
+			// I may change my mind, however for now this seems best
+			if p.tok == .lcbr && !p.exp_lcbr {
+				lhs = p.assoc_or_init_expr(lhs)
+			} else if !p.exp_pt && p.tok != .lpar {
+				p.error('unexpected type')
+			}
+		}
+		// selector handled in expr chaining loop below
+		// range handled in `p.range_expr()`
+		.dot, .dotdot, .ellipsis {}
+		else {
+			if p.tok.is_prefix() {
+				// NOTE: just use .highest for now, later we might need to define for each op
+				lhs = ast.PrefixExpr{
+					pos: p.pos
+					op: p.tok()
+					expr: p.expr(.highest)
+				}
+			} else {
+				p.error('expr: unexpected token `${p.tok}`')
+			}
+		}
+	}
+
+	// expr chaining
+	// TOOD: make sure there are no cases where we get stuck stuck in this loop
+	// for p.tok != .eof {
+	for {
+		// as cast
+		// this could be handled with infix instead
+		// if we choose not to support or chaning
+		if p.tok == .key_as {
+			p.next()
+			lhs = ast.AsCastExpr{
+				expr: lhs
+				typ: p.expect_type()
+			}
+		}
+		// call | cast
+		else if p.tok == .lpar {
+			pos := p.pos
+			// p.log('ast.CastExpr or CallExpr: ${typeof(lhs)}')
+			exp_lcbr := p.exp_lcbr
+			p.exp_lcbr = false
+			args := p.fn_arguments()
+			p.exp_lcbr = exp_lcbr
+			// definitely a call since we have `!` | `?`
+			// fncall()! (Propagate Result) | fncall()? (Propagate Option)
+			if p.tok in [.not, .question] {
+				lhs = ast.CallExpr{
+					lhs: lhs
+					args: args
+					pos: pos
+				}
+				// lhs = ast.PostfixExpr{
+				// 	expr: lhs
+				// 	op: p.tok()
+				// }
+			}
+			// could be a call or a cast (1 arg)
+			else if args.len == 1 {
+				// definitely a cast
+				if lhs is ast.Type {
+					lhs = ast.CastExpr{
+						typ: lhs
+						expr: args[0]
+						pos: pos
+					}
+				}
+				// work this out after type checking
+				else {
+					lhs = ast.CallOrCastExpr{
+						lhs: lhs
+						expr: args[0]
+						pos: pos
+					}
+				}
+			}
+			// definitely a call (0 args, or more than 1 arg)
+			else {
+				lhs = ast.CallExpr{
+					lhs: lhs
+					args: args
+					pos: pos
+				}
+			}
+		}
+		// NOTE: if we want we can handle init like this
+		// this is only needed for ident or selector, so there is really
+		// no point handling it here, since it wont be used for chaining
+		// else if p.tok == .lcbr && !p.exp_lcbr {
+		// 	lhs = p.assoc_or_init_expr(lhs)
+		// }
+		// index or generic call (args part, call handled above): `expr[i]` | `expr#[i]` | `expr[exprs]()`
+		else if p.tok in [.hash, .lsbr] {
+			// `array#[idx]`
+			if p.tok == .hash {
+				p.next()
+				p.expect(.lsbr)
+				// gated, even if followed by `(` we know it's `arr#[fn_idx]()` and not `fn[int]()`
+				// println('HERE')
+				lhs = ast.IndexExpr{
+					lhs: lhs
+					expr: p.range_expr(p.expr(.lowest))
+					is_gated: true
+				}
+				p.expect(.rsbr)
+			}
+			// `array[idx]` | `array[fn_idx]()` | fn[int]()` | `GenericStruct[int]{}`
+			else {
+				p.next() // .lsbr
+				// NOTE: `ast.GenericArgsOrIndexExpr` is only used for cases
+				// which absolutely cannot be determined until a later stage
+				// so try and determine every case we possibly can below
+				expr := p.range_expr(p.expr_or_type(.lowest))
+				mut exprs := [expr]
+				for p.tok == .comma {
+					p.next()
+					exprs << p.expr_or_type(.lowest)
+				}
+				p.expect(.rsbr)
+				// `GenericStruct[int]{}`
+				if p.tok == .lcbr && !p.exp_lcbr {
+					lhs = p.assoc_or_init_expr(ast.GenericArgs{ lhs: lhs, args: exprs })
+					// lhs = ast.GenericArgs{ lhs: lhs, args: exprs }
+				}
+				// `array[0]()` | `fn[int]()`
+				else if p.tok == .lpar {
+					// multiple exprs | `fn[GenericStruct[int]]()` nested generic args
+					if exprs.len > 1 || expr is ast.GenericArgs {
+						lhs = ast.GenericArgs{
+							lhs: lhs
+							args: exprs
+						}
+					}
+					// `ident[ident]()` this will be determined at a later stage by checking lhs
+					else if expr in [ast.Ident, ast.SelectorExpr] {
+						lhs = ast.GenericArgOrIndexExpr{
+							lhs: lhs
+							expr: expr
+						}
+					}
+					// `array[0]()` we know its an index
+					else {
+						lhs = ast.IndexExpr{
+							lhs: lhs
+							expr: expr
+						}
+					}
+				}
+				// `array[idx]` | `fn[GenericStructA[int], GenericStructB[int]]`
+				else {
+					// `fn[GenericStructA[int]]` | `GenericStructA[GenericStructB[int]]]` nested generic args
+					// TODO: make sure this does not cause false positives, may need extra check (.comma, .rsbr)
+					// if p.exp_pt && expr in [ast.GenericArgs, ast.Ident, ast.SelectorExpr] && p.tok in [.comma, .rsbr] {
+					if p.exp_pt && expr in [ast.GenericArgs, ast.Ident, ast.SelectorExpr] {
+						lhs = ast.GenericArgs{
+							lhs: lhs
+							args: exprs
+						}
+					} else {
+						lhs = ast.IndexExpr{
+							lhs: lhs
+							expr: expr
+						}
+					}
+				}
+			}
+		}
+		// SelectorExpr
+		else if p.tok == .dot {
+			p.next()
+			// p.log('ast.SelectorExpr')
+			lhs = ast.SelectorExpr{
+				lhs: lhs
+				// rhs: p.expr(.lowest)
+				rhs: p.ident()
+				pos: p.pos
+			}
+		}
+		// doing this here since it can be
+		// used between chaining selectors
+		// eg. `struct.field?.field`
+		// NOTE: should this require parens?
+		else if p.tok in [.not, .question] {
+			lhs = ast.PostfixExpr{
+				op: p.tok()
+				expr: lhs
+			}
+		} else if p.tok == .key_or {
+			// p.log('ast.OrExpr')
+			pos := p.pos
+			p.next()
+			lhs = ast.OrExpr{
+				expr: lhs
+				stmts: p.block()
+				pos: pos
+			}
+		}
+		// range
+		else if p.tok in [.dotdot, .ellipsis] {
+			// p.log('ast.RangeExpr')
+			// no need to continue
+			return ast.RangeExpr{
+				op: p.tok()
+				start: lhs
+				// if range ever gets used in other places, wont be able to check .rsbr
+				end: if p.tok == .rsbr { ast.empty_expr } else { p.expr(.lowest) }
+			}
+		} else {
+			break
+		}
+	}
+	// pratt
+	for int(min_bp) <= int(p.tok.left_binding_power()) {
+		if p.tok.is_infix() {
+			pos := p.pos
+			op := p.tok()
+			lhs = ast.InfixExpr{
+				op: op
+				lhs: lhs
+				// `x in y` allow range for this case, eg. `x in 1..10`
+				rhs: if op == .key_in {
+					p.range_expr(p.expr(op.right_binding_power()))
+				}
+				// `x is Type`
+				else if op == .key_is {
+					p.expect_type()
+				} else {
+					p.expr(op.right_binding_power())
+				}
+				pos: pos
+			}
+		} else if p.tok.is_postfix() {
+			lhs = ast.PostfixExpr{
+				op: p.tok()
+				expr: lhs
+			}
+		} else {
+			break
+		}
+	}
+	// p.log('returning: $p.tok')
+	return lhs
+}
+
+// parse and return `ast.RangeExpr` if found, otherwise return `lhs_expr`
+@[inline]
+fn (mut p Parser) range_expr(lhs_expr ast.Expr) ast.Expr {
+	if p.tok in [.dotdot, .ellipsis] {
+		return ast.RangeExpr{
+			op: p.tok()
+			start: lhs_expr
+			end: if p.tok == .rsbr { ast.empty_expr } else { p.expr(.lowest) }
+		}
+	}
+	return lhs_expr
+}
+
+// parse type or expr, eg. `typeof(expr|type)` | `array_or_generic_call[expr|type]()`
+@[inline]
+fn (mut p Parser) expr_or_type(min_bp token.BindingPower) ast.Expr {
+	// TODO: is there a better way to do this? see uses of `p.exp_pt`
+	exp_pt := p.exp_pt
+	p.exp_pt = true
+	expr := p.expr(min_bp)
+	p.exp_pt = exp_pt
+	return expr
+}
+
+// use peek() over always keeping next_tok one token ahead.
+// I have done it this way to keep scanner & parser in sync.
+// this simplifies getting any extra information from scanner
+// as I can retrieve it directly, no need to store somewhere.
+// this also help enforce the hard 1 token look ahead limit.
+@[inline]
+fn (mut p Parser) peek() token.Token {
+	if p.tok_next_ == .unknown {
+		p.tok_next_ = p.scanner.scan()
+	}
+	return p.tok_next_
+}
+
+@[inline]
+fn (mut p Parser) next() {
+	if p.tok_next_ != .unknown {
+		p.tok = p.tok_next_
+		p.tok_next_ = .unknown
+	} else {
+		p.tok = p.scanner.scan()
+	}
+	p.line = p.file.line_count()
+	p.lit = p.scanner.lit
+	p.pos = p.file.pos(p.scanner.pos)
+}
+
+// expect `tok` & go to next token
+@[inline]
+fn (mut p Parser) expect(tok token.Token) {
+	if p.tok != tok {
+		p.error_expected(tok, p.tok)
+	}
+	p.next()
+}
+
+@[inline]
+pub fn (mut p Parser) expect_semi() {
+	match p.tok {
+		// semicolon is optional before a closing ')' or '}'
+		.rpar, .rcbr {}
+		.semicolon {
+			p.next()
+		}
+		else {
+			p.error_expected(.semicolon, p.tok)
+		}
+	}
+}
+
+// expect `.name` & return `p.lit` & go to next token
+@[inline]
+fn (mut p Parser) expect_name() string {
+	if p.tok != .name {
+		p.error_expected(.name, p.tok)
+	}
+	name := p.lit
+	p.next()
+	return name
+}
+
+// return `p.lit` & go to next token
+@[inline]
+fn (mut p Parser) lit() string {
+	// TODO: check if there is a better way to handle this?
+	// we should never use lit() in cases where p.lit is empty anyway
+	// lit := if p.lit.len == 0 { p.tok.str() } else { p.lit }
+	lit := p.lit
+	p.next()
+	return lit
+}
+
+// return `p.tok` & go to next token
+@[inline]
+fn (mut p Parser) tok() token.Token {
+	tok := p.tok
+	p.next()
+	return tok
+}
+
+@[inline]
+fn (mut p Parser) block() []ast.Stmt {
+	mut stmts := []ast.Stmt{}
+	p.expect(.lcbr)
+	for p.tok != .rcbr {
+		stmts << p.stmt()
+	}
+	// rcbr
+	p.next()
+	// TODO: correct way to error on `if x == Type{} {`
+	// is this the correct place for this, will it work in every case?
+	// if p.tok == .lcbr {
+	// 	// TODO: better error message
+	// 	p.error('init must be in parens when `{` is expected, eg. `if x == (Type{}) {`')
+	// }
+	return stmts
+}
+
+@[inline]
+fn (mut p Parser) expr_list() []ast.Expr {
+	mut exprs := []ast.Expr{}
+	for {
+		exprs << p.expr(.lowest)
+		// TODO: was this just for previous generics impl or was there another need?
+		// expr := p.expr(.lowest)
+		// // TODO: is this the best place/way to handle this?
+		// if expr is ast.EmptyExpr {
+		// 	p.error('expecting expr, got `$p.tok`')
+		// }
+		// exprs << expr
+		if p.tok != .comma {
+			break
+		}
+		p.next()
+	}
+	return exprs
+}
+
+// @[attribute] | [attribute]
+fn (mut p Parser) attributes() []ast.Attribute {
+	p.next()
+	mut attributes := []ast.Attribute{}
+	for {
+		// TODO: perhaps attrs with `.name` token before `:` we can set name
+		// as apposed to value of `Ident{name}`
+		mut name := ''
+		mut value := ast.empty_expr
+		mut comptime_cond := ast.empty_expr
+		// since unsafe is a keyword
+		if p.tok == .key_unsafe {
+			p.next()
+			// name = 'unsafe'
+			value = ast.Ident{
+				name: 'unsafe'
+				pos: p.pos
+			}
+		}
+		// TODO: properly
+		// consider using normal if expr
+		else if p.tok == .key_if {
+			p.next()
+			comptime_cond = p.expr(.lowest)
+			// if p.tok == .question {
+			// 	p.next()
+			// 	comptime_cond = ast.PostfixExpr{
+			// 		op: .question
+			// 		expr: comptime_cond
+			// 	}
+			// }
+		} else {
+			// name = p.expect_name()
+			value = p.expr(.lowest)
+			if p.tok == .colon {
+				if mut value is ast.Ident {
+					name = value.name
+				} else {
+					p.error('expecting identifier')
+				}
+				p.next() // ;
+				// NOTE: use tok instead of defining AttributeKind
+				// kind := p.tok
+				// TODO: do we need the match below or should we use:
+				// if p.tok in [.semicolon, .rsbr] { p.error('...') }
+				value = p.expr(.lowest)
+				// value = match p.tok {
+				// 	.name, .number, .string { p.lit() }
+				// 	else { p.error('unexpected ${p.tok}, an argument is expected after `:`') }
+				// }
+			}
+		}
+		attributes << ast.Attribute{
+			name: name
+			value: value
+			comptime_cond: comptime_cond
+		}
+		if p.tok == .semicolon {
+			p.next()
+			continue
+		}
+		p.expect(.rsbr)
+		p.expect_semi()
+		// @[attribute_a]
+		// [attribute_a]
+		if p.tok in [.attribute, .lsbr] {
+			p.next()
+			continue
+		}
+		break
+	}
+	// p.log('ast.Attribute: $name')
+	return attributes
+}
+
+// TODO:
+fn (mut p Parser) asm_stmt() ast.AsmStmt {
+	p.next()
+	_ = if p.tok == .key_volatile {
+		p.next()
+		true
+	} else {
+		false
+	}
+	arch := p.expect_name()
+	p.expect(.lcbr)
+	for p.tok != .rcbr {
+		p.next()
+	}
+	p.expect(.rcbr)
+	return ast.AsmStmt{
+		arch: arch
+	}
+}
+
+@[inline]
+fn (mut p Parser) assign_stmt(lhs []ast.Expr) ast.AssignStmt {
+	return ast.AssignStmt{
+		pos: p.pos
+		op: p.tok()
+		lhs: lhs
+		rhs: p.expr_list()
+	}
+}
+
+@[inline]
+fn (mut p Parser) comptime_expr() ast.Expr {
+	pos := p.pos
+	match p.tok {
+		.key_if {
+			return ast.ComptimeExpr{
+				expr: p.if_expr(true)
+				pos: pos
+			}
+		}
+		else {
+			return ast.ComptimeExpr{
+				expr: p.expr(.lowest)
+				pos: p.pos
+			}
+		}
+	}
+}
+
+@[inline]
+fn (mut p Parser) comptime_stmt() ast.Stmt {
+	p.next()
+	match p.tok {
+		.key_for {
+			return ast.ComptimeStmt{
+				stmt: p.for_stmt()
+			}
+		}
+		// don't expect semi, if_expr eats the final `;` because of
+		// comptime if, and I don't want to peek ahead an extra token.
+		// If the `$` in each branch is removed from IfExpr then this
+		// can be handled the same as all other cases
+		.key_if {
+			return ast.ExprStmt{
+				expr: p.comptime_expr()
+			}
+		}
+		else {
+			expr := p.comptime_expr()
+			p.expect_semi()
+			return ast.ExprStmt{
+				expr: expr
+			}
+		}
+	}
+}
+
+fn (mut p Parser) for_stmt() ast.ForStmt {
+	p.next()
+	exp_lcbr := p.exp_lcbr
+	p.exp_lcbr = true
+	mut init, mut cond, mut post := ast.empty_stmt, ast.empty_expr, ast.empty_stmt
+	// `for x < y {` | `for x:=1; x<=10; x++ {`
+	if p.tok != .lcbr {
+		mut expr := if p.tok != .semicolon { p.expr(.lowest) } else { ast.empty_expr }
+		// `x, y` in (`for mut x, y in z {` | `for x, y := 1, 2; ; {`)
+		expr2 := if p.tok == .comma {
+			p.next()
+			p.expr(.highest)
+		} else {
+			ast.empty_expr
+		}
+		// `for x in {`
+		if p.tok == .key_in {
+			// p.expect(.key_in)
+			p.next()
+			init = ast.ForInStmt{
+				key: expr
+				value: expr2
+				expr: p.expr(.lowest)
+			}
+		} else if p.tok == .lcbr {
+			// `for x in y {`
+			// TODO: maybe handle this differently
+			if mut expr is ast.InfixExpr && expr.op == .key_in {
+				init = ast.ForInStmt{
+					value: expr.lhs
+					expr: expr.rhs
+				}
+			}
+			// `for x < y {`
+			else {
+				cond = expr
+			}
+		}
+		// `for x:=1; x<=10; x++ {`
+		else {
+			if p.tok != .semicolon {
+				// init = p.complete_simple_stmt(expr, true)
+				if expr2 is ast.EmptyExpr {
+					init = p.complete_simple_stmt(expr, true)
+				} else {
+					mut exprs := [expr, expr2]
+					for p.tok == .comma {
+						p.next()
+						exprs << p.expr(.lowest)
+					}
+					if !p.tok.is_assignment() {
+						p.error('expecting assignment `for a, b, c := 1, 2, 3; ... {`')
+					}
+					init = p.assign_stmt(exprs)
+				}
+			}
+			p.expect(.semicolon)
+			if p.tok != .semicolon {
+				cond = p.expr(.lowest)
+			}
+			p.expect(.semicolon)
+			if p.tok != .lcbr {
+				post = p.simple_stmt()
+			}
+		}
+	}
+	p.exp_lcbr = exp_lcbr
+	stmts := p.block()
+	p.expect_semi()
+	return ast.ForStmt{
+		init: init
+		cond: cond
+		post: post
+		stmts: stmts
+	}
+}
+
+fn (mut p Parser) if_expr(is_comptime bool) ast.IfExpr {
+	// p.log('ast.IfExpr')
+	p.next()
+	// else if
+	// NOTE: it's a bit weird to parse because of the way comptime has
+	// `$` on every branch. Removing this would simplify things
+	if p.tok == .key_if || (p.tok == .dollar && p.peek() == .key_if) {
+		if is_comptime {
+			p.expect(.dollar)
+		}
+		// p.expect(.key_if)
+		p.next()
+	}
+	exp_lcbr := p.exp_lcbr
+	p.exp_lcbr = true
+	// mut cond := p.expr(.lowest)
+	// NOTE: the line above works, but avoid calling p.expr()
+	mut cond := if p.tok == .lcbr {
+		ast.empty_expr
+	} else {
+		// eg. `$if T in [?int, ?int] {`
+		if is_comptime { p.expr_or_type(.lowest) } else { p.expr(.lowest) }
+	}
+	mut else_expr := ast.empty_expr
+	// if p.tok == .question {
+	// 	// TODO: handle individual cases like this or globally
+	// 	// use postfix for this and add to token.is_postfix()?
+	// 	cond = ast.PostfixExpr{
+	// 		expr: cond
+	// 		op: p.tok
+	// 	}
+	// 	p.next()
+	// }
+	// if guard
+	if p.tok == .comma {
+		s := p.complete_simple_stmt(cond, false)
+		if s is ast.AssignStmt {
+			cond = ast.IfGuardExpr{
+				stmt: s
+			}
+		} else {
+			p.error('expecting assignment `if a, b := c {`')
+		}
+	} else if p.tok in [.assign, .decl_assign] {
+		cond = ast.IfGuardExpr{
+			stmt: p.assign_stmt([cond])
+		}
+	}
+	p.exp_lcbr = exp_lcbr
+	// TODO: this is to error on if with `{` on next line
+	if p.tok == .semicolon {
+		// p.next()
+		p.error('unexpected newline, expecting `{` after if clause')
+	}
+	stmts := p.block()
+	// this is because semis get inserted after branches (same in Go)
+	if p.tok == .semicolon {
+		p.next()
+	}
+	// else
+	if p.tok == .key_else || (p.tok == .dollar && p.peek() == .key_else) {
+		// we are using expect instead of next to ensure we error when `is_comptime`
+		// and not all branches have `$`, or `!is_comptime` and any branches have `$`.
+		// the same applies for the `else if` condition directly below.
+		if is_comptime {
+			p.expect(.dollar)
+		}
+		// p.expect(.key_else)
+		// p.next()
+		else_expr = p.if_expr(is_comptime)
+	}
+	return ast.IfExpr{
+		cond: cond
+		else_expr: else_expr
+		stmts: stmts
+	}
+}
+
+fn (mut p Parser) import_stmt() ast.ImportStmt {
+	p.next()
+	// NOTE: we can also use SelectorExpr if we like
+	// mod := p.expr(.lowest)
+	mut name := p.expect_name()
+	mut alias := name
+	for p.tok == .dot {
+		p.next()
+		alias = p.expect_name()
+		name += '.' + alias
+	}
+	is_aliased := p.tok == .key_as
+	if is_aliased {
+		p.next()
+		alias = p.expect_name()
+	}
+	mut symbols := []ast.Expr{}
+	// `import mod { sym1, sym2 }`
+	if p.tok == .lcbr {
+		p.next()
+		for p.tok == .name {
+			// symbols << p.expr_or_type(.lowest)
+			symbols << p.ident_or_type()
+			if p.tok == .comma {
+				p.next()
+			} else {
+				break
+			}
+		}
+		p.expect(.rcbr)
+	}
+	// p.log('ast.ImportStmt: $name as $alias')
+	return ast.ImportStmt{
+		name: name
+		alias: alias
+		is_aliased: is_aliased
+		symbols: symbols
+	}
+}
+
+fn (mut p Parser) directive() ast.Directive {
+	line := p.line
+	// value := p.lit() // if we scan whole line see scanner
+	p.next()
+	name := p.expect_name()
+	// TODO: handle properly
+	// NOTE: these line checks will be removed once this is parsed properly
+	// and only needed since auto semi is not inserted after `>`
+	mut value := p.lit()
+	for p.line == line {
+		if p.tok == .name {
+			value += p.lit()
+		} else {
+			value += p.tok.str()
+			p.next()
+		}
+	}
+	// p.next()
+	return ast.Directive{
+		name: name
+		value: value
+	}
+}
+
+fn (mut p Parser) const_decl(is_public bool) ast.ConstDecl {
+	p.next()
+	is_grouped := p.tok == .lpar
+	if is_grouped {
+		p.next()
+	}
+	mut fields := []ast.FieldInit{}
+	for {
+		name := p.expect_name()
+		p.expect(.assign)
+		value := p.expr(.lowest)
+		fields << ast.FieldInit{
+			name: name
+			value: value
+		}
+		p.expect(.semicolon)
+		if !is_grouped {
+			break
+		} else if p.tok == .rpar {
+			p.next()
+			p.expect(.semicolon)
+			break
+		}
+	}
+	return ast.ConstDecl{
+		is_public: is_public
+		fields: fields
+	}
+}
+
+fn (mut p Parser) fn_decl(is_public bool, attributes []ast.Attribute) ast.FnDecl {
+	pos := p.pos
+	p.next()
+	// method
+	mut is_method := false
+	mut receiver := ast.Parameter{}
+	if p.tok == .lpar {
+		is_method = true
+		p.next()
+		// TODO: use parse_ident & type
+		// receiver := p.ident() ?
+		is_mut := p.tok == .key_mut
+		is_shared := p.tok == .key_shared
+		if is_mut || is_shared {
+			p.next()
+		}
+		// // TODO: clean up, will this be done here or in checker
+		// receiver_name := p.expect_name()
+		// mut receiver_type := p.expect_type()
+		// if is_mut {
+		// 	if mut receiver_type is ast.PrefixExpr {
+		// 		if receiver_type.op == .amp {
+		// 			p.error('use `mut Type` not `mut &Type`. TODO: proper error message')
+		// 		}
+		// 	}
+		// 	receiver_type = ast.PrefixExpr{op: .amp, expr: receiver_type}
+		// }
+		receiver_pos := p.pos
+		receiver = ast.Parameter{
+			name: p.expect_name()
+			typ: p.expect_type()
+			// name: receiver_name
+			// typ: receiver_type
+			is_mut: is_mut
+			pos: receiver_pos
+		}
+		p.expect(.rpar)
+		// operator overload
+		// TODO: what a mess finish / clean up & separate if possible
+		if p.tok.is_overloadable() {
+			// println('look like overload!')
+			op := p.tok()
+			_ = op
+			p.expect(.lpar)
+			is_mut2 := p.tok == .key_mut
+			_ = is_mut2
+			if is_mut {
+				p.next()
+			}
+			receiver2 := ast.Parameter{
+				name: p.expect_name()
+				typ: p.expect_type()
+				is_mut: is_mut
+			}
+			_ = receiver2
+			p.expect(.rpar)
+			mut return_type := ast.empty_expr
+			_ = return_type
+			if p.tok != .lcbr {
+				return_type = p.expect_type()
+			}
+			p.block()
+			p.expect(.semicolon)
+			// TODO
+			return ast.FnDecl{
+				pos: p.pos
+			}
+		}
+	}
+	language := p.decl_language()
+	name_ident := p.ident()
+	mut name := name_ident.name
+	mut is_static := false
+	if p.tok == .dot {
+		p.next()
+		// static method `Type.name`
+		if language == .v {
+			name = p.expect_name()
+			is_method = true
+			is_static = true
+			receiver = ast.Parameter{
+				typ: name_ident
+			}
+		}
+		// eg. `Promise.resolve` in `JS.Promise.resolve`
+		else {
+			name += '.' + p.expect_name()
+			for p.tok == .dot {
+				p.next()
+				name += '.' + p.expect_name()
+			}
+		}
+	}
+	typ := p.fn_type()
+	// p.log('ast.FnDecl: $name $p.lit - $p.tok ($p.lit) - $p.tok_next_')
+	// also check line for better error detection
+	stmts := if p.tok == .lcbr {
+		p.block()
+	} else {
+		[]ast.Stmt{}
+	}
+	p.expect(.semicolon)
+	return ast.FnDecl{
+		attributes: attributes
+		is_public: is_public
+		is_method: is_method
+		is_static: is_static
+		receiver: receiver
+		name: name
+		language: language
+		typ: typ
+		stmts: stmts
+		pos: pos
+	}
+}
+
+fn (mut p Parser) fn_parameters() []ast.Parameter {
+	p.expect(.lpar)
+	mut params := []ast.Parameter{}
+	for p.tok != .rpar {
+		// TODO: parse all modifiers (shared)
+		pos := p.pos
+		is_mut := p.tok == .key_mut
+		if is_mut {
+			p.next()
+		}
+		// NOTE: case documented in `p.try_type()` todo
+		mut typ := p.expect_type()
+		mut name := ''
+		if mut typ is ast.Ident && p.tok !in [.comma, .rpar] {
+			name = typ.name
+			typ = p.expect_type()
+		}
+		params << ast.Parameter{
+			name: name
+			typ: typ
+			is_mut: is_mut
+			pos: pos
+		}
+		if p.tok == .comma {
+			p.next()
+		}
+	}
+	p.next()
+	return params
+}
+
+fn (mut p Parser) fn_arguments() []ast.Expr {
+	p.expect(.lpar)
+	// args := if p.tok == .rpar { []ast.Expr{} } else { p.expr_list() }
+	// NOTE: not using p.expr_list() as I need to support some special
+	// things like varg, lambda expression, and struct config syntax
+	// TODO: config syntax is getting deprecated, will become maps
+	// eventually use named default params instead (once implemented)
+	mut args := []ast.Expr{}
+	for p.tok != .rpar {
+		// NOTE: since these are only supported in fn arguments
+		// we will only handle them here, rather than in `p.expr`
+		expr := match p.tok {
+			// `...varg`
+			.ellipsis {
+				ast.Expr(ast.PrefixExpr{
+					op: p.tok()
+					expr: p.expr(.lowest)
+				})
+			}
+			// lambda expression - no args
+			.logical_or {
+				p.next()
+				ast.LambdaExpr{
+					expr: p.expr(.lowest)
+				}
+			}
+			// lambda expression - with args
+			.pipe {
+				p.next()
+				mut le_args := [p.ident()]
+				for p.tok == .comma {
+					p.next()
+					le_args << p.ident()
+				}
+				p.expect(.pipe)
+				ast.LambdaExpr{
+					args: le_args
+					expr: p.expr(.lowest)
+				}
+			}
+			else {
+				p.expr(.lowest)
+			}
+		}
+		// short struct config syntax
+		// TODO: if also supported anywhere else it can be moved to `p.expr()`
+		if p.tok == .colon {
+			p.next()
+			// println('looks like config syntax')
+			if expr !is ast.Ident {
+				p.error('expecting ident for struct config syntax?')
+			}
+			args << ast.FieldInit{
+				name: (expr as ast.Ident).name
+				value: p.expr(.lowest)
+			}
+			if p.tok == .semicolon {
+				p.next()
+			}
+		} else {
+			args << expr
+		}
+		// args << expr
+		if p.tok == .comma {
+			p.next()
+		}
+	}
+	p.next()
+	return args
+}
+
+fn (mut p Parser) enum_decl(is_public bool, attributes []ast.Attribute) ast.EnumDecl {
+	p.next()
+	name := p.expect_name()
+	as_type := if p.tok == .key_as {
+		p.next()
+		p.expect_type()
+	} else {
+		ast.empty_expr
+	}
+	// p.log('ast.EnumDecl: $name')
+	p.expect(.lcbr)
+	mut fields := []ast.FieldDecl{}
+	for p.tok != .rcbr {
+		field_name := p.expect_name()
+		mut value := ast.empty_expr
+		if p.tok == .assign {
+			p.next()
+			value = p.expr(.lowest)
+		}
+		field_attributes := if p.tok in [.attribute, .lsbr] {
+			p.attributes()
+		} else {
+			[]ast.Attribute{}
+		}
+		// p.expect_semi()
+		// p.expect(.semicolon)
+		if p.tok == .semicolon {
+			p.next()
+		}
+		fields << ast.FieldDecl{
+			name: field_name
+			value: value
+			attributes: field_attributes
+		}
+	}
+	p.next()
+	// p.expect_semi()
+	p.expect(.semicolon)
+	return ast.EnumDecl{
+		attributes: attributes
+		is_public: is_public
+		name: name
+		as_type: as_type
+		fields: fields
+	}
+}
+
+fn (mut p Parser) global_decl(attributes []ast.Attribute) ast.GlobalDecl {
+	p.next()
+	// NOTE: this got changed at some stage (or perhaps was never forced)
+	// if p.tok != .lpar {
+	//     p.error('globals must be grouped, e.g. `__global ( a = int(1) )`')
+	// }
+	// p.next()
+	is_grouped := p.tok == .lpar
+	if is_grouped {
+		p.next()
+	}
+	mut fields := []ast.FieldDecl{}
+	for {
+		name := p.expect_name()
+		if p.tok == .assign {
+			p.next()
+			fields << ast.FieldDecl{
+				name: name
+				value: p.expr(.lowest)
+			}
+		} else {
+			fields << ast.FieldDecl{
+				name: name
+				typ: p.expect_type()
+			}
+		}
+		p.expect(.semicolon)
+		if !is_grouped {
+			break
+		} else if p.tok == .rpar {
+			p.next()
+			p.expect(.semicolon)
+			break
+		}
+	}
+	return ast.GlobalDecl{
+		attributes: attributes
+		fields: fields
+	}
+}
+
+fn (mut p Parser) interface_decl(is_public bool, attributes []ast.Attribute) ast.InterfaceDecl {
+	p.next()
+	mut name := p.expect_name()
+	for p.tok == .dot {
+		p.next()
+		name += p.expect_name()
+	}
+	generic_params := if p.tok == .lsbr { p.generic_list() } else { []ast.Expr{} }
+	p.expect(.lcbr)
+	mut fields := []ast.FieldDecl{}
+	mut embedded := []ast.Expr{}
+	for p.tok != .rcbr {
+		is_mut := p.tok == .key_mut
+		if is_mut {
+			p.next()
+			p.expect(.colon)
+		}
+		mut field_name := ''
+		mut field_type := p.expect_type()
+		// `field type`
+		if p.tok != .semicolon {
+			if mut field_type is ast.Ident {
+				field_name = field_type.name
+			} else {
+				p.error('expecting field name')
+			}
+			fields << ast.FieldDecl{
+				name: field_name
+				typ: if p.tok == .lpar { ast.Type(p.fn_type()) } else { p.expect_type() }
+			}
+		}
+		// embedded interface
+		else {
+			embedded << field_type
+		}
+		// p.expect_semi()
+		p.expect(.semicolon)
+	}
+	// rcbr
+	p.next()
+	p.expect(.semicolon)
+	return ast.InterfaceDecl{
+		is_public: is_public
+		attributes: attributes
+		name: name
+		generic_params: generic_params
+		embedded: embedded
+		fields: fields
+	}
+}
+
+fn (mut p Parser) struct_decl(is_public bool, attributes []ast.Attribute) ast.StructDecl {
+	// TODO: union
+	// is_union := p.tok == .key_union
+	pos := p.pos
+	p.next()
+	language := p.decl_language()
+	name := p.expect_name()
+	// p.log('ast.StructDecl: $name')
+	generic_params := if p.tok == .lsbr { p.generic_list() } else { []ast.Expr{} }
+	// probably C struct decl with no body or {}
+	if p.tok != .lcbr {
+		if language == .v {
+			p.error('v struct decl must have a body')
+		}
+		return ast.StructDecl{
+			is_public: is_public
+			language: language
+			name: name
+			generic_params: generic_params
+			pos: pos
+		}
+	}
+	embedded, fields := p.struct_decl_fields(language)
+	return ast.StructDecl{
+		attributes: attributes
+		is_public: is_public
+		embedded: embedded
+		language: language
+		name: name
+		generic_params: generic_params
+		fields: fields
+		pos: pos
+	}
+}
+
+// returns (embedded_types, fields)
+fn (mut p Parser) struct_decl_fields(language ast.Language) ([]ast.Expr, []ast.FieldDecl) {
+	p.expect(.lcbr)
+	// fields
+	mut embedded := []ast.Expr{}
+	mut fields := []ast.FieldDecl{}
+	for p.tok != .rcbr {
+		is_pub := p.tok == .key_pub
+		if is_pub {
+			p.next()
+		}
+		is_mut := p.tok == .key_mut
+		if is_mut {
+			p.next()
+		}
+		if is_pub || is_mut {
+			p.expect(.colon)
+		}
+		// NOTE: case documented in `p.try_type()` todo
+		embed_or_name := p.expect_type()
+		// embedded struct
+		if p.tok == .semicolon {
+			if language != .v {
+				p.error('${language} structs do not support embedding')
+			}
+			p.next()
+			embedded << embed_or_name
+			continue
+		}
+		// field
+		field_name := match embed_or_name {
+			ast.Ident { embed_or_name.name }
+			else { p.error('invalid field name') }
+		}
+		field_type := p.expect_type()
+		// field - default value
+		field_value := if p.tok == .assign {
+			p.next()
+			p.expr(.lowest)
+		} else {
+			ast.empty_expr
+		}
+		field_attributes := if p.tok in [.attribute, .lsbr] {
+			p.attributes()
+		} else {
+			[]ast.Attribute{}
+		}
+		if p.tok == .semicolon {
+			p.next()
+		}
+		fields << ast.FieldDecl{
+			name: field_name
+			typ: field_type
+			value: field_value
+			attributes: field_attributes
+		}
+	}
+	p.next()
+	p.expect(.semicolon)
+	return embedded, fields
+}
+
+fn (mut p Parser) select_expr() ast.SelectExpr {
+	exp_lcbr := p.exp_lcbr
+	p.exp_lcbr = true
+	stmt := p.simple_stmt()
+	p.exp_lcbr = exp_lcbr
+	mut stmts := []ast.Stmt{}
+	if p.tok == .lcbr {
+		stmts = p.block()
+		p.expect_semi()
+	}
+	select_expr := ast.SelectExpr{
+		pos: p.pos
+		stmt: stmt
+		stmts: stmts
+		next: if p.tok != .rcbr { p.select_expr() } else { ast.empty_expr }
+	}
+	return select_expr
+}
+
+fn (mut p Parser) assoc_or_init_expr(typ ast.Expr) ast.Expr {
+	p.next() // .lcbr
+	// assoc
+	if p.tok == .ellipsis {
+		p.next()
+		lx := p.expr(.lowest)
+		p.expect(.semicolon)
+		mut fields := []ast.FieldInit{}
+		for p.tok != .rcbr {
+			if p.tok == .comma {
+				p.next()
+			}
+			field_name := p.expect_name()
+			p.expect(.colon)
+			fields << ast.FieldInit{
+				name: field_name
+				value: p.expr(.lowest)
+			}
+			p.expect_semi()
+		}
+		p.next()
+		return ast.AssocExpr{
+			typ: typ
+			expr: lx
+			fields: fields
+		}
+	}
+	// struct init
+	mut fields := []ast.FieldInit{}
+	mut prev_has_name := false
+	for p.tok != .rcbr {
+		// could be name or init without field name
+		mut field_name := ''
+		mut value := p.expr(.lowest)
+		// name / value
+		if p.tok == .colon {
+			match mut value {
+				// ast.BasicLiteral { field_name = value.value }
+				// ast.StringLiteral { field_name = value.value }
+				ast.Ident { field_name = value.name }
+				else { p.error('expected field name, got ${value.type_name()}') }
+			}
+			p.next()
+			value = p.expr(.lowest)
+		}
+		has_name := field_name.len > 0
+		if fields.len > 0 && has_name != prev_has_name {
+			p.error('cant mix & match name & no name')
+		}
+		prev_has_name = has_name
+		if p.tok == .comma {
+			p.next()
+		}
+		fields << ast.FieldInit{
+			name: field_name
+			value: value
+		}
+		if p.tok == .semicolon {
+			p.next()
+		}
+		// p.expect(.semicolon)
+	}
+	p.next()
+	return ast.InitExpr{
+		typ: typ
+		fields: fields
+	}
+}
+
+fn (mut p Parser) string_literal(kind ast.StringLiteralKind) ast.Expr {
+	value0 := p.lit()
+	if p.tok != .str_dollar {
+		return ast.StringLiteral{
+			kind: kind
+			value: value0
+		}
+	}
+	mut values := []string{}
+	mut inters := []ast.StringInter{}
+	values << value0
+	p.next()
+	p.expect(.lcbr)
+	inters << p.string_inter()
+	p.expect(.rcbr)
+	for p.tok == .string {
+		value := p.lit()
+		values << value
+		if p.tok == .str_dollar {
+			p.next()
+			p.expect(.lcbr)
+			inters << p.string_inter()
+			p.expect(.rcbr)
+		}
+	}
+	return ast.StringInterLiteral{
+		kind: kind
+		values: values
+		inters: inters
+	}
+}
+
+// TODO: finish
+fn (mut p Parser) string_inter() ast.StringInter {
+	expr := p.expr(.lowest)
+	mut format := ast.StringInterFormat.unformatted
+	mut format_expr := ast.empty_expr
+	// TODO: proper
+	if p.tok == .colon {
+		p.next()
+		// temp
+		if p.tok in [.number, .minus, .plus] {
+			format_expr = p.expr(.lowest)
+		}
+		// TODO
+		// if p.tok == .minus {
+		// 	p.next()
+		// }
+		// else if p.tok == .plus {
+		// 	p.next()
+		// }
+		// if p.tok == .number {
+		// 	_ = p.lit()
+		// }
+		if p.tok == .name {
+			format = ast.StringInterFormat.from_u8(p.lit[0]) or { p.error(err.msg()) }
+			p.next()
+		}
+	}
+	return ast.StringInter{
+		format: format
+		format_expr: format_expr
+		expr: expr
+	}
+}
+
+@[inline]
+fn (mut p Parser) generic_list() []ast.Expr {
+	p.next()
+	mut generic_list := [p.expect_type()]
+	for p.tok == .comma {
+		p.next()
+		generic_list << p.expect_type()
+	}
+	p.expect(.rsbr)
+	return generic_list
+}
+
+@[direct_array_access]
+fn (mut p Parser) decl_language() ast.Language {
+	mut language := ast.Language.v
+	if p.lit.len == 1 && p.lit[0] == `C` {
+		language = .c
+	} else if p.lit.len == 2 && p.lit[0] == `J` && p.lit[1] == `S` {
+		language = .js
+	} else {
+		return language
+	}
+	p.next()
+	p.expect(.dot)
+	return language
+}
+
+fn (mut p Parser) type_decl(is_public bool) ast.TypeDecl {
+	p.next()
+	language := p.decl_language()
+	name := p.expect_name()
+	generic_params := if p.tok == .lsbr { p.generic_list() } else { []ast.Expr{} }
+
+	// p.log('ast.TypeDecl: $name')
+	p.expect(.assign)
+	typ := p.expect_type()
+
+	// alias `type MyType = int`
+	if p.tok != .pipe {
+		p.expect(.semicolon)
+		return ast.TypeDecl{
+			is_public: is_public
+			language: language
+			name: name
+			generic_params: generic_params
+			base_type: typ
+		}
+	}
+	// sum type `type MyType = int | string`
+	p.next()
+	mut variants := [typ, p.expect_type()]
+	for p.tok == .pipe {
+		p.next()
+		variants << p.expect_type()
+	}
+	p.expect(.semicolon)
+	// TODO: consider separate node for alias / sum type ?
+	return ast.TypeDecl{
+		is_public: is_public
+		language: language
+		name: name
+		generic_params: generic_params
+		variants: variants
+	}
+}
+
+@[inline]
+fn (mut p Parser) ident() ast.Ident {
+	return ast.Ident{
+		pos: p.pos
+		name: p.expect_name()
+	}
+}
+
+@[inline]
+fn (mut p Parser) ident_or_selector_expr() ast.Expr {
+	ident := p.ident()
+	if p.tok == .dot {
+		p.next()
+		// TODO: remove this / come up with a good solution
+		if p.tok == .dollar {
+			p.next()
+			p.expr(.lowest)
+			return ast.SelectorExpr{
+				lhs: ident
+				rhs: ast.Ident{
+					name: 'TODO: comptime selector'
+				}
+				pos: p.pos
+			}
+		}
+		return ast.SelectorExpr{
+			lhs: ident
+			rhs: p.ident()
+			pos: p.pos
+		}
+	}
+	return ident
+}
+
+fn (mut p Parser) log(msg string) {
+	if p.pref.verbose {
+		println(msg)
+	}
+}
+
+// TODO/NOTE: this can be completely replaced with token.File.position()
+// I was only using this since it skips the binary search and is slightly
+// faster, howevrer if only used in error conditions this is irrelevant.
+fn (mut p Parser) current_position() token.Position {
+	pos := p.pos - p.file.base
+	return token.Position{
+		filename: p.file.name
+		line: p.line
+		offset: pos
+		column: pos - p.file.line_start(p.line) + 1
+	}
+}
+
+fn (mut p Parser) error_expected(exp token.Token, got token.Token) {
+	p.error('unexpected token. expecting `${exp}`, got `${got}`')
+}
+
+// so we can customize the error message used by warn & error
+fn (mut p Parser) error_message(msg string, kind errors.Kind, pos token.Position) {
+	errors.error(msg, errors.details(p.file, pos, 2), kind, pos)
+}
+
+fn (mut p Parser) warn(msg string) {
+	p.error_message(msg, .warning, p.current_position())
+}
+
+@[noreturn]
+fn (mut p Parser) error(msg string) {
+	p.error_with_position(msg, p.current_position())
+	// p.error_with_position(msg, p.file.position(p.pos))
+}
+
+@[noreturn]
+fn (mut p Parser) error_with_pos(msg string, pos token.Pos) {
+	p.error_with_position(msg, p.file.position(pos))
+}
+
+@[noreturn]
+fn (mut p Parser) error_with_position(msg string, pos token.Position) {
+	p.error_message(msg, .error, pos)
+	exit(1)
+}

--- a/vlib/v2/parser/type.v
+++ b/vlib/v2/parser/type.v
@@ -1,0 +1,248 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module parser
+
+import v2.ast
+
+@[inline]
+fn (mut p Parser) expect_type() ast.Expr {
+	// return p.try_type() or {
+	// 	p.error(err.msg())
+	// }
+	typ := p.try_type()
+	if typ is ast.EmptyExpr {
+		p.error('expecting type, got `${p.tok}`')
+	}
+	return typ
+}
+
+// TODO: use result or stick with empty expr?
+// pub fn (mut p Parser) try_type() !ast.Expr {
+fn (mut p Parser) try_type() ast.Expr {
+	match p.tok {
+		// pointer: `&type`
+		.amp {
+			p.next()
+			return ast.PrefixExpr{
+				op: .amp
+				expr: p.expect_type()
+			}
+		}
+		// comptime type: `$enum` | `$struct` |  etc
+		.dollar {
+			p.next()
+			return ast.ComptimeExpr{
+				// TODO: best way to handle this?
+				expr: match p.tok {
+					.name {
+						p.ident()
+					}
+					else {
+						// TODO: match only allowed tokens otherwise error
+						ast.Ident{
+							pos: p.pos
+							name: p.tok().str()
+						}
+					}
+				}
+			}
+		}
+		// variadic: `...type`
+		.ellipsis {
+			p.next()
+			// TODO: what will we use here?
+			return ast.PrefixExpr{
+				op: .ellipsis
+				expr: p.expect_type()
+			}
+		}
+		// atomic | shared
+		// eg. typespec in struct field with modifier. other cases handled in expr()
+		.key_atomic, .key_shared {
+			kind := p.tok
+			p.next()
+			return ast.ModifierExpr{
+				kind: kind
+				expr: p.expect_type()
+			}
+		}
+		// function: `fn(type) type`
+		.key_fn {
+			p.next()
+			return ast.Type(p.fn_type())
+		}
+		// nil
+		.key_nil {
+			p.next()
+			return ast.Type(ast.NilType{})
+		}
+		// none
+		.key_none {
+			p.next()
+			return ast.Type(ast.NoneType{})
+		}
+		// inline / anonymous struct
+		.key_struct {
+			p.next()
+			generic_params := if p.tok == .lsbr { p.generic_list() } else { []ast.Expr{} }
+			embedded, fields := p.struct_decl_fields(.v)
+			// TODO: should we use this or just StructDecl
+			// even though it technically is not one? hrmm
+			return ast.Type(ast.AnonStructType{
+				generic_params: generic_params
+				embedded: embedded
+				fields: fields
+			})
+		}
+		// tuple (multi return): `(type, type)`
+		.lpar {
+			p.next()
+			// expect at least two (so we otherwise error)
+			mut types := [p.expect_type()]
+			p.expect(.comma)
+			types << p.expect_type()
+			// more than two
+			for p.tok == .comma {
+				p.next()
+				types << p.expect_type()
+			}
+			p.expect(.rpar)
+			return ast.Type(ast.TupleType{
+				types: types
+			})
+		}
+		// array: `[]type` | `[len]type`
+		.lsbr {
+			p.next()
+			// dynamic array
+			if p.tok == .rsbr {
+				p.next()
+				return ast.Type(ast.ArrayType{
+					elem_type: p.expect_type()
+				})
+			}
+			// fixed array
+			len_expr := p.expr(.lowest)
+			p.expect(.rsbr)
+			return ast.Type(ast.ArrayFixedType{
+				len: len_expr
+				elem_type: p.expect_type()
+			})
+		}
+		// name | chan | map
+		.name {
+			pos := p.pos
+			// TODO: cleam this up
+			name := p.ident_or_named_type()
+			if p.tok == .lsbr && name !is ast.Type && p.tok != .semicolon {
+				// TODO: is there a better solution than this. maybe it should be the
+				// concern of p.fn_parameters() & p.struct_decl() rather than this?
+				// `fn(param_a []type)` | `struct { field_a []type }`
+				if name is ast.Ident && name.name.len + pos < p.pos {
+					return name
+				}
+				// TODO: using ast.GenericArgs here may not be correct,
+				// perhaps we should rename it to ast.GenericTypes
+				// if name is ast.Ident && p.pos == pos + name.name.len { return name }
+				return ast.Type(ast.GenericType{
+					name: name
+					params: p.generic_list()
+				})
+			}
+			return name
+		}
+		// result: `!` | `!type`
+		.not {
+			p.next()
+			return ast.Type(ast.ResultType{
+				base_type: if p.tok != .semicolon { p.try_type() } else { ast.empty_expr }
+				// base_type: p.tok != .semicolon { p.try_type() or { ast.empty_expr } } else { ast.empty_expr }
+			})
+		}
+		// option: `?` | `?type`
+		.question {
+			p.next()
+			return ast.Type(ast.OptionType{
+				base_type: if p.tok != .semicolon { p.try_type() } else { ast.empty_expr }
+				// base_type: if p.tok != .semicolon { p.try_type() or { ast.empty_expr } } else { ast.empty_expr }
+			})
+		}
+		else {
+			// return error('expecting type, got `$p.tok`')
+			return ast.empty_expr
+		}
+	}
+}
+
+// function type / signature
+fn (mut p Parser) fn_type() ast.FnType {
+	generic_params := if p.tok == .lsbr { p.generic_list() } else { []ast.Expr{} }
+	params := p.fn_parameters()
+	return ast.FnType{
+		generic_params: generic_params
+		params: params
+		return_type: if p.tok != .semicolon { p.try_type() } else { ast.empty_expr }
+	}
+}
+
+// `ident` | `map[type]type | `(`chan`|`chan type`) | (`thread`|`thread type`)
+@[direct_array_access]
+fn (mut p Parser) ident_or_named_type() ast.Expr {
+	pos := p.pos
+	// `map[type]type`
+	if p.lit.len == 3 && p.lit[0] == `m` && p.lit[1] == `a` && p.lit[2] == `p` {
+		p.next()
+		if p.tok == .lsbr {
+			p.next()
+			key_type := p.expect_type()
+			p.expect(.rsbr)
+			return ast.Type(ast.MapType{
+				key_type: key_type
+				value_type: p.expect_type()
+			})
+		}
+		// struct called `map` in builtin
+		return ast.Ident{
+			name: 'map'
+			pos: pos
+		}
+	}
+	// `chan` | `chan type`
+	if p.lit.len == 4 && p.lit[0] == `c` && p.lit[1] == `h` && p.lit[2] == `a` && p.lit[3] == `n` {
+		p.next()
+		elem_type := if p.tok != .semicolon { p.try_type() } else { ast.empty_expr }
+		if elem_type !is ast.EmptyExpr {
+			return ast.Type(ast.ChannelType{
+				elem_type: elem_type
+			})
+		}
+		// struct called `chan` in builtin
+		return ast.Ident{
+			name: 'chan'
+			pos: pos
+		}
+	}
+	// `thread` | `thread type`
+	else if p.lit.len == 6 && p.lit[0] == `t` && p.lit[1] == `h` && p.lit[2] == `r`
+		&& p.lit[3] == `e` && p.lit[4] == `a` && p.lit[5] == `d` {
+		p.next()
+		return ast.Type(ast.ThreadType{
+			elem_type: if p.tok != .semicolon { p.try_type() } else { ast.empty_expr }
+		})
+	}
+	// `ident` | `selector` - ident or type name
+	return p.ident_or_selector_expr()
+}
+
+// `ident` | (`Type`|`Type[T]`) | (`mod.Type`|`mod.Type[T]`)
+fn (mut p Parser) ident_or_type() ast.Expr {
+	ident_or_selector := p.ident_or_selector_expr()
+	if p.tok == .lsbr {
+		return ast.Type(ast.GenericType{
+			name: ident_or_selector
+			params: p.generic_list()
+		})
+	}
+	return ident_or_selector
+}

--- a/vlib/v2/pref/module.v
+++ b/vlib/v2/pref/module.v
@@ -1,0 +1,33 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module pref
+
+import os
+
+pub fn (p &Preferences) get_vlib_module_path(mod string) string {
+	mod_path := mod.replace('.', os.path_separator)
+	return os.join_path(p.vroot, 'vlib', mod_path)
+}
+
+// check for relative and then vlib
+pub fn (p &Preferences) get_module_path(mod string, importing_file_path string) string {
+	mod_path := mod.replace('.', os.path_separator)
+	// TODO: is this the best order?
+	// vlib
+	vlib_path := os.join_path(p.vroot, 'vlib', mod_path)
+	if os.is_dir(vlib_path) {
+		return vlib_path
+	}
+	// ~/.vmodules
+	vmodules_path := os.join_path(p.vmodules_path, mod_path)
+	if os.is_dir(vmodules_path) {
+		return vmodules_path
+	}
+	// relative to file importing it
+	relative_path := os.join_path(os.dir(importing_file_path), mod_path)
+	if os.is_dir(relative_path) {
+		return relative_path
+	}
+	panic('Preferences.get_module_path: cannot find module path for `${mod}`')
+}

--- a/vlib/v2/pref/pref.v
+++ b/vlib/v2/pref/pref.v
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module pref
+
+import os
+
+pub struct Preferences {
+pub mut:
+	debug        bool
+	verbose      bool
+	skip_genv    bool
+	skip_builtin bool
+	skip_imports bool
+	no_parallel  bool
+pub:
+	vroot         string = os.dir(@VEXE)
+	vmodules_path string = os.vmodules_dir()
+}
+
+pub fn new_preferences() Preferences {
+	return Preferences{}
+}
+
+pub fn new_preferences_using_options(options []string) Preferences {
+	return Preferences{
+		// config flags
+		debug: '--debug' in options || '-d' in options
+		verbose: '--verbose' in options || '-v' in options
+		skip_genv: '--skip-genv' in options
+		skip_builtin: '--skip-builtin' in options
+		skip_imports: '--skip-imports' in options
+		no_parallel: '--no-parallel' in options
+	}
+}

--- a/vlib/v2/scanner/scanner.v
+++ b/vlib/v2/scanner/scanner.v
@@ -1,0 +1,592 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module scanner
+
+import v2.token
+import v2.pref
+
+@[flag]
+pub enum Mode {
+	normal
+	scan_comments
+	skip_interpolation
+}
+
+pub struct Scanner {
+	pref               &pref.Preferences
+	mode               Mode
+	skip_interpolation bool
+mut:
+	file        &token.File = &token.File{}
+	src         string
+	insert_semi bool
+pub mut:
+	offset int // current char offset
+	pos    int // token offset (start of current token)
+	lit    string
+	// strings literals & interpolation
+	in_str_incomplete   bool
+	in_str_inter        bool
+	str_inter_cbr_depth int
+	str_quote           u8
+}
+
+pub fn new_scanner(prefs &pref.Preferences, mode Mode) &Scanner {
+	unsafe {
+		return &Scanner{
+			pref: prefs
+			mode: mode
+			skip_interpolation: mode.has(.skip_interpolation)
+		}
+	}
+}
+
+pub fn (mut s Scanner) init(file &token.File, src string) {
+	// reset since scanner instance may be reused
+	s.offset = 0
+	s.pos = 0
+	s.lit = ''
+	// s.in_str_incomplete = false
+	// s.in_str_inter = false
+	// s.str_inter_cbr_depth = 0
+	// init
+	s.file = unsafe { file }
+	s.src = src
+}
+
+@[direct_array_access]
+pub fn (mut s Scanner) scan() token.Token {
+	// before whitespace call to keep whitepsaces in string
+	// NOTE: before start: simply for a little more efficiency
+	// if !s.skip_interpolation && s.in_str_incomplete {
+	if s.in_str_incomplete {
+		s.in_str_incomplete = false
+		s.pos = s.offset
+		s.string_literal(false, s.str_quote)
+		s.lit = s.src[s.pos..s.offset]
+		return .string
+	}
+	start:
+	s.whitespace()
+	if s.offset == s.src.len {
+		s.lit = ''
+		if s.insert_semi {
+			s.insert_semi = false
+			return .semicolon
+		}
+		s.file.add_line(s.offset)
+		return .eof
+	}
+	c := s.src[s.offset]
+	s.pos = s.offset
+	preserve_insert_semi := s.insert_semi
+	s.insert_semi = false
+	if c == `\n` {
+		s.lit = ''
+		return .semicolon
+	}
+	// comment | `/=` | `/`
+	else if c == `/` {
+		c2 := s.src[s.offset + 1]
+		// comment
+		if c2 in [`/`, `*`] {
+			if preserve_insert_semi {
+				s.insert_semi = true
+			}
+			s.comment()
+			if !s.mode.has(.scan_comments) {
+				unsafe {
+					goto start
+				}
+			}
+			s.lit = s.src[s.pos..s.offset]
+			return .comment
+		}
+		// `/=`
+		else if c2 == `=` {
+			s.offset += 2
+			return .div_assign
+		}
+		s.offset++
+		// `/`
+		return .div
+	}
+	// number
+	else if c >= `0` && c <= `9` {
+		s.number()
+		s.lit = s.src[s.pos..s.offset]
+		s.insert_semi = true
+		return .number
+	}
+	// keyword | name
+	else if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c in [`_`, `@`] {
+		s.offset++
+		// NOTE: I have made `@[` a token instead of using `@` and `[` because `@`
+		// is not currently used as a token, and it is also easier to parse this way.
+		// if/when `@` becomes used as a token of it's own, then I may change this.
+		if c == `@` && s.src[s.offset] == `[` {
+			s.offset++
+			return .attribute
+		}
+		for s.offset < s.src.len {
+			c3 := s.src[s.offset]
+			if (c3 >= `a` && c3 <= `z`) || (c3 >= `A` && c3 <= `Z`)
+				|| (c3 >= `0` && c3 <= `9`) || c3 == `_` {
+				s.offset++
+				continue
+			}
+			break
+		}
+		s.lit = s.src[s.pos..s.offset]
+		tok := token.Token.from_string_tinyv(s.lit)
+		if tok in [.key_break, .key_continue, .key_none, .key_return, .key_false, .key_true, .name] {
+			s.insert_semi = true
+		}
+		return tok
+	}
+	// string
+	else if c in [`'`, `"`] {
+		s.offset++
+		if !s.in_str_inter {
+			s.str_quote = c
+		}
+		// TODO: I would prefer a better way to handle raw
+		s.string_literal(s.in_str_inter || s.src[s.offset - 2] == `r`, c)
+		s.lit = s.src[s.pos..s.offset]
+		s.insert_semi = true
+		return .string
+	}
+	// byte (char) `a`
+	else if c == `\`` {
+		s.offset++
+		// NOTE: if there is more than one char still scan it
+		// we can error at a later stage. should we error now?
+		for {
+			c2 := s.src[s.offset]
+			if c2 == c {
+				break
+			} else if c2 == `\\` {
+				s.offset += 2
+				continue
+			}
+			s.offset++
+		}
+		s.offset++
+		s.lit = s.src[s.pos + 1..s.offset - 1]
+		s.insert_semi = true
+		return .char
+	}
+	// s.lit not set, as tokens below get converted directly to string
+	// s.lit = c
+	s.lit = ''
+	s.offset++
+	match c {
+		`.` {
+			c2 := s.src[s.offset]
+			if c2 >= `0` && c2 <= `9` {
+				// TODO: only really need decimal
+				s.number()
+				s.lit = s.src[s.pos..s.offset]
+				return .number
+			} else if c2 == `.` {
+				s.offset++
+				if s.src[s.offset] == `.` {
+					s.offset++
+					return .ellipsis
+				}
+				return .dotdot
+			}
+			return .dot
+		}
+		`:` {
+			if s.src[s.offset] == `=` {
+				s.offset++
+				return .decl_assign
+			}
+			return .colon
+		}
+		`!` {
+			c2 := s.src[s.offset]
+			if c2 == `=` {
+				s.offset++
+				return .ne
+			} else if c2 == `i` {
+				c3 := s.src[s.offset + 1]
+				c4_is_space := s.src[s.offset + 2] in [` `, `\t`]
+				if c3 == `n` && c4_is_space {
+					s.offset += 2
+					return .not_in
+				} else if c3 == `s` && c4_is_space {
+					s.offset += 2
+					return .not_is
+				}
+			}
+			s.insert_semi = true
+			return .not
+		}
+		`=` {
+			c2 := s.src[s.offset]
+			if c2 == `=` {
+				s.offset++
+				return .eq
+			}
+			return .assign
+		}
+		`+` {
+			c2 := s.src[s.offset]
+			if c2 == `+` {
+				s.offset++
+				return .inc
+			} else if c2 == `=` {
+				s.offset++
+				return .plus_assign
+			}
+			return .plus
+		}
+		`-` {
+			c2 := s.src[s.offset]
+			if c2 == `-` {
+				s.offset++
+				return .dec
+			} else if c2 == `=` {
+				s.offset++
+				return .minus_assign
+			}
+			return .minus
+		}
+		`%` {
+			if s.src[s.offset] == `=` {
+				s.offset++
+				return .mod_assign
+			}
+			return .mod
+		}
+		`*` {
+			if s.src[s.offset] == `=` {
+				s.offset++
+				return .mul_assign
+			}
+			return .mul
+		}
+		`^` {
+			if s.src[s.offset] == `=` {
+				s.offset++
+				return .xor_assign
+			}
+			return .xor
+		}
+		`&` {
+			c2 := s.src[s.offset]
+			if c2 == `&` {
+				// so that we parse &&Type as two .amp instead of .and
+				// but this requires there is a space. we could check
+				// for capital or some other way, this is simplest for now.
+				if s.offset + 1 <= s.src.len && s.src[s.offset + 1] in [` `, `\t`] {
+					s.offset++
+					return .and
+				}
+			} else if c2 == `=` {
+				s.offset++
+				return .and_assign
+			}
+			return .amp
+		}
+		`|` {
+			c2 := s.src[s.offset]
+			if c2 == `|` {
+				s.offset++
+				return .logical_or
+			} else if c2 == `=` {
+				s.offset++
+				return .or_assign
+			}
+			return .pipe
+		}
+		`<` {
+			c2 := s.src[s.offset]
+			if c2 == `<` {
+				s.offset++
+				if s.src[s.offset] == `=` {
+					s.offset++
+					return .left_shift_assign
+				}
+				return .left_shift
+			} else if c2 == `=` {
+				s.offset++
+				return .le
+			} else if c2 == `-` {
+				s.offset++
+				return .arrow
+			}
+			return .lt
+		}
+		`>` {
+			c2 := s.src[s.offset]
+			if c2 == `>` {
+				s.offset++
+				c3 := s.src[s.offset]
+				if c3 == `>` {
+					s.offset++
+					if s.src[s.offset] == `=` {
+						s.offset++
+						return .right_shift_unsigned_assign
+					}
+					return .right_shift_unsigned
+				} else if c3 == `=` {
+					s.offset++
+					return .right_shift_assign
+				}
+				return .right_shift
+			} else if c2 == `=` {
+				s.offset++
+				return .ge
+			}
+			return .gt
+		}
+		`#` {
+			// if we choose to scan whole line
+			// s.line()
+			return .hash
+		}
+		// `@` { return .at }
+		`~` {
+			return .bit_not
+		}
+		`,` {
+			return .comma
+		}
+		`$` {
+			if s.in_str_inter {
+				return .str_dollar
+			}
+			return .dollar
+		}
+		`{` {
+			if s.in_str_inter {
+				s.str_inter_cbr_depth++
+			}
+			return .lcbr
+		}
+		`}` {
+			if s.in_str_inter {
+				s.str_inter_cbr_depth--
+				if s.str_inter_cbr_depth == 0 {
+					s.in_str_incomplete = true
+					s.in_str_inter = false
+				}
+			}
+			s.insert_semi = true
+			return .rcbr
+		}
+		`(` {
+			return .lpar
+		}
+		`)` {
+			s.insert_semi = true
+			return .rpar
+		}
+		`[` {
+			s.insert_semi = true
+			return .lsbr
+		}
+		`]` {
+			s.insert_semi = true
+			return .rsbr
+		}
+		`;` {
+			return .semicolon
+		}
+		`?` {
+			s.insert_semi = true
+			return .question
+		}
+		else {
+			return .unknown
+		}
+	}
+}
+
+// skip whitespace
+@[direct_array_access]
+fn (mut s Scanner) whitespace() {
+	for s.offset < s.src.len {
+		c := s.src[s.offset]
+		if c in [` `, `\t`, `\r`] {
+			s.offset++
+			continue
+		} else if c == `\n` {
+			if s.insert_semi {
+				return
+			}
+			s.offset++
+			s.file.add_line(s.offset)
+			continue
+		}
+		break
+	}
+	// s.insert_semi = false
+}
+
+@[direct_array_access]
+fn (mut s Scanner) line() {
+	// a newline reached here will get recorded by next whitespace call
+	// we could add them manually here, but whitespace is called anyway
+	for s.offset < s.src.len {
+		if s.src[s.offset] == `\n` {
+			break
+		}
+		s.offset++
+	}
+}
+
+@[direct_array_access]
+fn (mut s Scanner) comment() {
+	s.offset++
+	c := s.src[s.offset]
+	// single line
+	if c == `/` {
+		s.line()
+	}
+	// multi line
+	else if c == `*` {
+		s.offset++
+		mut ml_comment_depth := 1
+		for s.offset < s.src.len {
+			c2 := s.src[s.offset]
+			c3 := s.src[s.offset + 1]
+			if c2 == `\n` {
+				s.offset++
+				s.file.add_line(s.offset)
+			} else if c2 == `/` && c3 == `*` {
+				s.offset += 2
+				ml_comment_depth++
+			} else if c2 == `*` && c3 == `/` {
+				s.offset += 2
+				ml_comment_depth--
+				if ml_comment_depth == 0 {
+					break
+				}
+			} else {
+				s.offset++
+			}
+		}
+	}
+}
+
+@[direct_array_access]
+fn (mut s Scanner) string_literal(scan_as_raw bool, c_quote u8) {
+	// shortcut, scan whole string
+	if scan_as_raw {
+		for s.offset < s.src.len && s.src[s.offset] != c_quote {
+			s.offset++
+		}
+		s.offset++
+		return
+	}
+	// normal strings
+	for s.offset < s.src.len {
+		c := s.src[s.offset]
+		// escape `\\n` | `\'`
+		if c == `\\` {
+			s.offset += 2
+			continue
+		} else if c == `\n` {
+			s.offset++
+			s.file.add_line(s.offset)
+			continue
+		} else if c == `$` && s.src[s.offset + 1] == `{` {
+			s.in_str_inter = true
+			if s.skip_interpolation {
+				s.str_inter_cbr_depth++
+				s.offset += 2
+				continue
+			} else {
+				return
+			}
+		} else if s.skip_interpolation && s.in_str_inter {
+			if c == `{` {
+				s.str_inter_cbr_depth++
+			} else if c == `}` {
+				s.str_inter_cbr_depth--
+				if s.str_inter_cbr_depth == 0 {
+					s.in_str_inter = false
+				}
+			}
+		} else if c == c_quote && !s.in_str_inter {
+			s.offset++
+			break
+		}
+		s.offset++
+	}
+}
+
+@[direct_array_access]
+fn (mut s Scanner) number() {
+	if s.src[s.offset] == `0` {
+		s.offset++
+		c := s.src[s.offset]
+		// TODO: impl proper underscore support
+		// 0b (binary)
+		if c in [`b`, `B`] {
+			s.offset++
+			for {
+				c2 := s.src[s.offset]
+				if c2 in [`0`, `1`] || c2 == `_` {
+					s.offset++
+					continue
+				}
+				return
+			}
+		}
+		// 0x (hex)
+		else if c in [`x`, `X`] {
+			s.offset++
+			for {
+				c2 := s.src[s.offset]
+				if (c2 >= `0` && c2 <= `9`) || (c2 >= `a` && c2 <= `f`)
+					|| (c2 >= `A` && c2 <= `F`) || c2 == `_` {
+					s.offset++
+					continue
+				}
+				return
+			}
+		}
+		// 0o (octal)
+		else if c in [`o`, `O`] {
+			s.offset++
+			for {
+				c2 := s.src[s.offset]
+				if c2 >= `0` && c2 <= `7` {
+					s.offset++
+					continue
+				}
+				return
+			}
+		}
+	}
+	mut has_decimal := false
+	mut has_exponent := false
+	// TODO: proper impl of fraction / exponent
+	// continue decimal (and also completion of bin/octal)
+	for s.offset < s.src.len {
+		c := s.src[s.offset]
+		if (c >= `0` && c <= `9`) || c == `_` {
+			s.offset++
+			continue
+		}
+		// fraction
+		else if !has_decimal && c == `.` && s.src[s.offset + 1] != `.` {
+			has_decimal = true
+			s.offset++
+			continue
+		}
+		// exponent
+		else if !has_exponent && c in [`e`, `E`] {
+			has_exponent = true
+			s.offset++
+			continue
+		}
+		break
+	}
+}

--- a/vlib/v2/tests/advance.v_
+++ b/vlib/v2/tests/advance.v_
@@ -1,0 +1,37 @@
+module main
+
+fn main() {
+	a := 1
+	b := [1,2,3,4]
+	// c := b[0
+
+	if x == {} 
+
+	as_cast_a := sum_type_a as 
+	
+	if x == 100 {
+		
+	}
+
+	if y == 200 {
+		
+	}
+
+	// TODO: check line
+	// arr := [2]{}
+
+	
+
+	// for x in 1..10 {
+	// 	println(x)
+	// }
+}
+
+fn fn_a() ? {
+	
+}
+
+fn fn_b() {
+	a := 1
+	println('hello')
+}

--- a/vlib/v2/tests/generic_a.v_
+++ b/vlib/v2/tests/generic_a.v_
@@ -1,0 +1,15 @@
+module main
+
+struct StructA {}
+
+fn f[T](x T) {
+	d := x + x
+	println(d)
+}
+
+fn main() {
+	f(123)
+	f('abc')
+	// f(main)
+	f(StructA{})
+}

--- a/vlib/v2/tests/generic_fn.v_
+++ b/vlib/v2/tests/generic_fn.v_
@@ -1,0 +1,41 @@
+module main
+
+fn main() {
+	// generic_fn_a[int](1, 'hello')
+	// generic_fn_b[int, string](1, 'hello')
+	// generic_fn_a(1, 'hello')
+	generic_fn_b(1, 'hello')
+	generic_fn_c(['foo'], {'a': 'apple', 'b': 'bananna'})
+	generic_fn_d(fn(int, string) {
+		println(1)
+	})
+	generic_fn_e(fn(int, fn(map[string]string) string) {
+		println(1)
+	})
+}
+
+// fn generic_fn_a[T](param_a T, param_b string) {
+// 	println(param_a)
+// 	println(param_b)
+// }
+
+fn generic_fn_b[T,Y](param_a T, param_b Y) {
+	a := []T{}
+	b := map[T]int{}
+	c := map[T]Y{}
+	dump(a)
+	dump(b)
+	dump(c)
+}
+
+fn generic_fn_c[T,Y](param_a []T, param_b map[Y]T) {
+	println(param_a)
+}
+
+fn generic_fn_d[T,Y](param_a fn(T, Y)) {
+	println(param_a)
+}
+
+fn generic_fn_e[T,Y]( fn(T, fn(map[Y]Y) Y) ) {
+	println(param_a)
+}

--- a/vlib/v2/tests/if_a.v
+++ b/vlib/v2/tests/if_a.v
@@ -1,0 +1,23 @@
+module main
+
+type Expr = Ident | SelectorExpr
+
+struct Ident {
+	name string
+}
+
+struct SelectorExpr {
+	lhs Expr
+	rhs Expr
+	// op  int
+}
+
+fn main() {
+	a := Ident{
+		name: 'foo'
+	}
+	node := Expr(a)
+	if a.name == 'bar' {
+	} else if node !in [Ident, SelectorExpr] {
+	}
+}

--- a/vlib/v2/tests/selector_expr.v
+++ b/vlib/v2/tests/selector_expr.v
@@ -1,0 +1,32 @@
+module main
+
+struct StructA {
+	name string  = 'struct a'
+	b    StructB = StructB{}
+}
+
+struct StructB {
+	name string  = 'struct b'
+	c    StructC = StructC{}
+}
+
+struct StructC {
+	name string  = 'struct c'
+	d    StructD = StructD{}
+}
+
+struct StructD {
+	name string  = 'struct d'
+	e    StructE = StructE{}
+}
+
+struct StructE {
+	name string = 'struct e'
+}
+
+fn main() {
+	a := StructA{}
+	e := a.b.c.d.e
+	println(e.name)
+	println(a.b.c.d.e.name)
+}

--- a/vlib/v2/tests/string_interpolation.v
+++ b/vlib/v2/tests/string_interpolation.v
@@ -1,0 +1,20 @@
+module main
+
+fn test_main() {
+	string_literal_raw_a := r'raw string Literal b'
+	string_literal_inter_a := 'a == abc${a:2f} && and b == abc${b}...'
+	string_literal_inter_b := '${@MOD}.${@METHOD} - ${fn_call(unsafe { 1 })}'
+	string_literal_inter_c := '${mod.fn_call(1)} | ${mod.fn_call('a').join(' ')} > out'
+	// NOTE: d) tests nested quotes of same kind (although why is this allowed?)
+	string_literal_inter_d := '${mod.fn_call(1)} | ${mod.fn_call(unsafe { 1 }, mod.fn_call('a')).join(' ')} > out'
+	string_literal_inter_e := '${mod.fn_call(1)} | ${mod.fn_call(mod.fn_call('a')).join(' ')} > out'
+	// TODO: remember to talk to alex to confirm behaviour of nested strings
+	// x := 'hello ${foo('${x}')} ${x}'
+}
+
+fn test_basic() {
+	pi := 3.14159265359
+	pi_name := 'Pi'
+	pi_symbol := `π`
+	pi_description := '${pi_name} (${pi_symbol}) is a mathematical constant that is the ratio of a circle\'s circumference to its diameter, approximately equal ${pi:.5}.'
+}

--- a/vlib/v2/tests/syntax.v_
+++ b/vlib/v2/tests/syntax.v_
@@ -1,0 +1,670 @@
+// this file is just to test the scanner & parser so there may
+// be a bunch of stuff in here that does not really make sense
+/* multi
+   line
+   comment */
+/*// nested comment a */
+/* // nested comment b */
+/*/* nested comment c */*/
+[has_globals]
+module main
+
+import mod_a
+import mod_b.submod_a
+import mod_c { sym_a, TypeA, TypeB[T] }
+
+#include <header_a.h>
+#flag -L lib_a
+__global (
+	global_a string
+	global_b = 'global_b_value'
+)
+
+const (
+	const_a = 1
+	const_b = 'two'
+)
+// we don't want this parsed as `TypeA[unsafe]`
+__global global_before_fn_with_attr_a TypeA
+
+[unsafe]
+pub fn fn_with_attr_after_global_a() {}
+
+type AliasA = int
+type SumTypeA = StructA | int | string | []string
+
+pub type OptionalA = ?int
+
+pub type DatabasePool[T] = fn (tid int) T
+
+pub type C.BOOL = bool 
+
+// we don't want this to be parsed as:
+// `type FnA = fn() fn...`
+type FnA = fn()
+fn fn_after_type_fn_a() int {}
+// we don't want this to be parsed as:
+// `type FnA = fn() ?fn...`
+type FnB = fn() ?
+fn fn_after_type_fn_b() int {}
+
+pub const const_array_followed_by_attribute_a = ['a', 'b']
+[attribute_after_array_init]
+fn fn_with_attribute_after_array_init() { println('v') }
+
+[attribute_a]
+@[attribute_b]
+enum EnumA {
+	value_a     [json: 'ValueA']
+	value_b     @[json: 'ValueB']
+	// NOTE: will not work with old attribute syntax due to ambiguity
+	value_c = 2 @[json: 'ValueC']
+}
+
+enum EnumB as u16 {
+	value_a
+	value_b
+}
+
+[attribute_a: 'attribute_a_val'; attribute_b]
+@[attribute_c: 'attribute_c_val']
+@[attribute_d]
+['/product/edit'; post]
+struct StructA {
+	field_a int
+	field_b string
+	field_c fn(int) int
+	field_d string = 'foo'
+	field_e int = 1 + 2 + (4*4)
+	// NOTE: will not work with old attribute syntax due to ambiguity
+	field_f string = 'bar' @[attribute_a; attribute_b]
+	field_g int = 111 @[attribute_a; attribute_b]
+	field_h int = field_h_default() @[attribute_a]
+}
+
+fn StructA.static_method_a() int {
+	return 1
+}
+
+// TODO: modifiers
+struct StructB {
+	StructA // embedded
+mut:
+	field_a int    [attribute_a: 'value_a']
+	field_b string @[attribute_b: 'value_b']
+	field_c struct {
+		field_a string
+		field_b int = 1
+	}
+}
+
+struct StructC {
+	StructA
+	foo.StructA
+mut: // TODO: modifiers
+	field_a int
+	field_b string
+}
+
+struct StructD {
+	field_a shared int
+	field_b shared []int = [0]
+}
+
+struct StructD {
+	field_a ?&StructD
+}
+
+struct C.StructA {}
+
+interface InterfaceA {
+	field_a string
+	method_a() string
+	method_b(string) string
+}
+
+// TODO: modifiers
+interface InterfaceB {
+	InterfaceA // embedded
+mut:
+	method_a(string) string
+}
+
+interface InterfaceGenericA[T] {
+	field_a T
+}
+
+fn C.external_fn_a(arg_a int) int
+
+__global total_m = 0
+[unsafe]
+fn fn_with_comment_and_attribute_a() {}
+
+[attribute_a: 'attribute_a_val'; attribute_b]
+[attribute_c: 'attribute_c_val']
+[attribute_d]
+fn fn_a(arg_a string, arg_b int) int {
+	println('fn_a($arg_a, $arg_b)')
+	return 1
+}
+
+// TODO: error on missing name/type
+// fn fn_b(arg_a string, arg_b, arg_c, arg_d int) int {
+fn fn_b(arg_a string, arg_b int, arg_c int, arg_d int) int {
+	println('fn_b($arg_a, $arg_b, $arg_c, $arg_d)')
+	return 1
+}
+
+fn fn_c(arg_a [][]StructA, arg_b [4]StructA) [][]StructA {
+	println('fn_b($arg_a, $arg_b)')
+	return arg_a
+}
+
+fn fn_d(arg_a GenericStructA[int], arg_b moda.GenericStructA[int]) {
+	println('fn_d($arg_a, $arg_b)')
+}
+
+fn C.fn_d(GenericStructA[int], moda.GenericStructA[int])
+
+fn fn_optional_a() ?int {
+	return 1
+}
+
+fn fn_optional_b() ?int {
+	return fn_optional_a()?
+}
+
+fn fn_optional_c() ?&StructD {
+	a := StructD{
+		field_a: &StructD{}
+	}
+	dump(a.field_a)
+	dump(a.field_a?.field_a)
+	assert a.field_a?.field_a == none
+	return a.field_a?
+}
+
+fn fn_opt_c() ?int {
+	return fn_optional_a()!
+}
+
+fn fn_result_a() ! {
+	return 1
+}
+
+fn fn_result_b() !int {
+	return 1
+}
+
+
+fn fn_multi_return_a() (int, int) {
+	return 1,2
+}
+
+fn fn_multi_return_optional_a() ?(int, int) {
+	return 1,2
+}
+
+fn fn_variadic_a(arg_a int, arg_b ...string) {
+	fn_variadic_b(...arg_b)
+	fn_variadic_b(...['a', 'b', 'c', 'd'])
+}
+
+fn fn_variadic_b(arg_a ...string) {
+	println(arg_a)
+}
+
+fn fn_arg_struct_int_a(arg_a StructA, arg_b int) {
+	println(arg_a)
+}
+
+fn (rec &StructA) method_a(arg_a string, arg_b int) int {
+	println('StructA.method_a($arg_a, $arg_b)')
+	return 1
+}
+
+// TODO: operator overload (last missing parser feature, I think :D)
+pub fn (a StructA) == (b StructA) bool {
+	return a.field_a == b.field_a
+}
+
+fn channel_test(arg_a chan string) {
+	ch := chan int{cap: 20}
+	ch <- 111
+	rec := <-ch
+}
+
+fn spawn_test() {
+	t := spawn fn() {
+		for i in 0..100 {
+			println('$i...')
+		}
+	}()
+	t.wait()
+}
+
+fn fn_result_a() !int {
+	array_a := [1,2,3,4]
+	return  array_a[0]!
+}
+
+fn main_a() {
+	a := 1
+	b, c := 1, 2
+	array_init_a := [1,2,3,4]
+	array_init_b := [1,2,3,4]!
+	array_init_c := [array_init_a]
+	array_init_d := []string{len: 2, cap: 2}
+	array_init_e := [][]string{}
+	array_init_f := [2][]int{init:[1]}
+	array_init_g := [2][][][][]int{}
+	array_init_h := [2][][][][2]int{}
+	// TODO: better error for missing `]`
+	// array_init_i := [['a','b','c','d']
+	array_init_i := [['a','b','c','d']]
+	array_init_j := []&StructA{}
+	array_init_k := [fn(arg_a int) int { return 1 }]
+	array_init_i := [fn() int { return 1 }()]
+	array_init_thread_a := []thread int{cap: 16}
+	expr_a expr_b // TODO: error ?
+	expr_a; expr_b // TODO: error
+	map_init_long_string_string := map[string]string{}
+	map_init_long_string_array_string := map[string][]string{}
+	mut map_init_short_string_string := {'key_a': 'value_a'}
+	map_init_short_string_string = {} // test empty
+	map_init_short_string_array_string := {'key_a': ['value_a', 'value_b']}
+	map_init_short_ident_string := {key_a: 'value_a'} // unsupported key type
+	mut map_init_short_enum_value_init_expr := map[EnumA]StructA{}
+	// make sure we don't chain `StructA{field_a: 1}.value_b` as SelectorExpr
+	map_init_short_enum_value_init_expr = {
+		.value_a: StructA{
+			field_a: 1
+		}
+		.value_b: StructA{
+			field_a: 1
+		}
+		.value_c: StructA{
+			field_a: 1
+		}
+	}
+	struct_init_a := StructA{field_a: 1, field_b: 'v'}
+	struct_init_b := foo.StructA{field_a: 1, field_b: 'v'}
+	struct_init_c := StructA{1, 'v'}
+	// NOTE: no longer supported. will error
+	// assoc_old_a := {struct_a|field_a: 111}
+	// assoc_old_b := {
+	// 	...struct_a
+	// 	field_a: 1
+	// }
+	assoc_current_a := StructA{
+		...struct_a
+		// field_a: 1
+	}
+	string_literal_v_a := 'string literal a'
+	string_literal_v_b := "string literal b"
+	string_literal_c_a := c'c string literal a'
+	string_literal_raw_a := r'string $literal raw a'
+	thred_init_a := thread int{cap: 20}
+	call_a := fn_a('string', 1)
+	call_b := fn_b('string', 1, a, b)
+	call_c := array_init_g[0](1)
+	call_d := struct_a.method_a('string', 1)
+	call_e := struct_a.field_c(1)
+	call_f := array_init_k[0]()
+	call_g := array_init_k[fn() { return 0 }()]()
+	call_h := array_init_k[array_init_b[0]]()
+	call_config_syntax_a := fn_arg_struct_int_a(field_a: 1, field_b: 'b', 2)
+	call_lambda_expr_a := array_init_a.sorted(|x,y| x > y)
+	call_lambda_expr_b := f(|| 1)
+	call_selector_a := 'hello v world'
+		.split(' v ')
+		.join(' ')
+	call_comptime_a := $fn_a('string', 1)
+	// comptime call as expr stmt only
+	$fn_a('string', 1)
+	$compile_warn('compile warn')
+	cast_a := u8(1)
+	cast_b := &[]u8([1,2,3,4])
+	// the following casts should error later about not being
+	// able to cast array types, unless it gets implemented.
+	cast_c := []u8([1,2,3,4])
+	cast_d := [][][]u8([[[1,2,3,4]]])
+	cast_d := ?&?int(a)
+	fn_literal_a := fn(param_a int, param_b int) int {
+		return param_a+param_b
+	}
+	fn_literal_call_a := fn_literal_a(2, 4)
+	fn_literal_direct_call_a := fn(param_a int, param_b int) int {
+		return param_a+param_b
+	}(2, 4)
+	fn_literal_capturing_vars_a := fn [infix_a, infix_b] (param_a int, param_b int) int {
+		return (infix_a+infix_b)*(param_a+param_b)
+	}
+	fn_literal_capturing_vars_direct_call_a := fn [infix_a, infix_b] (param_a int, param_b int) int {
+		return (infix_a+infix_b)*(param_a+param_b)
+	}(2, 4)
+	index_a := array_init_a[0]
+	index_a := array_init_a[a]
+	index_b := struct_a.field_b[1]
+	index_c := [StructA{}][0] // direct index after init
+	index_d := [[1,2,3,4]][0][1] // unlimited chaining (add more examples)
+	index_e := [fn() []StructA { return [fn() []StructA { return [StructA{}] }()][0] }()[0]][0] // more chaining
+	index_f := fn() []string { return ['a', 'b'] }()[0]
+	index_g := array_init_e[0] or { ['e', 'f'] }[0]
+	index_range_a := array_init_a[0..2]
+	index_range_b := array_init_a[2..]
+	index_range_c := array_init_a[..2]
+	index_range_d := array_init_a[1+2..1+2]
+	index_range_e := array_init_a[1+2..]
+	index_range_f := array_init_a[..1+2]
+	index_range_g := array_init_a[1+2...1+2]
+	index_range_h := array_init_a[1+2...]
+	index_range_i := array_init_a[...1+2]
+	index_range_j := [[1,2,3,4]][0][2..4]
+	index_range_k := [[1,2,3,4]][0][2...4]
+	index_or_a := array_init_a[0] or { 1 }
+	index_or_b := array_init_c[0] or { [5,6,7,8] }[0]
+	index_or_c := fn() []int { return [array_init_a[0] or { 1 }] }()[0] or { 1 }
+	index_or_d := match index_a {
+		int { array_init_a }
+		else { [5,6,7,8] }
+	}[0] or { 1 }
+	infix_a := 1 * 2
+	infix_b := 1 + 2 * 3 / 4 + 5
+	infix_c := infix_a * 4 * 2 + 11 / 2
+	infix_d := a == b && c == d
+	infix_and_paren_expr_a := ((((infix_b + 1) * 2) + 111) * 2) / 2
+	infix_and_paren_expr_b := (((((x * array_init_a[0] +
+		array_init_a[1]) * x + array_init_a[2]) * x + array_init_a[3]) * x +
+		array_init_a[4]) * x + array_init_a[5]) * x + array_init_a[6]
+	prefix_a := &StructA{}
+	prefix_b := &&StructA{}
+	prefix_c := -infix_a + 2
+	prefix_optional_a := ?mod_a.StructA{}
+	prefix_optional_b := ?mod_a.StructA(none)
+	assert a == 1
+	assert a == 1, 'a does not equal 1'
+	assert c <= 2, 'c is greater than 2'
+	if val := array_init_a[0] {
+		println(val)
+	}
+	if res_a := fn_optional_a() {
+		println('if guard: $res_a')
+	}
+	if res_a, res_b := fn_multi_return_optional_a() {
+		println('if guard: $res_a, $res_b')
+	}
+	if res_a, res_b := fn_optional_a(), fn_optional_b() {
+		println('if guard: ${res_a}, ${res_b}')
+	}
+	if err == IError(MyError{}) {
+		println('err == IError(MyError{})')
+	}
+	if struct_init_a == (StructA{}) {
+		println('struct_init_a == (StructA{})')
+	}
+	// TODO: tricky
+	// if struct_init_a == StructA{} {
+	// 	println('struct_init_a == StructA{}')
+	// }
+	// if StructA{} == StructA{} {
+	// 	println('StructA{} == StructA{}')
+	// }
+	// if struct_init_a is StructA {
+	// 	println(1)
+	// }
+	if struct_init_a is []StructA {
+		println(1)
+	}
+	if a == 1 {
+		println('1 a == $s')
+	}
+	else if a == 2 {
+		println('2 a == $s')
+	}
+	else {
+		println('a == $s')
+	}
+	if (if a > 0 {
+		1
+	} else {
+		2
+	}) < 2 {
+		println('if expr in if cond < 2')
+	}
+	if a > 0 { StructA{} } else { StructB{} }.method_a()
+	$if linux {
+		println('linux')
+	}
+	$else $if windows {
+		println('windows')
+	}
+	$else {
+		println('other')
+	}
+	$if option_a ? {
+		println('custom option: `v -d option_a`')
+	}
+	$if T is $array {
+		println('T is array')		
+	}
+	$else $if T is $struct {
+		println('T is struct')		
+	}
+	$if T in [?int, ?int] {
+		println('option int')
+	}
+	for val_a in array_init_a {
+		println(val_a)
+	}
+	// TODO: error (unless first 2 are allowed? 0..10 and 0..infinity)
+	// the third one definitely needs to error
+	// for val_a in ..10 {}
+	// for val_a in 0.. {}
+	// for val_a in .. {}
+	for val_a in 0..10 {
+		println(val_a)
+	}
+	for key_a, val_a in array_init_a {
+		println(key_a)
+		println(val_a)
+	}
+	for key_a, mut val_a in array_init_a {
+		println(key_a)
+		println(val_a)
+	}
+	for idx_a in 0 .. a + 1 {
+		println(idx_a)
+	}
+	for key, value in {
+		'a': 'apple'
+		'b': 'bananna'
+	} {
+		println('${key}: ${value}')
+	}
+	for mut left_node is ast.InfixExpr {
+		if left_node.op == .and && mut left_node.right is ast.InfixExpr {
+			if left_node.right.op == .key_is {
+				println('xx')
+			}
+		}
+	}
+	for a:=0; a<=100; a++ {
+		println(a)
+	}
+	for mut a:=0; a<=100; {
+		a++
+		println(a)
+	}
+	for a, b := 0, 1; a < 4; a++ {
+		println('$a - $b')
+	}
+	for a, b, c, d := 0, 1, 2, 3; a < 4; a++ {
+		println('$a - $b')
+	}
+	// currently erroring in this case
+	// for a := 1 {}
+	for ; x < 100; {
+		println(x)
+	}
+	for x < 100 {
+		println(x)
+	}
+	for ; ; {
+		println('infinite loop')
+	}
+	for {
+		println('infinite loop')
+	}
+	$for x == 1 {
+		println('comptime for')
+	}
+	$for field in U.fields {
+		// TODO: parser needs to handle
+		// currently just skipping past
+		if val.$(field.name).str() != 'Option(none)' {
+			fields_len++
+		}
+	}
+	for_label_a: for i := 4; true; i++ {
+		println(i)
+		for {
+			if i < 7 {
+				continue for_label_a
+			} else {
+				break for_label_a
+			}
+		}
+	}
+	// fn literals
+	// capture list & generic params
+	fn [a, b] [T] () {
+		println('captured vars: ${a}, ${b}')
+	}[int]()
+	// capture list only
+	fn [a, b] () {
+		println('captured vars: ${a}, ${b}')
+	}()
+	// generic params only
+	fn [T] () {
+		println(typeof(T))
+	}[int]()
+	sumtype_a := SumTypeA(111)
+	as_cast_a := sumtype_a as int
+	// NOTE: or for as is not currently supported
+	// I may remove it unless supported is added
+	as_cast_b := sumtype_a as int or {
+		println('cast error')
+	}
+	match sumtype_a {
+		StructA { println('StructA') }
+		int { println('int') }
+		string { println('string') }
+		[]string { println('[]string') }
+	}
+	mut ptr_a := &voidptr(0)
+	unsafe {
+		*ptr_a = 0
+		(*ptr_a) = *ptr_a - 1
+		((*ptr_a)) = *ptr_a - 1
+		*(ptr_a) = *ptr_a - 1
+		*((ptr_a)) = *ptr_a - 1
+		(*(ptr_a)) = *ptr_a - 1
+	}
+	mut ptr_b := &voidptr(0)
+	unsafe {
+		*ptr_b = 0
+	}
+	unsafe_a := unsafe { mut d := 1 d++ d }
+	unsafe_a := unsafe { mut d := 1; d++; d }
+	unsafe_b := unsafe {
+		mut d := 1
+		d++
+		d
+	}
+	shared array_int_shared_a := []int{}
+	shared array_string_shared_a := []String{}
+	lock {
+		array_int_shared_a << 1
+		array_int_shared_a << 2
+	}
+	lock array_string_shared_a {
+		array_string_shared_a << 'a'
+		array_string_shared_a << 'b'
+	}
+	lock array_int_shared; rlock array_string_shared {
+		array_int_shared << 3
+		println(array_string_shared[0])
+	}
+	lock a,b; rlock c,d; lock e,f; rlock g,h {
+		println('silly lock test')
+	}
+	fn_a('string', unsafe {*ptr_a})
+	{
+		block_test_a := 1
+	}
+
+	ch_a := chan int{}
+	_ = <-ch_a or {
+		println('channel closed')
+	}
+	select {
+		a := <-ch_a
+		b := <-ch_a { b+=2 }
+		c := <-ch_a or {
+			panic('channel closed')
+		}
+		500 * time.millisecond {
+			eprintln('> more than 0.5s passed without a channel being ready')
+		}		
+	}
+	__asm {
+	    ldrex   tmp, [addr]
+	    strex   tmp, value, [addr]
+	}
+	sql := 'test_ident_named_sql'
+	db_a := sqlite.connect('db_a') or {
+		panic('could not connect to db: ${err}')
+	}
+	nr_items := sql db {
+		select count from items
+	}
+	users := sql db {
+		select from User where name == 'first${user_suffix}'
+	}
+
+	// REMOVE BELOW - TEMP TESTING OR MOVE TO APPRIPRIATE PLACE ABOVE
+
+	x.member.free()
+	x.member.submember1.free()
+	x.member.submember1.submember2.free()
+	x.y = cmdline.option(current_args, arg, '10').int()
+	x.y = cmdline.option(current_args, arg, 
+	'10').int()
+
+	assert 'href="${url('/test')}"' == 'href="/test.html"'
+	assert '"${show_info('abc')}"' == '"abc"'
+
+	// TODO: confirm there are no cases where
+	// there is ambiguity with `|` infix expr
+	// lines_indents := lines
+	//     .filter(|line| !line.is_blank())``
+	//     .map(|line| line.indent_width())
+
+	// TODO: 
+	for mut x is MyType {
+		println(x)
+	}
+
+	ms := t.swatches[name].elapsed().microseconds()
+
+	if !v.pref.is_bare && v.pref.build_mode != .build_module &&
+		v.pref.os in [.linux, .freebsd, .openbsd, .netbsd, .dragonfly, .solaris, .haiku] {
+	}
+
+	rng.shuffle[T](mut res, config_)!
+
+
+	link_cmd := '${call(it.replace('.c',
+		'.o')).join(' ')}'
+}

--- a/vlib/v2/tests/syntax_ambiguities.v_
+++ b/vlib/v2/tests/syntax_ambiguities.v_
@@ -1,0 +1,21 @@
+// this file is just to test the parser so there may be a
+// bunch of stuff in here that does not really make sense
+
+const len_a = 6
+struct StructA {
+	// NOTE: ideally attributes would not use `[]`
+	// it would eliminate these issues completely. 
+
+	// ambiguous: return `!` followed by attribute or
+	// result w/ fixed array `![attribute_a]func_b`?
+	// rely on newline and space between `!` and `[`,
+	// or check later if we are using a var or const?
+	// try eliminate this type of thing from the syntax.
+	// TODO/FIXME: currently broken, must fix.
+	func_a fn() ! [attribute_a]
+	// this is fine
+	func_b fn() ![len_a]u8
+
+	// fixed - parse as attribute, not as index of `'foo'`
+	field_c string = 'foo' [attribute_a]
+}

--- a/vlib/v2/tests/syntax_generics.v_
+++ b/vlib/v2/tests/syntax_generics.v_
@@ -1,0 +1,89 @@
+// this file is just to test the parser so there may be a
+// bunch of stuff in here that does not really make sense
+module main
+
+struct GenericStructA[T] {
+	field_a T
+}
+
+struct GenericStructB[T,U] {
+	field_a T
+	field_b U
+}
+
+fn fn_generic_a[T](param_a T, param_b string, param_c int) int {
+	println('fn_generic_a: $param_a.type, $param_b.type, $param_c.type')
+	return 1
+}
+
+fn fn_generic_b[T,Y](param_a T, param_b Y) int {
+	println('fn_generic_a: $param_a.type, $param_b.type')
+}
+
+fn fn_generic_c[fn[U,I](U, I) U, Y](param_a T, param_b Y) int {
+	println('fn_generic_c')
+	return 1
+}
+
+fn test_generic_struct_init() {
+	a := GenericStructA[int] {
+		field_a: 1
+	}
+}
+
+fn fn_generic_init_a[T](param_a T) {
+	// TODO: infer correct init after type checking
+	// eg. array, chan, map, or struct init.
+	mut a := T{}
+	for k, v in param_a {
+		a[k] = v
+	}
+	println(a)
+}
+
+fn test_generic_init() {
+	fn_generic_init_a[map[string]string]({'a': 'apple'})
+}
+
+// assoc works with generic structs although
+// this will probably never be supported or used
+fn test_generic_assoc() {
+		struct_a := GenericStructB[int,int]{field_a: 1, field_b: 2}
+		assoc_struct_b := GenericStructB[int,int]{
+		...struct_b
+		field_a: 10
+		field_b: 20
+	}
+}
+
+fn test_generic_call() {
+	call_generic_a := fn_generic_a[GenericStructA](GenericStructA{}, 'string', 1)
+	fn_generic_b[int,int](1,2)
+}
+
+fn test_generic_complex_or_nested() {
+	fn_generic_c[fn[U,I](U, I) U, I](fn[U,I](param_a U, param_b I) U {}, 1)
+
+	fn_generic_b[GenericStructA[Y],int](GenericStructA[int]{}, 1)
+	fn_generic_b[GenericStructA[Y],GenericStructA[Y]](GenericStructA[int]{}, 1)
+	struct_a := GenericStructA[int]{field_a: 1}
+
+	fn_generic_b[[]string,map[string]string{}](1, 1) // TODO: error
+
+	fn_a := fn(param_a string, param_b int, param_c int) {}
+	fn_b := fn(param_a string, param_b int, param_c int) {}
+	fn_c := fn(param_a string, param_b int, param_c int) {}
+	fn_a('a', a < b, a < b, c)
+	fn_a('a', foo: a < b, a < b, c)
+	fn_b('a', fn_generic_c[fn[T,Y](int),int](1))
+	fn_b('a', fn_generic_c[fn[T,Y](int),int](a < if (fn_generic_b[int,int](1,2) > 2) { 1 } else { 2 }, 2), 1)
+	fn_b('a', moda.fn_generic_b[fn[T,Y](int),int](a < if (fn_generic_b[int,int](1,2) > 2) { 1 } else { 2 }, 2), fn_generic_b[int,int](1,2))
+	fn_b('a', modb.submodb.fn_generic_b[int,int](fn_generic_b[int,int](fn_generic_b[int,int](1,2) < (fn_generic_b[int,int](1,2) - 2), 2)),fn_generic_b[int,int](1,2))
+	
+	fn_c(fn_generic_b[GenericStructB[int,int]](GenericStructB<int>{}, 1), moda.fn_generic_b[GenericStructB[int,int]](GenericStructB[int]{}, 1))
+	fn_c(a < fn_generic_b[GenericStructB[GenericStructA[int],int]](GenericStructB[int]{}, 1), moda.fn_generic_b[GenericStructB[int,int]](GenericStructB<int>{}, 1))
+	
+	// return if x < 64 { fn_generic_b[int,int](1,2) } else { fn_generic_b[int,int](1, 2) < (fn_generic_b[int,int](1, 2) - 2) }
+	return fn_generic_b[int,int](1, 2) < b, c > d, e < f, g > h, fn_generic_b[int,int](fn_generic_b[int,int](fn_generic_b[int,int](1, 2), 2), 2) > j, k < l, m
+}
+

--- a/vlib/v2/tests/typeof.v_
+++ b/vlib/v2/tests/typeof.v_
@@ -1,0 +1,135 @@
+module main
+
+fn test_typeof_fn() {
+	assert typeof(fn (s string, x u32) (int, f32)).name == 'fn (string, u32) (int, f32)'
+}
+
+fn test_typeof_fn_literal() {
+	assert typeof(fn (i int) int {return i+1}).name == 'TODO' 
+}
+
+fn test_typeof_int() {
+	assert typeof(int).idx == 7
+	assert typeof(int).name == 'int'
+}
+
+fn test_typeof_u32() {
+	assert typeof(u32).idx == 12
+	assert typeof(u32).name == 'u32'
+}
+
+fn test_typeof_string() {
+	assert typeof(string).idx == 20
+	assert typeof(string).name == 'string'
+
+	assert typeof[string]().idx == 20
+}
+
+fn test_typeof_optional_type() {
+	assert typeof(?string).name == '?string'
+}
+
+fn test_typeof_result_type() {
+	assert typeof(!string).name == '!string'
+}
+
+fn test_typeof_array_type() {
+	assert typeof([]string).name == '[]string'
+	assert typeof(['a', 'b']).name == '[]string'
+}
+
+fn test_typeof_array_index() {
+	assert typeof(['a', 'b'][0]).name == 'string'
+}
+
+fn test_typeof_map_type() {
+	assert typeof(map[string]int).name == 'map[string]int'
+}
+
+fn test_typeof_nil() {
+	assert typeof(nil).name == 'nil'
+}
+
+fn test_typeof_none() {
+	assert typeof(none).name == 'none'
+}
+
+fn test_typeof_pointer() {
+	assert typeof(&string).name == '&string'
+}
+
+//
+
+struct MyStruct {}
+
+struct MyGenericStruct[T] {}
+
+struct MyGenericStruct2[T, U] {}
+
+fn test_typeof_struct_type() {
+	assert typeof(MyStruct).name == 'MyStruct'
+	assert typeof(MyGenericStruct).name == 'MyGenericStruct'
+	assert typeof(MyGenericStruct[int]).name == 'MyGenericStruct<int>'
+	assert typeof(MyGenericStruct[string]).name == 'MyGenericStruct<string>'
+	assert typeof(MyGenericStruct2).name == 'MyGenericStruct2'
+	assert typeof(MyGenericStruct2[string, int]).name == 'MyGenericStruct2<string, int>'
+}
+
+//
+
+union MyUnion {
+	x int
+	s string
+}
+
+fn test_typeof_union_type() {
+	assert typeof(MyUnion).name == 'MyUnion'
+}
+
+//
+
+type Abc = int | string
+
+fn test_typeof_sumtype() {
+	assert typeof(Abc).name == 'Abc'
+}
+
+//
+
+enum EFoo {
+	a
+	b
+	c
+}
+
+fn test_typeof_enum() {
+	assert typeof(EFoo).name == 'EFoo'
+}
+
+//
+
+type AnAlias = int
+
+fn test_typeof_alias() {
+	assert typeof(AnAlias).name == 'AnAlias'
+}
+
+//
+
+fn abc[T](x T) string {
+	return typeof(T).name
+}
+
+fn test_typeof_generic_type() {
+	assert abc<int>(123) == 'int'
+	assert abc<string>('xyz') == 'string'
+}
+
+//
+
+fn test_typeof_idx_comparison() {
+	i := 123
+	u := u32(5)
+	assert typeof(int).idx == typeof(i).idx
+	assert typeof(u32).idx == typeof(u).idx
+}

--- a/vlib/v2/token/position.v
+++ b/vlib/v2/token/position.v
@@ -1,0 +1,204 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module token
+
+import sync
+
+// TODO: finish fileset / file / base pos etc
+
+// compact encoding of a source position within a file set
+type Pos = int
+
+pub struct Position {
+pub:
+	filename string
+	offset   int
+	line     int
+	column   int
+}
+
+pub fn (p Position) str() string {
+	return '${p.filename}:${p.line}:${p.column}'
+}
+
+pub struct File {
+pub:
+	name string
+	base int
+	size int
+mut:
+	line_offsets []int = [0] // start of each line
+}
+
+pub struct FileSet {
+mut:
+	base int = 1 // reserve 0 for no position
+	// files shared []&File
+	files []&File
+	mu    &sync.Mutex = sync.new_mutex()
+}
+
+pub fn FileSet.new() &FileSet {
+	return &FileSet{}
+}
+
+// TODO:
+pub fn (mut fs FileSet) add_file(filename string, base_ int, size int) &File {
+	//	eprintln('>>> add_file fs: ${voidptr(fs)} | filename: $filename | base_: $base_ | size: $size')
+	fs.mu.@lock()
+	defer {
+		fs.mu.unlock()
+	}
+	mut base := if base_ < 0 { fs.base } else { base_ }
+
+	// eprintln('>>> add_file fs: ${voidptr(fs)} | base: ${base:10} | fs.base: $fs.base | base_: ${base_:10} | size: ${size:10} | filename: $filename')
+
+	if base < fs.base {
+		panic('invalid base ${base} (should be >= ${fs.base}')
+	}
+	file := &File{
+		name: filename
+		base: base
+		size: size
+	}
+	if size < 0 {
+		panic('invalid size ${size} (should be >= 0)')
+	}
+	base += size + 1 // +1 because EOF also has a position
+	if base < 0 {
+		panic('token.Pos offset overflow (> 2G of source code in file set)')
+	}
+	// add the file to the file set
+	// fs.base = base
+	// lock fs.files {
+	// 	// TODO: add shared to fs.base (fix compiler errors first)
+	// 	fs.files << file
+	// }
+	// fs.last = file
+	fs.base = base
+	fs.files << file
+	return file
+}
+
+fn search_files(files []&File, x int) int {
+	// binary search
+	mut min, mut max := 0, files.len
+	for min < max {
+		mid := (min + max) / 2
+		// println('# min: $min, mid: $mid, max: $max')
+		if files[mid].base <= x {
+			min = mid + 1
+		} else {
+			max = mid
+		}
+	}
+	return min - 1
+
+	// linear seach
+	// for i := files.len-1; i>=0; i-- {
+	// 	file := files[i]
+	// 	if file.base < x && x <= file.base + file.size {
+	// 		// println('found file for pos `$x` i = $i:')
+	// 		// dump(file)
+	// 		return i
+	// 	}
+	// }
+	// return -1
+}
+
+pub fn (mut fs FileSet) file(pos Pos) &File {
+	//	eprintln('>>>>>>>>> file fs: ${voidptr(fs)} | pos: $pos')
+	fs.mu.@lock()
+	defer {
+		fs.mu.unlock()
+	}
+
+	// lock fs.files
+	// last file
+	// if last_file := fs.files.last() {
+	// 	// p_int
+	// 	if last_file.base <= int(pos) && int(p) <- f.base+f.size {
+	// 		return last_file
+	// 	}
+	// }
+	// i := search_files(lock fs.files { fs.files }, pos)
+	i := search_files(fs.files, pos)
+	if i >= 0 {
+		file := fs.files[i]
+		if int(pos) <= file.base + file.size {
+			// we could store last and retrieve and try above
+			return file
+		}
+	}
+
+	dump(fs)
+	panic('cannot find file for pos: ${pos}')
+}
+
+// pub fn new_file(filename string) File {
+// 	return File{
+// 		name: filename
+// 	}
+// }
+
+@[inline]
+pub fn (mut f File) add_line(offset int) {
+	f.line_offsets << offset
+}
+
+@[inline]
+pub fn (f &File) line_count() int {
+	return f.line_offsets.len
+}
+
+pub fn (f &File) line_start(line int) int {
+	return f.line_offsets[line - 1] or {
+		panic('invlid line `${line}` (must be > 0 & < ${f.line_count()})')
+	}
+}
+
+pub fn (f &File) line(pos Pos) int {
+	return f.find_line(pos)
+}
+
+pub fn (f &File) pos(offset int) Pos {
+	if offset > f.size {
+		panic('invalid offset')
+	}
+	return Pos(f.base + offset)
+}
+
+pub fn (f &File) position(pos Pos) Position {
+	offset := int(pos) - f.base
+	line, column := f.find_line_and_column(offset)
+	return Position{
+		filename: f.name
+		offset: offset
+		line: line
+		column: column
+	}
+}
+
+// return (line, column) when passed pos
+pub fn (f &File) find_line_and_column(pos int) (int, int) {
+	line := f.find_line(pos)
+	return line, pos - f.line_offsets[line - 1] + 1
+}
+
+// return line when passed pos (binary search)
+// NOTE: only used for error conditions
+// therefore search speed is not an issue
+pub fn (f &File) find_line(pos int) int {
+	mut min, mut max := 0, f.line_offsets.len
+	for min < max {
+		mid := (min + max) / 2
+		// println('# min: $min, mid: $mid, max: $max')
+		if f.line_offsets[mid] <= pos {
+			min = mid + 1
+		} else {
+			max = mid
+		}
+	}
+	return min
+}

--- a/vlib/v2/token/token.v
+++ b/vlib/v2/token/token.v
@@ -1,0 +1,344 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module token
+
+pub enum Token {
+	amp // &
+	and // &&
+	and_assign // &=
+	arrow // <-
+	assign // =
+	// at // @
+	attribute
+	bit_not // ~
+	char // `A` - rune
+	colon // :
+	comma // ,
+	comment
+	dec // --
+	decl_assign // :=
+	div // /
+	div_assign // /=
+	dollar // $
+	dot // .
+	dotdot // ..
+	ellipsis // ...
+	eof
+	eq // ==
+	ge // >=
+	gt // >
+	hash // #
+	inc // ++
+	key_as
+	key_asm
+	key_assert
+	key_atomic
+	key_break
+	key_const
+	key_continue
+	key_defer
+	key_dump
+	key_else
+	key_enum
+	key_false
+	key_fn
+	key_for
+	key_global
+	key_go
+	key_goto
+	key_if
+	key_import
+	key_in
+	key_interface
+	key_is
+	key_isreftype
+	key_likely
+	key_lock
+	key_match
+	key_module
+	key_mut
+	key_nil
+	key_none
+	key_offsetof
+	key_or
+	key_pub
+	key_return
+	key_rlock
+	key_select
+	key_shared
+	key_sizeof
+	key_spawn
+	key_static
+	key_struct
+	key_true
+	key_type
+	key_typeof
+	key_union
+	key_unlikely
+	key_unsafe
+	key_volatile
+	lcbr // {
+	le // <=
+	left_shift // <<
+	left_shift_assign // >>=
+	logical_or // ||
+	lpar // (
+	lsbr // [
+	lt // <
+	minus // -
+	minus_assign // -=
+	mod // %
+	mod_assign // %=
+	mul // *
+	mul_assign // *=
+	name // user
+	ne // !=
+	not // !
+	not_in // !in
+	not_is // !is
+	number // 123
+	or_assign // |=
+	pipe // |
+	plus // +
+	plus_assign // +=
+	question // ?
+	rcbr // }
+	right_shift // >>
+	right_shift_assign // <<=
+	right_shift_unsigned // >>>
+	right_shift_unsigned_assign // >>>=
+	rpar // )
+	rsbr // ]
+	semicolon // ;
+	str_dollar
+	string // 'foo'
+	unknown
+	xor // ^
+	xor_assign // ^=
+}
+
+pub enum BindingPower {
+	lowest
+	one
+	two
+	three
+	four
+	highest
+}
+
+@[inline]
+pub fn (t Token) left_binding_power() BindingPower {
+	return match t {
+		// `||`
+		.logical_or { .lowest }
+		// `&&`
+		.and { .one }
+		// `==` | `!=` | `<` | `<=` | `>` | `>=` | `in` | `!in` | `is` | `!is`
+		.eq, .ne, .lt, .le, .gt, .ge, .key_in, .not_in, .key_is, .not_is { .two }
+		// `+` |  `-` |  `|` | `^`
+		.plus, .minus, .pipe, .xor { .three }
+		// `*` |  `/` | `%` | `<<` | `>>` | `>>>` | `&`
+		.mul, .div, .mod, .left_shift, .right_shift, .right_shift_unsigned, .amp { .four }
+		else { .lowest }
+	}
+}
+
+// TODO: double check / fix this. just use what is needed instead of this
+@[inline]
+pub fn (t Token) right_binding_power() BindingPower {
+	return unsafe { BindingPower((int(t.left_binding_power()) + 1)) }
+}
+
+@[inline]
+pub fn (t Token) is_prefix() bool {
+	return t in [.minus, .amp, .mul, .not, .bit_not, .arrow]
+}
+
+@[inline]
+pub fn (t Token) is_infix() bool {
+	return t in [
+		.amp,
+		.and,
+		.arrow,
+		.div,
+		// .dot,
+		.eq,
+		.ge,
+		.gt,
+		// .key_as,
+		.key_in,
+		.key_is,
+		.le,
+		.left_shift,
+		.logical_or,
+		.lt,
+		.minus,
+		.mod,
+		.mul,
+		.ne,
+		.not_in,
+		.not_is,
+		.pipe,
+		.plus,
+		.right_shift,
+		.right_shift_unsigned,
+		.xor,
+	]
+}
+
+@[inline]
+pub fn (t Token) is_postfix() bool {
+	return t in [.dec, .inc]
+	// return t in [.dec, .inc, .not, .question]
+}
+
+@[inline]
+pub fn (t Token) is_assignment() bool {
+	return t in [
+		.and_assign,
+		.assign,
+		.decl_assign,
+		.div_assign,
+		.left_shift_assign,
+		.minus_assign,
+		.mod_assign,
+		.mul_assign,
+		.or_assign,
+		.plus_assign,
+		.right_shift_assign,
+		.right_shift_unsigned_assign,
+		.xor_assign,
+	]
+}
+
+@[inline]
+pub fn (t Token) is_overloadable() bool {
+	// `/` | `==` | `>=` | `>` | `<=` | `<` | `-` | `%` | `*` | `!=` | `|` | `+` | `^`
+	return t in [.div, .eq, .ge, .gt, .le, .lt, .minus, .mod, .mul, .ne, .pipe, .plus, .xor]
+}
+
+@[inline]
+pub fn (t Token) is_comparison() bool {
+	// `==` | `>=` | `>` | `in` | `is` | `<=` | `<` | `!=` | `!in` | `!is`
+	return t in [.eq, .ge, .gt, .key_in, .key_is, .le, .lt, .ne, .not_in, .not_is]
+}
+
+// NOTE: probably switch back to map again later.
+// for dev this is easier to see if any tokens are missing.
+pub fn (t Token) str() string {
+	return match t {
+		.amp { '&' }
+		.and { '&&' }
+		.and_assign { '&=' }
+		.arrow { '<-' }
+		.assign { '=' }
+		// .at { '@' }
+		.attribute { '@[' }
+		.bit_not { '~' }
+		.char { 'char' }
+		.colon { ':' }
+		.comma { ',' }
+		.comment { '// comment' }
+		.dec { '--' }
+		.decl_assign { ':=' }
+		.div { '/' }
+		.div_assign { '/=' }
+		.dollar { '$' }
+		.dot { '.' }
+		.dotdot { '..' }
+		.ellipsis { '...' }
+		.eof { 'eof' }
+		.eq { '==' }
+		.ge { '>=' }
+		.gt { '>' }
+		.hash { '#' }
+		.inc { '++' }
+		.key_as { 'as' }
+		.key_asm { 'asm' }
+		.key_assert { 'assert' }
+		.key_atomic { 'atomic' }
+		.key_break { 'break' }
+		.key_const { 'const' }
+		.key_continue { 'continue' }
+		.key_defer { 'defer' }
+		.key_dump { 'dump' }
+		.key_else { 'else' }
+		.key_enum { 'enum' }
+		.key_false { 'false' }
+		.key_fn { 'fn' }
+		.key_for { 'for' }
+		.key_global { '__global' }
+		.key_go { 'go' }
+		.key_goto { 'goto' }
+		.key_if { 'if' }
+		.key_import { 'import' }
+		.key_in { 'in' }
+		.key_interface { 'interface' }
+		.key_is { 'is' }
+		.key_isreftype { 'isreftype' }
+		.key_likely { '_likely_' }
+		.key_lock { 'lock' }
+		.key_match { 'match' }
+		.key_module { 'module' }
+		.key_mut { 'mut' }
+		.key_nil { 'nil' }
+		.key_none { 'none' }
+		.key_offsetof { '__offsetof' }
+		.key_or { 'or' }
+		.key_pub { 'pub' }
+		.key_return { 'return' }
+		.key_rlock { 'rlock' }
+		.key_select { 'select' }
+		.key_shared { 'shared' }
+		.key_sizeof { 'sizeof' }
+		.key_spawn { 'spawn' }
+		.key_static { 'static' }
+		.key_struct { 'struct' }
+		.key_true { 'true' }
+		.key_type { 'type' }
+		.key_typeof { 'typeof' }
+		.key_union { 'union' }
+		.key_unlikely { '_unlikely_' }
+		.key_unsafe { 'unsafe' }
+		.key_volatile { 'volatile' }
+		.lcbr { '{' }
+		.le { '<=' }
+		.left_shift { '<<' }
+		.left_shift_assign { '<<=' }
+		.logical_or { '||' }
+		.lpar { '(' }
+		.lsbr { '[' }
+		.lt { '<' }
+		.minus { '-' }
+		.minus_assign { '-=' }
+		.mod { '%' }
+		.mod_assign { '%=' }
+		.mul { '*' }
+		.mul_assign { '*=' }
+		.name { 'name' }
+		.ne { '!=' }
+		.not { '!' }
+		.not_in { '!in' }
+		.not_is { '!is' }
+		.number { 'number' }
+		.or_assign { '|=' }
+		.pipe { '|' }
+		.plus { '+' }
+		.plus_assign { '+=' }
+		.question { '?' }
+		.rcbr { '}' }
+		.right_shift { '>>' }
+		.right_shift_assign { '>>=' }
+		.right_shift_unsigned { '>>>' }
+		.right_shift_unsigned_assign { '>>>=' }
+		.rpar { ')' }
+		.rsbr { ']' }
+		.semicolon { ';' }
+		.str_dollar { '\${' }
+		.string { 'string' }
+		.unknown { 'unknown' }
+		.xor { '^' }
+		.xor_assign { '^=' }
+	}
+}

--- a/vlib/v2/token/util.v
+++ b/vlib/v2/token/util.v
@@ -1,0 +1,463 @@
+module token
+
+// NOTE: add keyword tokens here
+// TODO: allow overriding this method in main v compiler
+// that is why this method was renamed from `from_string`
+// vfmt off
+@[direct_array_access]
+pub fn Token.from_string_tinyv(name string) Token {
+	match name.len {
+		2 {
+			match name[0] {
+				`a` {
+					match name[1] {
+						`s` { return .key_as }
+						else { return .name }
+					}
+				}
+				`f` {
+					match name[1] {
+						`n` { return .key_fn }
+						else { return .name }
+					}
+				}
+				`g` {
+					match name[1] {
+						`o` { return .key_go }
+						else { return .name }
+					}
+				}
+				`i` {
+					match name[1] {
+						`f` { return .key_if }
+						`n` { return .key_in }
+						`s` { return .key_is }
+						else { return .name }
+					}
+				}
+				`o` {
+					match name[1] {
+						`r` { return .key_or }
+						else { return .name }
+					}
+				}
+				else {
+					return .name
+				}
+			}
+			return .name
+		}
+		3 {
+			match name[0] {
+				`a` {
+					if name[1] == `s` && name[2] == `m` {
+						return .key_asm
+					} else {
+						return .name
+					}
+				}
+				`f` {
+					if name[1] == `o` && name[2] == `r` {
+						return .key_for
+					} else {
+						return .name
+					}
+				}
+				`m` {
+					if name[1] == `u` && name[2] == `t` {
+						return .key_mut
+					} else {
+						return .name
+					}
+				}
+				`n` {
+					if name[1] == `i` && name[2] == `l` {
+						return .key_nil
+					} else {
+						return .name
+					}
+				}
+				`p` {
+					if name[1] == `u` && name[2] == `b` {
+						return .key_pub
+					} else {
+						return .name
+					}
+				}
+				else {
+					return .name
+				}
+			}
+			return .name
+		}
+		4 {
+			match name[0] {
+				`d` {
+					if name[1] == `u` && name[2] == `m` && name[3] == `p` {
+						return .key_dump
+					} else {
+						return .name
+					}
+				}
+				`e` {
+					match name[1] {
+						`l` {
+							if name[2] == `s` && name[3] == `e` {
+								return .key_else
+							} else {
+								return .name
+							}
+						}
+						`n` {
+							if name[2] == `u` && name[3] == `m` {
+								return .key_enum
+							} else {
+								return .name
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				`g` {
+					if name[1] == `o` && name[2] == `t` && name[3] == `o` {
+						return .key_goto
+					} else {
+						return .name
+					}
+				}
+				`l` {
+					if name[1] == `o` && name[2] == `c` && name[3] == `k` {
+						return .key_lock
+					} else {
+						return .name
+					}
+				}
+				`n` {
+					if name[1] == `o` && name[2] == `n` && name[3] == `e` {
+						return .key_none
+					} else {
+						return .name
+					}
+				}
+				`t` {
+					match name[1] {
+						`r` {
+							if name[2] == `u` && name[3] == `e` {
+								return .key_true
+							} else {
+								return .name
+							}
+						}
+						`y` {
+							if name[2] == `p` && name[3] == `e` {
+								return .key_type
+							} else {
+								return .name
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				else {
+					return .name
+				}
+			}
+		}
+		5 {
+			match name[0] {
+				`b` {
+					if name[1] == `r` && name[2] == `e` && name[3] == `a` && name[4] == `k` {
+						return .key_break
+					} else {
+						return .name
+					}
+				}
+				`c` {
+					if name[1] == `o` && name[2] == `n` && name[3] == `s` && name[4] == `t` {
+						return .key_const
+					} else {
+						return .name
+					}
+				}
+				`d` {
+					if name[1] == `e` && name[2] == `f` && name[3] == `e` && name[4] == `r` {
+						return .key_defer
+					} else {
+						return .name
+					}
+				}
+				`f` {
+					if name[1] == `a` && name[2] == `l` && name[3] == `s` && name[4] == `e` {
+						return .key_false
+					} else {
+						return .name
+					}
+				}
+				`m` {
+					if name[1] == `a` && name[2] == `t` && name[3] == `c` && name[4] == `h` {
+						return .key_match
+					} else {
+						return .name
+					}
+				}
+				`r` {
+					if name[1] == `l` && name[2] == `o` && name[3] == `c` && name[4] == `k` {
+						return .key_rlock
+					} else {
+						return .name
+					}
+				}
+				`s` {
+					if name[1] == `p` && name[2] == `a` && name[3] == `w` && name[4] == `n` {
+						return .key_spawn
+					} else {
+						return .name
+					}
+				}
+				`u` {
+					if name[1] == `n` && name[2] == `i` && name[3] == `o` && name[4] == `n` {
+						return .key_union
+					} else {
+						return .name
+					}
+				}
+				else {
+					return .name
+				}
+			}
+		}
+		6 {
+			match name[0] {
+				`a` {
+					match name[1] {
+						`s` {
+							if name[2] == `s` && name[3] == `e` && name[4] == `r` && name[5] == `t` {
+								return .key_assert
+							} else {
+								return .name
+							}
+						}
+						`t` {
+							if name[2] == `o` && name[3] == `m` && name[4] == `i` && name[5] == `c` {
+								return .key_atomic
+							} else {
+								return .name
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				`i` {
+					if name[1] == `m` && name[2] == `p` && name[3] == `o` && name[4] == `r`
+						&& name[5] == `t` {
+						return .key_import
+					} else {
+						return .name
+					}
+				}
+				`m` {
+					if name[1] == `o` && name[2] == `d` && name[3] == `u` && name[4] == `l`
+						&& name[5] == `e` {
+						return .key_module
+					} else {
+						return .name
+					}
+				}
+				`r` {
+					if name[1] == `e` && name[2] == `t` && name[3] == `u` && name[4] == `r`
+						&& name[5] == `n` {
+						return .key_return
+					} else {
+						return .name
+					}
+				}
+				`s` {
+					match name[1] {
+						`e` {
+							if name[2] == `l` && name[3] == `e` && name[4] == `c` && name[5] == `t` {
+								return .key_select
+							} else {
+								return .name
+							}
+						}
+						`h` {
+							if name[2] == `a` && name[3] == `r` && name[4] == `e` && name[5] == `d` {
+								return .key_shared
+							} else {
+								return .name
+							}
+						}
+						`i` {
+							if name[2] == `z` && name[3] == `e` && name[4] == `o` && name[5] == `f` {
+								return .key_sizeof
+							} else {
+								return .name
+							}
+						}
+						`t` {
+							match name[2] {
+								`a` {
+									if name[3] == `t` && name[4] == `i` && name[5] == `c` {
+										return .key_static
+									} else {
+										return .name
+									}
+								}
+								`r` {
+									if name[3] == `u` && name[4] == `c` && name[5] == `t` {
+										return .key_struct
+									} else {
+										return .name
+									}
+								}
+								else {
+									return .name
+								}
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				`t` {
+					if name[1] == `y` && name[2] == `p` && name[3] == `e` && name[4] == `o`
+						&& name[5] == `f` {
+						return .key_typeof
+					} else {
+						return .name
+					}
+				}
+				`u` {
+					if name[1] == `n` && name[2] == `s` && name[3] == `a` && name[4] == `f`
+						&& name[5] == `e` {
+						return .key_unsafe
+					} else {
+						return .name
+					}
+				}
+				else {
+					return .name
+				}
+			}
+		}
+		8 {
+			match name[0] {
+				`_` {
+					match name[1] {
+						`_` {
+							if name[2] == `g` && name[3] == `l` && name[4] == `o` && name[5] == `b`
+								&& name[6] == `a` && name[7] == `l` {
+								return .key_global
+							} else {
+								return .name
+							}
+						}
+						`l` {
+							if name[2] == `i` && name[3] == `k` && name[4] == `e` && name[5] == `l`
+								&& name[6] == `y` && name[7] == `_` {
+								return .key_likely
+							} else {
+								return .name
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				`c` {
+					if name[1] == `o` && name[2] == `n` && name[3] == `t` && name[4] == `i`
+						&& name[5] == `n` && name[6] == `u` && name[7] == `e` {
+						return .key_continue
+					} else {
+						return .name
+					}
+				}
+				`v` {
+					if name[1] == `o` && name[2] == `l` && name[3] == `a` && name[4] == `t`
+						&& name[5] == `i` && name[6] == `l` && name[7] == `e` {
+						return .key_volatile
+					} else {
+						return .name
+					}
+				}
+				else {
+					return .name
+				}
+			}
+		}
+		9 {
+			match name[0] {
+				`i` {
+					match name[1] {
+						`n` {
+							if name[2] == `t` && name[3] == `e` && name[4] == `r` && name[5] == `f`
+								&& name[6] == `a` && name[7] == `c` && name[8] == `e` {
+								return .key_interface
+							} else {
+								return .name
+							}
+						}
+						`s` {
+							if name[2] == `r` && name[3] == `e` && name[4] == `f` && name[5] == `t`
+								&& name[6] == `y` && name[7] == `p` && name[8] == `e` {
+								return .key_isreftype
+							} else {
+								return .name
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				else {
+					return .name
+				}
+			}
+		}
+		10 {
+			match name[0] {
+				`_` {
+					match name[1] {
+						`_` {
+							if name[2] == `o` && name[3] == `f` && name[4] == `f` && name[5] == `s`
+								&& name[6] == `e` && name[7] == `t` && name[8] == `o`
+								&& name[9] == `f` {
+								return .key_offsetof
+							} else {
+								return .name
+							}
+						}
+						`u` {
+							if name[2] == `n` && name[3] == `l` && name[4] == `i` && name[5] == `k`
+								&& name[6] == `e` && name[7] == `l` && name[8] == `y`
+								&& name[9] == `_` {
+								return .key_unlikely
+							} else {
+								return .name
+							}
+						}
+						else {
+							return .name
+						}
+					}
+				}
+				else {
+					return .name
+				}
+			}
+		}
+		else {
+			return .name
+		}
+	}
+}
+// vfmt on

--- a/vlib/v2/types/checker.v
+++ b/vlib/v2/types/checker.v
@@ -1,0 +1,2327 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module types
+
+import time
+import v2.ast
+import v2.errors
+import v2.pref
+import v2.token
+
+struct Environment {
+mut:
+	// errors with no default value
+	scopes shared map[string]&Scope = map[string]&Scope{}
+	// types map[int]Type
+	// TODO:
+	// methods map...
+	// methods map[int][]&Fn
+	methods           map[string][]&Fn
+	generic_types     map[string][]map[string]Type
+	cur_generic_types []map[string]Type
+}
+
+pub fn Environment.new() &Environment {
+	return &Environment{}
+}
+
+enum DeferredKind {
+	fn_decl
+	fn_decl_generic
+	struct_decl
+	const_decl
+}
+
+struct Deferred {
+	kind  DeferredKind
+	func  fn () = unsafe { nil }
+	scope &Scope
+}
+
+struct Checker {
+	pref &pref.Preferences
+	// info Info
+	// TODO: mod
+	mod &Module = new_module('main', '')
+mut:
+	env           &Environment = &Environment{}
+	file_set      &token.FileSet
+	scope         &Scope = new_scope(unsafe { nil })
+	c_scope       &Scope = new_scope(unsafe { nil })
+	deferred      []Deferred
+	expected_type ?Type
+
+	generic_params []string
+	// TODO: remove once fields/methods with same name
+	// are no longer allowed & removed.
+	expecting_method bool
+}
+
+pub fn Checker.new(prefs &pref.Preferences, file_set &token.FileSet, env &Environment) &Checker {
+	return &Checker{
+		pref: unsafe { prefs }
+		file_set: unsafe { file_set }
+		env: unsafe { env }
+	}
+}
+
+pub fn (mut c Checker) get_module_scope(module_name string, parent &Scope) &Scope {
+	// return c.env.scopes[module_name] or {
+	// 	s := new_scope(parent)
+	// 	c.env.scopes[module_name] = s
+	// 	s
+	// }
+	return lock c.env.scopes {
+		c.env.scopes[module_name] or {
+			s := new_scope(parent)
+			c.env.scopes[module_name] = s
+			s
+		}
+	}
+}
+
+pub fn (mut c Checker) check_files(files []ast.File) {
+	// c.file_set = unsafe { file_set }
+	c.preregister_all_scopes(files)
+	c.preregister_all_types(files)
+
+	for file in files {
+		c.check_file(file)
+	}
+	// c.log('DEFERRED - START')
+	// TODO: a better way to do this, please.
+	// ideally just resolve what needs to be
+	// const decl
+	for d in c.deferred {
+		if d.kind != .const_decl {
+			continue
+		}
+		c.scope = d.scope
+		d.func()
+	}
+	// fn decls
+	for d in c.deferred {
+		if d.kind != .fn_decl {
+			continue
+		}
+		c.scope = d.scope
+		d.func()
+	}
+	// fn decls - generic
+	for d in c.deferred {
+		if d.kind != .fn_decl_generic {
+			continue
+		}
+		c.scope = d.scope
+		d.func()
+	}
+	// c.log('DEFERRED - END')
+}
+
+pub fn (mut c Checker) check_file(file ast.File) {
+	if !c.pref.verbose {
+		unsafe {
+			goto start_no_time
+		}
+	}
+	mut sw := time.new_stopwatch()
+	start_no_time:
+	// file_scope := new_scope(c.mod.scope)
+	// mut mod_scope := new_scope(c.mod.scope)
+	// c.env.scopes[file.mod] = mod_scope
+	mut mod_scope := lock c.env.scopes {
+		c.env.scopes[file.mod] or {
+			panic('not found for mod: ${file.mod}')
+			// c.env.scopes[file.mod] = c.mod.scope
+			// c.mod.scope
+		}
+	}
+	c.scope = mod_scope
+	// mut mod_scope := c.env.scopes[file.mod] or {
+	// 	panic('scope should exist')
+	// }
+	// c.scope = mod_scope
+	for stmt in file.stmts {
+		// if stmt is ast.Decl {
+		match stmt {
+			ast.EnumDecl, ast.InterfaceDecl, ast.StructDecl, ast.TypeDecl {
+				continue
+			}
+			else {
+				c.decl(stmt)
+			}
+		}
+		// }
+	}
+	for stmt in file.stmts {
+		c.stmt(stmt)
+	}
+	if c.pref.verbose {
+		check_time := sw.elapsed()
+		println('type check ${file.name}: ${check_time.milliseconds()}ms (${check_time.microseconds()}us)')
+	}
+}
+
+fn (mut c Checker) preregister_scopes(file ast.File) {
+	builtin_scope := c.get_module_scope('builtin', universe)
+
+	mod_scope := c.get_module_scope(file.mod, builtin_scope)
+	c.scope = mod_scope
+	// add self (own module) for constants. can use own module prefix inside module
+	c.scope.insert(file.mod, Module{ scope: c.get_module_scope(file.mod, builtin_scope) })
+	// add imports
+	for imp in file.imports {
+		mod := if imp.is_aliased { imp.name.all_after_last('.') } else { imp.alias }
+		c.scope.insert(imp.alias, Module{ scope: c.get_module_scope(mod, builtin_scope) })
+	}
+	// add C
+	c.scope.insert('C', Module{ scope: c.c_scope })
+}
+
+fn (mut c Checker) preregister_all_scopes(files []ast.File) {
+	// builtin_scope := c.get_module_scope('builtin', universe)
+	// preregister scopes & imports
+	for file in files {
+		c.preregister_scopes(file)
+		// mod_scope := c.get_module_scope(file.mod, builtin_scope)
+		// c.scope = mod_scope
+		// // add self (own module) for constants
+		// c.scope.insert(file.mod, Module{scope: c.get_module_scope(file.mod, builtin_scope)})
+		// // add imports
+		// for imp in file.imports {
+		// 	mod :=  if imp.is_aliased { imp.name.all_after_last('.') } else { imp.alias }
+		// 	c.scope.insert(imp.alias, Module{scope: c.get_module_scope(mod, builtin_scope)})
+		// }
+		// // add C
+		// c.scope.insert('C', Module{scope: c.c_scope})
+	}
+}
+
+fn (mut c Checker) preregister_types(file ast.File) {
+	mut mod_scope := c.env.scopes[file.mod] or { panic('scope should exist') }
+	c.scope = mod_scope
+	for stmt in file.stmts {
+		// if stmt is ast.Decl {
+		match stmt {
+			ast.EnumDecl, ast.InterfaceDecl, ast.StructDecl, ast.TypeDecl {}
+			else {
+				continue
+			}
+		}
+		c.decl(stmt)
+		// }
+	}
+}
+
+fn (mut c Checker) preregister_all_types(files []ast.File) {
+	for file in files {
+		c.preregister_types(file)
+	}
+	// c.log('DEFERRED - START')
+	for d in c.deferred {
+		if d.kind != .struct_decl {
+			continue
+		}
+		c.scope = d.scope
+		d.func()
+	}
+	// c.log('DEFERRED - END')
+}
+
+fn (mut c Checker) decl(decl ast.Stmt) {
+	match decl {
+		ast.ConstDecl {
+			for field in decl.fields {
+				// c.log('const decl: $field.name')
+				obj := Const{
+					mod: c.mod
+					name: field.name
+					// typ: c.expr(field.value)
+				}
+				c.scope.insert(obj.name, obj)
+				// TODO: check if constains references to other consts and only
+				// delay those. or keep dererring until type is known othewise error
+				// work out best way to do this, and use same approach for everything
+				c.later(fn [mut c, field] () {
+					// c.log('updating const $field.name type')
+					const_type := c.expr(field.value)
+					if mut cd := c.scope.lookup(field.name) {
+						if mut cd is Const {
+							cd.typ = const_type.typed_default()
+						}
+					}
+				}, .const_decl)
+			}
+		}
+		ast.EnumDecl {
+			// TODO: if non builtin types can be used as part of
+			// the expr then these will need to get delayed also.
+			mut fields := []Field{}
+			for field in decl.fields {
+				fields << Field{
+					name: field.name
+				}
+			}
+			// as_type := decl.as_type !is ast.EmptyExpr { c.expr(decl.as_type) } else { Type(int_) }
+			obj := Enum{
+				is_flag: decl.attributes.has('flag')
+				name: decl.name
+				fields: fields
+			}
+			c.scope.insert(obj.name, Type(obj))
+		}
+		ast.FnDecl {
+			// if decl.typ.generic_params.len > 0 {
+			// 	fn_decl := decl
+			// 	c.later(fn[mut c, fn_decl]() {
+			// 		c.fn_decl(fn_decl)
+			// 	}, .fn_decl_generic)
+			// } else {
+			// 	c.fn_decl(decl)
+			// }
+			c.fn_decl(decl)
+		}
+		ast.GlobalDecl {
+			// for field in decl.fields {
+			// 	// field_type := c.expr(field.typ)
+			// 	// if field.name == 'g_timers' {
+			// 	// 	// dump(field.typ)
+			// 	// 	panic('# g_timers: $field_type.name()')
+			// 	// }
+			// 	obj := Global{
+			// 		name: field.name
+			// 		// typ: c.expr(field.typ)
+			// 		typ: c.expr(field.value)
+			// 	}
+			// 	// c.log('GlobalDecl: $field.name - $obj.typ.type_name()')
+			// 	c.scope.insert(field.name, obj)
+			// }
+		}
+		ast.InterfaceDecl {
+			// TODO:
+			obj := Interface{
+				name: decl.name
+			}
+			c.scope.insert(decl.name, Type(obj))
+			interface_decl := decl
+			mut scope := c.scope
+			c.later(fn [mut c, mut scope, interface_decl] () {
+				mut fields := []Field{}
+				for field in interface_decl.fields {
+					fields << Field{
+						name: field.name
+						typ: c.expr(field.typ)
+					}
+				}
+				if mut id := scope.lookup(interface_decl.name) {
+					if mut id is Type {
+						if mut id is Interface {
+							id.fields = fields
+						}
+					}
+				}
+			}, .struct_decl)
+		}
+		ast.StructDecl {
+			// c.log(' # StructDecl: $decl.name')
+			// TODO: clean this up
+			struct_decl := decl
+			c.later(fn [mut c, struct_decl] () {
+				// c.log('add fields: $struct_decl.name')
+				mut fields := []Field{}
+				for field in struct_decl.fields {
+					fields << Field{
+						name: field.name
+						typ: c.expr(field.typ)
+					}
+				}
+				mut embedded := []Struct{}
+				for embedded_expr in struct_decl.embedded {
+					embedded_type := c.expr(embedded_expr)
+					if embedded_type is Struct {
+						embedded << embedded_type
+					} else {
+						c.error_with_pos('can only structs, `${embedded_type.name()}` is not a struct.',
+							struct_decl.pos)
+					}
+				}
+				mut update_scope := if struct_decl.language == .c { c.c_scope } else { c.scope }
+				// TODO: work best way to do this?
+				// modify the original type since, that is
+				// the one every Type will be pointing to
+				if mut sd := update_scope.lookup(struct_decl.name) {
+					if mut sd is Type {
+						if mut sd is Struct {
+							sd.fields = fields
+							sd.embedded = embedded
+						}
+					}
+				}
+				// obj := types.Struct{
+				// 	name: struct_decl.name
+				// 	fields: fields
+				// }
+				// typ := Type(obj)
+				// c.scope.insert(struct_decl.name, typ)
+			}, .struct_decl)
+			// c.log('struct decl: $decl.name')
+			obj := Struct{
+				name: decl.name
+				// fields: [Field{name: 'len', typ: ast.Ident{name: 'int'}}]
+				// fields: [Field{name: 'len'}]
+			}
+			mut typ := Type(obj)
+			// TODO: proper
+			if decl.language == .c {
+				c.c_scope.insert(decl.name, typ)
+			} else {
+				c.scope.insert(decl.name, typ)
+			}
+		}
+		ast.TypeDecl {
+			type_decl := decl
+			// alias
+			if decl.variants.len == 0 {
+				alias_type := Alias{
+					name: decl.name
+					// TODO: defer
+					// parent: c.expr(decl.base_type)
+				}
+				mut typ := Type(alias_type)
+				c.scope.insert(decl.name, typ)
+				c.later(fn [mut c, type_decl] () {
+					// mut obj := c.scope.lookup(type_decl.name) or { panic(err.msg()) }
+					// mut typ := obj.typ()
+					// if mut typ is Alias {
+					// 	typ.base_type = c.expr(type_decl.base_type)
+					// }
+					if mut obj := c.scope.lookup(type_decl.name) {
+						if mut obj is Type {
+							if mut obj is Alias {
+								obj.base_type = c.expr(type_decl.base_type)
+							}
+						}
+					}
+				}, .struct_decl)
+			}
+			// sum type
+			else {
+				sum_type := SumType{
+					name: decl.name
+					// variants: decl.variants
+				}
+				mut typ := Type(sum_type)
+				c.scope.insert(decl.name, typ)
+				c.later(fn [mut c, type_decl] () {
+					mut obj := c.scope.lookup(type_decl.name) or { panic(err.msg()) }
+					mut typ := obj.typ()
+					// mut typ := c.expr(ast.Ident{name: type_decl.name})
+					if mut typ is SumType {
+						for variant in type_decl.variants {
+							typ.variants << c.expr(variant)
+						}
+					}
+				}, .struct_decl)
+			}
+		}
+		else {}
+	}
+}
+
+fn (mut c Checker) check_types(exp_type Type, got_type Type) bool {
+	// TODO: will this work with Primitive? might need to add comparison methods
+	if got_type == exp_type {
+		return true
+	}
+	// number literals
+	if exp_type.is_number() && got_type.is_number_literal() {
+		return true
+	}
+	// primitives
+	if exp_type is Primitive && got_type is Primitive {
+		// mut got_props := got_type.props
+		// got_props.clear(.untyped)
+		// // checks if both match flot or int
+		// if got_props == exp_type.props {
+		// 	return true
+		// }
+	}
+
+	return false
+}
+
+fn (mut c Checker) expr(expr ast.Expr) Type {
+	c.log('expr: ${expr.type_name()}')
+	match expr {
+		ast.ArrayInitExpr {
+			// c.log('ArrayInit:')
+			// `[1,2,3,4]`
+			if expr.exprs.len > 0 {
+				is_fixed := expr.len !is ast.EmptyExpr
+				// TODO: check all exprs
+				first_elem_type := c.expr(expr.exprs.first())
+				// NOTE: why did I have this shortcut here?
+				// if expr.exprs.len == 1 {
+				// 	if first_elem_type.is_number_literal() {
+				// 		return Array{
+				// 			elem_type: int_
+				// 		}
+				// 	}
+				// }
+				// TODO: promote [0] - proper
+				expected_type_prev := c.expected_type
+				expected_type := c.expected_type or {
+					// `[Type.value_a, .value_b]`
+					// set expected type for checking `.value_b`
+					if first_elem_type is Enum {
+						c.expected_type = first_elem_type
+					}
+					first_elem_type
+				}
+
+				for i, elem_expr in expr.exprs {
+					if i == 0 {
+						continue
+					}
+					mut elem_type := c.expr(elem_expr)
+					// TODO: best way to handle this?
+					if elem_type.is_number_literal() && first_elem_type.is_number() {
+						elem_type = first_elem_type
+					}
+					// sum type, check variants
+					if (expected_type is SumType && elem_type !in expected_type.variants)
+						&& elem_type != first_elem_type // everyting else
+					  {
+						// TOOD: add generl method for promotion/coersion
+						c.error_with_pos('expecting element of type: ${first_elem_type.name()}, got ${elem_type.name()}',
+							expr.pos)
+					}
+				}
+				c.expected_type = expected_type_prev
+				return if is_fixed {
+					ArrayFixed{
+						len: expr.exprs.len
+						elem_type: first_elem_type
+					}
+				} else {
+					Array{
+						elem_type: first_elem_type
+					}
+				}
+			}
+			// `[]int{}`
+			return c.expr(expr.typ)
+		}
+		ast.AsCastExpr {
+			// TODO:
+			c.expr(expr.expr)
+			return c.expr(expr.typ)
+		}
+		ast.BasicLiteral {
+			// c.log('ast.BasicLiteral: $expr.kind.str(): $expr.value')
+			match expr.kind {
+				.char {
+					return char_
+				}
+				.key_false, .key_true {
+					return bool_
+				}
+				// TODO:
+				.number {
+					// TODO: had to be a better way to do this
+					// should this be handled earlier? scanner?
+					if expr.value.contains('.') {
+						return float_literal_
+					}
+					return int_literal_
+				}
+				else {
+					panic('invalid ast.BasicLiteral kind: ${expr.kind}')
+				}
+			}
+		}
+		ast.CallOrCastExpr {
+			// c.log('CallOrCastExpr: $lhs_type.name()')
+			// lhs_type := c.expr(expr.lhs)
+			// // call
+			// if lhs_type is FnType {
+			// 	return c.call_expr(ast.CallExpr{lhs: expr.lhs, args: [expr.expr]})
+			// }
+			// // cast
+			// // expr_type := c.expr(expr.expr)
+			// // TODO: check if expr_type can be cast to lhs_type
+			// return lhs_type
+			return c.expr(c.resolve_call_or_cast_expr(expr))
+		}
+		ast.CallExpr {
+			// TOOD/FIXME: proper
+			// we need a way to handle C.stat|sigaction() / C.stat|sigaction{}
+			// multiple items with same name inside scope lookup.
+			if expr.lhs is ast.SelectorExpr {
+				if expr.lhs.rhs.name == 'stat' {
+					return int_
+				}
+			}
+			return c.call_expr(expr)
+		}
+		ast.CastExpr {
+			typ := c.expr(expr.typ)
+			c.log('CastExpr: ${typ.name()}')
+			return typ
+		}
+		ast.ComptimeExpr {
+			cexpr := c.resolve_expr(expr.expr)
+			// TODO: move to checker, where `ast.*Or*` nodes will be resolved.
+			if cexpr !in [ast.CallExpr, ast.IfExpr] {
+				c.error_with_pos('unsupported comptime: ${cexpr.type_name()}', expr.pos)
+			}
+			// TODO: $if dynamic_bohem ...
+			if cexpr is ast.IfExpr {
+				c.log('TODO: comptime IfExpr')
+				return void_
+			}
+			c.log('ComptimeExpr: ' + cexpr.type_name())
+			// return c.expr(cexpr)
+		}
+		ast.EmptyExpr {
+			// TODO:
+			return void_
+		}
+		ast.FnLiteral {
+			return c.fn_type(expr.typ, FnTypeAttribute.empty)
+		}
+		ast.GenericArgs {
+			// NOTE: first generic args handled in CallExpr
+			// this is generic struct nested in generic args
+			mut name := ''
+			match expr.lhs {
+				ast.Ident {
+					name = expr.lhs.name
+				}
+				else {}
+			}
+			mut args := []string{}
+			for arg in expr.args {
+				if arg is ast.Ident {
+					args << arg.name
+				}
+			}
+			lhs_type := c.expr(expr.lhs)
+			if lhs_type is FnType {
+				return FnType{
+					...lhs_type
+					generic_params: args
+				}
+			}
+
+			return Struct{
+				name: name
+				generic_params: args
+			}
+		}
+		ast.GenericArgOrIndexExpr {
+			return c.expr(c.resolve_generic_arg_or_index_expr(expr))
+		}
+		ast.Ident {
+			// c.log('ident: $expr.name')
+			obj := c.ident(expr)
+			typ := obj.typ()
+			// TODO:
+			if expr.name == 'string' {
+				if typ is Struct {
+					return string_
+				}
+			}
+			return typ
+		}
+		ast.IfExpr {
+			// if guard
+			if expr.cond is ast.IfGuardExpr {
+				c.open_scope()
+				c.assign_stmt(expr.cond.stmt, true)
+				c.stmt_list(expr.stmts)
+				c.close_scope()
+				if expr.else_expr is ast.IfExpr {
+					c.open_scope()
+					c.scope.insert('err', Type(Struct{ name: 'Error' }))
+					c.stmt_list(expr.else_expr.stmts)
+					c.close_scope()
+				}
+				// TODO: never used, add a special type?
+				return void_
+			}
+
+			// normal if
+			return c.if_expr(expr)
+		}
+		ast.IfGuardExpr {
+			c.assign_stmt(expr.stmt, true)
+			// TODO:
+			return bool_
+		}
+		ast.IndexExpr {
+			lhs_type := c.expr(expr.lhs)
+			// TODO: make sure lhs_type is indexable
+			// if !lhs_type.is_indexable() { c.error('cannot index ${lhs_type.name()}') }
+			value_type := if expr.expr is ast.RangeExpr {
+				lhs_type
+			} else {
+				lhs_type.value_type()
+			}
+			// c.log('IndexExpr: ${value_type.name()} / ${lhs_type.name()}')
+			return value_type
+		}
+		ast.InfixExpr {
+			lhs_type := c.expr(expr.lhs)
+			// TODO: why was I setting expected type for enum here?
+			// expected_type := c.expected_type
+			// if lhs_type is Enum {
+			// 	c.expected_type = lhs_type
+			// }
+			c.expr(expr.rhs)
+			// c.expected_type = expected_type
+			if expr.op.is_comparison() {
+				return bool_
+			}
+			return lhs_type
+		}
+		ast.InitExpr {
+			// TODO: try handle this from expr
+			// mut typ_expr := expr.typ
+			// if expr.typ is ast.GenericArgs {
+			// 	typ_expr = expr.typ.lhs
+			// }
+			typ := c.expr(expr.typ)
+			// TODO:
+			// if typ is ast.ChannelType {
+			// 	for field in expr.fields {
+			// 		match field.name {
+			// 			'cap' {}
+			// 			else { c.error_with_pos('unknown channel attribute `${key}`') }
+			// 		}
+			// 	}
+			// }
+			// TODO:
+			// for field in expr.fields {
+			// 	if field.value !is ast.EmptyExpr {
+			// 		field_expr_type := c.expr(field.value)
+			// 	}
+			// }
+			return typ
+		}
+		ast.KeywordOperator {
+			// TODO:
+			typ := c.expr(expr.exprs[0])
+			match expr.op {
+				.key_go, .key_spawn {
+					return Thread{}
+				}
+				else {
+					return typ
+				}
+			}
+		}
+		ast.MapInitExpr {
+			// TOOD: type check keys/vals
+			// `map[type]type{}`
+			if expr.typ !is ast.EmptyExpr {
+				typ := c.expr(expr.typ)
+				return typ
+			}
+			// `{}`
+			if expr.keys.len == 0 {
+				return c.expected_type or {
+					c.error_with_pos('empty map {} used in unsupported context', expr.pos)
+				}
+			}
+			// `{key: value}`
+			key0_type := c.expr(expr.keys[0])
+			value0_type := c.expr(expr.vals[0])
+			return Map{
+				key_type: key0_type
+				value_type: value0_type
+			}
+		}
+		ast.MatchExpr {
+			return c.match_expr(expr, true)
+		}
+		ast.ModifierExpr {
+			// if expr.expr !is ast.Ident && expr.expr !is ast.Type {
+			// 	panic('not ident: $expr.expr.type_name()')
+			// }
+			return c.expr(expr.expr)
+		}
+		ast.OrExpr {
+			cond := c.resolve_expr(expr.expr)
+			cond_type := c.expr(cond).unwrap()
+			// c.log('OrExpr: ${cond_type.name()}')
+			if expr.stmts.len > 0 {
+				last_stmt := expr.stmts.last()
+				if last_stmt is ast.ExprStmt {
+					expr_stmt_type := c.expr(last_stmt.expr).unwrap()
+					// c.log('OrExpr: last_stmt_type: ${cond_type.name()}')
+					// TODO: non returning call (currently just checking void)
+					// should probably lookup function/method and check for noreturn attribute?
+					// if cond is ast.CallExpr {}
+					// do we need to do promotion here
+
+					// last stmt expr does does not return a type
+					if expr_stmt_type !is Void && !c.check_types(cond_type, expr_stmt_type) {
+						c.error_with_pos('or expr expecting ${cond_type.name()}, got ${expr_stmt_type.name()}',
+							expr.pos)
+					}
+					return cond_type
+				}
+			}
+			return cond_type
+		}
+		ast.ParenExpr {
+			return c.expr(expr.expr)
+		}
+		ast.PostfixExpr {
+			// TODO:
+			// typ := c.expr(expr.expr)
+			// if typ is FnType {
+			// 	if rt := typ.return_type {
+			// 		if rt in [OptionType, ResultType] { return typ }
+			// 	}
+			// 	if expr.op == .not {
+			// 		return_type := OptionType{base_type: typ.return_type or { void_ }}
+			// 		return FnType{...typ, return_type: return_type}
+			// 	}
+			// 	else if expr.op == .question {
+			// 		return_type := ResultType{base_type: typ.return_type or { void_ }}
+			// 		return FnType{...typ, return_type: return_type}
+			// 	}
+			// }
+			// return typ
+
+			return c.expr(expr.expr)
+		}
+		ast.PrefixExpr {
+			expr_type := c.expr(expr.expr)
+			if expr.op == .amp {
+				return Pointer{
+					base_type: expr_type
+				}
+			} else if expr.op == .mul {
+				if expr_type is Pointer {
+					// c.log('DEREF')
+					return expr_type.base_type
+				} else {
+					c.error_with_pos('deref on non pointer type `${expr_type.name()}`',
+						expr.pos)
+				}
+			}
+			return c.expr(expr.expr)
+		}
+		ast.RangeExpr {
+			c.expr(expr.start)
+			c.expr(expr.end)
+			return Type(Array{
+				elem_type: int_
+			})
+		}
+		ast.SelectExpr {
+			c.stmt_list(expr.stmts)
+		}
+		ast.SelectorExpr {
+			// enum value: `.green`
+			if expr.lhs is ast.EmptyExpr {
+				// c.log('got enum value')
+				// // dump(expr)
+				// return c.expected_type
+				return c.expected_type or {
+					c.error_with_pos('c.expected_type is not set', expr.pos)
+				}
+
+				// return int_
+			}
+			// normal selector
+			return c.selector_expr(expr)
+		}
+		ast.StringInterLiteral {
+			// TODO:
+			return string_
+		}
+		ast.StringLiteral {
+			return string_
+		}
+		ast.Tuple {
+			mut types := []Type{}
+			for x in expr.exprs {
+				types << c.expr(x)
+			}
+			return Tuple{
+				types: types
+			}
+		}
+		ast.Type {
+			match expr {
+				ast.AnonStructType {}
+				ast.ArrayType {
+					return Array{
+						elem_type: c.expr(expr.elem_type)
+					}
+				}
+				ast.ArrayFixedType {
+					// TODO:
+					return Array{
+						elem_type: c.expr(expr.elem_type)
+					}
+				}
+				ast.ChannelType {
+					return Channel{
+						elem_type: if expr.elem_type !is ast.EmptyExpr {
+							c.expr(expr.elem_type)
+						} else {
+							none
+						}
+					}
+				}
+				ast.FnType {
+					return c.fn_type(expr, FnTypeAttribute.empty)
+				}
+				ast.GenericType {
+					// TODO:
+					return c.expr(expr.name)
+					// return c
+				}
+				ast.MapType {
+					return Map{
+						key_type: c.expr(expr.key_type)
+						value_type: c.expr(expr.value_type)
+					}
+				}
+				ast.NilType {
+					return nil_
+				}
+				ast.NoneType {
+					return none_
+				}
+				ast.OptionType {
+					return OptionType{
+						base_type: c.expr(expr.base_type)
+					}
+				}
+				ast.ResultType {
+					return ResultType{
+						base_type: c.expr(expr.base_type)
+					}
+				}
+				ast.ThreadType {
+					return Thread{
+						elem_type: if expr.elem_type !is ast.EmptyExpr {
+							c.expr(expr.elem_type)
+						} else {
+							none
+						}
+					}
+				}
+				ast.TupleType {
+					mut types := []Type{}
+					for tx in expr.types {
+						types << c.expr(tx)
+					}
+					return Tuple{
+						types: types
+					}
+				}
+				// else{
+				// 	c.log('expr.Type: not implemented ${expr.type_name()} - ${typeof(expr).name}')
+				// }
+			}
+		}
+		ast.UnsafeExpr {
+			// TODO: proper
+			c.stmt_list(expr.stmts)
+			last_stmt := expr.stmts.last()
+			if last_stmt is ast.ExprStmt {
+				return c.expr(last_stmt.expr)
+			}
+			// TODO: impl: avoid returning types everywhere / using void
+			// perhaps use a struct and set the type and other info in it when needed
+			return void_
+		}
+		else {}
+	}
+	// TOODO: remove (add all variants)
+	c.log('expr: unhandled ${expr.type_name()}')
+	return int_
+}
+
+fn (mut c Checker) stmt(stmt ast.Stmt) {
+	match stmt {
+		ast.AssertStmt {
+			c.expr(stmt.expr)
+		}
+		ast.AssignStmt {
+			c.assign_stmt(stmt, false)
+		}
+		ast.BlockStmt {
+			c.stmt_list(stmt.stmts)
+		}
+		// ast.Decl {
+		// 	// Handled earlier
+		// 	// match stmt {
+		// 	// 	ast.FnDecl{}
+		// 	// 	ast.TypeDecl {}
+		// 	// 	else {}
+		// 	// }
+		// }
+		ast.GlobalDecl {
+			for field in stmt.fields {
+				// c.log('GlobalDecl: $field.name - $obj.typ.type_name()')
+				field_type := if field.typ !is ast.EmptyExpr {
+					c.expr(field.typ)
+				} else {
+					c.expr(field.value)
+				}
+				obj := Global{
+					name: field.name
+					typ: field_type
+				}
+				c.scope.insert(field.name, obj)
+			}
+		}
+		ast.DeferStmt {
+			c.stmt_list(stmt.stmts)
+		}
+		ast.ExprStmt {
+			if stmt.expr is ast.MatchExpr {
+				c.match_expr(stmt.expr, false)
+			} else {
+				c.expr(stmt.expr)
+			}
+		}
+		ast.ForStmt {
+			c.open_scope()
+			// TODO: vars for other for loops
+			if stmt.init is ast.ForInStmt {
+				expr_type := c.expr(stmt.init.expr)
+				if stmt.init.key is ast.Ident {
+					// TODO: remove
+					if expr_type is Void {
+						c.scope.print(false)
+						// dump(stmt)
+						panic('## expr_type is Void!')
+					}
+					key_type := expr_type.key_type()
+					c.scope.insert(stmt.init.key.name, key_type)
+				}
+				mut value_type := expr_type.value_type()
+				if stmt.init.value is ast.ModifierExpr {
+					if stmt.init.value.kind == .key_mut {
+						value_type = value_type.ref()
+					}
+					if stmt.init.value.expr is ast.Ident {
+						c.scope.insert(stmt.init.value.expr.name, value_type)
+					}
+				} else if stmt.init.value is ast.Ident {
+					c.scope.insert(stmt.init.value.name, value_type)
+				}
+			} else {
+				if stmt.cond !is ast.EmptyExpr {
+					sc_names, sc_types := c.extract_smartcasts(stmt.cond)
+					c.apply_smartcasts(sc_names, sc_types)
+				}
+				// c.stmt(stmt.init)
+			}
+			// sc_names, sc_types := c.extract_smartcasts(stmt.cond)
+			// c.apply_smartcasts(sc_names, sc_types)
+			c.stmt(stmt.init)
+			c.expr(stmt.cond)
+			c.stmt(stmt.post)
+			c.stmt_list(stmt.stmts)
+			c.close_scope()
+		}
+		ast.ImportStmt {
+			// c.log('import: $stmt.name as $stmt.alias')
+		}
+		ast.ReturnStmt {
+			c.log('ReturnStmt:')
+			for expr in stmt.exprs {
+				c.expr(expr)
+			}
+		}
+		else {}
+	}
+}
+
+fn (mut c Checker) stmt_list(stmts []ast.Stmt) {
+	for stmt in stmts {
+		c.stmt(stmt)
+	}
+}
+
+fn (mut c Checker) later(func fn (), kind DeferredKind) {
+	c.deferred << Deferred{
+		kind: kind
+		func: func
+		scope: c.scope
+	}
+}
+
+fn (mut c Checker) assign_stmt(stmt ast.AssignStmt, unwrap_optional bool) {
+	for i, lx in stmt.lhs {
+		// TODO: proper / tuple (handle multi return)
+		rx := stmt.rhs[i] or { stmt.rhs[0] }
+		// lhs_type := c.scope.lookup_parent
+		// TODO: ident field for blank ident?
+		mut is_blank_ident := false
+		if lx is ast.Ident {
+			is_blank_ident = lx.name == '_'
+		}
+		mut lhs_type := Type(void_)
+		if stmt.op != .decl_assign && !is_blank_ident {
+			lhs_type = c.expr(lx)
+		}
+		expected_type := c.expected_type
+		if lhs_type is Enum {
+			c.expected_type = lhs_type
+		}
+		rhs_type := c.expr(rx)
+		// if t := expected_type {
+		// 	c.log('AssignStmt: setting expected_type to: $t.name()')
+		// } else {
+		// 	c.log('AssignStmt: setting expected_type to: none')
+		// }
+		c.expected_type = expected_type
+		// c.expected_type = none
+		mut expr_type := rhs_type
+		if unwrap_optional {
+			expr_type = expr_type.unwrap()
+		}
+		if rhs_type is Tuple {
+			expr_type = rhs_type.types[i]
+		}
+		// promote untyped literals
+		expr_type = expr_type.typed_default()
+		// TODO: assignment check
+		// if stmt.op != .decl_assign {
+		// 	c.assignment(expr_type, lhs_type) or {
+		// 		c.log('error!!')
+		// 		c.error_with_pos(err.msg(), stmt.pos)
+		// 	}
+		// }
+		// TODO: proper
+		// TODO: modifiers, lx_unwrapped := c.unwrap...
+		// or some method to use modifiers
+		lx_unwrapped := c.unwrap_expr(lx)
+		if lx_unwrapped is ast.Ident {
+			c.scope.insert(lx_unwrapped.name, expr_type)
+		}
+	}
+}
+
+// TODO:
+// fn (mut c Checker) assignment(lx ast.Expr, typ Type) {
+fn (mut c Checker) assignment(from_type Type, to_type Type) ! {
+	// same type
+	if from_type == to_type {
+		return
+	}
+	// numbers literals
+	if from_type.is_number_literal() && to_type.is_number() {
+		return
+	}
+	// aliases
+	if from_type is Alias {
+		return c.assignment(from_type.base_type, to_type)
+	}
+	if to_type is Alias {
+		return c.assignment(from_type, to_type.base_type)
+	}
+	// TODO: provide context about if inside unsafe
+	if to_type is FnType {
+		// allow nil to fn pointer
+		if from_type is Nil {
+			return
+		}
+	}
+	// pointers
+	if to_type is Pointer {
+		if from_type is Nil {
+			return
+		}
+		if from_type.is_number() {
+			return
+		}
+		// same
+		if from_type is Pointer {
+			// allow assigning &void to any pointer
+			if from_type.base_type is Void {
+				return
+			}
+			//
+			if from_type.base_type.is_number() {
+				return
+			}
+			// return c.assignment(from_type.base_type, to_type.base_type)!
+			if from_type.base_type == to_type.base_type {
+				return
+			}
+		}
+	}
+	if to_type.is_number() {
+		// for now all all numvers to be compatible
+		if from_type.is_number() {
+			return
+		}
+		// TODO: since char is currently its own type, should this be changed?
+		if from_type is Char {
+			return
+		}
+	}
+	// // dump(from_type)
+	// // dump(to_type)
+	return error('cannot assign `${from_type.name()}` to `${to_type.name()}`')
+}
+
+// fn (mut c Checker) implicit_type(from_type Type, to_type Type) !Type {
+// 	if from_type.is_number_literal() && to_type.is_numver() {
+// 		return to_type
+// 	}
+// }
+
+fn (mut c Checker) block(stmts []ast.Stmt) {
+}
+
+fn (mut c Checker) apply_smartcast(sc_name_ ast.Expr, sc_type Type) {
+	sc_name := c.unwrap_ident(sc_name_)
+	if sc_name is ast.Ident {
+		// println('added smartcast for ${sc_name.name} to ${sc_type.name()}')
+		c.scope.insert(sc_name.name, sc_type)
+	} else if sc_name is ast.SelectorExpr {
+		// field := c.selector_expr(sc_name)
+		// if sc_name.lhs is ast.Ident {
+		// 	field := c.find_field_or_method()
+		// 	c.scope.insert(sc_name.lhs.name, SmartCastSelector{origin: field, field: sc_name.rhs.name, cast_type: sc_type})
+		// }
+		// c.log('@@ selector smartcast: ${sc_name.name()} - ${field.type_name()}')
+		// println('added smartcast for ${sc_name.name()} to ${sc_type.name()}')
+		c.scope.field_smartcasts[sc_name.name()] = sc_type
+	}
+}
+
+fn (mut c Checker) apply_smartcasts(sc_names []ast.Expr, sc_types []Type) {
+	for i, sc_name in sc_names {
+		c.apply_smartcast(sc_name, sc_types[i])
+	}
+}
+
+fn (mut c Checker) extract_smartcasts(expr ast.Expr) ([]ast.Expr, []Type) {
+	mut names := []ast.Expr{}
+	mut types := []Type{}
+	expr_u := c.unwrap_expr(expr)
+	if expr_u is ast.InfixExpr {
+		if expr_u.op == .key_is {
+			// eprintln('adding smartcast')
+			names << expr_u.lhs
+			types << c.expr(c.unwrap_expr(expr_u.rhs))
+			// typ := c.expr(expr_u.rhs)
+			// types << typ
+		}
+		// TODO: is this just needed for && ?
+		else {
+			lhs_names, lhs_types := c.extract_smartcasts(c.unwrap_expr(expr_u.lhs))
+			rhs_names, rhs_types := c.extract_smartcasts(c.unwrap_expr(expr_u.rhs))
+			names << lhs_names
+			types << lhs_types
+			names << rhs_names
+			types << rhs_types
+		}
+	}
+	// else if cond is ast.ParenExpr {
+	// 	names2, types2 := c.extract_smartcasts(cond.expr)
+	// 	names << names2
+	// 	types << types2
+	// }
+	return names, types
+}
+
+fn (mut c Checker) fn_decl(decl ast.FnDecl) {
+	// c.log('ast.FnDecl: $decl.name: $c.file.name')
+	// c.log('return type:')
+	// c.expr(decl.typ.return_type)
+	mut prev_scope := c.scope
+	c.open_scope()
+	// mut fn_scope := c.scope
+	// if decl.typ.generic_params.len > 0 {
+	// 	eprintln('## GENERIC FN DECL: $decl.name')
+	// }
+	mut typ := Type(c.fn_type(decl.typ, FnTypeAttribute.from_ast_attributes(decl.attributes)))
+	obj := Fn{
+		name: decl.name
+		typ: typ
+	}
+	// TODO:
+	if decl.is_method {
+		// mut is_mut := false
+		// receiver_type := if decl.receiver.typ is ast.ModifierExpr {
+		// 	c.log('MUT RECEIVER')
+		// 	is_mut = decl.receiver.typ.kind == .key_mut
+		// 	if is_mut { Type(Pointer{base_type: c.expr(decl.receiver.typ.expr)}) }
+		// 	else { c.expr(decl.receiver.typ) }
+		// } else {
+		// 	c.expr(decl.receiver.typ)
+		// }
+		mut receiver_type := c.expr(decl.receiver.typ)
+		if decl.receiver.is_mut {
+			if mut receiver_type is Pointer {
+				c.error_with_pos('use `mut Type` not `mut &Type`. TODO: proper error message',
+					decl.receiver.pos)
+			}
+			receiver_type = Pointer{
+				base_type: receiver_type
+			}
+		}
+
+		c.scope.insert(decl.receiver.name, receiver_type)
+		// TODO: interface methods
+		receiver_base_type := receiver_type.base_type()
+		method_owner_type := if receiver_type is Pointer {
+			receiver_base_type
+		} else {
+			receiver_type
+		}
+		// type_name := if base_type is Interface { receiver_type.name() } else { base_type.name() }
+		// c.env.methods[type_name] << &obj
+		// c.env.methods[receiver_type.base_type().name()] << &obj
+		c.env.methods[method_owner_type.name()] << &obj
+		c.log('registering method: ${decl.name} for ${receiver_type.name()} - ${method_owner_type.name()} - ${receiver_base_type.name()}')
+		c.scope.insert(decl.receiver.name, c.expr(decl.receiver.typ))
+	} else {
+		if decl.language == .c {
+			c.c_scope.insert(decl.name, obj)
+		} else {
+			prev_scope.insert(decl.name, obj)
+		}
+	}
+	fn_decl := decl
+	deferred_kind := if decl.typ.generic_params.len > 0 {
+		DeferredKind.fn_decl_generic
+	} else {
+		DeferredKind.fn_decl
+	}
+	// if decl.typ.generic_params.len == 0 {
+	c.later(fn [mut c, fn_decl, typ] () {
+		// if fn_decl.typ.generic_params.len > 0 {
+		// 	panic('GENERIC FN')
+		// }
+		// eprintln('@@ FnDecl: $fn_decl.name - $fn_decl.typ.generic_params.len')
+		if typ is FnType {
+			if fn_decl.typ.generic_params.len > 0 {
+				// eprintln('## DEFERRED GENERIC FN: $fn_decl.name - $typ.generic_params.len')
+				// eprintln('FnType:')
+				// eprintln(typ)
+				generic_types := c.env.generic_types[fn_decl.name] or {
+					c.error_with_pos('missing generic type information for ${fn_decl.name}',
+						fn_decl.pos)
+				}
+				c.env.cur_generic_types << generic_types
+				// c.env.cur_generic_types << typ.generic_types
+				// // dump(generic_types)
+			}
+			// if typ.generic_params.len == 0 || (typ.generic_params.len > 0 && typ.generic_types.len > 0) {
+			if typ.generic_params.len == 0
+				|| (typ.generic_params.len > 0 && c.env.cur_generic_types.len > 0) {
+				expected_type := c.expected_type
+				c.expected_type = typ.return_type
+				c.stmt_list(fn_decl.stmts)
+				c.expected_type = expected_type
+			}
+			c.env.cur_generic_types = []
+		}
+	}, deferred_kind)
+	// }
+	c.close_scope()
+}
+
+fn (mut c Checker) if_expr(expr ast.IfExpr) Type {
+	c.open_scope()
+	// BIG MESS peanut head! Fix this :)
+	// TODO: this probably is not the best way to do this
+	// need to think about this some more. also should this only
+	// work for the top level? how complicated can this get? eiip
+	// NOTE: in the current compiler there are smartcasts and then there
+	// are explicit auto casts. I have inplemeted this just using smartcasts
+	// for now, however I will come back to this, and work out what is most appropriate
+	mut cond_type := Type(void_)
+	mut is_inline_smartcast := false
+	cond := c.unwrap_expr(expr.cond)
+	if cond is ast.InfixExpr {
+		cond_type = Type(bool_)
+		mut left_node := c.unwrap_expr(cond.lhs)
+		for mut left_node is ast.InfixExpr {
+			left_node_rhs := c.unwrap_expr(left_node.rhs)
+			if left_node.op == .and && left_node_rhs is ast.InfixExpr {
+				if left_node_rhs.op == .key_is {
+					is_inline_smartcast = true
+					// c.expr(left_node.rhs)
+					sc_names, sc_types := c.extract_smartcasts(left_node.rhs)
+					c.apply_smartcasts(sc_names, sc_types)
+					// c.expr(left_node.lhs)
+				}
+			}
+			if left_node.op == .key_is {
+				is_inline_smartcast = true
+				// c.expr(left_node.lhs)
+				sc_names, sc_types := c.extract_smartcasts(left_node)
+				c.apply_smartcasts(sc_names, sc_types)
+				// c.expr(left_node.rhs)
+				break
+			} else if left_node.op == .and {
+				left_node = c.unwrap_expr(left_node.lhs)
+			} else {
+				break
+			}
+		}
+		right_node := c.unwrap_expr(cond.rhs)
+		if right_node is ast.InfixExpr && right_node.op == .key_is {
+			is_inline_smartcast = true
+			// c.expr(right_node.lhs)
+			sc_names, sc_types := c.extract_smartcasts(right_node)
+			c.apply_smartcasts(sc_names, sc_types)
+			// c.expr(right_node.rhs)
+		}
+	}
+	if !is_inline_smartcast {
+		// println('## not is_inline_smartcast')
+		cond_type = c.expr(expr.cond)
+		sc_names, sc_types := c.extract_smartcasts(expr.cond)
+		c.apply_smartcasts(sc_names, sc_types)
+	}
+	_ = cond_type
+	c.stmt_list(expr.stmts)
+	mut typ := Type(void_)
+	if expr.stmts.len > 0 {
+		last_stmt := expr.stmts.last()
+		if last_stmt is ast.ExprStmt {
+			typ = c.expr(last_stmt.expr)
+		}
+	}
+	c.close_scope()
+	// return typ
+	else_type := if expr.else_expr !is ast.EmptyExpr { c.expr(expr.else_expr) } else { typ }
+	return else_type
+	// TODO: check all branches types match
+}
+
+fn (mut c Checker) match_expr(expr ast.MatchExpr, used_as_expr bool) Type {
+	expr_type := c.expr(expr.expr)
+	expected_type := c.expected_type
+	if expr_type is Enum {
+		c.expected_type = expr_type
+	}
+	mut last_stmt_type := Type(void_)
+	for i, branch in expr.branches {
+		c.open_scope()
+		for cond in branch.cond {
+			expr_unwrapped := c.unwrap_ident(expr.expr)
+			cond_type := c.expr(cond)
+			if cond in [ast.Ident, ast.SelectorExpr] {
+				// `.value` enum value (without type)
+				if cond is ast.SelectorExpr && cond.lhs is ast.EmptyExpr {
+					continue
+				}
+				c.apply_smartcast(expr_unwrapped, cond_type)
+			}
+		}
+		c.stmt_list(branch.stmts)
+		// mut is_noreturn := false
+		if used_as_expr && branch.stmts.len > 0 {
+			last_stmt := branch.stmts.last()
+			if last_stmt is ast.ExprStmt {
+				t := c.expr(last_stmt.expr)
+				// TODO: non else branch can only return void if its a noreturn
+				// if last_stmt is ast.ExprStmt {
+				// 	if last_stmt.expr is ast.CallExpr {
+				// 		lhs := c.expr(last_stmt.expr.lhs)
+				// 		if lhs is FnType {
+				// 			is_noreturn = lhs.attributes.has(.noreturn)
+				// 		}
+				// 	}
+				// }
+				// TODO: fix last branch / void expr
+				// actually make sure its an else branch
+				if _ := expected_type {
+					if i > 0 && (i < expr.branches.len - 1 && t !is Void) {
+						// if t != last_stmt_type {
+						if !t.is_compatible_with(last_stmt_type) {
+							// TODO: better error message
+							c.error_with_pos('${i} all branches must return same type (exp ${last_stmt_type.name()} got ${t.name()})',
+								last_stmt.expr.pos())
+						}
+					}
+					last_stmt_type = t
+				}
+			}
+		}
+		c.close_scope()
+	}
+	c.expected_type = expected_type
+	return last_stmt_type
+}
+
+// TODO: unwrap ModifierExpr etc
+// fn (mut c Checker) argument() ast.Expr {}
+
+fn (mut c Checker) resolve_generic_arg_or_index_expr(expr ast.GenericArgOrIndexExpr) ast.Expr {
+	lhs_type := c.expr(expr.lhs)
+	// expr_type := c.expr(expr.expr)
+	if lhs_type is FnType {
+		return ast.GenericArgs{
+			lhs: expr.lhs
+			args: [expr.expr]
+		}
+	} else {
+		// c.unwrap_lhs_expr(ast.IndexExpr{lhs: expr.lhs, expr: expr.expr})
+		return ast.IndexExpr{
+			lhs: expr.lhs
+			expr: expr.expr
+		}
+	}
+}
+
+fn (mut c Checker) resolve_call_or_cast_expr(expr ast.CallOrCastExpr) ast.Expr {
+	lhs_type := c.expr(expr.lhs)
+	// expr_type := c.expr(expr.expr)
+	if lhs_type is FnType {
+		return ast.CallExpr{
+			lhs: expr.lhs
+			args: [expr.expr]
+			pos: expr.pos
+		}
+	} else {
+		// c.log(expr)
+		return ast.CastExpr{
+			typ: expr.lhs
+			expr: expr.expr
+			pos: expr.pos
+		}
+	}
+}
+
+// TODO:
+fn (mut c Checker) resolve_expr(expr ast.Expr) ast.Expr {
+	match expr {
+		ast.CallOrCastExpr {
+			return c.resolve_call_or_cast_expr(expr)
+		}
+		ast.GenericArgOrIndexExpr {
+			return c.resolve_generic_arg_or_index_expr(expr)
+		}
+		else {
+			return expr
+		}
+	}
+}
+
+// TODO:
+fn (mut c Checker) unwrap_ident(expr ast.Expr) ast.Expr {
+	match expr {
+		ast.ModifierExpr {
+			return expr.expr
+		}
+		else {
+			return expr
+		}
+	}
+}
+
+// TODO:
+fn (mut c Checker) unwrap_expr(expr ast.Expr) ast.Expr {
+	match expr {
+		// ast.Ident, ast.IndexExpr, ast.SelectorExpr {
+		// 	return expr
+		// }
+		ast.CallOrCastExpr {
+			// return c.unwrap_expr(c.resolve_expr(expr.expr))
+			return c.unwrap_expr(c.resolve_call_or_cast_expr(expr))
+		}
+		ast.ModifierExpr {
+			// TODO: actually do something with modifiers :)
+			return c.unwrap_expr(expr.expr)
+		}
+		ast.ParenExpr {
+			return c.unwrap_expr(expr.expr)
+		}
+		ast.PrefixExpr {
+			return c.unwrap_expr(expr.expr)
+		}
+		else {
+			// TODO: expr.pos()
+			// c.error_with_pos('unwrap_expr: missing impl for expr ${expr.type_name()}', 2)
+			// no unwrap needed
+			return expr
+		}
+	}
+}
+
+// TODO:
+fn (mut c Checker) unwrap_lhs_expr(expr ast.Expr) ast.Expr {
+	match expr {
+		ast.ModifierExpr {
+			// return expr.expr
+			return c.unwrap_lhs_expr(expr.expr)
+		}
+		ast.GenericArgs {
+			// lhs_type := c.expr(expr.lhs)
+			mut generic_arg_types := []Type{}
+			for arg in expr.args {
+				generic_arg_types << c.expr(arg)
+			}
+			return expr.lhs
+		}
+		ast.GenericArgOrIndexExpr {
+			return c.unwrap_lhs_expr(c.resolve_generic_arg_or_index_expr(expr))
+		}
+		else {
+			return expr
+		}
+	}
+}
+
+// TODO: clean up & add any missing cases & missing recursion
+fn (mut c Checker) infer_generic_type(param_type Type, arg_type Type, mut type_map map[string]Type) ! {
+	map_type := fn [mut type_map] (name string, typ Type) ! {
+		if existing := type_map[name] {
+			// TODO: might need custom eq methods
+			if existing != typ && typ !is NamedType {
+				return error('${name} was previouly used as ${existing.name()}, got ${typ.name()}')
+			}
+		}
+		type_map[name] = typ
+	}
+	match param_type {
+		Array {
+			if param_type.elem_type is NamedType && arg_type is Array {
+				map_type(param_type.elem_type, arg_type.elem_type)!
+			}
+		}
+		Channel {
+			if pt_et := param_type.elem_type {
+				if pt_et is NamedType && arg_type is Channel {
+					if at_et := arg_type.elem_type {
+						map_type(pt_et, at_et)!
+					}
+				}
+			}
+		}
+		FnType {
+			if arg_type is FnType {
+				for i, param_param in param_type.params {
+					arg_param := arg_type.params[i]
+					c.infer_generic_type(param_param.typ, arg_param.typ, mut type_map)!
+				}
+				if param_rt := param_type.return_type {
+					if arg_rt := arg_type.return_type {
+						c.infer_generic_type(param_rt, arg_rt, mut type_map)!
+					}
+				}
+			}
+		}
+		Map {
+			if arg_type is Map {
+				if param_type.key_type is NamedType {
+					map_type(param_type.key_type, arg_type.key_type)!
+				}
+				if param_type.value_type is NamedType {
+					map_type(param_type.value_type, arg_type.value_type)!
+				}
+			}
+		}
+		NamedType {
+			map_type(param_type, arg_type)!
+		}
+		Struct {}
+		OptionType {
+			if param_type.base_type is NamedType && arg_type is OptionType {
+				map_type(param_type.base_type, arg_type.base_type)!
+			}
+		}
+		ResultType {
+			if param_type.base_type is NamedType && arg_type is ResultType {
+				map_type(param_type.base_type, arg_type.base_type)!
+			}
+		}
+		Thread {
+			if pt_et := param_type.elem_type {
+				if pt_et is NamedType && arg_type is Thread {
+					if at_et := arg_type.elem_type {
+						map_type(pt_et, at_et)!
+					}
+				}
+			}
+		}
+		else {
+			println('missing ${param_type.type_name()}')
+		}
+	}
+}
+
+fn (mut c Checker) call_expr(expr ast.CallExpr) Type {
+	lhs_expr := c.resolve_expr(expr.lhs)
+	// TODO: remove, see comment at field decl
+	expecting_method := c.expecting_method
+	if lhs_expr is ast.SelectorExpr {
+		c.expecting_method = true
+	}
+	mut fn_ := c.expr(lhs_expr)
+	// fn_ := c.expr(expr.lhs)
+	c.expecting_method = expecting_method
+	// c.log('call expr: $fn_.type_name() - $fn_.name() - ${lhs_expr.type_name()}')
+
+	// if expr.lhs is PrefixExpr {
+	// 	xpr.op
+	// }
+	// if expr.lhs is Postfix
+	// TODO: time.StopWatch has a fields and methods with the same name
+	// and field was being returned instead of the methods. we could set a precedence
+	// however what if the field is a fn type? (i guess one or the other could still habve priority)
+	// TOOD: talk to alex and spy about this
+	if expr.lhs is ast.SelectorExpr {
+		// POO POO
+		// if expr.lhs.lhs is ast.Ident {
+		if fn_ is Primitive && expr.lhs.rhs.name == 'start' {
+			// c.log('#### ${expr.lhs.rhs.name}')
+			// what is going on here?
+			fn_ = FnType{}
+		} else if fn_ is Primitive && expr.lhs.rhs.name == 'elapsed' {
+			// c.log('#### ${expr.lhs.rhs.name}')
+			fn_ = FnType{
+				return_type: Type(Alias{
+					name: 'Duration'
+					base_type: i64_
+				})
+			}
+		}
+		// }
+	}
+	// 	else if lhs_expr is ast.GenericArgs {
+	// 	c.log('GENERIC CALL: ')
+
+	// }
+	if mut fn_ is Alias {
+		fn_ = fn_.base_type
+	}
+	if mut fn_ is FnType {
+		if fn_.generic_params.len > 0 {
+			// file := c.file_set.file(expr.pos)
+			// pos := file.position(expr.pos)
+			// eprintln('GENERIC CALL: $expr.lhs.name() - $expr.pos - $file.name:$pos.line')
+			mut generic_type_map := map[string]Type{}
+			// generic types provided `[int, string]`
+			if lhs_expr is ast.GenericArgs {
+				// panic('GOT GENERIC CALL')
+				mut generic_types := []Type{}
+				for i, ga in lhs_expr.args {
+					generic_param := fn_.generic_params[i]
+					generic_type := c.expr(ga)
+					generic_types << generic_type
+					generic_type_map[generic_param] = generic_type
+				}
+				// eprintln('GENERIC TYPES: $expr.lhs.name()')
+				// dump(generic_types)
+			}
+			// infer generic types from args
+			else {
+				// TODO: move above (to be done globally)
+				// once error is fixed
+				mut arg_types := []Type{}
+				// eprintln('INFERRED GENERIC TYPES: $expr.lhs.name()')
+				for i, arg in expr.args {
+					param := fn_.params[i]
+					arg_type := c.expr(arg).typed_default()
+					arg_types << arg_type
+					// eprintln('call arg: ${param.typ.type_name()} - ${arg_type.type_name()}')
+
+					// println('infcerring call: ')
+					c.infer_generic_type(param.typ, arg_type, mut generic_type_map) or {
+						c.error_with_pos(err.msg(), expr.pos)
+					}
+					// if param.typ !is NamedType {
+					// 	eprintln('Generic argument: $param.typ.name() - $arg_type.name()')
+					// 	eprintln('should be NamedType but got $param.typ.name()')
+					// }
+				}
+			}
+			// eprintln('## GENERIC TYPE MAP: $expr.lhs.name()')
+			// eprintln('========================')
+			// for k,v in generic_type_map {
+			// 	eprintln(' * $k -> $v')
+			// }
+			// eprintln('========================')
+			// if expr.lhs is ast.Ident {
+			// 	if expr.lhs.name == 'generic_fn_d' {
+			// 		panic('.')	
+			// 	}
+			// }
+			// dump(generic_type_map)
+			if generic_type_map.len > 0 {
+				fn_.generic_types << generic_type_map
+				c.env.generic_types[lhs_expr.name()] << generic_type_map
+			}
+		} else if lhs_expr is ast.GenericArgs {
+			c.error_with_pos('cannot call non generic fuction with generic argument list',
+				expr.pos)
+		}
+
+		// TODO: is this best place for this?
+		// why is it not beeing used any more? check if we are somehow skipping its uses
+		// need to find a better way to do this, this only happens becasue there are
+		// compiler magic, call_expr & selector expr both end up needing information which
+		// the other one has
+		if lhs_expr is ast.SelectorExpr {
+			if lhs_expr.rhs.name in ['filter', 'map'] {
+				if rt := fn_.return_type {
+					// c.log('#### it variable inserted')
+					// fn_.scope.insert('it', rt)
+					c.scope.insert('it', rt.value_type())
+				}
+				if lhs_expr.rhs.name == 'map' {
+					rt := c.expr(expr.args[0])
+					c.log('map: ${rt.name()}')
+					fn_ = FnType{
+						...fn_
+						return_type: Array{
+							elem_type: rt
+						}
+					}
+				}
+			}
+		}
+		// TODO/FIXME: is FnType.return_type goin to stay optional
+		// or not and just use void in case of returning nothing
+		if return_type := fn_.return_type {
+			// if expr.lhs is ast.SelectorExpr {
+			// 	if expr.lhs.lhs is ast.Ident {
+			// 		if expr.lhs.lhs.name == 'g_timers' && expr.lhs.rhs.name == 'show' {
+			// 			c.log('## 2 ${expr.lhs.lhs.name}: fn_.type()')
+			// 		}
+			// 	}
+			// }
+			c.log('returning: ${return_type.name()}')
+			return return_type
+		}
+		return void_
+	}
+
+	for arg in expr.args {
+		c.expr(arg)
+	}
+
+	c.error_with_pos('call on non fn: ${fn_.type_name()}', expr.pos)
+}
+
+// TODO:
+// fn (mut c Checker) fn_arguments() {}
+
+// fn (mut c Checker) declare(scope &Scope, name string) {
+
+// }
+
+fn (mut c Checker) fn_type(fn_type ast.FnType, attributes FnTypeAttribute) FnType {
+	// c.open_scope()
+	// array of T types
+	mut generic_params := []string{}
+	for generic_param in fn_type.generic_params {
+		if generic_param is ast.Ident {
+			// generic_params << NamedType(generic_param.name)
+			generic_params << generic_param.name
+		} else {
+			// TODO: correct position
+			c.error_with_pos('expecting identifier', 0)
+		}
+	}
+	mut params := []Parameter{}
+	mut is_variadic := false
+	// TODO: proper
+	if generic_params.len > 0 {
+		c.generic_params = generic_params
+	}
+	for i, param in fn_type.params {
+		// of param type is generic, replace with NamedType
+		// mut param_type := if param.typ is ast.Ident {
+		// 	if param.typ.name in generic_params {
+		// 		Type(NamedType(param.typ.name))
+		// 	} else {
+		// 		c.expr(param.typ)
+		// 	}
+		// } else { c.expr(param.typ) }
+		mut param_type := c.expr(param.typ)
+		if param.typ is ast.PrefixExpr {
+			if param.typ.op == .ellipsis {
+				if i < fn_type.params.len - 1 {
+					c.error_with_pos('variadic must be last parameter.', param.pos)
+				}
+				param_type = Array{
+					elem_type: param_type
+				}
+				is_variadic = true
+			}
+		}
+		// if param.is_mut && param_type !is Pointer {
+		if param.is_mut {
+			param_type = Pointer{
+				base_type: param_type
+			}
+		}
+		params << Parameter{
+			name: param.name
+			// typ: c.expr(param.typ)
+			typ: param_type
+			is_mut: param.is_mut
+		}
+		c.scope.insert(param.name, param_type)
+	}
+	// if return type is generic replace with NamedType
+	// mut return_type := if fn_type.return_type is ast.Ident {
+	// 	if fn_type.return_type.name in generic_params {
+	// 		Type(NamedType(fn_type.return_type.name))
+	// 	} else {
+	// 		c.expr(fn_type.return_type)
+	// 	}
+	// } else { c.expr(fn_type.return_type) }
+
+	mut typ := FnType{
+		generic_params: generic_params
+		params: params
+		// return_type: return_type
+		return_type: c.expr(fn_type.return_type)
+		is_variadic: is_variadic
+		attributes: attributes
+		// scope: c.scope
+	}
+	if generic_params.len > 0 {
+		c.generic_params = []
+	}
+	// c.close_scope()
+	return typ
+}
+
+fn (mut c Checker) ident(ident ast.Ident) Object {
+	obj := c.scope.lookup_parent(ident.name, ident.pos) or {
+		if ident.name == '_' {
+			c.error_with_pos('cannot use _ as value or type', ident.pos)
+			// TODO: compiler error
+			return Type(void_)
+		} else {
+			// TODO/FIXME: generic param - hack
+			// if ident.name.len == 1 && ident.name[0].is_capital() {
+			// 	return Type(string_)
+			// }
+		}
+
+		if ident.name in c.generic_params {
+			return Type(NamedType(ident.name))
+		}
+
+		for generic_types in c.env.cur_generic_types {
+			if generic_type := generic_types[ident.name] {
+				// eprintln('## replaced generic type ${ident.name} with ${generic_type.name()}')
+				return generic_type
+			}
+		}
+
+		// TODO: proper
+		if ident.name in [
+			'@VROOT',
+			'@VMODROOT',
+			'@VEXEROOT',
+			'@VCURRENTHASH',
+			'@FN',
+			'@METHOD',
+			'@MOD',
+			'@STRUCT',
+			'@VEXE',
+			'@FILE',
+			'@LINE',
+			'@COLUMN',
+			'@VHASH',
+			'@VMOD_FILE',
+			'@FILE_LINE',
+		] {
+			return Type(string_)
+		}
+
+		// TODO: proper
+		if ident.name in ['compile_error', 'compile_warn'] {
+			return Type(FnType{
+				return_type: void_
+			})
+		}
+
+		// c.scope.print(false)
+		// c.scope.print(true)
+		c.error_with_pos('unknown ident `${ident.name} - ${ident.pos}`', ident.pos)
+	}
+	c.log('ident: ${ident.name} - ${obj.typ().name()}')
+	return obj
+}
+
+fn (mut c Checker) selector_expr(expr ast.SelectorExpr) Type {
+	c.log('## selector_expr')
+	// file := c.file_set.file(expr.pos)
+	// pos := file.position(expr.pos)
+	// c.log('${expr.name()} - $expr.rhs.name')
+	// println('selector_expr: ${expr.rhs.name} - ${file.name}:${pos.line} - ${pos.column}')
+
+	// TODO: check todo in scope.v
+	if expr.lhs in [ast.Ident, ast.SelectorExpr] {
+		// println('looking for smartcast $expr.name()')
+		if cast_type := c.scope.lookup_field_smartcast(expr.name()) {
+			// println('## 1 found smartcast for ${expr.name()} - ${cast_type.type_name()} - ${cast_type.name()} - ${expr.rhs.name}')
+			return cast_type
+		}
+		if cast_type := c.scope.lookup_field_smartcast(expr.lhs.name()) {
+			// println('## 2 found smartcast for ${expr.lhs.name()} - ${cast_type.type_name()} - ${cast_type.name()} - ${expr.rhs.name}')
+			return c.find_field_or_method(cast_type, expr.rhs.name) or {
+				c.error_with_pos('## smartcast field lookup error ' + err.msg(), expr.pos)
+			}
+		}
+	}
+
+	if expr.lhs is ast.Ident {
+		lhs_obj := c.ident(expr.lhs)
+		// c.log('LHS.RHS: $expr.lhs.name . $expr.rhs.name - $lhs_obj.typ().name()')
+		match lhs_obj {
+			Const {
+				return c.find_field_or_method(lhs_obj.typ, expr.rhs.name) or {
+					c.error_with_pos(err.msg(), expr.pos)
+				}
+			}
+			Global {
+				return c.find_field_or_method(lhs_obj.typ, expr.rhs.name) or {
+					c.error_with_pos(err.msg(), expr.pos)
+				}
+			}
+			Module {
+				// return lhs_type.scope.lookup_parent(expr.rhs.name)
+				mut mod_scope := lhs_obj.scope
+				rhs_obj := mod_scope.lookup_parent(expr.rhs.name, expr.rhs.pos) or {
+					// TODO: proper
+					if expr.lhs.name == 'C' {
+						// c.log('assuming C constant: $expr.lhs.name . $expr.rhs.name')
+						return int_
+					}
+					mod_scope.print(true)
+					c.error_with_pos('missing ${expr.lhs.name}.${expr.rhs.name}', expr.pos)
+				}
+				return rhs_obj.typ()
+			}
+			Type {
+				return c.find_field_or_method(lhs_obj, expr.rhs.name) or {
+					c.error_with_pos(err.msg(), expr.pos)
+				}
+			}
+			// SmartCastSelector {
+			// 	c.log('@@ found smart cast selector: $expr.rhs.name')
+			// 	if expr.rhs.name == lhs_obj.field {
+			// 		return lhs_obj.cast_type
+			// 		// return c.find_field_or_method(lhs_obj.cast_type, expr.rhs.name) or { c.error_with_pos(err.msg(), expr.pos) }
+			// 	}
+			// 	return c.find_field_or_method(lhs_obj.origin, expr.rhs.name) or { c.error_with_pos(err.msg(), expr.pos) }
+			// }
+			else {
+				c.error_with_pos('unsupported ${lhs_obj.type_name()} - ${expr.rhs.name}',
+					0)
+			}
+		}
+	}
+	// else {
+	// 	panic('unexpected expr.lhs: $expr.lhs.type_name()')
+	// }
+	// TODO: this will be removed
+	// unset when checking lhs, only needed for rightmost selector
+	expecting_method := c.expecting_method
+	c.expecting_method = false
+	lhs_type := c.expr(expr.lhs)
+	c.expecting_method = expecting_method
+	return c.find_field_or_method(lhs_type, expr.rhs.name) or {
+		c.error_with_pos(err.msg(), expr.pos)
+	}
+}
+
+fn (mut c Checker) find_field_or_method(t Type, name string) !Type {
+	// TODO: is this the best way to do this?
+	// this whole field/method search needs to be cleaned up
+	// fields and method with same name should not be allowed to begin with!
+	if c.expecting_method {
+		if method := c.find_method(t, name) {
+			return method
+		}
+	}
+	match t {
+		Alias {
+			// if field_or_method_type := c.find_field_or_method(t, name) {
+			// 	return field_or_method_type
+			// }
+			if field_or_method_type := c.find_field_or_method(t.base_type, name) {
+				return field_or_method_type
+			}
+		}
+		Array {
+			// TODO: has to be a better way
+			// there is probably no reason to look these up, and just do what we do above
+			mut builtin_scope := c.get_module_scope('builtin', universe)
+			at := builtin_scope.lookup_parent('array', 0) or { panic('missing builtin array type') }
+			at_type := at.typ()
+			// c.log('ARRAY: looking for field or method $name on $t.name()')
+			// // dump(t)
+			if field_or_method_type := c.find_field_or_method(at_type, name) {
+				c.log('found ${name}')
+				if field_or_method_type is FnType {
+					if name in ['clone', 'map', 'filter'] {
+						// c.log('SNEAKY: $t.name()')
+						// return t
+						return FnType{
+							...field_or_method_type
+							return_type: t
+						}
+					}
+					// TODO: proper PLEASE! :D
+					else if name in ['first', 'last'] {
+						return FnType{
+							...field_or_method_type
+							return_type: t.elem_type
+						}
+					}
+				}
+				return field_or_method_type
+			}
+		}
+		ArrayFixed {
+			if name in ['clone', 'map', 'filter'] {
+				return FnType{
+					return_type: t
+				}
+			} else if name in ['first', 'last'] {
+				return FnType{
+					return_type: t.elem_type
+				}
+			} else if name == 'len' {
+				return int_
+			}
+		}
+		Channel {
+			println('channel . ${name}')
+			// TODO: sync must be imported when channels are used
+			mut sync_scope := c.get_module_scope('sync', universe)
+			at := sync_scope.lookup_parent('Channel', 0) or { panic('missing builtin chan type') }
+			at_type := at.typ()
+			if field_or_method_type := c.find_field_or_method(at_type, name) {
+				return field_or_method_type
+			}
+		}
+		Enum {
+			for field in t.fields {
+				if field.name == name {
+					return t
+					// return int_
+				}
+			}
+			// flags - compiler magic (currently)
+			if name == 'has' {
+				return bool_
+			} else if name == 'all' {
+				return int_
+			} else if name in ['clear', 'set'] {
+				return void_
+			}
+		}
+		Interface {
+			// c.log('looking for fields on interface ${t.name()}')
+			for field in t.fields {
+				if field.name == name {
+					// c.log('found field ${name} for interface ${t.name()}')
+					if c.expecting_method && field.typ !is FnType {
+						continue
+					}
+					return field.typ
+				}
+			}
+		}
+		Map {
+			mut builtin_scope := c.get_module_scope('builtin', universe)
+			at := builtin_scope.lookup_parent('map', 0) or { panic('missing builtin map type') }
+			at_type := at.typ()
+			// c.log('MAP: looking for field or method $name on $t.name()')
+			if field_or_method_type := c.find_field_or_method(at_type, name) {
+				if name == 'keys' {
+					if field_or_method_type is FnType {
+						return FnType{
+							...field_or_method_type
+							return_type: Array{
+								elem_type: t.key_type
+							}
+						}
+					}
+				}
+				return field_or_method_type
+			}
+		}
+		Pointer {
+			return c.find_field_or_method(t.base_type, name)!
+		}
+		ResultType {
+			return c.find_field_or_method(t.base_type, name)!
+		}
+		// TODO:
+		// currently should be handled at bottom by find_method call
+		// Primitive {
+		// 	c.log('#### method on ptimitive: ${name} on ${t.name()}')
+		// 	// if name in ['free'] { return FnType{return_type: void_} }
+		// }
+		String {
+			if name == 'len' {
+				return int_
+			}
+			if o := c.scope.lookup_parent('string', 0) {
+				// c.log(o)
+				return c.find_field_or_method(o.typ(), name)
+			}
+		}
+		Struct {
+			for field in t.fields {
+				// c.log('comparing field $field.name with $name for $t.name')
+				if field.name == name {
+					c.log('found field ${name} for ${t.name}: ${field.typ.name()} (${field.typ.type_name()})')
+					return field.typ
+				}
+			}
+			for embedded_type in t.embedded {
+				if embedded_field_or_method_type := c.find_field_or_method(embedded_type,
+					name)
+				{
+					return embedded_field_or_method_type
+				}
+			}
+		}
+		SumType {
+			// if !c.expecting_method {
+			mut prev_type := Type(nil_)
+			for i, variant in t.variants {
+				if variant is Struct {
+					mut has_field := false
+					for field in variant.fields {
+						if field.name == name {
+							has_field = true
+							if i > 0 && field.typ != prev_type {
+								return error('field ${name} must have the same type for all variants of ${t.name()}')
+							}
+							prev_type = field.typ
+							break
+						}
+					}
+					if !has_field {
+						return error('not all variants of ${t.name()} have the field ${name}')
+					}
+				}
+			}
+			return prev_type
+			// }
+		}
+		Thread {
+			// TODO:
+			if name == 'wait' {
+				c.open_scope()
+				fn_type := FnType{
+					return_type: t.elem_type or { t }
+				}
+				c.close_scope()
+				return fn_type
+			}
+		}
+		else {
+			c.log('find_field_or_method: unhandled ${t.name()}')
+		}
+	}
+	// else if t is FnType {
+	// 			c.log('FnType: $t.name')
+	// }
+
+	// // dump(t)
+	// c.log('returning none for $t.type_name() - $name')
+	if method := c.find_method(t, name) {
+		return method
+	}
+	if t is Struct {
+		// dump(t.fields)
+	}
+	base_type := t.base_type()
+	return error('cannot find field or method: `${name}` for type ${t.type_name()} - ${t.name()} - (base: ${base_type.type_name()})')
+}
+
+fn (mut c Checker) find_method(t Type, name string) !Type {
+	c.log('looking for method `${name}` on type `${t.name()}`')
+	// TODO: do we need to look for methods on the non base type first?
+	// I think we will for aliases, probably not other types. we might
+	// need to differentiate then for base_type / base_type in this case
+	mut base_type := t.base_type()
+	// TODO: interface methods
+	// if base_type is Interface { base_type = t }
+	base_type_name := if t is Pointer { base_type.name() } else { t.name() }
+	// c.log('base_type_name: $base_type_name - $t.type_name() - $base_type.type_name()')
+	if methods := c.env.methods[base_type_name] {
+		for method in methods {
+			// c.log('# $method.name - $name')
+			if method.name == name {
+				c.log('found method ${name} for ${t.name()}')
+				return method.typ
+			}
+		}
+	}
+	return error('cannot find method `${name}` for `${t.name()}`')
+}
+
+// fn (mut c &Checker) open_scope(node ast.Node, comment string) {
+// 	scope := new_scope(c.scope, node.Pos(), node.End(), comment)
+// 	c.record_scope(node, scope)
+// 	c.scope = scope
+// }
+fn (mut c Checker) open_scope() {
+	c.scope = new_scope(c.scope)
+}
+
+fn (mut c Checker) close_scope() {
+	c.scope = c.scope.parent
+}
+
+// so we can customize the error message used by warn & error
+fn (mut c Checker) error_message(msg string, kind errors.Kind, pos token.Position, file &token.File) {
+	errors.error(msg, errors.details(file, pos, 2), kind, pos)
+}
+
+// fn (mut c Checker) warn(msg string) {
+// 	c.error_message(msg, .warning, p.current_position())
+// }
+
+// [noreturn]
+// fn (mut c Checker) error(msg string) {
+// 	c.error_with_position(msg, p.current_position())
+// }
+
+@[noreturn]
+fn (mut c Checker) error_with_pos(msg string, pos token.Pos) {
+	file := c.file_set.file(pos)
+	c.error_with_position(msg, file.position(pos), file)
+}
+
+@[noreturn]
+fn (mut c Checker) error_with_position(msg string, pos token.Position, file &token.File) {
+	c.error_message(msg, .error, pos, file)
+	exit(1)
+}
+
+@[if verbose ?]
+fn (c Checker) log[T](s T) {
+	println(s)
+}
+
+@[if verbose ?]
+fn (c Checker) elog[T](s T) {
+	eprintln(s)
+}

--- a/vlib/v2/types/module.v
+++ b/vlib/v2/types/module.v
@@ -1,0 +1,19 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module types
+
+pub struct Module {
+	name    string
+	path    string
+	imports []Module
+	scope   &Scope = new_scope(unsafe { nil })
+}
+
+pub fn new_module(name string, path string) &Module {
+	return &Module{
+		name: name
+		path: path
+		scope: new_scope(universe)
+	}
+}

--- a/vlib/v2/types/object.v
+++ b/vlib/v2/types/object.v
@@ -1,0 +1,32 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module types
+
+import v2.token
+
+struct ObjectCommon {
+	parent &Scope = unsafe { nil }
+	pos    token.Pos
+	mod    &Module
+	name   string
+mut:
+	typ Type
+	// order_    u32
+	// color_    color
+}
+
+struct Const {
+	ObjectCommon
+}
+
+struct Global {
+	name string
+	typ  Type
+}
+
+struct Fn {
+	name string
+	// typ  FnType // signature
+	typ Type // signature
+}

--- a/vlib/v2/types/scope.v
+++ b/vlib/v2/types/scope.v
@@ -1,0 +1,156 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module types
+
+import v2.token
+
+pub type Object = Const | Fn | Global | Module | SmartCastSelector | Type
+
+// pub type Object = Const | Fn | Global | Module |
+// 	Alias | Array | Enum | Map | Pointer | Primitive | String | Struct | SumType
+
+struct SmartCastSelector {
+	origin    Type
+	field     string
+	cast_type Type
+}
+
+pub struct Scope {
+	parent &Scope = unsafe { nil }
+mut:
+	objects map[string]Object
+	// TODO: try implement using original concept
+	field_smartcasts map[string]Type
+	// smartcasts map[string]Type
+	// TODO: it may be more efficient looking up local vars using an ID
+	// even if we had to store them in two different places. investigate.
+	// variables []Object
+	start int
+	end   int
+}
+
+pub fn new_scope(parent &Scope) &Scope {
+	unsafe {
+		return &Scope{
+			parent: parent
+		}
+	}
+}
+
+// TODO: try implement the alternate method I was experimenting with (SmartCastSelector)
+// i'm not sure if it is actually possible though. need to explore it.
+pub fn (mut s Scope) lookup_field_smartcast(name string) ?Type {
+	mut scope := unsafe { s }
+	for ; scope != unsafe { nil }; scope = scope.parent {
+		if field_smartcast := scope.field_smartcasts[name] {
+			return field_smartcast
+		}
+	}
+	return none
+}
+
+pub fn (mut s Scope) lookup(name string) ?Object {
+	if obj := s.objects[name] {
+		return obj
+	}
+	return none
+}
+
+pub fn (mut s Scope) lookup_parent(name string, pos token.Pos) ?Object {
+	mut scope := unsafe { s }
+	for ; scope != unsafe { nil }; scope = scope.parent {
+		if obj := scope.lookup(name) {
+			return obj
+			// if !pos.is_valid() || cmpPos(obj.scopePos(), pos) <= 0 {
+			// 	return s, obj
+			// }
+		}
+	}
+	// println('lookup_parent: NOT FOUND: $name')
+	return none
+}
+
+pub fn (mut s Scope) lookup_parent_with_scope(name string, pos token.Pos) ?(&Scope, Object) {
+	mut scope := unsafe { s }
+	for ; scope != unsafe { nil }; scope = scope.parent {
+		if obj := scope.lookup(name) {
+			return scope, obj
+			// if !pos.is_valid() || cmpPos(obj.scopePos(), pos) <= 0 {
+			// 	return s, obj
+			// }
+		}
+	}
+	// println('lookup_parent: NOT FOUND: $name')
+	return none
+}
+
+pub fn (mut s Scope) insert(name string, obj Object) {
+	// println(' - register: $name: ${obj.type_name()}')
+	// TODO/FIXME:
+	// if name in s.objects {
+	// 	println(' #### EXISTS: $name')
+	// 	mut existing := s.objects[name] or { panic('should exist') }
+	// 	if mut existing is Type {
+	// 		if mut existing is Struct {
+	// 			// if existing.name == 'mapnode' {
+	// 				if obj is Type {
+	// 					if obj is Struct {
+	// 						existing.fields = obj.fields
+	// 						// existing.fields << obj.fields
+	// 					}
+	// 				}
+	// 			// }
+	// 		}
+	// 	}
+	// 	// if name == 'mapnode' {
+	// 	// 	println(obj)
+	// 	// 	println(s.objects[name])
+	// 	// 	panic('...')
+	// 	// }
+	// }
+	if name !in s.objects {
+		s.objects[name] = obj
+	}
+}
+
+pub fn (s &Scope) print(recurse_parents bool) {
+	println('# SCOPE:')
+	for name, obj in s.objects {
+		println(' * ${name}: ${obj.type_name()}')
+		// if obj is Type {
+		// 	println('    - ${name}: ${obj.type_name()}')
+		// }
+	}
+	if recurse_parents && s.parent != unsafe { nil } {
+		s.parent.print(recurse_parents)
+	}
+}
+
+pub fn (obj &Object) typ() Type {
+	match obj {
+		Const {
+			return obj.typ
+		}
+		Fn {
+			return obj.typ
+		}
+		Global {
+			return obj.typ
+		}
+		Module {
+			// TODO:
+			println('#### got Module')
+			return Type(u16_)
+		}
+		SmartCastSelector {
+			return obj.origin
+		}
+		Type {
+			return obj
+		}
+		// else {
+		// 	panic('missing obj.typ() for ${obj.type_name()}')
+		// }
+	}
+}

--- a/vlib/v2/types/types.v
+++ b/vlib/v2/types/types.v
@@ -1,0 +1,593 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module types
+
+import v2.ast
+
+// TODO: fix nested sum type in tinyv (like TS)
+pub type Type = Alias
+	| Array
+	| ArrayFixed
+	| Channel
+	| Char
+	| Enum
+	| FnType
+	| ISize
+	| Interface
+	| Map
+	| NamedType
+	| Nil
+	| None
+	| OptionType
+	| Pointer
+	| Primitive
+	| ResultType
+	| Rune
+	| String
+	| Struct
+	| SumType
+	| Thread
+	| Tuple
+	| USize
+	| Void
+
+@[flag]
+enum Properties {
+	boolean
+	float
+	integer
+	unsigned
+	untyped
+}
+
+// TODO: decide if kind will be used or just properties
+// enum PrimitiveKind {
+// 	bool_
+// 	i8_
+// 	i16_
+// 	// i32_
+// 	int_
+// 	i64_
+// 	// u8_
+// 	byte_
+// 	u16_
+// 	u32_
+// 	u64_
+// 	untyped_int
+// 	untyped_float
+// }
+
+struct Primitive {
+	// kind  PrimitiveKind
+	props Properties
+	size  u8
+}
+
+struct Alias {
+	name string
+mut:
+	base_type Type
+}
+
+struct Array {
+	elem_type Type
+}
+
+struct ArrayFixed {
+	len       int
+	elem_type Type
+}
+
+struct Channel {
+	elem_type ?Type
+}
+
+struct Enum {
+	// TODO: store attributes enum or bool?
+	is_flag bool
+	name    string
+	fields  []Field
+	// fields	map[string]Type
+}
+
+struct OptionType {
+	base_type Type
+}
+
+struct Parameter {
+	name   string
+	typ    Type
+	is_mut bool
+}
+
+struct ResultType {
+	base_type Type
+}
+
+@[flag]
+enum FnTypeAttribute {
+	empty
+	noreturn
+}
+
+fn FnTypeAttribute.from_ast_attributes(ast_attrs []ast.Attribute) FnTypeAttribute {
+	mut attrs := FnTypeAttribute.empty
+	for attr in ast_attrs {
+		match attr.name {
+			'noreturn' { attrs.set(.noreturn) }
+			else {}
+		}
+	}
+	return attrs
+}
+
+struct FnType {
+	// generic_params []NamedType // T  ,Y
+	generic_params []string // T  ,Y
+	// TODO: save in checker.env? or gere?
+	// I think I prefer checker env
+	// generic_types  []Types  // int,int
+	params      []Parameter
+	return_type ?Type
+	is_variadic bool
+	attributes  FnTypeAttribute
+mut:
+	generic_types []map[string]Type
+	// scope was originally used for deferred type checking
+	// but its better if we dont need it here, although it may
+	// be meeded for soething later im not thinking of??
+	// 	scope          &Scope
+}
+
+struct Interface {
+	name string
+mut:
+	fields []Field
+	// fields map[string]Type
+	// TODO:
+}
+
+struct Map {
+	key_type   Type
+	value_type Type
+}
+
+struct Pointer {
+	base_type Type
+}
+
+// struct String {
+// }
+
+// Generic `T`, `Y` etc
+type NamedType = string
+
+// struct NamedType {
+// 	name string
+// }
+
+struct Field {
+	name string
+	typ  Type
+}
+
+// struct Method {
+// 	name string
+// 	typ  FnType
+// }
+
+struct Struct {
+	name           string
+	generic_params []string
+mut:
+	embedded []Struct
+	// embedded       []Type
+	fields []Field
+	// fields	 map[string]Type
+	// methods 	   []Method
+}
+
+// TODO:
+fn (t Struct) str() string {
+	return 'Struct.str (${t.name()})'
+}
+
+// TODO: module not included in check
+fn (a Struct) == (b Struct) bool {
+	if a.name == b.name {
+		return true
+	}
+	return false
+}
+
+struct SumType {
+	name string
+mut:
+	variants []Type
+}
+
+struct Thread {
+	elem_type ?Type
+	// return_type Type
+}
+
+struct Tuple {
+	types []Type
+}
+
+type Char = u8
+type ISize = u8
+type USize = u8
+type Rune = u8
+type String = u8
+
+// type IntLiteral = u8
+// type FloatLiteral = u8
+type Void = u8
+type Nil = u8
+type None = u8
+
+fn (t Type) base_type() Type {
+	match t {
+		// TOOD: add base_type method
+		Alias {
+			return t.base_type
+			// should we fully resolve all aliases, or just one level here?
+			// return t.base_type.base_type()
+		}
+		OptionType, ResultType, Pointer {
+			return t.base_type
+		}
+		// TODO: why as I doing this instead of else? to make it easy to find unhandled cases?
+		Primitive, Array, ArrayFixed, Channel, Char, Enum, FnType, Interface, ISize, Map, Rune,
+		String, Struct, SumType, Thread, Tuple, USize, Void, Nil, None, NamedType {
+			return t
+		}
+		// else {
+		// 	return t
+		// }
+	}
+}
+
+// return the key type used with for in loops
+fn (t Type) key_type() Type {
+	match t {
+		Map { return t.key_type }
+		// TOOD: struct here is 'struct string', need to fix this.
+		// we could use an alias? remove once fixed.
+		// Array, ArrayFixed, String, Struct { return int_ }
+		// else { panic('TODO: should never be called on ${t.type_name()}') }
+		// TODO: see checker ForStmt -> ForInStmt when value is pointer
+		else { return int_ }
+	}
+}
+
+// return the value type used with for in loops
+fn (t Type) value_type() Type {
+	match t {
+		Array, ArrayFixed { return t.elem_type }
+		Channel { return t.elem_type or { t } } // TODO: ?
+		Map { return t.value_type }
+		Pointer { return t.base_type.value_type() }
+		String { return u8_ }
+		Thread { return t.elem_type or { t } } // TODO: ?
+		OptionType, ResultType { return t.base_type.value_type() }
+		else { return t.base_type() }
+	}
+}
+
+// converts untyped constant / literal to its default type
+// if is already typed then it returns itself
+fn (t Type) typed_default() Type {
+	// this handles int & float
+	if t is Primitive && t.is_number_literal() {
+		mut concrete_props := t.props
+		concrete_props.clear(.untyped)
+		// TODO: platform dependant size - see universe
+		size := u8(if t.props.has(.float) { 32 } else { 0 })
+		return Primitive{
+			...t
+			props: concrete_props
+			size: size
+		}
+	}
+	return t
+}
+
+// unwraps option or result
+fn (t Type) unwrap() Type {
+	match t {
+		OptionType, ResultType {
+			return t.base_type
+		}
+		else {
+			return t
+		}
+	}
+}
+
+fn (t Type) ref() Pointer {
+	return Pointer{
+		base_type: t
+	}
+}
+
+fn (t Type) deref() Type {
+	if t is Pointer {
+		return t.base_type
+	}
+	panic('Type.deref(): ${t.name()} is not a pointer')
+}
+
+// TODO:
+fn (t Type) is_compatible_with(t2 Type) bool {
+	if t == t2 {
+		return true
+	} else if t is Alias {
+		return t.base_type.is_compatible_with(t2)
+	} else if t2 is Alias {
+		return t.is_compatible_with(t2.base_type)
+	}
+	return false
+}
+
+fn (t Type) is_float() bool {
+	if t is Primitive {
+		return t.is_float()
+	}
+	return false
+}
+
+fn (t Type) is_integer() bool {
+	if t is Primitive {
+		return t.is_integer()
+	}
+	return false
+}
+
+fn (t Type) is_number() bool {
+	if t is ISize {
+		return true
+	}
+	if t is Primitive {
+		return t.is_number()
+	}
+	return false
+}
+
+// int_literal || float_literal
+fn (t Type) is_number_literal() bool {
+	if t is Primitive {
+		return t.is_number_literal()
+	}
+	return false
+}
+
+fn (t Type) is_float_literal() bool {
+	if t is Primitive {
+		return t.is_float_literal()
+	}
+	return false
+}
+
+fn (t Type) is_int_literal() bool {
+	if t is Primitive {
+		return t.is_int_literal()
+	}
+	return false
+}
+
+fn (t Primitive) is_float() bool {
+	return t.props.has(.float)
+}
+
+fn (t Primitive) is_integer() bool {
+	return t.props.has(.integer)
+}
+
+fn (t Primitive) is_number() bool {
+	// TODO: should we make sure is not .untyped
+	return !t.props.has(.untyped) && t.props.has(.integer | .float)
+}
+
+fn (t Primitive) is_number_literal() bool {
+	return t.props.has(.untyped) && t.props.has(.integer | .float)
+}
+
+fn (t Primitive) is_float_literal() bool {
+	return t.props.has(.untyped) && t.props.has(.float)
+}
+
+fn (t Primitive) is_int_literal() bool {
+	return t.props.has(.untyped) && t.props.has(.integer)
+}
+
+fn (t Type) name() string {
+	match t {
+		Primitive, Alias, Array, ArrayFixed, Channel, Char, Enum, FnType, Interface, ISize, Map,
+		OptionType, Pointer, ResultType, Rune, String, Struct, SumType, Thread, Tuple, USize, Void,
+		Nil, None, NamedType {
+			return t.name()
+		}
+	}
+}
+
+// TODO: clean up :0
+fn (t Primitive) name() string {
+	if t.props.has(.boolean) {
+		return 'bool'
+	} else if t.props.has(.untyped) {
+		if t.props.has(.integer) {
+			return 'int_literal'
+		} else if t.props.has(.float) {
+			return 'float_literal'
+		}
+	} else if t.props.has(.integer) {
+		if t.props.has(.unsigned) {
+			return 'u${t.size}'
+		} else {
+			// TODO:
+			if t.size == 0 {
+				return 'int'
+			}
+			return 'i${t.size}'
+		}
+	} else if t.props.has(.float) {
+		return 'f${t.size}'
+	}
+	println(t)
+	panic(t.props.str())
+	return 'malformed primitive' // lol
+	// TODO: match seems broke when multuple flags are set
+	// actually it was not broken, it matches the bits for flags
+	// matches single only, if multiple are set it will not match.
+	//
+	// match t.props {
+	// 	.boolean {
+	// 		return 'bool'
+	// 	}
+	// 	.integer {
+	// 		if t.props.has(.unsigned) {
+	// 			return 'u$t.size'
+	// 		} else {
+	// 			if t.size == 32 {
+	// 				return 'int'
+	// 			}
+	// 			return 'i$t.size'
+	// 		}
+	// 	}
+	// 	.float {
+	// 		return 'f$t.size'
+	// 	}
+	// 	else {
+	// 		println(t)
+	// 		panic(t.props.str())
+	// 		return 'malformed primitive' // lol
+	// 	}
+	// }		
+}
+
+fn (t Alias) name() string {
+	return t.name
+}
+
+fn (t Array) name() string {
+	return '[]${t.elem_type.name()}'
+}
+
+fn (t ArrayFixed) name() string {
+	return '[${t.len}]${t.elem_type.name()}'
+}
+
+fn (t Channel) name() string {
+	if elem_type := t.elem_type {
+		return 'chan ${elem_type.name()}'
+	}
+	return 'chan'
+}
+
+fn (t Char) name() string {
+	return 'char'
+}
+
+fn (t Enum) name() string {
+	return t.name
+}
+
+fn (t FnType) name() string {
+	mut name := 'fn ('
+	for i, param in t.params {
+		if param.name.len > 0 {
+			name += '${param.name} '
+		}
+		name += param.typ.name()
+		if i < t.params.len - 1 {
+			name += ', '
+		}
+	}
+	mut return_type_name := ''
+	if rt := t.return_type {
+		return_type_name = rt.name()
+	}
+	name += ') ${return_type_name}'
+	return name
+}
+
+fn (t Interface) name() string {
+	return t.name
+}
+
+fn (t Map) name() string {
+	return 'map[${t.key_type.name()}]${t.value_type.name()}'
+}
+
+fn (t NamedType) name() string {
+	return t
+}
+
+fn (t OptionType) name() string {
+	return '?' + t.base_type.name()
+}
+
+fn (t Pointer) name() string {
+	return '&' + t.base_type.name()
+}
+
+fn (t ResultType) name() string {
+	return '!' + t.base_type.name()
+}
+
+fn (t Rune) name() string {
+	return 'rune'
+}
+
+fn (t String) name() string {
+	return 'string'
+}
+
+fn (t Struct) name() string {
+	return t.name
+}
+
+fn (t SumType) name() string {
+	return t.name
+}
+
+fn (t Thread) name() string {
+	return 'thread'
+}
+
+fn (t Tuple) name() string {
+	// TODO: use faster method
+	types_str := t.types.map(|typ| typ.name()).join(', ')
+	return 'tuple (${types_str})'
+}
+
+fn (t ISize) name() string {
+	return 'isize'
+}
+
+fn (t USize) name() string {
+	return 'usize'
+}
+
+// fn (t IntLiteral) name() string {
+// 	return 'int_literal'
+// }
+
+// fn (t FloatLiteral) name() string {
+// 	return 'float_literal'
+// }
+
+fn (t Void) name() string {
+	return 'void'
+}
+
+fn (t Nil) name() string {
+	return 'nil'
+}
+
+fn (t None) name() string {
+	return 'none'
+}

--- a/vlib/v2/types/universe.v
+++ b/vlib/v2/types/universe.v
@@ -1,0 +1,140 @@
+// Copyright (c) 2020-2023 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+// [has_globals]
+module types
+
+// __global universe = init_universe()
+const universe = init_universe()
+
+const (
+	// primitives
+	bool_ = Primitive{
+		props: .boolean
+	}
+	i8_ = Primitive{
+		props: .integer
+		size: 8
+	}
+	i16_ = Primitive{
+		props: .integer
+		size: 16
+	}
+	i32_ = Primitive{
+		props: .integer
+		size: 32
+	}
+	// TODO: represent platform specific size
+	// will this be calculated at compile time?
+	int_ = Primitive{
+		props: .integer
+		// size: 32
+	}
+	i64_ = Primitive{
+		props: .integer
+		size: 64
+	}
+	u8_ = Primitive{
+		props: .integer | .unsigned
+		size: 8
+	}
+	// byte_ = Primitive{props: .integer | .unsigned, size: 8}
+	byte_ = Alias{
+		name: 'byte'
+		base_type: u8_
+	}
+	u16_ = Primitive{
+		props: .integer | .unsigned
+		size: 16
+	}
+	u32_ = Primitive{
+		props: .integer | .unsigned
+		size: 32
+	}
+	u64_ = Primitive{
+		props: .integer | .unsigned
+		size: 64
+	}
+	f32_ = Primitive{
+		props: .float
+		size: 32
+	}
+	f64_ = Primitive{
+		props: .float
+		size: 64
+	}
+	// complex / non primitives
+	string_  = String(0)
+	chan_    = Channel{}
+	char_    = Char(0)
+	isize_   = ISize(0)
+	usize_   = USize(0)
+	rune_    = Rune(0)
+	void_    = Void(0)
+	nil_     = Nil(0)
+	none_    = None(0)
+	byteptr_ = Alias{
+		name: 'byteptr'
+		base_type: Pointer{
+			base_type: byte_
+		}
+	}
+	charptr_ = Alias{
+		name: 'charptr'
+		base_type: Pointer{
+			base_type: char_
+		}
+	}
+	voidptr_ = Alias{
+		name: 'voidptr'
+		base_type: Pointer{
+			base_type: void_
+		}
+	}
+	int_literal_ = Primitive{
+		props: .untyped | .integer
+	}
+	float_literal_ = Primitive{
+		props: .untyped | .float
+	}
+	// int_literal_   = IntLiteral(0)
+	// float_literal_ = FloatLiteral(0)
+	// TODO: is this what thread should be?
+	thread_ = Thread{}
+)
+
+pub fn init_universe() &Scope {
+	// universe scope
+	mut universe_ := new_scope(unsafe { nil })
+	universe_.insert('bool', Type(types.bool_))
+	universe_.insert('i8', Type(types.i8_))
+	universe_.insert('i16', Type(types.i16_))
+	universe_.insert('i32', Type(types.i32_))
+	universe_.insert('int', Type(types.int_))
+	universe_.insert('i64', Type(types.i64_))
+	universe_.insert('u8', Type(types.u8_))
+	universe_.insert('byte', Type(types.byte_))
+	universe_.insert('u16', Type(types.u16_))
+	universe_.insert('u32', Type(types.u32_))
+	universe_.insert('u64', Type(types.u64_))
+	universe_.insert('f32', Type(types.f32_))
+	universe_.insert('f64', Type(types.f64_))
+	// TODO:
+	universe_.insert('string', Type(types.string_))
+	universe_.insert('chan', Type(types.chan_))
+	universe_.insert('char', Type(types.char_))
+	universe_.insert('isize', Type(types.isize_))
+	universe_.insert('usize', Type(types.usize_))
+	universe_.insert('rune', Type(types.rune_))
+	universe_.insert('void', Type(types.void_))
+	universe_.insert('nil', Type(types.nil_))
+	universe_.insert('none', Type(types.nil_))
+	universe_.insert('byteptr', Type(types.byteptr_))
+	universe_.insert('charptr', Type(types.charptr_))
+	universe_.insert('voidptr', Type(types.voidptr_))
+	universe_.insert('int_literal', Type(types.int_literal_))
+	universe_.insert('float_literal', Type(types.float_literal_))
+	universe_.insert('float_literal', Type(types.float_literal_))
+	universe_.insert('thread', Type(types.thread_))
+	return universe_
+}

--- a/vlib/v2/util/worker_pool.v
+++ b/vlib/v2/util/worker_pool.v
@@ -1,0 +1,74 @@
+module util
+
+// TODO: remove workaround once fixed in compiler
+struct SharedIntWorkaround {
+pub mut:
+	value int
+}
+
+pub struct WorkerPool[T, Y] {
+mut:
+	workers   []thread
+	queue_len shared SharedIntWorkaround
+	ch_in     chan T
+	ch_out    chan Y
+}
+
+pub fn WorkerPool.new[T, Y]() &WorkerPool[T, Y] {
+	return &WorkerPool[T, Y]{
+		ch_in: chan T{cap: 1000}
+		ch_out: chan Y{cap: 1000}
+	}
+}
+
+pub fn (mut wp WorkerPool[T, Y]) add_worker(t thread) {
+	wp.workers << t
+}
+
+pub fn (mut wp WorkerPool[T, Y]) active_jobs() int {
+	return lock wp.queue_len {
+		wp.queue_len.value
+	}
+}
+
+pub fn (mut wp WorkerPool[T, Y]) get_job() !T {
+	return <-wp.ch_in or { none }
+}
+
+pub fn (mut wp WorkerPool[T, Y]) push_result(result Y) {
+	wp.ch_out <- result
+	wp.job_done()
+}
+
+pub fn (mut wp WorkerPool[T, Y]) job_done() {
+	lock wp.queue_len {
+		wp.queue_len.value--
+	}
+}
+
+pub fn (mut wp WorkerPool[T, Y]) queue_job(job T) {
+	wp.ch_in <- job
+	lock wp.queue_len {
+		wp.queue_len.value++
+	}
+}
+
+pub fn (mut wp WorkerPool[T, Y]) queue_jobs(jobs []T) {
+	for job in jobs {
+		wp.queue_job(job)
+	}
+}
+
+pub fn (mut wp WorkerPool[T, Y]) wait_for_results() []Y {
+	mut results := []Y{}
+	for wp.active_jobs() > 0 {
+		result := <-wp.ch_out
+		results << result
+	}
+
+	wp.ch_in.close()
+	wp.ch_out.close()
+	wp.workers.wait()
+
+	return results
+}


### PR DESCRIPTION
<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2fffcfa</samp>

This pull request adds the initial implementation of the v2 command-line tool and its supporting modules. It includes the main function, the builder struct and its methods for parsing, type checking, and generating code, the error handling and reporting, the type parsing, the module resolution, and the preferences. It also adds some test files for the parser features, such as generics and advance.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2fffcfa</samp>

*  Add the main module and function for the v2 command-line tool ([link](https://github.com/vlang/v/pull/19963/files?diff=unified&w=0#diff-e3b083bb27b9535528f704308cf95e6b8d4ac831e46ae07e9053227134ecd63aR1-R28)). It uses the `pref` module to create preferences from the command-line arguments and the `builder` module to build the given files.
