### PR TITLE
v.util: ensure output of `color_compare_files` is colorized

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -40,6 +40,11 @@ pub fn find_working_diff_command() !string {
 			return error('could not find specified VDIFF_TOOL ${diffcmd}')
 		}
 		if p.exit_code == 0 { // success
+			if diffcmd in ['gdiff', 'diff'] {
+				if p.output.contains('GNU diffutils') && env_diffopts == '' {
+					return '${diffcmd} --color=always'
+				}
+			}
 			if diffcmd in ['code', 'code.cmd'] {
 				// there is no guarantee that the env opts exist
 				// or include `-d`, so (harmlessly) add it


### PR DESCRIPTION
Makes the function do what it's name implies. I was really missing this when there is just diff installed and working in the codebase.

|Current|Updated|
|-|-|
| ![Screenshot_20240409_195735](https://github.com/vlang/v/assets/34311583/6dfb628d-c3c9-4c23-bb31-8405755a565e)|![Screenshot_20240409_195741](https://github.com/vlang/v/assets/34311583/d9a2c8f0-d2a4-41f1-8f45-a599187636ab)|

Due to the ansi codes in the output, it will conflict with #21242. Depending on which one is resolved first conflicts in the other will need to be taken care of.

