### PR TITLE
vpm: init_settings: mkdir_all before set_output_path

### DIFF
--- a/cmd/tools/vpm/settings.v
+++ b/cmd/tools/vpm/settings.v
@@ -36,6 +36,7 @@ fn init_settings() VpmSettings {
 	if dbg_env != '0' {
 		logger.set_level(.debug)
 		if dbg_env == '' {
+			os.mkdir_all(os.join_path(vmodules_path, 'cache'), mode: 0o700) or { panic(err) }
 			logger.set_output_path(os.join_path(vmodules_path, 'cache', 'vpm.log'))
 		}
 	}


### PR DESCRIPTION
`os.open_append` called by `logger.set_output_path` calls `C._wfopen(wpath, mode.to_wide())` with `mode := 'ab'`. When the folder `$VMODULES\cache` does not exist, `C._wfopen(wpath, mode.to_wide())` returns NULL and causes an error.

This PR aims to avoid 'V panic: error while opening log file `$VMODULES\cache\vpm.log` for appending' error.

Before modification:
```
# echo $VMODULES
/d/gym/test/mingw-w64-packages/mingw-w64-v/vmodules/mingw-w64-i686-v-weekly.2024.19-1

# ll $VMODULES
ls: cannot access '/d/gym/test/mingw-w64-packages/mingw-w64-v/vmodules/mingw-w64-i686-v-weekly.2024.19-1': No such file or directory

# ./v run cmd/tools/vpm/install_test.v
V panic: error while opening log file D:\gym\test\mingw-w64-packages\mingw-w64-v\vmodules\mingw-w64-i686-v-weekly.2024.19-1\cache\vpm.log for appending
v hash: d6d0f9b
print_backtrace_skipping_top_frames is not implemented

```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
