### PR TITLE
picoev,net.http: use Time.http_header_string method, to improve performance

### DIFF
--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -128,8 +128,7 @@ pub fn (c &Cookie) str() string {
 		}
 	}
 	if c.expires.year > 1600 {
-		e := c.expires
-		time_str := '${e.weekday_str()}, ${e.day.str()} ${e.smonth()} ${e.year} ${e.hhmmss()} GMT'
+		time_str := c.expires.http_header_string()
 		b.write_string('; expires=')
 		b.write_string(time_str)
 	}

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -410,10 +410,7 @@ fn update_date_string(mut pv Picoev) {
 	for {
 		// get GMT (UTC) time for the HTTP Date header
 		gmt := time.utc()
-		mut date_string := gmt.strftime('---, %d --- %Y %H:%M:%S GMT')
-		date_string = date_string.replace_once('---', gmt.weekday_str())
-		date_string = date_string.replace_once('---', gmt.smonth())
-		pv.date = date_string
+		pv.date = gmt.http_header_string()
 		time.sleep(time.second)
 	}
 }


### PR DESCRIPTION
use faster http_header_string method

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3OTZiZGYwMmQ4YTAzZmIyZGYzYjgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.BkDaJpvGe1lxPYYMFLulQZm2_2wR1iXURZpfW1dMMkE">Huly&reg;: <b>V_0.6-21068</b></a></sub>