### PR TITLE
checker: optimize error messages for method not exists(fix #20364)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1715,7 +1715,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	mut unknown_method_msg := if field := c.table.find_field(left_sym, method_name) {
 		'unknown method `${field.name}` did you mean to access the field with the same name instead?'
 	} else {
-		'unknown method or field: `${left_sym.name}.${method_name}`'
+		name := left_sym.symbol_name_except_generic().replace_each(['<', '[', '>', ']'])
+		'unknown method or field: `${name}.${method_name}`'
 	}
 	if left_type.has_flag(.option) && method_name != 'str' {
 		c.error('Option type cannot be called directly', node.left.pos())
@@ -1903,7 +1904,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					node.pos)
 			}
 			if left_sym.kind == .array_fixed {
-				c.error('unknown method or field: ${left_sym.name}.free()', node.pos)
+				name := left_sym.symbol_name_except_generic().replace_each(['<', '[', '>', ']'])
+				c.error('unknown method or field: ${name}.free()', node.pos)
 			}
 			return ast.void_type
 		}

--- a/vlib/v/checker/tests/unknown_method.out
+++ b/vlib/v/checker/tests/unknown_method.out
@@ -1,12 +1,20 @@
-vlib/v/checker/tests/unknown_method.vv:7:12: error: unknown method or field: `Test.sdd`
-    5 | fn main() {
-    6 |     t := Test{}
-    7 |     println(t.sdd())
+vlib/v/checker/tests/unknown_method.vv:13:12: error: unknown method or field: `Test.sdd`
+   11 | fn main() {
+   12 |     t := Test{}
+   13 |     println(t.sdd())
       |               ~~~~~
-    8 | }
-vlib/v/checker/tests/unknown_method.vv:7:2: error: `println` can not print void expressions
-    5 | fn main() {
-    6 |     t := Test{}
-    7 |     println(t.sdd())
+   14 | 
+   15 |     foo := new_foo[int]()
+vlib/v/checker/tests/unknown_method.vv:13:2: error: `println` can not print void expressions
+   11 | fn main() {
+   12 |     t := Test{}
+   13 |     println(t.sdd())
       |     ~~~~~~~~~~~~~~~~
-    8 | }
+   14 | 
+   15 |     foo := new_foo[int]()
+vlib/v/checker/tests/unknown_method.vv:16:6: error: unknown method or field: `Foo[F].bar`
+   14 | 
+   15 |     foo := new_foo[int]()
+   16 |     foo.bar()
+      |         ~~~~~
+   17 | }

--- a/vlib/v/checker/tests/unknown_method.vv
+++ b/vlib/v/checker/tests/unknown_method.vv
@@ -2,7 +2,16 @@ module main
 
 struct Test {}
 
+struct Foo[T] {}
+
+fn new_foo[F]() Foo[F] {
+	return Foo[F]{}
+}
+
 fn main() {
 	t := Test{}
 	println(t.sdd())
+
+	foo := new_foo[int]()
+	foo.bar()
 }


### PR DESCRIPTION
1. Close #20364 
2. Add tests.

```v
struct Builder[T] {
mut:
	buf T
}

pub fn new_builder[F](mut fixed_array F) !Builder[F] {
	$if F is $array_fixed {
		return Builder[F]{fixed_array}
	} $else {
		return error('fixed_buf need be a fixed array')
	}
}

fn main() {
	mut fixed := [3]u8{}
	mut sb := new_builder(mut fixed) or {
		return
	}
	sb.write_string("")
}
```
outputs:
```
a.v:21:5: error: unknown method or field: `Builder[F].write_string`
   19 |     }
   20 |     // println(sb)
   21 |     sb.write_string("")
      |        ~~~~~~~~~~~~~~~~
   22 | }
   23 |
If the code of your project is in multiple files, try with `v .` instead of `v a.v`
```