### PR TITLE
parser: fix close_scope() missing when field.name is sort, sorted(fix#20436)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3205,6 +3205,9 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	is_filter := field_name in ['filter', 'map', 'any', 'all']
 	if is_filter || field_name == 'sort' || field_name == 'sorted' {
 		p.open_scope()
+		defer {
+			p.close_scope()
+		}
 	}
 	// ! in mutable methods
 	if p.tok.kind == .not && p.peek_tok.kind == .lpar {
@@ -3267,9 +3270,6 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 			scope: p.scope
 			comments: comments
 		}
-		if is_filter || field_name == 'sort' || field_name == 'sorted' {
-			p.close_scope()
-		}
 		return mcall_expr
 	}
 	mut is_mut := false
@@ -3315,9 +3315,6 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		next_token: p.tok.kind
 	}
 
-	if is_filter || field_name == 'sort' || field_name == 'sorted' {
-		p.close_scope()
-	}
 	return sel_expr
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3315,7 +3315,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		next_token: p.tok.kind
 	}
 
-	if is_filter {
+	if is_filter || field_name == 'sort' || field_name == 'sorted' {
 		p.close_scope()
 	}
 	return sel_expr

--- a/vlib/v/tests/selectorexpt_field_name_test.v
+++ b/vlib/v/tests/selectorexpt_field_name_test.v
@@ -1,0 +1,15 @@
+// for issue 20436
+// phenomenon:
+// close_scope() is lost when selectexpr has two special names: sort and sorted.
+// This problem can be tested using closure arguments.
+struct Foo {
+	sort []int
+}
+
+fn test_main() {
+	f := Foo{}
+
+	fn [f] () {
+		assert f.sort.len == 0
+	}()
+}


### PR DESCRIPTION
1. Fixed #20436
2. Add tests.

```v
struct Foo {
	sort []int
}

fn main() {
	f := Foo{}

	fn [f] () {
		println(f.sort.len)
		assert f.sort.len == 0
	}()
}
```
outputs:
```
0
```