### PR TITLE
cgen: fix comptime smartcast as receiver on method call

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1307,10 +1307,14 @@ fn (mut g Gen) resolve_receiver_type(node ast.CallExpr) (ast.Type, &ast.TypeSymb
 	if node.from_embed_types.len == 0 && node.left is ast.Ident {
 		if node.left.obj is ast.Var {
 			if node.left.obj.smartcasts.len > 0 {
-				unwrapped_rec_type = g.unwrap_generic(node.left.obj.smartcasts.last())
-				cast_sym := g.table.sym(unwrapped_rec_type)
-				if cast_sym.info is ast.Aggregate {
-					unwrapped_rec_type = cast_sym.info.types[g.aggregate_type_idx]
+				if node.left.obj.ct_type_var == .smartcast {
+					unwrapped_rec_type = g.unwrap_generic(g.comptime.get_comptime_var_type(node.left))
+				} else {
+					unwrapped_rec_type = g.unwrap_generic(node.left.obj.smartcasts.last())
+					cast_sym := g.table.sym(unwrapped_rec_type)
+					if cast_sym.info is ast.Aggregate {
+						unwrapped_rec_type = cast_sym.info.types[g.aggregate_type_idx]
+					}
 				}
 			}
 		}

--- a/vlib/v/tests/comptime_smart_receiver_test.v
+++ b/vlib/v/tests/comptime_smart_receiver_test.v
@@ -1,0 +1,35 @@
+struct Context {
+}
+
+struct Input {
+}
+
+struct Block {
+	x int
+	y int
+mut:
+	children []Element
+}
+
+type Element = Block | Input
+
+fn (input Input) draw(mut ctx Context, x int, y int) {}
+
+fn (block Block) draw(mut ctx Context, x int, y int) {
+	for child in block.children {
+		child.draw(mut ctx, block.x + x, block.y + y)
+	}
+}
+
+fn (elt Element) draw(mut ctx Context, x int, y int) {
+	$for T in Element.variants {
+		if elt is T {
+			elt.draw(mut ctx, x, y)
+			return
+		}
+	}
+}
+
+fn test_main() {
+	assert true
+}


### PR DESCRIPTION
Fix #20742