### PR TITLE
net.html: fix doc comments for html.parse functions

### DIFF
--- a/vlib/net/html/html.v
+++ b/vlib/net/html/html.v
@@ -3,8 +3,8 @@ module html
 import os
 
 // parse parses and returns the DOM from the given text.
-// Note: this function will parse all tags to lowercase.
-// E.g. <MyTag>content<MyTag/> is converted to <mytag>content<mytag>
+// Note: this function converts tags to lowercase.
+// E.g. <MyTag>content</MyTag> is parsed as <mytag>content</mytag>.
 pub fn parse(text string) DocumentObjectModel {
 	mut parser := Parser{}
 	parser.parse_html(text)
@@ -12,8 +12,8 @@ pub fn parse(text string) DocumentObjectModel {
 }
 
 // parse_file parses and returns the DOM from the contents of a file.
-// Note: this function will parse all tags to lowercase.
-// E.g. <MyTag>content<MyTag/> is converted to <mytag>content<mytag>
+// Note: this function converts tags to lowercase.
+// E.g. <MyTag>content</MyTag> is parsed as <mytag>content</mytag>.
 pub fn parse_file(filename string) DocumentObjectModel {
 	content := os.read_file(filename) or { return DocumentObjectModel{
 		root: &Tag{}


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 133140e</samp>

Improved documentation of `html.v` parsing functions. Added comments to explain that they only handle lowercase tags, as per the HTML standard.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 133140e</samp>

*  Clarify that `parse` and `parse_file` functions do not modify input text ([link](https://github.com/vlang/v/pull/20109/files?diff=unified&w=0#diff-15684b4e12c85dab3aedde3c6a0638c8a2ce74b4c2d12fb07a78969f55442b87L6-R7), [link](https://github.com/vlang/v/pull/20109/files?diff=unified&w=0#diff-15684b4e12c85dab3aedde3c6a0638c8a2ce74b4c2d12fb07a78969f55442b87L15-R16))
