### PR TITLE
ci: add tools ci

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -6,11 +6,16 @@ on:
       - '**.md'
       - '**.yml'
       - '!**/linux_ci.yml'
+      - 'cmd/tools'
+      - '!cmd/tools/builders/**.v'
   pull_request:
     paths-ignore:
       - '**.md'
       - '**.yml'
       - '!**/linux_ci.yml'
+      - 'cmd/tools'
+      - '!cmd/tools/builders/**.v'
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
@@ -64,9 +69,9 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: ./v test-self
+        run: ./v test-self vlib
       # - name: Self tests (-cstrict)
-      #   run: V_CI_CSTRICT=1 ./v -cstrict test-self
+      #   run: V_CI_CSTRICT=1 ./v -cstrict test-self vlib
       - name: Build examples
         run: ./v -W build-examples
       - name: Run the submodule example, using a relative path
@@ -156,11 +161,11 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: ./v test-self
+        run: ./v test-self vlib
       - name: Self tests (-prod)
-        run: ./v -o vprod -prod cmd/v && ./vprod test-self
+        run: ./v -o vprod -prod cmd/v && ./vprod test-self vlib
       - name: Self tests (-cstrict)
-        run: VTEST_JUST_ESSENTIAL=1 V_CI_CSTRICT=1 ./v -cc gcc -cstrict test-self
+        run: VTEST_JUST_ESSENTIAL=1 V_CI_CSTRICT=1 ./v -cc gcc -cstrict test-self vlib
       - name: Build examples
         run: ./v build-examples
       - name: Build tetris with -autofree
@@ -259,13 +264,11 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: ./v test-self
+        run: ./v test-self vlib
       - name: Self tests (vprod)
-        run: |
-          ./v -o vprod -prod cmd/v
-          ./vprod test-self
+        run: ./v -o vprod -prod cmd/v && ./vprod test-self vlib
       - name: Self tests (-cstrict)
-        run: VTEST_JUST_ESSENTIAL=1 V_CI_CSTRICT=1 ./vprod -cstrict test-self
+        run: VTEST_JUST_ESSENTIAL=1 V_CI_CSTRICT=1 ./vprod -cstrict test-self vlib
 
       - name: Build examples
         run: ./v build-examples
@@ -334,4 +337,4 @@ jobs:
   #   - name: quick debug
   #     run: ./v -stats vlib/strconv/format_test.v
   #   - name: Self tests
-  #     run: ./v test-self
+  #     run: ./v test-self vlib

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -6,11 +6,15 @@ on:
       - '**.md'
       - '**.yml'
       - '!**/macos_ci.yml'
+      - 'cmd/tools'
+      - '!cmd/tools/builders/**.v'
   pull_request:
     paths-ignore:
       - '**.md'
       - '**.yml'
       - '!**/macos_ci.yml'
+      - 'cmd/tools'
+      - '!cmd/tools/builders/**.v'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
@@ -63,7 +67,7 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: VJOBS=1 ./v test-self
+        run: VJOBS=1 ./v test-self vlib
       - name: Build examples
         run: ./v build-examples
       - name: Build tetris with -autofree

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -17,8 +17,6 @@ on:
       - '!**'
       - '!**.md'
       - '!**.yml'
-      - 'cmd/tools/vtest*'
-      - 'cmd/tools/builders/**.v'
       - 'vlib/builtin/**.v'
       - 'vlib/strconv/**.v'
       - 'vlib/strings/**.v'
@@ -44,8 +42,6 @@ on:
   pull_request:
     paths:
       - '!**'
-      - 'cmd/tools/vtest*'
-      - 'cmd/tools/builders/**.v'
       - 'vlib/builtin/**.v'
       - 'vlib/strconv/**.v'
       - 'vlib/strings/**.v'
@@ -94,7 +90,7 @@ jobs:
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Self tests (-fsanitize=undefined)
-        run: ./v -cflags "-fsanitize=undefined" -o v2 cmd/v && ./v2 -cflags -fsanitize=undefined test-self
+        run: ./v -cflags "-fsanitize=undefined" -o v2 cmd/v && ./v2 -cflags -fsanitize=undefined test-self vlib
       - name: Build examples (V compiled with -fsanitize=undefined)
         run: ./v2 build-examples
 
@@ -141,11 +137,11 @@ jobs:
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Self tests (-fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self
+        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self vlib
       - name: Self tests (V compiled with -fsanitize=address)
         run:
           ./v -cflags -fsanitize=address -o v cmd/v &&
-          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler
+          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=address)
         run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
@@ -175,7 +171,7 @@ jobs:
       ##          .\.github\workflows\windows-install-sqlite.bat
       ##      - name: Self tests (TODO: /fsanitize=address)
       ##        run: |
-      ##          .\v.exe -cflags "/fsanitize=address" test-self
+      ##          .\v.exe -cflags "/fsanitize=address" test-self vlib
 
   tests-sanitize-address-gcc:
     runs-on: ubuntu-20.04
@@ -197,11 +193,11 @@ jobs:
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Self tests (-fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-self
+        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-self vlib
       - name: Self tests (V compiled with -fsanitize=address)
         run:
           ./v -cflags -fsanitize=address,pointer-compare,pointer-subtract -o v cmd/v &&
-          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler
+          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=address)
         run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
@@ -225,10 +221,10 @@ jobs:
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Self tests (-fsanitize=memory)
-        run: ./v -cflags -fsanitize=memory test-self
+        run: ./v -cflags -fsanitize=memory test-self vlib
       - name: Self tests (V compiled with -fsanitize=memory)
         run: |
           ./v -cflags -fsanitize=memory -o v cmd/v
-          ./v -cc tcc test-self -msan-compiler
+          ./v -cc tcc test-self -msan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=memory)
         run: ./v build-examples

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -1,0 +1,63 @@
+name: Tools CI
+
+on:
+  push:
+    paths:
+      - '**/tools_ci.yml'
+      - 'cmd/tools/**'
+      - 'vlib/**'
+      - 'thirdparty/**'
+      - '!**.md'
+  pull_request:
+    paths:
+      - '**/tools_ci.yml'
+      - 'cmd/tools/**'
+      - 'vlib/**'
+      - 'thirdparty/**'
+      - '!**.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-12]
+        optimization: ['', -prod]
+        include:
+          - os: ubuntu-20.04
+            cc: tcc
+          - os: ubuntu-20.04
+            cc: gcc
+          - os: ubuntu-20.04
+            cc: clang
+          - os: windows-2019
+            cc: tcc
+          - os: windows-2019
+            cc: gcc
+          - os: windows-2019
+            cc: msvc
+          - os: macos-12
+            cc: clang
+          - optimization: -cflags -fsanitize=undefined
+            os: ubuntu-20.04
+            cc: clang
+          - optimization: -cflags -fsanitize=memory
+            os: ubuntu-20.04
+            cc: clang
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      VFLAGS: -cc ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        if: runner.os != 'Windows'
+        run: make -j4 && ./v ${{ matrix.optimization }} -showcc -o v cmd/v && ./v doctor
+      - name: Build V (Windows)
+        if: runner.os == 'Windows'
+        run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 ${{ matrix.optimization }} -showcc -o v.exe cmd/v && ./v doctor
+      - name: Test
+        run: ./v ${{ matrix.optimization }} -d network test-self cmd/tools

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -49,7 +49,7 @@ jobs:
             cmd="./v -cc clang -cflags -fsanitize=memory test-self cmd"
             echo $cmd && $cmd
           else
-            # TODO: enable thread sanitzer after switching to ubuntu-22.04. Ref. https://github.com/orgs/community/discussions/63391
+            # TODO: enable thread sanitizer after switching to ubuntu-22.04. Ref. https://github.com/orgs/community/discussions/63391
             # cmd="./v -cc gcc -cflags -fsanitize=thread test-self cmd"
             # echo $cmd && $cmd
             cmd="./v -cc gcc -cflags -fsanitize=address,leak,undefined,shift,shift-exponent,shift-base,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,bounds-strict,alignment,object-size,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr test-self cmd/tools"

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -36,28 +36,25 @@ jobs:
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Test
-        run: ./v test-self cmd/tools
+        run: ./v test-self cmd
       - name: Test (-cstrict)
         if: ${{ matrix.cc != 'tcc' }}
-        run: ./v -cstrict test-self cmd/tools
-      - name: Test (-prod)
-        if: ${{ matrix.cc != 'tcc' }}
-        run: ./v -prod test-self cmd/tools
+        run: ./v -W -cstrict test-self cmd
       - name: Test sanitized
         if: ${{ matrix.cc != 'tcc' }}
         run: |
           if [[ ${{ matrix.cc }} == "clang" ]]; then
-            cmd="./v -cc clang -cflags -fsanitize=undefined test-self cmd/tools"
+            cmd="./v -cc clang -cflags -fsanitize=undefined test-self cmd"
             echo $cmd && $cmd
-            cmd="./v -cc clang -cflags -fsanitize=memory test-self cmd/tools"
+            cmd="./v -cc clang -cflags -fsanitize=memory test-self cmd"
             echo $cmd && $cmd
           else
             # TODO: enable thread sanitzer after switching to ubuntu-22.04. Ref. https://github.com/orgs/community/discussions/63391
-            # cmd="./v -cc gcc -cflags -fsanitize=thread test-self cmd/tools"
+            # cmd="./v -cc gcc -cflags -fsanitize=thread test-self cmd"
             # echo $cmd && $cmd
             cmd="./v -cc gcc -cflags -fsanitize=address,leak,undefined,shift,shift-exponent,shift-base,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,bounds-strict,alignment,object-size,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr test-self cmd/tools"
             echo $cmd && $cmd
-            # cmd="./v -cc gcc -cflags -fsanitize=kernel-address test-self cmd/tools"
+            # cmd="./v -cc gcc -cflags -fsanitize=kernel-address test-self cmd"
             # echo $cmd && $cmd
           fi
 
@@ -74,11 +71,9 @@ jobs:
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Test
-        run: ./v test-self cmd/tools
+        run: ./v test-self cmd
       - name: Test (-cstrict)
-        run: ./v -cstrict test-self cmd/tools
-      - name: Test (-prod)
-        run: ./v -prod test-self cmd/tools
+        run: ./v -W -cstrict test-self cmd
 
   windows:
     runs-on: windows-2019
@@ -93,10 +88,7 @@ jobs:
       - name: Build V
         run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
       - name: Test
-        run: ./v test-self cmd/tools
+        run: ./v test-self cmd
       - name: Test (-cstrict)
         if: ${{ matrix.cc == 'msvc' }}
-        run: ./v -cstrict test-self cmd/tools
-      - name: Test (-prod)
-        if: ${{ matrix.cc != 'tcc' }}
-        run: ./v -prod test-self cmd/tools
+        run: ./v -W -cstrict test-self cmd

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -3,18 +3,20 @@ name: Tools CI
 on:
   push:
     paths:
-      - '**/tools_ci.yml'
-      - 'cmd/tools/**'
+      - 'cmd/**'
+      - '!cmd/tools/vpm/**'
       - 'vlib/**'
       - 'thirdparty/**'
       - '!**.md'
+      - '**/tools_ci.yml'
   pull_request:
     paths:
-      - '**/tools_ci.yml'
-      - 'cmd/tools/**'
+      - 'cmd/**'
+      - '!cmd/tools/vpm/**'
       - 'vlib/**'
       - 'thirdparty/**'
       - '!**.md'
+      - '**/tools_ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
@@ -34,27 +36,28 @@ jobs:
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Test
-        run: ./v -d network test-self cmd/tools
+        run: ./v test-self cmd/tools
       - name: Test (-cstrict)
         if: ${{ matrix.cc != 'tcc' }}
-        run: ./v -cstrict -d network test-self cmd/tools
+        run: ./v -cstrict test-self cmd/tools
       - name: Test (-prod)
         if: ${{ matrix.cc != 'tcc' }}
-        run: ./v -prod -d network test-self cmd/tools
+        run: ./v -prod test-self cmd/tools
       - name: Test sanitized
         if: ${{ matrix.cc != 'tcc' }}
         run: |
           if [[ ${{ matrix.cc }} == "clang" ]]; then
-            cmd="./v -cc clang -cflags -fsanitize=undefined -d network test-self cmd/tools"
+            cmd="./v -cc clang -cflags -fsanitize=undefined test-self cmd/tools"
             echo $cmd && $cmd
-            cmd="./v -cc clang -cflags -fsanitize=memory -d network test-self cmd/tools"
+            cmd="./v -cc clang -cflags -fsanitize=memory test-self cmd/tools"
             echo $cmd && $cmd
           else
-            # ./v -cc gcc -cflags -fsanitize=kernel-address -d network test-self cmd/tools
-            cmd="./v -cc gcc -cflags -fsanitize=thread -d network test-self cmd/tools"
+            cmd="./v -cc gcc -cflags -fsanitize=thread test-self cmd/tools"
             echo $cmd && $cmd
-            cmd="./v -cc gcc -cflags -fsanitize=address,leak,undefined,shift,shift-exponent,shift-base,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,bounds-strict,alignment,object-size,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr -d network test-self cmd/tools"
+            cmd="./v -cc gcc -cflags -fsanitize=address,leak,undefined,shift,shift-exponent,shift-base,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,bounds-strict,alignment,object-size,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr test-self cmd/tools"
             echo $cmd && $cmd
+            # cmd="./v -cc gcc -cflags -fsanitize=kernel-address test-self cmd/tools"
+            # echo $cmd && $cmd
           fi
 
   macos:
@@ -70,11 +73,11 @@ jobs:
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Test
-        run: ./v -d network test-self cmd/tools
+        run: ./v test-self cmd/tools
       - name: Test (-cstrict)
-        run: ./v -cstrict -d network test-self cmd/tools
+        run: ./v -cstrict test-self cmd/tools
       - name: Test (-prod)
-        run: ./v -prod -d network test-self cmd/tools
+        run: ./v -prod test-self cmd/tools
 
   windows:
     runs-on: windows-2019
@@ -89,10 +92,10 @@ jobs:
       - name: Build V
         run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
       - name: Test
-        run: ./v -d network test-self cmd/tools
+        run: ./v test-self cmd/tools
       - name: Test (-cstrict)
-        if: ${{ matrix.cc == 'msvc' }}
-        run: ./v -cstrict -d network test-self cmd/tools
+        if: ${{ matrix.cc != 'tcc' }}
+        run: ./v -cstrict test-self cmd/tools
       - name: Test (-prod)
         if: ${{ matrix.cc != 'tcc' }}
-        run: ./v -prod -d network test-self cmd/tools
+        run: ./v -prod test-self cmd/tools

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -52,8 +52,9 @@ jobs:
             cmd="./v -cc clang -cflags -fsanitize=memory test-self cmd/tools"
             echo $cmd && $cmd
           else
-            cmd="./v -cc gcc -cflags -fsanitize=thread test-self cmd/tools"
-            echo $cmd && $cmd
+            # TODO: enable thread sanitzer after switching to ubuntu-22.04. Ref. https://github.com/orgs/community/discussions/63391
+            # cmd="./v -cc gcc -cflags -fsanitize=thread test-self cmd/tools"
+            # echo $cmd && $cmd
             cmd="./v -cc gcc -cflags -fsanitize=address,leak,undefined,shift,shift-exponent,shift-base,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,bounds-strict,alignment,object-size,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr test-self cmd/tools"
             echo $cmd && $cmd
             # cmd="./v -cc gcc -cflags -fsanitize=kernel-address test-self cmd/tools"
@@ -94,7 +95,7 @@ jobs:
       - name: Test
         run: ./v test-self cmd/tools
       - name: Test (-cstrict)
-        if: ${{ matrix.cc != 'tcc' }}
+        if: ${{ matrix.cc == 'msvc' }}
         run: ./v -cstrict test-self cmd/tools
       - name: Test (-prod)
         if: ${{ matrix.cc != 'tcc' }}

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
+        run: ./make.bat -${{ matrix.cc }} && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
       - name: Test
         run: ./v test-self cmd
       - name: Test (-cstrict)

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -21,43 +21,78 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  linux:
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
-        optimization: ['', -prod]
-        include:
-          - os: ubuntu-20.04
-            cc: tcc
-          - os: ubuntu-20.04
-            cc: gcc
-          - os: ubuntu-20.04
-            cc: clang
-          - os: windows-2019
-            cc: tcc
-          - os: windows-2019
-            cc: gcc
-          - os: windows-2019
-            cc: msvc
-          - os: macos-12
-            cc: clang
-          - optimization: -cflags -fsanitize=undefined
-            os: ubuntu-20.04
-            cc: clang
-          - optimization: -cflags -fsanitize=memory
-            os: ubuntu-20.04
-            cc: clang
+        cc: [tcc, gcc, clang]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
     env:
       VFLAGS: -cc ${{ matrix.cc }}
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        if: runner.os != 'Windows'
-        run: make -j4 && ./v ${{ matrix.optimization }} -showcc -o v cmd/v && ./v doctor
-      - name: Build V (Windows)
-        if: runner.os == 'Windows'
-        run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 ${{ matrix.optimization }} -showcc -o v.exe cmd/v && ./v doctor
+        run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Test
-        run: ./v ${{ matrix.optimization }} -d network test-self cmd/tools
+        run: ./v -d network test-self cmd/tools
+      - name: Test (-cstrict)
+        if: ${{ matrix.cc != 'tcc' }}
+        run: ./v -cstrict -d network test-self cmd/tools
+      - name: Test (-prod)
+        if: ${{ matrix.cc != 'tcc' }}
+        run: ./v -prod -d network test-self cmd/tools
+      - name: Test sanitized
+        if: ${{ matrix.cc != 'tcc' }}
+        run: |
+          if [[ ${{ matrix.cc }} == "clang" ]]; then
+            cmd="./v -cc clang -cflags -fsanitize=undefined -d network test-self cmd/tools"
+            echo $cmd && $cmd
+            cmd="./v -cc clang -cflags -fsanitize=memory -d network test-self cmd/tools"
+            echo $cmd && $cmd
+          else
+            # ./v -cc gcc -cflags -fsanitize=kernel-address -d network test-self cmd/tools
+            cmd="./v -cc gcc -cflags -fsanitize=thread -d network test-self cmd/tools"
+            echo $cmd && $cmd
+            cmd="./v -cc gcc -cflags -fsanitize=address,leak,undefined,shift,shift-exponent,shift-base,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,bounds-strict,alignment,object-size,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr -d network test-self cmd/tools"
+            echo $cmd && $cmd
+          fi
+
+  macos:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        cc: [clang]
+      fail-fast: false
+    env:
+      VFLAGS: -cc ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
+      - name: Test
+        run: ./v -d network test-self cmd/tools
+      - name: Test (-cstrict)
+        run: ./v -cstrict -d network test-self cmd/tools
+      - name: Test (-prod)
+        run: ./v -prod -d network test-self cmd/tools
+
+  windows:
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        cc: [tcc, gcc, msvc]
+      fail-fast: false
+    env:
+      VFLAGS: -cc ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
+      - name: Test
+        run: ./v -d network test-self cmd/tools
+      - name: Test (-cstrict)
+        if: ${{ matrix.cc == 'msvc' }}
+        run: ./v -cstrict -d network test-self cmd/tools
+      - name: Test (-prod)
+        if: ${{ matrix.cc != 'tcc' }}
+        run: ./v -prod -d network test-self cmd/tools

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -6,11 +6,15 @@ on:
       - '**.md'
       - '**.yml'
       - '!**/windows_ci.yml'
+      - 'cmd/tools'
+      - '!cmd/tools/builders/**.v'
   pull_request:
     paths-ignore:
       - '**.md'
       - '**.yml'
       - '!**/windows_ci.yml'
+      - 'cmd/tools'
+      - '!cmd/tools/builders/**.v'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
@@ -50,7 +54,7 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: .\v.exe test-self
+        run: .\v.exe test-self vlib
       # - name: Test
       #   run: .\v.exe test-all
       - name: Build option_test.c.v with -autofree
@@ -99,9 +103,7 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: |
-          ./v -cg cmd\tools\vtest-self.v
-          ./v test-self
+        run: ./v -cg cmd\tools\vtest-self.v && ./v test-self vlib
       # - name: Test
       #   run: .\v.exe test-all
       - name: Test v->js
@@ -154,7 +156,7 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: ./v test-self
+        run: ./v test-self vlib
       - name: Test v->js
         run: ./v -o hi.js examples/hello_v_js.v && node hi.js
       - name: Test v binaries
@@ -196,7 +198,7 @@ jobs:
       #   run: ./v doc clipboard
       #
       # - name: Self tests
-      #   run: ./v test-self
+      #   run: ./v test-self vlib
       # - name: Test v->js
       #   run: ./v -o hi.js examples/hello_v_js.v && node hi.js
       # - name: Test v binaries

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -103,7 +103,9 @@ jobs:
       - name: Test pure V math module
         run: ./v -exclude @vlib/math/*.c.v test vlib/math/
       - name: Self tests
-        run: ./v -cg cmd\tools\vtest-self.v && ./v test-self vlib
+        run: |
+          ./v -cg cmd\tools\vtest-self.v
+          ./v test-self vlib
       # - name: Test
       #   run: .\v.exe test-all
       - name: Test v->js


### PR DESCRIPTION
With the PR, CI is intended to run as follows:

- Updates only made to cmd/tools -> run tool workflows (takes about 3 minutes), don't run regular vlib workflows
  (exception: changes to builder tools will also trigger regular workflows)
- Changes including vlib -> run regular platform workflows (now focusing on vlib) + tool workflows

Other notable changes:
- For most situations, there should also be faster workflow runs for the current platform/sanitized CI, since the tools workflow is run in parallel and tool tests are extracted from regular platform workflows.
 (there will be situations where the benefit of the parallel run will be relativized due to limited runner availability, e.g., when there are many open PRs / active workflow runs. However, there is more potential to optimize our workflows for better runner availability to maximize the occasions of the benefit - I would utilize it with further evolution of the workflows.)
- Tool tests are extended to always include sanitized test runs and to test optimization on all platforms.