### PR TITLE
v: optimize literal string comparison (`match`, `in` and `==`)

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -220,11 +220,11 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				if field.typ.has_flag(.option) {
 					left_arg_opt := g.read_opt_field(left_type, field_name, 'a', field.typ)
 					right_arg_opt := g.read_opt_field(left_type, field_name, 'b', field.typ)
-					fn_builder.write_string('(((${left_arg_opt}).len == (${right_arg_opt}).len && (${left_arg_opt}).len == 0) || string__eq(${left_arg_opt}, ${right_arg_opt}))')
+					fn_builder.write_string('(((${left_arg_opt}).len == (${right_arg_opt}).len && (${left_arg_opt}).len == 0) || fast_string_eq(${left_arg_opt}, ${right_arg_opt}))')
 				} else if field.typ.is_ptr() {
-					fn_builder.write_string('((${left_arg}->len == ${right_arg}->len && ${left_arg}->len == 0) || string__eq(*(${left_arg}), *(${right_arg})))')
+					fn_builder.write_string('((${left_arg}->len == ${right_arg}->len && ${left_arg}->len == 0) || fast_string_eq(*(${left_arg}), *(${right_arg})))')
 				} else {
-					fn_builder.write_string('((${left_arg}.len == ${right_arg}.len && ${left_arg}.len == 0) || string__eq(${left_arg}, ${right_arg}))')
+					fn_builder.write_string('((${left_arg}.len == ${right_arg}.len && ${left_arg}.len == 0) || fast_string_eq(${left_arg}, ${right_arg}))')
 				}
 			} else if field_type.sym.kind == .sum_type && !field.typ.is_ptr() {
 				eq_fn := g.gen_sumtype_equality_fn(field.typ)
@@ -294,7 +294,7 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 		if info.parent_type.has_flag(.option) {
 			left_var = '*' + g.read_opt(info.parent_type, 'a')
 			right_var = '*' + g.read_opt(info.parent_type, 'b')
-			fn_builder.writeln('\treturn ((${left_var}).len == (${right_var}).len && (${left_var}).len == 0) || string__eq(${left_var}, ${right_var});')
+			fn_builder.writeln('\treturn ((${left_var}).len == (${right_var}).len && (${left_var}).len == 0) || fast_string_eq(${left_var}, ${right_var});')
 		} else {
 			fn_builder.writeln('\treturn string__eq(a, b);')
 		}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -636,7 +636,11 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, right ast.ArrayInit) {
 		match elem_sym.kind {
 			.string, .alias, .sum_type, .map, .interface, .array, .struct {
 				if elem_sym.kind == .string {
-					g.write('string__eq(')
+					if array_expr is ast.StringLiteral {
+						g.write('fast_string_eq(')
+					} else {
+						g.write('string__eq(')
+					}
 					if left.is_auto_deref_var() || (left is ast.Ident && left.info is ast.IdentVar
 						&& g.table.sym(left.obj.typ).kind in [.interface, .sum_type]) {
 						g.write('*')

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -495,7 +495,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 						if expr is ast.StringLiteral {
 							slit := cescape_nonascii(util.smart_quote(expr.val, expr.is_raw))
 							if node.cond_type.is_ptr() {
-								g.write('_SLIT_EQ(${ptr_str}${cond_var}->str, ${ptr_str}${cond_var}->len, "${slit}")')
+								g.write('_SLIT_EQ(${cond_var}->str, ${cond_var}->len, "${slit}")')
 							} else {
 								g.write('_SLIT_EQ(${cond_var}.str, ${cond_var}.len, "${slit}")')
 							}

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -492,7 +492,11 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 					}
 					.string {
 						ptr_str := if node.cond_type.is_ptr() { '*' } else { '' }
-						g.write('string__eq(${ptr_str}${cond_var}, ')
+						if expr is ast.StringLiteral {
+							g.write('fast_string_eq(${ptr_str}${cond_var}, ')
+						} else {
+							g.write('string__eq(${ptr_str}${cond_var}, ')
+						}
 						g.expr(expr)
 						g.write(')')
 					}

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -4,6 +4,7 @@
 module c
 
 import v.ast
+import v.util
 
 fn (mut g Gen) need_tmp_var_in_match(node ast.MatchExpr) bool {
 	if node.is_expr && node.return_type != ast.void_type && node.return_type != 0 {
@@ -491,14 +492,19 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 						g.write(')')
 					}
 					.string {
-						ptr_str := if node.cond_type.is_ptr() { '*' } else { '' }
 						if expr is ast.StringLiteral {
-							g.write('fast_string_eq(${ptr_str}${cond_var}, ')
+							slit := cescape_nonascii(util.smart_quote(expr.val, expr.is_raw))
+							if node.cond_type.is_ptr() {
+								g.write('_SLIT_EQ(${ptr_str}${cond_var}->str, ${ptr_str}${cond_var}->len, "${slit}")')
+							} else {
+								g.write('_SLIT_EQ(${cond_var}.str, ${cond_var}.len, "${slit}")')
+							}
 						} else {
-							g.write('string__eq(${ptr_str}${cond_var}, ')
+							ptr_str := if node.cond_type.is_ptr() { '*' } else { '' }
+							g.write('fast_string_eq(${ptr_str}${cond_var}, ')
+							g.expr(expr)
+							g.write(')')
 						}
-						g.expr(expr)
-						g.write(')')
 					}
 					.struct {
 						derefs_expr := '*'.repeat(g.get_expr_type(expr).nr_muls())


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/abdd038c-13cd-4bca-8fce-07932918c4f5)
![image](https://github.com/user-attachments/assets/667c3253-018b-4d5f-bddd-9079325b7992)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFhNGViZGYwMmQ4YTAzZmIzMzYxYWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.xKtrUwQm3CiTBRfc1T0OjsjvxB_Mjb3F_6PSPuDxy5E">Huly&reg;: <b>V_0.6-21092</b></a></sub>