### PR TITLE
os(windows): fflush stdout and stderr before calling _wsystem

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -400,6 +400,8 @@ pub fn system(cmd string) int {
 		// overcome bug in system & _wsystem (cmd) when first char is quote `"`
 		wcmd := if cmd.len > 1 && cmd[0] == `"` && cmd[1] != `"` { '"${cmd}"' } else { cmd }
 		unsafe {
+			C.fflush(C.stdout)
+			C.fflush(C.stderr)
 			ret = C._wsystem(wcmd.to_wide())
 		}
 	} $else {


### PR DESCRIPTION
According to the remarks of [_wsystem](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/system-wsystem?view=msvc-170) api, we must explicitly flush, by using fflush or _flushall, or close any stream before calling system.
In the pipe stdout and stderr environment, the lack of fflush operation will cause the display content to be misaligned.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07c72cf</samp>

Flush stdout and stderr before os.exit in `vlib/os/os.c.v`. This improves output reliability and consistency across platforms.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07c72cf</samp>

* Flush standard output and error streams before exiting ([link](https://github.com/vlang/v/pull/20029/files?diff=unified&w=0#diff-4d8978da445d7babd96c096c86416b20ed658ebb83dca96f12c5c43f16cc3d61R403-R404))
