### PR TITLE
arrays: simplify arrays.sum and arrays.reduce

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -249,12 +249,8 @@ pub fn sum[T](array []T) !T {
 	} else {
 		mut head := array[0]
 
-		for i, e in array {
-			if i == 0 {
-				continue
-			} else {
-				head += e
-			}
+		for e in array[1..] {
+			head += e
 		}
 
 		return head
@@ -272,12 +268,8 @@ pub fn reduce[T](array []T, reduce_op fn (acc T, elem T) T) !T {
 	} else {
 		mut value := array[0]
 
-		for i, e in array {
-			if i == 0 {
-				continue
-			} else {
-				value = reduce_op(value, e)
-			}
+		for e in array[1..] {
+			value = reduce_op(value, e)
 		}
 
 		return value


### PR DESCRIPTION
I don't know if this improves performance, if cutting the array makes a new copy of it.
If it's not, close it.