### PR TITLE
vrepl: fix output of the fn call (related #21792)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -480,6 +480,8 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				}
 			} else if temp_line.starts_with('#include ') {
 				temp_source_code = '${temp_line}\n' + r.current_source_code(false, false)
+			} else if temp_line.starts_with('fn') {
+				temp_source_code = r.current_source_code(false, false)
 			} else {
 				temp_source_code = r.current_source_code(true, false) + '\n${temp_line}\n'
 			}
@@ -492,6 +494,8 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 					r.parse_import(r.line)
 				} else if r.line.starts_with('#include ') {
 					r.includes << r.line
+				} else if r.line.starts_with('fn ') {
+					r.functions << r.line
 				} else {
 					r.lines << r.line
 				}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -435,6 +435,8 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			if s.output.len > r.last_output.len {
 				cur_line_output := s.output[r.last_output.len..]
 				print_output(cur_line_output)
+				r.last_output = s.output.clone()
+				r.lines << r.line
 			}
 		} else {
 			mut temp_line := r.line
@@ -442,9 +444,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			filter_line := r.line.replace(r.line.find_between("'", "'"), '').replace(r.line.find_between('"',
 				'"'), '')
 			mut is_statement := false
-			if func_call {
-				is_statement = true
-			} else if filter_line.count('=') % 2 == 1
+			if filter_line.count('=') % 2 == 1
 				&& (filter_line.count('!=') + filter_line.count('>=') + filter_line.count('<=')) == 0 {
 				is_statement = true
 			} else {
@@ -467,6 +467,8 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				if s.output.len > r.last_output.len {
 					cur_line_output := s.output[r.last_output.len..]
 					print_output(cur_line_output)
+					r.last_output = s.output.clone()
+					r.lines << temp_line
 				}
 				continue
 			}

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -435,8 +435,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			if s.output.len > r.last_output.len {
 				cur_line_output := s.output[r.last_output.len..]
 				print_output(cur_line_output)
-				r.last_output = s.output.clone()
-				r.lines << r.line
+				if s.exit_code == 0 {
+					r.last_output = s.output.clone()
+					r.lines << r.line
+				}
 			}
 		} else {
 			mut temp_line := r.line
@@ -467,8 +469,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				if s.output.len > r.last_output.len {
 					cur_line_output := s.output[r.last_output.len..]
 					print_output(cur_line_output)
-					r.last_output = s.output.clone()
-					r.lines << temp_line
+					if s.exit_code == 0 {
+						r.last_output = s.output.clone()
+						r.lines << temp_line
+					}
 				}
 				continue
 			}

--- a/vlib/v/slow_tests/repl/comptime_tmpl.repl
+++ b/vlib/v/slow_tests/repl/comptime_tmpl.repl
@@ -1,3 +1,3 @@
-print($tmpl('./tmpl/hello.txt'))
+$tmpl('./tmpl/hello.txt')
 ===output===
 hello

--- a/vlib/v/slow_tests/repl/fn_calls.repl
+++ b/vlib/v/slow_tests/repl/fn_calls.repl
@@ -1,4 +1,4 @@
-println(math.sinf(50.0))
+math.sinf(50.0)
 println(1+math.sinf(50.0))
 fn test() { println('foo') } fn test2(a int) { println(a) }
 test()

--- a/vlib/v/slow_tests/repl/import_alias.repl
+++ b/vlib/v/slow_tests/repl/import_alias.repl
@@ -1,4 +1,4 @@
 import encoding.hex as z
-print(z.decode('AB09CD')!.hex())
+z.decode('AB09CD')!.hex()
 ===output===
 ab09cd

--- a/vlib/v/slow_tests/repl/method_call1.repl
+++ b/vlib/v/slow_tests/repl/method_call1.repl
@@ -1,0 +1,8 @@
+mut values := [1, 2, 3]
+values
+values.pop()
+values
+===output===
+[1, 2, 3]
+3
+[1, 2]

--- a/vlib/v/slow_tests/repl/method_call2.repl
+++ b/vlib/v/slow_tests/repl/method_call2.repl
@@ -1,7 +1,8 @@
 mut values := [1, 2, 3]
 values
-values.pop()
+println(values.pop())
 values
 ===output===
 [1, 2, 3]
+3
 [1, 2]


### PR DESCRIPTION
This PR fix output of the fn call (related #21792).

- Fix output of the fn call.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 0c2d72f . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut values := [1, 2, 3]
>>> values.pop()
3
>>> values
[1, 2]
>>>
```
```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 0c2d72f . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut values := [1, 2, 3]
>>> println(values.pop())
3
>>> values
[1, 2]
>>>
```
```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 0dd0311 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut a := 22
>>> fn info(n int) int { return n }
>>> info(a)
22
>>> info(11)
11
>>> 
```