### PR TITLE
checker: fix checking got 'none' from or_block of map index(fix #20390)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1284,7 +1284,7 @@ fn (mut c Checker) check_or_last_stmt(mut stmt ast.Stmt, ret_type ast.Type, expr
 				last_stmt_typ := c.expr(mut stmt.expr)
 
 				if last_stmt_typ.has_flag(.option) || last_stmt_typ == ast.none_type {
-					if stmt.expr in [ast.Ident, ast.SelectorExpr, ast.CallExpr, ast.None] {
+					if stmt.expr in [ast.Ident, ast.SelectorExpr, ast.CallExpr, ast.None, ast.CastExpr] {
 						expected_type_name := c.table.type_to_str(ret_type.clear_flags(.option,
 							.result))
 						got_type_name := c.table.type_to_str(last_stmt_typ)

--- a/vlib/v/checker/tests/map_index_or_block_type_mismatch_err.out
+++ b/vlib/v/checker/tests/map_index_or_block_type_mismatch_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/map_index_or_block_type_mismatch_err.vv:4:20: error: `or` block must provide a value of type `int`, not `none`
+    2 | fn index_got_none_from_or_block() {
+    3 |     m := map[string]int{}
+    4 |     _ = m['key'] or { none }
+      |                       ~~~~
+    5 |     _ = m['key'] or { ?int(none) }
+    6 | }
+vlib/v/checker/tests/map_index_or_block_type_mismatch_err.vv:5:21: error: `or` block must provide a value of type `int`, not `?int`
+    3 |     m := map[string]int{}
+    4 |     _ = m['key'] or { none }
+    5 |     _ = m['key'] or { ?int(none) }
+      |                        ~~~~~~~~~
+    6 | }

--- a/vlib/v/checker/tests/map_index_or_block_type_mismatch_err.vv
+++ b/vlib/v/checker/tests/map_index_or_block_type_mismatch_err.vv
@@ -1,0 +1,6 @@
+// for issue 20390
+fn index_got_none_from_or_block() {
+	m := map[string]int{}
+	_ = m['key'] or { none }
+	_ = m['key'] or { ?int(none) }
+}


### PR DESCRIPTION
1. Fixed #20390 
2. Add tests.

```v
fn get_value(m map[string]int, key string) ?int {
	return m[key] or { ?int(none) }
}
```

outputs:

```
a.v:3:22: error: `or` block must provide a value of type `int`, not `?int`
    1 | // https://github.com/vlang/v/issues/20390
    2 | fn get_value(m map[string]int, key string) ?int {
    3 |     return m[key] or { ?int(none) }
      |                         ~~~~~~~~~
    4 | }
    5 |
```