### PR TITLE
builtin: improve `fixed_array_any_all_test.v` (related #22609)

### DIFF
--- a/vlib/builtin/fixed_array_any_all_test.v
+++ b/vlib/builtin/fixed_array_any_all_test.v
@@ -1,42 +1,37 @@
 fn test_any_all_of_ints() {
 	ia := [1, 2, 3]!
-	mut ii := ia.any(it > 2)
-	println(ii)
-	assert ii
 
-	ii = ia.all(it > 1)
-	println(ii)
-	assert !ii
+	assert ia.any(it > 2)
+	assert ia.any(|x| x > 2)
 
-	ii = ia.any(it == 2)
-	println(ii)
-	assert ii
+	assert !ia.all(it > 1)
+	assert !ia.all(|x| x > 1)
 
-	ii = ia.all(it == 3)
-	println(ii)
-	assert !ii
+	assert ia.any(it == 2)
+	assert ia.any(|x| x == 2)
+
+	assert !ia.all(it == 3)
+	assert !ia.all(|x| x == 3)
 }
 
 fn test_any_all_of_strings() {
 	sa := ['a', 'b', 'c']!
-	mut si := sa.any(it == 'b')
-	println(si)
-	assert si
 
-	si = sa.all(it == 'c')
-	println(si)
-	assert !si
+	assert sa.any(it == 'b')
+	assert sa.any(|x| x == 'b')
+
+	assert !sa.all(it == 'c')
+	assert !sa.all(|x| x == 'c')
 }
 
 fn test_any_all_of_voidptrs() {
 	pa := [voidptr(123), voidptr(45), voidptr(99)]!
-	mut pi := pa.any(it == voidptr(45))
-	println(pi)
-	assert pi
 
-	pi = pa.all(it == voidptr(123))
-	println(pi)
-	assert !pi
+	assert pa.any(it == voidptr(45))
+	assert pa.any(|x| x == voidptr(45))
+
+	assert !pa.all(it == voidptr(123))
+	assert !pa.all(|x| x == voidptr(123))
 }
 
 fn a() {}
@@ -49,11 +44,10 @@ fn v() {}
 
 fn test_any_all_of_fns() {
 	fa := [a, b, c]!
-	mut fi := fa.any(it == b)
-	println(fi)
-	assert fi
 
-	fi = fa.all(it == v)
-	println(fi)
-	assert !fi
+	assert fa.any(it == b)
+	assert fa.any(|x| x == b)
+
+	assert !fa.all(it == v)
+	assert !fa.all(|x| x == v)
 }


### PR DESCRIPTION
This PR improve fixed_array_any_all_test.v (related #22609).

- Add lambda expr tests.

```v
fn test_any_all_of_ints() {
	ia := [1, 2, 3]!

	assert ia.any(it > 2)
	assert ia.any(|x| x > 2)

	assert !ia.all(it > 1)
	assert !ia.all(|x| x > 1)

	assert ia.any(it == 2)
	assert ia.any(|x| x == 2)

	assert !ia.all(it == 3)
	assert !ia.all(|x| x == 3)
}

fn test_any_all_of_strings() {
	sa := ['a', 'b', 'c']!

	assert sa.any(it == 'b')
	assert sa.any(|x| x == 'b')

	assert !sa.all(it == 'c')
	assert !sa.all(|x| x == 'c')
}

fn test_any_all_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!

	assert pa.any(it == voidptr(45))
	assert pa.any(|x| x == voidptr(45))

	assert !pa.all(it == voidptr(123))
	assert !pa.all(|x| x == voidptr(123))
}

fn a() {}

fn b() {}

fn c() {}

fn v() {}

fn test_any_all_of_fns() {
	fa := [a, b, c]!

	assert fa.any(it == b)
	assert fa.any(|x| x == b)

	assert !fa.all(it == v)
	assert !fa.all(|x| x == v)
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3YTQ2MGYwMmQ4YTAzZmIyZGZhYjUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.L00fRPsdetWK-d-hOsxAo_nfSHX1RVrqJi8ZHd_ff-o">Huly&reg;: <b>V_0.6-21070</b></a></sub>