### PR TITLE
net.listen_tcp af .unix expect to return error

### DIFF
--- a/vlib/net/tcp_test.v
+++ b/vlib/net/tcp_test.v
@@ -78,21 +78,10 @@ fn test_tcp_ip() {
 
 fn test_tcp_unix() {
 	eprintln('\n>>> ${@FN}')
-	// TODO(emily):
-	// whilst windows supposedly supports unix sockets
-	// this doesnt work (wsaeopnotsupp at the call to bind())
-	$if !windows {
-		address := os.real_path('tcp-test.sock')
-		// address := 'tcp-test.sock'
-		println('${address}')
+	address := 'tcp-test.sock'
 
-		mut l := net.listen_tcp(.unix, address) or { panic(err) }
-		start_echo_server(mut l)
-		echo(address) or { panic(err) }
-		l.close() or {}
-
-		os.rm(address) or { panic('failed to remove socket file') }
-	}
+	mut l := net.listen_tcp(.unix, address) or { return }
+	assert false
 }
 
 fn testsuite_end() {


### PR DESCRIPTION
The vlib listen_tcp API only allows IP based address family.
The UNIX domain stream- and datagram is tested in
net/unix/unix_tests.v.

