### PR TITLE
cgen: apply the `a in [x,y,z]` optimisation for ast.IndexExpr and ast.SelectorExpr again

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -518,7 +518,8 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 			elem_type := node.right.elem_type
 			elem_sym := g.table.sym(elem_type)
 			// TODO: replace ast.Ident check with proper side effect analysis
-			if node.right.exprs.len > 0 && node.left is ast.Ident {
+			if node.right.exprs.len > 0 && (node.left is ast.Ident
+				|| node.left is ast.IndexExpr || node.left is ast.SelectorExpr) {
 				// `a in [1,2,3]` optimization => `a == 1 || a == 2 || a == 3`
 				// avoids an allocation
 				g.write('(')


### PR DESCRIPTION
The cost of only doing the optimization for `ast.Ident`, was ~12% slowdown for `v self` and larger produced .c and executable sizes (because of the additional generated .contains() methods).

This adds back the same optimization for the cases of ast.SelectorExpr - `x.y` and ast.IndexExpr - a[i] to reduce the amount of generated code and restore some of the compilation speed.