### PR TITLE
checker: fix checking give static map as default or init value to struct fields(fix #20512)

### DIFF
--- a/vlib/v/checker/tests/struct_field_init_and_default_is_map_err.out
+++ b/vlib/v/checker/tests/struct_field_init_and_default_is_map_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/struct_field_init_and_default_is_map_err.vv:7:25: error: cannot copy map: call `move` or `clone` method (or use a reference)
+    5 | struct Foo {
+    6 | mut:
+    7 |     field map[string]int = const_map
+      |                            ~~~~~~~~~
+    8 | }
+    9 |
+vlib/v/checker/tests/struct_field_init_and_default_is_map_err.vv:12:10: error: cannot assign a const map to mut struct field, call `clone` method (or use a reference)
+   10 | fn main() {
+   11 |     _ = Foo{
+   12 |         field: const_map
+      |                ~~~~~~~~~
+   13 |     }
+   14 | }

--- a/vlib/v/checker/tests/struct_field_init_and_default_is_map_err.vv
+++ b/vlib/v/checker/tests/struct_field_init_and_default_is_map_err.vv
@@ -1,0 +1,14 @@
+const const_map = {
+	'key': 4
+}
+
+struct Foo {
+mut:
+	field map[string]int = const_map
+}
+
+fn main() {
+	_ = Foo{
+		field: const_map
+	}
+}


### PR DESCRIPTION
1. Fixed #20512 
2. Add tests.

```v
const const_map = {
	'key': 4
}

struct Foo {
mut:
	field map[string]int = const_map
}

fn main() {
	_ = Foo{
		field: const_map
	}
}
```
outputs:
```
a.v:7:25: error: cannot copy map: call `move` or `clone` method (or use a reference)
    5 | struct Foo {
    6 | mut:
    7 |     field map[string]int = const_map
      |                            ~~~~~~~~~
    8 | }
    9 |
a.v:12:10: error: cannot assign a const map to mut struct field, call `clone` method (or use a reference)
   10 | fn main() {
   11 |     _ = Foo{
   12 |         field: const_map
      |                ~~~~~~~~~
   13 |     }
   14 | }
```