### PR TITLE
fmt: fix formatting for imports of submodule from module src dir

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -382,12 +382,14 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 	normalized_mod := if f.inside_vmodules {
 		imp.source_name
+	} else if imp.mod.len == 0 {
+		imp.alias
 	} else {
-		mod := if imp.mod.len == 0 { imp.alias } else { imp.mod }
-		if mod.starts_with('src.') {
-			mod.all_after('src.')
+		mod_last := imp.mod.all_after_last('.')
+		if imp.source_name == mod_last {
+			mod_last
 		} else {
-			mod
+			imp.mod
 		}
 	}
 	is_diff := imp.alias != normalized_mod && !normalized_mod.ends_with('.' + imp.alias)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -384,7 +384,11 @@ pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 		imp.source_name
 	} else {
 		mod := if imp.mod.len == 0 { imp.alias } else { imp.mod }
-		mod.all_after('src.') // Ignore the 'src.' folder prefix since src/ folder is root of code
+		if mod.starts_with('src.') {
+			mod.all_after('src.')
+		} else {
+			mod
+		}
 	}
 	is_diff := imp.alias != normalized_mod && !normalized_mod.ends_with('.' + imp.alias)
 	mut imp_alias_suffix := if is_diff { ' as ${imp.alias}' } else { '' }

--- a/vlib/v/fmt/tests/import_submod_from_vmodule_src_dir_keep.vv
+++ b/vlib/v/fmt/tests/import_submod_from_vmodule_src_dir_keep.vv
@@ -1,0 +1,1 @@
+import foo.bar.src.baz


### PR DESCRIPTION
Resolves #19799

With the linked PR vfmt won't break the import anymore. I think, since it's a working import it's okay when fmt just keeps it for now. Eventually we can check if a module placed in the `src` dir of a parent module is recognize when importing it without the src dir like `import artemkakun.textproc.punctuation` and let vfmt do the job of removing the `src.` part - currently, the module would not be found.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
