### PR TITLE
checker: add missing checker for `any` type

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -118,6 +118,9 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			node.return_type_pos)
 	}
 	if node.return_type != ast.void_type {
+		if node.language == .v && node.return_type.clear_option_and_result() == ast.any_type {
+			c.error('cannot use type `any` here', node.return_type_pos)
+		}
 		if ct_attr_idx := node.attrs.find_comptime_define() {
 			sexpr := node.attrs[ct_attr_idx].ct_expr.str()
 			c.error('only functions that do NOT return values can have `[if ${sexpr}]` tags',

--- a/vlib/v/checker/tests/any_return_type_err.out
+++ b/vlib/v/checker/tests/any_return_type_err.out
@@ -1,0 +1,42 @@
+vlib/v/checker/tests/any_return_type_err.vv:4:19: error: cannot use type `any` here
+    2 | }
+    3 | 
+    4 | fn (f Test) abc() any {
+      |                   ~~~
+    5 |     return 0
+    6 | }
+vlib/v/checker/tests/any_return_type_err.vv:8:20: error: cannot use type `any` here
+    6 | }
+    7 | 
+    8 | fn (f Test) abc2() ?any {
+      |                    ~~~~
+    9 |     return 0
+   10 | }
+vlib/v/checker/tests/any_return_type_err.vv:12:20: error: cannot use type `any` here
+   10 | }
+   11 | 
+   12 | fn (f Test) abc3() !any {
+      |                    ~~~~
+   13 |     return 0
+   14 | }
+vlib/v/checker/tests/any_return_type_err.vv:16:10: error: cannot use type `any` here
+   14 | }
+   15 | 
+   16 | fn foo() any {
+      |          ~~~
+   17 |     return 3
+   18 | }
+vlib/v/checker/tests/any_return_type_err.vv:20:11: error: cannot use type `any` here
+   18 | }
+   19 | 
+   20 | fn foo2() ?any {
+      |           ~~~~
+   21 |     return 3
+   22 | }
+vlib/v/checker/tests/any_return_type_err.vv:24:11: error: cannot use type `any` here
+   22 | }
+   23 | 
+   24 | fn foo3() !any {
+      |           ~~~~
+   25 |     return 3
+   26 | }

--- a/vlib/v/checker/tests/any_return_type_err.vv
+++ b/vlib/v/checker/tests/any_return_type_err.vv
@@ -1,0 +1,30 @@
+struct Test {
+}
+
+fn (f Test) abc() any {
+	return 0
+}
+
+fn (f Test) abc2() ?any {
+	return 0
+}
+
+fn (f Test) abc3() !any {
+	return 0
+}
+
+fn foo() any {
+	return 3
+}
+
+fn foo2() ?any {
+	return 3
+}
+
+fn foo3() !any {
+	return 3
+}
+
+fn main() {
+	println('any ${foo}')
+}


### PR DESCRIPTION
Fix #12623