### PR TITLE
gg: fix overlapping slices in `draw_slice_filled()`

### DIFF
--- a/examples/gg/arcs_and_slices.v
+++ b/examples/gg/arcs_and_slices.v
@@ -7,7 +7,10 @@ import math
 const win_width = 700
 const win_height = 800
 const bg_color = gx.white
-const colour = gx.black
+
+// A transparent color is used to aid in verifying that
+// rendering is precise on each of the the arc types (e.g. no overlapping or double rendered slices)
+const colour = gx.rgba(100, 100, 0, 100)
 
 enum Selection {
 	segs = 0
@@ -28,9 +31,7 @@ mut:
 }
 
 fn main() {
-	mut app := &App{
-		gg: 0
-	}
+	mut app := &App{}
 	app.gg = gg.new_context(
 		width: win_width
 		height: win_height

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -727,9 +727,7 @@ pub fn (ctx &Context) draw_slice_filled(x f32, y f32, radius f32, start_angle f3
 		xx *= rad_factor
 		yy *= rad_factor
 		sgl.v2f(xx + nx, yy + ny)
-		if i % 1 == 0 {
-			sgl.v2f(nx, ny)
-		}
+		sgl.v2f(nx, ny)
 	}
 	sgl.end()
 }

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -727,7 +727,7 @@ pub fn (ctx &Context) draw_slice_filled(x f32, y f32, radius f32, start_angle f3
 		xx *= rad_factor
 		yy *= rad_factor
 		sgl.v2f(xx + nx, yy + ny)
-		if i & 1 == 0 {
+		if i % 1 == 0 {
 			sgl.v2f(nx, ny)
 		}
 	}


### PR DESCRIPTION
Before this PR (using a transparent color instead of black):
![image](https://github.com/vlang/v/assets/768942/8403b384-f5b3-41f6-973b-41586ee86510)
After this PR:
![image](https://github.com/vlang/v/assets/768942/4e6c0bb2-3e2b-47e5-a1d6-4f4e4018ebc3)