### PR TITLE
builder: fix msvc build thirdparty obj file from .cpp

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -226,7 +226,6 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		skip_files << 'examples/coroutines/coroutines_bench.v'
 		$if msvc {
 			skip_files << 'vlib/v/tests/consts/const_comptime_eval_before_vinit_test.v' // _constructor used
-			skip_files << 'vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v'
 		}
 		$if solaris {
 			skip_files << 'examples/pico/pico.v'

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -401,7 +401,9 @@ fn (mut v Builder) build_thirdparty_obj_file_with_msvc(mod string, path string, 
 	}
 	println('${obj_path} not found, building it (with msvc)...')
 	flush_stdout()
-	cfile := '${path_without_o_postfix}.c'
+	cfile := cfile := if os.exists('${path_without_o_postfix}.c') { '${path_without_o_postfix}.c' } else {
+               '${path_without_o_postfix}.cpp'
+       }
 	flags := msvc_string_flags(moduleflags)
 	inc_dirs := flags.inc_paths.join(' ')
 	defines := flags.defines.join(' ')

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -401,9 +401,11 @@ fn (mut v Builder) build_thirdparty_obj_file_with_msvc(mod string, path string, 
 	}
 	println('${obj_path} not found, building it (with msvc)...')
 	flush_stdout()
-	cfile := cfile := if os.exists('${path_without_o_postfix}.c') { '${path_without_o_postfix}.c' } else {
-               '${path_without_o_postfix}.cpp'
-       }
+	cfile := if os.exists('${path_without_o_postfix}.c') {
+		'${path_without_o_postfix}.c'
+	} else {
+		'${path_without_o_postfix}.cpp'
+	}
 	flags := msvc_string_flags(moduleflags)
 	inc_dirs := flags.inc_paths.join(' ')
 	defines := flags.defines.join(' ')


### PR DESCRIPTION
Fix #22772

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJjYzk2ZmU3Y2M1YTc4NTQyOTUyMGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.gtek6uvdqdi2RsMlqlMUHBqY2rcUCAE5zuZB1gIefLk">Huly&reg;: <b>V_0.6-21235</b></a></sub>