### PR TITLE
json: fix struct with option enum field

### DIFF
--- a/vlib/json/json_decode_option_enum_test.v
+++ b/vlib/json/json_decode_option_enum_test.v
@@ -1,0 +1,18 @@
+import json
+
+enum Lang {
+	en = 1
+}
+
+struct Request {
+	lang ?Lang // ?string, ?int are ok
+}
+
+fn test_main() {
+	assert dump(json.decode(Request, '{}')!) == Request{
+		lang: ?Lang(none)
+	}
+	assert dump(json.decode(Request, '{"lang": "en"}')!) == Request{
+		lang: .en
+	}
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -673,7 +673,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				is_option_field := field.typ.has_flag(.option)
 				if field.typ.has_flag(.option) {
 					gen_js_get_opt(js_dec_name(field_type), field_type, styp, tmp, name, mut
-						dec, true)
+						dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp} && !cJSON_IsNull(jsonroot_${tmp})) {')
 				} else {
 					gen_js_get(styp, tmp, name, mut dec, is_required)


### PR DESCRIPTION
Fix #20593

```V
import json

enum Lang {
	en = 1
}

struct Request {
	lang ?Lang // ?string, ?int are ok
}

fn test_main() {
	assert dump(json.decode(Request, '{}')!) == Request{
		lang: ?Lang(none)
	}
	assert dump(json.decode(Request, '{"lang": "en"}')!) == Request{
		lang: .en
	}
}
```