### PR TITLE
cgen: fix fixed array return when returning fixed array initialization

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5282,11 +5282,17 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 					if node.exprs[0] is ast.Ident {
 						g.write('memcpy(${tmpvar}.ret_arr, ${g.expr_string(node.exprs[0])}, sizeof(${g.typ(node.types[0])})) /*ret*/')
 					} else if node.exprs[0] in [ast.ArrayInit, ast.StructInit] {
-						tmpvar2 := g.new_tmp_var()
-						g.write('${g.typ(node.types[0])} ${tmpvar2} = ')
-						g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
-						g.writeln(';')
-						g.write('memcpy(${tmpvar}.ret_arr, ${tmpvar2}, sizeof(${g.typ(node.types[0])})) /*ret*/')
+						if node.exprs[0] is ast.ArrayInit && node.exprs[0].is_fixed {
+							g.write('memcpy(${tmpvar}.ret_arr, ')
+							g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
+							g.write(', sizeof(${g.typ(node.types[0])})) /*ret*/')
+						} else {
+							tmpvar2 := g.new_tmp_var()
+							g.write('${g.typ(node.types[0])} ${tmpvar2} = ')
+							g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
+							g.writeln(';')
+							g.write('memcpy(${tmpvar}.ret_arr, ${tmpvar2}, sizeof(${g.typ(node.types[0])})) /*ret*/')
+						}
 					} else {
 						g.write('memcpy(${tmpvar}.ret_arr, ')
 						g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5282,7 +5282,8 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 					if node.exprs[0] is ast.Ident {
 						g.write('memcpy(${tmpvar}.ret_arr, ${g.expr_string(node.exprs[0])}, sizeof(${g.typ(node.types[0])})) /*ret*/')
 					} else if node.exprs[0] in [ast.ArrayInit, ast.StructInit] {
-						if node.exprs[0] is ast.ArrayInit && node.exprs[0].is_fixed {
+						if node.exprs[0] is ast.ArrayInit && node.exprs[0].is_fixed
+							&& node.exprs[0].has_init {
 							g.write('memcpy(${tmpvar}.ret_arr, ')
 							g.expr_with_cast(node.exprs[0], node.types[0], g.fn_decl.return_type)
 							g.write(', sizeof(${g.typ(node.types[0])})) /*ret*/')

--- a/vlib/v/tests/fixed_array_return_decl_test.v
+++ b/vlib/v/tests/fixed_array_return_decl_test.v
@@ -1,0 +1,58 @@
+import runtime { is_big_endian }
+
+union F32A {
+	float f32
+	value [4]u8
+}
+
+union F64A {
+	float f64
+	value [8]u8
+}
+
+pub fn read_f32le(bytes [4]u8) f32 {
+	if is_big_endian() {
+		bytes_rev := [4]u8{init: bytes[3 - index]}
+		float := F32A{
+			value: bytes_rev
+		}
+		unsafe {
+			return float.float
+		}
+	} else {
+		float := F32A{
+			value: bytes
+		}
+		unsafe {
+			return float.float
+		}
+	}
+}
+
+pub fn write_f32le(float f32) [4]u8 {
+	float_copy := F32A{
+		float: float
+	}
+	if is_big_endian() {
+		unsafe {
+			return [4]u8{init: float_copy.value[3 - index]}
+		}
+	} else {
+		unsafe {
+			return float_copy.value
+		}
+	}
+}
+
+fn test_zeroed() {
+	a := [4]u8{}
+	b := write_f32le(0.0)
+	assert a == b
+}
+
+fn test_value() {
+	mut a2 := [4]u8{}
+	a2 = [u8(205), 204, 204, 61]!
+	b2 := write_f32le(0.1)
+	assert a2 == b2
+}


### PR DESCRIPTION
Fix #20261

```V
import runtime { is_big_endian }

union F32A {
	float f32
	value [4]u8
}

union F64A {
	float f64
	value [8]u8
}

pub fn read_f32le(bytes [4]u8) f32 {
	if is_big_endian() {
		bytes_rev := [4]u8{init: bytes[3 - index]}
		float := F32A{value: bytes_rev}
		unsafe {
			return float.float
		}
	} else {
		float := F32A{value: bytes}
		unsafe {
			return float.float
		}
	}
}

pub fn write_f32le(float f32) [4]u8 {
	float_copy := F32A{float: float}
	if is_big_endian() {
		unsafe {
			return [4]u8{init: float_copy.value[3 - index]}
		}
	} else {
		unsafe {
			return float_copy.value
		}
	}
}

fn main() {
    a := [4]u8{}
    b := write_f32le(0.0)
    assert a == b


    mut a2 := [4]u8{}
    a2 = [u8(205),204,204,61]!
    b2 := write_f32le(0.1)
    assert a2 == b2
}
```