### PR TITLE
table: fix global const ordering with string inter literal

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2418,6 +2418,11 @@ pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
 		PrefixExpr {
 			names << t.dependent_names_in_expr(expr.right)
 		}
+		StringInterLiteral {
+			for inter_expr in expr.exprs {
+				names << t.dependent_names_in_expr(inter_expr)
+			}
+		}
 		SelectorExpr {
 			names << t.dependent_names_in_expr(expr.expr)
 		}

--- a/vlib/v/tests/const_order_with_str_interp_test.v
+++ b/vlib/v/tests/const_order_with_str_interp_test.v
@@ -1,0 +1,9 @@
+import os
+
+const exe_path = os.executable()
+const exe_old_path = '${exe_path}.old'
+
+fn test_main() {
+	assert exe_path == os.executable()
+	assert exe_old_path == '${os.executable()}.old'
+}


### PR DESCRIPTION
Fix #20760