### PR TITLE
vweb & x.vweb: fix typo in README documentation

### DIFF
--- a/vlib/vweb/csrf/README.md
+++ b/vlib/vweb/csrf/README.md
@@ -1,6 +1,6 @@
 # Cross-Site Request Forgery (CSRF) protection
 
-This module implements the [double submit cookie][owasp] technique to protect routes 
+This module implements the [double submit cookie][owasp] technique to protect routes
 from CSRF attacks.
 
 CSRF is a type of attack that occurs when a malicious program/website (and others) causes
@@ -17,11 +17,11 @@ isn't vulnerable to CSRF-attacks.
 
 ## Usage
 
-You can add `CsrfApp` to your own `App` struct to have the functions available 
-in your app's context, or you can use it with the middleware of vweb. 
+You can add `CsrfApp` to your own `App` struct to have the functions available
+in your app's context, or you can use it with the middleware of vweb.
 
 The advantage of the middleware approach is that you have to define
-the configuration separate from your `App`. This makes it possible to share the 
+the configuration separate from your `App`. This makes it possible to share the
 configuration between modules or controllers.
 
 ### Usage with the CsrfApp
@@ -143,7 +143,7 @@ index.html (the hidden input has changed)
 ```
 
 ### Protect all routes
-It is possible to protect all routes against CSRF-attacks. Every request that is not 
+It is possible to protect all routes against CSRF-attacks. Every request that is not
 defined as a [safe method](#safe-methods) (`GET`, `OPTIONS`, `HEAD` by default)
 will have CSRF-protection.
 
@@ -157,10 +157,10 @@ pub fn (mut app App) before_request() {
 ```
 
 ## How it works
-This module implements the [double submit cookie][owasp] technique: a random token 
+This module implements the [double submit cookie][owasp] technique: a random token
 is generated, the CSRF-token. The hmac of this token and the secret key is stored in a cookie.
 
-When a request is made, the CSRF-token should be placed inside a HTML form element. 
+When a request is made, the CSRF-token should be placed inside a HTML form element.
 The CSRF-token the hmac of the CSRF-token in the formdata is compared to the cookie.
 If the values match, the request is accepted.
 
@@ -175,14 +175,14 @@ This is a high level overview of the implementation.
 ## Security Considerations
 
 ### The secret key
-The secret key should be a random string that is not easily guessable. 
+The secret key should be a random string that is not easily guessable.
 The recommended size is 64 bytes.
 
 ### Sessions
 If your app supports some kind of user sessions, it is recommended to cryptographically
 bind the CSRF-token to the users' session. You can do that by providing the name
 of the session ID cookie. If an attacker changes the session ID in the cookie, in the
-token or both the hmac will be different adn the request will be rejected.
+token or both the hmac will be different and the request will be rejected.
 
 **Example**:
 ```v ignore
@@ -193,7 +193,7 @@ csrf_config = csrf.CsrfConfig{
 ```
 
 ### Safe Methods
-The HTTP methods `GET`, `OPTIONS`, `HEAD` are considered 
+The HTTP methods `GET`, `OPTIONS`, `HEAD` are considered
 [safe methods][mozilla-safe-methods] meaning they should not alter the state of
 an application. If a request with a "safe method" is made, the csrf protection will be skipped.
 
@@ -219,12 +219,12 @@ config := csrf.CsrfConfig{
 ```
 
 #### Referer, Origin header check
-In some cases (like if your server is behind a proxy), the Origin or Referer header will 
-not be present. If that is your case you can set `check_origin_and_referer` to `false`. 
+In some cases (like if your server is behind a proxy), the Origin or Referer header will
+not be present. If that is your case you can set `check_origin_and_referer` to `false`.
 Request will now be accepted when the Origin *or* Referer header is valid.
 
 ### Share csrf cookie with subdomains
-If you need to share the CSRF-token cookie with subdomains, you can set 
+If you need to share the CSRF-token cookie with subdomains, you can set
 `same_site` to `.same_site_lax_mode`.
 
 ## Configuration

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -664,7 +664,7 @@ app.register_controller[Example, Context]('example.com', '/', mut example_app)!
 
 vweb has a number of utility methods that make it easier to handle requests and send responses.
 These methods are available on `vweb.Context` and directly on your own context struct if you
-embed `vweb.Context`. Below are some of te most used methods, look at the
+embed `vweb.Context`. Below are some of the most used methods, look at the
 [standard library documentation](https://modules.vlang.io/) to see them all.
 
 ### Request methods

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -27,7 +27,7 @@ Use the `-prod` flag when building for production.
 
 ## Getting Started
 
-To start, you must import the module `x.vweb` and define a structure which will 
+To start, you must import the module `x.vweb` and define a structure which will
 represent your app and a structure which will represent the context of a request.
 These structures must be declared with the `pub` keyword.
 
@@ -77,7 +77,7 @@ fn main() {
 You can use the `App` struct for data you want to keep during the lifetime of your program,
 or for data that you want to share between different routes.
 
-A new `Context` struct is created every time a request is received, 
+A new `Context` struct is created every time a request is received,
 so it can contain different data for each request.
 
 ## Defining endpoints
@@ -181,7 +181,7 @@ If we visit http://localhost:port/hello/vaesel we would see the text `Hello vaes
 
 ### Routes with Parameter Arrays
 
-If you want multiple parameters in your route and if you want to parse the parameters 
+If you want multiple parameters in your route and if you want to parse the parameters
 yourself, or you want a wildcard route, you can add `...`  after the `:` and name,
 e.g. `@['/:path...']`.
 
@@ -202,9 +202,9 @@ You have direct access to query values by accessing the `query` field on your co
 You are also able to access any formdata or files that were sent
 with the request with the fields `.form` and `.files` respectively.
 
-In the following example, visiting http://localhost:port/user?name=Vweb we 
+In the following example, visiting http://localhost:port/user?name=Vweb we
 will see the text `Hello Vweb!`. And if we access the route without the `name` parameter,
-http://localhost:port/user, we will see the text `no user was found`, 
+http://localhost:port/user, we will see the text `no user was found`,
 
 **Example:**
 ```v ignore
@@ -265,7 +265,7 @@ pub fn (app &App) normal(mut ctx Context) vweb.Result {
 ```
 
 In this example we defined an endpoint with a parameter first. If we access our app
-on the url http://localhost:port/normal we will not see `from normal`, but 
+on the url http://localhost:port/normal we will not see `from normal`, but
 `from with_parameter, path: "normal"`.
 
 ### Custom not found page
@@ -333,7 +333,7 @@ fn main() {
 }
 ```
 
-If we start the app with `v run main.v` we can access our `main.css` file at 
+If we start the app with `v run main.v` we can access our `main.css` file at
 http://localhost:8080/static/css/main.css
 
 ### Mounting folders at specific locations
@@ -406,7 +406,7 @@ pub struct App {
 
 ### Use case
 
-We could, for example, get the cookies for an HTTP request and check if the user has already 
+We could, for example, get the cookies for an HTTP request and check if the user has already
 accepted our cookie policy. Let's modify our Context struct to store whether the user has
 accepted our policy or not.
 
@@ -422,7 +422,7 @@ pub mut:
 In vweb middleware functions take a `mut` parameter with the type of your context struct
 and must return `bool`. We have full access to modify our Context struct!
 
-The return value indicates to vweb whether it can continue or has to stop. If we send a 
+The return value indicates to vweb whether it can continue or has to stop. If we send a
 response to the client in a middleware function vweb has to stop, so we return `false`.
 
 **Example:**
@@ -472,7 +472,7 @@ fn main() {
 
 ### Types of middleware
 
-In the previous example we used so called "global" middleware. This type of middleware 
+In the previous example we used so called "global" middleware. This type of middleware
 applies to every endpoint defined on our app struct; global. It is also possible
 to register middleware for only a certain route(s).
 
@@ -523,8 +523,8 @@ Vweb will handle requests in the following order:
 4. Execute global "after" middleware
 5. Execute "after" middleware that matches the requested route
 
-In each step, except for step `3`, vweb will evaluate the middleware in the order that 
-they are registered; when you call `app.use` or `app.route_use`. 
+In each step, except for step `3`, vweb will evaluate the middleware in the order that
+they are registered; when you call `app.use` or `app.route_use`.
 
 ### Early exit
 
@@ -555,7 +555,7 @@ Because we register `early_exit` before `logger` our logging middleware will nev
 
 Controllers can be used to split up your app logic so you are able to have one struct
 per "route group".  E.g. a struct `Admin` for urls starting with `'/admin'` and a struct `Foo`
-for urls starting with `'/foo'`. 
+for urls starting with `'/foo'`.
 
 To use controllers we have to embed `vweb.Controller` on
 our app struct and when we register a controller we also have to specify
@@ -622,8 +622,8 @@ pub fn (app &Admin) path(mut ctx Context) vweb.Result {
     return ctx.text('Admin')
 }
 ```
-When we registerted the controller with 
-`app.register_controller[Admin, Context]('/admin', mut admin_app)!` 
+When we registerted the controller with
+`app.register_controller[Admin, Context]('/admin', mut admin_app)!`
 we told vweb that the namespace of that controller is `'/admin'` so in this example we would
 see the text "Admin" if we navigate to the url `'/admin/path'`.
 
@@ -664,7 +664,7 @@ app.register_controller[Example, Context]('example.com', '/', mut example_app)!
 
 vweb has a number of utility methods that make it easier to handle requests and send responses.
 These methods are available on `vweb.Context` and directly on your own context struct if you
-embed `vweb.Context`. Below are some of te most used methods, look at the 
+embed `vweb.Context`. Below are some of te most used methods, look at the
 [standard library documentation](https://modules.vlang.io/) to see them all.
 
 ### Request methods
@@ -695,7 +695,7 @@ pub fn (app &App) index(mut ctx Context) vweb.Result {
 
 ### Response methods
 
-You can directly modify the HTTP response by changing the `res` field, 
+You can directly modify the HTTP response by changing the `res` field,
 which is of the type `http.Response`.
 
 #### Send response with different MIME types
@@ -798,7 +798,7 @@ error with a message.
 
 ## Advanced usage
 
-If you need more controll over the TCP connection with a client, for example when 
+If you need more controll over the TCP connection with a client, for example when
 you want to keep the connection open. You can call `ctx.takeover_conn`.
 
 When this function is called you are free to do anything you want with the TCP
@@ -807,9 +807,9 @@ sending a response over the connection and closing it.
 
 ### Empty Result
 
-Sometimes you want to send the response in another thread, for example when using 
+Sometimes you want to send the response in another thread, for example when using
 [Server Sent Events](sse/README.md). When you are sure that a response will be sent
-over the TCP connection you can return `vweb.no_result()`. This function does nothinng
+over the TCP connection you can return `vweb.no_result()`. This function does nothing
 and returns an empty `vweb.Result` struct, letting vweb know that we sent a response ourself.
 
 > **Note:**

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -622,7 +622,7 @@ pub fn (app &Admin) path(mut ctx Context) vweb.Result {
     return ctx.text('Admin')
 }
 ```
-When we registerted the controller with
+When we registered the controller with
 `app.register_controller[Admin, Context]('/admin', mut admin_app)!`
 we told vweb that the namespace of that controller is `'/admin'` so in this example we would
 see the text "Admin" if we navigate to the url `'/admin/path'`.

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -9,7 +9,7 @@ features.
 - **Easy to deploy** just one binary file that also includes all templates. No need to install any
   dependencies.
 - **Templates are precompiled** all errors are visible at compilation time, not at runtime.
-- **Middleware** functionality similair to other big frameworks.
+- **Middleware** functionality similar to other big frameworks.
 - **Controllers** to split up your apps logic.
 
 ## Quick Start

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -798,7 +798,7 @@ error with a message.
 
 ## Advanced usage
 
-If you need more controll over the TCP connection with a client, for example when
+If you need more control over the TCP connection with a client, for example when
 you want to keep the connection open. You can call `ctx.takeover_conn`.
 
 When this function is called you are free to do anything you want with the TCP

--- a/vlib/x/vweb/csrf/README.md
+++ b/vlib/x/vweb/csrf/README.md
@@ -1,6 +1,6 @@
 # Cross-Site Request Forgery (CSRF) protection
 
-This module implements the [double submit cookie][owasp] technique to protect routes 
+This module implements the [double submit cookie][owasp] technique to protect routes
 from CSRF attacks.
 
 CSRF is a type of attack that occurs when a malicious program/website (and others) causes
@@ -17,8 +17,8 @@ isn't vulnerable to CSRF-attacks.
 
 ## Usage
 
-To enable CSRF-protection for your vweb app you must embed the `CsrfContext` struct 
-on your `Context` struct. You must also provide configuration options 
+To enable CSRF-protection for your vweb app you must embed the `CsrfContext` struct
+on your `Context` struct. You must also provide configuration options
 (see [configuration & security](#configuration--security-considerations)).
 
 **Example:**
@@ -64,7 +64,7 @@ fn main() {
 ### Setting the token
 
 For the CSRF-protection to work we have to generate an anti-CSRF token and set it
-as an hidden input field on any form that will be submitted to the route we 
+as an hidden input field on any form that will be submitted to the route we
 want to protect.
 
 **Example:**
@@ -97,12 +97,12 @@ fn (app &App) login(mut ctx, password string) vweb.Result {
 </form>
 ```
 
-If we run the app with `v run main.v` and navigate to `http://localhost:8080/` 
+If we run the app with `v run main.v` and navigate to `http://localhost:8080/`
 we will see the login form and we can login using the password "password".
 
 If we remove the hidden input, by removing the line `@{ctx.csrf_token_input()}`
 from our html code we will see an error message indicating that the CSRF token
-is not set or invalid! By default the CSRF module sends an HTTP-403 response when 
+is not set or invalid! By default the CSRF module sends an HTTP-403 response when
 a token is invalid, if you want to send a custom response see the
 [advanced usage](#advanced-usage) section.
 
@@ -113,7 +113,7 @@ a token is invalid, if you want to send a custom response see the
 ## Advanced Usage
 
 If you want more control over what routes are protected or what action you want to
-do when a CSRF-token is invalid, you can call `csrf.protect`  yourself whenever you want 
+do when a CSRF-token is invalid, you can call `csrf.protect`  yourself whenever you want
 to protect a route against CSRF attacks. This function returns `false` if the current CSRF token
 and cookie combination is not valid.
 
@@ -150,10 +150,10 @@ ctx.clear_csrf_token()
 ```
 
 ## How it works
-This module implements the [double submit cookie][owasp] technique: a random token 
+This module implements the [double submit cookie][owasp] technique: a random token
 is generated, the CSRF-token. The hmac of this token and the secret key is stored in a cookie.
 
-When a request is made, the CSRF-token should be placed inside a HTML form element. 
+When a request is made, the CSRF-token should be placed inside a HTML form element.
 The CSRF-token the hmac of the CSRF-token in the formdata is compared to the cookie.
 If the values match, the request is accepted.
 
@@ -161,7 +161,7 @@ This approach has the advantage of being stateless: there is no need to store to
 side and validate them. The token and cookie are bound cryptographically to each other so
 an attacker would need to know both values in order to make a CSRF-attack succeed. That
 is why is it important to **not leak the CSRF-token** via an url, or some other way. This is way
-by default the `HTTPOnlye` flag on the cookie is set to true.
+by default the `HTTPOnly` flag on the cookie is set to true.
 See [client side CSRF][client-side-csrf] for more information.
 
 This is a high level overview of the implementation.
@@ -169,7 +169,7 @@ This is a high level overview of the implementation.
 ## Configuration & Security Considerations
 
 ### The secret key
-The secret key should be a random string that is not easily guessable. 
+The secret key should be a random string that is not easily guessable.
 
 ### Sessions
 If your app supports some kind of user sessions, it is recommended to cryptographically
@@ -186,7 +186,7 @@ csrf_config = csrf.CsrfConfig{
 ```
 
 ### Safe Methods
-The HTTP methods `GET`, `OPTIONS`, `HEAD` are considered 
+The HTTP methods `GET`, `OPTIONS`, `HEAD` are considered
 [safe methods][mozilla-safe-methods] meaning they should not alter the state of
 an application. If a request with a "safe method" is made, the csrf protection will be skipped.
 
@@ -212,12 +212,12 @@ config := csrf.CsrfConfig{
 ```
 
 #### Referer, Origin header check
-In some cases (like if your server is behind a proxy), the Origin or Referer header will 
-not be present. If that is your case you can set `check_origin_and_referer` to `false`. 
+In some cases (like if your server is behind a proxy), the Origin or Referer header will
+not be present. If that is your case you can set `check_origin_and_referer` to `false`.
 Request will now be accepted when the Origin *or* Referer header is valid.
 
 ### Share csrf cookie with subdomains
-If you need to share the CSRF-token cookie with subdomains, you can set 
+If you need to share the CSRF-token cookie with subdomains, you can set
 `same_site` to `.same_site_lax_mode`.
 
 ## Configuration

--- a/vlib/x/vweb/csrf/README.md
+++ b/vlib/x/vweb/csrf/README.md
@@ -175,7 +175,7 @@ The secret key should be a random string that is not easily guessable.
 If your app supports some kind of user sessions, it is recommended to cryptographically
 bind the CSRF-token to the users' session. You can do that by providing the name
 of the session ID cookie. If an attacker changes the session ID in the cookie, in the
-token or both the hmac will be different adn the request will be rejected.
+token or both the hmac will be different and the request will be rejected.
 
 **Example**:
 ```v ignore

--- a/vlib/x/vweb/sse/README.md
+++ b/vlib/x/vweb/sse/README.md
@@ -49,7 +49,7 @@ Javascript code:
 const eventSource = new EventSource('/sse');
 
 eventSource.addEventListener('message', (event) => {
-	console.log('received mesage:', event.data);
+	console.log('received message:', event.data);
 });
 
 eventSource.addEventListener('close', () => {

--- a/vlib/x/vweb/sse/README.md
+++ b/vlib/x/vweb/sse/README.md
@@ -7,14 +7,14 @@ for detailed description of the protocol, and a simple web browser client exampl
 
 ## Usage
 
-With SSE we want to keep the connection open, so we are able to 
+With SSE we want to keep the connection open, so we are able to
 keep sending events to the client. But if we hold the connection open indefinitely
-vweb isn't able to process any other requests. 
+vweb isn't able to process any other requests.
 
-We can let vweb know that it can continue processing other requests and that we will 
+We can let vweb know that it can continue processing other requests and that we will
 handle the connection ourself by calling `ctx.takeover_conn()` and and returning an empty result
 with `vweb.no_result()`. Vweb will not close the connection and we can handle
-the connection in a seperate thread.
+the connection in a separate thread.
 
 **Example:**
 ```v ignore


### PR DESCRIPTION
remove unused whitespace and fix typo:

vweb.csrf: 
- adn -> and

x.vweb:
- nothinng -> nothing
- controll -> control
- te -> the
- registerted -> registered
- similair -> similar

x.vweb.csrf:
- HTTPOnlye -> HTTPOnly
- adn -> and

x.vweb.sse:
- seperate -> separate
- mesage -> message