### PR TITLE
checker: fix missing check for empty noreturn fn 

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -368,8 +368,9 @@ fn (mut c Checker) check_noreturn_fn_decl(mut node ast.FnDecl) {
 	if uses_return_stmt(node.stmts) {
 		c.error('[noreturn] functions cannot use return statements', node.pos)
 	}
+	mut pos := node.pos
+	mut is_valid_end_of_noreturn_fn := false
 	if node.stmts.len != 0 {
-		mut is_valid_end_of_noreturn_fn := false
 		last_stmt := node.stmts.last()
 		match last_stmt {
 			ast.ExprStmt {
@@ -392,12 +393,12 @@ fn (mut c Checker) check_noreturn_fn_decl(mut node ast.FnDecl) {
 			else {}
 		}
 		if !is_valid_end_of_noreturn_fn {
-			c.error('@[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop',
-				last_stmt.pos)
+			pos = last_stmt.pos
 		}
-	} else {
+	}
+	if !is_valid_end_of_noreturn_fn {
 		c.error('@[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop',
-			node.pos)
+			pos)
 	}
 }
 

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -394,8 +394,10 @@ fn (mut c Checker) check_noreturn_fn_decl(mut node ast.FnDecl) {
 		if !is_valid_end_of_noreturn_fn {
 			c.error('@[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop',
 				last_stmt.pos)
-			return
 		}
+	} else {
+		c.error('@[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop',
+			node.pos)
 	}
 }
 

--- a/vlib/v/checker/tests/empty_fn_noreturn_err.out
+++ b/vlib/v/checker/tests/empty_fn_noreturn_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/empty_fn_noreturn_err.vv:2:1: error: @[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop
+    1 | @[noreturn]
+    2 | fn f() {
+      | ~~~~~~
+    3 | }

--- a/vlib/v/checker/tests/empty_fn_noreturn_err.vv
+++ b/vlib/v/checker/tests/empty_fn_noreturn_err.vv
@@ -1,0 +1,3 @@
+@[noreturn]
+fn f() {
+}

--- a/vlib/v/tests/reflection_test.v
+++ b/vlib/v/tests/reflection_test.v
@@ -21,6 +21,7 @@ fn test2(arg []string) {}
 
 @[noreturn]
 fn test3(a reflection.Function) {
+	panic('foo')
 }
 
 fn test_module_existing() {


### PR DESCRIPTION
Fix #22468

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA3YmEzMzBiYjJlYTE0Yjc5YTNkOGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.juYaDZlUNeFZPrvOl06dG4A1C2URs8iQqPaW4kX5Csk">Huly&reg;: <b>V_0.6-20932</b></a></sub>