### PR TITLE
checker: add error when initializing sumtype with struct as first type

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -772,11 +772,6 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 						init_field.expr.pos.extend(init_field.expr.expr.pos()))
 				}
 			}
-			// Check uninitialized refs/sum types
-			// The variable `fields` contains two parts, the first part is the same as info.fields,
-			// and the second part is all fields embedded in the structure
-			// If the return value data composition form in `c.table.struct_fields()` is modified,
-			// need to modify here accordingly.
 			c.check_uninitialized_struct_fields_and_embeds(node, type_sym, mut info, mut
 				inited_fields)
 			// println('>> checked_types.len: $checked_types.len | checked_types: $checked_types | type_sym: $type_sym.name ')
@@ -785,11 +780,6 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 			first_typ := (type_sym.info as ast.SumType).variants[0]
 			first_sym := c.table.final_sym(first_typ)
 			if first_sym.kind == .struct_ {
-				// Check uninitialized refs/sum types
-				// The variable `fields` contains two parts, the first part is the same as info.fields,
-				// and the second part is all fields embedded in the structure
-				// If the return value data composition form in `c.table.struct_fields()` is modified,
-				// need to modify here accordingly.
 				mut info := first_sym.info as ast.Struct
 				c.check_uninitialized_struct_fields_and_embeds(node, first_sym, mut info, mut
 					inited_fields)
@@ -847,6 +837,11 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 	return node.typ
 }
 
+// Check uninitialized refs/sum types
+// The variable `fields` contains two parts, the first part is the same as info.fields,
+// and the second part is all fields embedded in the structure
+// If the return value data composition form in `c.table.struct_fields()` is modified,
+// need to modify here accordingly.
 fn (mut c Checker) check_uninitialized_struct_fields_and_embeds(node ast.StructInit, type_sym ast.TypeSymbol, mut info ast.Struct, mut inited_fields []string) {
 	mut fields := c.table.struct_fields(type_sym)
 	mut checked_types := []ast.Type{}

--- a/vlib/v/checker/tests/sumtype_init_with_ref_fields_err.out
+++ b/vlib/v/checker/tests/sumtype_init_with_ref_fields_err.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/sumtype_init_with_ref_fields_err.vv:9:10: error: reference field `Node.parent` must be initialized
+    7 | 
+    8 | fn main() {
+    9 |     s := Sumtype{}
+      |          ~~~~~~~~~
+   10 |     dump(s)
+   11 | }
+vlib/v/checker/tests/sumtype_init_with_ref_fields_err.vv:9:10: error: reference field `Node.left` must be initialized
+    7 | 
+    8 | fn main() {
+    9 |     s := Sumtype{}
+      |          ~~~~~~~~~
+   10 |     dump(s)
+   11 | }
+vlib/v/checker/tests/sumtype_init_with_ref_fields_err.vv:9:10: error: reference field `Node.right` must be initialized
+    7 | 
+    8 | fn main() {
+    9 |     s := Sumtype{}
+      |          ~~~~~~~~~
+   10 |     dump(s)
+   11 | }

--- a/vlib/v/checker/tests/sumtype_init_with_ref_fields_err.vv
+++ b/vlib/v/checker/tests/sumtype_init_with_ref_fields_err.vv
@@ -1,0 +1,11 @@
+struct Node {
+    parent &Node
+    left &Node
+    right &Node
+}
+type Sumtype = Node | int
+
+fn main() {
+    s := Sumtype{}
+    dump(s)
+}


### PR DESCRIPTION
This PR add a checker error when initializing struct via sumtype as first variant type.

```v
struct Node {
    parent &Node
    left &Node
    right &Node
}
type Sumtype = Node | int

fn main() {
    s := Sumtype{}
    dump(s)
}
```

```
bug.v:9:10: error: reference field `Node.parent` must be initialized
    7 | 
    8 | fn main() {
    9 |     s := Sumtype{}
      |          ~~~~~~~~~
   10 |     dump(s)
   11 | }
bug.v:9:10: error: reference field `Node.left` must be initialized
    7 | 
    8 | fn main() {
    9 |     s := Sumtype{}
      |          ~~~~~~~~~
   10 |     dump(s)
   11 | }
bug.v:9:10: error: reference field `Node.right` must be initialized
    7 | 
    8 | fn main() {
    9 |     s := Sumtype{}
      |          ~~~~~~~~~
   10 |     dump(s)
   11 | }
```