### PR TITLE
checker: add a qualification to array elements ref initialization checks

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -102,7 +102,10 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.warn('arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`)',
 				node.pos)
 		}
-		c.check_elements_ref_fields_initialized(node.elem_type, node.pos)
+		// `&Struct{} check
+		if node.has_len {
+			c.check_elements_ref_fields_initialized(node.elem_type, node.pos)
+		}
 		return node.typ
 	}
 

--- a/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
@@ -1,34 +1,34 @@
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:8:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
-    6 | 
+    6 |
     7 | fn main() {
-    8 |     _ = []Foo{}
+    8 |     _ = []Foo{len: 1}
       |         ~~~~~~
     9 |     _ = [1]Foo{}
    10 |     _ = map[string]Foo{}
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:9:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
     7 | fn main() {
-    8 |     _ = []Foo{}
+    8 |     _ = []Foo{len: 1}
     9 |     _ = [1]Foo{}
       |         ~~~~~~~~
    10 |     _ = map[string]Foo{}
    11 |     _ = map[string][]Foo{}
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:10:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
-    8 |     _ = []Foo{}
+    8 |     _ = []Foo{len: 1}
     9 |     _ = [1]Foo{}
    10 |     _ = map[string]Foo{}
       |         ~~~~~~~~~~~~~~~~
    11 |     _ = map[string][]Foo{}
-   12 |     _ = []AliasFoo{}
+   12 |     _ = []AliasFoo{len: 1}
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:11:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
     9 |     _ = [1]Foo{}
    10 |     _ = map[string]Foo{}
    11 |     _ = map[string][]Foo{}
       |         ~~~~~~~~~~~~~~~~~~
-   12 |     _ = []AliasFoo{}
+   12 |     _ = []AliasFoo{len: 1}
    13 | }
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:12:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
    10 |     _ = map[string]Foo{}
    11 |     _ = map[string][]Foo{}
-   12 |     _ = []AliasFoo{}
+   12 |     _ = []AliasFoo{len: 1}
       |         ~~~~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv
+++ b/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv
@@ -5,9 +5,9 @@ struct Foo {
 type AliasFoo = Foo
 
 fn main() {
-	_ = []Foo{}
+	_ = []Foo{len: 1}
 	_ = [1]Foo{}
 	_ = map[string]Foo{}
 	_ = map[string][]Foo{}
-	_ = []AliasFoo{}
+	_ = []AliasFoo{len: 1}
 }


### PR DESCRIPTION
1. The check of PR 19944 is too strict and can be relaxed when no `len` argument is specified in `[]&Struct{}`
2. The related tests were adjusted