### PR TITLE
builder: use cc enum in CcompilerOptions, fix cc detection, enable cc guessing without prod flag

### DIFF
--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -39,6 +39,7 @@ on:
       - 'vlib/v/markused/**.v'
       - 'vlib/v/preludes/**.v'
       - 'vlib/v/embed_file/**.v'
+      - '**/sanitized_ci.yml'
   pull_request:
     paths:
       - '!**'
@@ -64,6 +65,7 @@ on:
       - 'vlib/v/markused/**.v'
       - 'vlib/v/preludes/**.v'
       - 'vlib/v/embed_file/**.v'
+      - '**/sanitized_ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
@@ -161,7 +163,7 @@ jobs:
           .\make.bat -msvc
           .\v.exe self
       - name: Ensure code is well formatted
-        run: v test-cleancode
+        run: ./v test-cleancode
       # - name: Install dependencies
       #   run: |
       #     .\v.exe setup-freetype

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -163,7 +163,7 @@ jobs:
           .\make.bat -msvc
           .\v.exe self
       - name: Ensure code is well formatted
-        run: ./v test-cleancode
+        run: .\v.exe test-cleancode
       # - name: Install dependencies
       #   run: |
       #     .\v.exe setup-freetype

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -186,6 +186,8 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 				cc_ver.output.contains('clang version ') { .clang }
 				else { panic('failed to detect C compiler from version info `${cc_ver.output}`') }
 			}
+		} else {
+			panic('unknown C compiler')
 		}
 	} else {
 		cc_file_name := os.file_name(ccompiler)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -178,7 +178,8 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 	ccoptions.debug_mode = v.pref.is_debug
 	ccoptions.guessed_compiler = v.pref.ccompiler
-	if ccoptions.guessed_compiler == 'cc' && v.pref.is_prod {
+	guess_compiler := $if macos { true } $else { v.pref.is_prod }
+	if ccoptions.guessed_compiler == 'cc' && guess_compiler {
 		// deliberately guessing only for -prod builds for performance reasons
 		ccversion := os.execute('cc --version')
 		if ccversion.exit_code == 0 {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -180,20 +180,14 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	ccoptions.guessed_compiler = v.pref.ccompiler
 	if ccoptions.guessed_compiler == 'cc' {
 		if cc_ver := os.execute_opt('cc --version') {
-			if gcc_ver := os.execute_opt('gcc --version') {
-				if cc_ver.output == gcc_ver.output {
-					ccoptions.cc = .gcc
-				}
-			} else if clang_ver := os.execute_opt('clang --version') {
-				if cc_ver.output == clang_ver.output {
-					ccoptions.cc = .clang
-				}
-			} else if gpp_ver := os.execute_opt('g++ --version') {
-				if cc_ver.output == gpp_ver.output {
-					ccoptions.cc = .gcc
-				}
+			if cc_ver.output.contains('Free Software Foundation')
+				&& cc_ver.output.contains('This is free software') {
+				// Also covers `g++-9` and `g++-11`.
+				ccoptions.cc = .gcc
+			} else if cc_ver.output.contains('clang version ') {
+				ccoptions.cc = .clang
 			} else {
-				panic('unknown C compiler')
+				panic('failed to detect C compiler from version info `${cc_ver.output}`')
 			}
 		}
 	} else {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -180,14 +180,11 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	ccoptions.guessed_compiler = v.pref.ccompiler
 	if ccoptions.guessed_compiler == 'cc' {
 		if cc_ver := os.execute_opt('cc --version') {
-			if cc_ver.output.contains('Free Software Foundation')
-				&& cc_ver.output.contains('This is free software') {
-				// Also covers `g++-9` and `g++-11`.
-				ccoptions.cc = .gcc
-			} else if cc_ver.output.contains('clang version ') {
-				ccoptions.cc = .clang
-			} else {
-				panic('failed to detect C compiler from version info `${cc_ver.output}`')
+			ccoptions.cc = match true {
+				// Also covers `g++`, `g++-9`, `g++-11` etc.
+				cc_ver.output.replace('\n', '').contains('Free Software Foundation, Inc.This is free software;') { .gcc }
+				cc_ver.output.contains('clang version ') { .clang }
+				else { panic('failed to detect C compiler from version info `${cc_ver.output}`') }
 			}
 		}
 	} else {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -190,7 +190,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 				if v.pref.is_verbose {
 					eprintln('failed to detect C compiler from version info `${cc_ver.output}`')
 				}
-				eprintln('Compilation with unkown C compiler')
+				eprintln('Compilation with unknown C compiler')
 				ccoptions.cc = .unknown
 			}
 		} else {
@@ -209,7 +209,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 			// vfmt on
 		}
 		if ccoptions.cc == .unknown {
-			eprintln('Compilation with unkown C compiler `${cc_file_name}`')
+			eprintln('Compilation with unknown C compiler `${cc_file_name}`')
 		}
 	}
 

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -94,18 +94,21 @@ fn (mut v Builder) show_cc(cmd string, response_file string, response_file_conte
 	}
 }
 
+enum CC {
+	tcc
+	gcc
+	icc
+	msvc
+	clang
+}
+
 struct CcompilerOptions {
 mut:
 	guessed_compiler string
 	shared_postfix   string // .so, .dll
 	//
-	//
-	debug_mode  bool
-	is_cc_tcc   bool
-	is_cc_gcc   bool
-	is_cc_icc   bool
-	is_cc_msvc  bool
-	is_cc_clang bool
+	debug_mode bool
+	cc         CC
 	//
 	env_cflags  string // prepended *before* everything else
 	env_ldflags string // appended *after* everything else
@@ -189,17 +192,17 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 	}
 	ccompiler_file_name := os.file_name(ccompiler)
-	ccoptions.is_cc_tcc = ccompiler_file_name.contains('tcc') || ccoptions.guessed_compiler == 'tcc'
-	ccoptions.is_cc_gcc = ccompiler_file_name.contains('gcc') || ccoptions.guessed_compiler == 'gcc'
-	ccoptions.is_cc_icc = ccompiler_file_name.contains('icc') || ccoptions.guessed_compiler == 'icc'
-	ccoptions.is_cc_msvc = ccompiler_file_name.contains('msvc')
-		|| ccoptions.guessed_compiler == 'msvc'
-	ccoptions.is_cc_clang = ccompiler_file_name.contains('clang')
-		|| ccoptions.guessed_compiler == 'clang'
+	ccoptions.cc = match true {
+		ccompiler_file_name.contains('tcc') || ccoptions.guessed_compiler == 'tcc' { .tcc }
+		ccompiler_file_name.contains('gcc') || ccoptions.guessed_compiler == 'gcc' { .gcc }
+		ccompiler_file_name.contains('clang') || ccoptions.guessed_compiler == 'clang' { .clang }
+		ccompiler_file_name.contains('msvc') || ccoptions.guessed_compiler == 'msvc' { .msvc }
+		ccompiler_file_name.contains('icc') || ccoptions.guessed_compiler == 'icc' { .icc }
+		else { panic('unknown ccompiler: ${ccompiler_file_name}') }
+	}
 
 	// Add -fwrapv to handle UB overflows
-	if (ccoptions.is_cc_gcc || ccoptions.is_cc_clang || ccoptions.is_cc_tcc)
-		&& v.pref.os in [.macos, .linux, .windows] {
+	if ccoptions.cc in [.gcc, .clang, .tcc] && v.pref.os in [.macos, .linux, .windows] {
 		ccoptions.args << '-fwrapv'
 	}
 
@@ -208,7 +211,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		ccoptions.args << '-fpermissive'
 		ccoptions.args << '-w'
 	}
-	if ccoptions.is_cc_clang {
+	if ccoptions.cc == .clang {
 		if ccoptions.debug_mode {
 			debug_options = ['-g', '-O0']
 		}
@@ -227,7 +230,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 			'-Wno-int-to-void-pointer-cast',
 		]
 	}
-	if ccoptions.is_cc_gcc {
+	if ccoptions.cc == .gcc {
 		if ccoptions.debug_mode {
 			debug_options = ['-g']
 			if user_darwin_version > 9 {
@@ -236,7 +239,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 		optimization_options = ['-O3', '-flto']
 	}
-	if ccoptions.is_cc_icc {
+	if ccoptions.cc == .icc {
 		if ccoptions.debug_mode {
 			debug_options = ['-g']
 			if user_darwin_version > 9 {
@@ -251,7 +254,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 	if v.pref.is_prod {
 		// don't warn for vlib tests
-		if ccoptions.is_cc_tcc && !(v.parsed_files.len > 0
+		if ccoptions.cc == .tcc && !(v.parsed_files.len > 0
 			&& v.parsed_files.last().path.contains('vlib')) {
 			eprintln('Note: tcc is not recommended for -prod builds')
 		}
@@ -298,7 +301,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		ccoptions.args << '-Wl,--no-entry'
 	}
 	if ccoptions.debug_mode && builder.current_os != 'windows' && v.pref.build_mode != .build_module {
-		if builder.current_os == 'macos' && !ccoptions.is_cc_tcc {
+		if ccoptions.cc != .tcc && builder.current_os == 'macos' {
 			ccoptions.linker_flags << '-Wl,-export_dynamic' // clang for mac needs export_dynamic instead of -rdynamic
 		} else {
 			ccoptions.linker_flags << '-rdynamic' // needed for nicer symbolic backtraces
@@ -306,7 +309,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 	if v.pref.os == .freebsd {
 		// Needed for -usecache on FreeBSD 13, otherwise we get `ld: error: duplicate symbol: _const_math__bits__de_bruijn32` errors there
-		if !ccoptions.is_cc_tcc {
+		if ccoptions.cc != .tcc {
 			ccoptions.linker_flags << '-Wl,--allow-multiple-definition'
 		} else {
 			// tcc needs this, otherwise it fails to compile the runetype.h system header with:
@@ -318,7 +321,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	if ccompiler != 'msvc' && v.pref.os != .freebsd {
 		ccoptions.wargs << '-Werror=implicit-function-declaration'
 	}
-	if ccoptions.is_cc_tcc {
+	if ccoptions.cc == .tcc {
 		// tcc 806b3f98 needs this flag too:
 		ccoptions.wargs << '-Wno-write-strings'
 	}
@@ -333,7 +336,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 
 	// macOS code can include objective C  TODO remove once objective C is replaced with C
 	if v.pref.os in [.macos, .ios] {
-		if !ccoptions.is_cc_tcc && !user_darwin_ppc && !v.pref.is_bare && ccompiler != 'musl-gcc' {
+		if ccoptions.cc != .tcc && !user_darwin_ppc && !v.pref.is_bare && ccompiler != 'musl-gcc' {
 			ccoptions.source_args << '-x objective-c'
 		}
 	}
@@ -378,14 +381,14 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	ccoptions.pre_args << others
 	ccoptions.linker_flags << libs
 	if v.pref.use_cache && v.pref.build_mode != .build_module {
-		if !ccoptions.is_cc_tcc {
+		if ccoptions.cc != .tcc {
 			$if linux {
 				ccoptions.linker_flags << '-Xlinker -z'
 				ccoptions.linker_flags << '-Xlinker muldefs'
 			}
 		}
 	}
-	if ccoptions.is_cc_tcc && 'no_backtrace' !in v.pref.compile_defines {
+	if ccoptions.cc == .tcc && 'no_backtrace' !in v.pref.compile_defines {
 		ccoptions.post_args << '-bt25'
 	}
 	// Without these libs compilation will fail on Linux
@@ -426,7 +429,7 @@ fn (v &Builder) all_args(ccoptions CcompilerOptions) []string {
 		// /volatile:ms - there seems to be no equivalent,
 		// normally msvc should use /volatile:iso
 		// but it could have an impact on vinix if it is created with msvc.
-		if !ccoptions.is_cc_msvc {
+		if ccoptions.cc != .msvc {
 			if v.pref.os != .wasm32_emscripten {
 				all << '-Wl,-stack=16777216'
 			}
@@ -625,7 +628,7 @@ pub fn (mut v Builder) cc() {
 			}
 		}
 		$if windows {
-			if v.ccoptions.is_cc_tcc {
+			if v.ccoptions.cc == .tcc {
 				def_name := v.pref.out_name[0..v.pref.out_name.len - 4]
 				v.pref.cleanup_files << '${def_name}.def'
 			}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -178,28 +178,32 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 	ccoptions.debug_mode = v.pref.is_debug
 	ccoptions.guessed_compiler = v.pref.ccompiler
-	guess_compiler := $if macos { true } $else { v.pref.is_prod }
-	if ccoptions.guessed_compiler == 'cc' && guess_compiler {
-		// deliberately guessing only for -prod builds for performance reasons
-		ccversion := os.execute('cc --version')
-		if ccversion.exit_code == 0 {
-			if ccversion.output.contains('This is free software;')
-				&& ccversion.output.contains('Free Software Foundation, Inc.') {
-				ccoptions.guessed_compiler = 'gcc'
-			}
-			if ccversion.output.contains('clang version ') {
-				ccoptions.guessed_compiler = 'clang'
+	if ccoptions.guessed_compiler == 'cc' {
+		if cc_ver := os.execute_opt('cc --version') {
+			if gcc_ver := os.execute_opt('gcc --version') {
+				if cc_ver.output == gcc_ver.output {
+					ccoptions.cc = .gcc
+				}
+			} else if clang_ver := os.execute_opt('clang --version') {
+				if cc_ver.output == clang_ver.output {
+					ccoptions.cc = .clang
+				}
+			} else if gpp_ver := os.execute_opt('g++ --version') {
+				if cc_ver.output == gpp_ver.output {
+					ccoptions.cc = .gcc
+				}
 			}
 		}
-	}
-	ccompiler_file_name := os.file_name(ccompiler)
-	ccoptions.cc = match true {
-		ccompiler_file_name.contains('tcc') || ccoptions.guessed_compiler == 'tcc' { .tcc }
-		ccompiler_file_name.contains('gcc') || ccoptions.guessed_compiler == 'gcc' { .gcc }
-		ccompiler_file_name.contains('clang') || ccoptions.guessed_compiler == 'clang' { .clang }
-		ccompiler_file_name.contains('msvc') || ccoptions.guessed_compiler == 'msvc' { .msvc }
-		ccompiler_file_name.contains('icc') || ccoptions.guessed_compiler == 'icc' { .icc }
-		else { panic('unknown ccompiler: ${ccompiler_file_name}') }
+	} else {
+		ccompiler_file_name := os.file_name(ccompiler)
+		ccoptions.cc = match true {
+			ccompiler_file_name.contains('tcc') || ccoptions.guessed_compiler == 'tcc' { .tcc }
+			ccompiler_file_name.contains('gcc') || ccoptions.guessed_compiler == 'gcc' { .gcc }
+			ccompiler_file_name.contains('clang') || ccoptions.guessed_compiler == 'clang' { .clang }
+			ccompiler_file_name.contains('msvc') || ccoptions.guessed_compiler == 'msvc' { .msvc }
+			ccompiler_file_name.contains('icc') || ccoptions.guessed_compiler == 'icc' { .icc }
+			else { panic('unknown ccompiler: ${ccompiler_file_name}') }
+		}
 	}
 
 	// Add -fwrapv to handle UB overflows

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -192,17 +192,21 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 				if cc_ver.output == gpp_ver.output {
 					ccoptions.cc = .gcc
 				}
+			} else {
+				panic('unknown C compiler')
 			}
 		}
 	} else {
-		ccompiler_file_name := os.file_name(ccompiler)
+		cc_file_name := os.file_name(ccompiler)
 		ccoptions.cc = match true {
-			ccompiler_file_name.contains('tcc') || ccoptions.guessed_compiler == 'tcc' { .tcc }
-			ccompiler_file_name.contains('gcc') || ccoptions.guessed_compiler == 'gcc' { .gcc }
-			ccompiler_file_name.contains('clang') || ccoptions.guessed_compiler == 'clang' { .clang }
-			ccompiler_file_name.contains('msvc') || ccoptions.guessed_compiler == 'msvc' { .msvc }
-			ccompiler_file_name.contains('icc') || ccoptions.guessed_compiler == 'icc' { .icc }
-			else { panic('unknown ccompiler: ${ccompiler_file_name}') }
+			// vfmt off
+			cc_file_name.contains('tcc') || ccoptions.guessed_compiler == 'tcc' { .tcc }
+			cc_file_name.contains('gcc') || cc_file_name.contains('g++') || ccoptions.guessed_compiler == 'gcc' { .gcc }
+			cc_file_name.contains('clang') || ccoptions.guessed_compiler == 'clang' { .clang }
+			cc_file_name.contains('msvc') || ccoptions.guessed_compiler == 'msvc' { .msvc }
+			cc_file_name.contains('icc') || ccoptions.guessed_compiler == 'icc' { .icc }
+			else { panic('unknown C compiler `${cc_file_name}`') }
+			// vfmt on
 		}
 	}
 


### PR DESCRIPTION
- The PR utilizes an enum for the CC instead of multiple boolean fields on the CcompilerOptions struct. Since only one CC can be used at a time,  structuring things this way can make sense.

  A nice side effect of the change was discovering a bug where the CC is not set when compiling V on macOS. This was fixed by enabling compiler guessing on macOS even when V is not compiled in prod mode

  Example CI after swapping to use an enum and panicking on an unknown compiler:
  - macos-12: https://github.com/ttytm/v/actions/runs/8870500885/job/24352354898
  - macos-14: https://github.com/ttytm/v/actions/runs/8870500874/job/24352354543

- To pass the sanitized workflow, a vpath in a step (which was enabled in a recently made change) was fixed. Additionally, a trigger was added for changes to this sanitized workflow.


---
Edit:
Refs. for development / review purposes
- Commit no. 3 9b58466 contains the first full CI run after the initial changes from which further improvements were started.
