### PR TITLE
tools, ci: print info to use v symlink instead of `v symlink -githubci`

### DIFF
--- a/.github/workflows/symlink_ci.yml
+++ b/.github/workflows/symlink_ci.yml
@@ -49,8 +49,9 @@ jobs:
           rm $(which v)
           v --version && exit 1 || exit 0
       - name: Symlink (-githubci)
+        run: ./v symlink -githubci
+      - name: Test after symlink with -githubci (in a separate script)
         run: |
-          ./v symlink -githubci
           cd /tmp/ && v version
           cd ~ && v version
           echo 'println(123)' > hi.v

--- a/.github/workflows/symlink_ci.yml
+++ b/.github/workflows/symlink_ci.yml
@@ -50,7 +50,7 @@ jobs:
           v --version && exit 1 || exit 0
       - name: Symlink (-githubci)
         run: |
-          ./v symlink --githubci
+          ./v symlink -githubci
           cd /tmp/ && v version
           cd ~ && v version
           echo 'println(123)' > hi.v

--- a/cmd/tools/vsymlink/vsymlink.v
+++ b/cmd/tools/vsymlink/vsymlink.v
@@ -4,17 +4,20 @@ const vexe = os.real_path(os.getenv_opt('VEXE') or { @VEXE })
 
 fn main() {
 	at_exit(|| os.rmdir_all(os.vtmp_dir()) or {}) or {}
-
-	if os.args.len > 3 {
-		print('usage: v symlink [OPTIONS]')
-		exit(1)
+	if os.args.len > 2 {
+		if '-githubci' in os.args {
+			// TODO: [AFTER 2024-09-31] remove `-githubci` flag and function and only print usage and exit(1) .
+			if os.getenv('GITHUB_JOB') != '' {
+				println('::warning::Use `v symlink` instead of `v symlink -githubci`')
+			}
+			setup_symlink_github()
+			return
+		} else {
+			println('usage: v symlink')
+			exit(1)
+		}
 	}
-
-	if '-githubci' in os.args {
-		setup_symlink_github()
-	} else {
-		setup_symlink()
-	}
+	setup_symlink()
 }
 
 fn setup_symlink_github() {


### PR DESCRIPTION
This one contains an interesting coincidence and revelation. 

The last update used `./v symlink --githubci` (double-dashed) instead of `./v symlink -githubci` to cover extended cases for the flag. However, the double-dashed flag results in the default symlink being used instead of the GITHUB_PATH-symlink that is based on the current directory. Now, using the symlink with the single dash flag `-githubci` fails to pass the extended test cases.

This shows that using the flag actually results in worse functionality. The solution would be to already use `setup_symlink` instead of `setup_symlink_github` (even when the flag is passed), as it fixes an issue.

Based on the recent heated(while still constructive) discussion, the coincidence might look like an evil plan, setting this revelation up, but it really was just a tiny mistake that happened in the last PR.