### PR TITLE
v: fix `-skip-unused` compilation when using substrings with check

### DIFF
--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -80,6 +80,7 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 			string_idx_str + '.trim',
 			string_idx_str + '.substr',
 			string_idx_str + '.substr_ni',
+			string_idx_str + '.substr_with_check',
 			string_idx_str + '.at',
 			string_idx_str + '.at_with_check',
 			string_idx_str + '.index_kmp',


### PR DESCRIPTION
Fixes compilation with the `skip-unused` flag when using a substr with a check.

```v
// try.v
// v -skip-unused try.v
fn main() {
	try('foo')!
}

fn try(str string) !string {
	return str[..3] or { panic('failed to get substr') }
}
```
With the changes the above code compiles cleanly. Currently, it's throwing:
```
==================
/tmp/v_1000/temp.01HSVATM49ZWGNT7F2C6JJ4RGJ.tmp.c:6007: warning: implicit declaration of function 'string_substr_with_check'
/tmp/v_1000/temp.01HSVATM49ZWGNT7F2C6JJ4RGJ.tmp.c:6007: error: '{' expected (got ";")
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.
```