### PR TITLE
v.ast: comment on the `IndexExpr.is_farray` field

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1144,7 +1144,7 @@ pub mut:
 	is_setter bool
 	is_map    bool
 	is_array  bool
-	is_farray bool
+	is_farray bool // fixed array
 	is_option bool // IfGuard
 	is_direct bool // Set if the underlying memory can be safely accessed
 	is_gated  bool // #[] gated array


### PR DESCRIPTION
Add comment for farray

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA0MDNlMmI5ODBmNDFkYjY2Y2ZlZjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.pUj6-aNOl4WDPk0c2eFsXkJzyBLbmexyFqwrBERKWjg">Huly&reg;: <b>V_0.6-20899</b></a></sub>