### PR TITLE
checker: fix generic interface inferring error (fix #19951)

### DIFF
--- a/vlib/v/tests/generic_interface_array_type_infer_test.v
+++ b/vlib/v/tests/generic_interface_array_type_infer_test.v
@@ -1,0 +1,24 @@
+struct Metadata {}
+
+struct TagOrText {}
+
+pub interface Layout[R] {
+	render(content []R) string
+}
+
+struct DefaultLayout {
+}
+
+pub fn (self DefaultLayout) to_layout() Layout[TagOrText] {
+	return self
+}
+
+pub fn (self DefaultLayout) render(content []TagOrText) string {
+	return 'Hello world'
+}
+
+fn test_generic_interface_array_type_infer() {
+	ret := DefaultLayout{}.to_layout().render([])
+	println(ret)
+	assert ret == 'Hello world'
+}


### PR DESCRIPTION
This PR fix generic interface inferring error (fix #19951).

- Fix generic interface inferring error.
- Add test.

```v
struct Metadata {}

struct TagOrText {}

pub interface Layout[R] {
	render(content []R) string
}

struct DefaultLayout {
}

pub fn (self DefaultLayout) to_layout() Layout[TagOrText] {
	return self
}

pub fn (self DefaultLayout) render(content []TagOrText) string {
	return 'Hello world'
}

fn main() {
	ret := DefaultLayout{}.to_layout().render([])
	println(ret)
	assert ret == 'Hello world'
}

PS D:\Test\v\tt1> v run .
Hello world
```