### PR TITLE
cgen: fix returning option call in non-option fn (fix #20939)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6715,6 +6715,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 						if !is_array_fixed {
 							if g.inside_return && !g.inside_struct_init
 								&& expr_stmt.expr is ast.CallExpr
+								&& g.cur_fn.return_type.has_option_or_result()
 								&& return_type.has_option_or_result()
 								&& expr_stmt.expr.or_block.kind == .absent {
 								g.write('${cvar_name} = ')

--- a/vlib/v/tests/return_option_call_in_non_option_fn_test.v
+++ b/vlib/v/tests/return_option_call_in_non_option_fn_test.v
@@ -1,0 +1,11 @@
+import rand
+
+pub fn random_number() i64 {
+	return rand.i64_in_range(111111, 999999) or { rand.i64() }
+}
+
+fn test_return_option_call_in_non_option_fn() {
+	ret := random_number()
+	println(ret)
+	assert true
+}


### PR DESCRIPTION
This PR fix returning option call in non-option fn (fix #20939).

- Fix returning option call in non-option fn.
- Add test.

```v
import rand

pub fn random_number() i64 {
	return rand.i64_in_range(111111, 999999) or { rand.i64() }
}

fn main() {
	ret := random_number()
	println(ret)
	assert true
}

PS D:\Test\v\tt1> v run .
350474
```