### PR TITLE
cgen: fix coutput_test.v on Windows and tcc compiler

### DIFF
--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -246,13 +246,13 @@ fn should_skip(relpath string) bool {
 			eprintln('> skipping ${relpath} on windows')
 			return true
 		}
-		$if gcc {
+		$if !msvc {
 			if relpath.contains('_msvc_windows.vv') {
 				eprintln('> skipping ${relpath} on gcc')
 				return true
 			}
 		}
-		$if msvc {
+		$if !gcc {
 			if relpath.contains('_gcc_windows.vv') {
 				eprintln('> skipping ${relpath} on msvc')
 				return true

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -248,13 +248,13 @@ fn should_skip(relpath string) bool {
 		}
 		$if !msvc {
 			if relpath.contains('_msvc_windows.vv') {
-				eprintln('> skipping ${relpath} on gcc')
+				eprintln('> skipping ${relpath} on !msvc')
 				return true
 			}
 		}
 		$if !gcc {
 			if relpath.contains('_gcc_windows.vv') {
-				eprintln('> skipping ${relpath} on msvc')
+				eprintln('> skipping ${relpath} on !gcc')
 				return true
 			}
 		}


### PR DESCRIPTION
This PR fix coutput_test.v on Windows and tcc compiler.

before (on Windows and tcc compiler):
```v
 FAIL  [ 470/1961] C:   605.2 ms, R: 54168.989 ms vlib/v/gen/c/coutput_test.v
         retry: 1
      comp_cmd: "D:\Vlang\v\v.exe" -skip-running   -o "C:\Users\yuyi9\AppData\Local\Temp\v_0\tsession_46d0_01J61XG3YHRFYQ9YXRE0JYXYGR\470_0\coutput_test.exe" "D:\Vlang\v\vlib\v\gen\c\coutput_test.v"
       run_cmd: "C:\Users\yuyi9\AppData\Local\Temp\v_0\tsession_46d0_01J61XG3YHRFYQ9YXRE0JYXYGR\470_0\coutput_test.exe"
failure code: 1; foutput.len: 16060; failure output:
---------------------------------------------------------------------------------------------------- retry: 0 ; max_retry: 0 ; r.exit_code: 1 ; trimmed_output.len: 15890
> testing whether .out files match:
OK   C:   378ms, R:29ms v run vlib/v/gen/c/testdata/addition.vv == vlib/v/gen/c/testdata/addition.out
OK   C:   373ms, R:24ms v run vlib/v/gen/c/testdata/alias_c_parent_type_decl.vv == vlib/v/gen/c/testdata/alias_c_parent_type_decl.out
OK   C:   369ms, R:27ms v run vlib/v/gen/c/testdata/alias_interface_method_call.vv == vlib/v/gen/c/testdata/alias_interface_method_call.out
OK   C:   386ms, R:29ms v run vlib/v/gen/c/testdata/alias_of_array_method_call.vv == vlib/v/gen/c/testdata/alias_of_array_method_call.out
OK   C:  2939ms, R:24ms v -cc gcc -os windows run vlib/v/gen/c/testdata/aligned_attr_gcc_windows.vv == vlib/v/gen/c/testdata/aligned_attr_gcc_windows.out
OK   C:   382ms, R:22ms v -cc msvc -os windows run vlib/v/gen/c/testdata/aligned_attr_msvc_windows.vv == vlib/v/gen/c/testdata/aligned_attr_msvc_windows.out
> skipping vlib/v/gen/c/testdata/aligned_attr_nix.vv on windows
OK   C:   397ms, R:25ms v run vlib/v/gen/c/testdata/array_as_interface.vv == vlib/v/gen/c/testdata/array_as_interface.out
OK   C:   370ms, R:29ms v run vlib/v/gen/c/testdata/array_init_no_error.vv == vlib/v/gen/c/testdata/array_init_no_error.out
OK   C:   362ms, R:26ms v run vlib/v/gen/c/testdata/assert_fncalls.vv == vlib/v/gen/c/testdata/assert_fncalls.out
OK   C:   372ms, R:24ms v -autofree run vlib/v/gen/c/testdata/assigning_and_printing_struct_with_optional_field.vv == vlib/v/gen/c/testdata/assigning_and_printing_struct_with_optional_field.out
OK   C:   368ms, R:29ms v run vlib/v/gen/c/testdata/attr_string_quotes_escape.vv == vlib/v/gen/c/testdata/attr_string_quotes_escape.out
OK   C:   628ms, R:35ms v -d callstack run vlib/v/gen/c/testdata/callstack.vv == vlib/v/gen/c/testdata/callstack.out
OK   C:   355ms, R:27ms v run vlib/v/gen/c/testdata/comptime_interface_field.vv == vlib/v/gen/c/testdata/comptime_interface_field.out
OK   C:   348ms, R:26ms v run vlib/v/gen/c/testdata/comptime_option_call.vv == vlib/v/gen/c/testdata/comptime_option_call.out
OK   C:   378ms, R:30ms v run vlib/v/gen/c/testdata/const_references.vv == vlib/v/gen/c/testdata/const_references.out
OK   C:   364ms, R:30ms v run vlib/v/gen/c/testdata/c_varargs.vv == vlib/v/gen/c/testdata/c_varargs.out
OK   C:  6510ms, R:31ms v -prod run vlib/v/gen/c/testdata/embed_with_prod.vv == vlib/v/gen/c/testdata/embed_with_prod.out
OK   C:  6953ms, R:26ms v -prod run vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.vv == vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.out
OK   C:  6125ms, R:30ms v -prod run vlib/v/gen/c/testdata/embed_with_prod_zlib.vv == vlib/v/gen/c/testdata/embed_with_prod_zlib.out
OK   C:   341ms, R:26ms v run vlib/v/gen/c/testdata/enum_switch_case.vv == vlib/v/gen/c/testdata/enum_switch_case.out
OK   C:   366ms, R:32ms v run vlib/v/gen/c/testdata/export_and_weak.vv == vlib/v/gen/c/testdata/export_and_weak.out
OK   C:   418ms, R:25ms v run vlib/v/gen/c/testdata/for_in.vv == vlib/v/gen/c/testdata/for_in.out
> skipping vlib/v/gen/c/testdata/freestanding_module_import_1.vv on != linux
> skipping vlib/v/gen/c/testdata/freestanding_module_import_2.vv on != linux
OK   C:   384ms, R:29ms v run vlib/v/gen/c/testdata/gen_expr_to_string_with_call_and_return_ref.vv == vlib/v/gen/c/testdata/gen_expr_to_string_with_call_and_return_ref.out
OK   C:   404ms, R:26ms v -d init_on run vlib/v/gen/c/testdata/init_fn_with_if_attr_defined.vv == vlib/v/gen/c/testdata/init_fn_with_if_attr_defined.out
OK   C:   365ms, R:26ms v -d not_defined run vlib/v/gen/c/testdata/init_fn_with_if_attr_not_defined.vv == vlib/v/gen/c/testdata/init_fn_with_if_attr_not_defined.out
OK   C:   365ms, R:28ms v run vlib/v/gen/c/testdata/multi_return_ignored_if_guard.vv == vlib/v/gen/c/testdata/multi_return_ignored_if_guard.out
OK   C:   385ms, R:31ms v run vlib/v/gen/c/testdata/mutable_receiver_type_mapping.vv == vlib/v/gen/c/testdata/mutable_receiver_type_mapping.out
OK   C:   391ms, R:25ms v run vlib/v/gen/c/testdata/none_literal_str.vv == vlib/v/gen/c/testdata/none_literal_str.out
OK   C:   381ms, R:29ms v run vlib/v/gen/c/testdata/preinclude_example.vv == vlib/v/gen/c/testdata/preinclude_example.out
OK   C:   363ms, R:29ms v run vlib/v/gen/c/testdata/preinclude_example_changed_order.vv == vlib/v/gen/c/testdata/preinclude_example_changed_order.out
OK   C:   370ms, R:26ms v run vlib/v/gen/c/testdata/ref_sumtype_map_as_struct_field.vv == vlib/v/gen/c/testdata/ref_sumtype_map_as_struct_field.out
OK   C:  3994ms, R:23ms v -prod -skip-unused run vlib/v/gen/c/testdata/self_printer_with_prod.vv == vlib/v/gen/c/testdata/self_printer_with_prod.out
OK   C:   370ms, R:24ms v run vlib/v/gen/c/testdata/spawn_call_fn_struct_field.vv == vlib/v/gen/c/testdata/spawn_call_fn_struct_field.out
> skipping vlib/v/gen/c/testdata/spawn_stack_nix.vv on windows
OK   C:   360ms, R:27ms v run vlib/v/gen/c/testdata/spawn_stack_windows.vv == vlib/v/gen/c/testdata/spawn_stack_windows.out
OK   C:   394ms, R:28ms v run vlib/v/gen/c/testdata/strlit_len_optimization.vv == vlib/v/gen/c/testdata/strlit_len_optimization.out
OK   C:   360ms, R:25ms v run vlib/v/gen/c/testdata/struct_field_free.vv == vlib/v/gen/c/testdata/struct_field_free.out
OK   C:   367ms, R:31ms v run vlib/v/gen/c/testdata/struct_fn_member_print.vv == vlib/v/gen/c/testdata/struct_fn_member_print.out
OK   C:   370ms, R:24ms v run vlib/v/gen/c/testdata/sumtype_pass_by_reference.vv == vlib/v/gen/c/testdata/sumtype_pass_by_reference.out
OK   C:   387ms, R:28ms v run vlib/v/gen/c/testdata/sumtype_struct_depend_order.vv == vlib/v/gen/c/testdata/sumtype_struct_depend_order.out
OK   C:   356ms, R:24ms v -translated run vlib/v/gen/c/testdata/translated_const_fixed_array.vv == vlib/v/gen/c/testdata/translated_const_fixed_array.out
OK   C:   409ms, R:29ms v run vlib/v/gen/c/testdata/translated_module.vv == vlib/v/gen/c/testdata/translated_module.out
OK   C:   348ms, R:29ms v -d my_f64=2.0 -d my_i64=3 -d my_string="a four" -d my_bool -d my_char=g -d my_size=8 -d field_fsa_size=16 run vlib/v/gen/c/testdata/use_flag_comptime_values.vv == vlib/v/gen/c/testdata/use_flag_comptime_values.out
OK   C:   361ms, R:27ms v -d ddd1=true -d ddd2=false run vlib/v/gen/c/testdata/use_flag_comptime_with_if.vv == vlib/v/gen/c/testdata/use_flag_comptime_with_if.out
OK   C:   391ms, R:28ms v run vlib/v/gen/c/testdata/volatile.vv == vlib/v/gen/c/testdata/volatile.out
> testing whether all line patterns in `.c.must_have` files match:
OK   C:  302ms v -o -  vlib/v/gen/c/testdata/addition.vv matches vlib/v/gen/c/testdata/addition.c.must_have
OK   C:  292ms v -o -  vlib/v/gen/c/testdata/addr.vv matches vlib/v/gen/c/testdata/addr.c.must_have
OK   C:  295ms v -o -  vlib/v/gen/c/testdata/alias_c_parent_type_decl.vv matches vlib/v/gen/c/testdata/alias_c_parent_type_decl.c.must_have
OK   C:  313ms v -o - -cc gcc -os windows vlib/v/gen/c/testdata/aligned_attr_gcc_windows.vv matches vlib/v/gen/c/testdata/aligned_attr_gcc_windows.c.must_have
FAIL C:  296ms v -o - -cc msvc -os windows vlib/v/gen/c/testdata/aligned_attr_msvc_windows.vv matches vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have
D:/Vlang/v/vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have:1: expected match error:
`"D:\Vlang\v\v.exe" -o - -cc msvc -os windows "D:\Vlang\v\vlib\v\gen\c\testdata\aligned_attr_msvc_windows.vv"` did NOT produce expected line:
struct __declspec(align (8)) main__Test {
FAIL C:  296ms v -o - -cc msvc -os windows vlib/v/gen/c/testdata/aligned_attr_msvc_windows.vv matches vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have
D:/Vlang/v/vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have:2: expected match error:
`"D:\Vlang\v\v.exe" -o - -cc msvc -os windows "D:\Vlang\v\vlib\v\gen\c\testdata\aligned_attr_msvc_windows.vv"` did NOT produce expected line:
struct __declspec(align (16)) main__Test2 {
FAIL C:  296ms v -o - -cc msvc -os windows vlib/v/gen/c/testdata/aligned_attr_msvc_windows.vv matches vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have
D:/Vlang/v/vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have:3: expected match error:
`"D:\Vlang\v\v.exe" -o - -cc msvc -os windows "D:\Vlang\v\vlib\v\gen\c\testdata\aligned_attr_msvc_windows.vv"` did NOT produce expected line:
union __declspec(align (8)) main__Test3 {
--------- failed patterns: -------------------------------------------
struct __declspec(align (8)) main__Test {
struct __declspec(align (16)) main__Test2 {
union __declspec(align (8)) main__Test3 {
----------------------------------------------------------------------
> skipping vlib/v/gen/c/testdata/aligned_attr_nix.vv on windows
OK   C:  295ms v -o -  vlib/v/gen/c/testdata/assert_fncalls.vv matches vlib/v/gen/c/testdata/assert_fncalls.c.must_have
OK   C:  310ms v -o -  vlib/v/gen/c/testdata/check_combination_of_alias_and_sumtype.vv matches vlib/v/gen/c/testdata/check_combination_of_alias_and_sumtype.c.must_have
OK   C:  312ms v -o - -shared vlib/v/gen/c/testdata/closure_shared_lib.vv matches vlib/v/gen/c/testdata/closure_shared_lib.c.must_have
OK   C:  292ms v -o -  vlib/v/gen/c/testdata/compare_structs.vv matches vlib/v/gen/c/testdata/compare_structs.c.must_have
OK   C:  293ms v -o - -d customflag vlib/v/gen/c/testdata/comptime_if_attribute_in_test2.vv matches vlib/v/gen/c/testdata/comptime_if_attribute_in_test2.c.must_have
OK   C:  314ms v -o -  vlib/v/gen/c/testdata/comp_if_unknown.vv matches vlib/v/gen/c/testdata/comp_if_unknown.c.must_have
OK   C:  290ms v -o - -os windows vlib/v/gen/c/testdata/console_windows_program.vv matches vlib/v/gen/c/testdata/console_windows_program.c.must_have
OK   C:  306ms v -o -  vlib/v/gen/c/testdata/const_references.vv matches vlib/v/gen/c/testdata/const_references.c.must_have
OK   C:  300ms v -o -  vlib/v/gen/c/testdata/c_varargs.vv matches vlib/v/gen/c/testdata/c_varargs.c.must_have
OK   C:  408ms v -o -  vlib/v/gen/c/testdata/embed.vv matches vlib/v/gen/c/testdata/embed.c.must_have
OK   C:  435ms v -o - -prod vlib/v/gen/c/testdata/embed_with_prod.vv matches vlib/v/gen/c/testdata/embed_with_prod.c.must_have
OK   C:  651ms v -o - -prod vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.vv matches vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.c.must_have
OK   C:  559ms v -o - -prod vlib/v/gen/c/testdata/embed_with_prod_zlib.vv matches vlib/v/gen/c/testdata/embed_with_prod_zlib.c.must_have
OK   C:  305ms v -o -  vlib/v/gen/c/testdata/enum_switch_case.vv matches vlib/v/gen/c/testdata/enum_switch_case.c.must_have
OK   C:  288ms v -o -  vlib/v/gen/c/testdata/export_and_weak.vv matches vlib/v/gen/c/testdata/export_and_weak.c.must_have
OK   C:  313ms v -o -  vlib/v/gen/c/testdata/for_in.vv matches vlib/v/gen/c/testdata/for_in.c.must_have
OK   C:  294ms v -o - -shared vlib/v/gen/c/testdata/func_type_dependency.vv matches vlib/v/gen/c/testdata/func_type_dependency.c.must_have
OK   C:  306ms v -o - -enable-globals vlib/v/gen/c/testdata/globals_with_weak_tag.vv matches vlib/v/gen/c/testdata/globals_with_weak_tag.c.must_have
> skipping vlib/v/gen/c/testdata/global_export_nix.vv on windows
OK   C:  305ms v -o - -enable-globals vlib/v/gen/c/testdata/global_initializer.vv matches vlib/v/gen/c/testdata/global_initializer.c.must_have
OK   C:  298ms v -o - -os windows vlib/v/gen/c/testdata/gui_windows_program.vv matches vlib/v/gen/c/testdata/gui_windows_program.c.must_have
OK   C:  325ms v -o - -os windows vlib/v/gen/c/testdata/gui_windows_program_with_console_tag.vv matches vlib/v/gen/c/testdata/gui_windows_program_with_console_tag.c.must_have
OK   C:  327ms v -o - -d init_on vlib/v/gen/c/testdata/init_fn_with_if_attr_defined.vv matches vlib/v/gen/c/testdata/init_fn_with_if_attr_defined.c.must_have
OK   C:  283ms v -o - -d not_defined vlib/v/gen/c/testdata/init_fn_with_if_attr_not_defined.vv matches vlib/v/gen/c/testdata/init_fn_with_if_attr_not_defined.c.must_have
> skipping vlib/v/gen/c/testdata/linker_section_nix.vv on windows
> skipping vlib/v/gen/c/testdata/spawn_stack_nix.vv on windows
OK   C:  318ms v -o -  vlib/v/gen/c/testdata/spawn_stack_windows.vv matches vlib/v/gen/c/testdata/spawn_stack_windows.c.must_have
OK   C:  301ms v -o -  vlib/v/gen/c/testdata/strlit_len_optimization.vv matches vlib/v/gen/c/testdata/strlit_len_optimization.c.must_have
OK   C:  273ms v -o -  vlib/v/gen/c/testdata/struct_fn_member_print.vv matches vlib/v/gen/c/testdata/struct_fn_member_print.c.must_have
OK   C:  299ms v -o -  vlib/v/gen/c/testdata/translated_module.vv matches vlib/v/gen/c/testdata/translated_module.c.must_have
OK   C:  323ms v -o -  vlib/v/gen/c/testdata/unused_import_aliased_as_underscore.vv matches vlib/v/gen/c/testdata/unused_import_aliased_as_underscore.c.must_have
OK   C:  288ms v -o -  vlib/v/gen/c/testdata/volatile.vv matches vlib/v/gen/c/testdata/volatile.c.must_have
--------- failed commands: -------------------------------------------
  > v -o - -cc msvc -os windows vlib/v/gen/c/testdata/aligned_attr_msvc_windows.vv matches vlib/v/gen/c/testdata/aligned_attr_msvc_windows.c.must_have
----------------------------------------------------------------------
D:\\Vlang\\v\\vlib\\v\\gen\\c\\coutput_test.v:179: ✗ fn test_c_must_have_files
   > assert total_errors == 0
     Left value: 3
```