### PR TITLE
checker: fix missing map type definition syntax

### DIFF
--- a/vlib/v/checker/tests/map_def_err.out
+++ b/vlib/v/checker/tests/map_def_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/map_def_err.vv:2:7: error: cannot use the map type without key and value definition
+    1 | struct Foo {
+    2 |   bar map
+      |       ~~~
+    3 | }

--- a/vlib/v/checker/tests/map_def_err.vv
+++ b/vlib/v/checker/tests/map_def_err.vv
@@ -1,0 +1,3 @@
+struct Foo {
+  bar map
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -116,6 +116,11 @@ fn (mut p Parser) parse_map_type() ast.Type {
 	}
 	p.next()
 	if p.tok.kind != .lsbr {
+		if p.inside_struct_field_decl {
+			p.error_with_pos('cannot use the map type without key and value definition',
+				p.prev_tok.pos())
+			return 0
+		}
 		return ast.map_type
 	}
 	p.check(.lsbr)


### PR DESCRIPTION
Fix #21622