### PR TITLE
cgen: fix wrong missing unsafe block checking when calling generic functions with @[unsafe] attr

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -49,7 +49,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	c.fn_level++
 	c.in_for_count = 0
 	c.inside_defer = false
-	c.inside_unsafe = false
+	c.inside_unsafe = node.is_unsafe
 	c.returns = false
 	defer {
 		c.stmt_level = prev_stmt_level

--- a/vlib/v/checker/tests/unsafe_generic_call_test.out
+++ b/vlib/v/checker/tests/unsafe_generic_call_test.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/unsafe_generic_call_test.vv:1:1: error: a _test.v file should have *at least* one `test_` function
+    1 | module main
+      | ^
+    2 | 
+    3 | import arrays
+Details: The name of a test function in V, should start with `test_`.
+The test function should take 0 parameters, and no return type. Example:
+fn test_xyz(){ assert 2 + 2 == 4 }

--- a/vlib/v/checker/tests/unsafe_generic_call_test.out
+++ b/vlib/v/checker/tests/unsafe_generic_call_test.out
@@ -1,8 +1,1 @@
-vlib/v/checker/tests/unsafe_generic_call_test.vv:1:1: error: a _test.v file should have *at least* one `test_` function
-    1 | module main
-      | ^
-    2 | 
-    3 | import arrays
-Details: The name of a test function in V, should start with `test_`.
-The test function should take 0 parameters, and no return type. Example:
-fn test_xyz(){ assert 2 + 2 == 4 }
+[&Blah{}]

--- a/vlib/v/checker/tests/unsafe_generic_call_test.vv
+++ b/vlib/v/checker/tests/unsafe_generic_call_test.vv
@@ -4,7 +4,7 @@ import arrays
 
 struct Blah {}
 
-fn main() {
+fn test_main() {
 	pointers := [&int(1234)]
 	length := 1
 	array := unsafe { arrays.carray_to_varray[&Blah](pointers, length) }

--- a/vlib/v/checker/tests/unsafe_generic_call_test.vv
+++ b/vlib/v/checker/tests/unsafe_generic_call_test.vv
@@ -1,0 +1,12 @@
+module main
+
+import arrays
+
+struct Blah {}
+
+fn main() {
+	pointers := [&int(1234)]
+	length := 1
+	array := unsafe { arrays.carray_to_varray[&Blah](pointers, length) }
+	println(array)
+}


### PR DESCRIPTION
Fix #21893