### PR TITLE
vet, parser: remove vet_errors and vet_notices from parser

### DIFF
--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -110,11 +110,10 @@ fn (mut vt Vet) vet_file(path string) {
 	prefs.is_vsh = path.ends_with('.vsh')
 	mut table := ast.new_table()
 	vt.vprintln("vetting file '${path}'...")
-	file, errors, notices := parser.parse_vet_file(path, mut table, prefs)
+	file, errors := parser.parse_vet_file(path, mut table, prefs)
 	vt.stmts(file.stmts)
 	// Transfer errors from scanner and parser
 	vt.errors << errors
-	vt.notices << notices
 	source_lines := os.read_lines(vt.file) or { []string{} }
 	for ln, line in source_lines {
 		vt.vet_line(source_lines, line, ln)

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -112,8 +112,6 @@ pub mut:
 	errors         []errors.Error
 	warnings       []errors.Warning
 	notices        []errors.Notice
-	vet_errors     []vet.Error
-	vet_notices    []vet.Error
 	template_paths []string // record all compiled $tmpl files; needed for `v watch run webserver.v`
 }
 
@@ -259,7 +257,7 @@ pub fn parse_file(path string, mut table ast.Table, comments_mode scanner.Commen
 	return res
 }
 
-pub fn parse_vet_file(path string, mut table_ ast.Table, pref_ &pref.Preferences) (&ast.File, []vet.Error, []vet.Error) {
+pub fn parse_vet_file(path string, mut table_ ast.Table, pref_ &pref.Preferences) (&ast.File, []vet.Error) {
 	$if trace_parse_vet_file ? {
 		eprintln('> ${@MOD}.${@FN} path: ${path}')
 	}
@@ -278,10 +276,10 @@ pub fn parse_vet_file(path string, mut table_ ast.Table, pref_ &pref.Preferences
 		warnings: []errors.Warning{}
 	}
 	p.set_path(path)
-	p.vet_errors << p.scanner.vet_errors
+	vet_errors := p.scanner.vet_errors
 	file := p.parse()
 	unsafe { p.free_scanner() }
-	return file, p.vet_errors, p.vet_notices
+	return file, vet_errors
 }
 
 pub fn (mut p Parser) parse() &ast.File {
@@ -2149,34 +2147,6 @@ fn (mut p Parser) note_with_pos(s string, pos token.Pos) {
 			reporter: .parser
 			message: s
 		}
-	}
-}
-
-fn (mut p Parser) vet_error(msg string, line int, fix vet.FixKind, typ vet.ErrorType) {
-	pos := token.Pos{
-		line_nr: line + 1
-	}
-	p.vet_errors << vet.Error{
-		message: msg
-		file_path: p.scanner.file_path
-		pos: pos
-		kind: .error
-		fix: fix
-		typ: typ
-	}
-}
-
-fn (mut p Parser) vet_notice(msg string, line int, fix vet.FixKind, typ vet.ErrorType) {
-	pos := token.Pos{
-		line_nr: line + 1
-	}
-	p.vet_notices << vet.Error{
-		message: msg
-		file_path: p.scanner.file_path
-		pos: pos
-		kind: .notice
-		fix: fix
-		typ: typ
 	}
 }
 


### PR DESCRIPTION
After #21422, #21423 this PR can already remove vet_errors and vet_notices from the parser. Extending vvet to be able to handle the scanner errors as well would be the next step.