### PR TITLE
checker, cgen: fix auto dereference mut variable in if expr (fix #21309)

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -420,7 +420,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						if node.typ == ast.void_type {
 							// first branch of if expression
 							node.is_expr = true
-							node.typ = stmt.typ
+							if stmt.expr.is_auto_deref_var() {
+								node.typ = stmt.typ.deref()
+							} else {
+								node.typ = stmt.typ
+							}
 							continue
 						} else if node.typ in [ast.float_literal_type, ast.int_literal_type] {
 							if node.typ == ast.int_literal_type {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2186,6 +2186,9 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 			// }
 			old_is_void_expr_stmt := g.is_void_expr_stmt
 			g.is_void_expr_stmt = !node.is_expr
+			if node.expr.is_auto_deref_var() {
+				g.write('*')
+			}
 			if node.typ != ast.void_type && g.expected_cast_type != 0
 				&& node.expr !in [ast.IfExpr, ast.MatchExpr] {
 				g.expr_with_cast(node.expr, node.typ, g.expected_cast_type)

--- a/vlib/v/tests/deref_mut_variable_in_if_expr_test.v
+++ b/vlib/v/tests/deref_mut_variable_in_if_expr_test.v
@@ -1,0 +1,17 @@
+struct Foo {
+	str string
+}
+
+fn (mut f Foo) foo(f2 Foo) string {
+	return (if f.str != '' {
+		f
+	} else {
+		f2
+	}).str
+}
+
+fn test_deref_mut_var_in_if_expr() {
+	mut foo := Foo{}
+	dump(foo.foo(Foo{ str: 'a' }))
+	assert foo.foo(Foo{ str: 'a' }) == 'a'
+}


### PR DESCRIPTION
This PR fix auto dereference mut variable in if expr (fix #21309).

- Fix auto dereference mut variable in if expr.
- Add test.

```v
struct Foo {
	str string
}

fn (mut f Foo) foo(f2 Foo) string {
	return (if f.str != '' {
		f
	} else {
		f2
	}).str
}

fn main() {
	mut foo := Foo{}
	dump(foo.foo(Foo{ str: 'a' }))
	assert foo.foo(Foo{ str: 'a' }) == 'a'
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:15] foo.foo(main.Foo{....}): a
```