### PR TITLE
cgen: fix map methods call with generic types

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -948,8 +948,16 @@ fn (mut g Gen) gen_arg_from_type(node_type ast.Type, node ast.Expr) {
 
 fn (mut g Gen) gen_map_method_call(node ast.CallExpr, left_type ast.Type, left_sym ast.TypeSymbol) bool {
 	match node.name {
-		'clear' {
-			g.write('map_clear(')
+		'reserve' {
+			g.write('map_reserve(')
+			g.gen_arg_from_type(left_type, node.left)
+			g.write(', ')
+			g.expr(node.args[0].expr)
+			g.write(')')
+			return true
+		}
+		'free', 'clear' {
+			g.write('map_${node.name}(')
 			g.gen_arg_from_type(left_type, node.left)
 			g.write(')')
 			return true

--- a/vlib/v/tests/map_generic_call_test.v
+++ b/vlib/v/tests/map_generic_call_test.v
@@ -1,0 +1,36 @@
+struct FooParams[K, V] {
+	k  K
+	v  V
+	k2 K
+}
+
+struct Foo[K, V] {
+	k K
+mut:
+	m map[K]V
+}
+
+fn new_foo[K, V](params FooParams[K, V]) Foo[K, V] {
+	return Foo[K, V]{
+		k: params.k2
+		m: {
+			params.k: params.v
+		}
+	}
+}
+
+fn (mut p Foo[K, V]) f() {
+	mut y := p.m.move()
+	y.clear()
+	y.reserve(6)
+	y.delete(p.k)
+	assert y.keys().len == 0
+	assert y.values().len == 0
+	assert y.clone().len == 0
+	unsafe { y.free() }
+}
+
+fn test_main() {
+	mut foo := new_foo(FooParams{ k: 'abc', v: 42, k2: 'def' })
+	foo.f()
+}


### PR DESCRIPTION
Fix #20827