### PR TITLE
cgen: allow alias to array fixed to be initialized like `[n]int{}`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1536,7 +1536,7 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		}
 	}
 	field_name := node.field_name
-	sym := c.table.sym(typ)
+	sym := c.table.final_sym(typ)
 	if (typ.has_flag(.variadic) || sym.kind == .array_fixed) && field_name == 'len' {
 		node.typ = ast.int_type
 		return ast.int_type
@@ -2824,7 +2824,7 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 			}
 
 			unwrapped_expr_type := c.unwrap_generic(node.expr_type)
-			tsym := c.table.sym(unwrapped_expr_type)
+			tsym := c.table.final_sym(unwrapped_expr_type)
 			if tsym.kind == .array_fixed {
 				info := tsym.info as ast.ArrayFixed
 				if !info.is_fn_ret {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1536,8 +1536,9 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 		}
 	}
 	field_name := node.field_name
-	sym := c.table.final_sym(typ)
-	if (typ.has_flag(.variadic) || sym.kind == .array_fixed) && field_name == 'len' {
+	sym := c.table.sym(typ)
+	final_sym := c.table.final_sym(typ)
+	if (typ.has_flag(.variadic) || final_sym.kind == .array_fixed) && field_name == 'len' {
 		node.typ = ast.int_type
 		return ast.int_type
 	}
@@ -2824,9 +2825,10 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 			}
 
 			unwrapped_expr_type := c.unwrap_generic(node.expr_type)
-			tsym := c.table.final_sym(unwrapped_expr_type)
-			if tsym.kind == .array_fixed {
-				info := tsym.info as ast.ArrayFixed
+			tsym := c.table.sym(unwrapped_expr_type)
+			tsym_final := c.table.final_sym(unwrapped_expr_type)
+			if tsym_final.kind == .array_fixed {
+				info := tsym_final.info as ast.ArrayFixed
 				if !info.is_fn_ret {
 					// for dumping fixed array we must register the fixed array struct to return from function
 					c.table.find_or_register_array_fixed(info.elem_type, info.size, info.size_expr,

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -554,10 +554,16 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 					c.error('unknown struct: ${type_sym.name}', node.pos)
 					return ast.void_type
 				}
-				if sym.kind == .struct_ {
-					info = sym.info as ast.Struct
-				} else {
-					c.error('alias type name: ${sym.name} is not struct type', node.pos)
+				match sym.kind {
+					.struct_ {
+						info = sym.info as ast.Struct
+					}
+					.array, .array_fixed {
+						// we do allow []int{}, [10]int{}
+					}
+					else {
+						c.error('alias type name: ${sym.name} is not struct type', node.pos)
+					}
 				}
 			} else {
 				info = type_sym.info as ast.Struct

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3833,7 +3833,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 	}
-	sym := g.table.final_sym(g.unwrap_generic(node.expr_type))
+	sym := g.table.sym(g.unwrap_generic(node.expr_type))
 	field_name := if sym.language == .v { c_name(node.field_name) } else { node.field_name }
 	is_as_cast := node.expr is ast.AsCast
 	if is_as_cast {
@@ -3889,11 +3889,12 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		opt_base_typ := g.base_type(node.expr_type)
 		g.write('(*(${opt_base_typ}*)')
 	}
-	if sym.kind == .array_fixed {
+	final_sym := g.table.final_sym(g.unwrap_generic(node.expr_type))
+	if final_sym.kind == .array_fixed {
 		if node.field_name != 'len' {
 			g.error('field_name should be `len`', node.pos)
 		}
-		info := sym.info as ast.ArrayFixed
+		info := final_sym.info as ast.ArrayFixed
 		g.write('${info.size}')
 		return
 	} else if sym.kind == .chan && (node.field_name == 'len' || node.field_name == 'closed') {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3833,7 +3833,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if node.expr_type == 0 {
 		g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 	}
-	sym := g.table.sym(g.unwrap_generic(node.expr_type))
+	sym := g.table.final_sym(g.unwrap_generic(node.expr_type))
 	field_name := if sym.language == .v { c_name(node.field_name) } else { node.field_name }
 	is_as_cast := node.expr is ast.AsCast
 	if is_as_cast {

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -307,7 +307,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 			cond_var = g.expr_string(node.cond)
 		}
 		idx := if node.key_var in ['', '_'] { g.new_tmp_var() } else { node.key_var }
-		cond_sym := g.table.sym(node.cond_type)
+		cond_sym := g.table.final_sym(node.cond_type)
 		info := cond_sym.info as ast.ArrayFixed
 		g.writeln('for (int ${idx} = 0; ${idx} != ${info.size}; ++${idx}) {')
 		if node.val_var != '_' {

--- a/vlib/v/tests/alias_fixed_arr_test.v
+++ b/vlib/v/tests/alias_fixed_arr_test.v
@@ -1,0 +1,19 @@
+type MyArray = [10]int
+type MyArray2 = []int
+
+fn test_main() {
+	a := MyArray{}
+
+	assert dump(a.len) == 10
+
+	mut count := 0
+	for w in a {
+		dump(w)
+		count++
+	}
+	assert count == 10
+
+	b := MyArray2{}
+	z := dump(b)
+	assert z.len == 0
+}


### PR DESCRIPTION
Fix #21783