### PR TITLE
Fix iconv type cstrict

### DIFF
--- a/vlib/encoding/iconv/iconv_nix.c.v
+++ b/vlib/encoding/iconv/iconv_nix.c.v
@@ -5,9 +5,9 @@ module iconv
 #include <iconv.h>
 #flag darwin -liconv
 
-fn C.iconv_open(tocode &u8, fromcode &u8) voidptr
+fn C.iconv_open(tocode charptr, fromcode charptr) voidptr
 fn C.iconv_close(cd voidptr) int
-fn C.iconv(cd voidptr, inbuf &&u8, inbytesleft &usize, outbuf &&u8, outbytesleft &usize) usize
+fn C.iconv(cd voidptr, inbuf &charptr, inbytesleft &usize, outbuf &charptr, outbytesleft &usize) usize
 
 // conv convert `fromcode` encoding string to `tocode` encoding string
 @[direct_array_access]
@@ -35,7 +35,7 @@ fn conv(tocode string, fromcode string, src &u8, src_len int) ![]u8 {
 		else {}
 	}
 
-	mut cd := C.iconv_open(dst_encoding.str, src_encoding.str)
+	mut cd := C.iconv_open(charptr(dst_encoding.str), charptr(src_encoding.str))
 	if isize(cd) == -1 {
 		return error('platform can\'t convert from ${src_encoding} to ${dst_encoding}')
 	}
@@ -43,8 +43,8 @@ fn conv(tocode string, fromcode string, src &u8, src_len int) ![]u8 {
 
 	mut dst := []u8{len: (src_len + 1) * 4} // this should be enough to hold the dst encoding string
 
-	mut src_ptr := &u8(src)
-	mut dst_ptr := &u8(dst.data)
+	mut src_ptr := charptr(src)
+	mut dst_ptr := charptr(dst.data)
 	mut src_left := usize(src_len)
 	mut dst_left := usize(dst.len)
 	res := C.iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left)

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -1,12 +1,14 @@
 module main
 
 import os
+import encoding.iconv
 
 const vexe = @VEXE
 const test_path = os.join_path(os.vtmp_dir(), 'run_check')
+const test_path2 = os.join_path(test_path, '测试目录')
 
 fn testsuite_begin() {
-	os.mkdir_all(test_path) or {}
+	os.mkdir_all(test_path2) or {}
 }
 
 fn testsuite_end() {
@@ -40,6 +42,36 @@ fn test_conditional_executable_removal() {
 
 	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
 	after_second_run___ := os.ls(test_path)!
+	dump(after_second_run___)
+	assert executable in after_second_run___
+}
+
+fn test_windows_ansi_path_name() {
+	os.chdir(test_path2)!
+	os.write_file('测试.v', 'fn main(){\n\tprintln("Hello World!")\n}\n')!
+
+	mut executable := '测试'
+	$if windows {
+		executable += '.exe'
+	}
+
+	original_file_list_ := os.ls(test_path2)!
+	dump(original_file_list_)
+	assert executable !in original_file_list_
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_run_file_list := os.ls(test_path2)!.filter(os.exists(it))
+	dump(after_run_file_list)
+	assert executable !in after_run_file_list
+
+	assert os.execute('${os.quoted_path(vexe)} . -o ${executable}').exit_code == 0
+	assert os.execute('./${executable}').output.trim_space() == 'Hello World!'
+	after_compilation__ := os.ls(test_path2)!
+	dump(after_compilation__)
+	assert executable in after_compilation__
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_second_run___ := os.ls(test_path2)!
 	dump(after_second_run___)
 	assert executable in after_second_run___
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -9,6 +9,7 @@ import v.pref
 import v.util
 import v.vcache
 import term
+import encoding.iconv
 
 const c_std = 'c99'
 const c_std_gnu = 'gnu99'
@@ -666,8 +667,15 @@ pub fn (mut v Builder) cc() {
 			response_file_content = str_args.replace('\\', '\\\\')
 			rspexpr := '@${response_file}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
-			os.write_file(response_file, response_file_content) or {
-				verror('Unable to write to C response file "${response_file}"')
+			$if windows {
+				// Windows use ANSI encoding for path/filename
+				// NOTE: use 'ANSI' encoding, not 'UTF-8'
+				iconv.write_file_encoding(response_file, response_file_content, 'ANSI',
+					false) or { verror('Unable to write to C response file "${response_file}"') }
+			} $else {
+				os.write_file(response_file, response_file_content) or {
+					verror('Unable to write to C response file "${response_file}"')
+				}
 			}
 		}
 		if !v.ccoptions.debug_mode {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -4,6 +4,7 @@ import os
 import time
 import v.util
 import v.cflag
+import encoding.iconv
 
 #flag windows -l shell32
 #flag windows -l dbghelp
@@ -357,7 +358,8 @@ pub fn (mut v Builder) cc_msvc() {
 	v.dump_c_options(a)
 	args := a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	os.write_file(out_name_cmd_line, args) or {
+	// NOTE: use 'ANSI' encoding, not 'UTF-8'
+	iconv.write_file_encoding(out_name_cmd_line, args, 'ANSI', false) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

fix clang -cstrict error


```sh
/tmp/v_1000/xx.01J980Z12CW3YET5B6W4SNBXKN.tmp.c:42438:18: error: passing 'u8 *' (aka 'unsigned char *') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
 42438 |         cd = iconv_open(dst_encoding.str, src_encoding.str);
       |                         ^~~~~~~~~~~~~~~~
/usr/include/iconv.h:43:40: note: passing argument to parameter '__tocode' here
   43 | extern iconv_t iconv_open (const char *__tocode, const char *__fromcode)
      |                                        ^
/tmp/v_1000/xx.01J980Z12CW3YET5B6W4SNBXKN.tmp.c:42438:36: error: passing 'u8 *' (aka 'unsigned char *') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
 42438 |         cd = iconv_open(dst_encoding.str, src_encoding.str);
       |                                           ^~~~~~~~~~~~~~~~
/usr/include/iconv.h:43:62: note: passing argument to parameter '__fromcode' here
   43 | extern iconv_t iconv_open (const char *__tocode, const char *__fromcode)
      |                                                              ^
/tmp/v_1000/xx.01J980Z12CW3YET5B6W4SNBXKN.tmp.c:42448:24: error: incompatible pointer types passing 'u8 **' (aka 'unsigned char **') to parameter of type 'char **' [-Werror,-Wincompatible-pointer-types]
 42448 |         usize res = iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left);
       |                               ^~~~~~~~
/usr/include/iconv.h:49:54: note: passing argument to parameter '__inbuf' here
   49 | extern size_t iconv (iconv_t __cd, char **__restrict __inbuf,
      |                                                      ^
/tmp/v_1000/xx.01J980Z12CW3YET5B6W4SNBXKN.tmp.c:42448:45: error: incompatible pointer types passing 'u8 **' (aka 'unsigned char **') to parameter of type 'char **' [-Werror,-Wincompatible-pointer-types]
 42448 |         usize res = iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left);
       |                                                    ^~~~~~~~
/usr/include/iconv.h:51:26: note: passing argument to parameter '__outbuf' here
   51 |                      char **__restrict __outbuf,
      |                                        ^
4 errors generated.
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .
```
