### PR TITLE
checker: fix nested if expr method call (fix #20976)

### DIFF
--- a/vlib/v/tests/nested_if_expr_method_call_test.v
+++ b/vlib/v/tests/nested_if_expr_method_call_test.v
@@ -1,0 +1,33 @@
+fn test_nested_if_expr_method_call() {
+	str_from_nested_exp1 := if true {
+		if true { 'foo.bar' } else { 'foo.bar.baz' }.all_after('foo.')
+	} else {
+		'foo'
+	}
+	println(str_from_nested_exp1)
+	assert str_from_nested_exp1 == 'bar'
+
+	str_from_nested_exp2 := if true {
+		(if true { 'foo.bar' } else { 'foo.bar.baz' }).all_after('foo.')
+	} else {
+		'foo'
+	}
+	println(str_from_nested_exp2)
+	assert str_from_nested_exp2 == 'bar'
+
+	str_from_nested_exp3 := if true {
+		'foo'
+	} else {
+		if true { 'foo.bar' } else { 'foo.bar.baz' }.all_after('foo.')
+	}
+	println(str_from_nested_exp3)
+	assert str_from_nested_exp3 == 'foo'
+
+	str_from_nested_exp4 := if true {
+		'foo'
+	} else {
+		(if true { 'foo.bar' } else { 'foo.bar.baz' }).all_after('foo.')
+	}
+	println(str_from_nested_exp4)
+	assert str_from_nested_exp4 == 'foo'
+}


### PR DESCRIPTION
This PR fix nested if expr method call (fix #20976).

- Fix nested if expr method call.
- Add test.

```v
fn main() {
	str_from_nested_exp1 := if true {
		if true { 'foo.bar' } else { 'foo.bar.baz' }.all_after('foo.')
	} else {
		'foo'
	}
	println(str_from_nested_exp1)
	assert str_from_nested_exp1 == 'bar'

	str_from_nested_exp2 := if true {
		(if true { 'foo.bar' } else { 'foo.bar.baz' }).all_after('foo.')
	} else {
		'foo'
	}
	println(str_from_nested_exp2)
	assert str_from_nested_exp2 == 'bar'

	str_from_nested_exp3 := if true {
		'foo'
	} else {
		if true { 'foo.bar' } else { 'foo.bar.baz' }.all_after('foo.')
	}
	println(str_from_nested_exp3)
	assert str_from_nested_exp3 == 'foo'

	str_from_nested_exp4 := if true {
		'foo'
	} else {
		(if true { 'foo.bar' } else { 'foo.bar.baz' }).all_after('foo.')
	}
	println(str_from_nested_exp4)
	assert str_from_nested_exp4 == 'foo'
}

PS D:\Test\v\tt1> v run .
bar
bar
foo
foo
```