### PR TITLE
cgen: avoid generation of empty `or` block

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7163,6 +7163,11 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 // `os.cp(...)` => `Option bool tmp = os__cp(...); if (tmp.state != 0) { ... }`
 // Returns the type of the last stmt
 fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Type) {
+	if or_block.kind == .block && or_block.stmts.len == 0 {
+		// generate nothing, block is empty
+		g.write(';')
+		return
+	}
 	cvar_name := c_name(var_name)
 	mut mr_styp := g.base_type(return_type)
 	is_none_ok := return_type == ast.ovoid_type

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7165,7 +7165,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Type) {
 	if or_block.kind == .block && or_block.stmts.len == 0 {
 		// generate nothing, block is empty
-		g.write(';')
+		g.write(';\n${util.tabs(g.indent)}(void)${var_name};')
 		return
 	}
 	cvar_name := c_name(var_name)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7163,12 +7163,12 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 // `os.cp(...)` => `Option bool tmp = os__cp(...); if (tmp.state != 0) { ... }`
 // Returns the type of the last stmt
 fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Type) {
+	cvar_name := c_name(var_name)
 	if or_block.kind == .block && or_block.stmts.len == 0 {
 		// generate nothing, block is empty
-		g.write(';\n${util.tabs(g.indent)}(void)${var_name};')
+		g.write(';\n${util.tabs(g.indent)}(void)${cvar_name};')
 		return
 	}
-	cvar_name := c_name(var_name)
 	mut mr_styp := g.base_type(return_type)
 	is_none_ok := return_type == ast.ovoid_type
 	g.writeln(';')

--- a/vlib/v/gen/c/testdata/unused_result_err.c.must_have
+++ b/vlib/v/gen/c/testdata/unused_result_err.c.must_have
@@ -1,0 +1,2 @@
+_result_void _t1 = main__res();
+(void)_t1;

--- a/vlib/v/gen/c/testdata/unused_result_err.vv
+++ b/vlib/v/gen/c/testdata/unused_result_err.vv
@@ -1,0 +1,7 @@
+module main
+
+fn res() ! {}
+
+fn main() {
+	res() or {}
+}


### PR DESCRIPTION
With this PR, code like the following:

```v
module main

fn res() ! {}

fn main() {
	res() or {}
}
```

It will be generated in C like this:

```c
VV_LOCAL_SYMBOL void main__main(void) {
        _result_void _t1 = main__res();
        (void)_t1;
 ;
}
```

Previously it was generated like this:

```c
VV_LOCAL_SYMBOL void main__main(void) {
        _result_void _t1 = main__res();
        if (_t1.is_error) {
                IError err = _t1.err;
        }

 ;
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJiN2I5YWU3Y2M1YTc4NTQyOGMwMDgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.JIk2mdp4ZycKegOK1gb-kUK66CmsZRvuh43bsXZq6BU">Huly&reg;: <b>V_0.6-21221</b></a></sub>