### PR TITLE
wasm,test,ci: prevent false negatives, activate windows in workflow tests

### DIFF
--- a/.github/workflows/wasm_backend_ci.yml
+++ b/.github/workflows/wasm_backend_ci.yml
@@ -42,50 +42,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
-env:
-  VTEST_ONLY: wasm
-
 jobs:
-  wasm-backend-ubuntu:
-    runs-on: ubuntu-22.04
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-12, windows-2022]
+      fail-fast: false
     timeout-minutes: 121
+    env:
+      VTEST_ONLY: wasm
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        if: runner.os != 'Windows'
+        run: make -j4
+      - name: Build V (Windows)
+        if: runner.os == 'Windows'
+        run: ./make.bat
       - name: Build examples
         run: ./v build-examples
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3.1
       - name: Test the WASM backend
         run: ./v test vlib/v/gen/wasm/tests/
-
-  wasm-backend-macos:
-    runs-on: macOS-12
-    timeout-minutes: 121
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build V
-        run: make -j4 && ./v symlink -githubci
-      - name: Build examples
-        run: ./v build-examples
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v3.1
-      - name: Test the WASM backend
-        run: ./v test vlib/v/gen/wasm/tests/
-
-  wasm-backend-windows:
-    runs-on: windows-2022
-    timeout-minutes: 121
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build V
-        run: ./make.bat -msvc
-      - name: Symlink V
-        run: ./v symlink -githubci
-      - name: Build examples
-        run: v build-examples
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v3.1
-      - name: Test the WASM backend
-        run: v test vlib/v/gen/wasm/tests/

--- a/.github/workflows/wasm_backend_ci.yml
+++ b/.github/workflows/wasm_backend_ci.yml
@@ -3,8 +3,6 @@ name: wasm backend CI
 on:
   push:
     paths:
-      - '!**'
-      - '!**.md'
       - 'cmd/tools/builders/**.v'
       - 'vlib/builtin/**.v'
       - 'vlib/v/ast/**.v'
@@ -20,10 +18,9 @@ on:
       - 'vlib/v/preludes/**.v'
       - 'vlib/v/gen/wasm/**.v'
       - 'vlib/v/gen/wasm/tests/**.v'
+      - '**/wasm_backend_ci.yml'
   pull_request:
     paths:
-      - '!**'
-      - '!**.md'
       - 'cmd/tools/builders/**.v'
       - 'vlib/builtin/**.v'
       - 'vlib/v/ast/**.v'
@@ -39,10 +36,14 @@ on:
       - 'vlib/v/preludes/**.v'
       - 'vlib/v/gen/wasm/**.v'
       - 'vlib/v/gen/wasm/tests/**.v'
+      - '**/wasm_backend_ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
+
+env:
+  VTEST_ONLY: wasm
 
 jobs:
   wasm-backend-ubuntu:
@@ -50,55 +51,41 @@ jobs:
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
-
       - name: Build V
-        run: make && ./v symlink -githubci
-
+        run: make -j4 && ./v symlink -githubci
       - name: Build examples
-        run: VTEST_ONLY=wasm ./v build-examples
-
-      - name: Install wasmer to execute WASM modules
-        run: |
-          curl https://get.wasmer.io -sSfL | sh
-          sudo ln -s ~/.wasmer/bin/wasmer /usr/local/bin
-
+        run: ./v build-examples
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v3.1
       - name: Test the WASM backend
         run: ./v test vlib/v/gen/wasm/tests/
-
 
   wasm-backend-macos:
     runs-on: macOS-12
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
-
       - name: Build V
-        run: make && ./v symlink -githubci
-
+        run: make -j4 && ./v symlink -githubci
       - name: Build examples
-        run: VTEST_ONLY=wasm ./v build-examples
-
-      - name: Install wasmer to execute WASM modules
-        run: |
-          curl https://get.wasmer.io -sSfL | sh
-          sudo ln -s ~/.wasmer/bin/wasmer /usr/local/bin
-
+        run: ./v build-examples
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v3.1
       - name: Test the WASM backend
         run: ./v test vlib/v/gen/wasm/tests/
 
-#  wasm-backend-windows:
-#    runs-on: windows-2022
-#    timeout-minutes: 121
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Build V
-#        run: .\make.bat -msvc
-#      - name: Symlink V
-#        run: .\v.exe symlink -githubci
-#
-#      - name: Build examples
-#        run: $env:VTEST_ONLY='wasm'; v build-examples
-#
-#      - name: Test the WASM backend
-#        run: v -stats test vlib/v/gen/wasm/tests/
+  wasm-backend-windows:
+    runs-on: windows-2022
+    timeout-minutes: 121
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build V
+        run: ./make.bat -msvc
+      - name: Symlink V
+        run: ./v symlink -githubci
+      - name: Build examples
+        run: v build-examples
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v3.1
+      - name: Test the WASM backend
+        run: v test vlib/v/gen/wasm/tests/

--- a/vlib/v/gen/wasm/tests/wasm_test.v
+++ b/vlib/v/gen/wasm/tests/wasm_test.v
@@ -38,10 +38,16 @@ fn test_wasm() {
 		os.rmdir_all(wrkdir) or {}
 	}
 	os.chdir(wrkdir) or {}
-	tests := files.filter(it.ends_with('.vv'))
+	mut tests := files.filter(it.ends_with('.vv'))
 	if tests.len == 0 {
 		println('no wasm tests found')
 		assert false
+	}
+	$if windows {
+		// FIXME:
+		if os.getenv('CI') == 'true' {
+			tests = tests.filter(it != 'arrays.vv' && it != 'asm.vv' && it != 'builtin.vv')
+		}
 	}
 	bench.set_total_expected_steps(tests.len)
 	for test in tests {

--- a/vlib/v/gen/wasm/tests/wasm_test.v
+++ b/vlib/v/gen/wasm/tests/wasm_test.v
@@ -20,6 +20,9 @@ fn test_wasm() {
 
 	if !runtime_found {
 		eprintln('cannot find suitable wasm runtime, exiting...')
+		if os.getenv('VTEST_ONLY') == 'wasm' {
+			exit(1)
+		}
 		exit(0)
 	}
 

--- a/vlib/v/gen/wasm/tests/wasm_test.v
+++ b/vlib/v/gen/wasm/tests/wasm_test.v
@@ -30,14 +30,14 @@ fn test_wasm() {
 	vexe := os.getenv('VEXE')
 	vroot := os.dir(vexe)
 	dir := os.join_path(vroot, 'vlib/v/gen/wasm/tests')
-	files := os.ls(dir) or { panic(err) }
+	files := os.ls(dir)!
 	//
 	wrkdir := os.join_path(os.vtmp_dir(), 'wasm_tests')
-	os.mkdir_all(wrkdir) or { panic(err) }
+	os.mkdir_all(wrkdir)!
 	defer {
 		os.rmdir_all(wrkdir) or {}
 	}
-	os.chdir(wrkdir) or {}
+	os.chdir(wrkdir)!
 	mut tests := files.filter(it.ends_with('.vv'))
 	if tests.len == 0 {
 		println('no wasm tests found')
@@ -46,7 +46,7 @@ fn test_wasm() {
 	$if windows {
 		// FIXME:
 		if os.getenv('CI') == 'true' {
-			tests = tests.filter(it != 'arrays.vv' && it != 'asm.vv' && it != 'builtin.vv')
+			tests = tests.filter(it !in ['arrays.vv', 'asm.vv', 'builtin.vv'])
 		}
 	}
 	bench.set_total_expected_steps(tests.len)
@@ -69,7 +69,7 @@ fn test_wasm() {
 			eprintln(bench.step_message_fail(cmd))
 
 			if os.exists(tmperrfile) {
-				err := os.read_file(tmperrfile) or { panic(err) }
+				err := os.read_file(tmperrfile)!
 				eprintln(err)
 			}
 


### PR DESCRIPTION
- Currently, when running wasm test without a runtime available, they pass without additional  info about the missing wasm runtime. This makes it easy to miss malfunctions or regressions.

  ```sh
  # pass without info
  ./v test vlib/v/gen/wasm/tests/
  # directly calling a test file would already include the error message and pass.
  ./v vlib/v/gen/wasm/tests/wasm_test.v
  ```
  
  With the updates `exit(1)` instead of `exit(0)` would be used when tests are called with `VTEST_ONLY=wasm` (env variable that is also used in CI). This will give a more appropriate test result when explicitly testing wasm code and prevent false negatives.
  
  ```sh
  # would now error when no runtime is available
  VTEST_ONLY=wasm ./v test vlib/v/gen/wasm/tests/
  ```

- Windows tests are activated as far as they work to prevent regressing further (3 tests where disabled for windows ci runs).

All updates should be easy to follow per commit.
