### PR TITLE
checker: fix missing struct field type checking for type mismatch (ref vs non-ref)

### DIFF
--- a/vlib/v/checker/tests/struct_field_mismatch_ref_err.out
+++ b/vlib/v/checker/tests/struct_field_mismatch_ref_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_mismatch_ref_err.vv:6:26: error: field is not reference but default value is reference
+    4 | struct SafeCounter {
+    5 | mut:
+    6 |     mt sync.Mutex = sync.new_mutex()
+      |                          ~~~~~~~~~~~
+    7 | pub mut:
+    8 |     value map[string]int

--- a/vlib/v/checker/tests/struct_field_mismatch_ref_err.vv
+++ b/vlib/v/checker/tests/struct_field_mismatch_ref_err.vv
@@ -1,0 +1,40 @@
+import sync
+import time
+
+struct SafeCounter {
+mut:
+    mt sync.Mutex = sync.new_mutex()
+pub mut:
+    value map[string]int
+}
+
+fn (mut c SafeCounter) inc(key string) {
+    c.mt.@lock()
+    defer {
+        c.mt.unlock()
+    }
+    c.value[key]++
+}
+
+fn (mut c SafeCounter) value(key string) int {
+    c.mt.@lock()
+    defer {
+        c.mt.unlock()
+    }
+    return c.value[key]
+}
+
+fn main() {
+    mut counter := &SafeCounter{}
+
+    for i := 0; i < 5; i++ {
+        spawn fn [mut counter] () {
+            for j := 0; j < 100; j++ {
+                counter.inc('key')
+            }
+        }()
+    }
+
+    time.sleep(1 * time.second)
+    println(counter.value('key'))
+}


### PR DESCRIPTION
Fix #18088

```v
bug.v:6:26: error: field is not reference but default value is reference
    4 | struct SafeCounter {
    5 | mut:
    6 |     mt sync.Mutex = sync.new_mutex()
      |                          ~~~~~~~~~~~
    7 | pub mut:
    8 |     value map[string]int
```