### PR TITLE
cgen: fix match with mut cond variable (fix #22201)

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -491,7 +491,8 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 						g.write(')')
 					}
 					.string {
-						g.write('string__eq(${cond_var}, ')
+						ptr_str := if node.cond_type.is_ptr() { '*' } else { '' }
+						g.write('string__eq(${ptr_str}${cond_var}, ')
 						g.expr(expr)
 						g.write(')')
 					}

--- a/vlib/v/tests/conditions/matches/match_with_mut_cond_var_test.v
+++ b/vlib/v/tests/conditions/matches/match_with_mut_cond_var_test.v
@@ -1,0 +1,10 @@
+fn test_match_with_mut_cond_var() {
+	mut aaa := []string{}
+	for mut ccc in aaa {
+		match ccc {
+			'/' {}
+			else {}
+		}
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix match with mut cond variable (fix #22201).

- Fix match with mut cond variable.
- Add test.

```v
fn main() {
	mut aaa := ['/', 'a', 'b']
	for mut ccc in aaa {
		match ccc {
			'/' { println(ccc) }
			else { println(ccc) }
		}
	}
}

PS D:\Test\v\tt1> v run .    
/
a
b
```