### PR TITLE
vdoc: don't add additional _docs directory when an out path is specified

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -371,7 +371,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			out.path = os.real_path('.')
 		}
 		if cfg.is_multi {
-			out.path = os.join_path(out.path, '_docs')
+			out.path = if out.path == '.' { '_docs' } else { out.path }
 			if !os.exists(out.path) {
 				os.mkdir(out.path) or { panic(err) }
 			} else {


### PR DESCRIPTION
Running a command that specifies an output path for the documentation like `v doc -m -f html -o docs .` currently creates a `docs/_docs` directory. The change removes adding the additional directory and uses the output path as final directory for the document files. This is likely the more expected result and the behavior that is easier to work with.