### PR TITLE
v: utilize new diff functions p1

### DIFF
--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -1,5 +1,4 @@
 import os
-import rand
 import term
 import v.util.diff
 import v.util.vtest
@@ -409,10 +408,10 @@ fn chunka(s []u8, chunk_size int) string {
 
 fn diff_content(expected string, found string) {
 	println(term.bold(term.yellow('diff: ')))
-	if diff_cmd := diff.find_working_diff_command() {
-		println(diff.color_compare_strings(diff_cmd, rand.ulid(), expected, found))
+	if diff_ := diff.compare_text(expected, found) {
+		println(diff_)
 	} else {
-		println('>>>> could not find a working diff command; dumping bytes instead...')
+		println('>>>> `${err}`; dumping bytes instead...')
 		println('expected bytes:\n${chunka(expected.bytes(), 25)}')
 		println('   found bytes:\n${chunka(found.bytes(), 25)}')
 		println('============')

--- a/vlib/v/slow_tests/inout/compiler_test.v
+++ b/vlib/v/slow_tests/inout/compiler_test.v
@@ -95,16 +95,18 @@ fn test_all() {
 		}
 		if expected != found {
 			println(term.red('FAIL'))
-			println(term.header('expected:', '-'))
-			println(expected)
-			println(term.header('found:', '-'))
-			println(found)
-			if diff_cmd != '' {
+			if diff_ := diff.compare_text(expected, found) {
 				println(term.header('difference:', '-'))
-				println(diff.color_compare_strings(diff_cmd, rand.ulid(), expected, found))
+				println(diff_)
+				total_errors++
 			} else {
-				println(term.h_divider('-'))
+				println(err)
+				println(term.header('expected:', '-'))
+				println(expected)
+				println(term.header('found:', '-'))
+				println(found)
 			}
+			println(term.h_divider('-'))
 			total_errors++
 		} else {
 			println(term.green('OK'))


### PR DESCRIPTION
Regarding the utilization of the new diff functions. 

Currently, printing diffs has different approaches in the code base. The two with the main differences I try to point out are shown below.

Since things can also be improved and made more consistent when integrating the new functions, this PR takes two places that allow us to decide on an updated that might be more suited then the other. Then it could serve as preferred way when updating the new diff functions in other places.

- Approach 1. (visible in the updated `vlib/v/compiler_errors_test.v`)
  Prints diffs **OR** expected and found.
- Approach 2. (visible in the updated `slow_tests/inout/compiler_test.v`)
  Prints first expected then found **AND** then differences. This currently used more frequently. 
  
  Atm. the PR updates slow_tests/inout/compiler_test.v from A2 to A1. Resulting in:
  | Current | Updated |
  | - | - |
  | ![Screenshot_20240505_134055](https://github.com/vlang/v/assets/34311583/30c03e49-5144-412d-a501-8c8cc48adb18) | ![Screenshot_20240505_134927](https://github.com/vlang/v/assets/34311583/c712744d-a673-4b2c-8feb-d4c74b5eb23b) |

  
