### PR TITLE
v.scanner: optimise performance, use precomputed tables, and s.substr_unsafe/2 instead of s.substr/2 in .indent_name/0 and .num_lit/2

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,7 +239,7 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+		if util.func_char_table[c] {
 			s.pos++
 			continue
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -528,6 +528,18 @@ fn (mut s Scanner) ident_number() string {
 	}
 }
 
+const nonwhite_space_bytes_table = fill_nonwhite_space_bytes_table()
+
+fn fill_nonwhite_space_bytes_table() [255]bool {
+	mut bytes := [255]bool{}
+	for c in 0 .. 255 {
+		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
+			bytes[c] = true
+		}
+	}
+	return bytes
+}
+
 @[direct_array_access; inline]
 fn (mut s Scanner) skip_whitespace() {
 	for s.pos < s.text.len {
@@ -537,7 +549,7 @@ fn (mut s Scanner) skip_whitespace() {
 			s.pos++
 			continue
 		}
-		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
+		if scanner.nonwhite_space_bytes_table[c] {
 			return
 		}
 		c_is_nl := c == scanner.b_cr || c == scanner.b_lf

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -257,14 +257,14 @@ fn (mut s Scanner) ident_name() string {
 		}
 		break
 	}
-	name := s.text[start..s.pos]
+	name := s.text.substr_unsafe(start, s.pos)
 	s.pos--
 	return name
 }
 
 fn (s Scanner) num_lit(start int, end int) string {
 	if s.is_fmt {
-		return s.text[start..end]
+		return s.text.substr_unsafe(start, end)
 	}
 	unsafe {
 		txt := s.text.str

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,7 +239,7 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if util.func_char_table[c] {
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
 			s.pos++
 			continue
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,7 +239,19 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+		if c >= `a` && c <= `z` {
+			s.pos++
+			continue
+		}
+		if c == `_` {
+			s.pos++
+			continue
+		}
+		if c >= `A` && c <= `Z` {
+			s.pos++
+			continue
+		}
+		if c >= `0` && c <= `9` {
 			s.pos++
 			continue
 		}

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -1,13 +1,34 @@
 module util
 
-@[inline]
-pub fn is_name_char(c u8) bool {
-	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
+pub const name_char_table = get_name_char_table()
+
+fn get_name_char_table() [255]bool {
+	mut res := [255]bool{}
+	for c in 0 .. 255 {
+		res[c] = (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
+	}
+	return res
 }
 
-@[inline]
+pub const func_char_table = get_func_char_table()
+
+fn get_func_char_table() [255]bool {
+	mut res := [255]bool{}
+	for c in 0 .. 255 {
+		res[c] = (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
+			|| (c >= `0` && c <= `9`)
+	}
+	return res
+}
+
+@[direct_array_access; inline]
+pub fn is_name_char(c u8) bool {
+	return util.name_char_table[c]
+}
+
+@[direct_array_access; inline]
 pub fn is_func_char(c u8) bool {
-	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_` || (c >= `0` && c <= `9`)
+	return util.func_char_table[c]
 }
 
 pub fn contains_capital(s string) bool {

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -1,34 +1,13 @@
 module util
 
-pub const name_char_table = get_name_char_table()
-
-fn get_name_char_table() [255]bool {
-	mut res := [255]bool{}
-	for c in 0 .. 255 {
-		res[c] = (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
-	}
-	return res
-}
-
-pub const func_char_table = get_func_char_table()
-
-fn get_func_char_table() [255]bool {
-	mut res := [255]bool{}
-	for c in 0 .. 255 {
-		res[c] = (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
-			|| (c >= `0` && c <= `9`)
-	}
-	return res
-}
-
-@[direct_array_access; inline]
+@[inline]
 pub fn is_name_char(c u8) bool {
-	return util.name_char_table[c]
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
 }
 
-@[direct_array_access; inline]
+@[inline]
 pub fn is_func_char(c u8) bool {
-	return util.func_char_table[c]
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_` || (c >= `0` && c <= `9`)
 }
 
 pub fn contains_capital(s string) bool {


### PR DESCRIPTION
- **v.scanner: use precomputed character tables instead of checks**
- **v.scanner: use util.func_char_table in Scanner.ident_name/0**
- **v.scanner: restore the checks in ident_name, instead of using util.func_char_table**
- **v.scanner: split long condition in ident_name into several smaller ones**
- **v.scanner: use substr_unsafe in Scanner.ident_name/0 and Scanner.num_lit/2**
