### PR TITLE
builtin: add `string.wrap` method + tests

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -4,6 +4,7 @@
 module builtin
 
 import strconv
+import strings
 
 /*
 Note: A V string should be/is immutable from the point of view of
@@ -2819,4 +2820,41 @@ pub fn (s string) snake_to_camel() string {
 		b[i] = 0
 	}
 	return unsafe { tos(b, i) }
+}
+
+@[params]
+pub struct WrapConfig {
+pub:
+	width int    = 80
+	end   string = '\n'
+}
+
+// wrap will wrap the string `s` when each line exceeds the width specified in
+// `width` (default value is 80), and will use `end` (default value is '\n') as
+// a line break.
+// Example: `assert 'Hello, my name is Carl and I am a delivery'.wrap(width: 20) == 'Hello, my name is\nCarl and I am a\ndelivery'`
+pub fn (s string) wrap(config WrapConfig) string {
+	if config.width <= 0 {
+		return ''
+	}
+	words := s.fields()
+	if words.len == 0 {
+		return ''
+	}
+	mut sb := strings.new_builder(50)
+	sb.write_string(words[0])
+	mut space_left := config.width - words[0].len
+	for i in 1 .. words.len {
+		word := words[i]
+		if word.len + 1 > space_left {
+			sb.write_string(config.end)
+			sb.write_string(word)
+			space_left = config.width - word.len
+		} else {
+			sb.write_string(' ')
+			sb.write_string(word)
+			space_left -= 1 + word.len
+		}
+	}
+	return sb.str()
 }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -2840,7 +2840,7 @@ pub fn (s string) wrap(config WrapConfig) string {
 	if words.len == 0 {
 		return ''
 	}
-	mut sb := strings.new_builder(50)
+	mut sb := strings.new_builder(s.len)
 	sb.write_string(words[0])
 	mut space_left := config.width - words[0].len
 	for i in 1 .. words.len {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -2829,9 +2829,8 @@ pub:
 	end   string = '\n'
 }
 
-// wrap will wrap the string `s` when each line exceeds the width specified in
-// `width` (default value is 80), and will use `end` (default value is '\n') as
-// a line break.
+// wrap wraps the string `s` when each line exceeds the width specified in `width`
+// (default value is 80), and will use `end` (default value is '\n') as a line break.
 // Example: `assert 'Hello, my name is Carl and I am a delivery'.wrap(width: 20) == 'Hello, my name is\nCarl and I am a\ndelivery'`
 pub fn (s string) wrap(config WrapConfig) string {
 	if config.width <= 0 {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -1570,3 +1570,10 @@ fn test_snake_to_camel() {
 	assert '_abcd'.snake_to_camel() == 'Abcd'
 	assert '_abcd_'.snake_to_camel() == 'Abcd'
 }
+
+fn test_string_wrap() {
+	assert 'Hello World'.wrap(width: 10) == 'Hello\nWorld'
+	assert 'Hello World'.wrap(width: 10, end: '<linea-break>') == 'Hello<linea-break>World'
+	assert 'The V programming language'.wrap(width: 20, end: '|') == 'The V programming|language'
+	assert 'Hello, my name is Carl and I am a delivery'.wrap(width: 20) == 'Hello, my name is\nCarl and I am a\ndelivery'
+}

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -4,7 +4,6 @@
 module scanner
 
 import os
-import strings
 import strconv
 import v.token
 import v.pref

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -937,7 +937,7 @@ pub fn (mut s Scanner) text_scan() token.Token {
 					// If name is all uppercase, the user is probably looking for a compile time variable ("at-token")
 					if name.is_upper() {
 						comptime_vars := token.valid_at_tokens.join(', ')
-						s.add_error_detail(wrap('available compile time variables: ${comptime_vars}',
+						s.add_error_detail('available compile time variables: ${comptime_vars}'.wrap(
 							width: 90
 						))
 					}
@@ -1859,38 +1859,4 @@ pub fn new_silent_scanner() &Scanner {
 	return &Scanner{
 		pref: p
 	}
-}
-
-@[params]
-struct WrapConfig {
-pub:
-	width int    = 80
-	end   string = '\n'
-}
-
-// wrap wraps the given string within `width` in characters.
-fn wrap(s string, config WrapConfig) string {
-	if config.width <= 0 {
-		return ''
-	}
-	words := s.fields()
-	if words.len == 0 {
-		return ''
-	}
-	mut sb := strings.new_builder(50)
-	sb.write_string(words[0])
-	mut space_left := config.width - words[0].len
-	for i in 1 .. words.len {
-		word := words[i]
-		if word.len + 1 > space_left {
-			sb.write_string(config.end)
-			sb.write_string(word)
-			space_left = config.width - word.len
-		} else {
-			sb.write_string(' ')
-			sb.write_string(word)
-			space_left -= 1 + word.len
-		}
-	}
-	return sb.str()
 }


### PR DESCRIPTION
This PR adds a new method called `wrap` to `string`, this method was previously introduced in commit 8d1ba46875c8183bfffde4642d824f7b6d1dfcfd.
The `wrap` function added to the `v.scanner` module is also removed and the new method is used instead.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA0MDc2OGI5ODBmNDFkYjY2ZDA2NDYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.1SrquIOgR6e10iy5SixxbVBOD6OiB6n__F5N9-ygRYA">Huly&reg;: <b>V_0.6-20902</b></a></sub>