### PR TITLE
vlib/v/help/common: remove extraneous word "of"

### DIFF
--- a/vlib/v/help/common/where.txt
+++ b/vlib/v/help/common/where.txt
@@ -22,7 +22,7 @@ symbol_name can be:
   regexp
 
 Options:
-  -mod  [mod_name]    Restrict to search recursively only within of the given
+  -mod  [mod_name]    Restrict to search recursively only within the given
                       module, if not provided search in entire v scope
                       (use -mod main to search inside all your project).
   -dir  [dir_path]    Restrict to search non recursively within the given


### PR DESCRIPTION
Just fixing a minor wording problem.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
