### PR TITLE
breaking,vlib: update handling of imports whose symbols are not directly used in imported file, remove `pub const is_used = 1` workarounds

### DIFF
--- a/examples/sokol/drawing.v
+++ b/examples/sokol/drawing.v
@@ -1,4 +1,3 @@
-import sokol
 import sokol.sapp
 import sokol.gfx
 import sokol.sgl
@@ -6,8 +5,6 @@ import sokol.sgl
 struct AppState {
 	pass_action gfx.PassAction
 }
-
-const used_import = sokol.used_import
 
 fn main() {
 	state := &AppState{

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -3,13 +3,10 @@
 module main
 
 import time
-import sokol
 import sokol.sapp
 import sokol.gfx
 import sokol.sgl
 import particle
-
-const used_import = sokol.used_import
 
 fn main() {
 	mut app := &App{

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -21,8 +21,6 @@ $if windows {
 pub type Context = C.FONScontext
 
 //#flag -lfreetype
-// TODO: fontstash.used_import is used to keep v from warning about unused imports
-pub const used_import = 1
 pub const invalid = C.FONS_INVALID
 
 // create_internal returns a fontstash Context allocated on the heap.

--- a/vlib/gx/text.c.v
+++ b/vlib/gx/text.c.v
@@ -1,8 +1,6 @@
 module gx
 
-import fontstash
-
-const used_import = fontstash.used_import
+import fontstash as _
 
 pub enum HorizontalAlign {
 	left   = C.FONS_ALIGN_LEFT

--- a/vlib/json/cjson/cjson_wrapper.c.v
+++ b/vlib/json/cjson/cjson_wrapper.c.v
@@ -28,8 +28,6 @@ pub:
 	// TODO: `@string &char` from above does not work. It should be fixed, at least inside `struct C.`.
 }
 
-pub const used = 1
-
 pub type Node = C.cJSON
 
 fn C.cJSON_Version() &char

--- a/vlib/json/json_primitives.c.v
+++ b/vlib/json/json_primitives.c.v
@@ -8,8 +8,6 @@ module json
 #include "cJSON.h"
 #define js_get(object, key) cJSON_GetObjectItemCaseSensitive((object), (key))
 
-pub const used = 1
-
 pub struct C.cJSON {
 	valueint    int
 	valuedouble f64

--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -1,7 +1,5 @@
 module mbedtls
 
-pub const is_used = 1
-
 #flag -I @VEXEROOT/thirdparty/mbedtls/library
 #flag -I @VEXEROOT/thirdparty/mbedtls/include
 // #flag -D _FILE_OFFSET_BITS=64

--- a/vlib/net/mbedtls/mbedtls_compiles_test.v
+++ b/vlib/net/mbedtls/mbedtls_compiles_test.v
@@ -1,6 +1,5 @@
-import net.mbedtls
+import net.mbedtls as _
 
 fn test_mbedtls_compiles() {
-	assert mbedtls.is_used == 1
 	assert true
 }

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -156,8 +156,6 @@ fn init() {
 	}
 }
 
-pub const is_used = true
-
 // ssl_error returns non error ssl code or error if unrecoverable and we should panic
 fn ssl_error(ret int, ssl voidptr) !SSLError {
 	res := C.SSL_get_error(ssl, ret)

--- a/vlib/net/openssl/openssl_compiles_test.c.v
+++ b/vlib/net/openssl/openssl_compiles_test.c.v
@@ -1,4 +1,4 @@
-import net.openssl
+import net.openssl as _
 
 struct Abc {
 	x &C.SSL_CTX
@@ -9,9 +9,4 @@ fn test_printing_struct_with_reference_field_of_type_ssl_ctx() {
 	dump(a)
 	sa := a.str()
 	assert sa.contains('&C.SSL_CTX(0x7b)')
-}
-
-fn test_openssl_compiles() {
-	assert openssl.is_used
-	assert true
 }

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -1,7 +1,5 @@
 module c
 
-pub const used_import = 1
-
 #flag -I @VEXEROOT/thirdparty/sokol
 #flag -I @VEXEROOT/thirdparty/sokol/util
 #flag freebsd -I /usr/local/include

--- a/vlib/sokol/f/f.v
+++ b/vlib/sokol/f/f.v
@@ -1,9 +1,7 @@
 module f
 
-import fontstash
-import sokol.c
-
-pub const used_import = fontstash.used_import + c.used_import
+import fontstash as _
+import sokol.c as _
 
 #flag linux -I.
 

--- a/vlib/sokol/gfx/gfx.c.v
+++ b/vlib/sokol/gfx/gfx.c.v
@@ -1,11 +1,9 @@
 module gfx
 
-import sokol.c
+import sokol.c as _
 import sokol.memory
 
 pub const version = 1
-
-pub const used_import = c.used_import
 
 // setup initialises the SOKOL's gfx library, based on the information passed in `desc`
 pub fn setup(desc &Desc) {

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -4,8 +4,6 @@ module sapp
 import sokol.gfx
 import sokol.memory
 
-pub const used_import = gfx.used_import
-
 // Android needs a global reference to `g_desc`
 __global g_desc C.sapp_desc
 

--- a/vlib/sokol/sfons/sfons.c.v
+++ b/vlib/sokol/sfons/sfons.c.v
@@ -1,11 +1,8 @@
 module sfons
 
 import fontstash
-import sokol.f
+import sokol.f as _
 import sokol.memory
-
-// keep v from warning about unused imports
-const used_import = f.used_import + fontstash.used_import + 1
 
 // create a new Context/font atlas, for rendering glyphs, given its dimensions `width` and `height`
 @[inline]

--- a/vlib/sokol/sokol.v
+++ b/vlib/sokol/sokol.v
@@ -1,17 +1,13 @@
 module sokol
 
-import sokol.c
-import sokol.f
+import sokol.c as _
+import sokol.f as _
 
-pub const used_import = c.used_import + f.used_import
-
-/*
-pub enum Key {
-	up=C.SAPP_KEYCODE_UP
-	left = C.SAPP_KEYCODE_LEFT
-	right =C.SAPP_KEYCODE_RIGHT
-	down = C.SAPP_KEYCODE_DOWN
+/* pub enum Key {
+	up     = C.SAPP_KEYCODE_UP
+	left   = C.SAPP_KEYCODE_LEFT
+	right  = C.SAPP_KEYCODE_RIGHT
+	down   = C.SAPP_KEYCODE_DOWN
 	escape = C.SAPP_KEYCODE_ESCAPE
-	space = C.SAPP_KEYCODE_SPACE
-}
-*/
+	space  = C.SAPP_KEYCODE_SPACE
+} */

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -2,9 +2,6 @@ module sync
 
 import time
 import rand
-import sync.stdatomic
-
-const aops_used = stdatomic.used
 
 // how often to try to get data without blocking before to wait for semaphore
 const spinloops = 750

--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -86,5 +86,3 @@ fn C.atomic_compare_exchange_strong_u64(voidptr, voidptr, u64) bool
 fn C.atomic_exchange_u64(voidptr, u64) u64
 fn C.atomic_fetch_add_u64(voidptr, u64) u64
 fn C.atomic_fetch_sub_u64(voidptr, u64) u64
-
-pub const used = 1

--- a/vlib/v/checker/tests/import_mod_as_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_duplicate_err.out
@@ -4,7 +4,7 @@ vlib/v/checker/tests/import_mod_as_duplicate_err.vv:3:16: error: cannot import `
     3 | import json as json2
       |                ~~~~~
     4 | 
-    5 | const used = true
+    5 | _ := json2.encode('foo')
 vlib/v/checker/tests/import_mod_as_duplicate_err.vv:1:1: error: project must include a `main` module or be a shared library (compile with `v -shared`)
     1 | module json2
       | ^

--- a/vlib/v/checker/tests/import_mod_as_duplicate_err.vv
+++ b/vlib/v/checker/tests/import_mod_as_duplicate_err.vv
@@ -2,6 +2,4 @@ module json2
 
 import json as json2
 
-const used = true
-
-println(json2.used)
+_ := json2.encode('foo')

--- a/vlib/v/checker/tests/modules/module_with_redeclaration/redeclare_time_structs.c.v
+++ b/vlib/v/checker/tests/modules/module_with_redeclaration/redeclare_time_structs.c.v
@@ -2,8 +2,6 @@ module module_with_redeclaration
 
 import sokol.memory
 
-pub const used = 1
-
 @[typedef]
 pub struct C.saudio_allocator {
 pub mut:

--- a/vlib/v/embed_file/embed_file.v
+++ b/vlib/v/embed_file/embed_file.v
@@ -1,7 +1,5 @@
 module embed_file
 
-pub const is_used = 1
-
 // EmbedFileData encapsulates functionality for the `$embed_file()` compile time call.
 pub struct EmbedFileData {
 	apath            string

--- a/vlib/v/gen/c/testdata/gui_windows_program.vv
+++ b/vlib/v/gen/c/testdata/gui_windows_program.vv
@@ -1,7 +1,5 @@
 // vtest vflags: -os windows
-import sokol
-
-const used_import = sokol.used_import
+import sokol as _
 
 fn main() {
 	println('hello world')

--- a/vlib/v/gen/c/testdata/gui_windows_program_with_console_tag.vv
+++ b/vlib/v/gen/c/testdata/gui_windows_program_with_console_tag.vv
@@ -1,7 +1,5 @@
 // vtest vflags: -os windows
-import sokol
-
-const used_import = sokol.used_import
+import sokol as _
 
 @[console]
 fn main() {

--- a/vlib/v/live/common.c.v
+++ b/vlib/v/live/common.c.v
@@ -1,7 +1,5 @@
 module live
 
-pub const is_used = 1
-
 pub type FNLinkLiveSymbols = fn (linkcb voidptr)
 
 pub type FNLiveReloadCB = fn (info &LiveReloadInfo)

--- a/vlib/v/live/executable/reloader.c.v
+++ b/vlib/v/live/executable/reloader.c.v
@@ -5,8 +5,6 @@ import time
 import dl
 import v.live
 
-pub const is_used = 1
-
 // The live reloader code is implemented here.
 // Note: new_live_reload_info will be called by generated C code inside main()
 @[markused]

--- a/vlib/v/live/sharedlib/live_sharedlib.v
+++ b/vlib/v/live/sharedlib/live_sharedlib.v
@@ -1,5 +1,3 @@
 module sharedlib
 
-import v.live
-
-pub const is_used = live.is_used + 1
+import v.live as _

--- a/vlib/v/preludes/embed_file/embed_file.v
+++ b/vlib/v/preludes/embed_file/embed_file.v
@@ -1,7 +1,5 @@
-module embed_file
-
 // This prelude is loaded in every v program that uses `$embed_file`,
 // in both the main executable, and in the shared library.
-import v.embed_file
+module embed_file
 
-const no_warning_embed_file_is_used = embed_file.is_used
+import v.embed_file as _

--- a/vlib/v/preludes/live.v
+++ b/vlib/v/preludes/live.v
@@ -1,7 +1,5 @@
-module main
-
 // This prelude is loaded in every v program compiled with -live,
 // in both the main executable, and in the shared library.
-import v.live
+module main
 
-const no_warning_live_is_used = live.is_used
+import v.live as _

--- a/vlib/v/preludes/live_main.v
+++ b/vlib/v/preludes/live_main.v
@@ -1,7 +1,5 @@
-module main
-
 // This prelude is loaded in every v program compiled with -live,
 // but only for the main executable.
-import v.live.executable
+module main
 
-const no_warning_live_executable_is_used = executable.is_used
+import v.live.executable as _

--- a/vlib/v/preludes/live_shared.v
+++ b/vlib/v/preludes/live_shared.v
@@ -1,7 +1,5 @@
-module main
-
 // This prelude is loaded in every v program compiled with -live,
 // but only for the shared library.
-import v.live.sharedlib
+module main
 
-const no_warning_live_shared_is_used = sharedlib.is_used
+import v.live.sharedlib as _

--- a/vlib/v/preludes/trace_calls.v
+++ b/vlib/v/preludes/trace_calls.v
@@ -1,5 +1,3 @@
 module main
 
-import v.trace_calls
-
-const trace_calls_used = trace_calls.is_used
+import v.trace_calls as _

--- a/vlib/v/trace_calls/tracing_calls.c.v
+++ b/vlib/v/trace_calls/tracing_calls.c.v
@@ -5,8 +5,6 @@ module trace_calls
 __global g_stack_base = &u8(0)
 __global g_start_time = u64(0)
 
-pub const is_used = 1
-
 @[markused]
 pub fn on_call(fname string) {
 	mut volatile pfbase := unsafe { &u8(0) }


### PR DESCRIPTION
The changes move from using a workaround with public constants to a less verbose, imho more elegant way to handle imports whose symbols are not directly used (a case mostly for our C wrappers).

This will also remove the "workaround-constants" - that might be confusing - from module documentations. E.g. json, mbedtls and several others
|||
| -- | -- |
| ![Screenshot_20240401_184439](https://github.com/vlang/v/assets/34311583/b174c2c6-d7f4-474f-87dc-1b5dcd13225b) | ![Screenshot_20240401_184446](https://github.com/vlang/v/assets/34311583/fc957f54-a090-46fa-9c5b-c562cb086a1d) |



Changes are covered by our current test suite.