### PR TITLE
docs: update null convention in ORM example

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4978,9 +4978,9 @@ import db.sqlite
 @[table: 'customers']
 struct Customer {
 	id        int    @[primary; sql: serial] // a field named `id` of integer type must be the first field
-	name      string @[nonull]
-	nr_orders int
-	country   string @[nonull]
+	name      string
+	nr_orders ?int
+	country   string
 }
 
 db := sqlite.connect('customers.db')!

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4979,7 +4979,7 @@ import db.sqlite
 struct Customer {
 	id        int    @[primary; sql: serial] // a field named `id` of integer type must be the first field
 	name      string
-	nr_orders ?int
+	nr_orders int
 	country   string
 }
 


### PR DESCRIPTION
The @[nonull] attribute is no longer used and is replaced by using an option type. https://github.com/vlang/v/pull/19379
