### PR TITLE
cgen: fix c struct option alias printing

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -179,7 +179,7 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 	}
 	parent_type := typ.clear_flag(.option)
 	sym := g.table.sym(parent_type)
-	sym_has_str_method, _, _ := sym.str_method_info()
+	sym_has_str_method, expects_ptr, _ := sym.str_method_info()
 	parent_str_fn_name := g.get_str_fn(parent_type)
 
 	g.definitions.writeln('string ${str_fn_name}(${styp} it); // auto')
@@ -188,7 +188,13 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 	g.auto_str_funcs.writeln('string indent_${str_fn_name}(${styp} it, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstring res;')
 	g.auto_str_funcs.writeln('\tif (it.state == 0) {')
-	deref := if typ.is_ptr() { '**(${sym.cname}**)&' } else { '*(${sym.cname}*)' }
+	deref := if typ.is_ptr() {
+		'**(${sym.cname}**)&'
+	} else if expects_ptr {
+		'(${sym.cname}*)'
+	} else {
+		'*(${sym.cname}*)'
+	}
 	if sym.kind == .string {
 		if typ.nr_muls() > 1 {
 			g.auto_str_funcs.writeln('\t\tres = ptr_str(*(${sym.cname}**)&it.data);')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1117,6 +1117,9 @@ fn (mut g Gen) gen_to_str_method_call(node ast.CallExpr) bool {
 				}
 				g.gen_expr_to_string(left_node, rec_type)
 				return true
+			} else if left_node.or_expr.kind == .propagate_option {
+				g.gen_expr_to_string(left_node, g.unwrap_generic(node.left_type))
+				return true
 			}
 		}
 	} else if left_node is ast.None {

--- a/vlib/v/tests/c_structs/cstruct.h
+++ b/vlib/v/tests/c_structs/cstruct.h
@@ -26,3 +26,9 @@ typedef struct Foo {
 typedef struct Bar {
     int a;
 } Bar;
+
+///
+
+typedef struct TestAlias {
+    int a;
+};

--- a/vlib/v/tests/c_structs/cstruct_alias_test.v
+++ b/vlib/v/tests/c_structs/cstruct_alias_test.v
@@ -1,0 +1,15 @@
+#include "@VMODROOT/cstruct.h"
+
+struct C.TestAlias {
+}
+
+type Foo = C.TestAlias
+
+fn call() ?Foo {
+	return Foo{}
+}
+
+fn test_main() {
+	a := call()
+	assert a?.str() == 'Foo(C.TestAlias{})'
+}


### PR DESCRIPTION
Fix #21493