### PR TITLE
vlib: fix syntax error in go_array_wait_test.v

### DIFF
--- a/vlib/v/tests/go_array_wait_test.v
+++ b/vlib/v/tests/go_array_wait_test.v
@@ -41,9 +41,8 @@ fn test_array_thread_void_wait() {
 
 fn test_void_thread_decl() {
 	shared a := [2, 3, 9]
-	mut t1 := thread(0)
+	mut t1 := spawn g(shared a, 0)
 	mut tarr := []thread{len: 2}
-	t1 = spawn g(shared a, 0)
 	tarr[0] = spawn g(shared a, 1)
 	tarr[1] = spawn g(shared a, 2)
 	t1.wait()


### PR DESCRIPTION
Fix compiler syntax error.  At some point in time this syntax might have been legal, but now it is neither legal nor required.