### PR TITLE
x.json2.decoder2: attributes

### DIFF
--- a/vlib/x/json2/decoder2/attributes.v
+++ b/vlib/x/json2/decoder2/attributes.v
@@ -1,0 +1,67 @@
+module decoder2
+
+pub enum AttributeBehaviorOnComptimeForFieldsLoop {
+	// do nothing
+	none_
+	// skip the field
+	continue_
+	// break the loop
+	break_
+}
+
+pub struct MutableFieldData {
+pub mut:
+	name          string // the name of the field f
+	typ           int    // the internal TypeID of the field f,
+	unaliased_typ int    // if f's type was an alias of int, this will be TypeID(int)
+
+	is_pub bool // f is in a `pub:` section
+	is_mut bool // f is in a `mut:` section
+
+	is_shared bool // `f shared Abc`
+	is_atomic bool // `f atomic int` , TODO
+	is_option bool // `f ?string` , TODO
+
+	is_array  bool // `f []string` , TODO
+	is_map    bool // `f map[string]int` , TODO
+	is_chan   bool // `f chan int` , TODO
+	is_enum   bool // `f Enum` where Enum is an enum
+	is_struct bool // `f Abc` where Abc is a struct , TODO
+	is_alias  bool // `f MyInt` where `type MyInt = int`, TODO
+
+	indirections u8 // 0 for `f int`, 1 for `f &int`, 2 for `f &&int` , TODO
+}
+
+pub fn new_mutable_from_field_data(field_data FieldData) MutableFieldData {
+	return MutableFieldData{
+		name:          field_data.name
+		typ:           field_data.typ
+		unaliased_typ: field_data.unaliased_typ
+		is_pub:        field_data.is_pub
+		is_mut:        field_data.is_mut
+		is_shared:     field_data.is_shared
+		is_atomic:     field_data.is_atomic
+		is_option:     field_data.is_option
+		is_array:      field_data.is_array
+		is_map:        field_data.is_map
+		is_chan:       field_data.is_chan
+		is_enum:       field_data.is_enum
+		is_struct:     field_data.is_struct
+		is_alias:      field_data.is_alias
+		indirections:  field_data.indirections
+	}
+}
+
+const default_attributes_handlers = {
+	'skip': skip_attribute_handler
+	'json': json_attribute_handler
+}
+
+fn skip_attribute_handler(arg string, mut field MutableFieldData, value_info ValueInfo) AttributeBehaviorOnComptimeForFieldsLoop {
+	return .continue_
+}
+
+fn json_attribute_handler(arg string, mut field MutableFieldData, value_info ValueInfo) AttributeBehaviorOnComptimeForFieldsLoop {
+	field.name = arg
+	return .none_
+}

--- a/vlib/x/json2/decoder2/attributes_test.v
+++ b/vlib/x/json2/decoder2/attributes_test.v
@@ -1,0 +1,61 @@
+import x.json2.decoder2 as json
+
+struct StruWithJsonAttribute {
+	a     int
+	name2 string @[json: 'name']
+	b     int
+}
+
+struct StruWithSkipAttribute {
+	a     int
+	name2 string @[skip]
+	b     int
+}
+
+struct StruWithCustomUserAttribute {
+	a    int    @[some_custom_attribute_created_by_user]
+	name string @[some_custom_attribute_created_by_user]
+	b    int    @[some_custom_attribute_created_by_user]
+}
+
+fn test_default_attributes() {
+	assert json.decode[StruWithJsonAttribute]('{"name": "hola", "a": 2, "b": 3}')! == StruWithJsonAttribute{
+		a:     2
+		name2: 'hola'
+		b:     3
+	}
+
+	assert json.decode[StruWithSkipAttribute]('{"name2": "hola", "a": 2, "b": 3}')! == StruWithSkipAttribute{
+		a:     2
+		name2: ''
+		b:     3
+	}
+}
+
+fn do_something_attribute_handler(arg string, mut field json.MutableFieldData, value_info json.ValueInfo) json.AttributeBehaviorOnComptimeForFieldsLoop {
+	println('this do something, like change the field name, print this message, etc')
+
+	// don't decode if the field is int
+	if field.typ == typeof[int]().idx {
+		return .continue_
+	}
+
+	return .none_
+}
+
+fn test_custom_user_attribute() {
+	mut result := StruWithCustomUserAttribute{}
+
+	mut decoder := json.new_decoder[StruWithCustomUserAttribute]('{"name": "hola", "a": 2, "b": 3}',
+		{
+		'some_custom_attribute_created_by_user': do_something_attribute_handler
+	})!
+
+	decoder.decode_value(mut &result)!
+
+	assert result == StruWithCustomUserAttribute{
+		a:    0
+		name: 'hola'
+		b:    0
+	}
+}


### PR DESCRIPTION
```sh
V cache folder /home/hitalo/.vmodules/.cache was wiped.
V tmp.c and tests folder folder /tmp/v_1000 was wiped.
Starting benchmark...
max_iterations: 1000000

***Structure and maps***
 SPENT   347.086 ms in decoder2.decode[Stru](json_data)!
 SPENT   475.593 ms in old_json.decode(Stru, json_data)!

 SPENT   394.047 ms in decoder2.decode[SumTypes](json_data)!
 SPENT   503.372 ms in old_json.decode(SumTypes, json_data)!

 SPENT    88.243 ms in decoder2.decode[StructType[string]](json_data1)!
 SPENT    97.144 ms in old_json.decode(StructType[string], json_data1)!

 SPENT    89.701 ms in decoder2.decode[StructTypeOption[string]](json_data1)!
 SPENT    98.341 ms in old_json.decode(StructTypeOption[string], json_data1)!

 SPENT    69.165 ms in decoder2.decode[StructType[int]](json_data2)!
 SPENT   123.711 ms in old_json.decode(StructType[int], json_data2)!

 SPENT   191.122 ms in decoder2.decode[map[string]string](json_data1)!
 SPENT   198.495 ms in old_json.decode(map[string]string, json_data1)!


***arrays***
 SPENT   331.274 ms in decoder2.decode[[]int]('[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]')!
 SPENT   560.674 ms in old_json.decode([]int, '[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]')!


***simple types***
 SPENT    28.513 ms in decoder2.decode[int]('2')!
 SPENT    26.833 ms in decoder2.decode[bool]('true')!
 SPENT    60.771 ms in decoder2.decode[time.Time]('2022-03-11T13:54:25')!
 SPENT    88.026 ms in decoder2.decode[string]('"abcdefghijklimnopqrstuv"')!

***alias***
 SPENT    27.310 ms in decoder2.decode[IntAlias](2)!
 SPENT    89.452 ms in decoder2.decode[StringAlias]('"abcdefghijklimnopqrstuv"')!

***Sumtypes***
 SPENT    62.700 ms in decoder2.decode[SumTypes](2)!
 SPENT   130.320 ms in decoder2.decode[SumTypes]('"abcdefghijklimnopqrstuv"')!
```
