### PR TITLE
checker: fix incorrect checks when struct fields are ref and option type(fix #19555)

### DIFF
--- a/vlib/json/json_encode_recursive_ptr_test.v
+++ b/vlib/json/json_encode_recursive_ptr_test.v
@@ -9,7 +9,7 @@ struct PostTag {
 }
 
 fn test_main() {
-	new_post_tag := PostTag{}
+	new_post_tag := &PostTag{}
 	assert json.encode(new_post_tag) == '{"id":"","visibility":"","createdAt":"","metadata":""}'
 
 	new_post_tag2 := PostTag{

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -704,8 +704,9 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 							c.error('reference field must be initialized with reference',
 								init_field.pos)
 						}
-					} else if exp_type.is_pointer() && !got_type.is_any_kind_of_pointer()
-						&& !got_type.is_int() {
+					} else if exp_type.is_any_kind_of_pointer()
+						&& !got_type.is_any_kind_of_pointer() && !got_type.is_int()
+						&& (!exp_type.has_flag(.option) || got_type.idx() != ast.none_type_idx) {
 						got_typ_str := c.table.type_to_str(got_type)
 						exp_typ_str := c.table.type_to_str(exp_type)
 						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',

--- a/vlib/v/checker/tests/struct_field_init_option_ref_err.out
+++ b/vlib/v/checker/tests/struct_field_init_option_ref_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_init_option_ref_err.vv:12:3: error: cannot assign to field `field`: expected a pointer `?&Foo`, but got `?Foo`
+   10 |     foo := ?Foo{}
+   11 |     _ := Bar{
+   12 |         field: foo
+      |         ~~~~~~~~~~
+   13 |     }
+   14 | }

--- a/vlib/v/checker/tests/struct_field_init_option_ref_err.vv
+++ b/vlib/v/checker/tests/struct_field_init_option_ref_err.vv
@@ -1,0 +1,14 @@
+module main
+
+struct Foo {}
+
+struct Bar {
+	field ?&Foo
+}
+
+fn main() {
+	foo := ?Foo{}
+	_ := Bar{
+		field: foo
+	}
+}


### PR DESCRIPTION
1. Fixed #19555
2. Add tests.

```v
module main
import rand

struct MyType {
	foo string
}

struct TypeWithOption {
	maybe ?&MyType
}

fn main() {
	println("trying...")
	x := rand.int()

	ptr := if x > 0 {
		?MyType(MyType{foo:"bar"})
	} else {
		?MyType(none)
	}

	container := TypeWithOption{maybe: ptr} // Expects ?&MyType, not ?MyType. Sema doesn't catch this, I guess.
	println("success!")
	println(container)
}
```
outputs:
```
a.v:22:30: error: cannot assign to field `maybe`: expected a pointer `?&MyType`, but got `?MyType`
   20 |     }
   21 | 
   22 |     container := TypeWithOption{maybe: ptr} // Expects ?&MyType, not ?MyType. Sema doesn't catch this, I guess.
      |                                 ~~~~~~~~~~
   23 |     println("success!")
   24 |     println(container)
```
```