### PR TITLE
all: replace enum field name '@xxx' with 'xxx'

### DIFF
--- a/cmd/tools/vwhere/finder.v
+++ b/cmd/tools/vwhere/finder.v
@@ -104,10 +104,10 @@ fn (mut fdr Finder) search_for_matches() {
 	na := '${fdr.name}'
 
 	query := match fdr.symbol {
-		.@fn { '.*${sy}${sp}${na}${sp}${op}.*${cp}.*' }
+		.fn { '.*${sy}${sp}${na}${sp}${op}.*${cp}.*' }
 		.method { '.*fn${st}${na}${sp}${op}.*${cp}.*' }
 		.var { '.*${na}${sp}:=.*' }
-		.@const { '.*${na}${sp} = .*' }
+		.const { '.*${na}${sp} = .*' }
 		.regexp { '${na}' }
 		else { '.*${sy}${sp}${na}${sp}.*' } // struct, enum, interface
 	}
@@ -120,7 +120,7 @@ fn (mut fdr Finder) search_for_matches() {
 fn (mut fdr Finder) search_within_file(file string, query string) {
 	mut re := regex.regex_opt(query) or { panic(err) }
 	lines := os.read_lines(file) or { panic(err) }
-	mut const_found := if fdr.symbol == .@const { false } else { true }
+	mut const_found := if fdr.symbol == .const { false } else { true }
 	mut n_line := 1
 	for line in lines {
 		match fdr.visib {
@@ -129,7 +129,7 @@ fn (mut fdr Finder) search_within_file(file string, query string) {
 					const_found = true
 				}
 			}
-			.@pub {
+			.pub {
 				if line.contains('pub const (') {
 					const_found = true
 				}
@@ -144,13 +144,13 @@ fn (mut fdr Finder) search_within_file(file string, query string) {
 			words := line.split(' ').filter(it != '').map(it.trim('\t'))
 			match fdr.visib {
 				.all {}
-				.@pub {
-					if 'pub' !in words && fdr.symbol != .@const {
+				.pub {
+					if 'pub' !in words && fdr.symbol != .const {
 						continue
 					}
 				}
 				.pri {
-					if 'pub' in words && fdr.symbol != .@const {
+					if 'pub' in words && fdr.symbol != .const {
 						continue
 					}
 				}
@@ -170,7 +170,7 @@ fn (mut fdr Finder) search_within_file(file string, query string) {
 			}
 			fdr.matches << Match{file, n_line, words.join(' ').trim(' {')}
 		}
-		if line.starts_with(')') && fdr.symbol == .@const {
+		if line.starts_with(')') && fdr.symbol == .const {
 			const_found = false
 		}
 		n_line++

--- a/cmd/tools/vwhere/finder_utils.v
+++ b/cmd/tools/vwhere/finder_utils.v
@@ -6,12 +6,12 @@ import os.cmdline
 
 // Symbol type to search
 enum Symbol {
-	@fn
+	fn
 	method
-	@struct
-	@interface
-	@enum
-	@const
+	struct
+	interface
+	enum
+	const
 	var
 	regexp
 }
@@ -19,7 +19,7 @@ enum Symbol {
 // Visibility of the symbols to search
 enum Visibility {
 	all
-	@pub
+	pub
 	pri
 }
 
@@ -35,18 +35,18 @@ const verbose = '-v' in cmdline.only_options(_args)
 const header = '-h' in cmdline.only_options(_args)
 const format = '-f' in cmdline.only_options(_args)
 const symbols = {
-	'fn':        Symbol.@fn
+	'fn':        Symbol.fn
 	'method':    .method
-	'struct':    .@struct
-	'interface': .@interface
-	'enum':      .@enum
-	'const':     .@const
+	'struct':    .struct
+	'interface': .interface
+	'enum':      .enum
+	'const':     .const
 	'var':       .var
 	'regexp':    .regexp
 }
 const visibilities = {
 	'all': Visibility.all
-	'pub': .@pub
+	'pub': .pub
 	'pri': .pri
 }
 const mutabilities = {

--- a/cmd/tools/vwhere/vwhere_test.v
+++ b/cmd/tools/vwhere/vwhere_test.v
@@ -8,15 +8,15 @@ fn test_create_finder() {
 	mut fdr := Finder{}
 
 	fdr.configure_from_arguments(['some'])
-	assert fdr.symbol == .@fn
+	assert fdr.symbol == .fn
 	assert fdr.name == 'some'
 	assert fdr.visib == .all
 	assert fdr.mutab == .any
 
 	fdr.configure_from_arguments(['fn', 'some', '-vis', 'pub'])
-	assert fdr.symbol == .@fn
+	assert fdr.symbol == .fn
 	assert fdr.name == 'some'
-	assert fdr.visib == .@pub
+	assert fdr.visib == .pub
 
 	fdr.configure_from_arguments(['method', 'Some.some', '-vis', 'pri'])
 	assert fdr.symbol == .method
@@ -25,23 +25,23 @@ fn test_create_finder() {
 	assert fdr.visib == .pri
 
 	fdr.configure_from_arguments(['struct', 'Some', '-mod', 'foo'])
-	assert fdr.symbol == .@struct
+	assert fdr.symbol == .struct
 	assert fdr.name == 'Some'
 	assert fdr.modul == 'foo'
 
 	fdr.configure_from_arguments(['interface', 'Some', '-mod', 'foo', '-dir', 'bar'])
-	assert fdr.symbol == .@interface
+	assert fdr.symbol == .interface
 	assert fdr.name == 'Some'
 	assert fdr.modul == 'foo'
 	assert fdr.dirs == ['bar']
 
 	fdr.configure_from_arguments(['enum', 'Some', '-dir', 'bar', '-dir', 'baz'])
-	assert fdr.symbol == .@enum
+	assert fdr.symbol == .enum
 	assert fdr.name == 'Some'
 	assert fdr.dirs == ['bar', 'baz']
 
 	fdr.configure_from_arguments(['const', 'some'])
-	assert fdr.symbol == .@const
+	assert fdr.symbol == .const
 	assert fdr.name == 'some'
 
 	fdr.configure_from_arguments(['var', 'some', '-mut', 'yes'])

--- a/vlib/sokol/gfx/enums.v
+++ b/vlib/sokol/gfx/enums.v
@@ -14,7 +14,7 @@ pub enum Backend {
 // PixelFormat is C.sg_pixel_format
 pub enum PixelFormat as u32 {
 	_default // value 0 reserved for default-init
-	@none
+	none
 
 	r8
 	r8sn
@@ -126,7 +126,7 @@ pub enum BufferType as u32 {
 
 pub enum IndexType as u32 {
 	_default // value 0 reserved for default-init
-	@none
+	none
 	uint16
 	uint32
 	_num
@@ -193,7 +193,7 @@ pub enum PrimitiveType as u32 {
 
 pub enum Filter as u32 {
 	_default // value 0 reserved for default-init
-	@none
+	none
 	nearest
 	linear
 	_num
@@ -267,7 +267,7 @@ pub enum UniformType as u32 {
 
 pub enum CullMode as u32 {
 	_default // value 0 reserved for default-init
-	@none
+	none
 	front
 	back
 	_num
@@ -343,7 +343,7 @@ pub enum BlendOp as u32 {
 
 pub enum ColorMask as u32 {
 	_default   = 0    // value 0 reserved for default-init
-	@none      = 0x10 // special value for 'all channels disabled
+	none       = 0x10 // special value for 'all channels disabled
 	r          = 1
 	g          = 2
 	rg         = 3

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -28,8 +28,8 @@ pub fn create_default_pass(action gfx.PassAction) gfx.Pass {
 pub fn glue_environment() gfx.Environment {
 	mut env := gfx.Environment{}
 	unsafe { vmemset(&env, 0, int(sizeof(env))) }
-	env.defaults.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
-	env.defaults.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
+	env.defaults.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.none }
+	env.defaults.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.none }
 	env.defaults.sample_count = sample_count()
 	$if macos && !darwin_sokol_glcore33 ? {
 		env.metal.device = metal_get_device()
@@ -51,8 +51,8 @@ pub fn glue_swapchain() gfx.Swapchain {
 	swapchain.width = width()
 	swapchain.height = height()
 	swapchain.sample_count = sample_count()
-	swapchain.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.@none }
-	swapchain.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.@none }
+	swapchain.color_format = gfx.PixelFormat.from(color_format()) or { gfx.PixelFormat.none }
+	swapchain.depth_format = gfx.PixelFormat.from(depth_format()) or { gfx.PixelFormat.none }
 	$if macos && !darwin_sokol_glcore33 ? {
 		swapchain.metal.current_drawable = metal_get_current_drawable()
 		swapchain.metal.depth_stencil_texture = metal_get_depth_stencil_texture()

--- a/vlib/v/tests/interfaces/interface_with_multi_nested_embed_3_test.v
+++ b/vlib/v/tests/interfaces/interface_with_multi_nested_embed_3_test.v
@@ -5,7 +5,7 @@ mut:
 }
 
 enum NodeType {
-	@none
+	none
 }
 
 struct Node {


### PR DESCRIPTION
This PR replace enum field name '@xxx' with 'xxx'.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA3ZjIzMmM3ZDZhNTZhOGY4ZDViNTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.PzpdRRdPPJWU0ek-SDmruPLP7bNYCM7HbAkjBXJpZwY">Huly&reg;: <b>V_0.6-20937</b></a></sub>