### PR TITLE
ci: add vpm workflow

### DIFF
--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -15,7 +15,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-12]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: vlang
+      - name: Build V
+        if: runner.os != 'Windows'
+        run: cd vlang && make -j4 && ./v doctor
+      - name: Build V (Windows)
+        if: runner.os == 'Windows'
+        run: cd vlang && ./make.bat && ./v doctor
+      - name: Cache V
+        uses: actions/cache/save@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-${{ github.sha }}
+
   linux:
+    needs: setup
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -24,13 +47,16 @@ jobs:
     env:
       VFLAGS: -cc ${{ matrix.cc }} -d network
     steps:
-      - uses: actions/checkout@v4
-      - name: Build V
-        run: make -j4 && ./v doctor
+      - name: Restore V cache
+        uses: actions/cache/restore@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-${{ github.sha }}
       - name: Test
-        run: ./v test cmd/tools/vpm
+        run: cd vlang && ./v test cmd/tools/vpm
 
   windows:
+    needs: setup
     runs-on: windows-2019
     strategy:
       matrix:
@@ -39,19 +65,24 @@ jobs:
     env:
       VFLAGS: -cc ${{ matrix.cc }} -d network
     steps:
-      - uses: actions/checkout@v4
-      - name: Build V
-        run: ./make.bat -${{ matrix.cc }} && ./v doctor
+      - name: Restore V cache
+        uses: actions/cache/restore@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-${{ github.sha }}
       - name: Test
-        run: ./v test cmd/tools/vpm
+        run: cd vlang && ./v test cmd/tools/vpm
 
   macos:
+    needs: setup
     runs-on: macos-12
     env:
       VFLAGS: -d network
     steps:
-      - uses: actions/checkout@v4
-      - name: Build V
-        run: make -j4 && ./v doctor
+      - name: Restore V cache
+        uses: actions/cache/restore@v3
+        with:
+          path: vlang
+          key: ${{ runner.os }}-${{ github.sha }}
       - name: Test
-        run: ./v test cmd/tools/vpm
+        run: cd vlang && ./v test cmd/tools/vpm

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     paths:
       - '**/vpm_ci.yml'
-      - 'cmd/tools/vpm.yml'
+      - '**/cmd/tools/vpm/**'
   pull_request:
     paths:
       - '**/vpm_ci.yml'
-      - 'cmd/tools/vpm.yml'
+      - '**/cmd/tools/vpm/**'
 
 concurrency:
   group: vpm-ci-${{ github.event.pull_request.number || github.sha }}
@@ -26,10 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: |
-          make -j4
-          [[ ${{ matrix.cc }} != "tcc" ]] && ./v -cc ${{ matrix.cc }} -cg -cstrict -o v cmd/v
-          ./v doctor
+        run: make -j4 && ./v doctor
       - name: Test
         run: ./v test cmd/tools/vpm
 

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -11,7 +11,7 @@ on:
       - 'cmd/tools/vpm.yml'
 
 concurrency:
-  group: build-vpm-apps-${{ github.event.pull_request.number || github.sha }}
+  group: vpm-ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -1,0 +1,60 @@
+name: VPM CI
+
+on:
+  push:
+    paths:
+      - '**/vpm_ci.yml'
+      - 'cmd/tools/vpm.yml'
+  pull_request:
+    paths:
+      - '**/vpm_ci.yml'
+      - 'cmd/tools/vpm.yml'
+
+concurrency:
+  group: build-vpm-apps-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cc: [tcc, gcc, clang]
+      fail-fast: false
+    env:
+      VFLAGS: -cc ${{ matrix.cc }} -d network
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: |
+          make -j4
+          [[ ${{ matrix.cc }} != "tcc" ]] && ./v -cc ${{ matrix.cc }} -cg -cstrict -o v cmd/v
+          ./v doctor
+      - name: Test
+        run: ./v test cmd/tools/vpm
+
+  windows:
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        cc: [tcc, gcc, msvc]
+      fail-fast: false
+    env:
+      VFLAGS: -cc ${{ matrix.cc }} -d network
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: ./make.bat -${{ matrix.cc }} && ./v doctor
+      - name: Test
+        run: ./v test cmd/tools/vpm
+
+  macos:
+    runs-on: macos-12
+    env:
+      VFLAGS: -d network
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: make -j4 && ./v doctor
+      - name: Test
+        run: ./v test cmd/tools/vpm

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -37,47 +37,29 @@ jobs:
           path: vlang
           key: ${{ runner.os }}-${{ github.sha }}
 
-  linux:
+  test:
     needs: setup
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        cc: [tcc, gcc, clang]
+        include:
+          - os: ubuntu-20.04
+            cc: tcc
+          - os: ubuntu-20.04
+            cc: gcc
+          - os: ubuntu-20.04
+            cc: clang
+          - os: windows-2019
+            cc: tcc
+          - os: windows-2019
+            cc: gcc
+          - os: windows-2019
+            cc: msvc
+          - os: macos-12
+            cc: clang
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     env:
       VFLAGS: -cc ${{ matrix.cc }} -d network
-    steps:
-      - name: Restore V cache
-        uses: actions/cache/restore@v3
-        with:
-          path: vlang
-          key: ${{ runner.os }}-${{ github.sha }}
-      - name: Test
-        run: cd vlang && ./v test cmd/tools/vpm
-
-  windows:
-    needs: setup
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        cc: [tcc, gcc, msvc]
-      fail-fast: false
-    env:
-      VFLAGS: -cc ${{ matrix.cc }} -d network
-    steps:
-      - name: Restore V cache
-        uses: actions/cache/restore@v3
-        with:
-          path: vlang
-          key: ${{ runner.os }}-${{ github.sha }}
-      - name: Test
-        run: cd vlang && ./v test cmd/tools/vpm
-
-  macos:
-    needs: setup
-    runs-on: macos-12
-    env:
-      VFLAGS: -d network
     steps:
       - name: Restore V cache
         uses: actions/cache/restore@v3


### PR DESCRIPTION
Due to the recent addition of the requirement to add `-d network` to include VPM tests into test runs, there is no CI coverage for VPM. The tests are always skipped because there are no runners defining this flag.

This PR adds a VPM workflow. It only runs when VPM related files or the workflow file have been changed, so there is no additional overhead when other changes are made in the codebase.

https://github.com/ttytm/v/actions/runs/7212169683

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35077c7</samp>

Add a GitHub Actions workflow to run CI tests for `vpm` on different OS and C compilers. The workflow file is `.github/workflows/vpm_ci.yml`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35077c7</samp>

* Add a new workflow file for GitHub Actions to run CI tests for vpm (F0)
