### PR TITLE
builtin: fix compilation with tcc on OpenBSD using libgc

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -58,7 +58,7 @@ $if dynamic_boehm ? {
 		#flag -ldl
 		#flag -lpthread
 	} $else $if freebsd {
-		// Tested on FreeBSD 13.0-RELEASE-p3, with clang, gcc and tcc:
+		// Tested on FreeBSD 13.0-RELEASE-p3, with clang, gcc and tcc
 		#flag -DGC_BUILTIN_ATOMIC=1
 		#flag -DBUS_PAGE_FAULT=T_PAGEFLT
 		$if !tinyc {
@@ -73,10 +73,16 @@ $if dynamic_boehm ? {
 		}
 		#flag -lpthread
 	} $else $if openbsd {
+		// Tested on OpenBSD 7.5, with clang, gcc and tcc
 		#flag -DGC_BUILTIN_ATOMIC=1
-		#flag -I/usr/local/include
-		$if !use_bundled_libgc ? {
+		$if !tinyc {
+			#flag -I @VEXEROOT/thirdparty/libgc/include
+			#flag @VEXEROOT/thirdparty/libgc/gc.o
+		}
+		$if tinyc {
+			#flag -I/usr/local/include
 			#flag $first_existing("/usr/local/lib/libgc.a", "/usr/lib/libgc.a")
+			#flag -lgc
 		}
 		#flag -lpthread
 	} $else $if windows {


### PR DESCRIPTION
Fix vlang/v#22156

**Tests OK on OpenBSD/amd64** with:
- `tcc` installed from OpenBSD packages (`pkg_add tcc`)
- `tcc` built for OpenBSD/amd64 => see https://github.com/vlang/tccbin/pull/54
- clang 16.0.6
- gcc version 11.2.0

```
$ ./thirdparty/tcc/tcc.exe -v
tcc version 0.9.28rc 2024-09-14 HEAD@b8b6a5fd (x86_64 OpenBSD)
$ ./v -cc tcc run ~/tmp/hello_world.v
Hello world from V

$ /usr/local/bin/tcc  -v
tcc version 0.9.27 2023-07-05 mob@5b28165 (x86_64 OpenBSD)
$ ./v -cc /usr/local/bin/tcc run ~/tmp/hello_world.v
Hello world from V

$ ./v -cc clang run ~/tmp/hello_world.v
Hello world from V
$ ./v -cc egcc run ~/tmp/hello_world.v
Hello world from V
```



