### PR TITLE
ci: remove `-stats` flag from tests

### DIFF
--- a/.github/workflows/native_backend_tests_ci.yml
+++ b/.github/workflows/native_backend_tests_ci.yml
@@ -78,5 +78,5 @@ jobs:
 
       - name: Run the native backend tests serially with more details
         run: |
-          v -stats vlib/v/gen/native/macho_test.v
-          v -stats vlib/v/gen/native/tests/native_test.v
+          v vlib/v/gen/native/macho_test.v
+          v vlib/v/gen/native/tests/native_test.v

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -146,7 +146,7 @@ jobs:
           echo "Build Go2V"
           v /tmp/go2v/
           echo "Run Go2V tests"
-          VJOBS=1 v -stats test /tmp/go2v/
+          VJOBS=1 v test /tmp/go2v/
 
       - name: Install UI through VPM and make sure its examples compile
         run: |
@@ -171,7 +171,7 @@ jobs:
           echo "Build msgpack"
           v -shared ~/.vmodules/msgpack/
           echo "Run msgpack tests"
-          v -stats test ~/.vmodules/msgpack/
+          v test ~/.vmodules/msgpack/
           echo "MessagePack examples should compile"
           v should-compile-all ~/.vmodules/msgpack/examples
 

--- a/.github/workflows/wasm_backend_tests_ci.yml
+++ b/.github/workflows/wasm_backend_tests_ci.yml
@@ -64,7 +64,7 @@ jobs:
           sudo ln -s ~/.wasmer/bin/wasmer /usr/local/bin
 
       - name: Test the WASM backend
-        run: ./v -stats test vlib/v/gen/wasm/tests/
+        run: ./v test vlib/v/gen/wasm/tests/
 
 
   wasm-backend-macos:
@@ -86,7 +86,7 @@ jobs:
           sudo ln -s ~/.wasmer/bin/wasmer /usr/local/bin
 
       - name: Test the WASM backend
-        run: ./v -stats test vlib/v/gen/wasm/tests/
+        run: ./v test vlib/v/gen/wasm/tests/
 
 #  wasm-backend-windows:
 #    runs-on: windows-2022


### PR DESCRIPTION
Prevents false positives in regards to the current problems with the `-stats` flag