### PR TITLE
hash: Update hash.Hash methods

### DIFF
--- a/vlib/hash/hash.v
+++ b/vlib/hash/hash.v
@@ -4,11 +4,15 @@
 module hash
 
 pub interface Hash {
+mut:
 	// Sum appends the current hash to b and returns the resulting array.
 	// It does not change the underlying hash state.
 	sum(b []u8) []u8
 	size() int
 	block_size() int
+	free()
+	reset()
+	write(p []u8) !int
 }
 
 interface Hash32er {


### PR DESCRIPTION
The hash.Hash interface was likely partially ported from Go. 
Over time Vlang evolved and structs that implement the hash.Hash interface also gained new methods to bridge the differences between the Go version and the V version.
These new methods were not added to the hash.Hash interface.
This pull request adds these new methods to the hash.Hash interface.