### PR TITLE
x.json2: add skippable field attr @json: '-'

### DIFF
--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -142,113 +142,120 @@ fn decode_struct[T](_ T, res map[string]Any) !T {
 	mut typ := T{}
 	$if T is $struct {
 		$for field in T.fields {
+			mut skip_field := false
 			mut json_name := field.name
+
 			for attr in field.attrs {
 				if attr.contains('json: ') {
 					json_name = attr.replace('json: ', '')
+					if json_name == '-' {
+						skip_field = true
+					}
 					break
 				}
 			}
 
-			$if field.is_enum {
-				if v := res[json_name] {
-					typ.$(field.name) = v.int()
-				} else {
-					$if field.is_option {
-						typ.$(field.name) = none
+			if !skip_field {
+				$if field.is_enum {
+					if v := res[json_name] {
+						typ.$(field.name) = v.int()
+					} else {
+						$if field.is_option {
+							typ.$(field.name) = none
+						}
 					}
-				}
-			} $else $if field.typ is u8 {
-				typ.$(field.name) = res[json_name]!.u64()
-			} $else $if field.typ is u16 {
-				typ.$(field.name) = res[json_name]!.u64()
-			} $else $if field.typ is u32 {
-				typ.$(field.name) = res[json_name]!.u64()
-			} $else $if field.typ is u64 {
-				typ.$(field.name) = res[json_name]!.u64()
-			} $else $if field.typ is int {
-				typ.$(field.name) = res[json_name]!.int()
-			} $else $if field.typ is i8 {
-				typ.$(field.name) = res[json_name]!.int()
-			} $else $if field.typ is i16 {
-				typ.$(field.name) = res[json_name]!.int()
-			} $else $if field.typ is i32 {
-				typ.$(field.name) = i32(res[field.name]!.int())
-			} $else $if field.typ is i64 {
-				typ.$(field.name) = res[json_name]!.i64()
-			} $else $if field.typ is ?u8 {
-				if json_name in res {
-					typ.$(field.name) = ?u8(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?i8 {
-				if json_name in res {
-					typ.$(field.name) = ?i8(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?u16 {
-				if json_name in res {
-					typ.$(field.name) = ?u16(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?i16 {
-				if json_name in res {
-					typ.$(field.name) = ?i16(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?u32 {
-				if json_name in res {
-					typ.$(field.name) = ?u32(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?i32 {
-				if json_name in res {
-					typ.$(field.name) = ?i32(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?u64 {
-				if json_name in res {
-					typ.$(field.name) = ?u64(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?i64 {
-				if json_name in res {
-					typ.$(field.name) = ?i64(res[json_name]!.i64())
-				}
-			} $else $if field.typ is ?int {
-				if json_name in res {
-					typ.$(field.name) = ?int(res[json_name]!.i64())
-				}
-			} $else $if field.typ is f32 {
-				typ.$(field.name) = res[json_name]!.f32()
-			} $else $if field.typ is ?f32 {
-				if json_name in res {
+				} $else $if field.typ is u8 {
+					typ.$(field.name) = res[json_name]!.u64()
+				} $else $if field.typ is u16 {
+					typ.$(field.name) = res[json_name]!.u64()
+				} $else $if field.typ is u32 {
+					typ.$(field.name) = res[json_name]!.u64()
+				} $else $if field.typ is u64 {
+					typ.$(field.name) = res[json_name]!.u64()
+				} $else $if field.typ is int {
+					typ.$(field.name) = res[json_name]!.int()
+				} $else $if field.typ is i8 {
+					typ.$(field.name) = res[json_name]!.int()
+				} $else $if field.typ is i16 {
+					typ.$(field.name) = res[json_name]!.int()
+				} $else $if field.typ is i32 {
+					typ.$(field.name) = i32(res[field.name]!.int())
+				} $else $if field.typ is i64 {
+					typ.$(field.name) = res[json_name]!.i64()
+				} $else $if field.typ is ?u8 {
+					if json_name in res {
+						typ.$(field.name) = ?u8(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?i8 {
+					if json_name in res {
+						typ.$(field.name) = ?i8(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?u16 {
+					if json_name in res {
+						typ.$(field.name) = ?u16(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?i16 {
+					if json_name in res {
+						typ.$(field.name) = ?i16(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?u32 {
+					if json_name in res {
+						typ.$(field.name) = ?u32(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?i32 {
+					if json_name in res {
+						typ.$(field.name) = ?i32(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?u64 {
+					if json_name in res {
+						typ.$(field.name) = ?u64(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?i64 {
+					if json_name in res {
+						typ.$(field.name) = ?i64(res[json_name]!.i64())
+					}
+				} $else $if field.typ is ?int {
+					if json_name in res {
+						typ.$(field.name) = ?int(res[json_name]!.i64())
+					}
+				} $else $if field.typ is f32 {
 					typ.$(field.name) = res[json_name]!.f32()
-				}
-			} $else $if field.typ is f64 {
-				typ.$(field.name) = res[json_name]!.f64()
-			} $else $if field.typ is ?f64 {
-				if json_name in res {
+				} $else $if field.typ is ?f32 {
+					if json_name in res {
+						typ.$(field.name) = res[json_name]!.f32()
+					}
+				} $else $if field.typ is f64 {
 					typ.$(field.name) = res[json_name]!.f64()
-				}
-			} $else $if field.typ is bool {
-				typ.$(field.name) = res[json_name]!.bool()
-			} $else $if field.typ is ?bool {
-				if json_name in res {
+				} $else $if field.typ is ?f64 {
+					if json_name in res {
+						typ.$(field.name) = res[json_name]!.f64()
+					}
+				} $else $if field.typ is bool {
 					typ.$(field.name) = res[json_name]!.bool()
-				}
-			} $else $if field.typ is string {
-				typ.$(field.name) = res[json_name]!.str()
-			} $else $if field.typ is ?string {
-				if json_name in res {
+				} $else $if field.typ is ?bool {
+					if json_name in res {
+						typ.$(field.name) = res[json_name]!.bool()
+					}
+				} $else $if field.typ is string {
 					typ.$(field.name) = res[json_name]!.str()
-				}
-			} $else $if field.typ is time.Time {
-				typ.$(field.name) = res[json_name]!.to_time()!
-			} $else $if field.typ is ?time.Time {
-				if json_name in res {
+				} $else $if field.typ is ?string {
+					if json_name in res {
+						typ.$(field.name) = res[json_name]!.str()
+					}
+				} $else $if field.typ is time.Time {
 					typ.$(field.name) = res[json_name]!.to_time()!
+				} $else $if field.typ is ?time.Time {
+					if json_name in res {
+						typ.$(field.name) = res[json_name]!.to_time()!
+					}
+				} $else $if field.is_array {
+				} $else $if field.is_struct {
+					typ.$(field.name) = decode_struct(typ.$(field.name), res[field.name]!.as_map())!
+				} $else $if field.is_alias {
+				} $else $if field.is_map {
+				} $else {
+					return error("The type of `${field.name}` can't be decoded. Please open an issue at https://github.com/vlang/v/issues/new/choose")
 				}
-			} $else $if field.is_array {
-			} $else $if field.is_struct {
-				typ.$(field.name) = decode_struct(typ.$(field.name), res[field.name]!.as_map())!
-			} $else $if field.is_alias {
-			} $else $if field.is_map {
-			} $else {
-				return error("The type of `${field.name}` can't be decoded. Please open an issue at https://github.com/vlang/v/issues/new/choose")
 			}
 		}
 	} $else $if T is $map {

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -177,12 +177,27 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 	mut fields_len := 0
 
 	$for field in U.fields {
-		$if field.is_option {
-			if val.$(field.name) != none {
+		mut skip_field := false
+
+		for attr in field.attrs {
+			if attr.contains('json: '){
+				json_name := attr.replace('json: ', '')
+				if json_name == '-' {
+					skip_field = true
+				}
+
+				break
+			}
+		}
+
+		if !skip_field {
+			$if field.is_option {
+				if val.$(field.name) != none {
+					fields_len++
+				}
+			} $else {
 				fields_len++
 			}
-		} $else {
-			fields_len++
 		}
 	}
 	$for field in U.fields {

--- a/vlib/x/json2/tests/decode_struct_test.v
+++ b/vlib/x/json2/tests/decode_struct_test.v
@@ -45,6 +45,30 @@ mut:
 	val &T
 }
 
+struct StructTypeSkippedFields[T] {
+mut:
+	val  T @[json: '-']
+	val1 T
+	val2 T @[json: '-']
+	val3 T
+}
+
+struct StructTypeSkippedFields2[T] {
+mut:
+	val  T
+	val1 T @[json: '-']
+	val2 T
+	val3 T @[json: '-']
+}
+
+struct StructTypeSkippedFields3[T] {
+mut:
+	val  T @[json: '-']
+	val1 T @[json: '-']
+	val2 T @[json: '-']
+	val3 T @[json: '-']
+}
+
 fn test_types() {
 	assert json.decode[StructType[string]]('{"val": ""}')!.val == ''
 	assert json.decode[StructType[string]]('{"val": "0"}')!.val == '0'
@@ -124,5 +148,34 @@ fn test_types() {
 		assert false
 	} else {
 		assert true
+	}
+}
+
+fn test_skipped_fields() {
+	if x := json.decode[StructTypeSkippedFields[int]]('{"val":10,"val1":10,"val2":10,"val3":10}') {
+		assert x.val == 0
+		assert x.val1 == 10
+		assert x.val2 == 0
+		assert x.val3 == 10
+	} else {
+		assert false
+	}
+
+	if x := json.decode[StructTypeSkippedFields2[int]]('{"val":10,"val1":10,"val2":10,"val3":10}') {
+		assert x.val == 10
+		assert x.val1 == 0
+		assert x.val2 == 10
+		assert x.val3 == 0
+	} else {
+		assert false
+	}
+
+	if x := json.decode[StructTypeSkippedFields3[int]]('{"val":10,"val1":10,"val2":10,"val3":10}') {
+		assert x.val == 0
+		assert x.val1 == 0
+		assert x.val2 == 0
+		assert x.val3 == 0
+	} else {
+		assert false
 	}
 }

--- a/vlib/x/json2/tests/encode_struct_test.v
+++ b/vlib/x/json2/tests/encode_struct_test.v
@@ -44,6 +44,30 @@ mut:
 	val &T
 }
 
+struct StructTypeSkippedFields[T] {
+mut:
+	val  T @[json: '-']
+	val1 T
+	val2 T @[json: '-']
+	val3 T
+}
+
+struct StructTypeSkippedFields2[T] {
+mut:
+	val  T
+	val1 T @[json: '-']
+	val2 T
+	val3 T @[json: '-']
+}
+
+struct StructTypeSkippedFields3[T] {
+mut:
+	val  T @[json: '-']
+	val1 T @[json: '-']
+	val2 T @[json: '-']
+	val3 T @[json: '-']
+}
+
 fn test_types() {
 	assert json.encode(StructType[string]{}) == '{"val":""}'
 	assert json.encode(StructType[string]{ val: '' }) == '{"val":""}'
@@ -209,6 +233,29 @@ fn test_option_array() {
 	// assert json.encode(StructTypeOption[[][]int]{
 	// 	val: [[0, 1], [0, 2, 3], [2], [5, 1]]
 	// }) == '{"val":[[0,1],[0,2,3],[2],[5,1]]}'
+}
+
+fn test_skipped_fields() {
+	assert json.encode(StructTypeSkippedFields[string]{
+		val: ''
+		val1: ''
+		val2: ''
+		val3: ''
+	}) == '{"val1":"","val3":""}'
+
+	assert json.encode(StructTypeSkippedFields2[string]{
+		val: ''
+		val1: ''
+		val2: ''
+		val3: ''
+	}) == '{"val":"","val2":""}'
+
+	assert json.encode(StructTypeSkippedFields3[string]{
+		val: ''
+		val1: ''
+		val2: ''
+		val3: ''
+	}) == '{}'
 }
 
 fn test_alias() {


### PR DESCRIPTION
Adds the `@json: '-'` Attribute to skip struct fields in the encoding/decoding process of `x.json2` module
This feature already exists in the main `json` module
Adds tests to ensure the fields are correctly skipped from encoding/decoding

Addresses: #20890