### PR TITLE
checker: don't cast match branch structs to IError when in sumtype

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -102,6 +102,8 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					if ret_type.idx() != expr_type.idx() {
 						if node.expected_type.has_option_or_result()
 							&& c.table.sym(stmt.typ).kind == .struct_
+							&& (c.table.sym(ret_type).kind != .sum_type
+							|| !c.check_types(expr_type, ret_type))
 							&& c.type_implements(stmt.typ, ast.error_type, node.pos) {
 							stmt.expr = ast.CastExpr{
 								expr:      stmt.expr

--- a/vlib/v/tests/return_match_expr_of_sumtype_do_not_cast_to_ierror_test.v
+++ b/vlib/v/tests/return_match_expr_of_sumtype_do_not_cast_to_ierror_test.v
@@ -1,0 +1,73 @@
+type Foo = int | string | Bar
+
+struct Bar {}
+
+fn foo_result_struct_second() !Foo {
+	return match true {
+		true { 1 }
+		else { Bar{} }
+	}
+}
+
+fn foo_option_struct_second() ?Foo {
+	return match true {
+		true { 1 }
+		else { Bar{} }
+	}
+}
+
+fn foo_result_string_second() !Foo {
+	return match true {
+		true { 1 }
+		else { '' }
+	}
+}
+
+fn foo_option_string_second() ?Foo {
+	return match true {
+		true { 1 }
+		else { '' }
+	}
+}
+
+fn foo_result_struct_first() !Foo {
+	return match true {
+		true { Bar{} }
+		else { 7 }
+	}
+}
+
+fn foo_option_struct_first() ?Foo {
+	return match true {
+		true { Bar{} }
+		else { 7 }
+	}
+}
+
+fn test_return_match_expr_of_sumtype_opt_res() {
+	mut ret := Foo{}
+
+	ret = foo_result_struct_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_option_struct_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_result_string_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_option_string_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_result_struct_first() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(Bar{})'
+
+	ret = foo_option_struct_first() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(Bar{})'
+}

--- a/vlib/v/tests/return_match_expr_of_sumtype_result_test.v
+++ b/vlib/v/tests/return_match_expr_of_sumtype_result_test.v
@@ -1,25 +1,73 @@
-type Foo = int | string
+type Foo = int | string | Bar
 
-fn foo1() !Foo {
+struct Bar {}
+
+fn foo_result_struct_second() !Foo {
+	return match true {
+		true { 1 }
+		else { Bar{} }
+	}
+}
+
+fn foo_option_struct_second() ?Foo {
+	return match true {
+		true { 1 }
+		else { Bar{} }
+	}
+}
+
+fn foo_result_string_second() !Foo {
 	return match true {
 		true { 1 }
 		else { '' }
 	}
 }
 
-fn foo2() ?Foo {
+fn foo_option_string_second() ?Foo {
 	return match true {
 		true { 1 }
 		else { '' }
+	}
+}
+
+fn foo_result_struct_first() !Foo {
+	return match true {
+		true { Bar{} }
+		else { 7 }
+	}
+}
+
+fn foo_option_struct_first() ?Foo {
+	return match true {
+		true { Bar{} }
+		else { 7 }
 	}
 }
 
 fn test_return_match_expr_of_sumtype_opt_res() {
-	ret1 := foo1() or { return }
-	println(ret1)
-	assert '${ret1}' == 'Foo(1)'
+	mut ret := Foo{}
 
-	ret2 := foo2() or { return }
-	println(ret2)
-	assert '${ret2}' == 'Foo(1)'
+	ret = foo_result_struct_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_option_struct_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_result_string_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_option_string_second() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(1)'
+
+	ret = foo_result_struct_first() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(Bar{})'
+
+	ret = foo_option_struct_first() or { return }
+	println(ret)
+	assert '${ret}' == 'Foo(Bar{})'
 }

--- a/vlib/v/tests/return_match_expr_of_sumtype_result_test.v
+++ b/vlib/v/tests/return_match_expr_of_sumtype_result_test.v
@@ -1,73 +1,25 @@
-type Foo = int | string | Bar
+type Foo = int | string
 
-struct Bar {}
-
-fn foo_result_struct_second() !Foo {
-	return match true {
-		true { 1 }
-		else { Bar{} }
-	}
-}
-
-fn foo_option_struct_second() ?Foo {
-	return match true {
-		true { 1 }
-		else { Bar{} }
-	}
-}
-
-fn foo_result_string_second() !Foo {
+fn foo1() !Foo {
 	return match true {
 		true { 1 }
 		else { '' }
 	}
 }
 
-fn foo_option_string_second() ?Foo {
+fn foo2() ?Foo {
 	return match true {
 		true { 1 }
 		else { '' }
-	}
-}
-
-fn foo_result_struct_first() !Foo {
-	return match true {
-		true { Bar{} }
-		else { 7 }
-	}
-}
-
-fn foo_option_struct_first() ?Foo {
-	return match true {
-		true { Bar{} }
-		else { 7 }
 	}
 }
 
 fn test_return_match_expr_of_sumtype_opt_res() {
-	mut ret := Foo{}
+	ret1 := foo1() or { return }
+	println(ret1)
+	assert '${ret1}' == 'Foo(1)'
 
-	ret = foo_result_struct_second() or { return }
-	println(ret)
-	assert '${ret}' == 'Foo(1)'
-
-	ret = foo_option_struct_second() or { return }
-	println(ret)
-	assert '${ret}' == 'Foo(1)'
-
-	ret = foo_result_string_second() or { return }
-	println(ret)
-	assert '${ret}' == 'Foo(1)'
-
-	ret = foo_option_string_second() or { return }
-	println(ret)
-	assert '${ret}' == 'Foo(1)'
-
-	ret = foo_result_struct_first() or { return }
-	println(ret)
-	assert '${ret}' == 'Foo(Bar{})'
-
-	ret = foo_option_struct_first() or { return }
-	println(ret)
-	assert '${ret}' == 'Foo(Bar{})'
+	ret2 := foo2() or { return }
+	println(ret2)
+	assert '${ret2}' == 'Foo(1)'
 }


### PR DESCRIPTION
Fixes #22435.

When checking match branch expression branch expression type, there was a check to cast yielded value to an `IError` when match return type is a Result and branch expression type is struct.

I added an additional test so that the cast (and check to ensure the struct conforms to the `IError` interface) does not occur when the return type is a sumtype and the struct is one of the sumtype types.

Tests updated to cover this

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA0NDYyMmI5ODBmNDFkYjY2ZDYwOTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lbvkaNkxRJ-eV-Ua7mKCPlfOytDK-cu3fHrRSOhGecU">Huly&reg;: <b>V_0.6-20905</b></a></sub>