### PR TITLE
v: allow sumtype init by variant comptime var `T(v)` / `SumType(v)`

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3197,8 +3197,9 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 
 	if mut node.expr is ast.ComptimeSelector {
 		node.expr_type = c.comptime.get_comptime_selector_type(node.expr, node.expr_type)
+	} else if node.expr is ast.Ident && c.comptime.is_comptime_variant_var(node.expr) {
+		node.expr_type = c.comptime.type_map['${c.comptime.comptime_for_variant_var}.typ']
 	}
-
 	mut from_type := c.unwrap_generic(node.expr_type)
 	from_sym := c.table.sym(from_type)
 	final_from_sym := c.table.final_sym(from_type)

--- a/vlib/v/comptime/comptimeinfo.v
+++ b/vlib/v/comptime/comptimeinfo.v
@@ -34,6 +34,12 @@ pub fn (mut ct ComptimeInfo) is_comptime_var(node ast.Expr) bool {
 	return ct.get_ct_type_var(node) != .no_comptime
 }
 
+// is_comptime_variant_var checks if the node is related to a comptime variant variable
+@[inline]
+pub fn (mut ct ComptimeInfo) is_comptime_variant_var(node ast.Ident) bool {
+	return node.name == ct.comptime_for_variant_var
+}
+
 // get_ct_type_var gets the comptime type of the variable (.generic_param, .key_var, etc)
 @[inline]
 pub fn (mut ct ComptimeInfo) get_ct_type_var(node ast.Expr) ast.ComptimeVarKind {

--- a/vlib/v/tests/sumtype_init_by_name_test.v
+++ b/vlib/v/tests/sumtype_init_by_name_test.v
@@ -1,0 +1,31 @@
+type Sum = int | string
+
+fn get[T](val T, type_name string) T {
+	$if T is $sumtype {
+		$for v in val.variants {
+			if type_name == typeof(v.typ).name {
+				return T(v)
+			}
+		}
+	}
+	return T{}
+}
+
+fn get2[T](val T, type_name string) T {
+	$if T is $sumtype {
+		$for v in val.variants {
+			if type_name == typeof(v.typ).name {
+				return Sum(v)
+			}
+		}
+	}
+	return T{}
+}
+
+fn test_main() {
+	assert dump(get(Sum{}, 'int')) == Sum(0)
+	assert dump(get(Sum{}, 'string')) == Sum('')
+
+	assert dump(get2(Sum{}, 'int')) == Sum(0)
+	assert dump(get2(Sum{}, 'string')) == Sum('')
+}


### PR DESCRIPTION
This PR allows to initialize Sumtype through its `variant` comptime types.

e.g.

```v
type Sum = int | string

fn get[T](val T, type_name string) T {
	$if T is $sumtype {
		$for v in val.variants {
			if type_name == typeof(v.typ).name {
				return T(v)
			}
		}
	}
	return T{}
}

fn main() {
	dump(get(Sum{}, 'int')) // Sum(0)
	dump(get(Sum{}, 'string')) // Sum('')
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFjZjc2OWYwMmQ4YTAzZmIzNDA3ZDYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ULlU4oSZIOGYmiUhRsXhHRu9fon0EsFShoWs56Gi2IQ">Huly&reg;: <b>V_0.6-21113</b></a></sub>