### PR TITLE
builtin: make FnExitCb type public

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -1,7 +1,7 @@
 @[has_globals]
 module builtin
 
-type FnExitCb = fn ()
+pub type FnExitCb = fn ()
 
 fn C.atexit(f FnExitCb) int
 fn C.strerror(int) &char


### PR DESCRIPTION
Mainly to have it available in the stdlib docs.