### PR TITLE
parser: fix infinite loop in Parser.sql stmt in `-silent -print-watched-files` mode (used by `v watch`)

### DIFF
--- a/vlib/v/parser/orm.v
+++ b/vlib/v/parser/orm.v
@@ -133,6 +133,10 @@ fn (mut p Parser) sql_stmt() ast.SqlStmt {
 	mut lines := []ast.SqlStmtLine{}
 
 	for p.tok.kind != .rcbr {
+		if p.tok.kind == .eof {
+			p.unexpected_with_pos(pos, got: 'eof, while parsing an SQL statement')
+			return ast.SqlStmt{}
+		}
 		lines << p.parse_sql_stmt_line()
 	}
 

--- a/vlib/v/parser/testdata/silent/orm_infinite_loop_in_parser_sql_stmt.vv
+++ b/vlib/v/parser/testdata/silent/orm_infinite_loop_in_parser_sql_stmt.vv
@@ -1,0 +1,68 @@
+module main
+
+import db.sqlite
+
+@[table: 'modules']
+struct Module {
+	id           int    @[primary; sql: serial]
+	name         string
+	nr_downloads int    @[sql: u64]
+	creator      User
+}
+
+struct User {
+	id             int    @[primary; sql: serial]
+	age            u32    @[unique: 'user']
+	name           string @[sql: 'username'; sql_type: 'VARCHAR(200)'; unique]
+	is_customer    bool   @[sql: 'abc'; unique: 'user']
+	skipped_string string @[skip]
+}
+
+struct Parent {
+	id       int     @[primary; sql: serial]
+	name     string
+	children []Child @[fkey: 'parent_id']
+}
+
+struct Child {
+	id        int    @[primary; sql: serial]
+	parent_id int
+	name      string
+}
+
+fn main() {
+	eprintln('------------ ${@METHOD} -----------------')
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		sql db {
+			drop table Parent
+			drop table Child
+		} or {}
+		db.close() or {}
+	}
+
+	sql db {
+		create table Parent
+	}!
+	sql db {
+		create table Child
+	}!
+	par := Parent{
+		name: 'test'
+		children: [
+			Child{
+				name: 'abc'
+			},
+			Child{
+				name: 'def'
+			},
+		]
+	}
+	sql db {
+		insert par into Parent
+	}!
+	sql db {
+		select from Parent where id == 1 & name == "whatever"
+	}!
+	eprintln(parent)
+}

--- a/vlib/v/parser/v_print_v_files_works_test.v
+++ b/vlib/v/parser/v_print_v_files_works_test.v
@@ -1,0 +1,30 @@
+import os
+
+const vexe = @VEXE
+const vroot = os.dir(vexe)
+
+fn test_print_v_files_in_stdout_mode() {
+	check_parsing_files_in_folder('vlib/v/parser/testdata/stdout', '-print-v-files')
+}
+
+//
+
+fn test_print_v_files_in_silent_mode() {
+	check_parsing_files_in_folder('vlib/v/parser/testdata/silent', '-silent -print-v-files')
+}
+
+fn test_print_watched_files_in_silent_mode__used_by_vwatch() {
+	check_parsing_files_in_folder('vlib/v/parser/testdata/silent', '-silent -print-watched-files')
+}
+
+fn check_parsing_files_in_folder(folder string, options string) {
+	println('> checking .vv files in folder: `${folder}`, with `${options}` ...')
+	files := os.walk_ext(os.join_path(vroot, folder), '.vv')
+	for f in files {
+		cmd := '${os.quoted_path(vexe)} ${options} ${os.quoted_path(f)}'
+		// eprintln('> cmd: $cmd')
+		res := os.execute(cmd)
+		assert res.exit_code == 0, 'failed cmd: ${cmd}, output:\n${res.output}'
+		assert res.output.split_into_lines().len > 10, 'there should be several files printed by cmd: ${cmd}'
+	}
+}


### PR DESCRIPTION
- parser: fix `-silent -print-v-files` (fix #20869)
- cleanup the output of v_parser_test.v
- parser: add a simpler (and faster to compile) test v_print_v_files_works_test.v
