### PR TITLE
regex: a few other typos and inconsistencies found

### DIFF
--- a/vlib/regex/README.md
+++ b/vlib/regex/README.md
@@ -134,7 +134,7 @@ The dot is a particular meta-char, that matches "any char".
 It is simpler to explain it with an example:
 
 Suppose you have `abccc ddeef` as a source string, that you want to parse
-with a regex. The following table show the query strings and the result of
+with a regex. The following table shows the query strings and the result of
 parsing source string.
 
 | query string | result      |
@@ -299,8 +299,8 @@ The `.group_csave` array will be filled then, following this logic:
 
 `re.group_csave[0]` - number of total saved records
 `re.group_csave[1+n*3]` - id of the saved group
-`re.group_csave[1+n*3]` - start index in the source string of the saved group
-`re.group_csave[1+n*3]` - end index in the source string of the saved group
+`re.group_csave[2+n*3]` - start index in the source string of the saved group
+`re.group_csave[3+n*3]` - end index in the source string of the saved group
 
 The regex will save groups, until it finishes, or finds that the array has no
 more space. If the space ends, no error is raised, and further records will
@@ -506,8 +506,8 @@ re.flag = regex.f_bin
 
 ### Initializer
 
-These functions are helper that create the `RE` struct,
-a `RE` struct can be created manually if you needed.
+These functions are helpers that create the `RE` struct.
+A `RE` struct can be created manually if needed.
 
 #### **Simplified initializer**
 
@@ -519,7 +519,7 @@ pub fn regex_opt(in_query string) ?RE
 #### **Base initializer**
 
 ```v ignore
-// new_regex create a REgex of small size, usually sufficient for ordinary use
+// new create a RE of small size, usually sufficient for ordinary use
 pub fn new() RE
 ```
 
@@ -528,8 +528,8 @@ pub fn new() RE
 After an initializer is used, the regex expression must be compiled with:
 
 ```v ignore
-// compile compiles the REgex returning an error if the compilation fails
-pub fn (mut re RE) compile_opt(in_txt string) ?
+// compile_opt compile RE pattern string,  returning an error if the compilation fails
+pub fn (mut re RE) compile_opt(pattern string) !
 ```
 
 ### Matching Functions
@@ -557,7 +557,7 @@ pub fn (mut re RE) find(in_txt string) (int, int)
 // the matches are [3,4] and [6,8]
 pub fn (mut re RE) find_all(in_txt string) []int
 
-// find_all find all the "non overlapping" occurrences of the matching pattern
+// find_all_str find all the "non overlapping" occurrences of the match pattern
 // return a list of strings
 // the result is like ['first match','secon match']
 pub fn (mut re RE) find_all_str(in_txt string) []string
@@ -567,7 +567,7 @@ pub fn (mut re RE) find_all_str(in_txt string) []string
 
 ```v ignore
 // replace return a string where the matches are replaced with the repl_str string,
-// this function support groups in the replace string
+// this function supports groups in the replace string
 pub fn (mut re RE) replace(in_txt string, repl string) string
 ```
 

--- a/vlib/regex/regex_opt.v
+++ b/vlib/regex/regex_opt.v
@@ -17,7 +17,7 @@ pub fn (mut re RE) compile_opt(pattern string) ! {
 	}
 }
 
-// new_regex create a RE of small size, usually sufficient for ordinary use
+// new create a RE of small size, usually sufficient for ordinary use
 pub fn new() RE {
 	// init regex
 	mut re := RE{}

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -472,7 +472,7 @@ fn (re RE) parsed_replace_string(in_txt string, repl string) string {
 }
 
 // replace return a string where the matches are replaced with the repl_str string,
-// this function support use groups in the replace string
+// this function supports groups in the replace string
 pub fn (mut re RE) replace(in_txt string, repl_str string) string {
 	mut i := 0
 	mut res := strings.new_builder(in_txt.len)


### PR DESCRIPTION
Saw some additional typos and minor inconsistencies in regex.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
