### PR TITLE
checker: multi return should check option is handled

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -505,12 +505,13 @@ pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, 
 						}
 					} else {
 						if attr.arg.trim(' ') == '' {
-							return error("references attribute needs to be in the format [references], [references: 'tablename'], or [references: 'tablename(field_id)']")
+							return error("references attribute needs to be in the format @[references], @[references: 'tablename'], or @[references: 'tablename(field_id)']")
 						}
 						if attr.arg.contains('(') {
-							ref_table, ref_field := attr.arg.split_once('(')
+							err := error("explicit references attribute should be written as @[references: 'tablename(field_id)']")
+							ref_table, ref_field := attr.arg.split_once('(') or { return err }
 							if !ref_field.ends_with(')') {
-								return error("explicit references attribute should be written as [references: 'tablename(field_id)']")
+								return err
 							}
 							references_table = ref_table
 							references_field = ref_field[..ref_field.len - 1]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1158,7 +1158,11 @@ fn (mut c Checker) check_expr_option_or_result_call(expr ast.Expr, ret_type ast.
 					'a Result'
 				}
 				return_modifier := if expr_ret_type.has_flag(.option) { '?' } else { '!' }
-				if expr_ret_type.has_flag(.result) && expr.or_block.kind == .absent {
+				requires_or_block := expr_ret_type.has_flag(.result)
+					|| (c.table.sym(expr_ret_type).kind == .multi_return
+					&& expr_ret_type.has_flag(.option))
+
+				if requires_or_block && expr.or_block.kind == .absent {
 					if c.inside_defer {
 						c.error('${expr.name}() returns ${return_modifier_kind}, so it should have an `or {}` block at the end',
 							expr.pos)

--- a/vlib/v/checker/tests/multi_return_option_not_propagated.out
+++ b/vlib/v/checker/tests/multi_return_option_not_propagated.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/multi_return_option_not_propagated.vv:9:10: error: abc() returns an Option, so it should have either an `or {}` block, or `?` at the end
+    7 |
+    8 | fn main() {
+    9 |     a, b := abc(10)
+      |             ~~~~~~~
+   10 |     println(a)
+   11 |     println(b)

--- a/vlib/v/checker/tests/multi_return_option_not_propagated.vv
+++ b/vlib/v/checker/tests/multi_return_option_not_propagated.vv
@@ -1,0 +1,12 @@
+fn abc(n int) ?(int, int) {
+	if n == 5 {
+		return 5, 10
+	}
+	return none
+}
+
+fn main() {
+	a, b := abc(10)
+	println(a)
+	println(b)
+}

--- a/vlib/v/tests/option_multi_return_test.v
+++ b/vlib/v/tests/option_multi_return_test.v
@@ -1,7 +1,7 @@
 struct MmapRangeLocal {}
 
 fn addr2range() ?(&MmapRangeLocal, ?u64, u64) {
-	return none
+	return unsafe { nil }, none, 0
 }
 
 fn foo(val ?int) (?int, ?int) {
@@ -31,13 +31,13 @@ fn tuple4() ?(?int, ?int) {
 }
 
 fn test_tuple_1() {
-	a, b := tuple()
+	a, b := tuple()?
 	assert a == 1
 	assert b == 2
 }
 
 fn test_tuple_2() {
-	a, b := tuple2()
+	a, b := tuple2()?
 	assert a == ''
 	assert b == 2
 }
@@ -48,14 +48,8 @@ fn test_tuple_3() {
 	assert b == none
 }
 
-fn test_tuple_4() {
-	a, b := tuple4()
-	assert a == none
-	assert b == none
-}
-
 fn test_none_ret() {
-	_, b, c := addr2range()
+	_, b, c := addr2range()?
 	assert b == none
 	assert c == 0
 }


### PR DESCRIPTION
Fixes #17874

This fix seems to have uncovered a bug in [vlib/orm/orm.v](https://github.com/vlang/v/blob/6c016e51b77c477051cdaa900f4548a95d03b70b/vlib/orm/orm.v#L511C9-L511C9) where the option is not handled which I've gone ahead and fixed.