### PR TITLE
cgen: fix `assert [1, 2, 3]!.map(it * 2) == [2, 4, 6]!`

### DIFF
--- a/vlib/builtin/fixed_array_map_test.v
+++ b/vlib/builtin/fixed_array_map_test.v
@@ -4,24 +4,42 @@ fn test_fixed_array_map() {
 	b1 := a.map(it * 2)
 	println(b1)
 	assert b1 == [2, 4, 6]!
+	b10 := [1, 2, 3]!.map(it * 2)
+	assert b10 == [2, 4, 6]!
+	assert [1, 2, 3]!.map(it * 2) == [2, 4, 6]!
 
 	b11 := a.map(|x| x * 2)
 	println(b11)
 	assert b11 == [2, 4, 6]!
+	b110 := [1, 2, 3]!.map(|x| x * 2)
+	assert b110 == [2, 4, 6]!
+	assert [1, 2, 3]!.map(|x| x * 2) == [2, 4, 6]!
 
 	b2 := a.map('${it}')
 	println(b2)
 	assert b2 == ['1', '2', '3']!
+	b20 := [1, 2, 3]!.map('${it}')
+	assert b20 == ['1', '2', '3']!
+	assert [1, 2, 3]!.map('${it}') == ['1', '2', '3']!
 
 	b22 := a.map(|x| '${x}')
 	println(b22)
 	assert b22 == ['1', '2', '3']!
+	b220 := [1, 2, 3]!.map(|x| '${x}')
+	assert b220 == ['1', '2', '3']!
+	assert [1, 2, 3]!.map(|x| '${x}') == ['1', '2', '3']!
 
 	b3 := a.map(it + 2)
 	println(b3)
 	assert b3 == [3, 4, 5]!
+	b30 := [1, 2, 3]!.map(it + 2)
+	assert b30 == [3, 4, 5]!
+	assert [1, 2, 3]!.map(it + 2) == [3, 4, 5]!
 
 	b33 := a.map(|x| x + 2)
 	println(b33)
 	assert b33 == [3, 4, 5]!
+	b330 := [1, 2, 3]!.map(|x| x + 2)
+	assert b330 == [3, 4, 5]!
+	assert [1, 2, 3]!.map(|x| x + 2) == [3, 4, 5]!
 }

--- a/vlib/v/gen/c/ctempvars.v
+++ b/vlib/v/gen/c/ctempvars.v
@@ -19,8 +19,15 @@ fn (mut g Gen) new_ctemp_var_then_gen(expr ast.Expr, expr_type ast.Type) ast.CTe
 
 fn (mut g Gen) gen_ctemp_var(tvar ast.CTempVar) {
 	styp := g.styp(tvar.typ)
-	g.write('${styp} ${tvar.name} = ')
-	g.expr(tvar.orig)
-	g.writeln(';')
+	if g.table.final_sym(tvar.typ).kind == .array_fixed {
+		g.writeln('${styp} ${tvar.name};')
+		g.write('memcpy(&${tvar.name}, &')
+		g.expr(tvar.orig)
+		g.writeln(' , sizeof(${styp}));')
+	} else {
+		g.write('${styp} ${tvar.name} = ')
+		g.expr(tvar.orig)
+		g.writeln(';')
+	}
 	g.set_current_pos_as_last_stmt_pos()
 }


### PR DESCRIPTION
This PR fix `assert [1, 2, 3]!.map(it * 2) == [2, 4, 6]!`.

- Fix `assert [1, 2, 3]!.map(it * 2) == [2, 4, 6]!`.
- Add tests.

```v
fn test_fixed_array_map() {
	a := [1, 2, 3]!

	b1 := a.map(it * 2)
	println(b1)
	assert b1 == [2, 4, 6]!
	b10 := [1, 2, 3]!.map(it * 2)
	assert b10 == [2, 4, 6]!
	assert [1, 2, 3]!.map(it * 2) == [2, 4, 6]!

	b11 := a.map(|x| x * 2)
	println(b11)
	assert b11 == [2, 4, 6]!
	b110 := [1, 2, 3]!.map(|x| x * 2)
	assert b110 == [2, 4, 6]!
	assert [1, 2, 3]!.map(|x| x * 2) == [2, 4, 6]!

	b2 := a.map('${it}')
	println(b2)
	assert b2 == ['1', '2', '3']!
	b20 := [1, 2, 3]!.map('${it}')
	assert b20 == ['1', '2', '3']!
	assert [1, 2, 3]!.map('${it}') == ['1', '2', '3']!

	b22 := a.map(|x| '${x}')
	println(b22)
	assert b22 == ['1', '2', '3']!
	b220 := [1, 2, 3]!.map(|x| '${x}')
	assert b220 == ['1', '2', '3']!
	assert [1, 2, 3]!.map(|x| '${x}') == ['1', '2', '3']!

	b3 := a.map(it + 2)
	println(b3)
	assert b3 == [3, 4, 5]!
	b30 := [1, 2, 3]!.map(it + 2)
	assert b30 == [3, 4, 5]!
	assert [1, 2, 3]!.map(it + 2) == [3, 4, 5]!

	b33 := a.map(|x| x + 2)
	println(b33)
	assert b33 == [3, 4, 5]!
	b330 := [1, 2, 3]!.map(|x| x + 2)
	assert b330 == [3, 4, 5]!
	assert [1, 2, 3]!.map(|x| x + 2) == [3, 4, 5]!
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI0NmM5ZjI3Y2M3NjgxYzYyNTg4NjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.FBC6uyxoPG8tQBvH2w7VdFCEhMapwNPQc-GfKRleyEI">Huly&reg;: <b>V_0.6-21169</b></a></sub>