### PR TITLE
parser: fix formatting struct decl with comments (fix #20202)

### DIFF
--- a/vlib/v/fmt/tests/struct_decl_with_comments_expected.vv
+++ b/vlib/v/fmt/tests/struct_decl_with_comments_expected.vv
@@ -1,0 +1,3 @@
+struct ABC { // size: 0x1=1 (source) (123 45 67) 20B
+	ff [0x20]u8
+}

--- a/vlib/v/fmt/tests/struct_decl_with_comments_input.vv
+++ b/vlib/v/fmt/tests/struct_decl_with_comments_input.vv
@@ -1,0 +1,4 @@
+struct ABC  //size: 0x1=1 (source) (123 45 67) 20B
+{
+        ff[0x20]                u8
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -52,6 +52,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 		p.table.reset_parsing_type()
 	}
 	generic_types, _ := p.parse_generic_types()
+	mut pre_comments := p.eat_comments()
 	no_body := p.tok.kind != .lcbr
 	if language == .v && no_body {
 		p.error('`${p.tok.lit}` lacks body')
@@ -93,11 +94,10 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 	mut is_field_pub := false
 	mut is_field_global := false
 	mut last_line := p.prev_tok.pos().line_nr + 1
-	mut pre_comments := []ast.Comment{}
 	mut end_comments := []ast.Comment{}
 	if !no_body {
 		p.check(.lcbr)
-		pre_comments = p.eat_comments()
+		pre_comments << p.eat_comments()
 		mut i := 0
 		for p.tok.kind != .rcbr {
 			mut comments := []ast.Comment{}


### PR DESCRIPTION
This PR fix formatting struct decl with comments (fix #20202).

- Fix formatting struct decl with comments.
- Add test.

```v
struct ABC  //size: 0x1=1 (source) (123 45 67) 20B
{
        ff[0x20]                u8
}
```
fmt to:
```v
struct ABC { // size: 0x1=1 (source) (123 45 67) 20B
	ff [0x20]u8
}
```