### PR TITLE
tools: fix vpm on macos, when using the bundled git executable

### DIFF
--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -26,7 +26,7 @@ const vcs_info = init_vcs_info() or {
 }
 
 fn init_vcs_info() !map[VCS]VCSInfo {
-	git_installed_raw_ver := os.execute_opt('git --version')!.output.all_after_last(' ').all_before('.windows').trim_space()
+	git_installed_raw_ver := os.execute_opt('git --version')!.output.all_after('git version ').all_before(' ').trim_space()
 	git_installed_ver := semver.from(git_installed_raw_ver)!
 	git_submod_filter_ver := semver.from('2.36.0')!
 	mut git_install_cmd := 'clone --depth=1 --recursive --shallow-submodules --filter=blob:none'

--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -26,7 +26,11 @@ const vcs_info = init_vcs_info() or {
 }
 
 fn init_vcs_info() !map[VCS]VCSInfo {
-	git_installed_raw_ver := os.execute_opt('git --version')!.output.all_after('git version ').all_before(' ').trim_space()
+	// The output from `git version` varies, depending on how git was compiled. Here are some examples:
+	// `git version 2.44.0` when compiled from source, or from brew on macos.
+	// `git version 2.39.3 (Apple Git-146)` on macos with XCode's cli tools.
+	// `git version 2.44.0.windows.1` on windows's Git Bash shell.
+	git_installed_raw_ver := os.execute_opt('git --version')!.output.all_after('git version ').all_before(' ').all_before('.windows').trim_space()
 	git_installed_ver := semver.from(git_installed_raw_ver)!
 	git_submod_filter_ver := semver.from('2.36.0')!
 	mut git_install_cmd := 'clone --depth=1 --recursive --shallow-submodules --filter=blob:none'

--- a/cmd/tools/vpm/vcs_test.v
+++ b/cmd/tools/vpm/vcs_test.v
@@ -1,0 +1,10 @@
+module main
+
+fn test_parse_git_version() {
+	if _ := parse_git_version('abcd') {
+		assert false
+	}
+	assert parse_git_version('git version 2.44.0.windows.1')! == '2.44.0'
+	assert parse_git_version('git version 2.34.0')! == '2.34.0'
+	assert parse_git_version('git version 2.39.3 (Apple Git-146)')! == '2.39.3'
+}


### PR DESCRIPTION
When git is not from brew:
`git --version` reports `git version 2.39.3 (Apple Git-146)`
When git is compiled from source, or is from brew, the reported version is: `git version 2.44.0`.

~~I do not know, when it will have a `.windows` suffix.~~

Edit: On the windows CI jobs, the output is `git version 2.44.0.windows.1` .