### PR TITLE
cgen: fix interface method call after smartcast

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1389,6 +1389,12 @@ pub fn (t &Table) is_interface_var(var ScopeObject) bool {
 		&& t.sym(var.smartcasts.last()).kind != .interface_
 }
 
+@[inline]
+pub fn (t &Table) is_interface_smartcast(var ScopeObject) bool {
+	return var is Var && var.orig_type != 0 && t.sym(var.orig_type).kind == .interface_
+		&& var.smartcasts.len > 0
+}
+
 // only used for debugging V compiler type bugs
 pub fn (t &Table) known_type_names() []string {
 	mut res := []string{cap: t.type_idxs.len}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1743,6 +1743,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			if !node.left.is_lvalue() {
 				g.write('ADDR(${rec_cc_type}, ')
 				cast_n++
+			} else if node.left is ast.Ident && g.table.is_interface_smartcast(node.left.obj) {
+				g.write('ADDR(${rec_cc_type}, ')
+				cast_n++
 			} else if !is_array_method_first_last_repeat && !(left_type.has_flag(.shared_f)
 				&& g.typ(left_type) == g.typ(node.receiver_type)) {
 				g.write('&')

--- a/vlib/v/tests/interfaces/interface_smartcast_call_test.v
+++ b/vlib/v/tests/interfaces/interface_smartcast_call_test.v
@@ -1,0 +1,12 @@
+interface Foo {}
+
+fn (f &Foo) func() {}
+
+struct Bar {}
+
+fn test_main() {
+	mut f := Foo(Bar{})
+	if mut f is Foo {
+		f.func()
+	}
+}


### PR DESCRIPTION
Fix #17056