### PR TITLE
checker: fix Map[K]V return type resolution on inferred generic function call 

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1492,6 +1492,12 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
 				concrete_types)
 			{
+				if c.table.sym(func.return_type).kind == .map {
+					if typ.has_flag(.generic) {
+						node.return_type = typ
+					}
+					return node.return_type
+				}
 				if typ.has_flag(.generic) {
 					node.return_type = typ
 				}


### PR DESCRIPTION
Fix #20106

This PR tries to fix the difference behavior from CallExpr when concrete type is present or not.

```V
fn generic[K,V](a map[K]V) {
	t := expect_map(a) // was not working right
	dump(t)
	t2 := expect_map[K,V](a) // working right
	dump(t2)
}

fn expect_map[K, V](a map[K]V) map[K]V {
}
```


<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ed2a82e</samp>

Fix a bug with generic map types in function return values. Add a checker case for functions that return a map type with a generic flag and set the node's return type accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ed2a82e</samp>

* Fix a bug related to generic map types ([link](https://github.com/vlang/v/pull/20112/files?diff=unified&w=0#diff-4f77499816a4f3d77c8e22529ca273ad1ebf948f744d16356eab0e7636de25aaR1495-R1500))
