### PR TITLE
vrepl: replace enum field name `@none` with `none`

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -67,7 +67,7 @@ const possible_statement_patterns = [
 ]
 
 enum FnType {
-	@none
+	none
 	void
 	fn_type
 }
@@ -183,7 +183,7 @@ fn (r &Repl) function_call(line string) (bool, FnType) {
 	if line.contains(':=') {
 		// an assignment to a variable:
 		// `z := abc()`
-		return false, FnType.@none
+		return false, FnType.none
 	}
 
 	// Check if it is a Vlib call
@@ -192,7 +192,7 @@ fn (r &Repl) function_call(line string) (bool, FnType) {
 		fntype := r.check_fn_type_kind(line)
 		return true, fntype
 	}
-	return false, FnType.@none
+	return false, FnType.none
 }
 
 // TODO(vincenzopalazzo) Remove this fancy check and add a regex


### PR DESCRIPTION
This PR replace enum field name `@none` with `none` in vrepl.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA3ZGI4N2U1OWQ0N2Y3YjVkMDcwNDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.pWFYEon_yHDxUqq-Tc5wT-npxuK3Vk4Q_a6P2HQfs7U">Huly&reg;: <b>V_0.6-20935</b></a></sub>