### PR TITLE
bitfield: add shift left/right functions

### DIFF
--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -600,6 +600,32 @@ pub fn (instance BitField) rotate(offset int) BitField {
 	return output
 }
 
+// shift_left shift-left the bits by `count` positions.
+pub fn (instance BitField) shift_left(count int) BitField {
+	size := instance.size
+	if count <= 0 {
+		return instance
+	} else if count >= size {
+		// return zeroes
+		return new(size)
+	}
+	zeroes := new(count)
+	return join(instance.slice(count, size), zeroes)
+}
+
+// shift_right shift-right the bits by `count` positions.
+pub fn (instance BitField) shift_right(count int) BitField {
+	size := instance.size
+	if count <= 0 {
+		return instance
+	} else if count >= size {
+		// return zeroes
+		return new(size)
+	}
+	zeroes := new(count)
+	return join(zeroes, instance.slice(0, size - count))
+}
+
 // Internal functions
 // clear_tail clears the extra bits that are not part of the bitfield, but yet are allocated
 @[inline]

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -366,4 +366,9 @@ fn test_bf_shift() {
 	assert bf_left.str() == '0011011111110000'
 	bf_right := bf.shift_right(4)
 	assert bf_right.str() == '0000000100110111'
+
+	bf_large_left := bf.shift_left(100)
+	bf_large_right := bf.shift_right(100)
+	assert bf_large_left.str() == '0000000000000000'
+	assert bf_large_right.str() == '0000000000000000'
 }

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -358,3 +358,12 @@ fn test_bf_printing() {
 	println(input)
 	assert true
 }
+
+fn test_bf_shift() {
+	str := '0001001101111111'
+	bf := bitfield.from_str(str)
+	bf_left := bf.shift_left(4)
+	assert bf_left.str() == '0011011111110000'
+	bf_right := bf.shift_right(4)
+	assert bf_right.str() == '0000000100110111'
+}


### PR DESCRIPTION
```v
bitfield.shift_left(count int)
bitfield.shift_right(count int)
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIyMmRjNzI3Y2M3NjgxYzYyM2E4MjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.PtCp09V_Y9-Csrs4Z4AA7TlIs7nbbHr3GEzkzRbNRVw">Huly&reg;: <b>V_0.6-21148</b></a></sub>