### PR TITLE
testing: implement a separate `-show-asserts` option, for cleaner test output (`-stats` still works, and still shows both the compilation stats and the asserts)

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -85,6 +85,7 @@ pub mut:
 	build_tools   bool // builds only executables in cmd/tools; used by `v build-tools'
 	silent_mode   bool
 	show_stats    bool
+	show_asserts  bool
 	progress_mode bool
 	root_relative bool // used by CI runs, so that the output is stable everywhere
 	nmessages     chan LogMessage // many publishers, single consumer/printer
@@ -314,6 +315,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		skip_files: skip_files
 		fail_fast: testing.fail_fast
 		show_stats: '-stats' in vargs.split(' ')
+		show_asserts: '-show-asserts' in vargs.split(' ')
 		vargs: vargs
 		vtmp_dir: new_vtmp_dir
 		hash: hash
@@ -658,6 +660,9 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		mut r := os.execute(run_cmd)
 		cmd_duration = d_cmd.elapsed()
 		ts.append_message_with_duration(.cmd_end, r.output, cmd_duration, mtc)
+		if ts.show_asserts && r.exit_code == 0 {
+			println(r.output.split_into_lines().filter(it.contains(' assert')).join('\n'))
+		}
 		if r.exit_code != 0 {
 			mut details := get_test_details(file)
 			mut trimmed_output := r.output.trim_space()

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -329,11 +329,11 @@ pub fn (v &Builder) get_user_files() []string {
 		}
 		user_files << v_test_runner_prelude
 	}
-	if v.pref.is_test && v.pref.is_stats {
+	if v.pref.is_test && v.pref.show_asserts {
 		user_files << os.join_path(preludes_path, 'tests_with_stats.v')
-	}
-	if v.pref.backend.is_js() && v.pref.is_stats && v.pref.is_test {
-		user_files << os.join_path(preludes_path, 'stats_import.js.v')
+		if v.pref.backend.is_js() {
+			user_files << os.join_path(preludes_path, 'stats_import.js.v')
+		}
 	}
 	if v.pref.is_prof {
 		user_files << os.join_path(preludes_path, 'profiled_program.v')

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -305,7 +305,7 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	mut all_tfuncs := g.get_all_test_function_names()
 	all_tfuncs = g.filter_only_matching_fn_names(all_tfuncs)
 	g.writeln('\tstring v_test_file = ${ctoslit(g.pref.path)};')
-	if g.pref.is_stats {
+	if g.pref.show_asserts {
 		g.writeln('\tmain__BenchedTests bt = main__start_testing(${all_tfuncs.len}, v_test_file);')
 	}
 	g.writeln('')
@@ -328,7 +328,7 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 		g.writeln('\t_vtrunner._method_fn_start(_vtobj);')
 		g.writeln('\tif (!setjmp(g_jump_buffer)) {')
 		//
-		if g.pref.is_stats {
+		if g.pref.show_asserts {
 			g.writeln('\t\tmain__BenchedTests_testing_step_start(&bt, tcname_${tnumber});')
 		}
 		g.writeln('\t\t${tcname}();')
@@ -339,12 +339,12 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 		g.writeln('\t\t_vtrunner._method_fn_fail(_vtobj);')
 		//
 		g.writeln('\t}')
-		if g.pref.is_stats {
+		if g.pref.show_asserts {
 			g.writeln('\tmain__BenchedTests_testing_step_end(&bt);')
 		}
 		g.writeln('')
 	}
-	if g.pref.is_stats {
+	if g.pref.show_asserts {
 		g.writeln('\tmain__BenchedTests_end_testing(&bt);')
 	}
 	g.writeln('')

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -104,7 +104,8 @@ pub mut:
 	is_crun            bool // similar to run, but does not recompile the executable, if there were no changes to the sources
 	is_debug           bool // turned on by -g or -cg, it tells v to pass -g to the C backend compiler.
 	is_vlines          bool // turned on by -g (it slows down .tmp.c generation slightly).
-	is_stats           bool // `v -stats file_test.v` will produce more detailed statistics for the tests that were run
+	is_stats           bool // `v -stats file.v` will produce more detailed statistics for the file that is compiled
+	show_asserts       bool // `VTEST_SHOW_ASSERTS=1 v file_test.v` will show details about the asserts done by a test file. Also activated for `-stats` and `-show-asserts`.
 	show_timings       bool // show how much time each compiler stage took
 	is_fmt             bool
 	is_vet             bool
@@ -361,6 +362,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-show-timings' {
 				res.show_timings = true
+			}
+			'-show-asserts' {
+				res.show_asserts = true
 			}
 			'-check-syntax' {
 				res.only_check_syntax = true
@@ -974,6 +978,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 	if command == 'run' {
 		res.is_run = true
 	}
+	res.show_asserts = res.show_asserts || res.is_stats || os.getenv('VTEST_SHOW_ASSERTS') != ''
 	if command == 'run' && res.is_prod && os.is_atty(1) > 0 {
 		eprintln_cond(show_output && !res.is_quiet, "Note: building an optimized binary takes much longer. It shouldn't be used with `v run`.")
 		eprintln_cond(show_output && !res.is_quiet, 'Use `v run` without optimization, or build an optimized binary with -prod first, then run it separately.')


### PR DESCRIPTION
![image](https://github.com/vlang/v/assets/26967/61181f07-af2b-483b-b8be-ee2c6ef886c5)
