### PR TITLE
cgen, ast, checker: fix auto deref arg when fn expects ref

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1560,6 +1560,7 @@ fn (t Tree) call_arg(node ast.CallArg) &Node {
 	obj.add_terse('is_mut', t.bool_node(node.is_mut))
 	obj.add_terse('share', t.enum_node(node.share))
 	obj.add_terse('expr', t.expr(node.expr))
+	obj.add_terse('should_be_ptr', t.bool_node(node.should_be_ptr))
 	obj.add('is_tmp_autofree', t.bool_node(node.is_tmp_autofree))
 	obj.add('pos', t.pos(node.pos))
 	obj.add('comments', t.array_node_comment(node.comments))

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -803,6 +803,7 @@ pub mut:
 	typ             Type
 	is_tmp_autofree bool // this tells cgen that a tmp variable has to be used for the arg expression in order to free it after the call
 	pos             token.Pos
+	should_be_ptr   bool // fn expects a ptr for this arg
 	// tmp_name        string // for autofree
 }
 

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1162,6 +1162,8 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		} else {
 			func.params[i]
 		}
+		// registers if the arg must be passed by ref to disable auto deref args
+		call_arg.should_be_ptr = param.typ.is_ptr() && !param.is_mut
 		if func.is_variadic && call_arg.expr is ast.ArrayDecompose {
 			if i > func.params.len - 1 {
 				c.error('too many arguments in call to `${func.name}`', node.pos)
@@ -1969,6 +1971,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					} else {
 						info.func.params[i]
 					}
+					// registers if the arg must be passed by ref to disable auto deref args
+					arg.should_be_ptr = param.typ.is_ptr() && !param.is_mut
 					if c.table.sym(param.typ).kind == .interface_ {
 						// cannot hide interface expected type to make possible to pass its interface type automatically
 						earg_types << if targ.idx() != param.typ.idx() { param.typ } else { targ }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -212,6 +212,7 @@ mut:
 	// where an aggregate (at least two types) is generated
 	// sum type deref needs to know which index to deref because unions take care of the correct field
 	aggregate_type_idx  int
+	arg_no_auto_deref   bool   // smartcast must not be dereferenced
 	branch_parent_pos   int    // used in BranchStmt (continue/break) for autofree stop position
 	returned_var_name   string // to detect that a var doesn't need to be freed since it's being returned
 	infix_left_var_name string // a && if expr
@@ -4695,7 +4696,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 								}
 								styp := g.base_type(node.obj.typ)
 								g.write('*(${styp}*)')
-							} else {
+							} else if !g.arg_no_auto_deref {
 								g.write('*')
 							}
 						} else if (g.inside_interface_deref && g.table.is_interface_var(node.obj))

--- a/vlib/v/tests/sumtype_ptr_arg_test.v
+++ b/vlib/v/tests/sumtype_ptr_arg_test.v
@@ -1,0 +1,33 @@
+struct Foo {
+	foo i32
+}
+
+struct Bar {
+	bar f32
+}
+
+type Foobar = Bar | Foo
+
+fn match_sum(sum Foobar) {
+	match sum {
+		Foo {
+			sum_foo(sum)
+		}
+		Bar {
+			sum_bar(sum)
+		}
+	}
+}
+
+fn sum_foo(i &Foo) {
+	assert true
+}
+
+fn sum_bar(i Bar) {
+	assert true
+}
+
+fn test_main() {
+	match_sum(Foo{ foo: 5 })
+	match_sum(Bar{ bar: 5 })
+}


### PR DESCRIPTION
Fix #20703