### PR TITLE
tools.vpm: add support for ssh and hg version installations

### DIFF
--- a/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/accept_reinstall_mod_with_version_installation.expect
@@ -10,7 +10,7 @@ set install_path [lindex $argv 4]
 
 spawn $vexe install $mod@$new_tag
 
-expect "Scanning `$mod`..." {} timeout { exit 1 }
+expect "Scanning `$mod@$new_tag`..." {} timeout { exit 1 }
 expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
 expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "\r" } timeout { exit 1 }
 expect "Installing `$mod`..." {} timeout { exit 1 }

--- a/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
+++ b/cmd/tools/vpm/expect/decline_reinstall_mod_with_version_installation.expect
@@ -10,7 +10,7 @@ set install_path [lindex $argv 4]
 
 spawn $vexe install $mod@$new_tag
 
-expect "Scanning `$mod`..." {} timeout { exit 1 }
+expect "Scanning `$mod@$new_tag`..." {} timeout { exit 1 }
 expect "Module `$mod@$cur_tag` is already installed at `$install_path`." {} timeout { exit 1 }
 expect "Replace it with `$mod@$new_tag`? \\\[Y/n\\\]: " { send "n\r" } timeout { exit 1 }
 

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -133,7 +133,9 @@ fn (m Module) install() InstallResult {
 			return .failed
 		}
 	}
-	os.execute_opt('mv ${os.quoted_path(m.tmp_path)} ${os.quoted_path(m.install_path)}') or {
+	// TODO: use `os.mv` when working.
+	mv_cmd := $if windows { 'move' } $else { 'mv' }
+	os.execute_opt('${mv_cmd} ${os.quoted_path(m.tmp_path)} ${os.quoted_path(m.install_path)}') or {
 		vpm_error('failed to install `${m.name}`.', details: err.msg())
 		return .failed
 	}

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -99,6 +99,9 @@ fn install_modules(modules []Module) {
 }
 
 fn (m Module) install() InstallResult {
+	defer {
+		os.rmdir_all(m.tmp_path) or {}
+	}
 	if m.is_installed {
 		// Case: installed, but not an explicit version. Update instead of continuing the installation.
 		if m.version == '' && m.installed_version == '' {
@@ -120,18 +123,20 @@ fn (m Module) install() InstallResult {
 			return .skipped
 		}
 	}
-	vcs := m.vcs or { settings.vcs }
-	args := vcs_info[vcs].args
-	version_opt := if m.version != '' { '${args.version} ${m.version}' } else { '' }
-	cmd := [vcs.str(), args.install, version_opt, m.url, os.quoted_path(m.install_path)].join(' ')
-	vpm_log(@FILE_LINE, @FN, 'command: ${cmd}')
 	println('Installing `${m.name}`...')
-	verbose_println('  cloning from `${m.url}` to `${m.install_path_fmted}`')
-	res := os.execute_opt(cmd) or {
+	// When the module should be relocated into a subdirectory we need to make sure
+	// it exists to not run into permission errors.
+	parent_dir := m.install_path.all_before_last(os.path_separator)
+	if !os.exists(parent_dir) {
+		os.mkdir_all(parent_dir) or {
+			vpm_error('failed to create module directory for `${m.name}`.', details: err.msg())
+			return .failed
+		}
+	}
+	os.execute_opt('mv ${os.quoted_path(m.tmp_path)} ${os.quoted_path(m.install_path)}') or {
 		vpm_error('failed to install `${m.name}`.', details: err.msg())
 		return .failed
 	}
-	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output}')
 	return .installed
 }
 

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -124,27 +124,6 @@ fn test_missing_repo_name_in_url() {
 }
 
 fn test_manifest_detection() {
-	// head branch == `main`.
-	mut manifest := fetch_manifest('v-analyzer', 'https://github.com/v-analyzer/v-analyzer',
-		'', true) or {
-		assert false
-		return
-	}
-	assert manifest.name == 'v-analyzer'
-	assert manifest.dependencies == ['https://github.com/v-analyzer/v-tree-sitter']
-	// head branch == `master`.
-	manifest = fetch_manifest('ui', 'https://github.com/pisaiah/ui', '', true) or {
-		assert false
-		return
-	}
-	assert manifest.name == 'iui'
-	// not a V module.
-	if v := fetch_manifest('octocat', 'https://github.com/octocat/octocat.github.io',
-		'', true)
-	{
-		assert false, v.str()
-		return
-	}
 	mut res := os.execute('${vexe} install https://github.com/octocat/octocat.github.io')
 	assert res.exit_code == 1
 	assert res.output.contains('failed to find `v.mod` for `https://github.com/octocat/octocat.github.io`'), res.output

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -99,7 +99,7 @@ fn test_install_from_url_with_git_version_tag() {
 	// Install invalid version verbose.
 	res = os.execute('${vexe} install -f -v ${url}@${tag}')
 	assert res.exit_code == 1, res.str()
-	assert res.output.contains('failed to find `v.mod` for `${url}@${tag}`'), res.output
+	assert res.output.contains('Could not find remote branch ${tag} to clone.'), res.output
 	// Install from GitLab.
 	url = 'https://gitlab.com/tobealive/webview'
 	tag = 'v0.6.0'

--- a/cmd/tools/vpm/install_version_test.v
+++ b/cmd/tools/vpm/install_version_test.v
@@ -70,7 +70,7 @@ fn test_install_from_vpm_with_git_version_tag() {
 	assert res.output.contains('Updating module `${ident}`'), res.output
 }
 
-fn test_install_from_url_with_git_version_tag() {
+fn test_install_from_git_url_with_version_tag() {
 	mut url := 'https://github.com/vlang/vsl'
 	mut tag := 'v0.1.50'
 	mut res := os.execute('${vexe} install ${url}@${tag}')
@@ -109,4 +109,57 @@ fn test_install_from_url_with_git_version_tag() {
 	manifest = get_vmod('webview')
 	assert manifest.name == 'webview'
 	assert manifest.version == '0.6.0'
+}
+
+fn test_install_from_hg_url_with_version_tag() ! {
+	hg_path := os.find_abs_path_of_executable('hg') or {
+		eprintln('skipping test, since `hg` is not executable.')
+		return
+	}
+	test_module_path := os.join_path(os.temp_dir(), rand.ulid(), 'hg_test_module')
+	defer {
+		os.rmdir_all(test_module_path) or {}
+	}
+	mut res := os.execute('hg init ${test_module_path}')
+	assert res.exit_code == 0, res.str()
+	os.chdir(test_module_path)!
+
+	os.write_file('v.mod', "Module{
+	name: 'my_awesome_v_module'
+	version: '0.1.0'
+}")!
+	res = os.execute('hg add')
+	assert res.exit_code == 0, res.str()
+	res = os.execute('hg --config ui.username=v_ci commit -m "initial commit"')
+	assert res.exit_code == 0, res.str()
+
+	os.write_file('README.md', 'Hello World!')!
+	res = os.execute('hg add')
+	assert res.exit_code == 0, res.str()
+	res = os.execute('hg --config ui.username=v_ci commit -m "add readme"')
+	assert res.exit_code == 0, res.str()
+
+	res = os.execute('hg tag v0.1.0')
+	assert res.exit_code == 0, res.str()
+
+	os.write_file('v.mod', "Module{
+	name: 'my_awesome_v_module'
+	version: '0.2.0'
+}")!
+	res = os.execute('hg add')
+	assert res.exit_code == 0, res.str()
+	res = os.execute('hg --config ui.username=v_ci commit -m "bump version to v0.2.0"')
+	assert res.exit_code == 0, res.str()
+
+	mut p, port := test_utils.hg_serve(hg_path, test_module_path)
+	res = os.execute('${vexe} install -v --hg http://127.0.0.1:${port}@v0.1.0')
+	if res.exit_code != 0 {
+		p.signal_kill()
+		assert false, res.str()
+	}
+	p.signal_kill()
+	// Get manifest from the vmodules directory.
+	manifest := get_vmod('my_awesome_v_module')
+	assert manifest.name == 'my_awesome_v_module'
+	assert manifest.version == '0.1.0'
 }

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -207,12 +207,17 @@ fn (mut m Module) get_installed() {
 	}
 }
 
-fn get_tmp_path(relative_path string) ?string {
+fn get_tmp_path(relative_path string) !string {
 	tmp_path := os.real_path(os.join_path(settings.tmp_path, relative_path))
 	if os.exists(tmp_path) {
 		// It's unlikely that the tmp_path already exists, but it might
 		// occur if vpm was canceled during an installation or update.
-		os.rmdir_all(tmp_path) or { return none }
+		$if windows {
+			// FIXME: Workaround for failing `rmdir` commands on Windows.
+			os.execute_opt('rd /s /q ${tmp_path}')!
+		} $else {
+			os.rmdir_all(tmp_path)!
+		}
 	}
 	return tmp_path
 }

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -132,11 +132,6 @@ fn (mut p Parser) parse_module(m string) {
 				p.errors++
 				return
 			}
-			if info_vcs != .git && version != '' {
-				vpm_error('skipping `${info.name}`, version installs are currently only supported for projects using `git`.')
-				p.errors++
-				return
-			}
 			info_vcs
 		} else {
 			VCS.git

--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -12,6 +12,7 @@ mut:
 	is_force              bool
 	server_urls           []string
 	vmodules_path         string
+	tmp_path              string
 	no_dl_count_increment bool
 	// To ensure that some test scenarios with conflicting module directory names do not get stuck in prompts.
 	// It is intended that VPM does not display a prompt when `VPM_FAIL_ON_PROMPT` is set.
@@ -37,6 +38,7 @@ fn init_settings() VpmSettings {
 		server_urls: cmdline.options(args, '--server-urls')
 		vcs: if '--hg' in opts { .hg } else { .git }
 		vmodules_path: os.vmodules_dir()
+		tmp_path: os.join_path(os.vtmp_dir(), 'vpm', 'modules')
 		no_dl_count_increment: os.getenv('CI') != '' || (no_inc_env != '' && no_inc_env != '0')
 		fail_on_prompt: os.getenv('VPM_FAIL_ON_PROMPT') != ''
 	}

--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -34,7 +34,7 @@ const vcs_info = {
 		dir: '.hg'
 		args: struct {
 			install: 'clone'
-			version: '' // not supported yet.
+			version: '--rev'
 			update: 'pull --update'
 			path: '-R'
 			outdated: ['incoming']

--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -42,6 +42,15 @@ const vcs_info = {
 	}
 }
 
+fn (vcs VCS) clone(url string, version string, path string) ! {
+	args := vcs_info[vcs].args
+	version_opt := if version != '' { '${args.version} ${version}' } else { '' }
+	cmd := [vcs.str(), args.install, version_opt, url, os.quoted_path(path)].join(' ')
+	vpm_log(@FILE_LINE, @FN, 'cmd: ${cmd}')
+	res := os.execute_opt(cmd)!
+	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output}')
+}
+
 fn (vcs &VCS) is_executable() ! {
 	cmd := vcs.str()
 	os.find_abs_path_of_executable(cmd) or {


### PR DESCRIPTION
- Adds support for ssh installs e.g. `v install git@github.com:vlang/libsodium.git`.
- and for version installs (`@<tag>`) for modules using mercurial.

ssh is currently kind of supported. While at current master ssh modules CANNOT be installed via `v install`, `v update` CAN update such modules when adding an ssh module manually or changing the origin url of a module to an ssh address. But the update command has other issues. Adding (hopefully full) ssh support - before fixing the remaining known issues with the update command in a next step - will help keep the current functionality intact and make working with the ssh feature easier.

SSH CI tests are not added here, if git ssh is set up locally, it can be tested as follows:
```sh
# Assuming this is a clean install 
❯ v install git@github.com:vlang/vsl
...

# Checking the url it should be the installed ssh address
❯ git -C ~/.vmodules/vsl ls-remote --get-url
git@github.com:vlang/vsl
❯ git ls-remote --refs ~/.vmodules/vsl
2cdb2dc2968f1e84ce01635ba8d5aa5dd11ecbb8        refs/heads/main
2cdb2dc2968f1e84ce01635ba8d5aa5dd11ecbb8        refs/remotes/origin/HEAD
2cdb2dc2968f1e84ce01635ba8d5aa5dd11ecbb8        refs/remotes/origin/main
```
```sh
# Installing with a .git ending and a version should work as well
❯ v install git@github.com:vlang/vsl.git@v0.1.50
Scanning `git@github.com:vlang/vsl.git@v0.1.50`...
Module `vsl` is already installed at `~/.vmodules/vsl`.
Replace it with `vsl@v0.1.50`? [Y/n]: 
Installing `vsl`...
Installed `vsl`.

❯ git ls-remote --refs ~/.vmodules/vsl
2f2bcc961982668c8685e2d999eaeb6b50920fce        refs/tags/v0.1.50
❯ git -C ~/.vmodules/vsl ls-remote --get-url
git@github.com:vlang/vsl.git
```



