### PR TITLE
examples/term.ui: add casts to term.ui functions to satisfy stricter type checking

### DIFF
--- a/examples/term.ui/cursor_chaser.v
+++ b/examples/term.ui/cursor_chaser.v
@@ -82,12 +82,15 @@ fn event(e &tui.Event, mut app App) {
 	}
 }
 
+type EventFn = fn (&tui.Event, voidptr)
+type FrameFn = fn (voidptr)
+
 fn main() {
 	mut app := &App{}
 	app.tui = tui.init(
 		user_data: app
-		frame_fn: frame
-		event_fn: event
+		frame_fn: FrameFn(frame)
+		event_fn: EventFn(event)
 		hide_cursor: true
 	)
 	app.tui.run()!

--- a/examples/term.ui/cursor_chaser.v
+++ b/examples/term.ui/cursor_chaser.v
@@ -83,6 +83,7 @@ fn event(e &tui.Event, mut app App) {
 }
 
 type EventFn = fn (&tui.Event, voidptr)
+
 type FrameFn = fn (voidptr)
 
 fn main() {

--- a/examples/term.ui/event_viewer.v
+++ b/examples/term.ui/event_viewer.v
@@ -30,11 +30,13 @@ fn event(e &tui.Event, mut app App) {
 	}
 }
 
+type EventFn = fn (&tui.Event, voidptr)
+
 fn main() {
 	mut app := &App{}
 	app.tui = tui.init(
 		user_data: app
-		event_fn: event
+		event_fn: EventFn(event)
 		window_title: 'V term.ui event viewer'
 		hide_cursor: true
 		capture_events: true

--- a/examples/term.ui/pong.v
+++ b/examples/term.ui/pong.v
@@ -481,8 +481,11 @@ fn event(e &ui.Event, mut app App) {
 }
 
 type InitFn = fn (voidptr)
+
 type EventFn = fn (&ui.Event, voidptr)
+
 type FrameFn = fn (voidptr)
+
 type CleanupFn = fn (voidptr)
 
 fn main() {

--- a/examples/term.ui/pong.v
+++ b/examples/term.ui/pong.v
@@ -480,14 +480,19 @@ fn event(e &ui.Event, mut app App) {
 	app.event(e)
 }
 
+type InitFn = fn (voidptr)
+type EventFn = fn (&ui.Event, voidptr)
+type FrameFn = fn (voidptr)
+type CleanupFn = fn (voidptr)
+
 fn main() {
 	mut app := &App{}
 	app.tui = ui.init(
 		user_data: app
-		init_fn: init
-		frame_fn: frame
-		cleanup_fn: cleanup
-		event_fn: event
+		init_fn: InitFn(init)
+		frame_fn: FrameFn(frame)
+		cleanup_fn: CleanupFn(cleanup)
+		event_fn: EventFn(event)
 		fail_fn: fail
 		capture_events: true
 		hide_cursor: true

--- a/examples/term.ui/rectangles.v
+++ b/examples/term.ui/rectangles.v
@@ -82,12 +82,15 @@ fn frame(mut app App) {
 	app.redraw = false
 }
 
+type EventFn = fn (&tui.Event, voidptr)
+type FrameFn = fn (voidptr)
+
 fn main() {
 	mut app := &App{}
 	app.tui = tui.init(
 		user_data: app
-		event_fn: event
-		frame_fn: frame
+		event_fn: EventFn(event)
+		frame_fn: FrameFn(frame)
 		hide_cursor: true
 		frame_rate: 60
 	)

--- a/examples/term.ui/rectangles.v
+++ b/examples/term.ui/rectangles.v
@@ -83,6 +83,7 @@ fn frame(mut app App) {
 }
 
 type EventFn = fn (&tui.Event, voidptr)
+
 type FrameFn = fn (voidptr)
 
 fn main() {

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -109,12 +109,15 @@ mut:
 	y int
 }
 
+type EventFn = fn (&ui.Event, voidptr)
+type FrameFn = fn (voidptr)
+
 fn main() {
 	mut app := &App{}
 	app.ui = ui.init(
 		user_data: app
-		frame_fn: frame
-		event_fn: event
+		frame_fn: FrameFn(frame)
+		event_fn: EventFn(event)
 		frame_rate: frame_rate
 		hide_cursor: true
 		window_title: 'V terminal pixelart drawing app'

--- a/examples/term.ui/term_drawing.v
+++ b/examples/term.ui/term_drawing.v
@@ -110,6 +110,7 @@ mut:
 }
 
 type EventFn = fn (&ui.Event, voidptr)
+
 type FrameFn = fn (voidptr)
 
 fn main() {

--- a/examples/term.ui/text_editor.v
+++ b/examples/term.ui/text_editor.v
@@ -630,7 +630,9 @@ fn event(e &tui.Event, mut a App) {
 }
 
 type InitFn = fn (voidptr)
+
 type EventFn = fn (&tui.Event, voidptr)
+
 type FrameFn = fn (voidptr)
 
 fn main() {

--- a/examples/term.ui/text_editor.v
+++ b/examples/term.ui/text_editor.v
@@ -629,6 +629,10 @@ fn event(e &tui.Event, mut a App) {
 	}
 }
 
+type InitFn = fn (voidptr)
+type EventFn = fn (&tui.Event, voidptr)
+type FrameFn = fn (voidptr)
+
 fn main() {
 	mut files := []string{}
 	if os.args.len > 1 {
@@ -639,9 +643,9 @@ fn main() {
 	}
 	a.tui = tui.init(
 		user_data: a
-		init_fn: init
-		frame_fn: frame
-		event_fn: event
+		init_fn: InitFn(init)
+		frame_fn: FrameFn(frame)
+		event_fn: EventFn(event)
 		capture_events: true
 	)
 	a.tui.run()!

--- a/examples/term.ui/vyper.v
+++ b/examples/term.ui/vyper.v
@@ -457,7 +457,9 @@ fn (mut a App) draw_gameover() {
 }
 
 type InitFn = fn (voidptr)
+
 type EventFn = fn (&termui.Event, voidptr)
+
 type FrameFn = fn (voidptr)
 
 fn main() {

--- a/examples/term.ui/vyper.v
+++ b/examples/term.ui/vyper.v
@@ -456,13 +456,17 @@ fn (mut a App) draw_gameover() {
 	a.termui.draw_text(start_x, (a.height / 2) + 3 * block_size, '   #####  #    # #    # ######   #######   ##   ###### #    #  ')
 }
 
+type InitFn = fn (voidptr)
+type EventFn = fn (&termui.Event, voidptr)
+type FrameFn = fn (voidptr)
+
 fn main() {
 	mut app := &App{}
 	app.termui = termui.init(
 		user_data: app
-		event_fn: event
-		frame_fn: frame
-		init_fn: init
+		event_fn: EventFn(event)
+		frame_fn: FrameFn(frame)
+		init_fn: InitFn(init)
 		hide_cursor: true
 		frame_rate: 10
 	)


### PR DESCRIPTION
When using clang version 14, the function types for init_fn, frame_fn, event_fn, and cleanup_fn were not strictly enforced and the example programs in examples/term.ui would all compile.

With clang version 16, these function types are strictly checked and the added type definitions clean up the errors.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
