### PR TITLE
cgen: fix spawn with non-pointer receiver

### DIFF
--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -101,6 +101,10 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	}
 	if expr.is_method {
 		g.write('${arg_tmp_var}${dot}arg0 = ')
+		if expr.left is ast.Ident && expr.left.obj.typ.is_ptr()
+			&& !node.call_expr.receiver_type.is_ptr() {
+			g.write('*')
+		}
 		g.expr(expr.left)
 		g.writeln(';')
 	}

--- a/vlib/v/tests/concurrency/spawn_with_different_method_receivers_test.v
+++ b/vlib/v/tests/concurrency/spawn_with_different_method_receivers_test.v
@@ -1,0 +1,23 @@
+struct Server {}
+
+fn (server Server) non_mutable_receiver() {
+	println(@LOCATION)
+}
+
+fn (mut s Server) mutable_receiver() {
+	println(@LOCATION)
+}
+
+fn (s &Server) reference_receiver() {
+	println(@LOCATION)
+}
+
+fn test_spawning_threads_with_methods_that_have_mutable_and_non_mutable_receivers() {
+	mut server := &Server{}
+	t1 := spawn server.non_mutable_receiver()
+	t2 := spawn server.mutable_receiver()
+	t3 := spawn server.reference_receiver()
+	t1.wait()
+	t2.wait()
+	t3.wait()
+}


### PR DESCRIPTION
Fix #22718

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzIzZWQ0YjI3Y2M3NjgxYzYyNTdjZjQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.NlvBilCcDbwXueAz2bDPwKEum7Zajn9rDcFTKmhgm2o">Huly&reg;: <b>V_0.6-21166</b></a></sub>