### PR TITLE
veb: support sendfile() syscall on FreeBSD

### DIFF
--- a/vlib/veb/sendfile_freebsd.c.v
+++ b/vlib/veb/sendfile_freebsd.c.v
@@ -1,0 +1,12 @@
+module veb
+
+fn C.sendfile(in_fd int, out_fd int, offset int, count int, voidptr offsetp, voidptr hdr, flags int) int
+
+fn sendfile(out_fd int, in_fd int, nr_bytes int) int {
+	// out_fd must be a stream socket descriptor.
+	r := C.sendfile(in_fd, out_fd, 0, nr_bytes, unsafe{nil}, unsafe{nil}, 0)
+	if r == 0 {
+		return nr_bytes
+	}
+	return r
+}

--- a/vlib/veb/sendfile_freebsd.c.v
+++ b/vlib/veb/sendfile_freebsd.c.v
@@ -4,7 +4,7 @@ fn C.sendfile(in_fd int, out_fd int, offset int, count int, voidptr offsetp, voi
 
 fn sendfile(out_fd int, in_fd int, nr_bytes int) int {
 	// out_fd must be a stream socket descriptor.
-	r := C.sendfile(in_fd, out_fd, 0, nr_bytes, unsafe{nil}, unsafe{nil}, 0)
+	r := C.sendfile(in_fd, out_fd, 0, nr_bytes, unsafe { nil }, unsafe { nil }, 0)
 	if r == 0 {
 		return nr_bytes
 	}

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -391,7 +391,7 @@ fn handle_timeout(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 fn handle_write_file(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 	mut bytes_to_write := int(params.file_responses[fd].total - params.file_responses[fd].pos)
 
-	$if linux {
+	$if linux || freebsd {
 		bytes_written := sendfile(fd, params.file_responses[fd].file.fd, bytes_to_write)
 		params.file_responses[fd].pos += bytes_written
 	} $else {

--- a/vlib/x/vweb/sendfile_freebsd.c.v
+++ b/vlib/x/vweb/sendfile_freebsd.c.v
@@ -1,0 +1,12 @@
+module vweb
+
+fn C.sendfile(in_fd int, out_fd int, offset int, count int, voidptr offsetp, voidptr hdr, flags int) int
+
+fn sendfile(out_fd int, in_fd int, nr_bytes int) int {
+	// out_fd must be a stream socket descriptor.
+	r := C.sendfile(in_fd, out_fd, 0, nr_bytes, unsafe{nil}, unsafe{nil}, 0)
+	if r == 0 {
+		return nr_bytes
+	}
+	return r
+}

--- a/vlib/x/vweb/sendfile_freebsd.c.v
+++ b/vlib/x/vweb/sendfile_freebsd.c.v
@@ -4,7 +4,7 @@ fn C.sendfile(in_fd int, out_fd int, offset int, count int, voidptr offsetp, voi
 
 fn sendfile(out_fd int, in_fd int, nr_bytes int) int {
 	// out_fd must be a stream socket descriptor.
-	r := C.sendfile(in_fd, out_fd, 0, nr_bytes, unsafe{nil}, unsafe{nil}, 0)
+	r := C.sendfile(in_fd, out_fd, 0, nr_bytes, unsafe { nil }, unsafe { nil }, 0)
 	if r == 0 {
 		return nr_bytes
 	}

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -391,7 +391,7 @@ fn handle_timeout(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 fn handle_write_file(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 	mut bytes_to_write := int(params.file_responses[fd].total - params.file_responses[fd].pos)
 
-	$if linux {
+	$if linux || freebsd {
 		bytes_written := sendfile(fd, params.file_responses[fd].file.fd, bytes_to_write)
 		params.file_responses[fd].pos += bytes_written
 	} $else {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Use sendfile() on FreeBSD in vlib/veb as well as vlib/x/vweb. This call API is somewhat different from the Linux one so fix up args and return the expected value on linux.  Note that at least `vlib/veb/tests/large_payload_test.v` uses sendfile and succeeds. Use of sendfile can be manually verified by running the test under ktrace.