### PR TITLE
vpm.tools: refine is_outdated, add `v outdated` test

### DIFF
--- a/cmd/tools/vpm/outdated.v
+++ b/cmd/tools/vpm/outdated.v
@@ -56,11 +56,15 @@ fn is_outdated(path string) bool {
 		vpm_log(@FILE_LINE, @FN, 'cmd: ${cmd}')
 		res := os.execute(cmd)
 		vpm_log(@FILE_LINE, @FN, 'output: ${res.output}')
+		if res.exit_code != 0 {
+			return false
+		}
 		if vcs == .hg {
-			return res.exit_code == 0
+			// HG uses only one outdated step. If it has not failed, the module is outdated.
+			return true
 		}
 		outputs << res.output
 	}
 	// Compare the current and latest origin commit sha.
-	return vcs == .git && outputs[1] != outputs[2]
+	return outputs[1] != outputs[2]
 }

--- a/cmd/tools/vpm/outdated_test.v
+++ b/cmd/tools/vpm/outdated_test.v
@@ -24,7 +24,7 @@ fn testsuite_end() {
 fn test_is_outdated_git_module() {
 	os.execute_or_exit('git clone https://github.com/vlang/libsodium.git')
 	assert !is_outdated('libsodium')
-	os.execute_or_exit('git -C libsodium reset --hard HEAD~1')
+	os.execute_or_exit('git -C libsodium reset --hard HEAD~')
 	assert is_outdated('libsodium')
 	os.execute_or_exit('git -C libsodium pull')
 	assert !is_outdated('libsodium')
@@ -41,4 +41,22 @@ fn test_is_outdated_hg_module() {
 	assert is_outdated('hello')
 	os.execute_or_exit('hg -R hello pull')
 	assert !is_outdated('hello')
+}
+
+fn test_outdated() {
+	for m in ['pcre', 'libsodium', 'https://github.com/spytheman/vtray', 'nedpals.args'] {
+		os.execute_or_exit('${vexe} install ${m}')
+	}
+	for m in ['pcre', 'vtray', os.join_path('nedpals', 'args')] {
+		os.execute_or_exit('git -C ${m} fetch --unshallow')
+		os.execute_or_exit('git -C ${m} reset --hard HEAD~')
+		assert is_outdated(m)
+	}
+	res := os.execute('${vexe} outdated')
+	assert res.exit_code == 0, res.str()
+	assert res.output.contains('Outdated modules:'), res.output
+	assert res.output.contains('pcre'), res.output
+	assert res.output.contains('vtray'), res.output
+	assert res.output.contains('nedpals.args'), res.output
+	assert !res.output.contains('libsodium'), res.output
 }

--- a/cmd/tools/vpm/outdated_test.v
+++ b/cmd/tools/vpm/outdated_test.v
@@ -47,6 +47,7 @@ fn test_outdated() {
 	for m in ['pcre', 'libsodium', 'https://github.com/spytheman/vtray', 'nedpals.args'] {
 		os.execute_or_exit('${vexe} install ${m}')
 	}
+	// "Outdate" previously installed. Leave out `libsodium`.
 	for m in ['pcre', 'vtray', os.join_path('nedpals', 'args')] {
 		os.execute_or_exit('git -C ${m} fetch --unshallow')
 		os.execute_or_exit('git -C ${m} reset --hard HEAD~')


### PR DESCRIPTION
Refines the `is_outdate` function and adds an integration test for the `v outdated` command.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

copilot:summary

copilot:walkthrough
