### PR TITLE
checker,cgen: change `x.filter(cond).len > 0` to `x.any(cond)`, and `x.filter(cond) == 0` to `x.all(!cond)`

### DIFF
--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -97,7 +97,7 @@ pub fn clone_or_pull(remote_git_url string, local_worktree_path string) {
 		remote_git_config_path := os.join_path(remote_git_url, '.git', 'config')
 		if os.is_dir(remote_git_url) && os.is_file(remote_git_config_path) {
 			lines := os.read_lines(remote_git_config_path) or { [] }
-			is_blobless_clone = lines.filter(it.contains('partialclonefilter = blob:none')).len > 0
+			is_blobless_clone = lines.any(it.contains('partialclonefilter = blob:none'))
 		}
 		if is_blobless_clone {
 			// Note:

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -440,7 +440,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	}
 
 	// vweb checks
-	if node.attrs.len > 0 && c.file.imports.filter(it.mod == 'vweb').len > 0 {
+	if node.attrs.len > 0 && c.file.imports.any(it.mod == 'vweb') {
 		// If it's a vweb action (has the ['/url'] attribute), make sure it returns a vweb.Result
 		for attr in node.attrs {
 			if attr.name.starts_with('/') {
@@ -879,7 +879,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		}
 	}
 	// already imported symbol (static Foo.new() in another module)
-	if !found && fn_name.contains('__static__') && fn_name[0].is_capital() {
+	if !found && fn_name.len > 0 && fn_name[0].is_capital() {
 		if index := fn_name.index('__static__') {
 			owner_name := fn_name#[..index]
 			for import_sym in c.file.imports.filter(it.syms.any(it.name == owner_name)) {
@@ -2526,7 +2526,7 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 	if f.is_variadic {
 		min_required_params--
 	} else {
-		has_decompose := node.args.filter(it.expr is ast.ArrayDecompose).len > 0
+		has_decompose := node.args.any(it.expr is ast.ArrayDecompose)
 		if has_decompose {
 			// if call(...args) is present
 			min_required_params = nr_args - 1
@@ -2540,7 +2540,7 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 			last_typ := f.params.last().typ
 			last_sym := c.table.sym(last_typ)
 			if last_sym.info is ast.Struct {
-				is_params := last_sym.info.attrs.filter(it.name == 'params' && !it.has_arg).len > 0
+				is_params := last_sym.info.attrs.any(it.name == 'params' && !it.has_arg)
 				if is_params {
 					// allow empty trailing struct syntax arg (`f()` where `f` is `fn(ConfigStruct)`)
 					node.args << ast.CallArg{

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -199,8 +199,7 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 			mut value_type := c.table.value_type(typ)
 			if sym.kind == .string {
 				value_type = ast.u8_type
-			} else if sym.kind == .aggregate
-				&& (sym.info as ast.Aggregate).types.filter(c.table.type_kind(it) !in [.array, .array_fixed, .string, .map]).len == 0 {
+			} else if sym.kind == .aggregate&& (sym.info as ast.Aggregate).types.all(c.table.type_kind(it) in [.array, .array_fixed, .string, .map]) {
 				value_type = c.table.value_type((sym.info as ast.Aggregate).types[0])
 			}
 			if value_type == ast.void_type || typ.has_flag(.result) {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -91,7 +91,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 				sym := c.table.sym(field.typ)
 				if sym.kind == .function {
 					if !field.typ.has_flag(.option) && !field.has_default_expr
-						&& field.attrs.filter(it.name == 'required').len == 0 {
+						&& field.attrs.all(it.name != 'required') {
 						error_msg := 'uninitialized `fn` struct fields are not allowed, since they can result in segfaults; use `?fn` or `[required]` or initialize the field with `=` (if you absolutely want to have unsafe function pointers, use `= unsafe { nil }`)'
 						c.note(error_msg, field.pos)
 					}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1684,7 +1684,7 @@ pub fn (mut g Gen) write_multi_return_types() {
 			continue
 		}
 		info := sym.mr_info()
-		if info.types.filter(it.has_flag(.generic)).len > 0 {
+		if info.types.any(it.has_flag(.generic)) {
 			continue
 		}
 		g.typedefs.writeln('typedef struct ${sym.cname} ${sym.cname};')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -130,8 +130,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		} else {
 			false
 		}
-		mut has_decompose := !m.is_variadic
-			&& node.args.filter(it.expr is ast.ArrayDecompose).len > 0
+		mut has_decompose := !m.is_variadic && node.args.any(it.expr is ast.ArrayDecompose)
 		// check argument length and types
 		if m.params.len - 1 != node.args.len && !expand_strs {
 			if g.inside_call {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -49,7 +49,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				}
 			}
 		} else if sym.info is ast.Aggregate
-			&& sym.info.types.filter(g.table.type_kind(it) !in [.array, .array_fixed, .string, .map]).len == 0 {
+			&& sym.info.types.all(g.table.type_kind(it) in [.array, .array_fixed, .string, .map]) {
 			// treating sumtype of array types
 			unwrapped_got_type := sym.info.types[g.aggregate_type_idx]
 			g.index_expr(ast.IndexExpr{ ...node, left_type: unwrapped_got_type })

--- a/vlib/v/tests/reflection_sym_test.v
+++ b/vlib/v/tests/reflection_sym_test.v
@@ -43,7 +43,7 @@ fn test_array_sym() {
 	assert typ.sym.kind == .array
 	assert typ.sym.language == .v
 	assert typ.sym.methods.len > 0
-	assert typ.sym.methods.filter(it.name == 'join').len > 0
+	assert typ.sym.methods.any(it.name == 'join')
 	assert typ.sym.name == '[]string'
 	assert (typ.sym.info as reflection.Array).nr_dims == 1
 	assert (typ.sym.info as reflection.Array).elem_type == typeof[string]().idx


### PR DESCRIPTION
Reduce the amount of allocations done in cgen by ~2MB for recompiling V itself.