### PR TITLE
tools: improve environment detection when creating symlinks

### DIFF
--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Install C2V
         run: |
           .github/workflows/retry.sh v install --git https://github.com/vlang/c2v
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Install C2V
         run: |
           .github/workflows/retry.sh v install --git https://github.com/vlang/c2v

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -16,35 +16,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-sudo:
+  symlink:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13]
-      fail-fast: false
-    env:
-      V_CI_SYMLINK: 1 # Use regular system symlinking.
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build V
-        run: make -j4
-      - name: Symlink
-        run: sudo ./v symlink
-      - name: Check if V is usable
-        run: |
-          pwd
-          v version
-          cd ~
-          pwd
-          v version
-          echo 'println(123)' > hi.v
-          v run hi.v
-
-  test-githubci:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-13]
       fail-fast: false
+    env:
+      V_CI_SYMLINK: 1 # Use regular system symlinking.
     steps:
       - uses: actions/checkout@v4
       - name: Build V
@@ -53,7 +55,7 @@ jobs:
         if: runner.os == 'Windows'
         run: ./make.bat
       - name: Symlink
-        run: ./v symlink -githubci
+        run: ./v symlink
       - name: Check if V is usable
         run: |
           pwd

--- a/.github/workflows/native_backend_ci.yml
+++ b/.github/workflows/native_backend_ci.yml
@@ -61,10 +61,10 @@ jobs:
         run: .github/workflows/retry.sh sudo apt -qq install binutils
       - name: Build V
         if: runner.os != 'Windows'
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Build V (Windows)
         if: runner.os == 'Windows'
-        run: ./make.bat && ./v symlink -githubci
+        run: ./make.bat && ./v symlink
       - name: Run the native backend tests serially with more details
         run: |
           v vlib/v/gen/native/macho_test.v

--- a/.github/workflows/symlink_ci.yml
+++ b/.github/workflows/symlink_ci.yml
@@ -1,15 +1,15 @@
-name: V Symlink Works
+name: Symlink CI
 
 on:
   workflow_dispatch:
   push:
     paths:
       - 'cmd/tools/vsymlink/**.v'
-      - '.github/workflows/check_symlink_works.yml'
+      - '.github/workflows/symlink_ci.yml'
   pull_request:
     paths:
       - 'cmd/tools/vsymlink/**.v'
-      - '.github/workflows/check_symlink_works.yml'
+      - '.github/workflows/symlink_ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name == 'master' && github.sha || github.ref_name }}

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -30,7 +30,7 @@ jobs:
           .github/workflows/retry.sh sudo apt install build-essential meson -y
 
       - name: Build V
-        run: make && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Clone current Vinix
         run: .github/workflows/retry.sh git clone https://github.com/vlang/vinix.git

--- a/.github/workflows/vup_works.yml
+++ b/.github/workflows/vup_works.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build v
-        run: make && ./v symlink -githubci && ./v version
+        run: make -j4 && ./v symlink && ./v version
 
       - name: Download latest release ZIP
         run: wget https://github.com/vlang/v/releases/latest/download/${{ matrix.zip }}

--- a/cmd/tools/vsymlink/vsymlink.v
+++ b/cmd/tools/vsymlink/vsymlink.v
@@ -4,34 +4,9 @@ const vexe = os.real_path(os.getenv_opt('VEXE') or { @VEXE })
 
 fn main() {
 	at_exit(|| os.rmdir_all(os.vtmp_dir()) or {}) or {}
-
-	if os.args.len > 3 {
-		print('usage: v symlink [OPTIONS]')
+	if os.args.len > 2 {
+		print('usage: v symlink')
 		exit(1)
 	}
-
-	if '-githubci' in os.args {
-		setup_symlink_github()
-	} else {
-		setup_symlink()
-	}
-}
-
-fn setup_symlink_github() {
-	// We append V's install location (which should
-	// be the current directory) to the PATH environment variable.
-
-	// Resources:
-	// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
-	// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-	mut content := os.read_file(os.getenv('GITHUB_PATH')) or {
-		eprintln('The `GITHUB_PATH` env variable is not defined.')
-		eprintln('    This command: `v symlink -githubci` is intended to be used within GithubActions .yml files.')
-		eprintln('    It also needs to be run *as is*, *** without `sudo` ***, otherwise it will not work.')
-		eprintln('    For local usage, outside CIs, on !windows, prefer `sudo ./v symlink` .')
-		eprintln('    On windows, use `.\\v.exe symlink` instead.')
-		exit(1)
-	}
-	content += '\n${os.getwd()}\n'
-	os.write_file(os.getenv('GITHUB_PATH'), content) or { panic('Failed to write to GITHUB_PATH.') }
+	setup_symlink()
 }

--- a/cmd/tools/vsymlink/vsymlink.v
+++ b/cmd/tools/vsymlink/vsymlink.v
@@ -5,8 +5,14 @@ const vexe = os.real_path(os.getenv_opt('VEXE') or { @VEXE })
 fn main() {
 	at_exit(|| os.rmdir_all(os.vtmp_dir()) or {}) or {}
 	if os.args.len > 2 {
-		print('usage: v symlink')
-		exit(1)
+		if '-githubci' in os.args {
+			// TODO: remove warning for deprecation of `-githubci` flag and
+			// only use the block below after 2024-09-31.
+			println('::warning::Use `v symlink` instead of `v symlink -githubci`')
+		} else {
+			println('usage: v symlink')
+			exit(1)
+		}
 	}
 	setup_symlink()
 }

--- a/cmd/tools/vsymlink/vsymlink_windows.c.v
+++ b/cmd/tools/vsymlink/vsymlink_windows.c.v
@@ -84,8 +84,7 @@ fn setup_symlink() {
 	}
 	C.RegCloseKey(reg_sys_env_handle)
 	if os.getenv('GITHUB_JOB') != '' {
-		// Append V's install location (should be the current directory) to GITHUBs PATH environment variable.
-
+		// Append V's install location to GITHUBs PATH environment variable.
 		// Resources:
 		// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
 		// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

--- a/cmd/tools/vsymlink/vsymlink_windows.c.v
+++ b/cmd/tools/vsymlink/vsymlink_windows.c.v
@@ -83,6 +83,21 @@ fn setup_symlink() {
 		warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
 	}
 	C.RegCloseKey(reg_sys_env_handle)
+	if os.getenv('GITHUB_JOB') != '' {
+		// Append V's install location (should be the current directory) to GITHUBs PATH environment variable.
+
+		// Resources:
+		// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
+		// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+		mut content := os.read_file(os.getenv('GITHUB_PATH')) or {
+			eprintln('The `GITHUB_PATH` env variable is not defined.')
+			exit(1)
+		}
+		content += '\n${new_sys_env_path}\n'
+		os.write_file(os.getenv('GITHUB_PATH'), content) or {
+			panic('Failed to write to GITHUB_PATH.')
+		}
+	}
 	println('Done.')
 	println('Note: Restart your shell/IDE to load the new %PATH%.')
 	println('After restarting your shell/IDE, give `v version` a try in another directory!')


### PR DESCRIPTION
The PR tries to bring goodies from all worlds for the `symlink` tool. 

- Simplifies maintenance.
- Makes the tool safer against regressions.
- Easier general usage for `v symlink` in CI runners (the `-githubci` flag might not be obvious, when using V in an external workflow).
- Relieves / frees runners in our current CI (as separate tests are no longer required).

**The diff may seem complicated but the change is actually simple:**

- `-githubci` flag becomes obsolete.
  1. It was already required for Windows only. Therefore handling of symlink_github was moved to the windows code.
  2. An improvement made alongside is that instead of adding only the current directory to the GITHUB_PATH, `new_sys_env_path` is added, which is also used on regular systems. **This brings the Windows test closer to a regular scenario outside CI.**
  3. This was automated when it is used in a Windows CI runner.

- To not introduce a breaking change, a warning message was added when the `-githubci` flag is used in workflows.

  ![Screenshot_20240507_142113](https://github.com/vlang/v/assets/34311583/0c2e2a16-6e04-4853-868a-ae5e65c788c6)
  Sample run with warning: https://github.com/ttytm/v/actions/runs/8985093496