### PR TITLE
cgen: reduce write calls (string_builder + gen.c)

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -143,9 +143,9 @@ pub fn (mut b Builder) write_string(s string) {
 	// b.buf << []u8(s)  // TODO
 }
 
-// write_2_string appends the strings `s1` and `s2` to the buffer
+// write_string2 appends the strings `s1` and `s2` to the buffer
 @[inline]
-pub fn (mut b Builder) write_2_string(s1 string, s2 string) {
+pub fn (mut b Builder) write_string2(s1 string, s2 string) {
 	if s1.len != 0 {
 		unsafe { b.push_many(s1.str, s1.len) }
 	}
@@ -215,9 +215,9 @@ pub fn (mut b Builder) writeln(s string) {
 	b << u8(`\n`)
 }
 
-// write2ln appends two strings: `s1` + `\n`, and `s2` + `\n`, to the buffer.
+// writeln2 appends two strings: `s1` + `\n`, and `s2` + `\n`, to the buffer.
 @[inline]
-pub fn (mut b Builder) write2ln(s1 string, s2 string) {
+pub fn (mut b Builder) writeln2(s1 string, s2 string) {
 	if s1 != '' {
 		unsafe { b.push_many(s1.str, s1.len) }
 	}

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -215,22 +215,16 @@ pub fn (mut b Builder) writeln(s string) {
 	b << u8(`\n`)
 }
 
-// write2ln appends two string `s1` and `s2`, and then a newline character.
+// write2ln appends two strings: `s1` + `\n`, and `s2` + `\n`, to the buffer.
 @[inline]
 pub fn (mut b Builder) write2ln(s1 string, s2 string) {
-	// for c in s {
-	// b.buf << c
-	// }
 	if s1 != '' {
 		unsafe { b.push_many(s1.str, s1.len) }
 	}
-	// b.buf << []u8(s)  // TODO
 	b << u8(`\n`)
-
 	if s2 != '' {
 		unsafe { b.push_many(s2.str, s2.len) }
 	}
-
 	b << u8(`\n`)
 }
 

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -143,7 +143,7 @@ pub fn (mut b Builder) write_string(s string) {
 	// b.buf << []u8(s)  // TODO
 }
 
-// write appends the strings `s1` and `s2` to the buffer
+// write_2_string appends the strings `s1` and `s2` to the buffer
 @[inline]
 pub fn (mut b Builder) write_2_string(s1 string, s2 string) {
 	if s1.len != 0 {
@@ -215,7 +215,7 @@ pub fn (mut b Builder) writeln(s string) {
 	b << u8(`\n`)
 }
 
-// writeln appends two string `s1` and `s2`, and then a newline character.
+// write2ln appends two string `s1` and `s2`, and then a newline character.
 @[inline]
 pub fn (mut b Builder) write2ln(s1 string, s2 string) {
 	// for c in s {

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -143,6 +143,17 @@ pub fn (mut b Builder) write_string(s string) {
 	// b.buf << []u8(s)  // TODO
 }
 
+// write appends the strings `s1` and `s2` to the buffer
+@[inline]
+pub fn (mut b Builder) write_2_string(s1 string, s2 string) {
+	if s1.len != 0 {
+		unsafe { b.push_many(s1.str, s1.len) }
+	}
+	if s2.len != 0 {
+		unsafe { b.push_many(s2.str, s2.len) }
+	}
+}
+
 // writeln_string appends the string `s`+`\n` to the buffer
 @[deprecated: 'use writeln() instead']
 @[deprecated_after: '2024-03-21']
@@ -201,6 +212,25 @@ pub fn (mut b Builder) writeln(s string) {
 		unsafe { b.push_many(s.str, s.len) }
 	}
 	// b.buf << []u8(s)  // TODO
+	b << u8(`\n`)
+}
+
+// writeln appends two string `s1` and `s2`, and then a newline character.
+@[inline]
+pub fn (mut b Builder) write2ln(s1 string, s2 string) {
+	// for c in s {
+	// b.buf << c
+	// }
+	if s1 != '' {
+		unsafe { b.push_many(s1.str, s1.len) }
+	}
+	// b.buf << []u8(s)  // TODO
+	b << u8(`\n`)
+
+	if s2 != '' {
+		unsafe { b.push_many(s2.str, s2.len) }
+	}
+
 	b << u8(`\n`)
 }
 

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -119,7 +119,8 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		g.write('}')
 		g.write2ln(';', '{')
 		g.indent++
-		g.write2ln('${elem_typ_str}* pelem = (${elem_typ_str}*)${past.tmp_var};', 'int _len = (int)sizeof(${past.tmp_var}) / sizeof(${elem_typ_str});')
+		g.writeln('${elem_typ_str}* pelem = (${elem_typ_str}*)${past.tmp_var};')
+		g.writeln('int _len = (int)sizeof(${past.tmp_var}) / sizeof(${elem_typ_str});')
 		g.writeln('for (int index=0; index<_len; index++, pelem++) {')
 		g.set_current_pos_as_last_stmt_pos()
 		g.indent++
@@ -327,7 +328,8 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		}
 		g.write2ln(';', '{')
 		g.indent++
-		g.write2ln('${elem_typ}* pelem = (${elem_typ}*)${past.tmp_var}.data;', 'for (int index=0; index<${past.tmp_var}.len; index++, pelem++) {')
+		g.writeln('${elem_typ}* pelem = (${elem_typ}*)${past.tmp_var}.data;')
+		g.writeln('for (int index=0; index<${past.tmp_var}.len; index++, pelem++) {')
 		g.set_current_pos_as_last_stmt_pos()
 		g.indent++
 		g.writeln('int it = index;') // FIXME: Remove this line when it is fully forbidden

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -117,7 +117,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			g.write('0')
 		}
 		g.write('}')
-		g.write2ln(';', '{')
+		g.writeln2(';', '{')
 		g.indent++
 		g.writeln('${elem_typ_str}* pelem = (${elem_typ_str}*)${past.tmp_var};')
 		g.writeln('int _len = (int)sizeof(${past.tmp_var}) / sizeof(${elem_typ_str});')
@@ -326,7 +326,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		} else if is_amp {
 			g.write(')')
 		}
-		g.write2ln(';', '{')
+		g.writeln2(';', '{')
 		g.indent++
 		g.writeln('${elem_typ}* pelem = (${elem_typ}*)${past.tmp_var}.data;')
 		g.writeln('for (int index=0; index<${past.tmp_var}.len; index++, pelem++) {')
@@ -405,7 +405,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 				g.write(g.type_default(node.elem_type))
 			}
 		}
-		g.write2ln(';', '}')
+		g.writeln2(';', '}')
 		g.write2(line, ' (voidptr)${tmp})')
 	} else if node.has_init {
 		g.write('&(${elem_styp}[]){')
@@ -572,7 +572,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 			g.expr(expr)
 		}
 	}
-	g.write2ln(';', 'array_push${noscan}((array*)&${past.tmp_var}, &${tmp_map_expr_result_name});')
+	g.writeln2(';', 'array_push${noscan}((array*)&${past.tmp_var}, &${tmp_map_expr_result_name});')
 	g.indent--
 	g.writeln('}')
 	if !is_embed_map_filter {
@@ -823,7 +823,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 			g.expr(expr)
 		}
 	}
-	g.write2ln(') {', '\tarray_push${noscan}((array*)&${past.tmp_var}, &${var_name});')
+	g.writeln2(') {', '\tarray_push${noscan}((array*)&${past.tmp_var}, &${var_name});')
 	g.writeln('}')
 	g.indent--
 	g.writeln('}')
@@ -1319,8 +1319,8 @@ fn (mut g Gen) gen_array_any(node ast.CallExpr) {
 			g.expr(expr)
 		}
 	}
-	g.write2ln(') {', '\t${past.tmp_var} = true;')
-	g.write2ln('\tbreak;', '}')
+	g.writeln2(') {', '\t${past.tmp_var} = true;')
+	g.writeln2('\tbreak;', '}')
 	g.indent--
 	g.writeln('}')
 	if !is_embed_map_filter {
@@ -1408,8 +1408,8 @@ fn (mut g Gen) gen_array_all(node ast.CallExpr) {
 			g.expr(expr)
 		}
 	}
-	g.write2ln(')) {', '\t${past.tmp_var} = false;')
-	g.write2ln('\tbreak;', '}')
+	g.writeln2(')) {', '\t${past.tmp_var} = false;')
+	g.writeln2('\tbreak;', '}')
 	g.indent--
 	g.writeln('}')
 	if !is_embed_map_filter {
@@ -1445,14 +1445,14 @@ fn (mut g Gen) write_prepared_tmp_value(tmp string, node &ast.CallExpr, tmp_styp
 	if node.left_type.has_flag(.shared_f) {
 		g.write('->val')
 	}
-	g.write2ln(';', 'int ${tmp}_len = ${tmp}_orig.len;')
+	g.writeln2(';', 'int ${tmp}_len = ${tmp}_orig.len;')
 	return has_infix_left_var_name
 }
 
 fn (mut g Gen) write_prepared_var(var_name string, inp_info ast.Array, inp_elem_type string, tmp string,
 	i string) {
 	if g.table.sym(inp_info.elem_type).kind == .array_fixed {
-		g.write2ln('${inp_elem_type} ${var_name};', 'memcpy(&${var_name}, ((${inp_elem_type}*) ${tmp}_orig.data)[${i}], sizeof(${inp_elem_type}));')
+		g.writeln2('${inp_elem_type} ${var_name};', 'memcpy(&${var_name}, ((${inp_elem_type}*) ${tmp}_orig.data)[${i}], sizeof(${inp_elem_type}));')
 	} else {
 		g.writeln('${inp_elem_type} ${var_name} = ((${inp_elem_type}*) ${tmp}_orig.data)[${i}];')
 	}

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -121,8 +121,7 @@ fn (mut g Gen) gen_assert_postfailure_mode(node ast.AssertStmt) {
 	if g.pref.is_test {
 		g.writeln('\tlongjmp(g_jump_buffer, 1);')
 	}
-	g.writeln('\t// TODO')
-	g.writeln('\t// Maybe print all vars in a test function if it fails?')
+	g.write2ln('\t// TODO', '\t// Maybe print all vars in a test function if it fails?')
 	if g.pref.assert_failure_mode != .continues {
 		g.writeln('\t_v_panic(_SLIT("Assertion failed..."));')
 	}

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -121,7 +121,7 @@ fn (mut g Gen) gen_assert_postfailure_mode(node ast.AssertStmt) {
 	if g.pref.is_test {
 		g.writeln('\tlongjmp(g_jump_buffer, 1);')
 	}
-	g.write2ln('\t// TODO', '\t// Maybe print all vars in a test function if it fails?')
+	g.writeln2('\t// TODO', '\t// Maybe print all vars in a test function if it fails?')
 	if g.pref.assert_failure_mode != .continues {
 		g.writeln('\t_v_panic(_SLIT("Assertion failed..."));')
 	}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -915,7 +915,7 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 			g.expr(lx)
 			sym := g.table.final_sym(node.left_types[i])
 			if sym.kind == .array_fixed {
-				g.write2ln(';', 'memcpy(&${g.expr_string(lx)}, &${mr_var_name}.arg${i}, sizeof(${styp}));')
+				g.writeln2(';', 'memcpy(&${g.expr_string(lx)}, &${mr_var_name}.arg${i}, sizeof(${styp}));')
 			} else {
 				if cur_indexexpr != -1 {
 					if is_auto_heap {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -915,8 +915,7 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 			g.expr(lx)
 			sym := g.table.final_sym(node.left_types[i])
 			if sym.kind == .array_fixed {
-				g.writeln(';')
-				g.writeln('memcpy(&${g.expr_string(lx)}, &${mr_var_name}.arg${i}, sizeof(${styp}));')
+				g.write2ln(';', 'memcpy(&${g.expr_string(lx)}, &${mr_var_name}.arg${i}, sizeof(${styp}));')
 			} else {
 				if cur_indexexpr != -1 {
 					if is_auto_heap {
@@ -1123,8 +1122,7 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			for lx in left {
 				if lx is ast.Ident {
 					if val.name == lx.name {
-						g.write('_var_')
-						g.write(lx.pos.pos.str())
+						g.write2('_var_', lx.pos.pos.str())
 						has_var = true
 						break
 					}
@@ -1138,8 +1136,7 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			mut has_var := false
 			for lx in left {
 				if val_.str() == lx.str() {
-					g.write('_var_')
-					g.write(lx.pos().pos.str())
+					g.write2('_var_', lx.pos().pos.str())
 					has_var = true
 					break
 				}
@@ -1152,10 +1149,8 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			sym := g.table.sym(val.left_type)
 			if _ := g.table.find_method(sym, val.op.str()) {
 				left_styp := g.styp(val.left_type.set_nr_muls(0))
-				g.write(left_styp)
-				g.write('_')
-				g.write(util.replace_op(val.op.str()))
-				g.write('(')
+				g.write2(left_styp, '_')
+				g.write2(util.replace_op(val.op.str()), '(')
 				g.gen_cross_tmp_variable(left, val.left)
 				g.write(', ')
 				g.gen_cross_tmp_variable(left, val.right)
@@ -1216,8 +1211,7 @@ fn (mut g Gen) gen_cross_tmp_variable(left []ast.Expr, val ast.Expr) {
 			mut has_var := false
 			for lx in left {
 				if val_.str() == lx.str() {
-					g.write('_var_')
-					g.write(lx.pos().pos.str())
+					g.write2('_var_', lx.pos().pos.str())
 					has_var = true
 					break
 				}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -417,8 +417,8 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 				{_SLIT("${clean_interface_v_type_name}(\'"), ${si_s_code}, {.d_s = ${val}}},
 				{_SLIT("\')"), 0, {.d_c = 0 }}
 			}))'
-			fn_builder.write_string('\tif (x._typ == _${styp}_${sub_sym.cname}_index)')
-			fn_builder.write_string(' return ${res};')
+			fn_builder.write_2_string('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
+				' return ${res};')
 		} else {
 			mut val := '${func_name}(${deref}(${sub_sym.cname}*)x._${sub_sym.cname}'
 			if should_use_indent_func(sub_sym.kind) && !sym_has_str_method {
@@ -429,8 +429,8 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 				{_SLIT("${clean_interface_v_type_name}("), ${si_s_code}, {.d_s = ${val}}},
 				{_SLIT(")"), 0, {.d_c = 0 }}
 			}))'
-			fn_builder.write_string('\tif (x._typ == _${styp}_${sub_sym.cname}_index)')
-			fn_builder.write_string(' return ${res};\n')
+			fn_builder.write_2_string('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
+				' return ${res};\n')
 		}
 	}
 	fn_builder.writeln('\treturn _SLIT("unknown interface value");')
@@ -1116,8 +1116,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 						'\tstring_free(&${tmpvar});')
 					fn_body.write_string(tmpvar)
 				} else {
-					fn_body.write_string(funcprefix)
-					fn_body.write_string(func)
+					fn_body.write_2_string(funcprefix, func)
 				}
 			}
 		}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -417,7 +417,7 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 				{_SLIT("${clean_interface_v_type_name}(\'"), ${si_s_code}, {.d_s = ${val}}},
 				{_SLIT("\')"), 0, {.d_c = 0 }}
 			}))'
-			fn_builder.write_2_string('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
+			fn_builder.write_string2('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
 				' return ${res};')
 		} else {
 			mut val := '${func_name}(${deref}(${sub_sym.cname}*)x._${sub_sym.cname}'
@@ -429,7 +429,7 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 				{_SLIT("${clean_interface_v_type_name}("), ${si_s_code}, {.d_s = ${val}}},
 				{_SLIT(")"), 0, {.d_c = 0 }}
 			}))'
-			fn_builder.write_2_string('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
+			fn_builder.write_string2('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
 				' return ${res};\n')
 		}
 	}
@@ -1116,7 +1116,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 						'\tstring_free(&${tmpvar});')
 					fn_body.write_string(tmpvar)
 				} else {
-					fn_body.write_2_string(funcprefix, func)
+					fn_body.write_string2(funcprefix, func)
 				}
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -535,13 +535,13 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	if g.out_options_forward.len > 0 || g.out_results_forward.len > 0 {
 		tail := g.type_definitions.cut_to(g.options_pos_forward)
 		if g.out_options_forward.len > 0 {
-			g.type_definitions.writeln('// #start V forward option_xxx definitions:')
-			g.type_definitions.writeln(g.out_options_forward.str())
+			g.type_definitions.write2ln('// #start V forward option_xxx definitions:',
+				g.out_options_forward.str())
 			g.type_definitions.writeln('// #end V forward option_xxx definitions\n')
 		}
 		if g.out_results_forward.len > 0 {
-			g.type_definitions.writeln('// #start V forward result_xxx definitions:')
-			g.type_definitions.writeln(g.out_results_forward.str())
+			g.type_definitions.write2ln('// #start V forward result_xxx definitions:',
+				g.out_results_forward.str())
 			g.type_definitions.writeln('// #end V forward result_xxx definitions\n')
 		}
 		g.type_definitions.writeln(tail)
@@ -838,8 +838,7 @@ pub fn (mut g Gen) init() {
 			g.cheaders.writeln(tcc_undef_has_include)
 			g.includes.writeln(tcc_undef_has_include)
 			if g.pref.os == .freebsd {
-				g.cheaders.writeln('#include <inttypes.h>')
-				g.cheaders.writeln('#include <stddef.h>')
+				g.cheaders.write2ln('#include <inttypes.h>', '#include <stddef.h>')
 			} else {
 				install_compiler_msg := ' Please install the package `build-essential`.'
 				g.cheaders.writeln(get_guarded_include_text('<inttypes.h>', 'The C compiler can not find <inttypes.h>.${install_compiler_msg}')) // int64_t etc
@@ -863,8 +862,7 @@ pub fn (mut g Gen) init() {
 		}
 	}
 	if g.pref.os == .ios {
-		g.cheaders.writeln('#define __TARGET_IOS__ 1')
-		g.cheaders.writeln('#include <spawn.h>')
+		g.cheaders.write2ln('#define __TARGET_IOS__ 1', '#include <spawn.h>')
 	}
 	g.write_builtin_types()
 	g.options_pos_forward = g.type_definitions.len
@@ -8039,16 +8037,14 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 			pmessage := 'string__plus(string__plus(tos3("`as_cast`: cannot convert "), tos3(v_typeof_interface_${interface_name}(x._typ))), tos3(" to ${util.strip_main_name(vsym.name)}"))'
 			if g.pref.is_debug {
 				// TODO: actually return a valid position here
-				conversion_functions.write_string('\tpanic_debug(1, tos3("builtin.v"), tos3("builtin"), tos3("__as_cast"), ')
-				conversion_functions.write_string(pmessage)
+				conversion_functions.write_2_string('\tpanic_debug(1, tos3("builtin.v"), tos3("builtin"), tos3("__as_cast"), ',
+					pmessage)
 				conversion_functions.writeln(');')
 			} else {
-				conversion_functions.write_string('\t_v_panic(')
-				conversion_functions.write_string(pmessage)
+				conversion_functions.write_2_string('\t_v_panic(', pmessage)
 				conversion_functions.writeln(');')
 			}
-			conversion_functions.writeln('\treturn (${vsym.cname}){0};')
-			conversion_functions.writeln('}')
+			conversion_functions.write2ln('\treturn (${vsym.cname}){0};', '}')
 		}
 		sb.writeln('// ^^^ number of types for interface ${interface_name}: ${current_iinidx - iinidx_minimum_base}')
 		if iname_table_length == 0 {
@@ -8061,8 +8057,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 		// add line return after interface index declarations
 		sb.writeln('')
 		if inter_methods.len > 0 {
-			sb.writeln(methods_wrapper.str())
-			sb.writeln(methods_struct_def.str())
+			sb.write2ln(methods_wrapper.str(), methods_struct_def.str())
 			sb.writeln(methods_struct.str())
 		}
 		sb.writeln(cast_functions.str())

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4328,11 +4328,13 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 		}
 		count += 1
 	}
-	g.write2ln('{', '\tMap_string_string _scope = new_map_init(&map_hash_string, &map_eq_string, &map_clone_string, &map_free_string, ${vars.len}, sizeof(string), sizeof(v__debug__DebugContextVar),')
+	g.writeln('{')
+	g.writeln('\tMap_string_string _scope = new_map_init(&map_hash_string, &map_eq_string, &map_clone_string, &map_free_string, ${vars.len}, sizeof(string), sizeof(v__debug__DebugContextVar),')
 	g.write2('\t\t_MOV((string[${vars.len}]){', keys.str())
 	g.writeln('}),')
 	g.write2('\t\t_MOV((v__debug__DebugContextVar[${vars.len}]){', values.str())
-	g.write2ln('}));', '\tv__debug__Debugger_interact(&g_debugger, (v__debug__DebugContextInfo){.is_anon=${is_anon},.is_generic=${is_generic},.is_method=${is_method},.receiver_typ_name=_SLIT("${receiver_type}"),.line=${paline},.file=_SLIT("${pafile}"),.mod=_SLIT("${pamod}"),.fn_name=_SLIT("${pafn}"),.scope=_scope});')
+	g.writeln('}));')
+	g.writeln('\tv__debug__Debugger_interact(&g_debugger, (v__debug__DebugContextInfo){.is_anon=${is_anon},.is_generic=${is_generic},.is_method=${is_method},.receiver_typ_name=_SLIT("${receiver_type}"),.line=${paline},.file=_SLIT("${pafile}"),.mod=_SLIT("${pamod}"),.fn_name=_SLIT("${pafn}"),.scope=_scope});')
 	g.write('}')
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -836,7 +836,8 @@ pub fn (mut g Gen) init() {
 		}
 	}
 	if g.pref.os == .ios {
-		g.cheaders.write2ln('#define __TARGET_IOS__ 1', '#include <spawn.h>')
+		g.cheaders.writeln('#define __TARGET_IOS__ 1')
+		g.cheaders.writeln('#include <spawn.h>')
 	}
 	g.write_builtin_types()
 	g.options_pos_forward = g.type_definitions.len

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6597,11 +6597,13 @@ fn (mut g Gen) write_init_function() {
 		} else {
 			g.writeln('__attribute__ ((constructor))')
 		}
-		g.write2ln('void _vinit_caller() {', '\tstatic bool once = false; if (once) {return;} once = true;')
+		g.writeln('void _vinit_caller() {')
+		g.writeln('\tstatic bool once = false; if (once) {return;} once = true;')
 		if g.nr_closures > 0 {
 			g.writeln('\t__closure_init(); // vinit_caller()')
 		}
-		g.write2ln('\t_vinit(0,0);', '}')
+		g.writeln('\t_vinit(0,0);')
+		g.writeln('}')
 
 		if g.pref.os == .windows {
 			g.write2ln('// workaround for windows, export _vcleanup_caller, let dl.close() call it',
@@ -6610,8 +6612,10 @@ fn (mut g Gen) write_init_function() {
 		} else {
 			g.writeln('__attribute__ ((destructor))')
 		}
-		g.write2ln('void _vcleanup_caller() {', '\tstatic bool once = false; if (once) {return;} once = true;')
-		g.write2ln('\t_vcleanup();', '}')
+		g.writeln('void _vcleanup_caller() {')
+		g.writeln('\tstatic bool once = false; if (once) {return;} once = true;')
+		g.writeln('\t_vcleanup();')
+		g.writeln('}')
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -801,7 +801,8 @@ pub fn (mut g Gen) init() {
 		if g.pref.os == .wasm32 {
 			g.cheaders.writeln('#define VWASM 1')
 			// Include <stdint.h> instead of <inttypes.h> for WASM target
-			g.cheaders.writeln2('#include <stdint.h>', '#include <stddef.h>')
+			g.cheaders.writeln('#include <stdint.h>')
+			g.cheaders.writeln('#include <stddef.h>')
 		} else {
 			tcc_undef_has_include := '
 #if defined(__TINYC__) && defined(__has_include)
@@ -812,7 +813,8 @@ pub fn (mut g Gen) init() {
 			g.cheaders.writeln(tcc_undef_has_include)
 			g.includes.writeln(tcc_undef_has_include)
 			if g.pref.os == .freebsd {
-				g.cheaders.writeln2('#include <inttypes.h>', '#include <stddef.h>')
+				g.cheaders.writeln('#include <inttypes.h>')
+				g.cheaders.writeln('#include <stddef.h>')
 			} else {
 				install_compiler_msg := ' Please install the package `build-essential`.'
 				g.cheaders.writeln(get_guarded_include_text('<inttypes.h>', 'The C compiler can not find <inttypes.h>.${install_compiler_msg}')) // int64_t etc

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -535,12 +535,12 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	if g.out_options_forward.len > 0 || g.out_results_forward.len > 0 {
 		tail := g.type_definitions.cut_to(g.options_pos_forward)
 		if g.out_options_forward.len > 0 {
-			g.type_definitions.write2ln('// #start V forward option_xxx definitions:',
+			g.type_definitions.writeln2('// #start V forward option_xxx definitions:',
 				g.out_options_forward.str())
 			g.type_definitions.writeln('// #end V forward option_xxx definitions\n')
 		}
 		if g.out_results_forward.len > 0 {
-			g.type_definitions.write2ln('// #start V forward result_xxx definitions:',
+			g.type_definitions.writeln2('// #start V forward result_xxx definitions:',
 				g.out_results_forward.str())
 			g.type_definitions.writeln('// #end V forward result_xxx definitions\n')
 		}
@@ -554,14 +554,14 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	if g.use_segfault_handler || g.pref.is_prof {
 		b.writeln('\n#define V_USE_SIGNAL_H')
 	}
-	b.write_2_string('\n// V comptime_definitions:\n', g.comptime_definitions.str())
-	b.write_2_string('\n// V typedefs:\n', g.typedefs.str())
-	b.write_2_string('\n // V preincludes:\n', g.preincludes.str())
-	b.write_2_string('\n// V cheaders:', g.cheaders.str())
+	b.write_string2('\n// V comptime_definitions:\n', g.comptime_definitions.str())
+	b.write_string2('\n// V typedefs:\n', g.typedefs.str())
+	b.write_string2('\n // V preincludes:\n', g.preincludes.str())
+	b.write_string2('\n// V cheaders:', g.cheaders.str())
 	if g.pcs_declarations.len > 0 {
-		b.write_2_string('\n// V profile counters:\n', g.pcs_declarations.str())
+		b.write_string2('\n// V profile counters:\n', g.pcs_declarations.str())
 	}
-	b.write_2_string('\n// V includes:\n', g.includes.str())
+	b.write_string2('\n// V includes:\n', g.includes.str())
 	b.writeln('\n// V global/const #define ... :')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
@@ -570,15 +570,15 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 			}
 		}
 	}
-	b.write_2_string('\n// Enum definitions:\n', g.enum_typedefs.str())
-	b.write_2_string('\n// Thread definitions:\n', g.thread_definitions.str())
-	b.write_2_string('\n// V type definitions:\n', g.type_definitions.str())
-	b.write_2_string('\n// V alias definitions:\n', g.alias_definitions.str())
-	b.write_2_string('\n// V shared types:\n', g.shared_types.str())
-	b.write_2_string('\n// V Option_xxx definitions:\n', g.out_options.str())
-	b.write_2_string('\n// V result_xxx definitions:\n', g.out_results.str())
-	b.write_2_string('\n// V json forward decls:\n', g.json_forward_decls.str())
-	b.write_2_string('\n// V definitions:\n', g.definitions.str())
+	b.write_string2('\n// Enum definitions:\n', g.enum_typedefs.str())
+	b.write_string2('\n// Thread definitions:\n', g.thread_definitions.str())
+	b.write_string2('\n// V type definitions:\n', g.type_definitions.str())
+	b.write_string2('\n// V alias definitions:\n', g.alias_definitions.str())
+	b.write_string2('\n// V shared types:\n', g.shared_types.str())
+	b.write_string2('\n// V Option_xxx definitions:\n', g.out_options.str())
+	b.write_string2('\n// V result_xxx definitions:\n', g.out_results.str())
+	b.write_string2('\n// V json forward decls:\n', g.json_forward_decls.str())
+	b.write_string2('\n// V definitions:\n', g.definitions.str())
 	b.writeln('\n// V global/const non-precomputed definitions:')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
@@ -589,29 +589,29 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	}
 	interface_table := g.interface_table()
 	if interface_table.len > 0 {
-		b.write_2_string('\n// V interface table:\n', interface_table)
+		b.write_string2('\n// V interface table:\n', interface_table)
 	}
 	if g.gowrappers.len > 0 {
-		b.write_2_string('\n// V gowrappers:\n', g.gowrappers.str())
+		b.write_string2('\n// V gowrappers:\n', g.gowrappers.str())
 	}
 	if g.hotcode_definitions.len > 0 {
-		b.write_2_string('\n// V hotcode definitions:\n', g.hotcode_definitions.str())
+		b.write_string2('\n// V hotcode definitions:\n', g.hotcode_definitions.str())
 	}
 	if g.embedded_data.len > 0 {
-		b.write_2_string('\n// V embedded data:\n', g.embedded_data.str())
+		b.write_string2('\n// V embedded data:\n', g.embedded_data.str())
 	}
 	if g.shared_functions.len > 0 {
 		b.writeln('\n// V shared type functions:\n')
-		b.write_2_string(g.shared_functions.str(), c_concurrency_helpers)
+		b.write_string2(g.shared_functions.str(), c_concurrency_helpers)
 	}
 	if g.channel_definitions.len > 0 {
-		b.write_2_string('\n// V channel code:\n', g.channel_definitions.str())
+		b.write_string2('\n// V channel code:\n', g.channel_definitions.str())
 	}
 	if g.auto_str_funcs.len > 0 {
-		b.write_2_string('\n// V auto str functions:\n', g.auto_str_funcs.str())
+		b.write_string2('\n// V auto str functions:\n', g.auto_str_funcs.str())
 	}
 	if g.dump_funcs.len > 0 {
-		b.write_2_string('\n// V dump functions:\n', g.dump_funcs.str())
+		b.write_string2('\n// V dump functions:\n', g.dump_funcs.str())
 	}
 	if g.auto_fn_definitions.len > 0 {
 		b.writeln('\n// V auto functions:')
@@ -621,7 +621,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	}
 	if g.anon_fn_definitions.len > 0 {
 		if g.nr_closures > 0 {
-			b.write2ln('\n// V closure helpers', c_closure_helpers(g.pref))
+			b.writeln2('\n// V closure helpers', c_closure_helpers(g.pref))
 		}
 		b.writeln('\n// V anon functions:')
 		for fn_def in g.anon_fn_definitions {
@@ -629,7 +629,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 		}
 	}
 	if g.pref.is_coverage {
-		b.write_2_string('\n// V coverage:\n', g.cov_declarations.str())
+		b.write_string2('\n// V coverage:\n', g.cov_declarations.str())
 	}
 	b.writeln('\n// end of V out')
 	mut header := b.last_n(b.len)
@@ -801,7 +801,7 @@ pub fn (mut g Gen) init() {
 		if g.pref.os == .wasm32 {
 			g.cheaders.writeln('#define VWASM 1')
 			// Include <stdint.h> instead of <inttypes.h> for WASM target
-			g.cheaders.write2ln('#include <stdint.h>', '#include <stddef.h>')
+			g.cheaders.writeln2('#include <stdint.h>', '#include <stddef.h>')
 		} else {
 			tcc_undef_has_include := '
 #if defined(__TINYC__) && defined(__has_include)
@@ -812,7 +812,7 @@ pub fn (mut g Gen) init() {
 			g.cheaders.writeln(tcc_undef_has_include)
 			g.includes.writeln(tcc_undef_has_include)
 			if g.pref.os == .freebsd {
-				g.cheaders.write2ln('#include <inttypes.h>', '#include <stddef.h>')
+				g.cheaders.writeln2('#include <inttypes.h>', '#include <stddef.h>')
 			} else {
 				install_compiler_msg := ' Please install the package `build-essential`.'
 				g.cheaders.writeln(get_guarded_include_text('<inttypes.h>', 'The C compiler can not find <inttypes.h>.${install_compiler_msg}')) // int64_t etc
@@ -959,7 +959,7 @@ pub fn (mut g Gen) get_sumtype_variant_name(typ ast.Type, sym ast.TypeSymbol) st
 }
 
 pub fn (mut g Gen) write_typeof_functions() {
-	g.write2ln('', '// >> typeof() support for sum types / interfaces')
+	g.writeln2('', '// >> typeof() support for sum types / interfaces')
 	for ityp, sym in g.table.type_symbols {
 		if sym.kind == .sum_type {
 			static_prefix := if g.pref.build_mode == .build_module { 'static ' } else { '' }
@@ -978,7 +978,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
 			} else {
 				tidx := g.table.find_type_idx(sym.name)
-				g.write2ln('\tswitch(sidx) {', '\t\tcase ${tidx}: return "${util.strip_main_name(sym.name)}";')
+				g.writeln2('\tswitch(sidx) {', '\t\tcase ${tidx}: return "${util.strip_main_name(sym.name)}";')
 				mut idxs := []int{}
 				for v in sum_info.variants {
 					if v in idxs {
@@ -988,10 +988,10 @@ pub fn (mut g Gen) write_typeof_functions() {
 					g.writeln('\t\tcase ${int(v)}: return "${util.strip_main_name(subtype.name)}";')
 					idxs << v
 				}
-				g.write2ln('\t\tdefault: return "unknown ${util.strip_main_name(sym.name)}";',
+				g.writeln2('\t\tdefault: return "unknown ${util.strip_main_name(sym.name)}";',
 					'\t}')
 			}
-			g.write2ln('}', '')
+			g.writeln2('}', '')
 			g.writeln('${static_prefix}int v_typeof_sumtype_idx_${sym.cname}(int sidx) { /* ${sym.name} */ ')
 			if g.pref.build_mode == .build_module {
 				g.writeln('\t\tif( sidx == _v_type_idx_${sym.cname}() ) return ${int(ityp)};')
@@ -1002,7 +1002,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\treturn ${int(ityp)};')
 			} else {
 				tidx := g.table.find_type_idx(sym.name)
-				g.write2ln('\tswitch(sidx) {', '\t\tcase ${tidx}: return ${int(ityp)};')
+				g.writeln2('\tswitch(sidx) {', '\t\tcase ${tidx}: return ${int(ityp)};')
 				mut idxs := []int{}
 				for v in sum_info.variants {
 					if v in idxs {
@@ -1011,7 +1011,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 					g.writeln('\t\tcase ${int(v)}: return ${int(v)};')
 					idxs << v
 				}
-				g.write2ln('\t\tdefault: return ${int(ityp)};', '\t}')
+				g.writeln2('\t\tdefault: return ${int(ityp)};', '\t}')
 			}
 			g.writeln('}')
 		} else if sym.kind == .interface {
@@ -1031,8 +1031,8 @@ pub fn (mut g Gen) write_typeof_functions() {
 				}
 				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return "${util.strip_main_name(sub_sym.name)}";')
 			}
-			g.write2ln('\treturn "unknown ${util.strip_main_name(sym.name)}";', '}')
-			g.write2ln('', 'static int v_typeof_interface_idx_${sym.cname}(int sidx) { /* ${sym.name} */ ')
+			g.writeln2('\treturn "unknown ${util.strip_main_name(sym.name)}";', '}')
+			g.writeln2('', 'static int v_typeof_interface_idx_${sym.cname}(int sidx) { /* ${sym.name} */ ')
 			for t in inter_info.types {
 				sub_sym := g.table.sym(ast.mktyp(t))
 				if sub_sym.info is ast.Struct && sub_sym.info.is_unresolved_generic() {
@@ -1040,10 +1040,10 @@ pub fn (mut g Gen) write_typeof_functions() {
 				}
 				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return ${int(t.set_nr_muls(0))};')
 			}
-			g.write2ln('\treturn ${int(ityp)};', '}')
+			g.writeln2('\treturn ${int(ityp)};', '}')
 		}
 	}
-	g.write2ln('// << typeof() support for sum types', '')
+	g.writeln2('// << typeof() support for sum types', '')
 }
 
 // V type to C typecc
@@ -2357,17 +2357,17 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 fn (mut g Gen) write_defer_stmts() {
 	for i := g.defer_stmts.len - 1; i >= 0; i-- {
 		defer_stmt := g.defer_stmts[i]
-		g.write2ln('// Defer begin', 'if (${g.defer_flag_var(defer_stmt)}) {')
+		g.writeln2('// Defer begin', 'if (${g.defer_flag_var(defer_stmt)}) {')
 		//		g.indent++
 		if defer_stmt.ifdef.len > 0 {
 			g.writeln(defer_stmt.ifdef)
 			g.stmts(defer_stmt.stmts)
-			g.write2ln('', '#endif')
+			g.writeln2('', '#endif')
 		} else {
 			g.stmts(defer_stmt.stmts)
 		}
 		//		g.indent--
-		g.write2ln('}', '// Defer end')
+		g.writeln2('}', '// Defer end')
 	}
 }
 
@@ -3623,7 +3623,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					expr_str = node.expr.name
 				}
 				g.writeln('if (${expr_str}.state != 0) {')
-				g.write2ln('\tpanic_option_not_set(_SLIT("none"));', '}')
+				g.writeln2('\tpanic_option_not_set(_SLIT("none"));', '}')
 				g.write(cur_line)
 				typ := g.resolve_comptime_type(node.expr, node.typ)
 				g.write('*(${g.base_type(typ)}*)&')
@@ -4347,9 +4347,9 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 		g.enum_typedefs.writeln('')
 		g.enum_typedefs.writeln('typedef ${enum_typ_name} ${enum_name};')
 		for i, field in node.fields {
-			g.enum_typedefs.write_2_string('\t#define ${enum_name}__${field.name} ', '(')
+			g.enum_typedefs.write_string2('\t#define ${enum_name}__${field.name} ', '(')
 			if is_flag {
-				g.enum_typedefs.write_2_string((u64(1) << i).str(), 'ULL')
+				g.enum_typedefs.write_string2((u64(1) << i).str(), 'ULL')
 			} else if field.has_expr {
 				expr_str := g.expr_string(field.expr)
 				g.enum_typedefs.write_string(expr_str)
@@ -4393,7 +4393,7 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 		} else if is_flag {
 			g.enum_typedefs.write_string(' = ')
 			cur_enum_expr = 'u64(1) << ${i}'
-			g.enum_typedefs.write_2_string((u64(1) << i).str(), 'U')
+			g.enum_typedefs.write_string2((u64(1) << i).str(), 'U')
 			cur_enum_offset = 0
 		}
 		cur_value := if cur_enum_offset > 0 {
@@ -4450,13 +4450,13 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('->mtx);')
 	} else {
 		mtxs = g.new_tmp_var()
-		g.write2ln('uintptr_t _arr_${mtxs}[${node.lockeds.len}];', 'bool _isrlck_${mtxs}[${node.lockeds.len}];')
+		g.writeln2('uintptr_t _arr_${mtxs}[${node.lockeds.len}];', 'bool _isrlck_${mtxs}[${node.lockeds.len}];')
 		mut j := 0
 		for i, is_rlock in node.is_rlock {
 			if !is_rlock {
 				g.write('_arr_${mtxs}[${j}] = (uintptr_t)&')
 				g.expr(node.lockeds[i])
-				g.write2ln('->mtx;', '_isrlck_${mtxs}[${j}] = false;')
+				g.writeln2('->mtx;', '_isrlck_${mtxs}[${j}] = false;')
 				j++
 			}
 		}
@@ -4464,7 +4464,7 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 			if is_rlock {
 				g.write('_arr_${mtxs}[${j}] = (uintptr_t)&')
 				g.expr(node.lockeds[i])
-				g.write2ln('->mtx;', '_isrlck_${mtxs}[${j}] = true;')
+				g.writeln2('->mtx;', '_isrlck_${mtxs}[${j}] = true;')
 				j++
 			}
 		}
@@ -4480,9 +4480,9 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		} else {
 			g.writeln('__sort_ptr(_arr_${mtxs}, _isrlck_${mtxs}, ${node.lockeds.len});')
 		}
-		g.write2ln('for (int ${mtxs}=0; ${mtxs}<${node.lockeds.len}; ${mtxs}++) {', '\tif (${mtxs} && _arr_${mtxs}[${mtxs}] == _arr_${mtxs}[${mtxs}-1]) continue;')
-		g.write2ln('\tif (_isrlck_${mtxs}[${mtxs}])', '\t\tsync__RwMutex_rlock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
-		g.write2ln('\telse', '\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
+		g.writeln2('for (int ${mtxs}=0; ${mtxs}<${node.lockeds.len}; ${mtxs}++) {', '\tif (${mtxs} && _arr_${mtxs}[${mtxs}] == _arr_${mtxs}[${mtxs}-1]) continue;')
+		g.writeln2('\tif (_isrlck_${mtxs}[${mtxs}])', '\t\tsync__RwMutex_rlock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
+		g.writeln2('\telse', '\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
 		g.writeln('}')
 	}
 	g.mtxs = mtxs
@@ -4510,10 +4510,10 @@ fn (mut g Gen) unlock_locks() {
 		g.expr(g.cur_lock.lockeds[0])
 		g.write('->mtx);')
 	} else {
-		g.write2ln('for (int ${g.mtxs}=${g.cur_lock.lockeds.len - 1}; ${g.mtxs}>=0; ${g.mtxs}--) {',
+		g.writeln2('for (int ${g.mtxs}=${g.cur_lock.lockeds.len - 1}; ${g.mtxs}>=0; ${g.mtxs}--) {',
 			'\tif (${g.mtxs} && _arr_${g.mtxs}[${g.mtxs}] == _arr_${g.mtxs}[${g.mtxs}-1]) continue;')
-		g.write2ln('\tif (_isrlck_${g.mtxs}[${g.mtxs}])', '\t\tsync__RwMutex_runlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
-		g.write2ln('\telse', '\t\tsync__RwMutex_unlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
+		g.writeln2('\tif (_isrlck_${g.mtxs}[${g.mtxs}])', '\t\tsync__RwMutex_runlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
+		g.writeln2('\telse', '\t\tsync__RwMutex_unlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
 		g.write('}')
 	}
 }
@@ -4569,7 +4569,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			g.expr(expr)
 			g.writeln(',')
 		}
-		g.write2ln('\t}),', '\t_MOV((${effective_typ_str}[${size}]){')
+		g.writeln2('\t}),', '\t_MOV((${effective_typ_str}[${size}]){')
 		for i, expr in node.vals {
 			g.write('\t\t')
 			if expr.is_auto_deref_var() {
@@ -4584,7 +4584,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			}
 			g.writeln(', ')
 		}
-		g.write2ln('\t})', ')')
+		g.writeln2('\t})', ')')
 	} else if node.has_update_expr {
 		g.write('map_clone(&(')
 		g.expr(node.update_expr)
@@ -4734,7 +4734,7 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	g.writeln(');')
 	// free the temps that were created
-	g.write2ln('array_free(&${objs_array});', 'array_free(&${directions_array});')
+	g.writeln2('array_free(&${objs_array});', 'array_free(&${directions_array});')
 	g.writeln('array_free(&${chan_array});')
 	mut i := 0
 	for j in 0 .. node.branches.len {
@@ -5130,10 +5130,10 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 					parent_type := (sym.info as ast.Alias).parent_type
 					tmp_var := g.new_tmp_var()
 					tmp_var2 := g.new_tmp_var()
-					g.write2ln('${styp} ${tmp_var};', '${g.styp(parent_type)} ${tmp_var2};')
+					g.writeln2('${styp} ${tmp_var};', '${g.styp(parent_type)} ${tmp_var2};')
 					g.write('_option_ok(&(${g.base_type(parent_type)}[]) { ')
 					g.expr(node.expr)
-					g.write2ln(' }, (${option_name}*)(&${tmp_var2}), sizeof(${g.base_type(parent_type)}));',
+					g.writeln2(' }, (${option_name}*)(&${tmp_var2}), sizeof(${g.base_type(parent_type)}));',
 						'_option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
 					g.write2(cur_stmt, tmp_var)
 				} else if node.expr_type.has_flag(.option) {
@@ -6424,7 +6424,7 @@ fn (mut g Gen) write_debug_calls_typeof_functions() {
 		return
 	}
 
-	g.write2ln('\t// we call these functions in debug mode so that the C compiler', '\t// does not optimize them and we can access them in the debugger.')
+	g.writeln2('\t// we call these functions in debug mode so that the C compiler', '\t// does not optimize them and we can access them in the debugger.')
 	for _, sym in g.table.type_symbols {
 		if sym.kind == .sum_type {
 			sum_info := sym.info as ast.SumType
@@ -6566,7 +6566,7 @@ fn (mut g Gen) write_init_function() {
 		// g.writeln('puts("cleaning up...");')
 		reversed_table_modules := g.table.modules.reverse()
 		for mod_name in reversed_table_modules {
-			g.write2ln('\t// Cleanups for module ${mod_name} :', g.cleanups[mod_name].str())
+			g.writeln2('\t// Cleanups for module ${mod_name} :', g.cleanups[mod_name].str())
 		}
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
 	}
@@ -6591,7 +6591,7 @@ fn (mut g Gen) write_init_function() {
 		// are initialized just once, and that they will be freed too.
 		// Note: os.args in this case will be [].
 		if g.pref.os == .windows {
-			g.write2ln('// workaround for windows, export _vinit_caller, let dl.open() call it',
+			g.writeln2('// workaround for windows, export _vinit_caller, let dl.open() call it',
 				'// NOTE: This is hardcoded in vlib/dl/dl_windows.c.v!')
 			g.writeln('VV_EXPORTED_SYMBOL void _vinit_caller();')
 		} else {
@@ -6606,7 +6606,7 @@ fn (mut g Gen) write_init_function() {
 		g.writeln('}')
 
 		if g.pref.os == .windows {
-			g.write2ln('// workaround for windows, export _vcleanup_caller, let dl.close() call it',
+			g.writeln2('// workaround for windows, export _vcleanup_caller, let dl.close() call it',
 				'// NOTE: This is hardcoded in vlib/dl/dl_windows.c.v!')
 			g.writeln('VV_EXPORTED_SYMBOL void _vcleanup_caller();')
 		} else {
@@ -7175,7 +7175,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				styp := g.styp(g.fn_decl.return_type)
 				err_obj := g.new_tmp_var()
-				g.write2ln('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(${result_name}));')
+				g.writeln2('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(${result_name}));')
 				g.writeln('\treturn ${err_obj};')
 			}
 		}
@@ -7203,7 +7203,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				styp := g.styp(g.fn_decl.return_type).replace('*', '_ptr')
 				err_obj := g.new_tmp_var()
-				g.write2ln('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
+				g.writeln2('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
 				g.writeln('\treturn ${err_obj};')
 			}
 		}
@@ -7950,14 +7950,14 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 			pmessage := 'string__plus(string__plus(tos3("`as_cast`: cannot convert "), tos3(v_typeof_interface_${interface_name}(x._typ))), tos3(" to ${util.strip_main_name(vsym.name)}"))'
 			if g.pref.is_debug {
 				// TODO: actually return a valid position here
-				conversion_functions.write_2_string('\tpanic_debug(1, tos3("builtin.v"), tos3("builtin"), tos3("__as_cast"), ',
+				conversion_functions.write_string2('\tpanic_debug(1, tos3("builtin.v"), tos3("builtin"), tos3("__as_cast"), ',
 					pmessage)
 				conversion_functions.writeln(');')
 			} else {
-				conversion_functions.write_2_string('\t_v_panic(', pmessage)
+				conversion_functions.write_string2('\t_v_panic(', pmessage)
 				conversion_functions.writeln(');')
 			}
-			conversion_functions.write2ln('\treturn (${vsym.cname}){0};', '}')
+			conversion_functions.writeln2('\treturn (${vsym.cname}){0};', '}')
 		}
 		sb.writeln('// ^^^ number of types for interface ${interface_name}: ${current_iinidx - iinidx_minimum_base}')
 		if iname_table_length == 0 {
@@ -7970,7 +7970,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 		// add line return after interface index declarations
 		sb.writeln('')
 		if inter_methods.len > 0 {
-			sb.write2ln(methods_wrapper.str(), methods_struct_def.str())
+			sb.writeln2(methods_wrapper.str(), methods_struct_def.str())
 			sb.writeln(methods_struct.str())
 		}
 		sb.writeln(cast_functions.str())

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4469,10 +4469,14 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 			}
 		}
 		if node.lockeds.len == 2 {
-			g.write2ln('if (_arr_${mtxs}[0] > _arr_${mtxs}[1]) {', '\tuintptr_t _ptr_${mtxs} = _arr_${mtxs}[0];')
-			g.write2ln('\t_arr_${mtxs}[0] = _arr_${mtxs}[1];', '\t_arr_${mtxs}[1] = _ptr_${mtxs};')
-			g.write2ln('\tbool _bool_${mtxs} = _isrlck_${mtxs}[0];', '\t_isrlck_${mtxs}[0] = _isrlck_${mtxs}[1];')
-			g.write2ln('\t_isrlck_${mtxs}[1] = _bool_${mtxs};', '}')
+			g.writeln('if (_arr_${mtxs}[0] > _arr_${mtxs}[1]) {')
+			g.writeln('\tuintptr_t _ptr_${mtxs} = _arr_${mtxs}[0];')
+			g.writeln('\t_arr_${mtxs}[0] = _arr_${mtxs}[1];')
+			g.writeln('\t_arr_${mtxs}[1] = _ptr_${mtxs};')
+			g.writeln('\tbool _bool_${mtxs} = _isrlck_${mtxs}[0];')
+			g.writeln('\t_isrlck_${mtxs}[0] = _isrlck_${mtxs}[1];')
+			g.writeln('\t_isrlck_${mtxs}[1] = _bool_${mtxs};')
+			g.writeln('}')
 		} else {
 			g.writeln('__sort_ptr(_arr_${mtxs}, _isrlck_${mtxs}, ${node.lockeds.len});')
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -554,20 +554,14 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	if g.use_segfault_handler || g.pref.is_prof {
 		b.writeln('\n#define V_USE_SIGNAL_H')
 	}
-	b.writeln('\n// V comptime_definitions:')
-	b.write_string(g.comptime_definitions.str())
-	b.writeln('\n// V typedefs:')
-	b.write_string(g.typedefs.str())
-	b.writeln('\n // V preincludes:')
-	b.write_string(g.preincludes.str())
-	b.writeln('\n// V cheaders:')
-	b.write_string(g.cheaders.str())
+	b.write_2_string('\n// V comptime_definitions:\n', g.comptime_definitions.str())
+	b.write_2_string('\n// V typedefs:\n', g.typedefs.str())
+	b.write_2_string('\n // V preincludes:\n', g.preincludes.str())
+	b.write_2_string('\n// V cheaders:', g.cheaders.str())
 	if g.pcs_declarations.len > 0 {
-		b.writeln('\n// V profile counters:')
-		b.write_string(g.pcs_declarations.str())
+		b.write_2_string('\n// V profile counters:\n', g.pcs_declarations.str())
 	}
-	b.writeln('\n// V includes:')
-	b.write_string(g.includes.str())
+	b.write_2_string('\n// V includes:\n', g.includes.str())
 	b.writeln('\n// V global/const #define ... :')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
@@ -576,24 +570,15 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 			}
 		}
 	}
-	b.writeln('\n// Enum definitions:')
-	b.write_string(g.enum_typedefs.str())
-	b.writeln('\n// Thread definitions:')
-	b.write_string(g.thread_definitions.str())
-	b.writeln('\n// V type definitions:')
-	b.write_string(g.type_definitions.str())
-	b.writeln('\n// V alias definitions:')
-	b.write_string(g.alias_definitions.str())
-	b.writeln('\n// V shared types:')
-	b.write_string(g.shared_types.str())
-	b.writeln('\n// V Option_xxx definitions:')
-	b.write_string(g.out_options.str())
-	b.writeln('\n// V result_xxx definitions:')
-	b.write_string(g.out_results.str())
-	b.writeln('\n// V json forward decls:')
-	b.write_string(g.json_forward_decls.str())
-	b.writeln('\n// V definitions:')
-	b.write_string(g.definitions.str())
+	b.write_2_string('\n// Enum definitions:\n', g.enum_typedefs.str())
+	b.write_2_string('\n// Thread definitions:\n', g.thread_definitions.str())
+	b.write_2_string('\n// V type definitions:\n', g.type_definitions.str())
+	b.write_2_string('\n// V alias definitions:\n', g.alias_definitions.str())
+	b.write_2_string('\n// V shared types:\n', g.shared_types.str())
+	b.write_2_string('\n// V Option_xxx definitions:\n', g.out_options.str())
+	b.write_2_string('\n// V result_xxx definitions:\n', g.out_results.str())
+	b.write_2_string('\n// V json forward decls:\n', g.json_forward_decls.str())
+	b.write_2_string('\n// V definitions:\n', g.definitions.str())
 	b.writeln('\n// V global/const non-precomputed definitions:')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
@@ -604,37 +589,29 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	}
 	interface_table := g.interface_table()
 	if interface_table.len > 0 {
-		b.writeln('\n// V interface table:')
-		b.write_string(interface_table)
+		b.write_2_string('\n// V interface table:\n', interface_table)
 	}
 	if g.gowrappers.len > 0 {
-		b.writeln('\n// V gowrappers:')
-		b.write_string(g.gowrappers.str())
+		b.write_2_string('\n// V gowrappers:\n', g.gowrappers.str())
 	}
 	if g.hotcode_definitions.len > 0 {
-		b.writeln('\n// V hotcode definitions:')
-		b.write_string(g.hotcode_definitions.str())
+		b.write_2_string('\n// V hotcode definitions:\n', g.hotcode_definitions.str())
 	}
 	if g.embedded_data.len > 0 {
-		b.writeln('\n// V embedded data:')
-		b.write_string(g.embedded_data.str())
+		b.write_2_string('\n// V embedded data:\n', g.embedded_data.str())
 	}
 	if g.shared_functions.len > 0 {
-		b.writeln('\n// V shared type functions:')
-		b.write_string(g.shared_functions.str())
-		b.write_string(c_concurrency_helpers)
+		b.writeln('\n// V shared type functions:\n')
+		b.write_2_string(g.shared_functions.str(), c_concurrency_helpers)
 	}
 	if g.channel_definitions.len > 0 {
-		b.writeln('\n// V channel code:')
-		b.write_string(g.channel_definitions.str())
+		b.write_2_string('\n// V channel code:\n', g.channel_definitions.str())
 	}
 	if g.auto_str_funcs.len > 0 {
-		b.writeln('\n// V auto str functions:')
-		b.write_string(g.auto_str_funcs.str())
+		b.write_2_string('\n// V auto str functions:\n', g.auto_str_funcs.str())
 	}
 	if g.dump_funcs.len > 0 {
-		b.writeln('\n// V dump functions:')
-		b.write_string(g.dump_funcs.str())
+		b.write_2_string('\n// V dump functions:\n', g.dump_funcs.str())
 	}
 	if g.auto_fn_definitions.len > 0 {
 		b.writeln('\n// V auto functions:')
@@ -644,8 +621,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	}
 	if g.anon_fn_definitions.len > 0 {
 		if g.nr_closures > 0 {
-			b.writeln('\n// V closure helpers')
-			b.writeln(c_closure_helpers(g.pref))
+			b.write2ln('\n// V closure helpers', c_closure_helpers(g.pref))
 		}
 		b.writeln('\n// V anon functions:')
 		for fn_def in g.anon_fn_definitions {
@@ -653,8 +629,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 		}
 	}
 	if g.pref.is_coverage {
-		b.writeln('\n// V coverage:')
-		b.write_string(g.cov_declarations.str())
+		b.write_2_string('\n// V coverage:\n', g.cov_declarations.str())
 	}
 	b.writeln('\n// end of V out')
 	mut header := b.last_n(b.len)
@@ -826,8 +801,7 @@ pub fn (mut g Gen) init() {
 		if g.pref.os == .wasm32 {
 			g.cheaders.writeln('#define VWASM 1')
 			// Include <stdint.h> instead of <inttypes.h> for WASM target
-			g.cheaders.writeln('#include <stdint.h>')
-			g.cheaders.writeln('#include <stddef.h>')
+			g.cheaders.write2ln('#include <stdint.h>', '#include <stddef.h>')
 		} else {
 			tcc_undef_has_include := '
 #if defined(__TINYC__) && defined(__has_include)
@@ -984,8 +958,7 @@ pub fn (mut g Gen) get_sumtype_variant_name(typ ast.Type, sym ast.TypeSymbol) st
 }
 
 pub fn (mut g Gen) write_typeof_functions() {
-	g.writeln('')
-	g.writeln('// >> typeof() support for sum types / interfaces')
+	g.write2ln('', '// >> typeof() support for sum types / interfaces')
 	for ityp, sym in g.table.type_symbols {
 		if sym.kind == .sum_type {
 			static_prefix := if g.pref.build_mode == .build_module { 'static ' } else { '' }
@@ -1004,8 +977,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
 			} else {
 				tidx := g.table.find_type_idx(sym.name)
-				g.writeln('\tswitch(sidx) {')
-				g.writeln('\t\tcase ${tidx}: return "${util.strip_main_name(sym.name)}";')
+				g.write2ln('\tswitch(sidx) {', '\t\tcase ${tidx}: return "${util.strip_main_name(sym.name)}";')
 				mut idxs := []int{}
 				for v in sum_info.variants {
 					if v in idxs {
@@ -1015,11 +987,10 @@ pub fn (mut g Gen) write_typeof_functions() {
 					g.writeln('\t\tcase ${int(v)}: return "${util.strip_main_name(subtype.name)}";')
 					idxs << v
 				}
-				g.writeln('\t\tdefault: return "unknown ${util.strip_main_name(sym.name)}";')
-				g.writeln('\t}')
+				g.write2ln('\t\tdefault: return "unknown ${util.strip_main_name(sym.name)}";',
+					'\t}')
 			}
-			g.writeln('}')
-			g.writeln('')
+			g.write2ln('}', '')
 			g.writeln('${static_prefix}int v_typeof_sumtype_idx_${sym.cname}(int sidx) { /* ${sym.name} */ ')
 			if g.pref.build_mode == .build_module {
 				g.writeln('\t\tif( sidx == _v_type_idx_${sym.cname}() ) return ${int(ityp)};')
@@ -1030,8 +1001,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\treturn ${int(ityp)};')
 			} else {
 				tidx := g.table.find_type_idx(sym.name)
-				g.writeln('\tswitch(sidx) {')
-				g.writeln('\t\tcase ${tidx}: return ${int(ityp)};')
+				g.write2ln('\tswitch(sidx) {', '\t\tcase ${tidx}: return ${int(ityp)};')
 				mut idxs := []int{}
 				for v in sum_info.variants {
 					if v in idxs {
@@ -1040,8 +1010,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 					g.writeln('\t\tcase ${int(v)}: return ${int(v)};')
 					idxs << v
 				}
-				g.writeln('\t\tdefault: return ${int(ityp)};')
-				g.writeln('\t}')
+				g.write2ln('\t\tdefault: return ${int(ityp)};', '\t}')
 			}
 			g.writeln('}')
 		} else if sym.kind == .interface {
@@ -1061,10 +1030,8 @@ pub fn (mut g Gen) write_typeof_functions() {
 				}
 				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return "${util.strip_main_name(sub_sym.name)}";')
 			}
-			g.writeln('\treturn "unknown ${util.strip_main_name(sym.name)}";')
-			g.writeln('}')
-			g.writeln('')
-			g.writeln('static int v_typeof_interface_idx_${sym.cname}(int sidx) { /* ${sym.name} */ ')
+			g.write2ln('\treturn "unknown ${util.strip_main_name(sym.name)}";', '}')
+			g.write2ln('', 'static int v_typeof_interface_idx_${sym.cname}(int sidx) { /* ${sym.name} */ ')
 			for t in inter_info.types {
 				sub_sym := g.table.sym(ast.mktyp(t))
 				if sub_sym.info is ast.Struct && sub_sym.info.is_unresolved_generic() {
@@ -1072,12 +1039,10 @@ pub fn (mut g Gen) write_typeof_functions() {
 				}
 				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return ${int(t.set_nr_muls(0))};')
 			}
-			g.writeln('\treturn ${int(ityp)};')
-			g.writeln('}')
+			g.write2ln('\treturn ${int(ityp)};', '}')
 		}
 	}
-	g.writeln('// << typeof() support for sum types')
-	g.writeln('')
+	g.write2ln('// << typeof() support for sum types', '')
 }
 
 // V type to C typecc
@@ -1995,8 +1960,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 	}
 	g.indent--
 	if g.inside_ternary > 0 {
-		g.write('')
-		g.write(')')
+		g.write2('', ')')
 	}
 	if g.is_autofree && !g.inside_vweb_tmpl && stmts.len > 0 {
 		// use the first stmt to get the scope
@@ -2115,8 +2079,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		g.set_current_pos_as_last_stmt_pos()
 	}
 
-	g.write(stmt_str)
-	g.write(' ')
+	g.write2(stmt_str, ' ')
 	g.write(tmp_var)
 }
 
@@ -2393,20 +2356,17 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 fn (mut g Gen) write_defer_stmts() {
 	for i := g.defer_stmts.len - 1; i >= 0; i-- {
 		defer_stmt := g.defer_stmts[i]
-		g.writeln('// Defer begin')
-		g.writeln('if (${g.defer_flag_var(defer_stmt)}) {')
+		g.write2ln('// Defer begin', 'if (${g.defer_flag_var(defer_stmt)}) {')
 		//		g.indent++
 		if defer_stmt.ifdef.len > 0 {
 			g.writeln(defer_stmt.ifdef)
 			g.stmts(defer_stmt.stmts)
-			g.writeln('')
-			g.writeln('#endif')
+			g.write2ln('', '#endif')
 		} else {
 			g.stmts(defer_stmt.stmts)
 		}
 		//		g.indent--
-		g.writeln('}')
-		g.writeln('// Defer end')
+		g.write2ln('}', '// Defer end')
 	}
 }
 
@@ -2620,8 +2580,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 				// Do not allocate for `Interface(unsafe{nil})` casts
 				is_nil_cast := expr is ast.UnsafeExpr && expr.expr is ast.Nil
 				if is_nil_cast {
-					g.write('/*nili*/')
-					g.write('((void*)0)')
+					g.write2('/*nili*/', '((void*)0)')
 					return
 				}
 			}
@@ -2687,8 +2646,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 					g.write('${got_styp} ${tmp_var} = ')
 					g.expr(expr)
 					g.writeln(';')
-					g.write(stmt_str)
-					g.write(' ')
+					g.write2(stmt_str, ' ')
 					g.write('${fname}(&${tmp_var})')
 					return
 				} else {
@@ -2857,8 +2815,7 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 		g.write(': ')
 	}
 	for i, clob in stmt.clobbered {
-		g.write('"')
-		g.write(clob.reg.name)
+		g.write2('"', clob.reg.name)
 		g.write('"')
 		if i + 1 < stmt.clobbered.len {
 			g.writeln(',')
@@ -3503,10 +3460,8 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			} else {
 				g.write('0')
 			}
-			g.write(', sizeof(')
-			g.write(elem_typ_str)
-			g.write(')>0 ? sizeof(')
-			g.write(elem_typ_str)
+			g.write2(', sizeof(', elem_typ_str)
+			g.write2(')>0 ? sizeof(', elem_typ_str)
 			g.write(') : 1)')
 		}
 		ast.CharLiteral {
@@ -3579,11 +3534,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 		}
 		ast.IntegerLiteral {
 			if node.val.starts_with('0o') {
-				g.write('0')
-				g.write(node.val[2..])
+				g.write2('0', node.val[2..])
 			} else if node.val.starts_with('-0o') {
-				g.write('-0')
-				g.write(node.val[3..])
+				g.write2('-0', node.val[3..])
 			} else {
 				g.write(node.val)
 			}
@@ -3669,8 +3622,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					expr_str = node.expr.name
 				}
 				g.writeln('if (${expr_str}.state != 0) {')
-				g.writeln('\tpanic_option_not_set(_SLIT("none"));')
-				g.writeln('}')
+				g.write2ln('\tpanic_option_not_set(_SLIT("none"));', '}')
 				g.write(cur_line)
 				typ := g.resolve_comptime_type(node.expr, node.typ)
 				g.write('*(${g.base_type(typ)}*)&')
@@ -3953,8 +3905,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			g.write(')')
 		}
 		g.or_block(tmp_var, node.or_block, node.typ)
-		g.write(stmt_str)
-		g.write(' ')
+		g.write2(stmt_str, ' ')
 		unwrapped_typ := node.typ.clear_option_and_result()
 		unwrapped_styp := g.styp(unwrapped_typ)
 		g.write('(*(${unwrapped_styp}*)${tmp_var}.data)')
@@ -3982,8 +3933,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		return
 	} else if g.enum_data_type == node.typ {
 		g.expr(node.expr)
-		g.write('.')
-		g.write(node.field_name)
+		g.write2('.', node.field_name)
 		return
 	}
 	mut sum_type_deref_field := ''
@@ -4133,8 +4083,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	n_ptr := node.expr_type.nr_muls() - 1
 	if n_ptr > 0 {
-		g.write('(')
-		g.write('*'.repeat(n_ptr))
+		g.write2('(', '*'.repeat(n_ptr))
 		g.expr(node.expr)
 		g.write(')')
 	} else {
@@ -4378,15 +4327,11 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 		}
 		count += 1
 	}
-	g.writeln('{')
-	g.writeln('\tMap_string_string _scope = new_map_init(&map_hash_string, &map_eq_string, &map_clone_string, &map_free_string, ${vars.len}, sizeof(string), sizeof(v__debug__DebugContextVar),')
-	g.write('\t\t_MOV((string[${vars.len}]){')
-	g.write(keys.str())
+	g.write2ln('{', '\tMap_string_string _scope = new_map_init(&map_hash_string, &map_eq_string, &map_clone_string, &map_free_string, ${vars.len}, sizeof(string), sizeof(v__debug__DebugContextVar),')
+	g.write2('\t\t_MOV((string[${vars.len}]){', keys.str())
 	g.writeln('}),')
-	g.write('\t\t_MOV((v__debug__DebugContextVar[${vars.len}]){')
-	g.write(values.str())
-	g.writeln('}));')
-	g.writeln('\tv__debug__Debugger_interact(&g_debugger, (v__debug__DebugContextInfo){.is_anon=${is_anon},.is_generic=${is_generic},.is_method=${is_method},.receiver_typ_name=_SLIT("${receiver_type}"),.line=${paline},.file=_SLIT("${pafile}"),.mod=_SLIT("${pamod}"),.fn_name=_SLIT("${pafn}"),.scope=_scope});')
+	g.write2('\t\t_MOV((v__debug__DebugContextVar[${vars.len}]){', values.str())
+	g.write2ln('}));', '\tv__debug__Debugger_interact(&g_debugger, (v__debug__DebugContextInfo){.is_anon=${is_anon},.is_generic=${is_generic},.is_method=${is_method},.receiver_typ_name=_SLIT("${receiver_type}"),.line=${paline},.file=_SLIT("${pafile}"),.mod=_SLIT("${pamod}"),.fn_name=_SLIT("${pafn}"),.scope=_scope});')
 	g.write('}')
 }
 
@@ -4399,11 +4344,9 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 		g.enum_typedefs.writeln('')
 		g.enum_typedefs.writeln('typedef ${enum_typ_name} ${enum_name};')
 		for i, field in node.fields {
-			g.enum_typedefs.write_string('\t#define ${enum_name}__${field.name} ')
-			g.enum_typedefs.write_string('(')
+			g.enum_typedefs.write_2_string('\t#define ${enum_name}__${field.name} ', '(')
 			if is_flag {
-				g.enum_typedefs.write_string((u64(1) << i).str())
-				g.enum_typedefs.write_string('ULL')
+				g.enum_typedefs.write_2_string((u64(1) << i).str(), 'ULL')
 			} else if field.has_expr {
 				expr_str := g.expr_string(field.expr)
 				g.enum_typedefs.write_string(expr_str)
@@ -4447,8 +4390,7 @@ fn (mut g Gen) enum_decl(node ast.EnumDecl) {
 		} else if is_flag {
 			g.enum_typedefs.write_string(' = ')
 			cur_enum_expr = 'u64(1) << ${i}'
-			g.enum_typedefs.write_string((u64(1) << i).str())
-			g.enum_typedefs.write_string('U')
+			g.enum_typedefs.write_2_string((u64(1) << i).str(), 'U')
 			cur_enum_offset = 0
 		}
 		cur_value := if cur_enum_offset > 0 {
@@ -4505,15 +4447,13 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln('->mtx);')
 	} else {
 		mtxs = g.new_tmp_var()
-		g.writeln('uintptr_t _arr_${mtxs}[${node.lockeds.len}];')
-		g.writeln('bool _isrlck_${mtxs}[${node.lockeds.len}];')
+		g.write2ln('uintptr_t _arr_${mtxs}[${node.lockeds.len}];', 'bool _isrlck_${mtxs}[${node.lockeds.len}];')
 		mut j := 0
 		for i, is_rlock in node.is_rlock {
 			if !is_rlock {
 				g.write('_arr_${mtxs}[${j}] = (uintptr_t)&')
 				g.expr(node.lockeds[i])
-				g.writeln('->mtx;')
-				g.writeln('_isrlck_${mtxs}[${j}] = false;')
+				g.write2ln('->mtx;', '_isrlck_${mtxs}[${j}] = false;')
 				j++
 			}
 		}
@@ -4521,29 +4461,21 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 			if is_rlock {
 				g.write('_arr_${mtxs}[${j}] = (uintptr_t)&')
 				g.expr(node.lockeds[i])
-				g.writeln('->mtx;')
-				g.writeln('_isrlck_${mtxs}[${j}] = true;')
+				g.write2ln('->mtx;', '_isrlck_${mtxs}[${j}] = true;')
 				j++
 			}
 		}
 		if node.lockeds.len == 2 {
-			g.writeln('if (_arr_${mtxs}[0] > _arr_${mtxs}[1]) {')
-			g.writeln('\tuintptr_t _ptr_${mtxs} = _arr_${mtxs}[0];')
-			g.writeln('\t_arr_${mtxs}[0] = _arr_${mtxs}[1];')
-			g.writeln('\t_arr_${mtxs}[1] = _ptr_${mtxs};')
-			g.writeln('\tbool _bool_${mtxs} = _isrlck_${mtxs}[0];')
-			g.writeln('\t_isrlck_${mtxs}[0] = _isrlck_${mtxs}[1];')
-			g.writeln('\t_isrlck_${mtxs}[1] = _bool_${mtxs};')
-			g.writeln('}')
+			g.write2ln('if (_arr_${mtxs}[0] > _arr_${mtxs}[1]) {', '\tuintptr_t _ptr_${mtxs} = _arr_${mtxs}[0];')
+			g.write2ln('\t_arr_${mtxs}[0] = _arr_${mtxs}[1];', '\t_arr_${mtxs}[1] = _ptr_${mtxs};')
+			g.write2ln('\tbool _bool_${mtxs} = _isrlck_${mtxs}[0];', '\t_isrlck_${mtxs}[0] = _isrlck_${mtxs}[1];')
+			g.write2ln('\t_isrlck_${mtxs}[1] = _bool_${mtxs};', '}')
 		} else {
 			g.writeln('__sort_ptr(_arr_${mtxs}, _isrlck_${mtxs}, ${node.lockeds.len});')
 		}
-		g.writeln('for (int ${mtxs}=0; ${mtxs}<${node.lockeds.len}; ${mtxs}++) {')
-		g.writeln('\tif (${mtxs} && _arr_${mtxs}[${mtxs}] == _arr_${mtxs}[${mtxs}-1]) continue;')
-		g.writeln('\tif (_isrlck_${mtxs}[${mtxs}])')
-		g.writeln('\t\tsync__RwMutex_rlock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
-		g.writeln('\telse')
-		g.writeln('\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
+		g.write2ln('for (int ${mtxs}=0; ${mtxs}<${node.lockeds.len}; ${mtxs}++) {', '\tif (${mtxs} && _arr_${mtxs}[${mtxs}] == _arr_${mtxs}[${mtxs}-1]) continue;')
+		g.write2ln('\tif (_isrlck_${mtxs}[${mtxs}])', '\t\tsync__RwMutex_rlock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
+		g.write2ln('\telse', '\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
 		g.writeln('}')
 	}
 	g.mtxs = mtxs
@@ -4559,8 +4491,7 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 	g.unlock_locks()
 	if node.is_expr {
 		g.writeln('')
-		g.write(cur_line)
-		g.write('${tmp_result}')
+		g.write2(cur_line, '${tmp_result}')
 	}
 }
 
@@ -4572,12 +4503,10 @@ fn (mut g Gen) unlock_locks() {
 		g.expr(g.cur_lock.lockeds[0])
 		g.write('->mtx);')
 	} else {
-		g.writeln('for (int ${g.mtxs}=${g.cur_lock.lockeds.len - 1}; ${g.mtxs}>=0; ${g.mtxs}--) {')
-		g.writeln('\tif (${g.mtxs} && _arr_${g.mtxs}[${g.mtxs}] == _arr_${g.mtxs}[${g.mtxs}-1]) continue;')
-		g.writeln('\tif (_isrlck_${g.mtxs}[${g.mtxs}])')
-		g.writeln('\t\tsync__RwMutex_runlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
-		g.writeln('\telse')
-		g.writeln('\t\tsync__RwMutex_unlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
+		g.write2ln('for (int ${g.mtxs}=${g.cur_lock.lockeds.len - 1}; ${g.mtxs}>=0; ${g.mtxs}--) {',
+			'\tif (${g.mtxs} && _arr_${g.mtxs}[${g.mtxs}] == _arr_${g.mtxs}[${g.mtxs}-1]) continue;')
+		g.write2ln('\tif (_isrlck_${g.mtxs}[${g.mtxs}])', '\t\tsync__RwMutex_runlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
+		g.write2ln('\telse', '\t\tsync__RwMutex_unlock((sync__RwMutex*)_arr_${g.mtxs}[${g.mtxs}]);')
 		g.write('}')
 	}
 }
@@ -4633,8 +4562,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			g.expr(expr)
 			g.writeln(',')
 		}
-		g.writeln('\t}),')
-		g.writeln('\t_MOV((${effective_typ_str}[${size}]){')
+		g.write2ln('\t}),', '\t_MOV((${effective_typ_str}[${size}]){')
 		for i, expr in node.vals {
 			g.write('\t\t')
 			if expr.is_auto_deref_var() {
@@ -4649,8 +4577,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 			}
 			g.writeln(', ')
 		}
-		g.writeln('\t})')
-		g.writeln(')')
+		g.write2ln('\t})', ')')
 	} else if node.has_update_expr {
 		g.write('map_clone(&(')
 		g.expr(node.update_expr)
@@ -4800,8 +4727,7 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	g.writeln(');')
 	// free the temps that were created
-	g.writeln('array_free(&${objs_array});')
-	g.writeln('array_free(&${directions_array});')
+	g.write2ln('array_free(&${objs_array});', 'array_free(&${directions_array});')
 	g.writeln('array_free(&${chan_array});')
 	mut i := 0
 	for j in 0 .. node.branches.len {
@@ -4825,8 +4751,7 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	g.writeln('}')
 	if is_expr {
 		g.empty_line = false
-		g.write(cur_line)
-		g.write('(${select_result} != -2)')
+		g.write2(cur_line, '(${select_result} != -2)')
 	}
 }
 
@@ -5041,10 +4966,8 @@ fn (mut g Gen) ident(node ast.Ident) {
 									g.write(closure_ctx + '->')
 								}
 								if node.obj.typ.nr_muls() > 1 {
-									g.write('(')
-									g.write('*'.repeat(node.obj.typ.nr_muls() - 1))
-									g.write(name)
-									g.write(')')
+									g.write2('(', '*'.repeat(node.obj.typ.nr_muls() - 1))
+									g.write2(name, ')')
 								} else {
 									g.write(name)
 								}
@@ -5200,14 +5123,12 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 					parent_type := (sym.info as ast.Alias).parent_type
 					tmp_var := g.new_tmp_var()
 					tmp_var2 := g.new_tmp_var()
-					g.writeln('${styp} ${tmp_var};')
-					g.writeln('${g.styp(parent_type)} ${tmp_var2};')
+					g.write2ln('${styp} ${tmp_var};', '${g.styp(parent_type)} ${tmp_var2};')
 					g.write('_option_ok(&(${g.base_type(parent_type)}[]) { ')
 					g.expr(node.expr)
-					g.writeln(' }, (${option_name}*)(&${tmp_var2}), sizeof(${g.base_type(parent_type)}));')
-					g.writeln('_option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
-					g.write(cur_stmt)
-					g.write(tmp_var)
+					g.write2ln(' }, (${option_name}*)(&${tmp_var2}), sizeof(${g.base_type(parent_type)}));',
+						'_option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
+					g.write2(cur_stmt, tmp_var)
 				} else if node.expr_type.has_flag(.option) {
 					g.expr_opt_with_cast(node.expr, expr_type, node.typ)
 				} else {
@@ -5675,8 +5596,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.expr(expr)
 				g.writeln(', sizeof(${expr_styp}));')
 				final_assignments += g.go_before_last_stmt() + '\t'
-				g.write(line)
-				g.write('{0}')
+				g.write2(line, '{0}')
 			} else {
 				if expr.is_auto_deref_var() {
 					g.write('*')
@@ -6497,8 +6417,7 @@ fn (mut g Gen) write_debug_calls_typeof_functions() {
 		return
 	}
 
-	g.writeln('\t// we call these functions in debug mode so that the C compiler')
-	g.writeln('\t// does not optimize them and we can access them in the debugger.')
+	g.write2ln('\t// we call these functions in debug mode so that the C compiler', '\t// does not optimize them and we can access them in the debugger.')
 	for _, sym in g.table.type_symbols {
 		if sym.kind == .sum_type {
 			sum_info := sym.info as ast.SumType
@@ -6640,8 +6559,7 @@ fn (mut g Gen) write_init_function() {
 		// g.writeln('puts("cleaning up...");')
 		reversed_table_modules := g.table.modules.reverse()
 		for mod_name in reversed_table_modules {
-			g.writeln('\t// Cleanups for module ${mod_name} :')
-			g.writeln(g.cleanups[mod_name].str())
+			g.write2ln('\t// Cleanups for module ${mod_name} :', g.cleanups[mod_name].str())
 		}
 		g.writeln('\tarray_free(&as_cast_type_indexes);')
 	}
@@ -6666,31 +6584,27 @@ fn (mut g Gen) write_init_function() {
 		// are initialized just once, and that they will be freed too.
 		// Note: os.args in this case will be [].
 		if g.pref.os == .windows {
-			g.writeln('// workaround for windows, export _vinit_caller, let dl.open() call it')
-			g.writeln('// NOTE: This is hardcoded in vlib/dl/dl_windows.c.v!')
+			g.write2ln('// workaround for windows, export _vinit_caller, let dl.open() call it',
+				'// NOTE: This is hardcoded in vlib/dl/dl_windows.c.v!')
 			g.writeln('VV_EXPORTED_SYMBOL void _vinit_caller();')
 		} else {
 			g.writeln('__attribute__ ((constructor))')
 		}
-		g.writeln('void _vinit_caller() {')
-		g.writeln('\tstatic bool once = false; if (once) {return;} once = true;')
+		g.write2ln('void _vinit_caller() {', '\tstatic bool once = false; if (once) {return;} once = true;')
 		if g.nr_closures > 0 {
 			g.writeln('\t__closure_init(); // vinit_caller()')
 		}
-		g.writeln('\t_vinit(0,0);')
-		g.writeln('}')
+		g.write2ln('\t_vinit(0,0);', '}')
 
 		if g.pref.os == .windows {
-			g.writeln('// workaround for windows, export _vcleanup_caller, let dl.close() call it')
-			g.writeln('// NOTE: This is hardcoded in vlib/dl/dl_windows.c.v!')
+			g.write2ln('// workaround for windows, export _vcleanup_caller, let dl.close() call it',
+				'// NOTE: This is hardcoded in vlib/dl/dl_windows.c.v!')
 			g.writeln('VV_EXPORTED_SYMBOL void _vcleanup_caller();')
 		} else {
 			g.writeln('__attribute__ ((destructor))')
 		}
-		g.writeln('void _vcleanup_caller() {')
-		g.writeln('\tstatic bool once = false; if (once) {return;} once = true;')
-		g.writeln('\t_vcleanup();')
-		g.writeln('}')
+		g.write2ln('void _vcleanup_caller() {', '\tstatic bool once = false; if (once) {return;} once = true;')
+		g.write2ln('\t_vcleanup();', '}')
 	}
 }
 
@@ -7250,8 +7164,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				styp := g.styp(g.fn_decl.return_type)
 				err_obj := g.new_tmp_var()
-				g.writeln('\t${styp} ${err_obj};')
-				g.writeln('\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(${result_name}));')
+				g.write2ln('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(${result_name}));')
 				g.writeln('\treturn ${err_obj};')
 			}
 		}
@@ -7279,8 +7192,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				styp := g.styp(g.fn_decl.return_type).replace('*', '_ptr')
 				err_obj := g.new_tmp_var()
-				g.writeln('\t${styp} ${err_obj};')
-				g.writeln('\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
+				g.write2ln('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
 				g.writeln('\treturn ${err_obj};')
 			}
 		}
@@ -7609,10 +7521,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			} else {
 				g.write('/* as */ *(${styp}*)__as_cast(')
 			}
-			g.write(tmp_var)
-			g.write(dot)
-			g.write('_${sym.cname},')
-			g.write(tmp_var)
+			g.write2(tmp_var, dot)
+			g.write2('_${sym.cname},', tmp_var)
 			g.write(dot)
 			sidx := g.type_sidx(unwrapped_node_typ)
 			g.write('_typ, ${sidx}); })')
@@ -7624,13 +7534,10 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			}
 			g.write('(')
 			g.expr(node.expr)
-			g.write(')')
-			g.write(dot)
-			g.write('_${sym.cname},')
-			g.write('(')
+			g.write2(')', dot)
+			g.write2('_${sym.cname},', '(')
 			g.expr(node.expr)
-			g.write(')')
-			g.write(dot)
+			g.write2(')', dot)
 			sidx := g.type_sidx(unwrapped_node_typ)
 			g.write('_typ, ${sidx})')
 		}
@@ -7672,11 +7579,9 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			} else {
 				g.write('/* as */ *(${styp}*)__as_cast(')
 			}
-			g.write(tmp_var)
-			g.write(dot)
+			g.write2(tmp_var, dot)
 			g.write('_${sym.cname},v_typeof_interface_idx_${expr_type_sym.cname}(')
-			g.write(tmp_var)
-			g.write(dot)
+			g.write2(tmp_var, dot)
 			sidx := g.type_sidx(unwrapped_node_typ)
 			g.write('_typ), ${sidx}); })')
 		} else {
@@ -7687,13 +7592,10 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			}
 			g.write('(')
 			g.expr(node.expr)
-			g.write(')')
-			g.write(dot)
-			g.write('_${sym.cname},v_typeof_interface_idx_${expr_type_sym.cname}(')
-			g.write('(')
+			g.write2(')', dot)
+			g.write2('_${sym.cname},v_typeof_interface_idx_${expr_type_sym.cname}(', '(')
 			g.expr(node.expr)
-			g.write(')')
-			g.write(dot)
+			g.write2(')', dot)
 			sidx := g.type_sidx(unwrapped_node_typ)
 			g.write('_typ), ${sidx})')
 		}

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -42,8 +42,8 @@ fn (mut g Gen) gen_vlines_reset() {
 		// The rest is auto generated code, which will not have
 		// different .v source file/line numbers.
 		g.vlines_path = util.vlines_escape_path(g.pref.out_name_c, g.pref.ccompiler)
-		g.write2ln('', '// Reset the C file/line numbers')
-		g.write2ln('${reset_dbg_line} "${g.vlines_path}"', '')
+		g.writeln2('', '// Reset the C file/line numbers')
+		g.writeln2('${reset_dbg_line} "${g.vlines_path}"', '')
 	}
 }
 
@@ -134,7 +134,7 @@ fn (mut g Gen) gen_c_main_function_only_header() {
 fn (mut g Gen) gen_c_main_function_header() {
 	g.gen_c_main_function_only_header()
 	g.gen_c_main_trace_calls_hook()
-	g.write2ln('\tg_main_argc = ___argc;', '\tg_main_argv = ___argv;')
+	g.writeln2('\tg_main_argc = ___argc;', '\tg_main_argv = ___argv;')
 	if g.nr_closures > 0 {
 		g.writeln('\t__closure_init(); // main()')
 	}
@@ -167,7 +167,7 @@ fn (mut g Gen) gen_c_main_header() {
 
 pub fn (mut g Gen) gen_c_main_footer() {
 	g.writeln('\t_vcleanup();')
-	g.write2ln('\treturn 0;', '}')
+	g.writeln2('\treturn 0;', '}')
 }
 
 pub fn (mut g Gen) gen_c_android_sokol_main() {
@@ -202,7 +202,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
 		if g.pref.gc_mode == .boehm_leak {
 			g.writeln('\tGC_set_find_leak(1);')
 		}
-		g.write2ln('\tGC_set_pages_executable(0);', '\tGC_INIT();')
+		g.writeln2('\tGC_set_pages_executable(0);', '\tGC_INIT();')
 		if g.pref.gc_mode in [.boehm_incr, .boehm_incr_opt] {
 			g.writeln('\tGC_enable_incremental();')
 		}
@@ -225,7 +225,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
 	}
 ')
 	}
-	g.write2ln('	return g_desc;', '}')
+	g.writeln2('	return g_desc;', '}')
 }
 
 pub fn (mut g Gen) write_tests_definitions() {
@@ -255,9 +255,9 @@ pub fn (mut g Gen) gen_failing_return_error_for_test_fn(return_stmt ast.Return, 
 
 pub fn (mut g Gen) gen_c_main_profile_hook() {
 	if g.pref.is_prof {
-		g.write2ln('', '\tsignal(SIGINT, vprint_profile_stats_on_signal);')
+		g.writeln2('', '\tsignal(SIGINT, vprint_profile_stats_on_signal);')
 		g.writeln('\tsignal(SIGTERM, vprint_profile_stats_on_signal);')
-		g.write2ln('\tatexit(vprint_profile_stats);', '')
+		g.writeln2('\tatexit(vprint_profile_stats);', '')
 	}
 	if g.pref.profile_file != '' {
 		if 'no_profile_startup' in g.pref.compile_defines {
@@ -300,11 +300,11 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	if g.pref.show_asserts {
 		g.writeln('\tmain__BenchedTests bt = main__start_testing(${all_tfuncs.len}, v_test_file);')
 	}
-	g.write2ln('', '\tstruct _main__TestRunner_interface_methods _vtrunner = main__TestRunner_name_table[test_runner._typ];')
-	g.write2ln('\tvoid * _vtobj = test_runner._object;', '')
+	g.writeln2('', '\tstruct _main__TestRunner_interface_methods _vtrunner = main__TestRunner_name_table[test_runner._typ];')
+	g.writeln2('\tvoid * _vtobj = test_runner._object;', '')
 	g.writeln('\tmain__VTestFileMetaInfo_free(test_runner.file_test_info);')
 	g.writeln('\t*(test_runner.file_test_info) = main__vtest_new_filemetainfo(v_test_file, ${all_tfuncs.len});')
-	g.write2ln('\t_vtrunner._method_start(_vtobj, ${all_tfuncs.len});', '')
+	g.writeln2('\t_vtrunner._method_start(_vtobj, ${all_tfuncs.len});', '')
 	for tnumber, tname in all_tfuncs {
 		tcname := util.no_dots(tname)
 		testfn := unsafe { g.table.fns[tname] }
@@ -336,12 +336,12 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	if g.pref.show_asserts {
 		g.writeln('\tmain__BenchedTests_end_testing(&bt);')
 	}
-	g.write2ln('', '\t_vtrunner._method_finish(_vtobj);')
+	g.writeln2('', '\t_vtrunner._method_finish(_vtobj);')
 	g.writeln('\tint test_exit_code = _vtrunner._method_exit_code(_vtobj);')
 
-	g.write2ln('\t_vtrunner._method__v_free(_vtobj);', '')
-	g.write2ln('\t_vcleanup();', '')
-	g.write2ln('\treturn test_exit_code;', '}')
+	g.writeln2('\t_vtrunner._method__v_free(_vtobj);', '')
+	g.writeln2('\t_vcleanup();', '')
+	g.writeln2('\treturn test_exit_code;', '}')
 	if g.pref.printfn_list.len > 0 && 'main' in g.pref.printfn_list {
 		println(g.out.after(main_fn_start_pos))
 	}

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -42,10 +42,8 @@ fn (mut g Gen) gen_vlines_reset() {
 		// The rest is auto generated code, which will not have
 		// different .v source file/line numbers.
 		g.vlines_path = util.vlines_escape_path(g.pref.out_name_c, g.pref.ccompiler)
-		g.writeln('')
-		g.writeln('// Reset the C file/line numbers')
-		g.writeln('${reset_dbg_line} "${g.vlines_path}"')
-		g.writeln('')
+		g.write2ln('', '// Reset the C file/line numbers')
+		g.write2ln('${reset_dbg_line} "${g.vlines_path}"', '')
 	}
 }
 
@@ -136,8 +134,7 @@ fn (mut g Gen) gen_c_main_function_only_header() {
 fn (mut g Gen) gen_c_main_function_header() {
 	g.gen_c_main_function_only_header()
 	g.gen_c_main_trace_calls_hook()
-	g.writeln('\tg_main_argc = ___argc;')
-	g.writeln('\tg_main_argv = ___argv;')
+	g.write2ln('\tg_main_argc = ___argc;', '\tg_main_argv = ___argv;')
 	if g.nr_closures > 0 {
 		g.writeln('\t__closure_init(); // main()')
 	}
@@ -170,8 +167,7 @@ fn (mut g Gen) gen_c_main_header() {
 
 pub fn (mut g Gen) gen_c_main_footer() {
 	g.writeln('\t_vcleanup();')
-	g.writeln('\treturn 0;')
-	g.writeln('}')
+	g.write2ln('\treturn 0;', '}')
 }
 
 pub fn (mut g Gen) gen_c_android_sokol_main() {
@@ -206,8 +202,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
 		if g.pref.gc_mode == .boehm_leak {
 			g.writeln('\tGC_set_find_leak(1);')
 		}
-		g.writeln('\tGC_set_pages_executable(0);')
-		g.writeln('\tGC_INIT();')
+		g.write2ln('\tGC_set_pages_executable(0);', '\tGC_INIT();')
 		if g.pref.gc_mode in [.boehm_incr, .boehm_incr_opt] {
 			g.writeln('\tGC_enable_incremental();')
 		}
@@ -230,8 +225,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
 	}
 ')
 	}
-	g.writeln('	return g_desc;')
-	g.writeln('}')
+	g.write2ln('	return g_desc;', '}')
 }
 
 pub fn (mut g Gen) write_tests_definitions() {
@@ -261,11 +255,9 @@ pub fn (mut g Gen) gen_failing_return_error_for_test_fn(return_stmt ast.Return, 
 
 pub fn (mut g Gen) gen_c_main_profile_hook() {
 	if g.pref.is_prof {
-		g.writeln('')
-		g.writeln('\tsignal(SIGINT, vprint_profile_stats_on_signal);')
+		g.write2ln('', '\tsignal(SIGINT, vprint_profile_stats_on_signal);')
 		g.writeln('\tsignal(SIGTERM, vprint_profile_stats_on_signal);')
-		g.writeln('\tatexit(vprint_profile_stats);')
-		g.writeln('')
+		g.write2ln('\tatexit(vprint_profile_stats);', '')
 	}
 	if g.pref.profile_file != '' {
 		if 'no_profile_startup' in g.pref.compile_defines {
@@ -308,14 +300,11 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	if g.pref.show_asserts {
 		g.writeln('\tmain__BenchedTests bt = main__start_testing(${all_tfuncs.len}, v_test_file);')
 	}
-	g.writeln('')
-	g.writeln('\tstruct _main__TestRunner_interface_methods _vtrunner = main__TestRunner_name_table[test_runner._typ];')
-	g.writeln('\tvoid * _vtobj = test_runner._object;')
-	g.writeln('')
+	g.write2ln('', '\tstruct _main__TestRunner_interface_methods _vtrunner = main__TestRunner_name_table[test_runner._typ];')
+	g.write2ln('\tvoid * _vtobj = test_runner._object;', '')
 	g.writeln('\tmain__VTestFileMetaInfo_free(test_runner.file_test_info);')
 	g.writeln('\t*(test_runner.file_test_info) = main__vtest_new_filemetainfo(v_test_file, ${all_tfuncs.len});')
-	g.writeln('\t_vtrunner._method_start(_vtobj, ${all_tfuncs.len});')
-	g.writeln('')
+	g.write2ln('\t_vtrunner._method_start(_vtobj, ${all_tfuncs.len});', '')
 	for tnumber, tname in all_tfuncs {
 		tcname := util.no_dots(tname)
 		testfn := unsafe { g.table.fns[tname] }
@@ -347,16 +336,12 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	if g.pref.show_asserts {
 		g.writeln('\tmain__BenchedTests_end_testing(&bt);')
 	}
-	g.writeln('')
-	g.writeln('\t_vtrunner._method_finish(_vtobj);')
+	g.write2ln('', '\t_vtrunner._method_finish(_vtobj);')
 	g.writeln('\tint test_exit_code = _vtrunner._method_exit_code(_vtobj);')
 
-	g.writeln('\t_vtrunner._method__v_free(_vtobj);')
-	g.writeln('')
-	g.writeln('\t_vcleanup();')
-	g.writeln('')
-	g.writeln('\treturn test_exit_code;')
-	g.writeln('}')
+	g.write2ln('\t_vtrunner._method__v_free(_vtobj);', '')
+	g.write2ln('\t_vcleanup();', '')
+	g.write2ln('\treturn test_exit_code;', '}')
 	if g.pref.printfn_list.len > 0 && 'main' in g.pref.printfn_list {
 		println(g.out.after(main_fn_start_pos))
 	}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -265,8 +265,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			if !g.inside_assign {
 				cur_line := g.go_before_last_stmt()
 				tmp_var := g.new_tmp_var()
-				g.write('${g.styp(m.return_type)} ${tmp_var} = ')
-				g.write(cur_line)
+				g.write2('${g.styp(m.return_type)} ${tmp_var} = ', cur_line)
 				g.or_block(tmp_var, node.or_block, m.return_type)
 			}
 		}
@@ -414,8 +413,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 						g.stmt(last)
 					}
 					g.skip_stmt_pos = prev_skip_stmt_pos
-					g.writeln(';')
-					g.writeln('}')
+					g.write2ln(';', '}')
 					g.indent--
 				} else {
 					g.indent++

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -413,7 +413,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 						g.stmt(last)
 					}
 					g.skip_stmt_pos = prev_skip_stmt_pos
-					g.write2ln(';', '}')
+					g.writeln2(';', '}')
 					g.indent--
 				} else {
 					g.indent++

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -341,7 +341,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 				}
 				g.writeln('\treturn ret;')
 			}
-			g.write2ln('}', '')
+			g.writeln2('}', '')
 			g.trace_fn_definitions << trace_fn
 		}
 	}
@@ -525,7 +525,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 			g.definitions.writeln('VV_EXPORTED_SYMBOL ${export_alias}; // exported fn ${node.name}')
 			g.writeln('${export_alias} {')
 			g.write2('\treturn ${name}(', fargs.join(', '))
-			g.write2ln(');', '}')
+			g.writeln2(');', '}')
 		}
 	}
 }
@@ -706,8 +706,8 @@ fn (mut g Gen) write_defer_stmts_when_needed() {
 		g.write_defer_stmts()
 	}
 	if g.defer_profile_code.len > 0 {
-		g.write2ln('', '\t// defer_profile_code')
-		g.write2ln(g.defer_profile_code, '')
+		g.writeln2('', '\t// defer_profile_code')
+		g.writeln2(g.defer_profile_code, '')
 	}
 }
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -341,8 +341,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 				}
 				g.writeln('\treturn ret;')
 			}
-			g.writeln('}')
-			g.writeln('')
+			g.write2ln('}', '')
 			g.trace_fn_definitions << trace_fn
 		}
 	}
@@ -525,10 +524,8 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 			export_alias := '${weak}${type_name} ${fn_attrs}${attr.arg}(${arg_str})'
 			g.definitions.writeln('VV_EXPORTED_SYMBOL ${export_alias}; // exported fn ${node.name}')
 			g.writeln('${export_alias} {')
-			g.write('\treturn ${name}(')
-			g.write(fargs.join(', '))
-			g.writeln(');')
-			g.writeln('}')
+			g.write2('\treturn ${name}(', fargs.join(', '))
+			g.write2ln(');', '}')
 		}
 	}
 }
@@ -709,10 +706,8 @@ fn (mut g Gen) write_defer_stmts_when_needed() {
 		g.write_defer_stmts()
 	}
 	if g.defer_profile_code.len > 0 {
-		g.writeln('')
-		g.writeln('\t// defer_profile_code')
-		g.writeln(g.defer_profile_code)
-		g.writeln('')
+		g.write2ln('', '\t// defer_profile_code')
+		g.write2ln(g.defer_profile_code, '')
 	}
 }
 
@@ -887,8 +882,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.expr(node)
 
 			g.inside_curry_call = old_inside_curry_call
-			g.write(line)
-			g.write('*(${g.base_type(ret_typ)}*)${tmp_res}.data')
+			g.write2(line, '*(${g.base_type(ret_typ)}*)${tmp_res}.data')
 			return
 		}
 	}
@@ -1131,8 +1125,7 @@ fn (mut g Gen) gen_array_method_call(node ast.CallExpr, left_type ast.Type, left
 				g.gen_arg_from_type(left_type, node.left)
 			} else {
 				if node.left_type.is_ptr() {
-					g.write('(')
-					g.write('*'.repeat(node.left_type.nr_muls()))
+					g.write2('(', '*'.repeat(node.left_type.nr_muls()))
 					g.expr(node.left)
 					g.write(')')
 				} else {
@@ -1652,8 +1645,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		left_type_name := util.no_dots(left_cc_type)
 		g.write('${c_name(left_type_name)}_name_table[')
 		if node.left.is_auto_deref_var() && left_type.nr_muls() > 1 {
-			g.write('(')
-			g.write('*'.repeat(left_type.nr_muls() - 1))
+			g.write2('(', '*'.repeat(left_type.nr_muls() - 1))
 			g.expr(node.left)
 			g.write(')')
 		} else {
@@ -1663,8 +1655,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		mname := c_fn_name(node.name)
 		g.write('${dot}_typ]._method_${mname}(')
 		if node.left.is_auto_deref_var() && left_type.nr_muls() > 1 {
-			g.write('(')
-			g.write('*'.repeat(left_type.nr_muls() - 1))
+			g.write2('(', '*'.repeat(left_type.nr_muls() - 1))
 			g.expr(node.left)
 			g.write(')')
 		} else {
@@ -1859,8 +1850,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		} else if !is_interface && node.from_embed_types.len > 0 {
 			n_ptr := node.left_type.nr_muls() - 1
 			if n_ptr > 0 {
-				g.write('(')
-				g.write('*'.repeat(n_ptr))
+				g.write2('(', '*'.repeat(n_ptr))
 				g.expr(node.left)
 				g.write(')')
 			} else {
@@ -1872,27 +1862,23 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 			if node.receiver_type.is_ptr() && left_type.is_ptr() {
 				// (main__IFoo*)bar
-				g.write('(')
-				g.write(g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('(', g.table.sym(node.from_embed_types.last()).cname)
 				g.write('*)')
 				g.expr(node.left)
 			} else if node.receiver_type.is_ptr() && !left_type.is_ptr() {
 				// (main__IFoo*)&bar
-				g.write('(')
-				g.write(g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('(', g.table.sym(node.from_embed_types.last()).cname)
 				g.write('*)&')
 				g.expr(node.left)
 			} else if !node.receiver_type.is_ptr() && left_type.is_ptr() {
 				// *((main__IFoo*)bar)
-				g.write('*((')
-				g.write(g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('*((', g.table.sym(node.from_embed_types.last()).cname)
 				g.write('*)')
 				g.expr(node.left)
 				g.write(')')
 			} else {
 				// *((main__IFoo*)&bar)
-				g.write('*((')
-				g.write(g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('*((', g.table.sym(node.from_embed_types.last()).cname)
 				g.write('*)&')
 				g.expr(node.left)
 				g.write(')')

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -239,8 +239,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 			cond_var = g.expr_string(node.cond)
 		} else {
 			cond_var = g.new_tmp_var()
-			g.write(g.styp(node.cond_type))
-			g.write(' ${cond_var} = ')
+			g.write2(g.styp(node.cond_type), ' ${cond_var} = ')
 			old_inside_opt_or_res := g.inside_opt_or_res
 			if node.cond_type.has_flag(.option) {
 				g.inside_opt_or_res = true
@@ -289,8 +288,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		cond_is_literal := node.cond is ast.ArrayInit
 		if cond_is_literal {
 			cond_var = g.new_tmp_var()
-			g.write(g.styp(node.cond_type))
-			g.write(' ${cond_var} = ')
+			g.write2(g.styp(node.cond_type), ' ${cond_var} = ')
 			g.expr(node.cond)
 			g.writeln(';')
 		} else if cond_type_is_ptr {
@@ -348,8 +346,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 			cond_var = g.expr_string(node.cond)
 		} else {
 			cond_var = g.new_tmp_var()
-			g.write(g.styp(node.cond_type))
-			g.write(' ${cond_var} = ')
+			g.write2(g.styp(node.cond_type), ' ${cond_var} = ')
 			g.expr(node.cond)
 			g.writeln(';')
 		}

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -354,8 +354,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				g.writeln(';')
 				branch_cond_var_names << cond_var_name
 				g.set_current_pos_as_last_stmt_pos()
-				g.writeln(line)
-				g.writeln('if (${cond_var_name}) {')
+				g.write2ln(line, 'if (${cond_var_name}) {')
 			} else if i > 0 && branch_cond_var_names.len > 0 && !needs_tmp_var && needs_conds_order {
 				cond_var_name := g.new_tmp_var()
 				line := g.go_before_last_stmt()

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -354,7 +354,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				g.writeln(';')
 				branch_cond_var_names << cond_var_name
 				g.set_current_pos_as_last_stmt_pos()
-				g.write2ln(line, 'if (${cond_var_name}) {')
+				g.writeln2(line, 'if (${cond_var_name}) {')
 			} else if i > 0 && branch_cond_var_names.len > 0 && !needs_tmp_var && needs_conds_order {
 				cond_var_name := g.new_tmp_var()
 				line := g.go_before_last_stmt()

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -117,8 +117,7 @@ fn (mut g Gen) index_range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 			g.write('${styp} ${var} = ')
 			g.expr(node.left)
 			g.writeln(';')
-			g.write(line)
-			g.write(' ${var})')
+			g.write2(line, ' ${var})')
 		} else {
 			g.expr(node.left)
 			g.write(')')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -145,14 +145,12 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 		} else {
 			g.write(g.styp(left.unaliased.set_nr_muls(0)))
 		}
-		g.write('__eq(')
-		g.write('*'.repeat(left.typ.nr_muls()))
+		g.write2('__eq(', '*'.repeat(left.typ.nr_muls()))
 		if eq_operator_expects_ptr {
 			g.write('&')
 		}
 		g.expr(node.left)
-		g.write(', ')
-		g.write('*'.repeat(right.typ.nr_muls()))
+		g.write2(', ', '*'.repeat(right.typ.nr_muls()))
 		if eq_operator_expects_ptr {
 			g.write('&')
 		}
@@ -362,28 +360,24 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 		method_name = g.generic_fn_name(concrete_types, method_name)
 		g.write(method_name)
 		if node.op in [.lt, .ge] {
-			g.write('(')
-			g.write('*'.repeat(left.typ.nr_muls()))
+			g.write2('(', '*'.repeat(left.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
 			g.expr(node.left)
-			g.write(', ')
-			g.write('*'.repeat(right.typ.nr_muls()))
+			g.write2(', ', '*'.repeat(right.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
 			g.expr(node.right)
 			g.write(')')
 		} else {
-			g.write('(')
-			g.write('*'.repeat(right.typ.nr_muls()))
+			g.write2('(', '*'.repeat(right.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
 			g.expr(node.right)
-			g.write(', ')
-			g.write('*'.repeat(left.typ.nr_muls()))
+			g.write2(', ', '*'.repeat(left.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
@@ -394,31 +388,26 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 		if node.op in [.le, .ge] {
 			g.write('!')
 		}
-		g.write(g.styp(left.typ.set_nr_muls(0)))
-		g.write('__lt')
+		g.write2(g.styp(left.typ.set_nr_muls(0)), '__lt')
 		if node.op in [.lt, .ge] {
-			g.write('(')
-			g.write('*'.repeat(left.typ.nr_muls()))
+			g.write2('(', '*'.repeat(left.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
 			g.expr(node.left)
-			g.write(', ')
-			g.write('*'.repeat(right.typ.nr_muls()))
+			g.write2(', ', '*'.repeat(right.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
 			g.expr(node.right)
 			g.write(')')
 		} else {
-			g.write('(')
-			g.write('*'.repeat(right.typ.nr_muls()))
+			g.write2('(', '*'.repeat(right.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
 			g.expr(node.right)
-			g.write(', ')
-			g.write('*'.repeat(left.typ.nr_muls()))
+			g.write2(', ', '*'.repeat(left.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
@@ -618,13 +607,11 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 		g.gen_array_contains(node.right_type, node.right, node.left_type, node.left)
 		g.write(')')
 	} else if right.unaliased_sym.kind == .string {
-		g.write('(')
-		g.write('string_contains(')
+		g.write2('(', 'string_contains(')
 		g.expr(node.right)
 		g.write(', ')
 		g.expr(node.left)
-		g.write(')')
-		g.write(')')
+		g.write('))')
 	}
 }
 
@@ -775,8 +762,7 @@ fn (mut g Gen) infix_expr_arithmetic_op(node ast.InfixExpr) {
 	if left.sym.info is ast.Struct && left.sym.info.generic_types.len > 0 {
 		mut method_name := left.sym.cname + '_' + util.replace_op(node.op.str())
 		method_name = g.generic_fn_name(left.sym.info.concrete_types, method_name)
-		g.write(method_name)
-		g.write('(')
+		g.write2(method_name, '(')
 		g.expr(node.left)
 		g.write(', ')
 		g.expr(node.right)
@@ -811,8 +797,7 @@ fn (mut g Gen) infix_expr_arithmetic_op(node ast.InfixExpr) {
 			g.writeln(';')
 			g.write(cur_line)
 		}
-		g.write(method_name)
-		g.write('(')
+		g.write2(method_name, '(')
 		g.op_arg(node.left, method.params[0].typ, left.typ)
 		if right_var != '' {
 			g.write(', ${right_var}')
@@ -1011,12 +996,10 @@ fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
 		g.empty_line = true
 		left_var := g.expr_with_opt(node.left, node.left_type, node.left_type)
 		g.writeln(';')
-		g.write(stmt_str)
-		g.write(' ')
+		g.write2(stmt_str, ' ')
 		g.write('${left_var}.state')
 	}
-	g.write(' ${node.op.str()} ')
-	g.write('2') // none state
+	g.write(' ${node.op.str()} 2') // none state
 }
 
 // gen_plain_infix_expr generates basic code for infix expressions,

--- a/vlib/v/gen/c/live.v
+++ b/vlib/v/gen/c/live.v
@@ -72,7 +72,7 @@ fn (mut g Gen) generate_hotcode_reloading_main_caller() {
 	}
 	g.writeln('')
 	// We are in live code reload mode, so start the .so loader in the background
-	g.write2ln('\t// live code initialization section:', '\t{')
+	g.writeln2('\t// live code initialization section:', '\t{')
 	g.writeln('\t\t// initialization of live function pointers')
 	for fname in g.hotcode_fn_names {
 		g.writeln('\t\timpl_live_${fname} = 0;')

--- a/vlib/v/gen/c/live.v
+++ b/vlib/v/gen/c/live.v
@@ -72,8 +72,7 @@ fn (mut g Gen) generate_hotcode_reloading_main_caller() {
 	}
 	g.writeln('')
 	// We are in live code reload mode, so start the .so loader in the background
-	g.writeln('\t// live code initialization section:')
-	g.writeln('\t{')
+	g.write2ln('\t// live code initialization section:', '\t{')
 	g.writeln('\t\t// initialization of live function pointers')
 	for fname in g.hotcode_fn_names {
 		g.writeln('\t\timpl_live_${fname} = 0;')

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -543,8 +543,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 		if g.inside_ternary == 0 && node.branches.len >= 1 {
 			if reset_if {
 				has_goto = true
-				g.writeln('\tgoto end_block_${node.pos.line_nr};')
-				g.writeln('}')
+				g.write2ln('\tgoto end_block_${node.pos.line_nr};', '}')
 				g.set_current_pos_as_last_stmt_pos()
 			} else {
 				g.write('}')

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -543,7 +543,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 		if g.inside_ternary == 0 && node.branches.len >= 1 {
 			if reset_if {
 				has_goto = true
-				g.write2ln('\tgoto end_block_${node.pos.line_nr};', '}')
+				g.writeln2('\tgoto end_block_${node.pos.line_nr};', '}')
 				g.set_current_pos_as_last_stmt_pos()
 			} else {
 				g.write('}')

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -60,8 +60,7 @@ fn (mut g Gen) sql_insert_expr(node ast.SqlExpr) {
 	g.write_orm_insert(hack_stmt_line, table_name, connection_var_name, result_var_name,
 		node.or_expr)
 
-	g.write(left)
-	g.write('orm__Connection_name_table[${connection_var_name}._typ]._method_last_id(${connection_var_name}._object)')
+	g.write2(left, 'orm__Connection_name_table[${connection_var_name}._typ]._method_last_id(${connection_var_name}._object)')
 }
 
 // sql_stmt writes C code that calls ORM functions for
@@ -258,8 +257,7 @@ fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connec
 		g.writeln('.fields = __new_array_with_default_noscan(${node.updated_columns.len}, ${node.updated_columns.len}, sizeof(string), 0')
 	}
 
-	g.writeln('),')
-	g.writeln('.data = new_array_from_c_array(${node.update_exprs.len}, ${node.update_exprs.len}, sizeof(orm__Primitive),')
+	g.write2ln('),', '.data = new_array_from_c_array(${node.update_exprs.len}, ${node.update_exprs.len}, sizeof(orm__Primitive),')
 
 	if node.update_exprs.len > 0 {
 		g.indent++
@@ -715,8 +713,7 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 		g.write('.is_and = __new_array_with_default_noscan(${is_ands.len}, ${is_ands.len}, sizeof(bool), 0')
 	}
 	g.indent--
-	g.writeln('),')
-	g.writeln('}')
+	g.write2ln('),', '}')
 }
 
 // write_orm_where_expr writes C code that generates expression which is used in the `QueryData`.
@@ -913,8 +910,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		g.writeln('NULL')
 	}
 	g.indent--
-	g.writeln('),')
-	g.writeln('.types = new_array_from_c_array(${types.len}, ${types.len}, sizeof(${ast.int_type_name}),')
+	g.write2ln('),', '.types = new_array_from_c_array(${types.len}, ${types.len}, sizeof(${ast.int_type_name}),')
 	g.indent++
 
 	if types.len > 0 {

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -257,7 +257,7 @@ fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connec
 		g.writeln('.fields = __new_array_with_default_noscan(${node.updated_columns.len}, ${node.updated_columns.len}, sizeof(string), 0')
 	}
 
-	g.write2ln('),', '.data = new_array_from_c_array(${node.update_exprs.len}, ${node.update_exprs.len}, sizeof(orm__Primitive),')
+	g.writeln2('),', '.data = new_array_from_c_array(${node.update_exprs.len}, ${node.update_exprs.len}, sizeof(orm__Primitive),')
 
 	if node.update_exprs.len > 0 {
 		g.indent++
@@ -713,7 +713,7 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 		g.write('.is_and = __new_array_with_default_noscan(${is_ands.len}, ${is_ands.len}, sizeof(bool), 0')
 	}
 	g.indent--
-	g.write2ln('),', '}')
+	g.writeln2('),', '}')
 }
 
 // write_orm_where_expr writes C code that generates expression which is used in the `QueryData`.
@@ -910,7 +910,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		g.writeln('NULL')
 	}
 	g.indent--
-	g.write2ln('),', '.types = new_array_from_c_array(${types.len}, ${types.len}, sizeof(${ast.int_type_name}),')
+	g.writeln2('),', '.types = new_array_from_c_array(${types.len}, ${types.len}, sizeof(${ast.int_type_name}),')
 	g.indent++
 
 	if types.len > 0 {

--- a/vlib/v/gen/c/profile.v
+++ b/vlib/v/gen/c/profile.v
@@ -32,7 +32,7 @@ fn (mut g Gen) profile_fn(fn_decl ast.FnDecl) {
 			g.writeln('\tv__profile_enabled = true;')
 		}
 		g.writeln('\tdouble _PROF_FN_START = ${measure_fn_name}();')
-		g.write2ln('\tif(v__profile_enabled) { ${fn_profile_counter_name_calls}++; } // ${fn_name}',
+		g.writeln2('\tif(v__profile_enabled) { ${fn_profile_counter_name_calls}++; } // ${fn_name}',
 			'')
 		g.defer_profile_code = '\tif(v__profile_enabled) { ${fn_profile_counter_name} += ${measure_fn_name}() - _PROF_FN_START; }'
 		if should_restore_v__profile_enabled {

--- a/vlib/v/gen/c/profile.v
+++ b/vlib/v/gen/c/profile.v
@@ -32,8 +32,8 @@ fn (mut g Gen) profile_fn(fn_decl ast.FnDecl) {
 			g.writeln('\tv__profile_enabled = true;')
 		}
 		g.writeln('\tdouble _PROF_FN_START = ${measure_fn_name}();')
-		g.writeln2('\tif(v__profile_enabled) { ${fn_profile_counter_name_calls}++; } // ${fn_name}',
-			'')
+		g.writeln('\tif(v__profile_enabled) { ${fn_profile_counter_name_calls}++; } // ${fn_name}')
+		g.writeln('')
 		g.defer_profile_code = '\tif(v__profile_enabled) { ${fn_profile_counter_name} += ${measure_fn_name}() - _PROF_FN_START; }'
 		if should_restore_v__profile_enabled {
 			g.defer_profile_code += '\n\t\tv__profile_enabled = _prev_v__profile_enabled;'

--- a/vlib/v/gen/c/profile.v
+++ b/vlib/v/gen/c/profile.v
@@ -32,8 +32,8 @@ fn (mut g Gen) profile_fn(fn_decl ast.FnDecl) {
 			g.writeln('\tv__profile_enabled = true;')
 		}
 		g.writeln('\tdouble _PROF_FN_START = ${measure_fn_name}();')
-		g.writeln('\tif(v__profile_enabled) { ${fn_profile_counter_name_calls}++; } // ${fn_name}')
-		g.writeln('')
+		g.write2ln('\tif(v__profile_enabled) { ${fn_profile_counter_name_calls}++; } // ${fn_name}',
+			'')
 		g.defer_profile_code = '\tif(v__profile_enabled) { ${fn_profile_counter_name} += ${measure_fn_name}() - _PROF_FN_START; }'
 		if should_restore_v__profile_enabled {
 			g.defer_profile_code += '\n\t\tv__profile_enabled = _prev_v__profile_enabled;'

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -142,7 +142,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			if node.is_expr && node.call_expr.return_type != ast.void_type {
 				g.writeln('${gohandle_name} thread_${tmp} = {')
 				g.writeln('\t.ret_ptr = ${arg_tmp_var}->ret_ptr,')
-				g.write2ln('\t.handle = thread_handle_${tmp}', '};')
+				g.writeln2('\t.handle = thread_handle_${tmp}', '};')
 			}
 			if !node.is_expr {
 				g.writeln('CloseHandle(thread_${tmp});')
@@ -314,11 +314,11 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				&& (typ_sym.info as ast.Interface).defines_method(expr.name) {
 				rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 				receiver_type_name := util.no_dots(rec_cc_type)
-				g.gowrappers.write_2_string('${c_name(receiver_type_name)}_name_table[',
+				g.gowrappers.write_string2('${c_name(receiver_type_name)}_name_table[',
 					'arg->arg0')
 				idot := if expr.left_type.is_ptr() { '->' } else { '.' }
 				mname := c_name(expr.name)
-				g.gowrappers.write_2_string('${idot}_typ]._method_${mname}(', 'arg->arg0')
+				g.gowrappers.write_string2('${idot}_typ]._method_${mname}(', 'arg->arg0')
 				g.gowrappers.write_string('${idot}_object')
 			} else if typ_sym.kind == .struct && expr.is_field {
 				g.gowrappers.write_string('arg->arg0')
@@ -326,7 +326,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				mname := c_name(expr.name)
 				g.gowrappers.write_string('${idot}${mname}(')
 			} else {
-				g.gowrappers.write_2_string('arg->fn(', 'arg->arg0')
+				g.gowrappers.write_string2('arg->fn(', 'arg->arg0')
 			}
 			if expr.args.len > 0 && (typ_sym.kind != .struct || !expr.is_field) {
 				g.gowrappers.write_string(', ')

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -142,8 +142,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			if node.is_expr && node.call_expr.return_type != ast.void_type {
 				g.writeln('${gohandle_name} thread_${tmp} = {')
 				g.writeln('\t.ret_ptr = ${arg_tmp_var}->ret_ptr,')
-				g.writeln('\t.handle = thread_handle_${tmp}')
-				g.writeln('};')
+				g.write2ln('\t.handle = thread_handle_${tmp}', '};')
 			}
 			if !node.is_expr {
 				g.writeln('CloseHandle(thread_${tmp});')
@@ -315,12 +314,11 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				&& (typ_sym.info as ast.Interface).defines_method(expr.name) {
 				rec_cc_type := g.cc_type(unwrapped_rec_type, false)
 				receiver_type_name := util.no_dots(rec_cc_type)
-				g.gowrappers.write_string('${c_name(receiver_type_name)}_name_table[')
-				g.gowrappers.write_string('arg->arg0')
+				g.gowrappers.write_2_string('${c_name(receiver_type_name)}_name_table[',
+					'arg->arg0')
 				idot := if expr.left_type.is_ptr() { '->' } else { '.' }
 				mname := c_name(expr.name)
-				g.gowrappers.write_string('${idot}_typ]._method_${mname}(')
-				g.gowrappers.write_string('arg->arg0')
+				g.gowrappers.write_2_string('${idot}_typ]._method_${mname}(', 'arg->arg0')
 				g.gowrappers.write_string('${idot}_object')
 			} else if typ_sym.kind == .struct && expr.is_field {
 				g.gowrappers.write_string('arg->arg0')
@@ -328,8 +326,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				mname := c_name(expr.name)
 				g.gowrappers.write_string('${idot}${mname}(')
 			} else {
-				g.gowrappers.write_string('arg->fn(')
-				g.gowrappers.write_string('arg->arg0')
+				g.gowrappers.write_2_string('arg->fn(', 'arg->arg0')
 			}
 			if expr.args.len > 0 && (typ_sym.kind != .struct || !expr.is_field) {
 				g.gowrappers.write_string(', ')
@@ -400,8 +397,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	}
 	if node.is_expr {
 		g.empty_line = false
-		g.write(line)
-		g.write(handle)
+		g.write2(line, handle)
 	}
 }
 

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -8,12 +8,10 @@ import v.util
 fn (mut g Gen) string_literal(node ast.StringLiteral) {
 	escaped_val := cescape_nonascii(util.smart_quote(node.val, node.is_raw))
 	if node.language == .c {
-		g.write('"')
-		g.write(escaped_val)
+		g.write2('"', escaped_val)
 		g.write('"')
 	} else {
-		g.write('_SLIT("')
-		g.write(escaped_val)
+		g.write2('_SLIT("', escaped_val)
 		g.write('")')
 	}
 }
@@ -29,8 +27,7 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 		escaped_val := cescape_nonascii(util.smart_quote(val, false))
 		g.write('strings__Builder_write_string(&')
 		g.expr(call_expr.left)
-		g.write(', _SLIT("')
-		g.write(escaped_val)
+		g.write2(', _SLIT("', escaped_val)
 		g.writeln('"));')
 		if i >= node.exprs.len {
 			break
@@ -43,8 +40,7 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 		g.expr(call_expr.left)
 		g.write(', ')
 		typ := node.expr_types[i]
-		g.write(g.styp(typ))
-		g.write('_str(')
+		g.write2(g.styp(typ), '_str(')
 		sym := g.table.sym(typ)
 		if sym.kind != .function {
 			g.expr(node.exprs[i])
@@ -143,8 +139,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				} else {
 					g.expr(expr)
 				}
-				g.write('.data')
-				g.write(') ? _SLIT("Option(&nil)") : ')
+				g.write2('.data', ') ? _SLIT("Option(&nil)") : ')
 			} else {
 				inside_interface_deref_old := g.inside_interface_deref
 				g.inside_interface_deref = false
@@ -159,8 +154,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				g.write(') ? _SLIT("nil") : ')
 			}
 		}
-		g.write(str_fn_name)
-		g.write('(')
+		g.write2(str_fn_name, '(')
 		if str_method_expects_ptr && !is_ptr {
 			if is_dump_expr || (g.pref.ccompiler_type != .tinyc && expr is ast.CallExpr) {
 				g.write('ADDR(${g.styp(typ)}, ')

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -186,8 +186,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int, fmts []u8) {
 		dot := if typ.is_ptr() { '->' } else { '.' }
 		g.write('${dot}_typ]._method_str(')
 		g.expr(expr)
-		g.write('${dot}_object')
-		g.write(')')
+		g.write2('${dot}_object', ')')
 	} else if fmt == `s` || typ.has_flag(.variadic) {
 		mut exp_typ := typ
 		if expr is ast.Ident {
@@ -261,17 +260,14 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			}
 		}
 	}
-	g.write(' str_intp(')
-	g.write(node.vals.len.str())
-	g.write(', ')
-	g.write('_MOV((StrIntpData[]){')
+	g.write2(' str_intp(', node.vals.len.str())
+	g.write(', _MOV((StrIntpData[]){')
 	for i, val in node.vals {
 		mut escaped_val := cescape_nonascii(util.smart_quote(val, false))
 		escaped_val = escaped_val.replace('\0', '\\0')
 
 		if escaped_val.len > 0 {
-			g.write('{_SLIT("')
-			g.write(escaped_val)
+			g.write2('{_SLIT("', escaped_val)
 			g.write('"), ')
 		} else {
 			g.write('{_SLIT0, ')
@@ -284,10 +280,8 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 		}
 
 		ft_u64, ft_str := g.str_format(node, i, fmts)
-		g.write('0x')
-		g.write(ft_u64.hex())
-		g.write(', {.d_')
-		g.write(ft_str)
+		g.write2('0x', ft_u64.hex())
+		g.write2(', {.d_', ft_str)
 		g.write(' = ')
 
 		// for pointers we need a void* cast

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -108,8 +108,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		})
 		g.writeln('}, &${tmp_var}, sizeof(${base_styp}));')
 		g.empty_line = false
-		g.write(s)
-		g.write(tmp_var)
+		g.write2(s, tmp_var)
 		return
 	} else if g.inside_cinit {
 		if is_multiline {
@@ -461,8 +460,7 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 			g.expr(field.default_expr)
 			g.writeln(', sizeof(${styp}));')
 			g.empty_line = false
-			g.write(s)
-			g.write('{')
+			g.write2(s, '{')
 			for i in 0 .. final_sym.info.size {
 				g.write('${tmp_var}[${i}]')
 				if i != final_sym.info.size - 1 {

--- a/vlib/v/gen/c/text_manipulation.v
+++ b/vlib/v/gen/c/text_manipulation.v
@@ -84,6 +84,7 @@ fn (mut g Gen) writeln(s string) {
 }
 
 fn (mut g Gen) writeln2(s1 string, s2 string) {
+	// expansion for s1
 	$if trace_gen ? {
 		if g.file == unsafe { nil } {
 			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln2: ${s1}')
@@ -97,6 +98,7 @@ fn (mut g Gen) writeln2(s1 string, s2 string) {
 	g.out.writeln(s1)
 	g.empty_line = true
 
+	// expansion for s2
 	$if trace_gen ? {
 		if g.file == unsafe { nil } {
 			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln2: ${s2}')

--- a/vlib/v/gen/c/text_manipulation.v
+++ b/vlib/v/gen/c/text_manipulation.v
@@ -83,28 +83,25 @@ fn (mut g Gen) writeln(s string) {
 	g.empty_line = true
 }
 
-fn (mut g Gen) write2ln(s1 string, s2 string) {
+fn (mut g Gen) writeln2(s1 string, s2 string) {
 	$if trace_gen ? {
 		if g.file == unsafe { nil } {
-			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s1}')
+			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln2: ${s1}')
 		} else {
-			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s1}')
+			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln2: ${s1}')
 		}
 	}
 	if g.indent > 0 && g.empty_line {
 		g.out.write_string(util.tabs(g.indent))
-		// g.out_parallel[g.out_idx].write_string(util.tabs(g.indent))
 	}
-	// println('w len=$g.out_parallel.len')
 	g.out.writeln(s1)
-	// g.out_parallel[g.out_idx].writeln(s)
 	g.empty_line = true
 
 	$if trace_gen ? {
 		if g.file == unsafe { nil } {
-			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s2}')
+			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln2: ${s2}')
 		} else {
-			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s2}')
+			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln2: ${s2}')
 		}
 	}
 	if g.indent > 0 && g.empty_line {

--- a/vlib/v/gen/c/text_manipulation.v
+++ b/vlib/v/gen/c/text_manipulation.v
@@ -21,6 +21,35 @@ fn (mut g Gen) write(s string) {
 	g.empty_line = false
 }
 
+fn (mut g Gen) write2(s1 string, s2 string) {
+	$if trace_gen ? {
+		if g.file == unsafe { nil } {
+			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | write: ${s1}')
+		} else {
+			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | write: ${s1}')
+		}
+	}
+	if g.indent > 0 && g.empty_line {
+		g.out.write_string(util.tabs(g.indent))
+	}
+	g.out.write_string(s1)
+	g.empty_line = false
+
+	$if trace_gen ? {
+		if g.file == unsafe { nil } {
+			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | write: ${s2}')
+		} else {
+			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | write: ${s2}')
+		}
+	}
+
+	if g.indent > 0 && g.empty_line {
+		g.out.write_string(util.tabs(g.indent))
+	}
+	g.out.write_string(s2)
+	g.empty_line = false
+}
+
 fn (mut g Gen) write_decimal(x i64) {
 	$if trace_gen ? {
 		if g.file == unsafe { nil } {
@@ -51,6 +80,37 @@ fn (mut g Gen) writeln(s string) {
 	// println('w len=$g.out_parallel.len')
 	g.out.writeln(s)
 	// g.out_parallel[g.out_idx].writeln(s)
+	g.empty_line = true
+}
+
+fn (mut g Gen) write2ln(s1 string, s2 string) {
+	$if trace_gen ? {
+		if g.file == unsafe { nil } {
+			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s1}')
+		} else {
+			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s1}')
+		}
+	}
+	if g.indent > 0 && g.empty_line {
+		g.out.write_string(util.tabs(g.indent))
+		// g.out_parallel[g.out_idx].write_string(util.tabs(g.indent))
+	}
+	// println('w len=$g.out_parallel.len')
+	g.out.writeln(s1)
+	// g.out_parallel[g.out_idx].writeln(s)
+	g.empty_line = true
+
+	$if trace_gen ? {
+		if g.file == unsafe { nil } {
+			eprintln('gen file: <nil> | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s2}')
+		} else {
+			eprintln('gen file: ${g.file.path:-30} | last_fn_c_name: ${g.last_fn_c_name:-45} | writeln: ${s2}')
+		}
+	}
+	if g.indent > 0 && g.empty_line {
+		g.out.write_string(util.tabs(g.indent))
+	}
+	g.out.writeln(s2)
 	g.empty_line = true
 }
 


### PR DESCRIPTION
This PR aims to reduce calls to `g.writeln()`, `g.write()`, `sb.write_string()`, `sb.writeln()`.

![image](https://github.com/user-attachments/assets/779405a6-d19e-42cd-aa2d-7f511362f5b9)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2NWJhMDRjMjRlYTI4ODJmZDZkMzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ut7oZb_avaVUH3-pac4BcVdnPgdQ9fD8GkcFZP41wHw">Huly&reg;: <b>V_0.6-21059</b></a></sub>