### PR TITLE
db.pg: fix error with msvc compiler +instructions

### DIFF
--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -69,6 +69,11 @@ format *PG_VERSION_NUM 17* without 0 also should work
 
 7. Add libpq.dll to v/thirdparty/pg/win64
 
+If you are going to use the msvc compiler:
+7. Add libpq.lib(C:\Program Files\PostgreSQL\{version}\lib) to v/thirdparty/pg/win64/msvc
+
+8. Add libpq.dll, libcrypto-3-x64.dll, libssl-3-x64.dll to where your executable is.
+
 To get the libpq.dll file, you can install the PostgreSQL database, 
 and get this dll from its bin/ folder, or compile DB from source code.
 ```

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -6,7 +6,11 @@ import orm
 $if $pkgconfig('libpq') {
 	#pkgconfig --cflags --libs libpq
 } $else {
-	#flag -lpq
+	$if msvc {
+		#flag -llibpq
+	} $else {
+		#flag -lpq
+	}
 	#flag linux -I/usr/include/postgresql
 
 	#flag darwin -I/opt/local/include/postgresql11


### PR DESCRIPTION
Whenever it is compiled on Windows and there are no .dlls in the executable folder, it simply closes with the error code `-1073741515` equivalent to `0xC0000135`.

1. I'm adding to the readme which .dlls are needed.
2. Correcting the flag that is passed to the msvc compiler.
3. Explained where to place libpq if using the msvc compiler.