### PR TITLE
builder: add '-lelf' to linker flags on freebsd(fix #20481)

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -391,8 +391,9 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	if !v.pref.is_bare && v.pref.build_mode != .build_module
 		&& v.pref.os in [.linux, .freebsd, .openbsd, .netbsd, .dragonfly, .solaris, .haiku] {
 		if v.pref.os in [.freebsd, .netbsd] {
-			// Free/NetBSD: backtrace needs execinfo library while linking
+			// Free/NetBSD: backtrace needs execinfo library while linking, also execinfo depends on elf.
 			ccoptions.linker_flags << '-lexecinfo'
+			ccoptions.linker_flags << '-lelf'
 		}
 	}
 	ccoptions.env_cflags = os.getenv('CFLAGS')


### PR DESCRIPTION
Close #20481 

Tested on FreeBSD 13.2, `execinfo` depends on `elf`. After adding the `-lelf` link flag, the compiler passes normally.

<img width="632" alt="image" src="https://github.com/vlang/v/assets/27794478/4f8e43d1-6926-4e97-9912-9f626c773674">
