### PR TITLE
os(windows): Use _wputenv instead of _putenv to stay in sync with _wgetenv.

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -326,7 +326,7 @@ fn C._wsystem(command &u16) int
 
 fn C._wgetenv(varname &u16) voidptr
 
-fn C._putenv(envstring &char) int
+fn C._wputenv(envstring &u16) int
 
 fn C._waccess(path &u16, mode int) int
 

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -45,15 +45,18 @@ pub fn getenv_opt(key string) ?string {
 // os.setenv sets the value of an environment variable with `name` to `value`.
 pub fn setenv(name string, value string, overwrite bool) int {
 	$if windows {
-		format := '${name}=${value}'
+		format := '${name}=${value}'.to_wide()
+		defer {
+			unsafe { free(voidptr(format)) }
+		}
 		if overwrite {
 			unsafe {
-				return C._putenv(&char(format.str))
+				return C._wputenv(format)
 			}
 		} else {
 			if getenv(name).len == 0 {
 				unsafe {
-					return C._putenv(&char(format.str))
+					return C._wputenv(format)
 				}
 			}
 		}
@@ -68,8 +71,11 @@ pub fn setenv(name string, value string, overwrite bool) int {
 // os.unsetenv clears an environment variable with `name`.
 pub fn unsetenv(name string) int {
 	$if windows {
-		format := '${name}='
-		return C._putenv(&char(format.str))
+		format := '${name}='.to_wide()
+		defer {
+			unsafe { free(voidptr(format)) }
+		}
+		return C._wputenv(format)
 	} $else {
 		return C.unsetenv(&char(name.str))
 	}


### PR DESCRIPTION
The use of _wputenv (os.setenv) ensures that environment variables read by _wgetenv (os.getenv) are returned correctly when ACP is used instead of the utf8 code page.