### PR TITLE
strings: replace strings.Builder alias with a struct

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -426,7 +426,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					right := val as ast.Ident
 					v_var = right.name
 				}
-				pos := g.out.len
+				pos := g.out.buf.len
 				g.expr(left)
 
 				if g.is_arraymap_set && g.arraymap_set_pos > 0 {
@@ -554,9 +554,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 
 				fn_name := c_fn_name(g.get_ternary_name(ident.name))
 				g.write('${ret_styp} (${msvc_call_conv}*${fn_name}) (')
-				def_pos := g.definitions.len
+				def_pos := g.definitions.buf.len
 				g.fn_decl_params(func.func.params, unsafe { nil }, false)
-				g.definitions.go_back(g.definitions.len - def_pos)
+				g.definitions.go_back(g.definitions.buf.len - def_pos)
 				g.write(')${call_conv_attribute_suffix}')
 			} else {
 				if is_decl {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -897,7 +897,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 	mut fn_body := strings.new_builder(info.fields.len * 256)
 	defer {
 		fn_body_surrounder.builder_write_befores(mut fn_builder)
-		fn_builder << fn_body
+		fn_builder.buf << fn_body.buf
 		fn_body_surrounder.builder_write_afters(mut fn_builder)
 		fn_builder.writeln('\tstring_free(&indents);')
 		fn_builder.writeln('\treturn res;')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -358,23 +358,23 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) (string
 		util.timing_start('cgen unification')
 		for g in pp.get_results_ref[Gen]() {
 			global_g.embedded_files << g.embedded_files
-			global_g.out.write(g.out) or { panic(err) }
-			global_g.cheaders.write(g.cheaders) or { panic(err) }
-			global_g.preincludes.write(g.preincludes) or { panic(err) }
-			global_g.includes.write(g.includes) or { panic(err) }
-			global_g.typedefs.write(g.typedefs) or { panic(err) }
-			global_g.type_definitions.write(g.type_definitions) or { panic(err) }
-			global_g.alias_definitions.write(g.alias_definitions) or { panic(err) }
-			global_g.definitions.write(g.definitions) or { panic(err) }
-			global_g.gowrappers.write(g.gowrappers) or { panic(err) }
-			global_g.auto_str_funcs.write(g.auto_str_funcs) or { panic(err) }
-			global_g.dump_funcs.write(g.auto_str_funcs) or { panic(err) }
-			global_g.comptime_definitions.write(g.comptime_definitions) or { panic(err) }
-			global_g.pcs_declarations.write(g.pcs_declarations) or { panic(err) }
-			global_g.hotcode_definitions.write(g.hotcode_definitions) or { panic(err) }
-			global_g.embedded_data.write(g.embedded_data) or { panic(err) }
-			global_g.shared_types.write(g.shared_types) or { panic(err) }
-			global_g.shared_functions.write(g.channel_definitions) or { panic(err) }
+			global_g.out.write(g.out.buf) or { panic(err) }
+			global_g.cheaders.write(g.cheaders.buf) or { panic(err) }
+			global_g.preincludes.write(g.preincludes.buf) or { panic(err) }
+			global_g.includes.write(g.includes.buf) or { panic(err) }
+			global_g.typedefs.write(g.typedefs.buf) or { panic(err) }
+			global_g.type_definitions.write(g.type_definitions.buf) or { panic(err) }
+			global_g.alias_definitions.write(g.alias_definitions.buf) or { panic(err) }
+			global_g.definitions.write(g.definitions.buf) or { panic(err) }
+			global_g.gowrappers.write(g.gowrappers.buf) or { panic(err) }
+			global_g.auto_str_funcs.write(g.auto_str_funcs.buf) or { panic(err) }
+			global_g.dump_funcs.write(g.auto_str_funcs.buf) or { panic(err) }
+			global_g.comptime_definitions.write(g.comptime_definitions.buf) or { panic(err) }
+			global_g.pcs_declarations.write(g.pcs_declarations.buf) or { panic(err) }
+			global_g.hotcode_definitions.write(g.hotcode_definitions.buf) or { panic(err) }
+			global_g.embedded_data.write(g.embedded_data.buf) or { panic(err) }
+			global_g.shared_types.write(g.shared_types.buf) or { panic(err) }
+			global_g.shared_functions.write(g.channel_definitions.buf) or { panic(err) }
 
 			global_g.force_main_console = global_g.force_main_console || g.force_main_console
 
@@ -403,13 +403,13 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) (string
 			for k, v in g.sumtype_definitions {
 				global_g.sumtype_definitions[k] = v
 			}
-			global_g.json_forward_decls.write(g.json_forward_decls) or { panic(err) }
-			global_g.enum_typedefs.write(g.enum_typedefs) or { panic(err) }
-			global_g.channel_definitions.write(g.channel_definitions) or { panic(err) }
-			global_g.thread_definitions.write(g.thread_definitions) or { panic(err) }
-			global_g.sql_buf.write(g.sql_buf) or { panic(err) }
+			global_g.json_forward_decls.write(g.json_forward_decls.buf) or { panic(err) }
+			global_g.enum_typedefs.write(g.enum_typedefs.buf) or { panic(err) }
+			global_g.channel_definitions.write(g.channel_definitions.buf) or { panic(err) }
+			global_g.thread_definitions.write(g.thread_definitions.buf) or { panic(err) }
+			global_g.sql_buf.write(g.sql_buf.buf) or { panic(err) }
 
-			global_g.cleanups[g.file.mod.name].write(g.cleanup) or { panic(err) } // strings.Builder.write never fails; it is like that in the source
+			global_g.cleanups[g.file.mod.name].write(g.cleanup.buf) or { panic(err) } // strings.Builder.write never fails; it is like that in the source
 
 			for str_type in g.str_types {
 				global_g.str_types << str_type
@@ -498,14 +498,14 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) (string
 	}
 
 	// insert for options forward
-	if g.out_options_forward.len > 0 || g.out_results_forward.len > 0 {
+	if g.out_options_forward.buf.len > 0 || g.out_results_forward.buf.len > 0 {
 		tail := g.type_definitions.cut_to(g.options_pos_forward)
-		if g.out_options_forward.len > 0 {
+		if g.out_options_forward.buf.len > 0 {
 			g.type_definitions.writeln('// #start V forward option_xxx definitions:')
 			g.type_definitions.writeln(g.out_options_forward.str())
 			g.type_definitions.writeln('// #end V forward option_xxx definitions\n')
 		}
-		if g.out_results_forward.len > 0 {
+		if g.out_results_forward.buf.len > 0 {
 			g.type_definitions.writeln('// #start V forward result_xxx definitions:')
 			g.type_definitions.writeln(g.out_results_forward.str())
 			g.type_definitions.writeln('// #end V forward result_xxx definitions\n')
@@ -528,7 +528,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) (string
 	b.write_string(g.preincludes.str())
 	b.writeln('\n// V cheaders:')
 	b.write_string(g.cheaders.str())
-	if g.pcs_declarations.len > 0 {
+	if g.pcs_declarations.buf.len > 0 {
 		b.writeln('\n// V profile counters:')
 		b.write_string(g.pcs_declarations.str())
 	}
@@ -563,32 +563,32 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) (string
 		b.writeln('\n// V interface table:')
 		b.write_string(interface_table)
 	}
-	if g.gowrappers.len > 0 {
+	if g.gowrappers.buf.len > 0 {
 		b.writeln('\n// V gowrappers:')
 		b.write_string(g.gowrappers.str())
 	}
-	if g.hotcode_definitions.len > 0 {
+	if g.hotcode_definitions.buf.len > 0 {
 		b.writeln('\n// V hotcode definitions:')
 		b.write_string(g.hotcode_definitions.str())
 	}
-	if g.embedded_data.len > 0 {
+	if g.embedded_data.buf.len > 0 {
 		b.writeln('\n// V embedded data:')
 		b.write_string(g.embedded_data.str())
 	}
-	if g.shared_functions.len > 0 {
+	if g.shared_functions.buf.len > 0 {
 		b.writeln('\n// V shared type functions:')
 		b.write_string(g.shared_functions.str())
 		b.write_string(c_concurrency_helpers)
 	}
-	if g.channel_definitions.len > 0 {
+	if g.channel_definitions.buf.len > 0 {
 		b.writeln('\n// V channel code:')
 		b.write_string(g.channel_definitions.str())
 	}
-	if g.auto_str_funcs.len > 0 {
+	if g.auto_str_funcs.buf.len > 0 {
 		b.writeln('\n// V auto str functions:')
 		b.write_string(g.auto_str_funcs.str())
 	}
-	if g.dump_funcs.len > 0 {
+	if g.dump_funcs.buf.len > 0 {
 		b.writeln('\n// V dump functions:')
 		b.write_string(g.dump_funcs.str())
 	}
@@ -609,7 +609,7 @@ pub fn gen(files []&ast.File, table &ast.Table, pref_ &pref.Preferences) (string
 		}
 	}
 	b.writeln('\n// end of V out')
-	mut header := b.last_n(b.len)
+	mut header := b.last_n(b.buf.len)
 	header = '#ifndef V_HEADER_FILE\n#define V_HEADER_FILE' + header
 	header += '\n#endif\n'
 	out_str := g.out.str()
@@ -799,7 +799,7 @@ pub fn (mut g Gen) init() {
 		g.cheaders.writeln('#include <spawn.h>')
 	}
 	g.write_builtin_types()
-	g.options_pos_forward = g.type_definitions.len
+	g.options_pos_forward = g.type_definitions.buf.len
 	g.write_typedef_types()
 	g.write_typeof_functions()
 	g.write_sorted_types()
@@ -1037,7 +1037,7 @@ fn (mut g Gen) generic_fn_name(types []ast.Type, before string) string {
 }
 
 fn (mut g Gen) expr_string(expr ast.Expr) string {
-	pos := g.out.len
+	pos := g.out.buf.len
 	// pos2 := 	g.out_parallel[g.out_idx].len
 	g.expr(expr)
 	// g.out_parallel[g.out_idx].cut_to(pos2)
@@ -1045,7 +1045,7 @@ fn (mut g Gen) expr_string(expr ast.Expr) string {
 }
 
 fn (mut g Gen) expr_string_with_cast(expr ast.Expr, typ ast.Type, exp ast.Type) string {
-	pos := g.out.len
+	pos := g.out.buf.len
 	// pos2 := 	g.out_parallel[g.out_idx].len
 	g.expr_with_cast(expr, typ, exp)
 	// g.out_parallel[g.out_idx].cut_to(pos2)
@@ -1055,7 +1055,7 @@ fn (mut g Gen) expr_string_with_cast(expr ast.Expr, typ ast.Type, exp ast.Type) 
 // Surround a potentially multi-statement expression safely with `prepend` and `append`.
 // (and create a statement)
 fn (mut g Gen) expr_string_surround(prepend string, expr ast.Expr, append string) string {
-	pos := g.out.len
+	pos := g.out.buf.len
 	// pos2 := 	g.out_parallel[g.out_idx].len
 	g.stmt_path_pos << pos
 	defer {
@@ -1451,7 +1451,7 @@ pub fn (mut g Gen) write_typedef_types() {
 					len := styp.after('_')
 					mut fixed := g.typ(info.elem_type)
 					if elem_sym.info is ast.FnType {
-						pos := g.out.len
+						pos := g.out.buf.len
 						// pos2:=g.out_parallel[g.out_idx].len
 						g.write_fn_ptr_decl(&elem_sym.info, '')
 						fixed = g.out.cut_to(pos)
@@ -1667,7 +1667,7 @@ pub fn (mut g Gen) write_array_fixed_return_types() {
 }
 
 pub fn (mut g Gen) write_multi_return_types() {
-	start_pos := g.type_definitions.len
+	start_pos := g.type_definitions.buf.len
 	g.typedefs.writeln('\n// BEGIN_multi_return_typedefs')
 	g.type_definitions.writeln('\n// BEGIN_multi_return_structs')
 	for sym in g.table.type_symbols {
@@ -2570,10 +2570,10 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 }
 
 fn write_octal_escape(mut b strings.Builder, c u8) {
-	b << 92 // \
-	b << 48 + (c >> 6) // oct digit 2
-	b << 48 + (c >> 3) & 7 // oct digit 1
-	b << 48 + c & 7 // oct digit 0
+	b.buf << 92 // \
+	b.buf << 48 + (c >> 6) // oct digit 2
+	b.buf << 48 + (c >> 3) & 7 // oct digit 1
+	b.buf << 48 + c & 7 // oct digit 0
 }
 
 fn cescape_nonascii(original string) string {
@@ -4739,7 +4739,7 @@ fn (mut g Gen) hash_stmt(node ast.HashStmt) {
 	line_nr := node.pos.line_nr + 1
 	mut ct_condition := ''
 	if node.ct_conds.len > 0 {
-		ct_condition_start := g.out.len
+		ct_condition_start := g.out.buf.len
 		for idx, ct_expr in node.ct_conds {
 			g.comptime_if_cond(ct_expr, false)
 			if idx < node.ct_conds.len - 1 {
@@ -5818,7 +5818,7 @@ fn (mut g Gen) write_init_function() {
 	if g.pref.is_liveshared {
 		return
 	}
-	fn_vinit_start_pos := g.out.len
+	fn_vinit_start_pos := g.out.buf.len
 
 	// ___argv is declared as voidptr here, because that unifies the windows/unix logic
 	g.writeln('void _vinit(int ___argc, voidptr ___argv) {')
@@ -5906,7 +5906,7 @@ fn (mut g Gen) write_init_function() {
 		println(g.out.after(fn_vinit_start_pos))
 	}
 
-	fn_vcleanup_start_pos := g.out.len
+	fn_vcleanup_start_pos := g.out.buf.len
 	g.writeln('void _vcleanup(void) {')
 	if g.pref.trace_calls {
 		g.writeln('\tv__trace_calls__on_call(_SLIT("_vcleanup"));')
@@ -6078,7 +6078,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 						fixed_elem_name = fixed_elem_name[3..]
 					}
 					if elem_sym.info is ast.FnType {
-						pos := g.out.len
+						pos := g.out.buf.len
 						g.write_fn_ptr_decl(&elem_sym.info, '')
 						fixed_elem_name = g.out.cut_to(pos)
 						mut def_str := 'typedef ${fixed_elem_name};'
@@ -6946,7 +6946,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 					// inline void Cat_speak_Interface_Animal_method_wrapper(Cat c) { return Cat_speak(*c); }
 					iwpostfix := '_Interface_${interface_name}_method_wrapper'
 					methods_wrapper.write_string('static inline ${g.typ(method.return_type)} ${cctype}_${name}${iwpostfix}(')
-					params_start_pos := g.out.len
+					params_start_pos := g.out.buf.len
 					mut params := method.params.clone()
 					// hack to mutate typ
 					params[0] = ast.Param{
@@ -6954,7 +6954,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 						typ: st.set_nr_muls(1)
 					}
 					fargs, _, _ := g.fn_decl_params(params, unsafe { nil }, false)
-					mut parameter_name := g.out.cut_last(g.out.len - params_start_pos)
+					mut parameter_name := g.out.cut_last(g.out.buf.len - params_start_pos)
 
 					if st.is_ptr() {
 						parameter_name = parameter_name.trim_string_left('__shared__')

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -18,7 +18,7 @@ pub fn (mut g Gen) gen_c_main() {
 		return
 	}
 	g.out.writeln('')
-	main_fn_start_pos := g.out.len
+	main_fn_start_pos := g.out.buf.len
 
 	is_sokol := 'sokol' in g.table.imports
 	if (g.pref.os == .android && g.pref.is_apk) || (g.pref.os == .ios && is_sokol) {
@@ -233,7 +233,7 @@ pub fn (mut g Gen) gen_c_main_profile_hook() {
 }
 
 pub fn (mut g Gen) gen_c_main_for_tests() {
-	main_fn_start_pos := g.out.len
+	main_fn_start_pos := g.out.buf.len
 	g.writeln('')
 	g.gen_c_main_function_header()
 	if g.pref.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm_leak] {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -340,7 +340,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 	mut comptime_may_skip_else := false
 
 	for i, branch in node.branches {
-		start_pos := g.out.len
+		start_pos := g.out.buf.len
 		if comptime_may_skip_else {
 			continue // if we already have a known true, ignore other branches
 		}
@@ -361,7 +361,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 			comptime_if_stmts_skip = !comptime_if_stmts_skip
 			g.writeln('')
 		}
-		expr_str := g.out.last_n(g.out.len - start_pos).trim_space()
+		expr_str := g.out.last_n(g.out.buf.len - start_pos).trim_space()
 		if expr_str != '' {
 			if g.defer_ifdef != '' {
 				g.defer_ifdef += '\n' + '\t'.repeat(g.indent + 1)

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -115,7 +115,7 @@ fn (mut g Gen) dump_expr_definitions() {
 		if dump_sym.kind == .function {
 			fninfo := dump_sym.info as ast.FnType
 			str_dumparg_type = 'DumpFNType_${name}'
-			tdef_pos := g.out.len
+			tdef_pos := g.out.buf.len
 			g.write_fn_ptr_decl(&fninfo, str_dumparg_type)
 			str_tdef := g.out.after(tdef_pos)
 			g.go_back(str_tdef.len)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -56,7 +56,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 			g.definitions.write_string('static ')
 		}
 		if !node.is_anon {
-			g.out_fn_start_pos << g.out.len
+			g.out_fn_start_pos << g.out.buf.len
 		}
 	}
 	prev_is_direct_array_access := g.is_direct_array_access
@@ -66,7 +66,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 	}
 	g.gen_attrs(node.attrs)
 	mut skip := false
-	pos := g.out.len
+	pos := g.out.buf.len
 	should_bundle_module := util.should_bundle_module(node.mod)
 	if g.pref.build_mode == .build_module {
 		// TODO true for not just "builtin"
@@ -202,7 +202,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		// TODO remove unsafe
 		g.cur_fn = node
 	}
-	fn_start_pos := g.out.len
+	fn_start_pos := g.out.buf.len
 	is_closure := node.scope.has_inherited_vars()
 	mut cur_closure_ctx := ''
 	if is_closure {
@@ -304,7 +304,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		g.definitions.write_string(fn_header)
 		g.write(fn_header)
 	}
-	arg_start_pos := g.out.len
+	arg_start_pos := g.out.buf.len
 	fargs, fargtypes, heap_promoted := g.fn_decl_params(node.params, node.scope, node.is_variadic)
 	if is_closure {
 		g.nr_closures++
@@ -569,7 +569,7 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 		}
 		builder.writeln('};\n')
 	}
-	pos := g.out.len
+	pos := g.out.buf.len
 	was_anon_fn := g.anon_fn
 	g.anon_fn = true
 	g.fn_decl(node.decl)

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -422,7 +422,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		g.is_arraymap_set = old_is_arraymap_set
 		g.is_assign_lhs = old_is_assign_lhs
 		g.write('}')
-		g.arraymap_set_pos = g.out.len
+		g.arraymap_set_pos = g.out.buf.len
 		g.write(', &(${val_type_str}[]) { ')
 		if g.assign_op != .assign && info.value_type != ast.string_type {
 			zero := g.type_default(info.value_type)

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -61,7 +61,7 @@ fn (mut g Gen) gen_jsons() {
 			if sym.kind == .struct_ && !utyp.is_ptr() {
 				init_styp += ' = '
 				g.set_current_pos_as_last_stmt_pos()
-				pos := g.out.len
+				pos := g.out.buf.len
 				g.expr_with_tmp_var(ast.Expr(ast.StructInit{ typ: utyp, typ_str: styp }),
 					utyp, utyp, 'res')
 				init_styp = g.out.cut_to(pos).trim_space()
@@ -73,7 +73,7 @@ fn (mut g Gen) gen_jsons() {
 			if sym.kind == .struct_ {
 				init_styp += ' = '
 				g.set_current_pos_as_last_stmt_pos()
-				pos := g.out.len
+				pos := g.out.buf.len
 				g.write(init_styp)
 				g.expr(ast.Expr(ast.StructInit{
 					typ: utyp

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -330,7 +330,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				}
 			}
 			if has_cast {
-				pos := g.out.len
+				pos := g.out.buf.len
 				g.call_args(expr)
 				mut call_args_str := g.out.after(pos)
 				g.go_back(call_args_str.len)
@@ -343,7 +343,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				g.gowrappers.write_string(call_args_str)
 			} else if expr.name in ['print', 'println', 'eprint', 'eprintln', 'panic']
 				&& expr.args[0].typ != ast.string_type {
-				pos := g.out.len
+				pos := g.out.buf.len
 				g.gen_expr_to_string(expr.args[0].expr, expr.args[0].typ)
 				mut call_args_str := g.out.after(pos)
 				g.out.go_back(call_args_str.len)

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -443,7 +443,7 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 		}
 	}
 	// TODO avoid buffer manip
-	start_pos := g.type_definitions.len
+	start_pos := g.type_definitions.buf.len
 
 	mut pre_pragma := ''
 	mut post_pragma := ''

--- a/vlib/v/gen/c/text_manipulation.v
+++ b/vlib/v/gen/c/text_manipulation.v
@@ -59,7 +59,7 @@ fn (g &Gen) nth_stmt_pos(n int) int {
 
 @[inline]
 fn (mut g Gen) set_current_pos_as_last_stmt_pos() {
-	g.stmt_path_pos << g.out.len
+	g.stmt_path_pos << g.out.buf.len
 }
 
 @[inline]


### PR DESCRIPTION
In a conversation on [discord](https://discord.com/channels/592103645835821068/592106336838352923/1179966743863623783) I made a comparison between using an alias and the raw type, and it was noticed that it greatly improved the time that stringBuilder operated.

![image](https://github.com/vlang/v/assets/7676415/52661707-4012-4197-b62e-071949cf4aaa)

This was the example code to reproduce the time above.
```v
module main

import strings
import benchmark

fn main() {

	mut b := benchmark.start()

	mut s := strings.new_builder(300)
	msg := r'V full version: V 0.4.3 150f225.d9fae2e
OS: windows, Microsoft Windows 11 Pro v22631 64 bits
Processor: 12 cpus, 64bit, little endian, 

getwd: C:\Users\AndreLuiz\Desktop\teste
vexe: C:\v\v.exe
vexe mtime: 2023-12-01 02:43:49

vroot: OK, value: C:\v
VMODULES: OK, value: C:\Users\AndreLuiz\.vmodules
VTMP: OK, value: C:\Users\AndreLuiz\AppData\Local\Temp\v_0

Git version: git version 2.42.0.windows.2
Git vroot status: weekly.2023.48-26-gd9fae2ee
.git/config present: true

CC version: Error: 'cc' não é reconhecido como um comando interno
ou externo, um programa operável ou um arquivo em lotes.

thirdparty/tcc status: thirdparty-windows-amd64 a39eb79b'

	for _ in 0 .. 900000 {
		s.write_string(msg)
	}
	b.measure('write_string - currently Builder = []u8')
	// b.measure('write_string - struct Builder instead alias Builder = []u8')

	b.stop()
}
```
Improved by 319.757ms in this case.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d9fae2e</samp>

Refactored the `strings.Builder` type from an alias of `[]u8` to a `struct` with a `buf` field and updated all the places where it was used in the `vlib` codebase. This improved the clarity, extensibility, and performance of the type and the `strings` module.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d9fae2e</samp>

*  Change `strings.Builder` from a `[]u8` alias to a `struct` with a `buf` field of type `[]u8` to avoid confusion and bugs and allow future extensions (`[link](https://github.com/vlang/v/pull/20051/files?diff=unified&w=0#diff-ed970d96e6989f77b2c8664fdb155d4567979b1bc4f8e2271d2938b47615f479L10-R18)`)
