### PR TITLE
cgen: fix map comptime var type resolution on generic arg

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1073,9 +1073,21 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 						mut ctyp := g.get_comptime_var_type(call_arg.expr)
 						if ctyp != ast.void_type {
 							arg_sym := g.table.sym(ctyp)
-							if arg_sym.kind == .array && param_typ.has_flag(.generic)
-								&& g.table.final_sym(param_typ).kind == .array {
-								ctyp = (arg_sym.info as ast.Array).elem_type
+							param_sym := g.table.final_sym(param_typ)
+							if arg_sym.info is ast.Array && param_sym.kind == .array {
+								ctyp = arg_sym.info.elem_type
+							} else if arg_sym.info is ast.Map && param_sym.info is ast.Map {
+								if call_arg.expr.obj.ct_type_var == .value_var {
+									ctyp = arg_sym.info.value_type
+									if param_sym.info.value_type.nr_muls() > 0 && ctyp.nr_muls() > 0 {
+										ctyp = ctyp.set_nr_muls(0)
+									}
+								} else if call_arg.expr.obj.ct_type_var == .key_var {
+									ctyp = arg_sym.info.key_type
+									if param_sym.info.key_type.nr_muls() > 0 && ctyp.nr_muls() > 0 {
+										ctyp = ctyp.set_nr_muls(0)
+									}
+								}
 							}
 							comptime_args[i] = ctyp
 						}
@@ -1113,9 +1125,9 @@ fn (mut g Gen) change_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concret
 									}
 								}
 							} else if arg_sym.kind == .any {
-								mut cparam_type_sym := g.table.sym(g.unwrap_generic(ctyp))
-								if param_typ_sym.kind == .array && cparam_type_sym.kind == .array {
-									ctyp = (cparam_type_sym.info as ast.Array).elem_type
+								cparam_type_sym := g.table.sym(g.unwrap_generic(ctyp))
+								if param_typ_sym.kind == .array && cparam_type_sym.info is ast.Array {
+									ctyp = cparam_type_sym.info.elem_type
 									comptime_args[i] = ctyp
 								} else {
 									if node_.args[i].expr.is_auto_deref_var() {

--- a/vlib/v/tests/comptime_for_map_arg_test.v
+++ b/vlib/v/tests/comptime_for_map_arg_test.v
@@ -1,0 +1,33 @@
+fn merged[K, V](a map[K]V, b map[K]V) map[K]V {
+	mut o := a.clone()
+	for k, v in b {
+		$if V is $map {
+			o[k] = merged(o[k], v)
+		} $else {
+			o[k] = v
+		}
+	}
+	return o
+}
+
+fn test_main() {
+	a := {
+		'aa': {
+			'11': 1
+		}
+	}
+	b := {
+		'bb': {
+			'22': 2
+		}
+	}
+	c := merged(a, b)
+	assert c == {
+		'aa': {
+			'11': 1
+		}
+		'bb': {
+			'22': 2
+		}
+	}
+}


### PR DESCRIPTION
Fix #20037

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at de6fa1e</samp>

This pull request improves the support for comptime map arguments in generic functions and adds a test for it. It affects the C code generation module `vlib/v/gen/c/fn.v` and the test file `vlib/v/tests/comptime_for_map_arg_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at de6fa1e</samp>

*  Add support for comptime map arguments in generic functions ([link](https://github.com/vlang/v/pull/20085/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L1076-R1090))
* Simplify code by removing unnecessary `mut` modifier and using `is` operator ([link](https://github.com/vlang/v/pull/20085/files?diff=unified&w=0#diff-b49ab365e3d3ba4d77137d0f2abd7714e1a64318f07ee789912782444ab81cf9L1116-R1130))
* Add test case for comptime map arguments feature in `vlib/v/tests/comptime_for_map_arg_test.v` ([link](https://github.com/vlang/v/pull/20085/files?diff=unified&w=0#diff-965c7406588af77d89e3a7fd16790ced5ad7f8938182d429d290d1bd4d2b9436R1-R33))
