### PR TITLE
cgen: fix c codegen formatting for `return match`

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -77,7 +77,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	} else {
 		line := if is_expr {
 			g.empty_line = true
-			g.go_before_last_stmt()
+			g.go_before_last_stmt().trim_left('\t')
 		} else {
 			''
 		}


### PR DESCRIPTION
This PR removes an extra tab before return statement.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJhMjE4OGU3Y2M1YTc4NTQyODc2ZDIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.iwPe0vvWiTWeaHzkjhLtGIHAT4JGunbGVDS7RP_7498">Huly&reg;: <b>V_0.6-21215</b></a></sub>