### PR TITLE
x.vweb: fix large payload

### DIFF
--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -10,7 +10,7 @@ import strings
 import picoev
 
 // max read and write limits in bytes
-const max_read = 8096
+pub const max_read = 8096
 
 const max_write = 8096 * 2
 
@@ -493,11 +493,12 @@ fn handle_read[A, X](mut pv picoev.Picoev, mut params RequestParams, fd int) {
 			// request is incomplete wait until the socket becomes ready to read again
 			params.idx[fd] += n
 			// TODO: change this to a memcpy function?
-			req.data += buf.bytestr()
+			req.data += buf[0..n].bytestr()
 			params.incomplete_requests[fd] = req
 			return
 		} else {
 			// request is complete: n = bytes_to_read
+			params.idx[fd] += n
 			req.data += buf[0..n].bytestr()
 		}
 	}

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -10,8 +10,7 @@ import strings
 import picoev
 
 // max read and write limits in bytes
-pub const max_read = 8096
-
+const max_read = 8096
 const max_write = 8096 * 2
 
 // A type which doesn't get filtered inside templates

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -342,13 +342,11 @@ fn handle_write_file(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 
 	// TODO: use `sendfile` in linux for optimizations (?)
 	params.file_responses[fd].file.read_into_ptr(data, bytes_to_write) or {
-		eprintln('[vweb] error: read_into_ptr')
 		params.file_responses[fd].done()
 		pv.close_conn(fd)
 		return
 	}
 	actual_written := send_string_ptr(mut conn, data, bytes_to_write) or {
-		eprintln('[vweb] error: send_string_ptr')
 		params.file_responses[fd].done()
 		pv.close_conn(fd)
 		return
@@ -380,7 +378,6 @@ fn handle_write_string(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 	// pointer magic to start at the correct position in the buffer
 	data := unsafe { params.string_responses[fd].str.str + params.string_responses[fd].pos }
 	actual_written := send_string_ptr(mut conn, data, bytes_to_write) or {
-		eprintln('[vweb] error: string send ptr')
 		params.string_responses[fd].done()
 		pv.close_conn(fd)
 		return
@@ -598,7 +595,7 @@ fn handle_request[A, X](mut conn net.TcpConn, req http.Request, params &RequestP
 
 	// parse the URL, query and form data
 	mut url := urllib.parse(req.url) or {
-		eprintln('[vweb] error parsing path: ${err} "${req.url}"')
+		eprintln('[vweb] error parsing path "${req.url}": ${err}')
 		return none
 	}
 	query := parse_query_from_url(url)


### PR DESCRIPTION
x.vweb: fix large payload test

This pr adds missing bits of code to the request reading and string writing part of vweb. 

This pr also fixes a bug where more data would be read than the Content-Length headers value.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 66525ad</samp>

This pull request enhances the `vweb` module for web development with `v`. It fixes bugs, handles edge cases, and improves formatting and messages in `vlib/x/vweb/vweb.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 66525ad</samp>

*  Prevent errors and memory leaks when handling requests and responses ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L310-R314), [link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R467), [link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L479-R486), [link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L486-R497), [link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R532))
  - Check if string response is open before writing it to connection ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L310-R314))
  - Reset read buffer index to zero when receiving or aborting a request ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R467), [link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L479-R486))
  - Append only the needed bytes to request data when reading request body ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L486-R497))
  - Set string response open flag to true when generating a response ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R532))
* Improve error message when parsing request URL fails ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L590-R598))
  - Include the URL that caused the error in the message ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L590-R598))
* Remove empty line at the beginning of `vlib/x/vweb/vweb.v` ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L14))
  - Minor formatting improvement ([link](https://github.com/vlang/v/pull/20155/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L14))
