### PR TITLE
fix ANSI pathname under windows

### DIFF
--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -1,12 +1,14 @@
 module main
 
 import os
+import encoding.iconv
 
 const vexe = @VEXE
 const test_path = os.join_path(os.vtmp_dir(), 'run_check')
+const test_path2 = os.join_path(test_path, '测试目录')
 
 fn testsuite_begin() {
-	os.mkdir_all(test_path) or {}
+	os.mkdir_all(test_path2) or {}
 }
 
 fn testsuite_end() {
@@ -40,6 +42,36 @@ fn test_conditional_executable_removal() {
 
 	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
 	after_second_run___ := os.ls(test_path)!
+	dump(after_second_run___)
+	assert executable in after_second_run___
+}
+
+fn test_windows_ansi_path_name() {
+	os.chdir(test_path2)!
+	os.write_file('测试.v', 'fn main(){\n\tprintln("Hello World!")\n}\n')!
+
+	mut executable := '测试'
+	$if windows {
+		executable += '.exe'
+	}
+
+	original_file_list_ := os.ls(test_path2)!
+	dump(original_file_list_)
+	assert executable !in original_file_list_
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_run_file_list := os.ls(test_path2)!.filter(os.exists(it))
+	dump(after_run_file_list)
+	assert executable !in after_run_file_list
+
+	assert os.execute('${os.quoted_path(vexe)} . -o ${executable}').exit_code == 0
+	assert os.execute('./${executable}').output.trim_space() == 'Hello World!'
+	after_compilation__ := os.ls(test_path2)!
+	dump(after_compilation__)
+	assert executable in after_compilation__
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_second_run___ := os.ls(test_path2)!
 	dump(after_second_run___)
 	assert executable in after_second_run___
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -9,6 +9,7 @@ import v.pref
 import v.util
 import v.vcache
 import term
+import encoding.iconv
 
 const c_std = 'c99'
 const c_std_gnu = 'gnu99'
@@ -666,8 +667,15 @@ pub fn (mut v Builder) cc() {
 			response_file_content = str_args.replace('\\', '\\\\')
 			rspexpr := '@${response_file}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
-			os.write_file(response_file, response_file_content) or {
-				verror('Unable to write to C response file "${response_file}"')
+			$if windows {
+				// Windows use ANSI encoding for path/filename
+				// NOTE: use 'ANSI' encoding, not 'UTF-8'
+				iconv.write_file_encoding(response_file, response_file_content, 'ANSI',
+					false) or { verror('Unable to write to C response file "${response_file}"') }
+			} $else {
+				os.write_file(response_file, response_file_content) or {
+					verror('Unable to write to C response file "${response_file}"')
+				}
 			}
 		}
 		if !v.ccoptions.debug_mode {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -4,6 +4,7 @@ import os
 import time
 import v.util
 import v.cflag
+import encoding.iconv
 
 #flag windows -l shell32
 #flag windows -l dbghelp
@@ -357,7 +358,8 @@ pub fn (mut v Builder) cc_msvc() {
 	v.dump_c_options(a)
 	args := a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	os.write_file(out_name_cmd_line, args) or {
+	// NOTE: use 'ANSI' encoding, not 'UTF-8'
+	iconv.write_file_encoding(out_name_cmd_line, args, 'ANSI', false) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

fix #21502

This PR will make compile non-English pathname/filename under Windows possible.
For example:
```sh
v D:\测试目录\测试.v
测试.exe
```
