### PR TITLE
checker: remove unnecessary string interpolation in deprecation method calls

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3737,7 +3737,7 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 					node.obj = obj
 
 					if obj.attrs.contains('deprecated') && obj.mod != c.mod {
-						c.deprecate('const', '${obj.name}', obj.attrs, node.pos)
+						c.deprecate('const', obj.name, obj.attrs, node.pos)
 					}
 
 					if node.or_expr.kind != .absent {
@@ -3794,7 +3794,7 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		if node.obj is ast.ConstField {
 			field := node.obj as ast.ConstField
 			if field.attrs.contains('deprecated') && field.mod != c.mod {
-				c.deprecate('const', '${field.name}', field.attrs, node.pos)
+				c.deprecate('const', field.name, field.attrs, node.pos)
 			}
 		}
 		if builtin_type != ast.void_type {


### PR DESCRIPTION



<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
