### PR TITLE
doc: add Markdown check to contributing rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,8 @@ accordingly in the steps below.)
    `git checkout -b fix_alabala`
    - Don't forget to keep formatting standards, run `v fmt -w YOUR_MODIFIED_FILES`
      before committing (if you have not run the commands from 3.1)
+   - If you changed Markdown (`.md`) files, check them `v check-md YOUR_MODIFIED_FILES`
+     before committing (if you have not run the commands from 3.1)
 6. `git push pullrequest` Note: The `pullrequest` remote was setup on step 4
 
 7. On GitHub's web interface, go to: https://github.com/vlang/v/pulls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ accordingly in the steps below.)
    - Don't forget to keep formatting standards, run `v fmt -w YOUR_MODIFIED_FILES`
      before committing (if you have not run the commands from 3.1)
    - If you changed Markdown (`.md`) files, check them `v check-md YOUR_MODIFIED_FILES`
-     before committing (if you have not run the commands from 3.1)
+     before committing.
 6. `git push pullrequest` Note: The `pullrequest` remote was setup on step 4
 
 7. On GitHub's web interface, go to: https://github.com/vlang/v/pulls


### PR DESCRIPTION
I didn't find a reference to `v check-md` in `CONTRIBUTING.md` so I added it 