### PR TITLE
checker: check for receiver name clashing with global var

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -192,6 +192,10 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		}
 	}
 	if node.is_method {
+		if node.receiver.name in c.global_names {
+			c.error('cannot use global variable name `${node.receiver.name}` as receiver',
+				node.receiver_pos)
+		}
 		if node.receiver.typ.has_flag(.option) {
 			c.error('option types cannot have methods', node.receiver_pos)
 		}

--- a/vlib/v/checker/tests/globals/global_receiver_var_name_err.out
+++ b/vlib/v/checker/tests/globals/global_receiver_var_name_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/globals/global_receiver_var_name_err.vv:17:9: error: cannot use global variable name `game` as receiver
+   15 | }
+   16 | 
+   17 | fn (mut game Game) init() {
+      |         ~~~~~~~~~
+   18 |     game.world = GameObject{}
+   19 | }

--- a/vlib/v/checker/tests/globals/global_receiver_var_name_err.vv
+++ b/vlib/v/checker/tests/globals/global_receiver_var_name_err.vv
@@ -1,0 +1,21 @@
+module main
+
+struct Game {
+mut:
+	world     GameObject
+	object_id u32
+}
+
+__global (
+	game Game
+)
+
+struct GameObject {
+	id int = game.object_id++
+}
+
+fn (mut game Game) init() {
+	game.world = GameObject{}
+}
+
+fn main() {}


### PR DESCRIPTION
Fix #22698

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIyYjczNDI3Y2M3NjgxYzYyM2MwOTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.rlSaOKy0XyRnHYRA97ySIcLNg6gXWZj5Rj_r7ITT45U">Huly&reg;: <b>V_0.6-21156</b></a></sub>