### PR TITLE
parser: fix infix expr handling with cast on left side of << operator

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -551,20 +551,24 @@ fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bo
 			}
 		} else if p.tok.kind == .left_shift && p.is_stmt_ident {
 			// arr << elem
-			tok := p.tok
-			mut pos := tok.pos()
-			p.next()
-			right := p.expr(precedence - 1)
-			pos.update_last_line(p.prev_tok.line_nr)
-			if mut node is ast.IndexExpr {
-				node.recursive_arraymap_set_is_setter()
-			}
-			node = ast.InfixExpr{
-				left: node
-				right: right
-				op: tok.kind
-				pos: pos
-				is_stmt: true
+			if node is ast.CastExpr {
+				node = p.infix_expr(node)
+			} else {
+				tok := p.tok
+				mut pos := tok.pos()
+				p.next()
+				right := p.expr(precedence - 1)
+				pos.update_last_line(p.prev_tok.line_nr)
+				if mut node is ast.IndexExpr {
+					node.recursive_arraymap_set_is_setter()
+				}
+				node = ast.InfixExpr{
+					left: node
+					right: right
+					op: tok.kind
+					pos: pos
+					is_stmt: true
+				}
 			}
 		} else if p.tok.kind.is_infix() && !(p.tok.kind in [.minus, .amp, .mul]
 			&& p.tok.line_nr != p.prev_tok.line_nr) {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -550,10 +550,11 @@ fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bo
 				return node
 			}
 		} else if p.tok.kind == .left_shift && p.is_stmt_ident {
-			// arr << elem
+			// cast(expr) << expr
 			if node is ast.CastExpr {
 				node = p.infix_expr(node)
 			} else {
+				// arr << elem
 				tok := p.tok
 				mut pos := tok.pos()
 				p.next()

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -549,27 +549,22 @@ fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bo
 			} else {
 				return node
 			}
-		} else if p.tok.kind == .left_shift && p.is_stmt_ident {
-			// cast(expr) << expr
-			if node is ast.CastExpr {
-				node = p.infix_expr(node)
-			} else {
-				// arr << elem
-				tok := p.tok
-				mut pos := tok.pos()
-				p.next()
-				right := p.expr(precedence - 1)
-				pos.update_last_line(p.prev_tok.line_nr)
-				if mut node is ast.IndexExpr {
-					node.recursive_arraymap_set_is_setter()
-				}
-				node = ast.InfixExpr{
-					left: node
-					right: right
-					op: tok.kind
-					pos: pos
-					is_stmt: true
-				}
+		} else if node !is ast.CastExpr && p.tok.kind == .left_shift && p.is_stmt_ident {
+			// arr << elem
+			tok := p.tok
+			mut pos := tok.pos()
+			p.next()
+			right := p.expr(precedence - 1)
+			pos.update_last_line(p.prev_tok.line_nr)
+			if mut node is ast.IndexExpr {
+				node.recursive_arraymap_set_is_setter()
+			}
+			node = ast.InfixExpr{
+				left: node
+				right: right
+				op: tok.kind
+				pos: pos
+				is_stmt: true
 			}
 		} else if p.tok.kind.is_infix() && !(p.tok.kind in [.minus, .amp, .mul]
 			&& p.tok.line_nr != p.prev_tok.line_nr) {

--- a/vlib/v/tests/cast_precedence_test.v
+++ b/vlib/v/tests/cast_precedence_test.v
@@ -1,0 +1,12 @@
+fn test_main() {
+	assert (u8(1) << 1 | 1) == 3
+	assert (match 0 {
+		0 { u8(1) << 1 | 1 }
+		else { 0 }
+	}) == 3
+	assert (if true {
+		u8(1) << 1 | 1
+	} else {
+		0
+	}) == 3
+}


### PR DESCRIPTION
Fix #19978

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d602b26</samp>

This pull request fixes a parser bug with cast and left shift operators and adds a test file to check the correct precedence. The bug affected expressions like `u8(1) << 1 + 1` and caused incorrect parsing and compilation errors.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d602b26</samp>

* Fix parser bug for cast expressions followed by left shift and infix operators ([link](https://github.com/vlang/v/pull/19985/files?diff=unified&w=0#diff-9314b6794c584898ac6ec2df311b4575b393be151a38e2a1107751c31fa7ca3bL554-R572))
* Add test file `vlib/v/tests/cast_precedence_test.v` for cast precedence scenarios ([link](https://github.com/vlang/v/pull/19985/files?diff=unified&w=0#diff-3ae1dfe6366ea8c02018e65c50251832d0d01813a43be655c479ddaccabb45dfR1-R12))
