### PR TITLE
checker: fix if expr with compound conditions (fix #22496)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -1052,6 +1052,9 @@ fn (mut c Checker) autocast_in_if_conds(mut right ast.Expr, from_expr ast.Expr, 
 			c.autocast_in_if_conds(mut right.left, from_expr, from_type, to_type)
 			c.autocast_in_if_conds(mut right.right, from_expr, from_type, to_type)
 		}
+		ast.IndexExpr {
+			c.autocast_in_if_conds(mut right.left, from_expr, from_type, to_type)
+		}
 		else {}
 	}
 }

--- a/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_test.v
@@ -1,0 +1,9 @@
+type Foo = int | []int
+
+fn test_if_expr_with_compound_conds() {
+	a := Foo([3])
+	if a is []int && a[0] == 3 {
+		println('works')
+	}
+	assert true
+}


### PR DESCRIPTION
This PR fix if expr with compound conditions (fix #22496).

- Fix if expr with compound conditions.
- Add test.

```v
type Foo = int | []int

fn main() {
	a := Foo([3])
	if a is []int && a[0] == 3 {
		println('works')
	}
}

PS D:\Test\v\tt1> v run .
works
```