### PR TITLE
os: update comments

### DIFF
--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -259,6 +259,7 @@ pub fn (f &File) read(mut buf []u8) !int {
 }
 
 // **************************** Write ops  ***************************
+
 // write implements the Writer interface.
 // It returns how many bytes were actually written.
 pub fn (mut f File) write(buf []u8) !int {
@@ -559,6 +560,7 @@ pub fn (f &File) read_into_ptr(ptr &u8, max_size int) !int {
 }
 
 // **************************** Utility  ops ***********************
+
 // flush writes any buffered unwritten data left in the file stream.
 pub fn (mut f File) flush() {
 	if !f.is_opened {

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -146,8 +146,6 @@ pub fn read_file(path string) !string {
 	}
 }
 
-// ***************************** OS ops ************************
-//
 // truncate changes the size of the file located in `path` to `len`.
 // Note that changing symbolic links on Windows only works as admin.
 pub fn truncate(path string, len u64) ! {


### PR DESCRIPTION
Adds line breaks for comments that should define sections in the source code to not make them part of doc comments. 

E.g., like it's already done here:
https://github.com/vlang/v/blob/399af6768d04a57fc76b399343a7dc91642960b3/vlib/os/file.c.v#L415-L419

Removes one sectional comments for OS ops since all operations are OS ops in that file