### PR TITLE
v.gen.c: support inter-dependent function types

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1515,11 +1515,7 @@ static inline void __${sym.cname}_pushval(${sym.cname} ch, ${push_arg} val) {
 			g.write_alias_typesymbol_declaration(sym)
 		}
 	}
-	for sym in g.table.type_symbols {
-		if sym.kind == .function && sym.name !in c.builtins {
-			g.write_fn_typesymbol_declaration(sym)
-		}
-	}
+	g.write_sorted_fn_typesymbol_declaration()
 	// Generating interfaces after all the common types have been defined
 	// to prevent generating interface struct before definition of field types
 	for sym in g.table.type_symbols {
@@ -6367,6 +6363,63 @@ fn (mut g Gen) sort_globals_consts() {
 			if node.value == order {
 				g.sorted_global_const_names << node.name
 			}
+		}
+	}
+}
+
+// sort functions by dependent arguments and return value
+// As functions may depend on one another, make sure they are
+// defined in the correct order: add non dependent ones first.
+fn (mut g Gen) write_sorted_fn_typesymbol_declaration() {
+	util.timing_start(@METHOD)
+	defer {
+		util.timing_measure(@METHOD)
+	}
+	mut syms := []&ast.TypeSymbol{} // functions to be defined
+	for sym in g.table.type_symbols {
+		if sym.kind == .function && sym.name !in c.builtins {
+			syms << sym
+		}
+	}
+	mut pending := []&ast.TypeSymbol{} // functions with a dependency
+	for {
+		// Add non dependent functions or functions which
+		// dependency has been added.
+		next: for sym in syms {
+			info := sym.info as ast.FnType
+			func := info.func
+			return_sym := g.table.sym(func.return_type)
+			if return_sym in syms {
+				pending << sym
+				continue
+			}
+			for param in func.params {
+				param_sym := g.table.sym(param.typ)
+				if param_sym in syms {
+					pending << sym
+					continue next
+				}
+			}
+			g.write_fn_typesymbol_declaration(sym)
+		}
+		if pending.len == 0 {
+			// All functions were added.
+			break
+		}
+		if syms.len == pending.len {
+			// Could not add any function: there is a circular
+			// dependency.
+			mut deps := []string{}
+			for sym in pending {
+				deps << sym.name
+			}
+			verror(
+				'cgen.write_sorted_fn_typesymbol_declaration(): the following functions form a dependency cycle:\n' +
+				deps.join(','))
+		}
+		unsafe {
+			// Swap the to-be-processed and the dependent functions.
+			syms, pending = pending, syms[..0]
 		}
 	}
 }

--- a/vlib/v/gen/c/testdata/func_type_dependency.c.must_have
+++ b/vlib/v/gen/c/testdata/func_type_dependency.c.must_have
@@ -1,0 +1,4 @@
+typedef void (*gdi__Function_ptr)();
+typedef void (*gdi__Function_ptr2)();
+typedef gdi__Function_ptr* (*gdi__Get_proc_address)(i8*);
+typedef void (*gdi__Set_proc_address)(gdi__Function_ptr2*);

--- a/vlib/v/gen/c/testdata/func_type_dependency.vv
+++ b/vlib/v/gen/c/testdata/func_type_dependency.vv
@@ -1,0 +1,8 @@
+// vtest vflags: -shared
+module gdi
+
+pub type Get_proc_address = fn(&i8) &Function_ptr
+pub type Set_proc_address = fn(&Function_ptr2)
+
+pub type Function_ptr = fn ()
+pub type Function_ptr2 = fn ()


### PR DESCRIPTION
Allow a function type to depend on another.
Fixes #19367.

NB. I tried to use depgraph.DepGraph but for some reason it did not sort the types appropriately so I resorted to a basic slice algorithm.