### PR TITLE
vrepl: fix arbitrary script execute (fix #13981)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -353,15 +353,6 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 		if line.len <= -1 || line == 'exit' {
 			break
 		}
-		if exit_pos := line.index('exit') {
-			oparen := line[(exit_pos + 4)..].trim_space()
-			if oparen.starts_with('(') {
-				if closing := oparen.index(')') {
-					rc := oparen[1..closing].parse_int(0, 8) or { panic(err) }
-					return int(rc)
-				}
-			}
-		}
 		r.line = line
 		if r.line == '\n' {
 			continue
@@ -468,6 +459,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			}
 			// Note: starting a line with 2 spaces escapes the println heuristic
 			if oline.starts_with('  ') {
+				is_statement = true
+			}
+			// The parentheses do not match
+			if r.line.count('(') != r.line.count(')') {
 				is_statement = true
 			}
 			if !is_statement && (!func_call || fntype == FnType.fn_type) && r.line != '' {

--- a/vlib/v/slow_tests/repl/error_eval_script.repl
+++ b/vlib/v/slow_tests/repl/error_eval_script.repl
@@ -1,0 +1,7 @@
+"text") exit(-1)
+===output===
+error: expression evaluated but not used
+    5 | import math
+    6 | 
+    7 | "text") exit(-1)
+      | ~~~~~~


### PR DESCRIPTION
This PR fix arbitrary script execute (fix #13981).

- Fix arbitrary script execute.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 df18047 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> "text") exit(-1)
error: expression evaluated but not used
    5 | import math
    6 |
    7 | "text") exit(-1)
      | ~~~~~~
>>>
```