### PR TITLE
pref: disable -macosx-version-min clang flag by default

### DIFF
--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -157,7 +157,7 @@ pub mut:
 	use_cache              bool   // when set, use cached modules to speed up subsequent compilations, at the cost of slower initial ones (while the modules are cached)
 	retry_compilation      bool = true // retry the compilation with another C compiler, if tcc fails.
 	use_os_system_to_run   bool   // when set, use os.system() to run the produced executable, instead of os.new_process; works around segfaults on macos, that may happen when xcode is updated
-	macosx_version_min     string = '10.7' // relevant only for macos and ios targets
+	macosx_version_min     string = '0' // relevant only for macos and ios targets
 	// TODO Convert this into a []string
 	cflags  string // Additional options which will be passed to the C compiler *before* other options.
 	ldflags string // Additional options which will be passed to the C compiler *after* everything else.


### PR DESCRIPTION
Disable the `-macosx-version-min` clang flag which is poorly documented, but which seems to affect STL (and some other headers) and also which runtime is linked against.

This flag causes problems (on my Intel-based mac, at least), such as
* use of `C.environ` causes segfault
* `os.Process._spawn()` segfaults

This results in total breakage of some v commands, including `v run` and `v test`. E.g., `v run` segfaults as follows:
```
signal 11: segmentation fault
0   libsystem_platform.dylib            0x00007ff8009cf37d _sigtramp + 29
1   ???                                 0x0000000000000000 0x0 + 0
2   v                                   0x000000010bd3e5db os__Process__spawn + 155
3   v                                   0x000000010bd3e503 os__Process_wait + 35
4   v                                   0x000000010c072aa5 v__builder__Builder_run_compiled_executable_and_exit + 3701
5   v                                   0x000000010c07027c v__builder__compile + 124
6   v                                   0x000000010c07bd19 main__rebuild + 121
7   v                                   0x000000010c07af25 main__main + 2181
8   v                                   0x000000010c080830 main + 64
9   dyld                                0x00007ff8006193a6 start + 1942
```

This PR changes default behaviour of V compiler so that it does not pass a min macosx version to clang by default.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
