### PR TITLE
ci: pass a good commit to oldv.v in `bootstrapping_ci.yml`

### DIFF
--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -59,9 +59,8 @@ jobs:
           ls -la v_from_vc2 v_from_vc_produced_native_v2
       - name: Test `v up`
         run: |
-          # Get commit sha from the last successful, fast workflow that could build V on master.
-          # The workflow used below is `Path Testing CI` (18477644).
-          last_good_commit=$(curl -s "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=1" | jq -r '.workflow_runs[0].head_sha')
+          # Derive commit sha from an older successful fast workflow on master that was able to build V.
+          last_good_commit=$(curl -s "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=2" | jq -r '.workflow_runs[1].head_sha')
           echo "last_good_commit=$last_good_commit"
           ./v run cmd/tools/oldv.v -v $last_good_commit
           cd ~/.cache/oldv/v_at_$last_good_commit

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:
@@ -60,7 +61,12 @@ jobs:
       - name: Test `v up`
         run: |
           # Derive commit sha from an older successful fast workflow on master that was able to build V.
-          last_good_commit=$(curl -s "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=2" | jq -r '.workflow_runs[1].head_sha')
+          last_good_commit=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=2" \
+            | jq -r '.workflow_runs[1].head_sha')
           echo "last_good_commit=$last_good_commit"
           ./v run cmd/tools/oldv.v -v $last_good_commit
           cd ~/.cache/oldv/v_at_$last_good_commit

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   bootstrap-v:

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 30
     env:
       VFLAGS: -no-parallel
-      B_CFLAGS:
       B_LFLAGS: -lm -lpthread
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +36,7 @@ jobs:
         run: |
           ls -la v vc/v.c
           ./v -os cross -o vc/v.c cmd/v
-          cc $B_CFLAGS -o v_from_vc vc/v.c $B_LFLAGS
+          cc -o v_from_vc vc/v.c $B_LFLAGS
           ls -lart v_from_vc
           ./v_from_vc version
           ./v_from_vc run examples/hello_world.v
@@ -48,7 +47,7 @@ jobs:
           ls -la v vc/v.c v_from_vc v_from_vc_produced_native_v
           ./v_from_vc_produced_native_v -os cross -o vc/v.c cmd/v
           ### do it a second time, just in case:
-          clang $B_CFLAGS -o v_from_vc2 vc/v.c $B_LFLAGS
+          clang -o v_from_vc2 vc/v.c $B_LFLAGS
           ls -lart v_from_vc2
           ./v_from_vc2 version
           ./v_from_vc2 run examples/hello_world.v
@@ -60,8 +59,11 @@ jobs:
           ls -la v_from_vc2 v_from_vc_produced_native_v2
       - name: Test `v up`
         run: |
-          ./v cmd/tools/oldv.v
-          ./cmd/tools/oldv -v HEAD^^^
-          cd ~/.cache/oldv/v_at_HEAD___/
+          # Get commit sha from the last successful, fast workflow that could build V on master.
+          # The workflow used below is `Path Testing CI` (18477644).
+          last_good_commit=$(curl -s "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=1" | jq -r '.workflow_runs[0].head_sha')
+          echo "last_good_commit=$last_good_commit"
+          ./v run cmd/tools/oldv.v -v $last_good_commit
+          cd ~/.cache/oldv/v_at_$last_good_commit
           ./v version && ./v -v up && ./v version
           ./v -o v2 cmd/v && ./v2 -o v3 cmd/v

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -60,15 +60,16 @@ jobs:
           ls -la v_from_vc2 v_from_vc_produced_native_v2
       - name: Test `v up`
         run: |
-          # Derive commit sha from an older successful fast workflow on master that was able to build V.
-          last_good_commit=$(curl -L \
+          # Derive a commit sha from an older successful fast workflow on master that was able to build V.
+          # The workflow used below is `Path Testing CI` (18477644).
+          recent_good_commit=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=2" \
             | jq -r '.workflow_runs[1].head_sha')
-          echo "last_good_commit=$last_good_commit"
-          ./v run cmd/tools/oldv.v -v $last_good_commit
-          cd ~/.cache/oldv/v_at_$last_good_commit
+          echo "recent_good_commit=$recent_good_commit"
+          ./v run cmd/tools/oldv.v -v $recent_good_commit
+          cd ~/.cache/oldv/v_at_$recent_good_commit
           ./v version && ./v -v up && ./v version
           ./v -o v2 cmd/v && ./v2 -o v3 cmd/v


### PR DESCRIPTION
The changes should be able to address: https://github.com/vlang/v/commit/fd66067bc02dba9fc8198d1fea04c9e3c071de74#commitcomment-141513977


A small change included here is a resolved linter complaint for the empty
```
B_CFLAGS:
```
`B_CFLAGS: ''` Would address it, but as the var is apparently not used it was removed.