### PR TITLE
cgen: fix anon fn with prefix `&`

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -593,6 +593,11 @@ fn (mut g Gen) closure_ctx(node ast.FnDecl) string {
 }
 
 fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
+	is_amp := g.is_amp
+	g.is_amp = false
+	defer {
+		g.is_amp = is_amp
+	}
 	g.gen_anon_fn_decl(mut node)
 	fn_name := g.gen_closure_fn_name(node)
 	if !node.decl.scope.has_inherited_vars() {

--- a/vlib/v/tests/fns/anon_with_prefix_test.v
+++ b/vlib/v/tests/fns/anon_with_prefix_test.v
@@ -1,0 +1,19 @@
+module main
+
+struct TestA {
+	aa int
+}
+
+fn test_main() {
+	func := &fn () int {
+		arr := []TestA{}
+		return arr.len
+	}
+	assert func() == 0
+
+	func2 := &fn () int {
+		arr := []TestA{}
+		return arr.len
+	}
+	assert func2() == 0
+}


### PR DESCRIPTION
Fix #22628

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzE5NzZkNWYwMmQ4YTAzZmIyZmVmNzciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.plTRFJHxL5qwljP0YxJwBmptd7NM30ITjt1dpRu1I-Y">Huly&reg;: <b>V_0.6-21087</b></a></sub>