### PR TITLE
ast, parser: fix generic fn type with different generic type call (fix #22306)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1828,16 +1828,7 @@ pub fn (mut t Table) generic_type_names(generic_type Type) []string {
 			names << t.generic_type_names(sym.info.elem_type)
 		}
 		FnType {
-			mut func := sym.info.func
-			if func.return_type.has_flag(.generic) {
-				names << t.generic_type_names(func.return_type)
-			}
-			func.params = func.params.clone()
-			for mut param in func.params {
-				if param.typ.has_flag(.generic) {
-					generic_names_push_with_filter(mut names, t.generic_type_names(param.typ))
-				}
-			}
+			names << sym.info.func.generic_names
 		}
 		MultiReturn {
 			for ret_type in sym.info.types {

--- a/vlib/v/tests/generics/generic_fn_type_with_different_generic_type_test.v
+++ b/vlib/v/tests/generics/generic_fn_type_with_different_generic_type_test.v
@@ -1,0 +1,15 @@
+type Fn[T] = fn () T
+
+fn problem[X](f Fn[X]) X {
+	return f[X]()
+}
+
+fn foo() int {
+	return 1
+}
+
+fn test_generic_fn_type_with_different_generic_type() {
+	t := problem[int](foo)
+	println(t)
+	assert t == 1
+}


### PR DESCRIPTION
This PR fix generic fn type with different generic type call (fix #22306).

- Fix generic fn type with different generic type call.
- Add test.

```v
type Fn[T] = fn () T

fn problem[X](f Fn[X]) X {
	return f[X]()
}

fn foo() int {
	return 1
}

fn main() {
	t := problem[int](foo)
	println(t)
}

PS D:\Test\v\tt1> v run .
1
```