### PR TITLE
tools: fix build for tools in subfolders

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -543,7 +543,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	}
 	ts.benchmark.step()
 	tls_bench.step()
-	if abs_path in ts.skip_files {
+	if !ts.build_tools && abs_path in ts.skip_files {
 		ts.benchmark.skip()
 		tls_bench.skip()
 		if !testing.hide_skips {


### PR DESCRIPTION
- In 'cmd/tools/vbuild-tools.v', vast, vcreate, vdoc, vpm, vvet and vwhere tools (sources in subfolders) are initially skipped, then added into a test session.
- During session run (function 'worker_trunner'), build was skipped for the tools list above.

- Fix vlang/v#21119

---
Build with `./v build-tools` OK on Linux Debian testing/amd64 and OpenBSD current/amd64
