### PR TITLE
vlib: enable GC lib on rv64 build

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -44,7 +44,7 @@ $if dynamic_boehm ? {
 	$if macos || linux {
 		#flag -DGC_BUILTIN_ATOMIC=1
 		#flag -I @VEXEROOT/thirdparty/libgc/include
-		$if (prod && !tinyc && !debug) || !(amd64 || arm64 || i386 || arm32) {
+		$if (prod && !tinyc && !debug) || !(amd64 || arm64 || i386 || arm32 || rv64) {
 			// TODO: replace the architecture check with a `!$exists("@VEXEROOT/thirdparty/tcc/lib/libgc.a")` comptime call
 			#flag @VEXEROOT/thirdparty/libgc/gc.o
 		} $else {


### PR DESCRIPTION
After https://github.com/vlang/tccbin/pull/53 has merged.
We can use gcc/clang with libgc for V now.

```
>>> should_compile_filtered_files: res: ['/home/mzh/v/vlib/math/bits/bits.v', '/home/mzh/v/vlib/math/bits/bits_tables.v
', '/home/mzh/v/vlib/math/bits/unsafe_bits.v']
0.875    ms Builder.resolve_deps
172.462  ms Builder.parse_imports
79.080   ms SCAN
329.514  ms PARSE
430.260  ms ALL_FRONT_STAGES
0.050    ms Checker.generic_insts_to_concrete
254.352  ms CHECK
43.884   ms TRANSFORM
0.292    ms Table.complete_interface_check
0.112    ms Gen.write_sorted_fn_typesymbol_declaration
3.866    ms Gen.sort_structs
6.252    ms cgen init
77.833   ms cgen parallel processing
2.225    ms Gen.sort_globals_consts
6.491    ms cgen unification
0.451    ms Gen.write_init_function
0.645    ms Gen.interface_table
4.173    ms cgen common
96.161   ms C GEN
builder.cc() pref.out_name="/home/mzh/v/examples/hello_world"
build_thirdparty_obj_files: v.ast.cflags: [CFlag{ name: "-D" value: "GC_BUILTIN_ATOMIC=1" mod: "builtin" os: "" cached:
 "" }, CFlag{ name: "-I" value: "/home/mzh/v/thirdparty/libgc/include" mod: "builtin" os: "" cached: "" }, CFlag{ name:
 "" value: "/home/mzh/v/thirdparty/tcc/lib/libgc.a" mod: "builtin" os: "" cached: "" }, CFlag{ name: "-l" value: "dl" m
od: "builtin" os: "" cached: "" }, CFlag{ name: "-l" value: "pthread" mod: "builtin" os: "" cached: "" }, CFlag{ name:
"-D" value: "GC_THREADS=1" mod: "builtin" os: "" cached: "" }]
cc() isprod=false outname=/home/mzh/v/examples/hello_world
> C compiler cmd: 'clang' '@/tmp/v_1002/hello_world.01J8PJ989HDHPDM5EACQ9TFNXZ.tmp.c.rsp'
9826.349 ms C clang
Hello, World!
clang
=========
```

TCC still can't work since tcc can't link ST_NOTTYPE TLS_GD symbol yet, I will figure out how fix it.