### PR TITLE
checker: allow for `f() or { T{} }` part 2 (handle the case of an ignored result as well) (see also #22672)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1472,6 +1472,9 @@ fn (mut c Checker) check_or_last_stmt(mut stmt ast.Stmt, ret_type ast.Type, expr
 						return
 					}
 				}
+				if expr_return_type.has_flag(.generic) {
+					return
+				}
 				// opt_returning_string() or { ... 123 }
 				type_name := c.table.type_to_str(stmt.typ)
 				expr_return_type_name := c.table.type_to_str(expr_return_type)

--- a/vlib/v/tests/generics/generic_default_expression_in_or_block_test.v
+++ b/vlib/v/tests/generics/generic_default_expression_in_or_block_test.v
@@ -16,6 +16,7 @@ fn (mut s St[T]) peek_or_default() T {
 }
 
 fn (mut s St[T]) push(e T) {
+	s.peek() or { T{} }
 	x := s.peek() or { T{} } // this is deliberate
 	$if x is $array {
 		dump(x)


### PR DESCRIPTION
This is continuation of #22672 .

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzFmZTg0ZDI3Y2M3NjgxYzYyMzFkMmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lH1B4aIHYvnK4HyYMC_YOvGi_byJvv7Tarj-Is1hnIM">Huly&reg;: <b>V_0.6-21136</b></a></sub>