### PR TITLE
parser,checker: fix option map fn type and missing check for result param type

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -471,7 +471,7 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 			} else if val_sym.info is ast.FnType {
 				for param in val_sym.info.func.params {
 					if param.typ.has_flag(.result) {
-						c.error('Result type argument is not supported currently', node.pos)
+						c.error('result type arguments are not supported', node.pos)
 					}
 				}
 			}

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -468,6 +468,12 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 							node.pos)
 					}
 				}
+			} else if val_sym.info is ast.FnType {
+				for param in val_sym.info.func.params {
+					if param.typ.has_flag(.result) {
+						c.error('Result type argument is not supported currently', node.pos)
+					}
+				}
 			}
 		}
 		c.ensure_type_exists(info.key_type, node.pos)

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -264,7 +264,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					param.pos)
 			}
 			if param.typ.has_flag(.result) {
-				c.error('Result type argument is not supported currently', param.type_pos)
+				c.error('result type arguments are not supported', param.type_pos)
 			}
 			arg_typ_sym := c.table.sym(param.typ)
 			if arg_typ_sym.info is ast.Struct {

--- a/vlib/v/checker/tests/result_param_type_err.out
+++ b/vlib/v/checker/tests/result_param_type_err.out
@@ -3,11 +3,11 @@ vlib/v/checker/tests/result_param_type_err.vv:3:13: error: Result type argument 
     2 | 
     3 | fn func(arg !string, val &int) ?int {
       |             ~~~~~~~
-    4 |     unsafe { *val = 2 }
-    5 |     return 2
-vlib/v/checker/tests/result_param_type_err.vv:9:7: error: Result type argument is not supported currently
-    7 | 
-    8 | fn main() {
-    9 |     _ := map[string]fn(!string, &int) ?int{}
-      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   10 | }
+    4 |     unsafe {
+    5 |         *val = 2
+vlib/v/checker/tests/result_param_type_err.vv:11:7: error: Result type argument is not supported currently
+    9 | 
+   10 | fn main() {
+   11 |     _ := map[string]fn (!string, &int) ?int{}
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   12 | }

--- a/vlib/v/checker/tests/result_param_type_err.out
+++ b/vlib/v/checker/tests/result_param_type_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/result_param_type_err.vv:3:13: error: Result type argument is not supported currently
+    1 | module main
+    2 | 
+    3 | fn func(arg !string, val &int) ?int {
+      |             ~~~~~~~
+    4 |     unsafe { *val = 2 }
+    5 |     return 2
+vlib/v/checker/tests/result_param_type_err.vv:9:7: error: Result type argument is not supported currently
+    7 | 
+    8 | fn main() {
+    9 |     _ := map[string]fn(!string, &int) ?int{}
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   10 | }

--- a/vlib/v/checker/tests/result_param_type_err.out
+++ b/vlib/v/checker/tests/result_param_type_err.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/result_param_type_err.vv:3:13: error: Result type argument is not supported currently
+vlib/v/checker/tests/result_param_type_err.vv:3:13: error: result type arguments are not supported
     1 | module main
     2 | 
     3 | fn func(arg !string, val &int) ?int {
       |             ~~~~~~~
     4 |     unsafe {
     5 |         *val = 2
-vlib/v/checker/tests/result_param_type_err.vv:11:7: error: Result type argument is not supported currently
+vlib/v/checker/tests/result_param_type_err.vv:11:7: error: result type arguments are not supported
     9 | 
    10 | fn main() {
    11 |     _ := map[string]fn (!string, &int) ?int{}

--- a/vlib/v/checker/tests/result_param_type_err.vv
+++ b/vlib/v/checker/tests/result_param_type_err.vv
@@ -1,0 +1,12 @@
+module main
+
+fn func(arg !string, val &int) ?int {
+	unsafe {
+		*val = 2
+	}
+	return 2
+}
+
+fn main() {
+	_ := map[string]fn (!string, &int) ?int{}
+}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -517,6 +517,9 @@ fn (mut g Gen) fn_decl_str(info ast.FnType) string {
 		if i > 0 {
 			fn_str += ', '
 		}
+		if arg.typ.has_flag(.option) {
+			fn_str += '?'
+		}
 		fn_str += util.strip_main_name(g.table.get_type_name(g.unwrap_generic(arg.typ)))
 	}
 	fn_str += ')'

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -409,6 +409,9 @@ fn (mut g JsGen) fn_decl_str(info ast.FnType) string {
 		if i > 0 {
 			fn_str += ', '
 		}
+		if arg.typ.has_flag(.option) {
+			fn_str += '?'
+		}
 		fn_str += util.strip_main_name(g.table.get_type_name(g.unwrap_generic(arg.typ)))
 	}
 	fn_str += ')'

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3432,6 +3432,9 @@ fn (mut g JsGen) gen_typeof_expr(it ast.TypeOf) {
 		}
 		repr += ')'
 		if fn_info.return_type != ast.void_type {
+			if fn_info.return_type.has_flag(.option) {
+				repr += '?'
+			}
 			repr += ' ${g.table.get_type_name(fn_info.return_type)}'
 		}
 		g.write('"${repr}"')

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3425,6 +3425,9 @@ fn (mut g JsGen) gen_typeof_expr(it ast.TypeOf) {
 			if i > 0 {
 				repr += ', '
 			}
+			if arg.typ.has_flag(.option) {
+				repr += '?'
+			}
 			repr += g.table.get_type_name(arg.typ)
 		}
 		repr += ')'

--- a/vlib/v/gen/native/expr.v
+++ b/vlib/v/gen/native/expr.v
@@ -236,6 +236,9 @@ fn (mut g Gen) fn_decl_str(info ast.FnType) string {
 		if i > 0 {
 			fn_str += ', '
 		}
+		if arg.typ.has_flag(.option) {
+			fn_str += '?'
+		}
 		fn_str += util.strip_main_name(g.table.get_type_name(arg.typ))
 	}
 	fn_str += ')'

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -918,7 +918,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool, bool) {
 	}
 	is_generic_type := p.tok.kind == .name && p.tok.lit.len == 1 && p.tok.lit[0].is_capital()
 
-	types_only := p.tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]
+	types_only := p.tok.kind in [.question, .not, .amp, .ellipsis, .key_fn, .lsbr]
 		|| (p.peek_tok.kind == .comma && (p.table.known_type(param_name) || is_generic_type))
 		|| p.peek_tok.kind == .dot || p.peek_tok.kind == .rpar || p.fn_language == .c
 		|| (p.tok.kind == .key_mut && (p.peek_tok.kind in [.amp, .ellipsis, .key_fn, .lsbr]

--- a/vlib/v/tests/options/option_map_fn_value_test.v
+++ b/vlib/v/tests/options/option_map_fn_value_test.v
@@ -1,0 +1,29 @@
+module main
+
+fn func(arg ?string, val &int) ?int {
+	unsafe {
+		*val = 2
+	}
+	return 2
+}
+
+fn test_main() {
+	map1 := {
+		'json': func
+	}
+	assert typeof(map1['json']).name == 'fn (?string, int) ?int'
+
+	number := 0
+	ret := map1['json']('hi', &number)
+	assert number == ret?
+	assert ret? == 2
+
+	mut map2 := map[string]fn (?string, &int) ?int{}
+	map2['json'] = func
+	assert typeof(map2['json']).name == 'fn (?string, int) ?int'
+
+	number2 := 0
+	ret2 := map2['json']('', &number2)
+	assert number2 == ret2?
+	assert ret2? == 2
+}


### PR DESCRIPTION
Fix #22736

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI2MDFlMTI3Y2M3NjgxYzYyNWYyYzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.iZXgsd0VjB8ZaxM8vM-qQN2nppfJx-NUB6BY-3X6GyU">Huly&reg;: <b>V_0.6-21185</b></a></sub>