### PR TITLE
perf: `string.starts_with` and `string.ends_with` by 10x in TCC

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1510,13 +1510,10 @@ pub fn (s string) starts_with(p string) bool {
 pub fn (s string) ends_with(p string) bool {
 	if p.len > s.len {
 		return false
+	} else if unsafe { vmemcmp(s.str + s.len - p.len, p.str, p.len) == 0 } {
+		return true
 	}
-	for i in 0 .. p.len {
-		if unsafe { p.str[i] != s.str[s.len - p.len + i] } {
-			return false
-		}
-	}
-	return true
+	return false
 }
 
 // to_lower returns the string in all lowercase characters.

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1499,13 +1499,10 @@ pub fn (s string) contains_any_substr(substrs []string) bool {
 pub fn (s string) starts_with(p string) bool {
 	if p.len > s.len {
 		return false
+	} else if unsafe { vmemcmp(s.str, p.str, p.len) == 0 } {
+		return true
 	}
-	for i in 0 .. p.len {
-		if unsafe { s.str[i] != p.str[i] } {
-			return false
-		}
-	}
-	return true
+	return false
 }
 
 // ends_with returns `true` if the string ends with `p`.


### PR DESCRIPTION
10x faster in TCC
![image](https://github.com/user-attachments/assets/17c1bf54-e54c-4c82-bef4-8b61d5bdc36d)

```v
import benchmark

const max_iterations = 1_000_000

fn main() {
	value := 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
	mut b := benchmark.start()
	for i := 0; i < max_iterations; i++ {
		value.starts_with('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz')
		// value.ends_with('pqrstuvwxyzabcdefghijklmnopqrstuvwxyz')
	}
	b.measure("value.starts_with('abcd')")
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3OWZlZGYwMmQ4YTAzZmIyZGY3Y2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.o7v4jcrvPxhSOlIDmfjzuugN6wqo-TpUF1guvSWlxyM">Huly&reg;: <b>V_0.6-21069</b></a></sub>