### PR TITLE
cli: fix default flags when their command equivalents are disabled

### DIFF
--- a/vlib/cli/cli_test.v
+++ b/vlib/cli/cli_test.v
@@ -19,12 +19,8 @@ fn test_cli_programs() {
 			has_err = true
 			continue
 		}
-		mut expected_out := os.read_file(out_path)!
-		mut test_out := os.execute('${vexe} run ${test}').output
-		$if windows {
-			expected_out = expected_out.replace('\r\n', '\n')
-			test_out = test_out.replace('\r\n', '\n')
-		}
+		expected_out := os.read_file(out_path)!.replace('\r\n', '\n')
+		test_out := os.execute('${vexe} run ${test}').output.replace('\r\n', '\n')
 		diff_ := diff.compare_text(expected_out, test_out)!
 		if diff_ != '' {
 			println(term.red('FAIL'))

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -341,8 +341,7 @@ fn (cmd Command) check_version_flag() {
 	if cmd.defaults.parsed.version.flag && cmd.version != '' && cmd.flags.contains('version') {
 		version_flag := cmd.flags.get_bool('version') or { return } // ignore error and handle command normally
 		if version_flag {
-			version_cmd := cmd.commands.get('version') or { return } // ignore error and handle command normally
-			version_cmd.execute(version_cmd) or { panic(err) }
+			print_version_for_command(cmd) or { panic(err) }
 			exit(0)
 		}
 	}

--- a/vlib/cli/testdata/default_command_no_flag_err.out
+++ b/vlib/cli/testdata/default_command_no_flag_err.out
@@ -1,0 +1,1 @@
+Command `foo` has no flag `-man`

--- a/vlib/cli/testdata/default_command_no_flag_err.vv
+++ b/vlib/cli/testdata/default_command_no_flag_err.vv
@@ -1,0 +1,11 @@
+import cli { Command, CommandFlag }
+
+fn main() {
+	mut cmd := Command{
+		name: 'foo'
+		defaults: struct {
+			man: CommandFlag{true, false}
+		}
+	}
+	cmd.parse(['foo', '-man'])
+}

--- a/vlib/cli/testdata/default_help_flag_no_command.out
+++ b/vlib/cli/testdata/default_help_flag_no_command.out
@@ -1,0 +1,8 @@
+Usage: foo [flags] [commands]
+
+Flags:
+  -help               Prints help information.
+  -man                Prints the auto-generated manpage.
+
+Commands:
+  man                 Prints the auto-generated manpage.

--- a/vlib/cli/testdata/default_help_flag_no_command.vv
+++ b/vlib/cli/testdata/default_help_flag_no_command.vv
@@ -1,0 +1,11 @@
+import cli { Command, CommandFlag }
+
+fn main() {
+	mut cmd := Command{
+		name: 'foo'
+		defaults: struct {
+			help: CommandFlag{false, true}
+		}
+	}
+	cmd.parse(['foo', '-help'])
+}

--- a/vlib/cli/testdata/default_version_flag_no_command.out
+++ b/vlib/cli/testdata/default_version_flag_no_command.out
@@ -1,0 +1,1 @@
+foo version 0.1.0

--- a/vlib/cli/testdata/default_version_flag_no_command.vv
+++ b/vlib/cli/testdata/default_version_flag_no_command.vv
@@ -1,0 +1,13 @@
+import cli { Command, CommandFlag }
+
+fn main() {
+	mut cmd := Command{
+		name: 'foo'
+		version: '0.1.0'
+		posix_mode: true
+		defaults: struct {
+			version: CommandFlag{false, true}
+		}
+	}
+	cmd.parse(['foo', '--version'])
+}

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -19,29 +19,22 @@ fn version_cmd() Command {
 }
 
 fn print_version_for_command(cmd Command) ! {
-	version_cmd := if cmd.args.len > 0 {
-		mut cmd_ := &Command{}
-		for arg in cmd.args {
-			mut found := false
-			for sub_cmd in cmd.commands {
-				if sub_cmd.name == arg {
-					cmd_ = unsafe { &sub_cmd }
-					found = true
-					break
-				}
-			}
-			if !found {
-				args := cmd.args.join(' ')
-				println('Invalid command: ${args}')
+	if cmd.args.len > 0 {
+		for sub_cmd in cmd.commands {
+			if sub_cmd.name == cmd.args[0] {
+				version_cmd := unsafe { &sub_cmd }
+				print(version_cmd.version())
 				return
 			}
 		}
-		cmd_
+		println('Invalid command: ${cmd.args.join(' ')}')
 	} else if cmd.parent != unsafe { nil } {
-		cmd.parent
+		println(cmd.parent.version())
 	} else {
-		&cmd
+		println(cmd.version())
 	}
-	version := '${version_cmd.name} version ${version_cmd.version}'
-	println(version)
+}
+
+pub fn (cmd Command) version() string {
+	return '${cmd.name} version ${cmd.version}'
 }

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -14,12 +14,34 @@ fn version_cmd() Command {
 	return Command{
 		name: 'version'
 		description: 'Prints version information.'
-		execute: version_func
+		execute: print_version_for_command
 	}
 }
 
-fn version_func(version_cmd Command) ! {
-	cmd := version_cmd.parent
-	version := '${cmd.name} version ${cmd.version}'
+fn print_version_for_command(cmd Command) ! {
+	version_cmd := if cmd.args.len > 0 {
+		mut cmd_ := &Command{}
+		for arg in cmd.args {
+			mut found := false
+			for sub_cmd in cmd.commands {
+				if sub_cmd.name == arg {
+					cmd_ = unsafe { &sub_cmd }
+					found = true
+					break
+				}
+			}
+			if !found {
+				args := cmd.args.join(' ')
+				println('Invalid command: ${args}')
+				return
+			}
+		}
+		cmd_
+	} else if cmd.parent != unsafe { nil } {
+		cmd.parent
+	} else {
+		&cmd
+	}
+	version := '${version_cmd.name} version ${version_cmd.version}'
 	println(version)
 }

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -35,6 +35,7 @@ fn print_version_for_command(cmd Command) ! {
 	}
 }
 
+// version returns a generated version `string` for the `Command`.
 pub fn (cmd Command) version() string {
 	return '${cmd.name} version ${cmd.version}'
 }


### PR DESCRIPTION
Fixes default flags not working as expected when their commands are disabled.

Example:
```v
// foo.v
import cli { Command, CommandFlag }
import os

fn main() {
	mut cmd := Command{
		name: 'foo'
		version: '0.1.0'
		posix_mode: true
		defaults: struct {
			version: CommandFlag{false, true}
			help: CommandFlag{false, true}
		}
	}
	cmd.parse(os.args)
}
```
Current:
```sh
❯ v run foo.v --version
# no output
```

Updated:
```sh
❯ v run foo.v --version
foo version 0.1.0
```
