### PR TITLE
tools: improve `v symlink -githubci` diagnostic message, when used outside CIs or with sudo

### DIFF
--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout V
         uses: actions/checkout@v4
       - name: Build V
-        run: make && ./v symlink -githubci
+        run: make && sudo ./v symlink -githubci
       - name: Check if V is usable
         run: |
           pwd
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout V
         uses: actions/checkout@v4
       - name: Build V
-        run: make && ./v symlink -githubci
+        run: make && sudo ./v symlink -githubci
       - name: Check if V is usable
         run: |
           pwd

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -30,7 +30,6 @@ jobs:
           v run hi.v
           echo 'Using `sudo ./v symlink` :rocket: !!!' >> $GITHUB_STEP_SUMMARY
 
-jobs:
   check-ubuntu:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -28,7 +28,7 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
-          echo "Everything was fine" >> $GITHUB_STEP_SUMMARY
+          echo "Everything was fine :rocket:" >> $GITHUB_STEP_SUMMARY
 
   check-macos:
     runs-on: macos-13
@@ -46,7 +46,7 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
-          echo "Everything was fine on macos too" >> $GITHUB_STEP_SUMMARY
+          echo "Everything was fine on macos too :rocket:" >> $GITHUB_STEP_SUMMARY
 
   check-windows:
     runs-on: windows-2019
@@ -66,4 +66,4 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
-          echo "All fine on Windows as well" >> $GITHUB_STEP_SUMMARY
+          echo "All fine on Windows as well :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -28,6 +28,7 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
+          echo "Everything was fine" >> $GITHUB_STEP_SUMMARY
 
   check-macos:
     runs-on: macos-13
@@ -45,6 +46,7 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
+          echo "Everything was fine on macos too" >> $GITHUB_STEP_SUMMARY
 
   check-windows:
     runs-on: windows-2019
@@ -64,3 +66,4 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
+          echo "All fine on Windows as well" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -50,7 +50,6 @@ jobs:
 
   check-windows:
     runs-on: windows-2019
-    shell: bash
     steps:
       - name: Checkout V
         uses: actions/checkout@v4
@@ -59,6 +58,7 @@ jobs:
           .\make.bat
           .\v.exe symlink -githubci
       - name: Check if V is usable
+        shell: bash
         run: |
           pwd
           v version

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -12,6 +12,25 @@ on:
       - '.github/workflows/check_symlink_works.yml'
 
 jobs:
+  check-ubuntu-with-sudo:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout V
+        uses: actions/checkout@v4
+      - name: Build V
+        run: make && sudo ./v symlink
+      - name: Check if V is usable
+        run: |
+          pwd
+          v version
+          cd ~
+          pwd
+          v version
+          echo 'println(123)' > hi.v
+          v run hi.v
+          echo 'Using `sudo ./v symlink` :rocket: !!!' >> $GITHUB_STEP_SUMMARY
+
+jobs:
   check-ubuntu:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -1,0 +1,66 @@
+name: V Symlink Works
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'cmd/tools/vsymlink.v'
+      - '.github/workflows/check_symlink_works.yml'
+  pull_request:
+    paths:
+      - 'cmd/tools/vsymlink.v'
+      - '.github/workflows/check_symlink_works.yml'
+
+jobs:
+  check-ubuntu:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout V
+        uses: actions/checkout@v4
+      - name: Build V
+        run: make && ./v symlink -githubci
+      - name: Check if V is usable
+        run: |
+          pwd
+          v version
+          cd ~
+          pwd
+          v version
+          echo 'println(123)' > hi.v
+          v run hi.v
+
+  check-macos:
+    runs-on: macos-13
+    steps:
+      - name: Checkout V
+        uses: actions/checkout@v4
+      - name: Build V
+        run: make && ./v symlink -githubci
+      - name: Check if V is usable
+        run: |
+          pwd
+          v version
+          cd ~
+          pwd
+          v version
+          echo 'println(123)' > hi.v
+          v run hi.v
+
+  check-windows:
+    runs-on: windows-2019
+    steps:
+      - name: Checkout V
+        uses: actions/checkout@v4
+      - name: Build V
+        run: |
+          .\make.bat
+          .\v.exe symlink -githubci
+      - name: Check if V is usable
+        run: |
+          pwd
+          v version
+          cd c:\
+          pwd
+          v version
+          echo 'println(123)' > hi.v
+          v run hi.v

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout V
         uses: actions/checkout@v4
       - name: Build V
-        run: make && sudo ./v symlink -githubci
+        run: make && ./v symlink -githubci
       - name: Check if V is usable
         run: |
           pwd
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout V
         uses: actions/checkout@v4
       - name: Build V
-        run: make && sudo ./v symlink -githubci
+        run: make && ./v symlink -githubci
       - name: Check if V is usable
         run: |
           pwd

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           pwd
           v version
-          cd c:\
+          cd ~
           pwd
           v version
           echo 'println(123)' > hi.v

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -46,10 +46,11 @@ jobs:
           v version
           echo 'println(123)' > hi.v
           v run hi.v
-          echo "Everything was fine on macos too :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "Everything fine on macos too :rocket:" >> $GITHUB_STEP_SUMMARY
 
   check-windows:
     runs-on: windows-2019
+    shell: bash
     steps:
       - name: Checkout V
         uses: actions/checkout@v4

--- a/cmd/tools/vsymlink.v
+++ b/cmd/tools/vsymlink.v
@@ -39,7 +39,12 @@ fn setup_symlink_github() {
 	// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
 	// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
 	mut content := os.read_file(os.getenv('GITHUB_PATH')) or {
-		panic('Failed to read GITHUB_PATH.')
+		eprintln('The `GITHUB_PATH` env variable is not defined.')
+		eprintln('    This command: `v symlink -githubci` is intended to be used within GithubActions .yml files.')
+		eprintln('    It also needs to be run *as is*, *** without `sudo` ***, otherwise it will not work.')
+		eprintln('    For local usage, outside CIs, on !windows, prefer `sudo ./v symlink` .')
+		eprintln('    On windows, use `.\\v.exe symlink` instead.')
+		exit(1)
 	}
 	content += '\n${os.getwd()}\n'
 	os.write_file(os.getenv('GITHUB_PATH'), content) or { panic('Failed to write to GITHUB_PATH.') }


### PR DESCRIPTION
- **ci: add check_symlink_works.yml**
- **ci, experiment: try using `sudo ./v symlink -githubci`, for linux and macos**
- **ci: remove sudo usage, improve the diagnostic message for `sudo ./v symlink -githubci`.**
- **ci: checkout appending to GITHUB_STEP_SUMMARY**
- **ci: use :rocket: for GITHUB_STEP_SUMMARY**
- **ci: use shell: bash for the windows job**
- **ci: use shell: bash for the windows task (shell: is not valid for the entire job)**
- **ci: use cd ~ with bash on windows too**
