### PR TITLE
orm: fix checking invalid recursive structs(fix #20285)

### DIFF
--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -45,6 +45,13 @@ fn (mut c Checker) sql_expr(mut node ast.SqlExpr) ast.Type {
 	mut primary_field := ast.StructField{}
 
 	for field in fields {
+		field_typ, field_sym := c.get_non_array_type(field.typ)
+		if field_sym.kind == .struct_ && (field_typ.idx() == node.table_expr.typ.idx()
+			|| c.check_recursive_structs(field_sym, table_sym.name)) {
+			c.error('invalid recursive struct `${field_sym.name}`', field.pos)
+			return ast.void_type
+		}
+
 		if field.attrs.contains('primary') {
 			if has_primary {
 				c.orm_error('a struct can only have one primary key', field.pos)
@@ -717,4 +724,34 @@ fn (c &Checker) orm_get_field_pos(expr &ast.Expr) token.Pos {
 		pos = expr.pos()
 	}
 	return pos
+}
+
+// check_recursive_structs returns true if type is struct and has any child or nested child with the type of the given struct name,
+// array elements are all checked.
+fn (mut c Checker) check_recursive_structs(ts &ast.TypeSymbol, struct_name string) bool {
+	if ts.info is ast.Struct {
+		for field in ts.info.fields {
+			_, field_sym := c.get_non_array_type(field.typ)
+			if field_sym.kind == .struct_ && field_sym.name == struct_name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// returns the final non-array type by recursively retrieving the element type of an array type,
+// if the input type is not an array, it is returned directly.
+fn (mut c Checker) get_non_array_type(typ_ ast.Type) (ast.Type, &ast.TypeSymbol) {
+	mut typ := typ_
+	mut sym := c.table.sym(typ)
+	for {
+		if sym.kind == .array {
+			typ = sym.array_info().elem_type
+			sym = c.table.sym(typ)
+		} else {
+			break
+		}
+	}
+	return typ, sym
 }

--- a/vlib/v/checker/tests/orm_invalid_recursive_structs_err.out
+++ b/vlib/v/checker/tests/orm_invalid_recursive_structs_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_invalid_recursive_structs_err.vv:6:2: error: invalid recursive struct `Child`
+    4 | struct Parent {
+    5 |     id       int     @[primary; sql: serial]
+    6 |     children []Child @[fkey: 'parent_id']
+      |     ~~~~~~~~~~~~~~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/orm_invalid_recursive_structs_err.vv
+++ b/vlib/v/checker/tests/orm_invalid_recursive_structs_err.vv
@@ -1,0 +1,25 @@
+import db.sqlite
+
+@[table: 'parents']
+struct Parent {
+	id       int     @[primary; sql: serial]
+	children []Child @[fkey: 'parent_id']
+}
+
+@[table: 'children']
+struct Child {
+	id        int    @[primary; sql: serial]
+	parent_id int
+	parent    Parent
+}
+
+fn main() {
+	mut db := sqlite.connect('/dev/null') or { panic(err) }
+	defer {
+		db.close() or { panic(err) }
+	}
+
+	_ := sql db {
+		select from Parent
+	} or { panic(err) }
+}


### PR DESCRIPTION
1. Fixed #20285 
2. Add tests.

```v
import db.sqlite

@[table: 'parents']
struct Parent {
	id       int     @[primary; sql: serial]
	children []Child @[fkey: 'parent_id']
}

@[table: 'children']
struct Child {
	id        int    @[primary; sql: serial]
	parent_id int
	parent    Parent
}

fn main() {
	mut db := sqlite.connect('/dev/null') or { panic(err) }
	defer {
		db.close() or { panic(err) }
	}

	_ := sql db {
		select from Parent
	} or { panic(err) }
}
```
outputs:
```
a.v:8:2: error: invalid recursive struct `Child`
    6 | struct Parent {
    7 |     id int @[primary; sql: serial]
    8 |     children []Child @[fkey: 'parent_id']
      |     ~~~~~~~~~~~~~~~~
    9 | }
   10 |
```