### PR TITLE
tests: use `value` and show the .len field for the left/right values shown in failing assertions

### DIFF
--- a/vlib/v/preludes/test_runner_normal.v
+++ b/vlib/v/preludes/test_runner_normal.v
@@ -131,10 +131,10 @@ fn (mut runner NormalTestRunner) assert_fail(i &VAssertMetaInfo) {
 	}
 	eprintln('${final_filepath} ${final_funcname}')
 	if i.op.len > 0 && i.op != 'call' {
-		mut lvtitle := '    Left value:'
-		mut rvtitle := '    Right value:'
-		mut slvalue := '${i.lvalue}'
-		mut srvalue := '${i.rvalue}'
+		mut lvtitle := '    Left value (len: ${i.lvalue.len}):'
+		mut rvtitle := '    Right value (len: ${i.rvalue.len}):'
+		mut slvalue := '`${i.lvalue}`'
+		mut srvalue := '`${i.rvalue}`'
 		// Do not print duplicate values to avoid confusion. In mosts tests the developer does
 		// `assert foo() == [1, 2, 3]`
 		// There's no need to print "[1, 2, 3]" again (left: [1,2,3,4]  right:[1,2,3])

--- a/vlib/v/tests/skip_unused/assert_with_extra_message_works_test.run.out
+++ b/vlib/v/tests/skip_unused/assert_with_extra_message_works_test.run.out
@@ -1,6 +1,6 @@
 vlib/v/tests/skip_unused/assert_with_extra_message_works_test.vv:7: fn test_interpolation_with_assert_that_has_extra_message
    > assert 'abc$i' != 'abc77', my_failure_message(i)
-     Left value: abc77
-    Right value: abc77
+     Left value (len: 5): `abc77`
+    Right value (len: 5): `abc77`
         Message: the assert failed :-|, i: 77
 

--- a/vlib/v/tests/skip_unused/assert_with_extra_message_works_test.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/assert_with_extra_message_works_test.skip_unused.run.out
@@ -1,6 +1,6 @@
 vlib/v/tests/skip_unused/assert_with_extra_message_works_test.vv:7: fn test_interpolation_with_assert_that_has_extra_message
    > assert 'abc$i' != 'abc77', my_failure_message(i)
-     Left value: abc77
-    Right value: abc77
+     Left value (len: 5): `abc77`
+    Right value (len: 5): `abc77`
         Message: the assert failed :-|, i: 77
 

--- a/vlib/v/tests/skip_unused/assert_works_test.run.out
+++ b/vlib/v/tests/skip_unused/assert_works_test.run.out
@@ -1,5 +1,5 @@
 vlib/v/tests/skip_unused/assert_works_test.vv:2: fn test_abc
    > assert 'abc' == 'xyz'
-     Left value: abc
-    Right value: xyz
+     Left value (len: 3): `abc`
+    Right value (len: 3): `xyz`
 

--- a/vlib/v/tests/skip_unused/assert_works_test.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/assert_works_test.skip_unused.run.out
@@ -1,5 +1,5 @@
 vlib/v/tests/skip_unused/assert_works_test.vv:2: fn test_abc
    > assert 'abc' == 'xyz'
-     Left value: abc
-    Right value: xyz
+     Left value (len: 3): `abc`
+    Right value (len: 3): `xyz`
 


### PR DESCRIPTION
Following a discussion in Discord: https://discord.com/channels/592103645835821068/592106336838352923/1291054248938836019 .
Before:
![image](https://github.com/user-attachments/assets/305beb6e-e80c-4b15-9f81-abcf693f32de)

After:
![image](https://github.com/user-attachments/assets/59b3257b-7d18-43b0-acb8-fe21cb60030a)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmZkYmNjZjQzYjBiYWU0OTViMWZlZWEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Pwdf25iYF54kVY-6RwIL-Onj4RFD2EMD45DBPeh1IXY">Huly&reg;: <b>V_0.6-20855</b></a></sub>