### PR TITLE
ci: simplify workflow conditions

### DIFF
--- a/.github/workflows/bootstrapping_works_ci.yml
+++ b/.github/workflows/bootstrapping_works_ci.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   bootstrapping-works:
-    if: >
-        github.event_name != 'push'
-        || github.event.ref == 'refs/heads/master'
-        || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]

--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build-doom:
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12]
@@ -59,7 +59,7 @@ jobs:
           WAD_FILE=~/DOOM1.WAD ~/code/doom/build_whole_project.sh
 
   test-regression:
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:

--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -16,7 +16,7 @@ jobs:
 
   macos-cross:
     runs-on: macos-latest
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 25
     env:
       VFLAGS: -cc clang
@@ -48,7 +48,7 @@ jobs:
 
   linux-cross:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 25
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -97,7 +97,7 @@ jobs:
 
   windows-cross:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker_alpine.yml
+++ b/.github/workflows/docker_alpine.yml
@@ -17,10 +17,7 @@ concurrency:
 jobs:
   alpine-docker-musl-gcc:
     runs-on: ubuntu-20.04
-    if: >
-      github.event_name != 'push'
-      || github.event.ref == 'refs/heads/master'
-      || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 241
     container:
       image: thevlang/vlang:alpine-build

--- a/.github/workflows/docker_ubuntu.yml
+++ b/.github/workflows/docker_ubuntu.yml
@@ -17,10 +17,7 @@ concurrency:
 jobs:
   ubuntu-docker-musl:
     runs-on: ubuntu-20.04
-    if: >
-      github.event_name != 'push'
-      || github.event.ref == 'refs/heads/master'
-      || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     container:
       image: thevlang/vlang:ubuntu-build

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -15,10 +15,7 @@ on:
 jobs:
   check-markdown:
     runs-on: ubuntu-20.04
-    if: >
-      github.event_name != 'push'
-      || github.event.ref == 'refs/heads/master'
-      || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -31,10 +28,7 @@ jobs:
 
   report-missing-fn-doc:
     runs-on: ubuntu-20.04
-    if: >
-      github.event_name != 'push'
-      || github.event.ref == 'refs/heads/master'
-      || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 5
     env:
       MOPTIONS: --diff --deprecated --relative-paths --exclude /vlib/v/ --exclude /builtin/linux_bare/ --exclude /testdata/ --exclude /tests/

--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build-vc:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
       - name: Build V
@@ -62,5 +62,5 @@ jobs:
           git -C vc log -3
 
       - name: Deploy
-        if: github.event.repository.full_name == 'vlang/v' && github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.repository == 'vlang/v' && github.ref == 'refs/heads/master'
         run: git -C vc push || true

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   gg-regressions:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 20
     env:
       VFLAGS: -cc tcc

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   tcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -99,7 +99,7 @@ jobs:
 
   tcc-boehm-gc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -156,7 +156,7 @@ jobs:
 
   gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -262,7 +262,7 @@ jobs:
 
   clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang
@@ -352,7 +352,7 @@ jobs:
 
   # autofree-selfcompile:
   #   runs-on: ubuntu-20.04
-  #   if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+  #   if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
   #   timeout-minutes: 121
   #   env:
   #     VFLAGS: -cc gcc
@@ -365,7 +365,7 @@ jobs:
 
   # musl:
   #   runs-on: ubuntu-20.04
-  #   if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+  #   if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
   #   timeout-minutes: 121
   #   env:
   #     VFLAGS: -cc musl-gcc

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   clang:
     runs-on: macOS-12
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang

--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build-module-docs:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
       - name: Build V
@@ -39,5 +39,5 @@ jobs:
       - name: Build module documentation
         run: ./v doc -m -f html vlib/
       - name: Deploy docs to vercel
-        if: github.event.repository.full_name == 'vlang/v' && github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.repository == 'vlang/v' && github.ref == 'refs/heads/master'
         run: npx vercel --confirm --prod --name vmodules --token ${{ secrets.VERCEL_TOKEN }} vlib/_docs/ || true

--- a/.github/workflows/native_backend_tests_ci.yml
+++ b/.github/workflows/native_backend_tests_ci.yml
@@ -56,7 +56,7 @@ jobs:
           windows-2019
         ]
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   no-gpl-by-accident:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
 
   code-formatting:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       VFLAGS: -cc gcc
@@ -46,7 +46,7 @@ jobs:
 
   performance-regressions:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       VFLAGS: -cc gcc
@@ -71,7 +71,7 @@ jobs:
 
   misc-tooling:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -111,7 +111,7 @@ jobs:
 
   parser-silent:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/paths_ci.yml
+++ b/.github/workflows/paths_ci.yml
@@ -16,7 +16,7 @@ jobs:
 
   space-paths-linux:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       MY_V_PATH: '你好 my $path, @с интервали'
@@ -42,7 +42,7 @@ jobs:
 
   space-paths-macos:
     runs-on: macos-14
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       MY_V_PATH: '你好 my $path, @с интервали'
@@ -71,7 +71,7 @@ jobs:
 
   space-paths-windows:
     runs-on: windows-2022
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       MY_V_PATH: 'path with some $punctuation, and some spaces'

--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   network-tests-ubuntu:
     runs-on: ubuntu-20.04
-    if: github.event.ref == 'refs/heads/master' && github.event.repository.full_name == 'vlang/v'
+    if: github.ref == 'refs/heads/master' && github.repository == 'vlang/v'
     timeout-minutes: 30
     env:
       V_CI_PERIODIC: 1
@@ -22,10 +22,9 @@ jobs:
         ## - name: Run network tests
         ##   run: ./v -d network test vlib/net
 
-
   network-tests-macos:
     runs-on: macos-14
-    if: github.event.ref == 'refs/heads/master' && github.event.repository.full_name == 'vlang/v'
+    if: github.ref == 'refs/heads/master' && github.repository == 'vlang/v'
     timeout-minutes: 30
     env:
       V_CI_PERIODIC: 1
@@ -42,7 +41,7 @@ jobs:
 
   network-windows-msvc:
     runs-on: windows-2019
-    if: github.event.ref == 'refs/heads/master' && github.event.repository.full_name == 'vlang/v'
+    if: github.ref == 'refs/heads/master' && github.repository == 'vlang/v'
     timeout-minutes: 30
     env:
       V_CI_PERIODIC: 1

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -76,7 +76,7 @@ concurrency:
 jobs:
   tests-sanitize-undefined-clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc clang
@@ -101,7 +101,7 @@ jobs:
 
   tests-sanitize-undefined-gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc gcc
@@ -125,7 +125,7 @@ jobs:
 
   tests-sanitize-address-clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc clang
@@ -154,7 +154,7 @@ jobs:
 
   tests-sanitize-address-msvc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc msvc
@@ -183,7 +183,7 @@ jobs:
 
   tests-sanitize-address-gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc gcc
@@ -212,7 +212,7 @@ jobs:
 
   tests-sanitize-memory-clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc clang -gc none

--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   v-compiles-sdl-examples:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       VFLAGS: -cc tcc

--- a/.github/workflows/time_ci.yml
+++ b/.github/workflows/time_ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test-time-linux:
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
         run: TZ=Europe/Paris ./v test vlib/time/
 
   test-time-macos:
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         run: TZ=Europe/Paris ./v test vlib/time/
 
   test-time-windows:
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   toml-module-pass-external-test-suites:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -19,10 +19,7 @@ concurrency:
 jobs:
   v-apps-compile:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name != 'push'
-      || github.event.ref == 'refs/heads/master'
-      || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -206,10 +203,7 @@ jobs:
 
   vsl-and-vtl-compile:
     runs-on: ubuntu-20.04
-    if: >
-      github.event_name != 'push'
-      || github.event.ref == 'refs/heads/master'
-      || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -no-parallel

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   vab-compiles-v-examples:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VAB_FLAGS: --api 30 --build-tools 29.0.0 -v 3
@@ -59,7 +59,7 @@ jobs:
 
   v-compiles-os-android:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   vinix-build:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 10
     env:
       VFLAGS: -gc none

--- a/.github/workflows/wasm_backend_tests_ci.yml
+++ b/.github/workflows/wasm_backend_tests_ci.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   wasm-backend-ubuntu:
     runs-on: ubuntu-22.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
 
   wasm-backend-macos:
     runs-on: macOS-12
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
 
 #  wasm-backend-windows:
 #    runs-on: windows-2022
-#    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+#    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
 #    timeout-minutes: 121
 #    steps:
 #      - uses: actions/checkout@v4

--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   websocket_tests:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   gcc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 271
     env:
       VFLAGS: -cc gcc
@@ -71,7 +71,7 @@ jobs:
 
   msvc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 271
     env:
       VFLAGS: -cc msvc
@@ -117,7 +117,7 @@ jobs:
 
   tcc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.event.ref == 'refs/heads/master' || github.event.repository.full_name != 'vlang/v'
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 181
     env:
       VFLAGS: -cc tcc -no-retry-compilation


### PR DESCRIPTION
The PR updates the workflow condition that ensures that workflows run on all branches on forks, initially added here https://github.com/vlang/v/pull/14498

The PR simplifies the conditions by accessing the required values directly instead of retrieving them from a further nested event object.

I double-checked the correctness of the values with the docs and by reviewing their values on a fork. Still, please don't hesitate to share any potential concerns so they can be addressed. The change is part of a more exciting evolution that I'm preparing for a follow-up that will help improve developer convenience, but this one could be a nice to have in the history separately. 