### PR TITLE
crypto.blowfish: apply `@[direct_array_access]` to very commonly used functions

### DIFF
--- a/vlib/crypto/blowfish/block.v
+++ b/vlib/crypto/blowfish/block.v
@@ -1,6 +1,7 @@
 module blowfish
 
 // expand_key performs a key expansion on the given Blowfish cipher.
+@[direct_array_access]
 pub fn expand_key(key []u8, mut bf Blowfish) {
 	mut j := 0
 	for i := 0; i < 18; i++ {
@@ -41,6 +42,7 @@ pub fn expand_key(key []u8, mut bf Blowfish) {
 }
 
 // expand_key_with_salt using salt to expand the key.
+@[direct_array_access]
 pub fn expand_key_with_salt(key []u8, salt []u8, mut bf Blowfish) {
 	mut j := 0
 	for i := 0; i < 18; i++ {
@@ -85,6 +87,7 @@ pub fn expand_key_with_salt(key []u8, salt []u8, mut bf Blowfish) {
 }
 
 // setup_tables sets up the Blowfish cipher's pi and substitution tables.
+@[direct_array_access]
 fn setup_tables(l u32, r u32, mut bf Blowfish) (u32, u32) {
 	mut xl := l
 	mut xr := r
@@ -111,6 +114,7 @@ fn setup_tables(l u32, r u32, mut bf Blowfish) (u32, u32) {
 
 // get_next_word returns the next big-endian u32 value from the byte
 // slice at the given position in a circular manner, updating the position.
+@[direct_array_access]
 fn get_next_word(b []u8, pos &int) u32 {
 	mut w := u32(0)
 	mut j := 0


### PR DESCRIPTION
![image](https://github.com/vlang/v/assets/26967/a2b127b0-9974-4dee-8625-a6b55319bd4b)
