### PR TITLE
builtin: cleanup `u8.repeat()` and `rune.repeat()`

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -599,24 +599,17 @@ pub fn (b []u8) byterune() !rune {
 
 // repeat returns a new string with `count` number of copies of the byte it was called on.
 pub fn (b u8) repeat(count int) string {
-	if count < 0 {
-		panic('byte.repeat: count is negative: ${count}')
-	} else if count == 0 {
+	if count <= 0 {
 		return ''
 	} else if count == 1 {
 		return b.ascii_str()
 	}
-	mut ret := unsafe { malloc_noscan(count + 1) }
-	for i in 0 .. count {
-		unsafe {
-			ret[i] = b
-		}
-	}
-	new_len := count
+	mut bytes := unsafe { malloc_noscan(count + 1) }
 	unsafe {
-		ret[new_len] = 0
+		C.memset(bytes, b, count)
+		bytes[count] = `0`
 	}
-	return unsafe { ret.vstring_with_len(new_len) }
+	return unsafe { bytes.vstring_with_len(count) }
 }
 
 // for atomic ints, internal

--- a/vlib/builtin/js/rune.js.v
+++ b/vlib/builtin/js/rune.js.v
@@ -10,9 +10,7 @@ pub fn (ra []rune) string() string {
 }
 
 pub fn (c rune) repeat(count int) string {
-	if count < 0 {
-		panic('rune.repeat: count is negative: ${count}')
-	} else if count == 0 {
+	if count <= 0 {
 		return ''
 	} else if count == 1 {
 		return c.str()

--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -43,9 +43,7 @@ pub fn (ra []rune) string() string {
 
 // repeat returns a new string with `count` number of copies of the rune it was called on.
 pub fn (c rune) repeat(count int) string {
-	if count < 0 {
-		panic('rune.repeat: count is negative: ${count}')
-	} else if count == 0 {
+	if count <= 0 {
 		return ''
 	} else if count == 1 {
 		return c.str()


### PR DESCRIPTION
This PR cleanup `u8.repeat()` and `rune.repeat()`.