### PR TITLE
db/mysql: add FreeBSD name of mariadb client

### DIFF
--- a/vlib/db/mysql/_cdefs_nix.c.v
+++ b/vlib/db/mysql/_cdefs_nix.c.v
@@ -6,7 +6,12 @@ module mysql
 $if $pkgconfig('mysqlclient') {
 	#pkgconfig mysqlclient
 	#include <mysql.h> # Please install the libmysqlclient-dev development headers
-} $else {
+} $else $if $pkgconfig('mariadb') {
 	#pkgconfig mariadb
 	#include <mysql.h> # Please install the libmariadb-dev development headers
+} $else $if $pkgconfig('libmariadb') {
+	#pkgconfig libmariadb
+	#include <mysql.h> # Please install the mariadb client
+} $else {
+	#include <mysql.h> # Please install the mysql headers
 }


### PR DESCRIPTION
The pkgconfig name for the mysql client on FreeBSD, mysqlclient, is the same as it is for Linux.  However, the pkgconfig name for mariadb on FreeBSD is libmariadb instead of mariadb.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a722c58</samp>

Improved mariadb client library detection in `vlib/db/mysql` module. Added more pkgconfig names and a fallback header inclusion for `vlib/db/mysql/_cdefs_nix.c.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a722c58</samp>

* Improve compatibility of mysql module with different mariadb client library names and versions ([link](https://github.com/vlang/v/pull/20039/files?diff=unified&w=0#diff-ac8ba6a2f103e2e1490a1cc365703ee41b73bffed563447176686d8d6c451cc3L9-R16))
