### PR TITLE
reflection: split mod from typesymbol name

### DIFF
--- a/vlib/v/gen/c/reflection.v
+++ b/vlib/v/gen/c/reflection.v
@@ -81,9 +81,10 @@ fn (mut g Gen) gen_reflection_fn(node ast.Fn) string {
 @[inline]
 fn (mut g Gen) gen_reflection_sym(tsym ast.TypeSymbol) string {
 	kind_name := tsym.kind.str()
+	name := tsym.name.all_after_last('.')
 	info := g.gen_reflection_sym_info(tsym)
 	methods := g.gen_function_array(tsym.methods)
-	return '(${cprefix}TypeSymbol){.name=_SLIT("${tsym.name}"),.idx=${tsym.idx},.parent_idx=${tsym.parent_idx},.language=${cprefix}VLanguage__${tsym.language},.kind=${cprefix}VKind__${kind_name},.info=${info},.methods=${methods}}'
+	return '(${cprefix}TypeSymbol){.name=_SLIT("${name}"),.mod=_SLIT("${tsym.mod}"),.idx=${tsym.idx},.parent_idx=${tsym.parent_idx},.language=${cprefix}VLanguage__${tsym.language},.kind=${cprefix}VKind__${kind_name},.info=${info},.methods=${methods}}'
 }
 
 // gen_attrs_array generates C code for []Attr

--- a/vlib/v/reflection/reflection.v
+++ b/vlib/v/reflection/reflection.v
@@ -193,6 +193,7 @@ pub type TypeInfo = Alias
 pub struct TypeSymbol {
 pub:
 	name       string     // symbol name
+	mod        string     // mod name
 	idx        int        // symbol idx
 	parent_idx int        // symbol parent idx
 	language   VLanguage  // language

--- a/vlib/v/tests/reflection_sym_test.v
+++ b/vlib/v/tests/reflection_sym_test.v
@@ -79,13 +79,15 @@ fn test_multi_return_sym() {
 
 	typ := reflection.get_type(func.return_typ)?
 	assert typ.name == '(int, f64, string)'
+	assert typ.sym.mod == ''
 	assert typ.sym.language == .v
 	assert typ.sym.kind == .multi_return
 }
 
 fn test_enum_sym() {
 	var := reflection.type_of(Flags.foo)
-	assert var.sym.name == 'main.Flags'
+	assert var.sym.name == 'Flags'
+	assert var.sym.mod == 'main'
 	assert var.sym.parent_idx == 0
 	assert var.sym.kind == .enum
 	assert var.sym.language == .v
@@ -95,6 +97,7 @@ fn test_enum_sym() {
 fn test_struct_sym() {
 	var := reflection.type_of(Test{})
 	assert var.sym.kind == .struct
+	assert var.sym.mod == 'main'
 	assert (var.sym.info as reflection.Struct).attrs.len == 1
 	assert (var.sym.info as reflection.Struct).attrs == ['test_struct']
 


### PR DESCRIPTION
Fix #22488

This PR extracts the mod name from the `name` to a new `mod` field.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3ODk0M2YwMmQ4YTAzZmIyZGVhYWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.L33MBqHmYSwHvkwGr-Hon3JgRP8fetH7TyipaR21txo">Huly&reg;: <b>V_0.6-21067</b></a></sub>