### PR TITLE
checker: fix `json.encode_pretty` for struct expressions

### DIFF
--- a/vlib/json/tests/json_test.v
+++ b/vlib/json/tests/json_test.v
@@ -461,6 +461,13 @@ fn test_omit_empty() {
 	// println(json.encode_pretty(foo))
 }
 
+fn test_encode_struct_expression() {
+	assert json.encode(Foo2{'Foo'}) == '{"name":"Foo"}'
+	assert json.encode_pretty(Foo2{'Bar'}) == '{
+	"name":	"Bar"
+}'
+}
+
 struct Asdasd {
 	data GamePacketData
 }

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1563,8 +1563,8 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			|| final_param_sym.idx == ast.voidptr_type_idx
 			|| param.typ == ast.nil_type || final_param_sym.idx == ast.nil_type_idx)
 			&& !call_arg.typ.is_any_kind_of_pointer() && func.language == .v
-			&& !call_arg.expr.is_lvalue() && !c.pref.translated
-			&& !c.file.is_translated && func.name !in ['json.encode', 'json.encode_pretty'] {
+			&& !call_arg.expr.is_lvalue() && !c.pref.translated && !c.file.is_translated
+			&& func.name !in ['json.encode', 'json.encode_pretty'] {
 			c.error('expression cannot be passed as `voidptr`', call_arg.expr.pos())
 		}
 		// Handle expected interface

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1563,8 +1563,8 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			|| final_param_sym.idx == ast.voidptr_type_idx
 			|| param.typ == ast.nil_type || final_param_sym.idx == ast.nil_type_idx)
 			&& !call_arg.typ.is_any_kind_of_pointer() && func.language == .v
-			&& !call_arg.expr.is_lvalue() && func.name != 'json.encode' && !c.pref.translated
-			&& !c.file.is_translated {
+			&& !call_arg.expr.is_lvalue() && !c.pref.translated
+			&& !c.file.is_translated && func.name !in ['json.encode', 'json.encode_pretty'] {
 			c.error('expression cannot be passed as `voidptr`', call_arg.expr.pos())
 		}
 		// Handle expected interface


### PR DESCRIPTION
Fixes:

```v
error: expression cannot be passed as `voidptr`
   20 | 
   21 | if !os.is_file(path) {
   22 |     os.write_file(path, json.encode_pretty(Config{}))!
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNhNzhiNWU3Y2M1YTc4NTQyZDk3YjUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.YWcl0rBFIQEjlsLQaOKxXqxuvL-WGm4IzZgsgyUiaLI">Huly&reg;: <b>V_0.6-21340</b></a></sub>