### PR TITLE
checker: improve checking parameter mismatches for fixed array builtin methods

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3484,12 +3484,12 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 	if method_name == 'index' {
 		if node.args.len != 1 {
 			c.error('`.index()` expected 1 argument, but got ${node.args.len}', node.pos)
-			return ast.void_type
+			return ast.int_type
 		} else if !left_sym.has_method('index') {
 			arg_typ := c.expr(mut node.args[0].expr)
 			c.check_expected_call_arg(arg_typ, elem_typ, node.language, node.args[0]) or {
 				c.error('${err.msg()} in argument 1 to `.index()`', node.args[0].pos)
-				return ast.void_type
+				return ast.int_type
 			}
 		}
 		for i, mut arg in node.args {
@@ -3499,12 +3499,12 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 	} else if method_name == 'contains' {
 		if node.args.len != 1 {
 			c.error('`.contains()` expected 1 argument, but got ${node.args.len}', node.pos)
-			return ast.void_type
+			return ast.bool_type
 		} else if !left_sym.has_method('contains') {
 			arg_typ := c.expr(mut node.args[0].expr)
 			c.check_expected_call_arg(arg_typ, elem_typ, node.language, node.args[0]) or {
 				c.error('${err.msg()} in argument 1 to `.contains()`', node.args[0].pos)
-				return ast.void_type
+				return ast.bool_type
 			}
 		}
 		for i, mut arg in node.args {
@@ -3515,13 +3515,13 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 		if node.args.len != 1 {
 			c.error('`.${method_name}` expected 1 argument, but got ${node.args.len}',
 				node.pos)
-			return ast.void_type
+			return ast.bool_type
 		}
 		if node.args.len > 0 && mut node.args[0].expr is ast.LambdaExpr {
 			if node.args[0].expr.params.len != 1 {
 				c.error('lambda expressions used in the builtin array methods require exactly 1 parameter',
 					node.args[0].expr.pos)
-				return ast.void_type
+				return ast.bool_type
 			}
 			c.support_lambda_expr_one_param(elem_typ, ast.bool_type, mut node.args[0].expr)
 		} else {

--- a/vlib/v/checker/tests/fixed_array_builtin_method_args_err.out
+++ b/vlib/v/checker/tests/fixed_array_builtin_method_args_err.out
@@ -5,25 +5,11 @@ vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:4:11: error: `.index
       |              ~~~~~~~
     5 |     _ := arr.index('hello')
     6 |     _ := arr.contains()
-vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:4:4: error: assignment mismatch: 1 variable but `index()` returns 0 values
-    2 |     arr := [1, 2, 3]!
-    3 | 
-    4 |     _ := arr.index()
-      |       ~~
-    5 |     _ := arr.index('hello')
-    6 |     _ := arr.contains()
 vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:5:17: error: cannot use `string` as `int` in argument 1 to `.index()`
     3 | 
     4 |     _ := arr.index()
     5 |     _ := arr.index('hello')
       |                    ~~~~~~~
-    6 |     _ := arr.contains()
-    7 |     _ := arr.contains('hello')
-vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:5:4: error: assignment mismatch: 1 variable but `index()` returns 0 values
-    3 | 
-    4 |     _ := arr.index()
-    5 |     _ := arr.index('hello')
-      |       ~~
     6 |     _ := arr.contains()
     7 |     _ := arr.contains('hello')
 vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:6:11: error: `.contains()` expected 1 argument, but got 0
@@ -33,25 +19,11 @@ vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:6:11: error: `.conta
       |              ~~~~~~~~~~
     7 |     _ := arr.contains('hello')
     8 |     _ := arr.any()
-vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:6:4: error: assignment mismatch: 1 variable but `contains()` returns 0 values
-    4 |     _ := arr.index()
-    5 |     _ := arr.index('hello')
-    6 |     _ := arr.contains()
-      |       ~~
-    7 |     _ := arr.contains('hello')
-    8 |     _ := arr.any()
 vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:7:20: error: cannot use `string` as `int` in argument 1 to `.contains()`
     5 |     _ := arr.index('hello')
     6 |     _ := arr.contains()
     7 |     _ := arr.contains('hello')
       |                       ~~~~~~~
-    8 |     _ := arr.any()
-    9 |     _ := arr.any(22)
-vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:7:4: error: assignment mismatch: 1 variable but `contains()` returns 0 values
-    5 |     _ := arr.index('hello')
-    6 |     _ := arr.contains()
-    7 |     _ := arr.contains('hello')
-      |       ~~
     8 |     _ := arr.any()
     9 |     _ := arr.any(22)
 vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:8:11: error: `.any` expected 1 argument, but got 0
@@ -61,25 +33,11 @@ vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:8:11: error: `.any` 
       |              ~~~~~
     9 |     _ := arr.any(22)
    10 |     _ := arr.all()
-vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:8:4: error: assignment mismatch: 1 variable but `any()` returns 0 values
-    6 |     _ := arr.contains()
-    7 |     _ := arr.contains('hello')
-    8 |     _ := arr.any()
-      |       ~~
-    9 |     _ := arr.any(22)
-   10 |     _ := arr.all()
 vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:10:11: error: `.all` expected 1 argument, but got 0
     8 |     _ := arr.any()
     9 |     _ := arr.any(22)
    10 |     _ := arr.all()
       |              ~~~~~
-   11 |     _ := arr.all('hello')
-   12 | }
-vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:10:4: error: assignment mismatch: 1 variable but `all()` returns 0 values
-    8 |     _ := arr.any()
-    9 |     _ := arr.any(22)
-   10 |     _ := arr.all()
-      |       ~~
    11 |     _ := arr.all('hello')
    12 | }
 vlib/v/checker/tests/fixed_array_builtin_method_args_err.vv:11:15: error: type mismatch, should use e.g. `all(it > 2)`


### PR DESCRIPTION
This PR improve checking parameter mismatches for fixed array builtin methods.

```v
fn main() {
	arr := [1, 2, 3]!

	_ := arr.index()
	_ := arr.index('hello')
	_ := arr.contains()
	_ := arr.contains('hello')
	_ := arr.any()
	_ := arr.any(22)
	_ := arr.all()
	_ := arr.all('hello')
}

PS D:\Test\v\tt1> v run .
tt1.v:4:11: error: `.index()` expected 1 argument, but got 0
    2 |     arr := [1, 2, 3]!
    3 | 
    4 |     _ := arr.index()
      |              ~~~~~~~
    5 |     _ := arr.index('hello')
    6 |     _ := arr.contains()
tt1.v:5:17: error: cannot use `string` as `int` in argument 1 to `.index()`
    3 | 
    4 |     _ := arr.index()
    5 |     _ := arr.index('hello')
      |                    ~~~~~~~
    6 |     _ := arr.contains()
    7 |     _ := arr.contains('hello')
tt1.v:6:11: error: `.contains()` expected 1 argument, but got 0
    4 |     _ := arr.index()
    5 |     _ := arr.index('hello')
    6 |     _ := arr.contains()
      |              ~~~~~~~~~~
    7 |     _ := arr.contains('hello')
    8 |     _ := arr.any()
tt1.v:7:20: error: cannot use `string` as `int` in argument 1 to `.contains()`
    5 |     _ := arr.index('hello')
    6 |     _ := arr.contains()
    7 |     _ := arr.contains('hello')
      |                       ~~~~~~~
    8 |     _ := arr.any()
    9 |     _ := arr.any(22)
tt1.v:8:11: error: `.any` expected 1 argument, but got 0
    6 |     _ := arr.contains()
    7 |     _ := arr.contains('hello')
    8 |     _ := arr.any()
      |              ~~~~~
    9 |     _ := arr.any(22)
   10 |     _ := arr.all()
tt1.v:10:11: error: `.all` expected 1 argument, but got 0
    8 |     _ := arr.any()
    9 |     _ := arr.any(22)
   10 |     _ := arr.all()
      |              ~~~~~
   11 |     _ := arr.all('hello')
   12 | }
tt1.v:11:15: error: type mismatch, should use e.g. `all(it > 2)`
    9 |     _ := arr.any(22)
   10 |     _ := arr.all()
   11 |     _ := arr.all('hello')
      |                  ~~~~~~~
   12 | }
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE5MTk1ZGYwMmQ4YTAzZmIyZmNkYWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.bo7c-DbBH0gb-iBpPs0YHd_f_MRNXlmuUAoMhKGI_m0">Huly&reg;: <b>V_0.6-21079</b></a></sub>