### PR TITLE
tools.vpm: update vcs handling

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -216,10 +216,6 @@ fn get_path_of_existing_module(mod_name string) ?string {
 		vpm_error('skipping `${path}`, since it is not a directory.')
 		return none
 	}
-	vcs_used_in_dir(path) or {
-		vpm_error('skipping `${path}`, since it uses an unsupported version control system.')
-		return none
-	}
 	return path
 }
 

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -252,12 +252,6 @@ fn ensure_vmodules_dir_exist() {
 	}
 }
 
-fn (vcs &VCS) is_executable() ! {
-	os.find_abs_path_of_executable(vcs.cmd) or {
-		return error('VPM needs `${vcs.cmd}` to be installed.')
-	}
-}
-
 fn increment_module_download_count(name string) ! {
 	if settings.no_dl_count_increment {
 		println('Skipping download count increment for `${name}`.')
@@ -294,15 +288,6 @@ fn resolve_dependencies(manifest ?vmod.Manifest, modules []string) {
 		verbose_println('Found dependencies: ${deps}')
 		vpm_install(deps)
 	}
-}
-
-fn vcs_used_in_dir(dir string) ?VCS {
-	for vcs in supported_vcs.values() {
-		if os.is_dir(os.real_path(os.join_path(dir, vcs.dir))) {
-			return vcs
-		}
-	}
-	return none
 }
 
 fn verbose_println(msg string) {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -121,8 +121,9 @@ fn (m Module) install() InstallResult {
 		}
 	}
 	vcs := m.vcs or { settings.vcs }
-	version_opt := if m.version != '' { ' ${vcs.args.version} ${m.version}' } else { '' }
-	cmd := '${vcs.cmd} ${vcs.args.install}${version_opt} "${m.url}" "${m.install_path}"'
+	args := vcs_info[vcs].args
+	version_opt := if m.version != '' { '${args.version} ${m.version}' } else { '' }
+	cmd := [vcs.str(), args.install, version_opt, m.url, os.quoted_path(m.install_path)].join(' ')
 	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
 	println('Installing `${m.name}`...')
 	verbose_println('  cloning from `${m.url}` to `${m.install_path_fmted}`')

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -28,7 +28,7 @@ mut:
 
 fn parse_query(query []string) []Module {
 	mut p := Parser{
-		is_git_setting: settings.vcs.cmd == 'git'
+		is_git_setting: settings.vcs == .git
 	}
 	for m in query {
 		p.parse_module(m)
@@ -96,12 +96,12 @@ fn (mut p Parser) parse_module(m string) {
 		// Verify VCS.
 		mut is_git_module := true
 		vcs := if info.vcs != '' {
-			info_vcs := supported_vcs[info.vcs] or {
+			info_vcs := vcs_from_str(info.vcs) or {
 				vpm_error('skipping `${info.name}`, since it uses an unsupported version control system `${info.vcs}`.')
 				p.errors++
 				return
 			}
-			is_git_module = info.vcs == 'git'
+			is_git_module = info_vcs == .git
 			if !is_git_module && version != '' {
 				vpm_error('skipping `${info.name}`, version installs are currently only supported for projects using `git`.')
 				p.errors++
@@ -109,7 +109,7 @@ fn (mut p Parser) parse_module(m string) {
 			}
 			info_vcs
 		} else {
-			supported_vcs['git']
+			VCS.git
 		}
 		vcs.is_executable() or {
 			vpm_error(err.msg())

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -35,7 +35,7 @@ fn init_settings() VpmSettings {
 		is_verbose: '-v' in opts || '--verbose' in opts
 		is_force: '-f' in opts || '--force' in opts
 		server_urls: cmdline.options(args, '--server-urls')
-		vcs: supported_vcs[if '--hg' in opts { 'hg' } else { 'git' }]
+		vcs: if '--hg' in opts { .hg } else { .git }
 		vmodules_path: os.vmodules_dir()
 		no_dl_count_increment: os.getenv('CI') != '' || (no_inc_env != '' && no_inc_env != '0')
 		fail_on_prompt: os.getenv('VPM_FAIL_ON_PROMPT') != ''

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -54,7 +54,8 @@ fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &UpdateResult {
 		vpm_error(err.msg())
 		return &UpdateResult{}
 	}
-	cmd := '${vcs.cmd} ${vcs.args.path} "${install_path}" ${vcs.args.update}'
+	args := vcs_info[vcs].args
+	cmd := [vcs.str(), args.path, os.quoted_path(install_path), args.update].join(' ')
 	vpm_log(@FILE_LINE, @FN, 'cmd: ${cmd}')
 	println('Updating module `${name}` in `${fmt_mod_path(install_path)}`...')
 	res := os.execute_opt(cmd) or {

--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -1,0 +1,55 @@
+module main
+
+import os
+
+struct VCS {
+	cmd  string        @[required]
+	dir  string        @[required]
+	args struct {
+		install  string   @[required]
+		version  string   @[required] // flag to specify a version, added to install.
+		path     string   @[required] // flag to specify a path. E.g., used to explicitly work on a path during multithreaded updating.
+		update   string   @[required]
+		outdated []string @[required]
+	}
+}
+
+const supported_vcs = {
+	'git': VCS{
+		cmd: 'git'
+		dir: '.git'
+		args: struct {
+			install: 'clone --depth=1 --recursive --shallow-submodules'
+			version: '--single-branch -b'
+			update: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts when the upstream has more than 1 new commits.
+			path: '-C'
+			outdated: ['fetch', 'rev-parse @', 'rev-parse @{u}']
+		}
+	}
+	'hg':  VCS{
+		cmd: 'hg'
+		dir: '.hg'
+		args: struct {
+			install: 'clone'
+			version: '' // not supported yet.
+			update: 'pull --update'
+			path: '-R'
+			outdated: ['incoming']
+		}
+	}
+}
+
+fn (vcs &VCS) is_executable() ! {
+	os.find_abs_path_of_executable(vcs.cmd) or {
+		return error('VPM needs `${vcs.cmd}` to be installed.')
+	}
+}
+
+fn vcs_used_in_dir(dir string) ?VCS {
+	for vcs in supported_vcs.values() {
+		if os.is_dir(os.real_path(os.join_path(dir, vcs.dir))) {
+			return vcs
+		}
+	}
+	return none
+}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -9,48 +9,12 @@ import rand
 import v.help
 import v.vmod
 
-struct VCS {
-	dir  string        @[required]
-	cmd  string        @[required]
-	args struct {
-		install  string   @[required]
-		version  string   @[required] // flag to specify a version, added to install.
-		path     string   @[required] // flag to specify a path. E.g., used to explicitly work on a path during multithreaded updating.
-		update   string   @[required]
-		outdated []string @[required]
-	}
-}
-
 const settings = init_settings()
 const default_vpm_server_urls = ['https://vpm.vlang.io', 'https://vpm.url4e.com']
 const vpm_server_urls = rand.shuffle_clone(default_vpm_server_urls) or { [] } // ensure that all queries are distributed fairly
 const valid_vpm_commands = ['help', 'search', 'install', 'update', 'upgrade', 'outdated', 'list',
 	'remove', 'show']
 const excluded_dirs = ['cache', 'vlib']
-const supported_vcs = {
-	'git': VCS{
-		dir: '.git'
-		cmd: 'git'
-		args: struct {
-			install: 'clone --depth=1 --recursive --shallow-submodules'
-			version: '--single-branch -b'
-			update: 'pull --recurse-submodules' // pulling with `--depth=1` leads to conflicts when the upstream has more than 1 new commits.
-			path: '-C'
-			outdated: ['fetch', 'rev-parse @', 'rev-parse @{u}']
-		}
-	}
-	'hg':  VCS{
-		dir: '.hg'
-		cmd: 'hg'
-		args: struct {
-			install: 'clone'
-			version: '' // not supported yet.
-			update: 'pull --update'
-			path: '-R'
-			outdated: ['incoming']
-		}
-	}
-}
 
 fn main() {
 	// This tool is intended to be launched by the v frontend,


### PR DESCRIPTION
The changes of the PR, split into commits:
- Extract VCS related into `vcs.v`.
- Update VCS handling, add an enum `VCS` which is used as key for the `VCSInfo` map (before VCS) to simplify (e.g., just use the enum where necessary) and make more robust.
- Remove a VCS related function call that is not needed in `get_path_of_existing_module`.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e24db4</samp>

Refactor the code for handling version control systems in `vpm` and `vcs` modules. Use a `VCS` enum and a `vcs_info` map to simplify and unify the code. Move some functions to the `vcs` module and create reusable functions for installing and updating modules.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e24db4</samp>

*  Refactor the code to use the `VCS` enum and the `vcs_info` map instead of the `VCS` struct and the `supported_vcs` map for simplifying and avoiding repetition ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L42-R45), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL124-R126), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebL31-R31), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebL99-R104), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebL112-R112), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-42d222c576ba1a16697ef291c65b47849fa61a72305646b38c820241aeddff6aL38-R38), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L57-R58), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L12-L23), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-797957645f452cc5fbf29e1664588dacadaac83c3f4a5960896d25a5b210f545L30-L53))
* Move the `vcs` related functions and data to the `vcs.v` file for better organization and modularity ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L255-L260), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L299-L307), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-cfbe87b69041dcec9fb31af1989cfccc29c105636a021bec5759b451df5f54d0R1-R67))
* Replace the `is_hg` variable with the `vcs` enum value for readability and consistency ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L53-R53), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L59-R59))
* Add a condition to check if the vcs is `git` before comparing the outputs ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L59-R59))
* Remove the redundant call to `vcs_used_in_dir` since the `vcs` value is already obtained from the `Module` struct ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L220-L223))
* Move the code from the `install.v` and `update.v` files to the `common.v` file as functions named `install_module` and `update_module` that can be reused by other commands ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL124-R126), [link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-123d74052b240384d4fa168b07caef9a6b3d8069cc8de4932d6f3d9a51e685d9L57-R58))
* Handle the case where the `vcs_from_str` function returns `none` and report an error ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-694025ec50016544e9411cab6d33d3cd29492b80a29d1e94cba716c415cc28ebL99-R104))
* Use the `os.quoted_path` function to handle paths with spaces ([link](https://github.com/vlang/v/pull/20090/files?diff=unified&w=0#diff-71fc09895a23d4ace0c80364a53fa55b2e9ed8b555087e21efac860c559c6c55L42-R45))
