### PR TITLE
vweb, veb, x.vweb: Add m3u8 MIME type

### DIFF
--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -161,6 +161,7 @@ pub const mime_types = {
 	'.3gp':    'video/3gpp'
 	'.3g2':    'video/3gpp2'
 	'.7z':     'application/x-7z-compressed'
+	'.m3u8':   'application/vnd.apple.mpegurl'
 }
 
 pub const max_http_post_size = 1024 * 1024

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -142,6 +142,7 @@ pub const mime_types = {
 	'.3gp':    'video/3gpp'
 	'.3g2':    'video/3gpp2'
 	'.7z':     'application/x-7z-compressed'
+	'.m3u8':   'application/vnd.apple.mpegurl'
 }
 pub const max_http_post_size = 1024 * 1024
 pub const default_port = 8080

--- a/vlib/x/vweb/vweb.v
+++ b/vlib/x/vweb/vweb.v
@@ -162,6 +162,7 @@ pub const mime_types = {
 	'.3gp':    'video/3gpp'
 	'.3g2':    'video/3gpp2'
 	'.7z':     'application/x-7z-compressed'
+	'.m3u8':   'application/vnd.apple.mpegurl'
 }
 
 pub const max_http_post_size = 1024 * 1024


### PR DESCRIPTION
Adds the `M3U8 application/vnd.apple.mpegurl` for HLS video to vweb.

[See this wikipedia page for more info](https://en.wikipedia.org/wiki/M3U#Internet_media_types)