### PR TITLE
checker: optimize option and result typ check, add more typinfo to error details

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1162,16 +1162,13 @@ fn (mut c Checker) check_expr_option_or_result_call(expr ast.Expr, ret_type ast.
 			}
 			if expr_ret_type.has_option_or_result() {
 				if expr.or_block.kind == .absent && expr_ret_type.has_flag(.result) {
-					ret_typ_desc, ret_typ_tok := if expr_ret_type.has_flag(.option) {
-						'an Option', '?'
-					} else {
-						'a Result', '!'
-					}
+					ret_sym := c.table.sym(expr_ret_type)
+					ret_typ_tok := if expr_ret_type.has_flag(.option) { '?' } else { '!' }
 					if c.inside_defer {
-						c.error('${expr.name}() returns ${ret_typ_desc}, so it should have an `or {}` block at the end',
+						c.error('${expr.name}() returns `${ret_typ_tok}${ret_sym.name}`, so it should have an `or {}` block at the end',
 							expr.pos)
 					} else {
-						c.error('${expr.name}() returns ${ret_typ_desc}, so it should have either an `or {}` block, or `${ret_typ_tok}` at the end',
+						c.error('${expr.name}() returns `${ret_typ_tok}${ret_sym.name}`, so it should have either an `or {}` block, or `${ret_typ_tok}` at the end',
 							expr.pos)
 					}
 				} else if expr.or_block.kind != .absent {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1161,24 +1161,21 @@ fn (mut c Checker) check_expr_option_or_result_call(expr ast.Expr, ret_type ast.
 				}
 			}
 			if expr_ret_type.has_option_or_result() {
-				return_modifier_kind := if expr_ret_type.has_flag(.option) {
-					'an Option'
-				} else {
-					'a Result'
-				}
-				return_modifier := if expr_ret_type.has_flag(.option) { '?' } else { '!' }
-				if expr_ret_type.has_flag(.result) && expr.or_block.kind == .absent {
+				if expr.or_block.kind == .absent && expr_ret_type.has_flag(.result) {
+					ret_typ_desc, ret_typ_tok := if expr_ret_type.has_flag(.option) {
+						'an Option', '?'
+					} else {
+						'a Result', '!'
+					}
 					if c.inside_defer {
-						c.error('${expr.name}() returns ${return_modifier_kind}, so it should have an `or {}` block at the end',
+						c.error('${expr.name}() returns ${ret_typ_desc}, so it should have an `or {}` block at the end',
 							expr.pos)
 					} else {
-						c.error('${expr.name}() returns ${return_modifier_kind}, so it should have either an `or {}` block, or `${return_modifier}` at the end',
+						c.error('${expr.name}() returns ${ret_typ_desc}, so it should have either an `or {}` block, or `${ret_typ_tok}` at the end',
 							expr.pos)
 					}
-				} else {
-					if expr.or_block.kind != .absent {
-						c.check_or_expr(expr.or_block, ret_type, expr_ret_type, expr)
-					}
+				} else if expr.or_block.kind != .absent {
+					c.check_or_expr(expr.or_block, ret_type, expr_ret_type, expr)
 				}
 				return ret_type.clear_flag(.result)
 			} else {

--- a/vlib/v/checker/tests/alias_type_cast_option_result_unhandled_err.out
+++ b/vlib/v/checker/tests/alias_type_cast_option_result_unhandled_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/alias_type_cast_option_result_unhandled_err.vv:15:12: error: ret_abc_result() returns a Result, so it should have either an `or {}` block, or `!` at the end
+vlib/v/checker/tests/alias_type_cast_option_result_unhandled_err.vv:15:12: error: ret_abc_result() returns `!Abc`, so it should have either an `or {}` block, or `!` at the end
    13 | }
    14 | 
    15 | a := Alias(ret_abc_result())

--- a/vlib/v/checker/tests/as_cast_option_result_unhandled_err.out
+++ b/vlib/v/checker/tests/as_cast_option_result_unhandled_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/as_cast_option_result_unhandled_err.vv:11:6: error: ret_sum_result() returns a Result, so it should have either an `or {}` block, or `!` at the end
+vlib/v/checker/tests/as_cast_option_result_unhandled_err.vv:11:6: error: ret_sum_result() returns `!Sum`, so it should have either an `or {}` block, or `!` at the end
     9 | }
    10 | 
    11 | _ := ret_sum_result() as int

--- a/vlib/v/checker/tests/option_type_call_err.out
+++ b/vlib/v/checker/tests/option_type_call_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/option_type_call_err.vv:4:5: error: os.ls() returns a Result, so it should have either an `or {}` block, or `!` at the end
+vlib/v/checker/tests/option_type_call_err.vv:4:5: error: os.ls() returns `![]string`, so it should have either an `or {}` block, or `!` at the end
     2 | 
     3 | fn main() {
     4 |     os.ls('.').filter(it.ends_with('.v')) or { return }

--- a/vlib/v/checker/tests/result_missing_propagate_err.out
+++ b/vlib/v/checker/tests/result_missing_propagate_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/result_missing_propagate_err.vv:6:7: error: result() returns a Result, so it should have either an `or {}` block, or `!` at the end
-    4 |
+vlib/v/checker/tests/result_missing_propagate_err.vv:6:7: error: result() returns `!int`, so it should have either an `or {}` block, or `!` at the end
+    4 | 
     5 | fn main() {
     6 |     a := result()
       |          ~~~~~~~~

--- a/vlib/v/checker/tests/result_type_call_err.out
+++ b/vlib/v/checker/tests/result_type_call_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/result_type_call_err.vv:12:2: error: new_foo() returns a Result, so it should have either an `or {}` block, or `!` at the end
+vlib/v/checker/tests/result_type_call_err.vv:12:2: error: new_foo() returns `!Foo`, so it should have either an `or {}` block, or `!` at the end
    10 | 
    11 | fn main() {
    12 |     new_foo().foo()
@@ -10,7 +10,7 @@ vlib/v/checker/tests/result_type_call_err.vv:12:2: error: Result type cannot be 
    12 |     new_foo().foo()
       |     ~~~~~~~~~
    13 | }
-vlib/v/checker/tests/result_type_call_err.vv:12:12: error: foo() returns a Result, so it should have either an `or {}` block, or `!` at the end
+vlib/v/checker/tests/result_type_call_err.vv:12:12: error: foo() returns `!Foo`, so it should have either an `or {}` block, or `!` at the end
    10 | 
    11 | fn main() {
    12 |     new_foo().foo()

--- a/vlib/v/checker/tests/struct_field_init_with_result_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_result_err.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/struct_field_init_with_result_err.vv:10:18: error: example() returns a Result, so it should have either an `or {}` block, or `!` at the end
-    8 |
+vlib/v/checker/tests/struct_field_init_with_result_err.vv:10:18: error: example() returns `!int`, so it should have either an `or {}` block, or `!` at the end
+    8 | 
     9 | fn main() {
    10 |     println(Example{example()})
       |                     ~~~~~~~~~

--- a/vlib/v/checker/tests/struct_init_field_result_err.out
+++ b/vlib/v/checker/tests/struct_init_field_result_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_init_field_result_err.vv:14:15: error: time.parse() returns a Result, so it should have either an `or {}` block, or `!` at the end
+vlib/v/checker/tests/struct_init_field_result_err.vv:14:15: error: time.parse() returns `!time.Time`, so it should have either an `or {}` block, or `!` at the end
    12 | _ := Payload{
    13 |     sub: "1234567890",
    14 |     exp: time.parse("2019-01-01 00:00:00")


### PR DESCRIPTION
The main change of the PR is improving error messages to provide more details on return types. The changes serve as a base for a bugfix in a followup but take up their own scope so they are submitted separately.

The PR intentionally makes minimal changes to the error messages, keeping it similar to the current state. Imho the error messages can generally be optimized here by using error details to split things up into showing an expressive error message and providing a recommendation for action. But that's a scope for a separate PR as well.

There are also minor optimization to the codeblock of the check. It moves variables assignments deeper into the block scope where they are used and removes a duplicate conditional check. Modern compilers should be smart enough to optimize such variable assignments, so the optimization likely mainly helps with read-/maintainability.
