### PR TITLE
os: Fix unnecesary returns

### DIFF
--- a/vlib/os/process.c.v
+++ b/vlib/os/process.c.v
@@ -14,7 +14,6 @@ pub fn (mut p Process) signal_kill() {
 	}
 	p._signal_kill()
 	p.status = .aborted
-	return
 }
 
 // signal_pgkill - kills the whole process group
@@ -23,7 +22,6 @@ pub fn (mut p Process) signal_pgkill() {
 		return
 	}
 	p._signal_pgkill()
-	return
 }
 
 // signal_stop - stops the process, you can resume it with p.signal_continue()
@@ -33,7 +31,6 @@ pub fn (mut p Process) signal_stop() {
 	}
 	p._signal_stop()
 	p.status = .stopped
-	return
 }
 
 // signal_continue - tell a stopped process to continue/resume its work
@@ -43,7 +40,6 @@ pub fn (mut p Process) signal_continue() {
 	}
 	p._signal_continue()
 	p.status = .running
-	return
 }
 
 // wait - wait for a process to finish.
@@ -60,7 +56,6 @@ pub fn (mut p Process) wait() {
 		return
 	}
 	p._wait()
-	return
 }
 
 // close - free the OS resources associated with the process.
@@ -132,7 +127,6 @@ pub fn (mut p Process) set_redirect_stdio() {
 	$if trace_process_pipes ? {
 		eprintln('${@LOCATION}, pid: ${p.pid}, status: ${p.status}')
 	}
-	return
 }
 
 // stdin_write will write the string `s`, to the stdin pipe of the child process.
@@ -323,5 +317,4 @@ pub fn (mut p Process) run() {
 		return
 	}
 	p._spawn()
-	return
 }


### PR DESCRIPTION
Removing unnecesary `retun`s


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
