### PR TITLE
cgen: fix dump of alias to option fn type

### DIFF
--- a/vlib/v/tests/options/option_fn_alias_test.v
+++ b/vlib/v/tests/options/option_fn_alias_test.v
@@ -1,0 +1,12 @@
+type Foo = fn (bar string)
+
+fn test_main() {
+	mut func := ?Foo(none)
+	res := dump(func)
+	assert res == none
+
+	mut func2 := ?Foo(fn (bar string) {})
+	res2 := dump(func2)
+	assert res2 != none
+	assert res2?.str() == 'fn (string)'
+}


### PR DESCRIPTION
Fix #22670

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFlYWNlMTI3Y2M3NjgxYzYyMmRiOTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.XcnL0T7fg0VIjY1FMyFVGutFpSYRPH4_FPjNpNZtjwY">Huly&reg;: <b>V_0.6-21125</b></a></sub>