### PR TITLE
cgen: fix enum with comptime const value (fix #22386)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4406,6 +4406,8 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 				const_def := g.global_const_defs[util.no_dots(field.expr.name)]
 				if const_def.def.starts_with('#define') {
 					g.enum_typedefs.write_string(const_def.def.all_after_last(' '))
+				} else if const_def.def.contains('const') {
+					g.enum_typedefs.write_string(const_def.def.all_after_last('=').all_before_last(';'))
 				} else {
 					g.enum_typedefs.write_string(expr_str)
 				}

--- a/vlib/v/tests/enums/enum_with_comptime_const_test.v
+++ b/vlib/v/tests/enums/enum_with_comptime_const_test.v
@@ -1,0 +1,10 @@
+const enum_value = $if linux { 1 } $else { 2 }
+
+pub enum Test {
+	a = enum_value
+}
+
+fn test_enum_with_comptime_const() {
+	println(Test.a)
+	assert true
+}


### PR DESCRIPTION
This PR fix enum with comptime const value (fix #22386).

- Fix enum with comptime const value.
- Add test.

```v
const enum_value = $if linux { 1 } $else { 2 }

pub enum Test {
	a = enum_value
}

fn main() {
	println(Test.a)
}

PS D:\Test\v\tt1> v run .
a
```