### PR TITLE
os: update mv fns, improve performance, add params struct to control overwrite behavior

### DIFF
--- a/cmd/tools/vbump.v
+++ b/cmd/tools/vbump.v
@@ -109,7 +109,7 @@ fn process_file(input_file string, options Options) ! {
 	os.rm(backup_file) or {}
 
 	// Rename the original to the backup.
-	os.mv(input_file, backup_file) or { return error('Failed to copy file: ${input_file}') }
+	os.mv(input_file, backup_file) or { return error('Failed to move file: ${input_file}') }
 
 	// Process the old file and write it back to the original.
 	os.write_file(input_file, new_lines.join_lines()) or {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -134,12 +134,8 @@ fn (m Module) install() InstallResult {
 		}
 	}
 	os.mv(m.tmp_path, m.install_path) or {
-		// `os.mv` / `os.mv_by_cp` from the temp dir to the vmodules dir may fail on some linux systems.
-		// In such cases, fall back on `os.cp_app`.
-		os.cp_all(m.tmp_path, m.install_path, true) or {
-			vpm_error('failed to install `${m.name}`.', details: err.msg())
-			return .failed
-		}
+		vpm_error('failed to install `${m.name}`.', details: err.msg())
+		return .failed
 	}
 	return .installed
 }

--- a/cmd/tools/vshader.v
+++ b/cmd/tools/vshader.v
@@ -309,6 +309,10 @@ fn download_shdc(opt Options) ! {
 	os.chmod(dtmp_path, 0o775)!
 	// Move downloaded file in place
 	os.mv(dtmp_path, file)!
+	if runtime_os in ['linux', 'macos'] {
+		// Use the .exe file ending to minimize platform friction.
+		os.mv(file, shdc)!
+	}
 	// Update internal version file
 	os.write_file(shdc_version_file, shdc_version)!
 }

--- a/cmd/tools/vshader.v
+++ b/cmd/tools/vshader.v
@@ -309,10 +309,6 @@ fn download_shdc(opt Options) ! {
 	os.chmod(dtmp_path, 0o775)!
 	// Move downloaded file in place
 	os.mv(dtmp_path, file)!
-	if runtime_os in ['linux', 'macos'] {
-		// Use the .exe file ending to minimize platform friction.
-		os.mv(file, shdc)!
-	}
 	// Update internal version file
 	os.write_file(shdc_version_file, shdc_version)!
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -139,7 +139,7 @@ pub fn mv_by_cp(source string, target string, opts MvParams) ! {
 // mv moves files or folders from `src` to `dst`.
 pub fn mv(source string, target string, opts MvParams) ! {
 	if !opts.overwrite && exists(target) {
-		return error('Destination path already exist')
+		return error('target path already exist')
 	}
 	rename(source, target) or { mv_by_cp(source, target, opts)! }
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -119,11 +119,16 @@ pub fn cp_all(src string, dst string, overwrite bool) ! {
 	}
 }
 
+@[params]
+pub struct MvParams {
+	overwrite bool = true
+}
+
 // mv_by_cp copies files or folders from `source` to `target`.
 // If copying is successful, `source` is deleted.
 // It may be used when the paths are not on the same mount/partition.
-pub fn mv_by_cp(source string, target string) ! {
-	cp_all(source, target, true)!
+pub fn mv_by_cp(source string, target string, opts MvParams) ! {
+	cp_all(source, target, opts.overwrite)!
 	if is_dir(source) {
 		rmdir_all(source)!
 		return
@@ -132,8 +137,20 @@ pub fn mv_by_cp(source string, target string) ! {
 }
 
 // mv moves files or folders from `src` to `dst`.
-pub fn mv(source string, target string) ! {
-	rename(source, target) or { mv_by_cp(source, target)! }
+pub fn mv(source string, target string, opts MvParams) ! {
+	if exists(target) {
+		if !opts.overwrite {
+			return error('Destination path already exist')
+		}
+		if source != target {
+			if is_dir(target) {
+				rmdir_all(target)!
+			} else {
+				rm(target)!
+			}
+		}
+	}
+	rename(source, target) or { mv_by_cp(source, target, opts)! }
 }
 
 // read_lines reads the file in `path` into an array of lines.

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -138,17 +138,8 @@ pub fn mv_by_cp(source string, target string, opts MvParams) ! {
 
 // mv moves files or folders from `src` to `dst`.
 pub fn mv(source string, target string, opts MvParams) ! {
-	if exists(target) {
-		if !opts.overwrite {
-			return error('Destination path already exist')
-		}
-		if source != target {
-			if is_dir(target) {
-				rmdir_all(target)!
-			} else {
-				rm(target)!
-			}
-		}
+	if !opts.overwrite && exists(target) {
+		return error('Destination path already exist')
 	}
 	rename(source, target) or { mv_by_cp(source, target, opts)! }
 }

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -955,7 +955,7 @@ fn test_reading_from_empty_file() {
 	os.rm(empty_file)!
 }
 
-fn move_across_partitions_using_function(f fn (src string, dst string) !) ! {
+fn move_across_partitions_using_function(f fn (src string, dst string, opts os.MvParams) !) ! {
 	bindfs := os.find_abs_path_of_executable('bindfs') or {
 		eprintln('skipping test_mv_by_cp, because bindfs was not present')
 		return


### PR DESCRIPTION
The `rename` command that is used as first attempt by the `os.mv` function, fails when the target path exists, as `rename` doesn't overwrite. Then it falls back to using `mv_by_cp` which does overwrite (means the current default behavior of `mv` is to overwrite via `mv_by_cp`), but `mv_by_cp` is less performant.

Trying to use a consistent non-overwriting behavior would result in a breaking change. 
Therefore, the PR leaves overwriting on by default - equivalent to the system command `mv`, but improves it's behavior to still use `rename` command when possible, and by allowing to disable overwriting via a params struct.


That the fallback towards overwriting by `mv_by_cp` happens quite often, becomes noticeable when disabling overwriting. E.g. CI runs:
- https://github.com/ttytm/v/actions/runs/7170254702
- https://github.com/ttytm/v/actions/runs/7170254683
- https://github.com/ttytm/v/actions/runs/7170254677

<details>
<summary><i>outdated</i></summary>

A performance example: if the target directory already exists, falling back to `os.mv_by_cp` is already less than 100% performant when just wanting to move 2 1mb files.

```v
const src = os.join_path_single(os.home_dir(), 'v_mv_test_src')
const dst = os.join_path_single(os.home_dir(), 'v_mv_test_dst')

fn create_tpaths() ! {
	os.mkdir_all(src)!
	// Create 2 1mb files.
	os.write_file(os.join_path(src, '1mb_file1.txt'), '0123456789'.repeat(100 * 1024))!
	os.write_file(os.join_path(src, '1mb_file2.txt'), '0123456789'.repeat(100 * 1024))!
}

sw := time.new_stopwatch()
for _ in 0 .. 100 {
	create_tpaths()!
	os.mv(src, dst)!
}
dump(sw.elapsed())
```
Current master:
```
[mv.v:38] sw.elapsed(): 480.736ms
```
PR changes:
```
[mv.v:38] sw.elapsed(): 189.677ms
```
</details>

The PR also does some other changes related to the `os.mv` command as incremental refactor.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4cdda23</samp>

Added an `overwrite` option to `os.mv` and `os.mv_by_cp` functions and improved their behavior across platforms and partitions. Simplified and fixed some tools that use these functions. Updated the corresponding test function.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4cdda23</samp>

*  Add `overwrite` parameter to `os.mv` and `os.mv_by_cp` functions to control whether the target should be overwritten if it exists ([link](https://github.com/vlang/v/pull/20156/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09L122-R131),[link](https://github.com/vlang/v/pull/20156/files?diff=unified&w=0#diff-22cbd2b89c947c466ed738615da52dbef8a6bdf9baa298188c21022a42bf8a09L135-R153),[link](https://github.com/vlang/v/pull/20156/files?diff=unified&w=0#diff-e57dbc0169caaeb484c8664d548a544e6d3ac6f058b80b051a669ab2a0831b59L958-R958))
*  Remove platform-specific code and fallback logic from `vshader` and `vpm` tools, since `os.mv` handles cross-partition and cross-platform cases consistently ([link](https://github.com/vlang/v/pull/20156/files?diff=unified&w=0#diff-b98d619a1fa4a68426d81135a8e5e8b699f96f3dd40e942cc895917a286ec70cL137-R138),[link](https://github.com/vlang/v/pull/20156/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L312-L315))
*  Fix error message in `vbump` tool to say 'move' instead of 'copy' ([link](https://github.com/vlang/v/pull/20156/files?diff=unified&w=0#diff-f01136dcc522d23eec9fe1f172a0694164aa00c81778ea7a2f4a95474d3c355aL112-R112))
