### PR TITLE
checker: detect redundant ref when assigning call expr with ref return

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4259,7 +4259,8 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 		}
 	}
 	// TODO: testing ref/deref strategy
-	if node.op == .amp && !right_type.is_ptr() {
+	right_is_ptr := right_type.is_ptr()
+	if node.op == .amp && (!right_is_ptr || (right_is_ptr && node.right is ast.CallExpr)) {
 		mut expr := node.right
 		// if ParExpr get the innermost expr
 		for mut expr is ast.ParExpr {

--- a/vlib/v/checker/tests/assign_ref_call_expr_with_ref_return_err.out
+++ b/vlib/v/checker/tests/assign_ref_call_expr_with_ref_return_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/assign_ref_call_expr_with_ref_return_err.vv:8:6: error: cannot take the address of foo()
+    6 | }
+    7 | 
+    8 | _ := &foo()
+      |      ^
+    9 |

--- a/vlib/v/checker/tests/assign_ref_call_expr_with_ref_return_err.vv
+++ b/vlib/v/checker/tests/assign_ref_call_expr_with_ref_return_err.vv
@@ -1,0 +1,9 @@
+@[heap]
+struct Foo {}
+
+fn foo() &Foo {
+	return &Foo{}
+}
+
+_ := &foo()
+


### PR DESCRIPTION
Fixes:
```v
@[heap]
struct Foo {}

fn foo() &Foo {
	return &Foo{}
}

_ := &foo()
```
throwing:
```
error: lvalue expected
...
==================
(Use `v -cg` to print the entire error message)

builder error: 
==================
C error. This should never happen.
```