### PR TITLE
builtin, checker: fix aliases of u8 array clone() call (related #20290)

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -574,16 +574,6 @@ pub fn (c u8) is_capital() bool {
 	return c >= `A` && c <= `Z`
 }
 
-// clone clones the byte array, and returns the newly created copy.
-pub fn (b []u8) clone() []u8 {
-	mut res := []u8{len: b.len}
-	// mut res := make([]u8, {repeat:b.len})
-	for i in 0 .. b.len {
-		res[i] = b[i]
-	}
-	return res
-}
-
 // bytestr produces a string from *all* the bytes in the array.
 // Note: the returned string will have .len equal to the array.len,
 // even when some of the array bytes were `0`.

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1740,8 +1740,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	}
 	if final_left_sym.kind == .array {
 		if array_builtin_methods_chk.matches(method_name) && (left_sym.kind == .array
-			|| (left_sym.kind == .alias && method_name != 'clone'
-			&& !left_sym.has_method(method_name))) {
+			|| (left_sym.kind == .alias && !left_sym.has_method(method_name))) {
 			return c.array_builtin_method_call(mut node, left_type)
 		} else if method_name in ['insert', 'prepend'] {
 			if method_name == 'insert' {


### PR DESCRIPTION
This PR fix aliases of u8 array clone() call (related #20290).