### PR TITLE
v.builder: fix building with `-cc msvc` and non ASCII characters in paths on windows 11

### DIFF
--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -191,6 +191,8 @@ pub fn utf8_str_visible_length(s string) int {
 pub fn string_to_ansi_not_null_terminated(_str string) []u8 {
 	wstr := _str.to_wide()
 	mut ansi := wide_to_ansi(wstr)
-	ansi.pop() // remove tailing zero
+	if ansi.len > 0 {
+		unsafe { ansi.len-- } // remove tailing zero
+	}
 	return ansi
 }

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -355,9 +355,9 @@ pub fn (mut v Builder) cc_msvc() {
 		a << env_ldflags
 	}
 	v.dump_c_options(a)
-	args := a.join(' ')
+	args := '\xEF\xBB\xBF' + a.join(' ')
 	// write args to a file so that we dont smash createprocess
-	os.write_file_array(out_name_cmd_line, string_to_ansi_not_null_terminated(args)) or {
+	os.write_file(out_name_cmd_line, args) or {
 		verror('Unable to write response file to "${out_name_cmd_line}"')
 	}
 	cmd := '"${r.full_cl_exe_path}" "@${out_name_cmd_line}"'


### PR DESCRIPTION
- **v.builder: restore encoding used for .rsp files, when `-cc msvc` is used (fix msvc builds with non ASCII paths on windows 11)**
- **builtin: fix 'expression result unused' warning when building with clang**
