### PR TITLE
fmt: implement wrapping function's super long arguments (fix #15545, #21643)

### DIFF
--- a/cmd/tools/check_os_api_parity.v
+++ b/cmd/tools/check_os_api_parity.v
@@ -98,7 +98,8 @@ fn gen_api_for_module_in_os(mod_name string, os_ pref.OS) string {
 			if s is ast.FnDecl && s.is_pub {
 				fn_mod := s.modname()
 				if fn_mod == mod_name {
-					fn_signature := b.table.stringify_fn_decl(&s, mod_name, map[string]string{})
+					fn_signature := b.table.stringify_fn_decl(&s, mod_name, map[string]string{},
+						false)
 					fline := '${fn_mod}: ${fn_signature}'
 					res << fline
 				}

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -237,9 +237,25 @@ fn C.GetModuleFileName(hModule voidptr, lpFilename &u16, nSize u32) u32
 
 fn C.GetModuleFileNameW(hModule voidptr, lpFilename &u16, nSize u32) u32
 
-fn C.CreateFile(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
+fn C.CreateFile(
+	lpFilename &u16,
+	dwDesiredAccess u32,
+	dwShareMode u32,
+	lpSecurityAttributes &u16,
+	dwCreationDisposition u32,
+	dwFlagsAndAttributes u32,
+	hTemplateFile voidptr
+) voidptr
 
-fn C.CreateFileW(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
+fn C.CreateFileW(
+	lpFilename &u16,
+	dwDesiredAccess u32,
+	dwShareMode u32,
+	lpSecurityAttributes &u16,
+	dwCreationDisposition u32,
+	dwFlagsAndAttributes u32,
+	hTemplateFile voidptr
+) voidptr
 
 fn C.GetFinalPathNameByHandleW(hFile voidptr, lpFilePath &u16, nSize u32, dwFlags u32) u32
 
@@ -258,7 +274,18 @@ fn C.SendMessageTimeout() isize
 
 fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlags u32, uTimeout u32, lpdwResult &u64) isize
 
-fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
+fn C.CreateProcessW(
+	lpApplicationName &u16,
+	lpCommandLine &u16,
+	lpProcessAttributes voidptr,
+	lpThreadAttributes voidptr,
+	bInheritHandles bool,
+	dwCreationFlags u32,
+	lpEnvironment voidptr,
+	lpCurrentDirectory &u16,
+	lpStartupInfo voidptr,
+	lpProcessInformation voidptr
+) bool
 
 fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead &u32, lpOverlapped voidptr) bool
 
@@ -302,7 +329,16 @@ fn C.MultiByteToWideChar(codePage u32, dwFlags u32, lpMultiMyteStr &char, cbMult
 
 fn C.wcslen(str voidptr) usize
 
-fn C.WideCharToMultiByte(codePage u32, dwFlags u32, lpWideCharStr &u16, cchWideChar int, lpMultiByteStr &char, cbMultiByte int, lpDefaultChar &char, lpUsedDefaultChar &int) int
+fn C.WideCharToMultiByte(
+	codePage u32,
+	dwFlags u32,
+	lpWideCharStr &u16,
+	cchWideChar int,
+	lpMultiByteStr &char,
+	cbMultiByte int,
+	lpDefaultChar &char,
+	lpUsedDefaultChar &int
+) int
 
 fn C._wstat(path &u16, buffer &C._stat) int
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -269,7 +269,17 @@ fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
 	}
 }
 
-fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init(
+	hash_fn MapHashFn,
+	key_eq_fn MapEqFn,
+	clone_fn MapCloneFn,
+	free_fn MapFreeFn,
+	n int,
+	key_bytes int,
+	value_bytes int,
+	keys voidptr,
+	values voidptr
+) map {
 	mut out := new_map(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn, free_fn)
 	// TODO: pre-allocate n slots
 	mut pkey := &u8(keys)

--- a/vlib/builtin/map_d_gcboehm_opt.v
+++ b/vlib/builtin/map_d_gcboehm_opt.v
@@ -73,7 +73,14 @@ fn new_map_noscan_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_e
 	}
 }
 
-fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+fn new_map_noscan_key_value(
+	key_bytes int,
+	value_bytes int,
+	hash_fn MapHashFn,
+	key_eq_fn MapEqFn,
+	clone_fn MapCloneFn,
+	free_fn MapFreeFn
+) map {
 	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
@@ -95,7 +102,17 @@ fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, k
 	}
 }
 
-fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init_noscan_key(
+	hash_fn MapHashFn,
+	key_eq_fn MapEqFn,
+	clone_fn MapCloneFn,
+	free_fn MapFreeFn,
+	n int,
+	key_bytes int,
+	value_bytes int,
+	keys voidptr,
+	values voidptr
+) map {
 	mut out := new_map_noscan_key(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
 	// TODO: pre-allocate n slots
@@ -111,7 +128,17 @@ fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapClo
 	return out
 }
 
-fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init_noscan_value(
+	hash_fn MapHashFn,
+	key_eq_fn MapEqFn,
+	clone_fn MapCloneFn,
+	free_fn MapFreeFn,
+	n int,
+	key_bytes int,
+	value_bytes int,
+	keys voidptr,
+	values voidptr
+) map {
 	mut out := new_map_noscan_value(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
 	// TODO: pre-allocate n slots
@@ -127,7 +154,17 @@ fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapC
 	return out
 }
 
-fn new_map_init_noscan_key_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init_noscan_key_value(
+	hash_fn MapHashFn,
+	key_eq_fn MapEqFn,
+	clone_fn MapCloneFn,
+	free_fn MapFreeFn,
+	n int,
+	key_bytes int,
+	value_bytes int,
+	keys voidptr,
+	values voidptr
+) map {
 	mut out := new_map_noscan_key_value(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
 	// TODO: pre-allocate n slots

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -117,7 +117,16 @@ fn abs64(x i64) u64 {
 //---------------------------------------
 
 // convert from data format to compact u64
-pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u64 {
+pub fn get_str_intp_u64_format(
+	fmt_type StrIntpType,
+	in_width int,
+	in_precision int,
+	in_tail_zeros bool,
+	in_sign bool,
+	in_pad_ch u8,
+	in_base int,
+	in_upper_case bool
+) u64 {
 	width := if in_width != 0 { abs64(in_width) } else { u64(0) }
 	align := if in_width > 0 { u64(1 << 5) } else { u64(0) } // two bit 0 .left 1 .right, for now we use only one
 	upper_case := if in_upper_case { u64(1 << 7) } else { u64(0) }
@@ -134,7 +143,16 @@ pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision 
 }
 
 // convert from data format to compact u32
-pub fn get_str_intp_u32_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u32 {
+pub fn get_str_intp_u32_format(
+	fmt_type StrIntpType,
+	in_width int,
+	in_precision int,
+	in_tail_zeros bool,
+	in_sign bool,
+	in_pad_ch u8,
+	in_base int,
+	in_upper_case bool
+) u32 {
 	width := if in_width != 0 { abs64(in_width) } else { u32(0) }
 	align := if in_width > 0 { u32(1 << 5) } else { u32(0) } // two bit 0 .left 1 .right, for now we use only one
 	upper_case := if in_upper_case { u32(1 << 7) } else { u32(0) }

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -24,7 +24,20 @@ fn C.RegisterClassEx(class &WndClassEx) int
 
 fn C.GetClipboardOwner() C.HWND
 
-fn C.CreateWindowEx(dwExStyle i64, lpClassName &u16, lpWindowName &u16, dwStyle i64, x int, y int, nWidth int, nHeight int, hWndParent i64, hMenu voidptr, h_instance voidptr, lpParam voidptr) C.HWND
+fn C.CreateWindowEx(
+	dwExStyle i64,
+	lpClassName &u16,
+	lpWindowName &u16,
+	dwStyle i64,
+	x int,
+	y int,
+	nWidth int,
+	nHeight int,
+	hWndParent i64,
+	hMenu voidptr,
+	h_instance voidptr,
+	lpParam voidptr
+) C.HWND
 
 // fn C.MultiByteToWideChar(CodePage u32, dw_flags u16, lpMultiByteStr byteptr, cbMultiByte int, lpWideCharStr u16, cchWideChar int) int
 fn C.EmptyClipboard()

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -47,7 +47,17 @@ fn C.XSendEvent(d &C.Display, requestor Window, propagate int, mask i64, event &
 
 fn C.XInternAtom(d &C.Display, typ &u8, only_if_exists int) Atom
 
-fn C.XCreateSimpleWindow(d &C.Display, root Window, x int, y int, width u32, height u32, border_width u32, border u64, background u64) Window
+fn C.XCreateSimpleWindow(
+	d &C.Display,
+	root Window,
+	x int,
+	y int,
+	width u32,
+	height u32,
+	border_width u32,
+	border u64,
+	background u64
+) Window
 
 fn C.XOpenDisplay(name &u8) &C.Display
 
@@ -55,7 +65,20 @@ fn C.XConvertSelection(d &C.Display, selection Atom, target Atom, property Atom,
 
 fn C.XSync(d &C.Display, discard int) int
 
-fn C.XGetWindowProperty(d &C.Display, w Window, property Atom, offset i64, length i64, delete int, req_type Atom, actual_type_return &Atom, actual_format_return &int, nitems &u64, bytes_after_return &u64, prop_return &&u8) int
+fn C.XGetWindowProperty(
+	d &C.Display,
+	w Window,
+	property Atom,
+	offset i64,
+	length i64,
+	delete int,
+	req_type Atom,
+	actual_type_return &Atom,
+	actual_format_return &int,
+	nitems &u64,
+	bytes_after_return &u64,
+	prop_return &&u8
+) int
 
 fn C.XDeleteProperty(d &C.Display, w Window, property Atom) int
 

--- a/vlib/db/mssql/_cdefs.c.v
+++ b/vlib/db/mssql/_cdefs.c.v
@@ -4,17 +4,42 @@ fn C.SQLAllocHandle(handle_type C.SQLSMALLINT, input_handle C.SQLHANDLE, output_
 
 fn C.SQLSetEnvAttr(environment_handle C.SQLHENV, attribute C.SQLINTEGER, value C.SQLPOINTER, string_length C.SQLINTEGER) C.SQLRETURN
 
-fn C.SQLGetDiagRec(handle_type C.SQLSMALLINT, handle C.SQLHANDLE, rec_number C.SQLSMALLINT, sql_state &C.SQLCHAR, native_error &C.SQLINTEGER, message_text &C.SQLCHAR, buffer_length C.SQLSMALLINT, text_length &C.SQLSMALLINT) C.SQLRETURN
+fn C.SQLGetDiagRec(
+	handle_type C.SQLSMALLINT,
+	handle C.SQLHANDLE,
+	rec_number C.SQLSMALLINT,
+	sql_state &C.SQLCHAR,
+	native_error &C.SQLINTEGER,
+	message_text &C.SQLCHAR,
+	buffer_length C.SQLSMALLINT,
+	text_length &C.SQLSMALLINT
+) C.SQLRETURN
 
 fn C.SQLSetConnectAttr(connection_handle C.SQLHDBC, attribute C.SQLINTEGER, value C.SQLPOINTER, string_length C.SQLINTEGER) C.SQLRETURN
 
-fn C.SQLDriverConnect(hdbc C.SQLHDBC, hwnd C.SQLHWND, sz_conn_str_in &C.SQLCHAR, cb_conn_str_in C.SQLSMALLINT, sz_conn_str_out &C.SQLCHAR, cb_conn_str_out_max C.SQLSMALLINT, pcb_conn_str_out &C.SQLSMALLINT, f_driver_completion C.SQLUSMALLINT) C.SQLRETURN
+fn C.SQLDriverConnect(
+	hdbc C.SQLHDBC,
+	hwnd C.SQLHWND,
+	sz_conn_str_in &C.SQLCHAR,
+	cb_conn_str_in C.SQLSMALLINT,
+	sz_conn_str_out &C.SQLCHAR,
+	cb_conn_str_out_max C.SQLSMALLINT,
+	pcb_conn_str_out &C.SQLSMALLINT,
+	f_driver_completion C.SQLUSMALLINT
+) C.SQLRETURN
 
 fn C.SQLDisconnect(connection_handle C.SQLHDBC) C.SQLRETURN
 
 fn C.SQLExecDirect(statement_handle C.SQLHSTMT, statement_text &C.SQLCHAR, text_length C.SQLINTEGER) C.SQLRETURN
 
-fn C.SQLBindCol(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, target_type C.SQLSMALLINT, target_value C.SQLPOINTER, buffer_length C.SQLLEN, str_len_or_ind &C.SQLLEN) C.SQLRETURN
+fn C.SQLBindCol(
+	statement_handle C.SQLHSTMT,
+	column_number C.SQLUSMALLINT,
+	target_type C.SQLSMALLINT,
+	target_value C.SQLPOINTER,
+	buffer_length C.SQLLEN,
+	str_len_or_ind &C.SQLLEN
+) C.SQLRETURN
 
 fn C.SQLFetch(statement_handle C.SQLHSTMT) C.SQLRETURN
 
@@ -22,6 +47,14 @@ fn C.SQLFreeHandle(handle_type C.SQLSMALLINT, handle C.SQLHANDLE) C.SQLRETURN
 
 fn C.SQLNumResultCols(statement_handle C.SQLHSTMT, column_count &C.SQLSMALLINT) C.SQLRETURN
 
-fn C.SQLColAttribute(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, field_identifier C.SQLUSMALLINT, character_attribute C.SQLPOINTER, buffer_length C.SQLSMALLINT, string_length C.SQLSMALLINT, numeric_attribute &C.SQLLEN) C.SQLRETURN
+fn C.SQLColAttribute(
+	statement_handle C.SQLHSTMT,
+	column_number C.SQLUSMALLINT,
+	field_identifier C.SQLUSMALLINT,
+	character_attribute C.SQLPOINTER,
+	buffer_length C.SQLSMALLINT,
+	string_length C.SQLSMALLINT,
+	numeric_attribute &C.SQLLEN
+) C.SQLRETURN
 
 fn C.SQLRowCount(statement_handle C.SQLHSTMT, row_count &C.SQLLEN) C.SQLRETURN

--- a/vlib/db/mysql/_cdefs.c.v
+++ b/vlib/db/mysql/_cdefs.c.v
@@ -36,7 +36,16 @@ pub struct C.MYSQL_FIELD {
 fn C.mysql_init(mysql &C.MYSQL) &C.MYSQL
 
 // C.mysql_real_connect attempts to establish a connection to a MySQL server running on `host`.
-fn C.mysql_real_connect(mysql &C.MYSQL, host &char, user &char, passwd &char, db &char, port u32, unix_socket &char, client_flag ConnectionFlag) &C.MYSQL
+fn C.mysql_real_connect(
+	mysql &C.MYSQL,
+	host &char,
+	user &char,
+	passwd &char,
+	db &char,
+	port u32,
+	unix_socket &char,
+	client_flag ConnectionFlag
+) &C.MYSQL
 
 // C.mysql_query executes the SQL statement pointed to by the null-terminated string `stmt_str`.
 fn C.mysql_query(mysql &C.MYSQL, q &u8) int

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -137,7 +137,16 @@ fn C.PQnfields(const_res &C.PGresult) int
 // const char *const *paramValues
 // const int *paramLengths
 // const int *paramFormats
-fn C.PQexecParams(conn &C.PGconn, const_command &char, nParams int, const_paramTypes &int, const_paramValues &char, const_paramLengths &int, const_paramFormats &int, resultFormat int) &C.PGresult
+fn C.PQexecParams(
+	conn &C.PGconn,
+	const_command &char,
+	nParams int,
+	const_paramTypes &int,
+	const_paramValues &char,
+	const_paramLengths &int,
+	const_paramFormats &int,
+	resultFormat int
+) &C.PGresult
 
 fn C.PQputCopyData(conn &C.PGconn, const_buffer &char, nbytes int) int
 

--- a/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
+++ b/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
@@ -135,7 +135,13 @@ fn example_vfs_access(vfs &sqlite.Sqlite3_vfs, zPath &char, flags int, pResOut &
 	return sqlite.sqlite_ok
 }
 
-fn example_vfs_open(vfs &sqlite.Sqlite3_vfs, file_name_or_null_for_tempfile &char, vfs_opened_file &sqlite.Sqlite3_file, in_flags int, out_flags &int) int {
+fn example_vfs_open(
+	vfs &sqlite.Sqlite3_vfs,
+	file_name_or_null_for_tempfile &char,
+	vfs_opened_file &sqlite.Sqlite3_file,
+	in_flags int,
+	out_flags &int
+) int {
 	println('open called')
 
 	mut is_temp := false

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -794,7 +794,16 @@ pub fn (ctx Context) draw_arc_line(x f32, y f32, radius f32, start_angle f32, en
 // `end_angle` is the angle in radians at which the arc ends.
 // `segments` affects how smooth/round the arc is.
 // `c` is the color of the arc outline.
-pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_arc_empty(
+	x f32,
+	y f32,
+	inner_radius f32,
+	thickness f32,
+	start_angle f32,
+	end_angle f32,
+	segments int,
+	c gx.Color
+) {
 	outer_radius := inner_radius + thickness
 	if segments <= 0 || outer_radius < 0 {
 		return
@@ -857,7 +866,16 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f
 // `end_angle` is the angle in radians at which the arc ends.
 // `segments` affects how smooth/round the arc is.
 // `c` is the fill color of the arc.
-pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_arc_filled(
+	x f32,
+	y f32,
+	inner_radius f32,
+	thickness f32,
+	start_angle f32,
+	end_angle f32,
+	segments int,
+	c gx.Color
+) {
 	outer_radius := inner_radius + thickness
 	if segments <= 0 || outer_radius < 0 {
 		return

--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -88,7 +88,13 @@ fn C.getpeername(sockfd int, addr &Addr, addlen &u32) int
 
 fn C.inet_ntop(af AddrFamily, src voidptr, dst &char, dst_size int) &char
 
-fn C.WSAAddressToStringA(lpsaAddress &Addr, dwAddressLength u32, lpProtocolInfo voidptr, lpszAddressString &char, lpdwAddressStringLength &u32) int
+fn C.WSAAddressToStringA(
+	lpsaAddress &Addr,
+	dwAddressLength u32,
+	lpProtocolInfo voidptr,
+	lpszAddressString &char,
+	lpdwAddressStringLength &u32
+) int
 
 // fn C.getsockname(sockfd int, addr &C.sockaddr, addrlen &C.socklen_t) int
 fn C.getsockname(sockfd int, addr &C.sockaddr, addrlen &u32) int

--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -170,7 +170,13 @@ fn C.mbedtls_ssl_setup(&C.mbedtls_ssl_context, &C.mbedtls_ssl_config) int
 fn C.mbedtls_ssl_session_reset(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
 fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, fn (voidptr, &u8, usize) int, &C.mbedtls_ctr_drbg_context)
-fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, &C.mbedtls_ssl_send_t, &C.mbedtls_ssl_recv_t, &C.mbedtls_ssl_recv_timeout_t)
+fn C.mbedtls_ssl_set_bio(
+	&C.mbedtls_ssl_context,
+	&C.mbedtls_net_context,
+	&C.mbedtls_ssl_send_t,
+	&C.mbedtls_ssl_recv_t,
+	&C.mbedtls_ssl_recv_timeout_t
+)
 fn C.mbedtls_ssl_conf_own_cert(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_pk_context) int
 fn C.mbedtls_ssl_conf_ca_chain(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_x509_crl)
 fn C.mbedtls_ssl_set_hostname(&C.mbedtls_ssl_context, &char) int

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -207,7 +207,17 @@ pub interface Connection {
 // num - Stmt uses nums at prepared statements (? or ?1)
 // qm - Character for prepared statement (qm for question mark, as in sqlite)
 // start_pos - When num is true, it's the start position of the counter
-pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKind, num bool, qm string, start_pos int, data QueryData, where QueryData) (string, QueryData) {
+pub fn orm_stmt_gen(
+	sql_dialect SQLDialect,
+	table string,
+	q string,
+	kind StmtKind,
+	num bool,
+	qm string,
+	start_pos int,
+	data QueryData,
+	where QueryData
+) (string, QueryData) {
 	mut str := ''
 	mut c := start_pos
 	mut data_fields := []string{}
@@ -432,7 +442,15 @@ fn gen_where_clause(where QueryData, q string, qm string, num bool, mut c &int) 
 // fields - See TableField
 // sql_from_v - Function which maps type indices to sql type names
 // alternative - Needed for msdb
-pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, fields []TableField, sql_from_v fn (int) !string, alternative bool) !string {
+pub fn orm_table_gen(
+	table string,
+	q string,
+	defaults bool,
+	def_unique_len int,
+	fields []TableField,
+	sql_from_v fn (int) !string,
+	alternative bool
+) !string {
 	mut str := 'CREATE TABLE IF NOT EXISTS ${q}${table}${q} ('
 
 	if alternative {

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -6,7 +6,14 @@ fn C.GenerateConsoleCtrlEvent(event u32, pgid u32) bool
 fn C.GetModuleHandleA(name &char) HMODULE
 fn C.GetProcAddress(handle voidptr, procname &u8) voidptr
 fn C.TerminateProcess(process HANDLE, exit_code u32) bool
-fn C.PeekNamedPipe(hNamedPipe voidptr, lpBuffer voidptr, nBufferSize int, lpBytesRead voidptr, lpTotalBytesAvail voidptr, lpBytesLeftThisMessage voidptr) bool
+fn C.PeekNamedPipe(
+	hNamedPipe voidptr,
+	lpBuffer voidptr,
+	nBufferSize int,
+	lpBytesRead voidptr,
+	lpTotalBytesAvail voidptr,
+	lpBytesLeftThisMessage voidptr
+) bool
 
 type FN_NTSuspendResume = fn (voidptr) u64
 

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -220,13 +220,25 @@ pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, 
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &ShaderDesc {
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform(
+	block_index int,
+	uniform_index int,
+	name string,
+	@type UniformType,
+	array_count int
+) &ShaderDesc {
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &ShaderDesc {
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform(
+	block_index int,
+	uniform_index int,
+	name string,
+	@type UniformType,
+	array_count int
+) &ShaderDesc {
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc

--- a/vlib/sokol/memory/memory.c.v
+++ b/vlib/sokol/memory/memory.c.v
@@ -31,7 +31,15 @@ pub fn sfree(ptr voidptr, user_data voidptr) {
 
 fn C.SOKOL_LOG(const_message &char)
 
-pub fn slog(const_tag &char, log_level u32, log_item_id u32, const_message_or_null &char, line_nr u32, const_filename_or_null &char, user_data voidptr) {
+pub fn slog(
+	const_tag &char,
+	log_level u32,
+	log_item_id u32,
+	const_message_or_null &char,
+	line_nr u32,
+	const_filename_or_null &char,
+	user_data voidptr
+) {
 	C.fprintf(C.stderr, c'sokol.memory.slog | user_data: %p, const_tag: %s, level: %d, item_id: %d, fname: %s, line: %d, message: %s\n',
 		user_data, const_tag, log_level, log_item_id, const_filename_or_null, line_nr,
 		const_message_or_null)

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -154,7 +154,17 @@ pub fn load_from_memory(buf &u8, bufsize int, params LoadParams) !Image {
 // Resize functions
 //
 //-----------------------------------------------------------------------------
-fn C.stbir_resize_uint8_linear(input_pixels &u8, input_w int, input_h int, input_stride_in_bytes int, output_pixels &u8, output_w int, output_h int, output_stride_in_bytes int, num_channels int) int
+fn C.stbir_resize_uint8_linear(
+	input_pixels &u8,
+	input_w int,
+	input_h int,
+	input_stride_in_bytes int,
+	output_pixels &u8,
+	output_w int,
+	output_h int,
+	output_stride_in_bytes int,
+	num_channels int
+) int
 
 // resize_uint8 resizes `img` to dimensions of `output_w` and `output_h`
 pub fn resize_uint8(img &Image, output_w int, output_h int) !Image {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -84,11 +84,11 @@ pub fn (t &Table) stringify_anon_decl(node &AnonFn, cur_mod string, m2a map[stri
 		}
 		f.write_string('] ')
 	}
-	t.stringify_fn_after_name(node.decl, mut f, cur_mod, m2a)
+	t.stringify_fn_after_name(node.decl, mut f, cur_mod, m2a, false)
 	return f.str()
 }
 
-pub fn (t &Table) stringify_fn_decl(node &FnDecl, cur_mod string, m2a map[string]string) string {
+pub fn (t &Table) stringify_fn_decl(node &FnDecl, cur_mod string, m2a map[string]string, need_wrap bool) string {
 	mut f := strings.new_builder(30)
 	if node.is_pub {
 		f.write_string('pub ')
@@ -132,11 +132,11 @@ pub fn (t &Table) stringify_fn_decl(node &FnDecl, cur_mod string, m2a map[string
 	if name in ['+', '-', '*', '/', '%', '<', '>', '==', '!=', '>=', '<='] {
 		f.write_string(' ')
 	}
-	t.stringify_fn_after_name(node, mut f, cur_mod, m2a)
+	t.stringify_fn_after_name(node, mut f, cur_mod, m2a, need_wrap)
 	return f.str()
 }
 
-fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_mod string, m2a map[string]string) {
+fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_mod string, m2a map[string]string, need_wrap bool) {
 	mut add_para_types := true
 	mut is_wrap_needed := false
 	if node.generic_names.len > 0 {
@@ -188,6 +188,9 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		if is_wrap_needed {
 			f.write_string('\t')
 		}
+		if need_wrap {
+			f.write_string('\n\t')
+		}
 		if param.is_mut {
 			f.write_string(param.typ.share().str() + ' ')
 		}
@@ -228,10 +231,18 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			}
 		}
 		if !is_last_param {
-			f.write_string(', ')
+			if need_wrap {
+				f.write_string(',')
+			} else {
+				f.write_string(', ')
+			}
 		}
 	}
-	f.write_string(')')
+	if need_wrap {
+		f.write_string('\n)')
+	} else {
+		f.write_string(')')
+	}
 	if node.return_type != void_type {
 		sreturn_type := util.no_cur_mod(t.type_to_str(node.return_type), cur_mod)
 		short_sreturn_type := shorten_full_name_based_on_aliases(sreturn_type, m2a)

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -593,7 +593,8 @@ pub fn (mut b Builder) print_warnings_and_errors() {
 				for stmt in file.stmts {
 					if stmt is ast.FnDecl {
 						if stmt.name == fn_name {
-							fheader := b.table.stringify_fn_decl(&stmt, 'main', map[string]string{})
+							fheader := b.table.stringify_fn_decl(&stmt, 'main', map[string]string{},
+								false)
 							redefines << FunctionRedefinition{
 								fpath: file.path
 								fline: stmt.pos.line_nr

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1969,7 +1969,19 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 	}
 }
 
-fn (mut c Checker) check_enum_field_integer_literal(expr ast.IntegerLiteral, is_signed bool, is_multi_allowed bool, styp string, pos token.Pos, mut useen []u64, umin u64, umax u64, mut iseen []i64, imin i64, imax i64) {
+fn (mut c Checker) check_enum_field_integer_literal(
+	expr ast.IntegerLiteral,
+	is_signed bool,
+	is_multi_allowed bool,
+	styp string,
+	pos token.Pos,
+	mut useen []u64,
+	umin u64,
+	umax u64,
+	mut iseen []i64,
+	imin i64,
+	imax i64
+) {
 	mut overflows := false
 	mut uval := u64(0)
 	mut ival := i64(0)

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -936,7 +936,12 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 }
 
 // Recursively check whether the struct type field is initialized
-fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type, linked_name string, pos &token.Pos) {
+fn (mut c Checker) check_ref_fields_initialized(
+	struct_sym &ast.TypeSymbol,
+	mut checked_types []ast.Type,
+	linked_name string,
+	pos &token.Pos
+) {
 	if (c.pref.translated || c.file.is_translated) || struct_sym.language == .c {
 		return
 	}
@@ -978,7 +983,12 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 // This method is temporary and will only be called by the do_check_elements_ref_fields_initialized() method.
 // The goal is to give only a notice, not an error, for now. After a while,
 // when we change the notice to error, we can remove this temporary method.
-fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type, linked_name string, pos &token.Pos) {
+fn (mut c Checker) check_ref_fields_initialized_note(
+	struct_sym &ast.TypeSymbol,
+	mut checked_types []ast.Type,
+	linked_name string,
+	pos &token.Pos
+) {
 	if (c.pref.translated || c.file.is_translated) || struct_sym.language == .c {
 		return
 	}

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -186,7 +186,15 @@ fn (mut tasks Tasks) add(custom_vexe string, dir string, voptions string, result
 	tasks.add_evars('', custom_vexe, dir, voptions, result_extension, tests, is_module)
 }
 
-fn (mut tasks Tasks) add_evars(evars string, custom_vexe string, dir string, voptions string, result_extension string, tests []string, is_module bool) {
+fn (mut tasks Tasks) add_evars(
+	evars string,
+	custom_vexe string,
+	dir string,
+	voptions string,
+	result_extension string,
+	tests []string,
+	is_module bool
+) {
 	max_ntries := get_max_ntries()
 	paths := vtest.filter_vtest_only(tests, basepath: dir)
 	for path in paths {

--- a/vlib/v/doc/utils.v
+++ b/vlib/v/doc/utils.v
@@ -142,7 +142,7 @@ pub fn (mut d Doc) stmt_signature(stmt ast.Stmt) string {
 			return 'module ${stmt.name}'
 		}
 		ast.FnDecl {
-			return d.table.stringify_fn_decl(&stmt, d.fmt.cur_mod, d.fmt.mod2alias)
+			return d.table.stringify_fn_decl(&stmt, d.fmt.cur_mod, d.fmt.mod2alias, false)
 		}
 		else {
 			d.fmt.out = strings.new_builder(1000)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1083,7 +1083,11 @@ pub fn (mut f Fmt) enum_decl(node ast.EnumDecl) {
 
 pub fn (mut f Fmt) fn_decl(node ast.FnDecl) {
 	f.attrs(node.attrs)
-	f.write(f.table.stringify_fn_decl(&node, f.cur_mod, f.mod2alias))
+	mut fn_signature_str := f.table.stringify_fn_decl(&node, f.cur_mod, f.mod2alias, false)
+	if fn_signature_str.len > 140 {
+		fn_signature_str = f.table.stringify_fn_decl(&node, f.cur_mod, f.mod2alias, true)
+	}
+	f.write(fn_signature_str)
 	// Handle trailing comments after fn header declarations
 	if node.no_body && node.end_comments.len > 0 {
 		first_comment := node.end_comments[0]
@@ -1409,7 +1413,13 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 	f.writeln('}\n')
 }
 
-pub fn (mut f Fmt) calculate_alignment(fields []ast.StructField, mut field_aligns []AlignInfo, mut comment_aligns []AlignInfo, mut default_expr_aligns []AlignInfo, mut field_types []string) {
+pub fn (mut f Fmt) calculate_alignment(
+	fields []ast.StructField,
+	mut field_aligns []AlignInfo,
+	mut comment_aligns []AlignInfo,
+	mut default_expr_aligns []AlignInfo,
+	mut field_types []string
+) {
 	// Calculate the alignments first
 	for i, field in fields {
 		ft := f.no_cur_mod(f.table.type_to_str_using_aliases(field.typ, f.mod2alias))
@@ -1485,7 +1495,7 @@ pub fn (mut f Fmt) interface_method(method ast.FnDecl) {
 		f.comments(before_comments, level: .indent)
 	}
 	f.write('\t')
-	f.write(f.table.stringify_fn_decl(&method, f.cur_mod, f.mod2alias).all_after_first('fn '))
+	f.write(f.table.stringify_fn_decl(&method, f.cur_mod, f.mod2alias, false).all_after_first('fn '))
 	f.comments(end_comments, same_line: true, has_nl: false, level: .indent)
 	f.writeln('')
 	f.comments(method.next_comments, level: .indent)

--- a/vlib/v/fmt/tests/fn_with_super_long_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_super_long_args_keep.vv
@@ -1,0 +1,11 @@
+fn process_keyholder(
+	super_long_argument1 string,
+	super_long_argument2 string,
+	super_long_argument3 string,
+	super_long_argument4 string,
+	super_long_argument5 string
+) string {
+	return ''
+}
+
+fn main() {}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1111,7 +1111,15 @@ fn c_struct_ptr(sym &ast.TypeSymbol, typ ast.Type, expects_ptr bool) string {
 	return ''
 }
 
-fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.Type, fn_name string, field_name string, has_custom_str bool, expects_ptr bool) (string, bool) {
+fn struct_auto_str_func(
+	sym &ast.TypeSymbol,
+	lang ast.Language,
+	_field_type ast.Type,
+	fn_name string,
+	field_name string,
+	has_custom_str bool,
+	expects_ptr bool
+) (string, bool) {
 	$if trace_autostr ? {
 		eprintln('> struct_auto_str_func: ${sym.name} | field_type.debug() | ${fn_name} | ${field_name} | ${has_custom_str} | ${expects_ptr}')
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2492,7 +2492,15 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	g.auto_fn_definitions << sb.str()
 }
 
-fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr bool, exp_styp string, got_is_ptr bool, got_is_fn bool, got_styp string) {
+fn (mut g Gen) call_cfn_for_casting_expr(
+	fname string,
+	expr ast.Expr,
+	exp_is_ptr bool,
+	exp_styp string,
+	got_is_ptr bool,
+	got_is_fn bool,
+	got_styp string
+) {
 	mut rparen_n := 1
 	if exp_is_ptr {
 		g.write('HEAP(${exp_styp}, ')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1419,7 +1419,13 @@ fn (mut g Gen) resolve_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concre
 	return comptime_args
 }
 
-fn (mut g Gen) resolve_receiver_name(node ast.CallExpr, unwrapped_rec_type ast.Type, final_left_sym ast.TypeSymbol, left_sym ast.TypeSymbol, typ_sym ast.TypeSymbol) string {
+fn (mut g Gen) resolve_receiver_name(
+	node ast.CallExpr,
+	unwrapped_rec_type ast.Type,
+	final_left_sym ast.TypeSymbol,
+	left_sym ast.TypeSymbol,
+	typ_sym ast.TypeSymbol
+) string {
 	mut receiver_type_name := util.no_dots(g.cc_type(unwrapped_rec_type, false))
 	if final_left_sym.kind == .map && node.name in ['clone', 'move'] {
 		receiver_type_name = 'map'

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -221,7 +221,13 @@ fn (mut g Gen) write_orm_drop_table(table_name string, connection_var_name strin
 }
 
 // write_orm_insert writes C code that calls ORM functions for inserting structs into a table.
-fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string, or_expr &ast.OrExpr) {
+fn (mut g Gen) write_orm_insert(
+	node &ast.SqlStmtLine,
+	table_name string,
+	connection_var_name string,
+	result_var_name string,
+	or_expr &ast.OrExpr
+) {
 	last_ids_variable_name := g.new_tmp_var()
 
 	g.writeln('Array_orm__Primitive ${last_ids_variable_name} = __new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
@@ -295,7 +301,16 @@ fn (mut g Gen) write_orm_delete(node &ast.SqlStmtLine, table_name string, connec
 
 // write_orm_insert_with_last_ids writes C code that calls ORM functions for
 // inserting a struct into a table, saving inserted `id` into a passed variable.
-fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_var_name string, table_name string, last_ids_arr string, res string, pid string, fkey string, or_expr ast.OrExpr) {
+fn (mut g Gen) write_orm_insert_with_last_ids(
+	node ast.SqlStmtLine,
+	connection_var_name string,
+	table_name string,
+	last_ids_arr string,
+	res string,
+	pid string,
+	fkey string,
+	or_expr ast.OrExpr
+) {
 	mut subs := []ast.SqlStmtLine{}
 
 	mut subs_unwrapped_c_typ := []string{}
@@ -719,7 +734,14 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 }
 
 // write_orm_where_expr writes C code that generates expression which is used in the `QueryData`.
-fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut parentheses [][]int, mut kinds []string, mut data []ast.Expr, mut is_and []bool) {
+fn (mut g Gen) write_orm_where_expr(
+	expr ast.Expr,
+	mut fields []string,
+	mut parentheses [][]int,
+	mut kinds []string,
+	mut data []ast.Expr,
+	mut is_and []bool
+) {
 	match expr {
 		ast.InfixExpr {
 			g.sql_side = .left

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -905,7 +905,8 @@ pub fn (mut f Gen) enum_decl(node ast.EnumDecl) {
 
 pub fn (mut f Gen) fn_decl(node ast.FnDecl) {
 	f.attrs(node.attrs)
-	f.write(f.table.stringify_fn_decl(&node, f.cur_mod, f.mod2alias).replace('fn ', 'func '))
+	f.write(f.table.stringify_fn_decl(&node, f.cur_mod, f.mod2alias, false).replace('fn ',
+		'func '))
 	f.fn_body(node)
 }
 
@@ -1135,7 +1136,7 @@ pub fn (mut f Gen) interface_field(field ast.StructField) {
 
 pub fn (mut f Gen) interface_method(method ast.FnDecl) {
 	f.write('\t')
-	f.write(f.table.stringify_fn_decl(&method, f.cur_mod, f.mod2alias).after('fn '))
+	f.write(f.table.stringify_fn_decl(&method, f.cur_mod, f.mod2alias, false).after('fn '))
 	f.writeln('')
 	for param in method.params {
 		f.mark_types_import_as_used(param.typ)

--- a/vlib/v/gen/js/sourcemap/source_map_generator.v
+++ b/vlib/v/gen/js/sourcemap/source_map_generator.v
@@ -29,7 +29,13 @@ pub fn generate_empty_map() &Generator {
 	return &Generator{}
 }
 
-pub fn (mut g Generator) add_map(file string, source_root string, sources_content_inline bool, line_offset int, column_offset int) &SourceMap {
+pub fn (mut g Generator) add_map(
+	file string,
+	source_root string,
+	sources_content_inline bool,
+	line_offset int,
+	column_offset int
+) &SourceMap {
 	source_map := new_sourcemap(file, source_root, sources_content_inline)
 
 	offset := Offset{

--- a/vlib/v/live/executable/reloader.c.v
+++ b/vlib/v/live/executable/reloader.c.v
@@ -8,7 +8,13 @@ import v.live
 // The live reloader code is implemented here.
 // Note: new_live_reload_info will be called by generated C code inside main()
 @[markused]
-pub fn new_live_reload_info(original string, vexe string, vopts string, live_fn_mutex voidptr, live_linkfn live.FNLinkLiveSymbols) &live.LiveReloadInfo {
+pub fn new_live_reload_info(
+	original string,
+	vexe string,
+	vopts string,
+	live_fn_mutex voidptr,
+	live_linkfn live.FNLinkLiveSymbols
+) &live.LiveReloadInfo {
 	file_base := os.file_name(original).replace('.v', '')
 	so_dir := os.cache_dir()
 	mut so_extension := dl.dl_ext

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -424,7 +424,10 @@ fn check_and_clear_cache_files(c_folder string) ! {
 // Size limits are defined by the 'max_placeholders_key_size' and 'max_placeholders_value_size' constants.
 // Monitor dynamic content for updates by generating a checksum that is compared against the cached version to verify any changes.
 //
-fn (mut tm DynamicTemplateManager) check_tmpl_and_placeholders_size(f_path string, tmpl_var &map[string]DtmMultiTypeMap) !(string, string, string, TemplateType) {
+fn (mut tm DynamicTemplateManager) check_tmpl_and_placeholders_size(
+	f_path string,
+	tmpl_var &map[string]DtmMultiTypeMap
+) !(string, string, string, TemplateType) {
 	mut html_file := ''
 	mut file_name := ''
 	mut res_checksum_content := ''
@@ -522,7 +525,17 @@ fn (mut tm DynamicTemplateManager) check_tmpl_and_placeholders_size(f_path strin
 // This request is then sent to the cache handler channel, signaling either the need for a new cache or an update to an existing one.
 // The function returns the rendered immediately, without waiting for the cache to be created or updated.
 //
-fn (mut tm DynamicTemplateManager) create_template_cache_and_display(tcs CacheRequest, last_template_mod i64, unique_time i64, file_path string, tmpl_name string, cache_delay_expiration i64, placeholders &map[string]DtmMultiTypeMap, current_content_checksum string, tmpl_type TemplateType) string {
+fn (mut tm DynamicTemplateManager) create_template_cache_and_display(
+	tcs CacheRequest,
+	last_template_mod i64,
+	unique_time i64,
+	file_path string,
+	tmpl_name string,
+	cache_delay_expiration i64,
+	placeholders &map[string]DtmMultiTypeMap,
+	current_content_checksum string,
+	tmpl_type TemplateType
+) string {
 	// Control if cache delay expiration is correctly set. See the function itself for more details.
 	check_if_cache_delay_iscorrect(cache_delay_expiration, tmpl_name) or {
 		eprintln(err)
@@ -995,7 +1008,13 @@ const allowed_tags = ['<div>', '</div>', '<h1>', '</h1>', '<h2>', '</h2>', '<h3>
 
 const include_html_key_tag = '_#includehtml'
 
-fn (mut tm DynamicTemplateManager) parse_tmpl_file(file_path string, tmpl_name string, placeholders &map[string]DtmMultiTypeMap, is_compressed bool, tmpl_type TemplateType) string {
+fn (mut tm DynamicTemplateManager) parse_tmpl_file(
+	file_path string,
+	tmpl_name string,
+	placeholders &map[string]DtmMultiTypeMap,
+	is_compressed bool,
+	tmpl_type TemplateType
+) string {
 	mut tmpl_ := compile_template_file(file_path, tmpl_name, placeholders)
 
 	// Performs a light compression of the HTML output by removing usless spaces, newlines, and tabs if user selected this option.
@@ -1036,7 +1055,17 @@ fn check_if_cache_delay_iscorrect(cde i64, tmpl_name string) ! {
 // It assesses various conditions such as cache existence, cache expiration settings, and last modification timestamps ( template or dynamic content )
 // to decide whether to create a new cache, update an existing or delivered a valid cache content.
 //
-fn (mut tm DynamicTemplateManager) cache_request_route(is_cache_exist bool, neg_cache_delay_expiration i64, last_template_mod i64, test_current_template_mod i64, cache_del_exp i64, gen_at i64, c_time i64, content_checksum string, current_content_checksum string) (CacheRequest, i64) {
+fn (mut tm DynamicTemplateManager) cache_request_route(
+	is_cache_exist bool,
+	neg_cache_delay_expiration i64,
+	last_template_mod i64,
+	test_current_template_mod i64,
+	cache_del_exp i64,
+	gen_at i64,
+	c_time i64,
+	content_checksum string,
+	current_content_checksum string
+) (CacheRequest, i64) {
 	if !is_cache_exist || neg_cache_delay_expiration == -1 {
 		// Require cache creation
 		unique_ts := get_current_unix_micro_timestamp()


### PR DESCRIPTION
This PR implement wrapping function's super long arguments (fix #15545, fix #21643).

- Implement wrapping function's super long arguments.
- Add test.

- vlib\v\fmt\tests\fn_with_super_long_args_keep.vv
```v
fn process_keyholder(
	super_long_argument1 string,
	super_long_argument2 string,
	super_long_argument3 string,
	super_long_argument4 string,
	super_long_argument5 string
) string {
	return ''
}

fn main() {}
```

