### PR TITLE
checker: fix checking of default field initialisations, that are part of unions of structs tagged with `@[noinit]`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -341,6 +341,8 @@ pub:
 	is_deprecated    bool
 pub mut:
 	is_recursive     bool
+	is_part_of_union bool
+	container_typ    Type
 	default_expr     Expr
 	default_expr_typ Type
 	name             string

--- a/vlib/v/tests/modules/structs_with_noinit/shapes.v
+++ b/vlib/v/tests/modules/structs_with_noinit/shapes.v
@@ -1,0 +1,22 @@
+module structs_with_noinit
+
+@[noinit]
+pub struct Image {}
+
+@[noinit]
+pub struct Rect {}
+
+@[noinit]
+pub struct Circle {}
+
+pub fn make_circle() Circle {
+	return Circle{}
+}
+
+pub fn make_image() Image {
+	return Image{}
+}
+
+pub fn make_rect() Rect {
+	return Rect{}
+}

--- a/vlib/v/tests/struct_field_default_union_of_structs_marked_with_noinit_test.v
+++ b/vlib/v/tests/struct_field_default_union_of_structs_marked_with_noinit_test.v
@@ -1,0 +1,44 @@
+module main
+
+import structs_with_noinit
+
+enum RenderableKind {
+	circle
+	image
+	rect
+}
+
+union RenderableValue {
+	circle structs_with_noinit.Circle
+	image  structs_with_noinit.Image
+	rect   structs_with_noinit.Rect
+}
+
+struct Renderable {
+	RenderableValue
+	kind RenderableKind
+}
+
+fn draw(r Renderable) int {
+	match r.kind {
+		.circle {
+			println('()')
+			return 999
+		}
+		.rect {
+			println('[]')
+		}
+		.image {
+			println('o_O')
+		}
+	}
+	return 1
+}
+
+fn test_initialisation_of_a_struct_containing_embedded_union_field() {
+	r := Renderable{
+		kind: .circle
+		circle: structs_with_noinit.make_circle()
+	}
+	assert draw(r) == 999
+}


### PR DESCRIPTION
Fix #21585 .