### PR TITLE
fix path in `js_dom_draw_benchmark` example docs

### DIFF
--- a/examples/js_dom_draw_benchmark_chart/README.md
+++ b/examples/js_dom_draw_benchmark_chart/README.md
@@ -12,7 +12,7 @@
 The steps below assume that your current directory path is the examples project directory.
 
 ```
-cd examples/js_dom_draw_bechmark_chart
+cd examples/js_dom_draw_benchmark_chart
 ```
 
 Execute the following commands in separate terminal instances.

--- a/examples/js_dom_draw_benchmark_chart/chart/README.md
+++ b/examples/js_dom_draw_benchmark_chart/chart/README.md
@@ -15,7 +15,7 @@ A message like `[Vweb] Running app on http://localhost:3001/` should appear
 
 # To implement new benchmarks in v
 
-In `examples/js_dom_draw_bechmark_chart/v_vweb_orm/src/main.v` path
+In `examples/js_dom_draw_benchmark_chart/v_vweb_orm/src/main.v` path
 Create a route returning a `Response` struct like:
 
 ```v ignore


### PR DESCRIPTION
Example was renamed, but README files weren't updated.