### PR TITLE
tools: skip file that is not compatible with sanitized=undefined tests during v test-self

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -191,6 +191,7 @@ const skip_with_fsanitize_undefined = [
 	'vlib/orm/orm_insert_test.v',
 	'vlib/orm/orm_insert_reserved_name_test.v',
 	'vlib/orm/orm_references_test.v',
+	'vlib/v/compiler_errors_test.v',
 	'vlib/v/tests/orm_enum_test.v',
 	'vlib/v/tests/orm_sub_array_struct_test.v',
 	'vlib/v/tests/orm_handle_error_for_select_from_not_created_table_test.v',


### PR DESCRIPTION
```sh
./v -cc clang -cflags -fsanitize=undefined -o v2 cmd/v && ./v2 -cc clang -cflags -fsanitize=undefined vlib/v/compiler_errors_test.v
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
