### PR TITLE
GNUmakefile: don't check tcc if not available

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -144,7 +144,10 @@ fresh_vc:
 ifndef local
 latest_tcc: $(TMPTCC)/.git/config
 	cd $(TMPTCC) && $(GITCLEANPULL)
+ifneq (,$(wildcard ./tcc.exe))
 	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
+endif
+
 else
 latest_tcc:
 	@echo "Using local tcc"
@@ -161,7 +164,6 @@ ifneq (,$(findstring thirdparty-$(TCCOS)-$(TCCARCH), $(shell git ls-remote --hea
 else
 	@echo 'Pre-built TCC not available for thirdparty-$(TCCOS)-$(TCCARCH) at $(TCCREPO), will use the system compiler: $(CC)'
 	$(GITFASTCLONE) --branch thirdparty-unknown-unknown $(TCCREPO) $(TMPTCC)
-	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
 endif
 else
 	@echo "Using local tccbin"


### PR DESCRIPTION
On system where `thirdparty/tcc/tcc.exe` binary is not available (e.g. OpenBSD, NetBSD), during build with GNU `make`, don't check is `tcc` is working (don't run target `check_for_working_tcc`).

---
**Tests with GNU make**

- **OK** on OpenBSD current/amd64: **`tcc` not available**
```bash
$ gmake -v
GNU Make 4.4.1
Built for x86_64-unknown-openbsd7.6
(...)

$ gmake rebuild
rm -rf ./thirdparty/tcc
rm -rf ./thirdparty/legacy
rm -rf ./vc
gmake fresh_vc
gmake[1]: Entering directory '/home/fox/dev/vlang.git'
rm -rf ./vc
git clone --filter=blob:none --quiet https://github.com/vlang/vc ./vc
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 3 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (3/3), 1.07 MiB | 2.57 MiB/s, done.
Resolving deltas: 100% (1/1), done.
gmake[1]: Leaving directory '/home/fox/dev/vlang.git'
cd ./vc && git clean -xf && git pull --quiet
gmake fresh_tcc
gmake[1]: Entering directory '/home/fox/dev/vlang.git'
rm -rf ./thirdparty/tcc
Pre-built TCC not available for thirdparty-openbsd-amd64 at https://github.com/vlang/tccbin, will use the system compiler: cc
git clone --filter=blob:none --quiet --branch thirdparty-unknown-unknown https://github.com/vlang/tccbin ./thirdparty/tcc
remote: Enumerating objects: 1, done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 1 (from 1)
Receiving objects: 100% (1/1), 149 bytes | 37.00 KiB/s, done.
gmake[1]: Leaving directory '/home/fox/dev/vlang.git'
cd ./thirdparty/tcc && git clean -xf && git pull --quiet
cc  -std=gnu99 -w -o v1.exe ./vc/v.c -lm -lpthread -lexecinfo
./v1.exe -no-parallel -o v2.exe  cmd/v
./v2.exe -nocache -o ./v  cmd/v
rm -rf v1.exe v2.exe

Note: `tcc` was not used, so unless you install it yourself, your backend
C compiler will be `cc`, which is usually either `clang`, `gcc` or `msvc`.

These C compilers, are several times slower at compiling C source code,
compared to `tcc`. They do produce more optimised executables, but that
is done at the cost of compilation speed.

V has been successfully built
V 0.4.7 a7b4b67
```

- **OK** on Linux Debian/testing amd64: **`tcc` available** (`thirdparty/tcc/tcc.exe`)
```bash
$ make -v
GNU Make 4.3
Built for x86_64-pc-linux-gnu
(...)

$ make rebuild
rm -rf ./thirdparty/tcc
rm -rf ./thirdparty/legacy
rm -rf ./vc
make fresh_vc
make[1]: Entering directory '/home/fox/dev/vlang.git'
rm -rf ./vc
git clone --filter=blob:none --quiet https://github.com/vlang/vc ./vc
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 3 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (3/3), 1.07 MiB | 2.25 MiB/s, done.
Resolving deltas: 100% (1/1), done.
make[1]: Leaving directory '/home/fox/dev/vlang.git'
cd ./vc && git clean -xf && git pull --quiet
make fresh_tcc
make[1]: Entering directory '/home/fox/dev/vlang.git'
rm -rf ./thirdparty/tcc
git clone --filter=blob:none --quiet --branch thirdparty-linux-amd64 https://github.com/vlang/tccbin ./thirdparty/tcc
remote: Enumerating objects: 32, done.
remote: Counting objects: 100% (26/26), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 32 (delta 0), reused 15 (delta 0), pack-reused 6 (from 1)
Receiving objects: 100% (32/32), 8.39 MiB | 2.47 MiB/s, done.
make[2]: Entering directory '/home/fox/dev/vlang.git'
make[2]: Leaving directory '/home/fox/dev/vlang.git'
make[1]: Leaving directory '/home/fox/dev/vlang.git'
cd ./thirdparty/tcc && git clean -xf && git pull --quiet
cc  -std=gnu99 -w -o v1.exe ./vc/v.c -lm -lpthread
./v1.exe -no-parallel -o v2.exe  cmd/v
./v2.exe -nocache -o ./v  cmd/v
rm -rf v1.exe v2.exe
Your `tcc` is working. Good - it is much faster at compiling C source code.
V has been successfully built
V 0.4.7 a7b4b67
```