### PR TITLE
builtin: Add `is_hex()`, `is_int()`, `is_bin()`, and `is_oct()` by strings - Feature

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1788,93 +1788,86 @@ fn (s string) at_with_check(idx int) ?u8 {
 
 // Check if a string is an octal value. Returns 'true' if it is, or 'false' if it is not
 pub fn (str string) is_oct() bool {
-
 	mut tmp_string := str
 
 	if tmp_string.starts_with('0o') {
 		tmp_string = tmp_string[2..tmp_string.len]
-	}else if tmp_string.starts_with('-0o') {
+	} else if tmp_string.starts_with('-0o') {
 		tmp_string = tmp_string[3..tmp_string.len]
-	}else{
+	} else {
 		return false
 	}
 
 	if tmp_string.len >= 1 {
-
 		for s in tmp_string {
 			if u8(s) >= `0` && u8(s) <= `7` {
 				continue
-			}else{
+			} else {
 				return false
 			}
 		}
 		return true
-	}else{
+	} else {
 		return false
 	}
 }
 
-
 // Check if a string is an binary value. Returns 'true' if it is, or 'false' if it is not
 pub fn (str string) is_bin() bool {
-
 	mut tmp_string := str
 
 	if tmp_string.starts_with('0b') {
 		tmp_string = tmp_string[2..tmp_string.len]
-	}else if tmp_string.starts_with('-0b') {
+	} else if tmp_string.starts_with('-0b') {
 		tmp_string = tmp_string[3..tmp_string.len]
-	}else{
+	} else {
 		return false
 	}
 
 	if tmp_string.len >= 1 {
-
 		for s in tmp_string {
 			if u8(s) >= `0` && u8(s) <= `1` {
 				continue
-			}else{
+			} else {
 				return false
 			}
 		}
 		return true
-	}else{
+	} else {
 		return false
 	}
 }
 
 // Check if a string is an hexadecimal value. Returns 'true' if it is, or 'false' if it is not
 pub fn (str string) is_hex() bool {
-
 	mut tmp_string := str
 
 	if tmp_string.starts_with('0x') {
 		tmp_string = tmp_string[2..tmp_string.len]
-	}else if tmp_string.starts_with('-0x') {
+	} else if tmp_string.starts_with('-0x') {
 		tmp_string = tmp_string[3..tmp_string.len]
-	}else{
+	} else {
 		return false
 	}
 
 	if tmp_string.len >= 1 {
-		
 		for s in tmp_string {
-			if (u8(s) >= `0` && u8(s) <= `9`) || ((u8(s) >= `a` && u8(s) <= `f`) || (u8(s) >= `A` && u8(s) <= `F`))  {
+			if (u8(s) >= `0` && u8(s) <= `9`) || ((u8(s) >= `a` && u8(s) <= `f`)
+				|| (u8(s) >= `A` && u8(s) <= `F`)) {
 				continue
-			}else{
+			} else {
 				return false
 			}
 		}
 
 		return true
-	}else{
+	} else {
 		return false
 	}
 }
 
 // Check if a string is an integer value. Returns 'true' if it is, or 'false' if it is not
 pub fn (str string) is_int() bool {
-
 	mut tmp_string := str
 
 	if tmp_string.starts_with('-') {
@@ -1885,12 +1878,12 @@ pub fn (str string) is_int() bool {
 		for s in tmp_string {
 			if u8(s) >= `0` && u8(s) <= `9` {
 				continue
-			}else{
+			} else {
 				return false
 			}
 		}
 		return true
-	}else{
+	} else {
 		return false
 	}
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1786,6 +1786,116 @@ fn (s string) at_with_check(idx int) ?u8 {
 	}
 }
 
+// Check if a string is an octal value. Returns 'true' if it is, or 'false' if it is not
+pub fn (str string) is_oct() bool {
+
+	mut tmp_string := str
+	if tmp_string.len < 3 { return false } 
+
+	if tmp_string[0..2] == '0o' {
+		tmp_string = tmp_string[2..tmp_string.len]
+	}else if tmp_string[0..3] == '-0o' {
+		tmp_string = tmp_string[3..tmp_string.len]
+	}
+
+	if tmp_string.len >= 1 {
+
+		for s in tmp_string {
+			if u8(s) >= `0` && u8(s) <= `7` {
+				continue
+			}else{
+				return false
+			}
+		}
+		return true
+	}else{
+		return false
+	}
+}
+
+
+// Check if a string is an binary value. Returns 'true' if it is, or 'false' if it is not
+pub fn (str string) is_bin() bool {
+
+	mut tmp_string := str
+	if tmp_string.len < 3 { return false } 
+
+	if tmp_string[0..2] == '0b' {
+		tmp_string = tmp_string[2..tmp_string.len]
+	}else if tmp_string[0..3] == '-0b' {
+		tmp_string = tmp_string[3..tmp_string.len]
+	}
+
+	if tmp_string.len >= 1 {
+
+		for s in tmp_string {
+			if u8(s) >= `0` && u8(s) <= `1` {
+				continue
+			}else{
+				return false
+			}
+		}
+		return true
+	}else{
+		return false
+	}
+}
+
+// Check if a string is an hexadecimal value. Returns 'true' if it is, or 'false' if it is not
+pub fn (str string) is_hex() bool {
+
+	mut tmp_string := str
+	if tmp_string.len < 3 { return false } 
+
+	if tmp_string[0..2] == '0x' {
+		tmp_string = tmp_string[2..tmp_string.len]
+	}else if tmp_string[0..3] == '-0x' {
+		tmp_string = tmp_string[3..tmp_string.len]
+	}else{
+		return false
+	}
+
+	if tmp_string.len >= 1 {
+		
+		for s in tmp_string {
+			if (u8(s) >= `0` && u8(s) <= `9`) || ((u8(s) >= `a` && u8(s) <= `f`) || (u8(s) >= `A` && u8(s) <= `F`))  {
+				continue
+			}else{
+				return false
+			}
+		}
+
+		return true
+	}else{
+		return false
+	}
+}
+
+// Check if a string is an integer value. Returns 'true' if it is, or 'false' if it is not
+pub fn (str string) is_int() bool {
+
+	mut tmp_string := str
+
+	if tmp_string.len < 1 { return false }
+
+	if tmp_string[0].ascii_str() == '-' {
+		tmp_string = tmp_string[1..tmp_string.len]
+	}
+
+	if tmp_string.len >= 1 {
+		for s in tmp_string {
+			if u8(s) >= `0` && u8(s) <= `9` {
+				continue
+			}else{
+				return false
+			}
+		}
+		return true
+	}else{
+		return false
+	}
+}
+
 // is_space returns `true` if the byte is a white space character.
 // The following list is considered white space characters: ` `, `\t`, `\n`, `\v`, `\f`, `\r`, 0x85, 0xa0
 // Example: assert u8(` `).is_space() == true

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1787,105 +1787,146 @@ fn (s string) at_with_check(idx int) ?u8 {
 }
 
 // Check if a string is an octal value. Returns 'true' if it is, or 'false' if it is not
+@[direct_array_access]
 pub fn (str string) is_oct() bool {
-	mut tmp_string := str
+	mut i := 0
 
-	if tmp_string.starts_with('0o') {
-		tmp_string = tmp_string[2..tmp_string.len]
-	} else if tmp_string.starts_with('-0o') {
-		tmp_string = tmp_string[3..tmp_string.len]
-	} else {
-		return false
-	}
+	if str[i] == `0` {
+		i++
+	} else if str[i] == `-` || str[i] == `+` {
+		i++
 
-	if tmp_string.len >= 1 {
-		for s in tmp_string {
-			if u8(s) >= `0` && u8(s) <= `7` {
-				continue
-			} else {
-				return false
-			}
+		if str[i] == `0` {
+			i++
+		} else {
+			return false
 		}
-		return true
 	} else {
 		return false
 	}
+
+	if str[i] == `o` {
+		i++
+	} else {
+		return false
+	}
+
+	if i == str.len {
+		return false
+	}
+
+	for i < str.len {
+		if str[i] < `0` || str[i] > `7` {
+			return false
+		}
+		i++
+	}
+
+	return true
 }
 
 // Check if a string is an binary value. Returns 'true' if it is, or 'false' if it is not
+@[direct_array_access]
 pub fn (str string) is_bin() bool {
-	mut tmp_string := str
+	mut i := 0
 
-	if tmp_string.starts_with('0b') {
-		tmp_string = tmp_string[2..tmp_string.len]
-	} else if tmp_string.starts_with('-0b') {
-		tmp_string = tmp_string[3..tmp_string.len]
-	} else {
-		return false
-	}
+	if str[i] == `0` {
+		i++
+	} else if str[i] == `-` || str[i] == `+` {
+		i++
 
-	if tmp_string.len >= 1 {
-		for s in tmp_string {
-			if u8(s) >= `0` && u8(s) <= `1` {
-				continue
-			} else {
-				return false
-			}
+		if str[i] == `0` {
+			i++
+		} else {
+			return false
 		}
-		return true
 	} else {
 		return false
 	}
+
+	if str[i] == `b` {
+		i++
+	} else {
+		return false
+	}
+
+	if i == str.len {
+		return false
+	}
+
+	for i < str.len {
+		if str[i] < `0` || str[i] > `1` {
+			return false
+		}
+		i++
+	}
+
+	return true
 }
 
 // Check if a string is an hexadecimal value. Returns 'true' if it is, or 'false' if it is not
+@[direct_array_access]
 pub fn (str string) is_hex() bool {
-	mut tmp_string := str
+	mut i := 0
 
-	if tmp_string.starts_with('0x') {
-		tmp_string = tmp_string[2..tmp_string.len]
-	} else if tmp_string.starts_with('-0x') {
-		tmp_string = tmp_string[3..tmp_string.len]
-	} else {
-		return false
-	}
+	if str[i] == `0` {
+		i++
+	} else if str[i] == `-` || str[i] == `+` {
+		i++
 
-	if tmp_string.len >= 1 {
-		for s in tmp_string {
-			if (u8(s) >= `0` && u8(s) <= `9`) || ((u8(s) >= `a` && u8(s) <= `f`)
-				|| (u8(s) >= `A` && u8(s) <= `F`)) {
-				continue
-			} else {
-				return false
-			}
+		if str[i] == `0` {
+			i++
+		} else {
+			return false
 		}
-
-		return true
 	} else {
 		return false
 	}
+
+	if str[i] == `x` {
+		i++
+	} else {
+		return false
+	}
+
+	if i == str.len {
+		return false
+	}
+
+	for i < str.len {
+		if (str[i] < `0` || str[i] > `9`) && ((str[i] < `a` || str[i] > `f`)
+			&& (str[i] < `A` || str[i] > `F`)) {
+			return false
+		}
+		i++
+	}
+
+	return true
 }
 
 // Check if a string is an integer value. Returns 'true' if it is, or 'false' if it is not
+@[direct_array_access]
 pub fn (str string) is_int() bool {
-	mut tmp_string := str
+	mut i := 0
 
-	if tmp_string.starts_with('-') {
-		tmp_string = tmp_string[1..tmp_string.len]
+	if (str[i] != `-` && str[i] != `+`) && (!str[i].is_digit()) {
+		return false
+	} else {
+		i++
 	}
 
-	if tmp_string.len >= 1 {
-		for s in tmp_string {
-			if u8(s) >= `0` && u8(s) <= `9` {
-				continue
-			} else {
-				return false
-			}
-		}
-		return true
-	} else {
+	if i == str.len && (!str[i - 1].is_digit()) {
 		return false
 	}
+
+	for i < str.len {
+		if str[i] < `0` || str[i] > `9` {
+			return false
+		}
+		i++
+	}
+
+	return true
 }
 
 // is_space returns `true` if the byte is a white space character.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1790,12 +1790,13 @@ fn (s string) at_with_check(idx int) ?u8 {
 pub fn (str string) is_oct() bool {
 
 	mut tmp_string := str
-	if tmp_string.len < 3 { return false } 
 
-	if tmp_string[0..2] == '0o' {
+	if tmp_string.starts_with('0o') {
 		tmp_string = tmp_string[2..tmp_string.len]
-	}else if tmp_string[0..3] == '-0o' {
+	}else if tmp_string.starts_with('-0o') {
 		tmp_string = tmp_string[3..tmp_string.len]
+	}else{
+		return false
 	}
 
 	if tmp_string.len >= 1 {
@@ -1818,12 +1819,13 @@ pub fn (str string) is_oct() bool {
 pub fn (str string) is_bin() bool {
 
 	mut tmp_string := str
-	if tmp_string.len < 3 { return false } 
 
-	if tmp_string[0..2] == '0b' {
+	if tmp_string.starts_with('0b') {
 		tmp_string = tmp_string[2..tmp_string.len]
-	}else if tmp_string[0..3] == '-0b' {
+	}else if tmp_string.starts_with('-0b') {
 		tmp_string = tmp_string[3..tmp_string.len]
+	}else{
+		return false
 	}
 
 	if tmp_string.len >= 1 {
@@ -1845,11 +1847,10 @@ pub fn (str string) is_bin() bool {
 pub fn (str string) is_hex() bool {
 
 	mut tmp_string := str
-	if tmp_string.len < 3 { return false } 
 
-	if tmp_string[0..2] == '0x' {
+	if tmp_string.starts_with('0x') {
 		tmp_string = tmp_string[2..tmp_string.len]
-	}else if tmp_string[0..3] == '-0x' {
+	}else if tmp_string.starts_with('-0x') {
 		tmp_string = tmp_string[3..tmp_string.len]
 	}else{
 		return false
@@ -1876,9 +1877,7 @@ pub fn (str string) is_int() bool {
 
 	mut tmp_string := str
 
-	if tmp_string.len < 1 { return false }
-
-	if tmp_string[0].ascii_str() == '-' {
+	if tmp_string.starts_with('-') {
 		tmp_string = tmp_string[1..tmp_string.len]
 	}
 

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -438,12 +438,16 @@ fn test_is_bin() {
 	assert '-0'.is_bin() == false
 	assert '0x1'.is_bin() == false
 	assert '0x1A'.is_bin() == false
+	assert '+0b1101'.is_bin() == true
+	assert '+0b1'.is_bin() == true
 	assert '-0x1'.is_bin() == false
 	assert '-0x1A'.is_bin() == false
 	assert '0x'.is_bin() == false
 	assert '0'.is_bin() == false
 	assert '0xFF'.is_bin() == false
 	assert '0xG'.is_bin() == false
+	assert '-'.is_bin() == false
+	assert '+'.is_bin() == false
 	assert '-0xFF'.is_bin() == false
 	assert '0.34'.is_bin() == false
 	assert '0o23'.is_bin() == false
@@ -480,6 +484,10 @@ fn test_is_oct() {
 	assert '-0b1'.is_oct() == false
 	assert '-0b0'.is_oct() == false
 	assert '-0b1101'.is_oct() == false
+	assert '+0o234'.is_oct() == true
+	assert '+0o432'.is_oct() == true
+	assert '-'.is_oct() == false
+	assert '+'.is_oct() == false
 	assert '-0b0101'.is_oct() == false
 	assert '-324'.is_oct() == false
 	assert '-0'.is_oct() == false
@@ -503,8 +511,12 @@ fn test_is_hex() {
 	assert '0x1A'.is_hex() == true
 	assert '-0x1'.is_hex() == true
 	assert '-0x1A'.is_hex() == true
+	assert '+0x1'.is_hex() == true
+	assert '+0x1A'.is_hex() == true
 	assert '0x'.is_hex() == false
 	assert '0'.is_hex() == false
+	assert '-'.is_hex() == false
+	assert '+'.is_hex() == false
 	assert '0xFF'.is_hex() == true
 	assert '0xG'.is_hex() == false
 	assert '-0xFF'.is_hex() == true
@@ -526,6 +538,53 @@ fn test_is_int() {
 	assert '0.34'.is_int() == false
 	assert '0o23'.is_int() == false
 	assert 'vlang'.is_int() == false
+
+	assert '0o0'.is_int() == false
+	assert '0o1'.is_int() == false
+	assert '0o2'.is_int() == false
+	assert '-0o0'.is_int() == false
+	assert '-0o1'.is_int() == false
+	assert '-0o2'.is_int() == false
+
+	assert '0o04'.is_int() == false
+	assert '0o16'.is_int() == false
+	assert '0o23'.is_int() == false
+	assert '-0o05'.is_int() == false
+	assert '-0o13'.is_int() == false
+	assert '-0o22'.is_int() == false
+
+	assert '0o8'.is_int() == false
+	assert '0o9'.is_int() == false
+	assert '-0o8'.is_int() == false
+	assert '-0o9'.is_int() == false
+	assert '0o84'.is_int() == false
+	assert '0o96'.is_int() == false
+	assert '-0o83'.is_int() == false
+	assert '-0o2923'.is_int() == false
+	assert '0b1'.is_int() == false
+	assert '0b0'.is_int() == false
+	assert '0b'.is_int() == false
+	assert '-0b'.is_int() == false
+	assert '-0b1'.is_int() == false
+	assert '-0b0'.is_int() == false
+	assert '-0b1101'.is_int() == false
+	assert '-0b0101'.is_int() == false
+	assert '-324'.is_int() == true
+	assert '-0'.is_int() == true
+	assert '0x1'.is_int() == false
+	assert '0x1A'.is_int() == false
+	assert '-0x1'.is_int() == false
+	assert '-0x1A'.is_oct() == false
+	assert '0x'.is_int() == false
+	assert '0'.is_int() == true
+	assert '0xFF'.is_int() == false
+	assert '0xG'.is_int() == false
+	assert '-0xFF'.is_int() == false
+	assert '0.34'.is_int() == false
+	assert '-'.is_int() == false
+	assert '+'.is_int() == false
+	assert '+3'.is_int() == true
+	assert '+3232'.is_int() == true
 }
 
 fn test_trim_space() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -425,6 +425,113 @@ fn test_rsplit_once() ? {
 	assert ext3 == ''
 }
 
+fn test_is_bin(){
+
+	assert '0b1'.is_bin()       == true
+	assert '0b0'.is_bin()       == true
+	assert '0b'.is_bin()        == false
+	assert '-0b'.is_bin()       == false
+	assert '-0b1'.is_bin()      == true
+	assert '-0b0'.is_bin()      == true
+	assert '-0b1101'.is_bin()   == true
+	assert '-0b0101'.is_bin()   == true
+	assert '-324'.is_bin()      == false
+	assert '-0'.is_bin()        == false
+	assert '0x1'.is_bin()       == false
+	assert '0x1A'.is_bin()      == false
+	assert '-0x1'.is_bin()      == false
+	assert '-0x1A'.is_bin()     == false
+	assert '0x'.is_bin()        == false
+	assert '0'.is_bin()         == false
+	assert '0xFF'.is_bin()      == false
+	assert '0xG'.is_bin()       == false
+	assert '-0xFF'.is_bin()     == false
+	assert '0.34'.is_bin()      == false
+	assert '0o23'.is_bin()      == false
+	assert 'vlang'.is_bin()     == false
+}
+
+fn test_is_oct(){
+
+	assert '0o0'.is_oct()       == true
+	assert '0o1'.is_oct()       == true
+	assert '0o2'.is_oct()       == true
+	assert '-0o0'.is_oct()      == true
+	assert '-0o1'.is_oct()      == true
+	assert '-0o2'.is_oct()      == true
+
+	assert '0o04'.is_oct()      == true
+	assert '0o16'.is_oct()      == true
+	assert '0o23'.is_oct()      == true
+	assert '-0o05'.is_oct()     == true
+	assert '-0o13'.is_oct()     == true
+	assert '-0o22'.is_oct()     == true
+
+	assert '0o8'.is_oct()       == false
+	assert '0o9'.is_oct()       == false
+	assert '-0o8'.is_oct()      == false
+	assert '-0o9'.is_oct()      == false
+	assert '0o84'.is_oct()      == false
+	assert '0o96'.is_oct()      == false
+	assert '-0o83'.is_oct()     == false
+	assert '-0o2923'.is_oct()   == false
+	assert '0b1'.is_oct()       == false
+	assert '0b0'.is_oct()       == false
+	assert '0b'.is_oct()        == false
+	assert '-0b'.is_oct()       == false
+	assert '-0b1'.is_oct()      == false
+	assert '-0b0'.is_oct()      == false
+	assert '-0b1101'.is_oct()   == false
+	assert '-0b0101'.is_oct()   == false
+	assert '-324'.is_oct()      == false
+	assert '-0'.is_oct()        == false
+	assert '0x1'.is_oct()       == false
+	assert '0x1A'.is_oct()      == false
+	assert '-0x1'.is_oct()      == false
+	assert '-0x1A'.is_oct()     == false
+	assert '0x'.is_oct()        == false
+	assert '0'.is_oct()         == false
+	assert '0xFF'.is_oct()      == false
+	assert '0xG'.is_oct()       == false
+	assert '-0xFF'.is_oct()     == false
+	assert '0.34'.is_oct()      == false
+	assert 'vlang'.is_oct()     == false
+}
+
+fn test_is_hex(){
+
+	assert '-324'.is_hex()       == false
+	assert '-0'.is_hex()         == false
+	assert '0x1'.is_hex()        == true
+	assert '0x1A'.is_hex()       == true
+	assert '-0x1'.is_hex()       == true
+	assert '-0x1A'.is_hex()      == true
+	assert '0x'.is_hex()         == false
+	assert '0'.is_hex()          == false
+	assert '0xFF'.is_hex()       == true
+	assert '0xG'.is_hex()        == false
+	assert '-0xFF'.is_hex()      == true
+	assert '0b1101'.is_hex()     == false
+	assert '0.34'.is_hex()       == false
+	assert '0o23'.is_hex()       == false
+	assert 'vlang'.is_hex()      == false
+}
+
+fn test_is_int(){
+
+	assert '-324'.is_int()       == true
+	assert '234'.is_int()        == true
+	assert '-0'.is_int()         == true
+	assert '-b'.is_int()         == false
+	assert '-123456789'.is_int() == true
+	assert '123456789'.is_int()  == true
+	assert '0x1'.is_int()        == false
+	assert '0b1101'.is_int()     == false
+	assert '0.34'.is_int()       == false
+	assert '0o23'.is_int()       == false
+	assert 'vlang'.is_int()      == false
+}
+
 fn test_trim_space() {
 	a := ' a '
 	assert a.trim_space() == 'a'

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -425,111 +425,107 @@ fn test_rsplit_once() ? {
 	assert ext3 == ''
 }
 
-fn test_is_bin(){
-
-	assert '0b1'.is_bin()       == true
-	assert '0b0'.is_bin()       == true
-	assert '0b'.is_bin()        == false
-	assert '-0b'.is_bin()       == false
-	assert '-0b1'.is_bin()      == true
-	assert '-0b0'.is_bin()      == true
-	assert '-0b1101'.is_bin()   == true
-	assert '-0b0101'.is_bin()   == true
-	assert '-324'.is_bin()      == false
-	assert '-0'.is_bin()        == false
-	assert '0x1'.is_bin()       == false
-	assert '0x1A'.is_bin()      == false
-	assert '-0x1'.is_bin()      == false
-	assert '-0x1A'.is_bin()     == false
-	assert '0x'.is_bin()        == false
-	assert '0'.is_bin()         == false
-	assert '0xFF'.is_bin()      == false
-	assert '0xG'.is_bin()       == false
-	assert '-0xFF'.is_bin()     == false
-	assert '0.34'.is_bin()      == false
-	assert '0o23'.is_bin()      == false
-	assert 'vlang'.is_bin()     == false
+fn test_is_bin() {
+	assert '0b1'.is_bin() == true
+	assert '0b0'.is_bin() == true
+	assert '0b'.is_bin() == false
+	assert '-0b'.is_bin() == false
+	assert '-0b1'.is_bin() == true
+	assert '-0b0'.is_bin() == true
+	assert '-0b1101'.is_bin() == true
+	assert '-0b0101'.is_bin() == true
+	assert '-324'.is_bin() == false
+	assert '-0'.is_bin() == false
+	assert '0x1'.is_bin() == false
+	assert '0x1A'.is_bin() == false
+	assert '-0x1'.is_bin() == false
+	assert '-0x1A'.is_bin() == false
+	assert '0x'.is_bin() == false
+	assert '0'.is_bin() == false
+	assert '0xFF'.is_bin() == false
+	assert '0xG'.is_bin() == false
+	assert '-0xFF'.is_bin() == false
+	assert '0.34'.is_bin() == false
+	assert '0o23'.is_bin() == false
+	assert 'vlang'.is_bin() == false
 }
 
-fn test_is_oct(){
+fn test_is_oct() {
+	assert '0o0'.is_oct() == true
+	assert '0o1'.is_oct() == true
+	assert '0o2'.is_oct() == true
+	assert '-0o0'.is_oct() == true
+	assert '-0o1'.is_oct() == true
+	assert '-0o2'.is_oct() == true
 
-	assert '0o0'.is_oct()       == true
-	assert '0o1'.is_oct()       == true
-	assert '0o2'.is_oct()       == true
-	assert '-0o0'.is_oct()      == true
-	assert '-0o1'.is_oct()      == true
-	assert '-0o2'.is_oct()      == true
+	assert '0o04'.is_oct() == true
+	assert '0o16'.is_oct() == true
+	assert '0o23'.is_oct() == true
+	assert '-0o05'.is_oct() == true
+	assert '-0o13'.is_oct() == true
+	assert '-0o22'.is_oct() == true
 
-	assert '0o04'.is_oct()      == true
-	assert '0o16'.is_oct()      == true
-	assert '0o23'.is_oct()      == true
-	assert '-0o05'.is_oct()     == true
-	assert '-0o13'.is_oct()     == true
-	assert '-0o22'.is_oct()     == true
-
-	assert '0o8'.is_oct()       == false
-	assert '0o9'.is_oct()       == false
-	assert '-0o8'.is_oct()      == false
-	assert '-0o9'.is_oct()      == false
-	assert '0o84'.is_oct()      == false
-	assert '0o96'.is_oct()      == false
-	assert '-0o83'.is_oct()     == false
-	assert '-0o2923'.is_oct()   == false
-	assert '0b1'.is_oct()       == false
-	assert '0b0'.is_oct()       == false
-	assert '0b'.is_oct()        == false
-	assert '-0b'.is_oct()       == false
-	assert '-0b1'.is_oct()      == false
-	assert '-0b0'.is_oct()      == false
-	assert '-0b1101'.is_oct()   == false
-	assert '-0b0101'.is_oct()   == false
-	assert '-324'.is_oct()      == false
-	assert '-0'.is_oct()        == false
-	assert '0x1'.is_oct()       == false
-	assert '0x1A'.is_oct()      == false
-	assert '-0x1'.is_oct()      == false
-	assert '-0x1A'.is_oct()     == false
-	assert '0x'.is_oct()        == false
-	assert '0'.is_oct()         == false
-	assert '0xFF'.is_oct()      == false
-	assert '0xG'.is_oct()       == false
-	assert '-0xFF'.is_oct()     == false
-	assert '0.34'.is_oct()      == false
-	assert 'vlang'.is_oct()     == false
+	assert '0o8'.is_oct() == false
+	assert '0o9'.is_oct() == false
+	assert '-0o8'.is_oct() == false
+	assert '-0o9'.is_oct() == false
+	assert '0o84'.is_oct() == false
+	assert '0o96'.is_oct() == false
+	assert '-0o83'.is_oct() == false
+	assert '-0o2923'.is_oct() == false
+	assert '0b1'.is_oct() == false
+	assert '0b0'.is_oct() == false
+	assert '0b'.is_oct() == false
+	assert '-0b'.is_oct() == false
+	assert '-0b1'.is_oct() == false
+	assert '-0b0'.is_oct() == false
+	assert '-0b1101'.is_oct() == false
+	assert '-0b0101'.is_oct() == false
+	assert '-324'.is_oct() == false
+	assert '-0'.is_oct() == false
+	assert '0x1'.is_oct() == false
+	assert '0x1A'.is_oct() == false
+	assert '-0x1'.is_oct() == false
+	assert '-0x1A'.is_oct() == false
+	assert '0x'.is_oct() == false
+	assert '0'.is_oct() == false
+	assert '0xFF'.is_oct() == false
+	assert '0xG'.is_oct() == false
+	assert '-0xFF'.is_oct() == false
+	assert '0.34'.is_oct() == false
+	assert 'vlang'.is_oct() == false
 }
 
-fn test_is_hex(){
-
-	assert '-324'.is_hex()       == false
-	assert '-0'.is_hex()         == false
-	assert '0x1'.is_hex()        == true
-	assert '0x1A'.is_hex()       == true
-	assert '-0x1'.is_hex()       == true
-	assert '-0x1A'.is_hex()      == true
-	assert '0x'.is_hex()         == false
-	assert '0'.is_hex()          == false
-	assert '0xFF'.is_hex()       == true
-	assert '0xG'.is_hex()        == false
-	assert '-0xFF'.is_hex()      == true
-	assert '0b1101'.is_hex()     == false
-	assert '0.34'.is_hex()       == false
-	assert '0o23'.is_hex()       == false
-	assert 'vlang'.is_hex()      == false
+fn test_is_hex() {
+	assert '-324'.is_hex() == false
+	assert '-0'.is_hex() == false
+	assert '0x1'.is_hex() == true
+	assert '0x1A'.is_hex() == true
+	assert '-0x1'.is_hex() == true
+	assert '-0x1A'.is_hex() == true
+	assert '0x'.is_hex() == false
+	assert '0'.is_hex() == false
+	assert '0xFF'.is_hex() == true
+	assert '0xG'.is_hex() == false
+	assert '-0xFF'.is_hex() == true
+	assert '0b1101'.is_hex() == false
+	assert '0.34'.is_hex() == false
+	assert '0o23'.is_hex() == false
+	assert 'vlang'.is_hex() == false
 }
 
-fn test_is_int(){
-
-	assert '-324'.is_int()       == true
-	assert '234'.is_int()        == true
-	assert '-0'.is_int()         == true
-	assert '-b'.is_int()         == false
+fn test_is_int() {
+	assert '-324'.is_int() == true
+	assert '234'.is_int() == true
+	assert '-0'.is_int() == true
+	assert '-b'.is_int() == false
 	assert '-123456789'.is_int() == true
-	assert '123456789'.is_int()  == true
-	assert '0x1'.is_int()        == false
-	assert '0b1101'.is_int()     == false
-	assert '0.34'.is_int()       == false
-	assert '0o23'.is_int()       == false
-	assert 'vlang'.is_int()      == false
+	assert '123456789'.is_int() == true
+	assert '0x1'.is_int() == false
+	assert '0b1101'.is_int() == false
+	assert '0.34'.is_int() == false
+	assert '0o23'.is_int() == false
+	assert 'vlang'.is_int() == false
 }
 
 fn test_trim_space() {


### PR DESCRIPTION
### Code

```v
// Check if a string is an octal value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_oct() bool {
	mut i := 0

	if str[i] == `0` {
		i++
	} else if str[i] == `-` || str[i] == `+` {
		i++

		if str[i] == `0` {
			i++
		} else {
			return false
		}
	} else {
		return false
	}

	if str[i] == `o` {
		i++
	} else {
		return false
	}

	if i == str.len {
		return false
	}

	for i < str.len {
		if str[i] < `0` || str[i] > `7` {
			return false
		}
		i++
	}

	return true
}

// Check if a string is an binary value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_bin() bool {
	mut i := 0

	if str[i] == `0` {
		i++
	} else if str[i] == `-` || str[i] == `+` {
		i++

		if str[i] == `0` {
			i++
		} else {
			return false
		}
	} else {
		return false
	}

	if str[i] == `b` {
		i++
	} else {
		return false
	}

	if i == str.len {
		return false
	}

	for i < str.len {
		if str[i] < `0` || str[i] > `1` {
			return false
		}
		i++
	}

	return true
}

// Check if a string is an hexadecimal value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_hex() bool {
	mut i := 0

	if str[i] == `0` {
		i++
	} else if str[i] == `-` || str[i] == `+` {
		i++

		if str[i] == `0` {
			i++
		} else {
			return false
		}
	} else {
		return false
	}

	if str[i] == `x` {
		i++
	} else {
		return false
	}

	if i == str.len {
		return false
	}

	for i < str.len {
		if (str[i] < `0` || str[i] > `9`) && ((str[i] < `a` || str[i] > `f`)
			&& (str[i] < `A` || str[i] > `F`)) {
			return false
		}
		i++
	}

	return true
}

// Check if a string is an integer value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_int() bool {
	mut i := 0

	if (str[i] != `-` && str[i] != `+`) && (!str[i].is_digit()) {
		return false
	} else {
		i++
	}

	if i == str.len && (!str[i - 1].is_digit()) {
		return false
	}

	for i < str.len {
		if str[i] < `0` || str[i] > `9` {
			return false
		}
		i++
	}

	return true
}
```

### Test code

```v
// vlib/builtin/string_test.v file
fn test_is_bin(){

	assert '0b1'.is_bin()       == true
	assert '0b0'.is_bin()       == true
	assert '0b'.is_bin()        == false
	assert '-0b'.is_bin()       == false
	assert '-0b1'.is_bin()      == true
	assert '-0b0'.is_bin()      == true
	assert '-0b1101'.is_bin()   == true
	assert '-0b0101'.is_bin()   == true
	assert '-324'.is_bin()      == false
	assert '-0'.is_bin()        == false
	assert '0x1'.is_bin()       == false
	assert '0x1A'.is_bin()      == false
	assert '-0x1'.is_bin()      == false
	assert '-0x1A'.is_bin()     == false
	assert '0x'.is_bin()        == false
	assert '0'.is_bin()         == false
	assert '0xFF'.is_bin()      == false
	assert '0xG'.is_bin()       == false
	assert '-0xFF'.is_bin()     == false
	assert '0.34'.is_bin()      == false
	assert '0o23'.is_bin()      == false
	assert 'vlang'.is_bin()     == false
}

fn test_is_oct(){

	assert '0o0'.is_oct()       == true
	assert '0o1'.is_oct()       == true
	assert '0o2'.is_oct()       == true
	assert '-0o0'.is_oct()      == true
	assert '-0o1'.is_oct()      == true
	assert '-0o2'.is_oct()      == true

	assert '0o04'.is_oct()      == true
	assert '0o16'.is_oct()      == true
	assert '0o23'.is_oct()      == true
	assert '-0o05'.is_oct()     == true
	assert '-0o13'.is_oct()     == true
	assert '-0o22'.is_oct()     == true

	assert '0o8'.is_oct()       == false
	assert '0o9'.is_oct()       == false
	assert '-0o8'.is_oct()      == false
	assert '-0o9'.is_oct()      == false
	assert '0o84'.is_oct()      == false
	assert '0o96'.is_oct()      == false
	assert '-0o83'.is_oct()     == false
	assert '-0o2923'.is_oct()   == false
	assert '0b1'.is_oct()       == false
	assert '0b0'.is_oct()       == false
	assert '0b'.is_oct()        == false
	assert '-0b'.is_oct()       == false
	assert '-0b1'.is_oct()      == false
	assert '-0b0'.is_oct()      == false
	assert '-0b1101'.is_oct()   == false
	assert '-0b0101'.is_oct()   == false
	assert '-324'.is_oct()      == false
	assert '-0'.is_oct()        == false
	assert '0x1'.is_oct()       == false
	assert '0x1A'.is_oct()      == false
	assert '-0x1'.is_oct()      == false
	assert '-0x1A'.is_oct()     == false
	assert '0x'.is_oct()        == false
	assert '0'.is_oct()         == false
	assert '0xFF'.is_oct()      == false
	assert '0xG'.is_oct()       == false
	assert '-0xFF'.is_oct()     == false
	assert '0.34'.is_oct()      == false
	assert 'vlang'.is_oct()     == false
}

fn test_is_hex(){

	assert '-324'.is_hex()       == false
	assert '-0'.is_hex()         == false
	assert '0x1'.is_hex()        == true
	assert '0x1A'.is_hex()       == true
	assert '-0x1'.is_hex()       == true
	assert '-0x1A'.is_hex()      == true
	assert '0x'.is_hex()         == false
	assert '0'.is_hex()          == false
	assert '0xFF'.is_hex()       == true
	assert '0xG'.is_hex()        == false
	assert '-0xFF'.is_hex()      == true
	assert '0b1101'.is_hex()     == false
	assert '0.34'.is_hex()       == false
	assert '0o23'.is_hex()       == false
	assert 'vlang'.is_hex()      == false
}

fn test_is_int(){

	assert '-324'.is_int()       == true
	assert '234'.is_int()        == true
	assert '-0'.is_int()         == true
	assert '-b'.is_int()         == false
	assert '-123456789'.is_int() == true
	assert '123456789'.is_int()  == true
	assert '0x1'.is_int()        == false
	assert '0b1101'.is_int()     == false
	assert '0.34'.is_int()       == false
	assert '0o23'.is_int()       == false
	assert 'vlang'.is_int()      == false
}
```

### Test output 

![test](https://github.com/vlang/v/assets/32939036/fad19c62-8ee4-452a-bb02-c14cadc4b11a)
