### PR TITLE
checker: check enum field value duplicate (fix #21911)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1951,6 +1951,14 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 						}
 						if field.expr.kind == .constant && field.expr.obj.typ.is_int() {
 							// accepts int constants as enum value
+							if mut field.expr.obj is ast.ConstField {
+								if mut field.expr.obj.expr is ast.IntegerLiteral {
+									c.check_enum_field_integer_literal(field.expr.obj.expr,
+										signed, node.is_multi_allowed, senum_type, field.expr.pos, mut
+										useen, enum_umin, enum_umax, mut iseen, enum_imin,
+										enum_imax)
+								}
+							}
 							continue
 						}
 					}

--- a/vlib/v/checker/tests/enum_field_value_duplicate_d.out
+++ b/vlib/v/checker/tests/enum_field_value_duplicate_d.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/enum_field_value_duplicate_d.vv:6:6: error: enum value `1` already exists
+    4 |     a = one
+    5 |     b
+    6 |     c = one
+      |         ~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/enum_field_value_duplicate_d.vv
+++ b/vlib/v/checker/tests/enum_field_value_duplicate_d.vv
@@ -1,0 +1,13 @@
+const one = 1
+
+enum MyEnum {
+	a = one
+	b
+	c = one
+}
+
+fn main() {
+	$for val in MyEnum.values {
+		println('> name: ${val.name} | value: ${val.value}')
+	}
+}


### PR DESCRIPTION
This PR check enum field value duplicate (fix #21911).

- Check enum field value duplicate.
- Add test.

```v
const one = 1

enum MyEnum {
	a = one
	b
	c = one
}

fn main() {
	$for val in MyEnum.values {
		println('> name: ${val.name} | value: ${val.value}')
	}
}

PS D:\Test\v\tt1> v run .
tt1.v:6:6: error: enum value `1` already exists
    4 |     a = one
    5 |     b
    6 |     c = one
      |         ~~~
    7 | }
    8 |
```