### PR TITLE
v.builder: improve the C compilation output on cgen errors

### DIFF
--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -377,9 +377,9 @@ pub fn (mut v Builder) cc_msvc() {
 	}
 	util.timing_measure('C msvc')
 	if v.pref.show_c_output {
-		v.show_c_compiler_output(res)
+		v.show_c_compiler_output(r.full_cl_exe_path, res)
 	} else {
-		v.post_process_c_compiler_output(res)
+		v.post_process_c_compiler_output(r.full_cl_exe_path, res)
 	}
 	// println(res)
 	// println('C OUTPUT:')


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b18c2ae7-cdf2-4b57-bc40-bd7d23d7adb2)

After:
![image](https://github.com/user-attachments/assets/ccbc7c0c-a2dc-40a2-956a-c881f38336cc)
