### PR TITLE
cgen: fix optional closure direct call (fix #21165)

### DIFF
--- a/vlib/v/tests/closure_option_direct_call_test.v
+++ b/vlib/v/tests/closure_option_direct_call_test.v
@@ -1,0 +1,8 @@
+fn test_closure_option_direct_call() {
+	tmp_wd := 'aaa'
+	b := fn [tmp_wd] () !string {
+		return tmp_wd
+	}() or { panic(err) }
+	println(b)
+	assert b == 'aaa'
+}


### PR DESCRIPTION
This PR fix optional closure direct call (fix #21165).

- Fix optional closure direct call.
- Add test.

```v
fn main() {
	tmp_wd := 'aaa'
	b := fn [tmp_wd] () !string {
		return tmp_wd
	}() or { panic(err) }
	println(b)
	assert b == 'aaa'
}

PS D:\Test\v\tt1> v run .
aaa
```