### PR TITLE
x.json2: fix encoding of 💀🐈 etc emojis (fix #20243)

### DIFF
--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -574,8 +574,10 @@ fn (e &Encoder) encode_string(s string, mut wr io.Writer) ! {
 				wr.write(hex_code)!
 			} else {
 				// TODO: still figuring out what
-				// to do with more than 4 chars
-				wr.write(json2.space_bytes)!
+				// to do with more than 4 chars.
+				// According to https://www.json.org/json-en.html however, any codepoint is valid inside a string,
+				// so just passing it along should hopefully also work.
+				wr.write(slice.bytes())!
 			}
 			unsafe {
 				slice.free()

--- a/vlib/x/json2/encoder_test.v
+++ b/vlib/x/json2/encoder_test.v
@@ -34,7 +34,8 @@ fn test_json_string() {
 
 fn test_json_string_emoji() {
 	text := json.Any('🐈')
-	assert text.json_str() == r'" "'
+	assert text.json_str() == r'"🐈"'
+	assert json.Any('💀').json_str() == r'"💀"'
 }
 
 fn test_json_string_non_ascii() {


### PR DESCRIPTION
Fix #20243