### PR TITLE
encoding/asn1: fix time creation to also accommodate negative timezone offsets

### DIFF
--- a/vlib/x/encoding/asn1/time.v
+++ b/vlib/x/encoding/asn1/time.v
@@ -56,7 +56,7 @@ fn UtcTime.from_time(t time.Time) !UtcTime {
 	s := utime.custom_format(default_utctime_format) //  20241113060446+0
 	// Its rather a hack, not efieient as should be.
 	// TODO: make it better
-	str := s.split('+')
+	str := s.split_any('+-')
 	val := str[0] + 'Z'
 	utc := UtcTime.new(val)!
 	return utc
@@ -231,7 +231,7 @@ pub fn GeneralizedTime.from_time(t time.Time) !GeneralizedTime {
 	u := t.local_to_utc()
 	s := u.custom_format(default_genztime_format)
 	// adds support directly from time.Time
-	src := s.split('+')
+	src := s.split_any('+-')
 	val := src[0] + 'Z'
 	gt := GeneralizedTime.new(val)!
 

--- a/vlib/x/encoding/asn1/time_test.v
+++ b/vlib/x/encoding/asn1/time_test.v
@@ -47,10 +47,12 @@ fn test_create_utctime_from_std_time_with_negative_offset() ! {
 	tz := os.getenv('TZ')
 	os.setenv('TZ', 'utc 1', true)
 
+	defer {
+		os.setenv('TZ', tz, true)
+	}
+
 	now := time.new(year: 2024, month: 11, day: 13, hour: 17, minute: 45, second: 50)
 	UtcTime.from_time(now)!
-
-	os.setenv('TZ', tz, true)
 }
 
 fn test_serialize_utctime_error_without_z() ! {
@@ -131,8 +133,10 @@ fn test_create_generalizedtime_from_std_time_with_negative_offset() ! {
 	tz := os.getenv('TZ')
 	os.setenv('TZ', 'utc 1', true)
 
+	defer {
+		os.setenv('TZ', tz, true)
+	}
+
 	now := time.new(year: 2024, month: 11, day: 13, hour: 17, minute: 45, second: 50)
 	GeneralizedTime.from_time(now)!
-
-	os.setenv('TZ', tz, true)
 }

--- a/vlib/x/encoding/asn1/time_test.v
+++ b/vlib/x/encoding/asn1/time_test.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module asn1
 
+import os
 import time
 
 fn test_serialize_utctime_basic() ! {
@@ -40,6 +41,16 @@ fn test_create_utctime_from_std_time() ! {
 	// time to UtcTime back
 	tinp_back := UtcTime.from_time(t_inp_utc)!
 	assert tinp_back.value == inp
+}
+
+fn test_create_utctime_from_std_time_with_negative_offset() ! {
+	tz := os.getenv('TZ')
+	os.setenv('TZ', 'utc 1', true)
+
+	now := time.new(year: 2024, month: 11, day: 13, hour: 17, minute: 45, second: 50)
+	UtcTime.from_time(now)!
+
+	os.setenv('TZ', tz, true)
 }
 
 fn test_serialize_utctime_error_without_z() ! {
@@ -114,4 +125,14 @@ fn test_create_generalizedtime_from_std_time() ! {
 	g_utc_back := GeneralizedTime.from_time(g_utc)!
 
 	assert g_utc_back.value == s
+}
+
+fn test_create_generalizedtime_from_std_time_with_negative_offset() ! {
+	tz := os.getenv('TZ')
+	os.setenv('TZ', 'utc 1', true)
+
+	now := time.new(year: 2024, month: 11, day: 13, hour: 17, minute: 45, second: 50)
+	GeneralizedTime.from_time(now)!
+
+	os.setenv('TZ', tz, true)
 }


### PR DESCRIPTION
When splitting the string representation of the time, the code did not previously allow for negative timezone offsets.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM2MmRmMWU3Y2M1YTc4NTQyY2ViYmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.dtHSbpN4XE_CBKgTuN3iaOQsWbLx36X-6_mwGi1u7rM">Huly&reg;: <b>V_0.6-21304</b></a></sub>