### PR TITLE
v: consitently use `apt` instead of `apt-get` for common APT subcommands

### DIFF
--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -61,9 +61,9 @@ jobs:
         run: |
           ## sudo dpkg --add-architecture i386
           .github/workflows/retry.sh sudo apt update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libssl-dev sqlite3 libsqlite3-dev
-          .github/workflows/retry.sh sudo apt-get install --quiet -y mingw-w64 wine-stable winetricks
-          ## .github/workflows/retry.sh sudo apt-get install --quiet -y wine32
+          .github/workflows/retry.sh sudo apt install --quiet -y libssl-dev sqlite3 libsqlite3-dev
+          .github/workflows/retry.sh sudo apt install --quiet -y mingw-w64 wine-stable winetricks
+          ## .github/workflows/retry.sh sudo apt install --quiet -y wine32
 
       - name: Turn off the wine crash dialog
         run: winetricks nocrashdialog

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -40,8 +40,8 @@ jobs:
           # libxcursor-dev libxi-dev : V gfx deps
           # libgl1-mesa-dri          : For headless rendering / software DRI driver (LIBGL_ALWAYS_SOFTWARE=true)
           # freeglut3-dev            : Fixes graphic apps compilation with tcc
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install imagemagick openimageio-tools libgl1-mesa-dri xvfb libxcursor-dev libxi-dev freeglut3-dev xsel xclip
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install imagemagick openimageio-tools libgl1-mesa-dri xvfb libxcursor-dev libxi-dev freeglut3-dev xsel xclip
           .github/workflows/retry.sh wget https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
           .github/workflows/retry.sh git clone https://github.com/Larpon/gg-regression-images gg-regression-images
           chmod +x ./imgur.sh

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -31,13 +31,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install --quiet -y libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
           # The following is needed for examples/wkhtmltopdf.v
           .github/workflows/retry.sh wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
-          .github/workflows/retry.sh sudo apt-get install --quiet -y xfonts-75dpi xfonts-base
-          .github/workflows/retry.sh sudo apt-get install --quiet -y expect
+          .github/workflows/retry.sh sudo apt install --quiet -y xfonts-75dpi xfonts-base
+          .github/workflows/retry.sh sudo apt install --quiet -y expect
           .github/workflows/retry.sh sudo dpkg -i wkhtmltox_0.12.6-1.focal_amd64.deb
       - name: Build v
         run: |
@@ -118,9 +118,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
       - name: Build V
         run: make -j4 && ./v -cc gcc -cg -cstrict -o v cmd/v
       - name: Valgrind v.c
@@ -225,10 +225,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
-          .github/workflows/retry.sh sudo apt-get install --quiet -y clang
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt install --quiet -y clang
       - name: Build V
         run: make -j4 && ./v -cc clang -cg -cstrict -o v cmd/v
       - name: Valgrind
@@ -327,7 +327,7 @@ jobs:
   #   - uses: actions/checkout@v4
   #   - name: Install dependencies
   #     run: |
-  #        .github/workflows/retry.sh sudo apt-get install --quiet -y musl musl-tools libssl-dev sqlite3 libsqlite3-dev valgrind
+  #        .github/workflows/retry.sh sudo apt install --quiet -y musl musl-tools libssl-dev sqlite3 libsqlite3-dev valgrind
   #   - name: Build v
   #     run: echo $VFLAGS && make -j4 && ./v -cg -o v cmd/v
   #   # - name: Test v binaries

--- a/.github/workflows/native_backend_tests_ci.yml
+++ b/.github/workflows/native_backend_tests_ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install linker
         if: ${{ startsWith(matrix.os, 'ubuntu')}}
         run: |
-          .github/workflows/retry.sh sudo apt-get install --quiet -y binutils
+          .github/workflows/retry.sh sudo apt install --quiet -y binutils
 
       - name: Build V with make.bat
         if: ${{ startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -78,10 +78,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev postgresql libpq-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
-          .github/workflows/retry.sh sudo apt-get install --quiet -y g++-9 g++-11
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev postgresql libpq-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
+          .github/workflows/retry.sh sudo apt install --quiet -y g++-9 g++-11
 
       - name: Build v
         run: make

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -81,10 +81,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
-          .github/workflows/retry.sh sudo apt-get install clang
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt install clang
       - name: Build V
         run: make && ./v -cg -cstrict -o v cmd/v
       - name: Ensure code is well formatted
@@ -106,8 +106,8 @@ jobs:
       - name: Install dependencies
         run: |
           .github/workflows/retry.sh sudo apt update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
       - name: Build V
         run: make && ./v -cg -cstrict -o v cmd/v
       - name: Ensure code is well formatted
@@ -129,9 +129,9 @@ jobs:
       - name: Install dependencies
         run: |
           .github/workflows/retry.sh sudo apt update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
-          .github/workflows/retry.sh sudo apt-get install clang
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt install clang
       - name: Build V
         run: make && ./v -cg -cstrict -o v cmd/v
       - name: Ensure code is well formatted
@@ -185,9 +185,9 @@ jobs:
       - name: Install dependencies
         run: |
           .github/workflows/retry.sh sudo apt update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
-          .github/workflows/retry.sh sudo apt-get install clang
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt install clang
       - name: Build V
         run: make && ./v -cg -cstrict -o v cmd/v
       - name: Ensure code is well formatted
@@ -213,9 +213,9 @@ jobs:
       - name: Install dependencies
         run: |
           .github/workflows/retry.sh sudo apt update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          .github/workflows/retry.sh sudo apt-get install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
-          .github/workflows/retry.sh sudo apt-get install clang
+          .github/workflows/retry.sh sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          .github/workflows/retry.sh sudo apt install --quiet -y libfreetype6-dev  libxi-dev libxcursor-dev libgl-dev
+          .github/workflows/retry.sh sudo apt install clang
       - name: Build V
         run: make && ./v -cc clang -cg -cstrict -o v cmd/v
       - name: Ensure code is well formatted

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install --quiet -y jq libgc-dev
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install --quiet -y jq libgc-dev
       - name: Build V
         run: make
 

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -29,9 +29,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          v retry -- sudo apt-get update
-          v retry -- sudo apt-get install --quiet -y libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
-          v retry -- sudo apt-get install --quiet -y --no-install-recommends sassc libgit2-dev ## needed by gitly
+          v retry -- sudo apt update
+          v retry -- sudo apt install --quiet -y libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
+          v retry -- sudo apt install --quiet -y --no-install-recommends sassc libgit2-dev ## needed by gitly
 
       - name: Test vtcc
         run: .github/workflows/compile_v_with_vtcc.sh
@@ -214,16 +214,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          v retry -- sudo apt-get update
-          v retry -- sudo apt-get install --quiet -y libgc-dev   libsodium-dev libssl-dev sqlite3 libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
-          v retry -- sudo apt-get install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev ## for vsl/vtl
-          v retry -- sudo apt-get install --quiet -y --no-install-recommends libhdf5-cpp-103 libhdf5-dev libhdf5-mpi-dev hdf5-tools libopenmpi-dev opencl-headers liblapacke-dev libopenblas-dev ## needed by VSL
+          v retry -- sudo apt update
+          v retry -- sudo apt install --quiet -y libgc-dev   libsodium-dev libssl-dev sqlite3 libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev xfonts-75dpi xfonts-base
+          v retry -- sudo apt install --quiet -y --no-install-recommends gfortran liblapacke-dev libopenblas-dev ## for vsl/vtl
+          v retry -- sudo apt install --quiet -y --no-install-recommends libhdf5-cpp-103 libhdf5-dev libhdf5-mpi-dev hdf5-tools libopenmpi-dev opencl-headers liblapacke-dev libopenblas-dev ## needed by VSL
 
       - name: Build vlang/vsl
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           echo "Installing dependencies"
-          v retry -- sudo apt-get install --quiet -y --no-install-recommends \
+          v retry -- sudo apt install --quiet -y --no-install-recommends \
             gfortran \
             libxi-dev \
             libxcursor-dev \

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          .github/workflows/retry.sh sudo apt-get update
-          .github/workflows/retry.sh sudo apt-get install build-essential meson -y
+          .github/workflows/retry.sh sudo apt update
+          .github/workflows/retry.sh sudo apt install build-essential meson -y
 
       - name: Build V
         run: make

--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: .github/workflows/retry.sh sudo apt-get install --quiet -y libssl-dev
+        run: .github/workflows/retry.sh sudo apt install --quiet -y libssl-dev
       - name: Build v
         run: |
           echo $VFLAGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /opt/vlang
 
 ARG USE_LOCAL
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc clang make git binutils && \
-    apt-get clean && rm -rf /var/cache/apt/archives/* && \
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends gcc clang make git binutils && \
+    apt clean && rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /vlang-local

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6986,7 +6986,7 @@ v -os linux .
 For Ubuntu/Debian based distributions:
 
 ```shell
-sudo apt-get install gcc-mingw-w64-x86-64
+sudo apt install gcc-mingw-w64-x86-64
 ```
 
 For Arch based distributions:

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -14,7 +14,7 @@ $if freebsd {
 }
 #flag -lX11
 
-#include <X11/Xlib.h> # Please install a package with the X11 development headers, for example: `apt-get install libx11-dev`
+#include <X11/Xlib.h> # Please install a package with the X11 development headers, for example: `apt install libx11-dev`
 // X11
 
 @[typedef]

--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -21,7 +21,7 @@ sudo systemctl start  postgresql
 ### Ubuntu/Debian
 
 ```
-sudo apt-get install postgresql postgresql-client
+sudo apt install postgresql postgresql-client
 sudo systemctl enable postgresql # to autostart on startup
 sudo systemctl start  postgresql
 ```
@@ -41,7 +41,7 @@ gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin
 
 ## Installing libpq-dev or its equivalent for your OS:
 
-**Ubuntu/Debian**: `sudo apt-get install libpq-dev`
+**Ubuntu/Debian**: `sudo apt install libpq-dev`
 
 **Red Hat Linux (RHEL)**: `yum install postgresql-devel`
 

--- a/vlib/net/websocket/tests/autobahn/local_run/Dockerfile
+++ b/vlib/net/websocket/tests/autobahn/local_run/Dockerfile
@@ -6,7 +6,7 @@ FROM node:12.6-buster-slim
 
 COPY config/fuzzingserver.json /config/fuzzingserver.json
 RUN chmod +775 /config/fuzzingserver.json
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt update && \
+    apt install -y \
     docker \
     docker-compose

--- a/vlib/v/checker/tests/array_plus_assign_err.out
+++ b/vlib/v/checker/tests/array_plus_assign_err.out
@@ -1,8 +1,8 @@
 vlib/v/checker/tests/array_plus_assign_err.vv:1:5: warning: unused variable: `buffer`
     1 | mut buffer := []u8{cap: 1024}
       |     ~~~~~~
-    2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
+    2 | buffer += "ipconfig && sudo apt install -y some_amazing_package name + command output".bytes()
 vlib/v/checker/tests/array_plus_assign_err.vv:2:1: error: operator `+=` not defined on left operand type `[]u8`
     1 | mut buffer := []u8{cap: 1024}
-    2 | buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
+    2 | buffer += "ipconfig && sudo apt install -y some_amazing_package name + command output".bytes()
       | ~~~~~~

--- a/vlib/v/checker/tests/array_plus_assign_err.vv
+++ b/vlib/v/checker/tests/array_plus_assign_err.vv
@@ -1,2 +1,2 @@
 mut buffer := []u8{cap: 1024}
-buffer += "ipconfig && sudo apt-get install -y some_amazing_package name + command output".bytes()
+buffer += "ipconfig && sudo apt install -y some_amazing_package name + command output".bytes()

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -215,7 +215,7 @@ see also `v help build`.
       installing it), you can also tell V to use it instead of its own copy,
       by adding `-d dynamic_boehm` to the command line while compiling your program.
 
-      On Debian you can use `sudo apt-get install libgc-dev`.
+      On Debian you can use `sudo apt install libgc-dev`.
 
       On macOS, you can install it, using homebrew (https://homebrew.sh/)
       with `brew install libgc`.


### PR DESCRIPTION
Shouldn't be a crime to use the more modern `apt` command here if not needing features that are specific to `apt-get`. The latter for installing packages is reserved for my grandpa.