### PR TITLE
cgen: fix generic type init syntax for primitive types 

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -148,7 +148,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			}
 		}
 		inited_fields[field_name] = i
-		if sym.kind != .struct_ {
+		if sym.kind != .struct_ && (sym.kind == .string || !sym.is_primitive()) {
 			if init_field.typ == 0 {
 				g.checker_bug('struct init, field.typ is 0', init_field.pos)
 			}

--- a/vlib/v/tests/generic_init_syntax_test.v
+++ b/vlib/v/tests/generic_init_syntax_test.v
@@ -1,0 +1,14 @@
+type Int = int
+type MyIndex = struct {
+	Int Int
+}
+
+fn func[I]() I {
+	return I{0}
+}
+
+fn test_main() {
+	assert func[f64]() == 0.0
+	assert func[int]() == 0
+	assert func[bool]() == false
+}


### PR DESCRIPTION
Fix #17028