### PR TITLE
checker: fix checking when converting 'voidptr/nil' to struct aliases(fix #20429)

### DIFF
--- a/vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.out
+++ b/vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.out
@@ -1,0 +1,34 @@
+vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv:20:6: error: cannot cast `voidptr` to `AliasFoo1` (alias to `C.Foo1`)
+   18 | fn main() {
+   19 |     // test cast `voidptr/nil` to `alias`
+   20 |     _ = AliasFoo1(unsafe { nil })
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+   21 |     _ = AliasFoo2(voidptr(0))
+   22 |     _ = AliasBar(unsafe { nil })
+vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv:21:6: error: cannot cast `voidptr` to `AliasFoo2` (alias to `C.Foo2`)
+   19 |     // test cast `voidptr/nil` to `alias`
+   20 |     _ = AliasFoo1(unsafe { nil })
+   21 |     _ = AliasFoo2(voidptr(0))
+      |         ~~~~~~~~~~~~~~~~~~~~~
+   22 |     _ = AliasBar(unsafe { nil })
+   23 |
+vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv:22:6: error: cannot cast `voidptr` to `AliasBar` (alias to `Bar`)
+   20 |     _ = AliasFoo1(unsafe { nil })
+   21 |     _ = AliasFoo2(voidptr(0))
+   22 |     _ = AliasBar(unsafe { nil })
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~
+   23 | 
+   24 |     // test cast `voidptr/nil` to `non-alias` and has `typedef`
+vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv:25:8: error: cannot cast `voidptr` to struct
+   23 | 
+   24 |     // test cast `voidptr/nil` to `non-alias` and has `typedef`
+   25 |     _ = C.Foo1(unsafe { nil })
+      |           ~~~~~~~~~~~~~~~~~~~~
+   26 |     // test cast `voidptr/nil` to `non-alias` and no `typedef`
+   27 |     _ = C.Foo2(voidptr(0))
+vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv:27:8: error: cannot cast `voidptr` to struct
+   25 |     _ = C.Foo1(unsafe { nil })
+   26 |     // test cast `voidptr/nil` to `non-alias` and no `typedef`
+   27 |     _ = C.Foo2(voidptr(0))
+      |           ~~~~~~~~~~~~~~~~
+   28 | }

--- a/vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv
+++ b/vlib/v/checker/tests/cast_voidptr_to_struct_alias_err.vv
@@ -1,0 +1,28 @@
+module main
+
+// has `typedef`
+@[typedef]
+struct C.Foo1 {}
+
+type AliasFoo1 = C.Foo1
+
+// no `typedef`
+struct C.Foo2 {}
+
+type AliasFoo2 = C.Foo2
+
+struct Bar {}
+
+type AliasBar = Bar
+
+fn main() {
+	// test cast `voidptr/nil` to `alias`
+	_ = AliasFoo1(unsafe { nil })
+	_ = AliasFoo2(voidptr(0))
+	_ = AliasBar(unsafe { nil })
+
+	// test cast `voidptr/nil` to `non-alias` and has `typedef`
+	_ = C.Foo1(unsafe { nil })
+	// test cast `voidptr/nil` to `non-alias` and no `typedef`
+	_ = C.Foo2(voidptr(0))
+}


### PR DESCRIPTION
1. This PR: fix checking when converting `voidptr/nil` to struct aliases, maybe close #20429
    Maybe there's something wrong with my environment and I can't find the method `sdl.render_set_v_sync`, so I'm not sure, But it solves several issues with converting `voidptr/nil` to aliases.
 2. Add tests.
 
The issues:

```v
module main

@[typedef]
struct C.Foo {}

type AliasFoo = C.Foo

fn main() {
	_ = AliasFoo(unsafe { nil })
}
```
C error:
```
/tmp/v_501/a.4242773401540172409.tmp.c:12658:23: warning: cast to smaller integer type 'main__AliasFoo' (aka 'int') from 'void *' [-Wvoid-pointer-to-int-cast]
        {main__AliasFoo _ = ((main__AliasFoo)(((void*)0)));}
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
...
==================
```

```v
module main

struct Bar {}

type AliasBar = Bar

fn main() {
	_ = AliasBar(unsafe { nil })
}
```
C error:
```
==================
/tmp/v_501/a.1504543238470926751.tmp.c:12663:23: error: used type 'main__AliasBar' (aka 'struct main__Bar') where arithmetic or pointer type is required
        {main__AliasBar _ = ((main__AliasBar)(((void*)0)));}
                             ^               ~~~~~~~~~~~~
1 error generated.
...
==================
```
