### PR TITLE
scanner: remove redundancy from the message suggesting to use quotes instead of backticks for characters

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1640,19 +1640,16 @@ pub fn (mut s Scanner) ident_char() string {
 				s.error_with_pos('invalid character literal `${orig}` => `${c}` ([${err_info.join(', ')}]) (escape sequence did not refer to a singular rune)',
 					lspos)
 			} else if u.len == 0 {
-				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
-					lspos)
+				s.add_error_detail('use quotes for strings, backticks for characters')
 				s.error_with_pos('invalid empty character literal `${orig}`', lspos)
 			} else {
-				s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
-					lspos)
+				s.add_error_detail('use quotes for strings, backticks for characters')
 				s.error_with_pos('invalid character literal `${orig}` => `${c}` ([${err_info.join(', ')}]) (more than one character)',
 					lspos)
 			}
 		}
 	} else if c.ends_with('\n') {
-		s.add_error_detail_with_pos('use quotes for strings, backticks for characters',
-			lspos)
+		s.add_error_detail('use quotes for strings, backticks for characters')
 		s.error_with_pos('invalid character literal, use \`\\n\` instead', lspos)
 	} else if c.len > len {
 		ch := c[c.len - 1]

--- a/vlib/v/scanner/tests/empty_character_literal_err.out
+++ b/vlib/v/scanner/tests/empty_character_literal_err.out
@@ -4,10 +4,4 @@ vlib/v/scanner/tests/empty_character_literal_err.vv:2:7: error: invalid empty ch
       |          ^
     3 |     println(a)
     4 | }
-Details:
-vlib/v/scanner/tests/empty_character_literal_err.vv:2:7: details: use quotes for strings, backticks for characters
-    1 | fn main() {
-    2 |     a := ``
-      |          ^
-    3 |     println(a)
-    4 | }
+Details: use quotes for strings, backticks for characters

--- a/vlib/v/scanner/tests/invalid_character_literal_err_1.out
+++ b/vlib/v/scanner/tests/invalid_character_literal_err_1.out
@@ -1,7 +1,4 @@
 vlib/v/scanner/tests/invalid_character_literal_err_1.vv:1:6: error: invalid character literal `\n\t` => `\n\t` ([`\n`, `\t`]) (more than one character)
     1 | a := `\n\t`
       |      ^
-Details: 
-vlib/v/scanner/tests/invalid_character_literal_err_1.vv:1:6: details: use quotes for strings, backticks for characters
-    1 | a := `\n\t`
-      |      ^
+Details: use quotes for strings, backticks for characters

--- a/vlib/v/scanner/tests/invalid_character_literal_err_2.out
+++ b/vlib/v/scanner/tests/invalid_character_literal_err_2.out
@@ -1,7 +1,4 @@
 vlib/v/scanner/tests/invalid_character_literal_err_2.vv:1:6: error: invalid character literal `\nb` => `\nb` ([`\n`, `b`]) (more than one character)
     1 | a := `\nb`
       |      ^
-Details: 
-vlib/v/scanner/tests/invalid_character_literal_err_2.vv:1:6: details: use quotes for strings, backticks for characters
-    1 | a := `\nb`
-      |      ^
+Details: use quotes for strings, backticks for characters

--- a/vlib/v/scanner/tests/newline_character_literal_err.out
+++ b/vlib/v/scanner/tests/newline_character_literal_err.out
@@ -4,10 +4,4 @@ vlib/v/scanner/tests/newline_character_literal_err.vv:2:7: error: invalid charac
       |          ^
     3 | `
     4 |     println(a)
-Details:
-vlib/v/scanner/tests/newline_character_literal_err.vv:2:7: details: use quotes for strings, backticks for characters
-    1 | fn main() {
-    2 |     a := `
-      |          ^
-    3 | `
-    4 |     println(a)
+Details: use quotes for strings, backticks for characters

--- a/vlib/v/scanner/tests/unknown_escape_sequence_in_ident_char_1_err.out
+++ b/vlib/v/scanner/tests/unknown_escape_sequence_in_ident_char_1_err.out
@@ -4,10 +4,4 @@ vlib/v/scanner/tests/unknown_escape_sequence_in_ident_char_1_err.vv:2:6: error: 
       |         ^
     3 | `
     4 | }
-Details: 
-vlib/v/scanner/tests/unknown_escape_sequence_in_ident_char_1_err.vv:2:6: details: use quotes for strings, backticks for characters
-    1 | fn main() {
-    2 |     _ = `\
-      |         ^
-    3 | `
-    4 | }
+Details: use quotes for strings, backticks for characters


### PR DESCRIPTION
When using "`" for literals that are not characters, the compiler recommends using quotes for string, so far everything is fine, the problem is that when the compiler recommends that, it returns to showing the position where the error occurs, which is unnecessary, since the position is already shown previously. 

This PR removes that part of the suggestion.

Before:
```v
main.v:2:9: error: invalid character literal `ABC` => `ABC` ([`A`, `B`, `C`]) (more than one character)
    1 | fn main() {
    2 |     _ = `ABC`
      |         ^
    3 | }
Details: 
main.v:2:9: details: use quotes for strings, backticks for characters
    1 | fn main() {
    2 |     _ = `ABC`
      |         ^
    3 | }
```

After:
```v
main.v:2:9: error: invalid character literal `ABC` => `ABC` ([`A`, `B`, `C`]) (more than one character)
    1 | fn main() {
    2 |     _ = `ABC`
      |         ^
    3 | }
Details: use quotes for strings, backticks for characters
```