### PR TITLE
vdoc: fix indention of readme when generating docs with `-readme` in project root

### DIFF
--- a/cmd/tools/vdoc/utils.v
+++ b/cmd/tools/vdoc/utils.v
@@ -30,7 +30,7 @@ fn get_node_id(dn doc.DocNode) string {
 }
 
 fn is_module_readme(dn doc.DocNode) bool {
-	return dn.comments.len > 0 && dn.content == 'module ${dn.name}'
+	return dn.comments.len > 0 && (dn.content == 'module ${dn.name}' || dn.name == 'README')
 }
 
 fn trim_doc_node_description(desc string) string {


### PR DESCRIPTION
The change extends a conditional check so that readme files in the project root are correctly recognized as readme allowing them to be included in the recent fix regarding indentation.

When having run a command like `v doc -m -f html -readme .` 
 the current readme in `_docs/index.html` is rendered like:

![Screenshot_20240409_011957](https://github.com/vlang/v/assets/34311583/0a29a0e8-5279-4ab4-8a91-b84fac6890e9)
  
As part of the module the readme is working `_docs/module_name.html`

![Screenshot_20240409_012010](https://github.com/vlang/v/assets/34311583/6d45fad8-237d-45a7-aa86-f157527e803d)

