### PR TITLE
cgen: fix code generation wrong, when 'x.?[]array or {}' as a 'for-in' condition(fix #20528)

### DIFF
--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -235,7 +235,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		}
 		mut cond_var := ''
 		if (node.cond is ast.Ident && !node.cond_type.has_flag(.option))
-			|| node.cond is ast.SelectorExpr {
+			|| (node.cond is ast.SelectorExpr && node.cond.or_block.kind == .absent) {
 			cond_var = g.expr_string(node.cond)
 		} else {
 			cond_var = g.new_tmp_var()

--- a/vlib/v/tests/for_in_option_test.v
+++ b/vlib/v/tests/for_in_option_test.v
@@ -6,3 +6,23 @@ fn test_for_in_option() {
 	}
 	assert true
 }
+
+// for issue 20528
+// phenomenon: when the cond expr is SelectorExpr and the type is an array, cgen fails.
+struct Foo {
+	data ?[]int
+}
+
+fn (f Foo) get_first() ?int {
+	for d in f.data or { return none } {
+		return d
+	}
+	return none
+}
+
+fn test_cond_is_selector_array_and_with_or_block() {
+	foo := Foo{
+		data: [1, 2, 3]
+	}
+	assert foo.get_first()? == 1
+}


### PR DESCRIPTION
1. Fixed #20528
2. Add tests.

```v
pub type Snowflake = int

pub struct PermissionOverwrite {
	id Snowflake
	n  int
}

pub struct Channel {
	permission_overwrites ?[]PermissionOverwrite
}

pub fn (c Channel) get_overwrite(id Snowflake) ?PermissionOverwrite {
	for overwrite in c.permission_overwrites or { return none } {
		if overwrite.id == id {
			return overwrite
		}
	}
	return none
}

fn main() {
	channel := Channel{
		permission_overwrites: [
			PermissionOverwrite{
				id: 1
				n: 42
			},
			PermissionOverwrite{
				id: 2
				n: 84
			},
			PermissionOverwrite{
				id: 3
				n: 6969
			},
			PermissionOverwrite{
				id: 4
				n: 4242
			},
		]
	}
	println(channel.get_overwrite(3)?.n)
}
```
outputs:
```
6969
```