### PR TITLE
sha256/512: fix behavioral bug in .checksum

### DIFF
--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -201,7 +201,13 @@ fn (mut d Digest) checksum_internal() []u8 {
 @[deprecated: 'checksum() will be changed to a private method, use sum() instead']
 @[deprecated_after: '2024-04-30']
 pub fn (mut d Digest) checksum() []u8 {
-	return d.checksum_internal()
+	out := d.checksum_internal()
+	// if this digest has `size224` length, return the correct `size224` checksum
+	if d.is224 {
+		return out[0..sha256.size224]
+	}
+	// otherwise, returns a normal size
+	return out
 }
 
 // sum returns the SHA256 checksum of the bytes in `data`.

--- a/vlib/crypto/sha256/sha256_test.v
+++ b/vlib/crypto/sha256/sha256_test.v
@@ -28,3 +28,24 @@ fn test_crypto_sha256_writer_reset() {
 	sum := digest.sum([])
 	assert sum.hex() == 'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'
 }
+
+fn test_crypto_sha256_224() {
+	data := 'hello world\n'.bytes()
+	mut digest := sha256.new224()
+	expected := '95041dd60ab08c0bf5636d50be85fe9790300f39eb84602858a9b430'
+
+	// with sum224 function
+	sum224 := sha256.sum224(data)
+	assert sum224.hex() == expected
+
+	// with sum
+	_ := digest.write(data)!
+	sum := digest.sum([])
+	assert sum.hex() == expected
+
+	// with checksum
+	digest.reset()
+	_ := digest.write(data)!
+	chksum := digest.checksum()
+	assert chksum.hex() == expected
+}

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -274,7 +274,21 @@ fn (mut d Digest) checksum_internal() []u8 {
 @[deprecated: 'checksum() will be changed to a private method, use sum() instead']
 @[deprecated_after: '2024-04-30']
 pub fn (mut d Digest) checksum() []u8 {
-	return d.checksum_internal()
+	out := d.checksum_internal()
+	match d.function {
+		.sha384 {
+			return out[0..sha512.size384]
+		}
+		.sha512_224 {
+			return out[0..sha512.size224]
+		}
+		.sha512_256 {
+			return out[0..sha512.size256]
+		}
+		else {
+			return out
+		}
+	}
 }
 
 // sum512 returns the SHA512 checksum of the data.

--- a/vlib/crypto/sha512/sha512_test.v
+++ b/vlib/crypto/sha512/sha512_test.v
@@ -31,3 +31,54 @@ fn test_crypto_sha512_writer_reset() {
 	sum := digest.sum([])
 	assert sum.hex() == final_result
 }
+
+fn test_crypto_sha512_384() {
+	data := 'example bytes'.bytes()
+	sum384 := sha512.sum384(data)
+	expected := '8004e0038985a2d4dc40802b149f02cdd5868eaa58d87fae02f0cce2a3b566a6af63e34b11d5ba88c6035b96e587a6d6'
+	assert sum384.hex() == expected
+
+	mut d := sha512.new384()
+	d.write(data) or { assert false }
+	sum := d.sum([])
+	assert sum.hex() == expected
+
+	d.reset()
+	d.write(data) or { assert false }
+	chksum := d.checksum()
+	assert chksum.hex() == expected
+}
+
+fn test_crypto_sha512_224() {
+	data := 'example bytes'.bytes()
+	sum512_224 := sha512.sum512_224(data)
+	expected := '2bcbe17a1c3cb7b2b8b75c3118ed8525b6a4c505f2e59f3dc5dfe462'
+	assert sum512_224.hex() == expected
+
+	mut d := sha512.new512_224()
+	d.write(data) or { assert false }
+	sum := d.sum([])
+	assert sum.hex() == expected
+
+	d.reset()
+	d.write(data) or { assert false }
+	chksum := d.checksum()
+	assert chksum.hex() == expected
+}
+
+fn test_crypto_sha512_256() {
+	data := 'example bytes'.bytes()
+	sum512_256 := sha512.sum512_256(data)
+	expected := '984512a8f874623cf1e2d5bd85c7d1240214163db0ebd0919922768f94879563'
+	assert sum512_256.hex() == expected
+
+	mut d := sha512.new512_256()
+	d.write(data) or { assert false }
+	sum := d.sum([])
+	assert sum.hex() == expected
+
+	d.reset()
+	d.write(data) or { assert false }
+	chksum := d.checksum()
+	assert chksum.hex() == expected
+}


### PR DESCRIPTION
This PR basically fix behavioral bug in `crypto.sha256` and `crypto.sha512` especially in future deprecated `.checksum()` method of the Digest. This is discussed previously with @joe-conigliaro on discord channel, see this [thread](https://discord.com/channels/592103645835821068/592106336838352923/1209734382357577800) for detail.

Basically,  behavioral `.checksum()` bug comes from the facts the `.checksum()` just calls private `.checksum_internal()` without returning proper size of the underlying digest. Its affect `sha256` or `sha512` Digest when operates on non standard size of the module, ie., `size224` for `sha256` and the size other than `sha512.size` that sha512 support them.
This snippet from discord copied here for sake of clarity
```v
import encoding.hex
import crypto.sha256

fn main() {
    text := 'hello world\n'
    data := text.bytes()


    expected := hex.decode('95041dd60ab08c0bf5636d50be85fe9790300f39eb84602858a9b430')!
    hash := sha256.sum224(data)
    // with function based, it should produces correct behavioral result
    assert hash == expected

    // lets use digest based hash
    mut d := sha256.new224()

    _ := d.write(data)!
    out := d.sum([])
    // with sum, also produces correct behavioural result
    assert out == expected

    // lets use checksum 
    d.reset()
    _ := d.write(data)!
    out2 := d.checksum()
    // this assert would fail because out2 length is normal size (32 bytes) in this case
    assert out2 == expected
}
```

This PR comes with the fix for `sha256.Digest.checksum` and `sha512.Digest.checksum` and additional test confirm it.
Please give it a review...

Thanks @joe-conigliaro 

