### PR TITLE
util/diff: return diff options with the diff command for FreeBSD/OpenBSD

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -23,7 +23,7 @@ pub fn find_working_diff_command() !string {
 		}
 		$if freebsd || openbsd {
 			if diffcmd == 'diff' { // FreeBSD/OpenBSD diff have no `--version` option
-				return '${diffcmd} ${env_diffopts}'
+				return if env_diffopts != '' { '${diffcmd} ${env_diffopts}' } else { diffcmd }
 			}
 		}
 		p := os.execute('${diffcmd} --version')

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -23,7 +23,7 @@ pub fn find_working_diff_command() !string {
 		}
 		$if freebsd || openbsd {
 			if diffcmd == 'diff' { // FreeBSD/OpenBSD diff have no `--version` option
-				return diffcmd
+				return '${diffcmd} ${env_diffopts}'
 			}
 		}
 		p := os.execute('${diffcmd} --version')


### PR DESCRIPTION
When returning the diff command for FreeBSD or OpenBSD, the diff options from the environment were not included as they are for other OS's.

This fixes a broken unit test.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
