### PR TITLE
v: add map update-init syntax

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -78,6 +78,7 @@ by using any of the following commands in a terminal:
         * [Array slices](#array-slices)
     * [Fixed size arrays](#fixed-size-arrays)
     * [Maps](#maps)
+        * [Map update syntax](#map-update-syntax)
 
 </td><td width=33% valign=top>
 
@@ -480,7 +481,7 @@ fn main() {
 	}
 }
 ```
-While variable shadowing is not allowed, field shadowing is allowed. 
+While variable shadowing is not allowed, field shadowing is allowed.
 ```v
 pub struct Dimension {
 	width  int = -1
@@ -1461,6 +1462,36 @@ See all methods of
 [map](https://modules.vlang.io/index.html#map)
 and
 [maps](https://modules.vlang.io/maps.html).
+
+### Map update syntax
+
+As with stucts, V lets you initialise a map with an update applied on top of
+another map:
+
+```v
+const base_map = {
+	'a': 4
+	'b': 5
+}
+
+foo := {
+	...base_map
+	'b': 88
+	'c': 99
+}
+
+println(foo) // {'a': 4, 'b': 88, 'c': 99}
+```
+
+This is functionally equivalent to cloning the map and updating it, except that
+you don't have to declare a mutable variable:
+
+```v failcompile
+// same as above (except mutable)
+mut foo := base_map.clone()
+foo['b'] = 88
+foo['c'] = 99
+```
 
 ## Module imports
 
@@ -5634,7 +5665,7 @@ serializers for any data format. V has compile time `if` and `for` constructs:
 
 #### <h4 id="comptime-fields">.fields</h4>
 
-You can iterate over struct fields using `.fields`, it also works with generic types 
+You can iterate over struct fields using `.fields`, it also works with generic types
 (e.g. `T.fields`) and generic arguments (e.g. `param.fields` where `fn gen[T](param T) {`).
 
 ```v

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -284,6 +284,20 @@ fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_
 	return out
 }
 
+fn new_map_update_init(update &map, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+	mut out := unsafe { update.clone() }
+	mut pkey := &u8(keys)
+	mut pval := &u8(values)
+	for _ in 0 .. n {
+		unsafe {
+			out.set(pkey, pval)
+			pkey = pkey + key_bytes
+			pval = pval + value_bytes
+		}
+	}
+	return out
+}
+
 // move moves the map to a new location in memory.
 // It does this by copying to a new location, then setting the
 // old location to all `0` with `vmemset`

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1501,12 +1501,16 @@ pub:
 	comments  [][]Comment // comments after key-value pairs
 	pre_cmnts []Comment   // comments before the first key-value pair
 pub mut:
-	keys       []Expr
-	vals       []Expr
-	val_types  []Type
-	typ        Type
-	key_type   Type
-	value_type Type
+	keys                 []Expr
+	vals                 []Expr
+	val_types            []Type
+	typ                  Type
+	key_type             Type
+	value_type           Type
+	has_update_expr      bool // has `...a`
+	update_expr          Expr // `a` in `...a`
+	update_expr_pos      token.Pos
+	update_expr_comments []Comment
 }
 
 // s[10..20]

--- a/vlib/v/checker/tests/map_init_invalid_update.out
+++ b/vlib/v/checker/tests/map_init_invalid_update.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/map_init_invalid_update.vv:8:6: error: invalid map update: non-map type
+    6 |     foo := 'foo is a string'
+    7 |     a := {
+    8 |         ...foo // not a map
+      |            ~~~
+    9 |         'a': 5
+   10 |         'b': 6
+vlib/v/checker/tests/map_init_invalid_update.vv:19:6: error: invalid map update: non-map type
+   17 |     println(b)
+   18 |     c := {
+   19 |         ...Foo{9} // also not ok
+      |            ~~~~~~
+   20 |     }
+   21 |     println(c)

--- a/vlib/v/checker/tests/map_init_invalid_update.vv
+++ b/vlib/v/checker/tests/map_init_invalid_update.vv
@@ -1,0 +1,22 @@
+struct Foo {
+	x int
+}
+
+fn main() {
+	foo := 'foo is a string'
+	a := {
+		...foo // not a map
+		'a': 5
+		'b': 6
+	}
+	println(a)
+	b := {
+		...(a.clone()) // ok
+		'c': 99
+	}
+	println(b)
+	c := {
+		...Foo{9} // also not ok
+	}
+	println(c)
+}

--- a/vlib/v/checker/tests/map_init_wrong_expected_type.out
+++ b/vlib/v/checker/tests/map_init_wrong_expected_type.out
@@ -1,0 +1,49 @@
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:18:9: error: invalid map value: expected `int`, not `string`
+   16 |     b := Bar{
+   17 |         m: {
+   18 |             'a': '5'
+      |                  ~~~
+   19 |             'b': '6'
+   20 |         } // bad
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:19:9: error: invalid map value: expected `int`, not `string`
+   17 |         m: {
+   18 |             'a': '5'
+   19 |             'b': '6'
+      |                  ~~~
+   20 |         } // bad
+   21 |     }
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:36:9: error: invalid map value: expected `int`, not `string`
+   34 |         m: {
+   35 |             ...a.m
+   36 |             'c': '7'
+      |                  ~~~
+   37 |         } // bad values
+   38 |     }
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:43:9: error: invalid map update: expected `map[string]int`, not `map[string]string`
+   41 |     f := Bar{
+   42 |         m: {
+   43 |             ...x.m
+      |                  ^
+   44 |         } // bad update
+   45 |     }
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:48:9: error: invalid map update: expected `map[string]int`, not `map[string]string`
+   46 |     g := Bar{
+   47 |         m: {
+   48 |             ...x.m
+      |                  ^
+   49 |             'c': 7
+   50 |         } // bad update, ok values
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:54:9: error: invalid map update: expected `map[string]int`, not `map[string]string`
+   52 |     h := Bar{
+   53 |         m: {
+   54 |             ...x.m
+      |                  ^
+   55 |             'c': '7'
+   56 |         } // bad update, bad values
+vlib/v/checker/tests/map_init_wrong_expected_type.vv:55:9: error: invalid map value: expected `int`, not `string`
+   53 |         m: {
+   54 |             ...x.m
+   55 |             'c': '7'
+      |                  ~~~
+   56 |         } // bad update, bad values
+   57 |     }

--- a/vlib/v/checker/tests/map_init_wrong_expected_type.vv
+++ b/vlib/v/checker/tests/map_init_wrong_expected_type.vv
@@ -1,0 +1,66 @@
+struct Foo {
+	m map[string]string
+}
+
+struct Bar {
+	m map[string]int
+}
+
+fn main() {
+	a := Bar{
+		m: {
+			'a': 5
+			'b': 6
+		} // ok
+	}
+	b := Bar{
+		m: {
+			'a': '5'
+			'b': '6'
+		} // bad
+	}
+	c := Bar{
+		m: {
+			...a.m
+		} // ok
+	}
+	d := Bar{
+		m: {
+			...a.m
+			'c': 7
+		} // ok
+	}
+	e := Bar{
+		m: {
+			...a.m
+			'c': '7'
+		} // bad values
+	}
+
+	x := Foo{}
+	f := Bar{
+		m: {
+			...x.m
+		} // bad update
+	}
+	g := Bar{
+		m: {
+			...x.m
+			'c': 7
+		} // bad update, ok values
+	}
+	h := Bar{
+		m: {
+			...x.m
+			'c': '7'
+		} // bad update, bad values
+	}
+	println(a)
+	println(b)
+	println(c)
+	println(d)
+	println(e)
+	println(f)
+	println(g)
+	println(h)
+}

--- a/vlib/v/checker/tests/map_init_wrong_update_type.out
+++ b/vlib/v/checker/tests/map_init_wrong_update_type.out
@@ -1,0 +1,28 @@
+vlib/v/checker/tests/map_init_wrong_update_type.vv:12:8: error: invalid map value: expected `StrB`, not `int literal`
+   10 |     a := {
+   11 |         ...foo // not ok
+   12 |         'a': 5
+      |              ^
+   13 |         'b': 6
+   14 |     }
+vlib/v/checker/tests/map_init_wrong_update_type.vv:13:8: error: invalid map value: expected `StrB`, not `int literal`
+   11 |         ...foo // not ok
+   12 |         'a': 5
+   13 |         'b': 6
+      |              ^
+   14 |     }
+   15 |     b := {
+vlib/v/checker/tests/map_init_wrong_update_type.vv:17:3: error: invalid map key: expected `StrA`, not `Bar`
+   15 |     b := {
+   16 |         ...foo // not ok
+   17 |         Bar{'yes'}: '5'
+      |         ~~~~~~~~~~
+   18 |         Bar{'now'}: '6'
+   19 |     }
+vlib/v/checker/tests/map_init_wrong_update_type.vv:18:3: error: invalid map key: expected `StrA`, not `Bar`
+   16 |         ...foo // not ok
+   17 |         Bar{'yes'}: '5'
+   18 |         Bar{'now'}: '6'
+      |         ~~~~~~~~~~
+   19 |     }
+   20 |     c := {

--- a/vlib/v/checker/tests/map_init_wrong_update_type.vv
+++ b/vlib/v/checker/tests/map_init_wrong_update_type.vv
@@ -1,0 +1,28 @@
+struct Bar {
+	x string
+}
+
+type StrA = string
+type StrB = string
+
+fn main() {
+	foo := map[StrA]StrB{}
+	a := {
+		...foo // not ok
+		'a': 5
+		'b': 6
+	}
+	b := {
+		...foo // not ok
+		Bar{'yes'}: '5'
+		Bar{'now'}: '6'
+	}
+	c := {
+		...foo // ok
+		'up':   'down'
+		'left': 'right'
+	}
+	println(a)
+	println(b)
+	println(c)
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2624,7 +2624,7 @@ pub fn (mut f Fmt) lock_expr(node ast.LockExpr) {
 }
 
 pub fn (mut f Fmt) map_init(node ast.MapInit) {
-	if node.keys.len == 0 {
+	if node.keys.len == 0 && !node.has_update_expr {
 		if node.typ > ast.void_type {
 			sym := f.table.sym(node.typ)
 			info := sym.info as ast.Map
@@ -2644,6 +2644,15 @@ pub fn (mut f Fmt) map_init(node ast.MapInit) {
 	f.writeln('{')
 	f.indent++
 	f.comments(node.pre_cmnts)
+	if node.has_update_expr {
+		f.write('...')
+		f.expr(node.update_expr)
+		f.comments(node.update_expr_comments,
+			prev_line: node.update_expr_pos.last_line
+			has_nl: false
+		)
+		f.writeln('')
+	}
 	mut max_field_len := 0
 	mut skeys := []string{}
 	for key in node.keys {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4136,25 +4136,25 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 		}
 	}
 	if size > 0 {
-		if value_sym.kind == .function {
-			g.writeln('new_map_init${noscan}(${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}, ${size}, sizeof(${key_typ_str}), sizeof(voidptr),')
+		effective_typ_str := if value_sym.kind == .function { 'voidptr' } else { value_typ_str }
+		if node.has_update_expr {
+			g.writeln('new_map_update_init(')
+			g.write('\t&(')
+			g.expr(node.update_expr)
+			g.writeln('), ${size}, sizeof(${key_typ_str}), sizeof(${effective_typ_str}),')
 		} else {
-			g.writeln('new_map_init${noscan}(${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}, ${size}, sizeof(${key_typ_str}), sizeof(${value_typ_str}),')
+			g.writeln('new_map_init${noscan}(${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}, ${size}, sizeof(${key_typ_str}), sizeof(${effective_typ_str}),')
 		}
-		g.writeln('\t\t_MOV((${key_typ_str}[${size}]){')
+		g.writeln('\t_MOV((${key_typ_str}[${size}]){')
 		for expr in node.keys {
-			g.write('\t\t\t')
+			g.write('\t\t')
 			g.expr(expr)
-			g.writeln(', ')
+			g.writeln(',')
 		}
-		g.writeln('\t\t}),')
-		if value_sym.kind == .function {
-			g.writeln('\t\t_MOV((voidptr[${size}]){')
-		} else {
-			g.writeln('\t\t_MOV((${value_typ_str}[${size}]){')
-		}
+		g.writeln('\t}),')
+		g.writeln('\t_MOV((${effective_typ_str}[${size}]){')
 		for i, expr in node.vals {
-			g.write('\t\t\t')
+			g.write('\t\t')
 			if expr.is_auto_deref_var() {
 				g.write('*')
 			}
@@ -4167,12 +4167,15 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			}
 			g.writeln(', ')
 		}
-		g.writeln('\t\t})')
-		g.writeln('\t)')
+		g.writeln('\t})')
+		g.writeln(')')
+	} else if node.has_update_expr {
+		g.write('map_clone(&(')
+		g.expr(node.update_expr)
+		g.writeln('))')
 	} else {
-		g.write('new_map${noscan}(sizeof(${key_typ_str}), sizeof(${value_typ_str}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})')
+		g.writeln('new_map${noscan}(sizeof(${key_typ_str}), sizeof(${value_typ_str}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})')
 	}
-	g.writeln('')
 	if g.is_shared {
 		g.write('}, sizeof(${shared_styp}))')
 	} else if is_amp {

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -196,7 +196,22 @@ fn (mut p Parser) map_init() ast.MapInit {
 	mut keys := []ast.Expr{}
 	mut vals := []ast.Expr{}
 	mut comments := [][]ast.Comment{}
+	mut has_update_expr := false
+	mut update_expr := ast.empty_expr
+	mut update_expr_comments := []ast.Comment{}
+	mut update_expr_pos := token.Pos{}
 	pre_cmnts := p.eat_comments()
+	if p.tok.kind == .ellipsis {
+		// updating init { ...base_map, 'b': 44, 'c': 55 }
+		has_update_expr = true
+		p.check(.ellipsis)
+		update_expr = p.expr(0)
+		update_expr_pos = update_expr.pos()
+		if p.tok.kind == .comma {
+			p.next()
+		}
+		update_expr_comments << p.eat_comments(same_line: true)
+	}
 	for p.tok.kind !in [.rcbr, .eof] {
 		if p.tok.kind == .name && p.tok.lit in ['r', 'c', 'js'] {
 			key := p.string_expr()
@@ -219,6 +234,10 @@ fn (mut p Parser) map_init() ast.MapInit {
 		pos: first_pos.extend_with_last_line(p.tok.pos(), p.tok.line_nr)
 		comments: comments
 		pre_cmnts: pre_cmnts
+		has_update_expr: has_update_expr
+		update_expr: update_expr
+		update_expr_pos: update_expr_pos
+		update_expr_comments: update_expr_comments
 	}
 }
 

--- a/vlib/v/tests/map_init_with_update_test.v
+++ b/vlib/v/tests/map_init_with_update_test.v
@@ -1,0 +1,36 @@
+const base_map = {
+	'a': 4
+	'b': 5
+}
+
+fn test_map_init_with_update() {
+	foo := {
+		...base_map
+		'b': 88
+		'c': 99
+	}
+	assert base_map.keys() == ['a', 'b']
+	assert base_map['a'] == 4
+	assert base_map['b'] == 5
+	assert foo.keys() == ['a', 'b', 'c']
+	assert foo['a'] == 4
+	assert foo['b'] == 88
+	assert foo['c'] == 99
+
+	bar := {
+		...foo
+		'b': 6
+		'd': 7
+	}
+	assert base_map.keys() == ['a', 'b']
+	assert base_map['a'] == 4
+	assert base_map['b'] == 5
+	assert foo.keys() == ['a', 'b', 'c']
+	assert foo['a'] == 4
+	assert foo['b'] == 88
+	assert foo['c'] == 99
+	assert bar.keys() == ['a', 'b', 'c']
+	assert bar['a'] == 4
+	assert bar['b'] == 6
+	assert bar['d'] == 7
+}

--- a/vlib/v/tests/map_init_with_update_test.v
+++ b/vlib/v/tests/map_init_with_update_test.v
@@ -29,8 +29,24 @@ fn test_map_init_with_update() {
 	assert foo['a'] == 4
 	assert foo['b'] == 88
 	assert foo['c'] == 99
-	assert bar.keys() == ['a', 'b', 'c']
+	assert bar.keys() == ['a', 'b', 'c', 'd']
 	assert bar['a'] == 4
 	assert bar['b'] == 6
+	assert bar['c'] == 99
 	assert bar['d'] == 7
+}
+
+fn test_map_init_with_only_update() {
+	mut foo := {
+		...base_map
+	}
+	bar := {
+		...foo
+	}
+	foo['a'] = 99
+	foo['c'] = 99
+	assert bar.keys() == ['a', 'b']
+	assert bar['a'] == 4
+	assert bar['b'] == 5
+	assert bar == base_map
 }


### PR DESCRIPTION
Add support for map update-init syntax to v:

```v
foo := {
    ...base_map
    'a': 55
    'b': 66
}
```

which is functionally equivalent to:
```v
mut foo := base_map.clone()
foo['a'] = 55
foo['b'] = 66
```
except that it yields an expression which does not have to be mutable.

This PR updates:
* ast, checker, parser and cgen
* adds `new_map_update_init()` to builtin/map.v to support cgen
* docs
* v fmt
* v tests & checker tests

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
