### PR TITLE
examples: [flappylearning] fix link for image flappy.png

### DIFF
--- a/examples/flappylearning/README.md
+++ b/examples/flappylearning/README.md
@@ -7,7 +7,7 @@ flappy learning implemented by vlang
 v run game.v
 ```
 
-![flappy.png](img/flappy.png)
+![flappy.png](assets/img/flappy.png)
 
 ## thanks
 https://github.com/xviniette/FlappyLearning


### PR DESCRIPTION
change from https://github.com/vlang/v/blob/master/examples/flappylearning/img/flappy.png to https://github.com/vlang/v/blob/master/examples/flappylearning/assets/img/flappy.png