### PR TITLE
sync: add mutex.try*lock functions for FreeBSD too

### DIFF
--- a/vlib/sync/sync_freebsd.c.v
+++ b/vlib/sync/sync_freebsd.c.v
@@ -16,6 +16,7 @@ $if !android {
 @[trusted]
 fn C.pthread_mutex_init(voidptr, voidptr) int
 fn C.pthread_mutex_lock(voidptr) int
+fn C.pthread_mutex_trylock(voidptr) int
 fn C.pthread_mutex_unlock(voidptr) int
 fn C.pthread_mutex_destroy(voidptr) int
 fn C.pthread_rwlockattr_init(voidptr) int
@@ -25,6 +26,8 @@ fn C.pthread_rwlockattr_destroy(voidptr) int
 fn C.pthread_rwlock_init(voidptr, voidptr) int
 fn C.pthread_rwlock_rdlock(voidptr) int
 fn C.pthread_rwlock_wrlock(voidptr) int
+fn C.pthread_rwlock_tryrdlock(voidptr) int
+fn C.pthread_rwlock_trywrlock(voidptr) int
 fn C.pthread_rwlock_unlock(voidptr) int
 fn C.pthread_rwlock_destroy(voidptr) int
 fn C.sem_init(voidptr, int, u32) int
@@ -101,6 +104,13 @@ pub fn (mut m Mutex) @lock() {
 	C.pthread_mutex_lock(&m.mutex)
 }
 
+// try_lock try to lock the mutex instance and return immediately.
+// If the mutex was already locked, it will return false.
+@[inline]
+pub fn (mut m Mutex) try_lock() bool {
+	return C.pthread_mutex_trylock(&m.mutex) == 0
+}
+
 // unlock unlocks the mutex instance. The mutex is released, and one of
 // the other threads, that were blocked, because they called @lock can continue.
 @[inline]
@@ -137,6 +147,20 @@ pub fn (mut m RwMutex) @rlock() {
 @[inline]
 pub fn (mut m RwMutex) @lock() {
 	C.pthread_rwlock_wrlock(&m.mutex)
+}
+
+// try_rlock try to lock the given RwMutex instance for reading and return immediately.
+// If the mutex was already locked, it will return false.
+@[inline]
+pub fn (mut m RwMutex) try_rlock() bool {
+	return C.pthread_rwlock_tryrdlock(&m.mutex) == 0
+}
+
+// try_wlock try to lock the given RwMutex instance for writing and return immediately.
+// If the mutex was already locked, it will return false.
+@[inline]
+pub fn (mut m RwMutex) try_wlock() bool {
+	return C.pthread_rwlock_trywrlock(&m.mutex) == 0
 }
 
 // destroy frees the resources associated with the rwmutex instance.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
mutex: add try*lock functions for freebsd. This fixes the vlib/sync/mutex_test.v test.
