### PR TITLE
x.vweb: reimplement csrf module

### DIFF
--- a/vlib/x/vweb/context.v
+++ b/vlib/x/vweb/context.v
@@ -10,14 +10,6 @@ enum ContextReturnType {
 	file
 }
 
-pub enum RedirectType {
-	moved_permanently  = int(http.Status.moved_permanently)
-	found              = int(http.Status.found)
-	see_other          = int(http.Status.see_other)
-	temporary_redirect = int(http.Status.temporary_redirect)
-	permanent_redirect = int(http.Status.permanent_redirect)
-}
-
 // The Context struct represents the Context which holds the HTTP request and response.
 // It has fields for the query, form, files and methods for handling the request and response
 pub struct Context {
@@ -221,12 +213,10 @@ pub fn (mut ctx Context) server_error(msg string) Result {
 }
 
 // Redirect to an url
-pub fn (mut ctx Context) redirect(url string, redirect_type RedirectType) Result {
-	status := http.Status(redirect_type)
-	ctx.res.set_status(status)
-
+pub fn (mut ctx Context) redirect(url string) Result {
+	ctx.res.set_status(.found)
 	ctx.res.header.add(.location, url)
-	return ctx.send_response_to_client('text/plain', status.str())
+	return ctx.send_response_to_client('text/plain', '302 Found')
 }
 
 // before_request is always the first function that is executed and acts as middleware

--- a/vlib/x/vweb/context.v
+++ b/vlib/x/vweb/context.v
@@ -10,6 +10,14 @@ enum ContextReturnType {
 	file
 }
 
+pub enum RedirectType {
+	moved_permanently  = int(http.Status.moved_permanently)
+	found              = int(http.Status.found)
+	see_other          = int(http.Status.see_other)
+	temporary_redirect = int(http.Status.temporary_redirect)
+	permanent_redirect = int(http.Status.permanent_redirect)
+}
+
 // The Context struct represents the Context which holds the HTTP request and response.
 // It has fields for the query, form, files and methods for handling the request and response
 pub struct Context {
@@ -213,10 +221,12 @@ pub fn (mut ctx Context) server_error(msg string) Result {
 }
 
 // Redirect to an url
-pub fn (mut ctx Context) redirect(url string) Result {
-	ctx.res.set_status(.found)
+pub fn (mut ctx Context) redirect(url string, redirect_type RedirectType) Result {
+	status := http.Status(redirect_type)
+	ctx.res.set_status(status)
+
 	ctx.res.header.add(.location, url)
-	return ctx.send_response_to_client('text/plain', '302 Found')
+	return ctx.send_response_to_client('text/plain', status.str())
 }
 
 // before_request is always the first function that is executed and acts as middleware

--- a/vlib/x/vweb/csrf/README.md
+++ b/vlib/x/vweb/csrf/README.md
@@ -1,0 +1,237 @@
+# Cross-Site Request Forgery (CSRF) protection
+
+This module implements the [double submit cookie][owasp] technique to protect routes 
+from CSRF attacks.
+
+CSRF is a type of attack that occurs when a malicious program/website (and others) causes
+a user's web browser to perform an action without them knowing. A web browser automatically sends
+cookies to a website when it performs a request, including session cookies. So if a user is
+authenticated on your website the website can not distinguish a forged request by a legitimate
+request.
+
+## When to not add CSRF-protection
+If you are creating a service that is intended to be used by other servers e.g. an API,
+you probably don't want CSRF-protection. An alternative would be to send an Authorization
+token in, and only in, an HTTP-header (like JSON Web Tokens). If you do that your website
+isn't vulnerable to CSRF-attacks.
+
+## Usage
+
+You can add `CsrfApp` to your own `App` struct to have the functions available 
+in your app's context, or you can use it with the middleware of vweb. 
+
+The advantage of the middleware approach is that you have to define
+the configuration separate from your `App`. This makes it possible to share the 
+configuration between modules or controllers.
+
+### Usage with the CsrfApp
+
+Change `secret` and `allowed_hosts` when creating the `CsrfApp`.
+
+**Example**:
+```v ignore
+module main
+
+import net.http
+import vweb
+import vweb.csrf
+
+struct App {
+	vweb.Context
+pub mut:
+	csrf csrf.CsrfApp [vweb_global]
+}
+
+fn main() {
+	app := &App{
+		csrf: csrf.CsrfApp{
+			// change the secret
+			secret: 'my-64bytes-secret'
+			// change to which domains you want to allow
+			allowed_hosts: ['*']
+		}
+	}
+	vweb.run(app, 8080)
+}
+
+pub fn (mut app App) index() vweb.Result {
+	// this line sets `app.token` and the cookie
+	app.csrf.set_token(mut app.Context)
+	return $vweb.html()
+}
+
+[post]
+pub fn (mut app App) auth() vweb.Result {
+	// this line protects the route against CSRF
+	app.csrf.protect(mut app.Context)
+	return app.text('authenticated!')
+}
+```
+
+index.html
+```html
+<form action="/auth" method="post">
+    <input type="hidden" name="@app.csrf.token_name" value="@app.csrf.token"/>
+    <label for="password">Your password:</label>
+    <input type="text" id="password" name="password" placeholder="Your password" />
+</form>
+```
+
+### Usage without CsrfApp
+If you use `vweb.Middleware` you can protect multiple routes at once.
+
+**Example**:
+```v ignore
+module main
+
+import net.http
+import vweb
+import vweb.csrf
+
+const (
+	// the configuration moved here
+	csrf_config = csrf.CsrfConfig{
+		// change the secret
+		secret: 'my-64bytes-secret'
+		// change to which domains you want to allow
+		allowed_hosts: ['*']
+	}
+)
+
+struct App {
+	vweb.Context
+pub mut:
+	middlewares map[string][]vweb.Middleware
+}
+
+fn main() {
+	app := &App{
+		middlewares: {
+			// protect all routes starting with the url '/auth'
+			'/auth': [csrf.middleware(csrf_config)]
+		}
+	}
+	vweb.run(app, 8080)
+}
+
+pub fn (mut app App) index() vweb.Result {
+	// get the token and set the cookie
+	csrftoken := csrf.set_token(mut app.Context, csrf_config)
+	return $vweb.html()
+}
+
+[post]
+pub fn (mut app App) auth() vweb.Result {
+	return app.text('authenticated!')
+}
+
+[post]
+pub fn (mut app App) register() vweb.Result {
+	// protect an individual route with the following line
+	csrf.protect(mut app.Context, csrf_config)
+	// ...
+}
+```
+
+index.html (the hidden input has changed)
+```html
+<form action="/auth" method="post">
+    <input type="hidden" name="@csrf_config.token_name" value="@csrftoken"/>
+    <label for="password">Your password:</label>
+    <input type="text" id="password" name="password" placeholder="Your password" />
+</form>
+```
+
+### Protect all routes
+It is possible to protect all routes against CSRF-attacks. Every request that is not 
+defined as a [safe method](#safe-methods) (`GET`, `OPTIONS`, `HEAD` by default)
+will have CSRF-protection.
+
+**Example**:
+```v ignore
+pub fn (mut app App) before_request() {
+	app.csrf.protect(mut app.Context)
+	// or if you don't use `CsrfApp`:
+	// csrf.protect(mut app.Context, csrf_config)
+}
+```
+
+## How it works
+This module implements the [double submit cookie][owasp] technique: a random token 
+is generated, the CSRF-token. The hmac of this token and the secret key is stored in a cookie.
+
+When a request is made, the CSRF-token should be placed inside a HTML form element. 
+The CSRF-token the hmac of the CSRF-token in the formdata is compared to the cookie.
+If the values match, the request is accepted.
+
+This approach has the advantage of being stateless: there is no need to store tokens on the server
+side and validate them. The token and cookie are bound cryptographically to each other so
+an attacker would need to know both values in order to make a CSRF-attack succeed. That
+is why is it important to **not leak the CSRF-token** via an url, or some other way.
+See [client side CSRF][client-side-csrf] for more information.
+
+This is a high level overview of the implementation.
+
+## Security Considerations
+
+### The secret key
+The secret key should be a random string that is not easily guessable. 
+The recommended size is 64 bytes.
+
+### Sessions
+If your app supports some kind of user sessions, it is recommended to cryptographically
+bind the CSRF-token to the users' session. You can do that by providing the name
+of the session ID cookie. If an attacker changes the session ID in the cookie, in the
+token or both the hmac will be different adn the request will be rejected.
+
+**Example**:
+```v ignore
+csrf_config = csrf.CsrfConfig{
+	// ...
+	session_cookie: 'my_session_id_cookie_name'
+}
+```
+
+### Safe Methods
+The HTTP methods `GET`, `OPTIONS`, `HEAD` are considered 
+[safe methods][mozilla-safe-methods] meaning they should not alter the state of
+an application. If a request with a "safe method" is made, the csrf protection will be skipped.
+
+You can change which methods are considered safe by changing `CsrfConfig.safe_methods`.
+
+### Allowed Hosts
+
+By default, both the http Origin and Referer headers are checked and matched strictly
+to the values in `allowed_hosts`. That means that you need to include each subdomain.
+
+If the value of `allowed_hosts` contains the wildcard: `'*'` the headers will not be checked.
+
+#### Domain name matching
+The following configuration will not allow requests made from `test.example.com`,
+only from `example.com`.
+
+**Example**
+```v ignore
+config := csrf.CsrfConfig{
+    secret: '...'
+    allowed_hosts: ['example.com']
+}
+```
+
+#### Referer, Origin header check
+In some cases (like if your server is behind a proxy), the Origin or Referer header will 
+not be present. If that is your case you can set `check_origin_and_referer` to `false`. 
+Request will now be accepted when the Origin *or* Referer header is valid.
+
+### Share csrf cookie with subdomains
+If you need to share the CSRF-token cookie with subdomains, you can set 
+`same_site` to `.same_site_lax_mode`.
+
+## Configuration
+
+All configuration options are defined in `CsrfConfig`.
+
+[//]: # (Sources)
+[owasp]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+[client-side-csrf]: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#client-side-csrf
+[mozilla-safe-methods]: https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP

--- a/vlib/x/vweb/csrf/csrf.v
+++ b/vlib/x/vweb/csrf/csrf.v
@@ -38,7 +38,7 @@ pub:
 	// how long the cookie stays valid in seconds. Default is 30 days
 	max_age       int = 60 * 60 * 24 * 30
 	cookie_domain string
-	// whether the cookie can be send only over hTTPS
+	// whether the cookie can be send only over HTTPS
 	secure bool
 }
 
@@ -51,8 +51,9 @@ pub mut:
 }
 
 // set_token generates a new csrf_token and adds a Cookie to the response
-pub fn (mut ctx CsrfContext) set_csrf_token[T](mut user_context T) {
+pub fn (mut ctx CsrfContext) set_csrf_token[T](mut user_context T) string {
 	ctx.csrf_token = set_token(mut user_context, ctx.config)
+	return ctx.csrf_token
 }
 
 pub fn (ctx &CsrfContext) clear_csrf_token[T](mut user_context T) {

--- a/vlib/x/vweb/csrf/csrf.v
+++ b/vlib/x/vweb/csrf/csrf.v
@@ -1,0 +1,225 @@
+module csrf
+
+import crypto.hmac
+import crypto.sha256
+import encoding.base64
+import net.http
+import net.urllib
+import rand
+import time
+import x.vweb
+
+@[params]
+pub struct CsrfConfig {
+pub:
+	secret string
+	// how long the random part of the csrf-token should be
+	nonce_length int = 64
+	// HTTP "safe" methods meaning they shouldn't alter state.
+	// If a request with any of these methods is made, `protect` will always return true
+	// https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1
+	safe_methods []http.Method = [.get, .head, .options]
+	// which hosts are allowed, enforced by checking the Origin and Referer header
+	// if allowed_hosts contains '*' the check will be skipped.
+	// Subdomains need to be included separately: a request from `"sub.example.com"`
+	//  will be rejected when `allowed_host = ['example.com']`.
+	allowed_hosts []string
+	// if set to true both the Referer and Origin headers must match `allowed_hosts`
+	// else if either one is valid the request is accepted
+	check_origin_and_referer bool = true
+	// the name of the csrf-token in the hidden html input
+	token_name string = 'csrftoken'
+	// the name of the cookie that contains the session id
+	session_cookie string
+	// cookie options
+	cookie_name string        = 'csrftoken'
+	same_site   http.SameSite = .same_site_strict_mode
+	cookie_path string        = '/'
+	// how long the cookie stays valid in seconds. Default is 30 days
+	max_age       int = 60 * 60 * 24 * 30
+	cookie_domain string
+	// whether the cookie can be send only over hTTPS
+	secure bool
+}
+
+pub struct CsrfContext {
+pub mut:
+	config CsrfConfig
+	exempt bool
+	// the csrftoken that should be placed in an html form
+	csrf_token string
+}
+
+// set_token generates a new csrf_token and adds a Cookie to the response
+pub fn (mut ctx CsrfContext) set_csrf_token[T](mut user_context T) {
+	ctx.csrf_token = set_token(mut user_context, ctx.config)
+}
+
+pub fn (ctx &CsrfContext) clear_csrf_token[T](mut user_context T) {
+	user_context.set_cookie(http.Cookie{
+		name: config.cookie_name
+		value: ''
+		max_age: 0
+	})
+}
+
+pub fn (ctx &CsrfContext) csrf_token_input() vweb.RawHtml {
+	return '<input type="hidden" name="${ctx.config.token_name}" value="${ctx.csrf_token}">'
+}
+
+pub fn middleware[T](config CsrfConfig) vweb.MiddlewareOptions[T] {
+	return vweb.MiddlewareOptions[T]{
+		after: false
+		handler: fn [config] [T](mut ctx T) bool {
+			ctx.config = config
+			if ctx.exempt {
+				return true
+			} else if ctx.req.method in config.safe_methods {
+				return true
+			} else {
+				return protect(mut ctx, config)
+			}
+		}
+	}
+}
+
+// set_token returns the csrftoken and sets an encrypted cookie with the hmac of
+// `config.get_secret` and the csrftoken
+pub fn set_token(mut ctx vweb.Context, config &CsrfConfig) string {
+	expire_time := time.now().add_seconds(config.max_age)
+	session_id := ctx.get_cookie(config.session_cookie) or { '' }
+
+	token := generate_token(expire_time.unix_time(), session_id, config.nonce_length)
+	cookie := generate_cookie(expire_time.unix_time(), token, config.secret)
+
+	// the hmac key is set as a cookie and later validated with `app.token` that must
+	// be in an html form
+	ctx.set_cookie(http.Cookie{
+		name: config.cookie_name
+		value: cookie
+		same_site: config.same_site
+		http_only: true
+		secure: config.secure
+		path: config.cookie_path
+		expires: expire_time
+		max_age: config.max_age
+	})
+
+	return token
+}
+
+// protect returns false and sends an http 401 response when the csrf verification
+// fails. protect will always return true if the current request method is in
+// `config.safe_methods`.
+pub fn protect(mut ctx vweb.Context, config &CsrfConfig) bool {
+	// if the request method is a "safe" method we allow the request
+	if ctx.req.method in config.safe_methods {
+		return true
+	}
+
+	// check origin and referer header
+	if check_origin_and_referer(ctx, config) == false {
+		request_is_invalid(mut ctx)
+		return false
+	}
+
+	// use the session id from the cookie, not from the csrftoken
+	session_id := ctx.get_cookie(config.session_cookie) or { '' }
+
+	actual_token := ctx.form[config.token_name] or {
+		request_is_invalid(mut ctx)
+		return false
+	}
+	// retrieve timestamp and nonce from csrftoken
+	data := base64.url_decode_str(actual_token).split('.')
+	println(data)
+	if data.len < 3 {
+		request_is_invalid(mut ctx)
+		return false
+	}
+
+	// check the timestamp from the csrftoken against the current time
+	// if an attacker would change the timestamp on the cookie, the token or both the
+	// hmac would also change.
+	now := time.now().unix_time()
+	expire_timestamp := data[0].i64()
+	if expire_timestamp < now {
+		// token has expired
+		request_is_invalid(mut ctx)
+		return false
+	}
+	nonce := data.last()
+	expected_token := base64.url_encode_str('${expire_timestamp}.${session_id}.${nonce}')
+
+	mut actual_hash := ctx.get_cookie(config.cookie_name) or {
+		request_is_invalid(mut ctx)
+		return false
+	}
+	// old_expire := actual_hash.all_before('.')
+	// actual_hash = actual_hash.replace_once (old_expire, expire_timestamp.str())
+
+	// generate new hmac based on information in the http request
+	expected_hash := generate_cookie(expire_timestamp, expected_token, config.secret)
+	eprintln(actual_hash)
+	eprintln(expected_hash)
+
+	// if the new hmac matches the cookie value the request is legit
+	if actual_hash != expected_hash {
+		request_is_invalid(mut ctx)
+		return false
+	}
+	eprintln('matching')
+
+	return true
+}
+
+// check_origin_and_referer validates the `Origin` and `Referer` headers.
+fn check_origin_and_referer(ctx vweb.Context, config &CsrfConfig) bool {
+	// wildcard allow all hosts NOT SAFE!
+	if '*' in config.allowed_hosts {
+		return true
+	}
+
+	// only match host and match the full domain name
+	// because lets say `allowed_host` = `['example.com']`.
+	// Attackers shouldn't be able to bypass this check with the domain `example.com.attacker.com`
+
+	origin := ctx.get_header(.origin) or { return false }
+	origin_url := urllib.parse(origin) or { urllib.URL{} }
+
+	valid_origin := origin_url.hostname() in config.allowed_hosts
+
+	referer := ctx.get_header(.referer) or { return false }
+	referer_url := urllib.parse(referer) or { urllib.URL{} }
+
+	valid_referer := referer_url.hostname() in config.allowed_hosts
+
+	if config.check_origin_and_referer {
+		return valid_origin && valid_referer
+	} else {
+		return valid_origin || valid_referer
+	}
+}
+
+// request_is_invalid sends an http 403 response
+fn request_is_invalid(mut ctx vweb.Context) {
+	ctx.res.set_status(.forbidden)
+	ctx.text('Forbidden: Invalid or missing CSRF token')
+}
+
+fn generate_token(expire_time i64, session_id string, nonce_length int) string {
+	nonce := rand.string_from_set('0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz',
+		nonce_length)
+	token := '${expire_time}.${session_id}.${nonce}'
+
+	return base64.url_encode_str(token)
+}
+
+// generate_cookie converts secret key based on the request context and a random
+// token into an hmac key
+fn generate_cookie(expire_time i64, token string, secret string) string {
+	hash := base64.url_encode(hmac.new(secret.bytes(), token.bytes(), sha256.sum, sha256.block_size))
+	cookie := '${expire_time}.${hash}'
+
+	return cookie
+}

--- a/vlib/x/vweb/csrf/csrf.v
+++ b/vlib/x/vweb/csrf/csrf.v
@@ -56,6 +56,7 @@ pub fn (mut ctx CsrfContext) set_csrf_token[T](mut user_context T) string {
 	return ctx.csrf_token
 }
 
+// clear the csrf token and cookie header from the context
 pub fn (ctx &CsrfContext) clear_csrf_token[T](mut user_context T) {
 	user_context.set_cookie(http.Cookie{
 		name: config.cookie_name
@@ -64,10 +65,12 @@ pub fn (ctx &CsrfContext) clear_csrf_token[T](mut user_context T) {
 	})
 }
 
+// csrf_token_input returns an HTML hidden input containing the csrf token
 pub fn (ctx &CsrfContext) csrf_token_input() vweb.RawHtml {
 	return '<input type="hidden" name="${ctx.config.token_name}" value="${ctx.csrf_token}">'
 }
 
+// middleware returns a handler that you can use with vweb's middleware
 pub fn middleware[T](config CsrfConfig) vweb.MiddlewareOptions[T] {
 	return vweb.MiddlewareOptions[T]{
 		after: false

--- a/vlib/x/vweb/csrf/csrf_test.v
+++ b/vlib/x/vweb/csrf/csrf_test.v
@@ -1,0 +1,375 @@
+import time
+import net.http
+import net.html
+import os
+import x.vweb
+import x.vweb.csrf
+
+const sport = 12385
+const localserver = '127.0.0.1:${sport}'
+const exit_after_time = 12000 // milliseconds
+
+const session_id_cookie_name = 'session_id'
+const csrf_config = &csrf.CsrfConfig{
+	secret: 'my-256bit-secret'
+	allowed_hosts: ['*']
+	session_cookie: session_id_cookie_name
+}
+
+const allowed_origin = 'example.com'
+const csrf_config_origin = &csrf.CsrfConfig{
+	secret: 'my-256bit-secret'
+	allowed_hosts: [allowed_origin]
+	session_cookie: session_id_cookie_name
+}
+
+// 			Test CSRF functions
+// =====================================
+
+fn test_set_token() {
+	mut ctx := vweb.Context{}
+
+	token := csrf.set_token(mut ctx, csrf_config)
+
+	cookie := ctx.header.get(.set_cookie) or { '' }
+	assert cookie.len != 0
+	assert cookie.starts_with('${csrf_config.cookie_name}=')
+}
+
+fn test_protect() {
+	mut ctx := vweb.Context{}
+
+	token := csrf.set_token(mut ctx, csrf_config)
+
+	mut cookie := ctx.header.get(.set_cookie) or { '' }
+	// get cookie value from "name=value;"
+	cookie = cookie.split(' ')[0].all_after('=').replace(';', '')
+
+	form := {
+		csrf_config.token_name: token
+	}
+	cookie_map := {
+		csrf_config.cookie_name: cookie
+	}
+	ctx = vweb.Context{
+		form: form
+		req: http.Request{
+			method: .post
+			cookies: cookie_map
+		}
+	}
+	valid := csrf.protect(mut ctx, csrf_config)
+
+	assert valid == true
+}
+
+fn test_timeout() {
+	timeout := 1
+	short_time_config := &csrf.CsrfConfig{
+		secret: 'my-256bit-secret'
+		allowed_hosts: ['*']
+		session_cookie: session_id_cookie_name
+		max_age: timeout
+	}
+
+	mut ctx := vweb.Context{}
+
+	token := csrf.set_token(mut ctx, short_time_config)
+
+	// after 2 seconds the cookie should expire (maxage)
+	time.sleep(2 * time.second)
+	mut cookie := ctx.header.get(.set_cookie) or { '' }
+	// get cookie value from "name=value;"
+	cookie = cookie.split(' ')[0].all_after('=').replace(';', '')
+
+	form := {
+		short_time_config.token_name: token
+	}
+	cookie_map := {
+		short_time_config.cookie_name: cookie
+	}
+	ctx = vweb.Context{
+		form: form
+		req: http.Request{
+			method: .post
+			cookies: cookie_map
+		}
+	}
+
+	valid := csrf.protect(mut ctx, short_time_config)
+
+	assert valid == false
+}
+
+fn test_valid_origin() {
+	// valid because both Origin and Referer headers are present
+	token, cookie := get_token_cookie('')
+
+	form := {
+		csrf_config.token_name: token
+	}
+	cookie_map := {
+		csrf_config.cookie_name: cookie
+	}
+
+	mut req := http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	req.add_header(.origin, 'http://${allowed_origin}')
+	req.add_header(.referer, 'http://${allowed_origin}/test')
+	mut ctx := vweb.Context{
+		form: form
+		req: req
+	}
+
+	mut valid := csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == true
+}
+
+fn test_invalid_origin() {
+	// invalid because either the Origin, Referer or neither are present
+	token, cookie := get_token_cookie('')
+
+	form := {
+		csrf_config.token_name: token
+	}
+	cookie_map := {
+		csrf_config.cookie_name: cookie
+	}
+
+	mut req := http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	req.add_header(.origin, 'http://${allowed_origin}')
+	mut ctx := vweb.Context{
+		form: form
+		req: req
+	}
+
+	mut valid := csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == false
+
+	req = http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	req.add_header(.referer, 'http://${allowed_origin}/test')
+	ctx = vweb.Context{
+		form: form
+		req: req
+	}
+
+	valid = csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == false
+
+	req = http.Request{
+		method: .post
+		cookies: cookie_map
+	}
+	ctx = vweb.Context{
+		form: form
+		req: req
+	}
+
+	valid = csrf.protect(mut ctx, csrf_config_origin)
+	assert valid == false
+}
+
+// 			Testing App
+// ================================
+
+struct App {
+	vweb.Context
+pub mut:
+	csrf        csrf.CsrfApp                 @[vweb_global]
+	middlewares map[string][]vweb.Middleware
+}
+
+pub fn (mut app App) index() vweb.Result {
+	app.csrf.set_token(mut app.Context)
+
+	return app.html('<form action="/auth" method="post">
+    <input type="hidden" name="${app.csrf.token_name}" value="${app.csrf.token}"/>
+    <label for="password">Your password:</label>
+    <input type="text"  id="password" name="password" placeholder="Your password" />
+</form>')
+}
+
+@[post]
+pub fn (mut app App) auth() vweb.Result {
+	app.csrf.protect(mut app.Context)
+
+	return app.ok('authenticated')
+}
+
+pub fn (mut app App) middleware_index() vweb.Result {
+	csrftoken := csrf.set_token(mut app.Context, csrf_config)
+
+	return app.html('<form action="/auth" method="post">
+    <input type="hidden" name="${csrf_config.token_name}" value="${csrftoken}"/>
+    <label for="password">Your password:</label>
+    <input type="text"  id="password" name="password" placeholder="Your password" />
+</form>')
+}
+
+@[post]
+pub fn (mut app App) middleware_auth() vweb.Result {
+	return app.ok('middleware authenticated')
+}
+
+// 			App cleanup function
+// ======================================
+
+pub fn (mut app App) shutdown() vweb.Result {
+	spawn app.exit_gracefully()
+	return app.ok('good bye')
+}
+
+fn (mut app App) exit_gracefully() {
+	eprintln('>> webserver: exit_gracefully')
+	time.sleep(100 * time.millisecond)
+	exit(0)
+}
+
+fn exit_after_timeout[T](mut app T, timeout_in_ms int) {
+	time.sleep(timeout_in_ms * time.millisecond)
+	eprintln('>> webserver: pid: ${os.getpid()}, exiting ...')
+	app.shutdown()
+
+	eprintln('App timed out!')
+	assert true == false
+}
+
+// 			Tests for the App
+// ======================================
+
+fn test_run_app_in_background() {
+	mut app := &App{
+		csrf: csrf.CsrfApp{
+			secret: 'my-256bit-secret'
+			allowed_hosts: [allowed_origin]
+			session_cookie: session_id_cookie_name
+		}
+		middlewares: {
+			'/middleware_auth': [csrf.middleware(csrf_config)]
+		}
+	}
+	spawn vweb.run_at(app, port: sport, family: .ip)
+	spawn exit_after_timeout(mut app, exit_after_time)
+
+	time.sleep(500 * time.millisecond)
+}
+
+fn test_token_with_app() {
+	res := http.get('http://${localserver}/') or { panic(err) }
+
+	mut doc := html.parse(res.body)
+	inputs := doc.get_tags_by_attribute_value('type', 'hidden')
+	assert inputs.len == 1
+	assert csrf_config.token_name == inputs[0].attributes['name']
+}
+
+fn test_token_with_middleware() {
+	res := http.get('http://${localserver}/middleware_index') or { panic(err) }
+
+	mut doc := html.parse(res.body)
+	inputs := doc.get_tags_by_attribute_value('type', 'hidden')
+	assert inputs.len == 1
+	assert csrf_config.token_name == inputs[0].attributes['name']
+}
+
+// utility function to check whether the route at `path` is protected against csrf
+fn protect_route_util(path string) {
+	mut req := http.Request{
+		method: .post
+		url: 'http://${localserver}/${path}'
+	}
+	mut res := req.do() or { panic(err) }
+	assert res.status() == .forbidden
+
+	// A valid request with CSRF protection should have a cookie session id,
+	// csrftoken in `app.form` and the hmac of that token in a cookie
+	session_id := 'user_session_id'
+	token, cookie := get_token_cookie(session_id)
+
+	header := http.new_header_from_map({
+		http.CommonHeader.origin:  'http://${allowed_origin}'
+		http.CommonHeader.referer: 'http://${allowed_origin}/route'
+	})
+
+	formdata := http.url_encode_form_data({
+		csrf_config.token_name: token
+	})
+
+	// session id is altered: test if session hijacking is possible
+	// if the session id the csrftoken changes so the cookie can't be validated
+	mut cookies := {
+		csrf_config.cookie_name: cookie
+		session_id_cookie_name:  'altered'
+	}
+
+	req = http.Request{
+		method: .post
+		url: 'http://${localserver}/${path}'
+		data: formdata
+		cookies: cookies
+		header: header
+	}
+
+	res = req.do() or { panic(err) }
+	assert res.status() == .forbidden
+
+	// Everything is valid now and the request should succeed
+	cookies[session_id_cookie_name] = session_id
+
+	req = http.Request{
+		method: .post
+		url: 'http://${localserver}/${path}'
+		data: formdata
+		cookies: cookies
+		header: header
+	}
+
+	res = req.do() or { panic(err) }
+	assert res.status() == .ok
+}
+
+fn test_protect_with_app() {
+	protect_route_util('/auth')
+}
+
+fn test_protect_with_middleware() {
+	protect_route_util('middleware_auth')
+}
+
+fn testsuite_end() {
+	// This test is guaranteed to be called last.
+	// It sends a request to the server to shutdown.
+	x := http.get('http://${localserver}/shutdown') or {
+		assert err.msg() == ''
+		return
+	}
+	assert x.status() == .ok
+	assert x.body == 'good bye'
+}
+
+// Utility functions
+
+fn get_token_cookie(session_id string) (string, string) {
+	mut ctx := vweb.Context{
+		req: http.Request{
+			cookies: {
+				session_id_cookie_name: session_id
+			}
+		}
+	}
+
+	token := csrf.set_token(mut ctx, csrf_config_origin)
+
+	mut cookie := ctx.header.get(.set_cookie) or { '' }
+	// get cookie value from "name=value;"
+	cookie = cookie.split(' ')[0].all_after('=').replace(';', '')
+	return token, cookie
+}

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -644,7 +644,7 @@ fn handle_route[A, X](mut app A, mut user_context X, url urllib.URL, host string
 		// execute middleware functions after vweb is done and before the response is send
 		mut was_done := true
 		$if A is MiddlewareApp {
-			if not_found == false && middleware_has_sent_response == false {
+			if !not_found && !middleware_has_sent_response {
 				// if the middleware doesn't send an alternate response, but only changes the
 				// response object we only have to check if the `done` was previously set to true
 				was_done = user_context.Context.done

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -290,6 +290,7 @@ pub fn run_at[A, X](mut global_app A, params RunParams) ! {
 		user_data: pico_context
 		timeout_secs: params.timeout_in_seconds
 		family: params.family
+		host: params.host
 	)
 
 	// Forever accept every connection that comes
@@ -637,12 +638,13 @@ fn handle_request[A, X](mut conn net.TcpConn, req http.Request, params &RequestP
 fn handle_route[A, X](mut app A, mut user_context X, url urllib.URL, host string, routes &map[string]Route) {
 	mut route := Route{}
 	mut middleware_has_sent_response := false
+	mut not_found := false
 
 	defer {
 		// execute middleware functions after vweb is done and before the response is send
 		mut was_done := true
 		$if A is MiddlewareApp {
-			if middleware_has_sent_response == false {
+			if not_found == false && middleware_has_sent_response == false {
 				// if the middleware doesn't send an alternate response, but only changes the
 				// response object we only have to check if the `done` was previously set to true
 				was_done = user_context.Context.done
@@ -779,7 +781,7 @@ fn handle_route[A, X](mut app A, mut user_context X, url urllib.URL, host string
 	}
 	// return 404
 	user_context.not_found()
-	route = Route{}
+	not_found = true
 	return
 }
 


### PR DESCRIPTION
This pr reimplements vwebs CSRF module.

The old module is not compatible, since the structure had to be changed. The csrf context is now placed on the Context struct instead of the App struct. Internally the module works the same.

This pr also fixes a few bugs in vweb2 that were needed for testing.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fd693e4</samp>

This pull request introduces a new csrf module for vweb, which provides CSRF protection for web applications. It adds the files `csrf.v`, `csrf_test.v`, and `README.md` to the `vlib/x/vweb/csrf` directory, and modifies the `vlib/x/vweb/vweb.v` file to add a host field and improve the middleware handling. It also includes unit tests and documentation for the csrf module.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fd693e4</samp>

*  Implement the csrf module for vweb, providing cross-site request forgery protection for vweb routes ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-e9b61f8f028fe086ee9aac37ec951c00e91e1806c5d6e676a257741c53c306eaR1-R226),[link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-3f5abe8af8790b11a38f2beaf5a27885efa6b67e1c23c9b9ec27c295881013b6L1-R229))
  - Define structs and functions for generating, setting, clearing, and validating CSRF tokens and cookies ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-e9b61f8f028fe086ee9aac37ec951c00e91e1806c5d6e676a257741c53c306eaR1-R226))
  - Provide a middleware function for enabling CSRF protection for vweb routes, and a protect function for manually checking CSRF tokens ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-e9b61f8f028fe086ee9aac37ec951c00e91e1806c5d6e676a257741c53c306eaR1-R226))
  - Add a README.md file explaining the module's purpose, usage, configuration, and security considerations, with code examples and links ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-3f5abe8af8790b11a38f2beaf5a27885efa6b67e1c23c9b9ec27c295881013b6L1-R229))
* Add unit tests for the csrf module, using a simple vweb app with a login form and a protected route ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-feeac722b7a6cdbdfefff0a1b7394cf6cf1a55bef4531cf192abcfcc64cfff85R1-R340))
  - Test the set_token, protect, and middleware functions, as well as the timeout, origin, and referer checks ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-feeac722b7a6cdbdfefff0a1b7394cf6cf1a55bef4531cf192abcfcc64cfff85R1-R340))
  - Use the `http`, `html`, and `os` modules for making requests, parsing responses, and exiting the app ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-feeac722b7a6cdbdfefff0a1b7394cf6cf1a55bef4531cf192abcfcc64cfff85R1-R340))
* Add the host field to the vweb.Params struct, allowing specifying the host name or IP address to listen on ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R293))
* Modify the vweb.run function to skip the middleware execution when the route is not found ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R641),[link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L645-R647),[link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L782-R784))
  - Add a not_found variable to track whether the requested route was not found ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1R641),[link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L782-R784))
  - Add the not_found check to the condition for executing the middleware handler, preventing it from overriding the 404 response or sending a response after the route handler ([link](https://github.com/vlang/v/pull/20160/files?diff=unified&w=0#diff-8a2a94050ea4c363ff61b07456262cbf29d18330480722e93850da23eba87da1L645-R647))
