### PR TITLE
ci: fix failing jobs after 2684ef9

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -100,5 +100,5 @@ jobs:
         run: v -skip-unused test vlib/builtin/ vlib/math vlib/flag/ vlib/os/ vlib/strconv/
       - name: Test cross compilation to Linux
         run: |
-          v -d use_openssl -cc clang -showcc -gc none -o hi -os linux examples/hello_world.v
+          v -o hi -os linux examples/hello_world.v
           v -d use_openssl -cc clang -showcc -gc none -o hi -os linux examples/veb/veb_example.v

--- a/vlib/picoev/loop_linux.c.v
+++ b/vlib/picoev/loop_linux.c.v
@@ -1,7 +1,10 @@
 module picoev
 
 #include <sys/epoll.h>
-#include <sys/cdefs.h> // needed for cross compiling to linux
+
+$if !musl ? {
+	#include <sys/cdefs.h> // needed for cross compiling to linux
+}
 
 fn C.epoll_create(int) int
 fn C.epoll_wait(int, voidptr, int, int) int


### PR DESCRIPTION
Fixes the failures in the `alpine-docker-musl-gcc` and `ubuntu-docker-musl` jobs, that are compiled using musl, which does not have a `sys/cdefs.h` header.