### PR TITLE
parser: fix formatting comptime if expr after inc expr (fix #20927)

### DIFF
--- a/vlib/v/fmt/tests/comptime_if_after_inc_expr_keep.vv
+++ b/vlib/v/fmt/tests/comptime_if_after_inc_expr_keep.vv
@@ -1,0 +1,8 @@
+fn main() {
+	mut i := 0
+	i++
+	$if abc ? {
+		println(i)
+	}
+	println('done')
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -613,7 +613,7 @@ fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bo
 			if mut node is ast.IndexExpr {
 				node.recursive_mapset_is_setter(true)
 			}
-			is_c2v_prefix := p.peek_tok.kind == .dollar
+			is_c2v_prefix := p.peek_tok.kind == .dollar && p.peek_tok.is_next_to(p.tok)
 			node = ast.PostfixExpr{
 				op: p.tok.kind
 				expr: node


### PR DESCRIPTION
This PR fix formatting comptime if expr after inc expr (fix #20927).

- Fix formatting comptime if expr after inc expr.
- Add test.

vlib\v\fmt\tests\comptime_if_after_inc_expr_keep.vv
```v
fn main() {
	mut i := 0
	i++
	$if abc ? {
		println(i)
	}
	println('done')
}
```