### PR TITLE
cgen: perfect enum with comptime const value (related #22388)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4406,7 +4406,7 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 				const_def := g.global_const_defs[util.no_dots(field.expr.name)]
 				if const_def.def.starts_with('#define') {
 					g.enum_typedefs.write_string(const_def.def.all_after_last(' '))
-				} else if const_def.def.contains('const') {
+				} else if const_def.def.contains('const ') {
 					g.enum_typedefs.write_string(const_def.def.all_after_last('=').all_before_last(';'))
 				} else {
 					g.enum_typedefs.write_string(expr_str)


### PR DESCRIPTION
This PR perfect enum with comptime const value (related #22388).

- Avoid non-precomputed const variable names that contain const.