### PR TITLE
os(windows): Fix `win_spawn_process` not using `stdout pipe` in `cmd` console

### DIFF
--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -80,7 +80,7 @@ fn (mut p Process) win_spawn_process() int {
 		lp_reserved: unsafe { nil }
 		lp_desktop: unsafe { nil }
 		lp_title: unsafe { nil }
-		cb: sizeof(C.PROCESS_INFORMATION)
+		cb: sizeof(StartupInfo)
 	}
 	if p.use_stdio_ctl {
 		mut sa := SecurityAttributes{}


### PR DESCRIPTION
According to Microsoft documentation [ns-processthreadsapi-startupinfow](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow), `cb` is the size of the structure(_STARTUPINFOW), in bytes.

Run the following test code `test-process.v` under the `cmd` console:
```
import os

fn main() {
    mut process := os.new_process('v')
    process.set_args(['-v'])
    process.set_redirect_stdio()
    process.wait()

//  println('process : ${process}')

    println('filename         : ${process.filename          }')
    println('pid              : ${process.pid               }')
    println('code             : ${process.code              }')
    println('status           : ${process.status            }')
    println('err              : ${process.err               }')
    println('args             : ${process.args              }')
    println('work_folder      : ${process.work_folder       }')
    println('env_is_custom    : ${process.env_is_custom     }')
//  println('env              : ${process.env               }')
    println('use_stdio_ctl    : ${process.use_stdio_ctl     }')
    println('use_pgroup       : ${process.use_pgroup        }')
    println('stdio_fd         : ${process.stdio_fd          }')
    println('wdata            : ${process.wdata             }')
    println('create_no_window : ${process.create_no_window  }')

    if process.use_stdio_ctl {
      println('stdout           : ${process.stdout_slurp()    }')
      println('stderr           : ${process.stderr_slurp()    }')
    }

    process.close()
}

```
Before fixing:
```
# v run ..\..\test-process.v
V 0.4.4 ac2dcc2
filename         : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.4\v
pid              : 11296
code             : 0
status           : exited
err              :
args             : ['-v']
work_folder      :
env_is_custom    : false
use_stdio_ctl    : true
use_pgroup       : false
stdio_fd         : [-1, -1, -1]
wdata            : 2c80000
create_no_window : false
stdout           :
stderr           :
```
After modification:
```
# v run ..\..\test-process.v
filename         : D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-0.4.4\v
pid              : 3472
code             : 0
status           : exited
err              :
args             : ['-v']
work_folder      :
env_is_custom    : false
use_stdio_ctl    : true
use_pgroup       : false
stdio_fd         : [-1, -1, -1]
wdata            : 2d20000
create_no_window : false
stdout           : V 0.4.4 ac2dcc2

stderr           :
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
