### PR TITLE
fmt: fix formatting fixed array size of struct member

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1421,6 +1421,9 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			elem_str := t.type_to_str_using_aliases(info.elem_type, import_aliases)
 			if info.size_expr is EmptyExpr {
 				res = '[${info.size}]${elem_str}'
+			} else if info.size_expr is Ident {
+				size_str := t.shorten_user_defined_typenames(info.size_expr.name, import_aliases)
+				res = '[${size_str}]${elem_str}'
 			} else {
 				res = '[${info.size_expr}]${elem_str}'
 			}

--- a/vlib/v/fmt/tests/struct_fixed_array_ident_keep.vv
+++ b/vlib/v/fmt/tests/struct_fixed_array_ident_keep.vv
@@ -1,0 +1,11 @@
+import crypto.ed25519
+
+struct SSHClientHello {
+	version    u8
+	public_key [ed25519.public_key_size]u8
+}
+
+fn main() {
+	a := SSHClientHello{}
+	assert a.public_key.len == ed25519.public_key_size
+}


### PR DESCRIPTION
This PR fixes `vfmt` changing `ed25519.public_key_size` (Ident) to `crypto.ed25519.public_key_size` (SelectorExpr) on:

```v
struct SSHClientHello {
	version    u8
	public_key [ed25519.public_key_size]u8
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJmNDU1Y2U3Y2M1YTc4NTQyOWRmYjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.edgBZRfBYpfn0ZMvnYEcAck1h-xmdDn4BsxMH2oKUJo">Huly&reg;: <b>V_0.6-21261</b></a></sub>