### PR TITLE
cgen: use the real C line number instead of `#line 1000000 ...` in the C footer with `-g`

### DIFF
--- a/vlib/v/builder/cbuilder/cbuilder.v
+++ b/vlib/v/builder/cbuilder/cbuilder.v
@@ -56,7 +56,10 @@ pub fn build_c(mut b builder.Builder, v_files []string, out_file string) {
 	b.out_name_c = out_file
 	b.pref.out_name_c = os.real_path(out_file)
 	b.info('build_c(${out_file})')
-	output2 := gen_c(mut b, v_files)
+	mut output2 := gen_c(mut b, v_files)
+	if b.pref.is_vlines {
+		output2 = c.fix_reset_dbg_line(output2, out_file)
+	}
 	os.write_file(out_file, output2) or { panic(err) }
 	if b.pref.is_stats {
 		b.stats_lines = output2.count('\n') + 1

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -523,7 +523,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 
 	g.finish()
 
-	mut b := strings.new_builder(640000)
+	mut b := strings.new_builder(g.out.len + 200_000)
 	b.write_string(g.hashes())
 	if g.use_segfault_handler || g.pref.is_prof {
 		b.writeln('\n#define V_USE_SIGNAL_H')


### PR DESCRIPTION
This PR improves the debugging experience with gdb and lldb, for the generated vinit/vcleanup and main functions.