### PR TITLE
cgen: fix gen wrong for thread wrappers, when spawn with anon-fn array args(fix #19425)

### DIFF
--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -252,6 +252,19 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 					mut arg_types := f.params.map(it.typ)
 					arg_types = arg_types.map(muttable.resolve_generic_to_concrete(it,
 						f.generic_names, node.call_expr.concrete_types) or { it })
+					for i, typ in arg_types {
+						mut typ_sym := g.table.sym(typ)
+						for {
+							if mut typ_sym.info is ast.Array {
+								typ_sym = g.table.sym(typ_sym.info.elem_type)
+							} else {
+								if typ_sym.info is ast.FnType {
+									arg_types[i] = expr.args[i].typ
+								}
+								break
+							}
+						}
+					}
 					fn_var = g.fn_var_signature(return_type, arg_types, 'fn')
 				}
 			}

--- a/vlib/v/tests/go_call_fn_with_anon_fn_array_arg_test.v
+++ b/vlib/v/tests/go_call_fn_with_anon_fn_array_arg_test.v
@@ -1,0 +1,12 @@
+// for issue 19425
+type Func = fn ()
+
+fn handle_fns(fns []Func) {
+}
+
+fn test_main() {
+	mut fns := []Func{}
+	t := spawn handle_fns(fns)
+	t.wait()
+	assert true
+}

--- a/vlib/v/tests/go_call_fn_with_anon_fn_array_arg_test.v
+++ b/vlib/v/tests/go_call_fn_with_anon_fn_array_arg_test.v
@@ -1,12 +1,12 @@
 // for issue 19425
-type Func = fn ()
+interface MyInterface {}
 
-fn handle_fns(fns []Func) {
-}
+type Func = fn () int
+
+fn handle_fns(fns []Func, mut w MyInterface) {}
 
 fn test_main() {
-	mut fns := []Func{}
-	t := spawn handle_fns(fns)
-	t.wait()
+	mut w := &MyInterface(123)
+	spawn handle_fns([], mut w)
 	assert true
 }


### PR DESCRIPTION
1. Fixed #19425 
2. Add tests.

```v
module main

import time
import io
import os

interface Message {
	a int
}

struct Impl {
	a int
}

type HookFunc = fn (Message) ?Message

struct TestStruct {
	fns []HookFunc
}

fn (ts TestStruct) run(mut writer io.Writer) {
	spawn handle_fns(ts.fns, mut writer)
}

fn handle_fns(fns []HookFunc, mut writer io.Writer) {
	mut message := Message(Impl{a: 1})
	for f in fns {
		message = f(message) or { continue }
	}
	println(message)
}

fn main() {
	stack := TestStruct{
		fns: [
			fn (m Message) ?Message {
				return Message(Impl{a: m.a + 1})
			},
			fn (m Message) ?Message {
				return none
			}
		]
	}
	stack.run(mut os.stdout())
	time.sleep(2 * time.second)
}
```
outputs:
```
Message(Impl{
    a: 2
})
```
