### PR TITLE
js.dom: add querySelector[All] and NodeList

### DIFF
--- a/vlib/js/dom/dom.js.v
+++ b/vlib/js/dom/dom.js.v
@@ -206,7 +206,7 @@ pub interface JS.Node {
 	lookupPrefix(namespace JS.String) JS.String
 	normalize()
 	removeChild(child JS.Node) JS.Node
-	replaceChild(node JS.Node, child JS.Node) JS.Npde
+	replaceChild(node JS.Node, child JS.Node) JS.Node
 mut:
 	nodeValue   JS.String
 	textContent JS.String
@@ -378,6 +378,8 @@ pub interface JS.HTMLElement {
 	offsetTop      JS.Number
 	offsetWidth    JS.Number
 	click()
+	querySelector(selectors JS.String) ?JS.HTMLElement
+	querySelectorAll(selectors JS.String) JS.NodeList
 mut:
 	accessKey      JS.String
 	autocapitalize JS.String
@@ -390,6 +392,14 @@ mut:
 	spellcheck     JS.Boolean
 	title          JS.String
 	translate      JS.Boolean
+}
+
+pub type NodeListForEachCb = fn (JS.HTMLElement, JS.Number, JS.NodeList)
+
+pub interface JS.NodeList {
+	length JS.Number
+	forEach(cb NodeListForEachCb, thisArg JS.Any)
+	item(idx JS.Number) ?JS.Any
 }
 
 pub fn JS.HTMLElement.prototype.constructor() JS.HTMLElement


### PR DESCRIPTION
Example:

```v
// v -b js_browser .
import js.dom

fn main() {
	document := dom.document
	mut h1 := document.body.querySelector('main h1'.str)?
	list := document.body.querySelectorAll('ul li'.str)

	h1.innerText = 'Hello, world!'.str
	list.forEach(fn (elem JS.HTMLElement, num JS.Number, list JS.NodeList) {
		JS.console.log(elem)
	}, false)
}
```