### PR TITLE
v: add test for `struct` definition inside `fn`

### DIFF
--- a/vlib/v/tests/structs/struct_definition_inside_fn_test.v
+++ b/vlib/v/tests/structs/struct_definition_inside_fn_test.v
@@ -3,4 +3,6 @@ fn test_struct_definition_inside_fn() {
 		name string
 	}
 	assert App{"make"}.name == "make"
+	app := App{"v"}
+	assert app.name == "v"
 }

--- a/vlib/v/tests/structs/struct_definition_inside_fn_test.v
+++ b/vlib/v/tests/structs/struct_definition_inside_fn_test.v
@@ -1,8 +1,10 @@
 fn test_struct_definition_inside_fn() {
+
 	struct App {
 		name string
 	}
-	assert App{"make"}.name == "make"
-	app := App{"v"}
-	assert app.name == "v"
+
+	assert App{'make'}.name == 'make'
+	app := App{'v'}
+	assert app.name == 'v'
 }

--- a/vlib/v/tests/structs/struct_definition_inside_fn_test.v
+++ b/vlib/v/tests/structs/struct_definition_inside_fn_test.v
@@ -1,0 +1,6 @@
+fn test_struct_definition_inside_fn() {
+	struct App {
+		name string
+	}
+	assert App{"make"}.name == "make"
+}


### PR DESCRIPTION
This PR adds a simple test for the commit a2d385aee3f1295966991ab9caf1d98319de479d, where  `struct` definition inside `fn` is allowed.
