### PR TITLE
ci: update detection of accidentally added gpl licenses

### DIFF
--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
-      - name: Checkout V ${{ github.ref_name }}
+      - name: Checkout V ${{ github.head_ref }}
         uses: actions/checkout@v4
         with:
           path: v

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -21,14 +21,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  no-gpl-by-accident:
+  prevent-gpl-licenses:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - name: No GPL licensed code, should be added accidentally
+      - name: Checkout V ${{ github.ref_name }}
+        uses: actions/checkout@v4
+        with:
+          path: v
+      - name: Checkout V master
+        uses: actions/checkout@v4
+        with:
+          repository: vlang/v
+          path: vmaster
+      - name: Detect potentially added GPL licensed code
         run: |
-          ! grep -r --exclude="*.yml" "a GPL license" .
+          gpl_search_cmd="grep 'GPL' -r --exclude-dir=.git --exclude=*.yml --exclude=*.md --exclude=*.vv --exclude=*_test.v ."
+          cd vmaster
+          eval $gpl_search_cmd > ../gpl_res_vmaster
+          cd ../v
+          eval $gpl_search_cmd > ../gpl_res_vnew
+          cd ..
+          diff -d -a -U 2 --color=always gpl_res_vmaster gpl_res_vnew
 
   code-formatting:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Updates poor detection in the job that tries to prevent GPL licensed code.

Currently it is checked for the pattern `"a GPL license"`. Which will miss to detect a lot of potentially unwanted additions.
A GPL license can be GPL-2.0 GPLv2, AGPL, LGPL, LGPLv3, (LGPLv3) etc.. Grepping the projects code-base will give an idea. 

A screenshot of a sample run that includes a potential gpl license text:
![Screenshot_20240430_015503](https://github.com/vlang/v/assets/34311583/4ba2989b-f805-4f22-99bc-f47c80b644ac)


https://github.com/ttytm/v/actions/runs/8886970660/job/24401414482

If the CI should be triggered and there are no concerns, merging with the failed job should make it green for the run after the merge.

