### PR TITLE
test: make 'vlib/v/builder/builder_test.v' pass on older Windows versions.

### DIFF
--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -186,12 +186,12 @@ pub fn ls(path string) ![]string {
 		return error('ls(): Could not get a file handle: ' + get_error_msg(int(C.GetLastError())))
 	}
 	first_filename := unsafe { string_from_wide(&find_file_data.c_file_name[0]) }
-	if first_filename != '.' && first_filename != '..' && exists('${path}\\${first_filename}') {
+	if first_filename != '.' && first_filename != '..' {
 		dir_files << first_filename
 	}
 	for C.FindNextFile(h_find_files, voidptr(&find_file_data)) > 0 {
 		filename := unsafe { string_from_wide(&find_file_data.c_file_name[0]) }
-		if filename != '.' && filename != '..' && exists('${path}\\${filename}') {
+		if filename != '.' && filename != '..' {
 			dir_files << filename.clone()
 		}
 	}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -186,12 +186,12 @@ pub fn ls(path string) ![]string {
 		return error('ls(): Could not get a file handle: ' + get_error_msg(int(C.GetLastError())))
 	}
 	first_filename := unsafe { string_from_wide(&find_file_data.c_file_name[0]) }
-	if first_filename != '.' && first_filename != '..' {
+	if first_filename != '.' && first_filename != '..' && exists('${path}\\${first_filename}') {
 		dir_files << first_filename
 	}
 	for C.FindNextFile(h_find_files, voidptr(&find_file_data)) > 0 {
 		filename := unsafe { string_from_wide(&find_file_data.c_file_name[0]) }
-		if filename != '.' && filename != '..' {
+		if filename != '.' && filename != '..' && exists('${path}\\${filename}') {
 			dir_files << filename.clone()
 		}
 	}

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -28,7 +28,7 @@ fn test_conditional_executable_removal() {
 	assert executable !in original_file_list_
 
 	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
-	after_run_file_list := os.ls(test_path)!
+	after_run_file_list := os.ls(test_path)!.filter(os.exists(it))
 	dump(after_run_file_list)
 	assert executable !in after_run_file_list
 


### PR DESCRIPTION
This PR enables `v test vlib/v/builder/builder_test.v` to pass the test on Windows systems below Win10.

The following are the test results before modification:
```
v test                      vlib/v/builder/builder_test.v
---- Testing... ----------------------------------------------------------------
 FAIL  2431.316 ms vlib/v/builder/builder_test.v
         retry: 1
      comp_cmd: "D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-weekly.2024.05\mingw-w64-x86_64-v.exe" -skip-running   -o "D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-x86_64-v-weekly.2024.05-1\v_0\tsession_379c_25796335\01HNF86CWK22A0VZCBA79SRX6H\builder_test.exe" "D:\gym\test\mingw-w64-packages\mingw-w64-v\src\v-weekly.2024.05\vlib\v\builder\builder_test.v"
       run_cmd: "D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-x86_64-v-weekly.2024.05-1\v_0\tsession_379c_25796335\01HNF86CWK22A0VZCBA79SRX6H\builder_test.exe"
failure code: 1; foutput.len: 732; failure output:
---------------------------------------------------------------------------------------------------- retry: 0 ; max_retry: 0 ; r.exit_code: 1 ; trimmed_output.len: 564
[D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-weekly.2024.05\\vlib\\v\\builder\\builder_test.v:27] original_file_list_: ['src']
[D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-weekly.2024.05\\vlib\\v\\builder\\builder_test.v:32] after_run_file_list: ['run_check.exe', 'src']
D:\\gym\\test\\mingw-w64-packages\\mingw-w64-v\\src\\v-weekly.2024.05\\vlib\\v\\builder\\builder_test.v:33: fn test_conditional_executable_removal
   > assert executable !in after_run_file_list
     Left value: run_check.exe
    Right value: ['run_check.exe', 'src']
--------------------------------------------------------------------------------
```

If `time.sleep(200 * time.millisecond)` is added to [the test file](https://github.com/vlang/v/blob/e6570ddcf9208889adfe5f45869073e1305fd009/vlib/v/builder/builder_test.v#L31), the test will also have a chance to succeed.

So the root of the problem is: executing `os.execute('${os.quoted_path(vexe)} run .')` and then executing `os.ls(test_path)!` will cause the file list to contain non-existent files. These non-existent files will be deleted delayed by Windows.

Here are some links related to the question:

- https://github.com/PowerShell/PowerShell/issues/8211
- https://github.com/PowerShell/PowerShell/issues/8211
- https://github.com/golang/go/issues/25965
- https://github.com/dotnet/corefx/pull/38186
- https://github.com/dokan-dev/dokany/issues/883

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
