### PR TITLE
vrepl: fix enum and interface declarations

### DIFF
--- a/vlib/v/slow_tests/repl/enum.repl
+++ b/vlib/v/slow_tests/repl/enum.repl
@@ -1,0 +1,18 @@
+mut age := 20
+enum Info {
+young
+old
+}
+fn get_info(age int) Info {
+if age < 25 {
+return .young
+} else {
+return .old
+}
+}
+get_info(age)
+age = 45
+get_info(age)
+===output===
+young
+old

--- a/vlib/v/slow_tests/repl/interface.repl
+++ b/vlib/v/slow_tests/repl/interface.repl
@@ -1,0 +1,17 @@
+name := 'hello'
+interface Foo {
+get_name() string
+}
+struct Bar {
+name string
+}
+fn (bar Bar) get_name() string {
+return bar.name
+}
+fn get_name(foo Foo) string {
+return foo.get_name()
+}
+bar := Bar{name}
+get_name(bar)
+===output===
+hello


### PR DESCRIPTION
This PR fix enum and interface declarations in vrepl.

- Fix enum and interface declarations.
- Add tests.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 adb85e0 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut age := 22
>>> enum Info {
... young
... old
... }
>>> fn get_info(age int) Info {
... if age < 25 {
... return .young
... } else {
... return .old
... }
... }
>>> get_info(age)
young
>>> age = 45
>>> get_info(age)
old
>>>
```
```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 adb85e0 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> name := 'hello'
>>> interface Foo {
... get_name() string
... }
>>> struct Bar {
... name string
... }
>>> fn (b Bar) get_name() string {
... return b.name
... }
>>> fn get_name(foo Foo) string {
... return foo.get_name()
... }
>>> bar := Bar{name}
>>> get_name(bar)
hello
>>>
```