### PR TITLE
checker: fix generic fn with generic fn call returning generic map (fix #20106)

### DIFF
--- a/examples/graphs/bellman-ford.v
+++ b/examples/graphs/bellman-ford.v
@@ -23,7 +23,7 @@ mut:
 
 // building a map of with all edges etc of a graph, represented from a matrix adjacency
 // Input: matrix adjacency --> Output: edges list of src, dest and weight
-fn build_map_edges_from_graph(g [][]int) map[int]EDGE {
+fn build_map_edges_from_graph[T](g [][]T) map[T]EDGE {
 	n := g.len // TOTAL OF NODES for this graph -- its dimensions
 	mut edges_map := map[int]EDGE{} // a graph represented by map of edges
 
@@ -52,8 +52,8 @@ fn print_sol(dist []int) {
 // The main function that finds shortest distances from src
 // to all other vertices using Bellman-Ford algorithm.  The
 // function also detects negative weight cycle
-fn bellman_ford(graph [][]int, src int) {
-	mut edges := build_map_edges_from_graph(graph)
+fn bellman_ford[T](graph [][]T, src int) {
+	mut edges := build_map_edges_from_graph[int](graph)
 	// this function was done to adapt a graph representation
 	// by a adjacency matrix, to list of adjacency (using a MAP)
 	n_edges := edges.len // number of EDGES

--- a/examples/graphs/bellman-ford.v
+++ b/examples/graphs/bellman-ford.v
@@ -23,7 +23,7 @@ mut:
 
 // building a map of with all edges etc of a graph, represented from a matrix adjacency
 // Input: matrix adjacency --> Output: edges list of src, dest and weight
-fn build_map_edges_from_graph[T](g [][]T) map[T]EDGE {
+fn build_map_edges_from_graph(g [][]int) map[int]EDGE {
 	n := g.len // TOTAL OF NODES for this graph -- its dimensions
 	mut edges_map := map[int]EDGE{} // a graph represented by map of edges
 
@@ -52,7 +52,7 @@ fn print_sol(dist []int) {
 // The main function that finds shortest distances from src
 // to all other vertices using Bellman-Ford algorithm.  The
 // function also detects negative weight cycle
-fn bellman_ford[T](graph [][]T, src int) {
+fn bellman_ford(graph [][]int, src int) {
 	mut edges := build_map_edges_from_graph(graph)
 	// this function was done to adapt a graph representation
 	// by a adjacency matrix, to list of adjacency (using a MAP)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1471,7 +1471,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 	}
 
 	if func.generic_names.len > 0 {
-		if has_generic {
+		if has_generic || node.concrete_types.any(it.has_flag(.generic)) {
 			if typ := c.table.resolve_generic_to_concrete(func.return_type, func.generic_names,
 				node.concrete_types)
 			{

--- a/vlib/v/tests/generics_with_generics_fn_return_generics_map_type_test.v
+++ b/vlib/v/tests/generics_with_generics_fn_return_generics_map_type_test.v
@@ -1,0 +1,28 @@
+fn generic1[K, V](a map[K]V) string {
+	t := expect_map[K, V](a)
+	dump(t)
+	return '${t}'
+}
+
+fn generic2[K, V](a map[K]V) string {
+	t := expect_map(a)
+	dump(t)
+	return '${t}'
+}
+
+fn expect_map[K, V](a map[K]V) map[K]V {
+	return a
+}
+
+fn main() {
+	a := {
+		'a': 1
+	}
+	b := {
+		1: 'a'
+	}
+	assert generic1(a) == "{'a': 1}"
+	assert generic1(b) == "{1: 'a'}"
+	assert generic2(a) == "{'a': 1}"
+	assert generic2(b) == "{1: 'a'}"
+}

--- a/vlib/v/tests/generics_with_generics_fn_return_generics_map_type_test.v
+++ b/vlib/v/tests/generics_with_generics_fn_return_generics_map_type_test.v
@@ -14,7 +14,7 @@ fn expect_map[K, V](a map[K]V) map[K]V {
 	return a
 }
 
-fn main() {
+fn test_generics_with_generics_fn_return_map_type() {
 	a := {
 		'a': 1
 	}

--- a/vlib/v/tests/multiple_generic_resolve_test.v
+++ b/vlib/v/tests/multiple_generic_resolve_test.v
@@ -9,16 +9,17 @@ fn pre_start[T, R](app T, config R) string {
 	return start(app, config.val)
 }
 
-fn start[T, R](app T, otherthing R) R {
+fn start[T, R](app T, otherthing R) string {
 	println(otherthing)
-	return otherthing
+	return '${otherthing}'
 }
 
-fn test_main() {
+fn test_multiple_generic_resolve() {
 	app := App{}
 	testval := 'hello'
 	config := Config[string]{
 		val: testval
 	}
+
 	assert pre_start(app, config) == 'hello'
 }


### PR DESCRIPTION
This PR fix generic fn with generic fn call returning generic map (fix #20106).

- Fix generic fn with generic fn call returning generic map.
- Add test.

```v
fn generic1[K,V](a map[K]V) string {
	t := expect_map[K, V](a)
	dump(t)
	return '${t}'
}

fn generic2[K,V](a map[K]V) string {
	t := expect_map(a)
	dump(t)
	return '${t}'
}

fn expect_map[K, V](a map[K]V) map[K]V {
	return a
}

fn main() {
	a := { 'a': 1 }
	b := { 1: 'a' }
	assert generic1(a) == "{'a': 1}"
	assert generic1(b) == "{1: 'a'}"
	assert generic2(a) == "{'a': 1}"
	assert generic2(b) == "{1: 'a'}"
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:3] t: {'a': 1}
[.\\tt1.v:3] t: {1: 'a'}
[.\\tt1.v:9] t: {'a': 1}
[.\\tt1.v:9] t: {1: 'a'}
```