### PR TITLE
net: fix windows constants to make them public for net.unix usage

### DIFF
--- a/vlib/net/net_windows.c.v
+++ b/vlib/net/net_windows.c.v
@@ -748,8 +748,8 @@ pub const error_einprogress = WsaError.wsaeinprogress
 #include <ws2tcpip.h>
 
 // Constants that windows needs
-const fionbio = C.FIONBIO
-const msg_nosignal = 0
+pub const fionbio = C.FIONBIO
+pub const msg_nosignal = 0
 const wsa_v22 = 0x202
 
 // Error code returns the last socket error


### PR DESCRIPTION
Following this post: [forum_discuss](https://github.com/vlang/v/discussions/20174)

It was not possible to use or compile code containing calls to the "_net.unix_" library on a **Windows environment** ( in my case, Windows 10). The errors encountered were:

**v/vlib/net/unix/stream.c.v:73:54: error: constant 'net.msg_nosignal' is private**
`C.photon_send(c.sock.handle, ptr, remaining, net.msg_nosignal, c.write_timeout)`

**v/vlib/net/unix/stream.c.v:75:47: error: constant 'net.msg_nosignal' is private**
`C.send(c.sock.handle, ptr, remaining, net.msg_nosignal)`

**v/vlib/net/unix/stream.c.v:380:47: error: constant 'net.fionbio' is private**
`net.socket_error(C.ioctlsocket(handle, net.fionbio, &t))!`

**v/vlib/net/unix/stream.c.v:493:47: error: constant 'net.fionbio' is private**
`net.socket_error(C.ioctlsocket(sockfd, net.fionbio, &t))!`

### Test code to replicate the error:

```
module main

import net.unix

fn main() {
	println("test")
}
```

To address these issues, the affected constants have been made public in **net_windows.c.v** file.

I did not add a test file as merely importing '_net.unix_' in the code was sufficient to trigger the previously mentioned errors. However, if required, I am ready to provide it.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->