### PR TITLE
io.reader: Make read_all constants public

### DIFF
--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -29,8 +29,8 @@ mut:
 	read(mut buf []u8) !int
 }
 
-const read_all_len = 10 * 1024
-const read_all_grow_len = 1024
+pub const read_all_len = 10 * 1024
+pub const read_all_grow_len = 1024
 
 // ReadAllConfig allows options to be passed for the behaviour
 // of read_all.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

The `io.string_reader.StringReader` class uses private constants from `io.string_reader`. This PR makes those constants public so that the newly added StringReader class (and any future reader-like classes) can use them. Addresses #20975.   