### PR TITLE
v: add `@VMODHASH` comptime variable to store the commit sha of a V module

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5732,6 +5732,8 @@ that are substituted at compile time:
   recompiled on a different commit (after local modifications, or after
   using git bisect etc).
 - `@VMOD_FILE` => replaced with the contents of the nearest v.mod file (as a string).
+- `@VMODHASH` => is replaced by the shortened commit hash, derived from the .git directory
+  next to the nearest v.mod file (as a string).
 - `@VMODROOT` => will be substituted with the *folder*,
   where the nearest v.mod file is (as a string).
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3525,9 +3525,9 @@ fn (mut c Checker) at_expr(mut node ast.AtExpr) ast.Type {
 				c.error('@VMODHASH can only be used in projects that have a v.mod file',
 					node.pos)
 			}
-			hash := version.githash(os.dir(vmod_file_location.vmod_file), false)
-			if hash == '' {
-				c.error('failed to find commit hash', node.pos)
+			hash := version.githash(os.dir(vmod_file_location.vmod_file)) or {
+				c.error(err.msg(), node.pos)
+				''
 			}
 			node.val = hash
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3518,6 +3518,19 @@ fn (mut c Checker) at_expr(mut node ast.AtExpr) ast.Type {
 			vmod_file_location := mcache.get_by_file(c.file.path)
 			node.val = os.dir(vmod_file_location.vmod_file)
 		}
+		.vmod_hash {
+			mut mcache := vmod.get_cache()
+			vmod_file_location := mcache.get_by_file(c.file.path)
+			if vmod_file_location.vmod_file.len == 0 {
+				c.error('@VMODHASH can only be used in projects that have a v.mod file',
+					node.pos)
+			}
+			hash := version.githash(os.dir(vmod_file_location.vmod_file), false)
+			if hash == '' {
+				c.error('failed to find commit hash', node.pos)
+			}
+			node.val = hash
+		}
 		.unknown {
 			c.error('unknown @ identifier: ${node.name}. Available identifiers: ${token.valid_at_tokens}',
 				node.pos)

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -402,6 +402,7 @@ fn (mut p Parser) at() ast.AtExpr {
 		'@VEXE' { token.AtKind.vexe_path }
 		'@VEXEROOT' { token.AtKind.vexeroot_path }
 		'@VMODROOT' { token.AtKind.vmodroot_path }
+		'@VMODHASH' { token.AtKind.vmod_hash }
 		'@VROOT' { token.AtKind.vroot_path } // deprecated, use @VEXEROOT or @VMODROOT
 		else { token.AtKind.unknown }
 	}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -176,6 +176,7 @@ pub enum AtKind {
 	v_current_hash
 	vmod_file
 	vmodroot_path
+	vmod_hash
 	vroot_path // obsolete
 	vexeroot_path
 	file_path_line_nr
@@ -187,8 +188,8 @@ pub const assign_tokens = [Kind.assign, .plus_assign, .minus_assign, .mult_assig
 	.unsigned_right_shift_assign]
 
 pub const valid_at_tokens = ['@VROOT', '@VMODROOT', '@VEXEROOT', '@FN', '@METHOD', '@MOD', '@STRUCT',
-	'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@FILE_LINE',
-	'@LOCATION']
+	'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@VMODHASH',
+	'@FILE_LINE', '@LOCATION']
 
 pub const token_str = build_token_str()
 

--- a/vlib/v/util/version/version_test.v
+++ b/vlib/v/util/version/version_test.v
@@ -27,12 +27,12 @@ fn test_githash() {
 	os.write_file('v.mod', '')!
 	os.execute_opt('git add .')!
 	os.execute_opt('git commit -m "test1"')!
-	test_rev := os.execute_opt('git rev-parse --short HEAD')!.output.trim_space()
+	test_rev := os.execute_opt('git rev-parse --short=7 HEAD')!.output.trim_space()
 	assert test_rev == version.githash(git_proj_path)!
 	os.write_file('README.md', '')!
 	os.execute_opt('git add .')!
 	os.execute_opt('git commit -m "test2"')!
-	test_rev2 := os.execute_opt('git rev-parse --short HEAD')!.output.trim_space()
+	test_rev2 := os.execute_opt('git rev-parse --short=7 HEAD')!.output.trim_space()
 	assert test_rev2 != test_rev
 	assert test_rev2 == version.githash(git_proj_path)!
 }


### PR DESCRIPTION
The PR should implement the possibility to store a commit hash of a vmodule as a compile time variable. Similar to Similar to `@VHASH` / `@VCURRENTHASH` for V itself. The reason for it is that I encountered multiple scenarios where it would be useful and function calls in constants are not yet evaluated at comptime.