### PR TITLE
time: add http_header_string() for HTTP date/time stamps

### DIFF
--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -470,6 +470,14 @@ pub fn (t Time) utc_string() string {
 	return utc_string
 }
 
+// http_header_string returns a date string in the format used in HTTP headers, as defined in RFC 2616.
+pub fn (t Time) http_header_string() string {
+	day_str := t.weekday_str()
+	month_str := t.smonth()
+	http_header_string := '${day_str}, ${t.day} ${month_str} ${t.year} ${t.hour:02d}:${t.minute:02d}:${t.second:02d} GMT'
+	return http_header_string
+}
+
 // mceil returns the least integer value greater than or equal to x.
 fn mceil(x f64) f64 {
 	if x > 0 {

--- a/vlib/time/time_format_test.v
+++ b/vlib/time/time_format_test.v
@@ -86,3 +86,7 @@ fn test_get_fmt_str() {
 fn test_utc_string() {
 	assert 'Fri, 11 Jul 1980 21:23:42 UTC' == time_to_test.utc_string()
 }
+
+fn test_http_header_string() {
+	assert 'Fri, 11 Jul 1980 21:23:42 GMT' == time_to_test.http_header_string()
+}


### PR DESCRIPTION
This adds a UNIX time stamp to HTTP date/time stamp as defined in [RFC2616](https://www.rfc-editor.org/rfc/rfc2616#section-3.3.1), which should be used in HTTP headers such as `Expires`, `Last-Modified`, etc.

A test has been added to `vlib/time/time_format_test.v` to cover this new function.
