### PR TITLE
builtin: improve fixed_array_any_all_test.v

### DIFF
--- a/vlib/builtin/fixed_array_any_all_test.v
+++ b/vlib/builtin/fixed_array_any_all_test.v
@@ -3,15 +3,23 @@ fn test_any_all_of_ints() {
 
 	assert ia.any(it > 2)
 	assert ia.any(|x| x > 2)
+	assert [1, 2, 3]!.any(it > 2)
+	assert [1, 2, 3]!.any(|x| x > 2)
 
 	assert !ia.all(it > 1)
 	assert !ia.all(|x| x > 1)
+	assert ![1, 2, 3]!.all(it > 1)
+	assert ![1, 2, 3]!.all(|x| x > 1)
 
 	assert ia.any(it == 2)
 	assert ia.any(|x| x == 2)
+	assert [1, 2, 3]!.any(it == 2)
+	assert [1, 2, 3]!.any(|x| x == 2)
 
 	assert !ia.all(it == 3)
 	assert !ia.all(|x| x == 3)
+	assert ![1, 2, 3]!.all(it == 3)
+	assert ![1, 2, 3]!.all(|x| x == 3)
 }
 
 fn test_any_all_of_strings() {
@@ -19,9 +27,13 @@ fn test_any_all_of_strings() {
 
 	assert sa.any(it == 'b')
 	assert sa.any(|x| x == 'b')
+	assert ['a', 'b', 'c']!.any(it == 'b')
+	assert ['a', 'b', 'c']!.any(|x| x == 'b')
 
 	assert !sa.all(it == 'c')
 	assert !sa.all(|x| x == 'c')
+	assert !['a', 'b', 'c']!.all(it == 'c')
+	assert !['a', 'b', 'c']!.all(|x| x == 'c')
 }
 
 fn test_any_all_of_voidptrs() {
@@ -29,9 +41,13 @@ fn test_any_all_of_voidptrs() {
 
 	assert pa.any(it == voidptr(45))
 	assert pa.any(|x| x == voidptr(45))
+	assert [voidptr(123), voidptr(45), voidptr(99)]!.any(it == voidptr(45))
+	assert [voidptr(123), voidptr(45), voidptr(99)]!.any(|x| x == voidptr(45))
 
 	assert !pa.all(it == voidptr(123))
 	assert !pa.all(|x| x == voidptr(123))
+	assert ![voidptr(123), voidptr(45), voidptr(99)]!.all(it == voidptr(123))
+	assert ![voidptr(123), voidptr(45), voidptr(99)]!.all(|x| x == voidptr(123))
 }
 
 fn a() {}
@@ -47,7 +63,11 @@ fn test_any_all_of_fns() {
 
 	assert fa.any(it == b)
 	assert fa.any(|x| x == b)
+	assert [a, b, c]!.any(it == b)
+	assert [a, b, c]!.any(|x| x == b)
 
 	assert !fa.all(it == v)
 	assert !fa.all(|x| x == v)
+	assert ![a, b, c]!.all(it == v)
+	assert ![a, b, c]!.all(|x| x == v)
 }


### PR DESCRIPTION
This PR improve fixed_array_any_all_test.v.

- Add `assert [1, 2, 3]!.any(it > 2)`.

```v
fn test_any_all_of_ints() {
	ia := [1, 2, 3]!

	assert ia.any(it > 2)
	assert ia.any(|x| x > 2)
	assert [1, 2, 3]!.any(it > 2)
	assert [1, 2, 3]!.any(|x| x > 2)

	assert !ia.all(it > 1)
	assert !ia.all(|x| x > 1)
	assert ![1, 2, 3]!.all(it > 1)
	assert ![1, 2, 3]!.all(|x| x > 1)

	assert ia.any(it == 2)
	assert ia.any(|x| x == 2)
	assert [1, 2, 3]!.any(it == 2)
	assert [1, 2, 3]!.any(|x| x == 2)

	assert !ia.all(it == 3)
	assert !ia.all(|x| x == 3)
	assert ![1, 2, 3]!.all(it == 3)
	assert ![1, 2, 3]!.all(|x| x == 3)
}

fn test_any_all_of_strings() {
	sa := ['a', 'b', 'c']!

	assert sa.any(it == 'b')
	assert sa.any(|x| x == 'b')
	assert ['a', 'b', 'c']!.any(it == 'b')
	assert ['a', 'b', 'c']!.any(|x| x == 'b')

	assert !sa.all(it == 'c')
	assert !sa.all(|x| x == 'c')
	assert !['a', 'b', 'c']!.all(it == 'c')
	assert !['a', 'b', 'c']!.all(|x| x == 'c')
}

fn test_any_all_of_voidptrs() {
	pa := [voidptr(123), voidptr(45), voidptr(99)]!

	assert pa.any(it == voidptr(45))
	assert pa.any(|x| x == voidptr(45))
	assert [voidptr(123), voidptr(45), voidptr(99)]!.any(it == voidptr(45))
	assert [voidptr(123), voidptr(45), voidptr(99)]!.any(|x| x == voidptr(45))

	assert !pa.all(it == voidptr(123))
	assert !pa.all(|x| x == voidptr(123))
	assert ![voidptr(123), voidptr(45), voidptr(99)]!.all(it == voidptr(123))
	assert ![voidptr(123), voidptr(45), voidptr(99)]!.all(|x| x == voidptr(123))
}

fn a() {}

fn b() {}

fn c() {}

fn v() {}

fn test_any_all_of_fns() {
	fa := [a, b, c]!

	assert fa.any(it == b)
	assert fa.any(|x| x == b)
	assert [a, b, c]!.any(it == b)
	assert [a, b, c]!.any(|x| x == b)

	assert !fa.all(it == v)
	assert !fa.all(|x| x == v)
	assert ![a, b, c]!.all(it == v)
	assert ![a, b, c]!.all(|x| x == v)
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI2ZjRhZjI3Y2M3NjgxYzYyNjBkYTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.6aaW-siDgLY89tHiphum98joCm33az7-aeFrw0UoT-c">Huly&reg;: <b>V_0.6-21193</b></a></sub>