### PR TITLE
parser: fn type declaration does not check already registered name

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -321,7 +321,12 @@ fn (mut p Parser) parse_fn_type(name string, generic_types []ast.Type) ast.Type 
 	// MapFooFn typedefs are manually added in cheaders.v
 	// because typedefs get generated after the map struct is generated
 	has_decl := p.builtin_mod && name.starts_with('Map') && name.ends_with('Fn')
+	already_exists := p.table.find_type_idx(name) != 0
 	idx := p.table.find_or_register_fn_type(func, false, has_decl)
+	if already_exists && p.table.sym_by_idx(idx).kind != .function {
+		p.error_with_pos('cannot register fn `${name}`, another type with this name exists',
+			fn_type_pos)
+	}
 	if has_generic {
 		return ast.new_type(idx).set_flag(.generic)
 	}

--- a/vlib/v/parser/tests/already_existing_sym_err.out
+++ b/vlib/v/parser/tests/already_existing_sym_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/already_existing_sym_err.vv:16:6: error: cannot register fn `vnkxcb.Nk_plugin_alloc`, another type with this name exists
+   14 | }
+   15 | 
+   16 | type Nk_plugin_alloc = fn (Nk_handle, voidptr, Nk_size) voidptr
+      |      ~~~~~~~~~~~~~~~

--- a/vlib/v/parser/tests/already_existing_sym_err.vv
+++ b/vlib/v/parser/tests/already_existing_sym_err.vv
@@ -1,0 +1,16 @@
+@[translated]
+module vnkxcb
+
+type Nk_size = u32
+
+union Nk_handle {
+	ptr voidptr
+	id int
+}
+
+enum Nk_plugin_alloc {
+	nk_tree_node
+	nk_tree_tab
+}
+
+type Nk_plugin_alloc = fn (Nk_handle, voidptr, Nk_size) voidptr


### PR DESCRIPTION
Fix #20730

```v
@[translated]
module vnkxcb

type Nk_size = u32

union Nk_handle {
	ptr voidptr
	id int
}

enum Nk_plugin_alloc {
	nk_tree_node
	nk_tree_tab
}

type Nk_plugin_alloc = fn (Nk_handle, voidptr, Nk_size) voidptr // already registered name as Enum below
``` 