### PR TITLE
v/pkgconfig: add pkgconfig path for FreeBSD base packages

### DIFF
--- a/vlib/v/pkgconfig/pkgconfig.v
+++ b/vlib/v/pkgconfig/pkgconfig.v
@@ -15,6 +15,7 @@ const default_paths = [
 	'/usr/share/pkgconfig',
 	'/opt/homebrew/lib/pkgconfig', // Brew on macOS
 	'/usr/local/libdata/pkgconfig', // FreeBSD
+	'/usr/libdata/pkgconfig', // FreeBSD
 	'/usr/lib/i386-linux-gnu/pkgconfig', // Debian 32bit
 ]
 const version = '0.3.3'


### PR DESCRIPTION
For 3rd party software that is part of the base FreeBSD install, their pkg-config files are in /usr/libdata/pkgconfig.

This path was not in the set of default pkgconfig paths.  As a result, if a module relied upon some library or include file from the base system, even as an indirect dependency, it would not be found.

I added the base path after the path for pkgconfig files that are from installing packages or ports so that packages or ports would be found preferentially over ones in the base system.  For example, if a newer version of openssl was installed via the pkg command or as a port, it would be found instead of the one from the base install.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
