### PR TITLE
v: fix redundant emission of left expression in in infix expressions

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -517,7 +517,8 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 		if node.right is ast.ArrayInit {
 			elem_type := node.right.elem_type
 			elem_sym := g.table.sym(elem_type)
-			if node.right.exprs.len > 0 {
+			// TODO: replace ast.Ident check with proper side effect analysis
+			if node.right.exprs.len > 0 && node.left is ast.Ident {
 				// `a in [1,2,3]` optimization => `a == 1 || a == 2 || a == 3`
 				// avoids an allocation
 				g.write('(')

--- a/vlib/v/gen/c/testdata/for_in_side_effect.out
+++ b/vlib/v/gen/c/testdata/for_in_side_effect.out
@@ -1,0 +1,1 @@
+side effect

--- a/vlib/v/gen/c/testdata/for_in_side_effect.vv
+++ b/vlib/v/gen/c/testdata/for_in_side_effect.vv
@@ -1,0 +1,8 @@
+fn test() bool {
+	println('side effect')
+	return true
+}
+
+fn main() {
+	assert (test() in [false, true]) == true
+}


### PR DESCRIPTION
This PR fixes the issue addressed in #22758. It prevents the left expression of an `in` infix expression from being emitted multiple times. This occurs in the following code example:

```v
x() in [12, 13]
```

This gets optimized into:

```c
x() == 12 || x() == 13
```

In this case this optimization is incorrect.

The fix I implemented checks if the left expression is an `ast.Ident`. However, I'm unsure if there is side effect information present in the compiler. Having this information available would allow this optimization to be applied in more situations.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI5NDljNWU3Y2M1YTc4NTQyNzg2ZDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.0fmf9tYw_X9GuTIjy0IcYVVI1m6K669tgfWJ5HZYqkg">Huly&reg;: <b>V_0.6-21210</b></a></sub>