### PR TITLE
net: add net.Dialer and net.Connection interfaces, abstracting the different types of connections, already supported by the V network stack

### DIFF
--- a/vlib/net/connection.v
+++ b/vlib/net/connection.v
@@ -1,9 +1,9 @@
 module net
 
-// IConn provides a generic SOCK_STREAM style interface that protocols can use
+// Connection provides a generic SOCK_STREAM style interface that protocols can use
 // as a base connection object to support TCP, UNIX Domain Sockets and various
 // proxying solutions.
-pub interface IConn {
+pub interface Connection {
 	addr() !Addr
 	peer_addr() !Addr
 mut:

--- a/vlib/net/connection.v
+++ b/vlib/net/connection.v
@@ -1,0 +1,13 @@
+module net
+
+// IConn provides a generic SOCK_STREAM style interface that protocols can use
+// as a base connection object to support TCP, UNIX Domain Sockets and various
+// proxying solutions.
+pub interface IConn {
+	addr() !Addr
+	peer_addr() !Addr
+mut:
+	read(mut []u8) !int
+	write([]u8) !int
+	close() !
+}

--- a/vlib/net/dialer.v
+++ b/vlib/net/dialer.v
@@ -1,5 +1,6 @@
 module net
 
+// IDialer is an abstract dialer interface for producing connections to adresses.
 pub interface IDialer {
 	dial(address string) !IConn
 }

--- a/vlib/net/dialer.v
+++ b/vlib/net/dialer.v
@@ -1,0 +1,5 @@
+module net
+
+pub interface IDialer {
+	dial(address string) !IConn
+}

--- a/vlib/net/dialer.v
+++ b/vlib/net/dialer.v
@@ -1,6 +1,6 @@
 module net
 
-// IDialer is an abstract dialer interface for producing connections to adresses.
-pub interface IDialer {
-	dial(address string) !IConn
+// Dialer is an abstract dialer interface for producing connections to adresses.
+pub interface Dialer {
+	dial(address string) !Connection
 }

--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -244,6 +244,11 @@ enum Select {
 	except
 }
 
+// close terminates the ssl connection and does cleanup
+pub fn (mut s SSLConn) close() ! {
+	s.shutdown()!
+}
+
 // shutdown terminates the ssl connection and does cleanup
 pub fn (mut s SSLConn) shutdown() ! {
 	$if trace_ssl ? {
@@ -405,6 +410,11 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	}
 
 	s.opened = true
+}
+
+// addr retrieves the local ip address and port number for this connection
+pub fn (s &SSLConn) addr() !net.Addr {
+	return net.addr_from_socket_handle(s.handle)
 }
 
 // peer_addr retrieves the ip address and port number used by the peer

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -51,10 +51,15 @@ enum Select {
 	except
 }
 
+// close closes the ssl connection and does cleanup
+pub fn (mut s SSLConn) close() ! {
+	s.shutdown()!
+}
+
 // shutdown closes the ssl connection and does cleanup
 pub fn (mut s SSLConn) shutdown() ! {
 	$if trace_ssl ? {
-		eprintln(@METHOD)
+		eprintln(@METHODclose)
 	}
 
 	if s.ssl != 0 {
@@ -245,6 +250,11 @@ fn (mut s SSLConn) complete_connect() ! {
 			return error('SSL handshake failed (OpenSSL SSL_get_verify_result = ${res})')
 		}
 	}
+}
+
+// addr retrieves the local ip address and port number for this connection
+pub fn (s &SSLConn) addr() !net.Addr {
+	return net.addr_from_socket_handle(s.handle)
 }
 
 // peer_addr retrieves the ip address and port number used by the peer

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -59,7 +59,7 @@ pub fn (mut s SSLConn) close() ! {
 // shutdown closes the ssl connection and does cleanup
 pub fn (mut s SSLConn) shutdown() ! {
 	$if trace_ssl ? {
-		eprintln(@METHODclose)
+		eprintln(@METHOD)
 	}
 
 	if s.ssl != 0 {

--- a/vlib/net/socks/socks5.v
+++ b/vlib/net/socks/socks5.v
@@ -37,8 +37,7 @@ pub fn socks5_ssl_dial(proxy_url string, host string, username string, password 
 	return ssl_conn
 }
 
-// SOCKS5Dialer implements the IDialer interface initiating connections through
-// a SOCKS5 proxy.
+// SOCKS5Dialer implements the IDialer interface initiating connections through a SOCKS5 proxy.
 pub struct SOCKS5Dialer {
 pub:
 	dialer        net.IDialer

--- a/vlib/net/socks/socks5.v
+++ b/vlib/net/socks/socks5.v
@@ -37,10 +37,10 @@ pub fn socks5_ssl_dial(proxy_url string, host string, username string, password 
 	return ssl_conn
 }
 
-// SOCKS5Dialer implements the IDialer interface initiating connections through a SOCKS5 proxy.
+// SOCKS5Dialer implements the Dialer interface initiating connections through a SOCKS5 proxy.
 pub struct SOCKS5Dialer {
 pub:
-	dialer        net.IDialer
+	dialer        net.Dialer
 	proxy_address string
 	username      string
 	password      string
@@ -50,7 +50,7 @@ pub:
 // initiate connections. An underlying dialer is required to initiate the
 // connection to the proxy server. Most users should use either
 // net.default_tcp_dialer or ssl.create_ssl_dialer.
-pub fn new_socks5_dialer(base net.IDialer, proxy_address string, username string, password string) net.IDialer {
+pub fn new_socks5_dialer(base net.Dialer, proxy_address string, username string, password string) net.Dialer {
 	return &SOCKS5Dialer{
 		dialer: base
 		proxy_address: proxy_address
@@ -60,12 +60,12 @@ pub fn new_socks5_dialer(base net.IDialer, proxy_address string, username string
 }
 
 // dial initiates a new connection through the SOCKS5 proxy.
-pub fn (sd SOCKS5Dialer) dial(address string) !net.IConn {
+pub fn (sd SOCKS5Dialer) dial(address string) !net.Connection {
 	mut conn := sd.dialer.dial(sd.proxy_address)!
 	return handshake(mut conn, address, sd.username, sd.password)!
 }
 
-fn handshake(mut con net.IConn, host string, username string, password string) !net.IConn {
+fn handshake(mut con net.Connection, host string, username string, password string) !net.Connection {
 	mut v := [socks.socks_version5, 1]
 	if username.len > 0 {
 		v << socks.auth_user_password

--- a/vlib/net/socks/socks5_test.v
+++ b/vlib/net/socks/socks5_test.v
@@ -1,7 +1,5 @@
 module socks
 
-import net
-
 fn ipv4_socks() ! {
 	mut v := socks5_dial('127.0.0.1:9150', '1.1.1.1:80', '', '')!
 	assert v != unsafe { nil }

--- a/vlib/net/socks/socks5_test.v
+++ b/vlib/net/socks/socks5_test.v
@@ -1,5 +1,7 @@
 module socks
 
+import net
+
 fn ipv4_socks() ! {
 	mut v := socks5_dial('127.0.0.1:9150', '1.1.1.1:80', '', '')!
 	assert v != unsafe { nil }

--- a/vlib/net/ssl/dialer.v
+++ b/vlib/net/ssl/dialer.v
@@ -1,0 +1,20 @@
+module ssl
+
+import net
+
+pub struct SSLDialer {
+	config SSLConnectConfig
+}
+
+// create_ssl_dialer creates a dialer that will initiate SSL secured
+// connections.
+pub fn new_ssl_dialer(config SSLConnectConfig) net.IDialer {
+	return &SSLDialer{
+		config: config
+	}
+}
+
+// dial initiates a new SSL connection.
+pub fn (d SSLDialer) dial(address string) !net.IConn {
+	return new_ssl_conn(d.config)!
+}

--- a/vlib/net/ssl/dialer.v
+++ b/vlib/net/ssl/dialer.v
@@ -2,7 +2,7 @@ module ssl
 
 import net
 
-// SSLDialer is a concrete instance of the IDialer interface,
+// SSLDialer is a concrete instance of the Dialer interface,
 // for creating SSL socket connections.
 pub struct SSLDialer {
 	config SSLConnectConfig
@@ -10,13 +10,13 @@ pub struct SSLDialer {
 
 // create_ssl_dialer creates a dialer that will initiate SSL secured
 // connections.
-pub fn new_ssl_dialer(config SSLConnectConfig) net.IDialer {
+pub fn new_ssl_dialer(config SSLConnectConfig) net.Dialer {
 	return &SSLDialer{
 		config: config
 	}
 }
 
 // dial initiates a new SSL connection.
-pub fn (d SSLDialer) dial(address string) !net.IConn {
+pub fn (d SSLDialer) dial(address string) !net.Connection {
 	return new_ssl_conn(d.config)!
 }

--- a/vlib/net/ssl/dialer.v
+++ b/vlib/net/ssl/dialer.v
@@ -2,6 +2,8 @@ module ssl
 
 import net
 
+// SSLDialer is a concrete instance of the IDialer interface,
+// for creating SSL socket connections.
 pub struct SSLDialer {
 	config SSLConnectConfig
 }

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -6,18 +6,18 @@ import strings
 pub const tcp_default_read_timeout = 30 * time.second
 pub const tcp_default_write_timeout = 30 * time.second
 
-// TCPDialer is a concrete instance of the IDialer interface,
+// TCPDialer is a concrete instance of the Dialer interface,
 // for creating tcp connections.
 pub struct TCPDialer {}
 
 // dial will try to create a new abstract connection to the given address.
 // It will return an error, if that is not possible.
-pub fn (t TCPDialer) dial(address string) !IConn {
+pub fn (t TCPDialer) dial(address string) !Connection {
 	return dial_tcp(address)!
 }
 
-// default_tcp_dialer will give you an instance of IDialer, that is suitable for making new tcp connections.
-pub fn default_tcp_dialer() IDialer {
+// default_tcp_dialer will give you an instance of Dialer, that is suitable for making new tcp connections.
+pub fn default_tcp_dialer() Dialer {
 	return &TCPDialer{}
 }
 

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -6,6 +6,16 @@ import strings
 pub const tcp_default_read_timeout = 30 * time.second
 pub const tcp_default_write_timeout = 30 * time.second
 
+pub struct TCPDialer {}
+
+pub fn (t TCPDialer) dial(address string) !IConn {
+	return dial_tcp(address)!
+}
+
+pub fn default_tcp_dialer() IDialer {
+	return &TCPDialer{}
+}
+
 @[heap]
 pub struct TcpConn {
 pub mut:

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -6,12 +6,17 @@ import strings
 pub const tcp_default_read_timeout = 30 * time.second
 pub const tcp_default_write_timeout = 30 * time.second
 
+// TCPDialer is a concrete instance of the IDialer interface,
+// for creating tcp connections.
 pub struct TCPDialer {}
 
+// dial will try to create a new abstract connection to the given address.
+// It will return an error, if that is not possible.
 pub fn (t TCPDialer) dial(address string) !IConn {
 	return dial_tcp(address)!
 }
 
+// default_tcp_dialer will give you an instance of IDialer, that is suitable for making new tcp connections.
 pub fn default_tcp_dialer() IDialer {
 	return &TCPDialer{}
 }
@@ -28,6 +33,7 @@ pub mut:
 	is_blocking    bool = true
 }
 
+// dial_tcp will try to create a new TcpConn to the given address.
 pub fn dial_tcp(oaddress string) !&TcpConn {
 	mut address := oaddress
 	$if windows {
@@ -85,7 +91,7 @@ pub fn dial_tcp(oaddress string) !&TcpConn {
 	return error(err_builder.str())
 }
 
-// bind local address and dial.
+// dial_tcp_with_bind will bind the given local address `laddr` and dial.
 pub fn dial_tcp_with_bind(saddr string, laddr string) !&TcpConn {
 	addrs := resolve_addrs_fuzzy(saddr, .tcp) or {
 		return error('${err.msg()}; could not resolve address ${saddr} in dial_tcp_with_bind')
@@ -121,6 +127,7 @@ pub fn dial_tcp_with_bind(saddr string, laddr string) !&TcpConn {
 	return error('dial_tcp_with_bind failed for address ${saddr}')
 }
 
+// close closes the tcp connection
 pub fn (mut c TcpConn) close() ! {
 	$if trace_tcp ? {
 		eprintln('    TcpConn.close | c.sock.handle: ${c.sock.handle:6}')
@@ -128,6 +135,8 @@ pub fn (mut c TcpConn) close() ! {
 	c.sock.close()!
 }
 
+// read_ptr reads data from the tcp connection to the given buffer. It reads at most `len` bytes.
+// It returns the number of actually read bytes, which can vary between 0 to `len`.
 pub fn (c TcpConn) read_ptr(buf_ptr &u8, len int) !int {
 	mut should_ewouldblock := false
 	mut res := $if is_coroutine ? {
@@ -185,6 +194,9 @@ pub fn (c TcpConn) read_ptr(buf_ptr &u8, len int) !int {
 	return error('none')
 }
 
+// read reads data from the tcp connection into the mutable buffer `buf`.
+// The number of bytes read is limited to the length of the buffer `buf.len`.
+// The returned value is the number of read bytes (between 0 and `buf.len`).
 pub fn (c TcpConn) read(mut buf []u8) !int {
 	return c.read_ptr(buf.data, buf.len)!
 }

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -9,6 +9,12 @@ const unix_default_write_timeout = 30 * time.second
 const connect_timeout = 5 * time.second
 const msg_nosignal = 0x4000
 
+pub struct UnixDialer {}
+
+pub fn (u UnixDialer) dial(address string) !net.IConn {
+	return connect_stream(address)!
+}
+
 @[heap]
 pub struct StreamConn {
 pub mut:
@@ -38,6 +44,14 @@ pub fn connect_stream(socket_path string) !&StreamConn {
 		read_timeout: unix.unix_default_read_timeout
 		write_timeout: unix.unix_default_write_timeout
 	}
+}
+
+pub fn (c StreamConn) addr() !net.Addr {
+	return error('not implemented for unix connections')
+}
+
+pub fn (c StreamConn) peer_addr() !net.Addr {
+	return error('not implemented for unix connections')
 }
 
 // close closes the connection

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -9,13 +9,13 @@ const unix_default_write_timeout = 30 * time.second
 const connect_timeout = 5 * time.second
 const msg_nosignal = 0x4000
 
-// UnixDialer is a concrete instance of the IDialer interface,
+// UnixDialer is a concrete instance of the Dialer interface,
 // for creating unix socket connections.
 pub struct UnixDialer {}
 
 // dial will try to create a new abstract connection to the given address.
 // It will return an error, if that is not possible.
-pub fn (u UnixDialer) dial(address string) !net.IConn {
+pub fn (u UnixDialer) dial(address string) !net.Connection {
 	return connect_stream(address)!
 }
 

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -9,8 +9,12 @@ const unix_default_write_timeout = 30 * time.second
 const connect_timeout = 5 * time.second
 const msg_nosignal = 0x4000
 
+// UnixDialer is a concrete instance of the IDialer interface,
+// for creating unix socket connections.
 pub struct UnixDialer {}
 
+// dial will try to create a new abstract connection to the given address.
+// It will return an error, if that is not possible.
 pub fn (u UnixDialer) dial(address string) !net.IConn {
 	return connect_stream(address)!
 }
@@ -46,10 +50,12 @@ pub fn connect_stream(socket_path string) !&StreamConn {
 	}
 }
 
+// addr returns the local address of the stream
 pub fn (c StreamConn) addr() !net.Addr {
 	return error('not implemented for unix connections')
 }
 
+// peer_addr returns the address of the remote peer of the stream
 pub fn (c StreamConn) peer_addr() !net.Addr {
 	return error('not implemented for unix connections')
 }


### PR DESCRIPTION
From my thread on Discord:

> Hey there,
>
> I've recently taken an interest in vlang and I've been looking through the vlib net implementations.  I'm curious if you all would be open to some patches that move away from directly referencing `net.TCPConn` or `ssl.SSLConn` structures and instead work with interfaces (similar to golang).  For instance, I think the introduction of a `net.IDialer` interface as well as a `net.IConn` interface could go a long way to making vlangs net stack extendable, and reduce the amount of code required.
> 
> Taking the socks5.v (https://github.com/vlang/v/blob/master/vlib/net/socks/socks5.v) implementation as an example, today there are multiple entry points - one for TCP, one for SSL, which are required because its tightly bound to the concrete structures from TCP/SSL. There are a number of problems with this if you look at the code.  For instance, what if I want to customize the options passed to the SSL connection?  I'm stuck either going away from vlib or adding additional arguments to the function (which complicates usage and is a headache for existing code bases).  Similarly, what if I wanted to add a SOCKS5 proxy through a UNIX domain socket?  This would be a third entry point in the current code style. 
> 
> Now imagine we had an `net.IDialer` interface which took an address as a string and left it up to the implementation to determine how to make that connection.  As the coder I could pass in an implementation of `IDialer` for TCP (`net.tcp_default_dialer`), SSL (`ssl.default_dialer`), UNIX (`unix.default_dialer`) or even write my own implementation of some other network stack.  Now as a developer I have a lot more control.  I can setup my own SSL dialer implementation that returns SSL connections with whatever settings I want to configure. I could even implement a dialer on top of an HTTP Proxy to tunnel my SOCKS through HTTP first. 
> 
> If this is something the developers would be willing to consider patches for, I'd be willing to try and put some together.


The idea here is to create new interfaces around network connections and then migrate the protocol implementations to work around these interfaces.  This is one of the parts of Golang that makes it so flexible.  This PR  demonstrates a potential interface for dialing new network connections and another potential interface for implementing protocols on top of those connections. 

If the feedback here is favorable I will tackle a larger protocol (HTTP).

**Note**
I don't love the I____ style interface names but I'm trying to propose this in a way that is backwards compatible to existing code written against vlib. If breaking the contract is an option then we can have better names and likely simplify many of the written protocols.