### PR TITLE
orm, cgen: fix or_block missing when insert multi-association tables(fix #20017 #20019)

### DIFF
--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -473,6 +473,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			unsafe { fff.free() }
 			g.write_orm_insert_with_last_ids(arr, connection_var_name, g.get_table_name_by_struct_type(arr.table_expr.typ),
 				last_ids, res_, id_name, fkeys[i], or_expr)
+			g.or_block(res_, or_expr, ast.int_type.set_flag(.result))
 			g.indent--
 			g.writeln('}')
 		}


### PR DESCRIPTION
1. Fixed:
#20017
#20019
2. Add tests.

```
import db.sqlite

struct Master {
	id       int      @[primary]
	children []Detail @[fkey: parent_id]
}

struct Detail {
	id        int @[primary]
	parent_id int
}

fn main() {
	db := sqlite.connect(':memory:')!

	sql db {
		create table Master
	}!
	// The Detail table is intentionally not created
	// sql db {
	// 	create table Detail
	// }!

	new_master := Master{
		id: 1
		children: [Detail{
			id: 1
			parent_id: 1
		}]
	}
	sql db {
		insert new_master into Master
	} or {
		println(err)
		assert true
		return
	}
	assert false
}
```
outputs:
```
db.sqlite.SQLError: no such table: Detail (1) (INSERT INTO `Detail` (`id`, `parent_id`) VALUES (?1, ?2);); code: 1
```