### PR TITLE
fmt: fix enum fields with one empty line

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1359,13 +1359,14 @@ pub mut:
 // enum field in enum declaration
 pub struct EnumField {
 pub:
-	name          string // just `lock`, or `abc`, etc, no matter if the name is a keyword or not.
-	source_name   string // The name in the source, for example `@lock`, and `abc`. Note that `lock` is a keyword in V.
-	pos           token.Pos
-	comments      []Comment // comment after Enumfield in the same line
-	next_comments []Comment // comments between current EnumField and next EnumField
-	has_expr      bool      // true, when .expr has a value
-	attrs         []Attr
+	name             string // just `lock`, or `abc`, etc, no matter if the name is a keyword or not.
+	source_name      string // The name in the source, for example `@lock`, and `abc`. Note that `lock` is a keyword in V.
+	pos              token.Pos
+	comments         []Comment // comment after Enumfield in the same line
+	next_comments    []Comment // comments between current EnumField and next EnumField
+	has_expr         bool      // true, when .expr has a value
+	has_prev_newline bool      // empty newline before Enumfield
+	attrs            []Attr
 pub mut:
 	expr Expr // the value of current EnumField; 123 in `ename = 123`
 }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1072,9 +1072,9 @@ pub fn (mut f Fmt) enum_decl(node ast.EnumDecl) {
 		if i > 0 {
 			// keep one empty line between fields
 			last_field := node.fields[i - 1]
-			before_last_line := if last_field.comments.len > 0
-				&& last_field.pos.line_nr < last_field.comments.last().pos.last_line {
-				last_field.comments.last().pos.last_line
+			before_last_line := if last_field.next_comments.len > 0
+				&& last_field.pos.line_nr < last_field.next_comments.last().pos.last_line {
+				last_field.next_comments.last().pos.last_line
 			} else if last_field.has_expr {
 				last_field.expr.pos().last_line
 			} else {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1069,28 +1069,8 @@ pub fn (mut f Fmt) enum_decl(node ast.EnumDecl) {
 	mut attr_align_i := 0
 	mut comment_align_i := 0
 	for i, field in node.fields {
-		if i > 0 {
-			// keep one empty line between fields
-			last_field := node.fields[i - 1]
-			before_last_line := if last_field.next_comments.len > 0
-				&& last_field.pos.line_nr < last_field.next_comments.last().pos.last_line {
-				last_field.next_comments.last().pos.last_line
-			} else if last_field.has_expr {
-				last_field.expr.pos().last_line
-			} else {
-				last_field.pos.line_nr
-			}
-
-			next_first_line := if field.comments.len > 0
-				&& field.pos.line_nr > field.comments[0].pos.line_nr {
-				field.comments[0].pos.line_nr
-			} else {
-				field.pos.line_nr
-			}
-
-			if next_first_line - before_last_line > 1 {
-				f.writeln('')
-			}
+		if i > 0 && field.has_prev_newline {
+			f.writeln('')
 		}
 		f.write('\t${field.name}')
 		if field.has_expr {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1068,7 +1068,30 @@ pub fn (mut f Fmt) enum_decl(node ast.EnumDecl) {
 	mut value_align_i := 0
 	mut attr_align_i := 0
 	mut comment_align_i := 0
-	for field in node.fields {
+	for i, field in node.fields {
+		if i > 0 {
+			// keep one empty line between fields
+			last_field := node.fields[i - 1]
+			before_last_line := if last_field.comments.len > 0
+				&& last_field.pos.line_nr < last_field.comments.last().pos.last_line {
+				last_field.comments.last().pos.last_line
+			} else if last_field.has_expr {
+				last_field.expr.pos().last_line
+			} else {
+				last_field.pos.line_nr
+			}
+
+			next_first_line := if field.comments.len > 0
+				&& field.pos.line_nr > field.comments[0].pos.line_nr {
+				field.comments[0].pos.line_nr
+			} else {
+				field.pos.line_nr
+			}
+
+			if next_first_line - before_last_line > 1 {
+				f.writeln('')
+			}
+		}
 		f.write('\t${field.name}')
 		if field.has_expr {
 			if value_aligns[value_align_i].line_nr < field.pos.line_nr {

--- a/vlib/v/fmt/tests/enum_fields_with_empty_line_keep.vv
+++ b/vlib/v/fmt/tests/enum_fields_with_empty_line_keep.vv
@@ -3,6 +3,8 @@ enum Info {
 	bbb // bbb
 
 	cccc = 5 // cccc
+	//
+	ddddd = 10 // ddddd
 }
 
 fn main() {}

--- a/vlib/v/fmt/tests/enum_fields_with_empty_line_keep.vv
+++ b/vlib/v/fmt/tests/enum_fields_with_empty_line_keep.vv
@@ -1,0 +1,8 @@
+enum Info {
+	aa = 1 // aa
+	bbb // bbb
+
+	cccc = 5 // cccc
+}
+
+fn main() {}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4101,6 +4101,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	mut fields := []ast.EnumField{}
 	mut uses_exprs := false
 	mut enum_attrs := map[string][]ast.Attr{}
+	mut prev_last_line_nr := 0
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
 		pos := p.tok.pos()
 		val := p.check_name()
@@ -4123,12 +4124,19 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		}
 		comments := p.eat_comments(same_line: true)
 		next_comments := p.eat_comments()
+		has_prev_newline := prev_last_line_nr > 0 && pos.line_nr - prev_last_line_nr > 1
+		if next_comments.len > 0 {
+			prev_last_line_nr = next_comments.last().pos.last_line
+		} else {
+			prev_last_line_nr = pos.last_line
+		}
 		fields << ast.EnumField{
 			name: val
 			source_name: source_name(val)
 			pos: pos
 			expr: expr
 			has_expr: has_expr
+			has_prev_newline: has_prev_newline
 			comments: comments
 			next_comments: next_comments
 			attrs: attrs

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4101,9 +4101,9 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	mut fields := []ast.EnumField{}
 	mut uses_exprs := false
 	mut enum_attrs := map[string][]ast.Attr{}
-	mut prev_last_line_nr := 0
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
 		pos := p.tok.pos()
+		has_prev_newline := p.tok.line_nr - p.prev_tok.line_nr > 1
 		val := p.check_name()
 		vals << val
 		mut expr := ast.empty_expr
@@ -4124,12 +4124,6 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		}
 		comments := p.eat_comments(same_line: true)
 		next_comments := p.eat_comments()
-		has_prev_newline := prev_last_line_nr > 0 && pos.line_nr - prev_last_line_nr > 1
-		if next_comments.len > 0 {
-			prev_last_line_nr = next_comments.last().pos.last_line
-		} else {
-			prev_last_line_nr = pos.last_line
-		}
 		fields << ast.EnumField{
 			name: val
 			source_name: source_name(val)


### PR DESCRIPTION
This PR fix enum fields with one empty line.

- Fix enum fields with one empty line.
- Add a test.

enum_fields_with_empty_line_keep.vv
```v
enum Info {
	aa = 1 // aa
	bbb // bbb

	cccc = 5 // cccc
	//
	ddddd = 10 // ddddd
}

fn main() {}
```