### PR TITLE
regex: fix '\0' terminator always matched as last character(fix #19802)

### DIFF
--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -2429,7 +2429,8 @@ pub fn (mut re RE) match_base(in_txt &u8, in_txt_len int) (int, int) {
 				// println("ist_simple_char")
 				state.match_flag = false
 
-				if re.prog[state.pc].ch == ch {
+				if re.prog[state.pc].ch == ch
+					&& (state.i < in_txt_len - 1 || re.prog[state.pc].ch != 0) {
 					state.match_flag = true
 					l_ist = regex.ist_simple_char
 

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -186,13 +186,13 @@ match_test_suite = [
     TestItem{"/a/", r"^/a/[^/]+$", -1,3},
     TestItem{"/a/b",r"^/a/[^/]+$", 0,4},
 
-	// test `\0` as terminator
-	TestItem{"abc", "^abc\0$", -1,3},
-	TestItem{"abc\0", "^abc\0$", 0,4},
+    // test `\0` as terminator
+    TestItem{"abc", "^abc\0$", -1,3},
+    TestItem{"abc\0", "^abc\0$", 0,4},
 
-	// test has `\0` chars
-	TestItem{"abcxyz", "^abc\0xyz$", -1,3},
-	TestItem{"abc\0xyz", "^abc\0xyz$", 0,7},
+    // test has `\0` chars
+    TestItem{"abcxyz", "^abc\0xyz$", -1,3},
+    TestItem{"abc\0xyz", "^abc\0xyz$", 0,7},
 ]
 )
 

--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -185,6 +185,14 @@ match_test_suite = [
     // test last charr classes neg class
     TestItem{"/a/", r"^/a/[^/]+$", -1,3},
     TestItem{"/a/b",r"^/a/[^/]+$", 0,4},
+
+	// test `\0` as terminator
+	TestItem{"abc", "^abc\0$", -1,3},
+	TestItem{"abc\0", "^abc\0$", 0,4},
+
+	// test has `\0` chars
+	TestItem{"abcxyz", "^abc\0xyz$", -1,3},
+	TestItem{"abc\0xyz", "^abc\0xyz$", 0,7},
 ]
 )
 


### PR DESCRIPTION
1. Fixed #19802 
2. Add tests.

```v
import regex

fn main() {
	re1 := regex.regex_opt('^abc\0$')!
	assert re1.matches_string('abc') == false
	assert re1.matches_string('abc\0') == true

	re2 := regex.regex_opt('^abc\0xyz$')!
	assert re2.matches_string('abc' + 'xyz') == false
	assert re2.matches_string('abc\0xyz') == true
}
```
outputs:
```
passed
```