### PR TITLE
array: fix generated code for array.sorted() when using on mutable receiver

### DIFF
--- a/vlib/builtin/array_sort_on_receiver_test.v
+++ b/vlib/builtin/array_sort_on_receiver_test.v
@@ -1,0 +1,14 @@
+type Scores = []int
+
+pub fn (mut scores Scores) top_three() []int {
+	mut result := scores.sorted(b < a)
+	result.trim(3)
+	return result
+}
+
+fn test_main() {
+	a := Scores([3, 2, 1])
+	b := a.sorted()
+	assert dump(a) == [3, 2, 1]
+	assert dump(b) == [1, 2, 3]
+}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -710,7 +710,8 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 }
 
 fn (mut g Gen) gen_array_sort_call(node ast.CallExpr, compare_fn string) {
-	mut deref_field := g.dot_or_ptr(node.left_type)
+	// array.sorted uses a temporary variable (no pointer in use)
+	mut deref_field := if node.name == 'sorted' { '.' } else { g.dot_or_ptr(node.left_type) }
 	// eprintln('> qsort: pointer $node.left_type | deref_field: `$deref_field`')
 	g.empty_line = true
 	g.write('qsort(')

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -711,7 +711,7 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 
 fn (mut g Gen) gen_array_sort_call(node ast.CallExpr, compare_fn string) {
 	// array.sorted uses a temporary variable (no pointer in use)
-	mut deref_field := if node.name == 'sorted' { '.' } else { g.dot_or_ptr(node.left_type) }
+	deref_field := if node.name == 'sorted' { '.' } else { g.dot_or_ptr(node.left_type) }
 	// eprintln('> qsort: pointer $node.left_type | deref_field: `$deref_field`')
 	g.empty_line = true
 	g.write('qsort(')


### PR DESCRIPTION
Fix #20075

@shove70 sorry, I just noticed you were assigned it to you after fixing... Feel free to provide a better fix if desired.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fb279b6</samp>

This pull request adds a test for the `sorted` method on custom array types and fixes a code generation bug that caused a segmentation fault when using `sorted` on such types. The bug fix involves changing the syntax for accessing array fields in the generated C code.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fb279b6</samp>

* Fix a bug that caused a segmentation fault when calling `sorted` on a custom array type by using a dot instead of a pointer to access the array fields in the generated C code ([link](https://github.com/vlang/v/pull/20077/files?diff=unified&w=0#diff-1526c24366454b1cdc2d4471526b00889997ca0ce9cc2ca5ffefc4585ac73278L713-R714))
* Add a new test file `vlib/builtin/array_sort_on_receiver_test.v` that defines a custom type `Scores` as an alias for `[]int` and a method `top_three` that returns the three highest scores in a sorted copy of the array ([link](https://github.com/vlang/v/pull/20077/files?diff=unified&w=0#diff-cb3d7123bb78629c8d8b834488cbd365fc00c0d5ab28454772abeb7db91c9076R1-R14))
* Check that the original array is not modified by the `sorted` method and that the `sorted` method returns a new sorted array in the test file ([link](https://github.com/vlang/v/pull/20077/files?diff=unified&w=0#diff-cb3d7123bb78629c8d8b834488cbd365fc00c0d5ab28454772abeb7db91c9076R1-R14))
