### PR TITLE
vet: allow to overwrite excluded dirs

### DIFF
--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -34,8 +34,7 @@ fn check_path(vexe string, dir string, tests []string) int {
 	for path in paths {
 		program := path
 		print(path + ' ')
-		// -force is needed so that `v vet` would not skip the regression files
-		res := os.execute('${os.quoted_path(vexe)} vet -force -nocolor ${os.quoted_path(program)}')
+		res := os.execute('${os.quoted_path(vexe)} vet -nocolor ${os.quoted_path(program)}')
 		if res.exit_code < 0 {
 			panic(res.output)
 		}

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -63,13 +63,8 @@ fn main() {
 			vt.vet_file(path)
 		}
 		if os.is_dir(path) {
-			mut overwrite_exclude := false
-			for d in exclude_dirs {
-				if path.contains(d) {
-					overwrite_exclude = true
-				}
-			}
 			vt.vprintln("vetting folder: '${path}' ...")
+			overwrite_exclude := exclude_dirs.any(path.contains(it))
 			os.walk(path, fn [mut vt, overwrite_exclude] (p string) {
 				if p.ends_with('.v') || p.ends_with('.vv') {
 					if !overwrite_exclude {

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -37,7 +37,6 @@ fn main() {
 	vet_options := cmdline.options_after(os.args, ['vet'])
 	mut vt := Vet{
 		opt: Options{
-			is_force: '-force' in vet_options
 			is_werror: '-W' in vet_options
 			is_verbose: '-verbose' in vet_options || '-v' in vet_options
 			show_warnings: '-hide-warnings' !in vet_options && '-w' !in vet_options

--- a/vlib/v/help/common/vet.txt
+++ b/vlib/v/help/common/vet.txt
@@ -14,6 +14,3 @@ Options:
 
   -p                  Report private functions with missing documentation too
                       (by default, only the `pub fn` functions will be reported).
-
-  -force              (NB: vet development only!)
-                      Do not skip the vet regression tests.


### PR DESCRIPTION
Allows to run vet over paths that include e.g. `tests` or `testdata` when explictly passing them. Currently, they will be excluded without any information.

```sh
# Current
v vet vlib/v/fmt/testdata # Silently skipped

# With changes
v vet vlib/v/fmt/testdata # Vetted when explicitly specified
v vet vlib/v/fmt # Subdir /testdata will skipped
```

This feature also removes the need for keeping a flag that was used for vet development / test purposes.

E.g. checking out the first commit that just removes the flag before extending the functionality and running below will show the problems solved.
```
v cmd/tools/vvet/vet_test.v
```

