### PR TITLE
x.json2.decoder: full support sumtypes

### DIFF
--- a/vlib/x/json2/decoder2/decode_sumtype.v
+++ b/vlib/x/json2/decoder2/decode_sumtype.v
@@ -1,0 +1,70 @@
+module decoder2
+
+import time
+
+fn (mut decoder Decoder) get_decoded_sumtype_workaround[T](initialized_sumtype T) !T {
+	$if initialized_sumtype is $sumtype {
+		$for v in initialized_sumtype.variants {
+			if initialized_sumtype is v {
+				mut val := initialized_sumtype
+				decoder.decode_value(mut val)!
+				return T(val)
+			}
+		}
+	}
+	return initialized_sumtype
+}
+
+fn init_sumtype_by_value_kind[T](mut val T, value_info ValueInfo) ! {
+	$for v in val.variants {
+		if value_info.value_kind == .string_ {
+			$if v.typ is string {
+				val = T(v)
+				return
+			} $else $if v.typ is time.Time {
+				val = T(v)
+				return
+			}
+		} else if value_info.value_kind == .number {
+			$if v.typ is $float {
+				val = T(v)
+				return
+			} $else $if v.typ is $int {
+				val = T(v)
+				return
+			} $else $if v.typ is $enum {
+				val = T(v)
+				return
+			}
+		} else if value_info.value_kind == .boolean {
+			$if v.typ is bool {
+				val = T(v)
+				return
+			}
+		} else if value_info.value_kind == .object {
+			$if v.typ is $map {
+				val = T(v)
+				return
+			} $else $if v.typ is $struct {
+				// Will only be supported when json object has field "_type"
+				error('cannot encode value with ${typeof(val).name} type')
+			}
+		} else if value_info.value_kind == .array {
+			$if v.typ is $array {
+				val = T(v)
+				return
+			}
+		}
+	}
+}
+
+fn (mut decoder Decoder) decode_sumtype[T](mut val T) ! {
+	value_info := decoder.current_node.value
+
+	init_sumtype_by_value_kind(mut val, value_info)!
+
+	decoded_sumtype := decoder.get_decoded_sumtype_workaround(val)!
+	unsafe {
+		*val = decoded_sumtype
+	}
+}

--- a/vlib/x/json2/decoder2/tests/bench.v
+++ b/vlib/x/json2/decoder2/tests/bench.v
@@ -19,7 +19,7 @@ pub struct Stru2 {
 	churrasco string
 }
 
-type SumTypes = StructType[string] | bool | int | string | time.Time
+type SumTypes = Stru | bool | int | string | time.Time
 type StringAlias = string
 type IntAlias = int
 
@@ -48,7 +48,7 @@ mut:
 }
 
 fn main() {
-	json_data := '{"val": 1, "val2": "lala", "val3": {"a": 2, "churrasco": "leleu"}}'
+	json_data := '{"_type": "Stru", "val": 1, "val2": "lala", "val3": {"a": 2, "churrasco": "leleu"}}'
 	json_data1 := '{"val": "2"}'
 	json_data2 := '{"val": 2}'
 
@@ -71,6 +71,18 @@ fn main() {
 	}
 
 	b.measure('old_json.decode(Stru, json_data)!\n')
+
+	for i := 0; i < max_iterations; i++ {
+		_ := decoder2.decode[SumTypes](json_data)!
+	}
+
+	b.measure('decoder2.decode[SumTypes](json_data)!')
+
+	for i := 0; i < max_iterations; i++ {
+		_ := old_json.decode(SumTypes, json_data)!
+	}
+
+	b.measure('old_json.decode(SumTypes, json_data)!\n')
 
 	// StructType[string] **********************************************************
 	for i := 0; i < max_iterations; i++ {
@@ -185,4 +197,18 @@ fn main() {
 	}
 
 	b.measure('decoder2.decode[StringAlias](\'"abcdefghijklimnopqrstuv"\')!')
+
+	println('\n***Sumtypes***')
+
+	for i := 0; i < max_iterations; i++ {
+		_ := decoder2.decode[SumTypes]('2')!
+	}
+
+	b.measure('decoder2.decode[SumTypes](2)!')
+
+	for i := 0; i < max_iterations; i++ {
+		_ := decoder2.decode[SumTypes]('"abcdefghijklimnopqrstuv"')!
+	}
+
+	b.measure('decoder2.decode[SumTypes](\'"abcdefghijklimnopqrstuv"\')!')
 }

--- a/vlib/x/json2/decoder2/tests/decode_number_and_boolean_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_number_and_boolean_test.v
@@ -68,6 +68,8 @@ fn test_number() {
 	// Test f32
 	assert json.decode[f32]('0')! == 0.0
 	assert json.decode[f32]('1')! == 1.0
+	assert json.decode[f32]('1.2')! == 1.2
+	assert json.decode[f32]('-1.2')! == -1.2
 	assert json.decode[f32]('201')! == 201.0
 
 	assert json.decode[f32]('-1')! == -1.0
@@ -79,9 +81,11 @@ fn test_number() {
 	// Test f64
 	assert json.decode[f64]('0')! == 0.0
 	assert json.decode[f64]('1')! == 1.0
+	assert json.decode[f64]('1.2')! == 1.2
 	assert json.decode[f64]('201')! == 201.0
 
 	assert json.decode[f64]('-1')! == -1.0
+	assert json.decode[f64]('-1.2')! == -1.2
 	assert json.decode[f64]('-201')! == -201.0
 
 	assert json.decode[f64]('1234567890')! == 1234567890.0

--- a/vlib/x/json2/decoder2/tests/json_sumtype_test.v
+++ b/vlib/x/json2/decoder2/tests/json_sumtype_test.v
@@ -16,13 +16,13 @@ struct Price {
 	net f64
 }
 
-type Animal = Cat | Dog
+pub type Animal = Cat | Dog
 
-struct Cat {
+pub struct Cat {
 	cat_name string
 }
 
-struct Dog {
+pub struct Dog {
 	dog_name string
 }
 
@@ -73,4 +73,10 @@ fn test_any_sum_type() {
 	// 		'hello2': json2.Any('world')
 	// 	})
 	// })
+}
+
+fn test_sum_type_struct() {
+	assert json.decode[Animal]('{"cat_name": "Tom"}')! == Animal(Cat{'Tom'})
+	assert json.decode[Animal]('{"dog_name": "Rex"}')! == Animal(Cat{''})
+	assert json.decode[Animal]('{"dog_name": "Rex", "_type": "Dog"}')! == Animal(Dog{'Rex'})
 }

--- a/vlib/x/json2/decoder2/tests/json_sumtype_test.v
+++ b/vlib/x/json2/decoder2/tests/json_sumtype_test.v
@@ -1,4 +1,6 @@
 import x.json2.decoder2 as json
+import x.json2
+import time
 
 type Prices = Price | []Price
 
@@ -24,7 +26,7 @@ struct Dog {
 	dog_name string
 }
 
-type Sum = int | string | bool
+type Sum = int | string | bool | []string
 
 fn test_simple_sum_type() {
 	assert json.decode[Sum]('1')! == Sum(1)
@@ -33,4 +35,42 @@ fn test_simple_sum_type() {
 
 	assert json.decode[Sum]('true')! == Sum(true)
 	assert json.decode[Sum]('false')! == Sum(false)
+
+	assert json.decode[Sum]('["1", "2", "3"]')! == Sum(['1', '2', '3'])
+}
+
+fn test_any_sum_type() {
+	assert json.decode[json2.Any]('1')! == json2.Any(f64(1))
+	assert json.decode[json2.Any]('123321')! == json2.Any(f64(123321))
+
+	assert json.decode[json2.Any]('"hello"')! == json2.Any('hello')
+
+	assert json.decode[json2.Any]('true')! == json2.Any(true)
+	assert json.decode[json2.Any]('false')! == json2.Any(false)
+
+	assert json.decode[json2.Any]('1.1')! == json2.Any(f64(1.1))
+
+	// Uncomment this when #22693 is fixed
+	// assert json.decode[[]json2.Any]('["1", "2", "3"]')! == [json2.Any('1'), json2.Any('2'), json2.Any('3')]
+	// assert json.decode[json2.Any]('["1", "2", "3"]')! == json2.Any([json2.Any('1'), json2.Any('2'),
+	// 	json2.Any('3')])
+
+	// assert json.decode[[]json2.Any]('[true, false, true]')! == [json2.Any(true), json2.Any(false),
+	// 	json2.Any(true)]
+	// assert json.decode[json2.Any]('[true, false, true]')! == json2.Any([json2.Any(true), json2.Any(false),
+	// 	json2.Any(true)])
+
+	assert json.decode[json2.Any]('{"hello": "world"}')! == json2.Any({
+		'hello': json2.Any('world')
+	})
+
+	assert json.decode[map[string]json2.Any]('{"hello": "world"}')! == {
+		'hello': json2.Any('world')
+	}
+
+	// assert json.decode[json2.Any]('{"hello1": {"hello2": "world"}}')! == json2.Any({
+	// 	'hello1': json2.Any({
+	// 		'hello2': json2.Any('world')
+	// 	})
+	// })
 }

--- a/vlib/x/json2/types.v
+++ b/vlib/x/json2/types.v
@@ -5,8 +5,7 @@ import time
 // `Any` is a sum type that lists the possible types to be decoded and used.
 // `Any` priority order for numbers: floats -> signed integers -> unsigned integers
 // `Any` priority order for strings: string -> time.Time
-pub type Any = Null
-	| []Any
+pub type Any = []Any
 	| bool
 	| f64
 	| f32
@@ -22,6 +21,7 @@ pub type Any = Null
 	| u32
 	| u16
 	| u8
+	| Null
 
 // Decodable is an interface, that allows custom implementations for decoding structs from JSON encoded values
 pub interface Decodable {

--- a/vlib/x/json2/types.v
+++ b/vlib/x/json2/types.v
@@ -3,22 +3,24 @@ module json2
 import time
 
 // `Any` is a sum type that lists the possible types to be decoded and used.
+// `Any` priority order for numbers: floats -> signed integers -> unsigned integers
+// `Any` priority order for strings: string -> time.Time
 pub type Any = Null
 	| []Any
 	| bool
-	| f32
 	| f64
-	| i16
-	| i32
+	| f32
 	| i64
-	| i8
 	| int
+	| i32
+	| i16
+	| i8
 	| map[string]Any
 	| string
 	| time.Time
-	| u16
-	| u32
 	| u64
+	| u32
+	| u16
 	| u8
 
 // Decodable is an interface, that allows custom implementations for decoding structs from JSON encoded values


### PR DESCRIPTION
```v
fn test_any_sum_type() {
	assert json.decode[json2.Any]('1')! == json2.Any(f64(1))
	assert json.decode[json2.Any]('123321')! == json2.Any(f64(123321))

	assert json.decode[json2.Any]('"hello"')! == json2.Any('hello')

	assert json.decode[json2.Any]('true')! == json2.Any(true)
	assert json.decode[json2.Any]('false')! == json2.Any(false)

	assert json.decode[json2.Any]('1.1')! == json2.Any(f64(1.1))
}

fn test_sum_type_struct() {
	assert json.decode[Animal]('{"cat_name": "Tom"}')! == Animal(Cat{'Tom'})
	assert json.decode[Animal]('{"dog_name": "Rex"}')! == Animal(Cat{''})
	assert json.decode[Animal]('{"dog_name": "Rex", "_type": "Dog"}')! == Animal(Dog{'Rex'})
}
```

```sh
Starting benchmark...
max_iterations: 1000000

***Structure and maps***
 SPENT   372.589 ms in decoder2.decode[Stru](json_data)!
 SPENT   482.813 ms in old_json.decode(Stru, json_data)!

 SPENT   438.015 ms in decoder2.decode[SumTypes](json_data)!
 SPENT   517.501 ms in old_json.decode(SumTypes, json_data)!

 SPENT   107.221 ms in decoder2.decode[StructType[string]](json_data1)!
 SPENT   115.022 ms in old_json.decode(StructType[string], json_data1)!

 SPENT   128.189 ms in decoder2.decode[StructTypeOption[string]](json_data1)!
 SPENT   148.069 ms in old_json.decode(StructTypeOption[string], json_data1)!

 SPENT    66.202 ms in decoder2.decode[StructType[int]](json_data2)!
 SPENT   114.664 ms in old_json.decode(StructType[int], json_data2)!

 SPENT   223.931 ms in decoder2.decode[map[string]string](json_data1)!
 SPENT   204.046 ms in old_json.decode(map[string]string, json_data1)!


***arrays***
 SPENT   335.156 ms in decoder2.decode[[]int]('[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]')!
 SPENT   588.824 ms in old_json.decode([]int, '[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]')!


***simple types***
 SPENT    20.428 ms in decoder2.decode[int]('2')!
 SPENT    19.680 ms in decoder2.decode[bool]('true')!
 SPENT    76.902 ms in decoder2.decode[time.Time]('2022-03-11T13:54:25')!
 SPENT    94.225 ms in decoder2.decode[string]('"abcdefghijklimnopqrstuv"')!

***alias***
 SPENT    20.166 ms in decoder2.decode[IntAlias](2)!
 SPENT    92.587 ms in decoder2.decode[StringAlias]('"abcdefghijklimnopqrstuv"')!

***Sumtypes***
 SPENT    77.891 ms in decoder2.decode[SumTypes](2)!
 SPENT   143.630 ms in decoder2.decode[SumTypes]('"abcdefghijklimnopqrstuv"')!
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIxNGY5NzI3Y2M3NjgxYzYyMzg3ZTUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.U-DJuZFT0Fg2VZc24dsuS5L9ppfHKXbgfd9cEhYKmNg">Huly&reg;: <b>V_0.6-21143</b></a></sub>