### PR TITLE
checker: fix missing check for escape char on unicode checker

### DIFF
--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -143,7 +143,10 @@ fn (mut c Checker) string_lit(mut node ast.StringLiteral) ast.Type {
 				start_idx := idx
 				idx++
 				next_ch := node.val[idx] or { return ast.string_type }
-				if next_ch == `u` {
+				if next_ch == `\\` {
+					// ignore escaping char
+					idx++
+				} else if next_ch == `u` {
 					idx++
 					mut ch := node.val[idx] or { return ast.string_type }
 					mut hex_char_count := 0

--- a/vlib/v/tests/unicode_escape_test.v
+++ b/vlib/v/tests/unicode_escape_test.v
@@ -1,0 +1,9 @@
+fn test_main() {
+	a := r'\u306aefgh\t'
+
+	mut expected := '\\u306a'
+	expected += 'efgh\\t'
+
+	assert a == expected
+	assert a == '\\u306aefgh\\t'
+}


### PR DESCRIPTION
Fix #22427

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA2NjNkYWI5ODBmNDFkYjY4ODBmNGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ZLr_PAE7r-h3NfmA3JontiDTl2x4pstouPjSwhmccvE">Huly&reg;: <b>V_0.6-20921</b></a></sub>