### PR TITLE
cgen: fix  ref and deref when interface as a function parameter(fix #19947)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2318,6 +2318,10 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					g.write(')')
 					return
 				}
+			} else if arg_sym.kind == .interface_ && exp_sym.kind == .interface_ {
+				if exp_is_ptr && !arg_is_ptr {
+					g.write('&')
+				}
 			}
 		}
 	} else if arg_typ.has_flag(.shared_f) && !expected_type.has_flag(.shared_f) {

--- a/vlib/v/tests/fn_call_interface_args_test.v
+++ b/vlib/v/tests/fn_call_interface_args_test.v
@@ -1,0 +1,12 @@
+interface Foo {}
+
+fn has_interface_args(mut a Foo, b &Foo, c Foo) {
+	assert a == &Foo(1)
+	assert b == &Foo(1)
+	assert c == Foo(1)
+}
+
+fn test_fn_call_interface_args() {
+	mut arg := Foo(1)
+	has_interface_args(mut arg, arg, arg)
+}


### PR DESCRIPTION
1. Fixed #19947 
2. Add tests.

```v
interface Foo {}

fn main() {
	foo := Foo(1)
	thing(foo)
}

fn thing(src_objects Foo) {
	other_thing(src_objects, src_objects)
}

fn other_thing(a &Foo, b &Foo) {
	dump(a)
	dump(b)
}
```
outputs:
```
[a.v:14] a: &Foo(1)
[a.v:15] b: &Foo(1)
```