### PR TITLE
checker: fix missing option and result wrong type return type definition

### DIFF
--- a/vlib/v/checker/tests/option_and_result_err.out
+++ b/vlib/v/checker/tests/option_and_result_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/option_and_result_err.vv:1:11: error: the type must be Option or Result
+    1 | fn foo() !?i32 {
+      |           ^
+    2 |     return 6
+    3 | }

--- a/vlib/v/checker/tests/option_and_result_err.vv
+++ b/vlib/v/checker/tests/option_and_result_err.vv
@@ -1,0 +1,3 @@
+fn foo() !?i32 {
+	return 6
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -460,9 +460,22 @@ fn (mut p Parser) parse_type() ast.Type {
 	if p.tok.kind == .question {
 		p.next()
 		is_option = true
+		if p.tok.kind == .not {
+			p.next()
+			is_result = true
+		}
 	} else if p.tok.kind == .not {
 		p.next()
 		is_result = true
+		if p.tok.kind == .question {
+			p.next()
+			is_option = true
+		}
+	}
+
+	if is_option && is_result {
+		p.error_with_pos('the type must be Option or Result', p.prev_tok.pos())
+		return 0
 	}
 
 	if is_option || is_result {

--- a/vlib/v/parser/tests/option_result_err.out
+++ b/vlib/v/parser/tests/option_result_err.out
@@ -1,5 +1,5 @@
-vlib/v/parser/tests/option_result_err.vv:2:2: error: invalid expression: unexpected keyword `return`
+vlib/v/parser/tests/option_result_err.vv:1:11: error: the type must be Option or Result
     1 | fn abc() ?!string {
+      |           ^
     2 |     return ''
-      |     ~~~~~~
     3 | }

--- a/vlib/v/parser/tests/result_option_err.out
+++ b/vlib/v/parser/tests/result_option_err.out
@@ -1,5 +1,5 @@
-vlib/v/parser/tests/result_option_err.vv:2:2: error: invalid expression: unexpected keyword `return`
+vlib/v/parser/tests/result_option_err.vv:1:11: error: the type must be Option or Result
     1 | fn abc() ?!string {
+      |           ^
     2 |     return ''
-      |     ~~~~~~
     3 | }


### PR DESCRIPTION
Fix #21618