### PR TITLE
cgen: fix array of array fixed assignment

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -429,8 +429,10 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				pos := g.out.len
 				g.expr(left)
 
-				if g.is_arraymap_set && g.arraymap_set_pos > 0 {
-					g.go_back_to(g.arraymap_set_pos)
+				if g.is_arraymap_set && g.arraymap_set_pos >= 0 {
+					if g.arraymap_set_pos > 0 {
+						g.go_back_to(g.arraymap_set_pos)
+					}
 					g.write(', &${v_var})')
 					g.is_arraymap_set = false
 					g.arraymap_set_pos = 0

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -224,10 +224,12 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 								else {}
 							}
 				*/
-				if need_wrapper {
-					g.write(', &(${elem_type_str}[]) { ')
-				} else {
-					g.write(', &')
+				if elem_sym.kind != .array_fixed {
+					if need_wrapper {
+						g.write(', &(${elem_type_str}[]) { ')
+					} else {
+						g.write(', &')
+					}
 				}
 			} else {
 				// `x[0] *= y`

--- a/vlib/v/tests/array_with_fixed_array_test.v
+++ b/vlib/v/tests/array_with_fixed_array_test.v
@@ -1,0 +1,16 @@
+fn fixed() [2]int {
+	return [9, 9]!
+}
+
+fn test_main() {
+	arr := [1, 2]!
+	mut net := [][2]int{len: 4}
+	net[1] = [1, 1]!
+	net[0] = net[1]
+	net[2] = arr
+	net[3] = fixed()
+	assert net[0] == [1, 1]!
+	assert net[1] == [1, 1]!
+	assert net[2] == [1, 2]!
+	assert net[3] == [9, 9]!
+}


### PR DESCRIPTION
Fix #20130
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4250f7c</samp>

Fix code generation bugs for array map assignments and add a test case. The fixes prevent segmentation faults and compilation errors when assigning values to array maps of different kinds, including fixed arrays. The test case is in `vlib/v/tests/array_with_fixed_array_test.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4250f7c</samp>

* Fix code generation for assigning values to array maps ([link](https://github.com/vlang/v/pull/20133/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL432-R435), [link](https://github.com/vlang/v/pull/20133/files?diff=unified&w=0#diff-b058bb59569048c240a2f2f23b2056f787c45090e2dbc97a8aaf00500734ded4L227-R232))
  - Avoid segmentation fault when array map is empty and key is not found ([link](https://github.com/vlang/v/pull/20133/files?diff=unified&w=0#diff-31c7c9b847a62c45af521abc66f9a2dd60f109a09bbd48b2bc7888c81eb4498bL432-R435))
  - Avoid compilation error when value is a fixed array ([link](https://github.com/vlang/v/pull/20133/files?diff=unified&w=0#diff-b058bb59569048c240a2f2f23b2056f787c45090e2dbc97a8aaf00500734ded4L227-R232))
* Add test case for array map of fixed arrays in `vlib/v/tests/array_with_fixed_array_test.v` ([link](https://github.com/vlang/v/pull/20133/files?diff=unified&w=0#diff-6df605b4c421900c031686e919c35e1e8b11b867cfb411d71008f30ed6d075f6R1-R16))
