### PR TITLE
Make hash.Hash public and add tests to implementers

### DIFF
--- a/vlib/crypto/md5/md5_test.v
+++ b/vlib/crypto/md5/md5_test.v
@@ -2,6 +2,14 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.md5
+import hash
+
+// verify md5.Digest implements hash.Hash
+fn test_digest_implements_hash() {
+	get_digest := fn () hash.Hash {
+		return md5.new()
+	}
+}
 
 fn test_crypto_md5() {
 	assert md5.sum('this is a md5 checksum.'.bytes()).hex() == '6fb421ff99036547655984da12973431'

--- a/vlib/crypto/sha1/sha1_test.v
+++ b/vlib/crypto/sha1/sha1_test.v
@@ -2,6 +2,14 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.sha1
+import hash
+
+// verify sha1.Digest implements hash.Hash
+fn test_digest_implements_hash() {
+	get_digest := fn () hash.Hash {
+		return sha1.new()
+	}
+}
 
 fn test_crypto_sha1() {
 	assert sha1.sum('This is a sha1 checksum.'.bytes()).hex() == 'e100d74442faa5dcd59463b808983c810a8eb5a1'

--- a/vlib/crypto/sha256/sha256_test.v
+++ b/vlib/crypto/sha256/sha256_test.v
@@ -2,6 +2,14 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.sha256
+import hash
+
+// verify sha256.Digest implements hash.Hash
+fn test_digest_implements_hash() {
+	get_digest := fn () hash.Hash {
+		return sha256.new()
+	}
+}
 
 fn test_crypto_sha256() {
 	assert sha256.sum('This is a sha256 checksum.'.bytes()).hex() == 'dc7163299659529eae29683eb1ffec50d6c8fc7275ecb10c145fde0e125b8727'

--- a/vlib/crypto/sha512/sha512_test.v
+++ b/vlib/crypto/sha512/sha512_test.v
@@ -2,6 +2,14 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.sha512
+import hash
+
+// verify sha512.Digest implements hash.Hash
+fn test_digest_implements_hash() {
+	get_digest := fn () hash.Hash {
+		return sha512.new()
+	}
+}
 
 const final_result = '4143e55fcba7e39b20f62a1368e5eb28f64a8859458886117ac66027832e0f9f5263daec688c439d2d0fa07059334668d39e59543039703dbb7e03ec9da7f8d7'
 

--- a/vlib/hash/hash.v
+++ b/vlib/hash/hash.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module hash
 
-interface Hasher {
+pub interface Hash {
 	// Sum appends the current hash to b and returns the resulting array.
 	// It does not change the underlying hash state.
 	sum(b []u8) []u8


### PR DESCRIPTION
Inferface `hash.Hash` is made public, this allows users to use it.
Tests are added to md5, sha1, sha256 and sha512 to ensure each Digest struct implements the hash.Hash interface