### PR TITLE
cgen: fix initialization of const string arrays on msvc(fix #20287)

### DIFF
--- a/vlib/v/tests/const_fixed_array_of_string_value_msvc_test.v
+++ b/vlib/v/tests/const_fixed_array_of_string_value_msvc_test.v
@@ -1,0 +1,9 @@
+// for issue 20287
+// msvc does not support the "_SLIT" macro for fixed array of string values immediate initialization:
+// Array_fixed_string_5 _const_main__escaped_chars = {(_SLIT("\\b")), (_SLIT("\\f")), (_SLIT("\\n")), (_SLIT("\\r")), (_SLIT("\\t"))};
+// error C2099: initializer is not a constant
+const escaped_chars = [(r'\b'), (r'\f'), (r'\n'), (r'\r'), (r'\t')]!
+
+fn test_main() {
+	assert true
+}


### PR DESCRIPTION
1. Fixed #20287 
2. Add tests.

```v
const escaped_chars = [(r'\b'), (r'\f'), (r'\n'), (r'\r'), (r'\t')]!
```

v -cc msvc -o a.c a.v:
```c
Array_fixed_string_5 _const_main__escaped_chars; // inited later
```
......
```
// Initializations of consts for module main
_const_main__escaped_chars[0] = (_SLIT("\\b"));
_const_main__escaped_chars[1] = (_SLIT("\\f"));
_const_main__escaped_chars[2] = (_SLIT("\\n"));
_const_main__escaped_chars[3] = (_SLIT("\\r"));
_const_main__escaped_chars[4] = (_SLIT("\\t"));
```