### PR TITLE
cgen: fix struct init field with alias to array fixed

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -649,7 +649,7 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 		g.inside_cast_in_heap = 0 // prevent use of pointers in child structs
 
 		field_unwrap_typ := g.unwrap_generic(sfield.typ)
-		field_unwrap_sym := g.table.sym(field_unwrap_typ)
+		field_unwrap_sym := g.table.final_sym(field_unwrap_typ)
 		if field_unwrap_sym.kind == .array_fixed && sfield.expr in [ast.Ident, ast.SelectorExpr] {
 			info := field_unwrap_sym.info as ast.ArrayFixed
 			g.fixed_array_var_init(g.expr_string(sfield.expr), sfield.expr.is_auto_deref_var(),

--- a/vlib/v/tests/structs/struct_init_alias_array_fixed_test.v
+++ b/vlib/v/tests/structs/struct_init_alias_array_fixed_test.v
@@ -1,0 +1,23 @@
+module main
+
+type Mat4 = [16]f32
+
+struct VsParams {
+	mv  Mat4
+	mvp Mat4
+}
+
+struct Camera {
+	mv  Mat4
+	mvp Mat4
+}
+
+fn test_main() {
+	camera := Camera{}
+	vs_uniforms := VsParams{
+		mv:  camera.mv
+		mvp: camera.mvp
+	}
+	assert vs_uniforms.mv.len == 16
+	assert vs_uniforms.mvp.len == 16
+}


### PR DESCRIPTION
Fix #22339