### PR TITLE
net.http: fix panic on empty addr, cleanup `listen_and_serve` Server method

### DIFF
--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -62,10 +62,10 @@ pub fn (mut s Server) listen_and_serve() {
 		return
 	}
 	if l.family() == net.AddrFamily.unspec {
-		listen_addr := if s.addr == '' || s.addr == ':0' { 'localhost:0' } else { s.addr }
-		listen_fam := net.AddrFamily.ip
-		// listen_fam := $if windows { net.AddrFamily.ip } $else { net.AddrFamily.ip6 }
-		s.listener = net.listen_tcp(listen_fam, listen_addr) or {
+		listening_address := if s.addr == '' || s.addr == ':0' { 'localhost:0' } else { s.addr }
+		listen_family := net.AddrFamily.ip
+		// listen_family := $if windows { net.AddrFamily.ip } $else { net.AddrFamily.ip6 }
+		s.listener = net.listen_tcp(listen_family, listening_address) or {
 			eprintln('Listening on ${s.addr} failed, err: ${err}')
 			return
 		}

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -61,16 +61,11 @@ pub fn (mut s Server) listen_and_serve() {
 		eprintln('Failed getting listener address, err: ${err}')
 		return
 	}
-	mut listening_address := s.addr.clone()
 	if l.family() == net.AddrFamily.unspec {
-		if listening_address == ':0' {
-			listening_address = 'localhost:0'
-		}
-		mut listen_family := net.AddrFamily.ip
-		//		$if !windows {
-		//			listen_family = net.AddrFamily.ip6
-		//		}
-		s.listener = net.listen_tcp(listen_family, listening_address) or {
+		listen_addr := if s.addr == '' || s.addr == ':0' { 'localhost:0' } else { s.addr }
+		listen_fam := net.AddrFamily.ip
+		// listen_fam := $if windows { net.AddrFamily.ip } $else { net.AddrFamily.ip6 }
+		s.listener = net.listen_tcp(listen_fam, listen_addr) or {
 			eprintln('Listening on ${s.addr} failed, err: ${err}')
 			return
 		}
@@ -84,7 +79,6 @@ pub fn (mut s Server) listen_and_serve() {
 
 	// Create tcp connection channel
 	ch := chan &net.TcpConn{cap: s.pool_channel_slots}
-
 	// Create workers
 	mut ws := []thread{cap: s.worker_num}
 	for wid in 0 .. s.worker_num {
@@ -101,14 +95,10 @@ pub fn (mut s Server) listen_and_serve() {
 	if s.on_running != unsafe { nil } {
 		s.on_running(mut s)
 	}
-	for {
-		// break if we have a stop signal
-		if s.state != .running {
-			break
-		}
+	for s.state == .running {
 		mut conn := s.listener.accept() or {
 			if err.code() == net.err_timed_out_code {
-				// just skip network timeouts, they are normal
+				// Skip network timeouts, they are normal
 				continue
 			}
 			eprintln('accept() failed, reason: ${err}; skipping')

--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -226,7 +226,7 @@ fn test_my_counting_handler_on_random_port() {
 	}
 	mut server := &http.Server{
 		show_startup_message: false
-		port: 0
+		addr: ''
 		accept_timeout: atimeout
 		handler: MyCountingHandler{}
 		on_running: fn (mut server http.Server) {


### PR DESCRIPTION
Fixes a panic when the server gets an empty address. Does a cleanup to the related scope.

```v
import net.http

mut server := &http.Server{
	addr: ''
	on_running: fn (mut server http.Server) {
		spawn fn [mut server] () {
			println('server started')
			server.stop()
			println('server stopped')
		}()
	}
}
server.listen_and_serve()
```

Instead it will now behave like before passing 0 to the deprecated `port` field, or `:0` to `addr` - using a random port.