### PR TITLE
ast: fix generics with embed generics structs(fix #20021)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2110,6 +2110,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 						generic_names := t.get_generic_names(parent_info.generic_types)
 						for i in 0 .. fields.len {
 							if fields[i].typ.has_flag(.generic) {
+								orig_type := fields[i].typ
 								if fields[i].typ.idx() != info.parent_idx {
 									fields[i].typ = t.unwrap_generic_type(fields[i].typ,
 										generic_names, info.concrete_types)
@@ -2118,6 +2119,15 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 									generic_names, info.concrete_types)
 								{
 									fields[i].typ = t_typ
+								}
+								// Update type in `info.embeds`, if it's embed
+								if fields[i].name.len > 1 && fields[i].name[0].is_capital() {
+									for mut embed in parent_info.embeds {
+										if embed == orig_type {
+											embed = fields[i].typ.set_flag(.generic)
+											break
+										}
+									}
 								}
 							}
 						}

--- a/vlib/v/tests/generics_with_embed_generics_structs_test.v
+++ b/vlib/v/tests/generics_with_embed_generics_structs_test.v
@@ -1,0 +1,12 @@
+struct Foo[T] {
+	field T
+}
+
+struct MainStruct[T] {
+	Foo[T]
+}
+
+fn test_main() {
+	m := MainStruct[int]{}
+	assert m.field == 0
+}


### PR DESCRIPTION
1. Fixed #20021 
2. Add tests.

```v
struct Foo[T] {
	field T
}

struct MainStruct[T] {
	Foo[T]
}

fn main() {
	m := MainStruct[int]{}
	println(m.field)
}
```
outputs:
```
0
```