### PR TITLE
thirdparty: fix compilation of programs using miniz.h on OpenBSD

### DIFF
--- a/thirdparty/zip/miniz.h
+++ b/thirdparty/zip/miniz.h
@@ -5026,7 +5026,7 @@ static int mz_mkdir(const char *pDirname) {
 }
 
 #ifndef MINIZ_NO_TIME
-#if ( defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)) && !defined(FREEBSD)
+#if ( defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)) && !defined(FREEBSD)
    #include <utime.h>
 #else
    #include <sys/utime.h>
@@ -5073,7 +5073,7 @@ static int mz_mkdir(const char *pDirname) {
 
 #elif defined(__TINYC__)
 #ifndef MINIZ_NO_TIME
-#if ( defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)) && !defined(FREEBSD)
+#if ( defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)) && !defined(FREEBSD)
    #include <utime.h>
 #else
    #include <sys/utime.h>
@@ -5113,7 +5113,7 @@ static int mz_mkdir(const char *pDirname) {
 #define MZ_DELETE_FILE remove
 #define MZ_MKDIR(d) mkdir(d, 0755)
 
-#elif defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
Fix vlang/v#22253

---
Tests **OK** on OpenBSD/amd64 with tcc
```bash
$ ./v -showcc cmd/tools/vcompress.v
> C compiler cmd: '/home/fox/dev/vlang.git/thirdparty/tcc/tcc.exe' '@/tmp/v_1000/vcompress.01J82Q6J8AJ8YDG0VEP89BQA6S.tmp.c.rsp'
> C compiler response file "/tmp/v_1000/vcompress.01J82Q6J8AJ8YDG0VEP89BQA6S.tmp.c.rsp":
  -o "/home/fox/dev/vlang.git/cmd/tools/vcompress" -D GC_BUILTIN_ATOMIC=1 -D GC_THREADS=1 -I "/usr/local/include" -I "/home/fox/dev/vlang.git/thirdparty/zip" "/tmp/v_1000/vcompress.01J82Q6J8AJ8YDG0VEP89BQA6S.tmp.c" -std=c99 -D_DEFAULT_SOURCE -bt25 "/usr/local/lib/libgc.a" -lgc -lpthread

$ ./cmd/tools/vcompress
v compress <type> <in> <out>
supported types: zlib
```