### PR TITLE
vrepl: fix infix shift operation (fix #13968)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -39,7 +39,6 @@ const repl_folder = os.join_path(os.vtmp_dir(), 'repl')
 const possible_statement_patterns = [
 	'++',
 	'--',
-	'<<',
 	'//',
 	'/*',
 	'assert ',
@@ -461,19 +460,19 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				is_statement = true
 			}
 			if !is_statement && (!func_call || fntype == FnType.fn_type) && r.line != '' {
-				temp_line = 'println(${r.line})'
-				source_code := r.current_source_code(false, false) + '\n${temp_line}\n'
+				print_line := 'println(${r.line})'
+				source_code := r.current_source_code(false, false) + '\n${print_line}\n'
 				os.write_file(temp_file, source_code) or { panic(err) }
 				s := repl_run_vfile(temp_file) or { return 1 }
-				if s.output.len > r.last_output.len {
-					cur_line_output := s.output[r.last_output.len..]
-					print_output(cur_line_output)
-					if s.exit_code == 0 {
+				if s.exit_code == 0 {
+					if s.output.len > r.last_output.len {
+						cur_line_output := s.output[r.last_output.len..]
+						print_output(cur_line_output)
 						r.last_output = s.output.clone()
-						r.lines << temp_line
+						r.lines << print_line
 					}
+					continue
 				}
-				continue
 			}
 			mut temp_source_code := ''
 			if temp_line.starts_with('import ') {

--- a/vlib/v/slow_tests/repl/error_and_continue_print.repl
+++ b/vlib/v/slow_tests/repl/error_and_continue_print.repl
@@ -7,9 +7,9 @@ error: undefined ident: `a` (use `:=` to declare a variable)
     6 | 
     7 | a = 3
       | ^
-error: undefined ident: `b`
+error: `b` evaluated but not used
     5 | import math
     6 | 
-    7 | println(b)
-      |         ^
+    7 | b
+      | ^
 [4]

--- a/vlib/v/slow_tests/repl/error_exitasdfasdf.repl
+++ b/vlib/v/slow_tests/repl/error_exitasdfasdf.repl
@@ -1,7 +1,7 @@
 exitasdfasdf
 ===output===
-error: undefined ident: `exitasdfasdf`
+error: `exitasdfasdf` evaluated but not used
     5 | import math
     6 | 
-    7 | println(exitasdfasdf)
-      |         ~~~~~~~~~~~~
+    7 | exitasdfasdf
+      | ~~~~~~~~~~~~

--- a/vlib/v/slow_tests/repl/infix_shift_op.repl
+++ b/vlib/v/slow_tests/repl/infix_shift_op.repl
@@ -1,0 +1,17 @@
+4 >> 1
+4 << 1
+println(4 >> 1)
+println(4 << 1)
+typeof(4 >> 1).name
+typeof(4 << 1).name
+println(typeof(4 >> 1).name)
+println(typeof(4 << 1).name)
+===output===
+2
+8
+2
+8
+int literal
+int literal
+int literal
+int literal


### PR DESCRIPTION
This PR fix infix shift operation (fix #13968).

- Fix infix shift operation in vrepl.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 65966ae . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> 4 >> 1
2
>>> 4 << 1
8
>>> println(4 << 1)
8
>>> typeof(4 >> 1).name
int literal
>>> typeof(4 << 1).name
int literal
>>> 
```