### PR TITLE
dtm: redesign certain parts

### DIFF
--- a/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
+++ b/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
@@ -6,7 +6,7 @@ import os
 struct App {
 	vweb.Context
 pub mut:
-	dtm                &dtm.DynamicTemplateManager = dtm.create_dtm() @[vweb_global]
+	dtmi               &dtm.DynamicTemplateManager = unsafe { nil } @[vweb_global]
 	shared_data_string []string                    @[vweb_global]
 	shared_data_int    []int                       @[vweb_global]
 	shared_switch      int = 1                         @[vweb_global]
@@ -23,12 +23,12 @@ fn main() {
 	app.shared_data_int << 123456
 	app.shared_data_int << 7891011
 
-	dtm.initialize_dtm(mut app.dtm) or { eprintln(err) }
+	app.dtmi = dtm.initialize()
 	/*
-	app.initialize_dtm(mut &app.dtm,
+	app.initialize_dtm(
 	compress_html: false
 	active_cache_server: false
-	max_size_data_in_mem: 100) or { eprintln(err) }
+	max_size_data_in_mem: 100)
 	*/
 	go app.update_data()
 
@@ -46,7 +46,7 @@ pub fn (mut app App) index() vweb.Result {
 	tmpl_var['html_#includehtml'] = app.shared_data_string[app.shared_switch + 2]
 
 	// You can also modify the HTML template file directly without having to recompile the application.
-	html_content := app.dtm.serve_dynamic_template('index.html',
+	html_content := app.dtmi.expand('index.html',
 		placeholders: &tmpl_var
 		cache_delay_expiration: dtm.cache_delay_expiration_at_min
 	)

--- a/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
+++ b/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
@@ -23,7 +23,8 @@ fn main() {
 	app.shared_data_int << 123456
 	app.shared_data_int << 7891011
 
-	app.dtmi = dtm.initialize()
+	cache_folder_path := os.join_path(os.dir(os.executable()), 'vcache_dtm')
+	app.dtmi = dtm.initialize(def_cache_path: cache_folder_path)
 	defer {
 		app.dtmi.stop_cache_handler()
 	}

--- a/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
+++ b/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
@@ -24,6 +24,9 @@ fn main() {
 	app.shared_data_int << 7891011
 
 	app.dtmi = dtm.initialize()
+	defer {
+		app.dtmi.stop_cache_handler()
+	}
 	/*
 	dtm.initialize(
 	compress_html: false

--- a/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
+++ b/vlib/vweb/tests/dynamic_template_manager_test_server/dynamic_template_manager_test_server.v
@@ -25,7 +25,7 @@ fn main() {
 
 	app.dtmi = dtm.initialize()
 	/*
-	app.initialize_dtm(
+	dtm.initialize(
 	compress_html: false
 	active_cache_server: false
 	max_size_data_in_mem: 100)

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -81,7 +81,7 @@ mut:
 	nbr_of_remaining_template_request shared []RemainingTemplateRequest = []RemainingTemplateRequest{}
 	//	Dtm clock
 	c_time            i64
-	ch_stop_dtm_clock chan bool
+	ch_stop_dtm_clock chan bool = chan bool{cap: 5}
 	// Store small informations about already cached pages to improve the verification speed of the check_html_and_placeholders_size function.
 	html_file_info shared map[string]HtmlFileInfo = map[string]HtmlFileInfo{}
 	// Indicates whether the cache file storage directory is located in a temporary OS area
@@ -1201,7 +1201,7 @@ fn (mut tm DynamicTemplateManager) cache_request_route(is_cache_exist bool, neg_
 // this can potentially lead to cache expiration issues if there is zero traffic for a while."
 //
 
-// Minimum update interval ( in seconds ) set to 4 minutesminimum_wait_time_until_next_update
+// Minimum update interval ( in seconds ) set to 4 minutes minimum_wait_time_until_next_update
 const update_duration = 240
 
 fn (mut tm DynamicTemplateManager) handle_dtm_clock() {
@@ -1234,6 +1234,9 @@ fn (mut tm DynamicTemplateManager) handle_dtm_clock() {
 					break
 				}
 				else {
+					$if test {
+						break
+					}
 					// Attendre une seconde
 					time.sleep(1 * time.second)
 				}
@@ -1241,6 +1244,10 @@ fn (mut tm DynamicTemplateManager) handle_dtm_clock() {
 		}
 		// Reset wait time for next cycle.
 		minimum_wait_time_until_next_update = dtm.update_duration
+
+		$if test {
+			break
+		}
 	}
 }
 

--- a/vlib/x/templating/dtm/dynamic_template_manager_test.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager_test.v
@@ -154,16 +154,22 @@ fn test_remaining_template_request() {
 	}
 }
 
-fn test_check_html_and_placeholders_size() {
+fn test_check_tmpl_and_placeholders_size() {
 	mut dtmi := init_dtm(false, 0)
 	temp_html_file := os.join_path(dtmi.template_folder, dtm.temp_html_fp)
 	placeholders := map[string]DtmMultiTypeMap{}
 
-	path, filename, content_checksum := dtmi.check_html_and_placeholders_size(temp_html_file,
+	path, filename, content_checksum, tmpl_type := dtmi.check_tmpl_and_placeholders_size(temp_html_file,
 		&placeholders)!
 
+	is_html := if tmpl_type == TemplateType.html {
+		true
+	} else {
+		false
+	}
 	assert path.len > 10
 	assert filename.len > 3
+	assert is_html == true
 	//	assert content_checksum.len > 3
 }
 
@@ -280,7 +286,7 @@ fn test_chandler_remaining_cache_template_used() {
 	assert can_delete == true
 }
 
-fn test_parse_html_file() {
+fn test_parse_tmpl_file() {
 	mut dtmi := init_dtm(false, 0)
 	temp_folder := os.join_path(dtm.vtmp_dir, dtm.temp_dtm_dir)
 	templates_path := os.join_path(temp_folder, dtm.temp_templates_dir)
@@ -289,7 +295,8 @@ fn test_parse_html_file() {
 	mut placeholders := map[string]DtmMultiTypeMap{}
 
 	is_compressed := true
-	html := dtmi.parse_html_file(temp_html_file, dtm.temp_html_n, &placeholders, is_compressed)
+	html := dtmi.parse_tmpl_file(temp_html_file, dtm.temp_html_n, &placeholders, is_compressed,
+		TemplateType.html)
 
 	assert html.len > 0
 }
@@ -406,8 +413,8 @@ fn (mut tm DynamicTemplateManager) create_cache() string {
 	cache_delay_exp := i64(500) * i64(1000000)
 	placeholder := map[string]DtmMultiTypeMap{}
 	content_checksum := ''
-	html := tm.create_template_cache_and_display_html(.new, html_last_mod, c_time, temp_html_file,
-		dtm.temp_html_n, cache_delay_exp, &placeholder, content_checksum)
+	html := tm.create_template_cache_and_display(.new, html_last_mod, c_time, temp_html_file,
+		dtm.temp_html_n, cache_delay_exp, &placeholder, content_checksum, TemplateType.html)
 	time.sleep(5 * time.millisecond)
 	return html
 }

--- a/vlib/x/templating/dtm/dynamic_template_manager_test.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager_test.v
@@ -4,7 +4,7 @@ import os
 import time
 
 const temp_dtm_dir = 'dynamic_template_manager_test'
-const temp_cache_dir = 'vcache'
+const temp_cache_dir = 'vcache_dtm'
 const temp_templates_dir = 'templates'
 const temp_html_fp = 'temp.html'
 const temp_html_n = 'temp'
@@ -39,20 +39,20 @@ fn testsuite_begin() {
 }
 
 fn test_initialize_dtm() {
-	dtmi := init_dtm(false, 0)!
+	dtmi := init_dtm(false, 0)
 	assert dtmi.dtm_init_is_ok == true
 }
 
 fn test_check_and_clear_cache_files() {
-	dtmi := init_dtm(false, 0)!
-	dtmi.check_and_clear_cache_files()!
+	dtmi := init_dtm(false, 0)
+	check_and_clear_cache_files(dtmi.template_cache_folder)!
 
 	count_cache_files := os.ls(dtmi.template_cache_folder)!
 	assert count_cache_files.len == 0
 }
 
 fn test_create_template_cache_and_display_html() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)!
+	mut dtmi := init_dtm(true, max_size_data_in_memory)
 	defer {
 		dtmi.stop_cache_handler()
 	}
@@ -61,7 +61,7 @@ fn test_create_template_cache_and_display_html() {
 }
 
 fn test_get_cache() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)!
+	mut dtmi := init_dtm(true, max_size_data_in_memory)
 	dtmi.create_cache()
 	defer {
 		dtmi.stop_cache_handler()
@@ -73,7 +73,7 @@ fn test_get_cache() {
 }
 
 fn test_return_cache_info_isexistent() {
-	mut dtmi := init_dtm(false, 0)!
+	mut dtmi := init_dtm(false, 0)
 	path_template := os.join_path(dtmi.template_folder, dtm.temp_html_fp)
 	lock dtmi.template_caches {
 		dtmi.template_caches << TemplateCache{
@@ -129,7 +129,7 @@ fn test_return_cache_info_isexistent() {
 }
 
 fn test_remaining_template_request() {
-	mut dtmi := init_dtm(false, 0)!
+	mut dtmi := init_dtm(false, 0)
 
 	lock dtmi.nbr_of_remaining_template_request {
 		dtmi.nbr_of_remaining_template_request << RemainingTemplateRequest{
@@ -155,7 +155,7 @@ fn test_remaining_template_request() {
 }
 
 fn test_check_html_and_placeholders_size() {
-	mut dtmi := init_dtm(false, 0)!
+	mut dtmi := init_dtm(false, 0)
 	temp_html_file := os.join_path(dtmi.template_folder, dtm.temp_html_fp)
 	placeholders := map[string]DtmMultiTypeMap{}
 
@@ -168,7 +168,7 @@ fn test_check_html_and_placeholders_size() {
 }
 
 fn test_chandler_prevent_cache_duplicate_request() {
-	dtmi := init_dtm(false, 0)!
+	dtmi := init_dtm(false, 0)
 	temp_html_file := os.join_path(dtmi.template_folder, dtm.temp_html_fp)
 
 	lock dtmi.template_caches {
@@ -236,7 +236,7 @@ fn test_chandler_prevent_cache_duplicate_request() {
 }
 
 fn test_chandler_clear_specific_cache() {
-	mut dtmi := init_dtm(true, 0)!
+	mut dtmi := init_dtm(true, 0)
 	defer {
 		dtmi.stop_cache_handler()
 	}
@@ -252,7 +252,7 @@ fn test_chandler_clear_specific_cache() {
 }
 
 fn test_chandler_remaining_cache_template_used() {
-	mut dtmi := init_dtm(false, 0)!
+	mut dtmi := init_dtm(false, 0)
 	lock dtmi.nbr_of_remaining_template_request {
 		dtmi.nbr_of_remaining_template_request << RemainingTemplateRequest{
 			id: 1
@@ -281,7 +281,7 @@ fn test_chandler_remaining_cache_template_used() {
 }
 
 fn test_parse_html_file() {
-	mut dtmi := init_dtm(false, 0)!
+	mut dtmi := init_dtm(false, 0)
 	temp_folder := os.join_path(dtm.vtmp_dir, dtm.temp_dtm_dir)
 	templates_path := os.join_path(temp_folder, dtm.temp_templates_dir)
 	temp_html_file := os.join_path(templates_path, dtm.temp_html_fp)
@@ -301,7 +301,7 @@ fn test_check_if_cache_delay_iscorrect() {
 }
 
 fn test_cache_request_route() {
-	mut dtmi := init_dtm(false, 0)!
+	mut dtmi := init_dtm(false, 0)
 	mut is_cache_exist := true
 	mut cache_delay_expiration := i64(400)
 	mut last_template_mod := get_current_unix_micro_timestamp()
@@ -342,8 +342,18 @@ fn test_cache_request_route() {
 	assert request_type == CacheRequest.new
 }
 
+fn test_handle_dtm_clock() {
+	mut dtmi := init_dtm(true, max_size_data_in_memory)
+	defer {
+		dtmi.stop_cache_handler()
+	}
+	dtmi.handle_dtm_clock()
+	date_to_str := dtmi.c_time.str()
+	assert date_to_str.len > 10
+}
+
 fn test_cache_handler() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)!
+	mut dtmi := init_dtm(true, max_size_data_in_memory)
 	defer {
 		dtmi.stop_cache_handler()
 	}
@@ -372,12 +382,10 @@ fn testsuite_end() {
 
 // Utilities function :
 
-fn init_dtm(b bool, m int) !&DynamicTemplateManager {
+fn init_dtm(b bool, m int) &DynamicTemplateManager {
 	temp_folder := os.join_path(dtm.vtmp_dir, dtm.temp_dtm_dir)
 	vcache_path := os.join_path(temp_folder, dtm.temp_cache_dir)
 	templates_path := os.join_path(temp_folder, dtm.temp_templates_dir)
-
-	mut dtm := create_dtm()
 
 	init_params := DynamicTemplateManagerInitialisationParams{
 		active_cache_server: b
@@ -386,7 +394,7 @@ fn init_dtm(b bool, m int) !&DynamicTemplateManager {
 		test_template_dir: templates_path
 	}
 
-	initialize_dtm(mut dtm, init_params)!
+	dtm := initialize(init_params)
 
 	return dtm
 }


### PR DESCRIPTION
To adjust certain behaviors recommended in this PR: #20716 , the DTM has undergone some minor modifications:

- The creation and initialization of a DTM instance have been merged into the same function
- Some function names have been revised.
- Now, for the cache folder : User can define cache folder path. If not exist or problem with it, an attempt will be made to create the directory in the temporary storage area of the OS. Otherwise, cache system will be desactived and the problem is reported if the user had activated the cache service..
- Internal and external test files have been updated accordingly.
- Raw text files are now managed by the dtm

@spytheman  I will update the documentation in due course. However, this PR needs to be reviewed and, if accepted, merged as a priority; otherwise, the documentation will not match. Thank you!
