### PR TITLE
checker, cgen: fix comptimecall type resolution on function args

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -113,6 +113,8 @@ mut:
 	comptime_fields_type             map[string]ast.Type
 	comptime_for_field_value         ast.StructField // value of the field variable
 	comptime_enum_field_value        string // current enum value name
+	comptime_for_method              string // $for method in T.methods {}
+	comptime_for_method_var          string // $for method in T.methods {}; the variable name
 	fn_scope                         &ast.Scope = unsafe { nil }
 	main_fn_decl_node                ast.FnDecl
 	match_exhaustive_cutoff_limit    int = 10

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -115,6 +115,7 @@ mut:
 	comptime_enum_field_value        string // current enum value name
 	comptime_for_method              string // $for method in T.methods {}
 	comptime_for_method_var          string // $for method in T.methods {}; the variable name
+	comptime_values_stack            []CurrentComptimeValues // stores the values from the above on each $for loop, to make nesting them easier
 	fn_scope                         &ast.Scope = unsafe { nil }
 	main_fn_decl_node                ast.FnDecl
 	match_exhaustive_cutoff_limit    int = 10

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1565,6 +1565,8 @@ fn (mut c Checker) get_comptime_args(func ast.Fn, node_ ast.CallExpr, concrete_t
 			} else if call_arg.expr is ast.ComptimeSelector
 				&& c.table.is_comptime_var(call_arg.expr) {
 				comptime_args[i] = c.get_comptime_var_type(call_arg.expr)
+			} else if call_arg.expr is ast.ComptimeCall {
+				comptime_args[i] = c.get_comptime_var_type(call_arg.expr)
 			}
 		}
 	}

--- a/vlib/v/checker/tests/comptime_field_selector_not_name_err.out
+++ b/vlib/v/checker/tests/comptime_field_selector_not_name_err.out
@@ -40,3 +40,17 @@ vlib/v/checker/tests/comptime_field_selector_not_name_err.vv:15:12: error: expec
       |               ~~~~
    16 | }
    17 |
+vlib/v/checker/tests/comptime_field_selector_not_name_err.vv:15:10: error: compile time field access can only be used when iterating over `T.fields`
+   13 |         }
+   14 |     }
+   15 |     _ = t.$(f.name)
+      |             ^
+   16 | }
+   17 |
+vlib/v/checker/tests/comptime_field_selector_not_name_err.vv:15:10: error: unknown `$for` variable `f`
+   13 |         }
+   14 |     }
+   15 |     _ = t.$(f.name)
+      |             ^
+   16 | }
+   17 |

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1154,6 +1154,14 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 				if param_typ.nr_muls() > 0 && comptime_args[i].nr_muls() > 0 {
 					comptime_args[i] = comptime_args[i].set_nr_muls(0)
 				}
+			} else if mut call_arg.expr is ast.ComptimeCall {
+				if call_arg.expr.method_name == 'method' {
+					sym := g.table.sym(g.unwrap_generic(call_arg.expr.left_type))
+					// `app.$method()`
+					if m := sym.find_method(g.comptime_for_method) {
+						comptime_args[i] = m.return_type
+					}
+				}
 			}
 		}
 	}

--- a/vlib/v/tests/method_call_resolve_test.v
+++ b/vlib/v/tests/method_call_resolve_test.v
@@ -1,0 +1,46 @@
+struct Human {
+	name string
+}
+
+enum Animal {
+	dog
+	cat
+}
+
+type Entity = Animal | Human
+
+@[sumtype_to: Animal]
+fn (ent Entity) json_cast_to_animal() Animal {
+	return ent as Animal
+}
+
+@[sumtype_to: Human]
+fn (ent Entity) json_cast_to_human() Human {
+	return ent as Human
+}
+
+fn encode[T](val T) {
+	$if T is $sumtype {
+		$for method in T.methods {
+			if method.attrs.len >= 1 {
+				if method.attrs[0].contains('sumtype_to') {
+					if val.type_name() == method.attrs[0].all_after('sumtype_to:').trim_space() {
+						// println(val.$method())
+						encode(val.$method()) // Problem here !!!!!!!!!!!!!!!!!!!!!!!!!!!!!1!!!!11!
+					}
+				}
+			}
+		}
+	} $else $if T is $struct {
+		assert val == Human{
+			name: 'Monke'
+		}
+	} $else $if T is $enum {
+		assert val == Animal.cat
+	}
+}
+
+fn test_main() {
+	encode(Entity(Human{'Monke'}))
+	encode(Entity(Animal.cat))
+}

--- a/vlib/v/tests/method_call_resolve_test.v
+++ b/vlib/v/tests/method_call_resolve_test.v
@@ -25,8 +25,7 @@ fn encode[T](val T) {
 			if method.attrs.len >= 1 {
 				if method.attrs[0].contains('sumtype_to') {
 					if val.type_name() == method.attrs[0].all_after('sumtype_to:').trim_space() {
-						// println(val.$method())
-						encode(val.$method()) // Problem here !!!!!!!!!!!!!!!!!!!!!!!!!!!!!1!!!!11!
+						encode(val.$method())
 					}
 				}
 			}


### PR DESCRIPTION
Fix #20065

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a5e9582</samp>

This pull request adds comptime features to the V language, allowing method calls and `$for` loops over methods to be evaluated at compile time. It updates the checker and the C generator to handle the new syntax and semantics. It also adds a test file to demonstrate the usage and correctness of the comptime features.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a5e9582</samp>

*  Add support for comptime `$for` loops over methods of a type and resolution of method call expressions in comptime context ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R116-R117), [link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R47-R55), [link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R335-R344), [link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR1568-R1569), [link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9R1157-R1164), [link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-678d30e5db8dee324ec0a45fbc7e27162eaaed81875c1ee009a8ec7c5f510547R1-R46))
  * Modify the `Checker` struct to store the name of the method and the variable name used in the comptime `$for` loop ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R116-R117))
  * Extend the `Checker.comptime_expr_type` method to handle `ComptimeCall` nodes and return the type of the method call ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R47-R55))
  * Extend the `Checker.comptime_for` method to handle `.methods` nodes and iterate over the methods of the type, setting the `comptime_for_method` and `comptime_for_method_var` fields accordingly ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R335-R344))
  * Extend the `Checker.check_call_args` method to handle `ComptimeCall` nodes and add the type of the method call to the `comptime_args` array ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR1568-R1569))
  * Extend the `Gen.gen_call_args` method to handle `ComptimeCall` nodes with `method` name and add the return type of the method to the `comptime_args` array ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9R1157-R1164))
  * Add a test file `method_call_resolve_test.v` to demonstrate the use of comptime `$for` loops over methods and the resolution of method call expressions in comptime context ([link](https://github.com/vlang/v/pull/20070/files?diff=unified&w=0#diff-678d30e5db8dee324ec0a45fbc7e27162eaaed81875c1ee009a8ec7c5f510547R1-R46))
