### PR TITLE
orm: Ensure table creation before instance insertion [Issue #20017]

### DIFF
--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -198,6 +198,7 @@ pub interface Connection {
 	create(table string, fields []TableField) !
 	drop(table string) !
 	last_id() int
+	insert_if_table_exist(table_name string) !
 }
 
 // Generates an sql stmt, from universal parameter


### PR DESCRIPTION
Hello,

This PR will fix #20017. 

Check for the existence of a table before attempting insertion. 

If the table is not present, it triggers a panic with an explanatory message. 

Given that a panic is triggered, creating a test for this doesn't really make sense to me. However, if triggering a panic is not the desired approach (allowing code execution to continue while returning only an error message), please let me know and I will make the necessary modifications.

Similarly, if a test is absolutely required, please let me know. I am available for any necessary modifications.
