### PR TITLE
builtin: add `@[direct_array_access]` to js string trim_right method

### DIFF
--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -285,6 +285,7 @@ pub fn (s string) u8() u64 {
 
 // trim_right strips any of the characters given in `cutset` from the right of the string.
 // Example: assert ' Hello V d'.trim_right(' d') == ' Hello V'
+@[direct_array_access]
 pub fn (s string) trim_right(cutset string) string {
 	if s.len < 1 || cutset.len < 1 {
 		return s.clone()


### PR DESCRIPTION
Makes the usage of the attribute uniform with `trim_right` in `string.v` and `trim_left` in `string.js.v` / `string.v`