### PR TITLE
log,time: improve performance for writing a line to a log, add Time.format_rfc3339_micro/0

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -8,13 +8,13 @@ import time
 
 // TimeFormat define the log time string format, come from time/format.v
 pub enum TimeFormat {
-	tf_ss_micro      // YYYY-MM-DD HH:mm:ss.123456 (24h) default
+	tf_ss_micro      // YYYY-MM-DD HH:mm:ss.123456 (24h)
 	tf_default       // YYYY-MM-DD HH:mm (24h)
 	tf_ss            // YYYY-MM-DD HH:mm:ss (24h)
 	tf_ss_milli      // YYYY-MM-DD HH:mm:ss.123 (24h)
 	tf_ss_nano       // YYYY-MM-DD HH:mm:ss.123456789 (24h)
 	tf_rfc3339       // YYYY-MM-DDTHH:mm:ss.123Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
-	tf_rfc3339_micro // YYYY-MM-DDTHH:mm:ss.123456Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
+	tf_rfc3339_micro // default, YYYY-MM-DDTHH:mm:ss.123456Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 	tf_rfc3339_nano  // YYYY-MM-DDTHH:mm:ss.123456789Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 	tf_hhmm          // HH:mm (24h)
 	tf_hhmmss        // HH:mm:ss (24h)
@@ -115,11 +115,6 @@ pub fn (mut l Log) reopen() ! {
 	}
 }
 
-const space = ' '
-const lbracket = '['
-const rbracket = ']'
-const newline = '\n'
-
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
 	timestamp := l.time_format(time.utc())
@@ -127,16 +122,16 @@ fn (mut l Log) log_file(s string, level Level) {
 
 	unsafe {
 		l.ofile.write_ptr(timestamp.str, timestamp.len)
-		l.ofile.write_ptr(space.str, space.len)
+		l.ofile.write_ptr(' '.str, 1)
 
-		l.ofile.write_ptr(lbracket.str, 1)
+		l.ofile.write_ptr('['.str, 1)
 		l.ofile.write_ptr(e.str, e.len)
-		l.ofile.write_ptr(rbracket.str, 1)
+		l.ofile.write_ptr(']'.str, 1)
 
-		l.ofile.write_ptr(space.str, space.len)
+		l.ofile.write_ptr(' '.str, 1)
 		l.ofile.write_ptr(s.str, s.len)
 
-		l.ofile.write_ptr(newline.str, 1)
+		l.ofile.write_ptr('\n'.str, 1)
 	}
 	if l.always_flush {
 		l.flush()
@@ -220,6 +215,9 @@ pub fn (mut f Log) free() {
 // time_format return a timestamp string in the pre-defined format
 fn (l Log) time_format(t time.Time) string {
 	match l.time_format {
+		.tf_rfc3339_micro { // YYYY-MM-DDTHH:mm:ss.123456Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
+			return t.format_rfc3339_micro()
+		}
 		.tf_ss_micro { // YYYY-MM-DD HH:mm:ss.123456 (24h) default
 			return t.format_ss_micro()
 		}
@@ -237,9 +235,6 @@ fn (l Log) time_format(t time.Time) string {
 		}
 		.tf_rfc3339 { // YYYY-MM-DDTHH:mm:ss.123Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 			return t.format_rfc3339()
-		}
-		.tf_rfc3339_micro { // YYYY-MM-DDTHH:mm:ss.123456Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
-			return t.format_rfc3339_micro()
 		}
 		.tf_rfc3339_nano { // YYYY-MM-DDTHH:mm:ss.123456789Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 			return t.format_rfc3339_nano()

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -24,26 +24,6 @@ pub enum TimeFormat {
 	tf_custom_format // 'MMMM Do YY N kk:mm:ss A' output like: January 1st 22 AD 13:45:33 PM
 }
 
-// get_time_string_len returns the length of the time string for the given time format
-fn (l &Log) get_time_string_len() int {
-	match l.time_format {
-		.tf_ss_micro { return 26 }
-		.tf_default { return 16 }
-		.tf_ss { return 19 }
-		.tf_ss_milli { return 23 }
-		.tf_ss_nano { return 29 }
-		.tf_rfc3339 { return 24 }
-		.tf_rfc3339_nano { return 30 }
-		.tf_hhmm { return 5 }
-		.tf_hhmmss { return 8 }
-		.tf_hhmm12 { return 5 }
-		.tf_ymmdd { return 10 }
-		.tf_ddmmy { return 10 }
-		.tf_md { return 7 }
-		.tf_custom_format { return 30 }
-	}
-}
-
 // Log represents a logging object
 pub struct Log {
 mut:

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -8,12 +8,12 @@ import time
 
 // TimeFormat define the log time string format, come from time/format.v
 pub enum TimeFormat {
-	tf_ss_micro      // YYYY-MM-DD HH:mm:ss.123456 (24h)
+	tf_ss_micro      // YYYY-MM-DD HH:mm:ss.123456 (24h) default
 	tf_default       // YYYY-MM-DD HH:mm (24h)
 	tf_ss            // YYYY-MM-DD HH:mm:ss (24h)
 	tf_ss_milli      // YYYY-MM-DD HH:mm:ss.123 (24h)
 	tf_ss_nano       // YYYY-MM-DD HH:mm:ss.123456789 (24h)
-	tf_rfc3339       // YYYY-MM-DDTHH:mm:ss.123Z default (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
+	tf_rfc3339       // YYYY-MM-DDTHH:mm:ss.123Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 	tf_rfc3339_nano  // YYYY-MM-DDTHH:mm:ss.123456789Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 	tf_hhmm          // HH:mm (24h)
 	tf_hhmmss        // HH:mm:ss (24h)
@@ -51,7 +51,7 @@ mut:
 	output_label       string
 	ofile              os.File
 	output_target      LogTarget // output to console (stdout/stderr) or file or both.
-	time_format        TimeFormat = .tf_rfc3339
+	time_format        TimeFormat = .tf_ss_micro
 	custom_time_format string     = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
 	short_tag          bool
 	always_flush       bool // flush after every single .fatal(), .error(), .warn(), .info(), .debug() call

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -114,24 +114,28 @@ pub fn (mut l Log) reopen() ! {
 	}
 }
 
+const space = ' '
+const lbracket = '['
+const rbracket = ']'
+const newline = '\n'
+
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
 	timestamp := l.time_format(time.now())
 	e := tag_to_file(level, l.short_tag)
 
 	unsafe {
-		space := ' '
 		l.ofile.write_ptr(timestamp.str, timestamp.len)
 		l.ofile.write_ptr(space.str, space.len)
 
-		l.ofile.write_ptr('['.str, 1)
+		l.ofile.write_ptr(lbracket.str, 1)
 		l.ofile.write_ptr(e.str, e.len)
-		l.ofile.write_ptr(']'.str, 1)
+		l.ofile.write_ptr(rbracket.str, 1)
 
 		l.ofile.write_ptr(space.str, space.len)
 		l.ofile.write_ptr(s.str, s.len)
 
-		l.ofile.write_ptr('\n'.str, 1)
+		l.ofile.write_ptr(newline.str, 1)
 	}
 	if l.always_flush {
 		l.flush()

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -51,8 +51,8 @@ mut:
 	output_label       string
 	ofile              os.File
 	output_target      LogTarget // output to console (stdout/stderr) or file or both.
-	time_format        TimeFormat = .tf_ss_micro
-	custom_time_format string     = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
+	time_format        TimeFormat
+	custom_time_format string = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
 	short_tag          bool
 	always_flush       bool // flush after every single .fatal(), .error(), .warn(), .info(), .debug() call
 pub mut:
@@ -136,7 +136,7 @@ pub fn (mut l Log) reopen() ! {
 
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
-	timestamp := l.time_format(time.utc())
+	timestamp := l.time_format(time.now())
 	e := tag_to_file(level, l.short_tag)
 
 	unsafe {
@@ -160,7 +160,7 @@ fn (mut l Log) log_file(s string, level Level) {
 
 // log_cli writes log line `s` with `level` to stdout.
 fn (l &Log) log_cli(s string, level Level) {
-	timestamp := l.time_format(time.utc())
+	timestamp := l.time_format(time.now())
 	e := tag_to_cli(level, l.short_tag)
 	println('${timestamp} [${e}] ${s}')
 	if l.always_flush {

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -14,6 +14,7 @@ pub enum TimeFormat {
 	tf_ss_milli      // YYYY-MM-DD HH:mm:ss.123 (24h)
 	tf_ss_nano       // YYYY-MM-DD HH:mm:ss.123456789 (24h)
 	tf_rfc3339       // YYYY-MM-DDTHH:mm:ss.123Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
+	tf_rfc3339_micro // YYYY-MM-DDTHH:mm:ss.123456Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 	tf_rfc3339_nano  // YYYY-MM-DDTHH:mm:ss.123456789Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 	tf_hhmm          // HH:mm (24h)
 	tf_hhmmss        // HH:mm:ss (24h)
@@ -31,8 +32,8 @@ mut:
 	output_label       string
 	ofile              os.File
 	output_target      LogTarget // output to console (stdout/stderr) or file or both.
-	time_format        TimeFormat
-	custom_time_format string = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
+	time_format        TimeFormat = .tf_rfc3339_micro
+	custom_time_format string     = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
 	short_tag          bool
 	always_flush       bool // flush after every single .fatal(), .error(), .warn(), .info(), .debug() call
 pub mut:
@@ -121,7 +122,7 @@ const newline = '\n'
 
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
-	timestamp := l.time_format(time.now())
+	timestamp := l.time_format(time.utc())
 	e := tag_to_file(level, l.short_tag)
 
 	unsafe {
@@ -144,7 +145,7 @@ fn (mut l Log) log_file(s string, level Level) {
 
 // log_cli writes log line `s` with `level` to stdout.
 fn (l &Log) log_cli(s string, level Level) {
-	timestamp := l.time_format(time.now())
+	timestamp := l.time_format(time.utc())
 	e := tag_to_cli(level, l.short_tag)
 	println('${timestamp} [${e}] ${s}')
 	if l.always_flush {
@@ -236,6 +237,9 @@ fn (l Log) time_format(t time.Time) string {
 		}
 		.tf_rfc3339 { // YYYY-MM-DDTHH:mm:ss.123Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 			return t.format_rfc3339()
+		}
+		.tf_rfc3339_micro { // YYYY-MM-DDTHH:mm:ss.123456Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
+			return t.format_rfc3339_micro()
 		}
 		.tf_rfc3339_nano { // YYYY-MM-DDTHH:mm:ss.123456789Z (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 			return t.format_rfc3339_nano()

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -136,15 +136,15 @@ pub fn (mut l Log) reopen() ! {
 
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
-	// timestamp := l.time_format(time.utc())
-	// e := tag_to_file(level, l.short_tag)
+	timestamp := l.time_format(time.utc())
+	e := tag_to_file(level, l.short_tag)
 
 	unsafe {
-		// space := ' '
-		// l.ofile.write_ptr(timestamp.str, timestamp.len)
-		// l.ofile.write_ptr(space.str, space.len)
-		// l.ofile.write_ptr(e.str, e.len)
-		// l.ofile.write_ptr(space.str, space.len)
+		space := ' '
+		l.ofile.write_ptr(timestamp.str, timestamp.len)
+		l.ofile.write_ptr(space.str, space.len)
+		l.ofile.write_ptr(e.str, e.len)
+		l.ofile.write_ptr(space.str, space.len)
 		l.ofile.write_ptr(s.str, s.len)
 		l.ofile.write_ptr('\n'.str, 1)
 	}

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -24,7 +24,8 @@ pub enum TimeFormat {
 	tf_custom_format // 'MMMM Do YY N kk:mm:ss A' output like: January 1st 22 AD 13:45:33 PM
 }
 
-pub fn (l &Log) get_time_string_len() int {
+// get_time_string_len returns the length of the time string for the given time format
+fn (l &Log) get_time_string_len() int {
 	match l.time_format {
 		.tf_ss_micro { return 26 }
 		.tf_default { return 16 }
@@ -135,16 +136,17 @@ pub fn (mut l Log) reopen() ! {
 
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
-	timestamp := l.time_format(time.utc())
-	e := tag_to_file(level, l.short_tag)
+	// timestamp := l.time_format(time.utc())
+	// e := tag_to_file(level, l.short_tag)
 
 	unsafe {
-		space := ' '
-		l.ofile.write_ptr(timestamp.str, timestamp.len)
-		l.ofile.write_ptr(space.str, space.len)
-		l.ofile.write_ptr(e.str, e.len)
-		l.ofile.write_ptr(space.str, space.len)
+		// space := ' '
+		// l.ofile.write_ptr(timestamp.str, timestamp.len)
+		// l.ofile.write_ptr(space.str, space.len)
+		// l.ofile.write_ptr(e.str, e.len)
+		// l.ofile.write_ptr(space.str, space.len)
 		l.ofile.write_ptr(s.str, s.len)
+		l.ofile.write_ptr('\n'.str, 1)
 	}
 	if l.always_flush {
 		l.flush()

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -143,9 +143,14 @@ fn (mut l Log) log_file(s string, level Level) {
 		space := ' '
 		l.ofile.write_ptr(timestamp.str, timestamp.len)
 		l.ofile.write_ptr(space.str, space.len)
+
+		l.ofile.write_ptr('['.str, 1)
 		l.ofile.write_ptr(e.str, e.len)
+		l.ofile.write_ptr(']'.str, 1)
+
 		l.ofile.write_ptr(space.str, space.len)
 		l.ofile.write_ptr(s.str, s.len)
+
 		l.ofile.write_ptr('\n'.str, 1)
 	}
 	if l.always_flush {

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -174,6 +174,39 @@ pub fn (t Time) format_rfc3339() string {
 	return buf.bytestr()
 }
 
+// format_rfc3339_micro returns a date string in "YYYY-MM-DDTHH:mm:ss.123456Z" format (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
+@[manualfree]
+pub fn (t Time) format_rfc3339_micro() string {
+	mut buf := [u8(`0`), `0`, `0`, `0`, `-`, `0`, `0`, `-`, `0`, `0`, `T`, `0`, `0`, `:`, `0`,
+		`0`, `:`, `0`, `0`, `.`, `0`, `0`, `0`, `0`, `0`, `0`, `Z`]
+
+	defer {
+		unsafe { buf.free() }
+	}
+
+	t_ := time_with_unix(t)
+	if t_.is_local {
+		utc_time := t_.local_to_utc()
+		int_to_byte_array_no_pad(utc_time.year, mut buf, 4)
+		int_to_byte_array_no_pad(utc_time.month, mut buf, 7)
+		int_to_byte_array_no_pad(utc_time.day, mut buf, 10)
+		int_to_byte_array_no_pad(utc_time.hour, mut buf, 13)
+		int_to_byte_array_no_pad(utc_time.minute, mut buf, 16)
+		int_to_byte_array_no_pad(utc_time.second, mut buf, 19)
+		int_to_byte_array_no_pad(utc_time.nanosecond / 1000, mut buf, 26)
+	} else {
+		int_to_byte_array_no_pad(t_.year, mut buf, 4)
+		int_to_byte_array_no_pad(t_.month, mut buf, 7)
+		int_to_byte_array_no_pad(t_.day, mut buf, 10)
+		int_to_byte_array_no_pad(t_.hour, mut buf, 13)
+		int_to_byte_array_no_pad(t_.minute, mut buf, 16)
+		int_to_byte_array_no_pad(t_.second, mut buf, 19)
+		int_to_byte_array_no_pad(t_.nanosecond / 1000, mut buf, 26)
+	}
+
+	return buf.bytestr()
+}
+
 // format_rfc3339_nano returns a date string in "YYYY-MM-DDTHH:mm:ss.123456789Z" format (24 hours, see https://www.rfc-editor.org/rfc/rfc3339.html)
 @[manualfree]
 pub fn (t Time) format_rfc3339_nano() string {

--- a/vlib/time/time_test.v
+++ b/vlib/time/time_test.v
@@ -108,6 +108,18 @@ fn test_format_rfc3339() {
 	assert utc_res.contains('T')
 }
 
+fn test_format_rfc3339_micro() {
+	res := local_time_to_test.format_rfc3339_micro()
+	assert res.ends_with('23:42.123456Z')
+	assert res.starts_with('1980-07-1')
+	assert res.contains('T')
+
+	utc_res := utc_time_to_test.format_rfc3339_micro()
+	assert utc_res.ends_with('23:42.123456Z')
+	assert utc_res.starts_with('1980-07-1')
+	assert utc_res.contains('T')
+}
+
 fn test_format_rfc3339_nano() {
 	res := local_time_to_test.format_rfc3339_nano()
 	assert res.ends_with('23:42.123456789Z')

--- a/vlib/v/slow_tests/inout/dump_expression.out
+++ b/vlib/v/slow_tests/inout/dump_expression.out
@@ -10,7 +10,7 @@
             is_opened: false
         }
         output_target: console
-        time_format: tf_ss_micro
+        time_format: tf_rfc3339_micro
         custom_time_format: 'MMMM Do YY N kk:mm:ss A'
         short_tag: false
         always_flush: false


### PR DESCRIPTION
`v wipe-cache && v -prod crun log_.v > lala.log`

### Before

```sh
max_iterations: 1000000
SPENT  354.390 ms in log.info
SPENT  354.037 ms in log.error
SPENT   40.974 ms in println
```

### After

```sh
max_iterations: 1000000
SPENT  171.269 ms in log.info
SPENT  171.246 ms in log.error
SPENT   38.279 ms in println
```

```v
import log
import benchmark

const max_iterations := 1000000

fn main() {
	println('max_iterations: $max_iterations')

 	mut l := log.Log{}
	l.set_level(.info)
	l.set_full_logpath('./info.log')

	mut b := benchmark.start()

	for i := 0; i < max_iterations; i++ {
		l.info('Hello, World!')
	}

	b.measure('log.info')

	for i := 0; i < max_iterations; i++ {
		l.error('Hello, World!')
	}

	b.measure('log.error')

	for i := 0; i < max_iterations; i++ {
		println('Hello, World!')
	}
	b.measure('println')
}
```

*Note: if I remove time related format from log module

```sh
max_iterations: 1000000
SPENT   36.868 ms in log.info
SPENT   37.979 ms in log.error
SPENT   47.548 ms in println
```

*Note2: This was just a quick tweak I discovered out of curiosity. I'm not interested in making any major improvements right now, but there are several other tweaks and tests, such as using safe-threads when have logpath defined to log without interfering with the application's performance, and reusing time variables in some cases and managing cache.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFjZDY2M2YwMmQ4YTAzZmIzNDA1YTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.8f3Z-Tt5fv0RmVMRr9tRrxFCHWny4QshjNx86T4GLcc">Huly&reg;: <b>V_0.6-21111</b></a></sub>