### PR TITLE
checker: fix checking match branch call expr twice (fix #20709)

### DIFF
--- a/vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.out
+++ b/vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.out
@@ -1,0 +1,28 @@
+vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.vv:16:19: error: cannot use `&Foobar` as `&Foo` in argument 1 to `mutate_foo`
+   14 |     match foobar {
+   15 |         Foo {
+   16 |             mutate_foo(mut foobar)
+      |                            ~~~~~~
+   17 |         }
+   18 |         Bar {
+vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.vv:19:19: error: cannot use `&Foobar` as `&Bar` in argument 1 to `mutate_bar`
+   17 |         }
+   18 |         Bar {
+   19 |             mutate_bar(mut foobar)
+      |                            ~~~~~~
+   20 |         }
+   21 |     }
+vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.vv:27:19: error: cannot use `&Foobar` as `&Foo` in argument 1 to `mutate_foo`
+   25 |     return match foobar {
+   26 |         Foo {
+   27 |             mutate_foo(mut foobar)
+      |                            ~~~~~~
+   28 |         }
+   29 |         Bar {
+vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.vv:30:19: error: cannot use `&Foobar` as `&Bar` in argument 1 to `mutate_bar`
+   28 |         }
+   29 |         Bar {
+   30 |             mutate_bar(mut foobar)
+      |                            ~~~~~~
+   31 |         }
+   32 |     }

--- a/vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.vv
+++ b/vlib/v/checker/tests/match_branch_call_expr_arg_mismatch.vv
@@ -1,0 +1,49 @@
+struct Foo {
+mut:
+	x int
+}
+
+struct Bar {
+mut:
+	y int
+}
+
+type Foobar = Foo | Bar
+
+fn mutate_foobar1(mut foobar Foobar) {
+	match foobar {
+		Foo {
+			mutate_foo(mut foobar)
+		}
+		Bar {
+			mutate_bar(mut foobar)
+		}
+	}
+}
+
+fn mutate_foobar2(mut foobar Foobar) int {
+	return match foobar {
+		Foo {
+			mutate_foo(mut foobar)
+		}
+		Bar {
+			mutate_bar(mut foobar)
+		}
+	}
+}
+
+fn mutate_foo(mut foo Foo) int {
+	foo.x = 5
+	return 5
+}
+
+fn mutate_bar(mut bar Bar) int {
+	bar.y = 10
+	return 10
+}
+
+fn main() {
+	mut bar := Bar{y: 0}
+	mutate_foobar1(mut bar)
+	mutate_foobar2(mut bar)
+}


### PR DESCRIPTION
This PR fix checking match branch call expr twice (fix #20709).

- Fix checking match branch call expr twice.
- Add test.

```v
struct Foo {
mut:
	x int
}

struct Bar {
mut:
	y int
}

type Foobar = Foo | Bar

fn mutate_foobar1(mut foobar Foobar) {
	match foobar {
		Foo {
			mutate_foo(mut foobar)
		}
		Bar {
			mutate_bar(mut foobar)
		}
	}
}

fn mutate_foobar2(mut foobar Foobar) int {
	return match foobar {
		Foo {
			mutate_foo(mut foobar)
		}
		Bar {
			mutate_bar(mut foobar)
		}
	}
}

fn mutate_foo(mut foo Foo) int {
	foo.x = 5
	return 5
}

fn mutate_bar(mut bar Bar) int {
	bar.y = 10
	return 10
}

fn main() {
	mut bar := Bar{y: 0}
	mutate_foobar1(mut bar)
	mutate_foobar2(mut bar)
}

PS D:\Test\v\tt1> v run .
tt1.v:16:19: error: cannot use `&Foobar` as `&Foo` in argument 1 to `mutate_foo`
   14 |     match foobar {
   15 |         Foo {
   16 |             mutate_foo(mut foobar)
      |                            ~~~~~~
   17 |         }
   18 |         Bar {
tt1.v:19:19: error: cannot use `&Foobar` as `&Bar` in argument 1 to `mutate_bar`
   17 |         }
   18 |         Bar {
   19 |             mutate_bar(mut foobar)
      |                            ~~~~~~
   20 |         }
   21 |     }
tt1.v:27:19: error: cannot use `&Foobar` as `&Foo` in argument 1 to `mutate_foo`
   25 |     return match foobar {
   26 |         Foo {
   27 |             mutate_foo(mut foobar)
      |                            ~~~~~~
   28 |         }
   29 |         Bar {
tt1.v:30:19: error: cannot use `&Foobar` as `&Bar` in argument 1 to `mutate_bar`
   28 |         }
   29 |         Bar {
   30 |             mutate_bar(mut foobar)
      |                            ~~~~~~
   31 |         }
   32 |     }
```