### PR TITLE
checker: fix if expr with empty array init expression (related #22832)

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -422,6 +422,9 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 						}
 						continue
 					}
+					if c.expected_expr_type != ast.void_type {
+						c.expected_type = c.expected_expr_type
+					}
 					stmt.typ = c.expr(mut stmt.expr)
 					if c.table.type_kind(c.expected_type) == .multi_return
 						&& c.table.type_kind(stmt.typ) == .multi_return {
@@ -447,6 +450,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 							} else {
 								node.typ = stmt.typ
 							}
+							c.expected_expr_type = node.typ
 							continue
 						} else if node.typ in [ast.float_literal_type, ast.int_literal_type] {
 							if node.typ == ast.int_literal_type {

--- a/vlib/v/tests/conditions/ifs/if_expr_with_empty_array_init_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_with_empty_array_init_test.v
@@ -1,0 +1,14 @@
+fn test_if_expr_with_empty_array_init() {
+	arr1 := ['Peter', 'Bob']
+	arr2 := ['Sam', 'Mike']
+	typ := 1
+	names := if typ == 1 {
+		arr1
+	} else if typ == 2 {
+		arr2
+	} else {
+		[]
+	}
+	println(names)
+	assert names == ['Peter', 'Bob']
+}


### PR DESCRIPTION
This PR fix if expr with empty array init expression (related #22832).

- Fix if expr with empty array init expression.
- Add test.

```v
fn main() {
	arr1 := ['Peter', 'Bob']
	arr2 := ['Sam', 'Mike']
	typ := 1
	names := if typ == 1 {
		arr1
	} else if typ == 2 {
		arr2
	} else {
		[]
	}
	println(names)
	assert names == ['Peter', 'Bob']
}

PS D:\Test\v\tt1> v run .
['Peter', 'Bob']
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMzMWMxZWU3Y2M1YTc4NTQyYjUxOTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.o20ENs2aF_pRcDvJhGI4edxdclj2JE3FvVB-6HaKPfw">Huly&reg;: <b>V_0.6-21286</b></a></sub>