### PR TITLE
net:websocket EINTR handling

### DIFF
--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -133,12 +133,15 @@ pub fn (mut ws Client) listen() ! {
 	}
 	for ws.get_state() == .open {
 		msg := ws.read_next_message() or {
-			if ws.get_state() in [.closed, .closing] {
+			if err.code() == C.EINTR { // Check for EINTR and retry
+				continue
+			} else if ws.get_state() in [.closed, .closing] {
+				return
+			} else {
+				ws.debug_log('failed to read next message: ${err}')
+				ws.send_error_event('failed to read next message: ${err}')
 				return
 			}
-			ws.debug_log('failed to read next message: ${err}')
-			ws.send_error_event('failed to read next message: ${err}')
-			return err
 		}
 		if ws.get_state() in [.closed, .closing] {
 			return

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -140,7 +140,7 @@ pub fn (mut ws Client) listen() ! {
 			} else {
 				ws.debug_log('failed to read next message: ${err}')
 				ws.send_error_event('failed to read next message: ${err}')
-				return
+				return err
 			}
 		}
 		if ws.get_state() in [.closed, .closing] {

--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -133,7 +133,7 @@ pub fn (mut ws Client) listen() ! {
 	}
 	for ws.get_state() == .open {
 		msg := ws.read_next_message() or {
-			if err.code() == C.EINTR { // Check for EINTR and retry
+			if err.code() == net.error_eintr { // Check for EINTR and retry
 				continue
 			} else if ws.get_state() in [.closed, .closing] {
 				return


### PR DESCRIPTION
I am working on a TUI that connections to websocket servers. I am getting premature ws closures specifically when using net.websocket client in conjunction with term.ui. By checking for EINTR error code and continuing rather than returning ws.read_next_message() fails we avoid closing prematurely. EINTR calls should not cause ws closures in this case.

This change makes the websocket behave as expected.

I hope this helps others as for me it has fixed the problem.

