### PR TITLE
builtin: minor optimization in rune.map_to()

### DIFF
--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -131,14 +131,14 @@ fn (c rune) map_to(mode MapMode) rune {
 				unsafe { *(cur_map + 3) }
 			}
 			if offset == rune_maps_ul {
-				is_odd := (c - unsafe { *cur_map }) % 2 == 1
-				if mode in [.to_upper, .to_title] && is_odd {
-					return c - 1
-				} else if mode == .to_lower && !is_odd {
-					return c + 1
+				// upper, lower, upper, lower, ... sequence
+				cnt := (c - unsafe { *cur_map }) % 2
+				if mode in [.to_upper, .to_title] {
+					return c - cnt
 				}
-				return c
+				return c + 1 - cnt
 			} else if offset == rune_maps_utl {
+				// upper, title, lower, upper, title, lower, ... sequence
 				cnt := (c - unsafe { *cur_map }) % 3
 				if mode == .to_upper {
 					return c - cnt

--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -133,10 +133,10 @@ fn (c rune) map_to(mode MapMode) rune {
 			if offset == rune_maps_ul {
 				// upper, lower, upper, lower, ... sequence
 				cnt := (c - unsafe { *cur_map }) % 2
-				if mode in [.to_upper, .to_title] {
-					return c - cnt
+				if mode == .to_lower {
+					return c + 1 - cnt
 				}
-				return c + 1 - cnt
+				return c - cnt
 			} else if offset == rune_maps_utl {
 				// upper, title, lower, upper, title, lower, ... sequence
 				cnt := (c - unsafe { *cur_map }) % 3


### PR DESCRIPTION
This PR make a minor optimization in rune.map_to().

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJlMzQ1M2U3Y2M1YTc4NTQyOThhZDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.QOQ7P1jdSmZv9yQO9jCc0kaFg943jrJapTiy2dOMAmg">Huly&reg;: <b>V_0.6-21256</b></a></sub>