### PR TITLE
cgen: fix `assert [1, 2, 3]!.reverse() == [3, 2, 1]!`

### DIFF
--- a/vlib/builtin/fixed_array_reverse_test.v
+++ b/vlib/builtin/fixed_array_reverse_test.v
@@ -27,11 +27,13 @@ fn test_fixed_array_reverse() {
 	b := a.reverse()
 	assert a == ['hi', '1', '5', '3']!
 	assert b == ['3', '5', '1', 'hi']!
+	assert ['hi', '1', '5', '3']!.reverse() == ['3', '5', '1', 'hi']!
 
 	mut nums := [67, -3, 108, 42, 7]!
 	n := nums.reverse()
 	assert nums == [67, -3, 108, 42, 7]!
 	assert n == [7, 42, 108, -3, 67]!
+	assert [67, -3, 108, 42, 7]!.reverse() == [7, 42, 108, -3, 67]!
 
 	mut users := [User{22, 'Peter'}, User{20, 'Bob'}, User{25, 'Alice'}]!
 	u := users.reverse()
@@ -49,4 +51,12 @@ fn test_fixed_array_reverse() {
 	assert u[0].name == 'Alice'
 	assert u[1].name == 'Bob'
 	assert u[2].name == 'Peter'
+
+	u2 := [User{22, 'Peter'}, User{20, 'Bob'}, User{25, 'Alice'}]!.reverse()
+	assert u2[0].age == 25
+	assert u2[1].age == 20
+	assert u2[2].age == 22
+	assert u2[0].name == 'Alice'
+	assert u2[1].name == 'Bob'
+	assert u2[2].name == 'Peter'
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -833,7 +833,11 @@ fn (mut g Gen) gen_fixed_array_reverse(node ast.CallExpr) {
 	atype := g.styp(node.return_type)
 	g.writeln('${atype} ${past.tmp_var};')
 	g.write('memcpy(&${past.tmp_var}, &')
-	g.expr(node.left)
+	if node.left is ast.ArrayInit {
+		g.fixed_array_init_with_cast(node.left, node.left_type)
+	} else {
+		g.expr(node.left)
+	}
 	g.writeln(', sizeof(${atype}));')
 
 	unsafe {


### PR DESCRIPTION
This PR fix `assert [1, 2, 3]!.reverse() == [3, 2, 1]!`.

- Fix `assert [1, 2, 3]!.reverse() == [3, 2, 1]!`.
- Add tests.

```v
fn test_fixed_array_reverse() {
	a := ['hi', '1', '5', '3']!
	b := a.reverse()
	assert a == ['hi', '1', '5', '3']!
	assert b == ['3', '5', '1', 'hi']!
	assert ['hi', '1', '5', '3']!.reverse() == ['3', '5', '1', 'hi']!

	mut nums := [67, -3, 108, 42, 7]!
	n := nums.reverse()
	assert nums == [67, -3, 108, 42, 7]!
	assert n == [7, 42, 108, -3, 67]!
	assert [67, -3, 108, 42, 7]!.reverse() == [7, 42, 108, -3, 67]!

	mut users := [User{22, 'Peter'}, User{20, 'Bob'}, User{25, 'Alice'}]!
	u := users.reverse()

	assert users[0].age == 22
	assert users[1].age == 20
	assert users[2].age == 25
	assert users[0].name == 'Peter'
	assert users[1].name == 'Bob'
	assert users[2].name == 'Alice'

	assert u[0].age == 25
	assert u[1].age == 20
	assert u[2].age == 22
	assert u[0].name == 'Alice'
	assert u[1].name == 'Bob'
	assert u[2].name == 'Peter'

	u2 := [User{22, 'Peter'}, User{20, 'Bob'}, User{25, 'Alice'}]!.reverse()
	assert u2[0].age == 25
	assert u2[1].age == 20
	assert u2[2].age == 22
	assert u2[0].name == 'Alice'
	assert u2[1].name == 'Bob'
	assert u2[2].name == 'Peter'
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI2ZWE2YTI3Y2M3NjgxYzYyNjBjNWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.47MwDD_J8VAlZjQkf96433aB0Lxxc0zMdqBMTmQubBU">Huly&reg;: <b>V_0.6-21192</b></a></sub>