### PR TITLE
cgen: fix wrong cname of anon fn(fix #20163)

### DIFF
--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -113,9 +113,9 @@ fn (mut g Gen) fn_var_signature(return_type ast.Type, arg_types []ast.Type, var_
 	return sig
 }
 
-// generate anon fn cname, e.g. `anon_fn_void_int_string`
+// generate anon fn cname, e.g. `anon_fn_void_int_string`, `anon_fn_void_int_ptr_string`
 fn (mut g Gen) anon_fn_cname(return_type ast.Type, arg_types []ast.Type) string {
-	ret_styp := c_name(g.typ(return_type))
+	ret_styp := c_name(g.typ(return_type).replace('*', '_ptr'))
 	mut sig := '${ret_styp}_'
 	for j, arg_typ in arg_types {
 		arg_sym := g.table.sym(arg_typ)
@@ -124,7 +124,7 @@ fn (mut g Gen) anon_fn_cname(return_type ast.Type, arg_types []ast.Type) string 
 			arg_sig := g.anon_fn_cname(func.return_type, func.params.map(it.typ))
 			sig += 'fnon_fn_' + arg_sig
 		} else {
-			arg_styp := c_name(g.typ(arg_typ))
+			arg_styp := c_name(g.typ(arg_typ).replace('*', '_ptr'))
 			sig += arg_styp
 		}
 		if j < arg_types.len - 1 {

--- a/vlib/v/tests/anon_fn_test.v
+++ b/vlib/v/tests/anon_fn_test.v
@@ -41,3 +41,16 @@ fn test_anon_fn_returning_a_mut_parameter_should_act_the_same_as_normal_fn_retur
 	y := fnormal(mut b, 123)
 	assert a == b
 }
+
+// for issue 20163
+struct Struct {}
+
+fn test_spawn_anon_fn_with_closure_parameters_and_mut_ref_parameters() {
+	mut s := &Struct{}
+	a := 1
+
+	t := spawn fn [a] (mut s Struct) int {
+		return a
+	}(mut s)
+	assert t.wait() == 1
+}


### PR DESCRIPTION
1. Fixed #20163 
2. Add tests.

```v
import net

fn main() {
	mut conn := &net.TcpConn{}
	a := 1

	t := spawn fn [a] (mut conn net.TcpConn) int {
		return a
	}(mut conn)

	println(t.wait())
}
```
outputs:
```
1
```