### PR TITLE
sync: fix FreeBSD implementation of sync functions

### DIFF
--- a/vlib/sync/mutex_test.v
+++ b/vlib/sync/mutex_test.v
@@ -35,8 +35,8 @@ fn test_try_lock_mutex() {
 	try_fail := mx.try_lock()
 	assert try_fail == false
 	mx.unlock()
-	try_sucess := mx.try_lock()
-	assert try_sucess == true
-	mx.unlock() // you must unlock it, after try_lock sucess
+	try_success := mx.try_lock()
+	assert try_success == true
+	mx.unlock() // you must unlock it, after try_lock success
 	mx.destroy()
 }

--- a/vlib/sync/rwmutex_test.v
+++ b/vlib/sync/rwmutex_test.v
@@ -51,12 +51,12 @@ fn test_try_lock_rwmutex() {
 
 	mx.unlock()
 
-	// try_rlock will always sucess when mx unlocked,
+	// try_rlock will always succeed when mx unlocked,
 	// multiple try_rlock can apply to the same mx
-	try_sucess_reading2 := mx.try_rlock()
-	try_sucess_reading3 := mx.try_rlock()
-	assert try_sucess_reading2 == true
-	assert try_sucess_reading3 == true
+	try_success_reading2 := mx.try_rlock()
+	try_success_reading3 := mx.try_rlock()
+	assert try_success_reading2 == true
+	assert try_success_reading3 == true
 
 	// if mx is rlocked, then the try_wlock will fail
 	try_fail_writing2 := mx.try_wlock()
@@ -65,10 +65,10 @@ fn test_try_lock_rwmutex() {
 	mx.runlock()
 	mx.runlock() // you must release rlock mutiple times, as it was rlocked multiple times
 
-	// after mx release all rlock, try_wlock will sucess
-	try_sucess_writing3 := mx.try_wlock()
-	assert try_sucess_writing3 == true
+	// after mx release all rlock, try_wlock will succeed
+	try_success_writing3 := mx.try_wlock()
+	assert try_success_writing3 == true
 
-	mx.unlock() // you must unlock it, after try_wlock sucess
+	mx.unlock() // you must unlock it, after try_wlock success
 	mx.destroy()
 }


### PR DESCRIPTION
The FreeBSD implementation of the sync functions were not updated when the default, darwin, and windows implementations were.  As a result, the unit tests would fail on FreeBSD.  This change brings it into agreement with the other implementations.

In addition, I noticed a few spelling and grammar errors in the mutex_test.v and rwmutex_test.v files.  I did not change anything of substance in those files, just the spelling and grammar.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
