### PR TITLE
parser: fix formatting enum and interface decl with comments (related #20202)

### DIFF
--- a/vlib/v/fmt/tests/enum_decl_with_comment_expected.vv
+++ b/vlib/v/fmt/tests/enum_decl_with_comment_expected.vv
@@ -1,0 +1,4 @@
+enum ABC { // enum ABC
+	// aaa
+	aaa
+}

--- a/vlib/v/fmt/tests/enum_decl_with_comment_input.vv
+++ b/vlib/v/fmt/tests/enum_decl_with_comment_input.vv
@@ -1,0 +1,5 @@
+enum ABC  // enum ABC
+{
+	// aaa
+	aaa
+}

--- a/vlib/v/fmt/tests/interface_decl_with_comment_expected.vv
+++ b/vlib/v/fmt/tests/interface_decl_with_comment_expected.vv
@@ -1,0 +1,4 @@
+interface Abc { // interface Abc
+	a int
+	get_info() string
+}

--- a/vlib/v/fmt/tests/interface_decl_with_comment_input.vv
+++ b/vlib/v/fmt/tests/interface_decl_with_comment_input.vv
@@ -1,0 +1,5 @@
+interface Abc   // interface Abc
+{
+	a int
+	get_info() string
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4059,8 +4059,9 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		typ_pos = p.tok.pos()
 		enum_type = p.parse_type()
 	}
+	mut enum_decl_comments := p.eat_comments()
 	p.check(.lcbr)
-	enum_decl_comments := p.eat_comments()
+	enum_decl_comments << p.eat_comments()
 	senum_type := p.table.get_type_name(enum_type)
 	mut vals := []string{}
 	// mut default_exprs := []ast.Expr{}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -533,9 +533,9 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		interface_name = p.prepend_mod(modless_name)
 	}
 	generic_types, _ := p.parse_generic_types()
-	// println('interface decl $interface_name')
+	mut pre_comments := p.eat_comments()
 	p.check(.lcbr)
-	pre_comments := p.eat_comments()
+	pre_comments << p.eat_comments()
 	if modless_name in p.imported_symbols {
 		p.error_with_pos('cannot register interface `${interface_name}`, this type was already imported',
 			name_pos)


### PR DESCRIPTION
This PR fix formatting enum and interface decl with comments (related #20202).

- Fix formatting enum and interface decl with comments.
- Add tests.

```v
enum ABC  // enum ABC
{
	// aaa
	aaa
}

interface Abc   // interface Abc
{
	a int
	get_info() string
}
```
fmt to:
```v
enum ABC { // enum ABC
	// aaa
	aaa
}

interface Abc { // interface Abc
	a int
	get_info() string
}
```