### PR TITLE
cgen: fix array append map value with or expr (fix #22674)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -436,9 +436,9 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 			zero := g.type_default(info.value_type)
 			g.write('${zero} })))')
 		}
-	} else if g.inside_map_postfix || g.inside_map_infix || g.inside_map_index
-		|| g.inside_array_index
-		|| (g.is_assign_lhs && !g.is_arraymap_set && get_and_set_types) {
+	} else if !gen_or && (g.inside_map_postfix || g.inside_map_infix
+		|| g.inside_map_index || g.inside_array_index || (g.is_assign_lhs && !g.is_arraymap_set
+		&& get_and_set_types)) {
 		zero := g.type_default(info.value_type)
 		if node.is_setter {
 			g.write('(*(${val_type_str}*)map_get_and_set((map*)')

--- a/vlib/v/tests/builtin_arrays/array_append_map_with_or_expr_test.v
+++ b/vlib/v/tests/builtin_arrays/array_append_map_with_or_expr_test.v
@@ -1,0 +1,10 @@
+fn test_array_append_map_with_or_expr() {
+	foobar := {
+		'foo': 'Foo'
+		'bar': 'Bar'
+	}
+	mut arr := []string{}
+	arr << foobar['foo']
+	arr << foobar['baz'] or { 'Unknown' }
+	assert arr == ['Foo', 'Unknown']
+}


### PR DESCRIPTION
This PR fix array append map value with or expr (fix #22674).

- Fix array append map value with or expr.
- Add test.

```v
fn main() {
	foobar := {
		'foo': 'Foo'
		'bar': 'Bar'
	}
	mut arr := []string{}
	arr << foobar['foo']
	arr << foobar['baz'] or { 'Unknown' }
	assert arr == ['Foo', 'Unknown']
}

PS D:\Test\v\tt1> v run .
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFlZjljNzI3Y2M3NjgxYzYyMmViMjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0._4l6IA64IyStrPA6EMhiZ6GFtK6nGf9Koul8XqHPlJI">Huly&reg;: <b>V_0.6-21127</b></a></sub>