### PR TITLE
vrepl: fix os.input() (fix #5678)

### DIFF
--- a/vlib/v/slow_tests/repl/input.repl
+++ b/vlib/v/slow_tests/repl/input.repl
@@ -1,0 +1,9 @@
+mut s := os.input('aaa:')
+hello
+s
+s = os.input('bbb:')
+world
+s
+===output===
+hello
+world


### PR DESCRIPTION
This PR fix os.input() in vrepl tools (fix #5678).

- Fix os.input() in vrepl tool.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 4475759 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut s := os.input('aaa> ')
aaa> hello
>>> s
hello
>>> s = os.input('bbb> ')
bbb> world
>>> s
world
>>>
```