### PR TITLE
vfmt: fix `const` comments formatting

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -913,7 +913,7 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 	} else {
 		ast.Node(ast.NodeError{})
 	}
-	for _, field in node.fields {
+	for fidx, field in node.fields {
 		if field.comments.len > 0 {
 			if f.should_insert_newline_before_node(ast.Expr(field.comments[0]), prev_field) {
 				f.writeln('')
@@ -936,7 +936,8 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 		f.write('= ')
 		f.expr(field.expr)
 		f.comments(field.end_comments, same_line: true)
-		if node.is_block && field.end_comments.len == 0 {
+		if node.is_block && fidx < node.fields.len - 1 && node.fields.len > 1 {
+			// old style grouped consts, converted to the new style ungrouped const
 			f.writeln('')
 		} else {
 			// Write out single line comments after const expr if present

--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -25,6 +25,12 @@ const i_am_a_very_long_constant_name_so_i_stand_alone_and_my_length_is_over_90_c
 
 pub const i_am_pub_const = true
 
+const abc = 1 // abc
+
+const def = 2 // def
+
+const ghi = 3 // ghi
+
 fn main() {
 	a := [
 		[3, 5, 6],

--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -26,9 +26,7 @@ const i_am_a_very_long_constant_name_so_i_stand_alone_and_my_length_is_over_90_c
 pub const i_am_pub_const = true
 
 const abc = 1 // abc
-
 const def = 2 // def
-
 const ghi = 3 // ghi
 
 fn main() {

--- a/vlib/v/fmt/tests/consts_expected.vv
+++ b/vlib/v/fmt/tests/consts_expected.vv
@@ -26,7 +26,9 @@ const i_am_a_very_long_constant_name_so_i_stand_alone_and_my_length_is_over_90_c
 pub const i_am_pub_const = true
 
 const abc = 1 // abc
+
 const def = 2 // def
+
 const ghi = 3 // ghi
 
 fn main() {

--- a/vlib/v/fmt/tests/consts_input.vv
+++ b/vlib/v/fmt/tests/consts_input.vv
@@ -17,7 +17,7 @@ another_const = ['a', 'b'
 		]
 multiline_const = [
 		'first line',  'second line','third line',
-  'fourth line']		
+  'fourth line']
 )
 
 const (
@@ -26,6 +26,12 @@ const (
 
 pub const (
 i_am_pub_const=true
+)
+
+const (
+	abc = 1 // abc
+	def = 2 // def
+	ghi = 3 // ghi
 )
 
 fn main() {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3838,6 +3838,9 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 			p.vet_notice('use a fixed array, instead of a dynamic one', pos.line_nr, vet.FixKind.unknown,
 				.default)
 		}
+		if is_block {
+			end_comments << p.eat_comments(same_line: true)
+		}
 		field := ast.ConstField{
 			name: full_name
 			mod: p.mod
@@ -3851,6 +3854,9 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 		fields << field
 		p.table.global_scope.register(field)
 		comments = []
+		if is_block {
+			end_comments = []
+		}
 		if !is_block {
 			break
 		}


### PR DESCRIPTION
Fix #20000.

```v
$ cat main.v
const (
	abc = 1 // abc
	def = 2 // def
	ghi = 3 // ghi
)

fn main() {}
```

```v
$ v fmt main.v
const abc = 1 // abc
const def = 2 // def
const ghi = 3 // ghi

fn main() {}
```

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0a83026</samp>

This pull request enhances the parsing and formatting of constant blocks in V by fixing a syntax error, adding conditional statements, and updating the test files. It affects the files `vlib/v/parser/parser.v` and `vlib/v/fmt/tests/consts_input.vv` and `vlib/v/fmt/tests/consts_expected.vv`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0a83026</samp>

*  Preserve and format inline comments of constant blocks in V ([link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-645035e21e895f92f60b65620f22b9e897eda445dd64bdfb796f9b1753dabbcaR28-R33), [link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-723e240e00a31a5b4f31b4aba673d3d8d774ab9eea6e529d37785e1ee945b8b1R31-R36), [link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3841-R3843), [link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3857-R3859))
  * Add a block of constants with inline comments to `consts_input.vv` and `consts_expected.vv` to test the formatting of constant blocks with different delimiters and comments ([link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-645035e21e895f92f60b65620f22b9e897eda445dd64bdfb796f9b1753dabbcaR28-R33), [link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-723e240e00a31a5b4f31b4aba673d3d8d774ab9eea6e529d37785e1ee945b8b1R31-R36))
  * Modify `parse_const_decl` in `parser.v` to append any comments that follow the closing delimiter of a constant block to the `end_comments` array, and to reset the `end_comments` array after each constant block ([link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3841-R3843), [link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54R3857-R3859))
* Fix a syntax error in `consts_input.vv` by removing a trailing comma from the `multiline_const` array ([link](https://github.com/vlang/v/pull/20005/files?diff=unified&w=0#diff-723e240e00a31a5b4f31b4aba673d3d8d774ab9eea6e529d37785e1ee945b8b1L20-R20))
