### PR TITLE
strings/textscanner: fix off-by-one error in textscanner skip

### DIFF
--- a/vlib/strings/textscanner/textscanner.v
+++ b/vlib/strings/textscanner/textscanner.v
@@ -50,7 +50,7 @@ pub fn (mut ss TextScanner) next() int {
 // `skip()` does not return a result.
 @[inline]
 pub fn (mut ss TextScanner) skip() {
-	if ss.pos + 1 < ss.ilen {
+	if ss.pos < ss.ilen {
 		ss.pos++
 	}
 }

--- a/vlib/strings/textscanner/textscanner_test.js.v
+++ b/vlib/strings/textscanner/textscanner_test.js.v
@@ -31,6 +31,15 @@ fn test_skip() {
 	s.skip()
 	assert s.next() == `c`
 	assert s.next() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip()
+	assert s.peek() == `b`
+	s.skip()
+	assert s.peek() == `c`
+	s.skip()
+	assert s.peek() == -1
 }
 
 fn test_skip_n() {
@@ -38,6 +47,23 @@ fn test_skip_n() {
 	s.skip_n(2)
 	assert s.next() == `c`
 	assert s.next() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(2)
+	assert s.peek() == `c`
+	s.skip_n(2)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(3)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(4)
+	assert s.peek() == -1
 }
 
 fn test_peek() {

--- a/vlib/strings/textscanner/textscanner_test.v
+++ b/vlib/strings/textscanner/textscanner_test.v
@@ -31,6 +31,15 @@ fn test_skip() {
 	s.skip()
 	assert s.next() == `c`
 	assert s.next() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip()
+	assert s.peek() == `b`
+	s.skip()
+	assert s.peek() == `c`
+	s.skip()
+	assert s.peek() == -1
 }
 
 fn test_skip_n() {
@@ -38,6 +47,23 @@ fn test_skip_n() {
 	s.skip_n(2)
 	assert s.next() == `c`
 	assert s.next() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(2)
+	assert s.peek() == `c`
+	s.skip_n(2)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(3)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(4)
+	assert s.peek() == -1
 }
 
 fn test_peek() {


### PR DESCRIPTION
The skip function would not increment the current position if the current position was pointing to the last character in the input.  As a result, you could not skip to the end of input.  And, this means that you cannot detect end of input if you are using the skip function to move the current position forward.

Looking at the skip_n function, you can skip to the end of input.

This change makes skip and skip_n(1) work the same way and have the same semantics.

I have also updated the unit tests to detect proper behavior when reaching the end of input.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
