### PR TITLE
cgen: fix comptime ref_or_deref_arg for ComptimeSelector

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2303,7 +2303,11 @@ fn (mut g Gen) keep_alive_call_postgen(node ast.CallExpr, tmp_cnt_save int) {
 
 @[inline]
 fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang ast.Language) {
-	arg_typ := g.unwrap_generic(arg.typ)
+	arg_typ := if arg.expr is ast.ComptimeSelector {
+		g.unwrap_generic(g.comptime.get_comptime_var_type(arg.expr))
+	} else {
+		g.unwrap_generic(arg.typ)
+	}
 	arg_sym := g.table.sym(arg_typ)
 	exp_is_ptr := expected_type.is_any_kind_of_pointer()
 	arg_is_ptr := arg_typ.is_any_kind_of_pointer()

--- a/vlib/v/tests/comptime_deref_or_ref_test.v
+++ b/vlib/v/tests/comptime_deref_or_ref_test.v
@@ -1,0 +1,28 @@
+pub struct Association {
+	price       string
+	association &Association = unsafe { nil }
+}
+
+fn encode_struct[U](a U) {
+	mut c := 0
+	$for field in U.fields {
+		$if field.name == 'association' {
+			println(field.name)
+			c += 1
+			assert ptr_str(a.$(field.name)) == '0'
+		} $else {
+			println(field.name)
+			c += 1
+			assert ptr_str(a.$(field.name)) != '0'
+		}
+	}
+	assert c == 2
+}
+
+fn test_main() {
+	a := Association{}
+
+	assert ptr_str(a.price) != '0'
+	assert ptr_str(a.association) == '0'
+	encode_struct(a)
+}

--- a/vlib/v/tests/comptime_deref_or_ref_test.v
+++ b/vlib/v/tests/comptime_deref_or_ref_test.v
@@ -3,10 +3,17 @@ pub struct Association {
 	association &Association = unsafe { nil }
 }
 
+// needed to check the condition for #20400
+fn myprintln(s string) string {
+	println('---------> ${s}')
+	return s
+}
+
 fn encode_struct[U](a U) {
 	mut c := 0
 	$for field in U.fields {
 		$if field.name == 'association' {
+			x := myprintln(ptr_str(a.$(field.name)))
 			println(field.name)
 			c += 1
 			assert ptr_str(a.$(field.name)) == '0'
@@ -15,7 +22,13 @@ fn encode_struct[U](a U) {
 			c += 1
 			assert ptr_str(a.$(field.name)) != '0'
 		}
+		x := myprintln(ptr_str(a.$(field.name)))
+		if field.name == 'association' {
+			dump(x)
+			assert x == '0'
+		}
 	}
+	dump(c)
 	assert c == 2
 }
 


### PR DESCRIPTION
Fix #20400

```V
pub struct Association {
	price       string
	association &Association = unsafe { nil }
	
}

fn encode_struct[U](a U) {
	mut c := 0
	$for field in U.fields {
		$if field.name == 'association' {
			println(field.name)
			c += 1
			assert ptr_str(a.$(field.name)) == '0'
		} $else {
			println(field.name)
			c += 1
			assert ptr_str(a.$(field.name)) != '0'
		}
	}
	assert c == 2
}	

fn main() {
	a := Association{}

	assert ptr_str(a.price) != '0'
	assert ptr_str(a.association) == '0'
	encode_struct(a)
}
```