### PR TITLE
tools.vcreate: add `initial-branch=main` to git init

### DIFF
--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -272,7 +272,7 @@ indent_style = tab
 fn (c &Create) create_git_repo(dir string) {
 	// Initialize git and add a .gitignore file.
 	if !os.is_dir('${dir}/.git') {
-		res := os.execute('git init ${dir}')
+		res := os.execute('git init --initial-branch=main ${dir}')
 		if res.exit_code != 0 {
 			eprintln('')
 			cerror('unable to initialize a git repository')


### PR DESCRIPTION
This would init a git repository during scaffolding with a `main` instead of a `master` branch. The change might add a little more convenience for the bigger part of users since `main` became the default and most commonly used head branch.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f2838e4</samp>

Use `main` as the default branch name for V projects. Modify `vcreate` tool to set `main` as the initial branch when initializing a Git repository.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f2838e4</samp>

* Set the default branch name for V projects to `main` instead of `master` ([link](https://github.com/vlang/v/pull/20018/files?diff=unified&w=0#diff-1a69fed0525297da9db51ec220d6fa4c5065820418638b67bd88c235091d5e1eL275-R275),                            
