### PR TITLE
checker: fix index expr that left is if expr (fix #22654)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1006,6 +1006,13 @@ fn (mut c Checker) fail_if_immutable(mut expr ast.Expr) (string, token.Pos) {
 		ast.InfixExpr {
 			return '', expr.pos
 		}
+		ast.IfExpr {
+			for mut branch in expr.branches {
+				mut last_expr := (branch.stmts.last() as ast.ExprStmt).expr
+				c.fail_if_immutable(mut last_expr)
+			}
+			return '', expr.pos
+		}
 		else {
 			if !expr.is_pure_literal() {
 				c.error('unexpected expression `${expr.type_name()}`', expr.pos())

--- a/vlib/v/checker/tests/immutable_array_in_if_expr_index.out
+++ b/vlib/v/checker/tests/immutable_array_in_if_expr_index.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/immutable_array_in_if_expr_index.vv:4:13: error: `array_a` is immutable, declare it with `mut` to make it mutable
+    2 |     array_a := [1, 2, 3]
+    3 |     array_b := [4, 5, 6]
+    4 |     (if true { array_a } else { array_b })[0] = 999
+      |                ~~~~~~~
+    5 |     println(array_a)
+    6 | }
+vlib/v/checker/tests/immutable_array_in_if_expr_index.vv:4:30: error: `array_b` is immutable, declare it with `mut` to make it mutable
+    2 |     array_a := [1, 2, 3]
+    3 |     array_b := [4, 5, 6]
+    4 |     (if true { array_a } else { array_b })[0] = 999
+      |                                 ~~~~~~~
+    5 |     println(array_a)
+    6 | }

--- a/vlib/v/checker/tests/immutable_array_in_if_expr_index.vv
+++ b/vlib/v/checker/tests/immutable_array_in_if_expr_index.vv
@@ -1,0 +1,6 @@
+fn main() {
+	array_a := [1, 2, 3]
+	array_b := [4, 5, 6]
+	(if true { array_a } else { array_b })[0] = 999
+	println(array_a)
+}

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -6,8 +6,8 @@ module c
 import v.ast
 
 fn (mut g Gen) need_tmp_var_in_if(node ast.IfExpr) bool {
-	if node.is_expr && g.inside_ternary == 0 {
-		if g.is_autofree || node.typ.has_option_or_result() || node.is_comptime {
+	if node.is_expr && (g.inside_ternary == 0 || g.is_assign_lhs) {
+		if g.is_autofree || node.typ.has_option_or_result() || node.is_comptime || g.is_assign_lhs {
 			return true
 		}
 		for branch in node.branches {

--- a/vlib/v/tests/indexexpr_with_if_expr_test.v
+++ b/vlib/v/tests/indexexpr_with_if_expr_test.v
@@ -1,7 +1,11 @@
 fn test_indexexpr_with_if_expr() {
 	mut array_a := [1, 2, 3]
 	mut array_b := [4, 5, 6]
-	(if true { array_a } else { array_b })[0] = 999
+	(if true {
+		array_a
+	} else {
+		array_b
+	})[0] = 999
 	println(array_a)
 	assert array_a == [999, 2, 3]
 }

--- a/vlib/v/tests/indexexpr_with_if_expr_test.v
+++ b/vlib/v/tests/indexexpr_with_if_expr_test.v
@@ -1,0 +1,7 @@
+fn test_indexexpr_with_if_expr() {
+	mut array_a := [1, 2, 3]
+	mut array_b := [4, 5, 6]
+	(if true { array_a } else { array_b })[0] = 999
+	println(array_a)
+	assert array_a == [999, 2, 3]
+}

--- a/vlib/v/tests/indexexpr_with_if_expr_test.v
+++ b/vlib/v/tests/indexexpr_with_if_expr_test.v
@@ -1,6 +1,7 @@
 fn test_indexexpr_with_if_expr() {
 	mut array_a := [1, 2, 3]
 	mut array_b := [4, 5, 6]
+
 	(if true {
 		array_a
 	} else {


### PR DESCRIPTION
This PR fix index expr that left is if expr (fix #22654).

- Fix index expr that left is if expr.
- Add test.

```v
fn main() {
	mut array_a := [1, 2, 3]
	mut array_b := [4, 5, 6]
	(if true { array_a } else { array_b })[0] = 999
	println(array_a)
	assert array_a == [999, 2, 3]
}

PS D:\Test\v\tt1> v run .
[999, 2, 3]
```

```v
fn main() {
	array_a := [1, 2, 3]
	array_b := [4, 5, 6]
	(if true { array_a } else { array_b })[0] = 999
	println(array_a)
	assert array_a == [999, 2, 3]
}

PS D:\Test\v\tt1> v run .
tt1.v:4:13: error: `array_a` is immutable, declare it with `mut` to make it mutable
    2 |     array_a := [1, 2, 3]
    3 |     array_b := [4, 5, 6]
    4 |     (if true { array_a } else { array_b })[0] = 999
      |                ~~~~~~~
    5 |     println(array_a)
    6 |     assert array_a == [999, 2, 3]
tt1.v:4:30: error: `array_b` is immutable, declare it with `mut` to make it mutable
    2 |     array_a := [1, 2, 3]
    3 |     array_b := [4, 5, 6]
    4 |     (if true { array_a } else { array_b })[0] = 999
      |                                 ~~~~~~~
    5 |     println(array_a)
    6 |     assert array_a == [999, 2, 3]
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFjZDI0MGYwMmQ4YTAzZmIzNDA1MzIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.3f9lnsXgg3d11yvZOSSmjfC5pbJ-VBQGhHTo7TkCqv0">Huly&reg;: <b>V_0.6-21110</b></a></sub>