### PR TITLE
flag: include args after end-of-options(`--`) when checking min and max args

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -607,25 +607,19 @@ pub fn (mut fs FlagParser) finalize() ![]string {
 			}
 		}
 	}
-	if remaining.len < fs.min_free_args && fs.min_free_args > 0 {
+	remaining << fs.all_after_dashdash
+	if fs.min_free_args > remaining.len {
 		return &ArgsCountError{
 			want: fs.min_free_args
 			got: remaining.len
 		}
 	}
-	if remaining.len > fs.max_free_args && fs.max_free_args > 0 {
+	if fs.max_free_args < remaining.len {
 		return &ArgsCountError{
 			want: fs.max_free_args
 			got: remaining.len
 		}
 	}
-	if remaining.len > 0 && fs.max_free_args == 0 && fs.min_free_args == 0 {
-		return &ArgsCountError{
-			want: 0
-			got: remaining.len
-		}
-	}
-	remaining << fs.all_after_dashdash
 	return remaining
 }
 

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -204,6 +204,14 @@ fn test_free_args_could_be_limited() {
 	assert args[0] == 'a'
 	assert args[1] == 'b'
 	assert args[2] == 'c'
+
+	mut fp2 := flag.new_flag_parser(['--', 'a'])
+	fp2.limit_free_args_to_at_least(1)!
+	args2 := fp2.finalize() or {
+		assert false
+		return
+	}
+	assert args2[0] == 'a'
 }
 
 fn test_error_for_to_few_free_args() {


### PR DESCRIPTION
With the changes that are passed after `--` (end of options) will be considered as args when using `finalize` on a `FlaParser`.

To give an example that is currently using the flag module and suffering from the described issue on current master:

```
❯ v retry -- ls
Error: flag.ArgsCountError: Expected at least 1 arguments, but got 0
```

With the change:
```
❯ v retry -- ls
bench         changelogs0.x  CODE_OF_CONDUCT.md  doc         Dockerfile.alpine  examples     GNUmakefile  make.bat  README.md   samples   thirdparty  v3  vlib   v_old
CHANGELOG.md  cmd            CONTRIBUTING.md     Dockerfile  Dockerfile.cross   examples.sh  LICENSE      Makefile  ROADMAP.md  TESTS.md  tutorials   v            vc  v.mod
```

With the change, passing flags to a command after `--` will also be possible
```
❯ v retry -- ls -lah
total 30M
drwxr-xr-x 16 t t         4.0K Apr 19 00:03 .
drwxr-xr-x 17 t t         4.0K Apr 15 13:11 ..
drwxr-xr-x  3 t t         4.0K Sep  5  2023 bench
-rw-r--r--  1 t t         112K Apr 18 19:19 CHANGELOG.md
...
```

Currently the only possibility is to use quotes:
```
v retry 'ls -lah'
```


_If comparing the examples used above during local testing you might need to make sure that the vretry binary is recompiled_