### PR TITLE
ast, parser, fmt: cleanup fmt of struct fields with empty line

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -333,6 +333,7 @@ pub:
 	comments         []Comment
 	i                int
 	has_default_expr bool
+	has_prev_newline bool
 	attrs            []Attr
 	is_pub           bool
 	default_val      string

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -77,28 +77,8 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 			i == node.module_pos {
 				f.writeln('module:')
 			}
-			i > 0 {
-				// keep one empty line between fields (exclude one after mut:, pub:, ...)
-				last_field := node.fields[i - 1]
-				before_last_line := if last_field.comments.len > 0
-					&& last_field.pos.line_nr < last_field.comments.last().pos.last_line {
-					last_field.comments.last().pos.last_line
-				} else if last_field.has_default_expr {
-					last_field.default_expr.pos().last_line
-				} else {
-					last_field.pos.line_nr
-				}
-
-				next_first_line := if field.comments.len > 0
-					&& field.pos.line_nr > field.comments[0].pos.line_nr {
-					field.comments[0].pos.line_nr
-				} else {
-					field.pos.line_nr
-				}
-
-				if next_first_line - before_last_line > 1 {
-					f.writeln('')
-				}
+			i > 0 && field.has_prev_newline {
+				f.writeln('')
 			}
 			else {}
 		}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -186,11 +186,13 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				&& (p.peek_tok.kind != .lsbr || p.peek_token(2).kind != .rsbr))
 				|| p.peek_tok.kind == .dot) && language == .v && p.peek_tok.kind != .key_fn
 			is_on_top := ast_fields.len == 0 && !(is_field_pub || is_field_mut || is_field_global)
+			has_prev_newline := p.tok.line_nr - p.prev_tok.line_nr - p.prev_tok.lit.count('\n') > 1
 			mut field_name := ''
 			mut typ := ast.Type(0)
 			mut type_pos := token.Pos{}
 			mut field_pos := token.Pos{}
 			mut option_pos := token.Pos{}
+
 			if is_embed {
 				// struct embedding
 				type_pos = p.tok.pos()
@@ -305,6 +307,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					i: i
 					default_expr: default_expr
 					has_default_expr: has_default_expr
+					has_prev_newline: has_prev_newline
 					attrs: p.attrs
 					is_pub: is_embed || is_field_pub
 					is_mut: is_embed || is_field_mut


### PR DESCRIPTION
This PR cleanup fmt of struct fields with empty line.