### PR TITLE
ast, parser, fmt: fix fmt of enum fields with empty line

### DIFF
--- a/vlib/v/fmt/tests/enum_fields_with_empty_line_keep.vv
+++ b/vlib/v/fmt/tests/enum_fields_with_empty_line_keep.vv
@@ -2,8 +2,9 @@ enum Info {
 	aa = 1 // aa
 	bbb // bbb
 
-	cccc = 5 // cccc
-	//
+	cccc = 5 /* cccc
+	--- cccc
+	*/
 	ddddd = 10 // ddddd
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4103,7 +4103,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	mut enum_attrs := map[string][]ast.Attr{}
 	for p.tok.kind != .eof && p.tok.kind != .rcbr {
 		pos := p.tok.pos()
-		has_prev_newline := p.tok.line_nr - p.prev_tok.line_nr > 1
+		has_prev_newline := p.tok.line_nr - p.prev_tok.line_nr - p.prev_tok.lit.count('\n') > 1
 		val := p.check_name()
 		vals << val
 		mut expr := ast.empty_expr


### PR DESCRIPTION
This PR fix fmt of enum fields with empty line.

- Fix fmt of enum fields with empty line.
- Change test.

vlib\v\fmt\tests\enum_fields_with_empty_line_keep.vv
```v
enum Info {
	aa = 1 // aa
	bbb // bbb

	cccc = 5 /* cccc
	--- cccc
	*/
	ddddd = 10 // ddddd
}

fn main() {}
```