### PR TITLE
cgen: fix sort, sorted event calls when array aliases are used as receivers(fix #20075)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1649,7 +1649,7 @@ fn (mut c Checker) cast_to_fixed_array_ret(typ ast.Type, sym ast.TypeSymbol) ast
 	return typ
 }
 
-// checks if a type from another module is is expected and visible(`is_pub`)
+// checks if a type from another module is as expected and visible(`is_pub`)
 fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
 	mut sym := c.table.sym_by_idx(type_idx)
 	if sym.kind == .alias {

--- a/vlib/v/tests/array_methods_test.v
+++ b/vlib/v/tests/array_methods_test.v
@@ -73,3 +73,15 @@ fn test_string_eq_method_with_interface() {
 	}
 	assert false
 }
+
+// test deref when alias as receiver of methods
+type Array = []int
+
+pub fn (mut arr Array) alias_as_receiver_deref() []int {
+	return arr.sorted(b < a)
+}
+
+fn test_alias_as_receiver_deref() {
+	mut arr := Array([1, 2, 3])
+	assert arr.alias_as_receiver_deref() == [3, 2, 1]
+}


### PR DESCRIPTION
1. Fixed #20075 
2. Add tests.

```v
type Array = []int

pub fn (mut arr Array) alias_as_receiver_deref() []int {
	return arr.sorted(b < a)
}

fn main() {
	mut arr := Array([1, 2, 3])
	println(arr.alias_as_receiver_deref())
	mut arr2 := &arr
	println(arr2.alias_as_receiver_deref())
}
```
outputs:
```
[3, 2, 1]
[3, 2, 1]
```