### PR TITLE
v.util: rewrite diff module, deprecate old functions

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -200,19 +200,6 @@ fn print_compiler_options(compiler_params &pref.Preferences) {
 	eprintln('  is_script: ${compiler_params.is_script} ')
 }
 
-fn (mut foptions FormatOptions) find_diff_cmd() string {
-	if foptions.diff_cmd != '' {
-		return foptions.diff_cmd
-	}
-	if foptions.is_verify || foptions.is_diff {
-		foptions.diff_cmd = diff.find_working_diff_command() or {
-			eprintln(err)
-			exit(1)
-		}
-	}
-	return foptions.diff_cmd
-}
-
 fn (mut foptions FormatOptions) post_process_file(file string, formatted_file_path string) ! {
 	if formatted_file_path == '' {
 		return
@@ -230,12 +217,7 @@ fn (mut foptions FormatOptions) post_process_file(file string, formatted_file_pa
 		if !is_formatted_different {
 			return
 		}
-		diff_cmd := foptions.find_diff_cmd()
-		foptions.vlog('Using diff command: ${diff_cmd}')
-		diff_ := diff.color_compare_files(diff_cmd, file, formatted_file_path)
-		if diff_.len > 0 {
-			println(diff_)
-		}
+		println(diff.compare_files(file, formatted_file_path)!)
 		return
 	}
 	if foptions.is_verify {

--- a/vlib/v/util/diff.v
+++ b/vlib/v/util/diff.v
@@ -3,7 +3,7 @@ module util
 import v.util.diff
 
 // find_working_diff_command returns the first available command from a list of known diff cli tools.
-@[deprecated_after: '2024-05-31']
+@[deprecated_after: '2024-06-30']
 @[deprecated]
 pub fn find_working_diff_command() !string {
 	return diff.find_working_diff_command()
@@ -11,14 +11,14 @@ pub fn find_working_diff_command() !string {
 
 // color_compare_files returns a colored diff between two files.
 @[deprecated: 'use `diff.compare_files` instead']
-@[deprecated_after: '2024-05-31']
+@[deprecated_after: '2024-06-30']
 pub fn color_compare_files(diff_cmd string, path1 string, path2 string) string {
 	return diff.color_compare_files(diff_cmd, path1, path2)
 }
 
 // color_compare_strings returns a colored diff between two strings.
 @[deprecated: 'use `diff.compare_text` instead']
-@[deprecated_after: '2024-05-31']
+@[deprecated_after: '2024-06-30']
 pub fn color_compare_strings(diff_cmd string, unique_prefix string, expected string, found string) string {
 	return diff.color_compare_strings(diff_cmd, unique_prefix, expected, found)
 }

--- a/vlib/v/util/diff.v
+++ b/vlib/v/util/diff.v
@@ -3,16 +3,22 @@ module util
 import v.util.diff
 
 // find_working_diff_command returns the first available command from a list of known diff cli tools.
+@[deprecated_after: '2024-05-31']
+@[deprecated]
 pub fn find_working_diff_command() !string {
 	return diff.find_working_diff_command()
 }
 
 // color_compare_files returns a colored diff between two files.
+@[deprecated: 'use `diff.compare_files` instead']
+@[deprecated_after: '2024-05-31']
 pub fn color_compare_files(diff_cmd string, path1 string, path2 string) string {
 	return diff.color_compare_files(diff_cmd, path1, path2)
 }
 
 // color_compare_strings returns a colored diff between two strings.
+@[deprecated: 'use `diff.compare_text` instead']
+@[deprecated_after: '2024-05-31']
 pub fn color_compare_strings(diff_cmd string, unique_prefix string, expected string, found string) string {
 	return diff.color_compare_strings(diff_cmd, unique_prefix, expected, found)
 }

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -83,8 +83,14 @@ pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
 	}
 	path1 := os.join_path_single(tmp_dir, 'text1.txt')
 	path2 := os.join_path_single(tmp_dir, 'text2.txt')
-	os.write_file(path1, text1)!
-	os.write_file(path2, text2)!
+	// When comparing strings and not files, prevent `\ No newline at end of file` in the output.
+	if !text1.ends_with('\n') || !text2.ends_with('\n') {
+		os.write_file(path1, text1 + '\n')!
+		os.write_file(path2, text2 + '\n')!
+	} else {
+		os.write_file(path1, text1)!
+		os.write_file(path2, text2)!
+	}
 	return compare_files(path1, path2, opts)!
 }
 

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -84,8 +84,13 @@ pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
 	path1 := os.join_path_single(tmp_dir, 'text1.txt')
 	path2 := os.join_path_single(tmp_dir, 'text2.txt')
 	// Add `\n` when comparing strings to prevent `\ No newline at end of file` in the output.
-	os.write_file(path1, text1 + '\n')!
-	os.write_file(path2, text2 + '\n')!
+	if !text1.ends_with('\n') && !text2.ends_with('\n') {
+		os.write_file(path1, text1 + '\n')!
+		os.write_file(path2, text2 + '\n')!
+	} else {
+		os.write_file(path1, text1)!
+		os.write_file(path2, text2)!
+	}
 	return compare_files(path1, path2, opts)!
 }
 

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -62,8 +62,11 @@ pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
 		opts.tool
 	}
 	tool_cmd := $if windows { '${tool.str()}.exe' } $else { tool.str() }
-	os.find_abs_path_of_executable(tool_cmd) or {
-		return error('error: failed to find comparison command `${tool_cmd}`')
+	if opts.tool != .auto {
+		// At this point it was already ensured that the automatically detected tool is available.
+		os.find_abs_path_of_executable(tool_cmd) or {
+			return error('error: failed to find comparison command `${tool_cmd}`')
+		}
 	}
 	mut args := opts.args
 	if args == '' {

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -83,14 +83,8 @@ pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
 	}
 	path1 := os.join_path_single(tmp_dir, 'text1.txt')
 	path2 := os.join_path_single(tmp_dir, 'text2.txt')
-	// Add `\n` when comparing strings to prevent `\ No newline at end of file` in the output.
-	if !text1.ends_with('\n') && !text2.ends_with('\n') {
-		os.write_file(path1, text1 + '\n')!
-		os.write_file(path2, text2 + '\n')!
-	} else {
-		os.write_file(path1, text1)!
-		os.write_file(path2, text2)!
-	}
+	os.write_file(path1, text1)!
+	os.write_file(path2, text2)!
 	return compare_files(path1, path2, opts)!
 }
 

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -121,7 +121,8 @@ fn find_working_diff_tool() ?DiffTool {
 		os.find_abs_path_of_executable(cmd) or { continue }
 		if tool == .delta {
 			// Sanity check that the `delta` executable is actually the diff tool.
-			help_desc := os.execute('${cmd} --help').output.trim_space().all_before('\n')
+			res := os.execute_opt('${cmd} --help') or { continue }
+			help_desc := res.output.trim_space().all_before('\n')
 			if !help_desc.contains('diff') {
 				dbg('delta does not appear to be the diff tool `${help_desc}`', @LOCATION)
 				continue

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -105,7 +105,7 @@ fn find_working_diff_tool() ?DiffTool {
 			// Sanity check that the `delta` executable is actually the diff tool.
 			res := os.execute('${cmd} --help').output.split_into_lines()[0]
 			if !res.contains('diff') {
-				dbg('${@LOCATION} delta does not appear to be the diff tool `${res}`')
+				dbg('delta does not appear to be the diff tool `${res}`', @LOCATION)
 				continue
 			}
 		}
@@ -115,9 +115,9 @@ fn find_working_diff_tool() ?DiffTool {
 }
 
 fn run_tool(cmd string, dbg_location string) string {
-	dbg('${dbg_location}: cmd=`${cmd}`')
+	dbg('cmd=`${cmd}`', dbg_location)
 	res := os.execute(cmd)
-	dbg('${dbg_location}: res=`${res}`')
+	dbg('res=`${res}`', dbg_location)
 	return res.output.trim_right('\r\n')
 }
 
@@ -190,6 +190,6 @@ pub fn color_compare_strings(diff_cmd string, unique_prefix string, expected str
 }
 
 @[if vdiff_debug ?]
-fn dbg(msg string) {
-	println('[DIFF DEBUG] ' + msg)
+fn dbg(msg string, location string) {
+	println('[DIFF DEBUG] ${location}: ${msg}')
 }

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -71,6 +71,10 @@ pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
 
 // compare_text returns a string displaying the differences between two strings.
 pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
+	opts.find_tool()!
+	if text1 == text2 {
+		return ''
+	}
 	ctime := time.sys_mono_now()
 	tmp_dir := os.join_path_single(os.vtmp_dir(), ctime.str())
 	os.mkdir(tmp_dir)!

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -19,7 +19,7 @@ pub:
 	args string
 	// Sets the environment variable whose value can overwrite a diff command passed to a compare function.
 	// It also enables the use of commands that are not in the list of known diff tools.
-	// Set it to 'none' to disable it.
+	// Set it to `none` to disable it.
 	env_overwrite_var ?string = 'VDIFF_CMD'
 }
 
@@ -121,9 +121,9 @@ fn find_working_diff_tool() ?DiffTool {
 		os.find_abs_path_of_executable(cmd) or { continue }
 		if tool == .delta {
 			// Sanity check that the `delta` executable is actually the diff tool.
-			res := os.execute('${cmd} --help').output.split_into_lines()[0]
-			if !res.contains('diff') {
-				dbg('delta does not appear to be the diff tool `${res}`', @LOCATION)
+			help_desc := os.execute('${cmd} --help').output.trim_space().all_before('\n')
+			if !help_desc.contains('diff') {
+				dbg('delta does not appear to be the diff tool `${help_desc}`', @LOCATION)
 				continue
 			}
 		}

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -159,15 +159,16 @@ pub fn find_working_diff_command() !string {
 pub fn color_compare_files(diff_cmd string, path1 string, path2 string) string {
 	tool := diff_cmd.all_before(' ')
 	os.find_abs_path_of_executable(tool) or { return 'comparison command: `${tool}` not found' }
+	p1, p2 := os.quoted_path(os.real_path(path1)), os.quoted_path(os.real_path(path2))
 	if tool == 'diff' {
 		// Ensure that the diff command supports the color option.
 		// E.g., some BSD installations do not include `diffutils` as a core package alongside `diff`.
-		res := os.execute('${diff_cmd} --color=always ${diff.default_diff_args} ${os.quoted_path(path1)} ${os.quoted_path(path2)}')
+		res := os.execute('${diff_cmd} --color=always ${diff.default_diff_args} ${p1} ${p2}')
 		if !res.output.starts_with('diff: unrecognized option') {
 			return res.output.trim_right('\r\n')
 		}
 	}
-	cmd := '${diff_cmd} ${diff.default_diff_args} ${os.quoted_path(path1)} ${os.quoted_path(path2)}'
+	cmd := '${diff_cmd} ${diff.default_diff_args} ${p1} ${p2}'
 	return os.execute(cmd).output.trim_right('\r\n')
 }
 

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -14,7 +14,7 @@ pub enum DiffTool {
 @[params]
 pub struct CompareOptions {
 pub:
-	cmd DiffTool
+	tool DiffTool
 	// Custom args used with the diff command.
 	args string
 	// Sets the environment variable whose value can overwrite a diff command passed to a compare function.
@@ -52,14 +52,14 @@ pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
 			return run_tool('${tool} ${args} ${p1} ${p2}', @LOCATION)
 		}
 	}
-	tool := if opts.cmd == .auto {
+	tool := if opts.tool == .auto {
 		auto_tool := diff.available_tool or {
 			return error('error: failed to find comparison command')
 		}
 
 		auto_tool
 	} else {
-		opts.cmd
+		opts.tool
 	}
 	tool_cmd := $if windows { '${tool.str()}.exe' } $else { tool.str() }
 	os.find_abs_path_of_executable(tool_cmd) or {

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -97,7 +97,7 @@ fn test_compare_files() {
 }
 
 fn test_compare_string() {
-	mut res := diff.compare_text('abc', 'abcd', tool: .diff)!
+	mut res := diff.compare_text('abc\n', 'abcd\n', tool: .diff)!
 	assert res.contains('-abc'), res
 	assert res.contains('+abcd'), res
 	assert !res.contains('No newline at end of file'), res

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -46,7 +46,7 @@ fn test_compare_files() {
 	assert res.contains("name: 'foo'"), res
 
 	// From here on, pass `.diff` via the arg or environment variable to enforce consistent behavior in regular tests.
-	res = diff.compare_files(p1, p2, cmd: .diff)!
+	res = diff.compare_files(p1, p2, tool: .diff)!
 	assert res.contains("-\tname: 'Foo'"), res
 	assert res.contains("+\tname: 'foo'"), res
 	assert res.contains("-\tversion: '0.0.0'"), res
@@ -58,7 +58,7 @@ fn test_compare_files() {
 	assert res == diff.color_compare_files(diff.find_working_diff_command()!, p1, p2)
 
 	// Test custom options.
-	res = diff.compare_files(p1, p2, cmd: .diff, args: '-U 2 -i')!
+	res = diff.compare_files(p1, p2, tool: .diff, args: '-U 2 -i')!
 	assert !res.contains("+\tname: 'foo'"), res
 	assert res.contains("-\tversion: '0.0.0'"), res
 	assert res.contains("+\tversion: '0.1.0'"), res
@@ -83,21 +83,21 @@ fn test_compare_files() {
 		p1, p2))
 
 	// Test custom option that interferes with default options.
-	res = diff.compare_files(p1, p2, cmd: .diff, args: '--side-by-side', env_overwrite_var: none)!
+	res = diff.compare_files(p1, p2, tool: .diff, args: '--side-by-side', env_overwrite_var: none)!
 	assert res.match_glob("*version: '0.0.0'*|*version: '0.1.0'*"), res
 
 	// Test custom diff command.
 	// Test windows default `fc`.
 	/* $if windows { // TODO: enable when its `os.execute` output can be read.
-		res = diff.compare_files(p1, p1, cmd: .fc)!
+		res = diff.compare_files(p1, p1, tool: .fc)!
 		assert res.contains('FC: no differences encountered')
-		res = diff.compare_files(p1, p2, cmd: .fc, args: '/b')!
+		res = diff.compare_files(p1, p2, tool: .fc, args: '/b')!
 		assert res.contains('FC: ABCD longer than abc')
 	} */
 }
 
 fn test_compare_string() {
-	mut res := diff.compare_text('abc', 'abcd', cmd: .diff)!
+	mut res := diff.compare_text('abc', 'abcd', tool: .diff)!
 	assert res.contains('-abc'), res
 	assert res.contains('+abcd'), res
 	assert !res.contains('No newline at end of file'), res
@@ -115,7 +115,7 @@ fn test_coloring() {
 	os.write_file(p1, f1)!
 	os.write_file(p2, f2)!
 	esc := rune(27)
-	res := diff.compare_files(p1, p2, cmd: .diff)!
+	res := diff.compare_files(p1, p2, tool: .diff)!
 	assert res.contains('${esc}[31m-abc${esc}['), res
 	assert res.contains('${esc}[32m+abcd${esc}['), res
 	// Test deprecated

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -97,7 +97,7 @@ fn test_compare_files() {
 }
 
 fn test_compare_string() {
-	mut res := diff.compare_text('abc\n', 'abcd\n', tool: .diff)!
+	mut res := diff.compare_text('abc', 'abcd', tool: .diff)!
 	assert res.contains('-abc'), res
 	assert res.contains('+abcd'), res
 	assert !res.contains('No newline at end of file'), res

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -1,11 +1,14 @@
 import v.util.diff
 import os
+import term
 
 const tdir = os.join_path(os.vtmp_dir(), 'diff_test')
 
 fn testsuite_begin() {
+	// Disable environmental overwrites that can result in different compare outputs.
+	os.setenv('VDIFF_CMD', '', true)
 	os.find_abs_path_of_executable('diff') or {
-		eprintln('> skipping test, since this test requires `diff` to be installed')
+		eprintln('> skipping test `${@FILE}`, since this test requires `diff` to be installed')
 		exit(0)
 	}
 	os.mkdir_all(tdir)!
@@ -36,39 +39,73 @@ fn test_compare_files() {
 	os.write_file(p1, f1)!
 	os.write_file(p2, f2)!
 
-	mut res := diff.color_compare_files('diff', p1, p2)
+	// Test comparison without specifying a cmd only loosely, since an automatically detected tool
+	// or can result in a different compare output.
+	mut res := term.strip_ansi(diff.compare_files(p1, p2)!)
+	assert res.contains("name: 'Foo'"), res
+	assert res.contains("name: 'foo'"), res
+
+	// From here on, pass `.diff` via the arg or environment variable to enforce consistent behavior in regular tests.
+	res = diff.compare_files(p1, p2, cmd: .diff)!
 	assert res.contains("-\tname: 'Foo'"), res
 	assert res.contains("+\tname: 'foo'"), res
 	assert res.contains("-\tversion: '0.0.0'"), res
 	assert res.contains("+\tversion: '0.1.0'"), res
 	assert res.contains("+\tlicense: 'MIT'"), res
-
-	// Test adding a flag to the command.
-	res = diff.color_compare_files('diff --ignore-case', p1, p2)
-	assert !res.contains("+\tname: 'foo'"), res
-	assert res.contains("-\tversion: '0.0.0'"), res
-	assert res.contains("+\tversion: '0.1.0'"), res
-	assert res.contains("+\tlicense: 'MIT'"), res
-
+	// Test deprecated
+	assert res == diff.color_compare_files('diff', p1, p2)
 	// Test again using `find_working_diff_command()`.
-	os.setenv('VDIFF_TOOL', 'diff', true)
-	res = diff.color_compare_files(diff.find_working_diff_command()!, p1, p2)
-	assert res.contains("-\tversion: '0.0.0'"), res
-	assert res.contains("+\tversion: '0.1.0'"), res
-	assert res.contains("+\tlicense: 'MIT'"), res
+	assert res == diff.color_compare_files(diff.find_working_diff_command()!, p1, p2)
 
-	// Test adding a flag via env flag.
-	os.setenv('VDIFF_OPTIONS', '--ignore-case', true) // ignored, when VDIFF_TOOL is not explicitly set
-	res = diff.color_compare_files(diff.find_working_diff_command()!, p1, p2)
+	// Test custom options.
+	res = diff.compare_files(p1, p2, cmd: .diff, args: '-U 2 -i')!
 	assert !res.contains("+\tname: 'foo'"), res
 	assert res.contains("-\tversion: '0.0.0'"), res
 	assert res.contains("+\tversion: '0.1.0'"), res
 	assert res.contains("+\tlicense: 'MIT'"), res
+	// Test deprecated
+	assert res == term.strip_ansi(diff.color_compare_files('diff --ignore-case', p1, p2))
+
+	// Test options via env variable.
+	os.setenv('VDIFF_CMD', 'diff --ignore-case -U 2', true)
+	defer {
+		os.setenv('VDIFF_CMD', '', true)
+	}
+	res = diff.compare_files(p1, p2)!
+	assert !res.contains("+\tname: 'foo'"), res
+	assert res.contains("-\tversion: '0.0.0'"), res
+	assert res.contains("+\tversion: '0.1.0'"), res
+	assert res.contains("+\tlicense: 'MIT'"), res
+	// Test deprecated
+	os.setenv('VDIFF_TOOL', 'diff', true)
+	os.setenv('VDIFF_OPTIONS', '--ignore-case', true)
+	assert res == term.strip_ansi(diff.color_compare_files(diff.find_working_diff_command()!,
+		p1, p2))
+
+	// Test custom option that interferes with default options.
+	res = diff.compare_files(p1, p2, cmd: .diff, args: '--side-by-side', env_overwrite_var: none)!
+	assert res.match_glob("*version: '0.0.0'*|*version: '0.1.0'*"), res
+
+	// Test custom diff command.
+	// Test windows default `fc`.
+	/* $if windows { // TODO: enable when its `os.execute` output can be read.
+		res = diff.compare_files(p1, p1, cmd: .fc)!
+		assert res.contains('FC: no differences encountered')
+		res = diff.compare_files(p1, p2, cmd: .fc, args: '/b')!
+		assert res.contains('FC: ABCD longer than abc')
+	} */
+}
+
+fn test_compare_string() {
+	mut res := diff.compare_text('abc', 'abcd', cmd: .diff)!
+	assert res.contains('-abc'), res
+	assert res.contains('+abcd'), res
+	assert !res.contains('No newline at end of file'), res
 }
 
 fn test_coloring() {
 	if os.execute('diff --color=always').output.starts_with('diff: unrecognized option') {
-		eprintln('> skipping test, since `diff` does not support --color=always')
+		eprintln('> skipping test `${@FN}`, since `diff` does not support --color=always')
 		return
 	}
 	f1 := 'abc\n'
@@ -77,8 +114,10 @@ fn test_coloring() {
 	p2 := os.join_path(tdir, '${@FN}_f2.txt')
 	os.write_file(p1, f1)!
 	os.write_file(p2, f2)!
-	res := diff.color_compare_files('diff', p1, p2)
 	esc := rune(27)
+	res := diff.compare_files(p1, p2, cmd: .diff)!
 	assert res.contains('${esc}[31m-abc${esc}['), res
 	assert res.contains('${esc}[32m+abcd${esc}['), res
+	// Test deprecated
+	assert res == diff.color_compare_files('diff', p1, p2)
 }


### PR DESCRIPTION
The rewritten module should extend functionality, make usage easier/less verbose, fix issues and resolve friction points that may stand in the way of using it in whatever context.

## Some of the changes:

An overview of the changes is given below. However, it should not be necessary for the review, it was attempted to keep the code changes compact and easy to understand. Feel free to skip the overview.

### General reliability and predictability of return values:

- Use of known diff tools that can actually return a string value.

  To make the function call itself as safe and reliable as possible, tools like `code` and `opendiff` that open non-conforming files in a gui and do return a result string is limited to the overwrite via the environment variable. Additionally, it is possible to disable and to customize overwrites via the env variable.

### Error handling:

- Use of Result return types
  - The "old" module handles errors via unrecoverable panics or returns them formatted as string.
    Both should be resolved through using `!string` return types.

### Other changes:

- Fix  `\ No newline at end of file` in the return values of the string comparing function.
  Which is suboptimal for a function that by definition compares strings.
  ```v
  // Current
  diff.color_compare_strings(diff.find_working_diff_command()!, 'unique_smthn', 'abc', 'cde')
  // New
  diff.compare_text('abc', 'cde')!
  ```
  Comparing the output (assuming the automatically available diff command is `diff`)
  ```sh
  # Current
  ❯ v run file.v
  # ...
  -abc
  \ No newline at end of file
  +cde
  \ No newline at end of file

  # New
  ❯ v run file.v
  # ...
  -abc
  +cde
  ```

- Include [delta](https://github.com/so-fancy/diff-so-fancy) as diff tool. Which is a feature rich tool for human readable diffs that can help to analyze outputs. It can also emulate diff-so-fancy.

- Extend tests.

- For now, `vfmt.v` was updated as the only module that the diff module internally - also to make it easier testing the changes during a review locally. Other that use the current diff module could be updated separately.

### Better handled, more user oriented options:

- Handle options in a non-conflicting way. The current module has some defaults options that are hard coded to be always added, which might conflict with other args or tools.
  - **This is also a fix for the statement in `v fmt --help`**, which shows `VDIFF_OPTIONS="-W 80 -y"` (using the `-y` flag for side-by-side comparison).
    | Current | Updated |
    | - | - |
    | ![cur_diff_y](https://github.com/vlang/v/assets/34311583/bc1fe3ff-acd2-40de-aa55-3120ee27f561) | ![Screenshot_20240504_130540](https://github.com/vlang/v/assets/34311583/d802f596-da94-4b7e-8422-27012aad8e0d) |

    As a reference to verify that it's not a regression 87270e9936f44ee0eccf9da9eb56d6aed297467e is a commit before the recent fixes and preparations of the diff module.
  - Allows to use other tools
    | Current | Updated |
    | - | - |
    | ![cur_delta](https://github.com/vlang/v/assets/34311583/d7cce805-9c08-4f31-a290-6ed8e9860865) | ![Screenshot_20240504_130445](https://github.com/vlang/v/assets/34311583/c37bd4bd-6cc4-4d38-97ac-7126a5d7c295) |
