### PR TITLE
cgen: fix in expression with mut and ref(fix #20268)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1007,7 +1007,7 @@ fn (mut g Gen) gen_array_contains(left_type ast.Type, left ast.Expr, right_type 
 	} else {
 		left_sym.array_fixed_info().elem_type
 	}
-	if right.is_auto_deref_var()
+	if (right.is_auto_deref_var() && !elem_typ.is_ptr())
 		|| (g.table.sym(elem_typ).kind !in [.interface_, .sum_type, .struct_] && right is ast.Ident
 		&& right.info is ast.IdentVar
 		&& g.table.sym(right.obj.typ).kind in [.interface_, .sum_type]) {

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -327,3 +327,16 @@ fn test_in_array_of_sumtype() {
 	println(1 in arr)
 	assert 1 in arr
 }
+
+// for issue 20268
+struct Bar {}
+
+fn in_both_mut_ref(mut arr []&Bar, mut bar &Bar) {
+	assert bar !in arr
+}
+
+fn test_in_both_mut_and_ref() {
+	mut arr := []&Bar{}
+	mut bar := Bar{}
+	in_both_mut_ref(mut &arr, mut &bar)
+}

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -331,6 +331,7 @@ fn test_in_array_of_sumtype() {
 // for issue 20268
 struct Bar {}
 
+// vfmt off
 fn in_both_mut_ref(mut arr []&Bar, mut bar &Bar) {
 	assert bar !in arr
 }
@@ -340,3 +341,4 @@ fn test_in_both_mut_and_ref() {
 	mut bar := Bar{}
 	in_both_mut_ref(mut &arr, mut &bar)
 }
+// vfmt on


### PR DESCRIPTION
1. Fixed #20268
2. Add tests.

```v
struct At {
mut:
	list_lien	[]&At
}

fn (mut at At) li(mut at_li &At) {
	if at_li !in at.list_lien{	
	}
}

fn main() {
	mut at_1 := At{[]}
	mut at_2 := At{[]}
	at_1.li(mut &at_2)
}
```

outputs:
```
passed
```