### PR TITLE
cgen: fix cgen wrong when auto_heap var as closure args(fix #20208)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -509,8 +509,10 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	g.indent++
 	for var in node.inherited_vars {
 		mut has_inherited := false
+		mut is_ptr := false
 		if obj := node.decl.scope.find(var.name) {
 			if obj is ast.Var {
+				is_ptr = obj.typ.is_ptr()
 				if obj.has_inherited {
 					has_inherited = true
 					var_sym := g.table.sym(var.typ)
@@ -539,7 +541,17 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 			} else if g.is_autofree && !var.is_mut && var_sym.kind == .string {
 				g.writeln('.${var.name} = string_clone(${var.name}),')
 			} else {
-				g.writeln('.${var.name} = ${var.name},')
+				mut is_auto_heap := false
+				if obj := node.decl.scope.parent.find(var.name) {
+					if obj is ast.Var {
+						is_auto_heap = !obj.is_stack_obj && obj.is_auto_heap
+					}
+				}
+				if is_auto_heap && !is_ptr {
+					g.writeln('.${var.name} = *${var.name},')
+				} else {
+					g.writeln('.${var.name} = ${var.name},')
+				}
 			}
 		}
 	}

--- a/vlib/v/tests/closure_test.v
+++ b/vlib/v/tests/closure_test.v
@@ -268,3 +268,33 @@ fn test_array_string_and_map_as_closure_params_with_autofree() {
 	func()
 	assert true
 }
+
+// for issue 20208
+// phenomenon: cgen fails when the closure arg is auto_heap and is not reference.
+@[heap]
+struct Abc {
+	value int
+}
+
+@[heap]
+struct Container {
+	abc &Abc = unsafe { nil }
+}
+
+fn (mut c Container) m() fn () {
+	mut cr := &c
+	assert voidptr(c.abc) == voidptr(cr.abc)
+	f := fn [mut cr] () {
+		assert cr.abc.value == 1234
+	}
+	return f
+}
+
+fn test_auto_heap_var_and_non_ptr_as_closure_arg() {
+	mut c := &Container{
+		abc: &Abc{1234}
+	}
+	f := c.m()
+	f()
+	assert true
+}


### PR DESCRIPTION
1. Fixed #20208 
2. Add tests.

```v
@[heap]
struct Abc {
	value int
}

@[heap]
struct Container {
	aa &Abc = unsafe { nil }
}

fn (mut c Container) m() fn () {
	mut cr := &c
	dump(voidptr(c.aa))
	dump(voidptr(cr.aa))
	f := fn [mut cr] () {	
		dump(voidptr(cr.aa))
		dump(cr)
	}
	return f
}

mut c := &Container{aa: &Abc{1234}}
dump(voidptr(c))
dump(c)
dump(voidptr(c.aa))
f := c.m()
f()
```
outputs:
```
[a.v:24] voidptr(c): 0x10241ffd0
[a.v:25] c: &Container{
    aa: &Abc{
        value: 1234
    }
}
[a.v:26] voidptr(c.aa): 0x10241ffe0
[a.v:14] voidptr(c.aa): 0x10241ffe0
[a.v:15] voidptr(cr.aa): 0x10241ffe0
[a.v:17] voidptr(cr.aa): 0x10241ffe0
[a.v:18] cr: Container{
    aa: &Abc{
        value: 1234
    }
}
```

```v
@[heap]
struct Container {
	content int
}

fn foo(mut c Container) {
	c2 := c
	dump(c.content)
	dump(c2.content)
	tmp1 := fn [c] () {
		dump(c.content)
	}
	tmp1()
	tmp2 := fn [c2] () {
		dump(c2.content)
	}
	tmp2()
}

mut co := &Container{content: 1}
foo(mut co)
```
outputs:
```
[a.v:9] c.content: 1
[a.v:10] c2.content: 1
[a.v:12] c.content: 1
[a.v:16] c2.content: 1
```