### PR TITLE
cgen: fix infix expr and/or operate unnecessary evaluate (fix #21590)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1057,6 +1057,22 @@ fn (mut g Gen) infix_expr_and_or_op(node ast.InfixExpr) {
 				return
 			}
 		}
+	} else if node.right is ast.InfixExpr && g.need_tmp_var_in_expr(node.right) {
+		prev_inside_ternary := g.inside_ternary
+		g.inside_ternary = 0
+		tmp := g.new_tmp_var()
+		cur_line := g.go_before_last_stmt().trim_space()
+		g.empty_line = true
+		g.write('bool ${tmp} = (')
+		g.expr(node.left)
+		g.writeln(');')
+		g.set_current_pos_as_last_stmt_pos()
+		g.write('${cur_line} ${tmp} ${node.op.str()} ')
+		g.infix_left_var_name = if node.op == .and { tmp } else { '!${tmp}' }
+		g.expr(node.right)
+		g.infix_left_var_name = ''
+		g.inside_ternary = prev_inside_ternary
+		return
 	}
 	g.gen_plain_infix_expr(node)
 }

--- a/vlib/v/tests/infix_expr_and_or_operate_unnecessary_eval_test.v
+++ b/vlib/v/tests/infix_expr_and_or_operate_unnecessary_eval_test.v
@@ -1,0 +1,17 @@
+fn f(s string) !int {
+	if s == '' {
+		return error('invalid s')
+	}
+	return s.len
+}
+
+fn test_infix_expr_and_or_operate_unnecessary_eval() {
+	v := ''
+	x := v != 'xyz' || f(v)! < f('abc')!
+	dump(x)
+	assert x
+
+	y := v == 'xyz' && f(v)! < f('abc')!
+	dump(y)
+	assert !y
+}


### PR DESCRIPTION
This PR fix infix expr and/or operate unnecessary evaluate (fix #21590).

- Fix infix expr and/or operate unnecessary evaluate.
- Add test.

```v
fn f(s string) !int {
	if s == '' {
		return error('invalid s')
	}
	return s.len
}

fn main() {
	v := ''
	x := v != 'xyz' || f(v)! < f('abc')!
	dump(x)
	assert x

	y := v == 'xyz' && f(v)! < f('abc')!
	dump(y)
	assert !y
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:11] x: true
[.\\tt1.v:15] y: false
```