### PR TITLE
checker: fix generic method calls with multi generic types (fix #20330)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2026,6 +2026,12 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			if rec_is_generic && node.concrete_types.len == 0
 				&& method.generic_names.len == rec_sym.info.generic_types.len {
 				node.concrete_types = rec_sym.info.generic_types
+			} else if rec_is_generic && node.concrete_types.len > 0
+				&& method.generic_names.len > node.concrete_types.len
+				&& rec_sym.info.generic_types.len + node.concrete_types.len == method.generic_names.len {
+				t_concrete_types := node.concrete_types.clone()
+				node.concrete_types = rec_sym.info.generic_types
+				node.concrete_types << t_concrete_types
 			} else if !rec_is_generic && rec_sym.info.concrete_types.len > 0
 				&& node.concrete_types.len > 0
 				&& rec_sym.info.concrete_types.len + node.concrete_types.len == method.generic_names.len {

--- a/vlib/v/tests/generics_method_with_multi_types_test.v
+++ b/vlib/v/tests/generics_method_with_multi_types_test.v
@@ -50,3 +50,20 @@ fn test_generic_method_with_multi_types() {
 	assert app.next2(1) == 0
 	assert app.next3(1) == 0
 }
+
+// for issues 20330
+// phenomenon: Calling from one generic method to another loses the generic information of the receiver
+struct Foo[T] {}
+
+fn (f Foo[T]) method[U]() {
+	f.another_method[U]()
+}
+
+fn (f Foo[T]) another_method[U]() {}
+
+fn test_passes_multiple_types() {
+	f := Foo[string]{}
+	f.method[f32]()
+	f.method[u32]()
+	assert true
+}


### PR DESCRIPTION
1. Fixed #20330 
2. Add tests.

```v
module main

struct Test[T] {}

fn (t Test[T]) abc[U]() {
	t.xyz[U]()
}

fn (t Test[T]) xyz[U]() {}

fn main() {
	t := Test[string]{}
	t.abc[f32]()
	t.abc[u32]()
}
```

outputs:
```
passed
```