### PR TITLE
cgen: fix comptime call argument auto conversion for indexexpr

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -154,7 +154,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			arg := node.args.last()
 			param := m.params[node.args.len]
 
-			arg.expr is ast.Ident && g.table.type_to_str(arg.typ) == '[]string'
+			arg.expr in [ast.IndexExpr, ast.Ident] && g.table.type_to_str(arg.typ) == '[]string'
 				&& g.table.type_to_str(param.typ) != '[]string'
 		} else {
 			false

--- a/vlib/v/tests/comptimecall_slice_arg_test.v
+++ b/vlib/v/tests/comptimecall_slice_arg_test.v
@@ -1,0 +1,17 @@
+struct Dummy {}
+
+fn (d Dummy) sample(x int) int {
+	return x + 1
+}
+
+fn test_main() {
+	args := ['0', '5']
+	$for method in Dummy.methods {
+		if args.len > 1 {
+			assert Dummy{}.$method(args[1 ..]) == 6
+
+			tmp := args[1..]
+			assert Dummy{}.$method(tmp) == 6
+		}
+	}
+}


### PR DESCRIPTION
Fix #15232