### PR TITLE
flag: add custom value descriptions for bool, int, and float flags too

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -311,11 +311,24 @@ fn (mut fs FlagParser) parse_bool_value(longhand string, shorthand u8) !string {
 	return error("parameter '${longhand}' not found")
 }
 
+@[params]
+pub struct FlagConfig {
+pub:
+	val_desc string // descriptive string for an argument
+}
+
 // bool_opt returns an option with the bool value of the given command line flag, named `name`.
 // It returns an error, when the flag is not given by the user.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) bool_opt(name string, abbr u8, usage string) !bool {
-	fs.add_flag(name, abbr, usage, '<bool>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) bool_opt(name string, abbr u8, usage string, c FlagConfig) !bool {
+	val_desc := if c.val_desc == '' {
+		'<bool>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	parsed := fs.parse_bool_value(name, abbr) or {
 		return error("parameter '${name}' not provided")
 	}
@@ -326,16 +339,24 @@ pub fn (mut fs FlagParser) bool_opt(name string, abbr u8, usage string) !bool {
 // If that flag is given by the user, then it returns its parsed bool value.
 // When it is not, it returns the default value in `bdefault`.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) bool(name string, abbr u8, bdefault bool, usage string) bool {
-	value := fs.bool_opt(name, abbr, usage) or { return bdefault }
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) bool(name string, abbr u8, bdefault bool, usage string, c FlagConfig) bool {
+	value := fs.bool_opt(name, abbr, usage, c) or { return bdefault }
 	return value
 }
 
 // int_multi returns all values associated with the provided flag in `name`.
 // When that flag has no values, it returns an empty array.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) int_multi(name string, abbr u8, usage string) []int {
-	fs.add_flag(name, abbr, usage, '<multiple ints>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) int_multi(name string, abbr u8, usage string, c FlagConfig) []int {
+	val_desc := if c.val_desc == '' {
+		'<multiple ints>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	parsed := fs.parse_value(name, abbr)
 	mut value := []int{}
 	for val in parsed {
@@ -347,8 +368,15 @@ pub fn (mut fs FlagParser) int_multi(name string, abbr u8, usage string) []int {
 // int_opt returns an option with the integer value, associated with the flag in `name`.
 // When the flag is not given by the user, it returns an error.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) int_opt(name string, abbr u8, usage string) !int {
-	fs.add_flag(name, abbr, usage, '<int>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) int_opt(name string, abbr u8, usage string, c FlagConfig) !int {
+	val_desc := if c.val_desc == '' {
+		'<int>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	parsed := fs.parse_value(name, abbr)
 	if parsed.len == 0 {
 		return error("parameter '${name}' not provided")
@@ -361,16 +389,24 @@ pub fn (mut fs FlagParser) int_opt(name string, abbr u8, usage string) !int {
 // When the flag is given by the user, it returns its parsed integer value.
 // When it is not, it returns the integer value in `idefault`.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) int(name string, abbr u8, idefault int, usage string) int {
-	value := fs.int_opt(name, abbr, usage) or { return idefault }
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) int(name string, abbr u8, idefault int, usage string, c FlagConfig) int {
+	value := fs.int_opt(name, abbr, usage, c) or { return idefault }
 	return value
 }
 
 // float_multi returns all floating point values, associated with the flag named `name`.
 // When no values for that flag are found, it returns an empty array.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) float_multi(name string, abbr u8, usage string) []f64 {
-	fs.add_flag(name, abbr, usage, '<multiple floats>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) float_multi(name string, abbr u8, usage string, c FlagConfig) []f64 {
+	val_desc := if c.val_desc == '' {
+		'<multiple floats>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	parsed := fs.parse_value(name, abbr)
 	mut value := []f64{}
 	for val in parsed {
@@ -382,8 +418,15 @@ pub fn (mut fs FlagParser) float_multi(name string, abbr u8, usage string) []f64
 // float_opt returns an option with the floating point value, associated with the flag in `name`.
 // When the flag is not given by the user, it returns an error.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) float_opt(name string, abbr u8, usage string) !f64 {
-	fs.add_flag(name, abbr, usage, '<float>')
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) float_opt(name string, abbr u8, usage string, c FlagConfig) !f64 {
+	val_desc := if c.val_desc == '' {
+		'<float>'
+	} else {
+		c.val_desc
+	}
+
+	fs.add_flag(name, abbr, usage, val_desc)
 	parsed := fs.parse_value(name, abbr)
 	if parsed.len == 0 {
 		return error("parameter '${name}' not provided")
@@ -395,15 +438,10 @@ pub fn (mut fs FlagParser) float_opt(name string, abbr u8, usage string) !f64 {
 // When the flag is given by the user, it returns its parsed floating point value.
 // When it is not, it returns the value in `fdefault`.
 // This version supports abbreviations.
-pub fn (mut fs FlagParser) float(name string, abbr u8, fdefault f64, usage string) f64 {
-	value := fs.float_opt(name, abbr, usage) or { return fdefault }
+// This version supports a custom value description.
+pub fn (mut fs FlagParser) float(name string, abbr u8, fdefault f64, usage string, c FlagConfig) f64 {
+	value := fs.float_opt(name, abbr, usage, c) or { return fdefault }
 	return value
-}
-
-@[params]
-pub struct FlagConfig {
-pub:
-	val_desc string // descriptive string for an argument
 }
 
 // string_multi returns all string values, associated with the flag named `name`.

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -194,10 +194,62 @@ fn test_if_no_options_given_usage_message_does_not_contain_options() {
 	assert !fp.usage().contains('Options:')
 }
 
+fn test_default_val_descriptions_for_bools() {
+	mut fp := flag.new_flag_parser([])
+	fp.bool('a_bool', `b`, true, '')
+
+	// by default, boolean flags contain no value description
+	assert !fp.usage().contains('<bool>')
+}
+
+fn test_custom_val_descriptions_for_bools() {
+	mut fp := flag.new_flag_parser([])
+	fp.bool('a_bool', `b`, true, '', val_desc: '<custom bool>')
+
+	// a custom boolean value description will be output
+	assert fp.usage().contains('<custom bool>')
+}
+
+fn test_default_val_descriptions_for_ints() {
+	mut fp := flag.new_flag_parser([])
+	fp.int_multi('a_int', `a`, '')
+	fp.int('b_int', `i`, 0, '')
+
+	assert fp.usage().contains('<multiple ints>')
+	assert fp.usage().contains('<int>')
+}
+
+fn test_custom_val_descriptions_for_ints() {
+	mut fp := flag.new_flag_parser([])
+	fp.int_multi('a_int', `a`, '', val_desc: '<multi custom int>')
+	fp.int('b_int', `i`, 0, '', val_desc: '<custom int>')
+
+	assert fp.usage().contains('<multi custom int>')
+	assert fp.usage().contains('<custom int>')
+}
+
+fn test_default_val_descriptions_for_floats() {
+	mut fp := flag.new_flag_parser([])
+	fp.float_multi('a_float', `a`, '')
+	fp.float('b_float', `f`, 0.0, '')
+
+	assert fp.usage().contains('<multiple floats>')
+	assert fp.usage().contains('<float>')
+}
+
+fn test_custom_val_descriptions_for_floats() {
+	mut fp := flag.new_flag_parser([])
+	fp.float_multi('a_float', `a`, '', val_desc: '<multi custom float>')
+	fp.float('b_float', `f`, 0.0, '', val_desc: '<custom float>')
+
+	assert fp.usage().contains('<multi custom float>')
+	assert fp.usage().contains('<custom float>')
+}
+
 fn test_default_val_descriptions_for_strings() {
 	mut fp := flag.new_flag_parser([])
 	fp.string_multi('a_string', `a`, '')
-	fp.string('a_string', `s`, '', '')
+	fp.string('b_string', `s`, '', '')
 
 	assert fp.usage().contains('<multiple strings>')
 	assert fp.usage().contains('<string>')
@@ -205,11 +257,11 @@ fn test_default_val_descriptions_for_strings() {
 
 fn test_custom_val_descriptions_for_strings() {
 	mut fp := flag.new_flag_parser([])
-	fp.string_multi('a_string', `a`, '', val_desc: '<multi custom>')
-	fp.string('a_string', `s`, '', '', val_desc: '<custom>')
+	fp.string_multi('a_string', `a`, '', val_desc: '<multi custom string>')
+	fp.string('b_string', `s`, '', '', val_desc: '<custom string>')
 
-	assert fp.usage().contains('<multi custom>')
-	assert fp.usage().contains('<custom>')
+	assert fp.usage().contains('<multi custom string>')
+	assert fp.usage().contains('<custom string>')
 }
 
 fn test_free_args_could_be_limited() {


### PR DESCRIPTION
Added the same sort of value description to bool, int, and float flags as was added for string flags.  I also tweaked the code for string value descriptions.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
