### PR TITLE
tools.vpm: fix moving from temp to vmodules dir

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -133,11 +133,14 @@ fn (m Module) install() InstallResult {
 			return .failed
 		}
 	}
-	// TODO: use `os.mv` when working.
-	mv_cmd := $if windows { 'move' } $else { 'mv' }
-	os.execute_opt('${mv_cmd} ${os.quoted_path(m.tmp_path)} ${os.quoted_path(m.install_path)}') or {
-		vpm_error('failed to install `${m.name}`.', details: err.msg())
-		return .failed
+	os.mv(m.tmp_path, m.install_path) or {
+		// `os.mv` from the temp dir to the vmodules dir may fail on some linux systems.
+		// In such cases, fall back on the cli command `mv` for now.
+		vpm_log(@FILE_LINE, @FN, 'os.mv failed, trying cli command `mv` instead.')
+		os.execute_opt('mv ${os.quoted_path(m.tmp_path)} ${os.quoted_path(m.install_path)}') or {
+			vpm_error('failed to install `${m.name}`.', details: err.msg())
+			return .failed
+		}
 	}
 	return .installed
 }

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -134,10 +134,9 @@ fn (m Module) install() InstallResult {
 		}
 	}
 	os.mv(m.tmp_path, m.install_path) or {
-		// `os.mv` from the temp dir to the vmodules dir may fail on some linux systems.
-		// In such cases, fall back on the cli command `mv` for now.
-		vpm_log(@FILE_LINE, @FN, 'os.mv failed, trying cli command `mv` instead.')
-		os.execute_opt('mv ${os.quoted_path(m.tmp_path)} ${os.quoted_path(m.install_path)}') or {
+		// `os.mv` / `os.mv_by_cp` from the temp dir to the vmodules dir may fail on some linux systems.
+		// In such cases, fall back on `os.cp_app`.
+		os.cp_all(m.tmp_path, m.install_path, true) or {
 			vpm_error('failed to install `${m.name}`.', details: err.msg())
 			return .failed
 		}


### PR DESCRIPTION
For some V installations, e.g. when it's installed via the setup action in Windows CI, an `Access is denied` error might happen when trying to move from the temporary to the vmodules directory.

This is the reason why v-analyzer is currently failing. This regression should be fixed by this PR.

![Screenshot_20231211_140635](https://github.com/vlang/v/assets/34311583/05aa7675-f85e-4134-b9eb-0d6684f6cdf2)
ref.: https://github.com/ttytm/v-analyzer/actions/runs/7167557843/job/19513888974

In regular V CI when, when installing V from source, this issue doesn't happen:

![Screenshot_20231211_141015](https://github.com/vlang/v/assets/34311583/a0290160-1185-4735-8df8-13e6ae5d4c82)
ref.: https://github.com/ttytm/v/actions/runs/7167524975/job/19513788776
