### PR TITLE
checker: optimize error messages for must specify the generic type names(fix #20362)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -232,6 +232,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('Result type argument is not supported currently', param.type_pos)
 			}
 			arg_typ_sym := c.table.sym(param.typ)
+			pure_sym_name := arg_typ_sym.embed_name()
 			if arg_typ_sym.info is ast.Struct {
 				if !param.typ.is_ptr() && arg_typ_sym.info.is_heap { // set auto_heap to promote value parameter
 					mut v := node.scope.find_var(param.name) or { continue }
@@ -239,19 +240,19 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 				if arg_typ_sym.info.generic_types.len > 0 && !param.typ.has_flag(.generic)
 					&& arg_typ_sym.info.concrete_types.len == 0 {
-					c.error('generic struct `${arg_typ_sym.name}` in fn declaration must specify the generic type names, e.g. ${arg_typ_sym.name}[T]',
+					c.error('generic struct `${pure_sym_name}` in fn declaration must specify the generic type names, e.g. ${pure_sym_name}[T]',
 						param.type_pos)
 				}
 			} else if arg_typ_sym.info is ast.Interface {
 				if arg_typ_sym.info.generic_types.len > 0 && !param.typ.has_flag(.generic)
 					&& arg_typ_sym.info.concrete_types.len == 0 {
-					c.error('generic interface `${arg_typ_sym.name}` in fn declaration must specify the generic type names, e.g. ${arg_typ_sym.name}[T]',
+					c.error('generic interface `${pure_sym_name}` in fn declaration must specify the generic type names, e.g. ${pure_sym_name}[T]',
 						param.type_pos)
 				}
 			} else if arg_typ_sym.info is ast.SumType {
 				if arg_typ_sym.info.generic_types.len > 0 && !param.typ.has_flag(.generic)
 					&& arg_typ_sym.info.concrete_types.len == 0 {
-					c.error('generic sumtype `${arg_typ_sym.name}` in fn declaration must specify the generic type names, e.g. ${arg_typ_sym.name}[T]',
+					c.error('generic sumtype `${pure_sym_name}` in fn declaration must specify the generic type names, e.g. ${pure_sym_name}[T]',
 						param.type_pos)
 				}
 			}

--- a/vlib/v/checker/tests/generics_method_receiver_type_err_b.out
+++ b/vlib/v/checker/tests/generics_method_receiver_type_err_b.out
@@ -1,7 +1,14 @@
-vlib/v/checker/tests/generics_method_receiver_type_err_b.vv:8:12: error: generic struct `ConsumableResources` in fn declaration must specify the generic type names, e.g. ConsumableResources[T]
-    6 |     used_resources map[T]Resources
+vlib/v/checker/tests/generics_method_receiver_type_err_b.vv:9:12: error: generic struct `ConsumableResources` in fn declaration must specify the generic type names, e.g. ConsumableResources[T]
     7 | }
-    8 | pub fn (cr &ConsumableResources) get_total_resources() Resources {
+    8 | 
+    9 | pub fn (cr &ConsumableResources) get_total_resources() Resources {
       |            ~~~~~~~~~~~~~~~~~~~~
-    9 |     return cr.total_resources
-   10 | }
+   10 |     return cr.total_resources
+   11 | }
+vlib/v/checker/tests/generics_method_receiver_type_err_b.vv:19:11: error: generic struct `Foo` in fn declaration must specify the generic type names, e.g. Foo[T]
+   17 | }
+   18 | 
+   19 | pub fn (f Foo) method() {
+      |           ~~~
+   20 | }
+   21 |

--- a/vlib/v/checker/tests/generics_method_receiver_type_err_b.vv
+++ b/vlib/v/checker/tests/generics_method_receiver_type_err_b.vv
@@ -1,12 +1,22 @@
-pub struct Resources{}
+pub struct Resources {}
 
 pub struct ConsumableResources[T] {
 mut:
 	total_resources Resources
-	used_resources map[T]Resources
+	used_resources  map[T]Resources
 }
+
 pub fn (cr &ConsumableResources) get_total_resources() Resources {
 	return cr.total_resources
+}
+
+// for issue 20362
+struct Foo[T] {}
+
+pub fn new_foo[F](arg F) !Foo[F] {
+}
+
+pub fn (f Foo) method() {
 }
 
 fn main() {


### PR DESCRIPTION
1. Close #20362 
2. Add tests.

```v
struct Builder[T] {}

pub fn new_builder[F](mut fixed_array F) !Builder[F] {
}

pub fn (mut b Builder) write_string(s string) {
}
```
outputs:
```
a.v:6:15: error: generic struct `Builder` in fn declaration must specify the generic type names, e.g. Builder[T]
    4 | }
    5 | 
    6 | pub fn (mut b Builder) write_string(s string) {
      |               ~~~~~~~
    7 | }
    8 |
```