### PR TITLE
vdoc/vdoc_file_test.v: fix test_out_path

### DIFF
--- a/cmd/tools/vdoc/vdoc_file_test.v
+++ b/cmd/tools/vdoc/vdoc_file_test.v
@@ -98,11 +98,12 @@ fn test_out_path() {
 		os.rmdir_all(test_path) or {}
 	}
 	os.chdir(test_path)!
-	os.cp_all(os.join_path(vroot, 'vlib', small_pure_v_vlib_module), test_mod_path, true) or {}
+	mod_path := os.join_path(vroot, 'vlib', small_pure_v_vlib_module)
+	os.cp_all(mod_path, test_mod_path, true) or {}
 
 	// Relative input with default output path.
 	os.execute_opt('${vexe} doc -f html -m ${small_pure_v_vlib_module}')!
-	output_path := os.join_path(test_mod_path, '_docs', '${small_pure_v_vlib_module}.html')
+	output_path := os.join_path(mod_path, '_docs', '${small_pure_v_vlib_module}.html')
 	assert os.exists(output_path), output_path
 
 	// Custom out path (no `_docs` subdir).


### PR DESCRIPTION
It's not clear why the error doesn't appear in ci, but the local test keeps appearing

```
# ./v run cmd/tools/vdoc/tests/vdoc_file_test.v
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/basic/basic.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/comments/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/multiline/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/newlines/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/output_formats/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/readme_in_project_root/src/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/run_examples_bad/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/run_examples_good/main.v OK
D:/gym/test/mingw-w64-packages/mingw-w64-v/src/v-weekly.2024.19/cmd/tools/vdoc/tests/testdata/unsorted/main.v OK
cmd/tools/vdoc/tests/vdoc_file_test.v:105: ✗ fn test_out_path
    assert os.exists(output_path), output_path
        Message: D:\gym\test\mingw-w64-packages\mingw-w64-v\tmp\mingw-w64-i686-v-weekly.2024.19-1\v_0\vdoc_test_01HXE2FCMGCA3H48WQYMRGXX6H\bitfield\_docs\bitfield.html

```
In fact the generated file exists in the directory `os.join_path(vroot, 'vlib', small_pure_v_vlib_module)`, not `os.join_path(test_path, small_pure_v_vlib_module)`.

However, due to `os.cp_all(mod_path, test_mod_path, true) or {}`, the generated file will appear under `os.join_path(test_path, small_pure_v_vlib_module)` during the second test.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
