### PR TITLE
builtin: Add empty string verification suggested on PR #20540

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1791,6 +1791,10 @@ fn (s string) at_with_check(idx int) ?u8 {
 pub fn (str string) is_oct() bool {
 	mut i := 0
 
+	if str.len == 0 {
+		return false
+	}
+
 	if str[i] == `0` {
 		i++
 	} else if str[i] == `-` || str[i] == `+` {
@@ -1829,6 +1833,10 @@ pub fn (str string) is_oct() bool {
 @[direct_array_access]
 pub fn (str string) is_bin() bool {
 	mut i := 0
+
+	if str.len == 0 {
+		return false
+	}
 
 	if str[i] == `0` {
 		i++
@@ -1869,6 +1877,10 @@ pub fn (str string) is_bin() bool {
 pub fn (str string) is_hex() bool {
 	mut i := 0
 
+	if str.len == 0 {
+		return false
+	}
+
 	if str[i] == `0` {
 		i++
 	} else if str[i] == `-` || str[i] == `+` {
@@ -1908,6 +1920,10 @@ pub fn (str string) is_hex() bool {
 @[direct_array_access]
 pub fn (str string) is_int() bool {
 	mut i := 0
+
+	if str.len == 0 {
+		return false
+	}
 
 	if (str[i] != `-` && str[i] != `+`) && (!str[i].is_digit()) {
 		return false

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1791,7 +1791,9 @@ fn (s string) at_with_check(idx int) ?u8 {
 pub fn (str string) is_oct() bool {
 	mut i := 0
 
-	if str.len == 0 { return false }
+	if str.len == 0 {
+		return false
+	}
 
 	if str[i] == `0` {
 		i++

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1791,9 +1791,7 @@ fn (s string) at_with_check(idx int) ?u8 {
 pub fn (str string) is_oct() bool {
 	mut i := 0
 
-	if str.len == 0 {
-		return false
-	}
+	if str.len == 0 { return false }
 
 	if str[i] == `0` {
 		i++

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -426,6 +426,7 @@ fn test_rsplit_once() ? {
 }
 
 fn test_is_bin() {
+	assert ''.is_bin() == false
 	assert '0b1'.is_bin() == true
 	assert '0b0'.is_bin() == true
 	assert '0b'.is_bin() == false
@@ -455,6 +456,7 @@ fn test_is_bin() {
 }
 
 fn test_is_oct() {
+	assert ''.is_oct() == false
 	assert '0o0'.is_oct() == true
 	assert '0o1'.is_oct() == true
 	assert '0o2'.is_oct() == true
@@ -505,6 +507,7 @@ fn test_is_oct() {
 }
 
 fn test_is_hex() {
+	assert ''.is_hex() == false
 	assert '-324'.is_hex() == false
 	assert '-0'.is_hex() == false
 	assert '0x1'.is_hex() == true
@@ -527,6 +530,7 @@ fn test_is_hex() {
 }
 
 fn test_is_int() {
+	assert ''.is_int() == false
 	assert '-324'.is_int() == true
 	assert '234'.is_int() == true
 	assert '-0'.is_int() == true


### PR DESCRIPTION
Fulfilling the request of @spytheman on the merged PR #20540

```v
// Check if a string is an octal value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_oct() bool {
	mut i := 0

	if str.len == 0 {
		return false
	}

	if str[i] == `0` {
		i++
	} else if str[i] == `-` || str[i] == `+` {
		i++

		if str[i] == `0` {
			i++
		} else {
			return false
		}
	} else {
		return false
	}

	if str[i] == `o` {
		i++
	} else {
		return false
	}

	if i == str.len {
		return false
	}

	for i < str.len {
		if str[i] < `0` || str[i] > `7` {
			return false
		}
		i++
	}

	return true
}

// Check if a string is an binary value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_bin() bool {
	mut i := 0

	if str.len == 0 {
		return false
	}

	if str[i] == `0` {
		i++
	} else if str[i] == `-` || str[i] == `+` {
		i++

		if str[i] == `0` {
			i++
		} else {
			return false
		}
	} else {
		return false
	}

	if str[i] == `b` {
		i++
	} else {
		return false
	}

	if i == str.len {
		return false
	}

	for i < str.len {
		if str[i] < `0` || str[i] > `1` {
			return false
		}
		i++
	}

	return true
}

// Check if a string is an hexadecimal value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_hex() bool {
	mut i := 0

	if str.len == 0 {
		return false
	}

	if str[i] == `0` {
		i++
	} else if str[i] == `-` || str[i] == `+` {
		i++

		if str[i] == `0` {
			i++
		} else {
			return false
		}
	} else {
		return false
	}

	if str[i] == `x` {
		i++
	} else {
		return false
	}

	if i == str.len {
		return false
	}

	for i < str.len {
		if (str[i] < `0` || str[i] > `9`) && ((str[i] < `a` || str[i] > `f`)
			&& (str[i] < `A` || str[i] > `F`)) {
			return false
		}
		i++
	}

	return true
}

// Check if a string is an integer value. Returns 'true' if it is, or 'false' if it is not
@[direct_array_access]
pub fn (str string) is_int() bool {
	mut i := 0

	if str.len == 0 {
		return false
	}

	if (str[i] != `-` && str[i] != `+`) && (!str[i].is_digit()) {
		return false
	} else {
		i++
	}

	if i == str.len && (!str[i - 1].is_digit()) {
		return false
	}

	for i < str.len {
		if str[i] < `0` || str[i] > `9` {
			return false
		}
		i++
	}

	return true
}
```

and add

```v
assert ''.is_int() == false
assert ''.is_hex() == false
assert ''.is_bin() == false
assert ''.is_oct() == false
```
on string_test.v file