### PR TITLE
checker: fix missing check for fn var with generic return inherited to anon fn

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -608,12 +608,14 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 			c.error('original `${parent_var.name}` is immutable, declare it with `mut` to make it mutable',
 				var.pos)
 		}
-		parent_var_sym := c.table.final_sym(parent_var.typ)
-		if parent_var_sym.info is ast.FnType {
-			ret_typ := c.unwrap_generic(parent_var_sym.info.func.return_type)
-			if ret_typ.has_flag(.generic) {
-				c.error('original `${parent_var.name}` is a function that returns ${c.table.type_to_str(ret_typ)}. You must add the generic type to generic type list.',
-					var.pos)
+		if parent_var.typ != ast.no_type {
+			parent_var_sym := c.table.final_sym(parent_var.typ)
+			if parent_var_sym.info is ast.FnType {
+				ret_typ := c.unwrap_generic(parent_var_sym.info.func.return_type)
+				if ret_typ.has_flag(.generic) {
+					c.error('original `${parent_var.name}` is a function that returns ${c.table.type_to_str(ret_typ)}. You must add the generic type to generic type list.',
+						var.pos)
+				}
 			}
 		}
 		if parent_var.expr is ast.IfGuardExpr {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -608,6 +608,14 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 			c.error('original `${parent_var.name}` is immutable, declare it with `mut` to make it mutable',
 				var.pos)
 		}
+		parent_var_sym := c.table.final_sym(parent_var.typ)
+		if parent_var_sym.info is ast.FnType {
+			ret_typ := c.unwrap_generic(parent_var_sym.info.func.return_type)
+			if ret_typ.has_flag(.generic) {
+				c.error('original `${parent_var.name}` is a function that returns ${c.table.type_to_str(ret_typ)}. You must add the generic type to generic type list.',
+					var.pos)
+			}
+		}
 		if parent_var.expr is ast.IfGuardExpr {
 			sym := c.table.sym(parent_var.expr.expr_type)
 			if sym.info is ast.MultiReturn {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -613,8 +613,14 @@ fn (mut c Checker) anon_fn(mut node ast.AnonFn) ast.Type {
 			if parent_var_sym.info is ast.FnType {
 				ret_typ := c.unwrap_generic(parent_var_sym.info.func.return_type)
 				if ret_typ.has_flag(.generic) {
-					c.error('original `${parent_var.name}` is a function that returns ${c.table.type_to_str(ret_typ)}. You must add the generic type to generic type list.',
-						var.pos)
+					generic_names := c.table.generic_type_names(ret_typ)
+					curr_list := c.table.cur_fn.generic_names.join(', ')
+					for name in generic_names {
+						if name !in c.table.cur_fn.generic_names {
+							c.error('Add the generic type `${name}` to the anon fn generic list type, that is currently `[${curr_list}]`',
+								var.pos)
+						}
+					}
 				}
 			}
 		}

--- a/vlib/v/checker/tests/anon_missing_generic_err.out
+++ b/vlib/v/checker/tests/anon_missing_generic_err.out
@@ -1,14 +1,21 @@
 vlib/v/checker/tests/anon_missing_generic_err.vv:8:2: notice: uninitialized `fn` struct fields are not allowed, since they can result in segfaults; use `?fn` or `@[required]` or initialize the field with `=` (if you absolutely want to have unsafe function pointers, use `= unsafe { nil }`)
     6 | 
     7 | struct Factory {
-    8 |     build fn()!
-      |     ~~~~~~~~~~~
+    8 |     build fn () !
+      |     ~~~~~~~~~~~~~
     9 | }
-   10 | fn  inject[T](mut serv T)!{
-vlib/v/checker/tests/anon_missing_generic_err.vv:20:14: error: original `factory` is a function that returns !E. You must add the generic type to generic type list.
-   18 | fn use_factory[F, E](factory fn(dep F) !E) Factory{
-   19 |     return Factory{
-   20 |         build: fn [factory][F]()!{
+   10 |
+vlib/v/checker/tests/anon_missing_generic_err.vv:21:14: error: original `factory` is a function that returns !E. You must add the generic type to generic type list.
+   19 | fn use_factory[F, E](factory fn (dep F) !E) Factory {
+   20 |     return Factory{
+   21 |         build: fn [factory] [F]() ! {
       |                    ~~~~~~~
-   21 |                 mut dep := F{}
-   22 |                 inject[F](mut dep)!
+   22 |             mut dep := F{}
+   23 |             inject[F](mut dep)!
+vlib/v/checker/tests/anon_missing_generic_err.vv:12:16: error: $for expects a type name or variable name to be used here, but F is not a type or variable name
+   10 | 
+   11 | fn inject[T](mut serv T) ! {
+   12 |     $for field in T.fields {
+      |                   ^
+   13 |         if field.typ is string {
+   14 |             serv.$(field.name) = 'Hello world!'

--- a/vlib/v/checker/tests/anon_missing_generic_err.out
+++ b/vlib/v/checker/tests/anon_missing_generic_err.out
@@ -5,7 +5,7 @@ vlib/v/checker/tests/anon_missing_generic_err.vv:8:2: notice: uninitialized `fn`
       |     ~~~~~~~~~~~~~
     9 | }
    10 |
-vlib/v/checker/tests/anon_missing_generic_err.vv:21:14: error: original `factory` is a function that returns !E. You must add the generic type to generic type list.
+vlib/v/checker/tests/anon_missing_generic_err.vv:21:14: error: Add the generic type `E` to the anon fn generic list type, that is currently `[F]`
    19 | fn use_factory[F, E](factory fn (dep F) !E) Factory {
    20 |     return Factory{
    21 |         build: fn [factory] [F]() ! {

--- a/vlib/v/checker/tests/anon_missing_generic_err.out
+++ b/vlib/v/checker/tests/anon_missing_generic_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/anon_missing_generic_err.vv:8:2: notice: uninitialized `fn` struct fields are not allowed, since they can result in segfaults; use `?fn` or `@[required]` or initialize the field with `=` (if you absolutely want to have unsafe function pointers, use `= unsafe { nil }`)
+    6 | 
+    7 | struct Factory {
+    8 |     build fn()!
+      |     ~~~~~~~~~~~
+    9 | }
+   10 | fn  inject[T](mut serv T)!{
+vlib/v/checker/tests/anon_missing_generic_err.vv:20:14: error: original `factory` is a function that returns !E. You must add the generic type to generic type list.
+   18 | fn use_factory[F, E](factory fn(dep F) !E) Factory{
+   19 |     return Factory{
+   20 |         build: fn [factory][F]()!{
+      |                    ~~~~~~~
+   21 |                 mut dep := F{}
+   22 |                 inject[F](mut dep)!

--- a/vlib/v/checker/tests/anon_missing_generic_err.vv
+++ b/vlib/v/checker/tests/anon_missing_generic_err.vv
@@ -1,0 +1,33 @@
+struct Test {
+	something string
+}
+
+struct Dependency {}
+
+struct Factory {
+	build fn () !
+}
+
+fn inject[T](mut serv T) ! {
+	$for field in T.fields {
+		if field.typ is string {
+			serv.$(field.name) = 'Hello world!'
+		}
+	}
+}
+
+fn use_factory[F, E](factory fn (dep F) !E) Factory {
+	return Factory{
+		build: fn [factory] [F]() ! {
+			mut dep := F{}
+			inject[F](mut dep)!
+			dump(factory(dep)!)
+		}
+	}
+}
+
+use_factory[Dependency, Test](fn (dep Dependency) !Test {
+	return Test{
+		something: 'daleks!'
+	}
+}).build()!


### PR DESCRIPTION
Fix #19045

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFmOGI4YjI3Y2M3NjgxYzYyMzA1MmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.y_yJhgBb7bGyafNUS3ZbiXYuO3GcrLTWVTX_2SvpD7Y">Huly&reg;: <b>V_0.6-21132</b></a></sub>