### PR TITLE
docs: x.vweb typos

### DIFF
--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -574,7 +574,7 @@ for urls starting with `'/foo'`.
 
 To use controllers we have to embed `vweb.Controller` on
 our app struct and when we register a controller we also have to specify
-what the type of the context struct will be. That means that this is possible
+what the type of the context struct will be. That means that it is possible
 to have a different context struct for each controller and the main app struct.
 
 **Example:**

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -56,7 +56,7 @@ pub mut:
 pub struct App {
 pub:
 	// In the app struct we store data that should be accessible by all endpoints.
-	// For example a database or configuration values.
+	// For example, a database or configuration values.
 	secret_key string
 }
 
@@ -122,7 +122,7 @@ pub fn (app &App) create_product(mut ctx Context) vweb.Result {
 }
 ```
 
-By default endpoints are marked as GET requests only. It is also possible to
+By default, endpoints are marked as GET requests only. It is also possible to
 add multiple HTTP verbs per endpoint.
 
 **Example:**
@@ -185,7 +185,7 @@ If you want multiple parameters in your route and if you want to parse the param
 yourself, or you want a wildcard route, you can add `...`  after the `:` and name,
 e.g. `@['/:path...']`.
 
-This will match all routes after `'/'`. For example the url `/path/to/test` would give
+This will match all routes after `'/'`. For example, the url `/path/to/test` would give
 `path = '/path/to/test'`.
 
 ```v ignore
@@ -202,8 +202,8 @@ You have direct access to query values by accessing the `query` field on your co
 You are also able to access any formdata or files that were sent
 with the request with the fields `.form` and `.files` respectively.
 
-In the following example, visiting http://localhost:port/user?name=Vweb we
-will see the text `Hello Vweb!`. And if we access the route without the `name` parameter,
+In the following example, visiting http://localhost:port/user?name=vweb we
+will see the text `Hello vweb!`. And if we access the route without the `name` parameter,
 http://localhost:port/user, we will see the text `no user was found`,
 
 **Example:**
@@ -249,7 +249,7 @@ host in one app struct.
 
 ### Route Matching Order
 
-Vweb will match routes in the order that you define endpoints.
+vweb will match routes in the order that you define endpoints.
 
 **Example:**
 ```v ignore
@@ -270,7 +270,7 @@ on the url http://localhost:port/normal we will not see `from normal`, but
 
 ### Custom not found page
 
-You can implement a `not_found` endpoint that is called when a request is made and no
+You can implement a `not_found` endpoint that is called when a request is made, and no
 matching route is found to replace the default HTTP 404 not found page. This route
 has to be defined on our Context struct.
 
@@ -286,7 +286,7 @@ pub fn (mut ctx Context) not_found() vweb.Result {
 
 ## Static files and website
 
-Vweb also provides a way of handling static files. We can mount a folder at the root
+vweb also provides a way of handling static files. We can mount a folder at the root
 of our web app, or at a custom route. To start using static files we have to embed
 `vweb.StaticHandler` on our app struct.
 
@@ -303,7 +303,7 @@ Let's say you have the following file structure:
 └── main.v
 ```
 
-If we want all the documents inside the `static` sub-directory to be publicly accessible we can
+If we want all the documents inside the `static` sub-directory to be publicly accessible, we can
 use `handle_static`.
 
 > **Note:**
@@ -352,7 +352,7 @@ We can now access `main.css` directly at http://localhost:8080/css/main.css.
 If a request is made to the root of a static folder, vweb will look for an
 `index.html` or `ìndex.htm` file and serve it if available.
 Thus, it's also a good way to host a complete website.
-A example is available [here](/examples/vweb/static_website).
+An example is available [here](/examples/vweb/static_website).
 
 It is also possible to mount the `static` folder at a custom path.
 
@@ -376,7 +376,7 @@ app.serve_static('/path/main.css',  'static/css/main.css')!
 
 ### Dealing with MIME types
 
-By default vweb will map the extension of a file to a MIME type. If any of your static file's
+By default, vweb will map the extension of a file to a MIME type. If any of your static file's
 extensions do not have a default MIME type in vweb, vweb will throw an error and you
 have to add your MIME type to `.static_mime_types` yourself.
 
@@ -505,7 +505,7 @@ app.route_use('/user/:path...')
 
 ### Evaluation moment
 
-By default the registered middleware functions are executed *before* a method on your
+By default, the registered middleware functions are executed *before* a method on your
 app struct is called. You can also change this behaviour to execute middleware functions
 *after* a method on your app struct is called, but before the response is sent!
 
@@ -530,7 +530,7 @@ Anything you can do in "before" middleware, you can do in "after" middleware.
 
 ### Evaluation order
 
-Vweb will handle requests in the following order:
+vweb will handle requests in the following order:
 
 1. Execute global "before" middleware
 2. Execute "before" middleware that matches the requested route
@@ -574,7 +574,7 @@ for urls starting with `'/foo'`.
 
 To use controllers we have to embed `vweb.Controller` on
 our app struct and when we register a controller we also have to specify
-what the type of the context struct will be. That means that is is possible
+what the type of the context struct will be. That means that this is possible
 to have a different context struct for each controller and the main app struct.
 
 **Example:**
@@ -642,7 +642,7 @@ When we registered the controller with
 we told vweb that the namespace of that controller is `'/admin'` so in this example we would
 see the text "Admin" if we navigate to the url `'/admin/path'`.
 
-Vweb doesn't support duplicate routes, so if we add the following
+vweb doesn't support duplicate routes, so if we add the following
 route to the example the code will produce an error.
 
 ```v ignore
@@ -778,7 +778,7 @@ You must pass the type of redirect to vweb:
 
 If you want to change the request method, for example when you receive a post request and
 want to redirect to another page via a GET request, you should use `see_other`. If you want
-the HTTP method to stay the same you should use `found` generally speaking.
+the HTTP method to stay the same, you should use `found` generally speaking.
 
 **Example:**
 ```v ignore
@@ -825,7 +825,7 @@ sending a response over the connection and closing it.
 Sometimes you want to send the response in another thread, for example when using
 [Server Sent Events](sse/README.md). When you are sure that a response will be sent
 over the TCP connection you can return `vweb.no_result()`. This function does nothing
-and returns an empty `vweb.Result` struct, letting vweb know that we sent a response ourself.
+and returns an empty `vweb.Result` struct, letting vweb know that we sent a response ourselves.
 
 > **Note:**
 > It is important to call `ctx.takeover_conn` before you spawn a thread
@@ -856,7 +856,7 @@ pub fn (app &App) long_response(mut ctx Context) vweb.Result {
 	// if we don't the whole web server will block for 10 seconds,
 	// since vweb is singlethreaded
 	spawn handle_connection(mut ctx.conn)
-	// we will send a custom response ourself, so we can safely return an empty result
+	// we will send a custom response ourselves, so we can safely return an empty result
 	return vweb.no_result()
 }
 


### PR DESCRIPTION
- VWeb > vweb unification
- Missing commas
- other small fixes