### PR TITLE
v.pref: extract architecture related code into `arch.c.v`; rename `pref.c.v` to `pref.v`

### DIFF
--- a/vlib/v/pref/arch.c.v
+++ b/vlib/v/pref/arch.c.v
@@ -1,0 +1,70 @@
+module pref
+
+pub enum Arch {
+	_auto
+	amd64
+	arm64
+	arm32
+	rv64
+	rv32
+	i386
+	js_node
+	js_browser
+	js_freestanding
+	wasm32
+	_max
+}
+
+pub fn get_host_arch() Arch {
+	// Note: we can not use `$if arch` here, because V skips cgen for the non
+	// current comptime branches by default, so there is a bootstrapping
+	// problem => the __V_architecture macro is used to resolve it.
+	// TODO: think about how to solve it for non C backends, perhaps we
+	// need a comptime `$if native {` too, and/or a mechanism to always
+	// generate all branches for specific functions?
+	if C.__V_architecture <= int(Arch._auto) || C.__V_architecture >= int(Arch._max) {
+		return Arch.amd64
+	}
+	return unsafe { Arch(C.__V_architecture) }
+}
+
+pub fn arch_from_string(arch_str string) !Arch {
+	match arch_str {
+		'amd64', 'x86_64', 'x64', 'x86' {
+			return .amd64
+		}
+		'aarch64', 'arm64' {
+			return .arm64
+		}
+		'aarch32', 'arm32', 'arm' {
+			return .arm32
+		}
+		'rv64', 'riscv64', 'risc-v64', 'riscv', 'risc-v' {
+			return .rv64
+		}
+		'rv32', 'riscv32' {
+			return .rv32
+		}
+		'x86_32', 'x32', 'i386', 'IA-32', 'ia-32', 'ia32' {
+			return .i386
+		}
+		'js', 'js_node' {
+			return .js_node
+		}
+		'js_browser' {
+			return .js_browser
+		}
+		'js_freestanding' {
+			return .js_freestanding
+		}
+		'wasm32', 'wasm' {
+			return .wasm32
+		}
+		'' {
+			return ._auto
+		}
+		else {
+			return error('invalid arch: ${arch_str}')
+		}
+	}
+}

--- a/vlib/v/pref/arch.c.v
+++ b/vlib/v/pref/arch.c.v
@@ -2,11 +2,11 @@ module pref
 
 pub enum Arch {
 	_auto
-	amd64
-	arm64
-	arm32
-	rv64
-	rv32
+	amd64 // aka x86_64
+	arm64 // 64-bit arm
+	arm32 // 32-bit arm
+	rv64 // 64-bit risc-v
+	rv32 // 32-bit risc-v
 	i386
 	js_node
 	js_browser
@@ -30,22 +30,22 @@ pub fn get_host_arch() Arch {
 
 pub fn arch_from_string(arch_str string) !Arch {
 	match arch_str {
-		'amd64', 'x86_64', 'x64', 'x86' {
+		'amd64', 'x86_64', 'x64', 'x86' { // amd64 recommended
 			return .amd64
 		}
-		'aarch64', 'arm64' {
+		'aarch64', 'arm64' { // arm64 recommended
 			return .arm64
 		}
-		'aarch32', 'arm32', 'arm' {
+		'aarch32', 'arm32', 'arm' { // arm32 recommended
 			return .arm32
 		}
-		'rv64', 'riscv64', 'risc-v64', 'riscv', 'risc-v' {
+		'rv64', 'riscv64', 'risc-v64', 'riscv', 'risc-v' { // rv64 recommended
 			return .rv64
 		}
-		'rv32', 'riscv32' {
+		'rv32', 'riscv32' { // rv32 recommended
 			return .rv32
 		}
-		'x86_32', 'x32', 'i386', 'IA-32', 'ia-32', 'ia32' {
+		'x86_32', 'x32', 'i386', 'IA-32', 'ia-32', 'ia32' { // i386 recommended
 			return .i386
 		}
 		'js', 'js_node' {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -73,21 +73,6 @@ pub enum CompilerType {
 	cplusplus
 }
 
-pub enum Arch {
-	_auto
-	amd64 // aka x86_64
-	arm64 // 64-bit arm
-	arm32 // 32-bit arm
-	rv64 // 64-bit risc-v
-	rv32 // 32-bit risc-v
-	i386
-	js_node
-	js_browser
-	js_freestanding
-	wasm32
-	_max
-}
-
 pub const list_of_flags_with_param = ['b', 'd', 'e', 'o', 'define', 'backend', 'cc', 'os', 'cflags',
 	'ldflags', 'path', 'arch']
 
@@ -1115,53 +1100,6 @@ pub fn (pref &Preferences) should_output_to_stdout() bool {
 	return pref.out_name.ends_with('/-') || pref.out_name.ends_with(r'\-')
 }
 
-pub fn arch_from_string(arch_str string) !Arch {
-	match arch_str {
-		'amd64', 'x86_64', 'x64', 'x86' { // amd64 recommended
-
-			return .amd64
-		}
-		'aarch64', 'arm64' { // arm64 recommended
-
-			return .arm64
-		}
-		'aarch32', 'arm32', 'arm' { // arm32 recommended
-
-			return .arm32
-		}
-		'rv64', 'riscv64', 'risc-v64', 'riscv', 'risc-v' { // rv64 recommended
-
-			return .rv64
-		}
-		'rv32', 'riscv32' { // rv32 recommended
-
-			return .rv32
-		}
-		'x86_32', 'x32', 'i386', 'IA-32', 'ia-32', 'ia32' { // i386 recommended
-
-			return .i386
-		}
-		'js', 'js_node' {
-			return .js_node
-		}
-		'js_browser' {
-			return .js_browser
-		}
-		'js_freestanding' {
-			return .js_freestanding
-		}
-		'wasm32', 'wasm' {
-			return .wasm32
-		}
-		'' {
-			return ._auto
-		}
-		else {
-			return error('invalid arch: ${arch_str}')
-		}
-	}
-}
-
 fn must_exist(path string) {
 	if !os.exists(path) {
 		eprintln_exit('v expects that `${path}` exists, but it does not')
@@ -1216,19 +1154,6 @@ pub fn cc_from_string(cc_str string) CompilerType {
 		return .msvc
 	}
 	return .gcc
-}
-
-pub fn get_host_arch() Arch {
-	// Note: we can not use `$if arch` here, because V skips cgen for the non
-	// current comptime branches by default, so there is a bootstrapping
-	// problem => the __V_architecture macro is used to resolve it.
-	// TODO: think about how to solve it for non C backends, perhaps we
-	// need a comptime `$if native {` too, and/or a mechanism to always
-	// generate all branches for specific functions?
-	if C.__V_architecture <= int(Arch._auto) || C.__V_architecture >= int(Arch._max) {
-		return Arch.amd64
-	}
-	return unsafe { Arch(C.__V_architecture) }
 }
 
 fn (mut prefs Preferences) parse_define(define string) {


### PR DESCRIPTION
We similarly structure with pref/os. Since the arch code contains the only C code in pref.c.v it can be renamed to pref.v.