### PR TITLE
tests: add tests for checking fixed array .sort() errors

### DIFF
--- a/vlib/v/checker/tests/fixed_array_sort_err.out
+++ b/vlib/v/checker/tests/fixed_array_sort_err.out
@@ -1,0 +1,45 @@
+vlib/v/checker/tests/fixed_array_sort_err.vv:3:6: error: expected 0 or 1 argument, but got 2
+    1 | fn main() {
+    2 |     mut arr := [3, 2, 1]!
+    3 |     arr.sort(a < b, a)
+      |         ~~~~~~~~~~~~~~
+    4 |     arr.sort(a == b)
+    5 |     arr.sort(a > a)
+vlib/v/checker/tests/fixed_array_sort_err.vv:4:6: error: `.sort()` can only use `<` or `>` comparison
+    2 |     mut arr := [3, 2, 1]!
+    3 |     arr.sort(a < b, a)
+    4 |     arr.sort(a == b)
+      |         ~~~~~~~~~~~~
+    5 |     arr.sort(a > a)
+    6 |     arr.sort(c > d)
+vlib/v/checker/tests/fixed_array_sort_err.vv:5:6: error: `.sort()` cannot use same argument
+    3 |     arr.sort(a < b, a)
+    4 |     arr.sort(a == b)
+    5 |     arr.sort(a > a)
+      |         ~~~~~~~~~~~
+    6 |     arr.sort(c > d)
+    7 | }
+vlib/v/checker/tests/fixed_array_sort_err.vv:6:11: error: can not access external variable `c`
+    4 |     arr.sort(a == b)
+    5 |     arr.sort(a > a)
+    6 |     arr.sort(c > d)
+      |              ^
+    7 | }
+vlib/v/checker/tests/fixed_array_sort_err.vv:6:6: error: `.sort()` can only use `a` or `b` as argument, e.g. `arr.sort(a < b)`
+    4 |     arr.sort(a == b)
+    5 |     arr.sort(a > a)
+    6 |     arr.sort(c > d)
+      |         ~~~~~~~~~~~
+    7 | }
+vlib/v/checker/tests/fixed_array_sort_err.vv:6:11: error: undefined ident: `c`
+    4 |     arr.sort(a == b)
+    5 |     arr.sort(a > a)
+    6 |     arr.sort(c > d)
+      |              ^
+    7 | }
+vlib/v/checker/tests/fixed_array_sort_err.vv:6:15: error: undefined ident: `d`
+    4 |     arr.sort(a == b)
+    5 |     arr.sort(a > a)
+    6 |     arr.sort(c > d)
+      |                  ^
+    7 | }

--- a/vlib/v/checker/tests/fixed_array_sort_err.vv
+++ b/vlib/v/checker/tests/fixed_array_sort_err.vv
@@ -1,0 +1,7 @@
+fn main() {
+	mut arr := [3, 2, 1]!
+	arr.sort(a < b, a)
+	arr.sort(a == b)
+	arr.sort(a > a)
+	arr.sort(c > d)
+}

--- a/vlib/v/checker/tests/fn_return_fixed_array_sort_err.out
+++ b/vlib/v/checker/tests/fn_return_fixed_array_sort_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/fn_return_fixed_array_sort_err.vv:6:14: error: the `sort()` method can be called only on mutable receivers, but `ret_array()` is a call expression
+    4 | 
+    5 | fn main() {
+    6 |     ret_array().sort()
+      |                 ~~~~~~
+    7 | }
+vlib/v/checker/tests/fn_return_fixed_array_sort_err.vv:6:2: error: cannot pass expression as `mut`
+    4 | 
+    5 | fn main() {
+    6 |     ret_array().sort()
+      |     ~~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/fn_return_fixed_array_sort_err.vv
+++ b/vlib/v/checker/tests/fn_return_fixed_array_sort_err.vv
@@ -1,0 +1,7 @@
+fn ret_array() [3]int {
+	return [1, 3, 2]!
+}
+
+fn main() {
+	ret_array().sort()
+}


### PR DESCRIPTION
This PR add tests for checking fixed array .sort() errors.

```v
fn main() {
	mut arr := [3, 2, 1]!
	arr.sort(a < b, a)
	arr.sort(a == b)
	arr.sort(a > a)
	arr.sort(c > d)
}

PS D:\Test\v\tt1> v run .
tt1.v:3:6: error: expected 0 or 1 argument, but got 2
    1 | fn main() {
    2 |     mut arr := [3, 2, 1]!
    3 |     arr.sort(a < b, a)
      |         ~~~~~~~~~~~~~~
    4 |     arr.sort(a == b)
    5 |     arr.sort(a > a)
tt1.v:4:6: error: `.sort()` can only use `<` or `>` comparison
    2 |     mut arr := [3, 2, 1]!
    3 |     arr.sort(a < b, a)
    4 |     arr.sort(a == b)
      |         ~~~~~~~~~~~~
    5 |     arr.sort(a > a)
    6 |     arr.sort(c > d)
tt1.v:5:6: error: `.sort()` cannot use same argument
    3 |     arr.sort(a < b, a)
    4 |     arr.sort(a == b)
    5 |     arr.sort(a > a)
      |         ~~~~~~~~~~~
    6 |     arr.sort(c > d)
    7 | }
tt1.v:6:11: error: can not access external variable `c`
    4 |     arr.sort(a == b)
    5 |     arr.sort(a > a)
    6 |     arr.sort(c > d)
      |              ^
    7 | }
tt1.v:6:6: error: `.sort()` can only use `a` or `b` as argument, e.g. `arr.sort(a < b)`
    4 |     arr.sort(a == b)
    5 |     arr.sort(a > a)
    6 |     arr.sort(c > d)
      |         ~~~~~~~~~~~
    7 | }
tt1.v:6:11: error: undefined ident: `c`
    4 |     arr.sort(a == b)
    5 |     arr.sort(a > a)
    6 |     arr.sort(c > d)
      |              ^
    7 | }
tt1.v:6:15: error: undefined ident: `d`
    4 |     arr.sort(a == b)
    5 |     arr.sort(a > a)
    6 |     arr.sort(c > d)
      |                  ^
    7 | }
```

```v
fn ret_array() [3]int {
	return [1, 3, 2]!
}

fn main() {
	ret_array().sort()
}

PS D:\Test\v\tt1> v run .
tt1.v:6:14: error: the `sort()` method can be called only on mutable receivers, but `ret_array()` is a call expression
    4 |
    5 | fn main() {
    6 |     ret_array().sort()
      |                 ~~~~~~
    7 | }
tt1.v:6:2: error: cannot pass expression as `mut`
    4 |
    5 | fn main() {
    6 |     ret_array().sort()
      |     ~~~~~~~~~~~
    7 | }
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFjYWQ3ZGYwMmQ4YTAzZmIzNDAyNzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.K3poeNB9l1eImtrZeiXzuDEta8RC6-UVwgUcgYUHXd0">Huly&reg;: <b>V_0.6-21105</b></a></sub>