### PR TITLE
builder: use ANSI .rsp file under Windows

### DIFF
--- a/vlib/builtin/utf8.c.v
+++ b/vlib/builtin/utf8.c.v
@@ -2,6 +2,7 @@ module builtin
 
 import strings
 
+const cp_acp = 0
 const cp_utf8 = 65001
 
 // to_wide returns a pointer to an UTF-16 version of the string receiver.
@@ -91,4 +92,28 @@ pub fn string_from_wide2(_wstr &u16, len int) string {
 		res := sb.str()
 		return res
 	}
+}
+
+// wide_to_ansi create an ANSI string, given a windows
+// style string, encoded in UTF-16.
+// It use CP_ACP, which is ANSI code page identifier, as dest encoding.
+// NOTE: It return a vstring(encoded in UTF-8) []u8 under Linux.
+pub fn wide_to_ansi(_wstr &u16) []u8 {
+	$if windows {
+		num_bytes := C.WideCharToMultiByte(cp_acp, 0, _wstr, -1, 0, 0, 0, 0)
+		if num_bytes != 0 {
+			mut str_to := []u8{len: num_bytes}
+			C.WideCharToMultiByte(cp_acp, 0, _wstr, -1, &char(str_to.data), str_to.len,
+				0, 0)
+			return str_to
+		} else {
+			return []u8{}
+		}
+	} $else {
+		s := unsafe { string_from_wide(_wstr) }
+		mut str_to := []u8{len: s.len + 1}
+		unsafe { vmemcpy(str_to.data, s.str, s.len) }
+		return str_to
+	}
+	return []u8{} // TODO: remove this, bug?
 }

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -184,3 +184,13 @@ pub fn utf8_str_visible_length(s string) int {
 	}
 	return l
 }
+
+// string_to_ansi_not_null_terminated returns an ANSI version of the string `_str`.
+// NOTE: This is most useful for converting a vstring to an ANSI string under Windows.
+// NOTE: The ANSI string return is not null-terminated, then you can use `os.write_file_array` write an ANSI file.
+pub fn string_to_ansi_not_null_terminated(_str string) []u8 {
+	wstr := _str.to_wide()
+	mut ansi := wide_to_ansi(wstr)
+	ansi.pop() // remove tailing zero
+	return ansi
+}

--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -76,3 +76,12 @@ fn test_reverse_cyrillic_with_string_from_wide() {
 	z := unsafe { string_from_wide(ws) }
 	assert z == s
 }
+
+fn test_wide_to_ansi() {
+	ws := 'abc'.to_wide()
+	assert wide_to_ansi(ws) == [u8(97), 98, 99, 0]
+}
+
+fn test_string_to_ansi_not_null_terminated() {
+	assert string_to_ansi_not_null_terminated('abc') == [u8(97), 98, 99]
+}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -666,8 +666,14 @@ pub fn (mut v Builder) cc() {
 			response_file_content = str_args.replace('\\', '\\\\')
 			rspexpr := '@${response_file}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
-			os.write_file(response_file, response_file_content) or {
-				verror('Unable to write to C response file "${response_file}"')
+			$if windows {
+				os.write_file_array(response_file, string_to_ansi_not_null_terminated(response_file_content)) or {
+					verror('Unable to write to C response file "${response_file}"')
+				}
+			} $else {
+				os.write_file(response_file, response_file_content) or {
+					verror('Unable to write to C response file "${response_file}"')
+				}
 			}
 		}
 		if !v.ccoptions.debug_mode {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -355,9 +355,9 @@ pub fn (mut v Builder) cc_msvc() {
 		a << env_ldflags
 	}
 	v.dump_c_options(a)
-	args := '\xEF\xBB\xBF' + a.join(' ')
+	args := a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	os.write_file(out_name_cmd_line, args) or {
+	os.write_file_array(out_name_cmd_line, string_to_ansi_not_null_terminated(args)) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'


### PR DESCRIPTION
…nsi_not_null_terminated


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
As PR #22405 said, tcc will fail with non-ASCII filename under Windows 10.
So this PR try to make the .rsp file encoded in ANSI.
Also, builtin provide some new funcs help do the job UTF-8=>ANSI.
