### PR TITLE
websocket: updates the websocket server to be able to use another server socket

### DIFF
--- a/examples/vweb/vweb_websocket/assets/websocket_client.js
+++ b/examples/vweb/vweb_websocket/assets/websocket_client.js
@@ -1,0 +1,22 @@
+const messageList = document.getElementById('message-list');
+const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+const socket = new WebSocket(`${protocol}://${location.host}/ws`);
+let i = 0;
+
+function send(message) {
+  messageList.innerHTML += `<li>&gt; ${message}</li>`;
+  socket.send(message);
+}
+
+socket.addEventListener("open", (event) => {
+  console.log('Connected to WS server');
+  send('Salut tout le monde !');
+});
+
+socket.addEventListener("message", (event) => {
+  const { data } = event;
+  messageList.innerHTML += `<li>&lt; ${data}</li>`;
+  setTimeout(() => {
+    send(`Message reçu ${i++}`);
+  }, 3000);
+});

--- a/examples/vweb/vweb_websocket/assets/websocket_client.js
+++ b/examples/vweb/vweb_websocket/assets/websocket_client.js
@@ -10,13 +10,13 @@ function send(message) {
 
 socket.addEventListener("open", (event) => {
   console.log('Connected to WS server');
-  send('Salut tout le monde !');
+  send('Hey everyone !');
 });
 
 socket.addEventListener("message", (event) => {
   const { data } = event;
   messageList.innerHTML += `<li>&lt; ${data}</li>`;
   setTimeout(() => {
-    send(`Message reçu ${i++}`);
+    send(`Roger ${i++}`);
   }, 3000);
 });

--- a/examples/vweb/vweb_websocket/index.html
+++ b/examples/vweb/vweb_websocket/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang=en>
+<head>
+<meta charset=utf-8>
+<title>vweb websocket example page</title>
+</head>
+<body>
+  <ol id="message-list"></ol>
+  <script type="text/javascript" src="websocket_client.js"></script>
+</body>
+</html>

--- a/examples/vweb/vweb_websocket/vweb_websocket.v
+++ b/examples/vweb/vweb_websocket/vweb_websocket.v
@@ -44,7 +44,6 @@ fn new_websocker_server() !&websocket.Server {
 		logger: &log.Log{
 			level: .debug
 		}
-		is_headless: true
 	}
 	wss.on_connect(fn (mut server_client websocket.ServerClient) !bool {
 		slog('ws.on_connect, server_client.client_key: ${server_client.client_key}')

--- a/examples/vweb/vweb_websocket/vweb_websocket.v
+++ b/examples/vweb/vweb_websocket/vweb_websocket.v
@@ -70,8 +70,8 @@ pub fn (mut app App) index() vweb.Result {
 
 pub fn (mut app App) ws() !vweb.Result {
 	key := app.req.header.get(http.CommonHeader.sec_websocket_key)!
-	app.wss.handle_handcheck(mut app.conn, key) or {
-		wlog('handle_handcheck error: ${err.msg()}')
+	app.wss.handle_handshake(mut app.conn, key) or {
+		wlog('handle_handshake error: ${err.msg()}')
 		return err
 	}
 	return app.text('')

--- a/examples/vweb/vweb_websocket/vweb_websocket.v
+++ b/examples/vweb/vweb_websocket/vweb_websocket.v
@@ -1,0 +1,78 @@
+module main
+
+import log
+import net.http
+import net.websocket
+import term
+import vweb
+
+const http_port = 8080
+
+struct App {
+	vweb.Context
+mut:
+	wss &websocket.Server @[vweb_global]
+}
+
+fn slog(message string) {
+	eprintln(term.colorize(term.bright_yellow, message))
+}
+
+fn clog(message string) {
+	eprintln(term.colorize(term.cyan, message))
+}
+
+fn wlog(message string) {
+	eprintln(term.colorize(term.bright_blue, message))
+}
+
+fn main() {
+	mut app := new_app() or { panic(err) }
+	vweb.run(app, http_port)
+}
+
+fn new_app() !&App {
+	mut app := &App{
+		wss: new_websocker_server()!
+	}
+	app.handle_static('assets', true)
+	return app
+}
+
+fn new_websocker_server() !&websocket.Server {
+	mut wss := &websocket.Server{
+		logger: &log.Log{
+			level: .debug
+		}
+		is_headless: true
+	}
+	wss.on_connect(fn (mut server_client websocket.ServerClient) !bool {
+		slog('ws.on_connect, server_client.client_key: ${server_client.client_key}')
+		return true
+	})!
+	wss.on_message(fn (mut ws websocket.Client, msg &websocket.Message) ! {
+		slog('s.on_message msg.opcode: ${msg.opcode} | msg.payload: ${msg.payload}')
+		ws.write(msg.payload, msg.opcode) or {
+			eprintln('ws.write err: ${err}')
+			return err
+		}
+	})
+	wss.on_close(fn (mut ws websocket.Client, code int, reason string) ! {
+		slog('s.on_close code: ${code}, reason: ${reason}')
+	})
+	slog('Websocket Server initialized')
+	return wss
+}
+
+pub fn (mut app App) index() vweb.Result {
+	return $vweb.html()
+}
+
+pub fn (mut app App) ws() !vweb.Result {
+	key := app.req.header.get(http.CommonHeader.sec_websocket_key)!
+	app.wss.handle_handcheck(mut app.conn, key) or {
+		wlog('handle_handcheck error: ${err.msg()}')
+		return err
+	}
+	return app.text('')
+}

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -103,6 +103,7 @@ pub enum CommonHeader {
 	sec_fetch_site
 	sec_fetch_user
 	sec_websocket_accept
+	sec_websocket_key
 	server
 	server_timing
 	set_cookie
@@ -209,6 +210,7 @@ pub fn (h CommonHeader) str() string {
 		.sec_fetch_site { 'Sec-Fetch-Site' }
 		.sec_fetch_user { 'Sec-Fetch-User' }
 		.sec_websocket_accept { 'Sec-WebSocket-Accept' }
+		.sec_websocket_key { 'Sec-WebSocket-Key' }
 		.server { 'Server' }
 		.server_timing { 'Server-Timing' }
 		.set_cookie { 'Set-Cookie' }
@@ -314,6 +316,7 @@ const common_header_map = {
 	'sec-fetch-site':                      .sec_fetch_site
 	'sec-fetch-user':                      .sec_fetch_user
 	'sec-websocket-accept':                .sec_websocket_accept
+	'sec_websocket_key':                   .sec_websocket_key
 	'server':                              .server
 	'server-timing':                       .server_timing
 	'set-cookie':                          .set_cookie

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -25,10 +25,9 @@ mut:
 	message_callbacks       []MessageEventHandler // new message callback functions
 	close_callbacks         []CloseEventHandler   // close message callback functions
 pub:
-	family      net.AddrFamily = .ip
-	port        int  // port used as listen to incoming connections
-	is_ssl      bool // true if secure connection (not supported yet on server)
-	is_headless bool // true don't want to start a listener and use an other server
+	family net.AddrFamily = .ip
+	port   int  // port used as listen to incoming connections
+	is_ssl bool // true if secure connection (not supported yet on server)
 pub mut:
 	server_state shared ServerState
 }

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -25,9 +25,10 @@ mut:
 	message_callbacks       []MessageEventHandler // new message callback functions
 	close_callbacks         []CloseEventHandler   // close message callback functions
 pub:
-	family net.AddrFamily = .ip
-	port   int  // port used as listen to incoming connections
-	is_ssl bool // true if secure connection (not supported yet on server)
+	family      net.AddrFamily = .ip
+	port        int  // port used as listen to incoming connections
+	is_ssl      bool // true if secure connection (not supported yet on server)
+	is_headless bool // true don't want to start a listener and use an other server
 pub mut:
 	server_state shared ServerState
 }
@@ -134,22 +135,57 @@ fn (mut s Server) serve_client(mut c Client) ! {
 		c.logger.debug('server-> End serve client (${c.id})')
 	}
 	mut handshake_response, mut server_client := s.handle_server_handshake(mut c)!
-	accept := s.send_connect_event(mut server_client)!
-	if !accept {
-		s.logger.debug('server-> client not accepted')
-		c.shutdown_socket()!
-		return
-	}
-	// the client is accepted
-	c.socket_write(handshake_response.bytes())!
-	lock s.server_state {
-		s.server_state.clients[server_client.client.id] = server_client
-	}
-	s.setup_callbacks(mut server_client)
+	s.attach_client(mut server_client, handshake_response)!
 	c.listen() or {
 		s.logger.error(err.msg())
 		return err
 	}
+}
+
+pub fn (mut s Server) handle_handcheck(mut conn net.TcpConn, key string) !&ServerClient {
+	mut c := &Client{
+		is_server: true
+		conn: conn
+		ssl_conn: ssl.new_ssl_conn()!
+		logger: &log.Log{
+			level: .debug
+		}
+		client_state: ClientState{
+			state: .open
+		}
+		last_pong_ut: time.now().unix
+		id: rand.uuid_v4()
+	}
+	mut server_client := &ServerClient{
+		resource_name: 'GET'
+		client_key: key
+		client: unsafe { c }
+		server: unsafe { &s }
+	}
+	digest := create_key_challenge_response(key)!
+	handshake_response := 'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${digest}\r\n\r\n'
+	s.attach_client(mut server_client, handshake_response)!
+	spawn s.handle_ping()
+	c.listen() or {
+		s.logger.error(err.msg())
+		return err
+	}
+	return server_client
+}
+
+fn (mut s Server) attach_client(mut server_client ServerClient, handshake_response string) ! {
+	accept := s.send_connect_event(mut server_client)!
+	if !accept {
+		s.logger.debug('server-> client not accepted')
+		server_client.client.shutdown_socket()!
+		return
+	}
+	// the client is accepted
+	server_client.client.socket_write(handshake_response.bytes())!
+	lock s.server_state {
+		s.server_state.clients[server_client.client.id] = unsafe { server_client }
+	}
+	s.setup_callbacks(mut server_client)
 }
 
 // setup_callbacks initialize all callback functions

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -142,7 +142,8 @@ fn (mut s Server) serve_client(mut c Client) ! {
 	}
 }
 
-pub fn (mut s Server) handle_handcheck(mut conn net.TcpConn, key string) !&ServerClient {
+// handle_handshake use an existing connection to respond to the handshake for a given key
+pub fn (mut s Server) handle_handshake(mut conn net.TcpConn, key string) !&ServerClient {
 	mut c := &Client{
 		is_server: true
 		conn: conn

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -146,7 +146,7 @@ pub fn (mut s Server) handle_handshake(mut conn net.TcpConn, key string) !&Serve
 	mut c := &Client{
 		is_server: true
 		conn: conn
-		ssl_conn: ssl.new_ssl_conn()!
+		is_ssl: false
 		logger: &log.Log{
 			level: .debug
 		}


### PR DESCRIPTION
Hello, I am very new to vlang, so I might have done things wrong.

I updated the `websocket.Server` to allow it to not start a listener socket in order to use an external one (ie: vweb).

There are some caveats :
- the vweb request handler never ends. I would like to use middlewares, but I am not sure how to access the WebSocket server then
- in the example, I had to push force a `.js` file. This is a small script and could be inlined in a `<script type="text/javascript">` in `index.html` but the compiler try to parse it and fail.


<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8174157</samp>

This pull request adds an example of using the `net.websocket` module to create a headless WebSocket server and a vweb application that serves a simple WebSocket client. It also adds support for the `Sec-WebSocket-Key` header in the `net.http` module, which is needed for WebSocket handshaking. The example demonstrates how to handle WebSocket events, send and receive messages, and update the HTML page using JavaScript.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8174157</samp>

*  Implement a vweb application that supports WebSocket communication ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-fc3b3f0cadf1bcdf25aff1886c3524379b991161e89e26b3d4d8afb33371d1eaR1-R78), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3R106), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3R213), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3R319), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L28-R31), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L137-R188))
  - Add a `vweb_websocket.v` file that creates a `net.websocket.Server` instance and registers callbacks for WebSocket events ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-fc3b3f0cadf1bcdf25aff1886c3524379b991161e89e26b3d4d8afb33371d1eaR1-R78))
  - Define a route for the WebSocket endpoint and pass the connection and the key to the `handle_handshake` method of the WebSocket server ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-fc3b3f0cadf1bcdf25aff1886c3524379b991161e89e26b3d4d8afb33371d1eaR1-R78), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L137-R188))
  - Add a new enum value and cases for the `Sec-WebSocket-Key` header in the `net.http.Header` enum and its methods ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3R106), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3R213), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3R319))
  - Add a new field `is_headless` to the `net.websocket.Server` struct to indicate whether the server should start its own listener or use an external server ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L28-R31))
  - Refactor the `accept_client` method of the `net.websocket.Server` struct to extract the logic for attaching a client and sending the handshake response to a new method `attach_client` ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-7fe98d408934b485a5964fe8cc48e6bdc69d06395ce76057979e2a37d341be46L137-R188))
* Add an HTML file and a JavaScript file that demonstrate the WebSocket client functionality ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-553afce59c089b036e4e180a6ec2cd159e216bb7dae4018acb7700c940d051fdL1-R21), [link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-f69112faeaacef4e05eec38dc14af5cbb1a78d8715930e84ac19768b734346bdL1-R10))
  - Add an `index.html` file that loads the `websocket_client.js` script and displays an ordered list of messages exchanged with the server ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-f69112faeaacef4e05eec38dc14af5cbb1a78d8715930e84ac19768b734346bdL1-R10))
  - Add a `websocket_client.js` file that implements a simple WebSocket client that connects to the server, sends and receives messages, and updates the HTML page with the message list ([link](https://github.com/vlang/v/pull/20103/files?diff=unified&w=0#diff-553afce59c089b036e4e180a6ec2cd159e216bb7dae4018acb7700c940d051fdL1-R21))
