### PR TITLE
tools.fmt: extend exit codes to allow spotting unformatted files next to internal errors

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -99,7 +99,7 @@ fn main() {
 		}
 	}
 	mut errors := 0
-	mut internal_error_code := 0
+	mut has_internal_error := false
 	for file in files {
 		fpath := os.real_path(file)
 		mut worker_command_array := cli_args_no_files.clone()
@@ -112,7 +112,8 @@ fn main() {
 			eprintln(worker_result.output)
 			if worker_result.exit_code == 1 {
 				eprintln('Internal vfmt error while formatting file: ${file}.')
-				internal_error_code = 128
+				has_internal_error = true
+				continue
 			}
 			errors++
 			continue
@@ -131,15 +132,17 @@ fn main() {
 		}
 		errors++
 	}
+	ecode := if has_internal_error { 5 } else { 0 }
 	if errors > 0 {
 		eprintln('Encountered a total of: ${errors} formatting errors.')
 		match true {
-			foptions.is_noerror { exit(0 + internal_error_code) }
-			foptions.is_verify { exit(1 + internal_error_code) }
-			foptions.is_c { exit(2 + internal_error_code) }
-			else { exit(1 + internal_error_code) }
+			foptions.is_noerror { exit(0 + ecode) }
+			foptions.is_verify { exit(1 + ecode) }
+			foptions.is_c { exit(2 + ecode) }
+			else { exit(1 + ecode) }
 		}
 	}
+	exit(ecode)
 }
 
 fn setup_preferences_and_table() (&pref.Preferences, &ast.Table) {

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -99,6 +99,7 @@ fn main() {
 		}
 	}
 	mut errors := 0
+	mut internal_error_code := 0
 	for file in files {
 		fpath := os.real_path(file)
 		mut worker_command_array := cli_args_no_files.clone()
@@ -111,6 +112,7 @@ fn main() {
 			eprintln(worker_result.output)
 			if worker_result.exit_code == 1 {
 				eprintln('Internal vfmt error while formatting file: ${file}.')
+				internal_error_code = 128
 			}
 			errors++
 			continue
@@ -130,17 +132,13 @@ fn main() {
 		errors++
 	}
 	if errors > 0 {
-		eprintln('Encountered a total of: ${errors} errors.')
-		if foptions.is_noerror {
-			exit(0)
+		eprintln('Encountered a total of: ${errors} formatting errors.')
+		match true {
+			foptions.is_noerror { exit(0 + internal_error_code) }
+			foptions.is_verify { exit(1 + internal_error_code) }
+			foptions.is_c { exit(2 + internal_error_code) }
+			else { exit(1 + internal_error_code) }
 		}
-		if foptions.is_verify {
-			exit(1)
-		}
-		if foptions.is_c {
-			exit(2)
-		}
-		exit(1)
 	}
 }
 


### PR DESCRIPTION
This extends v fmts exit codes in case of errors. This way it would allow to spot if there are unformatted files next to internal errors, at least it would be easily checkable by a script based on the error code.  
E.g. a current use case would be using v fmt with with v-analyzer and encountering internal vfmt erros.
