### PR TITLE
cgen: fix selector indexexpr with fntype on assignment

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4063,8 +4063,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			if !receiver.typ.is_ptr() {
 				g.write('memdup_uncollectable(')
 			}
+			mut has_addr := false
 			if !node.expr_type.is_ptr() {
-				g.write('&')
+				if node.expr is ast.IndexExpr {
+					has_addr = true
+					g.write('ADDR(${g.styp(node.expr_type)}, ')
+				} else {
+					g.write('&')
+				}
 			}
 			if !node.expr.is_lvalue() {
 				current_stmt := g.go_before_last_stmt()
@@ -4074,6 +4080,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				g.expr(ast.Expr(var))
 			} else {
 				g.expr(node.expr)
+			}
+			if has_addr {
+				g.write(')')
 			}
 			if !receiver.typ.is_ptr() {
 				g.write(', sizeof(${expr_styp}))')

--- a/vlib/v/tests/selector_indexexpr_fn_type_assign_test.v
+++ b/vlib/v/tests/selector_indexexpr_fn_type_assign_test.v
@@ -1,0 +1,11 @@
+fn test_main() {
+	a := 'abcd'
+	b := a[0].str
+	println(typeof(b).name)
+	assert b() == u8(`a`).str()
+
+	c := [1]
+	d := c[0].str
+	println(typeof(d).name)
+	assert d() == '1'
+}


### PR DESCRIPTION
Fix #22635

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE5NzMwMWYwMmQ4YTAzZmIyZmVmMDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.WhIx48DAiLAE2dBm6u8WYBE3NtXqXbqg4InEQzMo9JA">Huly&reg;: <b>V_0.6-21086</b></a></sub>