### PR TITLE
cgen: fix code generation when 'in array init' is in the if-conds(fix#20300)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -518,7 +518,9 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 						expr: node.left
 						expr_type: ast.mktyp(node.left_type)
 					}
+					g.write('(')
 					g.gen_array_contains(node.right_type, node.right, elem_type, new_node_left)
+					g.write(')')
 					return
 				}
 			} else if elem_type_.sym.kind == .interface_ {
@@ -528,11 +530,15 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 					expr: node.left
 					expr_type: ast.mktyp(node.left_type)
 				}
+				g.write('(')
 				g.gen_array_contains(node.right_type, node.right, elem_type, new_node_left)
+				g.write(')')
 				return
 			}
 		}
+		g.write('(')
 		g.gen_array_contains(node.right_type, node.right, node.left_type, node.left)
+		g.write(')')
 	} else if right.unaliased_sym.kind == .map {
 		g.write('_IN_MAP(')
 		if !left.typ.is_ptr() {
@@ -597,17 +603,23 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 						expr: node.left
 						expr_type: ast.mktyp(node.left_type)
 					}
+					g.write('(')
 					g.gen_array_contains(node.right_type, node.right, elem_type, new_node_left)
+					g.write(')')
 					return
 				}
 			}
 		}
+		g.write('(')
 		g.gen_array_contains(node.right_type, node.right, node.left_type, node.left)
+		g.write(')')
 	} else if right.unaliased_sym.kind == .string {
+		g.write('(')
 		g.write('string_contains(')
 		g.expr(node.right)
 		g.write(', ')
 		g.expr(node.left)
+		g.write(')')
 		g.write(')')
 	}
 }

--- a/vlib/v/tests/if_expression_test.v
+++ b/vlib/v/tests/if_expression_test.v
@@ -263,3 +263,13 @@ fn test_noreturn() {
 		assert_false_noreturn()
 	}
 }
+
+// for issue 20300
+// Phenomenon of issue:
+// infix expr generates wraparound parentheses, but misses the case where `array_contains()` is used.
+fn test_in_array_init() {
+	if 0 in []int{} {
+		assert false
+	}
+	assert true
+}


### PR DESCRIPTION
1. Fixed #20300
2. Add tests.

```v
module main

import os

type Data = map[string]map[u32]map[string]u32

fn main() {
	content := os.read_file('input.txt') or {
		eprintln('Could not read file: ${err}')
		return
	}

	seeds, data := setup(content)
	result_one := part_one(seeds, data)
	print('Part one: ${result_one}')
}

fn setup(content string) ([]u32, Data) {
	mut seeds := []u32{}
	mut data := Data(map[string]map[u32]map[string]u32{})
	lines := content.split_into_lines()
	for i, line in lines {
		if line.starts_with('seeds:') {
			seeds = line.split(' ').filter(it.u32() != 0).map(it.u32())
		} else if ':' in line.split('') {
			key := line.split(' ')[0].trim(' ')
			for map_line in lines[i + 1..] {
				if map_line == '' {
					break
				}
				values := map_line.split(' ').map(it.u32())
				data[key][values[1]] = {
					'destination': values[0]
					'range':       values[2]
				}
			}
		}
	}

	return seeds, data
}

fn part_one(seeds []u32, data Data) u32 {
	mut min := u32(0)

	for seed in seeds {
		mut soil := seed
		for key in data['seed-to-soil'].keys() {
			if seed in []u32{len: int(data['seed-to-soil'][key]['range']), init: u32(index) + key} {
				soil = data['seed-to-soil'][key]['destination'] + seed - key
				break
			}
		}
		mut fertilizer := soil
		for key in data['soil-to-fertilizer'].keys() {
			if soil in []u32{len: int(data['soil-to-fertilizer'][key]['range']), init: u32(index) +
				key} {
				fertilizer = data['soil-to-fertilizer'][key]['destination'] + soil - key
				break
			}
		}
		mut water := fertilizer
		for key in data['fertilizer-to-water'].keys() {
			if fertilizer in []u32{len: int(data['fertilizer-to-water'][key]['range']), init:
				u32(index) + key} {
				water = data['fertilizer-to-water'][key]['destination'] + fertilizer - key
				break
			}
		}
		mut light := water
		for key in data['water-to-light'].keys() {
			if water in []u32{len: int(data['water-to-light'][key]['range']), init: u32(index) + key} {
				light = data['water-to-light'][key]['destination'] + water - key
				break
			}
		}
		mut temperature := light
		for key in data['light-to-temperature'].keys() {
			if light in []u32{len: int(data['light-to-temperature'][key]['range']), init:
				u32(index) + key} {
				temperature = data['light-to-temperature'][key]['destination'] + light - key
				break
			}
		}
		mut humidity := temperature
		for key in data['temperature-to-humidity'].keys() {
			if temperature in []u32{len: int(data['temperature-to-humidity'][key]['range']), init:
				u32(index) + key} {
				humidity = data['temperature-to-humidity'][key]['destination'] + temperature - key
				break
			}
		}
		mut location := humidity
		for key in data['humidity-to-location'].keys() {
			if humidity in []u32{len: int(data['humidity-to-location'][key]['range']), init:
				u32(index) + key} {
				location = data['humidity-to-location'][key]['destination'] + humidity - key
				break
			}
		}
		if location < min {
			min = location
		}
	}

	return min
}
```
outputs:
```
Compiled to pass
```