### PR TITLE
net.urllib: update parse host to allow for better error handling

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -578,7 +578,7 @@ fn parse_host(host string) !string {
 	if host.len > 0 && host[0] == `[` {
 		// parse an IP-Literal in RFC 3986 and RFC 6874.
 		// E.g., '[fe80::1]', '[fe80::1%25en0]', '[fe80::1]:80'.
-		mut i := host.index_u8_last(`]`)
+		i := host.index_u8_last(`]`)
 		if i == -1 {
 			return error(error_msg("parse_host: missing ']' in host", ''))
 		}
@@ -594,9 +594,9 @@ fn parse_host(host string) !string {
 		// We do impose some restrictions on the zone, to avoid stupidity
 		// like newlines.
 		if zone := host[..i].index('%25') {
-			host1 := unescape(host[..zone], .encode_host) or { return err.msg() }
-			host2 := unescape(host[zone..i], .encode_zone) or { return err.msg() }
-			host3 := unescape(host[i..], .encode_host) or { return err.msg() }
+			host1 := unescape(host[..zone], .encode_host)!
+			host2 := unescape(host[zone..i], .encode_zone)!
+			host3 := unescape(host[i..], .encode_host)!
 			return host1 + host2 + host3
 		}
 	} else {
@@ -609,10 +609,8 @@ fn parse_host(host string) !string {
 			}
 		}
 	}
-	h := unescape(host, .encode_host) or { return err.msg() }
+	h := unescape(host, .encode_host)!
 	return h
-	// host = h
-	// return host
 }
 
 // set_path sets the path and raw_path fields of the URL based on the provided


### PR DESCRIPTION
Currently, errors in this function are "covered" as the string type that would be returned when the function runs successful.

Using actual error returns is also closer to the Go implementation the function is based on:

Ref.: https://github.com/golang/go/blob/fa08befb25e6f4993021429aa222dad71a27ed07/src/net/url/url.go#L644-L656