### PR TITLE
examples: change var name '@type' to 'type' in net_resolve.v

### DIFF
--- a/examples/net_resolve.v
+++ b/examples/net_resolve.v
@@ -8,17 +8,17 @@ for addr in [
 ] {
 	println('${addr}')
 
-	for @type in [net.SocketType.tcp, .udp] {
+	for type in [net.SocketType.tcp, .udp] {
 		family := net.AddrFamily.unspec
 
-		addrs := net.resolve_addrs(addr, family, @type) or {
+		addrs := net.resolve_addrs(addr, family, type) or {
 			println('> None')
 			continue
 		}
 
 		for a in addrs {
 			f := a.family()
-			println('> ${a} ${f} ${@type}')
+			println('> ${a} ${f} ${type}')
 		}
 	}
 }


### PR DESCRIPTION
This PR change var name '@type' to 'type' in examples/net_resolve.v.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzBkY2JlYzhkY2MwMDM2MTU1YWVmYjQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.h9OR_7YLSWlLsiXUF1VDw0XomcozWdGe_XaESs4BXo0">Huly&reg;: <b>V_0.6-20981</b></a></sub>