### PR TITLE
docs: change installation instructions for cloning the V repository to use `--depth=1`

### DIFF
--- a/.github/workflows/build_vinix_locally.sh
+++ b/.github/workflows/build_vinix_locally.sh
@@ -21,11 +21,11 @@ mkdir -p $BUILD
 
 cd $BUILD
 echo "Clone current Vinix"
-./v retry -- git clone https://github.com/vlang/vinix.git --depth=1
+./v retry -- git clone --depth=1 https://github.com/vlang/vinix.git
 
 cd $BUILD
 echo "Clone current mlibc"
-./v retry -- git clone https://github.com/managarm/mlibc.git --depth=1
+./v retry -- git clone --depth=1 https://github.com/managarm/mlibc.git
 
 cd $BUILD
 echo "Patch mlibc for Vinix"

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -36,7 +36,7 @@ jobs:
           ./v retry -- sudo apt install build-essential -y
 
       - name: Clone current Vinix
-        run: ./v retry -- git clone https://github.com/vlang/vinix.git
+        run: ./v retry -- git clone --depth=1 https://github.com/vlang/vinix.git
 
       - name: Download Vinix kernel dependencies
         run: cd vinix/kernel && ./get-deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ accordingly in the steps below.)
    Let's say that the forked repository is at
    `https://github.com/YOUR_GITHUB_USERNAME/v` .
 2. Clone the main v repository https://github.com/vlang/v to a local folder on
-   your computer, say named nv/ (`git clone https://github.com/vlang/v nv`)
+   your computer, say named nv/ (`git clone --depth=1 https://github.com/vlang/v nv`)
 3. `cd nv`
    3.1 (optional) Run these commands, which ensure that all your code will be
    automatically formatted, before committing:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && \
 COPY . /vlang-local
 
 RUN if [ -z "${USE_LOCAL}" ] ; then \
-      git clone https://github.com/vlang/v/ /opt/vlang && \
+      git clone --depth=1 https://github.com/vlang/v /opt/vlang && \
       rm -rf /vlang-local ; \
     else \
       mv /vlang-local/* . && \

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Note: On Ubuntu/Debian, you may need to run `sudo apt install git build-essentia
 
 To get started, execute the following in your terminal/shell:
 ```bash
-git clone https://github.com/vlang/v
+git clone --depth=1 https://github.com/vlang/v
 cd v
 make
 ```
@@ -168,7 +168,7 @@ shell/editor after that, so that it can pick up the new PATH variable.
 ```bash
 # xbps-install -Su base-devel
 # xbps-install libatomic-devel
-$ git clone https://github.com/vlang/v
+$ git clone --depth=1 https://github.com/vlang/v
 $ cd v
 $ make
 ```
@@ -179,7 +179,7 @@ $ make
 
 
 ```bash
-git clone https://github.com/vlang/v
+git clone --depth=1 https://github.com/vlang/v
 cd v
 docker build -t vlang .
 docker run --rm -it vlang:latest
@@ -188,7 +188,7 @@ docker run --rm -it vlang:latest
 ### Docker with Alpine/musl
 
 ```bash
-git clone https://github.com/vlang/v
+git clone --depth=1 https://github.com/vlang/v
 cd v
 docker build -t vlang_alpine - < Dockerfile.alpine
 alias with_alpine='docker run -u 1000:1000 --rm -it -v .:/src -w /src vlang_alpine:latest'
@@ -219,7 +219,7 @@ Linux/macos:
 
 ```bash
 pkg install clang libexecinfo libgc libgc-static make git
-git clone https://github.com/vlang/v
+git clone --depth=1 https://github.com/vlang/v
 cd v
 make
 ```

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -24,7 +24,7 @@ Anything you can do in other languages, you can do in V.
 The best way to get the latest and greatest V, is to install it from source.
 It is easy, and it takes only a few seconds:
 ```bash
-git clone https://github.com/vlang/v
+git clone --depth=1 https://github.com/vlang/v
 cd v
 make
 ```


### PR DESCRIPTION
The big advantage of using `--depth=1` as the default instruction, is that it only downloads ~10MB currently, and that will stay more or less the same (it is proportional to the compressed size of the files in the latest checkout, and is not proportional to the size of the complete history).

It has big drawbacks for people that want to contribute actively to V, because cloning with `--depth=1` will mean that they will not get the complete history of the project, and some tooling uses that (bisecting for problems, `git blame` etc, are much more effective in a repository that has the complete history).

![image](https://github.com/user-attachments/assets/cebe4328-796b-48ec-b7b4-d2057665eed4)


A complete clone, currently downloads ~79MB in contrast, and can fail more easily for people that have less reliable or slower networks.