### PR TITLE
v.utils: allow to set names of compared items when diffing strings

### DIFF
--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -24,6 +24,14 @@ pub:
 	env_overwrite_var ?string = 'VDIFF_CMD'
 }
 
+@[params]
+pub struct CompareTextOptions {
+	CompareOptions
+pub:
+	base_name string = 'base'
+	target_name string = 'target'
+}
+
 // Default options for `diff` and `colordiff`.
 // Short `diff` args are supported more widely (e.g. on OpenBSD, ref. https://man.openbsd.org/diff.1).
 // `-d -a -U 2` ^= `--minimal --text --unified=2`
@@ -79,15 +87,15 @@ pub fn compare_files(path1 string, path2 string, opts CompareOptions) !string {
 }
 
 // compare_text returns a string displaying the differences between two strings.
-pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
+pub fn compare_text(text1 string, text2 string, opts CompareTextOptions) !string {
 	ctime := time.sys_mono_now()
 	tmp_dir := os.join_path_single(os.vtmp_dir(), ctime.str())
 	os.mkdir(tmp_dir)!
 	defer {
 		os.rmdir_all(tmp_dir) or {}
 	}
-	path1 := os.join_path_single(tmp_dir, 'text1.txt')
-	path2 := os.join_path_single(tmp_dir, 'text2.txt')
+	path1 := os.join_path_single(tmp_dir, opts.base_name)
+	path2 := os.join_path_single(tmp_dir, opts.target_name)
 	// When comparing strings and not files, prevent `\ No newline at end of file` in the output.
 	if !text1.ends_with('\n') || !text2.ends_with('\n') {
 		os.write_file(path1, text1 + '\n')!
@@ -96,7 +104,7 @@ pub fn compare_text(text1 string, text2 string, opts CompareOptions) !string {
 		os.write_file(path1, text1)!
 		os.write_file(path2, text2)!
 	}
-	return compare_files(path1, path2, opts)!
+	return compare_files(path1, path2, opts.CompareOptions)!
 }
 
 fn (opts CompareOptions) find_tool() !(DiffTool, string) {

--- a/vlib/v/util/diff/diff.v
+++ b/vlib/v/util/diff/diff.v
@@ -28,7 +28,7 @@ pub:
 pub struct CompareTextOptions {
 	CompareOptions
 pub:
-	base_name string = 'base'
+	base_name   string = 'base'
 	target_name string = 'target'
 }
 

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -107,6 +107,13 @@ fn test_compare_string() {
 	assert res.contains('-abc'), res
 	assert res.contains('+abcd'), res
 	assert !res.contains('No newline at end of file'), res
+	// Default base and target name.
+	assert res.match_glob("*---*base*"), res
+	assert res.match_glob("*+++*target*"), res
+	// Custom base and target name.
+	res = diff.compare_text('abc', 'abcd', tool: .diff, base_name: 'old.v', target_name: 'new.v')!
+	assert res.match_glob("*---*old.v*"), res
+	assert res.match_glob("*+++*new.v*"), res
 }
 
 fn test_coloring() {

--- a/vlib/v/util/diff/diff_test.v
+++ b/vlib/v/util/diff/diff_test.v
@@ -108,12 +108,12 @@ fn test_compare_string() {
 	assert res.contains('+abcd'), res
 	assert !res.contains('No newline at end of file'), res
 	// Default base and target name.
-	assert res.match_glob("*---*base*"), res
-	assert res.match_glob("*+++*target*"), res
+	assert res.match_glob('*---*base*'), res
+	assert res.match_glob('*+++*target*'), res
 	// Custom base and target name.
 	res = diff.compare_text('abc', 'abcd', tool: .diff, base_name: 'old.v', target_name: 'new.v')!
-	assert res.match_glob("*---*old.v*"), res
-	assert res.match_glob("*+++*new.v*"), res
+	assert res.match_glob('*---*old.v*'), res
+	assert res.match_glob('*+++*new.v*'), res
 }
 
 fn test_coloring() {


### PR DESCRIPTION
Allows further customization when comparing strings.

It adds the ability to set the names that are used for the temporary files when comparing strings directly.


Two main reason:

- Some names in the output can fit better
- Several diff viewers colorize based on on the file extension. E.g. when using delta or piping output like `v fmt -diff file.v | diff-so-fancy` or using other viewers set via `VDIFF_CMD`.

<details>

Filename samples:
|Current default (not customizable)|Updated default|Updated names passed|
|-|-|-|
|![Screenshot_20240606_045034](https://github.com/vlang/v/assets/34311583/d844ec43-8d0e-4d52-8438-cd0d0fb8a4e9)|![Screenshot_20240606_035334](https://github.com/vlang/v/assets/34311583/255883ca-69c1-4625-a30a-5fc6d201f6bd)|![Screenshot_20240606_035502](https://github.com/vlang/v/assets/34311583/5e892cb6-c9ca-4f92-8887-2a98e65c041c)|
  

E.g. using vs not using file extensions:


```v
import v.util.diff

fn main() {
	txt1 := '
sum = num1 + num2
print("The sum of {0} and {1} is {2}".format(num1, num2, sum))
	'
	txt2 := '
sum = num1+num2
print("The sum of {0} and {1} is {2}".format(num1, num2, sum))
	'
	println(diff.compare_text(txt1, txt2)!)
	// println(diff.compare_text(txt1, txt2, base_name: 'old.py', target_name: 'new.py')!)
}
```
|filename not set|colored based on filename|
|-|-|
|![Screenshot_20240606_035942](https://github.com/vlang/v/assets/34311583/ae707839-a4a7-4bad-afaf-a66939638706)|![Screenshot_20240606_040000](https://github.com/vlang/v/assets/34311583/b4468968-3cee-48f7-adb6-ba2acb383dc2)|


Suggestions for other new default names than `base` and `target` are welcome. Those should be general names similar to `text1` and `text2` since it's not always a comparison of e.g. `expected` and `output`.

</details>