### PR TITLE
Enhance read_line() for BufferedReader to accept custom line delimiters

### DIFF
--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -115,7 +115,7 @@ pub fn (r BufferedReader) end_of_stream() bool {
 
 // read_line attempts to read a line from the buffered reader.
 // It will read until it finds the specified line delimiter
-// such as (\n or \0) or the end of stream.
+// such as (\n, the default or \0) or the end of stream.
 pub fn (mut r BufferedReader) read_line(config BufferedReadLineConfig) !string {
 	if r.end_of_stream {
 		return Eof{}

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -113,7 +113,7 @@ pub fn (r BufferedReader) end_of_stream() bool {
 	return r.end_of_stream
 }
 
-// read_line_until attempts to read a line from the buffered reader.
+// read_line attempts to read a line from the buffered reader.
 // It will read until it finds the specified line delimiter
 // such as (\n or \0) or the end of stream.
 pub fn (mut r BufferedReader) read_line(config BufferedReadLineConfig) !string {

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -21,6 +21,12 @@ pub struct BufferedReaderConfig {
 	retries int = 2 // how many times to retry before assuming the stream ended
 }
 
+// BufferedReadLineConfig are options that can be given to the read_line() function.
+@[params]
+pub struct BufferedReadLineConfig {
+	delim u8 = `\n` // line delimiter
+}
+
 // new_buffered_reader creates a new BufferedReader.
 pub fn new_buffered_reader(o BufferedReaderConfig) &BufferedReader {
 	if o.cap <= 0 {
@@ -107,10 +113,10 @@ pub fn (r BufferedReader) end_of_stream() bool {
 	return r.end_of_stream
 }
 
-// read_line attempts to read a line from the buffered reader
-// it will read until it finds a new line character (\n) or
-// the end of stream.
-pub fn (mut r BufferedReader) read_line() !string {
+// read_line_until attempts to read a line from the buffered reader.
+// It will read until it finds the specified line delimiter
+// such as (\n or \0) or the end of stream.
+pub fn (mut r BufferedReader) read_line(config BufferedReadLineConfig) !string {
 	if r.end_of_stream {
 		return Eof{}
 	}
@@ -132,10 +138,10 @@ pub fn (mut r BufferedReader) read_line() !string {
 		for ; i < r.len; i++ {
 			r.total_read++
 			c := r.buf[i]
-			if c == `\n` {
+			if c == config.delim {
 				// great, we hit something
 				// do some checking for whether we hit \r\n or just \n
-				if i != 0 && r.buf[i - 1] == `\r` {
+				if i != 0 && config.delim == `\n` && r.buf[i - 1] == `\r` {
 					x := i - 1
 					line << r.buf[r.offset..x]
 				} else {

--- a/vlib/io/reader_test.v
+++ b/vlib/io/reader_test.v
@@ -161,3 +161,26 @@ fn test_totalread_readline() {
 
 	assert r.total_read == text.len
 }
+
+fn test_read_line_until_zero_terminated() {
+	text := 'This is a test\0Nice try!\0'
+	mut s := StringReader{
+		text: text
+	}
+	mut r := new_buffered_reader(reader: s)
+	line1 := r.read_line(delim: `\0`) or {
+		assert false
+		panic('bad')
+	}
+	assert line1 == 'This is a test'
+	line2 := r.read_line(delim: `\0`) or {
+		assert false
+		panic('bad')
+	}
+	assert line2 == 'Nice try!'
+	if _ := r.read_line(delim: `\0`) {
+		assert false
+		panic('bad')
+	}
+	assert r.end_of_stream()
+}


### PR DESCRIPTION
Enable BufferedReader to work consistently with lines terminated by characters other than \n (such as \0 when using coreutils with the zero-terminated option). 

Test for the new function has been added in reader_test.v; tests for existing read_line() pass as before.