### PR TITLE
docs: add missing @ on export attributes

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -7443,7 +7443,7 @@ By default all V functions have the following naming scheme in C: `[module name]
 
 For example, `fn foo() {}` in module `bar` will result in `bar__foo()`.
 
-To use a custom export name, use the `[export]` attribute:
+To use a custom export name, use the `@[export]` attribute:
 
 ```
 @[export: 'my_custom_c_name']

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -549,7 +549,7 @@ pub:
 	is_main               bool        // true for `fn main()`
 	is_test               bool        // true for `fn test_abcde() {}`, false for `fn test_abc(x int) {}`, or for fns that do not start with test_
 	is_conditional        bool        // true for `[if abc] fn abc(){}`
-	is_exported           bool        // true for `[export: 'exact_C_name']`
+	is_exported           bool        // true for `@[export: 'exact_C_name']`
 	is_keep_alive         bool        // passed memory must not be freed (by GC) before function returns
 	is_unsafe             bool        // true, when [unsafe] is used on a fn
 	is_markused           bool        // true, when an explicit `[markused]` tag was put on a fn; `-skip-unused` will not remove that fn

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -68,17 +68,17 @@ see also `v help build`.
          bare_panic(msg string)
             Print "V panic: " + msg, along with an optional backtrace
             and/or the V commit hash, and then exit.
-         [export: 'malloc']
+         @[export: 'malloc']
          __malloc(n usize) &C.void
             Allocates n bytes of memory and returns the pointer to the first
             byte.
-         [export: 'free']
+         @[export: 'free']
          __free(ptr &C.void)
             Free the block of memory ptr allocated by malloc.
          realloc(old_area &C.void, new_size usize) &C.void
             Allocates a new area of size new_size, copies old_area
             to the new area, and returns a pointer to the new area.
-         [export: 'calloc']
+         @[export: 'calloc']
          __calloc(nmemb usize, size usize) &C.void
             Like malloc, but sets all the bytes to `0` first.
          memcpy(dest &C.void, src &C.void, n usize) &C.void
@@ -102,7 +102,7 @@ see also `v help build`.
          bare_backtrace() string
             Return a backtrace that can be printed. If backtraces are not
             supported, return a message stating that backtraces do not work.
-         [export: 'exit']
+         @[export: 'exit']
          __exit(code int)
             Exit with code code. code is allowed to be ignored.
 


### PR DESCRIPTION
Noticed a few places where `@` was missing from `@[export]` attributes in docs/help and one comment.