### PR TITLE
vrepl: fix method call (fix #21788)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -442,7 +442,9 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			filter_line := r.line.replace(r.line.find_between("'", "'"), '').replace(r.line.find_between('"',
 				'"'), '')
 			mut is_statement := false
-			if filter_line.count('=') % 2 == 1
+			if func_call {
+				is_statement = true
+			} else if filter_line.count('=') % 2 == 1
 				&& (filter_line.count('!=') + filter_line.count('>=') + filter_line.count('<=')) == 0 {
 				is_statement = true
 			} else {

--- a/vlib/v/slow_tests/repl/comptime_tmpl.repl
+++ b/vlib/v/slow_tests/repl/comptime_tmpl.repl
@@ -1,3 +1,3 @@
-$tmpl('./tmpl/hello.txt')
+print($tmpl('./tmpl/hello.txt'))
 ===output===
 hello

--- a/vlib/v/slow_tests/repl/fn_calls.repl
+++ b/vlib/v/slow_tests/repl/fn_calls.repl
@@ -1,4 +1,4 @@
-math.sinf(50.0)
+println(math.sinf(50.0))
 println(1+math.sinf(50.0))
 fn test() { println('foo') } fn test2(a int) { println(a) }
 test()

--- a/vlib/v/slow_tests/repl/import_alias.repl
+++ b/vlib/v/slow_tests/repl/import_alias.repl
@@ -1,4 +1,4 @@
 import encoding.hex as z
-z.decode('AB09CD')!.hex()
+print(z.decode('AB09CD')!.hex())
 ===output===
 ab09cd

--- a/vlib/v/slow_tests/repl/method_call.repl
+++ b/vlib/v/slow_tests/repl/method_call.repl
@@ -1,0 +1,7 @@
+mut values := [1, 2, 3]
+values
+values.pop()
+values
+===output===
+[1, 2, 3]
+[1, 2]


### PR DESCRIPTION
This PR fix method call (fix #21788).

- Fix method call.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 209063f . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut values := [1, 2, 3]
>>> values.pop()
>>> values
[1, 2]
```