### PR TITLE
checker: fix lambda expr with result (fix #19874)

### DIFF
--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -63,7 +63,7 @@ pub fn (mut c Checker) lambda_expr(mut node ast.LambdaExpr, exp_typ ast.Type) as
 
 		mut stmts := []ast.Stmt{}
 		mut has_return := false
-		if return_type == ast.void_type {
+		if return_type.clear_flags(.option, .result) == ast.void_type {
 			stmts << ast.ExprStmt{
 				pos: node.pos
 				expr: node.expr

--- a/vlib/v/tests/lambda_expr_with_result_test.v
+++ b/vlib/v/tests/lambda_expr_with_result_test.v
@@ -1,0 +1,8 @@
+fn test_lambda_expr_with_result() {
+	take_lambda(|| println('abc'))
+	assert true
+}
+
+fn take_lambda(l fn () !) {
+	l() or { panic(err) }
+}


### PR DESCRIPTION
This PR fix lambda expr with result (fix #19874).

- Fix lambda expr with result.
- Add test.

```v
fn main() {
	take_lambda(|| println('abc'))
}

fn take_lambda(l fn () !) {
	l() or { panic(err) }
}

PS D:\Test\v\tt1> v run .
abc
```