### PR TITLE
checker: fix option mismatch checking on array initializations(fix #20409)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -212,6 +212,20 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				c.check_expected(typ, elem_type) or {
 					c.error('invalid array element: ${err.msg()}', expr.pos())
 				}
+				if !elem_type.has_flag(.option)
+					&& (typ.has_flag(.option) || typ.idx() == ast.none_type_idx) {
+					typ_str, elem_type_str := c.get_string_names_of(typ, elem_type)
+					if typ.idx() == ast.none_type_idx {
+						c.error('cannot use `${typ_str}` as `${elem_type_str}`', expr.pos())
+					} else {
+						c.error('cannot use `${typ_str}` as `${elem_type_str}`, it must be unwrapped first',
+							expr.pos())
+					}
+				} else if elem_type.has_flag(.option) && !typ.has_flag(.option)
+					&& typ.idx() != ast.none_type_idx && !expr.is_pure_literal() {
+					typ_str, elem_type_str := c.get_string_names_of(typ, elem_type)
+					c.error('cannot use `${typ_str}` as `${elem_type_str}`', expr.pos())
+				}
 			}
 		}
 		if node.is_fixed {

--- a/vlib/v/checker/tests/array_init_element_option_mismatch_err.out
+++ b/vlib/v/checker/tests/array_init_element_option_mismatch_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/array_init_element_option_mismatch_err.vv:8:11: error: cannot use `?string` as `string`, it must be unwrapped first
+    6 | fn main() {
+    7 |     str := ?string(none)
+    8 |     _ = ['', str]
+      |              ~~~
+    9 | 
+   10 |     foo := Foo{}
+vlib/v/checker/tests/array_init_element_option_mismatch_err.vv:11:18: error: cannot use `?string` as `string`, it must be unwrapped first
+    9 | 
+   10 |     foo := Foo{}
+   11 |     _ = [foo.a, foo.b]
+      |                     ^
+   12 |     _ = [foo.b, foo.a]
+   13 | }
+vlib/v/checker/tests/array_init_element_option_mismatch_err.vv:12:18: error: cannot use `string` as `?string`
+   10 |     foo := Foo{}
+   11 |     _ = [foo.a, foo.b]
+   12 |     _ = [foo.b, foo.a]
+      |                     ^
+   13 | }

--- a/vlib/v/checker/tests/array_init_element_option_mismatch_err.vv
+++ b/vlib/v/checker/tests/array_init_element_option_mismatch_err.vv
@@ -1,0 +1,13 @@
+struct Foo {
+	a string
+	b ?string
+}
+
+fn main() {
+	str := ?string(none)
+	_ = ['', str]
+
+	foo := Foo{}
+	_ = [foo.a, foo.b]
+	_ = [foo.b, foo.a]
+}


### PR DESCRIPTION
1. Fixed #20409 
2. Add tests.

When the array is initialized, V takes the type of the first element as the type of the array elements, so when the first type is not option, the following elements should not have option either.

```v
import db.pg

@[table: 'demo']
struct Demo {
	id int @[primary; sql: serial]
	a string
	b ?string
}

fn run() ! {
	conn := '' // insert own connection string
	db := pg.connect_with_conninfo(conn)!
	sql db { create table Demo }!
	demo := Demo{0, 'a', none}
	_ := db.exec_param_many('INSERT INTO demo(a, b) VALUES($1, $2)', [demo.a, demo.b])!
	db.close()
}

run() or { panic(err.msg()) }
```

outputs:
```
a.v:15:81: error: cannot use `?string` as `string`, it must be unwrapped first
   13 |     sql db { create table Demo }!
   14 |     demo := Demo{0, 'a', none}
   15 |     _ := db.exec_param_many('INSERT INTO demo(a, b) VALUES($1, $2)', [demo.a, demo.b])!
      |                                                                                    ^
   16 |     db.close()
   17 | }
```