### PR TITLE
parser: add support for inclusive match range with omiited zero ...5

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2890,7 +2890,9 @@ pub fn (mut f Fmt) prefix_expr(node ast.PrefixExpr) {
 }
 
 pub fn (mut f Fmt) range_expr(node ast.RangeExpr) {
-	f.expr(node.low)
+	if node.low !is ast.IntegerLiteral || (node.low is ast.IntegerLiteral && node.low.val != '0') {
+		f.expr(node.low)
+	}
 	if f.is_mbranch_expr && !f.is_index_expr {
 		f.write('...')
 	} else {

--- a/vlib/v/fmt/tests/array_slices_expected.vv
+++ b/vlib/v/fmt/tests/array_slices_expected.vv
@@ -1,6 +1,6 @@
 fn fn_contains_index_expr() {
 	arr := [1, 2, 3, 4, 5]
-	a := 1 in arr[0..]
+	a := 1 in arr[..]
 	_ := a
 	_ := 1 in arr[..2]
 	_ := 1 in arr[1..3]

--- a/vlib/v/fmt/tests/match_expected.vv
+++ b/vlib/v/fmt/tests/match_expected.vv
@@ -43,7 +43,7 @@ fn match_branch_extra_comma() {
 		int, string {}
 	}
 	match n {
-		0...5 {}
+		...5 {}
 		2, 3 {}
 		else {}
 	}

--- a/vlib/v/fmt/tests/match_keep.vv
+++ b/vlib/v/fmt/tests/match_keep.vv
@@ -1,11 +1,11 @@
 fn nested_match() {
 	match 100 {
-		0...1 {
+		...1 {
 			println('0 to 1')
 		}
 		else {
 			match 200 {
-				0...1 { println('0 to 1') }
+				...1 { println('0 to 1') }
 				else { println('unknown value') }
 			}
 		}

--- a/vlib/v/fmt/tests/string_interpolation_keep.vv
+++ b/vlib/v/fmt/tests/string_interpolation_keep.vv
@@ -13,7 +13,7 @@ fn main() {
 	_ = ' ${foo.method(bar).str()} '
 	println('(${some_struct.@type}, ${some_struct.y})')
 	_ := 'CastExpr ${int(d.e).str()}'
-	println('${f[0..4].bytestr()}')
+	println('${f[..4].bytestr()}')
 	_ := '${generic_fn[int]()}'
 	_ := '${foo.generic_method[int]()}'
 }

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -293,7 +293,10 @@ fn (mut p Parser) match_expr() ast.MatchExpr {
 			for {
 				p.inside_match_case = true
 				mut range_pos := p.tok.pos()
-				expr := p.expr(0)
+				expr := if p.tok.kind == .ellipsis { ast.Expr(ast.IntegerLiteral{
+						val: '0'
+						pos: range_pos
+					}) } else { p.expr(0) }
 				p.inside_match_case = false
 				if p.tok.kind == .dotdot {
 					p.error_with_pos('match only supports inclusive (`...`) ranges, not exclusive (`..`)',

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1262,7 +1262,7 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 
 				has_suffix := p.tok.lit[p.tok.lit.len - 1] in [`b`, `w`, `l`, `q`]
 				if !(p.tok.lit in parser.allowed_lock_prefix_ins || (has_suffix
-					&& p.tok.lit[0..p.tok.lit.len - 1] in parser.allowed_lock_prefix_ins)) {
+					&& p.tok.lit[..p.tok.lit.len - 1] in parser.allowed_lock_prefix_ins)) {
 					p.error('The lock prefix cannot be used on this instruction')
 				}
 				name += ' '

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -43,7 +43,7 @@ fn is_html_open_tag(name string, s string) bool {
 		return false
 	}
 
-	mut sub := trimmed_line[0..1]
+	mut sub := trimmed_line[..1]
 	if sub != '<' { // not start with '<'
 		return false
 	}
@@ -85,7 +85,7 @@ fn insert_template_code(fn_name string, tmpl_str_start string, line string) stri
 		rline = rline.replace(comptime_call_str, comptime_call_str.replace("\\'", r"'"))
 	}
 	if rline.ends_with('\\') {
-		rline = rline[0..rline.len - 2] + trailing_bs
+		rline = rline[..rline.len - 2] + trailing_bs
 	}
 
 	return rline


### PR DESCRIPTION
Removes obsolete zeros from range expressions. Based on #21166. Includes updates tests that cover the new feature.