### PR TITLE
checker: fix voidptr type checking 

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -306,7 +306,7 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 	if c.check_types(got, expected) {
 		if language == .v && idx_got == ast.voidptr_type_idx {
 			if expected.is_int_valptr() || expected.is_int() || idx_expected == ast.voidptr_type_idx
-				|| idx_expected == ast.charptr_type_idx {
+				|| idx_expected == ast.charptr_type_idx || idx_expected == ast.byteptr_type_idx {
 				return
 			}
 			exp_sym := c.table.final_sym(expected)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -162,7 +162,7 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 		exp_sym := c.table.final_sym(expected)
-		if exp_sym.kind !in [.function, .placeholder] {
+		if exp_sym.kind !in [.voidptr, .function, .placeholder] {
 			return false
 		}
 	}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -158,7 +158,7 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 		}
 	}
 	if got_idx == ast.voidptr_type_idx {
-		if expected.is_int_valptr() {
+		if expected.is_int_valptr() || expected.is_int() {
 			return true
 		}
 		exp_sym := c.table.final_sym(expected)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -305,12 +305,13 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 
 	if c.check_types(got, expected) {
 		if language == .v && idx_got == ast.voidptr_type_idx {
-			if expected.is_int_valptr() || expected.is_int() {
+			if expected.is_int_valptr() || expected.is_int() || idx_expected == ast.voidptr_type_idx
+				|| idx_expected == ast.charptr_type_idx {
 				return
 			}
 			exp_sym := c.table.final_sym(expected)
 			if exp_sym.language == .v
-				&& exp_sym.kind !in [.voidptr, .function, .placeholder, .array_fixed, .struct_] {
+				&& exp_sym.kind !in [.voidptr, .charptr, .byteptr, .function, .placeholder, .array_fixed, .struct_] {
 				got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
 				return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -310,7 +310,7 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 			}
 			exp_sym := c.table.final_sym(expected)
 			if exp_sym.language == .v
-				&& exp_sym.kind !in [.voidptr, .function, .placeholder, .array_fixed] {
+				&& exp_sym.kind !in [.voidptr, .function, .placeholder, .array_fixed, .struct_] {
 				got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
 				return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -162,7 +162,7 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 		exp_sym := c.table.final_sym(expected)
-		if exp_sym.kind !in [.voidptr, .function, .placeholder] {
+		if exp_sym.kind !in [.voidptr, .function, .placeholder, .array_fixed] {
 			return false
 		}
 	}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -305,8 +305,7 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 
 	if c.check_types(got, expected) {
 		if language == .v && idx_got == ast.voidptr_type_idx {
-			if expected.is_int_valptr() || expected.is_int() || idx_expected == ast.voidptr_type_idx
-				|| idx_expected == ast.charptr_type_idx || idx_expected == ast.byteptr_type_idx {
+			if expected.is_int_valptr() || expected.is_int() || expected.is_ptr() {
 				return
 			}
 			exp_sym := c.table.final_sym(expected)

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -157,15 +157,6 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 	}
-	if got_idx == ast.voidptr_type_idx {
-		if expected.is_int_valptr() || expected.is_int() {
-			return true
-		}
-		exp_sym := c.table.final_sym(expected)
-		if exp_sym.kind !in [.voidptr, .function, .placeholder, .array_fixed] {
-			return false
-		}
-	}
 	if expected == ast.charptr_type && got == ast.char_type.ref() {
 		return true
 	}
@@ -313,6 +304,17 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 	}
 
 	if c.check_types(got, expected) {
+		if language == .v && idx_got == ast.voidptr_type_idx {
+			if expected.is_int_valptr() || expected.is_int() {
+				return
+			}
+			exp_sym := c.table.final_sym(expected)
+			if exp_sym.language == .v
+				&& exp_sym.kind !in [.voidptr, .function, .placeholder, .array_fixed] {
+				got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
+				return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
+			}
+		}
 		if language != .v || expected.is_ptr() == got.is_ptr() || arg.is_mut
 			|| arg.expr.is_auto_deref_var() || got.has_flag(.shared_f)
 			|| c.table.sym(expected_).kind !in [.array, .map] {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -157,6 +157,15 @@ fn (mut c Checker) check_types(got ast.Type, expected ast.Type) bool {
 			return true
 		}
 	}
+	if got_idx == ast.voidptr_type_idx {
+		if expected.is_int_valptr() {
+			return true
+		}
+		exp_sym := c.table.final_sym(expected)
+		if exp_sym.kind !in [.function, .placeholder] {
+			return false
+		}
+	}
 	if expected == ast.charptr_type && got == ast.char_type.ref() {
 		return true
 	}

--- a/vlib/v/checker/tests/voidptr_arg_err.out
+++ b/vlib/v/checker/tests/voidptr_arg_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/voidptr_arg_err.vv:3:15: error: cannot use `voidptr` as `[]i32` in argument 1 to `test`
+    1 | fn test_main() {
+    2 |     c := voidptr(10)
+    3 |     println(test(c))
+      |                  ^
+    4 | }
+    5 |

--- a/vlib/v/checker/tests/voidptr_arg_err.vv
+++ b/vlib/v/checker/tests/voidptr_arg_err.vv
@@ -1,0 +1,8 @@
+fn test_main() {
+	c := voidptr(10)
+	println(test(c))
+}
+
+fn test(a []i32) i32 {
+	return a[0]
+}


### PR DESCRIPTION
Fix #17787

This PR blocks voidptr to be passed to non-allowable ptr type.