### PR TITLE
tools.vpm: update tests, add `get_installed` test

### DIFF
--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -51,7 +51,8 @@ fn test_install_dependencies_in_module_dir() {
 	}
 	assert v_mod.dependencies == ['markdown', 'pcre', 'https://github.com/spytheman/vtray']
 	// Run `v install`
-	mut res := os.execute_or_exit('${v} install --once')
+	mut res := os.execute('${v} install --once')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Detected v.mod file inside the project directory. Using it...'), res.output
 	assert res.output.contains('Installing `markdown`'), res.output
 	assert res.output.contains('Installing `pcre`'), res.output
@@ -60,12 +61,14 @@ fn test_install_dependencies_in_module_dir() {
 	assert get_mod_name(os.join_path(test_path, 'markdown', 'v.mod')) == 'markdown'
 	assert get_mod_name(os.join_path(test_path, 'pcre', 'v.mod')) == 'pcre'
 	assert get_mod_name(os.join_path(test_path, 'vtray', 'v.mod')) == 'vtray'
-	res = os.execute_or_exit('${v} install --once')
+	res = os.execute('${v} install --once')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('All modules are already installed.'), res.output
 }
 
 fn test_resolve_external_dependencies_during_module_install() {
-	res := os.execute_or_exit('${v} install -v https://github.com/ttytm/emoji-mart-desktop')
+	res := os.execute('${v} install -v https://github.com/ttytm/emoji-mart-desktop')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Found 2 dependencies'), res.output
 	assert res.output.contains('Installing `webview`'), res.output
 	assert res.output.contains('Installing `miniaudio`'), res.output
@@ -79,5 +82,6 @@ fn test_install_with_recursive_dependencies() {
 		time.sleep(2 * time.minute)
 		exit(1)
 	}()
-	os.execute_or_exit('${v} install https://gitlab.com/tobealive/a')
+	res := os.execute('${v} install https://gitlab.com/tobealive/a')
+	assert res.exit_code == 0, res.str()
 }

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -1,10 +1,11 @@
 // vtest retry: 3
 import os
-import v.vmod
 import time
+import rand
+import v.vmod
 
 const v = os.quoted_path(@VEXE)
-const test_path = os.join_path(os.vtmp_dir(), 'vpm_dependency_test')
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_dependency_test_${rand.ulid()}')
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)
@@ -29,10 +30,6 @@ fn test_install_dependencies_in_module_dir() {
 	os.mkdir_all(test_path) or {}
 	mod := 'my_module'
 	mod_path := os.join_path(test_path, mod)
-	$if windows {
-		// Make sure path is clean to work around CI failures with Windows MSVC.
-		os.system('rd /s /q ${mod_path}')
-	}
 	os.mkdir(mod_path)!
 	os.chdir(mod_path)!
 	// Create a v.mod file that lists dependencies.

--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -77,6 +77,7 @@ fn test_resolve_external_dependencies_during_module_install() {
 fn test_install_with_recursive_dependencies() {
 	spawn fn () {
 		time.sleep(2 * time.minute)
+		eprintln('Timeout while testing installation with recursive dependencies.')
 		exit(1)
 	}()
 	res := os.execute('${v} install https://gitlab.com/tobealive/a')

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -3,11 +3,12 @@
 module main
 
 import os
+import rand
 import v.vmod
 
 // Running tests appends a tsession path to VTMP, which is automatically cleaned up after the test.
 // The following will result in e.g. `$VTMP/tsession_7fe8e93bd740_1612958707536/test-vmodules/`.
-const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_test')
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_test_${rand.ulid()}')
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -21,7 +21,8 @@ fn testsuite_end() {
 }
 
 fn test_install_from_vpm_ident() {
-	res := os.execute_or_exit('${vexe} install nedpals.args')
+	res := os.execute('${vexe} install nedpals.args')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'nedpals', 'args', 'v.mod')) or {
 		assert false, err.msg()
@@ -32,7 +33,8 @@ fn test_install_from_vpm_ident() {
 }
 
 fn test_install_from_vpm_short_ident() {
-	os.execute_or_exit('${vexe} install pcre')
+	res := os.execute('${vexe} install pcre')
+	assert res.exit_code == 0, res.str()
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.msg()
 		return
@@ -42,7 +44,8 @@ fn test_install_from_vpm_short_ident() {
 }
 
 fn test_install_from_git_url() {
-	mut res := os.execute_or_exit('${vexe} install https://github.com/vlang/markdown')
+	mut res := os.execute('${vexe} install https://github.com/vlang/markdown')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `markdown`'), res.output
 	mut mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
@@ -50,22 +53,26 @@ fn test_install_from_git_url() {
 	}
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
-	res = os.execute_or_exit('${vexe} install http://github.com/Wertzui123/HashMap')
+	res = os.execute('${vexe} install http://github.com/Wertzui123/HashMap')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `HashMap`'), res.output
 	assert res.output.contains('`http` is deprecated'), res.output
 	mod = vmod.from_file(os.join_path(test_path, 'wertzui123', 'hashmap', 'v.mod')) or {
 		assert false, err.msg()
 		return
 	}
-	res = os.execute_or_exit('${vexe} install http://github.com/Wertzui123/HashMap')
+	res = os.execute('${vexe} install http://github.com/Wertzui123/HashMap')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `wertzui123.hashmap`'), res.output
 	assert res.output.contains('`http` is deprecated'), res.output
-	res = os.execute_or_exit('${vexe} install https://gitlab.com/tobealive/webview')
+	res = os.execute('${vexe} install https://gitlab.com/tobealive/webview')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installed `webview`'), res.output
 }
 
 fn test_install_already_existent() {
-	mut res := os.execute_or_exit('${vexe} install https://github.com/vlang/markdown')
+	mut res := os.execute('${vexe} install https://github.com/vlang/markdown')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'markdown', 'v.mod')) or {
 		assert false, err.msg()
@@ -74,7 +81,8 @@ fn test_install_already_existent() {
 	assert mod.name == 'markdown'
 	assert mod.dependencies == []string{}
 	// The same module but with the `.git` extension added.
-	os.execute_or_exit('${vexe} install https://github.com/vlang/markdown.git')
+	res = os.execute('${vexe} install https://github.com/vlang/markdown.git')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `markdown` in `${test_path}/markdown`'), res.output
 }
 
@@ -89,13 +97,15 @@ fn test_install_once() {
 	os.mkdir_all(test_path) or {}
 
 	// Install markdown module.
-	os.execute_or_exit('${vexe} install markdown')
+	mut res := os.execute('${vexe} install markdown')
+	assert res.exit_code == 0, res.str()
 	// Keep track of the last modified state of the v.mod file of the installed markdown module.
 	md_last_modified := os.file_last_mod_unix(os.join_path(test_path, 'markdown', 'v.mod'))
 
 	install_cmd := '${@VEXE} install https://github.com/vlang/markdown https://github.com/vlang/pcre --once -v'
 	// Try installing two modules, one of which is already installed.
-	mut res := os.execute_or_exit(install_cmd)
+	res = os.execute(install_cmd)
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains("Already installed modules: ['markdown']"), res.output
 	mod := vmod.from_file(os.join_path(test_path, 'pcre', 'v.mod')) or {
 		assert false, err.msg()
@@ -108,7 +118,8 @@ fn test_install_once() {
 		'v.mod'))
 
 	// Try installing two modules that are both already installed.
-	res = os.execute_or_exit(install_cmd)
+	res = os.execute(install_cmd)
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('All modules are already installed.'), res.output
 	assert md_last_modified == os.file_last_mod_unix(os.join_path(test_path, 'markdown',
 		'v.mod'))
@@ -147,7 +158,8 @@ fn test_manifest_detection() {
 	assert res.exit_code == 1
 	assert res.output.contains('failed to find `v.mod` for `https://github.com/octocat/octocat.github.io`'), res.output
 	// No error for vpm modules yet.
-	res = os.execute_or_exit('${vexe} install spytheman.regex')
+	res = os.execute('${vexe} install spytheman.regex')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('`spytheman.regex` is missing a manifest file'), res.output
 	assert res.output.contains('Installing `spytheman.regex`'), res.output
 }

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -37,7 +37,8 @@ fn test_reinstall_mod_with_version_installation() {
 	// Install version.
 	mod := 'vsl'
 	tag := 'v0.1.47'
-	os.execute_or_exit('${vexe} install ${mod}@${tag}')
+	mut res := os.execute('${vexe} install ${mod}@${tag}')
+	assert res.exit_code == 0, res.str()
 	mut name, mut version := get_mod_name_and_version(mod)
 	assert name == mod
 	assert version == tag.trim_left('v')
@@ -51,12 +52,14 @@ fn test_reinstall_mod_with_version_installation() {
 	decline_test := os.join_path(expect_tests_path, 'decline_reinstall_mod_with_version_installation.expect')
 	manifest_path := os.join_path(install_path, 'v.mod')
 	last_modified := os.file_last_mod_unix(manifest_path)
-	os.execute_or_exit('${expect_exe} ${decline_test} ${expect_args}')
+	res = os.execute('${expect_exe} ${decline_test} ${expect_args}')
+	assert res.exit_code == 0, res.str()
 	assert last_modified == os.file_last_mod_unix(manifest_path)
 
 	// Accept.
 	accept_test := os.join_path(expect_tests_path, 'accept_reinstall_mod_with_version_installation.expect')
-	os.execute_or_exit('${expect_exe} ${accept_test} ${expect_args}')
+	res = os.execute('${expect_exe} ${accept_test} ${expect_args}')
+	assert res.exit_code == 0, res.str()
 	name, version = get_mod_name_and_version(mod)
 	assert name == mod, name
 	assert version == new_tag.trim_left('v'), version

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -25,29 +25,28 @@ fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }
 
-fn get_mod_name_and_version(path string) (string, string) {
-	mod := vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
-		eprintln(err)
-		return '', ''
+fn get_vmod(path string) vmod.Manifest {
+	return vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
+		eprintln('Failed to parse v.mod for `${path}`')
+		exit(1)
 	}
-	return mod.name, mod.version
 }
 
 // Test installing another version of a module of which an explicit version is already installed.
 fn test_reinstall_mod_with_version_installation() {
 	// Install version.
-	mod := 'vsl'
+	ident := 'vsl'
 	tag := 'v0.1.47'
-	mut res := os.execute('${vexe} install ${mod}@${tag}')
+	mut res := os.execute('${vexe} install ${ident}@${tag}')
 	assert res.exit_code == 0, res.str()
-	mut name, mut version := get_mod_name_and_version(mod)
-	assert name == mod
-	assert version == tag.trim_left('v')
+	mut manifest := get_vmod(ident)
+	assert manifest.name == ident
+	assert manifest.version == tag.trim_left('v')
 
 	// Try reinstalling.
 	new_tag := 'v0.1.50'
-	install_path := os.real_path(os.join_path(test_path, mod))
-	expect_args := [vexe, mod, tag, new_tag, install_path].join(' ')
+	install_path := os.real_path(os.join_path(test_path, ident))
+	expect_args := [vexe, ident, tag, new_tag, install_path].join(' ')
 
 	// Decline.
 	decline_test := os.join_path(expect_tests_path, 'decline_reinstall_mod_with_version_installation.expect')
@@ -61,7 +60,7 @@ fn test_reinstall_mod_with_version_installation() {
 	accept_test := os.join_path(expect_tests_path, 'accept_reinstall_mod_with_version_installation.expect')
 	res = os.execute('${expect_exe} ${accept_test} ${expect_args}')
 	assert res.exit_code == 0, res.str()
-	name, version = get_mod_name_and_version(mod)
-	assert name == mod, name
-	assert version == new_tag.trim_left('v'), version
+	manifest = get_vmod(ident)
+	assert manifest.name == ident
+	assert manifest.version == new_tag.trim_left('v')
 }

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -1,9 +1,10 @@
 // vtest retry: 3
 import os
+import rand
 import v.vmod
 
 const vexe = os.quoted_path(@VEXE)
-const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test')
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test_${rand.ulid()}')
 const expect_tests_path = os.join_path(@VEXEROOT, 'cmd', 'tools', 'vpm', 'expect')
 const expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 	eprintln('skipping test, since expect is missing')

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -18,24 +18,24 @@ fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }
 
-fn get_mod_name_and_version(path string) (string, string) {
-	mod := vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
-		eprintln(err)
-		return '', ''
+fn get_vmod(path string) vmod.Manifest {
+	return vmod.from_file(os.join_path(test_path, path, 'v.mod')) or {
+		eprintln('Failed to parse v.mod for `${path}`')
+		exit(1)
 	}
-	return mod.name, mod.version
 }
 
 fn test_install_from_vpm_with_git_version_tag() {
 	ident := 'ttytm.webview'
+	relative_path := ident.replace('.', os.path_separator)
 	mut tag := 'v0.6.0'
 	mut res := os.execute('${vexe} install ${ident}@${tag}')
 	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `${ident}`'), res.output
 	assert res.output.contains('Installed `${ident}`'), res.output
-	mut name, mut version := get_mod_name_and_version(os.join_path('ttytm', 'webview'))
-	assert name == 'webview'
-	assert version == '0.6.0'
+	mut manifest := get_vmod(relative_path)
+	assert manifest.name == 'webview'
+	assert manifest.version == '0.6.0'
 	// Install same version without force flag.
 	res = os.execute('${vexe} install ${ident}@${tag}')
 	assert res.exit_code == 0, res.str()
@@ -45,9 +45,9 @@ fn test_install_from_vpm_with_git_version_tag() {
 	res = os.execute('${vexe} install -f ${ident}@${tag}')
 	assert res.output.contains('Installed `${ident}`'), res.output
 	assert res.exit_code == 0, res.str()
-	name, version = get_mod_name_and_version(os.join_path('ttytm', 'webview'))
-	assert name == 'webview'
-	assert version == '0.5.0'
+	manifest = get_vmod(relative_path)
+	assert manifest.name == 'webview'
+	assert manifest.version == '0.5.0'
 	// Install invalid version.
 	tag = '6.0'
 	res = os.execute('${vexe} install -f ${ident}@${tag}')
@@ -75,9 +75,9 @@ fn test_install_from_url_with_git_version_tag() {
 	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `vsl`'), res.output
 	assert res.output.contains('Installed `vsl`'), res.output
-	mut name, mut version := get_mod_name_and_version('vsl')
-	assert name == 'vsl'
-	assert version == '0.1.50'
+	mut manifest := get_vmod('vsl')
+	assert manifest.name == 'vsl'
+	assert manifest.version == '0.1.50'
 	// Install same version without force flag.
 	res = os.execute('${vexe} install ${url}@${tag}')
 	assert res.exit_code == 0, res.str()
@@ -87,9 +87,9 @@ fn test_install_from_url_with_git_version_tag() {
 	res = os.execute('${vexe} install -f ${url}@${tag}')
 	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installed `vsl`'), res.output
-	name, version = get_mod_name_and_version('vsl')
-	assert name == 'vsl'
-	assert version == '0.1.47'
+	manifest = get_vmod('vsl')
+	assert manifest.name == 'vsl'
+	assert manifest.version == '0.1.47'
 	// Install invalid version.
 	tag = 'abc'
 	res = os.execute('${vexe} install -f ${url}@${tag}')
@@ -98,13 +98,13 @@ fn test_install_from_url_with_git_version_tag() {
 	res = os.execute('${vexe} install -f -v ${url}@${tag}')
 	assert res.exit_code == 1, res.str()
 	assert res.output.contains('failed to find `v.mod` for `${url}@${tag}`'), res.output
-	// GitLab
+	// Install from GitLab.
 	url = 'https://gitlab.com/tobealive/webview'
 	tag = 'v0.6.0'
 	res = os.execute('${vexe} install ${url}@${tag}')
 	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installed `webview`'), res.output
-	name, version = get_mod_name_and_version('webview')
-	assert name == 'webview'
-	assert version == '0.6.0'
+	manifest = get_vmod('webview')
+	assert manifest.name == 'webview'
+	assert manifest.version == '0.6.0'
 }

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -28,55 +28,63 @@ fn get_mod_name_and_version(path string) (string, string) {
 fn test_install_from_vpm_with_git_version_tag() {
 	ident := 'ttytm.webview'
 	mut tag := 'v0.6.0'
-	mut res := os.execute_or_exit('${vexe} install ${ident}@${tag}')
+	mut res := os.execute('${vexe} install ${ident}@${tag}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `${ident}`'), res.output
 	assert res.output.contains('Installed `${ident}`'), res.output
 	mut name, mut version := get_mod_name_and_version(os.join_path('ttytm', 'webview'))
 	assert name == 'webview'
 	assert version == '0.6.0'
 	// Install same version without force flag.
-	res = os.execute_or_exit('${vexe} install ${ident}@${tag}')
+	res = os.execute('${vexe} install ${ident}@${tag}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Module `${ident}@${tag}` is already installed, use --force to overwrite'), res.output
 	// Install another version, add force flag to surpass confirmation.
 	tag = 'v0.5.0'
-	res = os.execute_or_exit('${vexe} install -f ${ident}@${tag}')
+	res = os.execute('${vexe} install -f ${ident}@${tag}')
 	assert res.output.contains('Installed `${ident}`'), res.output
+	assert res.exit_code == 0, res.str()
 	name, version = get_mod_name_and_version(os.join_path('ttytm', 'webview'))
 	assert name == 'webview'
 	assert version == '0.5.0'
 	// Install invalid version.
 	tag = '6.0'
 	res = os.execute('${vexe} install -f ${ident}@${tag}')
-	assert res.exit_code == 1
+	assert res.exit_code == 1, res.str()
 	assert res.output.contains('failed to install `${ident}`'), res.output
 	// Install invalid version verbose.
 	res = os.execute('${vexe} install -f -v ${ident}@${tag}')
-	assert res.exit_code == 1
+	assert res.exit_code == 1, res.str()
 	assert res.output.contains('failed to install `${ident}`'), res.output
 	assert res.output.contains('Remote branch 6.0 not found in upstream origin'), res.output
 	// Install without version tag after a version was installed
-	res = os.execute_or_exit('${vexe} install -f ${ident}')
+	res = os.execute('${vexe} install -f ${ident}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `${ident}`'), res.output
 	// Re-install latest version (without a tag). Should trigger an update, force should not be required.
-	res = os.execute_or_exit('${vexe} install ${ident}')
+	res = os.execute('${vexe} install ${ident}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `${ident}`'), res.output
 }
 
 fn test_install_from_url_with_git_version_tag() {
 	mut url := 'https://github.com/vlang/vsl'
 	mut tag := 'v0.1.50'
-	mut res := os.execute_or_exit('${vexe} install ${url}@${tag}')
+	mut res := os.execute('${vexe} install ${url}@${tag}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installing `vsl`'), res.output
 	assert res.output.contains('Installed `vsl`'), res.output
 	mut name, mut version := get_mod_name_and_version('vsl')
 	assert name == 'vsl'
 	assert version == '0.1.50'
 	// Install same version without force flag.
-	res = os.execute_or_exit('${vexe} install ${url}@${tag}')
+	res = os.execute('${vexe} install ${url}@${tag}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Module `vsl@${tag}` is already installed, use --force to overwrite'), res.output
 	// Install another version, add force flag to surpass confirmation.
 	tag = 'v0.1.47'
-	res = os.execute_or_exit('${vexe} install -f ${url}@${tag}')
+	res = os.execute('${vexe} install -f ${url}@${tag}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installed `vsl`'), res.output
 	name, version = get_mod_name_and_version('vsl')
 	assert name == 'vsl'
@@ -84,15 +92,16 @@ fn test_install_from_url_with_git_version_tag() {
 	// Install invalid version.
 	tag = 'abc'
 	res = os.execute('${vexe} install -f ${url}@${tag}')
-	assert res.exit_code == 1
+	assert res.exit_code == 1, res.str()
 	// Install invalid version verbose.
 	res = os.execute('${vexe} install -f -v ${url}@${tag}')
-	assert res.exit_code == 1
+	assert res.exit_code == 1, res.str()
 	assert res.output.contains('failed to find `v.mod` for `${url}@${tag}`'), res.output
 	// GitLab
 	url = 'https://gitlab.com/tobealive/webview'
 	tag = 'v0.6.0'
-	res = os.execute_or_exit('${vexe} install ${url}@${tag}')
+	res = os.execute('${vexe} install ${url}@${tag}')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Installed `webview`'), res.output
 	name, version = get_mod_name_and_version('webview')
 	assert name == 'webview'

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -2,9 +2,10 @@
 module main
 
 import os
+import rand
 import v.vmod
 
-const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test')
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test_${rand.ulid()}')
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -152,9 +152,9 @@ fn (mut p Parser) parse_module(m string) {
 	}
 }
 
-// TODO: add unit test
 fn (mut m Module) get_installed() {
 	refs := os.execute_opt('git ls-remote --refs ${m.install_path}') or { return }
+	vpm_log(@FILE_LINE, @FN, 'refs: ${refs}')
 	m.is_installed = true
 	// In case the head just temporarily matches a tag, make sure that there
 	// really is a version installation before adding it as `installed_version`.

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -19,7 +19,8 @@ fn test_update() {
 	os.execute_or_exit('${v} install pcre')
 	os.execute_or_exit('${v} install nedpals.args')
 	os.execute_or_exit('${v} install https://github.com/spytheman/vtray')
-	res := os.execute_opt('${v} update') or { panic(err) }
+	res := os.execute('${v} update')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `pcre`'), res.output
 	assert res.output.contains('Updating module `nedpals.args`'), res.output
 	assert res.output.contains('Updating module `vtray`'), res.output
@@ -28,21 +29,24 @@ fn test_update() {
 }
 
 fn test_update_idents() {
-	mut res := os.execute_or_exit('${v} update pcre')
+	mut res := os.execute('${v} update pcre')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `pcre`'), res.output
-	res = os.execute_or_exit('${v} update nedpals.args vtray')
+	res = os.execute('${v} update nedpals.args vtray')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `vtray`'), res.output
 	assert res.output.contains('Updating module `nedpals.args`'), res.output
 	// Update installed module using its url.
 	res = os.execute('${v} update https://github.com/spytheman/vtray')
+	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `vtray`'), res.output
 	// Try update not installed.
 	res = os.execute('${v} update vsl')
-	assert res.exit_code == 1
+	assert res.exit_code == 1, res.str()
 	assert res.output.contains('failed to find `vsl`'), res.output
 	// Try update mixed.
 	res = os.execute('${v} update pcre vsl')
-	assert res.exit_code == 1
+	assert res.exit_code == 1, res.str()
 	assert res.output.contains('Updating module `pcre`'), res.output
 	assert res.output.contains('failed to find `vsl`'), res.output
 }

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -1,8 +1,9 @@
 // vtest retry: 3
 import os
+import rand
 
 const v = os.quoted_path(@VEXE)
-const test_path = os.join_path(os.vtmp_dir(), 'vpm_update_test')
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_update_test_${rand.ulid()}')
 
 fn testsuite_begin() {
 	os.setenv('VMODULES', test_path, true)


### PR DESCRIPTION
Updates vpm tests that have increased in number, makes some minor improvements, adds a test.

Changes split into commits.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b40475b</samp>

The pull request enhances the vpm tool and its tests by refactoring code, improving error handling, increasing reliability, and adding more test cases and logging. It affects the files `dependency_test.v`, `install_test.v`, `install_version_input_test.v`, `install_version_test.v`, `update_test.v`, and `parse.v` in the `cmd/tools/vpm` directory.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b40475b</samp>

* Increase the retry count for vtest from 3 to 5 in `dependency_test.v`, `install_version_test.v`, and `update_test.v` to reduce flaky test failures ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L1-R1), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L1-R1), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeL1-R1))
* Replace os.execute_or_exit with os.execute and add assert statements to check the exit code and the output of the commands in various test cases in `dependency_test.v`, `install_test.v`, and `update_test.v` to improve error handling and test assertions ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L54-R55), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L63-R71), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-100ab516faebafe0676a0096555854c57184b049cb1b02b7c00a939c8a7d9a63L80-R87), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L150-R150), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeL22-R23), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-d9ff4530b6387dcb815a459584fd6f760d8a57dd7889a2b62a372614d32682eeL31-R49))
* Introduce a helper function get_vmod to parse the v.mod file and return a vmod.Manifest struct in `install_test.v`, and update the test cases in `install_test.v`, `install_version_input_test.v`, and `install_version_test.v` to use this function and access the manifest fields instead of separate variables ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L23-R76), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L92-R92), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L98-R103), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L111-R110), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L126-R137), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-fb5883fd548f11caedf8f3b5b9c7da41012141122199a063f87d20ac3728e81dL27-R31), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-fb5883fd548f11caedf8f3b5b9c7da41012141122199a063f87d20ac3728e81dL38-R48), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-fb5883fd548f11caedf8f3b5b9c7da41012141122199a063f87d20ac3728e81dL54-R64), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L20-R66), [link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L68-R108))
* Add a new test case to test the get_installed method of the Module struct in `install_test.v`, which checks the installation and version status of a module with different branch and tag states ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L158-R209))
* Add a logging statement to print the refs output of the git ls-remote command in `parse.v`, for debugging purposes ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebL155-R157))
* Add a comment to clarify that the last test case in `install_version_test.v` installs from a GitLab repository, not GitHub ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-98bae30d3699f1a4a4a67c9008f7dd3d381a88eee884b5e39a4a27b11af50e38L68-R108))
* Change the file name and the module name from install_test.v to dependency_test.v in `install_test.v`, to reflect the broader scope of the tests ([link](https://github.com/vlang/v/pull/20028/files?diff=unified&w=0#diff-78784e99c54e871f7a03ed28df4041d212af5f541b4ed8b5ffaf55fc3eef0a58L1-R1))
