### PR TITLE
builder: fix non-ASCII pathname under Windows

### DIFF
--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -4,9 +4,10 @@ import os
 
 const vexe = @VEXE
 const test_path = os.join_path(os.vtmp_dir(), 'run_check')
+const test_path2 = os.join_path(test_path, '测试目录')
 
 fn testsuite_begin() {
-	os.mkdir_all(test_path) or {}
+	os.mkdir_all(test_path2) or {}
 }
 
 fn testsuite_end() {
@@ -40,6 +41,36 @@ fn test_conditional_executable_removal() {
 
 	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
 	after_second_run___ := os.ls(test_path)!
+	dump(after_second_run___)
+	assert executable in after_second_run___
+}
+
+fn test_windows_ansi_path_name() {
+	os.chdir(test_path2)!
+	os.write_file('测试.v', 'fn main(){\n\tprintln("Hello World!")\n}\n')!
+
+	mut executable := '测试'
+	$if windows {
+		executable += '.exe'
+	}
+
+	original_file_list_ := os.ls(test_path2)!
+	dump(original_file_list_)
+	assert executable !in original_file_list_
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_run_file_list := os.ls(test_path2)!.filter(os.exists(it))
+	dump(after_run_file_list)
+	assert executable !in after_run_file_list
+
+	assert os.execute('${os.quoted_path(vexe)} . -o ${executable}').exit_code == 0
+	assert os.execute('./${executable}').output.trim_space() == 'Hello World!'
+	after_compilation__ := os.ls(test_path2)!
+	dump(after_compilation__)
+	assert executable in after_compilation__
+
+	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
+	after_second_run___ := os.ls(test_path2)!
 	dump(after_second_run___)
 	assert executable in after_second_run___
 }

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -4,10 +4,9 @@ import os
 
 const vexe = @VEXE
 const test_path = os.join_path(os.vtmp_dir(), 'run_check')
-const test_path2 = os.join_path(test_path, '测试目录')
 
 fn testsuite_begin() {
-	os.mkdir_all(test_path2) or {}
+	os.mkdir_all(test_path) or {}
 }
 
 fn testsuite_end() {
@@ -41,36 +40,6 @@ fn test_conditional_executable_removal() {
 
 	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
 	after_second_run___ := os.ls(test_path)!
-	dump(after_second_run___)
-	assert executable in after_second_run___
-}
-
-fn test_windows_ansi_path_name() {
-	os.chdir(test_path2)!
-	os.write_file('测试.v', 'fn main(){\n\tprintln("Hello World!")\n}\n')!
-
-	mut executable := '测试'
-	$if windows {
-		executable += '.exe'
-	}
-
-	original_file_list_ := os.ls(test_path2)!
-	dump(original_file_list_)
-	assert executable !in original_file_list_
-
-	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
-	after_run_file_list := os.ls(test_path2)!.filter(os.exists(it))
-	dump(after_run_file_list)
-	assert executable !in after_run_file_list
-
-	assert os.execute('${os.quoted_path(vexe)} . -o ${executable}').exit_code == 0
-	assert os.execute('./${executable}').output.trim_space() == 'Hello World!'
-	after_compilation__ := os.ls(test_path2)!
-	dump(after_compilation__)
-	assert executable in after_compilation__
-
-	assert os.execute('${os.quoted_path(vexe)} run .').output.trim_space() == 'Hello World!'
-	after_second_run___ := os.ls(test_path2)!
 	dump(after_second_run___)
 	assert executable in after_second_run___
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -9,6 +9,7 @@ import v.pref
 import v.util
 import v.vcache
 import term
+import encoding.iconv
 
 const c_std = 'c99'
 const c_std_gnu = 'gnu99'
@@ -666,7 +667,9 @@ pub fn (mut v Builder) cc() {
 			response_file_content = str_args.replace('\\', '\\\\')
 			rspexpr := '@${response_file}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
-			os.write_file(response_file, response_file_content) or {
+			// `LOCAL` encoding: ANSI/CP_ACP for Windows; UTF-8 for Linux
+			// Windows use ANSI encoding for path/filename
+			iconv.write_file_encoding(response_file, response_file_content, 'LOCAL', false) or {
 				verror('Unable to write to C response file "${response_file}"')
 			}
 		}

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -4,6 +4,7 @@ import os
 import time
 import v.util
 import v.cflag
+import encoding.iconv
 
 #flag windows -l shell32
 #flag windows -l dbghelp
@@ -357,7 +358,9 @@ pub fn (mut v Builder) cc_msvc() {
 	v.dump_c_options(a)
 	args := a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	os.write_file(out_name_cmd_line, args) or {
+	// `LOCAL` encoding: ANSI/CP_ACP for Windows; UTF-8 for Linux
+	// Windows use ANSI encoding for path/filename
+	iconv.write_file_encoding(out_name_cmd_line, args, 'LOCAL', false) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR may help solve #20743, #21502, #21718

Because Windows use CP_ACP encoding, not UTF-8. So the generated rsp file should be encoded in CP_ACP/ANSI encoding under Windows.

This PR will help users build non-ASCII filename/pathname:
```sh
D:\测试目录\你好.v

你好.exe
```

