### PR TITLE
x.sessions: change session Store interface to use results instead of options

### DIFF
--- a/vlib/x/sessions/README.md
+++ b/vlib/x/sessions/README.md
@@ -199,7 +199,7 @@ method.
 **Example:**
 ```v ignore
 pub fn (mut app App) logout(mut ctx Context) vweb.Result {
-	app.sessions.logout(mut ctx) or { return ctx.server_error('could logout, please try again') }
+	app.sessions.logout(mut ctx) or { return ctx.server_error('could not logout, please try again') }
 	return ctx.text('You are now logged out!')
 }
 ```

--- a/vlib/x/sessions/README.md
+++ b/vlib/x/sessions/README.md
@@ -159,7 +159,7 @@ pub fn (mut app App) login(mut ctx Context) vweb.Result {
 	// set a session id cookie and save data for the new user
 	app.sessions.save(mut ctx, User{
 		name: '[no name provided]'
-	})
+	}) or { return ctx.server_error('could not save session data, please try again') }
 	return ctx.text('You are now logged in!')
 }
 ```
@@ -181,7 +181,7 @@ pub fn (mut app App) save(mut ctx Context) vweb.Result {
 		// update the current user
 		app.sessions.save(mut ctx, User{
 			name: name
-		})
+		}) or { return ctx.server_error('could not save session data, please try again') }
 		return ctx.redirect('/', typ: .see_other)
 	} else {
 		// send HTTP 400 error
@@ -199,7 +199,7 @@ method.
 **Example:**
 ```v ignore
 pub fn (mut app App) logout(mut ctx Context) vweb.Result {
-	app.sessions.logout(mut ctx)
+	app.sessions.logout(mut ctx) or { return ctx.server_error('could logout, please try again') }
 	return ctx.text('You are now logged out!')
 }
 ```
@@ -277,7 +277,7 @@ and for verifying a signed session id. You can ofcourse generate your own sessio
 // generate a new session id and sign it
 session_id, signed_session_id := sessions.new_session_id(secret)
 // save session data to our store
-store.set(session_id, user)
+store.set(session_id, user)!
 
 // get a normal session id from the signed version and verify it
 verified_session_id, valid := sessions.verify_session_id(signed_session_id, secret)
@@ -310,20 +310,20 @@ mut:
 	// get the current session data if the id exists and if it's not expired.
 	// If the session is expired, any associated data should be destroyed.
 	// If `max_age=0` the store will not check for expiration of the session.
-	get(sid string, max_age time.Duration) ?T
+	get(sid string, max_age time.Duration) !T
 	// destroy session data for `sid`
-	destroy(sid string)
+	destroy(sid string) !
 	// set session data for `sid`
-	set(sid string, val T)
+	set(sid string, val T) !
 }
 
 // get data from all sessions, optional to implement
-pub fn (mut s Store) all[T]() []T {
+pub fn (mut s Store) all[T]() ![]T {
 	return []T{}
 }
 
 // clear all session data, optional to implement
-pub fn (mut s Store) clear[T]() {}
+pub fn (mut s Store) clear[T]() ! {}
 ```
 
 Only the `get`, `destroy` and `set` methods are required to implement.

--- a/vlib/x/sessions/db_store.v
+++ b/vlib/x/sessions/db_store.v
@@ -32,70 +32,61 @@ pub fn DBStore.create[T](db orm.Connection) !DBStore[T] {
 }
 
 // all gets the data from all sessions
-pub fn (mut store DBStore[T]) all() []T {
+pub fn (mut store DBStore[T]) all() ![]T {
 	rows := sql store.db {
 		select from DBStoreSessions
-	} or { []DBStoreSessions{} }
+	}!
 
 	// decode should never fail
-	return rows.map(json.decode(T, it.data) or {
-		eprintln('[vweb.sessions] DBStore error while decoding session data: ${err.msg()}')
-		T{}
-	})
+	return rows.map(json.decode(T, it.data)!)
 }
 
 // get session for session id `sid`. The session can be `max_age` old.
 // `max_age` will be ignored when set to `0`
-pub fn (mut store DBStore[T]) get(sid string, max_age time.Duration) ?T {
+pub fn (mut store DBStore[T]) get(sid string, max_age time.Duration) !T {
 	rows := sql store.db {
 		select from DBStoreSessions where session_id == sid
-	} or {
-		eprintln('[vweb.sessions] DBStore orm error: ${err.msg()}')
-		return none
-	}
+	}!
 
 	if rows.len == 1 {
 		record := rows[0]
 		// session is expired
 		if max_age != 0 && record.created_at.add(max_age) < time.now() {
-			store.destroy(sid)
-			return none
+			store.destroy(sid)!
+			return error('session is expired')
 		}
 
-		return json.decode(T, record.data) or { none }
+		return json.decode(T, record.data)!
 	} else {
-		return none
+		return error('session does not exist')
 	}
 }
 
 // destroy data for session id `sid`
-pub fn (mut store DBStore[T]) destroy(sid string) {
+pub fn (mut store DBStore[T]) destroy(sid string) ! {
 	sql store.db {
 		delete from DBStoreSessions where session_id == sid
-	} or { eprintln('[vweb.sessions] DBStore orm error: ${err.msg()}') }
+	}!
 }
 
 // clear all sessions
-pub fn (mut store DBStore[T]) clear() {
+pub fn (mut store DBStore[T]) clear() ! {
 	sql store.db {
 		delete from DBStoreSessions where session_id != ''
-	} or { eprintln('[vweb.sessions] DBStore orm error: ${err.msg()}') }
+	}!
 }
 
 // set session data for session id `sid`
-pub fn (mut store DBStore[T]) set(sid string, val T) {
+pub fn (mut store DBStore[T]) set(sid string, val T) ! {
 	count := sql store.db {
 		select count from DBStoreSessions where session_id == sid
-	} or {
-		eprintln('[vweb.sessions] DBStore orm error: ${err.msg()}')
-		return
-	}
+	}!
 
 	if count == 1 {
 		stringified := json.encode(val)
 		sql store.db {
 			update DBStoreSessions set data = stringified where session_id == sid
-		} or { eprintln('[vweb.sessions] DBStore orm error: ${err.msg()}') }
+		}!
 	} else {
 		record := DBStoreSessions{
 			session_id: sid
@@ -105,6 +96,6 @@ pub fn (mut store DBStore[T]) set(sid string, val T) {
 
 		sql store.db {
 			insert record into DBStoreSessions
-		} or { eprintln('[vweb.sessions] DBStore orm error: ${err.msg()}') }
+		}!
 	}
 }

--- a/vlib/x/sessions/memory_store.v
+++ b/vlib/x/sessions/memory_store.v
@@ -15,38 +15,38 @@ mut:
 }
 
 // get data from all sessions
-pub fn (mut store MemoryStore[T]) all() []T {
+pub fn (mut store MemoryStore[T]) all() ![]T {
 	return store.data.values().map(it.data)
 }
 
 // get session for session id `sid`. The session can be `max_age` old.
 // `max_age` will be ignored when set to `0`
-pub fn (mut store MemoryStore[T]) get(sid string, max_age time.Duration) ?T {
+pub fn (mut store MemoryStore[T]) get(sid string, max_age time.Duration) !T {
 	if record := store.data[sid] {
 		// session is expired
 		if max_age != 0 && record.created_at.add(max_age) < time.now() {
-			store.destroy(sid)
-			return none
+			store.destroy(sid)!
+			return error('session is expired')
 		}
 
 		return record.data
 	} else {
-		return none
+		return error('session does not exist')
 	}
 }
 
 // destroy data for session id `sid`
-pub fn (mut store MemoryStore[T]) destroy(sid string) {
+pub fn (mut store MemoryStore[T]) destroy(sid string) ! {
 	store.data.delete(sid)
 }
 
 // clear all sessions
-pub fn (mut store MemoryStore[T]) clear() {
+pub fn (mut store MemoryStore[T]) clear() ! {
 	store.data.clear()
 }
 
 // set session data for session id `sid`
-pub fn (mut store MemoryStore[T]) set(sid string, val T) {
+pub fn (mut store MemoryStore[T]) set(sid string, val T) ! {
 	if sid in store.data {
 		store.data[sid].data = val
 	} else {

--- a/vlib/x/sessions/store.v
+++ b/vlib/x/sessions/store.v
@@ -5,17 +5,17 @@ import time
 pub interface Store[T] {
 mut:
 	// get the current session data if the id exists and if it's not expired
-	get(sid string, max_age time.Duration) ?T
+	get(sid string, max_age time.Duration) !T
 	// destroy session data for `sid`
-	destroy(sid string)
+	destroy(sid string) !
 	// set session data for `val`
-	set(sid string, val T)
+	set(sid string, val T) !
 }
 
 // get data from all sessions, optional to implement
-pub fn (mut s Store) all[T]() []T {
+pub fn (mut s Store) all[T]() ![]T {
 	return []T{}
 }
 
 // clear all session data, optional to implement
-pub fn (mut s Store) clear[T]() {}
+pub fn (mut s Store) clear[T]() ! {}

--- a/vlib/x/sessions/tests/db_store_test.v
+++ b/vlib/x/sessions/tests/db_store_test.v
@@ -32,7 +32,7 @@ fn test_store_set() {
 		db.close() or {}
 	}
 	mut store := sessions.DBStore.create[User](db)!
-	store.set('a', default_user)
+	store.set('a', default_user)!
 
 	mut rows := sql db {
 		select from sessions.DBStoreSessions
@@ -44,7 +44,7 @@ fn test_store_set() {
 	assert rows[0].data == default_user_encoded
 
 	first_created := rows[0].created_at
-	store.set('a', User{ age: 99 })
+	store.set('a', User{ age: 99 })!
 
 	rows = sql db {
 		select from sessions.DBStoreSessions
@@ -60,12 +60,12 @@ fn test_store_get() {
 		db.close() or {}
 	}
 	mut store := sessions.DBStore.create[User](db)!
-	store.set('b', default_user)
+	store.set('b', default_user)!
 
 	if data := store.get('b', max_age) {
 		assert data == default_user
 	} else {
-		assert true == false, 'session data should not be none'
+		assert false, 'session data should not be none'
 	}
 }
 
@@ -75,12 +75,14 @@ fn test_store_session_expired() {
 		db.close() or {}
 	}
 	mut store := sessions.DBStore.create[User](db)!
-	store.set('c', default_user)
+	store.set('c', default_user)!
 
 	time.sleep(2 * max_age)
 
 	if data := store.get('c', max_age) {
-		assert true == false, 'session should be expired!'
+		assert false, 'session should be expired!'
+	} else {
+		assert err.msg() == 'session is expired'
 	}
 	// verify that data is deleted
 	rows := sql db {

--- a/vlib/x/sessions/tests/memory_store_test.v
+++ b/vlib/x/sessions/tests/memory_store_test.v
@@ -15,14 +15,14 @@ const default_user = User{
 
 fn test_store_set() {
 	mut store := sessions.MemoryStore[User]{}
-	store.set('a', default_user)
+	store.set('a', default_user)!
 
 	// check if created at time is not empty
 	assert store.data['a'].created_at != time.Time{}
 	assert store.data['a'].data == default_user
 
 	first_created := store.data['a'].created_at
-	store.set('a', User{ age: 99 })
+	store.set('a', User{ age: 99 })!
 
 	assert store.data['a'].created_at == first_created
 	assert store.data['a'].data.age == 99
@@ -30,23 +30,25 @@ fn test_store_set() {
 
 fn test_store_get() {
 	mut store := sessions.MemoryStore[User]{}
-	store.set('a', default_user)
+	store.set('a', default_user)!
 
 	if data := store.get('a', max_age) {
 		assert data == default_user
 	} else {
-		assert true == false, 'session data should not be none'
+		assert false, 'session data should not be none'
 	}
 }
 
 fn test_store_session_expired() {
 	mut store := sessions.MemoryStore[User]{}
-	store.set('a', default_user)
+	store.set('a', default_user)!
 
 	time.sleep(2 * max_age)
 
 	if data := store.get('a', max_age) {
-		assert true == false, 'session should be expired!'
+		assert false, 'session should be expired!'
+	} else {
+		assert err.msg() == 'session is expired'
 	}
 	assert store.data.len == 0
 }

--- a/vlib/x/sessions/tests/session_app_test.v
+++ b/vlib/x/sessions/tests/session_app_test.v
@@ -54,19 +54,19 @@ pub fn (app &App) protected(mut ctx Context) vweb.Result {
 }
 
 pub fn (mut app App) save_session(mut ctx Context) vweb.Result {
-	app.sessions.save(mut ctx, default_user)
+	app.sessions.save(mut ctx, default_user) or { return ctx.server_error(err.msg()) }
 	return ctx.ok('')
 }
 
 pub fn (mut app App) update_session(mut ctx Context) vweb.Result {
 	if mut user := ctx.session_data {
 		user.age++
-		app.sessions.save(mut ctx, user)
+		app.sessions.save(mut ctx, user) or { return ctx.server_error(err.msg()) }
 		// sessions module should also update the context
 		if new_user := ctx.session_data {
 			assert new_user == user, 'session data is not updated on the context'
 		} else {
-			assert true == false, 'session data should not be none'
+			assert false, 'session data should not be none'
 		}
 	}
 
@@ -74,7 +74,7 @@ pub fn (mut app App) update_session(mut ctx Context) vweb.Result {
 }
 
 pub fn (mut app App) destroy_session(mut ctx Context) vweb.Result {
-	app.sessions.destroy(mut ctx)
+	app.sessions.destroy(mut ctx) or { return ctx.server_error(err.msg()) }
 	// sessions module should also update the context
 	assert ctx.session_data == none
 
@@ -84,7 +84,7 @@ pub fn (mut app App) destroy_session(mut ctx Context) vweb.Result {
 fn testsuite_begin() {
 	spawn fn () {
 		time.sleep(exit_after)
-		assert true == false, 'timeout reached!'
+		assert false, 'timeout reached!'
 		exit(1)
 	}()
 


### PR DESCRIPTION
Change the session store implementation to use results instead of options. This way (database) errors can be propagated and handled by the end users instead of forcing a session store to handle the error.

Could not find any reason why the `db_store_test` failed very rarely (see [pr checks of 20774](https://github.com/vlang/v/actions/runs/7855494077/job/21437262845?pr=20774)). Adding error propagation will also help debug future issues.