### PR TITLE
vdoc: fix out path if `-o` is not passed but input has a path, add test

### DIFF
--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -49,12 +49,28 @@ fn test_run_examples_bad() {
 }
 
 fn test_out_path() {
+	// Work around CI issues covering v doc generation for relative input paths in tmp dir.
+	// Instead just generate documentation in the v source dir.
+	if os.getenv('CI') == 'true' {
+		mod := 'coroutines'
+		// Default output path.
+		os.execute_opt('${vexe} doc -f html -m vlib/${mod}')!
+		assert os.exists(os.join_path(vroot, 'vlib', 'coroutines', '_docs', '${mod}.html'))
+
+		// Custom out path (no `_docs` subdir).
+		out_dir := os.join_path(vroot, 'vlib', 'coroutines', 'docs')
+		os.execute_opt('${vexe} doc -f html -m -o ${out_dir} ${mod}')!
+		assert os.exists(os.join_path(out_dir, '${mod}.html'))
+
+		return
+	}
+
 	test_path := os.join_path(os.vtmp_dir(), 'vdoc_test_${rand.ulid()}')
-	os.mkdir_all(test_path) or {}
+	os.mkdir_all(test_path)!
+	os.chdir(test_path)!
 	defer {
 		os.rmdir_all(test_path) or {}
 	}
-	os.chdir(test_path)!
 
 	// Copy a *small* vlib module for the test.
 	mod := 'coroutines'

--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -48,6 +48,28 @@ fn test_run_examples_bad() {
 	assert res.output.contains('Example: assert 5 * 5 == 77'), res.output
 }
 
+fn test_out_path() {
+	test_path := os.join_path(os.vtmp_dir(), 'vdoc_test_${rand.ulid()}')
+	os.mkdir_all(test_path) or {}
+	defer {
+		os.rmdir_all(test_path) or {}
+	}
+	os.chdir(test_path)!
+
+	// Copy a *small* vlib module for the test.
+	mod := 'coroutines'
+	os.cp_all(os.join_path(vroot, 'vlib', mod), os.join_path(test_path, mod), true) or {}
+
+	// Relative input with default output path.
+	os.execute_opt('${vexe} doc -f html -m ${mod}')!
+	assert os.exists(os.join_path(test_path, mod, '_docs', '${mod}.html'))
+
+	// Custom out path (no `_docs` subdir).
+	out_dir := os.join_path(os.vtmp_dir(), 'docs_test')
+	os.execute_opt('${vexe} doc -f html -m -o ${out_dir} ${mod}')!
+	assert os.exists(os.join_path(out_dir, '${mod}.html'))
+}
+
 fn get_main_files_in_dir(dir string) []string {
 	mut mfiles := os.walk_ext(dir, '.v')
 	mfiles.sort()

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -371,7 +371,11 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			out.path = os.real_path('.')
 		}
 		if cfg.is_multi {
-			out.path = if out.path == '.' { '_docs' } else { out.path }
+			out.path = if cfg.input_path == out.path {
+				os.join_path(out.path, '_docs')
+			} else {
+				out.path
+			}
 			if !os.exists(out.path) {
 				os.mkdir(out.path) or { panic(err) }
 			} else {


### PR DESCRIPTION
docs should still land in `<path>/_docs` in such cases. Sorry for the regression