### PR TITLE
checker: fix lambda expr with fntype params and restore fixed_array_any_all_test.v

### DIFF
--- a/vlib/builtin/fixed_array_any_all_test.v
+++ b/vlib/builtin/fixed_array_any_all_test.v
@@ -46,8 +46,8 @@ fn test_any_all_of_fns() {
 	fa := [a, b, c]!
 
 	assert fa.any(it == b)
-	// assert fa.any(|x| x == b)
+	assert fa.any(|x| x == b)
 
 	assert !fa.all(it == v)
-	// assert !fa.all(|x| x == v)
+	assert !fa.all(|x| x == v)
 }

--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -156,14 +156,22 @@ pub fn (mut c Checker) support_lambda_expr_in_sort(param_type ast.Type, return_t
 }
 
 pub fn (mut c Checker) support_lambda_expr_one_param(param_type ast.Type, return_type ast.Type, mut expr ast.LambdaExpr) {
-	mut expected_fn := ast.Fn{
+	expected_fn := ast.Fn{
 		params:      [
 			ast.Param{
 				name: 'xx'
-				typ:  param_type
+				typ:  if c.table.final_sym(param_type).kind == .function {
+					ast.voidptr_type
+				} else {
+					param_type
+				}
 			},
 		]
-		return_type: return_type
+		return_type: if c.table.final_sym(return_type).kind == .function {
+			ast.voidptr_type
+		} else {
+			return_type
+		}
 	}
 	cb_type := c.table.find_or_register_fn_type(expected_fn, true, false)
 	expected_fn_type := ast.new_type(cb_type)


### PR DESCRIPTION
This PR fix lambda expr with fntype params and restore fixed_array_any_all_test.v.