### PR TITLE
parser: improve expected token detection in error messages for unterminated fn calls

### DIFF
--- a/vlib/v/parser/tests/fn_call_unexpected_eof_err.out
+++ b/vlib/v/parser/tests/fn_call_unexpected_eof_err.out
@@ -1,0 +1,3 @@
+vlib/v/parser/tests/fn_call_unexpected_eof_err.vv:5:1: error: unexpected eof, expecting `)`
+    3 | println(os.file_last_mod_unix('x.v')
+    4 |

--- a/vlib/v/parser/tests/fn_call_unexpected_eof_err.vv
+++ b/vlib/v/parser/tests/fn_call_unexpected_eof_err.vv
@@ -1,0 +1,4 @@
+import os
+
+println(os.file_last_mod_unix('x.v')
+


### PR DESCRIPTION
Fixes #21100

So that the expected token is shown as `)` instead of `,`.

```v
import os

println(os.file_last_mod_unix('x.v')
```

```v
import os

fn foo(i i64) {
	println(i)
}

foo(os.file_last_mod_unix('x.v')
```