### PR TITLE
cgen: fix struct field name using c keyword `typeof` (fix #22779)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -25,8 +25,8 @@ const c_reserved = ['asm', 'array', 'auto', 'bool', 'break', 'calloc', 'case', '
 	'exit', 'export', 'extern', 'false', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int',
 	'link', 'long', 'malloc', 'namespace', 'new', 'nil', 'panic', 'register', 'restrict', 'return',
 	'short', 'signed', 'sizeof', 'static', 'string', 'struct', 'switch', 'typedef', 'typename',
-	'union', 'unix', 'unsigned', 'void', 'volatile', 'while', 'template', 'true', 'small', 'stdout',
-	'stdin', 'stderr', 'far', 'near', 'huge', 'requires']
+	'typeof', 'union', 'unix', 'unsigned', 'void', 'volatile', 'while', 'template', 'true', 'small',
+	'stdout', 'stdin', 'stderr', 'far', 'near', 'huge', 'requires']
 const c_reserved_chk = token.new_keywords_matcher_from_array_trie(c_reserved)
 // same order as in token.Kind
 const cmp_str = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']

--- a/vlib/v/tests/structs/struct_field_name_using_c_keyword_test.v
+++ b/vlib/v/tests/structs/struct_field_name_using_c_keyword_test.v
@@ -1,0 +1,9 @@
+struct Keywords {
+	typeof u8
+}
+
+fn test_struct_field_name_using_c_reserved() {
+	key := Keywords{}
+	println(key)
+	assert true
+}


### PR DESCRIPTION
This PR fix struct field name using c keyword `typeof` (fix #22779).

- Fix struct field name using c keyword `typeof`.
- Add test.

```v
struct Keywords {
	typeof u8
}

fn main() {
	key := Keywords{}
	println(key)
}

PS D:\Test\v\tt1> v run .
Keywords{
    typeof: 0
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJjMTVkYmU3Y2M1YTc4NTQyOGZjODUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.i4j_Jdt0rlML5ZOQrCgw1krVgDBLA4HPlFBUkk33gFo">Huly&reg;: <b>V_0.6-21228</b></a></sub>