### PR TITLE
array: remove debugging println on the code

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -608,8 +608,6 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	// println('filter s="$s"')
 	rec_sym := g.table.final_sym(node.receiver_type)
 	if rec_sym.kind != .array {
-		println(node.name)
-		println(g.typ(node.receiver_type))
 		// println(rec_sym.kind)
 		verror('.sort() is an array method')
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dc3c1b4</samp>

Remove leftover debugging prints from C code generator for arrays. This cleans up the `vlib/v/gen/c/array.v` file and avoids unnecessary output.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dc3c1b4</samp>

* Remove debugging print statements from array receiver node generation ([link](https://github.com/vlang/v/pull/20076/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278L611-L612))
