### PR TITLE
parser: fix enum redeclaration error

### DIFF
--- a/vlib/v/checker/tests/enum_redeclare_err.out
+++ b/vlib/v/checker/tests/enum_redeclare_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/enum_redeclare_err.vv:7:10: error: cannot register enum `Enum`, another type with this name exists
+vlib/v/checker/tests/enum_redeclare_err.vv:7:1: error: cannot register enum `Enum`, another type with this name exists
     5 | 
     6 | @[flag]
     7 | pub enum Enum {
-      |          ~~~~
+      | ~~~~~~~~~~~~~
     8 |     a
     9 | }

--- a/vlib/v/checker/tests/enum_redeclare_err.out
+++ b/vlib/v/checker/tests/enum_redeclare_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/enum_redeclare_err.vv:7:10: error: cannot register enum `Enum`, another type with this name exists
+    5 | 
+    6 | @[flag]
+    7 | pub enum Enum {
+      |          ~~~~
+    8 |     a
+    9 | }

--- a/vlib/v/checker/tests/enum_redeclare_err.vv
+++ b/vlib/v/checker/tests/enum_redeclare_err.vv
@@ -1,0 +1,9 @@
+@[flag]
+pub enum Enum {
+    a
+}
+
+@[flag]
+pub enum Enum {
+    a
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4260,6 +4260,7 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			}
 		}
 		if !already_exists {
+			// enum already exists, skip method creation to avoid duplicate method errors
 			all_bits_set_value := '0b' + '1'.repeat(fields.len)
 			p.codegen('
 //

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4347,7 +4347,6 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 	}
 
 	if !already_exists {
-		// Enum already exists, skip registration to avoid Enum methods error in this phase
 		idx = p.table.register_sym(ast.TypeSymbol{
 			kind:   .enum
 			name:   name

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4328,11 +4328,6 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 		p.codegen(code_for_from_fn)
 	}
 
-	if already_exists {
-		// enum redeclaration, error emited on checker
-		enum_type = ast.invalid_type_idx
-	}
-
 	idx := p.table.register_sym(ast.TypeSymbol{
 		kind:   .enum
 		name:   name
@@ -4354,9 +4349,13 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			end_pos)
 	}
 
+	if idx == ast.invalid_type_idx {
+		enum_type = idx
+	}
+
 	enum_decl := ast.EnumDecl{
 		name:             name
-		typ:              if idx == ast.invalid_type_idx { ast.invalid_type } else { enum_type }
+		typ:              enum_type
 		typ_pos:          typ_pos
 		is_pub:           is_pub
 		is_flag:          is_flag

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4344,7 +4344,9 @@ fn (mut p Parser) enum_decl() ast.EnumDecl {
 			end_pos)
 	}
 	if idx == ast.invalid_type_idx {
-		enum_type = idx
+		p.error_with_pos('cannot register enum `${name}`, another type with this name exists',
+			end_pos)
+		return ast.EnumDecl{}
 	}
 
 	enum_decl := ast.EnumDecl{


### PR DESCRIPTION
Fix #22759

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJhMDQyOWU3Y2M1YTc4NTQyN2UxMmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.bsG19_9zoDr2WoXBSxmsZJoqIYa6HMx6ugLqP649qBQ">Huly&reg;: <b>V_0.6-21213</b></a></sub>