### PR TITLE
parser, checker: notify about unused function parameters

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -288,7 +288,9 @@ pub fn (mut c Checker) check_scope_vars(sc &ast.Scope) {
 			match obj {
 				ast.Var {
 					if !obj.is_used && obj.name[0] != `_` {
-						if !c.pref.translated && !c.file.is_translated {
+						if obj.is_arg {
+							c.note('unused parameter: `${obj.name}`', obj.pos)
+						} else if !c.pref.translated && !c.file.is_translated {
 							c.warn('unused variable: `${obj.name}`', obj.pos)
 						}
 					}

--- a/vlib/v/checker/tests/alias_map_unknown_op_overloading_err.out
+++ b/vlib/v/checker/tests/alias_map_unknown_op_overloading_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/alias_map_unknown_op_overloading_err.vv:9:5: notice: unused parameter: `a`
+    7 | }
+    8 | 
+    9 | fn (a Map) + (b Map) Map {
+      |     ^
+   10 |     str := b['23']
+   11 |     return Map({
 vlib/v/checker/tests/alias_map_unknown_op_overloading_err.vv:19:10: error: undefined operation `Map` - `Map`
    17 |     mut a := new_map()
    18 |     b := new_map()

--- a/vlib/v/checker/tests/any_return_type_err.out
+++ b/vlib/v/checker/tests/any_return_type_err.out
@@ -1,3 +1,24 @@
+vlib/v/checker/tests/any_return_type_err.vv:4:5: notice: unused parameter: `f`
+    2 | }
+    3 | 
+    4 | fn (f Test) abc() any {
+      |     ^
+    5 |     return 0
+    6 | }
+vlib/v/checker/tests/any_return_type_err.vv:8:5: notice: unused parameter: `f`
+    6 | }
+    7 | 
+    8 | fn (f Test) abc2() ?any {
+      |     ^
+    9 |     return 0
+   10 | }
+vlib/v/checker/tests/any_return_type_err.vv:12:5: notice: unused parameter: `f`
+   10 | }
+   11 | 
+   12 | fn (f Test) abc3() !any {
+      |     ^
+   13 |     return 0
+   14 | }
 vlib/v/checker/tests/any_return_type_err.vv:4:19: error: cannot use type `any` here
     2 | }
     3 | 

--- a/vlib/v/checker/tests/array_builtin_redefinition.out
+++ b/vlib/v/checker/tests/array_builtin_redefinition.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/array_builtin_redefinition.vv:7:5: notice: unused parameter: `a`
+    5 | // fn (a []Abc) repeat() int { return 0 }
+    6 | // fn (a []Abc) reverse() int { return 0 }
+    7 | fn (a []Abc) map() int {
+      |     ^
+    8 |     return 0
+    9 | }
 vlib/v/checker/tests/array_builtin_redefinition.vv:7:1: error: method overrides built-in array method
     5 | // fn (a []Abc) repeat() int { return 0 }
     6 | // fn (a []Abc) reverse() int { return 0 }

--- a/vlib/v/checker/tests/array_filter_fn_err.out
+++ b/vlib/v/checker/tests/array_filter_fn_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/array_filter_fn_err.vv:19:16: notice: unused parameter: `b`
+   17 | }
+   18 | 
+   19 | fn fil1(a int, b int) bool {
+      |                ^
+   20 |     return a > 0
+   21 | }
 vlib/v/checker/tests/array_filter_fn_err.vv:2:28: error: function needs exactly 1 argument
     1 | fn main() {
     2 |     a1 := [1, 2, 3, 4].filter(fn (a int, b int) bool {

--- a/vlib/v/checker/tests/array_init_without_init_value_err.out
+++ b/vlib/v/checker/tests/array_init_without_init_value_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/array_init_without_init_value_err.vv:35:5: notice: unused parameter: `a`
+   33 | }
+   34 | 
+   35 | fn (a LeStruct) give_string() string {
+      |     ^
+   36 |     return 'V'
+   37 | }
 vlib/v/checker/tests/array_init_without_init_value_err.vv:5:7: warning: arrays of sumtypes need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`, or if you also use `init:`)
     3 | 
     4 | fn main_sum_type() {

--- a/vlib/v/checker/tests/array_map_fn_err.out
+++ b/vlib/v/checker/tests/array_map_fn_err.out
@@ -1,3 +1,9 @@
+vlib/v/checker/tests/array_map_fn_err.vv:33:15: notice: unused parameter: `a`
+   31 | }
+   32 | 
+   33 | fn do_nothing(a string) {
+      |               ^
+   34 | }
 vlib/v/checker/tests/array_map_fn_err.vv:2:25: error: function needs exactly 1 argument
     1 | fn main() {
     2 |     a1 := [1, 2, 3, 4].map(fn (a int, b int) int {

--- a/vlib/v/checker/tests/arraydecompose_arg_err.out
+++ b/vlib/v/checker/tests/arraydecompose_arg_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/arraydecompose_arg_err.vv:1:27: notice: unused parameter: `s`
+    1 | fn test_arr(i int, f f64, s string) string {
+      |                           ^
+    2 |     return '${i} : ${f}'
+    3 | }
 vlib/v/checker/tests/arraydecompose_arg_err.vv:7:2: error: cannot have parameter after array decompose
     5 | fn test_main() {
     6 |     var := [0.0]

--- a/vlib/v/checker/tests/assert_extra_message.out
+++ b/vlib/v/checker/tests/assert_extra_message.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/assert_extra_message.vv:1:8: notice: unused parameter: `i`
+    1 | fn abc(i int) {
+      |        ^
+    2 | }
+    3 |
 vlib/v/checker/tests/assert_extra_message.vv:12:24: error: assert allows only a single string as its second argument, but found `void` instead
    10 |     assert 2 == 6 / 3, 'math works'
    11 |     assert 10 == i - 120, 'i: ${i}'

--- a/vlib/v/checker/tests/assign_deref_fn_call_on_left_side_err.out
+++ b/vlib/v/checker/tests/assign_deref_fn_call_on_left_side_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/assign_deref_fn_call_on_left_side_err.vv:3:8: notice: unused parameter: `s`
+    1 | struct Foo {}
+    2 | 
+    3 | fn foo(s string) &Foo {
+      |        ^
+    4 |     return &Foo{}
+    5 | }
 vlib/v/checker/tests/assign_deref_fn_call_on_left_side_err.vv:8:2: error: cannot dereference a function call on the left side of an assignment, use a temporary variable
     6 | 
     7 | fn main() {

--- a/vlib/v/checker/tests/assign_fn_call_on_left_side_err.out
+++ b/vlib/v/checker/tests/assign_fn_call_on_left_side_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv:1:8: notice: unused parameter: `s`
+    1 | fn foo(s string) int {
+      |        ^
+    2 |     return 1
+    3 | }
 vlib/v/checker/tests/assign_fn_call_on_left_side_err.vv:6:2: error: cannot call function `foo()` on the left side of an assignment
     4 | 
     5 | fn main() {

--- a/vlib/v/checker/tests/assign_type_mismatch_with_generics_err.out
+++ b/vlib/v/checker/tests/assign_type_mismatch_with_generics_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/assign_type_mismatch_with_generics_err.vv:10:26: notice: unused parameter: `arg`
+    8 | struct Bar {}
+    9 | 
+   10 | fn (mut f Foo[T]) method(arg T) {
+      |                          ~~~
+   11 |     mut b := false
+   12 |     if f.f != none {
 vlib/v/checker/tests/assign_type_mismatch_with_generics_err.vv:13:9: error: cannot assign to `b`: expected `bool`, not `fn (Bar) bool`
    11 |     mut b := false
    12 |     if f.f != none {

--- a/vlib/v/checker/tests/check_fn_init_as_mutable.out
+++ b/vlib/v/checker/tests/check_fn_init_as_mutable.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/check_fn_init_as_mutable.vv:3:16: notice: unused parameter: `ms`
+    1 | struct MyStruct {}
+    2 | 
+    3 | fn process(mut ms MyStruct) {}
+      |                ~~
+    4 | 
+    5 | fn main() {
 vlib/v/checker/tests/check_fn_init_as_mutable.vv:6:14: error: cannot pass a struct initialization as `mut`, you may want to use a variable `mut var := MyStruct{....}`
     4 | 
     5 | fn main() {

--- a/vlib/v/checker/tests/comptime_call_method.out
+++ b/vlib/v/checker/tests/comptime_call_method.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/comptime_call_method.vv:3:5: notice: unused parameter: `t`
+    1 | struct S1 {}
+    2 | 
+    3 | fn (t S1) m(s string) int {
+      |     ^
+    4 |     return 7
+    5 | }
+vlib/v/checker/tests/comptime_call_method.vv:3:13: notice: unused parameter: `s`
+    1 | struct S1 {}
+    2 | 
+    3 | fn (t S1) m(s string) int {
+      |             ^
+    4 |     return 7
+    5 | }
 vlib/v/checker/tests/comptime_call_method.vv:10:14: error: undefined ident: `wrong`
     8 |     s1 := S1{}
     9 |     $for method in S1.methods {

--- a/vlib/v/checker/tests/comptime_call_method_args_err.out
+++ b/vlib/v/checker/tests/comptime_call_method_args_err.out
@@ -1,5 +1,12 @@
+vlib/v/checker/tests/comptime_call_method_args_err.vv:13:5: notice: unused parameter: `t`
+   11 | }
+   12 | 
+   13 | fn (t S1) method_hello() string {
+      |     ^
+   14 |     return 'Hello'
+   15 | }
 vlib/v/checker/tests/comptime_call_method_args_err.vv:9:14: cgen error: expected 0 arguments to method S1.method_hello, but got 1
-    7 |
+    7 | 
     8 |     $for method in S1.methods {
     9 |         println(s1.$method('yo'))
       |                    ~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/comptime_call_method_void_err.out
+++ b/vlib/v/checker/tests/comptime_call_method_void_err.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/comptime_call_method_void_err.vv:5:5: notice: unused parameter: `d`
+    3 | struct Dummy {}
+    4 | 
+    5 | fn (d Dummy) sample2(file_name string) int {
+      |     ^
+    6 |     println(file_name)
+    7 |     return 22
+vlib/v/checker/tests/comptime_call_method_void_err.vv:10:5: notice: unused parameter: `d`
+    8 | }
+    9 | 
+   10 | fn (d Dummy) sample1(file_name string) {
+      |     ^
+   11 |     println(file_name)
+   12 | }
 vlib/v/checker/tests/comptime_call_method_void_err.vv:17:4: error: `println` can not print void expressions
    15 |     $for method in Dummy.methods {
    16 |         if os.args.len >= 1 {

--- a/vlib/v/checker/tests/comptime_call_no_unused_var.out
+++ b/vlib/v/checker/tests/comptime_call_no_unused_var.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/comptime_call_no_unused_var.vv:3:5: notice: unused parameter: `test`
+    1 | struct Test {}
+    2 | 
+    3 | fn (test Test) print() {
+      |     ~~~~
+    4 |     println('test')
+    5 | }
 vlib/v/checker/tests/comptime_call_no_unused_var.vv:11:8: error: unknown identifier `w`
     9 |     abc := 'print'
    10 |     test.$abc() // OK

--- a/vlib/v/checker/tests/duplicate_field_method_err.out
+++ b/vlib/v/checker/tests/duplicate_field_method_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/duplicate_field_method_err.vv:5:5: notice: unused parameter: `s`
+    3 | }
+    4 | 
+    5 | fn (s St) attr() {}
+      |     ^
+    6 | 
+    7 | interface Foo {
 vlib/v/checker/tests/duplicate_field_method_err.vv:5:1: error: type `St` has both field and method named `attr`
     3 | }
     4 | 

--- a/vlib/v/checker/tests/filter_func_return_nonbool_err.out
+++ b/vlib/v/checker/tests/filter_func_return_nonbool_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/filter_func_return_nonbool_err.vv:5:14: notice: unused parameter: `arg`
+    3 | }
+    4 | 
+    5 | fn stringsss(arg int) string {
+      |              ~~~
+    6 |     return ''
+    7 | }
 vlib/v/checker/tests/filter_func_return_nonbool_err.vv:2:2: warning: unused variable: `list`
     1 | fn main() {
     2 |     list := [1, 2, 3].filter(stringsss(it))

--- a/vlib/v/checker/tests/fn_args.out
+++ b/vlib/v/checker/tests/fn_args.out
@@ -1,3 +1,29 @@
+vlib/v/checker/tests/fn_args.vv:1:8: notice: unused parameter: `a`
+    1 | fn uu8(a u8) {}
+      |        ^
+    2 | 
+    3 | fn arr(a []int) {}
+vlib/v/checker/tests/fn_args.vv:3:8: notice: unused parameter: `a`
+    1 | fn uu8(a u8) {}
+    2 | 
+    3 | fn arr(a []int) {}
+      |        ^
+    4 | 
+    5 | fn fun(a fn (int)) {}
+vlib/v/checker/tests/fn_args.vv:5:8: notice: unused parameter: `a`
+    3 | fn arr(a []int) {}
+    4 | 
+    5 | fn fun(a fn (int)) {}
+      |        ^
+    6 | 
+    7 | fn basic() {
+vlib/v/checker/tests/fn_args.vv:18:6: notice: unused parameter: `p`
+   16 | }
+   17 | 
+   18 | fn f(p &S1) {}
+      |      ^
+   19 | 
+   20 | fn ptr() {
 vlib/v/checker/tests/fn_args.vv:9:6: error: cannot use `&int` as `u8` in argument 1 to `uu8`
     7 | fn basic() {
     8 |     v := 4

--- a/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_array_mismatch_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv:19:12: notice: unused parameter: `arr`
+   17 | }
+   18 | 
+   19 | fn bar(mut arr [][]int) {
+      |            ~~~
+   20 | }
+   21 |
 vlib/v/checker/tests/fn_call_arg_array_mismatch_err.vv:7:36: error: cannot use `string` as `array` in argument 2 to `os.write_file_array`
     5 | 
     6 | fn main() {

--- a/vlib/v/checker/tests/fn_call_arg_mismatch_err_b.out
+++ b/vlib/v/checker/tests/fn_call_arg_mismatch_err_b.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/fn_call_arg_mismatch_err_b.vv:5:8: notice: unused parameter: `x`
+    3 | }
+    4 | 
+    5 | fn foo(x int) {}
+      |        ^
+    6 | 
+    7 | fn bar() {}
 vlib/v/checker/tests/fn_call_arg_mismatch_err_b.vv:2:6: error: `bar()` (no value) used as value in argument 1 to `foo`
     1 | fn main() {
     2 |     foo(bar())

--- a/vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv:10:51: notice: unused parameter: `s_`
+    8 | }
+    9 | 
+   10 | fn (s SomethingImplemented) get_value_implemented(s_ &ISomething) int {
+      |                                                   ~~
+   11 |     return s.value
+   12 | }
 vlib/v/checker/tests/fn_call_arg_ptr_mismatch_err.vv:31:29: error: cannot use `&&SomethingImplemented` as `&ISomething` in argument 1 to `get_value_implemented`
    29 |     }
    30 |     // fn call

--- a/vlib/v/checker/tests/fn_call_with_extra_parenthesis.out
+++ b/vlib/v/checker/tests/fn_call_with_extra_parenthesis.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv:1:9: notice: unused parameter: `i`
+    1 | fn doit(i int) {
+      |         ^
+    2 | }
+    3 |
 vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv:5:2: error: expected 1 argument, but got 0
     3 | 
     4 | fn main() {

--- a/vlib/v/checker/tests/fn_duplicate.out
+++ b/vlib/v/checker/tests/fn_duplicate.out
@@ -1,3 +1,9 @@
+vlib/v/checker/tests/fn_duplicate.vv:4:6: notice: unused parameter: `i`
+    2 | }
+    3 | 
+    4 | fn f(i int) {
+      |      ^
+    5 | }
 builder error: redefinition of function `f`
 vlib/v/checker/tests/fn_duplicate.vv:1:1: conflicting declaration: fn f()
     1 | fn f() {
@@ -6,7 +12,7 @@ vlib/v/checker/tests/fn_duplicate.vv:1:1: conflicting declaration: fn f()
     3 |
 vlib/v/checker/tests/fn_duplicate.vv:4:1: conflicting declaration: fn f(i int)
     2 | }
-    3 |
+    3 | 
     4 | fn f(i int) {
       | ~~~~~~~~~~~
     5 | }

--- a/vlib/v/checker/tests/fn_param_import_sym_conflict.out
+++ b/vlib/v/checker/tests/fn_param_import_sym_conflict.out
@@ -16,6 +16,83 @@ vlib/v/checker/tests/fn_param_import_sym_conflict.vv:3:8: warning: module 'strs 
       |        ~~~~~~~
     4 | 
     5 | // FnDecl
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:6:6: notice: unused parameter: `arrays`
+    4 | 
+    5 | // FnDecl
+    6 | fn x(arrays []int) {
+      |      ~~~~~~
+    7 | }
+    8 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:12:9: notice: unused parameter: `arrays`
+   10 | }
+   11 | 
+   12 | fn maps(arrays []int) {
+      |         ~~~~~~
+   13 | }
+   14 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:24:5: notice: unused parameter: `arrays`
+   22 | struct Foo {}
+   23 | 
+   24 | fn (arrays Foo) x() {
+      |     ~~~~~~
+   25 | }
+   26 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:27:5: notice: unused parameter: `arrays`
+   25 | }
+   26 | 
+   27 | fn (arrays Foo) y(maps []int) {
+      |     ~~~~~~
+   28 | }
+   29 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:27:19: notice: unused parameter: `maps`
+   25 | }
+   26 | 
+   27 | fn (arrays Foo) y(maps []int) {
+      |                   ~~~~
+   28 | }
+   29 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:30:5: notice: unused parameter: `foo`
+   28 | }
+   29 | 
+   30 | fn (foo Foo) z(arrays []int) {
+      |     ~~~
+   31 | }
+   32 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:30:16: notice: unused parameter: `arrays`
+   28 | }
+   29 | 
+   30 | fn (foo Foo) z(arrays []int) {
+      |                ~~~~~~
+   31 | }
+   32 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:33:5: notice: unused parameter: `arrays`
+   31 | }
+   32 | 
+   33 | fn (arrays Foo) maps() {
+      |     ~~~~~~
+   34 | }
+   35 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:36:5: notice: unused parameter: `foo`
+   34 | }
+   35 | 
+   36 | fn (foo Foo) arrays() {
+      |     ~~~
+   37 | }
+   38 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:39:5: notice: unused parameter: `foo`
+   37 | }
+   38 | 
+   39 | fn (foo Foo) strings() {
+      |     ~~~
+   40 | }
+   41 |
+vlib/v/checker/tests/fn_param_import_sym_conflict.vv:42:5: notice: unused parameter: `foo`
+   40 | }
+   41 | 
+   42 | fn (foo Foo) strs() {
+      |     ~~~
+   43 | }
+   44 |
 vlib/v/checker/tests/fn_param_import_sym_conflict.vv:6:6: error: duplicate of an import symbol `arrays`
     4 | 
     5 | // FnDecl

--- a/vlib/v/checker/tests/fn_ref_arg_mismatch_err.out
+++ b/vlib/v/checker/tests/fn_ref_arg_mismatch_err.out
@@ -1,13 +1,20 @@
+vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv:5:5: notice: unused parameter: `f`
+    3 | struct Foo[T] {}
+    4 | 
+    5 | fn (f &Foo[T]) foo(a &T) {
+      |     ^
+    6 |     println(a)
+    7 | }
 vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv:15:10: error: literal argument cannot be passed as reference parameter `&T`
    13 | fn main() {
    14 |     foo := Foo[int]{}
    15 |     foo.foo(12)
       |             ~~
-   16 |
+   16 | 
    17 |     bar[int](12)
 vlib/v/checker/tests/fn_ref_arg_mismatch_err.vv:17:11: error: literal argument cannot be passed as reference parameter `&T`
    15 |     foo.foo(12)
-   16 |
+   16 | 
    17 |     bar[int](12)
       |              ~~
    18 | }

--- a/vlib/v/checker/tests/fn_return_void_fn_call_err.out
+++ b/vlib/v/checker/tests/fn_return_void_fn_call_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/fn_return_void_fn_call_err.vv:28:37: notice: unused parameter: `verbosity`
+   26 | }
+   27 | 
+   28 | fn install_from_github(unit string, verbosity int) ! {
+      |                                     ~~~~~~~~~
+   29 |     dump(unit)
+   30 | }
 vlib/v/checker/tests/fn_return_void_fn_call_err.vv:20:4: error: `install_from_github(unit, verbosity)!` used as value
    18 |     return match source {
    19 |         'github' {

--- a/vlib/v/checker/tests/for_in_iterator_returning_multiple_values_err.out
+++ b/vlib/v/checker/tests/for_in_iterator_returning_multiple_values_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/for_in_iterator_returning_multiple_values_err.vv:3:5: notice: unused parameter: `t`
+    1 | struct TestStruct {}
+    2 | 
+    3 | fn (t TestStruct) next() ?(string, string) {
+      |     ^
+    4 |     return 'foo', 'bar'
+    5 | }
 vlib/v/checker/tests/for_in_iterator_returning_multiple_values_err.vv:8:10: error: iterator method `next()` must not return multiple values
     6 | 
     7 | t := TestStruct{}

--- a/vlib/v/checker/tests/free_method_errors.out
+++ b/vlib/v/checker/tests/free_method_errors.out
@@ -1,3 +1,38 @@
+vlib/v/checker/tests/free_method_errors.vv:3:5: notice: unused parameter: `a`
+    1 | struct Error1 {}
+    2 | 
+    3 | fn (a Error1) free() {}
+      |     ^
+    4 | 
+    5 | struct Error2 {}
+vlib/v/checker/tests/free_method_errors.vv:7:5: notice: unused parameter: `a`
+    5 | struct Error2 {}
+    6 | 
+    7 | fn (a &Error2) free() f64 {}
+      |     ^
+    8 | 
+    9 | struct Error3 {}
+vlib/v/checker/tests/free_method_errors.vv:11:5: notice: unused parameter: `a`
+    9 | struct Error3 {}
+   10 | 
+   11 | fn (a &Error3) free(x int) {}
+      |     ^
+   12 | 
+   13 | struct Ok {}
+vlib/v/checker/tests/free_method_errors.vv:11:21: notice: unused parameter: `x`
+    9 | struct Error3 {}
+   10 | 
+   11 | fn (a &Error3) free(x int) {}
+      |                     ^
+   12 | 
+   13 | struct Ok {}
+vlib/v/checker/tests/free_method_errors.vv:15:5: notice: unused parameter: `a`
+   13 | struct Ok {}
+   14 | 
+   15 | fn (a &Ok) free() {}
+      |     ^
+   16 | 
+   17 | fn main() {
 vlib/v/checker/tests/free_method_errors.vv:3:5: error: `.free()` methods should be defined on either a `(mut x &Error1)`, or a `(x &Error1)` receiver
     1 | struct Error1 {}
     2 | 

--- a/vlib/v/checker/tests/from_string_on_non_enum_err.out
+++ b/vlib/v/checker/tests/from_string_on_non_enum_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/from_string_on_non_enum_err.vv:9:20: notice: unused parameter: `a`
+    7 | }
+    8 | 
+    9 | fn Bar.from_string(a string) {}
+      |                    ^
+   10 | 
+   11 | fn main() {
 vlib/v/checker/tests/from_string_on_non_enum_err.vv:12:2: error: expected enum, but `Foo` is struct
    10 | 
    11 | fn main() {

--- a/vlib/v/checker/tests/function_count_of_args_mismatch_err.out
+++ b/vlib/v/checker/tests/function_count_of_args_mismatch_err.out
@@ -1,3 +1,22 @@
+vlib/v/checker/tests/function_count_of_args_mismatch_err.vv:1:9: notice: unused parameter: `b`
+    1 | fn test(b bool) {
+      |         ^
+    2 | }
+    3 |
+vlib/v/checker/tests/function_count_of_args_mismatch_err.vv:4:13: notice: unused parameter: `b`
+    2 | }
+    3 | 
+    4 | fn test2[T](b bool, v T) {
+      |             ^
+    5 | }
+    6 |
+vlib/v/checker/tests/function_count_of_args_mismatch_err.vv:4:21: notice: unused parameter: `v`
+    2 | }
+    3 | 
+    4 | fn test2[T](b bool, v T) {
+      |                     ^
+    5 | }
+    6 |
 vlib/v/checker/tests/function_count_of_args_mismatch_err.vv:8:13: error: expected 1 argument, but got 3
     6 | 
     7 | fn main() {

--- a/vlib/v/checker/tests/function_missing_return_type.out
+++ b/vlib/v/checker/tests/function_missing_return_type.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/function_missing_return_type.vv:8:5: notice: unused parameter: `s`
+    6 | }
+    7 | 
+    8 | fn (s Abc) panic(message string) {
+      |     ^
+    9 |     println('called ${@METHOD} with message: ${message}')
+   10 | }
 vlib/v/checker/tests/function_missing_return_type.vv:1:1: error: missing return at end of function `h`
     1 | fn h() int {
       | ~~~~~~~~~~

--- a/vlib/v/checker/tests/generic_closure_fn_decl_err_b.out
+++ b/vlib/v/checker/tests/generic_closure_fn_decl_err_b.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/generic_closure_fn_decl_err_b.vv:4:5: notice: unused parameter: `p`
+    2 | }
+    3 | 
+    4 | fn (p MyPlugin) on_update() {
+      |     ^
+    5 |     println('[MyPlugin.on_update]')
+    6 | }
 vlib/v/checker/tests/generic_closure_fn_decl_err_b.vv:13:2: error: generic closure fn must specify type parameter, e.g. fn [foo] [T]()
    11 |     println(typeof(my_plugin).name) // MyPlugin
    12 | 

--- a/vlib/v/checker/tests/generic_fn_decl_err.out
+++ b/vlib/v/checker/tests/generic_fn_decl_err.out
@@ -1,3 +1,94 @@
+vlib/v/checker/tests/generic_fn_decl_err.vv:21:5: notice: unused parameter: `r`
+   19 | }
+   20 | 
+   21 | fn (r Db) create1[U](u U, p P) {
+      |     ^
+   22 |     println('Yo')
+   23 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:21:22: notice: unused parameter: `u`
+   19 | }
+   20 | 
+   21 | fn (r Db) create1[U](u U, p P) {
+      |                      ^
+   22 |     println('Yo')
+   23 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:21:27: notice: unused parameter: `p`
+   19 | }
+   20 | 
+   21 | fn (r Db) create1[U](u U, p P) {
+      |                           ^
+   22 |     println('Yo')
+   23 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:25:5: notice: unused parameter: `r`
+   23 | }
+   24 | 
+   25 | fn (r Db) create2[U](u U, p &P) {
+      |     ^
+   26 |     println('Yo')
+   27 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:25:22: notice: unused parameter: `u`
+   23 | }
+   24 | 
+   25 | fn (r Db) create2[U](u U, p &P) {
+      |                      ^
+   26 |     println('Yo')
+   27 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:25:27: notice: unused parameter: `p`
+   23 | }
+   24 | 
+   25 | fn (r Db) create2[U](u U, p &P) {
+      |                           ^
+   26 |     println('Yo')
+   27 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:29:5: notice: unused parameter: `r`
+   27 | }
+   28 | 
+   29 | fn (r Db) create3[U](u U, p []P) {
+      |     ^
+   30 |     println('Yo')
+   31 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:29:22: notice: unused parameter: `u`
+   27 | }
+   28 | 
+   29 | fn (r Db) create3[U](u U, p []P) {
+      |                      ^
+   30 |     println('Yo')
+   31 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:29:27: notice: unused parameter: `p`
+   27 | }
+   28 | 
+   29 | fn (r Db) create3[U](u U, p []P) {
+      |                           ^
+   30 |     println('Yo')
+   31 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:33:5: notice: unused parameter: `r`
+   31 | }
+   32 | 
+   33 | fn (r Db) create4[U](u U) P {
+      |     ^
+   34 |     return P{}
+   35 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:33:22: notice: unused parameter: `u`
+   31 | }
+   32 | 
+   33 | fn (r Db) create4[U](u U) P {
+      |                      ^
+   34 |     return P{}
+   35 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:37:5: notice: unused parameter: `r`
+   35 | }
+   36 | 
+   37 | fn (r Db) create5[U](u U) []P {
+      |     ^
+   38 |     return [P{}]
+   39 | }
+vlib/v/checker/tests/generic_fn_decl_err.vv:37:22: notice: unused parameter: `u`
+   35 | }
+   36 | 
+   37 | fn (r Db) create5[U](u U) []P {
+      |                      ^
+   38 |     return [P{}]
+   39 | }
 vlib/v/checker/tests/generic_fn_decl_err.vv:21:29: error: generic type name `P` is not mentioned in fn `create1[U]`
    19 | }
    20 | 

--- a/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
+++ b/vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:32:11: notice: unused parameter: `t`
+   30 | }
+   31 | 
+   32 | fn handle(t T) {
+      |           ^
+   33 |     println('hi')
+   34 | }
 vlib/v/checker/tests/generic_fn_decl_without_generic_names_err.vv:26:1: error: generic function declaration must specify generic type names
    24 | }
    25 | 

--- a/vlib/v/checker/tests/generic_fn_generic_name_unresolved_err.out
+++ b/vlib/v/checker/tests/generic_fn_generic_name_unresolved_err.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/generic_fn_generic_name_unresolved_err.vv:3:12: notice: unused parameter: `arg`
+    1 | module main
+    2 | 
+    3 | fn func[T](arg string, val T) int {
+      |            ~~~
+    4 |     return 2
+    5 | }
+vlib/v/checker/tests/generic_fn_generic_name_unresolved_err.vv:3:24: notice: unused parameter: `val`
+    1 | module main
+    2 | 
+    3 | fn func[T](arg string, val T) int {
+      |                        ~~~
+    4 |     return 2
+    5 | }
 vlib/v/checker/tests/generic_fn_generic_name_unresolved_err.vv:8:7: error: a generic fn with generic types, cannot be used outside of another generic fn
     6 | 
     7 | fn main() {

--- a/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
+++ b/vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:1:15: notice: unused parameter: `i`
+    1 | fn f1[T](x T, i int) T {
+      |               ^
+    2 |     return x
+    3 | }
 vlib/v/checker/tests/generic_fn_infinite_loop_limit_err.vv:6:2: warning: unused variable: `ff1`
     4 | 
     5 | fn main() {

--- a/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
+++ b/vlib/v/checker/tests/generic_fn_var_unresolved_err.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:3:12: notice: unused parameter: `arg`
+    1 | module main
+    2 | 
+    3 | fn func[T](arg string, mut val T) int {
+      |            ~~~
+    4 |     return 2
+    5 | }
+vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:3:28: notice: unused parameter: `val`
+    1 | module main
+    2 | 
+    3 | fn func[T](arg string, mut val T) int {
+      |                            ~~~
+    4 |     return 2
+    5 | }
 vlib/v/checker/tests/generic_fn_var_unresolved_err.vv:8:7: error: `func` is a generic fn, you should pass its concrete types, e.g. func[int]
     6 | 
     7 | fn main() {

--- a/vlib/v/checker/tests/generics_fn_arg_type_err.out
+++ b/vlib/v/checker/tests/generics_fn_arg_type_err.out
@@ -1,6 +1,27 @@
+vlib/v/checker/tests/generics_fn_arg_type_err.vv:10:9: notice: unused parameter: `list`
+    8 | }
+    9 | 
+   10 | fn (mut list LinkedList[T]) add(e T) {
+      |         ~~~~
+   11 |     // ...
+   12 | }
+vlib/v/checker/tests/generics_fn_arg_type_err.vv:10:33: notice: unused parameter: `e`
+    8 | }
+    9 | 
+   10 | fn (mut list LinkedList[T]) add(e T) {
+      |                                 ^
+   11 |     // ...
+   12 | }
+vlib/v/checker/tests/generics_fn_arg_type_err.vv:14:18: notice: unused parameter: `list`
+   12 | }
+   13 | 
+   14 | fn do_list_thing(list List) { // <--- Error here
+      |                  ~~~~
+   15 |     // ...
+   16 | }
 vlib/v/checker/tests/generics_fn_arg_type_err.vv:14:23: error: generic interface `List` in fn declaration must specify the generic type names, e.g. List[T]
    12 | }
-   13 |
+   13 | 
    14 | fn do_list_thing(list List) { // <--- Error here
       |                       ~~~~
    15 |     // ...

--- a/vlib/v/checker/tests/generics_fn_arguments_count_err.out
+++ b/vlib/v/checker/tests/generics_fn_arguments_count_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/generics_fn_arguments_count_err.vv:7:5: notice: unused parameter: `f`
+    5 | struct Foo {}
+    6 | 
+    7 | fn (f Foo) get_name[A, B](a A, b B) string {
+      |     ^
+    8 |     return '${a}, ${b}'
+    9 | }
 vlib/v/checker/tests/generics_fn_arguments_count_err.vv:12:18: error: expected 2 generic parameters, got 1
    10 | 
    11 | fn main() {

--- a/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.out
+++ b/vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.out
@@ -1,12 +1,38 @@
+vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:9:15: notice: unused parameter: `b`
+    7 | }
+    8 | 
+    9 | fn foo_str[T](b T, a string) {
+      |               ^
+   10 | }
+   11 |
+vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:9:20: notice: unused parameter: `a`
+    7 | }
+    8 | 
+    9 | fn foo_str[T](b T, a string) {
+      |                    ^
+   10 | }
+   11 |
+vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:16:5: notice: unused parameter: `f`
+   14 | }
+   15 | 
+   16 | fn (f Foo[T]) info(a string) {
+      |     ^
+   17 | }
+vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:16:20: notice: unused parameter: `a`
+   14 | }
+   15 | 
+   16 | fn (f Foo[T]) info(a string) {
+      |                    ^
+   17 | }
 vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:3:13: error: cannot use `[]rune` as `string` in argument 2 to `foo_str`
     1 | fn main() {
     2 |     x := 'ab'.runes()[..1]
     3 |     foo_str(1, x)
       |                ^
-    4 |
+    4 | 
     5 |     foo := Foo[int]{}
 vlib/v/checker/tests/generics_fn_called_multi_args_mismatch.vv:6:11: error: cannot use `[]rune` as `string` in argument 1 to `Foo[int].info`
-    4 |
+    4 | 
     5 |     foo := Foo[int]{}
     6 |     foo.info(x)
       |              ^

--- a/vlib/v/checker/tests/generics_method_called_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_method_called_arg_mismatch.out
@@ -1,3 +1,13 @@
+vlib/v/checker/tests/generics_method_called_arg_mismatch.vv:14:9: notice: unused parameter: `o`
+   12 | struct Obj {}
+   13 | 
+   14 | fn (mut o Obj) set[T](val T) {}
+      |         ^
+vlib/v/checker/tests/generics_method_called_arg_mismatch.vv:14:23: notice: unused parameter: `val`
+   12 | struct Obj {}
+   13 | 
+   14 | fn (mut o Obj) set[T](val T) {}
+      |                       ~~~
 vlib/v/checker/tests/generics_method_called_arg_mismatch.vv:3:15: error: cannot use `Foo` as `Bar` in argument 1 to `Obj.set`
     1 | fn main() {
     2 |     mut obj := Obj{}

--- a/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.out
+++ b/vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.out
@@ -1,5 +1,19 @@
+vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv:3:5: notice: unused parameter: `cl`
+    1 | struct Client {}
+    2 | 
+    3 | fn (cl Client) req[T](data ...string) {}
+      |     ~~
+    4 | 
+    5 | struct Product {}
+vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv:3:23: notice: unused parameter: `data`
+    1 | struct Client {}
+    2 | 
+    3 | fn (cl Client) req[T](data ...string) {}
+      |                       ~~~~
+    4 | 
+    5 | struct Product {}
 vlib/v/checker/tests/generics_method_called_variadic_arg_mismatch.vv:8:4: error: to pass `options` (string) to `req` (which accepts type `...string`), use `...options`
-    6 |
+    6 | 
     7 | fn (c Client) products_list(options ...string) {
     8 |     c.req[Product](options) // (...options) works
       |       ~~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/go_wait_or.out
+++ b/vlib/v/checker/tests/go_wait_or.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/go_wait_or.vv:5:6: notice: unused parameter: `n`
+    3 | }
+    4 | 
+    5 | fn e(n int) {}
+      |      ^
+    6 | 
+    7 | fn f(n int) ?f64 {
+vlib/v/checker/tests/go_wait_or.vv:11:6: notice: unused parameter: `n`
+    9 | }
+   10 | 
+   11 | fn g(n int) ? {}
+      |      ^
+   12 | 
+   13 | fn main() {
 vlib/v/checker/tests/go_wait_or.vv:18:16: error: unexpected `?`, the function `wait` does not return an Option
    16 |         spawn d(1),
    17 |     ]

--- a/vlib/v/checker/tests/implements_keyword.out
+++ b/vlib/v/checker/tests/implements_keyword.out
@@ -1,20 +1,33 @@
+vlib/v/checker/tests/implements_keyword.vv:8:5: notice: unused parameter: `e`
+    6 | }
+    7 | 
+    8 | fn (e CustomError) print_error2() {
+      |     ^
+    9 | }
+   10 |
+vlib/v/checker/tests/implements_keyword.vv:18:5: notice: unused parameter: `e`
+   16 | }
+   17 | 
+   18 | fn (e CustomError2) print_error3() {
+      |     ^
+   19 | }
 vlib/v/checker/tests/implements_keyword.vv:5:1: error: `CustomError` doesn't implement method `print_error` of interface `MyError`
     3 | }
-    4 |
+    4 | 
     5 | struct CustomError implements MyError {
       | ~~~~~~~~~~~~~~~~~~
     6 | }
     7 |
 vlib/v/checker/tests/implements_keyword.vv:15:1: error: `CustomError2` doesn't implement method `print_error` of interface `MyError`
    13 | }
-   14 |
+   14 | 
    15 | struct CustomError2 implements MyError, MyError2 {
       | ~~~~~~~~~~~~~~~~~~~
    16 | }
    17 |
 vlib/v/checker/tests/implements_keyword.vv:15:1: error: `CustomError2` doesn't implement method `print_error2` of interface `MyError2`
    13 | }
-   14 |
+   14 | 
    15 | struct CustomError2 implements MyError, MyError2 {
       | ~~~~~~~~~~~~~~~~~~~
    16 | }

--- a/vlib/v/checker/tests/incorrect_name_sum_type.out
+++ b/vlib/v/checker/tests/incorrect_name_sum_type.out
@@ -1,3 +1,16 @@
+vlib/v/checker/tests/incorrect_name_sum_type.vv:4:5: notice: unused parameter: `i`
+    2 | type Integer = i16 | i64 | i8 | int
+    3 | 
+    4 | fn (i Integer) type_idx() {
+      |     ^
+    5 | }
+    6 |
+vlib/v/checker/tests/incorrect_name_sum_type.vv:7:5: notice: unused parameter: `i`
+    5 | }
+    6 | 
+    7 | fn (i Integer) type_name() {
+      |     ^
+    8 | }
 vlib/v/checker/tests/incorrect_name_sum_type.vv:1:1: error: sum type `integer` must begin with capital letter
     1 | type integer = i16 | i64 | i8 | int
       | ~~~~~~~~~~~~

--- a/vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.out
+++ b/vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:23:5: notice: unused parameter: `s`
+   21 | struct Struct {}
+   22 | 
+   23 | fn (s Struct) some_method() {}
+      |     ^
+   24 | 
+   25 | fn type_unimplemented_interface() {
 vlib/v/checker/tests/infix_is_notis_interface_unimplemented_err.vv:8:14: error: `int` doesn't implement method `msg` of interface `IError`
     6 |     if _ := f() {
     7 |     } else {

--- a/vlib/v/checker/tests/interface_implementing_own_interface_method.out
+++ b/vlib/v/checker/tests/interface_implementing_own_interface_method.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/interface_implementing_own_interface_method.vv:5:5: notice: unused parameter: `a`
+    3 | }
+    4 | 
+    5 | fn (a Animal) speak() {
+      |     ^
+    6 |     println('speaking')
+    7 | }
 vlib/v/checker/tests/interface_implementing_own_interface_method.vv:5:1: error: interface `Animal` cannot implement its own interface method `speak`
     3 | }
     4 | 

--- a/vlib/v/checker/tests/interface_init_err.out
+++ b/vlib/v/checker/tests/interface_init_err.out
@@ -4,3 +4,10 @@ vlib/v/checker/tests/interface_init_err.vv:15:7: notice: interface field `Server
    15 |     _ := Server{}
       |          ~~~~~~~~
    16 | }
+vlib/v/checker/tests/interface_init_err.vv:10:5: notice: unused parameter: `s`
+    8 | }
+    9 | 
+   10 | fn (s Server) handle(x int) int {
+      |     ^
+   11 |     return x
+   12 | }

--- a/vlib/v/checker/tests/interface_sameness_check_for_mutable_methods.out
+++ b/vlib/v/checker/tests/interface_sameness_check_for_mutable_methods.out
@@ -1,5 +1,12 @@
+vlib/v/checker/tests/interface_sameness_check_for_mutable_methods.vv:8:5: notice: unused parameter: `st`
+    6 | struct St {}
+    7 | 
+    8 | fn (st St) method() int {
+      |     ~~
+    9 |     panic('')
+   10 | }
 vlib/v/checker/tests/interface_sameness_check_for_mutable_methods.vv:15:6: error: `St` incorrectly implements method `method` of interface `Interface`: expected return type `u32`
-   13 |
+   13 | 
    14 | fn bar() {
    15 |     foo(St{})
       |         ~~~~

--- a/vlib/v/checker/tests/interface_too_many_embedding_levels.out
+++ b/vlib/v/checker/tests/interface_too_many_embedding_levels.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/interface_too_many_embedding_levels.vv:421:5: notice: unused parameter: `s`
+  419 | }
+  420 | 
+  421 | fn (s Abc) m999() int {
+      |     ^
+  422 |     return 999
+  423 | }
 vlib/v/checker/tests/interface_too_many_embedding_levels.vv:9:1: error: too many interface embedding levels: 101, for interface `I103`
     7 | }
     8 | 

--- a/vlib/v/checker/tests/invalid_parameter_name_err.out
+++ b/vlib/v/checker/tests/invalid_parameter_name_err.out
@@ -1,6 +1,20 @@
+vlib/v/checker/tests/invalid_parameter_name_err.vv:4:9: notice: unused parameter: `b`
+    2 | }
+    3 | 
+    4 | fn (mut b Buffer) put8(char u8) ! {
+      |         ^
+    5 |     return error('-')
+    6 | }
+vlib/v/checker/tests/invalid_parameter_name_err.vv:4:24: notice: unused parameter: `char`
+    2 | }
+    3 | 
+    4 | fn (mut b Buffer) put8(char u8) ! {
+      |                        ~~~~
+    5 |     return error('-')
+    6 | }
 vlib/v/checker/tests/invalid_parameter_name_err.vv:4:24: error: invalid use of reserved type `char` as a parameter name
     2 | }
-    3 |
+    3 | 
     4 | fn (mut b Buffer) put8(char u8) ! {
       |                        ~~~~
     5 |     return error('-')

--- a/vlib/v/checker/tests/invalid_vweb_param_type.out
+++ b/vlib/v/checker/tests/invalid_vweb_param_type.out
@@ -1,5 +1,12 @@
+vlib/v/checker/tests/invalid_vweb_param_type.vv:8:24: notice: unused parameter: `list`
+    6 | 
+    7 | @['/:list'; get]
+    8 | fn (mut app App) index(list []bool) vweb.Result {
+      |                        ~~~~
+    9 |     return app.text('')
+   10 | }
 vlib/v/checker/tests/invalid_vweb_param_type.vv:8:24: error: invalid type `[]bool` for parameter `list` in vweb app method `index` (only strings, numbers, and bools are allowed)
-    6 |
+    6 | 
     7 | @['/:list'; get]
     8 | fn (mut app App) index(list []bool) vweb.Result {
       |                        ~~~~

--- a/vlib/v/checker/tests/is_type_invalid.out
+++ b/vlib/v/checker/tests/is_type_invalid.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/is_type_invalid.vv:9:5: notice: unused parameter: `d`
+    7 | struct Dog {}
+    8 | 
+    9 | fn (d Dog) speak() {}
+      |     ^
+   10 | 
+   11 | struct Cat {}
 vlib/v/checker/tests/is_type_invalid.vv:14:15: error: `IoS` has no variant `u8`
    12 | 
    13 | fn main() {

--- a/vlib/v/checker/tests/lambda_undefined_variables_err.out
+++ b/vlib/v/checker/tests/lambda_undefined_variables_err.out
@@ -1,32 +1,37 @@
+vlib/v/checker/tests/lambda_undefined_variables_err.vv:1:6: notice: unused parameter: `g`
+    1 | fn f(g fn (int) string) {
+      |      ^
+    2 | }
+    3 |
 vlib/v/checker/tests/lambda_undefined_variables_err.vv:7:2: warning: unused variable: `s2`
     5 |     f(|x| s1)
-    6 |
+    6 | 
     7 |     s2 := 'abc'
       |     ~~
     8 |     f(|x| s2)
     9 | }
 vlib/v/checker/tests/lambda_undefined_variables_err.vv:5:8: error: undefined ident: `s1`
-    3 |
+    3 | 
     4 | fn main() {
     5 |     f(|x| s1)
       |           ~~
-    6 |
+    6 | 
     7 |     s2 := 'abc'
 vlib/v/checker/tests/lambda_undefined_variables_err.vv:5:4: error: `s1` used as value
-    3 |
+    3 | 
     4 | fn main() {
     5 |     f(|x| s1)
       |       ~~~~~~
-    6 |
+    6 | 
     7 |     s2 := 'abc'
 vlib/v/checker/tests/lambda_undefined_variables_err.vv:8:8: error: undefined variable `s2`
-    6 |
+    6 | 
     7 |     s2 := 'abc'
     8 |     f(|x| s2)
       |           ~~
     9 | }
 vlib/v/checker/tests/lambda_undefined_variables_err.vv:8:4: error: `s2` used as value
-    6 |
+    6 | 
     7 |     s2 := 'abc'
     8 |     f(|x| s2)
       |       ~~~~~~

--- a/vlib/v/checker/tests/map_result_callback_fn_err.out
+++ b/vlib/v/checker/tests/map_result_callback_fn_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/map_result_callback_fn_err.vv:13:13: notice: unused parameter: `cmd`
+   11 | }
+   12 | 
+   13 | fn execsync(cmd cli.Command) ! {
+      |             ~~~
+   14 |     dens := os.read_lines('/etc/fox/dens')!.map(urllib.parse(it)!)
+   15 |     mut threads := []thread !{}
 vlib/v/checker/tests/map_result_callback_fn_err.vv:19:17: error: cannot use Result type in `map`
    17 |         threads << spawn update(den)
    18 |     }

--- a/vlib/v/checker/tests/match_alias_type_err.out
+++ b/vlib/v/checker/tests/match_alias_type_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/match_alias_type_err.vv:5:10: notice: unused parameter: `sql_`
+    3 | struct SelectStmt {}
+    4 | 
+    5 | fn parse(sql_ string) Stmt {
+      |          ~~~~
+    6 |     return SelectStmt{}
+    7 | }
 vlib/v/checker/tests/match_alias_type_err.vv:13:3: error: cannot match alias type `Stmt` with `SelectStmt`
    11 | 
    12 |     match stmt {

--- a/vlib/v/checker/tests/match_invalid_type.out
+++ b/vlib/v/checker/tests/match_invalid_type.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/match_invalid_type.vv:17:5: notice: unused parameter: `d`
+   15 | struct Dog {}
+   16 | 
+   17 | fn (d Dog) speak() {}
+      |     ^
+   18 | 
+   19 | struct Cat {}
 vlib/v/checker/tests/match_invalid_type.vv:5:3: error: `IoS` has no variant `u8`.
 2 possibilities: `int`, `string`.
     3 | fn sum() {

--- a/vlib/v/checker/tests/method_call_arg_mismatch.out
+++ b/vlib/v/checker/tests/method_call_arg_mismatch.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/method_call_arg_mismatch.vv:3:5: notice: unused parameter: `f`
+    1 | struct Foo {}
+    2 | 
+    3 | fn (f Foo) bar(baz fn ()) {}
+      |     ^
+    4 | 
+    5 | fn baz() {}
+vlib/v/checker/tests/method_call_arg_mismatch.vv:3:16: notice: unused parameter: `baz`
+    1 | struct Foo {}
+    2 | 
+    3 | fn (f Foo) bar(baz fn ()) {}
+      |                ~~~
+    4 | 
+    5 | fn baz() {}
 vlib/v/checker/tests/method_call_arg_mismatch.vv:9:10: error: `baz()` (no value) used as value in argument 1 to `Foo.bar`
     7 | fn main() {
     8 |     foo := Foo{}

--- a/vlib/v/checker/tests/method_call_with_empty_struct_init.out
+++ b/vlib/v/checker/tests/method_call_with_empty_struct_init.out
@@ -1,3 +1,24 @@
+vlib/v/checker/tests/method_call_with_empty_struct_init.vv:5:5: notice: unused parameter: `s`
+    3 | }
+    4 | 
+    5 | fn (s Abc) abc(x int, param Abc) {
+      |     ^
+    6 | }
+    7 |
+vlib/v/checker/tests/method_call_with_empty_struct_init.vv:5:16: notice: unused parameter: `x`
+    3 | }
+    4 | 
+    5 | fn (s Abc) abc(x int, param Abc) {
+      |                ^
+    6 | }
+    7 |
+vlib/v/checker/tests/method_call_with_empty_struct_init.vv:5:23: notice: unused parameter: `param`
+    3 | }
+    4 | 
+    5 | fn (s Abc) abc(x int, param Abc) {
+      |                       ~~~~~
+    6 | }
+    7 |
 vlib/v/checker/tests/method_call_with_empty_struct_init.vv:10:11: error: `{}` can not be used for initialising empty structs any more. Use `Abc{}` instead.
     8 | fn main() {
     9 |     s := Abc{}

--- a/vlib/v/checker/tests/method_op_err.out
+++ b/vlib/v/checker/tests/method_op_err.out
@@ -1,3 +1,38 @@
+vlib/v/checker/tests/method_op_err.vv:11:5: notice: unused parameter: `u`
+    9 | }
+   10 | 
+   11 | fn (u User) % () {
+      |     ^
+   12 | }
+   13 |
+vlib/v/checker/tests/method_op_err.vv:18:9: notice: unused parameter: `u`
+   16 | }
+   17 | 
+   18 | fn (mut u User) * (u1 User) User {
+      |         ^
+   19 |     return User{}
+   20 | }
+vlib/v/checker/tests/method_op_err.vv:18:20: notice: unused parameter: `u1`
+   16 | }
+   17 | 
+   18 | fn (mut u User) * (u1 User) User {
+      |                    ~~
+   19 |     return User{}
+   20 | }
+vlib/v/checker/tests/method_op_err.vv:22:5: notice: unused parameter: `u`
+   20 | }
+   21 | 
+   22 | fn (u User) / (mut u1 User) User {
+      |     ^
+   23 |     return User{}
+   24 | }
+vlib/v/checker/tests/method_op_err.vv:22:20: notice: unused parameter: `u1`
+   20 | }
+   21 | 
+   22 | fn (u User) / (mut u1 User) User {
+      |                    ~~
+   23 |     return User{}
+   24 | }
 vlib/v/checker/tests/method_op_err.vv:11:1: error: operator methods should have exactly 1 argument
     9 | }
    10 | 

--- a/vlib/v/checker/tests/method_wrong_arg_type.out
+++ b/vlib/v/checker/tests/method_wrong_arg_type.out
@@ -1,3 +1,24 @@
+vlib/v/checker/tests/method_wrong_arg_type.vv:13:5: notice: unused parameter: `s`
+   11 | struct Sss {}
+   12 | 
+   13 | fn (s Sss) info(msg string) {
+      |     ^
+   14 |     println(msg)
+   15 | }
+vlib/v/checker/tests/method_wrong_arg_type.vv:23:5: notice: unused parameter: `s`
+   21 | }
+   22 | 
+   23 | fn (s Sss) ptr(p &Sss) {}
+      |     ^
+   24 | 
+   25 | fn ptr_arg() {
+vlib/v/checker/tests/method_wrong_arg_type.vv:23:16: notice: unused parameter: `p`
+   21 | }
+   22 | 
+   23 | fn (s Sss) ptr(p &Sss) {}
+      |                ^
+   24 | 
+   25 | fn ptr_arg() {
 vlib/v/checker/tests/method_wrong_arg_type.vv:20:9: error: cannot use `MyEnum` as `string` in argument 1 to `Sss.info`
    18 |     e := MyEnum.x
    19 |     s := Sss{}

--- a/vlib/v/checker/tests/multi_return_err.out
+++ b/vlib/v/checker/tests/multi_return_err.out
@@ -1,3 +1,55 @@
+vlib/v/checker/tests/multi_return_err.vv:1:12: notice: unused parameter: `a1`
+    1 | fn my_func(a1 int, a2 int) {}
+      |            ~~
+    2 | 
+    3 | fn my_func2() (int, f64) {
+vlib/v/checker/tests/multi_return_err.vv:1:20: notice: unused parameter: `a2`
+    1 | fn my_func(a1 int, a2 int) {}
+      |                    ~~
+    2 | 
+    3 | fn my_func2() (int, f64) {
+vlib/v/checker/tests/multi_return_err.vv:7:13: notice: unused parameter: `a1`
+    5 | }
+    6 | 
+    7 | fn my_func3(a1 int, a2 int, a3 string) {}
+      |             ~~
+    8 | 
+    9 | fn my_func4(a0 string, a1 int, a2 int) {}
+vlib/v/checker/tests/multi_return_err.vv:7:21: notice: unused parameter: `a2`
+    5 | }
+    6 | 
+    7 | fn my_func3(a1 int, a2 int, a3 string) {}
+      |                     ~~
+    8 | 
+    9 | fn my_func4(a0 string, a1 int, a2 int) {}
+vlib/v/checker/tests/multi_return_err.vv:7:29: notice: unused parameter: `a3`
+    5 | }
+    6 | 
+    7 | fn my_func3(a1 int, a2 int, a3 string) {}
+      |                             ~~
+    8 | 
+    9 | fn my_func4(a0 string, a1 int, a2 int) {}
+vlib/v/checker/tests/multi_return_err.vv:9:13: notice: unused parameter: `a0`
+    7 | fn my_func3(a1 int, a2 int, a3 string) {}
+    8 | 
+    9 | fn my_func4(a0 string, a1 int, a2 int) {}
+      |             ~~
+   10 | 
+   11 | fn my_func5() {}
+vlib/v/checker/tests/multi_return_err.vv:9:24: notice: unused parameter: `a1`
+    7 | fn my_func3(a1 int, a2 int, a3 string) {}
+    8 | 
+    9 | fn my_func4(a0 string, a1 int, a2 int) {}
+      |                        ~~
+   10 | 
+   11 | fn my_func5() {}
+vlib/v/checker/tests/multi_return_err.vv:9:32: notice: unused parameter: `a2`
+    7 | fn my_func3(a1 int, a2 int, a3 string) {}
+    8 | 
+    9 | fn my_func4(a0 string, a1 int, a2 int) {}
+      |                                ~~
+   10 | 
+   11 | fn my_func5() {}
 vlib/v/checker/tests/multi_return_err.vv:18:10: error: cannot use `f64` as `int` in argument 2 to `my_func` from (int, f64)
    16 | 
    17 | fn main() {

--- a/vlib/v/checker/tests/multi_value_method_err.out
+++ b/vlib/v/checker/tests/multi_value_method_err.out
@@ -1,3 +1,6 @@
+vlib/v/checker/tests/multi_value_method_err.vv:1:5: notice: unused parameter: `v`
+    1 | fn (v (int, int)) f() {}
+      |     ^
 vlib/v/checker/tests/multi_value_method_err.vv:1:7: error: cannot define method on multi-value
     1 | fn (v (int, int)) f() {}
       |       ~~~~~~~~~~

--- a/vlib/v/checker/tests/multiple_pointer_yield_err.out
+++ b/vlib/v/checker/tests/multiple_pointer_yield_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/multiple_pointer_yield_err.vv:5:8: notice: unused parameter: `bar`
+    3 | }
+    4 | 
+    5 | fn foo(bar &&&Fail) {}
+      |        ~~~
+    6 | 
+    7 | fn main() {
 vlib/v/checker/tests/multiple_pointer_yield_err.vv:9:8: error: unexpected `&`, expecting expression
     7 | fn main() {
     8 |     f := Fail{}

--- a/vlib/v/checker/tests/mut_arg.out
+++ b/vlib/v/checker/tests/mut_arg.out
@@ -1,3 +1,15 @@
+vlib/v/checker/tests/mut_arg.vv:1:10: notice: unused parameter: `par`
+    1 | fn f(mut par []int) {
+      |          ~~~
+    2 | }
+    3 |
+vlib/v/checker/tests/mut_arg.vv:4:6: notice: unused parameter: `par`
+    2 | }
+    3 | 
+    4 | fn g(par []int) {
+      |      ~~~
+    5 | }
+    6 |
 vlib/v/checker/tests/mut_arg.vv:7:3: warning: automatic referencing/dereferencing is deprecated and will be removed soon (got: 0 references, expected: 1 references)
     5 | }
     6 | 

--- a/vlib/v/checker/tests/mut_interface_param_err.out
+++ b/vlib/v/checker/tests/mut_interface_param_err.out
@@ -1,3 +1,24 @@
+vlib/v/checker/tests/mut_interface_param_err.vv:8:9: notice: unused parameter: `b`
+    6 | struct Button {}
+    7 | 
+    8 | fn (mut b Button) init() {}
+      |         ^
+    9 | 
+   10 | struct Window {
+vlib/v/checker/tests/mut_interface_param_err.vv:15:9: notice: unused parameter: `w`
+   13 | }
+   14 | 
+   15 | fn (mut w Window) add(mut widget Widget) {}
+      |         ^
+   16 | 
+   17 | fn main() {
+vlib/v/checker/tests/mut_interface_param_err.vv:15:27: notice: unused parameter: `widget`
+   13 | }
+   14 | 
+   15 | fn (mut w Window) add(mut widget Widget) {}
+      |                           ~~~~~~
+   16 | 
+   17 | fn main() {
 vlib/v/checker/tests/mut_interface_param_err.vv:20:10: error: method `add` parameter `widget` is `mut`, so use `mut btn` instead
    18 |     mut win := Window{}
    19 |     mut btn := Button{}

--- a/vlib/v/checker/tests/no_interface_instantiation_b.out
+++ b/vlib/v/checker/tests/no_interface_instantiation_b.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/no_interface_instantiation_b.vv:3:10: notice: unused parameter: `s`
+    1 | interface Speaker {}
+    2 | 
+    3 | fn my_fn(s Speaker) {}
+      |          ^
+    4 | 
+    5 | fn main() {
 vlib/v/checker/tests/no_interface_instantiation_b.vv:6:2: error: expected 1 argument, but got 0
     4 | 
     5 | fn main() {

--- a/vlib/v/checker/tests/no_interface_instantiation_c.out
+++ b/vlib/v/checker/tests/no_interface_instantiation_c.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/no_interface_instantiation_c.vv:5:10: notice: unused parameter: `s`
+    3 | }
+    4 | 
+    5 | fn my_fn(s Speaker) {}
+      |          ^
+    6 | 
+    7 | fn main() {
 vlib/v/checker/tests/no_interface_instantiation_c.vv:9:3: error: cannot instantiate interface `Speaker`
     7 | fn main() {
     8 |     my_fn(

--- a/vlib/v/checker/tests/no_interface_str.out
+++ b/vlib/v/checker/tests/no_interface_str.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/no_interface_str.vv:8:5: notice: unused parameter: `c`
+    6 | }
+    7 | 
+    8 | fn (c Cow) speak() {
+      |     ^
+    9 |     println('moo')
+   10 | }
 vlib/v/checker/tests/no_interface_str.vv:18:12: error: interface `Animal` does not have a .str() method. Use typeof() instead
    16 | fn moin() {
    17 |     a := get_animal()

--- a/vlib/v/checker/tests/no_method_must_be_called_from_unsafe_in_translated.out
+++ b/vlib/v/checker/tests/no_method_must_be_called_from_unsafe_in_translated.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/no_method_must_be_called_from_unsafe_in_translated.vv:7:5: notice: unused parameter: `s`
+    5 | 
+    6 | @[unsafe]
+    7 | fn (s S1) f() {}
+      |     ^
+    8 | 
+    9 | fn main() {

--- a/vlib/v/checker/tests/no_method_on_interface_propagation.out
+++ b/vlib/v/checker/tests/no_method_on_interface_propagation.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/no_method_on_interface_propagation.vv:9:5: notice: unused parameter: `a`
+    7 | }
+    8 | 
+    9 | fn (a Animal) foo() {}
+      |     ^
+   10 | 
+   11 | fn new_animal(breed string) Animal {
 vlib/v/checker/tests/no_method_on_interface_propagation.vv:18:5: error: unknown method or field: `Cat.foo`
    16 |     a := new_animal('persian')
    17 |     if a is Cat {

--- a/vlib/v/checker/tests/no_operator_can_only_be_used_as_a_statement_in_translated.out
+++ b/vlib/v/checker/tests/no_operator_can_only_be_used_as_a_statement_in_translated.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/no_operator_can_only_be_used_as_a_statement_in_translated.vv:4:6: notice: unused parameter: `i`
+    2 | module main
+    3 | 
+    4 | fn f(i int) {}
+      |      ^
+    5 | 
+    6 | fn main() {

--- a/vlib/v/checker/tests/option_fn_err.out
+++ b/vlib/v/checker/tests/option_fn_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/option_fn_err.vv:7:11: notice: unused parameter: `v`
+    5 | }
+    6 | 
+    7 | fn bar[T](v T) ?T {
+      |           ^
+    8 |     return none
+    9 | }
 vlib/v/checker/tests/option_fn_err.vv:32:16: error: cannot use `?int` as `int`, it must be unwrapped first in argument 1 to `twice`
    30 |     foo()
    31 |     _ := bar(0)

--- a/vlib/v/checker/tests/option_in_receiver_err.out
+++ b/vlib/v/checker/tests/option_in_receiver_err.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/option_in_receiver_err.vv:6:9: notice: unused parameter: `f`
+    4 | }
+    5 | 
+    6 | fn (mut f Foo) t0(arr ?[]int) ?string {
+      |         ^
+    7 |     return arr?.len.str()
+    8 | }
+vlib/v/checker/tests/option_in_receiver_err.vv:10:9: notice: unused parameter: `f`
+    8 | }
+    9 | 
+   10 | fn (mut f ?Foo) t1(arr ?[]int) ?string {
+      |         ^
+   11 |     return arr?.len.str()
+   12 | }
 vlib/v/checker/tests/option_in_receiver_err.vv:10:9: error: option types cannot have methods
     8 | }
     9 | 

--- a/vlib/v/checker/tests/option_interface_mismatch.out
+++ b/vlib/v/checker/tests/option_interface_mismatch.out
@@ -1,5 +1,12 @@
+vlib/v/checker/tests/option_interface_mismatch.vv:10:16: notice: unused parameter: `line`
+    8 | }
+    9 | 
+   10 | fn give_string(line string) ?MObject {
+      |                ~~~~
+   11 |     return if true { 'string' } else { 'string' }
+   12 | }
 vlib/v/checker/tests/option_interface_mismatch.vv:11:9: error: mismatched types `?MObject` and `string`
-    9 |
+    9 | 
    10 | fn give_string(line string) ?MObject {
    11 |     return if true { 'string' } else { 'string' }
       |            ~~

--- a/vlib/v/checker/tests/option_multi_return_err.out
+++ b/vlib/v/checker/tests/option_multi_return_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/option_multi_return_err.vv:1:10: notice: unused parameter: `str`
+    1 | fn split(str string) ?(string, string) {
+      |          ~~~
+    2 |     return none
+    3 | }
 vlib/v/checker/tests/option_multi_return_err.vv:6:14: error: split() returns `?(string, string)`, so it should have either an `or {}` block, or `?` at the end
     4 | 
     5 | fn main() {

--- a/vlib/v/checker/tests/option_propagate_nested.out
+++ b/vlib/v/checker/tests/option_propagate_nested.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/option_propagate_nested.vv:19:9: notice: unused parameter: `s`
+   17 | }
+   18 | 
+   19 | fn (mut s St) raise() !f64 {
+      |         ^
+   20 |     return error('some error')
+   21 | }
 vlib/v/checker/tests/option_propagate_nested.vv:10:18: error: to propagate the Option call, `xx_prop` must return an Option
     8 | 
     9 | fn xx_prop() string {

--- a/vlib/v/checker/tests/passing_expr_to_fn_expecting_voidptr.out
+++ b/vlib/v/checker/tests/passing_expr_to_fn_expecting_voidptr.out
@@ -1,3 +1,13 @@
+vlib/v/checker/tests/passing_expr_to_fn_expecting_voidptr.vv:1:13: notice: unused parameter: `s`
+    1 | fn myprintf(s string, x voidptr) {
+      |             ^
+    2 | }
+    3 |
+vlib/v/checker/tests/passing_expr_to_fn_expecting_voidptr.vv:1:23: notice: unused parameter: `x`
+    1 | fn myprintf(s string, x voidptr) {
+      |                       ^
+    2 | }
+    3 |
 vlib/v/checker/tests/passing_expr_to_fn_expecting_voidptr.vv:4:23: error: expression cannot be passed as `voidptr`
     2 | }
     3 | 

--- a/vlib/v/checker/tests/receiver_unknown_type_single_letter.out
+++ b/vlib/v/checker/tests/receiver_unknown_type_single_letter.out
@@ -1,3 +1,6 @@
+vlib/v/checker/tests/receiver_unknown_type_single_letter.vv:1:5: notice: unused parameter: `p`
+    1 | fn (p Abc) foo() {}
+      |     ^
 vlib/v/checker/tests/receiver_unknown_type_single_letter.vv:1:7: error: unknown type `Abc`
     1 | fn (p Abc) foo() {}
       |       ~~~

--- a/vlib/v/checker/tests/result_param_type_err.out
+++ b/vlib/v/checker/tests/result_param_type_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/result_param_type_err.vv:3:9: notice: unused parameter: `arg`
+    1 | module main
+    2 | 
+    3 | fn func(arg !string, val &int) ?int {
+      |         ~~~
+    4 |     unsafe {
+    5 |         *val = 2
 vlib/v/checker/tests/result_param_type_err.vv:3:13: error: result type arguments are not supported
     1 | module main
     2 | 

--- a/vlib/v/checker/tests/result_type_call_err.out
+++ b/vlib/v/checker/tests/result_type_call_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/result_type_call_err.vv:3:5: notice: unused parameter: `f`
+    1 | struct Foo {}
+    2 | 
+    3 | fn (f Foo) foo() int {
+      |     ^
+    4 |     return 1
+    5 | }
 vlib/v/checker/tests/result_type_call_err.vv:12:2: error: new_foo() returns `!Foo`, so it should have either an `or {}` block, or `!` at the end
    10 | 
    11 | fn main() {

--- a/vlib/v/checker/tests/run/noreturn_method_can_be_used_instead_of_panic.run.out
+++ b/vlib/v/checker/tests/run/noreturn_method_can_be_used_instead_of_panic.run.out
@@ -1,1 +1,8 @@
+vlib/v/checker/tests/run/noreturn_method_can_be_used_instead_of_panic.vv:4:9: notice: unused parameter: `t`
+    2 | 
+    3 | @[noreturn]
+    4 | fn (mut t Test) zz_exit() {
+      |         ^
+    5 |     println('${@METHOD} called, as it should')
+    6 |     flush_stdout()
 Test.zz_exit called, as it should

--- a/vlib/v/checker/tests/shared_lock.out
+++ b/vlib/v/checker/tests/shared_lock.out
@@ -1,3 +1,45 @@
+vlib/v/checker/tests/shared_lock.vv:6:12: notice: unused parameter: `s`
+    4 | }
+    5 | 
+    6 | fn (shared s St) r(x St) {
+      |            ^
+    7 | }
+    8 |
+vlib/v/checker/tests/shared_lock.vv:6:20: notice: unused parameter: `x`
+    4 | }
+    5 | 
+    6 | fn (shared s St) r(x St) {
+      |                    ^
+    7 | }
+    8 |
+vlib/v/checker/tests/shared_lock.vv:9:5: notice: unused parameter: `s`
+    7 | }
+    8 | 
+    9 | fn (s St) m(shared x St) {
+      |     ^
+   10 | }
+   11 |
+vlib/v/checker/tests/shared_lock.vv:9:20: notice: unused parameter: `x`
+    7 | }
+    8 | 
+    9 | fn (s St) m(shared x St) {
+      |                    ^
+   10 | }
+   11 |
+vlib/v/checker/tests/shared_lock.vv:12:6: notice: unused parameter: `w`
+   10 | }
+   11 | 
+   12 | fn f(w int, shared x St) {
+      |      ^
+   13 | }
+   14 |
+vlib/v/checker/tests/shared_lock.vv:12:20: notice: unused parameter: `x`
+   10 | }
+   11 | 
+   12 | fn f(w int, shared x St) {
+      |                    ^
+   13 | }
+   14 |
 vlib/v/checker/tests/shared_lock.vv:20:5: error: method with `shared` receiver cannot be called inside `lock`/`rlock` block
    18 |     }
    19 |     lock x {

--- a/vlib/v/checker/tests/shared_param_err.out
+++ b/vlib/v/checker/tests/shared_param_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/shared_param_err.vv:7:27: notice: unused parameter: `c`
+    5 | }
+    6 | 
+    7 | fn (shared b St) g(shared c St) {
+      |                           ^
+    8 |     lock b {
+    9 |         b.x = 100
 vlib/v/checker/tests/shared_param_err.vv:23:12: error: method `g` parameter `c` is `shared`, so use `shared a` instead
    21 |         x: 10
    22 |     }

--- a/vlib/v/checker/tests/static_method_not_found_err.out
+++ b/vlib/v/checker/tests/static_method_not_found_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/static_method_not_found_err.vv:5:5: notice: unused parameter: `f`
+    3 | }
+    4 | 
+    5 | fn (f TestStruct) static_method() string {
+      |     ^
+    6 |     return 'hello'
+    7 | }
 vlib/v/checker/tests/static_method_not_found_err.vv:10:9: error: unknown function: TestStruct.static_method
     8 | 
     9 | fn main() {

--- a/vlib/v/checker/tests/str_method_0_arguments.out
+++ b/vlib/v/checker/tests/str_method_0_arguments.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/str_method_0_arguments.vv:5:16: notice: unused parameter: `x`
+    3 | }
+    4 | 
+    5 | fn (z Zzz) str(x int) string {
+      |                ^
+    6 |     return 'z: ${z.x}'
+    7 | }
 vlib/v/checker/tests/str_method_0_arguments.vv:5:1: error: .str() methods should have 0 arguments
     3 | }
     4 | 

--- a/vlib/v/checker/tests/str_method_return_string.out
+++ b/vlib/v/checker/tests/str_method_return_string.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/str_method_return_string.vv:5:16: notice: unused parameter: `x`
+    3 | }
+    4 | 
+    5 | fn (z Zzz) str(x int) int {
+      |                ^
+    6 |     return z.x
+    7 | }
 vlib/v/checker/tests/str_method_return_string.vv:5:1: error: .str() methods should return `string`
     3 | }
     4 | 

--- a/vlib/v/checker/tests/struct_field_init_fntype_mismatch.out
+++ b/vlib/v/checker/tests/struct_field_init_fntype_mismatch.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/struct_field_init_fntype_mismatch.vv:9:8: notice: unused parameter: `f`
+    7 | }
+    8 | 
+    9 | fn foo(f &Foo) {}
+      |        ^
+   10 | 
+   11 | fn main() {
 vlib/v/checker/tests/struct_field_init_fntype_mismatch.vv:13:3: error: cannot assign to field `foo_fn`: expected `fn (mut Foo)`, not `fn (&Foo)`
    11 | fn main() {
    12 |     srv := Server{

--- a/vlib/v/checker/tests/struct_field_init_with_void_expr_err.out
+++ b/vlib/v/checker/tests/struct_field_init_with_void_expr_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv:6:5: notice: unused parameter: `a`
+    4 | struct App {}
+    5 | 
+    6 | fn (a App) test_func() {}
+      |     ^
+    7 | 
+    8 | fn main() {
 vlib/v/checker/tests/struct_field_init_with_void_expr_err.vv:19:3: error: `app.test_func()` (no value) used as value
    17 |         name:        'add'
    18 |         description: 'Add something.'

--- a/vlib/v/checker/tests/struct_implements_interface_more_than_once_err.out
+++ b/vlib/v/checker/tests/struct_implements_interface_more_than_once_err.out
@@ -1,3 +1,31 @@
+vlib/v/checker/tests/struct_implements_interface_more_than_once_err.vv:7:5: notice: unused parameter: `a`
+    5 | }
+    6 | 
+    7 | fn (a Abc) write(buf []u8) !int {
+      |     ^
+    8 |     return 42
+    9 | }
+vlib/v/checker/tests/struct_implements_interface_more_than_once_err.vv:7:18: notice: unused parameter: `buf`
+    5 | }
+    6 | 
+    7 | fn (a Abc) write(buf []u8) !int {
+      |                  ~~~
+    8 |     return 42
+    9 | }
+vlib/v/checker/tests/struct_implements_interface_more_than_once_err.vv:17:5: notice: unused parameter: `a`
+   15 | // vfmt on
+   16 | 
+   17 | fn (a Def) write(buf []u8) !int {
+      |     ^
+   18 |     return 42
+   19 | }
+vlib/v/checker/tests/struct_implements_interface_more_than_once_err.vv:17:18: notice: unused parameter: `buf`
+   15 | // vfmt on
+   16 | 
+   17 | fn (a Def) write(buf []u8) !int {
+      |                  ~~~
+   18 |     return 42
+   19 | }
 vlib/v/checker/tests/struct_implements_interface_more_than_once_err.vv:3:31: error: struct type Abc cannot implement interface `io.Writer more than once`
     1 | import io { Writer }
     2 | 

--- a/vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.out
+++ b/vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.vv:16:5: notice: unused parameter: `a`
+   14 | 
+   15 | // Implementation is missing the return type.
+   16 | fn (a Stream) read(buf []u8) {}
+      |     ^
+   17 | 
+   18 | fn test_struct_init_with_interface_field() {
+vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.vv:16:20: notice: unused parameter: `buf`
+   14 | 
+   15 | // Implementation is missing the return type.
+   16 | fn (a Stream) read(buf []u8) {}
+      |                    ~~~
+   17 | 
+   18 | fn test_struct_init_with_interface_field() {
 vlib/v/checker/tests/struct_init_with_iface_embed_iface_with_incorrect_method_impl_ref_field_err.vv:21:3: error: `&Stream` incorrectly implements method `read` of interface `Refresher`: expected return type `!int`
    19 |     s := &Stream{}
    20 |     _ := &Server{

--- a/vlib/v/checker/tests/sumtype_define_recursively.out
+++ b/vlib/v/checker/tests/sumtype_define_recursively.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/sumtype_define_recursively.vv:3:6: notice: unused parameter: `exprs`
+    1 | type Expr = fn ([]Expr) Expr | int
+    2 | 
+    3 | fn f(exprs []Expr) Expr {
+      |      ~~~~~
+    4 |     return 0
+    5 | }
 vlib/v/checker/tests/sumtype_define_recursively.vv:1:13: error: sum type `Expr` cannot be defined recursively
     1 | type Expr = fn ([]Expr) Expr | int
       |             ~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/sync_receiver_decl.out
+++ b/vlib/v/checker/tests/sync_receiver_decl.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/sync_receiver_decl.vv:3:12: notice: unused parameter: `b`
+    1 | struct St {}
+    2 | 
+    3 | fn (shared b St) g() {}
+      |            ^
+    4 | 
+    5 | println('ok')

--- a/vlib/v/checker/tests/unimplemented_interface_a.out
+++ b/vlib/v/checker/tests/unimplemented_interface_a.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/unimplemented_interface_a.vv:7:8: notice: unused parameter: `a`
+    5 | struct Cat {}
+    6 | 
+    7 | fn foo(a Animal) {}
+      |        ^
+    8 | 
+    9 | fn main() {
 vlib/v/checker/tests/unimplemented_interface_a.vv:10:6: error: `Cat` doesn't implement method `name` of interface `Animal`
     8 | 
     9 | fn main() {

--- a/vlib/v/checker/tests/unimplemented_interface_b.out
+++ b/vlib/v/checker/tests/unimplemented_interface_b.out
@@ -1,3 +1,17 @@
+vlib/v/checker/tests/unimplemented_interface_b.vv:7:5: notice: unused parameter: `c`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) name() {}
+      |     ^
+    8 | 
+    9 | fn foo(a Animal) {}
+vlib/v/checker/tests/unimplemented_interface_b.vv:9:8: notice: unused parameter: `a`
+    7 | fn (c Cat) name() {}
+    8 | 
+    9 | fn foo(a Animal) {}
+      |        ^
+   10 | 
+   11 | fn main() {
 vlib/v/checker/tests/unimplemented_interface_b.vv:13:6: error: `Cat` incorrectly implements method `name` of interface `Animal`: expected return type `string`
    11 | fn main() {
    12 |     c := Cat{}

--- a/vlib/v/checker/tests/unimplemented_interface_c.out
+++ b/vlib/v/checker/tests/unimplemented_interface_c.out
@@ -1,5 +1,26 @@
+vlib/v/checker/tests/unimplemented_interface_c.vv:7:5: notice: unused parameter: `c`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) name(s string) {}
+      |     ^
+    8 | 
+    9 | fn foo(a Animal) {}
+vlib/v/checker/tests/unimplemented_interface_c.vv:7:17: notice: unused parameter: `s`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) name(s string) {}
+      |                 ^
+    8 | 
+    9 | fn foo(a Animal) {}
+vlib/v/checker/tests/unimplemented_interface_c.vv:9:8: notice: unused parameter: `a`
+    7 | fn (c Cat) name(s string) {}
+    8 | 
+    9 | fn foo(a Animal) {}
+      |        ^
+   10 | 
+   11 | fn main() {
 vlib/v/checker/tests/unimplemented_interface_c.vv:12:6: error: `Cat` incorrectly implements method `name` of interface `Animal`: expected 1 parameter(s), not 2
-   10 |
+   10 | 
    11 | fn main() {
    12 |     foo(Cat{})
       |         ~~~~~

--- a/vlib/v/checker/tests/unimplemented_interface_d.out
+++ b/vlib/v/checker/tests/unimplemented_interface_d.out
@@ -1,5 +1,19 @@
+vlib/v/checker/tests/unimplemented_interface_d.vv:7:5: notice: unused parameter: `c`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) speak() {}
+      |     ^
+    8 | 
+    9 | fn foo(a Animal) {}
+vlib/v/checker/tests/unimplemented_interface_d.vv:9:8: notice: unused parameter: `a`
+    7 | fn (c Cat) speak() {}
+    8 | 
+    9 | fn foo(a Animal) {}
+      |        ^
+   10 | 
+   11 | fn main() {
 vlib/v/checker/tests/unimplemented_interface_d.vv:12:6: error: `Cat` incorrectly implements method `speak` of interface `Animal`: expected 2 parameter(s), not 1
-   10 |
+   10 | 
    11 | fn main() {
    12 |     foo(Cat{})
       |         ~~~~~

--- a/vlib/v/checker/tests/unimplemented_interface_e.out
+++ b/vlib/v/checker/tests/unimplemented_interface_e.out
@@ -1,3 +1,24 @@
+vlib/v/checker/tests/unimplemented_interface_e.vv:7:5: notice: unused parameter: `c`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) speak(s &string) {}
+      |     ^
+    8 | 
+    9 | fn foo(a Animal) {}
+vlib/v/checker/tests/unimplemented_interface_e.vv:7:18: notice: unused parameter: `s`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) speak(s &string) {}
+      |                  ^
+    8 | 
+    9 | fn foo(a Animal) {}
+vlib/v/checker/tests/unimplemented_interface_e.vv:9:8: notice: unused parameter: `a`
+    7 | fn (c Cat) speak(s &string) {}
+    8 | 
+    9 | fn foo(a Animal) {}
+      |        ^
+   10 | 
+   11 | fn main() {
 vlib/v/checker/tests/unimplemented_interface_e.vv:12:6: error: `Cat` incorrectly implements method `speak` of interface `Animal`: expected `string`, not `&string` for parameter 1
    10 | 
    11 | fn main() {

--- a/vlib/v/checker/tests/unimplemented_interface_f.out
+++ b/vlib/v/checker/tests/unimplemented_interface_f.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/unimplemented_interface_f.vv:7:5: notice: unused parameter: `c`
+    5 | struct Cat {}
+    6 | 
+    7 | fn (c Cat) speak() {}
+      |     ^
+    8 | 
+    9 | fn main() {
 vlib/v/checker/tests/unimplemented_interface_f.vv:11:13: error: `Cat` incorrectly implements method `speak` of interface `Animal`: expected 2 parameter(s), not 1
     9 | fn main() {
    10 |     mut animals := []Animal{}

--- a/vlib/v/checker/tests/unknown_generic_type.out
+++ b/vlib/v/checker/tests/unknown_generic_type.out
@@ -1,5 +1,10 @@
+vlib/v/checker/tests/unknown_generic_type.vv:1:14: notice: unused parameter: `raw_data`
+    1 | fn decode[T](raw_data string) ?T {
+      |              ~~~~~~~~
+    2 |     return none
+    3 | }
 vlib/v/checker/tests/unknown_generic_type.vv:6:13: error: unknown type `Foo`
-    4 |
+    4 | 
     5 | fn main() {
     6 |     x := decode[Foo]('{"name": "test"}')?
       |                ~~~~~

--- a/vlib/v/checker/tests/unknown_method_suggest_name.out
+++ b/vlib/v/checker/tests/unknown_method_suggest_name.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/unknown_method_suggest_name.vv:20:5: notice: unused parameter: `p`
+   18 | }
+   19 | 
+   20 | fn (p Point) identity() Point {
+      |     ^
+   21 |     return Point{1, 1, 1}
+   22 | }
 vlib/v/checker/tests/unknown_method_suggest_name.vv:13:6: error: unknown type `hash.crc32.Crc33`.
 Did you mean `crc32.Crc32`?
    11 |     y   int

--- a/vlib/v/checker/tests/unsafe_method_as_field.out
+++ b/vlib/v/checker/tests/unsafe_method_as_field.out
@@ -1,3 +1,24 @@
+vlib/v/checker/tests/unsafe_method_as_field.vv:4:5: notice: unused parameter: `f`
+    2 | }
+    3 | 
+    4 | fn (f Foo) no_ref() int {
+      |     ^
+    5 |     return 1
+    6 | }
+vlib/v/checker/tests/unsafe_method_as_field.vv:8:5: notice: unused parameter: `f`
+    6 | }
+    7 | 
+    8 | fn (f &Foo) ref() int {
+      |     ^
+    9 |     return 1
+   10 | }
+vlib/v/checker/tests/unsafe_method_as_field.vv:16:5: notice: unused parameter: `f`
+   14 | }
+   15 | 
+   16 | fn (f &Bar) ref() int {
+      |     ^
+   17 |     return 1
+   18 | }
 vlib/v/checker/tests/unsafe_method_as_field.vv:23:7: error: method `Foo.ref` cannot be used as a variable outside `unsafe` blocks as its receiver might refer to an object stored on stack. Consider declaring `Foo` as `@[heap]`.
    21 |     f := Foo{}
    22 |     _ := f.no_ref // no error

--- a/vlib/v/checker/tests/unsafe_required.out
+++ b/vlib/v/checker/tests/unsafe_required.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/unsafe_required.vv:4:5: notice: unused parameter: `s`
+    2 | 
+    3 | @[unsafe]
+    4 | fn (s S1) f() {}
+      |     ^
+    5 | 
+    6 | fn test_funcs() {
 vlib/v/checker/tests/unsafe_required.vv:8:4: warning: method `S1.f` must be called from an `unsafe` block
     6 | fn test_funcs() {
     7 |     s := S1{}

--- a/vlib/v/checker/tests/unwrapped_result_infix_err.out
+++ b/vlib/v/checker/tests/unwrapped_result_infix_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/unwrapped_result_infix_err.vv:1:6: notice: unused parameter: `k`
+    1 | fn f(k string) !bool {
+      |      ^
+    2 |     return true
+    3 | }
 vlib/v/checker/tests/unwrapped_result_infix_err.vv:7:9: error: unwrapped Result cannot be used in an infix expression
     5 | fn g() ! {
     6 |     assert f('1')! == true

--- a/vlib/v/checker/tests/use_deprecated_function_warning.out
+++ b/vlib/v/checker/tests/use_deprecated_function_warning.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/use_deprecated_function_warning.vv:19:5: notice: unused parameter: `s`
+   17 | 
+   18 | @[deprecated: 'use bar instead']
+   19 | fn (s S1) m() {}
+      |     ^
+   20 | 
+   21 | fn method() {
 vlib/v/checker/tests/use_deprecated_function_warning.vv:12:2: warning: function `xyz` has been deprecated
    10 | 
    11 | fn main() {

--- a/vlib/v/checker/tests/void_function_assign_to_string.out
+++ b/vlib/v/checker/tests/void_function_assign_to_string.out
@@ -1,3 +1,13 @@
+vlib/v/checker/tests/void_function_assign_to_string.vv:1:6: notice: unused parameter: `x`
+    1 | fn x(x int, y int) {
+      |      ^
+    2 | }
+    3 |
+vlib/v/checker/tests/void_function_assign_to_string.vv:1:13: notice: unused parameter: `y`
+    1 | fn x(x int, y int) {
+      |             ^
+    2 | }
+    3 |
 vlib/v/checker/tests/void_function_assign_to_string.vv:6:4: error: assignment mismatch: 1 variable but `x()` returns 0 values
     4 | fn main() {
     5 |     mut a := ''

--- a/vlib/v/checker/tests/with_check_option/v_tictactoe.out
+++ b/vlib/v/checker/tests/with_check_option/v_tictactoe.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/with_check_option/v_tictactoe.vv:18:11: notice: unused parameter: `player`
+   16 | }
+   17 | 
+   18 | fn prompt(player string) (int, int) {
+      |           ~~~~~~
+   19 |     return 0, 0
+   20 | }
 vlib/v/checker/tests/with_check_option/v_tictactoe.vv:4:31: error: `len` and `cap` are invalid attributes for fixed array dimension
     2 | 
     3 | fn new_board() [][]string {

--- a/vlib/v/checker/tests/with_check_option/v_tictactoe_fixed_syntax_error.out
+++ b/vlib/v/checker/tests/with_check_option/v_tictactoe_fixed_syntax_error.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/with_check_option/v_tictactoe_fixed_syntax_error.vv:18:11: notice: unused parameter: `player`
+   16 | }
+   17 | 
+   18 | fn prompt(player string) (int, int) {
+      |           ~~~~~~
+   19 |     return 0, 0
+   20 | }
 vlib/v/checker/tests/with_check_option/v_tictactoe_fixed_syntax_error.vv:8:9: error: cannot use `[3][]string` as type `[][]string` in return argument
     6 |         board[i / 3][i % 3] = (i + 1).str()
     7 |     }

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -442,33 +442,6 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 		is_variadic = true
 	}
 	params << params_t
-	if !are_params_type_only {
-		for k, param in params {
-			if p.scope.known_var(param.name) {
-				p.error_with_pos('redefinition of parameter `${param.name}`', param.pos)
-				return ast.FnDecl{
-					scope: unsafe { nil }
-				}
-			}
-			is_stack_obj := !param.typ.has_flag(.shared_f) && (param.is_mut || param.typ.is_ptr())
-			p.scope.register(ast.Var{
-				name:          param.name
-				typ:           param.typ
-				is_mut:        param.is_mut
-				is_auto_deref: param.is_mut
-				is_stack_obj:  is_stack_obj
-				pos:           param.pos
-				is_used:       true
-				is_arg:        true
-				ct_type_var:   if (!is_method || k > 0) && param.typ.has_flag(.generic)
-					&& !param.typ.has_flag(.variadic) {
-					.generic_param
-				} else {
-					.no_comptime
-				}
-			})
-		}
-	}
 	// Return type
 	mut return_type_pos := p.tok.pos()
 	mut return_type := ast.void_type
@@ -515,6 +488,33 @@ run them via `v file.v` instead',
 		p.error_with_pos('cannot declare a static function as a receiver method', name_pos)
 	}
 	// Register
+	if !are_params_type_only {
+		for k, param in params {
+			if p.scope.known_var(param.name) {
+				p.error_with_pos('redefinition of parameter `${param.name}`', param.pos)
+				return ast.FnDecl{
+					scope: unsafe { nil }
+				}
+			}
+			is_stack_obj := !param.typ.has_flag(.shared_f) && (param.is_mut || param.typ.is_ptr())
+			p.scope.register(ast.Var{
+				name:          param.name
+				typ:           param.typ
+				is_mut:        param.is_mut
+				is_auto_deref: param.is_mut
+				is_stack_obj:  is_stack_obj
+				pos:           param.pos
+				is_used:       no_body || (p.inside_vlib_file && !p.file_path.ends_with('.vv'))
+				is_arg:        true
+				ct_type_var:   if (!is_method || k > 0) && param.typ.has_flag(.generic)
+					&& !param.typ.has_flag(.variadic) {
+					.generic_param
+				} else {
+					.no_comptime
+				}
+			})
+		}
+	}
 	if is_method {
 		// Do not allow to modify / add methods to types from other modules
 		// arrays/maps dont belong to a module only their element types do

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -504,7 +504,8 @@ run them via `v file.v` instead',
 				is_auto_deref: param.is_mut
 				is_stack_obj:  is_stack_obj
 				pos:           param.pos
-				is_used:       no_body || (p.inside_vlib_file && !p.file_path.ends_with('.vv'))
+				is_used:       is_pub || no_body
+					|| (p.inside_vlib_file && !p.file_path.ends_with('.vv'))
 				is_arg:        true
 				ct_type_var:   if (!is_method || k > 0) && param.typ.has_flag(.generic)
 					&& !param.typ.has_flag(.variadic) {

--- a/vlib/v/parser/tests/method_call_receiver_err.out
+++ b/vlib/v/parser/tests/method_call_receiver_err.out
@@ -1,3 +1,10 @@
+vlib/v/parser/tests/method_call_receiver_err.vv:13:5: notice: unused parameter: `t`
+   11 | }
+   12 | 
+   13 | fn (t S1) method_hello() string {
+      |     ^
+   14 |     return 'Hello'
+   15 | }
 vlib/v/parser/tests/method_call_receiver_err.vv:6:2: warning: unused variable: `s1`
     4 | 
     5 | fn main() {

--- a/vlib/v/parser/tests/postfix_err_a.out
+++ b/vlib/v/parser/tests/postfix_err_a.out
@@ -18,3 +18,8 @@ vlib/v/parser/tests/postfix_err_a.vv:9:9: warning: `--` operator can only be use
     9 |     _ = a[x--]
       |            ~~
    10 | }
+vlib/v/parser/tests/postfix_err_a.vv:1:6: notice: unused parameter: `i`
+    1 | fn f(i int) {}
+      |      ^
+    2 | 
+    3 | fn test_postfix() {

--- a/vlib/v/tests/skip_unused/generics_method.run.out
+++ b/vlib/v/tests/skip_unused/generics_method.run.out
@@ -1,1 +1,15 @@
+vlib/v/tests/skip_unused/generics_method.vv:13:9: notice: unused parameter: `self`
+   11 | }
+   12 | 
+   13 | fn (mut self App[M]) next[M, T](input T) f64 {
+      |         ~~~~
+   14 |     $if M is Something {
+   15 |         return 0
+vlib/v/tests/skip_unused/generics_method.vv:13:33: notice: unused parameter: `input`
+   11 | }
+   12 | 
+   13 | fn (mut self App[M]) next[M, T](input T) f64 {
+      |                                 ~~~~~
+   14 |     $if M is Something {
+   15 |         return 0
 0.0

--- a/vlib/v/tests/skip_unused/generics_method.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/generics_method.skip_unused.run.out
@@ -1,1 +1,15 @@
+vlib/v/tests/skip_unused/generics_method.vv:13:9: notice: unused parameter: `self`
+   11 | }
+   12 | 
+   13 | fn (mut self App[M]) next[M, T](input T) f64 {
+      |         ~~~~
+   14 |     $if M is Something {
+   15 |         return 0
+vlib/v/tests/skip_unused/generics_method.vv:13:33: notice: unused parameter: `input`
+   11 | }
+   12 | 
+   13 | fn (mut self App[M]) next[M, T](input T) f64 {
+      |                                 ~~~~~
+   14 |     $if M is Something {
+   15 |         return 0
 0.0

--- a/vlib/v/tests/skip_unused/nested_generics_method.run.out
+++ b/vlib/v/tests/skip_unused/nested_generics_method.run.out
@@ -1,1 +1,29 @@
+vlib/v/tests/skip_unused/nested_generics_method.vv:18:9: notice: unused parameter: `t`
+   16 | }
+   17 | 
+   18 | fn (mut t TypeA) next[T](input T) f64 {
+      |         ^
+   19 |     return 10
+   20 | }
+vlib/v/tests/skip_unused/nested_generics_method.vv:18:26: notice: unused parameter: `input`
+   16 | }
+   17 | 
+   18 | fn (mut t TypeA) next[T](input T) f64 {
+      |                          ~~~~~
+   19 |     return 10
+   20 | }
+vlib/v/tests/skip_unused/nested_generics_method.vv:22:9: notice: unused parameter: `t`
+   20 | }
+   21 | 
+   22 | fn (mut t TypeB) next[T](input T) f64 {
+      |         ^
+   23 |     return 11
+   24 | }
+vlib/v/tests/skip_unused/nested_generics_method.vv:22:26: notice: unused parameter: `input`
+   20 | }
+   21 | 
+   22 | fn (mut t TypeB) next[T](input T) f64 {
+      |                          ~~~~~
+   23 |     return 11
+   24 | }
 OK!!

--- a/vlib/v/tests/skip_unused/nested_generics_method.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/nested_generics_method.skip_unused.run.out
@@ -1,1 +1,29 @@
+vlib/v/tests/skip_unused/nested_generics_method.vv:18:9: notice: unused parameter: `t`
+   16 | }
+   17 | 
+   18 | fn (mut t TypeA) next[T](input T) f64 {
+      |         ^
+   19 |     return 10
+   20 | }
+vlib/v/tests/skip_unused/nested_generics_method.vv:18:26: notice: unused parameter: `input`
+   16 | }
+   17 | 
+   18 | fn (mut t TypeA) next[T](input T) f64 {
+      |                          ~~~~~
+   19 |     return 10
+   20 | }
+vlib/v/tests/skip_unused/nested_generics_method.vv:22:9: notice: unused parameter: `t`
+   20 | }
+   21 | 
+   22 | fn (mut t TypeB) next[T](input T) f64 {
+      |         ^
+   23 |     return 11
+   24 | }
+vlib/v/tests/skip_unused/nested_generics_method.vv:22:26: notice: unused parameter: `input`
+   20 | }
+   21 | 
+   22 | fn (mut t TypeB) next[T](input T) f64 {
+      |                          ~~~~~
+   23 |     return 11
+   24 | }
 OK!!


### PR DESCRIPTION
With changes code like the follow will result in a notification like shown below:

```v
fn foo(unused_var string) {
	println('foo')
}
```

```v
❯ v run foo.v
foo.v:1:8: notice: unused parameter: `unused_var`
    1 | fn foo(unused_var string) {
      |        ~~~~~~~~~~
    2 |     println('foo')
    3 |     a := 'a'
```

The change should allow for better detection of dead code. There are many situations where knowing about unused parameters can help resolve unintended behavior or simplify code, such as when removing historical parameter/argument residues after refactorings.

In the standard library, dead parameters are not removed in this PR; they were excluded from the notification. Removing this exclusion could help with the aforementioned benefits when working on the internal code.

Only the current tests have been updated without creating an additional explicit test, as I thought it might suffice to verify the behavior.

Since the change affects a series of test files, a note for the reviewer:
Actual code changes are only in `parser/fn.v` and `checker/checker.v`. Selecting those files or reviewing the test update commit (`Run autofix for compiler error tests`) separately might make things easier.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4OTJmZWU3Y2M1YTc4NTQyZDQ5MzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.7yinEwkYiF_lqlMk6DASD--aneomIVIRlupUeeAIoDw">Huly&reg;: <b>V_0.6-21318</b></a></sub>