### PR TITLE
ci: use shebang with better portability in shell scripts, format shell scripts

### DIFF
--- a/.github/workflows/build_vinix_locally.sh
+++ b/.github/workflows/build_vinix_locally.sh
@@ -29,28 +29,28 @@ echo "Clone current mlibc"
 
 cd $BUILD
 echo "Patch mlibc for Vinix"
-cd mlibc 
+cd mlibc
 patch -p3 < ../vinix/patches/mlibc/mlibc.patch
 
 cd $BUILD
 echo "Install mlibc headers"
-mkdir mlibc-build 
-cd mlibc-build 
-meson --cross-file ../vinix/cross_file.txt --prefix=/ -Dheaders_only=true ../mlibc 
-ninja 
-mkdir ../mlibc-headers 
+mkdir mlibc-build
+cd mlibc-build
+meson --cross-file ../vinix/cross_file.txt --prefix=/ -Dheaders_only=true ../mlibc
+ninja
+mkdir ../mlibc-headers
 DESTDIR=`realpath ../mlibc-headers` ninja install
 
 cd $BUILD
 echo "Attempt to build the Vinix kernel (debug)"
-cd vinix/kernel 
-make PROD=false CFLAGS="-D__vinix__ -O2 -g -pipe -I../../mlibc-headers/include" 
+cd vinix/kernel
+make PROD=false CFLAGS="-D__vinix__ -O2 -g -pipe -I../../mlibc-headers/include"
 make clean
 
 cd $BUILD
 echo "Attempt to build the Vinix kernel (prod)"
-cd vinix/kernel 
-make PROD=true  CFLAGS="-D__vinix__ -O2 -g -pipe -I../../mlibc-headers/include" 
+cd vinix/kernel
+make PROD=true  CFLAGS="-D__vinix__ -O2 -g -pipe -I../../mlibc-headers/include"
 make clean
 
 rm -rf $BUILD

--- a/.github/workflows/compile_shaders_in_examples.sh
+++ b/.github/workflows/compile_shaders_in_examples.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-for f in examples/sokol/*/ ; do 
-    echo "compiling shaders for $f ...";
-    time ./v shader $f;
+for f in examples/sokol/*/ ; do
+	echo "compiling shaders for $f ...";
+	time ./v shader $f;
 	echo "done";
 done;

--- a/.github/workflows/compile_shaders_in_examples.sh
+++ b/.github/workflows/compile_shaders_in_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for f in examples/sokol/*/ ; do 
     echo "compiling shaders for $f ...";

--- a/.github/workflows/compile_v_with_vtcc.sh
+++ b/.github/workflows/compile_v_with_vtcc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/.github/workflows/compile_v_with_vtcc.sh
+++ b/.github/workflows/compile_v_with_vtcc.sh
@@ -3,7 +3,7 @@
 set -ex
 
 function show() {
-  printf "\u001b[35m$1\u001b[0m\n"
+	printf "\u001b[35m$1\u001b[0m\n"
 }
 
 show "Prepare"
@@ -23,7 +23,7 @@ show "Generate the C file, for the current V version"
 ls -la vlang.c
 
 show "Compile the C file with vtcc"
-export tcclib=thirdparty/tcc/lib/tcc 
+export tcclib=thirdparty/tcc/lib/tcc
 export tccinc=$tcclib/include
 ./vtcc/xx -o v_compiled_with_vtcc vlang.c -L$tcclib -I$tccinc -lc -ldl -pthread -ltcc1 $tcclib/bt-log.o
 ls -la v_compiled_with_vtcc


### PR DESCRIPTION
I was encountering an issue regarding the bash path when trying to give the script with Felipe vtcc a shot locally.
Since not all *nixes have their bash in `/bin/bash`, the updated shebang provides a better coverage across different systems.



