### PR TITLE
parser: fix generic struct init detection `T{}`

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -72,6 +72,9 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 			} else if p.inside_for_expr && p.tok.kind == .name && p.tok.lit[0].is_capital()
 				&& p.peek_tok.kind == .lcbr && p.peek_token(2).kind in [.rcbr, .name] {
 				node = p.struct_init(p.mod + '.' + p.tok.lit, .normal, false)
+			} else if p.is_generic_name() && p.peek_tok.kind == .lcbr
+				&& p.peek_token(2).kind == .rcbr {
+				node = p.struct_init(p.mod + '.' + p.tok.lit, .normal, false)
 			} else {
 				if p.inside_comptime_if && p.is_generic_name() && p.peek_tok.kind != .dot {
 					// $if T is string {}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -73,7 +73,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				&& p.peek_tok.kind == .lcbr && p.peek_token(2).kind in [.rcbr, .name] {
 				node = p.struct_init(p.mod + '.' + p.tok.lit, .normal, false)
 			} else if p.is_generic_name() && p.peek_tok.kind == .lcbr
-				&& p.peek_token(2).kind == .rcbr {
+				&& p.peek_token(2).kind == .rcbr && p.peek_token(2).line_nr == p.tok.line_nr {
 				node = p.struct_init(p.mod + '.' + p.tok.lit, .normal, false)
 			} else {
 				if p.inside_comptime_if && p.is_generic_name() && p.peek_tok.kind != .dot {

--- a/vlib/v/tests/structs/struct_generic_init_test.v
+++ b/vlib/v/tests/structs/struct_generic_init_test.v
@@ -1,0 +1,16 @@
+struct St[T] {
+mut:
+	a T
+}
+
+fn (mut s St[T]) f(e T) {
+	if e != T{} {
+		s.a = e
+	}
+}
+
+fn test_main() {
+	mut s := St[int]{}
+	s.f(1)
+	assert s.a == 1
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFmNzk1NDI3Y2M3NjgxYzYyMzAxZGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.EUc6ZpvN8Hk6qpIPE4g7lsxiz-7oAJGrjSDqvWAdD8s">Huly&reg;: <b>V_0.6-21131</b></a></sub>