### PR TITLE
cgen: fix const with c string literal

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5953,9 +5953,10 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 			}
 			ast.StringLiteral {
 				val := g.expr_string(field.expr)
+				typ := if field.expr.language == .c { 'char*' } else { 'string' }
 				g.global_const_defs[util.no_dots(field.name)] = GlobalConstDef{
 					mod:   field.mod
-					def:   'string ${const_name}; // a string literal, inited later'
+					def:   '${typ} ${const_name}; // a string literal, inited later'
 					init:  '\t${const_name} = ${val};'
 					order: -1
 				}

--- a/vlib/v/tests/consts/const_c_string_test.v
+++ b/vlib/v/tests/consts/const_c_string_test.v
@@ -1,0 +1,7 @@
+const msg = c'test'
+
+fn test_main() {
+	unsafe {
+		assert msg.vstring() == 'test'
+	}
+}


### PR DESCRIPTION
Fix #22358

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZhODE0ZjQzYjBiYWU0OTU4Y2ZiMmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.zh-bPMmuyLcEbB8-btC268zZFo8pV3LBrjdXNJYGyw4">Huly&reg;: <b>V_0.6-20824</b></a></sub>