### PR TITLE
net/openssl: correctly assign nil to reference values

### DIFF
--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -34,8 +34,8 @@ pub fn new_ssl_conn(config SSLConnectConfig) !&SSLConn {
 	}
 	mut conn := &SSLConn{
 		config: config
-		sslctx: 0
-		ssl: 0
+		sslctx: unsafe { nil }
+		ssl: unsafe { nil }
 		handle: 0
 	}
 	conn.init() or { return err }


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 184f407</samp>

Fix compilation error in `vlib/net/openssl/ssl_connection.c.v` by using `unsafe { nil }` for pointer initialization. This change adapts to a stricter rule of the V compiler that forbids casting `0` to pointers.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 184f407</samp>

* Initialize `sslctx` and `ssl` fields of `SSLConn` struct to `unsafe { nil }` instead of `0` to avoid casting error ([link](https://github.com/vlang/v/pull/19981/files?diff=unified&w=0#diff-00828b42a4c4650ef74faa09f6da5f8e1f4bccca468ab771fd2eb8941d939ec5L37-R38))
