### PR TITLE
tools: use `v retry` in more places, that do network operations that can fail temporarily

### DIFF
--- a/cmd/tools/translate.v
+++ b/cmd/tools/translate.v
@@ -19,7 +19,7 @@ fn main() {
 		os.mkdir_all(vmodules)!
 		println('C2V is not installed. Cloning C2V to ${c2v_dir} ...')
 		os.chdir(vmodules)!
-		res := os.execute('git clone --filter=blob:none https://github.com/vlang/c2v')
+		res := os.execute('${os.quoted_path(vexe)} retry -- git clone --filter=blob:none https://github.com/vlang/c2v')
 		if res.exit_code != 0 {
 			eprintln('Failed to download C2V.')
 			exit(1)

--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -49,6 +49,8 @@ mut:
 	args          []string
 }
 
+const vexe = os.real_path(os.getenv_opt('VEXE') or { @VEXE })
+
 const vls_folder = os.join_path(os.home_dir(), '.vls')
 
 const vls_bin_folder = os.join_path(vls_folder, 'bin')
@@ -255,13 +257,13 @@ fn (upd VlsUpdater) compile_from_source() ! {
 
 	if !os.exists(vls_src_folder) {
 		upd.log('Cloning VLS repo...')
-		clone_result := os.execute('${git} clone --filter=blob:none https://github.com/vlang/vls ${vls_src_folder}')
+		clone_result := os.execute('${os.quoted_path(vexe)} retry -- ${git} clone --filter=blob:none https://github.com/vlang/vls ${vls_src_folder}')
 		if clone_result.exit_code != 0 {
 			return error('Failed to build VLS from source. Reason: ${clone_result.output}')
 		}
 	} else {
 		upd.log('Updating VLS repo...')
-		pull_result := os.execute('${git} -C ${vls_src_folder} pull')
+		pull_result := os.execute('${os.quoted_path(vexe)} retry -- ${git} -C ${vls_src_folder} pull')
 		if !upd.is_force && pull_result.output.trim_space() == 'Already up to date.' {
 			upd.log("VLS was already updated to it's latest version.")
 			return
@@ -282,7 +284,8 @@ fn (upd VlsUpdater) compile_from_source() ! {
 		return error('Cannot compile VLS from source: no appropriate C compiler found.')
 	}
 
-	compile_result := os.execute('v run ${os.join_path(vls_src_folder, 'build.vsh')} ${possible_compilers[selected_compiler_idx]}')
+	compile_result := os.execute('${os.quoted_path(vexe)} run ${os.join_path(vls_src_folder,
+		'build.vsh')} ${possible_compilers[selected_compiler_idx]}')
 	if compile_result.exit_code != 0 {
 		return error('Cannot compile VLS from source: ${compile_result.output}')
 	}

--- a/cmd/tools/vsetup-freetype.v
+++ b/cmd/tools/vsetup-freetype.v
@@ -9,12 +9,13 @@ const freetype_folder = os.join_path('thirdparty', 'freetype')
 fn main() {
 	$if windows {
 		println('Setup freetype...')
-		vroot := os.dir(os.real_path(os.getenv_opt('VEXE') or { @VEXE }))
+		vexe := os.real_path(os.getenv_opt('VEXE') or { @VEXE })
+		vroot := os.dir(vexe)
 		os.chdir(vroot)!
 		if os.is_dir(freetype_folder) {
 			println('Thirdparty "freetype" is already installed.')
 		} else {
-			s := os.execute('git clone --filter=blob:none ${freetype_repo_url} ${freetype_folder}')
+			s := os.execute('${os.quoted_path(vexe)} retry -- git clone --filter=blob:none ${freetype_repo_url} ${freetype_folder}')
 			if s.exit_code != 0 {
 				panic(s.output)
 			}

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -521,9 +521,9 @@ pub fn check_module_is_installed(modulename string, is_verbose bool, need_update
 		eprintln('check_module_is_installed: mod_v_file: ${mod_v_file}')
 		eprintln('check_module_is_installed: murl: ${murl}')
 	}
+	vexe := pref.vexe_path()
 	if os.exists(mod_v_file) {
 		if need_update {
-			vexe := pref.vexe_path()
 			update_cmd := "${os.quoted_path(vexe)} update '${modulename}'"
 			if is_verbose {
 				eprintln('check_module_is_installed: updating with ${update_cmd} ...')
@@ -548,10 +548,7 @@ and the existing module `${modulename}` may still work.')
 	if is_verbose {
 		eprintln('check_module_is_installed: cloning from ${murl} ...')
 	}
-	cloning_res := os.execute('git clone ${os.quoted_path(murl)} ${os.quoted_path(mpath)}')
-	if cloning_res.exit_code < 0 {
-		return error_with_code('git is not installed, error: ${cloning_res.output}', cloning_res.exit_code)
-	}
+	cloning_res := os.execute('${os.quoted_path(vexe)} retry -- git clone ${os.quoted_path(murl)} ${os.quoted_path(mpath)}')
 	if cloning_res.exit_code != 0 {
 		return error_with_code('cloning failed, details: ${cloning_res.output}', cloning_res.exit_code)
 	}


### PR DESCRIPTION
Prevent transient network problems from causing CI false positives like this one: https://github.com/vlang/v/actions/runs/11781538022/job/32814585067?pr=22832