### PR TITLE
checker: fix multi return using nil and voidptr

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3855,7 +3855,12 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 	mut mr_types := []ast.Type{}
 	for mut expr in node.vals {
-		mr_types << c.expr(mut expr)
+		mut typ := c.expr(mut expr)
+		if typ == ast.nil_type {
+			// nil and voidptr produces the same struct type name
+			typ = ast.voidptr_type
+		}
+		mr_types << typ
 	}
 	if node.vals.len == 1 {
 		typ := mr_types[0]

--- a/vlib/v/tests/multi_return_nil_voidptr_test.v
+++ b/vlib/v/tests/multi_return_nil_voidptr_test.v
@@ -1,0 +1,17 @@
+fn ret_int_ptr(arg int) !(int, voidptr) {
+	if arg < 0 {
+		return error('argument is smaller then zero')
+	}
+	return 1, [1, 2, 3].data
+}
+
+fn test_main() {
+	mut val1 := 0
+	mut val2 := unsafe { nil }
+	val1, val2 = ret_int_ptr(-1) or {
+		println(err)
+		val1, val2
+	}
+	assert val1 == 0
+	assert val2 == unsafe { nil }
+}


### PR DESCRIPTION
Fix #17343