### PR TITLE
v.util: make all available diff tools accessible, extend tests

### DIFF
--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -5,7 +5,7 @@ import term
 const tdir = os.join_path(os.vtmp_dir(), 'diff_test')
 
 fn testsuite_begin() {
-	if diff.DiffTool.diff !in diff.available_tools {
+	if diff.DiffTool.diff !in diff.available_tools() {
 		// On GitHub runners, diff should be available on all platforms.
 		// Prevent regressions by failing instead of skipping when it's not detected.
 		if os.getenv('CI') == 'true' {

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -5,13 +5,18 @@ import term
 const tdir = os.join_path(os.vtmp_dir(), 'diff_test')
 
 fn testsuite_begin() {
-	// Disable environmental overwrites that can result in different compare outputs.
-	os.setenv('VDIFF_CMD', '', true)
-	os.find_abs_path_of_executable('diff') or {
+	if diff.DiffTool.diff !in diff.available_tools {
+		// On GitHub runners, diff should be available on all platforms.
+		// Prevent regressions by failing instead of skipping when it's not detected.
+		if os.getenv('CI') == 'true' {
+			exit(1)
+		}
 		eprintln('> skipping test `${@FILE}`, since this test requires `diff` to be installed')
 		exit(0)
 	}
 	os.mkdir_all(tdir)!
+	// Disable environmental overwrites that can result in different compare outputs.
+	os.setenv('VDIFF_CMD', '', true)
 }
 
 fn testsuite_end() {


### PR DESCRIPTION
Providing information in the public constant should further extend developer possibilities. 

A test for this is added in a way that makes the tests for the full module more regression safe:

Ref., regarding the availability of `diff` as tool on all CI runners:
![Screenshot_20240506_120540](https://github.com/vlang/v/assets/34311583/90666964-5f28-4656-93f8-70393def8405)
