### PR TITLE
fmt: fix formating non-unsafe blocks with break line (fix #22900)

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -499,7 +499,7 @@ pub fn (mut f Fmt) stmts(stmts []ast.Stmt) {
 	mut prev_stmt := ast.empty_stmt
 	f.indent++
 	for i, stmt in stmts {
-		if i > 0 && !f.pref.building_v && f.should_insert_newline_before_node(stmt, prev_stmt) {
+		if i > 0 && f.should_insert_newline_before_node(stmt, prev_stmt) {
 			f.out.writeln('')
 		}
 		f.stmt(stmt)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -443,6 +443,13 @@ fn (f &Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node)
 			ast.Import {
 				return false
 			}
+			ast.Block {
+				if node is ast.Block && !node.is_unsafe {
+					return true
+				} else {
+					return false
+				}
+			}
 			ast.ConstDecl {
 				if node !is ast.ConstDecl && !(node is ast.ExprStmt && node.expr is ast.Comment) {
 					return true
@@ -489,10 +496,10 @@ pub fn (mut f Fmt) node_str(node ast.Node) string {
 //=== General Stmt-related methods and helpers ===//
 
 pub fn (mut f Fmt) stmts(stmts []ast.Stmt) {
-	mut prev_stmt := if stmts.len > 0 { stmts[0] } else { ast.empty_stmt }
+	mut prev_stmt := ast.empty_stmt
 	f.indent++
-	for stmt in stmts {
-		if !f.pref.building_v && f.should_insert_newline_before_node(stmt, prev_stmt) {
+	for i, stmt in stmts {
+		if i > 0 && !f.pref.building_v && f.should_insert_newline_before_node(stmt, prev_stmt) {
 			f.out.writeln('')
 		}
 		f.stmt(stmt)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -444,7 +444,7 @@ fn (f &Fmt) should_insert_newline_before_node(node ast.Node, prev_node ast.Node)
 				return false
 			}
 			ast.Block {
-				if node is ast.Block && !node.is_unsafe {
+				if node is ast.Block && !node.is_unsafe && node.pos.line_nr - prev_line_nr > 0 {
 					return true
 				} else {
 					return false

--- a/vlib/v/fmt/tests/blocks_keep.vv
+++ b/vlib/v/fmt/tests/blocks_keep.vv
@@ -1,0 +1,16 @@
+fn main() {
+	{
+		println('(1/3) My first small scope')
+		//
+	}
+
+	{
+		println('(2/3) My second small scope')
+		//
+	}
+	// A line below prevents the line removal
+
+	{
+		println('(3/3) My Third small scope')
+	}
+}

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -387,10 +387,10 @@ pub fn (mut f Gen) node_str(node ast.Node) string {
 //=== General Stmt-related methods and helpers ===//
 
 pub fn (mut f Gen) stmts(stmts []ast.Stmt) {
-	mut prev_stmt := if stmts.len > 0 { stmts[0] } else { ast.empty_stmt }
+	mut prev_stmt := ast.empty_stmt
 	f.indent++
-	for stmt in stmts {
-		if !f.pref.building_v && f.should_insert_newline_before_node(stmt, prev_stmt) {
+	for i, stmt in stmts {
+		if i > 0 && f.should_insert_newline_before_node(stmt, prev_stmt) {
 			f.out.writeln('')
 		}
 		f.stmt(stmt)

--- a/vlib/v/tests/structs/struct_local_test.v
+++ b/vlib/v/tests/structs/struct_local_test.v
@@ -1,5 +1,4 @@
 fn test_main() {
-
 	struct Foobar {
 		foo int
 	}
@@ -10,7 +9,6 @@ fn test_main() {
 }
 
 fn x() {
-
 	struct Foobar {
 		baz string
 	}

--- a/vlib/x/json2/decoder2/decode_test.v
+++ b/vlib/x/json2/decoder2/decode_test.v
@@ -181,7 +181,6 @@ fn test_check_json_format() {
 }
 
 fn test_get_value_kind() {
-
 	struct Object_ {
 		byte_      u8
 		value_kind ValueKind


### PR DESCRIPTION
This PR fix formating non-unsafe blocks with break line (fix #22900).

- Fix formating non-unsafe blocks with break line.
- Add test.

blocks_keep.vv

```v
fn main() {
	{
		println('(1/3) My first small scope')
		//
	}

	{
		println('(2/3) My second small scope')
		//
	}
	// A line below prevents the line removal

	{
		println('(3/3) My Third small scope')
	}
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNiNDIyOGU3Y2M1YTc4NTQyZGM2YjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.wuM0irfqiwgS5_ZDZb1ke71QTvvcEwAka0FNGTcBD7k">Huly&reg;: <b>V_0.6-21346</b></a></sub>