### PR TITLE
checker: check alias of array op overloading and fix op overloading (fix #22851)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -516,8 +516,14 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		.gt, .lt, .ge, .le {
 			unwrapped_left_type := c.unwrap_generic(left_type)
 			left_sym = c.table.sym(unwrapped_left_type)
+			if left_sym.kind == .alias && !left_sym.has_method_with_generic_parent(node.op.str()) {
+				left_sym = c.table.final_sym(unwrapped_left_type)
+			}
 			unwrapped_right_type := c.unwrap_generic(right_type)
 			right_sym = c.table.sym(unwrapped_right_type)
+			if right_sym.kind == .alias && !right_sym.has_method_with_generic_parent(node.op.str()) {
+				right_sym = c.table.final_sym(unwrapped_right_type)
+			}
 			if left_sym.kind in [.array, .array_fixed] && right_sym.kind in [.array, .array_fixed] {
 				c.error('only `==` and `!=` are defined on arrays', node.pos)
 			} else if left_sym.kind == .struct

--- a/vlib/v/checker/tests/alias_array_unknown_op_overloading_err.out
+++ b/vlib/v/checker/tests/alias_array_unknown_op_overloading_err.out
@@ -4,10 +4,38 @@ vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv:18:4: error: unde
    18 |     a -= b
       |       ~~
    19 |     println(a - b)
-   20 | }
+   20 |     println(a < b)
 vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv:19:10: error: undefined operation `Tuple` - `Tuple`
    17 |     b := new_tuple(12, 4.5, 6.7, 6)
    18 |     a -= b
    19 |     println(a - b)
       |             ~~~~~
-   20 | }
+   20 |     println(a < b)
+   21 |     println(a > b)
+vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv:20:12: error: only `==` and `!=` are defined on arrays
+   18 |     a -= b
+   19 |     println(a - b)
+   20 |     println(a < b)
+      |               ^
+   21 |     println(a > b)
+   22 |     println(a <= b)
+vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv:21:12: error: only `==` and `!=` are defined on arrays
+   19 |     println(a - b)
+   20 |     println(a < b)
+   21 |     println(a > b)
+      |               ^
+   22 |     println(a <= b)
+   23 |     println(a >= b)
+vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv:22:12: error: only `==` and `!=` are defined on arrays
+   20 |     println(a < b)
+   21 |     println(a > b)
+   22 |     println(a <= b)
+      |               ~~
+   23 |     println(a >= b)
+   24 | }
+vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv:23:12: error: only `==` and `!=` are defined on arrays
+   21 |     println(a > b)
+   22 |     println(a <= b)
+   23 |     println(a >= b)
+      |               ~~
+   24 | }

--- a/vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv
+++ b/vlib/v/checker/tests/alias_array_unknown_op_overloading_err.vv
@@ -17,4 +17,8 @@ fn main() {
 	b := new_tuple(12, 4.5, 6.7, 6)
 	a -= b
 	println(a - b)
+	println(a < b)
+	println(a > b)
+	println(a <= b)
+	println(a >= b)
 }

--- a/vlib/v/tests/builtin_arrays/array_of_alias_op_overload_test.v
+++ b/vlib/v/tests/builtin_arrays/array_of_alias_op_overload_test.v
@@ -1,0 +1,31 @@
+type Array1 = []u8
+
+type Array2 = []u8
+
+fn (a Array2) == (other Array2) bool {
+	return a[0] == other[0]
+}
+
+fn (a Array2) < (other Array2) bool {
+	return a[0] < other[0]
+}
+
+fn test_array_of_alias_op_overload() {
+	a := Array1([u8(127), 0, 0, 1])
+	b := Array1([u8(127), 0, 0, 1])
+
+	c := Array2([u8(127), 0, 0, 1])
+	d := Array2([u8(127), 0, 0, 1])
+
+	ret0 := a == b
+	println(ret0)
+	assert ret0
+
+	ret1 := c == d
+	println(ret1)
+	assert ret1
+
+	ret2 := c < d
+	println(ret2)
+	assert !ret2
+}


### PR DESCRIPTION
This PR check alias of array op overloading and fix op overloading (fix #22851).

- Check alias of array op overloading and fix op overloading.
- Add tests.

```v
type Array1 = []u8
type Array2 = []u8

fn (a Array2) == (other Array2) bool {
	return a[0] == other[0]
}

fn (a Array2) < (other Array2) bool {
	return a[0] < other[0]
}

fn main() {
	a := Array1([u8(127), 0, 0, 1])
	b := Array1([u8(127), 0, 0, 1])

	c := Array2([u8(127), 0, 0, 1])
	d := Array2([u8(127), 0, 0, 1])

	println(a == b)
	println(a < b)

	println(c == d)
	println(c < d)
}

PS D:\Test\v\tt1> v run .    
tt1.v:20:12: error: only `==` and `!=` are defined on arrays
   18 |
   19 |     println(a == b)
   20 |     println(a < b)
      |               ^
   21 |
   22 |     println(c == d)
```

```v
type Array1 = []u8
type Array2 = []u8

fn (a Array2) == (other Array2) bool {
	return a[0] == other[0]
}

fn (a Array2) < (other Array2) bool {
	return a[0] < other[0]
}

fn main() {
	a := Array1([u8(127), 0, 0, 1])
	b := Array1([u8(127), 0, 0, 1])

	c := Array2([u8(127), 0, 0, 1])
	d := Array2([u8(127), 0, 0, 1])

	println(a == b)

	println(c == d)
	println(c < d)
}

PS D:\Test\v\tt1> v run .
true
true
false
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM1ODkyYWU3Y2M1YTc4NTQyYzQ4NTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Pp1k2UVJ9WQ_5qsxS9AeJ1wEnUs4kUPdrvt9sncbUok">Huly&reg;: <b>V_0.6-21299</b></a></sub>