### PR TITLE
net: Allow special cases of ipv6 with ipv4 format

### DIFF
--- a/vlib/net/tcp_simple_client_server_test.v
+++ b/vlib/net/tcp_simple_client_server_test.v
@@ -66,7 +66,7 @@ fn test_socket_write_and_read() {
 	mut server, mut client, mut socket := setup()
 	addr := socket.peer_addr()!
 	ip := socket.peer_ip()!
-	assert ip in ['::1', 'localhost', '127.0.0.1']
+	assert ip in ['::1', 'localhost', '127.0.0.1', '::ffff:127.0.0.1']
 	println('> ip: ${ip} | addr: ${addr}')
 	defer {
 		cleanup(mut server, mut client, mut socket)


### PR DESCRIPTION
In some systems the IP address ::ffff:127.0.0.1 (which is equivalent to the local loopback address 127.0.0.1) it's used, allow to prevent the test fail

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZjNDA4MjQzYjBiYWU0OTVhMWE2YmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.fINV4L4cid8vY97OUs331xBHNgop1k0I6mdkFgh12a8">Huly&reg;: <b>V_0.6-20847</b></a></sub>