### PR TITLE
vweb, x.vweb: edit some descriptions

### DIFF
--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -20,8 +20,7 @@ in the browser. No need to quit the app, rebuild it, and refresh the page in the
 
 - **Very fast** performance of C on the web.
 - **Small binary** hello world website is <100 KB.
-- **Easy to deploy** just one binary file that also includes all templates. No need to install any
-  dependencies.
+- **Easy to deploy** just one binary file that also includes all templates. No need to install any dependencies.
 - **Templates are precompiled** all errors are visible at compilation time, not at runtime.
 - **Multithreaded** by default
 
@@ -69,7 +68,7 @@ fn new_app() &App {
 
 @['/']
 pub fn (mut app App) page_home() vweb.Result {
-	// all this constants can be accessed by src/templates/page/home.html file.
+	// all these constants can be accessed by src/templates/page/home.html file.
 	page_title := 'V is the new V'
 	v_url := 'https://github.com/vlang/v'
 
@@ -210,8 +209,8 @@ fn (mut app App) create_product() vweb.Result {
 
 #### - Parameters
 
-Parameters are passed directly in endpoint route using colon sign `:` and received using the same
-name at function
+Parameters are passed directly in the endpoint route using a colon sign `:` and received
+using the same name in the function.
 To pass a parameter to an endpoint, you simply define it inside an attribute, e. g.
 `['/hello/:user]`.
 After it is defined in the attribute, you have to add it as a function parameter.
@@ -230,9 +229,9 @@ You have access to the raw request data such as headers
 or the request body by accessing `app` (which is `vweb.Context`).
 If you want to read the request body, you can do that by calling `app.req.data`.
 To read the request headers, you just call `app.req.header` and access the
-header you want example. `app.req.header.get(.content_type)`. See `struct Header`
+header you want, for example `app.req.header.get(.content_type)`. See `struct Header`
 for all available methods (`v doc net.http Header`).
-It has, too, fields for the `query`, `form`, `files`.
+It also has fields for the `query`, `form`, and `files`.
 
 #### - Parameter Arrays
 

--- a/vlib/vweb/README.md
+++ b/vlib/vweb/README.md
@@ -20,9 +20,10 @@ in the browser. No need to quit the app, rebuild it, and refresh the page in the
 
 - **Very fast** performance of C on the web.
 - **Small binary** hello world website is <100 KB.
-- **Easy to deploy** just one binary file that also includes all templates. No need to install any dependencies.
 - **Templates are precompiled** all errors are visible at compilation time, not at runtime.
 - **Multithreaded** by default
+- **Easy to deploy** just one binary file that also includes all templates. No need to install any
+  dependencies.
 
 ### Examples
 

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -6,8 +6,7 @@ features.
 ## Features
 
 - **Very fast** performance of C on the web.
-- **Easy to deploy** just one binary file that also includes all templates. No need to install any
-  dependencies.
+- **Easy to deploy** just one binary file that also includes all templates. No need to install any dependencies.
 - **Templates are precompiled** all errors are visible at compilation time, not at runtime.
 - **Middleware** functionality similar to other big frameworks.
 - **Controllers** to split up your apps logic.

--- a/vlib/x/vweb/README.md
+++ b/vlib/x/vweb/README.md
@@ -6,10 +6,11 @@ features.
 ## Features
 
 - **Very fast** performance of C on the web.
-- **Easy to deploy** just one binary file that also includes all templates. No need to install any dependencies.
 - **Templates are precompiled** all errors are visible at compilation time, not at runtime.
 - **Middleware** functionality similar to other big frameworks.
 - **Controllers** to split up your apps logic.
+- **Easy to deploy** just one binary file that also includes all templates. No need to install any
+  dependencies.
 
 ## Quick Start
 


### PR DESCRIPTION
I noticed that the bullet points under the Features heading on both vweb and x.vweb were not formatting right due to the line for "Easy to deploy" being continued on a second line.

It seems like that would be a bug in vdoc but I was unable to find it.  The expedient fix is to just have that bullet point all on one line.

I also re-worded some other descriptive text to make it easier (at least for me) to understand.

I am not sure of the status of x.vweb vs. vweb.  Using `v new --web` generates files referencing vweb so I assume that is still the preferred version.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
