### PR TITLE
tools: refine `check_os_api_parity.v`

### DIFF
--- a/cmd/tools/check_os_api_parity.v
+++ b/cmd/tools/check_os_api_parity.v
@@ -10,8 +10,8 @@ import v.ast
 import rand
 import term
 
-const base_os = 'linux'
-const os_names = ['linux', 'macos', 'windows', 'freebsd', 'openbsd', 'solaris', 'termux']
+const base_os = pref.get_host_os()
+const os_list = [pref.OS.linux, .macos, .windows, .freebsd, .openbsd, .solaris, .termux]
 const skip_modules = [
 	'builtin.bare',
 	'builtin.linux_bare.old',
@@ -37,21 +37,19 @@ fn main() {
 	os.chdir(vroot)!
 	modules := if os.args.len > 1 { os.args[1..] } else { all_vlib_modules() }
 	mut diff_modules := map[string]bool{}
+	other_os_list := os_list.filter(it != base_os)
 	for m in modules {
 		if !is_verbose {
 			eprintln('Checking module: ${m} ...')
 		}
 		api_base := gen_api_for_module_in_os(m, base_os)
-		for oname in os_names {
-			if oname == base_os {
-				continue
-			}
-			api_os := gen_api_for_module_in_os(m, oname)
+		for other_os in other_os_list {
+			api_os := gen_api_for_module_in_os(m, other_os)
 			if api_base == api_os {
 				continue
 			}
 			diff_modules[m] = true
-			summary := 'Different APIs found for module: `${m}`, between OS base: `${base_os}` and OS: `${api_os}`'
+			summary := 'Different APIs found for module: `${m}`, between OS base: `${base_os}` and OS: `${other_os}`'
 			eprintln(term.header(summary, '-'))
 			if diff_cmd == '' {
 				continue
@@ -89,10 +87,11 @@ fn all_vlib_modules() []string {
 	return modules
 }
 
-fn gen_api_for_module_in_os(mod_name string, os_name string) string {
+fn gen_api_for_module_in_os(mod_name string, os_ pref.OS) string {
 	if is_verbose {
-		eprintln('Checking module: ${mod_name:-30} for OS: ${os_name:-10} ...')
+		eprintln('Checking module: ${mod_name:-30} for OS: ${os_:-10} ...')
 	}
+	os_name := os_.str().to_lower()
 	mpath := os.join_path('vlib', mod_name.replace('.', '/'))
 	tmpname := '/tmp/${mod_name}_${os_name}.c'
 	prefs, _ := pref.parse_args([], ['-os', os_name, '-o', tmpname, '-shared', mpath])


### PR DESCRIPTION
Refines the tool:
- addresses a flaw after the recent fixes https://github.com/vlang/v/pull/21367#issuecomment-2081482198
- uses the host os as base os instead of hardcoded linux
- uses the `pref.OS` enum for the checked os list this as a minor improvement to secure that actually relevant oses are checked.