### PR TITLE
sokol, gg, examples: update to match uptream at 058a4c5

### DIFF
--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -387,7 +387,8 @@ fn draw_cube_glsl(app App) {
 	}
 	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
-	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
+	pass := sapp.create_default_pass(pass_action)
+	gfx.begin_pass(&pass)
 	{
 		rot := [f32(app.mouse_y), f32(app.mouse_x)]
 		// ratio := f32(ws.width)/ws.height

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -329,7 +329,8 @@ fn frame(mut app App) {
 
 	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
-	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
+	pass := sapp.create_default_pass(pass_action)
+	gfx.begin_pass(&pass)
 
 	// glsl cube
 	draw_cube_glsl(app)

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -314,8 +314,6 @@ fn draw_cube_glsl(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size_real_pixels()
-
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
 		load_action: .clear

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -502,8 +502,6 @@ fn draw_end_glsl(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size_real_pixels()
-
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
 		load_action: .clear

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -516,7 +516,8 @@ fn frame(mut app App) {
 	}
 	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
-	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
+	pass := sapp.create_default_pass(pass_action)
+	gfx.begin_pass(&pass)
 
 	/*
 	// glsl cube

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -388,8 +388,6 @@ fn draw_end_glsl(app App) {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size_real_pixels()
-
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
 		load_action: .clear
@@ -402,7 +400,8 @@ fn frame(mut app App) {
 	}
 	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
-	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
+	pass := gg.create_default_pass(pass_action)
+	gfx.begin_pass(&pass)
 
 	draw_start_glsl(app)
 	draw_cube_glsl_i(mut app)

--- a/examples/sokol/06_obj_viewer/show_obj.v
+++ b/examples/sokol/06_obj_viewer/show_obj.v
@@ -144,8 +144,6 @@ fn draw_model(app App, model_pos m4.Vec4) u32 {
 }
 
 fn frame(mut app App) {
-	ws := gg.window_size_real_pixels()
-
 	// clear
 	mut color_action := gfx.ColorAttachmentAction{
 		load_action: .clear
@@ -159,7 +157,8 @@ fn frame(mut app App) {
 
 	mut pass_action := gfx.PassAction{}
 	pass_action.colors[0] = color_action
-	gfx.begin_default_pass(&pass_action, ws.width, ws.height)
+	pass := sapp.create_default_pass(pass_action)
+	gfx.begin_pass(&pass)
 
 	// render the data
 	draw_start_glsl(app)

--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -11,7 +11,7 @@ const used_import = sokol.used_import
 
 fn main() {
 	state := &AppState{
-		pass_action: gfx.create_clear_pass(0.1, 0.1, 0.1, 1.0)
+		pass_action: gfx.create_clear_pass_action(0.1, 0.1, 0.1, 1.0)
 	}
 	title := 'Sokol Drawing Template'
 	desc := sapp.Desc{
@@ -36,7 +36,8 @@ fn init(user_data voidptr) {
 fn frame(state &AppState) {
 	// println('frame')
 	draw()
-	gfx.begin_default_pass(&state.pass_action, sapp.width(), sapp.height())
+	pass := sapp.create_default_pass(state.pass_action)
+	gfx.begin_pass(&pass)
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -14,19 +14,8 @@ mut:
 }
 
 fn main() {
-	mut color_action := gfx.ColorAttachmentAction{
-		load_action: .clear
-		clear_value: gfx.Color{
-			r: 0.3
-			g: 0.3
-			b: 0.32
-			a: 1.0
-		}
-	}
-	mut pass_action := gfx.PassAction{}
-	pass_action.colors[0] = color_action
 	state := &AppState{
-		pass_action: pass_action
+		pass_action: gfx.create_clear_pass_action(0.3, 0.3, 0.32, 1.0)
 		font_context: unsafe { nil } // &fontstash.Context(0)
 	}
 	title := 'V Metal/GL Text Rendering'
@@ -57,7 +46,8 @@ fn init(mut state AppState) {
 
 fn frame(mut state AppState) {
 	state.render_font()
-	gfx.begin_default_pass(&state.pass_action, sapp.width(), sapp.height())
+	pass := sapp.create_default_pass(state.pass_action)
+	gfx.begin_pass(&pass)
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -107,7 +107,8 @@ fn init(mut state AppState) {
 
 fn frame(mut state AppState) {
 	state.render_font()
-	gfx.begin_default_pass(&state.pass_action, sapp.width(), sapp.height())
+	pass := sapp.create_default_pass(state.pass_action)
+	gfx.begin_pass(&pass)
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -15,7 +15,7 @@ fn main() {
 	mut app := &App{
 		width: 800
 		height: 400
-		pass_action: gfx.create_clear_pass(0.1, 0.1, 0.1, 1.0)
+		pass_action: gfx.create_clear_pass_action(0.1, 0.1, 0.1, 1.0)
 	}
 	app.init()
 	app.run()
@@ -105,7 +105,8 @@ fn frame(mut app App) {
 	dt := f64(t - app.last) / 1000.0
 	app.ps.update(dt)
 	draw(app)
-	gfx.begin_default_pass(&app.pass_action, app.width, app.height)
+	pass := sapp.create_default_pass(app.pass_action)
+	gfx.begin_pass(&pass)
 	sgl.default_pipeline()
 	sgl.draw()
 	gfx.end_pass()

--- a/examples/sokol/simple_shader_glsl/simple_shader.v
+++ b/examples/sokol/simple_shader_glsl/simple_shader.v
@@ -36,7 +36,7 @@ fn main() {
 	mut app := &App{
 		width: 800
 		height: 400
-		pass_action: gfx.create_clear_pass(0.0, 0.0, 0.0, 1.0) // This will create a black color as a default pass (window background color)
+		pass_action: gfx.create_clear_pass_action(0.0, 0.0, 0.0, 1.0) // This will create a black color as a default pass (window background color)
 	}
 	app.run()
 }
@@ -143,7 +143,8 @@ fn cleanup(user_data voidptr) {
 fn frame(user_data voidptr) {
 	mut app := unsafe { &App(user_data) }
 
-	gfx.begin_default_pass(&app.pass_action, sapp.width(), sapp.height())
+	pass := sapp.create_default_pass(state.pass_action)
+	gfx.begin_pass(&pass)
 
 	gfx.apply_pipeline(app.shader_pipeline)
 	gfx.apply_bindings(&app.bind)

--- a/thirdparty/sokol/sokol_app.h
+++ b/thirdparty/sokol/sokol_app.h
@@ -273,8 +273,9 @@
             Return the MSAA sample count of the default framebuffer.
 
         const void* sapp_metal_get_device(void)
-        const void* sapp_metal_get_renderpass_descriptor(void)
-        const void* sapp_metal_get_drawable(void)
+        const void* sapp_metal_get_current_drawable(void)
+        const void* sapp_metal_get_depth_stencil_texture(void)
+        const void* sapp_metal_get_msaa_color_texture(void)
             If the Metal backend has been selected, these functions return pointers
             to various Metal API objects required for rendering, otherwise
             they return a null pointer. These void pointers are actually
@@ -294,14 +295,10 @@
             Before being used as Objective-C object, the void* must be converted
             back with a (ARC) __bridge cast.
 
-        const void* sapp_win32_get_hwnd(void)
-            On Windows, get the window's HWND, otherwise a null pointer. The
-            HWND has been cast to a void pointer in order to be tunneled
-            through code which doesn't include Windows.h.
-
         const void* sapp_d3d11_get_device(void)
         const void* sapp_d3d11_get_device_context(void)
-        const void* sapp_d3d11_get_render_target_view(void)
+        const void* sapp_d3d11_get_render_view(void)
+        const void* sapp_d3d11_get_resolve_view(void);
         const void* sapp_d3d11_get_depth_stencil_view(void)
             Similar to the sapp_metal_* functions, the sapp_d3d11_* functions
             return pointers to D3D11 API objects required for rendering,
@@ -310,6 +307,11 @@
             render-target-view and depth-stencil-view may change from one
             frame to the next!
 
+        const void* sapp_win32_get_hwnd(void)
+            On Windows, get the window's HWND, otherwise a null pointer. The
+            HWND has been cast to a void pointer in order to be tunneled
+            through code which doesn't include Windows.h.
+
         const void* sapp_wgpu_get_device(void)
         const void* sapp_wgpu_get_render_view(void)
         const void* sapp_wgpu_get_resolve_view(void)
@@ -317,6 +319,10 @@
             These are the WebGPU-specific functions to get the WebGPU
             objects and values required for rendering. If sokol_app.h
             is not compiled with SOKOL_WGPU, these functions return null.
+
+        const uint32_t sapp_gl_get_framebuffer(void)
+            This returns the 'default framebuffer' of the GL context.
+            Typically this will be zero.
 
         const void* sapp_android_get_native_activity(void);
             On Android, get the native activity ANativeActivity pointer, otherwise
@@ -544,7 +550,7 @@
     Like clipboard support, drag'n'drop support must be explicitly enabled
     at startup in the sapp_desc struct.
 
-        sapp_desc sokol_main() {
+        sapp_desc sokol_main(void) {
             return (sapp_desc) {
                 .enable_dragndrop = true,   // default is false
                 ...
@@ -554,7 +560,7 @@
     You can also adjust the maximum number of files that are accepted
     in a drop operation, and the maximum path length in bytes if needed:
 
-        sapp_desc sokol_main() {
+        sapp_desc sokol_main(void) {
             return (sapp_desc) {
                 .enable_dragndrop = true,               // default is false
                 .max_dropped_files = 8,                 // default is 1
@@ -694,7 +700,7 @@
     For instance on a Retina Mac, returning the following sapp_desc
     struct from sokol_main():
 
-    sapp_desc sokol_main() {
+    sapp_desc sokol_main(void) {
         return (sapp_desc) {
             .width = 640,
             .height = 480,
@@ -774,7 +780,7 @@
     A `programmatic quit` initiated by calling sapp_quit() or
     sapp_request_quit() will work as described above: the cleanup callback is
     called, platform-specific cleanup is performed (on the web
-    this means that JS event handlers are unregisters), and then
+    this means that JS event handlers are unregistered), and then
     the request-animation-loop will be exited. However that's all. The
     web page itself will continue to exist (e.g. it's not possible to
     programmatically close the browser tab).
@@ -933,7 +939,7 @@
           append a new favicon link element, but not delete any manually
           defined favicon in the page
 
-    For an example and test of the window icon feature, check out the the
+    For an example and test of the window icon feature, check out the
     'icon-sapp' sample on the sokol-samples git repository.
 
     ONSCREEN KEYBOARD
@@ -948,13 +954,46 @@
 
         sapp_show_keyboard(false);
 
-    Note that on the web platform, the keyboard can only be shown from
-    inside an input handler. On such platforms, sapp_show_keyboard()
-    will only work as expected when it is called from inside the
-    sokol-app event callback function. When called from other places,
-    an internal flag will be set, and the onscreen keyboard will be
-    called at the next 'legal' opportunity (when the next input event
-    is handled).
+    Note that onscreen keyboard functionality is no longer supported
+    on the browser platform (the previous hacks and workarounds to make browser
+    keyboards work for on web applications that don't use HTML UIs
+    never really worked across browsers).
+
+    INPUT EVENT BUBBLING ON THE WEB PLATFORM
+    ========================================
+    By default, input event bubbling on the web platform is configured in
+    a way that makes the most sense for 'full-canvas' apps that cover the
+    entire browser client window area:
+
+    - mouse, touch and wheel events do not bubble up, this prevents various
+      ugly side events, like:
+        - HTML text overlays being selected on double- or triple-click into
+          the canvas
+        - 'scroll bumping' even when the canvas covers the entire client area
+    - key_up/down events for 'character keys' *do* bubble up (otherwise
+      the browser will not generate UNICODE character events)
+    - all other key events *do not* bubble up by default (this prevents side effects
+      like F1 opening help, or F7 starting 'caret browsing')
+    - character events do no bubble up (although I haven't noticed any side effects
+      otherwise)
+
+    Event bubbling can be enabled for input event categories during initialization
+    in the sapp_desc struct:
+
+        sapp_desc sokol_main(int argc, char* argv[]) {
+            return (sapp_desc){
+                //...
+                .html5_bubble_mouse_events = true,
+                .html5_bubble_touch_events = true,
+                .html5_bubble_wheel_events = true,
+                .html5_bubble_key_events = true,
+                .html5_bubble_char_events = true,
+            };
+        }
+
+    This basically opens the floodgates lets *all* input events bubble up to the browser.
+    To prevent individual events from bubbling, call sapp_consume_event() from within
+    the sokol_app.h event callback.
 
     OPTIONAL: DON'T HIJACK main() (#define SOKOL_NO_ENTRY)
     ======================================================
@@ -1108,10 +1147,7 @@
 
     TEMP NOTE DUMP
     ==============
-    - onscreen keyboard support on Android requires Java :(, should we even bother?
     - sapp_desc needs a bool whether to initialize depth-stencil surface
-    - GL context initialization needs more control (at least what GL version to initialize)
-    - application icon
     - the Android implementation calls cleanup_cb() and destroys the egl context in onDestroy
       at the latest but should do it earlier, in onStop, as an app is "killable" after onStop
       on Android Honeycomb and later (it can't be done at the moment as the app may be started
@@ -1464,7 +1500,6 @@ typedef struct sapp_range {
     Note that the actual image pixel format depends on the use case:
 
     - window icon pixels are RGBA8
-    - cursor images are ??? (FIXME)
 */
 typedef struct sapp_image_desc {
     int width;
@@ -1599,7 +1634,7 @@ typedef struct sapp_allocator {
     _SAPP_LOGITEM_XMACRO(ANDROID_NATIVE_ACTIVITY_DONE, "NativeActivity done") \
     _SAPP_LOGITEM_XMACRO(ANDROID_NATIVE_ACTIVITY_ONCREATE, "NativeActivity onCreate") \
     _SAPP_LOGITEM_XMACRO(ANDROID_CREATE_THREAD_PIPE_FAILED, "failed to create thread pipe") \
-    _SAPP_LOGITEM_XMACRO(ANDROID_NATIVE_ACTIVITY_CREATE_SUCCESS, "NativeActivity sucessfully created") \
+    _SAPP_LOGITEM_XMACRO(ANDROID_NATIVE_ACTIVITY_CREATE_SUCCESS, "NativeActivity successfully created") \
     _SAPP_LOGITEM_XMACRO(WGPU_SWAPCHAIN_CREATE_SURFACE_FAILED, "wgpu: failed to create surface for swapchain") \
     _SAPP_LOGITEM_XMACRO(WGPU_SWAPCHAIN_CREATE_SWAPCHAIN_FAILED, "wgpu: failed to create swapchain object") \
     _SAPP_LOGITEM_XMACRO(WGPU_SWAPCHAIN_CREATE_DEPTH_STENCIL_TEXTURE_FAILED, "wgpu: failed to create depth-stencil texture for swapchain") \
@@ -1672,7 +1707,7 @@ typedef struct sapp_desc {
     sapp_allocator allocator;           // optional memory allocation overrides (default: malloc/free)
     sapp_logger logger;                 // logging callback override (default: NO LOGGING!)
 
-    /* backend-specific options */
+    // backend-specific options
     int gl_major_version;               // override GL major and minor version (the default GL version is 3.2)
     int gl_minor_version;
     bool win32_console_utf8;            // if true, set the output console codepage to UTF-8
@@ -1683,6 +1718,13 @@ typedef struct sapp_desc {
     bool html5_preserve_drawing_buffer; // HTML5 only: whether to preserve default framebuffer content between frames
     bool html5_premultiplied_alpha;     // HTML5 only: whether the rendered pixels use premultiplied alpha convention
     bool html5_ask_leave_site;          // initial state of the internal html5_ask_leave_site flag (see sapp_html5_ask_leave_site())
+    bool html5_bubble_mouse_events;     // if true, mouse events will bubble up to the web page
+    bool html5_bubble_touch_events;     // same for touch events
+    bool html5_bubble_wheel_events;     // same for wheel events
+    bool html5_bubble_key_events;       // if true, bubble up *all* key events to browser, not just key events that represent characters
+    bool html5_bubble_char_events;      // if true, bubble up character events to browser
+    bool html5_use_emsc_set_main_loop;  // if true, use emscripten_set_main_loop() instead of emscripten_request_animation_frame_loop()
+    bool html5_emsc_set_main_loop_simulate_infinite_loop;   // this will be passed as the simulate_infinite_loop arg to emscripten_set_main_loop()
     bool ios_keyboard_resizes_canvas;   // if true, showing the iOS keyboard shrinks the canvas
     // __v_ start
     bool __v_native_render;             // V patch to allow for native rendering
@@ -1785,7 +1827,7 @@ SOKOL_APP_API_DECL sapp_desc sapp_query_desc(void);
 SOKOL_APP_API_DECL void sapp_request_quit(void);
 /* cancel a pending quit (when SAPP_EVENTTYPE_QUIT_REQUESTED has been received) */
 SOKOL_APP_API_DECL void sapp_cancel_quit(void);
-/* initiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUSTED) */
+/* initiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUESTED) */
 SOKOL_APP_API_DECL void sapp_quit(void);
 /* call from inside event callback to consume the current event (don't forward to platform) */
 SOKOL_APP_API_DECL void sapp_consume_event(void);
@@ -1823,10 +1865,12 @@ SOKOL_APP_API_DECL void sapp_html5_fetch_dropped_file(const sapp_html5_fetch_req
 
 /* Metal: get bridged pointer to Metal device object */
 SOKOL_APP_API_DECL const void* sapp_metal_get_device(void);
-/* Metal: get bridged pointer to this frame's renderpass descriptor */
-SOKOL_APP_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
-/* Metal: get bridged pointer to current drawable */
-SOKOL_APP_API_DECL const void* sapp_metal_get_drawable(void);
+/* Metal: get bridged pointer to MTKView's current drawable of type CAMetalDrawable */
+SOKOL_APP_API_DECL const void* sapp_metal_get_current_drawable(void);
+/* Metal: get bridged pointer to MTKView's depth-stencil texture of type MTLTexture */
+SOKOL_APP_API_DECL const void* sapp_metal_get_depth_stencil_texture(void);
+/* Metal: get bridged pointer to MTKView's msaa-color-texture of type MTLTexture (may be null) */
+SOKOL_APP_API_DECL const void* sapp_metal_get_msaa_color_texture(void);
 /* macOS: get bridged pointer to macOS NSWindow */
 SOKOL_APP_API_DECL const void* sapp_macos_get_window(void);
 /* iOS: get bridged pointer to iOS UIWindow */
@@ -1838,9 +1882,11 @@ SOKOL_APP_API_DECL const void* sapp_d3d11_get_device(void);
 SOKOL_APP_API_DECL const void* sapp_d3d11_get_device_context(void);
 /* D3D11: get pointer to IDXGISwapChain object */
 SOKOL_APP_API_DECL const void* sapp_d3d11_get_swap_chain(void);
-/* D3D11: get pointer to ID3D11RenderTargetView object */
-SOKOL_APP_API_DECL const void* sapp_d3d11_get_render_target_view(void);
-/* D3D11: get pointer to ID3D11DepthStencilView */
+/* D3D11: get pointer to ID3D11RenderTargetView object for rendering */
+SOKOL_APP_API_DECL const void* sapp_d3d11_get_render_view(void);
+/* D3D11: get pointer ID3D11RenderTargetView object for msaa-resolve (may return null) */
+SOKOL_APP_API_DECL const void* sapp_d3d11_get_resolve_view(void);
+/* D3D11: get pointer ID3D11DepthStencilView */
 SOKOL_APP_API_DECL const void* sapp_d3d11_get_depth_stencil_view(void);
 /* Win32: get the HWND window handle */
 SOKOL_APP_API_DECL const void* sapp_win32_get_hwnd(void);
@@ -1853,6 +1899,9 @@ SOKOL_APP_API_DECL const void* sapp_wgpu_get_render_view(void);
 SOKOL_APP_API_DECL const void* sapp_wgpu_get_resolve_view(void);
 /* WebGPU: get swapchain's WGPUTextureView for the depth-stencil surface */
 SOKOL_APP_API_DECL const void* sapp_wgpu_get_depth_stencil_view(void);
+
+/* GL: get framebuffer object */
+SOKOL_APP_API_DECL uint32_t sapp_gl_get_framebuffer(void);
 
 /* Android: get native activity handle */
 SOKOL_APP_API_DECL const void* sapp_android_get_native_activity(void);
@@ -1904,19 +1953,8 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 // NOTE: the pixel format values *must* be compatible with sg_pixel_format
 #define _SAPP_PIXELFORMAT_RGBA8 (23)
 #define _SAPP_PIXELFORMAT_BGRA8 (28)
-#define _SAPP_PIXELFORMAT_DEPTH (42)
-#define _SAPP_PIXELFORMAT_DEPTH_STENCIL (43)
-
-#if defined(_SAPP_MACOS) || defined(_SAPP_IOS)
-    // this is ARC compatible
-    #if defined(__cplusplus)
-        #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = type(); }
-    #else
-        #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = (type) { 0 }; }
-    #endif
-#else
-    #define _SAPP_CLEAR_ARC_STRUCT(type, item) { _sapp_clear(&item, sizeof(item)); }
-#endif
+#define _SAPP_PIXELFORMAT_DEPTH (43)
+#define _SAPP_PIXELFORMAT_DEPTH_STENCIL (44)
 
 // check if the config defines are alright
 #if defined(__APPLE__)
@@ -1969,11 +2007,20 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
         #if !defined(SOKOL_FORCE_EGL)
             #define _SAPP_GLX (1)
         #endif
-    #elif !defined(SOKOL_GLES3)
+        #define GL_GLEXT_PROTOTYPES
+        #include <GL/gl.h>
+    #elif defined(SOKOL_GLES3)
+        #include <GLES3/gl3.h>
+        #include <GLES3/gl3ext.h>
+    #else
         #error("sokol_app.h: unknown 3D API selected for Linux, must be SOKOL_GLCORE33, SOKOL_GLES3")
     #endif
 #else
 #error "sokol_app.h: Unknown platform"
+#endif
+
+#if defined(SOKOL_GLCORE33) || defined(SOKOL_GLES3)
+    #define _SAPP_ANY_GL (1)
 #endif
 
 #ifndef SOKOL_API_IMPL
@@ -2009,16 +2056,18 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
         #import <MetalKit/MetalKit.h>
     #endif
     #if defined(_SAPP_MACOS)
-        #if !defined(SOKOL_METAL)
+        #if defined(_SAPP_ANY_GL)
             #ifndef GL_SILENCE_DEPRECATION
             #define GL_SILENCE_DEPRECATION
             #endif
             #include <Cocoa/Cocoa.h>
+            #include <OpenGL/gl3.h>
         #endif
     #elif defined(_SAPP_IOS)
         #import <UIKit/UIKit.h>
-        #if !defined(SOKOL_METAL)
+        #if defined(_SAPP_ANY_GL)
             #import <GLKit/GLKit.h>
+            #include <OpenGLES/ES3/gl.h>
         #endif
     #endif
     #include <AvailabilityMacros.h>
@@ -2026,6 +2075,9 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #elif defined(_SAPP_EMSCRIPTEN)
     #if defined(SOKOL_WGPU)
         #include <webgpu/webgpu.h>
+    #endif
+    #if defined(SOKOL_GLES3)
+        #include <GLES3/gl3.h>
     #endif
     #include <emscripten/emscripten.h>
     #include <emscripten/html5.h>
@@ -2089,6 +2141,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <android/native_activity.h>
     #include <android/looper.h>
     #include <EGL/egl.h>
+    #include <GLES3/gl3.h>
 #elif defined(_SAPP_LINUX)
     #define GL_GLEXT_PROTOTYPES
     #include <X11/Xlib.h>
@@ -2109,6 +2162,18 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <pthread.h>    /* only used a linker-guard, search for _sapp_linux_run() and see first comment */
     #include <time.h>
 #endif
+
+#if defined(_SAPP_APPLE)
+    // this is ARC compatible
+    #if defined(__cplusplus)
+        #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = type(); }
+    #else
+        #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = (type) { 0 }; }
+    #endif
+#else
+    #define _SAPP_CLEAR_ARC_STRUCT(type, item) { _sapp_clear(&item, sizeof(item)); }
+#endif
+
 
 // ███████ ██████   █████  ███    ███ ███████     ████████ ██ ███    ███ ██ ███    ██  ██████
 // ██      ██   ██ ██   ██ ████  ████ ██             ██    ██ ████  ████ ██ ████   ██ ██
@@ -2443,9 +2508,6 @@ typedef struct {
 #endif
 
 typedef struct {
-    bool textfield_created;
-    bool wants_show_keyboard;
-    bool wants_hide_keyboard;
     bool mouse_lock_requested;
     uint16_t mouse_buttons;
 } _sapp_emsc_t;
@@ -2531,6 +2593,7 @@ typedef struct {
 #define WGL_STENCIL_BITS_ARB 0x2023
 #define WGL_DOUBLE_BUFFER_ARB 0x2011
 #define WGL_SAMPLES_ARB 0x2042
+#define WGL_CONTEXT_DEBUG_BIT_ARB 0x00000001
 #define WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB 0x00000002
 #define WGL_CONTEXT_PROFILE_MASK_ARB 0x9126
 #define WGL_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
@@ -2564,6 +2627,8 @@ typedef struct {
     PFNWGLGETEXTENSIONSSTRINGEXTPROC GetExtensionsStringEXT;
     PFNWGLGETEXTENSIONSSTRINGARBPROC GetExtensionsStringARB;
     PFNWGLCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
+    // special case glGetIntegerv
+    void (*GetIntegerv)(uint32_t pname, int32_t* data);
     bool ext_swap_control;
     bool arb_multisample;
     bool arb_pixel_format;
@@ -2751,6 +2816,9 @@ typedef struct {
     PFNGLXSWAPINTERVALMESAPROC SwapIntervalMESA;
     PFNGLXCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
 
+    // special case glGetIntegerv
+    void (*GetIntegerv)(uint32_t pname, int32_t* data);
+
     // extension availability
     bool EXT_swap_control;
     bool MESA_swap_control;
@@ -2768,8 +2836,13 @@ typedef struct {
 } _sapp_egl_t;
 
 #endif // _SAPP_GLX
-
 #endif // _SAPP_LINUX
+
+#if defined(_SAPP_ANY_GL)
+typedef struct {
+    uint32_t framebuffer;
+} _sapp_gl_t;
+#endif
 
 typedef struct {
     bool enabled;
@@ -2847,6 +2920,9 @@ typedef struct {
         #else
             _sapp_egl_t egl;
         #endif
+    #endif
+    #if defined(_SAPP_ANY_GL)
+        _sapp_gl_t gl;
     #endif
     char html5_canvas_selector[_SAPP_MAX_TITLE_LENGTH];
     char window_title[_SAPP_MAX_TITLE_LENGTH];      // UTF-8
@@ -3619,6 +3695,7 @@ _SOKOL_PRIVATE void _sapp_macos_update_dimensions(void) {
     else {
         _sapp.dpi_scale = 1.0f;
     }
+    _sapp.macos.view.layer.contentsScale = _sapp.dpi_scale; // NOTE: needed because we set layerContentsPlacement to a non-scaling value in windowWillStartLiveResize.
     const NSRect bounds = [_sapp.macos.view bounds];
     _sapp.window_width = (int)roundf(bounds.size.width);
     _sapp.window_height = (int)roundf(bounds.size.height);
@@ -4010,6 +4087,7 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
 
     [_sapp.macos.window makeKeyAndOrderFront:nil];
     _sapp_macos_update_dimensions();
+    [NSEvent setMouseCoalescingEnabled:NO];
 
     // __v_ start
     //[NSEvent setMouseCoalescingEnabled:NO];
@@ -4051,6 +4129,24 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
         return NO;
     }
 }
+
+#if defined(SOKOL_METAL)
+- (void)windowWillStartLiveResize:(NSNotification *)notification {
+    // Work around the MTKView resizing glitch by "anchoring" the layer to the window corner opposite
+    // to the currently manipulated corner (or edge). This prevents the content stretching back and
+    // forth during resizing. This is a workaround for this issue: https://github.com/floooh/sokol/issues/700
+    // Can be removed if/when migrating to CAMetalLayer: https://github.com/floooh/sokol/issues/727
+    bool resizing_from_left = _sapp.mouse.x < _sapp.window_width/2;
+    bool resizing_from_top = _sapp.mouse.y < _sapp.window_height/2;
+    NSViewLayerContentsPlacement placement;
+    if (resizing_from_left) {
+        placement = resizing_from_top ? NSViewLayerContentsPlacementBottomRight : NSViewLayerContentsPlacementTopRight;
+    } else {
+        placement = resizing_from_top ? NSViewLayerContentsPlacementBottomLeft : NSViewLayerContentsPlacementTopLeft;
+    }
+    _sapp.macos.view.layerContentsPlacement = placement;
+}
+#endif
 
 - (void)windowDidResize:(NSNotification*)notification {
     _SOKOL_UNUSED(notification);
@@ -4170,7 +4266,7 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
 }
 #endif
 
-_SOKOL_PRIVATE void _sapp_macos_poll_input_events() {
+_SOKOL_PRIVATE void _sapp_macos_poll_input_events(void) {
     /*
 
     NOTE: late event polling temporarily out-commented to check if this
@@ -4215,13 +4311,16 @@ _SOKOL_PRIVATE void _sapp_macos_poll_input_events() {
 
 - (void)drawRect:(NSRect)rect {
     _SOKOL_UNUSED(rect);
+    #if defined(_SAPP_ANY_GL)
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
+    #endif
     _sapp_timing_measure(&_sapp.timing);
     /* Catch any last-moment input events */
     _sapp_macos_poll_input_events();
     @autoreleasepool {
         _sapp_macos_frame();
     }
-    #if !defined(SOKOL_METAL)
+    #if defined(_SAPP_ANY_GL)
     [[_sapp.macos.view openGLContext] flushBuffer];
     #endif
 }
@@ -4744,6 +4843,9 @@ _SOKOL_PRIVATE void _sapp_ios_show_keyboard(bool shown) {
 @implementation _sapp_ios_view
 - (void)drawRect:(CGRect)rect {
     _SOKOL_UNUSED(rect);
+    #if defined(_SAPP_ANY_GL)
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
+    #endif
     _sapp_timing_measure(&_sapp.timing);
     @autoreleasepool {
         _sapp_ios_frame();
@@ -4779,7 +4881,7 @@ _SOKOL_PRIVATE void _sapp_ios_show_keyboard(bool shown) {
 #if defined(_SAPP_EMSCRIPTEN)
 
 #if defined(EM_JS_DEPS)
-EM_JS_DEPS(sokol_app, "$withStackSave,$allocateUTF8OnStack");
+EM_JS_DEPS(sokol_app, "$withStackSave,$stringToUTF8OnStack");
 #endif
 
 #ifdef __cplusplus
@@ -4787,13 +4889,6 @@ extern "C" {
 #endif
 
 typedef void (*_sapp_html5_fetch_callback) (const sapp_html5_fetch_response*);
-
-/* this function is called from a JS event handler when the user hides
-    the onscreen keyboard pressing the 'dismiss keyboard key'
-*/
-EMSCRIPTEN_KEEPALIVE void _sapp_emsc_notify_keyboard_hidden(void) {
-    _sapp.onscreen_keyboard_shown = false;
-}
 
 EMSCRIPTEN_KEEPALIVE void _sapp_emsc_onpaste(const char* str) {
     if (_sapp.clipboard.enabled) {
@@ -4885,27 +4980,6 @@ EMSCRIPTEN_KEEPALIVE void _sapp_emsc_invoke_fetch_cb(int index, int success, int
 } /* extern "C" */
 #endif
 
-/* Javascript helper functions for mobile virtual keyboard input */
-EM_JS(void, sapp_js_create_textfield, (void), {
-    const _sapp_inp = document.createElement("input");
-    _sapp_inp.type = "text";
-    _sapp_inp.id = "_sokol_app_input_element";
-    _sapp_inp.autocapitalize = "none";
-    _sapp_inp.addEventListener("focusout", function(_sapp_event) {
-        __sapp_emsc_notify_keyboard_hidden()
-
-    });
-    document.body.append(_sapp_inp);
-});
-
-EM_JS(void, sapp_js_focus_textfield, (void), {
-    document.getElementById("_sokol_app_input_element").focus();
-});
-
-EM_JS(void, sapp_js_unfocus_textfield, (void), {
-    document.getElementById("_sokol_app_input_element").blur();
-});
-
 EM_JS(void, sapp_js_add_beforeunload_listener, (void), {
     Module.sokol_beforeunload = (event) => {
         if (__sapp_html5_get_ask_leave_site() != 0) {
@@ -4924,7 +4998,7 @@ EM_JS(void, sapp_js_add_clipboard_listener, (void), {
     Module.sokol_paste = (event) => {
         const pasted_str = event.clipboardData.getData('text');
         withStackSave(() => {
-            const cstr = allocateUTF8OnStack(pasted_str);
+            const cstr = stringToUTF8OnStack(pasted_str);
             __sapp_emsc_onpaste(cstr);
         });
     };
@@ -4981,7 +5055,7 @@ EM_JS(void, sapp_js_add_dragndrop_listeners, (const char* canvas_name_cstr), {
         __sapp_emsc_begin_drop(files.length);
         for (let i = 0; i < files.length; i++) {
             withStackSave(() => {
-                const cstr = allocateUTF8OnStack(files[i].name);
+                const cstr = stringToUTF8OnStack(files[i].name);
                 __sapp_emsc_drop(i, cstr);
             });
         }
@@ -5040,45 +5114,6 @@ EM_JS(void, sapp_js_remove_dragndrop_listeners, (const char* canvas_name_cstr), 
     canvas.removeEventListener('dragover',  Module.sokol_dragover);
     canvas.removeEventListener('drop',      Module.sokol_drop);
 });
-
-/* called from the emscripten event handler to update the keyboard visibility
-    state, this must happen from an JS input event handler, otherwise
-    the request will be ignored by the browser
-*/
-_SOKOL_PRIVATE void _sapp_emsc_update_keyboard_state(void) {
-    if (_sapp.emsc.wants_show_keyboard) {
-        /* create input text field on demand */
-        if (!_sapp.emsc.textfield_created) {
-            _sapp.emsc.textfield_created = true;
-            sapp_js_create_textfield();
-        }
-        /* focus the text input field, this will bring up the keyboard */
-        _sapp.onscreen_keyboard_shown = true;
-        _sapp.emsc.wants_show_keyboard = false;
-        sapp_js_focus_textfield();
-    }
-    if (_sapp.emsc.wants_hide_keyboard) {
-        /* unfocus the text input field */
-        if (_sapp.emsc.textfield_created) {
-            _sapp.onscreen_keyboard_shown = false;
-            _sapp.emsc.wants_hide_keyboard = false;
-            sapp_js_unfocus_textfield();
-        }
-    }
-}
-
-/* actually showing the onscreen keyboard must be initiated from a JS
-    input event handler, so we'll just keep track of the desired
-    state, and the actual state change will happen with the next input event
-*/
-_SOKOL_PRIVATE void _sapp_emsc_show_keyboard(bool show) {
-    if (show) {
-        _sapp.emsc.wants_show_keyboard = true;
-    }
-    else {
-        _sapp.emsc.wants_hide_keyboard = true;
-    }
-}
 
 EM_JS(void, sapp_js_init, (const char* c_str_target), {
     // lookup and store canvas object by name
@@ -5305,6 +5340,7 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_size_changed(int event_type, const EmscriptenU
 
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_mouse_cb(int emsc_type, const EmscriptenMouseEvent* emsc_event, void* user_data) {
     _SOKOL_UNUSED(user_data);
+    bool consume_event = !_sapp.desc.html5_bubble_mouse_events;
     _sapp.emsc.mouse_buttons = emsc_event->buttons;
     if (_sapp.mouse.locked) {
         _sapp.mouse.dx = (float) emsc_event->movementX;
@@ -5365,20 +5401,20 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_mouse_cb(int emsc_type, const EmscriptenMouseE
             } else {
                 _sapp.event.mouse_button = SAPP_MOUSEBUTTON_INVALID;
             }
-            _sapp_call_event(&_sapp.event);
+            consume_event |= _sapp_call_event(&_sapp.event);
         }
         // mouse lock can only be activated in mouse button events (not in move, enter or leave)
         if (is_button_event) {
             _sapp_emsc_update_mouse_lock_state();
         }
     }
-    _sapp_emsc_update_keyboard_state();
-    return true;
+    return consume_event;
 }
 
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_wheel_cb(int emsc_type, const EmscriptenWheelEvent* emsc_event, void* user_data) {
     _SOKOL_UNUSED(emsc_type);
     _SOKOL_UNUSED(user_data);
+    bool consume_event = !_sapp.desc.html5_bubble_wheel_events;
     _sapp.emsc.mouse_buttons = emsc_event->mouse.buttons;
     if (_sapp_events_enabled()) {
         _sapp_init_event(SAPP_EVENTTYPE_MOUSE_SCROLL);
@@ -5393,11 +5429,10 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_wheel_cb(int emsc_type, const EmscriptenWheelE
         }
         _sapp.event.scroll_x = scale * (float)emsc_event->deltaX;
         _sapp.event.scroll_y = scale * (float)emsc_event->deltaY;
-        _sapp_call_event(&_sapp.event);
+        consume_event |= _sapp_call_event(&_sapp.event);
     }
-    _sapp_emsc_update_keyboard_state();
     _sapp_emsc_update_mouse_lock_state();
-    return true;
+    return consume_event;
 }
 
 static struct {
@@ -5521,9 +5556,15 @@ _SOKOL_PRIVATE sapp_keycode _sapp_emsc_translate_key(const char* str) {
     return SAPP_KEYCODE_INVALID;
 }
 
+// returns true if the key code is a 'character key', this is used to decide
+// if a key event needs to bubble up to create a char event
+_SOKOL_PRIVATE bool _sapp_emsc_is_char_key(sapp_keycode key_code) {
+    return key_code < SAPP_KEYCODE_WORLD_1;
+}
+
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_key_cb(int emsc_type, const EmscriptenKeyboardEvent* emsc_event, void* user_data) {
     _SOKOL_UNUSED(user_data);
-    bool retval = true;
+    bool consume_event = false;
     if (_sapp_events_enabled()) {
         sapp_event_type type;
         switch (emsc_type) {
@@ -5546,14 +5587,10 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_key_cb(int emsc_type, const EmscriptenKeyboard
             _sapp.event.key_repeat = emsc_event->repeat;
             _sapp.event.modifiers = _sapp_emsc_key_event_mods(emsc_event);
             if (type == SAPP_EVENTTYPE_CHAR) {
-                // FIXME: this doesn't appear to work on Android Chrome
+                // NOTE: charCode doesn't appear to be supported on Android Chrome
                 _sapp.event.char_code = emsc_event->charCode;
-                /* workaround to make Cmd+V work on Safari */
-                if ((emsc_event->metaKey) && (emsc_event->charCode == 118)) {
-                    retval = false;
-                }
-            }
-            else {
+                consume_event |= !_sapp.desc.html5_bubble_char_events;
+            } else {
                 if (0 != emsc_event->code[0]) {
                     // This code path is for desktop browsers which send untranslated 'physical' key code strings
                     // (which is what we actually want for key events)
@@ -5577,91 +5614,27 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_key_cb(int emsc_type, const EmscriptenKeyboard
                 {
                     send_keyup_followup = true;
                 }
-                // only forward keys to the browser (can further be suppressed by sapp_consume_event())
-                switch (_sapp.event.key_code) {
-                    case SAPP_KEYCODE_WORLD_1:
-                    case SAPP_KEYCODE_WORLD_2:
-                    case SAPP_KEYCODE_ESCAPE:
-                    case SAPP_KEYCODE_ENTER:
-                    case SAPP_KEYCODE_TAB:
-                    case SAPP_KEYCODE_BACKSPACE:
-                    case SAPP_KEYCODE_INSERT:
-                    case SAPP_KEYCODE_DELETE:
-                    case SAPP_KEYCODE_RIGHT:
-                    case SAPP_KEYCODE_LEFT:
-                    case SAPP_KEYCODE_DOWN:
-                    case SAPP_KEYCODE_UP:
-                    case SAPP_KEYCODE_PAGE_UP:
-                    case SAPP_KEYCODE_PAGE_DOWN:
-                    case SAPP_KEYCODE_HOME:
-                    case SAPP_KEYCODE_END:
-                    case SAPP_KEYCODE_CAPS_LOCK:
-                    case SAPP_KEYCODE_SCROLL_LOCK:
-                    case SAPP_KEYCODE_NUM_LOCK:
-                    case SAPP_KEYCODE_PRINT_SCREEN:
-                    case SAPP_KEYCODE_PAUSE:
-                    case SAPP_KEYCODE_F1:
-                    case SAPP_KEYCODE_F2:
-                    case SAPP_KEYCODE_F3:
-                    case SAPP_KEYCODE_F4:
-                    case SAPP_KEYCODE_F5:
-                    case SAPP_KEYCODE_F6:
-                    case SAPP_KEYCODE_F7:
-                    case SAPP_KEYCODE_F8:
-                    case SAPP_KEYCODE_F9:
-                    case SAPP_KEYCODE_F10:
-                    case SAPP_KEYCODE_F11:
-                    case SAPP_KEYCODE_F12:
-                    case SAPP_KEYCODE_F13:
-                    case SAPP_KEYCODE_F14:
-                    case SAPP_KEYCODE_F15:
-                    case SAPP_KEYCODE_F16:
-                    case SAPP_KEYCODE_F17:
-                    case SAPP_KEYCODE_F18:
-                    case SAPP_KEYCODE_F19:
-                    case SAPP_KEYCODE_F20:
-                    case SAPP_KEYCODE_F21:
-                    case SAPP_KEYCODE_F22:
-                    case SAPP_KEYCODE_F23:
-                    case SAPP_KEYCODE_F24:
-                    case SAPP_KEYCODE_F25:
-                    case SAPP_KEYCODE_LEFT_SHIFT:
-                    case SAPP_KEYCODE_LEFT_CONTROL:
-                    case SAPP_KEYCODE_LEFT_ALT:
-                    case SAPP_KEYCODE_LEFT_SUPER:
-                    case SAPP_KEYCODE_RIGHT_SHIFT:
-                    case SAPP_KEYCODE_RIGHT_CONTROL:
-                    case SAPP_KEYCODE_RIGHT_ALT:
-                    case SAPP_KEYCODE_RIGHT_SUPER:
-                    case SAPP_KEYCODE_MENU:
-                        /* consume the event */
-                        break;
-                    default:
-                        /* forward key to browser */
-                        retval = false;
-                        break;
+
+                // 'character key events' will always need to bubble up, otherwise the browser
+                // wouldn't be able to generate character events.
+                if (!_sapp_emsc_is_char_key(_sapp.event.key_code)) {
+                    consume_event |= !_sapp.desc.html5_bubble_key_events;
                 }
             }
-            if (_sapp_call_event(&_sapp.event)) {
-                // event was consumed via sapp_consume_event()
-                retval = true;
-            }
+            consume_event |= _sapp_call_event(&_sapp.event);
             if (send_keyup_followup) {
                 _sapp.event.type = SAPP_EVENTTYPE_KEY_UP;
-                if (_sapp_call_event(&_sapp.event)) {
-                    retval = true;
-                }
+                consume_event |= _sapp_call_event(&_sapp.event);
             }
         }
     }
-    _sapp_emsc_update_keyboard_state();
     _sapp_emsc_update_mouse_lock_state();
-    return retval;
+    return consume_event;
 }
 
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_touch_cb(int emsc_type, const EmscriptenTouchEvent* emsc_event, void* user_data) {
     _SOKOL_UNUSED(user_data);
-    bool retval = true;
+    bool consume_event = !_sapp.desc.html5_bubble_touch_events;
     if (_sapp_events_enabled()) {
         sapp_event_type type;
         switch (emsc_type) {
@@ -5679,7 +5652,6 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_touch_cb(int emsc_type, const EmscriptenTouchE
                 break;
             default:
                 type = SAPP_EVENTTYPE_INVALID;
-                retval = false;
                 break;
         }
         if (type != SAPP_EVENTTYPE_INVALID) {
@@ -5697,11 +5669,10 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_touch_cb(int emsc_type, const EmscriptenTouchE
                 dst->pos_y = src->targetY * _sapp.dpi_scale;
                 dst->changed = src->isChanged;
             }
-            _sapp_call_event(&_sapp.event);
+            consume_event |= _sapp_call_event(&_sapp.event);
         }
     }
-    _sapp_emsc_update_keyboard_state();
-    return retval;
+    return consume_event;
 }
 
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_focus_cb(int emsc_type, const EmscriptenFocusEvent* emsc_event, void* user_data) {
@@ -5757,8 +5728,10 @@ _SOKOL_PRIVATE void _sapp_emsc_webgl_init(void) {
     EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context(_sapp.html5_canvas_selector, &attrs);
     // FIXME: error message?
     emscripten_webgl_make_context_current(ctx);
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
 
-    /* some WebGL extension are not enabled automatically by emscripten */
+    // FIXME: remove PVRTC support here and in sokol-gfx at some point
+    // some WebGL extension are not enabled automatically by emscripten
     emscripten_webgl_enable_extension(ctx, "WEBKIT_WEBGL_compressed_texture_pvrtc");
 }
 #endif
@@ -5917,7 +5890,7 @@ _SOKOL_PRIVATE void _sapp_emsc_wgpu_request_adapter_cb(WGPURequestAdapterStatus 
 
     WGPUDeviceDescriptor dev_desc;
     _sapp_clear(&dev_desc, sizeof(dev_desc));
-    dev_desc.requiredFeaturesCount = cur_feature_index;
+    dev_desc.requiredFeatureCount = cur_feature_index;
     dev_desc.requiredFeatures = requiredFeatures,
     wgpuAdapterRequestDevice(adapter, &dev_desc, _sapp_emsc_wgpu_request_device_cb, 0);
 }
@@ -5944,6 +5917,9 @@ _SOKOL_PRIVATE void _sapp_emsc_wgpu_frame(void) {
 #endif // SOKOL_WGPU
 
 _SOKOL_PRIVATE void _sapp_emsc_register_eventhandlers(void) {
+    // NOTE: HTML canvas doesn't receive input focus, this is why key event handlers are added
+    // to the window object (this could be worked around by adding a "tab index" to the
+    // canvas)
     emscripten_set_mousedown_callback(_sapp.html5_canvas_selector, 0, true, _sapp_emsc_mouse_cb);
     emscripten_set_mouseup_callback(_sapp.html5_canvas_selector, 0, true, _sapp_emsc_mouse_cb);
     emscripten_set_mousemove_callback(_sapp.html5_canvas_selector, 0, true, _sapp_emsc_mouse_cb);
@@ -5974,7 +5950,7 @@ _SOKOL_PRIVATE void _sapp_emsc_register_eventhandlers(void) {
     #endif
 }
 
-_SOKOL_PRIVATE void _sapp_emsc_unregister_eventhandlers() {
+_SOKOL_PRIVATE void _sapp_emsc_unregister_eventhandlers(void) {
     emscripten_set_mousedown_callback(_sapp.html5_canvas_selector, 0, true, 0);
     emscripten_set_mouseup_callback(_sapp.html5_canvas_selector, 0, true, 0);
     emscripten_set_mousemove_callback(_sapp.html5_canvas_selector, 0, true, 0);
@@ -5992,6 +5968,9 @@ _SOKOL_PRIVATE void _sapp_emsc_unregister_eventhandlers() {
     emscripten_set_pointerlockerror_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, 0, true, 0);
     emscripten_set_focus_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, true, 0);
     emscripten_set_blur_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, true, 0);
+    if (!_sapp.desc.html5_canvas_resize) {
+        emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, true, 0);
+    }
     sapp_js_remove_beforeunload_listener();
     if (_sapp.clipboard.enabled) {
         sapp_js_remove_clipboard_listener();
@@ -6005,7 +5984,7 @@ _SOKOL_PRIVATE void _sapp_emsc_unregister_eventhandlers() {
     #endif
 }
 
-_SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
+_SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame_animation_loop(double time, void* userData) {
     _SOKOL_UNUSED(userData);
     _sapp_timing_external(&_sapp.timing, time / 1000.0);
 
@@ -6030,6 +6009,13 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
         return EM_FALSE;
     }
     return EM_TRUE;
+}
+
+_SOKOL_PRIVATE void _sapp_emsc_frame_main_loop(void) {
+    const double time = emscripten_performance_now();
+    if (!_sapp_emsc_frame_animation_loop(time, 0)) {
+        emscripten_cancel_main_loop();
+    }
 }
 
 _SOKOL_PRIVATE void _sapp_emsc_run(const sapp_desc* desc) {
@@ -6062,8 +6048,11 @@ _SOKOL_PRIVATE void _sapp_emsc_run(const sapp_desc* desc) {
     sapp_set_icon(&desc->icon);
 
     // start the frame loop
-    emscripten_request_animation_frame_loop(_sapp_emsc_frame, 0);
-
+    if (_sapp.desc.html5_use_emsc_set_main_loop) {
+        emscripten_set_main_loop(_sapp_emsc_frame_main_loop, 0, _sapp.desc.html5_emsc_set_main_loop_simulate_infinite_loop);
+    } else {
+        emscripten_request_animation_frame_loop(_sapp_emsc_frame_animation_loop, 0);
+    }
     // NOT A BUG: do not call _sapp_discard_state() here, instead this is
     // called in _sapp_emsc_frame() when the application is ordered to quit
 }
@@ -6497,14 +6486,6 @@ static inline HRESULT _sapp_d3d11_CreateDepthStencilView(ID3D11Device* self, ID3
     #endif
 }
 
-static inline void _sapp_d3d11_ResolveSubresource(ID3D11DeviceContext* self, ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource, UINT SrcSubresource, DXGI_FORMAT Format) {
-    #if defined(__cplusplus)
-        self->ResolveSubresource(pDstResource, DstSubresource, pSrcResource, SrcSubresource, Format);
-    #else
-        self->lpVtbl->ResolveSubresource(self, pDstResource, DstSubresource, pSrcResource, SrcSubresource, Format);
-    #endif
-}
-
 static inline HRESULT _sapp_dxgi_ResizeBuffers(IDXGISwapChain* self, UINT BufferCount, UINT Width, UINT Height, DXGI_FORMAT NewFormat, UINT SwapChainFlags) {
     #if defined(__cplusplus)
         return self->ResizeBuffers(BufferCount, Width, Height, NewFormat, SwapChainFlags);
@@ -6730,12 +6711,6 @@ _SOKOL_PRIVATE void _sapp_d3d11_resize_default_render_target(void) {
 }
 
 _SOKOL_PRIVATE void _sapp_d3d11_present(bool do_not_wait) {
-    /* do MSAA resolve if needed */
-    if (_sapp.sample_count > 1) {
-        SOKOL_ASSERT(_sapp.d3d11.rt);
-        SOKOL_ASSERT(_sapp.d3d11.msaa_rt);
-        _sapp_d3d11_ResolveSubresource(_sapp.d3d11.device_context, (ID3D11Resource*)_sapp.d3d11.rt, 0, (ID3D11Resource*)_sapp.d3d11.msaa_rt, 0, DXGI_FORMAT_B8G8R8A8_UNORM);
-    }
     UINT flags = 0;
     if (_sapp.win32.is_win10_or_greater && do_not_wait) {
         /* this hack/workaround somewhat improves window-movement and -sizing
@@ -6766,6 +6741,8 @@ _SOKOL_PRIVATE void _sapp_wgl_init(void) {
     SOKOL_ASSERT(_sapp.wgl.GetCurrentDC);
     _sapp.wgl.MakeCurrent = (PFN_wglMakeCurrent)(void*) GetProcAddress(_sapp.wgl.opengl32, "wglMakeCurrent");
     SOKOL_ASSERT(_sapp.wgl.MakeCurrent);
+    _sapp.wgl.GetIntegerv = (void(*)(uint32_t, int32_t*)) GetProcAddress(_sapp.wgl.opengl32, "glGetIntegerv");
+    SOKOL_ASSERT(_sapp.wgl.GetIntegerv);
 
     _sapp.wgl.msg_hwnd = CreateWindowExW(WS_EX_OVERLAPPEDWINDOW,
         L"SOKOLAPP",
@@ -7001,7 +6978,11 @@ _SOKOL_PRIVATE void _sapp_wgl_create_context(void) {
     const int attrs[] = {
         WGL_CONTEXT_MAJOR_VERSION_ARB, _sapp.desc.gl_major_version,
         WGL_CONTEXT_MINOR_VERSION_ARB, _sapp.desc.gl_minor_version,
+#if defined(SOKOL_DEBUG)
+        WGL_CONTEXT_FLAGS_ARB, WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB | WGL_CONTEXT_DEBUG_BIT_ARB,
+#else
         WGL_CONTEXT_FLAGS_ARB, WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
+#endif
         WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
         0, 0
     };
@@ -7026,6 +7007,8 @@ _SOKOL_PRIVATE void _sapp_wgl_create_context(void) {
         /* FIXME: DwmIsCompositionEnabled() (see GLFW) */
         _sapp.wgl.SwapIntervalEXT(_sapp.swap_interval);
     }
+    const uint32_t gl_framebuffer_binding = 0x8CA6;
+    _sapp.wgl.GetIntegerv(gl_framebuffer_binding, (int32_t*)&_sapp.gl.framebuffer);
 }
 
 _SOKOL_PRIVATE void _sapp_wgl_destroy_context(void) {
@@ -8302,6 +8285,7 @@ _SOKOL_PRIVATE bool _sapp_android_init_egl_surface(ANativeWindow* window) {
         return false;
     }
     _sapp.android.surface = surface;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
     return true;
 }
 
@@ -8437,8 +8421,8 @@ _SOKOL_PRIVATE bool _sapp_android_touch_event(const AInputEvent* e) {
     for (int32_t i = 0; i < _sapp.event.num_touches; i++) {
         sapp_touchpoint* dst = &_sapp.event.touches[i];
         dst->identifier = (uintptr_t)AMotionEvent_getPointerId(e, (size_t)i);
-        dst->pos_x = (AMotionEvent_getRawX(e, (size_t)i) / _sapp.window_width) * _sapp.framebuffer_width;
-        dst->pos_y = (AMotionEvent_getRawY(e, (size_t)i) / _sapp.window_height) * _sapp.framebuffer_height;
+        dst->pos_x = (AMotionEvent_getX(e, (size_t)i) / _sapp.window_width) * _sapp.framebuffer_width;
+        dst->pos_y = (AMotionEvent_getY(e, (size_t)i) / _sapp.window_height) * _sapp.framebuffer_height;
         dst->android_tooltype = (sapp_android_tooltype) AMotionEvent_getToolType(e, (size_t)i);
         if (action == AMOTION_EVENT_ACTION_POINTER_DOWN ||
             action == AMOTION_EVENT_ACTION_POINTER_UP) {
@@ -9828,7 +9812,7 @@ _SOKOL_PRIVATE void* _sapp_glx_getprocaddr(const char* procname)
     }
 }
 
-_SOKOL_PRIVATE void _sapp_glx_init() {
+_SOKOL_PRIVATE void _sapp_glx_init(void) {
     const char* sonames[] = { "libGL.so.1", "libGL.so", 0 };
     for (int i = 0; sonames[i]; i++) {
         _sapp.glx.libgl = dlopen(sonames[i], RTLD_LAZY|RTLD_GLOBAL);
@@ -9903,7 +9887,7 @@ _SOKOL_PRIVATE int _sapp_glx_attrib(GLXFBConfig fbconfig, int attrib) {
     return value;
 }
 
-_SOKOL_PRIVATE GLXFBConfig _sapp_glx_choosefbconfig() {
+_SOKOL_PRIVATE GLXFBConfig _sapp_glx_choosefbconfig(void) {
     GLXFBConfig* native_configs;
     _sapp_gl_fbconfig* usable_configs;
     const _sapp_gl_fbconfig* closest;
@@ -9990,6 +9974,11 @@ _SOKOL_PRIVATE void _sapp_glx_choose_visual(Visual** visual, int* depth) {
     XFree(result);
 }
 
+_SOKOL_PRIVATE void _sapp_glx_make_current(void) {
+    _sapp.glx.MakeCurrent(_sapp.x11.display, _sapp.glx.window, _sapp.glx.ctx);
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
+}
+
 _SOKOL_PRIVATE void _sapp_glx_create_context(void) {
     GLXFBConfig native = _sapp_glx_choosefbconfig();
     if (0 == native){
@@ -10015,6 +10004,7 @@ _SOKOL_PRIVATE void _sapp_glx_create_context(void) {
     if (!_sapp.glx.window) {
         _SAPP_PANIC(LINUX_GLX_CREATE_WINDOW_FAILED);
     }
+    _sapp_glx_make_current();
 }
 
 _SOKOL_PRIVATE void _sapp_glx_destroy_context(void) {
@@ -10028,16 +10018,11 @@ _SOKOL_PRIVATE void _sapp_glx_destroy_context(void) {
     }
 }
 
-_SOKOL_PRIVATE void _sapp_glx_make_current(void) {
-    _sapp.glx.MakeCurrent(_sapp.x11.display, _sapp.glx.window, _sapp.glx.ctx);
-}
-
 _SOKOL_PRIVATE void _sapp_glx_swap_buffers(void) {
     _sapp.glx.SwapBuffers(_sapp.x11.display, _sapp.glx.window);
 }
 
 _SOKOL_PRIVATE void _sapp_glx_swapinterval(int interval) {
-    _sapp_glx_make_current();
     if (_sapp.glx.EXT_swap_control) {
         _sapp.glx.SwapIntervalEXT(_sapp.x11.display, _sapp.glx.window, interval);
     }
@@ -11195,6 +11180,7 @@ _SOKOL_PRIVATE void _sapp_egl_init(void) {
     if (!eglMakeCurrent(_sapp.egl.display, _sapp.egl.surface, _sapp.egl.surface, _sapp.egl.context)) {
         _SAPP_PANIC(LINUX_EGL_MAKE_CURRENT_FAILED);
     }
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
 
     eglSwapInterval(_sapp.egl.display, _sapp.swap_interval);
 }
@@ -11445,8 +11431,6 @@ SOKOL_API_IMPL const void* sapp_egl_get_context(void) {
 SOKOL_API_IMPL void sapp_show_keyboard(bool show) {
     #if defined(_SAPP_IOS)
     _sapp_ios_show_keyboard(show);
-    #elif defined(_SAPP_EMSCRIPTEN)
-    _sapp_emsc_show_keyboard(show);
     #elif defined(_SAPP_ANDROID)
     _sapp_android_show_keyboard(show);
     #else
@@ -11704,22 +11688,7 @@ SOKOL_API_IMPL const void* sapp_metal_get_device(void) {
     #endif
 }
 
-SOKOL_API_IMPL const void* sapp_metal_get_renderpass_descriptor(void) {
-    SOKOL_ASSERT(_sapp.valid);
-    #if defined(SOKOL_METAL)
-        #if defined(_SAPP_MACOS)
-            const void* obj = (__bridge const void*) [_sapp.macos.view currentRenderPassDescriptor];
-        #else
-            const void* obj = (__bridge const void*) [_sapp.ios.view currentRenderPassDescriptor];
-        #endif
-        SOKOL_ASSERT(obj);
-        return obj;
-    #else
-        return 0;
-    #endif
-}
-
-SOKOL_API_IMPL const void* sapp_metal_get_drawable(void) {
+SOKOL_API_IMPL const void* sapp_metal_get_current_drawable(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_METAL)
         #if defined(_SAPP_MACOS)
@@ -11728,6 +11697,34 @@ SOKOL_API_IMPL const void* sapp_metal_get_drawable(void) {
             const void* obj = (__bridge const void*) [_sapp.ios.view currentDrawable];
         #endif
         SOKOL_ASSERT(obj);
+        return obj;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_metal_get_depth_stencil_texture(void) {
+    SOKOL_ASSERT(_sapp.valid);
+    #if defined(SOKOL_METAL)
+        #if defined(_SAPP_MACOS)
+            const void* obj = (__bridge const void*) [_sapp.macos.view depthStencilTexture];
+        #else
+            const void* obj = (__bridge const void*) [_sapp.ios.view depthStencilTexture];
+        #endif
+        return obj;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_metal_get_msaa_color_texture(void) {
+    SOKOL_ASSERT(_sapp.valid);
+    #if defined(SOKOL_METAL)
+        #if defined(_SAPP_MACOS)
+            const void* obj = (__bridge const void*) [_sapp.macos.view multisampleColorTexture];
+        #else
+            const void* obj = (__bridge const void*) [_sapp.ios.view multisampleColorTexture];
+        #endif
         return obj;
     #else
         return 0;
@@ -11781,14 +11778,29 @@ SOKOL_API_IMPL const void* sapp_d3d11_get_swap_chain(void) {
 #endif
 }
 
-SOKOL_API_IMPL const void* sapp_d3d11_get_render_target_view(void) {
+SOKOL_API_IMPL const void* sapp_d3d11_get_render_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
-        if (_sapp.d3d11.msaa_rtv) {
+        if (_sapp.sample_count > 1) {
+            SOKOL_ASSERT(_sapp.d3d11.msaa_rtv);
             return _sapp.d3d11.msaa_rtv;
-        }
-        else {
+        } else {
+            SOKOL_ASSERT(_sapp.d3d11.rtv);
             return _sapp.d3d11.rtv;
+        }
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_d3d11_get_resolve_view(void) {
+    SOKOL_ASSERT(_sapp.valid);
+    #if defined(SOKOL_D3D11)
+        if (_sapp.sample_count > 1) {
+            SOKOL_ASSERT(_sapp.d3d11.rtv);
+            return _sapp.d3d11.rtv;
+        } else {
+            return 0;
         }
     #else
         return 0;
@@ -11826,9 +11838,10 @@ SOKOL_API_IMPL const void* sapp_wgpu_get_render_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
         if (_sapp.sample_count > 1) {
+            SOKOL_ASSERT(_sapp.wgpu.msaa_view);
             return (const void*) _sapp.wgpu.msaa_view;
-        }
-        else {
+        } else {
+            SOKOL_ASSERT(_sapp.wgpu.swapchain_view);
             return (const void*) _sapp.wgpu.swapchain_view;
         }
     #else
@@ -11840,9 +11853,9 @@ SOKOL_API_IMPL const void* sapp_wgpu_get_resolve_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
         if (_sapp.sample_count > 1) {
+            SOKOL_ASSERT(_sapp.wgpu.swapchain_view);
             return (const void*) _sapp.wgpu.swapchain_view;
-        }
-        else {
+        } else {
             return 0;
         }
     #else
@@ -11854,6 +11867,15 @@ SOKOL_API_IMPL const void* sapp_wgpu_get_depth_stencil_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
         return (const void*) _sapp.wgpu.depth_stencil_view;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL uint32_t sapp_gl_get_framebuffer(void) {
+    SOKOL_ASSERT(_sapp.valid);
+    #if defined(_SAPP_ANY_GL)
+        return _sapp.gl.framebuffer;
     #else
         return 0;
     #endif

--- a/thirdparty/sokol/util/sokol_gl.h
+++ b/thirdparty/sokol/util/sokol_gl.h
@@ -453,7 +453,7 @@
 
         sgl_set_context(ctx);
 
-    The currently active context will implicitely be used by most sokol-gl functions
+    The currently active context will implicitly be used by most sokol-gl functions
     which don't take an explicit context handle as argument.
 
     To switch back to the default context, pass the global constant SGL_DEFAULT_CONTEXT:
@@ -833,7 +833,7 @@ SOKOL_GL_API_DECL sgl_context sgl_get_context(void);
 SOKOL_GL_API_DECL sgl_context sgl_default_context(void);
 
 /* draw recorded commands (call inside a sokol-gfx render pass) */
-SOKOL_GL_API_DECL void sgl_draw();
+SOKOL_GL_API_DECL void sgl_draw(void);
 SOKOL_GL_API_DECL void sgl_context_draw(sgl_context ctx);
 SOKOL_GL_API_DECL void sgl_draw_layer(int layer_id);
 SOKOL_GL_API_DECL void sgl_context_draw_layer(sgl_context ctx, int layer_id);

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -509,8 +509,8 @@ pub fn (ctx &Context) quit() {
 
 // set_bg_color sets the color of the window background to `c`.
 pub fn (mut ctx Context) set_bg_color(c gx.Color) {
-	ctx.clear_pass = gfx.create_clear_pass(f32(c.r) / 255.0, f32(c.g) / 255.0, f32(c.b) / 255.0,
-		f32(c.a) / 255.0)
+	ctx.clear_pass = gfx.create_clear_pass_action(f32(c.r) / 255.0, f32(c.g) / 255.0,
+		f32(c.b) / 255.0, f32(c.a) / 255.0)
 }
 
 // Resize the context's Window
@@ -566,6 +566,10 @@ const dontcare_pass = gfx.PassAction{
 	]!
 }
 
+pub fn create_default_pass(action gfx.PassAction) gfx.Pass {
+	return sapp.create_default_pass(action)
+}
+
 // end finishes all the drawing for the context ctx.
 // All accumulated draw calls before ctx.end(), will be done in a separate Sokol pass.
 //
@@ -592,14 +596,15 @@ pub fn (ctx &Context) end(options EndOptions) {
 			ctx.show_fps()
 		}
 	}
-	match options.how {
+	pass := match options.how {
 		.clear {
-			gfx.begin_default_pass(ctx.clear_pass, sapp.width(), sapp.height())
+			create_default_pass(ctx.clear_pass)
 		}
 		.passthru {
-			gfx.begin_default_pass(gg.dontcare_pass, sapp.width(), sapp.height())
+			create_default_pass(gg.dontcare_pass)
 		}
 	}
+	gfx.begin_pass(pass)
 	sgl.draw()
 	gfx.end_pass()
 	gfx.commit()

--- a/vlib/sokol/gfx/gfx.c.v
+++ b/vlib/sokol/gfx/gfx.c.v
@@ -66,6 +66,8 @@ pub fn make_pipeline(desc &PipelineDesc) Pipeline {
 }
 
 @[inline]
+// make_attachments creates an `Attachments` instance from `const_desc`.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn make_attachments(const_desc &AttachmentsDesc) Attachments {
 	return C.sg_make_attachments(const_desc)
 }
@@ -96,6 +98,8 @@ pub fn destroy_pipeline(pip Pipeline) {
 }
 
 @[inline]
+// destroy_attachments destroys the `atts` `Attachments`
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn destroy_attachments(atts Attachments) {
 	C.sg_destroy_attachments(atts)
 }
@@ -123,12 +127,11 @@ pub fn query_buffer_overflow(buf Buffer) bool {
 // rendering functions
 
 @[deprecated: 'use begin_pass instead, please see examples/sokol/* for how to utilize new unified begin_pass']
-@[deprecated_after: '2024-09-03']
 @[inline]
-pub fn begin_default_pass(action voidptr, width int, height int) {
-	panic('use ${@MOD}.begin_pass instead, please see examples/sokol/* for how to utilize new unified begin_pass function')
-}
+pub fn begin_default_pass(actions &PassAction, width int, height int) {}
 
+// begin_pass begins a rendering pass.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 @[inline]
 pub fn begin_pass(const_pass &Pass) {
 	C.sg_begin_pass(const_pass)
@@ -222,6 +225,8 @@ pub fn query_pipeline_state(pip Pipeline) ResourceState {
 }
 
 @[inline]
+// query_attachments_state returns the current state of a resource (INITIAL, ALLOC, VALID, FAILED, INVALID)
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn query_attachments_state(atts Attachments) ResourceState {
 	return ResourceState(C.sg_query_attachments_state(atts))
 }
@@ -248,6 +253,8 @@ pub fn query_pipeline_info(pip Pipeline) PipelineInfo {
 }
 
 @[inline]
+// query_attachments_info returns runtime information about the `atts` / `Attachments`.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn query_attachments_info(atts Attachments) AttachmentsInfo {
 	return C.sg_query_attachments_info(atts)
 }
@@ -274,6 +281,8 @@ pub fn query_pipeline_defaults(desc &Pipeline) PipelineDesc {
 }
 
 @[inline]
+// query_attachments_defaults returns `AttachmentsDesc` with default values replaced.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn query_attachments_defaults(desc &AttachmentsDesc) AttachmentsDesc {
 	return C.sg_query_attachments_defaults(unsafe { &AttachmentsDesc(voidptr(desc)) })
 }

--- a/vlib/sokol/gfx/gfx.c.v
+++ b/vlib/sokol/gfx/gfx.c.v
@@ -66,8 +66,8 @@ pub fn make_pipeline(desc &PipelineDesc) Pipeline {
 }
 
 @[inline]
-pub fn make_pass(desc &PassDesc) Pass {
-	return C.sg_make_pass(desc)
+pub fn make_attachments(const_desc &AttachmentsDesc) Attachments {
+	return C.sg_make_attachments(const_desc)
 }
 
 @[inline]
@@ -96,8 +96,8 @@ pub fn destroy_pipeline(pip Pipeline) {
 }
 
 @[inline]
-pub fn destroy_pass(pass Pass) {
-	C.sg_destroy_pass(pass)
+pub fn destroy_attachments(atts Attachments) {
+	C.sg_destroy_attachments(atts)
 }
 
 @[inline]
@@ -121,14 +121,17 @@ pub fn query_buffer_overflow(buf Buffer) bool {
 }
 
 // rendering functions
+
+@[deprecated: 'use begin_pass instead, please see examples/sokol/* for how to utilize new unified begin_pass']
+@[deprecated_after: '2024-09-03']
 @[inline]
-pub fn begin_default_pass(actions &PassAction, width int, height int) {
-	C.sg_begin_default_pass(actions, width, height)
+pub fn begin_default_pass(action voidptr, width int, height int) {
+	panic('use ${@MOD}.begin_pass instead, please see examples/sokol/* for how to utilize new unified begin_pass function')
 }
 
 @[inline]
-pub fn begin_pass(pass Pass, actions &PassAction) {
-	C.sg_begin_pass(pass, actions)
+pub fn begin_pass(const_pass &Pass) {
+	C.sg_begin_pass(const_pass)
 }
 
 @[inline]
@@ -219,8 +222,8 @@ pub fn query_pipeline_state(pip Pipeline) ResourceState {
 }
 
 @[inline]
-pub fn query_pass_state(pass Pass) ResourceState {
-	return ResourceState(C.sg_query_pass_state(pass))
+pub fn query_attachments_state(atts Attachments) ResourceState {
+	return ResourceState(C.sg_query_attachments_state(atts))
 }
 
 // get runtime information about a resource
@@ -245,8 +248,8 @@ pub fn query_pipeline_info(pip Pipeline) PipelineInfo {
 }
 
 @[inline]
-pub fn query_pass_info(pass Pass) PassInfo {
-	return C.sg_query_pass_info(pass)
+pub fn query_attachments_info(atts Attachments) AttachmentsInfo {
+	return C.sg_query_attachments_info(atts)
 }
 
 // get resource creation desc struct with their default values replaced
@@ -271,24 +274,8 @@ pub fn query_pipeline_defaults(desc &Pipeline) PipelineDesc {
 }
 
 @[inline]
-pub fn query_pass_defaults(desc &Pass) PassDesc {
-	return C.sg_query_pass_defaults(unsafe { &PassDesc(voidptr(desc)) })
-}
-
-// rendering contexts (optional)
-@[inline]
-pub fn setup_context() Context {
-	return C.sg_setup_context()
-}
-
-@[inline]
-pub fn activate_context(ctx_id Context) {
-	C.sg_activate_context(ctx_id)
-}
-
-@[inline]
-pub fn discard_context(ctx_id Context) {
-	C.sg_discard_context(ctx_id)
+pub fn query_attachments_defaults(desc &AttachmentsDesc) AttachmentsDesc {
+	return C.sg_query_attachments_defaults(unsafe { &AttachmentsDesc(voidptr(desc)) })
 }
 
 // frame stats

--- a/vlib/sokol/gfx/gfx.c.v
+++ b/vlib/sokol/gfx/gfx.c.v
@@ -65,9 +65,9 @@ pub fn make_pipeline(desc &PipelineDesc) Pipeline {
 	return C.sg_make_pipeline(desc)
 }
 
-@[inline]
 // make_attachments creates an `Attachments` instance from `const_desc`.
 // See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
+@[inline]
 pub fn make_attachments(const_desc &AttachmentsDesc) Attachments {
 	return C.sg_make_attachments(const_desc)
 }
@@ -97,9 +97,9 @@ pub fn destroy_pipeline(pip Pipeline) {
 	C.sg_destroy_pipeline(pip)
 }
 
-@[inline]
 // destroy_attachments destroys the `atts` `Attachments`
 // See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
+@[inline]
 pub fn destroy_attachments(atts Attachments) {
 	C.sg_destroy_attachments(atts)
 }
@@ -224,9 +224,9 @@ pub fn query_pipeline_state(pip Pipeline) ResourceState {
 	return ResourceState(C.sg_query_pipeline_state(pip))
 }
 
-@[inline]
 // query_attachments_state returns the current state of a resource (INITIAL, ALLOC, VALID, FAILED, INVALID)
 // See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
+@[inline]
 pub fn query_attachments_state(atts Attachments) ResourceState {
 	return ResourceState(C.sg_query_attachments_state(atts))
 }
@@ -252,9 +252,9 @@ pub fn query_pipeline_info(pip Pipeline) PipelineInfo {
 	return C.sg_query_pipeline_info(pip)
 }
 
-@[inline]
 // query_attachments_info returns runtime information about the `atts` / `Attachments`.
 // See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
+@[inline]
 pub fn query_attachments_info(atts Attachments) AttachmentsInfo {
 	return C.sg_query_attachments_info(atts)
 }
@@ -280,9 +280,9 @@ pub fn query_pipeline_defaults(desc &Pipeline) PipelineDesc {
 	return C.sg_query_pipeline_defaults(unsafe { &PipelineDesc(voidptr(desc)) })
 }
 
-@[inline]
 // query_attachments_defaults returns `AttachmentsDesc` with default values replaced.
 // See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
+@[inline]
 pub fn query_attachments_defaults(desc &AttachmentsDesc) AttachmentsDesc {
 	return C.sg_query_attachments_defaults(unsafe { &AttachmentsDesc(voidptr(desc)) })
 }

--- a/vlib/sokol/gfx/gfx_funcs.c.v
+++ b/vlib/sokol/gfx/gfx_funcs.c.v
@@ -17,13 +17,13 @@ fn C.sg_make_image(const_desc &C.sg_image_desc) C.sg_image
 fn C.sg_make_sampler(const_desc &C.sg_sampler_desc) C.sg_sampler
 fn C.sg_make_shader(const_desc &C.sg_shader_desc) C.sg_shader
 fn C.sg_make_pipeline(const_desc &C.sg_pipeline_desc) C.sg_pipeline
-fn C.sg_make_pass(const_desc &C.sg_pass_desc) C.sg_pass
+fn C.sg_make_attachments(const_desc &C.sg_attachments_desc) C.sg_attachments
 fn C.sg_destroy_buffer(buf C.sg_buffer)
 fn C.sg_destroy_image(img C.sg_image)
 fn C.sg_destroy_sampler(smp C.sg_sampler)
 fn C.sg_destroy_shader(shd C.sg_shader)
 fn C.sg_destroy_pipeline(pip C.sg_pipeline)
-fn C.sg_destroy_pass(pass C.sg_pass)
+fn C.sg_destroy_attachments(atts C.sg_attachments)
 fn C.sg_update_buffer(buf C.sg_buffer, data &C.sg_range)
 fn C.sg_update_image(img C.sg_image, data &C.sg_image_data)
 fn C.sg_append_buffer(buf C.sg_buffer, data &C.sg_range) int
@@ -31,8 +31,7 @@ fn C.sg_query_buffer_overflow(buf C.sg_buffer) bool
 fn C.sg_query_buffer_will_overflow(buf C.sg_buffer, size usize) bool
 
 // rendering functions
-fn C.sg_begin_default_pass(actions &C.sg_pass_action, width int, height int)
-fn C.sg_begin_pass(pass C.sg_pass, actions &C.sg_pass_action)
+fn C.sg_begin_pass(const_pass &C.sg_pass)
 fn C.sg_apply_viewport(x int, y int, width int, height int, origin_top_left bool)
 fn C.sg_apply_viewportf(x f32, y f32, width f32, height f32, origin_top_left bool)
 fn C.sg_apply_scissor_rect(x int, y int, width int, height int, origin_top_left bool)
@@ -57,7 +56,7 @@ fn C.sg_query_image_state(img C.sg_image) ResourceState
 fn C.sg_query_sampler_state(smp C.sg_sampler) ResourceState
 fn C.sg_query_shader_state(shd C.sg_shader) ResourceState
 fn C.sg_query_pipeline_state(pip C.sg_pipeline) ResourceState
-fn C.sg_query_pass_state(pass C.sg_pass) ResourceState
+fn C.sg_query_attachments_state(atts C.sg_attachments) ResourceState
 
 // get runtime information about a resource
 fn C.sg_query_buffer_info(buf C.sg_buffer) C.sg_buffer_info
@@ -65,7 +64,7 @@ fn C.sg_query_image_info(img C.sg_image) C.sg_image_info
 fn C.sg_query_sampler_info(smp C.sg_sampler) C.sg_sampler_info
 fn C.sg_query_shader_info(shd C.sg_shader) C.sg_shader_info
 fn C.sg_query_pipeline_info(pip C.sg_pipeline) C.sg_pipeline_info
-fn C.sg_query_pass_info(pass C.sg_pass) C.sg_pass_info
+fn C.sg_query_attachments_info(atts C.sg_attachments) C.sg_attachments_info
 
 // get desc structs matching a specific resource (NOTE that not all creation attributes may be provided)
 fn C.sg_query_buffer_desc(buf C.sg_buffer) C.sg_buffer_desc
@@ -73,7 +72,7 @@ fn C.sg_query_image_desc(img C.sg_image) C.sg_image_desc
 fn C.sg_query_sampler_desc(smp C.sg_sampler) C.sg_sampler_desc
 fn C.sg_query_shader_desc(shd C.sg_shader) C.sg_shader_desc
 fn C.sg_query_pipeline_desc(pip C.sg_pipeline) C.sg_pipeline_desc
-fn C.sg_query_pass_desc(pass C.sg_pass) C.sg_pass_desc
+fn C.sg_query_attachments_desc(atts C.sg_attachments) C.sg_attachments_desc
 
 // get resource creation desc struct with their default values replaced
 fn C.sg_query_buffer_defaults(const_desc &C.sg_buffer_desc) C.sg_buffer_desc
@@ -81,7 +80,7 @@ fn C.sg_query_image_defaults(const_desc &C.sg_image_desc) C.sg_image_desc
 fn C.sg_query_sampler_defaults(const_desc &C.sg_sampler_desc) C.sg_sampler_desc
 fn C.sg_query_shader_defaults(const_desc &C.sg_shader_desc) C.sg_shader_desc
 fn C.sg_query_pipeline_defaults(const_desc &C.sg_pipeline_desc) C.sg_pipeline_desc
-fn C.sg_query_pass_defaults(const_desc &C.sg_pass_desc) C.sg_pass_desc
+fn C.sg_query_attachments_defaults(const_desc &C.sg_attachments_desc) C.sg_attachments_desc
 
 // separate resource allocation and initialization (for async setup)
 fn C.sg_alloc_buffer() C.sg_buffer
@@ -89,39 +88,34 @@ fn C.sg_alloc_image() C.sg_image
 fn C.sg_alloc_sampler() C.sg_sampler
 fn C.sg_alloc_shader() C.sg_shader
 fn C.sg_alloc_pipeline() C.sg_pipeline
-fn C.sg_alloc_pass() C.sg_pass
+fn C.sg_alloc_attachments() C.sg_attachments
 fn C.sg_dealloc_buffer(buf C.sg_buffer)
 fn C.sg_dealloc_image(img C.sg_image)
 fn C.sg_dealloc_sampler(smp C.sg_sampler)
 fn C.sg_dealloc_shader(shd C.sg_shader)
 fn C.sg_dealloc_pipeline(pip C.sg_pipeline)
-fn C.sg_dealloc_pass(pass C.sg_pass)
+fn C.sg_dealloc_attachments(atts C.sg_attachments)
 fn C.sg_init_buffer(buf C.sg_buffer, const_desc &C.sg_buffer_desc)
 fn C.sg_init_image(img C.sg_image, const_desc &C.sg_buffer_desc)
 fn C.sg_init_sampler(smg C.sg_sampler, const_desc &C.sg_sampler_desc)
 fn C.sg_init_shader(shd C.sg_shader, const_desc &C.sg_shader_desc)
 fn C.sg_init_pipeline(pip C.sg_pipeline, const_desc &C.sg_pipeline_desc)
-fn C.sg_init_pass(pass C.sg_pass, const_desc &C.sg_pass_desc)
+fn C.sg_init_attachments(atts C.sg_attachments, const_desc &C.sg_attachments_desc)
 fn C.sg_uninit_buffer(buf C.sg_buffer)
 fn C.sg_uninit_image(img C.sg_image)
 fn C.sg_uninit_sampler(smp C.sg_sampler)
 fn C.sg_uninit_shader(shd C.sg_shader)
 fn C.sg_uninit_pipeline(pip C.sg_pipeline)
-fn C.sg_uninit_pass(pass C.sg_pass)
+fn C.sg_uninit_attachments(atts C.sg_attachments)
 fn C.sg_fail_buffer(buf C.sg_buffer)
 fn C.sg_fail_image(img C.sg_image)
 fn C.sg_fail_sampler(smp C.sg_sampler)
 fn C.sg_fail_shader(shd C.sg_shader)
 fn C.sg_fail_pipeline(pip C.sg_pipeline)
-fn C.sg_fail_pass(pass C.sg_pass)
+fn C.sg_fail_attachments(atts C.sg_attachments)
 
 // frame stats
 fn C.sg_enable_frame_stats()
 fn C.sg_disable_frame_stats()
 fn C.sg_frame_stats_enabled() bool
 fn C.sg_query_frame_stats() C.sg_frame_stats
-
-// rendering contexts (optional)
-fn C.sg_setup_context() C.sg_context
-fn C.sg_activate_context(ctx_id C.sg_context)
-fn C.sg_discard_context(ctx_id C.sg_context)

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -76,8 +76,11 @@ pub struct C.sg_attachments {
 	id u32
 }
 
+// Attachments represents data that can be attached to a render pass.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub type Attachments = C.sg_attachments
 
+// free frees the resources occupied by the struct
 pub fn (mut a C.sg_attachments) free() {
 	C.sg_destroy_attachments(*a)
 }

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -3,63 +3,27 @@ module gfx
 // C.sg_desc describes
 pub struct C.sg_desc {
 pub mut:
-	buffer_pool_size               int
-	image_pool_size                int
-	sampler_pool_size              int
-	shader_pool_size               int
-	pipeline_pool_size             int
-	pass_pool_size                 int
-	context_pool_size              int
-	uniform_buffer_size            int
-	max_commit_listeners           int
-	disable_validation             bool // disable validation layer even in debug mode, useful for tests
-	mtl_force_managed_storage_mode bool // for debugging: use Metal managed storage mode for resources even with UMA
-	wgpu_disable_bindgroups_cache  bool // set to true to disable the WebGPU backend BindGroup cache
-	wgpu_bindgroups_cache_size     int  // number of slots in the WebGPU bindgroup cache (must be 2^N)
-	//
-	allocator C.sg_allocator
-	logger    C.sg_logger
-	//
-	context C.sg_context_desc
+	_start_canary                                   u32
+	buffer_pool_size                                int
+	image_pool_size                                 int
+	sampler_pool_size                               int
+	shader_pool_size                                int
+	pipeline_pool_size                              int
+	attachments_pool_size                           int
+	uniform_buffer_size                             int
+	max_commit_listeners                            int
+	disable_validation                              bool // disable validation layer even in debug mode, useful for tests
+	mtl_force_managed_storage_mode                  bool // for debugging: use Metal managed storage mode for resources even with UMA
+	mtl_use_command_buffer_with_retained_references bool // Metal: use a managed MTLCommandBuffer which ref-counts used resources
+	wgpu_disable_bindgroups_cache                   bool // set to true to disable the WebGPU backend BindGroup cache
+	wgpu_bindgroups_cache_size                      int  // number of slots in the WebGPU bindgroup cache (must be 2^N)
+	allocator                                       C.sg_allocator
+	logger                                          C.sg_logger // optional log function override
+	environment                                     C.sg_environment
+	_end_canary                                     u32
 }
 
 pub type Desc = C.sg_desc
-
-pub struct C.sg_context_desc {
-pub mut:
-	color_format PixelFormat
-	depth_format PixelFormat
-	sample_count int
-	gl           GLContextDesc
-	metal        MetalContextDesc
-	d3d11        D3D11ContextDesc
-	// TODO C.sg_wgpu_context_desc wgpu;
-}
-
-pub type ContextDesc = C.sg_context_desc
-
-pub struct C.sg_gl_context_desc {
-	force_gles2 bool
-}
-
-pub type GLContextDesc = C.sg_gl_context_desc
-
-pub struct C.sg_metal_context_desc {
-	device                   voidptr
-	renderpass_descriptor_cb fn () voidptr = unsafe { nil }
-	drawable_cb              fn () voidptr = unsafe { nil }
-}
-
-pub type MetalContextDesc = C.sg_metal_context_desc
-
-pub struct C.sg_d3d11_context_desc {
-	device                voidptr
-	device_context        voidptr
-	render_target_view_cb fn () voidptr = unsafe { nil }
-	depth_stencil_view_cb fn () voidptr = unsafe { nil }
-}
-
-pub type D3D11ContextDesc = C.sg_d3d11_context_desc
 
 pub struct C.sg_color_target_state {
 pub mut:
@@ -107,6 +71,44 @@ pub type Pipeline = C.sg_pipeline
 pub fn (mut p C.sg_pipeline) free() {
 	C.sg_destroy_pipeline(*p)
 }
+
+pub struct C.sg_attachments {
+	id u32
+}
+
+pub type Attachments = C.sg_attachments
+
+pub fn (mut a C.sg_attachments) free() {
+	C.sg_destroy_attachments(*a)
+}
+
+pub struct C.sg_attachment_desc {
+pub mut:
+	image     Image
+	mip_level int
+	slice     int
+}
+
+pub type AttachmentDesc = C.sg_attachment_desc
+
+pub struct C.sg_attachments_desc {
+pub mut:
+	_start_canary u32
+	colors        [4]AttachmentDesc
+	resolves      [4]AttachmentDesc
+	depth_stencil AttachmentDesc
+	label         &char = unsafe { nil }
+	_end_canary   u32
+}
+
+pub type AttachmentsDesc = C.sg_attachments_desc
+
+pub struct C.sg_attachments_info {
+pub mut:
+	slot SlotInfo // resource pool slot info
+}
+
+pub type AttachmentsInfo = C.sg_attachments_info
 
 pub struct C.sg_bindings {
 pub mut:
@@ -314,13 +316,6 @@ pub:
 
 pub type ShaderInfo = C.sg_shader_info
 
-pub struct C.sg_context {
-pub:
-	id u32
-}
-
-pub type Context = C.sg_context
-
 pub struct C.sg_range {
 pub mut:
 	ptr  voidptr
@@ -349,21 +344,6 @@ pub type Shader = C.sg_shader
 pub fn (mut s Shader) free() {
 	C.sg_destroy_shader(*s)
 }
-
-pub struct C.sg_pass_desc {
-pub mut:
-	color_attachments        [4]PassAttachmentDesc
-	depth_stencil_attachment PassAttachmentDesc
-	label                    &char
-}
-
-pub type PassDesc = C.sg_pass_desc
-
-pub struct C.sg_pass_info {
-	info SlotInfo
-}
-
-pub type PassInfo = C.sg_pass_info
 
 @[typedef]
 pub struct C.sg_frame_stats_gl {
@@ -571,15 +551,72 @@ pub mut:
 
 pub type PassAction = C.sg_pass_action
 
+@[typedef]
+pub struct C.sg_metal_swapchain {
+pub mut:
+	current_drawable voidptr
+	depth_stencil_texture voidptr  // MTLTexture
+	msaa_color_texture voidptr    // MTLTexture
+}
+
+pub type MetalSwapchain = C.sg_metal_swapchain
+
+@[typedef]
+pub struct C.sg_d3d11_swapchain {
+pub mut:
+	render_view voidptr // ID3D11RenderTargetView
+	resolve_view voidptr           // ID3D11RenderTargetView
+    depth_stencil_view voidptr     // ID3D11DepthStencilView
+}
+
+pub type D3d11Swapchain = C.sg_d3d11_swapchain
+
+@[typedef]
+pub struct C.sg_wgpu_swapchain {
+pub mut:
+	render_view voidptr // WGPUTextureView
+    resolve_view voidptr           // WGPUTextureView
+    depth_stencil_view voidptr     // WGPUTextureView
+}
+
+pub type WgpuSwapchain = C.sg_wgpu_swapchain
+
+@[typedef]
+pub struct C.sg_gl_swapchain {
+pub mut:
+	framebuffer u32
+}
+
+pub type GlSwapchain = C.sg_gl_swapchain
+
+@[typedef]
+pub struct C.sg_swapchain {
+pub mut:
+	width        int
+	height       int
+	sample_count int
+	color_format PixelFormat
+	depth_format PixelFormat
+	metal        MetalSwapchain
+	d3d11        D3d11Swapchain
+	wgpu         WgpuSwapchain
+	gl           GlSwapchain
+}
+
+pub type Swapchain = C.sg_swapchain
+
+@[typedef]
 pub struct C.sg_pass {
-	id u32
+pub mut:
+	_start_canary u32
+	action        PassAction
+	attachments   Attachments
+	swapchain     Swapchain
+	label         &char = unsafe { nil }
+	_end_canary   u32
 }
 
 pub type Pass = C.sg_pass
-
-pub fn (mut p Pass) free() {
-	C.sg_destroy_pass(*p)
-}
 
 pub struct C.sg_buffer_desc {
 pub mut:
@@ -745,7 +782,7 @@ pub:
 	max_image_size_array                int // max width/height pf SG_IMAGETYPE_ARRAY images
 	max_image_array_layers              int // max number of layers in SG_IMAGETYPE_ARRAY images
 	max_vertex_attrs                    int // <= SG_MAX_VERTEX_ATTRIBUTES (only on some GLES2 impls)
-	gl_max_vertex_uniform_vectors       int // <= GL_MAX_VERTEX_UNIFORM_VECTORS (only on GL backends)
+	gl_max_vertex_uniform_components    int // <= GL_MAX_VERTEX_UNIFORM_COMPONENTS (only on GL backends)
 	gl_max_combined_texture_image_units int // <= GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS (only on GL backends)
 }
 
@@ -868,21 +905,51 @@ pub:
 
 pub type PixelFormatInfo = C.sg_pixelformat_info
 
-pub struct C.sg_pass_attachment_desc {
+@[typedef]
+pub struct C.sg_environment_defaults {
 pub mut:
-	image     Image
-	mip_level int
-	slice     int
-	// image sg_image
-	// mip_level int
-	// union {
-	// face int
-	// layer int
-	// slice int
-	// }
+	color_format PixelFormat
+	depth_format PixelFormat
+	sample_count int
 }
 
-pub type PassAttachmentDesc = C.sg_pass_attachment_desc
+pub type EnvironmentDefaults = C.sg_environment_defaults
+
+@[typedef]
+pub struct C.sg_metal_environment {
+pub mut:
+	device voidptr
+}
+
+pub type MetalEnvironment = C.sg_metal_environment
+
+@[typedef]
+pub struct C.sg_d3d11_environment {
+pub mut:
+	device         voidptr
+	device_context voidptr
+}
+
+pub type D3d11Environment = C.sg_d3d11_environment
+
+@[typedef]
+pub struct C.sg_wgpu_environment {
+pub mut:
+	device voidptr
+}
+
+pub type WgpuEnvironment = C.sg_wgpu_environment
+
+@[typedef]
+pub struct C.sg_environment {
+pub mut:
+	defaults EnvironmentDefaults
+	metal    MetalEnvironment
+	d3d11    D3d11Environment
+	wgpu     WgpuEnvironment
+}
+
+pub type Environment = C.sg_environment
 
 // C.sg_commit_listener is used with sg_add_commit_listener, to add a callback,
 // which will be called in sg_commit(). This is useful for libraries building

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -554,9 +554,9 @@ pub type PassAction = C.sg_pass_action
 @[typedef]
 pub struct C.sg_metal_swapchain {
 pub mut:
-	current_drawable voidptr
-	depth_stencil_texture voidptr  // MTLTexture
-	msaa_color_texture voidptr    // MTLTexture
+	current_drawable      voidptr
+	depth_stencil_texture voidptr // MTLTexture
+	msaa_color_texture    voidptr // MTLTexture
 }
 
 pub type MetalSwapchain = C.sg_metal_swapchain
@@ -564,9 +564,9 @@ pub type MetalSwapchain = C.sg_metal_swapchain
 @[typedef]
 pub struct C.sg_d3d11_swapchain {
 pub mut:
-	render_view voidptr // ID3D11RenderTargetView
-	resolve_view voidptr           // ID3D11RenderTargetView
-    depth_stencil_view voidptr     // ID3D11DepthStencilView
+	render_view        voidptr // ID3D11RenderTargetView
+	resolve_view       voidptr // ID3D11RenderTargetView
+	depth_stencil_view voidptr // ID3D11DepthStencilView
 }
 
 pub type D3d11Swapchain = C.sg_d3d11_swapchain
@@ -574,9 +574,9 @@ pub type D3d11Swapchain = C.sg_d3d11_swapchain
 @[typedef]
 pub struct C.sg_wgpu_swapchain {
 pub mut:
-	render_view voidptr // WGPUTextureView
-    resolve_view voidptr           // WGPUTextureView
-    depth_stencil_view voidptr     // WGPUTextureView
+	render_view        voidptr // WGPUTextureView
+	resolve_view       voidptr // WGPUTextureView
+	depth_stencil_view voidptr // WGPUTextureView
 }
 
 pub type WgpuSwapchain = C.sg_wgpu_swapchain

--- a/vlib/sokol/gfx/gfx_utils.c.v
+++ b/vlib/sokol/gfx/gfx_utils.c.v
@@ -3,7 +3,7 @@ module gfx
 @[deprecated: 'use create_clear_pass_action instead']
 @[deprecated_after: '2024-09-03']
 pub fn create_clear_pass(r f32, g f32, b f32, a f32) PassAction {
-	return create_clear_pass_action(r,g,b,a)
+	return create_clear_pass_action(r, g, b, a)
 }
 
 pub fn create_clear_pass_action(r f32, g f32, b f32, a f32) PassAction {

--- a/vlib/sokol/gfx/gfx_utils.c.v
+++ b/vlib/sokol/gfx/gfx_utils.c.v
@@ -1,6 +1,12 @@
 module gfx
 
+@[deprecated: 'use create_clear_pass_action instead']
+@[deprecated_after: '2024-09-03']
 pub fn create_clear_pass(r f32, g f32, b f32, a f32) PassAction {
+	return create_clear_pass_action(r,g,b,a)
+}
+
+pub fn create_clear_pass_action(r f32, g f32, b f32, a f32) PassAction {
 	mut color_action := ColorAttachmentAction{
 		load_action: .clear // unsafe { Action(C.SG_ACTION_CLEAR) }
 		clear_value: Color{

--- a/vlib/sokol/gfx/gfx_utils.c.v
+++ b/vlib/sokol/gfx/gfx_utils.c.v
@@ -6,9 +6,11 @@ pub fn create_clear_pass(r f32, g f32, b f32, a f32) PassAction {
 	return create_clear_pass_action(r, g, b, a)
 }
 
+// create_clear_pass_action returns a *clearing* `PassAction` that clears the `Pass`
+// with the color defined by the color components `r`ed,`g`reen, `b`lue and `a`lpha.
 pub fn create_clear_pass_action(r f32, g f32, b f32, a f32) PassAction {
 	mut color_action := ColorAttachmentAction{
-		load_action: .clear // unsafe { Action(C.SG_ACTION_CLEAR) }
+		load_action: .clear
 		clear_value: Color{
 			r: r
 			g: g

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -29,9 +29,10 @@ pub fn glue_environment() gfx.Environment {
 	env.defaults.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
 	env.defaults.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
 	env.defaults.sample_count = sample_count()
-	$if macos {
-		env.metal.device = metal_get_device()
-	}
+	// if macos+metal
+	//$if macos {
+	//	env.metal.device = metal_get_device()
+	//}
 	// if windows and dx3d11
 	// env.d3d11.device = d3d11_get_device()
 	// env.d3d11.device_context = d3d11_get_device_context()
@@ -48,22 +49,21 @@ pub fn glue_swapchain() gfx.Swapchain {
 	swapchain.sample_count = sample_count()
 	swapchain.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
 	swapchain.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
-	$if macos {
-		swapchain.metal.current_drawable = metal_get_current_drawable()
-		swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()
-		swapchain.metal.msaa_color_texture = metal_get_msaa_color_texture()
-	}
+	// if macos+metal
+	//$if macos {
+	//	swapchain.metal.current_drawable = metal_get_current_drawable()
+	//	swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()
+	//	swapchain.metal.msaa_color_texture = metal_get_msaa_color_texture()
+	//}
 	// if windows and dx3d11
 	// swapchain.d3d11.render_view = d3d11_get_render_view()
-	//swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
-	//swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
+	// swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
+	// swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
 	// if webgpu
-	//swapchain.wgpu.render_view = wgpu_get_render_view()
-	//swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
-	//swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
-	$else {
-		swapchain.gl.framebuffer = gl_get_framebuffer()
-	}
+	// swapchain.wgpu.render_view = wgpu_get_render_view()
+	// swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
+	// swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
+	swapchain.gl.framebuffer = gl_get_framebuffer()
 	return swapchain
 }
 

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -29,10 +29,9 @@ pub fn glue_environment() gfx.Environment {
 	env.defaults.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
 	env.defaults.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
 	env.defaults.sample_count = sample_count()
-	// if macos+metal
-	//$if macos {
-	//	env.metal.device = metal_get_device()
-	//}
+	$if macos {
+		env.metal.device = metal_get_device()
+	}
 	// if windows and dx3d11
 	// env.d3d11.device = d3d11_get_device()
 	// env.d3d11.device_context = d3d11_get_device_context()
@@ -49,21 +48,22 @@ pub fn glue_swapchain() gfx.Swapchain {
 	swapchain.sample_count = sample_count()
 	swapchain.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
 	swapchain.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
-	// if macos+metal
-	//$if macos {
-	//	swapchain.metal.current_drawable = metal_get_current_drawable()
-	//	swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()
-	//	swapchain.metal.msaa_color_texture = metal_get_msaa_color_texture()
-	//}
+	$if macos {
+		swapchain.metal.current_drawable = metal_get_current_drawable()
+		swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()
+		swapchain.metal.msaa_color_texture = metal_get_msaa_color_texture()
+	}
 	// if windows and dx3d11
 	// swapchain.d3d11.render_view = d3d11_get_render_view()
-	// swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
-	// swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
+	//swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
+	//swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
 	// if webgpu
-	// swapchain.wgpu.render_view = wgpu_get_render_view()
-	// swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
-	// swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
-	swapchain.gl.framebuffer = gl_get_framebuffer()
+	//swapchain.wgpu.render_view = wgpu_get_render_view()
+	//swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
+	//swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
+	$else {
+		swapchain.gl.framebuffer = gl_get_framebuffer()
+	}
 	return swapchain
 }
 

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -55,12 +55,12 @@ pub fn glue_swapchain() gfx.Swapchain {
 	}
 	// if windows and dx3d11
 	// swapchain.d3d11.render_view = d3d11_get_render_view()
-	//swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
-	//swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
+	// swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
+	// swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
 	// if webgpu
-	//swapchain.wgpu.render_view = wgpu_get_render_view()
-	//swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
-	//swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
+	// swapchain.wgpu.render_view = wgpu_get_render_view()
+	// swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
+	// swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
 	$else {
 		swapchain.gl.framebuffer = gl_get_framebuffer()
 	}

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -10,26 +10,61 @@ pub const used_import = gfx.used_import
 __global g_desc C.sapp_desc
 
 pub fn create_desc() gfx.Desc {
-	metal_desc := gfx.MetalContextDesc{
-		device: metal_get_device()
-		renderpass_descriptor_cb: metal_get_renderpass_descriptor
-		drawable_cb: metal_get_drawable
-	}
-	d3d11_desc := gfx.D3D11ContextDesc{
-		device: d3d11_get_device()
-		device_context: d3d11_get_device_context()
-		render_target_view_cb: d3d11_get_render_target_view
-		depth_stencil_view_cb: d3d11_get_depth_stencil_view
-	}
-
 	return gfx.Desc{
-		context: gfx.ContextDesc{
-			metal: metal_desc
-			d3d11: d3d11_desc
-			color_format: .bgra8
-		}
+		environment: glue_environment()
 		image_pool_size: 1000
 	}
+}
+
+pub fn create_default_pass(action gfx.PassAction) gfx.Pass {
+	return gfx.Pass{
+		action: action
+		swapchain: glue_swapchain()
+	}
+}
+
+pub fn glue_environment() gfx.Environment {
+	mut env := gfx.Environment{}
+	unsafe { vmemset(&env, 0, int(sizeof(env))) }
+	env.defaults.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
+	env.defaults.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
+	env.defaults.sample_count = sample_count()
+	$if macos {
+		env.metal.device = metal_get_device()
+	}
+	// if windows and dx3d11
+	// env.d3d11.device = d3d11_get_device()
+	// env.d3d11.device_context = d3d11_get_device_context()
+	// if webgpu
+	// env.wgpu.device = wgpu_get_device()
+	return env
+}
+
+pub fn glue_swapchain() gfx.Swapchain {
+	mut swapchain := gfx.Swapchain{}
+	unsafe { vmemset(&swapchain, 0, int(sizeof(swapchain))) }
+	swapchain.width = width()
+	swapchain.height = height()
+	swapchain.sample_count = sample_count()
+	swapchain.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
+	swapchain.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
+	$if macos {
+		swapchain.metal.current_drawable = metal_get_current_drawable()
+		swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()
+		swapchain.metal.msaa_color_texture = metal_get_msaa_color_texture()
+	}
+	// if windows and dx3d11
+	// swapchain.d3d11.render_view = d3d11_get_render_view()
+	//swapchain.d3d11.resolve_view = d3d11_get_resolve_view()
+	//swapchain.d3d11.depth_stencil_view = d3d11_get_depth_stencil_view()
+	// if webgpu
+	//swapchain.wgpu.render_view = wgpu_get_render_view()
+	//swapchain.wgpu.resolve_view = wgpu_get_resolve_view()
+	//swapchain.wgpu.depth_stencil_view = wgpu_get_depth_stencil_view()
+	$else {
+		swapchain.gl.framebuffer = gl_get_framebuffer()
+	}
+	return swapchain
 }
 
 // returns true after sokol-app has been initialized
@@ -210,16 +245,19 @@ pub fn metal_get_device() voidptr {
 	return voidptr(C.sapp_metal_get_device())
 }
 
-// Metal: get ARC-bridged pointer to this frame's renderpass descriptor
-@[inline]
-pub fn metal_get_renderpass_descriptor() voidptr {
-	return voidptr(C.sapp_metal_get_renderpass_descriptor())
+// Metal: get ARC-bridged pointer to current drawable
+pub fn metal_get_current_drawable() voidptr {
+	return C.sapp_metal_get_current_drawable()
 }
 
-// Metal: get ARC-bridged pointer to current drawable
-@[inline]
-pub fn metal_get_drawable() voidptr {
-	return voidptr(C.sapp_metal_get_drawable())
+// Metal: get bridged pointer to MTKView's depth-stencil texture of type MTLTexture
+pub fn metal_get_depth_stencil_texture() voidptr {
+	return C.sapp_metal_get_depth_stencil_texture()
+}
+
+// Metal: get bridged pointer to MTKView's msaa-color-texture of type MTLTexture (may be null)
+pub fn metal_get_msaa_color_texture() voidptr {
+	return C.sapp_metal_get_msaa_color_texture()
 }
 
 // macOS: get ARC-bridged pointer to macOS NSWindow
@@ -246,10 +284,16 @@ pub fn d3d11_get_device_context() voidptr {
 	return voidptr(C.sapp_d3d11_get_device_context())
 }
 
-// D3D11: get pointer to ID3D11RenderTargetView object
+// D3D11: get pointer to ID3D11RenderView object
 @[inline]
-pub fn d3d11_get_render_target_view() voidptr {
-	return voidptr(C.sapp_d3d11_get_render_target_view())
+pub fn d3d11_get_render_view() voidptr {
+	return voidptr(C.sapp_d3d11_get_render_view())
+}
+
+// D3D11: get pointer ID3D11RenderTargetView object for msaa-resolve (may return null)
+@[inline]
+pub fn d3d11_get_resolve_view() voidptr {
+	return C.sapp_d3d11_get_resolve_view()
 }
 
 // D3D11: get pointer to ID3D11DepthStencilView
@@ -262,6 +306,32 @@ pub fn d3d11_get_depth_stencil_view() voidptr {
 @[inline]
 pub fn win32_get_hwnd() voidptr {
 	return voidptr(C.sapp_win32_get_hwnd())
+}
+
+// WebGPU: get WGPUDevice handle
+pub fn wgpu_get_device() voidptr {
+	return C.sapp_wgpu_get_device()
+}
+
+// WebGPU: get swapchain's WGPUTextureView handle for rendering
+pub fn wgpu_get_render_view() voidptr {
+	return C.sapp_wgpu_get_render_view()
+}
+
+// WebGPU: get swapchain's MSAA-resolve WGPUTextureView (may return null)
+pub fn wgpu_get_resolve_view() voidptr {
+	return C.sapp_wgpu_get_resolve_view()
+}
+
+// WebGPU: get swapchain's WGPUTextureView for the depth-stencil surface
+pub fn wgpu_get_depth_stencil_view() voidptr {
+	return C.sapp_wgpu_get_depth_stencil_view()
+}
+
+// GL: get framebuffer object
+@[inline]
+pub fn gl_get_framebuffer() u32 {
+	return C.sapp_gl_get_framebuffer()
 }
 
 // Android: get native activity handle

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -33,7 +33,7 @@ pub fn glue_environment() gfx.Environment {
 	env.defaults.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
 	env.defaults.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
 	env.defaults.sample_count = sample_count()
-	$if macos {
+	$if macos && !darwin_sokol_glcore33 ? {
 		env.metal.device = metal_get_device()
 	}
 	// if windows and dx3d11
@@ -55,7 +55,7 @@ pub fn glue_swapchain() gfx.Swapchain {
 	swapchain.sample_count = sample_count()
 	swapchain.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
 	swapchain.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
-	$if macos {
+	$if macos && !darwin_sokol_glcore33 ? {
 		swapchain.metal.current_drawable = metal_get_current_drawable()
 		swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()
 		swapchain.metal.msaa_color_texture = metal_get_msaa_color_texture()

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -16,6 +16,7 @@ pub fn create_desc() gfx.Desc {
 	}
 }
 
+// create_default_pass creates a default `gfx.Pass` compatible with `sapp` and `sokol.gfx.begin_pass/1`.
 pub fn create_default_pass(action gfx.PassAction) gfx.Pass {
 	return gfx.Pass{
 		action: action
@@ -23,6 +24,9 @@ pub fn create_default_pass(action gfx.PassAction) gfx.Pass {
 	}
 }
 
+// glue_environment returns a `gfx.Environment` compatible for use with `sapp` specific `gfx.Pass`es.
+// The retuned `gfx.Environment` can be used when rendering via `sapp`.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn glue_environment() gfx.Environment {
 	mut env := gfx.Environment{}
 	unsafe { vmemset(&env, 0, int(sizeof(env))) }
@@ -40,6 +44,9 @@ pub fn glue_environment() gfx.Environment {
 	return env
 }
 
+// glue_swapchain returns a `gfx.Swapchain` compatible for use with `sapp` specific display/rendering `gfx.Pass`es.
+// The retuned `gfx.Swapchain` can be used when rendering via `sapp`.
+// See also: documentation at the top of thirdparty/sokol/sokol_gfx.h
 pub fn glue_swapchain() gfx.Swapchain {
 	mut swapchain := gfx.Swapchain{}
 	unsafe { vmemset(&swapchain, 0, int(sizeof(swapchain))) }

--- a/vlib/sokol/sapp/sapp_funcs.c.v
+++ b/vlib/sokol/sapp/sapp_funcs.c.v
@@ -110,11 +110,14 @@ fn C.sapp_html5_ask_leave_site(ask bool)
 // Metal: get ARC-bridged pointer to Metal device object
 fn C.sapp_metal_get_device() voidptr
 
-// Metal: get ARC-bridged pointer to this frame's renderpass descriptor
-fn C.sapp_metal_get_renderpass_descriptor() voidptr
-
 // Metal: get ARC-bridged pointer to current drawable
-fn C.sapp_metal_get_drawable() voidptr
+fn C.sapp_metal_get_current_drawable() voidptr
+
+// Metal: get bridged pointer to MTKView's depth-stencil texture of type MTLTexture
+fn C.sapp_metal_get_depth_stencil_texture() voidptr
+
+// Metal: get bridged pointer to MTKView's msaa-color-texture of type MTLTexture (may be null)
+fn C.sapp_metal_get_msaa_color_texture() voidptr
 
 // macOS: get ARC-bridged pointer to macOS NSWindow
 fn C.sapp_macos_get_window() voidptr
@@ -131,8 +134,11 @@ fn C.sapp_d3d11_get_device_context() voidptr
 // D3D11: get pointer to IDXGISwapChain object
 fn C.sapp_d3d11_get_swap_chain() voidptr
 
-// D3D11: get pointer to ID3D11RenderTargetView object
-fn C.sapp_d3d11_get_render_target_view() voidptr
+// D3D11: get pointer to ID3D11RenderView object
+fn C.sapp_d3d11_get_render_view() voidptr
+
+// D3D11: get pointer ID3D11RenderTargetView object for msaa-resolve (may return null)
+fn C.sapp_d3d11_get_resolve_view() voidptr
 
 // D3D11: get pointer to ID3D11DepthStencilView
 fn C.sapp_d3d11_get_depth_stencil_view() voidptr
@@ -151,6 +157,9 @@ fn C.sapp_wgpu_get_resolve_view() voidptr
 
 // WebGPU: get swapchain's WGPUTextureView for the depth-stencil surface
 fn C.sapp_wgpu_get_depth_stencil_view() voidptr
+
+// GL: get framebuffer object
+fn C.sapp_gl_get_framebuffer() u32
 
 // Android: get native activity handle
 fn C.sapp_android_get_native_activity() voidptr


### PR DESCRIPTION
So... quite a bit changed with this update.

**Highlights**

* `sg_begin_default_pass/3` has been removed in favor of a unified `sg_begin_pass/1` which account for a lot of the example changes.

* Instead of including yet another C dependency (`sokol_glue.h`) I decided to just implement it's 2 functions in V directly in `sapp.glue_environment/0` and `sapp.glue_swapchain/0` their current quirk is that they cannot be called before `sapp` has actually opened a window, hence all the `pass := sapp.create_default_pass(pass_action)` calls in the `frame` callback. There's no noticeable/visual/performance changes on my old hardware - but it would be cleaner if the `pass` was only created once when the app is intialized and the window fully opened, but it'll need some refactoring I think.

* Renamed `sapp.create_clear_pass/3` to `sapp.create_clear_pass_action/3` to minimize confusion now that the `gfx.Pass` has been re-utilized (it's been renamed from `sg_pass` -> `sg_attachments` and re-utilized as `sg_pass` :roll_eyes: ).

* `gg` has been modified to not use `begin_default_pass/3` anymore.

Also see official sokol [blog entry](https://floooh.github.io/2024/02/26/sokol-spring-cleaning-2024.html) on the matter.

I've only been able to test all `examples/sokol/*` and a few `examples/gg/*` (I've tested the `bezier_anim.v` and `examples/gg/many_thousands_of_circles.v` which uses `gg` and the `ctx.end(how: .passthru)`.

`sokol_app.h` and `sokol_gfx.h` has both been patched with V patches - but as usual I cannot test the macOS patches.