### PR TITLE
ast: cleanup and simplify `shorten_user_defined_typenames` method

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1467,33 +1467,33 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 	return res
 }
 
-fn (t Table) shorten_user_defined_typenames(originalname string, import_aliases map[string]string) string {
-	if alias := import_aliases[originalname] {
+fn (t Table) shorten_user_defined_typenames(original_name string, import_aliases map[string]string) string {
+	if alias := import_aliases[original_name] {
 		return alias
 	}
-	mut parts := originalname.split('.')
+	mut parts := original_name.split('.')
 	if parts.len > 1 {
 		// cur_mod.Type => Type
-		if t.cmod_prefix != '' && originalname.starts_with(t.cmod_prefix) {
-			return originalname.all_after(t.cmod_prefix)
+		if t.cmod_prefix != '' && original_name.starts_with(t.cmod_prefix) {
+			return original_name.all_after(t.cmod_prefix)
 		}
 		// mod.submod.submod2.Type => submod2.Type
 		if !parts[..parts.len - 1].any(it.contains('[')) {
 			mod_idx := parts.len - 2
 			if t.is_fmt {
-				parts[mod_idx] = originalname.all_before_last('.')
+				parts[mod_idx] = original_name.all_before_last('.')
 			}
 			if alias := import_aliases[parts[mod_idx]] {
 				parts[mod_idx] = alias
 			}
 			return parts[mod_idx..].join('.')
 		}
-		if originalname.contains('[]') {
+		if original_name.contains('[]') {
 			// []mod.name
-			return originalname.all_after('.')
+			return original_name.all_after('.')
 		}
 	}
-	return originalname
+	return original_name
 }
 
 @[minify]

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1468,41 +1468,32 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 }
 
 fn (t Table) shorten_user_defined_typenames(originalname string, import_aliases map[string]string) string {
-	mut res := originalname
-	if t.cmod_prefix.len > 0 && res.starts_with(t.cmod_prefix) {
+	if alias := import_aliases[originalname] {
+		return alias
+	}
+	mut parts := originalname.split('.')
+	if parts.len > 1 {
 		// cur_mod.Type => Type
-		res = res.replace_once(t.cmod_prefix, '')
-	} else if res in import_aliases {
-		res = import_aliases[res]
-	} else {
-		// FIXME: clean this case and remove the following if
-		// because it is an hack to format well the type when
-		// there is a []mod.name
-		if res.contains('[]') {
-			idx := res.index('.') or { -1 }
-			return res[idx + 1..]
+		if t.cmod_prefix != '' && originalname.starts_with(t.cmod_prefix) {
+			return originalname.all_after(t.cmod_prefix)
 		}
-		// types defined by the user
 		// mod.submod.submod2.Type => submod2.Type
-		mut parts := res.split('.')
-		if parts.len > 1 {
-			if parts[..parts.len - 1].all(!it.contains('[')) {
-				ind := parts.len - 2
-				if t.is_fmt {
-					// Rejoin the module parts for correct usage of aliases
-					parts[ind] = parts[..ind + 1].join('.')
-				}
-				if parts[ind] in import_aliases {
-					parts[ind] = import_aliases[parts[ind]]
-				}
-
-				res = parts[ind..].join('.')
+		if !parts[..parts.len - 1].any(it.contains('[')) {
+			mod_idx := parts.len - 2
+			if t.is_fmt {
+				parts[mod_idx] = originalname.all_before_last('.')
 			}
-		} else {
-			res = parts[0]
+			if alias := import_aliases[parts[mod_idx]] {
+				parts[mod_idx] = alias
+			}
+			return parts[mod_idx..].join('.')
+		}
+		if originalname.contains('[]') {
+			// []mod.name
+			return originalname.all_after('.')
 		}
 	}
-	return res
+	return originalname
 }
 
 @[minify]


### PR DESCRIPTION
The PR updates the mentioned method. The change should also bring be a slight performance improvement (not tested). It will help to add a simple fix in a follow up for further issues when running `v fmt` on modules inside a `$VMODULES` directory. 