### PR TITLE
vdoc: cleanup `vdoc_file_test.v`

### DIFF
--- a/cmd/tools/vdoc/tests/vdoc_file_test.v
+++ b/cmd/tools/vdoc/tests/vdoc_file_test.v
@@ -9,13 +9,37 @@ const vexe = os.quoted_path(vexe_path)
 const vroot = os.dir(vexe_path)
 const should_autofix = os.getenv('VAUTOFIX') != ''
 
-fn test_vet() {
+fn test_output() {
 	os.setenv('VCOLORS', 'never', true)
 	os.chdir(vroot)!
-	test_dir := 'cmd/tools/vdoc/tests/testdata'
-	main_files := get_main_files_in_dir(test_dir)
-	fails := check_path(test_dir, main_files)
-	assert fails == 0
+	mut total_fails := 0
+	test_files := vtest.filter_vtest_only(os.walk_ext('cmd/tools/vdoc/tests/testdata',
+		'.v'), basepath: vroot)
+	for path in test_files {
+		mut fails := 0
+		qpath := os.quoted_path(path)
+		path_no_ext := path.all_before_last('.')
+		print(path + ' ')
+		fails += check_output('${vexe} doc ${qpath}', path_no_ext + '.out')
+		fails += check_output('${vexe} doc -comments ${qpath}', '${path_no_ext}.unsorted.out',
+			should_sort: false
+		)
+		fails += check_output('${vexe} doc -comments ${qpath}', '${path_no_ext}.comments.out')
+		fails += check_output('${vexe} doc -readme -comments ${qpath}', '${path_no_ext}.readme.comments.out')
+		// test the main 3 different formats:
+		program_dir := os.quoted_path(if os.is_dir(path) { path } else { os.dir(path) })
+		for fmt in ['html', 'ansi', 'text'] {
+			fails += check_output('${vexe} doc -f ${fmt} -o - -html-only-contents -readme -comments ${program_dir}',
+				'${path_no_ext}.${fmt}')
+		}
+		if fails == 0 {
+			println(term.green('OK'))
+		} else {
+			total_fails += fails
+		}
+		flush_stdout()
+	}
+	assert total_fails == 0
 }
 
 fn test_run_examples_good() {
@@ -81,44 +105,6 @@ fn test_out_path() {
 	assert os.exists(os.join_path(out_dir, '${mod}.html'))
 }
 
-fn get_main_files_in_dir(dir string) []string {
-	mut mfiles := os.walk_ext(dir, '.v')
-	mfiles.sort()
-	return mfiles
-}
-
-fn check_path(dir string, tests []string) int {
-	mut total_fails := 0
-	paths := vtest.filter_vtest_only(tests, basepath: vroot)
-	for path in paths {
-		mut fails := 0
-		qpath := os.quoted_path(path)
-		path_no_ext := path.all_before_last('.')
-		print(path + ' ')
-		fails += check_output('${vexe} doc ${qpath}', path_no_ext + '.out')
-		fails += check_output('${vexe} doc -comments ${qpath}', '${path_no_ext}.unsorted.out',
-			should_sort: false
-		)
-		fails += check_output('${vexe} doc -comments ${qpath}', '${path_no_ext}.comments.out')
-		fails += check_output('${vexe} doc -readme -comments ${qpath}', '${path_no_ext}.readme.comments.out')
-		// test the main 3 different formats:
-		program_dir := os.quoted_path(if os.is_file(path) { os.dir(path) } else { path })
-		fails += check_output('${vexe} doc -f html -o - -html-only-contents -readme -comments ${program_dir}',
-			'${path_no_ext}.html')
-		fails += check_output('${vexe} doc -f ansi -o - -html-only-contents -readme -comments ${program_dir}',
-			'${path_no_ext}.ansi')
-		fails += check_output('${vexe} doc -f text -o - -html-only-contents -readme -comments ${program_dir}',
-			'${path_no_ext}.text')
-		//
-		total_fails += fails
-		if fails == 0 {
-			println(term.green('OK'))
-		}
-		flush_stdout()
-	}
-	return total_fails
-}
-
 fn print_compare(expected string, found string) {
 	diff_cmd := diff.find_working_diff_command() or { return }
 	println(term.red('FAIL'))
@@ -134,15 +120,6 @@ fn print_compare(expected string, found string) {
 	println('============\n')
 }
 
-fn clean_line_endings(s string) string {
-	mut res := s.trim_space()
-	res = res.replace(' \n', '\n')
-	res = res.replace(' \r\n', '\n')
-	res = res.replace('\r\n', '\n')
-	res = res.trim('\n')
-	return res
-}
-
 @[params]
 struct CheckOutputParams {
 	should_sort bool = true
@@ -153,16 +130,10 @@ fn check_output(cmd string, out_path string, opts CheckOutputParams) int {
 		return 0
 	}
 	mut fails := 0
-	mut expected := os.read_file(out_path) or { panic(err) }
-	expected = clean_line_endings(expected)
-
 	os.setenv('VDOC_SORT', opts.should_sort.str(), true)
-	res := os.execute(cmd)
-
-	if res.exit_code < 0 {
-		panic(res.output)
-	}
-	found := clean_line_endings(res.output)
+	expected := os.read_file(out_path) or { panic(err) }.replace('\r\n', '\n').trim_space()
+	res := os.execute_opt(cmd) or { panic(err) }
+	found := res.output.replace('\r\n', '\n').trim_space()
 	if expected != found {
 		print_compare(expected, found)
 		eprintln('>>>           cmd: VDOC_SORT=${opts.should_sort} ${cmd}')


### PR DESCRIPTION
Clarifies things to simplify maintaining and extending the doc tests. 
Initially, part of #21281 but was ultimately omitted for a simpler diff. 
Now, I'm submitting it separately from an update/fix that includes adding new tests.