### PR TITLE
checker, cgen: implement fixed array index()

### DIFF
--- a/vlib/builtin/fixed_array_index_test.v
+++ b/vlib/builtin/fixed_array_index_test.v
@@ -1,0 +1,35 @@
+fn test_index_of_ints() {
+	ia := [1, 2, 3]!
+	ii := ia.index(2)
+	dump(ii)
+	assert ii == 1
+}
+
+fn test_index_of_strings() {
+	sa := ['a', 'b', 'c']!
+	si := sa.index('b')
+	dump(si)
+	assert si == 1
+}
+
+fn test_index_of_voidptrs() {
+	pa := [voidptr(123), voidptr(45), voidptr(99)]!
+	pi := pa.index(voidptr(45))
+	dump(pi)
+	assert pi == 1
+}
+
+//////////
+
+fn a() {}
+
+fn b() {}
+
+fn c() {}
+
+fn test_index_of_fns() {
+	fa := [a, b, c]!
+	fi := fa.index(b)
+	dump(fi)
+	assert fi == 1
+}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1189,6 +1189,18 @@ fn (mut g Gen) gen_array_method_call(node ast.CallExpr, left_type ast.Type, left
 	return true
 }
 
+fn (mut g Gen) gen_fixed_array_method_call(node ast.CallExpr, left_type ast.Type, left_sym ast.TypeSymbol) bool {
+	match node.name {
+		'index' {
+			g.gen_array_index(node)
+		}
+		else {
+			return false
+		}
+	}
+	return true
+}
+
 fn (mut g Gen) gen_to_str_method_call(node ast.CallExpr) bool {
 	mut rec_type := node.receiver_type
 	if rec_type.has_flag(.shared_f) {
@@ -1677,6 +1689,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	final_left_sym := g.table.final_sym(left_type)
 	if final_left_sym.kind == .array && !(left_sym.kind == .alias && left_sym.has_method(node.name)) {
 		if g.gen_array_method_call(node, left_type, final_left_sym) {
+			return
+		}
+	}
+	if final_left_sym.kind == .array_fixed && !(left_sym.kind == .alias
+		&& left_sym.has_method(node.name)) {
+		if g.gen_fixed_array_method_call(node, left_type, final_left_sym) {
 			return
 		}
 	}

--- a/vlib/v/tests/builtin_arrays/fixed_array_literal_infix_test.v
+++ b/vlib/v/tests/builtin_arrays/fixed_array_literal_infix_test.v
@@ -24,3 +24,12 @@ fn test_array_of_fixed_array_index() {
 	println(ret)
 	assert ret == 0
 }
+
+fn test_fixed_array_of_fixed_array_index() {
+	mut a := [2][2]int{}
+	a[0] = [1, 2]!
+	println(a.index([1, 2]!))
+	ret := a.index([1, 2]!)
+	println(ret)
+	assert ret == 0
+}


### PR DESCRIPTION
This PR implement fixed array index().

- Implement fixed array index().
- Add test.

```v
fn test_index_of_ints() {
	ia := [1, 2, 3]!
	ii := ia.index(2)
	dump(ii)
	assert ii == 1
}

fn test_index_of_strings() {
	sa := ['a', 'b', 'c']!
	si := sa.index('b')
	dump(si)
	assert si == 1
}

fn test_index_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!
	pi := pa.index(voidptr(45))
	dump(pi)
	assert pi == 1
}

//////////

fn a() {}

fn b() {}

fn c() {}

fn test_index_of_fns() {
	fa := [a, b, c]!
	fi := fa.index(b)
	dump(fi)
	assert fi == 1
}

fn test_fixed_array_of_fixed_array_index() {
	mut a := [2][2]int{}
	a[0] = [1, 2]!
	println(a.index([1, 2]!))
	ret := a.index([1, 2]!)
	println(ret)
	assert ret == 0
}
```