### PR TITLE
vdoc: fix search in README `index.html` when documentation was generated with `v doc -f html -m -readme` flags

### DIFF
--- a/cmd/tools/vdoc/theme/doc.js
+++ b/cmd/tools/vdoc/theme/doc.js
@@ -12,6 +12,9 @@
 function setupScrollSpy() {
 	const mainContent = document.querySelector('#main-content');
 	const toc = mainContent.querySelector('.doc-toc');
+	if (!toc) {
+		return;
+	}
 	const sections = mainContent.querySelectorAll('section');
 	const sectionPositions = Array.from(sections).map((section) => section.offsetTop);
 	let lastActive = null;


### PR DESCRIPTION
Fixes the last bug mentioned in the recent issue https://github.com/vlang/v/issues/21222#issuecomment-2049838713.

For a low-effort-repro I would reference a module that is currently suffering from the issue:
E.g. try to use the search in the README index page of https://ttytm.github.io/dialog/index.html.

Trying again with the changes in the modules directory:

```sh
v doc -f html -m -readme .
```

|Current|Update|
| - | - |
| ![](https://github.com/vlang/v/assets/34311583/c1aa2dc9-1f1c-4e26-8342-77e7389d75b9) | ![](https://github.com/vlang/v/assets/34311583/21801696-6648-4c34-aa56-138dea78e22d) |
