### PR TITLE
checker: fix sumtype checking for voidptr variant

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -310,7 +310,7 @@ fn (mut c Checker) check_expected_call_arg(got ast.Type, expected_ ast.Type, lan
 			}
 			exp_sym := c.table.final_sym(expected)
 			if exp_sym.language == .v
-				&& exp_sym.kind !in [.voidptr, .charptr, .byteptr, .function, .placeholder, .array_fixed, .struct_] {
+				&& exp_sym.kind !in [.voidptr, .charptr, .byteptr, .function, .placeholder, .array_fixed, .sum_type, .struct_] {
 				got_typ_str, expected_typ_str := c.get_string_names_of(got, expected)
 				return error('cannot use `${got_typ_str}` as `${expected_typ_str}`')
 			}

--- a/vlib/v/tests/voidptr_sumtype_test.v
+++ b/vlib/v/tests/voidptr_sumtype_test.v
@@ -1,0 +1,14 @@
+type MySum = string | voidptr
+type Alias = voidptr
+
+fn t(a MySum) MySum {
+	return dump(a)
+}
+
+fn test_main() {
+	a := 'foo'
+	assert t(a) == MySum('foo')
+
+	b := voidptr(0x100)
+	assert t(b) == MySum(voidptr(0x100))
+}

--- a/vlib/v/tests/voidptr_sumtype_test.v
+++ b/vlib/v/tests/voidptr_sumtype_test.v
@@ -1,5 +1,4 @@
 type MySum = string | voidptr
-type Alias = voidptr
 
 fn t(a MySum) MySum {
 	return dump(a)


### PR DESCRIPTION
Allow passing voidptr to sumtype.

```v
type MySum = string | voidptr
type Alias = voidptr

fn t(a MySum) MySum {
	return dump(a)
}

fn test_main() {
	a := 'foo'
	assert t(a) == MySum('foo')

	b := voidptr(0x100)
	assert t(b) == MySum(voidptr(0x100))
}

```