### PR TITLE
sokol: added sampler to the 02_cube code, bugfix: #21547

### DIFF
--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -365,6 +365,7 @@ fn init_cube_glsl(mut app App) {
 	app.cube_bind.vertex_buffers[0] = vbuf
 	app.cube_bind.index_buffer = ibuf
 	app.cube_bind.fs.images[C.SLOT_tex] = app.texture
+	app.cube_bind.fs.samplers[C.SLOT_smp] = app.sampler
 	app.cube_pip_glsl = gfx.make_pipeline(&pipdesc)
 	println('GLSL init DONE!')
 }
@@ -484,8 +485,7 @@ fn frame(mut app App) {
 	y0 := 0
 	y1 := int(f32(dh) * 0.5)
 
-	// app.gg.begin()
-
+	
 	app.gg.begin()
 	{
 		sgl.defaults()
@@ -503,6 +503,7 @@ fn frame(mut app App) {
 		draw_texture_cubes(app)
 	}
 	app.gg.end()
+	
 
 	// glsl cube
 	draw_cube_glsl(app)

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -485,7 +485,6 @@ fn frame(mut app App) {
 	y0 := 0
 	y1 := int(f32(dh) * 0.5)
 
-	
 	app.gg.begin()
 	{
 		sgl.defaults()
@@ -503,7 +502,6 @@ fn frame(mut app App) {
 		draw_texture_cubes(app)
 	}
 	app.gg.end()
-	
 
 	// glsl cube
 	draw_cube_glsl(app)


### PR DESCRIPTION
**What's inside**
- fix bug #21547 for `sokol\02_cubes_glsl` where glsl shader is not running

The new version of sokol seem need an explicit declaration of the sampler to pass ot shader.
Adding the line: `app.cube bind.fs.samplers[C.SLOT_smp] = app.sampler` solve the problem