### PR TITLE
cgen: fix generated code for fixed array cast

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -146,6 +146,10 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		ret_typ := g.typ(node.typ)
 		g.write('${ret_typ} ${tmp_var} = ')
 	}
+	if g.inside_cast {
+		ret_typ := g.typ(node.typ)
+		g.write('(${ret_typ})')
+	}
 	g.write('{')
 	if node.has_val {
 		tmp_inside_array := g.inside_array_item

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -146,7 +146,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		ret_typ := g.typ(node.typ)
 		g.write('${ret_typ} ${tmp_var} = ')
 	}
-	if g.inside_cast {
+	if g.inside_struct_init && g.inside_cast {
 		ret_typ := g.typ(node.typ)
 		g.write('(${ret_typ})')
 	}

--- a/vlib/v/tests/cast_fixed_array_to_ptr_ptr_test.v
+++ b/vlib/v/tests/cast_fixed_array_to_ptr_ptr_test.v
@@ -1,0 +1,14 @@
+struct Foo {
+	bar &&char
+}
+
+fn test_main() {
+	foo := Foo{
+		bar: unsafe {
+			&&char(['a', 'b', nil]!)
+		}
+	}
+	println(foo)
+	a := unsafe { cstring_to_vstring(*foo.bar) }
+	assert a == 'a'
+}


### PR DESCRIPTION
Fix #20454

```V
struct Foo {
    bar &&char
}

fn main() {
    foo := Foo{
        bar: unsafe {
            &&char(['a', 'b', nil]!)
        }
    }
    println(foo)
	a := unsafe { cstring_to_vstring(*foo.bar) }
	assert a == 'a'
}
``` 