### PR TITLE
cgen: fix smartcast for struct fields(fix #20167)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2479,8 +2479,10 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 					}
 				}
 			} else if expr is ast.SelectorExpr {
-				if _ := scope.find_struct_field(expr.expr.str(), expr.expr_type, expr.field_name) {
-					is_already_sum_type = true
+				if v := scope.find_struct_field(expr.expr.str(), expr.expr_type, expr.field_name) {
+					if v.smartcasts.len > 0 && unwrapped_expected_type == v.orig_type {
+						is_already_sum_type = true
+					}
 				}
 			}
 			if is_already_sum_type && !g.inside_return {

--- a/vlib/v/tests/match_smartcast_test.v
+++ b/vlib/v/tests/match_smartcast_test.v
@@ -97,3 +97,23 @@ fn test_match_mut_selector() {
 		}
 	}
 }
+
+// for issue 20167
+type Any_1 = f64 | int | string
+type Any_2 = int | string
+
+struct Struct {
+	field Any_2
+}
+
+fn test_branches_return_struct_field() {
+	any_2 := Struct{Any_2(42)}
+	m := {
+		'item1': Any_1('')
+		'item2': match any_2.field {
+			string { any_2.field }
+			int { any_2.field }
+		}
+	}
+	assert m['item2']! == Any_1(42)
+}


### PR DESCRIPTION
1. Fixed #20167
2. Add tests.

```v
import x.json2

type Foo = f64 | int | string

fn f(j map[string]json2.Any) {
	println(j['name'] or { return })
	assert (j['name'] or { return } as string) == 'foo'
}

struct Bar {
	foo Foo
}

fn g(bar Bar) {
	f({
		'name':  json2.Any('foo')
		'value': match bar.foo {
			string { bar.foo }
			int { bar.foo }
			f64 { bar.foo }
		}
	})
}

fn main() {
	g(Bar{
		foo: Foo(42)
	})
}
```
outputs:
```
foo
```