### PR TITLE
fmt: insert auto imports after shebang

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -97,9 +97,14 @@ pub fn fmt(file ast.File, mut table ast.Table, pref_ &pref.Preferences, is_debug
 		}
 		return res
 	}
-	source_for_imports := res[..f.import_pos] + f.out_imports.str()
-	source_after_imports := res[f.import_pos..]
-	return source_for_imports + source_after_imports
+	mut import_start_pos := f.import_pos
+	if stmt := file.stmts[1] {
+		if stmt is ast.ExprStmt && stmt.expr is ast.Comment
+			&& (stmt.expr as ast.Comment).text.starts_with('#!') {
+			import_start_pos = stmt.pos.len
+		}
+	}
+	return res[..import_start_pos] + f.out_imports.str() + res[import_start_pos..]
 }
 
 pub fn (mut f Fmt) process_file_imports(file &ast.File) {

--- a/vlib/v/fmt/tests/import_auto_with_shebang_expected.vv
+++ b/vlib/v/fmt/tests/import_auto_with_shebang_expected.vv
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S v
+
+import os
+
+os.join_path('a', 'b', 'c')

--- a/vlib/v/fmt/tests/import_auto_with_shebang_input.vv
+++ b/vlib/v/fmt/tests/import_auto_with_shebang_input.vv
@@ -1,0 +1,3 @@
+#!/usr/bin/env -S v
+os.join_path('a','b','c')
+


### PR DESCRIPTION
input:
```v
#!/usr/bin/env -S v
os.join_path('a','b')
```

formatting it:

current:
```v
import os

#!/usr/bin/env -S v

os.join_path('a', 'b')
```

after:
```v
#!/usr/bin/env -S v

import os

os.join_path('a', 'b')
```