### PR TITLE
parser: optimize method parameter detection in used check

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -504,8 +504,7 @@ run them via `v file.v` instead',
 				is_auto_deref: param.is_mut
 				is_stack_obj:  is_stack_obj
 				pos:           param.pos
-				is_used:       is_pub || no_body
-					|| (is_method && rec.type_pos == param.type_pos) || p.builtin_mod
+				is_used:       is_pub || no_body || (is_method && k == 0) || p.builtin_mod
 				is_arg:        true
 				ct_type_var:   if (!is_method || k > 0) && param.typ.has_flag(.generic)
 					&& !param.typ.has_flag(.variadic) {


### PR DESCRIPTION
Instead of comparing the whole type_pos struct this can be the key index.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNjMjRlNGU3Y2M1YTc4NTQyZGY5YWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.3cr_Vo3JZzTM_z3JaGqD9Ftm8NpJC5TF9ATsVsW8gwI">Huly&reg;: <b>V_0.6-21358</b></a></sub>