### PR TITLE
cgen: fix codegen for alias type interface methods

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7955,7 +7955,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 					parent_sym := g.table.sym(st_sym.info.parent_type)
 					match parent_sym.info {
 						ast.Struct, ast.Interface, ast.SumType {
-							t_method_names := methods.map(it.name)
+							mut t_method_names := methods.map(it.name)
 							for method in parent_sym.methods {
 								if method.name in methodidx {
 									parent_method := parent_sym.find_method_with_generic_parent(method.name) or {
@@ -7967,6 +7967,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 									if parent_method.name !in t_method_names {
 										methods << parent_method
 										aliased_method_names << parent_method.name
+										t_method_names << parent_method.name
 									}
 								}
 							}
@@ -7977,10 +7978,11 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 				else {}
 			}
 			t_methods := g.table.get_embed_methods(st_sym)
-			t_method_names := methods.map(it.name)
+			mut t_method_names := methods.map(it.name)
 			for t_method in t_methods {
 				if t_method.name !in t_method_names {
 					methods << t_method
+					t_method_names << t_method.name
 				}
 			}
 

--- a/vlib/v/tests/fns/aliased_interface_methods_test.v
+++ b/vlib/v/tests/fns/aliased_interface_methods_test.v
@@ -1,0 +1,32 @@
+import x.encoding.asn1
+
+struct AExample {
+	a asn1.OctetString
+}
+
+fn (a AExample) tag() asn1.Tag {
+	return asn1.default_sequence_tag
+}
+
+fn (a AExample) payload() ![]u8 {
+	mut out := []u8{}
+	out << asn1.encode(a.a)!
+	return out
+}
+
+// BExample is aliased type, without redefined methods of AExample
+type BExample = AExample
+
+fn test_main() {
+	exa := AExample{
+		a: asn1.OctetString.new('hi')!
+	}
+	exb := BExample(exa)
+	assert '${exa.tag()}' == 'universal-true-16'
+	assert exa.payload()!.len == 4
+	assert asn1.encode(exa)!.len == 6
+
+	assert '${exb.tag()}' == 'universal-true-16'
+	assert exb.payload()!.len == 4
+	assert asn1.encode(exb)!.len == 6
+}


### PR DESCRIPTION
Fix #22901

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNiMmUyMGU3Y2M1YTc4NTQyZGMyNzMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.M9Dw7WnSxXHQa5PSCPi-ZHNiUNLsznebb9RSDdJfPWM">Huly&reg;: <b>V_0.6-21345</b></a></sub>