### PR TITLE
ci: update `binary_artifact.yml`

### DIFF
--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -139,6 +139,8 @@ jobs:
            rm -rf vc/
            rm -rf v_old.exe
            rm -rf vlib/v/tests/bench/gcboehm/*.svg
+           find |grep pdb$|xargs rm -rf
+           find |grep ilk$|xargs rm -rf
       - name: Create archive
         shell: msys2 {0}
         run: |

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -29,11 +29,11 @@ jobs:
           ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
       - name: Remove excluded
         run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+          rm -rf .git/
+          rm -rf thirdparty/tcc/.git/
+          rm -rf vc/
+          rm -rf v_old
+          rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
           cd ..
@@ -93,11 +93,11 @@ jobs:
           git clone --branch thirdparty-macos-arm64 --depth=1 https://github.com/vlang/tccbin thirdparty/tcc
       - name: Remove excluded
         run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+          rm -rf .git/
+          rm -rf thirdparty/tcc/.git/
+          rm -rf vc/
+          rm -rf v_old
+          rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
           cd ..
@@ -129,11 +129,11 @@ jobs:
       - name: Remove excluded
         shell: msys2 {0}
         run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+          rm -rf .git/
+          rm -rf thirdparty/tcc/.git/
+          rm -rf vc/
+          rm -rf v_old.exe
+          rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create archive
         shell: msys2 {0}
         run: |

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -36,10 +36,10 @@ jobs:
            rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
-          cd ..
-          zip -r9 --symlinks $ZIPNAME v/
-          mv $ZIPNAME v/
-          cd v/
+           cd ..
+           zip -r9 --symlinks $ZIPNAME v/
+           mv $ZIPNAME v/
+           cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
@@ -63,10 +63,10 @@ jobs:
         run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
-          cd ..
-          zip -r9 --symlinks $ZIPNAME v/
-          mv $ZIPNAME v/
-          cd v/
+           cd ..
+           zip -r9 --symlinks $ZIPNAME v/
+           mv $ZIPNAME v/
+           cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
@@ -137,11 +137,11 @@ jobs:
       - name: Create archive
         shell: msys2 {0}
         run: |
-          cd ..
-          # Use `powershell Compress-Archive`, because `zip` is not installed by default.
-          powershell Compress-Archive v $ZIPNAME
-          mv $ZIPNAME v/
-          cd v/
+           cd ..
+           # Use `powershell Compress-Archive`, because `zip` is not installed by default.
+           powershell Compress-Archive v $ZIPNAME
+           mv $ZIPNAME v/
+           cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -29,11 +29,11 @@ jobs:
           ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
       - name: Remove excluded
         run: |
-          rm -rf .git/
-          rm -rf thirdparty/tcc/.git/
-          rm -rf vc/
-          rm -rf v_old
-          rm -rf vlib/v/tests/bench/gcboehm/*.svg
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
           cd ..
@@ -93,11 +93,11 @@ jobs:
           git clone --branch thirdparty-macos-arm64 --depth=1 https://github.com/vlang/tccbin thirdparty/tcc
       - name: Remove excluded
         run: |
-          rm -rf .git/
-          rm -rf thirdparty/tcc/.git/
-          rm -rf vc/
-          rm -rf v_old
-          rm -rf vlib/v/tests/bench/gcboehm/*.svg
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
           cd ..
@@ -129,11 +129,11 @@ jobs:
       - name: Remove excluded
         shell: msys2 {0}
         run: |
-          rm -rf .git/
-          rm -rf thirdparty/tcc/.git/
-          rm -rf vc/
-          rm -rf v_old.exe
-          rm -rf vlib/v/tests/bench/gcboehm/*.svg
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old.exe
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create archive
         shell: msys2 {0}
         run: |

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -1,13 +1,19 @@
 name: Build binary artifacts
 
 on:
+  pull_request:
+    paths:
+      - '**/binary_artifact.yml'
   push:
     tags:
       - weekly.**
       - 0.**
 
-jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'master' }}
 
+jobs:
   build-linux:
     runs-on: ubuntu-20.04
     env:
@@ -15,25 +21,20 @@ jobs:
       ZIPNAME: v_linux.zip
     steps:
       - uses: actions/checkout@v4
-      - name: Compile
+      - name: Compile release binaries
         run: |
           make
           ./v -skip-unused -cc $CC -prod -o v cmd/v
           ./v -skip-unused -cc $CC -prod cmd/tools/vup.v
           ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
       - name: Remove excluded
-        run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
-           cd ..
-           zip -r9 --symlinks $ZIPNAME v/
-           mv $ZIPNAME v/
-           cd v/
+          cd ..
+          zip -r9 --symlinks $ZIPNAME v/
+          mv $ZIPNAME v/
+          cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
@@ -41,31 +42,26 @@ jobs:
           path: ${{ env.ZIPNAME }}
 
   build-macos-x86_64:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CC: clang
       ZIPNAME: v_macos_x86_64.zip
     steps:
       - uses: actions/checkout@v4
-      - name: Compile
+      - name: Compile release binaries
         run: |
           make
           ./v -skip-unused -cc $CC -prod -o v cmd/v
           ./v -skip-unused -cc $CC -prod cmd/tools/vup.v
           ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
       - name: Remove excluded
-        run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
-           cd ..
-           zip -r9 --symlinks $ZIPNAME v/
-           mv $ZIPNAME v/
-           cd v/
+          cd ..
+          zip -r9 --symlinks $ZIPNAME v/
+          mv $ZIPNAME v/
+          cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
@@ -78,10 +74,9 @@ jobs:
       TARGET_CFLAGS: -target arm64-apple-darwin
       VFLAGS: -skip-unused -cc clang
       ZIPNAME: v_macos_arm64.zip
-      TCC_OPTS: --branch thirdparty-macos-arm64
     steps:
       - uses: actions/checkout@v4
-      - name: Compile
+      - name: Compile release binaries
         run: |
           make
           ./v -cflags "$TARGET_CFLAGS" -prod cmd/tools/vup.v
@@ -89,21 +84,16 @@ jobs:
           ./v -cflags "$TARGET_CFLAGS" -prod -o v cmd/v
       - name: Get correct TCC for ARM64
         run: |
-           rm -rf thirdparty/tcc
-           git clone $TCC_OPTS https://github.com/vlang/tccbin thirdparty/tcc
+          rm -rf thirdparty/tcc
+          git clone --branch thirdparty-macos-arm64 --depth=1 https://github.com/vlang/tccbin thirdparty/tcc
       - name: Remove excluded
-        run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
-           cd ..
-           zip -r9 --symlinks $ZIPNAME v/
-           mv $ZIPNAME v/
-           cd v/
+          cd ..
+          zip -r9 --symlinks $ZIPNAME v/
+          mv $ZIPNAME v/
+          cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
@@ -118,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
-      - name: Compile needed executables with -prod
+      - name: Compile release binaries
         run: |
           .\make.bat -msvc
           .\v.exe -skip-unused -prod -cc msvc -o cmd/vprod.exe cmd/v
@@ -128,22 +118,15 @@ jobs:
           .\v.exe -skip-unused -prod -cc msvc cmd\tools\vdoctor.v
       - name: Remove excluded
         shell: msys2 {0}
-        run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old.exe
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
+        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old.exe vlib/v/tests/bench/gcboehm/*.svg
       - name: Create archive
         shell: msys2 {0}
         run: |
-           cd ..
-           powershell Compress-Archive v $ZIPNAME
-           mv $ZIPNAME v/
-           cd v/
-# NB: the powershell Compress-Archive line is from:
-# https://superuser.com/a/1336434/194881
-# It is needed, because `zip` is not installed by default :-|
+          cd ..
+          # Use `powershell Compress-Archive`, because `zip` is not installed by default.
+          powershell Compress-Archive v $ZIPNAME
+          mv $ZIPNAME v/
+          cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
@@ -151,28 +134,23 @@ jobs:
           path: ${{ env.ZIPNAME }}
 
   release:
-    name: Create Github Release
+    if: github.ref_type == 'tag'
     needs: [build-linux, build-windows, build-macos-x86_64, build-macos-arm64]
     runs-on: ubuntu-latest
     steps:
-      - name: Get short tag name
-        uses: winterjung/split@v2
-        id: split
-        with:
-          msg: ${{ github.ref }}
-          separator: /
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.split.outputs._2 }}
-          name: ${{ steps.split.outputs._2 }}
+          tag: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           commit: ${{ github.sha }}
           draft: false
           prerelease: false
 
   publish:
+    if: github.ref_type == 'tag'
     needs: [release]
     runs-on: ubuntu-latest
     strategy:
@@ -185,19 +163,13 @@ jobs:
         with:
           name: ${{ matrix.version }}
           path: ./${{ matrix.version }}
-      - name: Get short tag name
-        uses: winterjung/split@v2
-        id: split
-        with:
-          msg: ${{ github.ref }}
-          separator: /
       - name: Get release
         id: get_release_info
         uses: leahlundqvist/get-release@v1.3.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          tag_name: ${{ steps.split.outputs._2 }}
+          tag_name: ${{ github.ref_name }}
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -100,10 +100,10 @@ jobs:
            rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
-          cd ..
-          zip -r9 --symlinks $ZIPNAME v/
-          mv $ZIPNAME v/
-          cd v/
+           cd ..
+           zip -r9 --symlinks $ZIPNAME v/
+           mv $ZIPNAME v/
+           cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -60,7 +60,12 @@ jobs:
           ./v -skip-unused -cc $CC -prod cmd/tools/vup.v
           ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
       - name: Remove excluded
-        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
+        run: |
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
            cd ..

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -28,7 +28,12 @@ jobs:
           ./v -skip-unused -cc $CC -prod cmd/tools/vup.v
           ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
       - name: Remove excluded
-        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
+        run: |
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
           cd ..
@@ -87,7 +92,12 @@ jobs:
           rm -rf thirdparty/tcc
           git clone --branch thirdparty-macos-arm64 --depth=1 https://github.com/vlang/tccbin thirdparty/tcc
       - name: Remove excluded
-        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old vlib/v/tests/bench/gcboehm/*.svg
+        run: |
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create ZIP archive
         run: |
           cd ..
@@ -118,7 +128,12 @@ jobs:
           .\v.exe -skip-unused -prod -cc msvc cmd\tools\vdoctor.v
       - name: Remove excluded
         shell: msys2 {0}
-        run: rm -rf .git/ thirdparty/tcc/.git vc/ v_old.exe vlib/v/tests/bench/gcboehm/*.svg
+        run: |
+           rm -rf .git/
+           rm -rf thirdparty/tcc/.git/
+           rm -rf vc/
+           rm -rf v_old
+           rm -rf vlib/v/tests/bench/gcboehm/*.svg
       - name: Create archive
         shell: msys2 {0}
         run: |


### PR DESCRIPTION
- Adds tiggers to include PRs updating this workflow, while the publishing and releasing part is limited to tag pushes. 
- Simplifes the current state without compromising on functionality where it can be appropriate, makes more consistent.
- For macos-x86 `macos-13` was set instead of `macos-latest` because `macos-latest` is migrating towards arm runners.

The workflow run under this PR should allow to manually inspect the crated binary artifacts.
edit: https://github.com/vlang/v/actions/runs/8860588557?pr=21364

