### PR TITLE
cgen: fix lambda initialization on option struct field

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -616,6 +616,8 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 			if (sfield.expected_type.has_flag(.option) && !sfield.typ.has_flag(.option))
 				|| (sfield.expected_type.has_flag(.result) && !sfield.typ.has_flag(.result)) {
 				g.expr_with_opt(sfield.expr, sfield.typ, sfield.expected_type)
+			} else if sfield.expr is ast.LambdaExpr && sfield.expected_type.has_flag(.option) {
+				g.expr_opt_with_cast(sfield.expr, sfield.typ, sfield.expected_type)
 			} else {
 				g.left_is_opt = true
 				g.expr_with_cast(sfield.expr, sfield.typ, sfield.expected_type)

--- a/vlib/v/tests/anon_fn_option_test.v
+++ b/vlib/v/tests/anon_fn_option_test.v
@@ -1,0 +1,26 @@
+struct Foo {
+	bar ?fn ()
+}
+
+fn test_main() {
+	foo1 := Foo{
+		bar: || println('foo1')
+	}
+	foo2 := Foo{
+		bar: fn () {
+			println('foo2')
+		}
+	}
+	if bar_fn := foo1.bar {
+		bar_fn()
+		assert true
+	} else {
+		assert false
+	}
+	if bar_fn := foo2.bar {
+		bar_fn()
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
Fix #19474

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d54d18</samp>

Fix a segfault bug when using anon functions as optional struct fields. Add a test case in `anon_fn_option_test.v` to verify the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d54d18</samp>

* Fix a bug that caused a segmentation fault when using anonymous functions as optional struct fields ([link](https://github.com/vlang/v/pull/19995/files?diff=unified&w=0#diff-39b153f03f7716b81ec985f78b639cc050749c6e247a3f5745b47b2dd78e5a82R619-R620))
* Add a test case for the bug fix in `vlib/v/tests/anon_fn_option_test.v` ([link](https://github.com/vlang/v/pull/19995/files?diff=unified&w=0#diff-34a7270a1adba39864ed5c9beb622ecf73c2bfa40fa1fb2fcb5acbcf9e360617R1-R26))
