### PR TITLE
xml: update entity parse test

### DIFF
--- a/vlib/encoding/xml/test/local/12_doctype_entity/entity_expected.xml
+++ b/vlib/encoding/xml/test/local/12_doctype_entity/entity_expected.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE body [
+  <!ENTITY warning "Warning: Something bad happened... please refresh and try again.">
+]>
+<body>
+  <message>
+    Warning: Something bad happened... please refresh and try again.
+  </message>
+</body>

--- a/vlib/encoding/xml/test/local/12_doctype_entity/spec_entity_test.v
+++ b/vlib/encoding/xml/test/local/12_doctype_entity/spec_entity_test.v
@@ -4,38 +4,7 @@ import os
 import encoding.xml
 
 fn test_valid_parsing() {
-	path := os.join_path(os.dir(@FILE), 'entity.xml')
-
-	mut reverse_entities := xml.default_entities_reverse.clone()
-	reverse_entities['Warning: Something bad happened... please refresh and try again.'] = 'warning'
-
-	expected := xml.XMLDocument{
-		parsed_reverse_entities: reverse_entities
-		doctype: xml.DocumentType{
-			name: 'body'
-			dtd: xml.DocumentTypeDefinition{
-				name: ''
-				list: [
-					xml.DTDEntity{
-						name: 'warning'
-						value: 'Warning: Something bad happened... please refresh and try again.'
-					},
-				]
-			}
-		}
-		root: xml.XMLNode{
-			name: 'body'
-			children: [
-				xml.XMLNode{
-					name: 'message'
-					children: [
-						'Warning: Something bad happened... please refresh and try again.',
-					]
-				},
-			]
-		}
-	}
-	actual := xml.XMLDocument.from_file(path)!.validate()!
-
+	expected := xml.XMLDocument.from_file(os.join_path(os.dir(@FILE), 'entity.xml'))!.validate()!
+	actual := xml.XMLDocument.from_file(os.join_path(os.dir(@FILE), 'entity_expected.xml'))!.validate()!
 	assert expected == actual, 'Parsed XML document should be equal to expected XML document'
 }


### PR DESCRIPTION
Upgrades an xml test that assigns values to the private field `parsed_reverse_entities` which in an external test. Otherwise, the fields data is only used internally.

https://github.com/vlang/v/blob/254250d375acff5a92c2a0b1a3079c98e7e16244/vlib/encoding/xml/types.v#L61-L63

The new test might be more robust and easier to follow as well, as it compares the parses files with entities with an an expected file that have the entities already resolved. 

The upgrade is also required for #21183 