### PR TITLE
ci: use `v symlink` without `-githubci` for regular symlinking

### DIFF
--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Install C2V
         run: |
           v retry -- v install --git https://github.com/vlang/c2v
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Install C2V
         run: |
           v retry -- v install --git https://github.com/vlang/c2v

--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 10
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Install dependencies
         run: |
@@ -61,7 +61,7 @@ jobs:
         with:
           fetch-depth: 10
       - name: Build v
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build local v
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: All code is formatted
         run: v test-cleancode
       - name: Install dependencies for examples and tools
@@ -223,7 +223,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: All code is formatted
         run: v test-cleancode
       - name: Install dependencies for examples and tools
@@ -326,7 +326,7 @@ jobs:
   #     V_CI_MUSL: 1
   #   steps:
   #   - name: Build v
-  #     run: echo $VFLAGS && make -j4 && ./v symlink -githubci
+  #     run: echo $VFLAGS && make -j4 && ./v symlink
   #   - uses: actions/checkout@v4
   #   - name: Install dependencies for examples and tools
   #     run: v retry -- sudo apt install --quiet -y musl musl-tools libssl-dev sqlite3 libsqlite3-dev valgrind

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build v
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Build v with -prealloc
         run: |
           v -d debug_malloc -d debug_realloc -o v cmd/v

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci 
+        run: make -j4 && ./v symlink
       - name: Build V with -cstrict
         run: v -cg -cstrict -o v cmd/v
       - name: All code is formatted

--- a/.github/workflows/native_backend_ci.yml
+++ b/.github/workflows/native_backend_ci.yml
@@ -58,10 +58,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build V
         if: runner.os != 'Windows'
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Build V (Windows)
         if: runner.os == 'Windows'
-        run: ./make.bat && ./v symlink -githubci
+        run: ./make.bat && ./v symlink
       - name: Install linker
         if: runner.os == 'Linux'
         run: v retry -- sudo apt -qq install binutils

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Environment info
         run: echo $VFLAGS $GITHUB_SHA $GITHUB_REF
       - name: Build local v
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: v test-cleancode
         run: ./v test-cleancode
       - name: v test-fmt
@@ -70,7 +70,7 @@ jobs:
       - name: Environment info
         run: echo $VFLAGS $GITHUB_SHA $GITHUB_REF
       - name: Build local v
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Clone & Build previous vmaster/v
         run: |
           ./v retry -- git clone --depth=1 https://github.com/vlang/v vmaster/
@@ -94,7 +94,7 @@ jobs:
         with:
           fetch-depth: 10
       - name: Build v
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Install dependencies
         run: |
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build local v
         run: |
-          make -j4 && ./v symlink -githubci
+          make -j4 && ./v symlink
           ./v -g -d trace_parse_stmt cmd/tools/vtest-parser.v
       - name: Install zzuf
         run: ./v retry -- sudo apt install -qq zzuf

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Install dependencies
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Install dependencies
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Install dependencies
@@ -187,7 +187,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Install dependencies
@@ -217,7 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
         run: ./v test-cleancode
       - name: Install dependencies

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
       - name: Install dependencies
         run: |
           v retry -- sudo apt update

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Install vab
         run: |
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Install vab
         run: |

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build V
-        run: make -j4 && ./v symlink -githubci
+        run: make -j4 && ./v symlink
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/vup_works.yml
+++ b/.github/workflows/vup_works.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build v
-        run: make && ./v symlink -githubci && ./v version
+        run: make && ./v symlink && ./v version
 
       - name: Download latest release ZIP
         run: wget https://github.com/vlang/v/releases/latest/download/${{ matrix.zip }}

--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo $VFLAGS
           sudo ln -s $PWD/thirdparty/tcc/tcc.exe /usr/local/bin/tcc ## TODO: remove
-          make -j4 && ./v symlink -githubci
+          make -j4 && ./v symlink
           ./v -g -o v cmd/v
       - name: Install dependencies
         run: v retry -- sudo apt install --quiet -y libssl-dev

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           gcc --version
           .\make.bat -gcc
-          .\v.exe symlink -githubci
+          .\v.exe symlink
       - name: All code is formatted
         run: v test-cleancode
       - name: Test new v.c
@@ -86,7 +86,7 @@ jobs:
           echo %VFLAGS%
           echo $VFLAGS
           .\make.bat -msvc
-          .\v.exe symlink -githubci
+          .\v.exe symlink
       - name: Build V with WX
         run: v -cflags /WX self
       - name: All code is formatted
@@ -133,7 +133,7 @@ jobs:
       - name: Build with make.bat -tcc
         run: |
           .\make.bat -tcc
-          .\v.exe symlink -githubci
+          .\v.exe symlink
       - name: All code is formatted
         run: v test-cleancode
       - name: Test new v.c


### PR DESCRIPTION
Removes the flag for where `v symlink` is used in a "regular" way. Keeps it in tests that should test the flag.