### PR TITLE
fmt: add fn_with_mut_ref_params_keep.vv (related #21706)

### DIFF
--- a/vlib/v/fmt/tests/fn_with_mut_ref_params_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_mut_ref_params_keep.vv
@@ -1,0 +1,11 @@
+struct Bar {}
+
+fn in_both_mut_ref(mut arr []&Bar, mut bar &Bar) {
+	assert bar !in arr
+}
+
+fn main() {
+	mut arr := []&Bar{}
+	mut bar := Bar{}
+	in_both_mut_ref(mut &arr, mut &bar)
+}

--- a/vlib/v/tests/in_expression_test.v
+++ b/vlib/v/tests/in_expression_test.v
@@ -331,7 +331,6 @@ fn test_in_array_of_sumtype() {
 // for issue 20268
 struct Bar {}
 
-// vfmt off
 fn in_both_mut_ref(mut arr []&Bar, mut bar &Bar) {
 	assert bar !in arr
 }
@@ -341,4 +340,3 @@ fn test_in_both_mut_and_ref() {
 	mut bar := Bar{}
 	in_both_mut_ref(mut &arr, mut &bar)
 }
-// vfmt on


### PR DESCRIPTION
This PR add fn_with_mut_ref_params_keep.vv (related #21706).

- fn_with_mut_ref_params_keep.vv
```v
struct Bar {}

fn in_both_mut_ref(mut arr []&Bar, mut bar &Bar) {
	assert bar !in arr
}

fn main() {
	mut arr := []&Bar{}
	mut bar := Bar{}
	in_both_mut_ref(mut &arr, mut &bar)
}
```