### PR TITLE
cgen: fix string interp with zero characters(fix #20199)

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -263,7 +263,8 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 	g.write(' str_intp(${node.vals.len}, ')
 	g.write('_MOV((StrIntpData[]){')
 	for i, val in node.vals {
-		escaped_val := util.smart_quote(val, false)
+		mut escaped_val := util.smart_quote(val, false)
+		escaped_val = escaped_val.replace('\0', '\\0')
 
 		if escaped_val.len > 0 {
 			g.write('{_SLIT("${escaped_val}"), ')

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -217,3 +217,12 @@ fn test_intp_pointer_specifier_p() {
 	str2 := '${&foo:p}'
 	assert str1 == str2
 }
+
+// for issue: 20199
+// string contains the zero character: `\0`
+fn test_contains_zero_characters() {
+	mut str := 'abc'
+	str = '${str}\x00${str}'
+	assert str.len == 7
+	assert str == 'abc\0abc'
+}


### PR DESCRIPTION
1. Fixed #20199 
2. Add tests.

```v
module main

fn main() {
	test := 'test'
	println("$test\x00$test")
	println("$test\x00$test".len)
	println("$test\x00$test".bytes())
}
```

outputs:
```
testtest
9
[116, 101, 115, 116, 0, 116, 101, 115, 116]
```
