### PR TITLE
cgen: optimize literal string comparison (string__eq -> vmemcmp)

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -499,8 +499,8 @@ const c_helper_macros = '//============================== HELPER C MACROS ======
 #define _SLIT(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLEN(s, n) ((string){.str=(byteptr)("" s), .len=n, .is_lit=1})
 // optimized way to compare literal strings
-#define _SLIT_EQ(s, n, l) (n == sizeof(l)-1 && !vmemcmp(s, l, sizeof(l)-1))
-#define _SLIT_NE(s, n, l) (n != sizeof(l)-1 || vmemcmp(s, l, sizeof(l)-1))
+#define _SLIT_EQ(sptr, slen, lit) (slen == sizeof("" lit)-1 && !vmemcmp(sptr, "" lit, sizeof("" lit)-1))
+#define _SLIT_NE(sptr, slen, lit) (slen != sizeof("" lit)-1 || vmemcmp(sptr, "" lit, sizeof("" lit)-1))
 
 // take the address of an rvalue
 #define ADDR(type, expr) (&((type[]){expr}[0]))

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -498,6 +498,9 @@ const c_helper_macros = '//============================== HELPER C MACROS ======
 #define _SLIT0 (string){.str=(byteptr)(""), .len=0, .is_lit=1}
 #define _SLIT(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLEN(s, n) ((string){.str=(byteptr)("" s), .len=n, .is_lit=1})
+// optimized way to compare literal strings
+#define _SLIT_EQ(s, op, l) (s##op##len == sizeof(l)-1 && !vmemcmp(s##op##str, l, sizeof(l)-1))
+#define _SLIT_NE(s, op, l) (s##op##len != sizeof(l)-1 || vmemcmp(s##op##str, l, sizeof(l)-1))
 
 // take the address of an rvalue
 #define ADDR(type, expr) (&((type[]){expr}[0]))

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -499,8 +499,8 @@ const c_helper_macros = '//============================== HELPER C MACROS ======
 #define _SLIT(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLEN(s, n) ((string){.str=(byteptr)("" s), .len=n, .is_lit=1})
 // optimized way to compare literal strings
-#define _SLIT_EQ(sptr, slen, lit) (slen == sizeof("" lit)-1 && !vmemcmp(sptr, "" lit, sizeof("" lit)-1))
-#define _SLIT_NE(sptr, slen, lit) (slen != sizeof("" lit)-1 || vmemcmp(sptr, "" lit, sizeof("" lit)-1))
+#define _SLIT_EQ(sptr, slen, lit) (slen == sizeof("" lit)-1 && !vmemcmp(sptr, "" lit, slen))
+#define _SLIT_NE(sptr, slen, lit) (slen != sizeof("" lit)-1 || vmemcmp(sptr, "" lit, slen))
 
 // take the address of an rvalue
 #define ADDR(type, expr) (&((type[]){expr}[0]))

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -499,8 +499,8 @@ const c_helper_macros = '//============================== HELPER C MACROS ======
 #define _SLIT(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLEN(s, n) ((string){.str=(byteptr)("" s), .len=n, .is_lit=1})
 // optimized way to compare literal strings
-#define _SLIT_EQ(s, op, l) (s##op##len == sizeof(l)-1 && !vmemcmp(s##op##str, l, sizeof(l)-1))
-#define _SLIT_NE(s, op, l) (s##op##len != sizeof(l)-1 || vmemcmp(s##op##str, l, sizeof(l)-1))
+#define _SLIT_EQ(s, n, l) (n == sizeof(l)-1 && !vmemcmp(s, l, sizeof(l)-1))
+#define _SLIT_NE(s, n, l) (n != sizeof(l)-1 || vmemcmp(s, l, sizeof(l)-1))
 
 // take the address of an rvalue
 #define ADDR(type, expr) (&((type[]){expr}[0]))

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -145,7 +145,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			if node.op == .eq {
 				g.write('(${var}${arrow}len == sizeof("${slit}")-1 && !vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
 			} else {
-				g.write('(${var}${arrow}len ${node.op} sizeof("${slit}")-1 || vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
+				g.write('(${var}${arrow}len != sizeof("${slit}")-1 || vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
 			}
 		}
 	} else if has_defined_eq_operator {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -143,8 +143,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			var := g.expr_string(node.left)
 			arrow := if left.typ.is_ptr() { '->' } else { '.' }
 			if node.op == .eq {
-				g.write('${var}${arrow}len == sizeof("${slit}")-1 && ')
-				g.write('!vmemcmp(${var}.str, "${slit}", sizeof("${slit}")-1)')
+				g.write('(${var}${arrow}len == sizeof("${slit}")-1 && !vmemcmp(${var}.str, "${slit}", sizeof("${slit}")-1))')
 			} else {
 				g.write('(${var}${arrow}len ${node.op} sizeof("${slit}")-1 || vmemcmp(${var}.str, "${slit}", sizeof("${slit}")-1))')
 			}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -129,7 +129,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 		g.gen_plain_infix_expr(node)
 	} else if (left.typ.idx() == ast.string_type_idx || (!has_defined_eq_operator
 		&& left.unaliased.idx() == ast.string_type_idx)) && node.right is ast.StringLiteral
-		&& (node.right.val == '' || node.left in [ast.SelectorExpr, ast.Ident]) {
+		&& (node.right.val == '' || node.left is ast.Ident) {
 		if node.right.val == '' {
 			// `str == ''` -> `str.len == 0` optimization
 			g.write('(')
@@ -143,9 +143,9 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			var := g.expr_string(node.left)
 			arrow := if left.typ.is_ptr() { '->' } else { '.' }
 			if node.op == .eq {
-				g.write('(${var}${arrow}len == sizeof("${slit}")-1 && !vmemcmp(${var}.str, "${slit}", sizeof("${slit}")-1))')
+				g.write('(${var}${arrow}len == sizeof("${slit}")-1 && !vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
 			} else {
-				g.write('(${var}${arrow}len ${node.op} sizeof("${slit}")-1 || vmemcmp(${var}.str, "${slit}", sizeof("${slit}")-1))')
+				g.write('(${var}${arrow}len ${node.op} sizeof("${slit}")-1 || vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
 			}
 		}
 	} else if has_defined_eq_operator {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -129,7 +129,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 		g.gen_plain_infix_expr(node)
 	} else if (left.typ.idx() == ast.string_type_idx || (!has_defined_eq_operator
 		&& left.unaliased.idx() == ast.string_type_idx)) && node.right is ast.StringLiteral
-		&& (node.right.val == '' || node.left is ast.Ident) {
+		&& (node.right.val == '' || (node.left is ast.Ident && node.left.or_expr.kind == .absent)) {
 		if node.right.val == '' {
 			// `str == ''` -> `str.len == 0` optimization
 			g.write('(')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -128,7 +128,8 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 		|| (left.typ.is_ptr() && right.typ == ast.nil_type) {
 		g.gen_plain_infix_expr(node)
 	} else if (left.typ.idx() == ast.string_type_idx || (!has_defined_eq_operator
-		&& left.unaliased.idx() == ast.string_type_idx)) && node.right is ast.StringLiteral {
+		&& left.unaliased.idx() == ast.string_type_idx)) && node.right is ast.StringLiteral
+		&& (node.right.val == '' || node.left in [ast.SelectorExpr, ast.Ident]) {
 		if node.right.val == '' {
 			// `str == ''` -> `str.len == 0` optimization
 			g.write('(')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -143,9 +143,9 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			var := g.expr_string(node.left)
 			arrow := if left.typ.is_ptr() { '->' } else { '.' }
 			if node.op == .eq {
-				g.write('(${var}${arrow}len == sizeof("${slit}")-1 && !vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
+				g.write('_SLIT_EQ(${var}, ${arrow}, "${slit}")')
 			} else {
-				g.write('(${var}${arrow}len != sizeof("${slit}")-1 || vmemcmp(${var}${arrow}str, "${slit}", sizeof("${slit}")-1))')
+				g.write('_SLIT_NE(${var}, ${arrow}, "${slit}")')
 			}
 		}
 	} else if has_defined_eq_operator {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -143,9 +143,9 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			var := g.expr_string(node.left)
 			arrow := if left.typ.is_ptr() { '->' } else { '.' }
 			if node.op == .eq {
-				g.write('_SLIT_EQ(${var}, ${arrow}, "${slit}")')
+				g.write('_SLIT_EQ(${var}${arrow}str, ${var}${arrow}len, "${slit}")')
 			} else {
-				g.write('_SLIT_NE(${var}, ${arrow}, "${slit}")')
+				g.write('_SLIT_NE(${var}${arrow}str, ${var}${arrow}len, "${slit}")')
 			}
 		}
 	} else if has_defined_eq_operator {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -141,7 +141,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			g.write('vmemcmp(')
 			g.expr(node.left)
 			slit := cescape_nonascii(util.smart_quote(node.right.val, node.right.is_raw))
-			g.write('.str, "${slit}", sizeof("${slit}")) ${node.op} 0')
+			g.write('.str, "${slit}", sizeof("${slit}")-1) ${node.op} 0')
 		}
 	} else if has_defined_eq_operator {
 		if node.op == .ne {


### PR DESCRIPTION
This PR makes literal string comparison `==` and `!=` to generate `_SLIT_EQ` and `_SLIT_NE` macro usage instead of `string__eq`.

![image](https://github.com/user-attachments/assets/22a6764b-548e-48ca-8bb3-e14cc4cbb8a5)

![image](https://github.com/user-attachments/assets/29e8557e-378c-462d-abe2-c06714751753)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE2ZDczYjRjMjRlYTI4ODIwMjg3MGIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.HRdQ-mAsMEwqlHkFEXi7laxd422ZZoUjtahd9Nfq0kE">Huly&reg;: <b>V_0.6-21063</b></a></sub>