### PR TITLE
Fix iconv type cstrict, and LOCAL encoding support

### DIFF
--- a/vlib/encoding/iconv/iconv.v
+++ b/vlib/encoding/iconv/iconv.v
@@ -16,9 +16,18 @@ fn reverse_u32(src u32) u32 {
 // vstring_to_encoding convert V string `str` to `tocode` encoding string
 // tips: use `iconv --list` check for supported encodings
 pub fn vstring_to_encoding(str string, tocode string) ![]u8 {
-	encoding_name := tocode.to_upper()
+	mut encoding_name := tocode.to_upper()
 	if encoding_name in ['UTF16', 'UTF32', 'UTF-16', 'UTF-32']! {
 		return error('please use UTF16-LE/UTF-16BE/UTF-32LE/UTF-32BE instead')
+	}
+	$if windows {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'ANSI'
+		}
+	} $else {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'UTF-8'
+		}
 	}
 	return conv(tocode, 'UTF-8', str.str, str.len)
 }
@@ -26,9 +35,18 @@ pub fn vstring_to_encoding(str string, tocode string) ![]u8 {
 // encoding_to_vstring converts the given `bytes` using `fromcode` encoding, to a V string (encoded with UTF-8)
 // tips: use `iconv --list` check for supported encodings
 pub fn encoding_to_vstring(bytes []u8, fromcode string) !string {
-	encoding_name := fromcode.to_upper()
+	mut encoding_name := fromcode.to_upper()
 	if encoding_name in ['UTF16', 'UTF32', 'UTF-16', 'UTF-32']! {
 		return error('please use UTF16-LE/UTF-16BE/UTF-32LE/UTF-32BE instead')
+	}
+	$if windows {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'ANSI'
+		}
+	} $else {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'UTF-8'
+		}
 	}
 	mut dst := conv('UTF-8', fromcode, bytes.data, bytes.len)!
 	dst << 0 // add a tail zero, to build a vstring
@@ -43,7 +61,17 @@ pub fn encoding_to_vstring(bytes []u8, fromcode string) !string {
 // for utf32be, it will prepend 0x0000FEFF to the `src`
 pub fn create_utf_string_with_bom(src []u8, utf_type string) []u8 {
 	mut clone := src.clone()
-	match utf_type.to_upper() {
+	mut encoding_name := utf_type.to_upper()
+	$if windows {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'ANSI'
+		}
+	} $else {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'UTF-8'
+		}
+	}
+	match encoding_name {
 		'UTF8', 'UTF-8' {
 			clone.prepend([u8(0xEF), 0xBB, 0xBF])
 		}
@@ -73,7 +101,17 @@ pub fn create_utf_string_with_bom(src []u8, utf_type string) []u8 {
 @[direct_array_access]
 pub fn remove_utf_string_with_bom(src []u8, utf_type string) []u8 {
 	mut clone := src.clone()
-	match utf_type.to_upper() {
+	mut encoding_name := utf_type.to_upper()
+	$if windows {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'ANSI'
+		}
+	} $else {
+		if encoding_name == 'LOCAL' {
+			encoding_name = 'UTF-8'
+		}
+	}
+	match encoding_name {
 		'UTF8', 'UTF-8' {
 			if clone.len > 3 {
 				if clone[0] == u8(0xEF) && clone[1] == u8(0xBB) && clone[2] == u8(0xBF) {
@@ -119,10 +157,6 @@ pub fn remove_utf_string_with_bom(src []u8, utf_type string) []u8 {
 // write_file_encoding write_file convert `text` into `encoding` and writes to a file with the given `path`. If `path` already exists, it will be overwritten.
 // For `encoding` in UTF8/UTF16/UTF32, if `bom` is true, then a BOM header will write to the file.
 pub fn write_file_encoding(path string, text string, encoding string, bom bool) ! {
-	encoding_name := encoding.to_upper()
-	if encoding_name in ['UTF16', 'UTF32', 'UTF-16', 'UTF-32']! {
-		return error('please use UTF-16LE/UTF-16BE/UTF-32LE/UTF-32BE instead')
-	}
 	encoding_bytes := vstring_to_encoding(text, encoding)!
 	if bom && encoding.to_upper().starts_with('UTF') {
 		encoding_bom_bytes := create_utf_string_with_bom(encoding_bytes, encoding)
@@ -134,10 +168,6 @@ pub fn write_file_encoding(path string, text string, encoding string, bom bool) 
 
 // read_file_encoding reads the file in `path` with `encoding` and returns the contents
 pub fn read_file_encoding(path string, encoding string) !string {
-	encoding_name := encoding.to_upper()
-	if encoding_name in ['UTF16', 'UTF32', 'UTF-16', 'UTF-32']! {
-		return error('please use UTF-16LE/UTF-16BE/UTF-32LE/UTF-32BE instead')
-	}
 	encoding_bytes := os.read_file_array[u8](path)
 	encoding_without_bom_bytes := remove_utf_string_with_bom(encoding_bytes, encoding)
 	return encoding_to_vstring(encoding_without_bom_bytes, encoding)!

--- a/vlib/encoding/iconv/iconv_nix.c.v
+++ b/vlib/encoding/iconv/iconv_nix.c.v
@@ -5,9 +5,9 @@ module iconv
 #include <iconv.h>
 #flag darwin -liconv
 
-fn C.iconv_open(tocode &u8, fromcode &u8) voidptr
+fn C.iconv_open(tocode charptr, fromcode charptr) voidptr
 fn C.iconv_close(cd voidptr) int
-fn C.iconv(cd voidptr, inbuf &&u8, inbytesleft &usize, outbuf &&u8, outbytesleft &usize) usize
+fn C.iconv(cd voidptr, inbuf &charptr, inbytesleft &usize, outbuf &charptr, outbytesleft &usize) usize
 
 // conv convert `fromcode` encoding string to `tocode` encoding string
 @[direct_array_access]
@@ -35,7 +35,7 @@ fn conv(tocode string, fromcode string, src &u8, src_len int) ![]u8 {
 		else {}
 	}
 
-	mut cd := C.iconv_open(dst_encoding.str, src_encoding.str)
+	mut cd := C.iconv_open(charptr(dst_encoding.str), charptr(src_encoding.str))
 	if isize(cd) == -1 {
 		return error('platform can\'t convert from ${src_encoding} to ${dst_encoding}')
 	}
@@ -43,8 +43,8 @@ fn conv(tocode string, fromcode string, src &u8, src_len int) ![]u8 {
 
 	mut dst := []u8{len: (src_len + 1) * 4} // this should be enough to hold the dst encoding string
 
-	mut src_ptr := &u8(src)
-	mut dst_ptr := &u8(dst.data)
+	mut src_ptr := charptr(src)
+	mut dst_ptr := charptr(dst.data)
 	mut src_left := usize(src_len)
 	mut dst_left := usize(dst.len)
 	res := C.iconv(cd, &src_ptr, &src_left, &dst_ptr, &dst_left)

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -1,12 +1,14 @@
 module main
 
 import os
+import encoding.iconv
 
 const vexe = @VEXE
 const test_path = os.join_path(os.vtmp_dir(), 'run_check')
+const test_path2 = os.join_path(test_path, '测试目录')
 
 fn testsuite_begin() {
-	os.mkdir_all(test_path) or {}
+	os.mkdir_all(test_path2) or {}
 }
 
 fn testsuite_end() {
@@ -40,6 +42,36 @@ fn test_conditional_executable_removal() {
 
 	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
 	after_second_run___ := os.ls(test_path)!
+	dump(after_second_run___)
+	assert executable in after_second_run___
+}
+
+fn test_windows_ansi_path_name() {
+	os.chdir(test_path2)!
+	os.write_file('测试.v', 'fn main(){\n\tprintln("Hello World!")\n}\n')!
+
+	mut executable := '测试'
+	$if windows {
+		executable += '.exe'
+	}
+
+	original_file_list_ := os.ls(test_path2)!
+	dump(original_file_list_)
+	assert executable !in original_file_list_
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_run_file_list := os.ls(test_path2)!.filter(os.exists(it))
+	dump(after_run_file_list)
+	assert executable !in after_run_file_list
+
+	assert os.execute('${os.quoted_path(vexe)} . -o ${executable}').exit_code == 0
+	assert os.execute('./${executable}').output.trim_space() == 'Hello World!'
+	after_compilation__ := os.ls(test_path2)!
+	dump(after_compilation__)
+	assert executable in after_compilation__
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_second_run___ := os.ls(test_path2)!
 	dump(after_second_run___)
 	assert executable in after_second_run___
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -9,6 +9,7 @@ import v.pref
 import v.util
 import v.vcache
 import term
+import encoding.iconv
 
 const c_std = 'c99'
 const c_std_gnu = 'gnu99'
@@ -666,8 +667,15 @@ pub fn (mut v Builder) cc() {
 			response_file_content = str_args.replace('\\', '\\\\')
 			rspexpr := '@${response_file}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
-			os.write_file(response_file, response_file_content) or {
-				verror('Unable to write to C response file "${response_file}"')
+			$if windows {
+				// Windows use ANSI encoding for path/filename
+				// NOTE: use 'ANSI' encoding, not 'UTF-8'
+				iconv.write_file_encoding(response_file, response_file_content, 'ANSI',
+					false) or { verror('Unable to write to C response file "${response_file}"') }
+			} $else {
+				os.write_file(response_file, response_file_content) or {
+					verror('Unable to write to C response file "${response_file}"')
+				}
 			}
 		}
 		if !v.ccoptions.debug_mode {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -667,15 +667,10 @@ pub fn (mut v Builder) cc() {
 			response_file_content = str_args.replace('\\', '\\\\')
 			rspexpr := '@${response_file}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
-			$if windows {
-				// Windows use ANSI encoding for path/filename
-				// NOTE: use 'ANSI' encoding, not 'UTF-8'
-				iconv.write_file_encoding(response_file, response_file_content, 'ANSI',
-					false) or { verror('Unable to write to C response file "${response_file}"') }
-			} $else {
-				os.write_file(response_file, response_file_content) or {
-					verror('Unable to write to C response file "${response_file}"')
-				}
+			// Windows use ANSI encoding for path/filename, but Linux use UTF-8
+			// LOCAL encoding: this is ANSI under Windows, UTF-8 under Linux
+			iconv.write_file_encoding(response_file, response_file_content, 'LOCAL', false) or {
+				verror('Unable to write to C response file "${response_file}"')
 			}
 		}
 		if !v.ccoptions.debug_mode {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -4,6 +4,7 @@ import os
 import time
 import v.util
 import v.cflag
+import encoding.iconv
 
 #flag windows -l shell32
 #flag windows -l dbghelp
@@ -357,7 +358,8 @@ pub fn (mut v Builder) cc_msvc() {
 	v.dump_c_options(a)
 	args := a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	os.write_file(out_name_cmd_line, args) or {
+	// NOTE: use 'ANSI' encoding, not 'UTF-8'
+	iconv.write_file_encoding(out_name_cmd_line, args, 'ANSI', false) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -358,8 +358,8 @@ pub fn (mut v Builder) cc_msvc() {
 	v.dump_c_options(a)
 	args := a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	// NOTE: use 'ANSI' encoding, not 'UTF-8'
-	iconv.write_file_encoding(out_name_cmd_line, args, 'ANSI', false) or {
+	// NOTE: use 'ANSI'/'LOCAL' encoding, not 'UTF-8'
+	iconv.write_file_encoding(out_name_cmd_line, args, 'LOCAL', false) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
add LOCAL encoding: this is ANSI under Windows, UTF-8 under Linux
fix iconv type -cstrict error

This PR will make compile non-English pathname/filename under Windows possible.
For example:

```sh
v D:\测试目录\测试.v
测试.exe
```