### PR TITLE
vbuild-tools: prevent module update for sandboxed packaging

### DIFF
--- a/cmd/tools/vbuild-tools.v
+++ b/cmd/tools/vbuild-tools.v
@@ -19,7 +19,9 @@ const tools_in_subfolders = ['vast', 'vcreate', 'vdoc', 'vpm', 'vvet', 'vwhere']
 const non_packaged_tools = ['gen1m', 'gen_vc', 'fast', 'wyhash']
 
 fn main() {
-	util.ensure_modules_for_all_tools_are_installed('-v' in os.args)
+	if os.getenv('VTEST_SANDBOXED_PACKAGING') == '' {
+		util.ensure_modules_for_all_tools_are_installed('-v' in os.args)
+	}
 	args_string := os.args[1..].join(' ')
 	vexe := os.getenv('VEXE')
 	vroot := os.dir(vexe)


### PR DESCRIPTION
For packaging purposes, I need to launch `v build-tools` without any internet access, as Exherbo Linux prevents it at compile time. But the first thing this command does is to check modules and update them, even if they're already there. 

I've added the same env var use before (#21059) to avoid this check and internet access.