### PR TITLE
db/pg: add include and lib paths for postgres on freebsd

### DIFF
--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -27,6 +27,9 @@ $if $pkgconfig('libpq') {
 
 	#flag windows -I @VEXEROOT/thirdparty/pg/libpq
 	#flag windows -L @VEXEROOT/thirdparty/pg/win64
+
+	#flag freebsd -I/usr/local/include
+	#flag freebsd -L/usr/local/lib
 }
 
 // PostgreSQL Source Code


### PR DESCRIPTION
PostgreSQL headers and library were not being found when compiling on FreeBSD.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
