### PR TITLE
fmt: fix interface fields or methods with empty newlines

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -564,6 +564,7 @@ pub:
 	method_type_pos       token.Pos // `User` in ` fn (u User)` position
 	method_idx            int
 	rec_mut               bool // is receiver mutable
+	has_prev_newline      bool
 	rec_share             ShareType
 	language              Language // V, C, JS
 	file_mode             Language // whether *the file*, where a function was a '.c.v', '.js.v' etc.

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1408,17 +1408,29 @@ pub fn (mut f Fmt) interface_decl(node ast.InterfaceDecl) {
 
 	// TODO: alignment, comments, etc.
 	for field in immut_fields {
+		if field.has_prev_newline {
+			f.writeln('')
+		}
 		f.interface_field(field, type_align.max_len(field.pos.line_nr))
 	}
 	for method in immut_methods {
+		if method.has_prev_newline {
+			f.writeln('')
+		}
 		f.interface_method(method)
 	}
 	if mut_fields.len + mut_methods.len > 0 {
 		f.writeln('mut:')
 		for field in mut_fields {
+			if field.has_prev_newline {
+				f.writeln('')
+			}
 			f.interface_field(field, type_align.max_len(field.pos.line_nr))
 		}
 		for method in mut_methods {
+			if method.has_prev_newline {
+				f.writeln('')
+			}
 			f.interface_method(method)
 		}
 	}

--- a/vlib/v/fmt/tests/interface_with_empty_newline_keep.vv
+++ b/vlib/v/fmt/tests/interface_with_empty_newline_keep.vv
@@ -1,0 +1,15 @@
+interface Foo {
+	// a
+	a string
+
+	bb  int
+	ccc bool
+
+	m1() string
+	m2() int
+
+	m3() bool
+}
+
+fn main() {
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -654,6 +654,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		mut comments := p.eat_comments()
 		if p.peek_tok.kind == .lpar {
 			method_start_pos := p.tok.pos()
+			has_prev_newline := p.tok.line_nr - p.prev_tok.line_nr - p.prev_tok.lit.count('\n') > 1
 			line_nr := p.tok.line_nr
 			name := p.check_name()
 
@@ -676,16 +677,17 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			]
 			params << params_t
 			mut method := ast.FnDecl{
-				name:        name
-				short_name:  name
-				mod:         p.mod
-				params:      params
-				file:        p.file_path
-				return_type: ast.void_type
-				is_variadic: is_variadic
-				is_pub:      true
-				pos:         method_start_pos.extend(p.prev_tok.pos())
-				scope:       p.scope
+				name:             name
+				short_name:       name
+				mod:              p.mod
+				params:           params
+				file:             p.file_path
+				return_type:      ast.void_type
+				is_variadic:      is_variadic
+				is_pub:           true
+				pos:              method_start_pos.extend(p.prev_tok.pos())
+				scope:            p.scope
+				has_prev_newline: has_prev_newline
 			}
 			if p.tok.kind.is_start_of_type() && p.tok.line_nr == line_nr {
 				method.return_type_pos = p.tok.pos()
@@ -713,24 +715,27 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 		} else {
 			// interface fields
 			field_pos := p.tok.pos()
+			has_prev_newline := p.tok.line_nr - p.prev_tok.line_nr - p.prev_tok.lit.count('\n') > 1
 			field_name := p.check_name()
 			mut type_pos := p.tok.pos()
 			field_typ := p.parse_type()
 			type_pos = type_pos.extend(p.prev_tok.pos())
 			comments << p.eat_comments()
 			fields << ast.StructField{
-				name:     field_name
-				pos:      field_pos
-				type_pos: type_pos
-				typ:      field_typ
-				comments: comments
-				is_pub:   true
+				name:             field_name
+				pos:              field_pos
+				type_pos:         type_pos
+				typ:              field_typ
+				comments:         comments
+				is_pub:           true
+				has_prev_newline: has_prev_newline
 			}
 			info.fields << ast.StructField{
-				name:   field_name
-				typ:    field_typ
-				is_pub: true
-				is_mut: is_mut
+				name:             field_name
+				typ:              field_typ
+				is_pub:           true
+				is_mut:           is_mut
+				has_prev_newline: has_prev_newline
 			}
 		}
 	}


### PR DESCRIPTION
This PR fix interface fields or methods with empty newlines.

- Fix interface fields or methods with empty newlines.
- Add test.

interface_with_empty_newline_keep.vv
```v
interface Foo {
	// a
	a string

	bb  int
	ccc bool

	m1() string
	m2() int

	m3() bool
}

fn main() {
}
```