### PR TITLE
ast: duplicated code gen for embedded generic fields

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1955,7 +1955,7 @@ pub fn (mut t Table) unwrap_generic_type(typ Type, generic_names []string, concr
 							if mut parent_info is Struct {
 								for mut embed in parent_info.embeds {
 									if embed == orig_type {
-										embed = fields[i].typ.set_flag(.generic)
+										embed = fields[i].typ
 										break
 									}
 								}
@@ -2138,7 +2138,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 								if fields[i].name.len > 1 && fields[i].name[0].is_capital() {
 									for mut embed in parent_info.embeds {
 										if embed == orig_type {
-											embed = fields[i].typ.set_flag(.generic)
+											embed = fields[i].typ
 											break
 										}
 									}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1544,7 +1544,11 @@ pub fn (t &TypeSymbol) symbol_name_except_generic() string {
 }
 
 pub fn (t &TypeSymbol) embed_name() string {
-	if t.name.contains('[') {
+	if t.name.contains('<') {
+		// Abc<T>[int] => Abc
+		// main.Abc<T>[main.Enum] => Abc
+		return t.name.split('<')[0].split('.').last()
+	} else if t.name.contains('[') {
 		// Abc[int] => Abc
 		// main.Abc[main.Enum] => Abc
 		return t.name.split('[')[0].split('.').last()


### PR DESCRIPTION
This PR fixed: duplicated code gen for embedded generic fields

```v
struct Foo[T] {
	field T
}

struct MainStruct[T] {
	Foo[T]
}

fn main() {
	m := MainStruct[int]{}
	println(m.field)
}
```
code gen:

<img width="1030" alt="image" src="https://github.com/vlang/v/assets/27794478/94f7cd22-90ce-443d-8fbc-3095e8151708">

now:
```c
VV_LOCAL_SYMBOL void main__main(void) {
	main__MainStruct_T_int m = ((main__MainStruct_T_int){.Foo = ((main__Foo_T_int){.field = 0,}),});
	println(int_str(m.Foo.field));
}
```
