### PR TITLE
v: optimization improvements

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -746,12 +746,6 @@ fn (s string) == (a string) bool {
 	if s.len != a.len {
 		return false
 	}
-	if s.len > 0 {
-		last_idx := s.len - 1
-		if s[last_idx] != a[last_idx] {
-			return false
-		}
-	}
 	unsafe {
 		return vmemcmp(s.str, a.str, a.len) == 0
 	}

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -360,6 +360,7 @@ pub:
 	is_global        bool
 	is_volatile      bool
 	is_deprecated    bool
+	is_embed         bool
 pub mut:
 	is_recursive     bool
 	is_part_of_union bool
@@ -485,6 +486,7 @@ pub:
 	next_comments    []Comment
 	has_prev_newline bool
 	has_break_line   bool
+	is_embed         bool
 pub mut:
 	expr          Expr   // `val1`
 	name          string // 'field1'

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -40,6 +40,7 @@ pub fn new_scope(parent &Scope, start_pos int) &Scope {
 }
 */
 
+@[inline]
 fn (s &Scope) dont_lookup_parent() bool {
 	return s.parent == unsafe { nil } || s.detached_from_parent
 }

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2000,7 +2000,7 @@ pub fn (mut t Table) unwrap_generic_type_ex(typ Type, generic_names []string, co
 							}
 						}
 						// Update type in `info.embeds`, if it's embed
-						if fields[i].name.len > 1 && fields[i].name[0].is_capital() {
+						if fields[i].is_embed {
 							mut parent_sym := t.sym(typ)
 							mut parent_info := parent_sym.info
 							if mut parent_info is Struct {
@@ -2186,7 +2186,7 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 									fields[i].typ = t_typ
 								}
 								// Update type in `info.embeds`, if it's embed
-								if fields[i].name.len > 1 && fields[i].name[0].is_capital() {
+								if fields[i].is_embed {
 									for mut embed in parent_info.embeds {
 										if embed == orig_type {
 											embed = fields[i].typ

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1701,7 +1701,7 @@ pub fn (t &TypeSymbol) embed_name() string {
 
 pub fn (t &TypeSymbol) has_method(name string) bool {
 	for mut method in unsafe { t.methods } {
-		if method.name == name {
+		if method.name.len == name.len && method.name == name {
 			return true
 		}
 	}
@@ -1715,7 +1715,7 @@ pub fn (t &TypeSymbol) has_method_with_generic_parent(name string) bool {
 
 pub fn (t &TypeSymbol) find_method(name string) ?Fn {
 	for mut method in unsafe { t.methods } {
-		if method.name == name {
+		if method.name.len == name.len && method.name == name {
 			return method
 		}
 	}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1866,7 +1866,7 @@ pub fn (i &Interface) has_method(name string) bool {
 
 pub fn (s Struct) find_field(name string) ?StructField {
 	for mut field in unsafe { s.fields } {
-		if field.name == name {
+		if name.len == field.name.len && field.name == name {
 			return field
 		}
 	}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1830,7 +1830,7 @@ pub fn (t &TypeSymbol) has_field(name string) bool {
 
 fn (a &Aggregate) find_field(name string) ?StructField {
 	for mut field in unsafe { a.fields } {
-		if field.name == name {
+		if field.name.len == name.len && field.name == name {
 			return field
 		}
 	}
@@ -1839,7 +1839,7 @@ fn (a &Aggregate) find_field(name string) ?StructField {
 
 pub fn (i &Interface) find_field(name string) ?StructField {
 	for mut field in unsafe { i.fields } {
-		if field.name == name {
+		if field.name.len == name.len && field.name == name {
 			return field
 		}
 	}
@@ -1848,7 +1848,7 @@ pub fn (i &Interface) find_field(name string) ?StructField {
 
 pub fn (i &Interface) find_method(name string) ?Fn {
 	for mut method in unsafe { i.methods } {
-		if method.name == name {
+		if method.name.len == name.len && method.name == name {
 			return method
 		}
 	}
@@ -1857,7 +1857,7 @@ pub fn (i &Interface) find_method(name string) ?Fn {
 
 pub fn (i &Interface) has_method(name string) bool {
 	for mut method in unsafe { i.methods } {
-		if method.name == name {
+		if method.name.len == name.len && method.name == name {
 			return true
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5360,10 +5360,10 @@ fn (c &Checker) check_import_sym_conflict(ident string) bool {
 	for import_sym in c.file.imports {
 		// Check if alias exists or not
 		if !import_sym.alias.is_blank() {
-			if import_sym.alias == ident {
+			if import_sym.alias.len == ident.len && import_sym.alias == ident {
 				return true
 			}
-		} else if import_sym.mod == ident {
+		} else if import_sym.mod.len == ident.len && import_sym.mod == ident {
 			return true
 		}
 	}

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -806,8 +806,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 
 				// all the fields of initialized embedded struct are ignored, they are considered initialized
 				sym := c.table.sym(init_field.typ)
-				if init_field.name != '' && init_field.name[0].is_capital() && sym.kind == .struct
-					&& sym.language == .v {
+				if init_field.is_embed && sym.kind == .struct && sym.language == .v {
 					struct_fields := c.table.struct_fields(sym)
 					for struct_field in struct_fields {
 						inited_fields << struct_field.name
@@ -928,7 +927,7 @@ fn (mut c Checker) check_uninitialized_struct_fields_and_embeds(node ast.StructI
 			continue
 		}
 		sym := c.table.sym(field.typ)
-		if field.name != '' && field.name[0].is_capital() && sym.info is ast.Struct {
+		if field.is_embed && sym.info is ast.Struct {
 			// struct embeds
 			continue
 		}
@@ -957,13 +956,14 @@ fn (mut c Checker) check_uninitialized_struct_fields_and_embeds(node ast.StructI
 			}
 			continue
 		}
-		if field.typ.is_ptr() && !field.typ.has_flag(.shared_f) && !field.typ.has_flag(.option)
+		field_is_option := field.typ.has_flag(.option)
+		if field.typ.is_ptr() && !field.typ.has_flag(.shared_f) && !field_is_option
 			&& !node.has_update_expr && !c.pref.translated && !c.file.is_translated {
 			c.error('reference field `${type_sym.name}.${field.name}` must be initialized',
 				node.pos)
 			continue
 		}
-		if !field.typ.has_flag(.option) {
+		if !field_is_option {
 			if sym.kind == .struct {
 				c.check_ref_fields_initialized(sym, mut checked_types, '${type_sym.name}.${field.name}',
 					node.pos)
@@ -976,7 +976,7 @@ fn (mut c Checker) check_uninitialized_struct_fields_and_embeds(node ast.StructI
 			}
 		}
 		// Do not allow empty uninitialized interfaces
-		if sym.kind == .interface && !node.has_update_expr && !field.typ.has_flag(.option)
+		if sym.kind == .interface && !node.has_update_expr && !field_is_option
 			&& sym.language != .js && !field.attrs.contains('noinit') {
 			// TODO: should be an error instead, but first `ui` needs updating.
 			c.note('interface field `${type_sym.name}.${field.name}` must be initialized',
@@ -996,7 +996,7 @@ fn (mut c Checker) check_uninitialized_struct_fields_and_embeds(node ast.StructI
 			c.error('field `${type_sym.name}.${field.name}` must be initialized', node.pos)
 		}
 		if !node.has_update_expr && !field.has_default_expr && !field.typ.is_ptr()
-			&& !field.typ.has_flag(.option) {
+			&& !field_is_option {
 			field_final_sym := c.table.final_sym(field.typ)
 			if field_final_sym.kind == .struct {
 				mut zero_struct_init := ast.StructInit{
@@ -1063,7 +1063,7 @@ fn (mut c Checker) check_ref_fields_initialized(struct_sym &ast.TypeSymbol, mut 
 			if sym.language == .c {
 				continue
 			}
-			if field.name != '' && field.name[0].is_capital() && sym.language == .v {
+			if field.is_embed && sym.language == .v {
 				// an embedded struct field
 				continue
 			}
@@ -1106,7 +1106,7 @@ fn (mut c Checker) check_ref_fields_initialized_note(struct_sym &ast.TypeSymbol,
 			if sym.language == .c {
 				continue
 			}
-			if field.name != '' && field.name[0].is_capital() && sym.language == .v {
+			if field.is_embed && sym.language == .v {
 				// an embedded struct field
 				continue
 			}

--- a/vlib/v/depgraph/depgraph.v
+++ b/vlib/v/depgraph/depgraph.v
@@ -55,12 +55,14 @@ pub fn (o &OrderedDepMap) get(name string) []string {
 	return res
 }
 
+@[direct_array_access]
 pub fn (mut o OrderedDepMap) delete(name string) {
 	if name !in o.data {
 		panic('delete: no such key: ${name}')
 	}
 	for i, _ in o.keys {
-		if o.keys[i] == name {
+		item := o.keys[i]
+		if item.len == name.len && item == name {
 			o.keys.delete(i)
 			break
 		}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1012,8 +1012,12 @@ fn (mut g Gen) gen_array_contains_methods() {
 				ptr_typ := g.equality_fn(elem_type)
 				fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq(((${elem_type_str}*)a.data)[i], v)) {')
 			} else if elem_kind == .alias && elem_is_not_ptr {
-				ptr_typ := g.equality_fn(elem_type)
-				fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq(((${elem_type_str}*)a.data)[i], v)) {')
+				if g.no_eq_method_types[elem_type] {
+					fn_builder.writeln('\t\tif (((${elem_type_str}*)a.data)[i] == v) {')
+				} else {
+					ptr_typ := g.equality_fn(elem_type)
+					fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq(((${elem_type_str}*)a.data)[i], v)) {')
+				}
 			} else {
 				fn_builder.writeln('\t\tif (((${elem_type_str}*)a.data)[i] == v) {')
 			}
@@ -1050,8 +1054,12 @@ fn (mut g Gen) gen_array_contains_methods() {
 				ptr_typ := g.equality_fn(elem_type)
 				fn_builder.writeln('\t\tif (${ptr_typ}_sumtype_eq(a[i], v)) {')
 			} else if elem_kind == .alias && elem_is_not_ptr {
-				ptr_typ := g.equality_fn(elem_type)
-				fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq(a[i], v)) {')
+				if g.no_eq_method_types[elem_type] {
+					fn_builder.writeln('\t\tif (a[i] == v) {')
+				} else {
+					ptr_typ := g.equality_fn(elem_type)
+					fn_builder.writeln('\t\tif (${ptr_typ}_alias_eq(a[i], v)) {')
+				}
 			} else {
 				fn_builder.writeln('\t\tif (a[i] == v) {')
 			}

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -97,8 +97,12 @@ fn (mut g Gen) gen_sumtype_equality_fn(left_type ast.Type) string {
 			eq_fn := g.gen_map_equality_fn(typ)
 			fn_builder.writeln('\t\treturn ${eq_fn}_map_eq(*${left_arg}, *${right_arg});')
 		} else if variant.sym.kind == .alias && !typ.is_ptr() {
-			eq_fn := g.gen_alias_equality_fn(typ)
-			fn_builder.writeln('\t\treturn ${eq_fn}_alias_eq(*${left_arg}, *${right_arg});')
+			if g.no_eq_method_types[typ] {
+				fn_builder.writeln('\t\treturn *${left_arg} == *${right_arg};')
+			} else {
+				eq_fn := g.gen_alias_equality_fn(typ)
+				fn_builder.writeln('\t\treturn ${eq_fn}_alias_eq(*${left_arg}, *${right_arg});')
+			}
 		} else if variant.sym.kind == .function {
 			fn_builder.writeln('\t\treturn *((voidptr*)(*${left_arg})) == *((voidptr*)(*${right_arg}));')
 		} else {
@@ -242,8 +246,12 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				eq_fn := g.gen_map_equality_fn(field.typ)
 				fn_builder.write_string('${eq_fn}_map_eq(${left_arg}, ${right_arg})')
 			} else if field_type.sym.kind == .alias && !field.typ.is_ptr() {
-				eq_fn := g.gen_alias_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_alias_eq(${left_arg}, ${right_arg})')
+				if g.no_eq_method_types[field.typ] {
+					fn_builder.write_string('${left_arg} == ${right_arg}')
+				} else {
+					eq_fn := g.gen_alias_equality_fn(field.typ)
+					fn_builder.write_string('${eq_fn}_alias_eq(${left_arg}, ${right_arg})')
+				}
 			} else if field_type.sym.kind == .function && !field.typ.has_flag(.option) {
 				fn_builder.write_string('*((voidptr*)(${left_arg})) == *((voidptr*)(${right_arg}))')
 			} else if field_type.sym.kind == .interface

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -397,7 +397,7 @@ fn (mut g Gen) gen_array_equality_fn(left_type ast.Type) string {
 			fn_builder.writeln('\t\tif (((${ptr_elem_styp}*)${left_data})[i] != ((${ptr_elem_styp}*)${right_data})[i]) {')
 		} else {
 			eq_fn := g.gen_alias_equality_fn(elem.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_alias_eq(((${ptr_elem_styp}*)${left_data})[i], ((${ptr_elem_styp}*)${right_data})[i]) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_alias_eq(((${ptr_elem_styp}*)${left_data})[i], ((${ptr_elem_styp}*)${right_data})[i])) {')
 		}
 	} else if elem.sym.kind == .function {
 		fn_builder.writeln('\t\tif (*((voidptr*)((byte*)${left_data}+(i*${left_elem}))) != *((voidptr*)((byte*)${right_data}+(i*${right_elem})))) {')

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -393,8 +393,12 @@ fn (mut g Gen) gen_array_equality_fn(left_type ast.Type) string {
 		eq_fn := g.gen_map_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_map_eq(((${ptr_elem_styp}*)${left_data})[i], ((${ptr_elem_styp}*)${right_data})[i])) {')
 	} else if elem.sym.kind == .alias && !elem.typ.is_ptr() {
-		eq_fn := g.gen_alias_equality_fn(elem.typ)
-		fn_builder.writeln('\t\tif (!${eq_fn}_alias_eq(((${ptr_elem_styp}*)${left_data})[i], ((${ptr_elem_styp}*)${right_data})[i])) {')
+		if g.no_eq_method_types[elem.typ] {
+			fn_builder.writeln('\t\tif (((${ptr_elem_styp}*)${left_data})[i] != ((${ptr_elem_styp}*)${right_data})[i]) {')
+		} else {
+			eq_fn := g.gen_alias_equality_fn(elem.typ)
+			fn_builder.writeln('\t\tif (!${eq_fn}_alias_eq(((${ptr_elem_styp}*)${left_data})[i], ((${ptr_elem_styp}*)${right_data})[i]) {')
+		}
 	} else if elem.sym.kind == .function {
 		fn_builder.writeln('\t\tif (*((voidptr*)((byte*)${left_data}+(i*${left_elem}))) != *((voidptr*)((byte*)${right_data}+(i*${right_elem})))) {')
 	} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -494,7 +494,6 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	global_g.write_shareds()
 	global_g.write_chan_pop_option_fns()
 	global_g.write_chan_push_option_fns()
-	global_g.no_eq_method_types[global_g.table.find_type('Type')] = true
 	global_g.gen_array_contains_methods()
 	global_g.gen_array_index_methods()
 	global_g.gen_equality_fns()

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1062,13 +1062,13 @@ pub fn (mut g Gen) write_typeof_functions() {
 // V type to C typecc
 @[inline]
 fn (mut g Gen) styp(t ast.Type) string {
-	if t.has_flag(.option) {
+	if !t.has_option_or_result() {
+		return g.base_type(t)
+	} else if t.has_flag(.option) {
 		// Register an optional if it's not registered yet
 		return g.register_option(t)
-	} else if t.has_flag(.result) {
-		return g.register_result(t)
 	} else {
-		return g.base_type(t)
+		return g.register_result(t)
 	}
 }
 
@@ -1098,7 +1098,7 @@ fn (mut g Gen) base_type(_t ast.Type) string {
 	if t.has_flag(.shared_f) {
 		styp = g.find_or_register_shared(t, styp)
 	}
-	nr_muls := g.unwrap_generic(t).nr_muls()
+	nr_muls := t.nr_muls()
 	if nr_muls > 0 {
 		styp += strings.repeat(`*`, nr_muls)
 	}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -694,7 +694,8 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, left_type ast.Type, rig
 						if elem_sym.is_int() {
 							g.expr(left)
 							g.write(' == ')
-							if !((array_expr is ast.SelectorExpr && array_expr.typ == left_type)
+							if left_parent_idx != 0 && !((array_expr is ast.SelectorExpr
+								&& array_expr.typ == left_type)
 								|| (array_expr is ast.Ident && array_expr.obj.typ == left_type)) {
 								g.write('(${g.styp(left_parent_idx)})')
 							}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -782,7 +782,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				}
 			} else {
 				// embeded
-				if name.len > 0 && name[0].is_capital() && field_sym.info is ast.Struct {
+				if field.is_embed && field_sym.info is ast.Struct {
 					for embed in info.embeds {
 						if embed == int(field.typ) {
 							prefix_embed := if embed_prefix != '' {

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -31,7 +31,7 @@ fn (mut g Gen) unwrap_generic(typ ast.Type) ast.Type {
 					}
 				}
 			}
-		} else if typ.has_flag(.generic) && g.table.sym(typ).kind == .struct {
+		} else if g.table.sym(typ).kind == .struct {
 			// resolve selector `a.foo` where `a` is struct[T] on non generic function	
 			sym := g.table.sym(typ)
 			if sym.info is ast.Struct {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2214,6 +2214,7 @@ fn (mut p Parser) note_with_pos(s string, pos token.Pos) {
 	}
 }
 
+@[direct_array_access]
 fn (mut p Parser) parse_multi_expr(is_top_level bool) ast.Stmt {
 	// in here might be 1) multi-expr 2) multi-assign
 	// 1, a, c ... }       // multi-expression

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -340,6 +340,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				attrs:            p.attrs
 				is_pub:           is_embed || is_field_pub
 				is_mut:           is_embed || is_field_mut
+				is_embed:         is_embed
 				is_global:        is_field_global
 				is_volatile:      is_field_volatile
 				is_deprecated:    is_field_deprecated
@@ -503,6 +504,7 @@ fn (mut p Parser) struct_init(typ_str string, kind ast.StructInitKind, is_option
 				parent_type:      typ
 				has_prev_newline: has_prev_newline
 				has_break_line:   has_break_line
+				is_embed:         field_name.len > 0 && field_name[0].is_capital()
 			}
 		}
 	}


### PR DESCRIPTION
This PR tries to identify points to optimize by checking `gprof` output by:

- Reducing uneeded `string__eq` calls
- Removing repeated `typ.has_flag(.flag)` calls
- Reducing `array_get` calls where `@[direct_array_access]` can helps
- Reducing `alias_eq` calls to numeric types (like `ast.Type`)
- Reducing check for embed by adding `is_embed` flag to `ast.StructDecl` and `ast.StructInitField`

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIyZDM4MTI3Y2M3NjgxYzYyM2MyNWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.2VVEb-VNocN_dH4fnQ8m74k6wn9a6_YmpwUPzAxjTWo">Huly&reg;: <b>V_0.6-21157</b></a></sub>