### PR TITLE
os: fix `dir` function for quoted paths

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -291,9 +291,9 @@ pub fn dir(opath string) string {
 	if pos == 0 && path_separator == '/' {
 		return '/'
 	}
-	quote := match path[0] {
-		`'` { "'" }
-		`"` { '"' }
+	quote := match true {
+		opath[0] == `'` && opath[opath.len - 1] == `'` { "'" }
+		opath[0] == `"` && opath[opath.len - 1] == `"` { '"' }
 		else { '' }
 	}
 	return path[..pos] + quote

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -291,7 +291,12 @@ pub fn dir(opath string) string {
 	if pos == 0 && path_separator == '/' {
 		return '/'
 	}
-	return path[..pos]
+	quote := match path[0] {
+		`'` { "'" }
+		`"` { '"' }
+		else { '' }
+	}
+	return path[..pos] + quote
 }
 
 // base returns the last element of path.


### PR DESCRIPTION
When passing a quoted path to `os.dir` the change will result in: 

```v
os.dir('"foo/bar/baz"') // -> `"foo/bar"` instead of `"foo/bar`
```