### PR TITLE
vet: skip testdata dirs

### DIFF
--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -96,7 +96,8 @@ fn main() {
 
 // vet_file vets the file read from `path`.
 fn (mut vt Vet) vet_file(path string) {
-	if !vt.opt.is_force && (path.contains('/tests/') || path.contains('/slow_tests/')) {
+	if !vt.opt.is_force && (path.contains('/tests/') || path.contains('/slow_tests/')
+		|| path.contains('/testdata/')) {
 		// skip all /tests/ files, since usually their content is not
 		// important enough to be documented/vetted, and they may even
 		// contain intentionally invalid code.


### PR DESCRIPTION
Same reason as sated in the block of the code for the `/tests/` directory. 
Currently even e.g. `_input.vv` a testdata dir are vetted.
It will allow to extend automatic code vetting on actual module code.

> ```
> // skip all /tests/ files, since usually their content is not
> // important enough to be documented/vetted, and they may even
> // contain intentionally invalid code.
> ```