### PR TITLE
fmt: keep manual newlines after fn parameters in fn declarations, do not auto wrap

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -847,6 +847,12 @@ fn (t Tree) arg(node ast.Param) &Node {
 	obj.add_terse('name', t.string_node(node.name))
 	obj.add_terse('typ', t.type_node(node.typ))
 	obj.add_terse('is_mut', t.bool_node(node.is_mut))
+	obj.add_terse('is_shared', t.bool_node(node.is_shared))
+	obj.add_terse('is_atomic', t.bool_node(node.is_atomic))
+	obj.add_terse('is_auto_rec', t.bool_node(node.is_auto_rec))
+	obj.add_terse('on_newline', t.bool_node(node.on_newline))
+	obj.add('pos', t.pos(node.pos))
+	obj.add('type_pos', t.pos(node.type_pos))
 	return obj
 }
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -683,6 +683,7 @@ pub:
 	is_auto_rec bool
 	type_pos    token.Pos
 	is_hidden   bool // interface first arg
+	on_newline  bool // whether the argument starts on a new line
 pub mut:
 	typ      Type
 	comments []Comment

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -84,7 +84,7 @@ pub fn (t &Table) stringify_anon_decl(node &AnonFn, cur_mod string, m2a map[stri
 		}
 		f.write_string('] ')
 	}
-	t.stringify_fn_after_name(node.decl, mut f, cur_mod, m2a, false)
+	t.stringify_fn_after_name(node.decl, mut f, cur_mod, m2a)
 	return f.str()
 }
 
@@ -132,12 +132,11 @@ pub fn (t &Table) stringify_fn_decl(node &FnDecl, cur_mod string, m2a map[string
 	if name in ['+', '-', '*', '/', '%', '<', '>', '==', '!=', '>=', '<='] {
 		f.write_string(' ')
 	}
-	t.stringify_fn_after_name(node, mut f, cur_mod, m2a, needs_wrap)
+	t.stringify_fn_after_name(node, mut f, cur_mod, m2a)
 	return f.str()
 }
 
-fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_mod string, m2a map[string]string,
-	oneeds_wrap bool) {
+fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_mod string, m2a map[string]string) {
 	mut add_para_types := true
 	mut is_wrap_needed := false
 	if node.generic_names.len > 0 {

--- a/vlib/v/fmt/tests/donut_card_expected.vv
+++ b/vlib/v/fmt/tests/donut_card_expected.vv
@@ -5,7 +5,8 @@ import time { sleep }
 
 const alt = '.,-~:;=!*#$@'
 
-fn rd(cs int, ls int, a f64, b f64) {
+fn rd(cs int, ls int, a f64,
+	b f64) {
 	tt_spacing, p_spacing := 0.07, 0.02
 	r1, r2, k2 := 1, 2, 5
 	k1 := cs * k2 * 2 / (20 * (r1 + r2))

--- a/vlib/v/fmt/tests/expressions_expected.vv
+++ b/vlib/v/fmt/tests/expressions_expected.vv
@@ -58,7 +58,8 @@ fn main() {
 	}
 }
 
-fn gen_str_for_multi_return(mut g gen.Gen, info table.MultiReturn, styp string, str_fn_name string) {
+fn gen_str_for_multi_return(mut g gen.Gen,
+	info table.MultiReturn, styp string, str_fn_name string) {
 	for i, _ in info.types {
 		println('\tstrings__Builder_write(&sb, _STR("\'%.*s\\000\'", 2, a.arg${i}));')
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -894,6 +894,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 		|| (p.tok.kind == .key_mut && (p.peek_tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
 		|| p.peek_token(2).kind == .comma || p.peek_token(2).kind == .rpar
 		|| (p.peek_tok.kind == .name && p.peek_token(2).kind == .dot)))
+	mut prev_param_newline := p.tok.pos().line_nr
 	// TODO: copy paste, merge 2 branches
 	if types_only {
 		mut param_no := 1
@@ -983,7 +984,9 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 				typ: param_type
 				type_pos: type_pos
 				comments: comments
+				on_newline: prev_param_newline != pos.line_nr
 			}
+			prev_param_newline = pos.line_nr
 			param_no++
 			if param_no > 1024 {
 				p.error_with_pos('too many parameters', pos)
@@ -1094,7 +1097,9 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool) {
 					typ: typ
 					type_pos: type_pos[i]
 					comments: comments
+					on_newline: prev_param_newline != param_pos[i].line_nr
 				}
+				prev_param_newline = param_pos[i].line_nr
 				// if typ.typ.kind == .variadic && p.tok.kind == .comma {
 				if is_variadic && p.tok.kind == .comma && p.peek_tok.kind != .rpar {
 					p.error_with_pos('cannot use ...(variadic) with non-final parameter ${para_name}',


### PR DESCRIPTION
- **fmt: preserve manual line breaks in fn parameters, with no auto wrapping**
- **small cleanup (remove unused wrapping parameter in stringify_fn_after_name)**
