### PR TITLE
cgen, parser: fix option as possible match case for sumtype

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -77,7 +77,9 @@ fn (mut g Gen) gen_sumtype_equality_fn(left_type ast.Type) string {
 		left_arg := g.read_field(left_type, name, 'a')
 		right_arg := g.read_field(left_type, name, 'b')
 
-		if variant.sym.kind == .string {
+		if variant.typ.has_flag(.option) {
+			fn_builder.writeln('\t\treturn ((*${left_arg}).state == 2 && (*${right_arg}).state == 2) || !memcmp(&(*${left_arg}).data, &(*${right_arg}).data, sizeof(${g.base_type(variant.typ)}));')
+		} else if variant.sym.kind == .string {
 			fn_builder.writeln('\t\treturn string__eq(*${left_arg}, *${right_arg});')
 		} else if variant.sym.kind == .sum_type && !typ.is_ptr() {
 			eq_fn := g.gen_sumtype_equality_fn(typ)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6425,6 +6425,13 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				struct_names[name] = true
 				g.typedefs.writeln('typedef struct ${name} ${name};')
 				g.type_definitions.writeln('')
+
+				opt_types := sym.info.variants.filter(it.has_flag(.option))
+				for opt_type in opt_types {
+					// Option sum types are declared as _option_xx_ptr must be declared forward
+					g.options_forward << g.typ(opt_type.clear_option_and_result().set_nr_muls(1))
+				}
+
 				g.type_definitions.writeln('// Union sum type ${name} = ')
 				for variant in sym.info.variants {
 					g.type_definitions.writeln('//          | ${variant:4d} = ${g.typ(variant.idx()):-20s}')

--- a/vlib/v/tests/option_generic_sumtype_test.v
+++ b/vlib/v/tests/option_generic_sumtype_test.v
@@ -1,0 +1,17 @@
+struct Undefined {}
+
+type Foo[T] = ?T | Undefined
+
+@[params]
+struct Bar {
+	x Foo[bool] = Undefined{}
+}
+
+fn f(b Bar) Bar {
+	return dump(b)
+}
+
+fn test_main() {
+	a := f()
+	assert a == Bar{}
+}

--- a/vlib/v/tests/option_sum_type_test.v
+++ b/vlib/v/tests/option_sum_type_test.v
@@ -11,7 +11,7 @@ fn is_opt(f Foo) bool {
 	}
 }
 
-fn main() {
+fn test_main() {
 	dump(is_opt(Foo(?Bar(none))))
 	dump(is_opt(Foo(Baz{})))
 }

--- a/vlib/v/tests/option_sum_type_test.v
+++ b/vlib/v/tests/option_sum_type_test.v
@@ -1,0 +1,23 @@
+fn is_opt(f Foo) bool {
+	return match f {
+		Baz {
+			false
+		}
+		// vfmt off
+		?Bar {
+			true
+		}
+		// vfmt on
+	}
+}
+
+fn main() {
+	dump(is_opt(Foo(?Bar(none))))
+	dump(is_opt(Foo(Baz{})))
+}
+
+struct Baz {}
+
+struct Bar {}
+
+type Foo = ?Bar | Baz


### PR DESCRIPTION
Fix #21077
Fix #20823

Before this patch the option type as variant were created as option_xx_ptr, after this patch it will be a _option_xx* instead.