### PR TITLE
os: fix debugger_present() for non Windows OSes

### DIFF
--- a/vlib/os/debugger_darwin.c.v
+++ b/vlib/os/debugger_darwin.c.v
@@ -6,12 +6,38 @@ module os
 fn C.ptrace(int, u32, voidptr, int) int
 
 // debugger_present returns a bool indicating if the process is being debugged
-@[inline]
 pub fn debugger_present() bool {
 	// check if the parent could trace its process,
 	// if not a debugger must be present
 	$if macos {
-		return C.ptrace(C.PT_TRACE_ME, 0, voidptr(1), 0) == -1
+		// check if a child process could trace its parent process,
+		// if not a debugger must be present
+		pid := fork()
+		if pid == 0 {
+			ppid := getppid()
+			if C.ptrace(C.PT_TRACE_ME, ppid, unsafe { nil }, 0) == 0 {
+				C.waitpid(ppid, 0, 0)
+
+				// detach ptrace, otherwise further checks would indicate a debugger is present (ptrace is the Debugger then)
+				C.ptrace(C.PT_DETACH, ppid, 0, 0)
+
+				// no external debugger
+				exit(0)
+			} else {
+				// an error occured, a external debugger must be present
+				exit(1)
+			}
+		} else {
+			mut status := 0
+			// wait until child process dies
+			C.waitpid(pid, &status, 0)
+			// check exit code of child process check
+			if C.WEXITSTATUS(status) == 0 {
+				return false
+			} else {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/vlib/os/debugger_darwin.c.v
+++ b/vlib/os/debugger_darwin.c.v
@@ -7,8 +7,6 @@ fn C.ptrace(int, u32, voidptr, int) int
 
 // debugger_present returns a bool indicating if the process is being debugged
 pub fn debugger_present() bool {
-	// check if the parent could trace its process,
-	// if not a debugger must be present
 	$if macos {
 		// check if a child process could trace its parent process,
 		// if not a debugger must be present
@@ -29,9 +27,9 @@ pub fn debugger_present() bool {
 			}
 		} else {
 			mut status := 0
-			// wait until child process dies
+			// wait until the child process dies
 			C.waitpid(pid, &status, 0)
-			// check exit code of child process check
+			// check the exit code of the child process check
 			if C.WEXITSTATUS(status) == 0 {
 				return false
 			} else {

--- a/vlib/os/debugger_freebsd.c.v
+++ b/vlib/os/debugger_freebsd.c.v
@@ -5,12 +5,38 @@ module os
 fn C.ptrace(int, u32, voidptr, int) int
 
 // debugger_present returns a bool indicating if the process is being debugged
-@[inline]
 pub fn debugger_present() bool {
 	// check if the parent could trace its process,
 	// if not a debugger must be present
 	$if freebsd {
-		return C.ptrace(C.PT_TRACE_ME, 0, voidptr(1), 0) == -1
+		// check if a child process could trace its parent process,
+		// if not a debugger must be present
+		pid := fork()
+		if pid == 0 {
+			ppid := getppid()
+			if C.ptrace(C.PT_TRACE_ME, ppid, unsafe { nil }, 0) == 0 {
+				C.waitpid(ppid, 0, 0)
+
+				// detach ptrace, otherwise further checks would indicate a debugger is present (ptrace is the Debugger then)
+				C.ptrace(C.PT_DETACH, ppid, 0, 0)
+
+				// no external debugger
+				exit(0)
+			} else {
+				// an error occured, a external debugger must be present
+				exit(1)
+			}
+		} else {
+			mut status := 0
+			// wait until child process dies
+			C.waitpid(pid, &status, 0)
+			// check exit code of child process check
+			if C.WEXITSTATUS(status) == 0 {
+				return false
+			} else {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/vlib/os/debugger_freebsd.c.v
+++ b/vlib/os/debugger_freebsd.c.v
@@ -6,8 +6,6 @@ fn C.ptrace(int, u32, voidptr, int) int
 
 // debugger_present returns a bool indicating if the process is being debugged
 pub fn debugger_present() bool {
-	// check if the parent could trace its process,
-	// if not a debugger must be present
 	$if freebsd {
 		// check if a child process could trace its parent process,
 		// if not a debugger must be present
@@ -28,9 +26,9 @@ pub fn debugger_present() bool {
 			}
 		} else {
 			mut status := 0
-			// wait until child process dies
+			// wait until the child process dies
 			C.waitpid(pid, &status, 0)
-			// check exit code of child process check
+			// check the exit code of the child process check
 			if C.WEXITSTATUS(status) == 0 {
 				return false
 			} else {

--- a/vlib/os/debugger_linux.c.v
+++ b/vlib/os/debugger_linux.c.v
@@ -30,9 +30,9 @@ pub fn debugger_present() bool {
 				}
 			} else {
 				mut status := 0
-				// wait until child process dies
+				// wait until the child process dies
 				C.waitpid(pid, &status, 0)
-				// check exit code of child process check
+				// check the exit code of the child process check
 				if C.WEXITSTATUS(status) == 0 {
 					return false
 				} else {

--- a/vlib/os/debugger_linux.c.v
+++ b/vlib/os/debugger_linux.c.v
@@ -5,16 +5,40 @@ module os
 fn C.ptrace(u32, u32, voidptr, voidptr) u64
 
 // debugger_present returns a bool indicating if the process is being debugged
-@[inline]
 pub fn debugger_present() bool {
 	$if cross ? {
 		return false
 	}
 	$if !cross ? {
-		// check if the parent could trace its process,
-		// if not a debugger must be present
 		$if linux {
-			return C.ptrace(C.PTRACE_TRACEME, 0, 1, 0) == -1
+			// check if a child process could trace its parent process,
+			// if not a debugger must be present
+			pid := fork()
+			if pid == 0 {
+				ppid := getppid()
+				if C.ptrace(C.PTRACE_ATTACH, ppid, 0, 0) == 0 {
+					C.waitpid(ppid, 0, 0)
+
+					// detach ptrace, otherwise further checks would indicate a debugger is present (ptrace is the Debugger then)
+					C.ptrace(C.PTRACE_DETACH, ppid, 0, 0)
+
+					// no external debugger
+					exit(0)
+				} else {
+					// an error occured, a external debugger must be present
+					exit(1)
+				}
+			} else {
+				mut status := 0
+				// wait until child process dies
+				C.waitpid(pid, &status, 0)
+				// check exit code of child process check
+				if C.WEXITSTATUS(status) == 0 {
+					return false
+				} else {
+					return true
+				}
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
So far the `debugger_present()` function only works partially. All Unix-based systems use the same procedure. `C.ptrace()` is used to check whether the process can “debug” itself. If this is the case, no debugger is present, but `ptrace` is now used as such. If it is called again, the function immediately returns that a debugger is present. However, the appropriate “detach” function cannot be used if the process “follows” itself. 

Current behaviour on non Windows systems:
```v
fn main(){
  if os.debugger_present(){
    println("debugger here")
  }else{
    println("no debugger")
  }

  println("###between os.debugger_present()###")

  if os.debugger_present(){
    println("debugger here")
  }else{
    println("no debugger")
  }
}
```

Output:
```
no debugger
###between os.debugger_present()###
debugger here   <<< this should also be "no debugger"
```

A child process must therefore be created to do this. After checking, it is killed again. The resulting return value is checked and returned. 

Other procedures are dependent on compatible kernels and are not always functional. Windows has its own APIs and already works without problems.

Relevant literature:
- https://stackoverflow.com/questions/3596781/how-to-detect-if-the-current-process-is-being-run-by-gdb
- https://man7.org/linux/man-pages/man2/ptrace.2.html
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}d```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
