### PR TITLE
checker: fix struct init update with generics(fix #20136)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -879,7 +879,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 			c.error('cannot use struct update syntax in compile time expressions', node.update_expr_pos)
 		} else if expr_sym.kind != .struct_ {
 			s := c.table.type_to_str(update_type)
-			c.error('expected123 struct, found `${s}`', node.update_expr.pos())
+			c.error('expected struct, found `${s}`', node.update_expr.pos())
 		} else if update_type != node.typ {
 			from_sym := c.table.sym(update_type)
 			to_sym := c.table.sym(node.typ)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -874,11 +874,12 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 	if node.has_update_expr {
 		update_type := c.expr(mut node.update_expr)
 		node.update_expr_type = update_type
+		expr_sym := c.table.final_sym(c.unwrap_generic(update_type))
 		if node.update_expr is ast.ComptimeSelector {
 			c.error('cannot use struct update syntax in compile time expressions', node.update_expr_pos)
-		} else if c.table.final_sym(update_type).kind != .struct_ {
+		} else if expr_sym.kind != .struct_ {
 			s := c.table.type_to_str(update_type)
-			c.error('expected struct, found `${s}`', node.update_expr.pos())
+			c.error('expected123 struct, found `${s}`', node.update_expr.pos())
 		} else if update_type != node.typ {
 			from_sym := c.table.sym(update_type)
 			to_sym := c.table.sym(node.typ)

--- a/vlib/v/tests/struct_init_update_with_generics_test.v
+++ b/vlib/v/tests/struct_init_update_with_generics_test.v
@@ -1,0 +1,20 @@
+struct Foo {
+	a      int
+	b      string
+	isbool bool
+}
+
+fn do[T](f T) T {
+	return T{
+		...f
+		isbool: true
+	}
+}
+
+fn test_main() {
+	foo := do(Foo{
+		a: 1
+		b: '2'
+	})
+	assert foo.a == 1 && foo.b == '2' && foo.isbool
+}


### PR DESCRIPTION
1. Fixed #20136 
2. Add tests.

```v
struct S1 {
	a int
	b string
	isbool bool
}

fn do[T](s T) {
	println(T{
		...s
		isbool: true
	})
}

fn main() {
	do(S1{
		a: 1
		b: '2'
	})
}
```

outputs:
```
Shoves-MacBook:temp shove$ ./a
S1{
    a: 1
    b: '2'
    isbool: true
}
```