### PR TITLE
[Fix] - repl: Fixing an issue with `print` and println after the execution of for or `if` - ISSUE #20524

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -432,10 +432,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			source_code := r.current_source_code(false, false) + '\n${r.line}\n'
 			os.write_file(temp_file, source_code) or { panic(err) }
 			s := repl_run_vfile(temp_file) or { return 1 }
-			if s.output.len > r.last_output.len {
-				cur_line_output := s.output[r.last_output.len..]
-				print_output(cur_line_output)
-			}
+			print_output(s.output)
 		} else {
 			mut temp_line := r.line
 			func_call, fntype := r.function_call(r.line)

--- a/vlib/v/slow_tests/repl/error.repl
+++ b/vlib/v/slow_tests/repl/error.repl
@@ -5,8 +5,3 @@ error: undefined ident: `a`
     6 | 
     7 | println(a)
       |         ^
-error: `println` can not print void expressions
-    5 | import math
-    6 | 
-    7 | println(a)
-      | ~~~~~~~~~~

--- a/vlib/v/slow_tests/repl/error_and_continue_print.repl
+++ b/vlib/v/slow_tests/repl/error_and_continue_print.repl
@@ -7,19 +7,9 @@ error: undefined ident: `a` (use `:=` to declare a variable)
     6 | 
     7 | a = 3
       | ^
-error: cannot assign to `a`: expected `void`, not `int literal`
-    5 | import math
-    6 | 
-    7 | a = 3
-      |     ^
 error: undefined ident: `b`
     5 | import math
     6 | 
     7 | println(b)
       |         ^
-error: `println` can not print void expressions
-    5 | import math
-    6 | 
-    7 | println(b)
-      | ~~~~~~~~~~
 [4]

--- a/vlib/v/slow_tests/repl/error_exitasdfasdf.repl
+++ b/vlib/v/slow_tests/repl/error_exitasdfasdf.repl
@@ -5,8 +5,3 @@ error: undefined ident: `exitasdfasdf`
     6 | 
     7 | println(exitasdfasdf)
       |         ~~~~~~~~~~~~
-error: `println` can not print void expressions
-    5 | import math
-    6 | 
-    7 | println(exitasdfasdf)
-      | ~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/slow_tests/repl/function.repl
+++ b/vlib/v/slow_tests/repl/function.repl
@@ -1,0 +1,7 @@
+fn test() { println('foo') }
+fn test2(a int) {  println(a) }
+test()
+test2(42)
+===output===
+foo
+42

--- a/vlib/v/slow_tests/repl/function.repl
+++ b/vlib/v/slow_tests/repl/function.repl
@@ -1,7 +1,0 @@
-fn test() { println('foo') }
-fn test2(a int) {  println(a) }
-test()
-test2(42)
-===output===
-foo
-42

--- a/vlib/v/slow_tests/repl/function.repl.skip
+++ b/vlib/v/slow_tests/repl/function.repl.skip
@@ -1,4 +1,0 @@
-fn test() { println('foo') } test() fn test2(a int) {  println(a) } test2(42)
-===output===
-foo
-42

--- a/vlib/v/slow_tests/repl/if_and_for_with_print_inside_them.repl
+++ b/vlib/v/slow_tests/repl/if_and_for_with_print_inside_them.repl
@@ -1,0 +1,18 @@
+mut numbers := [1,2,3,4,5]
+if 1 in numbers {
+println('yes')
+}
+println('hi')
+for number in numbers {
+println(number)
+}
+println(numbers)
+===output===
+yes
+hi
+1
+2
+3
+4
+5
+[1, 2, 3, 4, 5]


### PR DESCRIPTION
### Correcting an issue described in the bug report!
### Followed the suggested solution provided in the issue #20524

### Tested implementation!

### Outcome after implementing the solution:

![solved](https://github.com/vlang/v/assets/32939036/a9b827df-ce82-4522-997b-6d32badc7f3a)

![solved2](https://github.com/vlang/v/assets/32939036/50880863-bb51-43d3-ba43-f37355f52d12)

![solvedfor](https://github.com/vlang/v/assets/32939036/f31f0381-23b7-4960-8a46-9e7860ef061c)

### Problems solved!

### v fmt -w cmd/tools/vrepl.v Execution result

![test](https://github.com/vlang/v/assets/32939036/b59a6192-1623-4b9a-82aa-fb1f9bd1361f)
