### PR TITLE
os(windows): fflush stdout and stderr before calling _wsystem

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -400,6 +400,8 @@ pub fn system(cmd string) int {
 		// overcome bug in system & _wsystem (cmd) when first char is quote `"`
 		wcmd := if cmd.len > 1 && cmd[0] == `"` && cmd[1] != `"` { '"${cmd}"' } else { cmd }
 		unsafe {
+			C.fflush(C.stdout)
+			C.fflush(C.stderr)
 			ret = C._wsystem(wcmd.to_wide())
 		}
 	} $else {


### PR DESCRIPTION
According to the remarks of [_wsystem](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/system-wsystem?view=msvc-170) api, we must explicitly flush, by using fflush or _flushall, or close any stream before calling system.

In the pipe stdout and stderr environment, the lack of fflush operation will cause the display content to be misaligned.

Before fixing:
```
lenovo@lenovo-PC MINGW64 /d/gym/test/mingw-w64-packages/mingw-w64-v/src/v-0.4.3
# ./v0 -keepc -g -showcc -cc gcc -o test_v.exe cmd/v
> C compiler cmd: gcc "@D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-x86_64-v-0.4.3-1\v_0\test_v.exe.tmp.c.rsp"
> C compiler response file "D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-x86_64-v-0.4.3-1\v_0\test_v.exe.tmp.c.rsp":
  -fwrapv -g -no-pie -o "D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-0.4.3\\test_v.exe" -Wl,-stack=16777216 -Werror=implicit-function-declaration -I "D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-0.4.3\\thirdparty\\stdatomic\\win" "D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\tmp\\mingw-w64-x86_64-v-0.4.3-1\\v_0\\test_v.exe.tmp.c" -std=c99 -D_DEFAULT_SOURCE -municode -ldbghelp -lws2_32 -ladvapi32 -lshell32

lenovo@lenovo-PC MINGW64 /d/gym/test/mingw-w64-packages/mingw-w64-v/src/v-0.4.3
# ./test_v -v repl
                                  ____    ____
                                  \   \  /   /
                                   \   \/   /
                                    \      /
                                     \    /
                                      \__/
Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
Note: the REPL is highly experimental. For best V experience, use a text editor,
save your code in a  main.v  file and execute:  v run main.v
V 0.4.3 44cf145 . Use  list  to see the accumulated program so far.
Use Ctrl-C or  exit  to exit, or  help  to see other available commands.
>>> exit

launch_tool vexe        : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\test_v.exe
launch_tool vroot       : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3
launch_tool tool_source : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\cmd\tools\vrepl.v
launch_tool tool_exe    : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\cmd\tools\vrepl.exe
launch_tool tool_args   : "-v" "repl"
launch_tool should_compile: true
Compiling vrepl with: ""D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\test_v.exe" "D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\cmd\tools\vrepl.v""

```
After modification:
```
lenovo@lenovo-PC MINGW64 /d/gym/test/mingw-w64-packages/mingw-w64-v/src/v-0.4.3
# ./v0 -keepc -g -showcc -cc gcc -o test_v.exe cmd/v
> C compiler cmd: gcc "@D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-x86_64-v-0.4.3-1\v_0\test_v.exe.tmp.c.rsp"
> C compiler response file "D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-x86_64-v-0.4.3-1\v_0\test_v.exe.tmp.c.rsp":
  -fwrapv -g -no-pie -o "D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-0.4.3\\test_v.exe" -Wl,-stack=16777216 -Werror=implicit-function-declaration -I "D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-0.4.3\\thirdparty\\stdatomic\\win" "D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\tmp\\mingw-w64-x86_64-v-0.4.3-1\\v_0\\test_v.exe.tmp.c" -std=c99 -D_DEFAULT_SOURCE -municode -ldbghelp -lws2_32 -ladvapi32 -lshell32

lenovo@lenovo-PC MINGW64 /d/gym/test/mingw-w64-packages/mingw-w64-v/src/v-0.4.3
# ./test_v -v repl
launch_tool vexe        : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\test_v.exe
launch_tool vroot       : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3
launch_tool tool_source : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\cmd\tools\vrepl.v
launch_tool tool_exe    : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\cmd\tools\vrepl.exe
launch_tool tool_args   : "-v" "repl"
launch_tool should_compile: true
Compiling vrepl with: ""D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\test_v.exe" "D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.3\cmd\tools\vrepl.v""
                                  ____    ____
                                  \   \  /   /
                                   \   \/   /
                                    \      /
                                     \    /
                                      \__/
Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
Note: the REPL is highly experimental. For best V experience, use a text editor,
save your code in a  main.v  file and execute:  v run main.v
V 0.4.3 44cf145 . Use  list  to see the accumulated program so far.
Use Ctrl-C or  exit  to exit, or  help  to see other available commands.
>>> exit

```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07c72cf</samp>

Flush stdout and stderr before os.exit in `vlib/os/os.c.v`. This improves output reliability and consistency across platforms.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07c72cf</samp>

* Flush standard output and error streams before exiting ([link](https://github.com/vlang/v/pull/20034/files?diff=unified&w=0#diff-4d8978da445d7babd96c096c86416b20ed658ebb83dca96f12c5c43f16cc3d61R403-R404))
