### PR TITLE
fmt: keep `C.` prefix for concrete type on generic fn call

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2126,6 +2126,9 @@ fn (mut f Fmt) write_generic_call_if_require(node ast.CallExpr) {
 			} else if tsym.language == .js && !tsym.name.starts_with('JS.') {
 				name = 'JS.' + name
 			}
+			if tsym.language == .c {
+				name = 'C.' + name
+			}
 			f.write(name)
 			f.mark_types_import_as_used(concrete_type)
 			if i != node.concrete_types.len - 1 {

--- a/vlib/v/fmt/tests/fn_call_concrete_type_keep.vv
+++ b/vlib/v/fmt/tests/fn_call_concrete_type_keep.vv
@@ -1,0 +1,16 @@
+fn to_v_array[T](d &T, len u32) []T {
+	mut ret := unsafe { []T{len: int(len)} }
+	for i in 0 .. len {
+		unsafe {
+			ret[i] = d[i]
+		}
+	}
+	unsafe {
+		free(d)
+	}
+	return ret
+}
+
+fn main() {
+	to_v_array[C.Foo](C.Foo{}, 123.2)
+}


### PR DESCRIPTION
Fix #22516

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBiZmIwYzQxNjJiMDJlNWRkNDI1NGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.3Yf1Awjm9C0o32-qVuYbWV0h7CCHINQ3wtbywQxvs4w">Huly&reg;: <b>V_0.6-20973</b></a></sub>