### PR TITLE
cgen: fix code generation when the function returns mut fixed array(fix #20366)

### DIFF
--- a/vlib/v/tests/return_fixed_array_test.v
+++ b/vlib/v/tests/return_fixed_array_test.v
@@ -21,3 +21,14 @@ fn test_without_alias() {
 	a := return_fixed_array()
 	assert a == [1, 2, 3]!
 }
+
+// for issue 20366: returns mut fixed array
+fn returns_mut_fixed_array(mut fixed_array [3]int) [3]int {
+	return fixed_array
+}
+
+fn test_returns_mut_fixed_array() {
+	mut fixed := [3]int{}
+	res := returns_mut_fixed_array(mut fixed)
+	assert res == [0, 0, 0]!
+}


### PR DESCRIPTION
1. Fixed #20366
2. Add tests.

```v
pub fn foo(mut fixed [3]int) [3]int {
	return fixed
}

fn main() {
	mut fixed := [3]int{}
	mut res := foo(mut fixed)
	println(res)
}
```
outputs:
```
[0, 0, 0]
```