### PR TITLE
checker: fix unwrap when generic structs are used as arguments in uncalled methods(fix #20132)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -900,6 +900,23 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 				generic_names := struct_sym.info.generic_types.map(c.table.sym(it).name)
 				node.typ = c.table.unwrap_generic_type(node.typ, generic_names, concrete_types)
 			}
+		} else if struct_sym.info.generic_types.len > 0
+			&& struct_sym.info.generic_types.len == struct_sym.info.concrete_types.len
+			&& c.table.cur_concrete_types.len == 0 {
+			parent_type := struct_sym.info.parent_type
+			parent_sym := c.table.sym(parent_type)
+			for method in parent_sym.methods {
+				generic_names := struct_sym.info.generic_types.map(c.table.sym(it).name)
+				for i, param in method.params {
+					if i == 0 || !param.typ.has_flag(.generic) {
+						continue
+					}
+					param_sym := c.table.sym(param.typ)
+					if param_sym.kind in [.struct_, .interface_, .sum_type] {
+						c.table.unwrap_generic_type(param.typ, generic_names, struct_sym.info.concrete_types)
+					}
+				}
+			}
 		}
 	}
 	return node.typ

--- a/vlib/v/tests/generics_struct_method_params_is_generics_struct_and_not_called_test.v
+++ b/vlib/v/tests/generics_struct_method_params_is_generics_struct_and_not_called_test.v
@@ -1,0 +1,17 @@
+struct Param[T] {
+}
+
+struct Struct[T] {
+}
+
+pub fn (s Struct[T]) method[T](p Param[T]) {
+}
+
+fn test_main() {
+	_ = Struct[int]{}
+	assert true
+	// NOTE:
+	// Do not test call Struct.method() here,
+	// to test unwrap of generic struct parameters when the method is not called.
+	// test results only need to can compile.
+}


### PR DESCRIPTION
1. Fixed #20132 
2. Add tests.

```v
import time

pub type EventListener[T] = fn (T) !

struct Chan[T] {
	c chan T
}

struct EventWaiter[T] {
	check ?fn (T) bool
	c &Chan[T]
}

pub struct EventController[T] {
mut:
	id int
	wait_fors map[int]EventWaiter[T]
	listeners map[int]EventListener[T]
}

fn (mut ec EventController[T]) generate_id() int {
	return ec.id++
}

@[params]
pub struct EmitOptions {
pub:
	error_handler ?fn (int, IError)
}

pub fn (mut ec EventController[T]) emit(e T, options EmitOptions) {
}

@[params]
pub struct EventWaitParams[T] {
pub:
	check ?fn (T) bool
	timeout ?time.Duration
}

pub fn (mut ec EventController[T]) wait[T](params EventWaitParams[T]) ?T {
	return none
}

pub fn (mut ec EventController[T]) override[T](listener EventListener[T]) EventController[T] {
	return ec
}

pub fn (mut ec EventController[T]) listen[T](listener EventListener[T]) EventController[T] {
	return ec
}

fn main() {
	ec := EventController[int]{}
}
```

outputs:
```
passed.
```
