### PR TITLE
checker: fix comptimecall type resolution on checker phase and method.return_type comptime checking and assignment from option comptimecall

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -112,9 +112,10 @@ mut:
 	comptime_fields_default_type     ast.Type
 	comptime_fields_type             map[string]ast.Type
 	comptime_for_field_value         ast.StructField // value of the field variable
-	comptime_enum_field_value        string // current enum value name
-	comptime_for_method              string // $for method in T.methods {}
-	comptime_for_method_var          string // $for method in T.methods {}; the variable name
+	comptime_enum_field_value        string   // current enum value name
+	comptime_for_method              string   // $for method in T.methods {}
+	comptime_for_method_var          string   // $for method in T.methods {}; the variable name
+	comptime_for_method_ret_type     ast.Type // $for method - current method.return_type field
 	comptime_values_stack            []CurrentComptimeValues // stores the values from the above on each $for loop, to make nesting them easier
 	fn_scope                         &ast.Scope = unsafe { nil }
 	main_fn_decl_node                ast.FnDecl

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -164,8 +164,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 			node.args[i].typ = c.expr(mut arg.expr)
 		}
 		c.stmts_ending_with_expression(mut node.or_block.stmts)
-		// assume string for now
-		return ast.string_type
+		return c.get_comptime_var_type(node)
 	}
 	if node.method_name == 'res' {
 		if !c.inside_defer {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -343,6 +343,7 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 		for method in methods {
 			c.comptime_for_method = method.name
 			c.comptime_for_method_var = node.val_var
+			c.comptime_for_method_ret_type = method.return_type
 			c.stmts(mut node.stmts)
 		}
 		c.pop_existing_comptime_values()
@@ -1068,6 +1069,7 @@ struct CurrentComptimeValues {
 	comptime_enum_field_value    string
 	comptime_for_method          string
 	comptime_for_method_var      string
+	comptime_for_method_ret_type ast.Type
 }
 
 fn (mut c Checker) push_existing_comptime_values() {
@@ -1080,6 +1082,7 @@ fn (mut c Checker) push_existing_comptime_values() {
 		comptime_enum_field_value: c.comptime_enum_field_value
 		comptime_for_method: c.comptime_for_method
 		comptime_for_method_var: c.comptime_for_method_var
+		comptime_for_method_ret_type: c.comptime_for_method_ret_type
 	}
 }
 
@@ -1093,4 +1096,5 @@ fn (mut c Checker) pop_existing_comptime_values() {
 	c.comptime_enum_field_value = old.comptime_enum_field_value
 	c.comptime_for_method = old.comptime_for_method
 	c.comptime_for_method_var = old.comptime_for_method_var
+	c.comptime_for_method_ret_type = old.comptime_for_method_ret_type
 }

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -344,6 +344,7 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 			c.comptime_for_method = method.name
 			c.comptime_for_method_var = node.val_var
 			c.comptime_for_method_ret_type = method.return_type
+			c.comptime_fields_type['${node.val_var}.return_type'] = method.return_type
 			c.stmts(mut node.stmts)
 		}
 		c.pop_existing_comptime_values()

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -231,27 +231,52 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						}
 					} else if branch.cond.op in [.eq, .ne] && left is ast.SelectorExpr
 						&& right is ast.StringLiteral {
-						if left.expr.str() == c.comptime_for_field_var {
-							if left.field_name == 'name' {
-								is_comptime_type_is_expr = true
-								match branch.cond.op {
-									.eq {
-										skip_state = if c.comptime_for_field_value.name == right.val.str() {
-											ComptimeBranchSkipState.eval
-										} else {
-											ComptimeBranchSkipState.skip
+						match left.expr.str() {
+							c.comptime_for_field_var {
+								if left.field_name == 'name' {
+									is_comptime_type_is_expr = true
+									match branch.cond.op {
+										.eq {
+											skip_state = if c.comptime_for_field_value.name == right.val.str() {
+												ComptimeBranchSkipState.eval
+											} else {
+												ComptimeBranchSkipState.skip
+											}
 										}
-									}
-									.ne {
-										skip_state = if c.comptime_for_field_value.name == right.val.str() {
-											ComptimeBranchSkipState.skip
-										} else {
-											ComptimeBranchSkipState.eval
+										.ne {
+											skip_state = if c.comptime_for_field_value.name == right.val.str() {
+												ComptimeBranchSkipState.skip
+											} else {
+												ComptimeBranchSkipState.eval
+											}
 										}
+										else {}
 									}
-									else {}
 								}
 							}
+							c.comptime_for_method_var {
+								if left.field_name == 'name' {
+									is_comptime_type_is_expr = true
+									match branch.cond.op {
+										.eq {
+											skip_state = if c.comptime_for_method == right.val.str() {
+												ComptimeBranchSkipState.eval
+											} else {
+												ComptimeBranchSkipState.skip
+											}
+										}
+										.ne {
+											skip_state = if c.comptime_for_method == right.val.str() {
+												ComptimeBranchSkipState.skip
+											} else {
+												ComptimeBranchSkipState.eval
+											}
+										}
+										else {}
+									}
+								}
+							}
+							else {}
 						}
 					}
 				}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -155,6 +155,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 								} else {
 									.skip
 								}
+							} else if comptime_field_name == c.comptime_for_method_var {
+								if left.field_name == 'return_type' {
+									skip_state = c.check_compatible_types(c.unwrap_generic(c.comptime_for_method_ret_type),
+										right as ast.TypeNode)
+								}
 							}
 						} else if left is ast.TypeNode {
 							is_comptime_type_is_expr = true
@@ -326,7 +331,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				node.branches[i].stmts = []
 			}
 			if comptime_field_name.len > 0 {
-				c.comptime_fields_type[comptime_field_name] = c.comptime_fields_default_type
+				if comptime_field_name == c.comptime_for_method_var {
+					c.comptime_fields_type[comptime_field_name] = c.comptime_for_method_ret_type
+				} else {
+					c.comptime_fields_type[comptime_field_name] = c.comptime_fields_default_type
+				}
 			}
 			c.skip_flags = cur_skip_flags
 			if c.fn_level == 0 && c.pref.output_cross_c && c.ct_cond_stack.len > 0 {

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -79,7 +79,7 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				c.error('cannot return `none` in unsafe block', expr.expr.pos)
 			}
 		}
-		if typ == ast.void_type && expr !is ast.ComptimeCall {
+		if typ == ast.void_type {
 			c.error('`${expr}` used as value', node.pos)
 			return
 		}

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -79,7 +79,7 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				c.error('cannot return `none` in unsafe block', expr.expr.pos)
 			}
 		}
-		if typ == ast.void_type {
+		if typ == ast.void_type && expr !is ast.ComptimeCall {
 			c.error('`${expr}` used as value', node.pos)
 			return
 		}

--- a/vlib/v/checker/tests/comptime_call_method_void_err.out
+++ b/vlib/v/checker/tests/comptime_call_method_void_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/comptime_call_method_void_err.vv:17:20: cgen error: method `sample1()` (no value) used as value
+vlib/v/checker/tests/comptime_call_method_void_err.vv:17:4: error: `println` can not print void expressions
    15 |     $for method in Dummy.methods {
    16 |         if os.args.len >= 1 {
    17 |             println(Dummy{}.$method(os.args[0]))
-      |                             ~~~~~~~~~~~~~~~~~~~
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    18 |         }
    19 |     }

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -875,9 +875,9 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 			styp := g.table.find_type_idx(sig)
 
 			// TODO: type aliases
-			ret_typ := method.return_type.idx()
+			ret_typ := method.return_type
 			g.writeln('\t${node.val_var}.typ = ${styp};')
-			g.writeln('\t${node.val_var}.return_type = ${ret_typ};')
+			g.writeln('\t${node.val_var}.return_type = ${ret_typ.idx()};')
 
 			g.comptime_var_type_map['${node.val_var}.return_type'] = ret_typ
 			g.comptime_var_type_map['${node.val_var}.typ'] = styp

--- a/vlib/v/gen/c/testdata/comptime_option_call.out
+++ b/vlib/v/gen/c/testdata/comptime_option_call.out
@@ -6,5 +6,5 @@ Option(none)
 Option(none)
 1
 1
-println(NIL)
+Option('')
 Option(none)

--- a/vlib/v/tests/comptime_method_test.v
+++ b/vlib/v/tests/comptime_method_test.v
@@ -1,0 +1,85 @@
+struct Test {}
+
+struct Test2 {}
+
+fn (t Test) t_0() ?int {
+	return none
+}
+
+fn (t Test) t_1() int {
+	return 0
+}
+
+fn (t Test) t_2() bool {
+	return true
+}
+
+fn (t Test) t_3() Test {
+	return t
+}
+
+fn test_main() {
+	t := Test{}
+	assert t_bool(t, 't_2')? == true
+	assert t_int(t, 't_1')? == 0
+	t_struct(t, 't_3')
+}
+
+fn t_bool[T](val T, method_name string) ?bool {
+	$for f in T.methods {
+		if method_name == f.name {
+			$if f.return_type is bool {
+				return val.$method()
+			}
+			$if f.return_type is int {
+				val.$method()
+			}
+		}
+	}
+	return none
+}
+
+fn t_int[T](val T, method_name string) ?int {
+	$for f in T.methods {
+		if method_name == f.name {
+			$if f.return_type is bool {
+				val.$method()
+			}
+			$if f.return_type is int {
+				return val.$method()
+			}
+		}
+	}
+	return none
+}
+
+fn t_struct[T](val T, method_name string) {
+	mut s := map[string]string{}
+
+	$for f in T.methods {
+		$if f.return_type is Test2 {
+			b := s[f.name] or {
+				println('z')
+				''
+			}
+			dump(b)
+		}
+		$if f.return_type is Test {
+			c := val.$method() or { Test{} }
+			dump(c)
+
+			s[f.name] = f.name
+			dump(s)
+			assert f.name == 't_3'
+			assert s[f.name] == 't_3'
+
+			b := s[f.name] or {
+				println('z')
+				''
+			}
+			dump(b)
+			return
+		}
+	}
+	assert false
+}

--- a/vlib/v/tests/method_call_resolve_test.v
+++ b/vlib/v/tests/method_call_resolve_test.v
@@ -7,6 +7,8 @@ enum Animal {
 	cat
 }
 
+struct Encoder {}
+
 type Entity = Animal | Human
 
 @[sumtype_to: Animal]
@@ -39,7 +41,34 @@ fn encode[T](val T) {
 	}
 }
 
-fn test_main() {
+fn test_func() {
 	encode(Entity(Human{'Monke'}))
 	encode(Entity(Animal.cat))
+}
+
+fn (e &Encoder) encode[T](val T) {
+	$if T is $sumtype {
+		$for method in T.methods {
+			if method.attrs.len >= 1 {
+				if method.attrs[0].contains('sumtype_to') {
+					if val.type_name() == method.attrs[0].all_after('sumtype_to:').trim_space() {
+						println(val.$method())
+						e.encode(val.$method())
+					}
+				}
+			}
+		}
+	} $else $if T is $struct {
+		assert val == Human{
+			name: 'Monke'
+		}
+	} $else $if T is $enum {
+		assert val == Animal.cat
+	}
+}
+
+fn test_method() {
+	e := Encoder{}
+	e.encode(Entity(Human{'Monke'}))
+	e.encode(Entity(Animal.cat))
 }


### PR DESCRIPTION
Fix #20091
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a87b85</samp>

This pull request improves the comptime features of V, especially the handling of comptime methods and variables with different types. It adds a new field to the `Checker` struct to store the return type of comptime methods in `$for` loops, and modifies the `gen_comptime_call` function to use the return type instead of the index. It also adds a new test for method call resolution on comptime variables, and updates the output of some existing tests to reflect the new behavior.
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a87b85</samp>

*  Add a new field `comptime_for_method_ret_type` to the `Checker` struct and the `CurrentComptimeValues` struct to store the return type of the current comptime method in a `$for` loop ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46L115-R118), [link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R1072))
*  Modify the `check_comptime_call` function to return the type of the comptime variable instead of assuming it is a string ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5L167-R167))
*  Assign the return type of the method to the `comptime_for_method_ret_type` field in the `check_comptime_call` function ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R346))
*  Copy and restore the `comptime_for_method_ret_type` field in the `gen_comptime_call` function to handle nested `$for` loops ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R1085), [link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-d6711043c2f12db1436c6384f8462d814ec375c49543098620889966f62260c5R1099))
*  Modify the `check_if` function to handle comptime conditions involving the return type or the name of the comptime method ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-92297a74e9e70557a4b47ca09faef734f8e4b97ac35dc69278794d134b2be211R158-R162), [link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-92297a74e9e70557a4b47ca09faef734f8e4b97ac35dc69278794d134b2be211L234-R284), [link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-92297a74e9e70557a4b47ca09faef734f8e4b97ac35dc69278794d134b2be211L304-R338))
*  Modify the `gen_comptime_call` function to use the return type of the method instead of its index in the comptime var type map ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-c1a64be6c57d784f62c3eefda33c833fe1e7369cda50c8fb6316ec5ff1e3508bL878-R880))
*  Modify the output of the comptime call method void error test and the comptime option call test to reflect the new error message and behavior ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-d798a7a2c78bb9852b1463b3f84545e4eb9bef033f095a16e2c523cfac991dcaL1-R5), [link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-8c9aa547291638ac74611e1424793fdcd009eb2874b44804bbaa4ba5c9409694L9-R9))
*  Add a new struct `Encoder` and a new test function and method to the `method_call_resolve_test.v` file to test the new feature of calling methods on comptime variables of sumtype, struct, and enum types ([link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-678d30e5db8dee324ec0a45fbc7e27162eaaed81875c1ee009a8ec7c5f510547R10-R11), [link](https://github.com/vlang/v/pull/20092/files?diff=unified&w=0#diff-678d30e5db8dee324ec0a45fbc7e27162eaaed81875c1ee009a8ec7c5f510547L42-R74))
