### PR TITLE
cgen, checker: allow `none` as arg to `?&type`

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -228,6 +228,7 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 		if expected.has_flag(.option) {
 			got_is_ptr := got.is_ptr()
 				|| (arg.expr is ast.Ident && (arg.expr as ast.Ident).is_mut())
+				|| arg.expr is ast.None
 			if (expected.is_ptr() && !got_is_ptr) || (!expected.is_ptr() && got.is_ptr()) {
 				got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
 				return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2552,6 +2552,9 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 					}
 					if atype.has_flag(.generic) || arg.expr is ast.StructInit {
 						g.write('(voidptr)&/*qq*/')
+					} else if arg.expr is ast.None {
+						g.expr_with_opt(arg.expr, arg_typ, expected_type)
+						return
 					} else {
 						needs_closing = true
 						if arg_typ_sym.kind in [.sum_type, .interface_] {

--- a/vlib/v/tests/option_ptr_arg_none_test.v
+++ b/vlib/v/tests/option_ptr_arg_none_test.v
@@ -1,0 +1,12 @@
+fn takes_optional_pointer(maybe_ptr ?&int) int {
+	if ptr := maybe_ptr {
+		return *ptr
+	} else {
+		return 0
+	}
+}
+
+fn test_main() {
+	val := takes_optional_pointer(none)
+	assert val == 0
+}


### PR DESCRIPTION
Fix #21213