### PR TITLE
vlib: use builtin flush functions

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -171,14 +171,14 @@ pub fn eprintln(s string) {
 	} $else $if ios {
 		C.WrappedNSLog(s.str)
 	} $else {
-		C.fflush(C.stdout)
-		C.fflush(C.stderr)
+		flush_stdout()
+		flush_stderr()
 		// eprintln is used in panics, so it should not fail at all
 		$if android && !termux {
 			C.android_print(C.stderr, c'%.*s\n', s.len, s.str)
 		}
 		_writeln_to_fd(2, s)
-		C.fflush(C.stderr)
+		flush_stderr()
 	}
 }
 
@@ -195,13 +195,13 @@ pub fn eprint(s string) {
 		// TODO: Implement a buffer as NSLog doesn't have a "print"
 		C.WrappedNSLog(s.str)
 	} $else {
-		C.fflush(C.stdout)
-		C.fflush(C.stderr)
+		flush_stdout()
+		flush_stderr()
 		$if android && !termux {
 			C.android_print(C.stderr, c'%.*s', s.len, s.str)
 		}
 		_write_buf_to_fd(2, s.str, s.len)
-		C.fflush(C.stderr)
+		flush_stderr()
 	}
 }
 

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -399,9 +399,9 @@ pub fn system(cmd string) int {
 	$if windows {
 		// overcome bug in system & _wsystem (cmd) when first char is quote `"`
 		wcmd := if cmd.len > 1 && cmd[0] == `"` && cmd[1] != `"` { '"${cmd}"' } else { cmd }
+		flush_stdout()
+		flush_stderr()
 		unsafe {
-			C.fflush(C.stdout)
-			C.fflush(C.stderr)
 			ret = C._wsystem(wcmd.to_wide())
 		}
 	} $else {

--- a/vlib/readline/readline_nix.c.v
+++ b/vlib/readline/readline_nix.c.v
@@ -121,7 +121,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ![]rune {
 	}
 	print(r.prompt)
 	for {
-		unsafe { C.fflush(C.stdout) }
+		flush_stdout()
 		c := r.read_char() or { return err }
 		a := r.analyse(c)
 		if r.execute(a, c) {

--- a/vlib/readline/readline_windows.c.v
+++ b/vlib/readline/readline_windows.c.v
@@ -36,7 +36,7 @@ pub fn (mut r Readline) read_line_utf8(prompt string) ![]rune {
 		r.previous_lines[0] = []rune{}
 	}
 	print(r.prompt)
-	unsafe { C.fflush(C.stdout) }
+	flush_stdout()
 	r.current = os.get_raw_line().runes()
 	r.previous_lines[0] = []rune{}
 	r.search_index = 0


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0d8289f</samp>

Refactored some builtin and os functions to use `flush_stdout` and `flush_stderr` from `vlib/builtin/builtin.c.v`. This improves code consistency and maintainability across different modules and platforms.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0d8289f</samp>

*  Refactor the code to use `flush_stdout` and `flush_stderr` functions from `vlib/builtin/builtin.c.v` instead of calling C functions directly ([link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL174-R175), [link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL181-R181), [link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-0488e6c77004fe125e9b9d01ac01a28736395ac65dcb3f9690b39065192e803eL198-R204), [link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-4d8978da445d7babd96c096c86416b20ed658ebb83dca96f12c5c43f16cc3d61L402-R404), [link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-2b9cdf457e060cc6059f839df50a26139bfd25d6cb4761056215a2259148a5c3L124-R124), [link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-ef1b50219bef80396d4e55f132ee520f518dfe8f071ed2b4f24099ee8ac663e8L39-R39))
* Move the code for printing to standard output and error from `vlib/os/os.c.v` to `vlib/builtin/builtin.c.v` as part of a larger restructuring of the `os` module ([link](https://github.com/vlang/v/pull/20108/files?diff=unified&w=0#diff-4d8978da445d7babd96c096c86416b20ed658ebb83dca96f12c5c43f16cc3d61L402-R404))
