### PR TITLE
cgen: fix option if expr with noreturn fn call (fix #22467)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1926,9 +1926,14 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 								g.fn_decl.return_type.clear_flag(.option)
 							}
 							styp = g.base_type(ret_typ)
-							g.write('_option_ok(&(${styp}[]) { ')
-							g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
-							g.writeln(' }, (${option_name}*)(&${tmp_var}), sizeof(${styp}));')
+							if stmt.expr is ast.CallExpr && stmt.expr.name == 'panic' {
+								g.expr(stmt.expr)
+								g.writeln(';')
+							} else {
+								g.write('_option_ok(&(${styp}[]) { ')
+								g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
+								g.writeln(' }, (${option_name}*)(&${tmp_var}), sizeof(${styp}));')
+							}
 						}
 					}
 				}
@@ -1958,9 +1963,14 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 						} else {
 							ret_typ := g.fn_decl.return_type.clear_flag(.result)
 							styp = g.base_type(ret_typ)
-							g.write('_result_ok(&(${styp}[]) { ')
-							g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
-							g.writeln(' }, (${result_name}*)(&${tmp_var}), sizeof(${styp}));')
+							if stmt.expr is ast.CallExpr && stmt.expr.name == 'panic' {
+								g.expr(stmt.expr)
+								g.writeln(';')
+							} else {
+								g.write('_result_ok(&(${styp}[]) { ')
+								g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
+								g.writeln(' }, (${result_name}*)(&${tmp_var}), sizeof(${styp}));')
+							}
 						}
 					}
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1926,7 +1926,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 								g.fn_decl.return_type.clear_flag(.option)
 							}
 							styp = g.base_type(ret_typ)
-							if stmt.expr is ast.CallExpr && stmt.expr.name == 'panic' {
+							if stmt.expr is ast.CallExpr && stmt.expr.is_noreturn {
 								g.expr(stmt.expr)
 								g.writeln(';')
 							} else {
@@ -1963,7 +1963,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 						} else {
 							ret_typ := g.fn_decl.return_type.clear_flag(.result)
 							styp = g.base_type(ret_typ)
-							if stmt.expr is ast.CallExpr && stmt.expr.name == 'panic' {
+							if stmt.expr is ast.CallExpr && stmt.expr.is_noreturn {
 								g.expr(stmt.expr)
 								g.writeln(';')
 							} else {

--- a/vlib/v/tests/options/option_if_expr_with_panic_call_test.v
+++ b/vlib/v/tests/options/option_if_expr_with_panic_call_test.v
@@ -1,0 +1,10 @@
+fn test_option_if_expr_with_panic_call() {
+	mut x := ?string(none)
+	x = if true {
+		''
+	} else {
+		panic('')
+	}
+	println(x)
+	assert true
+}


### PR DESCRIPTION
This PR fix option if expr with panic() call (fix #22467).

- Fix option if expr with panic() call.
- Add test.

```v
fn main() {
	mut x := ?string(none)
	x = if true {
		''
	} else {
		panic('')
	}
	println(x)
}

PS D:\Test\v\tt1> v run .
Option('')
```