### PR TITLE
vtest self: add native_test to skippable tests for sandboxed packaging

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -342,6 +342,7 @@ const skip_on_non_amd64_or_arm64 = [
 const skip_on_sandboxed_packaging = [
 	'do_not_remove',
 	'vlib/v/slow_tests/inout/compiler_test.v',
+	'vlib/v/gen/native/tests/native_test.v',
 	'vlib/v/compiler_errors_test.v',
 	'vlib/v/gen/c/coutput_test.v',
 ]


### PR DESCRIPTION
For packaging purposes, I've added the `native_test` in skipped essential tests from `v test-self`, as Exherbo Linux packages we can't use external compilers/linkers during install. This test use `ld` and then leads to an unfixable error.