### PR TITLE
cgen: fix codegen to emit callexpr one time for `in` expr optimization

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -657,6 +657,7 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 // and transform them in a series of equality comparison
 // i.e. `a in [1,2,3]` => `a == 1 || a == 2 || a == 3`
 fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, left_type ast.Type, right ast.ArrayInit) {
+	tmp_var := if left is ast.CallExpr { g.new_tmp_var() } else { '' }
 	mut elem_sym := g.table.sym(right.elem_type)
 	left_parent_idx := g.table.sym(left_type).parent_idx
 	for i, array_expr in right.exprs {
@@ -719,13 +720,39 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, left_type ast.Type, rig
 						g.write('${ptr_typ}_struct_eq(')
 					}
 				}
-				g.expr(left)
+				if left is ast.CallExpr {
+					if i == 0 {
+						line := g.go_before_last_stmt().trim_space()
+						g.empty_line = true
+						g.write('${g.styp(left.return_type)} ${tmp_var} = ')
+						g.expr(left)
+						g.writeln(';')
+						g.write2(line, tmp_var)
+					} else {
+						g.write(tmp_var)
+					}
+				} else {
+					g.expr(left)
+				}
 				g.write(', ')
 				g.expr(array_expr)
 				g.write(')')
 			}
 			else { // works in function kind
-				g.expr(left)
+				if left is ast.CallExpr {
+					if i == 0 {
+						line := g.go_before_last_stmt().trim_space()
+						g.empty_line = true
+						g.write('${g.styp(left.return_type)} ${tmp_var} = ')
+						g.expr(left)
+						g.writeln(';')
+						g.write2(line, tmp_var)
+					} else {
+						g.write(tmp_var)
+					}
+				} else {
+					g.expr(left)
+				}
 				g.write(' == ')
 				g.expr(array_expr)
 			}

--- a/vlib/v/slow_tests/inout/in_expr_callexpr.out
+++ b/vlib/v/slow_tests/inout/in_expr_callexpr.out
@@ -1,0 +1,4 @@
+t
+true
+t2
+true

--- a/vlib/v/slow_tests/inout/in_expr_callexpr.vv
+++ b/vlib/v/slow_tests/inout/in_expr_callexpr.vv
@@ -1,10 +1,10 @@
 fn t() bool {
-	println('${@FN}')
+	println(@FN)
 	return true
 }
 
 fn t2() int {
-	println('${@FN}')
+	println(@FN)
 	return 2
 }
 

--- a/vlib/v/slow_tests/inout/in_expr_callexpr.vv
+++ b/vlib/v/slow_tests/inout/in_expr_callexpr.vv
@@ -1,0 +1,14 @@
+fn t() bool {
+	println('${@FN}')
+	return true
+}
+
+fn t2() int {
+	println('${@FN}')
+	return 2
+}
+
+fn main() {
+	println(t() in [false, true])
+	println(t2() in [0, 1, 2, 3, 4, 5])
+}


### PR DESCRIPTION
Fix #22758

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzI5NTJlNWU3Y2M1YTc4NTQyNzg4YTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.kpe1y_WnxwqN70OaP7sMk82Mn6CM9WcH08_KnxSkGoU">Huly&reg;: <b>V_0.6-21211</b></a></sub>