### PR TITLE
checker: check expr evaluated but not used (fix #21436)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2219,6 +2219,12 @@ fn (mut c Checker) block(mut node ast.Block) {
 		c.stmts(mut node.stmts)
 		c.inside_unsafe = prev_unsafe
 	} else {
+		if node.stmts.len > 0 && node.stmts.last() is ast.ExprStmt {
+			last_stmt := node.stmts.last() as ast.ExprStmt
+			if last_stmt.expr !in [ast.CallExpr, ast.IfExpr, ast.MatchExpr, ast.InfixExpr] {
+				c.error('expression evaluated but not used', node.stmts.last().pos)
+			}
+		}
 		c.stmts(mut node.stmts)
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2222,7 +2222,7 @@ fn (mut c Checker) block(mut node ast.Block) {
 		if node.stmts.len > 0 && node.stmts.last() is ast.ExprStmt {
 			last_stmt := node.stmts.last() as ast.ExprStmt
 			if last_stmt.expr !in [ast.CallExpr, ast.IfExpr, ast.MatchExpr, ast.InfixExpr] {
-				c.error('expression evaluated but not used', node.stmts.last().pos)
+				c.warn('expression evaluated but not used', node.stmts.last().pos)
 			}
 		}
 		c.stmts(mut node.stmts)

--- a/vlib/v/checker/tests/expr_evaluated_but_not_used.out
+++ b/vlib/v/checker/tests/expr_evaluated_but_not_used.out
@@ -1,6 +1,7 @@
-vlib/v/checker/tests/expr_evaluated_but_not_used.vv:2:3: error: expression evaluated but not used
-    1 | fn main() {
-    2 |     {1, 2, 3, 4}
-      |      ^
-    3 |     println('works')
-    4 | }
+vlib/v/checker/tests/expr_evaluated_but_not_used.vv:7:3: warning: expression evaluated but not used
+    5 |         println(3)
+    6 |         println(4)
+    7 |         5
+      |         ^
+    8 |     }
+    9 |     println('works')

--- a/vlib/v/checker/tests/expr_evaluated_but_not_used.out
+++ b/vlib/v/checker/tests/expr_evaluated_but_not_used.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/expr_evaluated_but_not_used.vv:2:3: error: expression evaluated but not used
+    1 | fn main() {
+    2 |     {1, 2, 3, 4}
+      |      ^
+    3 |     println('works')
+    4 | }

--- a/vlib/v/checker/tests/expr_evaluated_but_not_used.vv
+++ b/vlib/v/checker/tests/expr_evaluated_but_not_used.vv
@@ -1,0 +1,4 @@
+fn main() {
+	{1, 2, 3, 4}
+	println('works')
+}

--- a/vlib/v/checker/tests/expr_evaluated_but_not_used.vv
+++ b/vlib/v/checker/tests/expr_evaluated_but_not_used.vv
@@ -1,4 +1,10 @@
 fn main() {
-	{1, 2, 3, 4}
+	{
+		println(1)
+		println(2)
+		println(3)
+		println(4)
+		5
+	}
 	println('works')
 }


### PR DESCRIPTION
This PR check expr evaluated but not used (fix #21436).

- Check expr evaluated but not used.
- Add test.

```v
fn main() {
	{1, 2, 3, 4}
	println('works')
}

PS D:\Test\v\tt1> v run .
tt1.v:2:3: error: expression evaluated but not used
    1 | fn main() {
    2 |     {1, 2, 3, 4}
      |      ^
    3 |     println('works')
    4 | }
```