### PR TITLE
cgen: fix auto str for interface struct member which implements str method

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1068,6 +1068,12 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 	} else if _field_type.has_flag(.option) || should_use_indent_func(sym.kind) {
 		obj := '${deref}it.${final_field_name}${sufix}'
 		if has_custom_str {
+			if sym.kind == .interface_ {
+				mut s := '${fn_name.trim_string_right('_str')}_name_table[${obj}'
+				dot := if field_type.is_ptr() { '->' } else { '.' }
+				s += '${dot}_typ]._method_str(${obj}${dot}_object)'
+				return s, true
+			}
 			return '${fn_name}(${obj})', true
 		}
 		return 'indent_${fn_name}(${obj}, indent_count + 1)', true

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1068,7 +1068,7 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 	} else if _field_type.has_flag(.option) || should_use_indent_func(sym.kind) {
 		obj := '${deref}it.${final_field_name}${sufix}'
 		if has_custom_str {
-			if sym.kind == .interface_ {
+			if sym.kind == .interface_ && (sym.info as ast.Interface).defines_method('str') {
 				iface_obj := 'it.${final_field_name}${sufix}'
 				dot := if field_type.is_ptr() { '->' } else { '.' }
 				return '${fn_name.trim_string_right('_str')}_name_table[${iface_obj}${dot}_typ]._method_str(${iface_obj}${dot}_object)', true

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1069,10 +1069,9 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 		obj := '${deref}it.${final_field_name}${sufix}'
 		if has_custom_str {
 			if sym.kind == .interface_ {
-				mut s := '${fn_name.trim_string_right('_str')}_name_table[${obj}'
+				iface_obj := 'it.${final_field_name}${sufix}'
 				dot := if field_type.is_ptr() { '->' } else { '.' }
-				s += '${dot}_typ]._method_str(${obj}${dot}_object)'
-				return s, true
+				return '${fn_name.trim_string_right('_str')}_name_table[${iface_obj}${dot}_typ]._method_str(${iface_obj}${dot}_object)', true
 			}
 			return '${fn_name}(${obj})', true
 		}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -108,6 +108,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		unwrap_option := expr is ast.Ident && expr.or_expr.kind == .propagate_option
 		exp_typ := if unwrap_option { typ.clear_flag(.option) } else { typ }
 		is_ptr := exp_typ.is_ptr()
+		is_dump_expr := expr is ast.DumpExpr
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.get_str_fn(exp_typ)
 		if is_ptr && !is_var_mut {
@@ -130,7 +131,14 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {
-			g.write('&')
+			if is_dump_expr {
+				g.write('ADDR(${g.typ(typ)}, ')
+				defer {
+					g.write(')')
+				}
+			} else {
+				g.write('&')
+			}
 		} else if is_ptr && typ.has_flag(.option) {
 			g.write('*(${g.typ(typ)}*)&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {

--- a/vlib/v/tests/interface_auto_str_test.v
+++ b/vlib/v/tests/interface_auto_str_test.v
@@ -1,0 +1,31 @@
+interface Context {
+	str() string
+}
+
+struct OtherContext {
+	a string
+}
+
+pub fn (o &OtherContext) str() string {
+	return 'OtherContext'
+}
+
+struct WithContext {
+pub mut:
+	ctx Context
+}
+
+fn with_function(ctx Context) {
+	println(ctx)
+}
+
+fn test_main() {
+	mut s := WithContext{
+		ctx: OtherContext{}
+	}
+	assert dump(s) == WithContext{
+		ctx: OtherContext{}
+	}
+
+	assert dump(OtherContext{}) == OtherContext{}
+}


### PR DESCRIPTION
Fix #18547

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e2df780</samp>

This pull request implements and tests the feature request #10464, which enables automatic `str` methods for interfaces. It modifies the `vlib/v/gen/c/str.v` and `vlib/v/gen/c/auto_str_methods.v` files to generate correct C code for calling `str` methods on interface values, and adds a new test file `vlib/v/tests/interface_auto_str_test.v` to verify the expected behavior.
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e2df780</samp>

*  Implement automatic `str` methods for interfaces ([link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bR1071-R1075), [link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-59fdbcf7230093246f7aa61fbb8b95b95cfec3d9e28994295354a23db89a0367R111), [link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-59fdbcf7230093246f7aa61fbb8b95b95cfec3d9e28994295354a23db89a0367L133-R141), [link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-80d037009a0728b033b63bb88c2f20e7a791563de7634fa8426eb51e1744b2adR1-R31))
  - Add a special case for interfaces with `str` methods in `vlib/v/gen/c/auto_str_methods.v` ([link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-f3725548dbb6f4b88c83c273d7bc401fbffd5af71532aaabfe47467d3e4ce95bR1071-R1075))
  - Handle `DumpExpr` for interfaces and other types with custom `str` methods in `vlib/v/gen/c/str.v` ([link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-59fdbcf7230093246f7aa61fbb8b95b95cfec3d9e28994295354a23db89a0367R111), [link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-59fdbcf7230093246f7aa61fbb8b95b95cfec3d9e28994295354a23db89a0367L133-R141))
  - Add a test file `vlib/v/tests/interface_auto_str_test.v` to check the expected output of the `str` and `dump` methods for interfaces and structs ([link](https://github.com/vlang/v/pull/19970/files?diff=unified&w=0#diff-80d037009a0728b033b63bb88c2f20e7a791563de7634fa8426eb51e1744b2adR1-R31))
