### PR TITLE
vweb: fix quickstart docs on how to create a new project

### DIFF
--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -7,7 +7,7 @@ The [gitly](https://gitly.org/) site is based on vweb.
 **_Some features may not be complete, and have some bugs._**
 
 ## Quick Start
-Just run **`v new <name> web`** in your terminal.
+Just run **`v new --web <name>`** in your terminal.
 
 Run your vweb app with a live reload via `v -d vweb_livereload watch run .`
 


### PR DESCRIPTION
This is updating `vweb`'s `Quick Start` guide with the current command to get a web project started.