### PR TITLE
vfmt: exit with error code if encountering diffs with `-diff` flag

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -145,7 +145,9 @@ fn main() {
 	}
 	ecode := if has_internal_error { 5 } else { 0 }
 	if errors > 0 {
-		eprintln('Encountered a total of: ${errors} formatting errors.')
+		if !foptions.is_diff {
+			eprintln('Encountered a total of: ${errors} formatting errors.')
+		}
 		match true {
 			foptions.is_noerror { exit(0 + ecode) }
 			foptions.is_verify { exit(1 + ecode) }
@@ -245,7 +247,7 @@ fn (mut foptions FormatOptions) post_process_file(file string, formatted_file_pa
 			return
 		}
 		println(diff.compare_files(file, formatted_file_path)!)
-		return
+		return error('')
 	}
 	if foptions.is_verify {
 		if !is_formatted_different {

--- a/examples/hello_world.v
+++ b/examples/hello_world.v
@@ -1,1 +1,1 @@
-println('Hello, World!')
+	println('Hello, World!')

--- a/examples/hello_world.v
+++ b/examples/hello_world.v
@@ -1,1 +1,1 @@
-	println('Hello, World!')
+println('Hello, World!')


### PR DESCRIPTION
Currently, it's hard to combine a diff-output while also verifying that paths are formatted.

Up to now I'm doing contortions like:
```sh
v fmt -verify <path> && exit 0 || v fmt -diff <path> && exit 1
```
`v fmt -verify -diff` is not possible either, since the single flags do return early.


With the changes, the `-diff` flag will cause an exit code 1 if diffs are encountered. This is equivalent to diff tools like `diff`.