### PR TITLE
docs: fix link for `an example of a module that calls C code from V`

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6962,7 +6962,7 @@ To cast a `voidptr` to a V reference, use `user := &User(user_void_ptr)`.
 
 `voidptr` can also be dereferenced into a V struct through casting: `user := User(user_void_ptr)`.
 
-[an example of a module that calls C code from V](https://github.com/vlang/v/blob/master/vlib/v/tests/project_with_c_code/mod1/wrapper.v)
+[an example of a module that calls C code from V](https://github.com/vlang/v/blob/master/vlib/v/tests/project_with_c_code/mod1/wrapper.c.v)
 
 ### C Declarations
 


### PR DESCRIPTION
change from https://github.com/vlang/v/blob/master/vlib/v/tests/project_with_c_code/mod1/wrapper.v to https://github.com/vlang/v/blob/master/vlib/v/tests/project_with_c_code/mod1/wrapper.c.v