### PR TITLE
cgen: cache the results of g.base_type/1

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1097,10 +1097,10 @@ fn (mut g Gen) styp(t ast.Type) string {
 }
 
 fn (mut g Gen) base_type(_t ast.Type) string {
-	t := g.unwrap_generic(_t)
-	if styp := g.styp_cache[t] {
+	if styp := g.styp_cache[_t] {
 		return styp
 	}
+	t := g.unwrap_generic(_t)
 	if g.pref.nofloat {
 		// TODO: compile time if for perf?
 		if t == ast.f32_type {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1097,10 +1097,10 @@ fn (mut g Gen) styp(t ast.Type) string {
 }
 
 fn (mut g Gen) base_type(_t ast.Type) string {
-	if styp := g.styp_cache[_t] {
+	t := g.unwrap_generic(_t)
+	if styp := g.styp_cache[t] {
 		return styp
 	}
-	t := g.unwrap_generic(_t)
 	if g.pref.nofloat {
 		// TODO: compile time if for perf?
 		if t == ast.f32_type {


### PR DESCRIPTION
Cgen `base_type()` caching

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2Yjk0ZjRjMjRlYTI4ODIwMTcyYzUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.8Vf7I1Q4SrtrFzf6iXS_xjnsffrRD6oa4kGhva3RR0E">Huly&reg;: <b>V_0.6-21062</b></a></sub>