### PR TITLE
cgen: fix call_expr in branches and left_expr of call_expr with or_block(fix #20044)

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -79,6 +79,9 @@ fn (mut g Gen) need_tmp_var_in_expr(expr ast.Expr) bool {
 			if expr.or_block.kind != .absent {
 				return true
 			}
+			if g.need_tmp_var_in_expr(expr.left) {
+				return true
+			}
 			for arg in expr.args {
 				if g.need_tmp_var_in_expr(arg.expr) {
 					return true

--- a/vlib/v/tests/if_match_branches_with_call_expr_with_or_block_test.v
+++ b/vlib/v/tests/if_match_branches_with_call_expr_with_or_block_test.v
@@ -1,0 +1,26 @@
+fn foo() !string {
+	return 'abc'
+}
+
+// exists call_expr in the if-else branches and the left_expr of call_expr with or_block
+fn test_if() {
+	res := if false {
+		''
+	} else {
+		foo() or { panic('error') }.trim('')
+	}
+	assert res == 'abc'
+}
+
+// exists call_expr in the match branches and the left_expr of call_expr with or_block
+fn test_match() {
+	res := match false {
+		true {
+			''
+		}
+		else {
+			foo() or { panic('error') }.trim('')
+		}
+	}
+	assert res == 'abc'
+}


### PR DESCRIPTION
1. Fixed #20044 
2. Add tests.

```v
fn baz(str string) !string {
	return str
}

foo := '/bar'
bar := if foo.contains('foo') {
	foo.all_after('foo')
} else {
	baz(foo) or { panic('panic') }.trim_left('/')
}

assert bar == 'bar'
println(bar)
```

outputs:
```
bar
```