### PR TITLE
ci,tests: enable vdoc tests on linux; fix unintended line break

### DIFF
--- a/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
@@ -14,7 +14,8 @@ fn funky()
     - bar
     # test
     ########### deep test
-    #a shouldn't have a newline test
+    #a shouldn't have a newline
+    test
     
     | foo bar   |  yes   |
     |-----------|--------|

--- a/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/newlines/main.comments.out
@@ -14,8 +14,7 @@ fn funky()
     - bar
     # test
     ########### deep test
-    #a shouldn't have a newline
-    test
+    #a shouldn't have a newline test
     
     | foo bar   |  yes   |
     |-----------|--------|

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
@@ -74,7 +74,6 @@ fn auth_verify(secret string, token string) bool {
     
     ### Processing command line args
     
-    
     ```v
     import os
     

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.text
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.text
@@ -13,7 +13,6 @@ module main
     
     ### Processing command line args
     
-    
     ```v
     import os
     

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -85,7 +85,6 @@ const essential_list = [
 const skip_test_files = [
 	'do_not_remove',
 	'cmd/tools/vdoc/html_tag_escape_test.v', // can't locate local module: markdown
-	'cmd/tools/vdoc/tests/vdoc_file_test.v', // fails on Windows; order of output is not as expected
 	'vlib/context/deadline_test.v', // sometimes blocks
 	'vlib/context/onecontext/onecontext_test.v', // backtrace_symbols is missing
 	'vlib/db/mysql/mysql_orm_test.v', // mysql not installed
@@ -278,6 +277,7 @@ const skip_on_linux = [
 ]
 const skip_on_non_linux = [
 	'do_not_remove',
+	'cmd/tools/vdoc/tests/vdoc_file_test.v', // order of output is not as expected
 ]
 const skip_on_windows_msvc = [
 	'do_not_remove',

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -80,7 +80,7 @@ pub fn merge_doc_comments(comments []DocComment) string {
 				}
 				continue
 			}
-			if l.starts_with('```') {
+			if has_codeblock_quote {
 				if !is_codeblock && !last_ends_with_lb {
 					comment += '\n'
 				}

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -66,21 +66,26 @@ pub fn merge_doc_comments(comments []DocComment) string {
 	for cmt in doc_comments.reverse() {
 		line_loop: for line in cmt.split_into_lines() {
 			l := line.trim_left('\x01').trim_space()
+			last_ends_with_lb := comment.ends_with('\n')
+			if l == '' {
+				comment += if last_ends_with_lb { '\n' } else { '\n\n' }
+				next_on_newline = true
+				continue
+			}
+			has_codeblock_quote := l.starts_with('```')
 			if is_codeblock {
 				comment += l + '\n'
+				if has_codeblock_quote {
+					is_codeblock = !is_codeblock
+				}
 				continue
 			}
 			if l.starts_with('```') {
-				if !is_codeblock {
+				if !is_codeblock && !last_ends_with_lb {
 					comment += '\n'
 				}
 				comment += l + '\n'
 				is_codeblock = !is_codeblock
-				next_on_newline = true
-				continue
-			}
-			if l == '' {
-				comment += if comment.ends_with('\n') { '\n' } else { '\n\n' }
 				next_on_newline = true
 				continue
 			}


### PR DESCRIPTION
The PR enables vdoc tests.

vdoc is currently not test covered as it is skipped on all platforms. 

Enabling the tests on a working Linux platform - also what we use to deploy V docs - reveals that there currently is one failing test to fix.

- [x] fix tests
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
