### PR TITLE
builtin: add `string.is_pure_ascii()`

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -307,10 +307,13 @@ pub fn (s string) len_utf8() int {
 	return l
 }
 
+// is_pure_ascii returns whether the string contains only ASCII characters.
+// Note that UTF8 encodes such characters in just 1 byte:
 // 1 byte:  0xxxxxxx
 // 2 bytes: 110xxxxx 10xxxxxx
 // 3 bytes: 1110xxxx 10xxxxxx 10xxxxxx
 // 4 bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+@[direct_array_access]
 pub fn (s string) is_pure_ascii() bool {
 	for i in 0 .. s.len {
 		if s[i] >= 0x80 {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -307,6 +307,19 @@ pub fn (s string) len_utf8() int {
 	return l
 }
 
+// 1 byte:  0xxxxxxx
+// 2 bytes: 110xxxxx 10xxxxxx
+// 3 bytes: 1110xxxx 10xxxxxx 10xxxxxx
+// 4 bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+pub fn (s string) is_pure_ascii() bool {
+	for i in 0 .. s.len {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
 // clone_static returns an independent copy of a given array.
 // It should be used only in -autofree generated code.
 @[inline]
@@ -1709,7 +1722,7 @@ pub fn (s string) trim(cutset string) string {
 	if s == '' || cutset == '' {
 		return s.clone()
 	}
-	if cutset.len_utf8() == cutset.len {
+	if cutset.is_pure_ascii() {
 		return s.trim_chars(cutset, .trim_both)
 	} else {
 		return s.trim_runes(cutset, .trim_both)
@@ -1825,7 +1838,7 @@ pub fn (s string) trim_left(cutset string) string {
 	if s == '' || cutset == '' {
 		return s.clone()
 	}
-	if cutset.len_utf8() == cutset.len {
+	if cutset.is_pure_ascii() {
 		return s.trim_chars(cutset, .trim_left)
 	} else {
 		return s.trim_runes(cutset, .trim_left)
@@ -1839,7 +1852,7 @@ pub fn (s string) trim_right(cutset string) string {
 	if s.len < 1 || cutset.len < 1 {
 		return s.clone()
 	}
-	if cutset.len_utf8() == cutset.len {
+	if cutset.is_pure_ascii() {
 		return s.trim_chars(cutset, .trim_right)
 	} else {
 		return s.trim_runes(cutset, .trim_right)

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -30,6 +30,14 @@ fn test_len_utf8() {
 	assert 'Λέξη'.len_utf8() == 4
 }
 
+fn test_is_pure_ascii() {
+	assert 'Vlang'.is_pure_ascii()
+	assert !'María'.is_pure_ascii()
+	assert !'姓名'.is_pure_ascii()
+	assert !'Слово'.is_pure_ascii()
+	assert !'Λέξη'.is_pure_ascii()
+}
+
 fn test_ends_with() {
 	a := 'browser.v'
 	assert a.ends_with('.v')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3795,7 +3795,7 @@ fn (mut g Gen) char_literal(node ast.CharLiteral) {
 		return
 	}
 	// TODO: optimize use L-char instead of u32 when possible
-	if node.val.len_utf8() < node.val.len {
+	if !node.val.is_pure_ascii() {
 		g.write('((rune)0x${node.val.utf32_code().hex()} /* `${node.val}` */)')
 		return
 	}

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -899,7 +899,7 @@ fn (mut g JsGen) expr(node_ ast.Expr) {
 			// TODO
 		}
 		ast.CharLiteral {
-			if node.val.len_utf8() < node.val.len {
+			if !node.val.is_pure_ascii() {
 				g.write("new rune('${node.val}'.charCodeAt())")
 			} else {
 				g.write("new u8('${node.val}')")


### PR DESCRIPTION
This PR add `string.is_pure_ascii()` and modify all the related calls.

```v
fn test_len_utf8() {
	assert 'Vlang'.len_utf8() == 5
	assert 'María'.len_utf8() == 5
	assert '姓名'.len_utf8() == 2
	assert 'Слово'.len_utf8() == 5
	assert 'Λέξη'.len_utf8() == 4
}

fn test_is_pure_ascii() {
	assert 'Vlang'.is_pure_ascii()
	assert !'María'.is_pure_ascii()
	assert !'姓名'.is_pure_ascii()
	assert !'Слово'.is_pure_ascii()
	assert !'Λέξη'.is_pure_ascii()
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI3NTNkNzI3Y2M3NjgxYzYyNjEzNzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.WlxeVX1Dv_lY1Pbo0OIKdGJkI_lYOQUJ64KUMdzaljs">Huly&reg;: <b>V_0.6-21194</b></a></sub>