### PR TITLE
examples: fix "call v from ruby" example for Windows and Mac

### DIFF
--- a/examples/call_v_from_ruby/test.rb
+++ b/examples/call_v_from_ruby/test.rb
@@ -22,7 +22,11 @@ end
 module Lib
   extend FFI::Library
 
-  ffi_lib File.join(File.dirname(__FILE__), 'test' + shared_library_extension)
+  begin
+    ffi_lib File.join(File.dirname(__FILE__), 'test' + shared_library_extension)
+  rescue LoadError
+    abort("No shared library test#{shared_library_extension} found. Check examples/call_v_from_ruby/README.md")
+  end
 
   attach_function :square, [:int], :int
   attach_function :sqrt_of_sum_of_squares, [:double, :double], :double

--- a/examples/call_v_from_ruby/test.rb
+++ b/examples/call_v_from_ruby/test.rb
@@ -7,10 +7,22 @@ end
 
 require 'ffi'
 
+# extension for shared libraries varies by platform - see vlib/dl/dl.v
+# get_shared_library_extension()
+def shared_library_extension
+  if Gem.win_platform?
+    '.dll'
+  elsif RUBY_PLATFORM =~ /darwin/ # MacOS
+    '.dylib'
+  else
+    '.so'
+  end
+end
+
 module Lib
   extend FFI::Library
 
-  ffi_lib File.join(File.dirname(__FILE__), 'test.so')
+  ffi_lib File.join(File.dirname(__FILE__), 'test' + shared_library_extension)
 
   attach_function :square, [:int], :int
   attach_function :sqrt_of_sum_of_squares, [:double, :double], :double


### PR DESCRIPTION
I noticed that the "call v from ruby" example doesn't work on MacOS, and likely also not on Windows, since the shared library artifact generated by `v -d no_backtrace -shared examples/call_v_from_ruby/test.v` has a different, platform-specific extension (`.dylib` and `.dll` respectively - [source](https://github.com/vlang/v/blob/757929392e0e7a75fc1272116460981e589737d5/vlib/dl/dl.v#L9-L20)) but the ruby code assumed `.so`.  

While I was there, I also improved the user feedback from the Ruby script if the shared library is missing.

- [x] Before submitting a PR, please run `v test-all`
  - Quite a few failures on my machine, but this also happens on `master` and I'm only changing ruby code, so I hope this is OK.
