### PR TITLE
ci: extend coverage, move app test from macos_ci to v_apps_and_modules_ci

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -30,7 +30,6 @@ jobs:
     timeout-minutes: 121
     env:
       VFLAGS: -cc clang
-      PKG_CONFIG_PATH: /usr/local/opt/pkgconfig:/usr/local/opt/libpq/lib/pkgconfig:/usr/local/opt/openssl@3/lib/pkgconfig:/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/libpq/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig
     steps:
       - uses: actions/checkout@v4
       - name: Build V
@@ -39,12 +38,6 @@ jobs:
         run: v -cg -cstrict -o v cmd/v
       - name: All code is formatted
         run: VJOBS=1 v test-cleancode
-      - name: Install dependencies
-        run: |
-          echo "PKG_CONFIG_PATH is '$PKG_CONFIG_PATH'"
-          v retry -- brew install libpq openssl mercurial
-          export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/opt/openssl/lib/"
-          echo "LIBRARY_PATH is '$LIBRARY_PATH'"
       - name: Run sanitizers
         run: |
           v -o v2 cmd/v -cflags -fsanitize=undefined
@@ -86,22 +79,6 @@ jobs:
       - name: v doctor
         run: |
           v doctor
-      - name: Test ved
-        run: |
-          v retry -- git clone --depth 1 https://github.com/vlang/ved
-          cd ved && ../v -o ved .
-          ../v -autofree .
-          ../v -prod .
-          cd ..
-      - name: Build V UI examples
-        run: |
-          v retry -- git clone --depth 1 https://github.com/vlang/ui
-          cd ui
-          mkdir -p ~/.vmodules
-          ln -s $(pwd) ~/.vmodules/ui
-          ../v -no-parallel examples/rectangles.v
-          ../v -no-parallel examples/users.v
-          ## ../v run examples/build_examples.vsh
       - name: V self compilation with -usecache
         run: |
           unset VFLAGS

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -132,6 +132,14 @@ jobs:
           # v -cc gcc run /tmp/gitly/tests/first_run.v
           # # /tmp/gitly/gitly -ci_run
 
+      - name: Build V UI examples
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: |
+          v retry -- v install ui
+          v -no-parallel ~/.vmodules/ui/examples/rectangles.v
+          v -no-parallel ~/.vmodules/ui/examples/users.v
+          # v run ~/.vmodules/ui/examples/build_examples.vsh
+
       - name: Build vlang/v-analyzer
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -18,7 +18,11 @@ concurrency:
 
 jobs:
   common:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-12, macos-14]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v4
@@ -29,12 +33,17 @@ jobs:
 
       - name: Install dependencies
         run: |
-          v retry -- sudo apt update
-          v retry -- sudo apt install --quiet -y libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev
-          v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libasound2-dev xfonts-75dpi xfonts-base
-          v retry -- sudo apt install --quiet -y --no-install-recommends sassc libgit2-dev ## needed by gitly
+          if [ $RUNNER_OS == 'Linux' ]; then
+            v retry -- sudo apt -qq update
+            v retry -- sudo apt -qq install libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev
+            v retry -- sudo apt -qq install libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libasound2-dev xfonts-75dpi xfonts-base
+            v retry -- sudo apt -qq install sassc libgit2-dev # needed by gitly
+          else
+            v retry brew install sassc libgit2
+          fi
 
       - name: Test vtcc
+        if: runner.os == 'Linux'
         run: .github/workflows/compile_v_with_vtcc.sh
 
       - name: Test vsql compilation and examples
@@ -150,7 +159,7 @@ jobs:
           fi
 
       - name: Build vlang/go2v
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && matrix.os != 'macos-14' }}
         run: |
           echo "Clone Go2V"
           v retry -- git clone --depth=1 https://github.com/vlang/go2v /tmp/go2v/
@@ -202,7 +211,11 @@ jobs:
       #     v test ~/.vmodules/nedpals/vex
 
   vsl:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12, macos-14]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 121
     env:
       VFLAGS: -no-parallel
@@ -213,10 +226,14 @@ jobs:
         run: make && sudo ./v symlink
       - name: Install dependencies
         run: |
+          if [ $RUNNER_OS == 'Linux' ]; then
           v retry -- sudo apt -qq update
           v retry -- sudo apt -qq install \
             libgc-dev libgl1-mesa-dev mesa-common-dev liblapacke-dev libopenblas-dev libopenmpi-dev \
             opencl-headers libxcursor-dev libxi-dev libhdf5-cpp-103 libhdf5-dev libhdf5-mpi-dev hdf5-tools
+          else
+            v retry brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
+          fi
       - name: Install vsl
         run: v retry -- v install vsl
       - name: Test with Pure V Backend
@@ -225,10 +242,17 @@ jobs:
         run: ~/.vmodules/vsl/bin/test --use-cblas
 
   vtl:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12, macos-14]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 121
     env:
       VFLAGS: -no-parallel
+      # Fixes complaints about $TERM not being set when running the vtl test script
+      # (a warning on Linux, but an error on macOS).
+      TERM: xterm
     steps:
       - uses: actions/checkout@v4
       - name: Build V
@@ -236,9 +260,13 @@ jobs:
         run: make && sudo ./v symlink
       - name: Install dependencies
         run: |
-          v retry -- sudo apt -qq update
-          v retry -- sudo apt -qq install \
-            libgc-dev libgl1-mesa-dev mesa-common-dev liblapacke-dev libopenblas-dev libopenmpi-dev
+          if [ $RUNNER_OS == 'Linux' ]; then
+            v retry -- sudo apt -qq update
+            v retry -- sudo apt -qq install \
+              libgc-dev libgl1-mesa-dev mesa-common-dev liblapacke-dev libopenblas-dev libopenmpi-dev
+          else
+            v retry brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
+          fi
           v retry v install vsl
       - name: Install vtl
         run: v retry v install vtl
@@ -250,7 +278,7 @@ jobs:
   vpm-site:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-12, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -56,6 +56,8 @@ jobs:
             cc: msvc
           - os: macos-12
             cc: clang
+          - os: macos-14
+            cc: clang
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Extends coverage on macOS and Linux

- V Apps and Modules get tested on macOS in `v_apps_and_modules_compile_ci.yml`
- macOS app-tests (ved and vlang/ui) that were tested in `macos_ci.yml` are now part of the above workflow
- vlang/ui examples that were tested on mac are now also tested on Linux
- vpm test runs include macos arm 