### PR TITLE
vlib: refactor empty string checks

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -316,7 +316,7 @@ fn auto_complete(args []string) {
 	if args.len <= 1 || args[0] != 'complete' {
 		if args.len == 1 {
 			shell_path := os.getenv('SHELL')
-			if shell_path.len > 0 {
+			if shell_path != '' {
 				shell_name := os.file_name(shell_path).to_lower()
 				if shell_name in auto_complete_shells {
 					println(setup_for_shell(shell_name))

--- a/cmd/tools/vdoc/files.v
+++ b/cmd/tools/vdoc/files.v
@@ -27,7 +27,7 @@ fn get_ignore_paths(path string) ![]string {
 }
 
 fn is_included(path string, ignore_paths []string) bool {
-	if path.len == 0 {
+	if path == '' {
 		return true
 	}
 	for ignore_path in ignore_paths {

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -317,7 +317,7 @@ ${tabs(2)}<script src="${vd.assets['dark_mode_js']}"></script>'
 
 fn get_src_link(repo_url string, file_name string, line_nr int) string {
 	mut url := urllib.parse(repo_url) or { return '' }
-	if url.path.len <= 1 || file_name.len == 0 {
+	if url.path.len <= 1 || file_name == '' {
 		return ''
 	}
 	url.path = url.path.trim_right('/') + match url.host {
@@ -530,7 +530,7 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 		hash_link = ' <a href="#${node_id}">#</a>'
 	}
 	dnw.writeln('${tabs(2)}<section id="${node_id}" class="doc-node${node_class}">')
-	if dn.name.len > 0 {
+	if dn.name != '' {
 		if dn.kind == .const_group {
 			dnw.write_string('${tabs(3)}<div class="title"><${head_tag}>${sym_name}${hash_link}</${head_tag}>')
 		} else {
@@ -571,7 +571,7 @@ fn doc_node_html(dn doc.DocNode, link string, head bool, include_examples bool, 
 }
 
 fn write_toc(dn doc.DocNode, mut toc strings.Builder) {
-	mut toc_slug := if dn.name.len == 0 || dn.content.len == 0 { '' } else { slug(dn.name) }
+	mut toc_slug := if dn.name == '' || dn.content.len == 0 { '' } else { slug(dn.name) }
 	if toc_slug == '' && dn.children.len > 0 {
 		if dn.children[0].name == '' {
 			toc_slug = slug(dn.name)

--- a/cmd/tools/vdoc/main.v
+++ b/cmd/tools/vdoc/main.v
@@ -49,7 +49,7 @@ fn main() {
 	}
 	args := os.args[2..].clone()
 	cfg := parse_arguments(args)
-	if cfg.input_path.len == 0 {
+	if cfg.input_path == '' {
 		eprintln('vdoc: No input path found.')
 		exit(1)
 	}
@@ -172,7 +172,7 @@ fn parse_arguments(args []string) Config {
 				cfg.is_verbose = true
 			}
 			else {
-				if cfg.input_path.len < 1 {
+				if cfg.input_path == '' {
 					cfg.input_path = arg
 				} else if !cfg.is_multi {
 					// Symbol name filtering should not be enabled

--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -29,7 +29,7 @@ fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {
 fn (vd VDoc) write_markdown_content(contents []doc.DocNode, mut cw strings.Builder, mut hw strings.Builder, indent int, with_toc bool) {
 	cfg := vd.cfg
 	for cn in contents {
-		if with_toc && cn.name.len > 0 {
+		if with_toc && cn.name != '' {
 			hw.writeln(' '.repeat(2 * indent) + '- [${slug(cn.name)}](#${cn.name})')
 			cw.writeln('## ${cn.name}')
 		}

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -260,7 +260,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		path: cfg.output_path
 		typ: cfg.output_type
 	}
-	if out.path.len == 0 {
+	if out.path == '' {
 		if cfg.output_type == .unset {
 			out.typ = .ansi
 		} else {
@@ -348,7 +348,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		exit(1)
 	}
 	vd.vprintln('Rendering docs...')
-	if out.path.len == 0 || out.path == 'stdout' || out.path == '-' {
+	if out.path == '' || out.path == 'stdout' || out.path == '-' {
 		if out.typ == .html {
 			vd.render_static_html(out)
 		}

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -214,7 +214,7 @@ fn (mut foptions FormatOptions) find_diff_cmd() string {
 }
 
 fn (mut foptions FormatOptions) post_process_file(file string, formatted_file_path string) ! {
-	if formatted_file_path.len == 0 {
+	if formatted_file_path == '' {
 		return
 	}
 	fc := os.read_file(file) or {

--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -299,7 +299,7 @@ fn (upd VlsUpdater) find_ls_path() !string {
 	if 'server_path' in manifest {
 		server_path := manifest['server_path'] or { return error('none') }
 		if server_path is string {
-			if server_path.len == 0 {
+			if server_path == '' {
 				return error('none')
 			}
 
@@ -361,7 +361,7 @@ fn (mut upd VlsUpdater) parse(mut fp flag.FlagParser) ! {
 	}
 
 	if upd.pass_to_ls {
-		if upd.ls_path.len == 0 {
+		if upd.ls_path == '' {
 			if ls_path := upd.find_ls_path() {
 				if !upd.is_force && upd.setup_kind == .install {
 					return error_with_code('VLS was already installed.', 102)
@@ -445,7 +445,7 @@ fn (upd VlsUpdater) cli_error(err IError) {
 }
 
 fn (upd VlsUpdater) check_installation() {
-	if upd.ls_path.len == 0 {
+	if upd.ls_path == '' {
 		upd.log('Language server is not installed')
 	} else {
 		upd.log('Language server is installed at: ${upd.ls_path}'.split(r'\').join(r'\\'))

--- a/cmd/tools/vwhere/finder_utils.v
+++ b/cmd/tools/vwhere/finder_utils.v
@@ -143,7 +143,7 @@ fn maybe_color(term_color fn (string) string, str string) string {
 }
 
 fn collect_v_files(path string, recursive bool) ![]string {
-	if path.len == 0 {
+	if path == '' {
 		return error('path cannot be empty')
 	}
 	if !os.is_dir(path) {

--- a/examples/vcasino/vcasino.v
+++ b/examples/vcasino/vcasino.v
@@ -47,7 +47,7 @@ fn get_bet_nbr() int {
 		println('Reminder: odd numbers are red and even are black.')
 		println('Type the number you want to bet on (between 0 and 49):')
 		line := os.get_line().trim_space()
-		if line.len < 1 {
+		if line == '' {
 			println('error: empty line.')
 			continue
 		}
@@ -70,7 +70,7 @@ fn get_bet(money int) int {
 	for bet <= 0 || bet > money {
 		println('You have ${money} V. Type in the amount of your bet:')
 		line := os.get_line().trim_space()
-		if line.len < 1 {
+		if line == '' {
 			println('error: empty line.')
 			continue
 		}

--- a/examples/viewer/file_scan.v
+++ b/examples/viewer/file_scan.v
@@ -139,7 +139,7 @@ fn (item_list Item_list) get_file_path() string {
 	if item_list.lst.len <= 0 || item_list.n_item <= 0 {
 		return ''
 	}
-	if item_list.lst[item_list.item_index].path.len > 0 {
+	if item_list.lst[item_list.item_index].path != '' {
 		return '${item_list.lst[item_list.item_index].path}${item_list.path_sep}${item_list.lst[item_list.item_index].name}'
 	}
 	return item_list.lst[item_list.item_index].name

--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -296,7 +296,7 @@ pub fn load_image(mut app App) {
 	}
 
 	file_path := app.item_list.get_file_path()
-	if file_path.len > 0 {
+	if file_path != '' {
 		// println("${app.item_list.lst[app.item_list.item_index]} $file_path ${app.item_list.lst.len}")
 		app.texture, app.sampler, app.img_w, app.img_h = app.load_texture_from_file(file_path)
 		app.img_ratio = f32(app.img_w) / f32(app.img_h)

--- a/examples/xvweb/todo/main.v
+++ b/examples/xvweb/todo/main.v
@@ -50,7 +50,7 @@ pub fn (app &App) create_todo(mut ctx Context, name string) vweb.Result {
 	// we could also access the name field by doing `name := ctx.form['name']`
 
 	// validate input field
-	if name.len == 0 {
+	if name == '' {
 		// set a form error
 		ctx.form_error = 'You must fill in all the fields!'
 		// send a HTTP 400 response code indicating that the form fields are incorrect

--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -287,7 +287,7 @@ pub fn (s string) u8() u64 {
 // Example: assert ' Hello V d'.trim_right(' d') == ' Hello V'
 @[direct_array_access]
 pub fn (s string) trim_right(cutset string) string {
-	if s.len < 1 || cutset.len < 1 {
+	if s == '' || cutset == '' {
 		return s.clone()
 	}
 
@@ -317,7 +317,7 @@ pub fn (s string) trim_right(cutset string) string {
 // Example: assert 'd Hello V developer'.trim_left(' d') == 'Hello V developer'
 @[direct_array_access]
 pub fn (s string) trim_left(cutset string) string {
-	if s.len < 1 || cutset.len < 1 {
+	if s == '' || cutset == '' {
 		return s.clone()
 	}
 	mut pos := 0
@@ -924,7 +924,7 @@ pub fn (s string) reverse() string {
 }
 
 pub fn (s string) trim(cutset string) string {
-	if s.len < 1 || cutset.len < 1 {
+	if s == '' || cutset == '' {
 		return s.clone()
 	}
 	mut pos_left := 0

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1678,7 +1678,7 @@ pub fn (s string) trim_space() string {
 // trim strips any of the characters given in `cutset` from the start and end of the string.
 // Example: assert ' ffHello V ffff'.trim(' f') == 'Hello V'
 pub fn (s string) trim(cutset string) string {
-	if s.len < 1 || cutset.len < 1 {
+	if s == '' || cutset == '' {
 		return s.clone()
 	}
 	left, right := s.trim_indexes(cutset)
@@ -1719,7 +1719,7 @@ pub fn (s string) trim_indexes(cutset string) (int, int) {
 // Example: assert 'd Hello V developer'.trim_left(' d') == 'Hello V developer'
 @[direct_array_access]
 pub fn (s string) trim_left(cutset string) string {
-	if s.len < 1 || cutset.len < 1 {
+	if s == '' || cutset == '' {
 		return s.clone()
 	}
 	mut pos := 0

--- a/vlib/compress/szip/szip.c.v
+++ b/vlib/compress/szip/szip.c.v
@@ -95,7 +95,7 @@ fn (om OpenMode) to_u8() u8 {
 // level: can be any value of the CompressionLevel enum.
 // mode: can be any value of the OpenMode enum.
 pub fn open(name string, level CompressionLevel, mode OpenMode) !&Zip {
-	if name.len == 0 {
+	if name == '' {
 		return error('szip: name of file empty')
 	}
 	p_zip := unsafe { &Zip(C.zip_open(&char(name.str), int(level), char(mode.to_u8()))) }

--- a/vlib/dl/loader/loader.v
+++ b/vlib/dl/loader/loader.v
@@ -68,7 +68,7 @@ pub:
 fn new_dynamic_lib_loader(conf DynamicLibLoaderConfig) !&DynamicLibLoader {
 	mut paths := []string{}
 
-	if conf.env_path.len > 0 {
+	if conf.env_path != '' {
 		if env_path := os.getenv_opt(conf.env_path) {
 			paths << env_path.split(os.path_delimiter)
 		}

--- a/vlib/encoding/xml/parser.v
+++ b/vlib/encoding/xml/parser.v
@@ -179,7 +179,7 @@ fn parse_entity(contents string) !(DTDEntity, string) {
 	entity_contents := contents[xml.entity_len..entity_end]
 
 	name := entity_contents.trim_left(' \t\n').all_before(' ')
-	if name.len == 0 {
+	if name == '' {
 		return error('Entity is missing name.')
 	}
 	value := entity_contents.all_after_first(name).trim_space().trim('"\'')
@@ -221,7 +221,7 @@ fn parse_element(contents string) !(DTDElement, string) {
 	}
 
 	name := element_contents[name_span.start..name_span.end].trim_left(' \t\n')
-	if name.len == 0 {
+	if name == '' {
 		return error('Element is missing name.')
 	}
 	definition_string := element_contents.all_after_first(name).trim_space().trim('"\'')

--- a/vlib/encoding/xml/validation.v
+++ b/vlib/encoding/xml/validation.v
@@ -75,7 +75,7 @@ pub fn (doc XMLDocument) validate() !XMLDocument {
 			new_root := doc.root.validate(elements, entities)!
 
 			// Check the DOCTYPE name matches the root name
-			if doc.doctype.name.len > 0 && doc.doctype.name != new_root.name {
+			if doc.doctype.name != '' && doc.doctype.name != new_root.name {
 				return error('Root element ${new_root.name} does not match DOCTYPE ${doc.doctype.name}')
 			}
 

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -36,7 +36,7 @@ fn (mut dom DocumentObjectModel) print_debug(data string) {
 
 @[inline]
 fn is_close_tag(tag &Tag) bool {
-	return tag.name.len > 0 && tag.name[0] == `/`
+	return tag.name != '' && tag.name[0] == `/`
 }
 
 fn (mut dom DocumentObjectModel) where_is(item_name string, attribute_name string) int {
@@ -138,7 +138,7 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 				stack.push(root_index)
 			}
 			dom.print_debug('Removed ' + temp_string + ' -- ' + tag_list[temp_int].name)
-		} else if tag.name.len > 0 {
+		} else if tag.name != '' {
 			dom.add_tag_attribute(tag) // error here
 			dom.add_tag_by_attribute(tag)
 			dom.add_tag_by_type(tag)

--- a/vlib/net/html/parser.v
+++ b/vlib/net/html/parser.v
@@ -100,7 +100,7 @@ fn (mut parser Parser) generate_tag() {
 	if parser.lexical_attributes.open_tag {
 		return
 	}
-	if parser.lexical_attributes.current_tag.name.len > 0
+	if parser.lexical_attributes.current_tag.name != ''
 		|| parser.lexical_attributes.current_tag.content.len > 0 {
 		parser.tags << parser.lexical_attributes.current_tag
 	}

--- a/vlib/net/html/tag.v
+++ b/vlib/net/html/tag.v
@@ -52,7 +52,7 @@ pub fn (tag &Tag) str() string {
 	html_str.write_string('<${tag.name}')
 	for key, value in tag.attributes {
 		html_str.write_string(' ${key}')
-		if value.len > 0 {
+		if value != '' {
 			html_str.write_string('="${value}"')
 		}
 	}

--- a/vlib/net/http/file/folder_index.v
+++ b/vlib/net/http/file/folder_index.v
@@ -60,7 +60,7 @@ fn write_page_table(mut sb strings.Builder, uri_path string, requested_file_path
 	sb.writeln('<th align="left" style="width: 200px">Last modified</th>')
 	sb.writeln('<th align="left">Name</th>')
 	sb.writeln('</tr>')
-	if uri_path.len == 0 {
+	if uri_path == '' {
 		sb.writeln('<tr>')
 		sb.writeln('<td>---</td>')
 		sb.writeln('<td>---</td>')

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -17,7 +17,7 @@ fn test_http_get_from_vlang_utc_now() {
 		println('Test getting current time from ${url} by http.get')
 		res := http.get(url) or { panic(err) }
 		assert res.status() == .ok
-		assert res.body.len > 0
+		assert res.body != ''
 		assert res.body.int() > 1566403696
 		println('Current time is: ${res.body.int()}')
 	}
@@ -39,7 +39,7 @@ fn test_public_servers() {
 		println('Testing http.get on public url: ${url} ')
 		res := http.get(url) or { panic(err) }
 		assert res.status() == .ok
-		assert res.body.len > 0
+		assert res.body != ''
 	}
 }
 
@@ -51,6 +51,6 @@ fn test_relative_redirects() {
 	} // tempfix periodic: httpbin relative redirects are broken
 	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
 	assert res.status() == .ok
-	assert res.body.len > 0
+	assert res.body != ''
 	assert res.body.contains('"abc": "xyz"')
 }

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -131,7 +131,7 @@ pub fn new_response(conf ResponseConfig) Response {
 		body: conf.body
 		header: conf.header
 	}
-	if resp.body.len > 0 && !resp.header.contains(.content_length) {
+	if resp.body != '' && !resp.header.contains(.content_length) {
 		resp.header.add(.content_length, resp.body.len.str())
 	}
 	resp.set_status(conf.status)

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -18,7 +18,7 @@ const dot_str = '.'
 
 // is_abs_path returns `true` if the given `path` is absolute.
 pub fn is_abs_path(path string) bool {
-	if path.len == 0 {
+	if path == '' {
 		return false
 	}
 	$if windows {
@@ -32,7 +32,7 @@ pub fn is_abs_path(path string) bool {
 // and returns the absolute path representation.
 pub fn abs_path(path string) string {
 	wd := getwd()
-	if path.len == 0 {
+	if path == '' {
 		return wd
 	}
 	npath := norm_path(path)
@@ -57,7 +57,7 @@ pub fn abs_path(path string) string {
 // - the last path separator
 @[direct_array_access]
 pub fn norm_path(path string) string {
-	if path.len == 0 {
+	if path == '' {
 		return os.dot_str
 	}
 	rooted := is_abs_path(path)
@@ -69,7 +69,7 @@ pub fn norm_path(path string) string {
 		volume = volume.replace(os.fslash_str, path_separator)
 	}
 	cpath := clean_path(path[volume_len..])
-	if cpath.len == 0 && volume_len == 0 {
+	if cpath == '' && volume_len == 0 {
 		return os.dot_str
 	}
 	spath := cpath.split(path_separator)
@@ -131,7 +131,7 @@ pub fn norm_path(path string) string {
 // An error is returned if there is no existing part of the given `path`.
 pub fn existing_path(path string) !string {
 	err := error('path does not exist')
-	if path.len == 0 {
+	if path == '' {
 		return err
 	}
 	if exists(path) {
@@ -164,7 +164,7 @@ pub fn existing_path(path string) !string {
 				recent_path = curr_path
 				continue
 			}
-			if recent_path.len == 0 {
+			if recent_path == '' {
 				break
 			}
 			return recent_path
@@ -180,7 +180,7 @@ pub fn existing_path(path string) !string {
 // - redundant separators
 // - the last path separator
 fn clean_path(path string) string {
-	if path.len == 0 {
+	if path == '' {
 		return os.empty_str
 	}
 	mut sb := strings.new_builder(path.len)

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -269,7 +269,7 @@ pub fn cp(src string, dst string) ! {
 // Note: os.vfopen is useful for compatibility with C libraries, that expect `FILE *`.
 // If you write pure V code, os.create or os.open are more convenient.
 pub fn vfopen(path string, mode string) !&C.FILE {
-	if path.len == 0 {
+	if path == '' {
 		return error('vfopen called with ""')
 	}
 	mut fp := unsafe { nil }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -62,7 +62,7 @@ fn executable_fallback() string {
 		} else {
 			// no choice but to try to walk the PATH folders :-| ...
 			foundpath := find_abs_path_of_executable(exepath) or { '' }
-			if foundpath.len > 0 {
+			if foundpath != '' {
 				exepath = foundpath
 			}
 		}
@@ -641,7 +641,7 @@ fn impl_walk_ext(path string, ext string, mut out []string) {
 // since it does not recurse, but processes them iteratively.
 // For listing only one level deep, see: `os.ls`
 pub fn walk(path string, f fn (string)) {
-	if path.len == 0 {
+	if path == '' {
 		return
 	}
 	if !is_dir(path) {
@@ -679,7 +679,7 @@ pub type FnWalkContextCB = fn (voidptr, string)
 // since it does not recurse, but processes them iteratively.
 // For listing only one level deep, see: `os.ls`
 pub fn walk_with_context(path string, context voidptr, fcb FnWalkContextCB) {
-	if path.len == 0 {
+	if path == '' {
 		return
 	}
 	if !is_dir(path) {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -296,7 +296,7 @@ fn init_os_args(argc int, argv &&u8) []string {
 //   }
 // ```
 pub fn ls(path string) ![]string {
-	if path.len == 0 {
+	if path == '' {
 		return error('ls() expects a folder, not an empty string')
 	}
 	mut res := []string{cap: 50}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -162,7 +162,7 @@ pub fn utime(path string, actime int, modtime int) ! {
 }
 
 pub fn ls(path string) ![]string {
-	if path.len == 0 {
+	if path == '' {
 		return error('ls() expects a folder, not an empty string')
 	}
 	mut find_file_data := Win32finddata{}

--- a/vlib/picohttpparser/picohttpparser.v
+++ b/vlib/picohttpparser/picohttpparser.v
@@ -53,7 +53,7 @@ fn (mut r Request) phr_parse_request_path(buf_start &u8, buf_end &u8, mut pret P
 		}
 	}
 	// validate
-	if method.len == 0 || path.len == 0 {
+	if method == '' || path == '' {
 		pret.ret = -1
 		pret.err = 'error parsing request: invalid method or path'
 		return
@@ -81,7 +81,7 @@ fn (mut r Request) phr_parse_request_path_pipeline(buf_start &u8, buf_end &u8, m
 		buf += pret.ret
 	}
 	// validate
-	if method.len == 0 || path.len == 0 {
+	if method == '' || path == '' {
 		pret.ret = -1
 		pret.err = 'error parsing request: invalid method or path'
 		return

--- a/vlib/strconv/atoi.v
+++ b/vlib/strconv/atoi.v
@@ -35,7 +35,7 @@ pub fn common_parse_uint(s string, _base int, _bit_size int, error_on_non_digit 
 // the second returned value contains the error code (0 = OK, >1 = index of first non-parseable character + 1, -1 = wrong base, -2 = wrong bit size, -3 = overflow)
 @[direct_array_access]
 pub fn common_parse_uint2(s string, _base int, _bit_size int) (u64, int) {
-	if s.len < 1 {
+	if s == '' {
 		return u64(0), 1
 	}
 
@@ -156,7 +156,7 @@ pub fn parse_uint(s string, _base int, _bit_size int) !u64 {
 // to stop on non or invalid digit characters and return with an error
 @[direct_array_access]
 pub fn common_parse_int(_s string, base int, _bit_size int, error_on_non_digit bool, error_on_high_digit bool) !i64 {
-	if _s.len < 1 {
+	if _s == '' {
 		// return error('parse_int: syntax error $s')
 		return i64(0)
 	}

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -195,7 +195,7 @@ pub fn (mut b Builder) writeln(s string) {
 	// for c in s {
 	// b.buf << c
 	// }
-	if s.len > 0 {
+	if s != '' {
 		unsafe { b.push_many(s.str, s.len) }
 	}
 	// b.buf << []u8(s)  // TODO

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -45,7 +45,7 @@ pub fn (b &Builder) byte_at(n int) u8 {
 }
 
 pub fn (mut b Builder) write_string(s string) {
-	if s.len == 0 {
+	if s == '' {
 		return
 	}
 
@@ -55,7 +55,7 @@ pub fn (mut b Builder) write_string(s string) {
 }
 
 pub fn (mut b Builder) writeln(s string) {
-	if s.len > 0 {
+	if s != '' {
 		b.write_string(s)
 	}
 

--- a/vlib/szip/szip.c.v
+++ b/vlib/szip/szip.c.v
@@ -97,7 +97,7 @@ fn (om OpenMode) to_u8() u8 {
 // level: can be any value of the CompressionLevel enum.
 // mode: can be any value of the OpenMode enum.
 pub fn open(name string, level CompressionLevel, mode OpenMode) !&Zip {
-	if name.len == 0 {
+	if name == '' {
 		return error('szip: name of file empty')
 	}
 	p_zip := unsafe { &Zip(C.zip_open(&char(name.str), int(level), char(mode.to_u8()))) }

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -138,7 +138,7 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 			sig += 'mut '
 		}
 		// Note: arg name is only added for fmt, else it would causes errors with generics
-		if t.is_fmt && arg.name.len > 0 {
+		if t.is_fmt && arg.name != '' {
 			sig += '${arg.name} '
 		}
 		arg_type_sym := t.sym(arg.typ)
@@ -1196,13 +1196,13 @@ pub fn (mut t Table) find_or_register_multi_return(mr_typs []Type) int {
 }
 
 pub fn (mut t Table) find_or_register_fn_type(f Fn, is_anon bool, has_decl bool) int {
-	name := if f.name.len == 0 { 'fn ${t.fn_type_source_signature(f)}' } else { f.name.clone() }
-	cname := if f.name.len == 0 {
+	name := if f.name == '' { 'fn ${t.fn_type_source_signature(f)}' } else { f.name.clone() }
+	cname := if f.name == '' {
 		'anon_fn_${t.fn_type_signature(f)}'
 	} else {
 		util.no_dots(f.name.clone()).replace_each(ast.fn_type_escape_seq)
 	}
-	anon := f.name.len == 0 || is_anon
+	anon := f.name == '' || is_anon
 	existing_idx := t.type_idxs[name]
 	if existing_idx > 0 && t.type_symbols[existing_idx].kind != .placeholder {
 		return existing_idx

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1359,7 +1359,7 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			} else {
 				if res.starts_with('fn (') {
 					// fn foo ()
-					has_names := info.func.params.any(it.name.len > 0)
+					has_names := info.func.params.any(it.name != '')
 					res = t.fn_signature_using_aliases(info.func, import_aliases,
 						type_only: !has_names
 					)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -466,7 +466,7 @@ fn (mut c Checker) check_matching_function_symbols(got_type_sym &ast.TypeSymbol,
 		if exp_arg_is_ptr != got_arg_is_ptr {
 			exp_arg_pointedness := if exp_arg_is_ptr { 'a pointer' } else { 'NOT a pointer' }
 			got_arg_pointedness := if got_arg_is_ptr { 'a pointer' } else { 'NOT a pointer' }
-			if exp_fn.name.len == 0 {
+			if exp_fn.name == '' {
 				c.add_error_detail('expected argument ${i + 1} to be ${exp_arg_pointedness}, but the passed argument ${
 					i + 1} is ${got_arg_pointedness}')
 			} else {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -493,7 +493,7 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 		c.error('anonymous function must declare a body', node.decl.pos)
 	}
 	for param in node.decl.params {
-		if param.name.len == 0 {
+		if param.name == '' {
 			c.error('use `_` to name an unused parameter', param.pos)
 		}
 	}
@@ -1107,7 +1107,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				node.pos)
 		}
 	}
-	if !func.is_pub && func.language == .v && func.name.len > 0 && func.mod.len > 0
+	if !func.is_pub && func.language == .v && func.name != '' && func.mod.len > 0
 		&& func.mod != c.mod && !c.pref.is_test {
 		c.error('function `${func.name}` is private', node.pos)
 	}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -715,8 +715,8 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 
 				// all the fields of initialized embedded struct are ignored, they are considered initialized
 				sym := c.table.sym(init_field.typ)
-				if init_field.name.len > 0 && init_field.name[0].is_capital()
-					&& sym.kind == .struct_ && sym.language == .v {
+				if init_field.name != '' && init_field.name[0].is_capital() && sym.kind == .struct_
+					&& sym.language == .v {
 					struct_fields := c.table.struct_fields(sym)
 					for struct_field in struct_fields {
 						inited_fields << struct_field.name
@@ -770,7 +770,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 					continue
 				}
 				sym := c.table.sym(field.typ)
-				if field.name.len > 0 && field.name[0].is_capital() && sym.info is ast.Struct {
+				if field.name != '' && field.name[0].is_capital() && sym.info is ast.Struct {
 					// struct embeds
 					continue
 				}
@@ -930,7 +930,7 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 			if sym.language == .c {
 				continue
 			}
-			if field.name.len > 0 && field.name[0].is_capital() && sym.language == .v {
+			if field.name != '' && field.name[0].is_capital() && sym.language == .v {
 				// an embedded struct field
 				continue
 			}
@@ -972,7 +972,7 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 			if sym.language == .c {
 				continue
 			}
-			if field.name.len > 0 && field.name[0].is_capital() && sym.language == .v {
+			if field.name != '' && field.name[0].is_capital() && sym.language == .v {
 				// an embedded struct field
 				continue
 			}

--- a/vlib/v/doc/doc.v
+++ b/vlib/v/doc/doc.v
@@ -201,7 +201,7 @@ pub fn (mut d Doc) stmt(mut stmt ast.Stmt, filename string) !DocNode {
 	if node.name.starts_with(d.orig_mod_name + '.') {
 		node.name = node.name.all_after(d.orig_mod_name + '.')
 	}
-	if node.name.len == 0 && node.comments.len == 0 && node.content.len == 0 {
+	if node.name == '' && node.comments.len == 0 && node.content.len == 0 {
 		return error('empty stmt')
 	}
 	match mut stmt {

--- a/vlib/v/gen/js/deep_copy.v
+++ b/vlib/v/gen/js/deep_copy.v
@@ -162,7 +162,7 @@ fn (mut g JsGen) gen_copy_for_struct(info ast.Struct, styp string, copy_fn_name 
 	fn_builder.writeln('\tlet $tmp = new ${styp}({});')
 	for field in info.fields {
 		println(field)
-		if field.name.len == 0 {
+		if field.name == '' {
 
 		} else {
 			mut shall_copy := true

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -11,7 +11,7 @@ import os
 fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 	first_pos := p.tok.pos()
 	mut name := if language == .js { p.check_js_name() } else { p.check_name() }
-	mut is_static_type_method := language == .v && name.len > 0 && name[0].is_capital()
+	mut is_static_type_method := language == .v && name != '' && name[0].is_capital()
 		&& p.tok.kind == .dot
 	if is_static_type_method {
 		p.check(.dot)
@@ -782,7 +782,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 	_, generic_names := p.parse_generic_types()
 	params, _, is_variadic := p.fn_params()
 	for param in params {
-		if param.name.len == 0 && p.table.sym(param.typ).kind != .placeholder {
+		if param.name == '' && p.table.sym(param.typ).kind != .placeholder {
 			p.error_with_pos('use `_` to name an unused parameter', param.pos)
 		}
 		if param.name in inherited_vars_name {
@@ -1004,7 +1004,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 			name := p.check_name()
 			comments << p.eat_comments()
 			mut param_names := [name]
-			if name.len > 0 && p.fn_language == .v && name[0].is_capital() {
+			if name != '' && p.fn_language == .v && name[0].is_capital() {
 				p.error_with_pos('parameter name must not begin with upper case letter (`${param_names[0]}`)',
 					p.prev_tok.pos())
 			}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -320,7 +320,7 @@ fn (mut p Parser) parse_fn_type(name string, generic_types []ast.Type) ast.Type 
 		is_method: false
 		attrs: p.attrs
 	}
-	if has_generic && generic_types.len == 0 && name.len > 0 {
+	if has_generic && generic_types.len == 0 && name != '' {
 		p.error_with_pos('`${name}` type is generic fntype, must specify the generic type names, e.g. ${name}[T]',
 			fn_type_pos)
 	}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2790,9 +2790,8 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// handle the easy cases first, then check for an already known V typename, not shadowed by a local variable
 		if (is_option || p.peek_tok.kind in [.lsbr, .lt, .lpar]) && (is_mod_cast
 			|| is_c_pointer_cast || is_c_type_cast || is_js_cast || is_generic_cast
-			|| (language == .v && name.len > 0 && (name[0].is_capital()
-			|| (!known_var && (name in p.table.type_idxs
-			|| name_w_mod in p.table.type_idxs))
+			|| (language == .v && name != '' && (name[0].is_capital() || (!known_var
+			&& (name in p.table.type_idxs || name_w_mod in p.table.type_idxs))
 			|| name.all_after_last('.')[0].is_capital()))) {
 			// MainLetter(x) is *always* a cast, as long as it is not `C.`
 			// TODO: handle C.stat()
@@ -3393,7 +3392,7 @@ fn (mut p Parser) parse_generic_types() ([]ast.Type, []string) {
 			p.check(.comma)
 		}
 		name := p.tok.lit
-		if name.len > 0 && !name[0].is_capital() {
+		if name != '' && !name[0].is_capital() {
 			p.error('generic parameter needs to be uppercase')
 		}
 		if name.len > 1 {

--- a/vlib/v/tests/results_test.v
+++ b/vlib/v/tests/results_test.v
@@ -75,7 +75,7 @@ fn test_unsafe_return_error() {
 }
 
 fn return_reference_type(path string) !&string {
-	if path.len == 0 {
+	if path == '' {
 		return error('vfopen called with ""')
 	}
 	str := ''

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -350,7 +350,7 @@ pub fn cached_read_source_file(path string) !string {
 	$if trace_cached_read_source_file ? {
 		println('cached_read_source_file            ${path}')
 	}
-	if path.len == 0 {
+	if path == '' {
 		unsafe { cache.sources.free() }
 		unsafe { free(cache) }
 		cache = &SourceCache(unsafe { nil })

--- a/vlib/v2/gen/v/gen.v
+++ b/vlib/v2/gen/v/gen.v
@@ -537,7 +537,7 @@ fn (mut g Gen) expr(expr ast.Expr) {
 		ast.InitExpr {
 			g.expr(expr.typ)
 			// with field names
-			if expr.fields.len > 0 && expr.fields[0].name.len > 0 {
+			if expr.fields.len > 0 && expr.fields[0].name != '' {
 				g.writeln('{')
 				in_init := g.in_init
 				g.in_init = true
@@ -886,7 +886,7 @@ fn (mut g Gen) attributes(attributes []ast.Attribute) {
 			g.write('if ')
 			g.expr(attribute.comptime_cond)
 		} else {
-			if attribute.name.len > 0 {
+			if attribute.name != '' {
 				g.write(attribute.name)
 				g.write(': ')
 			}
@@ -905,7 +905,7 @@ fn (mut g Gen) fn_type(typ ast.FnType) {
 	}
 	g.write('(')
 	for i, param in typ.params {
-		if param.name.len > 0 {
+		if param.name != '' {
 			g.write(param.name)
 			g.write(' ')
 		}

--- a/vlib/v2/types/types.v
+++ b/vlib/v2/types/types.v
@@ -498,7 +498,7 @@ fn (t Enum) name() string {
 fn (t FnType) name() string {
 	mut name := 'fn ('
 	for i, param in t.params {
-		if param.name.len > 0 {
+		if param.name != '' {
 			name += '${param.name} '
 		}
 		name += param.typ.name()

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -1059,7 +1059,7 @@ pub fn (mut ctx Context) mount_static_folder_at(directory_path string, mount_pat
 // and you have a file /var/share/myassets/main.css .
 // => That file will be available at URL: http://localhost/assets/main.css .
 pub fn (mut ctx Context) host_mount_static_folder_at(host string, directory_path string, mount_path string) bool {
-	if ctx.done || mount_path.len < 1 || mount_path[0] != `/` || !os.exists(directory_path) {
+	if ctx.done || mount_path == '' || mount_path[0] != `/` || !os.exists(directory_path) {
 		return false
 	}
 	dir_path := directory_path.trim_right('/')

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -205,7 +205,7 @@ pub fn initialize(dtm_init_params DynamicTemplateManagerInitialisationParams) &D
 	}
 	if active_cache_handler {
 		// Control if cache folder created by user exist
-		if dir_path.len > 0 && os.exists(dir_path) && os.is_dir(dir_path) {
+		if dir_path != '' && os.exists(dir_path) && os.is_dir(dir_path) {
 			// WARNING: When setting the directory for caching files and for testing purposes,
 			// 'check_and_clear_cache_files' function will delete all "*.cache" or "*.tmp" files inside the specified cache directory. Ensure that
 			// directory used for the cache does not contain any important files.

--- a/vlib/x/ttf/text_block.v
+++ b/vlib/x/ttf/text_block.v
@@ -78,7 +78,7 @@ pub fn (mut bmp BitMap) draw_text_block(text string, block Text_block) {
 			for c > 0 {
 				tmp_str := txt1[0..c].join(' ')
 				// println("tmp_str: ${tmp_str}")
-				if tmp_str.len < 1 {
+				if tmp_str == '' {
 					break
 				}
 

--- a/vlib/x/vweb/assets/assets.v
+++ b/vlib/x/vweb/assets/assets.v
@@ -281,7 +281,7 @@ pub fn minify_css(css string) string {
 
 	for line in lines {
 		trimmed := line.trim_space()
-		if trimmed.len > 0 {
+		if trimmed != '' {
 			sb.write_string(trimmed)
 		}
 	}
@@ -301,7 +301,7 @@ pub fn minify_js(js string) string {
 
 	for line in lines {
 		trimmed := line.trim_space()
-		if trimmed.len > 0 {
+		if trimmed != '' {
 			sb.write_string(trimmed)
 			sb.write_u8(` `)
 		}

--- a/vlib/x/vweb/context.v
+++ b/vlib/x/vweb/context.v
@@ -100,7 +100,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, response strin
 	// set Content-Type and Content-Length headers
 	mut custom_mimetype := if ctx.content_type.len == 0 { mimetype } else { ctx.content_type }
 	ctx.res.header.set(.content_type, custom_mimetype)
-	if ctx.res.body.len > 0 {
+	if ctx.res.body != '' {
 		ctx.res.header.set(.content_length, ctx.res.body.len.str())
 	}
 	// send vweb's closing headers

--- a/vlib/x/vweb/static_handler.v
+++ b/vlib/x/vweb/static_handler.v
@@ -81,7 +81,7 @@ pub fn (mut sh StaticHandler) mount_static_folder_at(directory_path string, moun
 // and you have a file /var/share/myassets/main.css .
 // => That file will be available at URL: http://localhost/assets/main.css .
 pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory_path string, mount_path string) !bool {
-	if mount_path.len < 1 || mount_path[0] != `/` {
+	if mount_path == '' || mount_path[0] != `/` {
 		return error('invalid mount path! The path should start with `/`')
 	} else if !os.exists(directory_path) {
 		return error('directory `${directory_path}` does not exist. The directory should be relative to the current working directory: ${os.getwd()}')


### PR DESCRIPTION
Instead of checking empty strings via `str_var.len > 0`, `str_var.len == 0`, `str_var.len < 1` 
the PR moves towards using `str_var != ''` and `str_var == ''`.

The former is longer to write, has no performance benefit, and, being less expressive, it comes with more mental overhead and requires more context to comprehend what (type) the condition checks. So imho making it unnecessary hard.

If a PR for `v vet` has a chance, I'd give it a shot implementing it. Imho it would be fitting to notify about this.