### PR TITLE
vrepl: fix structure definition

### DIFF
--- a/vlib/v/slow_tests/repl/struct_def_later.repl
+++ b/vlib/v/slow_tests/repl/struct_def_later.repl
@@ -1,0 +1,28 @@
+mut name := 'foo1'
+pub	struct	Info1 {
+name string
+}
+info1 := Info1{name}
+info1
+name = 'foo2'
+struct Info2 {
+name string
+}
+info2 := Info2{name}
+info2
+name = 'foo3'
+struct		Info3 {
+name string
+}
+info3 := Info3{name}
+info3
+===output===
+Info1{
+    name: 'foo1'
+}
+Info2{
+    name: 'foo2'
+}
+Info3{
+    name: 'foo3'
+}


### PR DESCRIPTION
This PR fix structure definition in vrepl.

- Fix structure definition.
- Add test.

before:
```v
yuyi@yuyi-PC:~/v$ v
 ____    ____ 
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor, 
   \      /    |  save your code in a  main.v  file and execute:  v run main.v 
    \    /     |  V 0.4.6 615a9a0 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut name := 'foo1'
>>> pub struct Info1 {
... name string
... }
notice: script mode started here
    5 | import math
    6 | 
    7 | mut name := 'foo1'
      | ~~~
    8 | pub struct Info1 {
    9 |
error: all definitions must occur before code in script mode
    6 | 
    7 | mut name := 'foo1'
    8 | pub struct Info1 {
      | ~~~
    9 | 
   10 | name string
>>> 
```

now:
```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 9088970 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut name := 'foo1'
>>> pub         struct          Info1 {
... name string
... }
>>> info1 := Info1{name}
>>> info1
Info1{
    name: 'foo1'
}
>>> struct      Info2 {
... name string
... }
>>> name = 'foo2'
>>> info2 := Info2{name}
>>> info2
Info2{
    name: 'foo2'
}
>>>
```