### PR TITLE
builtin: remove references to v_calloc in function comments

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -499,7 +499,7 @@ pub fn malloc_uncollectable(n isize) &u8 {
 
 // v_realloc resizes the memory block `b` with `n` bytes.
 // The `b byteptr` must be a pointer to an existing memory block
-// previously allocated with `malloc`, `v_calloc` or `vcalloc`.
+// previously allocated with `malloc` or `vcalloc`.
 // Please, see also realloc_data, and use it instead if possible.
 @[unsafe]
 pub fn v_realloc(b &u8, n isize) &u8 {
@@ -526,7 +526,7 @@ pub fn v_realloc(b &u8, n isize) &u8 {
 
 // realloc_data resizes the memory block pointed by `old_data` to `new_size`
 // bytes. `old_data` must be a pointer to an existing memory block, previously
-// allocated with `malloc`, `v_calloc` or `vcalloc`, of size `old_data`.
+// allocated with `malloc` or `vcalloc`, of size `old_data`.
 // realloc_data returns a pointer to the new location of the block.
 // Note: if you know the old data size, it is preferable to call `realloc_data`,
 // instead of `v_realloc`, at least during development, because `realloc_data`
@@ -572,7 +572,7 @@ pub fn realloc_data(old_data &u8, old_size int, new_size int) &u8 {
 
 // vcalloc dynamically allocates a zeroed `n` bytes block of memory on the heap.
 // vcalloc returns a `byteptr` pointing to the memory address of the allocated space.
-// Unlike `v_calloc` vcalloc checks for negative values given in `n`.
+// vcalloc checks for negative values given in `n`.
 pub fn vcalloc(n isize) &u8 {
 	$if trace_vcalloc ? {
 		total_m += n

--- a/vlib/builtin/wasm/builtin.v
+++ b/vlib/builtin/wasm/builtin.v
@@ -39,7 +39,7 @@ pub fn vwasm_memory_grow(size int) int {
 
 // vcalloc dynamically allocates a zeroed `n` bytes block of memory on the heap.
 // vcalloc returns a `byteptr` pointing to the memory address of the allocated space.
-// Unlike `v_calloc` vcalloc checks for negative values given in `n`.
+// vcalloc checks for negative values given in `n`.
 @[unsafe]
 pub fn vcalloc(n isize) &u8 {
 	if n <= 0 {


### PR DESCRIPTION
There were references to the v_calloc function but this function appears to have been removed.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
