### PR TITLE
debug: fix help and add docs for clear cmd

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6215,7 +6215,7 @@ example.v:3 vdbg>
 
 You can also see memory usage with `mem` or `memory` command, and
 check if the current context is an anon function (`anon?`), a method (`method?`) 
-or a generic method (`generic?`).
+or a generic method (`generic?`) and clear the terminal window (`clear`).
 
 ## Memory-unsafe code
 

--- a/vlib/v/debug/debug.v
+++ b/vlib/v/debug/debug.v
@@ -24,6 +24,7 @@ mut:
 		completion_list: [
 			'anon?',
 			'bt',
+			'clear',
 			'continue',
 			'generic?',
 			'heap',
@@ -38,7 +39,6 @@ mut:
 			'scope',
 			'unwatch',
 			'watch',
-			'clear',
 		]
 	}
 }
@@ -119,7 +119,7 @@ fn (mut d Debugger) print_help() {
 	println('  scope\t\t\tshow the vars in the current scope')
 	println('  u, unwatch <var>\tunwatches a variable')
 	println('  w, watch <var>\twatches a variable')
-	println('  clear\tClears the terminal window.')
+	println('  clear\t\t\tclears the terminal window')
 	flush_println('')
 }
 


### PR DESCRIPTION
This PR add docs for recent `clear` debug cmd and fix the debug helps format.