### PR TITLE
Add digital_rain.v to examples/gg

### DIFF
--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -137,6 +137,5 @@ fn random_rain_column(max_col int, max_height int) RainColumn {
 }
 
 fn random_rain_drop() u8 {
-	idx := rand.int_in_range(0, rain_drops.len) or { 0 }
-	return rain_drops[idx]
+	return rand.element(rain_drops) or { rain_drops.first() }
 }

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -1,3 +1,4 @@
+// Creates the digital rain effect from the movie, "The Matrix"
 module main
 
 import gg
@@ -24,7 +25,7 @@ mut:
 	col   int  // character based postion
 	len   int  // length of the rain column in characters
 	head  int  // y position of the rain column
-	drops []u8 // between 0 .. 1.0
+	drops []u8 // no retained graphics in gg, store entire column
 }
 
 fn main() {
@@ -35,7 +36,6 @@ fn main() {
 fn rain(mut app App) {
 	// calc rows and columns to use as matrix
 	app.screen_size = gg.screen_size()
-
 	// Create the drawing context
 	app.ctx = gg.new_context(
 		bg_color: gx.rgb(0, 0, 0)
@@ -50,10 +50,10 @@ fn rain(mut app App) {
 
 fn frame(mut app App) {
 	app.ctx.begin()
+	// figure out how many character rows and columns fit
 	if app.rows == 0 {
 		calc_sizes(mut app)
 	}
-
 	// gradually add rain columns
 	if app.rain_columns.len < app.cols / 4 * 3 {
 		app.rain_columns << random_rain_column(app.cols, app.rows)
@@ -64,7 +64,6 @@ fn frame(mut app App) {
 		draw_rain_column(rc, app)
 	}
 	app.ctx.end()
-
 	time.sleep(snooze)
 }
 
@@ -74,11 +73,12 @@ fn calc_sizes(mut app App) {
 		color: gx.green
 		mono: true
 	})
-
+	// figure out how big character it in pixesl
+	// Pad it or it looks too squashed
 	app.char_width, app.char_height = app.ctx.text_size('M')
 	app.char_width += 3
 	app.char_height += 1
-
+	// determine the size of the matrix in rows and columns
 	app.cols = app.screen_size.width / app.char_width
 	app.rows = app.screen_size.height / app.char_height
 }
@@ -91,9 +91,9 @@ fn update_rain_column(mut rc RainColumn, width int, height int) {
 }
 
 fn draw_rain_column(rc RainColumn, app App) {
-	end := rc.head - rc.len
-	x := rc.col * app.char_width
 	mut y := 0
+	x := rc.col * app.char_width
+	end := rc.head - rc.len
 	for i in 0 .. app.rows - 1 {
 		if i >= end && i < rc.head {
 			alpha := match i - end {

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -7,7 +7,7 @@ import rand
 import time
 
 const snooze = time.millisecond * 100
-const rain_drops = '0123456789!@#$%^&*()-=+[]{}|;:<>?~bdjpqtvz'
+const rain_drops = '0123456789!@#$%^&*()-=+[]{}|;:<>?~bdjpqtvz'.bytes()
 
 struct App {
 mut:

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -42,6 +42,9 @@ fn rain(mut app App) {
 		height: app.screen_size.height
 		user_data: app
 		window_title: 'Digital Rain'
+		init_fn: fn (mut app App) {
+			gg.toggle_fullscreen()
+		}
 		event_fn: fn (event &gg.Event, mut app App) {
 			if event.typ == .resized {
 				app.should_calc = true

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -46,8 +46,14 @@ fn rain(mut app App) {
 			gg.toggle_fullscreen()
 		}
 		event_fn: fn (event &gg.Event, mut app App) {
+			vprintln('event.typ: ${event.typ} | event.char_code: ${event.char_code}')
 			if event.typ == .resized {
 				app.should_calc = true
+				return
+			}
+			if event.typ == .char && event.char_code == `f` {
+				gg.toggle_fullscreen()
+				return
 			}
 		}
 		frame_fn: frame

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -128,6 +128,7 @@ fn random_rain_column(max_col int, max_height int) RainColumn {
 	mut rc := RainColumn{
 		col: rand.int_in_range(0, max_col) or { 0 }
 		len: rand.int_in_range(min_len, max_height / 4 * 3) or { min_len }
+		drops: []u8{cap: max_height}
 	}
 	for _ in 0 .. max_height {
 		rc.drops << random_rain_drop()

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -6,6 +6,7 @@ import gx
 import rand
 import time
 
+const font_size = 20
 const rain_drops = '0123456789!@#$%^&*()-=+[]{}|;:<>?~bdjpqtvz'.bytes()
 
 struct App {
@@ -96,11 +97,11 @@ fn vprintln(msg string) {
 fn calc_sizes(mut app App) {
 	app.screen_size = gg.window_size()
 	app.ctx.set_text_cfg(gx.TextCfg{
-		size: 20
+		size: font_size
 		color: gx.green
 		mono: true
 	})
-	// figure out how big character it in pixesl
+	// figure out how big character is in pixels
 	// Pad it or it looks too squashed
 	app.char_width, app.char_height = app.ctx.text_size('M')
 	app.char_width += 3
@@ -136,7 +137,7 @@ fn draw_rain_column(rc RainColumn, app App) {
 			}
 			at_head := i == rc.head - 1
 			cfg := gx.TextCfg{
-				size: 20
+				size: font_size
 				color: gg.Color{
 					r: if at_head { u8(255) } else { 0 }
 					g: 255

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -1,0 +1,141 @@
+module main
+
+import gg
+import gx
+import rand
+import time
+
+const snooze = time.millisecond * 100
+const rain_drops = '0123456789!@#$%^&*()-=+[]{}|;:<>?~bdjpqtvz'
+
+struct App {
+mut:
+	ctx          &gg.Context = unsafe { nil }
+	rows         int
+	cols         int
+	char_width   int
+	char_height  int
+	screen_size  gg.Size
+	rain_columns []RainColumn
+}
+
+struct RainColumn {
+mut:
+	col   int  // character based postion
+	len   int  // length of the rain column in characters
+	head  int  // y position of the rain column
+	drops []u8 // between 0 .. 1.0
+}
+
+fn main() {
+	mut app := &App{}
+	rain(mut app)
+}
+
+fn rain(mut app App) {
+	// calc rows and columns to use as matrix
+	app.screen_size = gg.screen_size()
+
+	// Create the drawing context
+	app.ctx = gg.new_context(
+		bg_color: gx.rgb(0, 0, 0)
+		width: app.screen_size.width
+		height: app.screen_size.height
+		user_data: app
+		window_title: 'Digital Rain'
+		frame_fn: frame
+	)
+	app.ctx.run()
+}
+
+fn frame(mut app App) {
+	app.ctx.begin()
+	if app.rows == 0 {
+		calc_sizes(mut app)
+	}
+
+	// gradually add rain columns
+	if app.rain_columns.len < app.cols / 4 * 3 {
+		app.rain_columns << random_rain_column(app.cols, app.rows)
+	}
+	// update and print all rain columns
+	for mut rc in app.rain_columns {
+		update_rain_column(mut rc, app.cols, app.rows)
+		draw_rain_column(rc, app)
+	}
+	app.ctx.end()
+
+	time.sleep(snooze)
+}
+
+fn calc_sizes(mut app App) {
+	app.ctx.set_text_cfg(gx.TextCfg{
+		size: 20
+		color: gx.green
+		mono: true
+	})
+
+	app.char_width, app.char_height = app.ctx.text_size('M')
+	app.char_width += 3
+	app.char_height += 1
+
+	app.cols = app.screen_size.width / app.char_width
+	app.rows = app.screen_size.height / app.char_height
+}
+
+fn update_rain_column(mut rc RainColumn, width int, height int) {
+	rc.head += 1
+	if rc.head > height + rc.len {
+		rc = random_rain_column(width, height)
+	}
+}
+
+fn draw_rain_column(rc RainColumn, app App) {
+	end := rc.head - rc.len
+	x := rc.col * app.char_width
+	mut y := 0
+	for i in 0 .. app.rows - 1 {
+		if i >= end && i < rc.head {
+			alpha := match i - end {
+				0 { u8(75) }
+				1 { u8(100) }
+				2 { u8(125) }
+				3 { u8(150) }
+				4 { u8(175) }
+				5 { u8(200) }
+				6 { u8(225) }
+				else { u8(255) }
+			}
+			at_head := i == rc.head - 1
+			cfg := gx.TextCfg{
+				size: 20
+				color: gg.Color{
+					r: if at_head { u8(255) } else { 0 }
+					g: 255
+					b: if at_head { u8(255) } else { 0 }
+					a: alpha
+				}
+				mono: true
+			}
+			app.ctx.draw_text(x, y, rc.drops[i].ascii_str(), cfg)
+		}
+		y += app.char_height
+	}
+}
+
+fn random_rain_column(max_col int, max_height int) RainColumn {
+	min_len := 6
+	mut rc := RainColumn{
+		col: rand.int_in_range(0, max_col) or { 0 }
+		len: rand.int_in_range(min_len, max_height / 4 * 3) or { min_len }
+	}
+	for _ in 0 .. max_height {
+		rc.drops << random_rain_drop()
+	}
+	return rc
+}
+
+fn random_rain_drop() u8 {
+	idx := rand.int_in_range(0, rain_drops.len) or { 0 }
+	return rain_drops[idx]
+}

--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -6,7 +6,6 @@ import gx
 import rand
 import time
 
-const snooze = time.millisecond * 100
 const rain_drops = '0123456789!@#$%^&*()-=+[]{}|;:<>?~bdjpqtvz'.bytes()
 
 struct App {
@@ -19,6 +18,7 @@ mut:
 	screen_size  gg.Size
 	should_calc  bool = true
 	rain_columns []RainColumn
+	delay        time.Duration = time.millisecond * 100
 }
 
 struct RainColumn {
@@ -55,6 +55,13 @@ fn rain(mut app App) {
 				gg.toggle_fullscreen()
 				return
 			}
+			if event.typ == .key_up && event.key_code == .up {
+				app.delay = app.delay + 50 * time.millisecond
+			}
+			if event.typ == .key_down && event.key_code == .down {
+				new_delay := app.delay - 50 * time.millisecond
+				app.delay = if new_delay > 0 { new_delay } else { 0 }
+			}
 		}
 		frame_fn: frame
 	)
@@ -77,8 +84,8 @@ fn frame(mut app App) {
 		draw_rain_column(rc, app)
 	}
 	app.ctx.end()
-	vprintln('frame: ${app.ctx.frame} | app.cols: ${app.cols} | app.rows: ${app.rows} | app.rain_columns.len: ${app.rain_columns.len}')
-	time.sleep(snooze)
+	vprintln('frame: ${app.ctx.frame} | app.cols: ${app.cols} | app.rows: ${app.rows} | app.rain_columns.len: ${app.rain_columns.len} | app.delay: ${app.delay}')
+	time.sleep(app.delay)
 }
 
 @[if verbose ?]


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This pull request implements the digital rain effect from the movie, "The Matrix", using `gg`. It is not feature complete, but decided getting some feedback was worth starting a pull request. Features needed:
- Window resizing logic
- Start the program in full screen. `gg.toggle_fullscreen()` didn't work for me. Maybe I'm using it wrong
- Keyboard shortcuts to change the rain speed
- Keyboard shortcut to toggle fullscreen
- Other ideas?

I'm OK with merging as is, but I'll likely add these other features in a few days.