### PR TITLE
cgen: fix sumtype with reference (fix #21721)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4931,7 +4931,14 @@ fn (mut g Gen) ident(node ast.Ident) {
 								if node.obj.is_inherited {
 									g.write(closure_ctx + '->')
 								}
-								g.write(name)
+								if node.obj.typ.nr_muls() > 1 {
+									g.write('(')
+									g.write('*'.repeat(node.obj.typ.nr_muls() - 1))
+									g.write(name)
+									g.write(')')
+								} else {
+									g.write(name)
+								}
 								if node.obj.orig_type.is_ptr() {
 									is_ptr = true
 								}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -695,6 +695,9 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 
 	cmp_op := if node.op == .key_is { '==' } else { '!=' }
 	g.write('(')
+	if node.left_type.nr_muls() > 1 {
+		g.write('*'.repeat(node.left_type.nr_muls() - 1))
+	}
 	if is_aggregate {
 		g.write('${node.left}')
 	} else {

--- a/vlib/v/tests/sumtype_with_reference_test.v
+++ b/vlib/v/tests/sumtype_with_reference_test.v
@@ -1,0 +1,29 @@
+struct Parse {
+mut:
+	stack []&Element
+}
+
+struct Balise {}
+
+struct RawText {
+	s string
+}
+
+type Element = Balise | RawText
+
+fn (mut p Parse) process_open_tag() string {
+	mut last := &p.stack[0]
+	if mut last is RawText {
+		println(last)
+		return last.s
+	} else {
+		return ''
+	}
+}
+
+fn test_sumtype_with_reference() {
+	mut parse := Parse{
+		stack: [&RawText{'raw'}]
+	}
+	assert parse.process_open_tag() == 'raw'
+}


### PR DESCRIPTION
This PR fix sumtype with reference (fix #21721).

- Fix sumtype with reference.
- Add test.

```v
struct Parse {
mut:
	stack []&Element
}

struct Balise {}

struct RawText {
	s string
}

type Element = Balise | RawText

fn (mut p Parse) process_open_tag() string {
	mut last := &p.stack[0]
	if mut last is RawText {
		println(last)
		return last.s
	} else {
		return ''
	}
}

fn main() {
	mut parse := Parse{
		stack: [&RawText{'raw'}]
	}
	assert parse.process_open_tag() == 'raw'
}

PS D:\Test\v\tt1> v run .
RawText{
    s: 'raw'
}
```