### PR TITLE
cgen: fix array fixed initialization from map indexing

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -491,7 +491,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 			else {
 				if mut left is ast.IndexExpr {
 					// eprintln('>>> left.is_setter: ${left.is_setter:10} | left.is_map: ${left.is_map:10} | left.is_array: ${left.is_array:10}')
-					if left.is_map && left.is_setter {
+					if (left.is_map || left.is_farray) && left.is_setter {
 						left.recursive_mapset_is_setter(true)
 					}
 				}

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -342,6 +342,16 @@ fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		g.expr(node.left)
 		g.writeln(';')
 		g.past_tmp_var_done(past)
+	} else if node.left is ast.IndexExpr && node.left.is_setter {
+		past := g.past_tmp_var_new()
+		styp := g.typ(node.left_type)
+		println(node.left)
+		g.write('${styp}* ${past.tmp_var} = &')
+		g.expr(node.left)
+		g.writeln(';')
+		g.write('(*')
+		g.past_tmp_var_done(past)
+		g.write(')')
 	} else {
 		if is_fn_index_call {
 			g.write('(*')
@@ -385,7 +395,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 			g.typ(val_type.clear_flag(.result))
 		}
 	}
-	get_and_set_types := val_sym.kind in [.struct_, .map, .array]
+	get_and_set_types := val_sym.kind in [.struct_, .map, .array, .array_fixed]
 	if g.is_assign_lhs && !g.is_arraymap_set && !get_and_set_types {
 		if g.assign_op == .assign || info.value_type == ast.string_type {
 			g.is_arraymap_set = true

--- a/vlib/v/tests/fixed_array_with_map_test.v
+++ b/vlib/v/tests/fixed_array_with_map_test.v
@@ -1,0 +1,26 @@
+module main
+
+struct File {
+	root string
+	path string
+}
+
+struct Test {
+mut:
+	mod_files map[string][5]File
+}
+
+fn test_main() {
+	mut test := Test{}
+	for i in 0 .. 4 {
+		test.mod_files['main'][i] = File{}
+	}
+	test.mod_files['main'][3] = File{
+		root: 'foo'
+		path: 'bar'
+	}
+	assert test.mod_files['main'][3] == File{
+		root: 'foo'
+		path: 'bar'
+	}
+}


### PR DESCRIPTION
Fix #22133