### PR TITLE
veb: refactor & fix C error when a port is unavailable

### DIFF
--- a/vlib/net/socket_options.c.v
+++ b/vlib/net/socket_options.c.v
@@ -23,6 +23,7 @@ pub enum SocketOption {
 	tcp_quickack     = C.TCP_QUICKACK
 	tcp_defer_accept = C.TCP_DEFER_ACCEPT
 	tcp_fastopen     = C.TCP_FASTOPEN
+	reuse_port       = C.SO_REUSEPORT
 }
 
 pub const opts_bool = [SocketOption.broadcast, .debug, .dont_route, .error, .keep_alive, .oob_inline]

--- a/vlib/net/socket_options.c.v
+++ b/vlib/net/socket_options.c.v
@@ -19,6 +19,10 @@ pub enum SocketOption {
 	send_timeout     = C.SO_SNDTIMEO
 	socket_type      = C.SO_TYPE
 	ipv6_only        = C.IPV6_V6ONLY
+	ip_proto_ipv6    = C.IPPROTO_IPV6
+	tcp_quickack     = C.TCP_QUICKACK
+	tcp_defer_accept = C.TCP_DEFER_ACCEPT
+	tcp_fastopen     = C.TCP_FASTOPEN
 }
 
 pub const opts_bool = [SocketOption.broadcast, .debug, .dont_route, .error, .keep_alive, .oob_inline]

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -5,6 +5,7 @@ import strings
 
 pub const tcp_default_read_timeout = 30 * time.second
 pub const tcp_default_write_timeout = 30 * time.second
+pub const int_size = sizeof(int)
 
 // TCPDialer is a concrete instance of the Dialer interface,
 // for creating tcp connections.
@@ -355,7 +356,7 @@ pub:
 }
 
 pub fn listen_tcp(family AddrFamily, saddr string, options ListenOptions) !&TcpListener {
-	if family != .ip && family != .ip6 {
+	if family !in [.ip, .ip6] {
 		return error('listen_tcp only supports ip and ip6')
 	}
 	mut s := new_tcp_socket(family) or { return error('${err.msg()}; could not create new socket') }
@@ -571,7 +572,7 @@ pub fn tcp_socket_from_handle_raw(sockfd int) TcpSocket {
 }
 
 fn (mut s TcpSocket) set_option(level int, opt int, value int) ! {
-	socket_error(C.setsockopt(s.handle, level, opt, &value, sizeof(int)))!
+	socket_error(C.setsockopt(s.handle, level, opt, &value, int_size))!
 }
 
 pub fn (mut s TcpSocket) set_option_bool(opt SocketOption, value bool) ! {

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -516,7 +516,7 @@ struct TcpSocket {
 // This is a workaround for issue https://github.com/vlang/v/issues/20858
 // `noline` ensure that in `-prod` mode(CFLAG = `-O3 -flto`), gcc does not generate wrong instruction sequence
 @[noinline]
-fn new_tcp_socket(family AddrFamily) !TcpSocket {
+pub fn new_tcp_socket(family AddrFamily) !TcpSocket {
 	handle := $if is_coroutine ? {
 		socket_error(C.photon_socket(family, SocketType.tcp, 0))!
 	} $else {

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -113,8 +113,7 @@ fn listen(config Config) !int {
 		socket.set_option_bool(.reuse_port, true)!
 		socket.set_option_bool(.tcp_quickack, true)!
 		socket.set_option_int(.tcp_defer_accept, config.timeout_secs)!
-		queue_len := max_queue
-		net.socket_error(C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_FASTOPEN, &queue_len, sizeof(int)))!
+		socket.set_option_int(.tcp_fastopen, max_queue)!
 	}
 
 	// addr settings


### PR DESCRIPTION
Fixes: https://github.com/vlang/v/issues/22292
Now veb it's using net module instead of calls of C to create the tcp socket
Makes some fn of net. public

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZiMTg2NDQzYjBiYWU0OTU5M2Q2MmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.yTVm2o7CnItv6asASu33wI-ANyQu6VfTkrQWSx5bpgo">Huly&reg;: <b>V_0.6-20834</b></a></sub>