### PR TITLE
all: remove the obsolete .code and .msg fields of IError

### DIFF
--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -14,10 +14,6 @@ pub fn panic(s string) {
 
 // IError holds information about an error instance
 pub interface IError {
-	// >> Hack to allow old style custom error implementations
-	// TODO: remove once deprecation period for `IError` methods has ended
-	msg  string
-	code int // <<
 	msg() string
 	code() int
 }
@@ -35,15 +31,7 @@ pub fn (err IError) str() string {
 			err.str()
 		}
 		else {
-			// >> Hack to allow old style custom error implementations
-			// TODO: remove once deprecation period for `IError` methods has ended
-			old_error_style := unsafe { voidptr(&err.msg.str) != voidptr(&err.code.str) } // if fields are not defined (new style) they don't have an offset between them
-			if old_error_style {
-				'${err.type_name()}: ${err.msg}'
-			} else {
-				// <<
-				'${err.type_name()}: ${err.msg()}'
-			}
+			'${err.type_name()}: ${err.msg()}'
 		}
 	}
 }

--- a/vlib/v/checker/tests/cast_to_interface_err.out
+++ b/vlib/v/checker/tests/cast_to_interface_err.out
@@ -1,11 +1,17 @@
-vlib/v/checker/tests/cast_to_interface_err.vv:20:9: notice: `CustomError` doesn't implement method `msg` of interface `IError`. The usage of fields is being deprecated in favor of methods.
-   18 |
+vlib/v/checker/tests/cast_to_interface_err.vv:20:9: error: `CustomError` doesn't implement method `msg` of interface `IError`
+   18 | 
+   19 | fn my_error() IError {
+   20 |     return IError(CustomError{})
+      |            ~~~~~~~~~~~~~~~~~~~~~
+   21 | }
+vlib/v/checker/tests/cast_to_interface_err.vv:20:9: error: `CustomError` doesn't implement method `code` of interface `IError`
+   18 | 
    19 | fn my_error() IError {
    20 |     return IError(CustomError{})
       |            ~~~~~~~~~~~~~~~~~~~~~
    21 | }
 vlib/v/checker/tests/cast_to_interface_err.vv:20:9: error: `CustomError` does not implement interface `IError`, cannot cast `CustomError` to interface `IError`
-   18 |
+   18 | 
    19 | fn my_error() IError {
    20 |     return IError(CustomError{})
       |            ~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.out
+++ b/vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.out
@@ -1,17 +1,17 @@
-vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:8:14: notice: `int` doesn't implement method `msg` of interface `IError`. The usage of fields is being deprecated in favor of methods.
+vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:8:14: error: `int` doesn't implement method `msg` of interface `IError`
     6 |     if _ := f() {
     7 |     } else {
     8 |         _ = err is int
       |                    ~~~
     9 |     }
    10 |
-vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:12:14: notice: `int` doesn't implement method `msg` of interface `IError`. The usage of fields is being deprecated in favor of methods.
-   10 | 
-   11 |     _ = f() or {
-   12 |         _ = err is int
+vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:8:14: error: `int` doesn't implement method `code` of interface `IError`
+    6 |     if _ := f() {
+    7 |     } else {
+    8 |         _ = err is int
       |                    ~~~
-   13 |         0
-   14 |     }
+    9 |     }
+   10 |
 vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:8:14: error: `int` doesn't implement interface `IError`
     6 |     if _ := f() {
     7 |     } else {
@@ -19,6 +19,20 @@ vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:8:14: error: 
       |                    ~~~
     9 |     }
    10 |
+vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:12:14: error: `int` doesn't implement method `msg` of interface `IError`
+   10 | 
+   11 |     _ = f() or {
+   12 |         _ = err is int
+      |                    ~~~
+   13 |         0
+   14 |     }
+vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:12:14: error: `int` doesn't implement method `code` of interface `IError`
+   10 | 
+   11 |     _ = f() or {
+   12 |         _ = err is int
+      |                    ~~~
+   13 |         0
+   14 |     }
 vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:12:14: error: `int` doesn't implement interface `IError`
    10 | 
    11 |     _ = f() or {

--- a/vlib/v/checker/tests/mut_receiver_wrong_return_type.out
+++ b/vlib/v/checker/tests/mut_receiver_wrong_return_type.out
@@ -1,25 +1,38 @@
-vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:2: notice: `&Test` doesn't implement method `msg` of interface `IError`. The usage of fields is being deprecated in favor of methods.
-    2 |
+vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:2: error: `&Test` doesn't implement method `msg` of interface `IError`
+    2 | 
     3 | fn (mut test Test) test() ?int {
     4 |     return test
       |     ~~~~~~~~~~~
     5 | }
     6 |
-vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:2: notice: `&Test` doesn't implement method `msg` of interface `IError`. The usage of fields is being deprecated in favor of methods.
-    6 |
-    7 | fn (mut test Test) test2() int {
-    8 |     return test
+vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:2: error: `&Test` doesn't implement method `code` of interface `IError`
+    2 | 
+    3 | fn (mut test Test) test() ?int {
+    4 |     return test
       |     ~~~~~~~~~~~
-    9 | }
+    5 | }
+    6 |
 vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:9: error: cannot use `Test` as type `?int` in return argument
-    2 |
+    2 | 
     3 | fn (mut test Test) test() ?int {
     4 |     return test
       |            ~~~~
     5 | }
     6 |
+vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:2: error: `&Test` doesn't implement method `msg` of interface `IError`
+    6 | 
+    7 | fn (mut test Test) test2() int {
+    8 |     return test
+      |     ~~~~~~~~~~~
+    9 | }
+vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:2: error: `&Test` doesn't implement method `code` of interface `IError`
+    6 | 
+    7 | fn (mut test Test) test2() int {
+    8 |     return test
+      |     ~~~~~~~~~~~
+    9 | }
 vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:9: error: cannot use `Test` as type `int` in return argument
-    6 |
+    6 | 
     7 | fn (mut test Test) test2() int {
     8 |     return test
       |            ~~~~

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7873,15 +7873,6 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 				}
 			}
 
-			// >> Hack to allow old style custom error implementations
-			// TODO: remove once deprecation period for `IError` methods has ended
-			// fix MSVC not handling empty struct inits
-			if methods.len == 0 && isym.idx == ast.error_type_idx {
-				methods_struct.writeln('\t\t._method_msg = NULL,')
-				methods_struct.writeln('\t\t._method_code = NULL,')
-			}
-			// <<
-
 			if g.pref.build_mode != .build_module {
 				methods_struct.writeln('\t},')
 			}


### PR DESCRIPTION
This PR remove the obsolete .code and .msg fields of IError.