### PR TITLE
vet, parser: move array_init_one_val checks from parser into vet

### DIFF
--- a/cmd/tools/vvet/tests/array_init_one_val.out
+++ b/cmd/tools/vvet/tests/array_init_one_val.out
@@ -1,2 +1,3 @@
-cmd/tools/vvet/tests/array_init_one_val.vv:2: error: Use `var == value` instead of `var in [value]`
+cmd/tools/vvet/tests/array_init_one_val.vv:2: error: Use `1 == 1` instead of `1 in [1]`
+cmd/tools/vvet/tests/array_init_one_val.vv:6: error: Use `'foo' != bar` instead of `'foo' !in [bar]`
 Note: You can run `v fmt -w file.v` to fix these errors automatically

--- a/cmd/tools/vvet/tests/array_init_one_val.vv
+++ b/cmd/tools/vvet/tests/array_init_one_val.vv
@@ -2,4 +2,8 @@ fn main() {
 	if 1 in [1] {
 		println('hello world')
 	}
+	bar := 'bar'
+	if 'foo' !in [bar] {
+		println('hello world')
+	}
 }

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -4,7 +4,6 @@
 module parser
 
 import v.ast
-import v.vet
 import v.token
 
 fn (mut p Parser) expr(precedence int) ast.Expr {
@@ -686,10 +685,6 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 		p.inside_in_array = false
 	}
 	p.expecting_type = prev_expecting_type
-	if p.pref.is_vet && op in [.key_in, .not_in] && right is ast.ArrayInit && right.exprs.len == 1 {
-		p.vet_error('Use `var == value` instead of `var in [value]`', pos.line_nr, vet.FixKind.vfmt,
-			.default)
-	}
 	mut or_stmts := []ast.Stmt{}
 	mut or_kind := ast.OrKind.absent
 	mut or_pos := p.tok.pos()


### PR DESCRIPTION
Due to similar locations changed in vvet this might conflict with #21421.
It's recommended to await the re-scan after one is resolved.