### PR TITLE
v: fix interface conversion codegen race issue

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -191,7 +191,7 @@ pub mut:
 	methods []Fn
 	embeds  []Type
 	// `I1 is I2` conversions
-	conversions map[int][]Type
+	conversions shared map[int][]Type
 	// generic interface support
 	is_generic     bool
 	generic_types  []Type

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7598,10 +7598,12 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		g.write(')')
 
 		mut info := expr_type_sym.info as ast.Interface
-		if node.typ !in info.conversions {
-			left_variants := g.table.iface_types[expr_type_sym.name]
-			right_variants := g.table.iface_types[sym.name]
-			info.conversions[node.typ] = left_variants.filter(it in right_variants)
+		lock info.conversions {
+			if node.typ !in info.conversions {
+				left_variants := g.table.iface_types[expr_type_sym.name]
+				right_variants := g.table.iface_types[sym.name]
+				info.conversions[node.typ] = left_variants.filter(it in right_variants)
+			}
 		}
 		expr_type_sym.info = info
 	} else if mut expr_type_sym.info is ast.Interface && node.expr_type != node.typ {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -776,18 +776,19 @@ fn (mut g Gen) gen_interface_is_op(node ast.InfixExpr) {
 	right_sym := g.table.sym(node.right_type)
 
 	mut info := left_sym.info as ast.Interface
-
-	common_variants := info.conversions[node.right_type] or {
-		left_variants := g.table.iface_types[left_sym.name]
-		right_variants := g.table.iface_types[right_sym.name]
-		c := left_variants.filter(it in right_variants)
-		info.conversions[node.right_type] = c
-		c
-	}
-	left_sym.info = info
-	if common_variants.len == 0 {
-		g.write('false')
-		return
+	lock info.conversions {
+		common_variants := info.conversions[node.right_type] or {
+			left_variants := g.table.iface_types[left_sym.name]
+			right_variants := g.table.iface_types[right_sym.name]
+			c := left_variants.filter(it in right_variants)
+			info.conversions[node.right_type] = c
+			c
+		}
+		left_sym.info = info
+		if common_variants.len == 0 {
+			g.write('false')
+			return
+		}
 	}
 	g.write('I_${left_sym.cname}_is_I_${right_sym.cname}(')
 	if node.left_type.is_ptr() {


### PR DESCRIPTION
This PR fixes the race issue about reading/writing on interface `info.conversions` map reffered by @medvednikov on PR #22640

Probably related to #17943

My test was:
`for i in $(seq 1 50); do v ui/examples/users.v && echo "Success compilation" ; done`

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFjNWNkMWYwMmQ4YTAzZmIzM2ZiYWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.j6sduk9HDtHXrFjYRzbp-9v-e1d4uPX_vVybXfAKcBI">Huly&reg;: <b>V_0.6-21104</b></a></sub>