### PR TITLE
ci: update binary artifact workflow, add matrix

### DIFF
--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -17,151 +17,90 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'master' }}
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-20.04
-    env:
-      CC: gcc
-      ZIPNAME: v_linux.zip
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-13, macos-14, windows-latest]
+        include:
+          - os: ubuntu-20.04
+            cc: gcc
+          - os: ubuntu-20.04
+            target: linux
+            artifact: v_linux.zip
+          - os: macos-13
+            cc: clang
+          - os: macos-13
+            target: macos_x86_64
+            artifact: v_macos_x86_64.zip
+          - os: macos-14
+            cc: clang
+          - os: macos-14
+            target: macos_arm64
+            artifact: v_macos_arm64.zip
+          - os: macos-14
+            cflags: -cflags "-target arm64-apple-darwin"
+          - os: windows-latest
+            cc: msvc
+            target: windows
+            artifact: v_windows.zip
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - name: Compile release binaries
+        if: runner.os != 'Windows'
         run: |
           make
-          ./v -skip-unused -cc $CC -prod -o v cmd/v
-          ./v -skip-unused -cc $CC -prod cmd/tools/vup.v
-          ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
-      - name: Remove excluded
+          ./v -cc ${{ matrix.cc }} ${{ matrix.cflags }} -skip-unused -prod -o v cmd/v
+          ./v -cc ${{ matrix.cc }} ${{ matrix.cflags }} -skip-unused -prod cmd/tools/vup.v
+          ./v -cc ${{ matrix.cc }} ${{ matrix.cflags }} -skip-unused -prod cmd/tools/vdoctor.v
+      - name: Compile release binaries (Windows)
+        if: runner.os == 'Windows'
         run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
-      - name: Create ZIP archive
-        run: |
-           cd ..
-           zip -r9 --symlinks $ZIPNAME v/
-           mv $ZIPNAME v/
-           cd v/
-      - name: Create artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux
-          path: ${{ env.ZIPNAME }}
-
-  build-macos-x86_64:
-    runs-on: macos-13
-    env:
-      CC: clang
-      ZIPNAME: v_macos_x86_64.zip
-    steps:
-      - uses: actions/checkout@v4
-      - name: Compile release binaries
-        run: |
-          make
-          ./v -skip-unused -cc $CC -prod -o v cmd/v
-          ./v -skip-unused -cc $CC -prod cmd/tools/vup.v
-          ./v -skip-unused -cc $CC -prod cmd/tools/vdoctor.v
-      - name: Remove excluded
-        run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
-      - name: Create ZIP archive
-        run: |
-           cd ..
-           zip -r9 --symlinks $ZIPNAME v/
-           mv $ZIPNAME v/
-           cd v/
-      - name: Create artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_x86_64
-          path: ${{ env.ZIPNAME }}
-
-  build-macos-arm64:
-    runs-on: macos-14
-    env:
-      TARGET_CFLAGS: -target arm64-apple-darwin
-      VFLAGS: -skip-unused -cc clang
-      ZIPNAME: v_macos_arm64.zip
-    steps:
-      - uses: actions/checkout@v4
-      - name: Compile release binaries
-        run: |
-          make
-          ./v -cflags "$TARGET_CFLAGS" -prod cmd/tools/vup.v
-          ./v -cflags "$TARGET_CFLAGS" -prod cmd/tools/vdoctor.v
-          ./v -cflags "$TARGET_CFLAGS" -prod -o v cmd/v
-      - name: Get correct TCC for ARM64
-        run: |
-          rm -rf thirdparty/tcc
-          git clone --branch thirdparty-macos-arm64 --depth=1 https://github.com/vlang/tccbin thirdparty/tcc
-      - name: Remove excluded
-        run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
-      - name: Create ZIP archive
-        run: |
-           cd ..
-           zip -r9 --symlinks $ZIPNAME v/
-           mv $ZIPNAME v/
-           cd v/
-      - name: Create artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_arm64
-          path: ${{ env.ZIPNAME }}
-
-  build-windows:
-    runs-on: windows-latest
-    env:
-      CC: msvc
-      ZIPNAME: v_windows.zip
-    steps:
-      - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
-      - name: Compile release binaries
-        run: |
-          .\make.bat -msvc
-          .\v.exe -skip-unused -prod -cc msvc -o cmd/vprod.exe cmd/v
+          ./make.bat -msvc
+          ./v -skip-unused -prod -cc msvc -o cmd/vprod.exe cmd/v
+          ./v -skip-unused -prod -cc msvc cmd/tools/vup.v
+          ./v -skip-unused -prod -cc msvc cmd/tools/vdoctor.v
           del *.exe
-          move cmd\vprod.exe v.exe
-          .\v.exe -skip-unused -prod -cc msvc cmd\tools\vup.v
-          .\v.exe -skip-unused -prod -cc msvc cmd\tools\vdoctor.v
-      - name: Remove excluded
-        shell: msys2 {0}
+          move cmd/vprod.exe v.exe
+      - name: Prepare artifact
+        shell: bash
         run: |
-           rm -rf .git/
-           rm -rf thirdparty/tcc/.git/
-           rm -rf vc/
-           rm -rf v_old.exe
-           rm -rf vlib/v/tests/bench/gcboehm/*.svg
-           find |grep pdb$|xargs rm -rf
-           find |grep ilk$|xargs rm -rf
-      - name: Create archive
-        shell: msys2 {0}
+          if [[ ${{ matrix.os }} == 'macos-14' ]]; then
+            rm -rf thirdparty/tcc
+            git clone --branch thirdparty-macos-arm64 --depth=1 https://github.com/vlang/tccbin thirdparty/tcc
+          fi
+          # Remove excluded
+          if [[ $RUNNER_OS == 'Windows' ]]; then
+            find . -type f \( -name "*.ilk" -o -name "*.pdb" \) -exec rm -rf {} +
+            rm -rf v_old.exe
+          fi
+          find . -type d -name ".git" -exec rm -rf {} +
+          rm -rf vc/
+          rm -rf v_old
+          rm -rf vlib/v/tests/bench/gcboehm/*.svg
+      - name: Create ZIP archive
+        shell: bash
         run: |
-           cd ..
-           # Use `powershell Compress-Archive`, because `zip` is not installed by default.
-           powershell Compress-Archive v $ZIPNAME
-           mv $ZIPNAME v/
-           cd v/
+          cd ..
+          if [[ $RUNNER_OS == 'Windows' ]]; then
+            7z a -tzip ${{ matrix.artifact }} v/
+          else
+            zip -r9 --symlinks ${{ matrix.artifact }} v/
+          fi
+          zipinfo ${{ matrix.artifact }}
+          mv ${{ matrix.artifact }} v/
+          cd v/
       - name: Create artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows
-          path: ${{ env.ZIPNAME }}
+          name: ${{ matrix.target }}
+          path: ${{ matrix.artifact }}
 
   release:
     name: Create Github Release
     if: github.ref_type == 'tag'
-    needs: [build-linux, build-windows, build-macos-x86_64, build-macos-arm64]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
@@ -177,7 +116,7 @@ jobs:
 
   publish:
     if: github.ref_type == 'tag'
-    needs: [release]
+    needs: release
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_name != 'master' }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   build:

--- a/.github/workflows/binary_artifact.yml
+++ b/.github/workflows/binary_artifact.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -98,50 +101,20 @@ jobs:
           path: ${{ matrix.artifact }}
 
   release:
-    name: Create Github Release
     if: github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Create Release
-        id: create_release
+      - uses: actions/download-artifact@v4
+      - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: |
+            ~/work/v/v/windows/v_windows.zip
+            ~/work/v/v/linux/v_linux.zip
+            ~/work/v/v/macos_arm64/v_macos_arm64.zip
+            ~/work/v/v/macos_x86_64/v_macos_x86_64.zip
           tag: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          commit: ${{ github.sha }}
           draft: false
           prerelease: false
-
-  publish:
-    if: github.ref_type == 'tag'
-    needs: release
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [windows, linux, macos_arm64, macos_x86_64]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Fetch artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.version }}
-          path: ./${{ matrix.version }}
-      - name: Get release
-        id: get_release_info
-        uses: leahlundqvist/get-release@v1.3.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          tag_name: ${{ github.ref_name }}
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ matrix.version }}/v_${{ matrix.version }}.zip
-          asset_name: v_${{ matrix.version }}.zip
-          asset_content_type: application/zip

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -1,13 +1,13 @@
-name: Build binary artifacts
+name: Release CI
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '**/binary_artifact.yml'
+      - '.github/workflows/release_ci.yml'
   push:
     paths:
-      - '**/binary_artifact.yml'
+      - '.github/workflows/release_ci.yml'
     tags:
       - weekly.**
       - 0.**


### PR DESCRIPTION
Same as with a recent matrix related CI update:
> Makes use of a matrix for jobs that share the same steps cross-platform or have marginal differences. This allows for easier and more consistent changes, and should simplify maintainability by reducing redundancy and eliminating the need to update and review the same things in multiple places.

While the changes manage to mainly simplify things, they also include improvements.

Notable changes concern only Windows release archives:
- data structure that allows for more platform consistency / independency when downloading and viewing the contents of a Windows archive.
  Example screenshots showing directories and archives in comparison on a Linux system:
  - Current - Windows and Linux directories after extraction on the left and archives on the right (windows is flat) 
    ![Screenshot_20240429_191308](https://github.com/vlang/v/assets/34311583/4a2117d5-45a1-4f60-9517-df487c40ff76)

  - Updated - Windows and Linux directories after extraction on the left and windows archive on the right.
    ![Screenshot_20240429_190102](https://github.com/vlang/v/assets/34311583/f100761b-9dc5-45de-9c9d-91ef6edc5c29)
    
- building is more than twice as fast (secondary for that workflow, but still notable)

Ref. CI runs:
- Run at current state: https://github.com/vlang/v/actions/runs/8876119311
- Test run with the updates: https://github.com/ttytm/v/actions/runs/8882381733 (alternatively the run below the PR)

<br>

It's one of the last planed rougher-/maintenance-changes to the CI, before moving towards suggestions that are more enhancement-based.