### PR TITLE
vtest,pref: add ability to have platform specific _test.v files

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -523,7 +523,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	}
 	ts.benchmark.step()
 	tls_bench.step()
-	if abs_path.replace('\\', '/') in ts.skip_files {
+	if abs_path in ts.skip_files {
 		ts.benchmark.skip()
 		tls_bench.skip()
 		if !testing.hide_skips {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -296,6 +296,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		skip_files << 'examples/wasm/mandelbrot/mandelbrot.wasm.v'
 		skip_files << 'examples/wasm/change_color_by_id/change_color_by_id.wasm.v'
 	}
+	skip_files = skip_files.map(os.abs_path)
 	vargs := _vargs.replace('-progress', '')
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
@@ -439,7 +440,8 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	}
 	tls_bench.no_cstep = true
 	tls_bench.njobs = ts.benchmark.njobs
-	mut relative_file := os.real_path(p.get_item[string](idx))
+	abs_path := os.real_path(p.get_item[string](idx))
+	mut relative_file := abs_path
 	mut cmd_options := [ts.vargs]
 	mut run_js := false
 
@@ -521,7 +523,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	}
 	ts.benchmark.step()
 	tls_bench.step()
-	if relative_file.replace('\\', '/') in ts.skip_files {
+	if abs_path.replace('\\', '/') in ts.skip_files {
 		ts.benchmark.skip()
 		tls_bench.skip()
 		if !testing.hide_skips {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -210,10 +210,12 @@ pub fn (mut ts TestSession) print_messages() {
 pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 	mut skip_files := []string{}
 	if will_compile {
-		// Skip the call_v_from_c files. They need special instructions for compilation.
+		// Skip the call_v_from_* files. They need special instructions for compilation.
 		// Check the README.md for detailed information.
 		skip_files << 'examples/call_v_from_c/v_test_print.v'
 		skip_files << 'examples/call_v_from_c/v_test_math.v'
+		skip_files << 'examples/call_v_from_python/test.v' // the example only makes sense to be compiled, when python is installed
+		skip_files << 'examples/call_v_from_ruby/test.v' // the example only makes sense to be compiled, when ruby is installed
 		// Skip the compilation of the coroutines example for now, since the Photon wrapper
 		// is only available on macos for now, and it is not yet trivial enough to
 		// build/install on the CI:
@@ -262,8 +264,6 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		}
 		if testing.runner_os != 'Linux' || testing.github_job != 'tcc' {
 			skip_files << 'examples/c_interop_wkhtmltopdf.v' // needs installation of wkhtmltopdf from https://github.com/wkhtmltopdf/packaging/releases
-			skip_files << 'examples/call_v_from_python/test.v' // the example only makes sense to be compiled, when python is installed
-			skip_files << 'examples/call_v_from_ruby/test.v' // the example only makes sense to be compiled, when ruby is installed
 			skip_files << 'vlib/vweb/vweb_app_test.v' // imports the `sqlite` module, which in turn includes sqlite3.h
 			skip_files << 'vlib/x/vweb/tests/vweb_app_test.v' // imports the `sqlite` module, which in turn includes sqlite3.h
 		}

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -94,6 +94,10 @@ const skip_test_files = [
 	'vlib/db/pg/pg_orm_test.v', // pg not installed
 	'vlib/db/pg/pg_test.v', // pg not installed
 	'vlib/db/pg/pg_double_test.v', // pg not installed
+	'vlib/v/tests/filtering_android_outside_termux_test.v', // platform filtering not baked into v test-self
+	'vlib/v/tests/filtering_macos_test.v', // platform filtering not baked into v test-self
+	'vlib/v/tests/filtering_nix_test.v', // platform filtering not baked into v test-self
+	'vlib/v/tests/filtering_windows_test.v', // platform filtering not baked into v test-self
 ]
 // These tests are too slow to be run in the CI on each PR/commit
 // in the sanitized modes:
@@ -474,6 +478,7 @@ fn main() {
 	$if !macos {
 		tsession.skip_files << skip_on_non_macos
 	}
+	tsession.skip_files = tsession.skip_files.map(os.abs_path)
 	tsession.test()
 	eprintln(tsession.benchmark.total_message(title))
 	if tsession.benchmark.nfail > 0 {

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -58,7 +58,7 @@ fn main() {
 						continue
 					}
 					ts.files << targ
-					ts.skip_files << targ
+					ts.skip_files << os.abs_path(targ)
 					continue
 				}
 				.ignore {}
@@ -116,7 +116,7 @@ pub fn (mut ctx Context) should_test_dir(path string, backend string) ([]string,
 						continue
 					}
 					res_files << p
-					skip_files << p
+					skip_files << os.abs_path(p)
 				}
 				.ignore {}
 			}

--- a/cmd/tools/vtest.v
+++ b/cmd/tools/vtest.v
@@ -5,6 +5,8 @@ import os.cmdline
 import testing
 import v.pref
 
+const host_os = pref.get_host_os()
+
 struct Context {
 mut:
 	verbose   bool
@@ -130,6 +132,18 @@ enum ShouldTestStatus {
 }
 
 fn (mut ctx Context) should_test(path string, backend string) ShouldTestStatus {
+	// Skip OS-specific tests if we are not running that OS
+	// Special case for android_outside_termux because of its
+	// underscores
+	if path.ends_with('_android_outside_termux_test.v') {
+		if !host_os.is_target_of('android_outside_termux') {
+			return .skip
+		}
+	}
+	os_target := path.all_before_last('_test.v').all_after_last('_')
+	if !host_os.is_target_of(os_target) {
+		return .skip
+	}
 	if path.ends_with('mysql_orm_test.v') {
 		testing.find_started_process('mysqld') or { return .skip }
 	}

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -158,6 +158,7 @@ pub fn (prefs &Preferences) should_compile_native(file string) bool {
 	return prefs.should_compile_c(file)
 }
 
+// TODO: Rework this using is_target_of()
 pub fn (prefs &Preferences) should_compile_c(file string) bool {
 	if file.ends_with('.js.v') {
 		// Probably something like `a.js.v`.
@@ -272,6 +273,38 @@ pub fn (prefs &Preferences) should_compile_asm(path string) bool {
 pub fn (prefs &Preferences) should_compile_js(file string) bool {
 	if !file.ends_with('.js.v') && file.split('.').len > 2 {
 		// Probably something like `a.c.v`.
+		return false
+	}
+	return true
+}
+
+// is_target_of returns true if this_os is included in the target specified
+// for example, 'nix' is true for Linux and FreeBSD but not Windows
+pub fn (this_os &OS) is_target_of(target string) bool {
+	if this_os == .all {
+		return true
+	}
+	// Note: Termux is running natively on Android devices, but the compilers there (clang) usually do not have access
+	// to the Android SDK. The code here ensures that you can have `_termux.c.v` and `_android_outside_termux.c.v` postfixes,
+	// to target both the cross compilation case (where the SDK headers are used and available), and the Termux case,
+	// where the Android SDK is not used.
+	// 'nix' means "all but Windows"
+	if (this_os == .windows && target == 'nix')
+		|| (this_os != .windows && target == 'windows')
+		|| (this_os != .linux && target == 'linux')
+		|| (this_os != .macos && target in ['darwin', 'macos'])
+		|| (this_os != .ios && target == 'ios')
+		|| (this_os != .freebsd && target == 'freebsd')
+		|| (this_os != .openbsd && target == 'openbsd')
+		|| (this_os != .netbsd && target == 'netbsd')
+		|| (this_os != .dragonfly && target == 'dragonfly')
+		|| (this_os != .solaris && target == 'solaris')
+		|| (this_os != .qnx && target == 'qnx')
+		|| (this_os != .serenity && target == 'serenity')
+		|| (this_os != .plan9 && target == 'plan9')
+		|| (this_os != .vinix && target == 'vinix')
+		|| (this_os != .android && target in ['android', 'android_outside_termux'])
+		|| (this_os != .termux && target == 'termux') {
 		return false
 	}
 	return true

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -280,7 +280,7 @@ pub fn (prefs &Preferences) should_compile_js(file string) bool {
 
 // is_target_of returns true if this_os is included in the target specified
 // for example, 'nix' is true for Linux and FreeBSD but not Windows
-pub fn (this_os &OS) is_target_of(target string) bool {
+pub fn (this_os OS) is_target_of(target string) bool {
 	if this_os == .all {
 		return true
 	}

--- a/vlib/v/tests/filtering_android_outside_termux_test.v
+++ b/vlib/v/tests/filtering_android_outside_termux_test.v
@@ -2,6 +2,6 @@ fn test_is_android() {
 	$if android {
 		assert true
 	} $else {
-		assert false
+		assert false, 'platform-specific test filtering failed'
 	}
 }

--- a/vlib/v/tests/filtering_android_outside_termux_test.v
+++ b/vlib/v/tests/filtering_android_outside_termux_test.v
@@ -1,5 +1,5 @@
-fn test_is_macos() {
-	$if android_outside_termux {
+fn test_is_android() {
+	$if android {
 		assert true
 	} $else {
 		assert false

--- a/vlib/v/tests/filtering_android_outside_termux_test.v
+++ b/vlib/v/tests/filtering_android_outside_termux_test.v
@@ -1,0 +1,7 @@
+fn test_is_macos() {
+	$if android_outside_termux {
+		assert true
+	} $else {
+		assert false
+	}
+}

--- a/vlib/v/tests/filtering_macos_test.v
+++ b/vlib/v/tests/filtering_macos_test.v
@@ -2,6 +2,6 @@ fn test_is_macos() {
 	$if macos {
 		assert true
 	} $else {
-		assert false
+		assert false, 'platform-specific test filtering failed'
 	}
 }

--- a/vlib/v/tests/filtering_macos_test.v
+++ b/vlib/v/tests/filtering_macos_test.v
@@ -1,0 +1,7 @@
+fn test_is_macos() {
+	$if macos {
+		assert true
+	} $else {
+		assert false
+	}
+}

--- a/vlib/v/tests/filtering_nix_test.v
+++ b/vlib/v/tests/filtering_nix_test.v
@@ -1,0 +1,7 @@
+fn test_is_nix() {
+	$if !windows {
+		assert true
+	} $else {
+		assert false
+	}
+}

--- a/vlib/v/tests/filtering_nix_test.v
+++ b/vlib/v/tests/filtering_nix_test.v
@@ -2,6 +2,6 @@ fn test_is_nix() {
 	$if !windows {
 		assert true
 	} $else {
-		assert false
+		assert false, 'platform-specific test filtering failed'
 	}
 }

--- a/vlib/v/tests/filtering_windows_test.v
+++ b/vlib/v/tests/filtering_windows_test.v
@@ -1,0 +1,7 @@
+fn test_is_windows() {
+	$if windows {
+		assert true
+	} $else {
+		assert false
+	}
+}

--- a/vlib/v/tests/filtering_windows_test.v
+++ b/vlib/v/tests/filtering_windows_test.v
@@ -2,6 +2,6 @@ fn test_is_windows() {
 	$if windows {
 		assert true
 	} $else {
-		assert false
+		assert false, 'platform-specific test filtering failed'
 	}
 }


### PR DESCRIPTION
Allow OS-specific _test.v files analogous to the logic re: `foo_nix.c.v` to make it easier to write platform-specific tests without a lot of `$if !windows {}` type code.
 
`foo_nix_test.v` would only run on nix OSes and `bar_windows_test.v` only on Windows, etc. On a non-targeted host OS, v test will skip the test with the `[SKIP]` message.

Technically, this could affect existing tests (though I didn't find any in the V repo) that are unfortunately named something like `<something>_windows_test.v` without targeting intention but this would be caught by the dev seeing the [SKIP] message.

`should_test()` in cmd/tools/vtest.v has been modified to check for an OS suffix and skip the test if the suffix is not a target of the host OS.

`pub fn (this_os &OS) is_target_of(target string) bool` has been added to vlib/pref/should_compile.v to make a reusable comparison between a selected OS and the target strings, for example, to have generic logic for 'nix' will never match Windows or to deal with `android_outside_termux` as a valid Android target.

Future work to use `is_target_of` to simplify existing code has been marked with TODO.