### PR TITLE
orm: fix orm insert issue if table missing [Issue : #20017]

### DIFF
--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -393,7 +393,7 @@ fn test_orm_insert_with_child_element_and_no_table() {
 		select from Parent
 	}!
 
-	assert p_table[1].children[0].name == 'Sophia'
+	assert p_table[2].children[0].name == 'Sophia'
 }
 
 @[table: 'customers']

--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -348,6 +348,54 @@ fn test_orm_insert_with_multiple_child_elements() {
 	assert parent.notes[2].text == 'Third note'
 }
 
+fn test_orm_insert_with_child_element_and_no_table() {
+	mut db := sqlite.connect(':memory:')!
+
+	sql db {
+		create table Parent
+	}!
+
+	new_parent := Parent{
+		name: 'test'
+		children: [
+			Child{
+				name: 'Lisa'
+			},
+		]
+	}
+
+	sql db {
+		insert new_parent into Parent
+	} or { assert true }
+
+	sql db {
+		create table Child
+	}!
+
+	sql db {
+		insert new_parent into Parent
+	} or { assert false }
+
+	new_parent_two := Parent{
+		name: 'retest'
+		children: [
+			Child{
+				name: 'Sophia'
+			},
+		]
+	}
+
+	sql db {
+		insert new_parent_two into Parent
+	} or { assert false }
+
+	p_table := sql db {
+		select from Parent
+	}!
+
+	assert p_table[1].children[0].name == 'Sophia'
+}
+
 @[table: 'customers']
 struct Customer {
 	id   i64    @[primary; sql: serial]

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -473,6 +473,13 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			unsafe { fff.free() }
 			g.write_orm_insert_with_last_ids(arr, connection_var_name, g.get_table_name_by_struct_type(arr.table_expr.typ),
 				last_ids, res_, id_name, fkeys[i], or_expr)
+			// Validates main insertion success before proceeding with sub insertions.
+			// If main insertion succeeds, errors in sub insertions are handled and propagated.
+			g.writeln('if (!${res}.is_error) {')
+			g.indent++
+			g.or_block(res_, or_expr, ast.int_type.set_flag(.result))
+			g.indent--
+			g.writeln('}')
 			g.indent--
 			g.writeln('}')
 		}

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -420,6 +420,8 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	g.writeln('}')
 	g.indent--
 	g.writeln(');')
+	// Validate main insertion success otherwise, handled and propagated error.
+	g.or_block(res, or_expr, ast.int_type.set_flag(.result))
 
 	if arrs.len > 0 {
 		mut id_name := g.new_tmp_var()
@@ -473,13 +475,8 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			unsafe { fff.free() }
 			g.write_orm_insert_with_last_ids(arr, connection_var_name, g.get_table_name_by_struct_type(arr.table_expr.typ),
 				last_ids, res_, id_name, fkeys[i], or_expr)
-			// Validates main insertion success before proceeding with sub insertions.
-			// If main insertion succeeds, errors in sub insertions are handled and propagated.
-			g.writeln('if (!${res}.is_error) {')
-			g.indent++
+			// Validates sub insertion success otherwise, handled and propagated error.	
 			g.or_block(res_, or_expr, ast.int_type.set_flag(.result))
-			g.indent--
-			g.writeln('}')
 			g.indent--
 			g.writeln('}')
 		}


### PR DESCRIPTION
Hello,

Fixed #20017 
Fixed #20019 

To achieve this, a condition has been added in cgen.orm to first verify if the primary element has been successfully inserted. Following this, it checks if the sub-element insertions are successful. 

If not, the error is captured and returned to the user code for handling as desired.

A test function has also been added.

Would it be necessary to includes files in v/slow_tests/ for this update?

I am available for any suggestions/modifications. 
