### PR TITLE
vdoc: include `src` dir when trying to generate doc comments for module with `v doc -comments <modname>`

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -311,8 +311,17 @@ fn (mut vd VDoc) generate_docs_from_file() {
 	for dirpath in dirs {
 		vd.vprintln('Generating ${out.typ} docs for "${dirpath}"')
 		mut dcs := doc.generate(dirpath, cfg.pub_only, true, cfg.platform, cfg.symbol_name) or {
-			vd.emit_generate_err(err)
-			exit(1)
+			// TODO: use a variable like `src_path := os.join_path(dirpath, 'src')` after `https://github.com/vlang/v/issues/21504`
+			if os.exists(os.join_path(dirpath, 'src')) {
+				doc.generate(os.join_path(dirpath, 'src'), cfg.pub_only, true, cfg.platform,
+					cfg.symbol_name) or {
+					vd.emit_generate_err(err)
+					exit(1)
+				}
+			} else {
+				vd.emit_generate_err(err)
+				exit(1)
+			}
 		}
 		if dcs.contents.len == 0 {
 			continue


### PR DESCRIPTION
If a module stores its code files in an `src` directory, it is currently necessary to explicitly pass the `src` directory as a submodule when generating the documentation for the module with `v doc`:

```sh
v doc -comments <modname>
v doc -comments <modname>.src # would be required
```
Without `.src` it will result in e.g.,:
```sh
❯ v doc -comments <modname>
Available modules:
==================
<modname>.examples
<modname>.src
```

With the changes, `<modname>` and `<modname>/src` would be tried as sources when using `v doc -comments <modname>`. This would lead to a more consistent behavior with regard to the `src` directory, similar to module imports.
