### PR TITLE
checker: fix anon struct init with const fields(fix #20452)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -792,9 +792,13 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 							&& field.default_expr.info is ast.IdentFn {
 							c.expr(mut field.default_expr)
 						} else {
-							c.expected_type = field.typ
-							field.default_expr_typ = c.expr(mut field.default_expr)
-							info.fields[i].default_expr_typ = field.default_expr_typ
+							if const_field := c.table.global_scope.find_const('${field.default_expr}') {
+								info.fields[i].default_expr_typ = const_field.typ
+							} else if type_sym.info is ast.Struct && type_sym.info.is_anon {
+								c.expected_type = field.typ
+								field.default_expr_typ = c.expr(mut field.default_expr)
+								info.fields[i].default_expr_typ = field.default_expr_typ
+							}
 						}
 					}
 					continue

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -792,9 +792,9 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 							&& field.default_expr.info is ast.IdentFn {
 							c.expr(mut field.default_expr)
 						} else {
-							if const_field := c.table.global_scope.find_const('${field.default_expr}') {
-								info.fields[i].default_expr_typ = const_field.typ
-							}
+							c.expected_type = field.typ
+							field.default_expr_typ = c.expr(mut field.default_expr)
+							info.fields[i].default_expr_typ = field.default_expr_typ
 						}
 					}
 					continue

--- a/vlib/v/tests/anon_struct_with_default_expr_test.v
+++ b/vlib/v/tests/anon_struct_with_default_expr_test.v
@@ -13,3 +13,21 @@ fn test_anon_struct_with_default_expr() {
 	println(bar.anon.foofoo.name)
 	assert bar.anon.foofoo.name == 'foofoo'
 }
+
+// for issue 20452
+// phenomenon:
+// cgen generates incorrect code when the default value of an anonymous struct field is the const variable.
+const hello = 'hello'
+
+// vfmt off
+fn method_passed_an_anon_struct_arg(arg struct {
+		name string
+		greeting string = hello
+	}) string {
+	return '${arg.greeting} ${arg.name}!'
+}
+// vfmt on
+
+fn test_anon_struct_with_const_default_expr() {
+	assert method_passed_an_anon_struct_arg(name: 'world') == 'hello world!'
+}


### PR DESCRIPTION
1. Fixed #20452 
2. Add tests.

```v
module main

const salutation = 'Good morning!'

fn greeting(args struct {
		name string
		salut string = salutation
	}) string {
	return 'Hi, ${args.name}! ${args.salut}'
}

fn main() {
	println(greeting(name: 'Flibby'))
}
```
outputs:
```
Hi, Flibby! Good morning!
```