### PR TITLE
flag: add optional value description to string parameters

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -400,19 +400,39 @@ pub fn (mut fs FlagParser) float(name string, abbr u8, fdefault f64, usage strin
 	return value
 }
 
+@[params]
+pub struct FlagConfig {
+pub:
+	val_desc string // descriptive string for an argument
+}
+
 // string_multi returns all string values, associated with the flag named `name`.
 // When no values for that flag are found, it returns an empty array.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) string_multi(name string, abbr u8, usage string) []string {
-	fs.add_flag(name, abbr, usage, '<multiple strings>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) string_multi(name string, abbr u8, usage string, c FlagConfig) []string {
+	val_desc := if c.val_desc == '' {
+		'<multiple strings>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	return fs.parse_value(name, abbr)
 }
 
 // string_opt returns an option with the string value, associated with the flag in `name`.
 // When the flag is not given by the user, it returns an error.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) string_opt(name string, abbr u8, usage string) !string {
-	fs.add_flag(name, abbr, usage, '<string>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) string_opt(name string, abbr u8, usage string, c FlagConfig) !string {
+	val_desc := if c.val_desc == '' {
+		'<string>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	parsed := fs.parse_value(name, abbr)
 	if parsed.len == 0 {
 		return error("parameter '${name}' not provided")
@@ -424,8 +444,9 @@ pub fn (mut fs FlagParser) string_opt(name string, abbr u8, usage string) !strin
 // If that flag is given as an option, then its parsed value is returned as a string.
 // When it is not, it returns the default string value in `sdefault`.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) string(name string, abbr u8, sdefault string, usage string) string {
-	value := fs.string_opt(name, abbr, usage) or { return sdefault }
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) string(name string, abbr u8, sdefault string, usage string, c FlagConfig) string {
+	value := fs.string_opt(name, abbr, usage, c) or { return sdefault }
 	return value
 }
 

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -194,6 +194,24 @@ fn test_if_no_options_given_usage_message_does_not_contain_options() {
 	assert !fp.usage().contains('Options:')
 }
 
+fn test_default_val_descriptions_for_strings() {
+	mut fp := flag.new_flag_parser([])
+	fp.string_multi('a_string', `a`, '')
+	fp.string('a_string', `s`, '', '')
+
+	assert fp.usage().contains('<multiple strings>')
+	assert fp.usage().contains('<string>')
+}
+
+fn test_custom_val_descriptions_for_strings() {
+	mut fp := flag.new_flag_parser([])
+	fp.string_multi('a_string', `a`, '', val_desc: '<multi custom>')
+	fp.string('a_string', `s`, '', '', val_desc: '<custom>')
+
+	assert fp.usage().contains('<multi custom>')
+	assert fp.usage().contains('<custom>')
+}
+
 fn test_free_args_could_be_limited() {
 	mut fp1 := flag.new_flag_parser(['a', 'b', 'c'])
 	fp1.limit_free_args(1, 4)!


### PR DESCRIPTION
When using command line flags with string parameters, I found that the default val_desc values used were not as descriptive as I would like.  And there was no way to override val_desc to a more descriptive value.

Using trailing struct literal arguments, I was able to add this capability without breaking any existing code.

I only did this for string parameters since that seemed to me to be the place where it would be most useful.  It could easily be added to the other types if desired.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
