### PR TITLE
vdoc: use directional overflow for search division

### DIFF
--- a/cmd/tools/vdoc/theme/doc.css
+++ b/cmd/tools/vdoc/theme/doc.css
@@ -312,7 +312,7 @@ hr {
 	text-decoration: underline;
 }
 .doc-nav .search {
-	overflow: scroll;
+	overflow-y: auto;
 }
 .doc-nav .search.hidden {
 	display: none;


### PR DESCRIPTION
When adding the fix in #22352 I didn't realize that chromium based Browsers will unnecessarily display scroll indicators because of that change:
![Screenshot_20241119_062855](https://github.com/user-attachments/assets/1607612c-389f-4f26-9ed6-ec4c1dd0db63)

With the change they are prevented, while the fix is preserved.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNjMjRiMGU3Y2M1YTc4NTQyZGY5OTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.WsLa3j7AG9Z7duVP0R8X4lM456GRABsapXrclBDgELw">Huly&reg;: <b>V_0.6-21357</b></a></sub>