### PR TITLE
checker: fix none check for match expr with option

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -55,7 +55,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 					branch.branch_pos)
 			}
 		}
-		if !branch.is_else && cond_is_option && branch.exprs[0] !is ast.None {
+		if !branch.is_else && cond_is_option && branch.exprs.any(it !is ast.None) {
 			c.error('`match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`',
 				branch.pos)
 		}

--- a/vlib/v/checker/tests/match_option_without_none_err.out
+++ b/vlib/v/checker/tests/match_option_without_none_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/match_option_without_none_err.vv:16:3: error: `match` expression with Option type only checks against `none`, to match its value you must unwrap it first `var?`
+   14 |     match p.part {
+   15 |         // Next weird line crashes compiler before sugesting 'unwrap' var?
+   16 |         none, 1 { return '' }
+      |         ~~~~~~~
+   17 |         else { return '${p.part}' }
+   18 |     }

--- a/vlib/v/checker/tests/match_option_without_none_err.vv
+++ b/vlib/v/checker/tests/match_option_without_none_err.vv
@@ -1,0 +1,19 @@
+pub struct Post {
+	part ?u8
+}
+
+fn (p Post) get_part_1() string {
+	part := p.part or { return '' }
+	match part {
+		0 { return '' }
+		else { return '${part}' }
+	}
+}
+
+fn (p Post) get_part_2() string {
+	match p.part {
+		// Next weird line crashes compiler before sugesting 'unwrap' var?
+		none, 1 { return '' }
+		else { return '${p.part}' }
+	}
+}


### PR DESCRIPTION
Fix #22728

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI1NzFmODI3Y2M3NjgxYzYyNWQ2MTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.uOC6lQsBRPmaCQpX6liilSIojG9ffKauPOEp8vcvrUQ">Huly&reg;: <b>V_0.6-21179</b></a></sub>