### PR TITLE
tools.shader: simplify, remove redundancies

### DIFF
--- a/cmd/tools/vshader.v
+++ b/cmd/tools/vshader.v
@@ -57,8 +57,8 @@ const shdc_urls = {
 	'osx_a64': 'https://github.com/floooh/sokol-tools-bin/raw/${shdc_full_hash}/bin/osx_arm64/sokol-shdc'
 }
 const shdc_version_file = os.join_path(cache_dir, 'sokol-shdc.version')
-const shdc = shdc_exe()
-const shdc_exe_name = 'sokol-shdc.exe'
+const shdc_exe = os.join_path(cache_dir, 'sokol-shdc.exe')
+const shdc = shdc_exe
 
 struct Options {
 	show_help    bool
@@ -260,13 +260,6 @@ fn ensure_external_tools(opt Options) ! {
 	download_shdc(opt)!
 }
 
-// shdc_exe returns an absolute path to the `sokol-shdc` tool.
-// Please note that the tool isn't guaranteed to actually be present, nor is
-// it guaranteed that it can be invoked.
-fn shdc_exe() string {
-	return os.join_path(cache_dir, shdc_exe_name)
-}
-
 // download_shdc downloads the `sokol-shdc` tool to an OS specific cache directory.
 fn download_shdc(opt Options) ! {
 	// We want to use the same, runtime, OS type as this tool is invoked on.
@@ -284,7 +277,7 @@ fn download_shdc(opt Options) ! {
 	if opt.verbose {
 		eprintln('> update_to_shdc_version: ${update_to_shdc_version} | shdc_version: ${shdc_version}')
 	}
-	file := shdc_exe()
+	file := shdc_exe
 	if opt.verbose {
 		if shdc_version != update_to_shdc_version && os.exists(file) {
 			eprintln('${tool_name} updating sokol-shdc to version ${shdc_version} ...')


### PR DESCRIPTION
related to: https://github.com/vlang/v/pull/20156#discussion_r1424611497

Viewing the changes split into the two commits, makes it hopefully easier two spot the unnecessary compilation and redundancy.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3b79958</samp>

Refactored `vshader.v` to streamline sokol shader compilation. Removed unnecessary code and made it platform-independent.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3b79958</samp>

*  Rename `shdc` variable to `shdc_exe` for clarity and consistency ([link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L60-R60), [link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L195-R194), [link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L241-R251))
*  Remove redundant `shdc_exe` function and inline its body ([link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L263-L269), [link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L287-R280))
*  Replace `file` variable with `shdc_exe` and simplify `os.mv` logic ([link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L295-R290), [link](https://github.com/vlang/v/pull/20161/files?diff=unified&w=0#diff-ad94daebf44540a9d25a53abaa5ac2f82093ea50b0fdefe0d8cea13c115dc565L311-R302))
