### PR TITLE
tools: update vretry.v, add test

### DIFF
--- a/cmd/tools/vretry.v
+++ b/cmd/tools/vretry.v
@@ -22,13 +22,13 @@ fn main() {
 	context.show_help = fp.bool('help', `h`, false, 'Show this help screen.')
 	context.timeout = fp.float('timeout', `t`, 300.0, 'Timeout in seconds. Default: 300.0 seconds.') * time.second
 	context.delay = fp.float('delay', `d`, 1.0, 'Delay between each retry in seconds. Default: 1.0 second.') * time.second
-	context.retries = fp.int('retries', `r`, 999_999_999, 'Maximum number of retries. Default: 999_999_999.')
+	context.retries = fp.int('retries', `r`, 10, 'Maximum number of retries. Default: 10.')
 	if context.show_help {
 		println(fp.usage())
 		exit(0)
 	}
 	command_args := fp.finalize() or {
-		eprintln('Error: ${err}')
+		eprintln('error: ${err}')
 		exit(1)
 	}
 	cmd := command_args.join(' ')
@@ -40,14 +40,12 @@ fn main() {
 	}(context)
 
 	mut res := 0
-	mut i := 0
-	for {
-		i++
+	for i in 0 .. context.retries {
 		res = os.system(cmd)
 		if res == 0 {
 			break
 		}
-		if i >= context.retries {
+		if i == context.retries - 1 {
 			eprintln('error: exceeded maximum number of retries (${context.retries})!')
 			exit(res)
 		}

--- a/cmd/tools/vretry_test.v
+++ b/cmd/tools/vretry_test.v
@@ -1,0 +1,29 @@
+import os
+
+const vexe = @VEXE
+
+fn test_retry() {
+	tpath := os.join_path(os.vtmp_dir(), 'vretry_test')
+	os.rmdir_all(tpath) or {}
+	os.mkdir_all(tpath)!
+	defer {
+		os.rmdir_all(tpath) or {}
+	}
+
+	fail_cmd := os.execute('${vexe} retry git asdf')
+	assert fail_cmd.exit_code != 0
+	assert fail_cmd.output.contains('error: exceeded maximum number of retries')
+
+	with_flags_fail_cmd := os.execute('${vexe} retry -d 0.2 -r 3 git asdf')
+	assert with_flags_fail_cmd.exit_code != 0
+	assert with_flags_fail_cmd.output.contains('error: exceeded maximum number of retries (3)!')
+
+	pass_cmd := os.execute('${vexe} retry git branch')
+	assert pass_cmd.exit_code == 0
+	assert pass_cmd.output.contains('master')
+
+	// Include flags on the cmd as well.
+	with_falgs_pass_cmd_with_falgs := os.execute('${vexe} retry -r 3 -- git branch --list')
+	assert with_falgs_pass_cmd_with_falgs.exit_code == 0
+	assert with_falgs_pass_cmd_with_falgs.output == os.execute('git branch --list').output
+}

--- a/cmd/tools/vretry_test.v
+++ b/cmd/tools/vretry_test.v
@@ -12,7 +12,7 @@ fn test_retry() {
 
 	fail_cmd := 'git asdf'
 	if os.getenv('CI') != 'true' {
-		// Skip longer taking test in CI runs.
+		// Skip longer running test in CI runs.
 		res := os.execute('${vexe} retry ${fail_cmd}')
 		assert res.exit_code != 0
 		assert res.output.contains('error: exceeded maximum number of retries')

--- a/cmd/tools/vretry_test.v
+++ b/cmd/tools/vretry_test.v
@@ -11,8 +11,8 @@ fn test_retry() {
 	}
 
 	fail_cmd := 'git asdf'
-	if os.getenv('CI') != 'true' {
-		// Skip longer running test in CI runs.
+	if os.getenv('CI') == 'true' {
+		// Skip longer running test on local runs.
 		res := os.execute('${vexe} retry ${fail_cmd}')
 		assert res.exit_code != 0
 		assert res.output.contains('error: exceeded maximum number of retries')

--- a/cmd/tools/vretry_test.v
+++ b/cmd/tools/vretry_test.v
@@ -10,24 +10,27 @@ fn test_retry() {
 		os.rmdir_all(tpath) or {}
 	}
 
+	fail_cmd := 'git asdf'
 	if os.getenv('CI') != 'true' {
 		// Skip longer taking test in CI runs.
-		fail_cmd := os.execute('${vexe} retry git asdf')
-		assert fail_cmd.exit_code != 0
-		assert fail_cmd.output.contains('error: exceeded maximum number of retries')
+		res := os.execute('${vexe} retry ${fail_cmd}')
+		assert res.exit_code != 0
+		assert res.output.contains('error: exceeded maximum number of retries')
 	}
 
-	with_flags_fail_cmd := os.execute('${vexe} retry -d 0.2 -r 3 git asdf')
-	assert with_flags_fail_cmd.exit_code != 0
-	assert with_flags_fail_cmd.output.contains('error: exceeded maximum number of retries (3)!')
+	mut res := os.execute('${vexe} retry -d 0.2 -r 3 ${fail_cmd}')
+	assert res.exit_code != 0
+	assert res.output.contains('error: exceeded maximum number of retries (3)!')
 
 	os.chdir(os.dir(vexe))!
-	pass_cmd := os.execute('${vexe} retry git branch')
-	assert pass_cmd.exit_code == 0
-	assert pass_cmd.output.contains('master')
+	pass_cmd := 'git branch'
+	res = os.execute('${vexe} retry ${pass_cmd}')
+	assert res.exit_code == 0
+	assert res.output == os.execute(pass_cmd).output
 
 	// Include flags on the cmd as well.
-	with_falgs_pass_cmd_with_falgs := os.execute('${vexe} retry -r 3 -- git branch --list')
-	assert with_falgs_pass_cmd_with_falgs.exit_code == 0
-	assert with_falgs_pass_cmd_with_falgs.output == os.execute('git branch --list').output
+	pass_cmd_with_flags := 'git branch --list'
+	res = os.execute('${vexe} retry -r 3 -- ${pass_cmd_with_flags}')
+	assert res.exit_code == 0
+	assert res.output == os.execute(pass_cmd_with_flags).output
 }

--- a/cmd/tools/vretry_test.v
+++ b/cmd/tools/vretry_test.v
@@ -10,14 +10,18 @@ fn test_retry() {
 		os.rmdir_all(tpath) or {}
 	}
 
-	fail_cmd := os.execute('${vexe} retry git asdf')
-	assert fail_cmd.exit_code != 0
-	assert fail_cmd.output.contains('error: exceeded maximum number of retries')
+	if os.getenv('CI') != 'true' {
+		// Skip longer taking test in CI runs.
+		fail_cmd := os.execute('${vexe} retry git asdf')
+		assert fail_cmd.exit_code != 0
+		assert fail_cmd.output.contains('error: exceeded maximum number of retries')
+	}
 
 	with_flags_fail_cmd := os.execute('${vexe} retry -d 0.2 -r 3 git asdf')
 	assert with_flags_fail_cmd.exit_code != 0
 	assert with_flags_fail_cmd.output.contains('error: exceeded maximum number of retries (3)!')
 
+	os.chdir(os.dir(vexe))!
 	pass_cmd := os.execute('${vexe} retry git branch')
 	assert pass_cmd.exit_code == 0
 	assert pass_cmd.output.contains('master')


### PR DESCRIPTION
Next to minor updates to `vretry` it uses a default retry count of 10 as it can be a more sensible default in comparison to getting stuck in 999_999_999 loop(/ for 300sec) when passing an invalid command. This default count is similar to `.github/workflows/retry.sh`.
It might be a better fit the other defaults (1 sec delay and timeout of 300sec) as well.

The added test will pass after #21310