### PR TITLE
fmt: fix type name on some cases

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -439,7 +439,7 @@ pub fn (x Expr) str() string {
 			return x.val.str()
 		}
 		CastExpr {
-			return '${x.typname}(${x.expr.str()})'
+			return '${global_table.type_to_str(x.typ)}(${x.expr.str()})'
 		}
 		CallExpr {
 			sargs := args2str(x.args)


### PR DESCRIPTION
Fix `&u8(foo)` formatting when formatting `ast.AsmIO`.

```v
asm amd64 {
			lock cmpxchgb '%1', '%2'
			; =a (rv)
			+m (*&u8(atom)) // this & is dropped without the PR
			; q (xchg)
			0 (cmp)
			; memory
		}
```