### PR TITLE
cgen: fix brackets are asymmetric in chained method calls (fix #20395)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1372,7 +1372,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 		g.get_free_method(rec_type)
 	}
-	mut has_cast := false
+	mut cast_n := 0
 
 	receiver_type_name = g.resolve_receiver_name(node, unwrapped_rec_type, final_left_sym,
 		left_sym, typ_sym)
@@ -1380,7 +1380,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		&& node.name in ['clear', 'repeat', 'sort_with_compare', 'sorted_with_compare', 'free', 'push_many', 'trim', 'first', 'last', 'pop', 'clone', 'reverse', 'slice', 'pointers'] {
 		if node.name in ['last', 'first', 'pop'] {
 			return_type_str := g.typ(node.return_type)
-			has_cast = true
+			cast_n++
 			g.write('(*(${return_type_str}*)')
 		}
 	}
@@ -1485,7 +1485,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		if !is_range_slice {
 			if !node.left.is_lvalue() {
 				g.write('ADDR(${rec_cc_type}, ')
-				has_cast = true
+				cast_n++
 			} else if !is_array_method_first_last_repeat && !(left_type.has_flag(.shared_f)
 				&& left_type == node.receiver_type) {
 				g.write('&')
@@ -1592,8 +1592,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write('->val')
 		}
 	}
-	if has_cast {
-		g.write(')')
+	if cast_n > 0 {
+		g.write(')'.repeat(cast_n))
 	}
 	is_variadic := node.expected_arg_types.len > 0
 		&& node.expected_arg_types.last().has_flag(.variadic)

--- a/vlib/v/tests/method_call_chain_test.v
+++ b/vlib/v/tests/method_call_chain_test.v
@@ -1,0 +1,7 @@
+// for issue 20395
+// Phenomenon: cgen brackets are asymmetric in chained method calls.
+fn test_main() {
+	mut path := 'hello/file.txt'
+	extension := path.split('.').pop()
+	assert extension == 'txt'
+}


### PR DESCRIPTION
1. Fixed #20395 
2. Add tests.

```v
module main
fn main() {
    mut path := 'hello/file.txt'
    extension := path.split('.').pop()
    println(extension)
}
```
outputs:
```
txt
```