### PR TITLE
checker: fix missing check for stack pointer return

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -292,6 +292,11 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 			mut r_expr := &node.exprs[expr_idxs[i]]
 			if mut r_expr is ast.Ident {
 				c.fail_if_stack_struct_action_outside_unsafe(mut r_expr, 'returned')
+			} else if mut r_expr is ast.PrefixExpr && r_expr.op == .amp {
+				// &var
+				if mut r_expr.right is ast.Ident {
+					c.fail_if_stack_struct_action_outside_unsafe(mut r_expr.right, 'returned')
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix #22726

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI4ZDNjNGU3Y2M1YTc4NTQyNzU5MmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.eTzrixq0IhWUBMcDDLuT_eR9JKE0gbgXl57b6PlSDbM">Huly&reg;: <b>V_0.6-21203</b></a></sub>