### PR TITLE
cgen: fix escape of non-ascii characters in string interpolation(fix #20432)

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -265,7 +265,7 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 	g.write(' str_intp(${node.vals.len}, ')
 	g.write('_MOV((StrIntpData[]){')
 	for i, val in node.vals {
-		mut escaped_val := util.smart_quote(val, false)
+		mut escaped_val := cescape_nonascii(util.smart_quote(val, false))
 		escaped_val = escaped_val.replace('\0', '\\0')
 
 		if escaped_val.len > 0 {

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -226,3 +226,10 @@ fn test_contains_zero_characters() {
 	assert str.len == 7
 	assert str == 'abc\0abc'
 }
+
+// for issue: 20432
+// non-ascii escape was lost
+fn test_interpo_non_ascii_characters() {
+	hello := '你好'
+	assert '${hello},世界！' == '你好,世界！'
+}


### PR DESCRIPTION
1. Fixed #20432 
2. Add tests.

```v
module main

fn main() {
	name := '李杰'
	println('${name},你好啊')
}
```
outputs:
```
李杰,你好啊
```