### PR TITLE
utils: fix module lookup if module import parts end with the word `modules`

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -57,6 +57,8 @@ jobs:
       #   run: V_CI_CSTRICT=1 ./v -cstrict test-self
       - name: Build examples
         run: ./v -W build-examples
+      - name: Run the submodule example, using a relative path
+        run: ./v -W run examples/submodule
       - name: Build v tools
         run: ./v -W build-tools
       - name: Build v binaries

--- a/examples/submodule/mymodules/main_functions.v
+++ b/examples/submodule/mymodules/main_functions.v
@@ -1,4 +1,4 @@
-module mymodule
+module mymodules
 
 pub fn add_xy(x int, y int) int {
 	return x + y

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -107,8 +107,10 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 		}
 	}
 	mut in_vmod_path := false
+	mut parts := path.split(os.path_separator)
+	parts.delete_last()
 	for vmod_folder in vmod_folders {
-		if path.contains(vmod_folder + os.path_separator) {
+		if vmod_folder in parts {
 			in_vmod_path = true
 			break
 		}

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -107,8 +107,7 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 		}
 	}
 	mut in_vmod_path := false
-	mut parts := path.split(os.path_separator)
-	parts.delete_last()
+	parts := path.split(os.path_separator)
 	for vmod_folder in vmod_folders {
 		if vmod_folder in parts {
 			in_vmod_path = true


### PR DESCRIPTION
Fixes #21078 

Contains a little module import name correction.

Should we run the related example run in CI and add a info comment to not change the modules name?