### PR TITLE
gg: make `PenConfig` fields public

### DIFF
--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -26,6 +26,7 @@ pub type FNUnClick = fn (x f32, y f32, button MouseButton, data voidptr)
 pub type FNChar = fn (c u32, data voidptr)
 
 pub struct PenConfig {
+pub:
 	color     gx.Color
 	line_type PenLineType = .solid
 	thickness int = 1


### PR DESCRIPTION
Initializing `PenConfig` struct produces an warning (error after 2024-05-31) saying that initializing private fields is not allowed.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
