### PR TITLE
parser: add support for inclusive match range with omited zero `...5`

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -293,7 +293,10 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			for {
 				p.inside_match_case = true
 				mut range_pos := p.tok.pos()
-				expr := p.expr(0)
+				expr := if p.tok.kind == .ellipsis { ast.Expr(ast.IntegerLiteral{
+						val: '0'
+						pos: range_pos
+					}) } else { p.expr(0) }
 				p.inside_match_case = false
 				if p.tok.kind == .dotdot {
 					p.error_with_pos('match only supports inclusive (`...`) ranges, not exclusive (`..`)',

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -293,6 +293,7 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			for {
 				p.inside_match_case = true
 				mut range_pos := p.tok.pos()
+				// Parse `...x` as `0...x`.
 				expr := if p.tok.kind == .ellipsis { ast.Expr(ast.IntegerLiteral{
 						val: '0'
 						pos: range_pos


### PR DESCRIPTION
Add support to omit the `0` for an inclusive range expression. Similar to what is already supported when accessing an `array[..5]`. E.g.,
```v
n := 3
match n {
	...5 {}
	else {}
}

x := `5`
match x {
	...`3` { println(n) }
	else { println('other') }
}

```