### PR TITLE
fmt: don't change paths when formatting imports

### DIFF
--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -107,7 +107,7 @@ jobs:
           # v -cc gcc run /tmp/gitly/tests/first_run.v
           # # /tmp/gitly/gitly -ci_run
 
-      - name: Build V Language Server (v-analyzer) vlang/v-analyzer
+      - name: Build vlang/v-analyzer
         run: |
           echo "Clone v-analyzer"
           .github/workflows/retry.sh git clone --depth=1 --filter=blob:none --recursive --shallow-submodules https://github.com/vlang/v-analyzer /tmp/v-analyzer
@@ -118,6 +118,18 @@ jobs:
           v build.vsh debug
           echo "Build v-analyzer release"
           v build.vsh release
+
+      - name: Format vlang/v-analyzer
+        run: |
+          cd /tmp/v-analyzer
+          set +e
+          v fmt -c .
+          exit_code=$?
+          if [[ $exit_code -ne 0 && $exit_code -ne 5 ]]; then
+            # Don't fail on on internal errors
+            v fmt -diff .
+            exit 1
+          fi
 
       - name: Build vlang/go2v
         run: |

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -372,13 +372,6 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 }
 
 pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
-	mut imp_res := imp.source_name
-	if imp.mod.starts_with('src.') || (imp.mod.contains('src.') && imp.mod != imp.source_name) {
-		imp_after_src := imp.mod.all_after('src.')
-		if imp.source_name.all_after('src.') == imp_after_src {
-			imp_res = imp_after_src
-		}
-	}
 	// Format / remove unused selective import symbols
 	// E.g.: `import foo { Foo }` || `import foo as f { Foo }`
 	has_alias := imp.alias != imp.source_name.all_after_last('.')
@@ -392,7 +385,7 @@ pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 			' {\n\t' + syms.join(',\n\t') + ',\n}'
 		}
 	}
-	return '${imp_res}${suffix}'
+	return '${imp.source_name}${suffix}'
 }
 
 //=== Node helpers ===//

--- a/vlib/v/fmt/testdata/vmodules/src_import/src/a/aa/import_without_src_expected.vv
+++ b/vlib/v/fmt/testdata/vmodules/src_import/src/a/aa/import_without_src_expected.vv
@@ -1,4 +1,0 @@
-// NOTE: A test that follows a directory strucutre and module naming like this one
-// also tests whether vfmt would add a prefix to the import.
-
-import a.ab

--- a/vlib/v/fmt/testdata/vmodules/src_import/src/a/aa/import_without_src_input.vv
+++ b/vlib/v/fmt/testdata/vmodules/src_import/src/a/aa/import_without_src_input.vv
@@ -1,4 +1,0 @@
-// NOTE: A test that follows a directory strucutre and module naming like this one
-// also tests whether vfmt would add a prefix to the import.
-
-import src.a.ab

--- a/vlib/v/fmt/testdata/vmodules/src_import/src/a/ab/ab.v
+++ b/vlib/v/fmt/testdata/vmodules/src_import/src/a/ab/ab.v
@@ -1,1 +1,0 @@
-// Submodule directory required for full test coverage of this module


### PR DESCRIPTION
@spytheman your point made here https://github.com/vlang/v/pull/21134#discussion_r1544440533  confirms itself.

With our current module lookup there are more scenarios where it is required to keep the a `src.` part in the import. E.g. in v-analyzer for `build.vsh` (`src.metadata`) or in `tools/project-checker.v`. By removing the `src.` prefix vfmt would break the functionality, since the imported modules are not found anymore. 
Now vfmt would not try to "outsmart" anymore. And for scenarios where an import prefixed with `src.` and as well as the path without `src.` are valid, both will be also seen as valid by vfmt. 

General formatting will still happen ofc, unused import symbols will be cleared, just the path of the import won't be changed anymore. 

The tests that check for the import path update were removed. All other behavior is tested due to older and recently added tests, the changes should be covered.