### PR TITLE
Fix for Issue #20510: https://github.com/vlang/v/issues/20510

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -297,7 +297,11 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		ccoptions.args << '-Wl,--no-entry'
 	}
 	if ccoptions.debug_mode && builder.current_os != 'windows' && v.pref.build_mode != .build_module {
-		ccoptions.linker_flags << '-rdynamic' // needed for nicer symbolic backtraces
+		if builder.current_os == 'macos' {
+			ccoptions.linker_flags << '-Wl,-export_dynamic' // clang for mac needs export_dynamic instead of -rdynamic
+		} else {
+			ccoptions.linker_flags << '-rdynamic' // needed for nicer symbolic backtraces
+		}
 	}
 	if v.pref.os == .freebsd {
 		// Needed for -usecache on FreeBSD 13, otherwise we get `ld: error: duplicate symbol: _const_math__bits__de_bruijn32` errors there


### PR DESCRIPTION
Replaces invalid linker flag "-rdynamic" with the clang/MacOS version "-Wl,-export_dynamic".

This enables cross-compiling from MacOS to Windows to work with debug enabled, which is currently broken.

I've tested this manually in my own project.



