### PR TITLE
autofree: fix argument freeing for json.encode and json.encode_pretty calls

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -705,6 +705,9 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 				// Only expressions like `str + 'b'` need to be freed.
 				continue
 			}
+			if arg.expr is ast.CallExpr && arg.expr.name in ['json.encode', 'json.encode_pretty'] {
+				continue
+			}
 			node.args[i].is_tmp_autofree = true
 		}
 		// TODO: copy pasta from above

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2428,7 +2428,7 @@ fn (mut g Gen) autofree_call_pregen(node ast.CallExpr) {
 			if arg.expr is ast.CallExpr && arg.expr.name in ['json.encode', 'json.encode_pretty'] {
 				t := '_arg_expr_${arg.expr.name.replace('.', '_')}_${arg.expr.pos.pos}'
 				defer {
-					g.writeln(';\nstring_free(&${t});')
+					g.writeln(';\n\tstring_free(&${t});')
 				}
 			}
 			continue

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2073,7 +2073,11 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			g.write('cJSON* ${json_obj} = ${encode_name}(')
 			g.call_args(node)
 			g.writeln(');')
-			tmp2 = g.new_tmp_var()
+			tmp2 = if g.is_autofree {
+				'_arg_expr_${node.name.replace('.', '_')}_${node.pos.pos}'
+			} else {
+				g.new_tmp_var()
+			}
 			if is_json_encode {
 				g.writeln('string ${tmp2} = json__json_print(${json_obj});')
 			} else {
@@ -2421,6 +2425,12 @@ fn (mut g Gen) autofree_call_pregen(node ast.CallExpr) {
 	args << node.args
 	for i, arg in args {
 		if !arg.is_tmp_autofree {
+			if arg.expr is ast.CallExpr && arg.expr.name in ['json.encode', 'json.encode_pretty'] {
+				t := '_arg_expr_${arg.expr.name.replace('.', '_')}_${arg.expr.pos.pos}'
+				defer {
+					g.writeln(';\nstring_free(&${t});')
+				}
+			}
 			continue
 		}
 		if arg.expr is ast.CallExpr {

--- a/vlib/v/gen/c/testdata/autofree_json_encode.c.must_have
+++ b/vlib/v/gen/c/testdata/autofree_json_encode.c.must_have
@@ -1,5 +1,5 @@
-string _arg_expr_json_encode_pretty_114 = json__json_print_pretty(_t1);
-string_free(&_arg_expr_json_encode_pretty_114);
-string _arg_expr_json_encode_143 = json__json_print(_t2);
-string d = (_arg_expr_json_encode_143);
+string _arg_expr_json_encode_pretty
+string_free(&_arg_expr_json_encode_pretty_
+string _arg_expr_json_encode_
+string d = (_arg_expr_json_encode_
 string_free(&d); // autofreed var main false

--- a/vlib/v/gen/c/testdata/autofree_json_encode.c.must_have
+++ b/vlib/v/gen/c/testdata/autofree_json_encode.c.must_have
@@ -1,0 +1,5 @@
+string _arg_expr_json_encode_pretty_114 = json__json_print_pretty(_t1);
+string_free(&_arg_expr_json_encode_pretty_114);
+string _arg_expr_json_encode_143 = json__json_print(_t2);
+string d = (_arg_expr_json_encode_143);
+string_free(&d); // autofreed var main false

--- a/vlib/v/gen/c/testdata/autofree_json_encode.vv
+++ b/vlib/v/gen/c/testdata/autofree_json_encode.vv
@@ -1,0 +1,16 @@
+// vtest vflags: -autofree
+import json
+
+struct Foo {
+	foo int
+}
+
+fn main() {
+	mut a := {
+		'foo': 123
+	}
+	println(json.encode_pretty(a))
+	d := json.encode(a)
+	dump(d)
+	println(json.decode(Foo, d)!)
+}


### PR DESCRIPTION
Fix ved CI failure.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJiZjYxYmU3Y2M1YTc4NTQyOGY4YmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.pKI_qNZxBTyTWabTVf2K1vLZYhBMCipmbLD_92g36zA">Huly&reg;: <b>V_0.6-21227</b></a></sub>