### PR TITLE
cgen: fix hardcoded `db__pg__DB_last_id` for `x := sql db { insert address into Address }`

### DIFF
--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -421,3 +421,36 @@ fn test_i64_primary_field_works_with_insertions_of_id_0() {
 	assert users.len == 2
 	// println("${users}")
 }
+
+struct Address {
+	id     i64 @[primary; sql: serial]
+	street string
+	number int
+}
+
+fn test_the_result_of_insert_should_be_the_last_insert_id() {
+	db := sqlite.connect(':memory:')!
+	address := Address{
+		street: 'abc'
+		number: 123
+	}
+	dump(address)
+	sql db {
+		create table Address
+	} or {}
+	aid1 := sql db {
+		insert address into Address
+	} or { panic(err) }
+	dump(aid1)
+	aid2 := sql db {
+		insert address into Address
+	} or { panic(err) }
+	dump(aid2)
+	assert aid2 == 2
+	addresses := sql db {
+		select from Address
+	}!
+	dump(addresses)
+	assert addresses.len == 2
+	assert addresses.all(it.street == 'abc' && it.number == 123)
+}

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -61,9 +61,7 @@ fn (mut g Gen) sql_insert_expr(node ast.SqlExpr) {
 		node.or_expr)
 
 	g.write(left)
-	g.write('db__pg__DB_last_id(')
-	g.expr(node.db_expr)
-	g.write(');')
+	g.write('orm__Connection_name_table[${connection_var_name}._typ]._method_last_id(${connection_var_name}._object)')
 }
 
 // sql_stmt writes C code that calls ORM functions for


### PR DESCRIPTION
Fix #22583 .

- **cgen: fix hardcoded db__pg__DB_last_id for `x := sql db { insert address into Address }`**

The problem this solves, was reported on Discord: https://discord.com/channels/592103645835821068/1146520093824651385/1297062271914344459 .

A local reproduction is:
```v
import db.sqlite

struct Address {
	street string
	number int
}

dblite := sqlite.connect('my_database.db')!
address := Address{'abc', 123}
dump(address)
sql dblite {
	create table Address
} or {}
aid := sql dblite {
	insert address into Address
} or {
	println('error inserting address')
	panic(err)
}
dump(aid)
```

... producing a C error on `master`.