### PR TITLE
vweb, x.vweb: update error checking when checking for io.Eof

### DIFF
--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -690,7 +690,7 @@ fn handle_conn[T](mut conn net.TcpConn, global_app &T, controllers []&Controller
 	// Request parse
 	req := http.parse_request(mut reader) or {
 		// Prevents errors from being thrown when BufferedReader is empty
-		if '${err}' != 'none' {
+		if err !is io.Eof {
 			eprintln('[vweb] tid: ${tid:03d}, error parsing request: ${err}')
 		}
 		return

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -487,7 +487,7 @@ fn handle_read[A, X](mut pv picoev.Picoev, mut params RequestParams, fd int) {
 		// request header first
 		req = http.parse_request_head(mut reader) or {
 			// Prevents errors from being thrown when BufferedReader is empty
-			if err.msg() != 'none' {
+			if err !is io.Eof {
 				eprintln('[vweb] error parsing request: ${err}')
 			}
 			pv.close_conn(fd)


### PR DESCRIPTION
Update error checking when a bufferred reader is empty.

The error in the `io` module got changed in #20619 

