### PR TITLE
cgen: improve fixed array literal in operation and index calls (related #22579)

### DIFF
--- a/vlib/v/tests/builtin_arrays/fixed_array_literal_infix_test.v
+++ b/vlib/v/tests/builtin_arrays/fixed_array_literal_infix_test.v
@@ -1,8 +1,26 @@
-fn test_main() {
+fn test_array_of_fixed_array_in_op() {
 	mut a := [][2]int{}
-	a << [0, 0]!
-	println([0, 0]! in a)
-	ret := [0, 0]! in a
+	a << [1, 2]!
+	println([1, 2]! in a)
+	ret := [1, 2]! in a
 	println(ret)
 	assert ret
+}
+
+fn test_fixed_array_of_fixed_array_in_op() {
+	mut a := [2][2]int{}
+	a[0] = [1, 2]!
+	println([1, 2]! in a)
+	ret := [1, 2]! in a
+	println(ret)
+	assert ret
+}
+
+fn test_array_of_fixed_array_index() {
+	mut a := [][2]int{}
+	a << [1, 2]!
+	println(a.index([1, 2]!))
+	ret := a.index([1, 2]!)
+	println(ret)
+	assert ret == 0
 }


### PR DESCRIPTION
This PR improve fixed array literal in operation and index calls (related #22579).

- Improve fixed array literal in operation and index calls.
- Add tests.

```v
fn test_array_of_fixed_array_in_op() {
	mut a := [][2]int{}
	a << [1, 2]!
	println([1, 2]! in a)
	ret := [1, 2]! in a
	println(ret)
	assert ret
}

fn test_fixed_array_of_fixed_array_in_op() {
	mut a := [2][2]int{}
	a[0] = [1, 2]!
	println([1, 2]! in a)
	ret := [1, 2]! in a
	println(ret)
	assert ret
}

fn test_array_of_fixed_array_index() {
	mut a := [][2]int{}
	a << [1, 2]!
	println(a.index([1, 2]!))
	ret := a.index([1, 2]!)
	println(ret)
	assert ret == 0
}
```