### PR TITLE
checker: check enum field value duplicate 2

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1952,9 +1952,13 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 						if field.expr.kind == .constant && field.expr.obj.typ.is_int() {
 							// accepts int constants as enum value
 							if mut field.expr.obj is ast.ConstField {
-								if mut field.expr.obj.expr is ast.IntegerLiteral {
-									c.check_enum_field_integer_literal(field.expr.obj.expr,
-										signed, node.is_multi_allowed, senum_type, field.expr.pos, mut
+								mut t := transformer.new_transformer_with_table(c.table,
+									c.pref)
+								folded_expr := t.expr(mut field.expr.obj.expr)
+
+								if folded_expr is ast.IntegerLiteral {
+									c.check_enum_field_integer_literal(folded_expr, signed,
+										node.is_multi_allowed, senum_type, field.expr.pos, mut
 										useen, enum_umin, enum_umax, mut iseen, enum_imin,
 										enum_imax)
 								}

--- a/vlib/v/checker/tests/enum_field_value_duplicate_e.out
+++ b/vlib/v/checker/tests/enum_field_value_duplicate_e.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/enum_field_value_duplicate_e.vv:4:6: error: enum value `2` already exists
+    2 |     a = one
+    3 |     b
+    4 |     c = one
+      |         ~~~
+    5 | }
+    6 |

--- a/vlib/v/checker/tests/enum_field_value_duplicate_e.vv
+++ b/vlib/v/checker/tests/enum_field_value_duplicate_e.vv
@@ -1,0 +1,13 @@
+enum MyEnum {
+	a = one
+	b
+	c = one
+}
+
+const one = 1 + 1
+
+fn main() {
+	$for val in MyEnum.values {
+		println('> name: ${val.name} | value: ${val.value}')
+	}
+}


### PR DESCRIPTION
This PR check enum field value duplicate 2.

- Check enum field value duplicate 2.
- Add test.

```v
enum MyEnum {
	a = one
	b
	c = one
}

const one = 1 + 1

fn main() {
	$for val in MyEnum.values {
		println('> name: ${val.name} | value: ${val.value}')
	}
}

PS D:\Test\v\tt1> v run .
tt1.v:4:6: error: enum value `2` already exists
    2 |     a = one
    3 |     b
    4 |     c = one
      |         ~~~
    5 | }
    6 |
```