### PR TITLE
ast: fix const field str()

### DIFF
--- a/vlib/encoding/csv/csv_reader_random_access.v
+++ b/vlib/encoding/csv/csv_reader_random_access.v
@@ -56,9 +56,9 @@ pub mut:
 
 	end_line      u8  = `\n`
 	end_line_len  int = endline_cr_len // size of the endline rune \n = 1, \r\n = 2
-	separator     u8  = `,`                // comma is the default separator
-	separator_len int = 1                  // size of the separator rune
-	quote         u8  = `"`                // double quote is the standard quote char
+	separator     u8  = `,`            // comma is the default separator
+	separator_len int = 1              // size of the separator rune
+	quote         u8  = `"`            // double quote is the standard quote char
 	quote_remove  bool // if true clear the cell from the quotes
 	comment       u8 = `#` // every line that start with the quote char is ignored
 
@@ -92,7 +92,7 @@ pub:
 	default_cell string = '*' // return this string if out of the csv boundaries
 	empty_cell   string // return this string if empty cell
 	end_line_len int = endline_cr_len // size of the endline rune
-	quote        u8  = `"`                // double quote is the standard quote char
+	quote        u8  = `"`            // double quote is the standard quote char
 	quote_remove bool // if true clear the cell from the quotes
 }
 

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -17,7 +17,7 @@ pub const max_headers = 50
 pub struct Header {
 pub mut:
 	// data map[string][]string
-	data [http.max_headers]HeaderKV
+	data [max_headers]HeaderKV
 mut:
 	cur_pos int
 	// map of lowercase header keys to their original keys

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -769,7 +769,7 @@ pub const sg_max_mipmaps = 16
 
 pub struct C.sg_image_data {
 pub mut:
-	subimage [gfx.sg_cubeface_num][gfx.sg_max_mipmaps]Range
+	subimage [sg_cubeface_num][sg_max_mipmaps]Range
 }
 
 pub type ImageData = C.sg_image_data

--- a/vlib/sokol/sapp/sapp_structs.c.v
+++ b/vlib/sokol/sapp/sapp_structs.c.v
@@ -29,7 +29,7 @@ pub type ImageDesc = C.sapp_image_desc
 pub struct C.sapp_icon_desc {
 pub:
 	sokol_default bool
-	images        [sapp.max_iconimages]ImageDesc
+	images        [max_iconimages]ImageDesc
 }
 
 pub type IconDesc = C.sapp_icon_desc
@@ -89,25 +89,25 @@ pub type Desc = C.sapp_desc
 @[typedef]
 pub struct C.sapp_event {
 pub:
-	frame_count        u64                              // current frame counter, always valid, useful for checking if two events were issued in the same frame
-	@type              EventType                        // the event type, always valid
-	key_code           KeyCode                          // the virtual key code, only valid in KEY_UP, KEY_DOWN
-	char_code          u32                              // the UTF-32 character code, only valid in CHAR events
-	key_repeat         bool                             // true if this is a key-repeat event, valid in KEY_UP, KEY_DOWN and CHAR
-	modifiers          u32                              // current modifier keys, valid in all key-, char- and mouse-events
-	mouse_button       MouseButton                      // mouse button that was pressed or released, valid in MOUSE_DOWN, MOUSE_UP
-	mouse_x            f32                              // current horizontal mouse position in pixels, always valid except during mouse lock
-	mouse_y            f32                              // current vertical mouse position in pixels, always valid except during mouse lock
-	mouse_dx           f32                              // relative horizontal mouse movement since last frame, always valid
-	mouse_dy           f32                              // relative vertical mouse movement since last frame, always valid
-	scroll_x           f32                              // horizontal mouse wheel scroll distance, valid in MOUSE_SCROLL events
-	scroll_y           f32                              // vertical mouse wheel scroll distance, valid in MOUSE_SCROLL events
-	num_touches        int                              // number of valid items in the touches[] array
-	touches            [sapp.max_touchpoints]TouchPoint // current touch points, valid in TOUCHES_BEGIN, TOUCHES_MOVED, TOUCHES_ENDED
-	window_width       int // current window- and framebuffer width in pixels, always valid
-	window_height      int // current window- and framebuffer height in pixels, always valid
-	framebuffer_width  int // = window_width * dpi_scale
-	framebuffer_height int // = window_height * dpi_scale
+	frame_count        u64                         // current frame counter, always valid, useful for checking if two events were issued in the same frame
+	@type              EventType                   // the event type, always valid
+	key_code           KeyCode                     // the virtual key code, only valid in KEY_UP, KEY_DOWN
+	char_code          u32                         // the UTF-32 character code, only valid in CHAR events
+	key_repeat         bool                        // true if this is a key-repeat event, valid in KEY_UP, KEY_DOWN and CHAR
+	modifiers          u32                         // current modifier keys, valid in all key-, char- and mouse-events
+	mouse_button       MouseButton                 // mouse button that was pressed or released, valid in MOUSE_DOWN, MOUSE_UP
+	mouse_x            f32                         // current horizontal mouse position in pixels, always valid except during mouse lock
+	mouse_y            f32                         // current vertical mouse position in pixels, always valid except during mouse lock
+	mouse_dx           f32                         // relative horizontal mouse movement since last frame, always valid
+	mouse_dy           f32                         // relative vertical mouse movement since last frame, always valid
+	scroll_x           f32                         // horizontal mouse wheel scroll distance, valid in MOUSE_SCROLL events
+	scroll_y           f32                         // vertical mouse wheel scroll distance, valid in MOUSE_SCROLL events
+	num_touches        int                         // number of valid items in the touches[] array
+	touches            [max_touchpoints]TouchPoint // current touch points, valid in TOUCHES_BEGIN, TOUCHES_MOVED, TOUCHES_ENDED
+	window_width       int                         // current window- and framebuffer width in pixels, always valid
+	window_height      int                         // current window- and framebuffer height in pixels, always valid
+	framebuffer_width  int                         // = window_width * dpi_scale
+	framebuffer_height int                         // = window_height * dpi_scale
 }
 
 pub type Event = C.sapp_event

--- a/vlib/term/termios/termios_android.c.v
+++ b/vlib/term/termios/termios_android.c.v
@@ -26,7 +26,7 @@ mut:
 	c_cflag  TcFlag
 	c_lflag  TcFlag
 	c_line   Cc
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }
@@ -58,7 +58,7 @@ pub mut:
 	c_cflag  TcFlag
 	c_lflag  TcFlag
 	c_line   Cc
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }

--- a/vlib/term/termios/termios_darwin.c.v
+++ b/vlib/term/termios/termios_darwin.c.v
@@ -25,7 +25,7 @@ mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }
@@ -56,7 +56,7 @@ pub mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }

--- a/vlib/term/termios/termios_dragonfly.c.v
+++ b/vlib/term/termios/termios_dragonfly.c.v
@@ -25,7 +25,7 @@ mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }
@@ -56,7 +56,7 @@ pub mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }

--- a/vlib/term/termios/termios_freebsd.c.v
+++ b/vlib/term/termios/termios_freebsd.c.v
@@ -25,7 +25,7 @@ mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }
@@ -56,7 +56,7 @@ pub mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }

--- a/vlib/term/termios/termios_linux.c.v
+++ b/vlib/term/termios/termios_linux.c.v
@@ -26,7 +26,7 @@ mut:
 	c_cflag  TcFlag
 	c_lflag  TcFlag
 	c_line   Cc
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }
@@ -58,7 +58,7 @@ pub mut:
 	c_cflag  TcFlag
 	c_lflag  TcFlag
 	c_line   Cc
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }

--- a/vlib/term/termios/termios_openbsd.c.v
+++ b/vlib/term/termios/termios_openbsd.c.v
@@ -25,7 +25,7 @@ mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }
@@ -56,7 +56,7 @@ pub mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	c_ispeed Speed
 	c_ospeed Speed
 }

--- a/vlib/term/termios/termios_qnx.c.v
+++ b/vlib/term/termios/termios_qnx.c.v
@@ -25,7 +25,7 @@ mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	reserved [3]u32
 	c_ispeed Speed
 	c_ospeed Speed
@@ -57,7 +57,7 @@ pub mut:
 	c_oflag  TcFlag
 	c_cflag  TcFlag
 	c_lflag  TcFlag
-	c_cc     [termios.cclen]Cc
+	c_cc     [cclen]Cc
 	reserved [3]u32
 	c_ispeed Speed
 	c_ospeed Speed

--- a/vlib/term/termios/termios_solaris.c.v
+++ b/vlib/term/termios/termios_solaris.c.v
@@ -25,7 +25,7 @@ mut:
 	c_oflag TcFlag
 	c_cflag TcFlag
 	c_lflag TcFlag
-	c_cc    [termios.cclen]Cc
+	c_cc    [cclen]Cc
 }
 
 fn C.tcgetattr(fd int, termios_p &C.termios) int
@@ -54,7 +54,7 @@ pub mut:
 	c_oflag TcFlag
 	c_cflag TcFlag
 	c_lflag TcFlag
-	c_cc    [termios.cclen]Cc
+	c_cc    [cclen]Cc
 }
 
 // tcgetattr is an unsafe wrapper around C.termios and keeps its semantic

--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -17,7 +17,7 @@ struct ExtraContext {
 mut:
 	stdin_handle  C.HANDLE
 	stdout_handle C.HANDLE
-	read_buf      [ui.buf_size]C.INPUT_RECORD
+	read_buf      [buf_size]C.INPUT_RECORD
 	mouse_down    MouseButton
 }
 

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -518,15 +518,6 @@ pub fn (x &Expr) str() string {
 			if x.cached_name != '' {
 				return x.cached_name
 			}
-			if obj := x.scope.find('${x.mod}.${x.name}') {
-				if obj is ConstField && x.mod != 'main' {
-					last_mod := x.mod.all_after_last('.')
-					unsafe {
-						x.cached_name = '${last_mod}.${x.name}'
-					}
-					return x.cached_name
-				}
-			}
 			unsafe {
 				x.cached_name = x.name.clone()
 			}

--- a/vlib/v/fmt/tests/struct_decl_with_const_default_value_and_comments_keep.vv
+++ b/vlib/v/fmt/tests/struct_decl_with_const_default_value_and_comments_keep.vv
@@ -11,9 +11,9 @@ pub mut:
 
 	end_line      u8  = `\n`
 	end_line_len  int = endline_cr_len // size of the endline rune \n = 1, \r\n = 2
-	separator     u8  = `,`                // comma is the default separator
-	separator_len int = 1                  // size of the separator rune
-	quote         u8  = `"`                // double quote is the standard quote char
+	separator     u8  = `,`            // comma is the default separator
+	separator_len int = 1              // size of the separator rune
+	quote         u8  = `"`            // double quote is the standard quote char
 	quote_remove  bool // if true clear the cell from the quotes
 	comment       u8 = `#` // every line that start with the quote char is ignored
 

--- a/vlib/v/gen/native/pe.v
+++ b/vlib/v/gen/native/pe.v
@@ -372,8 +372,8 @@ struct PeDataDir {
 
 struct PeDataDirs {
 mut:
-	debugnames [native.pe_num_data_dirs]string
-	dirs       [native.pe_num_data_dirs]PeDataDir
+	debugnames [pe_num_data_dirs]string
+	dirs       [pe_num_data_dirs]PeDataDir
 	base_addr  i64
 }
 


### PR DESCRIPTION
This PR fix const field str().

- Fix const field str().
- Modify a fmt test.

```v
module foo

pub const endline_cr_len = 1

pub struct RandomAccessReader {
pub mut:
	index i64

	start_index i64
	end_index   i64 = -1

	end_line      u8  = `\n`
	end_line_len  int = endline_cr_len // size of the endline rune \n = 1, \r\n = 2
	separator     u8  = `,`            // comma is the default separator
	separator_len int = 1              // size of the separator rune
	quote         u8  = `"`            // double quote is the standard quote char
	quote_remove  bool // if true clear the cell from the quotes
	comment       u8 = `#` // every line that start with the quote char is ignored

	default_cell string = '*' // return this string if out of the csv boundaries
	empty_cell   string = '#' // retunrn this if empty cell
	// ram buffer
	mem_buf_type  u32     // buffer type 0=File,1=RAM
	mem_buf       voidptr // buffer used to load chars from file
	mem_buf_size  i64     // size of the buffer
	mem_buf_start i64 = -1 // start index in the file of the read buffer
	mem_buf_end   i64 = -1 // end index in the file of the read buffer
	// csv map for quick access
	csv_map [][]i64
	// header
	header_row  int = -1 // row index of the header in the csv_map
	header_list []HeaderItem   // list of the header item
	header_map  map[string]int // map from header label to column index
}
```