### PR TITLE
builtin: fix 'aaaa'.split('aa') (fix #21936)

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -977,7 +977,7 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 		else {
 			mut start := 0
 			// Add up to `nth` segments left of every occurrence of the delimiter.
-			for i := 0; i + delim.len <= s.len; i++ {
+			for i := 0; i + delim.len <= s.len; {
 				if unsafe { s.substr_unsafe(i, i + delim.len) } == delim {
 					if nth > 0 && res.len == nth - 1 {
 						break
@@ -985,6 +985,8 @@ pub fn (s string) split_nth(delim string, nth int) []string {
 					res << s.substr(start, i)
 					i += delim.len
 					start = i
+				} else {
+					i++
 				}
 			}
 			// Then add the remaining part of the string as the last segment.

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -333,6 +333,13 @@ fn test_split() {
 	assert vals.len == 2
 	assert vals[0] == 'wavy turquoise'
 	assert vals[1] == ''
+	// /////////
+	s = 'aaaa'
+	vals = s.split('aa')
+	assert vals.len == 3
+	assert vals[0] == ''
+	assert vals[1] == ''
+	assert vals[2] == ''
 }
 
 fn test_rsplit() {


### PR DESCRIPTION
This PR fix 'aaaa'.split('aa') (fix #21936).

- Fix 'aaaa'.split('aa').
- Add test.

```v
fn main() {
	println('aaaa'.split('aa'))
}

PS D:\Test\v\tt1> v run .
['', '', '']
```