### PR TITLE
v.util: fix diff coloring, add test

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -45,7 +45,7 @@ pub fn find_working_diff_command() !string {
 pub fn color_compare_files(diff_cmd string, path1 string, path2 string) string {
 	cmd := diff_cmd.all_before(' ')
 	os.find_abs_path_of_executable(cmd) or { return 'comparison command: `${cmd}` not found' }
-	mut flags := $if openbsd {
+	flags := $if openbsd {
 		['-d', '-a', '-U', '2']
 	} $else $if freebsd {
 		['--minimal', '--text', '--unified=2']
@@ -53,10 +53,10 @@ pub fn color_compare_files(diff_cmd string, path1 string, path2 string) string {
 		['--minimal', '--text', '--unified=2', '--show-function-line="fn "']
 	}
 	if cmd == 'diff' {
-		color_flag := '--color=always'
-		if !os.execute('${cmd} ${color_flag}').output.contains(color_flag) {
-			// If the flag is unknown, it will be reprinted in the output.
-			flags << color_flag
+		color_diff_cmd := '${diff_cmd} --color=always ${flags.join(' ')} ${os.quoted_path(path1)} ${os.quoted_path(path2)}'
+		color_result := os.execute(color_diff_cmd)
+		if !color_result.output.starts_with('diff: unrecognized option') {
+			return color_result.output.trim_right('\r\n')
 		}
 	}
 	full_cmd := '${diff_cmd} ${flags.join(' ')} ${os.quoted_path(path1)} ${os.quoted_path(path2)}'

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -63,11 +63,22 @@ fn test_compare_files() {
 	assert res.contains("-\tversion: '0.0.0'"), res
 	assert res.contains("+\tversion: '0.1.0'"), res
 	assert res.contains("+\tlicense: 'MIT'"), res
+}
 
-	// Test coloring
-	if !os.execute('diff --color=always').output.contains('--color=always') {
+fn test_coloring() {
+	color_flag := '--color=always'
+	if os.execute('diff ${color_flag}').output.contains(color_flag) {
 		// If the flag is unknown, it will be reprinted in the output.
-		assert res.contains("[31m-\tversion: '0.0.0'[m"), res
-		assert res.contains("[32m+\tversion: '0.1.0'[m"), res
+		eprintln('> skipping test, since `diff` does not support `${color_flag}`')
+		return
 	}
+	f1 := 'abc\n'
+	f2 := 'abcd\n'
+	p1 := os.join_path(tdir, '${@FN}_f1.txt')
+	p2 := os.join_path(tdir, '${@FN}_f2.txt')
+	os.write_file(p1, f1)!
+	os.write_file(p2, f2)!
+	res := diff.color_compare_files('diff', p1, p2)
+	assert res.contains('[31m-abc[m'), res
+	assert res.contains('[32m+abcd[m'), res
 }

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -66,10 +66,8 @@ fn test_compare_files() {
 }
 
 fn test_coloring() {
-	color_flag := '--color=always'
-	if os.execute('diff ${color_flag}').output.contains(color_flag) {
-		// If the flag is unknown, it will be reprinted in the output.
-		eprintln('> skipping test, since `diff` does not support `${color_flag}`')
+	if os.execute('diff --color=always').output.starts_with('diff: unrecognized option') {
+		eprintln('> skipping test, since `diff` does not support --color=always')
 		return
 	}
 	f1 := 'abc\n'
@@ -79,6 +77,7 @@ fn test_coloring() {
 	os.write_file(p1, f1)!
 	os.write_file(p2, f2)!
 	res := diff.color_compare_files('diff', p1, p2)
-	assert res.contains('[31m-abc[m'), res
-	assert res.contains('[32m+abcd[m'), res
+	esc := rune(27)
+	assert res.contains('${esc}[31m-abc${esc}[0m'), res
+	assert res.contains('${esc}[32m+abcd${esc}[0m'), res
 }

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -51,13 +51,14 @@ fn test_compare_files() {
 	assert res.contains("+\tlicense: 'MIT'"), res
 
 	// Test again using `find_working_diff_command()`.
+	os.setenv('VDIFF_TOOL', 'diff', true)
 	res = diff.color_compare_files(diff.find_working_diff_command()!, p1, p2)
 	assert res.contains("-\tversion: '0.0.0'"), res
 	assert res.contains("+\tversion: '0.1.0'"), res
 	assert res.contains("+\tlicense: 'MIT'"), res
 
 	// Test adding a flag via env flag.
-	os.setenv('VDIFF_OPTIONS', '--ignore-case', true)
+	os.setenv('VDIFF_OPTIONS', '--ignore-case', true) // ignored, when VDIFF_TOOL is not explicitly set
 	res = diff.color_compare_files(diff.find_working_diff_command()!, p1, p2)
 	assert !res.contains("+\tname: 'foo'"), res
 	assert res.contains("-\tversion: '0.0.0'"), res

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -78,6 +78,6 @@ fn test_coloring() {
 	os.write_file(p2, f2)!
 	res := diff.color_compare_files('diff', p1, p2)
 	esc := rune(27)
-	assert res.contains('${esc}[31m-abc${esc}[0m'), res
-	assert res.contains('${esc}[32m+abcd${esc}[0m'), res
+	assert res.contains('${esc}[31m-abc${esc}['), res
+	assert res.contains('${esc}[32m+abcd${esc}['), res
 }


### PR DESCRIPTION
The PR should fix coloring when using a system default diff comparison and adds a test if the output actually includes color codes.