### PR TITLE
ast, cgen: fix closure variable with optional reference params (fix #21827)

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -203,9 +203,12 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		} else {
 			mut s := t.type_to_str(param.typ.clear_flag(.shared_f))
 			if param.is_mut {
-				if (!param_sym.is_number() && param_sym.kind != .bool)
+				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
 					|| node.language != .v
-					|| (param.typ.is_ptr() && t.sym(param.typ).kind == .struct_) {
+					|| (param.typ.is_ptr() && t.sym(param.typ).kind == .struct_)) {
+					s = s[1..]
+				} else if param.typ.is_ptr() && t.sym(param.typ).kind == .struct_
+					&& !s.contains('[') {
 					s = t.type_to_str(param.typ.clear_flag(.shared_f).deref())
 				}
 			}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -203,10 +203,10 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		} else {
 			mut s := t.type_to_str(param.typ.clear_flag(.shared_f))
 			if param.is_mut {
-				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
+				if (!param_sym.is_number() && param_sym.kind != .bool)
 					|| node.language != .v
-					|| (param.typ.is_ptr() && t.sym(param.typ).kind == .struct_)) {
-					s = s[1..]
+					|| (param.typ.is_ptr() && t.sym(param.typ).kind == .struct_) {
+					s = t.type_to_str(param.typ.clear_flag(.shared_f).deref())
 				}
 			}
 			s = util.no_cur_mod(s, cur_mod)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2060,8 +2060,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				} else {
 					g.write('_option_ok(&(${styp}[]) { ')
 				}
-				if !expr_typ.is_ptr() && ret_typ.is_ptr() {
-					g.write('&/*ref*/')
+				if ret_typ.nr_muls() > expr_typ.nr_muls() {
+					g.write('&'.repeat(ret_typ.nr_muls() - expr_typ.nr_muls()))
 				}
 			}
 		} else {
@@ -4830,6 +4830,9 @@ fn (mut g Gen) ident(node ast.Ident) {
 				if !g.is_assign_lhs && is_auto_heap {
 					g.write('(*${name})')
 				} else {
+					if node.obj is ast.Var && node.obj.is_inherited {
+						g.write(closure_ctx + '->')
+					}
 					g.write(name)
 				}
 			} else {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1727,7 +1727,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	} else if !node.receiver_type.is_ptr() && left_type.is_ptr() && node.name != 'str'
 		&& node.from_embed_types.len == 0 {
 		if !left_type.has_flag(.shared_f) {
-			g.write('/*rec*/*')
+			g.write('*'.repeat(left_type.nr_muls()))
 		}
 	} else if !is_range_slice && node.from_embed_types.len == 0 && node.name != 'str' {
 		diff := left_type.nr_muls() - node.receiver_type.nr_muls()

--- a/vlib/v/tests/option_reference_params_test.v
+++ b/vlib/v/tests/option_reference_params_test.v
@@ -1,0 +1,28 @@
+struct Logger {}
+
+fn (l Logger) log(this string) {
+	println(this)
+}
+
+fn new_logger() &Logger {
+	return &Logger{}
+}
+
+fn do_log(mut maybe_logr ?&Logger, this string) {
+	if logr := maybe_logr {
+		logr.log(this)
+	}
+}
+
+fn bang(mut logr ?&Logger, this string) {
+	nested_log := fn [mut logr] (this string) {
+		do_log(mut logr, this)
+	}
+	nested_log(this)
+}
+
+fn test_option_reference_params() {
+	mut logr := new_logger()
+	bang(mut logr, 'bang!')
+	assert true
+}


### PR DESCRIPTION
This PR fix closure variable with optional reference params (fix #21827).

- Fix closure variable with optional reference params.
- Fix fmt of mut optional reference params.
- Add test.

```v
struct Logger {}

fn (l Logger) log(this string) {
	println(this)
}

fn new_logger() &Logger {
	return &Logger{}
}

fn do_log(mut maybe_logr ?&Logger, this string) {
	if logr := maybe_logr {
		logr.log(this)
	}
}

fn bang(mut logr ?&Logger, this string) {
	nested_log := fn [mut logr] (this string) {
		do_log(mut logr, this)
	}
	nested_log(this)
}

fn main() {
	mut logr := new_logger()
	bang(mut logr, 'bang!')
	assert true
}

PS D:\Test\v\tt1> v run .
bang!
```