### PR TITLE
os: Fix File.read() in JS backends [Issue : #20501]

### DIFF
--- a/vlib/os/file.js.v
+++ b/vlib/os/file.js.v
@@ -84,9 +84,10 @@ pub fn (f &File) read(mut buf []u8) !int {
 	}
 	mut nbytes := 0
 	#try {
-	#let buffer = $fs.readFileSync(f.val.fd.valueOf());
+	#let readBuffer = Buffer.alloc(buf.val.len.valueOf());
+	#nbytes = $fs.readSync(f.val.fd.valueOf(), readBuffer, 0, buf.val.len.valueOf(), null);
 	#
-	#for (const val of buffer.values()) { buf.val.arr.arr[nbytes++] = new u8(val); }
+	#for (let i = 0; i < nbytes; i++) { buf.val.arr.arr[i] = new u8(readBuffer[i]); }
 	#}
 	#catch (e) { return error('' + e); }
 

--- a/vlib/os/file.js.v
+++ b/vlib/os/file.js.v
@@ -86,7 +86,7 @@ pub fn (f &File) read(mut buf []u8) !int {
 	#try {
 	#let buffer = $fs.readFileSync(f.val.fd.valueOf());
 	#
-	#for (const val of buffer.values()) { buf.arr[nbytes++] = val; }
+	#for (const val of buffer.values()) { buf.val.arr.arr[nbytes++] = new u8(val); }
 	#}
 	#catch (e) { return error('' + e); }
 

--- a/vlib/os/open_and_read_from_file_test.js.v
+++ b/vlib/os/open_and_read_from_file_test.js.v
@@ -1,0 +1,8 @@
+import os
+
+fn test_read_from_file() {
+	mut buf := []u8{len: 10}
+	f := os.open(@FILE)!
+	n := f.read(mut &buf)!
+	println(buf[..n])
+}


### PR DESCRIPTION
Fixed #20501 File.read() function for the JavaScript backend. 

The issue was due to incorrect array access in the JavaScript generated from V code.

To respond at ticket expectation : 

- _Using the js backend: expected to either read a non-zero amount of bytes, or raise an error._

The original function already includes a try-catch block to manage errors. Unless specifically requested, I don't plan to add additional error handling

_- Using the js_browser: expected to either fail compilation (since File I/O is unavailable in the browser), or for os.open() to always return an error._

the existing code already handles errors. If **open_file()** is called in a non-NodeJS environment, an error is generated. However, it appears that the test in ticket was conducted using Node.js, which could explain the observed results.

I'm always available for any suggestions/modifications.