### PR TITLE
cgen: fix C struct sumtype support

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -72,7 +72,7 @@ fn (mut g Gen) gen_sumtype_equality_fn(left_type ast.Type) string {
 	for typ in info.variants {
 		variant := g.unwrap(typ)
 		fn_builder.writeln('\tif (${left_typ} == ${int(variant.typ)}) {')
-		name := '_${g.get_sumtype_variant_name(variant.typ, variant.sym.cname)}'
+		name := '_${g.get_sumtype_variant_name(variant.typ, variant.sym)}'
 
 		left_arg := g.read_field(left_type, name, 'a')
 		right_arg := g.read_field(left_type, name, 'b')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -465,7 +465,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, typ_str
 			fn_builder.write_string('\t\tcase ${int(typ)}: return ${res};\n')
 		} else {
 			mut val := '${func_name}(${deref}(${typ_name}*)x._${g.get_sumtype_variant_name(typ,
-				sym.cname)}'
+				sym)}'
 			if should_use_indent_func(sym.kind) && !sym_has_str_method {
 				val += ', indent_count'
 			}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -440,8 +440,13 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, typ_str
 		typ_name := g.typ(typ)
 		mut func_name := g.get_str_fn(typ)
 		sym := g.table.sym(typ)
+		is_c_struct := sym.is_c_struct()
 		sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
-		deref := if sym_has_str_method && str_method_expects_ptr { ' ' } else { '*' }
+		deref := if is_c_struct || (sym_has_str_method && str_method_expects_ptr) {
+			' '
+		} else {
+			'*'
+		}
 		if should_use_indent_func(sym.kind) && !sym_has_str_method {
 			func_name = 'indent_${func_name}'
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2365,6 +2365,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	mut type_idx := g.type_sidx(got)
 	mut sb := strings.new_builder(128)
 	mut is_anon_fn := false
+	mut variant_name := g.get_sumtype_variant_name(got, got_sym)
 	if got_sym.info is ast.FnType {
 		got_name := 'fn ${g.table.fn_type_source_signature(got_sym.info.func)}'
 		got_cname = 'anon_fn_${g.table.fn_type_signature(got_sym.info.func)}'
@@ -2374,8 +2375,8 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 			variant_sym := g.table.sym(variant)
 			if variant_sym.info is ast.FnType {
 				if g.table.fn_type_source_signature(variant_sym.info.func) == g.table.fn_type_source_signature(got_sym.info.func) {
-					got_cname = variant_sym.cname
-					type_idx = variant.idx().str()
+					variant_name = g.get_sumtype_variant_name(variant, variant_sym)
+					type_idx = int(variant).str()
 					break
 				}
 			}
@@ -2405,7 +2406,6 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 		// if the variable is not used, the C compiler will optimize it away
 		sb.writeln('\t${embed_cname}* ${embed_name}_ptr = memdup(${accessor}, sizeof(${embed_cname}));')
 	}
-	variant_name := g.get_sumtype_variant_name(got, got_sym)
 	sb.write_string('\treturn (${exp_cname}){ ._${variant_name} = ptr, ._typ = ${type_idx}')
 	for field in (exp_sym.info as ast.SumType).fields {
 		mut ptr := 'ptr'

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2376,6 +2376,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 			if variant_sym.info is ast.FnType {
 				if g.table.fn_type_source_signature(variant_sym.info.func) == g.table.fn_type_source_signature(got_sym.info.func) {
 					variant_name = g.get_sumtype_variant_name(variant, variant_sym)
+					got_cname = g.get_sumtype_variant_type_name(variant, variant_sym)
 					type_idx = int(variant).str()
 					break
 				}

--- a/vlib/v/tests/c_structs/cstruct.h
+++ b/vlib/v/tests/c_structs/cstruct.h
@@ -20,8 +20,3 @@ typedef struct Foo {
 typedef struct Bar {
     int a;
 } Bar;
-
-typedef union Baz {
-    Foo foo;
-    Bar bar;
-} Baz;

--- a/vlib/v/tests/c_structs/cstruct.h
+++ b/vlib/v/tests/c_structs/cstruct.h
@@ -10,3 +10,18 @@ typedef struct Test2 {
 typedef struct Test1 {
     Test2 a;
 } Test1;
+
+/////
+
+typedef struct Foo {
+    int a;
+} Foo;
+
+typedef struct Bar {
+    int a;
+} Bar;
+
+typedef union Baz {
+    Foo foo;
+    Bar bar;
+} Baz;

--- a/vlib/v/tests/c_structs/cstruct_sumtype_test.v
+++ b/vlib/v/tests/c_structs/cstruct_sumtype_test.v
@@ -1,0 +1,22 @@
+#include "@VMODROOT/cstruct.h"
+
+const the_string = 'the string'
+
+@[typedef]
+struct C.Foo {
+	a int
+}
+
+struct C.Bar {
+	a int
+}
+
+type Baz = C.Bar | C.Foo
+
+fn test_cstruct() {
+	a := Baz(C.Foo{
+		a: 1000
+	})
+	dump(a)
+	assert (a as C.Foo).a == 1000
+}


### PR DESCRIPTION
Fix #21122

```v
#include "@VMODROOT/foo.h"

struct C.Foo {
	a int
}

struct C.Bar {
	a int
}

type Baz = C.Foo | C.Bar

fn main() {
	mut a := Baz{}
	a = C.Foo{a: 1000}
	dump(a)	
}
```