### PR TITLE
token: make is_assign() contain .decl_assign

### DIFF
--- a/cmd/tools/vdoc/highlight.v
+++ b/cmd/tools/vdoc/highlight.v
@@ -138,8 +138,8 @@ fn color_highlight(code string, tb &ast.Table) string {
 				else {
 					if token.is_key(tok.lit) || token.is_decl(tok.kind) {
 						tok_typ = .keyword
-					} else if tok.kind == .decl_assign || tok.kind.is_assign() || tok.is_unary()
-						|| tok.kind.is_relational() || tok.kind.is_infix() || tok.kind.is_postfix() {
+					} else if tok.kind.is_assign() || tok.is_unary() || tok.kind.is_relational()
+						|| tok.kind.is_infix() || tok.kind.is_postfix() {
 						tok_typ = .operator
 					}
 				}

--- a/cmd/tools/vdoc/html.v
+++ b/cmd/tools/vdoc/html.v
@@ -444,8 +444,8 @@ fn html_highlight(code string, tb &ast.Table) string {
 			else {
 				if token.is_key(tok.lit) || token.is_decl(tok.kind) {
 					tok_typ = .keyword
-				} else if tok.kind == .decl_assign || tok.kind.is_assign() || tok.is_unary()
-					|| tok.kind.is_relational() || tok.kind.is_infix() || tok.kind.is_postfix() {
+				} else if tok.kind.is_assign() || tok.is_unary() || tok.kind.is_relational()
+					|| tok.kind.is_infix() || tok.kind.is_postfix() {
 					tok_typ = .operator
 				}
 			}

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -30,7 +30,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		p.close_scope()
 		return for_stmt
-	} else if p.peek_tok.kind in [.decl_assign, .assign, .semicolon]
+	} else if p.peek_tok.kind == .semicolon
 		|| (p.peek_tok.kind in [.inc, .dec] && p.peek_token(2).kind in [.semicolon, .comma])
 		|| p.peek_tok.kind.is_assign() || p.tok.kind == .semicolon
 		|| (p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
@@ -47,7 +47,7 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		mut has_inc := false
 		mut is_multi := p.peek_tok.kind == .comma && p.peek_token(2).kind != .key_mut
 			&& p.peek_token(3).kind != .key_in
-		if p.peek_tok.kind in [.assign, .decl_assign] || p.peek_tok.kind.is_assign() || is_multi {
+		if p.peek_tok.kind.is_assign() || is_multi {
 			init = p.assign_stmt()
 			has_init = true
 		} else if p.peek_tok.kind in [.inc, .dec] {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2156,7 +2156,7 @@ fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 		return p.error('expecting `:=` (e.g. `mut x :=`)')
 	}
 	// TODO: remove translated
-	if p.tok.kind in [.assign, .decl_assign] || p.tok.kind.is_assign() {
+	if p.tok.kind.is_assign() {
 		return p.partial_assign_stmt(left)
 	} else if !p.pref.translated && !p.is_translated && !p.pref.is_fmt && !p.pref.is_vet
 		&& tok.kind !in [.key_if, .key_match, .key_lock, .key_rlock, .key_select] {

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -186,9 +186,9 @@ pub enum AtKind {
 	location
 }
 
-pub const assign_tokens = [Kind.assign, .plus_assign, .minus_assign, .mult_assign, .div_assign,
-	.xor_assign, .mod_assign, .or_assign, .and_assign, .right_shift_assign, .left_shift_assign,
-	.unsigned_right_shift_assign, .boolean_and_assign, .boolean_or_assign]
+pub const assign_tokens = [Kind.assign, .decl_assign, .plus_assign, .minus_assign, .mult_assign,
+	.div_assign, .xor_assign, .mod_assign, .or_assign, .and_assign, .right_shift_assign,
+	.left_shift_assign, .unsigned_right_shift_assign, .boolean_and_assign, .boolean_or_assign]
 
 pub const valid_at_tokens = ['@VROOT', '@VMODROOT', '@VEXEROOT', '@FN', '@METHOD', '@MOD', '@STRUCT',
 	'@VEXE', '@FILE', '@LINE', '@COLUMN', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@VMODHASH',


### PR DESCRIPTION
This PR make token.is_assign() contain .decl_assign.

- Make `token.is_assign()` contain `.decl_assign`.
- Modify related calls.