### PR TITLE
cgen: fix infix expr in method of mut receiver variable  (fix #20220)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1053,7 +1053,7 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		typ_str := g.typ(node.promoted_type)
 		g.write('(${typ_str})(')
 	}
-	if node.left_type.is_ptr() && node.left.is_auto_deref_var() {
+	if node.left_type.is_ptr() && node.left.is_auto_deref_var() && !node.right_type.is_pointer() {
 		g.write('*')
 	} else if !g.inside_interface_deref && node.left is ast.Ident
 		&& g.table.is_interface_var(node.left.obj) {
@@ -1065,7 +1065,7 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 	}
 	g.expr(node.left)
 	g.write(' ${node.op.str()} ')
-	if node.right_type.is_ptr() && node.right.is_auto_deref_var() {
+	if node.right_type.is_ptr() && node.right.is_auto_deref_var() && !node.left_type.is_pointer() {
 		g.write('*')
 		g.expr(node.right)
 	} else {

--- a/vlib/v/tests/infix_expr_in_mut_receiver_method_test.v
+++ b/vlib/v/tests/infix_expr_in_mut_receiver_method_test.v
@@ -1,0 +1,62 @@
+@[heap]
+struct UI {}
+
+pub fn (ui &UI) draw_rect() {
+	println('[]')
+}
+
+@[heap]
+pub interface Node {
+	id u64
+	draw()
+mut:
+	ui &UI
+	init(ui &UI) !
+}
+
+@[heap]
+pub struct Item {
+pub:
+	id u64 = 1
+mut:
+	ui   &UI = unsafe { nil }
+	body []&Node
+}
+
+pub fn (mut i Item) init(ui &UI) ! {
+	assert i != unsafe { nil } // This assert generates a C gen error
+	i.ui = ui
+	for mut child in i.body {
+		child.init(ui)!
+	}
+}
+
+pub fn (i &Item) draw() {
+	assert i != unsafe { nil }
+	for child in i.body {
+		child.draw()
+	}
+}
+
+@[heap]
+pub struct Rectangle {
+	Item
+pub mut:
+	field f32
+}
+
+pub fn (r &Rectangle) draw() {
+	assert r != unsafe { nil }
+	r.ui.draw_rect()
+	r.Item.draw()
+}
+
+fn test_infix_expr_in_mut_receiver_method() {
+	ui := &UI{}
+	mut rect := &Rectangle{}
+
+	rect.init(ui)!
+
+	rect.draw()
+	assert true
+}


### PR DESCRIPTION
This PR fix infix expr in method of mut receiver variable  (fix #20220).

- Fix infix expr in method of mut receiver variable.
- Add test.

```v
@[heap]
struct UI {}

pub fn (ui &UI) draw_rect() {
	println('[]')
}

@[heap]
pub interface Node {
	id u64
	draw()
mut:
	ui &UI
	init(ui &UI) !
}

@[heap]
pub struct Item {
pub:
	id u64 = 1
mut:
	ui   &UI = unsafe { nil }
	body []&Node
}

pub fn (mut i Item) init(ui &UI) ! {
	assert i != unsafe { nil } // This assert generates a C gen error
	i.ui = ui
	for mut child in i.body {
		child.init(ui)!
	}
}

pub fn (i &Item) draw() {
	assert i != unsafe { nil }
	for child in i.body {
		child.draw()
	}
}

@[heap]
pub struct Rectangle {
	Item
pub mut:
	field f32
}

pub fn (r &Rectangle) draw() {
	assert r != unsafe { nil }
	r.ui.draw_rect()
	r.Item.draw()
}

fn main() {
	ui := &UI{}
	mut rect := &Rectangle{}

	rect.init(ui)!

	rect.draw()
	assert true
}

PS D:\Test\v\tt1> v run .
[]
```