### PR TITLE
checker: fix return option mismatch checking

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -171,8 +171,8 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 			}
 		}
 		got_type := c.unwrap_generic(got_types[i])
-		if got_type.has_flag(.option)
-			&& got_type.clear_flag(.option) != exp_type.clear_flag(.option) {
+		if got_type.has_flag(.option) && (!exp_type.has_flag(.option)
+			|| got_type.clear_flag(.option) != exp_type.clear_flag(.option)) {
 			pos := node.exprs[expr_idxs[i]].pos()
 			c.error('cannot use `${c.table.type_to_str(got_type)}` as ${c.error_type_name(exp_type)} in return argument',
 				pos)

--- a/vlib/v/checker/tests/fn_mismatch_option_return_err.out
+++ b/vlib/v/checker/tests/fn_mismatch_option_return_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/fn_mismatch_option_return_err.vv:4:15: error: cannot use `?time.Duration` as type `time.Duration` in return argument
+    2 | 
+    3 | fn foo() time.Duration {
+    4 |     return ?time.Duration(0)
+      |                  ~~~~~~~~~~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/fn_mismatch_option_return_err.vv
+++ b/vlib/v/checker/tests/fn_mismatch_option_return_err.vv
@@ -1,0 +1,7 @@
+import time
+
+fn foo() time.Duration {
+	return ?time.Duration(0)
+}
+
+println(foo())


### PR DESCRIPTION
Fix #20418

```V
import time

fn foo() time.Duration {
	return ?time.Duration(0)
}

println(foo())
```