### PR TITLE
tools: fix compiling vwhere with `-cc gcc -cstrict`

### DIFF
--- a/cmd/tools/vwhere/finder_utils.v
+++ b/cmd/tools/vwhere/finder_utils.v
@@ -107,7 +107,7 @@ fn invalid_option(invalid ParamOption, arg string) {
 
 fn valid_args_quantity_or_show_help(args []string) {
 	if true in [
-		args.len < 1,
+		(args.len < 1),
 		'-help' in args,
 		'--help' in args,
 		args == ['help'],


### PR DESCRIPTION
fixes:
```
v -cc gcc -cstrict cmd/tools/vwhere
```