### PR TITLE
checker: fix fntype var marked as auto heap

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4375,7 +4375,7 @@ fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) {
 								node.obj.is_auto_heap = true
 							}
 						}
-						.sum_type, .interface_ {}
+						.sum_type, .interface_, .function {}
 						else {
 							node.obj.is_auto_heap = true
 						}

--- a/vlib/v/tests/pointers/ref_callback_test.v
+++ b/vlib/v/tests/pointers/ref_callback_test.v
@@ -1,0 +1,20 @@
+module main
+
+struct Struct_voidptr {
+	func voidptr
+}
+
+fn function() string {
+	return 'Function!'
+}
+
+fn test_main() {
+	fun := function
+
+	sct := Struct_voidptr{
+		func: &fun
+	}
+
+	assert fun() == 'Function!'
+	assert sct.func == &fun
+}


### PR DESCRIPTION
Fix #12347