### PR TITLE
checker: remove unnecessary struct ref field initialization checks and notifications at map initializing(fix #20245)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -405,7 +405,6 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		c.ensure_type_exists(info.value_type, node.pos)
 		node.key_type = info.key_type
 		node.value_type = info.value_type
-		c.check_elements_ref_fields_initialized(node.typ, node.pos)
 		return node.typ
 	}
 

--- a/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:8:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
-    6 |
+    6 | 
     7 | fn main() {
     8 |     _ = []Foo{len: 1}
       |         ~~~~~~
@@ -12,20 +12,6 @@ vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:9:6: not
       |         ~~~~~~~~
    10 |     _ = map[string]Foo{}
    11 |     _ = map[string][]Foo{}
-vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:10:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
-    8 |     _ = []Foo{len: 1}
-    9 |     _ = [1]Foo{}
-   10 |     _ = map[string]Foo{}
-      |         ~~~~~~~~~~~~~~~~
-   11 |     _ = map[string][]Foo{}
-   12 |     _ = []AliasFoo{len: 1}
-vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:11:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
-    9 |     _ = [1]Foo{}
-   10 |     _ = map[string]Foo{}
-   11 |     _ = map[string][]Foo{}
-      |         ~~~~~~~~~~~~~~~~~~
-   12 |     _ = []AliasFoo{len: 1}
-   13 | }
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:12:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)
    10 |     _ = map[string]Foo{}
    11 |     _ = map[string][]Foo{}


### PR DESCRIPTION
1. Close #20245 
2. Remove unnecessary notifications
3. Handle with the implicit creation of map instances later
