### PR TITLE
checker: fix missing check for alias to generic type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -533,7 +533,7 @@ fn (mut c Checker) alias_type_decl(node ast.AliasTypeDecl) {
 		c.error('cannot make an alias of Result type', node.type_pos)
 	}
 	match parent_typ_sym.kind {
-		.placeholder, .int_literal, .float_literal {
+		.placeholder, .int_literal, .float_literal, .any {
 			c.error('unknown aliased type `${parent_typ_sym.name}`', node.type_pos)
 		}
 		.alias {

--- a/vlib/v/checker/tests/alias_to_generic_err.out
+++ b/vlib/v/checker/tests/alias_to_generic_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/alias_to_generic_err.vv:4:12: error: unknown aliased type `T`
+    2 | module main
+    3 | 
+    4 | type Foo = T
+      |            ^
+    5 | 
+    6 | fn main() {

--- a/vlib/v/checker/tests/alias_to_generic_err.out
+++ b/vlib/v/checker/tests/alias_to_generic_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/alias_to_generic_err.vv:4:12: error: unknown aliased type `T`
-    2 | module main
-    3 | 
-    4 | type Foo = T
+vlib/v/checker/tests/alias_to_generic_err.vv:3:12: error: unknown aliased type `T`
+    1 | module main
+    2 | 
+    3 | type Foo = T
       |            ^
-    5 | 
-    6 | fn main() {
+    4 | 
+    5 | fn main() {

--- a/vlib/v/checker/tests/alias_to_generic_err.vv
+++ b/vlib/v/checker/tests/alias_to_generic_err.vv
@@ -1,0 +1,6 @@
+module main
+
+type Foo = T
+
+fn main() {
+}

--- a/vlib/v/checker/tests/any_type_err.out
+++ b/vlib/v/checker/tests/any_type_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/any_type_err.vv:3:16: error: cannot use type `any` here
+vlib/v/checker/tests/any_type_err.vv:3:16: error: unknown aliased type `any`
     1 | // Any types should error, while parametrically polymorphic should not.
     2 | 
     3 | type AnyType = any
@@ -19,6 +19,13 @@ vlib/v/checker/tests/any_type_err.vv:5:27: error: cannot use type `any` here
       |                           ~~~
     6 | 
     7 | type PolyType = T
+vlib/v/checker/tests/any_type_err.vv:7:17: error: unknown aliased type `T`
+    5 | type AnyPolySumType = T | any
+    6 | 
+    7 | type PolyType = T
+      |                 ^
+    8 | type PolySumType = T | string
+    9 |
 vlib/v/checker/tests/any_type_err.vv:11:6: error: cannot use type `any` here
     9 | 
    10 | struct AnyStructField[T] {


### PR DESCRIPTION
Fix #22359

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZhN2NjNDQzYjBiYWU0OTU4Y2UyYTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.GZuO0UZL4XXQnn-8sLZIULhcspvYbmInKidZhKYjZ0k">Huly&reg;: <b>V_0.6-20823</b></a></sub>