### PR TITLE
veb: fix veb example file_transform port typo

### DIFF
--- a/examples/veb/file_transform/file_transform.v
+++ b/examples/veb/file_transform/file_transform.v
@@ -13,7 +13,7 @@ pub struct App {
 
 fn main() {
 	mut app := &App{}
-	veb.run[App, Context](mut app, 8080)
+	veb.run[App, Context](mut app, port)
 }
 
 pub fn (mut app App) index() veb.Result {


### PR DESCRIPTION
Close #22508

Fix veb example file_transform port typo

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBiOTRkNTQxNjJiMDJlNWRkM2YyNzEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.NpPz5c34VWBH-I2tI-6p9jocQoHvQN0NtkCDOpWSsXo">Huly&reg;: <b>V_0.6-20968</b></a></sub>