### PR TITLE
x.vweb: accept query params as method arguments

### DIFF
--- a/vlib/x/vweb/tests/vweb_test.v
+++ b/vlib/x/vweb/tests/vweb_test.v
@@ -249,6 +249,12 @@ fn test_login_with_multipart_form_data_send_by_fetch() {
 	assert x.body == 'username: xmyusernamex | password: xmypassword123x'
 }
 
+fn test_query_params_are_passed_as_arguments() {
+	x := http.get('http://${localserver}/query_echo?c=3&a="test"&b=20')!
+	assert x.status() == .ok
+	assert x.body == 'a: x"test"x | b: x20x'
+}
+
 fn test_host() {
 	mut req := http.Request{
 		url: 'http://${localserver}/with_host'

--- a/vlib/x/vweb/tests/vweb_test_server.v
+++ b/vlib/x/vweb/tests/vweb_test_server.v
@@ -114,6 +114,11 @@ pub fn (mut app ServerApp) file_echo(mut ctx ServerContext) vweb.Result {
 	return ctx.text(ctx.files['file'][0].data)
 }
 
+@['/query_echo']
+pub fn (mut app ServerApp) query_echo(mut ctx ServerContext, a string, b int) vweb.Result {
+	return ctx.text('a: x${a}x | b: x${b}x')
+}
+
 // Make sure [post] works without the path
 @[post]
 pub fn (mut app ServerApp) json(mut ctx ServerContext) vweb.Result {

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -848,8 +848,7 @@ fn handle_route[A, X](mut app A, mut user_context X, url urllib.URL, host string
 							}
 
 							for param in method.args[1..] {
-								val := data[param.name] or { continue }
-								args << val
+								args << data[param.name]
 							}
 
 							app.$method(mut user_context, args)


### PR DESCRIPTION
Add ability to accept method arguments for query parameters in a `get` request the same way form values are passed as arguments in a `post` request.
