### PR TITLE
tools.vpm: evaluate dependencies when parsing modules

### DIFF
--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -61,8 +61,8 @@ fn test_install_dependencies_in_module_dir() {
 }
 
 fn test_resolve_external_dependencies_during_module_install() {
-	res := os.execute_or_exit('${v} install https://github.com/ttytm/emoji-mart-desktop')
-	assert res.output.contains('Resolving 2 dependencies'), res.output
+	res := os.execute_or_exit('${v} install -v https://github.com/ttytm/emoji-mart-desktop')
+	assert res.output.contains('Found 2 dependencies'), res.output
 	assert res.output.contains('Installing `webview`'), res.output
 	assert res.output.contains('Installing `miniaudio`'), res.output
 	// The external dependencies should have been installed to `<vmodules_dir>/<dependency_name>`

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -70,7 +70,6 @@ fn vpm_install(query []string) {
 
 fn install_modules(modules []Module) {
 	vpm_log(@FILE_LINE, @FN, 'modules: ${modules}')
-	idents := modules.map(it.name)
 	mut errors := 0
 	for m in modules {
 		vpm_log(@FILE_LINE, @FN, 'module: ${m}')
@@ -93,7 +92,6 @@ fn install_modules(modules []Module) {
 			}
 		}
 		println('Installed `${m.name}`.')
-		resolve_dependencies(get_manifest(m.install_path), idents)
 	}
 	if errors > 0 {
 		exit(1)


### PR DESCRIPTION
Evaluates dependencies earlier to fix a potential recursive loop when encountering certain combinations of module installations with shared dependencies. At the current state it's an issue that's not likely to happen, but eventually the fix would become important.

Adding a test that will protect against a regression will require to prepare some modules that provoke this issue. I would put it on the list and add it at a later point if thats okay.

This PR covers the install command, the update command is about to be improved as well. A similar fix will be part of it then.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef70b62</samp>

This pull request improves the module installation process in `vpm` by using a map and recursion to handle dependencies. It also updates the test case and the output message to reflect the changes.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef70b62</samp>

*  Remove dependency resolution from `install` function ([link](https://github.com/vlang/v/pull/19987/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL96)) and move it to `parse_query` function ([link](https://github.com/vlang/v/pull/19987/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebR23), [link](https://github.com/vlang/v/pull/19987/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebL130-R149)) in `parse.v`, which recursively scans and installs the dependencies of the modules in the query using a map
