### PR TITLE
ast, parser, checker: fix `@[deprecated]` attribute for in const defines (fix #20523)

### DIFF
--- a/vlib/math/const.v
+++ b/vlib/math/const.v
@@ -39,24 +39,70 @@ pub const max_f64 = 1.797693134862315708145274237317043567981e+308 // 2**1023 * 
 
 pub const smallest_non_zero_f64 = 4.940656458412465441765687928682213723651e-324
 
-@[deprecated: 'use built-in constants instead (e.g. min_i8 instead of math.min_i8)']
+@[deprecated: 'use built-in constant `min_i8` instead']
 @[deprecated_after: '2023-12-31']
 pub const min_i8 = i8(-128)
+
+@[deprecated: 'use built-in constant `max_i8` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_i8 = i8(127)
+
+@[deprecated: 'use built-in constant `min_i16` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_i16 = i16(-32768)
+
+@[deprecated: 'use built-in constant `max_i16` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_i16 = i16(32767)
+
+@[deprecated: 'use built-in constant `min_i32` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_i32 = i32(-2147483648)
+
+@[deprecated: 'use built-in constant `max_i32` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_i32 = i32(2147483647)
+
 // -9223372036854775808 is wrong, because C compilers parse literal values
 // without sign first, and 9223372036854775808 overflows i64, hence the
 // consecutive subtraction by 1
+
+@[deprecated: 'use built-in constant `min_i64` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_i64 = i64(-9223372036854775807 - 1)
+
+@[deprecated: 'use built-in constant `max_i64` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_i64 = i64(9223372036854775807)
+
+@[deprecated: 'use built-in constant `min_u8` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_u8 = u8(0)
+
+@[deprecated: 'use built-in constant `max_u8` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_u8 = u8(255)
+
+@[deprecated: 'use built-in constant `min_u16` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_u16 = u16(0)
+
+@[deprecated: 'use built-in constant `max_u16` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_u16 = u16(65535)
+
+@[deprecated: 'use built-in constant `min_u32` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_u32 = u32(0)
+
+@[deprecated: 'use built-in constant `max_u32` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_u32 = u32(4294967295)
+
+@[deprecated: 'use built-in constant `min_u64` instead']
+@[deprecated_after: '2023-12-31']
 pub const min_u64 = u64(0)
+
+@[deprecated: 'use built-in constant `max_u64` instead']
+@[deprecated_after: '2023-12-31']
 pub const max_u64 = u64(18446744073709551615)

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -363,6 +363,7 @@ pub:
 	is_pub      bool
 	is_markused bool // an explicit `[markused]` tag; the const will NOT be removed by `-skip-unused`, no matter what
 	pos         token.Pos
+	attrs       []Attr // same value as `attrs` of the ConstDecl to which it belongs
 pub mut:
 	expr         Expr      // the value expr of field; everything after `=`
 	typ          Type      // the type of the const field, it can be any type in V

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3685,6 +3685,10 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 					obj.typ = typ
 					node.obj = obj
 
+					if obj.attrs.contains('deprecated') && obj.mod != c.mod {
+						c.deprecate('const', '${obj.name}', obj.attrs, node.pos)
+					}
+
 					if node.or_expr.kind != .absent {
 						unwrapped_typ := typ.clear_option_and_result()
 						c.expected_or_type = unwrapped_typ
@@ -3736,6 +3740,12 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		saved_mod := node.mod
 		node.mod = 'builtin'
 		builtin_type := c.ident(mut node)
+		if node.obj is ast.ConstField {
+			field := node.obj as ast.ConstField
+			if field.attrs.contains('deprecated') && field.mod != c.mod {
+				c.deprecate('const', '${field.name}', field.attrs, node.pos)
+			}
+		}
 		if builtin_type != ast.void_type {
 			return builtin_type
 		}

--- a/vlib/v/checker/tests/deprecations_consts.out
+++ b/vlib/v/checker/tests/deprecations_consts.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/deprecations_consts.vv:3:10: warning: const `math.max_i8` has been deprecated since 2023-12-31, it will be an error after 2024-06-28; use built-in constant `max_i8` instead
+    1 | import math
+    2 | 
+    3 | _ = math.max_i8
+      |          ~~~~~~

--- a/vlib/v/checker/tests/deprecations_consts.vv
+++ b/vlib/v/checker/tests/deprecations_consts.vv
@@ -1,0 +1,3 @@
+import math
+
+_ = math.max_i8

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3875,6 +3875,7 @@ fn (mut p Parser) const_decl() ast.ConstDecl {
 			is_pub: is_pub
 			expr: expr
 			pos: pos.extend(expr.pos())
+			attrs: attrs
 			comments: comments
 			end_comments: end_comments
 			is_markused: is_markused


### PR DESCRIPTION
1. Fixed #20523
2. Add tests.

To avoid too many cluttered warnings, the deprecated notification mechanism for consts is:

- When using the const variable directly or indirectly.
- When used outside the module defined by const.

```v
import math
_ = math.max_i8
```
outputs:
```
a.v:3:10: warning: const `math.max_i8` has been deprecated since 2023-12-31, it will be an error after 2024-06-28; use built-in constant `max_i8` instead
    1 | 
    2 | import math
    3 | _ = math.max_i8
      |          ~~~~~~
    4 | 
    5 |
```