### PR TITLE
v/tests: fix assignment to pointer

### DIFF
--- a/vlib/v/tests/c_structs/cstruct_ref_test.v
+++ b/vlib/v/tests/c_structs/cstruct_ref_test.v
@@ -16,7 +16,7 @@ fn (it C.MyCStruct) wrap() MyWrapper {
 
 fn test_main() {
 	dump(C.MyCStruct{
-		data: 123
+		data: &u8(123)
 	}.wrap())
 	assert true
 }


### PR DESCRIPTION
The vlib/v/tests/c_structs/cstruct_ref_test.v test fails on FreeBSD and MacOS.  So I added a type conversion.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
