### PR TITLE
parser: fix parse_vet_file() with vfmt off/on flag

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -279,7 +279,16 @@ pub fn parse_vet_file(path string, table_ &ast.Table, pref_ &pref.Preferences) (
 	p.set_path(path)
 	if p.scanner.text.contains_any_substr(['\n  ', ' \n']) {
 		source_lines := os.read_lines(path) or { []string{} }
+		mut is_vfmt_off := false 
 		for lnumber, line in source_lines {
+			if line.starts_with('\x01 vfmt off') {
+				is_vfmt_off = true
+			} else if line.starts_with('\x01 vfmt on') {
+				is_vfmt_off = false
+			}
+			if is_vfmt_off {
+				continue
+			}
 			if line.starts_with('  ') {
 				p.vet_error('Looks like you are using spaces for indentation.', lnumber,
 					.vfmt, .space_indent)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -279,7 +279,7 @@ pub fn parse_vet_file(path string, table_ &ast.Table, pref_ &pref.Preferences) (
 	p.set_path(path)
 	if p.scanner.text.contains_any_substr(['\n  ', ' \n']) {
 		source_lines := os.read_lines(path) or { []string{} }
-		mut is_vfmt_off := false 
+		mut is_vfmt_off := false
 		for lnumber, line in source_lines {
 			if line.starts_with('\x01 vfmt off') {
 				is_vfmt_off = true

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -281,9 +281,9 @@ pub fn parse_vet_file(path string, table_ &ast.Table, pref_ &pref.Preferences) (
 		source_lines := os.read_lines(path) or { []string{} }
 		mut is_vfmt_off := false
 		for lnumber, line in source_lines {
-			if line.starts_with('\x01 vfmt off') {
+			if line.starts_with('// vfmt off') {
 				is_vfmt_off = true
-			} else if line.starts_with('\x01 vfmt on') {
+			} else if line.starts_with('// vfmt on') {
 				is_vfmt_off = false
 			}
 			if is_vfmt_off {

--- a/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
+++ b/vlib/v/tests/fn_call_with_newline_opening_brace_test.v
@@ -1,31 +1,31 @@
 // vfmt off
-struct Address
+struct Address  
 {
 	pub:
 		street string
 		city string
 		state string
-		zip int
+		zip int  
 }
 
-fn test_fn_call_with_newline_opening_brace()
+fn test_fn_call_with_newline_opening_brace()  
 {
-	println(initialized_address)
-	assert true
+	println(initialized_address) 
+	assert true 
 }
 
-struct AddressConfig {
+struct AddressConfig { 
 pub:
 
-	street string = '1234 Default St'
-	city   string = 'Your Favorite City'
-	state  string = 'Could Be Any'
-	zip    int    = 42
+	street string = '1234 Default St' 
+	city   string = 'Your Favorite City' 
+	state  string = 'Could Be Any' 
+	zip    int    = 42 
 }
 
-fn new_address(cfg AddressConfig) &Address
+fn new_address(cfg AddressConfig) &Address 
 {
-	return &Address
+	return &Address 
 	{
 		street:cfg.street
 		city:cfg.city
@@ -35,8 +35,8 @@ fn new_address(cfg AddressConfig) &Address
 }
 
 const (
-	default_address     = new_address(AddressConfig{})
-	initialized_address = new_address
+	default_address     = new_address(AddressConfig{}) 
+	initialized_address = new_address 
 	(
 		street: '0987 tluafeD tS'
 		city: 'ytiC etirovaF rouY'


### PR DESCRIPTION
This PR fix parse_vet_file() with vfmt off/on flag.

- Fix parse_vet_file() with vfmt off/on flag.
- Add test.

```v
// vfmt off
struct Address  
{
	pub:
		street string
		city string
		state string
		zip int  
}

fn test_fn_call_with_newline_opening_brace()  
{
	println(initialized_address) 
	assert true 
}

struct AddressConfig { 
pub:

	street string = '1234 Default St' 
	city   string = 'Your Favorite City' 
	state  string = 'Could Be Any' 
	zip    int    = 42 
}

fn new_address(cfg AddressConfig) &Address 
{
	return &Address 
	{
		street:cfg.street
		city:cfg.city
		state:cfg.state
		zip:cfg.zip
	}
}

const (
	default_address     = new_address(AddressConfig{}) 
	initialized_address = new_address 
	(
		street: '0987 tluafeD tS'
		city: 'ytiC etirovaF rouY'
		state: 'ynA eB dluoC'
		zip: 24
	)
)
// vfmt on

fn (a Address) str() string {
	return 'Address.str(): ${a.street}, ${a.city}, ${a.state} ${a.zip}'
}
```