### PR TITLE
builtin:  update `last_index_u8`, deprecate `index_u8_last` string methods, make consistent with `last_index`

### DIFF
--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -765,33 +765,23 @@ pub fn (s string) last_index(needle string) ?int {
 	return idx
 }
 
-// TODO: this no longer needs to be a separate method after index_u8_last has been removed.
+// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
+// It returns -1, if `c` is not found.
+@[deprecated: 'use `.last_index_u8(c u8)` instead']
+@[deprecated_after: '2024-06-30']
+pub fn (s string) index_u8_last(c u8) int {
+	return s.last_index_u8(c)
+}
+
+// last_index_u8 returns the index of the last occurrence of byte `c` if it was found in the string.
 @[direct_array_access]
-fn (s string) last_index_u8_(c u8) int {
+pub fn (s string) last_index_u8(c u8) int {
 	for i := s.len - 1; i >= 0; i-- {
 		if s[i] == c {
 			return i
 		}
 	}
 	return -1
-}
-
-// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
-// It returns -1, if `c` is not found.
-@[deprecated: 'use `.last_index_u8(c u8)` instead']
-@[deprecated_after: '2024-06-30']
-pub fn (s string) index_u8_last(c u8) int {
-	return s.last_index_u8_(c)
-}
-
-// last_index_u8 returns the index of the last occurrence of byte `c` if it was found in the string.
-@[inline]
-pub fn (s string) last_index_u8(c u8) ?int {
-	idx := s.last_index_u8_(c)
-	if idx == -1 {
-		return none
-	}
-	return idx
 }
 
 pub fn (s string) trim_space() string {

--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -765,6 +765,35 @@ pub fn (s string) last_index(needle string) ?int {
 	return idx
 }
 
+// TODO: this no longer needs to be a separate method after index_u8_last has been removed.
+@[direct_array_access]
+fn (s string) last_index_u8_(c u8) int {
+	for i := s.len - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
+// It returns -1, if `c` is not found.
+@[deprecated: 'use `.last_index_u8(c u8)` instead']
+@[deprecated_after: '2024-06-30']
+pub fn (s string) index_u8_last(c u8) int {
+	return s.last_index_u8_(c)
+}
+
+// last_index_u8 returns the index of the last occurrence of byte `c` if it was found in the string.
+@[inline]
+pub fn (s string) last_index_u8(c u8) ?int {
+	idx := s.last_index_u8_(c)
+	if idx == -1 {
+		return none
+	}
+	return idx
+}
+
 pub fn (s string) trim_space() string {
 	res := ''
 	#res.str = s.str.trim()
@@ -975,27 +1004,6 @@ pub fn (s string) index(search string) ?int {
 		return none
 	}
 	return res
-}
-
-// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
-// It returns -1, if `c` is not found.
-@[direct_array_access]
-pub fn (s string) index_u8_last(c u8) int {
-	for i := s.len - 1; i >= 0; i-- {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
-}
-
-// last_index_u8 returns the index of the last occurrence of byte `c` if found in the string.
-// It returns -1, if the byte `c` is not found.
-@[deprecated: 'use `.index_u8_last(c u8)` instead']
-@[deprecated_after: '2023-12-18']
-@[inline]
-pub fn (s string) last_index_u8(c u8) int {
-	return s.index_u8_last(c)
 }
 
 pub fn (_rune string) utf32_code() int {

--- a/vlib/builtin/js/string.js.v
+++ b/vlib/builtin/js/string.js.v
@@ -769,6 +769,7 @@ pub fn (s string) last_index(needle string) ?int {
 // It returns -1, if `c` is not found.
 @[deprecated: 'use `.last_index_u8(c u8)` instead']
 @[deprecated_after: '2024-06-30']
+@[inline]
 pub fn (s string) index_u8_last(c u8) int {
 	return s.last_index_u8(c)
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1338,33 +1338,23 @@ pub fn (s string) index_u8(c u8) int {
 	return -1
 }
 
-// TODO: this no longer needs to be a separate method after index_u8_last has been removed.
-@[direct_array_access]
-fn (s string) last_index_u8_(c u8) int {
+// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
+// It returns -1, if `c` is not found.
+@[deprecated: 'use `.last_index_u8(c u8)` instead']
+@[deprecated_after: '2024-06-30']
+pub fn (s string) index_u8_last(c u8) int {
+	return s.last_index_u8(c)
+}
+
+// last_index_u8 returns the index of the last occurrence of byte `c` if it was found in the string.
+@[inline]
+pub fn (s string) last_index_u8(c u8) int {
 	for i := s.len - 1; i >= 0; i-- {
 		if s[i] == c {
 			return i
 		}
 	}
 	return -1
-}
-
-// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
-// It returns -1, if `c` is not found.
-@[deprecated: 'use `.last_index_u8(c u8)` instead']
-@[deprecated_after: '2024-06-30']
-pub fn (s string) index_u8_last(c u8) int {
-	return s.last_index_u8_(c)
-}
-
-// last_index_u8 returns the index of the last occurrence of byte `c` if it was found in the string.
-@[inline]
-pub fn (s string) last_index_u8(c u8) ?int {
-	idx := s.last_index_u8_(c)
-	if idx == -1 {
-		return none
-	}
-	return idx
 }
 
 // count returns the number of occurrences of `substr` in the string.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1342,6 +1342,7 @@ pub fn (s string) index_u8(c u8) int {
 // It returns -1, if `c` is not found.
 @[deprecated: 'use `.last_index_u8(c u8)` instead']
 @[deprecated_after: '2024-06-30']
+@[inline]
 pub fn (s string) index_u8_last(c u8) int {
 	return s.last_index_u8(c)
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1338,25 +1338,33 @@ pub fn (s string) index_u8(c u8) int {
 	return -1
 }
 
-// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
-// It returns -1, if `c` is not found.
+// TODO: this no longer needs to be a separate method after index_u8_last has been removed.
 @[direct_array_access]
-pub fn (s string) index_u8_last(c u8) int {
+fn (s string) last_index_u8_(c u8) int {
 	for i := s.len - 1; i >= 0; i-- {
-		if unsafe { s.str[i] == c } {
+		if s[i] == c {
 			return i
 		}
 	}
 	return -1
 }
 
-// last_index_u8 returns the index of the last occurrence of byte `c` if found in the string.
-// It returns -1, if the byte `c` is not found.
-@[deprecated: 'use `.index_u8_last(c u8)` instead']
-@[deprecated_after: '2023-12-18']
+// index_u8_last returns the index of the *last* occurrence of the byte `c` (if found) in the string.
+// It returns -1, if `c` is not found.
+@[deprecated: 'use `.last_index_u8(c u8)` instead']
+@[deprecated_after: '2024-06-30']
+pub fn (s string) index_u8_last(c u8) int {
+	return s.last_index_u8_(c)
+}
+
+// last_index_u8 returns the index of the last occurrence of byte `c` if it was found in the string.
 @[inline]
-pub fn (s string) last_index_u8(c u8) int {
-	return s.index_u8_last(c)
+pub fn (s string) last_index_u8(c u8) ?int {
+	idx := s.last_index_u8_(c)
+	if idx == -1 {
+		return none
+	}
+	return idx
 }
 
 // count returns the number of occurrences of `substr` in the string.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -1490,7 +1490,7 @@ fn test_index_u8() {
 	//
 }
 
-fn test_index_last() {
+fn test_last_index() {
 	assert 'abcabca'.last_index('ca')? == 5
 	assert 'abcabca'.last_index('ab')? == 3
 	assert 'abcabca'.last_index('b')? == 4
@@ -1500,16 +1500,16 @@ fn test_index_last() {
 	// TODO: `assert 'Zabcabca'.index_last('Y') == none` is a cgen error, 2023/12/04
 }
 
-fn test_index_u8_last() {
-	assert 'abcabca'.index_u8_last(`a`) == 6
-	assert 'abcabca'.index_u8_last(`c`) == 5
-	assert 'abcabca'.index_u8_last(`b`) == 4
-	assert 'Zabcabca'.index_u8_last(`Z`) == 0
+fn test_last_index_u8() {
+	assert 'abcabca'.last_index_u8(`a`) == 6
+	assert 'abcabca'.last_index_u8(`c`) == 5
+	assert 'abcabca'.last_index_u8(`b`) == 4
+	assert 'Zabcabca'.last_index_u8(`Z`) == 0
 	//
-	assert 'abc'.index_u8(`d`) == -1
-	assert 'abc'.index_u8(`A`) == -1
-	assert 'abc'.index_u8(`B`) == -1
-	assert 'abc'.index_u8(`C`) == -1
+	assert 'abc'.last_index_u8(`d`) == -1
+	assert 'abc'.last_index_u8(`A`) == -1
+	assert 'abc'.last_index_u8(`B`) == -1
+	assert 'abc'.last_index_u8(`C`) == -1
 }
 
 fn test_contains_byte() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -1490,7 +1490,7 @@ fn test_index_u8() {
 	//
 }
 
-fn test_last_index() {
+fn test_index_last() {
 	assert 'abcabca'.last_index('ca')? == 5
 	assert 'abcabca'.last_index('ab')? == 3
 	assert 'abcabca'.last_index('b')? == 4
@@ -1500,24 +1500,16 @@ fn test_last_index() {
 	// TODO: `assert 'Zabcabca'.index_last('Y') == none` is a cgen error, 2023/12/04
 }
 
-fn test_last_index_u8() {
-	assert 'abcabca'.last_index_u8(`a`)? == 6
-	assert 'abcabca'.last_index_u8(`c`)? == 5
-	assert 'abcabca'.last_index_u8(`b`)? == 4
-	assert 'Zabcabca'.last_index_u8(`Z`)? == 0
+fn test_index_u8_last() {
+	assert 'abcabca'.index_u8_last(`a`) == 6
+	assert 'abcabca'.index_u8_last(`c`) == 5
+	assert 'abcabca'.index_u8_last(`b`) == 4
+	assert 'Zabcabca'.index_u8_last(`Z`) == 0
 	//
-	if idx := 'abc'.last_index_u8(`d`) {
-		assert false
-	}
-	if idx := 'abc'.last_index_u8(`A`) {
-		assert false
-	}
-	if idx := 'abc'.last_index_u8(`B`) {
-		assert false
-	}
-	if idx := 'abc'.last_index_u8(`C`) {
-		assert false
-	}
+	assert 'abc'.index_u8(`d`) == -1
+	assert 'abc'.index_u8(`A`) == -1
+	assert 'abc'.index_u8(`B`) == -1
+	assert 'abc'.index_u8(`C`) == -1
 }
 
 fn test_contains_byte() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -1490,7 +1490,7 @@ fn test_index_u8() {
 	//
 }
 
-fn test_index_last() {
+fn test_last_index() {
 	assert 'abcabca'.last_index('ca')? == 5
 	assert 'abcabca'.last_index('ab')? == 3
 	assert 'abcabca'.last_index('b')? == 4
@@ -1500,16 +1500,24 @@ fn test_index_last() {
 	// TODO: `assert 'Zabcabca'.index_last('Y') == none` is a cgen error, 2023/12/04
 }
 
-fn test_index_u8_last() {
-	assert 'abcabca'.index_u8_last(`a`) == 6
-	assert 'abcabca'.index_u8_last(`c`) == 5
-	assert 'abcabca'.index_u8_last(`b`) == 4
-	assert 'Zabcabca'.index_u8_last(`Z`) == 0
+fn test_last_index_u8() {
+	assert 'abcabca'.last_index_u8(`a`)? == 6
+	assert 'abcabca'.last_index_u8(`c`)? == 5
+	assert 'abcabca'.last_index_u8(`b`)? == 4
+	assert 'Zabcabca'.last_index_u8(`Z`)? == 0
 	//
-	assert 'abc'.index_u8(`d`) == -1
-	assert 'abc'.index_u8(`A`) == -1
-	assert 'abc'.index_u8(`B`) == -1
-	assert 'abc'.index_u8(`C`) == -1
+	if idx := 'abc'.last_index_u8(`d`) {
+		assert false
+	}
+	if idx := 'abc'.last_index_u8(`A`) {
+		assert false
+	}
+	if idx := 'abc'.last_index_u8(`B`) {
+		assert false
+	}
+	if idx := 'abc'.last_index_u8(`C`) {
+		assert false
+	}
 }
 
 fn test_contains_byte() {

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -534,7 +534,7 @@ struct ParseAuthorityRes {
 }
 
 fn parse_authority(authority string) !ParseAuthorityRes {
-	i := authority.index_u8_last(`@`)
+	i := authority.last_index_u8(`@`)
 	if i < 0 {
 		return ParseAuthorityRes{
 			host: parse_host(authority)!
@@ -564,7 +564,7 @@ fn parse_host(host string) !string {
 	if host.len > 0 && host[0] == `[` {
 		// parse an IP-Literal in RFC 3986 and RFC 6874.
 		// E.g., '[fe80::1]', '[fe80::1%25en0]', '[fe80::1]:80'.
-		i := host.index_u8_last(`]`)
+		i := host.last_index_u8(`]`)
 		if i == -1 {
 			return error(error_msg("parse_host: missing ']' in host", ''))
 		}
@@ -586,7 +586,7 @@ fn parse_host(host string) !string {
 			return host1 + host2 + host3
 		}
 	} else {
-		i := host.index_u8_last(`:`)
+		i := host.last_index_u8(`:`)
 		if i != -1 {
 			colon_port := host[i..]
 			if !valid_optional_port(colon_port) {
@@ -859,7 +859,7 @@ fn resolve_path(base string, ref string) string {
 	if ref == '' {
 		full = base
 	} else if ref[0] != `/` {
-		i := base.index_u8_last(`/`)
+		i := base.last_index_u8(`/`)
 		full = base[..i + 1] + ref
 	} else {
 		full = ref
@@ -993,7 +993,7 @@ pub fn (u &URL) port() string {
 pub fn split_host_port(hostport string) (string, string) {
 	mut host := hostport
 	mut port := ''
-	colon := host.index_u8_last(`:`)
+	colon := host.last_index_u8(`:`)
 	if colon != -1 {
 		if valid_optional_port(host[colon..]) {
 			port = host[colon + 1..]

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -534,8 +534,7 @@ struct ParseAuthorityRes {
 }
 
 fn parse_authority(authority string) !ParseAuthorityRes {
-	i := authority.index_u8_last(`@`)
-	if i < 0 {
+	i := authority.last_index_u8(`@`) or {
 		return ParseAuthorityRes{
 			host: parse_host(authority)!
 			user: user('')
@@ -585,14 +584,11 @@ fn parse_host(host string) !string {
 			host3 := unescape(host[i..], .encode_host)!
 			return host1 + host2 + host3
 		}
-	} else {
-		i := host.index_u8_last(`:`)
-		if i != -1 {
-			colon_port := host[i..]
-			if !valid_optional_port(colon_port) {
-				return error(error_msg('parse_host: invalid port ${colon_port} after host ',
-					''))
-			}
+	} else if i := host.last_index_u8(`:`) {
+		colon_port := host[i..]
+		if !valid_optional_port(colon_port) {
+			return error(error_msg('parse_host: invalid port ${colon_port} after host ',
+				''))
 		}
 	}
 	h := unescape(host, .encode_host)!
@@ -855,14 +851,16 @@ pub fn (v Values) encode() string {
 // resolve_path applies special path segments from refs and applies
 // them to base, per RFC 3986.
 fn resolve_path(base string, ref string) string {
-	mut full := ''
-	if ref == '' {
-		full = base
+	full := if ref == '' {
+		base
 	} else if ref[0] != `/` {
-		i := base.index_u8_last(`/`)
-		full = base[..i + 1] + ref
+		if i := base.last_index_u8(`/`) {
+			base[..i + 1] + ref
+		} else {
+			base + ref
+		}
 	} else {
-		full = ref
+		ref
 	}
 	if full == '' {
 		return ''
@@ -993,8 +991,7 @@ pub fn (u &URL) port() string {
 pub fn split_host_port(hostport string) (string, string) {
 	mut host := hostport
 	mut port := ''
-	colon := host.index_u8_last(`:`)
-	if colon != -1 {
+	if colon := host.last_index_u8(`:`) {
 		if valid_optional_port(host[colon..]) {
 			port = host[colon + 1..]
 			host = host[..colon]

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -266,11 +266,8 @@ pub fn file_ext(opath string) string {
 		return ''
 	}
 	path := file_name(opath)
-	pos := path.index_u8_last(`.`)
-	if pos == -1 {
-		return ''
-	}
-	if pos + 1 >= path.len || pos == 0 {
+	pos := path.last_index_u8(`.`) or { return '' }
+	if pos == 0 || pos + 1 >= path.len {
 		return ''
 	}
 	return path[pos..]

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -266,8 +266,11 @@ pub fn file_ext(opath string) string {
 		return ''
 	}
 	path := file_name(opath)
-	pos := path.last_index_u8(`.`) or { return '' }
-	if pos == 0 || pos + 1 >= path.len {
+	pos := path.index_u8_last(`.`)
+	if pos == -1 {
+		return ''
+	}
+	if pos + 1 >= path.len || pos == 0 {
 		return ''
 	}
 	return path[pos..]

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -266,7 +266,7 @@ pub fn file_ext(opath string) string {
 		return ''
 	}
 	path := file_name(opath)
-	pos := path.index_u8_last(`.`)
+	pos := path.last_index_u8(`.`)
 	if pos == -1 {
 		return ''
 	}

--- a/vlib/semver/parse.v
+++ b/vlib/semver/parse.v
@@ -19,7 +19,8 @@ fn parse(input string) RawVersion {
 	mut raw_version := input
 	mut prerelease := ''
 	mut metadata := ''
-	if plus_idx := raw_version.last_index_u8(`+`) {
+	plus_idx := raw_version.index_u8_last(`+`)
+	if plus_idx > 0 {
 		metadata = raw_version[(plus_idx + 1)..]
 		raw_version = raw_version[0..plus_idx]
 	}

--- a/vlib/semver/parse.v
+++ b/vlib/semver/parse.v
@@ -19,8 +19,7 @@ fn parse(input string) RawVersion {
 	mut raw_version := input
 	mut prerelease := ''
 	mut metadata := ''
-	plus_idx := raw_version.index_u8_last(`+`)
-	if plus_idx > 0 {
+	if plus_idx := raw_version.last_index_u8(`+`) {
 		metadata = raw_version[(plus_idx + 1)..]
 		raw_version = raw_version[0..plus_idx]
 	}

--- a/vlib/semver/parse.v
+++ b/vlib/semver/parse.v
@@ -19,7 +19,7 @@ fn parse(input string) RawVersion {
 	mut raw_version := input
 	mut prerelease := ''
 	mut metadata := ''
-	plus_idx := raw_version.index_u8_last(`+`)
+	plus_idx := raw_version.last_index_u8(`+`)
 	if plus_idx > 0 {
 		metadata = raw_version[(plus_idx + 1)..]
 		raw_version = raw_version[0..plus_idx]

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -449,12 +449,12 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 	// but `x := T{}` is ok.
 	if !c.is_builtin_mod && !c.inside_unsafe && type_sym.language == .v
 		&& c.table.cur_concrete_types.len == 0 {
-		pos := type_sym.name.index_u8_last(`.`)
-		first_letter := type_sym.name[pos + 1]
-		if !first_letter.is_capital() && (type_sym.kind != .struct_
-			|| !(type_sym.info is ast.Struct && type_sym.info.is_anon))
-			&& type_sym.kind != .placeholder {
-			c.error('cannot initialize builtin type `${type_sym.name}`', node.pos)
+		if pos := type_sym.name.last_index_u8(`.`) {
+			if !type_sym.name[pos + 1].is_capital() && (type_sym.kind != .struct_
+				|| !(type_sym.info is ast.Struct && type_sym.info.is_anon))
+				&& type_sym.kind != .placeholder {
+				c.error('cannot initialize builtin type `${type_sym.name}`', node.pos)
+			}
 		}
 		if type_sym.kind == .enum_ && !c.pref.translated && !c.file.is_translated {
 			c.error('cannot initialize enums', node.pos)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -449,12 +449,12 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 	// but `x := T{}` is ok.
 	if !c.is_builtin_mod && !c.inside_unsafe && type_sym.language == .v
 		&& c.table.cur_concrete_types.len == 0 {
-		if pos := type_sym.name.last_index_u8(`.`) {
-			if !type_sym.name[pos + 1].is_capital() && (type_sym.kind != .struct_
-				|| !(type_sym.info is ast.Struct && type_sym.info.is_anon))
-				&& type_sym.kind != .placeholder {
-				c.error('cannot initialize builtin type `${type_sym.name}`', node.pos)
-			}
+		pos := type_sym.name.index_u8_last(`.`)
+		first_letter := type_sym.name[pos + 1]
+		if !first_letter.is_capital() && (type_sym.kind != .struct_
+			|| !(type_sym.info is ast.Struct && type_sym.info.is_anon))
+			&& type_sym.kind != .placeholder {
+			c.error('cannot initialize builtin type `${type_sym.name}`', node.pos)
 		}
 		if type_sym.kind == .enum_ && !c.pref.translated && !c.file.is_translated {
 			c.error('cannot initialize enums', node.pos)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -449,7 +449,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 	// but `x := T{}` is ok.
 	if !c.is_builtin_mod && !c.inside_unsafe && type_sym.language == .v
 		&& c.table.cur_concrete_types.len == 0 {
-		pos := type_sym.name.index_u8_last(`.`)
+		pos := type_sym.name.last_index_u8(`.`)
 		first_letter := type_sym.name[pos + 1]
 		if !first_letter.is_capital() && (type_sym.kind != .struct_
 			|| !(type_sym.info is ast.Struct && type_sym.info.is_anon))

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -302,7 +302,8 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) stri
 				current_segment := g.out.substr(int(sm_pos), int(sourcemap_ns_entry.ns_pos))
 				current_line += u32(current_segment.count('\n'))
 				mut current_column := u32(0)
-				if last_nl_pos := current_segment.last_index_u8(`\n`) {
+				last_nl_pos := current_segment.index_u8_last(`\n`)
+				if last_nl_pos != -1 {
 					current_column = u32(current_segment.len - last_nl_pos - 1)
 				}
 				g.sourcemap.add_mapping(sourcemap_ns_entry.src_path, sourcemap.SourcePosition{
@@ -535,8 +536,11 @@ pub fn (mut g JsGen) new_tmp_var() string {
 // 'fn' => ''
 @[inline]
 fn get_ns(s string) string {
-	i := s.last_index_u8(`.`) or { return '' }
-	return s.substr(0, i)
+	idx := s.index_u8_last(`.`)
+	if idx == -1 {
+		return ''
+	}
+	return s.substr(0, idx)
 }
 
 fn (mut g JsGen) get_alias(name string) string {

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -302,8 +302,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) stri
 				current_segment := g.out.substr(int(sm_pos), int(sourcemap_ns_entry.ns_pos))
 				current_line += u32(current_segment.count('\n'))
 				mut current_column := u32(0)
-				last_nl_pos := current_segment.index_u8_last(`\n`)
-				if last_nl_pos != -1 {
+				if last_nl_pos := current_segment.last_index_u8(`\n`) {
 					current_column = u32(current_segment.len - last_nl_pos - 1)
 				}
 				g.sourcemap.add_mapping(sourcemap_ns_entry.src_path, sourcemap.SourcePosition{
@@ -536,11 +535,8 @@ pub fn (mut g JsGen) new_tmp_var() string {
 // 'fn' => ''
 @[inline]
 fn get_ns(s string) string {
-	idx := s.index_u8_last(`.`)
-	if idx == -1 {
-		return ''
-	}
-	return s.substr(0, idx)
+	i := s.last_index_u8(`.`) or { return '' }
+	return s.substr(0, i)
 }
 
 fn (mut g JsGen) get_alias(name string) string {

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -302,7 +302,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) stri
 				current_segment := g.out.substr(int(sm_pos), int(sourcemap_ns_entry.ns_pos))
 				current_line += u32(current_segment.count('\n'))
 				mut current_column := u32(0)
-				last_nl_pos := current_segment.index_u8_last(`\n`)
+				last_nl_pos := current_segment.last_index_u8(`\n`)
 				if last_nl_pos != -1 {
 					current_column = u32(current_segment.len - last_nl_pos - 1)
 				}
@@ -536,7 +536,7 @@ pub fn (mut g JsGen) new_tmp_var() string {
 // 'fn' => ''
 @[inline]
 fn get_ns(s string) string {
-	idx := s.index_u8_last(`.`)
+	idx := s.last_index_u8(`.`)
 	if idx == -1 {
 		return ''
 	}


### PR DESCRIPTION
Updates the `index_u8_last` => `last_index_u8` method and deprecates the former to be consistent with the recent switch made by Alex from `index_last` to `last_index`. It is also consistent with the Go func equivalents.
