### PR TITLE
cgen: fix assert checking fn option ret with `none`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2048,9 +2048,11 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 					((expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
 					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ.has_flag(.option))
 					|| (expr_typ == ret_typ && !(expr_typ.has_option_or_result()
-					&& (expr_typ.is_ptr() || g.table.type_kind(ret_typ) == .placeholder)))
+					&& (expr_typ.is_ptr() || expr is ast.LambdaExpr)))
 				// option ptr assignment simplification
 				if simple_assign {
+					println(g.table.type_kind(ret_typ))
+					println(expr)
 					g.write('${tmp_var} = ')
 				} else if expr_typ.has_flag(.option) && expr is ast.PrefixExpr
 					&& expr.right is ast.StructInit

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2051,8 +2051,6 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 					&& (expr_typ.is_ptr() || expr is ast.LambdaExpr)))
 				// option ptr assignment simplification
 				if simple_assign {
-					println(g.table.type_kind(ret_typ))
-					println(expr)
 					g.write('${tmp_var} = ')
 				} else if expr_typ.has_flag(.option) && expr is ast.PrefixExpr
 					&& expr.right is ast.StructInit

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2045,8 +2045,9 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				}
 			} else {
 				simple_assign =
-					(expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
-					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ.has_flag(.option)
+					((expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
+					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ.has_flag(.option))
+					|| expr_typ == ret_typ
 				// option ptr assignment simplification
 				if simple_assign {
 					g.write('${tmp_var} = ')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2047,8 +2047,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				simple_assign =
 					((expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
 					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ.has_flag(.option))
-					|| (expr_typ == ret_typ && !(expr_typ.is_ptr()
-					&& expr_typ.has_option_or_result()))
+					|| (expr_typ == ret_typ && !(expr_typ.has_option_or_result()
+					&& (expr_typ.is_ptr() || g.table.type_kind(ret_typ) == .placeholder)))
 				// option ptr assignment simplification
 				if simple_assign {
 					g.write('${tmp_var} = ')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2047,7 +2047,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				simple_assign =
 					((expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
 					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ.has_flag(.option))
-					|| expr_typ == ret_typ
+					|| (expr_typ == ret_typ && !(expr_typ.is_ptr()
+					&& expr_typ.has_option_or_result()))
 				// option ptr assignment simplification
 				if simple_assign {
 					g.write('${tmp_var} = ')

--- a/vlib/v/gen/c/ctempvars.v
+++ b/vlib/v/gen/c/ctempvars.v
@@ -22,4 +22,5 @@ fn (mut g Gen) gen_ctemp_var(tvar ast.CTempVar) {
 	g.write('${styp} ${tvar.name} = ')
 	g.expr(tvar.orig)
 	g.writeln(';')
+	g.set_current_pos_as_last_stmt_pos()
 }

--- a/vlib/v/tests/assert_fn_ret_option_test.v
+++ b/vlib/v/tests/assert_fn_ret_option_test.v
@@ -1,0 +1,8 @@
+fn find_token_by_id() ?int {
+	return none
+}
+
+fn test_main() {
+	assert find_token_by_id() == none
+	println('done')
+}


### PR DESCRIPTION
Fix #21715