### PR TITLE
builtin: simplify MessageError.msg()

### DIFF
--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -32,7 +32,7 @@ pub fn (err IError) str() string {
 			err.msg()
 		}
 		MessageError {
-			err.msg()
+			err.str()
 		}
 		else {
 			// >> Hack to allow old style custom error implementations
@@ -66,6 +66,11 @@ struct MessageError {
 pub:
 	msg  string
 	code int
+}
+
+// str returns the message and code of the MessageError
+pub fn (err MessageError) str() string {
+	return err.msg
 }
 
 // msg returns the message of the MessageError

--- a/vlib/builtin/result.v
+++ b/vlib/builtin/result.v
@@ -40,7 +40,7 @@ pub fn (err IError) str() string {
 			err.msg()
 		}
 		MessageError {
-			err.msg()
+			err.str()
 		}
 		else {
 			// >> Hack to allow old style custom error implementations
@@ -70,15 +70,20 @@ pub:
 	code int
 }
 
-// msg returns the message of MessageError
-pub fn (err MessageError) msg() string {
+// str returns both the .msg and .code of MessageError, when .code is != 0
+pub fn (err MessageError) str() string {
 	if err.code > 0 {
 		return '${err.msg}; code: ${err.code}'
 	}
 	return err.msg
 }
 
-// code returns the code of MessageError
+// msg returns only the message of MessageError
+pub fn (err MessageError) msg() string {
+	return err.msg
+}
+
+// code returns only the code of MessageError
 pub fn (err MessageError) code() int {
 	return err.code
 }

--- a/vlib/builtin/result.v
+++ b/vlib/builtin/result.v
@@ -40,7 +40,7 @@ pub fn (err IError) str() string {
 			err.msg()
 		}
 		MessageError {
-			err.str()
+			(*err).str()
 		}
 		else {
 			// >> Hack to allow old style custom error implementations

--- a/vlib/os/signal_test.v
+++ b/vlib/os/signal_test.v
@@ -20,7 +20,8 @@ fn test_signal_opt_invalid_argument() {
 		assert false
 	}
 	os.signal_opt(.kill, default_handler) or {
-		assert err.msg() == 'Invalid argument; code: 22'
+		assert err.str() == 'Invalid argument; code: 22'
+		assert err.msg() == 'Invalid argument'
 		assert err.code() == 22
 	}
 }

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -482,7 +482,7 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 		}
 		ast.PostfixExpr {
 			ifdef := g.comptime_if_to_ifdef((cond.expr as ast.Ident).name, true) or {
-				verror(err.msg())
+				verror(err.str())
 				return false, true
 			}
 			g.write('defined(${ifdef})')

--- a/vlib/v/slow_tests/inout/orm_panic_for_insert_into_not_created_table.out
+++ b/vlib/v/slow_tests/inout/orm_panic_for_insert_into_not_created_table.out
@@ -1,5 +1,5 @@
 ================ V panic ================
    module: main
  function: main()
-  message: no such table: User (1) (INSERT INTO `User` (`id`, `name`) VALUES (?1, ?2);); code: 1
+  message: no such table: User (1) (INSERT INTO `User` (`id`, `name`) VALUES (?1, ?2);)
      file: vlib/v/slow_tests/inout/orm_panic_for_insert_into_not_created_table.vv:17

--- a/vlib/v/slow_tests/inout/orm_panic_for_select_from_not_created_table.out
+++ b/vlib/v/slow_tests/inout/orm_panic_for_select_from_not_created_table.out
@@ -1,5 +1,5 @@
 ================ V panic ================
    module: main
  function: main()
-  message: no such table: User (1) (SELECT `id`, `name` FROM `User`;); code: 1
+  message: no such table: User (1) (SELECT `id`, `name` FROM `User`;)
      file: vlib/v/slow_tests/inout/orm_panic_for_select_from_not_created_table.vv:13

--- a/vlib/v/tests/option_test.c.v
+++ b/vlib/v/tests/option_test.c.v
@@ -8,11 +8,13 @@ fn test_err_with_code() {
 		assert false
 		_ := w
 	} else {
-		assert err.msg() == 'hi; code: 137'
+		assert err.str() == 'hi; code: 137'
+		assert err.msg() == 'hi'
 		assert err.code() == 137
 	}
 	v := opt_err_with_code(56) or {
-		assert err.msg() == 'hi; code: 56'
+		assert err.str() == 'hi; code: 56'
+		assert err.msg() == 'hi'
 		assert err.code() == 56
 		return
 	}
@@ -297,7 +299,7 @@ fn test_option_void_return_types_of_anon_fn() {
 }
 
 struct Foo {
-	f fn (int) !
+	f fn (int) ! = unsafe { nil }
 }
 
 fn test_option_void_return_types_of_anon_fn_in_struct() {

--- a/vlib/v/tests/results_test.v
+++ b/vlib/v/tests/results_test.v
@@ -104,11 +104,13 @@ fn test_err_with_code() {
 		assert false
 		_ := w
 	} else {
-		assert err.msg() == 'hi; code: 137'
+		assert err.str() == 'hi; code: 137'
+		assert err.msg() == 'hi'
 		assert err.code() == 137
 	}
 	v := res_err_with_code(56) or {
-		assert err.msg() == 'hi; code: 56'
+		assert err.str() == 'hi; code: 56'
+		assert err.msg() == 'hi'
 		assert err.code() == 56
 		return
 	}

--- a/vlib/vweb/tests/controller_duplicate_server.v
+++ b/vlib/vweb/tests/controller_duplicate_server.v
@@ -30,7 +30,6 @@ fn main() {
 	}
 	http_port := os.args[1].int()
 	assert http_port > 0
-	timeout := os.args[2].int()
 	mut app_dup := &App{
 		controllers: [
 			vweb.controller('/admin', &Admin{}),


### PR DESCRIPTION
- **builtin: let MessageError.msg() return only the message, make MessageError.str() return both the message and the code of an error**
- **fix warning in vlib/vweb/tests/controller_duplicate_server.v**
- **fix other test failures**


The PR was motivated by https://discord.com/channels/592103645835821068/592320321995014154/1241174911486136372 .