### PR TITLE
v.doc: fix scrolling on keyboard select in search results with overflow

### DIFF
--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -311,6 +311,9 @@ hr {
 .doc-nav > .content a:hover {
 	text-decoration: underline;
 }
+.doc-nav .search {
+	overflow: scroll;
+}
 .doc-nav .search.hidden {
 	display: none;
 }


### PR DESCRIPTION
The PR adds the overflow property to the search result division to improve keyboard accessibility. Currently, when cycling from the last search result to the first via keyboard, the selection is not visible because the overflow boundaries of the division are not set. The behaviour is visible in the short screencasts below.

- Current
  
  https://github.com/user-attachments/assets/05908a27-c402-470d-a8dd-8914291fb879


- Updated

  https://github.com/user-attachments/assets/bbdc0efa-5ea8-483a-9ea2-7a64bab6a443
