### PR TITLE
bechmark: Add min, max & avg to recorded measurements

### DIFF
--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -2,6 +2,7 @@ module benchmark
 
 import time
 import term
+import arrays
 
 pub const b_ok = term.ok_message('OK  ')
 pub const b_fail = term.fail_message('FAIL')
@@ -24,6 +25,7 @@ pub mut:
 	bok             string
 	bfail           string
 	measured_steps  []string
+	step_data       map[string][]f64
 }
 
 // new_benchmark returns a `Benchmark` instance on the stack.
@@ -145,6 +147,7 @@ pub fn (mut b Benchmark) record_measure(label string) i64 {
 	b.ok()
 	res := b.step_timer.elapsed().microseconds()
 	b.measured_steps << b.step_message_with_label(benchmark.b_spent, 'in ${label}')
+	b.step_data[label] << res
 	b.step()
 	return res
 }
@@ -244,6 +247,12 @@ pub fn (b &Benchmark) total_message(msg string) string {
 		}
 	}
 	tmsg += '${b.ntotal} total. ${term.colorize(term.bold, 'Elapsed time:')} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.'
+	if msg in b.step_data && b.step_data[msg].len != 0 {
+		min := arrays.min(b.step_data[msg]) or { 0 } / 1000.0
+		max := arrays.max(b.step_data[msg]) or { 0 } / 1000.0
+		avg := (arrays.sum(b.step_data[msg]) or { 0 } / b.step_data[msg].len) / 1000.0
+		tmsg += ' Min: ${min:.3f} ms. Max: ${max:.3f} ms. Avg: ${avg:.3f} ms'
+	}
 	return tmsg
 }
 

--- a/vlib/benchmark/benchmark.v
+++ b/vlib/benchmark/benchmark.v
@@ -247,7 +247,7 @@ pub fn (b &Benchmark) total_message(msg string) string {
 		}
 	}
 	tmsg += '${b.ntotal} total. ${term.colorize(term.bold, 'Elapsed time:')} ${b.bench_timer.elapsed().microseconds() / 1000} ms${njobs_label}.'
-	if msg in b.step_data && b.step_data[msg].len != 0 {
+	if msg in b.step_data && b.step_data[msg].len > 1 {
 		min := arrays.min(b.step_data[msg]) or { 0 } / 1000.0
 		max := arrays.max(b.step_data[msg]) or { 0 } / 1000.0
 		avg := (arrays.sum(b.step_data[msg]) or { 0 } / b.step_data[msg].len) / 1000.0

--- a/vlib/benchmark/benchmark_test.v
+++ b/vlib/benchmark/benchmark_test.v
@@ -39,7 +39,7 @@ fn test_record_measure() {
 
 fn test_total_message() {
 	mut b := benchmark.start()
-	for _ in 0..100 {
+	for _ in 0 .. 100 {
 		time.sleep(time.millisecond)
 		x := b.record_measure('sleeping 1')
 		assert x > 1_000

--- a/vlib/benchmark/benchmark_test.v
+++ b/vlib/benchmark/benchmark_test.v
@@ -51,4 +51,14 @@ fn test_total_message() {
 	assert res.contains(' Min: ')
 	assert res.contains(' Max: ')
 	assert res.contains(' Avg: ')
+
+	time.sleep(time.millisecond)
+	y := b.record_measure('sleeping 2')
+	assert y > 1_000
+	// Should not contain min max avg, insufficient information
+	res2 := b.total_message('sleeping 2')
+
+	assert !res2.contains(' Min: ')
+	assert !res2.contains(' Max: ')
+	assert !res2.contains(' Avg: ')
 }

--- a/vlib/benchmark/benchmark_test.v
+++ b/vlib/benchmark/benchmark_test.v
@@ -36,3 +36,19 @@ fn test_record_measure() {
 	assert res.contains('ms in sleeping 1')
 	assert res.contains('SPENT')
 }
+
+fn test_total_message() {
+	mut b := benchmark.start()
+	for _ in 0..100 {
+		time.sleep(time.millisecond)
+		x := b.record_measure('sleeping 1')
+		assert x > 1_000
+	}
+
+	res := b.total_message('sleeping 1')
+	println(res)
+
+	assert res.contains(' Min: ')
+	assert res.contains(' Max: ')
+	assert res.contains(' Avg: ')
+}


### PR DESCRIPTION
Add more bechmark information to recorded measurements.

old:
![image](https://github.com/user-attachments/assets/b5bd3884-ee44-453c-bd39-2ffcc224cd84)

new:
![image](https://github.com/user-attachments/assets/f35aa01b-ac28-4139-9434-c39698896986)
