### PR TITLE
checker: fix result call or_block with multi-statements (fix #21504)

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -123,7 +123,7 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 			// check each arg expression
 			node.args[i].typ = c.expr(mut arg.expr)
 		}
-		c.stmts_ending_with_expression(mut node.or_block.stmts)
+		c.stmts_ending_with_expression(mut node.or_block.stmts, c.expected_or_type)
 		return c.comptime.get_comptime_var_type(node)
 	}
 	if node.method_name == 'res' {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -600,7 +600,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 		}
 	}
 	c.expected_or_type = node.return_type.clear_flag(.result)
-	c.stmts_ending_with_expression(mut node.or_block.stmts)
+	c.stmts_ending_with_expression(mut node.or_block.stmts, c.expected_or_type)
 	c.expected_or_type = ast.void_type
 
 	if !c.inside_const && c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.is_main

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -324,7 +324,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			}
 			if !c.skip_flags {
 				if node_is_expr {
-					c.stmts_ending_with_expression(mut branch.stmts)
+					c.stmts_ending_with_expression(mut branch.stmts, c.expected_or_type)
 				} else {
 					c.stmts(mut branch.stmts)
 					c.check_non_expr_branch_last_stmt(branch.stmts)
@@ -341,7 +341,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					node.branches[i].stmts = []
 				}
 				if node_is_expr {
-					c.stmts_ending_with_expression(mut branch.stmts)
+					c.stmts_ending_with_expression(mut branch.stmts, c.expected_or_type)
 				} else {
 					c.stmts(mut branch.stmts)
 					c.check_non_expr_branch_last_stmt(branch.stmts)
@@ -364,7 +364,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			// smartcast sumtypes and interfaces when using `is`
 			c.smartcast_if_conds(mut branch.cond, mut branch.scope)
 			if node_is_expr {
-				c.stmts_ending_with_expression(mut branch.stmts)
+				c.stmts_ending_with_expression(mut branch.stmts, c.expected_or_type)
 			} else {
 				c.stmts(mut branch.stmts)
 				c.check_non_expr_branch_last_stmt(branch.stmts)

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -757,7 +757,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					c.error('cannot push `${c.table.type_to_str(right_type)}` on `${left_sym.name}`',
 						right_pos)
 				}
-				c.stmts_ending_with_expression(mut node.or_block.stmts)
+				c.stmts_ending_with_expression(mut node.or_block.stmts, c.expected_or_type)
 			} else {
 				c.error('cannot push on non-channel `${left_sym.name}`', left_pos)
 			}

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -43,7 +43,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	mut nbranches_without_return := 0
 	for mut branch in node.branches {
 		if node.is_expr {
-			c.stmts_ending_with_expression(mut branch.stmts)
+			c.stmts_ending_with_expression(mut branch.stmts, c.expected_or_type)
 		} else {
 			c.stmts(mut branch.stmts)
 		}

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -626,7 +626,7 @@ fn (mut c Checker) check_orm_or_expr(mut expr ORMExpr) {
 
 	if expr.or_expr.kind == .block {
 		c.expected_or_type = return_type.clear_flag(.result)
-		c.stmts_ending_with_expression(mut expr.or_expr.stmts)
+		c.stmts_ending_with_expression(mut expr.or_expr.stmts, c.expected_or_type)
 		c.expected_or_type = ast.void_type
 	}
 }

--- a/vlib/v/tests/result_call_or_block_with_stmts_test.v
+++ b/vlib/v/tests/result_call_or_block_with_stmts_test.v
@@ -1,0 +1,28 @@
+fn str_ret_fn(str string) string {
+	return str
+}
+
+fn foo(str string) !string {
+	if str.contains('foo') {
+		return str
+	}
+	return error('error')
+}
+
+fn test_result_call_or_block_with_stmts() {
+	var := foo('bar') or {
+		foo_var := str_ret_fn('foo')
+		if foo_var == 'foo' {
+			foo(foo_var) or {
+				eprintln(err)
+				exit(1)
+			}
+		} else {
+			eprintln(err)
+			exit(1)
+		}
+	}
+
+	println(var)
+	assert var == 'foo'
+}


### PR DESCRIPTION
This PR fix result call or_block with multi-statements (fix #21504).

- Fix result call or_block with multi-statements.
- Add test.

```v
fn str_ret_fn(str string) string {
	return str
}

fn foo(str string) !string {
	if str.contains('foo') {
		return str
	}
	return error('error')
}

fn main() {
	var := foo('bar') or {
		foo_var := str_ret_fn('foo')
		if foo_var == 'foo' {
			foo(foo_var) or {
				eprintln(err)
				exit(1)
			}
		} else {
			eprintln(err)
			exit(1)
		}
	}

	println(var)
	assert var == 'foo'
}

PS D:\Test\v\tt1> v run .
foo
```