### PR TITLE
checker, cgen: implement fixed array methods any() and all()

### DIFF
--- a/vlib/builtin/fixed_array_any_all_test.v
+++ b/vlib/builtin/fixed_array_any_all_test.v
@@ -1,0 +1,59 @@
+fn test_any_all_of_ints() {
+	ia := [1, 2, 3]!
+	mut ii := ia.any(it > 2)
+	println(ii)
+	assert ii
+
+	ii = ia.all(it > 1)
+	println(ii)
+	assert !ii
+
+	ii = ia.any(it == 2)
+	println(ii)
+	assert ii
+
+	ii = ia.all(it == 3)
+	println(ii)
+	assert !ii
+}
+
+fn test_any_all_of_strings() {
+	sa := ['a', 'b', 'c']!
+	mut si := sa.any(it == 'b')
+	println(si)
+	assert si
+
+	si = sa.all(it == 'c')
+	println(si)
+	assert !si
+}
+
+fn test_any_all_of_voidptrs() {
+	pa := [voidptr(123), voidptr(45), voidptr(99)]!
+	mut pi := pa.any(it == voidptr(45))
+	println(pi)
+	assert pi
+
+	pi = pa.all(it == voidptr(123))
+	println(pi)
+	assert !pi
+}
+
+fn a() {}
+
+fn b() {}
+
+fn c() {}
+
+fn v() {}
+
+fn test_any_all_of_fns() {
+	fa := [a, b, c]!
+	mut fi := fa.any(it == b)
+	println(fi)
+	assert fi
+
+	fi = fa.all(it == v)
+	println(fi)
+	assert !fi
+}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -513,7 +513,8 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	g.writeln('for (int ${i} = 0; ${i} < ${past.tmp_var}_len; ++${i}) {')
 	g.indent++
 	var_name := g.get_array_expr_param_name(mut expr)
-	g.write_prepared_var(var_name, inp_info, inp_elem_type, past.tmp_var, i)
+	g.write_prepared_var(var_name, inp_info.elem_type, inp_elem_type, past.tmp_var, i,
+		true)
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	match mut expr {
@@ -788,7 +789,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	i := g.new_tmp_var()
 	g.writeln('for (int ${i} = 0; ${i} < ${past.tmp_var}_len; ++${i}) {')
 	g.indent++
-	g.write_prepared_var(var_name, info, elem_type_str, past.tmp_var, i)
+	g.write_prepared_var(var_name, info.elem_type, elem_type_str, past.tmp_var, i, true)
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	match mut expr {
@@ -1267,9 +1268,13 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	}
 
 	sym := g.table.final_sym(node.left_type)
-	info := sym.info as ast.Array
-	// styp := g.styp(node.return_type)
-	elem_type_str := g.styp(info.elem_type)
+	left_is_array := sym.kind == .array
+	elem_type := if left_is_array {
+		(sym.info as ast.Array).elem_type
+	} else {
+		(sym.info as ast.ArrayFixed).elem_type
+	}
+	elem_type_str := g.styp(elem_type)
 	has_infix_left_var_name := g.write_prepared_tmp_value(past.tmp_var, node, 'bool',
 		'false')
 
@@ -1287,7 +1292,7 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 	g.writeln('for (int ${i} = 0; ${i} < ${past.tmp_var}_len; ++${i}) {')
 	g.indent++
 
-	g.write_prepared_var(var_name, info, elem_type_str, past.tmp_var, i)
+	g.write_prepared_var(var_name, elem_type, elem_type_str, past.tmp_var, i, left_is_array)
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
 	match mut expr {
@@ -1356,9 +1361,13 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 	}
 
 	sym := g.table.final_sym(node.left_type)
-	info := sym.info as ast.Array
-	// styp := g.styp(node.return_type)
-	elem_type_str := g.styp(info.elem_type)
+	left_is_array := sym.kind == .array
+	elem_type := if left_is_array {
+		(sym.info as ast.Array).elem_type
+	} else {
+		(sym.info as ast.ArrayFixed).elem_type
+	}
+	elem_type_str := g.styp(elem_type)
 
 	has_infix_left_var_name := g.write_prepared_tmp_value(past.tmp_var, node, 'bool',
 		'true')
@@ -1377,7 +1386,7 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 
 	g.writeln('for (int ${i} = 0; ${i} < ${past.tmp_var}_len; ++${i}) {')
 	g.indent++
-	g.write_prepared_var(var_name, info, elem_type_str, past.tmp_var, i)
+	g.write_prepared_var(var_name, elem_type, elem_type_str, past.tmp_var, i, left_is_array)
 	g.empty_line = true
 	g.set_current_pos_as_last_stmt_pos()
 	mut is_embed_map_filter := false
@@ -1455,26 +1464,57 @@ fn (mut g Gen) write_prepared_tmp_value(tmp string, node &ast.CallExpr, tmp_styp
 	} else {
 		node.left_type
 	}
-	g.write('${g.styp(left_type)} ${tmp}_orig = ')
-	if !node.left_type.has_flag(.shared_f) && node.left_type.is_ptr() {
-		g.write('*')
+	left_sym := g.table.final_sym(left_type)
+	if left_sym.kind == .array {
+		g.write('${g.styp(left_type)} ${tmp}_orig = ')
+		if !node.left_type.has_flag(.shared_f) && node.left_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.left)
+		if node.left_type.has_flag(.shared_f) {
+			g.write('->val')
+		}
+		g.writeln(';')
+		g.writeln('int ${tmp}_len = ${tmp}_orig.len;')
+	} else if left_sym.kind == .array_fixed {
+		left_info := left_sym.info as ast.ArrayFixed
+		left_styp := g.styp(left_type)
+		g.writeln('${left_styp} ${tmp}_orig;')
+		g.write('memcpy(&${tmp}_orig, &')
+		if !node.left_type.has_flag(.shared_f) && node.left_type.is_ptr() {
+			g.write('*')
+		}
+		g.expr(node.left)
+		if node.left_type.has_flag(.shared_f) {
+			g.write('->val')
+		}
+		g.writeln(', sizeof(${left_styp}));')
+		g.writeln('int ${tmp}_len = ${left_info.size};')
 	}
-	g.expr(node.left)
-	if node.left_type.has_flag(.shared_f) {
-		g.write('->val')
-	}
-	g.writeln(';')
-	g.writeln('int ${tmp}_len = ${tmp}_orig.len;')
 	return has_infix_left_var_name
 }
 
-fn (mut g Gen) write_prepared_var(var_name string, inp_info ast.Array, inp_elem_type string, tmp string,
-	i string) {
-	if g.table.sym(inp_info.elem_type).kind == .array_fixed {
-		g.writeln('${inp_elem_type} ${var_name};')
-		g.writeln('memcpy(&${var_name}, ((${inp_elem_type}*) ${tmp}_orig.data)[${i}], sizeof(${inp_elem_type}));')
+fn (mut g Gen) write_prepared_var(var_name string, elem_type ast.Type, inp_elem_type string, tmp string,
+	i string, is_array bool) {
+	elem_sym := g.table.sym(elem_type)
+	if is_array {
+		if elem_sym.kind == .array_fixed {
+			g.writeln('${inp_elem_type} ${var_name};')
+			g.writeln('memcpy(&${var_name}, ((${inp_elem_type}*) ${tmp}_orig.data)[${i}], sizeof(${inp_elem_type}));')
+		} else if elem_sym.kind == .function {
+			g.writeln('voidptr ${var_name} = ((${inp_elem_type}*) ${tmp}_orig.data)[${i}];')
+		} else {
+			g.writeln('${inp_elem_type} ${var_name} = ((${inp_elem_type}*) ${tmp}_orig.data)[${i}];')
+		}
 	} else {
-		g.writeln('${inp_elem_type} ${var_name} = ((${inp_elem_type}*) ${tmp}_orig.data)[${i}];')
+		if elem_sym.kind == .array_fixed {
+			g.writeln('${inp_elem_type} ${var_name};')
+			g.writeln('memcpy(&${var_name}, &${tmp}_orig[${i}], sizeof(${inp_elem_type}));')
+		} else if elem_sym.kind == .function {
+			g.writeln('voidptr ${var_name} = (voidptr)${tmp}_orig[${i}];')
+		} else {
+			g.writeln('${inp_elem_type} ${var_name} = ${tmp}_orig[${i}];')
+		}
 	}
 }
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1194,6 +1194,12 @@ fn (mut g Gen) gen_fixed_array_method_call(node ast.CallExpr, left_type ast.Type
 		'index' {
 			g.gen_array_index(node)
 		}
+		'any' {
+			g.gen_array_any(node)
+		}
+		'all' {
+			g.gen_array_all(node)
+		}
 		else {
 			return false
 		}


### PR DESCRIPTION
This PR implement fixed array methods any() and all().

- Implement fixed array methods any() and all().
- Add test.

```v
fn test_any_all_of_ints() {
	ia := [1, 2, 3]!
	mut ii := ia.any(it > 2)
	println(ii)
	assert ii

	ii = ia.all(it > 1)
	println(ii)
	assert !ii

	ii = ia.any(it == 2)
	println(ii)
	assert ii

	ii = ia.all(it == 3)
	println(ii)
	assert !ii
}

fn test_any_all_of_strings() {
	sa := ['a', 'b', 'c']!
	mut si := sa.any(it == 'b')
	println(si)
	assert si

	si = sa.all(it == 'c')
	println(si)
	assert !si
}

fn test_any_all_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!
	mut pi := pa.any(it == voidptr(45))
	println(pi)
	assert pi

	pi = pa.all(it == voidptr(123))
	println(pi)
	assert !pi
}

fn a() {}

fn b() {}

fn c() {}

fn v() {}

fn test_any_all_of_fns() {
	fa := [a, b, c]!
	mut fi := fa.any(it == b)
	println(fi)
	assert fi

	fi = fa.all(it == v)
	println(fi)
	assert !fi
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2NTZjODRjMjRlYTI4ODJmY2U2ZjMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.SHhn0l3pRpMQf5icWPei-KMUNyBgbQJJX8UVzhONj0w">Huly&reg;: <b>V_0.6-21058</b></a></sub>