### PR TITLE
v.pref: error for `v file.v --unknown-option`

### DIFF
--- a/cmd/tools/vdoc/vdoc_file_test.v
+++ b/cmd/tools/vdoc/vdoc_file_test.v
@@ -145,7 +145,6 @@ fn check_output(cmd string, out_path string, opts CheckOutputParams) int {
 	mut fails := 0
 	os.setenv('VDOC_SORT', opts.should_sort.str(), true)
 	expected := os.read_file(out_path) or { panic(err) }.replace('\r\n', '\n').trim_space()
-	dump(cmd)
 	res := os.execute_opt(cmd) or { panic(err) }
 	found := res.output.replace('\r\n', '\n').trim_space()
 	if expected != found {

--- a/cmd/tools/vdoc/vdoc_file_test.v
+++ b/cmd/tools/vdoc/vdoc_file_test.v
@@ -145,6 +145,7 @@ fn check_output(cmd string, out_path string, opts CheckOutputParams) int {
 	mut fails := 0
 	os.setenv('VDOC_SORT', opts.should_sort.str(), true)
 	expected := os.read_file(out_path) or { panic(err) }.replace('\r\n', '\n').trim_space()
+	dump(cmd)
 	res := os.execute_opt(cmd) or { panic(err) }
 	found := res.output.replace('\r\n', '\n').trim_space()
 	if expected != found {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -948,6 +948,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// Allow for `script.vsh abc 123 -option`, because -option is for the .vsh program, not for v
 					continue
 				}
+				if command == 'doc' {
+					// Allow for `v doc -comments file.v`
+					continue
+				}
 				err_detail := if command == '' { '' } else { ' for command `${command}`' }
 				eprintln_exit('Unknown argument `${arg}`${err_detail}')
 			}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -940,8 +940,8 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// arguments for e.g. fmt should be checked elsewhere
 					continue
 				}
-				extension := if command == '' { '' } else { ' for command `${command}`' }
-				eprintln_exit('Unknown argument `${arg}`${extension}')
+				err_detail := if command == '' { '' } else { ' for command `${command}`' }
+				eprintln_exit('Unknown argument `${arg}`${err_detail}')
 			}
 		}
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -924,6 +924,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				if command == 'build' && is_source_file(arg) {
 					eprintln_exit('Use `v ${arg}` instead.')
 				}
+				if is_source_file(arg) && arg.ends_with('.vsh') {
+					// store for future iterations
+					res.is_vsh = true
+				}
 				if !arg.starts_with('-') {
 					if command == '' {
 						command, command_idx = arg, i
@@ -938,6 +942,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				}
 				if command !in ['', 'build-module'] && !is_source_file(command) {
 					// arguments for e.g. fmt should be checked elsewhere
+					continue
+				}
+				if res.is_vsh && command_idx < i {
+					// Allow for `script.vsh abc 123 -option`, because -option is for the .vsh program, not for v
 					continue
 				}
 				err_detail := if command == '' { '' } else { ' for command `${command}`' }

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -936,12 +936,12 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					}
 					continue
 				}
-				if command !in ['', 'build-module'] {
+				if command !in ['', 'build-module'] && !is_source_file(command) {
 					// arguments for e.g. fmt should be checked elsewhere
 					continue
 				}
-				err_detail := if command == '' { '' } else { ' for command `${command}`' }
-				eprintln_exit('Unknown argument `${arg}`${err_detail}')
+				extension := if command == '' { '' } else { ' for command `${command}`' }
+				eprintln_exit('Unknown argument `${arg}`${extension}')
 			}
 		}
 	}

--- a/vlib/v/pref/unknown_options_test.v
+++ b/vlib/v/pref/unknown_options_test.v
@@ -34,6 +34,6 @@ fn test_unknown_option_flags_with_run() {
 
 	res_run_no_o := os.execute('${os.quoted_path(@VEXE)} run examples/hello_world.v --an-unknown-option')
 	assert res_run_no_o.exit_code == 0
-	assert res_run_no_o.output == 'Hello, World!\n'
+	assert res_run_no_o.output.trim_space() == 'Hello, World!'
 	assert !os.exists(tfile)
 }

--- a/vlib/v/pref/unknown_options_test.v
+++ b/vlib/v/pref/unknown_options_test.v
@@ -1,0 +1,39 @@
+import os
+
+const tfile = os.join_path(os.vtmp_dir(), 'unknown_options_output.c')
+
+fn test_unknown_option_flags_no_run() {
+	os.chdir(os.dir(@VEXE))!
+	os.rm(tfile) or {}
+
+	res1 := os.execute('${os.quoted_path(@VEXE)} -o ${os.quoted_path(tfile)} examples/hello_world.v --an-unknown-option')
+	assert res1.exit_code == 1
+	assert res1.output.starts_with('Unknown argument')
+	assert res1.output.contains('--an-unknown-option')
+	assert !os.exists(tfile)
+
+	res2 := os.execute('${os.quoted_path(@VEXE)} -o ${os.quoted_path(tfile)} --an-unknown-option examples/hello_world.v')
+	assert res2.exit_code == 1
+	assert res2.output.starts_with('Unknown argument')
+	assert res2.output.contains('--an-unknown-option')
+	assert !os.exists(tfile)
+}
+
+fn test_unknown_option_flags_with_run() {
+	res_run_o := os.execute('${os.quoted_path(@VEXE)} -o ${os.quoted_path(tfile)} run examples/hello_world.v --an-unknown-option')
+	assert res_run_o.exit_code == 0
+	assert res_run_o.output == '' // because of -o, there should not be an actual run, since compilation stopped after generating the .c file
+	assert os.exists(tfile)
+	os.rm(tfile) or {}
+
+	res_run_no_o_unknown_before_run := os.execute('${os.quoted_path(@VEXE)} --an-unknown-option run examples/hello_world.v ')
+	assert res_run_no_o_unknown_before_run.exit_code == 1
+	assert res_run_no_o_unknown_before_run.output.starts_with('Unknown argument')
+	assert res_run_no_o_unknown_before_run.output.contains('--an-unknown-option')
+	assert !os.exists(tfile)
+
+	res_run_no_o := os.execute('${os.quoted_path(@VEXE)} run examples/hello_world.v --an-unknown-option')
+	assert res_run_no_o.exit_code == 0
+	assert res_run_no_o.output == 'Hello, World!\n'
+	assert !os.exists(tfile)
+}

--- a/vlib/v/pref/vsh_envbang_test.v
+++ b/vlib/v/pref/vsh_envbang_test.v
@@ -21,7 +21,8 @@ println('hello')
 println(os.args)
 ")!
 	os.chmod(rnd_vsh_script_path, 0o700)!
-	res := os.execute('${os.quoted_path(rnd_vsh_script_path)} abc 123 -option')
+	cmd := '${os.quoted_path(rnd_vsh_script_path)} abc 123 -option'
+	res := os.execute(cmd)
 	assert res.exit_code == 0
 	lines := res.output.split_into_lines()
 	assert lines[0] == 'hello'

--- a/vlib/v/pref/vsh_envbang_test.v
+++ b/vlib/v/pref/vsh_envbang_test.v
@@ -21,8 +21,7 @@ println('hello')
 println(os.args)
 ")!
 	os.chmod(rnd_vsh_script_path, 0o700)!
-	cmd := '${os.quoted_path(rnd_vsh_script_path)} abc 123 -option'
-	res := os.execute(cmd)
+	res := os.execute('${os.quoted_path(rnd_vsh_script_path)} abc 123 -option')
 	assert res.exit_code == 0
 	lines := res.output.split_into_lines()
 	assert lines[0] == 'hello'


### PR DESCRIPTION
## Describe the Problem
Compiling a single code file with flags does not give a warning, and continues the compile.
This will work on real or fake flags
This does not look nice and could cause unknown usage.
```sh
$ ./v examples/hello_world.v -autofree
$ ./v examples/hello_world.v -garbage
$ echo $?
0
```

## Show the Change
This change reports an error and exits as such. It will report the same error if the argument is valid or not, but it is clear what the problem is.
```sh
$ ./v examples/hello_world.v -autofree
Build flags must be before the source file.
$ ./v examples/hello_world.v -garbage
Build flags must be before the source file.
$ echo $?
1
```