### PR TITLE
perf: time.format_rfc3339 and time.now() [10x faster together]

### DIFF
--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -34,8 +34,36 @@ pub fn (t Time) format_ss_nano() string {
 // RFC3339 is an Internet profile, based on the ISO 8601 standard for for representation of dates and times using the Gregorian calendar.
 // It is intended to improve consistency and interoperability, when representing and using date and time in Internet protocols.
 pub fn (t Time) format_rfc3339() string {
+	if t.year == 0 {
+		return '0000-00-00T00:00:00.000Z'
+	}
+
 	u := t.local_to_utc()
-	return '${u.year:04d}-${u.month:02d}-${u.day:02d}T${u.hour:02d}:${u.minute:02d}:${u.second:02d}.${(u.nanosecond / 1_000_000):03d}Z'
+
+	mut buffer := [u8(`0`), `0`, `0`, `0`, `-`, `0`, `0`, `-`, `0`, `0`, `T`, `0`, `0`, `:`, `0`,
+		`0`, `:`, `0`, `0`, `.`, `0`, `0`, `0`, `Z`]!
+
+	insert_text_on_fixed_array(mut buffer, 0, u.year.str(), 4)
+	insert_text_on_fixed_array(mut buffer, 5, u.month.str(), 2)
+	insert_text_on_fixed_array(mut buffer, 8, u.day.str(), 2)
+	insert_text_on_fixed_array(mut buffer, 11, u.hour.str(), 2)
+	insert_text_on_fixed_array(mut buffer, 14, u.minute.str(), 2)
+	insert_text_on_fixed_array(mut buffer, 17, u.second.str(), 2)
+	insert_text_on_fixed_array(mut buffer, 20, u.nanosecond.str(), 3)
+
+	return buffer[..].clone().bytestr()
+}
+
+fn insert_text_on_byte_array(mut buffer []u8, idx int, stri string, decimal_places int) {
+	for i := stri.len; i > 0; i-- {
+		buffer[idx + decimal_places - i] = stri[stri.len - i]
+	}
+}
+
+fn insert_text_on_fixed_array[F](mut buffer F, idx int, stri string, decimal_places int) {
+	for i := stri.len; i > 0; i-- {
+		buffer[idx + decimal_places - i] = stri[stri.len - i]
+	}
 }
 
 // format_rfc3339_nano returns a date string in "YYYY-MM-DDTHH:mm:ss.123456789Z" format (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
@@ -96,9 +124,9 @@ fn ordinal_suffix(n int) string {
 }
 
 const tokens_2 = ['MM', 'Mo', 'DD', 'Do', 'YY', 'ss', 'kk', 'NN', 'mm', 'hh', 'HH', 'ii', 'ZZ',
-	'dd', 'Qo', 'QQ', 'wo', 'ww']
-const tokens_3 = ['MMM', 'DDD', 'ZZZ', 'ddd']
-const tokens_4 = ['MMMM', 'DDDD', 'DDDo', 'dddd', 'YYYY']
+	'dd', 'Qo', 'QQ', 'wo', 'ww']!
+const tokens_3 = ['MMM', 'DDD', 'ZZZ', 'ddd']!
+const tokens_4 = ['MMMM', 'DDDD', 'DDDo', 'dddd', 'YYYY']!
 
 // custom_format returns a date with custom format
 //

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -34,11 +34,11 @@ pub fn (t Time) format_ss_nano() string {
 // RFC3339 is an Internet profile, based on the ISO 8601 standard for for representation of dates and times using the Gregorian calendar.
 // It is intended to improve consistency and interoperability, when representing and using date and time in Internet protocols.
 pub fn (t Time) format_rfc3339() string {
-	if t.year == 0 {
+	u := t.local_to_utc()
+
+	if u.year == 0 {
 		return '0000-00-00T00:00:00.000Z'
 	}
-
-	u := t.local_to_utc()
 
 	mut buffer := [u8(`0`), `0`, `0`, `0`, `-`, `0`, `0`, `-`, `0`, `0`, `T`, `0`, `0`, `:`, `0`,
 		`0`, `:`, `0`, `0`, `.`, `0`, `0`, `0`, `Z`]!

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -470,7 +470,6 @@ pub fn offset() int {
 // local_to_utc converts the receiver `t` to the corresponding UTC time, if it contains local time.
 // If the receiver already does contain UTC time, it returns it unchanged.
 pub fn (t Time) local_to_utc() Time {
-	// aqui
 	if !t.is_local {
 		return t
 	}

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -2,7 +2,7 @@ module time
 
 pub const days_string = 'MonTueWedThuFriSatSun'
 pub const long_days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
-pub const month_days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+pub const month_days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]!
 pub const months_string = 'JanFebMarAprMayJunJulAugSepOctNovDec'
 pub const long_months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
 	'September', 'October', 'November', 'December']
@@ -32,7 +32,7 @@ pub const days_before = [
 	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
 	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
 	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31,
-]
+]!
 
 // Time contains various time units for a point in time.
 pub struct Time {
@@ -470,6 +470,7 @@ pub fn offset() int {
 // local_to_utc converts the receiver `t` to the corresponding UTC time, if it contains local time.
 // If the receiver already does contain UTC time, it returns it unchanged.
 pub fn (t Time) local_to_utc() Time {
+	// aqui
 	if !t.is_local {
 		return t
 	}

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -87,7 +87,7 @@ fn linux_now() Time {
 }
 
 // fast_linux_now have 1ms less precision than linux_now
-fn fast_linux_now() Time {
+pub fn fast_linux_now() Time {
 	// get the high precision time as UTC realtime clock
 	// and use the nanoseconds part
 	mut ts := C.timespec{}

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -86,11 +86,30 @@ fn linux_now() Time {
 	return convert_ctime(loc_tm, int(ts.tv_nsec))
 }
 
+// fast_linux_now have 1ms less precision than linux_now
+fn fast_linux_now() Time {
+	// get the high precision time as UTC realtime clock
+	// and use the nanoseconds part
+	mut ts := C.timespec{}
+	C.clock_gettime(C.CLOCK_REALTIME_COARSE, &ts)
+	loc_tm := C.tm{}
+	C.localtime_r(voidptr(&ts.tv_sec), &loc_tm)
+	return convert_ctime(loc_tm, int(ts.tv_nsec))
+}
+
 fn linux_utc() Time {
 	// get the high precision time as UTC realtime clock
 	// and use the nanoseconds part
 	mut ts := C.timespec{}
 	C.clock_gettime(C.CLOCK_REALTIME, &ts)
+	return unix_nanosecond(i64(ts.tv_sec), int(ts.tv_nsec))
+}
+
+// fast_linux_utc have 1ms less precision than linux_utc
+// see https://access.redhat.com/documentation/pt-br/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/sect-posix_clocks
+fn fast_linux_utc() Time {
+	mut ts := C.timespec{}
+	C.clock_gettime(C.CLOCK_REALTIME_COARSE, &ts)
 	return unix_nanosecond(i64(ts.tv_sec), int(ts.tv_nsec))
 }
 

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -113,7 +113,7 @@ fn (e &Encoder) encode_any(val Any, level int, mut buf []u8) ! {
 			buf << `]`
 		}
 		time.Time {
-			str_time := val.format_rfc3339()
+			str_time := val.fast_format_rfc3339()
 			buf << `"`
 			unsafe { buf.push_many(str_time.str, str_time.len) }
 			buf << `"`
@@ -236,7 +236,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 				} $else $if field.typ is ?time.Time {
 					option_value := val.$(field.name) as ?time.Time
 					parsed_time := option_value as time.Time
-					e.encode_string(parsed_time.format_rfc3339(), mut buf)!
+					e.encode_string(parsed_time.fast_format_rfc3339(), mut buf)!
 				} $else $if field.is_array {
 					e.encode_array(value, level + 1, mut buf)!
 				} $else $if field.is_struct {
@@ -304,7 +304,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 			} $else $if field.typ is string {
 				e.encode_string(val.$(field.name).str(), mut buf)!
 			} $else $if field.typ is time.Time {
-				str_value := val.$(field.name).format_rfc3339()
+				str_value := val.$(field.name).fast_format_rfc3339()
 				buf << json2.quote_rune
 				unsafe { buf.push_many(str_value.str, str_value.len) }
 				buf << json2.quote_rune
@@ -349,7 +349,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 						if sum_type_value.contains_any(' /:-') {
 							date_time_str := time.parse(sum_type_value)!
 							unsafe {
-								str_value := date_time_str.format_rfc3339()
+								str_value := date_time_str.fast_format_rfc3339()
 								buf.push_many(str_value.str, str_value.len)
 							}
 						} else {
@@ -400,7 +400,7 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 					e.encode_string(val.$(field.name).str(), mut buf)!
 				} $else $if field.unaliased_typ is time.Time {
 					parsed_time := time.parse(val.$(field.name).str()) or { time.Time{} }
-					e.encode_string(parsed_time.format_rfc3339(), mut buf)!
+					e.encode_string(parsed_time.fast_format_rfc3339(), mut buf)!
 				} $else $if field.unaliased_typ is bool {
 					if val.$(field.name).str() == json2.true_in_string {
 						unsafe { buf.push_many(json2.true_in_string.str, json2.true_in_string.len) }


### PR DESCRIPTION
### TODO
- [ ] replace half by `now(presicion ?string)` // presicion will be `nanosecond`, `milisecond`, `sec` for performance purpose

### Benchmark
```v
import time
import benchmark
import os

const max_iterations = os.getenv_opt('MAX_ITERATIONS') or { '100000' }.int()

fn main() {
	empty_time := time.Time{}
	// now_time := time.now()
	// fast_now_time := time.fast_linux_now()


	mut b := benchmark.start()

	for _ in 0 .. max_iterations {
		_ := empty_time.fast_format_rfc3339()
	}

	b.measure('empty_time.fast_format_rfc3339()')

	for _ in 0 .. max_iterations {
		_ := empty_time.format_rfc3339()
	}

	b.measure('empty_time.format_rfc3339()\n')
// -------------------------------------------------------------------------------
	for _ in 0 .. max_iterations {
		_ := time.now().fast_format_rfc3339()
	}

	b.measure('time.now().fast_format_rfc3339()')


	for _ in 0 .. max_iterations {
		_ := time.now().format_rfc3339()
	}

	b.measure('time.now().format_rfc3339()\n')
// -------------------------------------------------------------------------------
	for _ in 0 .. max_iterations {
		_ := time.fast_linux_now().fast_format_rfc3339()
	}

	b.measure('time.fast_linux_now().fast_format_rfc3339()')


	for _ in 0 .. max_iterations {
		_ := time.fast_linux_now().format_rfc3339()
	}

	b.measure('time.fast_linux_now().format_rfc3339()\n')
// -------------------------------------------------------------------------------
}
```
```bash
╰─ ./v -prod crun la.v ─╯
 SPENT    20.646 ms in empty_time.fast_format_rfc3339()
 SPENT     0.350 ms in empty_time.format_rfc3339()

 SPENT   140.616 ms in time.now().fast_format_rfc3339()
 SPENT   270.342 ms in time.now().format_rfc3339() // [Worse]

 SPENT    20.827 ms in time.fast_linux_now().fast_format_rfc3339() // [Better]
 SPENT   152.914 ms in time.fast_linux_now().format_rfc3339()

```

### time benchs
```v
import benchmark

const max_iterations = 100_000

fn main() {
	mut b := benchmark.start()
	mut ts := C.timespec{}

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_REALTIME, &ts)
	}

	b.measure('CLOCK_REALTIME')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_REALTIME_COARSE, &ts)
	}

	b.measure('CLOCK_REALTIME_COARSE')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_MONOTONIC_COARSE, &ts)
	}

	b.measure('CLOCK_MONOTONIC_COARSE')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_MONOTONIC, &ts)
	}

	b.measure('CLOCK_MONOTONIC')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_MONOTONIC_RAW, &ts)
	}

	b.measure('CLOCK_MONOTONIC_RAW')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_BOOTTIME, &ts)
	}

	b.measure('CLOCK_BOOTTIME')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_PROCESS_CPUTIME_ID, &ts)
	}

	b.measure('CLOCK_PROCESS_CPUTIME_ID')

	for _ in 0 .. max_iterations {
		C.clock_gettime(C.CLOCK_THREAD_CPUTIME_ID, &ts)
	}

	b.measure('CLOCK_THREAD_CPUTIME_ID')

}
```
```bash
╰─ v -prod crun time_perf_teste.v ─╯
 SPENT   117.176 ms in CLOCK_REALTIME
 SPENT     0.546 ms in CLOCK_REALTIME_COARSE
 SPENT     0.523 ms in CLOCK_MONOTONIC_COARSE
 SPENT   118.127 ms in CLOCK_MONOTONIC
 SPENT   117.972 ms in CLOCK_MONOTONIC_RAW
 SPENT   119.232 ms in CLOCK_BOOTTIME
 SPENT    43.921 ms in CLOCK_PROCESS_CPUTIME_ID
 SPENT    40.514 ms in CLOCK_THREAD_CPUTIME_ID
```