### PR TITLE
v: support `-?` as alias to `-help`

### DIFF
--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -387,7 +387,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-check' {
 				res.check_only = true
 			}
-			'-h', '-help', '--help' {
+			'-?', '-h', '-help', '--help' {
 				// Note: help is *very important*, just respond to all variations:
 				res.is_help = true
 			}


### PR DESCRIPTION
Implements https://github.com/vlang/v/issues/20355