### PR TITLE
orm: fix "not equal" operator

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -92,7 +92,9 @@ pub enum SQLDialect {
 
 fn (kind OperationKind) to_str() string {
 	str := match kind {
-		.neq { '!=' }
+		// While most SQL databases support "!=" for not equal, "<>" is the standard
+		// operator.
+		.neq { '<>' }
 		.eq { '=' }
 		.gt { '>' }
 		.lt { '<' }


### PR DESCRIPTION
While most SQL databases support "!=" for not equal, "<>" is the standard operator.