### PR TITLE
tools: update `test-self` to allow to choose running tests for cmd and vlib

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -373,7 +373,9 @@ fn main() {
 		os.walk(os.join_path(vroot, dir), fn [mut tpaths_ref] (p string) {
 			if p.ends_with('_test.v') || p.ends_with('_test.c.v')
 				|| (testing.is_node_present && p.ends_with('_test.js.v')) {
-				tpaths_ref[p] = true
+				unsafe {
+					tpaths_ref[p] = true
+				}
 			}
 		})
 	}

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -341,12 +341,12 @@ fn main() {
 	vroot := os.dir(vexe)
 	os.chdir(vroot) or { panic(err) }
 	args_idx := os.args.index('test-self')
-	cmd_prefix := os.args[1..args_idx].join(' ')
-	args := os.args#[args_idx + 1..]
-	tdirs := if args.len > 0 {
+	vargs := os.args[1..args_idx]
+	targs := os.args#[args_idx + 1..]
+	tdirs := if targs.len > 0 {
 		mut dirs := []string{}
 		mut has_err := false
-		for arg in args {
+		for arg in targs {
 			// For now, handle flags separately.
 			if arg.starts_with('-') {
 				continue
@@ -367,7 +367,7 @@ fn main() {
 	}
 	title := 'testing: ${tdirs.join(', ')}'
 	testing.eheader(title)
-	mut tsession := testing.new_test_session(cmd_prefix, true)
+	mut tsession := testing.new_test_session(vargs.join(' '), true)
 	mut tpaths := map[string]bool{}
 	mut tpaths_ref := &tpaths
 	for dir in tdirs {

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -341,9 +341,11 @@ fn main() {
 	vroot := os.dir(vexe)
 	os.chdir(vroot) or { panic(err) }
 	args_idx := os.args.index('test-self')
-	cmd_prefix := os.args[1..args_idx].join(' ')
+	cmd_prefix := os.args[1..args_idx]
 	mut has_vlib_opt := false
 	mut has_cmd_opt := false
+	mut asan_compiler := false
+	mut msan_compiler := false
 	for arg in os.args#[args_idx + 1..] {
 		match arg {
 			'--vlib' {
@@ -352,10 +354,37 @@ fn main() {
 			'--cmd' {
 				has_cmd_opt = true
 			}
+			'--asan-compiler', '-asan-compiler' {
+				asan_compiler = true
+			}
+			'--msan-compiler', '-msan-compiler' {
+				msan_compiler = true
+			}
 			else {
 				eprintln('error: unknown argument `${arg}`')
 				exit(1)
 			}
+		}
+	}
+	mut werror := false
+	mut sanitize_memory := false
+	mut sanitize_address := false
+	mut sanitize_undefined := false
+	for arg in cmd_prefix {
+		match arg {
+			'-Werror', '-cstrict' {
+				werror = true
+			}
+			'-fsanitize=memory' {
+				sanitize_memory = true
+			}
+			'-fsanitize=address' {
+				sanitize_address = true
+			}
+			'-fsanitize=undefined' {
+				sanitize_undefined = true
+			}
+			else {}
 		}
 	}
 	include_vlib, include_cmd := if !has_vlib_opt && !has_cmd_opt {
@@ -370,7 +399,7 @@ fn main() {
 		else { '' }
 	}
 	testing.eheader(title)
-	mut tsession := testing.new_test_session(cmd_prefix, true)
+	mut tsession := testing.new_test_session(cmd_prefix.join(' '), true)
 	mut all_test_files := []string{}
 	if include_vlib {
 		all_test_files << os.walk_ext(os.join_path(vroot, 'vlib'), '_test.v')
@@ -409,32 +438,6 @@ fn main() {
 	tsession.files << all_test_files.filter(!it.contains('testdata' + os.path_separator))
 	tsession.skip_files << skip_test_files
 
-	mut werror := false
-	mut sanitize_memory := false
-	mut sanitize_address := false
-	mut sanitize_undefined := false
-	mut asan_compiler := false
-	mut msan_compiler := false
-	for arg in os.args {
-		if arg.contains('-asan-compiler') {
-			asan_compiler = true
-		}
-		if arg.contains('-msan-compiler') {
-			msan_compiler = true
-		}
-		if arg.contains('-Werror') || arg.contains('-cstrict') {
-			werror = true
-		}
-		if arg.contains('-fsanitize=memory') {
-			sanitize_memory = true
-		}
-		if arg.contains('-fsanitize=address') {
-			sanitize_address = true
-		}
-		if arg.contains('-fsanitize=undefined') {
-			sanitize_undefined = true
-		}
-	}
 	if os.getenv('VTEST_RUN_FSANITIZE_TOO_SLOW').len == 0
 		&& ((sanitize_undefined || sanitize_memory || sanitize_address)
 		|| (msan_compiler || asan_compiler)) {

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -352,10 +352,7 @@ fn main() {
 			'--cmd' {
 				has_cmd_opt = true
 			}
-			else {
-				eprintln('error: unknown argument `${arg}`')
-				exit(1)
-			}
+			else {}
 		}
 	}
 	include_vlib, include_cmd := if !has_vlib_opt && !has_cmd_opt {

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -367,7 +367,6 @@ fn main() {
 	}
 	title := 'testing: ${tdirs.join(', ')}'
 	testing.eheader(title)
-	mut tsession := testing.new_test_session(vargs.join(' '), true)
 	mut tpaths := map[string]bool{}
 	mut tpaths_ref := &tpaths
 	for dir in tdirs {
@@ -379,6 +378,13 @@ fn main() {
 		})
 	}
 	mut all_test_files := tpaths.keys()
+	if just_essential {
+		all_test_files = essential_list.map(os.join_path(vroot, it))
+	}
+	mut tsession := testing.new_test_session(vargs.join(' '), true)
+	tsession.exec_mode = .compile_and_run
+	tsession.files << all_test_files.filter(!it.contains('testdata' + os.path_separator))
+	tsession.skip_files << skip_test_files
 	if !testing.is_go_present {
 		tsession.skip_files << 'vlib/v/gen/golang/tests/golang_test.v'
 	}
@@ -395,12 +401,6 @@ fn main() {
 			tsession.skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v'
 		}
 	}
-	if just_essential {
-		all_test_files = essential_list.map(os.join_path(vroot, it))
-	}
-	tsession.exec_mode = .compile_and_run
-	tsession.files << all_test_files.filter(!it.contains('testdata' + os.path_separator))
-	tsession.skip_files << skip_test_files
 
 	mut werror := false
 	mut sanitize_memory := false

--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -358,8 +358,11 @@ fn main() {
 			}
 		}
 	}
-	include_vlib := has_vlib_opt || (!has_vlib_opt && !has_cmd_opt)
-	include_cmd := has_cmd_opt || (!has_vlib_opt && !has_cmd_opt)
+	include_vlib, include_cmd := if !has_vlib_opt && !has_cmd_opt {
+		true, true
+	} else {
+		has_vlib_opt, has_cmd_opt
+	}
 	title := 'testing ' + match true {
 		include_cmd && include_vlib { 'vlib & cmd' }
 		include_vlib { 'vlib' }


### PR DESCRIPTION
With the changes, it will be possible to choose to run `v test-self` for project parts in `cmd` and `vlib`. By default - as it already is - both will be included, the same when passing both flags `v test-self --vlib --cmd`.

This can also help with local development but is mainly motivated to further improve our current CI - running parts when and where required.

As far as I can see, when changes are made just to a cmd tool, it **should usually not** require to run tests for the whole vlib. While changes to the vlib **should** include running tests for cmd tools. On the CI part, this can skyrocket tool development and reduce stress on vlib development. As PRs including updates just made to a tool without changes on the vlib can skip the most heavy part of CI.

Workflow update suggestions would happen in a follow-up.
