### PR TITLE
cgen: remove ull, which will cause compile error?

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -835,13 +835,13 @@ static inline uint64_t wyhash(const void *key, size_t len, uint64_t seed, const 
 	return _wymix(secret[1]^len,_wymix(a^secret[1],b^seed));
 }
 // the default secret parameters
-static const uint64_t _wyp[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
+static const uint64_t _wyp[4] = {0xa0761d6478bd642f, 0xe7037ed1a0b428db, 0x8ebc6af09c88c6e3, 0x589965cc75374cc3};
 
 // a useful 64bit-64bit mix function to produce deterministic pseudo random numbers that can pass BigCrush and PractRand
-static inline uint64_t wyhash64(uint64_t A, uint64_t B){ A^=0xa0761d6478bd642full; B^=0xe7037ed1a0b428dbull; _wymum(&A,&B); return _wymix(A^0xa0761d6478bd642full,B^0xe7037ed1a0b428dbull);}
+static inline uint64_t wyhash64(uint64_t A, uint64_t B){ A^=0xa0761d6478bd642f; B^=0xe7037ed1a0b428db; _wymum(&A,&B); return _wymix(A^0xa0761d6478bd642f,B^0xe7037ed1a0b428db);}
 
 // the wyrand PRNG that pass BigCrush and PractRand
-static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642full; return _wymix(*seed,*seed^0xe7037ed1a0b428dbull);}
+static inline uint64_t wyrand(uint64_t *seed){ *seed+=0xa0761d6478bd642f; return _wymix(*seed,*seed^0xe7037ed1a0b428db);}
 
 #ifndef __vinix__
 // convert any 64 bit pseudo random numbers to uniform distribution [0,1). It can be combined with wyrand, wyhash64 or wyhash.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
```sh
make fresh_vc
make[1]: Entering directory '/home/runner/work/v/v'
rm -rf ./vc
git clone --filter=blob:none --quiet https://github.com/vlang/vc ./vc
make[1]: Leaving directory '/home/runner/work/v/v'
cd ./vc && git clean -xf && git pull --quiet
make fresh_tcc
make[1]: Entering directory '/home/runner/work/v/v'
rm -rf ./thirdparty/tcc
git clone --filter=blob:none --quiet --branch thirdparty-linux-amd64 https://github.com/vlang/tccbin ./thirdparty/tcc
make[2]: Entering directory '/home/runner/work/v/v'
make[2]: Leaving directory '/home/runner/work/v/v'
make[1]: Leaving directory '/home/runner/work/v/v'
cd ./thirdparty/tcc && git clean -xf && git pull --quiet
cc  -std=gnu99 -w -o v1.exe ./vc/v.c -lm -lpthread 
./v1.exe -no-parallel -o v2.exe  cmd/v
vlib/v/gen/c/cheaders.v:839:52: error: this hexadecimal number has unsuitable digit `u`
  837 | }
  838 | // the default secret parameters
  839 | static const uint64_t _wyp[4] = {0xa0761d6478bd642full, 0xe7037ed1a0b428dbull, 0x8ebc6af09c88c6e3ull, 0x589965cc75374cc3ull};
      |                                                    ^
  840 | 
  841 | // a useful 64bit-64bit mix function to produce deterministic pseudo random numbers that can pass BigCrush and PractRand
make: *** [GNUmakefile:114: all] Error 1
Error: Process completed with exit code 2.
```