### PR TITLE
cgen: fix aliases of array insert(...)/prepend(...) (fix #22323)

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -191,6 +191,24 @@ fn test_prepend_many() {
 	assert a == [5, 6, 1, 2, 3, 4]
 }
 
+type Strings = []string
+
+fn test_aliases_of_array_insert() {
+	mut strs := Strings(['hi'])
+	strs.insert(0, '22')
+	assert strs == ['22', 'hi']
+	strs.insert(1, ['11'])
+	assert strs == ['22', '11', 'hi']
+}
+
+fn test_aliases_of_array_prepend() {
+	mut strs := Strings(['hi'])
+	strs.prepend('22')
+	assert strs == ['22', 'hi']
+	strs.prepend(['44', '33'])
+	assert strs == ['44', '33', '22', 'hi']
+}
+
 fn test_strings() {
 	a := ['a', 'b', 'c']
 	assert a.str() == "['a', 'b', 'c']"

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -879,7 +879,7 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 	elem_type_str := g.typ(left_info.elem_type)
 	arg2_sym := g.table.final_sym(node.args[1].typ)
 	is_arg2_array := arg2_sym.kind == .array
-		&& node.args[1].typ.clear_flag(.variadic) == g.table.unaliased_type(node.left_type)
+		&& node.args[1].typ.clear_flag(.variadic) in [node.left_type, g.table.unaliased_type(node.left_type)]
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg2_array {
@@ -916,7 +916,7 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 	elem_type_str := g.typ(left_info.elem_type)
 	arg_sym := g.table.final_sym(node.args[0].typ)
 	is_arg_array := arg_sym.kind == .array
-		&& node.args[0].typ == g.table.unaliased_type(node.left_type)
+		&& node.args[0].typ in [node.left_type, g.table.unaliased_type(node.left_type)]
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg_array {

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -874,12 +874,12 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 
 // `nums.insert(0, 2)` `nums.insert(0, [2,3,4])`
 fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
-	left_sym := g.table.sym(node.left_type)
+	left_sym := g.table.final_sym(node.left_type)
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
-	arg2_sym := g.table.sym(node.args[1].typ)
+	arg2_sym := g.table.final_sym(node.args[1].typ)
 	is_arg2_array := arg2_sym.kind == .array
-		&& node.args[1].typ.clear_flag(.variadic) == node.left_type
+		&& node.args[1].typ.clear_flag(.variadic) == g.table.unaliased_type(node.left_type)
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg2_array {
@@ -911,11 +911,12 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 
 // `nums.prepend(2)` `nums.prepend([2,3,4])`
 fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
-	left_sym := g.table.sym(node.left_type)
+	left_sym := g.table.final_sym(node.left_type)
 	left_info := left_sym.info as ast.Array
 	elem_type_str := g.typ(left_info.elem_type)
-	arg_sym := g.table.sym(node.args[0].typ)
-	is_arg_array := arg_sym.kind == .array && node.args[0].typ == node.left_type
+	arg_sym := g.table.final_sym(node.args[0].typ)
+	is_arg_array := arg_sym.kind == .array
+		&& node.args[0].typ == g.table.unaliased_type(node.left_type)
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg_array {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1582,7 +1582,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	left_sym := g.table.sym(left_type)
 	final_left_sym := g.table.final_sym(left_type)
 	if left_sym.kind == .array || (final_left_sym.kind == .array
-		&& node.name in ['filter', 'map', 'sort', 'sorted', 'contains', 'any', 'all']) {
+		&& node.name in ['filter', 'map', 'sort', 'sorted', 'contains', 'any', 'all', 'insert', 'prepend']) {
 		if g.gen_array_method_call(node, left_type) {
 			return
 		}


### PR DESCRIPTION
This PR fix aliases of array insert(...)/prepend(...) (fix #22323).

- Fix aliases of array insert(...)/prepend(...).
- Add test.

```v
type Strings = []string

fn main() {
	mut strs := Strings(['hi', '1', '5', '3'])
	strs.insert(0, ['33', '22'])
	println(strs)
	strs.prepend('44')
	println(strs)
}

PS D:\Test\v\tt1> v run .
['33', '22', 'hi', '1', '5', '3']
['44', '33', '22', 'hi', '1', '5', '3']
```