### PR TITLE
checker: fix wrong overload operator checking for generic aliased type

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -354,11 +354,23 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					} else {
 						return_type = right_type
 					}
-				} else if right_final_sym.has_method(node.op.str()) {
+				} else if right_final_sym.has_method_with_generic_parent(node.op.str()) {
 					if method := right_final_sym.find_method(node.op.str()) {
 						return_type = method.return_type
 					} else {
 						return_type = right_type
+					}
+				} else if left_sym.has_method(node.op.str()) {
+					if method := left_sym.find_method(node.op.str()) {
+						return_type = method.return_type
+					} else {
+						return_type = left_type
+					}
+				} else if left_final_sym.has_method_with_generic_parent(node.op.str()) {
+					if method := left_final_sym.find_method(node.op.str()) {
+						return_type = method.return_type
+					} else {
+						return_type = left_type
 					}
 				} else {
 					left_name := c.table.type_to_str(unwrapped_left_type)

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -355,7 +355,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						return_type = right_type
 					}
 				} else if right_final_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := right_final_sym.find_method(node.op.str()) {
+					if method := right_final_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type
 					} else {
 						return_type = right_type
@@ -367,7 +367,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 						return_type = left_type
 					}
 				} else if left_final_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := left_final_sym.find_method(node.op.str()) {
+					if method := left_final_sym.find_method_with_generic_parent(node.op.str()) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type

--- a/vlib/v/tests/aliases/alias_with_op_overloading_test.v
+++ b/vlib/v/tests/aliases/alias_with_op_overloading_test.v
@@ -1,0 +1,22 @@
+module main
+
+import math.vec
+
+type Vector3 = vec.Vec3[f32]
+
+pub fn calc(a Vector3, b Vector3) Vector3 {
+	f := a.normalize()
+	return f * a + a * f
+}
+
+fn test_main() {
+	a := Vector3{
+		x: 1
+		y: 2
+		z: 3
+	}
+	t := calc(a, a)
+	assert int(t.x) == 0
+	assert int(t.y) == 2
+	assert int(t.z) == 4
+}


### PR DESCRIPTION
Fix #22471

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA3YzZiODBiYjJlYTE0Yjc5YTQ4YzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.y0WgMGte42Aakh1bie2jeW99Mc8PNhSGZx7xa9LW0sQ">Huly&reg;: <b>V_0.6-20933</b></a></sub>