### PR TITLE
string buffer: string_buffer_to_generic method

### DIFF
--- a/vlib/v/tests/builtin_arrays/array_test.v
+++ b/vlib/v/tests/builtin_arrays/array_test.v
@@ -82,7 +82,6 @@ fn test_string_buffer_to_generic_unsigned() {
 	value := u32(0)
 	unsafe { bytes.string_buffer_to_generic[u32](&value) }
 	assert value == 123
-	// assert unsafe { bytes.string_buffer_to_generic[?u32]() } == 123
 }
 
 fn test_string_buffer_to_generic_signed() {

--- a/vlib/v/tests/builtin_arrays/array_test.v
+++ b/vlib/v/tests/builtin_arrays/array_test.v
@@ -75,19 +75,30 @@ fn append_1d_1d(mut arr1 []string, arr2 []string) {
 	arr1 << arr2
 }
 
-fn test_string_buffer_to_generic() {
+fn test_string_buffer_to_generic_unsigned() {
 	// unsigned
 	string_value := '123'
 	bytes := unsafe { string_value.str.vbytes(3) }
-	assert unsafe { bytes.string_buffer_to_generic[u32]() } == 123
+	value := u32(0)
+	unsafe { bytes.string_buffer_to_generic[u32](&value) }
+	assert value == 123
+	// assert unsafe { bytes.string_buffer_to_generic[?u32]() } == 123
+}
 
+fn test_string_buffer_to_generic_signed() {
 	// signed
-	string_value2 := '-123'
-	bytes2 := unsafe { string_value2.str.vbytes(4) }
-	assert unsafe { bytes2.string_buffer_to_generic[int]() } == -123
+	string_value := '-123'
+	bytes := unsafe { string_value.str.vbytes(4) }
+	value := int(0)
+	unsafe { bytes.string_buffer_to_generic[int](&value) }
+	assert value == -123
+}
 
-	// decimal point
-	string_value3 := '123.456'
-	bytes3 := unsafe { string_value3.str.vbytes(7) }
-	assert unsafe { bytes3.string_buffer_to_generic[f32]() } == 123.456
+fn test_string_buffer_to_generic_float() {
+	// float
+	string_value := '123.456'
+	bytes := unsafe { string_value.str.vbytes(7) }
+	value := f32(0)
+	unsafe { bytes.string_buffer_to_generic[f32](&value) }
+	assert value == 123.456
 }

--- a/vlib/v/tests/builtin_arrays/array_test.v
+++ b/vlib/v/tests/builtin_arrays/array_test.v
@@ -74,3 +74,20 @@ fn append_2d_1d(mut arr1 [][]string, arr2 []string) {
 fn append_1d_1d(mut arr1 []string, arr2 []string) {
 	arr1 << arr2
 }
+
+fn test_string_buffer_to_generic() {
+	// unsigned
+	string_value := '123'
+	bytes := unsafe { string_value.str.vbytes(3) }
+	assert unsafe { bytes.string_buffer_to_generic[u32]() } == 123
+
+	// signed
+	string_value2 := '-123'
+	bytes2 := unsafe { string_value2.str.vbytes(4) }
+	assert unsafe { bytes2.string_buffer_to_generic[int]() } == -123
+
+	// decimal point
+	string_value3 := '123.456'
+	bytes3 := unsafe { string_value3.str.vbytes(7) }
+	assert unsafe { bytes3.string_buffer_to_generic[f32]() } == 123.456
+}


### PR DESCRIPTION
With this PR I intend to drastically reduce redundant codes, which are abundant in json2, like the one below.

```v
		$for field in T.fields {
				$if field.typ is u8 {
					typ.$(field.name) = res[json_name]!.u64()
				} $else $if field.typ is u16 {
					typ.$(field.name) = res[json_name]!.u64()
				} $else $if field.typ is u32 {
					typ.$(field.name) = res[json_name]!.u64()
				} $else $if field.typ is u64 {
					typ.$(field.name) = res[json_name]!.u64()
				} $else $if field.typ is int {
					typ.$(field.name) = res[json_name]!.int()
				} $else $if field.typ is i8 {
					typ.$(field.name) = res[json_name]!.int()
				} $else $if field.typ is i16 {
					typ.$(field.name) = res[json_name]!.int()
				} $else $if field.typ is i32 {
					typ.$(field.name) = i32(res[field.name]!.i32())
				} $else $if field.typ is i64 {
					typ.$(field.name) = res[json_name]!.i64()
				} 
		}
```

to only
```v
		$for field in T.fields {
				$if field.typ in [$int, $float] {
					unsafe { bytes.string_buffer_to_generic(&typ.$(field.name) ) }
				} 
		}
```