### PR TITLE
regex: fix typo in regex character class example

### DIFF
--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -67,7 +67,7 @@ but it doesn't match `C` or `z`.
 Inside a cc, it is possible to specify a "range" of characters, for example
 `[ad-h]` is equivalent to writing `[adefgh]`.
 
-A cc can have different ranges at the same time, for example `[a-zA-z0-9]`
+A cc can have different ranges at the same time, for example `[a-zA-Z0-9]`
 matches all the latin lowercase, uppercase and numeric characters.
 
 It is possible to negate the meaning of a cc, using the caret char at the


### PR DESCRIPTION
The character class example for all latin lowercase, uppercase, and numeric characters used a lower case `z` for the end of the range starting with `A`.  While the resulting character class would contain all the above mentioned characters, there would be a few more, unexpected, characters included in the range.  In particular, `[`, `\`, `]`,  `^`, `_`, and the backtick character.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
