### PR TITLE
cgen: fix sumtype aggregate with struct embeded (fix #22481)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4161,6 +4161,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			} else {
 				g.write_selector_expr_embed_name(node, node.from_embed_types)
 			}
+		} else if sym.info is ast.Aggregate {
+			agg_sym := g.table.sym(sym.info.types[g.aggregate_type_idx])
+			if !g.table.struct_has_field(agg_sym, field_name) {
+				g.write_selector_expr_embed_name(node, node.from_embed_types)
+			}
 		} else {
 			g.write_selector_expr_embed_name(node, node.from_embed_types)
 		}

--- a/vlib/v/tests/sumtypes/aggregate_with_struct_embed_test.v
+++ b/vlib/v/tests/sumtypes/aggregate_with_struct_embed_test.v
@@ -1,0 +1,24 @@
+type SumType = StructA | StructB
+
+struct StructA {
+	member string
+}
+
+struct StructB {
+	StructA
+}
+
+fn get_member(st SumType) string {
+	match st {
+		StructA, StructB {
+			return st.member
+		}
+	}
+}
+
+fn test_aggregate_with_struct_embed() {
+	struct_a := StructA{'hello'}
+	ret := get_member(struct_a)
+	println(ret)
+	assert ret == 'hello'
+}


### PR DESCRIPTION
This PR fix sumtype aggregate with struct embeded (fix #22481).

- Fix sumtype aggregate with struct embeded.
- Add test.

```v
type SumType = StructA | StructB

struct StructA {
	member string
}

struct StructB {
	StructA
}

fn get_member(st SumType) string {
	match st {
		StructA, StructB {
			return st.member
		}
	}
}

fn main() {
	struct_a := StructA{'hello'}
	ret := get_member(struct_a)
	println(ret)
	assert ret == 'hello'
}

PS D:\Test\v\tt1> v run .
hello
```