### PR TITLE
fmt: add a test for fn with c binding type args (related #13233)

### DIFF
--- a/vlib/v/fmt/tests/fn_with_c_binding_type_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_c_binding_type_args_keep.vv
@@ -1,0 +1,1 @@
+fn C.archive_entry_copy_stat(&C.archive_entry, const_stat &C.stat)


### PR DESCRIPTION
This PR add a test for fn with c binding type args (related #13233).

```v
fn C.archive_entry_copy_stat(&C.archive_entry, const_stat &C.stat)
```