### PR TITLE
net/unix: make error messages more specific

### DIFF
--- a/vlib/net/unix/unix_test.v
+++ b/vlib/net/unix/unix_test.v
@@ -16,11 +16,11 @@ fn handle_conn(mut c unix.StreamConn) {
 	for {
 		mut buf := []u8{len: 100, init: 0}
 		read := c.read(mut buf) or {
-			println('Server: connection dropped')
+			println('Server read: connection dropped')
 			return
 		}
 		c.write(buf[..read]) or {
-			println('Server: connection dropped')
+			println('Server write: connection dropped')
 			return
 		}
 	}


### PR DESCRIPTION
This is a trivial change that I find useful.  If you get a connection dropped error, you immediately know if it was on a read or write operation.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
