### PR TITLE
vweb: fix parsing url error when querypath is '//'(fix #20476)

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -512,7 +512,8 @@ fn parse_url(rawurl string, via_request bool) !URL {
 				''))
 		}
 	}
-	if ((url.scheme != '' || !via_request) && !rest.starts_with('///')) && rest.starts_with('//') {
+	if ((url.scheme != '' || !via_request) && !rest.starts_with('///')) && rest.starts_with('//')
+		&& rest.len > 2 {
 		authority, r := split(rest[2..], `/`, false)
 		rest = r
 		a := parse_authority(authority)!

--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -122,3 +122,9 @@ fn test_parse() {
 		}
 	}
 }
+
+fn test_parse_slashes() {
+	assert urllib.parse('/')!.str() == '/'
+	assert urllib.parse('//')!.str() == '//'
+	assert urllib.parse('///')!.str() == '///'
+}

--- a/vlib/vweb/tests/vweb_test.v
+++ b/vlib/vweb/tests/vweb_test.v
@@ -339,3 +339,16 @@ ${config.content}'
 	}
 	return read.bytestr()
 }
+
+// for issue 20476
+// phenomenon: parsing url error when querypath is `//`
+fn test_empty_querypath() {
+	mut x := http.get('http://${localserver}') or { panic(err) }
+	assert x.body == 'Welcome to VWeb'
+	x = http.get('http://${localserver}/') or { panic(err) }
+	assert x.body == 'Welcome to VWeb'
+	x = http.get('http://${localserver}//') or { panic(err) }
+	assert x.body == 'Welcome to VWeb'
+	x = http.get('http://${localserver}///') or { panic(err) }
+	assert x.body == 'Welcome to VWeb'
+}


### PR DESCRIPTION
Close #20476 