### PR TITLE
parser, cgen: a minor cleanup

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1451,11 +1451,9 @@ pub fn (mut g Gen) write_typedef_types() {
 				info := sym.info as ast.ArrayFixed
 				elem_sym := g.table.sym(info.elem_type)
 				if elem_sym.is_builtin() {
-					// .array_fixed {
 					styp := sym.cname
-					// array_fixed_char_300 => char x[300]
-					len := styp.after('_')
-					if len.int() > 0 {
+					len := info.size
+					if len > 0 {
 						mut fixed := g.typ(info.elem_type)
 						if elem_sym.info is ast.FnType {
 							pos := g.out.len

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -322,6 +322,9 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 	for_val := p.check_name()
 	mut kind := ast.ComptimeForKind.methods
 	p.open_scope()
+	defer {
+		p.close_scope()
+	}
 	match for_val {
 		'methods' {
 			p.scope.register(ast.Var{
@@ -370,7 +373,6 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 	}
 	spos := p.tok.pos()
 	stmts := p.parse_block()
-	p.close_scope()
 	return ast.ComptimeFor{
 		val_var: val_var
 		stmts: stmts

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -242,6 +242,9 @@ fn (mut p Parser) scope_register_index() {
 fn (mut p Parser) handle_index_variable(mut default_expr ast.Expr) bool {
 	mut has_index := false
 	p.open_scope()
+	defer {
+		p.close_scope()
+	}
 	p.scope_register_index()
 	default_expr = p.expr(0)
 	if var := p.scope.find_var('index') {
@@ -261,6 +264,5 @@ fn (mut p Parser) handle_index_variable(mut default_expr ast.Expr) bool {
 			has_index = is_used
 		}
 	}
-	p.close_scope()
 	return has_index
 }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -249,6 +249,9 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	p.check(.key_fn)
 	comments << p.eat_comments()
 	p.open_scope()
+	defer {
+		p.close_scope()
+	}
 	language_tok_pos := p.tok.pos()
 	mut language := p.parse_language()
 	p.fn_language = language
@@ -645,7 +648,6 @@ run them via `v file.v` instead',
 		p.table.register_fn_generic_types(fn_decl.fkey())
 	}
 	p.label_names = []
-	p.close_scope()
 	return fn_decl
 }
 

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -63,6 +63,9 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 	// TODO Handle aliasing sync
 	p.register_auto_import('sync')
 	p.open_scope()
+	defer {
+		p.close_scope()
+	}
 	mut pos := p.tok.pos()
 	mut lockeds := []ast.Expr{}
 	mut is_rlocked := []bool{}
@@ -95,7 +98,6 @@ fn (mut p Parser) lock_expr() ast.LockExpr {
 	}
 	stmts := p.parse_block_no_scope(false)
 	scope := p.scope
-	p.close_scope()
 	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.LockExpr{
 		lockeds: lockeds


### PR DESCRIPTION
This PR does some minor cleanup work based on the comments of several previous PRs.

- Moved some `close_scope()` into defer (parser).
- Get fixed array size from sym.info.size (cgen, suggestions from previous PR)
