### PR TITLE
ci: update detection of workflow cancellation scenarios

### DIFF
--- a/.github/workflows/bootstrapping_works_ci.yml
+++ b/.github/workflows/bootstrapping_works_ci.yml
@@ -10,9 +10,12 @@ on:
     paths-ignore:
       - "**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bootstrapping-works:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]

--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -19,12 +19,11 @@ on:
       - 'tutorials/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-doom:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12]
@@ -59,7 +58,6 @@ jobs:
           WAD_FILE=~/DOOM1.WAD ~/code/doom/build_whole_project.sh
 
   test-regression:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:

--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -12,11 +12,13 @@ on:
       - '**.yml'
       - '!**/cross_ci.yml'
 
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   macos-cross:
     runs-on: macos-latest
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 25
     env:
       VFLAGS: -cc clang
@@ -48,7 +50,6 @@ jobs:
 
   linux-cross:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 25
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -97,7 +98,6 @@ jobs:
 
   windows-cross:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker_alpine.yml
+++ b/.github/workflows/docker_alpine.yml
@@ -5,19 +5,20 @@ on:
     paths-ignore:
       - "**.md"
       - "**.yml"
+      - '!**/docker_alpine.yml'
   pull_request:
     paths-ignore:
       - "**.md"
       - "**.yml"
+      - '!**/docker_alpine.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   alpine-docker-musl-gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 241
     container:
       image: thevlang/vlang:alpine-build

--- a/.github/workflows/docker_ubuntu.yml
+++ b/.github/workflows/docker_ubuntu.yml
@@ -5,19 +5,20 @@ on:
     paths-ignore:
       - "**.md"
       - "**.yml"
+      - "!**/docker_ubuntu.yml"
   pull_request:
     paths-ignore:
       - "**.md"
       - "**.yml"
+      - "!**/docker_ubuntu.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   ubuntu-docker-musl:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     container:
       image: thevlang/vlang:ubuntu-build

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -8,8 +8,11 @@ on:
   push:
     paths-ignore:
       - "**.yml"
+      - "!**/docs_ci.yml"
   pull_request:
     paths-ignore:
+      - "**.yml"
+      - "!**/docs_ci.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -10,12 +10,14 @@ on:
       - "**.yml"
   pull_request:
     paths-ignore:
-      - "**.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-markdown:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +30,6 @@ jobs:
 
   report-missing-fn-doc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 5
     env:
       MOPTIONS: --diff --deprecated --relative-paths --exclude /vlib/v/ --exclude /builtin/linux_bare/ --exclude /testdata/ --exclude /tests/

--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -19,13 +19,12 @@ on:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
 
 jobs:
   build-vc:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
       - name: Build V

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -12,10 +12,13 @@ on:
       - '**.yml'
       - '!**/gg_regressions_ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gg-regressions:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 20
     env:
       VFLAGS: -cc tcc

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -13,13 +13,12 @@ on:
       - '!**/linux_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   tcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -99,7 +98,6 @@ jobs:
 
   tcc-boehm-gc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -156,7 +154,6 @@ jobs:
 
   gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -262,7 +259,6 @@ jobs:
 
   clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -13,13 +13,12 @@ on:
       - '!**/macos_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   clang:
     runs-on: macOS-12
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang

--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -19,13 +19,12 @@ on:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
 
 jobs:
   build-module-docs:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
       - name: Build V

--- a/.github/workflows/native_backend_tests_ci.yml
+++ b/.github/workflows/native_backend_tests_ci.yml
@@ -43,7 +43,7 @@ on:
       - 'vlib/v/gen/native/tests/**.v'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -56,7 +56,6 @@ jobs:
           windows-2019
         ]
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -13,13 +13,12 @@ on:
       - '!**/other_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   no-gpl-by-accident:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +28,6 @@ jobs:
 
   code-formatting:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       VFLAGS: -cc gcc
@@ -46,7 +44,6 @@ jobs:
 
   performance-regressions:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       VFLAGS: -cc gcc
@@ -71,7 +68,6 @@ jobs:
 
   misc-tooling:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation
@@ -111,7 +107,6 @@ jobs:
 
   parser-silent:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/paths_ci.yml
+++ b/.github/workflows/paths_ci.yml
@@ -4,19 +4,19 @@ on:
   push:
     paths-ignore:
       - "**.md"
+      - '!**/paths_ci.yml'
   pull_request:
     paths-ignore:
       - "**.md"
+      - '!**/paths_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
-
   space-paths-linux:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       MY_V_PATH: '你好 my $path, @с интервали'
@@ -42,7 +42,6 @@ jobs:
 
   space-paths-macos:
     runs-on: macos-14
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       MY_V_PATH: '你好 my $path, @с интервали'
@@ -71,7 +70,6 @@ jobs:
 
   space-paths-windows:
     runs-on: windows-2022
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       MY_V_PATH: 'path with some $punctuation, and some spaces'

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -70,13 +70,12 @@ on:
       - 'vlib/v/embed_file/**.v'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   tests-sanitize-undefined-clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc clang
@@ -101,7 +100,6 @@ jobs:
 
   tests-sanitize-undefined-gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc gcc
@@ -125,7 +123,6 @@ jobs:
 
   tests-sanitize-address-clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc clang
@@ -154,7 +151,6 @@ jobs:
 
   tests-sanitize-address-msvc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc msvc
@@ -183,7 +179,6 @@ jobs:
 
   tests-sanitize-address-gcc:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc gcc
@@ -212,7 +207,6 @@ jobs:
 
   tests-sanitize-memory-clang:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 240
     env:
       VFLAGS: -cc clang -gc none

--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -14,13 +14,12 @@ on:
       - '!**/sdl_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   v-compiles-sdl-examples:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     env:
       VFLAGS: -cc tcc

--- a/.github/workflows/time_ci.yml
+++ b/.github/workflows/time_ci.yml
@@ -13,12 +13,11 @@ on:
       - '!**/time_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   test-time-linux:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +35,6 @@ jobs:
         run: TZ=Europe/Paris ./v test vlib/time/
 
   test-time-macos:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +52,6 @@ jobs:
         run: TZ=Europe/Paris ./v test vlib/time/
 
   test-time-windows:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -12,10 +12,13 @@ on:
       - '**.yml'
       - '!**/toml_ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   toml-module-pass-external-test-suites:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -13,13 +13,12 @@ on:
       - '!**/v_apps_and_modules_compile_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   v-apps-compile:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -203,7 +202,6 @@ jobs:
 
   vsl-and-vtl-compile:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -no-parallel

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -13,10 +13,13 @@ on:
       - '**.yml'
       - '!**/vab_ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vab-compiles-v-examples:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VAB_FLAGS: --api 30 --build-tools 29.0.0 -v 3
@@ -59,7 +62,6 @@ jobs:
 
   v-compiles-os-android:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -13,10 +13,13 @@ on:
       - "**.yml"
       - "!**/vinix_ci.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vinix-build:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 10
     env:
       VFLAGS: -gc none

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -11,7 +11,7 @@ on:
       - '**/cmd/tools/vpm/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wasm_backend_tests_ci.yml
+++ b/.github/workflows/wasm_backend_tests_ci.yml
@@ -41,13 +41,12 @@ on:
       - 'vlib/v/gen/wasm/tests/**.v'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   wasm-backend-ubuntu:
     runs-on: ubuntu-22.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +68,6 @@ jobs:
 
   wasm-backend-macos:
     runs-on: macOS-12
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +88,6 @@ jobs:
 
 #  wasm-backend-windows:
 #    runs-on: windows-2022
-#    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
 #    timeout-minutes: 121
 #    steps:
 #      - uses: actions/checkout@v4

--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -12,10 +12,13 @@ on:
       - '**.yml'
       - '!**/websockets_ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   websocket_tests:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 121
     env:
       VFLAGS: -cc tcc -no-retry-compilation

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -13,13 +13,12 @@ on:
       - '!**/windows_ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:
   gcc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 271
     env:
       VFLAGS: -cc gcc
@@ -71,7 +70,6 @@ jobs:
 
   msvc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 271
     env:
       VFLAGS: -cc msvc
@@ -117,7 +115,6 @@ jobs:
 
   tcc:
     runs-on: windows-2019
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || github.repository != 'vlang/v'
     timeout-minutes: 181
     env:
       VFLAGS: -cc tcc -no-retry-compilation


### PR DESCRIPTION
The change should improve and extend our current concurrency and cancellation management. In doing this, it should also allow for simplifications.

The main change is about using concurrency groups that are more tailored to relevant scenarios:

- It will make adding conditions to every job obsolete, which are currently required to control workflow runs for forks and to prevent CI pollution on the original repository.
- It will make it more pleasant to work on branches on forks before opening PRs. Currently, pushing changes to the same branch on a fork will not cancel running and waiting workflows, unlike in a PR. Therefore, it's easy to run into blocked CI that would require long waiting times or manual cancellation to free the CI pipeline. Now, making the cancellation policy on a fork branch the same as for a PR should be the most helpful CI behavior.