### PR TITLE
v: improved comptime var checking with `is` operator and smartcasting

### DIFF
--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -129,6 +129,13 @@ pub fn (mut s Scope) update_ct_var_kind(name string, kind ComptimeVarKind) {
 	}
 }
 
+pub fn (mut s Scope) update_smartcasts(name string, typ Type) {
+	mut obj := unsafe { s.objects[name] }
+	if mut obj is Var {
+		obj.smartcasts = [typ]
+	}
+}
+
 // selector_expr:  name.field_name
 pub fn (mut s Scope) register_struct_field(name string, field ScopeStructField) {
 	if f := s.struct_fields[name] {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3852,7 +3852,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 					orig_type = expr.obj.typ
 				}
 				is_inherited = expr.obj.is_inherited
-				ct_type_var = if expr.obj.ct_type_var == .field_var {
+				ct_type_var = if expr.obj.ct_type_var in [.field_var, .generic_param] {
 					.smartcast
 				} else {
 					.no_comptime

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3794,7 +3794,7 @@ fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 }
 
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
-fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope) {
+fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope, is_comptime bool) {
 	sym := c.table.sym(cur_type)
 	to_type := if sym.kind == .interface_ && c.table.sym(to_type_).kind != .interface_ {
 		to_type_.ref()
@@ -3838,7 +3838,6 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 			}
 		}
 		ast.Ident {
-			is_comptime := c.comptime.inside_comptime_for
 			mut is_mut := false
 			mut smartcasts := []ast.Type{}
 			mut is_already_casted := false

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -285,7 +285,6 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 			}
 			c.comptime.comptime_for_enum_var = node.val_var
 			c.comptime.type_map[node.val_var] = c.enum_data_type
-			c.comptime.type_map['${node.val_var}.typ'] = node.typ
 			c.stmts(mut node.stmts)
 			c.pop_comptime_info()
 		} else {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -217,7 +217,7 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 		c.unwrap_generic(node.typ)
 	} else {
 		node.typ = c.expr(mut node.expr)
-		node.typ
+		c.unwrap_generic(node.typ)
 	}
 	sym := c.table.final_sym(typ)
 	if sym.kind == .placeholder || typ.has_flag(.generic) {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -285,6 +285,7 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 			}
 			c.comptime.comptime_for_enum_var = node.val_var
 			c.comptime.type_map[node.val_var] = c.enum_data_type
+			c.comptime.type_map['${node.val_var}.typ'] = node.typ
 			c.stmts(mut node.stmts)
 			c.pop_comptime_info()
 		} else {

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -285,7 +285,7 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 			if node.cond.right is ast.TypeNode && node.cond.left in [ast.Ident, ast.SelectorExpr] {
 				if c.table.type_kind(node.cond.left_type) in [.sum_type, .interface_] {
 					c.smartcast(mut node.cond.left, node.cond.left_type, node.cond.right_type, mut
-						node.scope)
+						node.scope, false)
 				}
 			}
 		}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -179,11 +179,10 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						} else if left is ast.Ident {
 							mut checked_type := ast.void_type
 							is_comptime_type_is_expr = true
-							if c.comptime.is_comptime_var(left) {
-								checked_type = c.unwrap_generic(c.comptime.get_comptime_var_type(left))
-							} else {
-								if var := left.scope.find_var(left.name) {
-									checked_type = c.unwrap_generic(var.typ)
+							if var := left.scope.find_var(left.name) {
+								checked_type = c.unwrap_generic(var.typ)
+								if var.smartcasts.len > 0 {
+									checked_type = c.unwrap_generic(var.smartcasts.last())
 								}
 							}
 							skip_state = c.check_compatible_types(checked_type, right as ast.TypeNode)

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -180,7 +180,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							mut checked_type := ast.void_type
 							is_comptime_type_is_expr = true
 							if c.comptime.is_comptime_var(left) {
-								checked_type = c.comptime.get_comptime_var_type(left)
+								checked_type = c.unwrap_generic(c.comptime.get_comptime_var_type(left))
 							} else {
 								if var := left.scope.find_var(left.name) {
 									checked_type = c.unwrap_generic(var.typ)
@@ -523,7 +523,7 @@ fn (mut c Checker) smartcast_if_conds(mut node ast.Expr, mut scope ast.Scope) {
 				scope)
 		} else if node.op == .key_is {
 			if node.left is ast.Ident && c.comptime.is_comptime_var(node.left) {
-				node.left_type = c.unwrap_generic(c.comptime.get_comptime_var_type(node.left))
+				node.left_type = c.comptime.get_comptime_var_type(node.left)
 			} else {
 				node.left_type = c.expr(mut node.left)
 			}
@@ -550,7 +550,7 @@ fn (mut c Checker) smartcast_if_conds(mut node ast.Expr, mut scope ast.Scope) {
 			}
 			if right_type != ast.Type(0) {
 				right_sym := c.table.sym(right_type)
-				mut expr_type := c.unwrap_generic(c.expr(mut node.left))
+				mut expr_type := c.unwrap_generic(node.left_type)
 				left_sym := c.table.sym(expr_type)
 				if left_sym.kind == .aggregate {
 					expr_type = (left_sym.info as ast.Aggregate).sum_type

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -662,8 +662,6 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 			if typ != ast.Type(0) {
-				left_type = c.unwrap_generic(left_type)
-				left_sym = c.table.sym(left_type)
 				typ_sym := c.table.sym(typ)
 				op := node.op.str()
 				if typ_sym.kind == .placeholder {
@@ -677,7 +675,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					if typ != ast.none_type_idx {
 						c.error('`${op}` can only be used to test for none in sql', node.pos)
 					}
-				} else if left_sym.kind !in [.interface_, .sum_type] {
+				} else if left_sym.kind !in [.interface_, .sum_type]
+					&& !c.comptime.is_comptime_var(node.left) {
 					c.error('`${op}` can only be used with interfaces and sum types',
 						node.pos) // can be used in sql too, but keep err simple
 				} else if mut left_sym.info is ast.SumType {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -662,6 +662,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			}
 			if typ != ast.Type(0) {
+				left_type = c.unwrap_generic(left_type)
+				left_sym = c.table.sym(left_type)
 				typ_sym := c.table.sym(typ)
 				op := node.op.str()
 				if typ_sym.kind == .placeholder {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -476,7 +476,8 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 					expr_type = expr_types[0].typ
 				}
 
-				c.smartcast(mut node.cond, node.cond_type, expr_type, mut branch.scope)
+				c.smartcast(mut node.cond, node.cond_type, expr_type, mut branch.scope,
+					false)
 			}
 		}
 	}

--- a/vlib/v/comptime/comptimeinfo.v
+++ b/vlib/v/comptime/comptimeinfo.v
@@ -54,7 +54,7 @@ pub fn (mut ct ComptimeInfo) get_comptime_var_type(node ast.Expr) ast.Type {
 				node.obj.typ
 			}
 			.smartcast {
-				ct.type_map['${ct.comptime_for_variant_var}.typ'] or { ast.void_type }
+				ct.type_map['${ct.comptime_for_variant_var}.typ'] or { node.obj.typ }
 			}
 			.key_var, .value_var {
 				// key and value variables from normal for stmt

--- a/vlib/v/comptime/comptimeinfo.v
+++ b/vlib/v/comptime/comptimeinfo.v
@@ -77,9 +77,6 @@ pub fn (mut ct ComptimeInfo) get_comptime_var_type(node ast.Expr) ast.Type {
 				ct.comptime_for_variant_var {
 					return ct.type_map['${ct.comptime_for_variant_var}.typ']
 				}
-				ct.comptime_for_enum_var {
-					return ct.type_map['${ct.comptime_for_enum_var}.typ']
-				}
 				else {
 					// field_var.typ from $for field
 					return ct.comptime_for_field_type

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4545,7 +4545,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 									}
 								}
 								if node.obj.ct_type_var == .smartcast {
-									cur_variant_sym := g.table.sym(g.comptime.type_map['${g.comptime.comptime_for_variant_var}.typ'])
+									cur_variant_sym := g.table.sym(g.unwrap_generic(g.comptime.get_comptime_var_type(node)))
 									g.write('${dot}_${cur_variant_sym.cname}')
 								} else if !is_option_unwrap
 									&& obj_sym.kind in [.sum_type, .interface_] {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -878,7 +878,11 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				if sym.info.vals.len > 0 {
 					g.writeln('\tEnumData ${node.val_var} = {0};')
 				}
+				g.push_new_comptime_info()
 				for val in sym.info.vals {
+					g.comptime.comptime_for_enum_var = node.val_var
+					g.comptime.type_map['${node.val_var}.typ'] = node.typ
+
 					g.writeln('/* enum vals ${i} */ {')
 					g.writeln('\t${node.val_var}.name = _SLIT("${val}");')
 					g.write('\t${node.val_var}.value = ')
@@ -900,6 +904,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					g.writeln('}')
 					i++
 				}
+				g.pop_comptime_info()
 			}
 		}
 	} else if node.kind == .attributes {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -673,7 +673,7 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 
 // infix_expr_is_op generates code for `is` and `!is`
 fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
-	mut left_sym := g.table.sym(node.left_type)
+	mut left_sym := g.table.sym(g.unwrap_generic(node.left_type))
 	is_aggregate := left_sym.kind == .aggregate
 	if is_aggregate {
 		parent_left_type := (left_sym.info as ast.Aggregate).sum_type

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -673,7 +673,11 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 
 // infix_expr_is_op generates code for `is` and `!is`
 fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
-	mut left_sym := g.table.sym(g.unwrap_generic(node.left_type))
+	mut left_sym := if g.comptime.is_comptime_var(node.left) {
+		g.table.sym(g.unwrap_generic(g.comptime.get_comptime_var_type(node.left)))
+	} else {
+		g.table.sym(node.left_type)
+	}
 	is_aggregate := left_sym.kind == .aggregate
 	if is_aggregate {
 		parent_left_type := (left_sym.info as ast.Aggregate).sum_type

--- a/vlib/v/tests/comptime_var_is_check_test.v
+++ b/vlib/v/tests/comptime_var_is_check_test.v
@@ -14,6 +14,6 @@ fn gen[T, R](sum T) R {
 }
 
 fn test_main() {
-	// assert dump(gen[TestSum, string](TestSum('foo'))) == 'foo'
+	assert dump(gen[TestSum, string](TestSum('foo'))) == 'foo'
 	assert dump(gen[TestSum, int](TestSum(123))) == 123
 }

--- a/vlib/v/tests/comptime_var_is_check_test.v
+++ b/vlib/v/tests/comptime_var_is_check_test.v
@@ -1,0 +1,19 @@
+type TestSum = int | string
+
+fn gen[T, R](sum T) R {
+	$if T is $sumtype {
+		$for v in sum.variants {
+			if sum is v {
+				$if sum is R {
+					return sum
+				}
+			}
+		}
+	}
+	return R{}
+}
+
+fn test_main() {
+	// assert dump(gen[TestSum, string](TestSum('foo'))) == 'foo'
+	assert dump(gen[TestSum, int](TestSum(123))) == 123
+}


### PR DESCRIPTION
Fix #20312

```v
type TestSum = string | int

fn gen[T, R](sum T) R {
	$if T is $sumtype {
		$for v in sum.variants {
			if sum is v {
				dump(sum)
				$if sum is R {
					return sum
				}
			}
		}
	}
	return R{}
}

fn main() {
	dump(gen[TestSum, string](TestSum('foo')))
}
```