### PR TITLE
checker: minor cleanup in lambda_expr.v

### DIFF
--- a/vlib/v/checker/lambda_expr.v
+++ b/vlib/v/checker/lambda_expr.v
@@ -3,7 +3,6 @@ module checker
 import v.ast
 
 pub fn (mut c Checker) lambda_expr(mut node ast.LambdaExpr, exp_typ ast.Type) ast.Type {
-	// defer { eprintln('> line: ${@LINE} | exp_typ: $exp_typ | node: ${voidptr(node)} | node.typ: ${node.typ}') }
 	if node.is_checked {
 		return node.typ
 	}
@@ -56,8 +55,6 @@ pub fn (mut c Checker) lambda_expr(mut node ast.LambdaExpr, exp_typ ast.Type) as
 				}
 			}
 		}
-		// dump(generic_types)
-		// dump(generic_names)
 
 		mut stmts := []ast.Stmt{}
 		mut has_return := false


### PR DESCRIPTION
This PR makes a minor cleanup in lambda_expr.v.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzMzNmJkYWU3Y2M1YTc4NTQyYjY4ZWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.LVNHodzWnmyMVqRg1sujwU3uVEEOn-hi5Yq9S3BzFMY">Huly&reg;: <b>V_0.6-21289</b></a></sub>