### PR TITLE
tools: default to -cc clang on FreeBSD tests

### DIFF
--- a/cmd/tools/vtest_test.v
+++ b/cmd/tools/vtest_test.v
@@ -13,7 +13,11 @@ fn testsuite_end() {
 }
 
 fn testsuite_begin() {
-	os.setenv('VFLAGS', '', true)
+	$if freebsd {
+		os.setenv('VFLAGS', '-cc clang', true)
+	} $else {
+		os.setenv('VFLAGS', '', true)
+	}
 	os.setenv('VCOLORS', 'never', true)
 	os.setenv('VJOBS', '2', true)
 	os.rmdir_all(tpath) or {}


### PR DESCRIPTION
tcc on FreeBSD does not support `.symver` which causes compile errors for cmd/tools/vtest_test.v.

When this omission gets corrected, we can remove this update but in the mean time, this allows the test to pass.  The choice to use clang as the C compiler is because that is the default compiler distributed with the base FreeBSD system.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the 
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
