### PR TITLE
regex: fix regex.split() (fix #16876)

### DIFF
--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -431,14 +431,14 @@ const (
 	split_test_suite = [
 		Test_split{'abcd 1234 efgh 1234 ghkl1234 ab34546df', r'\d+', ['abcd ', ' efgh ', ' ghkl',
 			' ab', 'df']},
-		Test_split{'abcd 1234 efgh 1234 ghkl1234 ab34546df', r'\a+', [' 1234 ', ' 1234 ', '1234 ',
-			'34546']},
+		Test_split{'abcd 1234 efgh 1234 ghkl1234 ab34546df', r'\a+', ['', ' 1234 ', ' 1234 ', '1234 ',
+			'34546', '']},
 		Test_split{'oggi pippo è andato a casa di pluto ed ha trovato pippo', r'p[iplut]+o', [
-			'oggi ', ' è andato a casa di ', ' ed ha trovato ']},
+			'oggi ', ' è andato a casa di ', ' ed ha trovato ', '']},
 		Test_split{'oggi pibao è andato a casa di pbababao ed ha trovato pibabababao', r'(pi?(ba)+o)', [
-			'oggi ', ' è andato a casa di ', ' ed ha trovato ']},
+			'oggi ', ' è andato a casa di ', ' ed ha trovato ', '']},
 		Test_split{'Today is a good day and tomorrow will be for sure.', r'[Tt]o\w+', [
-			' is a good day and ', ' will be for sure.']},
+			'', ' is a good day and ', ' will be for sure.']},
 		Test_split{'pera\nurl = https://github.com/dario/pig.html\npippo', r'url *= *https?://[\w./]+', [
 			'pera\n', '\npippo']},
 		Test_split{'pera\nurl = https://github.com/dario/pig.html\npippo', r'url *= *https?://.*' +
@@ -446,14 +446,16 @@ const (
 		Test_split{'#.#......##.#..#..##........##....###...##...######.......#.....#..#......#...#........###.#..#.', r'#[.#]{4}##[.#]{4}##[.#]{4}###', [
 			'#.#......##.#..#..##........#', '##.......#.....#..#......#...#........###.#..#.']},
 		Test_split{'#.#......##.#..#..##........##....###...##...######.......#.....#..#......#...#........###.#..#.', r'.*#[.#]{4}##[.#]{4}##[.#]{4}###', [
-			'##.......#.....#..#......#...#........###.#..#.']},
-		Test_split{'1234 Aa dddd Aaf 12334 Aa opopo Aaf', r'Aa.+Aaf', ['1234 ', ' 12334 ']},
+			'', '##.......#.....#..#......#...#........###.#..#.']},
+		Test_split{'1234 Aa dddd Aaf 12334 Aa opopo Aaf', r'Aa.+Aaf', ['1234 ', ' 12334 ', '']},
 		Test_split{'@for something @endfor @for something else @endfor altro testo @for body @endfor uno due @for senza dire più @endfor pippo', r'@for.+@endfor', [
-			' ', ' altro testo ', ' uno due ', ' pippo']},
+			'', ' ', ' altro testo ', ' uno due ', ' pippo']},
 		Test_split{'+++pippo+++\n elvo +++ pippo2 +++ +++ oggi+++', r'\+{3}.*\+{3}', [
-			'\n elvo ', ' ']},
+			'', '\n elvo ', ' ', '']},
 		Test_split{'foobar', r'\d', ['foobar']},
-		Test_split{'1234', r'\d+', []},
+		Test_split{'1234', r'\d+', ['', '']},
+		Test_split{'a-', r'-', ['a', '']},
+		Test_split{'-a', r'-', ['', 'a']},
 	]
 )
 // vfmt on

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -320,18 +320,13 @@ pub fn (mut re RE) split(in_txt string) []string {
 		return [in_txt]
 	}
 	for i := 0; i < pos.len; i += 2 {
-		if pos[i] == 0 {
-			continue
-		}
 		if i == 0 {
 			sections << in_txt[..pos[i]]
 		} else {
 			sections << in_txt[pos[i - 1]..pos[i]]
 		}
 	}
-	if pos[pos.len - 1] != in_txt.len {
-		sections << in_txt[pos[pos.len - 1]..]
-	}
+	sections << in_txt[pos[pos.len - 1]..]
 	return sections
 }
 


### PR DESCRIPTION
This PR fix regex.split() (fix #16876).

- Fix regex.split().
- Add test.

```v
import regex

fn main() {
	mut r := regex.regex_opt('-') or { panic(err) }
	println(r.split('a-'))
	println('a-'.split('-'))
	println(r.split('-a'))
	println('-a'.split('-'))
}

PS D:\Test\v\tt1> v run .
['a', '']
['a', '']
['', 'a']
['', 'a']
```