### PR TITLE
cgen: fix option initialization with default struct initialization to not be `none`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1968,7 +1968,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		}
 		if ret_typ.has_flag(.option) {
 			if expr_typ.has_flag(.option) && expr in [ast.StructInit, ast.ArrayInit, ast.MapInit] {
-				if expr is ast.StructInit {
+				if expr is ast.StructInit && expr.init_fields.len > 0 {
 					g.write('_option_ok(&(${styp}[]) { ')
 				} else {
 					g.write('_option_none(&(${styp}[]) { ')
@@ -1980,6 +1980,10 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				// option ptr assignment simplification
 				if is_ptr_to_ptr_assign {
 					g.write('${tmp_var} = ')
+				} else if expr_typ.has_flag(.option) && expr is ast.PrefixExpr
+					&& expr.right is ast.StructInit
+					&& (expr.right as ast.StructInit).init_fields.len == 0 {
+					g.write('_option_none(&(${styp}[]) { ')
 				} else {
 					g.write('_option_ok(&(${styp}[]) { ')
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1980,9 +1980,6 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				// option ptr assignment simplification
 				if is_ptr_to_ptr_assign {
 					g.write('${tmp_var} = ')
-				} else if expr is ast.PrefixExpr && expr.right is ast.StructInit
-					&& (expr.right as ast.StructInit).init_fields.len == 0 {
-					g.write('_option_none(&(${styp}[]) { ')
 				} else {
 					g.write('_option_ok(&(${styp}[]) { ')
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1968,7 +1968,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		}
 		if ret_typ.has_flag(.option) {
 			if expr_typ.has_flag(.option) && expr in [ast.StructInit, ast.ArrayInit, ast.MapInit] {
-				if expr is ast.StructInit && expr.init_fields.len > 0 {
+				if expr is ast.StructInit {
 					g.write('_option_ok(&(${styp}[]) { ')
 				} else {
 					g.write('_option_none(&(${styp}[]) { ')

--- a/vlib/v/tests/option_init_ptr_test.v
+++ b/vlib/v/tests/option_init_ptr_test.v
@@ -21,6 +21,6 @@ fn test_option_empty() {
 	b := &?Abc{}
 	dump(b)
 
-	assert a == none
-	assert b == none
+	assert a != none
+	assert b != none
 }

--- a/vlib/v/tests/option_init_ptr_test.v
+++ b/vlib/v/tests/option_init_ptr_test.v
@@ -21,6 +21,6 @@ fn test_option_empty() {
 	b := &?Abc{}
 	dump(b)
 
-	assert a != none
-	assert b != none
+	assert a == none
+	assert b == none
 }

--- a/vlib/v/tests/option_ptr_init_empty_test.v
+++ b/vlib/v/tests/option_ptr_init_empty_test.v
@@ -1,0 +1,21 @@
+pub struct Test {
+	a int = 10
+	b int = 5
+}
+
+pub struct ABC {
+	test ?&Test
+}
+
+fn test_main() {
+	abc := ABC{
+		test: &Test{}
+	}
+
+	if ttt := abc.test {
+		assert ttt.a == 10
+		assert ttt.b == 5
+	} else {
+		assert false
+	}
+}

--- a/vlib/v/tests/option_ptr_init_empty_test.v
+++ b/vlib/v/tests/option_ptr_init_empty_test.v
@@ -4,15 +4,24 @@ pub struct Test {
 }
 
 pub struct ABC {
-	test ?&Test
+	test  ?&Test
+	test2 ?Test
 }
 
 fn test_main() {
 	abc := ABC{
-		test: &Test{}
+		test: &Test{} // non option init
+		test2: Test{} // non option init
 	}
 
 	if ttt := abc.test {
+		assert ttt.a == 10
+		assert ttt.b == 5
+	} else {
+		assert false
+	}
+
+	if ttt := abc.test2 {
 		assert ttt.a == 10
 		assert ttt.b == 5
 	} else {


### PR DESCRIPTION
Fix #20345

```V
pub struct Test {
	a int = 10
	b int = 5
}

pub struct ABC {
	test ?&Test
}

fn test_main() {
	abc := ABC{
		test: &Test{}
	}

	if ttt := abc.test {
		assert ttt.a == 10
		assert ttt.b == 5
	} else {
		assert false
	}
}
``` 