### PR TITLE
v.util: remove fast path in `diff.compare_text`

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -80,10 +80,6 @@ pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
 
 // compare_text returns a string displaying the differences between two strings.
 pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
-	opts.find_tool()!
-	if text1 == text2 {
-		return ''
-	}
 	ctime := time.sys_mono_now()
 	tmp_dir := os.join_path_single(os.vtmp_dir(), ctime.str())
 	os.mkdir(tmp_dir)!


### PR DESCRIPTION
The equality check of the strings that should be compared is done in most cases before the function is called in the V code base. It can be expected that it will be the same for external projects if they use the module.

Due to this, what was thought as fast-path can become a slow-down in cases where the compiler is not able to optimize the double check. Therefore it is removed and the function merely cares about returning the result of the comparison result.
