### PR TITLE
docs: change link in docs for the builtin framework, from vlib/vweb to vlib/veb

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - Easy cross-compilation
 - REPL
 - [Built-in ORM](https://github.com/vlang/v/blob/master/doc/docs.md#orm)
-- [Built-in web framework](https://github.com/vlang/v/blob/master/vlib/vweb/README.md)
+- [Built-in web framework](https://github.com/vlang/v/tree/master/vlib/veb/README.md)
 - C and JavaScript backends
 - Great for writing low-level software ([Vinix OS](https://github.com/vlang/vinix))
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - Easy cross-compilation
 - REPL
 - [Built-in ORM](https://github.com/vlang/v/blob/master/doc/docs.md#orm)
-- [Built-in web framework](https://github.com/vlang/v/tree/master/vlib/veb/README.md)
+- [Built-in web framework](https://github.com/vlang/v/blob/master/vlib/veb/README.md)
 - C and JavaScript backends
 - Great for writing low-level software ([Vinix OS](https://github.com/vlang/vinix))
 


### PR DESCRIPTION
Link to the new one version instead of deprecated one