### PR TITLE
vrepl: fix const declaration and single line struct/enum/interface

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -31,6 +31,7 @@ mut:
 	functions_name  []string // all the user function names
 	structs         []string // all the struct definitions
 	enums           []string // all the enum definitions
+	consts          []string // all the const definitions
 	interfaces      []string // all the interface definitions
 	lines           []string // all the other lines/statements
 	temp_lines      []string // all the temporary expressions/printlns
@@ -203,6 +204,7 @@ fn (r &Repl) current_source_code(should_add_temp_lines bool, not_add_print bool)
 	}
 	all_lines << r.includes
 	all_lines << r.enums
+	all_lines << r.consts
 	all_lines << r.structs
 	all_lines << r.interfaces
 	all_lines << r.functions
@@ -343,6 +345,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 	}
 	mut r := new_repl(workdir)
 	mut pub_fn_or_fn_regex := regex.regex_opt(r'^(pub\s+)?fn\s') or { panic(err) }
+	mut pub_const_or_const_regex := regex.regex_opt(r'^(pub\s+)?const\s') or { panic(err) }
 	mut pub_struct_or_struct_regex := regex.regex_opt(r'^(pub\s+)?struct\s') or { panic(err) }
 	mut pub_enum_or_enum_regex := regex.regex_opt(r'^(pub\s+)?enum\s') or { panic(err) }
 	mut pub_interface_or_interface_regex := regex.regex_opt(r'^(pub\s+)?interface\s') or {
@@ -387,29 +390,36 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 		}
 
 		start_fn, _ := pub_fn_or_fn_regex.match_string(r.line)
-		if start_fn >= 0 {
+		starts_with_fn := start_fn >= 0
+		if starts_with_fn {
 			r.in_func = true
 			r.functions_name << r.line.all_after('fn').all_before('(').trim_space()
 		}
 		was_func := r.in_func
 
 		start_struct, _ := pub_struct_or_struct_regex.match_string(r.line)
-		if start_struct >= 0 {
+		starts_with_struct := start_struct >= 0
+		if starts_with_struct {
 			r.in_struct = true
 		}
 		was_struct := r.in_struct
 
 		start_enum, _ := pub_enum_or_enum_regex.match_string(r.line)
-		if start_enum >= 0 {
+		starts_with_enum := start_enum >= 0
+		if starts_with_enum {
 			r.in_enum = true
 		}
 		was_enum := r.in_enum
 
 		start_interface, _ := pub_interface_or_interface_regex.match_string(r.line)
-		if start_interface >= 0 {
+		starts_with_interface := start_interface >= 0
+		if starts_with_interface {
 			r.in_interface = true
 		}
 		was_interface := r.in_interface
+
+		start_const, _ := pub_const_or_const_regex.match_string(r.line)
+		starts_with_const := start_const >= 0
 
 		if r.checks() {
 			for rline in r.line.split('\n') {
@@ -533,7 +543,8 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				}
 			} else if temp_line.starts_with('#include ') {
 				temp_source_code = '${temp_line}\n' + r.current_source_code(false, false)
-			} else if temp_line.starts_with('fn ') {
+			} else if starts_with_fn || starts_with_const || starts_with_enum || starts_with_struct
+				|| starts_with_interface {
 				temp_source_code = r.current_source_code(false, false)
 			} else {
 				temp_source_code = r.current_source_code(true, false) + '\n${temp_line}\n'
@@ -547,8 +558,16 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 					r.parse_import(r.line)
 				} else if r.line.starts_with('#include ') {
 					r.includes << r.line
-				} else if r.line.starts_with('fn ') {
+				} else if starts_with_fn {
 					r.functions << r.line
+				} else if starts_with_const {
+					r.consts << r.line
+				} else if starts_with_enum {
+					r.enums << r.line
+				} else if starts_with_struct {
+					r.structs << r.line
+				} else if starts_with_interface {
+					r.interfaces << r.line
 				} else {
 					r.lines << r.line
 				}

--- a/vlib/v/slow_tests/repl/const.repl
+++ b/vlib/v/slow_tests/repl/const.repl
@@ -1,0 +1,6 @@
+mut a := [1, 2]
+pub const b = 3
+a << b
+a
+===output===
+[1, 2, 3]


### PR DESCRIPTION
This PR fix const declaration and single line struct/enum/interface.

- Fix const declaration and single line struct/enum/interface.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 e9652f8 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut a := [1, 2]
>>> pub const b = 3
>>> a << b
>>> a
[1, 2, 3]
>>> 
```