### PR TITLE
cgen: generate cjson array lines on uniform indent lvl

### DIFF
--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -1043,7 +1043,7 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 	${fixed_array_idx}
 	cJSON_ArrayForEach(jsval, root)
 	{
-	    ${s}
+		${s}
 		${array_element_assign}
 		${fixed_array_idx_increment}
 	}


### PR DESCRIPTION
A tiny chore, not worth the CI run on a busier time of the day.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNhZDBmOWU3Y2M1YTc4NTQyZGE1NmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ORuM8aU3LQkU6SLjRE42Bn_ClAQotZvKWblwhjsX9yQ">Huly&reg;: <b>V_0.6-21342</b></a></sub>