### PR TITLE
vlib/v/help: run help init with compiler under test

### DIFF
--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -42,7 +42,9 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 		}
 	}
 	if topic in help.cli_topics {
-		os.system('${@VEXE} ${topic} --help')
+		v_cmd_name := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
+		v_cmd := os.join_path(@VEXEROOT, v_cmd_name)
+		os.system('${v_cmd} ${topic} --help')
 		exit(opts.exit_code)
 	}
 	mut topic_path := ''

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -10,10 +10,7 @@ fn hdir(base string) string {
 }
 
 fn help_dir() string {
-	mut vexe := os.getenv('VEXE')
-	if vexe == '' {
-		vexe = os.executable()
-	}
+	vexe := get_vexe()
 	if vexe != '' {
 		return hdir(os.dir(vexe))
 	}
@@ -42,7 +39,8 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 		}
 	}
 	if topic in help.cli_topics {
-		os.system('${os.quoted_path(os.getenv('VEXE'))} ${topic} --help')
+		vexe := get_vexe()
+		os.system('${os.quoted_path(vexe)} ${topic} --help')
 		exit(opts.exit_code)
 	}
 	mut topic_path := ''
@@ -78,4 +76,12 @@ fn print_known_topics() {
 		}
 	}
 	println(res)
+}
+
+fn get_vexe() string {
+	mut vexe := os.getenv('VEXE')
+	if vexe == '' {
+		vexe = os.executable()
+	}
+	return vexe
 }

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -42,7 +42,7 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 		}
 	}
 	if topic in help.cli_topics {
-		os.system('${os.getenv('VEXE')} ${topic} --help')
+		os.system('${os.quoted_path(os.getenv('VEXE'))} ${topic} --help')
 		exit(opts.exit_code)
 	}
 	mut topic_path := ''

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -42,9 +42,7 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 		}
 	}
 	if topic in help.cli_topics {
-		v_cmd_name := if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-		v_cmd := os.join_path(@VEXEROOT, v_cmd_name)
-		os.system('${v_cmd} ${topic} --help')
+		os.system('${os.getenv('VEXE')} ${topic} --help')
 		exit(opts.exit_code)
 	}
 	mut topic_path := ''


### PR DESCRIPTION
I am not sure if this is the right way to fix this problem or not.

What is happening is that the code for handling `v help init` or `v help new` is using the v compiler that was used during the build process of the v compiler being tested.  I believe this is because it is using `@VEXE` as the program to execute.

When building the v compiler from source, you see the following lines of output from make:
```
cc  -std=gnu99 -w -o v1.exe ./vc/v.c -lm -lpthread -lexecinfo
./v1.exe -no-parallel -o v2.exe  cmd/v
./v2.exe -nocache -o ./v  cmd/v
rm -rf v1.exe v2.exe
```

My current working directory is `/home/kim/Projects/v/from_github/v` so the v compiler I am testing is `/home/kim/Projects/v/from_github/v/v`. But when I run `v help init` I see:

```
$ v help init
sh: /usr/home/kim/Projects/v/from_github/v/v2.exe: not found
```
And, as we can see, `v2.exe` was deleted as part of the make process.  Plus, the compiler I want to process the `help` topic is the one built by `v2.exe`, not `v2.exe` itself.

My understanding of `@VEXE` and `@VEXEROOT` are that they contain values determined at compile time, not run time.  So maybe my fix is not the best option and that we should be determining the run time path to the compiler and use that at this point.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0dc74a3</samp>

Use `@VEXEROOT` and `os.join_path` to find v executable path in `help.v`. This improves the reliability of the help system on different platforms.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0dc74a3</samp>

* Improve the help system of v by:
  - Finding the v executable path more robustly using `@VEXEROOT` and `os.join_path` instead of `@VEXE` to avoid issues with spaces or quotes ([link](https://github.com/vlang/v/pull/19990/files?diff=unified&w=0#diff-bc34b1e36495c201337eb50ce5e18fda04ceda0a77dfbe2e2ccc60b405e909e9L45-R47))
