### PR TITLE
checker: fix comptime if with comptime smartcast

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -122,6 +122,9 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							is_comptime_type_is_expr = true
 							if var := left.scope.find_var(left.name) {
 								checked_type = c.unwrap_generic(var.typ)
+								if var.smartcasts.len > 0 {
+									checked_type = c.unwrap_generic(var.smartcasts.last())
+								}
 							}
 							skip_state = if c.comptime.is_comptime_type(checked_type,
 								right as ast.ComptimeType)

--- a/vlib/v/slow_tests/inout/comptime_smartcast_variant.out
+++ b/vlib/v/slow_tests/inout/comptime_smartcast_variant.out
@@ -1,0 +1,5 @@
+[vlib/v/slow_tests/inout/comptime_smartcast_variant.vv:14] field_value: foo
+[vlib/v/slow_tests/inout/comptime_smartcast_variant.vv:18] '$field_value is a string': foo is a string
+[vlib/v/slow_tests/inout/comptime_smartcast_variant.vv:14] field_value: 1
+[vlib/v/slow_tests/inout/comptime_smartcast_variant.vv:16] '$field_value is an int': 1 is an int
+[vlib/v/slow_tests/inout/comptime_smartcast_variant.vv:33] v: done

--- a/vlib/v/slow_tests/inout/comptime_smartcast_variant.vv
+++ b/vlib/v/slow_tests/inout/comptime_smartcast_variant.vv
@@ -1,0 +1,34 @@
+type TestSum = int | string
+
+struct Abc {
+	s TestSum
+	t TestSum
+}
+
+fn get_value[T](obj T) string {
+	$for field in T.fields {
+		field_value := obj.$(field.name)
+		$if field_value is $sumtype {
+			$for field_variant in field_value.variants {
+				if field_value is field_variant {
+					dump(field_value)
+					$if field_value is $int {
+						dump('${field_value} is an int')
+					} $else $if field_value is $string {
+						dump('${field_value} is a string')
+					}
+				}
+			}
+		}
+	}
+	return 'done'
+}
+
+fn main() {
+	a := Abc{
+		s: TestSum('foo')
+		t: TestSum(1)
+	}
+	v := get_value(a)
+	dump(v)
+}


### PR DESCRIPTION
Fix #20460

```V
type TestSum = int | string
struct Abc { s TestSum t TestSum }

fn get_value[T](obj T) string {
    $for field in T.fields {
        field_value := obj.$(field.name)
        $if field_value is $sumtype {
            $for field_variant in field_value.variants {
                if field_value is field_variant {
                    dump(field_value)
                    $if field_value is $int {
                        dump("${field_value} is an int")
                    } $else $if field_value is $string {
                        dump("${field_value} is a string")
                    }
                }
            }
        }
    }
    return "done"
}

fn main() {
    a := Abc{ s: TestSum("foo"), t: TestSum(1) }
    v := get_value(a)
    dump(v)
}
```