### PR TITLE
checker, cgen: fix generics call with interface arg(fix #19976)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -279,8 +279,8 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 		}
 	} else {
 		got_typ_sym := c.table.sym(c.unwrap_generic(got))
-		expected_typ_sym := c.table.sym(c.unwrap_generic(expected_))
-		if expected_typ_sym.kind == .interface_ && c.type_implements(got, expected_, token.Pos{}) {
+		expected_typ_sym := c.table.sym(c.unwrap_generic(expected))
+		if expected_typ_sym.kind == .interface_ && c.type_implements(got, expected, token.Pos{}) {
 			return
 		}
 

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -828,7 +828,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 			} else {
 				g.write(', (')
 			}
-			g.expr_with_cast(node.right, node.right_type, left.unaliased.clear_flag(.shared_f))
+			g.expr_with_cast(node.right, right.typ, left.unaliased.clear_flag(.shared_f))
 			styp := g.typ(expected_push_many_atype)
 			g.write('), ${tmp_var}, ${styp})')
 		} else {
@@ -854,7 +854,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 				g.write(', _MOV((${elem_type_str}[]){ ')
 			}
 			if array_info.elem_type.has_flag(.option) {
-				g.expr_with_opt(node.right, node.right_type, array_info.elem_type)
+				g.expr_with_opt(node.right, right.typ, array_info.elem_type)
 			} else {
 				// if g.autofree
 				needs_clone := !g.is_builtin_mod
@@ -863,7 +863,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 				if needs_clone {
 					g.write('string_clone(')
 				}
-				g.expr_with_cast(node.right, node.right_type, array_info.elem_type)
+				g.expr_with_cast(node.right, right.typ, array_info.elem_type)
 				if needs_clone {
 					g.write(')')
 				}

--- a/vlib/v/tests/generics_call_with_interface_arg_test.v
+++ b/vlib/v/tests/generics_call_with_interface_arg_test.v
@@ -1,0 +1,13 @@
+import arrays
+
+interface Foo {}
+
+fn test_main() {
+	mut arr := []Foo{}
+	str := 'abc'
+	i := 0
+	arr = arrays.concat(arr, str, i)
+	assert arr == [Foo('abc'), Foo(0)]
+	arr = arrays.concat(arr, Foo(str), Foo(i))
+	assert arr == [Foo('abc'), Foo(0), Foo('abc'), Foo(0)]
+}


### PR DESCRIPTION
1. Fixed #19976 
2. Add tests.

```v
import arrays

interface AnythingGoes{ }

mut the_one_array := []AnythingGoes{}

some_string := 'It would suck'
another_string := 'if I was forced'
last_string := 'to << every var into the array'
random_int := 69

// this produces an error, but it shouldn't!
the_one_array = arrays.concat(the_one_array, some_string, another_string, last_string, random_int)

println(the_one_array)
```
outputs:
```
[AnythingGoes('It would suck'), AnythingGoes('if I was forced'), AnythingGoes('to << every var into the array'), AnythingGoes(69)]
```