### PR TITLE
cgen: fix wrong code generation when left of infixexpr is mut receiver(fix #20220)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1053,7 +1053,7 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		typ_str := g.typ(node.promoted_type)
 		g.write('(${typ_str})(')
 	}
-	if node.left_type.is_ptr() && node.left.is_auto_deref_var() {
+	if node.left_type.is_ptr() && node.left.is_auto_deref_var() && node.right_type != ast.nil_type {
 		g.write('*')
 	} else if !g.inside_interface_deref && node.left is ast.Ident
 		&& g.table.is_interface_var(node.left.obj) {

--- a/vlib/v/tests/infix_expr_test.v
+++ b/vlib/v/tests/infix_expr_test.v
@@ -81,3 +81,22 @@ fn test_cmp_u64_and_signed() {
 	assert u64(1) <= int(1)
 	assert !(u64(1) <= int(0))
 }
+
+// for issue 20220
+// test left is a receiver.
+struct Struct {
+}
+
+fn (s &Struct) foo() {
+	assert s != unsafe { nil }
+}
+
+fn (mut s Struct) bar() {
+	assert s != unsafe { nil }
+}
+
+fn test_left_is_receiver() {
+	mut s := Struct{}
+	s.foo()
+	s.bar()
+}


### PR DESCRIPTION
1. Fixed #20220
2. Add tests.

```v
@[heap]
struct UI {}

pub fn (ui &UI) draw_rect() {
	println('[]')
}

@[heap]
pub interface Node {
	id u64
	draw()
mut:
	ui &UI
	init(ui &UI) !
}

@[heap]
pub struct Item {
pub:
	id u64 = 1
mut:
	ui   &UI = unsafe { nil }
	body []&Node
}

pub fn (mut i Item) init(ui &UI) ! {
	assert i != unsafe { nil } // This assert generates a C gen error
	i.ui = ui
	for mut child in i.body {
		child.init(ui)!
	}
}

pub fn (i &Item) draw() {
	assert i != unsafe { nil }
	for child in i.body {
		child.draw()
	}
}

@[heap]
pub struct Rectangle {
	Item
pub mut:
	field f32
}

pub fn (r &Rectangle) draw() {
	assert r != unsafe { nil }
	r.ui.draw_rect()
	r.Item.draw()
}

fn main() {
	ui := &UI{}
	mut rect := &Rectangle{}

	rect.init(ui)!

	rect.draw()
}
```
outputs:
```
[]
```
