### PR TITLE
parser: cleanup and simplify language parsing

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -327,14 +327,11 @@ fn (mut p Parser) parse_type_with_mut(is_mut bool) ast.Type {
 
 // Parses any language indicators on a type.
 fn (mut p Parser) parse_language() ast.Language {
-	language := if p.tok.lit == 'C' {
-		ast.Language.c
-	} else if p.tok.lit == 'JS' {
-		ast.Language.js
-	} else if p.tok.lit == 'WASM' {
-		ast.Language.wasm
-	} else {
-		ast.Language.v
+	language := match p.tok.lit {
+		'C' { ast.Language.c }
+		'JS' { ast.Language.js }
+		'WASM' { ast.Language.wasm }
+		else { ast.Language.v }
 	}
 	if language != .v {
 		p.next()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2534,14 +2534,11 @@ fn (mut p Parser) name_expr() ast.Expr {
 			pos: type_pos
 		}
 	}
-	language := if p.tok.lit == 'C' {
-		ast.Language.c
-	} else if p.tok.lit == 'JS' {
-		ast.Language.js
-	} else if p.tok.lit == 'WASM' {
-		ast.Language.wasm
-	} else {
-		ast.Language.v
+	language := match p.tok.lit {
+		'C' { ast.Language.c }
+		'JS' { ast.Language.js }
+		'WASM' { ast.Language.wasm }
+		else { ast.Language.v }
 	}
 	if language != .v {
 		p.check_for_impure_v(language, p.tok.pos())

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2534,17 +2534,19 @@ fn (mut p Parser) name_expr() ast.Expr {
 			pos: type_pos
 		}
 	}
-	mut language := ast.Language.v
-	if p.tok.lit == 'C' {
-		language = ast.Language.c
-		p.check_for_impure_v(language, p.tok.pos())
+	language := if p.tok.lit == 'C' {
+		ast.Language.c
 	} else if p.tok.lit == 'JS' {
-		language = ast.Language.js
-		p.check_for_impure_v(language, p.tok.pos())
+		ast.Language.js
 	} else if p.tok.lit == 'WASM' {
-		language = ast.Language.wasm
+		ast.Language.wasm
+	} else {
+		ast.Language.v
+	}
+	if language != .v {
 		p.check_for_impure_v(language, p.tok.pos())
 	}
+	p.check_for_impure_v(language, p.tok.pos())
 	is_option := p.tok.kind == .question
 	if is_option {
 		if p.peek_tok.kind in [.name, .lsbr] {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2546,7 +2546,6 @@ fn (mut p Parser) name_expr() ast.Expr {
 	if language != .v {
 		p.check_for_impure_v(language, p.tok.pos())
 	}
-	p.check_for_impure_v(language, p.tok.pos())
 	is_option := p.tok.kind == .question
 	if is_option {
 		if p.peek_tok.kind in [.name, .lsbr] {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -25,19 +25,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	} else {
 		p.check(.key_union)
 	}
-	language := if p.tok.lit == 'C' && p.peek_tok.kind == .dot {
-		ast.Language.c
-	} else if p.tok.lit == 'JS' && p.peek_tok.kind == .dot {
-		ast.Language.js
-	} else if p.tok.lit == 'WASM' && p.peek_tok.kind == .dot {
-		ast.Language.wasm
-	} else {
-		ast.Language.v
-	}
-	if language != .v {
-		p.next() // C || JS
-		p.next() // .
-	}
+	language := p.parse_language()
 	name_pos := p.tok.pos()
 	p.check_for_impure_v(language, name_pos)
 	if p.disallow_declarations_in_script_mode() {
@@ -522,17 +510,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		p.next()
 	}
 	p.next() // `interface`
-	language := if p.tok.lit == 'C' && p.peek_tok.kind == .dot {
-		ast.Language.c
-	} else if p.tok.lit == 'JS' && p.peek_tok.kind == .dot {
-		ast.Language.js
-	} else {
-		ast.Language.v
-	}
-	if language != .v {
-		p.next() // C || JS | WASM
-		p.next() // .
-	}
+	language := p.parse_language()
 	name_pos := p.tok.pos()
 	p.check_for_impure_v(language, name_pos)
 	if p.disallow_declarations_in_script_mode() {


### PR DESCRIPTION

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 38e6033</samp>

Refactor the parsing of function, struct, and interface languages in V. Use a common `parse_language` method in `fn.v` and `struct.v` to avoid duplication and simplify the code. Replace `mut` variables and multiple `if` statements with `if` expressions for readability and consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 38e6033</samp>

*  Refactor the parsing of the language of a function, type, struct, or interface declaration into a separate method `parse_language` that returns an `ast.Language` enum value ([link](https://github.com/vlang/v/pull/20185/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL252-R258), [link](https://github.com/vlang/v/pull/20185/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26L28-R28), [link](https://github.com/vlang/v/pull/20185/files?diff=unified&w=0#diff-1f4945733e641a12922380bf6de337090085f7a3a48cf55c3e5ecc2822f3bb26L525-R513))
* Simplify the assignment of the function name based on the language using an `if` expression instead of a `mut` variable and multiple `if` statements in `vlib/v/parser/fn.v` ([link](https://github.com/vlang/v/pull/20185/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL524-R523))
* Move the parsing of the language of a type declaration from `vlib/v/parser/parser.v` to `vlib/v/parser/fn.v` and use an `if` expression instead of a `mut` variable and multiple `if` statements ([link](https://github.com/vlang/v/pull/20185/files?diff=unified&w=0#diff-bef72e5d08800ef9a0aa7a624aa3eec78f9d58c92fcff32610a617b50db3bb54L2537-R2549))
* Remove the redundant code that consumes the dot token after the language name in `vlib/v/parser/fn.v` ([link](https://github.com/vlang/v/pull/20185/files?diff=unified&w=0#diff-5bbd1691768bfa52335b8117c8e1df2cd5da9f6e91375c2692605ad534fdac4eL277-L278))
