### PR TITLE
builtin, cgen: improve the assert informations (related #22666)

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -78,7 +78,11 @@ pub fn (ami &VAssertMetaInfo) free() {
 fn __print_assert_failure(i &VAssertMetaInfo) {
 	eprintln('${i.fpath}:${i.line_nr + 1}: FAIL: fn ${i.fn_name}: assert ${i.src}')
 	if i.op.len > 0 && i.op != 'call' {
-		eprintln('   left value: ${i.llabel} = ${i.lvalue}')
+		if i.llabel == i.lvalue {
+			eprintln('  left value: ${i.llabel}')
+		} else {
+			eprintln('  left value: ${i.llabel} = ${i.lvalue}')
+		}
 		if i.rlabel == i.rvalue {
 			eprintln('  right value: ${i.rlabel}')
 		} else {

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -179,21 +179,21 @@ fn (mut g Gen) gen_assert_metainfo(node ast.AssertStmt, kind AssertMetainfoKind)
 
 fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 	// eprintln('> gen_assert_single_expr typ: $typ | expr: $expr | typeof(expr): ${typeof(expr)}')
-	unknown_value := '*unknown value*'
+	expr_str := '${expr}'
 	match expr {
 		ast.CastExpr {
 			if typ.is_float() || g.table.final_sym(typ).is_float() {
 				g.gen_expr_to_string(expr.expr, typ)
 			} else {
-				g.write(ctoslit(unknown_value))
+				g.write(ctoslit(expr_str))
 			}
 		}
 		ast.IfExpr, ast.MatchExpr {
-			g.write(ctoslit(unknown_value))
+			g.write(ctoslit(expr_str))
 		}
 		ast.IndexExpr {
 			if expr.index is ast.RangeExpr {
-				g.write(ctoslit(unknown_value))
+				g.write(ctoslit(expr_str))
 			} else {
 				g.gen_expr_to_string(expr, typ)
 			}
@@ -203,7 +203,7 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 				// TODO: remove this check;
 				// vlib/builtin/map_test.v (a map of &int, set to &int(0)) fails
 				// without special casing ast.CastExpr here
-				g.write(ctoslit(unknown_value))
+				g.write(ctoslit(expr_str))
 			} else {
 				g.gen_expr_to_string(expr, typ)
 			}

--- a/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.run.out
+++ b/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.run.out
@@ -1,0 +1,10 @@
+vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:5: fn test_ab
+   > assert a == b
+     Left value (len: 6): `Sum(1)`
+    Right value (len: 6): `Sum(2)`
+
+vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:9: fn test_sumtype_literals
+   > assert main.Sum(1) == main.Sum(2)
+     Left value (len: 11): `main.Sum(1)`
+    Right value (len: 11): `main.Sum(2)`
+

--- a/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.skip_unused.run.out
@@ -1,0 +1,10 @@
+vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:5: fn test_ab
+   > assert a == b
+     Left value (len: 6): `Sum(1)`
+    Right value (len: 6): `Sum(2)`
+
+vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:9: fn test_sumtype_literals
+   > assert main.Sum(1) == main.Sum(2)
+     Left value (len: 11): `main.Sum(1)`
+    Right value (len: 11): `main.Sum(2)`
+

--- a/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv
+++ b/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv
@@ -1,0 +1,10 @@
+type Sum = int | string
+
+fn test_ab() {
+	a, b := Sum(1), Sum(2)
+	assert a == b
+}
+
+fn test_sumtype_literals() {
+	assert Sum(1) == Sum(2)
+}


### PR DESCRIPTION
This PR improve the assert informations  (related #22666).

```v
type Sum = int | string

fn main() {
	assert Sum(1) == Sum(2)
}

PS D:\Test\v\tt1> v run .    
.\\tt1.v:4: FAIL: fn main.main: assert main.Sum(1) == main.Sum(2)
  left value: main.Sum(1)
  right value: main.Sum(2)
V panic: Assertion failed...
v hash: 14b1a14
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.01JB6ZGGR5EPG0CM0FD2MRVCFX.tmp.c:7314: at _v_panic: Backtrace
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.01JB6ZGGR5EPG0CM0FD2MRVCFX.tmp.c:13684: by main__main
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.01JB6ZGGR5EPG0CM0FD2MRVCFX.tmp.c:13721: by wmain
00466ea8 : by ???
0046700b : by ???
7ffe207e259d : by ???
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFlMzNjMDI3Y2M3NjgxYzYyMTA1ZTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.u-dQbS_udwiBU2EHiFqDYhFlxS-HQCePpcUBVzKorVQ">Huly&reg;: <b>V_0.6-21117</b></a></sub>