### PR TITLE
cgen: fix const array of struct initiatization on msvc

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -148,6 +148,11 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 	}
 	g.write('{')
 	if node.has_val {
+		tmp_inside_array := g.inside_array_item
+		g.inside_array_item = true
+		defer {
+			g.inside_array_item = tmp_inside_array
+		}
 		elem_type := (array_type.unaliased_sym.info as ast.ArrayFixed).elem_type
 		elem_sym := g.table.final_sym(elem_type)
 		for i, expr in node.exprs {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -144,6 +144,7 @@ mut:
 	inside_cast_in_heap       int // inside cast to interface type in heap (resolve recursive calls)
 	inside_cast               bool
 	inside_const              bool
+	inside_array_item         bool
 	inside_const_opt_or_res   bool
 	inside_lambda             bool
 	inside_cinit              bool

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -142,6 +142,7 @@ mut:
 	inside_for_c_stmt         bool
 	inside_comptime_for_field bool
 	inside_cast_in_heap       int // inside cast to interface type in heap (resolve recursive calls)
+	inside_cast               bool
 	inside_const              bool
 	inside_const_opt_or_res   bool
 	inside_lambda             bool
@@ -4564,6 +4565,11 @@ fn (mut g Gen) ident(node ast.Ident) {
 }
 
 fn (mut g Gen) cast_expr(node ast.CastExpr) {
+	tmp_inside_cast := g.inside_cast
+	g.inside_cast = true
+	defer {
+		g.inside_cast = tmp_inside_cast
+	}
 	node_typ := g.unwrap_generic(node.typ)
 	mut expr_type := node.expr_type
 	sym := g.table.sym(node_typ)

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -51,7 +51,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 	is_array := sym.kind in [.array_fixed, .array]
 
 	// detect if we need type casting on msvc initialization
-	const_msvc_init := g.is_cc_msvc && g.inside_const && g.inside_lambda && !g.inside_cast
+	const_msvc_init := g.is_cc_msvc && g.inside_const && !g.inside_cast && g.inside_array_item
 
 	if !g.inside_cinit && !is_anon && !is_array && !const_msvc_init {
 		g.write('(')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -49,7 +49,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = sym.info.is_anon
 	}
 	is_array := sym.kind in [.array_fixed, .array]
-	const_msvc_init := !g.inside_cast && g.inside_const && g.is_cc_msvc
+
+	// detect if we need type casting on msvc initialization
+	const_msvc_init := g.is_cc_msvc && g.inside_const && g.inside_lambda && !g.inside_cast
 
 	if !g.inside_cinit && !is_anon && !is_array && !const_msvc_init {
 		g.write('(')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -49,8 +49,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = sym.info.is_anon
 	}
 	is_array := sym.kind in [.array_fixed, .array]
+	const_msvc_init := g.inside_const && g.is_cc_msvc
 
-	if !g.inside_cinit && !is_anon && !is_array {
+	if !g.inside_cinit && !is_anon && !is_array && !const_msvc_init {
 		g.write('(')
 		defer {
 			g.write(')')
@@ -89,7 +90,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		if g.table.sym(node.typ).kind == .alias && g.table.unaliased_type(node.typ).is_ptr() {
 			g.write('&')
 		}
-		if is_array {
+		if is_array || const_msvc_init {
 			g.write('{')
 		} else if is_multiline {
 			g.writeln('(${styp}){')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -49,7 +49,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		is_anon = sym.info.is_anon
 	}
 	is_array := sym.kind in [.array_fixed, .array]
-	const_msvc_init := g.inside_const && g.is_cc_msvc
+	const_msvc_init := !g.inside_cast && g.inside_const && g.is_cc_msvc
 
 	if !g.inside_cinit && !is_anon && !is_array && !const_msvc_init {
 		g.write('(')

--- a/vlib/v/tests/const_array_struct_test.v
+++ b/vlib/v/tests/const_array_struct_test.v
@@ -1,0 +1,11 @@
+struct Uint128 {
+mut:
+	lo u64
+	hi u64
+}
+
+const zzz_test = [Uint128{1, 2}, Uint128{3, 4}]!
+
+fn test_main() {
+	assert dump(zzz_test) == zzz_test
+}


### PR DESCRIPTION
Fix #18892

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6b2e313</samp>

Fix code generation for structs and arrays in constants with MSVC. Use brace initializers instead of compound literals in `vlib/v/gen/c/struct.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6b2e313</samp>

*  Avoid using compound literal syntax for initializing structs inside constants when using MSVC ([link](https://github.com/vlang/v/pull/19969/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L52-R54), [link](https://github.com/vlang/v/pull/19969/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82L92-R93))
