### PR TITLE
checker: fix being too strict with generics in assignment type mismatch checking

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -735,7 +735,9 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 				}
 			}
 		}
-		if !is_blank_ident && right_sym.kind != .placeholder && left_sym.kind != .interface_ {
+		if !is_blank_ident && right_sym.kind != .placeholder && left_sym.kind != .interface_
+			&& ((!right_type.has_flag(.generic) && !left_type.has_flag(.generic))
+			|| right_sym.kind != left_sym.kind) {
 			// Dual sides check (compatibility check)
 			c.check_expected(right_type_unwrapped, left_type_unwrapped) or {
 				// allow literal values to auto deref var (e.g.`for mut v in values { v = 1.0 }`)

--- a/vlib/v/tests/assign_type_checking_with_generics_test.v
+++ b/vlib/v/tests/assign_type_checking_with_generics_test.v
@@ -1,0 +1,33 @@
+module main
+
+pub type EventListener[T] = fn (T) !
+
+pub type Check[T] = fn (T) bool
+
+pub struct EventController[T] {
+mut:
+	id        int
+	listeners map[int]EventListener[T]
+}
+
+fn (mut ec EventController[T]) generate_id() int {
+	return ec.id++
+}
+
+pub fn (mut ec EventController[T]) override(listener EventListener[T]) EventController[T] {
+	ec.listeners = {
+		ec.generate_id(): listener
+	}
+	return ec
+}
+
+fn use[T](_ EventController[T]) {}
+
+struct Foo {}
+
+struct Bar {}
+
+fn test_main() {
+	use(EventController[Foo]{})
+	use(EventController[Bar]{})
+}


### PR DESCRIPTION
Close #20335

This PR is a patch to PR #20327, temporarily relaxing the mismatch check on generic types.   :)

1. The test case of the original PR 20327 continues to be valid
2. `discord.v` on the submitted 94d5563 can already be compiled properly.

At present, the type mismatch check on assignment is too lenient for generics, and there will be some missed cases.  I have written it down in a memo and arranged time for detailed handling