### PR TITLE
comptime: cleanup

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -505,9 +505,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 						left.recursive_mapset_is_setter(true)
 					}
 
-					if right is ast.Ident && c.comptime.is_comptime_var(right) {
-						right_type = c.comptime.get_type(right)
-					}
+					right_type = c.comptime.get_type_or_default(right, right_type)
 				}
 				if mut left is ast.InfixExpr {
 					c.error('cannot use infix expression on the left side of `${node.op}`',

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3804,16 +3804,7 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 	// second use
 	if node.kind in [.constant, .global, .variable] {
 		info := node.info as ast.IdentVar
-		typ := if c.comptime.is_comptime_var(node) {
-			ctype := c.comptime.get_type(node)
-			if ctype != ast.void_type {
-				ctype
-			} else {
-				info.typ
-			}
-		} else {
-			info.typ
-		}
+		typ := c.comptime.get_type_or_default(node, info.typ)
 		// Got a var with type T, return current generic type
 		if node.or_expr.kind != .absent {
 			if !typ.has_flag(.option) {

--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -45,13 +45,8 @@ fn (mut c Checker) string_inter_lit(mut node ast.StringInterLiteral) ast.Type {
 	c.inside_interface_deref = true
 	for i, mut expr in node.exprs {
 		mut ftyp := c.expr(mut expr)
-		ftyp = c.check_expr_option_or_result_call(expr, ftyp)
-		if c.comptime.is_comptime_var(expr) {
-			ctyp := c.comptime.get_type(expr)
-			if ctyp != ast.void_type {
-				ftyp = ctyp
-			}
-		}
+		ftyp = c.comptime.get_type_or_default(expr, c.check_expr_option_or_result_call(expr,
+			ftyp))
 		if ftyp == ast.void_type {
 			c.error('expression does not return a value', expr.pos())
 		} else if ftyp == ast.char_type && ftyp.nr_muls() == 0 {

--- a/vlib/v/comptime/comptimeinfo.v
+++ b/vlib/v/comptime/comptimeinfo.v
@@ -80,6 +80,22 @@ pub fn (mut ct ComptimeInfo) get_expr_type(node ast.Expr) ast.Type {
 	return ctyp
 }
 
+// get_type_or_default retries the comptime value if the AST node is related to comptime otherwise default_typ is returned
+pub fn (mut ct ComptimeInfo) get_type_or_default(node ast.Expr, default_typ ast.Type) ast.Type {
+	match node {
+		ast.Ident {
+			if ct.is_comptime_var(node) {
+				ctyp := ct.get_type(node)
+				return if ctyp != ast.void_type { ctyp } else { default_typ }
+			}
+		}
+		else {
+			return default_typ
+		}
+	}
+	return default_typ
+}
+
 // get_type retrieves the actual type from a comptime related ast node
 @[inline]
 pub fn (mut ct ComptimeInfo) get_type(node ast.Expr) ast.Type {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -459,11 +459,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 fn (mut g Gen) get_expr_type(cond ast.Expr) ast.Type {
 	match cond {
 		ast.Ident {
-			return if g.comptime.is_comptime_var(cond) {
-				g.unwrap_generic(g.comptime.get_type(cond))
-			} else {
-				g.unwrap_generic(cond.obj.typ)
-			}
+			return g.unwrap_generic(g.comptime.get_type_or_default(cond, cond.obj.typ))
 		}
 		ast.TypeNode {
 			return g.unwrap_generic(cond.typ)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2169,13 +2169,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		defer {
 			g.inside_interface_deref = false
 		}
-		mut typ := node.args[0].typ
-		if g.comptime.is_comptime_var(node.args[0].expr) {
-			ctyp := g.comptime.get_type(node.args[0].expr)
-			if ctyp != ast.void_type {
-				typ = ctyp
-			}
-		}
+		mut typ := g.comptime.get_type_or_default(node.args[0].expr, node.args[0].typ)
 		if typ == 0 {
 			g.checker_bug('print arg.typ is 0', node.pos)
 		}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -795,11 +795,8 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, left_type ast.Type, rig
 
 // infix_expr_is_op generates code for `is` and `!is`
 fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
-	mut left_sym := if g.comptime.is_comptime_var(node.left) {
-		g.table.sym(g.unwrap_generic(g.comptime.get_type(node.left)))
-	} else {
-		g.table.sym(node.left_type)
-	}
+	mut left_sym := g.table.sym(g.unwrap_generic(g.comptime.get_type_or_default(node.left,
+		node.left_type)))
 	is_aggregate := left_sym.kind == .aggregate
 	if is_aggregate {
 		parent_left_type := (left_sym.info as ast.Aggregate).sum_type


### PR DESCRIPTION
This PR introduces `comptime.get_type_or_default` to simplify checking for comptime expr or getting its default value.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJiZTQwMWU3Y2M1YTc4NTQyOGY3M2EiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.PSXuFPdo_HMbJvGuWYCDE5w2kCk_tuBq_KhrvoPuB8U">Huly&reg;: <b>V_0.6-21226</b></a></sub>