### PR TITLE
orm: fix checking invalid recursive structs in sql stmts(fix #20278)

### DIFF
--- a/vlib/v/checker/tests/orm_invalid_recursive_structs_err_1.out
+++ b/vlib/v/checker/tests/orm_invalid_recursive_structs_err_1.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_invalid_recursive_structs_err_1.vv:6:2: error: ORM: invalid recursive struct `Child`
+    4 | struct Parent {
+    5 |     id       int     @[primary; sql: serial]
+    6 |     children []Child @[fkey: 'parent_id']
+      |     ~~~~~~~~~~~~~~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/orm_invalid_recursive_structs_err_1.vv
+++ b/vlib/v/checker/tests/orm_invalid_recursive_structs_err_1.vv
@@ -14,12 +14,12 @@ struct Child {
 }
 
 fn main() {
-	mut db := sqlite.connect('/dev/null') or { panic(err) }
+	mut db := sqlite.connect(':memory:')!
 	defer {
 		db.close() or { panic(err) }
 	}
 
-	_ := sql db {
+	_ = sql db {
 		select from Parent
-	} or { panic(err) }
+	}!
 }

--- a/vlib/v/checker/tests/orm_invalid_recursive_structs_err_2.out
+++ b/vlib/v/checker/tests/orm_invalid_recursive_structs_err_2.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/orm_invalid_recursive_structs_err.vv:6:2: error: invalid recursive struct `Child`
+vlib/v/checker/tests/orm_invalid_recursive_structs_err_2.vv:6:2: error: ORM: invalid recursive struct `Child`
     4 | struct Parent {
     5 |     id       int     @[primary; sql: serial]
     6 |     children []Child @[fkey: 'parent_id']

--- a/vlib/v/checker/tests/orm_invalid_recursive_structs_err_2.vv
+++ b/vlib/v/checker/tests/orm_invalid_recursive_structs_err_2.vv
@@ -1,0 +1,25 @@
+import db.sqlite
+
+@[table: 'parents']
+struct Parent {
+	id       int     @[primary; sql: serial]
+	children []Child @[fkey: 'parent_id']
+}
+
+@[table: 'children']
+struct Child {
+	id        int    @[primary; sql: serial]
+	parent_id int
+	parent    Parent
+}
+
+fn main() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or { panic(err) }
+	}
+
+	sql db {
+		create table Parent
+	}!
+}


### PR DESCRIPTION
1. Fixed #20278 
2. Add tests.

PR 20491 fixed only the `sql expr` case, but misses the `sql stmt` case, which should now be complete.
 
```v
import db.sqlite

@[table: 'character']
struct Character {
	id int @[primary; sql: serial]
	user_id User
}

@[table: 'user']                  
struct User {
	id int @[primary; sql: serial]
	characters []Character @[fkey: "user_id"]
}

fn main() {
	mut db := sqlite.connect(':memory:')!
	defer {
		db.close() or { panic(err) }
	}

	sql db {
		create table User
	}!
}
```
outputs:
```
a.v:13:5: error: ORM: invalid recursive struct `Character`
   11 | struct User {
   12 | 	id int @[primary; sql: serial]
   13 | 	characters []Character @[fkey: "user_id"]
      | 	~~~~~~~~~~~~~~~~~~~~~~
   14 | }
   15 |
```