### PR TITLE
cgen: fix code generated for `none` passed to generic option casting

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -71,8 +71,12 @@ fn (mut g Gen) expr_opt_with_cast(expr ast.Expr, expr_typ ast.Type, ret_typ ast.
 		styp := g.base_type(ret_typ)
 		decl_styp := g.typ(ret_typ).replace('*', '_ptr')
 		g.writeln('${decl_styp} ${past.tmp_var};')
-		g.write('_option_ok(&(${styp}[]) {')
-
+		is_none := expr is ast.CastExpr && expr.expr is ast.None
+		if is_none {
+			g.write('_option_none(&(${styp}[]) {')
+		} else {
+			g.write('_option_ok(&(${styp}[]) {')
+		}
 		if expr is ast.CastExpr && expr_typ.has_flag(.option) {
 			g.write('*((${g.base_type(expr_typ)}*)')
 			g.expr(expr)

--- a/vlib/v/tests/option_generic_cast_none_test.v
+++ b/vlib/v/tests/option_generic_cast_none_test.v
@@ -1,0 +1,27 @@
+pub type MyFn[T] = fn (mut my_state T)
+
+fn higher_order_fn[T](initial_state T, maybe_callback ?MyFn[T]) State {
+	mut my_state := initial_state
+	if callback := maybe_callback {
+		callback[T](mut my_state)
+		callback[T](mut my_state)
+	}
+	return my_state
+}
+
+pub struct State {
+mut:
+	x int
+}
+
+fn handler(mut my_state State) {
+	my_state.x += 1
+}
+
+fn test_main() {
+	mut state := State{}
+	state = higher_order_fn[State](state, ?MyFn[State](handler))
+	state = higher_order_fn[State](state, ?MyFn[State](none))
+	state = higher_order_fn[State](state, handler)
+	assert state.x == 4
+}


### PR DESCRIPTION
Fix #21215