### PR TITLE
parser: fix fn call with newline opening brace (fix #20258)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2683,10 +2683,9 @@ fn (mut p Parser) name_expr() ast.Expr {
 	is_generic_call := p.is_generic_call()
 	is_generic_cast := p.is_generic_cast()
 	is_generic_struct_init := p.is_generic_struct_init()
-	// p.warn('name expr  $p.tok.lit $p.peek_tok.str()')
-	same_line := p.tok.line_nr == p.peek_tok.line_nr
-	// `(` must be on same line as name token otherwise it's a ParExpr
-	if !same_line && p.peek_tok.kind == .lpar {
+	if p.peek_tok.kind == .lpar && p.tok.line_nr != p.peek_tok.line_nr
+		&& p.peek_token(2).is_next_to(p.peek_tok) {
+		// `(` must be on same line as name token otherwise it's a ParExpr
 		ident := p.ident(language)
 		node = ident
 		p.add_defer_var(ident)

--- a/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
+++ b/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
@@ -8,7 +8,7 @@ struct Address
 		zip int
 }
 
-fn test_fn_call_with_newline_opening_brace() 
+fn test_fn_call_with_newline_opening_brace()
 {
 	println(initialized_address)
 	assert true
@@ -20,7 +20,7 @@ pub:
 	street string = '1234 Default St'
 	city   string = 'Your Favorite City'
 	state  string = 'Could Be Any'
-	zip    int    = 42 
+	zip    int    = 42
 }
 
 fn new_address(cfg AddressConfig) &Address

--- a/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
+++ b/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
@@ -44,8 +44,8 @@ const (
 		zip: 24
 	)
 )
-	
-fn (a Address) str() string {
-	return 'Address.str(): $a.street, $a.city, $a.state $a.zip'
-}
 // vfmt on
+
+fn (a Address) str() string {
+	return 'Address.str(): ${a.street}, ${a.city}, ${a.state} ${a.zip}'
+}

--- a/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
+++ b/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
@@ -1,0 +1,51 @@
+// vfmt off
+struct Address
+{
+	pub:
+		street string
+		city string
+		state string
+		zip int
+}
+
+fn test_fn_call_with_newline_opening_brace() 
+{
+	println(initialized_address)
+	assert true
+}
+
+struct AddressConfig {
+pub:
+
+	street string = '1234 Default St'
+	city   string = 'Your Favorite City'
+	state  string = 'Could Be Any'
+	zip    int    = 42 
+}
+
+fn new_address(cfg AddressConfig) &Address
+{
+	return &Address
+	{
+		street:cfg.street
+		city:cfg.city
+		state:cfg.state
+		zip:cfg.zip
+	}
+}
+
+const (
+	default_address     = new_address(AddressConfig{})
+	initialized_address = new_address
+	(
+		street: '0987 tluafeD tS'
+		city: 'ytiC etirovaF rouY'
+		state: 'ynA eB dluoC'
+		zip: 24
+	)
+)
+	
+fn (a Address) str() string {
+	return 'Address.str(): $a.street, $a.city, $a.state $a.zip'
+}
+// vfmt on


### PR DESCRIPTION
This PR fix fn call with newline opening brace (fix #20258).

- Fix fn call with newline opening brace.
- Add test.

```v
// vfmt off
struct Address
{
	pub:
		street string
		city string
		state string
		zip int
}

fn main() 
{
	println(initialized_address)
	assert true
}

struct AddressConfig {
pub:

	street string = '1234 Default St'
	city   string = 'Your Favorite City'
	state  string = 'Could Be Any'
	zip    int    = 42 
}

fn new_address(cfg AddressConfig) &Address
{
	return &Address
	{
		street:cfg.street
		city:cfg.city
		state:cfg.state
		zip:cfg.zip
	}
}

const (
	default_address     = new_address(AddressConfig{})
	initialized_address = new_address
	(
		street: '0987 tluafeD tS'
		city: 'ytiC etirovaF rouY'
		state: 'ynA eB dluoC'
		zip: 24
	)
)
	
fn (a Address) str() string {
	return 'Address.str(): $a.street, $a.city, $a.state $a.zip'
}
// vfmt on

PS D:\Test\v\tt1> v run .
&Address.str(): 0987 tluafeD tS, ytiC etirovaF rouY, ynA eB dluoC 24
```