### PR TITLE
cgen: fix fixed array literal in infix expr (fix #22559)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -128,6 +128,8 @@ mut:
 	inside_map_postfix        bool // inside map++/-- postfix expr
 	inside_map_infix          bool // inside map<</+=/-= infix expr
 	inside_assign             bool
+	inside_index              bool
+	inside_infix              bool
 	inside_map_index          bool
 	inside_array_index        bool
 	inside_array_fixed_struct bool

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -7,6 +7,11 @@ import v.ast
 import v.util
 
 fn (mut g Gen) index_expr(node ast.IndexExpr) {
+	pre_inside_index := g.inside_index
+	g.inside_index = true
+	defer {
+		g.inside_index = pre_inside_index
+	}
 	if node.index is ast.RangeExpr {
 		g.index_range_expr(node, node.index)
 	} else {

--- a/vlib/v/tests/builtin_arrays/fixed_array_literal_infix_test.v
+++ b/vlib/v/tests/builtin_arrays/fixed_array_literal_infix_test.v
@@ -1,0 +1,8 @@
+fn test_fixed_array_literal_infix() {
+	mut a := [][2]int{}
+	a << [0, 0]!
+	println([0, 0]! in a)
+	ret := [0, 0]! in a
+	println(ret)
+	assert ret
+}


### PR DESCRIPTION
This PR fix fixed array literal in infix expr (fix #22559).

- Fix fixed array literal in infix expr.
- Add test.

```v
fn main() {
	mut a := [][2]int{}
	a << [0, 0]!
	println([0, 0]! in a)
	ret := [0, 0]! in a
	println(ret)
	assert ret
}

PS D:\Test\v\tt1> v run .
true
true
```