### PR TITLE
cgen: allow for `@[c_extern] fn C.somename(param1 int, param2 &char) &char`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -145,6 +145,7 @@ mut:
 	inside_call               bool
 	inside_curry_call         bool // inside foo()()!, foo()()?, foo()()
 	inside_dump_fn            bool
+	inside_c_extern           bool // inside `@[c_extern] fn C.somename(param1 int, param2 voidptr, param3 &char) &char`
 	expected_fixed_arr        bool
 	inside_for_c_stmt         bool
 	inside_cast_in_heap       int // inside cast to interface type in heap (resolve recursive calls)
@@ -2797,6 +2798,9 @@ fn ctoslit(s string) string {
 
 fn (mut g Gen) gen_attrs(attrs []ast.Attr) {
 	if g.pref.skip_unused {
+		return
+	}
+	if g.inside_c_extern {
 		return
 	}
 	for attr in attrs {

--- a/vlib/v/gen/c/testdata/c_extern_on_C_fn_declarations.c.must_have
+++ b/vlib/v/gen/c/testdata/c_extern_on_C_fn_declarations.c.must_have
@@ -1,0 +1,1 @@
+extern char* GifErrorString(int ecode);

--- a/vlib/v/gen/c/testdata/c_extern_on_C_fn_declarations.vv
+++ b/vlib/v/gen/c/testdata/c_extern_on_C_fn_declarations.vv
@@ -1,0 +1,16 @@
+// Note: there is NO #include here.
+// The V compiler will generate an `extern` declaration for the C function itself.
+// If you want to compile it, you need to have installed `libgif-dev` on your system.
+// After installing that package (or its equivalent), try for example:
+// `./v -cc gcc -cstrict run vlib/v/gen/c/testdata/c_extern_on_C_fn_declarations.vv`
+// There should be no error, and you should see a list of error messages, that the library ligif provides.
+
+#flag -lgif
+
+@[c_extern]
+fn C.GifErrorString(ecode int) &char
+
+println('hi')
+for i in 1 .. 10 {
+	unsafe { dump(cstring_to_vstring(C.GifErrorString(i))) }
+}


### PR DESCRIPTION
- **cgen: allow for `@[c_extern] fn C.somename(param1 int, param2 &char) &char`**
- **add a test .vv/.c.must_have pair**
