### PR TITLE
checker: rename `check_expr_opt_call` to `check_expr_result_call`

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -37,7 +37,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			if i == 0 {
 				right_first_type = right_type
 				node.right_types = [
-					c.check_expr_opt_call(right, right_first_type),
+					c.check_expr_result_call(right, right_first_type),
 				]
 			}
 			if right_type_sym.kind == .multi_return {
@@ -159,7 +159,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.inside_decl_rhs = false
 			c.inside_ref_lit = old_inside_ref_lit
 			if node.right_types.len == i {
-				node.right_types << c.check_expr_opt_call(node.right[i], right_type)
+				node.right_types << c.check_expr_result_call(node.right[i], right_type)
 			}
 		}
 		mut right := if i < node.right.len { node.right[i] } else { node.right[0] }

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -37,7 +37,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			if i == 0 {
 				right_first_type = right_type
 				node.right_types = [
-					c.check_expr_result_call(right, right_first_type),
+					c.check_expr_option_or_result_call(right, right_first_type),
 				]
 			}
 			if right_type_sym.kind == .multi_return {
@@ -159,7 +159,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			c.inside_decl_rhs = false
 			c.inside_ref_lit = old_inside_ref_lit
 			if node.right_types.len == i {
-				node.right_types << c.check_expr_result_call(node.right[i], right_type)
+				node.right_types << c.check_expr_option_or_result_call(node.right[i],
+					right_type)
 			}
 		}
 		mut right := if i < node.right.len { node.right[i] } else { node.right[0] }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1140,8 +1140,8 @@ fn (mut c Checker) expr_or_block_err(kind ast.OrKind, expr_name string, pos toke
 	}
 }
 
-// return the actual type of the expression, once the option is handled
-fn (mut c Checker) check_expr_opt_call(expr ast.Expr, ret_type ast.Type) ast.Type {
+// return the actual type of the expression, once the result is handled
+fn (mut c Checker) check_expr_result_call(expr ast.Expr, ret_type ast.Type) ast.Type {
 	match expr {
 		ast.CallExpr {
 			mut expr_ret_type := expr.return_type
@@ -1212,13 +1212,13 @@ fn (mut c Checker) check_expr_opt_call(expr ast.Expr, ret_type ast.Type) ast.Typ
 			}
 		}
 		ast.CastExpr {
-			c.check_expr_opt_call(expr.expr, ret_type)
+			c.check_expr_result_call(expr.expr, ret_type)
 		}
 		ast.AsCast {
-			c.check_expr_opt_call(expr.expr, ret_type)
+			c.check_expr_result_call(expr.expr, ret_type)
 		}
 		ast.ParExpr {
-			c.check_expr_opt_call(expr.expr, ret_type)
+			c.check_expr_result_call(expr.expr, ret_type)
 		}
 		else {}
 	}
@@ -1688,7 +1688,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 			c.error('duplicate const `${field.name}`', name_pos)
 		}
 		if field.expr is ast.CallExpr {
-			sym := c.table.sym(c.check_expr_opt_call(field.expr, c.expr(mut field.expr)))
+			sym := c.table.sym(c.check_expr_result_call(field.expr, c.expr(mut field.expr)))
 			if sym.kind == .multi_return {
 				c.error('const declarations do not support multiple return values yet',
 					field.expr.pos())
@@ -1708,7 +1708,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 		c.const_deps << field.name
 		prev_const_var := c.const_var
 		c.const_var = unsafe { field }
-		mut typ := c.check_expr_opt_call(field.expr, c.expr(mut field.expr))
+		mut typ := c.check_expr_result_call(field.expr, c.expr(mut field.expr))
 		if ct_value := c.eval_comptime_const_expr(field.expr, 0) {
 			field.comptime_expr_value = ct_value
 			if ct_value is u64 {
@@ -2076,9 +2076,9 @@ fn (mut c Checker) stmt(mut node ast.Stmt) {
 					}
 				}
 			}
-			c.check_expr_opt_call(node.expr, or_typ)
+			c.check_expr_result_call(node.expr, or_typ)
 			// TODO This should work, even if it's prolly useless .-.
-			// node.typ = c.check_expr_opt_call(node.expr, ast.void_type)
+			// node.typ = c.check_expr_result_call(node.expr, ast.void_type)
 		}
 		ast.FnDecl {
 			c.fn_decl(mut node)
@@ -2137,7 +2137,7 @@ fn (mut c Checker) stmt(mut node ast.Stmt) {
 fn (mut c Checker) assert_stmt(mut node ast.AssertStmt) {
 	cur_exp_typ := c.expected_type
 	c.expected_type = ast.bool_type
-	assert_type := c.check_expr_opt_call(node.expr, c.expr(mut node.expr))
+	assert_type := c.check_expr_result_call(node.expr, c.expr(mut node.expr))
 	if assert_type != ast.bool_type_idx {
 		atype_name := c.table.sym(assert_type).name
 		c.error('assert can be used only with `bool` expressions, but found `${atype_name}` instead',
@@ -2721,7 +2721,7 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 					node.expr_type = c.comptime.type_map[(node.expr as ast.Ident).name]
 				}
 			}
-			c.check_expr_opt_call(node.expr, node.expr_type)
+			c.check_expr_result_call(node.expr, node.expr_type)
 			etidx := node.expr_type.idx()
 			if etidx == ast.void_type_idx {
 				c.error('dump expression can not be void', node.expr.pos())
@@ -4448,7 +4448,7 @@ fn (mut c Checker) index_expr(mut node ast.IndexExpr) ast.Type {
 		c.expected_or_type = typ
 	}
 	c.stmts_ending_with_expression(mut node.or_expr.stmts)
-	c.check_expr_opt_call(node, typ)
+	c.check_expr_result_call(node, typ)
 	return typ
 }
 

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -73,7 +73,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.check_array_init_default_expr(mut node)
 		}
 		if node.has_len {
-			len_typ := c.check_expr_opt_call(node.len_expr, c.expr(mut node.len_expr))
+			len_typ := c.check_expr_result_call(node.len_expr, c.expr(mut node.len_expr))
 			if len_typ.has_flag(.option) {
 				c.error('cannot use unwrapped Option as length', node.len_expr.pos())
 			}
@@ -86,7 +86,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			}
 		}
 		if node.has_cap {
-			cap_typ := c.check_expr_opt_call(node.cap_expr, c.expr(mut node.cap_expr))
+			cap_typ := c.check_expr_result_call(node.cap_expr, c.expr(mut node.cap_expr))
 			if cap_typ.has_flag(.option) {
 				c.error('cannot use unwrapped Option as capacity', node.cap_expr.pos())
 			}
@@ -151,7 +151,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			}
 		}
 		for i, mut expr in node.exprs {
-			typ := c.check_expr_opt_call(expr, c.expr(mut expr))
+			typ := c.check_expr_result_call(expr, c.expr(mut expr))
 			if typ == ast.void_type {
 				c.error('invalid void array element type', expr.pos())
 			}
@@ -325,7 +325,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 
 fn (mut c Checker) check_array_init_default_expr(mut node ast.ArrayInit) {
 	mut init_expr := node.init_expr
-	init_typ := c.check_expr_opt_call(init_expr, c.expr(mut init_expr))
+	init_typ := c.check_expr_result_call(init_expr, c.expr(mut init_expr))
 	node.init_type = init_typ
 	if !node.elem_type.has_flag(.option) && init_typ.has_flag(.option) {
 		c.error('cannot use unwrapped Option as initializer', init_expr.pos())

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -73,7 +73,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			c.check_array_init_default_expr(mut node)
 		}
 		if node.has_len {
-			len_typ := c.check_expr_result_call(node.len_expr, c.expr(mut node.len_expr))
+			len_typ := c.check_expr_option_or_result_call(node.len_expr, c.expr(mut node.len_expr))
 			if len_typ.has_flag(.option) {
 				c.error('cannot use unwrapped Option as length', node.len_expr.pos())
 			}
@@ -86,7 +86,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			}
 		}
 		if node.has_cap {
-			cap_typ := c.check_expr_result_call(node.cap_expr, c.expr(mut node.cap_expr))
+			cap_typ := c.check_expr_option_or_result_call(node.cap_expr, c.expr(mut node.cap_expr))
 			if cap_typ.has_flag(.option) {
 				c.error('cannot use unwrapped Option as capacity', node.cap_expr.pos())
 			}
@@ -151,7 +151,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			}
 		}
 		for i, mut expr in node.exprs {
-			typ := c.check_expr_result_call(expr, c.expr(mut expr))
+			typ := c.check_expr_option_or_result_call(expr, c.expr(mut expr))
 			if typ == ast.void_type {
 				c.error('invalid void array element type', expr.pos())
 			}
@@ -325,7 +325,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 
 fn (mut c Checker) check_array_init_default_expr(mut node ast.ArrayInit) {
 	mut init_expr := node.init_expr
-	init_typ := c.check_expr_result_call(init_expr, c.expr(mut init_expr))
+	init_typ := c.check_expr_option_or_result_call(init_expr, c.expr(mut init_expr))
 	node.init_type = init_typ
 	if !node.elem_type.has_flag(.option) && init_typ.has_flag(.option) {
 		c.error('cannot use unwrapped Option as initializer', init_expr.pos())

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -531,7 +531,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	}
 	// If the left expr has an or_block, it needs to be checked for legal or_block statement.
 	left_type := c.expr(mut node.left)
-	c.check_expr_result_call(node.left, left_type)
+	c.check_expr_option_or_result_call(node.left, left_type)
 	// TODO merge logic from method_call and fn_call
 	// First check everything that applies to both fns and methods
 	old_inside_fn_arg := c.inside_fn_arg
@@ -602,7 +602,7 @@ fn (mut c Checker) builtin_args(mut node ast.CallExpr, fn_name string, func ast.
 	c.expected_type = ast.string_type
 	node.args[0].typ = c.expr(mut node.args[0].expr)
 	arg := node.args[0]
-	c.check_expr_result_call(arg.expr, arg.typ)
+	c.check_expr_option_or_result_call(arg.expr, arg.typ)
 	if arg.typ.is_void() {
 		c.error('`${fn_name}` can not print void expressions', node.pos)
 	} else if arg.typ == ast.char_type && arg.typ.nr_muls() == 0 {
@@ -1198,7 +1198,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			continue
 		}
 
-		mut arg_typ := c.check_expr_result_call(call_arg.expr, c.expr(mut call_arg.expr))
+		mut arg_typ := c.check_expr_option_or_result_call(call_arg.expr, c.expr(mut call_arg.expr))
 		if call_arg.expr is ast.StructInit {
 			arg_typ = c.expr(mut call_arg.expr)
 		}
@@ -1426,7 +1426,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				func.params[i]
 			}
 			c.expected_type = param.typ
-			typ := c.check_expr_result_call(call_arg.expr, c.expr(mut call_arg.expr))
+			typ := c.check_expr_option_or_result_call(call_arg.expr, c.expr(mut call_arg.expr))
 
 			if param.typ.has_flag(.generic) && func.generic_names.len == node.concrete_types.len {
 				if unwrap_typ := c.table.resolve_generic_to_concrete(param.typ, func.generic_names,
@@ -1921,7 +1921,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				mut earg_types := []ast.Type{}
 
 				for i, mut arg in node.args {
-					targ := c.check_expr_result_call(arg.expr, c.expr(mut arg.expr))
+					targ := c.check_expr_option_or_result_call(arg.expr, c.expr(mut arg.expr))
 					arg.typ = targ
 
 					param := if info.func.is_variadic && i >= info.func.params.len - 1 {
@@ -2137,7 +2137,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		exp_arg_sym := c.table.sym(exp_arg_typ)
 		c.expected_type = exp_arg_typ
 
-		mut got_arg_typ := c.check_expr_result_call(arg.expr, c.expr(mut arg.expr))
+		mut got_arg_typ := c.check_expr_option_or_result_call(arg.expr, c.expr(mut arg.expr))
 		node.args[i].typ = got_arg_typ
 		if no_type_promotion {
 			if got_arg_typ != exp_arg_typ {
@@ -2839,7 +2839,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	// map/filter are supposed to have 1 arg only
 	mut arg_type := unaliased_left_type
 	for mut arg in node.args {
-		arg_type = c.check_expr_result_call(arg.expr, c.expr(mut arg.expr))
+		arg_type = c.check_expr_option_or_result_call(arg.expr, c.expr(mut arg.expr))
 	}
 	if method_name == 'map' {
 		// eprintln('>>>>>>> map node.args[0].expr: ${node.args[0].expr}, left_type: ${left_type} | elem_typ: ${elem_typ} | arg_type: ${arg_type}')

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -531,7 +531,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	}
 	// If the left expr has an or_block, it needs to be checked for legal or_block statement.
 	left_type := c.expr(mut node.left)
-	c.check_expr_opt_call(node.left, left_type)
+	c.check_expr_result_call(node.left, left_type)
 	// TODO merge logic from method_call and fn_call
 	// First check everything that applies to both fns and methods
 	old_inside_fn_arg := c.inside_fn_arg
@@ -602,7 +602,7 @@ fn (mut c Checker) builtin_args(mut node ast.CallExpr, fn_name string, func ast.
 	c.expected_type = ast.string_type
 	node.args[0].typ = c.expr(mut node.args[0].expr)
 	arg := node.args[0]
-	c.check_expr_opt_call(arg.expr, arg.typ)
+	c.check_expr_result_call(arg.expr, arg.typ)
 	if arg.typ.is_void() {
 		c.error('`${fn_name}` can not print void expressions', node.pos)
 	} else if arg.typ == ast.char_type && arg.typ.nr_muls() == 0 {
@@ -1198,7 +1198,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			continue
 		}
 
-		mut arg_typ := c.check_expr_opt_call(call_arg.expr, c.expr(mut call_arg.expr))
+		mut arg_typ := c.check_expr_result_call(call_arg.expr, c.expr(mut call_arg.expr))
 		if call_arg.expr is ast.StructInit {
 			arg_typ = c.expr(mut call_arg.expr)
 		}
@@ -1426,7 +1426,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				func.params[i]
 			}
 			c.expected_type = param.typ
-			typ := c.check_expr_opt_call(call_arg.expr, c.expr(mut call_arg.expr))
+			typ := c.check_expr_result_call(call_arg.expr, c.expr(mut call_arg.expr))
 
 			if param.typ.has_flag(.generic) && func.generic_names.len == node.concrete_types.len {
 				if unwrap_typ := c.table.resolve_generic_to_concrete(param.typ, func.generic_names,
@@ -1921,7 +1921,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 				mut earg_types := []ast.Type{}
 
 				for i, mut arg in node.args {
-					targ := c.check_expr_opt_call(arg.expr, c.expr(mut arg.expr))
+					targ := c.check_expr_result_call(arg.expr, c.expr(mut arg.expr))
 					arg.typ = targ
 
 					param := if info.func.is_variadic && i >= info.func.params.len - 1 {
@@ -2137,7 +2137,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		exp_arg_sym := c.table.sym(exp_arg_typ)
 		c.expected_type = exp_arg_typ
 
-		mut got_arg_typ := c.check_expr_opt_call(arg.expr, c.expr(mut arg.expr))
+		mut got_arg_typ := c.check_expr_result_call(arg.expr, c.expr(mut arg.expr))
 		node.args[i].typ = got_arg_typ
 		if no_type_promotion {
 			if got_arg_typ != exp_arg_typ {
@@ -2839,7 +2839,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 	// map/filter are supposed to have 1 arg only
 	mut arg_type := unaliased_left_type
 	for mut arg in node.args {
-		arg_type = c.check_expr_opt_call(arg.expr, c.expr(mut arg.expr))
+		arg_type = c.check_expr_result_call(arg.expr, c.expr(mut arg.expr))
 	}
 	if method_name == 'map' {
 		// eprintln('>>>>>>> map node.args[0].expr: ${node.args[0].expr}, left_type: ${left_type} | elem_typ: ${elem_typ} | arg_type: ${arg_type}')

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -370,7 +370,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				if mut stmt is ast.ExprStmt {
 					if mut stmt.expr is ast.ConcatExpr {
 						for mut val in stmt.expr.vals {
-							c.check_expr_result_call(val, c.expr(mut val))
+							c.check_expr_option_or_result_call(val, c.expr(mut val))
 						}
 					}
 					c.expected_type = former_expected_type

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -370,7 +370,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				if mut stmt is ast.ExprStmt {
 					if mut stmt.expr is ast.ConcatExpr {
 						for mut val in stmt.expr.vals {
-							c.check_expr_opt_call(val, c.expr(mut val))
+							c.check_expr_result_call(val, c.expr(mut val))
 						}
 					}
 					c.expected_type = former_expected_type

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -163,10 +163,10 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		// .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .dot, .key_as, .right_shift {}
 		.eq, .ne {
 			if node.left is ast.CallExpr && node.left.or_block.stmts.len > 0 {
-				c.check_expr_opt_call(node.left, left_type)
+				c.check_expr_result_call(node.left, left_type)
 			}
 			if node.right is ast.CallExpr && node.right.or_block.stmts.len > 0 {
-				c.check_expr_opt_call(node.right, right_type)
+				c.check_expr_result_call(node.right, right_type)
 			}
 			if left_type in ast.integer_type_idxs && right_type in ast.integer_type_idxs {
 				is_left_type_signed := left_type in ast.signed_integer_type_idxs
@@ -525,7 +525,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						node.pos)
 				}
 				// `array << elm`
-				c.check_expr_opt_call(node.right, right_type)
+				c.check_expr_result_call(node.right, right_type)
 				node.auto_locked, _ = c.fail_if_immutable(mut node.left)
 				left_value_type := c.table.value_type(c.unwrap_generic(left_type))
 				left_value_sym := c.table.sym(c.unwrap_generic(left_value_type))

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -163,10 +163,10 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		// .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .dot, .key_as, .right_shift {}
 		.eq, .ne {
 			if node.left is ast.CallExpr && node.left.or_block.stmts.len > 0 {
-				c.check_expr_result_call(node.left, left_type)
+				c.check_expr_option_or_result_call(node.left, left_type)
 			}
 			if node.right is ast.CallExpr && node.right.or_block.stmts.len > 0 {
-				c.check_expr_result_call(node.right, right_type)
+				c.check_expr_option_or_result_call(node.right, right_type)
 			}
 			if left_type in ast.integer_type_idxs && right_type in ast.integer_type_idxs {
 				is_left_type_signed := left_type in ast.signed_integer_type_idxs
@@ -525,7 +525,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						node.pos)
 				}
 				// `array << elm`
-				c.check_expr_result_call(node.right, right_type)
+				c.check_expr_option_or_result_call(node.right, right_type)
 				node.auto_locked, _ = c.fail_if_immutable(mut node.left)
 				left_value_type := c.table.value_type(c.unwrap_generic(left_type))
 				left_value_sym := c.table.sym(c.unwrap_generic(left_value_type))

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -29,7 +29,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	if !c.ensure_type_exists(node.cond_type, node.pos) {
 		return ast.void_type
 	}
-	c.check_expr_result_call(node.cond, cond_type)
+	c.check_expr_option_or_result_call(node.cond, cond_type)
 	cond_type_sym := c.table.sym(cond_type)
 	cond_is_option := cond_type.has_flag(.option)
 	node.is_sum_type = cond_type_sym.kind in [.interface_, .sum_type]

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -29,7 +29,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	if !c.ensure_type_exists(node.cond_type, node.pos) {
 		return ast.void_type
 	}
-	c.check_expr_opt_call(node.cond, cond_type)
+	c.check_expr_result_call(node.cond, cond_type)
 	cond_type_sym := c.table.sym(cond_type)
 	cond_is_option := cond_type.has_flag(.option)
 	node.is_sum_type = cond_type_sym.kind in [.interface_, .sum_type]

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -230,7 +230,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if field.has_default_expr {
 				c.expected_type = field.typ
 				if !field.typ.has_flag(.option) && !field.typ.has_flag(.result) {
-					c.check_expr_result_call(field.default_expr, field.default_expr_typ)
+					c.check_expr_option_or_result_call(field.default_expr, field.default_expr_typ)
 				}
 				interface_implemented := sym.kind == .interface_
 					&& c.type_implements(field.default_expr_typ, field.typ, field.pos)
@@ -629,7 +629,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					c.error('`${init_field.expr}` (no value) used as value', init_field.pos)
 				}
 				if !exp_type.has_flag(.option) {
-					got_type = c.check_expr_result_call(init_field.expr, got_type)
+					got_type = c.check_expr_option_or_result_call(init_field.expr, got_type)
 					if got_type.has_flag(.option) {
 						c.error('cannot assign an Option value to a non-option struct field',
 							init_field.pos)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -230,7 +230,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if field.has_default_expr {
 				c.expected_type = field.typ
 				if !field.typ.has_flag(.option) && !field.typ.has_flag(.result) {
-					c.check_expr_opt_call(field.default_expr, field.default_expr_typ)
+					c.check_expr_result_call(field.default_expr, field.default_expr_typ)
 				}
 				interface_implemented := sym.kind == .interface_
 					&& c.type_implements(field.default_expr_typ, field.typ, field.pos)
@@ -629,7 +629,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					c.error('`${init_field.expr}` (no value) used as value', init_field.pos)
 				}
 				if !exp_type.has_flag(.option) {
-					got_type = c.check_expr_opt_call(init_field.expr, got_type)
+					got_type = c.check_expr_result_call(init_field.expr, got_type)
 					if got_type.has_flag(.option) {
 						c.error('cannot assign an Option value to a non-option struct field',
 							init_field.pos)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Renames `check_expr_opt_call` function to match the behavior since only the `.result` flag is cleared. 