### PR TITLE
checker: fix struct field init with generic fn variable (fix #20847)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -189,8 +189,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if is_decl || is_shared_re_assign {
 			// check generic struct init and return unwrap generic struct type
 			if mut right is ast.StructInit {
+				c.expr(mut right)
 				if right.typ.has_flag(.generic) {
-					c.expr(mut right)
 					right_type = right.typ
 				}
 			} else if mut right is ast.PrefixExpr {

--- a/vlib/v/tests/struct_field_init_with_generic_fn_test.v
+++ b/vlib/v/tests/struct_field_init_with_generic_fn_test.v
@@ -1,0 +1,36 @@
+struct ClassInfo {
+	func fn () int = unsafe { nil }
+}
+
+pub fn func2[T]() int {
+	return sizeof(T)
+}
+
+pub fn func1[T]() int {
+	ci := ClassInfo{
+		func: func2[T]
+	}
+	return ci.func()
+}
+
+struct Struct1 {}
+
+struct Struct2 {}
+
+fn test_struct_field_init_with_generic_fn() {
+	r1 := func1[i32]()
+	println(r1)
+	assert r1 == 4
+
+	r2 := func1[bool]()
+	println(r2)
+	assert r2 == 1
+
+	r3 := func1[Struct1]()
+	println(r3)
+	assert r3 == 1
+
+	r4 := func1[Struct2]()
+	println(r4)
+	assert r4 == 1
+}

--- a/vlib/v/tests/struct_field_init_with_generic_fn_test.v
+++ b/vlib/v/tests/struct_field_init_with_generic_fn_test.v
@@ -1,16 +1,15 @@
 struct ClassInfo {
-	func fn () int = unsafe { nil }
+	func fn () = unsafe { nil }
 }
 
-pub fn func2[T]() int {
-	return sizeof(T)
+pub fn func2[T]() {
 }
 
-pub fn func1[T]() int {
+pub fn func1[T]() {
 	ci := ClassInfo{
 		func: func2[T]
 	}
-	return ci.func()
+	ci.func()
 }
 
 struct Struct1 {}
@@ -18,19 +17,9 @@ struct Struct1 {}
 struct Struct2 {}
 
 fn test_struct_field_init_with_generic_fn() {
-	r1 := func1[i32]()
-	println(r1)
-	assert r1 == 4
-
-	r2 := func1[bool]()
-	println(r2)
-	assert r2 == 1
-
-	r3 := func1[Struct1]()
-	println(r3)
-	assert r3 == 1
-
-	r4 := func1[Struct2]()
-	println(r4)
-	assert r4 == 1
+	func1[i32]()
+	func1[bool]()
+	func1[Struct1]()
+	func1[Struct2]()
+	assert true
 }


### PR DESCRIPTION
This PR fix struct field init with generic fn variable (fix #20847).

- Fix struct field init with generic fn variable.
- Add test.

```v
struct ClassInfo {
	func fn () int = unsafe { nil }
}

pub fn func2[T]() int {
	return sizeof(T)
}

pub fn func1[T]() int {
	ci := ClassInfo{
		func: func2[T]
	}
	return ci.func()
}

struct Struct1 {}

struct Struct2 {}

fn main() {
	r1 := func1[i32]()
	println(r1)
	assert r1 == 4

	r2 := func1[bool]()
	println(r2)
	assert r2 == 1

	r3 := func1[Struct1]()
	println(r3)
	assert r3 == 1

	r4 := func1[Struct2]()
	println(r4)
	assert r4 == 1
}

PS D:\Test\v\tt1> v run .
4
1
1
1
```