### PR TITLE
crypto/scrypt: add missing comment of source for test vector

### DIFF
--- a/vlib/crypto/scrypt/scrypt_test.v
+++ b/vlib/crypto/scrypt/scrypt_test.v
@@ -203,6 +203,9 @@ struct ScryptTestData {
 	expected_result []u8
 }
 
+// The scrypt test vectors are taken from
+// [RFC7914](https://datatracker.ietf.org/doc/html/rfc7914#section-12)
+// section 12.
 const scrypt_test_cases = [
 	ScryptTestData{
 		name:            'test case 1'


### PR DESCRIPTION
I forgot to mention the source of the scrypt function test vector.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
