### PR TITLE
vfmt: remove empty `__global()`

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1221,12 +1221,11 @@ pub fn (mut f Fmt) for_stmt(node ast.ForStmt) {
 pub fn (mut f Fmt) global_decl(node ast.GlobalDecl) {
 	f.attrs(node.attrs)
 	if node.fields.len == 0 && node.pos.line_nr == node.pos.last_line {
-		f.writeln('__global ()')
+		// remove "__global()"
 		return
 	}
 	f.write('__global ')
 	mut max := 0
-	// mut has_assign := false
 	if node.is_block {
 		f.writeln('(')
 		f.indent++
@@ -1234,9 +1233,6 @@ pub fn (mut f Fmt) global_decl(node ast.GlobalDecl) {
 			if field.name.len > max {
 				max = field.name.len
 			}
-			// if field.has_expr {
-			// has_assign = true
-			//}
 		}
 	}
 	for field in node.fields {

--- a/vlib/v/fmt/tests/global_keep.vv
+++ b/vlib/v/fmt/tests/global_keep.vv
@@ -4,7 +4,6 @@ struct TestInt {
 
 __global x = bool(true)
 __global y f32
-__global ()
 __global (
 	spam string
 	foo  = int(5)


### PR DESCRIPTION
It doesn't make any sense to leave `__global` block empty. 
