### PR TITLE
ast: improve the assert informations (related #22668)

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -450,7 +450,8 @@ pub fn (x &Expr) str() string {
 			return x.val.str()
 		}
 		CastExpr {
-			return '${util.strip_main_name(global_table.type_to_str(x.typ))}(${x.expr.str()})'
+			type_name := util.strip_main_name(global_table.type_to_str(x.typ))
+			return '${type_name}(${x.expr.str()})'
 		}
 		CallExpr {
 			sargs := args2str(x.args)
@@ -513,7 +514,7 @@ pub fn (x &Expr) str() string {
 				return x.cached_name
 			}
 			unsafe {
-				x.cached_name = x.name.clone()
+				x.cached_name = util.strip_main_name(x.name.clone())
 			}
 			return x.cached_name
 		}

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -450,7 +450,11 @@ pub fn (x &Expr) str() string {
 			return x.val.str()
 		}
 		CastExpr {
-			return '${global_table.type_to_str(x.typ)}(${x.expr.str()})'
+			mut type_name := global_table.type_to_str(x.typ)
+			if global_table.cur_fn != unsafe { nil } {
+				type_name = util.no_cur_mod(type_name, global_table.cur_fn.mod)
+			}
+			return '${type_name}(${x.expr.str()})'
 		}
 		CallExpr {
 			sargs := args2str(x.args)

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -477,7 +477,11 @@ pub fn (x &Expr) str() string {
 			if x.name.contains('__static__') {
 				return '${x.mod}.${x.get_name()}(${sargs})${propagate_suffix}'
 			}
-			return '${x.mod}.${x.get_name()}(${sargs})${propagate_suffix}'
+			if x.mod == 'main' {
+				return '${x.get_name()}(${sargs})${propagate_suffix}'
+			} else {
+				return '${x.mod}.${x.get_name()}(${sargs})${propagate_suffix}'
+			}
 		}
 		CharLiteral {
 			return '`${x.val}`'

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -450,11 +450,7 @@ pub fn (x &Expr) str() string {
 			return x.val.str()
 		}
 		CastExpr {
-			mut type_name := global_table.type_to_str(x.typ)
-			if global_table.cur_fn != unsafe { nil } {
-				type_name = util.no_cur_mod(type_name, global_table.cur_fn.mod)
-			}
-			return '${type_name}(${x.expr.str()})'
+			return '${util.strip_main_name(global_table.type_to_str(x.typ))}(${x.expr.str()})'
 		}
 		CallExpr {
 			sargs := args2str(x.args)

--- a/vlib/v/checker/tests/globals_run/function_stored_in_global.run.out
+++ b/vlib/v/checker/tests/globals_run/function_stored_in_global.run.out
@@ -1,4 +1,4 @@
 [vlib/v/checker/tests/globals_run/function_stored_in_global.vv:14] voidptr(abc) == voidptr(cpu_get_id): true
-[vlib/v/checker/tests/globals_run/function_stored_in_global.vv:15] main.cpu_get_id(): 123
+[vlib/v/checker/tests/globals_run/function_stored_in_global.vv:15] cpu_get_id(): 123
 [vlib/v/checker/tests/globals_run/function_stored_in_global.vv:16] abc(): 123
-[vlib/v/checker/tests/globals_run/function_stored_in_global.vv:17] abc() == main.cpu_get_id(): true
+[vlib/v/checker/tests/globals_run/function_stored_in_global.vv:17] abc() == cpu_get_id(): true

--- a/vlib/v/checker/tests/globals_run/function_stored_in_global.run.out
+++ b/vlib/v/checker/tests/globals_run/function_stored_in_global.run.out
@@ -1,4 +1,4 @@
-[vlib/v/checker/tests/globals_run/function_stored_in_global.vv:14] voidptr(main.abc) == voidptr(cpu_get_id): true
+[vlib/v/checker/tests/globals_run/function_stored_in_global.vv:14] voidptr(abc) == voidptr(cpu_get_id): true
 [vlib/v/checker/tests/globals_run/function_stored_in_global.vv:15] main.cpu_get_id(): 123
 [vlib/v/checker/tests/globals_run/function_stored_in_global.vv:16] abc(): 123
 [vlib/v/checker/tests/globals_run/function_stored_in_global.vv:17] abc() == main.cpu_get_id(): true

--- a/vlib/v/slow_tests/inout/dump_sumtype_of_fntype.out
+++ b/vlib/v/slow_tests/inout/dump_sumtype_of_fntype.out
@@ -1,1 +1,1 @@
-[vlib/v/slow_tests/inout/dump_sumtype_of_fntype.vv:10] main.MyFnSumtype(main.f): MyFnSumtype(fn (int) v.ast.Expr)
+[vlib/v/slow_tests/inout/dump_sumtype_of_fntype.vv:10] MyFnSumtype(f): MyFnSumtype(fn (int) v.ast.Expr)

--- a/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.run.out
+++ b/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.run.out
@@ -4,7 +4,6 @@ vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:5: fn test_ab
     Right value (len: 6): `Sum(2)`
 
 vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:9: fn test_sumtype_literals
-   > assert main.Sum(1) == main.Sum(2)
-     Left value (len: 11): `main.Sum(1)`
-    Right value (len: 11): `main.Sum(2)`
-
+   > assert Sum(1) == Sum(2)
+     Left value (len: 6): `Sum(1)`
+    Right value (len: 6): `Sum(2)`

--- a/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.skip_unused.run.out
@@ -4,7 +4,6 @@ vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:5: fn test_ab
     Right value (len: 6): `Sum(2)`
 
 vlib/v/tests/skip_unused/assert_of_sumtype_values_works_test.vv:9: fn test_sumtype_literals
-   > assert main.Sum(1) == main.Sum(2)
-     Left value (len: 11): `main.Sum(1)`
-    Right value (len: 11): `main.Sum(2)`
-
+   > assert Sum(1) == Sum(2)
+     Left value (len: 6): `Sum(1)`
+    Right value (len: 6): `Sum(2)`


### PR DESCRIPTION
This PR improve the assert informations (related #22668).

```v
type Sum = int | string

fn main() {
   assert Sum(1) == Sum(2)
}

PS D:\Test\v\tt1> v run .
.\\tt1.v:4: FAIL: fn main.main: assert Sum(1) == Sum(2)
  left value: Sum(1)
  right value: Sum(2)
V panic: Assertion failed...
v hash: 9c72d94
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.01JB994DG71BPHW0GK9AEFXYZS.tmp.c:7314: at _v_panic: Backtrace
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.01JB994DG71BPHW0GK9AEFXYZS.tmp.c:13684: by main__main
C:/Users/yuyi9/AppData/Local/Temp/v_0/tt1.01JB994DG71BPHW0GK9AEFXYZS.tmp.c:13721: by wmain
00466ea8 : by ???
0046700b : by ???
7ffe207e259d : by ???
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFmNjBmMDI3Y2M3NjgxYzYyMmZlMzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.4wyBbAPhNxc1WtT6IVHN21_dWwC3I_svRHefqnAHqdQ">Huly&reg;: <b>V_0.6-21128</b></a></sub>