### PR TITLE
v.builder: fix errors in cstrict mode on OpenBSD with clang

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -333,6 +333,12 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 	}
 
+	// Fix 'braces around scalar initializer' errors
+	// on OpenBSD with clang for cstrict mode
+	if v.pref.os == .openbsd && ccoptions.cc == .clang {
+		ccoptions.wargs << '-Wno-braced-scalar-init'
+	}
+
 	if ccompiler != 'msvc' && v.pref.os != .freebsd {
 		ccoptions.wargs << '-Werror=implicit-function-declaration'
 	}


### PR DESCRIPTION
When building in cstrict mode on OpenBSD with clang, some "braces around scalar initializer" errors occur. Add '-Wno-braced-scalar-init' flag for this case.

Fix vlang/v#22129

---

Tests OK when building in cstrict mode with Clang v16 on OpenBSD/amd64 and Linux (Debian testing/amd64).