### PR TITLE
parser: check non-generic interface defining generic method (fix #20430)

### DIFF
--- a/vlib/v/checker/tests/generic_interface_method_decl_err.out
+++ b/vlib/v/checker/tests/generic_interface_method_decl_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/generic_interface_method_decl_err.vv:2:8: error: no need to add generic type names in generic interface's method
-    1 | interface Expr {
+    1 | interface Expr<R> {
     2 |     accept<R>(v Visitor<R>) R
       |           ^
     3 | }

--- a/vlib/v/checker/tests/generic_interface_method_decl_err.vv
+++ b/vlib/v/checker/tests/generic_interface_method_decl_err.vv
@@ -1,4 +1,4 @@
-interface Expr {
+interface Expr<R> {
 	accept<R>(v Visitor<R>) R
 }
 

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -632,8 +632,13 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			mut_pos = fields.len
 		}
 		if p.peek_tok.kind in [.lt, .lsbr] && p.peek_tok.is_next_to(p.tok) {
-			p.error_with_pos("no need to add generic type names in generic interface's method",
-				p.peek_tok.pos())
+			if generic_types.len == 0 {
+				p.error_with_pos('non-generic interface `${interface_name}` cannot define a generic method',
+					p.peek_tok.pos())
+			} else {
+				p.error_with_pos("no need to add generic type names in generic interface's method",
+					p.peek_tok.pos())
+			}
 			return ast.InterfaceDecl{}
 		}
 		mut comments := p.eat_comments()

--- a/vlib/v/parser/tests/generic_interface_decl_err.out
+++ b/vlib/v/parser/tests/generic_interface_decl_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/generic_interface_decl_err.vv:4:6: error: non-generic interface `Abc` cannot define a generic method
+    2 |
+    3 | interface Abc {
+    4 |     test[T]()
+      |         ^
+    5 | }
+    6 |

--- a/vlib/v/parser/tests/generic_interface_decl_err.vv
+++ b/vlib/v/parser/tests/generic_interface_decl_err.vv
@@ -1,0 +1,13 @@
+module main
+
+interface Abc {
+	test[T]()
+}
+
+struct Xyz {}
+
+fn (xyz Xyz) test[T]() {}
+
+fn main() {
+	_ := Abc(Xyz{})
+}


### PR DESCRIPTION
This PR check non-generic interface defining generic method (fix #20430).

- Check non-generic interface defining generic method.
- Add test.

```v
module main

interface Abc {
	test[T]()
}

struct Xyz {}

fn (xyz Xyz) test[T]() {}

fn main() {
	_ := Abc(Xyz{})
}

PS D:\Test\v\tt1> v run .
tt1.v:4:6: error: non-generic interface `Abc` cannot define a generic method
    2 | 
    3 | interface Abc {
    4 |     test[T]()
      |         ^
    5 | }
    6 |
```