### PR TITLE
tools.vpm: extract outdated logic into outdated.v, fix outdated hg, extend tests

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -3,7 +3,6 @@ module main
 import os
 import net.http
 import net.urllib
-import sync.pool
 import v.vmod
 import json
 import term
@@ -17,13 +16,6 @@ struct ModuleVpmInfo {
 	nr_downloads int
 }
 
-pub struct ModuleDateInfo {
-	name string
-mut:
-	outdated bool
-	exec_err bool
-}
-
 @[params]
 struct ErrorOptions {
 	details string
@@ -32,35 +24,6 @@ struct ErrorOptions {
 
 const vexe = os.quoted_path(os.getenv('VEXE'))
 const home_dir = os.home_dir()
-
-fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModuleDateInfo {
-	mut result := &ModuleDateInfo{
-		name: pp.get_item[string](idx)
-	}
-	path := get_path_of_existing_module(result.name) or { return result }
-	vcs := vcs_used_in_dir(path) or { return result }
-	args := vcs_info[vcs].args
-	mut outputs := []string{}
-	for step in args.outdated {
-		cmd := [vcs.str(), args.path, os.quoted_path(path), step].join(' ')
-		res := os.execute(cmd)
-		if res.exit_code < 0 {
-			verbose_println('Error command: ${cmd}')
-			verbose_println('Error details:\n${res.output}')
-			result.exec_err = true
-			return result
-		}
-		if vcs == .hg && res.exit_code == 1 {
-			result.outdated = true
-			return result
-		}
-		outputs << res.output
-	}
-	if vcs == .git && outputs[1] != outputs[2] {
-		result.outdated = true
-	}
-	return result
-}
 
 fn get_mod_vpm_info(name string) !ModuleVpmInfo {
 	if name.len < 2 || (!name[0].is_digit() && !name[0].is_letter()) {
@@ -123,22 +86,6 @@ fn get_name_from_url(raw_url string) !string {
 
 fn normalize_mod_path(path string) string {
 	return path.replace('-', '_').to_lower()
-}
-
-fn get_outdated() ![]string {
-	installed := get_installed_modules()
-	mut outdated := []string{}
-	mut pp := pool.new_pool_processor(callback: get_mod_date_info)
-	pp.work_on_items(installed)
-	for res in pp.get_results[ModuleDateInfo]() {
-		if res.exec_err {
-			return error('failed to check the latest commits for `${res.name}`.')
-		}
-		if res.outdated {
-			outdated << res.name
-		}
-	}
-	return outdated
 }
 
 fn get_all_modules() []string {

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -11,10 +11,7 @@ import test_utils
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_test_${rand.ulid()}')
 
 fn testsuite_begin() {
-	os.setenv('VMODULES', test_path, true)
-	os.setenv('VPM_DEBUG', '', true)
-	os.setenv('VPM_NO_INCREMENT', '1', true)
-	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
+	test_utils.set_test_env(test_path)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -2,6 +2,7 @@
 import os
 import rand
 import v.vmod
+import test_utils
 
 const vexe = os.quoted_path(@VEXE)
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_input_test_${rand.ulid()}')

--- a/cmd/tools/vpm/install_version_input_test.v
+++ b/cmd/tools/vpm/install_version_input_test.v
@@ -12,9 +12,7 @@ const expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 })
 
 fn testsuite_begin() {
-	os.setenv('VMODULES', test_path, true)
-	os.setenv('VPM_NO_INCREMENT', '1', true)
-	os.setenv('VPM_DEBUG', '', true)
+	test_utils.set_test_env(test_path)
 	// Explicitly disable fail on prompt.
 	os.setenv('VPM_FAIL_ON_PROMPT', '', true)
 	os.mkdir_all(test_path) or {}

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -8,10 +8,7 @@ import v.vmod
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test_${rand.ulid()}')
 
 fn testsuite_begin() {
-	os.setenv('VMODULES', test_path, true)
-	os.setenv('VPM_DEBUG', '', true)
-	os.setenv('VPM_NO_INCREMENT', '1', true)
-	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
+	test_utils.set_test_env(test_path)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -4,6 +4,7 @@ module main
 import os
 import rand
 import v.vmod
+import test_utils
 
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_version_test_${rand.ulid()}')
 

--- a/cmd/tools/vpm/outdated.v
+++ b/cmd/tools/vpm/outdated.v
@@ -1,0 +1,68 @@
+module main
+
+import os
+import sync.pool
+
+pub struct ModuleDateInfo {
+	name string
+mut:
+	outdated bool
+	exec_err bool
+}
+
+fn vpm_outdated() {
+	outdated := get_outdated() or { exit(1) }
+	if outdated.len > 0 {
+		println('Outdated modules:')
+		for m in outdated {
+			println('  ${m}')
+		}
+	} else {
+		println('Modules are up to date.')
+	}
+}
+
+fn get_outdated() ![]string {
+	installed := get_installed_modules()
+	mut outdated := []string{}
+	mut pp := pool.new_pool_processor(callback: get_mod_date_info)
+	pp.work_on_items(installed)
+	for res in pp.get_results[ModuleDateInfo]() {
+		if res.exec_err {
+			return error('failed to check the latest commits for `${res.name}`.')
+		}
+		if res.outdated {
+			outdated << res.name
+		}
+	}
+	return outdated
+}
+
+fn get_mod_date_info(mut pp pool.PoolProcessor, idx int, wid int) &ModuleDateInfo {
+	mut result := &ModuleDateInfo{
+		name: pp.get_item[string](idx)
+	}
+	path := get_path_of_existing_module(result.name) or { return result }
+	vcs := vcs_used_in_dir(path) or { return result }
+	args := vcs_info[vcs].args
+	mut outputs := []string{}
+	for step in args.outdated {
+		cmd := [vcs.str(), args.path, os.quoted_path(path), step].join(' ')
+		res := os.execute(cmd)
+		if res.exit_code < 0 {
+			verbose_println('Error command: ${cmd}')
+			verbose_println('Error details:\n${res.output}')
+			result.exec_err = true
+			return result
+		}
+		if vcs == .hg && res.exit_code == 1 {
+			result.outdated = true
+			return result
+		}
+		outputs << res.output
+	}
+	if vcs == .git && outputs[1] != outputs[2] {
+		result.outdated = true
+	}
+	return result
+}

--- a/cmd/tools/vpm/outdated_test.v
+++ b/cmd/tools/vpm/outdated_test.v
@@ -8,10 +8,7 @@ import test_utils
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_outdated_test_${rand.ulid()}')
 
 fn testsuite_begin() {
-	os.setenv('VMODULES', test_path, true)
-	os.setenv('VPM_DEBUG', '', true)
-	os.setenv('VPM_NO_INCREMENT', '1', true)
-	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
+	test_utils.set_test_env(test_path)
 	os.mkdir_all(test_path)!
 	os.chdir(test_path)!
 }

--- a/cmd/tools/vpm/outdated_test.v
+++ b/cmd/tools/vpm/outdated_test.v
@@ -17,19 +17,24 @@ fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }
 
-fn test_is_outdated() {
+fn test_is_outdated_git_module() {
 	os.execute_or_exit('git clone https://github.com/vlang/libsodium.git')
-	os.execute_or_exit('hg clone https://www.mercurial-scm.org/repo/hello')
 	assert !is_outdated('libsodium')
-	assert !is_outdated('hello')
-
 	os.execute_or_exit('git -C libsodium reset --hard HEAD~1')
-	os.execute_or_exit('hg --config extensions.strip= -R hello strip -r tip')
 	assert is_outdated('libsodium')
-	assert is_outdated('hello')
-
 	os.execute_or_exit('git -C libsodium pull')
-	os.execute_or_exit('hg -R hello pull')
 	assert !is_outdated('libsodium')
+}
+
+fn test_is_outdated_hg_module() {
+	os.find_abs_path_of_executable('hg') or {
+		eprintln('skipping test, since `hg` is not executable.')
+		return
+	}
+	os.execute_or_exit('hg clone https://www.mercurial-scm.org/repo/hello')
+	assert !is_outdated('hello')
+	os.execute_or_exit('hg --config extensions.strip= -R hello strip -r tip')
+	assert is_outdated('hello')
+	os.execute_or_exit('hg -R hello pull')
 	assert !is_outdated('hello')
 }

--- a/cmd/tools/vpm/outdated_test.v
+++ b/cmd/tools/vpm/outdated_test.v
@@ -1,0 +1,38 @@
+// vtest retry: 3
+module main
+
+import os
+import rand
+import test_utils
+
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_outdated_test_${rand.ulid()}')
+
+fn testsuite_begin() {
+	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_DEBUG', '', true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
+	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
+	os.mkdir_all(test_path)!
+	os.chdir(test_path)!
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
+fn test_is_outdated() {
+	os.execute_or_exit('git clone https://github.com/vlang/libsodium.git')
+	os.execute_or_exit('hg clone https://www.mercurial-scm.org/repo/hello')
+	assert !is_outdated('libsodium')
+	assert !is_outdated('hello')
+
+	os.execute_or_exit('git -C libsodium reset --hard HEAD~1')
+	os.execute_or_exit('hg --config extensions.strip= -R hello strip -r tip')
+	assert is_outdated('libsodium')
+	assert is_outdated('hello')
+
+	os.execute_or_exit('git -C libsodium pull')
+	os.execute_or_exit('hg -R hello pull')
+	assert !is_outdated('libsodium')
+	assert !is_outdated('hello')
+}

--- a/cmd/tools/vpm/test_utils/utils.v
+++ b/cmd/tools/vpm/test_utils/utils.v
@@ -4,7 +4,14 @@ import os
 import net
 import time
 
-fn hg_serve(hg_path string, path string) (&os.Process, int) {
+pub fn set_test_env(test_path string) {
+	os.setenv('VMODULES', test_path, true)
+	os.setenv('VPM_DEBUG', '', true)
+	os.setenv('VPM_NO_INCREMENT', '1', true)
+	os.setenv('VPM_FAIL_ON_PROMPT', '1', true)
+}
+
+pub fn hg_serve(hg_path string, path string) (&os.Process, int) {
 	mut port := 8000
 	for {
 		if mut l := net.listen_tcp(.ip6, ':${port}') {

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -6,9 +6,7 @@ const v = os.quoted_path(@VEXE)
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_update_test_${rand.ulid()}')
 
 fn testsuite_begin() {
-	os.setenv('VMODULES', test_path, true)
-	os.setenv('VPM_DEBUG', '', true)
-	os.setenv('VPM_NO_INCREMENT', '1', true)
+	test_utils.set_test_env(test_path)
 }
 
 fn testsuite_end() {

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -1,6 +1,7 @@
 // vtest retry: 3
 import os
 import rand
+import test_utils
 
 const v = os.quoted_path(@VEXE)
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_update_test_${rand.ulid()}')

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -66,7 +66,7 @@ fn main() {
 }
 
 fn vpm_upgrade() {
-	outdated := get_outdated() or { exit(1) }
+	outdated := get_outdated()
 	if outdated.len > 0 {
 		vpm_update(outdated)
 	} else {

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -74,18 +74,6 @@ fn vpm_upgrade() {
 	}
 }
 
-fn vpm_outdated() {
-	outdated := get_outdated() or { exit(1) }
-	if outdated.len > 0 {
-		println('Outdated modules:')
-		for m in outdated {
-			println('  ${m}')
-		}
-	} else {
-		println('Modules are up to date.')
-	}
-}
-
 fn vpm_list() {
 	installed := get_installed_modules()
 	if installed.len == 0 {


### PR DESCRIPTION
The PR extracts the "outdated-logic" into `outdated.v`. It fixes outdated detection for hg repositories and adds a unit tests for the outdated detection of git and hg repos.

It also extends the test utils that were added with the last pr by setting the test env for vpm tests with a util function.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d7cfcd7</samp>

This pull request refactors and improves the `vpm` tool by extracting the outdated functionality to a separate file and command, simplifying the upgrade logic, and using a helper function to set the common environment variables for testing. It also cleans up some unused code and adds tests for the `is_outdated` function.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d7cfcd7</samp>

* Implement `vpm outdated` command to check for outdated modules ([link](https://github.com/vlang/v/pull/20116/files?diff=unified&w=0#diff-e8f4d9cd8d4d997a91faef696ac0db1479eb87a48ce63beaed87964dbda98fa1R1-R62), [link](https://github.com/vlang/v/pull/20116/files?diff=unified&w=0#diff-770accea7573226ae6b708a392871038d6442d615da24596b300d0a14a2383bfR1-R35))
