### PR TITLE
cgen: fix array auto cloning

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1548,7 +1548,28 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 				}
 				g.write(')')
 			} else {
-				g.expr(node.left)
+				if node.left.is_gated {
+					g.write('array_slice_ni(')
+				} else {
+					g.write('array_slice(')
+				}
+				if node.left.left.is_auto_deref_var() {
+					g.write('*')
+				}
+				g.expr(node.left.left)
+				g.write(', ')
+				if range_expr.has_low {
+					g.expr(range_expr.low)
+				} else {
+					g.write('0')
+				}
+				g.write(', ')
+				if range_expr.has_high {
+					g.expr(range_expr.high)
+				} else {
+					g.write('2147483647') // max_int
+				}
+				g.write(')')
 			}
 		} else {
 			g.expr(node.left)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1531,7 +1531,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 
 				if arr_sym.kind == .array_fixed {
 					arr_info := arr_sym.array_fixed_info()
-					g.write('new_array_from_c_array_no_alloc(${arr_info.size}, 0, sizeof(${g.typ(arr_info.elem_type)}), ')
+					g.write('new_array_from_c_array_no_alloc(${arr_info.size}, ${arr_info.size}, sizeof(${g.typ(arr_info.elem_type)}), ')
 					g.expr(node.left.left)
 					g.write(')')
 				} else {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1524,53 +1524,6 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 				g.expr(node.left)
 				g.write(')')
 			}
-		} else if is_range_slice && node.left is ast.IndexExpr && node.left.index is ast.RangeExpr {
-			arr_type := g.unwrap_generic(node.left.left_type)
-			arr_sym := g.table.final_sym(arr_type)
-			range_expr := node.left.index as ast.RangeExpr
-
-			if arr_sym.kind == .array_fixed {
-				arr_info := arr_sym.array_fixed_info()
-				g.write('array_slice(new_array_from_c_array(${arr_info.size}, ${arr_info.size}, sizeof(${g.typ(arr_info.elem_type)}), ')
-				g.expr(node.left.left)
-				g.write(')')
-				g.write(', ')
-				if range_expr.has_low {
-					g.expr(range_expr.low)
-				} else {
-					g.write('0')
-				}
-				g.write(', ')
-				if range_expr.has_high {
-					g.expr(range_expr.high)
-				} else {
-					g.write('${arr_info.size}')
-				}
-				g.write(')')
-			} else {
-				if node.left.is_gated {
-					g.write('array_slice_ni(')
-				} else {
-					g.write('array_slice(')
-				}
-				if node.left.left.is_auto_deref_var() {
-					g.write('*')
-				}
-				g.expr(node.left.left)
-				g.write(', ')
-				if range_expr.has_low {
-					g.expr(range_expr.low)
-				} else {
-					g.write('0')
-				}
-				g.write(', ')
-				if range_expr.has_high {
-					g.expr(range_expr.high)
-				} else {
-					g.write('2147483647') // max_int
-				}
-				g.write(')')
-			}
 		} else {
 			g.expr(node.left)
 		}

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -65,11 +65,10 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 }
 
 fn (mut g Gen) index_range_expr(node ast.IndexExpr, range ast.RangeExpr) {
-	sym := g.table.final_sym(node.left_type)
+	sym := g.table.final_sym(g.unwrap_generic(node.left_type))
 	mut tmp_opt := ''
 	mut cur_line := ''
 	mut gen_or := node.or_expr.kind != .absent || node.is_option
-
 	if sym.kind == .string {
 		if node.is_gated {
 			g.write('string_substr_ni(')

--- a/vlib/v/tests/array_fixed_auto_clone_test.v
+++ b/vlib/v/tests/array_fixed_auto_clone_test.v
@@ -4,12 +4,15 @@ fn test_main() {
 }
 
 fn name[T](mut buf4 T) {
-	for idx in 0 .. 100 {
-		buf4[idx] = idx
-	}
+	mut bp := buf4[0..5]
+	assert bp.len == 5
+	println(bp)
 
-	mut bp := buf4[1..99]
-
-	println(bp.bytestr())
+	bp = buf4[..]
 	assert bp.len == 100
+	println(bp)
+
+	bp = buf4[4..]
+	assert bp.len == 96
+	println(bp)
 }

--- a/vlib/v/tests/array_fixed_auto_clone_test.v
+++ b/vlib/v/tests/array_fixed_auto_clone_test.v
@@ -1,9 +1,19 @@
 fn test_main() {
-	mut buf4 := [100]u8{}
-	name(mut buf4)
+	mut buf := [100]u8{}
+	name(mut buf)
+
+	mut buf2 := []u8{}
+	name(mut buf2)
 }
 
 fn name[T](mut buf4 T) {
+	for idx in 0 .. 100 {
+		$if T is $array_fixed {
+			buf4[idx] = idx
+		} $else $if T is $array {
+			buf4 << idx
+		}
+	}
 	mut bp := buf4[0..5]
 	assert bp.len == 5
 	println(bp)
@@ -14,5 +24,9 @@ fn name[T](mut buf4 T) {
 
 	bp = buf4[4..]
 	assert bp.len == 96
+	println(bp)
+
+	bp = buf4[1..99]
+	assert bp.len == 98
 	println(bp)
 }

--- a/vlib/v/tests/array_fixed_auto_clone_test.v
+++ b/vlib/v/tests/array_fixed_auto_clone_test.v
@@ -1,0 +1,15 @@
+fn test_main() {
+	mut buf4 := [100]u8{}
+	name(mut buf4)
+}
+
+fn name[T](mut buf4 T) {
+	for idx in 0 .. 100 {
+		buf4[idx] = idx
+	}
+
+	mut bp := buf4[1..99]
+
+	println(bp.bytestr())
+	assert bp.len == 100
+}


### PR DESCRIPTION
Fix #20071

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2142430</samp>

Implement range slices for fixed arrays in the C backend. Use `new_array_from_c_array_no_alloc` to create V arrays from C arrays without copying.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2142430</samp>

* Implement range slices for fixed arrays, strings, and maps in V ([link](https://github.com/vlang/v/pull/20078/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L1528-R1542),                      
