### PR TITLE
cgen: fix code generated for option type on concat expr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4699,7 +4699,10 @@ fn (mut g Gen) concat_expr(node ast.ConcatExpr) {
 		g.write('(${styp}){')
 		for i, expr in node.vals {
 			g.write('.arg${i}=')
+			old_left_is_opt := g.left_is_opt
+			g.left_is_opt = true
 			g.expr(expr)
+			g.left_is_opt = old_left_is_opt
 			if i < node.vals.len - 1 {
 				g.write(',')
 			}

--- a/vlib/v/tests/concat_option_test.v
+++ b/vlib/v/tests/concat_option_test.v
@@ -1,0 +1,20 @@
+fn opt(arg ?int) ?int {
+	return arg
+}
+
+fn test_main() {
+	_, a, b, c, d := match 0 {
+		0 {
+			a := ?bool(true)
+			b := ?bool(none)
+			3, a, b, opt(none), opt(5)
+		}
+		else {
+			3, ?bool(false), ?bool(false), ?int(false), ?int(false)
+		}
+	}
+	assert a? == true
+	assert b == none
+	assert c == none
+	assert d? == 5
+}


### PR DESCRIPTION
Fix #20043

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9336400</samp>

Fix a bug in the C backend for optional values in match expressions and add a test case. The bug caused incorrect C code generation for optional expressions as match arguments. The test case checks the expected values of four optional variables after a match expression.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9336400</samp>

* Fix bug in C backend for optional values in match expressions ([link](https://github.com/vlang/v/pull/20062/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecL4702-R4705))
* Add test case for optional values in match expressions ([link](https://github.com/vlang/v/pull/20062/files?diff=unified&w=0#diff-5c799bae0f71e2f02d7320adc3b2f83d96a68dec0fe52edfe3b9ea1329568eb6R1-R20))
