### PR TITLE
checker: check array.delete() argument mismatch (fix #22298)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3359,6 +3359,14 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		if method := c.table.find_method(unwrapped_left_sym, method_name) {
 			node.receiver_type = method.receiver_type
 		}
+		if node.args.len != 1 {
+			c.error('`.delete()` expected 1 argument, but got ${node.args.len}', node.pos)
+		} else {
+			arg_typ := c.expr(mut node.args[0].expr)
+			c.check_expected_call_arg(arg_typ, ast.int_type, node.language, node.args[0]) or {
+				c.error('${err.msg()} in argument 1 to `.delete()`', node.args[0].pos)
+			}
+		}
 		node.return_type = ast.void_type
 	}
 	return node.return_type

--- a/vlib/v/checker/tests/array_delete_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/array_delete_arg_mismatch_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/array_delete_arg_mismatch_err.vv:18:23: error: cannot use `IGameObject` as `int` in argument 1 to `.delete()`
+   16 | fn (mut game Game) gc() {
+   17 |     for obj in game.objects {
+   18 |         game.objects.delete(obj)
+      |                             ~~~
+   19 |     }
+   20 |     game.objects.clear()

--- a/vlib/v/checker/tests/array_delete_arg_mismatch_err.vv
+++ b/vlib/v/checker/tests/array_delete_arg_mismatch_err.vv
@@ -1,0 +1,23 @@
+interface IGameObject {
+mut:
+	name string
+}
+
+struct GameObject implements IGameObject {
+mut:
+	name string
+}
+
+struct Game {
+mut:
+	objects []IGameObject
+}
+
+fn (mut game Game) gc() {
+	for obj in game.objects {
+		game.objects.delete(obj)
+	}
+	game.objects.clear()
+}
+
+fn main() {}


### PR DESCRIPTION
This PR check array.delete() argument mismatch (fix #22298).

- Check array.delete() argument mismatch.
- Add test.

```v
interface IGameObject {
mut:
	name string
}

struct GameObject implements IGameObject {
mut:
	name string
}

struct Game {
mut:
	objects []IGameObject
}

fn (mut game Game) gc() {
	for obj in game.objects {
		game.objects.delete(obj)
	}
	game.objects.clear()
}

fn main() {}

PS D:\Test\v\tt1> v run .
tt1.v:18:23: error: cannot use `IGameObject` as `int` in argument 1 to `.delete()`
   16 | fn (mut game Game) gc() {
   17 |     for obj in game.objects {
   18 |         game.objects.delete(obj)
      |                             ~~~
   19 |     }
   20 |     game.objects.clear()
```