### PR TITLE
vdoc: fix character escape in code blocks in readme contents

### DIFF
--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -2,6 +2,7 @@ module main
 
 import os
 import net.urllib
+import encoding.html
 import strings
 import markdown
 import v.scanner
@@ -631,7 +632,7 @@ fn (f &MdHtmlCodeHighlighter) transform_content(parent markdown.ParentType, text
 		text)
 	if parent is markdown.MD_BLOCKTYPE && parent == .md_block_code {
 		if f.language == 'v' || f.language == 'vlang' {
-			return html_highlight(initial_transformed_text, f.table)
+			return html_highlight(html.unescape(initial_transformed_text), f.table)
 		}
 	}
 	return initial_transformed_text

--- a/cmd/tools/vdoc/tests/testdata/output_formats/README.md
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/README.md
@@ -20,6 +20,14 @@ fn main() {
 	dump(os.args)
 	dump(os.args.len)
 	assert os.args.len > 0
+
+	// Test escape characters like for `&` and `<`
+	mut arr := [1, 2, 3]
+	mut ref := &arr
+	arr << 4
+
+	ch := chan bool{cap: 1}
+	ch <- true
 }
 ```
 

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.ansi
@@ -12,6 +12,14 @@ fn main() {
     dump(os.args)
     dump(os.args.len)
     assert os.args.len > 0
+
+    // Test escape characters like for `&` and `<`
+    mut arr := [1, 2, 3]
+    mut ref := &arr
+    arr << 4
+
+    ch := chan bool{cap: 1}
+    ch <- true
 }
 
 A JWT example (test syntax highlighting)
@@ -81,6 +89,14 @@ fn auth_verify(secret string, token string) bool {
     dump(os.args)
     dump(os.args.len)
     assert os.args.len > 0
+    
+    // Test escape characters like for `&` and `<`
+    mut arr := [1, 2, 3]
+    mut ref := &arr
+    arr << 4
+    
+    ch := chan bool{cap: 1}
+    ch <- true
     }
     ```
     

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.html
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.html
@@ -5,7 +5,15 @@
 <span class="token keyword">fn</span> <span class="token function">main</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
     <span class="token keyword">dump</span><span class="token punctuation">(</span>os<span class="token punctuation">.</span>args<span class="token punctuation">)</span>
     <span class="token keyword">dump</span><span class="token punctuation">(</span>os<span class="token punctuation">.</span>args<span class="token punctuation">.</span>len<span class="token punctuation">)</span>
-    <span class="token keyword">assert</span> os<span class="token punctuation">.</span>args<span class="token punctuation">.</span>len <span class="token operator">&</span>gt<span class="token punctuation">;</span> <span class="token number">0</span>
+    <span class="token keyword">assert</span> os<span class="token punctuation">.</span>args<span class="token punctuation">.</span>len <span class="token operator">></span> <span class="token number">0</span>
+
+    <span class="token comment">// Test escape characters like for `&` and `<`</span>
+    <span class="token keyword">mut</span> arr <span class="token operator">:=</span> <span class="token punctuation">[</span><span class="token number">1</span><span class="token punctuation">,</span> <span class="token number">2</span><span class="token punctuation">,</span> <span class="token number">3</span><span class="token punctuation">]</span>
+    <span class="token keyword">mut</span> ref <span class="token operator">:=</span> <span class="token operator">&</span>arr
+    arr <span class="token operator"><<</span> <span class="token number">4</span>
+
+    ch <span class="token operator">:=</span> <span class="token builtin">chan</span> <span class="token builtin">bool</span><span class="token punctuation">{</span>cap<span class="token punctuation">:</span> <span class="token number">1</span><span class="token punctuation">}</span>
+    ch <span class="token operator"><-</span> <span class="token boolean">true</span>
 <span class="token punctuation">}</span></code></pre><h3>A JWT example (test syntax highlighting)</h3><pre><code class="language-v"><span class="token keyword">import</span> crypto<span class="token punctuation">.</span>hmac
 <span class="token keyword">import</span> crypto<span class="token punctuation">.</span>sha256
 <span class="token keyword">import</span> encoding<span class="token punctuation">.</span>base64

--- a/cmd/tools/vdoc/tests/testdata/output_formats/main.text
+++ b/cmd/tools/vdoc/tests/testdata/output_formats/main.text
@@ -20,6 +20,14 @@ module main
     dump(os.args)
     dump(os.args.len)
     assert os.args.len > 0
+    
+    // Test escape characters like for `&` and `<`
+    mut arr := [1, 2, 3]
+    mut ref := &arr
+    arr << 4
+    
+    ch := chan bool{cap: 1}
+    ch <- true
     }
     ```
     


### PR DESCRIPTION
Fixes #21222

Issue in current test:
![Screenshot_20240409_001957](https://github.com/vlang/v/assets/34311583/1abbfb0f-1b50-4fab-b251-30a28421f940)

Updated:
![Screenshot_20240409_002003](https://github.com/vlang/v/assets/34311583/1c6b569a-31eb-4bd2-8baa-f180a1e1383c)
![Screenshot_20240409_002750](https://github.com/vlang/v/assets/34311583/5fd49b1c-d395-4dcc-9b0a-cb85bcea482f)

