### PR TITLE
cgen: add possibility to have a global hidden

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5996,6 +5996,9 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 	if node.attrs.contains('weak') {
 		attributes += 'VWEAK '
 	}
+	if node.attrs.contains('hidden') {
+		attributes += 'VHIDDEN '
+	}
 	if node.attrs.contains('export') {
 		attributes += 'VV_EXPORTED_SYMBOL '
 	}

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -421,6 +421,18 @@ const c_common_macros = '
 	#endif
 #endif
 
+#if !defined(VHIDDEN)
+	#define VHIDDEN __attribute__((visibility("hidden")))
+	#ifdef _MSC_VER
+		#undef VHIDDEN
+		#define VHIDDEN
+	#endif
+	#if defined(__MINGW32__) || defined(__MINGW64__)
+		#undef VHIDDEN
+		#define VHIDDEN
+	#endif
+#endif
+
 #if !defined(VNORETURN)
 	#if defined(__TINYC__)
 		#include <stdnoreturn.h>


### PR DESCRIPTION
Makes possible to declare:

```v
@[hidden]
__global __dso_handle = 0
```