### PR TITLE
builtin: cleanup comments of struct string

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -45,14 +45,14 @@ pub struct string {
 pub:
 	str &u8 = 0 // points to a C style 0 terminated string of bytes.
 	len int // the length of the .str field, excluding the ending 0 byte. It is always equal to strlen(.str).
+mut:
+	is_lit int
 	// NB string.is_lit is an enumeration of the following:
 	// .is_lit == 0 => a fresh string, should be freed by autofree
 	// .is_lit == 1 => a literal string from .rodata, should NOT be freed
 	// .is_lit == -98761234 => already freed string, protects against double frees.
 	// ---------> ^^^^^^^^^ calling free on these is a bug.
 	// Any other value means that the string has been corrupted.
-mut:
-	is_lit int
 }
 
 // runes returns an array of all the utf runes in the string `s`


### PR DESCRIPTION
This PR cleanup comments of struct string.