### PR TITLE
ast: fix fn/method mut array args dimension mismatch check(fix #20172)

### DIFF
--- a/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.out
@@ -1,7 +1,14 @@
-vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv:9:36: error: cannot use `string` as `array` in argument 2 to `os.write_file_array`
-    7 |
-    8 | fn main() {
-    9 |     os.write_file_array(service_path, service_file) or {
+vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv:7:36: error: cannot use `string` as `array` in argument 2 to `os.write_file_array`
+    5 | 
+    6 | fn main() {
+    7 |     os.write_file_array(service_path, service_file) or {
       |                                       ~~~~~~~~~~~~
-   10 |         eprintln('Error: write file service')
-   11 |         exit(1)
+    8 |         eprintln('Error: write file service')
+    9 |         exit(1)
+vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv:16:10: error: cannot use `&[]int` as `&[][]int` in argument 1 to `bar`
+   14 | // dimension checking error when mut array is passed multiple times as args
+   15 | fn foo(mut arr []int) {
+   16 |     bar(mut arr)
+      |             ~~~
+   17 | }
+   18 |

--- a/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv
@@ -1,13 +1,25 @@
 import os
 
-const (
-	service_file = '[Unit]'
-	service_path = 'dockerman.service'
-)
+const service_file = '[Unit]'
+const service_path = 'dockerman.service'
 
 fn main() {
 	os.write_file_array(service_path, service_file) or {
 		eprintln('Error: write file service')
 		exit(1)
 	}
+}
+
+// for issue 20172
+// dimension checking error when mut array is passed multiple times as args
+fn foo(mut arr []int) {
+	bar(mut arr)
+}
+
+fn bar(mut arr [][]int) {
+}
+
+fn baz() {
+	mut arr := [1, 2, 3]
+	foo(mut arr)
 }


### PR DESCRIPTION
1. Fixed #20172 
2. Add tests.

```v
fn foo(mut arr []int) {
	bar(mut arr)
}

fn bar(mut arr [][]int) {
}

fn main() {
	mut arr := [1, 2, 3]
	foo(mut arr)
}
```
outputs:
```
a.v:2:10: error: cannot use `&[]int` as `&[][]int` in argument 1 to `bar`
    1 | fn foo(mut arr []int) {
    2 |     bar(mut arr)
      |             ~~~~~
    3 | }
    4 |
```