### PR TITLE
v: fix -skip-unused flag typo in v help command output

### DIFF
--- a/vlib/v/help/build/build.txt
+++ b/vlib/v/help/build/build.txt
@@ -159,7 +159,7 @@ NB: the build flags are shared with the run command too:
     Note: the same effect can be achieved by setting the environment variable VNORUN to 1.
 
   -skip-unused
-    Skip generating C/JS code for functions, that are provably not used by your project.
+    Skip generating C/JS code for functions, that are probably not used by your project.
     This speeds up compilation, and reduces the generated output size.
     It is still experimental, due to historical reasons, but please do try it,
     and report issues, if compilation breaks with that option for your program.


### PR DESCRIPTION
This PR fixes a typo in the `v help` command output, on the `-skip-unused` flag description.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM5MmNjNmU3Y2M1YTc4NTQyZDVhZTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.I3XHI6sdAZH7zSkjso4sZ1dm3HPnX5VABf33K0ElZBY">Huly&reg;: <b>V_0.6-21324</b></a></sub>