### PR TITLE
flag: fix parse_bool_value() with different order short args (fix #22176)

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -304,7 +304,7 @@ fn (mut fs FlagParser) parse_bool_value(longhand string, shorthand u8) !string {
 		}
 		if arg.len > 1 && arg[0] == `-` && arg[1] != `-` {
 			mut found := false
-			for j in 1 .. arg.len - 1 {
+			for j in 1 .. arg.len {
 				if arg[j].is_space() {
 					break
 				} else if arg[j] == shorthand {

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -501,3 +501,16 @@ fn test_finalize_with_multi_shortargs() {
 	println(additional_args.join_lines())
 	assert additional_args == []
 }
+
+fn test_finalize_with_multi_shortargs_different_order() {
+	mut fp := flag.new_flag_parser(['-ba', '-c'])
+	a_bool := fp.bool('a_bool', `a`, false, '')
+	assert a_bool
+	b_bool := fp.bool('b_bool', `b`, false, '')
+	assert b_bool
+	c_bool := fp.bool('c_bool', `c`, false, '')
+	assert c_bool
+	additional_args := fp.finalize()!
+	println(additional_args.join_lines())
+	assert additional_args == []
+}


### PR DESCRIPTION
This PR fix parse_bool_value() with different order short args (fix #22176).

- Fix parse_bool_value() with different order short args.
- Add test.

```v
import flag

fn main() {
	mut fp := flag.new_flag_parser(['-ba', '-c'])
	a_bool := fp.bool('a_bool', `a`, false, '')
	assert a_bool
	b_bool := fp.bool('b_bool', `b`, false, '')
	assert b_bool
	c_bool := fp.bool('c_bool', `c`, false, '')
	assert c_bool
	additional_args := fp.finalize()!
	println(additional_args.join_lines())
	assert additional_args == []
}

PS D:\Test\v\tt1> v run .
```