### PR TITLE
cgen: fix wrong type of vint_t and const riscv64

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -649,7 +649,7 @@ static void* g_live_info = NULL;
 
 const c_builtin_types = '
 //================================== builtin types ================================*/
-#if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64) || (defined(__riscv_xlen) && __riscv_xlen == 64)
 typedef int64_t vint_t;
 #else
 typedef int32_t vint_t;

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -1188,6 +1188,9 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_option bool) !strin
 		'i386' {
 			return '__V_x86'
 		}
+		'rv64', 'riscv64' {
+			return '__V_rv64'
+		}
 		// bitness:
 		'x64' {
 			return 'TARGET_IS_64BIT'


### PR DESCRIPTION
The size of vint_t for riscv64 should be 64.