### PR TITLE
v: cleanup calls to Scope.find() methods

### DIFF
--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -49,10 +49,10 @@ pub fn (s &Scope) find(name string) ?ScopeObject {
 	if s == unsafe { nil } {
 		return none
 	}
-	if name in sc.objects {
-		return unsafe { sc.objects[name] }
+	if name in s.objects {
+		return unsafe { s.objects[name] }
 	}
-	if sc.dont_lookup_parent() {
+	if s.dont_lookup_parent() {
 		return none
 	}
 	for sc := unsafe { s.parent }; true; sc = sc.parent {

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -49,13 +49,7 @@ pub fn (s &Scope) find(name string) ?ScopeObject {
 	if s == unsafe { nil } {
 		return none
 	}
-	if name in s.objects {
-		return unsafe { s.objects[name] }
-	}
-	if s.dont_lookup_parent() {
-		return none
-	}
-	for sc := unsafe { s.parent }; true; sc = sc.parent {
+	for sc := unsafe { s }; true; sc = sc.parent {
 		if name in sc.objects {
 			return unsafe { sc.objects[name] }
 		}

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -53,7 +53,7 @@ pub fn (s &Scope) find(name string) ?ScopeObject {
 		return unsafe { sc.objects[name] }
 	}
 	if sc.dont_lookup_parent() {
-		break
+		return none
 	}
 	for sc := unsafe { s.parent }; true; sc = sc.parent {
 		if name in sc.objects {

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -49,7 +49,13 @@ pub fn (s &Scope) find(name string) ?ScopeObject {
 	if s == unsafe { nil } {
 		return none
 	}
-	for sc := unsafe { s }; true; sc = sc.parent {
+	if name in sc.objects {
+		return unsafe { sc.objects[name] }
+	}
+	if sc.dont_lookup_parent() {
+		break
+	}
+	for sc := unsafe { s.parent }; true; sc = sc.parent {
 		if name in sc.objects {
 			return unsafe { sc.objects[name] }
 		}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -439,10 +439,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 					}
 					if is_decl {
 						full_name := '${left.mod}.${left.name}'
-						if obj := c.file.global_scope.find(full_name) {
-							if obj is ast.ConstField {
-								c.warn('duplicate of a const name `${full_name}`', left.pos)
-							}
+						if _ := c.file.global_scope.find_const(full_name) {
+							c.warn('duplicate of a const name `${full_name}`', left.pos)
 						}
 						if left.name == left.mod && left.name != 'main' {
 							c.error('duplicate of a module name `${left.name}`', left.pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1836,10 +1836,8 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 					field.expr.typ = (branch.stmts.last() as ast.ExprStmt).typ
 					field.typ = field.expr.typ
 					// update ConstField object's type in table
-					if mut obj := c.file.global_scope.find(field.name) {
-						if mut obj is ast.ConstField {
-							obj.typ = field.typ
-						}
+					if mut obj := c.file.global_scope.find_const(field.name) {
+						obj.typ = field.typ
 					}
 					break
 				}

--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -119,15 +119,13 @@ pub fn (mut c Checker) lambda_expr(mut node ast.LambdaExpr, exp_typ ast.Type) as
 }
 
 pub fn (mut c Checker) lambda_expr_fix_type_of_param(mut node ast.LambdaExpr, mut pident ast.Ident, ptype ast.Type) {
-	if mut v := node.scope.find(pident.name) {
-		if mut v is ast.Var {
-			v.is_arg = true
-			v.typ = ptype
-			v.is_auto_deref = ptype.is_ptr()
-			v.expr = ast.empty_expr
-			if ptype.has_flag(.generic) {
-				v.ct_type_var = .generic_param
-			}
+	if mut v := node.scope.find_var(pident.name) {
+		v.is_arg = true
+		v.typ = ptype
+		v.is_auto_deref = ptype.is_ptr()
+		v.expr = ast.empty_expr
+		if ptype.has_flag(.generic) {
+			v.ct_type_var = .generic_param
 		}
 	}
 	if pident.kind != .blank_ident {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2363,7 +2363,7 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 			}
 		}
 		if !is_local && !node.name.contains('.') && !f.inside_const {
-			if obj := f.file.global_scope.find_const('${f.cur_mod}.${node.name}') {
+			if _ := f.file.global_scope.find_const('${f.cur_mod}.${node.name}') {
 				const_name := node.name.all_after_last('.')
 				f.write(const_name)
 				if node.or_expr.kind == .block {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2363,15 +2363,13 @@ pub fn (mut f Fmt) ident(node ast.Ident) {
 			}
 		}
 		if !is_local && !node.name.contains('.') && !f.inside_const {
-			if obj := f.file.global_scope.find('${f.cur_mod}.${node.name}') {
-				if obj is ast.ConstField {
-					const_name := node.name.all_after_last('.')
-					f.write(const_name)
-					if node.or_expr.kind == .block {
-						f.or_expr(node.or_expr)
-					}
-					return
+			if obj := f.file.global_scope.find_const('${f.cur_mod}.${node.name}') {
+				const_name := node.name.all_after_last('.')
+				f.write(const_name)
+				if node.or_expr.kind == .block {
+					f.or_expr(node.or_expr)
 				}
+				return
 			}
 		}
 		name := f.short_module(node.name)

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1003,9 +1003,10 @@ fn (mut g Gen) gen_cross_var_assign(node &ast.AssignStmt) {
 				left_sym := g.table.sym(left_typ)
 				mut anon_ctx := ''
 				if g.anon_fn {
-					obj := left.scope.find(left.name)
-					if obj is ast.Var && obj.is_inherited {
-						anon_ctx = '${closure_ctx}->'
+					if obj := left.scope.find_var(left.name) {
+						if obj.is_inherited {
+							anon_ctx = '${closure_ctx}->'
+						}
 					}
 				}
 				if left_sym.kind == .function {


### PR DESCRIPTION
This PR aims optimize scope usage.

![image](https://github.com/user-attachments/assets/94333eb3-a6af-4c44-aa93-0bd5b53af2fd)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMyMzMzZWU3Y2M1YTc4NTQyYWUxNDUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.y96tJAyBIV1FTedfa74LMUuzhSQVjuE-yZHW7T2DrT4">Huly&reg;: <b>V_0.6-21278</b></a></sub>