### PR TITLE
dbg: fix scope command when breakpoint is on or-expr

### DIFF
--- a/vlib/v/debug/tests/or_expr_scope.expect
+++ b/vlib/v/debug/tests/or_expr_scope.expect
@@ -1,0 +1,12 @@
+#!/usr/bin/env expect
+source "common.tcl"
+
+expect "Break on *main* in ${test_file}:7\r\n"
+
+expect "${test_file}:7 vdbg> "
+send "scope\n"
+expect "err = fail (IError)"
+
+expect "${test_file}:7 vdbg> "
+send "q\n"
+expect eof

--- a/vlib/v/debug/tests/or_expr_scope.vv
+++ b/vlib/v/debug/tests/or_expr_scope.vv
@@ -1,0 +1,10 @@
+fn r() !bool {
+	return error('fail')
+}
+
+fn main() {
+	a := r() or {
+		$dbg;
+		false
+	}
+}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -209,6 +209,11 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 	if node.left_types.len < node.left.len {
 		g.checker_bug('node.left_types.len < node.left.len', node.pos)
 	}
+	last_curr_var_name := g.curr_var_name.clone()
+	g.curr_var_name = []
+	defer {
+		g.curr_var_name = last_curr_var_name
+	}
 
 	for i, mut left in node.left {
 		mut is_auto_heap := false
@@ -224,6 +229,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		left_sym := g.table.sym(g.unwrap_generic(var_type))
 		if mut left is ast.Ident {
 			ident = left
+			g.curr_var_name << ident.name
 			// id_info := ident.var_info()
 			// var_type = id_info.typ
 			blank_assign = left.kind == .blank_ident

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -218,10 +218,11 @@ mut:
 	// where an aggregate (at least two types) is generated
 	// sum type deref needs to know which index to deref because unions take care of the correct field
 	aggregate_type_idx  int
-	arg_no_auto_deref   bool   // smartcast must not be dereferenced
-	branch_parent_pos   int    // used in BranchStmt (continue/break) for autofree stop position
-	returned_var_name   string // to detect that a var doesn't need to be freed since it's being returned
-	infix_left_var_name string // a && if expr
+	arg_no_auto_deref   bool     // smartcast must not be dereferenced
+	branch_parent_pos   int      // used in BranchStmt (continue/break) for autofree stop position
+	returned_var_name   string   // to detect that a var doesn't need to be freed since it's being returned
+	infix_left_var_name string   // a && if expr
+	curr_var_name       []string // curr var name on assignment
 	called_fn_name      string
 	timers              &util.Timers = util.get_timers()
 	force_main_console  bool // true when [console] used on fn main()
@@ -4166,6 +4167,9 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 	mut count := 1
 	outer: for _, obj in scope_vars {
 		if obj.name !in vars {
+			if obj.name in g.curr_var_name {
+				continue
+			}
 			if obj is ast.Var && g.check_var_scope(obj, node.pos.pos) {
 				keys.write_string('_SLIT("${obj.name}")')
 				var_typ := if obj.ct_type_var != .no_comptime {


### PR DESCRIPTION
Fix #21772

```v
fn r() !bool {
	return error('fail')
}

fn main() {
	a := r() or {
		$dbg
		false
	}
}
```