### PR TITLE
tools: show the full test output, on known flaky test failure with `v test folder/`

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -702,6 +702,10 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 			}
 			full_failure_output := failure_output.str().trim_space()
 			if details.flaky && !fail_flaky {
+				ts.append_message(.info, '>>> flaky failures so far:', mtc)
+				for line in full_failure_output.split_into_lines() {
+					ts.append_message(.info, '>>>>>> ${line}', mtc)
+				}
 				ts.append_message(.info, '   *FAILURE* of the known flaky test file ${relative_file} is ignored, since VTEST_FAIL_FLAKY is 0 . Retry count: ${details.retry} .\n    comp_cmd: ${cmd}\n     run_cmd: ${run_cmd}',
 					mtc)
 				unsafe {


### PR DESCRIPTION
Make diagnosing flaky tests easier, on the CI and locally, without having to run them manually first.

It now shows all the lines below starting with `>>>`:
```
                 retrying 1/3 of vlib/x/vweb/tests/vweb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v ; known flaky: true ...
                 retrying 2/3 of vlib/x/vweb/tests/vweb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v ; known flaky: true ...
                 retrying 3/3 of vlib/x/vweb/tests/vweb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v ; known flaky: true ...
>>> flaky failures so far:
>>>>>> ---------------------------------------------------------------------------------------------------- retry: 0 ; max_retry: 3 ; r.exit_code: 1 ; trimmed_output.len: 1149
>>>>>> 2024-10-31T16:19:23.728582Z [DEBUG] testsuite_begin
>>>>>> 2024-10-31T16:19:23.728601Z [INFO ] working curl_executable found at: /usr/local/bin/curl
>>>>>> 2024-10-31T16:19:23.728604Z [DEBUG] starting watchdog thread to ensure the test will always exit one way or another...
>>>>>> 2024-10-31T16:19:23.728838Z [DEBUG] starting webserver...
>>>>>> [Vweb] Running app on http://localhost:23013/
>>>>>> 2024-10-31T16:19:23.735121Z [DEBUG] webserver started
>>>>>> 2024-10-31T16:19:23.748160Z [INFO ] > test_curl_connecting_through_ipv4_works
>>>>>> 2024-10-31T16:19:23.748577Z [INFO ] > test_net_http_connecting_through_ipv4_works
>>>>>> 2024-10-31T16:19:23.765041Z [INFO ] > test_curl_connecting_through_ipv6_works
>>>>>> /space/v/oo/vlib/x/vweb/tests/vweb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v:86: ✗ fn test_net_http_connecting_through_ipv6_works failed propagation with error: dial_tcp failed for address ::1:23013
>>>>>> tried addrs:
>>>>>>  0.0.0.0:0: net: socket error: 111; code: 111
>>>>>> 
>>>>>>    86 |  res := http.get('http://[::1]:${port}/')!
>>>>>> 2024-10-31T16:19:23.765479Z [DEBUG] testsuite_end
>>>>>> ---------------------------------------------------------------------------------------------------- retry: 1 ; max_retry: 3 ; r.exit_code: 1 ; trimmed_output.len: 1149
>>>>>> 2024-10-31T16:19:23.786566Z [DEBUG] testsuite_begin
>>>>>> 2024-10-31T16:19:23.786598Z [INFO ] working curl_executable found at: /usr/local/bin/curl
>>>>>> 2024-10-31T16:19:23.786602Z [DEBUG] starting watchdog thread to ensure the test will always exit one way or another...
```
etc...
