### PR TITLE
checker: check struct aliased field unsign type assigning negative value (fix #22868)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -801,7 +801,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 					c.fail_if_stack_struct_action_outside_unsafe(mut init_field.expr,
 						'assigned')
 				}
-				if field_info.typ in ast.unsigned_integer_type_idxs
+				if c.table.unaliased_type(exp_type) in ast.unsigned_integer_type_idxs
 					&& mut init_field.expr is ast.IntegerLiteral
 					&& (init_field.expr as ast.IntegerLiteral).val[0] == `-` {
 					c.error('cannot assign negative value to unsigned integer type', init_field.expr.pos)

--- a/vlib/v/checker/tests/struct_aliased_field_unsign_type_check_err.out
+++ b/vlib/v/checker/tests/struct_aliased_field_unsign_type_check_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_aliased_field_unsign_type_check_err.vv:9:9: error: cannot assign negative value to unsigned integer type
+    7 | fn main() {
+    8 |     app := App{
+    9 |         port: -1
+      |               ~~
+   10 |     }
+   11 |     println(app)

--- a/vlib/v/checker/tests/struct_aliased_field_unsign_type_check_err.vv
+++ b/vlib/v/checker/tests/struct_aliased_field_unsign_type_check_err.vv
@@ -1,0 +1,12 @@
+type Port = u16
+
+struct App {
+	port Port
+}
+
+fn main() {
+	app := App{
+		port: -1
+	}
+	println(app)
+}


### PR DESCRIPTION
This PR check struct aliased field unsign type assigning negative value (fix #22868).

- Check struct aliased field unsign type assigning negative value.
- Add test.

```v
type Port = u16

struct App {
	port Port
}

fn main() {
	app := App{
		port: -1
	}
	println(app)
}

PS D:\Test\v\tt1> v run .
tt1.v:9:9: error: cannot assign negative value to unsigned integer type
    7 | fn main() {
    8 |     app := App{
    9 |         port: -1
      |               ~~
   10 |     }
   11 |     println(app)
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4M2FjN2U3Y2M1YTc4NTQyZDNkYjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.NHWfJRENz5yKds8xw6ydP9xwKZT9WSLxNoKlQuqQSUQ">Huly&reg;: <b>V_0.6-21314</b></a></sub>