### PR TITLE
vrepl: fix handling of single-line type declaration syntax errors

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -71,6 +71,16 @@ enum FnType {
 	fn_type
 }
 
+enum DeclType {
+	include_ // #include ...
+	const_ // const ...
+	type_ // type ...
+	enum_ // enum ...
+	fn_ // fn ...
+	struct_ // struct ...
+	interface_ // interface ...
+}
+
 fn new_repl(folder string) Repl {
 	vstartup_source := os.read_file(vstartup) or { '' }.trim_right('\n\r').split_into_lines()
 	os.mkdir_all(folder) or {}
@@ -227,6 +237,45 @@ fn (r &Repl) current_source_code(should_add_temp_lines bool, not_add_print bool)
 	if should_add_temp_lines {
 		all_lines << r.temp_lines
 	}
+	return all_lines.join('\n')
+}
+
+fn (r &Repl) insert_source_code(typ DeclType, line string) string {
+	mut all_lines := r.import_to_source_code()
+
+	if vstartup != '' {
+		mut lines := r.vstartup_lines.filter(!it.starts_with('print'))
+		all_lines << lines
+	}
+	all_lines << r.includes
+	if typ == .include_ {
+		all_lines << line
+	}
+	all_lines << r.types
+	if typ == .type_ {
+		all_lines << line
+	}
+	all_lines << r.enums
+	if typ == .enum_ {
+		all_lines << line
+	}
+	all_lines << r.consts
+	if typ == .const_ {
+		all_lines << line
+	}
+	all_lines << r.structs
+	if typ == .struct_ {
+		all_lines << line
+	}
+	all_lines << r.interfaces
+	if typ == .interface_ {
+		all_lines << line
+	}
+	all_lines << r.functions
+	if typ == .fn_ {
+		all_lines << line
+	}
+	all_lines << r.lines
 	return all_lines.join('\n')
 }
 
@@ -421,9 +470,6 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 		}
 		was_interface := r.in_interface
 
-		starts_with_const := starts_with_type_decl(r.line, 'const')
-		starts_with_type := starts_with_type_decl(r.line, 'type')
-
 		if r.checks() {
 			for rline in r.line.split('\n') {
 				if r.in_func || was_func {
@@ -491,7 +537,6 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 				r.lines << trans_line
 			}
 		} else {
-			mut temp_line := r.line
 			func_call, fntype := r.function_call(r.line)
 			filter_line := r.line.replace(r.line.find_between("'", "'"), '').replace(r.line.find_between('"',
 				'"'), '')
@@ -515,6 +560,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			if r.line.count('(') != r.line.count(')') {
 				is_statement = true
 			}
+
 			if !is_statement && (!func_call || fntype == FnType.fn_type) && r.line != '' {
 				print_line := 'println(${r.line})'
 				source_code := r.current_source_code(false, false) + '\n${print_line}\n'
@@ -538,28 +584,44 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 					}
 				}
 			}
+
+			starts_with_const := starts_with_type_decl(r.line, 'const')
+			starts_with_type := starts_with_type_decl(r.line, 'type')
+			starts_with_import := r.line.starts_with('import ') || r.line.starts_with('import\t')
+			starts_with_include := r.line.starts_with('#include ')
+				|| r.line.starts_with('#include\t')
 			mut temp_source_code := ''
-			if temp_line.starts_with('import ') {
+
+			if starts_with_import {
 				mod := r.line.fields()[1]
 				if mod !in r.modules {
-					temp_source_code = '${temp_line}\n' + r.current_source_code(false, true)
+					temp_source_code = '${r.line}\n' + r.current_source_code(false, true)
 				}
-			} else if temp_line.starts_with('#include ') {
-				temp_source_code = '${temp_line}\n' + r.current_source_code(false, false)
-			} else if starts_with_fn || starts_with_const || starts_with_enum || starts_with_struct
-				|| starts_with_interface || starts_with_type {
-				temp_source_code = r.current_source_code(false, false)
+			} else if starts_with_include {
+				temp_source_code = r.insert_source_code(DeclType.include_, r.line)
+			} else if starts_with_fn {
+				temp_source_code = r.insert_source_code(DeclType.fn_, r.line)
+			} else if starts_with_const {
+				temp_source_code = r.insert_source_code(DeclType.const_, r.line)
+			} else if starts_with_enum {
+				temp_source_code = r.insert_source_code(DeclType.enum_, r.line)
+			} else if starts_with_struct {
+				temp_source_code = r.insert_source_code(DeclType.struct_, r.line)
+			} else if starts_with_interface {
+				temp_source_code = r.insert_source_code(DeclType.interface_, r.line)
+			} else if starts_with_type {
+				temp_source_code = r.insert_source_code(DeclType.type_, r.line)
 			} else {
-				temp_source_code = r.current_source_code(true, false) + '\n${temp_line}\n'
+				temp_source_code = r.current_source_code(true, false) + '\n${r.line}\n'
 			}
 			os.write_file(temp_file, temp_source_code) or { panic(err) }
 			s := repl_run_vfile(temp_file) or { return 1 }
 			if s.exit_code == 0 {
 				r.lines << r.temp_lines
 				r.temp_lines.clear()
-				if r.line.starts_with('import ') {
+				if starts_with_import {
 					r.parse_import(r.line)
-				} else if r.line.starts_with('#include ') {
+				} else if starts_with_include {
 					r.includes << r.line
 				} else if starts_with_fn {
 					r.functions << r.line

--- a/vlib/v/slow_tests/repl/error_single_line_fn_decl.repl
+++ b/vlib/v/slow_tests/repl/error_single_line_fn_decl.repl
@@ -1,0 +1,10 @@
+mut a := [1, 2]
+fn foo[int](a int) { print('hello') }
+===output===
+error: generic parameter needs to be uppercase
+    5 | import math
+    6 | 
+    7 | fn foo[int](a int) {
+      |        ~~~
+    8 |  print('hello') 
+    9 | }


### PR DESCRIPTION
This PR fix handling of single-line type declaration syntax errors.

- Fix handling of single-line type declaration syntax errors.
- Add a test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 a7db095 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut a := [1, 2]
>>> fn foo[int](a int) { print('hello') }
error: generic parameter needs to be uppercase
    5 | import math
    6 |
    7 | fn foo[int](a int) {
      |        ~~~
    8 |  print('hello')
    9 | }
>>> fn foo(a int) { print('hello') }
>>> foo(a)
error: cannot use `[]int` as `int` in argument 1 to `foo`
    9 | }
   10 | mut a := [1, 2]
   11 | foo(a)
      |     ^
>>> foo(22)
hello
>>>
```