### PR TITLE
builtin: add tests for rune.to_upper()

### DIFF
--- a/vlib/builtin/rune_test.v
+++ b/vlib/builtin/rune_test.v
@@ -40,3 +40,30 @@ fn test_bytes() {
 	r1 := `★`
 	assert r1.bytes() == [u8(0xe2), 0x98, 0x85]
 }
+
+fn test_to_upper() {
+	assert `c`.to_upper() == `C`
+	assert `C`.to_upper() == `C`
+	assert `δ`.to_upper() == `Δ`
+	assert `Δ`.to_upper() == `Δ`
+	assert `ā`.to_upper() == `Ā`
+	assert `Ā`.to_upper() == `Ā`
+}
+
+fn test_to_lower() {
+	assert `C`.to_lower() == `c`
+	assert `c`.to_lower() == `c`
+	assert `Δ`.to_lower() == `δ`
+	assert `δ`.to_lower() == `δ`
+	assert `Ā`.to_lower() == `ā`
+	assert `ā`.to_lower() == `ā`
+}
+
+fn test_to_title() {
+	assert `c`.to_title() == `C`
+	assert `C`.to_title() == `C`
+	assert `δ`.to_title() == `Δ`
+	assert `Δ`.to_title() == `Δ`
+	assert `ā`.to_title() == `Ā`
+	assert `Ā`.to_title() == `Ā`
+}


### PR DESCRIPTION
This PR add tests for rune.to_upper().

```v
fn test_to_upper() {
	assert `c`.to_upper() == `C`
	assert `C`.to_upper() == `C`
	assert `δ`.to_upper() == `Δ`
	assert `Δ`.to_upper() == `Δ`
	assert `ā`.to_upper() == `Ā`
	assert `Ā`.to_upper() == `Ā`
}

fn test_to_lower() {
	assert `C`.to_lower() == `c`
	assert `c`.to_lower() == `c`
	assert `Δ`.to_lower() == `δ`
	assert `δ`.to_lower() == `δ`
	assert `Ā`.to_lower() == `ā`
	assert `ā`.to_lower() == `ā`
}

fn test_to_title() {
	assert `c`.to_title() == `C`
	assert `C`.to_title() == `C`
	assert `δ`.to_title() == `Δ`
	assert `Δ`.to_title() == `Δ`
	assert `ā`.to_title() == `Ā`
	assert `Ā`.to_title() == `Ā`
}
```