### PR TITLE
cgen: fix `assert [1, 2, 3]!.contains(2)`

### DIFF
--- a/vlib/builtin/fixed_array_contains_test.v
+++ b/vlib/builtin/fixed_array_contains_test.v
@@ -3,10 +3,12 @@ fn test_contains_of_ints() {
 	mut ii := ia.contains(2)
 	dump(ii)
 	assert ii
+	assert [1, 2, 3]!.contains(2)
 
 	ii = ia.contains(5)
 	dump(ii)
 	assert !ii
+	assert ![1, 2, 3]!.contains(5)
 }
 
 fn test_contains_of_strings() {
@@ -14,10 +16,12 @@ fn test_contains_of_strings() {
 	mut si := sa.contains('b')
 	dump(si)
 	assert si
+	assert ['a', 'b', 'c']!.contains('b')
 
 	si = sa.contains('v')
 	dump(si)
 	assert !si
+	assert !['a', 'b', 'c']!.contains('v')
 }
 
 fn test_contains_of_voidptrs() {
@@ -25,10 +29,12 @@ fn test_contains_of_voidptrs() {
 	mut pi := pa.contains(voidptr(45))
 	dump(pi)
 	assert pi
+	assert [voidptr(123), voidptr(45), voidptr(99)]!.contains(voidptr(45))
 
 	pi = pa.contains(unsafe { nil })
 	dump(pi)
 	assert !pi
+	assert ![voidptr(123), voidptr(45), voidptr(99)]!.contains(unsafe { nil })
 }
 
 fn a() {}
@@ -44,8 +50,10 @@ fn test_contains_of_fns() {
 	mut fi := fa.contains(b)
 	dump(fi)
 	assert fi
+	assert [a, b, c]!.contains(b)
 
 	fi = fa.contains(v)
 	dump(fi)
 	assert !fi
+	assert ![a, b, c]!.contains(v)
 }


### PR DESCRIPTION
This PR fix `assert [1, 2, 3]!.contains(2)`.

- Fix `assert [1, 2, 3]!.contains(2)`.
- Add tests.

```v
fn test_contains_of_ints() {
	ia := [1, 2, 3]!
	mut ii := ia.contains(2)
	dump(ii)
	assert ii
	assert [1, 2, 3]!.contains(2)

	ii = ia.contains(5)
	dump(ii)
	assert !ii
	assert ![1, 2, 3]!.contains(5)
}

fn test_contains_of_strings() {
	sa := ['a', 'b', 'c']!
	mut si := sa.contains('b')
	dump(si)
	assert si
	assert ['a', 'b', 'c']!.contains('b')

	si = sa.contains('v')
	dump(si)
	assert !si
	assert !['a', 'b', 'c']!.contains('v')
}

fn test_contains_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!
	mut pi := pa.contains(voidptr(45))
	dump(pi)
	assert pi
	assert [voidptr(123), voidptr(45), voidptr(99)]!.contains(voidptr(45))

	pi = pa.contains(unsafe { nil })
	dump(pi)
	assert !pi
	assert ![voidptr(123), voidptr(45), voidptr(99)]!.contains(unsafe { nil })
}

fn a() {}

fn b() {}

fn c() {}

fn v() {}

fn test_contains_of_fns() {
	fa := [a, b, c]!
	mut fi := fa.contains(b)
	dump(fi)
	assert fi
	assert [a, b, c]!.contains(b)

	fi = fa.contains(v)
	dump(fi)
	assert !fi
	assert ![a, b, c]!.contains(v)
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI0ZGMwZjI3Y2M3NjgxYzYyNWE3ZDciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.32PNx1UeXvBxiDkDWhCmaCOM2HNJyYylZQeVZ1rC8Zo">Huly&reg;: <b>V_0.6-21172</b></a></sub>