### PR TITLE
os: refactor to use os.stat and os.lstat instead of unsafe C calls

### DIFF
--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -60,8 +60,9 @@ pub fn (m FileMode) bitmask() u32 {
 
 // inode returns the metadata of the file/inode, containing inode type, permission information, size and modification time.
 // it supports windows for regular files, but it doesn't matter if you use owner, group or others when checking permissions on windows.
+// if a symlink is targetted, it returns info on the link, not the target
 pub fn inode(path string) FileInfo {
-	attr := stat(path) or { Stat{} }
+	attr := lstat(path) or { Stat{} }
 	fm := attr.get_mode()
 	return FileInfo{
 		typ: fm.typ

--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -61,74 +61,14 @@ pub fn (m FileMode) bitmask() u32 {
 // inode returns the metadata of the file/inode, containing inode type, permission information, size and modification time.
 // it supports windows for regular files, but it doesn't matter if you use owner, group or others when checking permissions on windows.
 pub fn inode(path string) FileInfo {
-	mut attr := C.stat{}
-	$if windows {
-		// TODO: replace this with a C.GetFileAttributesW call instead.
-		// Use stat, lstat is not available on windows
-		unsafe { C.stat(&char(path.str), &attr) }
-		mut typ := FileType.regular
-		if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFDIR) {
-			typ = .directory
-		}
-		return FileInfo{
-			typ: typ
-			size: attr.st_size
-			mtime: attr.st_mtime
-			owner: FilePermission{
-				read: (attr.st_mode & u32(C.S_IREAD)) != 0
-				write: (attr.st_mode & u32(C.S_IWRITE)) != 0
-				execute: (attr.st_mode & u32(C.S_IEXEC)) != 0
-			}
-			group: FilePermission{
-				read: (attr.st_mode & u32(C.S_IREAD)) != 0
-				write: (attr.st_mode & u32(C.S_IWRITE)) != 0
-				execute: (attr.st_mode & u32(C.S_IEXEC)) != 0
-			}
-			others: FilePermission{
-				read: (attr.st_mode & u32(C.S_IREAD)) != 0
-				write: (attr.st_mode & u32(C.S_IWRITE)) != 0
-				execute: (attr.st_mode & u32(C.S_IEXEC)) != 0
-			}
-		}
-	} $else {
-		// note, that we use lstat here on purpose, to know the information about
-		// the potential symlinks themselves, not about the entities they point at
-		unsafe { C.lstat(&char(path.str), &attr) }
-		mut typ := FileType.unknown
-		if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFREG) {
-			typ = .regular
-		} else if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFDIR) {
-			typ = .directory
-		} else if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFCHR) {
-			typ = .character_device
-		} else if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFBLK) {
-			typ = .block_device
-		} else if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFIFO) {
-			typ = .fifo
-		} else if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFLNK) {
-			typ = .symbolic_link
-		} else if attr.st_mode & u32(C.S_IFMT) == u32(C.S_IFSOCK) {
-			typ = .socket
-		}
-		return FileInfo{
-			typ: typ
-			size: attr.st_size
-			mtime: attr.st_mtime
-			owner: FilePermission{
-				read: (attr.st_mode & u32(C.S_IRUSR)) != 0
-				write: (attr.st_mode & u32(C.S_IWUSR)) != 0
-				execute: (attr.st_mode & u32(C.S_IXUSR)) != 0
-			}
-			group: FilePermission{
-				read: (attr.st_mode & u32(C.S_IRGRP)) != 0
-				write: (attr.st_mode & u32(C.S_IWGRP)) != 0
-				execute: (attr.st_mode & u32(C.S_IXGRP)) != 0
-			}
-			others: FilePermission{
-				read: (attr.st_mode & u32(C.S_IROTH)) != 0
-				write: (attr.st_mode & u32(C.S_IWOTH)) != 0
-				execute: (attr.st_mode & u32(C.S_IXOTH)) != 0
-			}
-		}
+	attr := stat(path) or { Stat{} }
+	fm := attr.get_mode()
+	return FileInfo{
+		typ: fm.typ
+		owner: fm.owner
+		group: fm.group
+		others: fm.others
+		size: attr.size
+		mtime: attr.mtime
 	}
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -978,17 +978,18 @@ pub fn config_dir() !string {
 	return error('Cannot find config directory')
 }
 
+// Stat struct modeled on POSIX
 pub struct Stat {
 pub:
-	dev   u64
-	inode u64
-	mode  u32
-	nlink u64
-	uid   u32
-	gid   u32
-	rdev  u64
-	size  u64
-	atime i64
-	mtime i64
-	ctime i64
+	dev   u64 // ID of device containing file
+	inode u64 // Inode number
+	mode  u32 // File type and user/group/world permission bits
+	nlink u64 // Number of hard links to file
+	uid   u32 // Owner user ID
+	gid   u32 // Owner group ID
+	rdev  u64 // Device ID (if special file)
+	size  u64 // Total size in bytes
+	atime i64 // Last access (seconds since UNIX epoch)
+	mtime i64 // Last modified (seconds since UNIX epoch)
+	ctime i64 // Last status change (seconds since UNIX epoch)
 }

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -519,18 +519,15 @@ pub fn getegid() int {
 
 // Turns the given bit on or off, depending on the `enable` parameter
 pub fn posix_set_permission_bit(path_s string, mode u32, enable bool) {
-	mut s := C.stat{}
 	mut new_mode := u32(0)
-	path := &char(path_s.str)
-	unsafe {
-		C.stat(path, &s)
-		new_mode = s.st_mode
+	if s := stat(path_s) {
+		new_mode = s.mode
 	}
 	match enable {
 		true { new_mode |= mode }
 		false { new_mode &= (0o7777 - mode) }
 	}
-	C.chmod(path, int(new_mode))
+	C.chmod(&char(path_s.str), int(new_mode))
 }
 
 // get_long_path has no meaning for *nix, but has for windows, where `c:\folder\some~1` for example

--- a/vlib/os/os_stat_default.c.v
+++ b/vlib/os/os_stat_default.c.v
@@ -117,14 +117,14 @@ pub fn is_dir(path string) bool {
 // Warning: `is_link()` is known to cause a TOCTOU vulnerability when used incorrectly
 // (for more information: https://github.com/vlang/v/blob/master/vlib/os/README.md)
 pub fn is_link(path string) bool {
-	attr := stat(path) or { return false }
+	attr := lstat(path) or { return false }
 	return attr.get_filetype() == .symbolic_link
 }
 
 // kind_of_existing_path identifies whether path is a file, directory, or link
 fn kind_of_existing_path(path string) PathKind {
 	mut res := PathKind{}
-	attr := stat(path) or { return res }
+	attr := lstat(path) or { return res }
 	res.is_file = attr.get_filetype() == .regular
 	res.is_dir = attr.get_filetype() == .directory
 	res.is_link = attr.get_filetype() == .symbolic_link

--- a/vlib/os/os_stat_default.c.v
+++ b/vlib/os/os_stat_default.c.v
@@ -2,9 +2,36 @@ module os
 
 // stat returns a platform-agnostic Stat struct comparable to what is
 // available in other programming languages and fails with the POSIX
+// error if the stat call fails. Symlinks are followed and the resulting
+// Stat provided. (If this is not desired, use lstat().)
+pub fn stat(path string) !Stat {
+	mut s := C.stat{}
+	unsafe {
+		res := C.stat(&char(path.str), &s)
+		if res != 0 {
+			return error_posix()
+		}
+		return Stat{
+			dev: s.st_dev
+			inode: s.st_ino
+			nlink: s.st_nlink
+			mode: s.st_mode
+			uid: s.st_uid
+			gid: s.st_gid
+			rdev: s.st_rdev
+			size: s.st_size
+			atime: s.st_atime
+			mtime: s.st_mtime
+			ctime: s.st_ctime
+		}
+	}
+}
+
+// lstat returns a platform-agnostic Stat struct comparable to what is
+// available in other programming languages and fails with the POSIX
 // error if the stat call fails. If a link is stat'd, the stat info
 // for the link is provided.
-pub fn stat(path string) !Stat {
+pub fn lstat(path string) !Stat {
 	mut s := C.stat{}
 	unsafe {
 		res := C.lstat(&char(path.str), &s)

--- a/vlib/os/os_stat_default.c.v
+++ b/vlib/os/os_stat_default.c.v
@@ -79,3 +79,27 @@ pub fn (st Stat) get_mode() FileMode {
 		}
 	}
 }
+
+// is_dir returns a `bool` indicating whether the given `path` is a directory.
+pub fn is_dir(path string) bool {
+	attr := stat(path) or { return false }
+	return attr.get_filetype() == .directory
+}
+
+// is_link returns a boolean indicating whether `path` is a link.
+// Warning: `is_link()` is known to cause a TOCTOU vulnerability when used incorrectly
+// (for more information: https://github.com/vlang/v/blob/master/vlib/os/README.md)
+pub fn is_link(path string) bool {
+	attr := stat(path) or { return false }
+	return attr.get_filetype() == .symbolic_link
+}
+
+// kind_of_existing_path identifies whether path is a file, directory, or link
+fn kind_of_existing_path(path string) PathKind {
+	mut res := PathKind{}
+	attr := stat(path) or { return res }
+	res.is_file = attr.get_filetype() == .regular
+	res.is_dir = attr.get_filetype() == .directory
+	res.is_link = attr.get_filetype() == .symbolic_link
+	return res
+}

--- a/vlib/os/os_stat_windows.c.v
+++ b/vlib/os/os_stat_windows.c.v
@@ -29,6 +29,12 @@ pub fn stat(path string) !Stat {
 	}
 }
 
+// lstat is the same as stat() for Windows
+@[inline]
+pub fn lstat(path string) !Stat {
+	return stat(path)
+}
+
 // get_filetype returns the FileType from the Stat struct
 pub fn (st Stat) get_filetype() FileType {
 	match st.mode & u32(C.S_IFMT) {


### PR DESCRIPTION
Goal: simplify `os` codebase and reduce number of unsafe blocks.

Changes:
- Introduce os.lstat() to call C.lstat explicitly to be consistent with the behavior of C.stat() and C.lstat()
- Refactor the following functions to use os.stat() or os.lstat(): file_size, cp, is_executable, is_dir, is_link, kind_of_existing_path, file_last_mod_unix, posix_set_permission_bit, and inode
- Add comments to the Stat struct

When appropriate because of Win API instead of C lib calls, split functions between os_stat_default.c.v or os_stat_windows.c.v.

Regression tested with existing os tests.