### PR TITLE
fmt: fix import selective with interface implements (fix #22200)

### DIFF
--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -38,6 +38,7 @@ pub fn (mut f Fmt) struct_decl(node ast.StructDecl, is_anon bool) {
 			if i < node.implements_types.len - 1 {
 				f.write(', ')
 			}
+			f.mark_types_import_as_used(t)
 		}
 	}
 	// Calculate the alignments first

--- a/vlib/v/fmt/tests/import_selective_with_implements_keep.vv
+++ b/vlib/v/fmt/tests/import_selective_with_implements_keep.vv
@@ -1,0 +1,10 @@
+import v.ast.walker { Visitor }
+import v.ast { Node }
+
+struct Walker implements Visitor {
+	aaa string
+}
+
+fn (mut n Walker) visit(node &Node) ! {
+	panic('not implemented')
+}


### PR DESCRIPTION
This PR fix import selective with interface implements (fix #22200).

- Fix import selective with interface implements.
- Add test.

vlib\v\fmt\tests\import_selective_with_implements_keep.vv
```v
import v.ast.walker { Visitor }
import v.ast { Node }

struct Walker implements Visitor {
	aaa string
}

fn (mut n Walker) visit(node &Node) ! {
	panic('not implemented')
}
```