### PR TITLE
x.json2.decode2: add another internal test

### DIFF
--- a/vlib/x/json2/decoder2/decode_test.v
+++ b/vlib/x/json2/decoder2/decode_test.v
@@ -2,7 +2,6 @@ module decoder2
 
 fn test_nodes() {
 	mut nodes := []Node{}
-	empty_nodes_workaround := []Node{}
 
 	mut decoder := Decoder{
 		json: '{"val": "2"}'

--- a/vlib/x/json2/decoder2/decode_test.v
+++ b/vlib/x/json2/decoder2/decode_test.v
@@ -1,0 +1,43 @@
+module decoder2
+
+fn test_nodes() {
+	mut nodes := []Node{}
+	empty_nodes_workaround := []Node{}
+
+	mut decoder := Decoder{
+		json: '{"val": "2"}'
+	}
+
+	decoder.fulfill_nodes(mut nodes)
+
+	assert nodes.len == 1
+	assert nodes[0].key_pos == 2
+	assert nodes[0].key_len == 3
+	assert nodes[0].children == none
+	nodes = []
+
+	decoder = Decoder{
+		json: '{"val": 0, "val1": 1}'
+	}
+	decoder.fulfill_nodes(mut nodes)
+
+	assert nodes.len == 2
+	assert nodes[0].key_pos == 2
+	assert nodes[0].key_len == 3
+
+	assert nodes[1].key_pos == 12
+	assert nodes[1].key_len == 4
+
+	nodes = []
+
+	decoder = Decoder{
+		json: '{"val": {"val": 2}}'
+	}
+	decoder.fulfill_nodes(mut nodes)
+
+	assert nodes.len == 1
+	assert nodes[0].children != none
+	assert nodes[0].children?.len == 1
+	assert nodes[0].children?[0].key_pos == 10
+	assert nodes[0].children?[0].children == none
+}


### PR DESCRIPTION
Some json2 test

Next PR: include test bellow

```v
	nodes = []

	decoder = Decoder{
		json: '{"_type": "Cat", "val": 2}'
	}
	decoder.fulfill_nodes(mut nodes)

	dump(nodes)

	assert nodes.len == 1
	assert nodes[0].key_pos == 18
	assert nodes[0].key_len == 3
	assert nodes[0].children == none
```