### PR TITLE
fmt: implement wrapping function's super long arguments (fix #15545, #21643)

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -125,7 +125,8 @@ fn (mut ts TestSession) append_message(kind MessageKind, msg string, mtc Message
 	}
 }
 
-fn (mut ts TestSession) append_message_with_duration(kind MessageKind, msg string, d time.Duration, mtc MessageThreadContext) {
+fn (mut ts TestSession) append_message_with_duration(kind MessageKind, msg string, d time.Duration,
+	mtc MessageThreadContext) {
 	ts.nmessages <- LogMessage{
 		file: mtc.file
 		flow_id: mtc.flow_id

--- a/cmd/tools/vdoc/markdown.v
+++ b/cmd/tools/vdoc/markdown.v
@@ -26,7 +26,8 @@ fn (vd VDoc) gen_markdown(d doc.Doc, with_toc bool) string {
 	return hw.str() + '\n' + cw.str()
 }
 
-fn (vd VDoc) write_markdown_content(contents []doc.DocNode, mut cw strings.Builder, mut hw strings.Builder, indent int, with_toc bool) {
+fn (vd VDoc) write_markdown_content(contents []doc.DocNode, mut cw strings.Builder, mut hw strings.Builder,
+	indent int, with_toc bool) {
 	cfg := vd.cfg
 	for cn in contents {
 		if with_toc && cn.name != '' {

--- a/cmd/tools/vtest-cleancode.v
+++ b/cmd/tools/vtest-cleancode.v
@@ -55,7 +55,8 @@ fn main() {
 	v_test_vetting(pass_args)!
 }
 
-fn tsession(vargs string, tool_source string, tool_cmd string, tool_args string, flist []string, slist []string) testing.TestSession {
+fn tsession(vargs string, tool_source string, tool_cmd string, tool_args string, flist []string,
+	slist []string) testing.TestSession {
 	os.chdir(vroot) or {}
 	title_message := 'running ${tool_cmd} over most .v files'
 	testing.eheader(title_message)

--- a/examples/c_interop_wkhtmltopdf.v
+++ b/examples/c_interop_wkhtmltopdf.v
@@ -29,19 +29,22 @@ fn C.wkhtmltopdf_create_global_settings() &C.wkhtmltopdf_global_settings
 
 fn C.wkhtmltopdf_destroy_global_settings(global_settings &C.wkhtmltopdf_global_settings)
 
-fn C.wkhtmltopdf_set_global_setting(global_settings &C.wkhtmltopdf_global_settings, name &char, value &char) bool
+fn C.wkhtmltopdf_set_global_setting(global_settings &C.wkhtmltopdf_global_settings, name &char,
+	value &char) bool
 
 fn C.wkhtmltopdf_create_object_settings() &C.wkhtmltopdf_object_settings
 
 fn C.wkhtmltopdf_destroy_object_settings(object_settings &C.wkhtmltopdf_object_settings)
 
-fn C.wkhtmltopdf_set_object_setting(object_settings &C.wkhtmltopdf_object_settings, name &char, value &char) bool
+fn C.wkhtmltopdf_set_object_setting(object_settings &C.wkhtmltopdf_object_settings, name &char,
+	value &char) bool
 
 fn C.wkhtmltopdf_create_converter(global_settings &C.wkhtmltopdf_global_settings) &C.wkhtmltopdf_converter
 
 fn C.wkhtmltopdf_destroy_converter(converter &C.wkhtmltopdf_converter)
 
-fn C.wkhtmltopdf_add_object(converter &C.wkhtmltopdf_converter, object_settings &C.wkhtmltopdf_object_settings, data &char)
+fn C.wkhtmltopdf_add_object(converter &C.wkhtmltopdf_converter, object_settings &C.wkhtmltopdf_object_settings,
+	data &char)
 
 fn C.wkhtmltopdf_convert(converter &C.wkhtmltopdf_converter) bool
 

--- a/examples/graphs/dfs2.v
+++ b/examples/graphs/dfs2.v
@@ -48,7 +48,8 @@ pub mut:
 	pattern [][]string
 }
 
-fn (mut s Solution) find_pattern(adj map[string][]string, mut visited map[string]bool, node string, target string, mut path []string) {
+fn (mut s Solution) find_pattern(adj map[string][]string, mut visited map[string]bool, node string,
+	target string, mut path []string) {
 	path << node
 	visited[node] = true
 	if node == target {

--- a/examples/sokol/06_obj_viewer/modules/obj/rend.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/rend.v
@@ -70,7 +70,8 @@ pub fn load_texture(file_name string) (gfx.Image, gfx.Sampler) {
 /******************************************************************************
 * Pipeline
 ******************************************************************************/
-pub fn (mut obj_part ObjPart) create_pipeline(in_part []int, shader gfx.Shader, texture gfx.Image, sampler gfx.Sampler) Render_data {
+pub fn (mut obj_part ObjPart) create_pipeline(in_part []int, shader gfx.Shader, texture gfx.Image,
+	sampler gfx.Sampler) Render_data {
 	mut res := Render_data{}
 	obj_buf := obj_part.get_buffer(in_part)
 	res.n_vert = obj_buf.n_vertex

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -158,7 +158,8 @@ pub:
 }
 
 // step_message_with_label_and_duration returns a string describing the current step.
-pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg string, sduration time.Duration, opts MessageOptions) string {
+pub fn (b &Benchmark) step_message_with_label_and_duration(label string, msg string, sduration time.Duration,
+	opts MessageOptions) string {
 	timed_line := b.tdiff_in_ms(msg, sduration.microseconds())
 	if b.nexpected_steps > 1 {
 		mut sprogress := ''

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -172,7 +172,8 @@ pub fn gc_check_leaks() {
 	}
 }
 
-fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_bytes &usize, pbytes_since_gc &usize, ptotal_bytes &usize)
+fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_bytes &usize, pbytes_since_gc &usize,
+	ptotal_bytes &usize)
 fn C.GC_get_memory_use() usize
 
 pub struct C.GC_stack_base {

--- a/vlib/builtin/builtin_d_use_libbacktrace.c.v
+++ b/vlib/builtin/builtin_d_use_libbacktrace.c.v
@@ -14,8 +14,10 @@ type BacktraceErrorCallback = fn (data voidptr, msg &char, errnum int) voidptr
 
 type BacktraceFullCallback = fn (data voidptr, pc voidptr, filename &char, lineno int, func &char) &int
 
-fn C.backtrace_create_state(filename &char, threaded int, error_callback BacktraceErrorCallback, data voidptr) &C.backtrace_state
-fn C.backtrace_full(state &C.backtrace_state, skip int, cb BacktraceFullCallback, err_cb BacktraceErrorCallback, data voidptr) int
+fn C.backtrace_create_state(filename &char, threaded int, error_callback BacktraceErrorCallback,
+	data voidptr) &C.backtrace_state
+fn C.backtrace_full(state &C.backtrace_state, skip int, cb BacktraceFullCallback, err_cb BacktraceErrorCallback,
+	data voidptr) int
 
 __global bt_state = init_bt_state()
 

--- a/vlib/builtin/builtin_notd_gcboehm.c.v
+++ b/vlib/builtin/builtin_notd_gcboehm.c.v
@@ -14,7 +14,8 @@ fn C.GC_REALLOC(ptr voidptr, n usize) voidptr
 
 fn C.GC_FREE(ptr voidptr)
 
-fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_bytes &usize, pbytes_since_gc &usize, ptotal_bytes &usize)
+fn C.GC_get_heap_usage_safe(pheap_size &usize, pfree_bytes &usize, punmapped_bytes &usize, pbytes_since_gc &usize,
+	ptotal_bytes &usize)
 
 fn C.GC_get_memory_use() usize
 

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -87,9 +87,11 @@ fn C.geteuid() int
 
 fn C.system(cmd &char) int
 
-fn C.posix_spawn(child_pid &int, path &char, file_actions voidptr, attrp voidptr, argv &&char, envp &&char) int
+fn C.posix_spawn(child_pid &int, path &char, file_actions voidptr, attrp voidptr, argv &&char,
+	envp &&char) int
 
-fn C.posix_spawnp(child_pid &int, exefile &char, file_actions voidptr, attrp voidptr, argv &&char, envp &&char) int
+fn C.posix_spawnp(child_pid &int, exefile &char, file_actions voidptr, attrp voidptr, argv &&char,
+	envp &&char) int
 
 fn C.execve(cmd_path &char, args voidptr, envs voidptr) int
 
@@ -237,9 +239,11 @@ fn C.GetModuleFileName(hModule voidptr, lpFilename &u16, nSize u32) u32
 
 fn C.GetModuleFileNameW(hModule voidptr, lpFilename &u16, nSize u32) u32
 
-fn C.CreateFile(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
+fn C.CreateFile(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16,
+	dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
 
-fn C.CreateFileW(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
+fn C.CreateFileW(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16,
+	dwCreationDisposition u32, dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
 
 fn C.GetFinalPathNameByHandleW(hFile voidptr, lpFilePath &u16, nSize u32, dwFlags u32) u32
 
@@ -256,17 +260,22 @@ fn C.GetUserNameW(&u16, &u32) bool
 @[trusted]
 fn C.SendMessageTimeout() isize
 
-fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlags u32, uTimeout u32, lpdwResult &u64) isize
+fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlags u32, uTimeout u32,
+	lpdwResult &u64) isize
 
-fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr, lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
+fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr,
+	lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
 
-fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead &u32, lpOverlapped voidptr) bool
+fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead &u32,
+	lpOverlapped voidptr) bool
 
 fn C.GetFileAttributesW(lpFileName &u8) u32
 
-fn C.RegQueryValueEx(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8, lpcbData &u32) int
+fn C.RegQueryValueEx(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8,
+	lpcbData &u32) int
 
-fn C.RegQueryValueExW(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8, lpcbData &u32) int
+fn C.RegQueryValueExW(hKey voidptr, lpValueName &u16, lp_reserved &u32, lpType &u32, lpData &u8,
+	lpcbData &u32) int
 
 fn C.RegOpenKeyEx(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, phkResult voidptr) int
 
@@ -274,7 +283,8 @@ fn C.RegOpenKeyExW(hKey voidptr, lpSubKey &u16, ulOptions u32, samDesired u32, p
 
 fn C.RegSetValueEx(hKey voidptr, lpValueName &u16, dwType u32, lpData &u16, cbData u32) int
 
-fn C.RegSetValueExW(hKey voidptr, lpValueName &u16, reserved u32, dwType u32, const_lpData &u8, cbData u32) int
+fn C.RegSetValueExW(hKey voidptr, lpValueName &u16, reserved u32, dwType u32, const_lpData &u8,
+	cbData u32) int
 
 fn C.RegCloseKey(hKey voidptr) int
 
@@ -298,11 +308,13 @@ fn C.setbuf(voidptr, &char)
 
 fn C.SymCleanup(hProcess voidptr)
 
-fn C.MultiByteToWideChar(codePage u32, dwFlags u32, lpMultiMyteStr &char, cbMultiByte int, lpWideCharStr &u16, cchWideChar int) int
+fn C.MultiByteToWideChar(codePage u32, dwFlags u32, lpMultiMyteStr &char, cbMultiByte int, lpWideCharStr &u16,
+	cchWideChar int) int
 
 fn C.wcslen(str voidptr) usize
 
-fn C.WideCharToMultiByte(codePage u32, dwFlags u32, lpWideCharStr &u16, cchWideChar int, lpMultiByteStr &char, cbMultiByte int, lpDefaultChar &char, lpUsedDefaultChar &int) int
+fn C.WideCharToMultiByte(codePage u32, dwFlags u32, lpWideCharStr &u16, cchWideChar int, lpMultiByteStr &char,
+	cbMultiByte int, lpDefaultChar &char, lpUsedDefaultChar &int) int
 
 fn C._wstat(path &u16, buffer &C._stat) int
 
@@ -324,7 +336,8 @@ fn C._waccess(path &u16, mode int) int
 
 fn C._wremove(path &u16) int
 
-fn C.ReadConsole(in_input_handle voidptr, out_buffer voidptr, in_chars_to_read u32, out_read_chars &u32, in_input_control voidptr) bool
+fn C.ReadConsole(in_input_handle voidptr, out_buffer voidptr, in_chars_to_read u32, out_read_chars &u32,
+	in_input_control voidptr) bool
 
 fn C.WriteConsole() voidptr
 
@@ -354,7 +367,8 @@ fn C.FindClose(hFindFile voidptr)
 // macro
 fn C.MAKELANGID(lgid voidptr, srtid voidptr) int
 
-fn C.FormatMessageW(dwFlags u32, lpSource voidptr, dwMessageId u32, dwLanguageId u32, lpBuffer voidptr, nSize u32, arguments ...voidptr) u32
+fn C.FormatMessageW(dwFlags u32, lpSource voidptr, dwMessageId u32, dwLanguageId u32, lpBuffer voidptr,
+	nSize u32, arguments ...voidptr) u32
 
 fn C.CloseHandle(voidptr) int
 

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -264,7 +264,8 @@ fn C.SendMessageTimeoutW(hWnd voidptr, msg u32, wParam &u16, lParam &u32, fuFlag
 	lpdwResult &u64) isize
 
 fn C.CreateProcessW(lpApplicationName &u16, lpCommandLine &u16, lpProcessAttributes voidptr,
-	lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr, lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
+	lpThreadAttributes voidptr, bInheritHandles bool, dwCreationFlags u32, lpEnvironment voidptr,
+	lpCurrentDirectory &u16, lpStartupInfo voidptr, lpProcessInformation voidptr) bool
 
 fn C.ReadFile(hFile voidptr, lpBuffer voidptr, nNumberOfBytesToRead u32, lpNumberOfBytesRead &u32,
 	lpOverlapped voidptr) bool

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -247,7 +247,8 @@ fn map_free_string(pkey voidptr) {
 fn map_free_nop(_ voidptr) {
 }
 
-fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn,
+	free_fn MapFreeFn) map {
 	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
@@ -269,7 +270,8 @@ fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
 	}
 }
 
-fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn,
+	n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn, free_fn)
 	// TODO: pre-allocate n slots
 	mut pkey := &u8(keys)

--- a/vlib/builtin/map_d_gcboehm_opt.v
+++ b/vlib/builtin/map_d_gcboehm_opt.v
@@ -29,7 +29,8 @@ fn new_dense_array_noscan(key_bytes int, key_noscan bool, value_bytes int, value
 	}
 }
 
-fn new_map_noscan_key(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+fn new_map_noscan_key(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn,
+	free_fn MapFreeFn) map {
 	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
@@ -51,7 +52,8 @@ fn new_map_noscan_key(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_
 	}
 }
 
-fn new_map_noscan_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+fn new_map_noscan_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
+	clone_fn MapCloneFn, free_fn MapFreeFn) map {
 	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
@@ -73,7 +75,8 @@ fn new_map_noscan_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_e
 	}
 }
 
-fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
+	clone_fn MapCloneFn, free_fn MapFreeFn) map {
 	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
@@ -95,7 +98,8 @@ fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, k
 	}
 }
 
-fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn,
+	n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map_noscan_key(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
 	// TODO: pre-allocate n slots
@@ -111,7 +115,8 @@ fn new_map_init_noscan_key(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapClo
 	return out
 }
 
-fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn,
+	n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map_noscan_value(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
 	// TODO: pre-allocate n slots
@@ -127,7 +132,8 @@ fn new_map_init_noscan_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapC
 	return out
 }
 
-fn new_map_init_noscan_key_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
+fn new_map_init_noscan_key_value(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn,
+	n int, key_bytes int, value_bytes int, keys voidptr, values voidptr) map {
 	mut out := new_map_noscan_key_value(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn,
 		free_fn)
 	// TODO: pre-allocate n slots

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -117,7 +117,8 @@ fn abs64(x i64) u64 {
 //---------------------------------------
 
 // convert from data format to compact u64
-pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u64 {
+pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool,
+	in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u64 {
 	width := if in_width != 0 { abs64(in_width) } else { u64(0) }
 	align := if in_width > 0 { u64(1 << 5) } else { u64(0) } // two bit 0 .left 1 .right, for now we use only one
 	upper_case := if in_upper_case { u64(1 << 7) } else { u64(0) }
@@ -134,7 +135,8 @@ pub fn get_str_intp_u64_format(fmt_type StrIntpType, in_width int, in_precision 
 }
 
 // convert from data format to compact u32
-pub fn get_str_intp_u32_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool, in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u32 {
+pub fn get_str_intp_u32_format(fmt_type StrIntpType, in_width int, in_precision int, in_tail_zeros bool,
+	in_sign bool, in_pad_ch u8, in_base int, in_upper_case bool) u32 {
 	width := if in_width != 0 { abs64(in_width) } else { u32(0) }
 	align := if in_width > 0 { u32(1 << 5) } else { u32(0) } // two bit 0 .left 1 .right, for now we use only one
 	upper_case := if in_upper_case { u32(1 << 7) } else { u32(0) }

--- a/vlib/clipboard/clipboard_windows.c.v
+++ b/vlib/clipboard/clipboard_windows.c.v
@@ -24,7 +24,8 @@ fn C.RegisterClassEx(class &WndClassEx) int
 
 fn C.GetClipboardOwner() C.HWND
 
-fn C.CreateWindowEx(dwExStyle i64, lpClassName &u16, lpWindowName &u16, dwStyle i64, x int, y int, nWidth int, nHeight int, hWndParent i64, hMenu voidptr, h_instance voidptr, lpParam voidptr) C.HWND
+fn C.CreateWindowEx(dwExStyle i64, lpClassName &u16, lpWindowName &u16, dwStyle i64, x int, y int,
+	nWidth int, nHeight int, hWndParent i64, hMenu voidptr, h_instance voidptr, lpParam voidptr) C.HWND
 
 // fn C.MultiByteToWideChar(CodePage u32, dw_flags u16, lpMultiByteStr byteptr, cbMultiByte int, lpWideCharStr u16, cchWideChar int) int
 fn C.EmptyClipboard()

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -41,21 +41,25 @@ fn C.XSetSelectionOwner(d &C.Display, a Atom, w Window, time int)
 
 fn C.XGetSelectionOwner(d &C.Display, a Atom) Window
 
-fn C.XChangeProperty(d &C.Display, requestor Window, property Atom, typ Atom, format int, mode int, data voidptr, nelements int) int
+fn C.XChangeProperty(d &C.Display, requestor Window, property Atom, typ Atom, format int, mode int,
+	data voidptr, nelements int) int
 
 fn C.XSendEvent(d &C.Display, requestor Window, propagate int, mask i64, event &C.XEvent)
 
 fn C.XInternAtom(d &C.Display, typ &u8, only_if_exists int) Atom
 
-fn C.XCreateSimpleWindow(d &C.Display, root Window, x int, y int, width u32, height u32, border_width u32, border u64, background u64) Window
+fn C.XCreateSimpleWindow(d &C.Display, root Window, x int, y int, width u32, height u32, border_width u32,
+	border u64, background u64) Window
 
 fn C.XOpenDisplay(name &u8) &C.Display
 
-fn C.XConvertSelection(d &C.Display, selection Atom, target Atom, property Atom, requestor Window, time int) int
+fn C.XConvertSelection(d &C.Display, selection Atom, target Atom, property Atom, requestor Window,
+	time int) int
 
 fn C.XSync(d &C.Display, discard int) int
 
-fn C.XGetWindowProperty(d &C.Display, w Window, property Atom, offset i64, length i64, delete int, req_type Atom, actual_type_return &Atom, actual_format_return &int, nitems &u64, bytes_after_return &u64, prop_return &&u8) int
+fn C.XGetWindowProperty(d &C.Display, w Window, property Atom, offset i64, length i64, delete int,
+	req_type Atom, actual_type_return &Atom, actual_format_return &int, nitems &u64, bytes_after_return &u64, prop_return &&u8) int
 
 fn C.XDeleteProperty(d &C.Display, w Window, property Atom) int
 

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -59,7 +59,8 @@ fn C.XConvertSelection(d &C.Display, selection Atom, target Atom, property Atom,
 fn C.XSync(d &C.Display, discard int) int
 
 fn C.XGetWindowProperty(d &C.Display, w Window, property Atom, offset i64, length i64, delete int,
-	req_type Atom, actual_type_return &Atom, actual_format_return &int, nitems &u64, bytes_after_return &u64, prop_return &&u8) int
+	req_type Atom, actual_type_return &Atom, actual_format_return &int, nitems &u64, bytes_after_return &u64,
+	prop_return &&u8) int
 
 fn C.XDeleteProperty(d &C.Display, w Window, property Atom) int
 

--- a/vlib/crypto/ed25519/internal/edwards25519/scalar_alias_test.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/scalar_alias_test.v
@@ -54,7 +54,8 @@ fn test_check_aliasing_twoargs() {
 	}
 }
 
-fn check_aliasing_twoargs(f fn (mut v Scalar, x Scalar, y Scalar) Scalar, mut v Scalar, x Scalar, y Scalar) bool {
+fn check_aliasing_twoargs(f fn (mut v Scalar, x Scalar, y Scalar) Scalar, mut v Scalar, x Scalar,
+	y Scalar) bool {
 	x1, y1, mut v1 := x, y, Scalar{}
 
 	// Calculate a reference f(x, y) without aliasing.

--- a/vlib/datatypes/fsm/fsm.v
+++ b/vlib/datatypes/fsm/fsm.v
@@ -47,7 +47,8 @@ pub fn (mut s StateMachine) get_state() string {
 	return s.current_state
 }
 
-pub fn (mut s StateMachine) add_state(name string, entry EventHandlerFn, run EventHandlerFn, exit EventHandlerFn) {
+pub fn (mut s StateMachine) add_state(name string, entry EventHandlerFn, run EventHandlerFn,
+	exit EventHandlerFn) {
 	s.states[name] = State{
 		entry_handler: entry
 		run_handler: run

--- a/vlib/datatypes/quadtree.v
+++ b/vlib/datatypes/quadtree.v
@@ -19,7 +19,8 @@ pub mut:
 }
 
 // create returns a new configurable root node for the tree.
-pub fn (mut q Quadtree) create(x f64, y f64, width f64, height f64, capacity int, depth int, level int) Quadtree {
+pub fn (mut q Quadtree) create(x f64, y f64, width f64, height f64, capacity int, depth int,
+	level int) Quadtree {
 	return Quadtree{
 		perimeter: AABB{
 			x: x

--- a/vlib/db/mssql/_cdefs.c.v
+++ b/vlib/db/mssql/_cdefs.c.v
@@ -2,19 +2,24 @@ module mssql
 
 fn C.SQLAllocHandle(handle_type C.SQLSMALLINT, input_handle C.SQLHANDLE, output_handle &C.SQLHANDLE) C.SQLRETURN
 
-fn C.SQLSetEnvAttr(environment_handle C.SQLHENV, attribute C.SQLINTEGER, value C.SQLPOINTER, string_length C.SQLINTEGER) C.SQLRETURN
+fn C.SQLSetEnvAttr(environment_handle C.SQLHENV, attribute C.SQLINTEGER, value C.SQLPOINTER,
+	string_length C.SQLINTEGER) C.SQLRETURN
 
-fn C.SQLGetDiagRec(handle_type C.SQLSMALLINT, handle C.SQLHANDLE, rec_number C.SQLSMALLINT, sql_state &C.SQLCHAR, native_error &C.SQLINTEGER, message_text &C.SQLCHAR, buffer_length C.SQLSMALLINT, text_length &C.SQLSMALLINT) C.SQLRETURN
+fn C.SQLGetDiagRec(handle_type C.SQLSMALLINT, handle C.SQLHANDLE, rec_number C.SQLSMALLINT, sql_state &C.SQLCHAR,
+	native_error &C.SQLINTEGER, message_text &C.SQLCHAR, buffer_length C.SQLSMALLINT, text_length &C.SQLSMALLINT) C.SQLRETURN
 
-fn C.SQLSetConnectAttr(connection_handle C.SQLHDBC, attribute C.SQLINTEGER, value C.SQLPOINTER, string_length C.SQLINTEGER) C.SQLRETURN
+fn C.SQLSetConnectAttr(connection_handle C.SQLHDBC, attribute C.SQLINTEGER, value C.SQLPOINTER,
+	string_length C.SQLINTEGER) C.SQLRETURN
 
-fn C.SQLDriverConnect(hdbc C.SQLHDBC, hwnd C.SQLHWND, sz_conn_str_in &C.SQLCHAR, cb_conn_str_in C.SQLSMALLINT, sz_conn_str_out &C.SQLCHAR, cb_conn_str_out_max C.SQLSMALLINT, pcb_conn_str_out &C.SQLSMALLINT, f_driver_completion C.SQLUSMALLINT) C.SQLRETURN
+fn C.SQLDriverConnect(hdbc C.SQLHDBC, hwnd C.SQLHWND, sz_conn_str_in &C.SQLCHAR, cb_conn_str_in C.SQLSMALLINT,
+	sz_conn_str_out &C.SQLCHAR, cb_conn_str_out_max C.SQLSMALLINT, pcb_conn_str_out &C.SQLSMALLINT, f_driver_completion C.SQLUSMALLINT) C.SQLRETURN
 
 fn C.SQLDisconnect(connection_handle C.SQLHDBC) C.SQLRETURN
 
 fn C.SQLExecDirect(statement_handle C.SQLHSTMT, statement_text &C.SQLCHAR, text_length C.SQLINTEGER) C.SQLRETURN
 
-fn C.SQLBindCol(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, target_type C.SQLSMALLINT, target_value C.SQLPOINTER, buffer_length C.SQLLEN, str_len_or_ind &C.SQLLEN) C.SQLRETURN
+fn C.SQLBindCol(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, target_type C.SQLSMALLINT,
+	target_value C.SQLPOINTER, buffer_length C.SQLLEN, str_len_or_ind &C.SQLLEN) C.SQLRETURN
 
 fn C.SQLFetch(statement_handle C.SQLHSTMT) C.SQLRETURN
 
@@ -22,6 +27,7 @@ fn C.SQLFreeHandle(handle_type C.SQLSMALLINT, handle C.SQLHANDLE) C.SQLRETURN
 
 fn C.SQLNumResultCols(statement_handle C.SQLHSTMT, column_count &C.SQLSMALLINT) C.SQLRETURN
 
-fn C.SQLColAttribute(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, field_identifier C.SQLUSMALLINT, character_attribute C.SQLPOINTER, buffer_length C.SQLSMALLINT, string_length C.SQLSMALLINT, numeric_attribute &C.SQLLEN) C.SQLRETURN
+fn C.SQLColAttribute(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, field_identifier C.SQLUSMALLINT,
+	character_attribute C.SQLPOINTER, buffer_length C.SQLSMALLINT, string_length C.SQLSMALLINT, numeric_attribute &C.SQLLEN) C.SQLRETURN
 
 fn C.SQLRowCount(statement_handle C.SQLHSTMT, row_count &C.SQLLEN) C.SQLRETURN

--- a/vlib/db/mssql/_cdefs.c.v
+++ b/vlib/db/mssql/_cdefs.c.v
@@ -12,7 +12,8 @@ fn C.SQLSetConnectAttr(connection_handle C.SQLHDBC, attribute C.SQLINTEGER, valu
 	string_length C.SQLINTEGER) C.SQLRETURN
 
 fn C.SQLDriverConnect(hdbc C.SQLHDBC, hwnd C.SQLHWND, sz_conn_str_in &C.SQLCHAR, cb_conn_str_in C.SQLSMALLINT,
-	sz_conn_str_out &C.SQLCHAR, cb_conn_str_out_max C.SQLSMALLINT, pcb_conn_str_out &C.SQLSMALLINT, f_driver_completion C.SQLUSMALLINT) C.SQLRETURN
+	sz_conn_str_out &C.SQLCHAR, cb_conn_str_out_max C.SQLSMALLINT, pcb_conn_str_out &C.SQLSMALLINT,
+	f_driver_completion C.SQLUSMALLINT) C.SQLRETURN
 
 fn C.SQLDisconnect(connection_handle C.SQLHDBC) C.SQLRETURN
 

--- a/vlib/db/mysql/_cdefs.c.v
+++ b/vlib/db/mysql/_cdefs.c.v
@@ -36,7 +36,8 @@ pub struct C.MYSQL_FIELD {
 fn C.mysql_init(mysql &C.MYSQL) &C.MYSQL
 
 // C.mysql_real_connect attempts to establish a connection to a MySQL server running on `host`.
-fn C.mysql_real_connect(mysql &C.MYSQL, host &char, user &char, passwd &char, db &char, port u32, unix_socket &char, client_flag ConnectionFlag) &C.MYSQL
+fn C.mysql_real_connect(mysql &C.MYSQL, host &char, user &char, passwd &char, db &char, port u32,
+	unix_socket &char, client_flag ConnectionFlag) &C.MYSQL
 
 // C.mysql_query executes the SQL statement pointed to by the null-terminated string `stmt_str`.
 fn C.mysql_query(mysql &C.MYSQL, q &u8) int

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -137,7 +137,8 @@ fn C.PQnfields(const_res &C.PGresult) int
 // const char *const *paramValues
 // const int *paramLengths
 // const int *paramFormats
-fn C.PQexecParams(conn &C.PGconn, const_command &char, nParams int, const_paramTypes &int, const_paramValues &char, const_paramLengths &int, const_paramFormats &int, resultFormat int) &C.PGresult
+fn C.PQexecParams(conn &C.PGconn, const_command &char, nParams int, const_paramTypes &int, const_paramValues &char,
+	const_paramLengths &int, const_paramFormats &int, resultFormat int) &C.PGresult
 
 fn C.PQputCopyData(conn &C.PGconn, const_buffer &char, nbytes int) int
 

--- a/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
+++ b/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
@@ -135,7 +135,8 @@ fn example_vfs_access(vfs &sqlite.Sqlite3_vfs, zPath &char, flags int, pResOut &
 	return sqlite.sqlite_ok
 }
 
-fn example_vfs_open(vfs &sqlite.Sqlite3_vfs, file_name_or_null_for_tempfile &char, vfs_opened_file &sqlite.Sqlite3_file, in_flags int, out_flags &int) int {
+fn example_vfs_open(vfs &sqlite.Sqlite3_vfs, file_name_or_null_for_tempfile &char, vfs_opened_file &sqlite.Sqlite3_file,
+	in_flags int, out_flags &int) int {
 	println('open called')
 
 	mut is_temp := false

--- a/vlib/gg/bezier.c.v
+++ b/vlib/gg/bezier.c.v
@@ -18,7 +18,8 @@ pub fn (ctx &Context) draw_cubic_bezier_recursive(points []f32, c Color) {
 
 // draw_cubic_bezier_recursive_scalar is the same as `draw_cubic_bezier_recursive`, except that the `points` are given
 // as indiviual x,y f32 scalar parameters, and not in a single dynamic array parameter.
-pub fn (ctx &Context) draw_cubic_bezier_recursive_scalar(x1 f32, y1 f32, x2 f32, y2 f32, x3 f32, y3 f32, x4 f32, y4 f32, c Color) {
+pub fn (ctx &Context) draw_cubic_bezier_recursive_scalar(x1 f32, y1 f32, x2 f32, y2 f32, x3 f32,
+	y3 f32, x4 f32, y4 f32, c Color) {
 	if c.a == 0 {
 		return
 	}
@@ -34,7 +35,8 @@ pub fn (ctx &Context) draw_cubic_bezier_recursive_scalar(x1 f32, y1 f32, x2 f32,
 }
 
 // based on nsvg__flattenCubicBez, from https://github.com/memononen/nanosvg/ :
-fn (ctx &Context) cubic_bezier_rec(x1 f32, y1 f32, x2 f32, y2 f32, x3 f32, y3 f32, x4 f32, y4 f32, level int) {
+fn (ctx &Context) cubic_bezier_rec(x1 f32, y1 f32, x2 f32, y2 f32, x3 f32, y3 f32, x4 f32, y4 f32,
+	level int) {
 	if level > 10 {
 		return
 	}

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -670,7 +670,8 @@ pub fn (ctx &Context) draw_circle_line(x f32, y f32, radius int, segments int, c
 }
 
 // draw_slice_empty draws the outline of a circle slice/pie
-pub fn (ctx &Context) draw_slice_empty(x f32, y f32, radius f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_slice_empty(x f32, y f32, radius f32, start_angle f32, end_angle f32,
+	segments int, c gx.Color) {
 	if segments <= 0 || radius <= 0 {
 		return
 	}
@@ -706,7 +707,8 @@ pub fn (ctx &Context) draw_slice_empty(x f32, y f32, radius f32, start_angle f32
 // `end_angle` is the angle in radians at which the slice ends.
 // `segments` affects how smooth/round the slice is.
 // `c` is the fill color.
-pub fn (ctx &Context) draw_slice_filled(x f32, y f32, radius f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_slice_filled(x f32, y f32, radius f32, start_angle f32, end_angle f32,
+	segments int, c gx.Color) {
 	if segments <= 0 || radius < 0 {
 		return
 	}
@@ -747,7 +749,8 @@ pub fn (ctx &Context) draw_slice_filled(x f32, y f32, radius f32, start_angle f3
 // `end_angle` is the angle in radians at which the arc ends.
 // `segments` affects how smooth/round the arc is.
 // `c` is the color of the arc/outline.
-pub fn (ctx Context) draw_arc_line(x f32, y f32, radius f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx Context) draw_arc_line(x f32, y f32, radius f32, start_angle f32, end_angle f32,
+	segments int, c gx.Color) {
 	if segments <= 0 || radius < 0 {
 		return
 	}
@@ -794,7 +797,8 @@ pub fn (ctx Context) draw_arc_line(x f32, y f32, radius f32, start_angle f32, en
 // `end_angle` is the angle in radians at which the arc ends.
 // `segments` affects how smooth/round the arc is.
 // `c` is the color of the arc outline.
-pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f32, start_angle f32,
+	end_angle f32, segments int, c gx.Color) {
 	outer_radius := inner_radius + thickness
 	if segments <= 0 || outer_radius < 0 {
 		return
@@ -857,7 +861,8 @@ pub fn (ctx &Context) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f
 // `end_angle` is the angle in radians at which the arc ends.
 // `segments` affects how smooth/round the arc is.
 // `c` is the fill color of the arc.
-pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, c gx.Color) {
+pub fn (ctx &Context) draw_arc_filled(x f32, y f32, inner_radius f32, thickness f32, start_angle f32,
+	end_angle f32, segments int, c gx.Color) {
 	outer_radius := inner_radius + thickness
 	if segments <= 0 || outer_radius < 0 {
 		return

--- a/vlib/gg/gg_ui.c.v
+++ b/vlib/gg/gg_ui.c.v
@@ -16,7 +16,8 @@ pub fn (ctx &Context) has_text_style() bool {
 }
 
 pub fn (ctx &Context) set_text_style(font_name string, font_path string, size int, color gx.Color,
-	align int, vertical_align int) {}
+	align int, vertical_align int) {
+}
 
 // default draw_text (draw_text_def but without set_text_cfg)
 pub fn (ctx &Context) draw_text_default(x int, y int, text string) {

--- a/vlib/gg/gg_ui.c.v
+++ b/vlib/gg/gg_ui.c.v
@@ -15,7 +15,8 @@ pub fn (ctx &Context) has_text_style() bool {
 	return false
 }
 
-pub fn (ctx &Context) set_text_style(font_name string, font_path string, size int, color gx.Color, align int, vertical_align int) {}
+pub fn (ctx &Context) set_text_style(font_name string, font_path string, size int, color gx.Color,
+	align int, vertical_align int) {}
 
 // default draw_text (draw_text_def but without set_text_cfg)
 pub fn (ctx &Context) draw_text_default(x int, y int, text string) {

--- a/vlib/js/dom/dom.js.v
+++ b/vlib/js/dom/dom.js.v
@@ -48,6 +48,8 @@ mut:
 }
 
 pub interface JS.DOMMatrix {
+	JS.DOMMatrix
+	JS.DOMMatrix
 	is2D       JS.Boolean
 	isIdentity JS.Boolean
 	flipX() JS.DOMMatrix
@@ -57,7 +59,7 @@ pub interface JS.DOMMatrix {
 	rotate(rotX JS.Number, rotY JS.Number, rotZ JS.Number) JS.DOMMatrix
 	rotateAxisAngle(x JS.Number, y JS.Number, z JS.Number, angle JS.Number) JS.DOMMatrix
 	scale(scaleX JS.Number, scaleY JS.Number, scaleZ JS.Number, originX JS.Number, originY JS.Number,
-	originZ JS.Number) JS.DOMMatrix
+	originZ JS.Number)
 	scale3d(scale JS.Number, originX JS.Number, originY JS.Number, originZ JS.Number) JS.DOMMatrix
 	skewX(sx JS.Number) JS.DOMMatrix
 	skewY(sy JS.Number) JS.DOMMatrix
@@ -70,7 +72,7 @@ pub interface JS.DOMMatrix {
 	rotateSelf(rotX JS.Number, rotY JS.Number, rotZ JS.Number) JS.DOMMatrix
 	scale3dSelf(scale JS.Number, originX JS.Number, originY JS.Number, originZ JS.Number) JS.DOMMatrix
 	scaleSelf(scaleX JS.Number, scaleY JS.Number, scaleZ JS.Number, originX JS.Number, originY JS.Number,
-	originZ JS.Number) JS.DOMMatrix
+	originZ JS.Number)
 	toString() JS.String
 mut:
 	a   JS.Number
@@ -439,6 +441,7 @@ mut:
 pub type FillStyle = JS.CanvasGradient | JS.CanvasPattern | JS.String
 
 pub interface JS.CanvasRenderingContext2D {
+	JS.CanvasGradient
 	canvas JS.HTMLCanvasElement
 	beginPath()
 	clip(path JS.Path2D, fillRule JS.String)
@@ -448,7 +451,7 @@ pub interface JS.CanvasRenderingContext2D {
 	stoke(path JS.Path2D)
 	createLinearGradient(x0 JS.Number, y0 JS.Number, x1 JS.Number, y1 JS.Number) JS.CanvasGradient
 	createRadialGradient(x0 JS.Number, y0 JS.Number, r0 JS.Number, x1 JS.Number, y1 JS.Number,
-	r1 JS.Number) JS.CanvasGradient
+	r1 JS.Number)
 	createPattern(image JS.CanvasImageSource, repetition JS.String) ?JS.CanvasPattern
 	arc(x JS.Number, y JS.Number, radius JS.Number, startAngle JS.Number, endAngle JS.Number,
 	counterclockwise JS.Boolean)

--- a/vlib/js/dom/dom.js.v
+++ b/vlib/js/dom/dom.js.v
@@ -56,7 +56,8 @@ pub interface JS.DOMMatrix {
 	multiply(other JS.DOMMatrix) JS.DOMMatrix
 	rotate(rotX JS.Number, rotY JS.Number, rotZ JS.Number) JS.DOMMatrix
 	rotateAxisAngle(x JS.Number, y JS.Number, z JS.Number, angle JS.Number) JS.DOMMatrix
-	scale(scaleX JS.Number, scaleY JS.Number, scaleZ JS.Number, originX JS.Number, originY JS.Number, originZ JS.Number) JS.DOMMatrix
+	scale(scaleX JS.Number, scaleY JS.Number, scaleZ JS.Number, originX JS.Number, originY JS.Number,
+	originZ JS.Number) JS.DOMMatrix
 	scale3d(scale JS.Number, originX JS.Number, originY JS.Number, originZ JS.Number) JS.DOMMatrix
 	skewX(sx JS.Number) JS.DOMMatrix
 	skewY(sy JS.Number) JS.DOMMatrix
@@ -68,7 +69,8 @@ pub interface JS.DOMMatrix {
 	rotateFromVectorSelf(x JS.Number, y JS.Number) JS.DOMMatrix
 	rotateSelf(rotX JS.Number, rotY JS.Number, rotZ JS.Number) JS.DOMMatrix
 	scale3dSelf(scale JS.Number, originX JS.Number, originY JS.Number, originZ JS.Number) JS.DOMMatrix
-	scaleSelf(scaleX JS.Number, scaleY JS.Number, scaleZ JS.Number, originX JS.Number, originY JS.Number, originZ JS.Number) JS.DOMMatrix
+	scaleSelf(scaleX JS.Number, scaleY JS.Number, scaleZ JS.Number, originX JS.Number, originY JS.Number,
+	originZ JS.Number) JS.DOMMatrix
 	toString() JS.String
 mut:
 	a   JS.Number
@@ -445,13 +447,17 @@ pub interface JS.CanvasRenderingContext2D {
 	isPointInStroke(path JS.Path2D, x JS.Number, y JS.Number) JS.Boolean
 	stoke(path JS.Path2D)
 	createLinearGradient(x0 JS.Number, y0 JS.Number, x1 JS.Number, y1 JS.Number) JS.CanvasGradient
-	createRadialGradient(x0 JS.Number, y0 JS.Number, r0 JS.Number, x1 JS.Number, y1 JS.Number, r1 JS.Number) JS.CanvasGradient
+	createRadialGradient(x0 JS.Number, y0 JS.Number, r0 JS.Number, x1 JS.Number, y1 JS.Number,
+	r1 JS.Number) JS.CanvasGradient
 	createPattern(image JS.CanvasImageSource, repetition JS.String) ?JS.CanvasPattern
-	arc(x JS.Number, y JS.Number, radius JS.Number, startAngle JS.Number, endAngle JS.Number, counterclockwise JS.Boolean)
+	arc(x JS.Number, y JS.Number, radius JS.Number, startAngle JS.Number, endAngle JS.Number,
+	counterclockwise JS.Boolean)
 	arcTo(x1 JS.Number, y1 JS.Number, x2 JS.Number, y2 JS.Number, radius JS.Number)
-	bezierCurveTo(cp1x JS.Number, cp1y JS.Number, cp2x JS.Number, cp2y JS.Number, x JS.Number, y JS.Number)
+	bezierCurveTo(cp1x JS.Number, cp1y JS.Number, cp2x JS.Number, cp2y JS.Number, x JS.Number,
+	y JS.Number)
 	closePath()
-	ellipse(x JS.Number, y JS.Number, radiusX JS.Number, radiusY JS.Number, rotation JS.Number, startAngle JS.Number, endAngle JS.Number, counterclockwise JS.Boolean)
+	ellipse(x JS.Number, y JS.Number, radiusX JS.Number, radiusY JS.Number, rotation JS.Number,
+	startAngle JS.Number, endAngle JS.Number, counterclockwise JS.Boolean)
 	lineTo(x JS.Number, y JS.Number)
 	moveTo(x JS.Number, y JS.Number)
 	quadraticCurveTo(cpx JS.Number, cpy JS.Number, x JS.Number, y JS.Number)
@@ -671,8 +677,10 @@ pub interface JS.WebGLRenderingContext {
 	enableVertexAttribArray(index JS.Number)
 	finish()
 	flush()
-	framebufferRenderbuffer(target JS.Number, attachment JS.Number, renderbuffertarget JS.Number, renderbuffer JS.WebGLRenderbuffer)
-	framebufferTexture2D(target JS.Number, attachment JS.Number, textarget JS.Number, texture JS.WebGLTexture, level JS.Number)
+	framebufferRenderbuffer(target JS.Number, attachment JS.Number, renderbuffertarget JS.Number,
+	renderbuffer JS.WebGLRenderbuffer)
+	framebufferTexture2D(target JS.Number, attachment JS.Number, textarget JS.Number, texture JS.WebGLTexture,
+	level JS.Number)
 	frontFace(mode JS.Number)
 	generateMipmap(target JS.Number)
 	getError() JS.Number
@@ -683,7 +691,8 @@ pub interface JS.WebGLRenderingContext {
 	bufferData(target JS.Number, data JS.TypedArray, usage JS.Number)
 	shaderSource(shader JS.WebGLShader, source JS.String)
 	getShaderParameter(shader JS.WebGLShader, pname JS.Number) JS.Any
-	vertexAttribPointer(index JS.Number, size JS.Number, typ JS.Number, normalized JS.Boolean, stride JS.Number, offset JS.Number)
+	vertexAttribPointer(index JS.Number, size JS.Number, typ JS.Number, normalized JS.Boolean,
+	stride JS.Number, offset JS.Number)
 	getAttribLocation(program JS.WebGLProgram, name JS.String) JS.Number
 	useProgram(program JS.WebGLProgram)
 	getUniformLocation(program JS.WebGLProgram, name JS.String) ?JS.WebGLUniformLocation
@@ -720,10 +729,14 @@ pub interface JS.WebGLRenderingContext {
 	vertexAttrib4f(index JS.Number, x JS.Number, y JS.Number, z JS.Number, w JS.Number)
 	vertexAttrib4fv(index JS.Number, x JS.Number, y JS.Number, z JS.Number, w JS.Number, values JS.Array)
 	bufferSubData(target JS.Number, offset JS.Number, data JS.TypedArray)
-	compressedTexImage2D(target JS.Number, level JS.Number, internalformat JS.Number, width JS.Number, height JS.Number, border JS.Number, data JS.TypedArray)
-	compressedTexSubImage2D(target JS.Number, level JS.Number, xoffset JS.Number, yoffset JS.Number, width JS.Number, height JS.Number, format JS.Number, data JS.TypedArray)
-	readPixels(x JS.Number, y JS.Number, width JS.Number, height JS.Number, format JS.Number, typ JS.Number, border JS.Number, pixels JS.TypedArray)
-	texImage2D(target JS.Number, level JS.Number, internalformat JS.Number, format JS.Number, source JS.Node)
+	compressedTexImage2D(target JS.Number, level JS.Number, internalformat JS.Number, width JS.Number,
+	height JS.Number, border JS.Number, data JS.TypedArray)
+	compressedTexSubImage2D(target JS.Number, level JS.Number, xoffset JS.Number, yoffset JS.Number,
+	width JS.Number, height JS.Number, format JS.Number, data JS.TypedArray)
+	readPixels(x JS.Number, y JS.Number, width JS.Number, height JS.Number, format JS.Number,
+	typ JS.Number, border JS.Number, pixels JS.TypedArray)
+	texImage2D(target JS.Number, level JS.Number, internalformat JS.Number, format JS.Number,
+	source JS.Node)
 }
 
 pub interface JS.WebGL2RenderingContext {

--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -88,7 +88,8 @@ fn C.getpeername(sockfd int, addr &Addr, addlen &u32) int
 
 fn C.inet_ntop(af AddrFamily, src voidptr, dst &char, dst_size int) &char
 
-fn C.WSAAddressToStringA(lpsaAddress &Addr, dwAddressLength u32, lpProtocolInfo voidptr, lpszAddressString &char, lpdwAddressStringLength &u32) int
+fn C.WSAAddressToStringA(lpsaAddress &Addr, dwAddressLength u32, lpProtocolInfo voidptr, lpszAddressString &char,
+	lpdwAddressStringLength &u32) int
 
 // fn C.getsockname(sockfd int, addr &C.sockaddr, addrlen &C.socklen_t) int
 fn C.getsockname(sockfd int, addr &C.sockaddr, addrlen &u32) int

--- a/vlib/net/http/download_silent_downloader.v
+++ b/vlib/net/http/download_silent_downloader.v
@@ -18,7 +18,8 @@ pub fn (mut d SilentStreamingDownloader) on_start(mut request Request, path stri
 }
 
 // on_chunk is called multiple times, once per chunk of received content.
-pub fn (mut d SilentStreamingDownloader) on_chunk(request &Request, chunk []u8, already_received u64, expected u64) ! {
+pub fn (mut d SilentStreamingDownloader) on_chunk(request &Request, chunk []u8, already_received u64,
+	expected u64) ! {
 	d.f.write(chunk)!
 }
 

--- a/vlib/net/http/download_terminal_downloader.v
+++ b/vlib/net/http/download_terminal_downloader.v
@@ -19,7 +19,8 @@ pub fn (mut d TerminalStreamingDownloader) on_start(mut request Request, path st
 }
 
 // on_chunk is called multiple times, once per chunk of received content.
-pub fn (mut d TerminalStreamingDownloader) on_chunk(request &Request, chunk []u8, already_received u64, expected u64) ! {
+pub fn (mut d TerminalStreamingDownloader) on_chunk(request &Request, chunk []u8, already_received u64,
+	expected u64) ! {
 	now := time.now()
 	elapsed := now - d.start_time
 	// delta_elapsed := now - d.past_time

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -283,7 +283,8 @@ fn (req &Request) http_do(host string, method Method, path string) !Response {
 // abstract over reading the whole content from TCP or SSL connections:
 type FnReceiveChunk = fn (con voidptr, buf &u8, bufsize int) !int
 
-fn (req &Request) receive_all_data_from_cb_in_builder(mut content strings.Builder, con voidptr, receive_chunk_cb FnReceiveChunk) ! {
+fn (req &Request) receive_all_data_from_cb_in_builder(mut content strings.Builder, con voidptr,
+	receive_chunk_cb FnReceiveChunk) ! {
 	mut buff := [bufsize]u8{}
 	bp := unsafe { &buff[0] }
 	mut readcounter := 0

--- a/vlib/net/mbedtls/mbedtls.c.v
+++ b/vlib/net/mbedtls/mbedtls.c.v
@@ -170,7 +170,8 @@ fn C.mbedtls_ssl_setup(&C.mbedtls_ssl_context, &C.mbedtls_ssl_config) int
 fn C.mbedtls_ssl_session_reset(&C.mbedtls_ssl_context)
 fn C.mbedtls_ssl_conf_authmode(&C.mbedtls_ssl_config, int)
 fn C.mbedtls_ssl_conf_rng(&C.mbedtls_ssl_config, fn (voidptr, &u8, usize) int, &C.mbedtls_ctr_drbg_context)
-fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, &C.mbedtls_ssl_send_t, &C.mbedtls_ssl_recv_t, &C.mbedtls_ssl_recv_timeout_t)
+fn C.mbedtls_ssl_set_bio(&C.mbedtls_ssl_context, &C.mbedtls_net_context, &C.mbedtls_ssl_send_t,
+	&C.mbedtls_ssl_recv_t, &C.mbedtls_ssl_recv_timeout_t)
 fn C.mbedtls_ssl_conf_own_cert(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_pk_context) int
 fn C.mbedtls_ssl_conf_ca_chain(&C.mbedtls_ssl_config, &C.mbedtls_x509_crt, &C.mbedtls_x509_crl)
 fn C.mbedtls_ssl_set_hostname(&C.mbedtls_ssl_context, &char) int
@@ -184,11 +185,14 @@ fn C.mbedtls_ssl_config_free(&C.mbedtls_ssl_config)
 
 fn C.mbedtls_pk_init(&C.mbedtls_pk_context)
 fn C.mbedtls_pk_free(&C.mbedtls_pk_context)
-fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, usize, &u8, usize, fn (voidptr, &u8, usize) int, voidptr) int
-fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, fn (voidptr, &u8, usize) int, voidptr) int
+fn C.mbedtls_pk_parse_key(&C.mbedtls_pk_context, &u8, usize, &u8, usize, fn (voidptr, &u8, usize) int,
+	voidptr) int
+fn C.mbedtls_pk_parse_keyfile(&C.mbedtls_pk_context, &char, &char, fn (voidptr, &u8, usize) int,
+	voidptr) int
 
 fn C.mbedtls_ctr_drbg_init(&C.mbedtls_ctr_drbg_context)
-fn C.mbedtls_ctr_drbg_seed(&C.mbedtls_ctr_drbg_context, fn (voidptr, &u8, usize), voidptr, &u8, usize) int
+fn C.mbedtls_ctr_drbg_seed(&C.mbedtls_ctr_drbg_context, fn (voidptr, &u8, usize), voidptr, &u8,
+	usize) int
 fn C.mbedtls_ctr_drbg_free(&C.mbedtls_ctr_drbg_context)
 fn C.mbedtls_ctr_drbg_random(voidptr, &u8, usize) int
 

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -207,7 +207,8 @@ pub interface Connection {
 // num - Stmt uses nums at prepared statements (? or ?1)
 // qm - Character for prepared statement (qm for question mark, as in sqlite)
 // start_pos - When num is true, it's the start position of the counter
-pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKind, num bool, qm string, start_pos int, data QueryData, where QueryData) (string, QueryData) {
+pub fn orm_stmt_gen(sql_dialect SQLDialect, table string, q string, kind StmtKind, num bool,
+	qm string, start_pos int, data QueryData, where QueryData) (string, QueryData) {
 	mut str := ''
 	mut c := start_pos
 	mut data_fields := []string{}
@@ -432,7 +433,8 @@ fn gen_where_clause(where QueryData, q string, qm string, num bool, mut c &int) 
 // fields - See TableField
 // sql_from_v - Function which maps type indices to sql type names
 // alternative - Needed for msdb
-pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, fields []TableField, sql_from_v fn (int) !string, alternative bool) !string {
+pub fn orm_table_gen(table string, q string, defaults bool, def_unique_len int, fields []TableField,
+	sql_from_v fn (int) !string, alternative bool) !string {
 	mut str := 'CREATE TABLE IF NOT EXISTS ${q}${table}${q} ('
 
 	if alternative {

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -6,7 +6,8 @@ fn C.GenerateConsoleCtrlEvent(event u32, pgid u32) bool
 fn C.GetModuleHandleA(name &char) HMODULE
 fn C.GetProcAddress(handle voidptr, procname &u8) voidptr
 fn C.TerminateProcess(process HANDLE, exit_code u32) bool
-fn C.PeekNamedPipe(hNamedPipe voidptr, lpBuffer voidptr, nBufferSize int, lpBytesRead voidptr, lpTotalBytesAvail voidptr, lpBytesLeftThisMessage voidptr) bool
+fn C.PeekNamedPipe(hNamedPipe voidptr, lpBuffer voidptr, nBufferSize int, lpBytesRead voidptr,
+	lpTotalBytesAvail voidptr, lpBytesLeftThisMessage voidptr) bool
 
 type FN_NTSuspendResume = fn (voidptr) u64
 

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -343,7 +343,8 @@ fn raw_callback(fd int, events int, context voidptr) {
 	}
 }
 
-fn default_error_callback(data voidptr, req picohttpparser.Request, mut res picohttpparser.Response, error IError) {
+fn default_error_callback(data voidptr, req picohttpparser.Request, mut res picohttpparser.Response,
+	error IError) {
 	eprintln('picoev: ${error}')
 	res.end()
 }

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -220,13 +220,15 @@ pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, 
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &ShaderDesc {
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string,
+	@type UniformType, array_count int) &ShaderDesc {
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType, array_count int) &ShaderDesc {
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string,
+	@type UniformType, array_count int) &ShaderDesc {
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
 	return desc

--- a/vlib/sokol/memory/memory.c.v
+++ b/vlib/sokol/memory/memory.c.v
@@ -31,7 +31,8 @@ pub fn sfree(ptr voidptr, user_data voidptr) {
 
 fn C.SOKOL_LOG(const_message &char)
 
-pub fn slog(const_tag &char, log_level u32, log_item_id u32, const_message_or_null &char, line_nr u32, const_filename_or_null &char, user_data voidptr) {
+pub fn slog(const_tag &char, log_level u32, log_item_id u32, const_message_or_null &char, line_nr u32,
+	const_filename_or_null &char, user_data voidptr) {
 	C.fprintf(C.stderr, c'sokol.memory.slog | user_data: %p, const_tag: %s, level: %d, item_id: %d, fname: %s, line: %d, message: %s\n',
 		user_data, const_tag, log_level, log_item_id, const_filename_or_null, line_nr,
 		const_message_or_null)

--- a/vlib/sokol/sgl/sgl.c.v
+++ b/vlib/sokol/sgl/sgl.c.v
@@ -224,7 +224,8 @@ pub fn perspective(fov_y f32, aspect f32, z_near f32, z_far f32) {
 }
 
 @[inline]
-pub fn lookat(eye_x f32, eye_y f32, eye_z f32, center_x f32, center_y f32, center_z f32, up_x f32, up_y f32, up_z f32) {
+pub fn lookat(eye_x f32, eye_y f32, eye_z f32, center_x f32, center_y f32, center_z f32, up_x f32,
+	up_y f32, up_z f32) {
 	C.sgl_lookat(eye_x, eye_y, eye_z, center_x, center_y, center_z, up_x, up_y, up_z)
 }
 

--- a/vlib/sokol/sgl/sgl_funcs.c.v
+++ b/vlib/sokol/sgl/sgl_funcs.c.v
@@ -51,7 +51,8 @@ fn C.sgl_translate(x f32, y f32, z f32)
 fn C.sgl_frustum(l f32, r f32, b f32, t f32, n f32, f f32)
 fn C.sgl_ortho(l f32, r f32, b f32, t f32, n f32, f f32)
 fn C.sgl_perspective(fov_y f32, aspect f32, z_near f32, z_far f32)
-fn C.sgl_lookat(eye_x f32, eye_y f32, eye_z f32, center_x f32, center_y f32, center_z f32, up_x f32, up_y f32, up_z f32)
+fn C.sgl_lookat(eye_x f32, eye_y f32, eye_z f32, center_x f32, center_y f32, center_z f32, up_x f32,
+	up_y f32, up_z f32)
 fn C.sgl_push_matrix()
 fn C.sgl_pop_matrix()
 

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -154,7 +154,8 @@ pub fn load_from_memory(buf &u8, bufsize int, params LoadParams) !Image {
 // Resize functions
 //
 //-----------------------------------------------------------------------------
-fn C.stbir_resize_uint8_linear(input_pixels &u8, input_w int, input_h int, input_stride_in_bytes int, output_pixels &u8, output_w int, output_h int, output_stride_in_bytes int, num_channels int) int
+fn C.stbir_resize_uint8_linear(input_pixels &u8, input_w int, input_h int, input_stride_in_bytes int,
+	output_pixels &u8, output_w int, output_h int, output_stride_in_bytes int, num_channels int) int
 
 // resize_uint8 resizes `img` to dimensions of `output_w` and `output_h`
 pub fn resize_uint8(img &Image, output_w int, output_h int) !Image {

--- a/vlib/term/term_windows.c.v
+++ b/vlib/term/term_windows.c.v
@@ -53,7 +53,8 @@ fn C.SetConsoleTitle(title &u16) bool
 fn C.SetConsoleCursorPosition(handle C.HANDLE, coord C.COORD) bool
 
 // ref - https://docs.microsoft.com/en-us/windows/console/scrollconsolescreenbuffer
-fn C.ScrollConsoleScreenBuffer(output C.HANDLE, scroll_rect &C.SMALL_RECT, clip_rect &C.SMALL_RECT, des C.COORD, fill &C.CHAR_INFO) bool
+fn C.ScrollConsoleScreenBuffer(output C.HANDLE, scroll_rect &C.SMALL_RECT, clip_rect &C.SMALL_RECT,
+	des C.COORD, fill &C.CHAR_INFO) bool
 
 // get_terminal_size returns a number of columns and rows of terminal window.
 pub fn get_terminal_size() (int, int) {

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -37,7 +37,8 @@ fn C.GetSystemTimeAsFileTime(lpSystemTimeAsFileTime &C._FILETIME)
 
 fn C.FileTimeToSystemTime(lpFileTime &C._FILETIME, lpSystemTime &SystemTime)
 
-fn C.SystemTimeToTzSpecificLocalTime(lpTimeZoneInformation &C.TIME_ZONE_INFORMATION, lpUniversalTime &SystemTime, lpLocalTime &SystemTime)
+fn C.SystemTimeToTzSpecificLocalTime(lpTimeZoneInformation &C.TIME_ZONE_INFORMATION, lpUniversalTime &SystemTime,
+	lpLocalTime &SystemTime)
 
 fn C.localtime_s(t &C.time_t, tm &C.tm)
 

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -162,7 +162,7 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		}
 	}
 	f.write_string('(')
-	mut has_wrapped := false
+	mut last_len := 0
 	for i, param in node.params {
 		// skip receiver
 		if node.is_method && i == 0 {
@@ -229,9 +229,9 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			}
 		}
 		if !is_last_param {
-			if f.len > 90 && !has_wrapped {
+			if f.len - last_len > 90 {
 				f.write_string(',\n\t')
-				has_wrapped = true
+				last_len = f.len
 			} else {
 				f.write_string(', ')
 			}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -162,6 +162,7 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		}
 	}
 	f.write_string('(')
+	mut has_wrapped := false
 	for i, param in node.params {
 		// skip receiver
 		if node.is_method && i == 0 {
@@ -228,7 +229,12 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 			}
 		}
 		if !is_last_param {
-			f.write_string(', ')
+			if f.len > 90 && !has_wrapped {
+				f.write_string(',\n\t')
+				has_wrapped = true
+			} else {
+				f.write_string(', ')
+			}
 		}
 	}
 	f.write_string(')')

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1553,7 +1553,8 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 	return false
 }
 
-pub fn (mut t Table) resolve_generic_static_type_name(fn_name string, generic_names []string, concrete_types []Type) string {
+pub fn (mut t Table) resolve_generic_static_type_name(fn_name string, generic_names []string,
+	concrete_types []Type) string {
 	if index := fn_name.index('__static__') {
 		if index > 0 {
 			generic_name := fn_name[0..index]

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -194,7 +194,8 @@ fn (c Checker) check_multiple_ptr_match(got ast.Type, expected ast.Type, param a
 	return true
 }
 
-fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, language ast.Language, arg ast.CallArg) ! {
+fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, language ast.Language,
+	arg ast.CallArg) ! {
 	if got == 0 {
 		return error('unexpected 0 type')
 	}
@@ -599,7 +600,8 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type_ ast.Type, righ
 	return left_type
 }
 
-fn (mut c Checker) promote_keeping_aliases(left_type ast.Type, right_type ast.Type, left_kind ast.Kind, right_kind ast.Kind) ast.Type {
+fn (mut c Checker) promote_keeping_aliases(left_type ast.Type, right_type ast.Type, left_kind ast.Kind,
+	right_kind ast.Kind) ast.Type {
 	if left_type == right_type && left_kind == .alias && right_kind == .alias {
 		return left_type
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1972,7 +1972,8 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 }
 
 fn (mut c Checker) check_enum_field_integer_literal(expr ast.IntegerLiteral, is_signed bool,
-	is_multi_allowed bool, styp string, pos token.Pos, mut useen []u64, umin u64, umax u64, mut iseen []i64, imin i64, imax i64) {
+	is_multi_allowed bool, styp string, pos token.Pos, mut useen []u64, umin u64, umax u64, mut iseen []i64,
+	imin i64, imax i64) {
 	mut overflows := false
 	mut uval := u64(0)
 	mut ival := i64(0)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -604,7 +604,8 @@ fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 	}
 }
 
-fn (mut c Checker) check_alias_vs_element_type_of_parent(node ast.AliasTypeDecl, element_type_of_parent ast.Type, label string) {
+fn (mut c Checker) check_alias_vs_element_type_of_parent(node ast.AliasTypeDecl, element_type_of_parent ast.Type,
+	label string) {
 	if node.typ.idx() != element_type_of_parent.idx() {
 		return
 	}
@@ -1268,7 +1269,8 @@ fn (mut c Checker) check_expr_option_or_result_call(expr ast.Expr, ret_type ast.
 	return ret_type
 }
 
-fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_return_type ast.Type, expr ast.Expr) {
+fn (mut c Checker) check_or_expr(node ast.OrExpr, ret_type ast.Type, expr_return_type ast.Type,
+	expr ast.Expr) {
 	if node.kind == .propagate_option {
 		if c.table.cur_fn != unsafe { nil } && !c.table.cur_fn.return_type.has_flag(.option)
 			&& !c.table.cur_fn.is_main && !c.table.cur_fn.is_test && !c.inside_const {
@@ -1969,7 +1971,8 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 	}
 }
 
-fn (mut c Checker) check_enum_field_integer_literal(expr ast.IntegerLiteral, is_signed bool, is_multi_allowed bool, styp string, pos token.Pos, mut useen []u64, umin u64, umax u64, mut iseen []i64, imin i64, imax i64) {
+fn (mut c Checker) check_enum_field_integer_literal(expr ast.IntegerLiteral, is_signed bool,
+	is_multi_allowed bool, styp string, pos token.Pos, mut useen []u64, umin u64, umax u64, mut iseen []i64, imin i64, imax i64) {
 	mut overflows := false
 	mut uval := u64(0)
 	mut ival := i64(0)
@@ -3969,7 +3972,8 @@ fn (mut c Checker) concat_expr(mut node ast.ConcatExpr) ast.Type {
 }
 
 // smartcast takes the expression with the current type which should be smartcasted to the target type in the given scope
-fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope, is_comptime bool) {
+fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.Type, mut scope ast.Scope,
+	is_comptime bool) {
 	sym := c.table.sym(cur_type)
 	to_type := if sym.kind == .interface_ && c.table.sym(to_type_).kind != .interface_ {
 		to_type_.ref()
@@ -4472,12 +4476,14 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 	return right_type
 }
 
-fn (mut c Checker) type_error_for_operator(op_label string, types_label string, found_type_label string, pos token.Pos) {
+fn (mut c Checker) type_error_for_operator(op_label string, types_label string, found_type_label string,
+	pos token.Pos) {
 	c.error('operator `${op_label}` can only be used with ${types_label} types, but the value after `${op_label}` is of type `${found_type_label}` instead',
 		pos)
 }
 
-fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_type ast.Type, pos token.Pos, range_index bool, is_gated bool) {
+fn (mut c Checker) check_index(typ_sym &ast.TypeSymbol, index ast.Expr, index_type ast.Type,
+	pos token.Pos, range_index bool, is_gated bool) {
 	if typ_sym.kind in [.array, .array_fixed, .string] {
 		index_type_sym := c.table.sym(index_type)
 		if !(index_type.is_int() || index_type_sym.kind == .enum_
@@ -5171,7 +5177,8 @@ fn (mut c Checker) check_unused_labels() {
 	}
 }
 
-fn (mut c Checker) deprecate_old_isreftype_and_sizeof_of_a_guessed_type(is_guessed_type bool, typ ast.Type, pos token.Pos, label string) {
+fn (mut c Checker) deprecate_old_isreftype_and_sizeof_of_a_guessed_type(is_guessed_type bool,
+	typ ast.Type, pos token.Pos, label string) {
 	if is_guessed_type {
 		styp := c.table.type_to_str(typ)
 		c.note('`${label}(${styp})` is deprecated. Use `v fmt -w .` to convert it to `${label}[${styp}]()` instead.',

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -596,7 +596,8 @@ fn (mut c Checker) check_elements_ref_fields_initialized(typ ast.Type, pos &toke
 }
 
 // Recursively check the element, and its children for ref uninitialized fields
-fn (mut c Checker) do_check_elements_ref_fields_initialized(sym &ast.TypeSymbol, mut checked_types []ast.Type, pos &token.Pos) {
+fn (mut c Checker) do_check_elements_ref_fields_initialized(sym &ast.TypeSymbol, mut checked_types []ast.Type,
+	pos &token.Pos) {
 	if sym.info is ast.Struct {
 		linked_name := sym.name
 		// For now, let's call this method and give a notice instead of an error.

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1801,7 +1801,8 @@ fn (mut c Checker) cast_to_fixed_array_ret(typ ast.Type, sym ast.TypeSymbol) ast
 }
 
 // checks if a type from another module is as expected and visible(`is_pub`)
-fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
+fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind,
+	pos &token.Pos) bool {
 	mut sym := c.table.sym_by_idx(type_idx)
 	if sym.kind == .alias {
 		parent_type := (sym.info as ast.Alias).parent_type

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -929,14 +929,16 @@ fn (mut c Checker) check_like_operator(node &ast.InfixExpr) ast.Type {
 	return node.promoted_type
 }
 
-fn (mut c Checker) invalid_operator_error(op token.Kind, left_type ast.Type, right_type ast.Type, pos token.Pos) {
+fn (mut c Checker) invalid_operator_error(op token.Kind, left_type ast.Type, right_type ast.Type,
+	pos token.Pos) {
 	left_name := c.table.type_to_str(left_type)
 	right_name := c.table.type_to_str(right_type)
 	c.error('invalid operator `${op}` to `${left_name}` and `${right_name}`', pos)
 }
 
 // `if node is ast.Ident && node.is_mut { ... }` -> `if node is ast.Ident && (node as ast.Ident).is_mut { ... }`
-fn (mut c Checker) autocast_in_if_conds(mut right ast.Expr, from_expr ast.Expr, from_type ast.Type, to_type ast.Type) {
+fn (mut c Checker) autocast_in_if_conds(mut right ast.Expr, from_expr ast.Expr, from_type ast.Type,
+	to_type ast.Type) {
 	if '${right}' == from_expr.str() {
 		right = ast.AsCast{
 			typ: to_type

--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -120,7 +120,8 @@ pub fn (mut c Checker) lambda_expr(mut node ast.LambdaExpr, exp_typ ast.Type) as
 	return exp_typ
 }
 
-pub fn (mut c Checker) lambda_expr_fix_type_of_param(mut node ast.LambdaExpr, mut pident ast.Ident, ptype ast.Type) {
+pub fn (mut c Checker) lambda_expr_fix_type_of_param(mut node ast.LambdaExpr, mut pident ast.Ident,
+	ptype ast.Type) {
 	if mut v := node.scope.find(pident.name) {
 		if mut v is ast.Var {
 			v.is_arg = true
@@ -135,7 +136,8 @@ pub fn (mut c Checker) lambda_expr_fix_type_of_param(mut node ast.LambdaExpr, mu
 	}
 }
 
-pub fn (mut c Checker) support_lambda_expr_in_sort(param_type ast.Type, return_type ast.Type, mut expr ast.LambdaExpr) {
+pub fn (mut c Checker) support_lambda_expr_in_sort(param_type ast.Type, return_type ast.Type,
+	mut expr ast.LambdaExpr) {
 	is_auto_rec := param_type.is_ptr()
 	mut expected_fn := ast.Fn{
 		params: [
@@ -157,7 +159,8 @@ pub fn (mut c Checker) support_lambda_expr_in_sort(param_type ast.Type, return_t
 	c.lambda_expr(mut expr, expected_fn_type)
 }
 
-pub fn (mut c Checker) support_lambda_expr_one_param(param_type ast.Type, return_type ast.Type, mut expr ast.LambdaExpr) {
+pub fn (mut c Checker) support_lambda_expr_one_param(param_type ast.Type, return_type ast.Type,
+	mut expr ast.LambdaExpr) {
 	mut expected_fn := ast.Fn{
 		params: [
 			ast.Param{

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -397,7 +397,8 @@ fn (mut c Checker) check_orm_non_primitive_struct_field_attrs(field ast.StructFi
 	}
 }
 
-fn (mut c Checker) fetch_and_check_orm_fields(info ast.Struct, pos token.Pos, table_name string, sql_expr ast.SqlExpr) []ast.StructField {
+fn (mut c Checker) fetch_and_check_orm_fields(info ast.Struct, pos token.Pos, table_name string,
+	sql_expr ast.SqlExpr) []ast.StructField {
 	if cache := c.orm_table_fields[table_name] {
 		return cache
 	}
@@ -451,7 +452,8 @@ fn (mut c Checker) fetch_and_check_orm_fields(info ast.Struct, pos token.Pos, ta
 
 // check_sql_value_expr_is_comptime_with_natural_number_or_expr_with_int_type checks that an expression is compile-time
 // and contains an integer greater than or equal to zero or it is a runtime expression with an integer type.
-fn (mut c Checker) check_sql_value_expr_is_comptime_with_natural_number_or_expr_with_int_type(mut expr ast.Expr, sql_keyword string) {
+fn (mut c Checker) check_sql_value_expr_is_comptime_with_natural_number_or_expr_with_int_type(mut expr ast.Expr,
+	sql_keyword string) {
 	comptime_number := c.get_comptime_number_value(mut expr) or {
 		c.check_sql_expr_type_is_int(expr, sql_keyword)
 		return
@@ -543,7 +545,8 @@ fn (mut c Checker) check_expr_has_no_fn_calls_with_non_orm_return_type(expr &ast
 // check_where_expr_has_no_pointless_exprs checks that an expression has no pointless expressions
 // which don't affect the result. For example, `where 3` is pointless.
 // Also, it checks that the left side of the infix expression is always the structure field.
-fn (mut c Checker) check_where_expr_has_no_pointless_exprs(table_type_symbol &ast.TypeSymbol, field_names []string, expr &ast.Expr) {
+fn (mut c Checker) check_where_expr_has_no_pointless_exprs(table_type_symbol &ast.TypeSymbol,
+	field_names []string, expr &ast.Expr) {
 	// Skip type checking for generated subqueries
 	// that are not linked to scope and vars but only created for cgen.
 	if expr is ast.None {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -936,7 +936,8 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 }
 
 // Recursively check whether the struct type field is initialized
-fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type, linked_name string, pos &token.Pos) {
+fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type,
+	linked_name string, pos &token.Pos) {
 	if (c.pref.translated || c.file.is_translated) || struct_sym.language == .c {
 		return
 	}
@@ -978,7 +979,8 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 // This method is temporary and will only be called by the do_check_elements_ref_fields_initialized() method.
 // The goal is to give only a notice, not an error, for now. After a while,
 // when we change the notice to error, we can remove this temporary method.
-fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type, linked_name string, pos &token.Pos) {
+fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol, mut checked_types []ast.Type,
+	linked_name string, pos &token.Pos) {
 	if (c.pref.translated || c.file.is_translated) || struct_sym.language == .c {
 		return
 	}

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -182,11 +182,13 @@ fn (mut tasks Tasks) add_checked_run(voptions string, result_extension string, t
 	tasks.add('', checker_dir, voptions, result_extension, tests, false)
 }
 
-fn (mut tasks Tasks) add(custom_vexe string, dir string, voptions string, result_extension string, tests []string, is_module bool) {
+fn (mut tasks Tasks) add(custom_vexe string, dir string, voptions string, result_extension string,
+	tests []string, is_module bool) {
 	tasks.add_evars('', custom_vexe, dir, voptions, result_extension, tests, is_module)
 }
 
-fn (mut tasks Tasks) add_evars(evars string, custom_vexe string, dir string, voptions string, result_extension string, tests []string, is_module bool) {
+fn (mut tasks Tasks) add_evars(evars string, custom_vexe string, dir string, voptions string,
+	result_extension string, tests []string, is_module bool) {
 	max_ntries := get_max_ntries()
 	paths := vtest.filter_vtest_only(tests, basepath: dir)
 	for path in paths {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1409,7 +1409,8 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 	f.writeln('}\n')
 }
 
-pub fn (mut f Fmt) calculate_alignment(fields []ast.StructField, mut field_aligns []AlignInfo, mut comment_aligns []AlignInfo, mut default_expr_aligns []AlignInfo, mut field_types []string) {
+pub fn (mut f Fmt) calculate_alignment(fields []ast.StructField, mut field_aligns []AlignInfo,
+	mut comment_aligns []AlignInfo, mut default_expr_aligns []AlignInfo, mut field_types []string) {
 	// Calculate the alignments first
 	for i, field in fields {
 		ft := f.no_cur_mod(f.table.type_to_str_using_aliases(field.typ, f.mod2alias))
@@ -2577,7 +2578,8 @@ fn split_up_infix(infix_str string, ignore_paren bool, is_cond_infix bool) ([]st
 
 const wsinfix_depth_max = 10
 
-fn (mut f Fmt) write_splitted_infix(conditions []string, penalties []int, ignore_paren bool, is_cond bool) {
+fn (mut f Fmt) write_splitted_infix(conditions []string, penalties []int, ignore_paren bool,
+	is_cond bool) {
 	f.wsinfix_depth++
 	defer { f.wsinfix_depth-- }
 	for i, cnd in conditions {

--- a/vlib/v/fmt/tests/fn_with_long_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_long_args_keep.vv
@@ -1,5 +1,11 @@
-fn process_keyholder(super_long_argument1 string, super_long_argument2 string, super_long_argument3 string,
+fn process_keyholder1(super_long_argument1 string, super_long_argument2 string, super_long_argument3 string,
 	super_long_argument4 string, super_long_argument5 string) string {
+	return ''
+}
+
+fn process_keyholder2(super_long_argument1 string, super_long_argument2 string, super_long_argument3 string,
+	super_long_argument4 string, super_long_argument5 string, super_long_argument6 string, super_long_argument7 string,
+	super_long_argument8 string) string {
 	return ''
 }
 

--- a/vlib/v/fmt/tests/fn_with_long_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_long_args_keep.vv
@@ -1,0 +1,6 @@
+fn process_keyholder(super_long_argument1 string, super_long_argument2 string, super_long_argument3 string,
+	super_long_argument4 string, super_long_argument5 string) string {
+	return ''
+}
+
+fn main() {}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -279,7 +279,8 @@ fn (mut g Gen) struct_has_array_or_map_field(elem_typ ast.Type) bool {
 }
 
 // `[]int{len: 6, cap: 10, init: index * index}`
-fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp bool, shared_styp string, var_name string) {
+fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp bool, shared_styp string,
+	var_name string) {
 	prev_inside_lambda := g.inside_lambda
 	g.inside_lambda = true
 	defer {
@@ -1393,7 +1394,8 @@ fn (mut g Gen) write_prepared_tmp_value(tmp string, node &ast.CallExpr, tmp_styp
 	return has_infix_left_var_name
 }
 
-fn (mut g Gen) write_prepared_var(var_name string, inp_info ast.Array, inp_elem_type string, tmp string, i string) {
+fn (mut g Gen) write_prepared_var(var_name string, inp_info ast.Array, inp_elem_type string,
+	tmp string, i string) {
 	if g.table.sym(inp_info.elem_type).kind == .array_fixed {
 		g.writeln('${inp_elem_type} ${var_name};')
 		g.writeln('memcpy(&${var_name}, ((${inp_elem_type}*) ${tmp}_orig.data)[${i}], sizeof(${inp_elem_type}));')
@@ -1402,7 +1404,8 @@ fn (mut g Gen) write_prepared_var(var_name string, inp_info ast.Array, inp_elem_
 	}
 }
 
-fn (mut g Gen) fixed_array_var_init(expr_str string, is_auto_deref bool, elem_type ast.Type, size int) {
+fn (mut g Gen) fixed_array_var_init(expr_str string, is_auto_deref bool, elem_type ast.Type,
+	size int) {
 	elem_sym := g.table.sym(elem_type)
 	if !g.inside_array_fixed_struct {
 		g.write('{')

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -7,7 +7,8 @@ import v.ast
 import v.util
 import v.token
 
-fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr ast.Expr, ret_typ ast.Type, in_heap bool) {
+fn (mut g Gen) expr_with_opt_or_block(expr ast.Expr, expr_typ ast.Type, var_expr ast.Expr, ret_typ ast.Type,
+	in_heap bool) {
 	gen_or := expr is ast.Ident && expr.or_expr.kind != .absent
 	if gen_or {
 		old_inside_opt_or_res := g.inside_opt_or_res

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -895,7 +895,8 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 	return .si_i32
 }
 
-fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp string, typ_str string, str_fn_name string) {
+fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp string, typ_str string,
+	str_fn_name string) {
 	$if trace_autostr ? {
 		eprintln('> gen_str_for_struct: ${info.parent_type.debug()} | ${styp} | ${str_fn_name}')
 	}
@@ -1111,7 +1112,8 @@ fn c_struct_ptr(sym &ast.TypeSymbol, typ ast.Type, expects_ptr bool) string {
 	return ''
 }
 
-fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.Type, fn_name string, field_name string, has_custom_str bool, expects_ptr bool) (string, bool) {
+fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.Type, fn_name string,
+	field_name string, has_custom_str bool, expects_ptr bool) (string, bool) {
 	$if trace_autostr ? {
 		eprintln('> struct_auto_str_func: ${sym.name} | field_type.debug() | ${fn_name} | ${field_name} | ${has_custom_str} | ${expects_ptr}')
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2492,7 +2492,8 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	g.auto_fn_definitions << sb.str()
 }
 
-fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr bool, exp_styp string, got_is_ptr bool, got_is_fn bool, got_styp string) {
+fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr bool, exp_styp string,
+	got_is_ptr bool, got_is_fn bool, got_styp string) {
 	mut rparen_n := 1
 	if exp_is_ptr {
 		g.write('HEAP(${exp_styp}, ')
@@ -3085,7 +3086,8 @@ fn (mut g Gen) print_autofree_var(var ast.Var, comment string) {
 	println('autofree: ${g.file.path}:${var.pos.line_nr}: skipping `${var.name}` in fn `${g.last_fn_c_name}`. ${comment}')
 }
 
-fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int, line_nr int, free_parent_scopes bool, stop_pos int) {
+fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int, line_nr int,
+	free_parent_scopes bool, stop_pos int) {
 	if scope == unsafe { nil } {
 		return
 	}
@@ -5937,7 +5939,8 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 	}
 }
 
-fn (mut g Gen) const_decl_precomputed(mod string, name string, field_name string, ct_value ast.ComptTimeConstValue, typ ast.Type) bool {
+fn (mut g Gen) const_decl_precomputed(mod string, name string, field_name string, ct_value ast.ComptTimeConstValue,
+	typ ast.Type) bool {
 	mut styp := g.typ(typ)
 	cname := if g.pref.translated && !g.is_builtin_mod { name } else { '_const_${name}' }
 	$if trace_const_precomputed ? {
@@ -6037,7 +6040,8 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, field_name string
 	return true
 }
 
-fn (mut g Gen) const_decl_write_precomputed(mod string, styp string, cname string, field_name string, ct_value string) {
+fn (mut g Gen) const_decl_write_precomputed(mod string, styp string, cname string, field_name string,
+	ct_value string) {
 	if g.pref.is_livemain || g.pref.is_liveshared {
 		// Note: tcc has problems reloading .so files with consts in them, when the consts are then used inside the reloaded
 		// live functions. As a workaround, just use simple #define macros in this case.
@@ -6091,7 +6095,8 @@ fn (mut g Gen) c_const_name(name string) string {
 	return if g.pref.translated && !g.is_builtin_mod { name } else { '_const_${name}' }
 }
 
-fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ ast.Type, unwrap_option bool, surround_cbr bool) {
+fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ ast.Type, unwrap_option bool,
+	surround_cbr bool) {
 	// Initialize more complex consts in `void _vinit/2{}`
 	// (C doesn't allow init expressions that can't be resolved at compile time).
 	mut styp := g.typ(typ)
@@ -6152,7 +6157,8 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ
 	}
 }
 
-fn (mut g Gen) const_decl_init_later_msvc_string_fixed_array(mod string, name string, expr ast.ArrayInit, typ ast.Type) {
+fn (mut g Gen) const_decl_init_later_msvc_string_fixed_array(mod string, name string, expr ast.ArrayInit,
+	typ ast.Type) {
 	mut styp := g.typ(typ)
 	cname := g.c_const_name(name)
 	mut init := strings.new_builder(100)
@@ -6933,7 +6939,8 @@ fn (mut g Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 	}
 }
 
-fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast.Stmt, return_type ast.Type, is_option bool) {
+fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast.Stmt, return_type ast.Type,
+	is_option bool) {
 	g.indent++
 	for i, stmt in stmts {
 		if i == stmts.len - 1 {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1419,7 +1419,8 @@ fn (mut g Gen) resolve_comptime_args(func ast.Fn, mut node_ ast.CallExpr, concre
 	return comptime_args
 }
 
-fn (mut g Gen) resolve_receiver_name(node ast.CallExpr, unwrapped_rec_type ast.Type, final_left_sym ast.TypeSymbol, left_sym ast.TypeSymbol, typ_sym ast.TypeSymbol) string {
+fn (mut g Gen) resolve_receiver_name(node ast.CallExpr, unwrapped_rec_type ast.Type, final_left_sym ast.TypeSymbol,
+	left_sym ast.TypeSymbol, typ_sym ast.TypeSymbol) string {
 	mut receiver_type_name := util.no_dots(g.cc_type(unwrapped_rec_type, false))
 	if final_left_sym.kind == .map && node.name in ['clone', 'move'] {
 		receiver_type_name = 'map'

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -219,7 +219,8 @@ ${enc_fn_dec} {
 }
 
 @[inline]
-fn (mut g Gen) gen_enum_to_str(utyp ast.Type, sym ast.TypeSymbol, enum_var string, result_var string, ident string, mut enc strings.Builder) {
+fn (mut g Gen) gen_enum_to_str(utyp ast.Type, sym ast.TypeSymbol, enum_var string, result_var string,
+	ident string, mut enc strings.Builder) {
 	enum_prefix := g.gen_enum_prefix(utyp.clear_flag(.option))
 	enc.writeln('${ident}switch (${enum_var}) {')
 	for val in (sym.info as ast.Enum).vals {
@@ -238,7 +239,8 @@ fn (mut g Gen) gen_enum_to_str(utyp ast.Type, sym ast.TypeSymbol, enum_var strin
 }
 
 @[inline]
-fn (mut g Gen) gen_str_to_enum(utyp ast.Type, sym ast.TypeSymbol, val_var string, result_var string, ident string, mut dec strings.Builder) {
+fn (mut g Gen) gen_str_to_enum(utyp ast.Type, sym ast.TypeSymbol, val_var string, result_var string,
+	ident string, mut dec strings.Builder) {
 	enum_prefix := g.gen_enum_prefix(utyp.clear_flag(.option))
 	is_option := utyp.has_flag(.option)
 	for k, val in (sym.info as ast.Enum).vals {
@@ -359,7 +361,8 @@ fn (mut g Gen) gen_option_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec
 }
 
 @[inline]
-fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc strings.Builder, mut dec strings.Builder, ret_styp string) {
+fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc strings.Builder,
+	mut dec strings.Builder, ret_styp string) {
 	info := sym.info as ast.SumType
 	type_var := g.new_tmp_var()
 	typ := g.table.type_idxs[sym.name]
@@ -602,7 +605,8 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 }
 
 @[inline]
-fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp string, mut enc strings.Builder, mut dec strings.Builder) {
+fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp string, mut enc strings.Builder,
+	mut dec strings.Builder) {
 	info := type_info as ast.Struct
 	for field in info.fields {
 		mut name := field.name
@@ -889,7 +893,8 @@ fn gen_js_get(styp string, tmp string, name string, mut dec strings.Builder, is_
 	}
 }
 
-fn gen_js_get_opt(dec_name string, field_type string, styp string, tmp string, name string, mut dec strings.Builder, is_required bool) {
+fn gen_js_get_opt(dec_name string, field_type string, styp string, tmp string, name string, mut dec strings.Builder,
+	is_required bool) {
 	gen_js_get(styp, tmp, name, mut dec, is_required)
 	value_field_type := field_type.replace('*', '_ptr')
 	dec.writeln('\t${result_name}_${value_field_type.replace('*', '_ptr')} ${tmp} = {0};')

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -262,7 +262,8 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 	}
 }
 
-fn (mut g Gen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var string, tmp_var string, cond_fsym ast.TypeSymbol) {
+fn (mut g Gen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var string, tmp_var string,
+	cond_fsym ast.TypeSymbol) {
 	node_cond_type_unsigned := node.cond_type in [ast.u16_type, ast.u32_type, ast.u64_type]
 	cname := '${cond_fsym.cname}__'
 

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -142,7 +142,8 @@ fn (mut g Gen) write_orm_connection_init(connection_var_name string, db_expr &as
 }
 
 // write_orm_create_table writes C code that calls ORM functions for creating tables.
-fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string) {
+fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, connection_var_name string,
+	result_var_name string) {
 	g.writeln('// sql { create table `${table_name}` }')
 	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_create(')
 	g.indent++
@@ -221,7 +222,8 @@ fn (mut g Gen) write_orm_drop_table(table_name string, connection_var_name strin
 }
 
 // write_orm_insert writes C code that calls ORM functions for inserting structs into a table.
-fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string, or_expr &ast.OrExpr) {
+fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connection_var_name string,
+	result_var_name string, or_expr &ast.OrExpr) {
 	last_ids_variable_name := g.new_tmp_var()
 
 	g.writeln('Array_orm__Primitive ${last_ids_variable_name} = __new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
@@ -230,7 +232,8 @@ fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connec
 }
 
 // write_orm_update writes C code that calls ORM functions for updating rows.
-fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string) {
+fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connection_var_name string,
+	result_var_name string) {
 	g.writeln('// sql { update `${table_name}` }')
 	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_update(')
 	g.indent++
@@ -282,7 +285,8 @@ fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connec
 }
 
 // write_orm_delete writes C code that calls ORM functions for deleting rows.
-fn (mut g Gen) write_orm_delete(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string) {
+fn (mut g Gen) write_orm_delete(node &ast.SqlStmtLine, table_name string, connection_var_name string,
+	result_var_name string) {
 	g.writeln('// sql { delete from `${table_name}` }')
 	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method__v_delete(')
 	g.indent++
@@ -295,7 +299,8 @@ fn (mut g Gen) write_orm_delete(node &ast.SqlStmtLine, table_name string, connec
 
 // write_orm_insert_with_last_ids writes C code that calls ORM functions for
 // inserting a struct into a table, saving inserted `id` into a passed variable.
-fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_var_name string, table_name string, last_ids_arr string, res string, pid string, fkey string, or_expr ast.OrExpr) {
+fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_var_name string,
+	table_name string, last_ids_arr string, res string, pid string, fkey string, or_expr ast.OrExpr) {
 	mut subs := []ast.SqlStmtLine{}
 
 	mut subs_unwrapped_c_typ := []string{}
@@ -719,7 +724,8 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 }
 
 // write_orm_where_expr writes C code that generates expression which is used in the `QueryData`.
-fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut parentheses [][]int, mut kinds []string, mut data []ast.Expr, mut is_and []bool) {
+fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut parentheses [][]int,
+	mut kinds []string, mut data []ast.Expr, mut is_and []bool) {
 	match expr {
 		ast.InfixExpr {
 			g.sql_side = .left

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -1818,7 +1818,8 @@ fn split_up_infix(infix_str string, ignore_paren bool, is_cond_infix bool) ([]st
 
 const wsinfix_depth_max = 10
 
-fn (mut f Gen) write_splitted_infix(conditions []string, penalties []int, ignore_paren bool, is_cond bool) {
+fn (mut f Gen) write_splitted_infix(conditions []string, penalties []int, ignore_paren bool,
+	is_cond bool) {
 	f.wsinfix_depth++
 	defer {
 		f.wsinfix_depth--

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -786,7 +786,8 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 	fn_builder.writeln('}')
 }
 
-fn struct_auto_str_func(mut g JsGen, sym &ast.TypeSymbol, field_type ast.Type, fn_name string, field_name string) string {
+fn struct_auto_str_func(mut g JsGen, sym &ast.TypeSymbol, field_type ast.Type, fn_name string,
+	field_name string) string {
 	has_custom_str, expects_ptr, _ := sym.str_method_info()
 	if sym.kind == .enum_ {
 		return '${fn_name}(it.${g.js_name(field_name)})'

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -2557,7 +2557,8 @@ fn (mut g JsGen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var M
 	}
 }
 
-fn (mut g JsGen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var MatchCond, tmp_var string, enum_typ ast.TypeSymbol) {
+fn (mut g JsGen) match_expr_switch(node ast.MatchExpr, is_expr bool, cond_var MatchCond, tmp_var string,
+	enum_typ ast.TypeSymbol) {
 	mut range_branches := []ast.MatchBranch{cap: node.branches.len} // branches have RangeExpr cannot emit as switch case branch, we handle it in default branch
 	mut default_generated := false
 	g.empty_line = true

--- a/vlib/v/gen/js/sourcemap/mappings.v
+++ b/vlib/v/gen/js/sourcemap/mappings.v
@@ -52,7 +52,8 @@ fn new_mappings() Mappings {
 }
 
 // Add the given source mapping
-fn (mut m Mappings) add_mapping(gen_line u32, gen_column u32, sources_ind u32, source_position SourcePositionType, names_ind NameIndexType) {
+fn (mut m Mappings) add_mapping(gen_line u32, gen_column u32, sources_ind u32, source_position SourcePositionType,
+	names_ind NameIndexType) {
 	if !(gen_line > m.last.gen_line
 		|| (gen_line == m.last.gen_line && gen_column >= m.last.gen_column)) {
 		m.is_sorted = false

--- a/vlib/v/gen/js/sourcemap/source_map.v
+++ b/vlib/v/gen/js/sourcemap/source_map.v
@@ -36,7 +36,8 @@ pub fn new_sourcemap(file string, source_root string, sources_content_inline boo
 }
 
 // Add a single mapping from original source line and column to the generated source's line and column for this source map being created.
-pub fn (mut sm SourceMap) add_mapping(source_name string, source_position SourcePositionType, gen_line u32, gen_column u32, name string) {
+pub fn (mut sm SourceMap) add_mapping(source_name string, source_position SourcePositionType,
+	gen_line u32, gen_column u32, name string) {
 	if source_name == '' {
 		panic('add_mapping, source_name should not be ""')
 	}

--- a/vlib/v/gen/js/sourcemap/source_map_generator.v
+++ b/vlib/v/gen/js/sourcemap/source_map_generator.v
@@ -29,7 +29,8 @@ pub fn generate_empty_map() &Generator {
 	return &Generator{}
 }
 
-pub fn (mut g Generator) add_map(file string, source_root string, sources_content_inline bool, line_offset int, column_offset int) &SourceMap {
+pub fn (mut g Generator) add_map(file string, source_root string, sources_content_inline bool,
+	line_offset int, column_offset int) &SourceMap {
 	source_map := new_sourcemap(file, source_root, sources_content_inline)
 
 	offset := Offset{

--- a/vlib/v/gen/native/elf.v
+++ b/vlib/v/gen/native/elf.v
@@ -300,7 +300,8 @@ mut:
 	size  i64 // Symbol size.
 }
 
-fn (mut g Gen) create_symbol_table_section(str_name string, info u8, bind u8, other i8, value i64, size i64, shndx i16) SymbolTableSection {
+fn (mut g Gen) create_symbol_table_section(str_name string, info u8, bind u8, other i8, value i64,
+	size i64, shndx i16) SymbolTableSection {
 	return SymbolTableSection{
 		str_name: str_name
 		info: i8(info | bind << 4)
@@ -442,7 +443,8 @@ mut:
 	data   SectionData = DynSymSection{}
 }
 
-fn (mut g Gen) create_section(name string, typ i32, link i32, info i32, addralign i64, entsize i64, data SectionData) Section {
+fn (mut g Gen) create_section(name string, typ i32, link i32, info i32, addralign i64, entsize i64,
+	data SectionData) Section {
 	return Section{
 		name: name
 		header: SectionHeader{

--- a/vlib/v/gen/native/readdll.c.v
+++ b/vlib/v/gen/native/readdll.c.v
@@ -16,7 +16,8 @@ struct SystemDll {
 	full_path string
 }
 
-fn C.SearchPathA(lp_path &char, lp_file_name &char, lp_extension &char, n_buffer_length u32, lp_buffer &char, lp_file_part &&char) u32
+fn C.SearchPathA(lp_path &char, lp_file_name &char, lp_extension &char, n_buffer_length u32,
+	lp_buffer &char, lp_file_part &&char) u32
 fn C.GetLastError() u32
 
 fn (mut g Gen) lookup_system_dll(dll string) !SystemDll {

--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -511,7 +511,8 @@ pub fn (mut g Gen) prefix_expr(node ast.PrefixExpr, expected ast.Type) {
 	}
 }
 
-pub fn (mut g Gen) if_branch(ifexpr ast.IfExpr, expected ast.Type, unpacked_params []wasm.ValType, idx int, existing_rvars []Var) {
+pub fn (mut g Gen) if_branch(ifexpr ast.IfExpr, expected ast.Type, unpacked_params []wasm.ValType,
+	idx int, existing_rvars []Var) {
 	curr := ifexpr.branches[idx]
 
 	g.expr(curr.cond, ast.bool_type)

--- a/vlib/v/live/executable/reloader.c.v
+++ b/vlib/v/live/executable/reloader.c.v
@@ -8,7 +8,8 @@ import v.live
 // The live reloader code is implemented here.
 // Note: new_live_reload_info will be called by generated C code inside main()
 @[markused]
-pub fn new_live_reload_info(original string, vexe string, vopts string, live_fn_mutex voidptr, live_linkfn live.FNLinkLiveSymbols) &live.LiveReloadInfo {
+pub fn new_live_reload_info(original string, vexe string, vopts string, live_fn_mutex voidptr,
+	live_linkfn live.FNLinkLiveSymbols) &live.LiveReloadInfo {
 	file_base := os.file_name(original).replace('.v', '')
 	so_dir := os.cache_dir()
 	mut so_extension := dl.dl_ext

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -441,7 +441,8 @@ fn all_fn_const_and_global(ast_files []&ast.File) (map[string]ast.FnDecl, map[st
 	return all_fns, all_consts, all_globals
 }
 
-fn handle_vweb(mut table ast.Table, mut all_fn_root_names []string, result_name string, filter_name string, context_name string) {
+fn handle_vweb(mut table ast.Table, mut all_fn_root_names []string, result_name string, filter_name string,
+	context_name string) {
 	// handle vweb magic router methods:
 	result_type_idx := table.find_type_idx(result_name)
 	if result_type_idx != 0 {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -138,7 +138,8 @@ pub fn parse_stmt(text string, mut table ast.Table, mut scope ast.Scope) ast.Stm
 	return p.stmt(false)
 }
 
-pub fn parse_comptime(tmpl_path string, text string, mut table ast.Table, pref_ &pref.Preferences, mut scope ast.Scope) &ast.File {
+pub fn parse_comptime(tmpl_path string, text string, mut table ast.Table, pref_ &pref.Preferences,
+	mut scope ast.Scope) &ast.File {
 	$if trace_parse_comptime ? {
 		eprintln('> ${@MOD}.${@FN} text: ${text}')
 	}
@@ -156,7 +157,8 @@ pub fn parse_comptime(tmpl_path string, text string, mut table ast.Table, pref_ 
 	return res
 }
 
-pub fn parse_text(text string, path string, mut table ast.Table, comments_mode scanner.CommentsMode, pref_ &pref.Preferences) &ast.File {
+pub fn parse_text(text string, path string, mut table ast.Table, comments_mode scanner.CommentsMode,
+	pref_ &pref.Preferences) &ast.File {
 	$if trace_parse_text ? {
 		eprintln('> ${@MOD}.${@FN} comments_mode: ${comments_mode:-20} | path: ${path:-20} | text: ${text}')
 	}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -272,7 +272,8 @@ fn detect_musl(mut res Preferences) {
 }
 
 @[noreturn]
-fn run_code_in_tmp_vfile_and_exit(args []string, mut res Preferences, option_name string, extension string, content string) {
+fn run_code_in_tmp_vfile_and_exit(args []string, mut res Preferences, option_name string, extension string,
+	content string) {
 	tmp_file_path := rand.ulid()
 	mut tmp_exe_file_path := res.out_name
 	mut output_option := ''

--- a/vlib/v/preludes/test_runner_dump.v
+++ b/vlib/v/preludes/test_runner_dump.v
@@ -76,7 +76,8 @@ fn (mut runner DumpTestRunner) fn_fail() {
 	runner.fn_fails++
 }
 
-fn (mut runner DumpTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn (mut runner DumpTestRunner) fn_error(line_nr int, file string, mod string, fn_name string,
+	errmsg string) {
 	eprintln('> ${@METHOD} test function propagated error: ${runner.fname}, line_nr: ${line_nr}, file: ${file}, mod: ${mod}, fn_name: ${fn_name}, errmsg: ${errmsg}')
 }
 

--- a/vlib/v/preludes/test_runner_normal.v
+++ b/vlib/v/preludes/test_runner_normal.v
@@ -90,7 +90,8 @@ fn (mut runner NormalTestRunner) fn_fail() {
 	runner.fn_fails++
 }
 
-fn (mut runner NormalTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn (mut runner NormalTestRunner) fn_error(line_nr int, file string, mod string, fn_name string,
+	errmsg string) {
 	filepath := if runner.use_relative_paths { file.clone() } else { os.real_path(file) }
 	mut final_filepath := filepath + ':${line_nr}:'
 	if runner.use_color {

--- a/vlib/v/preludes/test_runner_simple.v
+++ b/vlib/v/preludes/test_runner_simple.v
@@ -67,7 +67,8 @@ fn (mut runner SimpleTestRunner) fn_fail() {
 	eprintln('>>> fail ${runner.fname}')
 }
 
-fn (mut runner SimpleTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn (mut runner SimpleTestRunner) fn_error(line_nr int, file string, mod string, fn_name string,
+	errmsg string) {
 	eprintln('>>> SimpleTestRunner fn_error ${runner.fname}, line_nr: ${line_nr}, file: ${file}, mod: ${mod}, fn_name: ${fn_name}, errmsg: ${errmsg}')
 }
 

--- a/vlib/v/preludes/test_runner_tap.v
+++ b/vlib/v/preludes/test_runner_tap.v
@@ -92,7 +92,8 @@ fn (mut runner TAPTestRunner) fn_fail() {
 	runner.fn_fails++
 }
 
-fn (mut runner TAPTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn (mut runner TAPTestRunner) fn_error(line_nr int, file string, mod string, fn_name string,
+	errmsg string) {
 	flush_println('# test function propagated error: ${runner.fname}, line_nr: ${line_nr}, file: ${file}, mod: ${mod}, fn_name: ${fn_name}, errmsg: ${errmsg}')
 }
 

--- a/vlib/v/preludes/test_runner_teamcity.v
+++ b/vlib/v/preludes/test_runner_teamcity.v
@@ -148,7 +148,8 @@ fn (mut _ TeamcityTestRunner) prepare_value(raw string) string {
 		.replace("'", "|'")
 }
 
-fn (mut runner TeamcityTestRunner) fn_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn (mut runner TeamcityTestRunner) fn_error(line_nr int, file string, mod string, fn_name string,
+	errmsg string) {
 	eprintln('>>> TeamcityTestRunner fn_error ${runner.fname}, line_nr: ${line_nr}, file: ${file}, mod: ${mod}, fn_name: ${fn_name}, errmsg: ${errmsg}')
 }
 

--- a/vlib/v/tests/bench/math_big_gcd/bench_euclid.v
+++ b/vlib/v/tests/bench/math_big_gcd/bench_euclid.v
@@ -218,7 +218,8 @@ fn run_benchmark(data []DataI, heap bool, mut clocks Clocks) bool {
 	return true
 }
 
-fn bench_euclid_vs_binary(test_config PrimeCfg, heap bool, predicate_fn fn (ps PrimeSet) bool, mut clocks Clocks) bool {
+fn bench_euclid_vs_binary(test_config PrimeCfg, heap bool, predicate_fn fn (ps PrimeSet) bool,
+	mut clocks Clocks) bool {
 	testprimes := prime.random_set(test_config) or { panic(err) }
 
 	// validate the test-data

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -6,7 +6,8 @@ import os
 import v.pref
 
 @[if trace_util_qualify ?]
-fn trace_qualify(callfn string, mod string, file_path string, kind_res string, result string, detail string) {
+fn trace_qualify(callfn string, mod string, file_path string, kind_res string, result string,
+	detail string) {
 	eprintln('> ${callfn:15}: ${mod:-18} | file_path: ${file_path:-71} | => ${kind_res:14}: ${result:-18} ; ${detail}')
 }
 

--- a/vlib/veb/assets/assets.v
+++ b/vlib/veb/assets/assets.v
@@ -129,7 +129,8 @@ pub fn (mut am AssetManager) add(asset_type AssetType, file_path string, include
 	}
 }
 
-fn (mut am AssetManager) minify_and_cache(asset_type AssetType, file_path string, last_modified i64, include_name string) !(string, bool) {
+fn (mut am AssetManager) minify_and_cache(asset_type AssetType, file_path string, last_modified i64,
+	include_name string) !(string, bool) {
 	if asset_type == .all {
 		return error('cannot minify asset of type "all"')
 	}

--- a/vlib/veb/controller.v
+++ b/vlib/veb/controller.v
@@ -35,7 +35,8 @@ pub fn controller[A, X](path string, mut global_app A) !&ControllerPath {
 	// no need to type `ControllerHandler` as generic since it's not needed for closures
 	return &ControllerPath{
 		path: path
-		handler: fn [mut global_app, path, routes, controllers_sorted] [A, X](ctx &Context, mut url urllib.URL, host string) &Context {
+		handler: fn [mut global_app, path, routes, controllers_sorted] [A, X](ctx &Context, mut url urllib.URL,
+	host string) &Context {
 			// transform the url
 			url.path = url.path.all_after_first(path)
 

--- a/vlib/veb/static_handler.v
+++ b/vlib/veb/static_handler.v
@@ -80,7 +80,8 @@ pub fn (mut sh StaticHandler) mount_static_folder_at(directory_path string, moun
 // For example: suppose you have called .host_mount_static_folder_at('localhost', '/var/share/myassets', '/assets'),
 // and you have a file /var/share/myassets/main.css .
 // => That file will be available at URL: http://localhost/assets/main.css .
-pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory_path string, mount_path string) !bool {
+pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory_path string,
+	mount_path string) !bool {
 	if mount_path == '' || mount_path[0] != `/` {
 		return error('invalid mount path! The path should start with `/`')
 	} else if !os.exists(directory_path) {

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -668,7 +668,8 @@ fn new_request_app[T](global_app &T, ctx Context, tid int) &T {
 }
 
 @[manualfree]
-fn handle_conn[T](mut conn net.TcpConn, global_app &T, controllers []&ControllerPath, routes &map[string]Route, tid int) {
+fn handle_conn[T](mut conn net.TcpConn, global_app &T, controllers []&ControllerPath, routes &map[string]Route,
+	tid int) {
 	conn.set_read_timeout(30 * time.second)
 	conn.set_write_timeout(30 * time.second)
 	defer {

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -523,7 +523,8 @@ fn (mut tm DynamicTemplateManager) check_tmpl_and_placeholders_size(f_path strin
 // The function returns the rendered immediately, without waiting for the cache to be created or updated.
 //
 fn (mut tm DynamicTemplateManager) create_template_cache_and_display(tcs CacheRequest, last_template_mod i64,
-	unique_time i64, file_path string, tmpl_name string, cache_delay_expiration i64, placeholders &map[string]DtmMultiTypeMap, current_content_checksum string, tmpl_type TemplateType) string {
+	unique_time i64, file_path string, tmpl_name string, cache_delay_expiration i64, placeholders &map[string]DtmMultiTypeMap,
+	current_content_checksum string, tmpl_type TemplateType) string {
 	// Control if cache delay expiration is correctly set. See the function itself for more details.
 	check_if_cache_delay_iscorrect(cache_delay_expiration, tmpl_name) or {
 		eprintln(err)
@@ -1040,7 +1041,8 @@ fn check_if_cache_delay_iscorrect(cde i64, tmpl_name string) ! {
 // to decide whether to create a new cache, update an existing or delivered a valid cache content.
 //
 fn (mut tm DynamicTemplateManager) cache_request_route(is_cache_exist bool, neg_cache_delay_expiration i64,
-	last_template_mod i64, test_current_template_mod i64, cache_del_exp i64, gen_at i64, c_time i64, content_checksum string, current_content_checksum string) (CacheRequest, i64) {
+	last_template_mod i64, test_current_template_mod i64, cache_del_exp i64, gen_at i64, c_time i64,
+	content_checksum string, current_content_checksum string) (CacheRequest, i64) {
 	if !is_cache_exist || neg_cache_delay_expiration == -1 {
 		// Require cache creation
 		unique_ts := get_current_unix_micro_timestamp()

--- a/vlib/x/templating/dtm/dynamic_template_manager.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager.v
@@ -522,7 +522,8 @@ fn (mut tm DynamicTemplateManager) check_tmpl_and_placeholders_size(f_path strin
 // This request is then sent to the cache handler channel, signaling either the need for a new cache or an update to an existing one.
 // The function returns the rendered immediately, without waiting for the cache to be created or updated.
 //
-fn (mut tm DynamicTemplateManager) create_template_cache_and_display(tcs CacheRequest, last_template_mod i64, unique_time i64, file_path string, tmpl_name string, cache_delay_expiration i64, placeholders &map[string]DtmMultiTypeMap, current_content_checksum string, tmpl_type TemplateType) string {
+fn (mut tm DynamicTemplateManager) create_template_cache_and_display(tcs CacheRequest, last_template_mod i64,
+	unique_time i64, file_path string, tmpl_name string, cache_delay_expiration i64, placeholders &map[string]DtmMultiTypeMap, current_content_checksum string, tmpl_type TemplateType) string {
 	// Control if cache delay expiration is correctly set. See the function itself for more details.
 	check_if_cache_delay_iscorrect(cache_delay_expiration, tmpl_name) or {
 		eprintln(err)
@@ -927,7 +928,8 @@ fn (mut tm DynamicTemplateManager) chandler_clear_specific_cache(id int) (int, b
 // The function returns a boolean value: if true, it authorizes the destruction of the expired cache, ensuring that it's only removed when no longer in use.
 // If false, it indicates that the cache cannot yet be destroyed due to ongoing usage.
 //
-fn (mut tm DynamicTemplateManager) chandler_remaining_cache_template_used(cr CacheRequest, id int, old_id int) bool {
+fn (mut tm DynamicTemplateManager) chandler_remaining_cache_template_used(cr CacheRequest, id int,
+	old_id int) bool {
 	lock tm.nbr_of_remaining_template_request {
 		match cr {
 			// Adds a new request in 'nbr_of_remaining_template_request' to track the usage of the newly created cache
@@ -995,7 +997,8 @@ const allowed_tags = ['<div>', '</div>', '<h1>', '</h1>', '<h2>', '</h2>', '<h3>
 
 const include_html_key_tag = '_#includehtml'
 
-fn (mut tm DynamicTemplateManager) parse_tmpl_file(file_path string, tmpl_name string, placeholders &map[string]DtmMultiTypeMap, is_compressed bool, tmpl_type TemplateType) string {
+fn (mut tm DynamicTemplateManager) parse_tmpl_file(file_path string, tmpl_name string, placeholders &map[string]DtmMultiTypeMap,
+	is_compressed bool, tmpl_type TemplateType) string {
 	mut tmpl_ := compile_template_file(file_path, tmpl_name, placeholders)
 
 	// Performs a light compression of the HTML output by removing usless spaces, newlines, and tabs if user selected this option.
@@ -1036,7 +1039,8 @@ fn check_if_cache_delay_iscorrect(cde i64, tmpl_name string) ! {
 // It assesses various conditions such as cache existence, cache expiration settings, and last modification timestamps ( template or dynamic content )
 // to decide whether to create a new cache, update an existing or delivered a valid cache content.
 //
-fn (mut tm DynamicTemplateManager) cache_request_route(is_cache_exist bool, neg_cache_delay_expiration i64, last_template_mod i64, test_current_template_mod i64, cache_del_exp i64, gen_at i64, c_time i64, content_checksum string, current_content_checksum string) (CacheRequest, i64) {
+fn (mut tm DynamicTemplateManager) cache_request_route(is_cache_exist bool, neg_cache_delay_expiration i64,
+	last_template_mod i64, test_current_template_mod i64, cache_del_exp i64, gen_at i64, c_time i64, content_checksum string, current_content_checksum string) (CacheRequest, i64) {
 	if !is_cache_exist || neg_cache_delay_expiration == -1 {
 		// Require cache creation
 		unique_ts := get_current_unix_micro_timestamp()

--- a/vlib/x/templating/dtm/tmpl.v
+++ b/vlib/x/templating/dtm/tmpl.v
@@ -130,7 +130,8 @@ fn replace_placeholders_with_data(line string, data &map[string]DtmMultiTypeMap,
 	return rline
 }
 
-fn insert_template_code(fn_name string, tmpl_str_start string, line string, data &map[string]DtmMultiTypeMap, state State) string {
+fn insert_template_code(fn_name string, tmpl_str_start string, line string, data &map[string]DtmMultiTypeMap,
+	state State) string {
 	// HTML, may include `@var`
 	// escaped by cgen, unless it's a `vweb.RawHtml` string
 	trailing_bs := dtm.tmpl_str_end + 'sb_${fn_name}.write_u8(92)\n' + tmpl_str_start

--- a/vlib/x/ttf/render_bmp.v
+++ b/vlib/x/ttf/render_bmp.v
@@ -394,7 +394,8 @@ pub fn (mut bmp BitMap) box(in_x0 int, in_y0 int, in_x1 int, in_y1 int, c u32) {
 	bmp.line(in_x0, in_y0, in_x0, in_y1, c)
 }
 
-pub fn (mut bmp BitMap) quadratic(in_x0 int, in_y0 int, in_x1 int, in_y1 int, in_cx int, in_cy int, c u32) {
+pub fn (mut bmp BitMap) quadratic(in_x0 int, in_y0 int, in_x1 int, in_y1 int, in_cx int, in_cy int,
+	c u32) {
 	/*
 	x0 := int(in_x0 * bmp.scale)
 	x1 := int(in_x1 * bmp.scale)

--- a/vlib/x/vweb/assets/assets.v
+++ b/vlib/x/vweb/assets/assets.v
@@ -129,7 +129,8 @@ pub fn (mut am AssetManager) add(asset_type AssetType, file_path string, include
 	}
 }
 
-fn (mut am AssetManager) minify_and_cache(asset_type AssetType, file_path string, last_modified i64, include_name string) !(string, bool) {
+fn (mut am AssetManager) minify_and_cache(asset_type AssetType, file_path string, last_modified i64,
+	include_name string) !(string, bool) {
 	if asset_type == .all {
 		return error('cannot minify asset of type "all"')
 	}

--- a/vlib/x/vweb/controller.v
+++ b/vlib/x/vweb/controller.v
@@ -35,7 +35,8 @@ pub fn controller[A, X](path string, mut global_app A) !&ControllerPath {
 	// no need to type `ControllerHandler` as generic since it's not needed for closures
 	return &ControllerPath{
 		path: path
-		handler: fn [mut global_app, path, routes, controllers_sorted] [A, X](ctx &Context, mut url urllib.URL, host string) &Context {
+		handler: fn [mut global_app, path, routes, controllers_sorted] [A, X](ctx &Context, mut url urllib.URL,
+	host string) &Context {
 			// transform the url
 			url.path = url.path.all_after_first(path)
 

--- a/vlib/x/vweb/static_handler.v
+++ b/vlib/x/vweb/static_handler.v
@@ -80,7 +80,8 @@ pub fn (mut sh StaticHandler) mount_static_folder_at(directory_path string, moun
 // For example: suppose you have called .host_mount_static_folder_at('localhost', '/var/share/myassets', '/assets'),
 // and you have a file /var/share/myassets/main.css .
 // => That file will be available at URL: http://localhost/assets/main.css .
-pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory_path string, mount_path string) !bool {
+pub fn (mut sh StaticHandler) host_mount_static_folder_at(host string, directory_path string,
+	mount_path string) !bool {
 	if mount_path == '' || mount_path[0] != `/` {
 		return error('invalid mount path! The path should start with `/`')
 	} else if !os.exists(directory_path) {


### PR DESCRIPTION
This PR implement wrapping function's super long arguments (fix #15545, fix #21643).

- Implement wrapping function's super long arguments.
- Add test.

- vlib\v\fmt\tests\fn_with_long_args_keep.vv
```v
fn process_keyholder1(super_long_argument1 string, super_long_argument2 string, super_long_argument3 string,
	super_long_argument4 string, super_long_argument5 string) string {
	return ''
}

fn process_keyholder2(super_long_argument1 string, super_long_argument2 string, super_long_argument3 string,
	super_long_argument4 string, super_long_argument5 string, super_long_argument6 string, super_long_argument7 string,
	super_long_argument8 string) string {
	return ''
}

fn main() {}
```