### PR TITLE
docs: add `Warnings and declaration errors` section in docs.md

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -444,13 +444,32 @@ a, b = b, a
 println('${a}, ${b}') // 1, 0
 ```
 
-### Declaration errors
+### Warnings and declaration errors
 
 In development mode the compiler will warn you that you haven't used the variable
 (you'll get an "unused variable" warning).
 In production mode (enabled by passing the `-prod` flag to v – `v -prod foo.v`)
 it will not compile at all (like in Go).
+```v failcompile nofmt
+fn main() {
+	a := 10
+	// warning: unused variable `a`
+}
+```
+To ignore values returned by a function `_` can be used
+```v failcompile nofmt
+fn foo() (int, int) {
+	return 2, 3
+}
+fn main() {
+	c, _ := foo()
+	print(c)
+	// no warning about unused variable returned by foo.
+}
+```
 
+Unlike most languages, variable shadowing is not allowed. Declaring a variable with a name
+that is already used in a parent scope will cause a compilation error.
 ```v failcompile nofmt
 fn main() {
 	a := 10
@@ -460,9 +479,6 @@ fn main() {
 	// warning: unused variable `a`
 }
 ```
-
-Unlike most languages, variable shadowing is not allowed. Declaring a variable with a name
-that is already used in a parent scope will cause a compilation error.
 
 ## V Types
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -476,7 +476,6 @@ fn main() {
 	if true {
 		a := 20 // error: redefinition of `a`
 	}
-	// warning: unused variable `a`
 }
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -450,17 +450,19 @@ In development mode the compiler will warn you that you haven't used the variabl
 (you'll get an "unused variable" warning).
 In production mode (enabled by passing the `-prod` flag to v – `v -prod foo.v`)
 it will not compile at all (like in Go).
-```v failcompile nofmt
+```v
 fn main() {
 	a := 10
 	// warning: unused variable `a`
 }
 ```
+
 To ignore values returned by a function `_` can be used
-```v failcompile nofmt
+```v
 fn foo() (int, int) {
 	return 2, 3
 }
+
 fn main() {
 	c, _ := foo()
 	print(c)

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -66,7 +66,7 @@ by using any of the following commands in a terminal:
 * [Variables](#variables)
     * [Mutable variables](#mutable-variables)
     * [Initialization vs assignment](#initialization-vs-assignment)
-    * [Declaration errors](#declaration-errors)
+    * [Warnings and declaration errors](#warnings-and-declaration-errors)
 * [V types](#v-types)
     * [Primitive types](#primitive-types)
     * [Strings](#strings)


### PR DESCRIPTION
Update docs.md provide accurate examples for warning and errors
The current mentioned example is not clear enough the explain the secnario where an warning is displayed and when error is displayed.Hence the PR to update them we clearer example.
