### PR TITLE
cgen: fix array fixed initialization with prefixexpr &

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -24,7 +24,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 	}
 	len := node.exprs.len
 	if array_type.unaliased_sym.kind == .array_fixed {
-		g.fixed_array_init(node, array_type, var_name)
+		g.fixed_array_init(node, array_type, var_name, is_amp)
 		if is_amp {
 			g.write(')')
 		}
@@ -79,7 +79,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 	}
 }
 
-fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name string) {
+fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name string, is_amp bool) {
 	prev_inside_lambda := g.inside_lambda
 	g.inside_lambda = true
 	defer {
@@ -177,6 +177,8 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 				g.write(', ')
 			}
 		}
+	} else if is_amp {
+		g.write('0')
 	} else {
 		elem_sym := g.table.final_sym(node.elem_type)
 		if elem_sym.kind == .map {

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -210,8 +210,13 @@ fn (mut g Gen) dump_expr_definitions() {
 		surrounder.builder_write_afters(mut dump_fns)
 		if is_fixed_arr_ret {
 			tmp_var := g.new_tmp_var()
-			dump_fns.writeln('\t${str_dumparg_ret_type} ${tmp_var} = {0};')
-			dump_fns.writeln('\tmemcpy(${tmp_var}.ret_arr, dump_arg, sizeof(${str_dumparg_type}));')
+			if typ.is_ptr() {
+				dump_fns.writeln('\t${str_dumparg_ret_type} ${tmp_var} = HEAP(${g.typ(typ.set_nr_muls(0))}, {0});')
+				dump_fns.writeln('\tmemcpy(${tmp_var}->ret_arr, dump_arg, sizeof(${str_dumparg_type}));')
+			} else {
+				dump_fns.writeln('\t${str_dumparg_ret_type} ${tmp_var} = {0};')
+				dump_fns.writeln('\tmemcpy(${tmp_var}.ret_arr, dump_arg, sizeof(${str_dumparg_type}));')
+			}
 			dump_fns.writeln('\treturn ${tmp_var};')
 		} else {
 			dump_fns.writeln('\treturn dump_arg;')

--- a/vlib/v/tests/array_fixed_ptr_test.v
+++ b/vlib/v/tests/array_fixed_ptr_test.v
@@ -1,0 +1,11 @@
+fn test_main() {
+	a := &[2]u8{}
+	dump(a)
+	assert a.len == 2
+}
+
+fn test_empty() {
+	_ := &[2]u8{}
+
+	assert true
+}


### PR DESCRIPTION
Fix #20343 

```v
fn test_main() {
	a := &[2]u8{}
	dump(a)
	assert a.len == 2
}

fn test_empty() {
	_ := &[2]u8{}

	assert true
}
```