### PR TITLE
pref: fix version flag handling

### DIFF
--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -401,7 +401,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				}
 				res.is_quiet = true
 			}
-			'-v' {
+			'-v', '-V', '--version', '-version' {
 				if command_pos != -1 {
 					// a -v flag after the command, is intended for the command, not for V itself
 					continue
@@ -958,11 +958,6 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 						&& command !in known_external_commands && res.raw_vsh_tmp_prefix == '' {
 						eprintln_exit('Too many targets. Specify just one target: <target.v|target_directory>.')
 					}
-					continue
-				}
-				if arg in ['-V', '-version', '--version'] {
-					command = 'version'
-					command_pos = i
 					continue
 				}
 				if command != '' && command != 'build-module' {

--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -404,7 +404,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-v', '-V', '--version', '-version' {
 				if command_pos == -1 {
 					// Version flags after a command are intended for the command, not for V itself.
-					if args.len > 1 && arg == '-v' {
+					if current_args.len > 1 && arg == '-v' {
 						// With additional args after the `-v` flag, it toggles verbosity, like Clang.
 						// E.g.: `v -v` VS `v -v run examples/hello_world.v`.
 						res.is_verbose = true

--- a/vlib/v/pref/pref.c.v
+++ b/vlib/v/pref/pref.c.v
@@ -402,16 +402,15 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				res.is_quiet = true
 			}
 			'-v', '-V', '--version', '-version' {
-				if command_pos != -1 {
-					// a -v flag after the command, is intended for the command, not for V itself
-					continue
-				}
-				// `-v` flag is for setting verbosity, but without any args it prints the version, like Clang
-				if args.len > 1 {
-					res.is_verbose = true
-				} else {
-					command = 'version'
-					command_pos = i
+				if command_pos == -1 {
+					// Version flags after a command are intended for the command, not for V itself.
+					if args.len > 1 && arg == '-v' {
+						// With additional args after the `-v` flag, it toggles verbosity, like Clang.
+						// E.g.: `v -v` VS `v -v run examples/hello_world.v`.
+						res.is_verbose = true
+					} else {
+						command = 'version'
+					}
 				}
 			}
 			'-progress' {

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -1,8 +1,40 @@
 module pref
 
+import v.vmod
+import os
+
 fn test_check_parametes() {
 	// reproducing issue https://github.com/vlang/v/issues/13983
 	_, cmd := parse_args_and_show_errors(['help'], [''], true)
 	// no command found from args
 	assert cmd == ''
+}
+
+fn test_version_falg() {
+	// Vars instead of consts to prevent dupl decls in pref.
+	vexe := @VEXE
+	vroot := os.dir(vexe)
+
+	v_ver := vmod.from_file(os.join_path(vroot, 'v.mod'))!.version
+	v_ver_cmd_res := os.execute_opt('${vexe} --version')!.output
+	assert v_ver_cmd_res.starts_with('V ${v_ver}'), v_ver_cmd_res
+
+	v_retry_ver_cmd_res := os.execute_opt('${vexe} retry --version')!.output
+	assert v_retry_ver_cmd_res != v_ver_cmd_res
+
+	v_git_ver_subcmd_res := os.execute_opt('${vexe} retry -- git --version')!.output
+	assert v_git_ver_subcmd_res !in [v_ver_cmd_res, v_retry_ver_cmd_res]
+
+	// Test version / verbosity toggle.
+	assert os.execute_opt('${vexe} -v')!.output == v_ver_cmd_res
+	assert os.execute_opt('${vexe} -cc tcc -v')!.output == v_ver_cmd_res
+
+	example_path := os.join_path(vroot, 'examples', 'hello_world.v')
+	v_verbose_cmd_res := os.execute_opt('${vexe} -v run ${example_path}')!.output
+	assert v_verbose_cmd_res != v_ver_cmd_res
+	assert v_verbose_cmd_res.contains('v.pref.lookup_path:')
+
+	v_verbose_cmd_with_additional_args_res := os.execute_opt('${vexe} -cc tcc -v run ${example_path}')!.output
+	assert v_verbose_cmd_with_additional_args_res != v_ver_cmd_res
+	assert v_verbose_cmd_with_additional_args_res.contains('v.pref.lookup_path:')
 }


### PR DESCRIPTION
Current:
```sh
❯ v --version
V 0.4.5 3226365
❯ v retry --version
V 0.4.5 3226365
❯ v retry -- git --version
V 0.4.5 3226365
```
Updated:
```sh
❯ v --version
V 0.4.5 21b76c1
❯ v retry --version
v retry 0.0.1
❯ v retry -- git --version
git version 2.44.0
```
