### PR TITLE
regex, vfmt: optimize receiver with reference

### DIFF
--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -82,7 +82,7 @@ fn utf8util_char_len(b u8) int {
 
 // get_char get a char from position i and return an u32 with the unicode code
 @[direct_array_access; inline]
-fn (re RE) get_char(in_txt string, i int) (u32, int) {
+fn (re &RE) get_char(in_txt string, i int) (u32, int) {
 	ini := unsafe { in_txt.str[i] }
 	// ascii 8 bit
 	if (re.flag & f_bin) != 0 || ini & 0x80 == 0 {
@@ -101,7 +101,7 @@ fn (re RE) get_char(in_txt string, i int) (u32, int) {
 
 // get_charb get a char from position i and return an u32 with the unicode code
 @[direct_array_access; inline]
-fn (re RE) get_charb(in_txt &u8, i int) (u32, int) {
+fn (re &RE) get_charb(in_txt &u8, i int) (u32, int) {
 	// ascii 8 bit
 	if (re.flag & f_bin) != 0 || unsafe { in_txt[i] } & 0x80 == 0 {
 		return u32(unsafe { in_txt[i] }), 1
@@ -187,7 +187,7 @@ fn is_upper(in_char u8) bool {
 	return tmp <= 25
 }
 
-pub fn (re RE) get_parse_error_string(err int) string {
+pub fn (re &RE) get_parse_error_string(err int) string {
 	match err {
 		compile_ok { return 'compile_ok' }
 		no_match_found { return 'no_match_found' }
@@ -403,7 +403,7 @@ enum BSLS_parse_state {
 }
 
 // parse_bsls return (index, str_len) bsls_validator_array index, len of the backslash sequence if present
-fn (re RE) parse_bsls(in_txt string, in_i int) (int, int, u32) {
+fn (re &RE) parse_bsls(in_txt string, in_i int) (int, int, u32) {
 	mut status := BSLS_parse_state.start
 	mut i := in_i
 	mut hex_max_len := 2
@@ -539,7 +539,7 @@ enum CharClass_parse_state {
 	finish
 }
 
-fn (re RE) get_char_class(pc int) string {
+fn (re &RE) get_char_class(pc int) string {
 	buf := []u8{len: (re.cc.len)}
 	mut buf_ptr := unsafe { &u8(&buf) }
 
@@ -602,7 +602,7 @@ fn (re RE) get_char_class(pc int) string {
 	return unsafe { tos_clone(buf_ptr) }
 }
 
-fn (re RE) check_char_class(pc int, ch rune) bool {
+fn (re &RE) check_char_class(pc int, ch rune) bool {
 	mut cc_i := re.prog[pc].cc_index
 	for cc_i >= 0 && cc_i < re.cc.len && re.cc[cc_i].cc_type != cc_end {
 		if re.cc[cc_i].cc_type == cc_bsls {
@@ -757,7 +757,7 @@ enum Quant_parse_state {
 }
 
 // parse_quantifier return (min, max, str_len, greedy_flag) of a {min,max}? quantifier starting after the { char
-fn (re RE) parse_quantifier(in_txt string, in_i int) (int, int, int, bool) {
+fn (re &RE) parse_quantifier(in_txt string, in_i int) (int, int, int, bool) {
 	mut status := Quant_parse_state.start
 	mut i := in_i
 
@@ -887,7 +887,7 @@ enum Group_parse_state {
 }
 
 // parse_groups parse a group for ? (question mark) syntax, if found, return (error, capture_flag, negate_flag, name_of_the_group, next_index)
-fn (re RE) parse_groups(in_txt string, in_i int) (int, bool, bool, string, int) {
+fn (re &RE) parse_groups(in_txt string, in_i int) (int, bool, bool, string, int) {
 	mut status := Group_parse_state.start
 	mut i := in_i
 	mut name := ''
@@ -1530,7 +1530,7 @@ fn (mut re RE) impl_compile(in_txt string) (int, int) {
 }
 
 // get_code return the compiled code as regex string, note: may be different from the source!
-pub fn (re RE) get_code() string {
+pub fn (re &RE) get_code() string {
 	mut pc1 := 0
 	mut res := strings.new_builder(re.cc.len * 2 * re.prog.len)
 	res.write_string('========================================\nv RegEx compiler v ${v_regex_version} output:\n')
@@ -1617,7 +1617,7 @@ pub fn (re RE) get_code() string {
 }
 
 // get_query return a string with a reconstruction of the query starting from the regex program code
-pub fn (re RE) get_query() string {
+pub fn (re &RE) get_query() string {
 	mut res := strings.new_builder(re.query.len * 2)
 
 	if (re.flag & f_ms) != 0 {

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -38,7 +38,7 @@ pub fn regex_base(pattern string) (RE, int, int) {
 *
 ******************************************************************************/
 // get_group_bounds_by_name get a group boundaries by its name
-pub fn (re RE) get_group_bounds_by_name(group_name string) (int, int) {
+pub fn (re &RE) get_group_bounds_by_name(group_name string) (int, int) {
 	if group_name in re.group_map {
 		tmp_index := re.group_map[group_name] - 1
 		start := re.groups[tmp_index * 2]
@@ -49,7 +49,7 @@ pub fn (re RE) get_group_bounds_by_name(group_name string) (int, int) {
 }
 
 // get_group_by_name get a group boundaries by its name
-pub fn (re RE) get_group_by_name(in_txt string, group_name string) string {
+pub fn (re &RE) get_group_by_name(in_txt string, group_name string) string {
 	if group_name in re.group_map {
 		tmp_index := re.group_map[group_name] - 1
 		start := re.groups[tmp_index * 2]
@@ -62,7 +62,7 @@ pub fn (re RE) get_group_by_name(in_txt string, group_name string) string {
 }
 
 // get_group_by_id get a group string by its id
-pub fn (re RE) get_group_by_id(in_txt string, group_id int) string {
+pub fn (re &RE) get_group_by_id(in_txt string, group_id int) string {
 	if group_id < (re.groups.len >> 1) {
 		index := group_id * 2
 		start := re.groups[index]
@@ -75,7 +75,7 @@ pub fn (re RE) get_group_by_id(in_txt string, group_id int) string {
 }
 
 // get_group_by_id get a group boundaries by its id
-pub fn (re RE) get_group_bounds_by_id(group_id int) (int, int) {
+pub fn (re &RE) get_group_bounds_by_id(group_id int) (int, int) {
 	if group_id < re.group_count {
 		index := group_id * 2
 		return re.groups[index], re.groups[index + 1]
@@ -90,7 +90,7 @@ pub:
 }
 
 // get_group_list return a list of Re_group for the found groups
-pub fn (re RE) get_group_list() []Re_group {
+pub fn (re &RE) get_group_list() []Re_group {
 	mut res := []Re_group{len: re.groups.len >> 1}
 	mut gi := 0
 	// println("len: ${re.groups.len} groups: ${re.groups}")
@@ -446,7 +446,7 @@ pub fn (mut re RE) replace_by_fn(in_txt string, repl_fn FnReplace) string {
 	return res.str()
 }
 
-fn (re RE) parsed_replace_string(in_txt string, repl string) string {
+fn (re &RE) parsed_replace_string(in_txt string, repl string) string {
 	str_lst := repl.split('\\')
 	mut res := str_lst[0]
 	mut i := 1

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -246,7 +246,7 @@ pub fn (mut f Fmt) set_current_module_name(cmodname string) {
 	f.table.cmod_prefix = cmodname + '.'
 }
 
-fn (f Fmt) get_modname_prefix(mname string) (string, string) {
+fn (f &Fmt) get_modname_prefix(mname string) (string, string) {
 	// ./tests/proto_module_importing_vproto_keep.vv to know, why here is checked for ']' and '&'
 	if !mname.contains(']') && !mname.contains('&') {
 		return mname, ''
@@ -385,7 +385,7 @@ pub fn (mut f Fmt) imports(imports []ast.Import) {
 	}
 }
 
-pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
+pub fn (f &Fmt) imp_stmt_str(imp ast.Import) string {
 	// Format / remove unused selective import symbols
 	// E.g.: `import foo { Foo }` || `import foo as f { Foo }`
 	has_alias := imp.alias != imp.source_name.all_after_last('.')
@@ -404,7 +404,7 @@ pub fn (f Fmt) imp_stmt_str(imp ast.Import) string {
 
 //=== Node helpers ===//
 
-fn (f Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) bool {
+fn (f &Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node) bool {
 	// No need to insert a newline if there is already one
 	if f.out.last_n(2) == '\n\n' {
 		return false


### PR DESCRIPTION
This PR optimize receiver with reference because struct `RE` and struct `Fmt` are relatively large structures.