### PR TITLE
fix needs_fill_until check

### DIFF
--- a/vlib/io/string_reader/string_reader.v
+++ b/vlib/io/string_reader/string_reader.v
@@ -52,7 +52,7 @@ pub fn (r StringReader) needs_fill() bool {
 // needs_fill_until returns whether the buffer needs refilling in order to read
 // `n` bytes
 pub fn (r StringReader) needs_fill_until(n int) bool {
-	return r.offset + n >= r.builder.len
+	return r.offset + n > r.builder.len
 }
 
 // fill_bufer tries to read data into the buffer until either a 0 length read or if read_to_end_of_stream

--- a/vlib/io/string_reader/string_reader_test.v
+++ b/vlib/io/string_reader/string_reader_test.v
@@ -89,6 +89,20 @@ fn test_from_string() {
 	}
 }
 
+fn test_from_string_read_byte_one_by_one() {
+	mut reader := StringReader.new(source: 'test')
+	assert reader.read_bytes(1)![0].ascii_str() == 't'
+	assert reader.read_bytes(1)![0].ascii_str() == 'e'
+	assert reader.read_bytes(1)![0].ascii_str() == 's'
+	assert reader.read_bytes(1)![0].ascii_str() == 't'
+
+	if _ := reader.read_all(false) {
+		assert false, 'should return Eof'
+	} else {
+		assert err is io.Eof
+	}
+}
+
 fn test_from_string_and_reader() {
 	buf := Buf{
 		bytes: 'buffer'.bytes()


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR is meant to address https://github.com/vlang/v/issues/20998. 

It changes the condition so that if you request the last byte individually, then StringReader won't fail when the current offset is equal to the length of the builder before it increases the offset to EOF.
