### PR TITLE
v: cleanup mark var as used operation

### DIFF
--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -14,6 +14,7 @@ pub mut:
 	children             []&Scope
 	start_pos            int
 	end_pos              int
+	used_vars            map[string]bool
 }
 
 @[unsafe]
@@ -260,6 +261,27 @@ pub fn (sc &Scope) show(depth int, max_depth int) string {
 		}
 	}
 	return out
+}
+
+pub fn (mut sc Scope) mark_used(varname string) bool {
+	if varname in sc.used_vars {
+		return true
+	}
+	if mut obj := sc.find(varname) {
+		match mut obj {
+			Var {
+				obj.is_used = true
+				sc.used_vars[varname] = true
+				return true
+			}
+			GlobalField {
+				sc.used_vars[varname] = true
+				return true
+			}
+			else {}
+		}
+	}
+	return false
 }
 
 pub fn (sc &Scope) str() string {

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -262,7 +262,7 @@ pub fn (sc &Scope) show(depth int, max_depth int) string {
 	return out
 }
 
-pub fn (mut sc Scope) mark_used(varname string) bool {
+pub fn (mut sc Scope) mark_var_as_used(varname string) bool {
 	mut obj := sc.find(varname) or { return false }
 	if mut obj is Var {
 		obj.is_used = true

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -264,7 +264,7 @@ pub fn (sc &Scope) show(depth int, max_depth int) string {
 }
 
 pub fn (mut sc Scope) mark_used(varname string) bool {
-	if varname in sc.used_vars {
+	if sc.used_vars.len > 0 && varname in sc.used_vars {
 		return true
 	}
 	if mut obj := sc.find(varname) {

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -14,7 +14,6 @@ pub mut:
 	children             []&Scope
 	start_pos            int
 	end_pos              int
-	used_vars            map[string]bool
 }
 
 @[unsafe]
@@ -264,22 +263,12 @@ pub fn (sc &Scope) show(depth int, max_depth int) string {
 }
 
 pub fn (mut sc Scope) mark_used(varname string) bool {
-	if sc.used_vars.len > 0 && varname in sc.used_vars {
+	mut obj := sc.find(varname) or { return false }
+	if mut obj is Var {
+		obj.is_used = true
 		return true
-	}
-	if mut obj := sc.find(varname) {
-		match mut obj {
-			Var {
-				obj.is_used = true
-				sc.used_vars[varname] = true
-				return true
-			}
-			GlobalField {
-				sc.used_vars[varname] = true
-				return true
-			}
-			else {}
-		}
+	} else if obj is GlobalField {
+		return true
 	}
 	return false
 }

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -352,7 +352,7 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 		typ = p.parse_any_type(lang, false, true, false)
 	} else {
 		expr = p.ident(lang)
-		p.mark_var_as_used((expr as ast.Ident).name)
+		p.scope.mark_used((expr as ast.Ident).name)
 	}
 	typ_pos = typ_pos.extend(p.prev_tok.pos())
 	p.check(.dot)
@@ -470,7 +470,7 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 	if p.peek_tok.kind == .lpar {
 		method_pos := p.tok.pos()
 		method_name := p.check_name()
-		p.mark_var_as_used(method_name)
+		p.scope.mark_used(method_name)
 		// `app.$action()` (`action` is a string)
 		p.check(.lpar)
 		args := p.call_args()

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -352,7 +352,7 @@ fn (mut p Parser) comptime_for() ast.ComptimeFor {
 		typ = p.parse_any_type(lang, false, true, false)
 	} else {
 		expr = p.ident(lang)
-		p.scope.mark_used((expr as ast.Ident).name)
+		p.scope.mark_var_as_used((expr as ast.Ident).name)
 	}
 	typ_pos = typ_pos.extend(p.prev_tok.pos())
 	p.check(.dot)
@@ -470,7 +470,7 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 	if p.peek_tok.kind == .lpar {
 		method_pos := p.tok.pos()
 		method_name := p.check_name()
-		p.scope.mark_used(method_name)
+		p.scope.mark_var_as_used(method_name)
 		// `app.$action()` (`action` is a string)
 		p.check(.lpar)
 		args := p.call_args()

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -73,7 +73,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				ident := p.ident(.v)
 				node = ident
 				if p.peek_tok.kind != .assign && (p.inside_if_cond || p.inside_match) {
-					p.scope.mark_used(ident.name)
+					p.scope.mark_var_as_used(ident.name)
 				}
 				p.add_defer_var(ident)
 				p.is_stmt_ident = is_stmt_ident
@@ -356,7 +356,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 			} else {
 				p.check(.lpar)
 				pos := p.tok.pos()
-				mut is_known_var := p.scope.mark_used(p.tok.lit)
+				mut is_known_var := p.scope.mark_var_as_used(p.tok.lit)
 					|| p.table.global_scope.known_const(p.mod + '.' + p.tok.lit)
 				//|| p.table.known_fn(p.mod + '.' + p.tok.lit)
 				// assume `mod.` prefix leads to a type
@@ -524,7 +524,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				// variable name: type
 				ident := p.ident(.v)
 				node = ident
-				p.scope.mark_used(ident.name)
+				p.scope.mark_var_as_used(ident.name)
 				p.add_defer_var(ident)
 				p.is_stmt_ident = is_stmt_ident
 			} else if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -73,7 +73,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				ident := p.ident(.v)
 				node = ident
 				if p.peek_tok.kind != .assign && (p.inside_if_cond || p.inside_match) {
-					p.mark_var_as_used(ident.name)
+					p.scope.mark_used(ident.name)
 				}
 				p.add_defer_var(ident)
 				p.is_stmt_ident = is_stmt_ident
@@ -356,7 +356,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 			} else {
 				p.check(.lpar)
 				pos := p.tok.pos()
-				mut is_known_var := p.mark_var_as_used(p.tok.lit)
+				mut is_known_var := p.scope.mark_used(p.tok.lit)
 					|| p.table.global_scope.known_const(p.mod + '.' + p.tok.lit)
 				//|| p.table.known_fn(p.mod + '.' + p.tok.lit)
 				// assume `mod.` prefix leads to a type
@@ -524,7 +524,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				// variable name: type
 				ident := p.ident(.v)
 				node = ident
-				p.mark_var_as_used(ident.name)
+				p.scope.mark_used(ident.name)
 				p.add_defer_var(ident)
 				p.is_stmt_ident = is_stmt_ident
 			} else if p.tok.kind != .eof && !(p.tok.kind == .rsbr && p.inside_asm) {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4586,23 +4586,7 @@ fn (mut p Parser) rewind_scanner_to_current_token_in_new_mode() {
 
 // returns true if `varname` is known
 fn (mut p Parser) mark_var_as_used(varname string) bool {
-	if mut obj := p.scope.find(varname) {
-		match mut obj {
-			ast.Var {
-				obj.is_used = true
-				return true
-			}
-			ast.GlobalField {
-				// obj.is_used = true
-				return true
-			}
-			// ast.ConstField {
-			// return true
-			//}
-			else {}
-		}
-	}
-	return false
+	return p.scope.mark_used(varname)
 }
 
 fn (mut p Parser) unsafe_stmt() ast.Stmt {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1058,7 +1058,7 @@ fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			} else if p.peek_tok.kind == .name {
 				return p.unexpected(got: 'name `${p.tok.lit}`')
 			} else if !p.inside_if_expr && !p.inside_match_body && !p.inside_or_expr
-				&& p.peek_tok.kind in [.rcbr, .eof] && !p.scope.mark_used(p.tok.lit) {
+				&& p.peek_tok.kind in [.rcbr, .eof] && !p.scope.mark_var_as_used(p.tok.lit) {
 				return p.error_with_pos('`${p.tok.lit}` evaluated but not used', p.tok.pos())
 			}
 			return p.parse_multi_expr(is_top_level)
@@ -2626,7 +2626,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// get type position before moving to next
 		is_known_var := p.scope.known_var(p.tok.lit)
 		if is_known_var {
-			p.scope.mark_used(p.tok.lit)
+			p.scope.mark_var_as_used(p.tok.lit)
 			return p.ident(.v)
 		} else {
 			type_pos := p.tok.pos()
@@ -2748,7 +2748,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 	known_var := if p.peek_tok.kind.is_assign() {
 		p.scope.known_var(p.tok.lit)
 	} else {
-		p.scope.mark_used(p.tok.lit)
+		p.scope.mark_var_as_used(p.tok.lit)
 	}
 	// Handle modules
 	mut is_mod_cast := false

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1058,7 +1058,7 @@ fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 			} else if p.peek_tok.kind == .name {
 				return p.unexpected(got: 'name `${p.tok.lit}`')
 			} else if !p.inside_if_expr && !p.inside_match_body && !p.inside_or_expr
-				&& p.peek_tok.kind in [.rcbr, .eof] && !p.mark_var_as_used(p.tok.lit) {
+				&& p.peek_tok.kind in [.rcbr, .eof] && !p.scope.mark_used(p.tok.lit) {
 				return p.error_with_pos('`${p.tok.lit}` evaluated but not used', p.tok.pos())
 			}
 			return p.parse_multi_expr(is_top_level)
@@ -2626,7 +2626,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 		// get type position before moving to next
 		is_known_var := p.scope.known_var(p.tok.lit)
 		if is_known_var {
-			p.mark_var_as_used(p.tok.lit)
+			p.scope.mark_used(p.tok.lit)
 			return p.ident(.v)
 		} else {
 			type_pos := p.tok.pos()
@@ -2748,7 +2748,7 @@ fn (mut p Parser) name_expr() ast.Expr {
 	known_var := if p.peek_tok.kind.is_assign() {
 		p.scope.known_var(p.tok.lit)
 	} else {
-		p.mark_var_as_used(p.tok.lit)
+		p.scope.mark_used(p.tok.lit)
 	}
 	// Handle modules
 	mut is_mod_cast := false
@@ -4582,11 +4582,6 @@ fn (mut p Parser) rewind_scanner_to_current_token_in_new_mode() {
 			break
 		}
 	}
-}
-
-// returns true if `varname` is known
-fn (mut p Parser) mark_var_as_used(varname string) bool {
-	return p.scope.mark_used(varname)
 }
 
 fn (mut p Parser) unsafe_stmt() ast.Stmt {


### PR DESCRIPTION
This PR aims cleanup mark var as used operation on Scope.
The logic was moved from parser to Scope.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMzNGQ3M2U3Y2M1YTc4NTQyYjYyNzMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.nnx8Xugyn8sdy3c6X_dWjO2vfiGT12K1YVP7nPwKd7w">Huly&reg;: <b>V_0.6-21287</b></a></sub>