### PR TITLE
tools: add short tests in `v test-all` to ensure that `-d trace_http_request` and `-d trace_http_response` compile and work

### DIFF
--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -366,6 +366,22 @@ fn get_all_commands() []Command {
 		okmsg: '`v install` works.'
 	}
 	res << Command{
+		okmsg: 'Running net.http with -d trace_http_request works.'
+		line: '${vexe} -d trace_http_request -e \'import net.http; x := http.fetch(url: "https://vpm.url4e.com/some/unknown/url")!; println(x.status_code)\''
+		runcmd: .execute
+		starts_with: '> GET /some/unknown/url HTTP/1.1'
+		contains: 'User-Agent: v.http'
+		ends_with: '404\n'
+	}
+	res << Command{
+		okmsg: 'Running net.http with -d trace_http_response works.'
+		line: '${vexe} -d trace_http_response -e \'import net.http; x := http.fetch(url: "https://vpm.url4e.com/some/unknown/url")!; println(x.status_code)\''
+		runcmd: .execute
+		starts_with: '< HTTP/1.1 404 Not Found'
+		contains: 'Server: nginx'
+		ends_with: '404\n'
+	}
+	res << Command{
 		line: '${vexe} -usecache -cg examples/hello_world.v'
 		okmsg: '`v -usecache -cg` works.'
 		rmfile: 'examples/hello_world'


### PR DESCRIPTION
Commit faea2d9 contained a short and quick typo fix, but without tests.

This adds tests too, so that `v test-all` can check that `-d trace_http_request` and `-d trace_http_response` will continue to work in the future.