### PR TITLE
v: implement _variant sumtype member to retrieve its current variant type idx

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1492,6 +1492,9 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		node.typ = ast.int_type
 		return ast.int_type
 	}
+	if sym.kind == .sum_type && field_name == '_variant' {
+		return ast.int_type
+	}
 	if sym.kind == .chan {
 		if field_name == 'closed' {
 			node.typ = ast.bool_type

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3706,6 +3706,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		info := sym.info as ast.ArrayFixed
 		g.write('${info.size}')
 		return
+	} else if sym.kind == .sum_type && node.field_name == '_variant' {
+		g.write('v_typeof_sumtype_idx_${sym.cname}(')
+		g.expr(node.expr)
+		g.write('._typ)')
+		return
 	} else if sym.kind == .chan && (node.field_name == 'len' || node.field_name == 'closed') {
 		g.write('sync__Channel_${node.field_name}(')
 		g.expr(node.expr)


### PR DESCRIPTION
This PR implements the follow feature:

```V
struct Test {
}
type TestSum = int | bool | Test

fn (t Test) test() {

}

fn main() {
	mut a := TestSum(Test{})
	println(a._variant) // 95
	a = 1
	println(a._variant) // 8
	a = false
	println(a._variant) // 19

	println(typeof[a]().idx) // 97
}
```

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c9ee6e1</samp>

This pull request adds support for accessing the `_variant` field of sum types in V. It modifies the `checker` and the `C generator` modules to handle this feature and generate the appropriate C code.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c9ee6e1</samp>

*  Add support for accessing the `_variant` field of sum types ([link](https://github.com/vlang/v/pull/20184/files?diff=unified&w=0#diff-22c1eb3704a15ee5526dec7b8cfe3f172f040b0aabfc682f2d76d55d174cac46R1495-R1497), [link](https://github.com/vlang/v/pull/20184/files?diff=unified&w=0#diff-1327b3543e8530b1f5a8352284a6ad6acd3565e323c845af1fb372d34faafcecR3709-R3713))
