### PR TITLE
[x.json2] [FIX] Encoding Structs with Skipped fields not generating commas correctly

### DIFF
--- a/vlib/x/json2/tests/encode_struct_skippable_fields_test.v
+++ b/vlib/x/json2/tests/encode_struct_skippable_fields_test.v
@@ -1,0 +1,134 @@
+import time
+import x.json2 as json
+
+struct StructTypeSkippedFields[T] {
+mut:
+	val  T @[json: '-']
+	val1 T
+	val2 T @[json: '-']
+	val3 T
+}
+
+struct StructTypeSkippedFields1[T] {
+mut:
+	val  T
+	val1 T @[json: '-']
+	val2 T
+	val3 T @[json: '-']
+}
+
+struct StructTypeSkippedFields2[T] {
+mut:
+	val  T @[json: '-']
+	val1 T @[json: '-']
+	val2 T @[json: '-']
+	val3 T @[json: '-']
+}
+
+struct StructTypeSkippedFields3[T, U, V] {
+mut:
+	val  T @[json: '-']
+	val1 U
+	val2 V
+	val3 T @[json: '-']
+}
+
+struct StructTypeSkippedFields4 {
+mut:
+	val  string    @[json: '-']
+	val1 i64
+	val2 f64
+	val3 time.Time
+}
+
+struct StructTypeSkippedFields5 {
+mut:
+	val  string    @[json: '-']
+	val1 i64       @[json: '-']
+	val2 f64
+	val3 time.Time
+}
+
+struct StructTypeSkippedFields6 {
+mut:
+	val  string    @[json: '-']
+	val1 i64
+	val2 f64       @[json: '-']
+	val3 time.Time
+}
+
+struct StructTypeSkippedFields7 {
+mut:
+	val  string
+	val1 i64       @[json: '-']
+	val2 f64       @[json: '-']
+	val3 time.Time
+}
+
+struct StructTypeSkippedFields8 {
+mut:
+	val  string
+	val1 i64       @[json: '-']
+	val2 f64
+	val3 time.Time @[json: '-']
+}
+
+fn test_encode_struct_skipped_fields() {
+	assert json.encode(StructTypeSkippedFields[string]{
+		val: 'string_val'
+		val1: 'string_val1'
+		val2: 'string_val2'
+		val3: 'string_val3'
+	}) == '{"val1":"string_val1","val3":"string_val3"}'
+
+	assert json.encode(StructTypeSkippedFields1[string]{
+		val: 'string_val'
+		val1: 'string_val1'
+		val2: 'string_val2'
+		val3: 'string_val3'
+	}) == '{"val":"string_val","val2":"string_val2"}'
+
+	assert json.encode(StructTypeSkippedFields2[string]{
+		val: 'string_val'
+		val1: 'string_val1'
+		val2: 'string_val2'
+		val3: 'string_val3'
+	}) == '{}'
+
+	assert json.encode(StructTypeSkippedFields3[string, i64, f64]{
+		val: 'string_val'
+		val1: 1
+		val2: 1.0
+		val3: 'string_val'
+	}) == '{"val1":1,"val2":1.0}'
+
+	assert json.encode(StructTypeSkippedFields4{
+		val: 'string_val'
+		val1: 1
+		val2: 1.0
+	}) == '{"val1":1,"val2":1.0,"val3":"0000-00-00T00:00:00.000Z"}'
+
+	assert json.encode(StructTypeSkippedFields5{
+		val: 'string_val'
+		val1: 1
+		val2: 1.0
+	}) == '{"val2":1.0,"val3":"0000-00-00T00:00:00.000Z"}'
+
+	assert json.encode(StructTypeSkippedFields6{
+		val: 'string_val'
+		val1: 1
+		val2: 1.0
+	}) == '{"val1":1,"val3":"0000-00-00T00:00:00.000Z"}'
+
+	assert json.encode(StructTypeSkippedFields7{
+		val: 'string_val'
+		val1: 1
+		val2: 1.0
+	}) == '{"val":"string_val","val3":"0000-00-00T00:00:00.000Z"}'
+
+	assert json.encode(StructTypeSkippedFields8{
+		val: 'string_val'
+		val1: 1
+		val2: 1.0
+	}) == '{"val":"string_val","val2":1.0}'
+}

--- a/vlib/x/json2/tests/encode_struct_test.v
+++ b/vlib/x/json2/tests/encode_struct_test.v
@@ -44,30 +44,6 @@ mut:
 	val &T
 }
 
-struct StructTypeSkippedFields[T] {
-mut:
-	val  T @[json: '-']
-	val1 T
-	val2 T @[json: '-']
-	val3 T
-}
-
-struct StructTypeSkippedFields2[T] {
-mut:
-	val  T
-	val1 T @[json: '-']
-	val2 T
-	val3 T @[json: '-']
-}
-
-struct StructTypeSkippedFields3[T] {
-mut:
-	val  T @[json: '-']
-	val1 T @[json: '-']
-	val2 T @[json: '-']
-	val3 T @[json: '-']
-}
-
 fn test_types() {
 	assert json.encode(StructType[string]{}) == '{"val":""}'
 	assert json.encode(StructType[string]{ val: '' }) == '{"val":""}'
@@ -233,29 +209,6 @@ fn test_option_array() {
 	// assert json.encode(StructTypeOption[[][]int]{
 	// 	val: [[0, 1], [0, 2, 3], [2], [5, 1]]
 	// }) == '{"val":[[0,1],[0,2,3],[2],[5,1]]}'
-}
-
-fn test_skipped_fields() {
-	assert json.encode(StructTypeSkippedFields[string]{
-		val: ''
-		val1: ''
-		val2: ''
-		val3: ''
-	}) == '{"val1":"","val3":""}'
-
-	assert json.encode(StructTypeSkippedFields2[string]{
-		val: ''
-		val1: ''
-		val2: ''
-		val3: ''
-	}) == '{"val":"","val2":""}'
-
-	assert json.encode(StructTypeSkippedFields3[string]{
-		val: ''
-		val1: ''
-		val2: ''
-		val3: ''
-	}) == '{}'
 }
 
 fn test_alias() {


### PR DESCRIPTION
### Yesterday my PR #20892 adding a missing feature in the x.json2 module got merged.
Although all tests were passing, the encoding of structs were not working properly for some reason, even if they were on the tests.
However my struct encoding tests were only using generic structs that only had fields of the same type:
```v
struct StructTypeSkippedFields[T] {
mut:
	val  T @[json: '-']
	val1 T
	val2 T @[json: '-']
	val3 T
}
```

These kind of structs were passing on the tests. However as soon as I tested them with non generic structs with different types on each field, they were not encoding correctly, having missing commas

This is what it would look like:

```v
struct StructTypeSkippedField5 {
pub mut:
	val string @[json: '-']
	val1 int @[json: '-']
	val2 f64
	val3 bool
	val4 string
	val5 string
}

json2.encode(StructTypeSkippedField5{
	val: 'foo'
	val1: 999
	val2: 999.0
	val3: true
	val4: 'bar'
	val5: 'baz'
}) // The result would be: {"val2": 999.0,"val3":true"val4":"bar""val5":"baz"}
```

### This PR Fixes this bug, and adds new tests to ensure they are always encoded correctly