### PR TITLE
v/pref: handle using gcc on FreeBSD

### DIFF
--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -38,6 +38,9 @@ fn test_version_flag() {
 	$if freebsd && clang {
 		compiler = 'clang'
 	}
+	$if freebsd && gcc {
+		compiler = 'gcc'
+	}
 
 	v_verbose_cmd_with_additional_args_res := os.execute_opt('${vexe} -cc ${compiler} -v run ${example_path}')!.output
 	assert v_verbose_cmd_with_additional_args_res != v_ver_cmd_res

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -32,17 +32,7 @@ fn test_version_flag() {
 	assert v_verbose_cmd_res != v_ver_cmd_res
 	assert v_verbose_cmd_res.contains('v.pref.lookup_path:')
 
-	// tcc does not handle the symver assembly directive which is
-	// a problem on FreeBSD 14
-	mut compiler := 'tcc'
-	$if freebsd && clang {
-		compiler = 'clang'
-	}
-	$if freebsd && gcc {
-		compiler = 'gcc'
-	}
-
-	v_verbose_cmd_with_additional_args_res := os.execute_opt('${vexe} -cc ${compiler} -v run ${example_path}')!.output
+	v_verbose_cmd_with_additional_args_res := os.execute_opt('${vexe} -g -v run ${example_path}')!.output
 	assert v_verbose_cmd_with_additional_args_res != v_ver_cmd_res
 	assert v_verbose_cmd_with_additional_args_res.contains('v.pref.lookup_path:')
 }


### PR DESCRIPTION
When testing with VFLAGS='-cc gcc' I ran in to a similar problem that happened when I was testing with VFLAGS='-cc clang'.

The particular problem I am seeing is:
```
$ echo $VFLAGS
-cc gcc

$ v test vlib/v/pref/pref_test.v
---- Testing... ---------------------------------------------------------------------------------------
 FAIL     0.000 ms vlib/v/pref/pref_test.v
>> compilation failed:
==================
tcc: error: Unknown relocation type for got: 541
```

I had previously put in a test for freebsd and clang.  Now, I am adding a test for freebsd and gcc.

Is it possible to instead test for !tinyc and then use the currently specified compiler from the -cc parameter?  Otherwise, I am reduced to testing for every possible c compiler by name.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
