### PR TITLE
vrepl: fix variable name starts with `print` (fix #13981)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -384,7 +384,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			r.in_func = true
 			r.functions_name << r.line.all_before(':= fn(').trim_space()
 		}
-		if r.line.starts_with('fn') {
+		if r.line.starts_with('fn ') {
 			r.in_func = true
 			r.functions_name << r.line.all_after('fn').all_before('(').trim_space()
 		}
@@ -428,7 +428,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 		if r.line.starts_with('=') {
 			r.line = 'println(' + r.line[1..] + ')'
 		}
-		if r.line.starts_with('print') {
+		if r.line.starts_with('print(') || r.line.starts_with('println(') {
 			source_code := r.current_source_code(false, false) + '\n${r.line}\n'
 			os.write_file(temp_file, source_code) or { panic(err) }
 			s := repl_run_vfile(temp_file) or { return 1 }
@@ -484,7 +484,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				}
 			} else if temp_line.starts_with('#include ') {
 				temp_source_code = '${temp_line}\n' + r.current_source_code(false, false)
-			} else if temp_line.starts_with('fn') {
+			} else if temp_line.starts_with('fn ') {
 				temp_source_code = r.current_source_code(false, false)
 			} else {
 				temp_source_code = r.current_source_code(true, false) + '\n${temp_line}\n'

--- a/vlib/v/slow_tests/repl/var_starts_with_print.repl
+++ b/vlib/v/slow_tests/repl/var_starts_with_print.repl
@@ -1,0 +1,7 @@
+a_variable := "yessir"
+a_variable
+printme := "ohno"
+printme
+===output===
+yessir
+ohno


### PR DESCRIPTION
This PR fix variable name starts with `print` (fix #13981).

- Fix variable name starts with `print`.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 a67bfeb . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> a_variable := 'yessir'
>>> a_variable
yessir
>>> printme := 'ohno'
>>> printme
ohno
>>> 
```