### PR TITLE
flag, examples: add `compact` to `flag.DocOptions`

### DIFF
--- a/examples/flag/flag_layout_editor.v
+++ b/examples/flag/flag_layout_editor.v
@@ -36,6 +36,8 @@ enum Edit {
 	description_padding
 	description_width
 	flag_indent
+	// DocOptions.compact
+	compact
 	// DocOptions.show flags
 	name
 	version
@@ -56,6 +58,9 @@ pub fn (e Edit) next() Edit {
 			.flag_indent
 		}
 		.flag_indent {
+			.compact
+		}
+		.compact {
 			.name
 		}
 		.name {
@@ -124,6 +129,9 @@ fn event(e &tui.Event, mut app App) {
 			.description_width {
 				app.layout.description_width += incr_decr
 			}
+			.compact {
+				app.options.compact = !app.options.compact
+			}
 			.name {
 				app.options.show.toggle(.name)
 			}
@@ -164,6 +172,9 @@ fn frame(mut app App) {
 		}
 		.description_width {
 			'${app.layout.description_width}'
+		}
+		.compact {
+			if app.options.compact { 'on' } else { 'off' }
 		}
 		.name {
 			if app.options.show.has(.name) { 'on' } else { 'off' }

--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -115,7 +115,8 @@ pub mut:
 pub struct DocOptions {
 pub mut:
 	flag_header string = '\nOptions:'
-	show        Show   = ~Show.zero()
+	compact     bool
+	show        Show = ~Show.zero()
 }
 
 // max_width returns the total width of the `DocLayout`.
@@ -732,12 +733,20 @@ pub fn (fm FlagMapper) fields_docs(dc DocConfig) ![]string {
 		flag_line_diff := flag_line.len - pad_desc
 		if flag_line_diff < 0 {
 			diff := -flag_line_diff
-			docs << flag_line + ' '.repeat(diff) +
-				keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') + '\n'
+			mut line := flag_line + ' '.repeat(diff) +
+				keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}')
+			if !dc.options.compact {
+				line += '\n'
+			}
+			docs << line
 		} else {
 			docs << flag_line
-			docs << empty_padding + keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') +
-				'\n'
+			mut line := empty_padding +
+				keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}')
+			if !dc.options.compact {
+				line += '\n'
+			}
+			docs << line
 		}
 	}
 	// Look for custom flag entries starting with delimiter
@@ -746,12 +755,20 @@ pub fn (fm FlagMapper) fields_docs(dc DocConfig) ![]string {
 			flag_line_diff := entry.len - pad_desc + indent_flags
 			if flag_line_diff < 0 {
 				diff := -flag_line_diff
-				docs << indent_flags_padding + entry.trim(' ') + ' '.repeat(diff) +
-					keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') + '\n'
+				mut line := indent_flags_padding + entry.trim(' ') + ' '.repeat(diff) +
+					keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}')
+				if !dc.options.compact {
+					line += '\n'
+				}
+				docs << line
 			} else {
 				docs << indent_flags_padding + entry.trim(' ')
-				docs << empty_padding +
-					keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}') + '\n'
+				mut line := empty_padding +
+					keep_at_max(doc, desc_max).replace('\n', '\n${empty_padding}')
+				if !dc.options.compact {
+					line += '\n'
+				}
+				docs << line
 			}
 		}
 	}


### PR DESCRIPTION
This adds an option to let the flag output be compact, which resembles how the `FlagParser` renders it's flags.

Compact mode `false` (default):
![image](https://github.com/user-attachments/assets/81dc9fbe-30e3-4122-8c31-7bc0d381305d)
Compact mode `true`:
![image](https://github.com/user-attachments/assets/2bdb757c-f9d4-4446-997a-d8e3eabb5b07)
