### PR TITLE
builtin: panic on trying to grow arrays with capacity bigger than 2^31, instead of overflowing a.cap (partial fix for #21918)

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -436,6 +436,7 @@ pub fn (mut a array) drop(num int) {
 	a.data = unsafe { &u8(a.data) + blen }
 	a.offset += int(blen) // TODO: offset should become 64bit as well
 	a.len -= n
+	a.cap -= n
 }
 
 // we manually inline this for single operations for performance without -prod

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -676,8 +676,11 @@ fn (mut a array) set(i int, val voidptr) {
 }
 
 fn (mut a array) push(val voidptr) {
-	if a.len < 0 || a.len > max_int {
-		panic('array.push: invalid len: ${a.len}')
+	if a.len < 0 {
+		panic('array.push: negative len')
+	}
+	if a.len >= max_int {
+		panic('array.push: len bigger than max_int')
 	}
 	if a.len >= a.cap {
 		a.ensure_cap(a.len + 1)
@@ -695,7 +698,8 @@ pub fn (mut a3 array) push_many(val voidptr, size int) {
 	}
 	new_len := i64(a3.len) + i64(size)
 	if new_len > max_int {
-		panic('array.push_many: new len exceeds max_int: ${new_len}')
+		// string interpolation also uses <<; avoid it, use a fixed string for the panic
+		panic('array.push_many: new len exceeds max_int')
 	}
 	if new_len >= a3.cap {
 		a3.ensure_cap(int(new_len))

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -95,9 +95,17 @@ fn (mut a array) ensure_cap_noscan(required int) {
 	if a.flags.has(.nogrow) {
 		panic('array.ensure_cap_noscan: array with the flag `.nogrow` cannot grow in size, array required new size: ${required}')
 	}
-	mut cap := if a.cap > 0 { a.cap } else { 2 }
+	mut cap := if a.cap > 0 { i64(a.cap) } else { i64(2) }
 	for required > cap {
 		cap *= 2
+	}
+	if cap > max_int {
+		if a.cap < max_int {
+			// limit the capacity, since bigger values, will overflow the 32bit integer used to store it
+			cap = max_int
+		} else {
+			panic('array.ensure_cap: array needs to grow to cap = ${cap}, which is > 2^31')
+		}
 	}
 	new_size := u64(cap) * u64(a.element_size)
 	new_data := vcalloc_noscan(new_size)
@@ -107,7 +115,7 @@ fn (mut a array) ensure_cap_noscan(required int) {
 	}
 	a.data = new_data
 	a.offset = 0
-	a.cap = cap
+	a.cap = int(cap)
 }
 
 // repeat returns a new array with the given array elements repeated given times.

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -256,8 +256,11 @@ fn (a &array) clone_to_depth_noscan(depth int) array {
 }
 
 fn (mut a array) push_noscan(val voidptr) {
-	if a.len < 0 || a.len > max_int {
-		panic('array.push_noscan: invalid len: ${a.len}')
+	if a.len < 0 {
+		panic('array.push_noscan: negative len')
+	}
+	if a.len >= max_int {
+		panic('array.push_noscan: len bigger than max_int')
 	}
 	if a.len >= a.cap {
 		a.ensure_cap_noscan(a.len + 1)
@@ -275,7 +278,8 @@ fn (mut a3 array) push_many_noscan(val voidptr, size int) {
 	}
 	new_len := i64(a3.len) + i64(size)
 	if new_len > max_int {
-		panic('array.push_many_noscan: new len exceeds max_int: ${new_len}')
+		// string interpolation also uses <<; avoid it, use a fixed string for the panic
+		panic('array.push_many_noscan: new len exceeds max_int')
 	}
 	if a3.data == val && a3.data != 0 {
 		// handle `arr << arr`

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -53,8 +53,8 @@ pub const max_i16 = i16(32767)
 pub const min_i32 = i32(-2147483648)
 pub const max_i32 = i32(2147483647)
 
-pub const min_int = min_i32
-pub const max_int = max_i32
+pub const min_int = int(-2147483648)
+pub const max_int = int(2147483647)
 
 // -9223372036854775808 is wrong, because C compilers parse literal values
 // without sign first, and 9223372036854775808 overflows i64, hence the


### PR DESCRIPTION
This PR limits dynamic array capacity growth to max_int , and makes sure that a panic happens if that needs to be exceeded, instead of silently overflowing the .cap field (thus breaking the invariant about .len <= .cap).

It is a temporary workaround for #21918 , providing a better experience (allows for growing/processing till the actual limit, and a panic with a stacktrace, when the limit is reached, for improved debugging), until V transitions to using 64 bit numbers for the .len and .cap array fields.