### PR TITLE
tools: improve performance of `v test-cleancode` and `v fmt -inprocess -verify .`

### DIFF
--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -83,7 +83,7 @@ fn v_test_vetting(vargs string) ! {
 	fmt_cmd, fmt_args := if is_fix {
 		'${os.quoted_path(vexe)} fmt -w', 'fmt -w'
 	} else {
-		'${os.quoted_path(vexe)} fmt -verify', 'fmt -verify'
+		'${os.quoted_path(vexe)} fmt -inprocess -verify', 'fmt -inprocess -verify'
 	}
 	vfmt_list := util.find_all_v_files(vfmt_verify_list) or { return }
 	exceptions := util.find_all_v_files(vfmt_known_failing_exceptions) or { return }

--- a/vlib/v/help/common/fmt.txt
+++ b/vlib/v/help/common/fmt.txt
@@ -32,6 +32,11 @@ Options:
   -verify        Make sure the provided file is already formatted. Useful for
                  checking code contributions in CI for example.
 
+  -inprocess     Do everything in the same process. More prone to crashes in
+                 case of parser bugs for invalid source files, and it needs
+                 more memory, but it is faster for thousands of files, since
+                 it avoids the interprocess communication overhead.
+
 Environment Variables:
   VDIFF_CMD      A custom tool and options that will be used for viewing the
                  differences between the original and the temporarily formatted


### PR DESCRIPTION
Before:
![image](https://github.com/vlang/v/assets/26967/fefc6f37-f300-4c7a-b823-54f996128804)

After:
![image](https://github.com/vlang/v/assets/26967/9e032ad1-93dc-4e9d-b6b9-b871bd57bb91)
