### PR TITLE
cgen: fix code generation when fn returns option/result fixed array(fix #20373)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5207,8 +5207,20 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				}
 			}
 			for i, expr in node.exprs {
-				g.expr_with_cast(expr, node.types[i], fn_ret_type.clear_flags(.option,
-					.result))
+				if return_sym.kind == .array_fixed {
+					line := g.go_before_last_stmt().trim_space()
+					g.empty_line = true
+					tmp_var_2 := g.new_tmp_var()
+					g.writeln('${ret_typ} ${tmp_var_2} = {0};')
+					g.write('memcpy(${tmp_var_2}.data, ')
+					g.expr(expr)
+					g.writeln(', sizeof(${styp}));')
+					g.write(line)
+					g.write(' *(${tmp_var_2}.data)')
+				} else {
+					g.expr_with_cast(expr, node.types[i], fn_ret_type.clear_flags(.option,
+						.result))
+				}
 				if i < node.exprs.len - 1 {
 					g.write(', ')
 				}
@@ -5239,6 +5251,16 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			for i, expr in node.exprs {
 				if fn_ret_type.has_flag(.option) {
 					g.expr_with_opt(expr, node.types[i], fn_ret_type.clear_flag(.result))
+				} else if return_sym.kind == .array_fixed {
+					line := g.go_before_last_stmt().trim_space()
+					g.empty_line = true
+					tmp_var_2 := g.new_tmp_var()
+					g.writeln('${ret_typ} ${tmp_var_2} = {0};')
+					g.write('memcpy(${tmp_var_2}.data, ')
+					g.expr(expr)
+					g.writeln(', sizeof(${styp}));')
+					g.write(line)
+					g.write(' *(${tmp_var_2}.data)')
 				} else {
 					g.expr_with_cast(expr, node.types[i], fn_ret_type.clear_flag(.result))
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5207,7 +5207,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				}
 			}
 			for i, expr in node.exprs {
-				if return_sym.kind == .array_fixed {
+				if return_sym.kind == .array_fixed && expr !is ast.ArrayInit {
 					line := g.go_before_last_stmt().trim_space()
 					g.empty_line = true
 					tmp_var_2 := g.new_tmp_var()
@@ -5251,7 +5251,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			for i, expr in node.exprs {
 				if fn_ret_type.has_flag(.option) {
 					g.expr_with_opt(expr, node.types[i], fn_ret_type.clear_flag(.result))
-				} else if return_sym.kind == .array_fixed {
+				} else if return_sym.kind == .array_fixed && expr !is ast.ArrayInit {
 					line := g.go_before_last_stmt().trim_space()
 					g.empty_line = true
 					tmp_var_2 := g.new_tmp_var()

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -826,6 +826,10 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 					unwrapped_styp = g.typ(g.assign_ct_type.derive(node.return_type).clear_flags(.option,
 						.result))
 				}
+				if g.table.sym(node.return_type).kind == .array_fixed
+					&& unwrapped_styp.starts_with('_v_') {
+					unwrapped_styp = unwrapped_styp[3..]
+				}
 				g.write('\n ${cur_line} (*(${unwrapped_styp}*)${tmp_opt}.data)')
 			} else {
 				g.write('\n ${cur_line} ${tmp_opt}')
@@ -1602,6 +1606,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	g.write(')')
 	if node.return_type != 0 && !node.return_type.has_flag(.option)
+		&& !node.return_type.has_flag(.result)
 		&& g.table.final_sym(node.return_type).kind == .array_fixed {
 		// it's non-option fixed array, requires accessing .ret_arr member to get the array
 		g.write('.ret_arr')
@@ -1939,6 +1944,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				g.write(')')
 			}
 			if node.return_type != 0 && !node.return_type.has_flag(.option)
+				&& !node.return_type.has_flag(.result)
 				&& g.table.final_sym(node.return_type).kind == .array_fixed {
 				// it's non-option fixed array, requires accessing .ret_arr member to get the array
 				g.write('.ret_arr')

--- a/vlib/v/tests/return_fixed_array_test.v
+++ b/vlib/v/tests/return_fixed_array_test.v
@@ -32,3 +32,28 @@ fn test_returns_mut_fixed_array() {
 	res := returns_mut_fixed_array(mut fixed)
 	assert res == [0, 0, 0]!
 }
+
+// for issue 20373: returns option / result fixed array
+pub fn returns_option_fixed_array(fixed [3]int) ?[3]int {
+	return fixed
+}
+
+pub fn returns_result_fixed_array(fixed [3]int) ![3]int {
+	return fixed
+}
+
+fn test_returns_option_and_result_fixed_array() {
+	mut fixed := [3]int{}
+
+	mut res := returns_option_fixed_array(fixed) or {
+		assert false
+		return
+	}
+	assert res == [0, 0, 0]!
+
+	res = returns_result_fixed_array(fixed) or {
+		assert false
+		return
+	}
+	assert res == [0, 0, 0]!
+}


### PR DESCRIPTION
1. Fixed #20373 
2. Add tests.

```v
pub fn foo(fixed [3]int) ![3]int {
	return fixed
}

fn main() {
	mut fixed := [3]int{}
	mut res := foo(fixed) or {
		return
	}
	println(res)
}
```

```v
pub fn foo(fixed [3]int) ?[3]int {
	return fixed
}

fn main() {
	mut fixed := [3]int{}
	mut res := foo(fixed) or {
		return
	}
	println(res)
}
```
outputs:
```
[0, 0, 0]
```