### PR TITLE
doc: update linebreak logic, handle "highlight-comments"

### DIFF
--- a/cmd/tools/vdoc/tests/testdata/multiline/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.comments.out
@@ -5,5 +5,40 @@ fn a1()
 fn a2()
     this should be merged into the same line
 fn a3()
-    This should be its own parapgraph, because it ends with a dot.  
+    This should be its own parapgraph.
+    
     This should be another paragraph.
+fn a4()
+    This should be merged into one parapgraph.
+    
+    Note: this should be it's own paragraph.
+fn a5()
+    This should be its own parapgraph.
+    
+    Note: this should also be it own paragraph
+    
+    Note: this should be it's own paragraph.
+fn a6()
+    A comment
+    
+    Fixme: this should be it's own paragraph.
+    
+    Fixme: this should be it's own paragraph.
+    
+    Fixme: this should be it's own paragraph.
+fn a7()
+    A comment
+    
+    Todo: this should be it's own paragraph.
+    
+    Todo: this should be it's own paragraph.
+    
+    Todo: this should be it's own paragraph.
+fn a8()
+    A comment
+    
+    Todo: this should be it's own paragraph.
+    
+    Note: this should be it's own paragraph.
+    
+    Fixme: this should be it's own paragraph.

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.out
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.out
@@ -3,3 +3,8 @@ module main
 fn a1()
 fn a2()
 fn a3()
+fn a4()
+fn a5()
+fn a6()
+fn a7()
+fn a8()

--- a/cmd/tools/vdoc/tests/testdata/multiline/main.v
+++ b/cmd/tools/vdoc/tests/testdata/multiline/main.v
@@ -9,8 +9,47 @@ pub fn a2() {
 	println('hi')
 }
 
-// This should be its own parapgraph, because it ends with a dot.
+// This should be its own parapgraph.
+//
 // This should be another paragraph.
 pub fn a3() {
+	println('hi')
+}
+
+// This should be merged
+// into one parapgraph.
+// Note: this should be it's own paragraph.
+pub fn a4() {
+	println('hi')
+}
+
+// This should be its own parapgraph.
+// NOTE: this should also be it own paragraph
+// note: this should be it's own paragraph.
+pub fn a5() {
+	println('hi')
+}
+
+// A comment
+// Fixme: this should be it's own paragraph.
+// fixme: this should be it's own paragraph.
+// FIXME: this should be it's own paragraph.
+pub fn a6() {
+	println('hi')
+}
+
+// A comment
+// TODO: this should be it's own paragraph.
+// todo: this should be it's own paragraph.
+// Todo: this should be it's own paragraph.
+pub fn a7() {
+	println('hi')
+}
+
+// A comment
+// TODO: this should be it's own paragraph.
+// NOTE: this should be it's own paragraph.
+// FIXME: this should be it's own paragraph.
+pub fn a8() {
 	println('hi')
 }

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
@@ -3,8 +3,7 @@ module main
 fn funky()
     hello
     
-    empty line
-    newline using a full stop.  
+    line after empty line, newline after commentline.
     ```v
     code
     ```

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.v
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.v
@@ -1,7 +1,7 @@
 // hello
 //
-// empty line
-// newline using a full stop.
+// line after empty line,
+// newline after commentline.
 // ```v
 // code
 // ```

--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -408,6 +408,8 @@ hr {
 	font-size: 1rem;
 	line-height: 1.6;
 	letter-spacing: 0.025em;
+	max-width: 100ch;
+	word-wrap: break-word;
 }
 .doc-content a {
 	color: #2779bd;


### PR DESCRIPTION
The PR updates the linebreak handling and treats lines that start with `Note` || `Fixme` || `Todo` (indepdent of lettercase) as own paragraphs. 

The current logic of adding line breaks after periods was removed, as it inevitable results in inconsistencies. Instead, a word-wrap via css was added if a line exceeds 100 characters (this similar to how doc comments are handled in go docs). While removing the period line breaks might not result in a better outcome for every single case that intentionally made use of this, I think for the bigger part can benefit from the change and that the general consistency outweigh it.

Many comments use `Note:` / `NOTE:` / `note:` to add additional info or emphasize something. 
Those would now be put into a separate paragraph. If such a comment is used, the casing would now also be made uniform to `Note:` (it's the most often used and also the casing for highlight commetns on github). Same for `Fixme:` and `Todo:`


Example:
![Screenshot_20231122_111635](https://github.com/vlang/v/assets/34311583/ba588fa0-1826-4897-8a83-e9bde8303411)

![Screenshot_20231122_111628](https://github.com/vlang/v/assets/34311583/adee26b0-fad0-4bc7-96c8-4b6555e49340)


Test locally via:
```
v self
v doc -m -f html vlib

```
Open `/vlib/_docs/index.html` in a browser