### PR TITLE
parser, checker: fix sorting compare fn with mut reference parameter (fix #21662)

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -210,8 +210,8 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			mut s := t.type_to_str(param.typ.clear_flag(.shared_f))
 			if param.is_mut {
 				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
-					|| node.language != .v || !(param.typ.is_int_valptr()
-					|| param.typ.is_bool() || param.typ.has_flag(.option))) {
+					|| node.language != .v
+					|| (param.typ.is_ptr() && t.sym(param.typ).kind == .struct_)) {
 					s = s[1..]
 				}
 			}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -207,7 +207,13 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			}
 			f.write_string('}')
 		} else {
-			mut s := t.type_to_str(param.typ.clear_flag(.shared_f))
+			param_typ := if param.is_mut && !(param.typ.is_int_valptr()
+				|| param.typ.has_flag(.option)) {
+				param.typ.deref()
+			} else {
+				param.typ
+			}
+			mut s := t.type_to_str(param_typ.clear_flag(.shared_f))
 			if param.is_mut {
 				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
 					|| node.language != .v) {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -207,19 +207,14 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			}
 			f.write_string('}')
 		} else {
-			param_typ := if param.is_mut && !(param.typ.is_int_valptr()
-				|| param.typ.has_flag(.option)) {
-				param.typ.deref()
-			} else {
-				param.typ
+			mut s := t.type_to_str(param.typ.clear_flag(.shared_f))
+			if param.is_mut {
+				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
+					|| node.language != .v || !(param.typ.is_int_valptr()
+					|| param.typ.has_flag(.option))) {
+					s = s[1..]
+				}
 			}
-			mut s := t.type_to_str(param_typ.clear_flag(.shared_f))
-			// if param.is_mut {
-			// 	if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
-			// 		|| node.language != .v) {
-			// 		s = s[1..]
-			// 	}
-			// }
 			s = util.no_cur_mod(s, cur_mod)
 			s = shorten_full_name_based_on_aliases(s, m2a)
 			if should_add_type {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -211,7 +211,7 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			if param.is_mut {
 				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
 					|| node.language != .v || !(param.typ.is_int_valptr()
-					|| param.typ.has_flag(.option))) {
+					|| param.typ.is_bool() || param.typ.has_flag(.option))) {
 					s = s[1..]
 				}
 			}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -214,12 +214,12 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 				param.typ
 			}
 			mut s := t.type_to_str(param_typ.clear_flag(.shared_f))
-			if param.is_mut {
-				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
-					|| node.language != .v) {
-					s = s[1..]
-				}
-			}
+			// if param.is_mut {
+			// 	if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
+			// 		|| node.language != .v) {
+			// 		s = s[1..]
+			// 	}
+			// }
 			s = util.no_cur_mod(s, cur_mod)
 			s = shorten_full_name_based_on_aliases(s, m2a)
 			if should_add_type {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -203,6 +203,9 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				.array {
 					if left_sym.kind !in [.sum_type, .interface_] {
 						elem_type := right_final_sym.array_info().elem_type
+						if node.left.is_auto_deref_var() {
+							left_type = left_type.deref()
+						}
 						c.check_expected(left_type, elem_type) or {
 							c.error('left operand to `${node.op}` does not match the array element type: ${err.msg()}',
 								left_right_pos)
@@ -214,6 +217,9 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 							}
 						} else {
 							elem_type := right_final_sym.array_info().elem_type
+							if node.left.is_auto_deref_var() {
+								left_type = left_type.deref()
+							}
 							c.check_expected(left_type, elem_type) or {
 								c.error('left operand to `${node.op}` does not match the array element type: ${err.msg()}',
 									left_right_pos)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -943,7 +943,8 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 					p.error_with_pos('generic object cannot be `atomic`or `shared`', pos)
 					return []ast.Param{}, false, false
 				}
-				if param_type.is_int_valptr() || param_type.has_flag(.option) {
+				if param_type.is_int_valptr() || param_type.is_bool()
+					|| param_type.has_flag(.option) || p.pref.translated || p.is_translated {
 					param_type = param_type.set_nr_muls(1)
 				} else {
 					param_type = param_type.ref()
@@ -1063,7 +1064,8 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 						pos)
 					return []ast.Param{}, false, false
 				}
-				if typ.is_int_valptr() || typ.has_flag(.option) {
+				if typ.is_int_valptr() || typ.is_bool() || typ.has_flag(.option)
+					|| p.pref.translated || p.is_translated {
 					typ = typ.set_nr_muls(1)
 				} else {
 					typ = typ.ref()

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -943,11 +943,10 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 					p.error_with_pos('generic object cannot be `atomic`or `shared`', pos)
 					return []ast.Param{}, false, false
 				}
-				if param_type.is_int_valptr() || param_type.is_bool()
-					|| param_type.has_flag(.option) || p.pref.translated || p.is_translated {
-					param_type = param_type.set_nr_muls(1)
-				} else {
+				if param_type.is_ptr() && p.table.sym(param_type).kind == .struct_ {
 					param_type = param_type.ref()
+				} else {
+					param_type = param_type.set_nr_muls(1)
 				}
 				if is_shared {
 					param_type = param_type.set_flag(.shared_f)
@@ -1064,11 +1063,10 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 						pos)
 					return []ast.Param{}, false, false
 				}
-				if typ.is_int_valptr() || typ.is_bool() || typ.has_flag(.option)
-					|| p.pref.translated || p.is_translated {
-					typ = typ.set_nr_muls(1)
-				} else {
+				if typ.is_ptr() && p.table.sym(typ).kind == .struct_ {
 					typ = typ.ref()
+				} else {
+					typ = typ.set_nr_muls(1)
 				}
 				if is_shared {
 					typ = typ.set_flag(.shared_f)

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -943,11 +943,11 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 					p.error_with_pos('generic object cannot be `atomic`or `shared`', pos)
 					return []ast.Param{}, false, false
 				}
-				// if arg_type.is_ptr() {
-				// p.error('cannot mut')
-				// }
-				// arg_type = arg_type.ref()
-				param_type = param_type.set_nr_muls(1)
+				if param_type.is_int_valptr() || param_type.has_flag(.option) {
+					param_type = param_type.set_nr_muls(1)
+				} else {
+					param_type = param_type.ref()
+				}
 				if is_shared {
 					param_type = param_type.set_flag(.shared_f)
 				}
@@ -1063,7 +1063,11 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 						pos)
 					return []ast.Param{}, false, false
 				}
-				typ = typ.set_nr_muls(1)
+				if typ.is_int_valptr() || typ.has_flag(.option) {
+					typ = typ.set_nr_muls(1)
+				} else {
+					typ = typ.ref()
+				}
 				if is_shared {
 					typ = typ.set_flag(.shared_f)
 				}

--- a/vlib/v/tests/sorting_compare_fn_with_mut_reference_test.v
+++ b/vlib/v/tests/sorting_compare_fn_with_mut_reference_test.v
@@ -1,7 +1,7 @@
 struct Thing {
 mut:
-	a int = 2
-	b int = 4
+	a  int = 2
+	b  int = 4
 	av int
 }
 

--- a/vlib/v/tests/sorting_compare_fn_with_mut_reference_test.v
+++ b/vlib/v/tests/sorting_compare_fn_with_mut_reference_test.v
@@ -1,0 +1,40 @@
+struct Thing {
+mut:
+	a int = 2
+	b int = 4
+	av int
+}
+
+fn (mut t Thing) average() int {
+	t.av = (t.a + t.b) / 2
+	return t.av
+}
+
+struct Things {
+mut:
+	items []&Thing
+}
+
+fn (mut t Things) sort() {
+	t.items.sort_with_compare(fn (mut a &Thing, mut b &Thing) int {
+		if a.average() > b.average() {
+			return 1
+		} else if a.average() < b.average() {
+			return -1
+		}
+		return 0
+	})
+}
+
+fn test_sort_compare_fn_with_mut_ref_param() {
+	mut t := Things{}
+	t.items << &Thing{2, 4, 0}
+	t.items << &Thing{5, 7, 0}
+	t.items << &Thing{1, 2, 0}
+	t.sort()
+	println(t)
+	assert t.items.len == 3
+	assert t.items[0] == &Thing{1, 2, 1}
+	assert t.items[1] == &Thing{2, 4, 3}
+	assert t.items[2] == &Thing{5, 7, 6}
+}


### PR DESCRIPTION
This PR fix sorting compare fn with mut reference parameter (fix #21662).

- Fix sorting compare fn with mut reference parameter.
- Add test.

```v
struct Thing {
mut:
	a  int = 2
	b  int = 4
	av int
}

fn (mut t Thing) average() int {
	t.av = (t.a + t.b) / 2
	return t.av
}

struct Things {
mut:
	items []&Thing
}

fn (mut t Things) sort() {
	t.items.sort_with_compare(fn (mut a &Thing, mut b &Thing) int {
		if a.average() > b.average() {
			return 1
		} else if a.average() < b.average() {
			return -1
		}
		return 0
	})
}

fn main() {
	mut t := Things{}
	t.items << &Thing{2, 4, 0}
	t.items << &Thing{5, 7, 0}
	t.items << &Thing{1, 2, 0}
	t.sort()
	println(t)
	assert t.items.len == 3
	assert t.items[0] == &Thing{1, 2, 1}
	assert t.items[1] == &Thing{2, 4, 3}
	assert t.items[2] == &Thing{5, 7, 6}
}

PS D:\Test\v\tt1> v run .
Things{
    items: [&Thing{
    a: 1
    b: 2
    av: 1
}, &Thing{
    a: 2
    b: 4
    av: 3
}, &Thing{
    a: 5
    b: 7
    av: 6
}]
}
```