### PR TITLE
net.urllib: cleanup parse_authority, add test

### DIFF
--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -3,17 +3,6 @@
 // that can be found in the LICENSE file.
 import net.urllib
 
-fn test_net_urllib() {
-	test_url := 'https://joe:pass@www.mydomain.com:8080/som/url?param1=test1&param2=test2&foo=bar#testfragment'
-	u := urllib.parse(test_url) or {
-		assert false
-		return
-	}
-	assert u.scheme == 'https' && u.hostname() == 'www.mydomain.com' && u.port() == '8080'
-		&& u.path == '/som/url' && u.fragment == 'testfragment' && u.user.username == 'joe'
-		&& u.user.password == 'pass'
-}
-
 fn test_str() {
 	url := urllib.parse('https://en.wikipedia.org/wiki/Brazil_(1985_film)') or {
 		panic('unable to parse URL')
@@ -115,12 +104,14 @@ fn test_parse() {
 		'ws://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4000',
 	]
 	for url in urls {
-		_ := urllib.parse(url) or {
-			eprintln(err)
-			assert false
-			return
-		}
+		urllib.parse(url)!
 	}
+
+	test_url := 'https://joe:pass@www.mydomain.com:8080/som/url?param1=test1&param2=test2&foo=bar#testfragment'
+	u := urllib.parse(test_url)!
+	assert u.scheme == 'https' && u.hostname() == 'www.mydomain.com' && u.port() == '8080'
+		&& u.path == '/som/url' && u.fragment == 'testfragment' && u.user.username == 'joe'
+		&& u.user.password == 'pass'
 }
 
 fn test_parse_slashes() {

--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -4,9 +4,6 @@
 import net.urllib
 
 fn test_net_urllib() {
-	test_query := 'Hellö Wörld@vlang'
-	assert urllib.query_escape(test_query) == 'Hell%C3%B6+W%C3%B6rld%40vlang'
-
 	test_url := 'https://joe:pass@www.mydomain.com:8080/som/url?param1=test1&param2=test2&foo=bar#testfragment'
 	u := urllib.parse(test_url) or {
 		assert false
@@ -25,13 +22,16 @@ fn test_str() {
 }
 
 fn test_escape_unescape() {
-	original := 'те ст: т\\%'
-	escaped := urllib.query_escape(original)
+	mut original := 'те ст: т\\%'
+	mut escaped := urllib.query_escape(original)
 	assert escaped == '%D1%82%D0%B5+%D1%81%D1%82%3A+%D1%82%5C%25'
-	unescaped := urllib.query_unescape(escaped) or {
-		assert false
-		return
-	}
+	mut unescaped := urllib.query_unescape(escaped)!
+	assert unescaped == original
+
+	original = 'Hellö Wörld@vlang'
+	escaped = urllib.query_escape(original)
+	assert escaped == 'Hell%C3%B6+W%C3%B6rld%40vlang'
+	unescaped = urllib.query_unescape(escaped)!
 	assert unescaped == original
 }
 

--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -114,6 +114,20 @@ fn test_parse() {
 		&& u.user.password == 'pass'
 }
 
+fn test_parse_authority() {
+	test_urls := {
+		'ftp://webmaster@www.google.com/':            ['webmaster', '']
+		'http://j@ne:password@google.com':            ['j@ne', 'password']
+		'http://jane:p@ssword@google.com/p@th?q=@go': ['jane', 'p@ssword']
+	}
+
+	for url, expected in test_urls {
+		u := urllib.parse(url)!
+		assert u.user.username == expected[0]
+		assert u.user.password == expected[1]
+	}
+}
+
 fn test_parse_slashes() {
 	assert urllib.parse('/')!.str() == '/'
 	assert urllib.parse('//')!.str() == '//'


### PR DESCRIPTION
Updates the internal urllib function `parse_authority` that is used by the public `parse` function. Adds tests.

As far as I could tell the current implementation was based of Go's implementation, which has a different error handling. With V it was possible to make the code more readable while managing to slightly improve the performance at the same time.

<details>
<summary>Performance test:</summary>

```
❯ v repeat -r 20 benchmarks/pa_gcc_new benchmarks/pa_gcc_old
Summary after 1 series x 20 runs (`>` is the first cmd)                                                                                                                            
 >  1       === `benchmarks/pa_gcc_new`
                232.0ms ± σ:   6.6ms, 224.8ms … 254.0ms
    2     +2.5% `benchmarks/pa_gcc_old`
                237.7ms ± σ:   4.3ms, 231.8ms … 251.2ms
```
```
❯ v repeat -r 20 benchmarks/pa_clang_new benchmarks/pa_clang_old
Summary after 1 series x 20 runs (`>` is the first cmd)                                                                                                                            
 >  1       === `benchmarks/pa_clang_new`
                206.1ms ± σ:   2.2ms, 202.2ms … 210.2ms
    2     +1.4% `benchmarks/pa_clang_old`
                209.0ms ± σ:   2.7ms, 204.9ms … 215.4ms
```

```v
import net.urllib

fn main() {
	test_urls := [
		'https://joe:pass@www.mydomain.com:8080/som/url?param1=test1&param2=test2&foo=bar#testfragment',
		'ftp://webmaster@www.google.com/',
		'http://j@ne:password@google.com',
		'http://jane:p@ssword@google.com/p@th?q=@go',
	]

	for _ in 0 .. 100_000 {
		for url in test_urls {
			urllib.parse(url)!
		}
	}
}
```

</details>
