### PR TITLE
picoev: handle `EAGAIN` or `EWOULDBLOCK` quietly

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -212,6 +212,10 @@ fn accept_callback(listen_fd int, events int, cb_arg voidptr) {
 	accepted_fd := accept(listen_fd)
 
 	if accepted_fd == -1 {
+		if fatal_socket_error(accepted_fd) == false {
+			return
+		}
+
 		eprintln('Error during accept')
 		return
 	}
@@ -298,11 +302,11 @@ fn raw_callback(fd int, events int, context voidptr) {
 				pv.close_conn(fd)
 				return
 			} else if r == -1 {
-				eprintln('Error during req_read')
-
 				if fatal_socket_error(fd) == false {
 					return
 				}
+
+				eprintln('Error during req_read')
 
 				// fatal error
 				pv.close_conn(fd)


### PR DESCRIPTION
C [`recv`](https://linux.die.net/man/2/recv) and [`accept`](https://linux.die.net/man/2/accept) calls can reply with `EAGAIN` or `EWOULDBLOCK` on a `-1` return value, which is to be expected for the asynchronous picoev event loop server.

Fix #21316 by continuing silently in these cases.

As a runtime asynchronous bug, the test is a stressful benchmark. In one terminal:

```
$ v run pico.v
Starting webserver on http://localhost:8089/ ...
```

In another (on a 24-core machine):

```
$ siege --concurrent=22 --reps=5000 http://localhost:8089
...
Transactions:                 110000 hits
Availability:                 100.00 %
Elapsed time:                   7.50 secs
Data transferred:               1.47 MB
Response time:                  0.00 secs
Transaction rate:           14666.67 trans/sec
Throughput:                     0.20 MB/sec
Concurrency:                   20.20
Successful transactions:      110000
Failed transactions:               0
Longest transaction:            0.96
Shortest transaction:           0.00
```

After this patch, there are no `Error during req_read` or `Error during accept` messages. :+1: