### PR TITLE
cgen: fix fixed array handling with operator overloading call

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -369,7 +369,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		right_sym := g.table.sym(unwrapped_val_type)
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
-			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr]
+			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr, ast.InfixExpr]
 			|| (val is ast.CastExpr && val.expr !is ast.ArrayInit)
 			|| (val is ast.PrefixExpr && val.op == .arrow)
 			|| (val is ast.UnsafeExpr && val.expr is ast.Ident)) && !g.pref.translated

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -807,6 +807,12 @@ fn (mut g Gen) infix_expr_arithmetic_op(node ast.InfixExpr) {
 			g.op_arg(node.right, method.params[1].typ, right.typ)
 		}
 		g.write(')')
+
+		if left.typ != 0 && !left.typ.has_flag(.option) && !left.typ.has_flag(.result)
+			&& g.table.final_sym(left.typ).kind == .array_fixed {
+			// it's non-option fixed array, requires accessing .ret_arr member to get the array
+			g.write('.ret_arr')
+		}
 	}
 }
 

--- a/vlib/v/tests/fixed_array_op_overload_test.v
+++ b/vlib/v/tests/fixed_array_op_overload_test.v
@@ -1,0 +1,16 @@
+type Vec3 = [3]int
+
+fn (v Vec3) add(u Vec3) Vec3 {
+	return Vec3([v[0] + u[0], v[1] + u[1], v[2] + u[2]]!)
+}
+
+fn (v Vec3) + (u Vec3) Vec3 {
+	return Vec3([v[0] + u[0], v[1] + u[1], v[2] + u[2]]!)
+}
+
+fn test_main() {
+	vec := Vec3([1, 2, 3]!)
+	a := vec.add(vec)
+	b := vec + vec
+	assert a == b
+}


### PR DESCRIPTION
Fix #20467

```V
type Vec3 = [3]int

fn (v Vec3) add(u Vec3) Vec3 {
	return Vec3([v[0] + u[0], v[1] + u[1], v[2] + u[2]]!)
}

fn (v Vec3) + (u Vec3) Vec3 {
	return Vec3([v[0] + u[0], v[1] + u[1], v[2] + u[2]]!)
}

fn test_main() {
	vec := Vec3([1, 2, 3]!)
	a := vec.add(vec)
	b := vec + vec
	assert a == b
}
```