### PR TITLE
V init: Add all prompts as flags as well

### DIFF
--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -190,11 +190,12 @@ fn (mut c Create) prompt(args []string) {
 			exit(3)
 		}
 	}
-
 }
 
 fn get_description(cmd Command) string {
-	mut description := cmd.flags.get_string('description') or { os.input('Input your project description: ') }
+	mut description := cmd.flags.get_string('description') or {
+		os.input('Input your project description: ')
+	}
 
 	return description
 }
@@ -202,7 +203,9 @@ fn get_description(cmd Command) string {
 fn get_license(cmd Command) string {
 	default_license := 'MIT'
 
-	mut license := cmd.flags.get_string('license') or { os.input('Input the license of your project: ') }
+	mut license := cmd.flags.get_string('license') or {
+		os.input('Input the license of your project: ')
+	}
 
 	if license == '' {
 		license = default_license
@@ -214,7 +217,9 @@ fn get_license(cmd Command) string {
 fn get_version(cmd Command) string {
 	default_version := '0.0.0'
 
-	mut version := cmd.flags.get_string('project_version') or { os.input('Input the version of your project: ') }
+	mut version := cmd.flags.get_string('project_version') or {
+		os.input('Input the version of your project: ')
+	}
 
 	if version == '' {
 		version = default_version


### PR DESCRIPTION
## Adds

Flags on `v init`:

```
--description (if '' - empty string, then it's gonna prompt)
--project-version (--version conflicted with v's version, default: 0.0.0)
--license (default: MIT)
```

## Reason / What it fixes:

As a user, I wanted to make a quick bin/sh command that would auto-create a project with `v` without any prompts, I wanted all to be automatically and the prompts would auto-fill themselves with the information I already had from the script. But prompts preventing that. 

Even if there is another way, it feels much more straightforward to just have the prompts accessible as flags, so the user can notice them immediately.
