### PR TITLE
parser: check using comptime veb/vweb without import veb/vweb

### DIFF
--- a/examples/vweb/veb_example.v
+++ b/examples/vweb/veb_example.v
@@ -33,6 +33,7 @@ pub fn (mut app App) user_endpoint(mut ctx Context, user string) veb.Result {
 	})
 }
 
+// vfmt off
 pub fn (mut app App) index(mut ctx Context) veb.Result {
 	mut c := 0
 	lock app.state {
@@ -46,13 +47,13 @@ pub fn (mut app App) index(mut ctx Context) veb.Result {
 	show := true
 	hello := 'Hello world from veb, request number: ${c}'
 	numbers := [1, 2, 3]
-	return $vweb.html()
+	return $veb.html()
 }
 
 pub fn (mut app App) custom_template(mut ctx Context) veb.Result {
-	return $vweb.html('custom.html')
+	return $veb.html('custom.html')
 }
-
+// vfmt on
 pub fn (mut app App) show_text(mut ctx Context) veb.Result {
 	return ctx.text('Hello world from veb')
 }

--- a/examples/vweb/veb_example.v
+++ b/examples/vweb/veb_example.v
@@ -33,7 +33,6 @@ pub fn (mut app App) user_endpoint(mut ctx Context, user string) veb.Result {
 	})
 }
 
-// vfmt off
 pub fn (mut app App) index(mut ctx Context) veb.Result {
 	mut c := 0
 	lock app.state {
@@ -53,7 +52,7 @@ pub fn (mut app App) index(mut ctx Context) veb.Result {
 pub fn (mut app App) custom_template(mut ctx Context) veb.Result {
 	return $veb.html('custom.html')
 }
-// vfmt on
+
 pub fn (mut app App) show_text(mut ctx Context) veb.Result {
 	return ctx.text('Hello world from veb')
 }

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1938,6 +1938,7 @@ pub:
 	method_pos       token.Pos
 	scope            &Scope = unsafe { nil }
 	is_vweb          bool
+	is_veb           bool
 	is_embed         bool // $embed_file(...)
 	is_env           bool // $env(...) // TODO: deprecate after $d() is stable
 	is_compile_value bool // $d(...)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2153,11 +2153,19 @@ pub fn (mut f Fmt) comptime_call(node ast.ComptimeCall) {
 	if node.is_vweb {
 		if node.method_name == 'html' {
 			if node.args.len == 1 && node.args[0].expr is ast.StringLiteral {
-				f.write('\$vweb.html(')
+				if node.is_veb {
+					f.write('\$veb.html(')
+				} else {
+					f.write('\$vweb.html(')
+				}
 				f.expr(node.args[0].expr)
 				f.write(')')
 			} else {
-				f.write('\$vweb.html()')
+				if node.is_veb {
+					f.write('\$veb.html()')
+				} else {
+					f.write('\$vweb.html()')
+				}
 			}
 		} else {
 			f.write('\$tmpl(')

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -106,6 +106,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	}
 	start_pos := p.tok.pos()
 	p.check(.dollar)
+	mut is_veb := false
 	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()`, `\$vweb.html()`, `\$compile_error()`, `\$compile_warn()`, `\$d()` and `\$res()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
 		name := p.check_name() // skip `vweb.html()` TODO
@@ -117,9 +118,12 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 		if name == 'vweb' && 'vweb' !in import_mods && 'x.vweb' !in import_mods {
 			p.error_with_pos('`\$vweb` cannot be used without import vweb', start_pos.extend(p.prev_tok.pos()))
 			return err_node
-		} else if name == 'veb' && 'veb' !in import_mods {
-			p.error_with_pos('`\$veb` cannot be used without import veb', start_pos.extend(p.prev_tok.pos()))
-			return err_node
+		} else if name == 'veb' {
+			if 'veb' !in import_mods {
+				p.error_with_pos('`\$veb` cannot be used without import veb', start_pos.extend(p.prev_tok.pos()))
+				return err_node
+			}
+			is_veb = true
 		}
 		p.check(.dot)
 	}
@@ -273,6 +277,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 				return ast.ComptimeCall{
 					scope: unsafe { nil }
 					is_vweb: true
+					is_veb: is_veb
 					method_name: method_name
 					args_var: literal_string_param
 					args: [arg]
@@ -314,6 +319,7 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	return ast.ComptimeCall{
 		scope: unsafe { nil }
 		is_vweb: true
+		is_veb: is_veb
 		vweb_tmpl: file
 		method_name: method_name
 		args_var: literal_string_param

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -113,6 +113,13 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 			p.error(error_msg)
 			return err_node
 		}
+		if name == 'vweb' && 'vweb' !in p.ast_imports.map(it.mod) {
+			p.error_with_pos('`\$vweb` cannot be used without import vweb', start_pos.extend(p.prev_tok.pos()))
+			return err_node
+		} else if name == 'veb' && 'veb' !in p.ast_imports.map(it.mod) {
+			p.error_with_pos('`\$veb` cannot be used without import veb', start_pos.extend(p.prev_tok.pos()))
+			return err_node
+		}
 		p.check(.dot)
 	}
 	method_name := p.check_name()

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -116,11 +116,11 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 		}
 		import_mods := p.ast_imports.map(it.mod)
 		if name == 'vweb' && 'vweb' !in import_mods && 'x.vweb' !in import_mods {
-			p.error_with_pos('`\$vweb` cannot be used without import vweb', start_pos.extend(p.prev_tok.pos()))
+			p.error_with_pos('`\$vweb` cannot be used without importing vweb', start_pos.extend(p.prev_tok.pos()))
 			return err_node
 		} else if name == 'veb' {
 			if 'veb' !in import_mods {
-				p.error_with_pos('`\$veb` cannot be used without import veb', start_pos.extend(p.prev_tok.pos()))
+				p.error_with_pos('`\$veb` cannot be used without importing veb', start_pos.extend(p.prev_tok.pos()))
 				return err_node
 			}
 			is_veb = true

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -113,10 +113,11 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 			p.error(error_msg)
 			return err_node
 		}
-		if name == 'vweb' && 'vweb' !in p.ast_imports.map(it.mod) {
+		import_mods := p.ast_imports.map(it.mod)
+		if name == 'vweb' && 'vweb' !in import_mods && 'x.vweb' !in import_mods {
 			p.error_with_pos('`\$vweb` cannot be used without import vweb', start_pos.extend(p.prev_tok.pos()))
 			return err_node
-		} else if name == 'veb' && 'veb' !in p.ast_imports.map(it.mod) {
+		} else if name == 'veb' && 'veb' !in import_mods {
 			p.error_with_pos('`\$veb` cannot be used without import veb', start_pos.extend(p.prev_tok.pos()))
 			return err_node
 		}

--- a/vlib/v/parser/tests/comptime_veb_without_import_veb_err.out
+++ b/vlib/v/parser/tests/comptime_veb_without_import_veb_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/comptime_veb_without_import_veb_err.vv:2:2: error: `$veb` cannot be used without import veb
+vlib/v/parser/tests/comptime_veb_without_import_veb_err.vv:2:2: error: `$veb` cannot be used without importing veb
     1 | fn main() {
     2 |     $veb.html('index.html')
       |     ~~~~

--- a/vlib/v/parser/tests/comptime_veb_without_import_veb_err.out
+++ b/vlib/v/parser/tests/comptime_veb_without_import_veb_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/comptime_veb_without_import_veb_err.vv:2:2: error: `$veb` cannot be used without import veb
+    1 | fn main() {
+    2 |     $veb.html('index.html')
+      |     ~~~~
+    3 | }

--- a/vlib/v/parser/tests/comptime_veb_without_import_veb_err.vv
+++ b/vlib/v/parser/tests/comptime_veb_without_import_veb_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	$veb.html('index.html')
+}

--- a/vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.out
+++ b/vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.out
@@ -1,4 +1,4 @@
-vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.vv:2:2: error: `$vweb` cannot be used without import vweb
+vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.vv:2:2: error: `$vweb` cannot be used without importing vweb
     1 | fn main() {
     2 |     $vweb.html('index.html')
       |     ~~~~~

--- a/vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.out
+++ b/vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.out
@@ -1,0 +1,5 @@
+vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.vv:2:2: error: `$vweb` cannot be used without import vweb
+    1 | fn main() {
+    2 |     $vweb.html('index.html')
+      |     ~~~~~
+    3 | }

--- a/vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.vv
+++ b/vlib/v/parser/tests/comptime_vweb_without_import_vweb_err.vv
@@ -1,0 +1,3 @@
+fn main() {
+	$vweb.html('index.html')
+}


### PR DESCRIPTION
This PR check using comptime veb/vweb without import veb/vweb.

- Check using comptime veb/vweb without import veb/vweb.
- Add test.

```v
fn main() {
	$veb.html('index.html')
}

PS D:\Test\v\tt1> v run .
tt1.v:2:2: error: `$veb` cannot be used without import veb
    1 | fn main() {
    2 |     $veb.html('index.html')
      |     ~~~~
    3 | }
```
```v
fn main() {
	$vweb.html('index.html')
}

PS D:\Test\v\tt1> v run .
tt1.v:2:2: error: `$vweb` cannot be used without import vweb
    1 | fn main() {
    2 |     $vweb.html('index.html')
      |     ~~~~~
    3 | }
```