### PR TITLE
parser, checker: move error handling for `any` type to the checker to resolve parsing issues

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -579,11 +579,17 @@ fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 		}
 		// The rest of the parent symbol kinds are also allowed, since they are either primitive types,
 		// that in turn do not allow recursion, or are abstract enough so that they can not be checked at comptime:
+		.any {
+			if parent_typ_sym.language != .js && !node.parent_type.has_flag(.generic)
+				&& c.file.mod.name != 'builtin' {
+				c.error('cannot use type `any` here', node.type_pos)
+			}
+		}
 		else {}
 		/*
 		.voidptr, .byteptr, .charptr {}
 		.char, .rune, .bool {}
-		.string, .enum_, .none_, .any {}
+		.string, .enum_, .none_,
 		.i8, .i16, .int, .i64, .isize {}
 		.u8, .u16, .u32, .u64, .usize {}
 		.f32, .f64 {}
@@ -649,6 +655,9 @@ and use a reference to the sum type instead: `var := &${node.name}(${variant_nam
 			c.error('unknown type `${sym.name}`', variant.pos)
 		} else if sym.kind == .interface_ && sym.language != .js {
 			c.error('sum type cannot hold an interface', variant.pos)
+		} else if sym.kind == .any && !variant.typ.has_flag(.generic)
+			&& c.file.mod.name != 'builtin' {
+			c.error('cannot use type `any` here', variant.pos)
 		} else if sym.kind == .struct_ && sym.language == .js {
 			c.error('sum type cannot hold a JS struct', variant.pos)
 		} else if sym.info is ast.Struct {
@@ -3038,6 +3047,10 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 
 	if to_type.has_flag(.result) {
 		c.error('casting to Result type is forbidden', node.pos)
+	}
+	if to_sym.kind == .any && to_sym.language != .js && !to_type.has_flag(.generic)
+		&& c.file.mod.name != 'builtin' {
+		c.error('cannot use type `any` here', node.pos)
 	}
 
 	if (to_sym.is_number() && from_sym.name == 'JS.Number')

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -182,12 +182,9 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 						c.warn('byte is deprecated, use u8 instead', field.type_pos)
 					}
 				}
-				.any {
-					if sym.language != .js && !has_generic_types && c.file.mod.name != 'builtin' {
-						c.error('cannot use type `any` here', field.type_pos)
-					}
+				else {
+					c.check_any_type(field.typ, sym, field.type_pos)
 				}
-				else {}
 			}
 
 			if field.has_default_expr {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -182,6 +182,11 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 						c.warn('byte is deprecated, use u8 instead', field.type_pos)
 					}
 				}
+				.any {
+					if sym.language != .js && !has_generic_types && c.file.mod.name != 'builtin' {
+						c.error('cannot use type `any` here', field.type_pos)
+					}
+				}
 				else {}
 			}
 

--- a/vlib/v/checker/tests/any_type_err.out
+++ b/vlib/v/checker/tests/any_type_err.out
@@ -1,0 +1,41 @@
+vlib/v/checker/tests/any_type_err.vv:3:16: error: cannot use type `any` here
+    1 | // Any types should error, while parametrically polymorphic should not.
+    2 | 
+    3 | type AnyType = any
+      |                ~~~
+    4 | type AnySumType = any | string
+    5 | type AnyPolySumType = T | any
+vlib/v/checker/tests/any_type_err.vv:4:19: error: cannot use type `any` here
+    2 | 
+    3 | type AnyType = any
+    4 | type AnySumType = any | string
+      |                   ~~~
+    5 | type AnyPolySumType = T | any
+    6 |
+vlib/v/checker/tests/any_type_err.vv:5:27: error: cannot use type `any` here
+    3 | type AnyType = any
+    4 | type AnySumType = any | string
+    5 | type AnyPolySumType = T | any
+      |                           ~~~
+    6 | 
+    7 | type PolyType = T
+vlib/v/checker/tests/any_type_err.vv:11:6: error: cannot use type `any` here
+    9 | 
+   10 | struct AnyStructField {
+   11 |     foo any
+      |         ~~~
+   12 |     bar T
+   13 | }
+vlib/v/checker/tests/any_type_err.vv:10:1: error: generic struct `AnyStructField` declaration must specify the generic type names, e.g. AnyStructField[T]
+    8 | type PolySumType = T | string
+    9 | 
+   10 | struct AnyStructField {
+      | ~~~~~~~~~~~~~~~~~~~~~
+   11 |     foo any
+   12 |     bar T
+vlib/v/checker/tests/any_type_err.vv:16:7: error: cannot use type `any` here
+   14 | 
+   15 | fn any_cast() {
+   16 |     _ := any('foo')
+      |          ~~~~~~~~~~
+   17 | }

--- a/vlib/v/checker/tests/any_type_err.out
+++ b/vlib/v/checker/tests/any_type_err.out
@@ -21,18 +21,11 @@ vlib/v/checker/tests/any_type_err.vv:5:27: error: cannot use type `any` here
     7 | type PolyType = T
 vlib/v/checker/tests/any_type_err.vv:11:6: error: cannot use type `any` here
     9 | 
-   10 | struct AnyStructField {
+   10 | struct AnyStructField[T] {
    11 |     foo any
       |         ~~~
    12 |     bar T
    13 | }
-vlib/v/checker/tests/any_type_err.vv:10:1: error: generic struct `AnyStructField` declaration must specify the generic type names, e.g. AnyStructField[T]
-    8 | type PolySumType = T | string
-    9 | 
-   10 | struct AnyStructField {
-      | ~~~~~~~~~~~~~~~~~~~~~
-   11 |     foo any
-   12 |     bar T
 vlib/v/checker/tests/any_type_err.vv:16:7: error: cannot use type `any` here
    14 | 
    15 | fn any_cast() {

--- a/vlib/v/checker/tests/any_type_err.vv
+++ b/vlib/v/checker/tests/any_type_err.vv
@@ -7,7 +7,7 @@ type AnyPolySumType = T | any
 type PolyType = T
 type PolySumType = T | string
 
-struct AnyStructField {
+struct AnyStructField[T] {
 	foo any
 	bar T
 }

--- a/vlib/v/checker/tests/any_type_err.vv
+++ b/vlib/v/checker/tests/any_type_err.vv
@@ -1,0 +1,17 @@
+// Any types should error, while parametrically polymorphic should not.
+
+type AnyType = any
+type AnySumType = any | string
+type AnyPolySumType = T | any
+
+type PolyType = T
+type PolySumType = T | string
+
+struct AnyStructField {
+	foo any
+	bar T
+}
+
+fn any_cast() {
+	_ := any('foo')
+}

--- a/vlib/v/checker/tests/struct_field_with_any_type_err.out
+++ b/vlib/v/checker/tests/struct_field_with_any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use `any` type here
+vlib/v/checker/tests/struct_field_with_any_type_err.vv:2:6: error: cannot use type `any` here
     1 | struct My_type {
     2 |     fld any
       |         ~~~

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -723,9 +723,6 @@ fn (mut p Parser) parse_any_type(language ast.Language, is_ptr bool, check_dot b
 						ret = ast.int_literal_type
 					}
 					'any' {
-						if p.file_backend_mode != .js && p.mod != 'builtin' {
-							p.error('cannot use `any` type here')
-						}
 						ret = ast.any_type
 					}
 					else {

--- a/vlib/v/parser/tests/cast_to_any_type_err.out
+++ b/vlib/v/parser/tests/cast_to_any_type_err.out
@@ -1,6 +1,0 @@
-vlib/v/parser/tests/cast_to_any_type_err.vv:2:7: error: cannot use `any` type here
-    1 | fn main() {
-    2 |     a := any(22)
-      |          ~~~
-    3 |     println(a)
-    4 | }

--- a/vlib/v/parser/tests/cast_to_any_type_err.vv
+++ b/vlib/v/parser/tests/cast_to_any_type_err.vv
@@ -1,4 +1,0 @@
-fn main() {
-	a := any(22)
-	println(a)
-}


### PR DESCRIPTION
This can be a checker error. The type error during parsing causes parsing interruption and internal errors. E.g.:

```v
// any.v
type Any = any
```
```sh
v fmt any.v
```
```
error: cannot use `any` type here
    1 | type Any = any
      |            ~~~

Internal vfmt error while formatting file: any.v.
```

similar to how `type MyType = unknown_type` is treated