### PR TITLE
v/slow_tests/repl: use real path of test folder for repl tests

### DIFF
--- a/vlib/v/slow_tests/repl/repl_test.v
+++ b/vlib/v/slow_tests/repl/repl_test.v
@@ -71,11 +71,12 @@ fn worker_repl(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		p.set_thread_context(idx, tls_bench)
 	}
 	tls_bench.cstep = idx
-	tfolder := os.join_path(cdir, 'vrepl_tests_${idx}')
+	mut tfolder := os.join_path(cdir, 'vrepl_tests_${idx}')
 	if os.is_dir(tfolder) {
 		os.rmdir_all(tfolder) or { panic(err) }
 	}
 	os.mkdir(tfolder) or { panic(err) }
+	tfolder = os.real_path(tfolder)
 	file := p.get_item[string](idx)
 	session.bmark.step()
 	tls_bench.step()


### PR DESCRIPTION
When running `v vlib/v/slow_tests/repl/repl_test.v`, test 9 would fail.  On one of my machines, `/home` is a symlink to `/usr/home` so my home directory `/home/kim` has a real path of `/usr/home/kim`.

The problem is that the test folder has the `/home/kim` prefix and when this value is removed from the result messages returned from a test, the `/usr` part is still in the error message and therefore it doesn't match the expected output.  Lines 61-62 in `vlib/v/slow_tests/repl/runner/runner.v` remove the working directory from the error messages and without using the real path of tfolder, it does not work properly when the path to tfolder has a symlink in it.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef06cfd</samp>

Fix some REPL tests on Windows by using real paths for temporary folders. Make `tfolder` mutable and assign it the result of `os.real_path` in `vlib/v/slow_tests/repl/repl_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef06cfd</samp>

* Make `tfolder` mutable and assign it the real path of the created folder to avoid potential issues with symbolic links or relative paths when running the REPL tests on Windows ([link](https://github.com/vlang/v/pull/20007/files?diff=unified&w=0#diff-ac0246eb90424ddd37032ebadd3b982174162f85e22d12468cb311e1841ffda6L74-R79))
