### PR TITLE
picoev: fix wrong return on failure

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -352,7 +352,7 @@ fn default_error_callback(data voidptr, req picohttpparser.Request, mut res pico
 pub fn new(config Config) !&Picoev {
 	listening_socket_fd := listen(config) or {
 		eprintln('Error during listen: ${err}')
-		return unsafe { nil }
+		return err
 	}
 
 	mut pv := &Picoev{


### PR DESCRIPTION
Fix #22292

Just noticed running `examples/veb/veb_assets/vweb_assets.v`

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA2NjdkZGI5ODBmNDFkYjY4ODcyNDIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.BxEjstnqB3OkW18WEmgzptDoBFvO16FB2-PmK2Rmk2w">Huly&reg;: <b>V_0.6-20922</b></a></sub>