### PR TITLE
cgen: fix comptime variant string interpolation

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -191,7 +191,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int, fmts []u8) {
 	} else if fmt == `s` || typ.has_flag(.variadic) {
 		mut exp_typ := typ
 		if expr is ast.Ident {
-			if g.comptime.is_comptime_var(expr) {
+			if g.comptime.get_ct_type_var(expr) == .smartcast {
 				exp_typ = g.comptime.get_comptime_var_type(expr)
 			} else if expr.obj is ast.Var {
 				if expr.obj.smartcasts.len > 0 {

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -191,7 +191,9 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int, fmts []u8) {
 	} else if fmt == `s` || typ.has_flag(.variadic) {
 		mut exp_typ := typ
 		if expr is ast.Ident {
-			if expr.obj is ast.Var {
+			if g.comptime.is_comptime_var(expr) {
+				exp_typ = g.comptime.get_comptime_var_type(expr)
+			} else if expr.obj is ast.Var {
 				if expr.obj.smartcasts.len > 0 {
 					exp_typ = g.unwrap_generic(expr.obj.smartcasts.last())
 					cast_sym := g.table.sym(exp_typ)

--- a/vlib/v/tests/comptime/comptime_variant_interp_test.v
+++ b/vlib/v/tests/comptime/comptime_variant_interp_test.v
@@ -1,0 +1,23 @@
+module main
+
+struct Foo {
+	a int
+}
+
+type SumType = Foo | int | string
+
+fn (v SumType) cast[T](val T) string {
+	mut res := ''
+	$for variant_value in v.variants {
+		if v is variant_value {
+			println('v: ${v}')
+			res = 'v: ${v}'
+			println(res)
+		}
+	}
+	return res
+}
+
+fn test_main() {
+	assert SumType(1).cast[int](1) == 'v: 1'
+}


### PR DESCRIPTION
Fix #22366

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZhZDJmYjQzYjBiYWU0OTU5MDlmMmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.J1RCiBKO4rRoU6kt37P_KuzrcXUYTDHRgosxKsmEsoE">Huly&reg;: <b>V_0.6-20830</b></a></sub>