### PR TITLE
cgen: refactor to streamline gen_map_method_call()

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1017,6 +1017,11 @@ fn (mut g Gen) gen_map_method_call(node ast.CallExpr, left_type ast.Type, left_s
 			g.expr(node.args[0].expr)
 			g.write('})')
 		}
+		'keys', 'values' {
+			g.write('map_${node.name}(')
+			g.gen_arg_from_type(left_type, node.left)
+			g.write(')')
+		}
 		else {
 			return false
 		}
@@ -1678,8 +1683,6 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	mut name := util.no_dots('${receiver_type_name}_${node.name}')
 	if left_sym.kind == .chan && node.name in ['close', 'try_pop', 'try_push'] {
 		name = 'sync__Channel_${node.name}'
-	} else if final_left_sym.kind == .map && node.name in ['keys', 'values'] {
-		name = 'map_${node.name}'
 	}
 	if g.pref.obfuscate && g.cur_mod.name == 'main' && name.starts_with('main__')
 		&& node.name != 'str' {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -987,6 +987,11 @@ fn (mut g Gen) gen_arg_from_type(node_type ast.Type, node ast.Expr) {
 	} else {
 		if node_type.is_ptr() {
 			g.expr(node)
+		} else if !node.is_lvalue()
+			|| (node is ast.Ident && g.table.is_interface_smartcast(node.obj)) {
+			g.write('ADDR(${g.typ(node_type)}, ')
+			g.expr(node)
+			g.write(')')
 		} else {
 			g.write('&')
 			g.expr(node)


### PR DESCRIPTION
This PR refactor to streamline gen_map_method_call().

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZhNzUyNDQzYjBiYWU0OTU4Y2M1YjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.t46LcWGJskubYRaErTpkI3bvv-GWUaVfJOdCK2Vbve8">Huly&reg;: <b>V_0.6-20819</b></a></sub>