### PR TITLE
v/pref: Fix pref test on Freebsd

### DIFF
--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -34,7 +34,14 @@ fn test_version_falg() {
 	assert v_verbose_cmd_res != v_ver_cmd_res
 	assert v_verbose_cmd_res.contains('v.pref.lookup_path:')
 
-	v_verbose_cmd_with_additional_args_res := os.execute_opt('${vexe} -cc tcc -v run ${example_path}')!.output
+	// tcc does not handle the symver assembly directive which is
+	// a problem on FreeBSD 14
+	mut compiler := 'tcc'
+	$if freebsd && clang {
+		compiler = 'clang'
+	}
+
+	v_verbose_cmd_with_additional_args_res := os.execute_opt('${vexe} -cc ${compiler} -v run ${example_path}')!.output
 	assert v_verbose_cmd_with_additional_args_res != v_ver_cmd_res
 	assert v_verbose_cmd_with_additional_args_res.contains('v.pref.lookup_path:')
 }


### PR DESCRIPTION
On FreeBSD 14, there is a problem using tcc because it does not deal with the symver assembly directive.

There is a discussion and preliminary, partial fix discussed in https://lists.gnu.org/archive/html/tinycc-devel/2023-11/msg00006.html

The clang compiler comes standard on FreeBSD so it is always available unless it has been removed.

Until tcc addresses the problem, this change allows the test to pass.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
