### PR TITLE
parser: fix generics method chaining call (fix #22418)

### DIFF
--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -835,6 +835,7 @@ fn (mut p Parser) find_type_or_add_placeholder(name string, language ast.Languag
 							...sym
 							name:          sym_name
 							rname:         sym.name
+							parent_idx:    sym.idx
 							generic_types: p.init_generic_types.clone()
 						})
 					}

--- a/vlib/v/tests/generics/generics_method_chaining_call_test.v
+++ b/vlib/v/tests/generics/generics_method_chaining_call_test.v
@@ -1,0 +1,32 @@
+struct Seq[T] {
+	ar []T
+}
+
+type MapFn[T, K] = fn (T) K
+
+fn (s Seq[T]) map[K](map_fn MapFn[T, K]) Seq[K] {
+	mut map_ar := []K{cap: s.ar.len}
+
+	for _, i in s.ar {
+		map_ar << map_fn[T, K](i)
+	}
+
+	return Seq[K]{map_ar}
+}
+
+fn test_generics_method_chaining_call() {
+	s := Seq[string]{['one', 'two']}
+		.map[int](fn (element string) int {
+			match element {
+				'one' { return 1 }
+				'two' { return 2 }
+				else { return -1 }
+			}
+		})
+		.map[int](fn (element int) int {
+			return element + 2
+		})
+
+	println(s)
+	assert s.ar == [3, 4]
+}


### PR DESCRIPTION
This PR fix generics method chaining call (fix #22418).

- Fix generics method chaining call.
- Add test.

```v
struct Seq[T] {
	ar []T
}

type MapFn[T, K] = fn (T) K

fn (s Seq[T]) map[K](map_fn MapFn[T, K]) Seq[K] {
	mut map_ar := []K{cap: s.ar.len}

	for _, i in s.ar {
		map_ar << map_fn[T, K](i)
	}

	return Seq[K]{map_ar}
}

fn main() {
	s := Seq[string]{['one', 'two']}
		.map[int](fn (element string) int {
			match element {
				'one' { return 1 }
				'two' { return 2 }
				else { return -1 }
			}
		})
		.map[int](fn (element int) int {
			return element + 2
		})

	println(s)
}

PS D:\Test\v\tt1> v run .       
Seq[int]{
    ar: [3, 4]
}
```