### PR TITLE
cgen: fix bug preventing generation of closures from methods

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4044,7 +4044,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			if !node.expr_type.is_ptr() {
 				g.write('&')
 			}
-			g.expr(node.expr)
+			if !node.expr.is_lvalue() {
+				current_stmt := g.go_before_last_stmt()
+				var := g.new_ctemp_var_then_gen(node.expr, node.expr_type)
+				g.write(current_stmt)
+				g.expr(ast.Expr(var))
+			} else {
+				g.expr(node.expr)
+			}
 			if !receiver.typ.is_ptr() {
 				g.write(', sizeof(${expr_styp}))')
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4046,8 +4046,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			}
 			if !node.expr.is_lvalue() {
 				current_stmt := g.go_before_last_stmt()
+				g.empty_line = true
 				var := g.new_ctemp_var_then_gen(node.expr, node.expr_type)
-				g.write(current_stmt)
+				g.write(current_stmt.trim_left('\t '))
 				g.expr(ast.Expr(var))
 			} else {
 				g.expr(node.expr)

--- a/vlib/v/tests/closure_of_method_defined_on_alias_test.v
+++ b/vlib/v/tests/closure_of_method_defined_on_alias_test.v
@@ -1,13 +1,15 @@
 type UInt = u32
 
-fn (me UInt) member() {
+fn (me UInt) member() u32 {
 	println('member called')
+	return me * 10
 }
 
 fn test_1() {
 	println('start')
 	x := UInt(4).member
 	println('med')
-	x()
+	res := x()
 	println('done')
+	assert res == 40
 }

--- a/vlib/v/tests/closure_of_method_defined_on_alias_test.v
+++ b/vlib/v/tests/closure_of_method_defined_on_alias_test.v
@@ -1,0 +1,13 @@
+type UInt = u32
+
+fn (me UInt) member() {
+	println('member called')
+}
+
+fn test_1() {
+	println('start')
+	x := UInt(4).member
+	println('med')
+	x()
+	println('done')
+}


### PR DESCRIPTION
Allows the following code to compile and execute correctly:
```v
type UInt = u32;

fn (me UInt) member() {
  println("member called")
}

fn test_1() {
  x := UInt(4).member
  x()
}
```

The changes made change the generated C output from
```c
VV_LOCAL_SYMBOL void main__test_1(void) {
	println(_SLIT("start"));
	void (*x) (void) = __closure_create(_V_closure_main__UInt_take_136, memdup_uncollectable(&((main__UInt)(4)), sizeof(main__UInt)));
	println(_SLIT("med"));
	x();
	println(_SLIT("done"));
}
```
to
```c
VV_LOCAL_SYMBOL void main__test_1(void) {
	println(_SLIT("start"));
main__UInt _t1 = ((main__UInt)(4));
		void (*x) (void) = __closure_create(_V_closure_main__UInt_take_136, memdup_uncollectable(&_t1, sizeof(main__UInt)));
	println(_SLIT("med"));
	x();
	println(_SLIT("done"));
}
```

This does use one of the functions marked as a hack (`Gen.go_before_last_stmt`), and the indentation in the generated code is also off - I would appreciate edits/suggestions for how to correct this. Also, I am aware that a similar bug exists in the JS backend too, which I hope to submit another PR to fix.