### PR TITLE
checker: fix generic lambda with late concrete type inference

### DIFF
--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -75,7 +75,7 @@ fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Type {
 		if fmt == `_` { // set default representation for type if none has been given
 			fmt = c.get_default_fmt(ftyp, typ)
 			if fmt == `_` {
-				if typ != ast.void_type {
+				if typ != ast.void_type && !(c.inside_lambda && typ.has_flag(.generic)) {
 					c.error('no known default format for type `${c.table.get_type_name(ftyp)}`',
 						node.fmt_poss[i])
 				}

--- a/vlib/v/comptime/comptimeinfo.v
+++ b/vlib/v/comptime/comptimeinfo.v
@@ -287,6 +287,9 @@ fn (mut ct ComptimeInfo) comptime_get_kind_var(var ast.Ident) ?ast.ComptimeForKi
 
 pub fn (mut ct ComptimeInfo) unwrap_generic_expr(expr ast.Expr, default_typ ast.Type) ast.Type {
 	match expr {
+		ast.StringLiteral, ast.StringInterLiteral {
+			return ast.string_type
+		}
 		ast.ParExpr {
 			return ct.unwrap_generic_expr(expr.expr, default_typ)
 		}

--- a/vlib/v/tests/generics/generic_lambda_inference_test.v
+++ b/vlib/v/tests/generics/generic_lambda_inference_test.v
@@ -1,0 +1,21 @@
+const result = ['0: a', '1: b', '2: c', '3: d']
+
+fn mapi[T, U](arr []T, callback fn (int, T) U) []U {
+	mut mapped := []U{}
+	for i, el in arr {
+		mapped << callback(i, el)
+	}
+	return mapped
+}
+
+fn test_main() {
+	arr := [`a`, `b`, `c`, `d`]
+	arr_1 := mapi(arr, |i, e| '${i}: ${e}')
+	assert arr_1 == result
+	arr_2 := mapi[rune, string](arr, |i, e| '${i}: ${e}')
+	assert arr_2 == result
+	arr_3 := mapi(arr, fn (i int, e rune) string {
+		return '${i}: ${e}'
+	})
+	assert arr_3 == result
+}


### PR DESCRIPTION
Fix #22497

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBiMTEyMTQxNjJiMDJlNWRkM2MyZTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.0HALGzwpEnt_062l0HnS3ly42ZownWQXytSzrDYZQEI">Huly&reg;: <b>V_0.6-20966</b></a></sub>