### PR TITLE
vweb: add optional parameter to redirect function to set http code

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -310,7 +310,7 @@ pub fn (mut ctx Context) server_error(ecode int) Result {
 
 @[params]
 pub struct RedirectParams {
-	status_code int = 302 
+	status_code int = 302
 }
 
 // Redirect to an url


### PR DESCRIPTION
The vweb redirect function defaults to the 302 http code, which retains the http verb used in the request. Redirecting after reaching endpoints with verbs like DELETE will result in attempting to reach the redirected endpoint with DELETE, which may not always be desired. 

This PR adds an optional parameter to the redirect function, to allow the 303 http code to be used instead, which will redirect with GET instead of the original http verb. 


<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a27ae8b</samp>

Enhance `vweb.redirect` to support various HTTP redirection types. Add `http.303` constant.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a27ae8b</samp>

* Add a constant and a struct for handling different types of HTTP redirections ([link](https://github.com/vlang/v/pull/20082/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R36-R40), [link](https://github.com/vlang/v/pull/20082/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80L306-R317))
* Implement the logic for 303 See Other redirection ([link](https://github.com/vlang/v/pull/20082/files?diff=unified&w=0#diff-694cdbe16b700f23ab1ec25807adbb3864af7d46788aa84b10f725eb9a401c80R323-R325))
