### PR TITLE
vdoc: enable browser custom search with ?q=<search>

### DIFF
--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -90,7 +90,6 @@ function setupDarkMode() {
 }
 
 function setupSearch() {
-	const searchInput = document.getElementById('search');
 	const onInputChange = debounce((e) => {
 		const searchValue = e.target.value.toLowerCase();
 		const docNav = document.querySelector('.doc-nav');
@@ -160,7 +159,18 @@ function setupSearch() {
 			});
 		}
 	});
-	searchInput.addEventListener('input', onInputChange);
+	const searchInput = document.querySelector('#search input');
+	const url = document.location.toString();
+	if (url.includes('?')) {
+		const query = url.split('?').slice(1).filter(p => p.startsWith('q=')).map(p => p.replace(/^q=/, ''))[0] || '';
+		if (query) {
+			searchInput.value = query;
+			searchInput.focus();
+			onInputChange({ target: { value: query }});
+		}
+	}
+	const searchInputDiv = document.getElementById('search');
+	searchInputDiv.addEventListener('input', onInputChange);
 	setupSearchKeymaps();
 }
 

--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -162,11 +162,16 @@ function setupSearch() {
 	const searchInput = document.querySelector('#search input');
 	const url = document.location.toString();
 	if (url.includes('?')) {
-		const query = url.split('?').slice(1).filter(p => p.startsWith('q=')).map(p => p.replace(/^q=/, ''))[0] || '';
+		const query =
+			url
+				.split('?')
+				.slice(1)
+				.filter((p) => p.startsWith('q='))
+				.map((p) => p.replace(/^q=/, ''))[0] || '';
 		if (query) {
 			searchInput.value = query;
 			searchInput.focus();
-			onInputChange({ target: { value: query }});
+			onInputChange({ target: { value: query } });
 		}
 	}
 	const searchInputDiv = document.getElementById('search');


### PR DESCRIPTION
Some browsers (e.g. Chrome) have a feature called "site search" that allow you to associate a shortcut with a custom site search string URL. For example, the shortcut "gl" can be set to `https://pkg.go.dev/search?q=%s` such that if you type "gl net/http" the browser would search for `https://pkg.go.dev/search?q=net/http` which then redirects to `https://pkg.go.dev/net/http`.

This PR would allow users to create a "vl" shortcut set to `https://modules.vlang.io/?q=%s` that would immediately act as if the user had typed `Ctrl-k` followed by their search string.

I have tested this locally with `?q=<alert>yo</alert>` and `?q=&lt;alert&gt;yo&lt;/alert&gt;` and it appears that [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) does not need to be called, as these characters are being escaped already.

Note that I ran `v test-all` locally and there were 5 errors that appear to be unrelated to this change:

```
---- Summary of `v test-all`: -----------------------------------------------------------------------------------------------
Total runtime: 366120 ms
...
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -os linux -experimental -b native -o hw.linux examples/hello_world.v
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -os macos -experimental -b native -o hw.macos examples/hello_world.v
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -o vtmp_werror -cstrict cmd/v
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' check-md -hide-warnings .
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -o v.c cmd/v && cc -Werror v.c -lpthread -lm && rm -rf a.out
```

This was run on a Mac M2 Max running Sonoma 14.2.