### PR TITLE
cgen: fix struct field with default optional value (fix #11119)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -415,6 +415,14 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 					g.struct_init(default_init)
 				}
 				return true
+			} else if sym.language == .v && !field.typ.is_ptr() && sym.mod != 'builtin'
+				&& !sym.info.is_empty_struct() {
+				default_init := ast.StructInit{
+					typ: field.typ
+				}
+				g.write('.${field_name} = ')
+				g.struct_init(default_init)
+				return true
 			}
 		}
 	}

--- a/vlib/v/tests/structs/struct_field_default_value_optional_test.v
+++ b/vlib/v/tests/structs/struct_field_default_value_optional_test.v
@@ -1,0 +1,27 @@
+import regex
+
+struct RegexCache {
+mut:
+	tag_script_start regex.RE = regex.regex_opt(r'^script.*>') or { panic(err) }
+}
+
+pub struct Tokenizer {
+mut:
+	regex_cache RegexCache = RegexCache{}
+}
+
+fn new_parser() &Parser {
+	mut parser := &Parser{}
+	return parser
+}
+
+pub struct Parser {
+mut:
+	tnzr Tokenizer
+}
+
+fn test_struct_field_default_value_optional() {
+	p := new_parser()
+	println(p)
+	assert true
+}


### PR DESCRIPTION
This PR fix struct field with default optional value (fix #11119).

- Fix struct field with default optional value.
- Add test.

```v
import regex

struct RegexCache {
mut:
	tag_script_start regex.RE = regex.regex_opt(r'^script.*>') or { panic(err) }
}

pub struct Tokenizer {
mut:
	regex_cache RegexCache = RegexCache{}
}

fn new_parser() &Parser {
	mut parser := &Parser{}
	return parser
}

pub struct Parser {
mut:
	tnzr Tokenizer
}

fn main() {
	p := new_parser()
	println(p)
}

PS D:\Test\v\tt1> v run .    
&Parser{
    tnzr: Tokenizer{
        regex_cache: RegexCache{
            tag_script_start: regex.RE{
                prog: [regex.Token{
                    ist: 2147483647
                    ch: 115
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2147483647
                    ch: 99
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2147483647
                    ch: 114
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2147483647
                    ch: 105
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2147483647
                    ch: 112
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2147483647
                    ch: 116
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2550136832
                    ch: 0
                    ch_len: 0
                    flag: 0
                    rep_min: 0
                    rep_max: 1073741824
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: 7
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2147483647
                    ch: 62
                    ch_len: 1
                    flag: 0
                    rep_min: 1
                    rep_max: 1
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 2281701376
                    ch: 0
                    ch_len: 0
                    flag: 0
                    rep_min: 0
                    rep_max: 0
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 0
                    ch: 0
                    ch_len: 0
                    flag: 0
                    rep_min: 0
                    rep_max: 0
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }, regex.Token{
                    ist: 0
                    ch: 0
                    ch_len: 0
                    flag: 0
                    rep_min: 0
                    rep_max: 0
                    greedy: false
                    cc_index: -1
                    rep: 0
                    validator: fn (u8) bool
                    group_neg: false
                    group_rep: 0
                    group_id: -1
                    goto_pc: -1
                    next_is_or: false
                    dot_check_pc: -1
                    bsls_check_pc: -1
                    cc_check_pc: -1
                    last_dot_flag: false
                    source_index: 0
                }]
                prog_len: 8
                cc: [regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }, regex.CharClass{
                    cc_type: 0
                    ch0: 0
                    ch1: 0
                    validator: fn (u8) bool
                }]
                cc_index: 0
                group_count: 0
                groups: []
                group_max_nested: 5
                group_max: 5
                state_list: []
                group_csave_flag: false
                group_csave: []
                group_map: {}
                group_stack: [-1, -1, -1, -1, -1]
                group_data: [-1, -1, -1, -1, -1]
                flag: 2
                debug: 0
                log_func: fn (string)
                query: '^script.*>'
            }
        }
    }
}
```