### PR TITLE
ast, parser: add comments to several representations of complete qualified names for generics

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1215,6 +1215,10 @@ pub fn (t &Table) clean_generics_type_str(typ Type) string {
 	return result.all_before('[')
 }
 
+// strip_extra_struct_types returns the name of remove the `<generic names>` from the
+// complete qualified name and keep the `[concrete names]`, For example:
+// `main.Foo<T, <T, U>>[int, [int, string]]` -> `main.Foo[int, [int, string]]`
+// `main.Foo<T>[int] -> main.Foo[int]`
 fn strip_extra_struct_types(name string) string {
 	mut start := 0
 	mut is_start := false
@@ -1531,7 +1535,9 @@ pub fn (t &Table) fn_signature_using_aliases(func &Fn, import_aliases map[string
 }
 
 // symbol_name_except_generic return the name of the complete qualified name of the type,
-// but without the generic parts. For example, `main.Abc[int]` -> `main.Abc`
+// but without the generic parts. For example:
+// `main.Abc[int]` -> `main.Abc`
+// `main.Abc<T>[int]` -> `main.Abc<T>`
 pub fn (t &TypeSymbol) symbol_name_except_generic() string {
 	// main.Abc[int]
 	mut embed_name := t.name
@@ -1543,6 +1549,10 @@ pub fn (t &TypeSymbol) symbol_name_except_generic() string {
 	return embed_name
 }
 
+// embed_name return the pure name of the complete qualified name of the type,
+// without the generic parts, concrete parts and mod parts. For example:
+// `main.Abc[int]` -> `Abc`
+// `main.Abc<T>[int]` -> `Abc`
 pub fn (t &TypeSymbol) embed_name() string {
 	if t.name.contains('<') {
 		// Abc<T>[int] => Abc

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1215,7 +1215,7 @@ pub fn (t &Table) clean_generics_type_str(typ Type) string {
 	return result.all_before('[')
 }
 
-// strip_extra_struct_types returns the name of remove the `<generic names>` from the
+// strip_extra_struct_types removes the `<generic names>` from the
 // complete qualified name and keep the `[concrete names]`, For example:
 // `main.Foo<T, <T, U>>[int, [int, string]]` -> `main.Foo[int, [int, string]]`
 // `main.Foo<T>[int] -> main.Foo[int]`

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -721,7 +721,7 @@ fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Languag
 					// NOTE:
 					// Used here for the wraparound `< >` characters, is not a reserved character in generic syntax,
 					// is used as the `generic names` part of the qualified type name,
-					// while the `[ ]` characters is the `concrete namea` part of the qualified type name.
+					// while the `[ ]` characters is the `concrete names` part of the qualified type name.
 					// The two pairs characters distinguish the generic name from the concrete name, such as:
 					//   main.Foo<T, U>[int, string]
 					//   main.Foo<T, <T, U>>[int, [int, string]]

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -718,6 +718,18 @@ fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Languag
 					&& p.struct_init_generic_types != sym.info.generic_types {
 					generic_names := p.types_to_names(p.struct_init_generic_types, p.tok.pos(),
 						'struct_init_generic_types') or { return ast.Type(0) }
+					// NOTE:
+					// Used here for the wraparound `< >` characters, is not a reserved character in generic syntax,
+					// is used as the `generic names` part of the qualified type name,
+					// while the `[ ]` characters is the `concrete namea` part of the qualified type name.
+					// The two pairs characters distinguish the generic name from the concrete name, such as:
+					//   main.Foo<T, U>[int, string]
+					//   main.Foo<T, <T, U>>[int, [int, string]]
+					//   ...
+					// There are methods in ast/types that rely on this representation:
+					//   fn symbol_name_except_generic()
+					//   fn embed_name()
+					//   fn strip_extra_struct_types()
 					mut sym_name := sym.name + '<'
 					for i, gt in generic_names {
 						sym_name += gt


### PR DESCRIPTION
There's a real chance of confusion here, and the notes are added to make it easier to read and remember.