### PR TITLE
vrepl: fix error of undefined ident (related #21855)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -472,6 +472,14 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 						r.lines << print_line
 					}
 					continue
+				} else {
+					if s.output.len > r.last_output.len {
+						cur_line_output := s.output[r.last_output.len..]
+						if cur_line_output.contains('undefined ident:') {
+							print_output(cur_line_output)
+							continue
+						}
+					}
 				}
 			}
 			mut temp_source_code := ''

--- a/vlib/v/slow_tests/repl/error_and_continue_print.repl
+++ b/vlib/v/slow_tests/repl/error_and_continue_print.repl
@@ -7,9 +7,9 @@ error: undefined ident: `a` (use `:=` to declare a variable)
     6 | 
     7 | a = 3
       | ^
-error: `b` evaluated but not used
+error: undefined ident: `b`
     5 | import math
     6 | 
-    7 | b
-      | ^
+    7 | println(b)
+      |         ^
 [4]

--- a/vlib/v/slow_tests/repl/error_exitasdfasdf.repl
+++ b/vlib/v/slow_tests/repl/error_exitasdfasdf.repl
@@ -1,7 +1,7 @@
 exitasdfasdf
 ===output===
-error: `exitasdfasdf` evaluated but not used
+error: undefined ident: `exitasdfasdf`
     5 | import math
     6 | 
-    7 | exitasdfasdf
-      | ~~~~~~~~~~~~
+    7 | println(exitasdfasdf)
+      |         ~~~~~~~~~~~~


### PR DESCRIPTION
This PR fix error of undefined ident (related #21855).

- Fix error of undefined ident.
- Modify the related tests.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 c2f7afd . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> exitasdfasdf
error: undefined ident: `exitasdfasdf`
    5 | import math
    6 |
    7 | println(exitasdfasdf)
      |         ~~~~~~~~~~~~
>>> 
```