### PR TITLE
get UdpSocket local address 

### DIFF
--- a/vlib/net/udp.c.v
+++ b/vlib/net/udp.c.v
@@ -284,3 +284,7 @@ fn (s &UdpSocket) remote() !Addr {
 	}
 	return error('none')
 }
+		
+pub fn (s &UdpSocket) local_addr() Addr {
+	return s.l
+}

--- a/vlib/net/udp_test.v
+++ b/vlib/net/udp_test.v
@@ -59,3 +59,10 @@ fn test_udp() {
 
 	l.close() or {}
 }
+
+fn test_udp_local_addr() {
+	mut l := net.listen_udp(server_addr) or { panic('could not listen_udp: ${err}') }
+	assert server_addr == l.sock.local_addr().str()
+	l.close() or {}
+}
+


### PR DESCRIPTION
UdpSocket l field has local address,but it's not public, add the local_addr()