### PR TITLE
os: format readme, fix markdown inside html

### DIFF
--- a/vlib/os/README.md
+++ b/vlib/os/README.md
@@ -8,16 +8,16 @@ handling processes etc.
 
 ### Security advice related to TOCTOU attacks
 
-A few `os` module functions can lead to the <b>TOCTOU</b> vulnerability if used incorrectly.
-<b>TOCTOU</b> (Time-of-Check-to-Time-of-Use problem) can occur when a file, folder or similar
+A few `os` module functions can lead to the **TOCTOU** vulnerability if used incorrectly.
+**TOCTOU** (Time-of-Check-to-Time-of-Use problem) can occur when a file, folder or similar
 is checked for certain specifications (e.g. read, write permissions) and a change is made
 afterwards.
 In the time between the initial check and the edit, an attacker can then cause damage.
 The following example shows an attack strategy on the left and an improved variant on the right
-so that <b>TOCTOU</b> is no longer possible.
+so that **TOCTOU** is no longer possible.
 
-<b>Example</b>
-<i>Hint</i>: `os.create()` opens a file in write-only mode
+**Example** <br>
+*Hint*: `os.create()` opens a file in write-only mode
 
 <table>
 <tr>
@@ -56,7 +56,7 @@ f.close()
 </tr>
 </table>
 
-<b> Proven affected functions </b></br>
+**Proven affected functions** <br>
 The following functions should be used with care and only when used correctly.
 
 - os.is_readable()

--- a/vlib/os/README.md
+++ b/vlib/os/README.md
@@ -4,19 +4,17 @@
 command line arguments, reading/writing files, listing folders,
 handling processes etc.
 
-* * *
-
+---
 
 ### Security advice related to TOCTOU attacks
 
-A few `os` module functions can lead to the <b>TOCTOU</b> vulnerability if used incorrectly. 
-<b>TOCTOU</b> (Time-of-Check-to-Time-of-Use problem) can occur when a file, folder or similar 
-is checked for certain specifications (e.g. read, write permissions) and a change is made 
-afterwards. 
-In the time between the initial check and the edit, an attacker can then cause damage. 
-The following example shows an attack strategy on the left and an improved variant on the right 
+A few `os` module functions can lead to the <b>TOCTOU</b> vulnerability if used incorrectly.
+<b>TOCTOU</b> (Time-of-Check-to-Time-of-Use problem) can occur when a file, folder or similar
+is checked for certain specifications (e.g. read, write permissions) and a change is made
+afterwards.
+In the time between the initial check and the edit, an attacker can then cause damage.
+The following example shows an attack strategy on the left and an improved variant on the right
 so that <b>TOCTOU</b> is no longer possible.
-
 
 <b>Example</b>
 <i>Hint</i>: `os.create()` opens a file in write-only mode
@@ -39,6 +37,7 @@ if os.is_writable("file") {
     f.close()
 }
 ```
+
 </td>
 <td>
 
@@ -52,6 +51,7 @@ mut f := os.create('path/to/file') or {
 
 f.close()
 ```
+
 </td>
 </tr>
 </table>
@@ -59,7 +59,7 @@ f.close()
 <b> Proven affected functions </b></br>
 The following functions should be used with care and only when used correctly.
 
-* os.is_readable()
-* os.is_writable()
-* os.is_executable()
-* os.is_link()
+- os.is_readable()
+- os.is_writable()
+- os.is_executable()
+- os.is_link()


### PR DESCRIPTION
Auto-formats the os modules readme. Doing so it fixes an issue with markdown inside html tags.
The formatting changes match with what is used for the bigger part other markdown files in the codebase.

Following commonmarks recommended formatting for markdown inside html tags works here as a fix. Stackoverflow answer with link to commonmark example: https://stackoverflow.com/a/29378250

|Current|After formatting|
|-|-|
|![Screenshot_20240415_084810](https://github.com/vlang/v/assets/34311583/6eb5240e-093b-40e9-8c69-d1187be83ee9)|![Screenshot_20240415_084800](https://github.com/vlang/v/assets/34311583/d0453ed8-6854-4b2b-9c41-96f9e16fa0c4)|

<details>

Putting markdown immediately after a tag **never works**(at least as far as I know). It even breaks highlighting in the example below. It **can work** to have a tag immediately after markdown. The latter stopped working for vdoc after the recent fixes regarding indentation and escape characters. The recommended way is to keep a line-break before and after tags. Maybe following recommended commonmark formatting (which is applied by markdown formatters) is good enough as a fix now.

|MD immediatly after opening tag|MD followed by tag|
|-|-|
|![Screenshot_20240415_090704](https://github.com/vlang/v/assets/34311583/df4da984-b5fb-452a-b087-e9ccbc9d222f)|![Screenshot_20240415_090711](https://github.com/vlang/v/assets/34311583/766a1c25-7f47-43f3-9697-155087ffca74)|

</details>