### PR TITLE
strconv: fix remove_tail_zeros bug

### DIFF
--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -491,13 +491,17 @@ pub fn remove_tail_zeros(s string) string {
 		if i_s < s.len && s[i_s] == `.` {
 			mut i_s1 := i_s + 1
 			mut sum := 0
+			mut i_s2 := i_s1 // last non-zero index after `.`
 			for i_s1 < s.len && s[i_s1] >= `0` && s[i_s1] <= `9` {
 				sum += s[i_s1] - u8(`0`)
+				if s[i_s1] != `0` {
+					i_s2 = i_s1
+				}
 				i_s1++
 			}
 			// decimal part must be copied
 			if sum > 0 {
-				for c_i in i_s .. i_s1 {
+				for c_i in i_s .. i_s2 + 1 {
 					buf[i_d] = s[c_i]
 					i_d++
 				}

--- a/vlib/strconv/format_test.v
+++ b/vlib/strconv/format_test.v
@@ -119,3 +119,10 @@ fn test_sprintf_with_escape() {
 	s := unsafe { strconv.v_sprintf('%d is 100%% awesome', n) }
 	assert s == '69 is 100% awesome'
 }
+
+fn test_remove_tail_zeros() {
+	assert strconv.remove_tail_zeros('1.234000000000') == '1.234'
+	assert strconv.remove_tail_zeros('1.0000000') == '1'
+	assert strconv.remove_tail_zeros('1234') == '1234'
+	assert strconv.remove_tail_zeros('1.00000000007') == '1.00000000007'
+}

--- a/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_float_fmt_test.v
+++ b/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_float_fmt_test.v
@@ -1,13 +1,13 @@
 fn test_string_interpolation_float_fmt() {
 	mut a := 76.295
 	eprintln('${a:8.2}')
-	assert '${a:8.2}' == '   76.30'
+	assert '${a:8.2}' == '    76.3'
 	eprintln('${a:8.2f}')
 	assert '${a:8.2f}' == '   76.30'
 
 	a = 76.296
 	eprintln('${a:8.2}')
-	assert '${a:8.2}' == '   76.30'
+	assert '${a:8.2}' == '    76.3'
 	eprintln('${a:8.2f}')
 	assert '${a:8.2f}' == '   76.30'
 }

--- a/vlib/v/tests/casts/cast_to_empty_interface_test.v
+++ b/vlib/v/tests/casts/cast_to_empty_interface_test.v
@@ -22,8 +22,8 @@ fn test_cast_to_empty_interface() {
 	assert ret_strings[1] == 'int               22'
 	assert ret_strings[2] == 'int             8888'
 	assert ret_strings[3] == 'int             9999'
-	assert ret_strings[4] == 'f64               1.110'
-	assert ret_strings[5] == 'f64               2.220'
-	assert ret_strings[6] == 'f64               8.880'
-	assert ret_strings[7] == 'f64               9.990'
+	assert ret_strings[4] == 'f64                1.11'
+	assert ret_strings[5] == 'f64                2.22'
+	assert ret_strings[6] == 'f64                8.88'
+	assert ret_strings[7] == 'f64                9.99'
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
fix issue #22421 , it is a bug in `strconv.remove_tail_zeros()`

```v
	assert strconv.remove_tail_zeros('1.234000000000') == '1.234'
	assert strconv.remove_tail_zeros('1.0000000') == '1'
	assert strconv.remove_tail_zeros('1234') == '1234'
	assert strconv.remove_tail_zeros('1.00000000007') == '1.00000000007'
```
