### PR TITLE
flag: add `flag.to_struct[T]()!` and `flag.to_doc[T]()!` + tests

### DIFF
--- a/examples/flag/animated_help_text.v
+++ b/examples/flag/animated_help_text.v
@@ -1,0 +1,93 @@
+import term.ui as tui
+import flag
+
+struct DocTest {
+	show_version bool   @[short: v; xdoc: 'Show version and exit']
+	debug_level  int    @[long: debug; short: d; xdoc: 'Debug level']
+	level        f32    @[only: l; xdoc: 'Do not show this']
+	example      string
+	square       bool
+	multi        int    @[only: m; repeats]
+	wroom        []int  @[short: w]
+	the_limit    string
+}
+
+struct App {
+mut:
+	tui       &tui.Context = unsafe { nil }
+	frame     int
+	square    string = '.____.\n|    |\n|    |\n|____|'
+	pad       int    = 1
+	direction int    = 1
+}
+
+fn event(e &tui.Event, mut app App) {
+	match e.typ {
+		.mouse_down {}
+		.mouse_drag {}
+		.mouse_up {}
+		.key_down {
+			if e.code == .c {
+			} else if e.code == .escape {
+				exit(0)
+			}
+		}
+		else {}
+	}
+}
+
+fn frame(mut app App) {
+	app.tui.clear()
+	app.frame++
+
+	if app.frame % 4 == 0 {
+		app.pad += app.direction
+		app.square = '${' '.repeat(app.pad)}.____.\n${' '.repeat(app.pad)}|    |\n${' '.repeat(app.pad)}|    |\n${' '.repeat(app.pad)}|____|'
+	}
+	if app.frame % 100 == 0 {
+		if app.direction > 0 {
+			app.direction = -1
+		} else {
+			app.direction = 1
+		}
+	}
+
+	help_text := flag.to_doc[DocTest](
+		version: '1.0'
+		description: 'Hello! This should show an *animated* example application description.
+We are at frame ${app.frame}.
+Press ESCAPE or Ctrl+C to exit'
+		footer: '
+Press ESCAPE or Ctrl+C to exit'
+		fields: {
+			'level':                                    'Level of lorem ipsum\nand more\nmany many many more.\nNotice how user newlines/format is kept since\ninput lines are all less or within\nthe default layout.description_padding\nand max width'
+			'example':                                  'Looong example text without newlines or anything else and lorem ipsum and more and many many many more. Should be auto fitted'
+			'the_limit':                                'Looonglimittextwithoutnewlinesoranythingelseandlorem ipsumandmoreandmanymanymanymore ffffffffffffffffffffffffffffffff f'
+			'multi':                                    'This flag can be repeated'
+			'-e, --extra':                              'Secret flag that does not exist on the struct, but we want documented (in same format as the others)'
+			'-q, --quiet-and-quite-long-flag <string>': 'Mega long description and secret flag that does not exist on the struct, but we want documented. Also the flag has custom newlines\nand the flag line itself is super long'
+			'square':                                   '${app.square}'
+		}
+	) or { '' }
+
+	app.tui.draw_text(0, 0, '${help_text}')
+	app.tui.reset()
+
+	app.tui.flush()
+}
+
+type EventFn = fn (&tui.Event, voidptr)
+
+type FrameFn = fn (voidptr)
+
+fn main() {
+	mut app := &App{}
+	app.tui = tui.init(
+		user_data: app
+		event_fn: EventFn(event)
+		frame_fn: FrameFn(frame)
+		hide_cursor: true
+		frame_rate: 60
+	)
+	app.tui.run()!
+}

--- a/examples/flag/animated_help_text.v
+++ b/examples/flag/animated_help_text.v
@@ -62,7 +62,6 @@ Press ESCAPE or Ctrl+C to exit'
 		fields: {
 			'level':                                    'Level of lorem ipsum\nand more\nmany many many more.\nNotice how user newlines/format is kept since\ninput lines are all less or within\nthe default layout.description_padding\nand max width'
 			'example':                                  'Looong example text without newlines or anything else and lorem ipsum and more and many many many more. Should be auto fitted'
-			'the_limit':                                'Looonglimittextwithoutnewlinesoranythingelseandlorem ipsumandmoreandmanymanymanymore ffffffffffffffffffffffffffffffff f'
 			'multi':                                    'This flag can be repeated'
 			'-e, --extra':                              'Secret flag that does not exist on the struct, but we want documented (in same format as the others)'
 			'-q, --quiet-and-quite-long-flag <string>': 'Mega long description and secret flag that does not exist on the struct, but we want documented. Also the flag has custom newlines\nand the flag line itself is super long'

--- a/examples/flag/flag_layout_editor.v
+++ b/examples/flag/flag_layout_editor.v
@@ -1,0 +1,221 @@
+import term.ui as tui
+import flags
+
+struct DocTest {
+	show_version bool   @[short: v; xdoc: 'Show version and exit']
+	debug_level  int    @[long: debug; short: d; xdoc: 'Debug level']
+	level        f32    @[only: l; xdoc: 'Do not show this']
+	example      string
+	square       bool
+	multi        int    @[only: m; repeats]
+	wroom        []int  @[short: w]
+	the_limit    string
+}
+
+const field_docs = {
+	'level':                                    'Level of lorem ipsum\nand more\nmany many many more.\nNotice how user newlines/format is kept since\ninput lines are all less or within\nthe default layout.description_padding\nand max width'
+	'example':                                  'Looong example text without newlines or anything else and lorem ipsum and more and many many many more. Should be auto fitted'
+	'the_limit':                                'Looongbobbytextwithoutnewlinesoranythingelseandlorem ipsumandmoreandmanymanymanymore ffffffffffffffffffffffffffffffff f'
+	'multi':                                    'This flag can be repeated'
+	'-e, --extra':                              'Secret flag that does not exist on the struct, but we want documented (in same format as the others)'
+	'-q, --quiet-and-quite-long-flag <string>': 'Mega long description and secret flag that does not exist on the struct, but we want documented. Also the flag has custom newlines\nand the flag line itself is super long'
+}
+
+struct App {
+mut:
+	tui     &tui.Context = unsafe { nil }
+	layout  flags.DocLayout
+	options flags.DocOptions
+	edit    Edit
+}
+
+enum Edit {
+	// DocLayout fields
+	description_padding
+	description_width
+	flag_indent
+	// DocOptions.show flags
+	flags
+	flag_type
+	flag_hint
+	description
+	flags_header
+	footer
+	name_and_version
+}
+
+pub fn (e Edit) next() Edit {
+	return match e {
+		.name_and_version {
+			.description_padding
+		}
+		.description_padding {
+			.description_width
+		}
+		.description_width {
+			.flag_indent
+		}
+		.flag_indent {
+			.flags
+		}
+		.flags {
+			.flag_type
+		}
+		.flag_type {
+			.flag_hint
+		}
+		.flag_hint {
+			.description
+		}
+		.description {
+			.flags_header
+		}
+		.flags_header {
+			.footer
+		}
+		.footer {
+			.name_and_version
+		}
+	}
+}
+
+fn event(e &tui.Event, mut app App) {
+	mut incr_decr := 0
+	match e.typ {
+		.mouse_down {
+			app.edit = app.edit.next()
+		}
+		.mouse_drag {}
+		.mouse_up {}
+		.key_down {
+			match e.code {
+				.left {
+					incr_decr = -1
+				}
+				.right {
+					incr_decr = 1
+				}
+				.space {
+					app.edit = app.edit.next()
+				}
+				.escape {
+					exit(0)
+				}
+				else {}
+			}
+		}
+		else {}
+	}
+
+	if incr_decr != 0 {
+		match app.edit {
+			.flag_indent {
+				app.layout.flag_indent += incr_decr
+			}
+			.description_padding {
+				app.layout.description_padding += incr_decr
+			}
+			.description_width {
+				app.layout.description_width += incr_decr
+			}
+			.name_and_version {
+				app.options.show.toggle(.name_and_version)
+			}
+			.flags {
+				app.options.show.toggle(.flags)
+			}
+			.flag_type {
+				app.options.show.toggle(.flag_type)
+			}
+			.flag_hint {
+				app.options.show.toggle(.flag_hint)
+			}
+			.description {
+				app.options.show.toggle(.description)
+			}
+			.flags_header {
+				app.options.show.toggle(.flags_header)
+			}
+			.footer {
+				app.options.show.toggle(.footer)
+			}
+		}
+	}
+}
+
+fn frame(mut app App) {
+	app.tui.clear()
+
+	mut value := match app.edit {
+		.flag_indent {
+			'${app.layout.flag_indent}'
+		}
+		.description_padding {
+			'${app.layout.description_padding}'
+		}
+		.description_width {
+			'${app.layout.description_width}'
+		}
+		.name_and_version {
+			if app.options.show.has(.name_and_version) { 'on' } else { 'off' }
+		}
+		.flags {
+			if app.options.show.has(.flags) { 'on' } else { 'off' }
+		}
+		.flag_type {
+			if app.options.show.has(.flag_type) { 'on' } else { 'off' }
+		}
+		.flag_hint {
+			if app.options.show.has(.flag_hint) { 'on' } else { 'off' }
+		}
+		.description {
+			if app.options.show.has(.description) { 'on' } else { 'off' }
+		}
+		.flags_header {
+			if app.options.show.has(.flags_header) { 'on' } else { 'off' }
+		}
+		.footer {
+			if app.options.show.has(.footer) { 'on' } else { 'off' }
+		}
+	}
+
+	app.tui.draw_text(0, 0, 'Click left-mouse button or use space to edit the next property.
+Use keyboard arrow keys right and left to adjust the value of the property
+Editing property: ${app.edit}, value: ${value}')
+
+	help_text := flags.to_doc[DocTest](
+		version: '1.0'
+		description: 'Simple DocLayout editor.
+Press ESCAPE or Ctrl+C to exit and print layout code'
+		footer: '
+Press ESCAPE or Ctrl+C to exit and print layout code'
+		fields: unsafe { field_docs }
+		layout: app.layout
+		options: app.options
+	) or { '' }
+
+	app.tui.draw_text(0, 5, '${help_text}')
+	app.tui.reset()
+
+	app.tui.flush()
+}
+
+type EventFn = fn (&tui.Event, voidptr)
+
+type FrameFn = fn (voidptr)
+
+fn main() {
+	mut app := &App{}
+	at_exit(fn [app] () {
+		println('${app.layout}\n')
+		println('${app.options}')
+	}) or {}
+	app.tui = tui.init(
+		user_data: app
+		event_fn: EventFn(event)
+		frame_fn: FrameFn(frame)
+		hide_cursor: true
+		frame_rate: 60
+	)
+	app.tui.run()!
+}

--- a/examples/flag/flag_layout_editor.v
+++ b/examples/flag/flag_layout_editor.v
@@ -1,6 +1,8 @@
 import term.ui as tui
 import flag
 
+@[name: 'flag_layout_editor']
+@[version: '1.0']
 struct DocTest {
 	show_version bool   @[short: v; xdoc: 'Show version and exit']
 	debug_level  int    @[long: debug; short: d; xdoc: 'Debug level']
@@ -35,20 +37,18 @@ enum Edit {
 	description_width
 	flag_indent
 	// DocOptions.show flags
+	name
+	version
 	flags
 	flag_type
 	flag_hint
 	description
 	flags_header
 	footer
-	name_and_version
 }
 
 pub fn (e Edit) next() Edit {
 	return match e {
-		.name_and_version {
-			.description_padding
-		}
 		.description_padding {
 			.description_width
 		}
@@ -56,6 +56,12 @@ pub fn (e Edit) next() Edit {
 			.flag_indent
 		}
 		.flag_indent {
+			.name
+		}
+		.name {
+			.version
+		}
+		.version {
 			.flags
 		}
 		.flags {
@@ -74,7 +80,7 @@ pub fn (e Edit) next() Edit {
 			.footer
 		}
 		.footer {
-			.name_and_version
+			.description_padding
 		}
 	}
 }
@@ -118,8 +124,11 @@ fn event(e &tui.Event, mut app App) {
 			.description_width {
 				app.layout.description_width += incr_decr
 			}
-			.name_and_version {
-				app.options.show.toggle(.name_and_version)
+			.name {
+				app.options.show.toggle(.name)
+			}
+			.version {
+				app.options.show.toggle(.version)
 			}
 			.flags {
 				app.options.show.toggle(.flags)
@@ -156,8 +165,11 @@ fn frame(mut app App) {
 		.description_width {
 			'${app.layout.description_width}'
 		}
-		.name_and_version {
-			if app.options.show.has(.name_and_version) { 'on' } else { 'off' }
+		.name {
+			if app.options.show.has(.name) { 'on' } else { 'off' }
+		}
+		.version {
+			if app.options.show.has(.version) { 'on' } else { 'off' }
 		}
 		.flags {
 			if app.options.show.has(.flags) { 'on' } else { 'off' }
@@ -184,7 +196,6 @@ Use keyboard arrow keys right and left to adjust the value of the property
 Editing property: ${app.edit}, value: ${value}')
 
 	help_text := flag.to_doc[DocTest](
-		version: '1.0'
 		description: 'Simple DocLayout editor.
 Press ESCAPE or Ctrl+C to exit and print layout code'
 		footer: '

--- a/examples/flag/flag_layout_editor.v
+++ b/examples/flag/flag_layout_editor.v
@@ -1,5 +1,5 @@
 import term.ui as tui
-import flags
+import flag
 
 struct DocTest {
 	show_version bool   @[short: v; xdoc: 'Show version and exit']
@@ -24,8 +24,8 @@ const field_docs = {
 struct App {
 mut:
 	tui     &tui.Context = unsafe { nil }
-	layout  flags.DocLayout
-	options flags.DocOptions
+	layout  flag.DocLayout
+	options flag.DocOptions
 	edit    Edit
 }
 
@@ -183,7 +183,7 @@ fn frame(mut app App) {
 Use keyboard arrow keys right and left to adjust the value of the property
 Editing property: ${app.edit}, value: ${value}')
 
-	help_text := flags.to_doc[DocTest](
+	help_text := flag.to_doc[DocTest](
 		version: '1.0'
 		description: 'Simple DocLayout editor.
 Press ESCAPE or Ctrl+C to exit and print layout code'

--- a/vlib/flag/README.md
+++ b/vlib/flag/README.md
@@ -3,7 +3,8 @@
 A V module to parse, map and document different command line option flag styles
 (as typically found in in `os.args`).
 
-`flag.to_struct[T](os.args)!` can map flags into user defined V `struct`s via compile time reflection.
+`flag.to_struct[T](os.args)!` can map flags into user defined V `struct`s via
+compile time reflection.
 
 The module supports several flag "styles" like:
 
@@ -116,8 +117,8 @@ See also `examples/flag/flag_layout_editor.v` for a WYSIWYG editor.
 # Sub commands
 
 Due to the nature of how `to_struct[T]` works it is not suited for applications that use
-sub commands at first glance. `git` and `v` are examples of command line applications that uses sub commands
-e.g.: `v help xyz`, where `help` is the sub command.
+sub commands at first glance. `git` and `v` are examples of command line applications
+that uses sub commands e.g.: `v help xyz`, where `help` is the sub command.
 
 To support this "flag" style in your application and still use `to_struct[T]()` you can
 simply parse out your sub command prior to mapping any flags.

--- a/vlib/flag/README.md
+++ b/vlib/flag/README.md
@@ -39,8 +39,8 @@ import os
 
 @[xdoc: 'My application that does X']
 @[footer: 'A footer']
-@[name: 'app']
 @[version: '1.2.3']
+@[name: 'app']
 struct Config {
 	show_version bool   @[short: v; xdoc: 'Show version and exit']
 	debug_level  int    @[long: debug; short: d; xdoc: 'Debug level']

--- a/vlib/flag/README.md
+++ b/vlib/flag/README.md
@@ -1,19 +1,174 @@
-## Description
+# Description
 
-The `flag` module is a command line option parser.
+A V module to parse, map and document different command line option flag styles
+(as typically found in in `os.args`).
+
+`flag.to_struct[T](os.args)!` can map flags into user defined V `struct`s via compile time reflection.
+
+The module supports several flag "styles" like:
+
+* POSIX short style (`-v`)
+* POSIX short style repeats (`-vvvvv`)
+* GNU long style (`--long` / `--long=value`
+* Go `flag` module style (`-flag`, `-flag-name` and GNU long)
+* V style (`-v`,`-version`)
+
 Its main features are:
 
 - simplicity of usage.
 - parses flags like `-f` or '--flag' or '--stuff=things' or '--things stuff'.
 - handles bool, int, float and string args.
-- can print usage information listing all the declared flags.
-- handles unknown arguments as error.
+- can flexibly generate usage information, listing all the declared flags.
 
 See also the `cli` module, for a more complex command line option parser,
 that supports declaring multiple subcommands each having a separate set of
 options.
 
-## Examples
+# Example
+
+Put the following V code in a file `flags_example.v` and run it with:
+
+```bash
+v run flags_example.v -h
+```
+
+```v
+import flag
+import os
+
+struct Config {
+	show_version bool   @[short: v; xdoc: 'Show version and exit']
+	debug_level  int    @[long: debug; short: d; xdoc: 'Debug level']
+	level        f32    @[only: l; xdoc: 'This doc text is overwritten']
+	example      string
+	square       bool
+	show_help    bool   @[long: help; short: h]
+	multi        int    @[only: m; repeats]
+	wroom        []int  @[short: w]
+	ignore_me    string @[ignore]
+}
+
+fn main() {
+	// Map POSIX and GNU style flags found in `os.args` to fields on struct `T`
+	config, no_matches := flag.to_struct[Config](os.args, skip: 1)!
+
+	if no_matches.len > 0 {
+		println('The following flags could not be mapped to any fields on the struct:')
+		for index in no_matches {
+			println('${index}: ${os.args[no_matches[index]]}')
+		}
+	}
+
+	if config.show_help {
+		// Generate and layout (a configuable) documentation for the flags
+		documentation := flag.to_doc[Config](
+			version: '1.0'
+			description: 'My application'
+			fields: {
+				'level':                                    'This is a doc string of the field `level` on struct `Config`'
+				'example':                                  'This is another doc string'
+				'multi':                                    'This flag can be repeated'
+				'-e, --extra':                              'Extra flag that does not exist on the struct, but we want documented (in same format as the others)'
+				'-q, --quiet-and-quite-long-flag <string>': 'This is a flag with a long name'
+				'square':                                   '.____.\n|    |\n|    |\n|____|'
+			}
+		)!
+		println(documentation)
+		exit(0)
+	}
+
+	dump(config)
+}
+```
+
+# Usage
+
+The 2 most useful functions in the module is `to_struct[T]()` and `to_doc[T]()`.
+
+## `to_struct[T](...)`
+
+`to_struct[T](input []string, config ParseConfig) !(T, []int)` maps flags found in `input`
+to *matching* fields on `T`. The matching is determined via hints that the user can
+specify with special field attributes. The matching is done in the following way:
+
+1. Match the flag name with the field name directly (`my_field` matches e.g. `--my-field`).
+  * Underscores (`_`) in long field names are converted to `-`.
+  * Fields with the attribute `@[ignore]` is ignored.
+  * Fields with the attribute `@[only: n]` will only match if the short flag `-n` is provided.
+  * Fields with the attribute `@[long: my_name]` will match the flag `--my-name`.
+2. Match a field's short identifier, if specified.
+  * Short identifiers are specified using `@[short: n]`
+  * To map a field *solely* to a short flag use `@[only: n]`
+  * Short flags that repeats is mapped to fields via the attribute `@[repeats]`
+
+## `to_doc[T](...)`
+
+`pub fn to_doc[T](dc DocConfig) !string` returns an auto-generated `string` with flag
+documentation. The documentation can be tweaked in several ways to suit any special
+user needs via the `DocConfig` configuration struct.
+
+See also `examples/flag/flag_layout_editor.v` for a WYSIWYG editor.
+
+# Sub commands
+
+Due to the nature of how `to_struct[T]` works it is not suited for applications that use
+sub commands at first glance. `git` and `v` are examples of command line applications that uses sub commands
+e.g.: `v help xyz`, where `help` is the sub command.
+
+To support this "flag" style in your application and still use `to_struct[T]()` you can
+simply parse out your sub command prior to mapping any flags.
+
+Try the following example.
+
+Put the following V code in a file `subcmd.v` and run it with:
+
+```bash
+v run subcmd.v -h && v run subcmd.v sub -h && v run subcmd.v sub --do-stuff # observe the different outputs.
+```
+
+```v
+import flag
+import os
+
+struct Config {
+	show_help bool @[long: help; short: h; xdoc: 'Show version and exit']
+}
+
+struct ConfigSub {
+	show_help bool @[long: help; short: h; xdoc: 'Show version and exit']
+	do_stuff  bool @[xdoc: 'Do stuff']
+}
+
+fn main() {
+	// Handle sub command `sub` if provided
+	if os.args.len > 1 && !os.args[1].starts_with('-') {
+		if os.args[1] == 'sub' {
+			config_for_sub, _ := flag.to_struct[ConfigSub](os.args, skip: 2)! // NOTE the `skip: 2`
+			if config_for_sub.do_stuff {
+				println('Working...')
+				exit(0)
+			}
+			if config_for_sub.show_help {
+				println(flag.to_doc[ConfigSub](
+					description: 'My sub command'
+				)!)
+				exit(0)
+			}
+		}
+	}
+
+	config, _ := flag.to_struct[Config](os.args, skip: 1)!
+
+	if config.show_help {
+		println(flag.to_doc[Config](
+			description: 'My application'
+		)!)
+		exit(0)
+	}
+}
+```
+
+# Other examples
 
 ```v
 module main

--- a/vlib/flag/README.md
+++ b/vlib/flag/README.md
@@ -174,6 +174,8 @@ fn main() {
 
 # Other examples
 
+If you want to parse flags in a more function-based manner you can use the `FlagParser` instead.
+
 ```v
 module main
 

--- a/vlib/flag/README.md
+++ b/vlib/flag/README.md
@@ -36,6 +36,10 @@ v run flags_example.v -h
 import flag
 import os
 
+@[xdoc: 'My application that does X']
+@[footer: 'A footer']
+@[name: 'app']
+@[version: '1.2.3']
 struct Config {
 	show_version bool   @[short: v; xdoc: 'Show version and exit']
 	debug_level  int    @[long: debug; short: d; xdoc: 'Debug level']
@@ -62,8 +66,7 @@ fn main() {
 	if config.show_help {
 		// Generate and layout (a configuable) documentation for the flags
 		documentation := flag.to_doc[Config](
-			version: '1.0'
-			description: 'My application'
+			version: '1.0' // NOTE: this overrides the `@[version: '1.2.3']` struct attribute
 			fields: {
 				'level':                                    'This is a doc string of the field `level` on struct `Config`'
 				'example':                                  'This is another doc string'
@@ -105,7 +108,8 @@ specify with special field attributes. The matching is done in the following way
 
 `pub fn to_doc[T](dc DocConfig) !string` returns an auto-generated `string` with flag
 documentation. The documentation can be tweaked in several ways to suit any special
-user needs via the `DocConfig` configuration struct.
+user needs via the `DocConfig` configuration struct or directly via attributes
+on the struct itself and it's fields.
 
 See also `examples/flag/flag_layout_editor.v` for a WYSIWYG editor.
 

--- a/vlib/flag/cmd_exe_style_flags_test.v
+++ b/vlib/flag/cmd_exe_style_flags_test.v
@@ -1,0 +1,65 @@
+// Test .short (POSIX) parse style
+import flag
+
+const cmd_exe_args = ['/a', 'C:\\', '/B', 'xyz', '/a', 'D:\\', '/d', '/e', '/c', '"xyz"']
+
+const cmd_exe_mixed_args = ['/a', 'C:\\', '/Big', 'hij', '/a', 'D:\\', '/Dev', '/e', '/c', '"xyz"']
+
+const cmd_exe_args_with_tail = ['/a', 'C:\\', '/b', '/B', 'xyz', '/a', 'D:\\', '/d', '/e', '/c',
+	'"xyz"', '"/path/to/x"', '"/path/to/y"', '"/path/to/z"']
+
+struct Config {
+	big_b      string = 'def'   @[long: Big; short: B]
+	small_b    bool     @[short: b]
+	a_device   []string @[short: a]
+	paths      []string @[tail]
+	not_mapped string = 'not changed'
+	e          bool
+	b          bool     @[long: Dev; only: d]
+	u          string   @[short: c]
+}
+
+fn test_cmd_exe() {
+	config, _ := flag.to_struct[Config](cmd_exe_args, style: .cmd_exe, delimiter: '/')!
+	assert config.big_b == 'xyz'
+	assert config.small_b == false
+	assert config.a_device.len == 2
+	assert config.a_device[0] == 'C:\\'
+	assert config.a_device[1] == 'D:\\'
+	assert config.paths.len == 0
+	assert config.not_mapped == 'not changed'
+	assert config.e
+	assert config.b
+	assert config.u == '"xyz"'
+}
+
+fn test_cmd_exe_mixed() {
+	config, _ := flag.to_struct[Config](cmd_exe_mixed_args, style: .cmd_exe, delimiter: '/')!
+	assert config.big_b == 'hij'
+	assert config.small_b == false
+	assert config.a_device.len == 2
+	assert config.a_device[0] == 'C:\\'
+	assert config.a_device[1] == 'D:\\'
+	assert config.paths.len == 0
+	assert config.not_mapped == 'not changed'
+	assert config.e
+	assert config.b
+	assert config.u == '"xyz"'
+}
+
+fn test_cmd_exe_with_tail() {
+	config, _ := flag.to_struct[Config](cmd_exe_args_with_tail, style: .cmd_exe, delimiter: '/')!
+	assert config.big_b == 'xyz'
+	assert config.small_b
+	assert config.a_device.len == 2
+	assert config.a_device[0] == 'C:\\'
+	assert config.a_device[1] == 'D:\\'
+	assert config.paths.len == 3
+	assert config.paths[0] == '"/path/to/x"'
+	assert config.paths[1] == '"/path/to/y"'
+	assert config.paths[2] == '"/path/to/z"'
+	assert config.not_mapped == 'not changed'
+	assert config.e
+	assert config.b
+	assert config.u == '"xyz"'
+}

--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -1,0 +1,1473 @@
+module flag
+
+import os
+
+struct FlagData {
+	raw        string  @[required]
+	field_name string  @[required]
+	delimiter  string
+	name       string
+	arg        ?string
+	pos        int
+	repeats    int = 1
+}
+
+struct FlagContext {
+	raw       string @[required] // raw arg array entry. E.g.: `--id=val`
+	delimiter string // usually `'-'`
+	name      string // either struct field name or what is defined in `@[long: <name>]`
+	next      string // peek at what is the next flag/arg
+	pos       int    // position in arg array
+}
+
+pub enum Style {
+	short // Posix short only, allows multiple shorts -def is `-d -e -f` and "sticky" arguments e.g.: `-ofoo` = `-o foo`
+	long // GNU style long option *only*. E.g.: `--name` or `--name=value`
+	short_long // extends `posix` style shorts with GNU style long options: `--flag` or `--name=value`
+	v // V style flags as found in flags for the `v` compiler. Single flag denote `-` followed by string identifier e.g.: `-verbose`, `-name value`, `-v`, `-n value` or `-d ident=value`
+	go_flag // GO `flag` module style. Single flag denote `-` followed by string identifier e.g.: `-verbose`, `-name value`, `-v` or `-n value` and both long `--name value` and GNU long `--name=value`
+	cmd_exe // `cmd.exe` style flags. Single flag denote `/` followed by lower- or upper-case character
+}
+
+struct StructInfo {
+	name   string
+	fields map[string]StructField
+}
+
+@[flag]
+pub enum FieldHints {
+	is_bool
+	is_array
+	is_ignore
+	is_int_type
+	has_tail
+	short_only
+	can_repeat
+}
+
+// StructField is a representation of the data collected via reflection on the input `T` struct.
+// `match_name` is resolved upon reflection and represents the longest flag name value the user wants
+// to be mapped to this field. If users has indicated that they want to match a field as a short/abbrevation flag
+// `short` is accounted instead of `match_name`
+struct StructField {
+	name       string // name of the field on the struct, *not used* for resolving mappings, use `match_name`
+	match_name string // match_name is either `name` or the value of `@[long: x]` or `@[only: x]`
+	short      string // single char short alias of field, sat via `@[short: x]` or `@[only: x]`
+	hints      FieldHints = FieldHints.zero()
+	attrs      map[string]string // collection of `@[x: y]` sat on the field, read via reflection
+	type_name  string
+	doc        string // documentation string sat via `@[xdoc: x y z]`
+}
+
+fn (sf StructField) shortest_match_name() ?string {
+	mut name := sf.short // if `short` is sat it takes precedence over `match_name`
+	if name == '' && sf.match_name.len == 1 {
+		name = sf.match_name
+	}
+	if name != '' {
+		return name
+	}
+	return none
+}
+
+@[params]
+pub struct ParseConfig {
+pub:
+	delimiter string = '-' // delimiter used for flags
+	style     Style  = .short_long // expected flag style
+	stop      ?string // single, usually '--', string that stops parsing flags/options
+	skip      u16     // skip this amount in the input argument array, usually `1` for skipping executable or subcmd entry
+}
+
+@[params]
+pub struct DocConfig {
+pub:
+	delimiter string = '-' // delimiter used for flags
+	style     Style  = .short_long // expected flag style
+pub mut:
+	name        string = os.file_name(os.executable()) // application name
+	version     string            // application version
+	description string            // application description
+	footer      string            // application description footer written after auto-generated flags list/ field descriptions
+	layout      DocLayout         // documentation layout
+	options     DocOptions        // documentation options
+	fields      map[string]string // doc strings for each field (overwrites @[doc: xxx] attributes)
+}
+
+@[flag]
+pub enum Show {
+	flags
+	flag_type
+	flag_hint
+	description
+	flags_header
+	footer
+	name_and_version
+}
+
+pub struct DocLayout {
+pub mut:
+	description_padding int = 28
+	description_width   int = 50
+	flag_indent         int = 2
+}
+
+pub struct DocOptions {
+pub mut:
+	flag_header string = '\nOptions:'
+	show        Show   = ~Show.zero()
+}
+
+pub fn (dl DocLayout) max_width() int {
+	return dl.flag_indent + dl.description_padding + dl.description_width
+}
+
+pub struct FlagMapper {
+pub:
+	config ParseConfig @[required]
+	input  []string    @[required]
+mut:
+	si                   StructInfo
+	handled_pos          []int // tracks handled positions in the `input` args array. NOTE: can contain duplicates
+	field_map_flag       map[string]FlagData
+	array_field_map_flag map[string][]FlagData
+	no_match             []int // indicies of unmatched flags in the `input` array
+}
+
+@[if trace_flag_mapper ?]
+fn trace_println(str string) {
+	println(str)
+}
+
+@[if trace_flag_mapper ? && debug]
+fn trace_dbg_println(str string) {
+	println(str)
+}
+
+// dbg_match returns a debug string with data about the mapping of a flag to a field
+fn (fm FlagMapper) dbg_match(flag_ctx FlagContext, field StructField, arg string, field_extra string) string {
+	struct_name := fm.si.name
+	extra := if field_extra != '' { '/' + field_extra } else { '' }
+	return '${struct_name}.${field.name}/${field.short}${extra} in ${flag_ctx.raw}/${flag_ctx.name} = `${arg}`'
+}
+
+fn (fm FlagMapper) get_struct_info[T]() !StructInfo {
+	mut struct_fields := map[string]StructField{}
+	mut struct_name := ''
+	mut used_names := []string{}
+	$if T is $struct {
+		struct_name = T.name
+		trace_println('${@FN}: mapping struct "${struct_name}"...')
+		// Handle positional first so they can be marked as handled
+		$for field in T.fields {
+			mut hints := FieldHints.zero()
+			mut match_name := field.name.replace('_', '-')
+			trace_println('${@FN}: field "${field.name}":')
+			mut attrs := map[string]string{}
+			for attr in field.attrs {
+				trace_println('\tattribute: "${attr}"')
+				if attr.contains(':') {
+					split := attr.split(':')
+					attrs[split[0].trim(' ')] = split[1].trim(' ')
+				} else {
+					attrs[attr.trim(' ')] = 'true'
+				}
+			}
+			if long_alias := attrs['long'] {
+				match_name = long_alias.replace('_', '-')
+			}
+			if only := attrs['only'] {
+				if only.len == 0 {
+					return error('attribute @[only] on ${struct_name}.${match_name} can not be empty, use @[only: x]')
+				} else if only.len == 1 {
+					hints.set(.short_only)
+					attrs['short'] = only
+					if only in used_names {
+						return error('attribute @[only: ${only}] on ${struct_name}.${field.name}, "${only}" is already in use')
+					}
+				} else if only.len > 1 {
+					match_name = only
+				}
+			}
+
+			mut short := ''
+			if short_alias := attrs['short'] {
+				if short_alias.len != 1 {
+					return error('attribute @[short: ${short}] on ${struct_name}.${field.name} can only be a single character')
+				}
+				short = short_alias
+
+				if short in used_names {
+					return error('attribute @[short: ${short_alias}] on ${struct_name}.${field.name}, "${short}" is already in use')
+				}
+				used_names << short
+			}
+
+			trace_println('\tmatch name: "${match_name}"')
+			used_names << match_name
+
+			$if field.typ is int {
+				hints.set(.is_int_type)
+			} $else $if field.typ is i64 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is u64 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is i32 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is u32 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is i16 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is u16 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is i8 {
+				hints.set(.is_int_type)
+			} $else $if field.typ is u8 {
+				hints.set(.is_int_type)
+			}
+
+			if _ := attrs['repeats'] {
+				hints.set(.can_repeat)
+			}
+			if _ := attrs['tail'] {
+				hints.set(.has_tail)
+			}
+			if _ := attrs['ignore'] {
+				hints.set(.is_ignore)
+			}
+
+			$if field.typ is bool {
+				trace_println('\tfield "${field.name}" is a bool')
+				hints.set(.is_bool)
+			}
+			$if field.is_array {
+				trace_println('\tfield "${field.name}" is array')
+				hints.set(.is_array)
+			}
+
+			if !hints.has(.is_int_type) && hints.has(.can_repeat) {
+				return error('`@[repeats] can only be used on integer type fields like `int`, `u32` etc.')
+			}
+
+			mut doc := ''
+			// `xdoc` was chosen because of `vfmt` sorting attributes alphabetically - so to avoid cluttering attributes
+			// we want the doc strings to be among the last attributes. To make it flexible to users we provide
+			// `$d('v:flag:doc_attr','xdoc')` to let users tweak it.
+			if docs := attrs[$d('v:flag:doc_attr', 'xdoc')] {
+				trace_println('\tdoc for field "${field.name}": ${docs}')
+				doc = docs
+			}
+
+			struct_fields[field.name] = StructField{
+				name: field.name
+				match_name: match_name
+				hints: hints
+				short: short
+				attrs: attrs
+				type_name: typeof(field).name
+				doc: doc
+			}
+		}
+	} $else {
+		return error('the type `${T.name}` can not be decoded.')
+	}
+
+	return StructInfo{
+		name: struct_name
+		fields: struct_fields
+	}
+}
+
+fn (m map[string]FlagData) query_flag_with_name(name string) ?FlagData {
+	for _, flag_data in m {
+		if flag_data.name == name {
+			return flag_data
+		}
+	}
+	return none
+}
+
+pub fn to_struct[T](input []string, config ParseConfig) !(T, []int) {
+	mut fm := FlagMapper{
+		config: config
+		input: input
+	}
+	fm.parse[T]()!
+	st := fm.to_struct[T]()!
+	return st, fm.no_matches()
+}
+
+pub fn to_doc[T](dc DocConfig) !string {
+	mut fm := FlagMapper{
+		config: ParseConfig{
+			delimiter: dc.delimiter
+			style: dc.style
+		}
+		input: []
+	}
+	fm.si = fm.get_struct_info[T]()!
+	return fm.to_doc(dc)!
+}
+
+pub fn (fm FlagMapper) no_matches() []int {
+	return fm.no_match
+}
+
+pub fn (mut fm FlagMapper) parse[T]() ! {
+	config := fm.config
+	style := config.style
+	delimiter := config.delimiter
+	args := fm.input
+
+	trace_println('${@FN}: parsing ${args}')
+	if config.skip > 0 {
+		// skip X entries. Could be the "exe", "executable" or "subcmd" - or more if the user wishes
+		for i in 0 .. int(config.skip) {
+			fm.handled_pos << i
+		}
+	}
+
+	// Gather runtime information about T
+	fm.si = fm.get_struct_info[T]()!
+	struct_name := fm.si.name
+
+	// Find the position of the last flag in `input`
+	mut pos_last_flag := -1
+	for pos, arg in args {
+		if arg.starts_with(delimiter) {
+			pos_last_flag = pos
+		}
+	}
+
+	for pos, arg in args {
+		if arg == '' {
+			fm.no_match << pos
+			continue
+		}
+		mut pos_is_handled := pos in fm.handled_pos
+
+		if !pos_is_handled {
+			// Stop parsing as soon as possible if `--` (or user defined) stop option is sat and encountered
+			if arg == config.stop or { '' } {
+				trace_println('${@FN}: reached option stop (${config.stop}) at index ${pos}')
+				// record all positions after this as not matching, unless pos is the last entry
+				if pos < args.len - 1 {
+					for unused_pos in pos + 1 .. args.len {
+						fm.no_match << unused_pos
+					}
+				}
+				break
+			}
+		}
+
+		// peek next arg
+		mut next := if pos + 1 < args.len { args[pos + 1] } else { '' }
+
+		// Parse arg entry (potential flag)
+		mut is_flag := false // `flag` starts with `-` (default value) or user defined
+		mut flag_name := ''
+		if arg.starts_with(delimiter) {
+			is_flag = true
+			flag_name = arg.trim_left(delimiter)
+			// Parse GNU (GO `flag`) `--name=value`
+			if style in [.long, .short_long, .go_flag] {
+				flag_name = flag_name.all_before('=')
+			}
+		}
+
+		// A flag, find best matching field in struct, if any
+		if is_flag {
+			// Figure out and validate used delimiter
+			used_delimiter := arg.all_before(flag_name)
+			is_long_delimiter := used_delimiter.count(delimiter) == 2
+			is_short_delimiter := used_delimiter.count(delimiter) == 1
+			is_invalid_delimiter := !is_long_delimiter && !is_short_delimiter
+			if is_invalid_delimiter {
+				return error('invalid delimiter `${used_delimiter}` for flag `${arg}`')
+			}
+			if is_long_delimiter {
+				if style == .v {
+					return error('long delimiter `${used_delimiter}` encountered in flag `${arg}` in ${style} (V) style parsing mode')
+				}
+				if style == .short {
+					return error('long delimiter `${used_delimiter}` encountered in flag `${arg}` in ${style} (POSIX) style parsing mode')
+				}
+			}
+
+			if is_short_delimiter {
+				if style == .long {
+					return error('short delimiter `${used_delimiter}` encountered in flag `${arg}` in ${style} (GNU) style parsing mode')
+				}
+				if style == .short_long && flag_name.len > 1 && flag_name.contains('-') {
+					return error('long name `${flag_name}` used with short delimiter `${used_delimiter}` in flag `${arg}` in ${style} (POSIX/GNU) style parsing mode')
+				}
+			}
+
+			if flag_name == '' {
+				return error('invalid delimiter-only flag `${arg}`')
+			}
+
+			flag_ctx := FlagContext{
+				raw: arg
+				delimiter: used_delimiter
+				name: flag_name
+				next: next
+				pos: pos
+			}
+
+			// Identify and match short clusters first. Example: `-yxz( arg)` = `-y -x -z( arg)`
+			if is_short_delimiter && style in [.short, .short_long] {
+				fm.map_posix_short_cluster(flag_ctx)!
+			}
+
+			pos_is_handled = pos in fm.handled_pos
+			if pos_is_handled {
+				trace_dbg_println('${@FN}: skipping position "${pos}". Already handled')
+				continue
+			}
+
+			for _, field in fm.si.fields {
+				if field.hints.has(.is_ignore) {
+					trace_dbg_println('${@FN}: skipping field "${field.name}" has an @[ignore] attribute')
+					continue
+				}
+				// Field already identified, skip
+				if _ := fm.field_map_flag[field.name] {
+					trace_dbg_println('${@FN}: skipping field "${field.name}" already identified')
+					continue
+				}
+
+				trace_println('${@FN}: matching `${used_delimiter}` ${if is_long_delimiter {
+					'(long)'
+				} else {
+					'(short)'
+				}} flag "${arg}/${flag_name}" is it matching "${field.name}${if field.short != '' {
+					'/' + field.short
+				} else {
+					''
+				}}"?')
+
+				if field.hints.has(.short_only) {
+					trace_println('${@FN}: skipping long delimiter `${used_delimiter}` match for ${struct_name}.${field.name} since it has [only: ${field.short}]')
+				}
+
+				if is_short_delimiter {
+					if style in [.short, .short_long] {
+						if fm.map_posix_short(flag_ctx, field)! {
+							continue
+						}
+					} else if style == .v {
+						if fm.map_v(flag_ctx, field)! {
+							continue
+						}
+					} else if style == .cmd_exe {
+						if fm.map_cmd_exe(flag_ctx, field)! {
+							continue
+						}
+					} else if style == .go_flag {
+						if fm.map_go_flag_short(flag_ctx, field)! {
+							continue
+						}
+					}
+				}
+
+				if is_long_delimiter {
+					// Parse GNU `--name=value`
+					if style in [.long, .short_long] {
+						if fm.map_gnu_long(flag_ctx, field)! {
+							continue
+						}
+					} else if style == .go_flag {
+						if fm.map_go_flag_long(flag_ctx, field)! {
+							continue
+						}
+					}
+				}
+			}
+		}
+
+		// Extract any tail according to config
+		if pos >= pos_last_flag + 1 {
+			pos_is_handled = pos in fm.handled_pos
+			if pos_is_handled {
+				trace_dbg_println('${@FN}: (tail) skipping position "${pos}". Already handled')
+				continue
+			}
+			for _, field in fm.si.fields {
+				if field.hints.has(.is_ignore) {
+					trace_dbg_println('${@FN}: (tail) skipping field "${field.name}" has an @[ignore] attribute')
+					continue
+				}
+				// Field already mapped, skip
+				if _ := fm.field_map_flag[field.name] {
+					trace_dbg_println('${@FN}: (tail) skipping field "${field.name}" already identified')
+					continue
+				}
+				if field.hints.has(.has_tail) {
+					if last_handled_pos := fm.handled_pos[fm.handled_pos.len - 1] {
+						trace_println('${@FN}: (tail) flag `${arg}` last_handled_pos: ${last_handled_pos} pos: ${pos}')
+						if pos == last_handled_pos + 1 {
+							if field.hints.has(.is_array) {
+								fm.array_field_map_flag[field.name] << FlagData{
+									raw: arg
+									field_name: field.name
+									arg: arg // .arg is used when assigning at comptime to []XYZ
+									pos: pos
+								}
+							} else {
+								fm.field_map_flag[field.name] = FlagData{
+									raw: arg
+									field_name: field.name
+									arg: arg
+									pos: pos
+								}
+							}
+							fm.handled_pos << pos
+							continue
+						}
+					}
+				}
+			}
+		}
+		if pos !in fm.handled_pos && pos !in fm.no_match {
+			fm.no_match << pos
+			// TODO: flag_name := arg.trim_left(delimiter) // WHY?
+			if already_flag := fm.field_map_flag.query_flag_with_name(arg.trim_left(delimiter)) {
+				return error('flag `${arg} ${next}` is already mapped to field `${already_flag.field_name}` via `${already_flag.delimiter}${already_flag.name} ${already_flag.arg or {
+					''
+				}}`')
+			}
+		}
+	}
+}
+
+pub fn (fm FlagMapper) to_doc(dc DocConfig) !string {
+	mut docs := []string{}
+
+	if dc.options.show.has(.name_and_version) {
+		docs << '${dc.name} ${dc.version}'
+	}
+
+	if dc.options.show.has(.description) {
+		docs << keep_at_max(dc.description, dc.layout.max_width())
+	}
+
+	if dc.options.show.has(.flags) {
+		fields_docs := fm.fields_docs(dc)!
+		if fields_docs.len > 0 {
+			if dc.options.show.has(.flags_header) {
+				docs << dc.options.flag_header
+			}
+			docs << fields_docs
+		}
+	}
+
+	if dc.options.show.has(.footer) {
+		docs << keep_at_max(dc.footer, dc.layout.max_width())
+	}
+
+	if dc.options.show.has(.name_and_version) {
+		mut longest_line := 0
+		for doc_line in docs {
+			lines := doc_line.split('\n')
+			for line in lines {
+				if line.len > longest_line {
+					longest_line = line.len
+				}
+			}
+		}
+		docs.insert(1, '-'.repeat(longest_line))
+	}
+	return docs.join('\n')
+}
+
+pub fn (fm FlagMapper) fields_docs(dc DocConfig) ![]string {
+	short_delimiter := match dc.style {
+		.short, .short_long, .v, .go_flag, .cmd_exe { dc.delimiter }
+		.long { dc.delimiter.repeat(2) }
+	}
+	long_delimiter := match dc.style {
+		.short, .v, .go_flag, .cmd_exe { dc.delimiter }
+		.long, .short_long { dc.delimiter.repeat(2) }
+	}
+
+	pad_desc := if dc.layout.description_padding < 0 { 0 } else { dc.layout.description_padding }
+	empty_padding := ' '.repeat(pad_desc)
+	indent_flags := if dc.layout.flag_indent < 0 { 0 } else { dc.layout.flag_indent }
+	indent_flags_padding := ' '.repeat(indent_flags)
+	desc_max := if dc.layout.description_width < 1 { 1 } else { dc.layout.description_width }
+
+	mut docs := []string{}
+	for _, field in fm.si.fields {
+		if field.hints.has(.is_ignore) {
+			trace_println('${@FN}: skipping field "${field.name}" has an @[ignore] attribute')
+			continue
+		}
+		doc := dc.fields[field.name] or { field.doc }
+		short := field.shortest_match_name() or { '' }
+		long := field.match_name
+
+		// -f, --flag <type>
+		mut flag_line := indent_flags_padding
+		flag_line += if short != '' { '${short_delimiter}${short}' } else { '' }
+		if !field.hints.has(.short_only) && long != '' {
+			if short != '' {
+				flag_line += ', '
+			}
+			flag_line += '${long_delimiter}${long}'
+		}
+		if dc.options.show.has(.flag_type) && field.type_name != 'bool' {
+			if !field.hints.has(.can_repeat) {
+				flag_line += ' <${field.type_name.replace('[]', '')}>'
+			}
+		}
+		if dc.options.show.has(.flag_hint) {
+			if field.hints.has(.is_array) {
+				flag_line += ' (allowed multiple times)'
+			}
+			if field.hints.has(.can_repeat) {
+				flag_line += ', ${short_delimiter}${short}${short}${short}... (can repeat)'
+			}
+		}
+		flag_line_diff := flag_line.len - pad_desc
+		if flag_line_diff < 0 {
+			diff := -flag_line_diff
+			docs << flag_line + ' '.repeat(diff) +
+				keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') + '\n'
+		} else {
+			docs << flag_line
+			docs << empty_padding + keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') +
+				'\n'
+		}
+	}
+	// Look for custom flag entries starting with delimiter
+	for entry, doc in dc.fields {
+		if entry.starts_with(dc.delimiter) {
+			flag_line_diff := entry.len - pad_desc + indent_flags
+			if flag_line_diff < 0 {
+				diff := -flag_line_diff
+				docs << indent_flags_padding + entry.trim(' ') + ' '.repeat(diff) +
+					keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') + '\n'
+			} else {
+				docs << indent_flags_padding + entry.trim(' ')
+				docs << empty_padding +
+					keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') + '\n'
+			}
+		}
+	}
+	if docs.len > 0 {
+		docs[docs.len - 1] = docs[docs.len - 1].trim_right(' \n')
+	}
+	return docs
+}
+
+// keep_at_max returns `str` that is kept at a line width of `max` characters.
+// User provided newlines is ignored in case the `str` has to be corrected to
+// fit the provided `max` width value. Lines longer than `max` are not dealt with.
+fn keep_at_max(str string, max int) string {
+	safe_max := if max <= 0 { 1 } else { max }
+	if str.len <= safe_max || str.count(' ') == 0 {
+		return str
+	}
+	mut fitted := ''
+	mut width := 0
+	mut last_possible_break := str.index(' ') or { 0 }
+	mut never_touched := true
+	s := str.trim_space()
+	for i, c in s {
+		width++
+		if c == ` ` {
+			last_possible_break = i
+		} else if c == `\n` {
+			width = 0
+		}
+		if width == safe_max {
+			never_touched = false
+			fitted = s[..last_possible_break] + '\n'
+			// At this point we are refitting the doc string so user provided newlines can not be kept
+			// ... at least not without a tremendous increase in code complexity, that highly likely
+			// will not suit all use-cases anyway.
+			fitted += keep_at_max(s[last_possible_break..].replace('\n', ' ').trim(' '),
+				safe_max).trim(' ')
+		} else if width > safe_max {
+			break
+		}
+	}
+	if never_touched {
+		return str
+	}
+	return fitted
+}
+
+// to_struct returns an instance of `T` that has the parsed flags from `input` mapped to the fields of struct `T`.
+pub fn (fm FlagMapper) to_struct[T]() !T {
+	// Generate T result
+	mut result := T{}
+
+	$if T is $struct {
+		struct_name := T.name
+		$for field in T.fields {
+			if f := fm.field_map_flag[field.name] {
+				a_or_r := f.arg or { '${f.repeats}' }
+				$if field.typ is int {
+					// TODO: find a way to move this kind of duplicate code out
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					trace_dbg_println('${@FN}: assigning (int) ${struct_name}.${field.name} = ${a_or_r}')
+					result.$(field.name) = a_or_r.int()
+				} $else $if field.typ is i64 {
+					trace_dbg_println('${@FN}: assigning (i64) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.i64()
+				} $else $if field.typ is u64 {
+					trace_dbg_println('${@FN}: assigning (u64) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.u64()
+				} $else $if field.typ is i32 {
+					trace_dbg_println('${@FN}: assigning (i32) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.i32()
+				} $else $if field.typ is u32 {
+					trace_dbg_println('${@FN}: assigning (u32) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.u32()
+				} $else $if field.typ is i16 {
+					trace_dbg_println('${@FN}: assigning (i16) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.i16()
+				} $else $if field.typ is u16 {
+					trace_dbg_println('${@FN}: assigning (u16) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.u16()
+				} $else $if field.typ is i8 {
+					trace_dbg_println('${@FN}: assigning (i8) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.i8()
+				} $else $if field.typ is u8 {
+					trace_dbg_println('${@FN}: assigning (u8) ${struct_name}.${field.name} = ${a_or_r}')
+					if !a_or_r.is_int() {
+						return error('can not assign non-integer value `${a_or_r}` from flag `${f.raw}` to `${struct_name}.${field.name}`')
+					}
+					result.$(field.name) = a_or_r.u8()
+				} $else $if field.typ is f32 {
+					result.$(field.name) = f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.f32()
+				} $else $if field.typ is f64 {
+					result.$(field.name) = f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.f64()
+				} $else $if field.typ is bool {
+					if arg := f.arg {
+						return error('can not assign `${arg}` to bool field `${field.name}`')
+					}
+					result.$(field.name) = true
+				} $else $if field.typ is string {
+					result.$(field.name) = f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.str()
+				} $else {
+					return error('field type: ${field.typ} for ${field.name} is not supported')
+				}
+			}
+			for f in fm.array_field_map_flag[field.name] {
+				// trace_println('${@FN}: appending ${field.name} << ${f.arg}')
+				$if field.typ is []string {
+					// TODO: find a way to move this kind of duplicate code out
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.str()
+				} $else $if field.typ is []int {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.int()
+				} $else $if field.typ is []i64 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.i64()
+				} $else $if field.typ is []u64 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.u64()
+				} $else $if field.typ is []i32 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.i32()
+				} $else $if field.typ is []u32 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.u32()
+				} $else $if field.typ is []i16 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.i16()
+				} $else $if field.typ is []u16 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.u16()
+				} $else $if field.typ is []i8 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.i8()
+				} $else $if field.typ is []u8 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.u8()
+				} $else $if field.typ is []f32 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.f32()
+				} $else $if field.typ is []f64 {
+					result.$(field.name) << f.arg or {
+						return error('failed appending ${f.raw} to ${field.name}')
+					}
+						.f64()
+				} $else {
+					return error('field type: ${field.typ} for multi value ${field.name} is not supported')
+				}
+			}
+		}
+	} $else {
+		return error('the type `${T.name}` can not be decoded.')
+	}
+
+	return result
+}
+
+// map_v returns `true` if the V style flag in `flag_ctx` can be mapped to `field`.
+// map_v adds data of the match in the internal structures for further processing if applicable
+fn (mut fm FlagMapper) map_v(flag_ctx FlagContext, field StructField) !bool {
+	flag_raw := flag_ctx.raw
+	flag_name := flag_ctx.name
+	pos := flag_ctx.pos
+	used_delimiter := flag_ctx.delimiter
+	next := flag_ctx.next
+
+	if field.hints.has(.is_bool) {
+		if flag_name == field.match_name {
+			arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+			if arg != '' {
+				return error('flag `${flag_raw}` can not be assigned to bool field "${field.name}"')
+			}
+			trace_println('${@FN}: found match for (bool) ${fm.dbg_match(flag_ctx, field,
+				'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		}
+	}
+
+	if flag_name == field.match_name || flag_name == field.short {
+		if field.hints.has(.is_array) {
+			trace_println('${@FN}: found match for (V style multiple occurences) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+			fm.array_field_map_flag[field.name] << FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+		} else {
+			trace_println('${@FN}: found match for (V style) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+		}
+		fm.handled_pos << pos
+		fm.handled_pos << pos + 1 // arg
+		return true
+	}
+	return false
+}
+
+// map_go_flag_short returns `true` if the GO short style flag in `flag_ctx` can be mapped to `field`.
+// map_go_flag_short adds data of the match in the internal structures for further processing if applicable
+fn (mut fm FlagMapper) map_go_flag_short(flag_ctx FlagContext, field StructField) !bool {
+	flag_raw := flag_ctx.raw
+	flag_name := flag_ctx.name
+	pos := flag_ctx.pos
+	used_delimiter := flag_ctx.delimiter
+	next := flag_ctx.next
+
+	if field.hints.has(.is_bool) {
+		if flag_name == field.match_name {
+			arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+			if arg != '' {
+				return error('flag `${flag_raw}` can not be assigned to bool field "${field.name}"')
+			}
+			trace_println('${@FN}: found match for (bool) ${fm.dbg_match(flag_ctx, field,
+				'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		}
+	}
+
+	if flag_name == field.match_name || flag_name == field.short {
+		if field.hints.has(.is_array) {
+			trace_println('${@FN}: found match for (GO short style multiple occurences) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+			fm.array_field_map_flag[field.name] << FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+		} else {
+			trace_println('${@FN}: found match for (GO short style) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+		}
+		fm.handled_pos << pos
+		fm.handled_pos << pos + 1 // arg
+		return true
+	}
+	return false
+}
+
+// map_go_flag_long returns `true` if the GO long style flag in `flag_ctx` can be mapped to `field`.
+// map_go_flag_long adds data of the match in the internal structures for further processing if applicable
+fn (mut fm FlagMapper) map_go_flag_long(flag_ctx FlagContext, field StructField) !bool {
+	flag_raw := flag_ctx.raw
+	flag_name := flag_ctx.name
+	pos := flag_ctx.pos
+	used_delimiter := flag_ctx.delimiter
+
+	if flag_name == field.match_name {
+		if field.hints.has(.is_bool) {
+			arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+			if arg != '' {
+				return error('flag `${flag_raw}` can not be assigned to bool field "${field.name}"')
+			}
+			trace_println('${@FN}: found match for (bool) (GO `flag` style) ${fm.dbg_match(flag_ctx,
+				field, 'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		}
+
+		if !flag_raw.contains('=') {
+			if field.hints.has(.is_int_type) && field.hints.has(.can_repeat) {
+				return error('field `${field.name}` has @[repeats], only POSIX short style allows repeating')
+			}
+			return error('long delimiter `${used_delimiter}` flag `${flag_raw}` mapping to `${field.name}` in ${fm.config.style} style parsing mode, expects GO (GNU) style assignment. E.g.: --name=value')
+		}
+
+		arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+		if field.hints.has(.is_array) {
+			trace_println('${@FN}: found match for (GO `flag` style multiple occurences) ${fm.dbg_match(flag_ctx,
+				field, arg, '')}')
+			fm.array_field_map_flag[field.name] << FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: arg
+				pos: pos
+			}
+		} else {
+			trace_println('${@FN}: found match for (GO `flag` style) ${fm.dbg_match(flag_ctx,
+				field, arg, '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: arg
+				pos: pos
+			}
+		}
+		fm.handled_pos << pos // NOTE: arg is part of the flag in GO (GNU) long style args
+		return true
+	}
+	return false
+}
+
+// map_gnu_long returns `true` if the GNU (long) style flag in `flag_ctx` can be mapped to `field`.
+// map_gnu_long adds data of the match in the internal structures for further processing if applicable
+fn (mut fm FlagMapper) map_gnu_long(flag_ctx FlagContext, field StructField) !bool {
+	flag_raw := flag_ctx.raw
+	flag_name := flag_ctx.name
+	pos := flag_ctx.pos
+	used_delimiter := flag_ctx.delimiter
+
+	if flag_name == field.match_name {
+		if field.hints.has(.is_bool) {
+			arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+			if arg != '' {
+				return error('flag `${flag_raw}` can not be assigned to bool field "${field.name}"')
+			}
+			trace_println('${@FN}: found match for (bool) ${fm.dbg_match(flag_ctx, field,
+				'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		} else if fm.config.style in [.long, .short_long] && !flag_raw.contains('=') {
+			if field.hints.has(.is_int_type) && field.hints.has(.can_repeat) {
+				return error('field `${field.name}` has @[repeats], only POSIX short style allows repeating')
+			}
+			return error('long delimiter `${used_delimiter}` flag `${flag_raw}` mapping to `${field.name}` in ${fm.config.style} style parsing mode, expects GNU style assignment. E.g.: --name=value')
+		}
+
+		arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+		if field.hints.has(.is_array) {
+			trace_println('${@FN}: found match for (GNU style multiple occurences) ${fm.dbg_match(flag_ctx,
+				field, arg, '')}')
+			fm.array_field_map_flag[field.name] << FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: arg
+				pos: pos
+			}
+		} else {
+			trace_println('${@FN}: found match for (GNU style) ${fm.dbg_match(flag_ctx,
+				field, arg, '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: arg
+				pos: pos
+			}
+		}
+		fm.handled_pos << pos // NOTE: arg is part of the flag in GNU long style args
+		return true
+	}
+	return false
+}
+
+// map_posix_short_cluster looks for multiple combined short flags and optional
+// tail arguments e.g. `-yxz( a)` = `-y -x -z( a)` and maps them to the respective struct fields.
+// map_posix_short_cluster adds data of the match in the internal structures for further processing if applicable.
+fn (mut fm FlagMapper) map_posix_short_cluster(flag_ctx FlagContext) ! {
+	flag_name := flag_ctx.name
+	if flag_name.len <= 1 {
+		return
+	}
+	// Do not handle multiple `-vv`, `map_posix_short` does that
+	if flag_name[0] == flag_name[1] {
+		return
+	}
+
+	if flag_name.len > 1 {
+		mut split := flag_name.split('')
+		mut matched_fields := map[string]StructField{}
+		for mflag in split {
+			mut matched := false
+			for _, field in fm.si.fields {
+				if smatch_name := field.shortest_match_name() {
+					if mflag == smatch_name {
+						trace_println('${@FN}: cluster flag `${mflag}` matches field `${smatch_name}`')
+						matched_fields[mflag] = field
+						matched = true
+					}
+				}
+			}
+			if !matched {
+				break
+			}
+		}
+
+		if matched_fields.len == 0 {
+			return
+		}
+
+		// Iterate `split` instead of `matched_fields` since the order of appearance has significance
+		for i := 0; i < split.len; i++ {
+			mflag := split[i]
+			if field := matched_fields[mflag] {
+				// trace_println('${@FN}: ${mflag} matches ${field.name}')
+				mf := FlagData{
+					raw: flag_ctx.raw
+					field_name: field.name
+					delimiter: flag_ctx.delimiter
+					name: mflag
+					pos: flag_ctx.pos
+				}
+				if field.hints.has(.is_bool) {
+					trace_println('${@FN}: found match for (bool) ${fm.dbg_match(flag_ctx,
+						field, 'true', '')}')
+					fm.field_map_flag[mf.field_name] = mf
+					fm.handled_pos << flag_ctx.pos
+				} else {
+					mut arg := split[i + 1..].clone().join('')
+					mut next_is_used := false
+					if arg == '' {
+						arg = flag_ctx.next
+						if arg != '' {
+							next_is_used = true
+						}
+					}
+					if field.hints.has(.is_array) {
+						fm.array_field_map_flag[mf.field_name] << FlagData{
+							...mf
+							arg: arg
+						}
+						trace_println('${@FN}: found match for (array) ${fm.dbg_match(flag_ctx,
+							field, arg, '')}')
+					} else {
+						trace_println('${@FN}: found match for (other) ${fm.dbg_match(flag_ctx,
+							field, arg, '')}')
+						fm.field_map_flag[mf.field_name] = FlagData{
+							...mf
+							arg: arg
+						}
+					}
+					fm.handled_pos << flag_ctx.pos
+					if next_is_used {
+						fm.handled_pos << flag_ctx.pos + 1 // next
+					}
+					break
+				}
+			}
+		}
+	}
+}
+
+// map_posix_short returns `true` if the POSIX (short) style flag in `flag_ctx` can be mapped to `field`.
+// map_posix_short adds data of the match in the internal structures for further processing if applicable
+// map_posix_short handles, amoung other things the mapping of repeatable short flags. E.g.: `-vvv vvv`
+fn (mut fm FlagMapper) map_posix_short(flag_ctx FlagContext, field StructField) !bool {
+	flag_raw := flag_ctx.raw
+	mut flag_name := flag_ctx.name
+	pos := flag_ctx.pos
+	used_delimiter := flag_ctx.delimiter
+	mut next := flag_ctx.next
+	struct_name := fm.si.name
+
+	first_letter := flag_name.split('')[0]
+	next_first_letter := if next != '' {
+		next.split('')[0]
+	} else {
+		''
+	}
+	count_of_first_letter_repeats := flag_name.count(first_letter)
+	count_of_next_first_letter_repeats := next.count(next_first_letter)
+
+	if field.hints.has(.is_bool) {
+		if flag_name == field.match_name {
+			arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
+			if arg != '' {
+				return error('flag `${flag_raw}` can not be assigned to bool field "${field.name}"')
+			}
+			trace_println('${@FN}: found match for (bool) ${fm.dbg_match(flag_ctx, field,
+				'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		}
+
+		if field.short == flag_name {
+			trace_println('${@FN}: found match for (bool) ${fm.dbg_match(flag_ctx, field,
+				'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		}
+	}
+
+	if first_letter == field.short {
+		// `-vvvvv`, `-vv vvv` or `-v vvvv`
+		if field.hints.has(.can_repeat) {
+			mut do_continue := false
+			if count_of_first_letter_repeats == flag_name.len {
+				trace_println('${@FN}: found match for (repeatable) ${fm.dbg_match(flag_ctx,
+					field, 'true', '')}')
+				fm.field_map_flag[field.name] = FlagData{
+					raw: flag_raw
+					field_name: field.name
+					delimiter: used_delimiter
+					name: flag_name
+					pos: pos
+					repeats: count_of_first_letter_repeats
+				}
+				fm.handled_pos << pos
+				do_continue = true
+
+				if next_first_letter == first_letter
+					&& count_of_next_first_letter_repeats == next.len {
+					trace_println('${@FN}: field "${field.name}" allow repeats and ${flag_raw} ${next} repeats ${
+						count_of_next_first_letter_repeats + count_of_first_letter_repeats} times (via argument)')
+					fm.field_map_flag[field.name] = FlagData{
+						raw: flag_raw
+						field_name: field.name
+						delimiter: used_delimiter
+						name: flag_name
+						pos: pos
+						repeats: count_of_next_first_letter_repeats + count_of_first_letter_repeats
+					}
+					fm.handled_pos << pos
+					fm.handled_pos << pos + 1 // next
+					do_continue = true
+				} else {
+					trace_println('${@FN}: field "${field.name}" allow repeats and ${flag_raw} repeats ${count_of_first_letter_repeats} times')
+				}
+				if do_continue {
+					return true
+				}
+			}
+		} else if field.hints.has(.is_array) {
+			split := flag_name.trim_string_left(field.short)
+			mut next_is_handled := true
+			if split != '' {
+				next = split
+				flag_name = flag_name.trim_string_right(split)
+				next_is_handled = false
+			}
+
+			if next == '' {
+				return error('flag "${flag_raw}" expects an argument')
+			}
+			trace_println('${@FN}: found match for (multiple occurences) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+
+			fm.array_field_map_flag[field.name] << FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+			fm.handled_pos << pos
+			if next_is_handled {
+				fm.handled_pos << pos + 1 // next
+			}
+			return true
+		}
+	}
+	if (fm.config.style == .short || field.hints.has(.short_only)) && first_letter == field.short {
+		split := flag_name.trim_string_left(field.short)
+		mut next_is_handled := true
+		if split != '' {
+			next = split
+			flag_name = flag_name.trim_string_right(split)
+			next_is_handled = false
+		}
+
+		if next == '' {
+			return error('flag "${flag_raw}" expects an argument')
+		}
+		trace_println('${@FN}: found match for (short only) ${struct_name}.${field.name} (${field.match_name}) = ${field.short} = ${next}')
+
+		fm.field_map_flag[field.name] = FlagData{
+			raw: flag_raw
+			field_name: field.name
+			delimiter: used_delimiter
+			name: flag_name
+			arg: next
+			pos: pos
+			repeats: count_of_first_letter_repeats
+		}
+		fm.handled_pos << pos
+		if next_is_handled {
+			fm.handled_pos << pos + 1 // next
+		}
+		return true
+	} else if flag_name == field.match_name && !(field.hints.has(.short_only)
+		&& flag_name == field.short) {
+		trace_println('${@FN}: found match for (repeats) ${fm.dbg_match(flag_ctx, field,
+			next, '')}')
+		if next == '' {
+			return error('flag "${flag_raw}" expects an argument')
+		}
+		fm.field_map_flag[field.name] = FlagData{
+			raw: flag_raw
+			field_name: field.name
+			delimiter: used_delimiter
+			name: flag_name
+			arg: next
+			pos: pos
+			repeats: count_of_first_letter_repeats
+		}
+		fm.handled_pos << pos
+		fm.handled_pos << pos + 1 // next
+		return true
+	}
+	return false
+}
+
+// map_cmd_exe returns `true` if the CMD.EXE style flag in `flag_ctx` can be mapped to `field`.
+// map_cmd_exe adds data of the match in the internal structures for further processing if applicable
+fn (mut fm FlagMapper) map_cmd_exe(flag_ctx FlagContext, field StructField) !bool {
+	flag_raw := flag_ctx.raw
+	flag_name := flag_ctx.name
+	pos := flag_ctx.pos
+	used_delimiter := flag_ctx.delimiter
+	next := flag_ctx.next
+
+	if flag_name == field.match_name {
+		if field.hints.has(.is_bool) {
+			trace_println('${@FN}: found (long) match for (bool) (CMD.EXE style) ${fm.dbg_match(flag_ctx,
+				field, 'true', '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				pos: pos
+			}
+			fm.handled_pos << pos
+			return true
+		}
+		// Not sure original CMD.EXE flags supported multiple flags with same name??
+		if field.hints.has(.is_array) {
+			trace_println('${@FN}: found match for (CMD.EXE style multiple occurences) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+			fm.array_field_map_flag[field.name] << FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+		} else {
+			trace_println('${@FN}: found match for (CMD.EXE style) ${fm.dbg_match(flag_ctx,
+				field, next, '')}')
+			fm.field_map_flag[field.name] = FlagData{
+				raw: flag_raw
+				field_name: field.name
+				delimiter: used_delimiter
+				name: flag_name
+				arg: next
+				pos: pos
+			}
+		}
+		fm.handled_pos << pos
+		fm.handled_pos << pos + 1 // arg
+		return true
+	}
+	// Not aware of CMD.EXE flags longer than one (ASCII??) character
+	if shortest_match_name := field.shortest_match_name() {
+		if flag_name == shortest_match_name {
+			if field.hints.has(.is_bool) {
+				trace_println('${@FN}: found match for (bool) (CMD.EXE style) ${fm.dbg_match(flag_ctx,
+					field, 'true', '')}')
+				fm.field_map_flag[field.name] = FlagData{
+					raw: flag_raw
+					field_name: field.name
+					delimiter: used_delimiter
+					name: flag_name
+					pos: pos
+				}
+				fm.handled_pos << pos
+				return true
+			}
+
+			// Not sure original CMD.EXE flags supported multiple flags with same name??
+			if field.hints.has(.is_array) {
+				trace_println('${@FN}: found match for (CMD.EXE style multiple occurences) ${fm.dbg_match(flag_ctx,
+					field, next, '')}')
+				fm.array_field_map_flag[field.name] << FlagData{
+					raw: flag_raw
+					field_name: field.name
+					delimiter: used_delimiter
+					name: flag_name
+					arg: next
+					pos: pos
+				}
+			} else {
+				trace_println('${@FN}: found match for (CMD.EXE style) ${fm.dbg_match(flag_ctx,
+					field, next, '')}')
+				fm.field_map_flag[field.name] = FlagData{
+					raw: flag_raw
+					field_name: field.name
+					delimiter: used_delimiter
+					name: flag_name
+					arg: next
+					pos: pos
+				}
+			}
+			fm.handled_pos << pos
+			fm.handled_pos << pos + 1 // arg
+			return true
+		}
+	}
+	return false
+}

--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -119,6 +119,7 @@ pub mut:
 	show        Show   = ~Show.zero()
 }
 
+// max_width returns the total width of the `DocLayout`.
 pub fn (dl DocLayout) max_width() int {
 	return dl.flag_indent + dl.description_padding + dl.description_width
 }
@@ -296,6 +297,7 @@ fn (m map[string]FlagData) query_flag_with_name(name string) ?FlagData {
 	return none
 }
 
+// to_struct returns `T` with field values sat to any matching flags in `input`.
 pub fn to_struct[T](input []string, config ParseConfig) !(T, []int) {
 	mut fm := FlagMapper{
 		config: config
@@ -306,6 +308,8 @@ pub fn to_struct[T](input []string, config ParseConfig) !(T, []int) {
 	return st, fm.no_matches()
 }
 
+// to_doc returns a "usage" style documentation `string` generated from
+// attributes on `T` or via the `dc` argument.
 pub fn to_doc[T](dc DocConfig) !string {
 	mut fm := FlagMapper{
 		config: ParseConfig{
@@ -318,10 +322,13 @@ pub fn to_doc[T](dc DocConfig) !string {
 	return fm.to_doc(dc)!
 }
 
+// no_matches returns an array of indicies from the `input` (usually `os.args`),
+// that could not be matched against any fields.
 pub fn (fm FlagMapper) no_matches() []int {
 	return fm.no_match
 }
 
+// parse parses `T` to an internal data representation.
 pub fn (mut fm FlagMapper) parse[T]() ! {
 	config := fm.config
 	style := config.style
@@ -550,6 +557,8 @@ pub fn (mut fm FlagMapper) parse[T]() ! {
 	}
 }
 
+// to_doc returns a "usage" style documentation `string` generated from
+// the internal data structures generated via the `parse()` function.
 pub fn (fm FlagMapper) to_doc(dc DocConfig) !string {
 	mut docs := []string{}
 
@@ -633,6 +642,7 @@ pub fn (fm FlagMapper) to_doc(dc DocConfig) !string {
 	return docs.join('\n')
 }
 
+// fields_docs returns every line of the combined field documentation.
 pub fn (fm FlagMapper) fields_docs(dc DocConfig) ![]string {
 	short_delimiter := match dc.style {
 		.short, .short_long, .v, .go_flag, .cmd_exe { dc.delimiter }

--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -527,14 +527,14 @@ pub fn (mut fm FlagMapper) parse[T]() ! {
 								fm.array_field_map_flag[field.name] << FlagData{
 									raw: arg
 									field_name: field.name
-									arg: arg // .arg is used when assigning at comptime to []XYZ
+									arg: ?string(arg) // .arg is used when assigning at comptime to []XYZ
 									pos: pos
 								}
 							} else {
 								fm.field_map_flag[field.name] = FlagData{
 									raw: arg
 									field_name: field.name
-									arg: arg
+									arg: ?string(arg)
 									pos: pos
 								}
 							}
@@ -963,7 +963,7 @@ fn (mut fm FlagMapper) map_v(flag_ctx FlagContext, field StructField) !bool {
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 		} else {
@@ -974,7 +974,7 @@ fn (mut fm FlagMapper) map_v(flag_ctx FlagContext, field StructField) !bool {
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 		}
@@ -1023,7 +1023,7 @@ fn (mut fm FlagMapper) map_go_flag_short(flag_ctx FlagContext, field StructField
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 		} else {
@@ -1034,7 +1034,7 @@ fn (mut fm FlagMapper) map_go_flag_short(flag_ctx FlagContext, field StructField
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 		}
@@ -1088,7 +1088,7 @@ fn (mut fm FlagMapper) map_go_flag_long(flag_ctx FlagContext, field StructField)
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: arg
+				arg: ?string(arg)
 				pos: pos
 			}
 		} else {
@@ -1099,7 +1099,7 @@ fn (mut fm FlagMapper) map_go_flag_long(flag_ctx FlagContext, field StructField)
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: arg
+				arg: ?string(arg)
 				pos: pos
 			}
 		}
@@ -1150,7 +1150,7 @@ fn (mut fm FlagMapper) map_gnu_long(flag_ctx FlagContext, field StructField) !bo
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: arg
+				arg: ?string(arg)
 				pos: pos
 			}
 		} else {
@@ -1161,7 +1161,7 @@ fn (mut fm FlagMapper) map_gnu_long(flag_ctx FlagContext, field StructField) !bo
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: arg
+				arg: ?string(arg)
 				pos: pos
 			}
 		}
@@ -1236,7 +1236,7 @@ fn (mut fm FlagMapper) map_posix_short_cluster(flag_ctx FlagContext) ! {
 					if field.hints.has(.is_array) {
 						fm.array_field_map_flag[mf.field_name] << FlagData{
 							...mf
-							arg: arg
+							arg: ?string(arg)
 						}
 						trace_println('${@FN}: found match for (array) ${fm.dbg_match(flag_ctx,
 							field, arg, '')}')
@@ -1245,7 +1245,7 @@ fn (mut fm FlagMapper) map_posix_short_cluster(flag_ctx FlagContext) ! {
 							field, arg, '')}')
 						fm.field_map_flag[mf.field_name] = FlagData{
 							...mf
-							arg: arg
+							arg: ?string(arg)
 						}
 					}
 					fm.handled_pos << flag_ctx.pos
@@ -1373,7 +1373,7 @@ fn (mut fm FlagMapper) map_posix_short(flag_ctx FlagContext, field StructField) 
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 			fm.handled_pos << pos
@@ -1402,7 +1402,7 @@ fn (mut fm FlagMapper) map_posix_short(flag_ctx FlagContext, field StructField) 
 			field_name: field.name
 			delimiter: used_delimiter
 			name: flag_name
-			arg: next
+			arg: ?string(next)
 			pos: pos
 			repeats: count_of_first_letter_repeats
 		}
@@ -1423,7 +1423,7 @@ fn (mut fm FlagMapper) map_posix_short(flag_ctx FlagContext, field StructField) 
 			field_name: field.name
 			delimiter: used_delimiter
 			name: flag_name
-			arg: next
+			arg: ?string(next)
 			pos: pos
 			repeats: count_of_first_letter_repeats
 		}
@@ -1466,7 +1466,7 @@ fn (mut fm FlagMapper) map_cmd_exe(flag_ctx FlagContext, field StructField) !boo
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 		} else {
@@ -1477,7 +1477,7 @@ fn (mut fm FlagMapper) map_cmd_exe(flag_ctx FlagContext, field StructField) !boo
 				field_name: field.name
 				delimiter: used_delimiter
 				name: flag_name
-				arg: next
+				arg: ?string(next)
 				pos: pos
 			}
 		}
@@ -1511,7 +1511,7 @@ fn (mut fm FlagMapper) map_cmd_exe(flag_ctx FlagContext, field StructField) !boo
 					field_name: field.name
 					delimiter: used_delimiter
 					name: flag_name
-					arg: next
+					arg: ?string(next)
 					pos: pos
 				}
 			} else {
@@ -1522,7 +1522,7 @@ fn (mut fm FlagMapper) map_cmd_exe(flag_ctx FlagContext, field StructField) !boo
 					field_name: field.name
 					delimiter: used_delimiter
 					name: flag_name
-					arg: next
+					arg: ?string(next)
 					pos: pos
 				}
 			}

--- a/vlib/flag/flag_to_doc_test.v
+++ b/vlib/flag/flag_to_doc_test.v
@@ -1,0 +1,72 @@
+import flag
+
+const doc1 = 'an app 1.2.3
+--------------------------------------------------------
+Some config struct
+
+Options:
+  -v, --show-version        Show version and exit
+
+  -d, --debug <int>         Debug level
+
+  -l <f32>                  This doc text is overwritten
+Use ESC to exit'
+
+const doc2 = 'an app 1.2.3
+-----------------------------------------------------------------------------
+Some config struct
+
+Options:
+  -v, --show-version        Show version and exit
+
+  -d, --debug <int>         Debug level
+
+  -l <f32>                  This is a doc string of the field `level` on
+                            struct `Config`
+
+  -e, --extra               Extra flag that does not exist on the struct, but
+                            we want documented (in same format as the others)
+Use ESC to exit'
+
+const doc3 = 'my app 1.0
+--------------------------------------------------------
+My application
+
+Options:
+  -v, --show-version        Show version and exit
+
+  -d, --debug <int>         Debug level
+
+  -l <f32>                  This doc text is overwritten
+Use ESC to exit'
+
+@[xdoc: 'Some config struct']
+@[footer: 'Use ESC to exit']
+@[name: 'an app']
+@[version: '1.2.3']
+struct Config {
+	show_version bool @[short: v; xdoc: 'Show version and exit']
+	debug_level  int  @[long: debug; short: d; xdoc: 'Debug level']
+	level        f32  @[only: l; xdoc: 'This doc text is overwritten']
+}
+
+fn test_direct_to_doc() {
+	assert flag.to_doc[Config]()! == doc1
+}
+
+fn test_attrs() {
+	assert flag.to_doc[Config](
+		fields: {
+			'level':       'This is a doc string of the field `level` on struct `Config`'
+			'-e, --extra': 'Extra flag that does not exist on the struct, but we want documented (in same format as the others)'
+		}
+	)! == doc2
+}
+
+fn test_attrs_override() {
+	assert flag.to_doc[Config](
+		name: 'my app'
+		version: '1.0'
+		description: 'My application'
+	)! == doc3
+}

--- a/vlib/flag/flag_to_misc_test.v
+++ b/vlib/flag/flag_to_misc_test.v
@@ -1,0 +1,171 @@
+import flag
+
+const all_style_enums = [flag.Style.short, .short_long, .long, .v]
+const posix_gnu_style_enums = [flag.Style.short, .short_long, .long]
+const mixed_args = ['/path/to/exe', '-vv', 'vvv', '-version', '--mix', '--mix-all=all', '-ldflags',
+	'-m', '2', '-fgh', '["test", "test"]', '-m', '{map: 2, ml-q:"hello"}']
+
+const posix_and_gnu_args = ['-vv', 'vvv', '-mwindows', '-d', 'one', '--device=two', '--amount=8',
+	'-d', 'three']
+
+const posix_and_gnu_args_with_subcmd = ['/path/to/exe', 'subcmd', '-vv', 'vvv', '-mwindows', '-d',
+	'one', '--device=two', '--amount=8', '-d', 'three']
+
+const posix_and_gnu_args_with_paths = ['/path/to/exe', '-vv', 'vvv', '-mwindows', '-d', 'one',
+	'--device=two', '--amount=8', '-d', 'three', '/path/to/a', '/path/to/b']
+
+const posix_args_error = ['/path/to/exe', '-vv', 'vvv', '-mwindows', '-m', 'gnu']
+const gnu_args = ['--f=10.2', '--mix', '--test=test', '--amount=5', '--version', 'other']
+const gnu_args_error = ['--f=10.2', '--mix', '--test=test', '--amount=5', '--version', 'other',
+	'oo']
+const ignore_args_error = ['--show-version', '--some-test=ouch', '--amount=5', 'end']
+
+struct Config {
+	mix           bool
+	linker_option string   @[only: m]
+	mix_hard      bool     @[json: muh] // Test that no other attributes get picked up
+	def_test      string = 'def'   @[long: test; short: t]
+	device        []string @[short: d]
+	paths         []string @[tail]
+	amount        int = 1
+	verbosity     int      @[repeats; short: v]
+	show_version  bool     @[long: version]
+	no_long_beef  bool     @[only: n]
+}
+
+struct LongConfig {
+	f            f32
+	mix          bool
+	some_test    string = 'abc' @[long: test]
+	path         string @[tail]
+	amount       int = 1
+	show_version bool   @[long: version]
+}
+
+struct IgnoreConfig {
+	some_test    string = 'abc' @[ignore]
+	path         string @[tail]
+	amount       int = 1
+	show_version bool
+}
+
+fn test_flags() {
+	// Test .short_long parse style
+	config1, _ := flag.to_struct[Config](posix_and_gnu_args_with_subcmd, skip: 1)!
+	assert config1.mix == false
+	assert config1.verbosity == 5
+	assert config1.amount == 8
+	assert config1.def_test == 'def'
+	assert 'one' in config1.device
+	assert 'two' in config1.device
+	assert 'three' in config1.device
+	assert config1.linker_option == 'windows'
+
+	config2, _ := flag.to_struct[Config](posix_and_gnu_args)!
+	assert config2.mix == false
+	assert config2.verbosity == 5
+	assert config2.amount == 8
+	assert config2.def_test == 'def'
+	assert 'one' in config2.device
+	assert 'two' in config2.device
+	assert 'three' in config2.device
+	assert config2.device.len == 3
+	assert config2.linker_option == 'windows'
+
+	mut posix_and_gnu_args_plus_test := posix_and_gnu_args.clone()
+	posix_and_gnu_args_plus_test << ['--test=ok', '-d', 'four']
+	config3, _ := flag.to_struct[Config](posix_and_gnu_args_plus_test)!
+	assert config3.mix == false
+	assert config3.verbosity == 5
+	assert config3.amount == 8
+	assert config3.def_test == 'ok'
+	assert config3.device.len == 4
+	assert 'one' == config3.device[0]
+	assert 'two' == config3.device[1]
+	assert 'three' == config3.device[2]
+	assert 'four' == config3.device[3]
+	assert config3.linker_option == 'windows'
+
+	config4, _ := flag.to_struct[Config](posix_and_gnu_args_with_paths, skip: 1)!
+	assert config4.verbosity == 5
+	assert config4.amount == 8
+	assert config4.def_test == 'def'
+	assert config4.device.len == 3
+	assert 'one' == config4.device[0]
+	assert 'two' == config4.device[1]
+	assert 'three' == config4.device[2]
+	assert config4.linker_option == 'windows'
+	assert config4.paths.len == 2
+	assert config4.paths[0] == '/path/to/a'
+	assert config4.paths[1] == '/path/to/b'
+}
+
+fn test_long_flags() {
+	// Test .long parse style
+	lc1, _ := flag.to_struct[LongConfig](gnu_args, style: .long)!
+	assert lc1.f == 10.2
+	assert lc1.mix == true
+	assert lc1.some_test == 'test'
+	assert lc1.path == 'other'
+	assert lc1.amount == 5
+	assert lc1.show_version == true
+}
+
+fn test_flag_error_messages() {
+	// Test error for GNU long flag in .short (Posix) mode
+	if _, _ := flag.to_struct[Config](posix_and_gnu_args_with_subcmd,
+		skip: 1
+		style: .short
+	)
+	{
+		assert false, 'flags should not have reached this assert'
+	} else {
+		assert err.msg() == 'long delimiter `--` encountered in flag `--device=two` in short (POSIX) style parsing mode'
+	}
+
+	// Test double mapping of flags
+	if _, _ := flag.to_struct[Config](posix_args_error, skip: 1) {
+		assert false, 'flags should not have reached this assert'
+	} else {
+		assert err.msg() == 'flag `-m gnu` is already mapped to field `linker_option` via `-m windows`'
+	}
+
+	for e_num in all_style_enums {
+		// Test no match for non-flag as first arg (usually the `/path/to/executable`) - which must be skipped with `.skip`
+		if _, no_matches := flag.to_struct[Config](posix_and_gnu_args_with_subcmd,
+			style: e_num
+		)
+		{
+			assert no_matches == [0, 1] // index 0 = executable, index 1 = subcmd
+		}
+	}
+
+	for e_num in posix_gnu_style_enums {
+		if _, _ := flag.to_struct[Config](mixed_args, skip: 1, style: e_num) {
+			assert false, 'flags should not have reached this assert'
+		} else {
+			if e_num == .short {
+				assert err.msg() == 'long delimiter `--` encountered in flag `--mix` in short (POSIX) style parsing mode'
+			} else if e_num == .long {
+				assert err.msg() == 'short delimiter `-` encountered in flag `-vv` in long (GNU) style parsing mode'
+			} else {
+				assert err.msg() == 'flag `-m {map: 2, ml-q:"hello"}` is already mapped to field `linker_option` via `-m 2`'
+			}
+			assert true
+		}
+	}
+	if _, no_matches := flag.to_struct[LongConfig](gnu_args_error, style: .long) {
+		assert no_matches == [6]
+	} else {
+		assert false, 'flags should not have reached this assert'
+	}
+
+	if _, _ := flag.to_struct[LongConfig](['--version=1.2.3'], style: .long) {
+		assert false, 'flags should not have reached this assert'
+	} else {
+		assert err.msg() == 'flag `--version=1.2.3` can not be assigned to bool field "show_version"'
+	}
+	if _, no_matches := flag.to_struct[IgnoreConfig](ignore_args_error, style: .long) {
+		assert no_matches == [1]
+	}
+}

--- a/vlib/flag/gnu_style_flags_test.v
+++ b/vlib/flag/gnu_style_flags_test.v
@@ -1,0 +1,58 @@
+// Test .long (GNU) parse style
+import flag
+
+const exe_and_gnu_args = ['/path/to/exe', '--f=10.2', '--mix', '--f2=2', '--test=test', '--amount=5',
+	'--version=1.2.3']
+const exe_and_gnu_args_with_tail = ['/path/to/exe', '--f2=2', '--f=10.2', '--mix', '--test=test',
+	'--amount=6', '--version=1.2.3', '/path/to/x', '/path/to/y', '/path/to/z']
+
+struct Config {
+	f           f32
+	f2          f64
+	mix         bool
+	some_test   string = 'abc' @[long: test]
+	path        string @[tail]
+	amount      int = 1
+	version_str string @[long: version]
+}
+
+fn test_pure_gnu_long() {
+	config, _ := flag.to_struct[Config](exe_and_gnu_args, skip: 1, style: .long)!
+	assert config.f == 10.2
+	assert config.f2 == 2.0
+	assert config.mix == true
+	assert config.some_test == 'test'
+	assert config.path == ''
+	assert config.amount == 5
+	assert config.version_str == '1.2.3'
+}
+
+fn test_pure_gnu_long_no_exe() {
+	config, _ := flag.to_struct[Config](exe_and_gnu_args[1..], style: .long)!
+	assert config.f == 10.2
+	assert config.f2 == 2.0
+	assert config.mix == true
+	assert config.some_test == 'test'
+	assert config.path == ''
+	assert config.amount == 5
+	assert config.version_str == '1.2.3'
+}
+
+fn test_pure_gnu_long_with_tail() {
+	config, no_matches := flag.to_struct[Config](exe_and_gnu_args_with_tail, skip: 1, style: .long)!
+	assert config.path == '/path/to/x'
+	assert exe_and_gnu_args_with_tail[no_matches[0]] == '/path/to/y'
+	assert exe_and_gnu_args_with_tail[no_matches[1]] == '/path/to/z'
+
+	assert config.amount == 6
+}
+
+fn test_pure_gnu_long_with_tail_no_exe() {
+	a := exe_and_gnu_args_with_tail[1..]
+	config, no_matches := flag.to_struct[Config](a, style: .long)!
+	assert config.path == '/path/to/x'
+	assert a[no_matches[0]] == '/path/to/y'
+	assert a[no_matches[1]] == '/path/to/z'
+
+	assert config.amount == 6
+}

--- a/vlib/flag/go_flag_style_flags_test.v
+++ b/vlib/flag/go_flag_style_flags_test.v
@@ -1,0 +1,90 @@
+// Test .v (V) parse style
+import flag
+
+const exe_and_go_flag_args = ['/path/to/exe', '-version', '-d', 'ident=val', '-o', '/path/to',
+	'-test', 'abc', '-done', '-define', 'two', '-live', '--flag', '--flag-value=ok']
+const exe_and_go_flag_args_with_tail = ['/path/to/exe', '-version', '--flag', '--flag-value=ok',
+	'-d', 'ident=val', '-test', 'abc', '-done', '-d', 'two', '-live', 'run', '/path/to']
+
+struct Prefs {
+	flag       bool
+	flag_value string
+	version    bool     @[short: v]
+	is_live    bool     @[long: live]
+	is_done    bool     @[long: done]
+	test       string
+	defines    []string @[long: define; short: d]
+	tail       []string @[tail]
+	out        string   @[only: o]
+	not_mapped string = 'not changed'
+}
+
+fn test_go_flag_style() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_go_flag_args, skip: 1, style: .go_flag)!
+	assert prefs.flag
+	assert prefs.flag_value == 'ok'
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.tail.len == 0
+	assert prefs.out == '/path/to'
+	assert prefs.not_mapped == 'not changed'
+}
+
+fn test_go_flag_style_no_exe() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_go_flag_args[1..], style: .go_flag)!
+	assert prefs.flag
+	assert prefs.flag_value == 'ok'
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.tail.len == 0
+	assert prefs.out == '/path/to'
+	assert prefs.not_mapped == 'not changed'
+}
+
+fn test_go_flag_style_with_tail() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_go_flag_args_with_tail, skip: 1, style: .go_flag)!
+	assert prefs.flag
+	assert prefs.flag_value == 'ok'
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.out == ''
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.tail.len == 2
+	assert prefs.tail[0] == 'run'
+	assert prefs.tail[1] == '/path/to'
+}
+
+fn test_go_flag_style_with_tail_no_exe() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_go_flag_args_with_tail[1..], style: .go_flag)!
+	assert prefs.flag
+	assert prefs.flag_value == 'ok'
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.out == ''
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.tail.len == 2
+	assert prefs.tail[0] == 'run'
+	assert prefs.tail[1] == '/path/to'
+}

--- a/vlib/flag/posix_style_flags_test.v
+++ b/vlib/flag/posix_style_flags_test.v
@@ -1,0 +1,147 @@
+// Test .short (POSIX) parse style
+import flag
+
+const exe_and_posix_args = ['/path/to/exe', '-vv', 'vvv', '-mwindows', '-t', 'abc', '-done', '-d',
+	'two', '-dthree', '-xyz', '2']
+
+const exe_and_posix_args_with_tail = ['/path/to/exe', '-vvv', 'vvv', '-t', 'abc', '-done', '-d',
+	'two', '-dthree', '/path/to/x', '/path/to/y', '/path/to/z']
+
+const posix_multi_short_args_1 = ['-vv', 'vvv', '-done', '-d', 'two', '-yxz2']
+const posix_multi_short_args_2 = ['-vv', 'vvv', '-done', '-d', 'two', '-yxz', '2']
+const posix_multi_short_args_3 = ['-vv', 'vvv', '-xyz', '2', '-done', '-d', 'two']
+const posix_multi_short_args_4 = ['-yxz2', '-vv', 'vvv', '-done', '-d', 'two']
+const posix_multi_short_args_1_err = ['-zxy']
+
+struct Config {
+	linker_option string   @[short: m]
+	test          string = 'def'   @[short: t]
+	device        []string @[short: d]
+	paths         []string @[tail]
+	verbosity     int      @[repeats; short: v]
+	not_mapped    string = 'not changed'
+	x             bool
+	b             bool     @[only: y]
+	u             int      @[short: z]
+}
+
+fn test_pure_posix_short() {
+	config, _ := flag.to_struct[Config](exe_and_posix_args, skip: 1, style: .short)!
+	assert config.verbosity == 5
+	assert config.test == 'abc'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert 'three' in config.device
+	assert config.linker_option == 'windows'
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 0
+	assert config.x
+	assert config.b
+	assert config.u == 2
+}
+
+fn test_pure_posix_multi_short_1() {
+	config, _ := flag.to_struct[Config](posix_multi_short_args_1, style: .short)!
+	assert config.verbosity == 5
+	assert config.test == 'def'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert config.linker_option == ''
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 0
+	assert config.x
+	assert config.b
+	assert config.u == 2
+}
+
+fn test_pure_posix_multi_short_2() {
+	config, _ := flag.to_struct[Config](posix_multi_short_args_2, style: .short)!
+	assert config.verbosity == 5
+	assert config.test == 'def'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert config.linker_option == ''
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 0
+	assert config.x
+	assert config.b
+	assert config.u == 2
+}
+
+fn test_pure_posix_multi_short_3() {
+	config, _ := flag.to_struct[Config](posix_multi_short_args_3, style: .short)!
+	assert config.verbosity == 5
+	assert config.test == 'def'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert config.linker_option == ''
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 0
+	assert config.x
+	assert config.b
+	assert config.u == 2
+}
+
+fn test_pure_posix_multi_short_4() {
+	config, _ := flag.to_struct[Config](posix_multi_short_args_4, style: .short)!
+	assert config.verbosity == 5
+	assert config.test == 'def'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert config.linker_option == ''
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 0
+	assert config.x
+	assert config.b
+	assert config.u == 2
+}
+
+fn test_pure_posix_multi_short_err_1() {
+	if _, _ := flag.to_struct[Config](posix_multi_short_args_1_err, style: .short) {
+		assert false, 'flags should not have reached this assert'
+	} else {
+		assert err.msg() == 'can not assign non-integer value `xy` from flag `-zxy` to `Config.u`'
+	}
+}
+
+fn test_pure_posix_short_no_exe() {
+	config, _ := flag.to_struct[Config](exe_and_posix_args[1..], style: .short)!
+	assert config.verbosity == 5
+	assert config.test == 'abc'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert 'three' in config.device
+	assert config.linker_option == 'windows'
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 0
+}
+
+fn test_pure_posix_short_with_tail() {
+	config, _ := flag.to_struct[Config](exe_and_posix_args_with_tail, skip: 1, style: .short)!
+	assert config.verbosity == 6
+	assert config.test == 'abc'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert 'three' in config.device
+	assert config.linker_option == ''
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 3
+	assert config.paths[0] == '/path/to/x'
+	assert config.paths[1] == '/path/to/y'
+	assert config.paths[2] == '/path/to/z'
+}
+
+fn test_pure_posix_short_with_tail_no_exe() {
+	config, _ := flag.to_struct[Config](exe_and_posix_args_with_tail[1..], style: .short)!
+	assert config.verbosity == 6
+	assert config.test == 'abc'
+	assert 'one' in config.device
+	assert 'two' in config.device
+	assert 'three' in config.device
+	assert config.linker_option == ''
+	assert config.not_mapped == 'not changed'
+	assert config.paths.len == 3
+	assert config.paths[0] == '/path/to/x'
+	assert config.paths[1] == '/path/to/y'
+	assert config.paths[2] == '/path/to/z'
+}

--- a/vlib/flag/v_style_flags_test.v
+++ b/vlib/flag/v_style_flags_test.v
@@ -1,0 +1,80 @@
+// Test .v (V) parse style
+import flag
+
+const exe_and_v_args = ['/path/to/exe', '-version', '-d', 'ident=val', '-o', '/path/to', '-test',
+	'abc', '-done', '-define', 'two', '-live']
+const exe_and_v_args_with_tail = ['/path/to/exe', '-version', '-d', 'ident=val', '-test', 'abc',
+	'-done', '-d', 'two', '-live', 'run', '/path/to']
+
+struct Prefs {
+	version    bool     @[short: v]
+	is_live    bool     @[long: live]
+	is_done    bool     @[long: done]
+	test       string
+	defines    []string @[long: define; short: d]
+	tail       []string @[tail]
+	out        string   @[only: o]
+	not_mapped string = 'not changed'
+}
+
+fn test_pure_v_style() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_v_args, skip: 1, style: .v)!
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.tail.len == 0
+	assert prefs.out == '/path/to'
+	assert prefs.not_mapped == 'not changed'
+}
+
+fn test_pure_v_style_no_exe() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_v_args[1..], style: .v)!
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.tail.len == 0
+	assert prefs.out == '/path/to'
+	assert prefs.not_mapped == 'not changed'
+}
+
+fn test_pure_v_style_with_tail() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_v_args_with_tail, skip: 1, style: .v)!
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.out == ''
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.tail.len == 2
+	assert prefs.tail[0] == 'run'
+	assert prefs.tail[1] == '/path/to'
+}
+
+fn test_pure_v_style_with_tail_no_exe() {
+	prefs, _ := flag.to_struct[Prefs](exe_and_v_args_with_tail[1..], style: .v)!
+	assert prefs.version
+	assert prefs.is_live
+	assert prefs.is_done
+	assert prefs.test == 'abc'
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.defines.len == 2
+	assert prefs.defines[0] == 'ident=val'
+	assert prefs.defines[1] == 'two'
+	assert prefs.out == ''
+	assert prefs.not_mapped == 'not changed'
+	assert prefs.tail.len == 2
+	assert prefs.tail[0] == 'run'
+	assert prefs.tail[1] == '/path/to'
+}


### PR DESCRIPTION
This PR adds the functionality of https://github.com/larpon/flags to vlib's `flag` module.

Making it possible to map different styles of command line flags/options directly to a V `struct` via reflection.
It can also generate (customizable) "usage" documentation from the `struct`.

I've included two examples - one showing how you can make animated usage/help and one which is a small `WYSIWYG` editor, demoing most of the documentation layout features.

The flag styles supported are:
* POSIX (short and repeatable short) `-v`, `-vvv vv`
* GNU (long) `--long` and `--long=value`
* POSIX/GNU (long+short) in combination
* Go `flag` module style `-l`, `-long`, `-long value` + `--long` and `--long=value`
* V style `-l`, `-long`, `-long value`
* CMD.EXE style `/m`, `/M` or `/Moo` (activated by passing `style: .cmd_exe, delimiter: '/'` config params)

Please note that currently the POSIX/GNU style **is the default**.
I've settled on this since the vast majority of command line tools I've worked with use this style combination.
I'm not sure if we should make the V style (or something else) the default instead :shrug: 