### PR TITLE
cgen: fix missing return code generated

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1958,6 +1958,8 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 							}
 						}
 					}
+				} else if stmt is ast.Return {
+					g.stmt(stmt)
 				}
 			} else {
 				g.set_current_pos_as_last_stmt_pos()

--- a/vlib/v/gen/c/testdata/if_else_return.c.must_have
+++ b/vlib/v/gen/c/testdata/if_else_return.c.must_have
@@ -1,0 +1,10 @@
+VV_LOCAL_SYMBOL _result_string main__empty(string s) {
+_result_string _t2; /* if prepend */
+if ((s).len != 0) {
+_result_ok(&(string[]) { s }, (_result*)(&_t2), sizeof(string));
+} else {
+return (_result_string){ .is_error=true, .err=_v_error(_SLIT("empty")), .data={EMPTY_STRUCT_INITIALIZATION} };
+}
+_result_string _t1 =  _t2;
+return _t1;
+}

--- a/vlib/v/gen/c/testdata/if_else_return.out
+++ b/vlib/v/gen/c/testdata/if_else_return.out
@@ -1,0 +1,1 @@
+expected error empty

--- a/vlib/v/gen/c/testdata/if_else_return.vv
+++ b/vlib/v/gen/c/testdata/if_else_return.vv
@@ -1,0 +1,21 @@
+fn empty(s string) !string {
+	return if s != '' {
+		s
+	} else {
+		return error('empty')
+	}
+}
+
+fn main() {
+	str_1 := empty('something') or {
+		assert false, 'something is not empty!'
+		return
+	}
+	assert str_1 == 'something'
+
+	str_2 := empty('') or {
+		println('expected error ${err}')
+		return
+	}
+	assert false, 'invalid accepted ${str_2}'
+}


### PR DESCRIPTION
Fix #22838

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMyYzA5NmU3Y2M1YTc4NTQyYjQwOTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.1J9fbK_6LL9-824Ly15f1e7YSOYNttNpT_rjWldJUt8">Huly&reg;: <b>V_0.6-21284</b></a></sub>