### PR TITLE
parser: fix enum field name same as keyword (fix #22455)

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -679,17 +679,28 @@ fn (mut p Parser) check_js_name() string {
 	return name
 }
 
+fn is_ident_name(name string) bool {
+	if name.len == 0 || !util.name_char_table[name[0]] {
+		return false
+	}
+	for i in 1 .. name.len {
+		if !util.func_char_table[name[i]] {
+			return false
+		}
+	}
+	return true
+}
+
 fn (mut p Parser) check_name() string {
 	pos := p.tok.pos()
 	name := p.tok.lit
 	if p.tok.kind != .name && p.peek_tok.kind == .dot && name in p.imports {
 		p.register_used_import(name)
 	}
-	match p.tok.kind {
-		.key_struct { p.check(.key_struct) }
-		.key_enum { p.check(.key_enum) }
-		.key_interface { p.check(.key_interface) }
-		else { p.check(.name) }
+	if !is_ident_name(name) {
+		p.check(.name)
+	} else {
+		p.next()
 	}
 	if !p.inside_orm && !p.inside_attr_decl && name == 'sql' {
 		p.error_with_pos('unexpected keyword `sql`, expecting name', pos)

--- a/vlib/v/tests/enums/enum_field_name_same_as_keyword_test.v
+++ b/vlib/v/tests/enums/enum_field_name_same_as_keyword_test.v
@@ -1,0 +1,24 @@
+enum Kind {
+	none
+	const
+	enum
+	struct
+	interface
+	sum_type
+	i32
+	f64
+}
+
+fn type_kind(kind Kind) string {
+	return '${kind}'
+}
+
+fn test_enum_field_name_same_as_keyword() {
+	mut ret := type_kind(Kind.none)
+	println(ret)
+	assert ret == 'none'
+
+	ret = type_kind(Kind.struct)
+	println(ret)
+	assert ret == 'struct'
+}


### PR DESCRIPTION
This PR fix enum field name same as keyword (fix #22455).

- Fix enum field name same as keyword.
- Add test.

```v
enum TypeKind {
	none
	const
	enum
	struct
	interface
	sum_type
	i32
	f64
}

fn type_kind(kind TypeKind) string {
	return '${kind}'
}

fn main() {
	mut ret := type_kind(TypeKind.none)
	println(ret)
	assert ret == 'none'

	ret = type_kind(TypeKind.struct)
	println(ret)
	assert ret == 'struct'
}

PS D:\Test\v\tt1> v run .
none
struct
```