### PR TITLE
checker: fix missing check for interface cast of option type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3174,7 +3174,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	} else if from_type == ast.none_type && !to_type.has_flag(.option) && !to_type.has_flag(.result) {
 		type_name := c.table.type_to_str(to_type)
 		c.error('cannot cast `none` to `${type_name}`', node.pos)
-	} else if from_sym.kind == .struct_ && !from_type.is_ptr() {
+	} else if !from_type.has_option_or_result() && from_sym.kind == .struct_ && !from_type.is_ptr() {
 		if (final_to_is_ptr || to_sym.kind !in [.sum_type, .interface_]) && !c.is_builtin_mod {
 			from_type_name := c.table.type_to_str(from_type)
 			type_name := c.table.type_to_str(to_type)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3148,7 +3148,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			tt := c.table.type_to_str(to_type)
 			c.error('cannot cast `${ft}` to `${tt}`', node.pos)
 		}
-	} else if mut to_sym.info is ast.Interface {
+	} else if !from_type.has_option_or_result() && mut to_sym.info is ast.Interface {
 		if c.type_implements(from_type, to_type, node.pos) {
 			if !from_type.is_any_kind_of_pointer() && from_sym.kind != .interface_
 				&& !c.inside_unsafe {

--- a/vlib/v/checker/tests/interface_option_cast_err.out
+++ b/vlib/v/checker/tests/interface_option_cast_err.out
@@ -1,0 +1,19 @@
+vlib/v/checker/tests/interface_option_cast_err.vv:12:2: warning: unused variable: `b`
+   10 |     a := ?Foo{}
+   11 |     dump(a)
+   12 |     b := IFoo(a?)
+      |     ^
+   13 |     c := IFoo(a)
+   14 | }
+vlib/v/checker/tests/interface_option_cast_err.vv:13:2: warning: unused variable: `c`
+   11 |     dump(a)
+   12 |     b := IFoo(a?)
+   13 |     c := IFoo(a)
+      |     ^
+   14 | }
+vlib/v/checker/tests/interface_option_cast_err.vv:13:7: error: cannot type cast an Option
+   11 |     dump(a)
+   12 |     b := IFoo(a?)
+   13 |     c := IFoo(a)
+      |          ~~~~~~~
+   14 | }

--- a/vlib/v/checker/tests/interface_option_cast_err.vv
+++ b/vlib/v/checker/tests/interface_option_cast_err.vv
@@ -1,0 +1,14 @@
+interface IFoo {
+	a int
+}
+
+struct Foo {
+	a int
+}
+
+fn main() {
+	a := ?Foo{}
+	dump(a)
+	b := IFoo(a?)
+	c := IFoo(a)
+}


### PR DESCRIPTION
Fix missing interface cast checking

```v
interface IFoo {
	a int
}

struct Foo {
	a int
}

fn main() {
	a := ?Foo{}
	dump(a)
	b := IFoo(a?)
	c := IFoo(a) // must be an error
}
```