### PR TITLE
pref: cleanup `Backend` and `CompilerType` functions, make minor performance adjustments

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1136,8 +1136,8 @@ pub fn cc_from_string(s string) CompilerType {
 		cc.contains('tcc') || cc.contains('tinyc') { .tinyc }
 		cc.contains('gcc') { .gcc }
 		cc.contains('clang') { .clang }
-		cc.contains('mingw') { .mingw }
 		cc.contains('msvc') { .msvc }
+		cc.contains('mingw') { .mingw }
 		cc.contains('++') { .cplusplus }
 		else { .gcc }
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1131,7 +1131,7 @@ pub fn cc_from_string(s string) CompilerType {
 	if s == '' {
 		return .gcc
 	}
-	cc := s.all_after_last('\\').all_after_last('/')
+	cc := os.file_name(s).to_lower()
 	return match true {
 		cc.contains('tcc') || cc.contains('tinyc') { .tinyc }
 		cc.contains('gcc') { .gcc }


### PR DESCRIPTION
The PR does a cleanup and makes minor adjustments. E.g., sorting match arms for more relevant matches first, adding a `gcc` arm instead of using it only in the fallback.