### PR TITLE
v: implement $for comptime T.variants

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -107,6 +107,11 @@ pub:
 	typ         int
 }
 
+pub struct VariantData {
+pub:
+	typ int
+}
+
 pub struct EnumData {
 pub:
 	name  string

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1201,6 +1201,7 @@ pub enum ComptimeForKind {
 	fields
 	attributes
 	values
+	variants
 }
 
 pub struct ComptimeFor {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -869,5 +869,6 @@ pub fn (e ComptimeForKind) str() string {
 		.fields { return 'fields' }
 		.attributes { return 'attributes' }
 		.values { return 'values' }
+		.variants { return 'variants' }
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -109,6 +109,7 @@ mut:
 	vweb_gen_types                   []ast.Type // vweb route checks
 	timers                           &util.Timers = util.get_timers()
 	comptime_for_field_var           string
+	comptime_for_variant_var         string
 	comptime_fields_default_type     ast.Type
 	comptime_fields_type             map[string]ast.Type
 	comptime_for_field_value         ast.StructField // value of the field variable
@@ -137,6 +138,7 @@ mut:
 	goto_labels       map[string]ast.GotoLabel // to check for unused goto labels
 	enum_data_type    ast.Type
 	field_data_type   ast.Type
+	variant_data_type ast.Type
 	fn_return_type    ast.Type
 	orm_table_fields  map[string][]ast.StructField // known table structs
 	//

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -160,6 +160,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 									skip_state = c.check_compatible_types(c.unwrap_generic(c.comptime_for_method_ret_type),
 										right as ast.TypeNode)
 								}
+							} else if comptime_field_name == c.comptime_for_variant_var {
+								if left.field_name == 'typ' {
+									skip_state = c.check_compatible_types(c.comptime_fields_type['${c.comptime_for_variant_var}.typ'],
+										right as ast.TypeNode)
+								}
 							}
 						} else if left is ast.TypeNode {
 							is_comptime_type_is_expr = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -45,6 +45,7 @@ pub struct Gen {
 	pref                &pref.Preferences = unsafe { nil }
 	field_data_type     ast.Type // cache her to avoid map lookups
 	enum_data_type      ast.Type // cache her to avoid map lookups
+	variant_data_type   ast.Type // cache her to avoid map lookups
 	module_built        string
 	timers_should_print bool
 mut:

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -999,6 +999,25 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				i++
 			}
 		}
+	} else if node.kind == .variants {
+		if sym.info is ast.SumType {
+			if sym.info.variants.len > 0 {
+				g.writeln('\tVariantData ${node.val_var} = {0};')
+			}
+			g.inside_comptime_for_field = true
+			g.push_existing_comptime_values()
+			for variant in sym.info.variants {
+				g.comptime_for_field_var = node.val_var
+				g.comptime_var_type_map['${node.val_var}.typ'] = variant
+
+				g.writeln('/* variant ${i} */ {')
+				g.writeln('\t${node.val_var}.typ = ${variant.idx()};')
+				g.stmts(node.stmts)
+				g.writeln('}')
+				i++
+			}
+			g.pop_existing_comptime_values()
+		}
 	}
 	g.indent--
 	g.writeln('}// \$for')

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -335,6 +335,14 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 			})
 			kind = .fields
 		}
+		'variants' {
+			p.scope.register(ast.Var{
+				name: val_var
+				typ: p.table.find_type_idx('VariantData')
+				pos: var_pos
+			})
+			kind = .variants
+		}
 		'attributes' {
 			p.scope.register(ast.Var{
 				name: val_var
@@ -344,7 +352,7 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 			kind = .attributes
 		}
 		else {
-			p.error_with_pos('unknown kind `${for_val}`, available are: `methods`, `fields`, `values`, or `attributes`',
+			p.error_with_pos('unknown kind `${for_val}`, available are: `methods`, `fields`, `values`, `variants` or `attributes`',
 				p.prev_tok.pos())
 			return ast.ComptimeFor{}
 		}

--- a/vlib/v/parser/tests/comptime_unknown_meta_kind_err.out
+++ b/vlib/v/parser/tests/comptime_unknown_meta_kind_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/comptime_unknown_meta_kind_err.vv:7:20: error: unknown kind `abcde`, available are: `methods`, `fields`, `values`, or `attributes`
+vlib/v/parser/tests/comptime_unknown_meta_kind_err.vv:7:20: error: unknown kind `abcde`, available are: `methods`, `fields`, `values`, `variants` or `attributes`
     5 | 
     6 | fn test_main() {
     7 |     $for item in Test.abcde {


### PR DESCRIPTION
Fix #20176

```V
type TestSum = int | string

fn gen[T](val T) {
    $if val is $sumtype {
        $for f in T.variants {
            dump(f)
            dump(f.typ)
            $if f.typ is $int {
                dump('is int')
            } $else $if f.typ is string {
                dump('is string')
            }
        }
    }
}

fn main() {
    a := TestSum(123)
    gen(a)
}
```

copilot:summary

copilot:walkthrough
