### PR TITLE
ast, markused, checker: modified comments on generic receiver type storage

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -752,8 +752,8 @@ pub mut:
 	or_block               OrExpr
 	left                   Expr // `user` in `user.register()`
 	left_type              Type // type of `user`
-	receiver_type          Type // User
-	receiver_concrete_type Type // We need the receiver to be T in cgen, so save the concrete type to node.receiver_concrete_type
+	receiver_type          Type // User / T, if receiver is generic, then cgen requires receiver_type to be T
+	receiver_concrete_type Type // if receiver_type is T, then receiver_concrete_type is concrete type, otherwise it is the same as receiver_type
 	return_type            Type
 	fn_var_type            Type   // the fn type, when `is_fn_a_const` or `is_fn_var` is true
 	const_name             string // the fully qualified name of the const, i.e. `main.c`, given `const c = abc`, and callexpr: `c()`

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2359,13 +2359,13 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if is_method_from_embed {
 		node.receiver_type = node.from_embed_types.last().derive(method.params[0].typ)
 	} else if is_generic {
-		// We need the receiver to be T in cgen.
-		// so save the concrete type to node.receiver_concrete_type
-		// TODO: cant we just set all these to the concrete type in checker? then no need in gen
+		// if receiver is generic, then cgen requires `receiver_type` to be T.
+		// and the concrete type is stored in `receiver_concrete_type` below.
 		node.receiver_type = left_type.derive(method.params[0].typ).set_flag(.generic)
 	} else {
 		node.receiver_type = method.params[0].typ
 	}
+	// if receiver_type is T, then `receiver_concrete_type` is concrete type, otherwise it is the same as `receiver_type`.
 	node.receiver_concrete_type = if is_method_from_embed {
 		node.from_embed_types.last().derive(method.params[0].typ)
 	} else {

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -518,8 +518,8 @@ pub fn (mut w Walker) call_expr(mut node ast.CallExpr) {
 	w.mark_fn_as_used(fn_name)
 	if node.is_method && node.receiver_type.has_flag(.generic) && node.receiver_concrete_type != 0
 		&& !node.receiver_concrete_type.has_flag(.generic) {
-		// We need the receiver to be T in cgen.
-		// so save the concrete type to node.receiver_concrete_type
+		// if receiver is generic, then cgen requires `node.receiver_type` to be T.
+		// We therefore need to get the concrete type from `node.receiver_concrete_type`.
 		fkey := '${int(node.receiver_concrete_type)}.${node.name}'
 		w.used_fns[fkey] = true
 	}


### PR DESCRIPTION
The comment of PR 20527 was not clear enough to be misleading, and this PR rewrites it.