### PR TITLE
ast, fmt: improve submodule type alias lookup; fix formatting of modules in `$VMODULES`

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1473,10 +1473,6 @@ fn (t Table) shorten_user_defined_typenames(original_name string, import_aliases
 	}
 	mut parts := original_name.split('.')
 	if parts.len > 1 {
-		// cur_mod.Type => Type
-		if t.cmod_prefix != '' && original_name.starts_with(t.cmod_prefix) {
-			return original_name.all_after(t.cmod_prefix)
-		}
 		// mod.submod.submod2.Type => submod2.Type
 		if !parts[..parts.len - 1].any(it.contains('[')) {
 			mod_idx := parts.len - 2
@@ -1485,6 +1481,9 @@ fn (t Table) shorten_user_defined_typenames(original_name string, import_aliases
 			}
 			if alias := import_aliases[parts[mod_idx]] {
 				parts[mod_idx] = alias
+			} else if t.cmod_prefix != '' && original_name.starts_with(t.cmod_prefix) {
+				// cur_mod.Type => Type
+				return original_name.all_after(t.cmod_prefix)
 			}
 			return parts[mod_idx..].join('.')
 		}

--- a/vlib/v/fmt/fmt_vmodules_test.v
+++ b/vlib/v/fmt/fmt_vmodules_test.v
@@ -2,10 +2,9 @@ import os
 
 const vexe = os.quoted_path(@VEXE)
 const vmodules_tdir = os.join_path(os.vtmp_dir(), 'fmt_vmodules_test')
-const module_tdir = os.join_path(vmodules_tdir, 'foo')
 
 fn testsuite_begin() {
-	os.mkdir_all(module_tdir) or {}
+	os.mkdir_all(vmodules_tdir) or {}
 	os.setenv('VMODULES', vmodules_tdir, true)
 }
 
@@ -13,7 +12,9 @@ fn testsuite_end() {
 	os.rmdir_all(vmodules_tdir) or {}
 }
 
-fn test_fmt_vmodules() {
+fn test_fmt_imports() {
+	mod_tdir := os.join_path(vmodules_tdir, @FN)
+	os.mkdir_all(mod_tdir)!
 	tfile_content := [
 		'import x.json2 as json',
 		'import datatypes { Stack }',
@@ -21,6 +22,34 @@ fn test_fmt_vmodules() {
 		'const foo = Stack[string]{}',
 		'',
 	].join_lines()
-	os.write_file(os.join_path(module_tdir, 'main.v'), tfile_content)!
-	os.execute_opt('${vexe} fmt -c ${module_tdir}') or { assert false, err.msg() }
+	os.write_file(os.join_path(mod_tdir, 'main.v'), tfile_content)!
+	os.execute_opt('${vexe} fmt -c ${mod_tdir}') or { assert false, err.msg() }
+}
+
+fn test_fmt_submod_type_alias() {
+	mod_tdir := os.join_path(vmodules_tdir, @FN)
+	mod_src_tdir := os.join_path(mod_tdir, 'src')
+	submod_tdir := os.join_path(mod_tdir, 'bar', 'baz')
+	os.mkdir_all(mod_src_tdir)!
+	os.mkdir_all(submod_tdir)!
+	tfile_content := [
+		'module ${@FN}',
+		'',
+		'import bar.baz',
+		'',
+		'type MyAlias = baz.Baz',
+		'',
+	].join_lines()
+	submod_tfile_content := [
+		'module baz',
+		'',
+		'enum BarBaz {',
+		'	bar',
+		'	baz',
+		'}',
+		'',
+	].join_lines()
+	os.write_file(os.join_path(mod_src_tdir, 'foo.v'), tfile_content)!
+	os.write_file(os.join_path(submod_tdir, 'baz.v'), submod_tfile_content)!
+	os.execute_opt('${vexe} fmt -c ${mod_tdir}') or { assert false, err.msg() }
 }


### PR DESCRIPTION
Fixes an issue where

```v
// ~/.vmodules/foo/foo.v || ~/.vmodules/foo/src/foo.v
module foo

import bar.baz

type MyAlias = baz.Baz
// Will be formatted into:
// type MyAlias = bar.baz.Baz
``` 

```v
// ~/.vmodules/foo/bar/baz/baz.v
module baz

enum Baz {
	bar
	baz
}
```

