### PR TITLE
cgen: fix wrong heap promoted arg detection

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -628,6 +628,7 @@ fn (mut g Gen) fn_decl_params(params []ast.Param, scope &ast.Scope, is_variadic 
 			g.definitions.write_string(')')
 			fparams << caname
 			fparamtypes << param_type_name
+			heap_promoted << false
 		} else {
 			mut heap_prom := false
 			if scope != unsafe { nil } {

--- a/vlib/v/tests/fn_heap_promoted_test.v
+++ b/vlib/v/tests/fn_heap_promoted_test.v
@@ -1,0 +1,17 @@
+@[heap]
+struct Context {}
+
+type Method = fn (ctx Context)
+
+fn call(method Method, ctx Context) { // or switch `ctx` and `method` also ok
+	method(ctx)
+}
+
+fn get(ctx Context) {
+	println('ok')
+}
+
+fn test_main() {
+	call(get, Context{})
+	assert true
+}


### PR DESCRIPTION
Fix #20419

```V
@[heap]
struct Context {}

type Method = fn (ctx Context)

fn call(method Method, ctx Context) { // or switch `ctx` and `method` also ok
	method(ctx)
}

fn get(ctx Context) {
	println('ok')
}

fn test_main() {
	call(get, Context{})
	assert true
}
```