### PR TITLE
v: update linguist languages, add .vdocignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@
 *.vsh linguist-language=V text=auto eol=lf
 **/v.mod linguist-language=V text=auto eol=lf
 *.bat text=auto eol=crlf
- Dockerfile.* linguist-language=Dockerfile
 *.toml text eol=lf
+Dockerfile.* linguist-language=Dockerfile
+.vdocignore linguist-language=ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,10 @@
+* text=auto eol=lf
+*.bat eol=crlf
+
 *.v linguist-language=V text=auto eol=lf
 *.vv linguist-language=V text=auto eol=lf
 *.vsh linguist-language=V text=auto eol=lf
 **/v.mod linguist-language=V text=auto eol=lf
-*.bat text=auto eol=crlf
-*.toml text eol=lf
-Dockerfile.* linguist-language=Dockerfile
 .vdocignore linguist-language=ignore
+
+Dockerfile.* linguist-language=Dockerfile

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -248,6 +248,7 @@ fn (c &Create) write_gitattributes() {
 **/*.vv linguist-language=V
 **/*.vsh linguist-language=V
 **/v.mod linguist-language=V
+.vdocignore linguist-language=ignore
 '
 	os.write_file(path, content) or { panic(err) }
 }

--- a/cmd/tools/vcreate/vcreate_init_test.v
+++ b/cmd/tools/vcreate/vcreate_init_test.v
@@ -91,6 +91,7 @@ fn init_and_check() ! {
 		'**/*.vv linguist-language=V',
 		'**/*.vsh linguist-language=V',
 		'**/v.mod linguist-language=V',
+		'.vdocignore linguist-language=ignore',
 		'',
 	].join_lines()
 


### PR DESCRIPTION
For highlighting / in some editors comment toggle.

Example in viewing a .vdocignore file on github 
|Current|Updated|
|-|-|
|![Screenshot_20240420_131307](https://github.com/vlang/v/assets/34311583/730ad434-52d8-4623-96b5-9723aa75376e)|![Screenshot_20240420_131305](https://github.com/vlang/v/assets/34311583/d1f69b3f-d772-4d28-a2bd-ad0afdb28dbb)|

