### PR TITLE
v2: fix typo in checker.v

### DIFF
--- a/vlib/v2/types/checker.v
+++ b/vlib/v2/types/checker.v
@@ -1765,7 +1765,7 @@ fn (mut c Checker) call_expr(expr ast.CallExpr) Type {
 				c.env.generic_types[lhs_expr.name()] << generic_type_map
 			}
 		} else if lhs_expr is ast.GenericArgs {
-			c.error_with_pos('cannot call non generic fuction with generic argument list',
+			c.error_with_pos('cannot call non generic function with generic argument list',
 				expr.pos)
 		}
 


### PR DESCRIPTION
fuction -> function



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 63e31af</samp>

Fix a typo in a non generic function error message in `vlib/v2/types/checker.v`. This change enhances the user experience of the V compiler.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 63e31af</samp>

* Fix a typo in the error message for non generic function calls with generic arguments ([link](https://github.com/vlang/v/pull/20064/files?diff=unified&w=0#diff-dd0f65f31ef4d2984f56087aa89b4a47655a0955bccce67610f8fe58e1f41f7bL1768-R1768))
