### PR TITLE
docs: fix broken links by adding missing READMEs

### DIFF
--- a/vlib/coroutines/README.md
+++ b/vlib/coroutines/README.md
@@ -1,0 +1,3 @@
+## Description
+
+`coroutines` is a namespace for a wrapper around third party/photon.

--- a/vlib/db/README.md
+++ b/vlib/db/README.md
@@ -1,0 +1,4 @@
+## Description
+
+`db` is a namespace that contains several useful modules 
+for operating with databases (SQLite, MySQL, MSQL, etc.)

--- a/vlib/v2/README.md
+++ b/vlib/v2/README.md
@@ -1,0 +1,3 @@
+## Description
+
+`v2` is a namespace containing a new version of the compiler (still in development).


### PR DESCRIPTION
As mentioned at #17003 missing README broke the links so add some short READMEs for such cases

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE5NjAxM2YwMmQ4YTAzZmIyZmViNmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ZiJl2cEHpP-UKUMKoLzSUjGxYpC3uRTB4jxdeAMIuow">Huly&reg;: <b>V_0.6-21085</b></a></sub>