### PR TITLE
x.vweb: add configuration options and handle incomplete requests

### DIFF
--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -156,3 +156,12 @@ pub fn (mut r BufferedReader) read_line(config BufferedReadLineConfig) !string {
 	}
 	return Eof{}
 }
+
+// get_read_data returns the data that the buffered reader has read from `start` until `end`
+pub fn (r &BufferedReader) get_read_data(start int, end int) ![]u8 {
+	if end > r.buf.len {
+		return Eof{}
+	}
+
+	return r.buf[start..end]
+}

--- a/vlib/x/vweb/tests/config/incomplete_request_test.v
+++ b/vlib/x/vweb/tests/config/incomplete_request_test.v
@@ -1,0 +1,86 @@
+import time
+import x.vweb
+import net
+import net.http
+
+const port = 13020
+const exit_after = time.second * 20
+
+pub struct Context {
+	vweb.Context
+}
+
+pub struct App {
+mut:
+	started chan bool
+}
+
+pub fn (mut app App) before_accept_loop() {
+	app.started <- true
+}
+
+pub fn (mut app App) index(mut ctx Context) vweb.Result {
+	return ctx.text('Hello V!')
+}
+
+fn testsuite_begin() {
+	mut app := &App{}
+	spawn vweb.run_at[App, Context](mut app,
+		port: port
+		timeout_in_seconds: 15
+		config: vweb.Config{
+			max_nr_of_incomplete_requests: 1
+		}
+	)
+	_ := <-app.started
+
+	spawn fn () {
+		time.sleep(exit_after)
+		assert false, 'timeout reached'
+		exit(1)
+	}()
+}
+
+fn test_incomplete_request() {
+	// simulate a slow network where the request headers are received in parts
+	// we set the maximum number of incomplete requests on a connection to 1.
+	// This means that when we send another incomplete request we expect vweb
+	// to close the connection.
+
+	mut conn := net.dial_tcp('127.0.0.1:${port}')!
+	defer {
+		conn.close() or {}
+	}
+
+	conn.write_string('GET / HTTP/1.1\r
+User-Agent: V\r
+Acc')!
+
+	// simulate network delay
+	time.sleep(time.second * 2)
+	conn.write_string('ept: */*\r\n\r\n')!
+
+	// simulate network delay
+	time.sleep(time.second * 2)
+	mut buf := []u8{len: 86}
+	conn.read(mut buf)!
+	resp := http.parse_response(buf.bytestr())!
+	assert resp.status() == .ok
+	assert resp.body == 'Hello V!'
+
+	// do second request
+
+	// simulate network delay
+	time.sleep(time.second * 2)
+	conn.write_string('GET / HTTP/1.1\r
+User-Agent: V\r
+Acc')!
+
+	// simulate network delay
+	time.sleep(time.second * 2)
+
+	buf = []u8{len: 103}
+	conn.read(mut buf)!
+	bad_resp := http.parse_response(buf.bytestr())!
+	assert bad_resp.status() == .bad_request
+}

--- a/vlib/x/vweb/tests/config/incomplete_request_test.v
+++ b/vlib/x/vweb/tests/config/incomplete_request_test.v
@@ -1,3 +1,5 @@
+// vtest flaky: true
+// vtest retry: 3
 import time
 import x.vweb
 import net

--- a/vlib/x/vweb/tests/config/max_header_size_test.v
+++ b/vlib/x/vweb/tests/config/max_header_size_test.v
@@ -1,0 +1,59 @@
+import net.http
+import time
+import x.vweb
+
+const port = 13021
+const exit_after = time.second * 10
+const header_size = 1000
+const localserver = 'http://localhost:${port}'
+
+pub struct Context {
+	vweb.Context
+}
+
+pub struct App {
+mut:
+	started chan bool
+}
+
+pub fn (mut app App) before_accept_loop() {
+	app.started <- true
+}
+
+pub fn (mut app App) index(mut ctx Context) vweb.Result {
+	return ctx.text('Hello V!')
+}
+
+fn testsuite_begin() {
+	mut app := &App{}
+	spawn vweb.run_at[App, Context](mut app,
+		port: port
+		timeout_in_seconds: 2
+		config: vweb.Config{
+			max_header_len: header_size
+		}
+	)
+	_ := <-app.started
+
+	spawn fn () {
+		time.sleep(exit_after)
+		assert false, 'timeout reached'
+		exit(1)
+	}()
+}
+
+fn test_larger_header_size() {
+	mut buf := []u8{len: header_size * 2, init: `a`}
+	str := buf.bytestr()
+
+	mut header := http.new_custom_header_from_map({
+		'X-Large-Header': str
+	})!
+
+	mut x := http.fetch(http.FetchConfig{
+		url: localserver
+		header: header
+	})!
+
+	assert x.status() == .request_entity_too_large
+}

--- a/vlib/x/vweb/tests/config/max_request_body_len_test.v
+++ b/vlib/x/vweb/tests/config/max_request_body_len_test.v
@@ -1,0 +1,56 @@
+import time
+import x.vweb
+import net
+import net.http
+
+const port = 13022
+const exit_after = time.second * 10
+const body_len = 1000
+const localserver = 'http://localhost:${port}'
+
+pub struct Context {
+	vweb.Context
+}
+
+pub struct App {
+mut:
+	started chan bool
+}
+
+pub fn (mut app App) before_accept_loop() {
+	app.started <- true
+}
+
+pub fn (mut app App) index(mut ctx Context) vweb.Result {
+	return ctx.text('Hello V!')
+}
+
+fn testsuite_begin() {
+	mut app := &App{}
+	spawn vweb.run_at[App, Context](mut app,
+		port: port
+		timeout_in_seconds: 15
+		config: vweb.Config{
+			max_request_body_len: body_len
+		}
+	)
+	_ := <-app.started
+
+	spawn fn () {
+		time.sleep(exit_after)
+		assert false, 'timeout reached'
+		exit(1)
+	}()
+}
+
+fn test_larger_body_len() {
+	mut buf := []u8{len: body_len * 2, init: `a`}
+	str := buf.bytestr()
+
+	mut x := http.fetch(http.FetchConfig{
+		url: localserver
+		data: str
+	})!
+
+	assert x.status() == .request_entity_too_large
+}

--- a/vlib/x/vweb/tests/large_payload_test.v
+++ b/vlib/x/vweb/tests/large_payload_test.v
@@ -10,6 +10,7 @@ const port = 13002
 const localserver = 'http://127.0.0.1:${port}'
 
 const exit_after = time.second * 10
+const header_size = vweb.max_read * 2
 
 const tmp_file = os.join_path(os.vtmp_dir(), 'vweb_large_payload.txt')
 
@@ -47,7 +48,14 @@ fn testsuite_begin() {
 	}()
 
 	mut app := &App{}
-	spawn vweb.run_at[App, Context](mut app, port: port, timeout_in_seconds: 2, family: .ip)
+	spawn vweb.run_at[App, Context](mut app,
+		port: port
+		timeout_in_seconds: 2
+		family: .ip
+		config: vweb.Config{
+			max_header_len: header_size
+		}
+	)
 	// app startup time
 	_ := <-app.started
 }
@@ -68,7 +76,7 @@ fn test_large_request_body() {
 fn test_large_request_header() {
 	// same test as test_large_request_body, but then with a large header,
 	// which is parsed seperately
-	mut buf := []u8{len: vweb.max_read * 2, init: `a`}
+	mut buf := []u8{len: header_size, init: `a`}
 
 	str := buf.bytestr()
 	// make 1 header longer than vwebs max read limit

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -521,13 +521,9 @@ fn handle_read[A, X](mut pv picoev.Picoev, mut params RequestParams, fd int) {
 	mut reader := if !is_first_data_of_request {
 		// the previous request was incomplete, append incoming data to the buffer
 		// so the request headers can be parsed again in their entirety
-		max_size := incoming_req.buf.len + vweb.max_read
-		mut new_buf := []u8{len: max_size, cap: max_size}
-		// copy the previous request buffer to the new buffered reader
-		copy(mut new_buf, incoming_req.buf)
 		&io.BufferedReader{
 			reader: conn
-			buf: new_buf
+			buf: incoming_req.buf
 			len: incoming_req.buf.len
 			offset: 0
 			mfails: 2


### PR DESCRIPTION
This pr adds a `Config` struct to `x.vweb` to change the default behaviour of vweb.

When vweb encounters an incomplete request it will now wait until a timeout occurs for new data instead of immediately closing the connection. The `Config` struct contains an option to limit the number of incomplete requests per connetion that are allowed before the connection is closed.

The `Config` struct also adds the option to limit the maximum HTTP header size and the maximum body length for a request.