### PR TITLE
comptime: fix wrong type resolution on infix

### DIFF
--- a/vlib/v/comptime/comptimeinfo.v
+++ b/vlib/v/comptime/comptimeinfo.v
@@ -66,18 +66,22 @@ pub fn (mut ct ComptimeInfo) is_generic_param_var(node ast.Expr) bool {
 		&& (node.obj as ast.Var).ct_type_var == .generic_param
 }
 
-// get_expr_type computes the ast node type regarding its or_expr
-pub fn (mut ct ComptimeInfo) get_expr_type(node ast.Expr) ast.Type {
+// get_expr_type_or_default computes the ast node type regarding its or_expr if its comptime var otherwise default_typ is returned
+pub fn (mut ct ComptimeInfo) get_expr_type_or_default(node ast.Expr, default_typ ast.Type) ast.Type {
+	if !ct.is_comptime_expr(node) {
+		return default_typ
+	}
 	ctyp := ct.get_type(node)
 	match node {
 		ast.Ident {
+			// returns the unwrapped type of the var
 			if ctyp.has_flag(.option) && node.or_expr.kind != .absent {
 				return ctyp.clear_flag(.option)
 			}
 		}
 		else {}
 	}
-	return ctyp
+	return if ctyp != ast.void_type { ctyp } else { default_typ }
 }
 
 // get_type_or_default retries the comptime value if the AST node is related to comptime otherwise default_typ is returned

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -96,16 +96,8 @@ fn (mut g Gen) infix_expr_arrow_op(node ast.InfixExpr) {
 
 // infix_expr_eq_op generates code for `==` and `!=`
 fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
-	left_type := if g.comptime.is_comptime_expr(node.left) {
-		g.comptime.get_expr_type(node.left)
-	} else {
-		node.left_type
-	}
-	right_type := if g.comptime.is_comptime_expr(node.right) {
-		g.comptime.get_expr_type(node.right)
-	} else {
-		node.right_type
-	}
+	left_type := g.comptime.get_expr_type_or_default(node.left, node.left_type)
+	right_type := g.comptime.get_expr_type_or_default(node.right, node.right_type)
 	left := g.unwrap(left_type)
 	right := g.unwrap(right_type)
 	mut has_defined_eq_operator := false

--- a/vlib/v/tests/comptime/comptime_infix_test.v
+++ b/vlib/v/tests/comptime/comptime_infix_test.v
@@ -1,0 +1,18 @@
+pub fn get_first[T](arr []T) T {
+	mut first := arr[0]
+	for i, v in arr {
+		if i == 0 {
+			first = v
+		}
+		if first == v {
+			break
+		}
+	}
+	return first
+}
+
+fn test_main() {
+	assert get_first(['foo', 'bar']) == 'foo'
+	assert get_first([1, 2]) == 1
+	assert get_first([1.2, 2.0]) == 1.2
+}


### PR DESCRIPTION
Fix bug spoted by @shove70  👍🏻

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJkZWVlMGU3Y2M1YTc4NTQyOTdiY2QiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.wO0P0qioOx0LslsAjNuK9x8RIJJjnr9MPDxIfdh_kIU">Huly&reg;: <b>V_0.6-21250</b></a></sub>