### PR TITLE
ui: handle dpi change when moving window to another monitor

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -407,10 +407,7 @@ fn gg_event_fn(ce voidptr, user_data voidptr) {
 		}
 		.resized {
 			ctx.scale = dpi_scale()
-			mut ft_scale := &ctx.ft.scale
-			unsafe {
-				*ft_scale = ctx.scale
-			}
+			ctx.ft.scale = ctx.scale
 			if ctx.config.resized_fn != unsafe { nil } {
 				ctx.config.resized_fn(e, ctx.config.user_data)
 			}

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -406,6 +406,11 @@ fn gg_event_fn(ce voidptr, user_data voidptr) {
 			}
 		}
 		.resized {
+			ctx.scale = dpi_scale()
+			mut ft_scale := &ctx.ft.scale
+			unsafe {
+				*ft_scale = ctx.scale
+			}
 			if ctx.config.resized_fn != unsafe { nil } {
 				ctx.config.resized_fn(e, ctx.config.user_data)
 			}

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -16,7 +16,8 @@ pub:
 	font_bold   int
 	font_mono   int
 	font_italic int
-	scale       f32 = 1.0
+pub mut:
+	scale f32 = 1.0
 }
 
 fn new_ft(c FTConfig) ?&FT {


### PR DESCRIPTION
Update the dpi scaling in ctx and ctx.ft when a window is dragged to a monitor with a different dpi scaling. 