### PR TITLE
test: add a test for short enum syntax across modules (related #12183)

### DIFF
--- a/examples/http_server.v
+++ b/examples/http_server.v
@@ -7,7 +7,7 @@ struct ExampleHandler {}
 fn (h ExampleHandler) handle(req Request) Response {
 	mut res := Response{
 		header: http.new_header_from_map({
-			CommonHeader.content_type: 'text/plain'
+			.content_type: 'text/plain'
 		})
 	}
 	mut status_code := 200

--- a/examples/http_server.v
+++ b/examples/http_server.v
@@ -1,6 +1,6 @@
 module main
 
-import net.http { CommonHeader, Request, Response, Server }
+import net.http { Request, Response, Server }
 
 struct ExampleHandler {}
 

--- a/vlib/v/tests/enums/short_enum_syntax_across_module_test.v
+++ b/vlib/v/tests/enums/short_enum_syntax_across_module_test.v
@@ -1,0 +1,10 @@
+import net.http
+
+fn test_short_enum_syntax_across_module() {
+	header := http.new_header_from_map({
+		.content_type: 'application/json'
+	})
+
+	println(header)
+	assert true
+}

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -240,8 +240,8 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, res string) bo
 	}
 	// build the header after the potential modification of resp.body from above
 	header := http.new_header_from_map({
-		http.CommonHeader.content_type:   mimetype
-		http.CommonHeader.content_length: resp.body.len.str()
+		.content_type:   mimetype
+		.content_length: resp.body.len.str()
 	}).join(ctx.header)
 	resp.header = header.join(headers_close)
 


### PR DESCRIPTION
This PR add a test for short enum syntax across modules (related #12183).

- Add a test for short enum syntax across modules.
- Modify all the related files.

```v
import net.http

fn main() {
	header := http.new_header_from_map({
		.content_type: 'application/json'
	})

	println(header)
}

PS D:\Test\v\tt1> v run .       
Content-Type: application/json
```