### PR TITLE
cgen: fix fixed array handling on generic result return and on or block

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -76,8 +76,8 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		g.inside_opt_or_res = old_inside_opt_or_res
 	}
 	g.write(')')
-	if (g.inside_assign || g.expected_fixed_arr) && !expr_type.has_flag(.option)
-		&& g.table.type_kind(expr_type) == .array_fixed {
+	if (g.inside_assign || g.expected_fixed_arr) && !expr_type.has_option_or_result()
+		&& g.table.final_sym(expr_type).kind == .array_fixed {
 		g.write('.ret_arr')
 	}
 }
@@ -121,7 +121,7 @@ fn (mut g Gen) dump_expr_definitions() {
 			g.go_back(str_tdef.len)
 			dump_typedefs['typedef ${str_tdef};'] = true
 			str_dumparg_ret_type = str_dumparg_type
-		} else if !typ.has_flag(.option) && dump_sym.is_array_fixed() {
+		} else if !typ.has_option_or_result() && dump_sym.is_array_fixed() {
 			match dump_sym.kind {
 				.array_fixed {
 					if (dump_sym.info as ast.ArrayFixed).is_fn_ret {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -228,10 +228,10 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	mut type_name := g.typ(g.unwrap_generic(node.return_type))
 
 	ret_sym := g.table.sym(g.unwrap_generic(node.return_type))
-	if node.return_type.has_flag(.generic) && !node.return_type.has_flag(.option)
+	if node.return_type.has_flag(.generic) && !node.return_type.has_option_or_result()
 		&& ret_sym.kind == .array_fixed {
 		type_name = '_v_${type_name}'
-	} else if ret_sym.kind == .alias && !node.return_type.has_flag(.option) {
+	} else if ret_sym.kind == .alias && !node.return_type.has_option_or_result() {
 		unalias_typ := g.table.unaliased_type(node.return_type)
 		unalias_sym := g.table.sym(unalias_typ)
 		if unalias_sym.kind == .array_fixed {
@@ -1606,8 +1606,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		g.write(', ${array_depth}')
 	}
 	g.write(')')
-	if node.return_type != 0 && !node.return_type.has_flag(.option)
-		&& !node.return_type.has_flag(.result)
+	if node.return_type != 0 && !node.return_type.has_option_or_result()
 		&& g.table.final_sym(node.return_type).kind == .array_fixed {
 		// it's non-option fixed array, requires accessing .ret_arr member to get the array
 		g.write('.ret_arr')
@@ -1946,8 +1945,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			if name != '&' {
 				g.write(')')
 			}
-			if node.return_type != 0 && !node.return_type.has_flag(.option)
-				&& !node.return_type.has_flag(.result)
+			if node.return_type != 0 && !node.return_type.has_option_or_result()
 				&& g.table.final_sym(node.return_type).kind == .array_fixed {
 				// it's non-option fixed array, requires accessing .ret_arr member to get the array
 				g.write('.ret_arr')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -808,7 +808,7 @@ fn (mut g Gen) infix_expr_arithmetic_op(node ast.InfixExpr) {
 		}
 		g.write(')')
 
-		if left.typ != 0 && !left.typ.has_flag(.option) && !left.typ.has_flag(.result)
+		if left.typ != 0 && !left.typ.has_option_or_result()
 			&& g.table.final_sym(left.typ).kind == .array_fixed {
 			// it's non-option fixed array, requires accessing .ret_arr member to get the array
 			g.write('.ret_arr')

--- a/vlib/v/tests/fixed_array_generic_ret_test.v
+++ b/vlib/v/tests/fixed_array_generic_ret_test.v
@@ -2,9 +2,20 @@ fn example[T]() ?T {
 	return T{}
 }
 
-fn test_main() {
+fn test_option() {
 	dump(example[[1]int]())
 
 	a := example[[1]int]()
 	assert a? == [0]!
+}
+
+fn example2[T]() !T {
+	return T{}
+}
+
+fn test_result() {
+	dump(example2[[1]int]()!)
+
+	a := example2[[1]int]()!
+	assert a == [0]!
 }

--- a/vlib/v/tests/option_or_result_fixed_arr_test.v
+++ b/vlib/v/tests/option_or_result_fixed_arr_test.v
@@ -1,0 +1,43 @@
+type Abc = [2]int
+
+// option
+fn a() ?Abc {
+	return [1, 2]!
+}
+
+fn b() ?Abc {
+	return none
+}
+
+// result
+fn aa() !Abc {
+	return [1, 2]!
+}
+
+fn bb() !Abc {
+	return error('b')
+}
+
+fn test_option() {
+	var_a := dump(a()?)
+	var_b := Abc([1, 2]!)
+	assert var_a == var_b
+}
+
+fn test_result() {
+	var_aa := dump(aa()!)
+	var_bb := Abc([1, 2]!)
+	assert var_aa == var_bb
+}
+
+fn test_opt_block() {
+	var_a := b() or { [0, 0]! }
+	dump(var_a)
+	assert var_a == Abc([0, 0]!)
+}
+
+fn test_res_block() {
+	var_a := bb() or { [0, 0]! }
+	dump(var_a)
+	assert var_a == Abc([0, 0]!)
+}


### PR DESCRIPTION
```v
type Abc = [2]int

// option
fn a() ?Abc {
	return [1, 2]!
}

fn b() ?Abc {
	return none
}

// result
fn aa() !Abc {
	return [1, 2]!
}

fn bb() !Abc {
	return error('b')
}

fn test_option() {
	var_a := dump(a()?)
	var_b := Abc([1, 2]!)
	assert var_a == var_b
}

fn test_result() {
	var_aa := dump(aa()!)
	var_bb := Abc([1, 2]!)
	assert var_aa == var_bb
}

fn test_opt_block() {
	var_a := b() or { [0, 0]! }
	dump(var_a)
	assert var_a == Abc([0, 0]!)
}

fn test_res_block() {
	var_a := bb() or { [0, 0]! }
	dump(var_a)
	assert var_a == Abc([0, 0]!)
}
```

```v
fn example2[T]() !T {
	return T{}
}

fn test_result() {
	dump(example2[[1]int]()!)

	a := example2[[1]int]()!
	assert a == [0]!
}
```