### PR TITLE
cgen: fix auto str for arr options with possible circular reference

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -342,6 +342,7 @@ fn (mut g Gen) gen_array_equality_fn(left_type ast.Type) string {
 
 	if left_type.has_flag(.option) {
 		fn_builder.writeln('\tif (a.state != b.state) return false;')
+		fn_builder.writeln('\tif (a.state == 2 && a.state == b.state) return true;')
 	}
 
 	fn_builder.writeln('\tif (${left_len} != ${right_len}) {')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1022,7 +1022,12 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 		// handle circular ref type of struct to the struct itself
 		if styp == field_styp && !allow_circular {
 			if is_field_array {
-				fn_body.write_string('it.${field_name}.len > 0 ? ${funcprefix}_SLIT("[<circular>]") : ${funcprefix}_SLIT("[]")')
+				if is_opt_field {
+					arr_styp := g.base_type(field.typ)
+					fn_body.write_string('it.${field_name}.state != 2 && (*(${arr_styp}*)it.${field_name}.data).len > 0 ? ${funcprefix}_SLIT("[<circular>]") : ${funcprefix}_SLIT("[]")')
+				} else {
+					fn_body.write_string('it.${field_name}.len > 0 ? ${funcprefix}_SLIT("[<circular>]") : ${funcprefix}_SLIT("[]")')
+				}
 			} else {
 				fn_body.write_string('${funcprefix}_SLIT("<circular>")')
 			}

--- a/vlib/v/tests/option_arr_auto_str_test.v
+++ b/vlib/v/tests/option_arr_auto_str_test.v
@@ -57,7 +57,10 @@ fn test_main() {
 		'type':        json2.Any(3)
 		'name':        'foo'
 		'description': 'This is my first command.'
-	})! == ApplicationCommandOption{
+	}) or {
+		assert false, 'Should not return error: ${err}'
+		return
+	} == ApplicationCommandOption{
 		typ: .string
 		name: 'foo'
 		description: 'This is my first command.'

--- a/vlib/v/tests/option_arr_auto_str_test.v
+++ b/vlib/v/tests/option_arr_auto_str_test.v
@@ -1,0 +1,65 @@
+import x.json2
+
+pub fn maybe_map[T, X](a []T, f fn (T) !X) ![]X {
+	mut r := []X{cap: a.len}
+	for v in a {
+		r << f(v)!
+	}
+	return r
+}
+
+pub enum ApplicationCommandOptionType {
+	sub_command       = 1
+	sub_command_group
+	string
+	integer
+	boolean
+	user
+	channel
+	role
+	mentionable
+	number
+	attachment
+}
+
+pub struct ApplicationCommandOption {
+pub:
+	typ         ApplicationCommandOptionType @[required]
+	name        string                       @[required]
+	description string                       @[required]
+	options     ?[]ApplicationCommandOption
+}
+
+pub fn ApplicationCommandOption.parse(j json2.Any) !ApplicationCommandOption {
+	match j {
+		map[string]json2.Any {
+			return ApplicationCommandOption{
+				typ: unsafe { ApplicationCommandOptionType(j['type']!.int()) }
+				name: j['name']! as string
+				description: j['description']! as string
+				options: if a := j['options'] {
+					maybe_map(a as []json2.Any, fn (k json2.Any) !ApplicationCommandOption {
+						return ApplicationCommandOption.parse(k)!
+					})!
+				} else {
+					none
+				}
+			}
+		}
+		else {
+			return error('expected application command option to be object, got ${j.type_name()}')
+		}
+	}
+}
+
+fn test_main() {
+	assert ApplicationCommandOption.parse({
+		'type':        json2.Any(3)
+		'name':        'foo'
+		'description': 'This is my first command.'
+	})! == ApplicationCommandOption{
+		typ: .string
+		name: 'foo'
+		description: 'This is my first command.'
+	}
+}


### PR DESCRIPTION
Fix #20350

```V
import x.json2

pub fn maybe_map[T, X](a []T, f fn (T) !X) ![]X {
	mut r := []X{cap: a.len}
	for v in a {
		r << f(v)!
	}
	return r
}

pub enum ApplicationCommandOptionType {
	sub_command       = 1
	sub_command_group
	string
	integer
	boolean
	user
	channel
	role
	mentionable
	number
	attachment
}

pub struct ApplicationCommandOption {
pub:
	typ         ApplicationCommandOptionType @[required]
	name        string                       @[required]
	description string                       @[required]
	options     ?[]ApplicationCommandOption
}

pub fn ApplicationCommandOption.parse(j json2.Any) !ApplicationCommandOption {
	match j {
		map[string]json2.Any {
			return ApplicationCommandOption{
				typ: unsafe { ApplicationCommandOptionType(j['type']!.int()) }
				name: j['name']! as string
				description: j['description']! as string
				options: if a := j['options'] {
					maybe_map(a as []json2.Any, fn (k json2.Any) !ApplicationCommandOption {
						return ApplicationCommandOption.parse(k)!
					})!
				} else {
					none
				}
			}
		}
		else {
			return error('expected application command option to be object, got ${j.type_name()}')
		}
	}
}

fn test_main() {
	assert ApplicationCommandOption.parse({
		'type':        json2.Any(3)
		'name':        'foo'
		'description': 'This is my first command.'
	})! == ApplicationCommandOption{
		typ: .string
		name: 'foo'
		description: 'This is my first command.'
	}
}
``` 