### PR TITLE
net.unix: Remove debug print.

### DIFF
--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -424,7 +424,6 @@ fn (mut s StreamSocket) connect(socket_path string) ! {
 	addr := addrs[0]
 	// cast to the correct type
 	alen := addr.len()
-	eprintln(addr)
 
 	$if net_nonblocking_sockets ? {
 		res := $if is_coroutine ? {


### PR DESCRIPTION
Prior to this patch, connecting over a Unix socket would print the path of the `.sock` file. Remove the debug print in order to give user code control over messages to the terminal.