### PR TITLE
Added unsafe line in clipboard_windows.c.v

### DIFF
--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -93,8 +93,8 @@ fn new_clipboard() &Clipboard {
 		cb_size: sizeof(WndClassEx)
 		lpfn_wnd_proc: voidptr(&C.DefWindowProc)
 		lpsz_class_name: class_name.to_wide()
-		lpsz_menu_name: 0
-		h_icon_sm: 0
+		lpsz_menu_name: unsafe { 0 }
+		h_icon_sm: unsafe { 0 }
 	}
 	if C.RegisterClassEx(voidptr(&wndclass)) == 0
 		&& C.GetLastError() != u32(C.ERROR_CLASS_ALREADY_EXISTS) {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->


**clipboard: Add ``unsafe`` line for windows**

This PR modifies the `WndClassEx` struct initialization to handle `lpsz_menu_name` and `h_icon_sm` in an unsafe block. This is necessary because V language requires explicit `unsafe` block for operations that could lead to undefined behaviors.

Before:
```v
// v/vlib/clipboard/clipboard_windows.c.v
.
.
.
wndclass := WndClassEx{
    cb_size: sizeof(WndClassEx)
    lpfn_wnd_proc: voidptr(&C.DefWindowProc)
    lpsz_class_name: class_name.to_wide()
    lpsz_menu_name: 0
    h_icon_sm: 0
}
```

After:
```v
// v/vlib/clipboard/clipboard_windows.c.v
.
.
.
wndclass := WndClassEx{
    cb_size: sizeof(WndClassEx)
    lpfn_wnd_proc: voidptr(&C.DefWindowProc)
    lpsz_class_name: class_name.to_wide()
    lpsz_menu_name: unsafe { 0 }
    h_icon_sm: unsafe { 0 }
}
```


Fix this notice
```bash
C:/Program Files/v/vlib/clipboard/clipboard_windows.c.v:96:3: notice: assigning `0` to a reference field is only allowed in `unsafe` blocks
   94 |         lpfn_wnd_proc: voidptr(&C.DefWindowProc)
   95 |         lpsz_class_name: class_name.to_wide()
   96 |         lpsz_menu_name: 0
      |         ~~~~~~~~~~~~~~~~~
   97 |         h_icon_sm: 0
   98 |     }
C:/Program Files/v/vlib/clipboard/clipboard_windows.c.v:97:3: notice: assigning `0` to a reference field is only allowed in `unsafe` blocks
   95 |         lpsz_class_name: class_name.to_wide()
   96 |         lpsz_menu_name: 0
   97 |         h_icon_sm: 0
      |         ~~~~~~~~~~~~
   98 |     }
   99 |     if C.RegisterClassEx(voidptr(&wndclass)) == 0
```



