### PR TITLE
pref: update `os_from_string`, add missing `qnx`, remove deprecated wasm options that used `-` instead of `_`

### DIFF
--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -86,6 +86,9 @@ pub fn os_from_string(os_str string) !OS {
 		'serenity' {
 			return .serenity
 		}
+		'qnx' {
+			return .qnx
+		}
 		'plan9' {
 			return .plan9
 		}
@@ -122,18 +125,6 @@ pub fn os_from_string(os_str string) !OS {
 			return .wasi
 		}
 		else {
-			// handle deprecated names:
-			match os_str {
-				'wasm32-emscripten' {
-					eprintln('Please use `-os wasm32_emscripten` instead.')
-					return .wasm32_emscripten
-				}
-				'wasm32-wasi' {
-					eprintln('Please use `-os wasm32_wasi` instead.')
-					return .wasm32_wasi
-				}
-				else {}
-			}
 			return error('bad OS ${os_str}')
 		}
 	}


### PR DESCRIPTION
Would extract a functional change from other updates I'd like to suggest.

As a change that is quasi related to the scope of the update - can the deprecated options be removed here? I've seen removing deprecated code is on the list, and these have been deprecated for quite some time.
