### PR TITLE
vpm: fix remove command on Windows, add test

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -291,3 +291,12 @@ fn fmt_mod_path(path string) string {
 fn at_version(version string) string {
 	return if version != '' { '@${version}' } else { '' }
 }
+
+// FIXME: Workaround for failing `rmdir` commands on Windows.
+fn rmdir_all(path string) ! {
+	$if windows {
+		os.execute_opt('rd /s /q ${path}')!
+	} $else {
+		os.rmdir_all(path)!
+	}
+}

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -166,10 +166,6 @@ fn (m Module) confirm_install() bool {
 
 fn (m Module) remove() ! {
 	verbose_println('Removing `${m.name}` from `${m.install_path_fmted}`...')
-	$if windows {
-		os.execute_opt('rd /s /q ${m.install_path}')!
-	} $else {
-		os.rmdir_all(m.install_path)!
-	}
+	rmdir_all(m.install_path)!
 	verbose_println('Removed `${m.name}`.')
 }

--- a/cmd/tools/vpm/install_test.v
+++ b/cmd/tools/vpm/install_test.v
@@ -82,12 +82,7 @@ fn test_install_already_existent() {
 
 fn test_install_once() {
 	// Start with a clean test path.
-	$if windows {
-		// FIXME: Workaround for failing `rmdir` commands on Windows.
-		os.system('rd /s /q ${test_path}')
-	} $else {
-		os.rmdir_all(test_path) or {}
-	}
+	rmdir_all(test_path) or {}
 	os.mkdir_all(test_path) or {}
 
 	// Install markdown module.

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -107,7 +107,7 @@ fn (mut p Parser) parse_module(m string) {
 			vpm_error('failed to find `v.mod` for `${ident}${at_version(version)}`.',
 				details: err.msg()
 			)
-			os.rmdir_all(tmp_path) or {}
+			rmdir_all(tmp_path) or {}
 			p.errors++
 			return
 		}
@@ -216,7 +216,7 @@ fn get_tmp_path(relative_path string) !string {
 	if os.exists(tmp_path) {
 		// It's unlikely that the tmp_path already exists, but it might
 		// occur if vpm was canceled during an installation or update.
-		rmdir_all(relative_path)!
+		rmdir_all(tmp_path)!
 	}
 	return tmp_path
 }

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -216,12 +216,7 @@ fn get_tmp_path(relative_path string) !string {
 	if os.exists(tmp_path) {
 		// It's unlikely that the tmp_path already exists, but it might
 		// occur if vpm was canceled during an installation or update.
-		$if windows {
-			// FIXME: Workaround for failing `rmdir` commands on Windows.
-			os.execute_opt('rd /s /q ${tmp_path}')!
-		} $else {
-			os.rmdir_all(tmp_path)!
-		}
+		rmdir_all(relative_path)!
 	}
 	return tmp_path
 }

--- a/cmd/tools/vpm/remove_test.v
+++ b/cmd/tools/vpm/remove_test.v
@@ -1,0 +1,27 @@
+// vtest retry: 3
+import os
+import rand
+import test_utils
+
+const vexe = os.quoted_path(@VEXE)
+const test_path = os.join_path(os.vtmp_dir(), 'vpm_remove_test_${rand.ulid()}')
+
+fn testsuite_begin() {
+	$if !network ? {
+		eprintln('> skipping ${@FILE}, when `-d network` is missing')
+		exit(0)
+	}
+	test_utils.set_test_env(test_path)
+}
+
+fn testsuite_end() {
+	os.rmdir_all(test_path) or {}
+}
+
+fn test_remove() {
+	os.execute_or_exit('${vexe} install https://github.com/hungrybluedev/xlsx')
+	mod_path := os.join_path(test_path, 'xlsx')
+	assert os.is_dir(mod_path)
+	res := os.execute('${vexe} remove xlsx')
+	assert !os.exists(mod_path)
+}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -97,13 +97,7 @@ fn vpm_remove(query []string) {
 		final_module_path := get_path_of_existing_module(m) or { continue }
 		println('Removing module "${m}" ...')
 		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
-		$if windows {
-			os.execute_opt('rd /s /q ${final_module_path}') or {
-				vpm_error(err.msg(), verbose: true)
-			}
-		} $else {
-			os.rmdir_all(final_module_path) or { vpm_error(err.msg(), verbose: true) }
-		}
+		rmdir_all(final_module_path) or { vpm_error(err.msg(), verbose: true) }
 		// Delete author directory if it is empty.
 		author := m.split('.')[0]
 		author_dir := os.real_path(os.join_path(settings.vmodules_path, author))
@@ -112,11 +106,7 @@ fn vpm_remove(query []string) {
 		}
 		if os.is_dir_empty(author_dir) {
 			verbose_println('Removing author folder ${author_dir}')
-			$if windows {
-				os.execute_opt('rd /s /q ${author_dir}') or { vpm_error(err.msg(), verbose: true) }
-			} $else {
-				os.rmdir(author_dir) or { vpm_error(err.msg(), verbose: true) }
-			}
+			rmdir_all(author_dir) or { vpm_error(err.msg(), verbose: true) }
 		}
 	}
 }

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -97,7 +97,13 @@ fn vpm_remove(query []string) {
 		final_module_path := get_path_of_existing_module(m) or { continue }
 		println('Removing module "${m}" ...')
 		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
-		os.rmdir_all(final_module_path) or { vpm_error(err.msg(), verbose: true) }
+		$if windows {
+			os.execute_opt('rd /s /q ${final_module_path}') or {
+				vpm_error(err.msg(), verbose: true)
+			}
+		} $else {
+			os.rmdir_all(final_module_path) or { vpm_error(err.msg(), verbose: true) }
+		}
 		// Delete author directory if it is empty.
 		author := m.split('.')[0]
 		author_dir := os.real_path(os.join_path(settings.vmodules_path, author))
@@ -106,7 +112,11 @@ fn vpm_remove(query []string) {
 		}
 		if os.is_dir_empty(author_dir) {
 			verbose_println('Removing author folder ${author_dir}')
-			os.rmdir(author_dir) or { vpm_error(err.msg(), verbose: true) }
+			$if windows {
+				os.execute_opt('rd /s /q ${author_dir}') or { vpm_error(err.msg(), verbose: true) }
+			} $else {
+				os.rmdir(author_dir) or { vpm_error(err.msg(), verbose: true) }
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #20775

Adds a fix which is already used in other places to work around failing rm_dir commands (apparently permissions issues) on Windows.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
