### PR TITLE
ci: make the `vab-compiles-v-examples` job, more robust to github runner and Android SDK changes

### DIFF
--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -1,6 +1,7 @@
 name: vab CI
 
 on:
+  workflow_call:
   push:
     paths-ignore:
       - "**.md"
@@ -19,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 8
+          java-version: 11
 
       - uses: actions/checkout@v3
       - name: Build V

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -39,7 +39,10 @@ jobs:
         run: vab --help
 
       - name: Run vab doctor
-        run: vab doctor
+        run: |
+          vab doctor
+          which d8 || true
+          which dx || true
 
       - name: Build graphical V examples as APK
         run: |


### PR DESCRIPTION
- ci: bump java-version: to 11 in .github/workflows/vab_ci.yml, to make the CI more robust to github action runner upgrades
- ci: show the paths to d8 and dx if possible in vab_ci.yml
