### PR TITLE
fmt: extend import import alias reference map for submodules

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -102,6 +102,7 @@ pub fn fmt(file ast.File, mut table ast.Table, pref_ &pref.Preferences, is_debug
 pub fn (mut f Fmt) process_file_imports(file &ast.File) {
 	for imp in file.imports {
 		f.mod2alias[imp.mod] = imp.alias
+		f.mod2alias[imp.mod.all_after('${file.mod.name}.')] = imp.alias
 		for sym in imp.syms {
 			f.mod2alias['${imp.mod}.${sym.name}'] = sym.name
 			f.mod2alias['${imp.mod.all_after_last('.')}.${sym.name}'] = sym.name

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -72,6 +72,9 @@ fn run_fmt(mut input_files []string) {
 fn test_fmt() {
 	mut input_files := os.walk_ext(os.join_path(tdir, 'tests'), '_input.vv')
 	run_fmt(mut input_files)
+
+	input_files = os.walk_ext(os.join_path(tdir, 'testdata', 'vmodules'), '_input.vv')
+	run_fmt(mut input_files)
 }
 
 fn test_fmt_vmodules() {

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -72,9 +72,6 @@ fn run_fmt(mut input_files []string) {
 fn test_fmt() {
 	mut input_files := os.walk_ext(os.join_path(tdir, 'tests'), '_input.vv')
 	run_fmt(mut input_files)
-
-	input_files = os.walk_ext(os.join_path(tdir, 'testdata', 'vmodules'), '_input.vv')
-	run_fmt(mut input_files)
 }
 
 fn test_fmt_vmodules() {

--- a/vlib/v/fmt/testdata/vmodules/submod_import_alias/vlas/module_alias_import_submod_in_submod_keep.vv
+++ b/vlib/v/fmt/testdata/vmodules/submod_import_alias/vlas/module_alias_import_submod_in_submod_keep.vv
@@ -1,0 +1,10 @@
+module vlas
+
+// `internal/blas` has to be intact as submodule directory structure for the test to be reliable.
+import internal.blas
+
+fn C.LAPACKE_dlange(matrix_layout blas.MemoryLayout) f64
+
+pub fn c_trans(trans bool) blas.Transpose {
+	return if trans { .trans } else { .no_trans }
+}

--- a/vlib/v/fmt/testdata/vmodules/submod_import_alias/vlas/module_alias_submod_import_parent_mod_expected.vv
+++ b/vlib/v/fmt/testdata/vmodules/submod_import_alias/vlas/module_alias_submod_import_parent_mod_expected.vv
@@ -1,0 +1,9 @@
+module vlas
+
+import submod_import_alias.vlas.internal.blas
+
+fn C.LAPACKE_dlange(matrix_layout blas.MemoryLayout) f64
+
+pub fn c_trans(trans bool) blas.Transpose {
+	return if trans { .trans } else { .no_trans }
+}

--- a/vlib/v/fmt/testdata/vmodules/submod_import_alias/vlas/module_alias_submod_import_parent_mod_input.vv
+++ b/vlib/v/fmt/testdata/vmodules/submod_import_alias/vlas/module_alias_submod_import_parent_mod_input.vv
@@ -1,0 +1,9 @@
+module vlas
+
+import submod_import_alias.vlas.internal.blas
+
+fn C.LAPACKE_dlange(matrix_layout internal.blas.MemoryLayout) f64
+
+pub fn c_trans(trans bool) internal.blas.Transpose {
+	return if trans { .trans } else { .no_trans }
+}


### PR DESCRIPTION
Should fix and cover the current fmt fails on vls.