### PR TITLE
v: reduce `table.sym()` called consecutively by using new `table.sym2()`

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -204,8 +204,7 @@ pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 		// don't check receiver for `.typ`
 		has_unexpected_type := i > 0 && f.params[i].typ != func.params[i].typ
 		// temporary hack for JS ifaces
-		lsym := t.sym(f.params[i].typ)
-		rsym := t.sym(func.params[i].typ)
+		lsym, rsym := t.sym2(f.params[i].typ, func.params[i].typ)
 		if lsym.language == .js && rsym.language == .js {
 			return ''
 		}
@@ -1071,8 +1070,7 @@ pub fn (t &Table) thread_cname(return_type Type) string {
 // e. g. map[string]int
 @[inline]
 pub fn (t &Table) map_name(key_type Type, value_type Type) string {
-	key_type_sym := t.sym(key_type)
-	value_type_sym := t.sym(value_type)
+	key_type_sym, value_type_sym := t.sym2(key_type, value_type)
 	ptr := if value_type.is_ptr() { '&'.repeat(value_type.nr_muls()) } else { '' }
 	opt := if value_type.has_flag(.option) { '?' } else { '' }
 	res := if value_type.has_flag(.result) { '!' } else { '' }
@@ -1081,8 +1079,7 @@ pub fn (t &Table) map_name(key_type Type, value_type Type) string {
 
 @[inline]
 pub fn (t &Table) map_cname(key_type Type, value_type Type) string {
-	key_type_sym := t.sym(key_type)
-	value_type_sym := t.sym(value_type)
+	key_type_sym, value_type_sym := t.sym2(key_type, value_type)
 	suffix := if value_type.is_ptr() { '_ptr'.repeat(value_type.nr_muls()) } else { '' }
 	opt := if value_type.has_flag(.option) { '_option_' } else { '' }
 	res := if value_type.has_flag(.result) { '_result_' } else { '' }

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -738,6 +738,22 @@ pub fn (t &Table) sym(typ Type) &TypeSymbol {
 	return invalid_type_symbol
 }
 
+@[direct_array_access]
+pub fn (t &Table) sym2(typ Type, typ2 Type) (&TypeSymbol, &TypeSymbol) {
+	idx, idx2 := typ.idx(), typ2.idx()
+	if idx > 0 && idx2 > 0 && idx < t.type_symbols.len && idx2 < t.type_symbols.len {
+		return t.type_symbols[idx], t.type_symbols[idx2]
+	}
+	// this should never happen
+	if idx <= 0 {
+		t.panic('table.sym2: invalid type (typ=${typ} idx=${idx}). Compiler bug. This should never happen. Please report the bug using `v bug file.v`.')
+	}
+	if idx2 <= 0 {
+		t.panic('table.sym2: invalid type (typ2=${typ} idx2=${idx}). Compiler bug. This should never happen. Please report the bug using `v bug file.v`.')
+	}
+	return invalid_type_symbol, invalid_type_symbol
+}
+
 // final_sym follows aliases until it gets to a "real" Type
 @[direct_array_access]
 pub fn (t &Table) final_sym(typ Type) &TypeSymbol {

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -542,9 +542,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		if left_type_unwrapped == 0 {
 			continue
 		}
-		left_sym := c.table.sym(left_type_unwrapped)
-		right_sym := c.table.sym(right_type_unwrapped)
-
+		left_sym, right_sym := c.table.sym2(left_type_unwrapped, right_type_unwrapped)
 		if left_sym.kind == .array && !c.inside_unsafe && right_sym.kind == .array
 			&& left is ast.Ident && !left.is_blank_ident() && right in [ast.Ident, ast.SelectorExpr]
 			&& ((node.op == .decl_assign && left.is_mut) || node.op == .assign) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1041,8 +1041,7 @@ fn (mut c Checker) type_implements(typ ast.Type, interface_type ast.Type, pos to
 	}
 	utyp := c.unwrap_generic(typ)
 	styp := c.table.type_to_str(utyp)
-	typ_sym := c.table.sym(utyp)
-	mut inter_sym := c.table.sym(interface_type)
+	typ_sym, mut inter_sym := c.table.sym2(utyp, interface_type)
 	if !inter_sym.is_pub && inter_sym.mod !in [typ_sym.mod, c.mod] && typ_sym.mod != 'builtin' {
 		c.error('`${styp}` cannot implement private interface `${inter_sym.name}` of other module',
 			pos)
@@ -2859,8 +2858,7 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 		}
 		ast.AsCast {
 			node.expr_type = c.expr(mut node.expr)
-			expr_type_sym := c.table.sym(node.expr_type)
-			type_sym := c.table.sym(c.unwrap_generic(node.typ))
+			expr_type_sym, type_sym := c.table.sym2(node.expr_type, c.unwrap_generic(node.typ))
 			if !c.is_builtin_mod {
 				c.table.used_features.as_cast = true
 			}
@@ -4554,8 +4552,7 @@ fn (mut c Checker) prefix_expr(mut node ast.PrefixExpr) ast.Type {
 				c.error('should not create object instance on the heap to simply access a member',
 					node.pos.extend(node.right.pos))
 			}
-			right_sym := c.table.sym(right_type)
-			expr_sym := c.table.sym(node.right.expr_type)
+			right_sym, expr_sym := c.table.sym2(right_type, node.right.expr_type)
 			if expr_sym.kind == .struct && (expr_sym.info as ast.Struct).is_minify
 				&& (node.right.typ == ast.bool_type_idx || (right_sym.kind == .enum
 				&& !(right_sym.info as ast.Enum).is_flag

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1669,8 +1669,8 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				if param_type.is_any_kind_of_pointer() && arg_typ.is_any_kind_of_pointer() {
 					continue
 				}
-				unaliased_param_sym := c.table.sym(c.table.unaliased_type(param_type))
-				unaliased_arg_sym := c.table.sym(c.table.unaliased_type(arg_typ))
+				unaliased_param_sym, unaliased_arg_sym := c.table.sym2(c.table.unaliased_type(param_type),
+					c.table.unaliased_type(arg_typ))
 				// Allow `[32]i8` as `&i8` etc
 				if ((unaliased_arg_sym.kind == .array_fixed || unaliased_arg_sym.kind == .array)
 					&& (param_is_number
@@ -2722,8 +2722,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr) ast.Type {
 			// if arg_typ_sym.kind == .string && typ_sym.has_method('str') {
 			// continue
 			// }
-			param_typ_sym := c.table.sym(exp_arg_typ)
-			arg_typ_sym := c.table.sym(got_arg_typ)
+			param_typ_sym, arg_typ_sym := c.table.sym2(exp_arg_typ, got_arg_typ)
 			if param_typ_sym.info is ast.Array && arg_typ_sym.info is ast.Array {
 				param_elem_type := c.table.unaliased_type(param_typ_sym.info.elem_type)
 				arg_elem_type := c.table.unaliased_type(arg_typ_sym.info.elem_type)

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -492,8 +492,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					c.check_div_mod_by_zero(node.right, node.op)
 				}
 
-				left_sym = c.table.sym(unwrapped_left_type)
-				right_sym = c.table.sym(unwrapped_right_type)
+				left_sym, right_sym = c.table.sym2(unwrapped_left_type, unwrapped_right_type)
 				if left_sym.info is ast.Alias && left_final_sym.is_primitive() {
 					if left_sym.has_method(node.op.str()) {
 						if method := left_sym.find_method(node.op.str()) {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -126,8 +126,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 						}
 					}
 					if stmt.typ != ast.error_type {
-						ret_sym := c.table.sym(ret_type)
-						stmt_sym := c.table.sym(stmt.typ)
+						ret_sym, stmt_sym := c.table.sym2(ret_type, stmt.typ)
 						if ret_sym.kind !in [.sum_type, .interface]
 							&& stmt_sym.kind in [.sum_type, .interface] {
 							c.error('return type mismatch, it should be `${ret_sym.name}`',

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -214,8 +214,7 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				exprv.pos)
 		}
 		if node.exprs[expr_idxs[i]] !is ast.ComptimeCall {
-			got_type_sym := c.table.sym(got_type)
-			exp_type_sym := c.table.sym(exp_type)
+			got_type_sym, exp_type_sym := c.table.sym2(got_type, exp_type)
 			pos := node.exprs[expr_idxs[i]].pos()
 			if c.check_types(got_type, exp_type) {
 				if exp_type.is_unsigned() && got_type.is_int_literal() {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -133,8 +133,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 				}
 
 				// disallow map `mut a = b`
-				field_sym := c.table.sym(field.typ)
-				expr_sym := c.table.sym(field.default_expr_typ)
+				field_sym, expr_sym := c.table.sym2(field.typ, field.default_expr_typ)
 				if field_sym.kind == .map && expr_sym.kind == .map && field.default_expr.is_lvalue()
 					&& field.is_mut
 					&& (!field.default_expr_typ.is_ptr() || field.default_expr is ast.Ident) {
@@ -389,8 +388,7 @@ fn minify_sort_fn(a &ast.StructField, b &ast.StructField) int {
 	}
 
 	mut t := global_table
-	a_sym := t.sym(a.typ)
-	b_sym := t.sym(b.typ)
+	a_sym, b_sym := t.sym2(a.typ, b.typ)
 
 	// push all non-flag enums to the end too, just before the bool fields
 	// TODO: support enums with custom field values as well
@@ -853,8 +851,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 			s := c.table.type_to_str(update_type)
 			c.error('expected struct, found `${s}`', node.update_expr.pos())
 		} else if update_type != node.typ {
-			from_sym := c.table.sym(update_type)
-			to_sym := c.table.sym(node.typ)
+			from_sym, to_sym := c.table.sym2(update_type, node.typ)
 			from_info := from_sym.info as ast.Struct
 			to_info := to_sym.info as ast.Struct
 			// TODO: this check is too strict

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2415,8 +2415,7 @@ struct SumtypeCastingFn {
 fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 	mut got, exp := got_.idx_type(), exp_.idx_type()
 	i := got | int(u32(exp) << 17) | int(u32(exp_.has_flag(.option)) << 16)
-	exp_sym := g.table.sym(exp)
-	mut got_sym := g.table.sym(got)
+	exp_sym, mut got_sym := g.table.sym2(exp, got)
 	cname := if exp == ast.int_type_idx {
 		ast.int_type_name
 	} else {
@@ -2451,7 +2450,7 @@ fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 
 fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	got, exp := fun.got, fun.exp
-	got_sym, exp_sym := g.table.sym(got), g.table.sym(exp)
+	got_sym, exp_sym := g.table.sym2(got, exp)
 	mut got_cname, exp_cname := g.get_sumtype_variant_type_name(got, got_sym), exp_sym.cname
 	mut type_idx := g.type_sidx(got)
 	mut sb := strings.new_builder(128)
@@ -4310,9 +4309,7 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 					obj.typ
 				}
 				values.write_string('{.typ=_SLIT("${g.table.type_to_str(g.unwrap_generic(var_typ))}"),.value=')
-				obj_sym := g.table.sym(obj.typ)
-				cast_sym := g.table.sym(var_typ)
-
+				obj_sym, cast_sym := g.table.sym2(obj.typ, var_typ)
 				mut param_var := strings.new_builder(50)
 				if obj.smartcasts.len > 0 {
 					is_option_unwrap := obj.typ.has_flag(.option)
@@ -7624,8 +7621,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 	// are the same), otherwise panic.
 	unwrapped_node_typ := g.unwrap_generic(node.typ)
 	styp := g.styp(unwrapped_node_typ)
-	sym := g.table.sym(unwrapped_node_typ)
-	mut expr_type_sym := g.table.sym(g.unwrap_generic(node.expr_type))
+	sym, mut expr_type_sym := g.table.sym2(unwrapped_node_typ, g.unwrap_generic(node.expr_type))
 	if mut expr_type_sym.info is ast.SumType {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
 		if node.expr.has_fn_call() && !g.is_cc_msvc {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2570,8 +2570,7 @@ fn (mut g Gen) expr_with_var(expr ast.Expr, got_type_raw ast.Type, expected_type
 // use instead of expr() when you need to cast to a different type
 fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_type ast.Type) {
 	got_type := ast.mktyp(got_type_raw)
-	exp_sym := g.table.sym(expected_type)
-	got_sym := g.table.sym(got_type)
+	exp_sym, got_sym := g.table.sym2(expected_type, got_type)
 	expected_is_ptr := expected_type.is_ptr()
 	got_is_ptr := got_type.is_ptr()
 	// allow using the new Error struct as a string, to avoid a breaking change
@@ -2641,9 +2640,9 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	}
 	if expected_type != ast.void_type {
 		unwrapped_expected_type := g.unwrap_generic(expected_type)
-		unwrapped_exp_sym := g.table.sym(unwrapped_expected_type)
 		mut unwrapped_got_type := g.unwrap_generic(got_type)
-		mut unwrapped_got_sym := g.table.sym(unwrapped_got_type)
+		unwrapped_exp_sym, mut unwrapped_got_sym := g.table.sym2(unwrapped_expected_type,
+			unwrapped_got_type)
 
 		expected_deref_type := if expected_is_ptr {
 			unwrapped_expected_type.deref()

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1624,8 +1624,8 @@ fn (mut g Gen) resolve_comptime_args(func &ast.Fn, mut node_ ast.CallExpr, concr
 					}
 				}
 			} else if mut call_arg.expr is ast.CastExpr {
-				cparam_type_sym := g.table.sym(g.unwrap_generic(call_arg.expr.typ))
-				param_typ_sym := g.table.sym(param_typ)
+				cparam_type_sym, param_typ_sym := g.table.sym2(g.unwrap_generic(call_arg.expr.typ),
+					param_typ)
 				if param_typ_sym.kind == .map && cparam_type_sym.info is ast.Map {
 					comptime_args[k] = cparam_type_sym.info.key_type
 					comptime_args[k + 1] = cparam_type_sym.info.value_type

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -849,9 +849,7 @@ fn (mut g Gen) infix_expr_is_op(node ast.InfixExpr) {
 }
 
 fn (mut g Gen) gen_interface_is_op(node ast.InfixExpr) {
-	mut left_sym := g.table.sym(node.left_type)
-	right_sym := g.table.sym(node.right_type)
-
+	mut left_sym, right_sym := g.table.sym2(node.left_type, node.right_type)
 	mut info := left_sym.info as ast.Interface
 	lock info.conversions {
 		common_variants := info.conversions[node.right_type] or {


### PR DESCRIPTION
This PR aims reduce consecutive calls to `table.sym()`.