### PR TITLE
pref: fix regression of command flags not working

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -964,9 +964,6 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				}
 				if command_idx < i && (res.is_vsh || (is_source_file(command)
 					&& command in known_external_commands)) {
-					if is_source_file(command) && os.is_dir(command) {
-						eprintln('Found `${command}` directory the in the working directory.\nUse `v ${command}/` to target it instead of running the V command.')
-					}
 					// When running programs, let them be responsible for the arguments passed to them.
 					// E.g.: `script.vsh cmd -opt` or `v run hello_world.v -opt`.
 					// But detect unknown arguments when building them. E.g.: `v hello_world.v -opt`.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -969,10 +969,6 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// But detect unknown arguments when building them. E.g.: `v hello_world.v -opt`.
 					continue
 				}
-				if command == 'doc' {
-					// Allow for `v doc -comments file.v`
-					continue
-				}
 				err_detail := if command == '' { '' } else { ' for command `${command}`' }
 				eprintln_exit('Unknown argument `${arg}`${err_detail}')
 			}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -962,8 +962,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// arguments for e.g. fmt should be checked elsewhere
 					continue
 				}
-				if res.is_vsh && command_idx < i {
-					// Allow for `script.vsh abc 123 -option`, because -option is for the .vsh program, not for v
+				if command_idx < i && (res.is_vsh || (is_source_file(command) && command in known_external_commands)) {
+					// When running programs, let them be responsible for the arguments passed to them.
+					// E.g.: `script.vsh cmd -opt` or `v run hello_world.v -opt`.
+					// But detect unknown arguments when building them. E.g.: `v hello_world.v -opt`.
 					continue
 				}
 				if command == 'doc' {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -962,7 +962,8 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// arguments for e.g. fmt should be checked elsewhere
 					continue
 				}
-				if command_idx < i && (res.is_vsh || (is_source_file(command) && command in known_external_commands)) {
+				if command_idx < i && (res.is_vsh || (is_source_file(command)
+					&& command in known_external_commands)) {
 					// When running programs, let them be responsible for the arguments passed to them.
 					// E.g.: `script.vsh cmd -opt` or `v run hello_world.v -opt`.
 					// But detect unknown arguments when building them. E.g.: `v hello_world.v -opt`.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -964,6 +964,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				}
 				if command_idx < i && (res.is_vsh || (is_source_file(command)
 					&& command in known_external_commands)) {
+					if is_source_file(command) && os.is_dir(command) {
+						eprintln('Found `${command}` directory the in the working directory.\nUse `v ${command}/` to target it instead of running the V command.')
+					}
 					// When running programs, let them be responsible for the arguments passed to them.
 					// E.g.: `script.vsh cmd -opt` or `v run hello_world.v -opt`.
 					// But detect unknown arguments when building them. E.g.: `v hello_world.v -opt`.


### PR DESCRIPTION
Fixes a regression where it's not possible to run some V commands with flags anymore after #21391. For example, if there is directory with the same name as the command, like having a `fmt` directory in the in the cwd and trying to run v fmt -diff file.v.

```sh
❯ v fmt -diff file.v
Unknown argument `-diff` for command `fmt`
```