### PR TITLE
vlib: add missing docstrings for vlib/v/ast/comptime_const_values.v  functions

### DIFF
--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -23,7 +23,7 @@ pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
 }
 
-// i8 tries to return a `ComptimeConstValue` as `i8` type
+// i8 tries to return a `CompTimeConstValue` as `i8` type
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?
 	if x > -129 && x < 128 {

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -18,10 +18,12 @@ pub type ComptTimeConstValue = EmptyExpr
 
 //| int
 
+// empty_comptime_const_expr return a EmptyExpr 
 pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
 }
 
+// i8 returns `i8` int if `val` in range else none
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?
 	if x > -129 && x < 128 {
@@ -30,6 +32,7 @@ pub fn (val ComptTimeConstValue) i8() ?i8 {
 	return none
 }
 
+// i16 returns `i16` int if `val` in range else none
 pub fn (val ComptTimeConstValue) i16() ?i16 {
 	x := val.i64()?
 	if x > -32769 && x < 32768 {
@@ -38,6 +41,7 @@ pub fn (val ComptTimeConstValue) i16() ?i16 {
 	return none
 }
 
+// int returns `int(i32)` if `val` in range else none
 pub fn (val ComptTimeConstValue) int() ?int {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -46,6 +50,7 @@ pub fn (val ComptTimeConstValue) int() ?int {
 	return none
 }
 
+// i32 returns `i32` int if `val` in range else none
 pub fn (val ComptTimeConstValue) i32() ?i32 {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -54,6 +59,7 @@ pub fn (val ComptTimeConstValue) i32() ?i32 {
 	return none
 }
 
+// voidptr returns a voidptr if is `val` a valid type else none
 pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	match val {
 		i8, i16, i32, i64, int { return voidptr(i64(val)) }
@@ -65,6 +71,7 @@ pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	return none
 }
 
+// i64 returns a i64 int if val is a int else none
 pub fn (val ComptTimeConstValue) i64() ?i64 {
 	match val {
 		i8 {
@@ -119,6 +126,7 @@ pub fn (val ComptTimeConstValue) i64() ?i64 {
 	return none
 }
 
+// u8 returns `u8` int if val in range else none
 pub fn (val ComptTimeConstValue) u8() ?u8 {
 	x := val.u64()?
 	if x < 256 {
@@ -127,6 +135,7 @@ pub fn (val ComptTimeConstValue) u8() ?u8 {
 	return none
 }
 
+// u16 returns `u16` int if val in range else none
 pub fn (val ComptTimeConstValue) u16() ?u16 {
 	x := val.u64()?
 	if x < 65536 {
@@ -135,6 +144,7 @@ pub fn (val ComptTimeConstValue) u16() ?u16 {
 	return none
 }
 
+// u32 returns `u32` int if val in range else none
 pub fn (val ComptTimeConstValue) u32() ?u32 {
 	x := val.u64()?
 	if x < 4294967296 {
@@ -143,6 +153,7 @@ pub fn (val ComptTimeConstValue) u32() ?u32 {
 	return none
 }
 
+// u64 returns `u64` int if val is a number >= 0 else none
 pub fn (val ComptTimeConstValue) u64() ?u64 {
 	match val {
 		i8 {
@@ -204,11 +215,13 @@ pub fn (val ComptTimeConstValue) u64() ?u64 {
 	return none
 }
 
+// f32 returns a `f32` number else none
 pub fn (val ComptTimeConstValue) f32() ?f32 {
 	x := val.f64()?
 	return f32(x)
 }
 
+// f64 returns a `f64` number else none
 pub fn (val ComptTimeConstValue) f64() ?f64 {
 	match val {
 		i8 {

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -18,12 +18,12 @@ pub type ComptTimeConstValue = EmptyExpr
 
 //| int
 
-// empty_comptime_const_expr return an EmptyExpr 
+// empty_comptime_const_expr return an EmptyExpr.
 pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
 }
 
-// i8 tries to return a `ComptTimeConstValue` as `i8` type
+// i8 tries to return a `ComptTimeConstValue` as `i8` type.
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?
 	if x > -129 && x < 128 {
@@ -32,7 +32,7 @@ pub fn (val ComptTimeConstValue) i8() ?i8 {
 	return none
 }
 
-// i16 tries to return a `CompTimeConstValue` as `i16` type 
+// i16 tries to return a `ComptTimeConstValue` as `i16` type.
 pub fn (val ComptTimeConstValue) i16() ?i16 {
 	x := val.i64()?
 	if x > -32769 && x < 32768 {
@@ -41,7 +41,7 @@ pub fn (val ComptTimeConstValue) i16() ?i16 {
 	return none
 }
 
-// int tries to return a `CompTimeConstValue` as `int` type
+// int tries to return a `ComptTimeConstValue` as `int` type.
 pub fn (val ComptTimeConstValue) int() ?int {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -50,7 +50,7 @@ pub fn (val ComptTimeConstValue) int() ?int {
 	return none
 }
 
-// i32 tries to return a `CompTimeConstValue` as `i32` type
+// i32 tries to return a `ComptTimeConstValue` as `i32` type.
 pub fn (val ComptTimeConstValue) i32() ?i32 {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -59,7 +59,7 @@ pub fn (val ComptTimeConstValue) i32() ?i32 {
 	return none
 }
 
-// voidptr tries to return a `CompTimeConstValue` as `voidptr` type
+// voidptr tries to return a `ComptTimeConstValue` as `voidptr` type.
 pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	match val {
 		i8, i16, i32, i64, int { return voidptr(i64(val)) }
@@ -71,7 +71,7 @@ pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	return none
 }
 
-// i64 tries to return a `CompTimeConstValue` as i64 type
+// i64 tries to return a `ComptTimeConstValue` as i64 type.
 pub fn (val ComptTimeConstValue) i64() ?i64 {
 	match val {
 		i8 {
@@ -126,7 +126,7 @@ pub fn (val ComptTimeConstValue) i64() ?i64 {
 	return none
 }
 
-// u8 tries to return a `CompTimeConstValue` as `u8` type
+// u8 tries to return a `ComptTimeConstValue` as `u8` type.
 pub fn (val ComptTimeConstValue) u8() ?u8 {
 	x := val.u64()?
 	if x < 256 {
@@ -135,7 +135,7 @@ pub fn (val ComptTimeConstValue) u8() ?u8 {
 	return none
 }
 
-// u16 tries to return a `CompTimeConstValue` as `u16` type
+// u16 tries to return a `ComptTimeConstValue` as `u16` type.
 pub fn (val ComptTimeConstValue) u16() ?u16 {
 	x := val.u64()?
 	if x < 65536 {
@@ -144,7 +144,7 @@ pub fn (val ComptTimeConstValue) u16() ?u16 {
 	return none
 }
 
-// u32 tries to return a `CompTimeConstValue` as `u32` type
+// u32 tries to return a `ComptTimeConstValue` as `u32` type.
 pub fn (val ComptTimeConstValue) u32() ?u32 {
 	x := val.u64()?
 	if x < 4294967296 {
@@ -153,7 +153,7 @@ pub fn (val ComptTimeConstValue) u32() ?u32 {
 	return none
 }
 
-// u64 tries to return a `CompTimeConstValue` as `u64` type
+// u64 tries to return a `ComptTimeConstValue` as `u64` type.
 pub fn (val ComptTimeConstValue) u64() ?u64 {
 	match val {
 		i8 {
@@ -215,13 +215,13 @@ pub fn (val ComptTimeConstValue) u64() ?u64 {
 	return none
 }
 
-// f32 tries to return a `CompTimeConstValue` as `f32` type
+// f32 tries to return a `ComptTimeConstValue` as `f32` type.
 pub fn (val ComptTimeConstValue) f32() ?f32 {
 	x := val.f64()?
 	return f32(x)
 }
 
-// f64 tries to return a `CompTimeConstValue` as `f64` type
+// f64 tries to return a `ComptTimeConstValue` as `f64` type.
 pub fn (val ComptTimeConstValue) f64() ?f64 {
 	match val {
 		i8 {
@@ -267,7 +267,7 @@ pub fn (val ComptTimeConstValue) f64() ?f64 {
 	return none
 }
 
-// string tries to return a `CompTimeConstValue` as `string` type
+// string tries to return a `ComptTimeConstValue` as `string` type.
 pub fn (val ComptTimeConstValue) string() ?string {
 	match val {
 		i8 {

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -23,7 +23,7 @@ pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
 }
 
-// i8 tries to return a `CompTimeConstValue` as `i8` type
+// i8 tries to return a `ComptTimeConstValue` as `i8` type
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?
 	if x > -129 && x < 128 {

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -18,12 +18,12 @@ pub type ComptTimeConstValue = EmptyExpr
 
 //| int
 
-// empty_comptime_const_expr return a EmptyExpr 
+// empty_comptime_const_expr return an EmptyExpr 
 pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
 }
 
-// i8 returns `i8` int if `val` in range else none
+// i8 tries to return a `ComptimeConstValue` as `i8` type
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?
 	if x > -129 && x < 128 {
@@ -32,7 +32,7 @@ pub fn (val ComptTimeConstValue) i8() ?i8 {
 	return none
 }
 
-// i16 returns `i16` int if `val` in range else none
+// i16 tries to return a `ComptimeConstValue` as `i16` type 
 pub fn (val ComptTimeConstValue) i16() ?i16 {
 	x := val.i64()?
 	if x > -32769 && x < 32768 {
@@ -41,7 +41,7 @@ pub fn (val ComptTimeConstValue) i16() ?i16 {
 	return none
 }
 
-// int returns `int(i32)` if `val` in range else none
+// int tries to return a `ComptimeConstValue` as `int` type
 pub fn (val ComptTimeConstValue) int() ?int {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -50,7 +50,7 @@ pub fn (val ComptTimeConstValue) int() ?int {
 	return none
 }
 
-// i32 returns `i32` int if `val` in range else none
+// i32 tries to return a `ComptimeConstValue` as `i32` type
 pub fn (val ComptTimeConstValue) i32() ?i32 {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -59,7 +59,7 @@ pub fn (val ComptTimeConstValue) i32() ?i32 {
 	return none
 }
 
-// voidptr returns a voidptr if is `val` a valid type else none
+// voidptr tries to return a `ComptimeConstValue` as `voidptr` type
 pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	match val {
 		i8, i16, i32, i64, int { return voidptr(i64(val)) }
@@ -71,7 +71,7 @@ pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	return none
 }
 
-// i64 returns a i64 int if val is a int else none
+// i64 tries to return a `ComptimeConstValue` as i64 type
 pub fn (val ComptTimeConstValue) i64() ?i64 {
 	match val {
 		i8 {
@@ -126,7 +126,7 @@ pub fn (val ComptTimeConstValue) i64() ?i64 {
 	return none
 }
 
-// u8 returns `u8` int if val in range else none
+// u8 tries to return a `ComptimeConstValue` as `u8` type
 pub fn (val ComptTimeConstValue) u8() ?u8 {
 	x := val.u64()?
 	if x < 256 {
@@ -135,7 +135,7 @@ pub fn (val ComptTimeConstValue) u8() ?u8 {
 	return none
 }
 
-// u16 returns `u16` int if val in range else none
+// u16 tries to return a `ComptimeConstValue` as `u16` type
 pub fn (val ComptTimeConstValue) u16() ?u16 {
 	x := val.u64()?
 	if x < 65536 {
@@ -144,7 +144,7 @@ pub fn (val ComptTimeConstValue) u16() ?u16 {
 	return none
 }
 
-// u32 returns `u32` int if val in range else none
+// u32 tries to return a `ComptimeConstValue` as `u32` type
 pub fn (val ComptTimeConstValue) u32() ?u32 {
 	x := val.u64()?
 	if x < 4294967296 {
@@ -153,7 +153,7 @@ pub fn (val ComptTimeConstValue) u32() ?u32 {
 	return none
 }
 
-// u64 returns `u64` int if val is a number >= 0 else none
+// u64 tries to return a `ComptimeConstValue` as `u64` type
 pub fn (val ComptTimeConstValue) u64() ?u64 {
 	match val {
 		i8 {
@@ -215,13 +215,13 @@ pub fn (val ComptTimeConstValue) u64() ?u64 {
 	return none
 }
 
-// f32 returns a `f32` number else none
+// f32 tries to return a `ComptimeConstValue` as `f32` type
 pub fn (val ComptTimeConstValue) f32() ?f32 {
 	x := val.f64()?
 	return f32(x)
 }
 
-// f64 returns a `f64` number else none
+// f64 tries to return a `ComptimeConstValue` as `f64` type
 pub fn (val ComptTimeConstValue) f64() ?f64 {
 	match val {
 		i8 {
@@ -267,6 +267,7 @@ pub fn (val ComptTimeConstValue) f64() ?f64 {
 	return none
 }
 
+// string tries to return a `ComptimeConstValue` as `string` type
 pub fn (val ComptTimeConstValue) string() ?string {
 	match val {
 		i8 {

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -23,7 +23,7 @@ pub fn empty_comptime_const_expr() ComptTimeConstValue {
 	return EmptyExpr(0)
 }
 
-// i8 tries to return a `ComptimeConstValue` as `i8` type
+// i8 tries to return a `CompTimeConstValue` as `i8` type
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?
 	if x > -129 && x < 128 {
@@ -32,7 +32,7 @@ pub fn (val ComptTimeConstValue) i8() ?i8 {
 	return none
 }
 
-// i16 tries to return a `ComptimeConstValue` as `i16` type 
+// i16 tries to return a `CompTimeConstValue` as `i16` type 
 pub fn (val ComptTimeConstValue) i16() ?i16 {
 	x := val.i64()?
 	if x > -32769 && x < 32768 {
@@ -41,7 +41,7 @@ pub fn (val ComptTimeConstValue) i16() ?i16 {
 	return none
 }
 
-// int tries to return a `ComptimeConstValue` as `int` type
+// int tries to return a `CompTimeConstValue` as `int` type
 pub fn (val ComptTimeConstValue) int() ?int {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -50,7 +50,7 @@ pub fn (val ComptTimeConstValue) int() ?int {
 	return none
 }
 
-// i32 tries to return a `ComptimeConstValue` as `i32` type
+// i32 tries to return a `CompTimeConstValue` as `i32` type
 pub fn (val ComptTimeConstValue) i32() ?i32 {
 	x := val.i64()?
 	if x > -2147483649 && x < 2147483648 {
@@ -59,7 +59,7 @@ pub fn (val ComptTimeConstValue) i32() ?i32 {
 	return none
 }
 
-// voidptr tries to return a `ComptimeConstValue` as `voidptr` type
+// voidptr tries to return a `CompTimeConstValue` as `voidptr` type
 pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	match val {
 		i8, i16, i32, i64, int { return voidptr(i64(val)) }
@@ -71,7 +71,7 @@ pub fn (val ComptTimeConstValue) voidptr() ?voidptr {
 	return none
 }
 
-// i64 tries to return a `ComptimeConstValue` as i64 type
+// i64 tries to return a `CompTimeConstValue` as i64 type
 pub fn (val ComptTimeConstValue) i64() ?i64 {
 	match val {
 		i8 {
@@ -126,7 +126,7 @@ pub fn (val ComptTimeConstValue) i64() ?i64 {
 	return none
 }
 
-// u8 tries to return a `ComptimeConstValue` as `u8` type
+// u8 tries to return a `CompTimeConstValue` as `u8` type
 pub fn (val ComptTimeConstValue) u8() ?u8 {
 	x := val.u64()?
 	if x < 256 {
@@ -135,7 +135,7 @@ pub fn (val ComptTimeConstValue) u8() ?u8 {
 	return none
 }
 
-// u16 tries to return a `ComptimeConstValue` as `u16` type
+// u16 tries to return a `CompTimeConstValue` as `u16` type
 pub fn (val ComptTimeConstValue) u16() ?u16 {
 	x := val.u64()?
 	if x < 65536 {
@@ -144,7 +144,7 @@ pub fn (val ComptTimeConstValue) u16() ?u16 {
 	return none
 }
 
-// u32 tries to return a `ComptimeConstValue` as `u32` type
+// u32 tries to return a `CompTimeConstValue` as `u32` type
 pub fn (val ComptTimeConstValue) u32() ?u32 {
 	x := val.u64()?
 	if x < 4294967296 {
@@ -153,7 +153,7 @@ pub fn (val ComptTimeConstValue) u32() ?u32 {
 	return none
 }
 
-// u64 tries to return a `ComptimeConstValue` as `u64` type
+// u64 tries to return a `CompTimeConstValue` as `u64` type
 pub fn (val ComptTimeConstValue) u64() ?u64 {
 	match val {
 		i8 {
@@ -215,13 +215,13 @@ pub fn (val ComptTimeConstValue) u64() ?u64 {
 	return none
 }
 
-// f32 tries to return a `ComptimeConstValue` as `f32` type
+// f32 tries to return a `CompTimeConstValue` as `f32` type
 pub fn (val ComptTimeConstValue) f32() ?f32 {
 	x := val.f64()?
 	return f32(x)
 }
 
-// f64 tries to return a `ComptimeConstValue` as `f64` type
+// f64 tries to return a `CompTimeConstValue` as `f64` type
 pub fn (val ComptTimeConstValue) f64() ?f64 {
 	match val {
 		i8 {
@@ -267,7 +267,7 @@ pub fn (val ComptTimeConstValue) f64() ?f64 {
 	return none
 }
 
-// string tries to return a `ComptimeConstValue` as `string` type
+// string tries to return a `CompTimeConstValue` as `string` type
 pub fn (val ComptTimeConstValue) string() ?string {
 	match val {
 		i8 {

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -433,6 +433,7 @@ fn (ts TypeSymbol) dbg_common(mut res []string) {
 	res << 'language: ${ts.language}'
 }
 
+// str returns the ast in string form
 pub fn (t Type) str() string {
 	return 'ast.Type(0x${t.hex()} = ${u32(t)})'
 }
@@ -717,7 +718,7 @@ pub fn mktyp(typ Type) Type {
 	}
 }
 
-// returns TypeSymbol kind only if there are no type modifiers
+// type_kind returns TypeSymbol kind only if there are no type modifiers
 pub fn (t &Table) type_kind(typ Type) Kind {
 	if typ.nr_muls() > 0 || typ.has_option_or_result() {
 		return Kind.placeholder
@@ -1008,6 +1009,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	t.register_sym(kind: .interface_, name: 'IError', cname: 'IError', mod: 'builtin') // 30
 	t.register_sym(kind: .voidptr, name: 'nil', cname: 'voidptr', mod: 'builtin') // 31
 }
+
 
 @[inline]
 pub fn (t &TypeSymbol) is_pointer() bool {

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -433,7 +433,7 @@ fn (ts TypeSymbol) dbg_common(mut res []string) {
 	res << 'language: ${ts.language}'
 }
 
-// str returns the ast in string form
+// str returns a string representation of the type.
 pub fn (t Type) str() string {
 	return 'ast.Type(0x${t.hex()} = ${u32(t)})'
 }
@@ -718,7 +718,7 @@ pub fn mktyp(typ Type) Type {
 	}
 }
 
-// type_kind returns TypeSymbol kind only if there are no type modifiers
+// type_kind returns the kind of the given type symbol.
 pub fn (t &Table) type_kind(typ Type) Kind {
 	if typ.nr_muls() > 0 || typ.has_option_or_result() {
 		return Kind.placeholder
@@ -1010,7 +1010,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	t.register_sym(kind: .voidptr, name: 'nil', cname: 'voidptr', mod: 'builtin') // 31
 }
 
-
+t
 @[inline]
 pub fn (t &TypeSymbol) is_pointer() bool {
 	return t.kind in [.byteptr, .charptr, .voidptr]

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1010,7 +1010,6 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	t.register_sym(kind: .voidptr, name: 'nil', cname: 'voidptr', mod: 'builtin') // 31
 }
 
-t
 @[inline]
 pub fn (t &TypeSymbol) is_pointer() bool {
 	return t.kind in [.byteptr, .charptr, .voidptr]


### PR DESCRIPTION
Part of #7047 