### PR TITLE
cgen: fix codegen for fn fixed array param w/ size defined by const

### DIFF
--- a/vlib/v/tests/fns/param_fixed_array_const_test.v
+++ b/vlib/v/tests/fns/param_fixed_array_const_test.v
@@ -2,20 +2,6 @@ module main
 
 import crypto.ed25519
 
-struct SSHClientHello {
-	version    u8
-	public_key [crypto.ed25519.public_key_size]u8
-}
-
-struct SSHServerHello {
-	version u8
-	send_me [crypto.ed25519.public_key_size]u8
-}
-
-struct SSHClientProof {
-	result [crypto.ed25519.public_key_size]u8
-}
-
 fn new_client_hello(public_key [ed25519.public_key_size]u8) {
 	assert public_key.len == ed25519.public_key_size
 	assert public_key.len != 0

--- a/vlib/v/tests/fns/param_fixed_array_const_test.v
+++ b/vlib/v/tests/fns/param_fixed_array_const_test.v
@@ -1,0 +1,26 @@
+module main
+
+import crypto.ed25519
+
+struct SSHClientHello {
+	version    u8
+	public_key [crypto.ed25519.public_key_size]u8
+}
+
+struct SSHServerHello {
+	version u8
+	send_me [crypto.ed25519.public_key_size]u8
+}
+
+struct SSHClientProof {
+	result [crypto.ed25519.public_key_size]u8
+}
+
+fn new_client_hello(public_key [ed25519.public_key_size]u8) {
+	assert public_key.len == ed25519.public_key_size
+	assert public_key.len != 0
+}
+
+fn test_main() {
+	new_client_hello([ed25519.public_key_size]u8{})
+}


### PR DESCRIPTION
Fix #22811

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJlN2NkOGU3Y2M1YTc4NTQyOTk3NzgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.K1k5rrMGWXmf0gUitraadXSiKYjYFVn8WE3E6gxePR0">Huly&reg;: <b>V_0.6-21258</b></a></sub>