### PR TITLE
cmd/tools/vwhere: sort the match results to make test less flaky

### DIFF
--- a/cmd/tools/vwhere/vwhere_test.v
+++ b/cmd/tools/vwhere/vwhere_test.v
@@ -190,6 +190,9 @@ fn test_find_in_dir_recursive() {
 	mut fdr := Finder{}
 	fdr.configure_from_arguments(args)
 	fdr.search_for_matches()
+	// the order of matches is not guaranteed.
+	// sorting by line number makes the result more deterministic.
+	fdr.matches.sort(a.line < b.line)
 	dump(fdr.matches)
 
 	assert fdr.matches == [


### PR DESCRIPTION
I noticed that on FreeBSD, the test_find_in_dir_recursive code did locate all the matches but they were in a different order from the expected value in the assertion.  I don't know if all OS/toolchain combinations will return the matches in the same order.  It does appear that FreeBSD using -cc clang returns the results in the opposite order.

Since the point of the test is to see if the 2 matches are found, sorting the matches by line number makes this test pass on FreeBSD without breaking other OS/toolchain combinations.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
