### PR TITLE
cgen: fix returns struct with mut fixed array init(with/without generics)(fix #20361)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1339,9 +1339,12 @@ fn (mut g Gen) fixed_array_var_init(expr ast.Expr, size int) {
 	g.write('{')
 	for i in 0 .. size {
 		if expr.is_auto_deref_var() {
-			g.write('*')
+			g.write('(*')
 		}
 		g.expr(expr)
+		if expr.is_auto_deref_var() {
+			g.write(')')
+		}
 		g.write('[${i}]')
 		if i != size - 1 {
 			g.write(', ')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -600,8 +600,9 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 		inside_cast_in_heap := g.inside_cast_in_heap
 		g.inside_cast_in_heap = 0 // prevent use of pointers in child structs
 
-		if field_type_sym.kind == .array_fixed && sfield.expr in [ast.Ident, ast.SelectorExpr] {
-			info := field_type_sym.info as ast.ArrayFixed
+		field_unwrap_sym := g.table.sym(g.unwrap_generic(sfield.typ))
+		if field_unwrap_sym.kind == .array_fixed && sfield.expr in [ast.Ident, ast.SelectorExpr] {
+			info := field_unwrap_sym.info as ast.ArrayFixed
 			g.fixed_array_var_init(sfield.expr, info.size)
 		} else {
 			if sfield.typ != ast.voidptr_type && sfield.typ != ast.nil_type

--- a/vlib/v/tests/struct_init_with_fixed_array_field_test.v
+++ b/vlib/v/tests/struct_init_with_fixed_array_field_test.v
@@ -26,3 +26,35 @@ fn test_struct_init_with_fixed_array_field() {
 	println(game.board)
 	assert '${game.board}' == '[x, o, x, o, o, x, x, x, o]'
 }
+
+// for issue 20361(part 1): returns struct with init mut fixed array fields without generics
+struct Foo {
+mut:
+	buf [3]int
+}
+
+pub fn returns_struct_with_mut_fixed_array_init(mut fixed [3]int) Foo {
+	return Foo{fixed}
+}
+
+fn test_returns_struct_with_mut_fixed_array_init() {
+	mut fixed := [3]int{}
+	mut foo := returns_struct_with_mut_fixed_array_init(mut fixed)
+	assert foo.buf == [0, 0, 0]!
+}
+
+// for issue 20361(part 2): returns struct with init mut fixed array fields with generics
+struct Bar[T] {
+mut:
+	buf T
+}
+
+pub fn returns_struct_with_mut_fixed_array_init_with_generics[T](mut fixed T) Bar[T] {
+	return Bar[T]{fixed}
+}
+
+fn test_returns_struct_with_mut_fixed_array_init_with_generics() {
+	mut fixed := [3]int{}
+	mut bar := returns_struct_with_mut_fixed_array_init_with_generics(mut fixed)
+	assert bar.buf == [0, 0, 0]!
+}


### PR DESCRIPTION
1. Fixed #20361
2. Both the cases with and without generics are fixed
3. Add tests.

```v
struct Builder {
mut:
	buf [3]int
}

pub fn new_builder(mut fixed [3]int) !Builder {
	return Builder{fixed}
}

fn main() {
	mut fixed := [3]int{}
	mut sb := new_builder(mut fixed) or {
		return
	}
	println(sb)
}
```
outputs:
```
[0, 0, 0]
```

```v
struct Builder[T] {
mut:
	buf T
}

pub fn new_builder[F](mut fixed_array F) !Builder[F] {
	$if F is $array_fixed {
		return Builder[F]{fixed_array}
	} $else {
		return error('fixed_buf need be a fixed array')
	}
}

fn main() {
	mut fixed := [3]u8{}
	mut sb := new_builder(mut fixed) or {
		eprintln(err)
		return
	}
	println(sb)
}
```
outputs:
```
Builder[[3]u8]{
    buf: [0, 0, 0]
}
```