### PR TITLE
checker: fix wrong error message for invalid array attr key

### DIFF
--- a/vlib/v/checker/tests/wrong_arr_field_err.out
+++ b/vlib/v/checker/tests/wrong_arr_field_err.out
@@ -1,0 +1,4 @@
+vlib/v/checker/tests/wrong_arr_field_err.vv:1:34: error: wrong field `init1`, expecting `len`, `cap`, or `init`
+    1 | arr := []int{len: 100, cap: 200, init1: index * 3}
+      |                                  ~~~~~
+    2 | println(arr)

--- a/vlib/v/checker/tests/wrong_arr_field_err.vv
+++ b/vlib/v/checker/tests/wrong_arr_field_err.vv
@@ -1,0 +1,2 @@
+arr := []int{len: 100, cap: 200, init1: index * 3}
+println(arr)

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -157,7 +157,8 @@ fn (mut p Parser) array_init(is_option bool, alias_array_type ast.Type) ast.Arra
 					has_index = p.handle_index_variable(mut init_expr)
 				}
 				else {
-					p.error('wrong field `${key}`, expecting `len`, `cap`, or `init`')
+					p.error_with_pos('wrong field `${key}`, expecting `len`, `cap`, or `init`',
+						attr_pos)
 					return ast.ArrayInit{}
 				}
 			}


### PR DESCRIPTION
```v
bug.v:1:34: error: wrong field `init1`, expecting `len`, `cap`, or `init`
    1 | arr := []int{len: 100, cap: 200, init1: index * 3}
      |                                  ~~~~~
    2 | println(arr)
```