### PR TITLE
update details to print either command or option

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -153,7 +153,8 @@ fn main() {
 	all_commands << external_tools
 	all_commands << other_commands
 	all_commands.sort()
-	eprintln(util.new_suggestion(command, all_commands).say('v: unknown command `${command}`'))
+	details := if command != '' { 'command `${command}`' } else { 'option `${args[0]}`' }
+	eprintln(util.new_suggestion(command, all_commands).say('v: unknown ${details}'))
 	eprintln('Run ${term.highlight_command('v help')} for usage.')
 	exit(1)
 }

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -970,6 +970,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// Allow for `v doc -comments file.v`
 					continue
 				}
+				if command_idx == 0 && i == 0 {
+					break
+				}
 				err_detail := if command == '' { '' } else { ' for command `${command}`' }
 				eprintln_exit('Unknown argument `${arg}`${err_detail}')
 			}

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -52,7 +52,7 @@ fn test_v_cmds_and_flags() {
 	assert too_many_targets_res.output.trim_space() == 'Too many targets. Specify just one target: <target.v|target_directory>.'
 
 	unknown_arg_res := os.execute('${vexe} -xyz')
-	assert unknown_arg_res.output.trim_space() == 'Unknown argument `-xyz`'
+	assert unknown_arg_res.output.contains('v: unknown option `-xyz`'), unknown_arg_res.output
 
 	unknown_arg_for_cmd_res := os.execute('${vexe} build-module -xyz ${vroot}/vlib/math')
 	assert unknown_arg_for_cmd_res.output.trim_space() == 'Unknown argument `-xyz` for command `build-module`'

--- a/vlib/v/pref/unknown_options_test.v
+++ b/vlib/v/pref/unknown_options_test.v
@@ -28,8 +28,7 @@ fn test_unknown_option_flags_with_run() {
 
 	res_run_no_o_unknown_before_run := os.execute('${os.quoted_path(@VEXE)} --an-unknown-option run examples/hello_world.v ')
 	assert res_run_no_o_unknown_before_run.exit_code == 1, res_run_no_o_unknown_before_run.output
-	assert res_run_no_o_unknown_before_run.output.starts_with('Unknown argument')
-	assert res_run_no_o_unknown_before_run.output.contains('--an-unknown-option')
+	assert res_run_no_o_unknown_before_run.output.contains('v: unknown option `--an-unknown-option`')
 	assert !os.exists(tfile)
 
 	res_run_no_o := os.execute('${os.quoted_path(@VEXE)} run examples/hello_world.v --an-unknown-option')

--- a/vlib/v/pref/unknown_options_test.v
+++ b/vlib/v/pref/unknown_options_test.v
@@ -8,14 +8,14 @@ fn test_unknown_option_flags_no_run() {
 
 	res1 := os.execute('${os.quoted_path(@VEXE)} -o ${os.quoted_path(tfile)} examples/hello_world.v --an-unknown-option')
 	assert res1.exit_code == 1, res1.output
-	assert res1.output.starts_with('Unknown argument')
-	assert res1.output.contains('--an-unknown-option')
+	assert res1.output.starts_with('Unknown argument'), res1.output
+	assert res1.output.contains('--an-unknown-option'), res1.output
 	assert !os.exists(tfile)
 
 	res2 := os.execute('${os.quoted_path(@VEXE)} -o ${os.quoted_path(tfile)} --an-unknown-option examples/hello_world.v')
 	assert res2.exit_code == 1, res2.output
-	assert res2.output.starts_with('Unknown argument')
-	assert res2.output.contains('--an-unknown-option')
+	assert res2.output.starts_with('Unknown argument'), res2.output
+	assert res2.output.contains('--an-unknown-option'), res2.output
 	assert !os.exists(tfile)
 }
 
@@ -28,7 +28,7 @@ fn test_unknown_option_flags_with_run() {
 
 	res_run_no_o_unknown_before_run := os.execute('${os.quoted_path(@VEXE)} --an-unknown-option run examples/hello_world.v ')
 	assert res_run_no_o_unknown_before_run.exit_code == 1, res_run_no_o_unknown_before_run.output
-	assert res_run_no_o_unknown_before_run.output.contains('v: unknown option `--an-unknown-option`')
+	assert res_run_no_o_unknown_before_run.output.contains('v: unknown option `--an-unknown-option`'), res_run_no_o_unknown_before_run.output
 	assert !os.exists(tfile)
 
 	res_run_no_o := os.execute('${os.quoted_path(@VEXE)} run examples/hello_world.v --an-unknown-option')


### PR DESCRIPTION
Improves errors on unknown arguments. Make passing an unknown option directly after v print a similar message like it does for an known command, pointing to `v help`.

Current:
- Command:
  ```sh
  ❯ v xyz
  v: unknown command `xyz`
  Run  v help  for usage.
  ```
- Options
  ```sh
  ❯ v -xyz
  Unknown argument `-xyz`
  ```

Updated:
- .
  ```sh
  ❯ v -xyz
  v: unknown option `-xyz`
  Run  v help  for usage.
  ```

