### PR TITLE
cgen: fix necessary clone when the closure param is string/array on autofree(fix #20498)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -534,6 +534,10 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 					g.write('${var.name}[${i}],')
 				}
 				g.writeln('},')
+			} else if g.is_autofree && !var.is_mut && var_sym.info is ast.Array {
+				g.writeln('.${var.name} = array_clone(&${var.name}),')
+			} else if g.is_autofree && !var.is_mut && var_sym.kind == .string {
+				g.writeln('.${var.name} = string_clone(${var.name}),')
 			} else {
 				g.writeln('.${var.name} = ${var.name},')
 			}

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -243,3 +243,20 @@ fn test_cross_var_assign_with_inherited() {
 	}
 	f()
 }
+
+// for issue 20498
+// test array / string as closure params with -auto-free
+fn get_func_that_contains_closure() fn () {
+	arr := [1, 2, 3]
+	str := '${'a'}bcabc'
+	return fn [arr, str] () {
+		assert arr == [1, 2, 3]
+		assert str == 'abcabc'
+	}
+}
+
+fn test_array_and_string_as_closure_params_with_autofree() {
+	func := get_func_that_contains_closure()
+	func()
+	assert true
+}


### PR DESCRIPTION
1. Fixed #20498 
2. Add tests.

```v
fn foo() fn() {
    arr := [1, 2, 3]
    return fn [arr] () {
        println(arr)
    }
}

fn main() {
    print_arr := foo()
    print_arr()
}
```
v -autofree run a.v
```
[1, 2, 3]
```