### PR TITLE
tools: make `./v symlink` work platform independent in CI

### DIFF
--- a/.github/workflows/check_symlink_works.yml
+++ b/.github/workflows/check_symlink_works.yml
@@ -16,18 +16,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-sudo:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-20.04, macos-13, windows-2019]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - name: Build V
-        run: make -j4
-      - name: Symlink
-        run: sudo ./v symlink
+      - name: Build and symlink (Windows)
+        if: runner.os == 'Windows'
+        run: ./make.bat && ./v symlink
+      - name: Build and symlink
+        if: runner.os != 'Windows'
+        run: make -j4 && sudo ./v symlink
       - name: Check if V is usable
         run: |
           pwd

--- a/cmd/tools/vsymlink/vsymlink.v
+++ b/cmd/tools/vsymlink/vsymlink.v
@@ -4,34 +4,9 @@ const vexe = os.real_path(os.getenv_opt('VEXE') or { @VEXE })
 
 fn main() {
 	at_exit(|| os.rmdir_all(os.vtmp_dir()) or {}) or {}
-
 	if os.args.len > 3 {
-		print('usage: v symlink [OPTIONS]')
+		println('usage: v symlink')
 		exit(1)
 	}
-
-	if '-githubci' in os.args {
-		setup_symlink_github()
-	} else {
-		setup_symlink()
-	}
-}
-
-fn setup_symlink_github() {
-	// We append V's install location (which should
-	// be the current directory) to the PATH environment variable.
-
-	// Resources:
-	// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
-	// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-	mut content := os.read_file(os.getenv('GITHUB_PATH')) or {
-		eprintln('The `GITHUB_PATH` env variable is not defined.')
-		eprintln('    This command: `v symlink -githubci` is intended to be used within GithubActions .yml files.')
-		eprintln('    It also needs to be run *as is*, *** without `sudo` ***, otherwise it will not work.')
-		eprintln('    For local usage, outside CIs, on !windows, prefer `sudo ./v symlink` .')
-		eprintln('    On windows, use `.\\v.exe symlink` instead.')
-		exit(1)
-	}
-	content += '\n${os.getwd()}\n'
-	os.write_file(os.getenv('GITHUB_PATH'), content) or { panic('Failed to write to GITHUB_PATH.') }
+	setup_symlink()
 }

--- a/cmd/tools/vsymlink/vsymlink.v
+++ b/cmd/tools/vsymlink/vsymlink.v
@@ -4,9 +4,34 @@ const vexe = os.real_path(os.getenv_opt('VEXE') or { @VEXE })
 
 fn main() {
 	at_exit(|| os.rmdir_all(os.vtmp_dir()) or {}) or {}
+
 	if os.args.len > 3 {
-		println('usage: v symlink')
+		print('usage: v symlink [OPTIONS]')
 		exit(1)
 	}
-	setup_symlink()
+
+	if '-githubci' in os.args {
+		setup_symlink_github()
+	} else {
+		setup_symlink()
+	}
+}
+
+fn setup_symlink_github() {
+	// We append V's install location (which should
+	// be the current directory) to the PATH environment variable.
+
+	// Resources:
+	// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
+	// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+	mut content := os.read_file(os.getenv('GITHUB_PATH')) or {
+		eprintln('The `GITHUB_PATH` env variable is not defined.')
+		eprintln('    This command: `v symlink -githubci` is intended to be used within GithubActions .yml files.')
+		eprintln('    It also needs to be run *as is*, *** without `sudo` ***, otherwise it will not work.')
+		eprintln('    For local usage, outside CIs, on !windows, prefer `sudo ./v symlink` .')
+		eprintln('    On windows, use `.\\v.exe symlink` instead.')
+		exit(1)
+	}
+	content += '\n${os.getwd()}\n'
+	os.write_file(os.getenv('GITHUB_PATH'), content) or { panic('Failed to write to GITHUB_PATH.') }
 }

--- a/cmd/tools/vsymlink/vsymlink_windows.c.v
+++ b/cmd/tools/vsymlink/vsymlink_windows.c.v
@@ -83,6 +83,20 @@ fn setup_symlink() {
 		warn_and_exit('You might need to run this again to have the `v` command in your %PATH%')
 	}
 	C.RegCloseKey(reg_sys_env_handle)
+	if os.getenv('GITHUB_JOB') != '' {
+		// Append V's install location to GITHUBs PATH environment variable.
+		// Resources:
+		// 1. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
+		// 2. https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+		mut content := os.read_file(os.getenv('GITHUB_PATH')) or {
+			eprintln('The `GITHUB_PATH` env variable is not defined.')
+			exit(1)
+		}
+		content += '\n${new_sys_env_path}\n'
+		os.write_file(os.getenv('GITHUB_PATH'), content) or {
+			panic('Failed to write to GITHUB_PATH.')
+		}
+	}
 	println('Done.')
 	println('Note: Restart your shell/IDE to load the new %PATH%.')
 	println('After restarting your shell/IDE, give `v version` a try in another directory!')


### PR DESCRIPTION
Splits up changes to make `./v symlink` work platform independent in CI.

The PR:
- Moves handling of github symlink to the `vsymlink_windows.c.v` code. On unix-like systems regular symlinking will be used, whether or not `-githubci` was passed.
- An improvement made alongside is that instead of adding `os.getwd()` to the GITHUB_PATH, `new_sys_env_path` is used. It is the path used on a regular windows systems -> Brings tests in Windows CI closer to a regular scenario, makes them more reliable.
- Now `./v symlink` should already work platform independent. The `-githubci` flag is not required anymore. Cases with `sudo` and the `-githubci` flag are still covered by the current, unchanged CI jobs. They should continue to work and there are no plans in changing this inside the PRs that are implementing this enhancement. Only adding an info that the flag is not required anymore.