### PR TITLE
fix coroutines with boehm GC by using stack pointer corrector

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -103,6 +103,7 @@ $if gcboehm_leak ? {
 }
 
 #include <gc.h>
+// #include <gc/gc_mark.h>
 
 // replacements for `malloc()/calloc()`, `realloc()` and `free()`
 // for use with Boehm-GC
@@ -148,11 +149,19 @@ pub struct C.GC_stack_base {
 	// reg_base voidptr
 }
 
-// pub struct C.GC_stack_base{}
-
 fn C.GC_get_stack_base(voidptr)
 fn C.GC_register_my_thread(voidptr) int
 fn C.GC_unregister_my_thread() int
 
+// fn C.GC_get_my_stackbottom(voidptr) voidptr
+// fn C.GC_set_stackbottom(voidptr, voidptr)
+// fn C.GC_push_all_stacks()
+
 fn C.GC_add_roots(voidptr, voidptr)
 fn C.GC_remove_roots(voidptr, voidptr)
+
+// fn C.GC_get_push_other_roots() fn()
+// fn C.GC_set_push_other_roots(fn())
+
+fn C.GC_get_sp_corrector() fn (voidptr, voidptr)
+fn C.GC_set_sp_corrector(fn (voidptr, voidptr))

--- a/vlib/coroutines/coroutines.c.v
+++ b/vlib/coroutines/coroutines.c.v
@@ -85,6 +85,9 @@ fn dealloc(_ voidptr, stack_ptr voidptr, stack_size int) {
 }
 
 fn init() {
+	// NOTE `sp_corrector` only works for platforms with the stack growing down
+	// MacOs, Win32 and Linux always have stack growing down.
+	// A proper solution is planned (hopefully) for boehm v8.4.0.
 	C.GC_set_sp_corrector(C.sp_corrector)
 	if C.GC_get_sp_corrector() == unsafe { nil } {
 		panic('stack pointer correction unsupported')

--- a/vlib/coroutines/coroutines.c.v
+++ b/vlib/coroutines/coroutines.c.v
@@ -75,7 +75,7 @@ fn dealloc(_ voidptr, stack_ptr voidptr, stack_size int) {
 	unsafe {
 		$if gcboehm ? {
 			// TODO: only do this once when the worker thread is killed (not in each coroutine)
-			// come up with a solution for this and `C.GC_register_my_thread(` (see alloc above)
+			// come up with a solution for this and `C.GC_register_my_thread` (see alloc above)
 			// C.GC_unregister_my_thread()
 
 			C.GC_remove_roots(stack_ptr, charptr(stack_ptr) + stack_size)
@@ -92,7 +92,6 @@ fn init() {
 	if C.GC_get_sp_corrector() == unsafe { nil } {
 		panic('stack pointer correction unsupported')
 	}
-	// C.GC_set_sp_corrector(C.sp_corrector)
 	C.set_photon_thread_stack_allocator(alloc, dealloc)
 	ret := C.photon_init_default()
 

--- a/vlib/coroutines/sp_corrector.c
+++ b/vlib/coroutines/sp_corrector.c
@@ -1,0 +1,32 @@
+// TODO: convert this to v code? handle all platforms
+// currently if it's not macos or win it defaults to the linux impl
+
+static void sp_corrector(void** sp_ptr, void* tid) {
+    size_t stack_size;
+    char* stack_addr;
+#ifdef __APPLE__
+    stack_size = pthread_get_stacksize_np((pthread_t)tid);
+    stack_addr = (char*) pthread_get_stackaddr_np((pthread_t)tid);
+#elif defined(_WIN64)
+    ULONG_PTR stack_low, stack_high;
+    GetCurrentThreadStackLimits(&stack_low, &stack_high);
+    stack_size = stack_high - stack_low;
+    stack_addr = (char*)stack_low;
+// #elif defined(__linux__)
+//     pthread_attr_t gattr;
+//     pthread_getattr_np((pthread_t)tid, &gattr);
+//     pthread_attr_getstack(&gattr, (void**)&stack_addr, &stack_size);
+//     pthread_attr_destroy(&gattr);
+// #else
+//     assert("unsupported platform");
+#else
+    pthread_attr_t gattr;
+    pthread_getattr_np((pthread_t)tid, &gattr);
+    pthread_attr_getstack(&gattr, (void**)&stack_addr, &stack_size);
+    pthread_attr_destroy(&gattr);
+#endif
+    char sp = (char)*sp_ptr;
+    if(sp <= (char)stack_addr || sp >= (char)(stack_addr+stack_size)) {
+        *sp_ptr = (void*)stack_addr;
+    }
+}

--- a/vlib/coroutines/sp_corrector.c
+++ b/vlib/coroutines/sp_corrector.c
@@ -26,7 +26,7 @@ static void sp_corrector(void** sp_ptr, void* tid) {
     pthread_attr_destroy(&gattr);
 #endif
     char sp = (char)*sp_ptr;
-    if(sp <= (char)stack_addr || sp >= (char)(stack_addr+stack_size)) {
+    if(sp <= stack_addr || sp >= stack_addr+stack_size) {
         *sp_ptr = (void*)stack_addr;
     }
 }

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -110,8 +110,9 @@ fn (mut g Gen) gen_c_main_header() {
 			g.writeln('\tGC_set_find_leak(1);')
 		}
 		g.writeln('\tGC_set_pages_executable(0);')
-		// NOTE: required when using GC_MALLOC & GC_register_my_thread
-		g.writeln('\tGC_allow_register_threads();')
+		if g.pref.use_coroutines {
+			g.writeln('\tGC_allow_register_threads();')
+		}
 		g.writeln('\tGC_INIT();')
 
 		if g.pref.gc_mode in [.boehm_incr, .boehm_incr_opt] {
@@ -247,7 +248,9 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 			g.writeln('\tGC_set_find_leak(1);')
 		}
 		g.writeln('\tGC_set_pages_executable(0);')
-		g.writeln('\tGC_allow_register_threads();')
+		if g.pref.use_coroutines {
+			g.writeln('\tGC_allow_register_threads();')
+		}
 		g.writeln('\tGC_INIT();')
 		if g.pref.gc_mode in [.boehm_incr, .boehm_incr_opt] {
 			g.writeln('\tGC_enable_incremental();')

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -111,7 +111,7 @@ fn (mut g Gen) gen_c_main_header() {
 		}
 		g.writeln('\tGC_set_pages_executable(0);')
 		// NOTE: required when using GC_MALLOC & GC_register_my_thread
-		// g.writeln('\tGC_allow_register_threads();')
+		g.writeln('\tGC_allow_register_threads();')
 		g.writeln('\tGC_INIT();')
 
 		if g.pref.gc_mode in [.boehm_incr, .boehm_incr_opt] {
@@ -247,8 +247,7 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 			g.writeln('\tGC_set_find_leak(1);')
 		}
 		g.writeln('\tGC_set_pages_executable(0);')
-		// NOTE: required when using GC_MALLOC & GC_register_my_thread
-		// g.writeln('\tGC_allow_register_threads();')
+		g.writeln('\tGC_allow_register_threads();')
 		g.writeln('\tGC_INIT();')
 		if g.pref.gc_mode in [.boehm_incr, .boehm_incr_opt] {
 			g.writeln('\tGC_enable_incremental();')


### PR DESCRIPTION
**This will only work once all the GC static libs are rebuilt to the newest version (actually it seems to be passing anyway, maybe there are no tests running for it 🤔)**

This fixes the GC crashes with coroutines. 

The segfaults were caused because boehm GC knows nothing about coroutines, it only knows about threads.
coroutines allocate their own stack and then the stack pointer is modified to point to that stack, however the GC does not know that this has happened. So we need to tell the GC about the correct stack base.