### PR TITLE
checker, gen: implement fixed array method contains()

### DIFF
--- a/vlib/builtin/fixed_array_contains_test.v
+++ b/vlib/builtin/fixed_array_contains_test.v
@@ -1,0 +1,51 @@
+fn test_contains_of_ints() {
+	ia := [1, 2, 3]!
+	mut ii := ia.contains(2)
+	dump(ii)
+	assert ii
+
+	ii = ia.contains(5)
+	dump(ii)
+	assert !ii
+}
+
+fn test_contains_of_strings() {
+	sa := ['a', 'b', 'c']!
+	mut si := sa.contains('b')
+	dump(si)
+	assert si
+
+	si = sa.contains('v')
+	dump(si)
+	assert !si
+}
+
+fn test_contains_of_voidptrs() {
+	pa := [voidptr(123), voidptr(45), voidptr(99)]!
+	mut pi := pa.contains(voidptr(45))
+	dump(pi)
+	assert pi
+
+	pi = pa.contains(unsafe { nil })
+	dump(pi)
+	assert !pi
+}
+
+fn a() {}
+
+fn b() {}
+
+fn c() {}
+
+fn v() {}
+
+fn test_contains_of_fns() {
+	fa := [a, b, c]!
+	mut fi := fa.contains(b)
+	dump(fi)
+	assert fi
+
+	fi = fa.contains(v)
+	dump(fi)
+	assert !fi
+}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -996,7 +996,6 @@ fn (mut g Gen) gen_array_contains_methods() {
 			elem_kind := g.table.sym(elem_type).kind
 			elem_is_not_ptr := elem_type.nr_muls() == 0
 			if elem_kind == .function {
-				left_type_str = 'Array_voidptr'
 				elem_type_str = 'voidptr'
 			}
 			g.type_definitions.writeln('static bool ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1194,6 +1194,9 @@ fn (mut g Gen) gen_fixed_array_method_call(node ast.CallExpr, left_type ast.Type
 		'index' {
 			g.gen_array_index(node)
 		}
+		'contains' {
+			g.gen_array_contains(left_type, node.left, node.args[0].typ, node.args[0].expr)
+		}
 		'any' {
 			g.gen_array_any(node)
 		}


### PR DESCRIPTION
This PR implement fixed array method contains().

- Implement fixed array method contains().
- Add test.

```v
fn test_contains_of_ints() {
	ia := [1, 2, 3]!
	mut ii := ia.contains(2)
	dump(ii)
	assert ii

	ii = ia.contains(5)
	dump(ii)
	assert !ii
}

fn test_contains_of_strings() {
	sa := ['a', 'b', 'c']!
	mut si := sa.contains('b')
	dump(si)
	assert si

	si = sa.contains('v')
	dump(si)
	assert !si
}

fn test_contains_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!
	mut pi := pa.contains(voidptr(45))
	dump(pi)
	assert pi

	pi = pa.contains(unsafe { nil })
	dump(pi)
	assert !pi
}

fn a() {}

fn b() {}

fn c() {}

fn v() {}

fn test_contains_of_fns() {
	fa := [a, b, c]!
	mut fi := fa.contains(b)
	dump(fi)
	assert fi

	fi = fa.contains(v)
	dump(fi)
	assert !fi
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3NzYzNmYwMmQ4YTAzZmIyZGRiZmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.a_62EbUrOOOFMHWASe27GJh3eDledpJOkIzOF2uqNqE">Huly&reg;: <b>V_0.6-21066</b></a></sub>