### PR TITLE
parser: fix parsing map value inside or expr (fix #12164)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -950,11 +950,20 @@ fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 	match p.tok.kind {
 		.lcbr {
 			mut pos := p.tok.pos()
-			stmts := p.parse_block()
-			pos.last_line = p.prev_tok.line_nr
-			return ast.Block{
-				stmts: stmts
-				pos:   pos
+			if p.peek_token(2).kind == .colon {
+				expr := p.expr(0)
+				// `{ 'abc' : 22 }`
+				return ast.ExprStmt{
+					expr: expr
+					pos:  pos
+				}
+			} else {
+				stmts := p.parse_block()
+				pos.last_line = p.prev_tok.line_nr
+				return ast.Block{
+					stmts: stmts
+					pos:   pos
+				}
 			}
 		}
 		.key_assert {

--- a/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.out
+++ b/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.out
@@ -1,0 +1,1 @@
+MapString({'abc': 'String Error'})

--- a/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.vv
+++ b/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.vv
@@ -1,0 +1,22 @@
+struct MyError {
+  msg string
+  code int
+}
+
+fn (my MyError) msg() string {
+	return my.msg
+}
+
+fn (my MyError) code() int {
+	return my.code
+}
+
+type MapString = map[string]string | int
+
+fn f() ?MapString {
+  return MyError{msg: 'String Error'}
+}
+
+fn main() {
+  println(f() or { { 'abc': err.msg() } })
+}


### PR DESCRIPTION
This PR fix parsing map value inside or expr (fix #12164).

- Fix parsing map value inside or expr.
- Add test.

```v
struct MyError {
  msg string
  code int
}

fn (my MyError) msg() string {
	return my.msg
}

fn (my MyError) code() int {
	return my.code
}

type MapString = map[string]string | int

fn f() ?MapString {
  return MyError{msg: 'String Error'}
}

fn main() {
  println(f() or { { 'abc': err.msg() } })
}

PS D:\Test\v\tt1> v run .
MapString({'abc': 'String Error'})
```