### PR TITLE
encoding.base58: fix notice for slice creation

### DIFF
--- a/vlib/encoding/base58/base58.v
+++ b/vlib/encoding/base58/base58.v
@@ -87,7 +87,7 @@ pub fn encode_walpha_bytes(input []u8, alphabet Alphabet) []u8 {
 	for i = zcount; i < sz && out[i] == 0; i++ {}
 
 	// now encode the values with actual alphabet in-place
-	val := out[i - zcount..]
+	val := out[i - zcount..].clone()
 	sz = val.len
 	for i = 0; i < sz; i++ {
 		out[i] = alphabet.encode[val[i]]

--- a/vlib/encoding/base58/base58.v
+++ b/vlib/encoding/base58/base58.v
@@ -87,7 +87,7 @@ pub fn encode_walpha_bytes(input []u8, alphabet Alphabet) []u8 {
 	for i = zcount; i < sz && out[i] == 0; i++ {}
 
 	// now encode the values with actual alphabet in-place
-	val := out[i - zcount..].clone()
+	val := unsafe { out[i - zcount..] }
 	sz = val.len
 	for i = 0; i < sz; i++ {
 		out[i] = alphabet.encode[val[i]]


### PR DESCRIPTION

```
>> compilation failed:
/opt/v/vlib/encoding/base58/base58.v:90:12: notice: an implicit clone of the slice was done here
   88 | 
   89 |     // now encode the values with actual alphabet in-place
   90 |     val := out[i - zcount..]
      |               ~~~~~~~~~~~~~~
   91 |     sz = val.len
   92 |     for i = 0; i < sz; i++ {
Details: /opt/v/vlib/encoding/base58/base58.v:90:12: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
   88 | 
   89 |     // now encode the values with actual alphabet in-place
   90 |     val := out[i - zcount..]
      |               ~~~~~~~~~~~~~~
   91 |     sz = val.len
   92 |     for i = 0; i < sz; i++ {

```
