### PR TITLE
v.builder: enable LTO for clang on OpenBSD

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -232,7 +232,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 		optimization_options = ['-O3']
 		mut have_flto := true
-		$if openbsd || windows {
+		$if windows {
 			have_flto = false
 		}
 		if have_flto {


### PR DESCRIPTION
LTO is supported by Clang compiler on OpenBSD => enable `-flto` during compilation (used with `-prod` for optimizations)

- OpenBSD clang manpage: https://man.openbsd.org/OpenBSD-current/man1/clang.1 => flag `-flto`
- Clang code `OpenBSD.cpp`, line 397 => `OpenBSD::HasNativeLLVMSupport = true` https://clang.llvm.org/doxygen//OpenBSD_8cpp_source.html#l00397

---

- Tests on OpenBSD/amd64 with `clang` v16 + `prod` => flag `-flto` used for compilation **OK** 
```bash
$ ./v -prod -cc clang -showcc -o /tmp/hello_world examples/hello_world.v
> C compiler cmd: 'clang' '@/tmp/v_1000/hello_world.01J825QPG073H9G4EXT8EEGF72.tmp.c.rsp'
> C compiler response file "/tmp/v_1000/hello_world.01J825QPG073H9G4EXT8EEGF72.tmp.c.rsp":
  -O3 -flto -DNDEBUG "/home/fox/.vmodules/cache/12/129a7ad1d9dc9094487dea50dd5193de.module.builtin.o" -o "/tmp/hello_world" -D GC_BUILTIN_ATOMIC=1 -D GC_THREADS=1 -I "/home/fox/dev/vlang.git/thirdparty/libgc/include" "/tmp/v_1000/hello_world.01J825QPG073H9G4EXT8EEGF72.tmp.c" -std=c99 -D_DEFAULT_SOURCE -lpthread

$ /tmp/hello_world
Hello, World!
```