### PR TITLE
v.debug: cleanup interactive_test.v

### DIFF
--- a/vlib/v/debug/interactive_test.v
+++ b/vlib/v/debug/interactive_test.v
@@ -30,7 +30,6 @@ fn gprint(msg string) {
 }
 
 fn test_debugger() {
-	os.chdir(expect_tests_path)!
 	all_expect_files := os.walk_ext(expect_tests_path, '.expect')
 	assert all_expect_files.len > 0, 'no .expect files found in ${expect_tests_path}'
 	mut oks := 0
@@ -56,7 +55,7 @@ fn test_debugger() {
 		}
 
 		verbose_options := if be_verbose { '-d' } else { '' }
-		expect_cmd := '${expect_exe} ${verbose_options} ${os.quoted_path(efile)} ${os.quoted_path(output_file)} ${os.quoted_path(vfile)}'
+		expect_cmd := '${expect_exe} ${verbose_options} -c "cd ${expect_tests_path}" ${os.quoted_path(efile)} ${os.quoted_path(output_file)} ${os.quoted_path(vfile)}'
 		if be_verbose {
 			gprintln(term.cyan(expect_cmd))
 		}

--- a/vlib/v/debug/interactive_test.v
+++ b/vlib/v/debug/interactive_test.v
@@ -5,7 +5,8 @@ import time
 const vexe = @VEXE
 const expect_tests_path = os.join_path(@VEXEROOT, 'vlib', 'v', 'debug', 'tests')
 const test_module_path = os.join_path(os.vtmp_dir(), 'test_vdbg_input')
-const bar = term.yellow('-'.repeat(100))
+const bar = term.yellow('-'.repeat(105))
+const be_verbose = os.getenv('GITHUB_JOB') != '' || os.getenv('VERBOSE') != ''
 
 const expect_exe = os.quoted_path(os.find_abs_path_of_executable('expect') or {
 	eprintln('skipping test, since expect is missing')
@@ -16,44 +17,76 @@ fn testsuite_begin() {
 	os.chdir(@VEXEROOT) or {}
 	os.rmdir_all(test_module_path) or {}
 	os.mkdir_all(test_module_path) or {}
-	dump(test_module_path)
 }
 
 fn gprintln(msg string) {
-	println(term.gray(msg))
+	println(term.green(msg))
+	flush_stdout()
+}
+
+fn gprint(msg string) {
+	print(term.green(msg))
+	flush_stdout()
 }
 
 fn test_debugger() {
-	os.chdir(test_module_path)!
+	os.chdir(expect_tests_path)!
 	all_expect_files := os.walk_ext(expect_tests_path, '.expect')
 	assert all_expect_files.len > 0, 'no .expect files found in ${expect_tests_path}'
-	for eidx, efile in all_expect_files {
+	mut oks := 0
+	for eidx, efile in all_expect_files.sorted() {
+		// if !efile.contains('sumtype') { gprintln('skipping $efile') continue }
 		vfile := efile.replace('.expect', '.vv')
 		output_file := os.join_path(test_module_path, os.file_name(efile).replace('.expect',
 			'.exe'))
 
-		println(bar)
-		gprintln('>>>> running test [${eidx + 1}/${all_expect_files.len}], ${term.magenta(efile)} ...')
+		if be_verbose {
+			println(bar)
+		}
+		gprint('>>>> Running [${eidx + 1}/${all_expect_files.len}] ${term.magenta(efile):-68} ... ')
+		if be_verbose {
+			println('')
+		}
 
 		compile_sw := time.new_stopwatch()
 		comp_res := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(output_file)} ${os.quoted_path(vfile)}')
-		gprintln('>>>>>>>>>>> compilation took ${compile_sw.elapsed().milliseconds()} ms, comp_res: ${comp_res}')
+		cdur_ms := compile_sw.elapsed().milliseconds()
+		if be_verbose {
+			gprintln('>>>>>>>>>>> compilation took ${cdur_ms} ms, comp_res: ${comp_res}')
+		}
 
-		expect_cmd := '${expect_exe} -d -c "set stty_init {rows 24 cols 80}" -c "set timeout 15" ${os.quoted_path(efile)} ${os.quoted_path(output_file)} ${os.quoted_path(vfile)}'
-		println(term.cyan(expect_cmd))
-		flush_stdout()
+		verbose_options := if be_verbose { '-d' } else { '' }
+		expect_cmd := '${expect_exe} ${verbose_options} ${os.quoted_path(efile)} ${os.quoted_path(output_file)} ${os.quoted_path(vfile)}'
+		if be_verbose {
+			gprintln(term.cyan(expect_cmd))
+		}
 		sw := time.new_stopwatch()
-		res := os.system(expect_cmd)
-		gprintln('>>>>>>>>>>> expect took: ${sw.elapsed().milliseconds()} ms, res: ${res}')
-
+		mut res := 0
+		if be_verbose {
+			res = os.system(expect_cmd)
+		} else {
+			result := os.execute(expect_cmd)
+			res = result.exit_code
+			if res != 0 {
+				eprintln(result.output)
+			}
+		}
+		edur_ms := sw.elapsed().milliseconds()
+		if be_verbose {
+			gprintln('>>>>>>>>>>> expect took: ${edur_ms} ms, res: ${res}')
+		}
 		if res != 0 {
 			assert false, term.red('failed expect cmd: ${expect_cmd}')
 		}
 		assert true
+		oks++
+		if !be_verbose {
+			gprintln('    c: ${cdur_ms} ms, e: ${edur_ms} ms')
+		}
 	}
 	os.chdir(@VEXEROOT) or {}
 	os.rmdir_all(test_module_path) or {}
 
 	println(bar)
-	gprintln(term.bold('A total of ${all_expect_files.len} tests for the debugger are OK'))
+	gprintln('Passed debugger tests: ${term.bold(oks.str())} of ${all_expect_files.len} total.')
 }

--- a/vlib/v/debug/tests/aggregate.expect
+++ b/vlib/v/debug/tests/aggregate.expect
@@ -1,9 +1,10 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "\[${test_file}:25\] a.a: 123\r\n"
-expect -ex "Break on \[main\] main in ${test_file}:26\r\n"
-expect -ex "${test_file}:26 vdbg> " { send "p a\n" } timeout { exit 1 }
-expect -ex "a = Test{\r\n    a: 123\r\n} ((main.main.Test | main.main.Test2))" { send "q\n" } timeout { exit 1 }
+expect "*${test_file}:25* a.a: 123\r\n"
+expect "Break * in ${test_file}:26\r\n"
+expect "${test_file}:26 vdbg> "
+send "p a\n"
+expect "a = Test{\r\n    a: 123\r\n} ((main.main.Test | main.main.Test2))"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/common.tcl
+++ b/vlib/v/debug/tests/common.tcl
@@ -1,0 +1,6 @@
+## This file will be included by all other .expect scripts in this folder.
+set timeout 2
+set stty_init {rows 24 cols 80}
+expect_after timeout { exit 1}
+set test_file [lindex $argv 1]
+spawn [lindex $argv 0]

--- a/vlib/v/debug/tests/comptime_smartcast.expect
+++ b/vlib/v/debug/tests/comptime_smartcast.expect
@@ -1,10 +1,13 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] comptime_smartcast in ${test_file}:3\r\n"
-expect "${test_file}:3 vdbg> " { send "p v\n" } timeout { exit 1 }
-expect "v = 1 (int)" { send "c\n" } timeout { exit 1 }
-expect "${test_file}:5 vdbg> " { send "p v\n" } timeout { exit 1 }
-expect "v = true (bool)" { send "q\n" } timeout { exit 1 }
+expect "Break on * comptime_smartcast in ${test_file}:3\r\n"
+expect "${test_file}:3 vdbg> "
+send "p v\n"
+expect "v = 1 (int)"
+send "c\n"
+expect "${test_file}:5 vdbg> "
+send "p v\n"
+expect "v = true (bool)"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/comptime_variant.expect
+++ b/vlib/v/debug/tests/comptime_variant.expect
@@ -1,8 +1,9 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] comptime_variant_int in ${test_file}:7"
-expect -ex "${test_file}:7 vdbg> " { send "p a\n" } timeout { exit 1 }
-expect -ex "a = 0 (int)" { send "q\n" } timeout { exit 1 }
+expect "Break on * comptime_variant_int in ${test_file}:7"
+expect "${test_file}:7 vdbg> "
+send "p a\n"
+expect "a = 0 (int)"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/interface_var.expect
+++ b/vlib/v/debug/tests/interface_var.expect
@@ -1,8 +1,9 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] interface_var in ${test_file}:14\r\n"
-expect -ex "${test_file}:14 vdbg> " { send "p a\n" } timeout { exit 1 }
-expect -ex "a = Test{\r\n    a: MySum(true)" { send "q\n" } timeout { exit 1 }
+expect "Break on * interface_var in ${test_file}:14\r\n"
+expect "${test_file}:14 vdbg> "
+send "p a\n"
+expect "a = Test{\r\n    a: MySum(true)"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/iteration.expect
+++ b/vlib/v/debug/tests/iteration.expect
@@ -1,16 +1,20 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
 expect "0"
 expect "1"
 expect "2"
 expect "4"
-expect "${test_file}:3 vdbg> " { send "p x\n" } timeout { exit 1 }
-expect "x = 5 (int literal)" { send "c\n"} timeout { exit 1 }
-expect "${test_file}:3 vdbg> " { send "p x\n" } timeout { exit 1 }
-expect "x = 6 (int literal)" { send "c\n"} timeout { exit 1 }
-expect "${test_file}:3 vdbg> " { send "q\n" } timeout { exit 1 }
+expect "${test_file}:3 vdbg> "
+send "p x\n"
+expect "x = 5 (int literal)"
+send "c\n"
+expect "${test_file}:3 vdbg> "
+send "p x\n"
+expect "x = 6 (int literal)"
+send "c\n"
+expect "${test_file}:3 vdbg> "
+send "q\n"
 expect "7"
 expect "8"
 expect "9"

--- a/vlib/v/debug/tests/mut_arg.expect
+++ b/vlib/v/debug/tests/mut_arg.expect
@@ -1,8 +1,9 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] mut_arg in ${test_file}:10\r\n"
-expect "${test_file}:10 vdbg> " { send "p b\n" } timeout { exit 1 }
-expect "b = foo (&main.Test)" { send "q\n" } timeout { exit 1 }
+expect "Break on *main* test_mut in ${test_file}:10\r\n"
+expect "${test_file}:10 vdbg> "
+send "p b\n"
+expect "b = foo (&main.Test)"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/option_unwrap.expect
+++ b/vlib/v/debug/tests/option_unwrap.expect
@@ -1,9 +1,11 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] option_unwrap in ${test_file}:4\r\n"
-expect -ex "${test_file}:4 vdbg> " { send "p a\n" } timeout { exit 1 }
-expect -ex "a = Option(123) (?int)" { send "p b\n" } timeout { exit 1 }
-expect -ex "b = 123 (int)" { send "q\n" } timeout { exit 1 }
+expect "Break on * option_unwrap in ${test_file}:4\r\n"
+expect "${test_file}:4 vdbg> "
+send "p a\n"
+expect "a = Option(123) (?int)"
+send "p b\n"
+expect "b = 123 (int)"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/smartcast.expect
+++ b/vlib/v/debug/tests/smartcast.expect
@@ -1,8 +1,9 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] smartcast in ${test_file}:3"
-expect -ex "${test_file}:3 vdbg> " { send "p a\n" } timeout { exit 1 }
-expect -ex "a = 1 (int)" { send "q\n" } timeout { exit 1 }
+expect "Break on * smartcast in ${test_file}:3"
+expect "${test_file}:3 vdbg> "
+send "p a\n"
+expect "a = 1 (int)"
+send "q\n"
 expect eof

--- a/vlib/v/debug/tests/sumtype.expect
+++ b/vlib/v/debug/tests/sumtype.expect
@@ -1,10 +1,13 @@
 #!/usr/bin/env expect
-spawn [lindex $argv 0]
-set test_file [lindex $argv 1]
+source "common.tcl"
 
-expect -ex "Break on \[main\] sumtype in ${test_file}:17"
-expect -ex "${test_file}:17 vdbg> " { send "p a\n" } timeout { exit 1 }
-expect -ex "a = Test{\r\n    a: MySum(false)\r\n} (main.Test)" { send "c\n" } timeout { exit 1 }
-expect -ex "${test_file}:25 vdbg> " { send "p b\n" } timeout { exit 1 }
-expect -ex "b = Test{\r\n    a: MySum(1)\r\n} (main.Test)" { send "q\n" } timeout { exit 1 }
+expect "Break on * sumtype in ${test_file}:17"
+expect "${test_file}:17 vdbg> "
+send "p a\n"
+expect "a = Test{\r\n    a: MySum(false)\r\n} (main.Test)"
+send "c\n"
+expect "${test_file}:25 vdbg> "
+send "p b\n"
+expect "b = Test{\r\n    a: MySum(1)\r\n} (main.Test)"
+send "q\n"
 expect eof


### PR DESCRIPTION
* Make the output of `./v vlib/v/debug/interactive_test.v` be much less verbose by default,
while still keeping it verbose on the CI.
`./v vlib/v/debug/interactive_test.v` now looks like this (when there is no failure):
![image](https://github.com/vlang/v/assets/26967/a8dd3536-1ec2-43ba-8d9b-5469e150433e)

* When there is a failure, it will be printed, as well as the command, that can be used to reproduce it:
![image](https://github.com/vlang/v/assets/26967/4d7bf508-90ca-4110-b723-43bec7eca11a)

* Simplify the .expect files, extract the common parts into a common.tcl script, sourced by the rest.


