### PR TITLE
cgen: fix `assert [1, 2, 3]!.index(2) == 1`

### DIFF
--- a/vlib/builtin/fixed_array_index_test.v
+++ b/vlib/builtin/fixed_array_index_test.v
@@ -3,10 +3,12 @@ fn test_index_of_ints() {
 	mut ii := ia.index(2)
 	dump(ii)
 	assert ii == 1
+	assert [1, 2, 3]!.index(2) == 1
 
 	ii = ia.index(5)
 	dump(ii)
 	assert ii == -1
+	assert [1, 2, 3]!.index(5) == -1
 }
 
 fn test_index_of_strings() {
@@ -14,10 +16,12 @@ fn test_index_of_strings() {
 	mut si := sa.index('b')
 	dump(si)
 	assert si == 1
+	assert ['a', 'b', 'c']!.index('b') == 1
 
 	si = sa.index('v')
 	dump(si)
 	assert si == -1
+	assert ['a', 'b', 'c']!.index('v') == -1
 }
 
 fn test_index_of_voidptrs() {
@@ -25,10 +29,12 @@ fn test_index_of_voidptrs() {
 	mut pi := pa.index(voidptr(45))
 	dump(pi)
 	assert pi == 1
+	assert [voidptr(123), voidptr(45), voidptr(99)]!.index(voidptr(45)) == 1
 
 	pi = pa.index(unsafe { nil })
 	dump(pi)
 	assert pi == -1
+	assert [voidptr(123), voidptr(45), voidptr(99)]!.index(unsafe { nil }) == -1
 }
 
 fn a() {}
@@ -44,8 +50,10 @@ fn test_index_of_fns() {
 	mut fi := fa.index(b)
 	dump(fi)
 	assert fi == 1
+	assert [a, b, c]!.index(b) == 1
 
 	fi = fa.index(v)
 	dump(fi)
 	assert fi == -1
+	assert [a, b, c]!.index(v) == -1
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1300,14 +1300,18 @@ fn (mut g Gen) gen_array_index_methods() {
 // `nums.index(2)`
 fn (mut g Gen) gen_array_index(node ast.CallExpr) {
 	fn_name := g.get_array_index_method(node.left_type)
+	left_sym := g.table.final_sym(node.left_type)
 	g.write('${fn_name}(')
 	if node.left_type.is_ptr() {
 		g.write('*')
 	}
-	g.expr(node.left)
+	if left_sym.kind == .array_fixed && node.left is ast.ArrayInit {
+		g.fixed_array_init_with_cast(node.left, node.left_type)
+	} else {
+		g.expr(node.left)
+	}
 	g.write(', ')
 
-	left_sym := g.table.final_sym(node.left_type)
 	elem_typ := if left_sym.kind == .array {
 		left_sym.array_info().elem_type
 	} else {


### PR DESCRIPTION
This PR fix `assert [1, 2, 3]!.index(2) == 1`.

- Fix `assert [1, 2, 3]!.index(2) == 1`.
- Add tests.

```v
fn test_index_of_ints() {
	ia := [1, 2, 3]!
	mut ii := ia.index(2)
	dump(ii)
	assert ii == 1
	assert [1, 2, 3]!.index(2) == 1

	ii = ia.index(5)
	dump(ii)
	assert ii == -1
	assert [1, 2, 3]!.index(5) == -1
}

fn test_index_of_strings() {
	sa := ['a', 'b', 'c']!
	mut si := sa.index('b')
	dump(si)
	assert si == 1
	assert ['a', 'b', 'c']!.index('b') == 1

	si = sa.index('v')
	dump(si)
	assert si == -1
	assert ['a', 'b', 'c']!.index('v') == -1
}

fn test_index_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!
	mut pi := pa.index(voidptr(45))
	dump(pi)
	assert pi == 1
	assert [voidptr(123), voidptr(45), voidptr(99)]!.index(voidptr(45)) == 1

	pi = pa.index(unsafe { nil })
	dump(pi)
	assert pi == -1
	assert [voidptr(123), voidptr(45), voidptr(99)]!.index(unsafe { nil }) == -1
}

fn a() {}

fn b() {}

fn c() {}

fn v() {}

fn test_index_of_fns() {
	fa := [a, b, c]!
	mut fi := fa.index(b)
	dump(fi)
	assert fi == 1
	assert [a, b, c]!.index(b) == 1

	fi = fa.index(v)
	dump(fi)
	assert fi == -1
	assert [a, b, c]!.index(v) == -1
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI0ZTRiMzI3Y2M3NjgxYzYyNWIxYzEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.i0zTJCQJNEt0U1n0t-fck7FgS7NqL7gPOHnxQvBNZGw">Huly&reg;: <b>V_0.6-21174</b></a></sub>