### PR TITLE
v.util: fix the performance of `v test-cleancode`, when a slower diff tool is installed

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -1,3 +1,4 @@
+@[has_globals]
 module diff
 
 import os
@@ -35,9 +36,16 @@ const known_diff_tool_defaults = {
 	// .fc:        '/lnt'
 }
 
+__global cached_available_tool = ?DiffTool(none)
+
 // Allows public checking for the available tool and prevents repeated searches
 // when using compare functions with automatic diff tool detection.
-pub const available_tool = find_working_diff_tool()
+pub fn available_tool() ?DiffTool {
+	if cached_available_tool == none {
+		cached_available_tool = find_working_diff_tool()
+	}
+	return cached_available_tool
+}
 
 // compare_files returns a string displaying the differences between two files.
 pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
@@ -96,7 +104,7 @@ pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
 
 fn (opts CompareOptions) find_tool() !(DiffTool, string) {
 	tool := if opts.tool == .auto {
-		auto_tool := diff.available_tool or {
+		auto_tool := available_tool() or {
 			return error('error: failed to find comparison command')
 		}
 


### PR DESCRIPTION
Using a constant meant that the diff tools were always found, even if they were not used.

That added some milliseconds, to the start time of programs that used `v.util.diff`, like `v fmt` or `v test-cleancode`.

Changing `available_tool` to be a function, allows it to delay, and cache the invocation of the slower find_working_diff_tool, until it is actually needed (which may be never).