### PR TITLE
vrepl: fix handling of multi-line type declaration syntax errors

### DIFF
--- a/vlib/v/slow_tests/repl/error_multi_line_fn_decl.repl
+++ b/vlib/v/slow_tests/repl/error_multi_line_fn_decl.repl
@@ -1,0 +1,20 @@
+mut a := 22
+fn test() {
+aaa
+}
+fn print_info(n int) {
+println('${n}')
+}
+print_info(a)
+a = 11
+print_info(a)
+===output===
+error: `aaa` evaluated but not used
+    7 | fn test() {
+    8 | 
+    9 | aaa
+      | ~~~
+   10 | 
+   11 | }
+22
+11


### PR DESCRIPTION
This PR fix handling of multi-line type declaration syntax errors.

- Fix handling of multi-line type declaration syntax errors.
- Add test.

```v
PS D:\Vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.6 5486f0b . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> mut a := 22
>>> fn test() {
... aaa
... }
error: `aaa` evaluated but not used
    7 | fn test() {
    8 |
    9 | aaa
      | ~~~
   10 |
   11 | }
>>> fn print_info(a int) {
... println('${a}')
... }
>>> print_info(a)
22
>>> a = 11
>>> print_info(a)
11
>>> 
```