### PR TITLE
checker: add test for iface embedding iface with erroneous implementation struct ref field init

### DIFF
--- a/vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.out
+++ b/vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.out
@@ -1,0 +1,9 @@
+vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.vv:21:3: error: `&Stream` incorrectly implements method `read` of interface `Refresher`: expected return type `!int`
+   19 |     s := &Stream{}
+   20 |     _ := &Server{
+   21 |         refresher: s
+      |         ~~~~~~~~~~~~
+   22 |     }
+   23 | }
+Details: main.Refresher has `fn read(x main.Refresher, buf []u8) !int`
+         main.Stream has `fn read(a main.Stream, buf []u8)`

--- a/vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.vv
+++ b/vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.vv
@@ -1,0 +1,23 @@
+interface Refresher {
+	Reader
+}
+
+interface Reader {
+	read(buf []u8) !int
+}
+
+struct Server {
+	refresher Refresher
+}
+
+struct Stream {}
+
+// Implementation is missing the return type.
+fn (a Stream) read(buf []u8) {}
+
+fn test_struct_init_with_interface_field() {
+	s := &Stream{}
+	_ := &Server{
+		refresher: s
+	}
+}


### PR DESCRIPTION
Due to a regression the following would result in a C error before #21030

```v
// iface_ref.v
interface Refresher {
	Reader
}

interface Reader {
	read(buf []u8) !int
}

struct Server {
	refresher Refresher
}

struct Stream {}

// Implementation is missing the return type.
fn (a Stream) read(buf []u8) {}

fn test_struct_init_with_interface_field() {
	s := &Stream{}
	_ := &Server{
		refresher: s
	}
}
```
With PR:
```
v self && v -cc gcc run ./iface_ref.v
```
```
iface_ref.v:20:3: error: `&Stream` incorrectly implements method `read` of interface `Refresher`: expected return type `!int`
   18 |     s := &Stream{}
   19 |     _ := &Server{
   20 |         refresher: s
      |         ~~~~~~~~~~~~
   21 |     }
   22 | }
Details: main.Refresher has `fn read(x main.Refresher, buf []u8) !int`
         main.Stream has `fn read(a main.Stream, buf []u8)`
```

Checking out the commiit before the fix:
```
git checkout aded18ad464bac4e74b0bd361ea10c39f72af382
v self && v -cc gcc run ./iface_ref.v
```
```
==================
iface_ref.01HS0XVCX1P510ZA68DED8G3TP.tmp.c:(.text+0x280f5): undefined reference to `I_main__Stream_to_Interface_main__Refresher'
collect2: error: ld returned 1 exit status
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.
```

Adding the rest should cover future regressions.
