### PR TITLE
tools.vpm: remove flaky flag from tests to better spot issues on different platforms

### DIFF
--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 import v.vmod

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -28,6 +28,10 @@ fn test_install_dependencies_in_module_dir() {
 	os.mkdir_all(test_path) or {}
 	mod := 'my_module'
 	mod_path := os.join_path(test_path, mod)
+	$if windows {
+		// Make sure path is clean to work around CI failures with Windows MSVC.
+		os.system('rd /s /q ${mod_path}')
+	}
 	os.mkdir(mod_path)!
 	os.chdir(mod_path)!
 	// Create a v.mod file that lists dependencies.

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -65,7 +65,7 @@ fn test_install_from_vpm_with_git_version_tag() {
 fn test_install_from_url_with_git_version_tag() {
 	mut url := 'https://github.com/vlang/vsl'
 	mut tag := 'v0.1.50'
-	mut res := os.execute_or_exit('v install ${url}@${tag}')
+	mut res := os.execute_or_exit('${vexe} install ${url}@${tag}')
 	assert res.output.contains('Installing `vsl`'), res.output
 	assert res.output.contains('Installed `vsl`'), res.output
 	mut name, mut version := get_mod_name_and_version('vsl')

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 module main
 

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 


### PR DESCRIPTION
The retries should do the job I think, if it fails anyway something is likely wrong. Marking them as flaky might result in some unresolved issues slipping through.

I usually don't run the tests on all platforms locally during development. Having changes CI covered that is not always green would help to better spot things.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b8a8459</samp>

Removed flaky test comments and improved `vpm` tests. The changes make the tests more reliable and consistent for the `vpm` tool, which manages V modules and versions.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b8a8459</samp>

* Remove flaky comments from three test files (`[link](https://github.com/vlang/v/pull/19986/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L1)`, `[link](https://github.com/vlang/v/pull/19986/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L1)`, `[link](https://github.com/vlang/v/pull/19986/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeL1)`) to enable them on CI
