### PR TITLE
cgen: fix struct field init with fixed array using index (fix #22616)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -673,7 +673,8 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 			info := field_unwrap_sym.info as ast.ArrayFixed
 			g.fixed_array_var_init(g.expr_string(sfield.expr), sfield.expr.is_auto_deref_var(),
 				info.elem_type, info.size)
-		} else if field_unwrap_sym.kind == .array_fixed && sfield.expr is ast.CallExpr {
+		} else if field_unwrap_sym.kind == .array_fixed && (sfield.expr is ast.CallExpr
+			|| (sfield.expr is ast.ArrayInit && sfield.expr.has_index)) {
 			info := field_unwrap_sym.info as ast.ArrayFixed
 			tmp_var := g.expr_with_var(sfield.expr, sfield.typ, sfield.expected_type)
 			g.fixed_array_var_init(tmp_var, false, info.elem_type, info.size)

--- a/vlib/v/tests/structs/struct_field_init_with_fixed_array_init_test.v
+++ b/vlib/v/tests/structs/struct_field_init_with_fixed_array_init_test.v
@@ -1,0 +1,18 @@
+fn test_struct_field_init_with_fixed_array_init() {
+	mut a := [5]int{init: [1, 2][index] or { 0 }}
+	struct ArrayTest {
+		aa [5]int
+	}
+
+	array_a := ArrayTest{
+		aa: a
+	}
+	println('array_a: ${array_a}')
+	assert array_a.aa == [1, 2, 0, 0, 0]!
+
+	array_b := ArrayTest{
+		aa: [5]int{init: [1, 2][index] or { 0 }}
+	}
+	println('array_b: ${array_b}')
+	assert array_b.aa == [1, 2, 0, 0, 0]!
+}


### PR DESCRIPTION
This PR fix struct field init with fixed array using index (fix #22616).

- Fix struct field init with fixed array using index.
- Add test.

```v
fn main() {
	mut a := [5]int{init: [1, 2][index] or { 0 }}
	struct ArrayTest {
		aa [5]int
	}

	array_a := ArrayTest{
		aa: a
	}
	println('array_a: ${array_a}')
	assert array_a.aa == [1, 2, 0, 0, 0]!

	array_b := ArrayTest{
		aa: [5]int{init: [1, 2][index] or { 0 }}
	}
	println('array_b: ${array_b}')
	assert array_b.aa == [1, 2, 0, 0, 0]!
}

PS D:\Test\v\tt1> v run .
array_a: ArrayTest{
    aa: [1, 2, 0, 0, 0]
}
array_b: ArrayTest{
    aa: [1, 2, 0, 0, 0]
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFhNDNhOWYwMmQ4YTAzZmIzMzYwODMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.68o5BT6P1fexrUazGawgdejWGdUiMzNc_jK1s-anTiw">Huly&reg;: <b>V_0.6-21090</b></a></sub>