### PR TITLE
checker, json: return error on invalid string input instead of empty string result

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -794,7 +794,20 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		}
 		c.expected_type = ast.string_type
 		node.args[1].typ = c.expr(mut node.args[1].expr)
-		if node.args[1].typ != ast.string_type {
+		if node.args[1].typ == ast.string_type {
+			if node.args[1].expr is ast.StringLiteral {
+				str_arg := node.args[1].expr
+				if str_arg.val.len > 2 && str_arg.val[0] != `{` && str_arg.val[0] != `[` {
+					c.error('json.decode: invalid json string', str_arg.pos)
+				}
+			} else if node.args[1].expr is ast.Ident && node.args[1].expr.obj is ast.Var {
+				str_var := (node.args[1].expr.obj as ast.Var).expr
+				str_var_val := str_var.str()
+				if str_var_val.len > 2 && str_var_val[0] != `{` && str_var_val[0] != `[` {
+					c.error('json.decode: invalid json string', str_var.pos())
+				}
+			}
+		} else {
 			c.error('json.decode: second argument needs to be a string', node.pos)
 		}
 		typ := expr as ast.TypeNode

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -803,7 +803,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			} else if node.args[1].expr is ast.Ident && node.args[1].expr.obj is ast.Var {
 				str_var := (node.args[1].expr.obj as ast.Var).expr
 				str_var_val := str_var.str()
-				if str_var_val.len > 2 && str_var_val[0] != `{` && str_var_val[0] != `[` {
+				if str_var_val.len > 2 && str_var_val[1] != `{` && str_var_val[1] != `[` {
 					c.error('json.decode: invalid json string', str_var.pos())
 				}
 			}

--- a/vlib/v/checker/tests/json_decode_invalid_string.out
+++ b/vlib/v/checker/tests/json_decode_invalid_string.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/json_decode_invalid_string.vv:7:8: error: json.decode: invalid json string
+    5 | }
+    6 | 
+    7 | txt := '"{"host": "localhost"}'
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~
+    8 | json.decode(TestStruct, txt)!
+    9 | json.decode(TestStruct, txt.trim_string_right('"'))!
+vlib/v/checker/tests/json_decode_invalid_string.vv:10:25: error: json.decode: invalid json string
+    8 | json.decode(TestStruct, txt)!
+    9 | json.decode(TestStruct, txt.trim_string_right('"'))!
+   10 | json.decode(TestStruct, 'h{ost: "localhost"}')!
+      |                         ~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/json_decode_invalid_string.vv
+++ b/vlib/v/checker/tests/json_decode_invalid_string.vv
@@ -1,0 +1,10 @@
+import json
+
+struct TestStruct {
+	host string
+}
+
+txt := '"{"host": "localhost"}'
+json.decode(TestStruct, txt)!
+json.decode(TestStruct, txt.trim_string_right('"'))!
+json.decode(TestStruct, 'h{ost: "localhost"}')!


### PR DESCRIPTION
With the PR we get errors for invalid Cjson input.

Currently, there are many occasions where decoding panics without an error. 
Or the main concern in the related issue, is an empty result return without an any error in case of using quotation marks when they shouldn't be used.

Atm:
```v
import json

struct TestStruct {
	host string
}

json.decode(TestStruct, "abc")! // Panics, but without an error value

//quote ⬇️ should not be there
txt := '"{"host": "localhost"}'
json.decode(TestStruct, txt)! // Currently an empty string
```
New errors:
```
error: json.decode: invalid json string
    5 | }
    6 | 
    7 | txt := '"{"host": "localhost"}'
      |        ~~~~~~~~~~~~~~~~~~~~~~~~
    8 | json.decode(TestStruct, txt)!
```

```
error: json.decode: invalid json string
    5 | }
    6 | 
    7 | json.decode(TestStruct, 'abc')!
      |                         ~~~~~
    8 | 
```
The change is simple but should hopefully do most validation needed for the module in regards to the nice progress that is being made on the json2 module.

Resolves #19801