### PR TITLE
sqlite: Functions thats returns the values resulting from a 'SELECT' query and name of column - Feature ISSUE #20565

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -1,5 +1,7 @@
 module sqlite
 
+import regex { regex_opt }
+
 $if freebsd || openbsd {
 	#flag -I/usr/local/include
 	#flag -L/usr/local/lib
@@ -83,6 +85,11 @@ pub fn (db &DB) str() string {
 pub struct Row {
 pub mut:
 	vals []string
+}
+
+pub struct QuerySet {
+pub mut:
+	vals map[string]string
 }
 
 //
@@ -246,6 +253,108 @@ pub fn (db &DB) exec(query string) ![]Row {
 		rows << row
 	}
 	return rows
+}
+
+@[manualfree]
+pub fn (db &DB) get_queryset(query string) ![]QuerySet {
+	query_lower := query.to_lower()
+
+	// 'select' syntax verified on: https://www.sqlite.org/lang_select.html and
+	// https://www.sqlite.org/syntax/join-clause.html
+	mut select_header := regex_opt(r'select((\s)+(all)|(distinct)(\s)+)|(\s)+')!
+	mut from := regex_opt(r'(\s)+from(\s)+')!
+
+	// This check eliminates queries that do not have the SELECT statement
+	if query_lower.count('select') == 1 {
+		// or do not include 'FROM', just like 'SELECT 1 + 1'
+		if select_header.matches_string(query_lower) && query_lower.contains(r'from') {
+			// The execution of this function indicates that the passed
+			// query is syntactically correct, which is why no additional verification
+			rows := db.exec(query)!
+
+			defer {
+				unsafe { rows.free() }
+			}
+
+			if rows.len == 0 {
+				return SQLError{
+					msg: 'No rows'
+					code: sqlite.sqlite_done
+				}
+			} else {
+				// Finding final index of select((\s)+(all)|(distinct)(\s)+)|(\s)+ inside query_lower string
+				_, end_select := select_header.match_string(query_lower)
+
+				// Finding initial and final index of (\s)+from(\s)+ inside query_lower string
+				init_from, end_from := from.find(query_lower)
+
+				// Get fields possibly separated by ',' like: select field_1, field_2 as f2, from table_name
+				fields := query.substr(end_select, init_from).split(',')
+
+				mut query_set := []QuerySet{}
+				mut tuple := map[string]string{}
+
+				if fields[0] == '*' {
+					table_name := query.substr(end_from, query.len).replace(';', '').split(' ')[0]
+
+					// Get all fields
+					all_columns_name := db.exec('pragma table_info(${table_name})')!
+
+					defer {
+						unsafe { all_columns_name.free() }
+					}
+
+					mut i := 0
+
+					for row in rows {
+						for i < row.vals.len {
+							// position 1 has a database column attribute
+							tuple[all_columns_name[i].vals[1]] = row.vals[i]
+							i++
+						}
+						i = 0
+
+						query_set << QuerySet{tuple}
+						tuple = map[string]string{}
+					}
+				} else {
+					mut i := 0
+
+					for row in rows {
+						for field in fields {
+							// verifying formats like:
+							// select column_1 as alias_column_1 from table_name  ->  alias creation with 'as'
+							// select column_1 alias_column_1 from table_name     ->  alias creationg without 'as'
+							// select column_1 from table_name -> with alias being column_1
+							all_field_alias := if field.contains('as') {
+								field.split('as')
+							} else {
+								field.split(' ')
+							}
+
+							alias := all_field_alias[all_field_alias.len - 1].replace(' ',
+								'')
+							tuple[alias] = row.vals[i]
+							i++
+						}
+
+						i = 0
+						query_set << QuerySet{tuple}
+						tuple = map[string]string{}
+					}
+				}
+
+				return query_set
+			}
+		} else {
+			return &SQLError{
+				msg: 'This is not a selection query'
+				code: sqlite.sqlite_done
+			}
+		}
+	} else {
+		return error('Subqueries are not supported!')
+	}
 }
 
 // exec_one executes a query on the given `db`.

--- a/vlib/db/sqlite/sqlite_test.v
+++ b/vlib/db/sqlite/sqlite_test.v
@@ -145,6 +145,12 @@ fn test_sqlite() {
 	db.get_queryset('select * from 	users	;') or { panic(err) }
 	assert db.get_affected_rows_count() == 1
 
+	db.get_queryset('select name,  id from 	users	;') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select name, id              from 	users;') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
 	db.close() or { panic(err) }
 	assert !db.is_open
 }

--- a/vlib/db/sqlite/sqlite_test.v
+++ b/vlib/db/sqlite/sqlite_test.v
@@ -79,6 +79,72 @@ fn test_sqlite() {
 	db.exec("delete from users where name='Sam'")!
 	assert db.get_affected_rows_count() == 1
 
+	db.get_queryset('SELECT * FROM users') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('Select * From users') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select * from users') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('SELECT		* FROM		users') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('Select		* From		users') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select		* from		users') or { panic(err) }
+	// assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('SELECT name, id FROM users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('Select name as n From users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select name n from users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('SELECT	name, id FROM 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('Select	name as name 	From users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select	name n from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('SELECT * FROM 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select id from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select id as i, name as n from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select id _id, name _n from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select max(id), name from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select max(id) as max, name from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select max(id) from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select max(id) max, name n from 	users WHERE id = 3') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select * from 	users;') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
+	db.get_queryset('select * from 	users	;') or { panic(err) }
+	assert db.get_affected_rows_count() == 1
+
 	db.close() or { panic(err) }
 	assert !db.is_open
 }


### PR DESCRIPTION
#### This pull request addresses the feature mentioned in issue #20565  and implements a function that returns the values resulting from a  'SELECT' query and the name of each column. If an alias is provided  either through the 'as' command or not, the returned value becomes  the alias.

['SELECT SYNTAX' - Documentation](https://www.sqlite.org/lang_select.html)
['JOIN SYNTAX' - Documentation](https://www.sqlite.org/syntax/join-clause.html)

[Source code](https://github.com/viniciusfdasilva/v/blob/master/vlib/db/sqlite/sqlite.c.v#L258-L358)

#### Examples:


#### All fields

```v
r := db.get_queryset('SELECT * FROM repository')! 
```

![query1](https://github.com/vlang/v/assets/32939036/ff8e770d-8ec2-492f-b5e1-5bf991c248da)


#### All names with explicit names

```v
r := db.get_queryset('SELECT name, id FROM repository')!
```

![query2](https://github.com/vlang/v/assets/32939036/33480ce4-b7dc-4ed2-a25e-5dc3a5dfe1ff)


#### All fields with alias

```v
r := db.get_queryset('SELECT name as n, id i FROM repository')!
```

![query3](https://github.com/vlang/v/assets/32939036/dd43bf8b-aa16-40f9-8150-6ed93ec0a4e3)


#### Specific field

```v
r := db.get_queryset('SELECT name FROM repository')! 
```

![query4](https://github.com/vlang/v/assets/32939036/754b0c6a-18e9-4ead-92ca-8570a4fa476c)


#### Specific field with alias and 'as'

```v
r := db.get_queryset('SELECT name as n FROM repository')! 
```

![query5e6](https://github.com/vlang/v/assets/32939036/f01ce3d3-9001-4753-86be-882ffcfe7914)


#### Specific field with alias without 'as'

```v
r := db.get_queryset('SELECT name n FROM repository')! 
```

![query5e6](https://github.com/vlang/v/assets/32939036/14511236-13f1-408b-8389-597f1a05760c)

#### All tests are in: `vlib/db/sqlite/sqlite_test.v`


#### OUTPUT TESTS

![test](https://github.com/vlang/v/assets/32939036/35ec042c-63be-4af9-bcbf-d04dfe844f31)
