### PR TITLE
json: allow anon struct as decode type

### DIFF
--- a/vlib/json/json_decode_anon_struct_test.v
+++ b/vlib/json/json_decode_anon_struct_test.v
@@ -1,0 +1,9 @@
+import json
+
+fn test_main() {
+	json_text := '{ "a": "b" }'
+	b := json.decode(struct {
+		a string
+	}, json_text)!.a
+	assert dump(b) == 'b'
+}

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -130,6 +130,7 @@ pub:
 	pos token.Pos
 pub mut:
 	typ          Type
+	stmt         Stmt = empty_stmt // for anon struct
 	end_comments []Comment // comments that after current type node
 }
 

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3085,6 +3085,9 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 				&& c.table.cur_fn.generic_names.len == 0 {
 				c.error('unexpected generic variable in non-generic function `${c.table.cur_fn.name}`',
 					node.pos)
+			} else if node.stmt != ast.empty_stmt && node.typ == ast.void_type {
+				c.stmt(mut node.stmt)
+				node.typ = c.table.find_type_idx((node.stmt as ast.StructDecl).name)
 			}
 			return node.typ
 		}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -837,8 +837,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				node.pos)
 			return ast.void_type
 		}
-		expr := node.args[0].expr
-		if expr is ast.TypeNode {
+		mut expr := node.args[0].expr
+		if mut expr is ast.TypeNode {
+			expr.typ = c.expr(mut expr)
 			mut unwrapped_typ := c.unwrap_generic(expr.typ)
 			if c.needs_unwrap_generic_type(expr.typ) {
 				unwrapped_typ = c.table.unwrap_generic_type(expr.typ, c.table.cur_fn.generic_names,
@@ -858,8 +859,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				c.error('json.decode: unknown type `${sym.name}`', node.pos)
 			}
 		} else {
-			typ := expr.type_name()
-			c.error('json.decode: first argument needs to be a type, got `${typ}`', node.pos)
+			typ_name := expr.type_name()
+			c.error('json.decode: first argument needs to be a type, got `${typ_name}`',
+				node.pos)
 			return ast.void_type
 		}
 		c.expected_type = ast.string_type

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -859,9 +859,8 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				c.error('json.decode: unknown type `${sym.name}`', node.pos)
 			}
 		} else {
-			typ_name := expr.type_name()
-			c.error('json.decode: first argument needs to be a type, got `${typ_name}`',
-				node.pos)
+			typ := expr.type_name()
+			c.error('json.decode: first argument needs to be a type, got `${typ}`', node.pos)
 			return ast.void_type
 		}
 		c.expected_type = ast.string_type

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -3215,8 +3215,13 @@ pub fn (mut f Fmt) string_inter_literal(node ast.StringInterLiteral) {
 }
 
 pub fn (mut f Fmt) type_expr(node ast.TypeNode) {
-	f.mark_types_import_as_used(node.typ)
-	f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
+	if node.stmt == ast.empty_stmt {
+		f.mark_types_import_as_used(node.typ)
+		f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
+	} else {
+		f.struct_decl(ast.StructDecl{ fields: (node.stmt as ast.StructDecl).fields },
+			true)
+	}
 }
 
 pub fn (mut f Fmt) type_of(node ast.TypeOf) {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -478,9 +478,19 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 		}
 		else {
 			if p.tok.kind == .key_struct && p.peek_tok.kind == .lcbr {
-				// Anonymous struct
-				p.next()
-				return p.struct_init('', .anon, false)
+				if p.expecting_type && p.inside_call_args {
+					// Anonymous struct	for json.decode
+					tok_pos := p.tok.pos()
+					return ast.TypeNode{
+						stmt: p.struct_decl(true)
+						pos:  tok_pos
+						typ:  ast.void_type
+					}
+				} else {
+					// Anonymous struct
+					p.next()
+					return p.struct_init('', .anon, false)
+				}
 			}
 			if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {
 				// eof should be handled where it happens


### PR DESCRIPTION
Fix #21703

```v
import json

fn main() {
	json_text := '{ "a": "b" }'
	b := json.decode(struct {
		a string
	}, json_text)!.a
	assert dump(b) == 'b'
}
``` 