### PR TITLE
time: update unix time acces, fix issues related to deviating unix times

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -82,7 +82,7 @@ jobs:
           .github/workflows/retry.sh git clone --depth 1 https://github.com/vlang/ved
           cd ved && ../v -o ved .
           ../v -autofree .
-          ../v -prod .
+          # ../v -prod . # NOTE: temporary disabled due to deprecations. Enable after resolving github.com/vlang/ved/pull/181
           cd ..
       - name: Build V UI examples
         run: |

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -74,7 +74,7 @@ jobs:
           .github/workflows/retry.sh git clone --depth 1 https://github.com/vlang/ved
           cd ved && ../v -o ved .
           ../v -autofree .
-          ../v -prod .
+          # ../v -prod . # NOTE: temporary disabled due to deprecations. Enable after resolving github.com/vlang/ved/pull/181
           cd ..
 
       - name: Build vlang/pdf
@@ -124,8 +124,8 @@ jobs:
           v install
           echo "Build v-analyzer debug"
           v build.vsh debug
-          echo "Build v-analyzer release"
-          v build.vsh release
+          # echo "Build v-analyzer release"
+          # v build.vsh release # NOTE: temporary disabled due to deprecations.
 
       - name: Format vlang/v-analyzer
         run: |

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1590,7 +1590,7 @@ fn main() {
 		month: 12
 		day: 25
 	}
-	println(time.new_time(my_time).utc_string())
+	println(time.new(my_time).utc_string())
 	println('Century: ${my_time.century()}')
 }
 ```

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -733,7 +733,7 @@ fn (mut app App) handle_swipe() {
 	adx, ady := math.abs(dx), math.abs(dy)
 	dmin := if math.min(adx, ady) > 0 { math.min(adx, ady) } else { 1 }
 	dmax := if math.max(adx, ady) > 0 { math.max(adx, ady) } else { 1 }
-	tdiff := int(e.time.unix_time_milli() - s.time.unix_time_milli())
+	tdiff := int(e.time.unix_milli() - s.time.unix_milli())
 	// TODO: make this calculation more accurate (don't use arbitrary numbers)
 	min_swipe_distance := int(math.sqrt(math.min(w, h) * tdiff / 100)) + 20
 	if dmax < min_swipe_distance {

--- a/vlib/context/onecontext/onecontext.v
+++ b/vlib/context/onecontext/onecontext.v
@@ -43,13 +43,13 @@ pub fn (octx OneContext) deadline() ?time.Time {
 
 	for ctx in octx.ctxs {
 		if deadline := ctx.deadline() {
-			if min.unix_time() == 0 || deadline < min {
+			if min.unix() == 0 || deadline < min {
 				min = deadline
 			}
 		}
 	}
 
-	if min.unix_time() == 0 {
+	if min.unix() == 0 {
 		return none
 	}
 

--- a/vlib/context/onecontext/onecontext_test.v
+++ b/vlib/context/onecontext/onecontext_test.v
@@ -95,7 +95,7 @@ fn test_merge_deadline_context_1() {
 	mut ctx, _ := merge(ctx1, ctx2)
 
 	if deadline := ctx.deadline() {
-		assert deadline.unix_time() != 0
+		assert deadline.unix() != 0
 	} else {
 		assert false
 	}
@@ -111,7 +111,7 @@ fn test_merge_deadline_context_2() {
 	mut ctx, _ := merge(ctx1, ctx2)
 
 	if deadline := ctx.deadline() {
-		assert deadline.unix_time() != 0
+		assert deadline.unix() != 0
 	} else {
 		assert false
 	}

--- a/vlib/db/mysql/orm.c.v
+++ b/vlib/db/mysql/orm.c.v
@@ -244,7 +244,7 @@ fn stmt_bind_primitive(mut stmt Stmt, data orm.Primitive) {
 			stmt.bind_text(data)
 		}
 		time.Time {
-			unix := int(data.unix)
+			unix := int(data.unix())
 			stmt_bind_primitive(mut stmt, unix)
 		}
 		orm.InfixType {

--- a/vlib/db/sqlite/orm.v
+++ b/vlib/db/sqlite/orm.v
@@ -140,7 +140,7 @@ fn bind(stmt Stmt, c &int, data orm.Primitive) int {
 			err = stmt.bind_text(c, data)
 		}
 		time.Time {
-			err = stmt.bind_int(c, int(data.unix))
+			err = stmt.bind_int(c, int(data.unix()))
 		}
 		orm.InfixType {
 			err = bind(stmt, c, data.right)

--- a/vlib/json/json_test.v
+++ b/vlib/json/json_test.v
@@ -95,7 +95,7 @@ fn test_encode_decode_sumtype() {
 	enc := json.encode(game)
 	// eprintln('Encoded Game: $enc')
 
-	assert enc == '{"title":"Super Mega Game","player":{"name":"Monke","_type":"Human"},"other":[{"tag":"Pen","_type":"Item"},{"tag":"Cookie","_type":"Item"},"cat","Stool",{"_type":"Time","value":${t.unix_time()}}]}'
+	assert enc == '{"title":"Super Mega Game","player":{"name":"Monke","_type":"Human"},"other":[{"tag":"Pen","_type":"Item"},{"tag":"Cookie","_type":"Item"},"cat","Stool",{"_type":"Time","value":${t.unix()}}]}'
 
 	dec := json.decode(SomeGame, enc)!
 	// eprintln('Decoded Game: $dec')
@@ -104,7 +104,7 @@ fn test_encode_decode_sumtype() {
 	assert game.player == dec.player
 	assert (game.other[2] as Animal) == .cat
 	assert dec.other[2] == Entity('cat')
-	assert (game.other[4] as time.Time).unix_time() == (dec.other[4] as time.Time).unix_time()
+	assert (game.other[4] as time.Time).unix() == (dec.other[4] as time.Time).unix()
 }
 
 fn bar[T](payload string) !Bar { // ?T doesn't work currently
@@ -156,7 +156,7 @@ fn test_parse_user() {
 fn test_encode_decode_time() {
 	user := User2{
 		age: 25
-		reg_date: time.new_time(year: 2020, month: 12, day: 22, hour: 7, minute: 23)
+		reg_date: time.new(year: 2020, month: 12, day: 22, hour: 7, minute: 23)
 	}
 	s := json.encode(user)
 	// println(s)

--- a/vlib/net/common.c.v
+++ b/vlib/net/common.c.v
@@ -4,9 +4,7 @@ import time
 
 // no_deadline should be given to functions when no deadline is wanted (i.e. all functions
 // return instantly)
-const no_deadline = time.Time{
-	unix: 0
-}
+const no_deadline = time.unix(0)
 
 // no_timeout should be given to functions when no timeout is wanted (i.e. all functions
 // return instantly)
@@ -148,7 +146,7 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 @[inline]
 fn select_deadline(handle int, test Select, deadline time.Time) !bool {
 	// if we have a 0 deadline here then the timeout that was passed was infinite...
-	infinite := deadline.unix_time() == 0
+	infinite := deadline.unix() == 0
 	for infinite || time.now() <= deadline {
 		timeout := if infinite { net.infinite_timeout } else { deadline - time.now() }
 		ready := @select(handle, test, timeout) or {

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -120,7 +120,7 @@ fn (mut s SSLConn) init() ! {
 		mut cert := s.config.cert
 		mut cert_key := s.config.cert_key
 		if s.config.in_memory_verification {
-			now := time.now().unix.str()
+			now := time.now().unix().str()
 			verify = os.temp_dir() + '/v_verify' + now
 			cert = os.temp_dir() + '/v_cert' + now
 			cert_key = os.temp_dir() + '/v_cert_key' + now

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -180,7 +180,7 @@ pub fn (c TcpConn) read(mut buf []u8) !int {
 }
 
 pub fn (mut c TcpConn) read_deadline() !time.Time {
-	if c.read_deadline.unix == 0 {
+	if c.read_deadline.unix() == 0 {
 		return c.read_deadline
 	}
 	return error('none')
@@ -245,7 +245,7 @@ pub fn (mut c TcpConn) set_read_deadline(deadline time.Time) {
 }
 
 pub fn (mut c TcpConn) write_deadline() !time.Time {
-	if c.write_deadline.unix == 0 {
+	if c.write_deadline.unix() == 0 {
 		return c.write_deadline
 	}
 	return error('none')
@@ -448,7 +448,7 @@ pub fn (mut l TcpListener) accept_only() !&TcpConn {
 }
 
 pub fn (c &TcpListener) accept_deadline() !time.Time {
-	if c.accept_deadline.unix != 0 {
+	if c.accept_deadline.unix() != 0 {
 		return c.accept_deadline
 	}
 	return error('invalid deadline')

--- a/vlib/net/udp.c.v
+++ b/vlib/net/udp.c.v
@@ -122,7 +122,7 @@ pub fn (mut c UdpConn) read(mut buf []u8) !(int, Addr) {
 }
 
 pub fn (c &UdpConn) read_deadline() !time.Time {
-	if c.read_deadline.unix == 0 {
+	if c.read_deadline.unix() == 0 {
 		return c.read_deadline
 	}
 	return error('none')
@@ -133,7 +133,7 @@ pub fn (mut c UdpConn) set_read_deadline(deadline time.Time) {
 }
 
 pub fn (c &UdpConn) write_deadline() !time.Time {
-	if c.write_deadline.unix == 0 {
+	if c.write_deadline.unix() == 0 {
 		return c.write_deadline
 	}
 	return error('none')

--- a/vlib/net/unix/common.c.v
+++ b/vlib/net/unix/common.c.v
@@ -5,9 +5,7 @@ import net
 
 // no_deadline should be given to functions when no deadline is wanted (i.e. all functions
 // return instantly)
-const no_deadline = time.Time{
-	unix: 0
-}
+const no_deadline = time.unix(0)
 // no_timeout should be given to functions when no timeout is wanted (i.e. all functions
 // return instantly)
 const no_timeout = time.Duration(0)
@@ -71,7 +69,7 @@ fn @select(handle int, test Select, timeout time.Duration) !bool {
 @[inline]
 fn select_deadline(handle int, test Select, deadline time.Time) !bool {
 	// if we have a 0 deadline here then the timeout that was passed was infinite...
-	infinite := deadline.unix_time() == 0
+	infinite := deadline.unix() == 0
 	for infinite || time.now() <= deadline {
 		timeout := if infinite { net.infinite_timeout } else { deadline - time.now() }
 		ready := @select(handle, test, timeout) or {

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -152,7 +152,7 @@ pub fn (mut c StreamConn) read(mut buf []u8) !int {
 
 // read_deadline returns the read deadline
 pub fn (mut c StreamConn) read_deadline() !time.Time {
-	if c.read_deadline.unix == 0 {
+	if c.read_deadline.unix() == 0 {
 		return c.read_deadline
 	}
 	return error('none')
@@ -165,7 +165,7 @@ pub fn (mut c StreamConn) set_read_deadline(deadline time.Time) {
 
 // write_deadline returns the write deadline
 pub fn (mut c StreamConn) write_deadline() !time.Time {
-	if c.write_deadline.unix == 0 {
+	if c.write_deadline.unix() == 0 {
 		return c.write_deadline
 	}
 	return error('none')
@@ -297,7 +297,7 @@ pub fn (mut l StreamListener) accept() !&StreamConn {
 
 // accept_deadline returns the deadline until a new client is accepted
 pub fn (l &StreamListener) accept_deadline() !time.Time {
-	if l.accept_deadline.unix != 0 {
+	if l.accept_deadline.unix() != 0 {
 		return l.accept_deadline
 	}
 	return error('no deadline')

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -171,7 +171,7 @@ pub fn (mut ws Client) listen() ! {
 			}
 			.pong {
 				ws.debug_log('read: pong')
-				ws.last_pong_ut = time.now().unix
+				ws.last_pong_ut = time.now().unix()
 				ws.send_message_event(msg)
 				if msg.payload.len > 0 {
 					unsafe { msg.free() }

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -108,7 +108,7 @@ fn (mut s Server) handle_ping() {
 					}
 					clients_to_remove << c.client.id
 				}
-				if (time.now().unix - c.client.last_pong_ut) > s.get_ping_interval() * 2 {
+				if (time.now().unix() - c.client.last_pong_ut) > s.get_ping_interval() * 2 {
 					clients_to_remove << c.client.id
 					c.client.close(1000, 'no pong received') or { continue }
 				}
@@ -150,7 +150,7 @@ pub fn (mut s Server) handle_handshake(mut conn net.TcpConn, key string) !&Serve
 		client_state: ClientState{
 			state: .open
 		}
-		last_pong_ut: time.now().unix
+		last_pong_ut: time.now().unix()
 		id: rand.uuid_v4()
 	}
 	mut server_client := &ServerClient{
@@ -225,7 +225,7 @@ fn (mut s Server) accept_new_client() !&Client {
 		client_state: ClientState{
 			state: .open
 		}
-		last_pong_ut: time.now().unix
+		last_pong_ut: time.now().unix()
 		id: rand.uuid_v4()
 	}
 	return c

--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -363,7 +363,7 @@ fn test_orm() {
 	}!
 
 	assert data.len == 1
-	assert tnow.unix == data[0].create.unix
+	assert tnow.unix() == data[0].create.unix()
 
 	mod := Module{}
 

--- a/vlib/os/environment_test.v
+++ b/vlib/os/environment_test.v
@@ -42,13 +42,13 @@ fn test_environ() {
 }
 
 fn test_setenv_var_not_exists() {
-	key := time.new_time(time.now()).unix
+	key := time.new(time.now()).unix()
 	os.setenv('foo${key}', 'bar', false)
 	assert os.getenv('foo${key}') == 'bar'
 }
 
 fn test_getenv_empty_var() {
-	key := time.new_time(time.now()).unix
+	key := time.new(time.now()).unix()
 	os.setenv('empty${key}', '""', false)
 	assert os.getenv('empty${key}') == '""'
 }

--- a/vlib/os/os_stat_test.v
+++ b/vlib/os/os_stat_test.v
@@ -22,13 +22,13 @@ fn test_stat() {
 
 	mut fstat := os.stat(test_file)!
 	eprintln(@LOCATION)
-	eprintln(' |  start_time: ${start_time.unix}\n |    end_time: ${end_time.unix}\n | fstat.ctime: ${fstat.ctime}\n | fstat.mtime: ${fstat.mtime}')
+	eprintln(' |  start_time: ${start_time.unix()}\n |    end_time: ${end_time.unix()}\n | fstat.ctime: ${fstat.ctime}\n | fstat.mtime: ${fstat.mtime}')
 	assert fstat.get_filetype() == .regular
 	assert fstat.size == u64(test_content.len)
-	assert fstat.ctime >= start_time.unix
-	assert fstat.ctime <= end_time.unix
-	assert fstat.mtime >= start_time.unix
-	assert fstat.mtime <= end_time.unix
+	assert fstat.ctime >= start_time.unix()
+	assert fstat.ctime <= end_time.unix()
+	assert fstat.mtime >= start_time.unix()
+	assert fstat.mtime <= end_time.unix()
 
 	$if !windows {
 		os.chmod(test_file, 0o600)!

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -869,8 +869,8 @@ fn test_utime() {
 		os.rm(filename) or { panic(err) }
 	}
 	f.write_string(hello) or { panic(err) }
-	atime := time.now().add_days(2).unix_time()
-	mtime := time.now().add_days(4).unix_time()
+	atime := time.now().add_days(2).unix()
+	mtime := time.now().add_days(4).unix()
 	os.utime(filename, int(atime), int(mtime)) or { panic(err) }
 	assert os.file_last_mod_unix(filename) == mtime
 }

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -323,10 +323,10 @@ pub fn (mut rng PRNG) f64_in_range(min f64, max f64) !f64 {
 // users or business transactions.
 // (https://news.ycombinator.com/item?id=14526173)
 pub fn (mut rng PRNG) ulid() string {
-	return internal_ulid_at_millisecond(mut rng, u64(time.utc().unix_time_milli()))
+	return internal_ulid_at_millisecond(mut rng, u64(time.utc().unix_milli()))
 }
 
-// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_time_milli`.
+// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_milli`.
 pub fn (mut rng PRNG) ulid_at_millisecond(unix_time_milli u64) string {
 	return internal_ulid_at_millisecond(mut rng, unix_time_milli)
 }
@@ -671,7 +671,7 @@ pub fn ulid() string {
 	return default_rng.ulid()
 }
 
-// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_time_milli`.
+// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_milli`.
 pub fn ulid_at_millisecond(unix_time_milli u64) string {
 	return default_rng.ulid_at_millisecond(unix_time_milli)
 }

--- a/vlib/rand/random_identifiers_test.v
+++ b/vlib/rand/random_identifiers_test.v
@@ -41,7 +41,7 @@ fn test_ulids_max_start_character_is_ok() {
 }
 
 fn test_ulids_generated_in_the_same_millisecond_have_the_same_prefix() {
-	t := u64(time.utc().unix_time_milli())
+	t := u64(time.utc().unix_milli())
 	mut ulid1 := ''
 	mut ulid2 := ''
 	mut ulid3 := ''

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -53,7 +53,7 @@ import time
 s := '2018-01-27 12:48:34'
 t := time.parse(s) or { panic('failing format: ${s} | err: ${err}') }
 println(t)
-println(t.unix_unix())
+println(t.unix())
 ```
 
 V's time module also has these parse methods:

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -53,7 +53,7 @@ import time
 s := '2018-01-27 12:48:34'
 t := time.parse(s) or { panic('failing format: ${s} | err: ${err}') }
 println(t)
-println(t.unix)
+println(t.unix_unix())
 ```
 
 V's time module also has these parse methods:

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -304,7 +304,7 @@ fn (mut p DateTimeParser) parse() !Time {
 		return error_invalid_time(0, '${month_name} has only 30 days')
 	}
 
-	return new_time(
+	return new(
 		year: year_
 		month: month_
 		day: day_in_month

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -151,12 +151,9 @@ pub fn (t Time) format_rfc3339() string {
 		unsafe { buf.free() }
 	}
 
-	if t.unix == 0 && t.nanosecond == 0 {
-		return buf.bytestr()
-	}
-
-	if t.is_local {
-		utc_time := t.local_to_utc()
+	t_ := time_with_unix(t)
+	if t_.is_local {
+		utc_time := t_.local_to_utc()
 		int_to_byte_array_no_pad(utc_time.year, mut buf, 4)
 		int_to_byte_array_no_pad(utc_time.month, mut buf, 7)
 		int_to_byte_array_no_pad(utc_time.day, mut buf, 10)
@@ -165,13 +162,13 @@ pub fn (t Time) format_rfc3339() string {
 		int_to_byte_array_no_pad(utc_time.second, mut buf, 19)
 		int_to_byte_array_no_pad(utc_time.nanosecond / 1_000_000, mut buf, 23)
 	} else {
-		int_to_byte_array_no_pad(t.year, mut buf, 4)
-		int_to_byte_array_no_pad(t.month, mut buf, 7)
-		int_to_byte_array_no_pad(t.day, mut buf, 10)
-		int_to_byte_array_no_pad(t.hour, mut buf, 13)
-		int_to_byte_array_no_pad(t.minute, mut buf, 16)
-		int_to_byte_array_no_pad(t.second, mut buf, 19)
-		int_to_byte_array_no_pad(t.nanosecond / 1_000_000, mut buf, 23)
+		int_to_byte_array_no_pad(t_.year, mut buf, 4)
+		int_to_byte_array_no_pad(t_.month, mut buf, 7)
+		int_to_byte_array_no_pad(t_.day, mut buf, 10)
+		int_to_byte_array_no_pad(t_.hour, mut buf, 13)
+		int_to_byte_array_no_pad(t_.minute, mut buf, 16)
+		int_to_byte_array_no_pad(t_.second, mut buf, 19)
+		int_to_byte_array_no_pad(t_.nanosecond / 1_000_000, mut buf, 23)
 	}
 
 	return buf.bytestr()
@@ -187,12 +184,9 @@ pub fn (t Time) format_rfc3339_nano() string {
 		unsafe { buf.free() }
 	}
 
-	if t.unix == 0 && t.nanosecond == 0 {
-		return buf.bytestr()
-	}
-
-	if t.is_local {
-		utc_time := t.local_to_utc()
+	t_ := time_with_unix(t)
+	if t_.is_local {
+		utc_time := t_.local_to_utc()
 		int_to_byte_array_no_pad(utc_time.year, mut buf, 4)
 		int_to_byte_array_no_pad(utc_time.month, mut buf, 7)
 		int_to_byte_array_no_pad(utc_time.day, mut buf, 10)
@@ -201,13 +195,13 @@ pub fn (t Time) format_rfc3339_nano() string {
 		int_to_byte_array_no_pad(utc_time.second, mut buf, 19)
 		int_to_byte_array_no_pad(utc_time.nanosecond, mut buf, 29)
 	} else {
-		int_to_byte_array_no_pad(t.year, mut buf, 4)
-		int_to_byte_array_no_pad(t.month, mut buf, 7)
-		int_to_byte_array_no_pad(t.day, mut buf, 10)
-		int_to_byte_array_no_pad(t.hour, mut buf, 13)
-		int_to_byte_array_no_pad(t.minute, mut buf, 16)
-		int_to_byte_array_no_pad(t.second, mut buf, 19)
-		int_to_byte_array_no_pad(t.nanosecond, mut buf, 29)
+		int_to_byte_array_no_pad(t_.year, mut buf, 4)
+		int_to_byte_array_no_pad(t_.month, mut buf, 7)
+		int_to_byte_array_no_pad(t_.day, mut buf, 10)
+		int_to_byte_array_no_pad(t_.hour, mut buf, 13)
+		int_to_byte_array_no_pad(t_.minute, mut buf, 16)
+		int_to_byte_array_no_pad(t_.second, mut buf, 19)
+		int_to_byte_array_no_pad(t_.nanosecond, mut buf, 29)
 	}
 
 	return buf.bytestr()

--- a/vlib/time/misc/misc.v
+++ b/vlib/time/misc/misc.v
@@ -3,7 +3,7 @@ module misc
 import rand
 import time
 
-const start_time_unix = time.now().unix
+const start_time_unix = time.now().unix()
 
 // random returns a random time struct in *the past*.
 pub fn random() time.Time {

--- a/vlib/time/misc/misc_test.v
+++ b/vlib/time/misc/misc_test.v
@@ -8,10 +8,10 @@ fn test_random() {
 	t2 := tmisc.random()
 	t3 := tmisc.random()
 	t4 := tmisc.random()
-	assert t1.unix != t2.unix
-	assert t1.unix != t3.unix
-	assert t1.unix != t4.unix
-	assert t2.unix != t3.unix
-	assert t2.unix != t4.unix
-	assert t3.unix != t4.unix
+	assert t1.unix() != t2.unix()
+	assert t1.unix() != t3.unix()
+	assert t1.unix() != t4.unix()
+	assert t2.unix() != t3.unix()
+	assert t2.unix() != t4.unix()
+	assert t3.unix() != t4.unix()
 }

--- a/vlib/time/operator.v
+++ b/vlib/time/operator.v
@@ -3,13 +3,13 @@ module time
 // operator `==` returns true if provided time is equal to time
 @[inline]
 pub fn (t1 Time) == (t2 Time) bool {
-	return t1.unix == t2.unix && t1.nanosecond == t2.nanosecond
+	return t1.unix() == t2.unix() && t1.nanosecond == t2.nanosecond
 }
 
 // operator `<` returns true if provided time is less than time
 @[inline]
 pub fn (t1 Time) < (t2 Time) bool {
-	return t1.unix < t2.unix || (t1.unix == t2.unix && t1.nanosecond < t2.nanosecond)
+	return t1.unix() < t2.unix() || (t1.unix() == t2.unix() && t1.nanosecond < t2.nanosecond)
 }
 
 // Time subtract using operator overloading.
@@ -18,7 +18,7 @@ pub fn (lhs Time) - (rhs Time) Duration {
 	// lhs.unix * 1_000_000_000 + i64(lhs.nanosecond) will overflow i64, for years > 3000 .
 	// Doing the diff first, and *then* multiplying by `second`, is less likely to overflow,
 	// since lhs and rhs will be likely close to each other.
-	unixs := i64(lhs.unix - rhs.unix) * second
+	unixs := i64(lhs.unix() - rhs.unix()) * second
 	nanos := lhs.nanosecond - rhs.nanosecond
 	return unixs + nanos
 }

--- a/vlib/time/operator_test.v
+++ b/vlib/time/operator_test.v
@@ -32,7 +32,7 @@ fn test_now_always_results_in_greater_time() {
 }
 
 fn test_time1_should_be_same_as_time2() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -41,7 +41,7 @@ fn test_time1_should_be_same_as_time2() {
 		second: 3
 		nanosecond: 100
 	})
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -54,7 +54,7 @@ fn test_time1_should_be_same_as_time2() {
 }
 
 fn test_time1_should_not_be_same_as_time2() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -64,7 +64,7 @@ fn test_time1_should_not_be_same_as_time2() {
 		nanosecond: 100
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -73,7 +73,7 @@ fn test_time1_should_not_be_same_as_time2() {
 		second: 3
 		nanosecond: 101
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -83,7 +83,7 @@ fn test_time1_should_not_be_same_as_time2() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -97,7 +97,7 @@ fn test_time1_should_not_be_same_as_time2() {
 }
 
 fn test_time1_should_be_greater_than_time2() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -107,7 +107,7 @@ fn test_time1_should_be_greater_than_time2() {
 		nanosecond: 102
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -116,7 +116,7 @@ fn test_time1_should_be_greater_than_time2() {
 		second: 3
 		nanosecond: 101
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -126,7 +126,7 @@ fn test_time1_should_be_greater_than_time2() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -140,7 +140,7 @@ fn test_time1_should_be_greater_than_time2() {
 }
 
 fn test_time2_should_be_less_than_time1() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -150,7 +150,7 @@ fn test_time2_should_be_less_than_time1() {
 		nanosecond: 102
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -159,7 +159,7 @@ fn test_time2_should_be_less_than_time1() {
 		second: 3
 		nanosecond: 101
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -169,7 +169,7 @@ fn test_time2_should_be_less_than_time1() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -183,7 +183,7 @@ fn test_time2_should_be_less_than_time1() {
 }
 
 fn test_time1_should_be_greater_or_equal_to_time2_when_gt() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -193,7 +193,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_gt() {
 		nanosecond: 102
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -202,7 +202,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_gt() {
 		second: 3
 		nanosecond: 101
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -212,7 +212,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_gt() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -226,7 +226,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_gt() {
 }
 
 fn test_time1_should_be_greater_or_equal_to_time2_when_eq() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -236,7 +236,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_eq() {
 		nanosecond: 100
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -245,7 +245,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_eq() {
 		second: 3
 		nanosecond: 100
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -255,7 +255,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_eq() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -269,7 +269,7 @@ fn test_time1_should_be_greater_or_equal_to_time2_when_eq() {
 }
 
 fn test_time1_should_be_less_or_equal_to_time2_when_lt() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -279,7 +279,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_lt() {
 		nanosecond: 100
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -288,7 +288,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_lt() {
 		second: 3
 		nanosecond: 101
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -298,7 +298,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_lt() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -312,7 +312,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_lt() {
 }
 
 fn test_time1_should_be_less_or_equal_to_time2_when_eq() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -322,7 +322,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_eq() {
 		nanosecond: 100
 	})
 	// Difference is one nanosecond
-	t2 := new_time(Time{
+	t2 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -331,7 +331,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_eq() {
 		second: 3
 		nanosecond: 100
 	})
-	t3 := new_time(Time{
+	t3 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -341,7 +341,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_eq() {
 		nanosecond: 0
 	})
 	// Difference is one second
-	t4 := new_time(Time{
+	t4 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -355,7 +355,7 @@ fn test_time1_should_be_less_or_equal_to_time2_when_eq() {
 }
 
 fn test_time2_copied_from_time1_should_be_equal() {
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10
@@ -364,7 +364,7 @@ fn test_time2_copied_from_time1_should_be_equal() {
 		second: 3
 		nanosecond: 100
 	})
-	t2 := new_time(t1)
+	t2 := new(t1)
 	assert t2 == t1
 }
 
@@ -372,7 +372,7 @@ fn test_subtract() {
 	d_seconds := 3
 	d_nanoseconds := 13
 	duration := d_seconds * second + d_nanoseconds * nanosecond
-	t1 := new_time(Time{
+	t1 := new(Time{
 		year: 2000
 		month: 5
 		day: 10

--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -26,7 +26,7 @@ pub fn parse_rfc3339(s string) !Time {
 	// Check if sn is date only
 	if !parts[0].contains_any(' Z') && parts[0].contains('-') {
 		year, month, day := parse_iso8601_date(sn)!
-		t = new_time(Time{
+		t = new(Time{
 			year: year
 			month: month
 			day: day
@@ -37,7 +37,7 @@ pub fn parse_rfc3339(s string) !Time {
 	if !parts[0].contains('-') && parts[0].contains(':') {
 		mut hour_, mut minute_, mut second_, mut microsecond_, mut nanosecond_, mut unix_offset, mut is_local_time := 0, 0, 0, 0, 0, i64(0), true
 		hour_, minute_, second_, microsecond_, nanosecond_, unix_offset, is_local_time = parse_iso8601_time(parts[0])!
-		t = new_time(Time{
+		t = new(Time{
 			hour: hour_
 			minute: minute_
 			second: second_
@@ -119,7 +119,7 @@ pub fn parse(s string) !Time {
 	if isecond > 59 || isecond < 0 {
 		return error_invalid_time(8, 'seconds must be between 0 and 60')
 	}
-	res := new_time(Time{
+	res := new(Time{
 		year: iyear
 		month: imonth
 		day: iday
@@ -176,7 +176,7 @@ pub fn parse_iso8601(s string) !Time {
 	if parts.len == 2 {
 		hour_, minute_, second_, microsecond_, nanosecond_, unix_offset, is_local_time = parse_iso8601_time(parts[1])!
 	}
-	mut t := new_time(
+	mut t := new(
 		year: year
 		month: month
 		day: day

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -9,7 +9,7 @@ fn test_parse() {
 	}
 	assert t.year == 2018 && t.month == 1 && t.day == 27 && t.hour == 12 && t.minute == 48
 		&& t.second == 34
-	assert t.unix == 1517057314
+	assert t.unix() == 1517057314
 }
 
 fn test_parse_invalid() {
@@ -33,7 +33,7 @@ fn test_parse_rfc2822() {
 	}
 	assert t1.year == 2019 && t1.month == 12 && t1.day == 12 && t1.hour == 6 && t1.minute == 7
 		&& t1.second == 45
-	assert t1.unix == 1576130865
+	assert t1.unix() == 1576130865
 	s2 := 'Thu 12 Dec 2019 06:07:45 +0800'
 	t2 := time.parse_rfc2822(s2) or {
 		eprintln('> failing format: ${s2} | err: ${err}')
@@ -42,7 +42,7 @@ fn test_parse_rfc2822() {
 	}
 	assert t2.year == 2019 && t2.month == 12 && t2.day == 12 && t2.hour == 6 && t2.minute == 7
 		&& t2.second == 45
-	assert t2.unix == 1576130865
+	assert t2.unix() == 1576130865
 }
 
 fn test_parse_rfc2822_invalid() {
@@ -192,14 +192,14 @@ fn test_ad_second_to_parse_result_in_2001() {
 	now_tm := time.parse('2001-01-01 04:00:00')!
 	future_tm := now_tm.add_seconds(60)
 	assert future_tm.str() == '2001-01-01 04:01:00'
-	assert now_tm.unix < future_tm.unix
+	assert now_tm.unix() < future_tm.unix()
 }
 
 fn test_ad_second_to_parse_result_pre_2001() {
 	now_tm := time.parse('2000-01-01 04:00:00')!
 	future_tm := now_tm.add_seconds(60)
 	assert future_tm.str() == '2000-01-01 04:01:00'
-	assert now_tm.unix < future_tm.unix
+	assert now_tm.unix() < future_tm.unix()
 }
 
 fn test_parse_format() {

--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -57,7 +57,13 @@ pub fn utc() Time {
 }
 
 // new_time returns a time struct with the calculated Unix time.
-fn new_time(t Time) Time {
+@[deprecated: 'use `new()` instead']
+@[deprecated_after: '2024-05-31']
+pub fn new_time(t Time) Time {
+	return time_with_unix(t)
+}
+
+fn time_with_unix(t Time) Time {
 	if t.unix != 0 {
 		return t
 	}

--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -57,7 +57,7 @@ pub fn utc() Time {
 }
 
 // new_time returns a time struct with the calculated Unix time.
-pub fn new_time(t Time) Time {
+fn new_time(t Time) Time {
 	if t.unix != 0 {
 		return t
 	}

--- a/vlib/time/time.js.v
+++ b/vlib/time/time.js.v
@@ -45,7 +45,7 @@ pub fn sleep(dur Duration) {
 }
 
 // new_time returns a time struct with the calculated Unix time.
-pub fn new_time(t Time) Time {
+fn new_time(t Time) Time {
 	if t.unix != 0 {
 		return t
 	}

--- a/vlib/time/time.js.v
+++ b/vlib/time/time.js.v
@@ -45,7 +45,13 @@ pub fn sleep(dur Duration) {
 }
 
 // new_time returns a time struct with the calculated Unix time.
-fn new_time(t Time) Time {
+@[deprecated: 'use `new()` instead']
+@[deprecated_after: '2024-05-31']
+pub fn new_time(t Time) Time {
+	return time_with_unix(t)
+}
+
+fn time_with_unix(t Time) Time {
 	if t.unix != 0 {
 		return t
 	}

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -159,20 +159,19 @@ pub fn (t Time) unix_time_nano() i64 {
 
 // add returns a new time with the given duration added.
 pub fn (t Time) add(duration_in_nanosecond Duration) Time {
-	t_with_unix := time_with_unix(t)
 	// This expression overflows i64 for big years (and we do not have i128 yet):
 	// nanos := t.unix * 1_000_000_000 + i64(t.nanosecond) <-
 	// ... so instead, handle the addition manually in parts ¯\_(ツ)_/¯
 	mut increased_time_nanosecond := i64(t.nanosecond) + duration_in_nanosecond.nanoseconds()
 	// increased_time_second
-	mut increased_time_second := t_with_unix.unix + (increased_time_nanosecond / second)
+	mut increased_time_second := t.unix() + (increased_time_nanosecond / second)
 	increased_time_nanosecond = increased_time_nanosecond % second
 	if increased_time_nanosecond < 0 {
 		increased_time_second--
 		increased_time_nanosecond += second
 	}
 	res := unix_nanosecond(increased_time_second, int(increased_time_nanosecond))
-	return if t_with_unix.is_local { res.as_local() } else { res }
+	return if t.is_local { res.as_local() } else { res }
 }
 
 // add_seconds returns a new time struct with an added number of seconds.
@@ -207,7 +206,7 @@ pub fn since(t Time) Duration {
 // ```
 pub fn (t Time) relative() string {
 	znow := now()
-	mut secs := znow.unix - t.unix
+	mut secs := znow.unix - t.unix()
 	mut prefix := ''
 	mut suffix := ''
 	if secs < 0 {
@@ -269,7 +268,7 @@ pub fn (t Time) relative() string {
 // ```
 pub fn (t Time) relative_short() string {
 	znow := now()
-	mut secs := znow.unix - t.unix
+	mut secs := znow.unix - t.unix()
 	mut prefix := ''
 	mut suffix := ''
 	if secs < 0 {

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -104,29 +104,57 @@ pub fn (t Time) smonth() string {
 	return time.months_string[i * 3..(i + 1) * 3]
 }
 
-// unix_time returns the UNIX time with second resolution.
+// unix returns the UNIX time with second resolution.
 @[inline]
-pub fn (t Time) unix_time() i64 {
+pub fn (t Time) unix() i64 {
 	return new_time(t).unix
 }
 
-// unix_time_milli returns the UNIX time with millisecond resolution.
+// unix_milli returns the UNIX time with millisecond resolution.
 @[inline]
-pub fn (t Time) unix_time_milli() i64 {
+pub fn (t Time) unix_milli() i64 {
 	return new_time(t).unix * 1_000 + (i64(t.nanosecond) / 1_000_000)
 }
 
-// unix_time_micro returns the UNIX time with microsecond resolution.
+// unix_micro returns the UNIX time with microsecond resolution.
 @[inline]
-pub fn (t Time) unix_time_micro() i64 {
+pub fn (t Time) unix_micro() i64 {
 	return new_time(t).unix * 1_000_000 + (i64(t.nanosecond) / 1_000)
 }
 
-// unix_time_nano returns the UNIX time with nanosecond resolution.
+// unix_nano returns the UNIX time with nanosecond resolution.
 @[inline]
-pub fn (t Time) unix_time_nano() i64 {
+pub fn (t Time) unix_nano() i64 {
 	// TODO: use i128 here, when V supports it, since the following expression overflows for years like 3001:
 	return new_time(t).unix * 1_000_000_000 + i64(t.nanosecond)
+}
+
+// unix_time returns the UNIX time with second resolution.
+@[deprecated: 'use `t.unix()` instead']
+@[deprecated_after: '2024-05-31']
+pub fn (t Time) unix_time() i64 {
+	return t.unix()
+}
+
+// unix_time_milli returns the UNIX time with millisecond resolution.
+@[deprecated: 'use `t.unix_milli()` instead']
+@[deprecated_after: '2024-05-31']
+pub fn (t Time) unix_time_milli() i64 {
+	return t.unix_milli()
+}
+
+// unix_time_micro returns the UNIX time with microsecond resolution.
+@[deprecated: 'use `t.unix_micro()` instead']
+@[deprecated_after: '2024-05-31']
+pub fn (t Time) unix_time_micro() i64 {
+	return t.unix_micro()
+}
+
+// unix_time_nano returns the UNIX time with nanosecond resolution.
+@[deprecated: 'use `t.unix_nano()` instead']
+@[deprecated_after: '2024-05-31']
+pub fn (t Time) unix_time_nano() i64 {
+	return t.unix_nano()
 }
 
 // add returns a new time with the given duration added.

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -113,20 +113,20 @@ pub fn (t Time) unix() i64 {
 // unix_milli returns the UNIX time with millisecond resolution.
 @[inline]
 pub fn (t Time) unix_milli() i64 {
-	return time_with_unix(t).unix * 1_000 + (i64(t.nanosecond) / 1_000_000)
+	return t.unix() * 1_000 + (i64(t.nanosecond) / 1_000_000)
 }
 
 // unix_micro returns the UNIX time with microsecond resolution.
 @[inline]
 pub fn (t Time) unix_micro() i64 {
-	return time_with_unix(t).unix * 1_000_000 + (i64(t.nanosecond) / 1_000)
+	return t.unix() * 1_000_000 + (i64(t.nanosecond) / 1_000)
 }
 
 // unix_nano returns the UNIX time with nanosecond resolution.
 @[inline]
 pub fn (t Time) unix_nano() i64 {
 	// TODO: use i128 here, when V supports it, since the following expression overflows for years like 3001:
-	return time_with_unix(t).unix * 1_000_000_000 + i64(t.nanosecond)
+	return t.unix() * 1_000_000_000 + i64(t.nanosecond)
 }
 
 // unix_time returns the UNIX time with second resolution.

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -36,6 +36,7 @@ pub const days_before = [
 
 // Time contains various time units for a point in time.
 pub struct Time {
+	unix i64
 pub:
 	year       int
 	month      int
@@ -44,7 +45,6 @@ pub:
 	minute     int
 	second     int
 	nanosecond int
-	unix       i64
 	is_local   bool // used to make time.now().local().local() == time.now().local()
 	//
 	microsecond int @[deprecated: 'use t.nanosecond / 1000 instead'; deprecated_after: '2023-08-05']
@@ -90,6 +90,11 @@ pub fn Time.new(t Time) Time {
 	return new_time(t)
 }
 
+// new returns a time struct with the calculated Unix time.
+pub fn new(t Time) Time {
+	return new_time(t)
+}
+
 // smonth returns the month name abbreviation.
 pub fn (t Time) smonth() string {
 	if t.month <= 0 || t.month > 12 {
@@ -102,53 +107,54 @@ pub fn (t Time) smonth() string {
 // unix_time returns the UNIX time with second resolution.
 @[inline]
 pub fn (t Time) unix_time() i64 {
-	return t.unix
+	return new_time(t).unix
 }
 
 // unix_time_milli returns the UNIX time with millisecond resolution.
 @[inline]
 pub fn (t Time) unix_time_milli() i64 {
-	return t.unix * 1_000 + (i64(t.nanosecond) / 1_000_000)
+	return new_time(t).unix * 1_000 + (i64(t.nanosecond) / 1_000_000)
 }
 
 // unix_time_micro returns the UNIX time with microsecond resolution.
 @[inline]
 pub fn (t Time) unix_time_micro() i64 {
-	return t.unix * 1_000_000 + (i64(t.nanosecond) / 1_000)
+	return new_time(t).unix * 1_000_000 + (i64(t.nanosecond) / 1_000)
 }
 
 // unix_time_nano returns the UNIX time with nanosecond resolution.
 @[inline]
 pub fn (t Time) unix_time_nano() i64 {
 	// TODO: use i128 here, when V supports it, since the following expression overflows for years like 3001:
-	return t.unix * 1_000_000_000 + i64(t.nanosecond)
+	return new_time(t).unix * 1_000_000_000 + i64(t.nanosecond)
 }
 
 // add returns a new time with the given duration added.
 pub fn (t Time) add(duration_in_nanosecond Duration) Time {
+	t_with_unix := new_time(t)
 	// This expression overflows i64 for big years (and we do not have i128 yet):
 	// nanos := t.unix * 1_000_000_000 + i64(t.nanosecond) <-
 	// ... so instead, handle the addition manually in parts ¯\_(ツ)_/¯
 	mut increased_time_nanosecond := i64(t.nanosecond) + duration_in_nanosecond.nanoseconds()
 	// increased_time_second
-	mut increased_time_second := t.unix + (increased_time_nanosecond / second)
+	mut increased_time_second := t_with_unix.unix + (increased_time_nanosecond / second)
 	increased_time_nanosecond = increased_time_nanosecond % second
 	if increased_time_nanosecond < 0 {
 		increased_time_second--
 		increased_time_nanosecond += second
 	}
 	res := unix_nanosecond(increased_time_second, int(increased_time_nanosecond))
-	return if t.is_local { res.as_local() } else { res }
+	return if t_with_unix.is_local { res.as_local() } else { res }
 }
 
 // add_seconds returns a new time struct with an added number of seconds.
 pub fn (t Time) add_seconds(seconds int) Time {
-	return t.add(seconds * second)
+	return new_time(t).add(seconds * second)
 }
 
 // add_days returns a new time struct with an added number of days.
 pub fn (t Time) add_days(days int) Time {
-	return t.add(days * 24 * hour)
+	return new_time(t).add(days * 24 * hour)
 }
 
 // since returns the time duration elapsed since a given time.

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -87,12 +87,12 @@ pub enum FormatDelimiter {
 }
 
 pub fn Time.new(t Time) Time {
-	return new_time(t)
+	return time_with_unix(t)
 }
 
 // new returns a time struct with the calculated Unix time.
 pub fn new(t Time) Time {
-	return new_time(t)
+	return time_with_unix(t)
 }
 
 // smonth returns the month name abbreviation.
@@ -107,26 +107,26 @@ pub fn (t Time) smonth() string {
 // unix returns the UNIX time with second resolution.
 @[inline]
 pub fn (t Time) unix() i64 {
-	return new_time(t).unix
+	return time_with_unix(t).unix
 }
 
 // unix_milli returns the UNIX time with millisecond resolution.
 @[inline]
 pub fn (t Time) unix_milli() i64 {
-	return new_time(t).unix * 1_000 + (i64(t.nanosecond) / 1_000_000)
+	return time_with_unix(t).unix * 1_000 + (i64(t.nanosecond) / 1_000_000)
 }
 
 // unix_micro returns the UNIX time with microsecond resolution.
 @[inline]
 pub fn (t Time) unix_micro() i64 {
-	return new_time(t).unix * 1_000_000 + (i64(t.nanosecond) / 1_000)
+	return time_with_unix(t).unix * 1_000_000 + (i64(t.nanosecond) / 1_000)
 }
 
 // unix_nano returns the UNIX time with nanosecond resolution.
 @[inline]
 pub fn (t Time) unix_nano() i64 {
 	// TODO: use i128 here, when V supports it, since the following expression overflows for years like 3001:
-	return new_time(t).unix * 1_000_000_000 + i64(t.nanosecond)
+	return time_with_unix(t).unix * 1_000_000_000 + i64(t.nanosecond)
 }
 
 // unix_time returns the UNIX time with second resolution.
@@ -159,7 +159,7 @@ pub fn (t Time) unix_time_nano() i64 {
 
 // add returns a new time with the given duration added.
 pub fn (t Time) add(duration_in_nanosecond Duration) Time {
-	t_with_unix := new_time(t)
+	t_with_unix := time_with_unix(t)
 	// This expression overflows i64 for big years (and we do not have i128 yet):
 	// nanos := t.unix * 1_000_000_000 + i64(t.nanosecond) <-
 	// ... so instead, handle the addition manually in parts ¯\_(ツ)_/¯
@@ -177,12 +177,12 @@ pub fn (t Time) add(duration_in_nanosecond Duration) Time {
 
 // add_seconds returns a new time struct with an added number of seconds.
 pub fn (t Time) add_seconds(seconds int) Time {
-	return new_time(t).add(seconds * second)
+	return time_with_unix(t).add(seconds * second)
 }
 
 // add_days returns a new time struct with an added number of days.
 pub fn (t Time) add_days(days int) Time {
-	return new_time(t).add(days * 24 * hour)
+	return time_with_unix(t).add(days * 24 * hour)
 }
 
 // since returns the time duration elapsed since a given time.

--- a/vlib/time/time_format_test.v
+++ b/vlib/time/time_format_test.v
@@ -7,12 +7,11 @@ const time_to_test = time.Time{
 	hour: 21
 	minute: 23
 	second: 42
-	unix: 332198622
 }
 
 fn test_now_format() {
 	t := time.now()
-	u := t.unix
+	u := t.unix()
 	assert t.format() == time.unix(int(u)).format()
 }
 

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -36,7 +36,8 @@ pub fn (t Time) local() Time {
 		return t
 	}
 	loc_tm := C.tm{}
-	C.localtime_r(voidptr(&t.unix), &loc_tm)
+	t_ := t.unix()
+	C.localtime_r(voidptr(&t_), &loc_tm)
 	return convert_ctime(loc_tm, t.nanosecond)
 }
 

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -1,7 +1,7 @@
 import time
 import math
 
-const local_time_to_test = time.Time{
+const local_time_to_test = time.new_time(
 	year: 1980
 	month: 7
 	day: 11
@@ -9,11 +9,10 @@ const local_time_to_test = time.Time{
 	minute: 23
 	second: 42
 	nanosecond: 123456789
-	unix: 332198622
 	is_local: true
-}
+)
 
-const utc_time_to_test = time.Time{
+const utc_time_to_test = time.new_time(
 	year: 1980
 	month: 7
 	day: 11
@@ -21,9 +20,8 @@ const utc_time_to_test = time.Time{
 	minute: 23
 	second: 42
 	nanosecond: 123456789
-	unix: 332198622
 	is_local: false
-}
+)
 
 fn test_is_leap_year() {
 	// 1996 % 4 = 0 and 1996 % 100 > 0
@@ -92,6 +90,8 @@ fn test_unix() {
 	assert t6.hour == 6
 	assert t6.minute == 9
 	assert t6.second == 29
+	assert local_time_to_test.unix_time() == 332198622
+	assert utc_time_to_test.unix_time() == 332198622
 }
 
 fn test_format_rfc3339() {
@@ -168,7 +168,6 @@ fn test_smonth() {
 			hour: 0
 			minute: 0
 			second: 0
-			unix: 0
 		}
 		assert t.smonth() == name
 	}
@@ -185,7 +184,6 @@ fn test_day_of_week() {
 			hour: 0
 			minute: 0
 			second: 0
-			unix: 0
 		}
 		assert day_of_week == t.day_of_week()
 	}
@@ -238,14 +236,14 @@ fn test_add() {
 	// dump(t2.debug())
 	assert t2.second == t1.second + d_seconds
 	assert t2.nanosecond == t1.nanosecond + d_nanoseconds
-	assert t2.unix == t1.unix + d_seconds
+	assert t2.unix_time() == t1.unix_time() + d_seconds
 	assert t2.is_local == t1.is_local
 	//
 	t3 := local_time_to_test.add(-duration)
 	// dump(t3.debug())
 	assert t3.second == t1.second - d_seconds
 	assert t3.nanosecond == t1.nanosecond - d_nanoseconds
-	assert t3.unix == t1.unix - d_seconds
+	assert t3.unix_time() == t1.unix_time() - d_seconds
 	assert t3.is_local == t1.is_local
 	//
 	t4 := local_time_to_test.as_local()
@@ -253,13 +251,26 @@ fn test_add() {
 	t5 := t4.add(duration)
 	// dump(t5.debug())
 	assert t5.is_local == t4.is_local
+
+	t := time.Time{
+		year: 2024
+		month: 4
+		day: 3
+	}
+	t_5am := t.add(time.hour * 5)
+	assert t_5am.hour == 5
+	next_day := t_5am.add_days(1)
+	assert next_day.day == 4 && next_day.day == t_5am.day + 1
+	assert next_day.year == t_5am.year && next_day.month == t.month
+	assert next_day.month == t_5am.month && next_day.month == t.month
+	assert next_day.hour == t_5am.hour && next_day.month == t.month
 }
 
 fn test_add_days() {
 	num_of_days := 3
 	t := local_time_to_test.add_days(num_of_days)
 	assert t.day == local_time_to_test.day + num_of_days
-	assert t.unix == local_time_to_test.unix + 86400 * num_of_days
+	assert t.unix_time() == local_time_to_test.unix_time() + 86400 * num_of_days
 }
 
 fn test_str() {
@@ -370,7 +381,7 @@ fn test_strftime() {
 fn test_add_seconds_to_time() {
 	now_tm := time.now()
 	future_tm := now_tm.add_seconds(60)
-	assert now_tm.unix < future_tm.unix
+	assert now_tm.unix_time() < future_tm.unix_time()
 }
 
 fn test_plus_equals_duration() {
@@ -396,6 +407,6 @@ fn test_tm_gmtoff() {
 		C.time(&rawtime) // C.tm{}
 
 		info := C.localtime(&rawtime)
-		assert info.tm_gmtoff == time.now().unix - time.utc().unix
+		assert info.tm_gmtoff == time.now().unix_time() - time.utc().unix_time()
 	}
 }

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -1,7 +1,7 @@
 import time
 import math
 
-const local_time_to_test = time.new_time(
+const local_time_to_test = time.new(
 	year: 1980
 	month: 7
 	day: 11
@@ -12,7 +12,7 @@ const local_time_to_test = time.new_time(
 	is_local: true
 )
 
-const utc_time_to_test = time.new_time(
+const utc_time_to_test = time.new(
 	year: 1980
 	month: 7
 	day: 11
@@ -90,8 +90,8 @@ fn test_unix() {
 	assert t6.hour == 6
 	assert t6.minute == 9
 	assert t6.second == 29
-	assert local_time_to_test.unix_time() == 332198622
-	assert utc_time_to_test.unix_time() == 332198622
+	assert local_time_to_test.unix() == 332198622
+	assert utc_time_to_test.unix() == 332198622
 }
 
 fn test_format_rfc3339() {
@@ -236,14 +236,14 @@ fn test_add() {
 	// dump(t2.debug())
 	assert t2.second == t1.second + d_seconds
 	assert t2.nanosecond == t1.nanosecond + d_nanoseconds
-	assert t2.unix_time() == t1.unix_time() + d_seconds
+	assert t2.unix() == t1.unix() + d_seconds
 	assert t2.is_local == t1.is_local
 	//
 	t3 := local_time_to_test.add(-duration)
 	// dump(t3.debug())
 	assert t3.second == t1.second - d_seconds
 	assert t3.nanosecond == t1.nanosecond - d_nanoseconds
-	assert t3.unix_time() == t1.unix_time() - d_seconds
+	assert t3.unix() == t1.unix() - d_seconds
 	assert t3.is_local == t1.is_local
 	//
 	t4 := local_time_to_test.as_local()
@@ -270,7 +270,7 @@ fn test_add_days() {
 	num_of_days := 3
 	t := local_time_to_test.add_days(num_of_days)
 	assert t.day == local_time_to_test.day + num_of_days
-	assert t.unix_time() == local_time_to_test.unix_time() + 86400 * num_of_days
+	assert t.unix() == local_time_to_test.unix() + 86400 * num_of_days
 }
 
 fn test_str() {
@@ -315,14 +315,14 @@ fn test_unix_time() {
 	t2 := time.utc()
 	eprintln('  t1: ${t1}')
 	eprintln('  t2: ${t2}')
-	ut1 := t1.unix_time()
-	ut2 := t2.unix_time()
+	ut1 := t1.unix()
+	ut2 := t2.unix()
 	eprintln(' ut1: ${ut1}')
 	eprintln(' ut2: ${ut2}')
 	assert ut2 - ut1 < 2
 	//
-	utm1 := t1.unix_time_milli()
-	utm2 := t2.unix_time_milli()
+	utm1 := t1.unix_milli()
+	utm2 := t2.unix_milli()
 	eprintln('utm1: ${utm1}')
 	eprintln('utm2: ${utm2}')
 	assert (utm1 - ut1 * 1000) < 1000
@@ -381,7 +381,7 @@ fn test_strftime() {
 fn test_add_seconds_to_time() {
 	now_tm := time.now()
 	future_tm := now_tm.add_seconds(60)
-	assert now_tm.unix_time() < future_tm.unix_time()
+	assert now_tm.unix() < future_tm.unix()
 }
 
 fn test_plus_equals_duration() {
@@ -407,6 +407,6 @@ fn test_tm_gmtoff() {
 		C.time(&rawtime) // C.tm{}
 
 		info := C.localtime(&rawtime)
-		assert info.tm_gmtoff == time.now().unix_time() - time.utc().unix_time()
+		assert info.tm_gmtoff == time.now().unix() - time.utc().unix()
 	}
 }

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -172,7 +172,13 @@ fn win_utc() Time {
 }
 
 // unix_time returns Unix time.
+@[deprecated: 'use `st.unix()` instead']
 fn (st SystemTime) unix_time() i64 {
+	return st.unix()
+}
+
+// unix returns Unix time.
+fn (st SystemTime) unix() i64 {
 	tt := C.tm{
 		tm_sec: st.second
 		tm_min: st.minute

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -120,7 +120,7 @@ pub fn (t Time) local() Time {
 		minute: st_local.minute
 		second: st_local.second // These are the same
 		nanosecond: int(st_local.millisecond) * 1_000_000
-		unix: st_local.unix_time()
+		unix: st_local.unix()
 	}
 	return t_local
 }
@@ -143,7 +143,7 @@ fn win_now() Time {
 		minute: st_local.minute
 		second: st_local.second
 		nanosecond: int(st_local.millisecond) * 1_000_000
-		unix: st_local.unix_time()
+		unix: st_local.unix()
 		is_local: true
 	}
 	return t
@@ -165,7 +165,7 @@ fn win_utc() Time {
 		minute: st_utc.minute
 		second: st_utc.second
 		nanosecond: int(st_utc.millisecond) * 1_000_000
-		unix: st_utc.unix_time()
+		unix: st_utc.unix()
 		is_local: false
 	}
 	return t

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1625,7 +1625,13 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		is_used_outside := sym.mod != c.mod
 		if is_used_outside && !field.is_pub && sym.language != .c {
 			unwrapped_sym := c.table.sym(c.unwrap_generic(typ))
-			c.error('field `${unwrapped_sym.name}.${field_name}` is not public', node.pos)
+			if unwrapped_sym.kind == .struct_ && unwrapped_sym.name == 'time.Time' {
+				c.add_error_detail('this will become an error after 2024-05-31')
+				c.warn('field `${unwrapped_sym.name}.${field_name}` is not public, use `${node.expr}.unix()` instead',
+					node.pos)
+			} else {
+				c.error('field `${unwrapped_sym.name}.${field_name}` is not public', node.pos)
+			}
 		}
 		field_sym := c.table.sym(field.typ)
 		if field.is_deprecated && is_used_outside {

--- a/vlib/v/checker/tests/import_duplicate_err.out
+++ b/vlib/v/checker/tests/import_duplicate_err.out
@@ -3,4 +3,4 @@ vlib/v/checker/tests/import_duplicate_err.vv:2:8: error: `time` was already impo
     2 | import time
       |        ~~~~
     3 | fn main() {
-    4 |     println(time.now().unix_time())
+    4 |     println(time.now().unix())

--- a/vlib/v/checker/tests/import_duplicate_err.vv
+++ b/vlib/v/checker/tests/import_duplicate_err.vv
@@ -1,5 +1,5 @@
 import time
 import time
 fn main() {
-	println(time.now().unix_time())
+	println(time.now().unix())
 }

--- a/vlib/v/checker/tests/import_multiple_modules_err.out
+++ b/vlib/v/checker/tests/import_multiple_modules_err.out
@@ -2,4 +2,4 @@ vlib/v/checker/tests/import_multiple_modules_err.vv:1:13: error: cannot import m
     1 | import time math
       |             ~~~~
     2 | fn main() {
-    3 |     println(time.now().unix_time())
+    3 |     println(time.now().unix())

--- a/vlib/v/checker/tests/import_multiple_modules_err.vv
+++ b/vlib/v/checker/tests/import_multiple_modules_err.vv
@@ -1,4 +1,4 @@
 import time math
 fn main() {
-	println(time.now().unix_time())
+	println(time.now().unix())
 }

--- a/vlib/v/preludes/test_runner_teamcity.v
+++ b/vlib/v/preludes/test_runner_teamcity.v
@@ -153,7 +153,7 @@ fn (mut runner TeamcityTestRunner) fn_error(line_nr int, file string, mod string
 }
 
 fn (mut runner TeamcityTestRunner) test_duration() i64 {
-	return time.now().unix_time_milli() - runner.start_time.unix_time_milli()
+	return time.now().unix_milli() - runner.start_time.unix_milli()
 }
 
 // print_service prepare and prints a Teamcity service message.

--- a/vlib/v/slow_tests/repl/import.repl
+++ b/vlib/v/slow_tests/repl/import.repl
@@ -1,4 +1,4 @@
 import time
-time.now().unix_time() > 160000
+time.now().unix() > 160000
 ===output===
 true

--- a/vlib/v/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
+++ b/vlib/v/tests/fn_expecting_ref_but_returning_struct_time_module_test.v
@@ -3,7 +3,7 @@ import time.misc as tmisc
 // using a manual temporary intermediate variable should always work:
 fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manual() {
 	t1 := tmisc.random()
-	t2 := t1.unix_time()
+	t2 := t1.unix()
 	println('res: ${t2}')
 	assert true
 }
@@ -12,7 +12,7 @@ fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_manu
 // TODO: Fix this.
 // v should produce temporary intermediate variables in chained calls:
 fn test_call_fn_that_requires_reference_with_function_that_returns_a_struct_chained() {
-	res := (tmisc.random().unix_time())
+	res := (tmisc.random().unix())
 	println('res: $res')
 	assert true
 }

--- a/vlib/v/tests/module_test.v
+++ b/vlib/v/tests/module_test.v
@@ -22,7 +22,7 @@ fn test_import() {
 	assert math.pi == math.pi
 	assert sha512.size == sha512.size
 	assert sum('module'.bytes()).hex() == sum('module'.bytes()).hex()
-	assert utc().unix_time() == utc().unix_time()
+	assert utc().unix() == utc().unix()
 }
 
 fn test_imports_array_as_fn_arg() {

--- a/vlib/vweb/assets/assets.v
+++ b/vlib/vweb/assets/assets.v
@@ -131,8 +131,8 @@ fn (am AssetManager) get_cache_key(asset_type string) string {
 	mut latest_modified := i64(0)
 	for asset in am.get_assets(asset_type) {
 		files_salt += asset.file_path
-		if asset.last_modified.unix > latest_modified {
-			latest_modified = asset.last_modified.unix
+		if asset.last_modified.unix() > latest_modified {
+			latest_modified = asset.last_modified.unix()
 		}
 	}
 	hash := md5.sum(files_salt.bytes()).hex()

--- a/vlib/vweb/csrf/csrf.v
+++ b/vlib/vweb/csrf/csrf.v
@@ -75,8 +75,8 @@ pub fn set_token(mut ctx vweb.Context, config &CsrfConfig) string {
 	expire_time := time.now().add_seconds(config.max_age)
 	session_id := ctx.get_cookie(config.session_cookie) or { '' }
 
-	token := generate_token(expire_time.unix_time(), session_id, config.nonce_length)
-	cookie := generate_cookie(expire_time.unix_time(), token, config.secret)
+	token := generate_token(expire_time.unix(), session_id, config.nonce_length)
+	cookie := generate_cookie(expire_time.unix(), token, config.secret)
 
 	// the hmac key is set as a cookie and later validated with `app.token` that must
 	// be in an html form
@@ -126,7 +126,7 @@ pub fn protect(mut ctx vweb.Context, config &CsrfConfig) bool {
 	// check the timestamp from the csrftoken against the current time
 	// if an attacker would change the timestamp on the cookie, the token or both the
 	// hmac would also change.
-	now := time.now().unix_time()
+	now := time.now().unix()
 	expire_timestamp := data[0].i64()
 	if expire_timestamp < now {
 		// token has expired

--- a/vlib/x/json2/decoder2/tests/decode_struct_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_struct_test.v
@@ -65,7 +65,7 @@ fn test_types() {
 	assert json.decode[StructType[time.Time]]('{"val": "2022-03-11T13:54:25.000Z"}')!.val.hour == fixed_time.hour
 	assert json.decode[StructType[time.Time]]('{"val": "2022-03-11T13:54:25.000Z"}')!.val.minute == fixed_time.minute
 	assert json.decode[StructType[time.Time]]('{"val": "2022-03-11T13:54:25.000Z"}')!.val.second == fixed_time.second
-	assert json.decode[StructType[time.Time]]('{"val": "2022-03-11T13:54:25.000Z"}')!.val.unix == fixed_time.unix
+	assert json.decode[StructType[time.Time]]('{"val": "2022-03-11T13:54:25.000Z"}')!.val.unix() == fixed_time.unix()
 }
 
 fn test_option_types() {

--- a/vlib/x/json2/tests/json_module_compatibility_test/json_test.v
+++ b/vlib/x/json2/tests/json_module_compatibility_test/json_test.v
@@ -91,7 +91,7 @@ fn test_parse_user() {
 fn test_encode_decode_time() {
 	user := User2{
 		age: 25
-		reg_date: time.new_time(year: 2020, month: 12, day: 22, hour: 7, minute: 23)
+		reg_date: time.new(year: 2020, month: 12, day: 22, hour: 7, minute: 23)
 	}
 	s := json.encode(user)
 

--- a/vlib/x/json2/tests/json_module_compatibility_test/json_todo_test.vv
+++ b/vlib/x/json2/tests/json_module_compatibility_test/json_todo_test.vv
@@ -69,14 +69,14 @@ struct SomeGame {
 
 //! BUGFIX - .from_json(res)
 fn test_encode_decode_sumtype() {
-	enc := '{"title":"Super Mega Game","player":{"name":"Monke","_type":"Human"},"other":[{"tag":"Pen","_type":"Item"},{"tag":"Cookie","_type":"Item"},1,"Stool",{"_type":"Time","value":${t.unix_time()}}]}'
+	enc := '{"title":"Super Mega Game","player":{"name":"Monke","_type":"Human"},"other":[{"tag":"Pen","_type":"Item"},{"tag":"Cookie","_type":"Item"},1,"Stool",{"_type":"Time","value":${t.unix()}}]}'
 
 	dec := json.decode[SomeGame](enc)!
 
 	assert game.title == dec.title
 	assert game.player == dec.player
 	assert (game.other[2] as Animal) == (dec.other[2] as Animal)
-	assert (game.other[4] as time.Time).unix_time() == (dec.other[4] as time.Time).unix_time()
+	assert (game.other[4] as time.Time).unix() == (dec.other[4] as time.Time).unix()
 }
 
 struct User2 {
@@ -116,7 +116,7 @@ fn test_parse_user() {
 fn test_encode_decode_time() {
 	user := User2{
 		age: 25
-		reg_date: time.new_time(year: 2020, month: 12, day: 22, hour: 7, minute: 23)
+		reg_date: time.new(year: 2020, month: 12, day: 22, hour: 7, minute: 23)
 	}
 	s := json.encode(user)
 	assert s.contains('"reg_date":1608621780')

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -1119,5 +1119,5 @@ fn (mut tm DynamicTemplateManager) handle_dtm_clock() {
 // This function is designed for handling timezone adjustments by converting the machine's local time at micro format to a universal micro format.
 //
 fn get_current_unix_micro_timestamp() i64 {
-	return time.now().unix_time_micro()
+	return time.now().unix_micro()
 }

--- a/vlib/x/vweb/csrf/csrf.v
+++ b/vlib/x/vweb/csrf/csrf.v
@@ -93,8 +93,8 @@ pub fn set_token(mut ctx vweb.Context, config &CsrfConfig) string {
 	expire_time := time.now().add_seconds(config.max_age)
 	session_id := ctx.get_cookie(config.session_cookie) or { '' }
 
-	token := generate_token(expire_time.unix_time(), session_id, config.nonce_length)
-	cookie := generate_cookie(expire_time.unix_time(), token, config.secret)
+	token := generate_token(expire_time.unix(), session_id, config.nonce_length)
+	cookie := generate_cookie(expire_time.unix(), token, config.secret)
 
 	// the hmac key is set as a cookie and later validated with `app.token` that must
 	// be in an html form
@@ -145,7 +145,7 @@ pub fn protect(mut ctx vweb.Context, config &CsrfConfig) bool {
 	// check the timestamp from the csrftoken against the current time
 	// if an attacker would change the timestamp on the cookie, the token or both the
 	// hmac would also change.
-	now := time.now().unix_time()
+	now := time.now().unix()
 	expire_timestamp := data[0].i64()
 	if expire_timestamp < now {
 		// token has expired


### PR DESCRIPTION
The PR fixes issues like #17162 and #17311

The fix does NOT add the `@[noinit]` attribute to the Time struct, as doing so would break its use in other structs, such as:

```v
struct Foo {
	t time.Time
}

foo := Foo{} // would not be possible anymore if Time is turned into a noinit struct
```

- The problem is fixed by ensuing explicitness - while still keeping the possibility the to create Time structs. 

  Only the `unix` field is turned into a private field. Not being able to init it with other fields resolves their interferes. Accessing and explicitly setting the `unix` field is possible via `unix()` function and method. This approach should provide a better predictable result and more general flexibility in comparison to a `@[noinit]` solution.

- The next change is making sure that the unix time is present or calculated when a time is used.  

- Unix methods have been updated in the go spirit. Former methods have been deprecatd.
  ```
  `unix_time` -> `unix`
  `unix_time_milli` -> `unix_milli`
  ```
  
While initially planned making it into a `v fmt` autofix, types of selector expressions are not parsed and not accessible via vfmt. Therefore I'm making the access of a `.unix` file into a checker warning, informing that it'll become an error and recommending to use `unix()` instead.

ref. https://discord.com/channels/592103645835821068/592320321995014154/1229503437029380107
