### PR TITLE
os: make SystemError public to enable use of os.error_* functions by other modules

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -1158,10 +1158,11 @@ pub fn last_error() IError {
 }
 
 // Magic constant because zero is used explicitly at times
-const error_code_not_set = 0x7EFEFEFE
+pub const error_code_not_set = 0x7EFEFEFE
 
 @[params]
-struct SystemError {
+pub struct SystemError {
+pub:
 	msg  string
 	code int = os.error_code_not_set
 }


### PR DESCRIPTION
This tiny PR makes the `SystemError` struct and the const `error_code_not_set` public, which will allow use of `os.error_posix()` and `os.error_win32()` by other modules.