### PR TITLE
ci: prevent unintended deployment workflow steps

### DIFF
--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -41,11 +41,11 @@ jobs:
           [ $(wc -l < vc/v.c) -gt 5000 ]
           [ $(wc -l < vc/v_win.c) -gt 5000 ]
 
+      - name: Deploy
+        if: ${{ github.event.repository.full_name == 'vlang/v' }}
+        run: |
           git -C vc add v.c v_win.c
           git -C vc commit -m "[v:master] $COMMIT_HASH - $COMMIT_MSG"
-
           # in case there are recent commits:
           .github/workflows/retry.sh git -C vc pull --rebase origin master
-          # Note that failure below may happen, due to vlang/vc rejecting the push
-          # from forked repos; that is not usually a problem.
-          git -C vc push || true 
+          git -C vc push || true

--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-module-docs:
     runs-on: ubuntu-20.04
+    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
       - name: Build V
@@ -22,5 +23,5 @@ jobs:
       - name: Build module documentation
         run: ./v doc -m -f html vlib/
       - name: Deploy docs to vercel
-        if: ${{ github.event_name == 'push' && github.event.repository.full_name == 'vlang/v' && github.event.ref == 'refs/heads/master' }}
+        if: ${{ github.event.repository.full_name == 'vlang/v' }}
         run: npx vercel --confirm --prod --name vmodules --token ${{ secrets.VERCEL_TOKEN }} vlib/_docs/ || true


### PR DESCRIPTION
- Limits the vc deployment workflow to run when relevant instead of
  > ```yml
  > # Note that failure below may happen, due to vlang/vc rejecting the push
  > # from forked repos; that is not usually a problem.
  > ```
- Extends the doc_ci workflow by adding the default condition that we currently use to make sure it runs when relevant.
