### PR TITLE
cgen, json: make errors more informative (resolve empty panics)

### DIFF
--- a/vlib/json/tests/json_decode_test.v
+++ b/vlib/json/tests/json_decode_test.v
@@ -90,7 +90,7 @@ struct DbConfig {
 
 fn test_decode_error_message_should_have_enough_context_empty() {
 	json.decode(DbConfig, '') or {
-		assert err.msg().len < 2
+		assert err.msg() == 'failed to decode JSON string'
 		return
 	}
 	assert false
@@ -98,7 +98,7 @@ fn test_decode_error_message_should_have_enough_context_empty() {
 
 fn test_decode_error_message_should_have_enough_context_just_brace() {
 	json.decode(DbConfig, '{') or {
-		assert err.msg() == '{'
+		assert err.msg() == 'failed to decode JSON string: {'
 		return
 	}
 	assert false
@@ -111,7 +111,7 @@ fn test_decode_error_message_should_have_enough_context_trailing_comma_at_end() 
     "user": "alex",
 }'
 	json.decode(DbConfig, txt) or {
-		assert err.msg() == '    "user": "alex",\n}'
+		assert err.msg().contains('    "user": "alex",\n}')
 		return
 	}
 	assert false
@@ -120,7 +120,7 @@ fn test_decode_error_message_should_have_enough_context_trailing_comma_at_end() 
 fn test_decode_error_message_should_have_enough_context_in_the_middle() {
 	txt := '{"host": "localhost", "dbname": "alex" "user": "alex", "port": "1234"}'
 	json.decode(DbConfig, txt) or {
-		assert err.msg() == 'ost", "dbname": "alex" "user":'
+		assert err.msg().contains('ost", "dbname": "alex" "user":')
 		return
 	}
 	assert false

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -119,9 +119,9 @@ ${dec_fn_dec} {
 				int maxchars = vstrlen_char(prevline_ptr);
 				vmemcpy(buf, prevline_ptr, (maxchars < maxcontext_chars ? maxchars : maxcontext_chars));
 			}
-			const char *colon;
-			colon = (buf[0] == \'\\0\') ? "" : ": ";
-			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(string_plus_two(_SLIT("failed to decode JSON string"), tos2(colon), tos2(buf))),.data = {0}};
+			string colon;
+			colon = (buf[0] == \'\\0\') ? _SLIT("") : _SLIT(": ");
+			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(string_plus_two(_SLIT("failed to decode JSON string"), colon, tos2(buf))),.data = {0}};
 		}
 	}
 ')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -99,7 +99,7 @@ ${dec_fn_dec} {
 			const int error_pos = (int)cJSON_GetErrorPos();
 			int maxcontext_chars = 30;
 			byte *buf = vcalloc_noscan(maxcontext_chars + 10);
-			if(error_pos > 0) {
+			if (error_pos > 0) {
 				int backlines = 1;
 				int backchars = error_pos < maxcontext_chars-7 ? (int)error_pos : maxcontext_chars-7 ;
 				char *prevline_ptr = (char*)error_ptr;
@@ -119,9 +119,12 @@ ${dec_fn_dec} {
 				int maxchars = vstrlen_char(prevline_ptr);
 				vmemcpy(buf, prevline_ptr, (maxchars < maxcontext_chars ? maxchars : maxcontext_chars));
 			}
-			string colon;
-			colon = (buf[0] == \'\\0\') ? _SLIT("") : _SLIT(": ");
-			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(string_plus_two(_SLIT("failed to decode JSON string"), colon, tos2(buf))),.data = {0}};
+			string msg;
+			msg = _SLIT("failed to decode JSON string");
+			if (buf[0] != \'\\0\') {
+				msg = string__plus(msg, _SLIT(": "));
+			}
+			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(string__plus(msg, tos2(buf))),.data = {0}};
 		}
 	}
 ')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -95,7 +95,7 @@ ${dec_fn_dec} {
 	${init_styp};
 	if (!root) {
 		const char *error_ptr = cJSON_GetErrorPtr();
-		if (error_ptr != NULL)	{
+		if (error_ptr != NULL) {
 			const int error_pos = (int)cJSON_GetErrorPos();
 			int maxcontext_chars = 30;
 			byte *buf = vcalloc_noscan(maxcontext_chars + 10);
@@ -119,7 +119,9 @@ ${dec_fn_dec} {
 				int maxchars = vstrlen_char(prevline_ptr);
 				vmemcpy(buf, prevline_ptr, (maxchars < maxcontext_chars ? maxchars : maxcontext_chars));
 			}
-			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(tos2(buf)),.data = {0}};
+			const char *colon;
+			colon = (buf[0] == \'\\0\') ? "" : ": ";
+			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(string_plus_two(_SLIT("failed to decode JSON string"), tos2(colon), tos2(buf))),.data = {0}};
 		}
 	}
 ')


### PR DESCRIPTION
The changes make error messages for `json.decode` more informative. The reason is that error messages we'll get when walking back on the cJSON error_ptr can currently be empty and become hard to localize. The example below would currently just print an empty line.

```v
json_txt := 'abc'
_ := json.decode(Foo2, json_txt) or {
	eprintln(err)
}
```

With the changes the errors message `failed to decode JSON string` is added. Similar to `failed to open file` during a `os.read_file` error.

---

This should help with the first of the two problems initially attempted to solve in #21184.
The second example in the linked PR could be addressed in a separate PR, where cgen is extended to add a check to verify the variable that should be decoded for validity.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNhYzc5M2U3Y2M1YTc4NTQyZGEyODYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.fKmjsPLGXhGozekEA4iGg3JOp84kGic8WhUYxcgIGss">Huly&reg;: <b>V_0.6-21341</b></a></sub>