### PR TITLE
Use "segoeui.ttf" font if exist on Windows

### DIFF
--- a/vlib/os/font/font.v
+++ b/vlib/os/font/font.v
@@ -28,9 +28,9 @@ pub fn default() string {
 		return env_font
 	}
 	$if windows {
-		if os.exists("C:\\Windows\\Fonts\\segoeui.ttf") {
+		if os.exists('C:\\Windows\\Fonts\\segoeui.ttf') {
 			debug_font_println('Using font "C:\\Windows\\Fonts\\segoeui.ttf"')
-			return "C:\\Windows\\Fonts\\segoeui.ttf"
+			return 'C:\\Windows\\Fonts\\segoeui.ttf'
 		}
 		debug_font_println('Using font "C:\\Windows\\Fonts\\arial.ttf"')
 		return 'C:\\Windows\\Fonts\\arial.ttf'

--- a/vlib/os/font/font.v
+++ b/vlib/os/font/font.v
@@ -28,6 +28,10 @@ pub fn default() string {
 		return env_font
 	}
 	$if windows {
+		if os.exists("C:\\Windows\\Fonts\\segoeui.ttf") {
+			debug_font_println('Using font "C:\\Windows\\Fonts\\segoeui.ttf"')
+			return "C:\\Windows\\Fonts\\segoeui.ttf"
+		}
 		debug_font_println('Using font "C:\\Windows\\Fonts\\arial.ttf"')
 		return 'C:\\Windows\\Fonts\\arial.ttf'
 	}


### PR DESCRIPTION
The PR will change default font to "segoeui.ttf" on Windows. To support legacy Windows versions, it will use Arial font when "segoeui.ttf" is not exist.

It's important to make UI consistent between system and V applications.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
