### PR TITLE
cgen: fix struct fixed array field init with default value (fix #22392)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -451,7 +451,7 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 			g.expr_with_tmp_var(field.default_expr, field.default_expr_typ, field.typ,
 				tmp_var)
 			return true
-		} else if final_sym.info is ast.ArrayFixed {
+		} else if final_sym.info is ast.ArrayFixed && field.default_expr !is ast.ArrayInit {
 			tmp_var := g.new_tmp_var()
 			s := g.go_before_last_stmt()
 			g.empty_line = true

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -457,7 +457,7 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 			g.empty_line = true
 			styp := g.typ(field.typ)
 			g.writeln('${styp} ${tmp_var} = {0};')
-			g.write('memcpy(&${tmp_var}, &')
+			g.write('memcpy(${tmp_var}, ')
 			g.expr(field.default_expr)
 			g.writeln(', sizeof(${styp}));')
 			g.empty_line = false

--- a/vlib/v/tests/structs/struct_field_fixed_array_init_with_default_value_test.v
+++ b/vlib/v/tests/structs/struct_field_fixed_array_init_with_default_value_test.v
@@ -1,0 +1,39 @@
+type Mat4 = [16]f32
+
+pub fn mat4(x0 f32, x1 f32, x2 f32, x3 f32, x4 f32, x5 f32, x6 f32, x7 f32, x8 f32, x9 f32, x10 f32, x11 f32, x12 f32, x13 f32, x14 f32, x15 f32) Mat4 {
+	return [
+		x0,
+		x1,
+		x2,
+		x3,
+		x4,
+		x5,
+		x6,
+		x7,
+		x8,
+		x9,
+		x10,
+		x11,
+		x12,
+		x13,
+		x14,
+		x15,
+	]!
+}
+
+pub fn unit_m4() Mat4 {
+	return mat4(f32(1), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+}
+
+struct GameObject {
+mut:
+	transform Mat4 = unit_m4()
+}
+
+fn test_struct_field_fixed_array_init_with_default_value() {
+	p := GameObject{}
+	println(p)
+	assert p.transform[0] == 1.0
+	assert p.transform[1] == 0.0
+	assert p.transform[5] == 1.0
+}


### PR DESCRIPTION
This PR fix struct fixed array field init with default value (fix #22392).

- Fix struct fixed array field init with default value.
- Add test.

```v
type Mat4 = [16]f32

pub fn mat4(x0 f32, x1 f32, x2 f32, x3 f32, x4 f32, x5 f32, x6 f32, x7 f32, x8 f32, x9 f32, x10 f32, x11 f32, x12 f32, x13 f32, x14 f32, x15 f32) Mat4 {
	return [
		x0,
		x1,
		x2,
		x3,
		x4,
		x5,
		x6,
		x7,
		x8,
		x9,
		x10,
		x11,
		x12,
		x13,
		x14,
		x15,
	]!
}

pub fn unit_m4() Mat4 {
	return mat4(f32(1), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
}

struct GameObject {
mut:
	transform Mat4 = unit_m4()
}

fn main() {
	p := GameObject{}
	println(p)
	assert p.transform[0] == 1.0
	assert p.transform[1] == 0.0
	assert p.transform[5] == 1.0
}

PS D:\Test\v\tt1> v run .    
GameObject{
    transform:     Mat4([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
}
```