### PR TITLE
ast: make Scope.find methods more robust, when called on default initialised `scope &Scope = unsafe { nil }` fields

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -162,6 +162,7 @@ const skip_with_fsanitize_memory = [
 	'vlib/v/tests/orm_stmt_wrong_return_checking_test.v',
 	'vlib/v/tests/orm_table_name_test.v',
 	'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
+	'vlib/v/tests/orm_create_several_tables_test.v',
 	'vlib/vweb/tests/vweb_test.v',
 	'vlib/vweb/csrf/csrf_test.v',
 	'vlib/vweb/request_test.v',

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -187,6 +187,7 @@ const skip_with_fsanitize_address = [
 	'vlib/v/tests/orm_enum_test.v',
 	'vlib/v/tests/orm_sub_array_struct_test.v',
 	'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
+	'vlib/v/tests/orm_create_several_tables_test.v',
 ]
 const skip_with_fsanitize_undefined = [
 	'do_not_remove',
@@ -197,6 +198,7 @@ const skip_with_fsanitize_undefined = [
 	'vlib/v/tests/orm_enum_test.v',
 	'vlib/v/tests/orm_sub_array_struct_test.v',
 	'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
+	'vlib/v/tests/orm_create_several_tables_test.v',
 	'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v', // fails compilation with: undefined reference to vtable for __cxxabiv1::__function_type_info'
 ]
 const skip_with_werror = [
@@ -250,6 +252,7 @@ const skip_on_ubuntu_musl = [
 	'vlib/v/tests/orm_stmt_wrong_return_checking_test.v',
 	'vlib/v/tests/orm_table_name_test.v',
 	'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',
+	'vlib/v/tests/orm_create_several_tables_test.v',
 	'vlib/v/tests/sql_statement_inside_fn_call_test.v',
 	'vlib/clipboard/clipboard_test.v',
 	'vlib/vweb/tests/vweb_test.v',

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -18,6 +18,9 @@ pub mut:
 
 @[unsafe]
 pub fn (s &Scope) free() {
+	if s == unsafe { nil } {
+		return
+	}
 	unsafe {
 		s.objects.free()
 		s.struct_fields.free()
@@ -42,6 +45,9 @@ fn (s &Scope) dont_lookup_parent() bool {
 }
 
 pub fn (s &Scope) find(name string) ?ScopeObject {
+	if s == unsafe { nil } {
+		return none
+	}
 	for sc := unsafe { s }; true; sc = sc.parent {
 		if name in sc.objects {
 			return unsafe { sc.objects[name] }
@@ -55,6 +61,9 @@ pub fn (s &Scope) find(name string) ?ScopeObject {
 
 // selector_expr:  name.field_name
 pub fn (s &Scope) find_struct_field(name string, struct_type Type, field_name string) ?ScopeStructField {
+	if s == unsafe { nil } {
+		return none
+	}
 	for sc := unsafe { s }; true; sc = sc.parent {
 		if field := sc.struct_fields[name] {
 			if field.struct_type == struct_type && field.name == field_name {
@@ -184,6 +193,9 @@ pub fn (s &Scope) innermost(pos int) &Scope {
 
 // get_all_vars extracts all current scope vars
 pub fn (s &Scope) get_all_vars() []ScopeObject {
+	if s == unsafe { nil } {
+		return []
+	}
 	mut scope_vars := []ScopeObject{}
 	for sc := unsafe { s }; true; sc = sc.parent {
 		if sc.objects.len > 0 {
@@ -212,7 +224,7 @@ pub fn (s &Scope) has_inherited_vars() bool {
 	return false
 }
 
-pub fn (sc Scope) show(depth int, max_depth int) string {
+pub fn (sc &Scope) show(depth int, max_depth int) string {
 	mut out := ''
 	mut indent := ''
 	for _ in 0 .. depth * 4 {
@@ -237,6 +249,6 @@ pub fn (sc Scope) show(depth int, max_depth int) string {
 	return out
 }
 
-pub fn (sc Scope) str() string {
+pub fn (sc &Scope) str() string {
 	return sc.show(0, 0)
 }

--- a/vlib/v/tests/orm_create_several_tables_test.v
+++ b/vlib/v/tests/orm_create_several_tables_test.v
@@ -1,0 +1,46 @@
+module main
+
+import os
+import db.sqlite
+
+@[table: 'visits']
+struct Visit {
+	id   int    @[primary; sql: serial]
+	site string
+}
+
+@[table: 'sites']
+struct Site {
+	hostname string  @[primary]
+	owner    int
+	visits   []Visit @[fkey: 'site']
+}
+
+@[table: 'users']
+struct User {
+	id    int    @[primary; sql: serial]
+	name  string
+	sites []Site @[fkey: 'owner']
+}
+
+fn init_db(path string) !sqlite.DB {
+	mut db := sqlite.connect(path)!
+
+	sql db {
+		create table User
+		create table Site
+		create table Visit
+	}!
+
+	return db
+}
+
+fn test_creating_db() {
+	db_folder := os.join_path(os.vtmp_dir(), 'creating_db')
+	os.mkdir_all(db_folder)!
+	db_path := os.join_path(db_folder, 'abc.db')
+	dump(db_path)
+	mut db := init_db(db_path)!
+	dump(db)
+	db.close()!
+}

--- a/vlib/v/tests/orm_create_several_tables_test.v
+++ b/vlib/v/tests/orm_create_several_tables_test.v
@@ -1,6 +1,5 @@
 module main
 
-import os
 import db.sqlite
 
 @[table: 'visits']
@@ -23,24 +22,12 @@ struct User {
 	sites []Site @[fkey: 'owner']
 }
 
-fn init_db(path string) !sqlite.DB {
-	mut db := sqlite.connect(path)!
-
+fn test_creating_db() {
+	mut db := sqlite.connect(':memory:')!
 	sql db {
 		create table User
 		create table Site
 		create table Visit
 	}!
-
-	return db
-}
-
-fn test_creating_db() {
-	db_folder := os.join_path(os.vtmp_dir(), 'creating_db')
-	os.mkdir_all(db_folder)!
-	db_path := os.join_path(db_folder, 'abc.db')
-	dump(db_path)
-	mut db := init_db(db_path)!
-	dump(db)
 	db.close()!
 }


### PR DESCRIPTION
Fix https://github.com/vlang/v/issues/18324 .