### PR TITLE
vlib: add port() for net.Addr

### DIFF
--- a/vlib/net/address.c.v
+++ b/vlib/net/address.c.v
@@ -60,6 +60,28 @@ pub fn (a Addr) family() AddrFamily {
 	return unsafe { AddrFamily(a.f) }
 }
 
+// port returns the ip or ip6 port of the given address `a`
+pub fn (a Addr) port() !u16 {
+	match unsafe { AddrFamily(a.f) } {
+		.ip {
+			unsafe {
+				return conv.ntoh16(a.addr.Ip.port)
+			}
+		}
+		.ip6 {
+			unsafe {
+				return conv.ntoh16(a.addr.Ip6.port)
+			}
+		}
+		.unix {
+			return error('unix addr has no port')
+		}
+		.unspec {
+			return error('unspec addr family when obtain port')
+		}
+	}
+}
+
 const max_ip_len = 24
 const max_ip6_len = 46
 

--- a/vlib/net/address_test.c.v
+++ b/vlib/net/address_test.c.v
@@ -1,5 +1,10 @@
 module net
 
+fn test_ip_port() {
+	assert new_ip(1234, addr_ip_any).port()! == 1234
+	assert new_ip6(1234, addr_ip6_any).port()! == 1234
+}
+
 fn test_diagnostics() {
 	dump(aoffset)
 	eprintln('--------')


### PR DESCRIPTION
When I start write a reverse proxy for my android / ios app, I need a port that is always available, so I set address `':0'`, then I try to obtain port that automatically assigned, but i can't find a function like `a.port()`.  Although I can parse the address to get the port, but this is inelegant, so i add function `.port()`.

```v
fn main() {
	mut server := net.listen_tcp(.ip, ':0') or { panic(err) }
	println(server.addr()!)
	println(server.addr()!.port()!) // add port func
	mut socket := server.accept()!
	// ...
}
```

```v
// port returns the ip or ip6 port of the given address `a`
pub fn (a Addr) port() !u16 {
	match unsafe { AddrFamily(a.f) } {
		.ip {
			unsafe {
				return conv.ntoh16(a.addr.Ip.port)
			}
		}
		.ip6 {
			unsafe {
				return conv.ntoh16(a.addr.Ip6.port)
			}
		}
		.unix {
			return error('unix addr has no port')
		}
		.unspec {
			return error('unspec addr family when obtain port')
		}
	}
}
```

```v
// address_port_test.v
import net
import strconv

fn test_ip_port(){
	mut server := net.listen_tcp(.ip, ':0') or {panic(err)}
	port_str := server.addr()!.str().split(':').last()
	port  := strconv.parse_uint(port_str, 10, 16)!
	assert port == server.addr()!.port()!
}

fn test_ip6_port(){
	mut server := net.listen_tcp(.ip6, ':0') or {panic(err)}
	port_str := server.addr()!.str().split(':').last()
	port  := strconv.parse_uint(port_str, 10, 16)!
	assert port == server.addr()!.port()!
}

fn test_unix_port(){
	a := net.Addr{
		f: u8(net.AddrFamily.unix)
	}

	p := a.port() or {
		assert err.str() == 'unix addr has no port'
		0
	}
	assert p == 0
}

fn test_unspec_port(){
	a := net.Addr{
		f: u8(net.AddrFamily.unspec)
	}

	p := a.port() or {
		assert err.str() == 'unspec addr family when obtain port'
		0
	}
	assert p == 0
}
```


