### PR TITLE
x.json2: decode array

### DIFF
--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -137,6 +137,25 @@ pub fn decode[T](src string) !T {
 	return decode_struct[T](T{}, res)
 }
 
+// decode_array is a generic function that decodes a JSON string into the array target type.
+pub fn decode_array[T](src string) ![]T {
+	res := raw_decode(src)!.as_map()
+	return decode_struct_array(T{}, res)
+}
+
+// decode_struct_array is a generic function that decodes a JSON map into array struct T.
+fn decode_struct_array[T](_ T, res map[string]Any) ![]T {
+	$if T is $struct {
+		mut arr := []T{}
+		for v in res.values() {
+			arr << decode_struct[T](T{}, v.as_map())!
+		}
+		return arr
+	} $else {
+		return error("The type `${T.name}` can't be decoded.")
+	}
+}
+
 // decode_struct is a generic function that decodes a JSON map into the struct T.
 fn decode_struct[T](_ T, res map[string]Any) !T {
 	mut typ := T{}


### PR DESCRIPTION
Fix #21168

Added generic way to decode a JSON array string into a array of generic type.


```v
import x.json2


pub struct Value {
	value string
}

pub struct Value2 {
	value string
}

fn main() {
	println(json2.decode_array[Value]('[{"value": "abc"}, {"value": "def"}]')!)
	println(json2.decode_array[Value2]('[{"value": "abc"}, {"value": "def"}]')!)
}
```