### PR TITLE
mysql: exec_one invalid memory access

### DIFF
--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -323,7 +323,7 @@ pub fn (db &DB) exec_one(query string) !Row {
 
 	mut row := Row{}
 	for i in 0 .. num_cols {
-		if unsafe { row_vals == &u8(0) } || unsafe { row_vals[i] == nil} {
+		if unsafe { row_vals == &u8(0) } || unsafe { row_vals[i] == nil } {
 			row.vals << ''
 		} else {
 			row.vals << mystring(unsafe { &u8(row_vals[i]) })

--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -323,7 +323,7 @@ pub fn (db &DB) exec_one(query string) !Row {
 
 	mut row := Row{}
 	for i in 0 .. num_cols {
-		if unsafe { row_vals == &u8(0) } {
+		if unsafe { row_vals == &u8(0) } || unsafe { row_vals[i] == nil} {
 			row.vals << ''
 		} else {
 			row.vals << mystring(unsafe { &u8(row_vals[i]) })

--- a/vlib/db/mysql/mysql_test.v
+++ b/vlib/db/mysql/mysql_test.v
@@ -61,24 +61,24 @@ fn test_mysql() {
 	response = db.exec_param_many('select * from users', [''])!
 	assert response == [
 		mysql.Row{
-			vals: ['1', 'jackson','']
+			vals: ['1', 'jackson', '']
 		},
 		mysql.Row{
-			vals: ['2', 'shannon','']
+			vals: ['2', 'shannon', '']
 		},
 		mysql.Row{
-			vals: ['3', 'bailey','']
+			vals: ['3', 'bailey', '']
 		},
 		mysql.Row{
-			vals: ['4', 'blaze','']
+			vals: ['4', 'blaze', '']
 		},
 		mysql.Row{
-			vals: ['5', 'Hi','']
+			vals: ['5', 'Hi', '']
 		},
 	]
 
 	response = db.exec_param('select * from users where username = ?', 'blaze')!
 	assert response[0] == mysql.Row{
-		vals: ['4', 'blaze','']
+		vals: ['4', 'blaze', '']
 	}
 }

--- a/vlib/db/mysql/mysql_test.v
+++ b/vlib/db/mysql/mysql_test.v
@@ -16,7 +16,8 @@ fn test_mysql() {
 
 	response = db.exec('create table if not exists users (
                         id INT PRIMARY KEY AUTO_INCREMENT,
-                        username TEXT
+                        username TEXT,
+						last_name TEXT NULL DEFAULT NULL
                       )')!
 	assert response == []mysql.Row{}
 
@@ -48,36 +49,36 @@ fn test_mysql() {
 		'jackson',
 	])!
 	assert response[0] == mysql.Row{
-		vals: ['1', 'jackson']
+		vals: ['1', 'jackson', '']
 	}
 
 	response = db.exec_param_many('select * from users where username = ? and id = ?',
 		['bailey', '3'])!
 	assert response[0] == mysql.Row{
-		vals: ['3', 'bailey']
+		vals: ['3', 'bailey', '']
 	}
 
 	response = db.exec_param_many('select * from users', [''])!
 	assert response == [
 		mysql.Row{
-			vals: ['1', 'jackson']
+			vals: ['1', 'jackson','']
 		},
 		mysql.Row{
-			vals: ['2', 'shannon']
+			vals: ['2', 'shannon','']
 		},
 		mysql.Row{
-			vals: ['3', 'bailey']
+			vals: ['3', 'bailey','']
 		},
 		mysql.Row{
-			vals: ['4', 'blaze']
+			vals: ['4', 'blaze','']
 		},
 		mysql.Row{
-			vals: ['5', 'Hi']
+			vals: ['5', 'Hi','']
 		},
 	]
 
 	response = db.exec_param('select * from users where username = ?', 'blaze')!
 	assert response[0] == mysql.Row{
-		vals: ['4', 'blaze']
+		vals: ['4', 'blaze','']
 	}
 }


### PR DESCRIPTION
When executing the exec_one() command, if a field with a NULL value came across, it caused the RUNTIME ERROR: invalid memory access error

