### PR TITLE
checker, cgen: fix the static from_string method of Enum across mods(fix #20050)

### DIFF
--- a/vlib/v/checker/tests/modules/enum_from_string_in_different_mods.out
+++ b/vlib/v/checker/tests/modules/enum_from_string_in_different_mods.out
@@ -1,0 +1,47 @@
+main.v:3:15: error: module `amod` type `MyEnum` is private
+    1 | module main
+    2 |
+    3 | import amod { MyEnum }
+      |               ~~~~~~
+    4 |
+    5 | fn main() {
+main.v:6:6: error: module `amod` type `amod.MyEnum` is private
+    4 |
+    5 | fn main() {
+    6 |     _ = MyEnum.from_string('item1')
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    7 |     _ = amod.MyEnum.from_string('item1')
+    8 |     _ = amod.MyStruct.from_string('item1')
+main.v:6:4: error: assignment mismatch: 1 variable(s) but `MyEnum.from_string()` returns 0 value(s)
+    4 |
+    5 | fn main() {
+    6 |     _ = MyEnum.from_string('item1')
+      |       ^
+    7 |     _ = amod.MyEnum.from_string('item1')
+    8 |     _ = amod.MyStruct.from_string('item1')
+main.v:7:11: error: module `amod` type `amod.MyEnum` is private
+    5 | fn main() {
+    6 |     _ = MyEnum.from_string('item1')
+    7 |     _ = amod.MyEnum.from_string('item1')
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    8 |     _ = amod.MyStruct.from_string('item1')
+    9 | }
+main.v:7:4: error: assignment mismatch: 1 variable(s) but `amod.MyEnum.from_string()` returns 0 value(s)
+    5 | fn main() {
+    6 |     _ = MyEnum.from_string('item1')
+    7 |     _ = amod.MyEnum.from_string('item1')
+      |       ^
+    8 |     _ = amod.MyStruct.from_string('item1')
+    9 | }
+main.v:8:11: error: expected enum, but `amod.MyStruct` is struct
+    6 |     _ = MyEnum.from_string('item1')
+    7 |     _ = amod.MyEnum.from_string('item1')
+    8 |     _ = amod.MyStruct.from_string('item1')
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 | }
+main.v:8:4: error: assignment mismatch: 1 variable(s) but `amod.MyStruct.from_string()` returns 0 value(s)
+    6 |     _ = MyEnum.from_string('item1')
+    7 |     _ = amod.MyEnum.from_string('item1')
+    8 |     _ = amod.MyStruct.from_string('item1')
+      |       ^
+    9 | }

--- a/vlib/v/checker/tests/modules/enum_from_string_in_different_mods/amod/amod.v
+++ b/vlib/v/checker/tests/modules/enum_from_string_in_different_mods/amod/amod.v
@@ -1,0 +1,8 @@
+module amod
+
+enum MyEnum {
+	item1
+	item2
+}
+
+pub struct MyStruct {}

--- a/vlib/v/checker/tests/modules/enum_from_string_in_different_mods/main.v
+++ b/vlib/v/checker/tests/modules/enum_from_string_in_different_mods/main.v
@@ -1,0 +1,9 @@
+module main
+
+import amod { MyEnum }
+
+fn main() {
+	_ = MyEnum.from_string('item1')
+	_ = amod.MyEnum.from_string('item1')
+	_ = amod.MyStruct.from_string('item1')
+}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1150,12 +1150,22 @@ fn should_use_indent_func(kind ast.Kind) bool {
 
 fn (mut g Gen) gen_enum_static_from_string(fn_name string) {
 	enum_name := fn_name.all_before('__static__')
-	mod_enum_name := if !enum_name.contains('.') {
+	mut mod_enum_name := if !enum_name.contains('.') {
 		g.cur_mod.name + '.' + enum_name
 	} else {
 		enum_name
 	}
-	idx := g.table.type_idxs[mod_enum_name]
+	mut idx := g.table.type_idxs[mod_enum_name]
+	if idx == 0 && (enum_name.contains('.') || enum_name[0].is_capital()) {
+		// no cur mod, find from another mods.
+		for import_sym in g.file.imports {
+			mod_enum_name = '${import_sym.mod}.${enum_name}'
+			idx = g.table.type_idxs[mod_enum_name]
+			if idx > 0 {
+				break
+			}
+		}
+	}
 	enum_typ := ast.Type(idx)
 	enum_styp := g.typ(enum_typ)
 	option_enum_typ := ast.Type(idx).set_flag(.option)
@@ -1164,9 +1174,10 @@ fn (mut g Gen) gen_enum_static_from_string(fn_name string) {
 	enum_field_vals := g.table.get_enum_field_vals(mod_enum_name)
 
 	mut fn_builder := strings.new_builder(512)
-	g.definitions.writeln('static ${option_enum_styp} ${fn_name}(string name); // auto')
+	fn_name_no_dots := util.no_dots(fn_name)
+	g.definitions.writeln('static ${option_enum_styp} ${fn_name_no_dots}(string name); // auto')
 
-	fn_builder.writeln('static ${option_enum_styp} ${fn_name}(string name) {')
+	fn_builder.writeln('static ${option_enum_styp} ${fn_name_no_dots}(string name) {')
 	fn_builder.writeln('\t${option_enum_styp} t1;')
 	fn_builder.writeln('\tbool exists = false;')
 	fn_builder.writeln('\tint inx = 0;')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1803,7 +1803,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				g.gen_enum_static_from_string(node.name)
 				g.str_fn_names << node.name
 			}
-			g.write('${node.name}(')
+			g.write('${util.no_dots(node.name)}(')
 			g.call_args(node)
 			g.write(')')
 		} else {

--- a/vlib/v/tests/modules/enum_from_string_in_different_mods/amod/amod.v
+++ b/vlib/v/tests/modules/enum_from_string_in_different_mods/amod/amod.v
@@ -1,0 +1,6 @@
+module amod
+
+pub enum MyEnum {
+	item1
+	item2
+}

--- a/vlib/v/tests/modules/enum_from_string_in_different_mods/main_test.v
+++ b/vlib/v/tests/modules/enum_from_string_in_different_mods/main_test.v
@@ -1,0 +1,10 @@
+module main
+
+import amod { MyEnum }
+
+fn test_main() {
+	item1 := MyEnum.from_string('item1')?
+	assert item1 == MyEnum.item1
+	item2 := amod.MyEnum.from_string('item2')?
+	assert item2 == MyEnum.item2
+}


### PR DESCRIPTION
1. Fixed #20050
2. The whole system is improved, including the handling of error information and so on.
3. Add tests.

