### PR TITLE
cgen: fix missing scope enclosing for const init which needs temp variables

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5722,7 +5722,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 						has_unwrap_opt_res)
 				} else {
 					g.const_decl_init_later(field.mod, name, field.expr, field.typ, false,
-						false)
+						true)
 				}
 			}
 		}

--- a/vlib/v/tests/modules/consts_with_complex_init/config.v
+++ b/vlib/v/tests/modules/consts_with_complex_init/config.v
@@ -1,0 +1,13 @@
+module main
+
+import rand
+
+struct MyStruct {
+	foo int
+}
+
+const my_struct = MyStruct{rand.intn(6) or { panic(err) }}
+
+fn main() {
+	dump('hello')
+}

--- a/vlib/v/tests/modules/consts_with_complex_init/consts_should_not_conflict_test.v
+++ b/vlib/v/tests/modules/consts_with_complex_init/consts_should_not_conflict_test.v
@@ -1,0 +1,9 @@
+module main
+
+import os
+
+const cfg_dir = os.join_path(os.config_dir() or { panic(err) }, 'foo')
+
+fn test_main() {
+	dump('hello')
+}


### PR DESCRIPTION
Fix #20970