### PR TITLE
examples: make `rotating_textured_quad.v` compile and run on Android

### DIFF
--- a/examples/gg/rotating_textured_quad.v
+++ b/examples/gg/rotating_textured_quad.v
@@ -10,9 +10,12 @@ pub mut:
 }
 
 pub fn (mut window Window) init() {
-	window.img = window.ctx.create_image(os.resource_abs_path('../assets/logo.png')) or {
-		panic(err)
+	image_path := $if android {
+		'logo.png'
+	} $else {
+		os.resource_abs_path('../assets/logo.png')
 	}
+	window.img = window.ctx.create_image(image_path) or { panic(err) }
 }
 
 pub fn (mut window Window) draw() {


### PR DESCRIPTION
This PR makes the `examples/gg//rotating_textured_quad.v` able to compile and run on Android via `vab`.

The example is currently not rendering the image for reasons I have been unable to pin-point.
I decided to not spend anymore time on it now - but still thought the changes was an improvement.

On my physical device the example looks like the attached image.
(I've tried rendering the image it with `window.ctx.draw_image_with_config(...)` which produced correct output but I can not pin-point exactly why the current code does not render on my device :shrug: )

![Screenshot_20240802_173602_V Test App](https://github.com/user-attachments/assets/f9ae3e15-e904-4caf-88b8-e28e7f818cd3)
