### PR TITLE
cgen: fix codegen for returning option aliased fixed array 

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2583,11 +2583,14 @@ fn (mut g Gen) expr_with_fixed_array(expr ast.Expr, got_type_raw ast.Type, expec
 			g.expr(item_expr)
 			g.writeln(', sizeof(${g.styp(val_typ)}));')
 		}
-	} else {
+	} else if expr is ast.CallExpr {
+		// return AliasToFixedArray(...)
 		g.writeln('${styp} ${tmp_var} = {0};')
 		g.write('memcpy(&${tmp_var}.data, ')
 		g.expr(expr)
 		g.writeln(', sizeof(${g.base_type(expected_type)}));')
+	} else {
+		g.expr(expr)
 	}
 	g.write(stmt_str)
 	return tmp_var

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5801,14 +5801,18 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 					g.writeln('${ret_typ} ${tmpvar} = ${tmp_var};')
 				} else {
 					g.writeln('${ret_typ} ${tmpvar} = (${ret_typ}){ .state=0, .err=_const_none__, .data={EMPTY_STRUCT_INITIALIZATION} };')
-					g.write('memcpy(${tmpvar}.data, ')
 					if expr0 is ast.StructInit {
-						g.expr_with_opt(expr0, node.types[0], fn_ret_type)
-						g.write('.data')
+						g.write('memcpy(${tmpvar}.data, ')
+						tmp_var := g.expr_with_opt(expr0, node.types[0], fn_ret_type)
+						g.writeln('.data, sizeof(${styp}));')
+						if tmp_var != '' {
+							g.writeln('${tmpvar}.state = ${tmp_var}.state;')
+						}
 					} else {
+						g.write('memcpy(${tmpvar}.data, ')
 						g.expr(expr0)
+						g.writeln(', sizeof(${styp}));')
 					}
-					g.writeln(', sizeof(${styp}));')
 				}
 			} else {
 				g.writeln('${ret_typ} ${tmpvar};')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5792,7 +5792,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			}
 		}
 		if fn_return_is_option && !expr_type_is_opt && return_sym.name != option_name {
-			if fn_return_is_fixed_array && (expr0 in [ast.StructInit, ast.CallExpr]
+			if fn_return_is_fixed_array && (expr0 in [ast.StructInit, ast.CallExpr, ast.CastExpr]
 				|| (expr0 is ast.ArrayInit && expr0.has_callexpr))
 				&& g.table.final_sym(node.types[0]).kind == .array_fixed {
 				styp := g.styp(fn_ret_type.clear_option_and_result())

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2584,7 +2584,7 @@ fn (mut g Gen) expr_with_fixed_array(expr ast.Expr, got_type_raw ast.Type, expec
 			g.writeln(', sizeof(${g.styp(val_typ)}));')
 		}
 	} else if expr is ast.CallExpr {
-		// return AliasToFixedArray(...)
+		// return var.call() where returns is option/result fixed array
 		g.writeln('${styp} ${tmp_var} = {0};')
 		g.write('memcpy(&${tmp_var}.data, ')
 		g.expr(expr)

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -451,6 +451,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		g.writeln('\tif (${t_var}.state != 0) break;')
 		val := if node.val_var in ['', '_'] { g.new_tmp_var() } else { node.val_var }
 		val_styp := g.styp(ret_typ.clear_option_and_result())
+		ret_is_fixed_array := g.table.sym(ret_typ).is_array_fixed()
 		if node.val_is_mut {
 			if ret_typ.has_flag(.option) {
 				g.writeln('\t${val_styp}* ${val} = (${val_styp}*)${t_var}.data;')
@@ -458,7 +459,12 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 				g.writeln('\t${val_styp} ${val} = (${val_styp})${t_var}.data;')
 			}
 		} else {
-			g.writeln('\t${val_styp} ${val} = *(${val_styp}*)${t_var}.data;')
+			if ret_is_fixed_array {
+				g.writeln('\t${val_styp} ${val} = {0};')
+				g.write('\tmemcpy(${val}, ${t_var}.data, sizeof(${val_styp}));')
+			} else {
+				g.writeln('\t${val_styp} ${val} = *(${val_styp}*)${t_var}.data;')
+			}
 		}
 	} else if node.kind == .aggregate {
 		for_type := (g.table.sym(node.cond_type).info as ast.Aggregate).types[g.aggregate_type_idx]

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -687,7 +687,7 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 					g.fixed_array_var_init(g.expr_string(sfield.expr), is_auto_deref_var,
 						field_unwrap_sym.info.elem_type, field_unwrap_sym.info.size)
 				}
-				ast.CallExpr {
+				ast.CastExpr, ast.CallExpr {
 					tmp_var := g.expr_with_var(sfield.expr, sfield.expected_type)
 					g.fixed_array_var_init(tmp_var, false, field_unwrap_sym.info.elem_type,
 						field_unwrap_sym.info.size)

--- a/vlib/v/tests/options/option_array_fixed_test.v
+++ b/vlib/v/tests/options/option_array_fixed_test.v
@@ -1,0 +1,35 @@
+module main
+
+type Arr = [4]u8
+
+fn foo(a int) ?Arr {
+	if a > 0 {
+		return Arr([u8(1), 2, 3, 4]!)
+	}
+	return none
+}
+
+fn bar(a int) !Arr {
+	if a > 0 {
+		return Arr([u8(1), 2, 3, 4]!)
+	}
+	return error('')
+}
+
+fn test_main() {
+	f := foo(1) or { Arr([u8(0), 0, 0, 0]!) }
+	dump(f)
+	assert f == [u8(1), 2, 3, 4]!
+
+	ff := foo(0)
+	dump(ff)
+	assert ff == none
+
+	b := bar(1) or { Arr([u8(0), 0, 0, 0]!) }
+	dump(f)
+	assert b == [u8(1), 2, 3, 4]!
+
+	bb := bar(0) or { Arr([u8(0), 0, 0, 0]!) }
+	dump(bb)
+	assert bb == [u8(0), 0, 0, 0]!
+}

--- a/vlib/v/tests/options/option_fixed_array_2_test.v
+++ b/vlib/v/tests/options/option_fixed_array_2_test.v
@@ -1,0 +1,52 @@
+module main
+
+import encoding.binary
+
+type Addr = [4]u8
+
+fn Addr.from_u32(a u32) Addr {
+	mut bytes := [4]u8{}
+	binary.big_endian_put_u32_fixed(mut bytes, a)
+	return Addr(bytes)
+}
+
+fn (a Addr) str() string {
+	return '${a[0]}.${a[1]}.${a[2]}.${a[3]}'
+}
+
+fn (a Addr) u32() u32 {
+	return binary.big_endian_u32_fixed(a)
+}
+
+struct Net {
+	netaddr   Addr
+	broadcast Addr
+mut:
+	h u32
+}
+
+fn (mut n Net) next() ?Addr {
+	if n.h >= n.broadcast.u32() + 1 {
+		return none
+	}
+	defer {
+		n.h++
+	}
+	return Addr.from_u32(n.h)
+}
+
+fn test_main() {
+	net := Net{
+		netaddr:   Addr([u8(172), 16, 16, 0]!)
+		broadcast: Addr([u8(172), 16, 16, 3]!)
+		h:         u32(2886733824)
+	}
+	mut rets := []string{}
+	for addr in net {
+		rets << addr.str()
+	}
+	assert rets[0] == '172.16.16.0'
+	assert rets[1] == '172.16.16.1'
+	assert rets[2] == '172.16.16.2'
+	assert rets[3] == '172.16.16.3'
+}


### PR DESCRIPTION
Fix #22910
Fix #22911

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNiYjJiNWU3Y2M1YTc4NTQyZGVhZjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.wKm0kKjIIHodWf1qYndZnXzldOV-D51T1BuueReAtJw">Huly&reg;: <b>V_0.6-21355</b></a></sub>