### PR TITLE
checker: fix missing check for struct initialization with @[noinit] attribute through T{} usage

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -99,7 +99,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	if node.language == .v && node.attrs.len > 0 {
 		if attr_export := node.attrs.find_first('export') {
 			if attr_export.arg == '' {
-				c.error('missing argument for [export] attribute', attr_export.pos)
+				c.error('missing argument for @[export] attribute', attr_export.pos)
 			}
 		}
 	}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -475,7 +475,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
 		if info.attrs.len > 0 && info.attrs.contains('noinit') && type_sym.mod != c.mod {
-			c.error('struct `${type_sym.name}` is declared with a `[noinit]` attribute, so ' +
+			c.error('struct `${type_sym.name}` is declared with a `@[noinit]` attribute, so ' +
 				'it cannot be initialized with `${type_sym.name}{}`', node.pos)
 		}
 	}
@@ -498,6 +498,10 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 			sym := c.table.sym(c.unwrap_generic(node.typ))
 			if sym.kind == .struct_ {
 				info := sym.info as ast.Struct
+				if info.attrs.len > 0 && info.attrs.contains('noinit') && sym.mod != c.mod {
+					c.error('struct `${sym.name}` is declared with a `@[noinit]` attribute, so ' +
+						'it cannot be initialized with `${sym.name}{}`', node.pos)
+				}
 				if node.no_keys && node.init_fields.len != info.fields.len {
 					fname := if info.fields.len != 1 { 'fields' } else { 'field' }
 					c.error('initializing struct `${sym.name}` needs `${info.fields.len}` ${fname}, but got `${node.init_fields.len}`',

--- a/vlib/v/checker/tests/missing_export_attr_arg_err.out
+++ b/vlib/v/checker/tests/missing_export_attr_arg_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/missing_export_attr_arg_err.vv:1:1: error: missing argument for [export] attribute
+vlib/v/checker/tests/missing_export_attr_arg_err.vv:1:1: error: missing argument for @[export] attribute
     1 | @[export]
       | ~~~~~~~~~
     2 | fn foo() string{

--- a/vlib/v/checker/tests/modules/module_struct_noinit.out
+++ b/vlib/v/checker/tests/modules/module_struct_noinit.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/modules/module_struct_noinit/src/main.v:9:9: error: struct `mod.Foo` is declared with a `@[noinit]` attribute, so it cannot be initialized with `mod.Foo{}`
+    7 | 
+    8 | fn default_value[T]() T {
+    9 |     return T{}
+      |            ~~~
+   10 | }

--- a/vlib/v/checker/tests/modules/module_struct_noinit/src/main.v
+++ b/vlib/v/checker/tests/modules/module_struct_noinit/src/main.v
@@ -1,8 +1,8 @@
 import mod
 
 fn main() {
-    dump(default_value[mod.Foo]())
-    println(default_value[mod.Foo]())
+	dump(default_value[mod.Foo]())
+	println(default_value[mod.Foo]())
 }
 
 fn default_value[T]() T {

--- a/vlib/v/checker/tests/modules/module_struct_noinit/src/main.v
+++ b/vlib/v/checker/tests/modules/module_struct_noinit/src/main.v
@@ -1,0 +1,10 @@
+import mod
+
+fn main() {
+    dump(default_value[mod.Foo]())
+    println(default_value[mod.Foo]())
+}
+
+fn default_value[T]() T {
+	return T{}
+}

--- a/vlib/v/checker/tests/modules/module_struct_noinit/src/mod.v
+++ b/vlib/v/checker/tests/modules/module_struct_noinit/src/mod.v
@@ -1,0 +1,6 @@
+module mod
+
+@[noinit]
+pub struct Foo {
+
+}

--- a/vlib/v/checker/tests/modules/module_struct_noinit/src/mod.v
+++ b/vlib/v/checker/tests/modules/module_struct_noinit/src/mod.v
@@ -2,5 +2,4 @@ module mod
 
 @[noinit]
 pub struct Foo {
-
 }


### PR DESCRIPTION
Fix #20508

```V
import mod1

fn main() {
    dump(default_value[mod1.Foo]())
    println(default_value[mod1.Foo]())

    //a := mod1.Foo{}
}

fn default_value[T]() T {
	return T{}
}
```