### PR TITLE
sync,os,thirdparty: fix cross compilation from macos to windows

### DIFF
--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -79,8 +79,8 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&per_page=2" \
-            | jq -r '.workflow_runs[1].head_sha')
+            "https://api.github.com/repos/vlang/v/actions/workflows/18477644/runs?branch=master&status=success&event=push&per_page=5&page=2" \
+            | jq -r '.workflow_runs[4].head_sha')
           echo "recent_good_commit=$recent_good_commit"
           # Build oldv at recent_good_commit.
           ./v run cmd/tools/oldv.v -v $recent_good_commit

--- a/thirdparty/stdatomic/nix/atomic.h
+++ b/thirdparty/stdatomic/nix/atomic.h
@@ -107,10 +107,10 @@ static inline void** atomic_load(void** x) {
 static inline void atomic_store(void** x, void* y) {
 	atomic_store_explicit((unsigned long long*)x, (uintptr_t)y, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_weak(void** x, void** expected, void* y) {
+static inline int atomic_compare_exchange_weak(void** x, void** expected, intptr_t y) {
 	return (int)atomic_compare_exchange_weak_explicit((unsigned long long*)x, (unsigned long long*)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_strong(void** x,  void** expected, void* y) {
+static inline int atomic_compare_exchange_strong(void** x,  void** expected, intptr_t y) {
 	return (int)atomic_compare_exchange_strong_explicit((unsigned long long*)x, (unsigned long long*)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
 static inline uintptr_t atomic_exchange(void** x, void* y) {

--- a/thirdparty/stdatomic/nix/atomic.h
+++ b/thirdparty/stdatomic/nix/atomic.h
@@ -311,10 +311,12 @@ static inline void* atomic_load_ptr(void** x) {
 static inline void atomic_store_ptr(void** x, void* y) {
 	atomic_store_explicit((_Atomic(uintptr_t)*)x, (uintptr_t)y, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_weak_ptr(void** x, void** expected, intptr_t y) {
+static inline int atomic_compare_exchange_weak_ptr(void** x, void** expected, void* y) {
+   	// `void* y` should be `intptr_t y`, but tcc fails for it
 	return (int)atomic_compare_exchange_weak_explicit((_Atomic(uintptr_t)*)x, (unsigned long *)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_strong_ptr(void** x, void** expected, intptr_t y) {
+static inline int atomic_compare_exchange_strong_ptr(void** x, void** expected, void* y) {
+   	// `void* y` should be `intptr_t y`, but tcc fails for it
 	return (int)atomic_compare_exchange_strong_explicit((_Atomic(uintptr_t)*)x, (unsigned long *)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
 static inline void* atomic_exchange_ptr(void** x, void* y) {

--- a/thirdparty/stdatomic/nix/atomic.h
+++ b/thirdparty/stdatomic/nix/atomic.h
@@ -311,10 +311,10 @@ static inline void* atomic_load_ptr(void** x) {
 static inline void atomic_store_ptr(void** x, void* y) {
 	atomic_store_explicit((_Atomic(uintptr_t)*)x, (uintptr_t)y, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_weak_ptr(void** x, void** expected, void* y) {
+static inline int atomic_compare_exchange_weak_ptr(void** x, void** expected, intptr_t y) {
 	return (int)atomic_compare_exchange_weak_explicit((_Atomic(uintptr_t)*)x, (unsigned long *)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_strong_ptr(void** x, void** expected, void* y) {
+static inline int atomic_compare_exchange_strong_ptr(void** x, void** expected, intptr_t y) {
 	return (int)atomic_compare_exchange_strong_explicit((_Atomic(uintptr_t)*)x, (unsigned long *)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
 static inline void* atomic_exchange_ptr(void** x, void* y) {

--- a/thirdparty/stdatomic/nix/atomic.h
+++ b/thirdparty/stdatomic/nix/atomic.h
@@ -311,12 +311,10 @@ static inline void* atomic_load_ptr(void** x) {
 static inline void atomic_store_ptr(void** x, void* y) {
 	atomic_store_explicit((_Atomic(uintptr_t)*)x, (uintptr_t)y, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_weak_ptr(void** x, void** expected, void* y) {
-   	// `void* y` should be `intptr_t y`, but tcc fails for it
+static inline int atomic_compare_exchange_weak_ptr(void** x, void** expected, intptr_t y) {
 	return (int)atomic_compare_exchange_weak_explicit((_Atomic(uintptr_t)*)x, (unsigned long *)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
-static inline int atomic_compare_exchange_strong_ptr(void** x, void** expected, void* y) {
-   	// `void* y` should be `intptr_t y`, but tcc fails for it
+static inline int atomic_compare_exchange_strong_ptr(void** x, void** expected, intptr_t y) {
 	return (int)atomic_compare_exchange_strong_explicit((_Atomic(uintptr_t)*)x, (unsigned long *)expected, (uintptr_t)y, memory_order_seq_cst, memory_order_seq_cst);
 }
 static inline void* atomic_exchange_ptr(void** x, void* y) {

--- a/thirdparty/stdatomic/win/atomic.h
+++ b/thirdparty/stdatomic/win/atomic.h
@@ -270,7 +270,7 @@ static inline int atomic_compare_exchange_strong_u32(unsigned* object, unsigned*
                                                  unsigned desired)
 {
 	unsigned old = *expected;
-    *expected = InterlockedCompareExchange(object, desired, old);
+    *expected = InterlockedCompareExchange((void *)object, desired, old);
     return *expected == old;
 }
 

--- a/thirdparty/stdatomic/win/atomic.h
+++ b/thirdparty/stdatomic/win/atomic.h
@@ -317,7 +317,7 @@ static inline int atomic_compare_exchange_strong_u16(unsigned short* object, uns
 }
 
 #define atomic_compare_exchange_weak_u16(object, expected, desired) \
-    atomic_compare_exchange_strong_u16(object, expected, desired)
+    atomic_compare_exchange_strong_u16((void*)object, expected, desired)
 
 #define atomic_fetch_add_u16(object, operand) \
     InterlockedExchangeAdd16(object, operand)

--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -6,7 +6,7 @@ fn C.CloseHandle(voidptr) bool
 
 pub fn (mut l FileLock) unlink() {
 	if l.fd != -1 {
-		C.CloseHandle(l.fd)
+		C.CloseHandle(voidptr(l.fd))
 		l.fd = -1
 	}
 	t_wide := l.name.to_wide()
@@ -21,7 +21,7 @@ pub fn (mut l FileLock) acquire() ! {
 	if fd == -1 {
 		return error_with_code('cannot create lock file ${l.name}', -1)
 	}
-	l.fd = fd
+	l.fd = int(fd)
 }
 
 fn open(f string) voidptr {
@@ -41,6 +41,6 @@ pub fn (mut l FileLock) try_acquire() bool {
 	if fd == -1 {
 		return false
 	}
-	l.fd = fd
+	l.fd = int(fd)
 	return true
 }

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -123,8 +123,8 @@ pub fn (mut ch Channel) close() {
 		return
 	}
 	mut nulladr := unsafe { nil }
-	for !C.atomic_compare_exchange_weak_ptr(unsafe { voidptr(&ch.adr_written) }, &nulladr,
-		voidptr(-1)) {
+	for !C.atomic_compare_exchange_weak_ptr(voidptr(&ch.adr_written), voidptr(&nulladr),
+		isize(-1)) {
 		nulladr = unsafe { nil }
 	}
 	ch.readsem_im.post()
@@ -184,14 +184,14 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 		mut got_sem := false
 		mut wradr := C.atomic_load_ptr(unsafe { &voidptr(&ch.write_adr) })
 		for wradr != C.NULL {
-			if C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.write_adr) },
-				&wradr, unsafe { nil })
+			if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.write_adr), voidptr(&wradr),
+				isize(0))
 			{
 				// there is a reader waiting for us
 				unsafe { C.memcpy(wradr, src, ch.objsize) }
 				mut nulladr := unsafe { nil }
-				for !C.atomic_compare_exchange_weak_ptr(unsafe { voidptr(&ch.adr_written) },
-					&nulladr, wradr) {
+				for !C.atomic_compare_exchange_weak_ptr(voidptr(&ch.adr_written), voidptr(&nulladr),
+					isize(wradr)) {
 					nulladr = unsafe { nil }
 				}
 				ch.readsem_im.post()
@@ -225,8 +225,8 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			wradr = C.atomic_load_ptr(unsafe { &voidptr(&ch.write_adr) })
 			if wradr != C.NULL {
 				mut src2 := src
-				if C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.read_adr) },
-					&src2, unsafe { nil })
+				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.read_adr), voidptr(&src2),
+					isize(0))
 				{
 					ch.writesem.post()
 					continue
@@ -247,8 +247,8 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			}
 			mut src2 := src
 			for sp := u32(0); sp < spinloops_ || read_in_progress; sp++ {
-				if C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.adr_read) },
-					&src2, unsafe { nil })
+				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2),
+					isize(0))
 				{
 					have_swapped = true
 					read_in_progress = true
@@ -271,7 +271,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 				}
 				if C.atomic_load_u16(&ch.closed) != 0 {
 					if have_swapped
-						|| C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.adr_read) }, &src2, unsafe { nil }) {
+						|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2), isize(0)) {
 						ch.writesem.post()
 						return .success
 					} else {
@@ -279,7 +279,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 					}
 				}
 				if have_swapped
-					|| C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.adr_read) }, &src2, unsafe { nil }) {
+					|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2), isize(0)) {
 					ch.writesem.post()
 					break
 				} else {
@@ -332,7 +332,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 					C.memcpy(wr_ptr, src, ch.objsize)
 				}
 				C.atomic_store_u16(unsafe { &u16(status_adr) }, u16(BufferElemStat.written))
-				C.atomic_fetch_add_u32(&ch.read_avail, 1)
+				C.atomic_fetch_add_u32(voidptr(&ch.read_avail), 1)
 				ch.readsem.post()
 				mut null16 := u16(0)
 				for !C.atomic_compare_exchange_weak_u16(&ch.read_sub_mtx, &null16, u16(1)) {
@@ -375,14 +375,14 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 			// unbuffered channel - first see if a `push()` has adversized
 			mut rdadr := C.atomic_load_ptr(unsafe { &voidptr(&ch.read_adr) })
 			for rdadr != C.NULL {
-				if C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.read_adr) },
-					&rdadr, unsafe { nil })
+				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.read_adr), voidptr(&rdadr),
+					isize(0))
 				{
 					// there is a writer waiting for us
 					unsafe { C.memcpy(dest, rdadr, ch.objsize) }
 					mut nulladr := unsafe { nil }
-					for !C.atomic_compare_exchange_weak_ptr(unsafe { voidptr(&ch.adr_read) },
-						&nulladr, rdadr) {
+					for !C.atomic_compare_exchange_weak_ptr(voidptr(&ch.adr_read), voidptr(&nulladr),
+						isize(rdadr)) {
 						nulladr = unsafe { nil }
 					}
 					ch.writesem_im.post()
@@ -453,7 +453,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 					C.memcpy(dest, rd_ptr, ch.objsize)
 				}
 				C.atomic_store_u16(unsafe { &u16(status_adr) }, u16(BufferElemStat.unused))
-				C.atomic_fetch_add_u32(&ch.write_free, 1)
+				C.atomic_fetch_add_u32(voidptr(&ch.write_free), 1)
 				ch.writesem.post()
 				mut null16 := u16(0)
 				for !C.atomic_compare_exchange_weak_u16(&ch.write_sub_mtx, &null16, u16(1)) {
@@ -472,8 +472,8 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 			mut rdadr := C.atomic_load_ptr(unsafe { &voidptr(&ch.read_adr) })
 			if rdadr != C.NULL {
 				mut dest2 := dest
-				if C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.write_adr) },
-					&dest2, unsafe { nil })
+				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.write_adr), voidptr(&dest2),
+					isize(0))
 				{
 					ch.readsem.post()
 					continue
@@ -494,8 +494,8 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 		}
 		mut dest2 := dest
 		for sp := u32(0); sp < spinloops_ || write_in_progress; sp++ {
-			if C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.adr_written) },
-				&dest2, unsafe { nil })
+			if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_written), voidptr(&dest2),
+				isize(0))
 			{
 				have_swapped = true
 				break
@@ -519,7 +519,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 				ch.readsem_im.wait()
 			}
 			if have_swapped
-				|| C.atomic_compare_exchange_strong_ptr(unsafe { &voidptr(&ch.adr_written) }, &dest2, unsafe { nil }) {
+				|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_written), voidptr(&dest2), isize(0)) {
 				ch.readsem.post()
 				break
 			} else {

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -123,7 +123,7 @@ pub fn (mut ch Channel) close() {
 		return
 	}
 	mut nulladr := unsafe { nil }
-	for !C.atomic_compare_exchange_weak_ptr(unsafe { &voidptr(&ch.adr_written) }, &nulladr,
+	for !C.atomic_compare_exchange_weak_ptr(unsafe { voidptr(&ch.adr_written) }, &nulladr,
 		voidptr(-1)) {
 		nulladr = unsafe { nil }
 	}
@@ -190,7 +190,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 				// there is a reader waiting for us
 				unsafe { C.memcpy(wradr, src, ch.objsize) }
 				mut nulladr := unsafe { nil }
-				for !C.atomic_compare_exchange_weak_ptr(unsafe { &voidptr(&ch.adr_written) },
+				for !C.atomic_compare_exchange_weak_ptr(unsafe { voidptr(&ch.adr_written) },
 					&nulladr, wradr) {
 					nulladr = unsafe { nil }
 				}
@@ -381,7 +381,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 					// there is a writer waiting for us
 					unsafe { C.memcpy(dest, rdadr, ch.objsize) }
 					mut nulladr := unsafe { nil }
-					for !C.atomic_compare_exchange_weak_ptr(unsafe { &voidptr(&ch.adr_read) },
+					for !C.atomic_compare_exchange_weak_ptr(unsafe { voidptr(&ch.adr_read) },
 						&nulladr, rdadr) {
 						nulladr = unsafe { nil }
 					}

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -124,7 +124,7 @@ pub fn (mut ch Channel) close() {
 	}
 	mut nulladr := unsafe { nil }
 	for !C.atomic_compare_exchange_weak_ptr(voidptr(&ch.adr_written), voidptr(&nulladr),
-		isize(-1)) {
+		voidptr(-1)) {
 		nulladr = unsafe { nil }
 	}
 	ch.readsem_im.post()
@@ -185,13 +185,13 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 		mut wradr := C.atomic_load_ptr(unsafe { &voidptr(&ch.write_adr) })
 		for wradr != C.NULL {
 			if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.write_adr), voidptr(&wradr),
-				isize(0))
+				unsafe { nil })
 			{
 				// there is a reader waiting for us
 				unsafe { C.memcpy(wradr, src, ch.objsize) }
 				mut nulladr := unsafe { nil }
 				for !C.atomic_compare_exchange_weak_ptr(voidptr(&ch.adr_written), voidptr(&nulladr),
-					isize(wradr)) {
+					voidptr(wradr)) {
 					nulladr = unsafe { nil }
 				}
 				ch.readsem_im.post()
@@ -226,7 +226,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			if wradr != C.NULL {
 				mut src2 := src
 				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.read_adr), voidptr(&src2),
-					isize(0))
+					unsafe { nil })
 				{
 					ch.writesem.post()
 					continue
@@ -248,7 +248,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			mut src2 := src
 			for sp := u32(0); sp < spinloops_ || read_in_progress; sp++ {
 				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2),
-					isize(0))
+					unsafe { nil })
 				{
 					have_swapped = true
 					read_in_progress = true
@@ -271,7 +271,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 				}
 				if C.atomic_load_u16(&ch.closed) != 0 {
 					if have_swapped
-						|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2), isize(0)) {
+						|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2), unsafe { nil }) {
 						ch.writesem.post()
 						return .success
 					} else {
@@ -279,7 +279,7 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 					}
 				}
 				if have_swapped
-					|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2), isize(0)) {
+					|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_read), voidptr(&src2), unsafe { nil }) {
 					ch.writesem.post()
 					break
 				} else {
@@ -376,13 +376,13 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 			mut rdadr := C.atomic_load_ptr(unsafe { &voidptr(&ch.read_adr) })
 			for rdadr != C.NULL {
 				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.read_adr), voidptr(&rdadr),
-					isize(0))
+					unsafe { nil })
 				{
 					// there is a writer waiting for us
 					unsafe { C.memcpy(dest, rdadr, ch.objsize) }
 					mut nulladr := unsafe { nil }
 					for !C.atomic_compare_exchange_weak_ptr(voidptr(&ch.adr_read), voidptr(&nulladr),
-						isize(rdadr)) {
+						voidptr(rdadr)) {
 						nulladr = unsafe { nil }
 					}
 					ch.writesem_im.post()
@@ -473,7 +473,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 			if rdadr != C.NULL {
 				mut dest2 := dest
 				if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.write_adr), voidptr(&dest2),
-					isize(0))
+					unsafe { nil })
 				{
 					ch.readsem.post()
 					continue
@@ -495,7 +495,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 		mut dest2 := dest
 		for sp := u32(0); sp < spinloops_ || write_in_progress; sp++ {
 			if C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_written), voidptr(&dest2),
-				isize(0))
+				unsafe { nil })
 			{
 				have_swapped = true
 				break
@@ -519,7 +519,7 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 				ch.readsem_im.wait()
 			}
 			if have_swapped
-				|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_written), voidptr(&dest2), isize(0)) {
+				|| C.atomic_compare_exchange_strong_ptr(voidptr(&ch.adr_written), voidptr(&dest2), unsafe { nil }) {
 				ch.readsem.post()
 				break
 			} else {

--- a/vlib/sync/pool/pool.c.v
+++ b/vlib/sync/pool/pool.c.v
@@ -111,7 +111,7 @@ fn process_in_thread(mut pool PoolProcessor, task_id int) {
 	cb := ThreadCB(pool.thread_cb)
 	ilen := pool.items.len
 	for {
-		idx := int(C.atomic_fetch_add_u32(&pool.ntask, 1))
+		idx := int(C.atomic_fetch_add_u32(voidptr(&pool.ntask), 1))
 		if idx >= ilen {
 			break
 		}

--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -94,8 +94,8 @@ $if linux {
 // The following functions are actually generic in C
 fn C.atomic_load_ptr(voidptr) voidptr
 fn C.atomic_store_ptr(voidptr, voidptr)
-fn C.atomic_compare_exchange_weak_ptr(voidptr, voidptr, isize) bool
-fn C.atomic_compare_exchange_strong_ptr(voidptr, voidptr, isize) bool
+fn C.atomic_compare_exchange_weak_ptr(voidptr, voidptr, voidptr) bool
+fn C.atomic_compare_exchange_strong_ptr(voidptr, voidptr, voidptr) bool
 fn C.atomic_exchange_ptr(voidptr, voidptr) voidptr
 fn C.atomic_fetch_add_ptr(voidptr, voidptr) voidptr
 fn C.atomic_fetch_sub_ptr(voidptr, voidptr) voidptr

--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -94,8 +94,8 @@ $if linux {
 // The following functions are actually generic in C
 fn C.atomic_load_ptr(voidptr) voidptr
 fn C.atomic_store_ptr(voidptr, voidptr)
-fn C.atomic_compare_exchange_weak_ptr(voidptr, voidptr, voidptr) bool
-fn C.atomic_compare_exchange_strong_ptr(voidptr, voidptr, voidptr) bool
+fn C.atomic_compare_exchange_weak_ptr(voidptr, voidptr, isize) bool
+fn C.atomic_compare_exchange_strong_ptr(voidptr, voidptr, isize) bool
 fn C.atomic_exchange_ptr(voidptr, voidptr) voidptr
 fn C.atomic_fetch_add_ptr(voidptr, voidptr) voidptr
 fn C.atomic_fetch_sub_ptr(voidptr, voidptr) voidptr

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -163,7 +163,7 @@ pub fn (mut sem Semaphore) post() {
 		}
 	}
 	C.AcquireSRWLockExclusive(&sem.mtx)
-	c = C.atomic_fetch_add_u32(&sem.count, 1)
+	c = C.atomic_fetch_add_u32(voidptr(&sem.count), 1)
 	if c == 0 {
 		C.WakeConditionVariable(&sem.cond)
 	}

--- a/vlib/sync/waitgroup.c.v
+++ b/vlib/sync/waitgroup.c.v
@@ -46,7 +46,7 @@ pub fn (mut wg WaitGroup) init() {
 // and unblocks any wait() calls if task count becomes zero.
 // add panics if task count drops below zero.
 pub fn (mut wg WaitGroup) add(delta int) {
-	old_nrjobs := int(C.atomic_fetch_add_u32(&wg.task_count, u32(delta)))
+	old_nrjobs := int(C.atomic_fetch_add_u32(voidptr(&wg.task_count), u32(delta)))
 	new_nrjobs := old_nrjobs + delta
 	mut num_waiters := C.atomic_load_u32(&wg.wait_count)
 	if new_nrjobs < 0 {
@@ -79,6 +79,6 @@ pub fn (mut wg WaitGroup) wait() {
 		// no need to wait
 		return
 	}
-	C.atomic_fetch_add_u32(&wg.wait_count, 1)
+	C.atomic_fetch_add_u32(voidptr(&wg.wait_count), 1)
 	wg.sem.wait() // blocks until task_count becomes 0
 }

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -25,7 +25,7 @@ fn find_windows_kit_internal(key RegKey, versions []string) !string {
 		unsafe {
 			for version in versions {
 				required_bytes := u32(0) // TODO: mut
-				result := C.RegQueryValueEx(key, version.to_wide(), 0, 0, 0, &required_bytes)
+				result := C.RegQueryValueEx(key, version.to_wide(), 0, 0, 0, voidptr(&required_bytes))
 				length := required_bytes / 2
 				if result != 0 {
 					continue
@@ -38,7 +38,8 @@ fn find_windows_kit_internal(key RegKey, versions []string) !string {
 				//
 				else {
 				}
-				result2 := C.RegQueryValueEx(key, version.to_wide(), 0, 0, value, &alloc_length)
+				result2 := C.RegQueryValueEx(key, version.to_wide(), 0, 0, voidptr(value),
+					voidptr(&alloc_length))
 				if result2 != 0 {
 					continue
 				}
@@ -85,7 +86,7 @@ fn find_windows_kit_root_by_reg(target_arch string) !WindowsKit {
 		root_key := RegKey(0)
 		path := 'SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots'
 		rc := C.RegOpenKeyEx(builder.hkey_local_machine, path.to_wide(), 0, builder.key_query_value | builder.key_wow64_32key | builder.key_enumerate_sub_keys,
-			&root_key)
+			voidptr(&root_key))
 
 		if rc != 0 {
 			return error('Unable to open root key')


### PR DESCRIPTION
- **ci: fix bootstrapping job, filter only event=push for finding commits with good CI runs, to prevent firing for commits on PRs with branch = master**
- **ci: workaround for cross compilation from macos to windows (mingw-w64--11.0.1_1.ventura.bottle.3.tar.gz is stricter)**
- **ci: fix os.filelock for windows (for crosscompiling from macos with mingw-w64--11.0.1_1.ventura.bottle.3.tar.gz)**
- **ci: fixes for cross compilation from macos->windows, due to stricter mingw-w64--11.0.1_1.ventura.bottle.3.tar.gz**
- **ci: fix cross compilation from macos to windows with mingw-w64**
