### PR TITLE
Add "no_bool" macro for clatest language standard

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -681,15 +681,17 @@ typedef u8 array_fixed_byte_300 [300];
 
 typedef struct sync__Channel* chan;
 
-#ifndef __cplusplus
-	#ifndef bool
-		#ifdef CUSTOM_DEFINE_4bytebool
-			typedef int bool;
-		#else
-			typedef u8 bool;
+#ifndef CUSTOM_DEFINE_no_bool
+	#ifndef __cplusplus
+		#ifndef bool
+			#ifdef CUSTOM_DEFINE_4bytebool
+				typedef int bool;
+			#else
+				typedef u8 bool;
+			#endif
+			#define true 1
+			#define false 0
 		#endif
-		#define true 1
-		#define false 0
 	#endif
 #endif
 


### PR DESCRIPTION
"bool" is a builtin type in latest c language standard, added "CUSTOM_DEFINE_no_bool" macro for compatibility.