### PR TITLE
checker: add error for `field [$d('x', 2)]int = [1, 2]!`

### DIFF
--- a/vlib/v/checker/tests/struct_field_fixed_size_init_with_d_as_size_err.out
+++ b/vlib/v/checker/tests/struct_field_fixed_size_init_with_d_as_size_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_fixed_size_init_with_d_as_size_err.vv:3:31: error: cannot initialize a fixed size array field that uses `$d()` as size quantifier since the size may change via -d
+    1 | struct Gin {
+    2 | mut:
+    3 |     juice [$d('amount', 4)]int = [1, 2, 3, 4]!
+      |                                  ~~~~~~~~~~~~~
+    4 | }
+    5 |

--- a/vlib/v/checker/tests/struct_field_fixed_size_init_with_d_as_size_err.vv
+++ b/vlib/v/checker/tests/struct_field_fixed_size_init_with_d_as_size_err.vv
@@ -1,0 +1,6 @@
+struct Gin {
+mut:
+	juice [$d('amount', 4)]int = [1, 2, 3, 4]!
+}
+
+fn main() {}


### PR DESCRIPTION
Add this:
```
vlib/v/checker/tests/struct_field_fixed_size_init_with_d_as_size_err.vv:3:31: error: cannot initialize a fixed size array field that uses `$d()` as size quantifier since the size may change via -d
    1 | struct Gin {
    2 | mut:
    3 |     juice [$d('amount', 4)]int = [1, 2, 3, 4]!
      |                                  ~~~~~~~~~~~~~
    4 | }
    5 |
```
for this code:
```v
struct Gin {
mut:
	juice [$d('amount', 4)]int = [1, 2, 3, 4]!
}

fn main() {}
```