### PR TITLE
vrepl: fix type declaration

### DIFF
--- a/vlib/v/slow_tests/repl/type_decl.repl
+++ b/vlib/v/slow_tests/repl/type_decl.repl
@@ -1,0 +1,6 @@
+a := 1
+pub		type	Int = int
+b := Int(a)
+b
+===output===
+1


### PR DESCRIPTION
This PR fix type declaration in vrepl.

- Fix type declaration in vrepl.
- Add test.
- Optimize with starts_with_type_decl().

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 6d3a2ac . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut a := 22
>>> pub         type Int = int
>>> b := Int(a)
>>> b
22
>>> 
```