### PR TITLE
repl: support executing shell commands on REPL with `!sh [COMMAND]`

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -100,7 +100,21 @@ fn repl_help() {
 	|Ctrl-C, Ctrl-D, exit   Exits the REPL.
 	|clear                  Clears the screen.
 	|pin                    Pins the entered program to the top.
+	|!sh [COMMAND]          Execute on REPL shell commands.
 '.strip_margin())
+}
+
+fn get_shell(command string) {
+	if command.contains('cd') {
+		
+		command_splited := command.split(' ')
+		assert command_splited.len >= 2
+		dir := command_splited[command_splited.len-1]
+		
+		os.chdir(dir) or { panic('Switch directory failed!') }
+	}else{
+		println(os.execute('timeout 1s ${command}').output)
+	}
 }
 
 fn (mut r Repl) checks() bool {
@@ -361,6 +375,12 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			repl_help()
 			continue
 		}
+
+		if r.line.len > 4 && r.line[0..3] == '!sh' {
+			get_shell(r.line[4..r.line.len])
+			continue
+		}
+		
 		if r.line.contains(':=') && r.line.contains('fn(') {
 			r.in_func = true
 			r.functions_name << r.line.all_before(':= fn(').trim_space()

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -110,7 +110,7 @@ fn run_shell(command string) {
 		assert command_splited.len >= 2
 		dir := command_splited[command_splited.len - 1]
 
-		os.chdir(dir) or { println('Switch directory failed!') }
+		os.chdir(dir) or { eprintln('`${command}` failed, err: ${err}') }
 	} else {
 		os.system(command)
 	}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -104,16 +104,15 @@ fn repl_help() {
 '.strip_margin())
 }
 
-fn get_shell(command string) {
-	if command.contains('cd') {
-		
+fn run_shell(command string) {
+	if command.len >= 2 && command[0..2] == 'cd' {
 		command_splited := command.split(' ')
 		assert command_splited.len >= 2
-		dir := command_splited[command_splited.len-1]
-		
-		os.chdir(dir) or { panic('Switch directory failed!') }
-	}else{
-		println(os.execute('timeout 1s ${command}').output)
+		dir := command_splited[command_splited.len - 1]
+
+		os.chdir(dir) or { println('Switch directory failed!') }
+	} else {
+		os.system(command)
 	}
 }
 
@@ -377,10 +376,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 		}
 
 		if r.line.len > 4 && r.line[0..3] == '!sh' {
-			get_shell(r.line[4..r.line.len])
+			run_shell(r.line[4..r.line.len])
 			continue
 		}
-		
+
 		if r.line.contains(':=') && r.line.contains('fn(') {
 			r.in_func = true
 			r.functions_name << r.line.all_before(':= fn(').trim_space()


### PR DESCRIPTION
## Add suport to execute shell scripts on v REPL

### Implementation code change on vrepl.v

```v
fn repl_help() {
	println(version.full_v_version(false))
	println('
	|help                   Displays this information.
	|list                   Show the program so far.
	|reset                  Clears the accumulated program, so you can start a fresh.
	|Ctrl-C, Ctrl-D, exit   Exits the REPL.
	|clear                  Clears the screen.
	|pin                    Pins the entered program to the top.
	|!sh [COMMAND]          Execute on REPL shell commands.
'.strip_margin())
}
```

```v
fn run_shell(command string) {
	if command.len >= 2 && command[0..2] == 'cd' {
		command_splited := command.split(' ')
		assert command_splited.len >= 2
		dir := command_splited[command_splited.len - 1]

		os.chdir(dir) or { eprintln('`${command}` failed, err: ${err}') }
	} else {
		os.system(command)
	}
}
```

```v
if r.line.len > 4 && r.line[0..3] == '!sh' {
	run_shell(r.line[4..r.line.len])
	continue
}
```

### Implementation working

![repl](https://github.com/vlang/v/assets/32939036/f33c890f-b7d5-425c-943b-13ab5c03d0a5)

### Tested implementation!

### v fmt -w cmd/tools/vrepl.v Execution result

![file](https://github.com/vlang/v/assets/32939036/a0c9740d-3342-4b1e-a832-66b4383d053b)