### PR TITLE
x.vweb: add error when static directory does not exist

### DIFF
--- a/vlib/x/vweb/static_handler.v
+++ b/vlib/x/vweb/static_handler.v
@@ -56,7 +56,7 @@ pub fn (mut sh StaticHandler) handle_static(directory_path string, root bool) !b
 // ```
 pub fn (mut sh StaticHandler) host_handle_static(host string, directory_path string, root bool) !bool {
 	if !os.exists(directory_path) {
-		return false
+		return error('directory "${directory_path}" does not exist. The directory should be relative to the current working directory')
 	}
 	dir_path := directory_path.trim_space().trim_right('/')
 	mut mount_path := ''
@@ -84,7 +84,7 @@ pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory
 	if mount_path.len < 1 || mount_path[0] != `/` {
 		return error('invalid mount path! The path should start with `/`')
 	} else if !os.exists(directory_path) {
-		return error('directory "${directory_path}" does not exist')
+		return error('directory "${directory_path}" does not exist. The directory should be relative to the current working directory')
 	}
 
 	dir_path := directory_path.trim_right('/')

--- a/vlib/x/vweb/static_handler.v
+++ b/vlib/x/vweb/static_handler.v
@@ -56,7 +56,7 @@ pub fn (mut sh StaticHandler) handle_static(directory_path string, root bool) !b
 // ```
 pub fn (mut sh StaticHandler) host_handle_static(host string, directory_path string, root bool) !bool {
 	if !os.exists(directory_path) {
-		return error('directory "${directory_path}" does not exist. The directory should be relative to the current working directory')
+		return error('directory `${directory_path}` does not exist. The directory should be relative to the current working directory: ${os.getwd()}')
 	}
 	dir_path := directory_path.trim_space().trim_right('/')
 	mut mount_path := ''
@@ -84,7 +84,7 @@ pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory
 	if mount_path.len < 1 || mount_path[0] != `/` {
 		return error('invalid mount path! The path should start with `/`')
 	} else if !os.exists(directory_path) {
-		return error('directory "${directory_path}" does not exist. The directory should be relative to the current working directory')
+		return error('directory `${directory_path}` does not exist. The directory should be relative to the current working directory: ${os.getwd()}')
 	}
 
 	dir_path := directory_path.trim_right('/')

--- a/vlib/x/vweb/tests/static_handler_test.v
+++ b/vlib/x/vweb/tests/static_handler_test.v
@@ -53,7 +53,7 @@ fn run_app_test() {
 	if _ := app.handle_static('not_found', true) {
 		assert true == false, 'should throw directory not found error'
 	} else {
-		assert err.msg() == 'directory "not_found" does not exist. The directory should be relative to the current working directory'
+		assert err.msg().starts_with('directory `not_found` does not exist') == true
 	}
 
 	app.handle_static('testdata', true) or { panic(err) }
@@ -67,7 +67,7 @@ fn run_app_test() {
 	if _ := app.mount_static_folder_at('not_found', '/static') {
 		assert true == false, 'should throw mount path does not exist error'
 	} else {
-		assert err.msg() == 'directory "not_found" does not exist. The directory should be relative to the current working directory'
+		assert err.msg().starts_with('directory `not_found` does not exist') == true
 	}
 
 	app.mount_static_folder_at('testdata', '/static') or { panic(err) }

--- a/vlib/x/vweb/tests/static_handler_test.v
+++ b/vlib/x/vweb/tests/static_handler_test.v
@@ -49,6 +49,13 @@ fn run_app_test() {
 	}
 
 	app.static_mime_types['.what'] = vweb.mime_types['.txt']
+
+	if _ := app.handle_static('not_found', true) {
+		assert true == false, 'should throw directory not found error'
+	} else {
+		assert err.msg() == 'directory "not_found" does not exist. The directory should be relative to the current working directory'
+	}
+
 	app.handle_static('testdata', true) or { panic(err) }
 
 	if _ := app.mount_static_folder_at('testdata', 'static') {
@@ -60,7 +67,7 @@ fn run_app_test() {
 	if _ := app.mount_static_folder_at('not_found', '/static') {
 		assert true == false, 'should throw mount path does not exist error'
 	} else {
-		assert err.msg() == 'directory "not_found" does not exist'
+		assert err.msg() == 'directory "not_found" does not exist. The directory should be relative to the current working directory'
 	}
 
 	app.mount_static_folder_at('testdata', '/static') or { panic(err) }

--- a/vlib/x/vweb/tests/static_handler_test.v
+++ b/vlib/x/vweb/tests/static_handler_test.v
@@ -51,7 +51,7 @@ fn run_app_test() {
 	app.static_mime_types['.what'] = vweb.mime_types['.txt']
 
 	if _ := app.handle_static('not_found', true) {
-		assert true == false, 'should throw directory not found error'
+		assert false, 'should throw directory not found error'
 	} else {
 		assert err.msg().starts_with('directory `not_found` does not exist') == true
 	}


### PR DESCRIPTION
This pr improves error handling when the directory passed to `StaticHandler` can't be found.

It now returns an error when the static directory does not exist, instead of `false`.

