### PR TITLE
cgen: fix `assert [2, 3, 1]!.sorted() == [1, 2, 3]!`

### DIFF
--- a/vlib/builtin/fixed_array_sort_test.v
+++ b/vlib/builtin/fixed_array_sort_test.v
@@ -48,6 +48,7 @@ fn test_sorted_immutable_original_should_not_change() {
 	b := a.sorted()
 	assert a == ['hi', '1', '5', '3']!
 	assert b == ['1', '3', '5', 'hi']!
+	assert ['hi', '1', '5', '3']!.sorted() == ['1', '3', '5', 'hi']!
 }
 
 fn test_sorted_mutable_original_should_not_change() {
@@ -55,6 +56,7 @@ fn test_sorted_mutable_original_should_not_change() {
 	b := a.sorted()
 	assert a == ['hi', '1', '5', '3']!
 	assert b == ['1', '3', '5', 'hi']!
+	assert ['hi', '1', '5', '3']!.sorted() == ['1', '3', '5', 'hi']!
 }
 
 fn test_sorted_reversed() {
@@ -62,12 +64,14 @@ fn test_sorted_reversed() {
 	bb := aa.sorted(a > b)
 	assert aa == ['hi', '1', '5', '3']!
 	assert bb == ['hi', '5', '3', '1']!
+	assert ['hi', '1', '5', '3']!.sorted(a > b) == ['hi', '5', '3', '1']!
 }
 
 fn test_sorted_by_len() {
 	a := ['hi', 'abc', 'a', 'zzzzz']!
 	c := a.sorted(a.len < b.len)
 	assert c == ['a', 'hi', 'abc', 'zzzzz']!
+	assert ['hi', 'abc', 'a', 'zzzzz']!.sorted(a.len < b.len) == ['a', 'hi', 'abc', 'zzzzz']!
 }
 
 fn test_sort_with_compare_1() {
@@ -97,6 +101,15 @@ fn test_sorted_with_compare_1() {
 	})
 	assert a == ['hi', '1', '5', '3']!
 	assert b == ['1', '3', '5', 'hi']!
+	assert ['hi', '1', '5', '3']!.sorted_with_compare(fn (a &string, b &string) int {
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
+		return 0
+	}) == ['1', '3', '5', 'hi']!
 }
 
 struct Ka {
@@ -163,4 +176,26 @@ fn test_sorted_with_compare_2() {
 	assert b[1].i == 100
 	assert b[2].s == 'ccc'
 	assert b[2].i == 102
+
+	b2 := [
+		Ka{
+			s: 'bbb'
+			i: 100
+		},
+		Ka{
+			s: 'aaa'
+			i: 101
+		},
+		Ka{
+			s: 'ccc'
+			i: 102
+		},
+	]!.sorted_with_compare(cmp)
+
+	assert b2[0].s == 'aaa'
+	assert b2[0].i == 101
+	assert b2[1].s == 'bbb'
+	assert b2[1].i == 100
+	assert b2[2].s == 'ccc'
+	assert b2[2].i == 102
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -636,7 +636,11 @@ fn (mut g Gen) gen_array_sorted(node ast.CallExpr) {
 	} else {
 		g.writeln('${atype} ${past.tmp_var};')
 		g.write('memcpy(&${past.tmp_var}, &')
-		g.expr(node.left)
+		if node.left is ast.ArrayInit {
+			g.fixed_array_init_with_cast(node.left, node.left_type)
+		} else {
+			g.expr(node.left)
+		}
 		g.writeln(', sizeof(${atype}));')
 	}
 
@@ -794,7 +798,11 @@ fn (mut g Gen) gen_fixed_array_sorted_with_compare(node ast.CallExpr) {
 	atype := g.styp(node.return_type)
 	g.writeln('${atype} ${past.tmp_var};')
 	g.write('memcpy(&${past.tmp_var}, &')
-	g.expr(node.left)
+	if node.left is ast.ArrayInit {
+		g.fixed_array_init_with_cast(node.left, node.left_type)
+	} else {
+		g.expr(node.left)
+	}
 	g.writeln(', sizeof(${atype}));')
 
 	unsafe {


### PR DESCRIPTION
This PR fix `assert [2, 3, 1]!.sorted() == [1, 2, 3]!`.

- Fix `assert [2, 3, 1]!.sorted() == [1, 2, 3]!`.
- Add tests.

```v
fn test_sorted_immutable_original_should_not_change() {
	a := ['hi', '1', '5', '3']!
	b := a.sorted()
	assert a == ['hi', '1', '5', '3']!
	assert b == ['1', '3', '5', 'hi']!
	assert ['hi', '1', '5', '3']!.sorted() == ['1', '3', '5', 'hi']!
}

fn test_sorted_mutable_original_should_not_change() {
	mut a := ['hi', '1', '5', '3']!
	b := a.sorted()
	assert a == ['hi', '1', '5', '3']!
	assert b == ['1', '3', '5', 'hi']!
	assert ['hi', '1', '5', '3']!.sorted() == ['1', '3', '5', 'hi']!
}

fn test_sorted_reversed() {
	aa := ['hi', '1', '5', '3']!
	bb := aa.sorted(a > b)
	assert aa == ['hi', '1', '5', '3']!
	assert bb == ['hi', '5', '3', '1']!
	assert ['hi', '1', '5', '3']!.sorted(a > b) == ['hi', '5', '3', '1']!
}

fn test_sorted_by_len() {
	a := ['hi', 'abc', 'a', 'zzzzz']!
	c := a.sorted(a.len < b.len)
	assert c == ['a', 'hi', 'abc', 'zzzzz']!
	assert ['hi', 'abc', 'a', 'zzzzz']!.sorted(a.len < b.len) == ['a', 'hi', 'abc', 'zzzzz']!
}


fn test_sorted_with_compare_1() {
	a := ['hi', '1', '5', '3']!
	b := a.sorted_with_compare(fn (a &string, b &string) int {
		if a < b {
			return -1
		}
		if a > b {
			return 1
		}
		return 0
	})
	assert a == ['hi', '1', '5', '3']!
	assert b == ['1', '3', '5', 'hi']!
	assert ['hi', '1', '5', '3']!.sorted_with_compare(fn (a &string, b &string) int {
		if a < b {
			return -1
		}
		if a > b {
			return 1
		}
		return 0
	}) == ['1', '3', '5', 'hi']!
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI2MmM1MTI3Y2M3NjgxYzYyNWY2MDIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.WHXEcxPdCgHknv3PRe3cxJQNZNhcq3ifZnBs0V5_7vk">Huly&reg;: <b>V_0.6-21186</b></a></sub>