### PR TITLE
tests: Also skip native tests on OpenBSD

### DIFF
--- a/vlib/v/gen/native/tests/native_test.v
+++ b/vlib/v/gen/native/tests/native_test.v
@@ -11,8 +11,8 @@ fn test_native() {
 		eprintln('>> skipping testing on ARM for now')
 		return
 	}
-	$if freebsd {
-		eprintln('>> skipping testing on FreeBSD for now')
+	$if freebsd || openbsd {
+		eprintln('>> skipping testing on FreeBSD/OpenBSD for now')
 		return
 	}
 	mut bench := benchmark.new_benchmark()


### PR DESCRIPTION
Just like on FreeBSD, skip the native tests for now.