### PR TITLE
docs: update range `for`: 0-based index rationale

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2058,6 +2058,15 @@ for i in 0 .. 5 {
 `low..high` means an *exclusive* range, which represents all values
 from `low` up to *but not including* `high`.
 
+> [!NOTE]
+> This exclusive range notation and zero-based indexing follow principles of
+logical consistency and error reduction. As Edsger W. Dijkstra outlines in
+'Why Numbering Should Start at Zero' ([EWD831](https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html)), zero-based indexing aligns the 
+index with the preceding elements in a sequence, simplifying handling and 
+minimizing errors, especially with adjacent subsequences. This logical and 
+efficient approach shapes our language design, emphasizing clarity and reducing 
+confusion in programming.
+
 #### Condition `for`
 
 ```v

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2061,7 +2061,9 @@ from `low` up to *but not including* `high`.
 > [!NOTE]
 > This exclusive range notation and zero-based indexing follow principles of
 logical consistency and error reduction. As Edsger W. Dijkstra outlines in
-'Why Numbering Should Start at Zero' ([EWD831](https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html)), zero-based indexing aligns the 
+'Why Numbering Should Start at Zero' 
+([EWD831](https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html)), 
+zero-based indexing aligns the 
 index with the preceding elements in a sequence, simplifying handling and 
 minimizing errors, especially with adjacent subsequences. This logical and 
 efficient approach shapes our language design, emphasizing clarity and reducing 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -2061,13 +2061,12 @@ from `low` up to *but not including* `high`.
 > [!NOTE]
 > This exclusive range notation and zero-based indexing follow principles of
 logical consistency and error reduction. As Edsger W. Dijkstra outlines in
-'Why Numbering Should Start at Zero' 
+'Why Numbering Should Start at Zero'
 ([EWD831](https://www.cs.utexas.edu/users/EWD/transcriptions/EWD08xx/EWD831.html)), 
-zero-based indexing aligns the 
-index with the preceding elements in a sequence, simplifying handling and 
-minimizing errors, especially with adjacent subsequences. This logical and 
-efficient approach shapes our language design, emphasizing clarity and reducing 
-confusion in programming.
+zero-based indexing aligns the index with the preceding elements in a sequence,
+simplifying handling and minimizing errors, especially with adjacent subsequences.
+This logical and efficient approach shapes our language design, emphasizing clarity
+and reducing confusion in programming.
 
 #### Condition `for`
 


### PR DESCRIPTION
Added a note to the Range `for` section in the documentation to explain the rationale behind using exclusive range notation and zero-based indexing. From spytheman in Discord https://discord.com/channels/592103645835821068/592115457029308427/1194711919572033576, This update references Edsger W. Dijkstra's 'Why Numbering Should Start at Zero' to provide theoretical backing and clarity on this design choice.