### PR TITLE
x.vweb: support HTTP 1.1 persistent connections

### DIFF
--- a/vlib/x/vweb/context.v
+++ b/vlib/x/vweb/context.v
@@ -35,6 +35,8 @@ mut:
 	// how the http response should be handled by vweb's backend
 	return_type ContextReturnType = .normal
 	return_file string
+	// If the `Connection: close` header is present the connection should always be closed
+	client_wants_to_close bool
 pub:
 	// TODO: move this to `handle_request`
 	// time.ticks() from start of vweb connection handle.
@@ -103,9 +105,9 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, response strin
 	}
 	// send vweb's closing headers
 	ctx.res.header.set(.server, 'VWeb')
-	// sent `Connection: close header` by default, if the user hasn't specified that the
-	// connection should not be closed.
-	if !ctx.takeover {
+	if !ctx.takeover && ctx.client_wants_to_close {
+		// Only sent the `Connection: close` header when the client wants to close
+		// the connection. This typically happens when the client only supports HTTP 1.0
 		ctx.res.header.set(.connection, 'close')
 	}
 	// set the http version

--- a/vlib/x/vweb/tests/persistent_connection_test.v
+++ b/vlib/x/vweb/tests/persistent_connection_test.v
@@ -1,0 +1,126 @@
+import net
+import net.http
+import io
+import os
+import time
+import x.vweb
+
+const exit_after = time.second * 10
+const port = 13009
+const localserver = 'localhost:${port}'
+const tcp_r_timeout = 2 * time.second
+const tcp_w_timeout = 2 * time.second
+const max_retries = 4
+
+const default_request = 'GET / HTTP/1.1
+User-Agent: VTESTS
+Accept: */*
+\r\n'
+
+const response_body = 'intact!'
+
+pub struct Context {
+	vweb.Context
+}
+
+pub struct App {
+mut:
+	started chan bool
+	counter int
+}
+
+pub fn (mut app App) before_accept_loop() {
+	app.started <- true
+}
+
+pub fn (mut app App) index(mut ctx Context) vweb.Result {
+	app.counter++
+	return ctx.text('${response_body}:${app.counter}')
+}
+
+pub fn (mut app App) reset(mut ctx Context) vweb.Result {
+	app.counter = 0
+	return ctx.ok('')
+}
+
+fn testsuite_begin() {
+	os.chdir(os.dir(@FILE))!
+	mut app := &App{}
+
+	spawn vweb.run_at[App, Context](mut app, port: port, timeout_in_seconds: 5)
+	_ := <-app.started
+
+	spawn fn () {
+		time.sleep(exit_after)
+		assert true == false, 'timeout reached!'
+		exit(1)
+	}()
+}
+
+fn test_conn_remains_intact() {
+	http.get('http://${localserver}/reset')!
+
+	mut conn := simple_tcp_client()!
+	conn.write_string(default_request)!
+
+	mut read := io.read_all(reader: conn)!
+	mut response := read.bytestr()
+	assert response.contains('Connection: close') == false, '`Connection` header should NOT be present!'
+	assert response.ends_with('${response_body}:1') == true, 'read response: ${response}'
+
+	// send request again over the same connection
+	conn.write_string(default_request)!
+
+	read = io.read_all(reader: conn)!
+	response = read.bytestr()
+	assert response.contains('Connection: close') == false, '`Connection` header should NOT be present!'
+	assert response.ends_with('${response_body}:2') == true, 'read response: ${response}'
+
+	conn.close() or {}
+}
+
+fn test_support_http_1() {
+	http.get('http://${localserver}/reset')!
+	// HTTP 1.0 always closes the connection after each request, so the client must
+	// send the Connection: close header. If that header is present the connection
+	// needs to be closed and a `Connection: close` header needs to be send back
+	mut x := http.fetch(http.FetchConfig{
+		url: 'http://${localserver}/'
+		header: http.new_header_from_map({
+			.connection: 'close'
+		})
+	})!
+	assert x.status() == .ok
+	if conn_header := x.header.get(.connection) {
+		assert conn_header == 'close'
+	} else {
+		assert false, '`Connection: close` header should be present!'
+	}
+}
+
+// utility code:
+
+fn simple_tcp_client() !&net.TcpConn {
+	mut client := &net.TcpConn(unsafe { nil })
+	mut tries := 0
+	for tries < max_retries {
+		tries++
+		eprintln('> client retries: ${tries}')
+		client = net.dial_tcp(localserver) or {
+			eprintln('dial error: ${err.msg()}')
+			if tries > max_retries {
+				return err
+			}
+			time.sleep(100 * time.millisecond)
+			continue
+		}
+		break
+	}
+	if client == unsafe { nil } {
+		eprintln('could not create a tcp client connection to http://${localserver} after ${max_retries} retries')
+		exit(1)
+	}
+	client.set_read_timeout(tcp_r_timeout)
+	client.set_write_timeout(tcp_w_timeout)
+	return client
+}

--- a/vlib/x/vweb/tests/vweb_test.v
+++ b/vlib/x/vweb/tests/vweb_test.v
@@ -61,6 +61,7 @@ fn assert_common_headers(received string) {
 	assert received.starts_with('HTTP/1.1 200 OK\r\n')
 	assert received.contains('Server: VWeb\r\n')
 	assert received.contains('Content-Length:')
+	assert received.contains('Connection: close\r\n')
 }
 
 fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
@@ -117,6 +118,7 @@ fn test_http_client_index() {
 	assert_common_http_headers(x)!
 	assert x.header.get(.content_type)! == 'text/plain'
 	assert x.body == 'Welcome to VWeb'
+	assert x.header.get(.connection)! == 'close'
 }
 
 fn test_http_client_404() {

--- a/vlib/x/vweb/tests/vweb_test.v
+++ b/vlib/x/vweb/tests/vweb_test.v
@@ -61,7 +61,6 @@ fn assert_common_headers(received string) {
 	assert received.starts_with('HTTP/1.1 200 OK\r\n')
 	assert received.contains('Server: VWeb\r\n')
 	assert received.contains('Content-Length:')
-	assert received.contains('Connection: close\r\n')
 }
 
 fn test_a_simple_tcp_client_can_connect_to_the_vweb_server() {
@@ -111,7 +110,6 @@ fn assert_common_http_headers(x http.Response) ! {
 	assert x.status() == .ok
 	assert x.header.get(.server)! == 'VWeb'
 	assert x.header.get(.content_length)!.int() > 0
-	assert x.header.get(.connection)! == 'close'
 }
 
 fn test_http_client_index() {
@@ -327,6 +325,7 @@ fn simple_tcp_client(config SimpleTcpClientConfig) !string {
 Host: ${config.host}
 User-Agent: ${config.agent}
 Accept: */*
+Connection: close
 ${config.headers}
 ${config.content}'
 	$if debug_net_socket_client ? {


### PR DESCRIPTION
Allow persistent HTTP connections so multiple requests and responses can be sent over a single connection.

Remove the default behaviour of vweb to always send the `Connection: close` header. The connection will be closed when the client sends the `Connection: close` header in the request, or if a read on the socket returns `0` indicating that the client has closed the connection. According to HTTP 1.1 standard.

This pr greatly improves the speed of `x.vweb` for clients that support HTTP 1.1 and higher