### PR TITLE
checker: fix mismatch checking when a function returns sumtype as an argument(fix #19325)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -436,6 +436,12 @@ fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSymbol,
 	if !c.check_basic(got_fn.return_type, exp_fn.return_type) {
 		return false
 	}
+	// The check for sumtype in c.check_basic() in the previous step is only for its variant to be subsumed
+	// So we need to do a second, more rigorous check of the return value being sumtype.
+	if c.table.final_sym(exp_fn.return_type).kind == .sum_type
+		&& got_fn.return_type.idx() != exp_fn.return_type.idx() {
+		return false
+	}
 	for i, got_arg in got_fn.params {
 		exp_arg := exp_fn.params[i]
 		exp_arg_typ := c.unwrap_generic(exp_arg.typ)

--- a/vlib/v/checker/tests/fn_call_arg_fn_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_fn_mismatch_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_call_arg_fn_mismatch_err.vv:14:8: error: cannot use `fn () string` as `fn () Response` in argument 1 to `event`
+   12 | 
+   13 | fn main() {
+   14 |     event(foo)
+      |           ~~~
+   15 | }

--- a/vlib/v/checker/tests/fn_call_arg_fn_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_call_arg_fn_mismatch_err.vv
@@ -1,0 +1,15 @@
+// for issue 19325
+type Response = int | string
+
+fn foo() string {
+	return 'hello'
+}
+
+fn event(cb fn () Response) {
+	resp := cb()
+	assert resp is string
+}
+
+fn main() {
+	event(foo)
+}


### PR DESCRIPTION
1. Fixed #19325 
2. Add tests.

```v
type Response = int | string

fn my_resp() string {
	return 'hello'
}

fn event(cb fn () Response) {
	resp := cb()
	dump(resp is string)
}

event(my_resp)
```
outputs:
```
a.v:12:7: error: cannot use `fn () string` as `fn () Response` in argument 1 to `event`
   10 | }
   11 | 
   12 | event(my_resp)
      |       ~~~~~~~
   13 | 
   14 |
```