### PR TITLE
checker: disallow directly indexing sumtype and interface, when using as parameters(fix #19811)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4319,7 +4319,8 @@ fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 	}
 	is_aggregate_arr := typ_sym.kind == .aggregate
 		&& (typ_sym.info as ast.Aggregate).types.filter(c.table.type_kind(it) !in [.array, .array_fixed, .string, .map]).len == 0
-	if typ_sym.kind !in [.array, .array_fixed, .string, .map] && !typ.is_ptr()
+	if typ_sym.kind !in [.array, .array_fixed, .string, .map]
+		&& (!typ.is_ptr() || typ_sym.kind in [.sum_type, .interface_])
 		&& typ !in [ast.byteptr_type, ast.charptr_type] && !typ.has_flag(.variadic)
 		&& !is_aggregate_arr {
 		c.error('type `${typ_sym.name}` does not support indexing', node.pos)

--- a/vlib/v/checker/tests/index_sumtype_or_interface_params_err.out
+++ b/vlib/v/checker/tests/index_sumtype_or_interface_params_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/index_sumtype_or_interface_params_err.vv:6:9: error: type `Foo` does not support indexing
+    4 | 
+    5 | fn sum_type_or_interface_as_parameters(mut foo Foo, mut bar Bar) {
+    6 |     _ = foo[0]
+      |            ~~~
+    7 |     _ = bar[0]
+    8 | }
+vlib/v/checker/tests/index_sumtype_or_interface_params_err.vv:7:9: error: type `Bar` does not support indexing
+    5 | fn sum_type_or_interface_as_parameters(mut foo Foo, mut bar Bar) {
+    6 |     _ = foo[0]
+    7 |     _ = bar[0]
+      |            ~~~
+    8 | }

--- a/vlib/v/checker/tests/index_sumtype_or_interface_params_err.vv
+++ b/vlib/v/checker/tests/index_sumtype_or_interface_params_err.vv
@@ -1,0 +1,8 @@
+type Foo = int | map[int]int
+
+interface Bar {}
+
+fn sum_type_or_interface_as_parameters(mut foo Foo, mut bar Bar) {
+	_ = foo[0]
+	_ = bar[0]
+}


### PR DESCRIPTION
1. Fixed #19811 
2. Add tests.

```v
type Tree = string| map[string]string

fn append(mut tree Tree) {
    print(tree["key"])
}

fn main() {
}
```

outputs:

```
a.v:4:15: error: type `Tree` does not support indexing
    2 | 
    3 | fn append(mut tree Tree) {
    4 |     print(tree["key"])
      |               ~~~~~~~
    5 | }
    6 |
```