### PR TITLE
cgen: fix method call checking against `none` 

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1048,7 +1048,7 @@ fn (mut g Gen) infix_expr_and_or_op(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
-	if node.left in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
+	if node.left in [ast.Ident, ast.SelectorExpr, ast.IndexExpr, ast.CallExpr] {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
 		g.expr(node.left)

--- a/vlib/v/tests/method_call_none_check_test.v
+++ b/vlib/v/tests/method_call_none_check_test.v
@@ -1,0 +1,28 @@
+struct Foo {
+	x int
+}
+
+struct Bar {
+	x int
+}
+
+type Foobar = Bar | Foo
+
+struct Foobars {
+	m map[string]Foobar
+}
+
+fn (f &Foobars) find_foobar(name string) ?Foobar {
+	return f.m[name] or { return none }
+}
+
+fn (mut f Foobars) is_known(name string) bool {
+	return f.find_foobar(name) != none
+}
+
+fn test_main() {
+	mut foobars := Foobars{
+		m: map[string]Foobar{}
+	}
+	assert foobars.is_known('deadbeef') == false
+}


### PR DESCRIPTION
Fix #20711

```V
struct Foo {
	x int
}
struct Bar {
	x int
}
type Foobar = Foo | Bar
struct Foobars {
	m map[string]Foobar
}
fn (f &Foobars) find_foobar(name string) ?Foobar {
	return f.m[name] or { return none }
}
fn (mut f Foobars) is_known(name string) bool {
	return f.find_foobar(name) != none
}

fn main() {
	mut foobars := Foobars{
		m: map[string]Foobar{}
	}
	println(foobars.is_known('deadbeef'))
}
```