### PR TITLE
vet, parser: rewrite vet error handling (improve parser performance extend vvet) p1

### DIFF
--- a/cmd/tools/install_binaryen.vsh
+++ b/cmd/tools/install_binaryen.vsh
@@ -26,10 +26,10 @@ fn main() {
 	// TODO: add retries here, github requests can fail
 	jq := http.get_text('https://api.github.com/repos/WebAssembly/binaryen/releases/latest')
 	tag := json.decode(JQ, jq)!.tag_name
-        if github_job != '' {
-                dump(jq)
-                dump(tag)
-        }
+	     if github_job != '' {
+	             dump(jq)
+	             dump(tag)
+	     }
 	*/
 	tag := 'version_112'
 

--- a/cmd/tools/vvet/filter.v
+++ b/cmd/tools/vvet/filter.v
@@ -1,0 +1,27 @@
+module main
+
+import v.token
+import v.vet
+
+type FilteredLines = map[vet.ErrorType]map[int]bool
+
+fn (mut fl FilteredLines) comments(is_multi bool, pos token.Pos) {
+	if !is_multi {
+		return
+	}
+	for ln in pos.line_nr + 1 .. pos.last_line + 1 {
+		fl[.space_indent][ln] = true
+	}
+}
+
+fn (mut fl FilteredLines) assigns(pos token.Pos) {
+	if pos.line_nr == pos.last_line {
+		return
+	}
+	for ln in pos.line_nr + 1 .. pos.last_line {
+		fl[.trailing_space][ln] = true
+		fl[.space_indent][ln] = true
+	}
+	fl[.trailing_space][pos.line_nr] = true
+	fl[.space_indent][pos.last_line] = true
+}


### PR DESCRIPTION
Currently, vet errors are validated and filtered in the parser.
 
The changes will help with to take vet to the next level while also simplifying the parser and improving it's performance. Similar to recent changes, this also fits under the mantra "Parse, don't validate".

This will also resolve TODOS, which should not be TODOs in those modules.

> ```v
> // TODO: `$if vet {` for performance`
> ```


To simplify reviewing things I'll try to submit the changes in a few parts that can hopefully stand on their own without falling appart. The parts should become simpler when things progress. 

The first part creates a base for vets evolution and extends it's ability to handle  trailing space and indentation errors on it's own. This already takes load of the parser.