### PR TITLE
x.json2.decoder2: init support to sumtype

### DIFF
--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -625,36 +625,26 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 		$for v in val.variants {
 			if value_info.value_kind == .string_ {
 				$if v.typ in [string, time.Time] {
-					unsafe {
-						val = T(v)
-					}
+					val = T(v)
 				}
 			} else if value_info.value_kind == .number {
 				$if v.typ in [$float, $int, $enum] {
-					unsafe {
-						val = T(v)
-					}
+					val = T(v)
 				}
 			} else if value_info.value_kind == .boolean {
 				$if v.typ is bool {
-					unsafe {
-						val = T(v)
-					}
+					val = T(v)
 				}
 			} else if value_info.value_kind == .object {
 				$if v.typ is $map {
-					unsafe {
-						val = T(v)
-					}
+					val = T(v)
 				} $else $if v.typ is $struct {
 					// Will only be supported when json object has field "_type"
 					error('cannot encode value with ${typeof(val).name} type')
 				}
 			} else if value_info.value_kind == .array {
 				$if v.typ is $array {
-					unsafe {
-						val = T(v)
-					}
+					val = T(v)
 				}
 			}
 		}

--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -549,6 +549,19 @@ pub fn decode[T](val string) !T {
 	return result
 }
 
+fn (mut decoder Decoder) get_decoded_sumtype_workaround[T](initialized_sumtype T) !T {
+	$if initialized_sumtype is $sumtype {
+		$for v in initialized_sumtype.variants {
+			if initialized_sumtype is v {
+				mut val := initialized_sumtype
+				decoder.decode_value(mut val)!
+				return T(val)
+			}
+		}
+	}
+	return initialized_sumtype
+}
+
 // decode_value decodes a value from the JSON nodes.
 fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 	$if T is $option {
@@ -607,10 +620,47 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 			val = string_buffer.bytestr()
 		}
 	} $else $if T.unaliased_typ is $sumtype {
+		value_info := decoder.current_node.value
+
 		$for v in val.variants {
-			if val is v {
-				decoder.decode_value(val)
+			if value_info.value_kind == .string_ {
+				$if v.typ in [string, time.Time] {
+					unsafe {
+						val = T(v)
+					}
+				}
+			} else if value_info.value_kind == .number {
+				$if v.typ in [$float, $int, $enum] {
+					unsafe {
+						val = T(v)
+					}
+				}
+			} else if value_info.value_kind == .boolean {
+				$if v.typ is bool {
+					unsafe {
+						val = T(v)
+					}
+				}
+			} else if value_info.value_kind == .object {
+				$if v.typ is $map {
+					unsafe {
+						val = T(v)
+					}
+				} $else $if v.typ is $struct {
+					// Will only be supported when json object has field "_type"
+					error('cannot encode value with ${typeof(val).name} type')
+				}
+			} else if value_info.value_kind == .array {
+				$if v.typ is $array {
+					unsafe {
+						val = T(v)
+					}
+				}
 			}
+		}
+		decoded_sumtype := decoder.get_decoded_sumtype_workaround(val)!
+		unsafe {
+			*val = decoded_sumtype
 		}
 	} $else $if T.unaliased_typ is time.Time {
 		time_info := decoder.current_node.value

--- a/vlib/x/json2/decoder2/tests/json_sumtype_test.v
+++ b/vlib/x/json2/decoder2/tests/json_sumtype_test.v
@@ -1,0 +1,36 @@
+import x.json2.decoder2 as json
+
+type Prices = Price | []Price
+
+pub struct ShopResponseData {
+	attributes Attributes
+}
+
+struct Attributes {
+	price ?Prices
+}
+
+struct Price {
+	net f64
+}
+
+type Animal = Cat | Dog
+
+struct Cat {
+	cat_name string
+}
+
+struct Dog {
+	dog_name string
+}
+
+type Sum = int | string | bool
+
+fn test_simple_sum_type() {
+	assert json.decode[Sum]('1')! == Sum(1)
+
+	assert json.decode[Sum]('"hello"')! == Sum('hello')
+
+	assert json.decode[Sum]('true')! == Sum(true)
+	assert json.decode[Sum]('false')! == Sum(false)
+}

--- a/vlib/x/json2/decoder2/tests/json_sumtype_test_todo.vv
+++ b/vlib/x/json2/decoder2/tests/json_sumtype_test_todo.vv
@@ -1,0 +1,109 @@
+import x.json2.decoder2 as json
+
+type Prices = Price | []Price
+
+pub struct ShopResponseData {
+	attributes Attributes
+}
+
+struct Attributes {
+	price ?Prices
+}
+
+struct Price {
+	net f64
+}
+
+type Animal = Cat | Dog
+
+struct Cat {
+	cat_name string
+}
+
+struct Dog {
+	dog_name string
+}
+
+type Sum = int | string | bool
+
+fn test_main() {
+	data := '{"attributes": {"price": [{"net": 1, "_type": "Price"}, {"net": 2, "_type": "Price"}]}}'
+	entity := json.decode[ShopResponseData](data) or { panic(err) }
+	assert entity == ShopResponseData{
+		attributes: Attributes{
+			price: Prices([Price{
+				net: 1
+			}, Price{
+				net: 2
+			}])
+		}
+	}
+
+	data2 := '{"attributes": {"price": {"net": 1, "_type": "Price"}}}'
+	entity2 := json.decode[ShopResponseData](data2) or { panic(err) }
+	assert entity2 == ShopResponseData{
+		attributes: Attributes{
+			price: Prices(Price{
+				net: 1
+			})
+		}
+	}
+
+	data3 := json.encode(ShopResponseData{
+		attributes: Attributes{
+			price: Prices([Price{
+				net: 1.2
+			}])
+		}
+	})
+	assert data3 == '{"attributes":{"price":[{"net":1.2,"_type":"Price"}]}}'
+
+	entity3 := json.decode[ShopResponseData](data3) or { panic(err) }
+	assert entity3 == ShopResponseData{
+		attributes: Attributes{
+			price: Prices([Price{
+				net: 1.2
+			}])
+		}
+	}
+}
+
+fn test_sum_types() {
+	data1 := json.encode(Animal(Dog{
+		dog_name: 'Caramelo'
+	}))
+	assert data1 == '{"dog_name":"Caramelo","_type":"Dog"}'
+
+	s := '{"_type":"Cat","cat_name":"Whiskers"}'
+	animal := json.decode[Animal](s) or {
+		println(err)
+		assert false
+		return
+	}
+
+	assert animal is Cat
+	if animal is Cat {
+		assert animal.cat_name == 'Whiskers'
+	} else {
+		assert false, 'Wrong sumtype decode. In this case animal is a Cat'
+	}
+
+	s2 := '[{"_type":"Cat","cat_name":"Whiskers"}, {"_type":"Dog","dog_name":"Goofie"}]'
+
+	animals := json.decode[[]Animal](s2) or {
+		println(err)
+		assert false
+		return
+	}
+
+	assert animals.len == 2
+	assert animals[0] is Cat
+	assert animals[1] is Dog
+	cat := animals[0] as Cat
+	dog := animals[1] as Dog
+	assert cat.cat_name == 'Whiskers'
+	assert dog.dog_name == 'Goofie'
+
+	j := json.encode(animals[0])
+	assert j == '{"cat_name":"Whiskers","_type":"Cat"}'
+}


### PR DESCRIPTION
```v
type Sum = int | string | bool

fn test_simple_sum_type() {
	assert json.decode[Sum]('1')! == Sum(1)

	assert json.decode[Sum]('"hello"')! == Sum('hello')

	assert json.decode[Sum]('true')! == Sum(true)
	assert json.decode[Sum]('false')! == Sum(false)
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFlM2YzZDI3Y2M3NjgxYzYyMTA2Y2QiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Tw5qqbMVJ6jfIG04yyGFnja9ehsKe3nUChu1l7GEslA">Huly&reg;: <b>V_0.6-21118</b></a></sub>