### PR TITLE
os: don't check rdev equality on FreeBSD

### DIFF
--- a/vlib/os/os_stat_test.v
+++ b/vlib/os/os_stat_test.v
@@ -56,8 +56,10 @@ fn test_stat() {
 	assert dstat.get_filetype() == .directory
 	assert fstat.dev == dstat.dev, 'File and directory should be created on same device'
 	$if !freebsd {
+		assert fstat.rdev == dstat.rdev, 'File and directory should have same device ID'
+	} $else {
 		// On FreeBSD, the rdev values are not necessarily the same for non-devices
 		// such as regular files and directories.
-		assert fstat.rdev == dstat.rdev, 'File and directory should have same device ID'
+		assert fstat.rdev != dstat.rdev, 'File and directory should not have same device ID'
 	}
 }

--- a/vlib/os/os_stat_test.v
+++ b/vlib/os/os_stat_test.v
@@ -55,5 +55,9 @@ fn test_stat() {
 	dstat := os.stat(temp_dir)!
 	assert dstat.get_filetype() == .directory
 	assert fstat.dev == dstat.dev, 'File and directory should be created on same device'
-	assert fstat.rdev == dstat.rdev, 'File and directory should have same device ID'
+	$if !freebsd {
+		// On FreeBSD, the rdev values are not necessarily the same for non-devices
+		// such as regular files and directories.
+		assert fstat.rdev == dstat.rdev, 'File and directory should have same device ID'
+	}
 }


### PR DESCRIPTION
On FreeBSD, the stat.rdev value of a regular file and its parent directory are not necessarily the same.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
