### PR TITLE
test: make 'test-self' pass under msys2/MINGW64

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -37,6 +37,8 @@ pub const fail_retry_delay_ms = get_fail_retry_delay_ms()
 
 pub const is_node_present = os.execute('node --version').exit_code == 0
 
+pub const is_go_present = os.execute('go version').exit_code == 0
+
 pub const all_processes = get_all_processes()
 
 pub const header_bytes_to_search_for_module_main = 500

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -336,7 +336,10 @@ fn main() {
 
 	if !testing.is_node_present {
 		testroot := vroot + os.path_separator
-		tsession.skip_files << test_js_files.map(it.replace(testroot, ''))
+		tsession.skip_files << test_js_files.map(it.replace(testroot, '').replace('\\', '/'))
+	}
+	if !testing.is_go_present {
+		tsession.skip_files << 'vlib/v/gen/golang/tests/golang_test.v'
 	}
 	testing.find_started_process('mysqld') or {
 		tsession.skip_files << 'vlib/db/mysql/mysql_orm_test.v'
@@ -427,6 +430,10 @@ fn main() {
 		tsession.skip_files << skip_on_windows
 		$if msvc {
 			tsession.skip_files << skip_on_windows_msvc
+		}
+		if !C.IsWindows10OrGreater() {
+			tsession.skip_files << 'vlib/net/unix/use_net_and_net_unix_together_test.v'
+			tsession.skip_files << 'vlib/net/unix/unix_test.v'
 		}
 	}
 	$if !windows {

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -336,7 +336,8 @@ fn main() {
 
 	if !testing.is_node_present {
 		testroot := vroot + os.path_separator
-		tsession.skip_files << test_js_files.map(it.replace(testroot, '').replace('\\', '/'))
+		tsession.skip_files << test_js_files.map(it.replace(testroot, '').replace('\\',
+			'/'))
 	}
 	if !testing.is_go_present {
 		tsession.skip_files << 'vlib/v/gen/golang/tests/golang_test.v'

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -432,10 +432,6 @@ fn main() {
 		$if msvc {
 			tsession.skip_files << skip_on_windows_msvc
 		}
-		if !C.IsWindows10OrGreater() {
-			tsession.skip_files << 'vlib/net/unix/use_net_and_net_unix_together_test.v'
-			tsession.skip_files << 'vlib/net/unix/unix_test.v'
-		}
 	}
 	$if !windows {
 		tsession.skip_files << skip_on_non_windows

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -5,10 +5,6 @@ import strings
 #flag windows -l advapi32
 #include <process.h>
 #include <sys/utime.h>
-#include <versionhelpers.h>
-
-// See https://docs.microsoft.com/en-us/windows/win32/api/versionhelpers/nf-versionhelpers-iswindows10orgreater
-fn C.IsWindows10OrGreater() bool
 
 // See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
 fn C.CreateSymbolicLinkW(&u16, &u16, u32) int
@@ -394,9 +390,7 @@ pub fn symlink(origin string, target string) ! {
 			flags ^= 1
 		}
 
-		if C.IsWindows10OrGreater() {
-			flags ^= 2 // SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
-		}
+		flags ^= 2 // SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
 		res := C.CreateSymbolicLinkW(target.to_wide(), origin.to_wide(), flags)
 
 		// 1 = success, != 1 failure => https://stackoverflow.com/questions/33010440/createsymboliclink-on-windows-10

--- a/vlib/v/gen/c/testdata/console_windows_program.vv
+++ b/vlib/v/gen/c/testdata/console_windows_program.vv
@@ -1,4 +1,4 @@
-// vtest vflags: -cc msvc -os windows
+// vtest vflags: -os windows
 
 @[console]
 fn main() {

--- a/vlib/v/gen/c/testdata/gui_windows_program.vv
+++ b/vlib/v/gen/c/testdata/gui_windows_program.vv
@@ -1,4 +1,4 @@
-// vtest vflags: -cc msvc -os windows
+// vtest vflags: -os windows
 import sokol
 
 const used_import = sokol.used_import

--- a/vlib/v/gen/c/testdata/gui_windows_program_with_console_tag.vv
+++ b/vlib/v/gen/c/testdata/gui_windows_program_with_console_tag.vv
@@ -1,4 +1,4 @@
-// vtest vflags: -cc msvc -os windows
+// vtest vflags: -os windows
 import sokol
 
 const used_import = sokol.used_import


### PR DESCRIPTION
This PR make 'test-self' pass under msys2/MINGW64.

- Correct the path separator of test_js_files in skip_files.
- Disable related tests when the go program cannot be found.
- ~Disable unix socket related tests on Windows systems below win10~
- ~Fix os.symlink errors in windows systems below win10~
- Fixed the error of os.raw_execute not using stdout pipe in cmd environment
- Make testdata available for gcc tests




<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at caf1113</samp>

This pull request improves the Windows compatibility and performance of the `os` and `testing` modules, and refactors some test code to the `testing` module. It also removes unnecessary `-cc msvc` flags from some test files.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at caf1113</samp>

*  Add `is_go_present` constant and skip tests that require Go if not present ([link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-75c5691a08429efb87dab471d51b87acbadf1757d2049fdedac90c180b7d752cR40-R41), [link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-4a4a26390fe9838e59fa3fd7afc2611d90fa43273e8fe37d6fcd105e7d2985f5L339-R343))
*  Move `#include <versionhelpers.h>` and `C.IsWindows10OrGreater` function from `os_windows.c.v` to `testing` module, and use it to skip tests that use Unix sockets or symbolic link flags on lower Windows versions ([link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-4d0b63075e5710479ceb92d7d03d1b1490e8ba49d6f4a7e4cdb2140498be8364L8-R12), [link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-4a4a26390fe9838e59fa3fd7afc2611d90fa43273e8fe37d6fcd105e7d2985f5R434-R437), [link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-4d0b63075e5710479ceb92d7d03d1b1490e8ba49d6f4a7e4cdb2140498be8364L393-R399))
*  Fix typo in `StartupInfo` struct name in `os_windows.c.v` to fix compilation error ([link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-4d0b63075e5710479ceb92d7d03d1b1490e8ba49d6f4a7e4cdb2140498be8364L327-R331))
*  Remove `-cc msvc` flag from `vtest` comments in `console_windows_program.vv`, `gui_windows_program.vv`, and `gui_windows_program_with_console_tag.vv` to simplify test commands and avoid potential conflicts ([link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-d4c907475569981cba664cb5374508827372fa190b77b5f0468777561c5d36dcL1-R1), [link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-ec34beebcbe83c75160d29df8fc05a5cfd05d8f47c6275a9e9763d40075ede8aL1-R1), [link](https://github.com/vlang/v/pull/20010/files?diff=unified&w=0#diff-dee15ed1ebc1001a0a6a091948ce11d972e09457898f065282929099514c22d2L1-R1))
