### PR TITLE
vpm.tools: add parse functions to handle module updates

### DIFF
--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -4,10 +4,6 @@ import os
 import sync.pool
 import v.help
 
-struct UpdateSession {
-	idents []string
-}
-
 pub struct UpdateResult {
 mut:
 	success bool
@@ -17,61 +13,60 @@ fn vpm_update(query []string) {
 	if settings.is_help {
 		help.print_and_exit('update')
 	}
-	idents := if query.len == 0 {
-		get_installed_modules()
+	mut p := Parser{}
+	if query.len == 0 {
+		p.parse_outdated()
 	} else {
-		query.clone()
+		p.parse_update_query(query)
 	}
+	// In case dependencies have changed, new modules may need to be installed.
+	mut to_update, mut to_install := []Module{}, []Module{}
+	for m in p.modules.values() {
+		if m.is_installed {
+			to_update << m
+		} else {
+			to_install << m
+		}
+	}
+	if to_update.len == 0 {
+		if p.errors > 0 {
+			exit(1)
+		} else {
+			println('All modules are up to date.')
+			exit(0)
+		}
+	}
+	vpm_log(@FILE_LINE, @FN, 'Modules to update: ${to_update}')
+	vpm_log(@FILE_LINE, @FN, 'Modules to install: ${to_install}')
 	mut pp := pool.new_pool_processor(callback: update_module)
-	ctx := UpdateSession{idents}
-	pp.set_shared_context(ctx)
-	pp.work_on_items(idents)
+	pp.work_on_items(to_update)
 	mut errors := 0
 	for res in pp.get_results[UpdateResult]() {
 		if !res.success {
 			errors++
-			continue
 		}
 	}
-	if errors > 0 {
+	if to_install.len != 0 {
+		install_modules(to_install)
+	}
+	if p.errors > 0 || errors > 0 {
 		exit(1)
 	}
 }
 
 fn update_module(mut pp pool.PoolProcessor, idx int, wid int) &UpdateResult {
-	ident := pp.get_item[string](idx)
-	// Usually, the module `ident`ifier. `get_name_from_url` is only relevant for `v update <module_url>`.
-	name := get_name_from_url(ident) or { ident }
-	install_path := get_path_of_existing_module(ident) or {
-		vpm_error('failed to find path for `${name}`.', verbose: true)
-		return &UpdateResult{}
-	}
-	vcs := vcs_used_in_dir(install_path) or {
-		vpm_error('failed to find version control system for `${name}`.', verbose: true)
-		return &UpdateResult{}
-	}
-	vcs.is_executable() or {
-		vpm_error(err.msg())
-		return &UpdateResult{}
-	}
+	m := pp.get_item[Module](idx)
+	vcs := m.vcs or { settings.vcs }
 	args := vcs_info[vcs].args
-	cmd := [vcs.str(), args.path, os.quoted_path(install_path), args.update].join(' ')
-	vpm_log(@FILE_LINE, @FN, 'cmd: ${cmd}')
-	println('Updating module `${name}` in `${fmt_mod_path(install_path)}`...')
+	cmd := [vcs.str(), args.path, os.quoted_path(m.install_path), args.update].join(' ')
+	vpm_log(@FILE_LINE, @FN, '> cmd: ${cmd}')
+	println('Updating module `${m.name}` in `${fmt_mod_path(m.install_path)}`...')
 	res := os.execute_opt(cmd) or {
-		vpm_error('failed to update module `${name}` in `${install_path}`.', details: err.msg())
+		vpm_error('failed to update module `${m.name}` in `${m.install_path}`.', details: err.msg())
 		return &UpdateResult{}
 	}
-	vpm_log(@FILE_LINE, @FN, 'cmd output: ${res.output.trim_space()}')
-	if res.output.contains('Already up to date.') {
-		println('Skipped module `${ident}`. Already up to date.')
-	} else {
-		println('Updated module `${ident}`.')
-	}
+	vpm_log(@FILE_LINE, @FN, '>> output: ${res.output.trim_space()}')
 	// Don't bail if the download count increment has failed.
-	increment_module_download_count(name) or { vpm_error(err.msg(), verbose: true) }
-	ctx := unsafe { &UpdateSession(pp.get_shared_context()) }
-	vpm_log(@FILE_LINE, @FN, 'ident: ${ident}; ctx: ${ctx}')
-	resolve_dependencies(get_manifest(install_path), ctx.idents)
+	increment_module_download_count(m.name) or { vpm_error(err.msg(), verbose: true) }
 	return &UpdateResult{true}
 }

--- a/cmd/tools/vpm/update_test.v
+++ b/cmd/tools/vpm/update_test.v
@@ -1,4 +1,6 @@
 // vtest retry: 3
+module main
+
 import os
 import rand
 import test_utils
@@ -18,39 +20,75 @@ fn testsuite_end() {
 	os.rmdir_all(test_path) or {}
 }
 
-// Tests if `v update` detects installed modules and runs successfully.
 fn test_update() {
-	os.execute_or_exit('${v} install pcre')
-	os.execute_or_exit('${v} install nedpals.args')
-	os.execute_or_exit('${v} install https://github.com/spytheman/vtray')
+	for m in ['pcre', 'https://github.com/spytheman/vtray', 'nedpals.args', 'ttytm.webview'] {
+		os.execute_or_exit('${v} install ${m}')
+	}
+	// "outdate" some modules, by removing their last commit.
+	for m in ['pcre', 'vtray', os.join_path('nedpals', 'args')] {
+		path := os.join_path(test_path, m)
+		os.execute_or_exit('git -C ${path} fetch --unshallow')
+		os.execute_or_exit('git -C ${path} reset --hard HEAD~')
+		assert is_outdated(path)
+	}
+	// Case: Run `v update` (without args).
 	res := os.execute('${v} update')
 	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `pcre`'), res.output
-	assert res.output.contains('Updating module `nedpals.args`'), res.output
 	assert res.output.contains('Updating module `vtray`'), res.output
-	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
+	assert res.output.contains('Updating module `nedpals.args`'), res.output
 	assert res.output.contains('Skipping download count increment for `pcre`.'), res.output
+	assert res.output.contains('Skipping download count increment for `nedpals.args`.'), res.output
+	assert !res.output.contains('Updating module `ttytm.webview`'), res.output
+	assert !res.output.contains('Skipping download count increment for `ttytm.webview`.'), res.output
+	for m in ['pcre', 'vtray', os.join_path('nedpals', 'args')] {
+		assert !is_outdated(os.join_path(test_path, m))
+	}
 }
 
-fn test_update_idents() {
-	mut res := os.execute('${v} update pcre')
+fn test_update_short_ident() {
+	os.execute_or_exit('git -C ${os.join_path(test_path, 'pcre')} reset --hard HEAD~')
+	res := os.execute('${v} update pcre')
 	assert res.exit_code == 0, res.str()
 	assert res.output.contains('Updating module `pcre`'), res.output
-	res = os.execute('${v} update nedpals.args vtray')
-	assert res.exit_code == 0, res.str()
-	assert res.output.contains('Updating module `vtray`'), res.output
-	assert res.output.contains('Updating module `nedpals.args`'), res.output
-	// Update installed module using its url.
-	res = os.execute('${v} update https://github.com/spytheman/vtray')
-	assert res.exit_code == 0, res.str()
-	assert res.output.contains('Updating module `vtray`'), res.output
-	// Try update not installed.
-	res = os.execute('${v} update vsl')
-	assert res.exit_code == 1, res.str()
-	assert res.output.contains('failed to find `vsl`'), res.output
-	// Try update mixed.
-	res = os.execute('${v} update pcre vsl')
-	assert res.exit_code == 1, res.str()
-	assert res.output.contains('Updating module `pcre`'), res.output
-	assert res.output.contains('failed to find `vsl`'), res.output
 }
+
+fn test_update_ident() {
+	os.execute_or_exit('git -C ${os.join_path(test_path, 'nedpals', 'args')} reset --hard HEAD~')
+	res := os.execute('${v} update nedpals.args')
+	assert res.exit_code == 0, res.str()
+	assert res.output.contains('Updating module `nedpals.args`'), res.output
+}
+
+fn test_update_url() {
+	os.execute_or_exit('git -C ${os.join_path(test_path, 'vtray')} reset --hard HEAD~')
+	res := os.execute('${v} update https://github.com/spytheman/vtray')
+	assert res.exit_code == 0, res.str()
+	assert res.output.contains('Updating module `vtray`'), res.output
+}
+
+fn test_update_multi_ident() {
+	os.execute_or_exit('git -C ${os.join_path(test_path, 'nedpals', 'args')} reset --hard HEAD~')
+	os.execute_or_exit('git -C ${os.join_path(test_path, 'vtray')} reset --hard HEAD~')
+	res := os.execute('${v} update nedpals.args vtray')
+	assert res.exit_code == 0, res.str()
+	assert res.output.contains('Updating module `nedpals.args`'), res.output
+	assert res.output.contains('Updating module `vtray`'), res.output
+}
+
+fn test_update_not_installed() {
+	res := os.execute('${v} update vsl')
+	assert res.exit_code == 1, res.str()
+	assert res.output.contains('failed to update `vsl`. Not installed.'), res.output
+}
+
+fn test_update_mixed_installed_not_installed() {
+	os.execute_or_exit('git -C ${os.join_path(test_path, 'pcre')} reset --hard HEAD~')
+	res := os.execute('${v} update pcre vsl')
+	assert res.exit_code == 1, res.str()
+	assert res.output.contains('Updating module `pcre`'), res.output
+	assert res.output.contains('failed to update `vsl`. Not installed.'), res.output
+}
+
+// TODO: hg tests
+// TODO: recursive test


### PR DESCRIPTION
One of the last changes to vpm before moving to working on the cmd_vpm2 repo. It's also the most complicated of the outstanding changes.

It adds parsing to the update command to improve evaluation of updatable modules. E.g. it, 
- fixes potential recursive loops with shared dependencies - currently it can happen when:
  ```
  v install https://gitlab.com/tobealive/a
  # below cause unintended recursive loops
  v install https://gitlab.com/tobealive/a # reinstall
  v update https://gitlab.com/tobealive/a # a module specific update with rec. deps
  v update # a full update if a module with rec. deps is installed
  ```
- improves detection of new modules to install when dependencies have changed. 

---

TODO:
- [ ] implement parsing urls of updatable hg modules
- [ ] add hg update test
- [ ] add recursive dependency test

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

copilot:summary

copilot:walkthrough
