### PR TITLE
v.builder: write an UTF8 BOM header for the .rsp file, when using '-cc msvc'

### DIFF
--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -355,7 +355,7 @@ pub fn (mut v Builder) cc_msvc() {
 		a << env_ldflags
 	}
 	v.dump_c_options(a)
-	args := a.join(' ')
+	args := '\xEF\xBB\xBF' + a.join(' ')
 	// write args to a file so that we dont smash createprocess
 	os.write_file(out_name_cmd_line, args) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')


### PR DESCRIPTION
Related to https://github.com/vlang/v/pull/22405 .

Building with `-cc msvc` is hampered, when the paths stored in the .rsp file, have non ASCII characters. This PR solves it, by adding an explicit BOM header, so that cl.exe can then interpret the content without guessing and failing, no matter what the current code page is.

TODO: make the msvc option handling code respect -no-rsp.