### PR TITLE
v.util: improve find_diff_cmd: don't add spaces to result without env opts

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -40,8 +40,8 @@ pub fn find_working_diff_command() !string {
 				}
 			}
 			if diffcmd in ['code', 'code.cmd'] {
-				cmd := '${diffcmd} ${if env_diffopts != '' { env_diffopts } else { '-d' }}'
-				return cmd
+				// Make sure the diff flag `-d` is included in any case.
+				return '${diffcmd} ${env_diffopts} -d'
 			}
 			// Don't add spaces to the cmd if there are no `env_diffopts`.
 			return if env_diffopts != '' { '${diffcmd} ${env_diffopts}' } else { diffcmd }

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -40,11 +40,11 @@ pub fn find_working_diff_command() !string {
 				}
 			}
 			if diffcmd in ['code', 'code.cmd'] {
-				// there is no guarantee that the env opts exist
-				// or include `-d`, so (harmlessly) add it
-				return '${diffcmd} ${env_diffopts} -d'
+				cmd := '${diffcmd} ${if env_diffopts != '' { env_diffopts } else { '-d' }}'
+				return cmd
 			}
-			return '${diffcmd} ${env_diffopts}'
+			// Don't add spaces to the cmd if there are no `env_diffopts`.
+			return if env_diffopts != '' { '${diffcmd} ${env_diffopts}' } else { diffcmd }
 		}
 	}
 	return error('No working "diff" command found')


### PR DESCRIPTION
- Adds test for the diff util module.

- Fixes an issue where `find_working_diff_command()!` adds spaces to the result, potentially making it unavailable to other commands. E.g. `os.find_abs_path_of_executable` would not find the result of the function.

  ```v
  cmd := util.find_working_diff_command()!
  dump(os.find_abs_path_of_executable(cmd)!)
  ```
  
Might even be required to make the changes in #21243 robust.