### PR TITLE
db.pg: Fix invalid memory access in res_to_rows

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -92,6 +92,7 @@ const skip_test_files = [
 	'vlib/db/mysql/mysql_test.v', // mysql not installed
 	'vlib/db/mysql/prepared_stmt_test.v', // mysql not installed
 	'vlib/db/pg/pg_orm_test.v', // pg not installed
+	'vlib/db/pg/pg_test.v', // pg not installed
 ]
 // These tests are too slow to be run in the CI on each PR/commit
 // in the sanitized modes:

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -191,7 +191,7 @@ fn res_to_rows(res voidptr) []Row {
 			} else {
 				val := C.PQgetvalue(res, i, j)
 				sval := unsafe { val.vstring() }
-				row.vals << sval
+				row.vals << sval.clone()
 			}
 		}
 		rows << row

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -190,8 +190,7 @@ fn res_to_rows(res voidptr) []Row {
 				row.vals << none
 			} else {
 				val := C.PQgetvalue(res, i, j)
-				sval := unsafe { val.vstring() }
-				row.vals << sval.clone()
+				row.vals << unsafe { cstring_to_vstring(val) }
 			}
 		}
 		rows << row

--- a/vlib/db/pg/pg_test.v
+++ b/vlib/db/pg/pg_test.v
@@ -1,0 +1,24 @@
+module main
+
+import db.pg
+
+const query = 'SELECT ischema.table_schema, c.relname, a.attname, t.typname, t.typalign, t.typlen
+  FROM pg_class c
+  JOIN information_schema.tables ischema on ischema.table_name = c.relname
+  JOIN pg_attribute a ON (a.attrelid = c.oid)
+  JOIN pg_type t ON (t.oid = a.atttypid)
+WHERE
+  a.attnum >= 0'
+
+fn test_large_exec() {
+	db := pg.connect(pg.Config{ user: 'postgres', password: 'secret', dbname: 'postgres' })!
+	defer {
+		db.close()
+	}
+
+	rows := db.exec(query)!
+	for row in rows {
+		// We just need to access the memory to ensure it's properly allocated
+		row.str()
+	}
+}


### PR DESCRIPTION
Closes: #20020 
- Fixes an invalid memory access caused by `.vstring()` reusing memory
- Adds a test to ensure returned memory is valid
- Prevents test from running in CI due to postgres not being installed
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
