### PR TITLE
vdoc,tests: detect expected files from input instead of hardcoding names

### DIFF
--- a/cmd/tools/vdoc/tests/testdata/basic/basic.comments.out
+++ b/cmd/tools/vdoc/tests/testdata/basic/basic.comments.out
@@ -1,7 +1,9 @@
-module main
+module basic
 
 const source_root = 'temp' // some const
 const another = int(5)
 const windowpos_undefined_mask = C.SDL_WINDOWPOS_UNDEFINED_MASK //   0x1FFF0000u
+    Used to indicate that you don't care what the window position is.
 const windowpos_undefined = C.SDL_WINDOWPOS_UNDEFINED
 fn funky()
+    funky - comment for function below

--- a/cmd/tools/vdoc/tests/testdata/basic/basic.out
+++ b/cmd/tools/vdoc/tests/testdata/basic/basic.out
@@ -1,9 +1,7 @@
-module main
+module basic
 
 const source_root = 'temp' // some const
 const another = int(5)
 const windowpos_undefined_mask = C.SDL_WINDOWPOS_UNDEFINED_MASK //   0x1FFF0000u
-    Used to indicate that you don't care what the window position is.
 const windowpos_undefined = C.SDL_WINDOWPOS_UNDEFINED
 fn funky()
-    funky - comment for function below

--- a/cmd/tools/vdoc/tests/testdata/basic/basic.v
+++ b/cmd/tools/vdoc/tests/testdata/basic/basic.v
@@ -1,3 +1,5 @@
+module basic
+
 pub const source_root = 'temp' // some const
 
 pub const another = int(5)

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -62,37 +62,20 @@ fn check_path(dir string, tests []string) int {
 		qpath := os.quoted_path(path)
 		path_no_ext := path.all_before_last('.')
 		print(path + ' ')
-		fails += check_output(
-			'${vexe} doc ${qpath}',
-			path_no_ext + '.out',
-		)
-		fails += check_output(
-			'${vexe} doc -comments ${qpath}',
-			path_no_ext + '.unsorted.out',
+		fails += check_output('${vexe} doc ${qpath}', path_no_ext + '.out')
+		fails += check_output('${vexe} doc -comments ${qpath}', '${path_no_ext}.unsorted.out',
 			should_sort: false
 		)
-		fails += check_output(
-			'${vexe} doc -comments ${qpath}',
-			path_no_ext + '.comments.out'
-		)
-		fails += check_output(
-			'${vexe} doc -readme -comments ${qpath}',
-			path_no_ext + '.readme.comments.out'
-		)
+		fails += check_output('${vexe} doc -comments ${qpath}', '${path_no_ext}.comments.out')
+		fails += check_output('${vexe} doc -readme -comments ${qpath}', '${path_no_ext}.readme.comments.out')
 		// test the main 3 different formats:
 		program_dir := os.quoted_path(if os.is_file(path) { os.dir(path) } else { path })
-		fails += check_output(
-			'${vexe} doc -f html -o - -html-only-contents -readme -comments ${program_dir}',
-			path_no_ext + '.html'
-		)
-		fails += check_output(
-			'${vexe} doc -f ansi -o - -html-only-contents -readme -comments ${program_dir}',
-			path_no_ext + '.ansi'
-		)
-		fails += check_output(
-			'${vexe} doc -f text -o - -html-only-contents -readme -comments ${program_dir}',
-			path_no_ext + '.text'
-		)
+		fails += check_output('${vexe} doc -f html -o - -html-only-contents -readme -comments ${program_dir}',
+			'${path_no_ext}.html')
+		fails += check_output('${vexe} doc -f ansi -o - -html-only-contents -readme -comments ${program_dir}',
+			'${path_no_ext}.ansi')
+		fails += check_output('${vexe} doc -f text -o - -html-only-contents -readme -comments ${program_dir}',
+			'${path_no_ext}.text')
 		//
 		total_fails += fails
 		if fails == 0 {
@@ -128,7 +111,7 @@ fn clean_line_endings(s string) string {
 
 @[params]
 struct CheckOutputParams {
-	should_sort   bool   = true
+	should_sort bool = true
 }
 
 fn check_output(cmd string, out_path string, opts CheckOutputParams) int {

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -4,12 +4,10 @@ import term
 import v.util.vtest
 import v.util.diff
 
-const vexe = os.quoted_path(@VEXE)
-
-const vroot = @VMODROOT
-
+const vexe_path = @VEXE
+const vexe = os.quoted_path(vexe_path)
+const vroot = os.dir(vexe_path)
 const diff_cmd = find_diff_cmd()
-
 const should_autofix = os.getenv('VAUTOFIX') != ''
 
 fn find_diff_cmd() string {
@@ -62,44 +60,38 @@ fn check_path(dir string, tests []string) int {
 	for path in paths {
 		mut fails := 0
 		qpath := os.quoted_path(path)
+		path_no_ext := path.all_before_last('.')
 		print(path + ' ')
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc ${qpath}'
-			out_filename: 'main.out'
+			'${vexe} doc ${qpath}',
+			path_no_ext + '.out',
 		)
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc -comments ${qpath}'
-			out_filename: 'main.unsorted.out'
+			'${vexe} doc -comments ${qpath}',
+			path_no_ext + '.unsorted.out',
 			should_sort: false
 		)
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc -comments ${qpath}'
-			out_filename: 'main.comments.out'
+			'${vexe} doc -comments ${qpath}',
+			path_no_ext + '.comments.out'
 		)
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc -readme -comments ${qpath}'
-			out_filename: 'main.readme.comments.out'
+			'${vexe} doc -readme -comments ${qpath}',
+			path_no_ext + '.readme.comments.out'
 		)
 		// test the main 3 different formats:
 		program_dir := os.quoted_path(if os.is_file(path) { os.dir(path) } else { path })
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc -f html -o - -html-only-contents -readme -comments ${program_dir}'
-			out_filename: 'main.html'
+			'${vexe} doc -f html -o - -html-only-contents -readme -comments ${program_dir}',
+			path_no_ext + '.html'
 		)
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc -f ansi -o - -html-only-contents -readme -comments ${program_dir}'
-			out_filename: 'main.ansi'
+			'${vexe} doc -f ansi -o - -html-only-contents -readme -comments ${program_dir}',
+			path_no_ext + '.ansi'
 		)
 		fails += check_output(
-			program: path
-			cmd: '${vexe} doc -f text -o - -html-only-contents -readme -comments ${program_dir}'
-			out_filename: 'main.text'
+			'${vexe} doc -f text -o - -html-only-contents -readme -comments ${program_dir}',
+			path_no_ext + '.text'
 		)
 		//
 		total_fails += fails
@@ -136,24 +128,19 @@ fn clean_line_endings(s string) string {
 
 @[params]
 struct CheckOutputParams {
-	program       string = 'some/dir/main.v'
-	cmd           string = 'v doc'
-	main_filename string = 'main.v'
-	out_filename  string = 'main.out'
 	should_sort   bool   = true
 }
 
-fn check_output(params CheckOutputParams) int {
-	out_file_path := params.program.replace(params.main_filename, params.out_filename)
-	if !os.exists(out_file_path) {
+fn check_output(cmd string, out_path string, opts CheckOutputParams) int {
+	if !os.exists(out_path) {
 		return 0
 	}
 	mut fails := 0
-	mut expected := os.read_file(out_file_path) or { panic(err) }
+	mut expected := os.read_file(out_path) or { panic(err) }
 	expected = clean_line_endings(expected)
 
-	os.setenv('VDOC_SORT', params.should_sort.str(), true)
-	res := os.execute(params.cmd)
+	os.setenv('VDOC_SORT', opts.should_sort.str(), true)
+	res := os.execute(cmd)
 
 	if res.exit_code < 0 {
 		panic(res.output)
@@ -161,13 +148,13 @@ fn check_output(params CheckOutputParams) int {
 	found := clean_line_endings(res.output)
 	if expected != found {
 		print_compare(expected, found)
-		eprintln('>>>           cmd: VDOC_SORT=${params.should_sort} ${params.cmd}')
-		eprintln('>>> out_file_path: `${out_file_path}`')
-		eprintln('>>>           fix: VDOC_SORT=${params.should_sort} ${params.cmd} > ${out_file_path}')
+		eprintln('>>>           cmd: VDOC_SORT=${opts.should_sort} ${cmd}')
+		eprintln('>>> out_file_path: `${out_path}`')
+		eprintln('>>>           fix: VDOC_SORT=${opts.should_sort} ${cmd} > ${out_path}')
 		fails++
 	}
 	if should_autofix {
-		os.write_file(out_file_path, res.output) or {}
+		os.write_file(out_path, res.output) or {}
 	}
 	return fails
 }


### PR DESCRIPTION
The PR extends vdoc tests while also simplifying the process of adding test files with modules/filenames other than main. This allows for a simpler inclusion of imho more "natural" use cases, as hared modules like libraries are the larger user base for public functions with generated documentation. It also updates one of the tests to make use of this new functionality. The changes should allow to tests vdoc functionality more easily when solidifying and extending it.