### PR TITLE
cgen: fix assert expr handling + print with comptime smartcast

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -17,11 +17,17 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 	}
 	mut node := original_assert_statement
 	g.writeln('// assert')
+
+	mut save_left := ast.empty_expr
+	mut save_right := ast.empty_expr
+
 	if mut node.expr is ast.InfixExpr {
 		if subst_expr := g.assert_subexpression_to_ctemp(node.expr.left, node.expr.left_type) {
+			save_left = node.expr.left
 			node.expr.left = subst_expr
 		}
 		if subst_expr := g.assert_subexpression_to_ctemp(node.expr.right, node.expr.right_type) {
+			save_right = node.expr.right
 			node.expr.right = subst_expr
 		}
 	}
@@ -55,6 +61,15 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 		g.writeln('\t__print_assert_failure(&${metaname_panic});')
 		g.gen_assert_postfailure_mode(node)
 		g.writeln('}')
+	}
+
+	if mut node.expr is ast.InfixExpr {
+		if node.expr.left is ast.CTempVar {
+			node.expr.left = save_left
+		}
+		if node.expr.right is ast.CTempVar {
+			node.expr.right = save_right
+		}
 	}
 }
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1816,6 +1816,8 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 							cast_sym := g.table.sym(typ)
 							if cast_sym.info is ast.Aggregate {
 								typ = cast_sym.info.types[g.aggregate_type_idx]
+							} else if expr.obj.ct_type_var == .smartcast {
+								typ = g.unwrap_generic(g.comptime.get_comptime_var_type(expr))
 							}
 						}
 						// handling println( var or { ... })

--- a/vlib/v/tests/comptime_smartcast_assert_test.v
+++ b/vlib/v/tests/comptime_smartcast_assert_test.v
@@ -39,6 +39,7 @@ fn name[T](val T) {
 				assert val.str() == ''
 			}
 			dump(val)
+			println(val)
 		}
 	}
 }

--- a/vlib/v/tests/comptime_smartcast_assert_test.v
+++ b/vlib/v/tests/comptime_smartcast_assert_test.v
@@ -1,0 +1,44 @@
+pub type Any = []Any
+	| bool
+	| f32
+	| f64
+	| i16
+	| i64
+	| i8
+	| int
+	| map[string]Any
+	| string
+	| u16
+	| u32
+	| u64
+	| u8
+
+fn test_main() {
+	ana := Any([Any('')])
+	name(ana)
+	match ana {
+		[]Any {
+			for i := 0; i < ana.len; i++ {
+				name(ana[i])
+			}
+		}
+		else {
+			assert false
+		}
+	}
+	assert true
+}
+
+fn name[T](val T) {
+	$for v in val.variants {
+		if val is v {
+			dump(val.str())
+			$if val is []Any {
+				assert val.str() == "[Any('')]"
+			} $else {
+				assert val.str() == ''
+			}
+			dump(val)
+		}
+	}
+}


### PR DESCRIPTION
Fix #20396

`assert_stmt()` was changing node.expr.left and node.expr.right inside. 

```V
pub type Any = []Any
	| bool
	| f32
	| f64
	| i16
	| i64
	| i8
	| int
	| map[string]Any
	| string
	| u16
	| u32
	| u64
	| u8

fn test_main() {
	ana := Any([Any('')])
	name(ana)
	match ana {
		[]Any {
			for i := 0; i < ana.len; i++ {
				name(ana[i])
			}
		}
		else {
			assert false
		}
	}
	assert true
}

fn name[T](val T) {
	$for v in val.variants {
		if val is v {
			dump(val.str())
			$if val is []Any {
				assert val.str() == "[Any('')]"
			} $else {
				assert val.str() == ''
			}
			dump(val)
		}
	}
}
```