### PR TITLE
builtin: add gc_collect/0, gc_get_warn_proc/0, gc_set_warn_proc/1. Use them to turn off GC warnings by default.

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -134,6 +134,13 @@ fn C.GC_is_disabled() int
 // protect memory block from being freed before this call
 fn C.GC_reachable_here(voidptr)
 
+// gc_collect explicitly performs a garbage collection run.
+// Note, that garbage collections are done automatically when needed in most cases,
+// so usually you should need to call that function often.
+pub fn gc_collect() {
+	C.GC_gcollect()
+}
+
 // for leak detection it is advisable to do explicit garbage collections
 pub fn gc_check_leaks() {
 	$if gcboehm_leak ? {
@@ -165,3 +172,22 @@ fn C.GC_remove_roots(voidptr, voidptr)
 
 fn C.GC_get_sp_corrector() fn (voidptr, voidptr)
 fn C.GC_set_sp_corrector(fn (voidptr, voidptr))
+
+// GC warnings are silenced by default, but can be redirected to a custom cb function by programs too:
+type FnGC_WarnCB = fn (msg &char, arg usize)
+
+fn C.GC_get_warn_proc() FnGC_WarnCB
+fn C.GC_set_warn_proc(cb FnGC_WarnCB)
+
+// gc_get_warn_proc returns the current callback fn, that will be used for printing GC warnings
+pub fn gc_get_warn_proc() FnGC_WarnCB {
+	return C.GC_get_warn_proc()
+}
+
+// gc_set_warn_proc sets the callback fn, that will be used for printing GC warnings
+pub fn gc_set_warn_proc(cb FnGC_WarnCB) {
+	C.GC_set_warn_proc(cb)
+}
+
+// used by builtin_init:
+fn internal_gc_warn_proc_none(msg &char, arg usize) {}

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -4,7 +4,7 @@
 module builtin
 
 fn builtin_init() {
-	// Do nothing
+	gc_set_warn_proc(internal_gc_warn_proc_none)
 }
 
 fn break_if_debugger_attached() {

--- a/vlib/builtin/builtin_notd_gcboehm.c.v
+++ b/vlib/builtin/builtin_notd_gcboehm.c.v
@@ -20,18 +20,25 @@ fn C.GC_get_memory_use() usize
 
 fn C.GC_gcollect()
 
-// gc_check_leaks is useful for detecting leaks, but it needs the GC to run. When it is not used, it is a NOP.
+// gc_check_leaks is useful for detecting leaks, but it needs the GC to run.
+// When GC is not used, it is a NOP.
 pub fn gc_check_leaks() {}
 
-// gc_collect explicitly performs a garbage collection. When the GC is not on, it is a NOP.
+// gc_collect explicitly performs a garbage collection.
+// When the GC is not on, it is a NOP.
 pub fn gc_collect() {}
 
 type FnGC_WarnCB = fn (msg &char, arg usize)
 
 fn C.GC_get_warn_proc() FnGC_WarnCB
 fn C.GC_set_warn_proc(cb FnGC_WarnCB)
+
+// gc_get_warn_proc returns the current callback fn, that will be used for printing GC warnings.
+// When the GC is not on, it is a NOP.
 pub fn gc_get_warn_proc() {}
 
+// gc_set_warn_proc sets the callback fn, that will be used for printing GC warnings.
+// When the GC is not on, it is a NOP.
 pub fn gc_set_warn_proc(cb FnGC_WarnCB) {}
 
 // used by builtin_init

--- a/vlib/builtin/builtin_notd_gcboehm.c.v
+++ b/vlib/builtin/builtin_notd_gcboehm.c.v
@@ -18,7 +18,21 @@ fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_byt
 
 fn C.GC_get_memory_use() usize
 
-// provide an empty function when manual memory management is used
-// to simplify leak detection
-//
+fn C.GC_gcollect()
+
+// gc_check_leaks is useful for detecting leaks, but it needs the GC to run. When it is not used, it is a NOP.
 pub fn gc_check_leaks() {}
+
+// gc_collect explicitly performs a garbage collection. When the GC is not on, it is a NOP.
+pub fn gc_collect() {}
+
+type FnGC_WarnCB = fn (msg &char, arg usize)
+
+fn C.GC_get_warn_proc() FnGC_WarnCB
+fn C.GC_set_warn_proc(cb FnGC_WarnCB)
+pub fn gc_get_warn_proc() {}
+
+pub fn gc_set_warn_proc(cb FnGC_WarnCB) {}
+
+// used by builtin_init
+fn internal_gc_warn_proc_none(msg &char, arg usize) {}

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -48,6 +48,7 @@ const enable_wrap_at_eol_output = 2
 const evable_virtual_terminal_processing = 4
 
 fn builtin_init() {
+	gc_set_warn_proc(internal_gc_warn_proc_none)
 	g_original_codepage = C.GetConsoleOutputCP()
 	C.SetConsoleOutputCP(cp_utf8)
 	C.atexit(restore_codepage)


### PR DESCRIPTION
With the new prebuilt libgc.a, I get warnings when running gg programs, similar to this one: 
```
#0 14:26:29 ᛋ master /v/oo❱v run examples/gg/mandelbrot.v
GC Warning: Heap grown by 4600 KiB while GC was disabled
```

This PR silences them by default, while also giving an API for redirecting them to a user specified callback, if needed.