### PR TITLE
vrepl: fix one-line if exprssion

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -53,6 +53,7 @@ const possible_statement_patterns = [
 	'import ',
 	'#include ',
 	'for ',
+	'if ',
 	'or ',
 	' as ',
 ]

--- a/vlib/v/slow_tests/repl/if_expr_oneline.repl
+++ b/vlib/v/slow_tests/repl/if_expr_oneline.repl
@@ -1,0 +1,4 @@
+a := 22
+if a > 10 { println('good') } else { println('bad') }
+===output===
+good


### PR DESCRIPTION
This PR fix one-line if exprssion.

- Fix one-line if exprssion.
- Add test.

before
```v
yuyi@yuyi-PC:~/v$ v
 ____    ____ 
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor, 
   \      /    |  save your code in a  main.v  file and execute:  v run main.v 
    \    /     |  V 0.4.6 547c056 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> a := 10
>>> if a > 5 { println('good') } else { println('bad') }
error: the final expression in `if` or `match`, must have a value of a non-void type
    7 | a := 10
    8 | println(if a > 5 {
    9 |  println('good') 
      |  ~~~~~~~~~~~~~~~
   10 | } else {
   11 |  println('bad')
>>> 
```
now
```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 547c056 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> a := 10
>>> if a > 5 { println('good') } else { println('bad') }
good
>>>
```