### PR TITLE
builtin: fix string.find_between(), when not found end string return ''

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1653,7 +1653,7 @@ pub fn (s string) find_between(start string, end string) string {
 	val := s[start_pos + start.len..]
 	end_pos := val.index_(end)
 	if end_pos == -1 {
-		return val
+		return ''
 	}
 	return val[..end_pos]
 }

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -44,8 +44,8 @@ fn test_ends_with() {
 fn test_between() {
 	s := 'hello [man] how you doing'
 	assert s.find_between('[', ']') == 'man'
-	assert s.find_between('[','A') == ''
-	assert s.find_between('',']') == ''
+	assert s.find_between('[', 'A') == ''
+	assert s.find_between('A', ']') == ''
 }
 
 fn test_compare() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -44,6 +44,8 @@ fn test_ends_with() {
 fn test_between() {
 	s := 'hello [man] how you doing'
 	assert s.find_between('[', ']') == 'man'
+	assert s.find_between('[','A') == ''
+	assert s.find_between('',']') == ''
 }
 
 fn test_compare() {


### PR DESCRIPTION
`find_between` returns the string found between start string and end string.

When `end` string not found, should return '', not the rest of string.

