### PR TITLE
cgen: fix enum field with const value (fix #21916) 

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -561,6 +561,14 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	}
 	b.writeln('\n// V includes:')
 	b.write_string(g.includes.str())
+	b.writeln('\n// V global/const #define ... :')
+	for var_name in g.sorted_global_const_names {
+		if var := g.global_const_defs[var_name] {
+			if var.def.starts_with('#define') {
+				b.writeln(var.def)
+			}
+		}
+	}
 	b.writeln('\n// Enum definitions:')
 	b.write_string(g.enum_typedefs.str())
 	b.writeln('\n// Thread definitions:')
@@ -579,10 +587,12 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	b.write_string(g.json_forward_decls.str())
 	b.writeln('\n// V definitions:')
 	b.write_string(g.definitions.str())
-	b.writeln('\n// V global/const definitions:')
+	b.writeln('\n// V global/const non-precomputed definitions:')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
-			b.writeln(var.def)
+			if !var.def.starts_with('#define') {
+				b.writeln(var.def)
+			}
 		}
 	}
 	interface_table := g.interface_table()

--- a/vlib/v/tests/enum_with_const_test.v
+++ b/vlib/v/tests/enum_with_const_test.v
@@ -1,0 +1,19 @@
+enum Foo {
+	a = c
+	b = 1
+	c = 2
+}
+
+const c = 0
+
+fn test_enum_with_const() {
+	mut foo := Foo.c
+	foo = .a
+	ret := match foo {
+		.a { 'a' }
+		.b { 'b' }
+		.c { 'c' }
+	}
+	println(ret)
+	assert ret == 'a'
+}


### PR DESCRIPTION
This PR fix enum field with const value (fix #21916).

- Fix enum field with const value.
- Add test.

```v
enum Foo {
	a = c
	b = 1
	c = 2
}

const c = 0

fn main() {
	mut foo := Foo.c
	foo = .a
	ret := match foo {
		.a { 'a' }
		.b { 'b' }
		.c { 'c' }
	}
	println(ret)
	assert ret == 'a'
}

PS D:\Test\v\tt1> v run .    
a
```