### PR TITLE
ast, checker: fix generics with embed generic method call (fix #19968)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -312,7 +312,7 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) !
 		mut embed_of_found_methods := []Type{}
 		for embed in sym.info.embeds {
 			embed_sym := t.sym(embed)
-			if m := t.find_method(embed_sym, method_name) {
+			if m := embed_sym.find_method_with_generic_parent(method_name) {
 				found_methods << m
 				embed_of_found_methods << embed
 			} else {
@@ -332,7 +332,7 @@ pub fn (t &Table) find_method_from_embeds(sym &TypeSymbol, method_name string) !
 		mut embed_of_found_methods := []Type{}
 		for embed in sym.info.embeds {
 			embed_sym := t.sym(embed)
-			if m := t.find_method(embed_sym, method_name) {
+			if m := embed_sym.find_method_with_generic_parent(method_name) {
 				found_methods << m
 				embed_of_found_methods << embed
 			} else {

--- a/vlib/v/tests/generics_with_embed_generics_method_call_test.v
+++ b/vlib/v/tests/generics_with_embed_generics_method_call_test.v
@@ -1,0 +1,29 @@
+pub type Handler[T] = fn (mut T) bool
+
+struct Collector[T] {
+mut:
+	handlers []Handler[T]
+}
+
+pub fn (mut c Collector[T]) use(func Handler[T]) {
+	c.handlers << func
+}
+
+pub struct Context {}
+
+fn handler(mut ctx Context) bool {
+	println('from test_handler!')
+	return true
+}
+
+pub struct MainStruct {
+	Collector[Context]
+}
+
+fn test_generics_with_embed_generic_method_call() {
+	mut s := MainStruct{}
+
+	s.use(handler)
+
+	assert s.handlers.len == 1
+}


### PR DESCRIPTION
This PR fix generics with embed generic method call (fix #19968).

- Fix generics with embed generic method call.
- Add test.

```v
pub type Handler[T] = fn (mut T) bool

struct Collector[T] {
mut:
	handlers []Handler[T]
}

pub fn (mut c Collector[T]) use(func Handler[T]) {
	c.handlers << func
}

pub struct Context {}

fn handler(mut ctx Context) bool {
	println('from test_handler!')
	return true
}

pub struct MainStruct {
	Collector[Context]
}

fn main() {
	mut s := MainStruct{}

	s.use(handler)

	println(s)
	assert s.handlers.len == 1
}

PS D:\Test\v\tt1> v run .    
MainStruct{
    Collector: Collector[Context]{
        handlers: [fn (mut Context) bool]
    }
}
```