### PR TITLE
examples: add `gc_is_enabled()` check to `2048` to prevent crash in Android emulator

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -883,7 +883,7 @@ fn frame(mut app App) {
 		// do GC once per 2 seconds
 		// eprintln('> gc_memory_use: ${gc_memory_use()}')
 		if gc_is_enabled() {
-			// Avoid assert error when built with `-gc` on some systems
+			// Avoid assert error when built with `-cg` on some systems
 			gc_disable()
 		}
 		gc_enable()

--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -882,6 +882,10 @@ fn frame(mut app App) {
 	if app.gg.frame % 120 == 0 {
 		// do GC once per 2 seconds
 		// eprintln('> gc_memory_use: ${gc_memory_use()}')
+		if gc_is_enabled() {
+			// Avoid assert error when built with `-gc` on some systems
+			gc_disable()
+		}
 		gc_enable()
 		gc_collect()
 		gc_disable()


### PR DESCRIPTION
This PR fixes a case where compiling with `-cg` causes an assert in the garbage collector to trigger. It only happens on the `aosp_atd` type of emulator for reasons I have not been able to pin point. I'm trying to speed up `vab` emulator runs by using official "slimmer" emulator images (some reports 40% speed ups) and ran into this edge-case.

It can be reproduced with a working `vab` and Andoid SDK+NDK setup like this
```bash
echo yes | sdkmanager 'system-images;android-30;aosp_atd;x86_64'
echo no | avdmanager create avd --force --name test --abi aosp_atd/x86_64 --package 'system-images;android-30;aosp_atd;x86_64'
emulator -avd test -wipe-data -no-metrics -no-snapshot -no-boot-anim -camera-back emulated -camera-front emulated &
adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
export ANDROID_SERIAL="emulator-5554"
VAB_FLAGS="-cg --log-clear --archs x86_64" vab --package-id "io.v.apk.v2048" run /path/to/v/examples/2048
adb -e logcat -d > /tmp/logcat.dump.txt
```

The `2048` app will freeze in the emulator after a few frames (which is even more baffling) and the logcat dump will then contain something like this:
```
...
09-21 18:06:48.282  1742  1767 D BDWGC   : World-stopped marking took 0 ms 604000 ns (0 ms in average)
09-21 18:06:48.282  1742  1767 D BDWGC   : GC #5 freed -22176 bytes, heap 1000 KiB (+ 497 KiB internal)
09-21 18:06:48.282  1742  1767 D BDWGC   : In-use heap: 79% (339 KiB pointers + 457 KiB other)
09-21 18:06:48.282  1742  1767 D BDWGC   : In-use heap: 64% (339 KiB pointers + 310 KiB other)
09-21 18:06:48.282  1742  1767 I BDWGC   : Grow heap to 4916 KiB after 0 bytes allocated
09-21 18:06:48.292  1742  1767 D BDWGC   : World-stopped marking took 1 ms 824000 ns (0 ms in average)
09-21 18:06:48.292  1742  1767 D BDWGC   : GC #6 freed 0 bytes, heap 4916 KiB (+ 497 KiB internal)
09-21 18:06:48.292  1742  1767 D BDWGC   : In-use heap: 0% (3923 KiB pointers + 3894 KiB other)
09-21 18:06:48.292  1742  1767 D BDWGC   : In-use heap: 86% (3923 KiB pointers + 310 KiB other)
09-21 18:06:48.292  1742  1767 I BDWGC   : Grow heap to 10648 KiB after 0 bytes allocated
09-21 18:06:48.315   323   392 D goldfish-address-space: claimShared: Ask to claim region [0x3fc578000 0x3fc640000]
09-21 18:06:48.322   323   392 D goldfish-address-space: claimShared: Ask to claim region [0x3fc640000 0x3fc708000]
09-21 18:06:48.387   413   413 I perfetto: probes_producer.cc:230  Ftrace setup (target_buf=1)
09-21 18:06:48.576   413   413 I perfetto: ftrace_procfs.cc:176    enabled ftrace
09-21 18:06:48.621     0     0 W perfetto: enabled ftrace
09-21 18:06:50.280  1742  1767 E BDWGC   : Assertion failure: /home/lmp/Projects/v/thirdparty/libgc/gc.c:24663
09-21 18:06:50.280  1742  1767 F BDWGC   : assertion failure
--------- beginning of crash
09-21 18:06:50.280  1742  1767 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 1767 (io.v.apk.v2048), pid 1742 (io.v.apk.v2048)
09-21 18:06:50.309  1774  1774 I crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
...
```

Assertion leads to these lines in `thirdparty/libgc/gc.c:24663`:
https://github.com/vlang/v/blob/5e624a5b23d1c8ce2a901f1c1612fdc4d623d48d/thirdparty/libgc/gc.c#L24663
This told me that somehow the garbage collector `GC_dont_gc` variable is unbalanced at some point during execution.
I haven't been able to reproduce it on other systems (locally) or other emulator images which is a bit baffling. But the changes in the PR fixes the assert.

... compiling and running *without* `-cg` results in a working 2048 game.

**NOTE** it is `-cg` and **not** `-gc` as I originally typed (confusing since the garbage collector is involved :sweat_smile: )