### PR TITLE
parser: check enum method duplicated (fix #20924)

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -666,6 +666,7 @@ pub:
 	file                  string
 	file_mode             Language
 	pos                   token.Pos
+	name_pos              token.Pos
 	return_type_pos       token.Pos
 pub mut:
 	return_type        Type

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -347,7 +347,15 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				}
 			}
 			if is_duplicate {
-				p.error_with_pos('duplicate method `${name}`', name_pos)
+				if type_sym.kind == .enum_ {
+					if enum_fn := type_sym.find_method(name) {
+						name_pos = enum_fn.name_pos
+					}
+					p.error_with_pos('duplicate method `${name}`, `${name}` is an enum type built-in method',
+						name_pos)
+				} else {
+					p.error_with_pos('duplicate method `${name}`', name_pos)
+				}
 				return ast.FnDecl{
 					scope: unsafe { nil }
 				}
@@ -539,6 +547,7 @@ run them via `v file.v` instead',
 			mod:      p.mod
 			file:     p.file_path
 			pos:      start_pos
+			name_pos: name_pos
 			language: language
 		})
 	} else {
@@ -591,6 +600,7 @@ run them via `v file.v` instead',
 			mod:      p.mod
 			file:     p.file_path
 			pos:      start_pos
+			name_pos: name_pos
 			language: language
 		})
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -347,7 +347,8 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 				}
 			}
 			if is_duplicate {
-				if type_sym.kind == .enum_ {
+				if type_sym.kind == .enum_
+					&& name in ['is_empty', 'has', 'all', 'set', 'set_all', 'clear', 'clear_all', 'toggle', 'zero', 'from'] {
 					if enum_fn := type_sym.find_method(name) {
 						name_pos = enum_fn.name_pos
 					}

--- a/vlib/v/parser/tests/enum_method_duplicated_err.out
+++ b/vlib/v/parser/tests/enum_method_duplicated_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/enum_method_duplicated_err.vv:13:14: error: duplicate method `has`, `has` is an enum type built-in method
+   11 | }
+   12 | 
+   13 | fn (f Flags) has(f2 Flags) bool {
+      |              ~~~
+   14 |     return f & f2 > 0
+   15 | }

--- a/vlib/v/parser/tests/enum_method_duplicated_err.vv
+++ b/vlib/v/parser/tests/enum_method_duplicated_err.vv
@@ -1,0 +1,17 @@
+@[flag]
+enum Flags {
+	bit0
+	bit1
+	bit2
+	bit3
+	bit4
+	bit5
+	bit6
+	bit7
+}
+
+fn (f Flags) has(f2 Flags) bool {
+	return f & f2 > 0
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check enum method duplicated (fix #20924).

- Check enum method duplicated.
- Add test.

```v
@[flag]
enum Flags {
	bit0
	bit1
	bit2
	bit3
	bit4
	bit5
	bit6
	bit7
}

fn (f Flags) has(f2 Flags) bool {
	return f & f2 > 0
}

fn main() {}

PS D:\Test\v\tt1> v run .
tt1.v:13:14: error: duplicate method `has`, `has` is an enum type built-in method
   11 | }
   12 | 
   13 | fn (f Flags) has(f2 Flags) bool {
      |              ~~~
   14 |     return f & f2 > 0
   15 | }
```