### PR TITLE
parser: fix case of falsely registering imports as used, remove unused imports

### DIFF
--- a/examples/pendulum-simulation/modules/sim/anim/worker.v
+++ b/examples/pendulum-simulation/modules/sim/anim/worker.v
@@ -1,7 +1,6 @@
 module anim
 
 import benchmark
-import sim
 import sim.img
 
 fn pixels_worker(mut app App) {

--- a/examples/sokol/fonts.v
+++ b/examples/sokol/fonts.v
@@ -1,4 +1,3 @@
-import sokol
 import sokol.sapp
 import sokol.gfx
 import sokol.sgl

--- a/examples/sokol/freetype_raven.v
+++ b/examples/sokol/freetype_raven.v
@@ -1,4 +1,3 @@
-import sokol
 import sokol.sapp
 import sokol.gfx
 import sokol.sgl

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -3,9 +3,8 @@
 module gg
 
 import gx
-import sokol
-import sokol.sgl
 import math
+import sokol.sgl
 
 // draw_pixel draws one pixel on the screen.
 //

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -6,7 +6,6 @@ module gg
 import os
 import os.font
 import gx
-import sokol
 import sokol.sapp
 import sokol.sgl
 import sokol.gfx

--- a/vlib/math/big/division_array_ops.v
+++ b/vlib/math/big/division_array_ops.v
@@ -1,6 +1,5 @@
 module big
 
-import math
 import math.bits
 
 // suppose operand_a bigger than operand_b and both not null.

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -2,7 +2,6 @@ module cbuilder
 
 import os
 import time
-import sync
 import v.util
 import v.builder
 import sync.pool

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -6,7 +6,6 @@ module builder
 import os
 import v.pref
 import v.util
-import v.checker
 
 pub type FnBackend = fn (mut b Builder)
 

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -2,7 +2,6 @@ module builder
 
 import os
 import time
-import v.pref
 import v.util
 import v.cflag
 

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -3,7 +3,6 @@
 module checker
 
 import v.ast
-import v.pref
 
 // TODO: 600 line function
 fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1,7 +1,6 @@
 module checker
 
 import v.ast
-import v.pref
 import v.util
 import v.token
 

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -3,7 +3,6 @@
 module checker
 
 import v.ast
-import v.pref
 import v.token
 
 fn (mut c Checker) check_compatible_types(left_type ast.Type, right ast.TypeNode) ComptimeBranchSkipState {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -1,7 +1,6 @@
 module checker
 
 import v.ast
-import v.pref
 import v.token
 
 fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -3,7 +3,6 @@
 module checker
 
 import v.ast
-import v.pref
 
 // error_type_name returns a proper type name reference for error messages
 // ? => Option type

--- a/vlib/v/checker/tests/mul_op_wrong_type_err.out
+++ b/vlib/v/checker/tests/mul_op_wrong_type_err.out
@@ -1,98 +1,98 @@
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:5:13: error: mismatched types `Aaa` and `int literal`
-    3 | struct Aaa{}
-    4 | fn main() {
-    5 |     println(Aaa{} * 10)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:4:13: error: mismatched types `Aaa` and `int literal`
+    2 | struct Aaa{}
+    3 | fn main() {
+    4 |     println(Aaa{} * 10)
       |             ~~~~~~~~~~
-    6 |     println(10 * Aaa{})
-    7 |     println([1,2,3] * 10)
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:5:13: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
-    3 | struct Aaa{}
-    4 | fn main() {
-    5 |     println(Aaa{} * 10)
+    5 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:4:13: error: infix expr: cannot use `int literal` (right expression) as `Aaa`
+    2 | struct Aaa{}
+    3 | fn main() {
+    4 |     println(Aaa{} * 10)
       |             ~~~~~~~~~~
-    6 |     println(10 * Aaa{})
-    7 |     println([1,2,3] * 10)
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:6:13: error: mismatched types `int literal` and `Aaa`
-    4 | fn main() {
-    5 |     println(Aaa{} * 10)
-    6 |     println(10 * Aaa{})
+    5 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:5:13: error: mismatched types `int literal` and `Aaa`
+    3 | fn main() {
+    4 |     println(Aaa{} * 10)
+    5 |     println(10 * Aaa{})
       |             ~~~~~~~~~~
-    7 |     println([1,2,3] * 10)
-    8 |     println(10 * [1,2,3])
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:6:13: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
-    4 | fn main() {
-    5 |     println(Aaa{} * 10)
-    6 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
+    7 |     println(10 * [1,2,3])
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:5:13: error: infix expr: cannot use `Aaa` (right expression) as `int literal`
+    3 | fn main() {
+    4 |     println(Aaa{} * 10)
+    5 |     println(10 * Aaa{})
       |             ~~~~~~~~~~
-    7 |     println([1,2,3] * 10)
-    8 |     println(10 * [1,2,3])
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:7:13: error: mismatched types `[]int` and `int literal`
-    5 |     println(Aaa{} * 10)
-    6 |     println(10 * Aaa{})
-    7 |     println([1,2,3] * 10)
+    6 |     println([1,2,3] * 10)
+    7 |     println(10 * [1,2,3])
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:6:13: error: mismatched types `[]int` and `int literal`
+    4 |     println(Aaa{} * 10)
+    5 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
       |             ~~~~~~~~~~~~
-    8 |     println(10 * [1,2,3])
-    9 |     a := map[string]int
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:7:13: error: infix expr: cannot use `int literal` (right expression) as `[]int`
-    5 |     println(Aaa{} * 10)
-    6 |     println(10 * Aaa{})
-    7 |     println([1,2,3] * 10)
+    7 |     println(10 * [1,2,3])
+    8 |     a := map[string]int
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:6:13: error: infix expr: cannot use `int literal` (right expression) as `[]int`
+    4 |     println(Aaa{} * 10)
+    5 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
       |             ~~~~~~~~~~~~
-    8 |     println(10 * [1,2,3])
-    9 |     a := map[string]int
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:8:13: error: mismatched types `int literal` and `[]int`
-    6 |     println(10 * Aaa{})
-    7 |     println([1,2,3] * 10)
-    8 |     println(10 * [1,2,3])
+    7 |     println(10 * [1,2,3])
+    8 |     a := map[string]int
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:7:13: error: mismatched types `int literal` and `[]int`
+    5 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
+    7 |     println(10 * [1,2,3])
       |             ~~~~~~~~~~~~
-    9 |     a := map[string]int
-   10 |     println(a * 10)
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:8:13: error: infix expr: cannot use `[]int` (right expression) as `int literal`
-    6 |     println(10 * Aaa{})
-    7 |     println([1,2,3] * 10)
-    8 |     println(10 * [1,2,3])
+    8 |     a := map[string]int
+    9 |     println(a * 10)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:7:13: error: infix expr: cannot use `[]int` (right expression) as `int literal`
+    5 |     println(10 * Aaa{})
+    6 |     println([1,2,3] * 10)
+    7 |     println(10 * [1,2,3])
       |             ~~~~~~~~~~~~
-    9 |     a := map[string]int
-   10 |     println(a * 10)
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:10:13: error: mismatched types `map[string]int` and `int literal`
-    8 |     println(10 * [1,2,3])
-    9 |     a := map[string]int
-   10 |     println(a * 10)
+    8 |     a := map[string]int
+    9 |     println(a * 10)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:9:13: error: mismatched types `map[string]int` and `int literal`
+    7 |     println(10 * [1,2,3])
+    8 |     a := map[string]int
+    9 |     println(a * 10)
       |             ~~~~~~
-   11 |     println(10 * a)
-   12 |     c1 := cmplx.complex(1,-2)
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:10:13: error: infix expr: cannot use `int literal` (right expression) as `map[string]int`
-    8 |     println(10 * [1,2,3])
-    9 |     a := map[string]int
-   10 |     println(a * 10)
+   10 |     println(10 * a)
+   11 |     c1 := cmplx.complex(1,-2)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:9:13: error: infix expr: cannot use `int literal` (right expression) as `map[string]int`
+    7 |     println(10 * [1,2,3])
+    8 |     a := map[string]int
+    9 |     println(a * 10)
       |             ~~~~~~
-   11 |     println(10 * a)
-   12 |     c1 := cmplx.complex(1,-2)
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:11:13: error: mismatched types `int literal` and `map[string]int`
-    9 |     a := map[string]int
-   10 |     println(a * 10)
-   11 |     println(10 * a)
+   10 |     println(10 * a)
+   11 |     c1 := cmplx.complex(1,-2)
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:10:13: error: mismatched types `int literal` and `map[string]int`
+    8 |     a := map[string]int
+    9 |     println(a * 10)
+   10 |     println(10 * a)
       |             ~~~~~~
-   12 |     c1 := cmplx.complex(1,-2)
-   13 |     c2 := c1 * 2.0
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:11:13: error: infix expr: cannot use `map[string]int` (right expression) as `int literal`
-    9 |     a := map[string]int
-   10 |     println(a * 10)
-   11 |     println(10 * a)
+   11 |     c1 := cmplx.complex(1,-2)
+   12 |     c2 := c1 * 2.0
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:10:13: error: infix expr: cannot use `map[string]int` (right expression) as `int literal`
+    8 |     a := map[string]int
+    9 |     println(a * 10)
+   10 |     println(10 * a)
       |             ~~~~~~
-   12 |     c1 := cmplx.complex(1,-2)
-   13 |     c2 := c1 * 2.0
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:13:8: error: infix expr: cannot use `float literal` (right expression) as `math.complex.Complex`
-   11 |     println(10 * a)
-   12 |     c1 := cmplx.complex(1,-2)
-   13 |     c2 := c1 * 2.0
+   11 |     c1 := cmplx.complex(1,-2)
+   12 |     c2 := c1 * 2.0
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:12:8: error: infix expr: cannot use `float literal` (right expression) as `math.complex.Complex`
+   10 |     println(10 * a)
+   11 |     c1 := cmplx.complex(1,-2)
+   12 |     c2 := c1 * 2.0
       |           ~~~~~~~~
-   14 |     println(c2)
-   15 |     c3 := 2.0 * c1
-vlib/v/checker/tests/mul_op_wrong_type_err.vv:15:8: error: infix expr: cannot use `math.complex.Complex` (right expression) as `float literal`
-   13 |     c2 := c1 * 2.0
-   14 |     println(c2)
-   15 |     c3 := 2.0 * c1
+   13 |     println(c2)
+   14 |     c3 := 2.0 * c1
+vlib/v/checker/tests/mul_op_wrong_type_err.vv:14:8: error: infix expr: cannot use `math.complex.Complex` (right expression) as `float literal`
+   12 |     c2 := c1 * 2.0
+   13 |     println(c2)
+   14 |     c3 := 2.0 * c1
       |           ~~~~~~~~
-   16 |     println(c3)
-   17 | }
+   15 |     println(c3)
+   16 | }

--- a/vlib/v/checker/tests/mul_op_wrong_type_err.vv
+++ b/vlib/v/checker/tests/mul_op_wrong_type_err.vv
@@ -1,4 +1,3 @@
-import math
 import math.complex as cmplx
 struct Aaa{}
 fn main() {

--- a/vlib/v/checker/tests/unused_import_err.out
+++ b/vlib/v/checker/tests/unused_import_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/unused_import_err.vv:1:8: warning: module 'te (term)' is imported but never used
+    1 | import term as te
+      |        ~~~~
+    2 | import te.ui
+vlib/v/checker/tests/unused_import_err.vv:2:8: warning: module 'ui (te.ui)' is imported but never used
+    1 | import term as te
+    2 | import te.ui
+      |        ~~~~~
+vlib/v/checker/tests/unused_import_err.vv:2:1: builder error: cannot import module "te.ui" (not found)
+    1 | import term as te
+    2 | import te.ui
+      | ~~~~~~~~~~~~

--- a/vlib/v/checker/tests/unused_import_err.vv
+++ b/vlib/v/checker/tests/unused_import_err.vv
@@ -1,0 +1,2 @@
+import term as te
+import te.ui

--- a/vlib/v/gen/js/comptime.v
+++ b/vlib/v/gen/js/comptime.v
@@ -1,7 +1,6 @@
 module js
 
 import v.ast
-import v.pref
 
 fn (mut g JsGen) comptime_if(node ast.IfExpr) {
 	if !node.is_expr && !node.has_else && node.branches.len == 1 {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -5,7 +5,6 @@ module parser
 
 import os
 import v.ast
-import v.pref
 import v.token
 
 const supported_comptime_calls = ['html', 'tmpl', 'env', 'embed_file', 'pkgconfig', 'compile_error',

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -699,7 +699,7 @@ fn (mut p Parser) check_js_name() string {
 fn (mut p Parser) check_name() string {
 	pos := p.tok.pos()
 	name := p.tok.lit
-	if p.peek_tok.kind == .dot && name in p.imports {
+	if p.tok.kind != .name && p.peek_tok.kind == .dot && name in p.imports {
 		p.register_used_import(name)
 	}
 	match p.tok.kind {

--- a/vlib/x/sessions/tests/session_app_test.v
+++ b/vlib/x/sessions/tests/session_app_test.v
@@ -1,5 +1,4 @@
 import net.http
-import os
 import time
 import x.sessions
 import x.vweb


### PR DESCRIPTION
Fixes e.g,
```v
import term as te
import te.ui // alias `te` as part of another import would register the import `term` as used, despite its never being used.

fn main() {}
```
The change reveals a lot of unused imports that are removed in this PR as a requirement to pass CI.