### PR TITLE
checker: fix missing auto `from_string` type restriction

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2070,8 +2070,8 @@ fn (mut c Checker) check_type_sym_kind(name string, type_idx int, expected_kind 
 
 // checks if a type from another module is as expected and visible(`is_pub`)
 fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
-	if c.check_type_sym_kind(name, type_idx, expected_kind, pos) {
-		return true
+	if !c.check_type_sym_kind(name, type_idx, expected_kind, pos) {
+		return false
 	}
 	mut sym := c.table.sym_by_idx(type_idx)
 	if !sym.is_pub {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1093,6 +1093,10 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 			mut idx := c.table.type_idxs[full_enum_name]
 			if idx > 0 {
+				if c.table.final_sym(idx).kind != .enum {
+					c.error('type `${enum_name}` is not an enum', node.pos)
+					return ast.void_type
+				}
 				// is from another mod.
 				if enum_name.contains('.') {
 					if !c.check_type_and_visibility(full_enum_name, idx, .enum, node.pos) {
@@ -1106,6 +1110,10 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 					idx = c.table.type_idxs[full_enum_name]
 					if idx < 1 {
 						continue
+					}
+					if c.table.final_sym(idx).kind != .enum {
+						c.error('type `${enum_name}` is not an enum', node.pos)
+						return ast.void_type
 					}
 					if !c.check_type_and_visibility(full_enum_name, idx, .enum, node.pos) {
 						return ast.void_type

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1093,13 +1093,13 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 			mut idx := c.table.type_idxs[full_enum_name]
 			if idx > 0 {
-				if c.table.final_sym(idx).kind != .enum {
-					c.error('type `${enum_name}` is not an enum', node.pos)
-					return ast.void_type
-				}
 				// is from another mod.
 				if enum_name.contains('.') {
 					if !c.check_type_and_visibility(full_enum_name, idx, .enum, node.pos) {
+						return ast.void_type
+					}
+				} else {
+					if !c.check_type_sym_kind(full_enum_name, idx, .enum, node.pos) {
 						return ast.void_type
 					}
 				}
@@ -1110,10 +1110,6 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 					idx = c.table.type_idxs[full_enum_name]
 					if idx < 1 {
 						continue
-					}
-					if c.table.final_sym(idx).kind != .enum {
-						c.error('type `${enum_name}` is not an enum', node.pos)
-						return ast.void_type
 					}
 					if !c.check_type_and_visibility(full_enum_name, idx, .enum, node.pos) {
 						return ast.void_type
@@ -2058,8 +2054,8 @@ fn (mut c Checker) cast_to_fixed_array_ret(typ ast.Type, sym ast.TypeSymbol) ast
 	return typ
 }
 
-// checks if a type from another module is as expected and visible(`is_pub`)
-fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
+// checks if a symbol kind is an expected kind
+fn (mut c Checker) check_type_sym_kind(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
 	mut sym := c.table.sym_by_idx(type_idx)
 	if sym.kind == .alias {
 		parent_type := (sym.info as ast.Alias).parent_type
@@ -2069,6 +2065,15 @@ fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected
 		c.error('expected ${expected_kind}, but `${name}` is ${sym.kind}', pos)
 		return false
 	}
+	return true
+}
+
+// checks if a type from another module is as expected and visible(`is_pub`)
+fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
+	if c.check_type_sym_kind(name, type_idx, expected_kind, pos) {
+		return true
+	}
+	mut sym := c.table.sym_by_idx(type_idx)
 	if !sym.is_pub {
 		c.error('module `${sym.mod}` type `${sym.name}` is private', pos)
 		return false

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2070,10 +2070,15 @@ fn (mut c Checker) check_type_sym_kind(name string, type_idx int, expected_kind 
 
 // checks if a type from another module is as expected and visible(`is_pub`)
 fn (mut c Checker) check_type_and_visibility(name string, type_idx int, expected_kind &ast.Kind, pos &token.Pos) bool {
-	if !c.check_type_sym_kind(name, type_idx, expected_kind, pos) {
+	mut sym := c.table.sym_by_idx(type_idx)
+	if sym.kind == .alias {
+		parent_type := (sym.info as ast.Alias).parent_type
+		sym = c.table.sym(parent_type)
+	}
+	if sym.kind != expected_kind {
+		c.error('expected ${expected_kind}, but `${name}` is ${sym.kind}', pos)
 		return false
 	}
-	mut sym := c.table.sym_by_idx(type_idx)
 	if !sym.is_pub {
 		c.error('module `${sym.mod}` type `${sym.name}` is private', pos)
 		return false

--- a/vlib/v/checker/tests/from_string_on_non_enum_err.out
+++ b/vlib/v/checker/tests/from_string_on_non_enum_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/from_string_on_non_enum_err.vv:12:2: error: type `Foo` is not an enum
+   10 | 
+   11 | fn main() {
+   12 |     Foo.from_string('foo')
+      |     ~~~~~~~~~~~~~~~~~~~~~~
+   13 |     Bar.from_string('bar')
+   14 | }

--- a/vlib/v/checker/tests/from_string_on_non_enum_err.out
+++ b/vlib/v/checker/tests/from_string_on_non_enum_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/from_string_on_non_enum_err.vv:12:2: error: type `Foo` is not an enum
+vlib/v/checker/tests/from_string_on_non_enum_err.vv:12:2: error: expected enum, but `Foo` is struct
    10 | 
    11 | fn main() {
    12 |     Foo.from_string('foo')

--- a/vlib/v/checker/tests/from_string_on_non_enum_err.vv
+++ b/vlib/v/checker/tests/from_string_on_non_enum_err.vv
@@ -1,0 +1,14 @@
+struct Foo {
+	a int
+}
+
+struct Bar {
+	b int
+}
+
+fn Bar.from_string(a string) {}
+
+fn main() {
+	Foo.from_string('foo')
+	Bar.from_string('bar')
+}


### PR DESCRIPTION
Fix bug spoted on @blackshirt asn1 pr #22783.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJkZTVlOWU3Y2M1YTc4NTQyOTc5ZGUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.NYDituPwxJq7Jsa2D_nnlwfNhU3CeFHRuEuKFPZ9CW4">Huly&reg;: <b>V_0.6-21249</b></a></sub>