### PR TITLE
cgen: add missing clear method

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -880,8 +880,6 @@ fn (mut g Gen) gen_arg_from_type(node_type ast.Type, node ast.Expr) {
 fn (mut g Gen) gen_map_method_call(node ast.CallExpr, left_type ast.Type, left_sym ast.TypeSymbol) bool {
 	match node.name {
 		'clear' {
-			left_info := left_sym.info as ast.Map
-			elem_type_str := g.typ(left_info.key_type)
 			g.write('map_clear(')
 			g.gen_arg_from_type(left_type, node.left)
 			g.write(')')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -879,6 +879,14 @@ fn (mut g Gen) gen_arg_from_type(node_type ast.Type, node ast.Expr) {
 
 fn (mut g Gen) gen_map_method_call(node ast.CallExpr, left_type ast.Type, left_sym ast.TypeSymbol) bool {
 	match node.name {
+		'clear' {
+			left_info := left_sym.info as ast.Map
+			elem_type_str := g.typ(left_info.key_type)
+			g.write('map_clear(')
+			g.gen_arg_from_type(left_type, node.left)
+			g.write(')')
+			return true
+		}
 		'delete' {
 			left_info := left_sym.info as ast.Map
 			elem_type_str := g.typ(left_info.key_type)

--- a/vlib/v/tests/map_clear_test.v
+++ b/vlib/v/tests/map_clear_test.v
@@ -1,0 +1,49 @@
+pub type EventListener[T] = fn (T) !
+
+pub struct EventController[T] {
+mut:
+	id        int
+	listeners map[int]EventListener[T]
+}
+
+fn (mut ec EventController[T]) generate_id() int {
+	return ec.id++
+}
+
+pub fn (mut ec EventController[T]) override(listener EventListener[T]) EventController[T] {
+	ec.listeners.clear()
+	return ec.listen(listener)
+}
+
+pub fn (mut ec EventController[T]) listen(listener EventListener[T]) EventController[T] {
+	ec.listeners[ec.generate_id()] = listener
+	return ec
+}
+
+struct Foo {}
+
+struct Bar {}
+
+fn make[T](i int) EventController[T] {
+	return EventController[T]{
+		id: i
+	}
+}
+
+fn test_main() {
+	mut a := EventController[Foo]{
+		id: 1
+		listeners: {
+			1: fn (a Foo) ! {
+				dump(1)
+			}
+		}
+	}
+	assert dump(a).id == 1
+	assert dump(a).listeners.len == 1
+	a.override(fn (a Foo) ! {
+		dump(2)
+	})
+	assert dump(a).id == 2
+	assert dump(a).listeners.len == 1
+}


### PR DESCRIPTION
Fix #20338

Missing map method .clear() translation to map_clear() call.