### PR TITLE
vdoc: improve vdocignore file handling by walking all .vdocignore sub-paths in IgnoreRules.get, add test

### DIFF
--- a/cmd/tools/vdoc/vdoc_test.v
+++ b/cmd/tools/vdoc/vdoc_test.v
@@ -3,6 +3,19 @@ module main
 import os
 import arrays
 
+const tpath = os.join_path(os.vtmp_dir(), 'vod_test_module')
+
+fn testsuite_begin() {
+	os.rmdir_all(tpath) or {}
+	os.mkdir_all(tpath)!
+	os.chdir(tpath)!
+}
+
+
+fn testsuite_end() {
+	os.rmdir_all(tpath) or {}
+}
+
 fn test_trim_doc_node_description() {
 	mod := 'foo'
 	mut readme := '## Description
@@ -20,16 +33,17 @@ It also assists with composing and testing baz.'
 	assert res2 == res
 }
 
+fn test_ignore_rules() {
+	os.write_file('.vdocignore', ['pattern1', 'pattern2', '/path1'].join_lines())!
+	os.mkdir('subdir')!
+	os.write_file(os.join_path('subdir', '.vdocignore'), ['pattern3', '/path2'].join_lines())!
+	rules := IgnoreRules.get('.')
+	assert rules.patterns['.'] == ['pattern1', 'pattern2']
+	assert rules.patterns['./subdir'] == ['pattern3']
+	assert rules.paths == {'./path1': true, './subdir/path2': true}
+}
+
 fn test_get_module_list() {
-	tpath := os.join_path(os.vtmp_dir(), 'vod_test_module')
-	os.rmdir_all(tpath) or {}
-	os.mkdir_all(tpath)!
-	defer {
-		os.rmdir_all(tpath) or {}
-	}
-
-	os.chdir(tpath)!
-
 	// For information on leading slash rules, refer to the comments in `IgnoreRules.get`.
 	ignore_rules := ['bravo', '/echo', '/foxtrot/golf', 'hotel.v/', 'india/juliett']
 	os.write_file('.vdocignore', ignore_rules.join_lines())!


### PR DESCRIPTION
With the changes, all ignore rules for a specified directory and its subdirectories are gathered first. This removes coupling with the process of getting modules and should simplify  and improve testability. A test is also added.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
