### PR TITLE
cgen: fix array fixed code generation for more than 1 dimension

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2620,7 +2620,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 				// Do not allocate for `Interface(unsafe{nil})` casts
 				is_nil_cast := expr is ast.UnsafeExpr && expr.expr is ast.Nil
 				if is_nil_cast {
-					g.write2('/*nili*/', '((void*)0)')
+					g.write2('/*nil*/', '((void*)0)')
 					return
 				}
 			}
@@ -6901,7 +6901,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 											base)};')
 									}
 								}
-							} else {
+							} else if !(elem_sym.info is ast.ArrayFixed && elem_sym.info.is_fn_ret) {
 								g.type_definitions.writeln('typedef ${fixed_elem_name} ${styp} [${len}];')
 							}
 						}

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -692,8 +692,11 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 						field_unwrap_sym.info.size)
 				}
 				ast.ArrayInit {
-					if sfield.expr.has_index
-						|| (sfield.expr.exprs.len > 0 && sfield.expr.exprs.any(it is ast.CallExpr)) {
+					if sfield.expr.has_index {
+						tmp_var := g.expr_with_var(sfield.expr, sfield.typ, sfield.expected_type)
+						g.fixed_array_var_init(tmp_var, false, field_unwrap_sym.info.elem_type,
+							field_unwrap_sym.info.size)
+					} else if sfield.expr.exprs.len > 0 && sfield.expr.exprs.any(it is ast.CallExpr) {
 						tmp_var := g.expr_with_fixed_array(sfield.expr, sfield.typ, sfield.expected_type)
 						g.fixed_array_var_init(tmp_var, false, field_unwrap_sym.info.elem_type,
 							field_unwrap_sym.info.size)

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -694,7 +694,7 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 				ast.ArrayInit {
 					if sfield.expr.has_index
 						|| (sfield.expr.exprs.len > 0 && sfield.expr.exprs.any(it is ast.CallExpr)) {
-						tmp_var := g.expr_with_var(sfield.expr, sfield.typ, sfield.expected_type)
+						tmp_var := g.expr_with_fixed_array(sfield.expr, sfield.typ, sfield.expected_type)
 						g.fixed_array_var_init(tmp_var, false, field_unwrap_sym.info.elem_type,
 							field_unwrap_sym.info.size)
 					} else {

--- a/vlib/v/tests/fixed_array_2_dims_init_test.v
+++ b/vlib/v/tests/fixed_array_2_dims_init_test.v
@@ -5,14 +5,18 @@ struct Uniforms {
 }
 
 fn r() [4]f32 {
-	return [4]f32{}
+	return [f32(1.1), 1.2, 1.3, 1.4]!
 }
 
 fn test_main() {
-	_ := Uniforms{
+	v := Uniforms{
 		lights: [
 			r(),
 			r(),
 		]!
 	}
+	assert v.lights[0][0] == f32(1.1)
+	assert v.lights[0][1] == f32(1.2)
+	assert v.lights[0][2] == f32(1.3)
+	assert v.lights[0][3] == f32(1.4)
 }

--- a/vlib/v/tests/fixed_array_2_dims_init_test.v
+++ b/vlib/v/tests/fixed_array_2_dims_init_test.v
@@ -1,0 +1,18 @@
+module main
+
+struct Uniforms {
+	lights [2][4]f32
+}
+
+fn r() [4]f32 {
+	return [4]f32{}
+}
+
+fn test_main() {
+	_ := Uniforms{
+		lights: [
+			r(),
+			r(),
+		]!
+	}
+}


### PR DESCRIPTION
Fix #22866

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4OWFhY2U3Y2M1YTc4NTQyZDQ5OTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.OBnOZCbvk_blQHZ2VbHeJxt2OOxwIP_kY1GN26KPJJU">Huly&reg;: <b>V_0.6-21319</b></a></sub>