### PR TITLE
Hub docker action - add cache and trigger

### DIFF
--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -26,33 +26,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-#      - name: Docker build
-#        run: |
-#          docker build -f Dockerfile.${{ matrix.os }} --platform linux/amd64,linux/arm64 -t thevlang/vlang:{{ version }} -t thevlang/vlang:latest
-#
-#      - name: Docker push
-#        run: |
-#          docker push thevlang/vlang:{{ version }} thevlang/vlang:latest
-#
-#      - uses: docker/build-push-action@v4
-#        with:
-#          platforms: ${{ vars.PLATFORMS}}
-#          tags: ${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os}}-build
-#          push: ${{ github.event_name != 'pull_request' }}
-#          file: docker/vlang/Dockerfile.${{ matrix.os }}.build
-#          build-args: "USER=${{vars.DOCKER_REPOSITORY}}"
-#
-#      - name: Build and push
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: .
-#          file: ./Dockerfile
-#          push: true
-#          tags: agasdrm/blog:latest,agasdrm/blog:${{ github.run_number }}
-#          platforms: linux/amd64,linux/arm64/v8
-#          cache-from: type=local,src=/tmp/.buildx-cache
-#          cache-to: type=local,dest=/tmp/.buildx-cache
-
       - name: generate tags conditionally
         id: gen_tags
         run: |
@@ -65,6 +38,7 @@ jobs:
       - uses: docker/build-push-action@v4
         name: Build and deploy v image
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.gen_tags.outputs.TAGS }}
           file: docker/vlang/Dockerfile.${{ matrix.os }}
@@ -74,6 +48,7 @@ jobs:
       - uses: docker/build-push-action@v4
         name: Build and deploy developer build
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           tags: thevlang/vlang:${{ matrix.os }}-dev
           file: docker/vlang/Dockerfile.${{ matrix.os }}.dev-full

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '[0-9].[0-9]+.[0-9]+'   # trigger on new release tag
-      - 'weekly.*'              # trigger on weekly tag
+      - '[0-9].[0-9]+.[0-9]+' # trigger on new release tag
+      - 'weekly.*' # trigger on weekly tag
 
 jobs:
   publish-new-docker-images:

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -2,6 +2,10 @@ name: hub_docker_ci
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '[0-9].[0-9]+.[0-9]+'   # trigger on new release tag
+      - 'weekly.*'              # trigger on weekly tag
 
 jobs:
   publish-new-docker-images:
@@ -35,17 +39,19 @@ jobs:
             echo 'TAGS=thevlang/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
           fi
 
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v6
         name: Build and deploy v image
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.gen_tags.outputs.TAGS }}
           file: docker/vlang/Dockerfile.${{ matrix.os }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           build-args: 'USER=thevlang'
+          cache-from: type=registry,ref=thevlang/vlang:${{ matrix.os }}-buildcache
+          cache-to: type=registry,ref=thevlang/vlang:${{ matrix.os }}-buildcache,mode=max
 
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v6
         name: Build and deploy developer build
         with:
           context: .
@@ -53,4 +59,6 @@ jobs:
           tags: thevlang/vlang:${{ matrix.os }}-dev
           file: docker/vlang/Dockerfile.${{ matrix.os }}.dev-full
           build-args: 'USER=thevlang'
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          cache-from: type=registry,ref=thevlang/vlang:${{ matrix.os }}-dev-buildcache
+          cache-to: type=registry,ref=thevlang/vlang:${{ matrix.os }}-dev-buildcache,mode=max

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -1,0 +1,81 @@
+name: hub_docker_ci
+
+on:
+  workflow_dispatch:
+
+jobs:
+  example_matrix:
+    strategy:
+      matrix:
+        os: [debian, alpine]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'vlang/docker'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to hub.docker.com
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+#      - name: Docker build
+#        run: |
+#          docker build -f Dockerfile.${{ matrix.os }} --platform linux/amd64,linux/arm64 -t thevlang/vlang:{{ version }} -t thevlang/vlang:latest
+#
+#      - name: Docker push
+#        run: |
+#          docker push thevlang/vlang:{{ version }} thevlang/vlang:latest
+#
+#      - uses: docker/build-push-action@v4
+#        with:
+#          platforms: ${{ vars.PLATFORMS}}
+#          tags: ${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os}}-build
+#          push: ${{ github.event_name != 'pull_request' }}
+#          file: docker/vlang/Dockerfile.${{ matrix.os }}.build
+#          build-args: "USER=${{vars.DOCKER_REPOSITORY}}"
+#
+#      - name: Build and push
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: .
+#          file: ./Dockerfile
+#          push: true
+#          tags: agasdrm/blog:latest,agasdrm/blog:${{ github.run_number }}
+#          platforms: linux/amd64,linux/arm64/v8
+#          cache-from: type=local,src=/tmp/.buildx-cache
+#          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: generate tags conditionally
+        id: gen_tags
+        run: |
+          if [[ ${{ matrix.os }} == 'debian' ]]; then
+            echo 'TAGS=${{ vars.DOCKER_REPOSITORY }}/vlang:latest,${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
+          else
+            echo 'TAGS=${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
+          fi
+
+      - uses: docker/build-push-action@v4
+        name: Build and deploy v image
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.gen_tags.outputs.TAGS }}
+          file: docker/vlang/Dockerfile.${{ matrix.os }}
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: "USER=thevlang"
+
+      - uses: docker/build-push-action@v4
+        name: Build and deploy developer build
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os }}-dev
+          file: docker/vlang/Dockerfile.${{ matrix.os }}.dev-full
+          build-args: "USER=thevlang"
+          push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -57,9 +57,9 @@ jobs:
         id: gen_tags
         run: |
           if [[ ${{ matrix.os }} == 'debian' ]]; then
-            echo 'TAGS=${{ vars.DOCKER_REPOSITORY }}/vlang:latest,${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
+            echo 'TAGS=thevlang/vlang:latest,thevlang/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
           else
-            echo 'TAGS=${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
+            echo 'TAGS=thevlang/vlang:${{ matrix.os }}' >> $GITHUB_OUTPUT
           fi
 
       - uses: docker/build-push-action@v4
@@ -75,7 +75,7 @@ jobs:
         name: Build and deploy developer build
         with:
           platforms: linux/amd64,linux/arm64
-          tags: ${{ vars.DOCKER_REPOSITORY }}/vlang:${{ matrix.os }}-dev
+          tags: thevlang/vlang:${{ matrix.os }}-dev
           file: docker/vlang/Dockerfile.${{ matrix.os }}.dev-full
           build-args: "USER=thevlang"
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -43,7 +43,7 @@ jobs:
           tags: ${{ steps.gen_tags.outputs.TAGS }}
           file: docker/vlang/Dockerfile.${{ matrix.os }}
           push: ${{ github.event_name != 'pull_request' }}
-          build-args: "USER=thevlang"
+          build-args: 'USER=thevlang'
 
       - uses: docker/build-push-action@v4
         name: Build and deploy developer build
@@ -52,5 +52,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: thevlang/vlang:${{ matrix.os }}-dev
           file: docker/vlang/Dockerfile.${{ matrix.os }}.dev-full
-          build-args: "USER=thevlang"
+          build-args: 'USER=thevlang'
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Use cache images from docker repository during build process to store intermediate layers. This change should speed up build process.

Trigger on new release and weekly tags. Others will be ignored.