### PR TITLE
cgen: optimise the generated code for returning literal values and option/result values

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5524,32 +5524,29 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	g.defer_return_tmp_var = tmpvar
 	ret_typ := g.ret_styp(g.unwrap_generic(fn_ret_type))
 
+	// `return fn_call_opt()`
+	if node.exprs.len == 1 && (fn_return_is_option || fn_return_is_result)
+		&& node.exprs[0] is ast.CallExpr && node.exprs[0].return_type == g.fn_decl.return_type
+		&& node.exprs[0].or_block.kind == .absent {
+		if g.defer_stmts.len > 0 {
+			g.write('${ret_typ} ${tmpvar} = ')
+			g.expr(node.exprs[0])
+			g.writeln(';')
+			g.write_defer_stmts_when_needed()
+			g.writeln('return ${tmpvar};')
+		} else {
+			g.write_defer_stmts_when_needed()
+			g.write('return ')
+			g.expr(node.exprs[0])
+			g.writeln(';')
+		}
+		return
+	}
 	mut use_tmp_var := g.defer_stmts.len > 0 || g.defer_profile_code.len > 0
 		|| g.cur_lock.lockeds.len > 0
 		|| (fn_return_is_multi && node.exprs.len >= 1 && fn_return_is_option)
 		|| fn_return_is_fixed_array
 		|| (fn_return_is_multi && node.types.any(g.table.final_sym(it).kind == .array_fixed))
-
-	if node.exprs.len == 1 {
-		// `return fn_call_opt()`
-		if (fn_return_is_option || fn_return_is_result) && node.exprs[0] is ast.CallExpr
-			&& node.exprs[0].return_type == g.fn_decl.return_type
-			&& node.exprs[0].or_block.kind == .absent {
-			if use_tmp_var {
-				g.write('${ret_typ} ${tmpvar} = ')
-				g.expr(node.exprs[0])
-				g.writeln(';')
-				g.write_defer_stmts_when_needed()
-				g.writeln('return ${tmpvar};')
-			} else {
-				g.write_defer_stmts_when_needed()
-				g.write('return ')
-				g.expr(node.exprs[0])
-				g.writeln(';')
-			}
-			return
-		}
-	}
 	// handle promoting none/error/function returning _option'
 	if fn_return_is_option {
 		option_none := node.exprs[0] is ast.None

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5523,24 +5523,33 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	tmpvar := g.new_tmp_var()
 	g.defer_return_tmp_var = tmpvar
 	ret_typ := g.ret_styp(g.unwrap_generic(fn_ret_type))
-	if node.exprs.len == 1 {
-		// `return fn_call_opt()`
-		if (fn_return_is_option || fn_return_is_result) && node.exprs[0] is ast.CallExpr
-			&& node.exprs[0].return_type == g.fn_decl.return_type
-			&& node.exprs[0].or_block.kind == .absent {
-			g.write('${ret_typ} ${tmpvar} = ')
-			g.expr(node.exprs[0])
-			g.writeln(';')
-			g.write_defer_stmts_when_needed()
-			g.writeln('return ${tmpvar};')
-			return
-		}
-	}
+
 	mut use_tmp_var := g.defer_stmts.len > 0 || g.defer_profile_code.len > 0
 		|| g.cur_lock.lockeds.len > 0
 		|| (fn_return_is_multi && node.exprs.len >= 1 && fn_return_is_option)
 		|| fn_return_is_fixed_array
 		|| (fn_return_is_multi && node.types.any(g.table.final_sym(it).kind == .array_fixed))
+
+	if node.exprs.len == 1 {
+		// `return fn_call_opt()`
+		if (fn_return_is_option || fn_return_is_result) && node.exprs[0] is ast.CallExpr
+			&& node.exprs[0].return_type == g.fn_decl.return_type
+			&& node.exprs[0].or_block.kind == .absent {
+			if use_tmp_var {
+				g.write('${ret_typ} ${tmpvar} = ')
+				g.expr(node.exprs[0])
+				g.writeln(';')
+				g.write_defer_stmts_when_needed()
+				g.writeln('return ${tmpvar};')
+			} else {
+				g.write_defer_stmts_when_needed()
+				g.write('return ')
+				g.expr(node.exprs[0])
+				g.writeln(';')
+			}
+			return
+		}
+	}
 	// handle promoting none/error/function returning _option'
 	if fn_return_is_option {
 		option_none := node.exprs[0] is ast.None
@@ -5828,7 +5837,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			// Don't use a tmp var if a variable is simply returned: `return x`
 			// Just in case of defer statements exists, that the return values cannot
 			// be modified.
-			if node.exprs[0] !is ast.Ident || use_tmp_var {
+			if use_tmp_var || !(node.exprs[0].is_literal() || node.exprs[0] is ast.Ident) {
 				use_tmp_var = true
 				g.write('${ret_typ} ${tmpvar} = ')
 			} else {

--- a/vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.c.must_have
+++ b/vlib/v/gen/c/testdata/embed_with_prod_and_several_decoders.c.must_have
@@ -4,7 +4,7 @@
 
 VV_LOCAL_SYMBOL void v__preludes__embed_file__zlib__init(void);
 VV_LOCAL_SYMBOL _result_Array_u8 v__preludes__embed_file__zlib__ZLibDecoder_decompress(v__preludes__embed_file__zlib__ZLibDecoder _d1, Array_u8 data) {
-= compress__zlib__decompress(data);
+return compress__zlib__decompress(data);
 
 res.compressed = v__embed_file__find_index_entry_by_path((voidptr)_v_embed_file_index, _SLIT("embed.vv"), _SLIT("zlib"))->data;
 res.compression_type = _SLIT("zlib");


### PR DESCRIPTION
This PR improves the code generated by not using stack to alloc option struct to its immediate return and by returning literal values directly.

![image](https://github.com/user-attachments/assets/e5f58906-7c67-467f-8f2a-aafbc9ddb38c)

![image](https://github.com/user-attachments/assets/fff02a6b-936d-4cfc-b928-e3ec19c74ef4)

![image](https://github.com/user-attachments/assets/03049f5b-1412-45fb-ba1d-a68b978b4dfb)

![image](https://github.com/user-attachments/assets/a556f1de-41cf-4b8c-94f1-352cb782477a)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE3YWE3NWYwMmQ4YTAzZmIyZTk2ZDMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.1N6Z-NfS51PsjjADcC37LUJ4ynd04YpiBFC0rFnD6GQ">Huly&reg;: <b>V_0.6-21071</b></a></sub>