### PR TITLE
cgen: use C99 short fixed array init syntax

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -96,8 +96,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		if var_name.len == 0 {
 			g.write('${ret_typ} ${past.tmp_var} =')
 		}
-		g.write('{0}')
-		g.writeln(';')
+		g.writeln('{0};')
 		g.writeln('{')
 		g.indent++
 		g.writeln('${elem_typ}* pelem = (${elem_typ}*)${past.tmp_var};')


### PR DESCRIPTION
Before this change, cgen would initialize fixed arrays like this:

```c
Array_fixed_u8_5 buffer = {0, 0, 0, 0, 0};
```

This means that large arrays would generate *a lot* of C code just for initializing the array, and that significantly increased compilation times. C99 allows this short initialization syntax (see C99 6.7.8/21):

```c
Array_fixed_u8_2048 buffer = {0}; // array of 2048 zeroes
```

Size of v.c before this change: 6,35 MB (6 665 526 bytes)
Size of v.c after this change: 6,11 MB (6 411 950 bytes) **(-253 kb)**
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
