### PR TITLE
checker: fix ref elements of the array must be initialized right away(fix #14958)

### DIFF
--- a/vlib/v/checker/tests/ptr_array_init.out
+++ b/vlib/v/checker/tests/ptr_array_init.out
@@ -3,10 +3,25 @@ vlib/v/checker/tests/ptr_array_init.vv:2:11: warning: arrays of references need 
     2 |     println(*[]&int{len: 1}[0])
       |              ~~~~~~~
     3 |     println([1]&int{})
-    4 | }
+    4 |     _ = [][1]&int{len: 1}[0][0]
 vlib/v/checker/tests/ptr_array_init.vv:3:10: warning: fixed arrays of references need to be initialized right away (unless inside `unsafe`)
     1 | fn main() {
     2 |     println(*[]&int{len: 1}[0])
     3 |     println([1]&int{})
       |             ~~~~~~~~~
-    4 | }
+    4 |     _ = [][1]&int{len: 1}[0][0]
+    5 |     _ = []map[int]&int{len: 1}
+vlib/v/checker/tests/ptr_array_init.vv:4:6: warning: arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`)
+    2 |     println(*[]&int{len: 1}[0])
+    3 |     println([1]&int{})
+    4 |     _ = [][1]&int{len: 1}[0][0]
+      |         ~~~~~~~~~~
+    5 |     _ = []map[int]&int{len: 1}
+    6 | }
+vlib/v/checker/tests/ptr_array_init.vv:5:6: warning: arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`)
+    3 |     println([1]&int{})
+    4 |     _ = [][1]&int{len: 1}[0][0]
+    5 |     _ = []map[int]&int{len: 1}
+      |         ~~~~~~~~~~~~~~~
+    6 | }
+  

--- a/vlib/v/checker/tests/ptr_array_init.vv
+++ b/vlib/v/checker/tests/ptr_array_init.vv
@@ -1,4 +1,6 @@
 fn main() {
 	println(*[]&int{len: 1}[0])
 	println([1]&int{})
+	_ = [][1]&int{len: 1}[0][0]
+	_ = []map[int]&int{len: 1}
 }


### PR DESCRIPTION
1. Close #14958 
2. this PR just changed the check to be recursive so can check its children.
3. Add tests.

```v
fn main() {
	_ = [][1]&int{len: 1}[0][0]
	_ = []map[int]&int{len: 1}
}
```
outputs:
```
vlib/v/checker/tests/ptr_array_init_2.vv:2:6: warning: arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`)
    1 | fn main() {
    2 |     _ = [][1]&int{len: 1}[0][0]
      |         ~~~~~~~~~~
    3 |     _ = []map[int]&int{len: 1}
    4 | }
vlib/v/checker/tests/ptr_array_init_2.vv:3:6: warning: arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`)
    1 | fn main() {
    2 |     _ = [][1]&int{len: 1}[0][0]
    3 |     _ = []map[int]&int{len: 1}
      |         ~~~~~~~~~~~~~~~
    4 | }

```