### PR TITLE
tools.vpm: fix install paths, only normalize relevant, restore assign `install_path_fmted`, add input tests

### DIFF
--- a/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
@@ -1,0 +1,21 @@
+#!/usr/bin/env expect
+
+set timeout 3
+
+# Pass v_root as arg, since we chdir into a temp directory during testing and create a project there.
+set v_root [lindex $argv 0]
+set mod [lindex $argv 1]
+set cur_tag [lindex $argv 2]
+set new_tag [lindex $argv 3]
+set install_path [lindex $argv 4]
+
+spawn $v_root/v install $mod@$new_tag
+
+expect "Scanning `$mod`..." {} timeout { exit 1 }
+expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
+expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "\r" } timeout { exit 1 }
+expect "Installing `$mod`..." {} timeout { exit 1 }
+expect "Skipping download count increment for `$mod`." {} timeout { exit 1 }
+expect "Installed `$mod`." {} timeout { exit 1 }
+
+expect eof

--- a/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
@@ -2,14 +2,13 @@
 
 set timeout 3
 
-# Pass v_root as arg, since we chdir into a temp directory during testing and create a project there.
-set v_root [lindex $argv 0]
+set vexe [lindex $argv 0]
 set mod [lindex $argv 1]
 set cur_tag [lindex $argv 2]
 set new_tag [lindex $argv 3]
 set install_path [lindex $argv 4]
 
-spawn $v_root/v install $mod@$new_tag
+spawn $vexe install $mod@$new_tag
 
 expect "Scanning `$mod`..." {} timeout { exit 1 }
 expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }

--- a/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
@@ -11,11 +11,11 @@ set install_path [lindex $argv 4]
 
 spawn $v_root/v install $mod@$new_tag
 
-expect "Scanning `$mod`..."
-expect "Module `$mod@$cur_tag` is already installed at `$install_path`."
+expect "Scanning `$mod`..." {} timeout { exit 1 }
+expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
 expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "\r" } timeout { exit 1 }
-expect "Installing `$mod`..."
-expect "Skipping download count increment for `$mod`."
-expect "Installed `$mod`."
+expect "Installing `$mod`..." {} timeout { exit 1 }
+expect "Skipping download count increment for `$mod`." {} timeout { exit 1 }
+expect "Installed `$mod`." {} timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
@@ -11,11 +11,11 @@ set install_path [lindex $argv 4]
 
 spawn $v_root/v install $mod@$new_tag
 
-expect "Scanning `$mod`..." {} timeout { exit 1 }
-expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
+expect "Scanning `$mod`..."
+expect "Module `$mod@$cur_tag` is already installed at `$install_path`."
 expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "\r" } timeout { exit 1 }
-expect "Installing `$mod`..." {} timeout { exit 1 }
-expect "Skipping download count increment for `$mod`." {} timeout { exit 1 }
-expect "Installed `$mod`." {} timeout { exit 1 }
+expect "Installing `$mod`..."
+expect "Skipping download count increment for `$mod`."
+expect "Installed `$mod`."
 
 expect eof

--- a/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
@@ -11,8 +11,8 @@ set install_path [lindex $argv 4]
 
 spawn $v_root/v install $mod@$new_tag
 
-expect "Scanning `$mod`..."
-expect "Module `$mod@$cur_tag` is already installed at `$install_path`."
+expect "Scanning `$mod`..." {} timeout { exit 1 }
+expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
 expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "n\r" } timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
@@ -2,14 +2,13 @@
 
 set timeout 3
 
-# Pass v_root as arg, since we chdir into a temp directory during testing and create a project there.
-set v_root [lindex $argv 0]
+set vexe [lindex $argv 0]
 set mod [lindex $argv 1]
 set cur_tag [lindex $argv 2]
 set new_tag [lindex $argv 3]
 set install_path [lindex $argv 4]
 
-spawn $v_root/v install $mod@$new_tag
+spawn $vexe install $mod@$new_tag
 
 expect "Scanning `$mod`..." {} timeout { exit 1 }
 expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }

--- a/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
@@ -1,0 +1,18 @@
+#!/usr/bin/env expect
+
+set timeout 3
+
+# Pass v_root as arg, since we chdir into a temp directory during testing and create a project there.
+set v_root [lindex $argv 0]
+set mod [lindex $argv 1]
+set cur_tag [lindex $argv 2]
+set new_tag [lindex $argv 3]
+set install_path [lindex $argv 4]
+
+spawn $v_root/v install $mod@$new_tag
+
+expect "Scanning `$mod`..." {} timeout { exit 1 }
+expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
+expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "n\r" } timeout { exit 1 }
+
+expect eof

--- a/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
@@ -11,8 +11,8 @@ set install_path [lindex $argv 4]
 
 spawn $v_root/v install $mod@$new_tag
 
-expect "Scanning `$mod`..." {} timeout { exit 1 }
-expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
+expect "Scanning `$mod`..."
+expect "Module `$mod@$cur_tag` is already installed at `$install_path`."
 expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "n\r" } timeout { exit 1 }
 
 expect eof

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -141,14 +141,14 @@ fn (m Module) confirm_install() bool {
 		println('Module `${m.name}${at_version(m.installed_version)}` is already installed, use --force to overwrite.')
 		return false
 	} else {
-		install_version := at_version(if m.version == '' { 'latest' } else { m.version })
 		println('Module `${m.name}${at_version(m.installed_version)}` is already installed at `${m.install_path_fmted}`.')
 		if settings.fail_on_prompt {
 			vpm_error('VPM should not have entered a confirmation prompt.')
 			exit(1)
 		}
+		install_version := at_version(if m.version == '' { 'latest' } else { m.version })
 		input := os.input('Replace it with `${m.name}${install_version}`? [Y/n]: ')
-		match input.to_lower() {
+		match input.trim_space().to_lower() {
 			'', 'y' {
 				return true
 			}

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -4,9 +4,8 @@ import v.vmod
 
 const (
 	vexe              = os.quoted_path(@VEXE)
-	vroot             = os.quoted_path(@VEXEROOT)
 	test_path         = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test')
-	expect_tests_path = os.join_path(vroot, 'cmd', 'tools', 'vpm', 'expect')
+	expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vpm', 'expect')
 	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
@@ -51,7 +50,7 @@ fn test_reinstall_mod_with_version_installation() {
 	$if macos {
 		mod_path = '/private' + os.join_path(test_path, mod)
 	}
-	expect_args := [vroot, mod, tag, new_tag, mod_path].join(' ')
+	expect_args := [vexe, mod, tag, new_tag, mod_path].join(' ')
 
 	// Decline.
 	decline_test := os.join_path(expect_tests_path, 'decline_reinstall_mod_with_version_installation.expect')

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -2,15 +2,13 @@
 import os
 import v.vmod
 
-const (
-	vexe              = os.quoted_path(@VEXE)
-	test_path         = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test')
-	expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vpm', 'expect')
-	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
-		eprintln('skipping test, since expect is missing')
-		exit(0)
-	})
-)
+const vexe = os.quoted_path(@VEXE)
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test')
+const expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vpm', 'expect')
+const expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
+	eprintln('skipping test, since expect is missing')
+	exit(0)
+})
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
@@ -44,17 +42,14 @@ fn test_reinstall_mod_with_version_installation() {
 	assert name == mod
 	assert version == tag.trim_left('v')
 
-	// Try reinstalling
+	// Try reinstalling.
 	new_tag := 'v0.1.50'
-	mut mod_path := os.join_path(test_path, mod)
-	$if macos {
-		mod_path = '/private' + os.join_path(test_path, mod)
-	}
-	expect_args := [vexe, mod, tag, new_tag, mod_path].join(' ')
+	install_path := os.real_path(os.join_path(test_path, mod))
+	expect_args := [vexe, mod, tag, new_tag, install_path].join(' ')
 
 	// Decline.
 	decline_test := os.join_path(expect_tests_path, 'decline_reinstall_mod_with_version_installation.expect')
-	manifest_path := os.join_path(mod_path, 'v.mod')
+	manifest_path := os.join_path(install_path, 'v.mod')
 	last_modified := os.file_last_mod_unix(manifest_path)
 	os.execute_or_exit('${expect_exe} ${decline_test} ${expect_args}')
 	assert last_modified == os.file_last_mod_unix(manifest_path)

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -47,7 +47,10 @@ fn test_reinstall_mod_with_version_installation() {
 
 	// Try reinstalling
 	new_tag := 'v0.1.50'
-	mod_path := os.join_path(test_path, mod)
+	mut mod_path := os.join_path(test_path, mod)
+	$if macos {
+		mod_path = '/private' + os.join_path(test_path, mod)
+	}
 	expect_args := [vroot, mod, tag, new_tag, mod_path].join(' ')
 
 	// Decline.

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -1,0 +1,65 @@
+// vtest retry: 3
+import os
+import v.vmod
+
+const (
+	vroot             = os.quoted_path(@VEXEROOT)
+	test_path         = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test')
+	expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vpm', 'expect')
+	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
+		eprintln('skipping test, since expect is missing')
+		exit(0)
+	})
+)
+
+fn testsuite_begin() {
+	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
+	os.setenv('VPM_DEBUG', '', true)
+	// Explicitly disable fail on prompt.
+	os.setenv('VPM_FAIL_ON_PROMPT', '', true)
+	os.mkdir_all(test_path) or {}
+	os.chdir(test_path)!
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
+fn get_mod_name_and_version(path string) (string, string) {
+	mod := vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
+		eprintln(err)
+		return '', ''
+	}
+	return mod.name, mod.version
+}
+
+// Test installing another version of a module of which an explicit version is already installed.
+fn test_reinstall_mod_with_version_installation() {
+	// Install version.
+	mod := 'vsl'
+	tag := 'v0.1.47'
+	os.execute_or_exit('v install ${mod}@${tag}')
+	mut name, mut version := get_mod_name_and_version(mod)
+	assert name == mod
+	assert version == tag.trim_left('v')
+
+	// Try reinstalling
+	new_tag := 'v0.1.50'
+	mod_path := os.join_path(test_path, mod)
+	expect_args := [vroot, mod, tag, new_tag, mod_path].join(' ')
+
+	// Decline.
+	decline_test := os.join_path(expect_tests_path, 'decline_reinstall_mod_with_version_installation.expect')
+	manifest_path := os.join_path(mod_path, 'v.mod')
+	last_modified := os.file_last_mod_unix(manifest_path)
+	os.execute_or_exit('${expect_exe} ${decline_test} ${expect_args}')
+	assert last_modified == os.file_last_mod_unix(manifest_path)
+
+	// Accept.
+	accept_test := os.join_path(expect_tests_path, 'accept_reinstall_mod_with_version_installation.expect')
+	os.execute_or_exit('${expect_exe} ${accept_test} ${expect_args}')
+	name, version = get_mod_name_and_version(mod)
+	assert name == mod, name
+	assert version == new_tag.trim_left('v'), version
+}

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -3,9 +3,10 @@ import os
 import v.vmod
 
 const (
+	vexe              = os.quoted_path(@VEXE)
 	vroot             = os.quoted_path(@VEXEROOT)
 	test_path         = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test')
-	expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vpm', 'expect')
+	expect_tests_path = os.join_path(vroot, 'cmd', 'tools', 'vpm', 'expect')
 	expect_exe        = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 		eprintln('skipping test, since expect is missing')
 		exit(0)
@@ -39,7 +40,7 @@ fn test_reinstall_mod_with_version_installation() {
 	// Install version.
 	mod := 'vsl'
 	tag := 'v0.1.47'
-	os.execute_or_exit('v install ${mod}@${tag}')
+	os.execute_or_exit('${vexe} install ${mod}@${tag}')
 	mut name, mut version := get_mod_name_and_version(mod)
 	assert name == mod
 	assert version == tag.trim_left('v')

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -124,6 +124,7 @@ fn parse_query(query []string) []Module {
 				manifest: manifest
 			}
 		}
+		mod.install_path_fmted = fmt_mod_path(mod.install_path)
 		mod.version = version
 		mod.get_installed()
 		modules << mod

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -58,13 +58,12 @@ fn parse_query(query []string) []Module {
 				continue
 			}
 			// Resolve path.
-			base := if is_http { publisher } else { '' }
-			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
-				base, manifest.name)))
+			mod_path := normalize_mod_path(os.join_path(if is_http { publisher } else { '' },
+				manifest.name))
 			Module{
 				name: manifest.name
 				url: ident
-				install_path: install_path
+				install_path: os.real_path(os.join_path(settings.vmodules_path, mod_path))
 				is_external: true
 				manifest: manifest
 			}
@@ -113,14 +112,12 @@ fn parse_query(query []string) []Module {
 				vmod.Manifest{}
 			}
 			// Resolve path.
-			ident_as_path := info.name.replace('.', os.path_separator)
-			install_path := normalize_mod_path(os.real_path(os.join_path(settings.vmodules_path,
-				ident_as_path)))
+			mod_path := normalize_mod_path(info.name.replace('.', os.path_separator))
 			Module{
 				name: info.name
 				url: info.url
 				vcs: vcs
-				install_path: install_path
+				install_path: os.real_path(os.join_path(settings.vmodules_path, mod_path))
 				manifest: manifest
 			}
 		}


### PR DESCRIPTION
Fixes an oopsi accidentally removing to set the formatted install path when parsing.

Adds expect tests regarding input.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at acbb17b</samp>

This pull request adds tests and improves the user interface for installing modules with specific versions using `vpm`. It uses `expect` scripts to simulate and verify the interactive prompts for reinstalling modules, and trims and formats the user input and output.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at acbb17b</samp>

* Trim whitespace from user input for module replacement prompt ([link](https://github.com/vlang/v/pull/19984/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL151-R151))
* Format module install path for consistent output ([link](https://github.com/vlang/v/pull/19984/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebR127))
* Add expect scripts to test interactive prompt for module replacement ([link](https://github.com/vlang/v/pull/19984/files?diff=unified&w=0#diff-20cad2f8bd5b5092236769c39f4fac95bdb46e70cf2ea7d52e814e5afe756053R1-R21), [link](https://github.com/vlang/v/pull/19984/files?diff=unified&w=0#diff-506c1491970c8b6daaf76ce1bd3060de5c10bd5af8ffbb5869e113dbb9efc896R1-R18))
* Add test file `install_version_input_test.v` to run expect scripts and check module name and version ([link](https://github.com/vlang/v/pull/19984/files?diff=unified&w=0#diff-fb5883fd548f11caedf8f3b5b9c7da41012141122199a063f87d20ac3728e81dR1-R65))
