### PR TITLE
fmt: don't break `it` variable name in match expression function calls

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -39,7 +39,7 @@ pub mut:
 	mod2alias          map[string]string // for `import time as t`, will contain: 'time'=>'t'
 	mod2syms           map[string]string // import time { now } 'time.now'=>'now'
 	use_short_fn_args  bool
-	single_line_fields bool   // should struct fields be on a single line
+	single_line_fields bool // should struct fields be on a single line
 	in_lambda_depth    int
 	inside_const       bool
 	inside_unsafe      bool

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -40,7 +40,6 @@ pub mut:
 	mod2syms           map[string]string // import time { now } 'time.now'=>'now'
 	use_short_fn_args  bool
 	single_line_fields bool   // should struct fields be on a single line
-	it_name            string // the name to replace `it` with
 	in_lambda_depth    int
 	inside_const       bool
 	inside_unsafe      bool
@@ -2258,9 +2257,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 		}
 	}
 	f.write_language_prefix(node.language)
-	if node.name == 'it' && f.it_name != '' && f.in_lambda_depth == 0 { // allow `it` in lambdas
-		f.write(f.it_name)
-	} else if node.kind == .blank_ident {
+	if node.kind == .blank_ident {
 		f.write('_')
 	} else {
 		mut is_local := false
@@ -2773,9 +2770,6 @@ fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
 pub fn (mut f Fmt) match_expr(node ast.MatchExpr) {
 	f.write('match ')
 	f.expr(node.cond)
-	if node.cond is ast.Ident {
-		f.it_name = node.cond.name
-	}
 	f.writeln(' {')
 	f.indent++
 	f.comments(node.comments)
@@ -2806,7 +2800,6 @@ pub fn (mut f Fmt) match_expr(node ast.MatchExpr) {
 	}
 	f.indent--
 	f.write('}')
-	f.it_name = ''
 }
 
 pub fn (mut f Fmt) offset_of(node ast.OffsetOf) {


### PR DESCRIPTION
Fixes

```v
import arrays

struct Release {
	version    string
	prerelease bool
}

releases := [Release{'1.0.0-dev', true}, Release{'0.2.0', false}, Release{'0.1.0', false}]

version := 'nightly'
v := match version {
	'nightly' {
		arrays.find_first(releases, fn (it Release) bool {
			return it.prerelease
		})?
	}
	else {
		Release{}
	}
}

dump(v)
```

Where v fmt does
```diff
v := match version {
	'nightly' {
		first_l_match := arrays.find_first(arr, fn (it Foo) bool {
-			return !it.prerelease
+			return !version.prerelease
		})?
	}
}
```


The fix is achieved by removing code whose use was likely superseded and it remained as a hotbed for errors. This assumption is based no breaking tested cases and not being able to trigger what the condition apparently should cover.

