### PR TITLE
checker: check mismatch of fn call mut argument (fix #21857)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -249,6 +249,12 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 			}
 		}
 
+		// `fn foo(mut p &Expr); mut expr := Expr{}; foo(mut expr)`
+		if expected.nr_muls() > 1 && arg.is_mut && !got.is_ptr() {
+			got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
+			return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
+		}
+
 		exp_sym_idx := c.table.sym(expected).idx
 		got_sym_idx := c.table.sym(got).idx
 

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -250,7 +250,7 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 		}
 
 		// `fn foo(mut p &Expr); mut expr := Expr{}; foo(mut expr)`
-		if expected.nr_muls() > 1 && arg.is_mut && !got.is_ptr() {
+		if arg.is_mut && expected.nr_muls() > 1 && !got.is_ptr() {
 			got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
 			return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
 		}

--- a/vlib/v/checker/tests/fn_call_mut_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_mut_arg_mismatch_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/fn_call_mut_arg_mismatch_err.vv:15:10: error: cannot use `Expr1` as `&&Expr1` in argument 1 to `foo`
+   13 |         name: '123'
+   14 |     }
+   15 |     foo(mut expr)
+      |             ~~~~
+   16 | }

--- a/vlib/v/checker/tests/fn_call_mut_arg_mismatch_err.vv
+++ b/vlib/v/checker/tests/fn_call_mut_arg_mismatch_err.vv
@@ -1,0 +1,16 @@
+module main
+
+pub struct Expr1 {
+	name string
+}
+
+fn foo(mut expr &Expr1) { // <---- &
+	println(expr.name)
+}
+
+fn main() {
+	mut expr := Expr1{
+		name: '123'
+	}
+	foo(mut expr)
+}


### PR DESCRIPTION
This PR check mismatch of fn call mut argument (fix #21857).

- Check mismatch of fn call mut argument.
- Add test.

```v
module main

pub struct Expr1 {
	name string
}

fn foo(mut expr &Expr1) { // <---- &
	println(expr.name)
}

fn main() {
	mut expr := Expr1{
		name: '123'
	}
	foo(mut expr)
}

PS D:\Test\v\tt1> v run .
tt1.v:15:10: error: cannot use `Expr1` as `&&Expr1` in argument 1 to `foo`
   13 |         name: '123'
   14 |     }
   15 |     foo(mut expr)
      |             ~~~~
   16 | }
```