### PR TITLE
encoding.base32: fix warning of implicit clone of array by declaring unsafe

### DIFF
--- a/vlib/encoding/base32/base32.v
+++ b/vlib/encoding/base32/base32.v
@@ -286,7 +286,9 @@ fn (enc &Encoding) decode_(src_ []u8, mut dst []u8) !(int, bool) {
 				break
 			}
 			in0 := src[0]
-			src = src[1..]
+			unsafe {
+				src = src[1..]
+			}
 			if in0 == enc.padding_char && j >= 2 && src.len < 8 {
 				// We`ve reached the end and there`s padding
 				if src.len + j < 8 - 1 {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Received the following warning when importing `encoding.base32`
```
v run base32_test.v
/Users/mike/Documents/github/v/vlib/encoding/base32/base32.v:289:13: notice: an implicit clone of the slice was done here
  287 |             }
  288 |             in0 := src[0]
  289 |             src = src[1..]
      |                      ~~~~~
  290 |             if in0 == enc.padding_char && j >= 2 && src.len < 8 {
  291 |                 // We`ve reached the end and there`s padding
Details: /Users/mike/Documents/github/v/vlib/encoding/base32/base32.v:289:13: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
  287 |             }
  288 |             in0 := src[0]
  289 |             src = src[1..]
      |                      ~~~~~
  290 |             if in0 == enc.padding_char && j >= 2 && src.len < 8 {
  291 |                 // We`ve reached the end and there`s padding
```
This PR uses an explicit `unsafe` to suppress the warning.  