### PR TITLE
os: fix `os.join_path('/', 'file.txt')` and `os.join_path_single('/', 'file.txt')` (fix #20231)

### DIFF
--- a/vlib/os/dir_expansions_test.v
+++ b/vlib/os/dir_expansions_test.v
@@ -23,7 +23,7 @@ fn test_ensure_folder_is_writable() {
 
 fn test_expand_tilde_to_home() {
 	os.setenv('HOME', '/tmp/home/folder', true)
-	os.setenv('USERPROFILE', '/tmp/home/folder', true)
+	os.setenv('USERPROFILE', r'\tmp\home\folder', true)
 	//
 	home_test := os.join_path(os.home_dir(), 'test', 'tilde', 'expansion')
 	home_expansion_test := os.expand_tilde_to_home(os.join_path('~', 'test', 'tilde',

--- a/vlib/os/join_path_test.v
+++ b/vlib/os/join_path_test.v
@@ -6,6 +6,7 @@ fn test_join_path() {
 		assert os.join_path('', 'f1', 'f2') == r'f1\f2'
 		assert os.join_path('v', '', 'dir') == r'v\dir'
 		assert os.join_path('foo\\bar', '.\\file.txt') == r'foo\bar\file.txt'
+		assert os.join_path('/opt/v', './x') == r'\opt\v\x'
 	} $else {
 		assert os.join_path('v', 'vlib', 'os') == 'v/vlib/os'
 		assert os.join_path('/foo/bar', './file.txt') == '/foo/bar/file.txt'
@@ -13,6 +14,8 @@ fn test_join_path() {
 		assert os.join_path('v', '', 'dir') == 'v/dir'
 		assert os.join_path('/', 'test') == '/test'
 		assert os.join_path('foo/bar', './file.txt') == 'foo/bar/file.txt'
+		assert os.join_path('/opt/v', './x') == '/opt/v/x'
+		assert os.join_path('./a', './b') == './a/b'
 	}
 }
 
@@ -21,9 +24,12 @@ fn test_join_path_single() {
 		assert os.join_path_single('/foo/bar', './file.txt') == r'\foo\bar\file.txt'
 		assert os.join_path_single('/', 'test') == r'\test'
 		assert os.join_path_single('foo\\bar', '.\\file.txt') == r'foo\bar\file.txt'
+		assert os.join_path_single('/opt/v', './x') == r'\opt\v\x'
 	} $else {
 		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
 		assert os.join_path_single('/', 'test') == '/test'
 		assert os.join_path_single('foo/bar', './file.txt') == 'foo/bar/file.txt'
+		assert os.join_path_single('/opt/v', './x') == '/opt/v/x'
+		assert os.join_path_single('./a', './b') == './a/b'
 	}
 }

--- a/vlib/os/join_path_test.v
+++ b/vlib/os/join_path_test.v
@@ -1,0 +1,29 @@
+import os
+
+fn test_join_path() {
+	$if windows {
+		assert os.join_path('v', 'vlib', 'os') == r'v\vlib\os'
+		assert os.join_path('', 'f1', 'f2') == r'f1\f2'
+		assert os.join_path('v', '', 'dir') == r'v\dir'
+		assert os.join_path('foo\\bar', '.\\file.txt') == r'foo\bar\file.txt'
+	} $else {
+		assert os.join_path('v', 'vlib', 'os') == 'v/vlib/os'
+		assert os.join_path('/foo/bar', './file.txt') == '/foo/bar/file.txt'
+		assert os.join_path('', 'f1', 'f2') == 'f1/f2'
+		assert os.join_path('v', '', 'dir') == 'v/dir'
+		assert os.join_path('/', 'test') == '/test'
+		assert os.join_path('foo/bar', './file.txt') == 'foo/bar/file.txt'
+	}
+}
+
+fn test_join_path_single() {
+	$if windows {
+		assert os.join_path_single('/foo/bar', './file.txt') == r'\foo\bar\file.txt'
+		assert os.join_path_single('/', 'test') == r'\test'
+		assert os.join_path_single('foo\\bar', '.\\file.txt') == r'foo\bar\file.txt'
+	} $else {
+		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
+		assert os.join_path_single('/', 'test') == '/test'
+		assert os.join_path_single('foo/bar', './file.txt') == 'foo/bar/file.txt'
+	}
+}

--- a/vlib/os/join_path_test.v
+++ b/vlib/os/join_path_test.v
@@ -1,13 +1,30 @@
 import os
 
 fn test_join_path() {
+	assert os.join_path('', '', '') == ''
+	assert os.join_path('', '') == ''
+	assert os.join_path('') == ''
+	assert os.join_path('b', '', '') == 'b'
+	assert os.join_path('b', '') == 'b'
+	assert os.join_path('b') == 'b'
+	assert os.join_path('', '', './b') == 'b'
+	assert os.join_path('', '', '/b') == 'b'
+	assert os.join_path('', '', 'b') == 'b'
+	assert os.join_path('', './b') == 'b'
+	assert os.join_path('', '/b') == 'b'
+	assert os.join_path('', 'b') == 'b'
+	assert os.join_path('b', '') == 'b'
 	$if windows {
+		assert os.join_path('./b', '') == r'.\b'
+		assert os.join_path('/b', '') == r'\b'
 		assert os.join_path('v', 'vlib', 'os') == r'v\vlib\os'
 		assert os.join_path('', 'f1', 'f2') == r'f1\f2'
 		assert os.join_path('v', '', 'dir') == r'v\dir'
 		assert os.join_path('foo\\bar', '.\\file.txt') == r'foo\bar\file.txt'
 		assert os.join_path('/opt/v', './x') == r'\opt\v\x'
 	} $else {
+		assert os.join_path('./b', '') == './b'
+		assert os.join_path('/b', '') == '/b'
 		assert os.join_path('v', 'vlib', 'os') == 'v/vlib/os'
 		assert os.join_path('/foo/bar', './file.txt') == '/foo/bar/file.txt'
 		assert os.join_path('', 'f1', 'f2') == 'f1/f2'
@@ -20,16 +37,26 @@ fn test_join_path() {
 }
 
 fn test_join_path_single() {
+	assert os.join_path_single('', '') == ''
+	assert os.join_path_single('', './b') == 'b'
+	assert os.join_path_single('', '/b') == 'b'
+	assert os.join_path_single('', 'b') == 'b'
+	assert os.join_path_single('b', '') == 'b'
 	$if windows {
+		assert os.join_path_single('./b', '') == r'.\b'
+		assert os.join_path_single('/b', '') == r'\b'
 		assert os.join_path_single('/foo/bar', './file.txt') == r'\foo\bar\file.txt'
 		assert os.join_path_single('/', 'test') == r'\test'
 		assert os.join_path_single('foo\\bar', '.\\file.txt') == r'foo\bar\file.txt'
 		assert os.join_path_single('/opt/v', './x') == r'\opt\v\x'
 	} $else {
+		assert os.join_path_single('./b', '') == r'./b'
+		assert os.join_path_single('/b', '') == r'/b'
 		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
 		assert os.join_path_single('/', 'test') == '/test'
 		assert os.join_path_single('foo/bar', './file.txt') == 'foo/bar/file.txt'
 		assert os.join_path_single('/opt/v', './x') == '/opt/v/x'
 		assert os.join_path_single('./a', './b') == './a/b'
+		assert os.join_path_single('a', './b') == 'a/b'
 	}
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -588,7 +588,7 @@ pub fn join_path(base string, dirs ...string) string {
 		}
 	}
 	mut res := sb.str()
-	if sbase == '' {
+	if base == '' {
 		res = res.trim_left(path_separator)
 	}
 	if res.contains('/./') {
@@ -617,7 +617,12 @@ pub fn join_path_single(base string, elem string) string {
 		sb.write_string(path_separator)
 	}
 	sb.write_string(elem)
-	return sb.str()
+	mut res := sb.str()
+	if res.contains('/./') {
+		// Fix `join_path("/foo/bar", "./file.txt")` => `/foo/bar/./file.txt`
+		res = res.replace('/./', '/')
+	}
+	return res
 }
 
 // walk_ext returns a recursive list of all files in `path` ending with `ext`.

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -637,7 +637,7 @@ fn normalize_path_in_builder(mut sb strings.Builder) {
 	for idx in 0 .. sb.len - 3 {
 		if sb[idx] == rs && sb[idx + 1] == `.` && sb[idx + 2] == rs {
 			unsafe {
-				for j := idx + 1; j < sb.len - 3; j++ {
+				for j := idx + 1; j < sb.len - 2; j++ {
 					sb[j] = sb[j + 2]
 				}
 				sb.len -= 2

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -609,13 +609,17 @@ pub fn join_path_single(base string, elem string) string {
 	defer {
 		unsafe { sbase.free() }
 	}
-	if base != '' {
-		sb.write_string(sbase)
+	sb.write_string(sbase)
+	if elem != '' {
 		sb.write_string(path_separator)
+		sb.write_string(elem)
 	}
-	sb.write_string(elem)
 	normalize_path_in_builder(mut sb)
-	return sb.str()
+	mut res := sb.str()
+	if base == '' {
+		res = res.trim_left(path_separator)
+	}
+	return res
 }
 
 @[direct_array_access]

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -620,8 +620,12 @@ pub fn join_path_single(base string, elem string) string {
 
 @[direct_array_access]
 fn normalize_path_in_builder(mut sb strings.Builder) {
-	fs := $if windows { `/` } $else { `\\` }
-	rs := $if windows { `\\` } $else { `/` }
+	mut fs := `\\`
+	mut rs := `/`
+	$if windows {
+		fs = `/`
+		rs = `\\`
+	}
 	for idx in 0 .. sb.len {
 		unsafe {
 			if sb[idx] == fs {
@@ -633,7 +637,9 @@ fn normalize_path_in_builder(mut sb strings.Builder) {
 	for idx in 0 .. sb.len - 3 {
 		if sb[idx] == rs && sb[idx + 1] == `.` && sb[idx + 2] == rs {
 			unsafe {
-				vmemcpy(&sb[idx + 1], &sb[idx + 3], sb.len - idx)
+				for j := idx + 1; j < sb.len - 3; j++ {
+					sb[j] = sb[j + 2]
+				}
 				sb.len -= 2
 			}
 		}

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -624,6 +624,18 @@ fn test_join() {
 		assert os.join_path('/foo/bar', './file.txt') == '/foo/bar/file.txt'
 		assert os.join_path('', 'f1', 'f2') == 'f1/f2'
 		assert os.join_path('v', '', 'dir') == 'v/dir'
+		assert os.join_path('/', 'test') == '/test'
+	}
+}
+
+fn test_join_path_single() {
+	assert os.join_path_single('foo/bar', './file.txt') == 'foo/bar/file.txt'
+	$if windows {
+		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
+		assert os.join_path_single('/', 'test') == '/test'
+	} $else {
+		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
+		assert os.join_path_single('/', 'test') == '/test'
 	}
 }
 

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -614,31 +614,6 @@ fn test_file_ext() {
 	assert os.file_ext('\\.git\\') == ''
 }
 
-fn test_join() {
-	$if windows {
-		assert os.join_path('v', 'vlib', 'os') == 'v\\vlib\\os'
-		assert os.join_path('', 'f1', 'f2') == 'f1\\f2'
-		assert os.join_path('v', '', 'dir') == 'v\\dir'
-	} $else {
-		assert os.join_path('v', 'vlib', 'os') == 'v/vlib/os'
-		assert os.join_path('/foo/bar', './file.txt') == '/foo/bar/file.txt'
-		assert os.join_path('', 'f1', 'f2') == 'f1/f2'
-		assert os.join_path('v', '', 'dir') == 'v/dir'
-		assert os.join_path('/', 'test') == '/test'
-	}
-}
-
-fn test_join_path_single() {
-	assert os.join_path_single('foo/bar', './file.txt') == 'foo/bar/file.txt'
-	$if windows {
-		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
-		assert os.join_path_single('/', 'test') == '/test'
-	} $else {
-		assert os.join_path_single('/foo/bar', './file.txt') == '/foo/bar/file.txt'
-		assert os.join_path_single('/', 'test') == '/test'
-	}
-}
-
 fn test_rmdir_all() {
 	mut dirs := ['some/dir', 'some/.hidden/directory']
 	$if windows {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3688,6 +3688,10 @@ fn (mut p Parser) import_stmt() ast.Import {
 		return import_node
 	}
 	mut source_name := p.check_name()
+	if source_name == '' {
+		p.error_with_pos('import name can not be empty', pos)
+		return import_node
+	}
 	mut mod_name_arr := []string{}
 	mod_name_arr << source_name
 	if import_pos.line_nr != pos.line_nr {


### PR DESCRIPTION
Fix #20231 .