### PR TITLE
vlib: fix wildcard matching of `match_glob`

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -2659,6 +2659,9 @@ pub fn (name string) match_glob(pattern string) bool {
 	nlen := name.len
 	for px < plen || nx < nlen {
 		if px < plen {
+			if nx == nlen {
+				break
+			}
 			c := pattern[px]
 			match c {
 				`?` {
@@ -2674,8 +2677,8 @@ pub fn (name string) match_glob(pattern string) bool {
 					// Try to match at nx.
 					// If that doesn't work out, restart at nx+1 next.
 					next_px = px
-					next_nx = nx + 1
-					px++
+					next_nx = nx
+					nx++
 					continue
 				}
 				`[` {
@@ -2731,7 +2734,7 @@ pub fn (name string) match_glob(pattern string) bool {
 		if 0 < next_nx && next_nx <= nlen {
 			// A mismatch, try restarting:
 			px = next_px
-			nx = next_nx
+			nx = next_nx + 1
 			continue
 		}
 		return false

--- a/vlib/strings/match_glob_test.v
+++ b/vlib/strings/match_glob_test.v
@@ -1,0 +1,20 @@
+fn test_main() {
+	assert '1*b'.match_glob('*[*]b') == true
+	assert '1*b'.match_glob('1[*]b') == true
+
+	assert '1****b'.match_glob('1*b') == true
+	assert '1****b'.match_glob('1[*]b') == false
+	assert '1****b'.match_glob('*[*]b') == true
+	assert '*b'.match_glob('*[*]b') == true
+
+	assert '**'.match_glob('*[*]') == true
+	assert '**'.match_glob('[*]*') == true
+
+	assert '**'.match_glob('*?') == true
+	assert '**'.match_glob('?*') == true
+
+	assert '**'.match_glob('[*]?') == true
+	assert '**'.match_glob('?[*]') == true
+
+	assert '**'.match_glob('??') == true
+}


### PR DESCRIPTION
Fix #22867

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4MDY0M2U3Y2M1YTc4NTQyZDM5MWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.59nBm2VOzBRM-tNdZek6g44WTCwqTwgm9aKSVhLUsJ0">Huly&reg;: <b>V_0.6-21312</b></a></sub>