### PR TITLE
vdoc: add attributes to enums and structs

### DIFF
--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -242,6 +242,14 @@ pub fn (mut d Doc) stmt(mut stmt ast.Stmt, filename string) !DocNode {
 					}
 				}
 			}
+			for sa in stmt.attrs {
+				node.attrs[sa.name] = if sa.has_at {
+					'@[${sa.str()}]'
+				} else {
+					'[${sa.str()}]'
+				}
+				node.tags << node.attrs[sa.name]
+			}
 		}
 		ast.InterfaceDecl {
 			node.kind = .interface_
@@ -263,6 +271,14 @@ pub fn (mut d Doc) stmt(mut stmt ast.Stmt, filename string) !DocNode {
 						return_type: ret_type
 					}
 				}
+			}
+			for sa in stmt.attrs {
+				node.attrs[sa.name] = if sa.has_at {
+					'@[${sa.str()}]'
+				} else {
+					'[${sa.str()}]'
+				}
+				node.tags << node.attrs[sa.name]
 			}
 		}
 		ast.TypeDecl {

--- a/vlib/v/doc/doc_test.v
+++ b/vlib/v/doc/doc_test.v
@@ -16,3 +16,47 @@ fn test_generate_from_mod() {
 	assert nested_mod_doc.contents.len == 3
 	assert nested_mod_doc.contents['ChunkScanner'].children.len == 3
 }
+
+fn test_tags_with_flag_struct_attribute() {
+	mod_name := 'gg'
+	mod_doc := doc.generate_from_mod(mod_name, false, true) or {
+		eprintln(err)
+		assert false
+		doc.Doc{}
+	}
+	assert mod_doc.head.name == mod_name
+
+	mouse_buttons := mod_doc.contents['MouseButtons']!
+	assert mouse_buttons.content == '@[flag]
+pub enum MouseButtons {
+	left
+	right
+	middle
+}'
+	assert mouse_buttons.attrs == {
+		'flag': '@[flag]'
+	}
+	assert mouse_buttons.tags == ['@[flag]']
+
+	end_options := mod_doc.contents['EndOptions']
+	assert end_options.content == '@[params]
+pub struct EndOptions {
+	how EndEnum
+}'
+	assert end_options.attrs == {
+		'params': '@[params]'
+	}
+	assert end_options.tags == ['@[params]']
+
+	pipeline_container := mod_doc.contents['PipelineContainer']
+	assert pipeline_container.content == '@[heap]
+pub struct PipelineContainer {
+pub mut:
+	alpha sgl.Pipeline
+	add   sgl.Pipeline
+}'
+	assert pipeline_container.attrs == {
+		'heap': '@[heap]'
+	}
+	assert pipeline_container.tags == ['@[heap]']
+}


### PR DESCRIPTION
Fixes: #20714.

This PR adds attributes for enums and structs to the documentation.

Here is a light-mode example:

<img width="1727" alt="add-tags-2024-03-03_21-58-36" src="https://github.com/vlang/v/assets/6598971/8e27d6ed-aa54-47fe-9365-76b72eb30fda">

and here is the dark-mode for the same example:

<img width="1727" alt="dark-mode-2024-03-03_22-00-51" src="https://github.com/vlang/v/assets/6598971/45a32761-7913-4546-8cd4-991f7d8d696e">

Note that I ran `v test-all` locally and there were 5 errors that appear to be unrelated to this change:

```
---- Summary of `v test-all`: ---------------------------------------------------------------------------------------------------
Total runtime: 349169 ms
...
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -os linux -experimental -b native -o hw.linux examples/hello_world.v
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -os macos -experimental -b native -o hw.macos examples/hello_world.v
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -o vtmp_werror -cstrict cmd/v
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' check-md -hide-warnings .
>      Failed: '/Users/glenn/src/github.com/vlang/v/v' -o v.c cmd/v && cc -Werror v.c -lpthread -lm && rm -rf a.out
```