### PR TITLE
parser, checker, pref: allow getting notified about unused function params

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -289,7 +289,13 @@ pub fn (mut c Checker) check_scope_vars(sc &ast.Scope) {
 				ast.Var {
 					if !obj.is_used && obj.name[0] != `_` {
 						if !c.pref.translated && !c.file.is_translated {
-							c.warn('unused variable: `${obj.name}`', obj.pos)
+							if obj.is_arg {
+								if c.pref.show_unused_params {
+									c.note('unused parameter: `${obj.name}`', obj.pos)
+								}
+							} else {
+								c.warn('unused variable: `${obj.name}`', obj.pos)
+							}
 						}
 					}
 					if obj.is_mut && !obj.is_changed && !c.is_builtin_mod && obj.name != 'it' {

--- a/vlib/v/checker/tests/unused_param.out
+++ b/vlib/v/checker/tests/unused_param.out
@@ -11,4 +11,4 @@ vlib/v/checker/tests/unused_param.vv:7:9: notice: unused parameter: `unused_para
     7 | fn func(unused_param int) {}
       |         ~~~~~~~~~~~~
     8 | 
-    9 | pub fn pub_func(unused_param int) {}
+    9 | fn func2(_ int) {}

--- a/vlib/v/checker/tests/unused_param.out
+++ b/vlib/v/checker/tests/unused_param.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/unused_param.vv:5:33: notice: unused parameter: `unused_param`
+    3 | struct Foo {}
+    4 | 
+    5 | fn (unused_receiver Foo) method(unused_param int) {}
+      |                                 ~~~~~~~~~~~~
+    6 | 
+    7 | fn func(unused_param int) {}
+vlib/v/checker/tests/unused_param.vv:7:9: notice: unused parameter: `unused_param`
+    5 | fn (unused_receiver Foo) method(unused_param int) {}
+    6 | 
+    7 | fn func(unused_param int) {}
+      |         ~~~~~~~~~~~~
+    8 | 
+    9 | pub fn pub_func(unused_param int) {}

--- a/vlib/v/checker/tests/unused_param.vv
+++ b/vlib/v/checker/tests/unused_param.vv
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+struct Foo {}
+
+fn (unused_receiver Foo) method(unused_param int) {}
+
+fn func(unused_param int) {}
+
+pub fn pub_func(unused_param int) {}
+
+fn C.puts(unused_c_param &char) int

--- a/vlib/v/checker/tests/unused_param.vv
+++ b/vlib/v/checker/tests/unused_param.vv
@@ -6,6 +6,8 @@ fn (unused_receiver Foo) method(unused_param int) {}
 
 fn func(unused_param int) {}
 
+fn func2(_ int) {}
+
 pub fn pub_func(unused_param int) {}
 
 fn C.puts(unused_c_param &char) int

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -8,6 +8,7 @@ import benchmark
 
 const skip_files = [
 	'non_existing.vv', // minimize commit diff churn, do not remove
+	'vlib/v/checker/tests/unused_param.vv',
 ]
 
 const skip_on_cstrict = [

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -146,6 +146,7 @@ pub mut:
 	show_c_output          bool   // -show-c-output, print all cc output even if the code was compiled correctly
 	show_callgraph         bool   // -show-callgraph, print the program callgraph, in a Graphviz DOT format to stdout
 	show_depgraph          bool   // -show-depgraph, print the program module dependency graph, in a Graphviz DOT format to stdout
+	show_unused_params     bool   // NOTE: temporary until making it a default.
 	dump_c_flags           string // `-dump-c-flags file.txt` - let V store all C flags, passed to the backend C compiler in `file.txt`, one C flag/value per line.
 	dump_modules           string // `-dump-modules modules.txt` - let V store all V modules, that were used by the compiled program in `modules.txt`, one module per line.
 	dump_files             string // `-dump-files files.txt` - let V store all V or .template file paths, that were used by the compiled program in `files.txt`, one path per line.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -950,6 +950,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				res.parse_line_info(res.line_info)
 				i++
 			}
+			'-check-unused-fn-args' {
+				res.show_unused_params = true
+			}
 			'-use-coroutines' {
 				res.use_coroutines = true
 				$if macos || linux {


### PR DESCRIPTION
The PR should implement #22875 as desired.

Example:

![Screenshot_20241116_212257](https://github.com/user-attachments/assets/cc0fe85c-bf83-4266-b48b-4972ac2bef54)

NOTE: the v-analyzer hints won't work until this is on by default. For now, when compiling with `-check-unused-fn-args` you'll get:

```v
fn (unused_receiver Foo) method(unused_param int) {}

fn func(unused_param int) {}
```

```
❯ v -check-unused-fn-args run vlib/v/checker/tests/unused_param.vv
vlib/v/checker/tests/unused_param.vv:5:33: notice: unused parameter: `unused_param`
    3 | struct Foo {}
    4 | 
    5 | fn (unused_receiver Foo) method(unused_param int) {}
      |                                 ~~~~~~~~~~~~
    6 | 
    7 | fn func(unused_param int) {}
vlib/v/checker/tests/unused_param.vv:7:9: notice: unused parameter: `unused_param`
    5 | fn (unused_receiver Foo) method(unused_param int) {}
    6 | 
    7 | fn func(unused_param int) {}
      |         ~~~~~~~~~~~~
    8 | 
    9 | pub fn pub_func(unused_param int) {}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4ZTIxNWU3Y2M1YTc4NTQyZDUxMjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.nGz_aOKL4lO7OxrpWGkYgDEC0atMwC-1mZVkyuNh_tU">Huly&reg;: <b>V_0.6-21322</b></a></sub>