### PR TITLE
cgen: fix codegen for if comptime with `-g`

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -353,7 +353,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 		g.write(util.tabs(g.indent))
 		styp := g.styp(node.typ)
 		g.writeln('${styp} ${tmp_var};')
-		stmt_str.trim_space()
+		stmt_str
 	} else {
 		''
 	}

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -160,7 +160,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	}
 	g.write(cur_line)
 	if need_tmp_var {
-		g.write('${tmp_var}')
+		g.write(tmp_var)
 	}
 	if is_expr && !need_tmp_var {
 		g.write(')')

--- a/vlib/v/gen/c/testdata/comptime_if_cond.vv
+++ b/vlib/v/gen/c/testdata/comptime_if_cond.vv
@@ -1,3 +1,4 @@
+// vtest vflags: -g
 struct TaggedSource {}
 
 type SumType = TaggedSource | int
@@ -21,4 +22,5 @@ fn f() {
 		}
 	}
 	assert path == 'c'
+	println('done')
 }

--- a/vlib/v/tests/comptime/comptime_if_cond_test.v
+++ b/vlib/v/tests/comptime/comptime_if_cond_test.v
@@ -1,0 +1,24 @@
+struct TaggedSource {}
+
+type SumType = TaggedSource | int
+
+fn test_main() {
+	f()
+}
+
+fn f() {
+	source := SumType(0)
+	path := match source {
+		TaggedSource {
+			$if foo ? {
+				'a'
+			} $else {
+				'b'
+			}
+		}
+		else {
+			'c'
+		}
+	}
+	assert path == 'c'
+}


### PR DESCRIPTION
Fix #22873

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNhMjJhMGU3Y2M1YTc4NTQyZDhkNTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.M7ERA4Rm2PK9vtufrKFX_pIEEAAbBMSFzmsPWqKfEsk">Huly&reg;: <b>V_0.6-21331</b></a></sub>