### PR TITLE
builtin, strings: improve consistency and behavior regarding explicit mutability

### DIFF
--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -51,7 +51,7 @@ pub fn (c rune) repeat(count int) string {
 		return c.str()
 	}
 	mut buffer := [5]u8{}
-	res := unsafe { utf32_to_str_no_malloc(u32(c), &buffer[0]) }
+	res := unsafe { utf32_to_str_no_malloc(u32(c), mut &buffer[0]) }
 	return res.repeat(count)
 }
 
@@ -59,7 +59,8 @@ pub fn (c rune) repeat(count int) string {
 @[manualfree]
 pub fn (c rune) bytes() []u8 {
 	mut res := []u8{cap: 5}
-	res.len = unsafe { utf32_decode_to_buffer(u32(c), &u8(res.data)) }
+	mut buf := &u8(res.data)
+	res.len = unsafe { utf32_decode_to_buffer(u32(c), mut buf) }
 	return res
 }
 

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -12,7 +12,7 @@ pub fn utf8_char_len(b u8) int {
 pub fn utf32_to_str(code u32) string {
 	unsafe {
 		mut buffer := malloc_noscan(5)
-		res := utf32_to_str_no_malloc(code, buffer)
+		res := utf32_to_str_no_malloc(code, mut buffer)
 		if res.len == 0 {
 			// the buffer was not used at all
 			free(buffer)
@@ -22,9 +22,9 @@ pub fn utf32_to_str(code u32) string {
 }
 
 @[manualfree; unsafe]
-pub fn utf32_to_str_no_malloc(code u32, buf &u8) string {
+pub fn utf32_to_str_no_malloc(code u32, mut buf &u8) string {
 	unsafe {
-		len := utf32_decode_to_buffer(code, buf)
+		len := utf32_decode_to_buffer(code, mut buf)
 		if len == 0 {
 			return ''
 		}
@@ -34,7 +34,7 @@ pub fn utf32_to_str_no_malloc(code u32, buf &u8) string {
 }
 
 @[manualfree; unsafe]
-pub fn utf32_decode_to_buffer(code u32, buf &u8) int {
+pub fn utf32_decode_to_buffer(code u32, mut buf &u8) int {
 	unsafe {
 		icode := int(code) // Prevents doing casts everywhere
 		mut buffer := &u8(buf)

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -40,7 +40,7 @@ pub fn (mut b Builder) write_ptr(ptr &u8, len int) {
 @[manualfree]
 pub fn (mut b Builder) write_rune(r rune) {
 	mut buffer := [5]u8{}
-	res := unsafe { utf32_to_str_no_malloc(u32(r), &buffer[0]) }
+	res := unsafe { utf32_to_str_no_malloc(u32(r), mut &buffer[0]) }
 	if res.len == 0 {
 		return
 	}
@@ -51,7 +51,7 @@ pub fn (mut b Builder) write_rune(r rune) {
 pub fn (mut b Builder) write_runes(runes []rune) {
 	mut buffer := [5]u8{}
 	for r in runes {
-		res := unsafe { utf32_to_str_no_malloc(u32(r), &buffer[0]) }
+		res := unsafe { utf32_to_str_no_malloc(u32(r), mut &buffer[0]) }
 		if res.len == 0 {
 			continue
 		}

--- a/vlib/v/slow_tests/valgrind/buffer_passed_in_fn_that_uses_tos_on_it.v
+++ b/vlib/v/slow_tests/valgrind/buffer_passed_in_fn_that_uses_tos_on_it.v
@@ -1,7 +1,7 @@
 fn main() {
 	unsafe {
 		mut buffer := malloc_noscan(5)
-		s := utf32_to_str_no_malloc(77, buffer)
+		s := utf32_to_str_no_malloc(77, mut buffer)
 		println(s)
 	}
 }


### PR DESCRIPTION
Will require to pass a buffer arg that is muted as mutable.

The variables that were passed to the updated utf32_ fns were were already declared as mutable, the change makes sure the arg needs to be passed as mutable as well.