### PR TITLE
v.util: use tmp instead of cache dir for temporary diff files

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -84,14 +84,16 @@ pub fn color_compare_files(diff_cmd string, file1 string, file2 string) string {
 }
 
 pub fn color_compare_strings(diff_cmd string, unique_prefix string, expected string, found string) string {
-	cdir := os.join_path_single(os.cache_dir(), unique_prefix)
-	os.mkdir(cdir) or {}
+	tmp_dir := os.join_path_single(os.vtmp_dir(), unique_prefix)
+	os.mkdir(tmp_dir) or {}
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
 	ctime := time.sys_mono_now()
-	e_file := os.join_path_single(cdir, '${ctime}.expected.txt')
-	f_file := os.join_path_single(cdir, '${ctime}.found.txt')
+	e_file := os.join_path_single(tmp_dir, '${ctime}.expected.txt')
+	f_file := os.join_path_single(tmp_dir, '${ctime}.found.txt')
 	os.write_file(e_file, expected) or { panic(err) }
 	os.write_file(f_file, found) or { panic(err) }
 	res := color_compare_files(diff_cmd, e_file, f_file)
-	os.rmdir_all(cdir) or {}
 	return res
 }


### PR DESCRIPTION
For the temporary diff files we can use the temp instead of the cache directory 
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
