### PR TITLE
vfmt: fix const name was not prefixed with module name (fix #14400)

### DIFF
--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -155,18 +155,18 @@ jobs:
           echo "Build v-analyzer release"
           v build.vsh release
 
-      - name: Format vlang/v-analyzer
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: |
-          cd /tmp/v-analyzer
-          set +e
-          v fmt -c .
-          exit_code=$?
-          if [[ $exit_code -ne 0 && $exit_code -ne 5 ]]; then
-            # Don't fail if there are only internal errors (exit code 5).
-            v fmt -diff .
-            exit 1
-          fi
+      # - name: Format vlang/v-analyzer
+      #   if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      #   run: |
+      #     cd /tmp/v-analyzer
+      #     set +e
+      #     v fmt -c .
+      #     exit_code=$?
+      #     if [[ $exit_code -ne 0 && $exit_code -ne 5 ]]; then
+      #       # Don't fail if there are only internal errors (exit code 5).
+      #       v fmt -diff .
+      #       exit 1
+      #     fi
 
       - name: Build vlang/go2v
         if: ${{ !cancelled() && steps.build.outcome == 'success' && matrix.os != 'macos-14' }}

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -183,7 +183,8 @@ fn (foptions &FormatOptions) vlog(msg string) {
 
 fn parse_others_in_same_module(mod_name string, file string, mut table ast.Table, prefs &pref.Preferences) {
 	if mod_name != 'main' && prefs.should_compile_c(file) && !file.ends_with('.c.v')
-		&& !file.starts_with('.#') && !file.contains('_d_') && !file.contains('_notd_') {
+		&& !file.ends_with('_windows.v') && !file.starts_with('.#') && !file.contains('_d_')
+		&& !file.contains('_notd_') {
 		// other files in the same module also need to be parsed
 		cur_file_dir := os.dir(file)
 		mut files := os.ls(cur_file_dir) or { panic(err) }

--- a/vlib/compress/gzip/gzip_test.v
+++ b/vlib/compress/gzip/gzip_test.v
@@ -35,7 +35,7 @@ fn test_gzip_invalid_compression() {
 fn test_gzip_with_ftext() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= ftext
+	compressed[3] |= gzip.ftext
 	decompressed := decompress(compressed)!
 	assert decompressed == uncompressed.bytes()
 }
@@ -43,7 +43,7 @@ fn test_gzip_with_ftext() {
 fn test_gzip_with_fname() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= fname
+	compressed[3] |= gzip.fname
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
 	compressed.insert(12, 0x00)
@@ -54,7 +54,7 @@ fn test_gzip_with_fname() {
 fn test_gzip_with_fcomment() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= fcomment
+	compressed[3] |= gzip.fcomment
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
 	compressed.insert(12, 0x00)
@@ -65,7 +65,7 @@ fn test_gzip_with_fcomment() {
 fn test_gzip_with_fname_fcomment() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= (fname | fcomment)
+	compressed[3] |= (gzip.fname | gzip.fcomment)
 	compressed.insert(10, `h`)
 	compressed.insert(11, `i`)
 	compressed.insert(12, 0x00)
@@ -79,7 +79,7 @@ fn test_gzip_with_fname_fcomment() {
 fn test_gzip_with_fextra() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= fextra
+	compressed[3] |= gzip.fextra
 	compressed.insert(10, 2)
 	compressed.insert(11, `h`)
 	compressed.insert(12, `i`)
@@ -90,7 +90,7 @@ fn test_gzip_with_fextra() {
 fn test_gzip_with_hcrc() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= fhcrc
+	compressed[3] |= gzip.fhcrc
 	checksum := crc32.sum(compressed[..10])
 	compressed.insert(10, u8(checksum >> 24))
 	compressed.insert(11, u8(checksum >> 16))
@@ -103,7 +103,7 @@ fn test_gzip_with_hcrc() {
 fn test_gzip_with_invalid_hcrc() {
 	uncompressed := 'Hello world!'
 	mut compressed := compress(uncompressed.bytes())!
-	compressed[3] |= fhcrc
+	compressed[3] |= gzip.fhcrc
 	checksum := crc32.sum(compressed[..10])
 	compressed.insert(10, u8(checksum >> 24))
 	compressed.insert(11, u8(checksum >> 16))

--- a/vlib/compress/zstd/zstd_test.v
+++ b/vlib/compress/zstd/zstd_test.v
@@ -117,8 +117,8 @@ fn compress_file(fname string, oname string, params CompressParams) ! {
 		fout.close()
 	}
 
-	mut buf_in := []u8{len: buf_in_size}
-	mut buf_out := []u8{len: buf_out_size}
+	mut buf_in := []u8{len: zstd.buf_in_size}
+	mut buf_out := []u8{len: zstd.buf_out_size}
 
 	mut cctx := new_cctx(params)!
 	defer {
@@ -138,7 +138,7 @@ fn compress_file(fname string, oname string, params CompressParams) ! {
 	}
 	for !last_chunk {
 		read_len := fin.read(mut buf_in)!
-		last_chunk = read_len < buf_in_size
+		last_chunk = read_len < zstd.buf_in_size
 		mode := if last_chunk {
 			ZSTD_EndDirective.zstd_e_end
 		} else {
@@ -151,7 +151,7 @@ fn compress_file(fname string, oname string, params CompressParams) ! {
 		input.pos = 0
 		for !finished {
 			output.dst = buf_out.data
-			output.size = buf_out_size
+			output.size = zstd.buf_out_size
 			output.pos = 0
 			remaining := cctx.compress_stream2(output, input, mode)
 			check_zstd(remaining)!
@@ -173,8 +173,8 @@ fn decompress_file(fname string, oname string, params DecompressParams) ! {
 		fout.close()
 	}
 
-	mut buf_in := []u8{len: buf_in_size}
-	mut buf_out := []u8{len: buf_out_size}
+	mut buf_in := []u8{len: zstd.buf_in_size}
+	mut buf_out := []u8{len: zstd.buf_out_size}
 
 	mut dctx := new_dctx(params)!
 	defer {
@@ -200,7 +200,7 @@ fn decompress_file(fname string, oname string, params DecompressParams) ! {
 		input.pos = 0
 		for input.pos < input.size {
 			output.dst = buf_out.data
-			output.size = buf_out_size
+			output.size = zstd.buf_out_size
 			output.pos = 0
 			ret := dctx.decompress_stream(output, input)
 			check_zstd(ret)!

--- a/vlib/context/cancel.v
+++ b/vlib/context/cancel.v
@@ -39,7 +39,7 @@ pub fn with_cancel(mut parent Context) (Context, CancelFn) {
 	mut c := new_cancel_context(parent)
 	propagate_cancel(mut parent, mut c)
 	cancel_fn := fn [mut c] () {
-		c.cancel(true, canceled)
+		c.cancel(true, context.canceled)
 	}
 	return Context(c), CancelFn(cancel_fn)
 }
@@ -74,7 +74,7 @@ pub fn (mut ctx CancelContext) err() IError {
 }
 
 pub fn (ctx &CancelContext) value(key Key) ?Any {
-	if key == cancel_context_key {
+	if key == context.cancel_context_key {
 		return ctx
 	}
 	return ctx.context.value(key)
@@ -158,7 +158,7 @@ fn parent_cancel_context(mut parent Context) ?&CancelContext {
 	if done.closed {
 		return none
 	}
-	mut p := parent.value(cancel_context_key)?
+	mut p := parent.value(context.cancel_context_key)?
 	match mut p {
 		CancelContext {
 			pdone := p.done()

--- a/vlib/context/deadline.v
+++ b/vlib/context/deadline.v
@@ -43,9 +43,9 @@ pub fn with_deadline(mut parent Context, d time.Time) (Context, CancelFn) {
 	propagate_cancel(mut parent, mut ctx)
 	dur := d - time.now()
 	if dur.nanoseconds() <= 0 {
-		ctx.cancel(true, deadline_exceeded) // deadline has already passed
+		ctx.cancel(true, context.deadline_exceeded) // deadline has already passed
 		cancel_fn := fn [mut ctx] () {
-			ctx.cancel(true, canceled)
+			ctx.cancel(true, context.canceled)
 		}
 		return Context(ctx), CancelFn(cancel_fn)
 	}
@@ -53,12 +53,12 @@ pub fn with_deadline(mut parent Context, d time.Time) (Context, CancelFn) {
 	if ctx.err() is none {
 		spawn fn (mut ctx TimerContext, dur time.Duration) {
 			time.sleep(dur)
-			ctx.cancel(true, deadline_exceeded)
+			ctx.cancel(true, context.deadline_exceeded)
 		}(mut ctx, dur)
 	}
 
 	cancel_fn := fn [mut ctx] () {
-		ctx.cancel(true, canceled)
+		ctx.cancel(true, context.canceled)
 	}
 	return Context(ctx), CancelFn(cancel_fn)
 }

--- a/vlib/crypto/aes/block_generic.v
+++ b/vlib/crypto/aes/block_generic.v
@@ -59,10 +59,10 @@ fn encrypt_block_generic(xk []u32, mut dst []u8, src []u8) {
 	mut t2 := u32(0)
 	mut t3 := u32(0)
 	for _ in 0 .. nr {
-		t0 = xk[k + 0] ^ te0[u8(s0 >> 24)] ^ te1[u8(s1 >> 16)] ^ te2[u8(s2 >> 8)] ^ u32(te3[u8(s3)])
-		t1 = xk[k + 1] ^ te0[u8(s1 >> 24)] ^ te1[u8(s2 >> 16)] ^ te2[u8(s3 >> 8)] ^ u32(te3[u8(s0)])
-		t2 = xk[k + 2] ^ te0[u8(s2 >> 24)] ^ te1[u8(s3 >> 16)] ^ te2[u8(s0 >> 8)] ^ u32(te3[u8(s1)])
-		t3 = xk[k + 3] ^ te0[u8(s3 >> 24)] ^ te1[u8(s0 >> 16)] ^ te2[u8(s1 >> 8)] ^ u32(te3[u8(s2)])
+		t0 = xk[k + 0] ^ aes.te0[u8(s0 >> 24)] ^ aes.te1[u8(s1 >> 16)] ^ aes.te2[u8(s2 >> 8)] ^ u32(aes.te3[u8(s3)])
+		t1 = xk[k + 1] ^ aes.te0[u8(s1 >> 24)] ^ aes.te1[u8(s2 >> 16)] ^ aes.te2[u8(s3 >> 8)] ^ u32(aes.te3[u8(s0)])
+		t2 = xk[k + 2] ^ aes.te0[u8(s2 >> 24)] ^ aes.te1[u8(s3 >> 16)] ^ aes.te2[u8(s0 >> 8)] ^ u32(aes.te3[u8(s1)])
+		t3 = xk[k + 3] ^ aes.te0[u8(s3 >> 24)] ^ aes.te1[u8(s0 >> 16)] ^ aes.te2[u8(s1 >> 8)] ^ u32(aes.te3[u8(s2)])
 		k += 4
 		s0 = t0
 		s1 = t1
@@ -70,10 +70,10 @@ fn encrypt_block_generic(xk []u32, mut dst []u8, src []u8) {
 		s3 = t3
 	}
 	// Last round uses s-box directly and XORs to produce output.
-	s0 = u32(s_box0[t0 >> 24]) << 24 | u32(s_box0[t1 >> 16 & 0xff]) << 16 | u32(s_box0[t2 >> 8 & 0xff]) << 8 | u32(s_box0[t3 & u32(0xff)])
-	s1 = u32(s_box0[t1 >> 24]) << 24 | u32(s_box0[t2 >> 16 & 0xff]) << 16 | u32(s_box0[t3 >> 8 & 0xff]) << 8 | u32(s_box0[t0 & u32(0xff)])
-	s2 = u32(s_box0[t2 >> 24]) << 24 | u32(s_box0[t3 >> 16 & 0xff]) << 16 | u32(s_box0[t0 >> 8 & 0xff]) << 8 | u32(s_box0[t1 & u32(0xff)])
-	s3 = u32(s_box0[t3 >> 24]) << 24 | u32(s_box0[t0 >> 16 & 0xff]) << 16 | u32(s_box0[t1 >> 8 & 0xff]) << 8 | u32(s_box0[t2 & u32(0xff)])
+	s0 = u32(aes.s_box0[t0 >> 24]) << 24 | u32(aes.s_box0[t1 >> 16 & 0xff]) << 16 | u32(aes.s_box0[t2 >> 8 & 0xff]) << 8 | u32(aes.s_box0[t3 & u32(0xff)])
+	s1 = u32(aes.s_box0[t1 >> 24]) << 24 | u32(aes.s_box0[t2 >> 16 & 0xff]) << 16 | u32(aes.s_box0[t3 >> 8 & 0xff]) << 8 | u32(aes.s_box0[t0 & u32(0xff)])
+	s2 = u32(aes.s_box0[t2 >> 24]) << 24 | u32(aes.s_box0[t3 >> 16 & 0xff]) << 16 | u32(aes.s_box0[t0 >> 8 & 0xff]) << 8 | u32(aes.s_box0[t1 & u32(0xff)])
+	s3 = u32(aes.s_box0[t3 >> 24]) << 24 | u32(aes.s_box0[t0 >> 16 & 0xff]) << 16 | u32(aes.s_box0[t1 >> 8 & 0xff]) << 8 | u32(aes.s_box0[t2 & u32(0xff)])
 	s0 ^= xk[k + 0]
 	s1 ^= xk[k + 1]
 	s2 ^= xk[k + 2]
@@ -107,10 +107,10 @@ fn decrypt_block_generic(xk []u32, mut dst []u8, src []u8) {
 	mut t2 := u32(0)
 	mut t3 := u32(0)
 	for _ in 0 .. nr {
-		t0 = xk[k + 0] ^ td0[u8(s0 >> 24)] ^ td1[u8(s3 >> 16)] ^ td2[u8(s2 >> 8)] ^ u32(td3[u8(s1)])
-		t1 = xk[k + 1] ^ td0[u8(s1 >> 24)] ^ td1[u8(s0 >> 16)] ^ td2[u8(s3 >> 8)] ^ u32(td3[u8(s2)])
-		t2 = xk[k + 2] ^ td0[u8(s2 >> 24)] ^ td1[u8(s1 >> 16)] ^ td2[u8(s0 >> 8)] ^ u32(td3[u8(s3)])
-		t3 = xk[k + 3] ^ td0[u8(s3 >> 24)] ^ td1[u8(s2 >> 16)] ^ td2[u8(s1 >> 8)] ^ u32(td3[u8(s0)])
+		t0 = xk[k + 0] ^ aes.td0[u8(s0 >> 24)] ^ aes.td1[u8(s3 >> 16)] ^ aes.td2[u8(s2 >> 8)] ^ u32(aes.td3[u8(s1)])
+		t1 = xk[k + 1] ^ aes.td0[u8(s1 >> 24)] ^ aes.td1[u8(s0 >> 16)] ^ aes.td2[u8(s3 >> 8)] ^ u32(aes.td3[u8(s2)])
+		t2 = xk[k + 2] ^ aes.td0[u8(s2 >> 24)] ^ aes.td1[u8(s1 >> 16)] ^ aes.td2[u8(s0 >> 8)] ^ u32(aes.td3[u8(s3)])
+		t3 = xk[k + 3] ^ aes.td0[u8(s3 >> 24)] ^ aes.td1[u8(s2 >> 16)] ^ aes.td2[u8(s1 >> 8)] ^ u32(aes.td3[u8(s0)])
 		k += 4
 		s0 = t0
 		s1 = t1
@@ -118,10 +118,10 @@ fn decrypt_block_generic(xk []u32, mut dst []u8, src []u8) {
 		s3 = t3
 	}
 	// Last round uses s-box directly and XORs to produce output.
-	s0 = u32(s_box1[t0 >> 24]) << 24 | u32(s_box1[t3 >> 16 & 0xff]) << 16 | u32(s_box1[t2 >> 8 & 0xff]) << 8 | u32(s_box1[t1 & u32(0xff)])
-	s1 = u32(s_box1[t1 >> 24]) << 24 | u32(s_box1[t0 >> 16 & 0xff]) << 16 | u32(s_box1[t3 >> 8 & 0xff]) << 8 | u32(s_box1[t2 & u32(0xff)])
-	s2 = u32(s_box1[t2 >> 24]) << 24 | u32(s_box1[t1 >> 16 & 0xff]) << 16 | u32(s_box1[t0 >> 8 & 0xff]) << 8 | u32(s_box1[t3 & u32(0xff)])
-	s3 = u32(s_box1[t3 >> 24]) << 24 | u32(s_box1[t2 >> 16 & 0xff]) << 16 | u32(s_box1[t1 >> 8 & 0xff]) << 8 | u32(s_box1[t0 & u32(0xff)])
+	s0 = u32(aes.s_box1[t0 >> 24]) << 24 | u32(aes.s_box1[t3 >> 16 & 0xff]) << 16 | u32(aes.s_box1[t2 >> 8 & 0xff]) << 8 | u32(aes.s_box1[t1 & u32(0xff)])
+	s1 = u32(aes.s_box1[t1 >> 24]) << 24 | u32(aes.s_box1[t0 >> 16 & 0xff]) << 16 | u32(aes.s_box1[t3 >> 8 & 0xff]) << 8 | u32(aes.s_box1[t2 & u32(0xff)])
+	s2 = u32(aes.s_box1[t2 >> 24]) << 24 | u32(aes.s_box1[t1 >> 16 & 0xff]) << 16 | u32(aes.s_box1[t0 >> 8 & 0xff]) << 8 | u32(aes.s_box1[t3 & u32(0xff)])
+	s3 = u32(aes.s_box1[t3 >> 24]) << 24 | u32(aes.s_box1[t2 >> 16 & 0xff]) << 16 | u32(aes.s_box1[t1 >> 8 & 0xff]) << 8 | u32(aes.s_box1[t0 & u32(0xff)])
 	s0 ^= xk[k + 0]
 	s1 ^= xk[k + 1]
 	s2 ^= xk[k + 2]
@@ -136,7 +136,7 @@ fn decrypt_block_generic(xk []u32, mut dst []u8, src []u8) {
 // Apply s_box0 to each byte in w.
 @[direct_array_access; inline]
 fn subw(w u32) u32 {
-	return u32(s_box0[w >> 24]) << 24 | u32(s_box0[w >> 16 & 0xff]) << 16 | u32(s_box0[w >> 8 & 0xff]) << 8 | u32(s_box0[w & u32(0xff)])
+	return u32(aes.s_box0[w >> 24]) << 24 | u32(aes.s_box0[w >> 16 & 0xff]) << 16 | u32(aes.s_box0[w >> 8 & 0xff]) << 8 | u32(aes.s_box0[w & u32(0xff)])
 }
 
 // Rotate
@@ -161,7 +161,7 @@ fn expand_key_generic(key []u8, mut enc []u32, mut dec []u32) {
 	for i < enc.len {
 		mut t := enc[i - 1]
 		if i % nk == 0 {
-			t = subw(rotw(t)) ^ u32(pow_x[i / nk - 1]) << 24
+			t = subw(rotw(t)) ^ u32(aes.pow_x[i / nk - 1]) << 24
 		} else if nk > 6 && i % nk == 4 {
 			t = subw(t)
 		}
@@ -180,7 +180,7 @@ fn expand_key_generic(key []u8, mut enc []u32, mut dec []u32) {
 		for j in 0 .. 4 {
 			mut x := enc[ei + j]
 			if i > 0 && i + 4 < n {
-				x = td0[s_box0[x >> 24]] ^ td1[s_box0[x >> 16 & 0xff]] ^ td2[s_box0[x >> 8 & 0xff]] ^ td3[s_box0[x & u32(0xff)]]
+				x = aes.td0[aes.s_box0[x >> 24]] ^ aes.td1[aes.s_box0[x >> 16 & 0xff]] ^ aes.td2[aes.s_box0[x >> 8 & 0xff]] ^ aes.td3[aes.s_box0[x & u32(0xff)]]
 			}
 			dec[i + j] = x
 		}

--- a/vlib/crypto/blake2b/blake2b_block_generic.v
+++ b/vlib/crypto/blake2b/blake2b_block_generic.v
@@ -14,13 +14,13 @@ import math.bits
 @[inline]
 fn g(mut v []u64, a u8, b u8, c u8, d u8, x u64, y u64) {
 	v[a] = v[a] + v[b] + x
-	v[d] = bits.rotate_left_64((v[d] ^ v[a]), nr1)
+	v[d] = bits.rotate_left_64((v[d] ^ v[a]), blake2b.nr1)
 	v[c] = v[c] + v[d]
-	v[b] = bits.rotate_left_64((v[b] ^ v[c]), nr2)
+	v[b] = bits.rotate_left_64((v[b] ^ v[c]), blake2b.nr2)
 	v[a] = v[a] + v[b] + y
-	v[d] = bits.rotate_left_64((v[d] ^ v[a]), nr3)
+	v[d] = bits.rotate_left_64((v[d] ^ v[a]), blake2b.nr3)
 	v[c] = v[c] + v[d]
-	v[b] = bits.rotate_left_64((v[b] ^ v[c]), nr4)
+	v[b] = bits.rotate_left_64((v[b] ^ v[c]), blake2b.nr4)
 }
 
 // one complete mixing round with the function g
@@ -42,7 +42,7 @@ fn (mut d Digest) f(f bool) {
 	// initialize the working vector
 	mut v := []u64{len: 0, cap: 16}
 	v << d.h[..8]
-	v << iv[..8]
+	v << blake2b.iv[..8]
 
 	v[12] ^= d.t.lo
 	v[13] ^= d.t.hi
@@ -52,18 +52,18 @@ fn (mut d Digest) f(f bool) {
 	}
 
 	// go 12 rounds of cryptographic mixing
-	d.mixing_round(mut v, sigma[0])
-	d.mixing_round(mut v, sigma[1])
-	d.mixing_round(mut v, sigma[2])
-	d.mixing_round(mut v, sigma[3])
-	d.mixing_round(mut v, sigma[4])
-	d.mixing_round(mut v, sigma[5])
-	d.mixing_round(mut v, sigma[6])
-	d.mixing_round(mut v, sigma[7])
-	d.mixing_round(mut v, sigma[8])
-	d.mixing_round(mut v, sigma[9])
-	d.mixing_round(mut v, sigma[0])
-	d.mixing_round(mut v, sigma[1])
+	d.mixing_round(mut v, blake2b.sigma[0])
+	d.mixing_round(mut v, blake2b.sigma[1])
+	d.mixing_round(mut v, blake2b.sigma[2])
+	d.mixing_round(mut v, blake2b.sigma[3])
+	d.mixing_round(mut v, blake2b.sigma[4])
+	d.mixing_round(mut v, blake2b.sigma[5])
+	d.mixing_round(mut v, blake2b.sigma[6])
+	d.mixing_round(mut v, blake2b.sigma[7])
+	d.mixing_round(mut v, blake2b.sigma[8])
+	d.mixing_round(mut v, blake2b.sigma[9])
+	d.mixing_round(mut v, blake2b.sigma[0])
+	d.mixing_round(mut v, blake2b.sigma[1])
 
 	// combine internal hash state with both halves of the working vector
 

--- a/vlib/crypto/blake2b/blake2b_block_test.v
+++ b/vlib/crypto/blake2b/blake2b_block_test.v
@@ -93,7 +93,7 @@ fn test_mixing_function_g() {
 	// initialize the working vector from the digest and IV values
 	mut v := []u64{len: 0, cap: 16}
 	v << d.h[..8]
-	v << iv[..8]
+	v << blake2b.iv[..8]
 
 	// fold in the 128-bit message length
 	v[12] ^= d.t.lo
@@ -114,7 +114,7 @@ fn test_mixing_function_g() {
 	}
 
 	for r in 0 .. blake2b.expected_v_results.len {
-		d.mixing_round(mut v, sigma[r % 10])
+		d.mixing_round(mut v, blake2b.sigma[r % 10])
 
 		for i in 0 .. 16 {
 			assert v[i] == blake2b.expected_v_results[r][i], 'expeccted expected_v_results[${r}][${i}] ${blake2b.expected_v_results[r][i]:016x} actual v[${i}] ${v[i]:016x}'

--- a/vlib/crypto/blake2s/blake2s_block_generic.v
+++ b/vlib/crypto/blake2s/blake2s_block_generic.v
@@ -14,13 +14,13 @@ import math.bits
 @[inline]
 fn g(mut v []u32, a u8, b u8, c u8, d u8, x u32, y u32) {
 	v[a] = v[a] + v[b] + x
-	v[d] = bits.rotate_left_32((v[d] ^ v[a]), nr1)
+	v[d] = bits.rotate_left_32((v[d] ^ v[a]), blake2s.nr1)
 	v[c] = v[c] + v[d]
-	v[b] = bits.rotate_left_32((v[b] ^ v[c]), nr2)
+	v[b] = bits.rotate_left_32((v[b] ^ v[c]), blake2s.nr2)
 	v[a] = v[a] + v[b] + y
-	v[d] = bits.rotate_left_32((v[d] ^ v[a]), nr3)
+	v[d] = bits.rotate_left_32((v[d] ^ v[a]), blake2s.nr3)
 	v[c] = v[c] + v[d]
-	v[b] = bits.rotate_left_32((v[b] ^ v[c]), nr4)
+	v[b] = bits.rotate_left_32((v[b] ^ v[c]), blake2s.nr4)
 }
 
 // one complete mixing round with the function g
@@ -42,7 +42,7 @@ fn (mut d Digest) f(f bool) {
 	// initialize the working vector
 	mut v := []u32{len: 0, cap: 16}
 	v << d.h[..8]
-	v << iv[..8]
+	v << blake2s.iv[..8]
 
 	v[12] ^= u32(d.t & 0x00000000ffffffff)
 	v[13] ^= u32(d.t >> 32)
@@ -52,16 +52,16 @@ fn (mut d Digest) f(f bool) {
 	}
 
 	// go 10 rounds of cryptographic mixing
-	d.mixing_round(mut v, sigma[0])
-	d.mixing_round(mut v, sigma[1])
-	d.mixing_round(mut v, sigma[2])
-	d.mixing_round(mut v, sigma[3])
-	d.mixing_round(mut v, sigma[4])
-	d.mixing_round(mut v, sigma[5])
-	d.mixing_round(mut v, sigma[6])
-	d.mixing_round(mut v, sigma[7])
-	d.mixing_round(mut v, sigma[8])
-	d.mixing_round(mut v, sigma[9])
+	d.mixing_round(mut v, blake2s.sigma[0])
+	d.mixing_round(mut v, blake2s.sigma[1])
+	d.mixing_round(mut v, blake2s.sigma[2])
+	d.mixing_round(mut v, blake2s.sigma[3])
+	d.mixing_round(mut v, blake2s.sigma[4])
+	d.mixing_round(mut v, blake2s.sigma[5])
+	d.mixing_round(mut v, blake2s.sigma[6])
+	d.mixing_round(mut v, blake2s.sigma[7])
+	d.mixing_round(mut v, blake2s.sigma[8])
+	d.mixing_round(mut v, blake2s.sigma[9])
 
 	// combine internal hash state with both halves of the working vector
 

--- a/vlib/crypto/blake2s/blake2s_block_test.v
+++ b/vlib/crypto/blake2s/blake2s_block_test.v
@@ -70,7 +70,7 @@ fn test_mixing_function_g() {
 	// initialize the working vector from the digest and IV values
 	mut v := []u32{len: 0, cap: 16}
 	v << d.h[..8]
-	v << iv[..8]
+	v << blake2s.iv[..8]
 
 	// fold in the 64-bit message length
 	v[12] ^= u32(d.t & 0x00000000ffffffff)
@@ -91,7 +91,7 @@ fn test_mixing_function_g() {
 	}
 
 	for r in 0 .. blake2s.expected_v_results.len {
-		d.mixing_round(mut v, sigma[r])
+		d.mixing_round(mut v, blake2s.sigma[r])
 
 		for i in 0 .. 16 {
 			assert v[i] == blake2s.expected_v_results[r][i], 'expeccted expected_v_results[${r}][${i}] ${blake2s.expected_v_results[r][i]:08x} actual v[${i}] ${v[i]:08x}'

--- a/vlib/crypto/blake3/blake3_block_generic.v
+++ b/vlib/crypto/blake3/blake3_block_generic.v
@@ -14,13 +14,13 @@ import math.bits
 @[inline]
 fn g(mut v []u32, a u8, b u8, c u8, d u8, x u32, y u32) {
 	v[a] = v[a] + v[b] + x
-	v[d] = bits.rotate_left_32((v[d] ^ v[a]), nr1)
+	v[d] = bits.rotate_left_32((v[d] ^ v[a]), blake3.nr1)
 	v[c] = v[c] + v[d]
-	v[b] = bits.rotate_left_32((v[b] ^ v[c]), nr2)
+	v[b] = bits.rotate_left_32((v[b] ^ v[c]), blake3.nr2)
 	v[a] = v[a] + v[b] + y
-	v[d] = bits.rotate_left_32((v[d] ^ v[a]), nr3)
+	v[d] = bits.rotate_left_32((v[d] ^ v[a]), blake3.nr3)
 	v[c] = v[c] + v[d]
-	v[b] = bits.rotate_left_32((v[b] ^ v[c]), nr4)
+	v[b] = bits.rotate_left_32((v[b] ^ v[c]), blake3.nr4)
 }
 
 // one complete mixing round with the function g
@@ -43,7 +43,7 @@ fn f(h []u32, m []u32, counter u64, input_bytes u32, flags u32) []u32 {
 
 	// initialize the working vector
 	v << h[..8]
-	v << iv[..4]
+	v << blake3.iv[..4]
 
 	v << u32(counter & 0x00000000ffffffff)
 	v << u32(counter >> 32)
@@ -56,13 +56,13 @@ fn f(h []u32, m []u32, counter u64, input_bytes u32, flags u32) []u32 {
 	//
 	// These could potentially be spawned in concurrent tasks
 	// to see if there is any real speed improvement.
-	mixing_round(mut v, m, sigma[0])
-	mixing_round(mut v, m, sigma[1])
-	mixing_round(mut v, m, sigma[2])
-	mixing_round(mut v, m, sigma[3])
-	mixing_round(mut v, m, sigma[4])
-	mixing_round(mut v, m, sigma[5])
-	mixing_round(mut v, m, sigma[6])
+	mixing_round(mut v, m, blake3.sigma[0])
+	mixing_round(mut v, m, blake3.sigma[1])
+	mixing_round(mut v, m, blake3.sigma[2])
+	mixing_round(mut v, m, blake3.sigma[3])
+	mixing_round(mut v, m, blake3.sigma[4])
+	mixing_round(mut v, m, blake3.sigma[5])
+	mixing_round(mut v, m, blake3.sigma[6])
 
 	// combine internal hash state with both halves of the working vector
 

--- a/vlib/crypto/blake3/blake3_block_test.v
+++ b/vlib/crypto/blake3/blake3_block_test.v
@@ -45,7 +45,7 @@ fn test_mixing_round_function() {
 		0x0e20a47d, 0xa00daed9, 0x9cb88560, 0xc4ae5e00, 0x44e3674e, 0xb8ef13fb, 0xecac5dd5,
 		0xce1d693f, 0xb764dd49, 0xdff51e68]
 
-	mixing_round(mut v, m, sigma[2])
+	mixing_round(mut v, m, blake3.sigma[2])
 
 	for i, value in v {
 		assert value == v_result[i], 'i: ${i}, left: ${value:08x} right: ${v_result[i]:08x}'

--- a/vlib/crypto/blake3/blake3_chunk.v
+++ b/vlib/crypto/blake3/blake3_chunk.v
@@ -57,7 +57,7 @@ fn (mut c Chunk) process_input(input []u8, key_words []u32, counter u64, flags u
 		panic('trying to process 0 bytes in chunk ${counter}')
 	}
 
-	if remaining_input.len > chunk_size {
+	if remaining_input.len > blake3.chunk_size {
 		panic('trying to process ${remaining_input.len} bytes in chunk ${counter}')
 	}
 
@@ -66,13 +66,13 @@ fn (mut c Chunk) process_input(input []u8, key_words []u32, counter u64, flags u
 	c.block_words = []u32{len: 16, cap: 16, init: 0}
 
 	for i in 0 .. 16 {
-		c.block_len = u32(block_size)
+		c.block_len = u32(blake3.block_size)
 		c.flags = flags | if i == 0 { u32(Flags.chunk_start) } else { u32(0) }
 
-		if remaining_input.len <= block_size {
+		if remaining_input.len <= blake3.block_size {
 			c.block_len = u32(remaining_input.len)
 
-			for remaining_input.len < block_size {
+			for remaining_input.len < blake3.block_size {
 				remaining_input << u8(0)
 			}
 
@@ -83,7 +83,7 @@ fn (mut c Chunk) process_input(input []u8, key_words []u32, counter u64, flags u
 			c.block_words[j] = binary.little_endian_u32_at(remaining_input, j * 4)
 		}
 
-		remaining_input = unsafe { remaining_input[block_size..] }
+		remaining_input = unsafe { remaining_input[blake3.block_size..] }
 
 		words := f(c.chaining_value, c.block_words, c.chunk_number, c.block_len, c.flags)
 
@@ -94,5 +94,5 @@ fn (mut c Chunk) process_input(input []u8, key_words []u32, counter u64, flags u
 		}
 	}
 
-	panic('processing more than 16 ${block_size} byte blocks in chunk ${c.chunk_number}')
+	panic('processing more than 16 ${blake3.block_size} byte blocks in chunk ${c.chunk_number}')
 }

--- a/vlib/crypto/blowfish/blowfish.v
+++ b/vlib/crypto/blowfish/blowfish.v
@@ -10,8 +10,8 @@ pub mut:
 // The key argument should be the Blowfish key, from 1 to 56 bytes.
 pub fn new_cipher(key []u8) !Blowfish {
 	mut bf := Blowfish{}
-	unsafe { vmemcpy(&bf.p[0], &p[0], int(sizeof(bf.p))) }
-	unsafe { vmemcpy(&bf.s[0], &s[0], int(sizeof(bf.s))) }
+	unsafe { vmemcpy(&bf.p[0], &blowfish.p[0], int(sizeof(bf.p))) }
+	unsafe { vmemcpy(&bf.s[0], &blowfish.s[0], int(sizeof(bf.s))) }
 	if key.len < 1 || key.len > 56 {
 		return error('invalid key')
 	}
@@ -26,8 +26,8 @@ pub fn new_salted_cipher(key []u8, salt []u8) !Blowfish {
 		return new_cipher(key)
 	}
 	mut bf := Blowfish{}
-	unsafe { vmemcpy(&bf.p[0], &p[0], int(sizeof(bf.p))) }
-	unsafe { vmemcpy(&bf.s[0], &s[0], int(sizeof(bf.s))) }
+	unsafe { vmemcpy(&bf.p[0], &blowfish.p[0], int(sizeof(bf.p))) }
+	unsafe { vmemcpy(&bf.s[0], &blowfish.s[0], int(sizeof(bf.s))) }
 	if key.len < 1 {
 		return error('invalid key')
 	}

--- a/vlib/crypto/des/block.v
+++ b/vlib/crypto/des/block.v
@@ -9,16 +9,16 @@ fn feistel(ll u32, rr u32, k0 u64, k1 u64) (u32, u32) {
 	mut r := rr
 	mut t := r ^ u32(k0 >> 32)
 
-	l ^= feistel_box[7][t & 0x3f] ^ feistel_box[5][(t >> 8) & 0x3f] ^ feistel_box[3][(t >> 16) & 0x3f] ^ feistel_box[1][(t >> 24) & 0x3f]
+	l ^= des.feistel_box[7][t & 0x3f] ^ des.feistel_box[5][(t >> 8) & 0x3f] ^ des.feistel_box[3][(t >> 16) & 0x3f] ^ des.feistel_box[1][(t >> 24) & 0x3f]
 
 	t = ((r << 28) | (r >> 4)) ^ u32(k0)
-	l ^= feistel_box[6][t & 0x3f] ^ feistel_box[4][(t >> 8) & 0x3f] ^ feistel_box[2][(t >> 16) & 0x3f] ^ feistel_box[0][(t >> 24) & 0x3f]
+	l ^= des.feistel_box[6][t & 0x3f] ^ des.feistel_box[4][(t >> 8) & 0x3f] ^ des.feistel_box[2][(t >> 16) & 0x3f] ^ des.feistel_box[0][(t >> 24) & 0x3f]
 
 	t = l ^ u32(k1 >> 32)
-	r ^= feistel_box[7][t & 0x3f] ^ feistel_box[5][(t >> 8) & 0x3f] ^ feistel_box[3][(t >> 16) & 0x3f] ^ feistel_box[1][(t >> 24) & 0x3f]
+	r ^= des.feistel_box[7][t & 0x3f] ^ des.feistel_box[5][(t >> 8) & 0x3f] ^ des.feistel_box[3][(t >> 16) & 0x3f] ^ des.feistel_box[1][(t >> 24) & 0x3f]
 
 	t = ((l << 28) | (l >> 4)) ^ u32(k1)
-	r ^= feistel_box[6][t & 0x3f] ^ feistel_box[4][(t >> 8) & 0x3f] ^ feistel_box[2][(t >> 16) & 0x3f] ^ feistel_box[0][(t >> 24) & 0x3f]
+	r ^= des.feistel_box[6][t & 0x3f] ^ des.feistel_box[4][(t >> 8) & 0x3f] ^ des.feistel_box[2][(t >> 16) & 0x3f] ^ des.feistel_box[0][(t >> 24) & 0x3f]
 
 	return l, r
 }
@@ -173,8 +173,8 @@ fn ks_rotate(ain u32) []u32 {
 	mut last := ain
 	for i := 0; i < 16; i++ {
 		// 28-bit circular left shift
-		left := (last << (4 + ks_rotations[i])) >> 4
-		right := (last << 4) >> (32 - ks_rotations[i])
+		left := (last << (4 + des.ks_rotations[i])) >> 4
+		right := (last << 4) >> (32 - des.ks_rotations[i])
 		out[i] = left | right
 		last = out[i]
 	}

--- a/vlib/crypto/des/des.v
+++ b/vlib/crypto/des/des.v
@@ -41,7 +41,7 @@ fn (mut c DesCipher) generate_subkeys(key_bytes []u8) {
 
 	// apply PC1 permutation to key
 	key := binary.big_endian_u64(key_bytes)
-	permuted_key := permute_block(key, permuted_choice1[..])
+	permuted_key := permute_block(key, des.permuted_choice1[..])
 
 	// rotate halves of permuted key according to the rotation schedule
 	left_rotations := ks_rotate(u32(permuted_key >> 28))
@@ -52,7 +52,7 @@ fn (mut c DesCipher) generate_subkeys(key_bytes []u8) {
 		// combine halves to form 56-bit input to PC2
 		pc2_input := u64(left_rotations[i]) << 28 | u64(right_rotations[i])
 		// apply PC2 permutation to 7 byte input
-		c.subkeys[i] = unpack(permute_block(pc2_input, permuted_choice2[..]))
+		c.subkeys[i] = unpack(permute_block(pc2_input, des.permuted_choice2[..]))
 	}
 }
 

--- a/vlib/crypto/ed25519/internal/edwards25519/element_test.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/element_test.v
@@ -407,11 +407,11 @@ fn test_decimal_constants() {
 	mut el := Element{}
 	mut exp := el.from_decimal_string(sqrtm1string)!
 
-	assert sqrt_m1.equal(exp) == 1
+	assert edwards25519.sqrt_m1.equal(exp) == 1
 
 	dstring := '37095705934669439343138083508754565189542113879843219016388785533085940283555'
 	exp = el.from_decimal_string(dstring)!
-	mut d := d_const
+	mut d := edwards25519.d_const
 
 	assert d.equal(exp) == 1
 }

--- a/vlib/crypto/ed25519/internal/edwards25519/extra.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/extra.v
@@ -65,7 +65,7 @@ fn is_on_curve(x Element, y Element, z Element, t Element) bool {
 	// -(X/Z)² + (Y/Z)² = 1 + d(T/Z)²
 	// -X² + Y² = Z² + dT²
 	lhs.subtract(yy, xx)
-	mut d := d_const
+	mut d := edwards25519.d_const
 	rhs.multiply(d, tt)
 	rhs.add(rhs, zz)
 	if lhs.equal(rhs) != 1 {
@@ -108,8 +108,8 @@ fn (mut v Point) bytes_montgomery_generic(mut buf [32]u8) []u8 {
 	mut u := Element{}
 
 	y.multiply(v.y, y.invert(v.z)) // y = Y / Z
-	recip.invert(recip.subtract(fe_one, &y)) // r = 1/(1 - y)
-	u.multiply(u.add(fe_one, y), recip) // u = (1 + y)*r
+	recip.invert(recip.subtract(edwards25519.fe_one, &y)) // r = 1/(1 - y)
+	u.multiply(u.add(edwards25519.fe_one, y), recip) // u = (1 + y)*r
 
 	return copy_field_element(mut buf, mut u)
 }

--- a/vlib/crypto/ed25519/internal/edwards25519/extra_test.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/extra_test.v
@@ -122,7 +122,7 @@ fn invert_works(mut xinv Scalar, x NotZeroScalar) bool {
 	xinv.invert(x)
 	mut check := Scalar{}
 	check.multiply(x, xinv)
-	return check == sc_one && is_reduced(xinv)
+	return check == edwards25519.sc_one && is_reduced(xinv)
 }
 
 fn test_scalar_invert() {

--- a/vlib/crypto/ed25519/internal/edwards25519/point.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/point.v
@@ -80,7 +80,7 @@ mut:
 
 fn check_initialized(points ...Point) {
 	for _, p in points {
-		if p.x == fe_zero && p.y == fe_zero {
+		if p.x == edwards25519.fe_zero && p.y == edwards25519.fe_zero {
 			panic('edwards25519: use of uninitialized Point')
 		}
 	}
@@ -135,12 +135,12 @@ pub fn (mut v Point) set_bytes(x []u8) !Point {
 	mut el1 := Element{}
 	y2 := el1.square(y)
 	mut el2 := Element{}
-	u := el2.subtract(y2, fe_one)
+	u := el2.subtract(y2, edwards25519.fe_one)
 
 	// v = dy² + 1
 	mut el3 := Element{}
 	mut vv := el3.multiply(y2, edwards25519.d_const)
-	vv = vv.add(vv, fe_one)
+	vv = vv.add(vv, edwards25519.fe_one)
 
 	// x = +√(u/v)
 	mut el4 := Element{}

--- a/vlib/crypto/ed25519/internal/edwards25519/point_test.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/point_test.v
@@ -119,7 +119,7 @@ fn test_generator() {
 
 	assert hex.encode(b.x.bytes()) == x
 	assert hex.encode(b.y.bytes()) == y
-	assert b.z.equal(fe_one) == 1
+	assert b.z.equal(edwards25519.fe_one) == 1
 	// Check that t is correct.
 	assert check_on_curve(b) == true
 }

--- a/vlib/crypto/ed25519/internal/edwards25519/scalar_test.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/scalar_test.v
@@ -15,9 +15,9 @@ fn testsuite_begin() {
 }
 
 fn test_scalar_equal() {
-	assert sc_one.equal(sc_minus_one) != 1
+	assert edwards25519.sc_one.equal(edwards25519.sc_minus_one) != 1
 
-	assert sc_minus_one.equal(sc_minus_one) != 0
+	assert edwards25519.sc_minus_one.equal(edwards25519.sc_minus_one) != 0
 }
 
 fn test_scalar_non_adjacent_form() {
@@ -104,13 +104,13 @@ const sc_error = Scalar{
 }
 
 fn test_scalar_set_canonical_bytes_on_noncanonical_value() {
-	mut b := sc_minus_one.s
+	mut b := edwards25519.sc_minus_one.s
 	b[31] += 1
 
-	mut s := sc_one
+	mut s := edwards25519.sc_one
 	out := s.set_canonical_bytes(b[..]) or { edwards25519.sc_error } // set_canonical_bytes shouldn't worked on a non-canonical value"
 	assert out == edwards25519.sc_error
-	assert s == sc_one
+	assert s == edwards25519.sc_one
 }
 
 fn test_scalar_set_uniform_bytes() {

--- a/vlib/crypto/ed25519/internal/edwards25519/table_test.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/table_test.v
@@ -24,7 +24,7 @@ fn test_proj_lookup_table() {
 	acc_p1.add(acc_p3, tmp3)
 	acc_p3.from_p1(acc_p1)
 
-	assert acc_p3.equal(id_point) == 1
+	assert acc_p3.equal(edwards25519.id_point) == 1
 }
 
 fn test_affine_lookup_table() {
@@ -51,7 +51,7 @@ fn test_affine_lookup_table() {
 	acc_p1.add_affine(acc_p3, tmp3)
 	acc_p3.from_p1(acc_p1)
 
-	assert acc_p3.equal(id_point) == 1
+	assert acc_p3.equal(edwards25519.id_point) == 1
 }
 
 fn test_naf_lookup_table5() {

--- a/vlib/crypto/md5/md5block_generic.v
+++ b/vlib/crypto/md5/md5block_generic.v
@@ -24,7 +24,7 @@ fn block_generic(mut dig Digest, p []u8) {
 	mut c := dig.s[2]
 	mut d := dig.s[3]
 
-	for i := 0; i <= p.len - block_size; i += block_size {
+	for i := 0; i <= p.len - md5.block_size; i += md5.block_size {
 		// save current state
 		aa := a
 		bb := b

--- a/vlib/crypto/pem/decode.v
+++ b/vlib/crypto/pem/decode.v
@@ -21,7 +21,7 @@ pub fn decode_only(data string) ?Block {
 @[direct_array_access; inline]
 pub fn decode(data string) ?(Block, string) {
 	block, rest := decode_internal(data)?
-	return block, rest[rest.index(pem_end)? + pem_end.len..].all_after_first(pem_eol)
+	return block, rest[rest.index(pem.pem_end)? + pem.pem_end.len..].all_after_first(pem.pem_eol)
 }
 
 // decode_internal allows `decode` variations to deal with the rest of the data as
@@ -31,11 +31,11 @@ pub fn decode(data string) ?(Block, string) {
 fn decode_internal(data string) ?(Block, string) {
 	// direct_array_access safety: since we use the string.index method here,
 	// we won't get an invalid index since it would otherwise return `none`
-	mut rest := data[data.index(pem_begin)?..]
-	mut block := Block.new(rest[pem_begin.len..].all_before(pem_eol))
-	block.headers, rest = parse_headers(rest[pem_begin.len..].all_after(pem_eol).trim_left(' \n\t\v\f\r'))?
+	mut rest := data[data.index(pem.pem_begin)?..]
+	mut block := Block.new(rest[pem.pem_begin.len..].all_before(pem.pem_eol))
+	block.headers, rest = parse_headers(rest[pem.pem_begin.len..].all_after(pem.pem_eol).trim_left(' \n\t\v\f\r'))?
 
-	block_end_index := rest.index(pem_end)?
+	block_end_index := rest.index(pem.pem_end)?
 	b64_data := rest[..block_end_index].replace_each(['\r', '', '\n', '', '\t', '', ' ', ''])
 	block_data_len := block_end_index / 4 * 3
 	block.data = []u8{len: block_data_len, cap: block_data_len + 3, init: 0}
@@ -47,10 +47,10 @@ fn decode_internal(data string) ?(Block, string) {
 
 @[direct_array_access]
 fn parse_headers(block string) ?(map[string][]string, string) {
-	headers_str := block.all_before(pem_end).all_before('\n\n')
+	headers_str := block.all_before(pem.pem_end).all_before('\n\n')
 
 	// check that something was split or if it's empty
-	if headers_str.len == block.all_before(pem_end).len || headers_str.len == 0 {
+	if headers_str.len == block.all_before(pem.pem_end).len || headers_str.len == 0 {
 		return map[string][]string{}, block
 	}
 
@@ -61,7 +61,7 @@ fn parse_headers(block string) ?(map[string][]string, string) {
 	// index the key/value separator ':', otherwise
 	// return none because it should exist
 	// the initialisation of this function already tells us headers are present
-	mut colon_index := headers_separated[0].index(colon) or { return none }
+	mut colon_index := headers_separated[0].index(pem.colon) or { return none }
 
 	mut headers := map[string][]string{}
 	mut index := 0
@@ -77,7 +77,7 @@ fn parse_headers(block string) ?(map[string][]string, string) {
 
 		for colon_index = 0; index < headers_separated.len - 1 && colon_index == 0; {
 			index++
-			colon_index = headers_separated[index].index(colon) or {
+			colon_index = headers_separated[index].index(pem.colon) or {
 				val += headers_separated[index].trim_space()
 				0
 			}

--- a/vlib/crypto/pem/encode.v
+++ b/vlib/crypto/pem/encode.v
@@ -49,8 +49,8 @@ pub fn (block Block) encode(config EncodeConfig) !string {
 
 	inner += wrap_lines(base64.encode(block.data), newline, length)
 
-	return '${pem_begin}${block.block_type}${pem_eol}${newline}' + '${inner}' +
-		'${pem_end}${block.block_type}${pem_eol}'
+	return '${pem.pem_begin}${block.block_type}${pem.pem_eol}${newline}' + '${inner}' +
+		'${pem.pem_end}${block.block_type}${pem.pem_eol}'
 }
 
 @[inline]

--- a/vlib/crypto/sha1/sha1block_generic.v
+++ b/vlib/crypto/sha1/sha1block_generic.v
@@ -22,7 +22,7 @@ fn block_generic(mut dig Digest, p_ []u8) {
 		mut h2 := dig.h[2]
 		mut h3 := dig.h[3]
 		mut h4 := dig.h[4]
-		for p.len >= chunk {
+		for p.len >= sha1.chunk {
 			// Can interlace the computation of w with the
 			// rounds below if needed for speed.
 			for i in 0 .. 16 {
@@ -101,10 +101,10 @@ fn block_generic(mut dig Digest, p_ []u8) {
 			h2 += c
 			h3 += d
 			h4 += e
-			if chunk >= p.len {
+			if sha1.chunk >= p.len {
 				p = []
 			} else {
-				p = p[chunk..]
+				p = p[sha1.chunk..]
 			}
 		}
 		dig.h[0] = h0

--- a/vlib/crypto/sha256/sha256block_generic.v
+++ b/vlib/crypto/sha256/sha256block_generic.v
@@ -88,7 +88,7 @@ fn block_generic(mut dig Digest, p_ []u8) {
 		mut h5 := dig.h[5]
 		mut h6 := dig.h[6]
 		mut h7 := dig.h[7]
-		for p.len >= chunk {
+		for p.len >= sha256.chunk {
 			// Can interlace the computation of w with the
 			// rounds below if needed for speed.
 			for i in 0 .. 16 {
@@ -134,10 +134,10 @@ fn block_generic(mut dig Digest, p_ []u8) {
 			h5 += f
 			h6 += g
 			h7 += h
-			if chunk >= p.len {
+			if sha256.chunk >= p.len {
 				p = []
 			} else {
-				p = p[chunk..]
+				p = p[sha256.chunk..]
 			}
 		}
 		dig.h[0] = h0

--- a/vlib/crypto/sha3/sha3_state_test.v
+++ b/vlib/crypto/sha3/sha3_state_test.v
@@ -1,58 +1,58 @@
 module sha3
 
 fn test_round_constants() {
-	assert iota_round_constants[0] == 0x0000000000000001
-	assert iota_round_constants[1] == 0x0000000000008082
-	assert iota_round_constants[2] == 0x800000000000808A
-	assert iota_round_constants[3] == 0x8000000080008000
-	assert iota_round_constants[4] == 0x000000000000808B
-	assert iota_round_constants[5] == 0x0000000080000001
-	assert iota_round_constants[6] == 0x8000000080008081
-	assert iota_round_constants[7] == 0x8000000000008009
-	assert iota_round_constants[8] == 0x000000000000008A
-	assert iota_round_constants[9] == 0x0000000000000088
-	assert iota_round_constants[10] == 0x0000000080008009
-	assert iota_round_constants[11] == 0x000000008000000A
-	assert iota_round_constants[12] == 0x000000008000808B
-	assert iota_round_constants[13] == 0x800000000000008B
-	assert iota_round_constants[14] == 0x8000000000008089
-	assert iota_round_constants[15] == 0x8000000000008003
-	assert iota_round_constants[16] == 0x8000000000008002
-	assert iota_round_constants[17] == 0x8000000000000080
-	assert iota_round_constants[18] == 0x000000000000800A
-	assert iota_round_constants[19] == 0x800000008000000A
-	assert iota_round_constants[20] == 0x8000000080008081
-	assert iota_round_constants[21] == 0x8000000000008080
-	assert iota_round_constants[22] == 0x0000000080000001
-	assert iota_round_constants[23] == 0x8000000080008008
+	assert sha3.iota_round_constants[0] == 0x0000000000000001
+	assert sha3.iota_round_constants[1] == 0x0000000000008082
+	assert sha3.iota_round_constants[2] == 0x800000000000808A
+	assert sha3.iota_round_constants[3] == 0x8000000080008000
+	assert sha3.iota_round_constants[4] == 0x000000000000808B
+	assert sha3.iota_round_constants[5] == 0x0000000080000001
+	assert sha3.iota_round_constants[6] == 0x8000000080008081
+	assert sha3.iota_round_constants[7] == 0x8000000000008009
+	assert sha3.iota_round_constants[8] == 0x000000000000008A
+	assert sha3.iota_round_constants[9] == 0x0000000000000088
+	assert sha3.iota_round_constants[10] == 0x0000000080008009
+	assert sha3.iota_round_constants[11] == 0x000000008000000A
+	assert sha3.iota_round_constants[12] == 0x000000008000808B
+	assert sha3.iota_round_constants[13] == 0x800000000000008B
+	assert sha3.iota_round_constants[14] == 0x8000000000008089
+	assert sha3.iota_round_constants[15] == 0x8000000000008003
+	assert sha3.iota_round_constants[16] == 0x8000000000008002
+	assert sha3.iota_round_constants[17] == 0x8000000000000080
+	assert sha3.iota_round_constants[18] == 0x000000000000800A
+	assert sha3.iota_round_constants[19] == 0x800000008000000A
+	assert sha3.iota_round_constants[20] == 0x8000000080008081
+	assert sha3.iota_round_constants[21] == 0x8000000000008080
+	assert sha3.iota_round_constants[22] == 0x0000000080000001
+	assert sha3.iota_round_constants[23] == 0x8000000080008008
 }
 
 fn test_rho_offsets() {
-	assert rho_offsets[0][0] == 0
-	assert rho_offsets[1][0] == 1
-	assert rho_offsets[2][0] == 62
-	assert rho_offsets[3][0] == 28
-	assert rho_offsets[4][0] == 27
-	assert rho_offsets[0][1] == 36
-	assert rho_offsets[1][1] == 44
-	assert rho_offsets[2][1] == 6
-	assert rho_offsets[3][1] == 55
-	assert rho_offsets[4][1] == 20
-	assert rho_offsets[0][2] == 3
-	assert rho_offsets[1][2] == 10
-	assert rho_offsets[2][2] == 43
-	assert rho_offsets[3][2] == 25
-	assert rho_offsets[4][2] == 39
-	assert rho_offsets[0][3] == 41
-	assert rho_offsets[1][3] == 45
-	assert rho_offsets[2][3] == 15
-	assert rho_offsets[3][3] == 21
-	assert rho_offsets[4][3] == 8
-	assert rho_offsets[0][4] == 18
-	assert rho_offsets[1][4] == 2
-	assert rho_offsets[2][4] == 61
-	assert rho_offsets[3][4] == 56
-	assert rho_offsets[4][4] == 14
+	assert sha3.rho_offsets[0][0] == 0
+	assert sha3.rho_offsets[1][0] == 1
+	assert sha3.rho_offsets[2][0] == 62
+	assert sha3.rho_offsets[3][0] == 28
+	assert sha3.rho_offsets[4][0] == 27
+	assert sha3.rho_offsets[0][1] == 36
+	assert sha3.rho_offsets[1][1] == 44
+	assert sha3.rho_offsets[2][1] == 6
+	assert sha3.rho_offsets[3][1] == 55
+	assert sha3.rho_offsets[4][1] == 20
+	assert sha3.rho_offsets[0][2] == 3
+	assert sha3.rho_offsets[1][2] == 10
+	assert sha3.rho_offsets[2][2] == 43
+	assert sha3.rho_offsets[3][2] == 25
+	assert sha3.rho_offsets[4][2] == 39
+	assert sha3.rho_offsets[0][3] == 41
+	assert sha3.rho_offsets[1][3] == 45
+	assert sha3.rho_offsets[2][3] == 15
+	assert sha3.rho_offsets[3][3] == 21
+	assert sha3.rho_offsets[4][3] == 8
+	assert sha3.rho_offsets[0][4] == 18
+	assert sha3.rho_offsets[1][4] == 2
+	assert sha3.rho_offsets[2][4] == 61
+	assert sha3.rho_offsets[3][4] == 56
+	assert sha3.rho_offsets[4][4] == 14
 }
 
 fn test_zero_state() {

--- a/vlib/crypto/sha512/sha512block_generic.v
+++ b/vlib/crypto/sha512/sha512block_generic.v
@@ -46,7 +46,7 @@ fn block_generic(mut dig Digest, p_ []u8) {
 		mut h5 := dig.h[5]
 		mut h6 := dig.h[6]
 		mut h7 := dig.h[7]
-		for p.len >= chunk {
+		for p.len >= sha512.chunk {
 			for i in 0 .. 16 {
 				j := i * 8
 				// vfmt off
@@ -101,10 +101,10 @@ fn block_generic(mut dig Digest, p_ []u8) {
 			h5 += f
 			h6 += g
 			h7 += h
-			if chunk >= p.len {
+			if sha512.chunk >= p.len {
 				p = []
 			} else {
-				p = p[chunk..]
+				p = p[sha512.chunk..]
 			}
 		}
 		dig.h[0] = h0

--- a/vlib/db/sqlite/orm.v
+++ b/vlib/db/sqlite/orm.v
@@ -23,7 +23,7 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 	if config.is_count {
 		// 2. Get count of returned values & add it to ret array
 		step := stmt.step()
-		if step !in [sqlite_row, sqlite_ok, sqlite_done] {
+		if step !in [sqlite.sqlite_row, sqlite.sqlite_ok, sqlite.sqlite_done] {
 			return db.error_message(step, query)
 		}
 		count := stmt.sqlite_select_column(0, 8)!
@@ -33,10 +33,10 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 	for {
 		// 2. Parse returned values
 		step := stmt.step()
-		if step == sqlite_done {
+		if step == sqlite.sqlite_done {
 			break
 		}
-		if step != sqlite_ok && step != sqlite_row {
+		if step != sqlite.sqlite_ok && step != sqlite.sqlite_row {
 			break
 		}
 		mut row := []orm.Primitive{}

--- a/vlib/encoding/base58/base58.v
+++ b/vlib/encoding/base58/base58.v
@@ -6,7 +6,7 @@ import math
 
 // encode_int encodes any integer type to base58 string with Bitcoin alphabet
 pub fn encode_int(input int) !string {
-	return encode_int_walpha(input, btc_alphabet)
+	return encode_int_walpha(input, base58.btc_alphabet)
 }
 
 // encode_int_walpha any integer type to base58 string with custom alphabet
@@ -32,12 +32,12 @@ pub fn encode_int_walpha(input int, alphabet Alphabet) !string {
 
 // encode encodes the input string to base58 with the Bitcoin alphabet
 pub fn encode(input string) string {
-	return encode_walpha(input, btc_alphabet)
+	return encode_walpha(input, base58.btc_alphabet)
 }
 
 // encode_bytes encodes the input array to base58, with the Bitcoin alphabet
 pub fn encode_bytes(input []u8) []u8 {
-	return encode_walpha_bytes(input, btc_alphabet)
+	return encode_walpha_bytes(input, base58.btc_alphabet)
 }
 
 // encode_walpha encodes the input string to base58 with a custom aplhabet
@@ -98,7 +98,7 @@ pub fn encode_walpha_bytes(input []u8, alphabet Alphabet) []u8 {
 
 // decode_int decodes base58 string to an integer with Bitcoin alphabet
 pub fn decode_int(input string) !int {
-	return decode_int_walpha(input, btc_alphabet)
+	return decode_int_walpha(input, base58.btc_alphabet)
 }
 
 // decode_int_walpha decodes base58 string to an integer with custom alphabet
@@ -122,12 +122,12 @@ pub fn decode_int_walpha(input string, alphabet Alphabet) !int {
 
 // decode decodes the base58 input string, using the Bitcoin alphabet
 pub fn decode(str string) !string {
-	return decode_walpha(str, btc_alphabet)
+	return decode_walpha(str, base58.btc_alphabet)
 }
 
 // decode_bytes decodes the base58 encoded input array, using the Bitcoin alphabet
 pub fn decode_bytes(input []u8) ![]u8 {
-	return decode_walpha_bytes(input, btc_alphabet)
+	return decode_walpha_bytes(input, base58.btc_alphabet)
 }
 
 // decode_walpha decodes the base58 encoded input string, using custom alphabet

--- a/vlib/encoding/csv/csv_reader_sequential.v
+++ b/vlib/encoding/csv/csv_reader_sequential.v
@@ -24,8 +24,8 @@ pub:
 	comment      u8     = `#` // every line that start with the comment char is ignored
 	default_cell string = '*' // return this string if out of the csv boundaries
 	empty_cell   string // return this string if empty cell
-	end_line_len int = endline_cr_len // size of the endline rune
-	quote        u8  = `"`            // double quote is the standard quote char
+	end_line_len int = csv.endline_cr_len // size of the endline rune
+	quote        u8  = `"`                // double quote is the standard quote char
 }
 
 pub struct SequentialReader {
@@ -40,10 +40,10 @@ pub mut:
 	end_index   i64 = -1
 
 	end_line      u8  = `\n`
-	end_line_len  int = endline_cr_len // size of the endline rune \n = 1, \r\n = 2
-	separator     u8  = `,`            // comma is the default separator
-	separator_len int = 1              // size of the separator rune
-	quote         u8  = `"`            // double quote is the standard quote char
+	end_line_len  int = csv.endline_cr_len // size of the endline rune \n = 1, \r\n = 2
+	separator     u8  = `,`                // comma is the default separator
+	separator_len int = 1                  // size of the separator rune
+	quote         u8  = `"`                // double quote is the standard quote char
 
 	comment u8 = `#` // every line that start with the quote char is ignored
 
@@ -71,7 +71,7 @@ pub fn csv_sequential_reader(cfg SequentialReaderConfig) !&SequentialReader {
 
 	// reading from a RAM buffer
 	if cfg.scr_buf != 0 && cfg.scr_buf_len > 0 {
-		cr.mem_buf_type = ram_csv // RAM buffer
+		cr.mem_buf_type = csv.ram_csv // RAM buffer
 		cr.mem_buf = cfg.scr_buf
 		cr.mem_buf_size = cfg.scr_buf_len
 		if cfg.end_index == -1 {
@@ -95,7 +95,7 @@ pub fn csv_sequential_reader(cfg SequentialReaderConfig) !&SequentialReader {
 		if !os.exists(cfg.file_path) {
 			return error('ERROR: file ${cfg.file_path} not found!')
 		}
-		cr.mem_buf_type = file_csv // File buffer
+		cr.mem_buf_type = csv.file_csv // File buffer
 		// allocate the memory
 		unsafe {
 			cr.mem_buf = malloc(cfg.mem_buf_size)
@@ -141,9 +141,9 @@ pub fn csv_sequential_reader(cfg SequentialReaderConfig) !&SequentialReader {
 
 // dispose_csv_reader release the resources used by the csv_reader
 pub fn (mut cr SequentialReader) dispose_csv_reader() {
-	if cr.mem_buf_type == ram_csv {
+	if cr.mem_buf_type == csv.ram_csv {
 		// do nothing, ram buffer is static
-	} else if cr.mem_buf_type == file_csv {
+	} else if cr.mem_buf_type == csv.file_csv {
 		// file close
 		if cr.f.is_opened {
 			cr.f.close()
@@ -166,7 +166,7 @@ pub fn (mut cr SequentialReader) has_data() i64 {
 }
 
 fn (mut cr SequentialReader) fill_buffer(index i64) ! {
-	if cr.mem_buf_type == ram_csv {
+	if cr.mem_buf_type == csv.ram_csv {
 		// for now do nothing if ram buffer
 	} else {
 		cr.f.seek(index, .start)!

--- a/vlib/encoding/html/escape.v
+++ b/vlib/encoding/html/escape.v
@@ -84,7 +84,7 @@ fn unescape_all(input string) string {
 			} else {
 				// Named entity (e.g., &lt;)
 				entity := runes[i + 1..j].string()
-				if v := named_references[entity] {
+				if v := html.named_references[entity] {
 					result << v
 				} else {
 					// Leave unknown entities unchanged

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -132,20 +132,20 @@ pub fn is_punct(s string, index int) bool {
 // is_control return true if the rune is control code
 pub fn is_control(r rune) bool {
 	// control codes are all below 0xff
-	if r > max_latin_1 {
+	if r > utf8.max_latin_1 {
 		return false
 	}
-	return props[u8(r)] == 1
+	return utf8.props[u8(r)] == 1
 }
 
 // is_letter returns true if the rune is unicode letter or in unicode category L
 pub fn is_letter(r rune) bool {
 	if (r >= `a` && r <= `z`) || (r >= `A` && r <= `Z`) {
 		return true
-	} else if r <= max_latin_1 {
-		return props[u8(r)] & p_l_mask != 0
+	} else if r <= utf8.max_latin_1 {
+		return utf8.props[u8(r)] & utf8.p_l_mask != 0
 	}
-	return is_excluding_latin(letter_table, r)
+	return is_excluding_latin(utf8.letter_table, r)
 }
 
 // is_space returns true if the rune is character in unicode category Z with property white space or the following character set:
@@ -153,7 +153,7 @@ pub fn is_letter(r rune) bool {
 // `\t`, `\n`, `\v`, `\f`, `\r`, ` `, 0x85 (NEL), 0xA0 (NBSP)
 // ```
 pub fn is_space(r rune) bool {
-	if r <= max_latin_1 {
+	if r <= utf8.max_latin_1 {
 		match r {
 			`\t`, `\n`, `\v`, `\f`, `\r`, ` `, 0x85, 0xA0 {
 				return true
@@ -163,15 +163,15 @@ pub fn is_space(r rune) bool {
 			}
 		}
 	}
-	return is_excluding_latin(white_space_table, r)
+	return is_excluding_latin(utf8.white_space_table, r)
 }
 
 // is_number returns true if the rune is unicode number or in unicode category N
 pub fn is_number(r rune) bool {
-	if r <= max_latin_1 {
-		return props[u8(r)] & p_n != 0
+	if r <= utf8.max_latin_1 {
+		return utf8.props[u8(r)] & utf8.p_n != 0
 	}
-	return is_excluding_latin(number_table, r)
+	return is_excluding_latin(utf8.number_table, r)
 }
 
 // is_uchar_punct return true if the input unicode is a western unicode punctuation

--- a/vlib/encoding/xml/types.v
+++ b/vlib/encoding/xml/types.v
@@ -63,7 +63,7 @@ pub:
 type DTDInfo = DocumentTypeDefinition | string
 
 struct Prolog {
-	parsed_reverse_entities map[string]string = default_entities_reverse.clone()
+	parsed_reverse_entities map[string]string = xml.default_entities_reverse.clone()
 pub:
 	version  string       = '1.0'
 	encoding string       = 'UTF-8'

--- a/vlib/encoding/xml/validation.v
+++ b/vlib/encoding/xml/validation.v
@@ -48,8 +48,8 @@ pub fn (doc XMLDocument) validate() !XMLDocument {
 		DocumentTypeDefinition {
 			// Store the element and entity definitions
 			mut elements := map[string]DTDElement{}
-			mut entities := default_entities.clone()
-			mut reverse_entities := default_entities_reverse.clone()
+			mut entities := xml.default_entities.clone()
+			mut reverse_entities := xml.default_entities_reverse.clone()
 
 			for item in doc.doctype.dtd.list {
 				match item {

--- a/vlib/gg/m4/vector.v
+++ b/vlib/gg/m4/vector.v
@@ -39,7 +39,7 @@ pub fn vec4(x f32, y f32, z f32, w f32) Vec4 {
 pub fn (x Vec4) is_equal(y Vec4) bool {
 	unsafe {
 		for c, value in x.e {
-			if f32_abs(value - y.e[c]) > precision {
+			if f32_abs(value - y.e[c]) > m4.precision {
 				return false
 			}
 		}
@@ -52,7 +52,7 @@ pub fn (x Vec4) is_equal(y Vec4) bool {
 pub fn (x Vec4) clean() Vec4 {
 	mut n := x
 	for c, value in x.e {
-		if f32_abs(value) < precision {
+		if f32_abs(value) < m4.precision {
 			n.e[c] = 0
 		}
 	}

--- a/vlib/gx/text.v
+++ b/vlib/gx/text.v
@@ -7,7 +7,7 @@ pub const align_right = HorizontalAlign.right
 @[params]
 pub struct TextCfg {
 pub:
-	color          Color           = black
+	color          Color           = gx.black
 	size           int             = 16
 	align          HorizontalAlign = .left
 	vertical_align VerticalAlign   = .top

--- a/vlib/math/big/exponentiation.v
+++ b/vlib/math/big/exponentiation.v
@@ -16,7 +16,7 @@ struct MontgomeryContext {
 // the modulus provided in the integer `m`; assume m is odd and m != 0
 fn (m Integer) montgomery() MontgomeryContext {
 	$if debug {
-		assert m != zero_int
+		assert m != big.zero_int
 		assert m.is_odd()
 	}
 
@@ -29,8 +29,8 @@ fn (m Integer) montgomery() MontgomeryContext {
 		// ri := multiplicative inverse of r in the ring Z/nZ
 		// ri * r == 1 (mod n)
 		// ni = ((ri * 2^(log_2(n))) - 1) / n
-		ni: (one_int.left_shift(b).mod_inv(n).left_shift(b) - one_int) / n
-		rr: one_int.left_shift(b * 2) % n
+		ni: (big.one_int.left_shift(b).mod_inv(n).left_shift(b) - big.one_int) / n
+		rr: big.one_int.left_shift(b * 2) % n
 	}
 }
 
@@ -41,7 +41,7 @@ fn (m Integer) montgomery() MontgomeryContext {
 @[direct_array_access]
 fn (a Integer) mont_odd(x Integer, m Integer) Integer {
 	$if debug {
-		assert a > one_int && x > one_int
+		assert a > big.one_int && x > big.one_int
 		assert m.is_odd()
 	}
 
@@ -77,7 +77,7 @@ fn (a Integer) mont_odd(x Integer, m Integer) Integer {
 			signum: 1
 		}
 	} else {
-		one_int.to_mont(ctx)
+		big.one_int.to_mont(ctx)
 	}
 
 	mut start := true
@@ -159,12 +159,12 @@ fn (a Integer) mont_odd(x Integer, m Integer) Integer {
 @[direct_array_access]
 fn (a Integer) mont_even(x Integer, m Integer) Integer {
 	$if debug {
-		assert a > one_int && x > one_int
+		assert a > big.one_int && x > big.one_int
 		assert !m.is_odd()
 	}
 
 	m1, j := m.rsh_to_set_bit()
-	m2 := one_int.left_shift(j)
+	m2 := big.one_int.left_shift(j)
 
 	$if debug {
 		assert m1 * m2 == m
@@ -179,7 +179,7 @@ fn (a Integer) mont_even(x Integer, m Integer) Integer {
 	m1i := m1.mod_inv(m2)
 
 	$if debug {
-		assert (m1i * m1).mask_bits(m2n) == one_int
+		assert (m1i * m1).mask_bits(m2n) == big.one_int
 	}
 
 	t1 := x1.mask_bits(m2n)
@@ -189,7 +189,7 @@ fn (a Integer) mont_even(x Integer, m Integer) Integer {
 		(t2 - t1).mask_bits(m2n)
 	} else {
 		// (x2 - x1) % m2 = 1 + ((~((x2 % m2) - (x1 % m2))) % m2)
-		(t1 - t2).abs().bitwise_not().mask_bits(m2n) + one_int
+		(t1 - t2).abs().bitwise_not().mask_bits(m2n) + big.one_int
 	} * m1i).mask_bits(m2n)
 
 	return x1 + m1 * t
@@ -201,7 +201,7 @@ fn (a Integer) mont_even(x Integer, m Integer) Integer {
 @[direct_array_access]
 fn (a Integer) exp_binary(x Integer, m Integer) Integer {
 	$if debug {
-		assert a > one_int && x > one_int
+		assert a > big.one_int && x > big.one_int
 		assert m.is_power_of_2()
 	}
 
@@ -221,7 +221,7 @@ fn (a Integer) exp_binary(x Integer, m Integer) Integer {
 		table[i] = (table[i - 1] * d).mask_bits(n)
 	}
 
-	mut r := one_int
+	mut r := big.one_int
 
 	mut start := true
 	mut wstart := if x.bit_len() - 1 > n {
@@ -303,7 +303,7 @@ fn get_window_size(n u32) int {
 // space and reduces the result to montgomery space
 fn (a Integer) mont_mul(b Integer, ctx MontgomeryContext) Integer {
 	if (a.digits.len + b.digits.len) > 2 * ctx.n.digits.len {
-		return zero_int
+		return big.zero_int
 	}
 
 	t := a * b

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -49,7 +49,7 @@ fn int_signum(value int) int {
 // integer_from_int creates a new `big.Integer` from the given int value.
 pub fn integer_from_int(value int) Integer {
 	if value == 0 {
-		return zero_int
+		return big.zero_int
 	}
 	return Integer{
 		digits: [u32(iabs(value))]
@@ -60,7 +60,7 @@ pub fn integer_from_int(value int) Integer {
 // integer_from_u32 creates a new `big.Integer` from the given u32 value.
 pub fn integer_from_u32(value u32) Integer {
 	if value == 0 {
-		return zero_int
+		return big.zero_int
 	}
 	return Integer{
 		digits: [value]
@@ -71,7 +71,7 @@ pub fn integer_from_u32(value u32) Integer {
 // integer_from_i64 creates a new `big.Integer` from the given i64 value.
 pub fn integer_from_i64(value i64) Integer {
 	if value == 0 {
-		return zero_int
+		return big.zero_int
 	}
 
 	signum_value := if value < 0 { -1 } else { 1 }
@@ -96,7 +96,7 @@ pub fn integer_from_i64(value i64) Integer {
 // integer_from_u64 creates a new `big.Integer` from the given u64 value.
 pub fn integer_from_u64(value u64) Integer {
 	if value == 0 {
-		return zero_int
+		return big.zero_int
 	}
 
 	lower := u32(value & 0x00000000ffffffff)
@@ -249,7 +249,7 @@ fn integer_from_regular_string(characters string, radix u32) Integer {
 
 	start_index := if sign_present { 1 } else { 0 }
 
-	mut result := zero_int
+	mut result := big.zero_int
 	radix_int := integer_from_u32(radix)
 
 	for index := start_index; index < characters.len; index++ {
@@ -269,7 +269,7 @@ fn integer_from_regular_string(characters string, radix u32) Integer {
 // abs returns the absolute value of the integer `a`.
 pub fn (a Integer) abs() Integer {
 	return if a.signum == 0 {
-		zero_int
+		big.zero_int
 	} else {
 		Integer{
 			digits: a.digits.clone()
@@ -281,7 +281,7 @@ pub fn (a Integer) abs() Integer {
 // neg returns the result of negation of the integer `a`.
 pub fn (a Integer) neg() Integer {
 	return if a.signum == 0 {
-		zero_int
+		big.zero_int
 	} else {
 		Integer{
 			digits: a.digits.clone()
@@ -338,7 +338,7 @@ fn (integer Integer) add(addend Integer) Integer {
 fn (integer Integer) subtract(subtrahend Integer) Integer {
 	cmp := integer.abs_cmp(subtrahend)
 	if cmp == 0 {
-		return zero_int
+		return big.zero_int
 	}
 	a, b := if cmp > 0 { integer, subtrahend } else { subtrahend, integer }
 	mut storage := []u32{len: a.digits.len}
@@ -353,12 +353,12 @@ fn (integer Integer) subtract(subtrahend Integer) Integer {
 pub fn (multiplicand Integer) * (multiplier Integer) Integer {
 	// Quick exits
 	if multiplicand.signum == 0 || multiplier.signum == 0 {
-		return zero_int
+		return big.zero_int
 	}
-	if multiplicand == one_int {
+	if multiplicand == big.one_int {
 		return multiplier.clone()
 	}
-	if multiplier == one_int {
+	if multiplier == big.one_int {
 		return multiplicand.clone()
 	}
 	// The final sign is the product of the signs
@@ -381,10 +381,10 @@ fn (dividend Integer) div_mod_internal(divisor Integer) (Integer, Integer) {
 	}
 
 	if dividend.signum == 0 {
-		return zero_int, zero_int
+		return big.zero_int, big.zero_int
 	}
-	if divisor == one_int {
-		return dividend.clone(), zero_int
+	if divisor == big.one_int {
+		return dividend.clone(), big.zero_int
 	}
 	if divisor.signum == -1 {
 		q, r := dividend.div_mod_internal(divisor.neg())
@@ -393,9 +393,9 @@ fn (dividend Integer) div_mod_internal(divisor Integer) (Integer, Integer) {
 	if dividend.signum == -1 {
 		q, r := dividend.neg().div_mod_internal(divisor)
 		if r.signum == 0 {
-			return q.neg(), zero_int
+			return q.neg(), big.zero_int
 		} else {
-			return q.neg() - one_int, divisor - r
+			return q.neg() - big.one_int, divisor - r
 		}
 	}
 	// Division for positive integers
@@ -485,7 +485,7 @@ fn (a Integer) mask_bits(n u32) Integer {
 	}
 
 	if a.digits.len == 0 || n == 0 {
-		return zero_int
+		return big.zero_int
 	}
 
 	w := n / 32
@@ -517,14 +517,14 @@ fn (a Integer) mask_bits(n u32) Integer {
 // pow returns the integer `base` raised to the power of the u32 `exponent`.
 pub fn (base Integer) pow(exponent u32) Integer {
 	if exponent == 0 {
-		return one_int
+		return big.one_int
 	}
 	if exponent == 1 {
 		return base.clone()
 	}
 	mut n := exponent
 	mut x := base
-	mut y := one_int
+	mut y := big.one_int
 	for n > 1 {
 		if n & 1 == 1 {
 			y *= x
@@ -538,14 +538,14 @@ pub fn (base Integer) pow(exponent u32) Integer {
 // mod_pow returns the integer `base` raised to the power of the u32 `exponent` modulo the integer `modulus`.
 pub fn (base Integer) mod_pow(exponent u32, modulus Integer) Integer {
 	if exponent == 0 {
-		return one_int
+		return big.one_int
 	}
 	if exponent == 1 {
 		return base % modulus
 	}
 	mut n := exponent
 	mut x := base % modulus
-	mut y := one_int
+	mut y := big.one_int
 	for n > 1 {
 		if n & 1 == 1 {
 			y *= x % modulus
@@ -565,17 +565,17 @@ pub fn (base Integer) big_mod_pow(exponent Integer, modulus Integer) !Integer {
 
 	// this goes first as otherwise 1 could be returned incorrectly if base == 1
 	if modulus.bit_len() <= 1 {
-		return zero_int
+		return big.zero_int
 	}
 
 	// x^0 == 1 || 1^x == 1
 	if exponent.signum == 0 || base.bit_len() == 1 {
-		return one_int
+		return big.one_int
 	}
 
 	// 0^x == 0 (x != 0 due to previous clause)
 	if base.signum == 0 {
-		return one_int
+		return big.one_int
 	}
 
 	if exponent.bit_len() == 1 {
@@ -607,12 +607,12 @@ pub fn (base Integer) big_mod_pow(exponent Integer, modulus Integer) !Integer {
 
 // inc increments `a` by 1 in place.
 pub fn (mut a Integer) inc() {
-	a = a + one_int
+	a = a + big.one_int
 }
 
 // dec decrements `a` by 1 in place.
 pub fn (mut a Integer) dec() {
-	a = a - one_int
+	a = a - big.one_int
 }
 
 // == returns `true` if the integers `a` and `b` are equal in value and sign.
@@ -665,7 +665,7 @@ pub fn (mut a Integer) set_bit(i u32, value bool) {
 
 	if target_index >= a.digits.len {
 		if value {
-			a = one_int.left_shift(i).bitwise_or(a)
+			a = big.one_int.left_shift(i).bitwise_or(a)
 		}
 		return
 	}
@@ -780,7 +780,7 @@ pub fn (a Integer) right_shift(amount u32) Integer {
 	normalised_amount := amount & 31
 	digit_offset := int(amount >> 5)
 	if digit_offset >= a.digits.len {
-		return zero_int
+		return big.zero_int
 	}
 	mut new_array := []u32{len: a.digits.len - digit_offset}
 	for index in 0 .. new_array.len {
@@ -871,8 +871,8 @@ fn (integer Integer) general_radix_str(radix u32) string {
 	divisor := integer_from_u32(radix)
 
 	mut current := integer.abs()
-	mut new_current := zero_int
-	mut digit := zero_int
+	mut new_current := big.zero_int
+	mut digit := big.zero_int
 	mut rune_array := []rune{cap: current.digits.len * 4}
 	for current.signum > 0 {
 		new_current, digit = current.div_mod_internal(divisor)
@@ -969,9 +969,9 @@ pub fn (a Integer) bytes() ([]u8, int) {
 // factorial returns the factorial of the integer `a`.
 pub fn (a Integer) factorial() Integer {
 	if a.signum == 0 {
-		return one_int
+		return big.one_int
 	}
-	mut product := one_int
+	mut product := big.one_int
 	mut current := a
 	for current.signum != 0 {
 		product *= current
@@ -1005,10 +1005,10 @@ pub fn (a Integer) isqrt_checked() !Integer {
 	if shift & 1 == 1 {
 		shift += 1
 	}
-	mut result := zero_int
+	mut result := big.zero_int
 	for shift >= 0 {
 		result = result.left_shift(1)
-		larger := result + one_int
+		larger := result + big.one_int
 		if (larger * larger).abs_cmp(a.right_shift(u32(shift))) <= 0 {
 			result = larger
 		}
@@ -1048,8 +1048,8 @@ pub fn (a Integer) gcd_binary(b Integer) Integer {
 	if b.signum == 0 {
 		return a.abs()
 	}
-	if a.abs_cmp(one_int) == 0 || b.abs_cmp(one_int) == 0 {
-		return one_int
+	if a.abs_cmp(big.one_int) == 0 || b.abs_cmp(big.one_int) == 0 {
+		return big.one_int
 	}
 
 	mut aa, az := a.abs().rsh_to_set_bit()
@@ -1098,7 +1098,7 @@ pub fn (a Integer) gcd_euclid(b Integer) Integer {
 pub fn (a Integer) mod_inverse(n Integer) !Integer {
 	return if n.bit_len() <= 1 {
 		error('math.big: Modulus `n` must be greater than 1')
-	} else if a.gcd(n) != one_int {
+	} else if a.gcd(n) != big.one_int {
 		error('math.big: No multiplicative inverse')
 	} else {
 		a.mod_inv(n)
@@ -1124,16 +1124,16 @@ fn (a Integer) mod_inv(m Integer) Integer {
 		signum: 1
 	}
 	mut b := a
-	mut x := one_int
-	mut y := zero_int
+	mut x := big.one_int
+	mut y := big.zero_int
 	if b.signum < 0 || b.abs_cmp(n) >= 0 {
 		b = b % n
 	}
 	mut sign := -1
 
-	for b != zero_int {
+	for b != big.zero_int {
 		q, r := if n.bit_len() == b.bit_len() {
-			one_int, n - b
+			big.one_int, n - b
 		} else {
 			// safe because the loop terminates if b == 0
 			n.div_mod_internal(b)
@@ -1143,7 +1143,7 @@ fn (a Integer) mod_inv(m Integer) Integer {
 		b = r
 
 		// tmp := q * x + y
-		tmp := if q == one_int {
+		tmp := if q == big.one_int {
 			x
 		} else if q.digits.len == 1 && q.digits[0] & (q.digits[0] - 1) == 0 {
 			x.left_shift(u32(bits.trailing_zeros_32(q.digits[0])))
@@ -1161,7 +1161,7 @@ fn (a Integer) mod_inv(m Integer) Integer {
 	}
 
 	$if debug {
-		assert n == one_int
+		assert n == big.one_int
 	}
 
 	return if y.signum > 0 && y.abs_cmp(m) < 0 {
@@ -1177,7 +1177,7 @@ fn (a Integer) mod_inv(m Integer) Integer {
 @[direct_array_access; inline]
 fn (x Integer) rsh_to_set_bit() (Integer, u32) {
 	if x.digits.len == 0 {
-		return zero_int, 0
+		return big.zero_int, 0
 	}
 
 	mut n := u32(0)

--- a/vlib/math/big/special_array_ops.v
+++ b/vlib/math/big/special_array_ops.v
@@ -32,7 +32,7 @@ fn newton_divide_array_by_array(operand_a []u32, operand_b []u32, mut quotient [
 	// https://en.wikipedia.org/wiki/Division_algorithm#Newton%E2%80%93Raphson_division
 	// use 48/17 - 32/17.D (divisor)
 	initial_guess := (((integer_from_int(48) - (integer_from_int(32) * b)) * integer_from_i64(0x0f0f0f0f0f0f0f0f)).right_shift(64)).neg() // / 17 == 0x11
-	if initial_guess > zero_int {
+	if initial_guess > big.zero_int {
 		x = initial_guess
 	}
 	mut lastx := integer_from_int(0)
@@ -182,9 +182,9 @@ fn toom3_multiply_digit_array(operand_a []u32, operand_b []u32, mut storage []u3
 	}
 
 	// Zero arrays by default
-	mut b0 := zero_int.clone()
-	mut b1 := zero_int.clone()
-	mut b2 := zero_int.clone()
+	mut b0 := big.zero_int.clone()
+	mut b1 := big.zero_int.clone()
+	mut b2 := big.zero_int.clone()
 
 	if operand_b.len < k {
 		b0 = Integer{
@@ -228,7 +228,7 @@ fn toom3_multiply_digit_array(operand_a []u32, operand_b []u32, mut storage []u3
 	p2 := ((ptemp + a2).left_shift(1) - a0) * ((qtemp + b2).left_shift(1) - b0)
 	pinf := a2 * b2
 
-	mut t2, _ := (p2 - vm1).div_mod_internal(three_int)
+	mut t2, _ := (p2 - vm1).div_mod_internal(big.three_int)
 	mut tm1 := (p1 - vm1).right_shift(1)
 	mut t1 := p1 - p0
 	t2 = (t2 - t1).right_shift(1)

--- a/vlib/math/bits.v
+++ b/vlib/math/bits.v
@@ -49,7 +49,7 @@ pub fn is_inf(f f64, sign int) bool {
 	// To avoid the floating-point hardware, could use:
 	// x := f64_bits(f);
 	// return sign >= 0 && x == uvinf || sign <= 0 && x == uvneginf;
-	return (sign >= 0 && f > max_f64) || (sign <= 0 && f < -max_f64)
+	return (sign >= 0 && f > math.max_f64) || (sign <= 0 && f < -math.max_f64)
 }
 
 // is_finite returns true if f is finite

--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -47,7 +47,7 @@ pub fn leading_zeros_64(x u64) int {
 // trailing_zeros_8 returns the number of trailing zero bits in x; the result is 8 for x == 0.
 @[direct_array_access]
 pub fn trailing_zeros_8(x u8) int {
-	return int(ntz_8_tab[x])
+	return int(bits.ntz_8_tab[x])
 }
 
 // trailing_zeros_16 returns the number of trailing zero bits in x; the result is 16 for x == 0.
@@ -94,20 +94,20 @@ pub fn trailing_zeros_64(x u64) int {
 // ones_count_8 returns the number of one bits ("population count") in x.
 @[direct_array_access]
 pub fn ones_count_8(x u8) int {
-	return int(pop_8_tab[x])
+	return int(bits.pop_8_tab[x])
 }
 
 // ones_count_16 returns the number of one bits ("population count") in x.
 @[direct_array_access]
 pub fn ones_count_16(x u16) int {
-	return int(pop_8_tab[x >> 8] + pop_8_tab[x & u16(0xff)])
+	return int(bits.pop_8_tab[x >> 8] + bits.pop_8_tab[x & u16(0xff)])
 }
 
 // ones_count_32 returns the number of one bits ("population count") in x.
 @[direct_array_access]
 pub fn ones_count_32(x u32) int {
-	return int(pop_8_tab[x >> 24] + pop_8_tab[x >> 16 & 0xff] + pop_8_tab[x >> 8 & 0xff] +
-		pop_8_tab[x & u32(0xff)])
+	return int(bits.pop_8_tab[x >> 24] + bits.pop_8_tab[x >> 16 & 0xff] +
+		bits.pop_8_tab[x >> 8 & 0xff] + bits.pop_8_tab[x & u32(0xff)])
 }
 
 // ones_count_64 returns the number of one bits ("population count") in x.
@@ -190,13 +190,13 @@ pub fn rotate_left_64(x u64, k int) u64 {
 // reverse_8 returns the value of x with its bits in reversed order.
 @[direct_array_access; inline]
 pub fn reverse_8(x u8) u8 {
-	return rev_8_tab[x]
+	return bits.rev_8_tab[x]
 }
 
 // reverse_16 returns the value of x with its bits in reversed order.
 @[direct_array_access; inline]
 pub fn reverse_16(x u16) u16 {
-	return u16(rev_8_tab[x >> 8]) | (u16(rev_8_tab[x & u16(0xff)]) << 8)
+	return u16(bits.rev_8_tab[x >> 8]) | (u16(bits.rev_8_tab[x & u16(0xff)]) << 8)
 }
 
 // reverse_32 returns the value of x with its bits in reversed order.
@@ -249,7 +249,7 @@ pub fn reverse_bytes_64(x u64) u64 {
 // len_8 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
 @[direct_array_access]
 pub fn len_8(x u8) int {
-	return int(len_8_tab[x])
+	return int(bits.len_8_tab[x])
 }
 
 // len_16 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
@@ -261,7 +261,7 @@ pub fn len_16(x u16) int {
 		y >>= 8
 		n = 8
 	}
-	return n + int(len_8_tab[y])
+	return n + int(bits.len_8_tab[y])
 }
 
 // len_32 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
@@ -277,7 +277,7 @@ pub fn len_32(x u32) int {
 		y >>= 8
 		n += 8
 	}
-	return n + int(len_8_tab[y])
+	return n + int(bits.len_8_tab[y])
 }
 
 // len_64 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
@@ -297,7 +297,7 @@ pub fn len_64(x u64) int {
 		y >>= 8
 		n += 8
 	}
-	return n + int(len_8_tab[y])
+	return n + int(bits.len_8_tab[y])
 }
 
 // --- Add with carry ---

--- a/vlib/math/exp.v
+++ b/vlib/math/exp.v
@@ -169,7 +169,7 @@ pub fn expm1(x f64) f64 {
 		return f64(-1)
 	}
 	// FIXME: this should be improved
-	if abs(x) < ln2 { // Compute the taylor series S = x + (1/2!) x^2 + (1/3!) x^3 + ...
+	if abs(x) < math.ln2 { // Compute the taylor series S = x + (1/2!) x^2 + (1/3!) x^3 + ...
 		mut i := 1.0
 		mut sum := x
 		mut term := x / 1.0

--- a/vlib/math/factorial.v
+++ b/vlib/math/factorial.v
@@ -3,12 +3,12 @@ module math
 // factorial calculates the factorial of the provided value.
 pub fn factorial(n f64) f64 {
 	// For a large positive argument (n >= factorials_table.len) return max_f64
-	if n >= factorials_table.len {
-		return max_f64
+	if n >= math.factorials_table.len {
+		return math.max_f64
 	}
 	// Otherwise return n!.
 	if n == f64(i64(n)) && n >= 0.0 {
-		return factorials_table[i64(n)]
+		return math.factorials_table[i64(n)]
 	}
 	return gamma(n + 1.0)
 }
@@ -17,13 +17,13 @@ pub fn factorial(n f64) f64 {
 pub fn log_factorial(n f64) f64 {
 	// For a large positive argument (n < 0) return max_f64
 	if n < 0 {
-		return -max_f64
+		return -math.max_f64
 	}
 	// If n < N then return ln(n!).
 	if n != f64(i64(n)) {
 		return log_gamma(n + 1)
-	} else if n < log_factorials_table.len {
-		return log_factorials_table[i64(n)]
+	} else if n < math.log_factorials_table.len {
+		return math.log_factorials_table[i64(n)]
 	}
 	// Otherwise return asymptotic expansion of ln(n!).
 	return log_factorial_asymptotic_expansion(int(n))
@@ -34,10 +34,10 @@ fn log_factorial_asymptotic_expansion(n int) f64 {
 	mut term := []f64{}
 	xx := f64((n + 1) * (n + 1))
 	mut xj := f64(n + 1)
-	log_factorial := log_sqrt_2pi - xj + (xj - 0.5) * log(xj)
+	log_factorial := math.log_sqrt_2pi - xj + (xj - 0.5) * log(xj)
 	mut i := 0
 	for i = 0; i < m; i++ {
-		term << bernoulli[i] / xj
+		term << math.bernoulli[i] / xj
 		xj *= xx
 	}
 	mut sum := term[m - 1]
@@ -61,7 +61,7 @@ pub fn factoriali(n int) i64 {
 	}
 
 	if n < 21 {
-		return i64(factorials_table[n])
+		return i64(math.factorials_table[n])
 	}
 
 	return i64(-1)

--- a/vlib/math/floor.v
+++ b/vlib/math/floor.v
@@ -137,23 +137,23 @@ pub fn round_sig(x f64, sig_digits int) f64 {
 // round_to_even(nan) = nan
 pub fn round_to_even(x f64) f64 {
 	mut bits := f64_bits(x)
-	mut e_ := (bits >> shift) & mask
-	if e_ >= bias {
+	mut e_ := (bits >> math.shift) & math.mask
+	if e_ >= math.bias {
 		// round abs(x) >= 1.
 		// - Large numbers without fractional components, infinity, and nan are unchanged.
 		// - Add 0.499.. or 0.5 before truncating depending on whether the truncated
 		// number is even or odd (respectively).
-		half_minus_ulp := u64(u64(1) << (shift - 1)) - 1
-		e_ -= u64(bias)
-		bits += (half_minus_ulp + (bits >> (shift - e_)) & 1) >> e_
-		bits &= frac_mask >> e_
-		bits ^= frac_mask >> e_
-	} else if e_ == bias - 1 && bits & frac_mask != 0 {
+		half_minus_ulp := u64(u64(1) << (math.shift - 1)) - 1
+		e_ -= u64(math.bias)
+		bits += (half_minus_ulp + (bits >> (math.shift - e_)) & 1) >> e_
+		bits &= math.frac_mask >> e_
+		bits ^= math.frac_mask >> e_
+	} else if e_ == math.bias - 1 && bits & math.frac_mask != 0 {
 		// round 0.5 < abs(x) < 1.
-		bits = bits & sign_mask | uvone // +-1
+		bits = bits & math.sign_mask | math.uvone // +-1
 	} else {
 		// round abs(x) <= 0.5 including denormals.
-		bits &= sign_mask // +-0
+		bits &= math.sign_mask // +-0
 	}
 	return f64_from_bits(bits)
 }

--- a/vlib/math/gamma.v
+++ b/vlib/math/gamma.v
@@ -14,8 +14,8 @@ fn stirling(x f64) (f64, f64) {
 	sqrt_two_pi := 2.506628274631000502417
 	max_stirling := 143.01608
 	mut w := 1.0 / x
-	w = 1.0 + w * ((((gamma_s[0] * w + gamma_s[1]) * w + gamma_s[2]) * w + gamma_s[3]) * w +
-		gamma_s[4])
+	w = 1.0 + w * ((((math.gamma_s[0] * w + math.gamma_s[1]) * w + math.gamma_s[2]) * w +
+		math.gamma_s[3]) * w + math.gamma_s[4])
 	mut y1 := exp(x)
 	mut y2 := 1.0
 	if x > max_stirling { // avoid Pow() overflow
@@ -70,7 +70,7 @@ pub fn gamma(a f64) f64 {
 			p = p + 1
 			z = q - p
 		}
-		z = q * sin(pi * z)
+		z = q * sin(math.pi * z)
 		if z == 0 {
 			return inf(signgam)
 		}
@@ -78,9 +78,9 @@ pub fn gamma(a f64) f64 {
 		absz := abs(z)
 		d := absz * sq1 * sq2
 		if is_inf(d, 0) {
-			z = pi / absz / sq1 / sq2
+			z = math.pi / absz / sq1 / sq2
 		} else {
-			z = pi / d
+			z = math.pi / d
 		}
 		return f64(signgam) * z
 	}
@@ -112,10 +112,11 @@ pub fn gamma(a f64) f64 {
 		return z
 	}
 	x = x - 2
-	p = (((((x * gamma_p[0] + gamma_p[1]) * x + gamma_p[2]) * x + gamma_p[3]) * x +
-		gamma_p[4]) * x + gamma_p[5]) * x + gamma_p[6]
-	q = ((((((x * gamma_q[0] + gamma_q[1]) * x + gamma_q[2]) * x + gamma_q[3]) * x +
-		gamma_q[4]) * x + gamma_q[5]) * x + gamma_q[6]) * x + gamma_q[7]
+	p = (((((x * math.gamma_p[0] + math.gamma_p[1]) * x + math.gamma_p[2]) * x +
+		math.gamma_p[3]) * x + math.gamma_p[4]) * x + math.gamma_p[5]) * x + math.gamma_p[6]
+	q = ((((((x * math.gamma_q[0] + math.gamma_q[1]) * x + math.gamma_q[2]) * x +
+		math.gamma_q[3]) * x + math.gamma_q[4]) * x + math.gamma_q[5]) * x + math.gamma_q[6]) * x +
+		math.gamma_q[7]
 	if true {
 		return z * p / q
 	}
@@ -181,7 +182,7 @@ pub fn log_gamma_sign(a f64) (f64, int) {
 		if t == 0 {
 			return inf(1), sign
 		}
-		nadj = log(pi / abs(t * x))
+		nadj = log(math.pi / abs(t * x))
 		if t < 0 {
 			sign = -1
 		}
@@ -219,37 +220,38 @@ pub fn log_gamma_sign(a f64) (f64, int) {
 		}
 		if i == 0 {
 			z := y * y
-			gamma_p1 := lgamma_a[0] + z * (lgamma_a[2] + z * (lgamma_a[4] + z * (lgamma_a[6] +
-				z * (lgamma_a[8] + z * lgamma_a[10]))))
-			gamma_p2 := z * (lgamma_a[1] + z * (lgamma_a[3] + z * (lgamma_a[5] + z * (lgamma_a[7] +
-				z * (lgamma_a[9] + z * lgamma_a[11])))))
+			gamma_p1 := math.lgamma_a[0] + z * (math.lgamma_a[2] + z * (math.lgamma_a[4] +
+				z * (math.lgamma_a[6] + z * (math.lgamma_a[8] + z * math.lgamma_a[10]))))
+			gamma_p2 := z * (math.lgamma_a[1] + z * (math.lgamma_a[3] + z * (math.lgamma_a[5] +
+				z * (math.lgamma_a[7] + z * (math.lgamma_a[9] + z * math.lgamma_a[11])))))
 			p := y * gamma_p1 + gamma_p2
 			lgamma += (p - 0.5 * y)
 		} else if i == 1 {
 			z := y * y
 			w := z * y
-			gamma_p1 := lgamma_t[0] + w * (lgamma_t[3] + w * (lgamma_t[6] + w * (lgamma_t[9] +
-				w * lgamma_t[12]))) // parallel comp
-			gamma_p2 := lgamma_t[1] + w * (lgamma_t[4] + w * (lgamma_t[7] + w * (lgamma_t[10] +
-				w * lgamma_t[13])))
-			gamma_p3 := lgamma_t[2] + w * (lgamma_t[5] + w * (lgamma_t[8] + w * (lgamma_t[11] +
-				w * lgamma_t[14])))
+			gamma_p1 := math.lgamma_t[0] + w * (math.lgamma_t[3] + w * (math.lgamma_t[6] +
+				w * (math.lgamma_t[9] + w * math.lgamma_t[12]))) // parallel comp
+			gamma_p2 := math.lgamma_t[1] + w * (math.lgamma_t[4] + w * (math.lgamma_t[7] +
+				w * (math.lgamma_t[10] + w * math.lgamma_t[13])))
+			gamma_p3 := math.lgamma_t[2] + w * (math.lgamma_t[5] + w * (math.lgamma_t[8] +
+				w * (math.lgamma_t[11] + w * math.lgamma_t[14])))
 			p := z * gamma_p1 - (tt - w * (gamma_p2 + y * gamma_p3))
 			lgamma += (tf + p)
 		} else if i == 2 {
-			gamma_p1 := y * (lgamma_u[0] + y * (lgamma_u[1] + y * (lgamma_u[2] + y * (lgamma_u[3] +
-				y * (lgamma_u[4] + y * lgamma_u[5])))))
-			gamma_p2 := 1.0 + y * (lgamma_v[1] + y * (lgamma_v[2] + y * (lgamma_v[3] +
-				y * (lgamma_v[4] + y * lgamma_v[5]))))
+			gamma_p1 := y * (math.lgamma_u[0] + y * (math.lgamma_u[1] + y * (math.lgamma_u[2] +
+				y * (math.lgamma_u[3] + y * (math.lgamma_u[4] + y * math.lgamma_u[5])))))
+			gamma_p2 := 1.0 + y * (math.lgamma_v[1] + y * (math.lgamma_v[2] +
+				y * (math.lgamma_v[3] + y * (math.lgamma_v[4] + y * math.lgamma_v[5]))))
 			lgamma += (-0.5 * y + gamma_p1 / gamma_p2)
 		}
 	} else if x < 8 { // 2 <= x < 8
 		i := int(x)
 		y := x - f64(i)
-		p := y * (lgamma_s[0] + y * (lgamma_s[1] + y * (lgamma_s[2] + y * (lgamma_s[3] +
-			y * (lgamma_s[4] + y * (lgamma_s[5] + y * lgamma_s[6]))))))
-		q := 1.0 + y * (lgamma_r[1] + y * (lgamma_r[2] + y * (lgamma_r[3] + y * (lgamma_r[4] +
-			y * (lgamma_r[5] + y * lgamma_r[6])))))
+		p := y * (math.lgamma_s[0] + y * (math.lgamma_s[1] + y * (math.lgamma_s[2] +
+			y * (math.lgamma_s[3] + y * (math.lgamma_s[4] + y * (math.lgamma_s[5] +
+			y * math.lgamma_s[6]))))))
+		q := 1.0 + y * (math.lgamma_r[1] + y * (math.lgamma_r[2] + y * (math.lgamma_r[3] +
+			y * (math.lgamma_r[4] + y * (math.lgamma_r[5] + y * math.lgamma_r[6])))))
 		lgamma = 0.5 * y + p / q
 		mut z := 1.0 // lgamma(1+s) = log(s) + lgamma(s)
 		if i == 7 {
@@ -282,8 +284,9 @@ pub fn log_gamma_sign(a f64) (f64, int) {
 		t := log(x)
 		z := 1.0 / x
 		y := z * z
-		w := lgamma_w[0] + z * (lgamma_w[1] + y * (lgamma_w[2] + y * (lgamma_w[3] +
-			y * (lgamma_w[4] + y * (lgamma_w[5] + y * lgamma_w[6])))))
+		w := math.lgamma_w[0] + z * (math.lgamma_w[1] + y * (math.lgamma_w[2] +
+			y * (math.lgamma_w[3] + y * (math.lgamma_w[4] + y * (math.lgamma_w[5] +
+			y * math.lgamma_w[6])))))
 		lgamma = (x - 0.5) * (t - 1.0) + w
 	} else { // 2**58 <= x <= Inf
 		lgamma = x * (log(x) - 1.0)
@@ -300,7 +303,7 @@ fn sin_pi(x_ f64) f64 {
 	two52 := exp2(52) // 0x4330000000000000 ~4.5036e+15
 	two53 := exp2(53) // 0x4340000000000000 ~9.0072e+15
 	if x < 0.25 {
-		return -sin(pi * x)
+		return -sin(math.pi * x)
 	}
 	// argument reduction
 	mut z := floor(x)
@@ -322,15 +325,15 @@ fn sin_pi(x_ f64) f64 {
 		}
 	}
 	if n == 0 {
-		x = sin(pi * x)
+		x = sin(math.pi * x)
 	} else if n == 1 || n == 2 {
-		x = cos(pi * (0.5 - x))
+		x = cos(math.pi * (0.5 - x))
 	} else if n == 3 || n == 4 {
-		x = sin(pi * (1.0 - x))
+		x = sin(math.pi * (1.0 - x))
 	} else if n == 5 || n == 6 {
-		x = -cos(pi * (x - 1.5))
+		x = -cos(math.pi * (x - 1.5))
 	} else {
-		x = sin(pi * (x - 2))
+		x = sin(math.pi * (x - 2))
 	}
 	return -x
 }

--- a/vlib/math/hypot.v
+++ b/vlib/math/hypot.v
@@ -15,7 +15,7 @@ pub fn hypot(x f64, y f64) f64 {
 		cmin, cmax := minmax(abs_x, abs_y)
 		rat := cmin / cmax
 		root_term := sqrt(1.0 + rat * rat)
-		if cmax < max_f64 / root_term {
+		if cmax < math.max_f64 / root_term {
 			result = cmax * root_term
 		} else {
 			panic('overflow in hypot_e function')

--- a/vlib/math/invhyp.v
+++ b/vlib/math/invhyp.v
@@ -7,7 +7,7 @@ pub fn acosh(x f64) f64 {
 	if x == 0.0 {
 		return 0.0
 	} else if x > 1.0 / internal.sqrt_f64_epsilon {
-		return log(x) + pi * 2
+		return log(x) + math.pi * 2
 	} else if x > 2.0 {
 		return log(2.0 * x - 1.0 / (sqrt(x * x - 1.0) + x))
 	} else if x > 1.0 {
@@ -25,7 +25,7 @@ pub fn asinh(x f64) f64 {
 	a := abs(x)
 	s := if x < 0 { -1.0 } else { 1.0 }
 	if a > 1.0 / internal.sqrt_f64_epsilon {
-		return s * (log(a) + pi * 2.0)
+		return s * (log(a) + math.pi * 2.0)
 	} else if a > 2.0 {
 		return s * log(2.0 * a + 1.0 / (a + sqrt(a * a + 1.0)))
 	} else if a > internal.sqrt_f64_epsilon {

--- a/vlib/math/invtrig.v
+++ b/vlib/math/invtrig.v
@@ -76,9 +76,9 @@ fn satan(x f64) f64 {
 		return xatan(x)
 	}
 	if x > math.tan3pio8 {
-		return pi / 2.0 - xatan(1.0 / x) + f64(math.morebits)
+		return math.pi / 2.0 - xatan(1.0 / x) + f64(math.morebits)
 	}
-	return pi / 4 + xatan((x - 1.0) / (x + 1.0)) + 0.5 * f64(math.morebits)
+	return math.pi / 4 + xatan((x - 1.0) / (x + 1.0)) + 0.5 * f64(math.morebits)
 }
 
 // atan returns the arctangent, in radians, of x.
@@ -127,33 +127,33 @@ pub fn atan2(y f64, x f64) f64 {
 		if x >= 0 && !signbit(x) {
 			return copysign(0, y)
 		}
-		return copysign(pi, y)
+		return copysign(math.pi, y)
 	}
 	if x == 0.0 {
-		return copysign(pi / 2.0, y)
+		return copysign(math.pi / 2.0, y)
 	}
 	if is_inf(x, 0) {
 		if is_inf(x, 1) {
 			if is_inf(y, 0) {
-				return copysign(pi / 4, y)
+				return copysign(math.pi / 4, y)
 			}
 			return copysign(0, y)
 		}
 		if is_inf(y, 0) {
-			return copysign(3.0 * pi / 4.0, y)
+			return copysign(3.0 * math.pi / 4.0, y)
 		}
-		return copysign(pi, y)
+		return copysign(math.pi, y)
 	}
 	if is_inf(y, 0) {
-		return copysign(pi / 2.0, y)
+		return copysign(math.pi / 2.0, y)
 	}
 	// Call atan and determine the quadrant.
 	q := atan(y / x)
 	if x < 0 {
 		if q <= 0 {
-			return q + pi
+			return q + math.pi
 		}
-		return q - pi
+		return q - math.pi
 	}
 	return q
 }
@@ -185,7 +185,7 @@ pub fn asin(x_ f64) f64 {
 	}
 	mut temp := sqrt(1.0 - x * x)
 	if x > 0.7 {
-		temp = pi / 2.0 - satan(temp / x)
+		temp = math.pi / 2.0 - satan(temp / x)
 	} else {
 		temp = satan(x / temp)
 	}
@@ -207,8 +207,8 @@ pub fn acos(x f64) f64 {
 	if x > 0.5 {
 		return f64(2.0) * asin(sqrt(0.5 - 0.5 * x))
 	}
-	mut z := pi / f64(4.0) - asin(x)
+	mut z := math.pi / f64(4.0) - asin(x)
 	z = z + math.morebits
-	z = z + pi / f64(4.0)
+	z = z + math.pi / f64(4.0)
 	return z
 }

--- a/vlib/math/limit.v
+++ b/vlib/math/limit.v
@@ -7,34 +7,34 @@ module math
 @[inline]
 pub fn maxof[T]() T {
 	$if T is i8 {
-		return max_i8
+		return math.max_i8
 	} $else $if T is i16 {
-		return max_i16
+		return math.max_i16
 	} $else $if T is i32 {
-		return max_i32
+		return math.max_i32
 	} $else $if T is i32 {
-		return max_i32
+		return math.max_i32
 	} $else $if T is i64 {
-		return max_i64
+		return math.max_i64
 	} $else $if T is u8 {
-		return max_u8
+		return math.max_u8
 	} $else $if T is byte {
-		return max_u8
+		return math.max_u8
 	} $else $if T is u16 {
-		return max_u16
+		return math.max_u16
 	} $else $if T is u32 {
-		return max_u32
+		return math.max_u32
 	} $else $if T is u64 {
-		return max_u64
+		return math.max_u64
 	} $else $if T is f32 {
-		return max_f32
+		return math.max_f32
 	} $else $if T is f64 {
-		return max_f64
+		return math.max_f64
 	} $else $if T is int {
 		$if new_int ? {
-			return int(max_i64)
+			return int(math.max_i64)
 		}
-		return int(max_i32)
+		return int(math.max_i32)
 	} $else {
 		panic('A maximum value of the type `${typeof[T]().name}` is not defined.')
 	}
@@ -44,34 +44,34 @@ pub fn maxof[T]() T {
 @[inline]
 pub fn minof[T]() T {
 	$if T is i8 {
-		return min_i8
+		return math.min_i8
 	} $else $if T is i16 {
-		return min_i16
+		return math.min_i16
 	} $else $if T is i32 {
-		return min_i32
+		return math.min_i32
 	} $else $if T is i32 {
-		return min_i32
+		return math.min_i32
 	} $else $if T is i64 {
-		return min_i64
+		return math.min_i64
 	} $else $if T is u8 {
-		return min_u8
+		return math.min_u8
 	} $else $if T is byte {
-		return min_u8
+		return math.min_u8
 	} $else $if T is u16 {
-		return min_u16
+		return math.min_u16
 	} $else $if T is u32 {
-		return min_u32
+		return math.min_u32
 	} $else $if T is u64 {
-		return min_u64
+		return math.min_u64
 	} $else $if T is f32 {
-		return -max_f32
+		return -math.max_f32
 	} $else $if T is f64 {
-		return -max_f64
+		return -math.max_f64
 	} $else $if T is int {
 		$if new_int ? {
-			return int(min_i64)
+			return int(math.min_i64)
 		}
-		return int(min_i32)
+		return int(math.min_i32)
 	} $else {
 		panic('A minimum value of the type `${typeof[T]().name}` is not defined.')
 	}

--- a/vlib/math/log.v
+++ b/vlib/math/log.v
@@ -10,7 +10,7 @@ pub fn log_n(x f64, b f64) f64 {
 // log10 returns the decimal logarithm of x.
 // The special cases are the same as for log.
 pub fn log10(x f64) f64 {
-	return log(x) * (1.0 / ln10)
+	return log(x) * (1.0 / math.ln10)
 }
 
 // log2 returns the binary logarithm of x.
@@ -22,7 +22,7 @@ pub fn log2(x f64) f64 {
 	if frac == 0.5 {
 		return f64(exp - 1)
 	}
-	return log(frac) * (1.0 / ln2) + f64(exp)
+	return log(frac) * (1.0 / math.ln2) + f64(exp)
 }
 
 // log1p returns log(1+x)
@@ -59,13 +59,13 @@ pub fn log_b(x f64) f64 {
 // ilog_b(nan) = max_i32
 pub fn ilog_b(x f64) int {
 	if x == 0 {
-		return int(min_i32)
+		return int(math.min_i32)
 	}
 	if is_nan(x) {
-		return int(max_i32)
+		return int(math.max_i32)
 	}
 	if is_inf(x, 0) {
-		return int(max_i32)
+		return int(math.max_i32)
 	}
 	return ilog_b_(x)
 }
@@ -74,7 +74,7 @@ pub fn ilog_b(x f64) int {
 // non-zero.
 fn ilog_b_(x_ f64) int {
 	x, exp := normalize(x_)
-	return int((f64_bits(x) >> shift) & mask) - bias + exp
+	return int((f64_bits(x) >> math.shift) & math.mask) - math.bias + exp
 }
 
 // log returns the natural logarithm of x
@@ -140,7 +140,7 @@ pub fn log(a f64) f64 {
 	}
 
 	mut f1, mut ki := frexp(x)
-	if f1 < sqrt2 / 2 {
+	if f1 < math.sqrt2 / 2 {
 		f1 *= 2
 		ki--
 	}

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -33,21 +33,21 @@ pub fn aprox_cos(a f64) f64 {
 // copysign returns a value with the magnitude of x and the sign of y
 @[inline]
 pub fn copysign(x f64, y f64) f64 {
-	return f64_from_bits((f64_bits(x) & ~sign_mask) | (f64_bits(y) & sign_mask))
+	return f64_from_bits((f64_bits(x) & ~math.sign_mask) | (f64_bits(y) & math.sign_mask))
 }
 
 // degrees converts an angle in radians to a corresponding angle in degrees.
 @[inline]
 pub fn degrees(radians f64) f64 {
-	return radians * (180.0 / pi)
+	return radians * (180.0 / math.pi)
 }
 
 // angle_diff calculates the difference between angles in radians
 @[inline]
 pub fn angle_diff(radian_a f64, radian_b f64) f64 {
-	mut delta := fmod(radian_b - radian_a, tau)
-	delta = fmod(delta + 1.5 * tau, tau)
-	delta -= .5 * tau
+	mut delta := fmod(radian_b - radian_a, math.tau)
+	delta = fmod(delta + 1.5 * math.tau, math.tau)
+	delta -= .5 * math.tau
 	return delta
 }
 
@@ -157,13 +157,13 @@ pub fn signi(n f64) int {
 // radians converts an angle in degrees to a corresponding angle in radians.
 @[inline]
 pub fn radians(degrees f64) f64 {
-	return degrees * (pi / 180.0)
+	return degrees * (math.pi / 180.0)
 }
 
 // signbit returns a value with the boolean representation of the sign for x
 @[inline]
 pub fn signbit(x f64) bool {
-	return f64_bits(x) & sign_mask != 0
+	return f64_bits(x) & math.sign_mask != 0
 }
 
 // tolerance checks if a and b difference are less than or equal to the tolerance value

--- a/vlib/math/math_test.v
+++ b/vlib/math/math_test.v
@@ -203,9 +203,9 @@ fn test_nan() {
 
 fn test_angle_diff() {
 	for pair in [
-		[pi, pi_2, -pi_2],
-		[pi_2 * 3.0, pi_2, -pi],
-		[pi / 6.0, two_thirds * pi, pi_2],
+		[math.pi, math.pi_2, -math.pi_2],
+		[math.pi_2 * 3.0, math.pi_2, -math.pi],
+		[math.pi / 6.0, math.two_thirds * math.pi, math.pi_2],
 	] {
 		assert angle_diff(pair[0], pair[1]) == pair[2]
 	}
@@ -217,7 +217,7 @@ fn test_acos() {
 		f := acos(a)
 		assert soclose(math.acos_[i], f, 1e-7)
 	}
-	vfacos_sc_ := [-pi, 1, pi, nan()]
+	vfacos_sc_ := [-math.pi, 1, math.pi, nan()]
 	acos_sc_ := [nan(), 0, nan(), nan()]
 	for i := 0; i < vfacos_sc_.len; i++ {
 		f := acos(vfacos_sc_[i])
@@ -245,7 +245,7 @@ fn test_asin() {
 		f := asin(a)
 		assert veryclose(math.asin_[i], f)
 	}
-	vfasin_sc_ := [-pi, copysign(0, -1), 0, pi, nan()]
+	vfasin_sc_ := [-math.pi, copysign(0, -1), 0, math.pi, nan()]
 	asin_sc_ := [nan(), copysign(0, -1), 0, nan(), nan()]
 	for i := 0; i < vfasin_sc_.len; i++ {
 		f := asin(vfasin_sc_[i])
@@ -272,7 +272,7 @@ fn test_atan() {
 		assert veryclose(math.atan_[i], f)
 	}
 	vfatan_sc_ := [inf(-1), copysign(0, -1), 0, inf(1), nan()]
-	atan_sc_ := [f64(-pi / 2), copysign(0, -1), 0, pi / 2, nan()]
+	atan_sc_ := [f64(-math.pi / 2), copysign(0, -1), 0, math.pi / 2, nan()]
 	for i := 0; i < vfatan_sc_.len; i++ {
 		f := atan(vfatan_sc_[i])
 		assert alike(atan_sc_[i], f)
@@ -285,7 +285,7 @@ fn test_atanh() {
 		f := atanh(a)
 		assert veryclose(math.atanh_[i], f)
 	}
-	vfatanh_sc_ := [inf(-1), -pi, -1, copysign(0, -1), 0, 1, pi, inf(1),
+	vfatanh_sc_ := [inf(-1), -math.pi, -1, copysign(0, -1), 0, 1, math.pi, inf(1),
 		nan()]
 	atanh_sc_ := [nan(), nan(), inf(-1), copysign(0, -1), 0, inf(1),
 		nan(), nan(), nan()]
@@ -300,49 +300,53 @@ fn test_atan2() {
 		f := atan2(10, math.vf_[i])
 		assert veryclose(math.atan2_[i], f)
 	}
-	vfatan2_sc_ := [[inf(-1), inf(-1)], [inf(-1), -pi], [inf(-1), 0],
-		[inf(-1), pi], [inf(-1), inf(1)], [inf(-1), nan()], [-pi, inf(-1)],
-		[-pi, 0], [-pi, inf(1)], [-pi, nan()], [f64(-0.0), inf(-1)],
-		[f64(-0.0), -pi], [f64(-0.0), -0.0], [f64(-0.0), 0], [f64(-0.0), pi],
+	vfatan2_sc_ := [[inf(-1), inf(-1)], [inf(-1), -math.pi], [
+		inf(-1), 0],
+		[inf(-1), math.pi], [inf(-1), inf(1)], [inf(-1), nan()],
+		[-math.pi, inf(-1)], [-math.pi, 0], [-math.pi, inf(1)],
+		[-math.pi, nan()], [f64(-0.0), inf(-1)], [f64(-0.0), -math.pi],
+		[f64(-0.0), -0.0], [f64(-0.0), 0], [f64(-0.0), math.pi],
 		[f64(-0.0), inf(1)], [f64(-0.0), nan()], [f64(0), inf(-1)],
-		[f64(0), -pi], [f64(0), -0.0], [f64(0), 0], [f64(0), pi],
-		[f64(0), inf(1)], [f64(0), nan()], [pi, inf(-1)], [pi, 0],
-		[pi, inf(1)], [pi, nan()], [inf(1), inf(-1)], [inf(1), -pi],
-		[inf(1), 0], [inf(1), pi], [inf(1), inf(1)], [inf(1), nan()],
-		[nan(), nan()]]
-	atan2_sc_ := [f64(-3.0) * pi / 4.0, // atan2(-inf, -inf)
-	 	-pi / 2, // atan2(-inf, -pi)
-	 	-pi / 2, // atan2(-inf, +0)
-	 	-pi / 2, // atan2(-inf, pi)
-	 	-pi / 4, // atan2(-inf, +inf)
+		[f64(0), -math.pi], [f64(0), -0.0], [f64(0), 0], [f64(0), math.pi],
+		[f64(0), inf(1)], [f64(0), nan()], [math.pi, inf(-1)],
+		[math.pi, 0], [math.pi, inf(1)], [math.pi, nan()], [inf(1),
+			inf(-1)],
+		[inf(1), -math.pi], [inf(1), 0], [inf(1), math.pi], [inf(1),
+			inf(1)],
+		[inf(1), nan()], [nan(), nan()]]
+	atan2_sc_ := [f64(-3.0) * math.pi / 4.0, // atan2(-inf, -inf)
+	 	-math.pi / 2, // atan2(-inf, -pi)
+	 	-math.pi / 2, // atan2(-inf, +0)
+	 	-math.pi / 2, // atan2(-inf, pi)
+	 	-math.pi / 4, // atan2(-inf, +inf)
 	 	nan(), // atan2(-inf, nan)
-	 	-pi, // atan2(-pi, -inf)
-	 	-pi / 2, // atan2(-pi, +0)
+	 	-math.pi, // atan2(-pi, -inf)
+	 	-math.pi / 2, // atan2(-pi, +0)
 	 	-0.0, // atan2(-pi, inf)
 	 	nan(), // atan2(-pi, nan)
-	 	-pi, // atan2(-0, -inf)
-	 	-pi, // atan2(-0, -pi)
-	 	-pi, // atan2(-0, -0)
+	 	-math.pi, // atan2(-0, -inf)
+	 	-math.pi, // atan2(-0, -pi)
+	 	-math.pi, // atan2(-0, -0)
 	 	-0.0, // atan2(-0, +0)
 	 	-0.0, // atan2(-0, pi)
 	 	-0.0, // atan2(-0, +inf)
 	 	nan(), // atan2(-0, nan)
-	 	pi, // atan2(+0, -inf)
-	 	pi, // atan2(+0, -pi)
-	 	pi, // atan2(+0, -0)
+	 	math.pi, // atan2(+0, -inf)
+	 	math.pi, // atan2(+0, -pi)
+	 	math.pi, // atan2(+0, -0)
 	 	0, // atan2(+0, +0)
 	 	0, // atan2(+0, pi)
 	 	0, // atan2(+0, +inf)
 	 	nan(), // atan2(+0, nan)
-	 	pi, // atan2(pi, -inf)
-	 	pi / 2, // atan2(pi, +0)
+	 	math.pi, // atan2(pi, -inf)
+	 	math.pi / 2, // atan2(pi, +0)
 	 	0, // atan2(pi, +inf)
 	 	nan(), // atan2(pi, nan)
-	 	3.0 * pi / 4, // atan2(+inf, -inf)
-	 	pi / 2, // atan2(+inf, -pi)
-	 	pi / 2, // atan2(+inf, +0)
-	 	pi / 2, // atan2(+inf, pi)
-	 	pi / 4, // atan2(+inf, +inf)
+	 	3.0 * math.pi / 4, // atan2(+inf, -inf)
+	 	math.pi / 2, // atan2(+inf, -pi)
+	 	math.pi / 2, // atan2(+inf, +0)
+	 	math.pi / 2, // atan2(+inf, pi)
+	 	math.pi / 4, // atan2(+inf, +inf)
 	 	nan(), // atan2(+inf, nan)
 	 	nan(), // atan2(nan, nan)
 	]
@@ -469,7 +473,7 @@ fn test_signi() {
 	assert signi(inf(-1)) == -1
 	assert signi(-72234878292.4586129) == -1
 	assert signi(-10) == -1
-	assert signi(-pi) == -1
+	assert signi(-math.pi) == -1
 	assert signi(-1) == -1
 	assert signi(-0.000000000001) == -1
 	assert signi(-0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001) == -1
@@ -478,7 +482,7 @@ fn test_signi() {
 	assert signi(inf(1)) == 1
 	assert signi(72234878292.4586129) == 1
 	assert signi(10) == 1
-	assert signi(pi) == 1
+	assert signi(math.pi) == 1
 	assert signi(1) == 1
 	assert signi(0.000000000001) == 1
 	assert signi(0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001) == 1
@@ -490,7 +494,7 @@ fn test_sign() {
 	assert sign(inf(-1)) == -1.0
 	assert sign(-72234878292.4586129) == -1.0
 	assert sign(-10) == -1.0
-	assert sign(-pi) == -1.0
+	assert sign(-math.pi) == -1.0
 	assert sign(-1) == -1.0
 	assert sign(-0.000000000001) == -1.0
 	assert sign(-0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001) == -1.0
@@ -499,7 +503,7 @@ fn test_sign() {
 	assert sign(inf(1)) == 1.0
 	assert sign(72234878292.4586129) == 1
 	assert sign(10) == 1.0
-	assert sign(pi) == 1.0
+	assert sign(math.pi) == 1.0
 	assert sign(1) == 1.0
 	assert sign(0.000000000001) == 1.0
 	assert sign(0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001) == 1.0
@@ -714,11 +718,11 @@ fn test_log() {
 		f := log(a)
 		assert math.log_[i] == f
 	}
-	vflog_sc_ := [inf(-1), -pi, copysign(0, -1), 0, 1, inf(1),
+	vflog_sc_ := [inf(-1), -math.pi, copysign(0, -1), 0, 1, inf(1),
 		nan()]
 	log_sc_ := [nan(), nan(), inf(-1), inf(-1), 0, inf(1), nan()]
 	f := log(10)
-	assert f == ln10
+	assert f == math.ln10
 	for i := 0; i < vflog_sc_.len; i++ {
 		g := log(vflog_sc_[i])
 		assert alike(log_sc_[i], g)
@@ -731,7 +735,7 @@ fn test_log10() {
 		f := log10(a)
 		assert veryclose(math.log10_[i], f)
 	}
-	vflog_sc_ := [inf(-1), -pi, copysign(0, -1), 0, 1, inf(1),
+	vflog_sc_ := [inf(-1), -math.pi, copysign(0, -1), 0, 1, inf(1),
 		nan()]
 	log_sc_ := [nan(), nan(), inf(-1), inf(-1), 0, inf(1), nan()]
 	for i := 0; i < vflog_sc_.len; i++ {
@@ -745,25 +749,27 @@ fn test_pow() {
 		f := pow(10, math.vf_[i])
 		assert close(math.pow_[i], f)
 	}
-	vfpow_sc_ := [[inf(-1), -pi], [inf(-1), -3], [inf(-1), -0.0],
-		[inf(-1), 0], [inf(-1), 1], [inf(-1), 3], [inf(-1), pi],
-		[inf(-1), 0.5], [inf(-1), nan()], [-pi, inf(-1)], [-pi, -pi],
-		[-pi, -0.0], [-pi, 0], [-pi, 1], [-pi, pi], [-pi, inf(1)],
-		[-pi, nan()], [f64(-1), inf(-1)], [f64(-1), inf(1)], [f64(-1), nan()],
-		[f64(-1 / 2), inf(-1)], [f64(-1 / 2), inf(1)], [f64(-0.0), inf(-1)],
-		[f64(-0.0), -pi], [f64(-0.0), -0.5], [f64(-0.0), -3],
-		[f64(-0.0), 3], [f64(-0.0), pi], [f64(-0.0), 0.5], [f64(-0.0), inf(1)],
-		[f64(0), inf(-1)], [f64(0), -pi], [f64(0), -3], [f64(0), -0.0],
-		[f64(0), 0], [f64(0), 3], [f64(0), pi], [f64(0), inf(1)],
-		[f64(0), nan()], [f64(1 / 2), inf(-1)], [f64(1 / 2), inf(1)],
-		[f64(1), inf(-1)], [f64(1), inf(1)], [f64(1), nan()],
-		[pi, inf(-1)], [pi, -0.0], [pi, 0], [pi, 1], [pi, inf(1)],
-		[pi, nan()], [inf(1), -pi], [inf(1), -0.0], [inf(1), 0],
-		[inf(1), 1], [inf(1), pi], [inf(1), nan()], [nan(), -pi],
-		[nan(), -0.0], [nan(), 0], [nan(), 1], [nan(), pi], [nan(),
-			nan()],
-		[5.0, 2.0], [5.0, 3.0], [5.0, 10.0], [5.0, -2.0], [-5.0, -1.0],
-		[-5.0, -2.0], [-5.0, -3.0]]
+	vfpow_sc_ := [[inf(-1), -math.pi], [inf(-1), -3], [inf(-1), -0.0],
+		[inf(-1), 0], [inf(-1), 1], [inf(-1), 3], [inf(-1), math.pi],
+		[inf(-1), 0.5], [inf(-1), nan()], [-math.pi, inf(-1)],
+		[-math.pi, -math.pi], [-math.pi, -0.0], [-math.pi, 0],
+		[-math.pi, 1], [-math.pi, math.pi], [-math.pi, inf(1)],
+		[-math.pi, nan()], [f64(-1), inf(-1)], [f64(-1), inf(1)],
+		[f64(-1), nan()], [f64(-1 / 2), inf(-1)], [f64(-1 / 2), inf(1)],
+		[f64(-0.0), inf(-1)], [f64(-0.0), -math.pi], [f64(-0.0), -0.5],
+		[f64(-0.0), -3], [f64(-0.0), 3], [f64(-0.0), math.pi],
+		[f64(-0.0), 0.5], [f64(-0.0), inf(1)], [f64(0), inf(-1)],
+		[f64(0), -math.pi], [f64(0), -3], [f64(0), -0.0], [f64(0), 0],
+		[f64(0), 3], [f64(0), math.pi], [f64(0), inf(1)], [f64(0), nan()],
+		[f64(1 / 2), inf(-1)], [f64(1 / 2), inf(1)], [f64(1), inf(-1)],
+		[f64(1), inf(1)], [f64(1), nan()], [math.pi, inf(-1)],
+		[math.pi, -0.0], [math.pi, 0], [math.pi, 1], [math.pi, inf(1)],
+		[math.pi, nan()], [inf(1), -math.pi], [inf(1), -0.0],
+		[inf(1), 0], [inf(1), 1], [inf(1), math.pi], [inf(1), nan()],
+		[nan(), -math.pi], [nan(), -0.0], [nan(), 0], [nan(), 1],
+		[nan(), math.pi], [nan(), nan()], [5.0, 2.0], [5.0, 3.0],
+		[5.0, 10.0], [5.0, -2.0], [-5.0, -1.0], [-5.0, -2.0],
+		[-5.0, -3.0]]
 	pow_sc_ := [f64(0), // pow(-inf, -pi)
 	 	-0.0, // pow(-inf, -3)
 	 	1, // pow(-inf, -0)
@@ -777,7 +783,7 @@ fn test_pow() {
 	 	nan(), // pow(-pi, -pi)
 	 	1, // pow(-pi, -0)
 	 	1, // pow(-pi, +0)
-	 	-pi, // pow(-pi, 1)
+	 	-math.pi, // pow(-pi, 1)
 	 	nan(), // pow(-pi, pi)
 	 	inf(1), // pow(-pi, +inf)
 	 	nan(), // pow(-pi, nan)
@@ -811,7 +817,7 @@ fn test_pow() {
 	 	0, // pow(pi, -inf)
 	 	1, // pow(pi, -0)
 	 	1, // pow(pi, +0)
-	 	pi, // pow(pi, 1)
+	 	math.pi, // pow(pi, 1)
 	 	inf(1), // pow(pi, +inf)
 	 	nan(), // pow(pi, nan)
 	 	0, // pow(+inf, -pi)
@@ -929,7 +935,8 @@ fn test_sqrt() {
 		f = sqrt(a)
 		assert veryclose(math.sqrt_[i], f)
 	}
-	vfsqrt_sc_ := [inf(-1), -pi, copysign(0, -1), 0, inf(1), nan()]
+	vfsqrt_sc_ := [inf(-1), -math.pi, copysign(0, -1), 0, inf(1),
+		nan()]
 	sqrt_sc_ := [nan(), nan(), copysign(0, -1), 0, inf(1), nan()]
 	for i := 0; i < vfsqrt_sc_.len; i++ {
 		mut f := sqrt(vfsqrt_sc_[i])
@@ -1048,7 +1055,7 @@ fn test_digits() {
 // testing for Trig(vf_[i] + large) == Trig(vf_[i]), where large is
 // a multiple of 2 * pi, is misleading.]
 fn test_large_cos() {
-	large := 100000.0 * pi
+	large := 100000.0 * math.pi
 	for i := 0; i < math.vf_.len; i++ {
 		f1 := math.cos_large_[i]
 		f2 := cos(math.vf_[i] + large)
@@ -1057,7 +1064,7 @@ fn test_large_cos() {
 }
 
 fn test_large_sin() {
-	large := 100000.0 * pi
+	large := 100000.0 * math.pi
 	for i := 0; i < math.vf_.len; i++ {
 		f1 := math.sin_large_[i]
 		f2 := sin(math.vf_[i] + large)
@@ -1066,7 +1073,7 @@ fn test_large_sin() {
 }
 
 fn test_large_tan() {
-	large := 100000.0 * pi
+	large := 100000.0 * math.pi
 	for i := 0; i < math.vf_.len; i++ {
 		f1 := math.tan_large_[i]
 		f2 := tan(math.vf_[i] + large)
@@ -1105,14 +1112,14 @@ fn test_count_digits() {
 }
 
 fn test_min_max_int_str() {
-	assert min_i64.str() == '-9223372036854775808'
-	assert max_i64.str() == '9223372036854775807'
-	assert min_i32.str() == '-2147483648'
-	assert max_i32.str() == '2147483647'
-	assert min_i16.str() == '-32768'
-	assert max_i16.str() == '32767'
-	assert min_i8.str() == '-128'
-	assert max_i8.str() == '127'
+	assert math.min_i64.str() == '-9223372036854775808'
+	assert math.max_i64.str() == '9223372036854775807'
+	assert math.min_i32.str() == '-2147483648'
+	assert math.max_i32.str() == '2147483647'
+	assert math.min_i16.str() == '-32768'
+	assert math.max_i16.str() == '32767'
+	assert math.min_i8.str() == '-128'
+	assert math.max_i8.str() == '127'
 }
 
 fn test_maxof_minof() {

--- a/vlib/math/sin.v
+++ b/vlib/math/sin.v
@@ -54,7 +54,7 @@ pub fn sin(x f64) f64 {
 		return x * (1.0 - x2 / 6.0)
 	} else {
 		mut sgn_result := sgn_x
-		mut y := floor(abs_x / (0.25 * pi))
+		mut y := floor(abs_x / (0.25 * math.pi))
 		mut octant := int(y - ldexp(floor(ldexp(y, -3)), 3))
 		if (octant & 1) == 1 {
 			octant++
@@ -68,11 +68,11 @@ pub fn sin(x f64) f64 {
 		z := ((abs_x - y * p1) - y * p2) - y * p3
 		mut result := 0.0
 		if octant == 0 {
-			t := 8.0 * abs(z) / pi - 1.0
+			t := 8.0 * abs(z) / math.pi - 1.0
 			sin_cs_val, _ := math.sin_cs.eval_e(t)
 			result = z * (1.0 + z * z * sin_cs_val)
 		} else {
-			t := 8.0 * abs(z) / pi - 1.0
+			t := 8.0 * abs(z) / math.pi - 1.0
 			cos_cs_val, _ := math.cos_cs.eval_e(t)
 			result = 1.0 - 0.5 * z * z * (1.0 - z * z * cos_cs_val)
 		}
@@ -92,7 +92,7 @@ pub fn cos(x f64) f64 {
 		return 1.0 - 0.5 * x2
 	} else {
 		mut sgn_result := 1
-		mut y := floor(abs_x / (0.25 * pi))
+		mut y := floor(abs_x / (0.25 * math.pi))
 		mut octant := int(y - ldexp(floor(ldexp(y, -3)), 3))
 		if (octant & 1) == 1 {
 			octant++
@@ -109,11 +109,11 @@ pub fn cos(x f64) f64 {
 		z := ((abs_x - y * p1) - y * p2) - y * p3
 		mut result := 0.0
 		if octant == 0 {
-			t := 8.0 * abs(z) / pi - 1.0
+			t := 8.0 * abs(z) / math.pi - 1.0
 			cos_cs_val, _ := math.cos_cs.eval_e(t)
 			result = 1.0 - 0.5 * z * z * (1.0 - z * z * cos_cs_val)
 		} else {
-			t := 8.0 * abs(z) / pi - 1.0
+			t := 8.0 * abs(z) / math.pi - 1.0
 			sin_cs_val, _ := math.sin_cs.eval_e(t)
 			result = z * (1.0 + z * z * sin_cs_val)
 		}
@@ -153,7 +153,7 @@ pub fn sincos(x f64) (f64, f64) {
 	} else {
 		mut sgn_result_sin := sgn_x
 		mut sgn_result_cos := 1
-		mut y := floor(abs_x / (0.25 * pi))
+		mut y := floor(abs_x / (0.25 * math.pi))
 		mut octant := int(y - ldexp(floor(ldexp(y, -3)), 3))
 		if (octant & 1) == 1 {
 			octant++
@@ -167,7 +167,7 @@ pub fn sincos(x f64) (f64, f64) {
 		}
 		sgn_result_cos = if octant > 1 { -sgn_result_cos } else { sgn_result_cos }
 		z := ((abs_x - y * p1) - y * p2) - y * p3
-		t := 8.0 * abs(z) / pi - 1.0
+		t := 8.0 * abs(z) / math.pi - 1.0
 		sin_cs_val, _ := math.sin_cs.eval_e(t)
 		cos_cs_val, _ := math.cos_cs.eval_e(t)
 		mut result_sin := 0.0

--- a/vlib/math/sqrt.v
+++ b/vlib/math/sqrt.v
@@ -20,7 +20,7 @@ pub fn sqrt(a f64) f64 {
 	// relative error of approximation = 7.47e-3
 	x = 4.173075996388649989089e-1 + 5.9016206709064458299663e-1 * z // adjust for odd powers of 2
 	if (ex & 1) != 0 {
-		x *= sqrt2
+		x *= math.sqrt2
 	}
 	x = ldexp(x, ex >> 1)
 	// newton iterations

--- a/vlib/math/tan.v
+++ b/vlib/math/tan.v
@@ -35,7 +35,7 @@ pub fn tan(a f64) f64 {
 		return 0.0
 	}
 	// compute x mod pi_4
-	mut y := floor(x * 4.0 / pi) // strip high bits of integer part
+	mut y := floor(x * 4.0 / math.pi) // strip high bits of integer part
 	mut z := ldexp(y, -3)
 	z = floor(z) // integer part of y/8
 	z = y - ldexp(z, 3) // y - 16 * (y/16) // integer and fractional part modulo one octant
@@ -82,7 +82,7 @@ pub fn cot(a f64) f64 {
 		return 0.0
 	}
 	// compute x mod pi_4
-	mut y := floor(x * 4.0 / pi) // strip high bits of integer part
+	mut y := floor(x * 4.0 / math.pi) // strip high bits of integer part
 	mut z := ldexp(y, -3)
 	z = floor(z) // integer part of y/8
 	z = y - ldexp(z, 3) // y - 16 * (y/16) // integer and fractional part modulo one octant

--- a/vlib/math/unsigned/uint256.v
+++ b/vlib/math/unsigned/uint256.v
@@ -8,13 +8,13 @@ pub const uint256_max = Uint256{uint128_max, uint128_max}
 // Uint256 is an unsigned 256-bit number
 pub struct Uint256 {
 pub mut:
-	lo Uint128 = uint128_zero // lower 128 bit half
-	hi Uint128 = uint128_zero // upper 128 bit half
+	lo Uint128 = unsigned.uint128_zero // lower 128 bit half
+	hi Uint128 = unsigned.uint128_zero // upper 128 bit half
 }
 
 // uint256_from_128 creates a new `unsigned.Uint256` from the given Uint128 value
 pub fn uint256_from_128(v Uint128) Uint256 {
-	return Uint256{v, uint128_zero}
+	return Uint256{v, unsigned.uint128_zero}
 }
 
 // uint256_from_64 creates a new `unsigned.Uint256` from the given u64 value
@@ -66,7 +66,7 @@ pub fn (u Uint256) and(v Uint256) Uint256 {
 
 // and_128 returns a Uint256 value that is the bitwise and of u and v, which is a Uint128
 pub fn (u Uint256) and_128(v Uint128) Uint256 {
-	return Uint256{u.lo.and(v), uint128_zero}
+	return Uint256{u.lo.and(v), unsigned.uint128_zero}
 }
 
 // or_ returns a Uint256 value that is the bitwise or of u and v
@@ -205,10 +205,10 @@ pub fn (u Uint256) quo_rem(v Uint256) (Uint256, Uint256) {
 pub fn (u Uint256) quo_rem_128(v Uint128) (Uint256, Uint128) {
 	if u.hi.cmp(v) < 0 {
 		lo, r := div_128(u.hi, u.lo, v)
-		return Uint256{lo, uint128_zero}, r
+		return Uint256{lo, unsigned.uint128_zero}, r
 	}
 
-	hi, r := div_128(uint128_zero, u.hi, v)
+	hi, r := div_128(unsigned.uint128_zero, u.hi, v)
 	lo, r2 := div_128(r, u.lo, v)
 	return Uint256{lo, hi}, r2
 }
@@ -228,7 +228,7 @@ pub fn (u Uint256) quo_rem_64(v u64) (Uint256, u64) {
 pub fn (u Uint256) rsh(n_ u32) Uint256 {
 	mut n := n_
 	if n > 128 {
-		return Uint256{u.hi.rsh(n - 128), uint128_zero}
+		return Uint256{u.hi.rsh(n - 128), unsigned.uint128_zero}
 	}
 
 	if n > 64 {
@@ -242,7 +242,7 @@ pub fn (u Uint256) rsh(n_ u32) Uint256 {
 pub fn (u Uint256) lsh(n_ u32) Uint256 {
 	mut n := n_
 	if n > 128 {
-		return Uint256{u.lo.lsh(n - 128), uint128_zero}
+		return Uint256{u.lo.lsh(n - 128), unsigned.uint128_zero}
 	}
 
 	if n > 64 {

--- a/vlib/math/vec/vec3.v
+++ b/vlib/math/vec/vec3.v
@@ -270,7 +270,7 @@ pub fn (v Vec3[T]) eq(u Vec3[T]) bool {
 
 // eq_epsilon returns a bool indicating if the two vectors are equal within the module `vec_epsilon` const.
 pub fn (v Vec3[T]) eq_epsilon(u Vec3[T]) bool {
-	return v.eq_approx[T, f32](u, vec_epsilon)
+	return v.eq_approx[T, f32](u, vec.vec_epsilon)
 }
 
 // eq_approx returns whether these vectors are approximately equal within `tolerance`.

--- a/vlib/math/vec/vec4.v
+++ b/vlib/math/vec/vec4.v
@@ -289,7 +289,7 @@ pub fn (v Vec4[T]) eq(u Vec4[T]) bool {
 
 // eq_epsilon returns a bool indicating if the two vectors are equal within the module `vec_epsilon` const.
 pub fn (v Vec4[T]) eq_epsilon(u Vec4[T]) bool {
-	return v.eq_approx[T, f32](u, vec_epsilon)
+	return v.eq_approx[T, f32](u, vec.vec_epsilon)
 }
 
 // eq_approx returns whether these vectors are approximately equal within `tolerance`.

--- a/vlib/net/html/dom.v
+++ b/vlib/net/html/dom.v
@@ -109,7 +109,7 @@ fn (mut dom DocumentObjectModel) construct(tag_list []&Tag) {
 	}
 
 	mut temp_map := map[string]int{}
-	mut temp_int := null_element
+	mut temp_int := html.null_element
 	mut temp_string := ''
 	mut stack := Stack{}
 	dom.btree = BTree{}

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -70,11 +70,11 @@ fn test_header_delete() {
 
 fn test_header_delete_not_existing() {
 	mut h := new_header()
-	assert h.data.len == max_headers
+	assert h.data.len == http.max_headers
 	assert h.values(.dnt).len == 0
 	// assert h.keys.len == 0
 	h.delete(.dnt)
-	assert h.data.len == max_headers
+	assert h.data.len == http.max_headers
 	assert h.values(.dnt).len == 0
 	// assert h.keys.len == 0
 }

--- a/vlib/net/http/mime/mime.v
+++ b/vlib/net/http/mime/mime.v
@@ -9,25 +9,25 @@ pub struct MimeType {
 
 // returns a `MimeType` for the given MIME type
 pub fn get_complete_mime_type(mt string) MimeType {
-	return db[mt]
+	return mime.db[mt]
 }
 
 // returns the MIME type for the given file extension
 pub fn get_mime_type(ext string) string {
-	return ext_to_mt_str[ext]
+	return mime.ext_to_mt_str[ext]
 }
 
 // returns a `content-type` header ready to use for the given MIME type
 pub fn get_content_type(mt string) string {
-	mt_struct := db[mt]
+	mt_struct := mime.db[mt]
 	charset := if mt_struct.charset.len > 0 { mt_struct.charset.to_lower() } else { 'utf-8' }
 	return '${mt}; charset=${charset}'
 }
 
 // returns the default extension for the given MIME type
 pub fn get_default_ext(mt string) string {
-	return if db[mt].extensions.len > 0 {
-		db[mt].extensions[0]
+	return if mime.db[mt].extensions.len > 0 {
+		mime.db[mt].extensions[0]
 	} else {
 		''
 	}
@@ -35,5 +35,5 @@ pub fn get_default_ext(mt string) string {
 
 // returns true if the given MIME type exists
 pub fn exists(mt string) bool {
-	return mt in db
+	return mt in mime.db
 }

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -98,8 +98,8 @@ pub fn (req &Request) do() !Response {
 	mut resp := Response{}
 	mut nredirects := 0
 	for {
-		if nredirects == max_redirects {
-			return error('http.request.do: maximum number of redirects reached (${max_redirects})')
+		if nredirects == http.max_redirects {
+			return error('http.request.do: maximum number of redirects reached (${http.max_redirects})')
 		}
 		qresp := req.method_and_url_to_response(req.method, rurl)!
 		resp = qresp
@@ -284,7 +284,7 @@ fn (req &Request) http_do(host string, method Method, path string) !Response {
 type FnReceiveChunk = fn (con voidptr, buf &u8, bufsize int) !int
 
 fn (req &Request) receive_all_data_from_cb_in_builder(mut content strings.Builder, con voidptr, receive_chunk_cb FnReceiveChunk) ! {
-	mut buff := [bufsize]u8{}
+	mut buff := [http.bufsize]u8{}
 	bp := unsafe { &buff[0] }
 	mut readcounter := 0
 	mut body_pos := u64(0)
@@ -294,7 +294,7 @@ fn (req &Request) receive_all_data_from_cb_in_builder(mut content strings.Builde
 	mut status_code := -1
 	for {
 		readcounter++
-		len := receive_chunk_cb(con, bp, bufsize) or { break }
+		len := receive_chunk_cb(con, bp, http.bufsize) or { break }
 		$if debug_http ? {
 			eprintln('ssl_do, read ${readcounter:4d} | len: ${len}')
 			eprintln('-'.repeat(20))

--- a/vlib/net/util.v
+++ b/vlib/net/util.v
@@ -8,7 +8,7 @@ pub fn validate_port(port int) !u16 {
 	if port <= net.socket_max_port {
 		return u16(port)
 	} else {
-		return err_port_out_of_range
+		return net.err_port_out_of_range
 	}
 }
 

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -43,7 +43,7 @@ pub mut:
 	panic_on_callback bool               // set to true of callbacks can panic
 	client_state      shared ClientState // current state of connection
 	// logger used to log messages
-	logger        &log.Logger = default_logger
+	logger        &log.Logger = websocket.default_logger
 	resource_name string // name of current resource
 	last_pong_ut  i64    // last time in unix time we got a pong message
 }
@@ -85,7 +85,7 @@ pub struct ClientOpt {
 pub:
 	read_timeout  i64         = 30 * time.second
 	write_timeout i64         = 30 * time.second
-	logger        &log.Logger = default_logger
+	logger        &log.Logger = websocket.default_logger
 }
 
 // new_client instance a new websocket client
@@ -188,7 +188,7 @@ pub fn (mut ws Client) listen() ! {
 						return error('close payload cannot be 1 byte')
 					}
 					code := u16(msg.payload[0]) << 8 | u16(msg.payload[1])
-					if code in invalid_close_codes {
+					if code in websocket.invalid_close_codes {
 						ws.close(1002, 'invalid close code: ${code}')!
 						return error('invalid close code: ${code}')
 					}

--- a/vlib/net/websocket/websocket_server.v
+++ b/vlib/net/websocket/websocket_server.v
@@ -17,7 +17,7 @@ pub mut:
 // Server represents a websocket server connection
 pub struct Server {
 mut:
-	logger                  &log.Logger      = default_logger
+	logger                  &log.Logger      = websocket.default_logger
 	ls                      &net.TcpListener = unsafe { nil } // listener used to get incoming connection to socket
 	accept_client_callbacks []AcceptClientFn      // accept client callback functions
 	message_callbacks       []MessageEventHandler // new message callback functions
@@ -43,7 +43,7 @@ pub mut:
 @[params]
 pub struct ServerOpt {
 pub:
-	logger &log.Logger = default_logger
+	logger &log.Logger = websocket.default_logger
 }
 
 // new_server instance a new websocket server on provided port and route

--- a/vlib/os/args.v
+++ b/vlib/os/args.v
@@ -6,16 +6,16 @@ module os
 // args_after returns all os.args, located *after* a specified `cut_word`.
 // When `cut_word` is NOT found, os.args is returned unmodified.
 pub fn args_after(cut_word string) []string {
-	if args.len == 0 {
+	if os.args.len == 0 {
 		return []string{}
 	}
 	mut cargs := []string{}
-	if cut_word !in args {
-		cargs = args.clone()
+	if cut_word !in os.args {
+		cargs = os.args.clone()
 	} else {
 		mut found := false
-		cargs << args[0]
-		for a in args[1..] {
+		cargs << os.args[0]
+		for a in os.args[1..] {
 			if a == cut_word {
 				found = true
 				continue
@@ -32,15 +32,15 @@ pub fn args_after(cut_word string) []string {
 // args_before returns all os.args, located *before* a specified `cut_word`.
 // When `cut_word` is NOT found, os.args is returned unmodified.
 pub fn args_before(cut_word string) []string {
-	if args.len == 0 {
+	if os.args.len == 0 {
 		return []string{}
 	}
 	mut cargs := []string{}
-	if cut_word !in args {
-		cargs = args.clone()
+	if cut_word !in os.args {
+		cargs = os.args.clone()
 	} else {
-		cargs << args[0]
-		for a in args[1..] {
+		cargs << os.args[0]
+		for a in os.args[1..] {
 			if a == cut_word {
 				break
 			}

--- a/vlib/os/filepath.v
+++ b/vlib/os/filepath.v
@@ -42,7 +42,7 @@ pub fn abs_path(path string) string {
 	if !is_abs_path(npath) {
 		mut sb := strings.new_builder(npath.len)
 		sb.write_string(wd)
-		sb.write_string(path_separator)
+		sb.write_string(os.path_separator)
 		sb.write_string(npath)
 		return norm_path(sb.str())
 	}
@@ -66,13 +66,13 @@ pub fn norm_path(path string) string {
 	volume_len := win_volume_len(path)
 	mut volume := path[..volume_len]
 	if volume_len != 0 && volume.contains(os.fslash_str) {
-		volume = volume.replace(os.fslash_str, path_separator)
+		volume = volume.replace(os.fslash_str, os.path_separator)
 	}
 	cpath := clean_path(path[volume_len..])
 	if cpath == '' && volume_len == 0 {
 		return os.dot_str
 	}
-	spath := cpath.split(path_separator)
+	spath := cpath.split(os.path_separator)
 	if os.dot_dot !in spath {
 		return if volume_len != 0 { volume + cpath } else { cpath }
 	}
@@ -80,7 +80,7 @@ pub fn norm_path(path string) string {
 	spath_len := spath.len
 	mut sb := strings.new_builder(cpath.len)
 	if rooted {
-		sb.write_string(path_separator)
+		sb.write_string(os.path_separator)
 	}
 	mut new_path := []string{cap: spath_len}
 	mut backlink_count := 0
@@ -107,10 +107,10 @@ pub fn norm_path(path string) string {
 			if new_path.len == 0 && i == backlink_count - 1 {
 				break
 			}
-			sb.write_string(path_separator)
+			sb.write_string(os.path_separator)
 		}
 	}
-	sb.write_string(new_path.join(path_separator))
+	sb.write_string(new_path.join(os.path_separator))
 	res := sb.str()
 	if res.len == 0 {
 		if volume_len != 0 {
@@ -119,7 +119,7 @@ pub fn norm_path(path string) string {
 		if !rooted {
 			return os.dot_str
 		}
-		return path_separator
+		return os.path_separator
 	}
 	if volume_len != 0 {
 		return volume + res
@@ -221,19 +221,19 @@ fn clean_path(path string) string {
 // to_slash returns the result of replacing each separator character
 // in path with a slash (`/`).
 pub fn to_slash(path string) string {
-	if path_separator == '/' {
+	if os.path_separator == '/' {
 		return path
 	}
-	return path.replace(path_separator, '/')
+	return path.replace(os.path_separator, '/')
 }
 
 // from_slash returns the result of replacing each slash (`/`) character
 // is path with a separator character.
 pub fn from_slash(path string) string {
-	if path_separator == '/' {
+	if os.path_separator == '/' {
 		return path
 	}
-	return path.replace('/', path_separator)
+	return path.replace('/', os.path_separator)
 }
 
 // win_volume_len returns the length of the

--- a/vlib/os/filepath_test.v
+++ b/vlib/os/filepath_test.v
@@ -54,7 +54,7 @@ fn test_clean_path() {
 }
 
 fn test_to_slash() {
-	sep := path_separator
+	sep := os.path_separator
 	assert to_slash('') == ''
 	assert to_slash(sep) == ('/')
 	assert to_slash([sep, 'a', sep, 'b'].join('')) == '/a/b'
@@ -62,7 +62,7 @@ fn test_to_slash() {
 }
 
 fn test_from_slash() {
-	sep := path_separator
+	sep := os.path_separator
 	assert from_slash('') == ''
 	assert from_slash('/') == sep
 	assert from_slash('/a/b') == [sep, 'a', sep, 'b'].join('')
@@ -112,7 +112,7 @@ fn test_norm_path() {
 
 fn test_abs_path() {
 	wd := getwd()
-	wd_w_sep := wd + path_separator
+	wd_w_sep := wd + os.path_separator
 	$if windows {
 		assert abs_path('path/to/file.v') == '${wd_w_sep}path\\to\\file.v'
 		assert abs_path('path/to/file.v') == '${wd_w_sep}path\\to\\file.v'

--- a/vlib/os/filepath_windows.v
+++ b/vlib/os/filepath_windows.v
@@ -11,7 +11,7 @@ module os
 pub fn windows_volume(path string) string {
 	volume_len := win_volume_len(path)
 	if volume_len == 0 {
-		return os.empty_str
+		return empty_str
 	}
 	return path[..volume_len]
 }

--- a/vlib/os/filepath_windows.v
+++ b/vlib/os/filepath_windows.v
@@ -11,7 +11,7 @@ module os
 pub fn windows_volume(path string) string {
 	volume_len := win_volume_len(path)
 	if volume_len == 0 {
-		return empty_str
+		return os.empty_str
 	}
 	return path[..volume_len]
 }

--- a/vlib/picoev/picoev_test.v
+++ b/vlib/picoev/picoev_test.v
@@ -4,7 +4,7 @@ fn test_if_all_file_descriptors_are_properly_initialized() {
 	mut pv := &Picoev{}
 	pv.init()
 
-	for i in 0 .. max_fds {
+	for i in 0 .. picoev.max_fds {
 		assert unsafe { pv.file_descriptors[i] } != unsafe { nil }
 		assert unsafe { pv.file_descriptors[i].loop_id } == -1
 		assert unsafe { pv.file_descriptors[i].fd } == 0

--- a/vlib/picohttpparser/picohttpparser.v
+++ b/vlib/picohttpparser/picohttpparser.v
@@ -182,7 +182,7 @@ fn (mut r Request) parse_headers(buf_start &u8, buf_end &u8, mut pret Pret) &u8 
 
 	mut i := 0
 
-	for i = r.num_headers; i < max_headers; i++ {
+	for i = r.num_headers; i < picohttpparser.max_headers; i++ {
 		// CHECK_EOF
 		if buf == buf_end {
 			pret.ret = -2
@@ -277,7 +277,7 @@ fn (mut r Request) parse_headers(buf_start &u8, buf_end &u8, mut pret Pret) &u8 
 		}
 	}
 
-	if i == max_headers {
+	if i == picohttpparser.max_headers {
 		// too many headers
 		eprintln('Too many headers!')
 		pret.ret = -1

--- a/vlib/regex/regex_opt.v
+++ b/vlib/regex/regex_opt.v
@@ -6,7 +6,7 @@ import strings
 pub fn (mut re RE) compile_opt(pattern string) ! {
 	re_err, err_pos := re.impl_compile(pattern)
 
-	if re_err != compile_ok {
+	if re_err != regex.compile_ok {
 		mut err_msg := strings.new_builder(300)
 		err_msg.write_string('\nquery: ${pattern}\n')
 		line := '-'.repeat(err_pos)
@@ -21,11 +21,11 @@ pub fn (mut re RE) compile_opt(pattern string) ! {
 pub fn new() RE {
 	// init regex
 	mut re := RE{}
-	re.prog = []Token{len: max_code_len + 1} // max program length, can not be longer then the pattern
-	re.cc = []CharClass{len: max_code_len} // can not be more char class the length of the pattern
+	re.prog = []Token{len: regex.max_code_len + 1} // max program length, can not be longer then the pattern
+	re.cc = []CharClass{len: regex.max_code_len} // can not be more char class the length of the pattern
 	re.group_csave_flag = false // enable continuos group saving
 	re.group_max_nested = 128 // set max 128 group nested
-	re.group_max = max_code_len >> 1 // we can't have more groups than the half of the pattern legth
+	re.group_max = regex.max_code_len >> 1 // we can't have more groups than the half of the pattern legth
 
 	re.group_stack = []int{len: re.group_max, init: -1}
 	re.group_data = []int{len: re.group_max, init: -1}

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -132,14 +132,14 @@ pub fn (re &RE) match_string(in_txt string) (int, int) {
 		}
 
 		if start >= 0 && end > start {
-			if (re.flag & f_ms) != 0 && start > 0 {
-				return no_match_found, 0
+			if (re.flag & regex.f_ms) != 0 && start > 0 {
+				return regex.no_match_found, 0
 			}
-			if (re.flag & f_me) != 0 && end < in_txt.len {
-				if in_txt[end] in new_line_list {
+			if (re.flag & regex.f_me) != 0 && end < in_txt.len {
+				if in_txt[end] in regex.new_line_list {
 					return start, end
 				}
-				return no_match_found, 0
+				return regex.no_match_found, 0
 			}
 			return start, end
 		}
@@ -150,7 +150,7 @@ pub fn (re &RE) match_string(in_txt string) (int, int) {
 // matches_string Checks if the pattern matches the in_txt string
 pub fn (re &RE) matches_string(in_txt string) bool {
 	start, _ := re.match_string(in_txt)
-	return start != no_match_found
+	return start != regex.no_match_found
 }
 
 /******************************************************************************
@@ -203,11 +203,11 @@ pub fn (mut re RE) find(in_txt string) (int, int) {
 					gi++
 				}
 				// when ^ (f_ms) is used, it must match on beginning of string
-				if (re.flag & f_ms) != 0 && s > 0 {
+				if (re.flag & regex.f_ms) != 0 && s > 0 {
 					break
 				}
 				// when $ (f_me) is used, it must match on ending of string
-				if (re.flag & f_me) != 0 && i + e < in_txt.len {
+				if (re.flag & regex.f_me) != 0 && i + e < in_txt.len {
 					break
 				}
 				return i + s, i + e

--- a/vlib/semver/range.v
+++ b/vlib/semver/range.v
@@ -120,22 +120,22 @@ fn parse_comparator(input string) ?Comparator {
 
 fn parse_xrange(input string) ?Version {
 	mut raw_ver := parse(input).complete()
-	for typ in versions {
+	for typ in semver.versions {
 		if raw_ver.raw_ints[typ].index_any(semver.x_range_symbols) == -1 {
 			continue
 		}
 		match typ {
-			ver_major {
-				raw_ver.raw_ints[ver_major] = '0'
-				raw_ver.raw_ints[ver_minor] = '0'
-				raw_ver.raw_ints[ver_patch] = '0'
+			semver.ver_major {
+				raw_ver.raw_ints[semver.ver_major] = '0'
+				raw_ver.raw_ints[semver.ver_minor] = '0'
+				raw_ver.raw_ints[semver.ver_patch] = '0'
 			}
-			ver_minor {
-				raw_ver.raw_ints[ver_minor] = '0'
-				raw_ver.raw_ints[ver_patch] = '0'
+			semver.ver_minor {
+				raw_ver.raw_ints[semver.ver_minor] = '0'
+				raw_ver.raw_ints[semver.ver_patch] = '0'
 			}
-			ver_patch {
-				raw_ver.raw_ints[ver_patch] = '0'
+			semver.ver_patch {
+				raw_ver.raw_ints[semver.ver_patch] = '0'
 			}
 			else {}
 		}
@@ -187,10 +187,10 @@ fn expand_hyphen(raw_range string) ?ComparatorSet {
 	}
 	min_ver := coerce_version(raw_versions[0]) or { return none }
 	raw_max_ver := parse(raw_versions[1])
-	if raw_max_ver.is_missing(ver_major) {
+	if raw_max_ver.is_missing(semver.ver_major) {
 		return none
 	}
-	if raw_max_ver.is_missing(ver_minor) {
+	if raw_max_ver.is_missing(semver.ver_minor) {
 		max_ver := raw_max_ver.coerce() or { return none }.increment(.minor)
 		return make_comparator_set_ge_lt(min_ver, max_ver)
 	}

--- a/vlib/strconv/utilities.v
+++ b/vlib/strconv/utilities.v
@@ -69,14 +69,14 @@ fn mul_shift_32(m u32, mul u64, ishift int) u32 {
 
 @[direct_array_access; inline]
 fn mul_pow5_invdiv_pow2(m u32, q u32, j int) u32 {
-	assert1(q < pow5_inv_split_32.len, 'q < pow5_inv_split_32.len')
-	return mul_shift_32(m, pow5_inv_split_32[q], j)
+	assert1(q < strconv.pow5_inv_split_32.len, 'q < pow5_inv_split_32.len')
+	return mul_shift_32(m, strconv.pow5_inv_split_32[q], j)
 }
 
 @[direct_array_access; inline]
 fn mul_pow5_div_pow2(m u32, i u32, j int) u32 {
-	assert1(i < pow5_split_32.len, 'i < pow5_split_32.len')
-	return mul_shift_32(m, pow5_split_32[i], j)
+	assert1(i < strconv.pow5_split_32.len, 'i < pow5_split_32.len')
+	return mul_shift_32(m, strconv.pow5_split_32[i], j)
 }
 
 fn pow5_factor_32(i_v u32) u32 {

--- a/vlib/time/date_time_parser.v
+++ b/vlib/time/date_time_parser.v
@@ -76,12 +76,12 @@ fn (mut p DateTimeParser) must_be_string_one_of(oneof []string) !string {
 }
 
 fn (mut p DateTimeParser) must_be_valid_month() !int {
-	for v in long_months {
+	for v in time.long_months {
 		if p.current_pos_datetime + v.len < p.datetime.len {
 			month_name := p.datetime[p.current_pos_datetime..p.current_pos_datetime + v.len]
 			if v == month_name {
 				p.current_pos_datetime += v.len
-				return long_months.index(month_name) + 1
+				return time.long_months.index(month_name) + 1
 			}
 		}
 	}
@@ -91,8 +91,8 @@ fn (mut p DateTimeParser) must_be_valid_month() !int {
 fn (mut p DateTimeParser) must_be_valid_three_letter_month() !int {
 	if p.current_pos_datetime + 3 < p.datetime.len {
 		letters := p.datetime[p.current_pos_datetime..p.current_pos_datetime + 3]
-		for m := 1; m <= long_months.len; m++ {
-			if months_string[(m - 1) * 3..m * 3] == letters {
+		for m := 1; m <= time.long_months.len; m++ {
+			if time.months_string[(m - 1) * 3..m * 3] == letters {
 				p.current_pos_datetime += 3
 				return m
 			}
@@ -102,7 +102,7 @@ fn (mut p DateTimeParser) must_be_valid_three_letter_month() !int {
 }
 
 fn (mut p DateTimeParser) must_be_valid_week_day() !string {
-	for v in long_days {
+	for v in time.long_days {
 		if p.current_pos_datetime + v.len < p.datetime.len {
 			weekday := p.datetime[p.current_pos_datetime..p.current_pos_datetime + v.len]
 			if v == weekday {
@@ -117,8 +117,8 @@ fn (mut p DateTimeParser) must_be_valid_week_day() !string {
 fn (mut p DateTimeParser) must_be_valid_two_letter_week_day() !int {
 	if p.current_pos_datetime + 2 < p.datetime.len {
 		letters := p.datetime[p.current_pos_datetime..p.current_pos_datetime + 2]
-		for d := 1; d <= long_days.len; d++ {
-			if days_string[(d - 1) * 3..d * 3 - 1] == letters {
+		for d := 1; d <= time.long_days.len; d++ {
+			if time.days_string[(d - 1) * 3..d * 3 - 1] == letters {
 				p.current_pos_datetime += 2
 				return d
 			}
@@ -130,8 +130,8 @@ fn (mut p DateTimeParser) must_be_valid_two_letter_week_day() !int {
 fn (mut p DateTimeParser) must_be_valid_three_letter_week_day() !int {
 	if p.current_pos_datetime + 3 < p.datetime.len {
 		letters := p.datetime[p.current_pos_datetime..p.current_pos_datetime + 3]
-		for d := 1; d <= long_days.len; d++ {
-			if days_string[(d - 1) * 3..d * 3] == letters {
+		for d := 1; d <= time.long_days.len; d++ {
+			if time.days_string[(d - 1) * 3..d * 3] == letters {
 				p.current_pos_datetime += 3
 				return d
 			}

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -368,10 +368,10 @@ pub fn (t Time) custom_format(s string) string {
 				sb.write_string(ordinal_suffix(t.month))
 			}
 			'MMM' {
-				sb.write_string(long_months[t.month - 1][0..3])
+				sb.write_string(time.long_months[t.month - 1][0..3])
 			}
 			'MMMM' {
-				sb.write_string(long_months[t.month - 1])
+				sb.write_string(time.long_months[t.month - 1])
 			}
 			'D' {
 				sb.write_string(t.day.str())
@@ -383,26 +383,26 @@ pub fn (t Time) custom_format(s string) string {
 				sb.write_string(ordinal_suffix(t.day))
 			}
 			'DDD' {
-				sb.write_string((t.day + days_before[t.month - 1] + int(is_leap_year(t.year))).str())
+				sb.write_string((t.day + time.days_before[t.month - 1] + int(is_leap_year(t.year))).str())
 			}
 			'DDDD' {
-				sb.write_string('${t.day + days_before[t.month - 1] + int(is_leap_year(t.year)):03}')
+				sb.write_string('${t.day + time.days_before[t.month - 1] + int(is_leap_year(t.year)):03}')
 			}
 			'DDDo' {
-				sb.write_string(ordinal_suffix(t.day + days_before[t.month - 1] +
+				sb.write_string(ordinal_suffix(t.day + time.days_before[t.month - 1] +
 					int(is_leap_year(t.year))))
 			}
 			'd' {
 				sb.write_string('${t.day_of_week() % 7}')
 			}
 			'dd' {
-				sb.write_string(long_days[t.day_of_week() - 1][0..2])
+				sb.write_string(time.long_days[t.day_of_week() - 1][0..2])
 			}
 			'ddd' {
-				sb.write_string(long_days[t.day_of_week() - 1][0..3])
+				sb.write_string(time.long_days[t.day_of_week() - 1][0..3])
 			}
 			'dddd' {
-				sb.write_string(long_days[t.day_of_week() - 1])
+				sb.write_string(time.long_days[t.day_of_week() - 1])
 			}
 			'YY' {
 				sb.write_string(t.year.str()[2..4])
@@ -451,15 +451,15 @@ pub fn (t Time) custom_format(s string) string {
 				sb.write_string('${(t.hour + 1):02}')
 			}
 			'w' {
-				sb.write_string('${mceil((t.day + days_before[t.month - 1] +
+				sb.write_string('${mceil((t.day + time.days_before[t.month - 1] +
 					int(is_leap_year(t.year))) / 7):.0}')
 			}
 			'ww' {
-				sb.write_string('${mceil((t.day + days_before[t.month - 1] +
+				sb.write_string('${mceil((t.day + time.days_before[t.month - 1] +
 					int(is_leap_year(t.year))) / 7):02.0}')
 			}
 			'wo' {
-				sb.write_string(ordinal_suffix(int(mceil((t.day + days_before[t.month - 1] +
+				sb.write_string(ordinal_suffix(int(mceil((t.day + time.days_before[t.month - 1] +
 					int(is_leap_year(t.year))) / 7))))
 			}
 			'Q' {
@@ -483,7 +483,7 @@ pub fn (t Time) custom_format(s string) string {
 				sb.write_string('Anno Domini')
 			}
 			'Z' {
-				mut hours := offset() / seconds_per_hour
+				mut hours := offset() / time.seconds_per_hour
 				if hours >= 0 {
 					sb.write_string('+${hours}')
 				} else {
@@ -493,7 +493,7 @@ pub fn (t Time) custom_format(s string) string {
 			}
 			'ZZ' {
 				// TODO: update if minute differs?
-				mut hours := offset() / seconds_per_hour
+				mut hours := offset() / time.seconds_per_hour
 				if hours >= 0 {
 					sb.write_string('+${hours:02}00')
 				} else {
@@ -503,7 +503,7 @@ pub fn (t Time) custom_format(s string) string {
 			}
 			'ZZZ' {
 				// TODO: update if minute differs?
-				mut hours := offset() / seconds_per_hour
+				mut hours := offset() / time.seconds_per_hour
 				if hours >= 0 {
 					sb.write_string('+${hours:02}:00')
 				} else {

--- a/vlib/time/operator.v
+++ b/vlib/time/operator.v
@@ -18,7 +18,7 @@ pub fn (lhs Time) - (rhs Time) Duration {
 	// lhs.unix * 1_000_000_000 + i64(lhs.nanosecond) will overflow i64, for years > 3000 .
 	// Doing the diff first, and *then* multiplying by `second`, is less likely to overflow,
 	// since lhs and rhs will be likely close to each other.
-	unixs := i64(lhs.unix() - rhs.unix()) * second
+	unixs := i64(lhs.unix() - rhs.unix()) * time.second
 	nanos := lhs.nanosecond - rhs.nanosecond
 	return unixs + nanos
 }

--- a/vlib/time/operator_test.v
+++ b/vlib/time/operator_test.v
@@ -1,7 +1,7 @@
 module time
 
 fn assert_greater_time(ms int, t1 Time) {
-	sleep(ms * millisecond)
+	sleep(ms * time.millisecond)
 	t2 := now()
 	assert t2 > t1
 }
@@ -371,7 +371,7 @@ fn test_time2_copied_from_time1_should_be_equal() {
 fn test_subtract() {
 	d_seconds := 3
 	d_nanoseconds := 13
-	duration := d_seconds * second + d_nanoseconds * nanosecond
+	duration := d_seconds * time.second + d_nanoseconds * time.nanosecond
 	t1 := new(Time{
 		year:       2000
 		month:      5

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -164,11 +164,11 @@ pub fn (t Time) add(duration_in_nanosecond Duration) Time {
 	// ... so instead, handle the addition manually in parts ¯\_(ツ)_/¯
 	mut increased_time_nanosecond := i64(t.nanosecond) + duration_in_nanosecond.nanoseconds()
 	// increased_time_second
-	mut increased_time_second := t.unix() + (increased_time_nanosecond / second)
-	increased_time_nanosecond = increased_time_nanosecond % second
+	mut increased_time_second := t.unix() + (increased_time_nanosecond / time.second)
+	increased_time_nanosecond = increased_time_nanosecond % time.second
 	if increased_time_nanosecond < 0 {
 		increased_time_second--
-		increased_time_nanosecond += second
+		increased_time_nanosecond += time.second
 	}
 	res := unix_nanosecond(increased_time_second, int(increased_time_nanosecond))
 	return if t.is_local { res.as_local() } else { res }
@@ -176,12 +176,12 @@ pub fn (t Time) add(duration_in_nanosecond Duration) Time {
 
 // add_seconds returns a new time struct with an added number of seconds.
 pub fn (t Time) add_seconds(seconds int) Time {
-	return time_with_unix(t).add(seconds * second)
+	return time_with_unix(t).add(seconds * time.second)
 }
 
 // add_days returns a new time struct with an added number of days.
 pub fn (t Time) add_days(days int) Time {
-	return time_with_unix(t).add(days * 24 * hour)
+	return time_with_unix(t).add(days * 24 * time.hour)
 }
 
 // since returns the time duration elapsed since a given time.
@@ -382,7 +382,7 @@ pub fn (t Time) local_to_utc() Time {
 		return t
 	}
 	return Time{
-		...t.add(-offset() * second)
+		...t.add(-offset() * time.second)
 		is_local: false
 	}
 }
@@ -394,7 +394,7 @@ pub fn (u Time) utc_to_local() Time {
 		return u
 	}
 	return Time{
-		...u.add(offset() * second)
+		...u.add(offset() * time.second)
 		is_local: true
 	}
 }

--- a/vlib/time/unix.v
+++ b/vlib/time/unix.v
@@ -6,13 +6,13 @@ module time
 // unix returns a Time struct calculated from a Unix timestamp (number of seconds since 1970-01-01)
 pub fn unix(epoch i64) Time {
 	// Split into day and time
-	mut day_offset := epoch / seconds_per_day
-	if epoch % seconds_per_day < 0 {
+	mut day_offset := epoch / time.seconds_per_day
+	if epoch % time.seconds_per_day < 0 {
 		// Compensate for round towards zero on integers as we want floored instead
 		day_offset--
 	}
 	year, month, day := calculate_date_from_day_offset(day_offset)
-	hr, min, sec := calculate_time_from_second_offset(epoch % seconds_per_day)
+	hr, min, sec := calculate_time_from_second_offset(epoch % time.seconds_per_day)
 	return Time{
 		year:   year
 		month:  month
@@ -39,13 +39,13 @@ pub fn unix_microsecond(epoch i64, microsecond int) Time {
 // unix_nanosecond returns a Time struct given a Unix timestamp in seconds and a nanosecond value
 pub fn unix_nanosecond(abs_unix_timestamp i64, nanosecond int) Time {
 	// Split into day and time
-	mut day_offset := abs_unix_timestamp / seconds_per_day
-	if abs_unix_timestamp % seconds_per_day < 0 {
+	mut day_offset := abs_unix_timestamp / time.seconds_per_day
+	if abs_unix_timestamp % time.seconds_per_day < 0 {
 		// Compensate for rounding towards zero on integers as we want floored instead
 		day_offset--
 	}
 	year, month, day := calculate_date_from_day_offset(day_offset)
-	hour_, minute_, second_ := calculate_time_from_second_offset(abs_unix_timestamp % seconds_per_day)
+	hour_, minute_, second_ := calculate_time_from_second_offset(abs_unix_timestamp % time.seconds_per_day)
 	return Time{
 		year:       year
 		month:      month
@@ -69,22 +69,22 @@ fn calculate_date_from_day_offset(day_offset_ i64) (int, int, int) {
 
 	mut era := 0
 	if day_offset >= 0 {
-		era = int(day_offset / days_per_400_years)
+		era = int(day_offset / time.days_per_400_years)
 	} else {
-		era = int((day_offset - days_per_400_years - 1) / days_per_400_years)
+		era = int((day_offset - time.days_per_400_years - 1) / time.days_per_400_years)
 	}
 
 	// day_of_era => [0..146096]
-	day_of_era := day_offset - era * days_per_400_years
+	day_of_era := day_offset - era * time.days_per_400_years
 
 	// year_of_era => [0..399]
-	year_of_era := (day_of_era - day_of_era / (days_per_4_years - 1) +
-		day_of_era / days_per_100_years - day_of_era / (days_per_400_years - 1)) / days_in_year
+	year_of_era := (day_of_era - day_of_era / (time.days_per_4_years - 1) +
+		day_of_era / time.days_per_100_years - day_of_era / (time.days_per_400_years - 1)) / time.days_in_year
 
 	mut year := int(year_of_era + era * 400)
 
 	// day_of_year => with year beginning Mar 1 [0..365]
-	day_of_year := day_of_era - (days_in_year * year_of_era + year_of_era / 4 - year_of_era / 100)
+	day_of_year := day_of_era - (time.days_in_year * year_of_era + year_of_era / 4 - year_of_era / 100)
 
 	month_position := (5 * day_of_year + 2) / 153
 	day := int(day_of_year - (153 * month_position + 2) / 5 + 1)
@@ -108,11 +108,11 @@ fn calculate_date_from_day_offset(day_offset_ i64) (int, int, int) {
 fn calculate_time_from_second_offset(second_offset_ i64) (int, int, int) {
 	mut second_offset := second_offset_
 	if second_offset < 0 {
-		second_offset += seconds_per_day
+		second_offset += time.seconds_per_day
 	}
-	hour_ := second_offset / seconds_per_hour
-	second_offset %= seconds_per_hour
-	minute_ := second_offset / seconds_per_minute
-	second_offset %= seconds_per_minute
+	hour_ := second_offset / time.seconds_per_hour
+	second_offset %= time.seconds_per_hour
+	minute_ := second_offset / time.seconds_per_minute
+	second_offset %= time.seconds_per_minute
 	return int(hour_), int(minute_), int(second_offset)
 }

--- a/vlib/toml/any.v
+++ b/vlib/toml/any.v
@@ -278,7 +278,7 @@ pub fn (a []Any) to_toml() string {
 // quoted keys are supported as `a."b.c"` or `a.'b.c'`.
 // Arrays can be queried with `a[0].b[1].[2]`.
 pub fn (a Any) value(key string) Any {
-	key_split := parse_dotted_key(key) or { return null }
+	key_split := parse_dotted_key(key) or { return toml.null }
 	return a.value_(a, key_split)
 }
 
@@ -296,19 +296,19 @@ pub fn (a Any) value_opt(key string) !Any {
 // value_ returns the `Any` value found at `key`.
 fn (a Any) value_(value Any, key []string) Any {
 	if key.len == 0 {
-		return null
+		return toml.null
 	}
-	mut any_value := null
+	mut any_value := toml.null
 	k, index := parse_array_key(key[0])
 	if k == '' {
 		arr := value as []Any
-		any_value = arr[index] or { return null }
+		any_value = arr[index] or { return toml.null }
 	}
 	if value is map[string]Any {
-		any_value = value[k] or { return null }
+		any_value = value[k] or { return toml.null }
 		if index > -1 {
 			arr := any_value as []Any
-			any_value = arr[index] or { return null }
+			any_value = arr[index] or { return toml.null }
 		}
 	}
 	if key.len <= 1 {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1084,7 +1084,7 @@ pub mut:
 	right         Expr
 	left_type     Type
 	right_type    Type
-	promoted_type Type = void_type
+	promoted_type Type = ast.void_type
 	auto_locked   string
 	or_block      OrExpr
 
@@ -2186,12 +2186,12 @@ pub fn (expr Expr) is_expr() bool {
 
 pub fn (expr Expr) get_pure_type() Type {
 	return match expr {
-		BoolLiteral { bool_type }
-		CharLiteral { char_type }
-		FloatLiteral { f64_type }
-		StringLiteral { string_type }
-		IntegerLiteral { i64_type }
-		else { void_type }
+		BoolLiteral { ast.bool_type }
+		CharLiteral { ast.char_type }
+		FloatLiteral { ast.f64_type }
+		StringLiteral { ast.string_type }
+		IntegerLiteral { ast.i64_type }
+		else { ast.void_type }
 	}
 }
 
@@ -2596,7 +2596,7 @@ pub fn (expr Expr) is_literal() bool {
 		}
 		CastExpr {
 			!expr.has_arg && expr.expr.is_literal() && (expr.typ.is_any_kind_of_pointer()
-				|| expr.typ in [i8_type, i16_type, int_type, i64_type, u8_type, u16_type, u32_type, u64_type, f32_type, f64_type, char_type, bool_type, rune_type])
+				|| expr.typ in [ast.i8_type, ast.i16_type, ast.int_type, ast.i64_type, ast.u8_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.f32_type, ast.f64_type, ast.char_type, ast.bool_type, ast.rune_type])
 		}
 		SizeOf, IsRefType {
 			expr.is_type || expr.expr.is_literal()
@@ -2615,7 +2615,7 @@ pub fn type_can_start_with_token(tok &token.Token) bool {
 	return match tok.kind {
 		.name {
 			(tok.lit.len > 0 && tok.lit[0].is_capital())
-				|| builtin_type_names_matcher.matches(tok.lit)
+				|| ast.builtin_type_names_matcher.matches(tok.lit)
 		}
 		// Note: return type (T1, T2) should be handled elsewhere
 		.amp, .key_fn, .lsbr, .question {
@@ -2630,11 +2630,11 @@ pub fn type_can_start_with_token(tok &token.Token) bool {
 // validate_type_string_is_pure_literal returns `Error` if `str` can not be converted
 // to pure literal `typ` (`i64`, `f64`, `bool`, `char` or `string`).
 pub fn validate_type_string_is_pure_literal(typ Type, str string) ! {
-	if typ == bool_type {
+	if typ == ast.bool_type {
 		if !(str == 'true' || str == 'false') {
 			return error('bool literal `true` or `false` expected, found "${str}"')
 		}
-	} else if typ == char_type {
+	} else if typ == ast.char_type {
 		if str.starts_with('\\') {
 			if str.len <= 1 {
 				return error('empty escape sequence found')
@@ -2645,12 +2645,12 @@ pub fn validate_type_string_is_pure_literal(typ Type, str string) ! {
 		} else if str.len != 1 {
 			return error('char literal expected, found "${str}"')
 		}
-	} else if typ == f64_type {
+	} else if typ == ast.f64_type {
 		if str.count('.') != 1 {
 			return error('f64 literal expected, found "${str}"')
 		}
-	} else if typ == string_type {
-	} else if typ == i64_type {
+	} else if typ == ast.string_type {
+	} else if typ == ast.i64_type {
 		if !str.is_int() {
 			return error('i64 literal expected, found "${str}"')
 		}

--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -26,7 +26,7 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 	}
 	mut fos := ''
 	mut allowed_os_overrides := []string{}
-	allowed_os_overrides << valid_comptime_not_user_defined
+	allowed_os_overrides << ast.valid_comptime_not_user_defined
 	allowed_os_overrides << ctimedefines
 	for os_override in allowed_os_overrides {
 		if !flag.starts_with(os_override) {

--- a/vlib/v/ast/init.v
+++ b/vlib/v/ast/init.v
@@ -7,9 +7,9 @@ pub fn (t &Table) resolve_init(node StructInit, typ Type) Expr {
 			mut has_len := false
 			mut has_cap := false
 			mut has_init := false
-			mut len_expr := empty_expr
-			mut cap_expr := empty_expr
-			mut init_expr := empty_expr
+			mut len_expr := ast.empty_expr
+			mut cap_expr := ast.empty_expr
+			mut init_expr := ast.empty_expr
 			mut exprs := []Expr{}
 			for field in node.init_fields {
 				match field.name {

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -233,7 +233,7 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		old_pline = pline
 	}
 	f.write_string(')')
-	if node.return_type != void_type {
+	if node.return_type != ast.void_type {
 		sreturn_type := util.no_cur_mod(t.type_to_str(node.return_type), cur_mod)
 		short_sreturn_type := shorten_full_name_based_on_aliases(sreturn_type, m2a)
 		f.write_string(' ${short_sreturn_type}')

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -119,7 +119,7 @@ pub fn (t &Table) fn_type_signature(f &Fn) string {
 			sig += '_'
 		}
 	}
-	if f.return_type != 0 && f.return_type != void_type {
+	if f.return_type != 0 && f.return_type != ast.void_type {
 		sym := t.sym(f.return_type)
 		opt := if f.return_type.has_flag(.option) { 'option_' } else { '' }
 		res := if f.return_type.has_flag(.result) { 'result_' } else { '' }
@@ -147,11 +147,11 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 		}
 	}
 	sig += ')'
-	if f.return_type == ovoid_type {
+	if f.return_type == ast.ovoid_type {
 		sig += ' ?'
-	} else if f.return_type == rvoid_type {
+	} else if f.return_type == ast.rvoid_type {
 		sig += ' !'
-	} else if f.return_type != void_type && f.return_type != 0 {
+	} else if f.return_type != ast.void_type && f.return_type != 0 {
 		return_type_sym := t.sym(f.return_type)
 		if f.return_type.has_flag(.option) {
 			sig += ' ?${return_type_sym.name}'
@@ -716,7 +716,7 @@ pub fn (t &Table) get_final_type_name(typ Type) string {
 pub fn (t &Table) unalias_num_type(typ Type) Type {
 	sym := t.sym(typ)
 	if sym.info is Alias {
-		if sym.info.parent_type <= char_type && sym.info.parent_type >= void_type {
+		if sym.info.parent_type <= ast.char_type && sym.info.parent_type >= ast.void_type {
 			return sym.info.parent_type
 		}
 	}
@@ -748,9 +748,9 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 	}
 	// Override the already registered builtin types with the actual
 	// v struct declarations in the vlib/builtin module sources:
-	if (existing_idx >= string_type_idx && existing_idx <= map_type_idx)
-		|| existing_idx == error_type_idx {
-		if existing_idx == string_type_idx {
+	if (existing_idx >= ast.string_type_idx && existing_idx <= ast.map_type_idx)
+		|| existing_idx == ast.error_type_idx {
+		if existing_idx == ast.string_type_idx {
 			// existing_type := t.type_symbols[existing_idx]
 			unsafe {
 				*existing_symbol = &TypeSymbol{
@@ -767,7 +767,7 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 		}
 		return existing_idx
 	}
-	return invalid_type_idx
+	return ast.invalid_type_idx
 }
 
 @[inline]
@@ -937,7 +937,7 @@ pub fn (t &Table) chan_cname(elem_type Type, is_mut bool) string {
 
 @[inline]
 pub fn (t &Table) promise_name(return_type Type) string {
-	if return_type.idx() == void_type_idx {
+	if return_type.idx() == ast.void_type_idx {
 		return 'Promise[JS.Any, JS.Any]'
 	}
 
@@ -947,7 +947,7 @@ pub fn (t &Table) promise_name(return_type Type) string {
 
 @[inline]
 pub fn (t &Table) promise_cname(return_type Type) string {
-	if return_type == void_type {
+	if return_type == ast.void_type {
 		return 'Promise_Any_Any'
 	}
 
@@ -957,7 +957,7 @@ pub fn (t &Table) promise_cname(return_type Type) string {
 
 @[inline]
 pub fn (t &Table) thread_name(return_type Type) string {
-	if return_type.idx() == void_type_idx {
+	if return_type.idx() == ast.void_type_idx {
 		if return_type.has_flag(.option) {
 			return 'thread ?'
 		} else if return_type.has_flag(.result) {
@@ -975,7 +975,7 @@ pub fn (t &Table) thread_name(return_type Type) string {
 
 @[inline]
 pub fn (t &Table) thread_cname(return_type Type) string {
-	if return_type == void_type {
+	if return_type == ast.void_type {
 		if return_type.has_flag(.option) {
 			return '__v_thread_Option_void'
 		} else if return_type.has_flag(.result) {
@@ -1028,7 +1028,7 @@ pub fn (mut t Table) find_or_register_chan(elem_type Type, is_mut bool) int {
 	}
 	// register
 	chan_typ := TypeSymbol{
-		parent_idx: chan_type_idx
+		parent_idx: ast.chan_type_idx
 		kind:       .chan
 		name:       name
 		cname:      cname
@@ -1050,7 +1050,7 @@ pub fn (mut t Table) find_or_register_map(key_type Type, value_type Type) int {
 	}
 	// register
 	map_typ := TypeSymbol{
-		parent_idx: map_type_idx
+		parent_idx: ast.map_type_idx
 		kind:       .map
 		name:       name
 		cname:      cname
@@ -1072,7 +1072,7 @@ pub fn (mut t Table) find_or_register_thread(return_type Type) int {
 	}
 	// register
 	thread_typ := TypeSymbol{
-		parent_idx: thread_type_idx
+		parent_idx: ast.thread_type_idx
 		kind:       .thread
 		name:       name
 		cname:      cname
@@ -1117,7 +1117,7 @@ pub fn (mut t Table) find_or_register_array(elem_type Type) int {
 	cname := t.array_cname(elem_type)
 	// register
 	array_type_ := TypeSymbol{
-		parent_idx: array_type_idx
+		parent_idx: ast.array_type_idx
 		kind:       .array
 		name:       name
 		cname:      cname
@@ -1258,17 +1258,17 @@ pub fn (t &Table) value_type(typ Type) Type {
 	}
 	if sym.kind == .string && typ.is_ptr() {
 		// (&string)[i] => string
-		return string_type
+		return ast.string_type
 	}
 	if sym.kind in [.byteptr, .string] {
-		return u8_type
+		return ast.u8_type
 	}
 	if typ.is_ptr() {
 		// byte* => byte
 		// bytes[0] is a byte, not byte*
 		return typ.deref()
 	}
-	return void_type
+	return ast.void_type
 }
 
 pub fn (mut t Table) register_fn_generic_types(fn_name string) {
@@ -1382,8 +1382,8 @@ pub fn (t &Table) known_type_names() []string {
 	mut res := []string{cap: t.type_idxs.len}
 	for _, idx in t.type_idxs {
 		// Skip `int_literal_type_idx` and `float_literal_type_idx` because they shouldn't be visible to the User.
-		if idx !in [0, int_literal_type_idx, float_literal_type_idx] && t.known_type_idx(idx)
-			&& t.sym(idx).kind != .function {
+		if idx !in [0, ast.int_literal_type_idx, ast.float_literal_type_idx]
+			&& t.known_type_idx(idx) && t.sym(idx).kind != .function {
 			res << t.type_to_str(idx)
 		}
 	}
@@ -1450,23 +1450,23 @@ pub fn (mut t Table) complete_interface_check() {
 pub fn (mut t Table) bitsize_to_type(bit_size int) Type {
 	match bit_size {
 		8 {
-			return i8_type
+			return ast.i8_type
 		}
 		16 {
-			return i16_type
+			return ast.i16_type
 		}
 		32 {
-			return int_type
+			return ast.int_type
 		}
 		64 {
-			return i64_type
+			return ast.i64_type
 		}
 		else {
 			if bit_size % 8 != 0 { // there is no way to do `i2131(32)` so this should never be reached
 				t.panic('table.bitsize_to_type: compiler bug: bitsizes must be multiples of 8, but passed bit_size is ${bit_size}')
 			}
-			return new_type(t.find_or_register_array_fixed(u8_type, bit_size / 8, empty_expr,
-				false))
+			return new_type(t.find_or_register_array_fixed(ast.u8_type, bit_size / 8,
+				ast.empty_expr, false))
 		}
 	}
 }
@@ -1476,7 +1476,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 		// same type -> already casted to the interface
 		return true
 	}
-	if inter_typ.idx() == error_type_idx && typ.idx() == none_type_idx {
+	if inter_typ.idx() == ast.error_type_idx && typ.idx() == ast.none_type_idx {
 		// `none` "implements" the Error interface
 		return true
 	}
@@ -1520,7 +1520,7 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 		}
 		// verify fields
 		for ifield in inter_sym.info.fields {
-			if ifield.typ == voidptr_type || ifield.typ == nil_type {
+			if ifield.typ == ast.voidptr_type || ifield.typ == ast.nil_type {
 				// Allow `voidptr` fields in interfaces for now. (for example
 				// to enable .db check in vweb)
 				if t.struct_has_field(sym, ifield.name) {
@@ -1539,12 +1539,12 @@ pub fn (t Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 			}
 			return false
 		}
-		if typ != voidptr_type && typ != nil_type && typ != none_type
+		if typ != ast.voidptr_type && typ != ast.nil_type && typ != ast.none_type
 			&& !inter_sym.info.types.contains(typ) {
 			inter_sym.info.types << typ
 		}
-		if !inter_sym.info.types.contains(voidptr_type) {
-			inter_sym.info.types << voidptr_type
+		if !inter_sym.info.types.contains(ast.voidptr_type) {
+			inter_sym.info.types << ast.voidptr_type
 		}
 		return true
 	}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -993,7 +993,7 @@ pub fn (mut t Table) register_builtin_type_symbols() {
 	t.register_sym(kind: .i8, name: 'i8', cname: 'i8', mod: 'builtin') // 5
 	t.register_sym(kind: .i16, name: 'i16', cname: 'i16', mod: 'builtin') // 6
 	t.register_sym(kind: .i32, name: 'i32', cname: 'i32', mod: 'builtin') // 7
-	t.register_sym(kind: .int, name: 'int', cname: int_type_name, mod: 'builtin') // 8
+	t.register_sym(kind: .int, name: 'int', cname: ast.int_type_name, mod: 'builtin') // 8
 	t.register_sym(kind: .i64, name: 'i64', cname: 'i64', mod: 'builtin') // 9
 	t.register_sym(kind: .isize, name: 'isize', cname: 'isize', mod: 'builtin') // 10
 	t.register_sym(kind: .u8, name: 'u8', cname: 'u8', mod: 'builtin') // 11

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -334,7 +334,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				} else {
 					if is_decl {
 						c.check_valid_snake_case(left.name, 'variable name', left.pos)
-						if reserved_type_names_chk.matches(left.name) {
+						if checker.reserved_type_names_chk.matches(left.name) {
 							c.error('invalid use of reserved type `${left.name}` as a variable name',
 								left.pos)
 						}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -237,7 +237,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			if !c.ensure_type_exists(param.typ, param.type_pos) {
 				return
 			}
-			if reserved_type_names_chk.matches(param.name) {
+			if checker.reserved_type_names_chk.matches(param.name) {
 				c.error('invalid use of reserved type `${param.name}` as a parameter name',
 					param.pos)
 			}
@@ -311,7 +311,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				}
 			}
 			if !c.is_builtin_mod && node.mod == 'main'
-				&& node.name.after_char(`.`) in reserved_type_names {
+				&& node.name.after_char(`.`) in checker.reserved_type_names {
 				c.error('top level declaration cannot shadow builtin type', node.pos)
 			}
 			if _ := node.name.index('__static__') {
@@ -1999,7 +1999,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 		return ast.void_type
 	}
 	if final_left_sym.kind == .array {
-		if array_builtin_methods_chk.matches(method_name) && (left_sym.kind == .array
+		if checker.array_builtin_methods_chk.matches(method_name) && (left_sym.kind == .array
 			|| (left_sym.kind == .alias && !left_sym.has_method(method_name))) {
 			return c.array_builtin_method_call(mut node, left_type)
 		} else if method_name in ['insert', 'prepend'] {
@@ -2765,8 +2765,8 @@ fn (mut c Checker) post_process_generic_fns() ! {
 		c.mod = node.mod
 		fkey := node.fkey()
 		all_generic_fns[fkey]++
-		if all_generic_fns[fkey] > generic_fn_cutoff_limit_per_fn {
-			c.error('generic function visited more than ${generic_fn_cutoff_limit_per_fn} times',
+		if all_generic_fns[fkey] > checker.generic_fn_cutoff_limit_per_fn {
+			c.error('generic function visited more than ${checker.generic_fn_cutoff_limit_per_fn} times',
 				node.pos)
 			return error('fkey: ${fkey}')
 		}

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -34,13 +34,13 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 	mut typ := c.expr(mut node.cond)
 	if node.key_var.len > 0 && node.key_var != '_' {
 		c.check_valid_snake_case(node.key_var, 'variable name', node.pos)
-		if reserved_type_names_chk.matches(node.key_var) {
+		if checker.reserved_type_names_chk.matches(node.key_var) {
 			c.error('invalid use of reserved type `${node.key_var}` as key name', node.pos)
 		}
 	}
 	if node.val_var.len > 0 && node.val_var != '_' {
 		c.check_valid_snake_case(node.val_var, 'variable name', node.pos)
-		if reserved_type_names_chk.matches(node.val_var) {
+		if checker.reserved_type_names_chk.matches(node.val_var) {
 			c.error('invalid use of reserved type `${node.val_var}` as value name', node.pos)
 		}
 	}

--- a/vlib/v/checker/interface.v
+++ b/vlib/v/checker/interface.v
@@ -152,7 +152,7 @@ fn (mut c Checker) interface_decl(mut node ast.InterfaceDecl) {
 				if !c.ensure_type_exists(param.typ, param.pos) {
 					continue
 				}
-				if reserved_type_names_chk.matches(param.name) {
+				if checker.reserved_type_names_chk.matches(param.name) {
 					c.error('invalid use of reserved type `${param.name}` as a parameter name',
 						param.pos)
 				}

--- a/vlib/v/eval/infix.v
+++ b/vlib/v/eval/infix.v
@@ -2208,5 +2208,5 @@ fn (e Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.T
 			e.error('unknown infix expression: ${op}')
 		}
 	}
-	return empty // should e.error before this anyway
+	return eval.empty // should e.error before this anyway
 }

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -61,7 +61,8 @@ fn run_fmt(mut input_files []string) {
 
 fn parse_others_in_same_module(mod_name string, file string, mut table ast.Table, prefs &pref.Preferences) {
 	if mod_name != 'main' && prefs.should_compile_c(file) && !file.ends_with('.c.v')
-		&& !file.starts_with('.#') && !file.contains('_d_') && !file.contains('_notd_') {
+		&& !file.ends_with('_windows.v') && !file.starts_with('.#') && !file.contains('_d_')
+		&& !file.contains('_notd_') {
 		// other files in the same module also need to be parsed
 		cur_file_dir := os.dir(file)
 		mut files := os.ls(cur_file_dir) or { panic(err) }

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -308,7 +308,8 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 				f.comments(init_field.next_comments, has_nl: true, level: .keep)
 				if single_line_fields && (init_field.end_comments.len > 0
 					|| init_field.next_comments.len > 0
-					|| !expr_is_single_line(init_field.expr) || f.line_len > max_len) {
+					|| !expr_is_single_line(init_field.expr)
+					|| f.line_len > fmt.max_len) {
 					single_line_fields = false
 					f.out.go_back_to(fields_start)
 					f.line_len = fields_start

--- a/vlib/v/fmt/tests/foo/flt.v
+++ b/vlib/v/fmt/tests/foo/flt.v
@@ -1,0 +1,3 @@
+module test
+
+const name = 'Bob'

--- a/vlib/v/fmt/tests/foo/foo_keep.vv
+++ b/vlib/v/fmt/tests/foo/foo_keep.vv
@@ -1,0 +1,13 @@
+module test
+
+const full_name = 'Robert the Tomato'
+
+fn print_full_name() {
+	println(test.full_name)
+	println(test.full_name)
+}
+
+fn print_name() {
+	println(test.name)
+	println(test.name)
+}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -554,7 +554,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 			g.write('${ret_elem_type} ${tmp_map_expr_result_name} = ')
 			if expr.kind == .function {
 				if expr.obj is ast.Var && expr.obj.is_inherited {
-					g.write(closure_ctx + '->')
+					g.write(c.closure_ctx + '->')
 				}
 				g.write('${c_name(expr.name)}(${var_name})')
 			} else if expr.kind == .variable {
@@ -562,7 +562,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 				sym := g.table.sym(var_info.typ)
 				if sym.kind == .function {
 					if expr.obj is ast.Var && expr.obj.is_inherited {
-						g.write(closure_ctx + '->')
+						g.write(c.closure_ctx + '->')
 					}
 					g.write('${c_name(expr.name)}(${var_name})')
 				} else {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -88,7 +88,7 @@ fn (mut g Gen) expr_opt_with_cast(expr ast.Expr, expr_typ ast.Type, ret_typ ast.
 			g.expr_with_cast(expr, expr_typ, ret_typ)
 			g.inside_opt_or_res = old_inside_opt_or_res
 		}
-		g.writeln(' }, (${option_name}*)(&${past.tmp_var}), sizeof(${styp}));')
+		g.writeln(' }, (${c.option_name}*)(&${past.tmp_var}), sizeof(${styp}));')
 
 		return past.tmp_var
 	}
@@ -875,7 +875,7 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 				g.expr(lx)
 				g.write(' = ${tmp_var};')
 			} else {
-				g.write('_option_ok(&(${base_typ}[]) { ${tmp_var} }, (${option_name}*)(&')
+				g.write('_option_ok(&(${base_typ}[]) { ${tmp_var} }, (${c.option_name}*)(&')
 				tmp_left_is_opt := g.left_is_opt
 				g.left_is_opt = true
 				g.expr(lx)
@@ -967,7 +967,7 @@ fn (mut g Gen) gen_cross_var_assign(node &ast.AssignStmt) {
 				if g.anon_fn {
 					obj := left.scope.find(left.name)
 					if obj is ast.Var && obj.is_inherited {
-						anon_ctx = '${closure_ctx}->'
+						anon_ctx = '${c.closure_ctx}->'
 					}
 				}
 				if left_sym.kind == .function {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -618,7 +618,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	if g.shared_functions.len > 0 {
 		b.writeln('\n// V shared type functions:')
 		b.write_string(g.shared_functions.str())
-		b.write_string(c_concurrency_helpers)
+		b.write_string(c.c_concurrency_helpers)
 	}
 	if g.channel_definitions.len > 0 {
 		b.writeln('\n// V channel code:')
@@ -800,7 +800,7 @@ pub fn (mut g Gen) gen_file() {
 }
 
 pub fn (g &Gen) hashes() string {
-	return c_commit_hash_default.replace('@@@', version.vhash())
+	return c.c_commit_hash_default.replace('@@@', version.vhash())
 }
 
 pub fn (mut g Gen) init() {
@@ -848,14 +848,14 @@ pub fn (mut g Gen) init() {
 		if g.pref.nofloat {
 			g.cheaders.writeln('#define VNOFLOAT 1')
 		}
-		g.cheaders.writeln(c_builtin_types)
+		g.cheaders.writeln(c.c_builtin_types)
 		if g.pref.is_bare {
-			g.cheaders.writeln(c_bare_headers)
+			g.cheaders.writeln(c.c_bare_headers)
 		} else {
-			g.cheaders.writeln(c_headers)
+			g.cheaders.writeln(c.c_headers)
 		}
 		if !g.pref.skip_unused || g.table.used_maps > 0 {
-			g.cheaders.writeln(c_wyhash_headers)
+			g.cheaders.writeln(c.c_wyhash_headers)
 		}
 	}
 	if g.pref.os == .ios {
@@ -4881,7 +4881,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					g.write('(*${name})')
 				} else {
 					if node.obj is ast.Var && node.obj.is_inherited {
-						g.write(closure_ctx + '->')
+						g.write(c.closure_ctx + '->')
 					}
 					g.write(name)
 				}
@@ -4991,7 +4991,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 							mut is_ptr := false
 							if i == 0 {
 								if node.obj.is_inherited {
-									g.write(closure_ctx + '->')
+									g.write(c.closure_ctx + '->')
 								}
 								if node.obj.typ.nr_muls() > 1 {
 									g.write('(')
@@ -5043,7 +5043,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				}
 			}
 			if node.obj.is_inherited {
-				g.write(closure_ctx + '->')
+				g.write(c.closure_ctx + '->')
 			}
 		}
 	} else if node.info is ast.IdentFn {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1981,7 +1981,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			g.call_args(node)
 			g.writeln(');')
 			tmp2 = g.new_tmp_var()
-			g.writeln('${result_name}_${typ} ${tmp2} = ${fn_name}(${json_obj});')
+			g.writeln('${c.result_name}_${typ} ${tmp2} = ${fn_name}(${json_obj});')
 		}
 		if !g.is_autofree {
 			g.write('cJSON_Delete(${json_obj}); // del')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -77,7 +77,7 @@ fn (mut g Gen) infix_expr_arrow_op(node ast.InfixExpr) {
 	if gen_or {
 		elem_styp := g.typ(elem_type)
 		g.register_chan_push_option_fn(elem_styp, styp)
-		g.write('${option_name}_void ${tmp_opt} = __Option_${styp}_pushval(')
+		g.write('${c.option_name}_void ${tmp_opt} = __Option_${styp}_pushval(')
 	} else {
 		g.write('__${styp}_pushval(')
 	}
@@ -1096,7 +1096,7 @@ fn (mut g Gen) gen_safe_integer_infix_expr(cfg GenSafeIntegerCfg) {
 		64
 	}
 	op_idx := int(cfg.op) - int(token.Kind.eq)
-	op_str := if cfg.reverse { cmp_rev[op_idx] } else { cmp_str[op_idx] }
+	op_str := if cfg.reverse { c.cmp_rev[op_idx] } else { c.cmp_str[op_idx] }
 	g.write('_us${bitsize}_${op_str}(')
 	g.expr(cfg.unsigned_expr)
 	g.write(',')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -54,7 +54,7 @@ fn (mut g Gen) gen_jsons() {
 		// cJSON_Parse(str) call is added by the compiler
 		// Codegen decoder
 		dec_fn_name := js_dec_name(styp)
-		dec_fn_dec := '${result_name}_${ret_styp} ${dec_fn_name}(cJSON* root)'
+		dec_fn_dec := '${c.result_name}_${ret_styp} ${dec_fn_name}(cJSON* root)'
 
 		mut init_styp := '${styp} res'
 		if utyp.has_flag(.option) {
@@ -119,7 +119,7 @@ ${dec_fn_dec} {
 				int maxchars = vstrlen_char(prevline_ptr);
 				vmemcpy(buf, prevline_ptr, (maxchars < maxcontext_chars ? maxchars : maxcontext_chars));
 			}
-			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(tos2(buf)),.data = {0}};
+			return (${c.result_name}_${ret_styp}){.is_error = true,.err = _v_error(tos2(buf)),.data = {0}};
 		}
 	}
 ')
@@ -204,11 +204,11 @@ ${enc_fn_dec} {
 			g.gen_struct_enc_dec(utyp, sym.info, ret_styp, mut enc, mut dec)
 		}
 		// cJSON_delete
-		dec.writeln('\t${result_name}_${ret_styp} ret;')
-		dec.writeln('\t_result_ok(&res, (${result_name}*)&ret, sizeof(res));')
+		dec.writeln('\t${c.result_name}_${ret_styp} ret;')
+		dec.writeln('\t_result_ok(&res, (${c.result_name}*)&ret, sizeof(res));')
 		if utyp.has_flag(.option) {
 			dec.writeln('\tif (res.state != 2) {')
-			dec.writeln('\t\t_option_ok(&res.data, (${option_name}*)&ret.data, sizeof(${g.base_type(utyp)}));')
+			dec.writeln('\t\t_option_ok(&res.data, (${c.option_name}*)&ret.data, sizeof(${g.base_type(utyp)}));')
 			dec.writeln('\t}')
 		}
 		dec.writeln('\treturn ret;\n}')
@@ -284,7 +284,7 @@ fn (mut g Gen) gen_enum_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc strin
 		if is_option {
 			base_typ := g.typ(utyp.clear_flag(.option))
 			enc.writeln('\to = ${js_enc_name('u64')}(*val.data);')
-			dec.writeln('\t_option_ok(&(${base_typ}[]){ ${js_dec_name('u64')}(root) }, (${option_name}*)&res, sizeof(${base_typ}));')
+			dec.writeln('\t_option_ok(&(${base_typ}[]){ ${js_dec_name('u64')}(root) }, (${c.option_name}*)&res, sizeof(${base_typ}));')
 		} else {
 			dec.writeln('\tres = ${js_dec_name('u64')}(root);')
 			enc.writeln('\to = ${js_enc_name('u64')}(val);')
@@ -321,7 +321,7 @@ fn (mut g Gen) gen_prim_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec s
 			if typ.has_flag(.option) {
 				tmp_var := g.new_tmp_var()
 				dec.writeln('${type_str}* ${tmp_var} = HEAP(${type_str}, *(${type_str}*) ${dec_name}(root).data);')
-				dec.writeln('\t_option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${option_name}*)&res, sizeof(${type_str}*));')
+				dec.writeln('\t_option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${c.option_name}*)&res, sizeof(${type_str}*));')
 			} else {
 				dec.writeln('\tres = HEAP(${type_str}, *(${type_str}*) ${dec_name}(root).data);')
 			}
@@ -329,7 +329,7 @@ fn (mut g Gen) gen_prim_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec s
 			if typ.has_flag(.option) {
 				tmp_var := g.new_tmp_var()
 				dec.writeln('${type_str}* ${tmp_var} = HEAP(${type_str}, ${dec_name}(root));')
-				dec.writeln('\t_option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${option_name}*)&res, sizeof(${type_str}*));')
+				dec.writeln('\t_option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${c.option_name}*)&res, sizeof(${type_str}*));')
 			} else {
 				dec.writeln('\tres = HEAP(${type_str}, ${dec_name}(root));')
 			}
@@ -354,9 +354,9 @@ fn (mut g Gen) gen_option_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec
 
 	dec_name := js_dec_name(type_str)
 	dec.writeln('\tif (!cJSON_IsNull(root)) {')
-	dec.writeln('\t\t_option_ok(&(${type_str}[]){ ${dec_name}(root) }, (${option_name}*)&res, sizeof(${type_str}));')
+	dec.writeln('\t\t_option_ok(&(${type_str}[]){ ${dec_name}(root) }, (${c.option_name}*)&res, sizeof(${type_str}));')
 	dec.writeln('\t} else {')
-	dec.writeln('\t\t_option_none(&(${type_str}[]){ {0} }, (${option_name}*)&res, sizeof(${type_str}));')
+	dec.writeln('\t\t_option_none(&(${type_str}[]){ {0} }, (${c.option_name}*)&res, sizeof(${type_str}));')
 	dec.writeln('\t}')
 }
 
@@ -473,7 +473,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 				dec.writeln('\t\t${variant_typ} value = *(${variant_typ}*)(${tmp}.data);')
 			}
 			if is_option {
-				dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}(&value) }, (${option_name}*)&res, sizeof(${sym.cname}));')
+				dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}(&value) }, (${c.option_name}*)&res, sizeof(${sym.cname}));')
 			} else {
 				dec.writeln('\t\tres = ${variant_typ}_to_sumtype_${ret_styp}(&value);')
 			}
@@ -487,13 +487,13 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 				dec.writeln('\t\t\t}')
 			} else if !is_js_prim(variant_typ) && variant_sym.kind != .enum_ {
 				dec.writeln('\t\t\tif (strcmp("${unmangled_variant_name}", ${type_var}) == 0 && ${variant_sym.kind == .array} == cJSON_IsArray(root)) {')
-				dec.writeln('\t\t\t\t${result_name}_${variant_typ} ${tmp} = ${js_dec_name(variant_typ)}(root);')
+				dec.writeln('\t\t\t\t${c.result_name}_${variant_typ} ${tmp} = ${js_dec_name(variant_typ)}(root);')
 				dec.writeln('\t\t\t\tif (${tmp}.is_error) {')
 
-				dec.writeln('\t\t\t\t\treturn (${result_name}_${ret_styp}){ .is_error = true, .err = ${tmp}.err, .data = {0} };')
+				dec.writeln('\t\t\t\t\treturn (${c.result_name}_${ret_styp}){ .is_error = true, .err = ${tmp}.err, .data = {0} };')
 				dec.writeln('\t\t\t\t}')
 				if is_option {
-					dec.writeln('\t\t\t\t_option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}((${variant_typ}*)${tmp}.data) }, (${option_name}*)&res, sizeof(${sym.cname}));')
+					dec.writeln('\t\t\t\t_option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}((${variant_typ}*)${tmp}.data) }, (${c.option_name}*)&res, sizeof(${sym.cname}));')
 				} else {
 					dec.writeln('\t\t\t\t${prefix}res = ${variant_typ}_to_sumtype_${sym.cname}((${variant_typ}*)${tmp}.data);')
 				}
@@ -568,9 +568,9 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 						'cJSON_IsNumber(root->child)'
 					}
 					dec.writeln('\t\tif (cJSON_IsArray(root) && ${judge_elem_typ}) {')
-					dec.writeln('\t\t\t${result_name}_${var_t} ${tmp} = ${js_dec_name(var_t)}(root);')
+					dec.writeln('\t\t\t${c.result_name}_${var_t} ${tmp} = ${js_dec_name(var_t)}(root);')
 					dec.writeln('\t\t\tif (${tmp}.is_error) {')
-					dec.writeln('\t\t\t\treturn (${result_name}_${ret_styp}){ .is_error = true, .err = ${tmp}.err, .data = {0} };')
+					dec.writeln('\t\t\t\treturn (${c.result_name}_${ret_styp}){ .is_error = true, .err = ${tmp}.err, .data = {0} };')
 					dec.writeln('\t\t\t}')
 					if utyp.has_flag(.option) {
 						dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}((${var_t}*)${tmp}.data) }, &${prefix}res, sizeof(${sym.cname}));')
@@ -888,7 +888,7 @@ fn gen_js_get(styp string, tmp string, name string, mut dec strings.Builder, is_
 	dec.writeln('\tcJSON *jsonroot_${tmp} = js_get(root, "${name}");')
 	if is_required {
 		dec.writeln('\tif (jsonroot_${tmp} == 0) {')
-		dec.writeln('\t\treturn (${result_name}_${styp}){ .is_error = true, .err = _v_error(_SLIT("expected field \'${name}\' is missing")), .data = {0} };')
+		dec.writeln('\t\treturn (${c.result_name}_${styp}){ .is_error = true, .err = _v_error(_SLIT("expected field \'${name}\' is missing")), .data = {0} };')
 		dec.writeln('\t}')
 	}
 }
@@ -897,11 +897,11 @@ fn gen_js_get_opt(dec_name string, field_type string, styp string, tmp string, n
 	is_required bool) {
 	gen_js_get(styp, tmp, name, mut dec, is_required)
 	value_field_type := field_type.replace('*', '_ptr')
-	dec.writeln('\t${result_name}_${value_field_type.replace('*', '_ptr')} ${tmp} = {0};')
+	dec.writeln('\t${c.result_name}_${value_field_type.replace('*', '_ptr')} ${tmp} = {0};')
 	dec.writeln('\tif (jsonroot_${tmp}) {')
 	dec.writeln('\t\t${tmp} = ${dec_name}(jsonroot_${tmp});')
 	dec.writeln('\t\tif (${tmp}.is_error) {')
-	dec.writeln('\t\t\treturn (${result_name}_${styp}){ /*A*/ .is_error = true, .err = ${tmp}.err, .data = {0} };')
+	dec.writeln('\t\t\treturn (${c.result_name}_${styp}){ /*A*/ .is_error = true, .err = ${tmp}.err, .data = {0} };')
 	dec.writeln('\t\t}')
 	dec.writeln('\t}')
 }
@@ -946,7 +946,7 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 			fixed_array_idx_increment += 'fixed_array_idx++;'
 		} else {
 			array_element_assign += 'array_push${noscan}((array*)&res.data, &val);'
-			res_str += '_option_ok(&(${g.base_type(utyp)}[]) { __new_array${noscan}(0, 0, sizeof(${styp})) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));'
+			res_str += '_option_ok(&(${g.base_type(utyp)}[]) { __new_array${noscan}(0, 0, sizeof(${styp})) }, (${c.option_name}*)&res, sizeof(${g.base_type(utyp)}));'
 			array_free_str += 'array_free(&res.data);'
 		}
 	} else {
@@ -966,10 +966,10 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 		s = '${styp} val = ${fn_name}((cJSON *)jsval); '
 	} else {
 		s = '
-		${result_name}_${styp} val2 = ${fn_name} ((cJSON *)jsval);
+		${c.result_name}_${styp} val2 = ${fn_name} ((cJSON *)jsval);
 		if(val2.is_error) {
 			${array_free_str}
-			return *(${result_name}_${ret_styp}*)&val2;
+			return *(${c.result_name}_${ret_styp}*)&val2;
 		}
 		${styp} val = *(${styp}*)val2.data;
 '
@@ -977,7 +977,7 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 
 	return '
 	if(root && !cJSON_IsArray(root) && !cJSON_IsNull(root)) {
-		return (${result_name}_${ret_styp}){.is_error = true, .err = _v_error(string__plus(_SLIT("Json element is not an array: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
+		return (${c.result_name}_${ret_styp}){.is_error = true, .err = _v_error(string__plus(_SLIT("Json element is not an array: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
 	}
 	${res_str}
 	const cJSON *jsval = NULL;
@@ -1034,10 +1034,10 @@ fn (mut g Gen) decode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type,
 		s = '${styp_v} val = ${fn_name_v} (js_get(root, jsval->string));'
 	} else {
 		s = '
-		${result_name}_${ret_styp} val2 = ${fn_name_v} (js_get(root, jsval->string));
+		${c.result_name}_${ret_styp} val2 = ${fn_name_v} (js_get(root, jsval->string));
 		if(val2.is_error) {
 			map_free(&res);
-			return *(${result_name}_${ustyp}*)&val2;
+			return *(${c.result_name}_${ustyp}*)&val2;
 		}
 		${styp_v} val = *(${styp_v}*)val2.data;
 '
@@ -1046,9 +1046,9 @@ fn (mut g Gen) decode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type,
 	if utyp.has_flag(.option) {
 		return '
 		if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-			return (${result_name}_${ustyp}){ .is_error = true, .err = _v_error(string__plus(_SLIT("Json element is not an object: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
+			return (${c.result_name}_${ustyp}){ .is_error = true, .err = _v_error(string__plus(_SLIT("Json element is not an object: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
 		}
-		_option_ok(&(${g.base_type(utyp)}[]) { new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));
+		_option_ok(&(${g.base_type(utyp)}[]) { new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}) }, (${c.option_name}*)&res, sizeof(${g.base_type(utyp)}));
 		cJSON *jsval = NULL;
 		cJSON_ArrayForEach(jsval, root)
 		{
@@ -1060,7 +1060,7 @@ fn (mut g Gen) decode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type,
 	} else {
 		return '
 		if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-			return (${result_name}_${ustyp}){ .is_error = true, .err = _v_error(string__plus(_SLIT("Json element is not an object: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
+			return (${c.result_name}_${ustyp}){ .is_error = true, .err = _v_error(string__plus(_SLIT("Json element is not an object: "), tos2((byteptr)cJSON_PrintUnformatted(root)))), .data = {0}};
 		}
 		res = new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn});
 		cJSON *jsval = NULL;

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -145,7 +145,7 @@ fn (mut g Gen) write_orm_connection_init(connection_var_name string, db_expr &as
 fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, connection_var_name string,
 	result_var_name string) {
 	g.writeln('// sql { create table `${table_name}` }')
-	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_create(')
+	g.writeln('${c.result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_create(')
 	g.indent++
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.writeln('_SLIT("${table_name}"),')
@@ -213,7 +213,7 @@ fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, c
 // write_orm_drop_table writes C code that calls ORM functions for dropping tables.
 fn (mut g Gen) write_orm_drop_table(table_name string, connection_var_name string, result_var_name string) {
 	g.writeln('// sql { drop table `${table_name}` }')
-	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_drop(')
+	g.writeln('${c.result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_drop(')
 	g.indent++
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.writeln('_SLIT("${table_name}")')
@@ -234,7 +234,7 @@ fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connec
 // write_orm_update writes C code that calls ORM functions for updating rows.
 fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string) {
 	g.writeln('// sql { update `${table_name}` }')
-	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_update(')
+	g.writeln('${c.result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_update(')
 	g.indent++
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.writeln('_SLIT("${table_name}"),')
@@ -286,7 +286,7 @@ fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connec
 // write_orm_delete writes C code that calls ORM functions for deleting rows.
 fn (mut g Gen) write_orm_delete(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string) {
 	g.writeln('// sql { delete from `${table_name}` }')
-	g.writeln('${result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method__v_delete(')
+	g.writeln('${c.result_name}_void ${result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method__v_delete(')
 	g.indent++
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.writeln('_SLIT("${table_name}"),')
@@ -367,7 +367,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	}
 
 	g.writeln('// sql { insert into `${table_name}` }')
-	g.writeln('${result_name}_void ${res} = orm__Connection_name_table[${connection_var_name}._typ]._method_insert(')
+	g.writeln('${c.result_name}_void ${res} = orm__Connection_name_table[${connection_var_name}._typ]._method_insert(')
 	g.indent++
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.writeln('_SLIT("${table_name}"),')
@@ -854,7 +854,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 	g.sql_table_name = g.table.sym(node.table_expr.typ).name
 
 	g.writeln('// sql { select from `${table_name}` }')
-	g.writeln('${result_name}_Array_Array_orm__Primitive ${select_result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_select(')
+	g.writeln('${c.result_name}_Array_Array_orm__Primitive ${select_result_var_name} = orm__Connection_name_table[${connection_var_name}._typ]._method_select(')
 	g.indent++
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.writeln('(orm__SelectConfig){')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -135,7 +135,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		if is_ptr && !is_var_mut {
 			ref_str := '&'.repeat(typ.nr_muls())
-			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("${ref_str}"), ${si_s_code} ,{.d_s = isnil(')
+			g.write('str_intp(1, _MOV((StrIntpData[]){{_SLIT("${ref_str}"), ${c.si_s_code} ,{.d_s = isnil(')
 			if typ.has_flag(.option) {
 				g.write('*(${g.base_type(exp_typ)}*)&')
 				if temp_var_needed {

--- a/vlib/v/gen/js/builtin_types.v
+++ b/vlib/v/gen/js/builtin_types.v
@@ -332,7 +332,7 @@ fn (mut g JsGen) gen_builtin_prototype(c BuiltinPrototypeConfig) {
 // generate builtin type definitions, used for casting and methods.
 fn (mut g JsGen) gen_builtin_type_defs() {
 	g.inc_indent()
-	for typ_name in v_types {
+	for typ_name in js.v_types {
 		// TODO: JsDoc
 		match typ_name {
 			'i8', 'i16', 'int', 'int_literal' {

--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -55,7 +55,7 @@ fn (mut g JsGen) js_mname(name_ string) string {
 	mut parts := name.split('.')
 	if !is_js {
 		for i, p in parts {
-			if p in js_reserved {
+			if p in js.js_reserved {
 				parts[i] = 'v_${p}'
 			}
 		}
@@ -311,7 +311,7 @@ fn (mut g JsGen) method_call(node ast.CallExpr) {
 		}
 
 		if final_left_sym.kind == .array {
-			if it.name in special_array_methods {
+			if it.name in js.special_array_methods {
 				g.gen_array_method_call(it)
 				return
 			}
@@ -412,7 +412,7 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 	}
 	print_method := name
 	ret_sym := g.table.sym(it.return_type)
-	if it.language == .js && ret_sym.name in v_types && ret_sym.name != 'void' {
+	if it.language == .js && ret_sym.name in js.v_types && ret_sym.name != 'void' {
 		g.write('new ')
 		g.write(ret_sym.name)
 		g.write('(')
@@ -485,7 +485,7 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 		g.dec_indent()
 		g.write('})()')
 	}
-	if it.language == .js && ret_sym.name in v_types && ret_sym.name != 'void' {
+	if it.language == .js && ret_sym.name in js.v_types && ret_sym.name != 'void' {
 		g.write(')')
 	}
 	g.call_stack.delete_last()

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -272,7 +272,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) stri
 	//	mut eq_fn := $embed_file('fast_deep_equal.js')
 	//	out += eq_fn.data().vstring()
 	//}
-	out += fast_deep_eq_fn
+	out += js.fast_deep_eq_fn
 	/*
 	if pref.is_shared {
 		// Export, through CommonJS, the module of the entry file if `-shared` was passed

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -457,7 +457,7 @@ fn (op JumpOp) amd64() u16 {
 fn (mut c Amd64) cjmp(op JumpOp) i32 {
 	c.g.write16(op.amd64())
 	pos := c.g.pos()
-	c.g.write32(placeholder)
+	c.g.write32(native.placeholder)
 	c.g.println('${op}')
 	return i32(pos)
 }

--- a/vlib/v/gen/native/dos.v
+++ b/vlib/v/gen/native/dos.v
@@ -163,7 +163,7 @@ pub fn (mut g Gen) gen_dos_stub() {
 		0x24,
 	])
 
-	g.pad_to(dos_stub_end)
+	g.pad_to(native.dos_stub_end)
 
 	g.println('')
 	g.println('^^^ DOS Stub')

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -1185,7 +1185,7 @@ fn (mut g Gen) sym_string_table() i32 {
 					// that should be .rel32, not windows-specific
 					g.write32_at(i64(s.pos), pos - s.pos - 4)
 				} else {
-					g.write64_at(i64(s.pos), i64(pos) + base_addr)
+					g.write64_at(i64(s.pos), i64(pos) + native.base_addr)
 				}
 			}
 		}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -94,7 +94,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 		.dollar {
 			match p.peek_tok.kind {
 				.name, .key_struct, .key_enum, .key_interface {
-					if p.peek_tok.lit in comptime_types {
+					if p.peek_tok.lit in parser.comptime_types {
 						node = p.parse_comptime_type()
 					} else {
 						node = p.comptime_call()

--- a/vlib/v/pkgconfig/main.v
+++ b/vlib/v/pkgconfig/main.v
@@ -45,7 +45,7 @@ fn desc(mod string) !string {
 pub fn main(args []string) !&Main {
 	mut fp := flag.new_flag_parser(args)
 	fp.application('pkgconfig')
-	fp.version(version)
+	fp.version(pkgconfig.version)
 	mut m := &Main{
 		opt: parse_options(mut fp)
 	}
@@ -53,7 +53,7 @@ pub fn main(args []string) !&Main {
 	if opt.help {
 		m.res = fp.usage()
 	} else if opt.version {
-		m.res = version
+		m.res = pkgconfig.version
 	} else if opt.listall {
 		mut modules := list()
 		modules.sort()

--- a/vlib/v2/ast/desugar.v
+++ b/vlib/v2/ast/desugar.v
@@ -11,7 +11,7 @@ import v2.token
 pub fn (match_expr &MatchExpr) desugar() Expr {
 	mut if_expr := IfExpr{}
 	for i, branch in match_expr.branches {
-		mut branch_cond := empty_expr
+		mut branch_cond := ast.empty_expr
 		for cond in branch.cond {
 			op := if cond in [Ident, SelectorExpr] { token.Token.key_is } else { token.Token.eq }
 			c := InfixExpr{

--- a/vlib/v2/types/module.v
+++ b/vlib/v2/types/module.v
@@ -14,6 +14,6 @@ pub fn new_module(name string, path string) &Module {
 	return &Module{
 		name:  name
 		path:  path
-		scope: new_scope(universe)
+		scope: new_scope(types.universe)
 	}
 }

--- a/vlib/v2/types/scope.v
+++ b/vlib/v2/types/scope.v
@@ -141,7 +141,7 @@ pub fn (obj &Object) typ() Type {
 		Module {
 			// TODO:
 			println('#### got Module')
-			return Type(u16_)
+			return Type(types.u16_)
 		}
 		SmartCastSelector {
 			return obj.origin

--- a/vlib/v2/types/types.v
+++ b/vlib/v2/types/types.v
@@ -259,7 +259,7 @@ fn (t Type) key_type() Type {
 		// Array, ArrayFixed, String, Struct { return int_ }
 		// else { panic('TODO: should never be called on ${t.type_name()}') }
 		// TODO: see checker ForStmt -> ForInStmt when value is pointer
-		else { return int_ }
+		else { return types.int_ }
 	}
 }
 
@@ -270,7 +270,7 @@ fn (t Type) value_type() Type {
 		Channel { return t.elem_type or { t } } // TODO: ?
 		Map { return t.value_type }
 		Pointer { return t.base_type.value_type() }
-		String { return u8_ }
+		String { return types.u8_ }
 		Thread { return t.elem_type or { t } } // TODO: ?
 		OptionType, ResultType { return t.base_type.value_type() }
 		else { return t.base_type() }

--- a/vlib/veb/context.v
+++ b/vlib/veb/context.v
@@ -93,7 +93,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, response strin
 	ctx.res.body = response
 	$if veb_livereload ? {
 		if mimetype == 'text/html' {
-			ctx.res.body = response.replace('</html>', '<script src="/veb_livereload/${veb_livereload_server_start}/script.js"></script>\n</html>')
+			ctx.res.body = response.replace('</html>', '<script src="/veb_livereload/${veb.veb_livereload_server_start}/script.js"></script>\n</html>')
 		}
 	}
 
@@ -159,7 +159,7 @@ pub fn (mut ctx Context) file(file_path string) Result {
 		if ct := ctx.custom_mime_types[ext] {
 			content_type = ct
 		} else {
-			content_type = mime_types[ext]
+			content_type = veb.mime_types[ext]
 		}
 	}
 

--- a/vlib/veb/static_handler.v
+++ b/vlib/veb/static_handler.v
@@ -107,7 +107,7 @@ pub fn (mut sh StaticHandler) host_serve_static(host string, url string, file_pa
 	ext := os.file_ext(file_path)
 
 	// Rudimentary guard against adding files not in mime_types.
-	if ext !in sh.static_mime_types && ext !in mime_types {
+	if ext !in sh.static_mime_types && ext !in veb.mime_types {
 		return error('unknown MIME type for file extension "${ext}". You can register your MIME type in `app.static_mime_types`')
 	}
 	sh.static_files[url] = file_path

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -235,7 +235,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 	}
 	$if vweb_livereload ? {
 		if mimetype == 'text/html' {
-			resp.body = res.replace('</html>', '<script src="/vweb_livereload/${vweb_livereload_server_start}/script.js"></script>\n</html>')
+			resp.body = res.replace('</html>', '<script src="/vweb_livereload/${vweb.vweb_livereload_server_start}/script.js"></script>\n</html>')
 		}
 	}
 	// build the header after the potential modification of resp.body from above

--- a/vlib/x/crypto/chacha20/chacha_test.v
+++ b/vlib/x/crypto/chacha20/chacha_test.v
@@ -86,7 +86,7 @@ fn test_chacha20_simple_block_function() ! {
 	nonce := '000000090000004a00000000'
 	nonce_bytes := hex.decode(nonce)!
 
-	mut block := []u8{len: block_size}
+	mut block := []u8{len: chacha20.block_size}
 	mut cs := new_cipher(key_bytes, nonce_bytes)!
 	cs.set_counter(u32(1))
 	cs.chacha20_block()
@@ -113,7 +113,7 @@ fn test_chacha20_onetime_poly1305_key_generation() ! {
 
 		otk := hex.decode(v.otk)!
 		mut c := new_cipher(key, nonce)!
-		mut out := []u8{len: key_size}
+		mut out := []u8{len: chacha20.key_size}
 		c.xor_key_stream(mut out, out)
 
 		assert out == otk

--- a/vlib/x/crypto/chacha20/xchacha.v
+++ b/vlib/x/crypto/chacha20/xchacha.v
@@ -15,17 +15,17 @@ const h_nonce_size = 16
 @[direct_array_access]
 fn xchacha20(key []u8, nonce []u8) ![]u8 {
 	// early bound check
-	if key.len != key_size {
+	if key.len != chacha20.key_size {
 		return error('xchacha: Bad key size')
 	}
 	if nonce.len != chacha20.h_nonce_size {
 		return error('xchacha: Bad nonce size')
 	}
 	// initializes ChaCha20 state
-	mut x0 := cc0
-	mut x1 := cc1
-	mut x2 := cc2
-	mut x3 := cc3
+	mut x0 := chacha20.cc0
+	mut x1 := chacha20.cc1
+	mut x2 := chacha20.cc2
+	mut x3 := chacha20.cc3
 
 	mut x4 := binary.little_endian_u32(key[0..4])
 	mut x5 := binary.little_endian_u32(key[4..8])
@@ -83,7 +83,7 @@ fn xchacha20_encrypt(key []u8, nonce []u8, plaintext []u8) ![]u8 {
 
 fn xchacha20_encrypt_with_counter(key []u8, nonce []u8, ctr u32, plaintext []u8) ![]u8 {
 	// bound check elimination
-	_ = nonce[x_nonce_size - 1]
+	_ = nonce[chacha20.x_nonce_size - 1]
 	subkey := xchacha20(key, nonce[0..16])!
 	mut cnonce := nonce[16..24].clone()
 

--- a/vlib/x/crypto/chacha20poly1305/chacha20poly1305_test.v
+++ b/vlib/x/crypto/chacha20poly1305/chacha20poly1305_test.v
@@ -22,7 +22,7 @@ fn test_encrypt_example_test() ! {
 	mut cs := chacha20.new_cipher(key, nonce)!
 
 	// and then performing Chacha20 block function
-	mut polykey := []u8{len: key_size}
+	mut polykey := []u8{len: chacha20poly1305.key_size}
 	cs.xor_key_stream(mut polykey, polykey)
 
 	assert polykey == exp_onetime_key
@@ -32,8 +32,8 @@ fn test_encrypt_example_test() ! {
 
 	cipherout := c.encrypt(plaintext, nonce, aad)!
 	// cipherout is concatenation of ciphertext and overhead (tag) bytes
-	ciphertext := cipherout[0..cipherout.len - tag_size]
-	mac := cipherout[cipherout.len - tag_size..]
+	ciphertext := cipherout[0..cipherout.len - chacha20poly1305.tag_size]
+	mac := cipherout[cipherout.len - chacha20poly1305.tag_size..]
 
 	assert ciphertext == exp_ciphertext
 	assert mac == expected_tag
@@ -57,7 +57,7 @@ fn test_aead_decrypt_vector_test_51() ! {
 	mut cs := chacha20.new_cipher(key, nonce)!
 
 	// and then performing Chacha20 block function
-	mut polykey := []u8{len: key_size}
+	mut polykey := []u8{len: chacha20poly1305.key_size}
 	cs.xor_key_stream(mut polykey, polykey)
 
 	expected_otk := hex.decode('bdf04aa95ce4de8995b14bb6a18fecaf26478f50c054f563dbc0a21e261572aa')!
@@ -65,7 +65,7 @@ fn test_aead_decrypt_vector_test_51() ! {
 
 	constructed_msg := hex.decode('f33388860000000000004e910000000064a0861575861af460f062c79be643bd5e805cfd345cf389f108670ac76c8cb24c6cfc18755d43eea09ee94e382d26b0bdb7b73c321b0100d4f03b7f355894cf332f830e710b97ce98c8a84abd0b948114ad176e008d33bd60f982b1ff37c8559797a06ef4f0ef61c186324e2b3506383606907b6a7c02b0f9f6157b53c867e4b9166c767b804d46a59b5216cde7a4e99040c5a40433225ee282a1b0a06c523eaf4534d7f83fa1155b0047718cbc546a0d072b04b3564eea1b422273f548271a0bb2316053fa76991955ebd63159434ecebb4e466dae5a1073a6727627097a1049e617d91d361094fa68f0ff77987130305beaba2eda04df997b714d6c6f2c29a6ad5cb4022b02709b000000000000000c000000000000000901000000000000')!
 
-	mut mac := []u8{len: tag_size}
+	mut mac := []u8{len: chacha20poly1305.tag_size}
 	poly1305.create_tag(mut mac, constructed_msg, polykey)!
 	assert mac == expected_tag
 

--- a/vlib/x/crypto/poly1305/poly1305.v
+++ b/vlib/x/crypto/poly1305/poly1305.v
@@ -216,7 +216,7 @@ fn poly1305_update_block(mut po Poly1305, msg []u8) {
 fn (mut po Poly1305) reset() {
 	po.r = unsigned.uint128_zero
 	po.s = unsigned.uint128_zero
-	po.h = uint192_zero
+	po.h = poly1305.uint192_zero
 	po.leftover = 0
 	unsafe {
 		po.buffer.reset()

--- a/vlib/x/crypto/poly1305/poly1305_test.v
+++ b/vlib/x/crypto/poly1305/poly1305_test.v
@@ -41,7 +41,7 @@ fn test_incremental_update_ported_from_poly1305donna() ! {
 		0x62, 0x3d, 0x39]
 
 	// poly1305_auth(mac, nacl_msg, sizeof(nacl_msg), nacl_key);
-	mut mac := []u8{len: tag_size}
+	mut mac := []u8{len: poly1305.tag_size}
 	create_tag(mut mac, nacl_msg, nacl_key)!
 	assert mac == nacl_mac
 	// result &= poly1305_verify(nacl_mac, mac);
@@ -63,7 +63,7 @@ fn test_incremental_update_ported_from_poly1305donna() ! {
 	// poly1305_finish(&ctx, mac);
 	//	result &= poly1305_verify(nacl_mac, mac);
 	mut po := new(nacl_key)!
-	mut tag := []u8{len: tag_size}
+	mut tag := []u8{len: poly1305.tag_size}
 
 	po.update(nacl_msg)
 	po.finish(mut tag)
@@ -95,7 +95,7 @@ fn test_incremental_update_ported_from_poly1305donna() ! {
 
 	// poly1305_init(&total_ctx, total_key);
 	dump(total_key.len)
-	mut tkey := []u8{len: key_size}
+	mut tkey := []u8{len: poly1305.key_size}
 	_ := copy(mut tkey, total_key)
 	mut ptot := new(tkey)!
 	mut all_key := []u8{len: 32}
@@ -120,7 +120,7 @@ fn test_poly1305_with_smoked_messages_are_working_normally() ! {
 	// generates smoked message with full bits is set
 	msg := u8(0xff).repeat(135).bytes()
 	// msg = ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-	mut tag := []u8{len: tag_size}
+	mut tag := []u8{len: poly1305.tag_size}
 	create_tag(mut tag, msg, key)!
 
 	// lets verify its working normally
@@ -136,7 +136,7 @@ fn test_poly1305_core_rfc_vector_tests() ! {
 		msg := hex.decode(c.msg) or { panic(err.msg()) }
 		expected_tag := hex.decode(c.tag) or { panic(err.msg()) }
 
-		mut tag := []u8{len: tag_size}
+		mut tag := []u8{len: poly1305.tag_size}
 
 		// check for instance based method
 		mut po := new(key)!
@@ -163,7 +163,7 @@ fn test_poly1305_function_based_core_functionality() ! {
 		mut msg := hex.decode(c.msg) or { panic(err.msg()) }
 
 		expected_tag := hex.decode(c.tag) or { panic(err.msg()) }
-		mut tag := []u8{len: tag_size}
+		mut tag := []u8{len: poly1305.tag_size}
 
 		mut po := new(key)!
 
@@ -198,7 +198,7 @@ fn test_poly1305_smoked_data_vectors() ! {
 			// set with accumulator s
 			poly.h = s
 		}
-		mut tag := []u8{len: tag_size}
+		mut tag := []u8{len: poly1305.tag_size}
 
 		poly.update(msg)
 		poly.finish(mut tag)

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -437,7 +437,7 @@ fn (mut p Parser) decode_value() !Any {
 		.null {
 			p.next_with_err()!
 			if p.convert_type {
-				return Any(null)
+				return Any(json2.null)
 			}
 			return Any('null')
 		}

--- a/vlib/x/json2/scanner_test.v
+++ b/vlib/x/json2/scanner_test.v
@@ -40,7 +40,7 @@ fn test_str_invalid_escape() {
 }
 
 fn test_str_invalid_must_be_escape() {
-	for ch in important_escapable_chars {
+	for ch in json2.important_escapable_chars {
 		mut sc := Scanner{
 			text: [u8(`"`), `t`, ch, `"`]
 		}

--- a/vlib/x/templating/dtm/dynamic_template_manager_cache_system_test.v
+++ b/vlib/x/templating/dtm/dynamic_template_manager_cache_system_test.v
@@ -47,7 +47,7 @@ fn test_check_and_clear_cache_files() {
 }
 
 fn test_create_template_cache_and_display() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)
+	mut dtmi := init_dtm(true, dtm.max_size_data_in_memory)
 	defer {
 		dtmi.stop_cache_handler()
 	}
@@ -56,7 +56,7 @@ fn test_create_template_cache_and_display() {
 }
 
 fn test_get_cache() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)
+	mut dtmi := init_dtm(true, dtm.max_size_data_in_memory)
 	dtmi.create_cache()
 	defer {
 		dtmi.stop_cache_handler()
@@ -88,7 +88,7 @@ fn test_chandler_clear_specific_cache() {
 }
 
 fn test_handle_dtm_clock() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)
+	mut dtmi := init_dtm(true, dtm.max_size_data_in_memory)
 	defer {
 		dtmi.stop_cache_handler()
 	}
@@ -97,7 +97,7 @@ fn test_handle_dtm_clock() {
 }
 
 fn test_cache_handler() {
-	mut dtmi := init_dtm(true, max_size_data_in_memory)
+	mut dtmi := init_dtm(true, dtm.max_size_data_in_memory)
 	defer {
 		dtmi.stop_cache_handler()
 	}

--- a/vlib/x/templating/dtm/tmpl.v
+++ b/vlib/x/templating/dtm/tmpl.v
@@ -84,8 +84,8 @@ fn replace_placeholders_with_data(line string, data &map[string]DtmMultiTypeMap,
 	for key, value in data {
 		mut placeholder := '$${key}'
 
-		if placeholder.ends_with(include_html_key_tag) {
-			placeholder = placeholder.all_before_last(include_html_key_tag)
+		if placeholder.ends_with(dtm.include_html_key_tag) {
+			placeholder = placeholder.all_before_last(dtm.include_html_key_tag)
 			need_include_html = true
 		}
 		if !rline.contains(placeholder) {
@@ -105,7 +105,7 @@ fn replace_placeholders_with_data(line string, data &map[string]DtmMultiTypeMap,
 				if need_include_html {
 					if state == State.html {
 						// Iterates over allowed HTML tags for inclusion
-						for tag in allowed_tags {
+						for tag in dtm.allowed_tags {
 							// Escapes the HTML tag
 							escaped_tag := filter(tag)
 							// Replaces the escaped tags with actual HTML tags in the value
@@ -154,8 +154,8 @@ fn insert_template_code(fn_name string, tmpl_str_start string, line string, data
 // compile_file compiles the content of a file by the given path as a template
 fn compile_template_file(template_file string, fn_name string, data &map[string]DtmMultiTypeMap) string {
 	mut lines := os.read_lines(template_file) or {
-		eprintln('${message_signature_error} Template generator can not reading from ${template_file} file')
-		return internat_server_error
+		eprintln('${dtm.message_signature_error} Template generator can not reading from ${template_file} file')
+		return dtm.internat_server_error
 	}
 
 	basepath := os.dir(template_file)
@@ -186,12 +186,12 @@ fn compile_template_file(template_file string, fn_name string, data &map[string]
 		}
 		if line.contains('@header') {
 			position := line.index('@header') or { 0 }
-			eprintln("${message_signature_warn} Please use @include 'header' instead of @header (deprecated), position : ${position}")
+			eprintln("${dtm.message_signature_warn} Please use @include 'header' instead of @header (deprecated), position : ${position}")
 			continue
 		}
 		if line.contains('@footer') {
 			position := line.index('@footer') or { 0 }
-			eprintln("${message_signature_warn} Please use @include 'footer' instead of @footer (deprecated), position : ${position}")
+			eprintln("${dtm.message_signature_warn} Please use @include 'footer' instead of @footer (deprecated), position : ${position}")
 			continue
 		}
 		if line.contains('@include ') {
@@ -204,8 +204,8 @@ fn compile_template_file(template_file string, fn_name string, data &map[string]
 			} else {
 				s := '@include '
 				position := line.index(s) or { 0 }
-				eprintln("${message_signature_error} path for @include must be quoted with ' or \" without line breaks or extraneous characters between @include and the quotes, position : ${position}")
-				return internat_server_error
+				eprintln("${dtm.message_signature_error} path for @include must be quoted with ' or \" without line breaks or extraneous characters between @include and the quotes, position : ${position}")
+				return dtm.internat_server_error
 			}
 			mut file_ext := os.file_ext(file_name)
 			if file_ext == '' {
@@ -224,8 +224,8 @@ fn compile_template_file(template_file string, fn_name string, data &map[string]
 			}
 			file_content := os.read_file(file_path) or {
 				position := line.index('@include ') or { 0 } + '@include '.len
-				eprintln('${message_signature_error} Reading @include file "${file_name}" from path: ${file_path} failed, position : ${position}')
-				return internat_server_error
+				eprintln('${dtm.message_signature_error} Reading @include file "${file_name}" from path: ${file_path} failed, position : ${position}')
+				return dtm.internat_server_error
 			}
 
 			file_splitted := file_content.split_into_lines().reverse()

--- a/vlib/x/vweb/context.v
+++ b/vlib/x/vweb/context.v
@@ -93,7 +93,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, response strin
 	ctx.res.body = response
 	$if vweb_livereload ? {
 		if mimetype == 'text/html' {
-			ctx.res.body = response.replace('</html>', '<script src="/vweb_livereload/${vweb_livereload_server_start}/script.js"></script>\n</html>')
+			ctx.res.body = response.replace('</html>', '<script src="/vweb_livereload/${vweb.vweb_livereload_server_start}/script.js"></script>\n</html>')
 		}
 	}
 
@@ -159,7 +159,7 @@ pub fn (mut ctx Context) file(file_path string) Result {
 		if ct := ctx.custom_mime_types[ext] {
 			content_type = ct
 		} else {
-			content_type = mime_types[ext]
+			content_type = vweb.mime_types[ext]
 		}
 	}
 

--- a/vlib/x/vweb/static_handler.v
+++ b/vlib/x/vweb/static_handler.v
@@ -107,7 +107,7 @@ pub fn (mut sh StaticHandler) host_serve_static(host string, url string, file_pa
 	ext := os.file_ext(file_path)
 
 	// Rudimentary guard against adding files not in mime_types.
-	if ext !in sh.static_mime_types && ext !in mime_types {
+	if ext !in sh.static_mime_types && ext !in vweb.mime_types {
 		return error('unknown MIME type for file extension "${ext}". You can register your MIME type in `app.static_mime_types`')
 	}
 	sh.static_files[url] = file_path


### PR DESCRIPTION
This PR fix const name was not prefixed with module name (fix #14400).

- Fix const name was not prefixed with module name.
- Add test.

```v
module tt1

const full_name = 'Robert the Tomato'

fn print_full_name() {
	println(tt1.full_name)
	println(tt1.full_name)
}

fn print_name() {
	println(tt1.name)
	println(tt1.name)
}
```
```v
module tt1

const name = 'Bob'
```