### PR TITLE
checker: cleanup and simplify `check_ref_fields_initialized` methods

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -975,8 +975,7 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 			continue
 		}
 		sym := c.table.sym(field.typ)
-		if field.name.len > 0 && field.name[0].is_capital() && sym.info is ast.Struct
-			&& sym.language == .v {
+		if field.name.is_capital() && sym.info is ast.Struct && sym.language == .v {
 			// an embedded struct field
 			continue
 		}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -957,14 +957,11 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 // The goal is to give only a notice, not an error, for now. After a while,
 // when we change the notice to error, we can remove this temporary method.
 fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type, linked_name string, pos &token.Pos) {
-	if c.pref.translated || c.file.is_translated {
+	if (c.pref.translated || c.file.is_translated) || (struct_sym.language == .c
+		&& struct_sym.info is ast.Struct && struct_sym.info.is_typedef) {
 		return
 	}
-	if struct_sym.info is ast.Struct && struct_sym.language == .c && struct_sym.info.is_typedef {
-		return
-	}
-	fields := c.table.struct_fields(struct_sym)
-	for field in fields {
+	for field in c.table.struct_fields(struct_sym) {
 		if field.typ in checked_types {
 			continue
 		}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -965,10 +965,7 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 	}
 	fields := c.table.struct_fields(struct_sym)
 	for field in fields {
-		sym := c.table.sym(field.typ)
-		if field.name.len > 0 && field.name[0].is_capital() && sym.info is ast.Struct
-			&& sym.language == .v {
-			// an embedded struct field
+		if field.typ in checked_types {
 			continue
 		}
 		if field.typ.is_ptr() && !field.typ.has_flag(.shared_f) && !field.typ.has_flag(.option)
@@ -977,11 +974,14 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 				pos)
 			continue
 		}
+		sym := c.table.sym(field.typ)
+		if field.name.len > 0 && field.name[0].is_capital() && sym.info is ast.Struct
+			&& sym.language == .v {
+			// an embedded struct field
+			continue
+		}
 		if sym.info is ast.Struct {
 			if sym.language == .c && sym.info.is_typedef {
-				continue
-			}
-			if field.typ in checked_types {
 				continue
 			}
 			checked_types << field.typ

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -960,8 +960,7 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 	if c.pref.translated || c.file.is_translated {
 		return
 	}
-	if struct_sym.kind == .struct_ && struct_sym.language == .c
-		&& (struct_sym.info as ast.Struct).is_typedef {
+	if struct_sym.info is ast.Struct && struct_sym.language == .c && struct_sym.info.is_typedef {
 		return
 	}
 	fields := c.table.struct_fields(struct_sym)
@@ -978,8 +977,8 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 				pos)
 			continue
 		}
-		if sym.kind == .struct_ {
-			if sym.language == .c && (sym.info as ast.Struct).is_typedef {
+		if sym.info is ast.Struct {
+			if sym.language == .c && sym.info.is_typedef {
 				continue
 			}
 			if field.typ in checked_types {
@@ -988,8 +987,8 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 			checked_types << field.typ
 			c.check_ref_fields_initialized(sym, mut checked_types, '${linked_name}.${field.name}',
 				pos)
-		} else if sym.kind == .alias {
-			psym := c.table.sym((sym.info as ast.Alias).parent_type)
+		} else if sym.info is ast.Alias {
+			psym := c.table.sym(sym.info.parent_type)
 			if psym.kind == .struct_ {
 				checked_types << field.typ
 				c.check_ref_fields_initialized(psym, mut checked_types, '${linked_name}.${field.name}',

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -975,12 +975,12 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 			continue
 		}
 		sym := c.table.sym(field.typ)
-		if field.name.is_capital() && sym.info is ast.Struct && sym.language == .v {
-			// an embedded struct field
-			continue
-		}
 		if sym.info is ast.Struct {
 			if sym.language == .c && sym.info.is_typedef {
+				continue
+			}
+			if field.name.is_capital() && sym.language == .v {
+				// an embedded struct field
 				continue
 			}
 			checked_types << field.typ

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -909,19 +909,12 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 
 // Recursively check whether the struct type field is initialized
 fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type, linked_name string, pos &token.Pos) {
-	if c.pref.translated || c.file.is_translated {
+	if (c.pref.translated || c.file.is_translated) || (struct_sym.language == .c
+		&& struct_sym.info is ast.Struct && struct_sym.info.is_typedef) {
 		return
 	}
-	if struct_sym.kind == .struct_ && struct_sym.language == .c
-		&& (struct_sym.info as ast.Struct).is_typedef {
-		return
-	}
-	fields := c.table.struct_fields(struct_sym)
-	for field in fields {
-		sym := c.table.sym(field.typ)
-		if field.name.len > 0 && field.name[0].is_capital() && sym.info is ast.Struct
-			&& sym.language == .v {
-			// an embedded struct field
+	for field in c.table.struct_fields(struct_sym) {
+		if field.typ in checked_types {
 			continue
 		}
 		if field.typ.is_ptr() && !field.typ.has_flag(.shared_f) && !field.typ.has_flag(.option)
@@ -930,18 +923,20 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 				pos)
 			continue
 		}
-		if sym.kind == .struct_ {
-			if sym.language == .c && (sym.info as ast.Struct).is_typedef {
+		sym := c.table.sym(field.typ)
+		if sym.info is ast.Struct {
+			if sym.language == .c && sym.info.is_typedef {
 				continue
 			}
-			if field.typ in checked_types {
+			if field.name.is_capital() && sym.language == .v {
+				// an embedded struct field
 				continue
 			}
 			checked_types << field.typ
 			c.check_ref_fields_initialized(sym, mut checked_types, '${linked_name}.${field.name}',
 				pos)
-		} else if sym.kind == .alias {
-			psym := c.table.sym((sym.info as ast.Alias).parent_type)
+		} else if sym.info is ast.Alias {
+			psym := c.table.sym(sym.info.parent_type)
 			if psym.kind == .struct_ {
 				checked_types << field.typ
 				c.check_ref_fields_initialized(psym, mut checked_types, '${linked_name}.${field.name}',


### PR DESCRIPTION
Small cleanup of the checker method to reduce double checks, continue earlier/reduce load when possible and to improve future read-/maintainability. Tried building it up per commit in case this simplifies reviewing.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
