### PR TITLE
vdoc: select first result when entering search term, use more explict query for `header.doc-nav`

### DIFF
--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -1,5 +1,5 @@
 (function () {
-	const docnav = document.querySelector('.doc-nav');
+	const docnav = document.querySelector('header.doc-nav');
 	const active = docnav.querySelector('li.active');
 	active?.scrollIntoView({ block: 'center', inline: 'nearest' });
 	setupMobileToggle();
@@ -62,7 +62,7 @@ function setupScrollSpy() {
 
 function setupMobileToggle() {
 	document.getElementById('toggle-menu').addEventListener('click', () => {
-		const docNav = document.querySelector('.doc-nav');
+		const docNav = document.querySelector('header.doc-nav');
 		const isHidden = docNav.classList.contains('hidden');
 		docNav.classList.toggle('hidden');
 		const search = docNav.querySelector('.search');
@@ -92,7 +92,7 @@ function setupDarkMode() {
 function setupSearch() {
 	const onInputChange = debounce((e) => {
 		const searchValue = e.target.value.toLowerCase();
-		const docNav = document.querySelector('.doc-nav');
+		const docNav = document.querySelector('header.doc-nav');
 		const menu = docNav.querySelector('.content');
 		const search = docNav.querySelector('.search');
 		if (searchValue === '') {
@@ -182,6 +182,7 @@ function setupSearch() {
 function setupSearchKeymaps() {
 	const searchInput = document.querySelector('#search input');
 	const mainContent = document.querySelector('#main-content');
+	const docnav = document.querySelector('header.doc-nav');
 	// Keyboard shortcut indicator
 	const searchKeys = document.createElement('div');
 	const modifierKeyPrefix = navigator.platform.includes('Mac') ? '⌘' : 'Ctrl';
@@ -241,6 +242,7 @@ function setupSearchKeymaps() {
 				}
 				break;
 			default:
+				docnav.scroll(0, 0);
 				selectedIdx = -1;
 		}
 	});


### PR DESCRIPTION
Currently, there are some situations where search results are sub-optimally presented. For example, when opening a module site like https://modules.vlang.io/sync.html where the sidebar navigation on the left is already scrolled down. Then, upon entering a search term, such as `str`, the navigation remains scrolled down, the most relevant search results are not visible without manually scrolling up in the side bar. With the changes, upon entering a search term, the search navigation scrolls to the top.