### PR TITLE
cgen: fix `myarr [1]C.mytype` fixed array fields, for `pub type C.mytype = voidptr`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6570,9 +6570,6 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 					}
 					len := sym.info.size
 					if len > 0 {
-						if fixed_elem_name.starts_with('C__') {
-							fixed_elem_name = fixed_elem_name[3..]
-						}
 						if elem_sym.info is ast.FnType {
 							pos := g.out.len
 							g.write_fn_ptr_decl(&elem_sym.info, '')

--- a/vlib/v/tests/array_fixed_c_test.v
+++ b/vlib/v/tests/array_fixed_c_test.v
@@ -1,0 +1,9 @@
+type C.ArrFixedCTestType = voidptr
+
+struct WrapperStruct {
+mut:
+	arr_fixed_c_type [1]C.ArrFixedCTestType
+}
+
+fn test_main() {
+}


### PR DESCRIPTION
"C__" was removed for fixed size C. arrays and resulted in unknown type.
Fixed by removing the removal.

Not sure which tests are expected to fail, so please double check.

Cheers,
Anton