### PR TITLE
fmt: fix autoimport with sheband and comments above other imports

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -98,7 +98,8 @@ pub fn fmt(file ast.File, mut table ast.Table, pref_ &pref.Preferences, is_debug
 		return res
 	}
 	mut import_start_pos := f.import_pos
-	if stmt := file.stmts[1] {
+	if f.import_pos == 0 && file.stmts.len > 1 {
+		stmt := file.stmts[1]
 		if stmt is ast.ExprStmt && stmt.expr is ast.Comment
 			&& (stmt.expr as ast.Comment).text.starts_with('#!') {
 			import_start_pos = stmt.pos.len

--- a/vlib/v/fmt/tests/import_auto_with_shebang_and_comment_above_imports_expected.vv
+++ b/vlib/v/fmt/tests/import_auto_with_shebang_and_comment_above_imports_expected.vv
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S v
+
+// Comment
+import json
+os.join_path('', '')

--- a/vlib/v/fmt/tests/import_auto_with_shebang_and_comment_above_imports_input.vv
+++ b/vlib/v/fmt/tests/import_auto_with_shebang_and_comment_above_imports_input.vv
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S v
+
+// Comment
+import json
+import os
+
+os.join_path('', '')


### PR DESCRIPTION
Fixes where a current import like:

```v
#!/usr/bin/env -S v

// Comment
import json

os.join_path('', '')
```

Currently becomes
```v
#!/usr/bin/env -S v

import json
import os

// Comment
os.join_path('', '')
```

With the changes it should be formatted to
```v
#!/usr/bin/env -S v

// Comment
import json
import os

os.join_path('', '')
```