### PR TITLE
os: fix Process struct fields documentation applied to wrong field

### DIFF
--- a/vlib/os/process.v
+++ b/vlib/os/process.v
@@ -18,34 +18,20 @@ pub enum ProcessState {
 @[heap]
 pub struct Process {
 pub mut:
-	 // the process's command file path
-	filename string
-	// the PID of the process
-	pid      int
-	// the exit code of the process, != -1 *only* when status is .exited *and* the process was not aborted
-	code     int = -1
-	// the current status of the process
-	status ProcessState = .not_started
-	// if the process fails, contains the reason why
-	err              string
-	// the arguments that the command takes
-	args             []string
-	// the initial working folder of the process. When '', reuse the same folder as the parent process.
-	work_folder      string
-	// true, when the environment was customized with .set_environment
-	env_is_custom    bool
-	// the environment with which the process was started  (list of 'var=val')
-	env              []string
-	// when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
-	use_stdio_ctl    bool
-	// when true, the process will create a new process group, enabling .signal_pgkill()
-	use_pgroup       bool
-	// the stdio file descriptors for the child process, used only by the nix implementation
-	stdio_fd         [3]int
-	// the WProcess; used only by the windows implementation
-	wdata            voidptr
-	// sets a value indicating whether to start the process in a new window, The default is false; used only by the windows implementation
-	create_no_window bool
+	filename         string       // the process's command file path
+	pid              int          // the PID of the process
+	code             int = -1 // the exit code of the process, != -1 *only* when status is .exited *and* the process was not aborted
+	status           ProcessState = .not_started // the current status of the process
+	err              string       // if the process fails, contains the reason why
+	args             []string     // the arguments that the command takes
+	work_folder      string       // the initial working folder of the process. When '', reuse the same folder as the parent process.
+	env_is_custom    bool     // true, when the environment was customized with .set_environment
+	env              []string // the environment with which the process was started  (list of 'var=val')
+	use_stdio_ctl    bool     // when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
+	use_pgroup       bool     // when true, the process will create a new process group, enabling .signal_pgkill()
+	stdio_fd         [3]int   // the stdio file descriptors for the child process, used only by the nix implementation
+	wdata            voidptr  // the WProcess; used only by the windows implementation
+	create_no_window bool     // sets a value indicating whether to start the process in a new window, The default is false; used only by the windows implementation
 }
 
 // new_process - create a new process descriptor

--- a/vlib/os/process.v
+++ b/vlib/os/process.v
@@ -18,22 +18,34 @@ pub enum ProcessState {
 @[heap]
 pub struct Process {
 pub mut:
-	filename string // the process's command file path
-	pid      int    // the PID of the process
-	code     int = -1
+	 // the process's command file path
+	filename string
+	// the PID of the process
+	pid      int
 	// the exit code of the process, != -1 *only* when status is .exited *and* the process was not aborted
-	status ProcessState = .not_started
+	code     int = -1
 	// the current status of the process
-	err              string   // if the process fails, contains the reason why
-	args             []string // the arguments that the command takes
-	work_folder      string   // the initial working folder of the process. When '', reuse the same folder as the parent process.
-	env_is_custom    bool     // true, when the environment was customized with .set_environment
-	env              []string // the environment with which the process was started  (list of 'var=val')
-	use_stdio_ctl    bool     // when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
-	use_pgroup       bool     // when true, the process will create a new process group, enabling .signal_pgkill()
-	stdio_fd         [3]int   // the stdio file descriptors for the child process, used only by the nix implementation
-	wdata            voidptr  // the WProcess; used only by the windows implementation
-	create_no_window bool     // sets a value indicating whether to start the process in a new window, The default is false; used only by the windows implementation
+	status ProcessState = .not_started
+	// if the process fails, contains the reason why
+	err              string
+	// the arguments that the command takes
+	args             []string
+	// the initial working folder of the process. When '', reuse the same folder as the parent process.
+	work_folder      string
+	// true, when the environment was customized with .set_environment
+	env_is_custom    bool
+	// the environment with which the process was started  (list of 'var=val')
+	env              []string
+	// when true, then you can use p.stdin_write(), p.stdout_slurp() and p.stderr_slurp()
+	use_stdio_ctl    bool
+	// when true, the process will create a new process group, enabling .signal_pgkill()
+	use_pgroup       bool
+	// the stdio file descriptors for the child process, used only by the nix implementation
+	stdio_fd         [3]int
+	// the WProcess; used only by the windows implementation
+	wdata            voidptr
+	// sets a value indicating whether to start the process in a new window, The default is false; used only by the windows implementation
+	create_no_window bool
 }
 
 // new_process - create a new process descriptor


### PR DESCRIPTION
The fields of the `Process` struct in the `os` modules incorrectly have their documentation behind the field, instead of before. Example of what it currently looks like:
```V
pub struct Process {
pub mut:
        // ...
	pid      int    // the PID of the process
	code     int = -1
	// the exit code of the process, != -1 *only* when status is .exited *and* the process was not aborted
	// ...
}
```
This results in `code` incorrectly having the documentation associated with `pid`. This specific case is confusing in particular as both are integers and `code` could be mistaken for the `pid` after reading the associated comments.