### PR TITLE
ci: update gh action repository name

### DIFF
--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get short tag name
-        uses: jungwinter/split@v2
+        uses: winterjung/split@v2
         id: split
         with:
           msg: ${{ github.ref }}
@@ -181,7 +181,7 @@ jobs:
           name: ${{ matrix.version }}
           path: ./${{ matrix.version }}
       - name: Get short tag name
-        uses: jungwinter/split@v2
+        uses: winterjung/split@v2
         id: split
         with:
           msg: ${{ github.ref }}


### PR DESCRIPTION
The person renamed their Github account.
Currently the old name is redirecting to the new name, but someone already took the old name and just has to create a new repository with the same name for us to have a problem.

See https://github.com/winterjung/split/issues/23