### PR TITLE
v.fmt: drop newline in end comments for const

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -964,7 +964,7 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 			if node.end_comments.len > 0 && node.end_comments[0].text.contains('\n') {
 				f.writeln('\n')
 			}
-			f.comments(node.end_comments, same_line: true)
+			f.comments(node.end_comments, same_line: true, has_nl: false)
 		}
 		prev_field = field
 	}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -958,10 +958,10 @@ pub fn (mut f Fmt) const_decl(node ast.ConstDecl) {
 		if node.is_block && fidx < node.fields.len - 1 && node.fields.len > 1 {
 			// old style grouped consts, converted to the new style ungrouped const
 			f.writeln('')
-		} else {
+		} else if node.end_comments.len > 0 {
 			// Write out single line comments after const expr if present
 			// E.g.: `const x = 1 // <comment>`
-			if node.end_comments.len > 0 && node.end_comments[0].text.contains('\n') {
+			if node.end_comments[0].text.contains('\n') {
 				f.writeln('\n')
 			}
 			f.comments(node.end_comments, same_line: true, has_nl: false)

--- a/vlib/v/fmt/tests/consts_with_comments_end_keep.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_end_keep.vv
@@ -1,0 +1,3 @@
+const a = 'a' // hello
+const b = 'b' // comment
+const c = 'c'

--- a/vlib/v/fmt/tests/consts_with_comments_expected.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_expected.vv
@@ -1,7 +1,6 @@
 // leave
 const one = 1 // leave
-
-// move
+// leave
 
 const two = 2
 

--- a/vlib/v/fmt/tests/consts_with_comments_input.vv
+++ b/vlib/v/fmt/tests/consts_with_comments_input.vv
@@ -1,6 +1,6 @@
 // leave
 const one = 1 // leave
-// move
+// leave
 
 const two = 2 /* move
 */


### PR DESCRIPTION
Fixes #20657.