### PR TITLE
checker: fix return type checker when returning struct which implements IError on non-result fn

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -243,7 +243,7 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 					}
 				}
 				// `fn foo() !int { return Err{} }`
-				if got_type_sym.kind == .struct
+				if expected_fn_return_type_has_result && got_type_sym.kind == .struct
 					&& c.type_implements(got_type, ast.error_type, node.pos) {
 					node.exprs[expr_idxs[i]] = ast.CastExpr{
 						expr:      node.exprs[expr_idxs[i]]

--- a/vlib/v/checker/tests/mut_receiver_wrong_return_type.out
+++ b/vlib/v/checker/tests/mut_receiver_wrong_return_type.out
@@ -1,17 +1,3 @@
-vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:2: error: `&Test` doesn't implement method `msg` of interface `IError`
-    2 | 
-    3 | fn (mut test Test) test() ?int {
-    4 |     return test
-      |     ~~~~~~~~~~~
-    5 | }
-    6 |
-vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:2: error: `&Test` doesn't implement method `code` of interface `IError`
-    2 | 
-    3 | fn (mut test Test) test() ?int {
-    4 |     return test
-      |     ~~~~~~~~~~~
-    5 | }
-    6 |
 vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:9: error: cannot use `Test` as type `?int` in return argument
     2 | 
     3 | fn (mut test Test) test() ?int {
@@ -19,18 +5,6 @@ vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:4:9: error: cannot use `T
       |            ~~~~
     5 | }
     6 |
-vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:2: error: `&Test` doesn't implement method `msg` of interface `IError`
-    6 | 
-    7 | fn (mut test Test) test2() int {
-    8 |     return test
-      |     ~~~~~~~~~~~
-    9 | }
-vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:2: error: `&Test` doesn't implement method `code` of interface `IError`
-    6 | 
-    7 | fn (mut test Test) test2() int {
-    8 |     return test
-      |     ~~~~~~~~~~~
-    9 | }
 vlib/v/checker/tests/mut_receiver_wrong_return_type.vv:8:9: error: cannot use `Test` as type `int` in return argument
     6 | 
     7 | fn (mut test Test) test2() int {

--- a/vlib/v/checker/tests/wrong_return_type_err.out
+++ b/vlib/v/checker/tests/wrong_return_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/wrong_return_type_err.vv:9:10: error: cannot use `Error` as type `Val` in return argument
+    7 | fn new_val(num int) Val {
+    8 |     if num <= 0 {
+    9 |         return Error{}
+      |                ~~~~~~~
+   10 |     }
+   11 |     return Val{

--- a/vlib/v/checker/tests/wrong_return_type_err.out
+++ b/vlib/v/checker/tests/wrong_return_type_err.out
@@ -1,7 +1,14 @@
-vlib/v/checker/tests/wrong_return_type_err.vv:9:10: error: cannot use `Error` as type `Val` in return argument
-    7 | fn new_val(num int) Val {
+vlib/v/checker/tests/wrong_return_type_err.vv:9:10: error: cannot use `Error` as type `int` in return argument
+    7 | fn double_positive(num int) int {
     8 |     if num <= 0 {
     9 |         return Error{}
       |                ~~~~~~~
    10 |     }
-   11 |     return Val{
+   11 |     return num * 2
+vlib/v/checker/tests/wrong_return_type_err.vv:16:10: error: cannot use `Error` as type `Val` in return argument
+   14 | fn new_val(num int) Val {
+   15 |     if num <= 0 {
+   16 |         return Error{}
+      |                ~~~~~~~
+   17 |     }
+   18 |     return Val{

--- a/vlib/v/checker/tests/wrong_return_type_err.vv
+++ b/vlib/v/checker/tests/wrong_return_type_err.vv
@@ -4,6 +4,13 @@ struct Val {
 	val int
 }
 
+fn double_positive(num int) int {
+	if num <= 0 {
+		return Error{}
+	}
+	return num * 2
+}
+
 fn new_val(num int) Val {
 	if num <= 0 {
 		return Error{}

--- a/vlib/v/checker/tests/wrong_return_type_err.vv
+++ b/vlib/v/checker/tests/wrong_return_type_err.vv
@@ -1,0 +1,18 @@
+module main
+
+struct Val {
+	val int
+}
+
+fn new_val(num int) Val {
+	if num <= 0 {
+		return Error{}
+	}
+	return Val{
+		val: num
+	}
+}
+
+fn main() {
+	println(new_val(2))
+}

--- a/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.out
+++ b/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.out
@@ -1,1 +1,7 @@
-MapString({'abc': 'String Error'})
+vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.vv:17:9: error: cannot use `MyError` as type `?MapString` in return argument
+   15 | 
+   16 | fn f() ?MapString {
+   17 |     return MyError{
+      |            ~~~~~~~~
+   18 |         msg: 'String Error'
+   19 |     }

--- a/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.out
+++ b/vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.out
@@ -1,7 +1,0 @@
-vlib/v/slow_tests/inout/printing_option_or_expr_with_map_val.vv:17:9: error: cannot use `MyError` as type `?MapString` in return argument
-   15 | 
-   16 | fn f() ?MapString {
-   17 |     return MyError{
-      |            ~~~~~~~~
-   18 |         msg: 'String Error'
-   19 |     }

--- a/vlib/v/slow_tests/inout/printing_result_or_expr_with_map_val.out
+++ b/vlib/v/slow_tests/inout/printing_result_or_expr_with_map_val.out
@@ -1,0 +1,1 @@
+MapString({'abc': 'String Error'})

--- a/vlib/v/slow_tests/inout/printing_result_or_expr_with_map_val.vv
+++ b/vlib/v/slow_tests/inout/printing_result_or_expr_with_map_val.vv
@@ -13,7 +13,7 @@ fn (my MyError) code() int {
 
 type MapString = map[string]string | int
 
-fn f() ?MapString {
+fn f() !MapString {
 	return MyError{
 		msg: 'String Error'
 	}


### PR DESCRIPTION
Fix #22659
Fix #22658

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFjY2Y3OGYwMmQ4YTAzZmIzNDA0YzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ayD8fzOP3MbaaRpZTGvqup_m_tYARyDeoFABnw2oEjQ">Huly&reg;: <b>V_0.6-21109</b></a></sub>