### PR TITLE
cgen, checker: fix loop on aggregate of array of sumtype

### DIFF
--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -205,6 +205,9 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 			mut value_type := c.table.value_type(typ)
 			if sym.kind == .string {
 				value_type = ast.u8_type
+			} else if sym.kind == .aggregate
+				&& (sym.info as ast.Aggregate).types.filter(c.table.type_kind(it) !in [.array, .array_fixed, .string, .map]).len == 0 {
+				value_type = c.table.value_type((sym.info as ast.Aggregate).types[0])
 			}
 			if value_type == ast.void_type || typ.has_flag(.result) {
 				if typ != ast.void_type {

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -456,6 +456,25 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		} else {
 			g.writeln('\t${val_styp} ${val} = *(${val_styp}*)${t_var}.data;')
 		}
+	} else if node.kind == .aggregate {
+		for_type := (g.table.sym(node.cond_type).info as ast.Aggregate).types[g.aggregate_type_idx]
+		val_type := g.table.value_type(for_type)
+
+		node.scope.update_var_type(node.val_var, val_type)
+
+		g.for_in_stmt(ast.ForInStmt{
+			cond: node.cond
+			cond_type: for_type
+			kind: g.table.sym(for_type).kind
+			stmts: node.stmts
+			val_type: val_type
+			val_var: node.val_var
+			val_is_mut: node.val_is_mut
+			val_is_ref: node.val_is_ref
+		})
+
+		g.loop_depth--
+		return
 	} else {
 		typ_str := g.table.type_to_str(node.cond_type)
 		g.error('for in: unhandled symbol `${node.cond}` of type `${typ_str}`', node.pos)

--- a/vlib/v/tests/for_sumtype_arr_test.v
+++ b/vlib/v/tests/for_sumtype_arr_test.v
@@ -1,0 +1,52 @@
+type MySumType = []MyStructA | []MyStructB
+
+struct ParentStruct {
+	parent_field string
+}
+
+fn (f ParentStruct) foo() int {
+	return 123
+}
+
+struct MyStructA {
+	ParentStruct
+	a int = 1
+}
+
+struct MyStructB {
+	ParentStruct
+	a int = 2
+}
+
+fn check(mut t MySumType) {
+	match mut t {
+		[]MyStructA, []MyStructB {
+			for v in t {
+				println(v)
+				println(v.a)
+				println(v.parent_field)
+				println(v.foo())
+			}
+		}
+	}
+}
+
+fn test_a() {
+	s := MyStructA{
+		parent_field: 'common'
+	}
+
+	mut t := MySumType([s])
+	check(mut t)
+	assert true
+}
+
+fn test_b() {
+	s := MyStructB{
+		parent_field: 'common2'
+	}
+
+	mut t := MySumType([s])
+	check(mut t)
+	assert true
+}


### PR DESCRIPTION
Fix #18548

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1aa8120</samp>

This pull request adds support for using for-in loops over sum types that only contain array-like types, such as arrays, slices, or structs with array fields. It modifies the checker and the C generator to handle this case and adds a test file to verify the functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1aa8120</samp>

*  Handle for-in loop over sum types with array-like types ([link](https://github.com/vlang/v/pull/19988/files?diff=unified&w=0#diff-931ec6d8461b9b7b33ea7f466a7415af08451a21fc9fa637943c2d38008d0084R208-R210), [link](https://github.com/vlang/v/pull/19988/files?diff=unified&w=0#diff-99b72ea34f60e8a13ff9e0d2ef001f328a2e8c095312c3701da1720d78941d36R459-R477))
