### PR TITLE
pref: allow fetching the photonwrapper .so (for the coroutines) with curl too, or print details for manual download

### DIFF
--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -8,7 +8,6 @@ import os.cmdline
 import os
 import v.vcache
 import rand
-// import net.http // TODO can't use net.http on arm maccs: bignum.c arm asm error
 
 pub enum BuildMode {
 	// `v program.v'
@@ -902,8 +901,11 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_${os.user_os()}_${arch}.so'
 					if !os.exists(so_path) {
 						println('coroutines .so not found, downloading...')
-						// http.download_file(so_url, so_path) or { panic(err) }
-						os.execute_or_panic('wget -O "${so_path}" "${so_url}"')
+						os.execute_opt('wget -O "${so_path}" "${so_url}"') or {
+							os.execute_opt('curl -o "${so_path}" "${so_url}"') or {
+								panic('coroutines .so could not be downloaded with wget or curl. Download ${so_url}, place it in ${so_path} then try again.')
+							}
+						}
 						println('done!')
 					}
 					res.compile_defines << 'is_coroutine'


### PR DESCRIPTION
Fix for #20834 

This PR tries to use `curl` to download the coroutine's .so file for systems that do not use `wget`, and prints a message with manual download instructions if both `wget` and `curl` fail.