### PR TITLE
term: improve performance by caching redundant can_show_color calls

### DIFF
--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -1,3 +1,4 @@
+@[has_globals]
 module term
 
 import os
@@ -13,16 +14,33 @@ pub mut:
 	y int
 }
 
+__global can_show_color_on_stdout_cache = init_can_show_color_cache()
+__global can_show_color_on_stderr_cache = init_can_show_color_cache()
+
+fn init_can_show_color_cache() ?bool {
+	return none
+}
+
 // can_show_color_on_stdout returns true if colors are allowed in stdout;
 // returns false otherwise.
 pub fn can_show_color_on_stdout() bool {
-	return supports_escape_sequences(1)
+	if status := can_show_color_on_stdout_cache {
+		return status
+	}
+	status := supports_escape_sequences(1)
+	can_show_color_on_stdout_cache = status
+	return status
 }
 
 // can_show_color_on_stderr returns true if colors are allowed in stderr;
 // returns false otherwise.
 pub fn can_show_color_on_stderr() bool {
-	return supports_escape_sequences(2)
+	if status := can_show_color_on_stderr_cache {
+		return status
+	}
+	status := supports_escape_sequences(2)
+	can_show_color_on_stderr_cache = status
+	return status
 }
 
 // failed returns a bold white on red version of the string `s`

--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -14,12 +14,8 @@ pub mut:
 	y int
 }
 
-__global can_show_color_on_stdout_cache = init_can_show_color_cache()
-__global can_show_color_on_stderr_cache = init_can_show_color_cache()
-
-fn init_can_show_color_cache() ?bool {
-	return none
-}
+__global can_show_color_on_stdout_cache = ?bool(none)
+__global can_show_color_on_stderr_cache = ?bool(none)
 
 // can_show_color_on_stdout returns true if colors are allowed in stdout;
 // returns false otherwise.


### PR DESCRIPTION
When using the term module for CLI projects, functions like `colorize` and other functions that check first for the ability to display colors can be called quite a lot. Currently the value of `can_show_color_on_stdout()->supports_escape_sequences()` is re-processed on every call of these functions.

https://github.com/vlang/v/blob/5bba92a65adfbd160c3f09c4315f609c76936532/vlib/term/term.v#L184-L202

The changes add a cache for the can_show_color status which results in a speedup of 100%+.

```v
import term
import time

sw := time.new_stopwatch()

for _ in 0 .. 10_000 {
	term.ok_message('my message')
	term.colorize(term.red, 'red')
}

println(sw.elapsed())
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNhMzhkZmU3Y2M1YTc4NTQyZDkxY2QiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.SuznLYJVrzfIlzNSeSSv5D5lFXK8138-OcRFiWDTBSQ">Huly&reg;: <b>V_0.6-21336</b></a></sub>