### PR TITLE
all: replace struct field name '@type' with 'type'

### DIFF
--- a/examples/2048/2048.v
+++ b/examples/2048/2048.v
@@ -163,7 +163,7 @@ enum TileFormat {
 	exponent
 	shifts
 	none
-	end_ // To know when to wrap around
+	end // To know when to wrap around
 }
 
 enum GameState {
@@ -672,7 +672,7 @@ fn (app &App) draw_tiles() {
 						})
 					}
 					.none {} // Don't draw any text here, colors only
-					.end_ {} // Should never get here
+					.end {} // Should never get here
 				}
 			}
 		}
@@ -767,7 +767,7 @@ fn (mut app App) next_theme() {
 @[inline]
 fn (mut app App) next_tile_format() {
 	app.tile_format = unsafe { TileFormat(int(app.tile_format) + 1) }
-	if app.tile_format == .end_ {
+	if app.tile_format == .end {
 		app.tile_format = .normal
 	}
 }

--- a/examples/sokol/02_cubes_glsl/cube_glsl.v
+++ b/examples/sokol/02_cubes_glsl/cube_glsl.v
@@ -308,7 +308,7 @@ fn init_cube_glsl(mut app App) {
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 
-	vert_buffer_desc.@type = .vertexbuffer
+	vert_buffer_desc.type = .vertexbuffer
 	// vert_buffer_desc.usage   = .immutable
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
 
@@ -335,7 +335,7 @@ fn init_cube_glsl(mut app App) {
 		size: usize(indices.len * int(sizeof(u16)))
 	}
 
-	index_buffer_desc.@type = .indexbuffer
+	index_buffer_desc.type = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
 
 	// create shader

--- a/examples/sokol/03_march_tracing_glsl/rt_glsl.v
+++ b/examples/sokol/03_march_tracing_glsl/rt_glsl.v
@@ -175,7 +175,7 @@ fn init_cube_glsl(mut app App) {
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
 
-	vert_buffer_desc.@type = .vertexbuffer
+	vert_buffer_desc.type = .vertexbuffer
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
 
 	// create an index buffer for the cube
@@ -201,7 +201,7 @@ fn init_cube_glsl(mut app App) {
 		size: usize(indices.len * int(sizeof(u16)))
 	}
 
-	index_buffer_desc.@type = .indexbuffer
+	index_buffer_desc.type = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
 
 	// create shader

--- a/examples/sokol/04_multi_shader_glsl/rt_glsl.v
+++ b/examples/sokol/04_multi_shader_glsl/rt_glsl.v
@@ -115,7 +115,7 @@ fn (mut app App) init_glsl_shader(shader_name string, shader_desc &gfx.ShaderDes
 		ptr: vertices.data
 		size: vert_buffer_desc.size
 	}
-	vert_buffer_desc.@type = .vertexbuffer
+	vert_buffer_desc.type = .vertexbuffer
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
 
 	mut index_buffer_desc := gfx.BufferDesc{}
@@ -126,7 +126,7 @@ fn (mut app App) init_glsl_shader(shader_name string, shader_desc &gfx.ShaderDes
 		ptr: indices.data
 		size: index_buffer_desc.size
 	}
-	index_buffer_desc.@type = .indexbuffer
+	index_buffer_desc.type = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
 
 	// create shader

--- a/examples/sokol/05_instancing_glsl/rt_glsl.v
+++ b/examples/sokol/05_instancing_glsl/rt_glsl.v
@@ -186,7 +186,7 @@ fn init_cube_glsl_i(mut app App) {
 		ptr:  vertices.data
 		size: usize(vertices.len * int(sizeof(Vertex_t)))
 	}
-	vert_buffer_desc.@type = .vertexbuffer
+	vert_buffer_desc.type = .vertexbuffer
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
 
 	// create an instance buffer for the cube
@@ -196,7 +196,7 @@ fn init_cube_glsl_i(mut app App) {
 	unsafe { vmemset(&inst_buffer_desc, 0, int(sizeof(inst_buffer_desc))) }
 
 	inst_buffer_desc.size = usize(num_inst * int(sizeof(m4.Vec4)))
-	inst_buffer_desc.@type = .vertexbuffer
+	inst_buffer_desc.type = .vertexbuffer
 	inst_buffer_desc.usage = .stream
 	inst_buf := gfx.make_buffer(&inst_buffer_desc)
 
@@ -221,7 +221,7 @@ fn init_cube_glsl_i(mut app App) {
 		ptr:  indices.data
 		size: usize(indices.len * int(sizeof(u16)))
 	}
-	index_buffer_desc.@type = .indexbuffer
+	index_buffer_desc.type = .indexbuffer
 	ibuf := gfx.make_buffer(&index_buffer_desc)
 
 	// create shader

--- a/examples/sokol/06_obj_viewer/modules/obj/rend.v
+++ b/examples/sokol/06_obj_viewer/modules/obj/rend.v
@@ -86,7 +86,7 @@ pub fn (mut obj_part ObjPart) create_pipeline(in_part []int, shader gfx.Shader, 
 		size: usize(obj_buf.vbuf.len * int(sizeof(Vertex_pnct)))
 	}
 
-	vert_buffer_desc.@type = .vertexbuffer
+	vert_buffer_desc.type = .vertexbuffer
 	vert_buffer_desc.label = 'vertbuf_part_${in_part:03}'.str
 	vbuf := gfx.make_buffer(&vert_buffer_desc)
 
@@ -100,7 +100,7 @@ pub fn (mut obj_part ObjPart) create_pipeline(in_part []int, shader gfx.Shader, 
 		size: usize(obj_buf.ibuf.len * int(sizeof(u32)))
 	}
 
-	index_buffer_desc.@type = .indexbuffer
+	index_buffer_desc.type = .indexbuffer
 	index_buffer_desc.label = 'indbuf_part_${in_part:03}'.str
 	ibuf := gfx.make_buffer(&index_buffer_desc)
 

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -113,26 +113,26 @@ fn frame(mut app App) {
 }
 
 fn event(ev &sapp.Event, mut app App) {
-	if ev.@type == .mouse_move {
+	if ev.type == .mouse_move {
 		app.ps.explode(ev.mouse_x, ev.mouse_y)
 	}
-	if ev.@type == .mouse_up || ev.@type == .mouse_down {
+	if ev.type == .mouse_up || ev.type == .mouse_down {
 		if ev.mouse_button == .left {
-			is_pressed := ev.@type == .mouse_down
+			is_pressed := ev.type == .mouse_down
 			if is_pressed {
 				app.ps.explode(ev.mouse_x, ev.mouse_y)
 			}
 		}
 	}
-	if ev.@type == .key_up || ev.@type == .key_down {
+	if ev.type == .key_up || ev.type == .key_down {
 		if ev.key_code == .r {
-			is_pressed := ev.@type == .key_down
+			is_pressed := ev.type == .key_down
 			if is_pressed {
 				app.ps.reset()
 			}
 		}
 	}
-	if ev.@type == .touches_began || ev.@type == .touches_moved {
+	if ev.type == .touches_began || ev.type == .touches_moved {
 		if ev.num_touches > 0 {
 			touch_point := ev.touches[0]
 			app.ps.explode(touch_point.pos_x, touch_point.pos_y)

--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -89,7 +89,7 @@ mut:
 @[typedef]
 pub struct C.XSelectionEvent {
 mut:
-	@type     int
+	type      int
 	display   &C.Display = unsafe { nil } // Display the event was read from
 	requestor Window
 	selection Atom
@@ -114,7 +114,7 @@ mut:
 @[typedef]
 union C.XEvent {
 mut:
-	@type             int
+	type              int
 	xdestroywindow    C.XDestroyWindowEvent
 	xselectionclear   C.XSelectionClearEvent
 	xselectionrequest C.XSelectionRequestEvent
@@ -298,11 +298,11 @@ fn (mut cb Clipboard) start_listener() {
 	for {
 		time.sleep(1 * time.millisecond)
 		C.XNextEvent(cb.display, &event)
-		if unsafe { event.@type == 0 } {
+		if unsafe { event.type == 0 } {
 			println('error')
 			continue
 		}
-		match unsafe { event.@type } {
+		match unsafe { event.type } {
 			C.DestroyNotify {
 				if unsafe { event.xdestroywindow.window == cb.window } {
 					// we are done
@@ -327,7 +327,7 @@ fn (mut cb Clipboard) start_listener() {
 					xsre = unsafe { &event.xselectionrequest }
 
 					mut xse := C.XSelectionEvent{
-						@type:     C.SelectionNotify // 31
+						type:      C.SelectionNotify // 31
 						display:   xsre.display
 						requestor: xsre.requestor
 						selection: xsre.selection

--- a/vlib/db/mysql/_cdefs.c.v
+++ b/vlib/db/mysql/_cdefs.c.v
@@ -29,7 +29,7 @@ pub struct C.MYSQL_FIELD {
 	flags            u32 // Bit-flags that describe the field
 	decimals         u32 // Number of decimals in field
 	charsetnr        u32 // Character set
-	@type            int // Type of field. See enums.v for types
+	type             int // Type of field. See enums.v for types
 }
 
 // C.mysql_init allocates or initializes a MYSQL object suitable for `mysql_real_connect()`.

--- a/vlib/db/mysql/orm.c.v
+++ b/vlib/db/mysql/orm.c.v
@@ -26,7 +26,7 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 	// Allocate memory for each column.
 	for i in 0 .. num_fields {
 		field := unsafe { fields[i] }
-		match unsafe { FieldType(field.@type) } {
+		match unsafe { FieldType(field.type) } {
 			.type_tiny {
 				data_pointers << unsafe { malloc(1) }
 			}
@@ -48,7 +48,7 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 				data_pointers << &u8(0)
 			}
 			else {
-				return error('\'${unsafe { FieldType(field.@type) }}\' is not yet implemented. Please create a new issue at https://github.com/vlang/v/issues/new')
+				return error('\'${unsafe { FieldType(field.type) }}\' is not yet implemented. Please create a new issue at https://github.com/vlang/v/issues/new')
 			}
 		}
 	}
@@ -68,7 +68,7 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 
 	for i, mut mysql_bind in stmt.res {
 		field := unsafe { fields[i] }
-		field_type := unsafe { FieldType(field.@type) }
+		field_type := unsafe { FieldType(field.type) }
 		field_types << field_type
 
 		match types[i] {
@@ -87,7 +87,7 @@ pub fn (db DB) @select(config orm.SelectConfig, data orm.QueryData, where orm.Qu
 					}
 					.type_string, .type_blob {}
 					else {
-						return error('Unknown type ${field.@type}')
+						return error('Unknown type ${field.type}')
 					}
 				}
 			}

--- a/vlib/db/mysql/result.c.v
+++ b/vlib/db/mysql/result.c.v
@@ -30,7 +30,7 @@ pub struct Field {
 	flags            u32
 	decimals         u32
 	charsetnr        u32
-	type_            FieldType
+	type             FieldType
 }
 
 // fetch_row fetches the next row from a result.
@@ -112,7 +112,7 @@ pub fn (r Result) fields() []Field {
 				flags:            orig_fields.flags
 				decimals:         orig_fields.decimals
 				charsetnr:        orig_fields.charsetnr
-				type_:            FieldType(orig_fields.@type)
+				type:             FieldType(orig_fields.type)
 			}
 		}
 	}
@@ -142,7 +142,7 @@ pub fn (f Field) str() string {
 	flags: ${f.flags}
 	decimals: ${f.decimals}
 	charsetnr: ${f.charsetnr}
-	type: ${f.type_.str()}
+	type: ${f.type.str()}
 }
 '
 }

--- a/vlib/db/mysql/stmt.c.v
+++ b/vlib/db/mysql/stmt.c.v
@@ -268,7 +268,7 @@ pub fn (mut stmt Stmt) bind(typ int, buffer voidptr, buf_len u32) {
 pub fn (mut stmt Stmt) bind_res(fields &C.MYSQL_FIELD, dataptr []&u8, lengths []u32, num_fields int) {
 	for i in 0 .. num_fields {
 		stmt.res << C.MYSQL_BIND{
-			buffer_type: unsafe { fields[i].@type }
+			buffer_type: unsafe { fields[i].type }
 			buffer:      dataptr[i]
 			length:      &lengths[i]
 		}

--- a/vlib/json/cjson/cjson_wrapper.c.v
+++ b/vlib/json/cjson/cjson_wrapper.c.v
@@ -19,7 +19,7 @@ pub:
 	prev  &C.cJSON
 	child &C.cJSON // An array or object item will have a child pointer pointing to a chain of the items in the array/object
 
-	@type int // The type of the item, as above
+	type int // The type of the item, as above
 
 	valueint    int   // writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead
 	valuedouble f64   // The item's number, if type==cJSON_Number

--- a/vlib/net/address.c.v
+++ b/vlib/net/address.c.v
@@ -135,11 +135,11 @@ pub fn (a Addr) len() u32 {
 	}
 }
 
-// resolve_addrs converts the given `addr`, `family` and `@type` to a list of addresses
-pub fn resolve_addrs(addr string, family AddrFamily, @type SocketType) ![]Addr {
+// resolve_addrs converts the given `addr`, `family` and `typ` to a list of addresses
+pub fn resolve_addrs(addr string, family AddrFamily, typ SocketType) ![]Addr {
 	match family {
 		.ip, .ip6, .unspec {
-			return resolve_ipaddrs(addr, family, @type)
+			return resolve_ipaddrs(addr, family, typ)
 		}
 		.unix {
 			resolved := Unix{}
@@ -165,8 +165,8 @@ pub fn resolve_addrs(addr string, family AddrFamily, @type SocketType) ![]Addr {
 	}
 }
 
-// resolve_addrs converts the given `addr` and `@type` to a list of addresses
-pub fn resolve_addrs_fuzzy(addr string, @type SocketType) ![]Addr {
+// resolve_addrs converts the given `addr` and `typ` to a list of addresses
+pub fn resolve_addrs_fuzzy(addr string, typ SocketType) ![]Addr {
 	if addr.len == 0 {
 		return error('none')
 	}
@@ -177,10 +177,10 @@ pub fn resolve_addrs_fuzzy(addr string, @type SocketType) ![]Addr {
 	if addr.contains(':') {
 		// Colon is a reserved character in unix paths
 		// so this must be an ip address
-		return resolve_addrs(addr, .unspec, @type)
+		return resolve_addrs(addr, .unspec, typ)
 	}
 
-	return resolve_addrs(addr, .unix, @type)
+	return resolve_addrs(addr, .unix, typ)
 }
 
 // resolve_ipaddrs converts the given `addr`, `family` and `typ` to a list of addresses

--- a/vlib/sokol/gfx/gfx_structs.c.v
+++ b/vlib/sokol/gfx/gfx_structs.c.v
@@ -220,17 +220,17 @@ pub fn (mut desc C.sg_shader_desc) set_frag_uniform_block_size(block_index int, 
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, @type UniformType,
+pub fn (mut desc C.sg_shader_desc) set_vert_uniform(block_index int, uniform_index int, name string, typ UniformType,
 	array_count int) &ShaderDesc {
 	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
-	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
+	desc.vs.uniform_blocks[block_index].uniforms[uniform_index].type = typ
 	return desc
 }
 
-pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, @type UniformType,
+pub fn (mut desc C.sg_shader_desc) set_frag_uniform(block_index int, uniform_index int, name string, typ UniformType,
 	array_count int) &ShaderDesc {
 	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].name = &char(name.str)
-	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].@type = @type
+	desc.fs.uniform_blocks[block_index].uniforms[uniform_index].type = typ
 	return desc
 }
 
@@ -280,7 +280,7 @@ pub type ShaderUniformBlockDesc = C.sg_shader_uniform_block_desc
 pub struct C.sg_shader_uniform_desc {
 pub mut:
 	name        &char
-	@type       UniformType
+	type        UniformType
 	array_count int
 }
 
@@ -636,7 +636,7 @@ pub type Pass = C.sg_pass
 pub struct C.sg_buffer_desc {
 pub mut:
 	size  usize
-	@type BufferType
+	type  BufferType
 	usage Usage
 	data  Range
 	label &char
@@ -682,7 +682,7 @@ pub fn (mut b Buffer) free() {
 
 pub struct C.sg_image_desc {
 pub mut:
-	@type         ImageType
+	type          ImageType
 	render_target bool
 	width         int
 	height        int

--- a/vlib/sokol/sapp/sapp_structs.c.v
+++ b/vlib/sokol/sapp/sapp_structs.c.v
@@ -90,7 +90,7 @@ pub type Desc = C.sapp_desc
 pub struct C.sapp_event {
 pub:
 	frame_count        u64                         // current frame counter, always valid, useful for checking if two events were issued in the same frame
-	@type              EventType                   // the event type, always valid
+	type               EventType                   // the event type, always valid
 	key_code           KeyCode                     // the virtual key code, only valid in KEY_UP, KEY_DOWN
 	char_code          u32                         // the UTF-32 character code, only valid in CHAR events
 	key_repeat         bool                        // true if this is a key-repeat event, valid in KEY_UP, KEY_DOWN and CHAR
@@ -113,7 +113,7 @@ pub:
 pub type Event = C.sapp_event
 
 pub fn (e &C.sapp_event) str() string {
-	return 'evt: frame_count=${e.frame_count}, type=${e.@type}'
+	return 'evt: frame_count=${e.frame_count}, type=${e.type}'
 }
 
 @[typedef]

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -785,7 +785,7 @@ fn (mut c Checker) comptime_if_cond(mut cond ast.Expr, pos token.Pos) ComptimeBr
 							.skip
 						}
 					} else if cond.left in [ast.Ident, ast.SelectorExpr, ast.TypeNode] {
-						// `$if method.@type is string`
+						// `$if method.type is string`
 						c.expr(mut cond.left)
 						if cond.left is ast.SelectorExpr
 							&& c.comptime.is_comptime_selector_type(cond.left)


### PR DESCRIPTION
This PR replace struct field name '@type' with 'type'.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzA4ODk4NWM3ZDZhNTZhOGY4ZTFmZmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.3Ty6xl5jT-p8d98uXxcGPu9s0kQIBsqI6e_D2-AIfiE">Huly&reg;: <b>V_0.6-20943</b></a></sub>