### PR TITLE
cgen: fix spawn code generated when calling conditional function

### DIFF
--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -12,6 +12,9 @@ enum SpawnGoMode {
 }
 
 fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
+	if node.call_expr.should_be_skipped {
+		return
+	}
 	is_spawn := mode == .spawn_
 	is_go := mode == .go_
 	if is_spawn {

--- a/vlib/v/tests/spawn_with_cond_fncall_test.v
+++ b/vlib/v/tests/spawn_with_cond_fncall_test.v
@@ -1,0 +1,8 @@
+fn test_main() {
+	spawn print_messages_to_console_while_gg_is_gging()
+}
+
+@[if debug]
+fn print_messages_to_console_while_gg_is_gging() {
+	println('doing something')
+}


### PR DESCRIPTION
Fix #19352