### PR TITLE
ci: ensure `master` is available when trying to check out it's commits to build oldv

### DIFF
--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 10
+          fetch-depth: 0
       - name: Build V
         run: make -j4
       - name: Test bootstrapping (v.c can be compiled and run with -os cross)
@@ -68,6 +68,9 @@ jobs:
           ls -la v vc/v.c
           ls -la v_from_vc v_from_vc_produced_native_v
           ls -la v_from_vc2 v_from_vc_produced_native_v2
+      - name: Ensure V master is available
+        if: github.ref_name != 'master'
+        run: git branch master remotes/origin/master
       - name: Test `v up`
         run: |
           # Derive a commit sha from an older successful fast workflow on master that was able to build V.
@@ -79,7 +82,9 @@ jobs:
             "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=2" \
             | jq -r '.workflow_runs[1].head_sha')
           echo "recent_good_commit=$recent_good_commit"
+          # Build oldv at recent_good_commit.
           ./v run cmd/tools/oldv.v -v $recent_good_commit
           cd ~/.cache/oldv/v_at_$recent_good_commit
+          # Test updating
           ./v version && ./v -v up && ./v version
           ./v -o v2 cmd/v && ./v2 -o v3 cmd/v


### PR DESCRIPTION
Fixes workflow fails of the `Bootstrapping CI` on forks and occasionally in PRs. 

Failures happen, because oldv receives a commit that is available on master, but the master branch itself is not available in the workflow due to a shallow checkout of the checkout action.

The fix is simple by ensuring the master branch is available.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
