### PR TITLE
v up Info output.

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -91,7 +91,7 @@ fn (app App) recompile_v() bool {
 	self_result := os.execute(vself)
 	if self_result.exit_code == 0 {
 		println(self_result.output.trim_space())
-		println('> done recompiling.')
+		println('> Done recompiling.')
 		return true
 	} else {
 		println('> `${vself}` failed, running `make`...')
@@ -101,10 +101,10 @@ fn (app App) recompile_v() bool {
 }
 
 fn (app App) recompile_vup() bool {
-	eprintln('> recompiling vup.v ...')
+	eprintln('> Recompiling vup.v ...')
 	vup_result := os.execute('${os.quoted_path(app.vexe)} -g cmd/tools/vup.v')
 	if vup_result.exit_code != 0 {
-		eprintln('> failed recompiling vup.v .')
+		eprintln('> Failed recompiling vup.v .')
 		eprintln(vup_result.output)
 		return false
 	}


### PR DESCRIPTION
When using v up the following is displayed
```zsh
v up
Updating V...
> git_command: git pull https://github.com/vlang/v master
V self compiling (-cc tcc -o v2)...
V built successfully as executable "v".
> done recompiling.
> recompiling vup.v ...
Current V version: V 0.4.5 6cc096a, timestamp: 2024-05-07 20:38:32 +0300
```
With this, I've capitalised `>Done recompiling`and `recompiling vup.v`.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
