### PR TITLE
cgen: fix auto eq method for option fields

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -205,6 +205,9 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 			left_arg := g.read_field(left_type, field_name, 'a')
 			right_arg := g.read_field(left_type, field_name, 'b')
 
+			if field.typ.has_flag(.option) {
+				fn_builder.write_string('(${left_arg}.state == ${right_arg}.state && ${right_arg}.state == 2 || ')
+			}
 			if field_type.sym.kind == .string {
 				if field.typ.has_flag(.option) {
 					left_arg_opt := g.read_opt_field(left_type, field_name, 'a', field.typ)
@@ -241,9 +244,12 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				eq_fn := g.gen_interface_equality_fn(field.typ)
 				fn_builder.write_string('${eq_fn}_interface_eq(${ptr}${left_arg}, ${ptr}${right_arg})')
 			} else if field.typ.has_flag(.option) {
-				fn_builder.write_string('${left_arg}.state == ${right_arg}.state && !memcmp(&${left_arg}.data, &${right_arg}.data, sizeof(${g.base_type(field.typ)}))')
+				fn_builder.write_string('!memcmp(&${left_arg}.data, &${right_arg}.data, sizeof(${g.base_type(field.typ)}))')
 			} else {
 				fn_builder.write_string('${left_arg} == ${right_arg}')
+			}
+			if field.typ.has_flag(.option) {
+				fn_builder.write_string(')')
 			}
 		}
 	} else {

--- a/vlib/v/tests/option_auto_eq_test.v
+++ b/vlib/v/tests/option_auto_eq_test.v
@@ -1,0 +1,100 @@
+import x.json2
+
+pub struct PartialEmoji {
+pub:
+	id       ?int
+	name     string
+	animated bool
+}
+
+pub fn PartialEmoji.parse(j json2.Any) !PartialEmoji {
+	match j {
+		map[string]json2.Any {
+			return PartialEmoji{
+				id: if s := j['id'] {
+					if s !is json2.Null {
+						?int(s.int())
+					} else {
+						none
+					}
+				} else {
+					none
+				}
+				name: j['name']! as string
+				animated: if b := j['animated'] {
+					b as bool
+				} else {
+					false
+				}
+			}
+		}
+		else {
+			return error('expected partial emoji to be object, got ${j.type_name()}')
+		}
+	}
+}
+
+pub enum ButtonStyle {
+	primary   = 1
+	secondary
+	success
+	danger
+	link
+}
+
+pub struct Button {
+pub:
+	style     ButtonStyle = .secondary
+	label     ?string
+	emoji     ?PartialEmoji
+	custom_id ?string
+	url       ?string
+	disabled  ?bool
+}
+
+pub fn Button.parse(j json2.Any) !Button {
+	match j {
+		map[string]json2.Any {
+			return Button{
+				style: unsafe { ButtonStyle(j['style']!.int()) }
+				label: if s := j['label'] {
+					?string(s as string)
+				} else {
+					none
+				}
+				emoji: if o := j['emoji'] {
+					dump(PartialEmoji.parse(o)!)
+					?PartialEmoji(PartialEmoji.parse(o)!)
+				} else {
+					none
+				}
+				custom_id: if s := j['custom_id'] {
+					?string(s as string)
+				} else {
+					none
+				}
+				url: if s := j['url'] {
+					?string(s as string)
+				} else {
+					none
+				}
+				disabled: if b := j['disabled'] {
+					?bool(b as bool)
+				} else {
+					none
+				}
+			}
+		}
+		else {
+			return error('expected button to be object, got ${j.type_name()}')
+		}
+	}
+}
+
+fn test_main() {
+	assert Button.parse({
+		'style': json2.Any(2)
+	}) or { panic('That case should not return error: ${err}') } == Button{
+		style: .secondary
+	}
+}


### PR DESCRIPTION
Fix #20314

```V
import x.json2

pub struct PartialEmoji {
pub:
	id       ?int
	name     string
	animated bool
}

pub fn PartialEmoji.parse(j json2.Any) !PartialEmoji {
	match j {
		map[string]json2.Any {
			return PartialEmoji{
				id: if s := j['id'] {
					if s !is json2.Null {
						?int(s.int())
					} else {
						none
					}
				} else {
					none
				}
				name: j['name']! as string
				animated: if b := j['animated'] {
					b as bool
				} else {
					false
				}
			}
		}
		else {
			return error('expected partial emoji to be object, got ${j.type_name()}')
		}
	}
}

pub enum ButtonStyle {
	primary   = 1
	secondary
	success
	danger
	link
}

pub struct Button {
pub:
	style     ButtonStyle = .secondary
	label     ?string
	emoji     ?PartialEmoji
	custom_id ?string
	url       ?string
	disabled  ?bool
}

pub fn Button.parse(j json2.Any) !Button {
	match j {
		map[string]json2.Any {
			return Button{
				style: unsafe { ButtonStyle(j['style']!.int()) }
				label: if s := j['label'] {
					?string(s as string)
				} else {
					none
				}
				emoji: if o := j['emoji'] {
					dump(PartialEmoji.parse(o)!)
					?PartialEmoji(PartialEmoji.parse(o)!)
				} else {
					none
				}
				custom_id: if s := j['custom_id'] {
					?string(s as string)
				} else {
					none
				}
				url: if s := j['url'] {
					?string(s as string)
				} else {
					none
				}
				disabled: if b := j['disabled'] {
					?bool(b as bool)
				} else {
					none
				}
			}
		}
		else {
			return error('expected button to be object, got ${j.type_name()}')
		}
	}
}

fn main() {
	assert Button.parse({
		'style': json2.Any(2)
	}) or { panic('That case should not return error: ${err}') } == Button{
		style: .secondary
	}
}
```