### PR TITLE
v: parser: Fixed #22095

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -550,6 +550,7 @@ fn (p &Parser) is_array_type() bool {
 fn (mut p Parser) open_scope() {
 	if p.opened_scopes > p.max_opened_scopes {
 		p.error('nested opened scopes limit reached: ${p.max_opened_scopes}')
+		exit(1)
 	}
 	p.scope = &ast.Scope{
 		parent:    p.scope


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Apparently, the compiler segfaults when the nested open scope limit is reached in silent mode (as seen in #22095).

This is because a Parser.error doesn't exit when in silent mode.