### PR TITLE
cgen: fix codegen for const of fixed array

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6247,7 +6247,13 @@ fn (mut g Gen) const_decl_init_later_msvc_string_fixed_array(mod string, name st
 	cname := g.c_const_name(name)
 	mut init := strings.new_builder(100)
 	for i, elem_expr in expr.exprs {
-		init.writeln(g.expr_string_surround('\t${cname}[${i}] = ', elem_expr, ';'))
+		if elem_expr is ast.ArrayInit {
+			elem_typ := g.typ(elem_expr.typ)
+			init.writeln(g.expr_string_surround('\tmemcpy(${cname}[${i}], (${elem_typ})',
+				elem_expr, ', sizeof(${elem_typ}));'))
+		} else {
+			init.writeln(g.expr_string_surround('\t${cname}[${i}] = ', elem_expr, ';'))
+		}
 	}
 	mut def := '${styp} ${cname}'
 	g.global_const_defs[util.no_dots(name)] = GlobalConstDef{

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6247,7 +6247,7 @@ fn (mut g Gen) const_decl_init_later_msvc_string_fixed_array(mod string, name st
 	cname := g.c_const_name(name)
 	mut init := strings.new_builder(100)
 	for i, elem_expr in expr.exprs {
-		if elem_expr is ast.ArrayInit {
+		if elem_expr is ast.ArrayInit && elem_expr.is_fixed {
 			elem_typ := g.typ(elem_expr.typ)
 			init.writeln(g.expr_string_surround('\tmemcpy(${cname}[${i}], (${elem_typ})',
 				elem_expr, ', sizeof(${elem_typ}));'))

--- a/vlib/v/tests/consts/const_array_fixed_test.v
+++ b/vlib/v/tests/consts/const_array_fixed_test.v
@@ -10,7 +10,23 @@ __global (
 )
 
 const c = [[a.bar]!]!
+const d = [[a.bar]]!
+const e = [[a.bar]!]
+const f = [[[a.bar]!]!]!
+const g = [a.bar]
 
-fn test_main() {
-	dump(c == [[120]!]!)
+fn test_selector() {
+	assert dump(c == [[a.bar]!]!)
+	assert dump(d == [[a.bar]]!)
+	assert dump(e == [[a.bar]!])
+	assert dump(f == [[[a.bar]!]!]!)
+	assert dump(g == [a.bar])
+}
+
+fn test_literal() {
+	assert dump(c == [[120]!]!)
+	assert dump(d == [[120]]!)
+	assert dump(e == [[120]!])
+	assert dump(f == [[[120]!]!]!)
+	assert dump(g == [120])
 }

--- a/vlib/v/tests/consts/const_array_fixed_test.v
+++ b/vlib/v/tests/consts/const_array_fixed_test.v
@@ -1,0 +1,16 @@
+@[has_globals]
+module main
+
+struct Foo {
+	bar int = 120
+}
+
+__global (
+	a Foo
+)
+
+const c = [[a.bar]!]!
+
+fn test_main() {
+	dump(c == [[120]!]!)
+}


### PR DESCRIPTION
Fix #22357

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZhODRlODQzYjBiYWU0OTU4ZDI1ZDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.kOqSreeHIbfcT6pQlRXbuaooMh5eIstvEcby4raGi-w">Huly&reg;: <b>V_0.6-20827</b></a></sub>