### PR TITLE
net.http: Temporary fix intermittent segfault with http get text and gcc 13 2 [issue #20506]

### DIFF
--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -143,7 +143,7 @@ pub fn delete(url string) !Response {
 	return fetch(method: .delete, url: url)
 }
 
-// TODO - @[noinline] attribut is used for temporary fix the 'get_text()' intermittent segfault with GCC 13.2.x ( Issue #20506 )
+// TODO - @[noinline] attribut is used for temporary fix the 'get_text()' intermittent segfault / nil value when compiling with GCC 13.2.x and -prod option ( Issue #20506 )
 // fetch sends an HTTP request to the `url` with the given method and configuration.
 @[noinline]
 pub fn fetch(config FetchConfig) !Response {

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -143,7 +143,9 @@ pub fn delete(url string) !Response {
 	return fetch(method: .delete, url: url)
 }
 
+// TODO - @[noinline] attribut is used for temporary fix the 'get_text()' intermittent segfault with GCC 13.2.x ( Issue #20506 )
 // fetch sends an HTTP request to the `url` with the given method and configuration.
+@[noinline]
 pub fn fetch(config FetchConfig) !Response {
 	if config.url == '' {
 		return error('http.fetch: empty url')


### PR DESCRIPTION
Temporary fix #20506 

More details from here : https://github.com/vlang/v/issues/20506#issuecomment-1908943267

Thanks at @spytheman and @Casper64 for testing the proposed temporary solutions and taking the time to identify the one with the least impact on performance. ( See comments in issue ).