### PR TITLE
cgen: fix dumping array of reference (fix #21690)

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -55,7 +55,7 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		name = name[3..]
 	}
 	dump_fn_name := '_v_dump_expr_${name}' +
-		(if expr_type.is_ptr() { '_ptr'.repeat(expr_type.nr_muls()) } else { '' })
+		(if expr_type.is_ptr() { '__ptr'.repeat(expr_type.nr_muls()) } else { '' })
 	g.write(' ${dump_fn_name}(${ctoslit(fpath)}, ${line}, ${sexpr}, ')
 	if expr_type.has_flag(.shared_f) {
 		g.write('&')
@@ -156,7 +156,7 @@ fn (mut g Gen) dump_expr_definitions() {
 			str_dumparg_ret_type = str_dumparg_type
 		}
 		dump_fn_name := '_v_dump_expr_${name}' +
-			(if is_ptr { '_ptr'.repeat(typ.nr_muls()) } else { '' })
+			(if is_ptr { '__ptr'.repeat(typ.nr_muls()) } else { '' })
 
 		// protect against duplicate declarations:
 		if dump_already_generated_fns[dump_fn_name] {

--- a/vlib/v/slow_tests/inout/dump_array_of_ref.out
+++ b/vlib/v/slow_tests/inout/dump_array_of_ref.out
@@ -1,0 +1,10 @@
+[vlib/v/slow_tests/inout/dump_array_of_ref.vv:6] parents: &[Balise{
+    a: 11
+}, Balise{
+    a: 22
+}]
+[vlib/v/slow_tests/inout/dump_array_of_ref.vv:10] stack: [&Balise{
+    a: 10
+}, &Balise{
+    a: 20
+}]

--- a/vlib/v/slow_tests/inout/dump_array_of_ref.vv
+++ b/vlib/v/slow_tests/inout/dump_array_of_ref.vv
@@ -1,0 +1,16 @@
+struct Balise {
+	a int
+}
+
+fn escape_tag(mut parents []Balise) {
+	dump(parents)
+	mut stack := []&Balise{}
+	stack << &Balise{10}
+	stack << &Balise{20}
+	dump(stack)
+}
+
+fn main() {
+	mut bal := [Balise{11}, Balise{22}]
+	escape_tag(mut bal)
+}


### PR DESCRIPTION
This PR fix dumping array of reference (fix #21690).

- Fix dumping array of reference.
- Add test.

```v
struct Balise {
	a int
}

fn escape_tag(mut parents []Balise) {
	dump(parents)
	mut stack := []&Balise{}
	stack << &Balise{10}
	stack << &Balise{20}
	dump(stack)
}

fn main() {
	mut bal := [Balise{11}, Balise{22}]
	escape_tag(mut bal)
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:6] parents: &[Balise{
    a: 11
}, Balise{
    a: 22
}]
[.\\tt1.v:10] stack: [&Balise{
    a: 10
}, &Balise{
    a: 20
}]
```