### PR TITLE
vlib: fix http.delete() checking

### DIFF
--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -469,8 +469,8 @@ pub fn (mut h Header) delete(key CommonHeader) {
 
 // delete_custom deletes all values for a custom header key.
 pub fn (mut h Header) delete_custom(key string) {
-	for i, kv in h.data {
-		if kv.key == key {
+	for i := 0; i < h.cur_pos; i++ {
+		if h.data[i].key == key {
 			h.data[i] = HeaderKV{key, ''}
 		}
 	}

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -79,6 +79,13 @@ fn test_header_delete_not_existing() {
 	// assert h.keys.len == 0
 }
 
+fn test_delete_header() {
+	mut r := new_request(.get, '', '')
+	r.header.set(.authorization, 'foo')
+	r.header.delete(.authorization)
+	assert r.header.get(.authorization)! == ''
+}
+
 fn test_custom_header() {
 	mut h := new_header()
 	h.add_custom('AbC', 'dEf')!


### PR DESCRIPTION
Fix #20118

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5ffd874</samp>

Fix loop condition and improve performance in `Header.delete` method in `vlib/net/http/header.v`

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5ffd874</samp>

* Fix several issues with the `Header` struct and its methods ([link](https://github.com/vlang/v/pull/20131/files?diff=unified&w=0#diff-a9ae571002fb16f2a46112220c090c951d8d42b45eab6407e945accdb4ddbcf3L472-R473),                             F29L470
