### PR TITLE
v.util: fix condition for color attempt when auto tool is `diff`

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -56,7 +56,7 @@ pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
 	mut args := opts.args
 	if args == '' {
 		args = if defaults := diff.known_diff_tool_defaults[tool] { defaults } else { '' }
-		if opts.tool == .diff {
+		if tool == .diff {
 			// Ensure that the diff command supports the color option.
 			// E.g., some BSD installations or macOS diff (based on FreeBSD diff)
 			// might not include additional diffutils by default.


### PR DESCRIPTION
Fixes a mistake where a condition should use `tool` (the already resolved `opts.tool`). This will result in a correctly true condition when the `opts.tool` is `== .auto` and the auto tool is `diff`.