### PR TITLE
cgen: fix option string struct member init with autofree

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -640,7 +640,7 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 	mut cloned := false
 	if g.is_autofree && !sfield.typ.is_ptr() && field_type_sym.kind in [.array, .string] {
 		g.write('/*clone1*/')
-		if g.gen_clone_assignment(sfield.typ, sfield.expr, sfield.typ, false) {
+		if g.gen_clone_assignment(sfield.expected_type, sfield.expr, sfield.typ, false) {
 			cloned = true
 		}
 	}

--- a/vlib/v/gen/c/testdata/assigning_and_printing_struct_with_optional_field.out
+++ b/vlib/v/gen/c/testdata/assigning_and_printing_struct_with_optional_field.out
@@ -1,0 +1,5 @@
+autofree is on
+SomeStruct{
+    val: 0
+    arg: Option('xyz')
+}

--- a/vlib/v/gen/c/testdata/assigning_and_printing_struct_with_optional_field.vv
+++ b/vlib/v/gen/c/testdata/assigning_and_printing_struct_with_optional_field.vv
@@ -1,0 +1,14 @@
+// vtest vflags: -autofree
+struct SomeStruct {
+	val int
+	arg ?string
+}
+
+x := 'xyz'
+s := SomeStruct{
+	arg: x
+}
+$if autofree {
+	println('autofree is on')
+}
+println(s)


### PR DESCRIPTION
Fix #21849