### PR TITLE
checker: fix option interface member checking when `none` is passed

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1540,7 +1540,8 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 			}
 			return false
 		}
-		if typ != voidptr_type && typ != nil_type && !inter_sym.info.types.contains(typ) {
+		if typ != voidptr_type && typ != nil_type && typ != none_type
+			&& !inter_sym.info.types.contains(typ) {
 			inter_sym.info.types << typ
 		}
 		if !inter_sym.info.types.contains(voidptr_type) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1127,7 +1127,8 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 				}
 			}
 		}
-		if utyp != ast.voidptr_type && utyp != ast.nil_type && !inter_sym.info.types.contains(utyp) {
+		if utyp != ast.voidptr_type && utyp != ast.nil_type && utyp != ast.none_type
+			&& !inter_sym.info.types.contains(utyp) {
 			inter_sym.info.types << utyp
 		}
 		if !inter_sym.info.types.contains(ast.voidptr_type) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1056,7 +1056,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		inter_sym.methods
 	}
 	// voidptr is an escape hatch, it should be allowed to be passed
-	if utyp != ast.voidptr_type && utyp != ast.nil_type {
+	if utyp != ast.voidptr_type && utyp != ast.nil_type && utyp != ast.none_type {
 		mut are_methods_implemented := true
 
 		// Verify methods

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1056,7 +1056,8 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 		inter_sym.methods
 	}
 	// voidptr is an escape hatch, it should be allowed to be passed
-	if utyp != ast.voidptr_type && utyp != ast.nil_type && utyp != ast.none_type {
+	if utyp != ast.voidptr_type && utyp != ast.nil_type && !(interface_type.has_flag(.option)
+		&& utyp == ast.none_type) {
 		mut are_methods_implemented := true
 
 		// Verify methods

--- a/vlib/v/tests/option_interface_test.v
+++ b/vlib/v/tests/option_interface_test.v
@@ -1,0 +1,18 @@
+interface TestIntf {
+	test()
+}
+
+struct TestStruct {
+	ti ?TestIntf
+}
+
+fn TestStruct.new() TestStruct {
+	return TestStruct{
+		ti: none
+	}
+}
+
+fn test_main() {
+	t := TestStruct.new()
+	assert t.ti == none
+}


### PR DESCRIPTION
Fix #21507