### PR TITLE
examples, x: fix notice about assigning 0 to a reference field

### DIFF
--- a/examples/gg/bezier.v
+++ b/examples/gg/bezier.v
@@ -11,9 +11,7 @@ mut:
 }
 
 fn main() {
-	mut app := &App{
-		gg: 0
-	}
+	mut app := &App{}
 	app.gg = gg.new_context(
 		bg_color: gx.rgb(174, 198, 255)
 		width: 600

--- a/examples/gg/bezier_anim.v
+++ b/examples/gg/bezier_anim.v
@@ -31,7 +31,6 @@ fn (mut anim Anim) advance() {
 
 fn main() {
 	mut app := &App{
-		gg: 0
 		anim: &Anim{}
 	}
 	app.gg = gg.new_context(

--- a/vlib/x/ttf/README.md
+++ b/vlib/x/ttf/README.md
@@ -256,7 +256,7 @@ const font_paths = [
 
 struct App_data {
 pub mut:
-	gg        &gg.Context
+	gg        &gg.Context = unsafe { nil }
 	sg_img    gfx.Image
 	init_flag bool
 	frame_c   int
@@ -292,9 +292,7 @@ fn draw_frame(mut app App_data) {
 }
 
 fn main() {
-	mut app := &App_data{
-		gg: 0
-	}
+	mut app := &App_data{}
 
 	app.gg = gg.new_context(
 		width: win_width


### PR DESCRIPTION
Fixes a few "notice: assigning `0` to a reference field is only allowed in `unsafe` blocks" and some unnecessary `gg: 0` assignments
