### PR TITLE
checker, cgen: fix generic static method call return type resolution

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1611,7 +1611,7 @@ pub fn (t &Table) does_type_implement_interface(typ Type, inter_typ Type) bool {
 	return false
 }
 
-pub fn (mut t Table) convert_generic_static_type_name(fn_name string, generic_names []string, concrete_types []Type) string {
+pub fn (mut t Table) convert_generic_static_type_name(fn_name string, generic_names []string, concrete_types []Type) (Type, string) {
 	if index := fn_name.index('__static__') {
 		if index > 0 {
 			generic_name := fn_name[0..index]
@@ -1620,12 +1620,12 @@ pub fn (mut t Table) convert_generic_static_type_name(fn_name string, generic_na
 			if valid_generic {
 				name_type := t.find_type(generic_name).set_flag(.generic)
 				if typ := t.convert_generic_type(name_type, generic_names, concrete_types) {
-					return '${t.type_to_str(typ)}${fn_name[index..]}'
+					return name_type, '${t.type_to_str(typ)}${fn_name[index..]}'
 				}
 			}
 		}
 	}
-	return fn_name
+	return void_type, fn_name
 }
 
 // convert_generic_type convert generics to real types (T => int) or other generics type.

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -429,11 +429,12 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 											}
 										} else if right.is_static_method
 											&& right.left_type.has_flag(.generic) {
-											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = if right.or_block.kind == .absent {
+											fn_ret_type := if right.or_block.kind == .absent {
 												right.return_type
 											} else {
 												right.return_type.clear_option_and_result()
 											}
+											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = fn_ret_type
 										}
 									}
 								}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -429,12 +429,13 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 											}
 										} else if right.is_static_method
 											&& right.left_type.has_flag(.generic) {
-											fn_ret_type := if right.or_block.kind == .absent {
-												right.return_type
+											fn_ret_type := c.unwrap_generic(c.resolve_return_type(right))
+											var_type := if right.or_block.kind == .absent {
+												fn_ret_type
 											} else {
-												right.return_type.clear_option_and_result()
+												fn_ret_type.clear_option_and_result()
 											}
-											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = fn_ret_type
+											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = var_type
 										}
 									}
 								}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -413,8 +413,8 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									if left.obj.ct_type_var in [.generic_var, .no_comptime]
 										&& c.table.cur_fn != unsafe { nil }
 										&& c.table.cur_fn.generic_names.len != 0
-										&& !right.comptime_ret_val && c.is_generic_expr(right) //&& right.return_type_generic.has_flag(.generic)
-									  {
+										&& !right.comptime_ret_val
+										&& c.is_generic_expr(right) //&& right.return_type_generic.has_flag(.generic) {
 										// mark variable as generic var because its type changes according to fn return generic resolution type
 										left.obj.ct_type_var = .generic_var
 										if right.return_type_generic.has_flag(.generic) {
@@ -430,7 +430,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 											}
 										} else if right.is_static_method
 											&& right.left_type.has_flag(.generic) {
-											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = right.return_type
+											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = if right.or_block.kind == .absent {
+												right.return_type
+											} else {
+												right.return_type.clear_option_and_result()
+											}
 										}
 									}
 								}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -413,8 +413,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									if left.obj.ct_type_var in [.generic_var, .no_comptime]
 										&& c.table.cur_fn != unsafe { nil }
 										&& c.table.cur_fn.generic_names.len != 0
-										&& !right.comptime_ret_val
-										&& c.is_generic_expr(right) //&& right.return_type_generic.has_flag(.generic) {
+										&& !right.comptime_ret_val && c.is_generic_expr(right) {
 										// mark variable as generic var because its type changes according to fn return generic resolution type
 										left.obj.ct_type_var = .generic_var
 										if right.return_type_generic.has_flag(.generic) {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -413,20 +413,24 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 									if left.obj.ct_type_var in [.generic_var, .no_comptime]
 										&& c.table.cur_fn != unsafe { nil }
 										&& c.table.cur_fn.generic_names.len != 0
-										&& !right.comptime_ret_val
-										&& right.return_type_generic.has_flag(.generic)
-										&& c.is_generic_expr(right) {
+										&& !right.comptime_ret_val && c.is_generic_expr(right) //&& right.return_type_generic.has_flag(.generic)
+									  {
 										// mark variable as generic var because its type changes according to fn return generic resolution type
 										left.obj.ct_type_var = .generic_var
-										fn_ret_type := c.resolve_return_type(right)
-										if fn_ret_type != ast.void_type
-											&& c.table.final_sym(fn_ret_type).kind != .multi_return {
-											var_type := if right.or_block.kind == .absent {
-												fn_ret_type
-											} else {
-												fn_ret_type.clear_option_and_result()
+										if right.return_type_generic.has_flag(.generic) {
+											fn_ret_type := c.resolve_return_type(right)
+											if fn_ret_type != ast.void_type
+												&& c.table.final_sym(fn_ret_type).kind != .multi_return {
+												var_type := if right.or_block.kind == .absent {
+													fn_ret_type
+												} else {
+													fn_ret_type.clear_option_and_result()
+												}
+												c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = var_type
 											}
-											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = var_type
+										} else if right.is_static_method
+											&& right.left_type.has_flag(.generic) {
+											c.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = right.return_type
 										}
 									}
 								}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3849,12 +3849,6 @@ fn (mut c Checker) resolve_fn_return_type(func &ast.Fn, node ast.CallExpr) ast.T
 					concrete_types)
 			}
 		}
-	} else if node.is_static_method {
-		if node.return_type_generic.has_flag(.generic) {
-			return c.unwrap_generic(node.return_type_generic)
-		} else {
-			return func.return_type
-		}
 	} else {
 		concrete_types := node.concrete_types.map(c.unwrap_generic(it))
 		// generic func called from non-generic func

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3850,7 +3850,11 @@ fn (mut c Checker) resolve_fn_return_type(func &ast.Fn, node ast.CallExpr) ast.T
 			}
 		}
 	} else if node.is_static_method {
-		return func.return_type
+		if node.return_type_generic.has_flag(.generic) {
+			return c.unwrap_generic(node.return_type_generic)
+		} else {
+			return func.return_type
+		}
 	} else {
 		concrete_types := node.concrete_types.map(c.unwrap_generic(it))
 		// generic func called from non-generic func

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -107,6 +107,9 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 					if expr.obj.smartcasts.len > 0 {
 						typ = c.unwrap_generic(expr.obj.smartcasts.last())
 					}
+					if expr.obj.ct_type_var != .no_comptime {
+						typ = c.comptime.get_type_or_default(expr, typ)
+					}
 				}
 			}
 			got_types << typ

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -322,6 +322,17 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							g.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = var_type
 							// eprintln('>> ${func.name} > resolve ${left.name}.${left.obj.pos.pos}.generic to ${g.table.type_to_str(var_type)}')
 						}
+					} else if val.is_static_method && val.left_type.has_flag(.generic) {
+						fn_ret_type := g.resolve_return_type(val)
+						var_type = if val.or_block.kind == .absent {
+							fn_ret_type
+						} else {
+							fn_ret_type.clear_option_and_result()
+						}
+						val_type = var_type
+						left.obj.typ = var_type
+						g.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = var_type
+						g.assign_ct_type = var_type
 					}
 				}
 				is_auto_heap = left.obj.is_auto_heap

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -324,11 +324,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						}
 					} else if val.is_static_method && val.left_type.has_flag(.generic) {
 						fn_ret_type := g.resolve_return_type(val)
-						var_type = if val.or_block.kind == .absent {
-							fn_ret_type
-						} else {
-							fn_ret_type.clear_option_and_result()
-						}
+						var_type = fn_ret_type
 						val_type = var_type
 						left.obj.typ = var_type
 						g.comptime.type_map['g.${left.name}.${left.obj.pos.pos}'] = var_type

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1391,10 +1391,18 @@ fn (mut g Gen) resolve_return_type(node ast.CallExpr) ast.Type {
 			_, name := g.table.convert_generic_static_type_name(node.name, g.cur_fn.generic_names,
 				g.cur_concrete_types)
 			if func := g.table.find_fn(name) {
-				return func.return_type
+				return if node.or_block.kind == .absent {
+					func.return_type
+				} else {
+					func.return_type.clear_option_and_result()
+				}
 			}
 		}
-		return node.return_type
+		return if node.or_block.kind == .absent {
+			node.return_type
+		} else {
+			node.return_type.clear_option_and_result()
+		}
 	} else {
 		if func := g.table.find_fn(node.name) {
 			if func.generic_names.len > 0 {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1386,6 +1386,16 @@ fn (mut g Gen) resolve_return_type(node ast.CallExpr) ast.Type {
 				}
 			}
 		}
+	} else if node.is_static_method {
+		if g.cur_fn != unsafe { nil } {
+			_, name := g.table.convert_generic_static_type_name(node.name, g.cur_fn.generic_names,
+				g.cur_concrete_types)
+			if func := g.table.find_fn(name) {
+				println('>>>> ${node.fkey()} rets ${g.table.type_to_str(func.return_type)}')
+				return func.return_type
+			}
+		}
+		return node.return_type
 	} else {
 		if func := g.table.find_fn(node.name) {
 			if func.generic_names.len > 0 {
@@ -2014,7 +2024,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	// will be `0` for `foo()`
 	mut is_interface_call := false
 	mut is_selector_call := false
-	if node.left_type != 0 {
+	if node.is_method && node.left_type != 0 {
 		mut fn_typ := ast.no_type
 		left_sym := g.table.sym(node.left_type)
 		if node.is_field {
@@ -2048,7 +2058,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 	if node.is_static_method {
 		// resolve static call T.name()
 		if g.cur_fn != unsafe { nil } {
-			name = g.table.convert_generic_static_type_name(node.name, g.cur_fn.generic_names,
+			_, name = g.table.convert_generic_static_type_name(node.name, g.cur_fn.generic_names,
 				g.cur_concrete_types)
 		}
 	}
@@ -2276,7 +2286,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				// Temp fix generate call fn error when the struct type of sumtype
 				// has the fn field and is same to the struct name.
 				mut is_cast_needed := true
-				if node.left_type != 0 {
+				if node.is_method && node.left_type != 0 {
 					left_sym := g.table.sym(node.left_type)
 					if left_sym.kind == .struct && node.name == obj.name {
 						is_cast_needed = false

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1391,7 +1391,6 @@ fn (mut g Gen) resolve_return_type(node ast.CallExpr) ast.Type {
 			_, name := g.table.convert_generic_static_type_name(node.name, g.cur_fn.generic_names,
 				g.cur_concrete_types)
 			if func := g.table.find_fn(name) {
-				println('>>>> ${node.fkey()} rets ${g.table.type_to_str(func.return_type)}')
 				return func.return_type
 			}
 		}

--- a/vlib/v/tests/fns/generic_static_method_call_test.v
+++ b/vlib/v/tests/fns/generic_static_method_call_test.v
@@ -1,0 +1,48 @@
+struct Parser {
+mut:
+	data []u8
+}
+
+fn (mut p Parser) read_element[T]() !T {
+	t := T.parse(mut p)!
+	return t
+}
+
+struct TestA {
+	data []u8
+}
+
+fn TestA.parse(mut p Parser) !TestA {
+	return TestA{
+		data: p.data
+	}
+}
+
+struct TestB {
+	st string
+}
+
+fn TestB.parse(mut p Parser) !TestB {
+	return TestB{
+		st: p.data.hex()
+	}
+}
+
+fn test_main() {
+	data := []u8{len: 5, init: u8(5)}
+	mut p := Parser{
+		data: data
+	}
+
+	ta := p.read_element[TestA]()!
+	dump(ta)
+	assert ta == TestA{
+		data: [u8(5), 5, 5, 5, 5]
+	}
+
+	tb := p.read_element[TestB]()!
+	dump(tb)
+	assert tb == TestB{
+		st: '0505050505'
+	}
+}


### PR DESCRIPTION
Fix #22855

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM3MjBkNmU3Y2M1YTc4NTQyZDBiMmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.kI9zQMCN8HVa6tNeeTjhPmlMPm72A6rLWZvj7ieNZAY">Huly&reg;: <b>V_0.6-21308</b></a></sub>