### PR TITLE
cgen: fix comparing interface values of structs containing optional ref interface fields(fix #20212)

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -205,7 +205,8 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				fn_builder.write_string('${eq_fn}_alias_eq(${left_arg}, ${right_arg})')
 			} else if field_type.sym.kind == .function && !field.typ.has_flag(.option) {
 				fn_builder.write_string('*((voidptr*)(${left_arg})) == *((voidptr*)(${right_arg}))')
-			} else if field_type.sym.kind == .interface_ && !field.typ.is_ptr() {
+			} else if field_type.sym.kind == .interface_
+				&& (!field.typ.has_flag(.option) || !field.typ.is_ptr()) {
 				ptr := if field.typ.is_ptr() { '*'.repeat(field.typ.nr_muls()) } else { '' }
 				eq_fn := g.gen_interface_equality_fn(field.typ)
 				fn_builder.write_string('${eq_fn}_interface_eq(${ptr}${left_arg}, ${ptr}${right_arg})')

--- a/vlib/v/tests/interface_eq_methods_with_option_and_ref_test.v
+++ b/vlib/v/tests/interface_eq_methods_with_option_and_ref_test.v
@@ -1,4 +1,7 @@
-// for issue 19441
+// for issue 19441, 20212.
+// The issue 19441 manifests itself in the following way:
+// when the Mixin struct is present in the code, it causes a cgen error,
+// and when the Mixin struct is not included, the eq method results causes the final assertion to fail
 pub interface Iface {}
 
 pub struct Derived {}
@@ -16,6 +19,13 @@ fn test_main() {
 	mut arr := []&Iface{}
 	arr << &Derived{}
 	arr << &Derived{}
-
 	assert arr[0] == arr[1]
+
+	s1 := Iface(Struct{})
+	s2 := Iface(Struct{})
+	assert s1 == s2
+
+	i1 := Iface(Mixin{})
+	i2 := Iface(Mixin{})
+	assert i1 == i2
 }

--- a/vlib/v/tests/interface_eq_methods_with_option_and_ref_test.v
+++ b/vlib/v/tests/interface_eq_methods_with_option_and_ref_test.v
@@ -4,15 +4,22 @@
 // and when the Mixin struct is not included, the eq method results causes the final assertion to fail
 pub interface Iface {}
 
-pub struct Derived {}
-
-pub struct Struct {
-	field ?&Iface
+// test ref
+pub struct Derived {
+	field1 &Iface = unsafe { nil }
 }
 
+// test option and ref
+pub struct Struct {
+	field2 ?&Iface
+}
+
+// test non-ref and embeded
 pub struct Mixin {
 	Derived
 	Struct
+	field3 Iface = Iface(1)
+	field4 ?Iface
 }
 
 fn test_main() {


### PR DESCRIPTION
1. Fixed #20212
2. Add tests.

```v
pub interface Iface {}

// test ref
pub struct Derived {
	field1 &Iface = unsafe { nil }
}

// test option and ref
pub struct Struct {
	field2 ?&Iface
}

// test non-ref and embeded
pub struct Mixin {
	Derived
	Struct
	field3 Iface = Iface(1)
	field4 ?Iface
}

fn main() {
	mut arr := []&Iface{}
	arr << &Derived{}
	arr << &Derived{}
	assert arr[0] == arr[1]

	s1 := Iface(Struct{})
	s2 := Iface(Struct{})
	assert s1 == s2

	i1 := Iface(Mixin{})
	i2 := Iface(Mixin{})
	assert i1 == i2
}

```
outputs:
```
passed
```