### PR TITLE
sokol: Fix build on OpenBSD

### DIFF
--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -9,7 +9,7 @@ pub const used_import = 1
 
 #flag linux -lX11 -lGL -lXcursor -lXi -lpthread
 #flag freebsd -L/usr/local/lib -lX11 -lGL -lXcursor -lXi
-#flag openbsd -L/usr/X11R6/lib -lX11 -lGL -lXcursor -lXi
+#flag openbsd -I/usr/X11R6/include -L/usr/X11R6/lib -lX11 -lGL -lXcursor -lXi
 #flag windows -lgdi32
 
 $if windows {


### PR DESCRIPTION
It needs this include path in order to find `X11/Xlib.h`.

This was tested on OpenBSD/amd64 with a local X11 display using various programs in `examples/`.