### PR TITLE
test, ci: skip same files for `veb` on ubuntu musl that are skipped for `x.vweb`

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -280,6 +280,8 @@ const skip_on_ubuntu_musl = [
 	'vlib/x/sessions/tests/db_store_test.v',
 	'vlib/x/vweb/tests/vweb_test.v',
 	'vlib/x/vweb/tests/vweb_app_test.v',
+	'vlib/veb/tests/veb_test.v',
+	'vlib/veb/tests/veb_app_test.v',
 ]
 const skip_on_linux = [
 	'do_not_remove',


### PR DESCRIPTION
should fix currently failing ubuntu musl ci