### PR TITLE
parser: fix an error message when initializing a struct from another module(fix #20141)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2926,7 +2926,26 @@ fn (mut p Parser) name_expr() ast.Expr {
 			return node
 		} else if is_option && p.tok.kind == .lsbr {
 			return p.array_init(is_option)
+		} else if !known_var && language == .v && p.peek_tok.kind == .dot && !p.pref.is_fmt {
+			peek_tok2 := p.peek_token(2)
+			peek_tok3 := p.peek_token(3)
+			mod = p.tok.lit
+			mut n := -1
+			for p.peek_token(n).kind == .dot && p.peek_token(n - 1).kind == .name {
+				mod = p.peek_token(n - 1).lit + '.' + mod
+				n -= 2
+			}
+			if peek_tok2.kind == .name && peek_tok2.lit.len > 0 && peek_tok2.lit[0].is_capital()
+				&& peek_tok3.kind == .lcbr
+				&& (mod.len > p.tok.lit.len || !p.known_import(p.tok.lit)) {
+				mut msg := 'unknown module `${mod}`'
+				if mod.len > p.tok.lit.len && p.known_import(p.tok.lit) {
+					msg += '; did you mean `${p.tok.lit}`?'
+				}
+				p.error_with_pos(msg, p.tok.pos())
+			}
 		}
+
 		ident := p.ident(language)
 		node = ident
 		p.add_defer_var(ident)

--- a/vlib/v/parser/tests/struct_init_from_another_mod_err.out
+++ b/vlib/v/parser/tests/struct_init_from_another_mod_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/struct_init_from_another_mod_err.vv:6:27: error: unknown module `rand.config`; did you mean `config`?
+    4 | fn main() {
+    5 |     mut a := [0, 1, 2]
+    6 |     rand.shuffle(mut a, rand.config.ShuffleConfigStruct{})!
+      |                              ~~~~~~
+    7 | }

--- a/vlib/v/parser/tests/struct_init_from_another_mod_err.vv
+++ b/vlib/v/parser/tests/struct_init_from_another_mod_err.vv
@@ -1,0 +1,7 @@
+import rand
+import rand.config
+
+fn main() {
+	mut a := [0, 1, 2]
+	rand.shuffle(mut a, rand.config.ShuffleConfigStruct{})!
+}


### PR DESCRIPTION
1. Fixed #20141
2. Add tests.

```v
import rand
import rand.config

fn main() {
	mut a := [0, 1, 2]
	rand.shuffle(mut a, rand.config.ShuffleConfigStruct{})!
}
```
outputs:
```
a.v:6:27: error: unknown module `rand.config`; did you mean `config`?
    4 | fn main() {
    5 |     mut a := [0, 1, 2]
    6 |     rand.shuffle(mut a, rand.config.ShuffleConfigStruct{})!
      |                              ~~~~~~
    7 | }
    8 |
```

```v
import rand

fn main() {
	mut a := [0, 1, 2]
	rand.shuffle(mut a, rand.config.ShuffleConfigStruct{})!
}
```
outputs:
```
a.v:5:27: error: unknown module `rand.config`
    3 | fn main() {
    4 |     mut a := [0, 1, 2]
    5 |     rand.shuffle(mut a, rand.config.ShuffleConfigStruct{})!
      |                              ~~~~~~
    6 | }
    7 |
```