### PR TITLE
parser: check fn call args without comma between them (related #22021)

### DIFF
--- a/cmd/tools/vdoc/testdata/basic/basic.out
+++ b/cmd/tools/vdoc/testdata/basic/basic.out
@@ -1,7 +1,3 @@
-Warning: `markdown` exists, but is not updated.
-V will continue, since updates can fail due to temporary network problems,
-and the existing module `markdown` may still work.
---------------------------------------------------
 module basic
 
 const source_root = 'temp' // some const

--- a/cmd/tools/vdoc/testdata/basic/basic.out
+++ b/cmd/tools/vdoc/testdata/basic/basic.out
@@ -1,3 +1,7 @@
+Warning: `markdown` exists, but is not updated.
+V will continue, since updates can fail due to temporary network problems,
+and the existing module `markdown` may still work.
+--------------------------------------------------
 module basic
 
 const source_root = 'temp' // some const

--- a/vlib/v/checker/tests/like_operator_outside_orm_error.out
+++ b/vlib/v/checker/tests/like_operator_outside_orm_error.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/like_operator_outside_orm_error.vv:4:15: error: only `c`, `r`, `js` are recognized string prefixes, but you tried to use `like`
+vlib/v/checker/tests/like_operator_outside_orm_error.vv:4:15: error: unexpected name `like`, expecting `)`
     2 |     name := 'Luke'
     3 | 
     4 |     println(name like 'L%')

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -55,7 +55,8 @@ fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 	if p.tok.kind != .rpar {
 		params := p.table.fns[fn_name] or { unsafe { p.table.fns['${p.mod}.${fn_name}'] } }.params
 		if args.len < params.len && p.prev_tok.kind != .comma {
-			p.unexpected_with_pos(p.prev_tok.pos(), expecting: '`,`')
+			pos := if p.tok.kind == .eof { p.prev_tok.pos() } else { p.tok.pos() }
+			p.unexpected_with_pos(pos, expecting: '`,`')
 		} else if args.len > params.len {
 			ok_arg_pos := (args[params.len - 1] or { args[0] }).pos
 			pos := token.Pos{
@@ -64,7 +65,8 @@ fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 			}
 			p.unexpected_with_pos(pos.extend(p.tok.pos()), expecting: '`)`')
 		} else {
-			p.unexpected_with_pos(p.prev_tok.pos(), expecting: '`)`')
+			pos := if p.tok.kind == .eof { p.prev_tok.pos() } else { p.tok.pos() }
+			p.unexpected_with_pos(pos, expecting: '`)`')
 		}
 	}
 	last_pos := p.tok.pos()
@@ -119,7 +121,7 @@ fn (mut p Parser) call_args() []ast.CallArg {
 		p.inside_call_args = prev_inside_call_args
 	}
 	mut args := []ast.CallArg{}
-	for p.tok.kind != .rpar && p.tok.kind != .comma {
+	for p.tok.kind != .rpar {
 		if p.tok.kind == .eof {
 			return args
 		}
@@ -162,9 +164,10 @@ fn (mut p Parser) call_args() []ast.CallArg {
 			comments: comments
 			pos:      pos
 		}
-		if p.tok.kind == .comma {
-			p.next()
+		if p.tok.kind != .comma {
+			break
 		}
+		p.next()
 	}
 	return args
 }

--- a/vlib/v/parser/tests/fn_call_args_without_comma_1_err.out
+++ b/vlib/v/parser/tests/fn_call_args_without_comma_1_err.out
@@ -1,0 +1,6 @@
+vlib/v/parser/tests/fn_call_args_without_comma_1_err.vv:6:11: error: unexpected number `23`, expecting `,`
+    4 | 
+    5 | fn main() {
+    6 |     greet(17 23)
+      |              ~~
+    7 | }

--- a/vlib/v/parser/tests/fn_call_args_without_comma_1_err.vv
+++ b/vlib/v/parser/tests/fn_call_args_without_comma_1_err.vv
@@ -1,0 +1,7 @@
+fn greet(i1 int, i2 int) {
+	println('${i1} ${i2}')
+}
+
+fn main() {
+	greet(17 23)
+}

--- a/vlib/v/parser/tests/fn_call_args_without_comma_2_err.out
+++ b/vlib/v/parser/tests/fn_call_args_without_comma_2_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/fn_call_args_without_comma_2_err.vv:8:3: error: unexpected number `23`, expecting `,`
+    6 |     greet(
+    7 |         17
+    8 |         23
+      |         ~~
+    9 |     )
+   10 | }

--- a/vlib/v/parser/tests/fn_call_args_without_comma_2_err.vv
+++ b/vlib/v/parser/tests/fn_call_args_without_comma_2_err.vv
@@ -1,0 +1,10 @@
+fn greet(i1 int, i2 int) {
+	println('${i1} ${i2}')
+}
+
+fn main() {
+	greet(
+		17
+		23
+	)
+}

--- a/vlib/v/parser/tests/fn_call_unexpected_eof_rpar_multi_line_err.out
+++ b/vlib/v/parser/tests/fn_call_unexpected_eof_rpar_multi_line_err.out
@@ -1,5 +1,5 @@
-vlib/v/parser/tests/fn_call_unexpected_eof_rpar_multi_line_err.vv:1:14: error: unexpected eof, expecting `)`
+vlib/v/parser/tests/fn_call_unexpected_eof_rpar_multi_line_err.vv:1:15: error: unexpected name `bar`, expecting `)`
     1 | println('foo' bar
-      |              ~~~~
+      |               ~~~
     2 | println('baz')
     3 |


### PR DESCRIPTION
This PR check fn call args without comma between them (related #22021).

- Check fn call args without comma between them.
- Add test.

```v 
fn greet(i1 int, i2 int) {
	println('${i1} ${i2}')
}

fn main() {
	greet(17 23)
}

PS D:\Test\v\tt1> v run .       
tt1.v:6:11: error: unexpected number `23`, expecting `,`
    4 | 
    5 | fn main() {
    6 |     greet(17 23)
      |              ~~
    7 | }
```
```v
fn greet(i1 int, i2 int) {
	println('${i1} ${i2}')
}

fn main() {
	greet(
		17
		23
	)
}

PS D:\Test\v\tt1> v run .    
tt1.v:8:3: error: unexpected number `23`, expecting `,`
    6 |     greet(
    7 |         17
    8 |         23
      |         ~~
    9 |     )
   10 | }
```