### PR TITLE
checker: fix generic fn call with empty array argument (fix #22843)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1719,7 +1719,15 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			} else {
 				func.params[i]
 			}
-			c.expected_type = param.typ
+			if param.typ.has_flag(.generic) {
+				if unwrap_typ := c.table.convert_generic_type(param.typ, func.generic_names,
+					concrete_types)
+				{
+					c.expected_type = unwrap_typ
+				}
+			} else {
+				c.expected_type = param.typ
+			}
 			already_checked := node.language != .js && call_arg.expr is ast.CallExpr
 			typ := c.check_expr_option_or_result_call(call_arg.expr, if already_checked
 				&& mut call_arg.expr is ast.CallExpr {

--- a/vlib/v/tests/generics/generics_with_empty_array_arg_test.v
+++ b/vlib/v/tests/generics/generics_with_empty_array_arg_test.v
@@ -1,0 +1,29 @@
+fn count_str(array []string) int {
+	return array.len
+}
+
+fn count_int(array []int) int {
+	return array.len
+}
+
+fn count[T](array []T) int {
+	return array.len
+}
+
+fn test_generics_with_empty_array_arg() {
+	assert count_str(['one', 'two']) == 2
+	assert count_str([]string{}) == 0
+	assert count_str([]) == 0
+
+	assert count_int([1, 2]) == 2
+	assert count_int([]int{}) == 0
+	assert count_int([]) == 0
+
+	assert count[f64]([1.0, 2.0]) == 2
+	assert count[f64]([]f64{}) == 0
+	assert count[f64]([]) == 0
+
+	assert count[int]([1, 2]) == 2
+	assert count[int]([]int{}) == 0
+	assert count[int]([]) == 0
+}


### PR DESCRIPTION
This PR fix generic fn call with empty array argument (fix #22843).

- Fix generic fn call with empty array argument.
- Add test.

```v
fn count_str(array []string) int {
	return array.len
}

fn count_int(array []int) int {
	return array.len
}

fn count[T](array []T) int {
	return array.len
}

fn main() {
	assert count_str(['one', 'two']) == 2
	assert count_str([]string{}) == 0
	assert count_str([]) == 0

	assert count_int([1, 2]) == 2
	assert count_int([]int{}) == 0
	assert count_int([]) == 0

	assert count[f64]([1.0, 2.0]) == 2
	assert count[f64]([]f64{}) == 0
	assert count[f64]([]) == 0

	assert count[int]([1, 2]) == 2
	assert count[int]([]int{}) == 0
	assert count[int]([]) == 0
}

PS D:\Test\v\tt1> v run .
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM0MjBiM2U3Y2M1YTc4NTQyYmZmYWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.pZ6c5uIfyrQO7opggHjsWBwesBDlgjh_TWyyEsGcXYY">Huly&reg;: <b>V_0.6-21291</b></a></sub>