### PR TITLE
tools.vpm: improve detection of already parsed modules

### DIFF
--- a/cmd/tools/vpm/dependency_test.v
+++ b/cmd/tools/vpm/dependency_test.v
@@ -84,6 +84,14 @@ fn test_install_with_recursive_dependencies() {
 		eprintln('Timeout while testing installation with recursive dependencies.')
 		exit(1)
 	}()
-	res := os.execute('${v} install https://gitlab.com/tobealive/a')
+	mut res := os.execute('${v} install https://gitlab.com/tobealive/a')
+	assert res.exit_code == 0, res.str()
+
+	// Test the installation of a module when passing its URL with the `.git` extension.
+	// One of the modules dependencies `https://gitlab.com/tobealive/c` has the
+	// `https://gitlab.com/tobealive/a` dependency without `.git`.
+	res = os.execute('${v} remove a b c')
+	assert res.exit_code == 0, res.str()
+	res = os.execute('${v} install https://gitlab.com/tobealive/a.git')
 	assert res.exit_code == 0, res.str()
 }


### PR DESCRIPTION
Ensures that a module is recognized as the same module despite the various options for defining that module.

Examples of how the same module could be passed during installation / as a dependency.

`https://github.com/publisher/module`
`https://github.com/publisher/module.git`
`git@github.com:publisher/module`
`git@github.com:publisher/module.git`



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<!--

ATTENTION! ⚠️

The below commands will be replaced with Copilot AI generated PR description.
This description will be automatically updated to describe the latest commit of this PR.
If you decided to remove them - please, provide a detailed description of your changes.

-->

copilot:summary

copilot:walkthrough
