### PR TITLE
cgen: skip .placeholder when writing result generic types

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1185,6 +1185,9 @@ fn (mut g Gen) result_type_name(t ast.Type) (string, string) {
 	}
 	mut styp := ''
 	sym := g.table.sym(t)
+	if sym.kind == .placeholder {
+		return '', ''
+	}
 	if sym.info is ast.FnType {
 		base = 'anon_fn_${g.table.fn_type_signature(sym.info.func)}'
 	}
@@ -1278,7 +1281,7 @@ fn (mut g Gen) write_results() {
 		done = g.done_results.clone()
 	}
 	for base, styp in g.results {
-		if base in done {
+		if base in done || base == '' { // done or placeholder
 			continue
 		}
 		done << base

--- a/vlib/v/tests/result_generic_test.v
+++ b/vlib/v/tests/result_generic_test.v
@@ -19,16 +19,6 @@ fn take_part(count u32) TParser[[]u8] {
 	}
 }
 
-fn map[O](p TParser[u8], f TF[O]) TParser[O] {
-	return fn [p, f] [O](i []u8) !ParserResult[O] {
-		r := p(i)!
-		return ParserResult{
-			i: r.i
-			o: f(r.o)
-		}
-	}
-}
-
 fn test_main() {
 	input := '10_ttt_uuuu_qqq_'.bytes()
 

--- a/vlib/v/tests/result_generic_test.v
+++ b/vlib/v/tests/result_generic_test.v
@@ -1,0 +1,39 @@
+pub struct ParserResult[O] {
+	i []u8
+	o O
+}
+
+type TParser[O] = fn ([]u8) !ParserResult[O]
+
+type TF[O] = fn ([]u8) O
+
+fn take_part(count u32) TParser[[]u8] {
+	return fn [count] (i []u8) !ParserResult[[]u8] {
+		if i.len < count {
+			return error('error len: ${i}')
+		}
+		return ParserResult[[]u8]{
+			i: i[count..]
+			o: i[..count]
+		}
+	}
+}
+
+fn map[O](p TParser[u8], f TF[O]) TParser[O] {
+	return fn [p, f] [O](i []u8) !ParserResult[O] {
+		r := p(i)!
+		return ParserResult{
+			i: r.i
+			o: f(r.o)
+		}
+	}
+}
+
+fn test_main() {
+	input := '10_ttt_uuuu_qqq_'.bytes()
+
+	nnn := take_part(2)
+	res := nnn(input)!
+	assert res.i == [u8(95), 116, 116, 116, 95, 117, 117, 117, 117, 95, 113, 113, 113, 95]
+	assert res.o == [u8(49), 48]
+}


### PR DESCRIPTION
Fix #22008