### PR TITLE
repl(windows): make sure the prompt is output before user input.

### DIFF
--- a/vlib/readline/readline_windows.c.v
+++ b/vlib/readline/readline_windows.c.v
@@ -36,6 +36,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ![]rune {
 		r.previous_lines[0] = []rune{}
 	}
 	print(r.prompt)
+	unsafe { C.fflush(C.stdout) }
 	r.current = os.get_raw_line().runes()
 	r.previous_lines[0] = []rune{}
 	r.search_index = 0


### PR DESCRIPTION
This PR make sure the prompt is output before user input.

Before fixing:
```
# ./test_v repl
1+1
exit
                                  ____    ____
                                  \   \  /   /
                                   \   \/   /
                                    \      /
                                     \    /
                                      \__/
Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
Note: the REPL is highly experimental. For best V experience, use a text editor,
save your code in a  main.v  file and execute:  v run main.v
V 0.4.3 44cf145 . Use  list  to see the accumulated program so far.
Use Ctrl-C or  exit  to exit, or  help  to see other available commands.
>>> 2
>>>


```
After modification:
```
# ./test_v repl
                                  ____    ____
                                  \   \  /   /
                                   \   \/   /
                                    \      /
                                     \    /
                                      \__/
Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
Note: the REPL is highly experimental. For best V experience, use a text editor,
save your code in a  main.v  file and execute:  v run main.v
V 0.4.3 44cf145 . Use  list  to see the accumulated program so far.
Use Ctrl-C or  exit  to exit, or  help  to see other available commands.
>>> 1+1
2
>>> exit



```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6300176</samp>

Fix `readline` module on Windows by flushing output buffer before reading input. Modify `vlib/readline/readline_windows.c.v` to call `fflush` before `ReadConsoleInputW`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6300176</samp>

* Flush standard output buffer before reading user input on Windows ([link](https://github.com/vlang/v/pull/20035/files?diff=unified&w=0#diff-ef1b50219bef80396d4e55f132ee520f518dfe8f071ed2b4f24099ee8ac663e8R39))
