### PR TITLE
cgen: fix comptime selector of interface (fix #20864)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -10,6 +10,10 @@ import v.pref
 import v.comptime
 
 fn (mut g Gen) comptime_selector(node ast.ComptimeSelector) {
+	is_interface_field := g.table.sym(node.left_type).kind == .interface_
+	if is_interface_field {
+		g.write('*(')
+	}
 	g.expr(node.left)
 	if node.left_type.is_ptr() {
 		g.write('->')
@@ -23,11 +27,17 @@ fn (mut g Gen) comptime_selector(node ast.ComptimeSelector) {
 				&& node.field_expr.field_name == 'name' {
 				_, field_name := g.comptime.get_comptime_selector_var_type(node)
 				g.write(c_name(field_name))
+				if is_interface_field {
+					g.write(')')
+				}
 				return
 			}
 		}
 	}
 	g.expr(node.field_expr)
+	if is_interface_field {
+		g.write(')')
+	}
 }
 
 fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {

--- a/vlib/v/slow_tests/inout/comptime_selector_of_interface.out
+++ b/vlib/v/slow_tests/inout/comptime_selector_of_interface.out
@@ -1,0 +1,2 @@
+[vlib/v/slow_tests/inout/comptime_selector_of_interface.vv:12] p.count: 42
+[vlib/v/slow_tests/inout/comptime_selector_of_interface.vv:14] p.$(f.name): 42

--- a/vlib/v/slow_tests/inout/comptime_selector_of_interface.vv
+++ b/vlib/v/slow_tests/inout/comptime_selector_of_interface.vv
@@ -1,0 +1,16 @@
+struct People {
+	count int
+}
+
+interface IPeople {
+	count int
+}
+
+fn main() {
+	p := IPeople(People{42})
+
+	dump(p.count)
+	$for f in IPeople.fields {
+		dump(p.$(f.name))
+	}
+}


### PR DESCRIPTION
This PR fix comptime selector of interface (fix #20864).

- Fix comptime selector of interface.
- Add test.

```v
struct People {
	count int
}

interface IPeople {
	count int
}

fn main() {
	p := IPeople(People{42})

	dump(p.count)
	$for f in IPeople.fields {
		dump(p.$(f.name))
	}
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:12] p.count: 42
[.\\tt1.v:14] p.$(f.name): 42
```