### PR TITLE
checker: perfect if expr with compound conditions

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -1054,6 +1054,19 @@ fn (mut c Checker) autocast_in_if_conds(mut right ast.Expr, from_expr ast.Expr, 
 		}
 		ast.IndexExpr {
 			c.autocast_in_if_conds(mut right.left, from_expr, from_type, to_type)
+			c.autocast_in_if_conds(mut right.index, from_expr, from_type, to_type)
+		}
+		ast.RangeExpr {
+			c.autocast_in_if_conds(mut right.low, from_expr, from_type, to_type)
+			c.autocast_in_if_conds(mut right.high, from_expr, from_type, to_type)
+		}
+		ast.StringInterLiteral {
+			for mut expr in right.exprs {
+				c.autocast_in_if_conds(mut expr, from_expr, from_type, to_type)
+			}
+		}
+		ast.UnsafeExpr {
+			c.autocast_in_if_conds(mut right.expr, from_expr, from_type, to_type)
 		}
 		else {}
 	}

--- a/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_1_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_1_test.v
@@ -1,0 +1,14 @@
+type Foo = int | []int
+
+fn works() bool {
+	a := Foo([3])
+	if a is []int && a[0] == 3 {
+		println('works')
+		return true
+	}
+	return false
+}
+
+fn test_if_expr_with_compound_conds() {
+	assert works()
+}

--- a/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_2_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_2_test.v
@@ -1,0 +1,15 @@
+type Foo = int | []int
+
+fn works() bool {
+	arr := [1, 2, 3]
+	a := Foo(2)
+	if a is int && arr[a] == 3 {
+		println('works')
+		return true
+	}
+	return false
+}
+
+fn test_if_expr_with_compound_conds() {
+	assert works()
+}

--- a/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_3_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_3_test.v
@@ -1,0 +1,14 @@
+type Foo = int | []int
+
+fn works() bool {
+	a := Foo(2)
+	if a is int && '${a}' == '2' {
+		println('works')
+		return true
+	}
+	return false
+}
+
+fn test_if_expr_with_compound_conds() {
+	assert works()
+}

--- a/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_4_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_4_test.v
@@ -1,0 +1,15 @@
+type Foo = int | []int
+
+fn works() bool {
+	arr := [1, 2, 3]
+	a := Foo(2)
+	if a is int && unsafe { arr[..a] == [1, 2] } {
+		println('works')
+		return true
+	}
+	return false
+}
+
+fn test_if_expr_with_compound_conds() {
+	assert works()
+}

--- a/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_compound_conds_test.v
@@ -1,9 +1,0 @@
-type Foo = int | []int
-
-fn test_if_expr_with_compound_conds() {
-	a := Foo([3])
-	if a is []int && a[0] == 3 {
-		println('works')
-	}
-	assert true
-}


### PR DESCRIPTION
This PR perfect if expr with compound conditions.

- Perfect if expr with compound conditions.
- Add tests.

```v
type Foo = int | []int

fn works() bool {
	arr := [1, 2, 3]
	a := Foo(2)
	if a is int && arr[a] == 3 {
		println('works')
		return true
	}
	return false
}

fn test_if_expr_with_compound_conds() {
	assert works()
}
```
```v
type Foo = int | []int

fn works() bool {
	a := Foo(2)
	if a is int && '${a}' == '2' {
		println('works')
		return true
	}
	return false
}

fn test_if_expr_with_compound_conds() {
	assert works()
}
```
```v
type Foo = int | []int

fn works() bool {
	arr := [1, 2, 3]
	a := Foo(2)
	if a is int && unsafe { arr[..a] == [1, 2] } {
		println('works')
		return true
	}
	return false
}

fn test_if_expr_with_compound_conds() {
	assert works()
}
```