### PR TITLE
v, vet: move now obsolete vlib vet module to cmd vet

### DIFF
--- a/cmd/tools/vvet/errors.v
+++ b/cmd/tools/vvet/errors.v
@@ -1,7 +1,5 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
-module vet
-
 import v.token
 
 pub enum ErrorKind {
@@ -24,7 +22,7 @@ pub enum ErrorType {
 }
 
 @[minify]
-pub struct Error {
+pub struct VetError {
 pub mut:
 	kind ErrorKind @[required]
 pub:

--- a/cmd/tools/vvet/filter.v
+++ b/cmd/tools/vvet/filter.v
@@ -1,9 +1,8 @@
 module main
 
 import v.token
-import v.vet
 
-type FilteredLines = map[vet.ErrorType]map[int]bool
+type FilteredLines = map[ErrorType]map[int]bool
 
 fn (mut fl FilteredLines) comments(is_multi bool, pos token.Pos) {
 	if !is_multi {

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -4,7 +4,6 @@ module main
 
 import os
 import os.cmdline
-import v.vet
 import v.pref
 import v.parser
 import v.token
@@ -15,9 +14,9 @@ import term
 struct Vet {
 mut:
 	opt            Options
-	errors         []vet.Error
-	warns          []vet.Error
-	notices        []vet.Error
+	errors         []VetError
+	warns          []VetError
+	notices        []VetError
 	file           string
 	filtered_lines FilteredLines
 }
@@ -326,7 +325,7 @@ fn (vt &Vet) vprintln(s string) {
 	println(s)
 }
 
-fn (vt &Vet) e2string(err vet.Error) string {
+fn (vt &Vet) e2string(err VetError) string {
 	mut kind := '${err.kind}:'
 	mut location := '${err.file_path}:${err.pos.line_nr}:'
 	if vt.opt.use_color {
@@ -351,11 +350,11 @@ fn (mut vt Vet) vet_in_condition(expr ast.InfixExpr) {
 	}
 }
 
-fn (mut vt Vet) error(msg string, line int, fix vet.FixKind) {
+fn (mut vt Vet) error(msg string, line int, fix FixKind) {
 	pos := token.Pos{
 		line_nr: line + 1
 	}
-	vt.errors << vet.Error{
+	vt.errors << VetError{
 		message: msg
 		file_path: vt.file
 		pos: pos
@@ -365,11 +364,11 @@ fn (mut vt Vet) error(msg string, line int, fix vet.FixKind) {
 	}
 }
 
-fn (mut vt Vet) warn(msg string, line int, fix vet.FixKind) {
+fn (mut vt Vet) warn(msg string, line int, fix FixKind) {
 	pos := token.Pos{
 		line_nr: line + 1
 	}
-	mut w := vet.Error{
+	mut w := VetError{
 		message: msg
 		file_path: vt.file
 		pos: pos
@@ -385,11 +384,11 @@ fn (mut vt Vet) warn(msg string, line int, fix vet.FixKind) {
 	}
 }
 
-fn (mut vt Vet) notice(msg string, line int, fix vet.FixKind) {
+fn (mut vt Vet) notice(msg string, line int, fix FixKind) {
 	pos := token.Pos{
 		line_nr: line + 1
 	}
-	vt.notices << vet.Error{
+	vt.notices << VetError{
 		message: msg
 		file_path: vt.file
 		pos: pos


### PR DESCRIPTION
With the latest updates, we can move the `vlib/vet/vet.v` module, which was used for errors in the parser and scanner, to the vvet tool, as it is now able to handle the errors itself and not used anymore in the parser and scanner. This will cleanup the vlib and keep code closer to it's related source.