### PR TITLE
parser: allow for variable name using keyword 'type'

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -519,8 +519,14 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 					p.next()
 					return p.struct_init('', .anon, false)
 				}
-			}
-			if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {
+			} else if p.tok.kind == .key_type {
+				// variable name: type
+				ident := p.ident(ast.Language.v)
+				node = ident
+				p.mark_var_as_used(ident.name)
+				p.add_defer_var(ident)
+				p.is_stmt_ident = is_stmt_ident
+			} else if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {
 				// eof should be handled where it happens
 				return error('none')
 				// return p.unexpected(prepend_msg: 'invalid expression: ')

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2322,7 +2322,7 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 	if is_volatile {
 		p.next()
 	}
-	if p.tok.kind != .name {
+	if p.tok.kind !in [.name, .key_type] {
 		if is_mut || is_static || is_volatile {
 			p.error_with_pos('the `${modifier_kind}` keyword is invalid here', mut_pos)
 		} else {

--- a/vlib/v/tests/var_name_using_type_test.v
+++ b/vlib/v/tests/var_name_using_type_test.v
@@ -1,0 +1,22 @@
+fn info(type int) int {
+	return type
+}
+
+fn print_info() {
+	for type in [1, 2, 3] {
+		println(type)
+	}
+}
+
+fn test_var_name_using_type() {
+	ret := info(22)
+	println(ret)
+	assert ret == 22
+
+	type := 33
+	println(type)
+	assert type == 33
+
+	print_info()
+	assert true
+}


### PR DESCRIPTION
This PR allow for variable name using keyword 'type'.

- Allow for variable name using keyword 'type'.
- Add test.

```v
fn info(type int) int {
	return type
}

fn print_info() {
	for type in [1, 2, 3] {
		println(type)
	}
}

fn main() {
	ret := info(22)
	println(ret)
	assert ret == 22

	type := 33
	println(type)
	assert type == 33

	print_info()
	assert true
}

PS D:\Test\v\tt1> v run .    
22
33
1
2
3
```