### PR TITLE
tools: fix vtest-self.v on Windows and tcc compiler

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -444,10 +444,8 @@ fn main() {
 		tsession.skip_files << 'vlib/db/pg/pg_orm_test.v'
 		tsession.skip_files << 'vlib/db/pg/pg_double_test.v'
 	}
-	$if windows {
-		if cfg.github_job == 'tcc' {
-			tsession.skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v'
-		}
+	$if windows && tinyc {
+		tsession.skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v'
 	}
 	if !cfg.run_slow_sanitize
 		&& ((cfg.sanitize_undefined || cfg.sanitize_memory || cfg.sanitize_address)


### PR DESCRIPTION
This PR fix vtest-self.v on Windows and tcc compiler.

before (local v test-self on Windows and tcc compiler) :
```v
OK    [1640/1961] C:   674.9 ms, R:    39.054 ms vlib/v/tests/ref_struct_test.v
 FAIL  [1641/1961] C:  7211.4 ms, R:     0.000 ms vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v
>> compilation failed:
================== C compilation error (from tcc): ==============
cc: tcc: error: unrecognized file type
=================================================================
(You can pass `-cg`, or `-show-c-output` as well, to print all the C error messages).
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .

 OK    [1642/1961] C:   490.9 ms, R:    35.622 ms vlib/v/tests/reference_return_test.v
```