### PR TITLE
net: Corrected `status()` method comment to indicate return of `Status` enum field instead of struct.

### DIFF
--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -85,7 +85,7 @@ pub fn (r Response) cookies() []Cookie {
 	return cookies
 }
 
-// status parses the status_code into a Status struct
+// status parses the status_code and returns a corresponding enum field of Status
 pub fn (r Response) status() Status {
 	return status_from_int(r.status_code)
 }


### PR DESCRIPTION
The `status()` method comment states it returns a Status struct. This is incorrect. It in fact returns a field of the `Status` enum. I have updated the comment to reflect this and used wording to be consistent with https://github.com/vlang/v/blob/8466c6c03d77ae623ffc023272aacaa569c942ae/vlib/net/http/status.v#L79 .

