### PR TITLE
checker: fix generics method call with struct short syntax args(fix #20030)

### DIFF
--- a/vlib/v/tests/generics_method_call_with_short_syntax_args_test.v
+++ b/vlib/v/tests/generics_method_call_with_short_syntax_args_test.v
@@ -1,0 +1,22 @@
+struct Options[T] {
+	a T
+}
+
+struct Collector[T] {
+mut:
+	a T
+}
+
+fn (mut c Collector[T]) use(options Options[T]) {
+	c.a = options.a
+}
+
+struct MainStruct {
+	Collector[int]
+}
+
+fn test_main() {
+	mut s := MainStruct{}
+	s.use(a: 1)
+	assert s.a == 1
+}


### PR DESCRIPTION
1. Fixed #20030 
2. Add tests.

```v
pub type Handler[T] = fn (mut T) bool

@[params]
pub struct Options[T] {
	handler fn (mut T) bool @[required]
}

struct Collector[T] {
mut:
	handlers []Handler[T]
}

pub fn (mut c Collector[T]) use(options Options[T]) {
	c.handlers << options.handler
}

pub struct Context {}

fn test_handler(mut ctx Context) bool {
	println('from test_handler!')
	return true
}

pub struct MainStruct {
	Collector[Context]
}

fn main() {
	mut s := MainStruct{}
	s.use(handler: test_handler)
	assert s.handlers.len == 1
}
```

outputs:
```
passed
```