### PR TITLE
all: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@
 - io: add a `string_reader` submodule (#20893)
 - toml: return an error from toml.parse_file(), when the passed file path does not exist (#20912)
 - x.json2: fix encoder commas (#20916)
-- time: microoptimise the Time formating methods (use custom number->string conversion, instead of string interpolation) (#20917)
+- time: microoptimise the Time formatting methods (use custom number->string conversion, instead of string interpolation) (#20917)
 - x.json2: improve performance of string encoding for unicode special characters and emojis (#20867)
 - x.json2: minor performance improvement, update benchmark recommendations (#20954)
 - os: workaround a `-prod -cc gcc` bug, affecting os.open_file (fix #20923) (related to #20872) (#20960)
@@ -168,7 +168,7 @@
 - net: remove unused import in tcp_test.v
 - x.vweb: add error, when static directory does not exist (#20455)
 - net.urllib: fix parsing url error, when querypath is '//' (fix #20476) (#20504)
-- vweb: unify listen addres from tcp and print (#20448)
+- vweb: unify listen address from tcp and print (#20448)
 - net.unix: make the error messages in unix_test.v more specific (#20537)
 - vweb: add an optional Context.before_accept_loop/0 method, to make testing easier and more robust (#20538)
 - vweb: fix routes without results in vweb_app_test.v (#20548)
@@ -182,7 +182,7 @@
 - x.vweb: add cors middleware (#20713)
 - x.vweb: add new sessions module (#20642)
 - net: fix non-blocking read/write (#20438)
-- net: reduce flakyness of tcp test (#20761)
+- net: reduce flakiness of tcp test (#20761)
 - picoev: renaming, doc (#20567)
 - x.vweb: add full static host support, for urls ending with /folder/ , where the folder backing it, has `index.html` inside (#20784)
 - x.sessions: change session Store interface to use results instead of options (#20796)
@@ -464,7 +464,7 @@
 - Fix arrays alias built-in methods call(fix #19896) (#19910)
 - Fix generic array initialization (fix #19903) (#19916)
 - Fix option sumtype auto deref (#19919)
-- Ast, checker, cgen: fix interface embeded methods call(fix #16496) (#19936)
+- Ast, checker, cgen: fix interface embedded methods call(fix #16496) (#19936)
 - Fix ref and deref when an interface is used as a function parameter (fix #19947) (#19966)
 - Fix auto str for interface struct member which implements str method (#19970)
 - Fix generics call with interface arg (fix #19976) (#20002)
@@ -559,7 +559,7 @@
 - Fix fn call with option call argument in autofree mode (#19515)
 - Bring back pascal case check for aliases
 - C.xx = C.yy aliases
-- Allow casted integeral types in match ranges (#19572)
+- Allow casted integral types in match ranges (#19572)
 - Warn about byte deprecation, when used as a fn parameter (#19629)
 - Allow size of fixed array to be integral casts (#19663)
 - Fix generic array append (#19658)
@@ -631,7 +631,7 @@
 - orm: make is_null/is_not_null unary ops; don't bind null in where (#19635)
 
 #### Database drivers
-- pg: hande C calls, move to .c.v files (#19739)
+- pg: handle C calls, move to .c.v files (#19739)
 
 #### Native backend
 - native: support `-no-builtin` (generate executables < 1KB Linux with `v -no-builtin -b native examples/hello_world.v`)
@@ -654,7 +654,7 @@
 
 #### vfmt
 - Remove additional line breaks after call_expr before params struct args (#19795)
-- Fix map value aligment when using keys with uft8 symbols (#19689)
+- Fix map value alignment when using keys with uft8 symbols (#19689)
 - Align ternary expressions in const blocks (#19721)
 - Respect range index expressions in match branches (#19684)
 - Respect raw strings in `$embed_file(r'/some/path')` expressions (#19753)
@@ -1021,7 +1021,7 @@ https://github.com/vlang/v/blob/master/changelogs0.x/0.4.md
 - Disallow type matching with primitive vars.
 - Warning instead of error for unnecessary brackets in if/match.
 - Include import aliases when checking for import duplicates.
-- Fix infering generic array type in nested call.
+- Fix inferring generic array type in nested call.
 - Allow casted `enum val` and `const` as fixed array size.
 - Disallow multiple return values in const declarations.
 - Fix contains() with array of interfaces.

--- a/changelogs0.x/0.4.md
+++ b/changelogs0.x/0.4.md
@@ -95,7 +95,7 @@
 - Disallow type matching with primitive vars.
 - Warning instead of error for unnecessary brackets in if/match.
 - Include import aliases when checking for import duplicates.
-- Fix infering generic array type in nested call.
+- Fix inferring generic array type in nested call.
 - Allow casted `enum val` and `const` as fixed array size.
 - Disallow multiple return values in const declarations.
 - Fix contains() with array of interfaces.

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -525,7 +525,7 @@ fn auto_complete_request(args []string) []string {
 				add_sep := if part == '~' { os.path_separator } else { '' }
 				part = part.replace_once('~', os.home_dir().trim_right(os.path_separator)) + add_sep
 			}
-			is_abs_path := part.starts_with(os.path_separator) // TODO Windows support for drive prefixes
+			is_abs_path := part.starts_with(os.path_separator) // TODO: Windows support for drive prefixes
 			if part.ends_with(os.path_separator) || part == '.' || part == '..' {
 				// 'v <command>(.*/$|.|..)<tab>' -> output full directory list
 				ls_path = '.' + os.path_separator + part

--- a/cmd/tools/vdoc/main.v
+++ b/cmd/tools/vdoc/main.v
@@ -32,7 +32,7 @@ mut:
 	symbol_name      string
 	platform         doc.Platform
 	run_examples     bool // `-run-examples` will run all `// Example: assert mod.abc() == y` comments in the processed modules
-	// The options below are useful for generating a more stable HMTL, that is easier to regression test:
+	// The options below are useful for generating a more stable HTML, that is easier to regression test:
 	html_only_contents bool // `-html-only-contents` will produce only the content of any given page, without styling tags etc.
 	html_no_vhash      bool // `-html-no-vhash` will remove the version hash from the generated html
 	html_no_assets     bool // `-html-no-assets` will not include CSS and JS asset tags in the generated html

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -712,7 +712,7 @@ fn (mut app App) handle_tap() {
 			} else if avgy < (m * 9 / 10) + ypad {
 				app.new_game()
 			} else {
-				// TODO remove and implement an actual way to toggle themes on mobile
+				// TODO: remove and implement an actual way to toggle themes on mobile
 			}
 		}
 	} else if app.state == .over {

--- a/examples/sokol/06_obj_viewer/modules/obj/rend.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/rend.v
@@ -59,7 +59,7 @@ pub fn load_texture(file_name string) (gfx.Image, gfx.Sampler) {
 	buffer := read_bytes_from_file(file_name)
 	stbi.set_flip_vertically_on_load(true)
 	img := stbi.load_from_memory(buffer.data, buffer.len) or {
-		eprintln('Texure file: [${file_name}] ERROR!')
+		eprintln('Texture file: [${file_name}] ERROR!')
 		exit(0)
 	}
 	sg_img, sg_smp := create_texture(int(img.width), int(img.height), img.data)

--- a/examples/sokol/06_obj_viewer/modules/obj/util.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/util.v
@@ -30,13 +30,13 @@ pub fn read_bytes_from_file(file_path string) []u8 {
 	$if android {
 		path = 'models/' + file_path
 		buffer = os.read_apk_asset(path) or {
-			eprintln('Texure file: [${path}] NOT FOUND!')
+			eprintln('Texture file: [${path}] NOT FOUND!')
 			exit(0)
 		}
 	} $else {
 		path = os.resource_abs_path('assets/models/' + file_path)
 		buffer = os.read_bytes(path) or {
-			eprintln('Texure file: [${path}] NOT FOUND!')
+			eprintln('Texture file: [${path}] NOT FOUND!')
 			exit(0)
 		}
 	}

--- a/examples/term.ui/pong.v
+++ b/examples/term.ui/pong.v
@@ -80,7 +80,7 @@ fn (mut a App) event(e &ui.Event) {
 			if a.mode != .game {
 				return
 			}
-			// TODO mouse movement for real Pong sharks
+			// TODO: mouse movement for real Pong sharks
 			// a.game.move_player(player_one, 0, -1)
 		}
 		.key_down {
@@ -344,7 +344,7 @@ fn (mut g Game) quit() {
 }
 
 fn (mut g Game) draw_big_digit(px f32, py f32, digit int) {
-	// TODO use draw_line or draw_point to fix tearing with non-monospaced terminal fonts
+	// TODO: use draw_line or draw_point to fix tearing with non-monospaced terminal fonts
 	mut gfx := g.app.tui
 	x, y := int(px), int(py)
 	match digit {
@@ -457,7 +457,7 @@ fn (mut g Game) free() {
 	g.players.clear()
 }
 
-// TODO Remove these wrapper functions when we can assign methods as callbacks
+// TODO: Remove these wrapper functions when we can assign methods as callbacks
 fn init(mut app App) {
 	app.init()
 }

--- a/examples/tetris/tetris.js.v
+++ b/examples/tetris/tetris.js.v
@@ -320,7 +320,7 @@ fn (mut g Game) get_tetro() {
 	// g.tetro = g.tetros_cache[idx..idx + tetro_size].clone()
 }
 
-// TODO mut
+// TODO: mut
 fn (mut g Game) drop_tetro() {
 	for i in 0 .. tetro_size {
 		tetro := g.tetro[i]

--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -221,7 +221,7 @@ fn (mut app App) read_bytes(path string) bool {
 pub fn read_bytes_from_file(file_path string) []u8 {
 	mut buffer := []u8{}
 	buffer = os.read_bytes(file_path) or {
-		eprintln('ERROR: Texure file: [${file_path}] NOT FOUND.')
+		eprintln('ERROR: Texture file: [${file_path}] NOT FOUND.')
 		exit(0)
 	}
 	return buffer

--- a/examples/xvweb/todo/main.v
+++ b/examples/xvweb/todo/main.v
@@ -69,7 +69,7 @@ pub fn (app &App) create_todo(mut ctx Context, name string) vweb.Result {
 	// insert the todo into our database
 	sql app.db {
 		insert todo into Todo
-	} or { return ctx.server_error('could not insert a new TODO in the datbase') }
+	} or { return ctx.server_error('could not insert a new TODO in the database') }
 
 	ctx.created_todo = true
 
@@ -127,7 +127,7 @@ pub fn (app &App) delete_todo(mut ctx Context, id int) vweb.Result {
 
 fn main() {
 	os.chdir(os.dir(@FILE))!
-	// create a new App instance with a connection to the datbase
+	// create a new App instance with a connection to the database
 	mut app := &App{
 		db: sqlite.connect('todo.db')!
 	}

--- a/thirdparty/fontstash/fontstash.h
+++ b/thirdparty/fontstash/fontstash.h
@@ -102,7 +102,7 @@ typedef struct FONStextIter FONStextIter;
 
 typedef struct FONScontext FONScontext;
 
-// Contructor and destructor.
+// Constructor and destructor.
 FONS_DEF FONScontext* fonsCreateInternal(FONSparams* params);
 FONS_DEF void fonsDeleteInternal(FONScontext* s);
 

--- a/thirdparty/libatomic_ops/atomic_ops.h
+++ b/thirdparty/libatomic_ops/atomic_ops.h
@@ -270,7 +270,7 @@
 #   include <machine/sys/inline.h>
 #   define AO_compiler_barrier() _Asm_sched_fence()
 # else
-    /* FIXME - We do not know how to do this.  This is a guess. */
+    /* FIXME: We do not know how to do this.  This is a guess. */
     /* And probably a bad one.                                  */
     static volatile int AO_barrier_dummy;
 #   define AO_compiler_barrier() (void)(AO_barrier_dummy = AO_barrier_dummy)

--- a/thirdparty/libgc/gc.c
+++ b/thirdparty/libgc/gc.c
@@ -28976,7 +28976,7 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
             in_allocd_block = is_header_found_async(addr);
 #       endif
         if (!in_allocd_block) {
-            /* FIXME - We should make sure that we invoke the   */
+            /* FIXME: We should make sure that we invoke the   */
             /* old handler with the appropriate calling         */
             /* sequence, which often depends on SA_SIGINFO.     */
 

--- a/thirdparty/sokol/sokol_gfx.h
+++ b/thirdparty/sokol/sokol_gfx.h
@@ -14592,7 +14592,7 @@ _SOKOL_PRIVATE void _sg_wgpu_commit(void) {
 
 _SOKOL_PRIVATE void _sg_wgpu_apply_viewport(int x, int y, int w, int h, bool origin_top_left) {
     SOKOL_ASSERT(_sg.wgpu.pass_enc);
-    // FIXME FIXME FIXME: CLIPPING THE VIEWPORT HERE IS WRONG!!!
+    // FIXME: CLIPPING THE VIEWPORT HERE IS WRONG!!!
     // (but currently required because WebGPU insists that the viewport rectangle must be
     // fully contained inside the framebuffer, but this doesn't make any sense, and also
     // isn't required by the backend APIs)

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -85,7 +85,7 @@ pub fn merge[T](a []T, b []T) []T {
 	mut ia := 0
 	mut ib := 0
 	mut j := 0
-	// TODO efficient approach to merge_desc where: a[ia] >= b[ib]
+	// TODO: efficient approach to merge_desc where: a[ia] >= b[ib]
 	for ia < a.len && ib < b.len {
 		if a[ia] <= b[ib] {
 			m[j] = a[ia]

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -156,7 +156,7 @@ fn new_array_from_c_array(len int, cap int, elm_size int, c_array voidptr) array
 		len: len
 		cap: cap_
 	}
-	// TODO Write all memory functions (like memcpy) in V
+	// TODO: Write all memory functions (like memcpy) in V
 	unsafe { vmemcpy(arr.data, c_array, u64(len) * u64(elm_size)) }
 	return arr
 }

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -82,7 +82,7 @@ fn new_array_from_c_array_noscan(len int, cap int, elm_size int, c_array voidptr
 		len: len
 		cap: cap_
 	}
-	// TODO Write all memory functions (like memcpy) in V
+	// TODO: Write all memory functions (like memcpy) in V
 	unsafe { vmemcpy(arr.data, c_array, u64(len) * u64(elm_size)) }
 	return arr
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -925,7 +925,7 @@ fn test_i64_sort() {
 fn test_sort_index_expr() {
 	mut f := [[i64(50), 48], [i64(15)], [i64(1)], [i64(79)], [i64(38)],
 		[i64(0)], [i64(27)]]
-	// TODO This currently gives "indexing pointer" error without unsafe
+	// TODO: This currently gives "indexing pointer" error without unsafe
 	unsafe {
 		f.sort(a[0] < b[0])
 	}

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -67,7 +67,7 @@ fn builtin_init() {
 	}
 }
 
-// TODO copypaste from os
+// TODO: copypaste from os
 // we want to be able to use this here without having to `import os`
 struct ExceptionRecord {
 pub:

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -59,7 +59,7 @@ fn C.fputs(str &char, stream &C.FILE) int
 
 fn C.fflush(&C.FILE) int
 
-// TODO define args in these functions
+// TODO: define args in these functions
 fn C.fseek(stream &C.FILE, offset int, whence int) int
 
 fn C.fopen(filename &char, mode &char) &C.FILE

--- a/vlib/builtin/float.c.v
+++ b/vlib/builtin/float.c.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module builtin
 
-// TODO implement compile time conditional include
+// TODO: implement compile time conditional include
 // [if !nofloat]
 import strconv
 

--- a/vlib/builtin/js/array_test.js.v
+++ b/vlib/builtin/js/array_test.js.v
@@ -918,7 +918,7 @@ fn test_i64_sort() {
 fn test_sort_index_expr() {
 	mut f := [[i64(50), 48], [i64(15)], [i64(1)], [i64(79)], [i64(38)],
 		[i64(0)], [i64(27)]]
-	// TODO This currently gives "indexing pointer" error without unsafe
+	// TODO: This currently gives "indexing pointer" error without unsafe
 	unsafe {
 		f.sort(a[0] < b[0])
 	}

--- a/vlib/builtin/js/string_test.js.v
+++ b/vlib/builtin/js/string_test.js.v
@@ -670,7 +670,7 @@ fn test_repeat() {
 	assert s2.repeat(5) == s2
 	assert s2.repeat(1) == s2
 	assert s2.repeat(0) == s2
-	// TODO Add test for negative values
+	// TODO: Add test for negative values
 }
 
 fn test_starts_with() {

--- a/vlib/builtin/map.c.v
+++ b/vlib/builtin/map.c.v
@@ -40,7 +40,7 @@ fn map_hash_int_8(pkey voidptr) u64 {
 
 // Move all zeros to the end of the array and resize array
 fn (mut d DenseArray) zeros_to_end() {
-	// TODO alloca?
+	// TODO: alloca?
 	mut tmp_value := unsafe { malloc(d.value_bytes) }
 	mut tmp_key := unsafe { malloc(d.key_bytes) }
 	mut count := 0

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -271,7 +271,7 @@ fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
 
 fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn, free_fn)
-	// TODO pre-allocate n slots
+	// TODO: pre-allocate n slots
 	mut pkey := &u8(keys)
 	mut pval := &u8(values)
 	for _ in 0 .. n {

--- a/vlib/builtin/map_d_gcboehm_opt.v
+++ b/vlib/builtin/map_d_gcboehm_opt.v
@@ -98,7 +98,7 @@ fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, k
 fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map_noscan_key(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
-	// TODO pre-allocate n slots
+	// TODO: pre-allocate n slots
 	mut pkey := &u8(keys)
 	mut pval := &u8(values)
 	for _ in 0 .. n {
@@ -114,7 +114,7 @@ fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapClo
 fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map_noscan_value(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
-	// TODO pre-allocate n slots
+	// TODO: pre-allocate n slots
 	mut pkey := &u8(keys)
 	mut pval := &u8(values)
 	for _ in 0 .. n {
@@ -130,7 +130,7 @@ fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapC
 fn new_map_init_noscan_key_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map_noscan_key_value(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
-	// TODO pre-allocate n slots
+	// TODO: pre-allocate n slots
 	mut pkey := &u8(keys)
 	mut pval := &u8(values)
 	for _ in 0 .. n {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -354,7 +354,7 @@ pub fn (s string) replace(rep string, with string) string {
 	if !s.contains(rep) {
 		return s.clone()
 	}
-	// TODO PERF Allocating ints is expensive. Should be a stack array
+	// TODO: PERF Allocating ints is expensive. Should be a stack array
 	// Get locations of all reps within this string
 	mut idxs := []int{cap: s.len / rep.len}
 	defer {
@@ -515,7 +515,7 @@ pub fn (s string) replace_char(rep u8, with u8, repeat int) string {
 	if s.len == 0 {
 		return s.clone()
 	}
-	// TODO Allocating ints is expensive. Should be a stack array
+	// TODO: Allocating ints is expensive. Should be a stack array
 	// - string.replace()
 	mut idxs := []int{cap: s.len}
 	defer {
@@ -575,7 +575,7 @@ pub fn (s string) normalize_tabs(tab_len int) string {
 // bool returns `true` if the string equals the word "true" it will return `false` otherwise.
 @[inline]
 pub fn (s string) bool() bool {
-	return s == 'true' || s == 't' // TODO t for pg, remove
+	return s == 'true' || s == 't' // TODO: t for pg, remove
 }
 
 // int returns the value of the string as an integer `'1'.int() == 1`.
@@ -1402,7 +1402,7 @@ pub fn (s string) count(substr string) int {
 		i += substr.len
 		n++
 	}
-	return 0 // TODO can never get here - v doesn't know that
+	return 0 // TODO: can never get here - v doesn't know that
 }
 
 // contains_u8 returns `true` if the string contains the byte value `x`.
@@ -1497,7 +1497,7 @@ pub fn (s string) ends_with(p string) bool {
 }
 
 // to_lower returns the string in all lowercase characters.
-// TODO only works with ASCII
+// TODO: only works with ASCII
 @[direct_array_access]
 pub fn (s string) to_lower() string {
 	unsafe {
@@ -2102,7 +2102,7 @@ pub fn (s string) before(sub string) string {
 // Example: assert '23:34:45.234'.all_before('.') == '23:34:45'
 // Example: assert 'abcd'.all_before('.') == 'abcd'
 pub fn (s string) all_before(sub string) string {
-	// TODO remove dup method
+	// TODO: remove dup method
 	pos := s.index_(sub)
 	if pos == -1 {
 		return s.clone()

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -1111,7 +1111,7 @@ fn test_repeat() {
 	assert s2.repeat(5) == s2
 	assert s2.repeat(1) == s2
 	assert s2.repeat(0) == s2
-	// TODO Add test for negative values
+	// TODO: Add test for negative values
 }
 
 fn test_starts_with() {

--- a/vlib/clipboard/clipboard_darwin.c.v
+++ b/vlib/clipboard/clipboard_darwin.c.v
@@ -13,7 +13,7 @@ pub struct Clipboard {
 	pb             voidptr
 	last_cb_serial i64
 mut:
-	foo int // TODO remove, for mut hack
+	foo int // TODO: remove, for mut hack
 }
 
 fn C.darwin_new_pasteboard() voidptr

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -60,7 +60,7 @@ pub struct Clipboard {
 	retry_delay int
 mut:
 	hwnd voidptr
-	foo  int // TODO remove
+	foo  int // TODO: remove
 }
 
 fn (cb &Clipboard) get_clipboard_lock() bool {

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -43,7 +43,7 @@ fn C.XGetSelectionOwner(d &C.Display, a Atom) Window
 
 fn C.XChangeProperty(d &C.Display, requestor Window, property Atom, typ Atom, format int, mode int, data voidptr, nelements int) int
 
-fn C.XSendEvent(d &C.Display, requestor Window, propogate int, mask i64, event &C.XEvent)
+fn C.XSendEvent(d &C.Display, requestor Window, propagate int, mask i64, event &C.XEvent)
 
 fn C.XInternAtom(d &C.Display, typ &u8, only_if_exists int) Atom
 
@@ -207,7 +207,7 @@ pub fn (cb &Clipboard) check_availability() bool {
 pub fn (mut cb Clipboard) free() {
 	C.XDestroyWindow(cb.display, cb.window)
 	cb.window = Window(0)
-	// FIX ME: program hangs when closing display
+	// FIXME: program hangs when closing display
 	// XCloseDisplay(cb.display)
 }
 

--- a/vlib/compress/zstd/zstd.v
+++ b/vlib/compress/zstd/zstd.v
@@ -409,7 +409,7 @@ pub fn compress(data []u8, params CompressParams) ![]u8 {
 	}
 	check_zstd(cctx.set_parameter(.zstd_c_compression_level, params.compression_level))!
 	$if !(tinyc && windows) {
-		// TODO: tinyc on windows doesn't support mutiple thread
+		// TODO: tinyc on windows doesn't support multiple thread
 		check_zstd(cctx.set_parameter(.zstd_c_nb_workers, params.nb_threads))!
 	}
 	check_zstd(cctx.set_parameter(.zstd_c_checksum_flag, if params.checksum_flag { 1 } else { 0 }))!
@@ -457,7 +457,7 @@ pub fn new_cctx(params CompressParams) !&ZSTD_CCtx {
 	}
 	check_zstd(cctx.set_parameter(.zstd_c_compression_level, params.compression_level))!
 	$if !(tinyc && windows) {
-		// TODO: tinyc on windows doesn't support mutiple thread
+		// TODO: tinyc on windows doesn't support multiple thread
 		check_zstd(cctx.set_parameter(.zstd_c_nb_workers, params.nb_threads))!
 	}
 	check_zstd(cctx.set_parameter(.zstd_c_checksum_flag, if params.checksum_flag { 1 } else { 0 }))!

--- a/vlib/context/empty.v
+++ b/vlib/context/empty.v
@@ -60,7 +60,7 @@ pub fn (ctx &TodoContext) str() string {
 	return 'context.TODO'
 }
 
-// todo returns an empty Context. Code should use todo when
+// TODO: returns an empty Context. Code should use todo when
 // it's unclear which Context to use or it is not yet available (because the
 // surrounding function has not yet been extended to accept a Context
 // parameter).

--- a/vlib/crypto/hmac/hmac.v
+++ b/vlib/crypto/hmac/hmac.v
@@ -4,7 +4,7 @@ module hmac
 
 import crypto.internal.subtle
 
-const ipad = []u8{len: 256, init: 0x36} // TODO is 256 enough??
+const ipad = []u8{len: 256, init: 0x36} // TODO: is 256 enough??
 
 const opad = []u8{len: 256, init: 0x5C}
 const npad = []u8{len: 256, init: 0}

--- a/vlib/datatypes/bloom_filter.v
+++ b/vlib/datatypes/bloom_filter.v
@@ -4,7 +4,7 @@ module datatypes
 
 @[heap]
 struct BloomFilter[T] {
-	// TODO V bug
+	// TODO: V bug
 	hash_func fn (T) u32 = unsafe { nil } // hash function, input [T] , output u32
 	// hash_func     fn (T) u32 = empty_cb // hash function, input [T] , output u32
 	table_size    int // every entry is one-bit, packed into `table`

--- a/vlib/datatypes/bstree_test.v
+++ b/vlib/datatypes/bstree_test.v
@@ -99,8 +99,8 @@ fn test_remove_from_bst_one() {
 	assert bst.in_order_traversal() == [1, 10, 20]
 }
 
-// Another test n the remove BST, this remove an intermidia node
-// that it is a triky operation.
+// Another test n the remove BST, this remove an intermediate node
+// that it is a tricky operation.
 fn test_remove_from_bst_two() {
 	mut bst := BSTree[int]{}
 	assert bst.insert(10)

--- a/vlib/dlmalloc/dlmalloc.v
+++ b/vlib/dlmalloc/dlmalloc.v
@@ -199,7 +199,7 @@ fn overhead_for(c &Chunk) usize {
 	}
 }
 
-// In order for dlmalloc to efficently manage memory, it needs a way to communicate with the underlying platform.
+// In order for dlmalloc to efficiently manage memory, it needs a way to communicate with the underlying platform.
 // This `Allocator` type provides an interface for this communication.
 //
 //
@@ -954,7 +954,7 @@ fn (mut dl Dlmalloc) malloc_real(size usize) voidptr {
 
 				// todo(playXE): Find out why in the world this part of code does not work in
 				// some programs (esp. x.json2). Theoretically disabling this path just
-				// makes fragmentation a little worser but nothing really bad should happen
+				// makes fragmentation a little worse but nothing really bad should happen
 				if false && smallbits != 0 {
 					leftbits := (smallbits << idx) & left_bits(1 << idx)
 					leastbit := least_bit(leftbits)

--- a/vlib/encoding/txtar/txtar.v
+++ b/vlib/encoding/txtar/txtar.v
@@ -85,7 +85,7 @@ fn is_marker(data string) (string, string) {
 }
 
 // fix_nl returns the data, if it is empty, or if it ends in \n.
-// Otherwise it returns data + a final \n addded.
+// Otherwise it returns data + a final \n added.
 fn fix_nl(data string) string {
 	if data.len == 0 || data[data.len - 1] == `\n` {
 		return data

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -321,7 +321,7 @@ fn test_multiple_arguments() {
 		'-c',
 		'3.45',
 	])
-	// TODO Move to array comparison once it's implemented
+	// TODO: Move to array comparison once it's implemented
 	// assert fp.int_multi('some-flag', `a`, '') == [2, 3, 5] &&
 	//	fp.string_multi('some-flag', `b`, '') == ['a', 'c', 'b'] &&
 	//	fp.float_multi('some-flag', `c`, '') == [1.23, 2.34, 3.45]

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -234,7 +234,7 @@ pub fn (s &Context) vert_metrics(ascender &f32, descender &f32, lineh &f32) {
 	C.fonsVertMetrics(s, ascender, descender, lineh)
 }
 
-// text_iter_init initalizes the text iterator `iter`.
+// text_iter_init initializes the text iterator `iter`.
 @[inline]
 pub fn (s &Context) text_iter_init(iter &C.FONStextIter, x f32, y f32, str &char, end &char) int {
 	return C.fonsTextIterInit(s, iter, x, y, str, end)

--- a/vlib/fontstash/fontstash_funcs.c.v
+++ b/vlib/fontstash/fontstash_funcs.c.v
@@ -1,6 +1,6 @@
 module fontstash
 
-// Contructor and destructor.
+// Constructor and destructor.
 fn C.fonsCreateInternal(params &C.FONSparams) &C.FONScontext
 fn C.fonsDeleteInternal(s &C.FONScontext)
 

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -729,7 +729,7 @@ pub fn screen_size() Size {
 			height: int(C.GetSystemMetrics(C.SM_CYSCREEN))
 		}
 	}
-	// TODO linux, etc
+	// TODO: linux, etc
 	return Size{}
 }
 

--- a/vlib/gg/gg_darwin.m
+++ b/vlib/gg/gg_darwin.m
@@ -100,7 +100,7 @@ gg__Image darwin_create_image(string path_) {
 	res.path = path_;
 	res.ok = true;
 	// printf("inited img width=%d\n", res.width) ;
-	//  need __brige_retained so that the pointer is not freed by ARC
+	//  need __bridge_retained so that the pointer is not freed by ARC
 	res.data = (__bridge_retained voidptr)(img);
 	return res;
 }

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -195,7 +195,7 @@ pub fn (mut img Image) update_pixel_data(buf &u8) {
 // create_image_with_size creates an `Image` from `file` in the given
 // `width` x `height` dimension.
 //
-// TODO copypasta
+// TODO: copypasta
 pub fn (mut ctx Context) create_image_with_size(file string, width int, height int) Image {
 	if !gfx.is_valid() {
 		// Sokol is not initialized yet, add stbi object to a queue/cache
@@ -222,7 +222,7 @@ pub fn (mut ctx Context) create_image_with_size(file string, width int, height i
 
 // create_image creates an `Image` from `file`.
 //
-// TODO remove this
+// TODO: remove this
 fn create_image(file string) Image {
 	if !os.exists(file) {
 		println('gg.create_image(): file not found: ${file}')

--- a/vlib/gg/m4/vector.v
+++ b/vlib/gg/m4/vector.v
@@ -191,7 +191,7 @@ pub fn (x Vec4) sum() f32 {
 /*********************************************************************
 * Operators
 *********************************************************************/
-// + returns `a` + `b` (corresponding elements are addded)
+// + returns `a` + `b` (corresponding elements are added)
 @[inline]
 pub fn (a Vec4) + (b Vec4) Vec4 {
 	return Vec4{
@@ -236,7 +236,7 @@ pub fn (a Vec4) % (b Vec4) Vec4 {
 	}
 }
 
-// mul_vec4 returns a vectore, where the corresponding `x` and `y` elements are multiplied
+// mul_vec4 returns a vector, where the corresponding `x` and `y` elements are multiplied
 @[inline]
 pub fn (x Vec4) mul_vec4(y Vec4) Vec4 {
 	return Vec4{

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -176,7 +176,7 @@ pub fn (ctx &Context) draw_text2(p DrawTextParams) {
 		bold: p.bold
 		mono: p.mono
 		italic: p.italic
-	}) // TODO perf once it's the only function to draw text
+	}) // TODO: perf once it's the only function to draw text
 }
 
 // draw_text draws the string in `text_` starting at top-left position `x`,`y`.
@@ -197,7 +197,7 @@ pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg gx.TextCfg) {
 		eprintln('gg: draw_text(): font not initialized')
 		return
 	}
-	// text := text_.trim_space() // TODO remove/optimize
+	// text := text_.trim_space() // TODO: remove/optimize
 	// mut text := text_
 	// if text.contains('\t') {
 	// text = text.replace('\t', '    ')
@@ -233,7 +233,7 @@ pub fn (ctx &Context) text_width(s string) int {
 	ctx.ft.fons.text_bounds(0, 0, s, &buf[0])
 	if s.ends_with(' ') {
 		return int((buf[2] - buf[0]) / ctx.scale) +
-			ctx.text_width('i') // TODO fix this in fontstash?
+			ctx.text_width('i') // TODO: fix this in fontstash?
 	}
 	res := int((buf[2] - buf[0]) / ctx.scale)
 	// println('TW "$s" = $res')

--- a/vlib/hash/wyhash.v
+++ b/vlib/hash/wyhash.v
@@ -9,7 +9,7 @@
 // currently the C version performs slightly better
 // because it uses 128 bit int when available and
 // branch prediction hints. the C version will be
-// removed once the perfomance is matched.
+// removed once the performance is matched.
 // you can test performance by running:
 // `v run cmd/tools/bench/wyhash.v`
 // try running with and without the `-prod` flag

--- a/vlib/json/README.md
+++ b/vlib/json/README.md
@@ -27,7 +27,7 @@ mut:
 	salary f32
 	title  JobTitle @[json: 'ETitle'] // the key for this field will be 'ETitle', not 'title'
 	notes  string   @[omitempty]        // the JSON property is not created if the string is equal to '' (an empty string).
-	// TODO document @[raw]
+	// TODO: document @[raw]
 }
 
 fn main() {

--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -324,7 +324,7 @@ fn test_nested_type() {
 		assert data2.users[key].last_name == user.last_name
 		assert data2.users[key].is_registered == user.is_registered
 		assert data2.users[key].typ == user.typ
-		// assert data2.users[key].pets == user.pets // TODO FIX
+		// assert data2.users[key].pets == user.pets // TODO: FIX
 	}
 	for k, v in data.extra {
 		for k2, v2 in v {

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -153,7 +153,7 @@ pub fn delete(url string) !Response {
 	return fetch(method: .delete, url: url)
 }
 
-// TODO - @[noinline] attribut is used for temporary fix the 'get_text()' intermittent segfault / nil value when compiling with GCC 13.2.x and -prod option ( Issue #20506 )
+// TODO: @[noinline] attribute is used for temporary fix the 'get_text()' intermittent segfault / nil value when compiling with GCC 13.2.x and -prod option ( Issue #20506 )
 // fetch sends an HTTP request to the `url` with the given method and configuration.
 @[noinline]
 pub fn fetch(config FetchConfig) !Response {

--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -92,7 +92,7 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 		mut client := pr.ssl_dial('${host.host}:443')!
 
 		$if windows {
-			return error('Windows Not SUPPORTED') // todo windows ssl
+			return error('Windows Not SUPPORTED') // TODO: windows ssl
 			// response_text := req.do_request(req.build_request_headers(req.method, host_name,
 			// 	path))!
 			// client.shutdown()!

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -218,7 +218,7 @@ fn (req &Request) http_do(host string, method Method, path string) !Response {
 	mut client := net.dial_tcp(host)!
 	client.set_read_timeout(req.read_timeout)
 	client.set_write_timeout(req.write_timeout)
-	// TODO this really needs to be exposed somehow
+	// TODO: this really needs to be exposed somehow
 	client.write(s.bytes())!
 	$if trace_http_request ? {
 		eprintln('> ${s}')

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -345,7 +345,7 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 					$if trace_ssl ? {
 						eprintln('${@METHOD} ---> res: ssl write on closed connection .ssl_error_zero_return')
 					}
-					return error('ssl write on closed connection') // Todo error_with_code close
+					return error('ssl write on closed connection') // TODO: error_with_code close
 				}
 				$if trace_ssl ? {
 					eprintln('${@METHOD} ---> res: could not write SSL, err_res: ${err_res}')

--- a/vlib/net/socks/socks5.v
+++ b/vlib/net/socks/socks5.v
@@ -92,7 +92,7 @@ fn handshake(mut con net.TcpConn, host string, username string, password string)
 	} else if address.contains_only(':1234567890abcdf') {
 		// v << addr_type_ipv6
 		// v << parse_ipv4(address)!
-		// todo support ipv6
+		// TODO: support ipv6
 	} else { // domain
 		if address.len > 255 {
 			return error('${address} is too long')

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -547,7 +547,7 @@ fn (mut s TcpSocket) set_option(level int, opt int, value int) ! {
 }
 
 pub fn (mut s TcpSocket) set_option_bool(opt SocketOption, value bool) ! {
-	// TODO reenable when this `in` operation works again
+	// TODO: reenable when this `in` operation works again
 	// if opt !in opts_can_set {
 	// 	return err_option_not_settable
 	// }

--- a/vlib/net/udp.c.v
+++ b/vlib/net/udp.c.v
@@ -252,7 +252,7 @@ fn new_udp_socket_for_remote(raddr Addr) !&UdpSocket {
 }
 
 pub fn (mut s UdpSocket) set_option_bool(opt SocketOption, value bool) ! {
-	// TODO reenable when this `in` operation works again
+	// TODO: reenable when this `in` operation works again
 	// if opt !in opts_can_set {
 	// 	return err_option_not_settable
 	// }

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -191,7 +191,7 @@ pub fn (c &StreamConn) write_timeout() time.Duration {
 	return c.write_timeout
 }
 
-// set_write_timout sets the write timeout
+// set_write_timeout sets the write timeout
 pub fn (mut c StreamConn) set_write_timeout(t time.Duration) {
 	c.write_timeout = t
 }

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -209,7 +209,7 @@ fn unescape(s_ string, mode EncodingMode) !string {
 		}
 	}
 	if n == 0 && !has_plus {
-		return '${s}' // TODO `return s` once an autofree bug is fixed
+		return '${s}' // TODO: `return s` once an autofree bug is fixed
 	}
 	if s.len < 2 * n {
 		return error(error_msg('unescape: invalid escape sequence', ''))
@@ -751,7 +751,7 @@ pub fn (u URL) str() string {
 			// path reference.
 			i := path.index_u8(`:`)
 			if i > -1 {
-				// TODO remove this when autofree handles tmp
+				// TODO: remove this when autofree handles tmp
 				// expressions like this
 				if i > -1 && path[..i].index_u8(`/`) == -1 {
 					buf.write_string('./')

--- a/vlib/os/file.c.v
+++ b/vlib/os/file.c.v
@@ -291,7 +291,7 @@ pub fn (mut f File) writeln(s string) !int {
 		}
 	}
 	*/
-	// TODO perf
+	// TODO: perf
 	written := int(C.fwrite(s.str, 1, s.len, f.cfile))
 	if written == 0 && s.len != 0 {
 		return error('0 bytes written')
@@ -751,7 +751,7 @@ pub fn (mut f File) write_struct_at[T](t &T, pos u64) ! {
 	}
 }
 
-// TODO `write_raw[_at]` implementations are copy-pasted from `write_struct[_at]`
+// TODO: `write_raw[_at]` implementations are copy-pasted from `write_struct[_at]`
 
 // write_raw writes a single instance of type `T`
 pub fn (mut f File) write_raw[T](t &T) ! {

--- a/vlib/os/file_test.v
+++ b/vlib/os/file_test.v
@@ -84,7 +84,7 @@ fn test_read_bytes_into_newline_text() {
 // This test simulates the scenario when a byte stream is read and a newline byte
 // appears in that stream and an EOF occurs before the buffer is full.
 fn test_read_bytes_into_newline_binary() {
-	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
+	os.rm(tfile) or {} // FIXME: This is a workaround for macos, because the file isn't truncated when open with 'w'
 	mut bw := []u8{len: 15}
 	bw[9] = 0xff
 	bw[12] = 10 // newline
@@ -179,7 +179,7 @@ fn test_read_eof_last_read_full_buffer_fill() {
 }
 
 fn test_write_struct() {
-	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
+	os.rm(tfile) or {} // FIXME: This is a workaround for macos, because the file isn't truncated when open with 'w'
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w')!
 	f.write_struct(another_point)!
@@ -234,7 +234,7 @@ fn test_read_struct_at() {
 }
 
 fn test_write_raw() {
-	os.rm(tfile) or {} // FIXME This is a workaround for macos, because the file isn't truncated when open with 'w'
+	os.rm(tfile) or {} // FIXME: This is a workaround for macos, because the file isn't truncated when open with 'w'
 	size_of_point := int(sizeof(Point))
 	mut f := os.open_file(tfile, 'w')!
 	f.write_raw(another_point)!

--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -60,7 +60,7 @@ pub fn (m FileMode) bitmask() u32 {
 
 // inode returns the metadata of the file/inode, containing inode type, permission information, size and modification time.
 // it supports windows for regular files, but it doesn't matter if you use owner, group or others when checking permissions on windows.
-// if a symlink is targetted, it returns info on the link, not the target
+// if a symlink is targeted, it returns info on the link, not the target
 pub fn inode(path string) FileInfo {
 	attr := lstat(path) or { Stat{} }
 	fm := attr.get_mode()

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -239,7 +239,7 @@ pub fn cp(src string, dst string) ! {
 			return error_with_code('cp (permission): failed to write to ${dst} (fp_to: ${fp_to})',
 				int(fp_to))
 		}
-		// TODO use defer{} to close files in case of error or return.
+		// TODO: use defer{} to close files in case of error or return.
 		// Currently there is a C-Error when building.
 		mut buf := [1024]u8{}
 		mut count := 0
@@ -351,7 +351,7 @@ fn vpclose(f voidptr) int {
 // system works like `exec`, but only returns a return code.
 pub fn system(cmd string) int {
 	// if cmd.contains(';') || cmd.contains('&&') || cmd.contains('||') || cmd.contains('\n') {
-	// TODO remove panic
+	// TODO: remove panic
 	// panic(';, &&, || and \\n are not allowed in shell commands')
 	// }
 	mut ret := 0

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -173,7 +173,7 @@ pub fn sigint_to_signal_name(si int) string {
 	$if linux {
 		// From `man 7 signal` on linux:
 		match si {
-			// TODO dependent on platform
+			// TODO: dependent on platform
 			// works only on x86/ARM/most others
 			10 { // , 30, 16
 				return 'SIGUSR1'
@@ -780,7 +780,7 @@ pub fn temp_dir() string {
 	mut path := getenv('TMPDIR')
 	$if windows {
 		if path == '' {
-			// TODO see Qt's implementation?
+			// TODO: see Qt's implementation?
 			// https://doc.qt.io/qt-5/qdir.html#tempPath
 			// https://github.com/qt/qtbase/blob/e164d61ca8263fc4b46fdd916e1ea77c7dd2b735/src/corelib/io/qfilesystemengine_win.cpp#L1275
 			path = getenv('TEMP')
@@ -798,7 +798,7 @@ pub fn temp_dir() string {
 		return '/tmp'
 	}
 	$if android {
-		// TODO test+use '/data/local/tmp' on Android before using cache_dir()
+		// TODO: test+use '/data/local/tmp' on Android before using cache_dir()
 		if path == '' {
 			path = cache_dir()
 		}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -239,7 +239,7 @@ pub fn get_module_filename(handle HANDLE) !string {
 			}
 		}
 	}
-	panic('this should be unreachable') // TODO remove unreachable after loop
+	panic('this should be unreachable') // TODO: remove unreachable after loop
 }
 
 // Ref - https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-FormatMessageWa#parameters

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -316,7 +316,7 @@ pub fn (mut rng PRNG) f64_in_range(min f64, max f64) !f64 {
 	return min + rng.f64n(max - min)!
 }
 
-// ulid generates an Unique Lexicographically sortable IDentifier.
+// ulid generates an unique lexicographically sortable identifier.
 // See https://github.com/ulid/spec .
 // Note: ULIDs can leak timing information, if you make them public, because
 // you can infer the rate at which some resource is being created, like
@@ -661,7 +661,7 @@ const english_letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 const hex_chars = 'abcdef0123456789'
 const ascii_chars = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\^_`abcdefghijklmnopqrstuvwxyz{|}~'
 
-// ulid generates an Unique Lexicographically sortable IDentifier.
+// ulid generates an unique lexicographically sortable identifier.
 // See https://github.com/ulid/spec .
 // Note: ULIDs can leak timing information, if you make them public, because
 // you can infer the rate at which some resource is being created, like

--- a/vlib/readline/readline_default.c.v
+++ b/vlib/readline/readline_default.c.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //
-// TODO Mac version needs to be implemented
+// TODO: Mac version needs to be implemented
 // Will serve as more advanced input method
 // based on the work of https://github.com/AmokHuginnsson/replxx
 //

--- a/vlib/readline/readline_nix.c.v
+++ b/vlib/readline/readline_nix.c.v
@@ -27,7 +27,7 @@ enum Action {
 	delete_line
 	move_cursor_left
 	move_cursor_right
-	move_cursor_begining
+	move_cursor_start
 	move_cursor_end
 	move_cursor_word_left
 	move_cursor_word_right
@@ -206,7 +206,7 @@ fn (mut r Readline) analyse(c int) Action {
 			return .delete_word_left
 		} // CTRL + W
 		1 {
-			return .move_cursor_begining
+			return .move_cursor_start
 		} // ^A
 		5 {
 			return .move_cursor_end
@@ -235,7 +235,7 @@ fn (r Readline) analyse_control() Action {
 				`D` { return .move_cursor_left }
 				`B` { return .history_next }
 				`A` { return .history_previous }
-				`H` { return .move_cursor_begining }
+				`H` { return .move_cursor_start }
 				`F` { return .move_cursor_end }
 				`1` { return r.analyse_extended_control() }
 				`2`, `3` { return r.analyse_extended_control_no_eat(u8(sequence)) }
@@ -296,7 +296,7 @@ fn (mut r Readline) execute(a Action, c int) bool {
 		.delete_word_left { r.delete_word_left() }
 		.move_cursor_left { r.move_cursor_left() }
 		.move_cursor_right { r.move_cursor_right() }
-		.move_cursor_begining { r.move_cursor_begining() }
+		.move_cursor_start { r.move_cursor_start() }
 		.move_cursor_end { r.move_cursor_end() }
 		.move_cursor_word_left { r.move_cursor_word_left() }
 		.move_cursor_word_right { r.move_cursor_word_right() }
@@ -505,8 +505,8 @@ fn (mut r Readline) move_cursor_right() {
 	}
 }
 
-// move_cursor_begining moves the cursor to the beginning of the current line.
-fn (mut r Readline) move_cursor_begining() {
+// move_cursor_start moves the cursor to the beginning of the current line.
+fn (mut r Readline) move_cursor_start() {
 	r.cursor = 0
 	r.refresh_line()
 }

--- a/vlib/readline/readline_windows.c.v
+++ b/vlib/readline/readline_windows.c.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //
-// TODO Windows version needs to be implemented.
+// TODO: Windows version needs to be implemented.
 // Will serve as more advanced input method
 // based on the work of https://github.com/AmokHuginnsson/replxx
 //

--- a/vlib/semver/semver.v
+++ b/vlib/semver/semver.v
@@ -50,7 +50,7 @@ pub fn from(input string) !Version {
 
 // build returns a `Version` structure with given `major`, `minor` and `patch` versions.
 pub fn build(major int, minor int, patch int) Version {
-	// TODO Check if versions are greater than zero.
+	// TODO: Check if versions are greater than zero.
 	return Version{major, minor, patch, '', ''}
 }
 

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -59,7 +59,7 @@ $if emscripten ? {
 // for simplicity, all header includes are here because import order matters and we dont have any way
 // to ensure import order with V yet
 #define SOKOL_IMPL
-// TODO should not be defined for android graphic (apk/aab using sokol) builds, but we have no ways to undefine
+// TODO: should not be defined for android graphic (apk/aab using sokol) builds, but we have no ways to undefine
 //#define SOKOL_NO_ENTRY
 #flag linux   -DSOKOL_NO_ENTRY
 #flag darwin  -DSOKOL_NO_ENTRY
@@ -68,7 +68,7 @@ $if emscripten ? {
 #flag freebsd -DSOKOL_NO_ENTRY
 #flag openbsd -DSOKOL_NO_ENTRY
 #flag solaris -DSOKOL_NO_ENTRY
-// TODO end
+// TODO: end
 
 #flag linux -ldl
 

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -186,7 +186,7 @@ pub fn cancel_quit() {
 	C.sapp_cancel_quit()
 }
 
-// intiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUSTED)
+// initiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUESTED)
 @[inline]
 pub fn quit() {
 	C.sapp_quit()

--- a/vlib/sokol/sapp/sapp_funcs.c.v
+++ b/vlib/sokol/sapp/sapp_funcs.c.v
@@ -65,7 +65,7 @@ fn C.sapp_request_quit()
 // cancel a pending quit (when SAPP_EVENTTYPE_QUIT_REQUESTED has been received)
 fn C.sapp_cancel_quit()
 
-// intiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUSTED)
+// intiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUESTED)
 fn C.sapp_quit()
 
 // call from inside event callback to consume the current event (don't forward to platform)

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -117,7 +117,7 @@ enum ParserState {
 }
 
 // parser tries to parse the given string into a number
-// NOTE: #TOFIX need one char after the last char of the number
+// FIXME: need one char after the last char of the number
 @[direct_array_access]
 fn parser(s string) (ParserState, PrepNumber) {
 	mut digx := 0

--- a/vlib/strconv/atof_test.c.v
+++ b/vlib/strconv/atof_test.c.v
@@ -54,7 +54,7 @@ fn test_atof() {
 	}
 
 	// check conversion case 2 string <==> f64
-	// we don't test atof_quick beacuse we already know the rounding error
+	// we don't test atof_quick because we already know the rounding error
 	for c, x in src_num_str {
 		b := src_num[c].strlong()
 		value := strconv.atof64(x) or { panic(err) }

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -459,7 +459,7 @@ pub fn format_es(f f64, p BF_param) string {
 	}
 }
 
-// remove_tail_zeros strips traling zeros from `s` and return the resulting `string`.
+// remove_tail_zeros strips trailing zeros from `s` and return the resulting `string`.
 @[direct_array_access]
 pub fn remove_tail_zeros(s string) string {
 	unsafe {

--- a/vlib/strconv/vprintf.c.v
+++ b/vlib/strconv/vprintf.c.v
@@ -22,7 +22,7 @@ enum Char_parse_state {
 	reset_params
 }
 
-// v_printf prints a sprintf-like formated `string` to the terminal.
+// v_printf prints a sprintf-like formatted `string` to the terminal.
 // The format string `str` can be constructed at runtime.
 // Note, that this function is unsafe.
 // In most cases, you are better off using V's string interpolation,
@@ -32,7 +32,7 @@ pub fn v_printf(str string, pt ...voidptr) {
 	print(unsafe { v_sprintf(str, ...pt) })
 }
 
-// v_sprintf returns a sprintf-like formated `string`.
+// v_sprintf returns a sprintf-like formatted `string`.
 // The format string `str` can be constructed at runtime.
 // Note, that this function is unsafe.
 // In most cases, you are better off using V's string interpolation,
@@ -249,7 +249,7 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 				// println("$ch1 $ch2")
 				match ch1 {
 					// h for 16 bit int
-					// hh fot 8 bit int
+					// hh for 8 bit int
 					`h` {
 						if ch2 == `h` {
 							v_sprintf_panic(p_index, pt.len)
@@ -316,7 +316,7 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 				v_sprintf_panic(p_index, pt.len)
 				match ch1 {
 					// h for 16 bit unsigned int
-					// hh fot 8 bit unsigned int
+					// hh for 8 bit unsigned int
 					`h` {
 						if ch2 == `h` {
 							d1 = u64(unsafe { *(&u8(pt[p_index])) })

--- a/vlib/sync/channel_select_6_test.v
+++ b/vlib/sync/channel_select_6_test.v
@@ -44,7 +44,7 @@ fn do_rec_f64(ch chan f64, sumch chan f64) {
 fn test_select() {
 	ch1 := chan int{cap: 3}
 	ch2 := chan int{}
-	// buffer length of chf1 mus be mutiple of 3 (# select threads)
+	// buffer length of chf1 mus be multiple of 3 (# select threads)
 	chf1 := chan f64{cap: 30}
 	chf2 := chan f64{}
 	chsum1 := chan i64{}

--- a/vlib/sync/rwmutex_test.v
+++ b/vlib/sync/rwmutex_test.v
@@ -63,7 +63,7 @@ fn test_try_lock_rwmutex() {
 	assert try_fail_writing2 == false
 
 	mx.runlock()
-	mx.runlock() // you must release rlock mutiple times, as it was rlocked multiple times
+	mx.runlock() // you must release rlock multiple times, as it was rlocked multiple times
 
 	// after mx release all rlock, try_wlock will succeed
 	try_success_writing3 := mx.try_wlock()

--- a/vlib/term/termios/termios_windows.c.v
+++ b/vlib/term/termios/termios_windows.c.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //
-// TODO Windows version needs to be implemented.
+// TODO: Windows version needs to be implemented.
 // Will serve as more advanced input method
 // based on the work of https://github.com/AmokHuginnsson/replxx
 //

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -264,7 +264,7 @@ pub fn (t Time) md() string {
 	return t.get_fmt_date_str(.space, .mmmd)
 }
 
-// TODO test, improve performance
+// TODO: test, improve performance
 // appends ordinal suffix to a number
 fn ordinal_suffix(n int) string {
 	if n > 3 && n < 21 {
@@ -481,11 +481,11 @@ pub fn (t Time) custom_format(s string) string {
 				sb.write_string('${t.day_of_week() + 1}')
 			}
 			'N' {
-				// TODO integrate BC
+				// TODO: integrate BC
 				sb.write_string('AD')
 			}
 			'NN' {
-				// TODO integrate Before Christ
+				// TODO: integrate Before Christ
 				sb.write_string('Anno Domini')
 			}
 			'Z' {
@@ -498,7 +498,7 @@ pub fn (t Time) custom_format(s string) string {
 				}
 			}
 			'ZZ' {
-				// TODO update if minute differs?
+				// TODO: update if minute differs?
 				mut hours := offset() / seconds_per_hour
 				if hours >= 0 {
 					sb.write_string('+${hours:02}00')
@@ -508,7 +508,7 @@ pub fn (t Time) custom_format(s string) string {
 				}
 			}
 			'ZZZ' {
-				// TODO update if minute differs?
+				// TODO: update if minute differs?
 				mut hours := offset() / seconds_per_hour
 				if hours >= 0 {
 					sb.write_string('+${hours:02}:00')

--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -96,7 +96,7 @@ pub fn ticks() i64 {
 
 // str returns the time in the same format as `parse` expects ("YYYY-MM-DD HH:mm:ss").
 pub fn (t Time) str() string {
-	// TODO Define common default format for
+	// TODO: Define common default format for
 	// `str` and `parse` and use it in both ways
 	return t.format_ss()
 }

--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -37,7 +37,7 @@ pub fn (a Any) string() string {
 pub fn (a Any) to_toml() string {
 	match a {
 		map[string]Any {
-			// TODO more format control?
+			// TODO: more format control?
 			return a.to_inline_toml()
 		}
 		[]Any {

--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -510,7 +510,7 @@ fn validate_utf8_codepoint_string(str string) ! {
 		return error('Unicode code point `${str}` is outside the valid Unicode scalar value ranges.')
 	}
 	// Check if the Unicode value is actually in the valid Unicode scalar value ranges.
-	// TODO should probably be transferred / implemented in `utf8.validate(...)` also?
+	// TODO: should probably be transferred / implemented in `utf8.validate(...)` also?
 	if !((int_val >= 0x0000 && int_val <= 0xD7FF) || (int_val >= 0xE000 && int_val <= 0x10FFFF)) {
 		return error('Unicode code point `${str}` is not a valid Unicode scalar value.')
 	}
@@ -535,7 +535,7 @@ fn (c Checker) check_unicode_escape(esc_unicode string) ! {
 		return error('Unicode escape sequence `${esc_unicode}` should be at least ${hex_digits_len} in length.')
 	}
 	sequence = sequence[..hex_digits_len]
-	// TODO not enforced in BurnSushi testsuite??
+	// TODO: not enforced in BurnSushi testsuite??
 	// if !sequence.is_upper() {
 	//	return error('Unicode escape sequence `$esc_unicode` is not in all uppercase.')
 	//}

--- a/vlib/toml/decoder/decoder.v
+++ b/vlib/toml/decoder/decoder.v
@@ -74,7 +74,7 @@ fn (d Decoder) decode_number(mut n ast.Number) ! {
 pub fn decode_quoted_escapes(mut q ast.Quoted) ! {
 	// Setup a scanner in stack memory for easier navigation.
 	mut eat_whitespace := false
-	// TODO use string builder
+	// TODO: use string builder
 	mut decoded_s := ''
 	// See https://toml.io/en/v1.0.0#string for more info on string types.
 	is_basic := q.quote == `\"`

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -271,7 +271,7 @@ fn (p Parser) build_abs_dotted_key(key DottedKey) DottedKey {
 }
 
 // todo_msvc_astring2dkey worksaround a MSVC compile error.
-// TODO remove.
+// TODO: remove.
 fn todo_msvc_astring2dkey(s []string) DottedKey {
 	return s
 }
@@ -1489,7 +1489,7 @@ pub fn (mut p Parser) time() !ast.Time {
 	lit += p.tok.lit
 	p.check(.number)!
 	lit += p.tok.lit
-	// TODO does TOML even have optional seconds?
+	// TODO: does TOML even have optional seconds?
 	// if p.peek_tok.kind == .colon {
 	p.check(.colon)!
 	lit += p.tok.lit

--- a/vlib/toml/tests/alexcrichton_toml_rs_test.v
+++ b/vlib/toml/tests/alexcrichton_toml_rs_test.v
@@ -285,7 +285,7 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 				return '{ "type": "float", "value": "${val}" }'
 			}
 			v := value.i64()
-			// TODO workaround https://github.com/vlang/v/issues/9507
+			// TODO: workaround https://github.com/vlang/v/issues/9507
 			if v == i64(-9223372036854775807 - 1) {
 				return '{ "type": "integer", "value": "-9223372036854775808" }'
 			}

--- a/vlib/toml/tests/burntsushi_toml_test.v
+++ b/vlib/toml/tests/burntsushi_toml_test.v
@@ -25,7 +25,7 @@ const invalid_exceptions = [
 ]
 const valid_value_exceptions = []string{}
 // BUG with string interpolation of '${i64(-9223372036854775808)}') see below for workaround
-//'integer/long.toml', // TODO https://github.com/vlang/v/issues/9507
+//'integer/long.toml', // TODO: https://github.com/vlang/v/issues/9507
 
 const jq = os.find_abs_path_of_executable('jq') or { '' }
 const compare_work_dir_root = os.join_path(os.vtmp_dir(), 'toml', 'burntsushi')
@@ -251,7 +251,7 @@ fn to_burntsushi(value ast.Value) string {
 				return '{ "type": "float", "value": "${val}" }'
 			}
 			v := value.i64()
-			// TODO workaround https://github.com/vlang/v/issues/9507
+			// TODO: workaround https://github.com/vlang/v/issues/9507
 			if v == i64(-9223372036854775807 - 1) {
 				return '{ "type": "integer", "value": "-9223372036854775808" }'
 			}

--- a/vlib/toml/tests/iarna_toml_spec_test.v
+++ b/vlib/toml/tests/iarna_toml_spec_test.v
@@ -367,7 +367,7 @@ fn to_iarna(value ast.Value, skip_value_map bool) string {
 				return '{ "type": "float", "value": "${val}" }'
 			}
 			v := value.i64()
-			// TODO workaround https://github.com/vlang/v/issues/9507
+			// TODO: workaround https://github.com/vlang/v/issues/9507
 			if v == i64(-9223372036854775807 - 1) {
 				if skip_value_map {
 					return '-9223372036854775808'

--- a/vlib/toml/tests/nested_test.v
+++ b/vlib/toml/tests/nested_test.v
@@ -30,7 +30,7 @@ fn test_parse() {
 	// assert false
 
 	assert toml_doc.value('db.enabled').bool()
-	// TODO make this work
+	// TODO: make this work
 	assert toml_doc.value('servers.alpha.ip').string() == '10.0.0.1'
 	assert toml_doc.value('servers.alpha.dc').string() == 'eqdc10'
 

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -486,7 +486,7 @@ pub fn ast_to_any(value ast.Value) Any {
 	}
 
 	return toml.null
-	// TODO decide this
+	// TODO: decide this
 	// panic(@MOD + '.' + @STRUCT + '.' + @FN + ' can\'t convert "$value"')
 	// return Any('')
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -550,7 +550,7 @@ pub:
 	is_unsafe             bool        // true, when [unsafe] is used on a fn
 	is_markused           bool        // true, when an explicit `[markused]` tag was put on a fn; `-skip-unused` will not remove that fn
 	is_file_translated    bool        // true, when the file it resides in is `[translated]`
-	receiver              StructField // TODO this is not a struct field
+	receiver              StructField // TODO: this is not a struct field
 	receiver_pos          token.Pos   // `(u User)` in `fn (u User) name()` position
 	is_method             bool
 	is_static_type_method bool      // true for `fn Foo.bar() {}`
@@ -647,18 +647,19 @@ pub:
 	pos                   token.Pos
 	return_type_pos       token.Pos
 pub mut:
-	return_type       Type
-	receiver_type     Type // != 0, when .is_method == true
-	name              string
-	params            []Param
-	source_fn         voidptr // set in the checker, while processing fn declarations // TODO get rid of voidptr
-	usages            int
-	generic_names     []string
-	dep_names         []string // globals or consts dependent names
-	attrs             []Attr   // all fn attributes
-	is_conditional    bool     // true for `[if abc]fn(){}`
-	ctdefine_idx      int      // the index of the attribute, containing the compile time define [if mytag]
-	from_embeded_type Type     // for interface only, fn from the embedded interface
+	return_type        Type
+	receiver_type      Type // != 0, when .is_method == true
+	name               string
+	params             []Param
+	source_fn          voidptr // set in the checker, while processing fn declarations // TODO: get rid of voidptr
+	usages             int
+	generic_names      []string
+	dep_names          []string // globals or consts dependent names
+	attrs              []Attr   // all fn attributes
+	is_conditional     bool     // true for `[if abc]fn(){}`
+	ctdefine_idx       int      // the index of the attribute, containing the compile time define [if mytag]
+	from_embedded_type Type     // for interface only, fn from the embedded interface
+	from_embeded_type  Type     @[deprecated: 'use from_embedded_type instead'; deprecated_after: '2024-03-31']
 }
 
 fn (f &Fn) method_equals(o &Fn) bool {
@@ -710,8 +711,8 @@ pub fn (f &Fn) new_method_with_receiver_type(new_type_ Type) Fn {
 				new_method.params[i].typ = new_type
 			}
 		}
-		new_method.from_embeded_type = if f.from_embeded_type != 0 {
-			f.from_embeded_type
+		new_method.from_embedded_type = if f.from_embedded_type != 0 {
+			f.from_embedded_type
 		} else {
 			f.params[0].typ
 		}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -51,7 +51,7 @@ pub mut:
 }
 
 // used by vls to avoid leaks
-// TODO remove manual memory management
+// TODO: remove manual memory management
 @[unsafe]
 pub fn (mut t Table) free() {
 	unsafe {
@@ -531,7 +531,7 @@ pub fn (t &Table) find_field(s &TypeSymbol, name string) !StructField {
 					return field
 				}
 				// mut info := ts.info as SumType
-				// TODO a more detailed error so that it's easier to fix?
+				// TODO: a more detailed error so that it's easier to fix?
 				return error('field `${name}` does not exist or have the same type in all sumtype variants')
 			}
 			else {}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1150,7 +1150,7 @@ pub fn (t &Table) type_size(typ Type) (int, int) {
 			size = info.size * elem_size
 			align = elem_align
 		}
-		// TODO hardcoded:
+		// TODO: hardcoded:
 		.map {
 			size = if t.pointer_size == 8 { 120 } else { 80 }
 			align = t.pointer_size
@@ -1338,7 +1338,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			}
 		}
 		.chan {
-			// TODO currently the `chan` struct in builtin is not considered a struct but a chan
+			// TODO: currently the `chan` struct in builtin is not considered a struct but a chan
 			if sym.mod != 'builtin' && sym.name != 'chan' {
 				info := sym.info as Chan
 				mut elem_type := info.elem_type
@@ -1523,7 +1523,7 @@ pub fn (t &Table) fn_signature_using_aliases(func &Fn, import_aliases map[string
 	mut sb := strings.new_builder(20)
 	if !opts.skip_receiver {
 		sb.write_string('fn ')
-		// TODO write receiver
+		// TODO: write receiver
 	}
 	if !opts.type_only {
 		sb.write_string(func.name)

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -169,7 +169,7 @@ pub fn (mut b Builder) parse_imports() {
 	if b.pref.is_vsh {
 		done_imports << 'os'
 	}
-	// TODO (joe): decide if this is correct solution.
+	// TODO: (joe): decide if this is correct solution.
 	// in the case of building a module, the actual module files
 	// are passed via cmd line, so they have already been parsed
 	// by this stage. note that if one files from a module was
@@ -315,7 +315,7 @@ pub fn (b &Builder) import_graph() &depgraph.DepGraph {
 		if p.mod.name !in builtins {
 			deps << 'builtin'
 			if b.pref.backend == .c {
-				// TODO JavaScript backend doesn't handle os for now
+				// TODO: JavaScript backend doesn't handle os for now
 				// os import libraries so we exclude anything which could cause a loop
 				// git grep import vlib/os | cut -f2 -d: | cut -f2 -d" " | sort -u
 				// dl, os, os.cmdline, os.filelock, os.notify, strings, strings.textscanner, term.termios, time

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -794,7 +794,7 @@ fn (mut b Builder) cc_linux_cross() {
 		ldlld = 'ld.lld.exe'
 	}
 	linker_cmd := '${b.quote_compiler_name(ldlld)} ' + linker_args.join(' ')
-	// s = s.replace('SYSROOT', sysroot) // TODO $ inter bug
+	// s = s.replace('SYSROOT', sysroot) // TODO: $ inter bug
 	// s = s.replace('-o hi', '-o ' + c.pref.out_name)
 	if b.pref.show_cc {
 		println(linker_cmd)

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -263,7 +263,7 @@ pub fn (v Builder) get_builtin_files() []string {
 				builtin_files << v.v_files_from_dir(v.pref.bare_builtin_dir)
 			}
 			if v.pref.backend == .c {
-				// TODO JavaScript backend doesn't handle os for now
+				// TODO: JavaScript backend doesn't handle os for now
 				if v.pref.is_vsh && os.exists(os.join_path(location, 'os')) {
 					builtin_files << v.v_files_from_dir(os.join_path(location, 'os'))
 				}

--- a/vlib/v/builder/msvc.v
+++ b/vlib/v/builder/msvc.v
@@ -1,6 +1,6 @@
 module builder
 
-// TODO move this to msvc_default.v
+// TODO: move this to msvc_default.v
 struct MsvcResult {
 	full_cl_exe_path    string
 	exe_path            string

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -25,7 +25,7 @@ fn find_windows_kit_internal(key RegKey, versions []string) !string {
 	$if windows {
 		unsafe {
 			for version in versions {
-				required_bytes := u32(0) // TODO mut
+				required_bytes := u32(0) // TODO: mut
 				result := C.RegQueryValueEx(key, version.to_wide(), 0, 0, 0, &required_bytes)
 				length := required_bytes / 2
 				if result != 0 {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -5,11 +5,11 @@ module checker
 import v.ast
 import v.pref
 
-// TODO 600 line function
+// TODO: 600 line function
 fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 	prev_inside_assign := c.inside_assign
 	c.inside_assign = true
-	c.expected_type = ast.none_type // TODO a hack to make `x := if ... work`
+	c.expected_type = ast.none_type // TODO: a hack to make `x := if ... work`
 	defer {
 		c.expected_type = ast.void_type
 		c.inside_assign = prev_inside_assign
@@ -489,8 +489,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			continue
 		}
 		if c.pref.translated || c.file.is_translated {
-			// TODO fix this in C2V instead, for example cast enums to int before using `|` on them.
-			// TODO replace all c.pref.translated checks with `$if !translated` for performance
+			// TODO: fix this in C2V instead, for example cast enums to int before using `|` on them.
+			// TODO: replace all c.pref.translated checks with `$if !translated` for performance
 			continue
 		}
 		if left_type_unwrapped == 0 {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -416,7 +416,7 @@ fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 
 fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSymbol, exp_type_sym &ast.TypeSymbol) bool {
 	if c.pref.translated {
-		// TODO too open
+		// TODO: too open
 		return true
 	}
 	got_info := got_type_sym.info as ast.FnType

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -411,7 +411,7 @@ pub fn (mut c Checker) check_files(ast_files []&ast.File) {
 				exit(0)
 			} else if file.path.starts_with('./') {
 				// Maybe it's a "./foo.v", linfo.path has an absolute path
-				abs_path := os.join_path(os.getwd(), file.path).replace('/./', '/') // TODO join_path shouldn't have /./
+				abs_path := os.join_path(os.getwd(), file.path).replace('/./', '/') // TODO: join_path shouldn't have /./
 				if abs_path == c.pref.linfo.path {
 					c.check_files([ast_files[i]])
 					exit(0)
@@ -788,7 +788,7 @@ fn (mut c Checker) fail_if_immutable(mut expr ast.Expr) (string, token.Pos) {
 				}
 			} else if expr.obj is ast.ConstField && expr.name in c.const_names {
 				if !c.inside_unsafe && !c.pref.translated {
-					// TODO fix this in c2v, do not allow modification of all consts
+					// TODO: fix this in c2v, do not allow modification of all consts
 					// in translated code
 					c.error('cannot modify constant `${expr.name}`', expr.pos)
 				}
@@ -1418,7 +1418,7 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	c.prevent_sum_type_unwrapping_once = false
 
 	using_new_err_struct_save := c.using_new_err_struct
-	// TODO remove; this avoids a breaking change in syntax
+	// TODO: remove; this avoids a breaking change in syntax
 	if '${node.expr}' == 'err' {
 		c.using_new_err_struct = true
 	}
@@ -1704,7 +1704,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 		if checker.reserved_type_names_chk.matches(util.no_cur_mod(field.name, c.mod)) {
 			c.error('invalid use of reserved type `${field.name}` as a const name', field.pos)
 		}
-		// TODO Check const name once the syntax is decided
+		// TODO: Check const name once the syntax is decided
 		if field.name in c.const_names {
 			name_pos := token.Pos{
 				...field.pos
@@ -1837,7 +1837,7 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 	}
 	for i, mut field in node.fields {
 		if !c.pref.experimental && util.contains_capital(field.name) {
-			// TODO C2V uses hundreds of enums with capitals, remove -experimental check once it's handled
+			// TODO: C2V uses hundreds of enums with capitals, remove -experimental check once it's handled
 			c.error('field name `${field.name}` cannot contain uppercase letters, use snake_case instead',
 				field.pos)
 		}
@@ -2104,7 +2104,7 @@ fn (mut c Checker) stmt(mut node ast.Stmt) {
 				}
 			}
 			c.check_expr_option_or_result_call(node.expr, or_typ)
-			// TODO This should work, even if it's prolly useless .-.
+			// TODO: This should work, even if it's prolly useless .-.
 			// node.typ = c.check_expr_option_or_result_call(node.expr, ast.void_type)
 		}
 		ast.FnDecl {
@@ -4580,7 +4580,7 @@ fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 	}
 	mut typ := ast.new_type(typ_idx)
 	if c.pref.translated || c.file.is_translated {
-		// TODO make more strict
+		// TODO: make more strict
 		node.typ = typ
 		return typ
 	}
@@ -4596,7 +4596,7 @@ fn (mut c Checker) enum_val(mut node ast.EnumVal) ast.Type {
 	}
 	fsym := c.table.final_sym(typ)
 	if fsym.kind != .enum_ && !c.pref.translated && !c.file.is_translated {
-		// TODO in C int fields can be compared to enums, need to handle that in C2V
+		// TODO: in C int fields can be compared to enums, need to handle that in C2V
 		if typ_sym.kind == .placeholder {
 			// If it's a placeholder, the type doesn't exist, print
 			// an error that makes sense here.
@@ -4837,7 +4837,7 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) bool {
 	match sym.kind {
 		.placeholder {
 			// if sym.language == .c && sym.name == 'C.time_t' {
-			// TODO temporary hack until we can define C aliases
+			// TODO: temporary hack until we can define C aliases
 			// return true
 			//}
 			// if sym.language == .v && !sym.name.starts_with('C.') {
@@ -5034,7 +5034,7 @@ fn (mut c Checker) goto_stmt(node ast.GotoStmt) {
 fn (mut c Checker) check_unused_labels() {
 	for name, label in c.goto_labels {
 		if !label.is_used {
-			// TODO show label's location
+			// TODO: show label's location
 			c.warn('label `${name}` defined and not used', label.pos)
 			c.goto_labels[name].is_used = true // so that this warning is not shown again
 		}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -84,7 +84,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 		return c.table.find_type_idx('v.embed_file.EmbedFileData')
 	}
 	if node.is_vweb {
-		// TODO assoc parser bug
+		// TODO: assoc parser bug
 		save_cur_fn := c.table.cur_fn
 		pref_ := *c.pref
 		pref2 := &pref.Preferences{

--- a/vlib/v/checker/errors.v
+++ b/vlib/v/checker/errors.v
@@ -34,7 +34,7 @@ fn (mut c Checker) warn(s string, pos token.Pos) {
 
 fn (mut c Checker) error(message string, pos token.Pos) {
 	if (c.pref.translated || c.file.is_translated) && message.starts_with('mismatched types') {
-		// TODO move this
+		// TODO: move this
 		return
 	}
 	mut msg := message.replace('`Array_', '`[]')
@@ -55,7 +55,7 @@ fn (mut c Checker) error(message string, pos token.Pos) {
 
 fn (mut c Checker) fatal(message string, pos token.Pos) {
 	if (c.pref.translated || c.file.is_translated) && message.starts_with('mismatched types') {
-		// TODO move this
+		// TODO: move this
 		return
 	}
 	msg := message.replace('`Array_', '`[]')

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -169,7 +169,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 		mut sym := c.table.sym(node.receiver.typ)
 		if sym.kind == .array && !c.is_builtin_mod && node.name == 'map' {
-			// TODO `node.map in array_builtin_methods`
+			// TODO: `node.map in array_builtin_methods`
 			c.error('method overrides built-in array method', node.pos)
 		} else if sym.kind == .sum_type && node.name == 'type_name' {
 			c.error('method overrides built-in sum type method', node.pos)
@@ -327,7 +327,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 
 				if param_sym.kind == .string && receiver_sym.kind == .string {
 					// bypass check for strings
-					// TODO there must be a better way to handle that
+					// TODO: there must be a better way to handle that
 				} else if param_sym.kind !in [.struct_, .alias]
 					|| receiver_sym.kind !in [.struct_, .alias] {
 					c.error('operator methods are only allowed for struct and type alias',
@@ -358,7 +358,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			}
 		}
 	}
-	// TODO c.pref.is_vet
+	// TODO: c.pref.is_vet
 	if c.file.is_test && (!node.is_method && (node.short_name.starts_with('test_')
 		|| node.short_name.starts_with('testsuite_'))) {
 		if !c.pref.is_test {
@@ -540,7 +540,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	// If the left expr has an or_block, it needs to be checked for legal or_block statement.
 	left_type := c.expr(mut node.left)
 	c.check_expr_option_or_result_call(node.left, left_type)
-	// TODO merge logic from method_call and fn_call
+	// TODO: merge logic from method_call and fn_call
 	// First check everything that applies to both fns and methods
 	old_inside_fn_arg := c.inside_fn_arg
 	c.inside_fn_arg = true
@@ -576,7 +576,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 			}
 			node.args[i].is_tmp_autofree = true
 		}
-		// TODO copy pasta from above
+		// TODO: copy pasta from above
 		if node.receiver_type == ast.string_type
 			&& node.left !in [ast.Ident, ast.StringLiteral, ast.SelectorExpr] {
 			node.free_receiver = true
@@ -1347,7 +1347,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				} else {
 					param.typ
 				}
-				// TODO duplicated logic in check_types() (check_types.v)
+				// TODO: duplicated logic in check_types() (check_types.v)
 				// Allow enums to be used as ints and vice versa in translated code
 				if param_type.idx() in ast.integer_type_idxs && arg_typ_sym.kind == .enum_ {
 					continue
@@ -1907,9 +1907,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 	if m := c.table.find_method(left_sym, method_name) {
 		method = m
 		has_method = true
-		if left_sym.kind == .interface_ && m.from_embeded_type != 0 {
+		if left_sym.kind == .interface_ && m.from_embedded_type != 0 {
 			is_method_from_embed = true
-			node.from_embed_types = [m.from_embeded_type]
+			node.from_embed_types = [m.from_embedded_type]
 		}
 	} else {
 		if final_left_sym.kind in [.struct_, .sum_type, .interface_, .array] {
@@ -1930,9 +1930,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 					method = m
 					has_method = true
 					is_generic = true
-					if left_sym.kind == .interface_ && m.from_embeded_type != 0 {
+					if left_sym.kind == .interface_ && m.from_embedded_type != 0 {
 						is_method_from_embed = true
-						node.from_embed_types = [m.from_embeded_type]
+						node.from_embed_types = [m.from_embedded_type]
 					}
 				}
 			}
@@ -2526,7 +2526,7 @@ fn (mut c Checker) spawn_expr(mut node ast.SpawnExpr) ast.Type {
 }
 
 fn (mut c Checker) go_expr(mut node ast.GoExpr) ast.Type {
-	// TODO copypasta from spawn_expr
+	// TODO: copypasta from spawn_expr
 	ret_type := c.call_expr(mut node.call_expr)
 	if node.call_expr.or_block.kind != .absent {
 		c.error('option handling cannot be done in `go` call. Do it when calling `.wait()`',

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -189,7 +189,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					ls, _ := c.table.type_size(left_type)
 					rs, _ := c.table.type_size(right_type)
 					// prevent e.g. `u32 == i16` but not `u16 == i32` as max_u16 fits in i32
-					// TODO u32 == i32, change < to <=
+					// TODO: u32 == i32, change < to <=
 					if !c.pref.translated && ((is_left_type_signed && ls < rs)
 						|| (is_right_type_signed && rs < ls)) {
 						lt := c.table.sym(left_type).name
@@ -450,7 +450,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					if left_name == right_name {
 						if !(node.op == .lt && c.pref.translated) {
 							// Allow `&Foo < &Foo` in translated code.
-							// TODO maybe in unsafe as well?
+							// TODO: maybe in unsafe as well?
 							c.error('undefined operation `${left_name}` ${node.op.str()} `${right_name}`',
 								left_right_pos)
 						}
@@ -749,7 +749,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		c.error('bool types only have the following operators defined: `==`, `!=`, `||`, and `&&`',
 			node.pos)
 	} else if left_type == ast.string_type && node.op !in [.plus, .eq, .ne, .lt, .gt, .le, .ge] {
-		// TODO broken !in
+		// TODO: broken !in
 		c.error('string types only have the following operators defined: `==`, `!=`, `<`, `>`, `<=`, `>=`, and `+`',
 			node.pos)
 	} else if left_sym.kind == .enum_ && right_sym.kind == .enum_ && !eq_ne {
@@ -775,7 +775,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	} else if c.table.type_kind(right_type) == .sum_type && !eq_ne {
 		c.error('cannot use operator `${node.op}` with `${right_sym.name}`', node.pos)
 	}
-	// TODO move this to symmetric_check? Right now it would break `return 0` for `fn()?int `
+	// TODO: move this to symmetric_check? Right now it would break `return 0` for `fn()?int `
 	left_is_option := left_type.has_flag(.option)
 	right_is_option := right_type.has_flag(.option)
 	if left_is_option || right_is_option {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -854,7 +854,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 			to_sym := c.table.sym(node.typ)
 			from_info := from_sym.info as ast.Struct
 			to_info := to_sym.info as ast.Struct
-			// TODO this check is too strict
+			// TODO: this check is too strict
 			if !c.check_struct_signature(from_info, to_info)
 				|| !c.check_struct_signature_init_fields(from_info, to_info, node) {
 				c.error('struct `${from_sym.name}` is not compatible with struct `${to_sym.name}`',

--- a/vlib/v/checker/tests/immutable_deref.vv
+++ b/vlib/v/checker/tests/immutable_deref.vv
@@ -3,7 +3,7 @@ struct Context {}
 const ctx_ptr = &Context(unsafe { nil })
 
 fn main() {
-	// TODO unsafe bug, having this declaration inside `unsafe` results in an error
+	// TODO: unsafe bug, having this declaration inside `unsafe` results in an error
 	x := &ctx_ptr
 	unsafe {
 		*x = &Context{}

--- a/vlib/v/checker/tests/infix_err.out
+++ b/vlib/v/checker/tests/infix_err.out
@@ -45,45 +45,45 @@ vlib/v/checker/tests/infix_err.vv:11:7: error: `+` cannot be used with `?int`
    10 | 
    11 | _ = 4 + g()
       |       ^
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
    13 | _ = g() + int(3)
 vlib/v/checker/tests/infix_err.vv:11:9: error: unwrapped Option cannot be used in an infix expression
     9 | _ = f() + f()
    10 | 
    11 | _ = 4 + g()
       |         ~~~
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
    13 | _ = g() + int(3)
 vlib/v/checker/tests/infix_err.vv:12:14: error: unwrapped Option cannot be used in an infix expression
    10 | 
    11 | _ = 4 + g()
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
       |              ~~~
    13 | _ = g() + int(3)
    14 | _ = g() + 3
 vlib/v/checker/tests/infix_err.vv:13:9: error: `+` cannot be used with `?int`
    11 | _ = 4 + g()
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
    13 | _ = g() + int(3)
       |         ^
    14 | _ = g() + 3
    15 |
 vlib/v/checker/tests/infix_err.vv:13:5: error: unwrapped Option cannot be used in an infix expression
    11 | _ = 4 + g()
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
    13 | _ = g() + int(3)
       |     ~~~
    14 | _ = g() + 3
    15 |
 vlib/v/checker/tests/infix_err.vv:14:9: error: `+` cannot be used with `?int`
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
    13 | _ = g() + int(3)
    14 | _ = g() + 3
       |         ^
    15 | 
    16 | // binary operands
 vlib/v/checker/tests/infix_err.vv:14:5: error: unwrapped Option cannot be used in an infix expression
-   12 | _ = int(0) + g() // FIXME not detected
+   12 | _ = int(0) + g() // FIXME: not detected
    13 | _ = g() + int(3)
    14 | _ = g() + 3
       |     ~~~

--- a/vlib/v/checker/tests/infix_err.vv
+++ b/vlib/v/checker/tests/infix_err.vv
@@ -9,7 +9,7 @@ _ = f() + ''
 _ = f() + f()
 
 _ = 4 + g()
-_ = int(0) + g() // FIXME not detected
+_ = int(0) + g() // FIXME: not detected
 _ = g() + int(3)
 _ = g() + 3
 

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -18,7 +18,7 @@ pub fn merge_comments(comments []ast.Comment) string {
 
 // ast_comment_to_doc_comment converts an `ast.Comment` node type to a `DocComment`
 pub fn ast_comment_to_doc_comment(ast_node ast.Comment) DocComment {
-	text := ast_node.text // TODO .trim_left('\x01') // BUG why are this byte here in the first place?
+	text := ast_node.text // TODO: .trim_left('\x01') // BUG why are this byte here in the first place?
 	return DocComment{
 		text: text
 		is_multi: ast_node.is_multi

--- a/vlib/v/eval/expr.c.v
+++ b/vlib/v/eval/expr.c.v
@@ -501,7 +501,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 		}
 		ast.StructInit {
 			// eprintln('unhandled struct init at line $expr.pos.line_nr')
-			return 'helo'
+			return ''
 		}
 		ast.SizeOf {
 			return Uint{e.type_to_size(expr.typ), 64}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -349,7 +349,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 
 	for imp in imports {
 		if imp.mod !in f.used_imports {
-			// TODO bring back once only unused imports are removed
+			// TODO: bring back once only unused imports are removed
 			// continue
 		}
 		if imp.mod in f.auto_imports && imp.mod !in f.used_imports {
@@ -1538,7 +1538,7 @@ pub fn (mut f Fmt) sql_stmt_line(node ast.SqlStmtLine) {
 	sym := f.table.sym(node.table_expr.typ)
 	mut table_name := sym.name
 	if !table_name.starts_with('C.') && !table_name.starts_with('JS.') {
-		table_name = f.no_cur_mod(f.short_module(sym.name)) // TODO f.type_to_str?
+		table_name = f.no_cur_mod(f.short_module(sym.name)) // TODO: f.type_to_str?
 	}
 
 	f.mark_types_import_as_used(node.table_expr.typ)
@@ -1978,7 +1978,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 		if node.left is ast.Ident {
 			// `time.now()` without `time imported` is processed as a method call with `time` being
 			// a `node.left` expression. Import `time` automatically.
-			// TODO fetch all available modules
+			// TODO: fetch all available modules
 			if node.left.name in ['time', 'os', 'strings', 'math', 'json', 'base64']
 				&& !node.left.scope.known_var(node.left.name) {
 				f.file.imports << ast.Import{
@@ -3013,7 +3013,7 @@ pub fn (mut f Fmt) sql_expr(node ast.SqlExpr) {
 	sym := f.table.sym(node.table_expr.typ)
 	mut table_name := sym.name
 	if !table_name.starts_with('C.') && !table_name.starts_with('JS.') {
-		table_name = f.no_cur_mod(f.short_module(sym.name)) // TODO f.type_to_str?
+		table_name = f.no_cur_mod(f.short_module(sym.name)) // TODO: f.type_to_str?
 	}
 	if node.is_count {
 		f.write('count ')

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -234,7 +234,7 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 	sym_name := f.table.sym(node.typ).name
 	// f.write('<old name: $type_sym.name>')
 	mut name := if !sym_name.starts_with('C.') && !sym_name.starts_with('JS.') {
-		f.no_cur_mod(f.short_module(sym_name)) // TODO f.type_to_str?
+		f.no_cur_mod(f.short_module(sym_name)) // TODO: f.type_to_str?
 	} else {
 		sym_name
 	}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -165,7 +165,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 			}
 			if ok {
 				sref_name = '_sref${node.pos.pos}'
-				g.write('${type_to_free} ${sref_name} = (') // TODO we are copying the entire string here, optimize
+				g.write('${type_to_free} ${sref_name} = (') // TODO: we are copying the entire string here, optimize
 				// we can't just do `.str` since we need the extra data from the string struct
 				// doing `&string` is also not an option since the stack memory with the data will be overwritten
 				g.expr(left0) // node.left[0])
@@ -671,7 +671,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					tmp_var := g.new_tmp_var()
 					g.expr_with_tmp_var(val, val_type, var_type, tmp_var)
 				} else if is_fixed_array_var {
-					// TODO Instead of the translated check, check if it's a pointer already
+					// TODO: Instead of the translated check, check if it's a pointer already
 					// and don't generate memcpy &
 					typ_str := g.typ(val_type).trim('*')
 					final_typ_str := if is_fixed_array_var { '' } else { '(${typ_str}*)' }
@@ -769,7 +769,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 
 fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Type, return_sym ast.TypeSymbol) {
 	// multi return
-	// TODO Handle in if_expr
+	// TODO: Handle in if_expr
 	mr_var_name := 'mr_${node.pos.pos}'
 	mut is_option := return_type.has_flag(.option)
 	mut mr_styp := g.typ(return_type.clear_flag(.result))

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1010,7 +1010,7 @@ fn (mut g Gen) typ(t ast.Type) string {
 fn (mut g Gen) base_type(_t ast.Type) string {
 	t := g.unwrap_generic(_t)
 	if g.pref.nofloat {
-		// todo compile time if for perf?
+		// TODO: compile time if for perf?
 		if t == ast.f32_type {
 			return 'u32'
 		} else if t == ast.f64_type {
@@ -1082,7 +1082,7 @@ fn (mut g Gen) expr_string_surround(prepend string, expr ast.Expr, append string
 	return g.out.cut_to(pos)
 }
 
-// TODO this really shouldn't be separate from typ
+// TODO: this really shouldn't be separate from typ
 // but I(emily) would rather have this generation
 // all unified in one place so that it doesn't break
 // if one location changes
@@ -1832,7 +1832,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 							g.expr(stmt.expr)
 							g.writeln(';')
 						} else {
-							// on assignemnt or struct field initialization
+							// on assignment or struct field initialization
 							ret_typ := if g.inside_struct_init || g.inside_assign {
 								stmt.typ
 							} else {
@@ -2233,7 +2233,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			} else {
 				c_name(node.name)
 			}
-			// TODO For some reason, build fails with autofree with this line
+			// TODO: For some reason, build fails with autofree with this line
 			// as it's only informative, comment it for now
 			// g.gen_attrs(node.attrs)
 			// g.writeln('typedef struct {')
@@ -2935,13 +2935,13 @@ fn (mut g Gen) autofree_scope_vars_stop(pos int, line_nr int, free_parent_scopes
 		return
 	}
 	if pos == -1 {
-		// TODO why can pos be -1?
+		// TODO: why can pos be -1?
 		return
 	}
 	// eprintln('> free_scope_vars($pos)')
 	scope := g.file.scope.innermost(pos)
 	if scope.start_pos == 0 {
-		// TODO why can scope.pos be 0? (only outside fns?)
+		// TODO: why can scope.pos be 0? (only outside fns?)
 		return
 	}
 	g.trace_autofree('// autofree_scope_vars(pos=${pos} line_nr=${line_nr} scope.pos=${scope.start_pos} scope.end_pos=${scope.end_pos})')
@@ -2982,7 +2982,7 @@ fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int
 					continue
 				}
 				// if var.typ == 0 {
-				// // TODO why 0?
+				// // TODO: why 0?
 				// continue
 				// }
 				// if v.pos.pos > end_pos {
@@ -3089,7 +3089,7 @@ fn (mut g Gen) autofree_var_call(free_fn_name string, v ast.Var) {
 	// return
 	// }
 	if v.name.contains('expr_write_string_1_') {
-		// TODO remove this temporary hack
+		// TODO: remove this temporary hack
 		return
 	}
 	mut af := strings.new_builder(128)
@@ -4634,7 +4634,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					g.write('.data)')
 				}
 			}
-			// TODO globals hack
+			// TODO: globals hack
 			g.write('_const_')
 		}
 	}
@@ -4808,7 +4808,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			}
 		}
 	} else if node.info is ast.IdentFn {
-		// TODO PERF fn lookup for each fn call in translated mode
+		// TODO: PERF fn lookup for each fn call in translated mode
 		if func := g.table.find_fn(node.name) {
 			if g.pref.translated || g.file.is_translated || func.is_file_translated {
 				// `p_mobjthinker` => `P_MobjThinker`
@@ -4885,7 +4885,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 	} else {
 		styp := g.typ(node.typ)
 		if (g.pref.translated || g.file.is_translated) && sym.kind == .function {
-			// TODO handle the type in fn casts, not just exprs
+			// TODO: handle the type in fn casts, not just exprs
 			/*
 			info := sym.info as ast.FnType
 			if cattr := info.func.attrs.find_first('c') {
@@ -5599,7 +5599,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 }
 
-// check_expr_is_const checks if the expr is elegible to be used as const initializer on C global scope
+// check_expr_is_const checks if the expr is eligible to be used as const initializer on C global scope
 fn (mut g Gen) check_expr_is_const(expr ast.Expr) bool {
 	match expr {
 		ast.StringLiteral, ast.IntegerLiteral, ast.BoolLiteral, ast.FloatLiteral, ast.CharLiteral {
@@ -5999,7 +5999,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		&& !util.should_bundle_module(node.mod) {
 		'extern '
 	} else {
-		'${g.static_modifier} ' // TODO used to be '' before parallel_cc, may cause issues
+		'${g.static_modifier} ' // TODO: used to be '' before parallel_cc, may cause issues
 	}
 	// should the global be initialized now, not later in `vinit()`
 	cinit := node.attrs.contains('cinit')
@@ -7347,7 +7347,7 @@ fn (mut g Gen) interface_table() string {
 				arg := method.params[i]
 				methods_struct_def.write_string(', ${g.typ(arg.typ)} ${arg.name}')
 			}
-			// TODO g.fn_args(method.args[1..])
+			// TODO: g.fn_args(method.args[1..])
 			methods_struct_def.writeln(');')
 		}
 		methods_struct_def.writeln('};')
@@ -7387,7 +7387,7 @@ fn (mut g Gen) interface_table() string {
 			}
 			already_generated_mwrappers[interface_index_name] = current_iinidx
 			current_iinidx++
-			if isym.name != 'vweb.DbInterface' { // TODO remove this
+			if isym.name != 'vweb.DbInterface' { // TODO: remove this
 				sb.writeln('static ${interface_name} I_${cctype}_to_Interface_${interface_name}(${cctype}* x);')
 				mut cast_struct := strings.new_builder(100)
 				cast_struct.writeln('(${interface_name}) {')

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -514,7 +514,7 @@ const c_headers = c_helper_macros + c_unsigned_comparison_functions + c_common_m
 	r'
 // c_headers
 typedef int (*qsort_callback_func)(const void*, const void*);
-#include <stdio.h>  // TODO remove all these includes, define all function signatures and types manually
+#include <stdio.h>  // TODO: remove all these includes, define all function signatures and types manually
 #include <stdlib.h>
 #include <string.h>
 

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -545,7 +545,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 					}
 				}
 				.eq, .ne {
-					// TODO Implement `$if method.args.len == 1`
+					// TODO: Implement `$if method.args.len == 1`
 					if cond.left is ast.SelectorExpr && (g.comptime.comptime_for_field_var.len > 0
 						|| g.comptime.comptime_for_method.len > 0) {
 						if cond.right is ast.StringLiteral {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -69,7 +69,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 	pos := g.out.len
 	should_bundle_module := util.should_bundle_module(node.mod)
 	if g.pref.build_mode == .build_module {
-		// TODO true for not just "builtin"
+		// TODO: true for not just "builtin"
 		// TODO: clean this up
 		mod := if g.is_builtin_mod { 'builtin' } else { node.name.all_before_last('.') }
 		// for now dont skip generic functions as they are being marked as static
@@ -102,7 +102,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 	if node.is_main {
 		g.has_main = true
 	}
-	// TODO PERF remove this from here
+	// TODO: PERF remove this from here
 	is_backtrace := node.name.starts_with('backtrace')
 		&& node.name in ['backtrace_symbols', 'backtrace', 'backtrace_symbols_fd']
 	if is_backtrace {
@@ -129,7 +129,7 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 }
 
 fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
-	// TODO For some reason, build fails with autofree with this line
+	// TODO: For some reason, build fails with autofree with this line
 	// as it's only informative, comment it for now
 	// g.gen_attrs(it.attrs)
 	if node.language == .c {
@@ -199,7 +199,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		g.cur_fn = cur_fn_save
 	}
 	unsafe {
-		// TODO remove unsafe
+		// TODO: remove unsafe
 		g.cur_fn = node
 	}
 	fn_start_pos := g.out.len
@@ -579,7 +579,7 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	}
 	ctx_struct := g.closure_ctx(node.decl)
 	// it may be possible to optimize `memdup` out if the closure never leaves current scope
-	// TODO in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
+	// TODO: in case of an assignment, this should only call "__closure_set_data" and "__closure_set_function" (and free the former data)
 	g.write('__closure_create(${fn_name}, (${ctx_struct}*) memdup_uncollectable(&(${ctx_struct}){')
 	g.indent++
 	for var in node.inherited_vars {
@@ -1614,7 +1614,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		|| node.from_embed_types.len != 0 || (left_type.has_flag(.shared_f) && node.name != 'str')) {
 		// The receiver is a reference, but the caller provided a value
 		// Add `&` automatically.
-		// TODO same logic in call_args()
+		// TODO: same logic in call_args()
 		if !is_range_slice {
 			if !node.left.is_lvalue() {
 				g.write('ADDR(${rec_cc_type}, ')
@@ -1856,7 +1856,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		// For `[c: 'P_TryMove'] fn p_trymove( ... `
 		// every time `p_trymove` is called, `P_TryMove` must be generated instead.
 		if f := g.table.find_fn(node.name) {
-			// TODO PERF fn lookup for each fn call in translated mode
+			// TODO: PERF fn lookup for each fn call in translated mode
 			if cattr := f.attrs.find_first('c') {
 				name = cattr.arg
 			}
@@ -2130,7 +2130,7 @@ fn (mut g Gen) autofree_call_pregen(node ast.CallExpr) {
 	// like `foo(get_string())` or `foo(a + b)`
 	mut free_tmp_arg_vars := g.is_autofree && !g.is_builtin_mod && node.args.len > 0
 		&& !node.args[0].typ.has_flag(.option)
-		&& !node.args[0].typ.has_flag(.result) // TODO copy pasta checker.v
+		&& !node.args[0].typ.has_flag(.result) // TODO: copy pasta checker.v
 	if !free_tmp_arg_vars {
 		return
 	}
@@ -2223,7 +2223,7 @@ fn (mut g Gen) autofree_call_postgen(node_pos int) {
 		match mut obj {
 			ast.Var {
 				// if var.typ == 0 {
-				// // TODO why 0?
+				// // TODO: why 0?
 				// continue
 				// }
 				is_option := obj.typ.has_flag(.option)
@@ -2239,7 +2239,7 @@ fn (mut g Gen) autofree_call_postgen(node_pos int) {
 					// this means this tmp expr var has already been freed
 					continue
 				}
-				obj.is_used = true // TODO bug? sets all vars is_used to true
+				obj.is_used = true // TODO: bug? sets all vars is_used to true
 				g.autofree_variable(obj, is_option)
 				// g.nr_vars_to_free--
 			}
@@ -2369,7 +2369,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 			}
 		} else {
 			if use_tmp_var_autofree {
-				// TODO copypasta, move to an inline fn
+				// TODO: copypasta, move to an inline fn
 				fn_name := node.name.replace('.', '_')
 				name := '_arg_expr_${fn_name}_${i + 1}_${node.pos.pos}'
 				g.write('/*af arg2*/' + name)

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -179,7 +179,7 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 			is_last := j == node.branches.len - 1 && sumtype_index == branch.exprs.len - 1
 			if branch.is_else || (use_ternary && is_last) {
 				if use_ternary {
-					// TODO too many branches. maybe separate ?: matches
+					// TODO: too many branches. maybe separate ?: matches
 					g.write(' : ')
 				} else {
 					g.writeln('')
@@ -424,7 +424,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 		if branch.is_else || (use_ternary && is_last) {
 			if node.branches.len > 1 {
 				if use_ternary {
-					// TODO too many branches. maybe separate ?: matches
+					// TODO: too many branches. maybe separate ?: matches
 					g.write(' : ')
 				} else {
 					g.writeln('')

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -467,7 +467,7 @@ fn (mut g Gen) struct_decl(s ast.Struct, name string, is_anon bool) {
 			g.typedefs.writeln('typedef struct ${name} ${name};')
 		}
 	}
-	// TODO avoid buffer manip
+	// TODO: avoid buffer manip
 	start_pos := g.type_definitions.len
 
 	mut pre_pragma := ''

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -278,7 +278,7 @@ pub fn (mut f Gen) imports(imports []ast.Import) {
 
 	for imp in imports {
 		if imp.mod !in f.used_imports {
-			// TODO bring back once only unused imports are removed
+			// TODO: bring back once only unused imports are removed
 			// continue
 		}
 		if imp.mod in f.auto_imports && imp.mod !in f.used_imports {

--- a/vlib/v/gen/golang/struct.v
+++ b/vlib/v/gen/golang/struct.v
@@ -111,7 +111,7 @@ pub fn (mut f Gen) struct_init(node ast.StructInit) {
 	// f.write('<old name: $type_sym.name>')
 	mut name := type_sym.name
 	if !name.starts_with('C.') && !name.starts_with('JS.') {
-		name = f.no_cur_mod(f.short_module(type_sym.name)) // TODO f.type_to_str?
+		name = f.no_cur_mod(f.short_module(type_sym.name)) // TODO: f.type_to_str?
 	}
 	if name == 'void' {
 		name = ''

--- a/vlib/v/gen/golang/tests/golang_test.v
+++ b/vlib/v/gen/golang/tests/golang_test.v
@@ -6,7 +6,7 @@ const github_job = os.getenv('GITHUB_JOB')
 
 const is_verbose = os.getenv('VTEST_SHOW_CMD') != ''
 
-// TODO some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
+// TODO: some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
 fn test_golang() {
 	// this was failing on ubuntu-docker-musl, skip it for now
 	if github_job == 'ubuntu-docker-musl' {

--- a/vlib/v/gen/js/comptime.v
+++ b/vlib/v/gen/js/comptime.v
@@ -102,7 +102,7 @@ fn (mut g JsGen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 						if interface_sym.info is ast.Interface {
 							// q := g.table.sym(interface_sym.info.types[0])
 							checked_type := g.unwrap_generic(left.typ)
-							// TODO PERF this check is run twice (also in the checker)
+							// TODO: PERF this check is run twice (also in the checker)
 							// store the result in a field
 							is_true := g.table.does_type_implement_interface(checked_type,
 								got_type)
@@ -142,7 +142,7 @@ fn (mut g JsGen) comptime_if_cond(cond ast.Expr, pkg_exist bool) bool {
 					}
 				}
 				.eq, .ne {
-					// TODO Implement `$if method.args.len == 1`
+					// TODO: Implement `$if method.args.len == 1`
 					g.write('1')
 					return true
 				}

--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -638,7 +638,7 @@ fn (mut g JsGen) gen_method_decl(it ast.FnDecl, typ FnGenType) {
 	for attr in it.attrs {
 		if attr.name == 'async' {
 			if g.pref.output_es5 {
-				verror('cannot use [async] attribute when outputing ES5 source code')
+				verror('cannot use [async] attribute when outputting ES5 source code')
 			}
 			has_go = true
 			break

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -246,7 +246,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) stri
 		out += 'const loadRoutine = async () => {\n'
 		for mod, functions in g.wasm_import {
 			if g.pref.backend == .js_browser {
-				out += '\nawait fetch("${mod}").then(respone => respone.arrayBuffer()).then(bytes => '
+				out += '\nawait fetch("${mod}").then(resp => resp.arrayBuffer()).then(bytes => '
 				out += 'WebAssembly.instantiate(bytes,'
 				exports := g.wasm_export[mod]
 				out += '{ imports: { \n'
@@ -942,7 +942,7 @@ fn (mut g JsGen) expr(node_ ast.Expr) {
 			g.gen_if_expr(node)
 		}
 		ast.IfGuardExpr {
-			// TODO no options yet
+			// TODO: no options yet
 		}
 		ast.IndexExpr {
 			g.gen_index_expr(node)
@@ -2218,8 +2218,8 @@ fn (mut g JsGen) gen_ident(node ast.Ident) {
 	if node.kind == .blank_ident || name in ['', '_'] {
 		name = g.new_tmp_var()
 	}
-	// TODO `is`
-	// TODO handle options
+	// TODO: `is`
+	// TODO: handle options
 	g.write(name)
 
 	// TODO: Generate .val for basic types
@@ -2264,7 +2264,7 @@ fn (mut g JsGen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var M
 		if branch.is_else || (node.is_expr && is_last && tmp_var.len == 0) {
 			if node.branches.len > 1 {
 				if is_expr && tmp_var.len == 0 {
-					// TODO too many branches. maybe separate ?: matches
+					// TODO: too many branches. maybe separate ?: matches
 					g.write(' : ')
 				} else {
 					g.writeln('')
@@ -2974,7 +2974,7 @@ fn (mut g JsGen) gen_index_expr(expr ast.IndexExpr) {
 			g.write('))')
 		}
 	} else {
-		// TODO Does this cover all cases?
+		// TODO: Does this cover all cases?
 		g.expr(expr.left)
 		if expr.left_type.is_ptr() {
 			g.write('.valueOf()')

--- a/vlib/v/gen/js/jsgen_test.v
+++ b/vlib/v/gen/js/jsgen_test.v
@@ -52,7 +52,7 @@ fn test_example_compilation() {
 			if there_is_grep_available {
 				grep_code_sourcemap_found := os.system('grep -q -E "//#\\ssourceMappingURL=data:application/json;base64,[-A-Za-z0-9+/=]+$" ${os.quoted_path(jsfile)}')
 				assert grep_code_sourcemap_found == 0
-				println('file has a source map embeded')
+				println('file has a source map embedded')
 			} else {
 				println(' ... skipping testing for sourcemap ${file}, there is no grep present')
 			}

--- a/vlib/v/gen/js/tests/array.v
+++ b/vlib/v/gen/js/tests/array.v
@@ -16,7 +16,7 @@ fn vararg_test() {
 	variadic(1, 2, 3)
 }
 
-// TODO Remove `fn main` once vet supports scripts
+// TODO: Remove `fn main` once vet supports scripts
 fn main() {
 	vararg_test()
 

--- a/vlib/v/gen/js/tests/enum.v
+++ b/vlib/v/gen/js/tests/enum.v
@@ -6,7 +6,7 @@ enum Test {
 	baz
 }
 
-// TODO Remove `fn main` once vet supports scripts
+// TODO: Remove `fn main` once vet supports scripts
 fn main() {
 	mut a := hello.Ccc.a
 	a = .b

--- a/vlib/v/gen/js/tests/interp.v
+++ b/vlib/v/gen/js/tests/interp.v
@@ -38,8 +38,8 @@ fn formatted_string_interpolation() {
 }
 
 /*
-excape_dollar_in_string()
-fn excape_dollar_in_string() {
+escape_dollar_in_string()
+fn escape_dollar_in_string() {
 	i := 42
 	test_fn('($i)', '(42)')
 	println('(\$i)'.contains('i') && !'(\$i)'.contains('42'))

--- a/vlib/v/gen/js/tests/life.v
+++ b/vlib/v/gen/js/tests/life.v
@@ -77,7 +77,7 @@ fn show(game [][]bool) {
 	}
 }
 
-// TODO Remove `fn main` once vet supports scripts
+// TODO: Remove `fn main` once vet supports scripts
 fn main() {
 	mut game := [][]bool{len: h, init: []bool{len: w}}
 

--- a/vlib/v/gen/js/tests/simple_sourcemap.v
+++ b/vlib/v/gen/js/tests/simple_sourcemap.v
@@ -12,7 +12,7 @@ fn main() {
 			println('source map is working')
 		}
 	} else {
-		println('skiping test! node version >=12.12.0 required. Current Version is ${node_version}')
+		println('skipping test! node version >=12.12.0 required. Current Version is ${node_version}')
 	}
 }
 

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1074,7 +1074,7 @@ pub fn (mut c Amd64) pop(reg Amd64Register) {
 pub fn (mut c Amd64) sub8(reg Amd64Register, val i32) {
 	c.g.write8(0x48)
 	c.g.write8(0x83)
-	c.g.write8(0xe8 + i32(reg)) // TODO rax is different?
+	c.g.write8(0xe8 + i32(reg)) // TODO: rax is different?
 	c.g.write8(val)
 	c.g.println('sub8 ${reg},${int(val).hex2()}')
 }
@@ -2217,7 +2217,7 @@ fn (mut c Amd64) assign_right_expr(node ast.AssignStmt, i i32, right ast.Expr, n
 			} else {
 				c.g.n_error('only integers and idents can be used as indexes')
 			}
-			// TODO check if out of bounds access
+			// TODO: check if out of bounds access
 			c.mov_reg_to_var(ident, Amd64Register.eax)
 		}
 	}*/
@@ -2383,7 +2383,7 @@ fn (mut c Amd64) return_stmt(node ast.Return) {
 		for i, expr in node.exprs {
 			offset := c.g.structs[typ.idx()].offsets[i]
 			c.g.expr(expr)
-			// TODO expr not on rax
+			// TODO: expr not on rax
 			c.mov_reg_to_var(var, Amd64Register.rax, offset: offset, typ: ts.mr_info().types[i])
 		}
 		// store the multi return struct value
@@ -2461,7 +2461,7 @@ fn (mut c Amd64) multi_assign_stmt(node ast.AssignStmt) {
 		for i, expr in node.right {
 			offset := multi_return.offsets[i]
 			c.g.expr(expr)
-			// TODO expr not on rax
+			// TODO: expr not on rax
 			c.mov_reg_to_var(var, Amd64Register.rax, offset: offset, typ: node.right_types[i])
 		}
 		// store the multi return struct value
@@ -2736,7 +2736,7 @@ fn (mut c Amd64) prefix_expr(node ast.PrefixExpr) {
 		.not {
 			c.g.expr(node.right)
 			c.cmp_zero(Amd64Register.rax)
-			// TODO mov_extend_reg
+			// TODO: mov_extend_reg
 			c.mov64(Amd64Register.rax, 0)
 			c.cset(.e)
 		}
@@ -2773,7 +2773,7 @@ fn (mut c Amd64) fp_infix_expr(node ast.InfixExpr, left_type ast.Type) {
 		}
 		.gt, .lt, .ge, .le {
 			c.cmp_sse(.xmm0, .xmm1, left_type)
-			// TODO mov_extend_reg
+			// TODO: mov_extend_reg
 			c.mov64(Amd64Register.rax, 0)
 			c.cset(match node.op {
 				.gt { .a }
@@ -2853,7 +2853,7 @@ fn (mut c Amd64) infix_expr(node ast.InfixExpr) {
 	match node.op {
 		.eq, .ne, .gt, .lt, .ge, .le {
 			c.cmp_reg(.rax, .rdx)
-			// TODO mov_extend_reg
+			// TODO: mov_extend_reg
 			c.mov64(Amd64Register.rax, 0)
 			c.cset_op(node.op)
 		}
@@ -3341,7 +3341,7 @@ fn (mut c Amd64) init_struct(var Var, init ast.StructInit) {
 						if f.has_default_expr && !init.init_fields.map(it.name).contains(f.name) {
 							offset := c.g.structs[typ.idx()].offsets[i]
 							c.g.expr(f.default_expr)
-							// TODO expr not on rax
+							// TODO: expr not on rax
 							c.mov_reg_to_var(var, Amd64Register.rax, offset: offset, typ: f.typ)
 						}
 					}
@@ -3355,7 +3355,7 @@ fn (mut c Amd64) init_struct(var Var, init ast.StructInit) {
 				offset := c.g.structs[typ.idx()].offsets[field.i]
 
 				c.g.expr(f.expr)
-				// TODO expr not on rax
+				// TODO: expr not on rax
 				c.mov_reg_to_var(var, Amd64Register.rax, offset: offset, typ: field.typ)
 			}
 		}
@@ -3998,7 +3998,7 @@ fn (mut c Amd64) gen_cast_expr(expr ast.CastExpr) {
 			if c.g.get_type_size(expr.typ) == 8 && !expr.typ.is_signed() {
 				label1 := c.g.labels.new_label()
 				label2 := c.g.labels.new_label()
-				// TODO constant
+				// TODO: constant
 				c.movabs(Amd64Register.rdx, i64(u64(0x4000000000000000)))
 				match c.g.get_type_size(expr.expr_type) {
 					4 {

--- a/vlib/v/gen/native/arm64.v
+++ b/vlib/v/gen/native/arm64.v
@@ -97,7 +97,7 @@ fn (mut c Arm64) neg_regs(a Arm64Register, b Arm64Register) {
 
 fn (mut c Arm64) sub_sp(v i32) {
 	if c.g.pref.arch != .arm64 {
-		c.g.n_error('sub_sp is arm64-specifig')
+		c.g.n_error('sub_sp is arm64-specific')
 		return
 	}
 	// this is for 0x20 only
@@ -140,7 +140,7 @@ pub fn (mut c Arm64) fn_decl(node ast.FnDecl) {
 	mut offset := 0
 	for i in 0 .. node.params.len {
 		name := node.params[i].name
-		// TODO optimize. Right now 2 mov's are used instead of 1.
+		// TODO: optimize. Right now 2 mov's are used instead of 1.
 		g.allocate_var(name, 4, 0)
 		// `mov DWORD PTR [rbp-0x4],edi`
 		offset += 4

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -705,7 +705,7 @@ fn (mut g Gen) unwrap(typ ast.Type) ast.Type {
 
 // get type size, and calculate size and align and store them to the cache when the type is struct
 fn (mut g Gen) get_type_size(raw_type ast.Type) i32 {
-	// TODO type flags
+	// TODO: type flags
 	typ := g.unwrap(raw_type)
 	if raw_type.is_any_kind_of_pointer() || typ.is_any_kind_of_pointer() {
 		return g.code_gen.address_size()
@@ -1165,7 +1165,7 @@ fn (mut g Gen) gen_concat_expr(node ast.ConcatExpr) {
 	for i, expr in node.vals {
 		offset := g.structs[typ.idx()].offsets[i]
 		g.expr(expr)
-		// TODO expr not on rax
+		// TODO: expr not on rax
 		g.code_gen.mov_reg_to_var(var, main_reg,
 			offset: offset
 			typ: ts.mr_info().types[i]

--- a/vlib/v/gen/native/readdll.c.v
+++ b/vlib/v/gen/native/readdll.c.v
@@ -48,7 +48,7 @@ fn (mut g Gen) lookup_system_dll(dll string) !SystemDll {
 			}
 		}
 	} $else {
-		// todo look into librarys dirs
+		// TODO: look into librarys dirs
 		return SystemDll{
 			name: dll
 		}

--- a/vlib/v/gen/native/tests/ifs.vv
+++ b/vlib/v/gen/native/tests/ifs.vv
@@ -26,19 +26,19 @@ fn test_add() {
 	}
 	if 1 == 1 {
 		println('1 == 1')
-		// TODO assert here
+		// TODO: assert here
 	}
 	if 1 != 3 {
 		println('1 != 3')
-		// TODO assert here
+		// TODO: assert here
 	}
 	if 3 != 3 {
 		println('3 != 3 ERROR')
-		// TODO assert here
+		// TODO: assert here
 	}
 	if 1 > 3 {
 		println('1 > 3 ERROR')
-		// TODO assert here
+		// TODO: assert here
 	}
 	if get_bool() {
 		println('bool is true')

--- a/vlib/v/gen/native/tests/native_test.v
+++ b/vlib/v/gen/native/tests/native_test.v
@@ -5,7 +5,7 @@ import term
 
 const is_verbose = os.getenv('VTEST_SHOW_CMD') != ''
 
-// TODO some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
+// TODO: some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
 fn test_native() {
 	$if arm64 {
 		eprintln('>> skipping testing on ARM for now')

--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -320,7 +320,7 @@ pub fn (mut g Gen) bare_function_frame(func_start wasm.PatchPos) {
 	// stack pointer is perfectly acceptable.
 	//
 	if g.stack_frame != 0 {
-		prolouge := g.func.patch_pos()
+		prologue := g.func.patch_pos()
 		{
 			g.func.global_get(g.sp())
 			g.func.i32_const(i32(g.stack_frame))
@@ -332,7 +332,7 @@ pub fn (mut g Gen) bare_function_frame(func_start wasm.PatchPos) {
 				g.func.local_set(g.bp())
 			}
 		}
-		g.func.patch(func_start, prolouge)
+		g.func.patch(func_start, prologue)
 		if !g.is_leaf_function {
 			g.func.global_get(g.sp())
 			g.func.i32_const(i32(g.stack_frame))

--- a/vlib/v/gen/wasm/tests/wasm_test.v
+++ b/vlib/v/gen/wasm/tests/wasm_test.v
@@ -4,7 +4,7 @@ import term
 
 const is_verbose = os.getenv('VTEST_SHOW_CMD') != ''
 
-// TODO some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
+// TODO: some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
 fn test_wasm() {
 	mut runtimes := ['wasmer', 'wasmtime', 'wavm', 'wasm3']
 	mut runtime_found := false

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -34,7 +34,7 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 	fail_code := if opts.exit_code != 0 { opts.exit_code } else { 1 }
 	for c in topic {
 		if !c.is_letter() && !c.is_digit() && c != `-` {
-			print_topic_unkown(topic)
+			print_topic_unknown(topic)
 			exit(fail_code)
 		}
 	}
@@ -51,7 +51,7 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 		}
 	}
 	if topic_path == '' {
-		print_topic_unkown(topic)
+		print_topic_unknown(topic)
 		print_known_topics()
 		exit(fail_code)
 	}
@@ -62,7 +62,7 @@ pub fn print_and_exit(topic string, opts ExitOptions) {
 	exit(opts.exit_code)
 }
 
-fn print_topic_unkown(topic string) {
+fn print_topic_unknown(topic string) {
 	eprintln('error: unknown help topic "${topic}". Use `v help` for usage information.')
 }
 

--- a/vlib/v/help/help_test.v
+++ b/vlib/v/help/help_test.v
@@ -31,7 +31,7 @@ fn test_all_topics() {
 	}
 }
 
-fn test_uknown_topic() {
+fn test_unknown_topic() {
 	res := os.execute(vexe + ' help abc')
 	assert res.exit_code == 1, res.output
 	assert res.output.starts_with('error: unknown help topic "abc".')

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -228,7 +228,7 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 	mut node := unsafe { node_ }
 	match mut node {
 		ast.EmptyExpr {
-			// TODO make sure this doesn't happen
+			// TODO: make sure this doesn't happen
 			// panic('Walker: EmptyExpr')
 		}
 		ast.ComptimeType {}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -416,7 +416,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 					args := p.call_args()
 					p.check(.rpar)
 					mut or_kind := ast.OrKind.absent
-					mut or_stmts := []ast.Stmt{} // TODO remove unnecessary allocations by just using .absent
+					mut or_stmts := []ast.Stmt{} // TODO: remove unnecessary allocations by just using .absent
 					mut or_pos := p.tok.pos()
 					if p.tok.kind == .key_orelse {
 						// `foo() or {}``
@@ -626,7 +626,7 @@ fn (mut p Parser) expr_with_left(left ast.Expr, precedence int, is_stmt_ident bo
 				p.next()
 			}
 			p.next()
-			// return node // TODO bring back, only allow ++/-- in exprs in translated code
+			// return node // TODO: bring back, only allow ++/-- in exprs in translated code
 		} else {
 			return node
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -55,7 +55,7 @@ fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 	last_pos := p.tok.pos()
 	p.check(.rpar)
 	mut pos := first_pos.extend(last_pos)
-	mut or_stmts := []ast.Stmt{} // TODO remove unnecessary allocations by just using .absent
+	mut or_stmts := []ast.Stmt{} // TODO: remove unnecessary allocations by just using .absent
 	mut or_pos := p.tok.pos()
 	if p.tok.kind == .key_orelse {
 		// `foo() or {}``
@@ -297,7 +297,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 	mut name_pos := p.tok.pos()
 	if p.tok.kind == .name {
 		mut check_name := ''
-		// TODO high order fn
+		// TODO: high order fn
 		is_static_type_method = p.tok.lit.len > 0 && p.tok.lit[0].is_capital()
 			&& p.peek_tok.kind == .dot && language == .v // `fn Foo.bar() {}`
 		if is_static_type_method {
@@ -878,7 +878,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 		|| (p.tok.kind == .key_mut && (p.peek_tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
 		|| p.peek_token(2).kind == .comma || p.peek_token(2).kind == .rpar
 		|| (p.peek_tok.kind == .name && p.peek_token(2).kind == .dot)))
-	// TODO copy paste, merge 2 branches
+	// TODO: copy paste, merge 2 branches
 	if types_only {
 		mut param_no := 1
 		for p.tok.kind != .rpar {
@@ -1009,7 +1009,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 				type_pos << p.tok.pos()
 			}
 			if p.tok.kind == .key_mut {
-				// TODO remove old syntax
+				// TODO: remove old syntax
 				if !p.pref.is_fmt {
 					p.warn_with_pos('use `mut f Foo` instead of `f mut Foo`', p.tok.pos())
 				}
@@ -1144,7 +1144,7 @@ fn (mut p Parser) closure_vars() []ast.Param {
 		is_shared := p.tok.kind == .key_shared
 		is_atomic := p.tok.kind == .key_atomic
 		is_mut := p.tok.kind == .key_mut || is_shared || is_atomic
-		// FIXME is_shared & is_atomic aren't used further
+		// FIXME: is_shared & is_atomic aren't used further
 		if is_mut {
 			p.next()
 		}

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -154,7 +154,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		cond := p.expr(0)
 		// 0 .. 10
 		// start := p.tok.lit.int()
-		// TODO use RangeExpr
+		// TODO: use RangeExpr
 		mut high_expr := ast.empty_expr
 		mut is_range := false
 		if p.tok.kind == .ellipsis {

--- a/vlib/v/parser/lock.v
+++ b/vlib/v/parser/lock.v
@@ -60,7 +60,7 @@ fn (mut p Parser) lockable_list() []ast.Expr {
 }
 
 fn (mut p Parser) lock_expr() ast.LockExpr {
-	// TODO Handle aliasing sync
+	// TODO: Handle aliasing sync
 	p.register_auto_import('sync')
 	p.open_scope()
 	defer {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -832,7 +832,7 @@ fn (mut p Parser) top_stmt() ast.Stmt {
 			break
 		}
 	}
-	// TODO remove dummy return statement
+	// TODO: remove dummy return statement
 	// the compiler complains if it's not there
 	return ast.empty_stmt
 }
@@ -898,7 +898,7 @@ fn (mut p Parser) other_stmts(cur_stmt ast.Stmt) ast.Stmt {
 	}
 }
 
-// TODO [if vfmt]
+// TODO: [if vfmt]
 fn (mut p Parser) check_comment() ast.Comment {
 	if p.tok.kind == .comment {
 		return p.comment()
@@ -2236,7 +2236,7 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	if tok.kind == .key_mut && p.tok.kind != .decl_assign {
 		return p.error('expecting `:=` (e.g. `mut x :=`)')
 	}
-	// TODO remove translated
+	// TODO: remove translated
 	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left)
 	} else if !p.pref.translated && !p.is_translated && !p.pref.is_fmt && !p.pref.is_vet
@@ -2797,7 +2797,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 			|| name_w_mod in p.table.type_idxs))
 			|| name.all_after_last('.')[0].is_capital()))) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`
-			// TODO handle C.stat()
+			// TODO: handle C.stat()
 			start_pos := p.tok.pos()
 			mut to_typ := p.parse_type()
 			// this prevents inner casts to also have an `&`
@@ -3276,7 +3276,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		p.next()
 	}
 	// Method call
-	// TODO move to fn.v call_expr()
+	// TODO: move to fn.v call_expr()
 	mut concrete_types := []ast.Type{}
 	mut concrete_list_pos := p.tok.pos()
 	if is_generic_call {

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -655,7 +655,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				p.error_with_pos('duplicate method `${name}`', method_start_pos)
 				return ast.InterfaceDecl{}
 			}
-			params_t, _, is_variadic := p.fn_params() // TODO merge ast.Param and ast.Arg to avoid this
+			params_t, _, is_variadic := p.fn_params() // TODO: merge ast.Param and ast.Arg to avoid this
 			mut params := [
 				ast.Param{
 					name: 'x'

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -242,7 +242,7 @@ pub fn default_tcc_compiler() string {
 }
 
 pub fn (mut p Preferences) default_c_compiler() {
-	// TODO fix $if after 'string'
+	// TODO: fix $if after 'string'
 	$if windows {
 		p.ccompiler = 'gcc'
 		return

--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module pref
 
-// import v.ast // TODO this results in a compiler bug
+// import v.ast // TODO: this results in a compiler bug
 import os.cmdline
 import os
 import v.vcache
@@ -159,7 +159,7 @@ pub mut:
 	retry_compilation      bool = true // retry the compilation with another C compiler, if tcc fails.
 	use_os_system_to_run   bool   // when set, use os.system() to run the produced executable, instead of os.new_process; works around segfaults on macos, that may happen when xcode is updated
 	macosx_version_min     string = '0' // relevant only for macos and ios targets
-	// TODO Convert this into a []string
+	// TODO: Convert this into a []string
 	cflags  string // Additional options which will be passed to the C compiler *before* other options.
 	ldflags string // Additional options which will be passed to the C compiler *after* everything else.
 	// For example, passing -cflags -Os will cause the C compiler to optimize the generated binaries for size.

--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -174,7 +174,7 @@ pub fn (prefs &Preferences) should_compile_c(file string) bool {
 		return false
 	}
 	if prefs.building_v && prefs.output_cross_c && file.ends_with('_windows.v') {
-		// TODO temp hack to make msvc_windows.v work with -os cross
+		// TODO: temp hack to make msvc_windows.v work with -os cross
 		return true
 	}
 	if prefs.os == .windows && (file.ends_with('_nix.c.v') || file.ends_with('_nix.v')) {

--- a/vlib/v/preludes_js/test_runner.v
+++ b/vlib/v/preludes_js/test_runner.v
@@ -38,7 +38,7 @@ fn myeprintln(s string) {
 // / customizing the look & feel of the assertions results easier,
 // / since it is done in normal V code, instead of in embedded C ...
 // //////////////////////////////////////////////////////////////////
-// TODO copy pasta builtin.v fn ___print_assert_failure
+// TODO: copy pasta builtin.v fn ___print_assert_failure
 fn cb_assertion_failed(i VAssertMetaInfo) {
 	filepath := if use_relative_paths { i.fpath } else { os.real_path(i.fpath) }
 	mut final_filepath := filepath + ':${i.line_nr + 1}:'

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -810,14 +810,14 @@ pub fn (mut s Scanner) text_scan() token.Token {
 				return s.new_token(.chartoken, ident_char, ident_char.len + 2) // + two quotes
 			}
 			`(` {
-				// TODO `$if vet {` for performance
+				// TODO: `$if vet {` for performance
 				if s.pref.is_vet && s.text[s.pos + 1] == ` ` {
 					s.vet_error('Looks like you are adding a space after `(`', .vfmt)
 				}
 				return s.new_token(.lpar, '', 1)
 			}
 			`)` {
-				// TODO `$if vet {` for performance
+				// TODO: `$if vet {` for performance
 				if s.pref.is_vet && s.text[s.pos - 1] == ` ` {
 					s.vet_error('Looks like you are adding a space before `)`', .vfmt)
 				}

--- a/vlib/v/slow_tests/valgrind/1.strings_and_arrays.v
+++ b/vlib/v/slow_tests/valgrind/1.strings_and_arrays.v
@@ -133,7 +133,7 @@ fn reassign_arr() {
 	mut foo := Foo2{[10, 20, 30]}
 	foo.nums = [40, 50, 60] // same with struct fields
 	foo.nums = [70, 80, 90]
-	// TODO remove this once structs are freed automatically
+	// TODO: remove this once structs are freed automatically
 	foo.nums.free()
 }
 
@@ -211,7 +211,7 @@ fn tt() {
 }
 
 fn get_string(s string) string {
-	return s.clone() // TODO handle returning the argument without clone()
+	return s.clone() // TODO: handle returning the argument without clone()
 }
 
 fn if_expr() string {

--- a/vlib/v/tests/array_test.v
+++ b/vlib/v/tests/array_test.v
@@ -11,7 +11,7 @@ fn test_enum_val_as_fixed_array_size() {
 	arr1 := [int(Foo.first)]int{}
 	assert arr1 == [0]!
 
-	// TODO check why it fails on MSVC
+	// TODO: check why it fails on MSVC
 	$if !msvc {
 		arr2 := [enum_size]int{}
 		assert arr2 == [0, 0, 0]!

--- a/vlib/v/tests/bench/math_big_gcd/prime/maker.v
+++ b/vlib/v/tests/bench/math_big_gcd/prime/maker.v
@@ -81,7 +81,7 @@ fn read_toml_file() map[string][]string {
 		eprintln(err_msg)
 		panic(err)
 	}
-	// TODO what happens if this goes wrong ?
+	// TODO: what happens if this goes wrong ?
 	tm_primes := tm_doc.value('primes') as map[string]toml.Any
 
 	msg := 'expected a map[string][]string in TOML-data ? corrupt ?'

--- a/vlib/v/tests/comptime_generic_arg_test.v
+++ b/vlib/v/tests/comptime_generic_arg_test.v
@@ -10,7 +10,7 @@ mut:
 	total int
 }
 
-// count_chars count json sizen whithout new encode
+// count_chars count json sizen without new encode
 pub fn (mut count Count) count_chars[T](val T) {
 	$if T is $sumtype {
 		$for v in val.variants {

--- a/vlib/v/tests/comptime_selector_generic_arg_test.v
+++ b/vlib/v/tests/comptime_selector_generic_arg_test.v
@@ -10,7 +10,7 @@ mut:
 	total int
 }
 
-// count_chars count json sizen whithout new encode
+// count_chars count json sizen without new encode
 pub fn (mut count Count) count_chars[T](val T) {
 	$if val is $option {
 		workaround := val

--- a/vlib/v/tests/const_from_multi_branchs_of_if_expr_test.v
+++ b/vlib/v/tests/const_from_multi_branchs_of_if_expr_test.v
@@ -8,7 +8,7 @@ const bin = $if linux {
 	''
 }
 
-fn test_const_from_mutli_branchs_of_if_expr() {
+fn test_const_from_multi_branches_of_if_expr() {
 	println('Hello')
 	assert true
 }

--- a/vlib/v/tests/defer/defer_test.v
+++ b/vlib/v/tests/defer/defer_test.v
@@ -78,7 +78,7 @@ fn test_defer_with_anon_fn() {
 	}()
 	x := fn () {
 		defer {
-			println('defered 2')
+			println('deferred 2')
 		}
 		return
 	}

--- a/vlib/v/tests/for_in_mut_iterator_val_test.v
+++ b/vlib/v/tests/for_in_mut_iterator_val_test.v
@@ -32,7 +32,7 @@ fn (mut p Reader) next() ?&Packet {
 	return unsafe { packets[p.index - 1] }
 }
 
-fn test_for_in_mut_interator_val() {
+fn test_for_in_mut_iterator_val() {
 	r := Reader{}
 	mut rets := []string{}
 

--- a/vlib/v/tests/generics_return_inconsistent_types_generics_struct_test.v
+++ b/vlib/v/tests/generics_return_inconsistent_types_generics_struct_test.v
@@ -79,7 +79,7 @@ pub fn (f Foo) set[T, B](mut opt Optional[T], value T, b B) {
 	opt.typ = typeof(b).name
 }
 
-fn test_inconstent_types_generics_method_return_generics_struct() {
+fn test_inconsistent_types_generics_method_return_generics_struct() {
 	foo := Foo{}
 	mut o := foo.new_some[int, string](23, 'aaa')
 	println(foo.some[int](o))

--- a/vlib/v/tests/interface_eq_methods_with_option_and_ref_test.v
+++ b/vlib/v/tests/interface_eq_methods_with_option_and_ref_test.v
@@ -14,7 +14,7 @@ pub struct Struct {
 	field2 ?&Iface
 }
 
-// test non-ref and embeded
+// test non-ref and embedded
 pub struct Mixin {
 	Derived
 	Struct

--- a/vlib/v/tests/match_test.v
+++ b/vlib/v/tests/match_test.v
@@ -214,7 +214,7 @@ fn test_match_sumtype_multiple_types() {
 	match l {
 		Alfa, Bravo {
 			assert l.char == `a`
-			// TODO make methods work
+			// TODO: make methods work
 			// assert l.letter() == `a`
 		}
 		Charlie {

--- a/vlib/v/tests/multiple_matchs_in_one_expr_test.v
+++ b/vlib/v/tests/multiple_matchs_in_one_expr_test.v
@@ -19,7 +19,7 @@ fn hex_to_bytes(s string) ?[]u8 {
 	return ret
 }
 
-fn test_multiple_matchs_in_one_expr() {
+fn test_multiple_matches_in_one_expr() {
 	ret := hex_to_bytes('FFFF') or { 'error'.bytes() }
 	println(ret)
 	assert '${ret}' == '[85, 85]'

--- a/vlib/v/tests/mut_test.v
+++ b/vlib/v/tests/mut_test.v
@@ -17,7 +17,7 @@ fn test_mut() {
 	mut numbers := [1, 2, 3]
 	foo(7, mut numbers)
 	assert numbers.len == 3
-	// TODO bring back once << works with mutable args
+	// TODO: bring back once << works with mutable args
 	// assert numbers.len == 4
 	// assert numbers[0] == 7
 	// assert numbers[3] == 4

--- a/vlib/v/tests/option_default_values_test.v
+++ b/vlib/v/tests/option_default_values_test.v
@@ -110,7 +110,7 @@ fn test_nested_option_with_opt_fn_call_as_last_value() {
 	assert b == 1
 	c := i_0(0) or { i_0(0) or { 3 } }
 	assert c == 3
-	// TODO Enable once option in boolean expressions are working
+	// TODO: Enable once option in boolean expressions are working
 	// d := b_0(true) or {
 	// 	false && b_0(true) or {
 	// 		true

--- a/vlib/v/tests/string_interpolation_test.v
+++ b/vlib/v/tests/string_interpolation_test.v
@@ -31,7 +31,7 @@ fn test_formatted_string_interpolation() {
 	assert si__left == '23        '
 }
 
-fn test_excape_dollar_in_string() {
+fn test_escape_dollar_in_string() {
 	i := 42
 	assert '(${i})' == '(42)'
 	assert '(\$i)'.contains('i') && !'(\$i)'.contains('42')

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -213,7 +213,7 @@ fn build_keys() map[string]Kind {
 	return res
 }
 
-// TODO remove once we have `enum Kind { name('name') if('if') ... }`
+// TODO: remove once we have `enum Kind { name('name') if('if') ... }`
 fn build_token_str() []string {
 	mut s := []string{len: int(Kind._end_)}
 	s[Kind.unknown] = 'unknown'

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -470,7 +470,7 @@ pub fn (mut t Transformer) expr_stmt_match_expr(mut node ast.MatchExpr) ast.Expr
 }
 
 pub fn (mut t Transformer) for_c_stmt(mut node ast.ForCStmt) ast.Stmt {
-	// TODO we do not optimise array access for multi init
+	// TODO: we do not optimise array access for multi init
 	// for a,b := 0,1; a < 10; a,b = a+b, a {...}
 
 	if node.has_init && !node.is_multi {

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -60,10 +60,10 @@ pub fn qualify_module(pref_ &pref.Preferences, mod string, file_path string) str
 	// relative module (relative to working directory)
 	// TODO: find most stable solution & test with -usecache
 	//
-	// TODO 2022-01-30: Using os.getwd() here does not seem right *at all* imho.
-	// TODO 2022-01-30: That makes lookup dependent on fragile environment factors.
-	// TODO 2022-01-30: The lookup should be relative to the folder, in which the current file is,
-	// TODO 2022-01-30: *NOT* to the working folder of the compiler, which can change easily.
+	// TODO: 2022-01-30: Using os.getwd() here does not seem right *at all* imho.
+	// TODO: 2022-01-30: That makes lookup dependent on fragile environment factors.
+	// TODO: 2022-01-30: The lookup should be relative to the folder, in which the current file is,
+	// TODO: 2022-01-30: *NOT* to the working folder of the compiler, which can change easily.
 	if clean_file_path.replace(os.getwd() + os.path_separator, '') == mod {
 		trace_qualify(@FN, mod, file_path, 'module_res 2', mod, 'clean_file_path - getwd == mod, clean_file_path: ${clean_file_path}')
 		return mod

--- a/vlib/v/util/suggestions.v
+++ b/vlib/v/util/suggestions.v
@@ -71,9 +71,9 @@ pub fn (s Suggestion) say(msg string) string {
 	mut res := msg
 	mut found := false
 	if s.known.len > 0 {
-		top_posibility := s.known.last()
-		if top_posibility.similarity > 0.5 {
-			val := top_posibility.value
+		top_possibility := s.known.last()
+		if top_possibility.similarity > 0.5 {
+			val := top_possibility.value
 			if !val.starts_with('[]') {
 				res += '.\nDid you mean `${highlight_suggestion(val)}`?'
 				found = true

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -270,7 +270,7 @@ pub fn should_recompile_tool(vexe string, tool_source string, tool_name string, 
 		// eprintln('>>> should_recompile_tool: tool_source: $tool_source | $single_file_recompile | $newest_sfile')
 		return single_file_recompile
 	}
-	// TODO Caching should be done on the `vlib/v` level.
+	// TODO: Caching should be done on the `vlib/v` level.
 	mut should_compile := false
 	if !os.exists(tool_exe) {
 		should_compile = true

--- a/vlib/v2/ast/ast.v
+++ b/vlib/v2/ast/ast.v
@@ -81,7 +81,7 @@ pub type Stmt = AsmStmt
 // pub type Decl = ConstDecl | EnumDecl | FnDecl | GlobalDecl
 // 	| InterfaceDecl | StructDecl | TypeDecl
 
-// TOOD: (re)implement nested sumtype like TS (was removed from v)
+// TODO: (re)implement nested sumtype like TS (was removed from v)
 // currently need to cast to type in parser.type. Should I leave like
 // this or add these directly to Expr until nesting is implemented?
 pub type Type = AnonStructType
@@ -121,7 +121,7 @@ pub fn (t Type) name() string {
 	}
 }
 
-// TODO: fix this, shouldbe only what is needed
+// TODO: fix this, should be only what is needed
 pub fn (expr Expr) name() string {
 	return match expr {
 		AsCastExpr {

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -935,12 +935,12 @@ fn (mut p Parser) expr(min_bp token.BindingPower) ast.Expr {
 	}
 
 	// expr chaining
-	// TOOD: make sure there are no cases where we get stuck stuck in this loop
+	// TODO: make sure there are no cases where we get stuck stuck in this loop
 	// for p.tok != .eof {
 	for {
 		// as cast
 		// this could be handled with infix instead
-		// if we choose not to support or chaning
+		// if we choose not to support or chaining
 		if p.tok == .key_as {
 			p.next()
 			lhs = ast.AsCastExpr{

--- a/vlib/v2/scanner/scanner.v
+++ b/vlib/v2/scanner/scanner.v
@@ -57,7 +57,7 @@ pub fn (mut s Scanner) init(file &token.File, src string) {
 
 @[direct_array_access]
 pub fn (mut s Scanner) scan() token.Token {
-	// before whitespace call to keep whitepsaces in string
+	// before whitespace call to keep whitespaces in string
 	// NOTE: before start: simply for a little more efficiency
 	// if !s.skip_interpolation && s.in_str_incomplete {
 	if s.in_str_incomplete {

--- a/vlib/v2/tests/syntax.v_
+++ b/vlib/v2/tests/syntax.v_
@@ -633,7 +633,7 @@ fn main_a() {
 		select from User where name == 'first${user_suffix}'
 	}
 
-	// REMOVE BELOW - TEMP TESTING OR MOVE TO APPRIPRIATE PLACE ABOVE
+	// TODO: REMOVE BELOW - TEMP TESTING OR MOVE TO APPROPRIATE PLACE ABOVE
 
 	x.member.free()
 	x.member.submember1.free()

--- a/vlib/v2/token/position.v
+++ b/vlib/v2/token/position.v
@@ -95,7 +95,7 @@ fn search_files(files []&File, x int) int {
 	}
 	return min - 1
 
-	// linear seach
+	// linear search
 	// for i := files.len-1; i>=0; i-- {
 	// 	file := files[i]
 	// 	if file.base < x && x <= file.base + file.size {
@@ -154,7 +154,7 @@ pub fn (f &File) line_count() int {
 
 pub fn (f &File) line_start(line int) int {
 	return f.line_offsets[line - 1] or {
-		panic('invlid line `${line}` (must be > 0 & < ${f.line_count()})')
+		panic('invalid line `${line}` (must be > 0 & < ${f.line_count()})')
 	}
 }
 

--- a/vlib/v2/types/checker.v
+++ b/vlib/v2/types/checker.v
@@ -240,8 +240,8 @@ fn (mut c Checker) decl(decl ast.Stmt) {
 					// typ: c.expr(field.value)
 				}
 				c.scope.insert(obj.name, obj)
-				// TODO: check if constains references to other consts and only
-				// delay those. or keep dererring until type is known othewise error
+				// TODO: check if contains references to other consts and only
+				// delay those. or keep deferring until type is known otherwise error
 				// work out best way to do this, and use same approach for everything
 				c.later(fn [mut c, field] () {
 					// c.log('updating const $field.name type')
@@ -491,9 +491,9 @@ fn (mut c Checker) expr(expr ast.Expr) Type {
 					}
 					// sum type, check variants
 					if (expected_type is SumType && elem_type !in expected_type.variants)
-						&& elem_type != first_elem_type // everyting else
+						&& elem_type != first_elem_type // everything else
 					  {
-						// TOOD: add generl method for promotion/coersion
+						// TODO: add general method for promotion/coercion
 						c.error_with_pos('expecting element of type: ${first_elem_type.name()}, got ${elem_type.name()}',
 							expr.pos)
 					}
@@ -555,7 +555,7 @@ fn (mut c Checker) expr(expr ast.Expr) Type {
 			return c.expr(c.resolve_call_or_cast_expr(expr))
 		}
 		ast.CallExpr {
-			// TOOD/FIXME: proper
+			// TODO/FIXME:
 			// we need a way to handle C.stat|sigaction() / C.stat|sigaction{}
 			// multiple items with same name inside scope lookup.
 			if expr.lhs is ast.SelectorExpr {
@@ -723,7 +723,7 @@ fn (mut c Checker) expr(expr ast.Expr) Type {
 			}
 		}
 		ast.MapInitExpr {
-			// TOOD: type check keys/vals
+			// TODO: type check keys/vals
 			// `map[type]type{}`
 			if expr.typ !is ast.EmptyExpr {
 				typ := c.expr(expr.typ)
@@ -946,7 +946,7 @@ fn (mut c Checker) expr(expr ast.Expr) Type {
 		}
 		else {}
 	}
-	// TOODO: remove (add all variants)
+	// TODO: remove (add all variants)
 	c.log('expr: unhandled ${expr.type_name()}')
 	return int_
 }
@@ -1681,7 +1681,7 @@ fn (mut c Checker) call_expr(expr ast.CallExpr) Type {
 	// TODO: time.StopWatch has a fields and methods with the same name
 	// and field was being returned instead of the methods. we could set a precedence
 	// however what if the field is a fn type? (i guess one or the other could still habve priority)
-	// TOOD: talk to alex and spy about this
+	// TODO: talk to alex and spy about this
 	if expr.lhs is ast.SelectorExpr {
 		// POO POO
 		// if expr.lhs.lhs is ast.Ident {
@@ -1756,7 +1756,7 @@ fn (mut c Checker) call_expr(expr ast.CallExpr) Type {
 			// eprintln('========================')
 			// if expr.lhs is ast.Ident {
 			// 	if expr.lhs.name == 'generic_fn_d' {
-			// 		panic('.')	
+			// 		panic('.')
 			// 	}
 			// }
 			// dump(generic_type_map)
@@ -1770,8 +1770,8 @@ fn (mut c Checker) call_expr(expr ast.CallExpr) Type {
 		}
 
 		// TODO: is this best place for this?
-		// why is it not beeing used any more? check if we are somehow skipping its uses
-		// need to find a better way to do this, this only happens becasue there are
+		// why is it not being used any more? check if we are somehow skipping its uses
+		// need to find a better way to do this, this only happens because there are
 		// compiler magic, call_expr & selector expr both end up needing information which
 		// the other one has
 		if lhs_expr is ast.SelectorExpr {

--- a/vlib/v2/types/types.v
+++ b/vlib/v2/types/types.v
@@ -230,7 +230,7 @@ type None = u8
 
 fn (t Type) base_type() Type {
 	match t {
-		// TOOD: add base_type method
+		// TODO: add base_type method
 		Alias {
 			return t.base_type
 			// should we fully resolve all aliases, or just one level here?
@@ -254,7 +254,7 @@ fn (t Type) base_type() Type {
 fn (t Type) key_type() Type {
 	match t {
 		Map { return t.key_type }
-		// TOOD: struct here is 'struct string', need to fix this.
+		// TODO: struct here is 'struct string', need to fix this.
 		// we could use an alias? remove once fixed.
 		// Array, ArrayFixed, String, Struct { return int_ }
 		// else { panic('TODO: should never be called on ${t.type_name()}') }

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -323,7 +323,7 @@ executed when the url starts with the defined key.
 In the following example, if a user navigates to `/path/to/test` the middleware
 is executed in the following order: `middleware_func`, `other_func`, `global_middleware`.
 The middleware is executed in the same order as they are defined and if any function in
-the chain returns `false` the propogation is stopped.
+the chain returns `false` the propagation is stopped.
 
 **Example:**
 ```v

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -156,7 +156,7 @@ mut:
 pub:
 	// HTTP Request
 	req http.Request
-	// TODO Response
+	// TODO: Response
 pub mut:
 	done bool
 	// time.ticks() from start of vweb connection handle.
@@ -205,9 +205,9 @@ pub fn (ctx Context) init_server() {
 }
 
 // before_accept_loop is called once the vweb app is started, and listening, but before the loop that accepts
-// incomming request connections.
+// incoming request connections.
 // It will be called in the main thread, that runs vweb.run/2 or vweb.run_at/2.
-// It allows you to be notified about the successfull start of your app, and to synchronise your other threads
+// It allows you to be notified about the successful start of your app, and to synchronise your other threads
 // with the webserver start, without error prone and slow pooling or time.sleep waiting.
 // Defining this method is optional.
 pub fn (ctx &Context) before_accept_loop() {
@@ -219,7 +219,7 @@ pub fn (ctx &Context) before_accept_loop() {
 // Defining this method is optional.
 pub fn (ctx Context) before_request() {}
 
-// TODO - test
+// TODO: test
 // vweb intern function
 @[manualfree]
 pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bool {
@@ -276,7 +276,7 @@ pub fn (mut ctx Context) json_pretty[T](j T) Result {
 	return Result{}
 }
 
-// TODO - test
+// TODO: test
 // Response with file as payload
 pub fn (mut ctx Context) file(f_path string) Result {
 	if !os.exists(f_path) {
@@ -306,7 +306,7 @@ pub fn (mut ctx Context) ok(s string) Result {
 	return Result{}
 }
 
-// TODO - test
+// TODO: test
 // Response a server error
 pub fn (mut ctx Context) server_error(ecode int) Result {
 	$if debug {
@@ -342,7 +342,7 @@ pub fn (mut ctx Context) redirect(url string, params RedirectParams) Result {
 
 // Send an not_found response
 pub fn (mut ctx Context) not_found() Result {
-	// TODO add a [must_be_returned] attribute, so that the caller is forced to use `return app.not_found()`
+	// TODO: add a [must_be_returned] attribute, so that the caller is forced to use `return app.not_found()`
 	if ctx.done {
 		return Result{}
 	}
@@ -351,7 +351,7 @@ pub fn (mut ctx Context) not_found() Result {
 	return Result{}
 }
 
-// TODO - test
+// TODO: test
 // Sets a cookie
 pub fn (mut ctx Context) set_cookie(cookie http.Cookie) {
 	cookie_raw := cookie.str()
@@ -367,7 +367,7 @@ pub fn (mut ctx Context) set_content_type(typ string) {
 	ctx.content_type = typ
 }
 
-// TODO - test
+// TODO: test
 // Sets a cookie with a `expire_date`
 pub fn (mut ctx Context) set_cookie_with_expire_date(key string, val string, expire_date time.Time) {
 	cookie := http.Cookie{
@@ -387,7 +387,7 @@ pub fn (ctx &Context) get_cookie(key string) !string {
 	//}
 }
 
-// TODO - test
+// TODO: test
 // Sets the response status
 pub fn (mut ctx Context) set_status(code int, desc string) {
 	if code < 100 || code > 599 {
@@ -397,13 +397,13 @@ pub fn (mut ctx Context) set_status(code int, desc string) {
 	}
 }
 
-// TODO - test
+// TODO: test
 // Adds an header to the response with key and val
 pub fn (mut ctx Context) add_header(key string, val string) {
 	ctx.header.add_custom(key, val) or {}
 }
 
-// TODO - test
+// TODO: test
 // Returns the header data from the key
 pub fn (ctx &Context) get_header(key string) string {
 	return ctx.req.header.get_custom(key) or { '' }
@@ -1042,7 +1042,7 @@ pub fn (mut ctx Context) host_handle_static(host string, directory_path string, 
 	return true
 }
 
-// TODO - test
+// TODO: test
 // mount_static_folder_at - makes all static files in `directory_path` and inside it, available at http://server/mount_path
 // For example: suppose you have called .mount_static_folder_at('/var/share/myassets', '/assets'),
 // and you have a file /var/share/myassets/main.css .
@@ -1051,7 +1051,7 @@ pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_pat
 	return ctx.host_mount_static_folder_at('', directory_path, mount_path)
 }
 
-// TODO - test
+// TODO: test
 // host_mount_static_folder_at - makes all static files in `directory_path` and inside it, available at http://host/mount_path
 // For example: suppose you have called .host_mount_static_folder_at('localhost', '/var/share/myassets', '/assets'),
 // and you have a file /var/share/myassets/main.css .
@@ -1067,14 +1067,14 @@ pub fn (mut ctx Context) host_mount_static_folder_at(host string, directory_path
 	return true
 }
 
-// TODO - test
+// TODO: test
 // Serves a file static
 // `url` is the access path on the site, `file_path` is the real path to the file, `mime_type` is the file type
 pub fn (mut ctx Context) serve_static(url string, file_path string) {
 	ctx.host_serve_static('', url, file_path)
 }
 
-// TODO - test
+// TODO: test
 // Serves a file static
 // `url` is the access path on the site, `file_path` is the real path to the file
 // `mime_type` is the file type, `host` is the host to serve the file from

--- a/vlib/x/json2/count.v
+++ b/vlib/x/json2/count.v
@@ -57,7 +57,7 @@ fn (mut count Count) count_chars[T](val T) {
 	} $else $if T is $enum {
 		count.count_chars(int(val))
 	} $else $if T is $int {
-		// TODO benchmark
+		// TODO: benchmark
 		mut abs_val := val
 		if val < 0 {
 			count.total++ // -
@@ -85,7 +85,7 @@ fn (mut count Count) count_chars[T](val T) {
 fn (mut count Count) chars_in_struct[T](val T) {
 	count.total += 2 // {}
 	$for field in T.fields {
-		// TODO handle attributes
+		// TODO: handle attributes
 		count.total += field.name.len + 3 // "":
 		workaround := val.$(field.name)
 		count.count_chars(workaround)

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -260,7 +260,7 @@ fn decode_struct[T](_ T, res map[string]Any) !T {
 		}
 	} $else $if T is $map {
 		for k, v in res {
-			// // TODO - make this work to decode types like `map[string]StructType[bool]`
+			// // TODO: make this work to decode types like `map[string]StructType[bool]`
 			// $if typeof(typ[k]).idx is string {
 			// 	typ[k] = v.str()
 			// } $else $if typeof(typ[k]).idx is $struct {

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -302,16 +302,16 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 					str_value := val.$(field.name).str()
 					unsafe { buf.push_many(str_value.str, str_value.len) }
 				} $else $if field.is_array {
-					// TODO - replace for `field.typ is $array`
+					// TODO: replace for `field.typ is $array`
 					e.encode_array(value, level + 1, mut buf)!
 				} $else $if field.typ is $array {
-					// e.encode_array(value, level + 1, mut buf)! // FIXME - error: could not infer generic type `U` in call to `encode_array`
+					// e.encode_array(value, level + 1, mut buf)! // FIXME: error: could not infer generic type `U` in call to `encode_array`
 				} $else $if field.typ is $struct {
 					e.encode_struct(value, level + 1, mut buf)!
 				} $else $if field.is_map {
 					e.encode_map(value, level + 1, mut buf)!
 				} $else $if field.is_enum {
-					// TODO - replace for `field.typ is $enum`
+					// TODO: replace for `field.typ is $enum`
 					// str_value := int(val.$(field.name)).str()
 					// unsafe { buf.push_many(str_value.str, str_value.len) }
 					e.encode_value_with_level(val.$(field.name), level + 1, mut buf)!
@@ -389,7 +389,7 @@ fn (e &Encoder) encode_array[U](val []U, level int, mut buf []u8) ! {
 		} $else $if U is $sumtype {
 			e.encode_value_with_level(val[i], level + 1, mut buf)!
 		} $else $if U is $enum {
-			// TODO test
+			// TODO: test
 			e.encode_value_with_level(val[i], level + 1, mut buf)!
 		} $else {
 			return error('type ${typeof(val).name} cannot be array encoded')
@@ -443,7 +443,7 @@ pub fn (f Any) prettify_json_str() string {
 	return buf.bytestr()
 }
 
-// TODO - Need refactor. Is so slow. The longer the string, the lower the performance.
+// TODO: Need refactor. Is so slow. The longer the string, the lower the performance.
 // encode_string returns the JSON spec-compliant version of the string.
 @[direct_array_access]
 fn (e &Encoder) encode_string(s string, mut buf []u8) ! {

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -224,8 +224,8 @@ pub fn (f Any) to_time() !time.Time {
 			if is_unix_timestamp {
 				return time.unix(f.i64())
 			}
-			// TODO - parse_iso8601
-			// TODO - parse_rfc2822
+			// TODO: parse_iso8601
+			// TODO: parse_rfc2822
 			return time.parse(f)!
 		}
 		else {
@@ -257,7 +257,7 @@ pub fn map_from[T](t T) map[string]Any {
 			} $else $if field.is_option {
 				// TODO
 			} $else {
-				// TODO improve memory usage when convert
+				// TODO: improve memory usage when convert
 				$if field.typ is string {
 					m[field.name] = value.str()
 				} $else $if field.typ is bool {

--- a/vlib/x/json2/strict/strict.v
+++ b/vlib/x/json2/strict/strict.v
@@ -40,7 +40,7 @@ pub fn strict_check[T](json_data string) StructCheckResult {
 					return k.key == field_name
 				}) or { panic('${field.name} not found') }
 
-				// TODO get path here from `last_key.key`
+				// TODO: get path here from `last_key.key`
 				if last_key.value_type == .map {
 					check(val.$(field.name), tokens[last_key.token_pos + 2..], mut duplicates, mut
 						superfluous)

--- a/vlib/x/json2/tests/json_module_compatibility_test/json_test.v
+++ b/vlib/x/json2/tests/json_module_compatibility_test/json_test.v
@@ -214,7 +214,7 @@ fn test_generic_struct() {
 
 type StringAlias = string
 
-// TODO - encode_pretty array, sum types, struct, alias of struct and others...
+// TODO: encode_pretty array, sum types, struct, alias of struct and others...
 struct Foo2 {
 	ux8  u8
 	ux16 u16

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -728,7 +728,7 @@ fn (mut tm DynamicTemplateManager) remaining_template_request(b bool, v int) {
 // The manager handles cache operations in a multithreaded context, accepting up to a list of 200 operation requests. (Define in 'cache_handler_channel_cap' constant)
 // The HTML rendering is stored as a u8 array.
 //
-// TODO - Currently, the cache manager stops when it encounters an internal error requiring a restart of the program.
+// TODO: Currently, the cache manager stops when it encounters an internal error requiring a restart of the program.
 // ( it is designed to ignore external errors since these are already handled in a way that ensures no cache processing requests are affected ),
 // A recovery system will need to be implemented to ensure service continuity.
 //

--- a/vlib/x/vweb/middleware.v
+++ b/vlib/x/vweb/middleware.v
@@ -53,7 +53,7 @@ pub fn (mut m Middleware[T]) use(options MiddlewareOptions[T]) {
 	}
 }
 
-// route_use registers a middlware handler for a specific route(s)
+// route_use registers a middleware handler for a specific route(s)
 pub fn (mut m Middleware[T]) route_use(route string, options MiddlewareOptions[T]) {
 	middleware := RouteMiddleware{
 		url_parts: route.split('/').filter(it != '')
@@ -134,7 +134,7 @@ pub fn encode_gzip[T]() MiddlewareOptions[T] {
 				eprintln('[vweb] error while compressing with gzip: ${err.msg()}')
 				return true
 			}
-			// enables us to have full controll over what response is send over the connection
+			// enables us to have full control over what response is send over the connection
 			// and how.
 			ctx.takeover_conn()
 
@@ -195,7 +195,7 @@ pub:
 	// indicate if clients are able to access other headers than the "CORS-safelisted"
 	// response headers; `Access-Control-Expose-Headers`
 	expose_headers []string
-	// how long the results of a preflight requets can be cached, value is in seconds
+	// how long the results of a preflight request can be cached, value is in seconds
 	// ; `Access-Control-Max-Age`
 	max_age ?int
 }

--- a/vlib/x/vweb/tests/static_handler_test.v
+++ b/vlib/x/vweb/tests/static_handler_test.v
@@ -48,7 +48,7 @@ fn run_app_test() {
 	if _ := app.handle_static('testdata', true) {
 		assert true == false, 'should throw unknown mime type error'
 	} else {
-		assert err.msg().starts_with('unknown MIME type for file extension ".what"'), 'throws error on unkown mime type'
+		assert err.msg().starts_with('unknown MIME type for file extension ".what"'), 'throws error on unknown mime type'
 	}
 
 	app.static_mime_types['.what'] = vweb.mime_types['.txt']


### PR DESCRIPTION
The PR does more chores on the codebase, mainly typo fixing. It also standardizes "todo-comments" to the most common syntax in the project(i.e. ending them with a semicolon). Which is also the default syntax for highlighting such comment snippets by popular plugins like [marketplace.visualstudio.com/vscode-todo-highlight](https://marketplace.visualstudio.com/items?itemName=wayou.vscode-todo-highlight) and *folke/todo-comments.nvim*