### PR TITLE
v: allow multi return as fn argument

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -777,7 +777,7 @@ pub mut:
 	receiver_type          Type // User / T, if receiver is generic, then cgen requires receiver_type to be T
 	receiver_concrete_type Type // if receiver_type is T, then receiver_concrete_type is concrete type, otherwise it is the same as receiver_type
 	return_type            Type
-	return_type_generic    Type   // the original generic return type from fn def
+	return_type_generic    Type // the original generic return type from fn def
 	nr_ret_values          int = -1 // amount of return values
 	fn_var_type            Type   // the fn type, when `is_fn_a_const` or `is_fn_var` is true
 	const_name             string // the fully qualified name of the const, i.e. `main.c`, given `const c = abc`, and callexpr: `c()`

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -778,6 +778,7 @@ pub mut:
 	receiver_concrete_type Type // if receiver_type is T, then receiver_concrete_type is concrete type, otherwise it is the same as receiver_type
 	return_type            Type
 	return_type_generic    Type   // the original generic return type from fn def
+	nr_ret_values          int    // amount of return values
 	fn_var_type            Type   // the fn type, when `is_fn_a_const` or `is_fn_var` is true
 	const_name             string // the fully qualified name of the const, i.e. `main.c`, given `const c = abc`, and callexpr: `c()`
 	should_be_skipped      bool   // true for calls to `[if someflag?]` functions, when there is no `-d someflag`

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -778,7 +778,7 @@ pub mut:
 	receiver_concrete_type Type // if receiver_type is T, then receiver_concrete_type is concrete type, otherwise it is the same as receiver_type
 	return_type            Type
 	return_type_generic    Type   // the original generic return type from fn def
-	nr_ret_values          int    // amount of return values
+	nr_ret_values          int = -1 // amount of return values
 	fn_var_type            Type   // the fn type, when `is_fn_a_const` or `is_fn_var` is true
 	const_name             string // the fully qualified name of the const, i.e. `main.c`, given `const c = abc`, and callexpr: `c()`
 	should_be_skipped      bool   // true for calls to `[if someflag?]` functions, when there is no `-d someflag`

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -606,14 +606,16 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 			node.free_receiver = true
 		}
 	}
-	if node.return_type == ast.void_type {
-		node.nr_ret_values = 0
-	} else {
-		ret_sym := c.table.sym(node.return_type)
-		if ret_sym.info is ast.MultiReturn {
-			node.nr_ret_values = ret_sym.info.types.len
+	if node.nr_ret_values == -1 {
+		if node.return_type == ast.void_type {
+			node.nr_ret_values = 0
 		} else {
-			node.nr_ret_values = 1
+			ret_sym := c.table.sym(node.return_type)
+			if ret_sym.info is ast.MultiReturn {
+				node.nr_ret_values = ret_sym.info.types.len
+			} else {
+				node.nr_ret_values = 1
+			}
 		}
 	}
 	c.expected_or_type = node.return_type.clear_flag(.result)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2759,18 +2759,21 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 	}
 	// check if multi-return is used as unique argument to the function
 	if node.args.len == 1 && mut node.args[0].expr is ast.CallExpr {
-		if node.args[0].expr.nr_ret_values != -1 {
+		is_multi := node.args[0].expr.nr_ret_values > 1
+		if is_multi {
 			// it is a multi-return argument
 			nr_args = node.args[0].expr.nr_ret_values
-		}
-		if nr_args != nr_params {
-			unexpected_args_pos := node.args[0].pos.extend(node.args.last().pos)
-			if nr_args > 0 {
-				c.error('expected ${min_required_params} arguments, but got ${nr_args} from multi-return ${c.table.type_to_str(node.args[0].typ)}', unexpected_args_pos)
-			} else {
-				c.error('expected ${min_required_params} arguments, but got ${nr_args}', unexpected_args_pos)
+			if nr_args != nr_params {
+				unexpected_args_pos := node.args[0].pos.extend(node.args.last().pos)
+				if is_multi {
+					c.error('expected ${min_required_params} arguments, but got ${nr_args} from multi-return ${c.table.type_to_str(node.args[0].expr.return_type)}',
+						unexpected_args_pos)
+				} else {
+					c.error('expected ${min_required_params} arguments, but got ${nr_args}',
+						unexpected_args_pos)
+				}
+				return error('')
 			}
-			return error('')
 		}
 	}
 	if min_required_params < 0 {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -606,7 +606,7 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 			node.free_receiver = true
 		}
 	}
-	if node.nr_ret_values == -1 {
+	if node.nr_ret_values == -1 && node.return_type != 0 {
 		if node.return_type == ast.void_type {
 			node.nr_ret_values = 0
 		} else {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1352,7 +1352,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			if arg_typ !in [ast.voidptr_type, ast.nil_type]
 				&& !c.check_multiple_ptr_match(arg_typ, param.typ, param, call_arg) {
 				got_typ_str, expected_typ_str := c.get_string_names_of(arg_typ, param.typ)
-				c.error('1cannot use `${got_typ_str}` as `${expected_typ_str}` in argument ${i + 1} to `${fn_name}`',
+				c.error('cannot use `${got_typ_str}` as `${expected_typ_str}` in argument ${i + 1} to `${fn_name}`',
 					call_arg.pos)
 			}
 			continue
@@ -1473,7 +1473,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		if final_param_sym.kind == .struct_ && arg_typ !in [ast.voidptr_type, ast.nil_type]
 			&& !c.check_multiple_ptr_match(arg_typ, param.typ, param, call_arg) {
 			got_typ_str, expected_typ_str := c.get_string_names_of(arg_typ, param.typ)
-			c.error('2cannot use `${got_typ_str}` as `${expected_typ_str}` in argument ${i + 1} to `${fn_name}`',
+			c.error('cannot use `${got_typ_str}` as `${expected_typ_str}` in argument ${i + 1} to `${fn_name}`',
 				call_arg.pos)
 		}
 		// Warn about automatic (de)referencing, which will be removed soon.

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2765,13 +2765,8 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 			nr_args = node.args[0].expr.nr_ret_values
 			if nr_args != nr_params {
 				unexpected_args_pos := node.args[0].pos.extend(node.args.last().pos)
-				if is_multi {
-					c.error('expected ${min_required_params} arguments, but got ${nr_args} from multi-return ${c.table.type_to_str(node.args[0].expr.return_type)}',
-						unexpected_args_pos)
-				} else {
-					c.error('expected ${min_required_params} arguments, but got ${nr_args}',
-						unexpected_args_pos)
-				}
+				c.error('expected ${min_required_params} arguments, but got ${nr_args} from multi-return ${c.table.type_to_str(node.args[0].expr.return_type)}',
+					unexpected_args_pos)
 				return error('')
 			}
 		}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2759,13 +2759,17 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 	}
 	// check if multi-return is used as unique argument to the function
 	if node.args.len == 1 && mut node.args[0].expr is ast.CallExpr {
-		if node.args[0].expr.nr_ret_values > 1 {
+		if node.args[0].expr.nr_ret_values != -1 {
 			// it is a multi-return argument
 			nr_args = node.args[0].expr.nr_ret_values
 		}
 		if nr_args != nr_params {
 			unexpected_args_pos := node.args[0].pos.extend(node.args.last().pos)
-			c.error('expected ${min_required_params} arguments, but got ${nr_args}', unexpected_args_pos)
+			if nr_args > 0 {
+				c.error('expected ${min_required_params} arguments, but got ${nr_args} from multi-return ${c.table.type_to_str(node.args[0].typ)}', unexpected_args_pos)
+			} else {
+				c.error('expected ${min_required_params} arguments, but got ${nr_args}', unexpected_args_pos)
+			}
 			return error('')
 		}
 	}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -4,6 +4,8 @@ import v.ast
 import v.util
 import v.token
 
+const print_everything_fns = ['println', 'print', 'eprintln', 'eprint', 'panic']
+
 fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 	$if trace_post_process_generic_fns_types ? {
 		if node.generic_names.len > 0 {
@@ -1019,7 +1021,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		}
 	}
 	if is_native_builtin {
-		if node.args.len > 0 && fn_name in ['println', 'print', 'eprintln', 'eprint', 'panic'] {
+		if node.args.len > 0 && fn_name in checker.print_everything_fns {
 			c.builtin_args(mut node, fn_name, func)
 			return func.return_type
 		}
@@ -1185,7 +1187,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		c.check_expected_arg_count(mut node, func) or { return func.return_type }
 	}
 	// println / eprintln / panic can print anything
-	if node.args.len > 0 && fn_name in ['println', 'print', 'eprintln', 'eprint', 'panic'] {
+	if node.args.len > 0 && fn_name in checker.print_everything_fns {
 		c.builtin_args(mut node, fn_name, func)
 		return func.return_type
 	}
@@ -2760,7 +2762,7 @@ fn (mut c Checker) check_expected_arg_count(mut node ast.CallExpr, f &ast.Fn) ! 
 	// check if multi-return is used as unique argument to the function
 	if node.args.len == 1 && mut node.args[0].expr is ast.CallExpr {
 		is_multi := node.args[0].expr.nr_ret_values > 1
-		if is_multi {
+		if is_multi && node.name !in checker.print_everything_fns {
 			// it is a multi-return argument
 			nr_args = node.args[0].expr.nr_ret_values
 			if nr_args != nr_params {

--- a/vlib/v/checker/tests/multi_return_err.out
+++ b/vlib/v/checker/tests/multi_return_err.out
@@ -5,16 +5,16 @@ vlib/v/checker/tests/multi_return_err.vv:10:10: error: cannot use `f64` as `int`
       |             ~~~~~~~~~~
    11 |     my_func3(my_func2(), 'foo')
    12 |     my_func4('foo', my_func2())
-vlib/v/checker/tests/multi_return_err.vv:11:11: error: cannot use `f64` as `int` in argument 2 to `my_func3` from (int, f64)
+vlib/v/checker/tests/multi_return_err.vv:11:2: error: expected 3 arguments, but got 2
     9 | fn main() {
    10 |     my_func(my_func2())
    11 |     my_func3(my_func2(), 'foo')
-      |              ~~~~~~~~~~
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    12 |     my_func4('foo', my_func2())
    13 | }
-vlib/v/checker/tests/multi_return_err.vv:12:18: error: cannot use `f64` as `int` in argument 3 to `my_func4` from (int, f64)
+vlib/v/checker/tests/multi_return_err.vv:12:2: error: expected 3 arguments, but got 2
    10 |     my_func(my_func2())
    11 |     my_func3(my_func2(), 'foo')
    12 |     my_func4('foo', my_func2())
-      |                     ~~~~~~~~~~
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    13 | }

--- a/vlib/v/checker/tests/multi_return_err.out
+++ b/vlib/v/checker/tests/multi_return_err.out
@@ -19,11 +19,11 @@ vlib/v/checker/tests/multi_return_err.vv:16:2: error: expected 3 arguments, but 
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    17 |     my_func(my_func5())
    18 |     my_func(my_func6())
-vlib/v/checker/tests/multi_return_err.vv:17:10: error: expected 2 arguments, but got 0
+vlib/v/checker/tests/multi_return_err.vv:17:2: error: expected 2 arguments, but got 1
    15 |     my_func3(my_func2(), 'foo')
    16 |     my_func4('foo', my_func2())
    17 |     my_func(my_func5())
-      |             ~~~~~~~~~~
+      |     ~~~~~~~~~~~~~~~~~~~
    18 |     my_func(my_func6())
    19 | }
 vlib/v/checker/tests/multi_return_err.vv:18:10: error: expected 2 arguments, but got 3 from multi-return (int, int, int)

--- a/vlib/v/checker/tests/multi_return_err.out
+++ b/vlib/v/checker/tests/multi_return_err.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/multi_return_err.vv:10:10: error: cannot use `f64` as `int` in argument 2 to `my_func` from (int, f64)
+    8 | 
+    9 | fn main() {
+   10 |     my_func(my_func2())
+      |             ~~~~~~~~~~
+   11 |     my_func3(my_func2(), 'foo')
+   12 |     my_func4('foo', my_func2())
+vlib/v/checker/tests/multi_return_err.vv:11:11: error: cannot use `f64` as `int` in argument 2 to `my_func3` from (int, f64)
+    9 | fn main() {
+   10 |     my_func(my_func2())
+   11 |     my_func3(my_func2(), 'foo')
+      |              ~~~~~~~~~~
+   12 |     my_func4('foo', my_func2())
+   13 | }
+vlib/v/checker/tests/multi_return_err.vv:12:18: error: cannot use `f64` as `int` in argument 3 to `my_func4` from (int, f64)
+   10 |     my_func(my_func2())
+   11 |     my_func3(my_func2(), 'foo')
+   12 |     my_func4('foo', my_func2())
+      |                     ~~~~~~~~~~
+   13 | }

--- a/vlib/v/checker/tests/multi_return_err.out
+++ b/vlib/v/checker/tests/multi_return_err.out
@@ -1,20 +1,34 @@
-vlib/v/checker/tests/multi_return_err.vv:10:10: error: cannot use `f64` as `int` in argument 2 to `my_func` from (int, f64)
-    8 | 
-    9 | fn main() {
-   10 |     my_func(my_func2())
+vlib/v/checker/tests/multi_return_err.vv:14:10: error: cannot use `f64` as `int` in argument 2 to `my_func` from (int, f64)
+   12 | 
+   13 | fn main() {
+   14 |     my_func(my_func2())
       |             ~~~~~~~~~~
-   11 |     my_func3(my_func2(), 'foo')
-   12 |     my_func4('foo', my_func2())
-vlib/v/checker/tests/multi_return_err.vv:11:2: error: expected 3 arguments, but got 2
-    9 | fn main() {
-   10 |     my_func(my_func2())
-   11 |     my_func3(my_func2(), 'foo')
+   15 |     my_func3(my_func2(), 'foo')
+   16 |     my_func4('foo', my_func2())
+vlib/v/checker/tests/multi_return_err.vv:15:2: error: expected 3 arguments, but got 2
+   13 | fn main() {
+   14 |     my_func(my_func2())
+   15 |     my_func3(my_func2(), 'foo')
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   12 |     my_func4('foo', my_func2())
-   13 | }
-vlib/v/checker/tests/multi_return_err.vv:12:2: error: expected 3 arguments, but got 2
-   10 |     my_func(my_func2())
-   11 |     my_func3(my_func2(), 'foo')
-   12 |     my_func4('foo', my_func2())
+   16 |     my_func4('foo', my_func2())
+   17 |     my_func(my_func5())
+vlib/v/checker/tests/multi_return_err.vv:16:2: error: expected 3 arguments, but got 2
+   14 |     my_func(my_func2())
+   15 |     my_func3(my_func2(), 'foo')
+   16 |     my_func4('foo', my_func2())
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   13 | }
+   17 |     my_func(my_func5())
+   18 |     my_func(my_func6())
+vlib/v/checker/tests/multi_return_err.vv:17:10: error: expected 2 arguments, but got 0
+   15 |     my_func3(my_func2(), 'foo')
+   16 |     my_func4('foo', my_func2())
+   17 |     my_func(my_func5())
+      |             ~~~~~~~~~~
+   18 |     my_func(my_func6())
+   19 | }
+vlib/v/checker/tests/multi_return_err.vv:18:10: error: expected 2 arguments, but got 3 from multi-return (int, int, int)
+   16 |     my_func4('foo', my_func2())
+   17 |     my_func(my_func5())
+   18 |     my_func(my_func6())
+      |             ~~~~~~~~~~
+   19 | }

--- a/vlib/v/checker/tests/multi_return_err.vv
+++ b/vlib/v/checker/tests/multi_return_err.vv
@@ -1,0 +1,13 @@
+fn my_func(a1 int, a2 int)  {}
+
+fn my_func2() (int, f64) { return 0,0}
+
+fn my_func3(a1 int, a2 int, a3 string)  {}
+
+fn my_func4(a0 string, a1 int, a2 int)  {}
+
+fn main() {
+	my_func(my_func2())
+	my_func3(my_func2(), 'foo')
+	my_func4('foo', my_func2())
+}

--- a/vlib/v/checker/tests/multi_return_err.vv
+++ b/vlib/v/checker/tests/multi_return_err.vv
@@ -6,8 +6,14 @@ fn my_func3(a1 int, a2 int, a3 string)  {}
 
 fn my_func4(a0 string, a1 int, a2 int)  {}
 
+fn my_func5() {}
+
+fn my_func6() (int, int, int) { return 0,0,0}
+
 fn main() {
 	my_func(my_func2())
 	my_func3(my_func2(), 'foo')
 	my_func4('foo', my_func2())
+	my_func(my_func5())
+	my_func(my_func6())
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2463,6 +2463,25 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 			if !exp_option {
 				expected_types[i] = expected_types[i].clear_flag(.option)
 			}
+		} else if arg.expr is ast.CallExpr {
+			if arg.expr.nr_ret_values > 1 {
+				line := g.go_before_last_stmt().trim_space()
+				g.empty_line = true
+				ret_type := arg.expr.return_type
+				tmp_var := g.new_tmp_var()
+				g.write('${g.typ(ret_type)} ${tmp_var} = ')
+				g.expr(arg.expr)
+				g.writeln(';')
+				g.write(line)
+				for n in 0 .. arg.expr.nr_ret_values {
+					if n != arg.expr.nr_ret_values - 1 {
+						g.write('${tmp_var}.arg${n},')
+					} else {
+						g.write('${tmp_var}.arg${n}')
+					}
+				}
+				continue
+			}
 		}
 		use_tmp_var_autofree := g.is_autofree && arg.typ == ast.string_type && arg.is_tmp_autofree
 			&& !g.inside_const && !g.is_builtin_mod

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2474,8 +2474,8 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 				g.writeln(';')
 				g.write(line)
 				for n in 0 .. arg.expr.nr_ret_values {
-					if n != arg.expr.nr_ret_values - 1 {
-						g.write('${tmp_var}.arg${n},')
+					if n != arg.expr.nr_ret_values - 1 || i != args.len - 1 {
+						g.write('${tmp_var}.arg${n}, ')
 					} else {
 						g.write('${tmp_var}.arg${n}')
 					}

--- a/vlib/v/tests/multi_return_test.v
+++ b/vlib/v/tests/multi_return_test.v
@@ -4,32 +4,6 @@ fn my_func2() (int, int) {
 	return 0, 0
 }
 
-fn my_func3(a1 int, a2 int, a3 string) {}
-
-fn my_func4(a0 string, a1 int, a2 int) {}
-
-fn my_func5() (int, string) {
-	return 0, ''
-}
-
-fn my_func6(a1 int, a2 string) {}
-
-fn my_func7(a1 int, a2 string, a3 bool) {}
-
-fn my_func8(a1 int, a2 int, a3 string, a4 bool) {}
-
-fn my_func9() (string, bool) {
-	return '', false
-}
-
 fn test_main() {
 	my_func(my_func2())
-	my_func3(my_func2(), 'foo')
-	my_func4('foo', my_func2())
-}
-
-fn test_mixed() {
-	my_func6(my_func5())
-	my_func7(my_func5(), true)
-	my_func8(my_func2(), my_func9())
 }

--- a/vlib/v/tests/multi_return_test.v
+++ b/vlib/v/tests/multi_return_test.v
@@ -1,0 +1,35 @@
+fn my_func(a1 int, a2 int) {}
+
+fn my_func2() (int, int) {
+	return 0, 0
+}
+
+fn my_func3(a1 int, a2 int, a3 string) {}
+
+fn my_func4(a0 string, a1 int, a2 int) {}
+
+fn my_func5() (int, string) {
+	return 0, ''
+}
+
+fn my_func6(a1 int, a2 string) {}
+
+fn my_func7(a1 int, a2 string, a3 bool) {}
+
+fn my_func8(a1 int, a2 int, a3 string, a4 bool) {}
+
+fn my_func9() (string, bool) {
+	return '', false
+}
+
+fn test_main() {
+	my_func(my_func2())
+	my_func3(my_func2(), 'foo')
+	my_func4('foo', my_func2())
+}
+
+fn test_mixed() {
+	my_func6(my_func5())
+	my_func7(my_func5(), true)
+	my_func8(my_func2(), my_func9())
+}


### PR DESCRIPTION
Fix #21956

```v 
fn my_func(a1 int, a2 int)  {}

fn my_func2() (int, int)  { return 0,0 }

fn main() {
	my_func(my_func2())
}
```