### PR TITLE
checker: fix struct field init with generic anon fn (fix #18294)

### DIFF
--- a/vlib/v/tests/struct_field_init_with_generic_anon_fn_test.v
+++ b/vlib/v/tests/struct_field_init_with_generic_anon_fn_test.v
@@ -1,0 +1,30 @@
+pub struct Module {
+}
+
+pub struct Service {
+	callback fn () = unsafe { nil }
+}
+
+pub fn (mut self Module) do_anything[T]() {
+}
+
+pub fn (mut self Module) register[T]() {
+	_ := Service{
+		callback: fn [mut self] [T]() {
+			self.do_anything[T]()
+		}
+	}
+}
+
+struct Something {
+}
+
+struct SomethingDifferent {
+}
+
+fn test_struct_field_init_with_generic_anon_fn() {
+	mut mod := Module{}
+	mod.register[Something]()
+	mod.register[SomethingDifferent]()
+	assert true
+}


### PR DESCRIPTION
This PR fix struct field init with generic anon fn (fix #18294).

- Has been fixed by #20878.
- Add test.

```v
pub struct Module {
}

pub struct Service {
	callback fn () = unsafe { nil }
}

pub fn (mut self Module) do_anything[T]() {
}

pub fn (mut self Module) register[T]() {
	_ := Service{
		callback: fn [mut self] [T]() {
			self.do_anything[T]()
		}
	}
}

struct Something {
}

struct SomethingDifferent {
}

fn main() {
	mut mod := Module{}
	mod.register[Something]()
	mod.register[SomethingDifferent]()
	assert true
}

PS D:\Test\v\tt1> v run .
```