### PR TITLE
Make tetris example window not resizable

### DIFF
--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -171,6 +171,7 @@ fn main() {
 		frame_fn: frame
 		event_fn: on_event
 		font_path: fpath // wait_events: true
+		resizable: false
 	)
 	game.init_game()
 	game.gg.run() // Run the render loop in the main thread


### PR DESCRIPTION
On systems with tiling window manager, all resizable windows will be tiled.