### PR TITLE
cgen: fix reference variable str() method call (fix #19430)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1678,7 +1678,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	// TODO2
 	// g.generate_tmp_autofree_arg_vars(node, name)
 	if !node.receiver_type.is_ptr() && left_type.is_ptr() && node.name == 'str' {
-		g.write('ptr_str(')
+		if left_type.is_int_valptr() {
+			g.write('ptr_str(')
+		} else {
+			g.gen_expr_to_string(node.left, left_type)
+			return
+		}
 	} else if node.receiver_type.is_ptr() && left_type.is_ptr() && node.name == 'str'
 		&& !left_sym.has_method('str') {
 		g.gen_expr_to_string(node.left, left_type)

--- a/vlib/v/tests/reference_variable_str_test.v
+++ b/vlib/v/tests/reference_variable_str_test.v
@@ -1,0 +1,17 @@
+@[heap]
+struct Foo {
+	bar string = 'bar'
+	baz string = 'baz'
+}
+
+fn (foo Foo) str() string {
+	return 'bar: ${foo.bar}, baz: ${foo.baz}'
+}
+
+fn test_reference_variable_str() {
+	mut many_foos := []&Foo{len: 3, init: &Foo{}}
+	println(many_foos.map(it.str()).join('\n'))
+	println(many_foos)
+	assert many_foos.map(it.str()) == ['&bar: bar, baz: baz', '&bar: bar, baz: baz',
+		'&bar: bar, baz: baz']
+}


### PR DESCRIPTION
This PR fix reference variable str() method call (fix #19430).

- Fix reference variable str() method call.
- Add test.

```v
@[heap]
struct Foo {
	bar string = 'bar'
	baz string = 'baz'
}

fn (foo Foo) str() string {
	return 'bar: ${foo.bar}, baz: ${foo.baz}'
}

fn main() {
	mut many_foos := []&Foo{len: 3, init: &Foo{}}
	println(many_foos.map(it.str()).join('\n'))
	println(many_foos)
	assert many_foos.map(it.str()) == ['&bar: bar, baz: baz', '&bar: bar, baz: baz',
		'&bar: bar, baz: baz']
}

PS D:\Test\v\tt1> v run .
&bar: bar, baz: baz
&bar: bar, baz: baz
&bar: bar, baz: baz
[&bar: bar, baz: baz, &bar: bar, baz: baz, &bar: bar, baz: baz]
```