### PR TITLE
json: fix option sumtype handling

### DIFF
--- a/vlib/json/json_sumtype_test.v
+++ b/vlib/json/json_sumtype_test.v
@@ -1,0 +1,57 @@
+import json
+
+type Prices = Price | []Price
+
+pub struct ShopResponseData {
+	attributes Attributes
+}
+
+struct Attributes {
+	price ?Prices
+}
+
+struct Price {
+	net f64
+}
+
+fn test_main() {
+	data := '{"attributes": {"price": [{"net": 1, "_type": "Price"}, {"net": 2, "_type": "Price"}]}}'
+	entity := json.decode(ShopResponseData, data) or { panic(err) }
+	assert entity == ShopResponseData{
+		attributes: Attributes{
+			price: Prices([Price{
+				net: 1
+			}, Price{
+				net: 2
+			}])
+		}
+	}
+
+	data2 := '{"attributes": {"price": {"net": 1, "_type": "Price"}}}'
+	entity2 := json.decode(ShopResponseData, data2) or { panic(err) }
+	assert entity2 == ShopResponseData{
+		attributes: Attributes{
+			price: Prices(Price{
+				net: 1
+			})
+		}
+	}
+
+	data3 := json.encode(ShopResponseData{
+		attributes: Attributes{
+			price: Prices([Price{
+				net: 1.2
+			}])
+		}
+	})
+	assert data3 == '{"attributes":{"price":[{"net":1.2,"_type":"Price"}]}}'
+
+	entity3 := json.decode(ShopResponseData, data3) or { panic(err) }
+	assert entity3 == ShopResponseData{
+		attributes: Attributes{
+			price: Prices([Price{
+				net: 1.2
+			}])
+		}
+	}
+}


### PR DESCRIPTION
Fix #20181

```V
import json

type Prices = []Price | Price

pub struct ShopResponseData {
    attributes Attributes
}

struct Attributes {
    price ?Prices
}

struct Price {
    net f64
}

fn main() {
    data := '{"attributes": {"price": [{"net": 1, "_type": "Price"}, {"net": 2, "_type": "Price"}]}}'
    entity := json.decode(ShopResponseData, data) or { panic(err) }

    data2 := '{"attributes": {"price": {"net": 1, "_type": "Price"}}}'
    entity2 := json.decode(ShopResponseData, data2) or { panic(err) }


	data3 := json.encode(ShopResponseData{attributes: Attributes{price: Prices([Price{net:1.2}])}})
	println(data3)
	entity3 := json.decode(ShopResponseData, data3) or { panic(err) }
	println(entity3)

    println(entity)
    println(entity2)
	
}
```

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f83790b</samp>

Improve and fix `json_no_inline_sumtypes` flag for sumtypes. Add support for option sumtypes and struct variants in `vlib/v/gen/c/json.v`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f83790b</samp>

*  Fix bug and simplify code for encoding sumtypes with `json_no_inline_sumtypes` flag by removing unnecessary `else` branch ([link](https://github.com/vlang/v/pull/20186/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L394-R394))
*  Use `var_data` variable instead of `val` prefix for encoding sumtype variants that are time.Time or other structs to make code more consistent and avoid errors ([link](https://github.com/vlang/v/pull/20186/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L428-R426))
*  Add branch to handle decoding option sumtypes with `json_no_inline_sumtypes` flag by wrapping variant value in `_option_ok` call ([link](https://github.com/vlang/v/pull/20186/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L483-R483))
*  Check JSON value type when decoding sumtype variants that are structs and return appropriate type and option wrapping ([link](https://github.com/vlang/v/pull/20186/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48R549-R550), [link](https://github.com/vlang/v/pull/20186/files?diff=unified&w=0#diff-1067da5849e2cc623b0efeb705a1dfb35a5beb58d9e8972cde1dd2945bdc5d48L555-R563))
