### PR TITLE
strings: Builder.str() memory leak fix for -autofree.

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -228,6 +228,7 @@ pub fn (mut b Builder) str() string {
 	b << u8(0)
 	bcopy := unsafe { &u8(memdup_noscan(b.data, b.len)) }
 	s := unsafe { bcopy.vstring_with_len(b.len - 1) }
+	unsafe { free(bcopy) }
 	b.trim(0)
 	return s
 }


### PR DESCRIPTION
Should fix memory leak when `-gc none -autofree` flags in use:
```v
module main

struct MyLeak {
	a u32
}

fn leak_test(leak &MyLeak) {
	str := leak.str()
	_ = str
}

fn main() {
	leak := MyLeak{}
	leak_test(&leak)
}
```
This code no leaks when use default GC mode for C backend:
```sh
v .
```
and leaks (it can be detected with **valgrind** on linux or **leaks** on macos) when compile with:
```sh
v -gc none -autofree .
```