### PR TITLE
checker, cgen: implement methods sort_with_compare()/sorted_with_compare() for fixed array

### DIFF
--- a/vlib/builtin/fixed_array_sort_test.v
+++ b/vlib/builtin/fixed_array_sort_test.v
@@ -95,6 +95,7 @@ fn test_sorted_with_compare_1() {
 		}
 		return 0
 	})
+	assert a == ['hi', '1', '5', '3']!
 	assert b == ['1', '3', '5', 'hi']!
 }
 
@@ -149,6 +150,13 @@ fn test_sorted_with_compare_2() {
 		return compare_strings(a.s, b.s)
 	}
 	b := arr.sorted_with_compare(cmp)
+	assert arr[0].s == 'bbb'
+	assert arr[0].i == 100
+	assert arr[1].s == 'aaa'
+	assert arr[1].i == 101
+	assert arr[2].s == 'ccc'
+	assert arr[2].i == 102
+
 	assert b[0].s == 'aaa'
 	assert b[0].i == 101
 	assert b[1].s == 'bbb'

--- a/vlib/builtin/fixed_array_sort_test.v
+++ b/vlib/builtin/fixed_array_sort_test.v
@@ -69,3 +69,90 @@ fn test_sorted_by_len() {
 	c := a.sorted(a.len < b.len)
 	assert c == ['a', 'hi', 'abc', 'zzzzz']!
 }
+
+fn test_sort_with_compare_1() {
+	mut a := ['hi', '1', '5', '3']!
+	a.sort_with_compare(fn (a &string, b &string) int {
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
+		return 0
+	})
+	assert a == ['1', '3', '5', 'hi']!
+}
+
+fn test_sorted_with_compare_1() {
+	a := ['hi', '1', '5', '3']!
+	b := a.sorted_with_compare(fn (a &string, b &string) int {
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
+		return 0
+	})
+	assert b == ['1', '3', '5', 'hi']!
+}
+
+struct Ka {
+	s string
+	i int
+}
+
+fn test_sort_with_compare_2() {
+	mut arr := [
+		Ka{
+			s: 'bbb'
+			i: 100
+		},
+		Ka{
+			s: 'aaa'
+			i: 101
+		},
+		Ka{
+			s: 'ccc'
+			i: 102
+		},
+	]!
+	cmp := fn (a &Ka, b &Ka) int {
+		return compare_strings(a.s, b.s)
+	}
+	arr.sort_with_compare(cmp)
+	assert arr[0].s == 'aaa'
+	assert arr[0].i == 101
+	assert arr[1].s == 'bbb'
+	assert arr[1].i == 100
+	assert arr[2].s == 'ccc'
+	assert arr[2].i == 102
+}
+
+fn test_sorted_with_compare_2() {
+	arr := [
+		Ka{
+			s: 'bbb'
+			i: 100
+		},
+		Ka{
+			s: 'aaa'
+			i: 101
+		},
+		Ka{
+			s: 'ccc'
+			i: 102
+		},
+	]!
+	cmp := fn (a &Ka, b &Ka) int {
+		return compare_strings(a.s, b.s)
+	}
+	b := arr.sorted_with_compare(cmp)
+	assert b[0].s == 'aaa'
+	assert b[0].i == 101
+	assert b[1].s == 'bbb'
+	assert b[1].i == 100
+	assert b[2].s == 'ccc'
+	assert b[2].i == 102
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -33,7 +33,7 @@ pub const array_builtin_methods = ['filter', 'clone', 'repeat', 'reverse', 'map'
 	'first', 'last', 'pop', 'delete', 'insert', 'prepend']
 pub const array_builtin_methods_chk = token.new_keywords_matcher_from_array_trie(array_builtin_methods)
 pub const fixed_array_builtin_methods = ['contains', 'index', 'any', 'all', 'wait', 'map', 'sort',
-	'sorted']
+	'sorted', 'sort_with_compare', 'sorted_with_compare']
 pub const fixed_array_builtin_methods_chk = token.new_keywords_matcher_from_array_trie(fixed_array_builtin_methods)
 // TODO: remove `byte` from this list when it is no longer supported
 pub const reserved_type_names = ['byte', 'bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8', 'u16',

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1210,6 +1210,12 @@ fn (mut g Gen) gen_fixed_array_method_call(node ast.CallExpr, left_type ast.Type
 		'sorted' {
 			g.gen_array_sorted(node)
 		}
+		'sort_with_compare' {
+			g.gen_fixed_array_sort_with_compare(node)
+		}
+		'sorted_with_compare' {
+			g.gen_fixed_array_sorted_with_compare(node)
+		}
 		else {
 			return false
 		}


### PR DESCRIPTION
This PR implement methods sort_with_compare()/sorted_with_compare() for fixed array.

- Implement methods sort_with_compare()/sorted_with_compare() for fixed array.
- Add tests.

```v
fn test_sort_with_compare_1() {
	mut a := ['hi', '1', '5', '3']!
	a.sort_with_compare(fn (a &string, b &string) int {
		if a < b {
			return -1
		}
		if a > b {
			return 1
		}
		return 0
	})
	assert a == ['1', '3', '5', 'hi']!
}

fn test_sorted_with_compare_1() {
	a := ['hi', '1', '5', '3']!
	b := a.sorted_with_compare(fn (a &string, b &string) int {
		if a < b {
			return -1
		}
		if a > b {
			return 1
		}
		return 0
	})
	assert b == ['1', '3', '5', 'hi']!
}

struct Ka {
	s string
	i int
}

fn test_sort_with_compare_2() {
	mut arr := [
		Ka{
			s: 'bbb'
			i: 100
		},
		Ka{
			s: 'aaa'
			i: 101
		},
		Ka{
			s: 'ccc'
			i: 102
		},
	]!
	cmp := fn (a &Ka, b &Ka) int {
		return compare_strings(a.s, b.s)
	}
	arr.sort_with_compare(cmp)
	assert arr[0].s == 'aaa'
	assert arr[0].i == 101
	assert arr[1].s == 'bbb'
	assert arr[1].i == 100
	assert arr[2].s == 'ccc'
	assert arr[2].i == 102
}

fn test_sorted_with_compare_2() {
	arr := [
		Ka{
			s: 'bbb'
			i: 100
		},
		Ka{
			s: 'aaa'
			i: 101
		},
		Ka{
			s: 'ccc'
			i: 102
		},
	]!
	cmp := fn (a &Ka, b &Ka) int {
		return compare_strings(a.s, b.s)
	}
	b := arr.sorted_with_compare(cmp)
	assert b[0].s == 'aaa'
	assert b[0].i == 101
	assert b[1].s == 'bbb'
	assert b[1].i == 100
	assert b[2].s == 'ccc'
	assert b[2].i == 102
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIyNGM2MDI3Y2M3NjgxYzYyM2IxMDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ccnlJVzM76R0hpzn6SpiZzugeM8LQMhjeJ3QyT8EVOE">Huly&reg;: <b>V_0.6-21150</b></a></sub>