### PR TITLE
Add --depth=1 to installation clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Note: On Ubuntu/Debian, you may need to run `sudo apt install git build-essentia
 
 To get started, execute the following in your terminal/shell:
 ```bash
-git clone https://github.com/vlang/v
+git clone https://github.com/vlang/v --depth=1
 cd v
 make
 ```


### PR DESCRIPTION
People that just want to build from source the project just need the latest version, and maybe use `pull` for new versions. And people that want to contribute (so they probably need the git history) will clone their own fork. :heart: