### PR TITLE
checker: fix non dereferenced enum in match statements (fixes #10045)

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -300,6 +300,7 @@ fn (mut c Checker) get_comptime_number_value(mut expr ast.Expr) ?i64 {
 fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSymbol) {
 	c.expected_type = node.expected_type
 	cond_sym := c.table.sym(node.cond_type)
+	mut enum_ref_checked := false
 	// branch_exprs is a histogram of how many times
 	// an expr was used in the match
 	mut branch_exprs := map[string]int{}
@@ -385,6 +386,13 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				}
 				ast.EnumVal {
 					key = expr.val
+					if !enum_ref_checked {
+						enum_ref_checked = true
+						if node.cond_type.is_ptr() {
+							c.error('missing `*` dereferencing `${node.cond}` in match statement',
+								node.cond.pos())
+						}
+					}
 				}
 				else {
 					key = (*expr).str()

--- a/vlib/v/checker/tests/match_enum_ref.out
+++ b/vlib/v/checker/tests/match_enum_ref.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_enum_ref.vv:6:3: error: missing `*` dereferencing `t` in match statement
+    4 | fn f(t &SomeType) ?int {
+    5 |     return match
+    6 |         t    // note the missing asterisk
+      |         ^
+    7 |             {
+    8 |                 .a {

--- a/vlib/v/checker/tests/match_enum_ref.vv
+++ b/vlib/v/checker/tests/match_enum_ref.vv
@@ -1,0 +1,18 @@
+enum SomeType {
+	a
+}
+fn f(t &SomeType) ?int {
+	return match
+		t	// note the missing asterisk
+			{
+				.a {
+					panic('This does not happen!')
+					3
+				}
+			}
+}
+fn main() {
+	t := SomeType.a
+	f(&t)?
+	assert false // should not happen, but does
+}


### PR DESCRIPTION
Add a check for non-dereferenced enum values when used in a match statement and a corresponding test.
This fixes issue #10045.