### PR TITLE
debug: fix variable dereferencing

### DIFF
--- a/vlib/v/debug/tests/mut_sumtype.expect
+++ b/vlib/v/debug/tests/mut_sumtype.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/env expect
+source "common.tcl"
+
+expect "Break on *main* test in ${test_file}:8\r\n"
+expect "${test_file}:8 vdbg> "
+send "p f\n"
+expect "f = Test(Test2{}) (main.Test)"
+expect "${test_file}:8 vdbg> "
+send "p t\n"
+expect "t = Test(Test2{}) (&main.Test)"
+expect "${test_file}:8 vdbg> "
+send "q\n"
+expect eof

--- a/vlib/v/debug/tests/mut_sumtype.vv
+++ b/vlib/v/debug/tests/mut_sumtype.vv
@@ -1,0 +1,14 @@
+struct Test2 {}
+
+struct Test3 {}
+
+type Test = Test2 | Test3
+
+fn (f Test) test(mut t Test) {
+	$dbg;
+}
+
+fn main() {
+	mut a := Test(Test2{})
+	a.test(mut a)
+}

--- a/vlib/v/debug/tests/option.expect
+++ b/vlib/v/debug/tests/option.expect
@@ -1,0 +1,35 @@
+#!/usr/bin/env expect
+source "common.tcl"
+
+expect "Break on *main* test in ${test_file}:8\r\n"
+expect "${test_file}:8 vdbg> "
+send "p f\n"
+expect "f = Test(Test2{}) (main.Test)"
+expect "${test_file}:8 vdbg> "
+send "p t\n"
+expect "t = Option(Test(Test2{})) (?main.Test)"
+expect "${test_file}:8 vdbg> "
+send "c\n"
+
+expect "${test_file}:16 vdbg> "
+send "p a\n"
+expect "a = Option(none) (?int)"
+expect "${test_file}:16 vdbg> "
+send "c\n"
+
+expect "${test_file}:16 vdbg> "
+send "p a\n"
+expect "a = Option(1) (?int)"
+expect "${test_file}:16 vdbg> "
+send "c\n"
+
+expect "${test_file}:12 vdbg> "
+send "p f\n"
+expect "f = Test(Test2{}) (main.Test)"
+expect "${test_file}:12 vdbg> "
+send "p t\n"
+expect "t = Option(none) (?&main.Test)"
+
+expect "${test_file}:12 vdbg> "
+send "q\n"
+expect eof

--- a/vlib/v/debug/tests/option.vv
+++ b/vlib/v/debug/tests/option.vv
@@ -1,0 +1,28 @@
+struct Test2 {}
+
+struct Test3 {}
+
+type Test = Test2 | Test3
+
+fn (f Test) test(t ?Test) {
+	$dbg;
+}
+
+fn (f Test) test2(t ?&Test) {
+	$dbg;
+}
+
+fn test_int(a ?int) {
+	$dbg;
+}
+
+fn main() {
+	mut a := ?Test(Test2{})
+	a?.test(a)
+
+	test_int(?int(none))
+	test_int(?int(1))
+
+	b := ?&Test(none)
+	a?.test2(b)
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4006,14 +4006,19 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 						values.write_string('${func}(*(${base_typ}*)${obj.name}.data)}')
 					} else {
 						_, str_method_expects_ptr, _ := cast_sym.str_method_info()
+
+						// eprintln(">> ${obj.name} | str expects ptr? ${str_method_expects_ptr} | ptr? ${var_typ.is_ptr()} || auto heap? ${obj.is_auto_heap} | auto deref? ${obj.is_auto_deref}")
 						deref := if str_method_expects_ptr && !obj.typ.is_ptr() {
 							'&'
+						} else if obj.is_auto_heap && var_typ.is_ptr() && str_method_expects_ptr {
+							'*'
+						} else if !obj.is_auto_heap && var_typ.is_ptr() && str_method_expects_ptr {
+							''
+						} else if obj.is_auto_heap && var_typ.is_ptr() {
+							'*'
 						} else if obj.typ.is_ptr() && !obj.is_auto_deref {
 							'&'
 						} else if obj.typ.is_ptr() && obj.is_auto_deref {
-							''
-						} else if obj.is_auto_heap
-							|| (!var_typ.has_flag(.option) && var_typ.is_ptr()) {
 							'*'
 						} else {
 							''

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4008,7 +4008,9 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 						_, str_method_expects_ptr, _ := cast_sym.str_method_info()
 
 						// eprintln(">> ${obj.name} | str expects ptr? ${str_method_expects_ptr} | ptr? ${var_typ.is_ptr()} || auto heap? ${obj.is_auto_heap} | auto deref? ${obj.is_auto_deref}")
-						deref := if str_method_expects_ptr && !obj.typ.is_ptr() {
+						deref := if var_typ.has_flag(.option) {
+							''
+						} else if str_method_expects_ptr && !obj.typ.is_ptr() {
 							'&'
 						} else if obj.is_auto_heap && var_typ.is_ptr() && str_method_expects_ptr {
 							'*'


### PR DESCRIPTION
Fix dereferencing of variable when passing to .str() which expects ptr.

```V
struct Test2 {}

struct Test3 {}

type Test = Test2 | Test3

fn (f Test) test(mut t Test) {
	$dbg;
}

fn main() {
	mut a := Test(Test2{})
	a.test(mut a)
}
```