### PR TITLE
parser: update file path fields; use more expressive name for file path, remove obsolete `file_name_dir` field

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -91,7 +91,7 @@ fn (mut p Parser) hash() ast.HashStmt {
 	}
 	return ast.HashStmt{
 		mod: p.mod
-		source_file: p.file_name
+		source_file: p.file_path
 		val: val
 		kind: kind
 		main: main_str

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -720,7 +720,7 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 }
 
 fn (p &Parser) fileis(s string) bool {
-	return p.file_name.contains(s)
+	return p.file_path.contains(s)
 }
 
 fn (mut p Parser) prefix_expr() ast.Expr {

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -529,7 +529,7 @@ run them via `v file.v` instead',
 			//
 			no_body: no_body
 			mod: p.mod
-			file: p.file_name
+			file: p.file_path
 			pos: start_pos
 			language: language
 		})
@@ -580,7 +580,7 @@ run them via `v file.v` instead',
 			//
 			no_body: no_body
 			mod: p.mod
-			file: p.file_name
+			file: p.file_path
 			pos: start_pos
 			language: language
 		})
@@ -650,7 +650,7 @@ run them via `v file.v` instead',
 		pos: start_pos.extend_with_last_line(end_pos, p.prev_tok.line_nr)
 		name_pos: name_pos
 		body_pos: body_start_pos
-		file: p.file_name
+		file: p.file_path
 		is_builtin: p.builtin_mod || p.mod in util.builtin_module_parts
 		scope: p.scope
 		label_names: p.label_names
@@ -863,7 +863,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			is_anon: true
 			no_body: no_body
 			pos: pos.extend(p.prev_tok.pos())
-			file: p.file_name
+			file: p.file_path
 			scope: p.scope
 			label_names: label_names
 		}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -25,7 +25,6 @@ pub struct Parser {
 mut:
 	file_base         string       // "hello.v"
 	file_path         string       // "/home/user/hello.v"
-	file_dir_path     string       // "/home/user"
 	file_display_path string       // just "hello.v", when your current folder for the compilation is "/home/user/", otherwise the full path "/home/user/hello.v"
 	unique_prefix     string       // a hash of p.file_path, used for making anon fn generation unique
 	file_backend_mode ast.Language // .c for .c.v|.c.vv|.c.vsh files; .js for .js.v files, .amd64/.rv32/other arches for .amd64.v/.rv32.v/etc. files, .v otherwise.
@@ -199,10 +198,9 @@ const normalised_working_folder = (os.real_path(os.getwd()) + os.path_separator)
 pub fn (mut p Parser) set_path(path string) {
 	p.file_path = path
 	p.file_base = os.base(path)
-	p.file_dir_path = os.dir(path)
 	p.file_display_path = os.real_path(p.file_path).replace_once(parser.normalised_working_folder,
 		'').replace('\\', '/')
-	p.inside_vlib_file = p.file_dir_path.contains('vlib')
+	p.inside_vlib_file = os.dir(path).contains('vlib')
 	p.inside_test_file = p.file_base.ends_with('_test.v') || p.file_base.ends_with('_test.vv')
 		|| p.file_base.all_before_last('.v').all_before_last('.').ends_with('_test')
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -24,10 +24,10 @@ pub struct Parser {
 	pref &pref.Preferences = unsafe { nil }
 mut:
 	file_base         string       // "hello.v"
-	file_name         string       // "/home/user/hello.v"
-	file_name_dir     string       // "/home/user"
+	file_path         string       // "/home/user/hello.v"
+	file_dir_path     string       // "/home/user"
 	file_display_path string       // just "hello.v", when your current folder for the compilation is "/home/user/", otherwise the full path "/home/user/hello.v"
-	unique_prefix     string       // a hash of p.file_name, used for making anon fn generation unique
+	unique_prefix     string       // a hash of p.file_path, used for making anon fn generation unique
 	file_backend_mode ast.Language // .c for .c.v|.c.vv|.c.vsh files; .js for .js.v files, .amd64/.rv32/other arches for .amd64.v/.rv32.v/etc. files, .v otherwise.
 	// see comment in parse_file
 	tok                       token.Token
@@ -144,7 +144,7 @@ pub fn parse_comptime(tmpl_path string, text string, mut table ast.Table, pref_ 
 		eprintln('> ${@MOD}.${@FN} text: ${text}')
 	}
 	mut p := Parser{
-		file_name: tmpl_path
+		file_path: tmpl_path
 		scanner: scanner.new_scanner(text, .skip_comments, pref_)
 		table: table
 		pref: pref_
@@ -197,12 +197,12 @@ const normalised_working_folder = (os.real_path(os.getwd()) + os.path_separator)
 	'/')
 
 pub fn (mut p Parser) set_path(path string) {
-	p.file_name = path
+	p.file_path = path
 	p.file_base = os.base(path)
-	p.file_name_dir = os.dir(path)
-	p.file_display_path = os.real_path(p.file_name).replace_once(parser.normalised_working_folder,
+	p.file_dir_path = os.dir(path)
+	p.file_display_path = os.real_path(p.file_path).replace_once(parser.normalised_working_folder,
 		'').replace('\\', '/')
-	p.inside_vlib_file = p.file_name_dir.contains('vlib')
+	p.inside_vlib_file = p.file_dir_path.contains('vlib')
 	p.inside_test_file = p.file_base.ends_with('_test.v') || p.file_base.ends_with('_test.vv')
 		|| p.file_base.all_before_last('.v').all_before_last('.').ends_with('_test')
 
@@ -367,12 +367,12 @@ pub fn (mut p Parser) parse() &ast.File {
 	// codegen
 	if p.codegen_text.len > 0 && !p.pref.is_fmt {
 		ptext := 'module ' + p.mod.all_after_last('.') + '\n' + p.codegen_text
-		codegen_files << parse_text(ptext, p.file_name, mut p.table, p.scanner.comments_mode,
+		codegen_files << parse_text(ptext, p.file_path, mut p.table, p.scanner.comments_mode,
 			p.pref)
 	}
 
 	return &ast.File{
-		path: p.file_name
+		path: p.file_path
 		path_base: p.file_base
 		is_test: p.inside_test_file
 		is_generated: p.is_generated
@@ -712,7 +712,7 @@ fn (mut p Parser) check_name() string {
 
 @[if trace_parser ?]
 fn (p &Parser) trace_parser(label string) {
-	eprintln('parsing: ${p.file_name:-30}|tok.pos: ${p.tok.pos().line_str():-39}|tok.kind: ${p.tok.kind:-10}|tok.lit: ${p.tok.lit:-10}|${label}')
+	eprintln('parsing: ${p.file_path:-30}|tok.pos: ${p.tok.pos().line_str():-39}|tok.kind: ${p.tok.kind:-10}|tok.lit: ${p.tok.lit:-10}|${label}')
 }
 
 fn (mut p Parser) top_stmt() ast.Stmt {
@@ -882,7 +882,7 @@ fn (mut p Parser) other_stmts(cur_stmt ast.Stmt) ast.Stmt {
 			mod: 'main'
 			is_main: true
 			stmts: stmts
-			file: p.file_name
+			file: p.file_path
 			return_type: ast.void_type
 			scope: p.scope
 			label_names: p.label_names
@@ -2062,7 +2062,7 @@ fn (mut p Parser) error_with_pos(s string, pos token.Pos) ast.NodeError {
 	// print_backtrace()
 	mut kind := 'error:'
 	if p.pref.fatal_errors {
-		util.show_compiler_message(kind, pos: pos, file_path: p.file_name, message: s)
+		util.show_compiler_message(kind, pos: pos, file_path: p.file_path, message: s)
 		exit(1)
 	}
 	if p.pref.output_mode == .stdout && !p.pref.check_only {
@@ -2070,11 +2070,11 @@ fn (mut p Parser) error_with_pos(s string, pos token.Pos) ast.NodeError {
 			print_backtrace()
 			kind = 'parser error:'
 		}
-		util.show_compiler_message(kind, pos: pos, file_path: p.file_name, message: s)
+		util.show_compiler_message(kind, pos: pos, file_path: p.file_path, message: s)
 		exit(1)
 	} else {
 		p.errors << errors.Error{
-			file_path: p.file_name
+			file_path: p.file_path
 			pos: pos
 			reporter: .parser
 			message: s
@@ -2139,14 +2139,14 @@ fn (mut p Parser) warn_with_pos(s string, pos token.Pos) {
 		return
 	}
 	if p.pref.output_mode == .stdout && !p.pref.check_only {
-		util.show_compiler_message('warning:', pos: pos, file_path: p.file_name, message: s)
+		util.show_compiler_message('warning:', pos: pos, file_path: p.file_path, message: s)
 	} else {
 		if p.pref.message_limit >= 0 && p.warnings.len >= p.pref.message_limit {
 			p.should_abort = true
 			return
 		}
 		p.warnings << errors.Warning{
-			file_path: p.file_name
+			file_path: p.file_path
 			pos: pos
 			reporter: .parser
 			message: s
@@ -2166,10 +2166,10 @@ fn (mut p Parser) note_with_pos(s string, pos token.Pos) {
 		return
 	}
 	if p.pref.output_mode == .stdout && !p.pref.check_only {
-		util.show_compiler_message('notice:', pos: pos, file_path: p.file_name, message: s)
+		util.show_compiler_message('notice:', pos: pos, file_path: p.file_path, message: s)
 	} else {
 		p.notices << errors.Notice{
-			file_path: p.file_name
+			file_path: p.file_path
 			pos: pos
 			reporter: .parser
 			message: s
@@ -3658,7 +3658,7 @@ fn (mut p Parser) module_decl() ast.Module {
 		}
 		module_pos = attrs_pos.extend(name_pos)
 	}
-	full_name := util.qualify_module(p.pref, name, p.file_name)
+	full_name := util.qualify_module(p.pref, name, p.file_path)
 	p.mod = full_name
 	p.builtin_mod = p.mod == 'builtin'
 	mod_node = ast.Module{
@@ -3758,7 +3758,7 @@ fn (mut p Parser) import_stmt() ast.Import {
 			pos: import_pos.extend(pos)
 			mod_pos: pos
 			alias_pos: submod_pos
-			mod: util.qualify_import(p.pref, source_name, p.file_name)
+			mod: util.qualify_import(p.pref, source_name, p.file_path)
 			alias: mod_alias
 		}
 	}
@@ -3768,7 +3768,7 @@ fn (mut p Parser) import_stmt() ast.Import {
 			pos: import_node.pos
 			mod_pos: import_node.mod_pos
 			alias_pos: import_node.alias_pos
-			mod: util.qualify_import(p.pref, mod_name_arr[0], p.file_name)
+			mod: util.qualify_import(p.pref, mod_name_arr[0], p.file_path)
 			alias: mod_alias
 		}
 	}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -670,7 +670,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				short_name: name
 				mod: p.mod
 				params: params
-				file: p.file_name
+				file: p.file_path
 				return_type: ast.void_type
 				is_variadic: is_variadic
 				is_pub: true


### PR DESCRIPTION
Updates file field names on the parser. Main concern was `file_name` holding the path and same data field is e.g. used on the scanner named `file_path`. Imho simpler to understand during development when reading file_path and understanding assignments to path related fields then doing so with `file_name`.