### PR TITLE
parser,fmt: inform about invalid interop function bodies instead of removing them

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -577,7 +577,7 @@ run them via `v file.v` instead',
 	mut stmts := []ast.Stmt{}
 	body_start_pos := p.tok.pos()
 	if p.tok.kind == .lcbr {
-		if language != .v && language != .js {
+		if language != .v {
 			p.error_with_pos('interop functions cannot have a body', body_start_pos)
 		}
 		p.inside_fn = true


### PR DESCRIPTION
Fixes #12966

Where formatting
```v
fn JS.state_is_ready_on_leave(retval int) {
	println('Hooked callback')
}
```
results in
```v
fn JS.state_is_ready_on_leave(retval int)
```

With the changes it would throw an error instead
```
error: interop functions cannot have a body
    1 | fn JS.state_is_ready_on_leave(retval int) {
      |                                           ^
    2 |     println('Hooked callback')
    3 | }
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
