### PR TITLE
checker: fix missing info about generic fn var usage without concrete types

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3833,6 +3833,10 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		info := node.info as ast.IdentFn
 		if func := c.table.find_fn(node.name) {
 			if func.generic_names.len > 0 {
+				if node.concrete_types.len == 0 {
+					c.error('`${node.name}` is a generic fn, you should pass its concrete types, e.g. ${node.name}[int]',
+						node.pos)
+				}
 				concrete_types := node.concrete_types.map(c.unwrap_generic(it))
 				if concrete_types.all(!it.has_flag(.generic)) {
 					c.table.register_fn_concrete_types(func.fkey(), concrete_types)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4010,6 +4010,12 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		}
 		// Non-anon-function object (not a call), e.g. `onclick(my_click)`
 		if func := c.table.find_fn(name) {
+			if func.generic_names.len > 0 {
+				if node.concrete_types.len == 0 {
+					c.error('`${node.name}` is a generic fn, you should pass its concrete types, e.g. ${node.name}[int]',
+						node.pos)
+				}
+			}
 			return c.resolve_var_fn(func, mut node, name)
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -121,8 +121,9 @@ mut:
 	is_last_stmt                     bool
 	prevent_sum_type_unwrapping_once bool // needed for assign new values to sum type, stopping unwrapping then
 	using_new_err_struct             bool
-	need_recheck_generic_fns         bool // need recheck generic fns because there are cascaded nested generic fn
-	inside_sql                       bool // to handle sql table fields pseudo variables
+	need_recheck_generic_fns         bool            // need recheck generic fns because there are cascaded nested generic fn
+	generic_fns                      map[string]bool // register generic fns that needs recheck once
+	inside_sql                       bool            // to handle sql table fields pseudo variables
 	inside_selector_expr             bool
 	inside_interface_deref           bool
 	inside_decl_rhs                  bool

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -38,9 +38,10 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		// This is done so that all generic function calls can
 		// have a chance to populate c.table.fn_generic_types with
 		// the correct concrete types.
-		if !c.generic_fns[node.fkey()] {
+		fkey := node.fkey()
+		if !c.generic_fns[fkey] {
 			c.need_recheck_generic_fns = true
-			c.generic_fns[node.fkey()] = true
+			c.generic_fns[fkey] = true
 			c.file.generic_fns << node
 		}
 		return

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -38,8 +38,11 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 		// This is done so that all generic function calls can
 		// have a chance to populate c.table.fn_generic_types with
 		// the correct concrete types.
-		c.file.generic_fns << node
-		c.need_recheck_generic_fns = true
+		if !c.generic_fns[node.fkey()] {
+			c.need_recheck_generic_fns = true
+			c.generic_fns[node.fkey()] = true
+			c.file.generic_fns << node
+		}
 		return
 	}
 	node.ninstances++
@@ -2764,7 +2767,7 @@ fn (mut c Checker) post_process_generic_fns() ! {
 		fkey := node.fkey()
 		all_generic_fns[fkey]++
 		if all_generic_fns[fkey] > generic_fn_cutoff_limit_per_fn {
-			c.error('generic function visited more than ${generic_fn_cutoff_limit_per_fn} times',
+			c.error('${fkey} generic function visited more than ${generic_fn_cutoff_limit_per_fn} times',
 				node.pos)
 			return error('fkey: ${fkey}')
 		}

--- a/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
+++ b/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
@@ -5,6 +5,20 @@ vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:2: warning: unused 
       |     ~~~
     7 |     // ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
     8 | }
+vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:9: error: `f1` is a generic fn, you should pass its concrete types, e.g. f1[int]
+    4 | 
+    5 | fn main() {
+    6 |     ff1 := f1 // <-- missing e.g. `[int]`
+      |            ~~
+    7 |     // ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
+    8 | }
+vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:9: error: `f1` is a generic fn, you should pass its concrete types, e.g. f1[int]
+    4 | 
+    5 | fn main() {
+    6 |     ff1 := f1 // <-- missing e.g. `[int]`
+      |            ~~
+    7 |     // ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
+    8 | }
 vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:9: error: cannot assign `f1` as a generic function variable
     4 | 
     5 | fn main() {

--- a/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
+++ b/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
@@ -26,8 +26,3 @@ vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:9: error: cannot as
       |            ~~
     7 |     // ff1 := f1[int] <-- is a valid usage with generic return types that are not generic structs
     8 | }
-vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:1:1: error: generic function visited more than 10000 times
-    1 | fn f1[T](x T, i int) T {
-      | ~~~~~~~~~~~~~~~~~~~~~~
-    2 |     return x
-    3 | }

--- a/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
+++ b/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
@@ -19,10 +19,3 @@ vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:10:11: error: `func` is a 
       |                 ~~~~
    11 |     }
    12 | }
-vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:3:1: error: generic function visited more than 10000 times
-    1 | module main
-    2 | 
-    3 | fn func[T](arg string, mut val T) int {
-      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    4 |     return 2
-    5 | }

--- a/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
+++ b/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:8:7: error: `func` is a generic fn, you must pass its concrete types, e.g. func[int]
+    6 | 
+    7 | fn main() {
+    8 |     _ := func
+      |          ~~~~
+    9 | }
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:3:1: error: generic function visited more than 10000 times
+    1 | module main
+    2 | 
+    3 | fn func[T](arg string, mut val T) int {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4 |     return 2
+    5 | }

--- a/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
+++ b/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
@@ -1,9 +1,24 @@
-vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:8:7: error: `func` is a generic fn, you must pass its concrete types, e.g. func[int]
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:8:7: error: `func` is a generic fn, you should pass its concrete types, e.g. func[int]
     6 | 
     7 | fn main() {
     8 |     _ := func
       |          ~~~~
-    9 | }
+    9 |     _ := {
+   10 |         'test': func
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:8:7: error: `func` is a generic fn, you should pass its concrete types, e.g. func[int]
+    6 | 
+    7 | fn main() {
+    8 |     _ := func
+      |          ~~~~
+    9 |     _ := {
+   10 |         'test': func
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:10:11: error: `func` is a generic fn, you should pass its concrete types, e.g. func[int]
+    8 |     _ := func
+    9 |     _ := {
+   10 |         'test': func
+      |                 ~~~~
+   11 |     }
+   12 | }
 vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:3:1: error: generic function visited more than 10000 times
     1 | module main
     2 | 

--- a/vlib/v/checker/tests/generic_fn_var_unresolved_err.vv
+++ b/vlib/v/checker/tests/generic_fn_var_unresolved_err.vv
@@ -6,4 +6,7 @@ fn func[T](arg string, mut val T) int {
 
 fn main() {
 	_ := func
+	_ := {
+		'test': func
+	}
 }

--- a/vlib/v/checker/tests/generic_fn_var_unresolved_err.vv
+++ b/vlib/v/checker/tests/generic_fn_var_unresolved_err.vv
@@ -1,0 +1,9 @@
+module main
+
+fn func[T](arg string, mut val T) int {
+	return 2
+}
+
+fn main() {
+	_ := func
+}


### PR DESCRIPTION
Fix #22734
Fix #22733

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI2NGU0ODI3Y2M3NjgxYzYyNWZiYzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.2DCEqewNEJErvS_4wwF-VaGKiWLDZxxWXjSCLcVxaIA">Huly&reg;: <b>V_0.6-21190</b></a></sub>