### PR TITLE
v.scanner: use table lookups for very frequently done character checks

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -528,6 +528,18 @@ fn (mut s Scanner) ident_number() string {
 	}
 }
 
+const nonwhite_space_bytes_table = fill_nonwhite_space_bytes_table()
+
+fn fill_nonwhite_space_bytes_table() [255]bool {
+	mut bytes := [255]bool{}
+	for c in 0 .. 255 {
+		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
+			bytes[c] = true
+		}
+	}
+	return bytes
+}
+
 @[direct_array_access; inline]
 fn (mut s Scanner) skip_whitespace() {
 	for s.pos < s.text.len {
@@ -537,7 +549,7 @@ fn (mut s Scanner) skip_whitespace() {
 			s.pos++
 			continue
 		}
-		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
+		if scanner.nonwhite_space_bytes_table[c] {
 			return
 		}
 		c_is_nl := c == scanner.b_cr || c == scanner.b_lf

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -257,14 +257,14 @@ fn (mut s Scanner) ident_name() string {
 		}
 		break
 	}
-	name := s.text[start..s.pos]
+	name := s.text.substr_unsafe(start, s.pos)
 	s.pos--
 	return name
 }
 
 fn (s Scanner) num_lit(start int, end int) string {
 	if s.is_fmt {
-		return s.text[start..end]
+		return s.text.substr_unsafe(start, end)
 	}
 	unsafe {
 		txt := s.text.str

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,7 +239,7 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if util.func_char_table[c] {
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
 			s.pos++
 			continue
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,7 +239,19 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+		if c >= `a` && c <= `z` {
+			s.pos++
+			continue
+		}
+		if c == `_` {
+			s.pos++
+			continue
+		}
+		if c >= `A` && c <= `Z` {
+			s.pos++
+			continue
+		}
+		if c >= `0` && c <= `9` {
 			s.pos++
 			continue
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,19 +239,7 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if c >= `a` && c <= `z` {
-			s.pos++
-			continue
-		}
-		if c == `_` {
-			s.pos++
-			continue
-		}
-		if c >= `A` && c <= `Z` {
-			s.pos++
-			continue
-		}
-		if c >= `0` && c <= `9` {
+		if util.func_char_table[c] {
 			s.pos++
 			continue
 		}
@@ -698,7 +686,7 @@ pub fn (mut s Scanner) text_scan() token.Token {
 		c := s.text[s.pos]
 		nextc := s.look_ahead(1)
 		// name or keyword
-		if util.is_name_char(c) {
+		if util.name_char_table[c] {
 			name := s.ident_name()
 			// tmp hack to detect . in ${}
 			// Check if not .eof to prevent panic
@@ -1327,7 +1315,7 @@ pub fn (mut s Scanner) ident_string() string {
 			break
 		}
 		// $var
-		if prevc == `$` && util.is_name_char(c) && !is_raw
+		if prevc == `$` && util.name_char_table[c] && !is_raw
 			&& s.count_symbol_before(s.pos - 2, scanner.backslash) & 1 == 0 {
 			s.is_inside_string = true
 			s.is_inter_start = true

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -257,14 +257,14 @@ fn (mut s Scanner) ident_name() string {
 		}
 		break
 	}
-	name := s.text.substr_unsafe(start, s.pos)
+	name := s.text[start..s.pos]
 	s.pos--
 	return name
 }
 
 fn (s Scanner) num_lit(start int, end int) string {
 	if s.is_fmt {
-		return s.text.substr_unsafe(start, end)
+		return s.text[start..end]
 	}
 	unsafe {
 		txt := s.text.str

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -239,7 +239,7 @@ fn (mut s Scanner) ident_name() string {
 	s.pos++
 	for s.pos < s.text.len {
 		c := s.text[s.pos]
-		if c.is_alnum() || c == `_` {
+		if util.func_char_table[c] {
 			s.pos++
 			continue
 		}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -540,18 +540,6 @@ fn (mut s Scanner) ident_number() string {
 	}
 }
 
-const nonwhite_space_bytes_table = fill_nonwhite_space_bytes_table()
-
-fn fill_nonwhite_space_bytes_table() [255]bool {
-	mut bytes := [255]bool{}
-	for c in 0 .. 255 {
-		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
-			bytes[c] = true
-		}
-	}
-	return bytes
-}
-
 @[direct_array_access; inline]
 fn (mut s Scanner) skip_whitespace() {
 	for s.pos < s.text.len {
@@ -561,7 +549,7 @@ fn (mut s Scanner) skip_whitespace() {
 			s.pos++
 			continue
 		}
-		if scanner.nonwhite_space_bytes_table[c] {
+		if util.non_whitespace_table[c] {
 			return
 		}
 		c_is_nl := c == scanner.b_cr || c == scanner.b_lf

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -9,9 +9,7 @@ pub const non_whitespace_table = get_non_white_space_table()
 fn get_non_white_space_table() [256]bool {
 	mut bytes := [256]bool{}
 	for c in 0 .. 256 {
-		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
-			bytes[c] = true
-		}
+		bytes[c] = !u8(c).is_space()
 	}
 	return bytes
 }
@@ -19,7 +17,7 @@ fn get_non_white_space_table() [256]bool {
 fn get_name_char_table() [256]bool {
 	mut res := [256]bool{}
 	for c in 0 .. 256 {
-		res[c] = (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`) || c == `_`
+		res[c] = u8(c).is_letter() || c == `_`
 	}
 	return res
 }
@@ -27,8 +25,7 @@ fn get_name_char_table() [256]bool {
 fn get_func_char_table() [256]bool {
 	mut res := [256]bool{}
 	for c in 0 .. 256 {
-		res[c] = (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`)
-			|| (c >= `0` && c <= `9`) || c == `_`
+		res[c] = u8(c).is_letter() || u8(c).is_digit() || c == `_`
 	}
 	return res
 }

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -1,13 +1,33 @@
 module util
 
-@[inline]
-pub fn is_name_char(c u8) bool {
-	return c.is_letter() || c == `_`
+pub const name_char_table = get_name_char_table()
+
+pub const func_char_table = get_func_char_table()
+
+fn get_name_char_table() [256]bool {
+	mut res := [256]bool{}
+	for c in 0 .. 256 {
+		res[c] = c.is_letter() || c == `_`
+	}
+	return res
 }
 
-@[inline]
+fn get_func_char_table() [256]bool {
+	mut res := [256]bool{}
+	for c in 0 .. 256 {
+		res[c] = c.is_letter() || c.is_digit() || c == `_`
+	}
+	return res
+}
+
+@[direct_array_access; inline]
+pub fn is_name_char(c u8) bool {
+	return util.name_char_table[c]
+}
+
+@[direct_array_access; inline]
 pub fn is_func_char(c u8) bool {
-	return c.is_letter() || c == `_` || c.is_digit()
+	return util.func_char_table[c]
 }
 
 pub fn contains_capital(s string) bool {

--- a/vlib/v/util/scanning.v
+++ b/vlib/v/util/scanning.v
@@ -4,10 +4,22 @@ pub const name_char_table = get_name_char_table()
 
 pub const func_char_table = get_func_char_table()
 
+pub const non_whitespace_table = get_non_white_space_table()
+
+fn get_non_white_space_table() [256]bool {
+	mut bytes := [256]bool{}
+	for c in 0 .. 256 {
+		if !(c == 32 || (c > 8 && c < 14) || c == 0x85 || c == 0xa0) {
+			bytes[c] = true
+		}
+	}
+	return bytes
+}
+
 fn get_name_char_table() [256]bool {
 	mut res := [256]bool{}
 	for c in 0 .. 256 {
-		res[c] = c.is_letter() || c == `_`
+		res[c] = (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`) || c == `_`
 	}
 	return res
 }
@@ -15,7 +27,8 @@ fn get_name_char_table() [256]bool {
 fn get_func_char_table() [256]bool {
 	mut res := [256]bool{}
 	for c in 0 .. 256 {
-		res[c] = c.is_letter() || c.is_digit() || c == `_`
+		res[c] = (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`)
+			|| (c >= `0` && c <= `9`) || c == `_`
 	}
 	return res
 }


### PR DESCRIPTION
This has only the lookup changes from https://github.com/vlang/v/pull/21545 .
The substr_unsafe commit, turned out to be a problem.

- **v.scanner: use precomputed character tables instead of checks**
- **v.scanner: use util.func_char_table in Scanner.ident_name/0**
- **v.scanner: restore the checks in ident_name, instead of using util.func_char_table**
- **v.scanner: split long condition in ident_name into several smaller ones**
- **v.scanner: use substr_unsafe in Scanner.ident_name/0 and Scanner.num_lit/2**
- **Revert "v.scanner: use substr_unsafe in Scanner.ident_name/0 and Scanner.num_lit/2"**
- **v.scanner: move non_whitespace_table to v.util**
- **v.scanner: use util.func_char_table[c] and util.name_char_table[c] directly**
- **v.util: cleanup the table generating functions, by using the builtin u8 methods**
