### PR TITLE
cgen: ensure proper saving/restoring of cgen `map[k] := fn ()` state, when assigning anonymous fns (fix #22705)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -216,6 +216,15 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		g.curr_var_name = last_curr_var_name
 	}
 
+	old_is_arraymap_set := g.is_arraymap_set
+	old_is_assign_lhs := g.is_assign_lhs
+	old_assign_op := g.assign_op
+	defer {
+		g.is_arraymap_set = old_is_arraymap_set
+		g.is_assign_lhs = old_is_assign_lhs
+		g.assign_op = old_assign_op
+	}
+
 	for i, mut left in node.left {
 		mut is_auto_heap := false
 		mut var_type := node.left_types[i]

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -136,10 +136,18 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 	g.assign_op = node.op
 	g.inside_assign = true
 	g.assign_ct_type = 0
+	g.arraymap_set_pos = 0
+	g.is_arraymap_set = false
+	g.is_assign_lhs = false
+	g.is_shared = false
 	defer {
 		g.assign_op = .unknown
 		g.inside_assign = false
 		g.assign_ct_type = 0
+		g.arraymap_set_pos = 0
+		g.is_arraymap_set = false
+		g.is_assign_lhs = false
+		g.is_shared = false
 	}
 	op := if is_decl { token.Kind.assign } else { node.op }
 	right_expr := node.right[0]
@@ -210,20 +218,12 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 	if node.left_types.len < node.left.len {
 		g.checker_bug('node.left_types.len < node.left.len', node.pos)
 	}
+
 	last_curr_var_name := g.curr_var_name.clone()
-	g.curr_var_name = []
 	defer {
 		g.curr_var_name = last_curr_var_name
 	}
-
-	old_is_arraymap_set := g.is_arraymap_set
-	old_is_assign_lhs := g.is_assign_lhs
-	old_assign_op := g.assign_op
-	defer {
-		g.is_arraymap_set = old_is_arraymap_set
-		g.is_assign_lhs = old_is_assign_lhs
-		g.assign_op = old_assign_op
-	}
+	g.curr_var_name = []
 
 	for i, mut left in node.left {
 		mut is_auto_heap := false
@@ -819,11 +819,11 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				} else {
 					// var = &auto_heap_var
 					old_is_auto_heap := g.is_option_auto_heap
-					g.is_option_auto_heap = val_type.has_flag(.option) && val is ast.PrefixExpr
-						&& val.right is ast.Ident && (val.right as ast.Ident).is_auto_heap()
 					defer {
 						g.is_option_auto_heap = old_is_auto_heap
 					}
+					g.is_option_auto_heap = val_type.has_flag(.option) && val is ast.PrefixExpr
+						&& val.right is ast.Ident && (val.right as ast.Ident).is_auto_heap()
 					if var_type.has_flag(.option) || gen_or {
 						g.expr_with_opt_or_block(val, val_type, left, var_type, false)
 					} else if node.has_cross_var {

--- a/vlib/v/tests/init_global_test.v
+++ b/vlib/v/tests/init_global_test.v
@@ -1,5 +1,3 @@
-// vtest flaky: true
-// vtest retry: 4
 import sync
 
 fn one() int {


### PR DESCRIPTION
Fix #22705 .

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIyOWI0OTI3Y2M3NjgxYzYyM2JlZDgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.jDbJ4c-l2LkifI4SgxVRXHk1ScpdENhYWgL3OJ_wHS8">Huly&reg;: <b>V_0.6-21155</b></a></sub>