### PR TITLE
picoev: fix incompatible pointer type

### DIFF
--- a/vlib/picoev/loop_linux.c.v
+++ b/vlib/picoev/loop_linux.c.v
@@ -6,12 +6,12 @@ $if !musl ? {
 	#include <sys/cdefs.h> // needed for cross compiling to linux
 }
 
-fn C.epoll_create(int) int
-fn C.epoll_wait(int, voidptr, int, int) int
-fn C.epoll_ctl(int, int, int, voidptr) int
+fn C.epoll_create(__flags int) int
+fn C.epoll_wait(__epfd int, __events &C.epoll_event, __maxevents int, __timeout int) int
+fn C.epoll_ctl(__epfd int, __op int, __fd int, __event &C.epoll_event) int
 
 @[typedef]
-pub union C.epoll_data_t {
+union C.epoll_data {
 mut:
 	ptr voidptr
 	fd  int
@@ -21,9 +21,8 @@ mut:
 
 @[packed]
 pub struct C.epoll_event {
-mut:
 	events u32
-	data   C.epoll_data_t
+	data   C.epoll_data
 }
 
 @[heap]
@@ -106,7 +105,7 @@ fn (mut pv Picoev) update_events(fd int, events int) int {
 
 @[direct_array_access]
 fn (mut pv Picoev) poll_once(max_wait_in_sec int) int {
-	nevents := C.epoll_wait(pv.loop.epoll_fd, &pv.loop.events, max_fds, max_wait_in_sec * 1000)
+	nevents := C.epoll_wait(pv.loop.epoll_fd, &pv.loop.events[0], max_fds, max_wait_in_sec * 1000)
 
 	if nevents == -1 {
 		// timeout has occurred


### PR DESCRIPTION
`v -prod -gc none main.v -o main.c && gcc main.c `

```sh
main.c: In function ‘picoev__Picoev_poll_once’:
main.c:27012:54: warning: passing argument 2 of ‘epoll_wait’ from incompatible pointer type [-Wincompatible-pointer-types]
27012 |         int nevents = epoll_wait(pv->loop->epoll_fd, &pv->loop->events, _const_picoev__max_fds, (int)(max_wait_in_sec * 1000));
      |                                                      ^~~~~~~~~~~~~~~~~
      |                                                      |
      |                                                      struct epoll_event (*)[1024]
In file included from main.c:1214:
/usr/include/x86_64-linux-gnu/sys/epoll.h:124:56: note: expected ‘struct epoll_event *’ but argument is of type ‘struct epoll_event (*)[1024]’
  124 | extern int epoll_wait (int __epfd, struct epoll_event *__events,
      |                                    ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJjYWY1ZWU3Y2M1YTc4NTQyOTFjN2YiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.WW9CAAqHHoqD3yGYg0uZdt6IX1P4hVLslmDo6M6bYr4">Huly&reg;: <b>V_0.6-21231</b></a></sub>