### PR TITLE
cgen: fix missing line breaks in generated code with closure IIFE, when compiled with '-g'(fix #20306)

### DIFF
--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -16,7 +16,7 @@ import sokol.gfx
 import sokol.sgl
 import sokol.sapp
 import stbi
-import szip
+import compress.szip
 import strings
 
 // Help text
@@ -801,10 +801,10 @@ fn main() {
 
 	// App init
 	mut app := &App{
-		gg: 0
+		gg: unsafe { nil }
 		// zip fields
-		zip: 0
-		item_list: 0
+		zip: unsafe { nil }
+		item_list: unsafe { nil }
 	}
 
 	app.state = .scanning

--- a/examples/viewer/zip_container.v
+++ b/examples/viewer/zip_container.v
@@ -9,7 +9,7 @@
 * TODO:
 **********************************************************************/
 import sokol.gfx
-import szip
+import compress.szip
 
 fn (mut il Item_list) scan_zip(path string, in_index int) ! {
 	println('Scanning ZIP [${path}]')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -701,6 +701,9 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.expr(node.left)
 			g.writeln(';')
 			g.write(line)
+			if g.out.last_n(1) != '\n' {
+				g.writeln('')
+			}
 			g.write(tmp_var)
 		} else if node.or_block.kind == .absent {
 			g.expr(node.left)


### PR DESCRIPTION
Fixed #20306

The cause of this issue is that when compiled using the `-g` flag, the `line info` generated in the code does not break a line with the closure's calling code `_t1()`.


```v
x := 1

fn [x] () {
	println(2)
}()
```
original outputs:

```c
#line 1 "/usr/local/v/temp/a.v"
	int x = 1;
	void (*_t1) () = 	__closure_create(anon_fn_e61da51904666690__18, (struct _V_anon_fn_e61da51904666690__18_Ctx*) memdup_uncollectable(&(struct _V_anon_fn_e61da51904666690__18_Ctx){.x = x,
	}, sizeof(struct _V_anon_fn_e61da51904666690__18_Ctx)));
	#line 5 "/usr/local/v/temp/a.v"_t1();
}
```
now outputs:

```c
#line 1 "/usr/local/v/temp/a.v"
	int x = 1;
	void (*_t1) () = 	__closure_create(anon_fn_e61da51904666690__18, (struct _V_anon_fn_e61da51904666690__18_Ctx*) memdup_uncollectable(&(struct _V_anon_fn_e61da51904666690__18_Ctx){.x = x,
	}, sizeof(struct _V_anon_fn_e61da51904666690__18_Ctx)));
	#line 5 "/usr/local/v/temp/a.v"
	_t1();
}
```