### PR TITLE
ast: cache ident lookups for consts in ast Expr str

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1025,6 +1025,7 @@ pub mut:
 	mod            string
 	name           string
 	full_name      string
+	cached_name    string
 	kind           IdentKind
 	info           IdentInfo
 	is_mut         bool // if mut *token* is before name. Use `is_mut()` to lookup mut variable

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -269,7 +269,6 @@ struct GlobalConstDef {
 }
 
 pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (string, string, string, []int) {
-	defer { ast.dump_counters() }
 	mut module_built := ''
 	if pref_.build_mode == .build_module {
 		for file in files {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -269,6 +269,7 @@ struct GlobalConstDef {
 }
 
 pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (string, string, string, []int) {
+	defer { ast.dump_counters() }
 	mut module_built := ''
 	if pref_.build_mode == .build_module {
 		for file in files {


### PR DESCRIPTION
- **ast: cache Ident scope lookups for consts in Expr.str**
- **ast,cgen: remove instrumentation for the cached ident lookup, cleanup**
