### PR TITLE
db.sqlite: Fix exec_param_many bug

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -315,6 +315,9 @@ pub fn (db &DB) exec_param_many(query string, params []string) ![]Row {
 	for {
 		res = C.sqlite3_step(stmt)
 		if res != sqlite.sqlite_row {
+			if rows.len == 0 && is_error(res) {
+				return db.error_message(res, query)
+			}
 			break
 		}
 		mut row := Row{}

--- a/vlib/db/sqlite/sqlite_test.v
+++ b/vlib/db/sqlite/sqlite_test.v
@@ -95,3 +95,22 @@ fn test_alias_db() {
 	create_host(sqlite.connect(':memory:')!)!
 	assert true
 }
+
+fn test_exec_param_many() {
+	$if !linux {
+		return
+	}
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	assert db.is_open
+	db.exec('drop table if exists users')!
+	db.exec("create table users (id integer primary key, name text default '' unique);")!
+	db.exec("insert into users (name) values ('Sam')")!
+	db.exec_param_many('insert into users (id, name) values (?, ?)', [
+		'60',
+		'Sam',
+	]) or {
+		assert err.code() == 19 // constraint failure
+		return
+	}
+	assert false
+}


### PR DESCRIPTION
Fixes a bug where sqlite errors would not be caught through `exec_param_many` and it's associated methods.
Previously runtime failures like unique constraints and others would not be caught when using `exec_param_many`.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
