### PR TITLE
breaking,checker: disallow initializing private struct fields outside structs module

### DIFF
--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test vsql compilation and examples
         run: |
           echo "Install vsql"
-          .github/workflows/retry.sh v install elliotchance.vsql ; cd ~/.vmodules/elliotchance/vsql
+          .github/workflows/retry.sh v install https://github.com/ttytm/vsql@temp/vi-ci ; cd ~/.vmodules/vsql
           echo "Generate vsql/grammar.v"
           make vsql/grammar.v
           echo "Compile vsql"
@@ -53,10 +53,10 @@ jobs:
 
       - name: Test discord.v
         run: |
-          echo "Clone https://github.com/DarpHome/discord.v/"
-          .github/workflows/retry.sh git clone https://github.com/DarpHome/discord.v/ discord && cd discord
-          echo "Checkout last known good commit"
-          git checkout 533485c08f21df91ff62fea9477e7017d21f91c4
+          echo "Clone https://github.com/DarpHome/discord.v"
+          .github/workflows/retry.sh v install https://github.com/ttytm/discord.v@temp/v-ci && cd ~/.vmodules/discord
+          # echo "Checkout last known good commit"
+          # git checkout 789de8ad35ee2683fbcd950fc07936f052088d0c
           echo "Execute Tests"
           v test .
 

--- a/examples/pendulum-simulation/modules/sim/args/parser.v
+++ b/examples/pendulum-simulation/modules/sim/args/parser.v
@@ -11,6 +11,7 @@ const max_parallel_workers = runtime.nr_jobs()
 
 @[params]
 pub struct ParserSettings {
+pub:
 	sequential    bool
 	img           bool
 	extra_workers int

--- a/examples/pendulum-simulation/modules/sim/params.v
+++ b/examples/pendulum-simulation/modules/sim/params.v
@@ -11,6 +11,7 @@ pub const default_gravity = 4.9
 
 @[params]
 pub struct SimParams {
+pub:
 	rope_length     f64 = sim.default_rope_length
 	bearing_mass    f64 = sim.default_bearing_mass
 	magnet_spacing  f64 = sim.default_magnet_spacing

--- a/examples/pendulum-simulation/modules/sim/sim.v
+++ b/examples/pendulum-simulation/modules/sim/sim.v
@@ -1,7 +1,7 @@
 module sim
 
 pub struct SimState {
-mut:
+pub mut:
 	position Vector3D
 	velocity Vector3D
 	accel    Vector3D

--- a/examples/pendulum-simulation/modules/sim/vec.v
+++ b/examples/pendulum-simulation/modules/sim/vec.v
@@ -4,6 +4,7 @@ import math
 
 // Vector3D is a 3D vector
 pub struct Vector3D {
+pub:
 	x f64
 	y f64
 	z f64

--- a/examples/pendulum-simulation/modules/sim/worker.v
+++ b/examples/pendulum-simulation/modules/sim/worker.v
@@ -7,10 +7,10 @@ const max_iterations = 1000
 const simulation_delta_t = 0.0005
 
 pub struct SimRequest {
+pub:
 	params SimParams
 	state  SimState
-pub:
-	id int
+	id     int
 }
 
 pub struct SimResult {

--- a/examples/sokol/particles/modules/particle/particle.v
+++ b/examples/sokol/particles/modules/particle/particle.v
@@ -27,7 +27,7 @@ fn remap(v f64, min f64, max f64, new_min f64, new_max f64) f64 {
 
 // Particle
 pub struct Particle {
-mut:
+pub mut:
 	location       vec.Vec2[f64]
 	velocity       vec.Vec2[f64]
 	acceleration   vec.Vec2[f64]

--- a/examples/sokol/particles/modules/particle/system.v
+++ b/examples/sokol/particles/modules/particle/system.v
@@ -7,10 +7,12 @@ import rand
 import sokol.sgl
 
 pub struct SystemConfig {
+pub:
 	pool int
 }
 
 pub struct System {
+pub:
 	width  int
 	height int
 mut:

--- a/examples/vweb/vweb_websocket/vweb_websocket.v
+++ b/examples/vweb/vweb_websocket/vweb_websocket.v
@@ -40,11 +40,9 @@ fn new_app() !&App {
 }
 
 fn new_websocker_server() !&websocket.Server {
-	mut wss := &websocket.Server{
-		logger: &log.Log{
-			level: .debug
-		}
-	}
+	mut logger := &log.Log{}
+	logger.set_level(.debug)
+	mut wss := websocket.new_server(.ip, 8080, '', logger: logger)
 	wss.on_connect(fn (mut server_client websocket.ServerClient) !bool {
 		slog('ws.on_connect, server_client.client_key: ${server_client.client_key}')
 		return true

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -182,6 +182,7 @@ pub fn chunk[T](array []T, size int) [][]T {
 }
 
 pub struct WindowAttribute {
+pub:
 	size int
 	step int = 1
 }

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -153,6 +153,7 @@ pub fn (mut b Benchmark) record_measure(label string) i64 {
 // If it is set, the preparation time (compile time) will be shown before the measured runtime.
 @[params]
 pub struct MessageOptions {
+pub:
 	preparation time.Duration // the duration of the preparation time for the step
 }
 

--- a/vlib/cli/flag_test.v
+++ b/vlib/cli/flag_test.v
@@ -25,21 +25,6 @@ fn test_if_string_flag_parses() {
 	flag.parse(['-flag=value2'], false) or { panic(err) }
 	mut values := flag.get_strings() or { panic(err) }
 	assert values == ['value1', 'value2']
-
-	flags := [
-		cli.Flag{
-			flag: .string_array
-			name: 'flag'
-			value: ['a', 'b', 'c']
-		},
-		cli.Flag{
-			flag: .string
-			name: 'flag2'
-		},
-	]
-
-	values = flags.get_strings('flag') or { panic(err) }
-	assert values == ['a', 'b', 'c']
 }
 
 fn test_if_bool_flag_parses() {
@@ -94,21 +79,6 @@ fn test_if_int_flag_parses() {
 	flag.parse(['-flag=45'], false) or { panic(err) }
 	mut values := flag.get_ints() or { panic(err) }
 	assert values == [42, 45]
-
-	flags := [
-		cli.Flag{
-			flag: .int_array
-			name: 'flag'
-			value: ['1', '2', '3']
-		},
-		cli.Flag{
-			flag: .int
-			name: 'flag2'
-		},
-	]
-
-	values = flags.get_ints('flag') or { panic(err) }
-	assert values == [1, 2, 3]
 }
 
 fn test_if_float_flag_parses() {
@@ -139,21 +109,6 @@ fn test_if_float_flag_parses() {
 	flag.parse(['-flag=1.3'], false) or { panic(err) }
 	mut values := flag.get_floats() or { panic(err) }
 	assert values == [3.1, 1.3]
-
-	flags := [
-		cli.Flag{
-			flag: .float_array
-			name: 'flag'
-			value: ['1.1', '2.2', '3.3']
-		},
-		cli.Flag{
-			flag: .float
-			name: 'flag2'
-		},
-	]
-
-	values = flags.get_floats('flag') or { panic(err) }
-	assert values == [1.1, 2.2, 3.3]
 }
 
 fn test_if_flag_parses_with_abbrev() {

--- a/vlib/compress/gzip/gzip.v
+++ b/vlib/compress/gzip/gzip.v
@@ -42,6 +42,7 @@ pub fn compress(data []u8) ![]u8 {
 
 @[params]
 pub struct DecompressParams {
+pub:
 	verify_header_checksum bool = true
 	verify_length          bool = true
 	verify_checksum        bool = true

--- a/vlib/compress/szip/szip.c.v
+++ b/vlib/compress/szip/szip.c.v
@@ -7,6 +7,7 @@ import os
 
 @[params]
 pub struct ZipFolderOptions {
+pub:
 	omit_empty_folders bool
 }
 

--- a/vlib/compress/zstd/zstd.v
+++ b/vlib/compress/zstd/zstd.v
@@ -390,6 +390,7 @@ pub fn default_c_level() int {
 
 @[params]
 pub struct CompressParams {
+pub:
 	compression_level int // 1~22
 	nb_threads        int  = 1 // how many threads will be spawned to compress in parallel
 	checksum_flag     bool = true
@@ -422,6 +423,7 @@ pub fn compress(data []u8, params CompressParams) ![]u8 {
 
 @[params]
 pub struct DecompressParams {
+pub:
 	window_log_max int
 }
 

--- a/vlib/dl/loader/loader.v
+++ b/vlib/dl/loader/loader.v
@@ -53,6 +53,7 @@ mut:
 // DynamicLibLoaderConfig is a configuration for DynamicLibLoader.
 @[params]
 pub struct DynamicLibLoaderConfig {
+pub:
 	// flags is the flags for dlopen.
 	flags int = dl.rtld_lazy
 	// key is the key to register the DynamicLibLoader.

--- a/vlib/dlmalloc/dlmalloc.v
+++ b/vlib/dlmalloc/dlmalloc.v
@@ -205,6 +205,7 @@ fn overhead_for(c &Chunk) usize {
 //
 // Why not `interface?` Interfaces require memory allocation so it is simpler to pass a struct.
 pub struct Allocator {
+pub:
 	alloc            fn (voidptr, usize) (voidptr, usize, u32) = unsafe { nil }
 	remap            fn (voidptr, voidptr, usize, usize, bool) voidptr = unsafe { nil }
 	free_part        fn (voidptr, voidptr, usize, usize) bool = unsafe { nil }

--- a/vlib/encoding/csv/README_csv_reader.md
+++ b/vlib/encoding/csv/README_csv_reader.md
@@ -42,6 +42,7 @@ Using these structs, it is possible to change the behavior of the CSV Reader.
 The config struct is as follows:
 ```v ignore
 pub struct SequentialReaderConfig {
+pub:
 	scr_buf      voidptr // pointer to the buffer of data
 	scr_buf_len  i64     // if > 0 use the RAM pointed by scr_buf as source of data
 	file_path    string
@@ -128,6 +129,7 @@ Using these structs, it is possible to change the behavior of the CSV Reader.
 The config struct is as follows:
 ```v ignore
 pub struct RandomAccessReaderConfig {
+pub:
 	scr_buf      voidptr // pointer to the buffer of data
 	scr_buf_len  i64     // if > 0 use the RAM pointed from scr_buf as source of data
 	file_path    string

--- a/vlib/encoding/csv/csv_reader_random_access.v
+++ b/vlib/encoding/csv/csv_reader_random_access.v
@@ -80,6 +80,7 @@ pub mut:
 
 @[params]
 pub struct RandomAccessReaderConfig {
+pub:
 	scr_buf      voidptr // pointer to the buffer of data
 	scr_buf_len  i64     // if > 0 use the RAM pointed from scr_buf as source of data
 	file_path    string
@@ -344,6 +345,7 @@ pub fn (mut cr RandomAccessReader) get_row(y int) ![]string {
 
 @[params]
 pub struct GetCellConfig {
+pub:
 	x int
 	y int
 }
@@ -444,6 +446,7 @@ pub fn (mut cr RandomAccessReader) get_cellt(cfg GetCellConfig) !CellValue {
 ******************************************************************************/
 @[params]
 pub struct GetHeaderConf {
+pub:
 	header_row int // row where to inspect the header
 }
 

--- a/vlib/encoding/csv/csv_reader_sequential.v
+++ b/vlib/encoding/csv/csv_reader_sequential.v
@@ -13,6 +13,7 @@ import os
 
 @[params]
 pub struct SequentialReaderConfig {
+pub:
 	scr_buf      voidptr // pointer to the buffer of data
 	scr_buf_len  i64     // if > 0 use the RAM pointed by scr_buf as source of data
 	file_path    string

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -52,6 +52,7 @@ mut:
 
 @[params]
 pub struct ReaderConfig {
+pub:
 	delimiter u8 = `,`
 	comment   u8 = `#`
 }

--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -14,6 +14,7 @@ mut:
 
 @[params]
 pub struct WriterConfig {
+pub:
 	use_crlf  bool
 	delimiter u8 = `,`
 }

--- a/vlib/encoding/html/escape.v
+++ b/vlib/encoding/html/escape.v
@@ -5,12 +5,14 @@ import strconv
 
 @[params]
 pub struct EscapeConfig {
+pub:
 	quote bool = true
 }
 
 @[params]
 pub struct UnescapeConfig {
 	EscapeConfig
+pub:
 	all bool
 }
 

--- a/vlib/encoding/xml/entity.v
+++ b/vlib/encoding/xml/entity.v
@@ -20,6 +20,7 @@ pub const default_entities_reverse = {
 
 @[params]
 pub struct EscapeConfig {
+pub:
 	reverse_entities map[string]string = xml.default_entities_reverse
 }
 
@@ -38,6 +39,7 @@ pub fn escape_text(content string, config EscapeConfig) string {
 
 @[params]
 pub struct UnescapeConfig {
+pub:
 	entities map[string]string = xml.default_entities
 }
 

--- a/vlib/encoding/xml/types.v
+++ b/vlib/encoding/xml/types.v
@@ -37,21 +37,25 @@ pub:
 pub type DTDListItem = DTDElement | DTDEntity
 
 pub struct DTDEntity {
+pub:
 	name  string @[required]
 	value string @[required]
 }
 
 pub struct DTDElement {
+pub:
 	name       string   @[required]
 	definition []string @[required]
 }
 
 pub struct DocumentTypeDefinition {
+pub:
 	name string
 	list []DTDListItem
 }
 
 pub struct DocumentType {
+pub:
 	name string  @[required]
 	dtd  DTDInfo
 }

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -226,6 +226,7 @@ pub enum PaintStyle {
 
 @[params]
 pub struct DrawRectParams {
+pub:
 	x          f32
 	y          f32
 	w          f32

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -545,6 +545,7 @@ pub enum EndEnum {
 
 @[params]
 pub struct EndOptions {
+pub:
 	how EndEnum
 }
 

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -270,6 +270,7 @@ pub fn (mut ctx Context) create_image_from_byte_array(b []u8) !Image {
 }
 
 pub struct StreamingImageConfig {
+pub:
 	pixel_format gfx.PixelFormat = .rgba8
 	wrap_u       gfx.Wrap        = .clamp_to_edge
 	wrap_v       gfx.Wrap        = .clamp_to_edge

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -166,6 +166,7 @@ pub fn (ctx &Context) set_text_cfg(cfg gx.TextCfg) {
 
 @[params]
 pub struct DrawTextParams {
+pub:
 	x    int
 	y    int
 	text string

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -16,6 +16,7 @@ pub mut:
 
 // BufferedReaderConfig are options that can be given to a buffered reader.
 pub struct BufferedReaderConfig {
+pub:
 	reader  Reader
 	cap     int = 128 * 1024 // large for fast reading of big(ish) files
 	retries int = 2 // how many times to retry before assuming the stream ended

--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -35,9 +35,9 @@ pub const read_all_grow_len = 1024
 // ReadAllConfig allows options to be passed for the behaviour
 // of read_all.
 pub struct ReadAllConfig {
-	read_to_end_of_stream bool
 pub:
-	reader Reader
+	read_to_end_of_stream bool
+	reader                Reader
 }
 
 // read_all reads all bytes from a reader until either a 0 length read

--- a/vlib/io/reader.v
+++ b/vlib/io/reader.v
@@ -36,7 +36,7 @@ pub const read_all_grow_len = 1024
 // of read_all.
 pub struct ReadAllConfig {
 	read_to_end_of_stream bool
-mut:
+pub:
 	reader Reader
 }
 

--- a/vlib/io/string_reader/string_reader.v
+++ b/vlib/io/string_reader/string_reader.v
@@ -5,6 +5,7 @@ import strings
 
 @[params]
 pub struct StringReaderParams {
+pub:
 	// the reader interface
 	reader ?io.Reader
 	// initialize the builder with this source string

--- a/vlib/io/util/util.v
+++ b/vlib/io/util/util.v
@@ -7,6 +7,7 @@ const retries = 10000
 
 @[params]
 pub struct TempFileOptions {
+pub:
 	path    string = os.temp_dir()
 	pattern string
 }
@@ -40,6 +41,7 @@ pub fn temp_file(tfo TempFileOptions) !(os.File, string) {
 
 @[params]
 pub struct TempDirOptions {
+pub:
 	path    string = os.temp_dir()
 	pattern string
 }

--- a/vlib/log/file_log_test.v
+++ b/vlib/log/file_log_test.v
@@ -49,9 +49,8 @@ fn test_set_always_flush() {
 		os.rmdir_all(lfolder) or {}
 	}
 	dump(lfolder)
-	mut l := log.Log{
-		level: .info
-	}
+	mut l := log.Log{}
+	l.set_level(.info)
 	l.set_full_logpath(lpath1)
 	l.set_always_flush(true)
 	l.warn('one warning')

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -117,6 +117,7 @@ pub fn integer_from_u64(value u64) Integer {
 
 @[params]
 pub struct IntegerConfig {
+pub:
 	signum int = 1
 }
 

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -53,6 +53,7 @@ pub fn angle_diff(radian_a f64, radian_b f64) f64 {
 
 @[params]
 pub struct DigitParams {
+pub:
 	base    int = 10
 	reverse bool
 }

--- a/vlib/net/common.c.v
+++ b/vlib/net/common.c.v
@@ -26,6 +26,7 @@ pub enum ShutdownDirection {
 
 @[params]
 pub struct ShutdownConfig {
+pub:
 	how ShutdownDirection = .read_and_write
 }
 

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -23,6 +23,7 @@ mut:
 
 @[params]
 pub struct GetTagsOptions {
+pub:
 	name string
 }
 

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -352,6 +352,7 @@ pub fn (mut h Header) free() {
 }
 
 pub struct HeaderConfig {
+pub:
 	key   CommonHeader
 	value string
 }
@@ -490,6 +491,7 @@ pub fn (mut h Header) delete_custom(key string) {
 
 @[params]
 pub struct HeaderCoerceConfig {
+pub:
 	canonicalize bool
 }
 
@@ -553,6 +555,7 @@ pub fn (h Header) contains(key CommonHeader) bool {
 
 @[params]
 pub struct HeaderQueryConfig {
+pub:
 	exact bool
 }
 
@@ -666,6 +669,7 @@ pub fn (h Header) keys() []string {
 
 @[params]
 pub struct HeaderRenderConfig {
+pub:
 	version      Version
 	coerce       bool
 	canonicalize bool

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -15,9 +15,10 @@ pub const max_headers = 50
 
 // Header represents the key-value pairs in an HTTP header
 pub struct Header {
-mut:
+pub mut:
 	// data map[string][]string
-	data    [max_headers]HeaderKV
+	data [max_headers]HeaderKV
+mut:
 	cur_pos int
 	// map of lowercase header keys to their original keys
 	// in order of appearance

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -388,6 +388,7 @@ pub:
 
 pub struct UnexpectedExtraAttributeError {
 	Error
+pub:
 	attributes []string
 }
 

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -117,6 +117,7 @@ pub fn (mut r Response) set_version(v Version) {
 }
 
 pub struct ResponseConfig {
+pub:
 	version Version = .v1_1
 	status  Status  = .ok
 	header  Header

--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -32,8 +32,9 @@ struct SSLCerts {
 
 // SSLConn is the current connection
 pub struct SSLConn {
+pub:
 	config SSLConnectConfig
-mut:
+pub mut:
 	server_fd C.mbedtls_net_context
 	ssl       C.mbedtls_ssl_context
 	conf      C.mbedtls_ssl_config
@@ -215,6 +216,7 @@ pub fn (mut l SSLListener) accept() !&SSLConn {
 
 @[params]
 pub struct SSLConnectConfig {
+pub:
 	verify   string // the path to a rootca.pem file, containing trusted CA certificate(s)
 	cert     string // the path to a cert.pem file, containing client certificate(s) for the request
 	cert_key string // the path to a key.pem file, containing private keys for the client certificate(s)

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -7,8 +7,9 @@ import os
 
 // SSLConn is the current connection
 pub struct SSLConn {
+pub:
 	config SSLConnectConfig
-mut:
+pub mut:
 	sslctx   &C.SSL_CTX = unsafe { nil }
 	ssl      &C.SSL     = unsafe { nil }
 	handle   int
@@ -19,6 +20,7 @@ mut:
 
 @[params]
 pub struct SSLConnectConfig {
+pub:
 	verify   string // the path to a rootca.pem file, containing trusted CA certificate(s)
 	cert     string // the path to a cert.pem file, containing client certificate(s) for the request
 	cert_key string // the path to a key.pem file, containing private keys for the client certificate(s)

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -47,6 +47,7 @@ pub mut:
 }
 
 pub struct Mail {
+pub:
 	from        string
 	to          string
 	cc          string

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -9,8 +9,7 @@ pub const tcp_default_write_timeout = 30 * time.second
 @[heap]
 pub struct TcpConn {
 pub mut:
-	sock TcpSocket
-mut:
+	sock           TcpSocket
 	handle         int
 	write_deadline time.Time
 	read_deadline  time.Time

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -312,8 +312,7 @@ pub fn (c TcpConn) str() string {
 
 pub struct TcpListener {
 pub mut:
-	sock TcpSocket
-mut:
+	sock            TcpSocket
 	accept_timeout  time.Duration
 	accept_deadline time.Time
 	is_blocking     bool = true

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -224,6 +224,7 @@ mut:
 
 @[params]
 pub struct ListenOptions {
+pub:
 	backlog int = 128
 }
 

--- a/vlib/net/websocket/utils.v
+++ b/vlib/net/websocket/utils.v
@@ -4,6 +4,15 @@ import rand
 import crypto.sha1
 import encoding.base64
 import encoding.binary
+import log
+
+const default_logger = setup_default_logger()
+
+fn setup_default_logger() &log.Log {
+	mut l := &log.Log{}
+	l.set_level(.info)
+	return l
+}
 
 // htonl64 converts payload length to header bits
 fn htonl64(payload_len u64) []u8 {

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -43,9 +43,7 @@ pub mut:
 	panic_on_callback bool // set to true of callbacks can panic
 	client_state      shared ClientState // current state of connection
 	// logger used to log messages
-	logger &log.Logger = &log.Logger(&log.Log{
-	level: .info
-})
+	logger        &log.Logger = default_logger
 	resource_name string // name of current resource
 	last_pong_ut  i64    // last time in unix time we got a pong message
 }
@@ -87,9 +85,7 @@ pub struct ClientOpt {
 pub:
 	read_timeout  i64 = 30 * time.second
 	write_timeout i64 = 30 * time.second
-	logger        &log.Logger = &log.Logger(&log.Log{
-	level: .info
-})
+	logger        &log.Logger = default_logger
 }
 
 // new_client instance a new websocket client

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -84,6 +84,7 @@ pub enum OPCode {
 
 @[params]
 pub struct ClientOpt {
+pub:
 	read_timeout  i64 = 30 * time.second
 	write_timeout i64 = 30 * time.second
 	logger        &log.Logger = &log.Logger(&log.Log{

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -17,9 +17,7 @@ pub mut:
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	logger &log.Logger = &log.Logger(&log.Log{
-	level: .info
-})
+	logger                  &log.Logger      = default_logger
 	ls                      &net.TcpListener = unsafe { nil } // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions
 	message_callbacks       []MessageEventHandler // new message callback functions
@@ -45,9 +43,7 @@ pub mut:
 @[params]
 pub struct ServerOpt {
 pub:
-	logger &log.Logger = &log.Logger(&log.Log{
-	level: .info
-})
+	logger &log.Logger = default_logger
 }
 
 // new_server instance a new websocket server on provided port and route
@@ -144,13 +140,13 @@ fn (mut s Server) serve_client(mut c Client) ! {
 
 // handle_handshake use an existing connection to respond to the handshake for a given key
 pub fn (mut s Server) handle_handshake(mut conn net.TcpConn, key string) !&ServerClient {
+	mut logger := &log.Log{}
+	logger.set_level(.debug)
 	mut c := &Client{
 		is_server: true
 		conn: conn
 		is_ssl: false
-		logger: &log.Log{
-			level: .debug
-		}
+		logger: logger
 		client_state: ClientState{
 			state: .open
 		}

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -44,6 +44,7 @@ pub mut:
 
 @[params]
 pub struct ServerOpt {
+pub:
 	logger &log.Logger = &log.Logger(&log.Log{
 	level: .info
 })

--- a/vlib/os/fd.c.v
+++ b/vlib/os/fd.c.v
@@ -75,6 +75,7 @@ pub fn fd_read(fd int, maxbytes int) (string, int) {
 pub struct C.fd_set {}
 
 pub struct C.timeval {
+pub:
 	tv_sec  u64
 	tv_usec u64
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -121,6 +121,7 @@ pub fn cp_all(src string, dst string, overwrite bool) ! {
 
 @[params]
 pub struct MvParams {
+pub:
 	overwrite bool = true
 }
 
@@ -717,6 +718,7 @@ pub fn log(s string) {
 
 @[params]
 pub struct MkdirParams {
+pub:
 	mode u32 = 0o777 // note that the actual mode is affected by the process's umask
 }
 

--- a/vlib/readline/readline.v
+++ b/vlib/readline/readline.v
@@ -35,6 +35,7 @@ mut:
 	is_tty                 bool
 	last_prefix_completion []rune
 	last_completion_offset int
-	completion_list        []string
-	completion_callback    fn (string) []string = unsafe { nil }
+pub mut:
+	completion_list     []string
+	completion_callback fn (string) []string = unsafe { nil }
 }

--- a/vlib/readline/readline.v
+++ b/vlib/readline/readline.v
@@ -20,7 +20,7 @@ struct Winsize {
 // Readline is the key struct for reading and holding user input via a terminal.
 // Example: import readline { Readline }
 pub struct Readline {
-mut:
+pub mut:
 	is_raw                 bool
 	orig_termios           termios.Termios // Linux
 	current                []rune // Line being edited
@@ -35,7 +35,6 @@ mut:
 	is_tty                 bool
 	last_prefix_completion []rune
 	last_completion_offset int
-pub mut:
-	completion_list     []string
-	completion_callback fn (string) []string = unsafe { nil }
+	completion_list        []string
+	completion_callback    fn (string) []string = unsafe { nil }
 }

--- a/vlib/sokol/audio/audio.c.v
+++ b/vlib/sokol/audio/audio.c.v
@@ -83,6 +83,7 @@ pub mut:
 // | num_packets   | 64       | for push model only, number of packets in the backend ringbuffer |
 @[typedef]
 pub struct C.saudio_desc {
+pub:
 	sample_rate        int
 	num_channels       int
 	buffer_frames      int

--- a/vlib/sync/pool/pool.c.v
+++ b/vlib/sync/pool/pool.c.v
@@ -29,6 +29,7 @@ fn empty_cb(mut p PoolProcessor, idx int, task_id int) voidptr {
 }
 
 pub struct PoolProcessorConfig {
+pub:
 	maxjobs  int
 	callback ThreadCB = empty_cb
 }

--- a/vlib/szip/szip.c.v
+++ b/vlib/szip/szip.c.v
@@ -9,6 +9,7 @@ import os
 
 @[params]
 pub struct ZipFolderOptions {
+pub:
 	omit_empty_folders bool
 }
 

--- a/vlib/term/ui/input.v
+++ b/vlib/term/ui/input.v
@@ -183,6 +183,7 @@ pub mut:
 }
 
 pub struct Config {
+pub:
 	user_data  voidptr
 	init_fn    ?fn (voidptr)
 	frame_fn   ?fn (voidptr)

--- a/vlib/time/stopwatch.v
+++ b/vlib/time/stopwatch.v
@@ -5,6 +5,7 @@ module time
 
 @[params]
 pub struct StopWatchOptions {
+pub:
 	auto_start bool = true
 }
 

--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -7,6 +7,7 @@ module time
 
 // C.timeval represents a C time value.
 pub struct C.timeval {
+pub:
 	tv_sec  u64
 	tv_usec u64
 }

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -42,7 +42,7 @@ pub fn (t Time) local() Time {
 
 // in most systems, these are __quad_t, which is an i64
 pub struct C.timespec {
-mut:
+pub mut:
 	tv_sec  i64
 	tv_nsec i64
 }

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -48,6 +48,7 @@ const start_local_time = local_as_unix_time()
 
 // in most systems, these are __quad_t, which is an i64
 pub struct C.timespec {
+pub:
 	tv_sec  i64
 	tv_nsec i64
 }

--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -19,6 +19,7 @@ const utf8_max = 0x10FFFF
 
 // Checker checks a tree of TOML `ast.Value`'s for common errors.
 pub struct Checker {
+pub:
 	scanner &scanner.Scanner = unsafe { nil }
 }
 

--- a/vlib/toml/decoder/decoder.v
+++ b/vlib/toml/decoder/decoder.v
@@ -14,6 +14,7 @@ const utf8_max = 0x10FFFF
 
 // Decoder decode special sequences in a tree of TOML `ast.Value`'s.
 pub struct Decoder {
+pub:
 	scanner &scanner.Scanner = unsafe { nil }
 }
 

--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -203,6 +203,7 @@ fn to_any[T](value T) Any {
 
 // DateTime is the representation of an RFC 3339 datetime string.
 pub struct DateTime {
+pub:
 	datetime string
 }
 
@@ -213,6 +214,7 @@ pub fn (dt DateTime) str() string {
 
 // Date is the representation of an RFC 3339 date-only string.
 pub struct Date {
+pub:
 	date string
 }
 
@@ -223,6 +225,7 @@ pub fn (d Date) str() string {
 
 // Time is the representation of an RFC 3339 time-only string.
 pub struct Time {
+pub:
 	time string
 }
 

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -289,6 +289,7 @@ pub fn (t &Table) find_method(s &TypeSymbol, name string) !Fn {
 
 @[params]
 pub struct GetEmbedsOptions {
+pub:
 	preceding []Type
 }
 

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1511,6 +1511,7 @@ fn (t Table) shorten_user_defined_typenames(original_name string, import_aliases
 
 @[minify]
 pub struct FnSignatureOpts {
+pub:
 	skip_receiver bool
 	type_only     bool
 }

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -743,13 +743,13 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 					if c.mod != type_sym.mod {
 						if !field.is_pub {
 							parts := type_sym.name.split('.')
-							mod_type := if parts.len > 1 {
-								parts#[-2..].join('.')
-							} else {
-								parts.last()
-							}
 							for init_field in node.init_fields {
 								if field.name == init_field.name {
+									mod_type := if parts.len > 1 {
+										parts#[-2..].join('.')
+									} else {
+										parts.last()
+									}
 									c.error('cannot access private field `${field.name}` on `${mod_type}`',
 										init_field.pos)
 									break

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -748,8 +748,13 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 							} else {
 								parts.last()
 							}
-							c.error('cannot access private field `${field.name}` on `${mod_type}`',
-								node.pos)
+							for init_field in node.init_fields {
+								if field.name == init_field.name {
+									c.error('cannot access private field `${field.name}` on `${mod_type}`',
+										init_field.pos)
+									break
+								}
+							}
 						}
 						if field.is_deprecated {
 							for init_field in node.init_fields {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -741,8 +741,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 			for i, mut field in fields {
 				if field.name in inited_fields {
 					if c.mod != type_sym.mod {
-						// TODO: fix marking fields as pub on interop structs.
-						if !field.is_pub && type_sym.language == .v {
+						if !field.is_pub {
 							parts := type_sym.name.split('.')
 							mod_type := if parts.len > 1 {
 								parts#[-2..].join('.')

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -750,7 +750,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 									} else {
 										parts.last()
 									}
-									c.error('cannot access private field `${field.name}` on `${mod_type}`',
+									c.warn('cannot access private field `${field.name}` on `${mod_type}`',
 										init_field.pos)
 									break
 								}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -750,8 +750,10 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 									} else {
 										parts.last()
 									}
-									c.warn('cannot access private field `${field.name}` on `${mod_type}`',
+									c.add_error_detail('this will become an error after 2024-05-31')
+									c.warn('initalizing private field `${field.name}` of `${mod_type}`',
 										init_field.pos)
+									// c.error('cannot access private field `${field.name}` on `${mod_type}`', init_field.pos)
 									break
 								}
 							}

--- a/vlib/v/checker/tests/amod/amod.v
+++ b/vlib/v/checker/tests/amod/amod.v
@@ -1,5 +1,17 @@
 module amod
 
-pub struct Xyz {}
+pub struct Xyz {
+pub:
+	x int
+}
 
-pub struct Bcg {}
+pub struct Bcg {
+	x int
+}
+
+@[params]
+pub struct FooParams {
+	bar string
+}
+
+pub fn foo(opts FooParams) {}

--- a/vlib/v/checker/tests/modules/overload_return_type/point.v
+++ b/vlib/v/checker/tests/modules/overload_return_type/point.v
@@ -1,7 +1,7 @@
 module point
 
 pub struct Point {
-mut:
+pub mut:
 	x int
 	y int
 }

--- a/vlib/v/checker/tests/struct_field_private_err.out
+++ b/vlib/v/checker/tests/struct_field_private_err.out
@@ -1,12 +1,14 @@
-vlib/v/checker/tests/struct_field_private_err.vv:8:2: warning: cannot access private field `x` on `amod.Bcg`
+vlib/v/checker/tests/struct_field_private_err.vv:8:2: warning: initalizing private field `x` of `amod.Bcg`
     6 | 
     7 | _ := amod.Bcg{
     8 |     x: 0
       |     ~~~~
     9 | }
    10 |
-vlib/v/checker/tests/struct_field_private_err.vv:11:10: warning: cannot access private field `bar` on `amod.FooParams`
+Details: this will become an error after 2024-05-31
+vlib/v/checker/tests/struct_field_private_err.vv:11:10: warning: initalizing private field `bar` of `amod.FooParams`
     9 | }
    10 | 
    11 | amod.foo(bar: 'bar')
       |          ~~~~~~~~~~
+Details: this will become an error after 2024-05-31

--- a/vlib/v/checker/tests/struct_field_private_err.out
+++ b/vlib/v/checker/tests/struct_field_private_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/struct_field_private_err.vv:7:11: error: cannot access private field `x` on `amod.Bcg`
+    5 | }
+    6 | 
+    7 | _ := amod.Bcg{
+      |           ~~~~
+    8 |     x: 0
+    9 | }
+vlib/v/checker/tests/struct_field_private_err.vv:11:10: error: cannot access private field `bar` on `amod.FooParams`
+    9 | }
+   10 | 
+   11 | amod.foo(bar: 'bar')
+      |          ~~~~~~~~~~~

--- a/vlib/v/checker/tests/struct_field_private_err.out
+++ b/vlib/v/checker/tests/struct_field_private_err.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/struct_field_private_err.vv:8:2: error: cannot access private field `x` on `amod.Bcg`
+vlib/v/checker/tests/struct_field_private_err.vv:8:2: warning: cannot access private field `x` on `amod.Bcg`
     6 | 
     7 | _ := amod.Bcg{
     8 |     x: 0
       |     ~~~~
     9 | }
    10 |
-vlib/v/checker/tests/struct_field_private_err.vv:11:10: error: cannot access private field `bar` on `amod.FooParams`
+vlib/v/checker/tests/struct_field_private_err.vv:11:10: warning: cannot access private field `bar` on `amod.FooParams`
     9 | }
    10 | 
    11 | amod.foo(bar: 'bar')

--- a/vlib/v/checker/tests/struct_field_private_err.out
+++ b/vlib/v/checker/tests/struct_field_private_err.out
@@ -1,12 +1,12 @@
-vlib/v/checker/tests/struct_field_private_err.vv:7:11: error: cannot access private field `x` on `amod.Bcg`
-    5 | }
+vlib/v/checker/tests/struct_field_private_err.vv:8:2: error: cannot access private field `x` on `amod.Bcg`
     6 | 
     7 | _ := amod.Bcg{
-      |           ~~~~
     8 |     x: 0
+      |     ~~~~
     9 | }
+   10 |
 vlib/v/checker/tests/struct_field_private_err.vv:11:10: error: cannot access private field `bar` on `amod.FooParams`
     9 | }
    10 | 
    11 | amod.foo(bar: 'bar')
-      |          ~~~~~~~~~~~
+      |          ~~~~~~~~~~

--- a/vlib/v/checker/tests/struct_field_private_err.vv
+++ b/vlib/v/checker/tests/struct_field_private_err.vv
@@ -1,0 +1,11 @@
+import amod
+
+_ := amod.Xyz{
+	x: 0
+}
+
+_ := amod.Bcg{
+	x: 0
+}
+
+amod.foo(bar: 'bar')

--- a/vlib/v/checker/tests/struct_field_private_err.vv
+++ b/vlib/v/checker/tests/struct_field_private_err.vv
@@ -1,4 +1,4 @@
-import amod
+import v.checker.tests.amod
 
 _ := amod.Xyz{
 	x: 0

--- a/vlib/v/doc/doc_test.v
+++ b/vlib/v/doc/doc_test.v
@@ -41,6 +41,7 @@ pub enum MouseButtons {
 	end_options := mod_doc.contents['EndOptions']
 	assert end_options.content == '@[params]
 pub struct EndOptions {
+pub:
 	how EndEnum
 }'
 	assert end_options.attrs == {

--- a/vlib/v/dotgraph/dotgraph.v
+++ b/vlib/v/dotgraph/dotgraph.v
@@ -35,6 +35,7 @@ pub fn (mut d DotGraph) finish() {
 //
 
 pub struct NewNodeConfig {
+pub:
 	node_name        string
 	should_highlight bool
 	tooltip          string
@@ -57,6 +58,7 @@ pub fn (mut d DotGraph) new_node(nlabel string, cfg NewNodeConfig) {
 //
 
 pub struct NewEdgeConfig {
+pub:
 	should_highlight bool
 	ctx              voidptr = unsafe { nil }
 	name2node_fn     FnLabel2NodeName = node_name

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -51,6 +51,7 @@ pub fn (mut e Eval) run(expression string, args ...Object) ![]Object {
 type Symbol = Object | ast.EmptyStmt | ast.FnDecl
 
 pub struct Eval {
+pub:
 	pref &pref.Preferences = unsafe { nil }
 pub mut:
 	table                  &ast.Table = unsafe { nil }

--- a/vlib/v/fmt/align.v
+++ b/vlib/v/fmt/align.v
@@ -16,6 +16,7 @@ mut:
 
 @[params]
 struct AddInfoConfig {
+pub:
 	use_threshold bool
 }
 

--- a/vlib/v/fmt/attrs.v
+++ b/vlib/v/fmt/attrs.v
@@ -23,6 +23,7 @@ pub fn (mut f Fmt) attrs(attrs []ast.Attr) {
 
 @[params]
 pub struct AttrsOptions {
+pub:
 	same_line bool
 }
 

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -14,6 +14,7 @@ const bs = '\\'
 
 @[minify]
 pub struct Fmt {
+pub:
 	pref &pref.Preferences = unsafe { nil }
 pub mut:
 	file               ast.File
@@ -56,6 +57,7 @@ pub mut:
 
 @[params]
 pub struct FmtOptions {
+pub:
 	source_text string
 }
 
@@ -167,6 +169,7 @@ pub fn (mut f Fmt) wrap_long_line(penalty_idx int, add_indent bool) bool {
 
 @[params]
 pub struct RemoveNewLineConfig {
+pub:
 	imports_buffer bool // Work on f.out_imports instead of f.out
 }
 

--- a/vlib/v/gen/golang/attrs.v
+++ b/vlib/v/gen/golang/attrs.v
@@ -23,6 +23,7 @@ pub fn (mut f Gen) attrs(attrs []ast.Attr) {
 
 @[params]
 pub struct AttrsOptions {
+pub:
 	inline bool
 }
 

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -126,6 +126,7 @@ pub fn (mut f Gen) wrap_long_line(penalty_idx int, add_indent bool) bool {
 
 @[params]
 pub struct RemoveNewLineConfig {
+pub:
 	imports_buffer bool // Work on f.out_imports instead of f.out
 }
 

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -79,11 +79,13 @@ enum Amd64SetOp {
 
 @[params]
 struct AvailableAmd64Register {
+pub:
 	available Amd64Register
 }
 
 @[params]
 struct Amd64RegisterOption {
+pub:
 	reg    Amd64Register    = Amd64Register.rax
 	ssereg Amd64SSERegister = Amd64SSERegister.xmm0
 }

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -231,6 +231,7 @@ struct GlobalVar {}
 
 @[params]
 struct VarConfig {
+pub:
 	offset i32      // offset from the variable
 	typ    ast.Type // type of the value you want to process e.g. struct fields.
 }

--- a/vlib/v/gen/wasm/serialise/serialise.v
+++ b/vlib/v/gen/wasm/serialise/serialise.v
@@ -103,6 +103,7 @@ pub fn (mut p Pool) type_size(typ ast.Type) (int, int) {
 
 @[params]
 pub struct PoolOpts {
+pub:
 	null_terminated bool = true
 	intern_strings  bool = true
 	store_relocs    bool = true

--- a/vlib/v/help/help.v
+++ b/vlib/v/help/help.v
@@ -21,6 +21,7 @@ fn help_dir() string {
 
 @[params]
 pub struct ExitOptions {
+pub:
 	exit_code int
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -647,6 +647,7 @@ fn (mut p Parser) check(expected token.Kind) {
 
 @[params]
 struct ParamsForUnexpected {
+pub:
 	got            string
 	expecting      string
 	prepend_msg    string
@@ -929,6 +930,7 @@ fn (mut p Parser) comment_stmt() ast.ExprStmt {
 
 @[params]
 struct EatCommentsConfig {
+pub:
 	same_line bool // Only eat comments on the same line as the previous token
 	follow_up bool // Comments directly below the previous token as long as there is no empty line
 }
@@ -4647,6 +4649,7 @@ fn (mut p Parser) trace[T](fbase string, x &T) {
 
 @[params]
 struct ParserShowParams {
+pub:
 	msg   string
 	reach int = 3
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -21,6 +21,7 @@ const allowed_lock_prefix_ins = ['add', 'adc', 'and', 'btc', 'btr', 'bts', 'cmpx
 
 @[minify]
 pub struct Parser {
+pub:
 	pref &pref.Preferences = unsafe { nil }
 mut:
 	file_base         string       // "hello.v"
@@ -32,7 +33,6 @@ mut:
 	tok                       token.Token
 	prev_tok                  token.Token
 	peek_tok                  token.Token
-	table                     &ast.Table = unsafe { nil }
 	language                  ast.Language
 	fn_language               ast.Language // .c for `fn C.abcd()` declarations
 	expr_level                int  // prevent too deep recursions for pathological programs
@@ -70,17 +70,16 @@ mut:
 	inside_orm                bool
 	inside_chan_decl          bool
 	inside_attr_decl          bool
-	fixed_array_dim           int        // fixed array dim parsing level
-	or_is_handled             bool       // ignore `or` in this expression
-	builtin_mod               bool       // are we in the `builtin` module?
-	mod                       string     // current module name
-	is_manualfree             bool       // true when `[manualfree] module abc`, makes *all* fns in the current .v file, opt out of autofree
-	has_globals               bool       // `[has_globals] module abc` - allow globals declarations, even without -enable-globals, in that single .v file __only__
-	is_generated              bool       // `[generated] module abc` - turn off compiler notices for that single .v file __only__.
-	is_translated             bool       // `[translated] module abc` - mark a file as translated, to relax some compiler checks for translated code.
-	attrs                     []ast.Attr // attributes before next decl stmt
-	expr_mod                  string     // for constructing full type names in parse_type()
-	scope                     &ast.Scope = unsafe { nil }
+	fixed_array_dim           int               // fixed array dim parsing level
+	or_is_handled             bool              // ignore `or` in this expression
+	builtin_mod               bool              // are we in the `builtin` module?
+	mod                       string            // current module name
+	is_manualfree             bool              // true when `[manualfree] module abc`, makes *all* fns in the current .v file, opt out of autofree
+	has_globals               bool              // `[has_globals] module abc` - allow globals declarations, even without -enable-globals, in that single .v file __only__
+	is_generated              bool              // `[generated] module abc` - turn off compiler notices for that single .v file __only__.
+	is_translated             bool              // `[translated] module abc` - mark a file as translated, to relax some compiler checks for translated code.
+	attrs                     []ast.Attr        // attributes before next decl stmt
+	expr_mod                  string            // for constructing full type names in parse_type()
 	imports                   map[string]string // alias => mod_name
 	ast_imports               []ast.Import      // mod_names
 	used_imports              []string // alias
@@ -106,7 +105,10 @@ mut:
 	script_mode               bool
 	script_mode_start_token   token.Token
 pub mut:
-	scanner        &scanner.Scanner = unsafe { nil }
+	scanner        &scanner.Scanner     = unsafe { nil }
+	comments_mode  scanner.CommentsMode = .skip_comments
+	table          &ast.Table = unsafe { nil }
+	scope          &ast.Scope = unsafe { nil }
 	errors         []errors.Error
 	warnings       []errors.Warning
 	notices        []errors.Notice

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -105,10 +105,9 @@ mut:
 	script_mode               bool
 	script_mode_start_token   token.Token
 pub mut:
-	scanner        &scanner.Scanner     = unsafe { nil }
-	comments_mode  scanner.CommentsMode = .skip_comments
-	table          &ast.Table = unsafe { nil }
-	scope          &ast.Scope = unsafe { nil }
+	scanner        &scanner.Scanner = unsafe { nil }
+	table          &ast.Table       = unsafe { nil }
+	scope          &ast.Scope       = unsafe { nil }
 	errors         []errors.Error
 	warnings       []errors.Warning
 	notices        []errors.Notice

--- a/vlib/v/tests/generics_from_modules/newmodule/newmodule.v
+++ b/vlib/v/tests/generics_from_modules/newmodule/newmodule.v
@@ -1,7 +1,7 @@
 module newmodule
 
 pub struct Params[T] {
-mut:
+pub mut:
 	a []T
 	b int
 	c T

--- a/vlib/v/trace_calls/tracing_calls_nix.c.v
+++ b/vlib/v/trace_calls/tracing_calls_nix.c.v
@@ -1,7 +1,7 @@
 module trace_calls
 
 pub struct C.timespec {
-mut:
+pub mut:
 	tv_sec  i64
 	tv_nsec i64
 }

--- a/vlib/v/util/timers.v
+++ b/vlib/v/util/timers.v
@@ -20,6 +20,7 @@ pub mut:
 
 @[params]
 pub struct TimerParams {
+pub:
 	should_print bool
 	label        string
 }

--- a/vlib/v/util/vtest/vtest.v
+++ b/vlib/v/util/vtest/vtest.v
@@ -4,6 +4,7 @@ import os
 
 @[params]
 pub struct FilterVTestConfig {
+pub:
 	basepath    string
 	fix_slashes bool = true
 }

--- a/vlib/vweb/sse/sse.v
+++ b/vlib/vweb/sse/sse.v
@@ -29,6 +29,7 @@ pub mut:
 }
 
 pub struct SSEMessage {
+pub:
 	id    string
 	event string
 	data  string

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -321,6 +321,7 @@ pub fn (mut ctx Context) server_error(ecode int) Result {
 
 @[params]
 pub struct RedirectParams {
+pub:
 	status_code int = 302
 }
 
@@ -523,6 +524,7 @@ pub fn run[T](global_app &T, port int) {
 
 @[params]
 pub struct RunParams {
+pub:
 	family               net.AddrFamily = .ip6 // use `family: .ip, host: 'localhost'` when you want it to bind only to 127.0.0.1
 	host                 string
 	port                 int  = 8080
@@ -1215,6 +1217,7 @@ fn (mut w Worker[T]) process_incoming_requests() {
 
 @[params]
 pub struct PoolParams[T] {
+pub:
 	handler    fn () T = unsafe { nil } @[required]
 	nr_workers int = runtime.nr_jobs()
 }

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -8,6 +8,7 @@ import time
 // Encoder encodes the an `Any` type into JSON representation.
 // It provides parameters in order to change the end result.
 pub struct Encoder {
+pub:
 	newline              u8
 	newline_spaces_count int
 	escape_unicode       bool = true

--- a/vlib/x/json2/strict/strict.v
+++ b/vlib/x/json2/strict/strict.v
@@ -16,6 +16,7 @@ pub enum KeyType {
 }
 
 pub struct StructCheckResult {
+pub:
 	duplicates  []string
 	superfluous []string
 }

--- a/vlib/x/sessions/sessions.v
+++ b/vlib/x/sessions/sessions.v
@@ -54,6 +54,7 @@ pub mut:
 // CookieOptions contains the default settings for the cookie created in
 // the `Sessions` struct.
 pub struct CookieOptions {
+pub:
 	cookie_name string = 'sid'
 	domain      string
 	http_only   bool          = true

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -159,6 +159,7 @@ struct HtmlFileInfo {
 // TemplateCacheParams are used to specify cache expiration delay and provide placeholder data for substitution in templates.
 @[params]
 pub struct TemplateCacheParams {
+pub:
 	placeholders           &map[string]DtmMultiTypeMap = &map[string]DtmMultiTypeMap{}
 	cache_delay_expiration i64 = dtm.cache_delay_expiration_by_default
 }
@@ -166,6 +167,7 @@ pub struct TemplateCacheParams {
 // DynamicTemplateManagerInitialisationParams is used with 'initialize' function. (See below at initialize section)
 @[params]
 pub struct DynamicTemplateManagerInitialisationParams {
+pub:
 	def_cache_path       string
 	compress_html        bool = true
 	active_cache_server  bool = true

--- a/vlib/x/vweb/context.v
+++ b/vlib/x/vweb/context.v
@@ -227,6 +227,7 @@ pub fn (mut ctx Context) server_error(msg string) Result {
 
 @[params]
 pub struct RedirectParams {
+pub:
 	typ RedirectType
 }
 

--- a/vlib/x/vweb/middleware.v
+++ b/vlib/x/vweb/middleware.v
@@ -30,6 +30,7 @@ mut:
 
 @[params]
 pub struct MiddlewareOptions[T] {
+pub:
 	handler fn (mut ctx T) bool @[required]
 	after   bool
 }

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -210,6 +210,7 @@ pub fn run[A, X](mut global_app A, port int) {
 
 @[params]
 pub struct RunParams {
+pub:
 	// use `family: .ip, host: 'localhost'` when you want it to bind only to 127.0.0.1
 	family               net.AddrFamily = .ip6
 	host                 string


### PR DESCRIPTION
Currently, it's possible to init a struct and assign values to it's private fields. Only accessing fields directly will trigger an error.

Currently following is possible
```v
import amod

b := amod.Bcg{ // public struct
	x: 3 // private field
}
```
After the changes an error will be visible on initialization (ref. to added test:`struct_field_private_err.out`). Eventually the change should allow for better accessibility control and improved security.