### PR TITLE
v: add `typeof(var).indirections` and `T.indirections`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -287,6 +287,7 @@ pub enum GenericKindField {
 	name
 	typ
 	unaliased_typ
+	indirections
 }
 
 // `foo.bar`

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1531,16 +1531,15 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			.name {
 				return ast.string_type
 			}
-			.unaliased_typ {
-				return ast.int_type
-			}
-			.typ {
+			.unaliased_typ, .typ, .indirections {
 				return ast.int_type
 			}
 			else {
 				if node.field_name == 'name' {
 					return ast.string_type
 				} else if node.field_name == 'idx' {
+					return ast.int_type
+				} else if node.field_name == 'indirections' {
 					return ast.int_type
 				}
 				c.error('invalid field `.${node.field_name}` for type `${node.expr}`',

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -268,6 +268,12 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 									}
 								}
 							}
+						} else if left.expr is ast.TypeOf {
+							skip_state = if left.expr.typ.nr_muls() == right.val.i64() {
+								ComptimeBranchSkipState.eval
+							} else {
+								ComptimeBranchSkipState.skip
+							}
 						}
 					} else if branch.cond.op in [.eq, .ne] && left is ast.SelectorExpr
 						&& right is ast.StringLiteral {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3875,6 +3875,10 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				g.write(int(g.table.unaliased_type(g.unwrap_generic(node.name_type))).str())
 				return
 			}
+			.indirections {
+				g.write(int(g.unwrap_generic(node.name_type).nr_muls()).str())
+				return
+			}
 			.unknown {
 				// ast.TypeOf of `typeof(string).idx` etc
 				if node.field_name == 'name' {
@@ -3892,6 +3896,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 					}
 					// `typeof(expr).idx`
 					g.write(int(g.unwrap_generic(name_type)).str())
+					return
+				} else if node.field_name == 'indirections' {
+					mut name_type := node.name_type
+					if node.expr is ast.TypeOf {
+						name_type = g.resolve_comptime_type(node.expr.expr, name_type)
+					}
+					// `typeof(expr).indirections`
+					g.write(int(g.unwrap_generic(name_type).nr_muls()).str())
 					return
 				}
 				g.error('unknown generic field', node.pos)

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -469,6 +469,8 @@ fn (mut g Gen) get_expr_type(cond ast.Expr) ast.Type {
 				return g.unwrap_generic(cond.name_type)
 			} else if cond.gkind_field == .unaliased_typ {
 				return g.table.unaliased_type(g.unwrap_generic(cond.name_type))
+			} else if cond.gkind_field == .indirections {
+				return ast.int_type
 			} else {
 				name := '${cond.expr}.${cond.field_name}'
 				if name in g.comptime.type_map {

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3262,6 +3262,13 @@ fn (mut g JsGen) gen_selector_expr(it ast.SelectorExpr) {
 				g.write(')')
 				return
 			}
+			.indirections {
+				g.write('new int(')
+				g.write('${int(g.unwrap_generic(it.name_type).nr_muls())}')
+				g.write(')')
+				g.write(')')
+				return
+			}
 			.unknown {
 				if node.field_name == 'name' {
 					g.type_name(it.name_type)

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3252,20 +3252,17 @@ fn (mut g JsGen) gen_selector_expr(it ast.SelectorExpr) {
 				g.write('new int(')
 				g.write('${int(g.unwrap_generic(it.name_type))}')
 				g.write(')')
-				g.write(')')
 				return
 			}
 			.unaliased_typ {
 				g.write('new int(')
 				g.write('${int(g.table.unaliased_type(g.unwrap_generic(it.name_type)))}')
 				g.write(')')
-				g.write(')')
 				return
 			}
 			.indirections {
 				g.write('new int(')
 				g.write('${int(g.unwrap_generic(it.name_type).nr_muls())}')
-				g.write(')')
 				g.write(')')
 				return
 			}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2923,6 +2923,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 				'name' { ast.GenericKindField.name }
 				'typ' { ast.GenericKindField.typ }
 				'unaliased_typ' { ast.GenericKindField.unaliased_typ }
+				'indirections' { ast.GenericKindField.indirections }
 				else { ast.GenericKindField.unknown }
 			}
 			pos.extend(p.tok.pos())

--- a/vlib/v/tests/typeof_indirections_test.v
+++ b/vlib/v/tests/typeof_indirections_test.v
@@ -1,0 +1,18 @@
+fn indirections[T](val T) int {
+	return T.indirections
+}
+
+fn test_main() {
+	a := 0
+	assert typeof(a).indirections == 0
+	assert indirections(a) == 0
+	b := &a
+	assert typeof(b).indirections == 1
+	assert indirections(b) == 1
+	c := [1]
+	assert typeof(c).indirections == 0
+	assert indirections(c) == 0
+	d := &c
+	assert typeof(d).indirections == 1
+	assert indirections(d) == 1
+}


### PR DESCRIPTION
This PR adds a way to retrieve the number of indirections related to `typeof(expr)` and `T` generic type.

```v
fn indirections[T](val T) int {
	return T.indirections
}

fn test_main() {
	a := 0
	assert typeof(a).indirections == 0
	assert indirections(a) == 0
	b := &a
	assert typeof(b).indirections == 1
	assert indirections(b) == 1
	c := [1]
	assert typeof(c).indirections == 0
	assert indirections(c) == 0
	d := &c
	assert typeof(d).indirections == 1
	assert indirections(d) == 1
}
```

Related to #22792

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJlMDRhOGU3Y2M1YTc4NTQyOTdmOWEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.JzKDL2jfLYNYbQLoA0GpdCh_P_DTaOCaEP299uY_IIA">Huly&reg;: <b>V_0.6-21251</b></a></sub>