### PR TITLE
cgen, dl: add windows dll support, fix (#20447)

### DIFF
--- a/examples/dynamic_library_loader/modules/library/library.v
+++ b/examples/dynamic_library_loader/modules/library/library.v
@@ -10,7 +10,9 @@ module library
 // `library__add_1`, if not for the export: tag).
 @[export: 'add_1']
 pub fn add_1(x int, y int) int {
-	return my_private_function(x + y)
+	num := my_private_function(x + y)
+	println('hello from ${@FN} , num = ${num}')
+	return num
 }
 
 // this function is not exported and will not be visible to external programs.

--- a/examples/dynamic_library_loader/use_test.v
+++ b/examples/dynamic_library_loader/use_test.v
@@ -1,7 +1,5 @@
 module main
 
-// vtest flaky: true
-// vtest retry: 3
 import os
 import dl
 
@@ -31,6 +29,7 @@ fn test_can_compile_main_program() {
 	assert os.is_file(library_file_path)
 	result := v_compile('run use_shared_library.v')
 	// dump(result)
+	assert result.output.contains('hello from add_1 , num = 4')
 	assert result.output.contains('res: 4')
 	os.rm(library_file_path) or {}
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5914,8 +5914,9 @@ fn (mut g Gen) write_init_function() {
 		g.writeln('\tv__trace_calls__on_call(_SLIT("_vinit"));')
 	}
 
-	if g.use_segfault_handler {
+	if g.use_segfault_handler && !g.pref.is_shared {
 		// 11 is SIGSEGV. It is hardcoded here, to avoid FreeBSD compilation errors for trivial examples.
+		// shared object does not need this
 		g.writeln('#if __STDC_HOSTED__ == 1\n\tsignal(11, v_segmentation_fault_handler);\n#endif')
 	}
 	if g.pref.is_bare {
@@ -5930,7 +5931,10 @@ fn (mut g Gen) write_init_function() {
 	// calling module init functions too, just in case they do fail...
 	g.write('\tas_cast_type_indexes = ')
 	g.writeln(g.as_cast_name_table())
-	g.writeln('\tbuiltin_init();')
+	if !g.pref.is_shared {
+		// shared object does not need this
+		g.writeln('\tbuiltin_init();')
+	}
 
 	if g.nr_closures > 0 {
 		g.writeln('\t_closure_mtx_init();')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
As Windows LoadLibrary/FreeLibrary do not support constructor/destructor,  add vlib/dl_windows.c.v support a workaround.
Inside the dl.open(), call the _vinit_caller().
Inside the dl.close(), call the _vcleanup_caller().
This will build the v runtime environment for the DLL.

fix (#20447 )