### PR TITLE
builtin: reduce allocations in s.index_kmp/1 and s.replace/2

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -4,7 +4,6 @@
 module builtin
 
 import strconv
-import strings
 
 /*
 Note: A V string should be/is immutable from the point of view of
@@ -338,19 +337,12 @@ pub fn (a string) clone() string {
 }
 
 // replace_once replaces the first occurrence of `rep` with the string passed in `with`.
-@[manualfree]
 pub fn (s string) replace_once(rep string, with string) string {
 	idx := s.index_(rep)
 	if idx == -1 {
 		return s.clone()
 	}
-	mut sb := strings.new_builder(idx + with.len + (s.len - (idx + rep.len)))
-	sb.write_string(s.substr_unsafe(0, idx))
-	sb.write_string(with)
-	sb.write_string(s.substr_unsafe(idx + rep.len, s.len))
-	res := sb.str()
-	unsafe { sb.free() }
-	return res
+	return s.substr(0, idx) + with + s.substr(idx + rep.len, s.len)
 }
 
 const replace_stack_buffer_size = 10

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -355,14 +355,12 @@ pub fn (s string) replace(rep string, with string) string {
 	if !s.contains(rep) {
 		return s.clone()
 	}
-	// TODO: PERF Allocating ints is expensive. Should be a stack array
-	// Get locations of all reps within this string
 	mut pidxs_len := 0
 	pidxs_cap := s.len / rep.len
 	mut stack_idxs := [replace_stack_buffer_size]int{}
 	mut pidxs := unsafe { &stack_idxs[0] }
 	if pidxs_cap > replace_stack_buffer_size {
-		pidxs = unsafe { malloc(sizeof(int) * pidxs_cap) }
+		pidxs = unsafe { &int(malloc(sizeof(int) * pidxs_cap)) }
 	}
 	defer {
 		if pidxs_cap > replace_stack_buffer_size {
@@ -1262,7 +1260,7 @@ fn (s string) index_kmp(p string) int {
 	mut stack_prefixes := [kmp_stack_buffer_size]int{}
 	mut p_prefixes := unsafe { &stack_prefixes[0] }
 	if p.len > kmp_stack_buffer_size {
-		p_prefixes = unsafe { vcalloc(p.len * sizeof(int)) }
+		p_prefixes = unsafe { &int(vcalloc(p.len * sizeof(int))) }
 	}
 	defer {
 		if p.len > kmp_stack_buffer_size {


### PR DESCRIPTION
- **builtin: reduce allocations for s.index_kmp/1 and s.replace_once/2**
- **builtin: reduce allocations for s.replace/2**
- **builtin: restore s.replace_once/2 from master**
