### PR TITLE
tests: show compile time and runtime for each _test.v file in separate columns

### DIFF
--- a/cmd/tools/modules/testing/output.v
+++ b/cmd/tools/modules/testing/output.v
@@ -3,6 +3,8 @@ module testing
 import time
 
 pub enum MessageKind {
+	compile_begin // sent right before *each* _test.v file compilation, the resulting status is not known yet, but the _test.v file itself is
+	compile_end // sent right after *each* _test.v file compilation, the message contains the output of that compilation
 	cmd_begin // sent right before *each* _test.v file execution, the resulting status is not known yet, but the _test.v file itself is
 	cmd_end // sent right after *each* _test.v file execution, the message contains the output of that execution
 	//
@@ -21,7 +23,7 @@ pub:
 	kind    MessageKind   // see the MessageKind declaration above
 	file    string        // the _test.v file that the message is about
 	when    time.Time     // when was the message sent (messages are sent by the execution threads at the *end* of each event)
-	flow_id string        // the messages of each thread, producing LogMessage, will have all the same unique flowid. Messages by other threads will have other flowid. If you use VJOBS=1 to serialise the execution, then all messages will have the same flowid.
+	flow_id string        // the messages of each thread, producing LogMessage, will have all the same unique flow_id. Messages by other threads will have other flow_id. If you use VJOBS=1 to serialise the execution, then all messages will have the same flow_id.
 	took    time.Duration // the duration of the event, that this message describes
 	message string        // the actual message text; the result of the event, that the message describes; most reporters could ignore this, since it could be reconstructed by the other fields
 }

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -352,6 +352,7 @@ fn main() {
 	}
 	testing.eheader(title)
 	mut tsession := testing.new_test_session(cmd_prefix, true)
+	tsession.exec_mode = .compile_and_run
 	tsession.files << all_test_files.filter(!it.contains('testdata' + os.path_separator))
 	tsession.skip_files << skip_test_files
 

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -35,6 +35,7 @@ fn main() {
 	backend := if backend_pos == -1 { '.c' } else { args_before[backend_pos + 1] }
 
 	mut ts := testing.new_test_session(args_before.join(' '), true)
+	ts.exec_mode = .compile_and_run
 	ts.fail_fast = ctx.fail_fast
 	for targ in args_after {
 		if os.is_dir(targ) {

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -32,7 +32,7 @@ fn main() {
 		exit(1)
 	}
 	backend_pos := args_before.index('-b')
-	backend := if backend_pos == -1 { '.c' } else { args_before[backend_pos + 1] } // this giant mess because closures are not implemented
+	backend := if backend_pos == -1 { '.c' } else { args_before[backend_pos + 1] }
 
 	mut ts := testing.new_test_session(args_before.join(' '), true)
 	ts.fail_fast = ctx.fail_fast
@@ -150,6 +150,9 @@ fn (mut ctx Context) should_test(path string, backend string) ShouldTestStatus {
 		}
 	}
 	if path.ends_with('_test.v') {
+		return ctx.should_test_when_it_contains_matching_fns(path, backend)
+	}
+	if path.ends_with('_test.c.v') {
 		return ctx.should_test_when_it_contains_matching_fns(path, backend)
 	}
 	if path.ends_with('_test.js.v') {

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -70,6 +70,15 @@ pub fn (mut b Benchmark) step() {
 	}
 }
 
+// step_restart will restart the internal step timer.
+// Note that the step count will *stay the same*.
+// This method is useful, when you want to do some optional preparation
+// after you have called .step(), so that the time for that optional
+// preparation will *not* be added to the duration of the step.
+pub fn (mut b Benchmark) step_restart() {
+	b.step_timer.restart()
+}
+
 // fail increases the fail count by 1 and stops the internal timer.
 pub fn (mut b Benchmark) fail() {
 	b.step_timer.stop()

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -140,8 +140,15 @@ pub fn (mut b Benchmark) record_measure(label string) i64 {
 	return res
 }
 
+// MessageOptions allows passing an optional preparation time too to each label method.
+// If it is set, the preparation time (compile time) will be shown before the measured runtime.
+@[params]
+pub struct MessageOptions {
+	preparation time.Duration // the duration of the preparation time for the step
+}
+
 // step_message_with_label_and_duration returns a string describing the current step.
-pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg string, sduration time.Duration) string {
+pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg string, sduration time.Duration, opts MessageOptions) string {
 	timed_line := b.tdiff_in_ms(msg, sduration.microseconds())
 	if b.nexpected_steps > 1 {
 		mut sprogress := ''
@@ -170,34 +177,38 @@ pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg str
 				'${b.cstep:4d}/${b.nexpected_steps:4d}'
 			}
 		}
+		if opts.preparation > 0 {
+			return '${label:-5s} [${sprogress}] C: ${f64(opts.preparation.microseconds()) / 1_000.0:3.1f} ms, R: ${timed_line}'
+		}
 		return '${label:-5s} [${sprogress}] ${timed_line}'
 	}
 	return '${label:-5s}${timed_line}'
 }
 
 // step_message_with_label returns a string describing the current step using current time as duration.
-pub fn (b &Benchmark) step_message_with_label(label string, msg string) string {
-	return b.step_message_with_label_and_duration(label, msg, b.step_timer.elapsed())
+pub fn (b &Benchmark) step_message_with_label(label string, msg string, opts MessageOptions) string {
+	return b.step_message_with_label_and_duration(label, msg, b.step_timer.elapsed(),
+		opts)
 }
 
 // step_message returns a string describing the current step.
-pub fn (b &Benchmark) step_message(msg string) string {
-	return b.step_message_with_label('', msg)
+pub fn (b &Benchmark) step_message(msg string, opts MessageOptions) string {
+	return b.step_message_with_label('', msg, opts)
 }
 
 // step_message_ok returns a string describing the current step with an standard "OK" label.
-pub fn (b &Benchmark) step_message_ok(msg string) string {
-	return b.step_message_with_label(benchmark.b_ok, msg)
+pub fn (b &Benchmark) step_message_ok(msg string, opts MessageOptions) string {
+	return b.step_message_with_label(benchmark.b_ok, msg, opts)
 }
 
 // step_message_fail returns a string describing the current step with an standard "FAIL" label.
-pub fn (b &Benchmark) step_message_fail(msg string) string {
-	return b.step_message_with_label(benchmark.b_fail, msg)
+pub fn (b &Benchmark) step_message_fail(msg string, opts MessageOptions) string {
+	return b.step_message_with_label(benchmark.b_fail, msg, opts)
 }
 
 // step_message_skip returns a string describing the current step with an standard "SKIP" label.
-pub fn (b &Benchmark) step_message_skip(msg string) string {
-	return b.step_message_with_label(benchmark.b_skip, msg)
+pub fn (b &Benchmark) step_message_skip(msg string, opts MessageOptions) string {
+	return b.step_message_with_label(benchmark.b_skip, msg, opts)
 }
 
 // total_message returns a string with total summary of the benchmark run.
@@ -221,7 +232,7 @@ pub fn (b &Benchmark) total_message(msg string) string {
 			njobs_label = ', on ${term.colorize(term.bold, b.njobs.str())} parallel jobs'
 		}
 	}
-	tmsg += '${b.ntotal} total. ${term.colorize(term.bold, 'Runtime:')} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.\n'
+	tmsg += '${b.ntotal} total. ${term.colorize(term.bold, 'Elapsed time:')} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.'
 	return tmsg
 }
 

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -187,7 +187,7 @@ pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg str
 			}
 		}
 		if opts.preparation > 0 {
-			return '${label:-5s} [${sprogress}] C: ${f64(opts.preparation.microseconds()) / 1_000.0:3.1f} ms, R: ${timed_line}'
+			return '${label:-5s} [${sprogress}] C: ${f64(opts.preparation.microseconds()) / 1_000.0:6.1F} ms, R: ${timed_line}'
 		}
 		return '${label:-5s} [${sprogress}] ${timed_line}'
 	}

--- a/vlib/v/help/build/build.txt
+++ b/vlib/v/help/build/build.txt
@@ -149,6 +149,12 @@ NB: the build flags are shared with the run command too:
   -profile-no-inline
     Skip [inline] functions when profiling.
 
+  -skip-running
+    Skip the automatic running of a _test.v or .vsh file. Useful for debugging and testing.
+    V's testing program `v test` uses that option, to measure and report independently the
+    duration of each _test.v comptime, and then the duration of its runtime.
+    Note: the same effect can be achieved by setting the environment variable VNORUN to 1.
+
   -skip-unused
     Skip generating C/JS code for functions, that are provably not used by your project.
     This speeds up compilation, and reduces the generated output size.

--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -427,6 +427,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-silent' {
 				res.output_mode = .silent
 			}
+			'-skip-running' {
+				res.skip_running = true
+			}
 			'-cstrict' {
 				res.is_cstrict = true
 			}


### PR DESCRIPTION
- benchmark: support passing an optional preparation time for the step messages
- pref: support a -skip-running option
- testing: add `compile_begin` and `compile_end` messages to the testing.Reporter interface
- testing: support the new messages in the output_normal.v Reporter
- benchmark: add Benchmark.step_restart/0 method
- tools: fix `v test` to not skip _test.c.v files by default
- testing,benchmark: use the new -skip-running and the enhanced Reporter to implement a separate compilation time measurement for each test
