### PR TITLE
vdoc: rewrite and extend vdocignore

### DIFF
--- a/cmd/tools/vdoc/files.v
+++ b/cmd/tools/vdoc/files.v
@@ -7,33 +7,40 @@ mut:
 	patterns map[string]bool = {
 		'testdata': true
 		'tests':    true
-		'_test.v':  true
+		'*_test.v': true
 	}
 	paths map[string]bool
 }
 
-fn get_modules_list(opath string) []string {
+fn get_modules(path string) []string {
 	mut ignore_rules := IgnoreRules{}
-	res := get_modules(opath, mut ignore_rules)
+	mut modules := map[string]bool{}
+	for p in get_paths(path, mut ignore_rules) {
+		modules[os.dir(p)] = true
+	}
+	mut res := modules.keys()
+	res.sort()
 	return res
 }
 
-fn get_modules(opath string, mut ignore_rules IgnoreRules) []string {
+fn get_paths(path string, mut ignore_rules IgnoreRules) []string {
 	mut res := []string{}
-	for p in os.ls(opath) or { return [] } {
-		fp := os.join_path(opath, p)
+	for p in os.ls(path) or { return [] } {
+		ignore_rules.get(path)
+		fp := os.join_path(path, p)
 		if fp in ignore_rules.paths {
 			continue
 		}
 		is_dir := os.is_dir(fp)
-		if ignore_rules.patterns.keys().any(p.contains(it)
-			|| (is_dir && p.contains(it.trim_right('/'))))
+		if ignore_rules.patterns.keys().any(p == it
+			|| (it.contains('*') && p.ends_with(it.all_after('*')))
+			|| (is_dir && it.ends_with('/') && fp.ends_with(it.trim_right('/')))
+			|| (!it.ends_with('/') && it.contains('/') && fp.contains(it)))
 		{
 			continue
 		}
 		if is_dir {
-			ignore_rules.get(opath)
-			res << get_modules(fp, mut ignore_rules)
+			res << get_paths(fp, mut ignore_rules)
 			continue
 		}
 		if p.ends_with('.v') {
@@ -43,9 +50,6 @@ fn get_modules(opath string, mut ignore_rules IgnoreRules) []string {
 	return res
 }
 
-// Similar to `.gitignore`, a pattern starting with `/` should only ignore
-// the pattern relative to the directory of the `.vdocignore` file.
-// `/a` should ignore `/a` but not `/b/a`. While `a` should ignore `/a` and `/b/a`.
 fn (mut ignore_rules IgnoreRules) get(path string) {
 	ignore_content := os.read_file(os.join_path(path, '.vdocignore')) or { return }
 	if ignore_content.trim_space() == '' {
@@ -57,10 +61,16 @@ fn (mut ignore_rules IgnoreRules) get(path string) {
 			continue
 		}
 		if rule.contains('*.') || rule.contains('**') {
+			// Skip wildcards that are defined in an ignore file.
+			// For now, only add a basic implementation in `get_paths`
+			// that can handle the default `*_test.v` pattern.
 			eprintln('vdoc: Wildcards in ignore rules are not yet supported.')
 			continue
 		}
 		if rule.starts_with('/') {
+			// Similar to `.gitignore`, a pattern starting with `/` should only ignore
+			// the pattern relative to the directory of the `.vdocignore` file.
+			// `/a` should ignore `/a` but not `/b/a`. While `a` should ignore `/a` and `/b/a`.
 			ignore_rules.paths[os.join_path(path, rule.trim_left('/'))] = true
 		} else {
 			ignore_rules.patterns[rule] = true

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -244,7 +244,7 @@ fn (vd &VDoc) emit_generate_err(err IError) {
 	cfg := vd.cfg
 	mut err_msg := err.msg()
 	if err.code() == 1 {
-		mod_list := get_modules_list(cfg.input_path)
+		mod_list := get_modules(cfg.input_path)
 		println('Available modules:\n==================')
 		for mod in mod_list {
 			println(mod.all_after('vlib/').all_after('modules/').replace('/', '.'))
@@ -307,7 +307,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			}
 		}
 	}
-	dirs := if cfg.is_multi { get_modules_list(cfg.input_path) } else { [cfg.input_path] }
+	dirs := if cfg.is_multi { get_modules(cfg.input_path) } else { [cfg.input_path] }
 	for dirpath in dirs {
 		vd.vprintln('Generating ${out.typ} docs for "${dirpath}"')
 		mut dcs := doc.generate(dirpath, cfg.pub_only, true, cfg.platform, cfg.symbol_name) or {

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -244,7 +244,7 @@ fn (vd &VDoc) emit_generate_err(err IError) {
 	cfg := vd.cfg
 	mut err_msg := err.msg()
 	if err.code() == 1 {
-		mod_list := get_modules_list(cfg.input_path, []string{})
+		mod_list := get_modules_list(cfg.input_path)
 		println('Available modules:\n==================')
 		for mod in mod_list {
 			println(mod.all_after('vlib/').all_after('modules/').replace('/', '.'))
@@ -307,9 +307,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			}
 		}
 	}
-	dirs := if cfg.is_multi { get_modules_list(cfg.input_path, []string{}) } else { [
-			cfg.input_path,
-		] }
+	dirs := if cfg.is_multi { get_modules_list(cfg.input_path) } else { [cfg.input_path] }
 	for dirpath in dirs {
 		vd.vprintln('Generating ${out.typ} docs for "${dirpath}"')
 		mut dcs := doc.generate(dirpath, cfg.pub_only, true, cfg.platform, cfg.symbol_name) or {

--- a/cmd/tools/vdoc/vdoc_test.v
+++ b/cmd/tools/vdoc/vdoc_test.v
@@ -33,30 +33,29 @@ fn test_get_module_list() {
 	/* Create some submodules.
 	Modules inside `testdata` and `tests` directories and modules that
 	only contain `_test.v` files should be ignored by default. */
-	submodules_no_ignore := ['alpha', 'charly', 'charly/alpha']
-	submodules_to_ignore := ['alpha/bravo', 'bravo', 'tests', 'testdata', 'testdata/echo']
+	submodules_no_ignore := ['alpha', 'charly', 'charly/alpha', 'charly/echo', 'charly/foxtrot/golf',
+		'foxtrot', 'golf']
+	submodules_to_ignore := ['alpha/bravo', 'bravo', 'echo', 'foxtrot/golf', 'tests', 'testdata',
+		'testdata/echo']
 	for p in arrays.append(submodules_no_ignore, submodules_to_ignore) {
-		os.mkdir(p)!
-		mod_name := p.all_after('/')
+		os.mkdir_all(p)!
+		mod_name := p.all_after_last('/')
 		os.write_file(os.join_path(p, '${mod_name}.v'), 'module ${mod_name}')!
 	}
 	// Create a module that only contains a `_test.v` file.
 	os.mkdir('delta')!
 	os.write_file(os.join_path('delta', 'delta_test.v'), 'module delta')!
 
-	os.write_file('.vdocignore', 'bravo\nalpha/bravo\n')!
-	ignore_paths := get_ignore_paths(tpath)!
-	assert os.join_path(tpath, 'bravo') in ignore_paths
-	assert os.join_path(tpath, 'alpha/bravo') in ignore_paths
-	// Only `bravo` modules are part of `.vdocignore`. Ensure that no others are ignored.
-	assert ignore_paths.all(it.contains('bravo'))
+	// For information on a leading slash behaviour check the doc comment of `get_ignore_files`.
+	ignore_rules := ['bravo', '/echo', '/foxtrot/golf']
+	os.write_file('.vdocignore', ignore_rules.join_lines())!
 
-	// `get_modules_list` uses `get_ignore_paths` internally.
-	mod_list := get_modules_list(tpath, []string{})
+	mod_list := get_modules_list(tpath)
 	assert mod_list.len == submodules_no_ignore.len
-	assert mod_list.all(it.contains('alpha') || it.contains('charly')), mod_list.str()
-
-	// Test empty `.vdocignore` file.
-	os.write_file('.vdocignore', '')!
-	assert get_modules_list(tpath, []string{}) == []
+	for m in submodules_no_ignore {
+		assert mod_list.any(it.contains(os.join_path(tpath, m)))
+	}
+	for m in submodules_to_ignore {
+		assert !mod_list.any(it.contains(os.join_path(tpath, m)))
+	}
 }

--- a/cmd/tools/vdoc/vdoc_test.v
+++ b/cmd/tools/vdoc/vdoc_test.v
@@ -30,17 +30,40 @@ fn test_get_module_list() {
 
 	os.chdir(tpath)!
 
-	// For information on leading slash rules, refer to the doc comment of `get_ignore_files`.
-	ignore_rules := ['bravo', '/echo', '/foxtrot/golf', 'hotel.v/']
+	// For information on leading slash rules, refer to the comments in `IgnoreRules.get`.
+	ignore_rules := ['bravo', '/echo', '/foxtrot/golf', 'hotel.v/', 'india/juliett']
 	os.write_file('.vdocignore', ignore_rules.join_lines())!
 
 	/* Create some submodules.
 	Modules inside `testdata` and `tests` directories and modules that
 	only contain `_test.v` files should be ignored by default. */
-	submodules_no_ignore := ['alpha', 'charly', 'charly/alpha', 'charly/delta', 'charly/echo',
-		'charly/foxtrot/golf', 'foxtrot', 'golf']
-	submodules_to_ignore := ['alpha/bravo', 'alpha/delta', 'bravo', 'echo', 'foxtrot/golf', 'tests',
-		'testdata', 'testdata/echo', 'hotel.v']
+	// Modules NOT to ignore.
+	submodules_no_ignore := [
+		'alpha',
+		'alpha_bravo', // test `bravo`
+		'bravo_charly', // test `bravo`
+		'charly',
+		'charly/alpha',
+		'charly/delta', // test `delta` in separate ignore file in `alpha`
+		'charly/echo', // test `/echo`
+		'charly/foxtrot/golf', // test `/foxtrot/golf`
+		'foxtrot',
+		'golf',
+		'hotel', // will include a `hotel.v` file, whose pattern is in the ignore list with a trailing slash
+	]
+	// Modules TO ignore.
+	submodules_to_ignore := [
+		'alpha/bravo', // test `bravo`
+		'alpha/delta', // test `delta` in separate ignore file
+		'alpha/india/juliett/kilo', // test `india/juliett`
+		'bravo', // test `bravo`
+		'echo', // test `/echo`
+		'foxtrot/golf', // test `/foxtrot/golf`
+		'hotel.v', // test `hotel.v/`
+		'tests', // test default
+		'testdata', // test default
+		'testdata/foxtrot', // test default
+	]
 	for p in arrays.append(submodules_no_ignore, submodules_to_ignore) {
 		os.mkdir_all(p)!
 		mod_name := p.all_after_last('/')
@@ -49,24 +72,18 @@ fn test_get_module_list() {
 	// Create a module that only contains a `_test.v` file.
 	os.mkdir('delta')!
 	os.write_file(os.join_path('delta', 'delta_test.v'), 'module delta')!
-	// Create a file with a name whose pattern is in the ignore list with a trailing slash.
-	os.write_file(os.join_path('alpha', 'hotel.v'), 'module alpha')!
 	// Add a `.vdocignore` file to a submodule.
 	os.write_file(os.join_path('alpha', '.vdocignore'), 'delta\n')!
 
-	mod_list := get_modules_list(tpath)
+	mod_list := get_modules(tpath)
 	// dump(mod_list)
-	assert mod_list.len == submodules_no_ignore.len + 1 // +1 since `alpha/hotel.v` was added separately.
-	for m in submodules_no_ignore {
-		assert mod_list.any(it.contains(os.join_path(tpath, m)))
+	assert mod_list.len == submodules_no_ignore.len
+	for m in submodules_no_ignore.map(os.join_path(tpath, it)) {
+		assert m in mod_list
 	}
-	for m in submodules_to_ignore {
-		assert !mod_list.any(it.contains(os.join_path(tpath, m)))
+	for m in submodules_to_ignore.map(os.join_path(tpath, it)) {
+		assert m !in mod_list
 	}
 	// `delta` only contains a `_test.v` file.
 	assert !mod_list.any(it.contains(os.join_path(tpath, 'delta')))
-	// `hotel.v/` is added as ignore pattern with a tailing slash.
-	// The directory should be ignored while the file should be included.
-	assert !mod_list.any(it.contains(os.join_path(tpath, 'hotel.v')))
-	assert os.join_path(tpath, 'alpha', 'hotel.v') in mod_list
 }

--- a/cmd/tools/vdoc/vdoc_test.v
+++ b/cmd/tools/vdoc/vdoc_test.v
@@ -37,10 +37,10 @@ fn test_get_module_list() {
 	/* Create some submodules.
 	Modules inside `testdata` and `tests` directories and modules that
 	only contain `_test.v` files should be ignored by default. */
-	submodules_no_ignore := ['alpha', 'charly', 'charly/alpha', 'charly/echo', 'charly/foxtrot/golf',
-		'foxtrot', 'golf']
-	submodules_to_ignore := ['alpha/bravo', 'bravo', 'echo', 'foxtrot/golf', 'tests', 'testdata',
-		'testdata/echo', 'hotel.v']
+	submodules_no_ignore := ['alpha', 'charly', 'charly/alpha', 'charly/delta', 'charly/echo',
+		'charly/foxtrot/golf', 'foxtrot', 'golf']
+	submodules_to_ignore := ['alpha/bravo', 'alpha/delta', 'bravo', 'echo', 'foxtrot/golf', 'tests',
+		'testdata', 'testdata/echo', 'hotel.v']
 	for p in arrays.append(submodules_no_ignore, submodules_to_ignore) {
 		os.mkdir_all(p)!
 		mod_name := p.all_after_last('/')
@@ -51,8 +51,11 @@ fn test_get_module_list() {
 	os.write_file(os.join_path('delta', 'delta_test.v'), 'module delta')!
 	// Create a file with a name whose pattern is in the ignore list with a trailing slash.
 	os.write_file(os.join_path('alpha', 'hotel.v'), 'module alpha')!
+	// Add a `.vdocignore` file to a submodule.
+	os.write_file(os.join_path('alpha', '.vdocignore'), 'delta\n')!
 
 	mod_list := get_modules_list(tpath)
+	// dump(mod_list)
 	assert mod_list.len == submodules_no_ignore.len + 1 // +1 since `alpha/hotel.v` was added separately.
 	for m in submodules_no_ignore {
 		assert mod_list.any(it.contains(os.join_path(tpath, m)))
@@ -60,6 +63,7 @@ fn test_get_module_list() {
 	for m in submodules_to_ignore {
 		assert !mod_list.any(it.contains(os.join_path(tpath, m)))
 	}
+	// `delta` only contains a `_test.v` file.
 	assert !mod_list.any(it.contains(os.join_path(tpath, 'delta')))
 	// `hotel.v/` is added as ignore pattern with a tailing slash.
 	// The directory should be ignored while the file should be included.


### PR DESCRIPTION
After working on an improved status quo to also have a good fallback, this PR approaches to rewrite and to extend `.vdocignore`.

- It adds pattern support. 
  
  Until now to ignore `a` and the same pattern in a sub-directory (`b/a`) it is required to set the exact path for every subdirectory. Now it is sufficient to set the pattern

<table width="400">
<tr width="100%">
	<th>
	Ignore Goal
	</th>
	<th>
	Current
	</th>
	<th>
	Updated
	</th>
</tr>

<tr width="100%">
 <td>

<pre>
a
a/b
b/c/a
</pre>

 </td>

 <td>

<pre>
a
a/b
b/c/a
</pre>
 </td>
 <td>

<pre>
a
</pre>
 </td>
</tr>

</table>

  - Similar to gitignore a pattern starting with `/` will be treated as relative pattern.
    -> `/a` will ignore `/a` but not `/b/a`.  
    -> `/c/d` will ignore `/c/d` but not `/b/c/d`

- Treats lines starting with `#` as comments

- Removes the functionality that an empty ignore file ignores all in its directory.