### PR TITLE
testing: fix `v -stats test folder/` not failing for a _test.v that fails

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -536,7 +536,11 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		}
 	}
 
-	cmd := '${os.quoted_path(ts.vexe)} -skip-running ${cmd_options.join(' ')} ${os.quoted_path(file)}'
+	mut skip_running := '-skip-running'
+	if ts.show_stats {
+		skip_running = ''
+	}
+	cmd := '${os.quoted_path(ts.vexe)} ${skip_running} ${cmd_options.join(' ')} ${os.quoted_path(file)}'
 	run_cmd := if run_js {
 		'node ${os.quoted_path(generated_binary_fpath)}'
 	} else {
@@ -558,8 +562,6 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 	mut compile_cmd_duration := time.Duration(0)
 	mut cmd_duration := time.Duration(0)
 	if ts.show_stats {
-		ts.reporter.divider()
-
 		ts.append_message(.cmd_begin, cmd, mtc)
 		d_cmd := time.new_stopwatch()
 

--- a/cmd/tools/test_if_v_test_system_works.v
+++ b/cmd/tools/test_if_v_test_system_works.v
@@ -117,11 +117,13 @@ fn main() {
 	}
 	check_ok('${vexe} test ${ok_fpath}').matches('*OK*a_single_ok_test.v*')
 	check_ok('${vexe} test "${tdir}"').matches('*OK*a_single_ok_test.v*')
+	check_ok('${vexe} -stats test "${tdir}"').matches('*OK*a_single_ok_test.v*')
 	//
 	fail_fpath := create_test('a_single_failing_test.v', 'fn test_fail(){ assert 1 == 2 }')!
 	check_fail('${vexe} ${fail_fpath}').has('> assert 1 == 2').has('a_single_failing_test.v:1: fn test_fail')
 	check_fail('${vexe} test ${fail_fpath}').has('> assert 1 == 2').has('a_single_failing_test.v:1: fn test_fail')
 	check_fail('${vexe} test "${tdir}"').has('> assert 1 == 2')
+	check_fail('${vexe} -stats test "${tdir}"').has('> assert 1 == 2')
 	rel_dir := os.join_path(tdir, rand.ulid())
 	os.mkdir(rel_dir)!
 	os.chdir(rel_dir)!

--- a/cmd/tools/vtest_test.v
+++ b/cmd/tools/vtest_test.v
@@ -1,0 +1,80 @@
+import os
+import encoding.txtar
+
+const vexe = @VEXE
+const vroot = os.dir(vexe)
+const tpath = os.join_path(os.vtmp_dir(), 'vtest_folder')
+const tpath_passing = os.join_path(tpath, 'passing')
+const tpath_partial = os.join_path(tpath, 'partial')
+const mytest_exe = os.join_path(tpath, 'mytest.exe')
+
+fn testsuite_end() {
+	os.rmdir_all(tpath) or {}
+}
+
+fn testsuite_begin() {
+	os.setenv('VFLAGS', '', true)
+	os.setenv('VCOLORS', 'never', true)
+	os.setenv('VJOBS', '2', true)
+	os.rmdir_all(tpath) or {}
+	os.mkdir_all(tpath)!
+	txtar.unpack(txtar.parse('
+These are some known tests to make sure that `v test` and `v -stats test` work:
+-- passing/1_test.v --
+fn test_abc() { assert true; assert true; assert true }
+fn test_def() { assert 2 * 2 == 4 }
+-- passing/2_test.v --
+fn test_xyz() { assert 1 == 2 - 1 }
+fn test_abc() { assert 10 == 2 * 5 }
+-- partial/passing_test.v --
+fn test_xyz() { assert 3 == 10 - 7 }
+fn test_def() { assert 10 == 100 / 10 }
+-- partial/failing_test.v --
+fn test_xyz() { assert 5 == 7, "oh no" }
+'),
+		tpath)!
+	assert os.exists(os.join_path(tpath, 'passing/1_test.v'))
+	assert os.exists(os.join_path(tpath, 'passing/2_test.v'))
+	assert os.exists(os.join_path(tpath, 'partial/passing_test.v'))
+	assert os.exists(os.join_path(tpath, 'partial/failing_test.v'))
+}
+
+fn test_vtest_executable_compiles() {
+	os.chdir(vroot)!
+	os.execute_or_exit('${os.quoted_path(vexe)} -o ${tpath}/mytest.exe cmd/tools/vtest.v')
+	assert os.exists(mytest_exe), 'executable file: `${mytest_exe}` should exist'
+}
+
+fn test_with_several_test_files() {
+	res := os.execute_or_exit('${os.quoted_path(mytest_exe)} test ${os.quoted_path(tpath_passing)}')
+	assert !res.output.contains('1 assert'), res.output
+	assert !res.output.contains('3 asserts'), res.output
+	assert res.output.contains('2 passed, 2 total'), res.output
+	assert res.output.count('OK') == 2, res.output
+	assert res.output.contains('on 2 parallel jobs'), res.output
+}
+
+fn test_with_stats_and_several_test_files() {
+	// There should be more OKs here, since the output will have the inner OKs for each individual test fn:
+	res := os.execute_or_exit('${os.quoted_path(mytest_exe)} -stats test ${os.quoted_path(tpath_passing)}')
+	assert res.output.contains('1 assert'), res.output
+	assert res.output.contains('3 asserts'), res.output
+	assert res.output.contains('2 passed, 2 total'), res.output
+	assert res.output.count('OK') == 6, res.output
+}
+
+fn test_partial_failure() {
+	res := os.execute('${os.quoted_path(mytest_exe)} test ${os.quoted_path(tpath_partial)}')
+	assert res.exit_code == 1
+	assert res.output.contains('assert 5 == 7'), res.output
+	assert res.output.contains(' 1 failed, 1 passed, 2 total'), res.output
+	assert res.output.contains('Failed command'), res.output
+}
+
+fn test_with_stats_and_partial_failure() {
+	res := os.execute('${os.quoted_path(mytest_exe)} -stats test ${os.quoted_path(tpath_partial)}')
+	assert res.exit_code == 1
+	assert res.output.contains('assert 5 == 7'), res.output
+	assert res.output.contains(' 1 failed, 1 passed, 2 total'), res.output
+	assert res.output.contains('Failed command'), res.output
+}

--- a/cmd/tools/vtest_test.v
+++ b/cmd/tools/vtest_test.v
@@ -18,8 +18,8 @@ fn testsuite_begin() {
 	os.setenv('VJOBS', '2', true)
 	os.rmdir_all(tpath) or {}
 	os.mkdir_all(tpath)!
-	txtar.unpack(txtar.parse('
-These are some known tests to make sure that `v test` and `v -stats test` work:
+
+	txtar.parse('Some known test files to make sure `v test` and `v -stats test` work:
 -- passing/1_test.v --
 fn test_abc() { assert true; assert true; assert true }
 fn test_def() { assert 2 * 2 == 4 }
@@ -31,8 +31,7 @@ fn test_xyz() { assert 3 == 10 - 7 }
 fn test_def() { assert 10 == 100 / 10 }
 -- partial/failing_test.v --
 fn test_xyz() { assert 5 == 7, "oh no" }
-'),
-		tpath)!
+').unpack_to(tpath)!
 	assert os.exists(os.join_path(tpath, 'passing/1_test.v'))
 	assert os.exists(os.join_path(tpath, 'passing/2_test.v'))
 	assert os.exists(os.join_path(tpath, 'partial/passing_test.v'))

--- a/vlib/encoding/txtar/pack_unpack.v
+++ b/vlib/encoding/txtar/pack_unpack.v
@@ -52,3 +52,8 @@ pub fn parse_file(file_path string) !Archive {
 	content := os.read_file(file_path)!
 	return parse(content)
 }
+
+// unpack_to extracts the content of the archive `a`, into the folder `path`.
+pub fn (a &Archive) unpack_to(path string) ! {
+	unpack(a, path)!
+}

--- a/vlib/encoding/txtar/txtar_test.v
+++ b/vlib/encoding/txtar/txtar_test.v
@@ -78,7 +78,7 @@ fn test_parse() {
 
 fn test_parse_file() {
 	dump(@LOCATION)
-	fpath := os.join_path(os.temp_dir(), 'txtar.txt')
+	fpath := os.join_path(os.vtmp_dir(), 'txtar.txt')
 	defer {
 		os.rm(fpath) or {}
 	}
@@ -91,20 +91,29 @@ fn test_parse_file() {
 
 fn test_unpack_to_folder_then_pack_same_folder() {
 	dump(@LOCATION)
-	folder := os.join_path(os.temp_dir(), 'txtar_folder')
-	defer {
-		os.rmdir_all(folder) or {}
-	}
+	folder := os.join_path(os.vtmp_dir(), 'txtar_folder')
 	a := txtar.parse(simple_archive_content)
+
 	txtar.unpack(a, folder)!
-	assert os.is_file(os.join_path(folder, 'empty'))
-	assert os.is_file(os.join_path(folder, 'folder2/another.txt'))
-	assert os.is_file(os.join_path(folder, 'folder3/final.txt'))
+	check_folder(folder)
+	os.rmdir_all(folder) or {}
+
+	a.unpack_to(folder)!
+	check_folder(folder)
+
 	b := txtar.pack(folder, 'abc')!
+	os.rmdir_all(folder) or {}
+
 	assert a.comment != b.comment
 	assert b.comment == 'abc'
 	assert b.files.len == a.files.len
 	ofiles := a.files.sorted(|x, y| x.path < y.path)
 	pfiles := b.files.sorted(|x, y| x.path < y.path)
 	assert ofiles == pfiles
+}
+
+fn check_folder(folder string) {
+	assert os.is_file(os.join_path(folder, 'empty'))
+	assert os.is_file(os.join_path(folder, 'folder2/another.txt'))
+	assert os.is_file(os.join_path(folder, 'folder3/final.txt'))
 }


### PR DESCRIPTION
Fix #20778 .

Regression happened after https://github.com/vlang/v/pull/20520 .