### PR TITLE
cgen: fix array insert variadic arg variable (fix #20213)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -825,7 +825,8 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
 	arg2_sym := g.table.sym(node.args[1].typ)
-	is_arg2_array := arg2_sym.kind == .array && node.args[1].typ == node.left_type
+	is_arg2_array := arg2_sym.kind == .array
+		&& node.args[1].typ.clear_flag(.variadic) == node.left_type
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg2_array {

--- a/vlib/v/tests/array_insert_variadic_arg_variable_test.v
+++ b/vlib/v/tests/array_insert_variadic_arg_variable_test.v
@@ -1,0 +1,12 @@
+fn foo(args ...string) []string {
+	mut v := ['a']
+	v.insert(1, ['b'])
+	v.insert(1, args)
+	return v
+}
+
+fn test_array_insert_variadic_arg_variable() {
+	ret := foo('b')
+	println(ret)
+	assert ret == ['a', 'b', 'b']
+}


### PR DESCRIPTION
This PR fix array insert variadic arg variable (fix #20213).

- Fix array insert variadic arg variable.
- Add test.

```v
fn foo(args ...string) []string {
	mut v := ['a']
	v.insert(1, ['b'])
	v.insert(1, args)
	return v
}

fn main() {
	ret := foo('b')
	println(ret)
	assert ret == ['a', 'b', 'b']
}

PS D:\Test\v\tt1> v run .
['a', 'b', 'b']
```