### PR TITLE
cgen: force C struct types which does not implement str() to be passed as ptr

### DIFF
--- a/vlib/builtin/wchar/wchar.c.v
+++ b/vlib/builtin/wchar/wchar.c.v
@@ -30,7 +30,11 @@ pub fn (a Character) == (b Character) bool {
 // to_rune creates a V rune, given a Character
 @[inline]
 pub fn (c Character) to_rune() rune {
-	return unsafe { *(&rune(&c)) }
+	$if windows {
+		return unsafe { *(&rune(&c)) } & 0xFFFF
+	} $else {
+		return unsafe { *(&rune(&c)) }
+	}
 }
 
 // from_rune creates a Character, given a V rune

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1717,7 +1717,7 @@ pub fn (t &TypeSymbol) str_method_info() (bool, bool, int) {
 			expects_ptr = sym_str_method.params[0].typ.is_ptr()
 		}
 	}
-	expects_ptr = expects_ptr || (t.language == .c && t.kind == .struct_)
+	expects_ptr = expects_ptr || t.is_c_struct()
 	return has_str_method, expects_ptr, nr_args
 }
 

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -934,6 +934,15 @@ pub fn (t &TypeSymbol) is_array_fixed() bool {
 	}
 }
 
+pub fn (t &TypeSymbol) is_c_struct() bool {
+	if t.info is Struct {
+		return t.language == .c
+	} else if t.info is Alias {
+		return global_table.final_sym(t.info.parent_type).is_c_struct()
+	}
+	return false
+}
+
 pub fn (t &TypeSymbol) is_array_fixed_ret() bool {
 	if t.info is ArrayFixed {
 		return t.info.is_fn_ret
@@ -1708,6 +1717,7 @@ pub fn (t &TypeSymbol) str_method_info() (bool, bool, int) {
 			expects_ptr = sym_str_method.params[0].typ.is_ptr()
 		}
 	}
+	expects_ptr = expects_ptr || (t.language == .c && t.kind == .struct_)
 	return has_str_method, expects_ptr, nr_args
 }
 

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1716,8 +1716,10 @@ pub fn (t &TypeSymbol) str_method_info() (bool, bool, int) {
 		if nr_args > 0 {
 			expects_ptr = sym_str_method.params[0].typ.is_ptr()
 		}
+	} else {
+		// C Struct which does not implement str() are passed as pointer to handle incomplete type
+		expects_ptr = t.is_c_struct()
 	}
-	expects_ptr = expects_ptr || t.is_c_struct()
 	return has_str_method, expects_ptr, nr_args
 }
 

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1111,7 +1111,7 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 		if !field_type.is_ptr() && field_type.has_option_or_result() {
 			method_str = '(*(${sym.name}*)it${op}${final_field_name}.data)'
 		} else {
-			method_str += '${prefix}it${op}${final_field_name}'
+			method_str = '${prefix}it${op}${final_field_name}'
 		}
 		if sym.kind == .bool {
 			return '${method_str} ? _SLIT("true") : _SLIT("false")', false

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1076,7 +1076,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 	fn_body.writeln('\t}));')
 }
 
-// c_struct_ptr generates the C struct ptr argument for .str() method
+// c_struct_ptr handles the C struct argument for .str() method
 @[inline]
 pub fn c_struct_ptr(sym &ast.TypeSymbol, typ ast.Type, expects_ptr bool) string {
 	if sym.is_c_struct() {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1084,7 +1084,7 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 	deref, _ := deref_kind(expects_ptr, field_type.is_ptr(), field_type)
 	final_field_name := if lang == .c { field_name } else { c_name(field_name) }
 	op := if lang == .c { '->' } else { '.' }
-	prefix := if lang == .c && !field_type.is_ptr() { '&' } else { '' }
+	prefix := if sym.language == .c && !field_type.is_ptr() { '&' } else { '' }
 	if sym.kind == .enum_ {
 		return '${fn_name}(${deref}(it${op}${final_field_name}))', true
 	} else if _field_type.has_flag(.option) || should_use_indent_func(sym.kind) {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1126,7 +1126,7 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 		if !field_type.is_ptr() && field_type.has_option_or_result() {
 			method_str = '(*(${sym.name}*)it${op}${final_field_name}.data)'
 		} else {
-			method_str = '${prefix}it${op}${final_field_name}'
+			method_str = 'it${op}${final_field_name}'
 		}
 		if sym.kind == .bool {
 			return '${method_str} ? _SLIT("true") : _SLIT("false")', false

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2458,7 +2458,6 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			lock g.referenced_fns {
 				g.referenced_fns[fname] = true
 			}
-			fname = '/*${exp_sym}*/${fname}'
 			if exp_sym.info.is_generic {
 				fname = g.generic_fn_name(exp_sym.info.concrete_types, fname)
 			}

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -181,11 +181,23 @@ fn (mut g Gen) dump_expr_definitions() {
 				surrounder.add('\tstring value = isnil(&dump_arg.data) ? _SLIT("nil") : ${to_string_fn_name}(${deref}dump_arg);',
 					'\tstring_free(&value);')
 			} else {
-				surrounder.add('\tstring value = (dump_arg == NULL) ? _SLIT("nil") : ${to_string_fn_name}(${deref}dump_arg);',
+				final_sym := g.table.final_sym(dump_type)
+				prefix := if final_sym.language == .c && final_sym.kind == .struct_ {
+					'&'
+				} else {
+					deref
+				}
+				surrounder.add('\tstring value = (dump_arg == NULL) ? _SLIT("nil") : ${to_string_fn_name}(${prefix}dump_arg);',
 					'\tstring_free(&value);')
 			}
 		} else {
-			surrounder.add('\tstring value = ${to_string_fn_name}(${deref}dump_arg);',
+			final_sym := g.table.final_sym(dump_type)
+			prefix := if final_sym.language == .c && final_sym.kind == .struct_ {
+				'&'
+			} else {
+				deref
+			}
+			surrounder.add('\tstring value = ${to_string_fn_name}(${prefix}dump_arg);',
 				'\tstring_free(&value);')
 		}
 		surrounder.add('

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -182,7 +182,7 @@ fn (mut g Gen) dump_expr_definitions() {
 					'\tstring_free(&value);')
 			} else {
 				prefix := if dump_sym.is_c_struct() {
-					c_struct_ptr(dump_sym, dump_type)
+					c_struct_ptr(dump_sym, dump_type, str_method_expects_ptr)
 				} else {
 					deref
 				}
@@ -191,7 +191,7 @@ fn (mut g Gen) dump_expr_definitions() {
 			}
 		} else {
 			prefix := if dump_sym.is_c_struct() {
-				c_struct_ptr(dump_sym, dump_type)
+				c_struct_ptr(dump_sym, dump_type, str_method_expects_ptr)
 			} else {
 				deref
 			}

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -181,9 +181,8 @@ fn (mut g Gen) dump_expr_definitions() {
 				surrounder.add('\tstring value = isnil(&dump_arg.data) ? _SLIT("nil") : ${to_string_fn_name}(${deref}dump_arg);',
 					'\tstring_free(&value);')
 			} else {
-				final_sym := g.table.final_sym(dump_type)
-				prefix := if final_sym.language == .c && final_sym.kind == .struct_ {
-					'&'
+				prefix := if dump_sym.is_c_struct() {
+					c_struct_ptr(dump_sym, dump_type)
 				} else {
 					deref
 				}
@@ -191,9 +190,8 @@ fn (mut g Gen) dump_expr_definitions() {
 					'\tstring_free(&value);')
 			}
 		} else {
-			final_sym := g.table.final_sym(dump_type)
-			prefix := if final_sym.language == .c && final_sym.kind == .struct_ {
-				'&'
+			prefix := if dump_sym.is_c_struct() {
+				c_struct_ptr(dump_sym, dump_type)
 			} else {
 				deref
 			}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -162,7 +162,12 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		} else if is_ptr && typ.has_flag(.option) {
 			g.write('*(${g.typ(typ)}*)&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
-			g.write('*'.repeat(typ.nr_muls()))
+			if sym.language == .c {
+				ref_or_deref := if typ.nr_muls() == 0 { '&' } else { '*'.repeat(typ.nr_muls() - 1) }
+				g.write(ref_or_deref)
+			} else {
+				g.write('*'.repeat(typ.nr_muls()))
+			}
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -162,12 +162,15 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		} else if is_ptr && typ.has_flag(.option) {
 			g.write('*(${g.typ(typ)}*)&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
-			if sym.language == .c {
+			if sym.language == .c && sym.kind == .struct_ {
 				ref_or_deref := if typ.nr_muls() == 0 { '&' } else { '*'.repeat(typ.nr_muls() - 1) }
 				g.write(ref_or_deref)
 			} else {
 				g.write('*'.repeat(typ.nr_muls()))
 			}
+		} else if sym.language == .c && sym.kind == .struct_ {
+			ref_or_deref := if typ.nr_muls() == 0 { '&' } else { '*'.repeat(typ.nr_muls() - 1) }
+			g.write(ref_or_deref)
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -162,15 +162,13 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		} else if is_ptr && typ.has_flag(.option) {
 			g.write('*(${g.typ(typ)}*)&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
-			if sym.language == .c && sym.kind == .struct_ {
-				ref_or_deref := if typ.nr_muls() == 0 { '&' } else { '*'.repeat(typ.nr_muls() - 1) }
-				g.write(ref_or_deref)
+			if sym.is_c_struct() {
+				g.write(c_struct_ptr(sym, typ))
 			} else {
 				g.write('*'.repeat(typ.nr_muls()))
 			}
-		} else if sym.language == .c && sym.kind == .struct_ {
-			ref_or_deref := if typ.nr_muls() == 0 { '&' } else { '*'.repeat(typ.nr_muls() - 1) }
-			g.write(ref_or_deref)
+		} else if sym.is_c_struct() {
+			g.write(c_struct_ptr(sym, typ))
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {
@@ -208,9 +206,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 			} else if (!str_method_expects_ptr && is_ptr && !is_shared) || is_var_mut {
 				g.write('*')
 			} else {
-				final_sym := g.table.final_sym(typ)
-				if final_sym.language == .c && final_sym.kind == .struct_ {
-					g.write('&')
+				if sym.is_c_struct() {
+					g.write(c_struct_ptr(sym, typ))
 				}
 			}
 			g.expr_with_cast(expr, typ, typ)

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -151,7 +151,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {
-			if is_dump_expr || expr is ast.CallExpr {
+			if is_dump_expr {
 				g.write('ADDR(${g.typ(typ)}, ')
 				defer {
 					g.write(')')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -151,7 +151,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {
-			if is_dump_expr {
+			if is_dump_expr || expr is ast.CallExpr {
 				g.write('ADDR(${g.typ(typ)}, ')
 				defer {
 					g.write(')')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -151,7 +151,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		g.write('${str_fn_name}(')
 		if str_method_expects_ptr && !is_ptr {
-			if is_dump_expr {
+			if is_dump_expr || (g.pref.ccompiler_type != .tinyc && expr is ast.CallExpr) {
 				g.write('ADDR(${g.typ(typ)}, ')
 				defer {
 					g.write(')')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -204,6 +204,11 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				g.write('&')
 			} else if (!str_method_expects_ptr && is_ptr && !is_shared) || is_var_mut {
 				g.write('*')
+			} else {
+				final_sym := g.table.final_sym(typ)
+				if final_sym.language == .c && final_sym.kind == .struct_ {
+					g.write('&')
+				}
 			}
 			g.expr_with_cast(expr, typ, typ)
 		} else if typ.has_flag(.option) {

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -163,12 +163,12 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 			g.write('*(${g.typ(typ)}*)&')
 		} else if !str_method_expects_ptr && !is_shared && (is_ptr || is_var_mut) {
 			if sym.is_c_struct() {
-				g.write(c_struct_ptr(sym, typ))
+				g.write(c_struct_ptr(sym, typ, str_method_expects_ptr))
 			} else {
 				g.write('*'.repeat(typ.nr_muls()))
 			}
 		} else if sym.is_c_struct() {
-			g.write(c_struct_ptr(sym, typ))
+			g.write(c_struct_ptr(sym, typ, str_method_expects_ptr))
 		}
 		if expr is ast.ArrayInit {
 			if expr.is_fixed {
@@ -207,7 +207,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				g.write('*')
 			} else {
 				if sym.is_c_struct() {
-					g.write(c_struct_ptr(sym, typ))
+					g.write(c_struct_ptr(sym, typ, str_method_expects_ptr))
 				}
 			}
 			g.expr_with_cast(expr, typ, typ)

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -61,7 +61,6 @@ fn (mut g Gen) str_format(node ast.StringInterLiteral, i int, fmts []u8) (u64, s
 	mut remove_tail_zeros := false
 	fspec := fmts[i]
 	mut fmt_type := StrIntpType.si_no_str
-	g.write('/*${fspec} ${sym}*/')
 	// upper cases
 	if (fspec - `A`) <= (`Z` - `A`) {
 		upper_case = true

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -713,10 +713,16 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	mut is_auto_rec := false
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
-		if !rec.is_mut && !rec.typ.is_ptr() && info.fields.len > 8 {
+
+		// struct with more than 8 fields or C structs are passed as pointer
+		if !rec.is_mut && !rec.typ.is_ptr() && (type_sym.language == .c || info.fields.len > 8) {
 			rec.typ = rec.typ.ref()
 			is_auto_rec = true
 		}
+	} else if !rec.typ.is_ptr() && type_sym.is_c_struct() {
+		// C struct are passed as pointer
+		rec.typ = rec.typ.ref()
+		is_auto_rec = true
 	}
 
 	if rec.language != .v {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -713,7 +713,6 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	mut is_auto_rec := false
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
-
 		if !rec.is_mut && !rec.typ.is_ptr() && info.fields.len > 8 {
 			rec.typ = rec.typ.ref()
 			is_auto_rec = true

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -714,15 +714,10 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 	if type_sym.kind == .struct_ {
 		info := type_sym.info as ast.Struct
 
-		// struct with more than 8 fields or C structs are passed as pointer
-		if !rec.is_mut && !rec.typ.is_ptr() && (type_sym.language == .c || info.fields.len > 8) {
+		if !rec.is_mut && !rec.typ.is_ptr() && info.fields.len > 8 {
 			rec.typ = rec.typ.ref()
 			is_auto_rec = true
 		}
-	} else if !rec.typ.is_ptr() && type_sym.is_c_struct() {
-		// C struct are passed as pointer
-		rec.typ = rec.typ.ref()
-		is_auto_rec = true
 	}
 
 	if rec.language != .v {

--- a/vlib/v/tests/c_structs/cstruct.h
+++ b/vlib/v/tests/c_structs/cstruct.h
@@ -2,3 +2,11 @@
 struct Abc {
    int field;
 };
+
+typedef struct Test2 {
+
+} Test2;
+
+typedef struct Test1 {
+    Test2 a;
+} Test1;

--- a/vlib/v/tests/c_structs/cstruct.h
+++ b/vlib/v/tests/c_structs/cstruct.h
@@ -4,7 +4,7 @@ struct Abc {
 };
 
 typedef struct Test2 {
-
+    int a;
 } Test2;
 
 typedef struct Test1 {

--- a/vlib/v/tests/c_structs/cstruct_str_test.v
+++ b/vlib/v/tests/c_structs/cstruct_str_test.v
@@ -1,0 +1,50 @@
+#include "@VMODROOT/cstruct.h"
+
+@[typedef]
+struct C.Test2 {}
+
+@[typedef]
+struct C.Test1 {
+	a C.Test2
+}
+
+fn (s C.Test2) str() string {
+	return 'test2'
+}
+
+fn (s C.Test1) get() C.Test1 {
+	return s
+}
+
+fn (s C.Test1) s() string {
+	return '.${s.get()}.'
+}
+
+type TestAlias = C.Test2
+
+fn (s TestAlias) str() string {
+	return 'test_alias'
+}
+
+fn (s TestAlias) get() TestAlias {
+	return s
+}
+
+fn test_main() {
+	x := unsafe { &C.Test1(malloc(1024)) }
+	println(x)
+	assert dump('${x}') == '&C.Test1{
+    a: test2
+}'
+	println('.${x.get()}.${x.s()}')
+
+	y := unsafe { &TestAlias(malloc(1024)) }
+	println(y)
+	assert dump('${y}') == '&test_alias'
+	println('.${y.get()}.')
+
+	w := TestAlias(*y)
+	assert dump(w.str()) == 'test_alias'
+
+	assert true
+}


### PR DESCRIPTION
Fix #21053