### PR TITLE
builtin: drop C in int.v

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -606,7 +606,7 @@ pub fn (b u8) repeat(count int) string {
 	}
 	mut bytes := unsafe { malloc_noscan(count + 1) }
 	unsafe {
-		C.memset(bytes, b, count)
+		vmemset(bytes, b, count)
 		bytes[count] = `0`
 	}
 	return unsafe { bytes.vstring_with_len(count) }


### PR DESCRIPTION
` -Wimpure-v ` now default to coreutils, this PR fix test failure in coreutils
https://github.com/vlang/coreutils/actions/runs/10865356775/job/30151722872

Related: #20696