### PR TITLE
digital_rain.v: over print to simulate custom font used in movie effect

### DIFF
--- a/examples/gg/digital_rain.v
+++ b/examples/gg/digital_rain.v
@@ -36,7 +36,6 @@ fn main() {
 }
 
 fn rain(mut app App) {
-	// Create the drawing context
 	app.ctx = gg.new_context(
 		bg_color: gx.rgb(0, 0, 0)
 		width: app.screen_size.width
@@ -151,6 +150,8 @@ fn draw_rain_column(rc RainColumn, app App) {
 			}
 			if i < rc.drops.len {
 				app.ctx.draw_text(x, y, rc.drops[i].ascii_str(), cfg)
+				app.ctx.draw_text(x, y, rc.drops[(i + 10) % rc.drops.len].ascii_str(),
+					cfg)
 			} else {
 				vprintln('BAD i: ${i} | rc.drops.len: ${rc.drops.len}')
 			}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
The movie effect uses its own custom font (according to Wikipedia). By accident, I discovered overprinting with a different char produces chars similar to the movie effect (if you squint sideways 😆).