### PR TITLE
cgen: fix codegen for method call on rangeexpr

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1675,7 +1675,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	// if so, then instead of calling array_clone(&array_slice(...))
 	// call array_clone_static(array_slice(...))
 	mut is_range_slice := false
-	if node.receiver_type.is_ptr() && !left_type.is_ptr() {
+	if node.name == 'clone' && node.receiver_type.is_ptr() && !left_type.is_ptr() {
 		if node.left is ast.IndexExpr {
 			idx := node.left.index
 			if idx is ast.RangeExpr {

--- a/vlib/v/tests/fns/method_call_on_rangeexpr_test.v
+++ b/vlib/v/tests/fns/method_call_on_rangeexpr_test.v
@@ -1,4 +1,4 @@
-type Buffer = []byte
+type Buffer = []u8
 
 pub fn (mut sb Buffer) vbytes() string {
 	return sb[0..sb.len].a().str()
@@ -9,7 +9,7 @@ pub fn (mut sb Buffer) a() Buffer {
 }
 
 fn test_main() {
-	mut b := Buffer([]byte{cap: 10})
+	mut b := Buffer([]u8{cap: 10})
 	b << 1
 	b << 2
 	assert b.vbytes() == 'Buffer([1, 2])'

--- a/vlib/v/tests/fns/method_call_on_rangeexpr_test.v
+++ b/vlib/v/tests/fns/method_call_on_rangeexpr_test.v
@@ -1,0 +1,16 @@
+type Buffer = []byte
+
+pub fn (mut sb Buffer) vbytes() string {
+	return sb[0..sb.len].a().str()
+}
+
+pub fn (mut sb Buffer) a() Buffer {
+	return sb
+}
+
+fn test_main() {
+	mut b := Buffer([]byte{cap: 10})
+	b << 1
+	b << 2
+	assert b.vbytes() == 'Buffer([1, 2])'
+}


### PR DESCRIPTION
Fix #12610

```v
type Buffer = []byte

pub fn (mut sb Buffer) vbytes() string {
	return sb[0..sb.len].a().str()
}

pub fn (mut sb Buffer) a() Buffer {
	return sb
}

fn test_main() {
	mut b := Buffer([]byte{cap: 10})
	b << 1
	b << 2
	assert b.vbytes() == 'Buffer([1, 2])'
}
```