### PR TITLE
parser: parse string and array typ idx of `ScopeVar` and `Ident`

### DIFF
--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -226,6 +226,11 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr) ast.Stmt {
 						pos: lx.pos
 						is_stack_obj: p.inside_for
 					}
+					if p.prev_tok.kind == .string {
+						v.typ = ast.string_type_idx
+					} else if p.prev_tok.kind == .rsbr {
+						v.typ = ast.array_type_idx
+					}
 					if p.pref.autofree {
 						r0 := right[0]
 						if r0 is ast.CallExpr {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2288,6 +2288,17 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 		// `generic_fn[int]`
 		concrete_types = p.parse_concrete_types()
 	}
+	typ := match p.peek_tok.kind {
+		.string { ast.string_type_idx }
+		.lsbr { ast.array_type_idx }
+		else {
+			if p.tok.kind == .dot {
+				if var := p.scope.find_var(name) { var.typ } else { 0 }
+			} else {
+				0
+			}
+		}
+	}
 	return ast.Ident{
 		tok_kind: p.tok.kind
 		kind: .unresolved
@@ -2299,6 +2310,7 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 		is_mut: is_mut
 		mut_pos: mut_pos
 		info: ast.IdentVar{
+			typ: typ
 			is_mut: is_mut
 			is_static: is_static
 			is_volatile: is_volatile

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2289,8 +2289,12 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 		concrete_types = p.parse_concrete_types()
 	}
 	typ := match p.peek_tok.kind {
-		.string { ast.string_type_idx }
-		.lsbr { ast.array_type_idx }
+		.string {
+			ast.string_type_idx
+		}
+		.lsbr {
+			ast.array_type_idx
+		}
 		else {
 			if p.tok.kind == .dot {
 				if var := p.scope.find_var(name) { var.typ } else { 0 }


### PR DESCRIPTION
Will extend capabilities and e.g. allow to finish #21421.

Current types in `scope` and `info`
```sh
  scope: &# 3 - 311
* var: foo - ast.Type(0x0 = 0) # e.g. string type
* var: baz - ast.Type(0x0 = 0) # e.g. array type
# ...
info: ast.IdentInfo(ast.IdentVar{
    typ: ast.Type(0x0 = 0)
    share: mut
    is_mut: false
    is_static: false
    is_volatile: false
    is_option: false
})
# ...
```
Updated:
```sh
  scope: &# 3 - 311
* var: foo - ast.Type(0x15 = 21)
* var: baz - ast.Type(0x17 = 23)
# ...
info: ast.IdentInfo(ast.IdentVar{
    typ: ast.Type(0x17 = 23)
    share: mut
    is_mut: false
    is_static: false
    is_volatile: false
    is_option: false
})
# ...
```

The parsing can be limited to `p.pref.is_vet` and `p.pref.is_fmt` if it is preferred.