### PR TITLE
io: ensure BufferedReader.read_line() returns io.Eof

### DIFF
--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -112,7 +112,7 @@ pub fn (r BufferedReader) end_of_stream() bool {
 // the end of stream.
 pub fn (mut r BufferedReader) read_line() !string {
 	if r.end_of_stream {
-		return error('none')
+		return Eof{}
 	}
 	mut line := []u8{}
 	for {
@@ -122,7 +122,7 @@ pub fn (mut r BufferedReader) read_line() !string {
 				// We are at the end of the stream
 				if line.len == 0 {
 					// we had nothing so return nothing
-					return error('none')
+					return Eof{}
 				}
 				return line.bytestr()
 			}
@@ -148,5 +148,5 @@ pub fn (mut r BufferedReader) read_line() !string {
 		line << r.buf[r.offset..i]
 		r.offset = i
 	}
-	return error('none')
+	return Eof{}
 }

--- a/vlib/io/custom_string_reading_test.v
+++ b/vlib/io/custom_string_reading_test.v
@@ -55,3 +55,23 @@ pub fn test_reading_from_a_string() {
 		assert read_from_string(large_string, capacity) == large_string_bytes
 	}
 }
+
+pub fn test_buffered_reader_readline() {
+	text := 'hello\nworld'
+	want := text.split_into_lines()
+	mut str := StringReader{
+		text: text
+	}
+	mut stream := io.new_buffered_reader(reader: str)
+	mut buf := []u8{len: 1}
+	mut i := 0
+	for {
+		line := stream.read_line() or {
+			assert err is io.Eof
+			break
+		}
+		assert i < want.len
+		assert want[i] == line
+		i++
+	}
+}


### PR DESCRIPTION
BufferedReader.read_line() used to return `error('none')` upon reaching the end of the stream instead return `io.Eof`.