### PR TITLE
cgen: enable if guard to add `err` var on else branch after last `else if`

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -249,9 +249,9 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		if cond is ast.IfGuardExpr {
 			if !is_guard {
 				is_guard = true
-				guard_idx = i
 				guard_vars = []string{len: node.branches.len}
 			}
+			guard_idx = i // saves the last if guard index
 			if cond.expr !in [ast.IndexExpr, ast.PrefixExpr] {
 				var_name := g.new_tmp_var()
 				guard_vars[i] = var_name
@@ -269,7 +269,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 		// if last branch is `else {`
 		if i == node.branches.len - 1 && node.has_else {
 			g.writeln('{')
-			// define `err` only for simple `if val := opt {...} else {`
+			// define `err` for the last branch after a `if val := opt {...}' guard
 			if is_guard && guard_idx == i - 1 {
 				cvar_name := guard_vars[guard_idx]
 				g.writeln('\tIError err = ${cvar_name}.err;')

--- a/vlib/v/tests/if_guard_elseif_test.v
+++ b/vlib/v/tests/if_guard_elseif_test.v
@@ -1,0 +1,21 @@
+fn byte_str(num u32) !string {
+	return if num > 0xff { error('larger than byte') } else { num.str() }
+}
+
+fn short_str(num int) !string {
+	return if num > 0xffff { error('larger than short') } else { num.str() }
+}
+
+fn test_main() {
+	num := u32(0xfffff)
+	mut str := ''
+	if bs := byte_str(num) {
+		str = 'byte: ${bs}'
+	} else if ss := short_str(num) {
+		str = 'short: ${ss}'
+	} else {
+		str = 'err: ${err}'
+	}
+
+	assert str.contains('err:')
+}


### PR DESCRIPTION
Fix #22784

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJjYjExZGU3Y2M1YTc4NTQyOTI3ZmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.w09SV8ggqIFcrzogij1xyUlhp9E-H2r3zi2beBuDi6Q">Huly&reg;: <b>V_0.6-21232</b></a></sub>