### PR TITLE
vpm: revert deep clones

### DIFF
--- a/cmd/tools/vpm/outdated_test.v
+++ b/cmd/tools/vpm/outdated_test.v
@@ -15,7 +15,6 @@ fn testsuite_begin() {
 	test_utils.set_test_env(test_path)
 	os.mkdir_all(test_path)!
 	os.chdir(test_path)!
-	println('test_path: ${test_path}')
 }
 
 fn testsuite_end() {
@@ -50,7 +49,7 @@ fn test_outdated() {
 	}
 	// "Outdate" previously installed. Leave out `libsodium`.
 	for m in ['pcre', 'vtray', os.join_path('nedpals', 'args')] {
-		cmd_ok(@LOCATION, 'git -C ${m} fetch --all')
+		cmd_ok(@LOCATION, 'git -C ${m} fetch --unshallow')
 		cmd_ok(@LOCATION, 'git -C ${m} reset --hard HEAD~')
 		assert is_outdated(m)
 	}

--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -29,7 +29,7 @@ fn init_vcs_info() !map[VCS]VCSInfo {
 	git_installed_raw_ver := parse_git_version(os.execute_opt('git --version')!.output) or { '' }
 	git_installed_ver := semver.from(git_installed_raw_ver)!
 	git_submod_filter_ver := semver.from('2.36.0')!
-	mut git_install_cmd := 'clone --recursive --shallow-submodules --filter=blob:none'
+	mut git_install_cmd := 'clone --depth=1 --recursive --shallow-submodules --filter=blob:none'
 	if git_installed_ver >= git_submod_filter_ver {
 		git_install_cmd += ' --also-filter-submodules'
 	}


### PR DESCRIPTION
The suggestion keeps shallow cloning since it can make a tremendous difference to clone a repo just one commit deep.

The issue of not being able to run the sdl script after a `v install sdl` is addressed here: https://github.com/vlang/sdl/pull/742