### PR TITLE
cgen: fix aliases of fixed array infix expression (fix #22925)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -165,12 +165,20 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 		if eq_operator_expects_ptr {
 			g.write('&')
 		}
-		g.expr(node.left)
+		if node.left is ast.ArrayInit && g.table.sym(node.left_type).kind == .array_fixed {
+			g.fixed_array_init_with_cast(node.left, node.left_type)
+		} else {
+			g.expr(node.left)
+		}
 		g.write2(', ', '*'.repeat(right.typ.nr_muls()))
 		if eq_operator_expects_ptr {
 			g.write('&')
 		}
-		g.expr(node.right)
+		if node.right is ast.ArrayInit && g.table.sym(node.right_type).kind == .array_fixed {
+			g.fixed_array_init_with_cast(node.right, node.right_type)
+		} else {
+			g.expr(node.right)
+		}
 		g.write(')')
 	} else if left.unaliased.idx() == right.unaliased.idx()
 		&& left.sym.kind in [.array, .array_fixed, .alias, .map, .struct, .sum_type, .interface] {
@@ -414,7 +422,7 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 			g.expr(node.left)
 			g.write(')')
 		}
-	} else if left.sym.kind == right.sym.kind && has_operator_overloading {
+	} else if left.unaliased_sym.kind == right.unaliased_sym.kind && has_operator_overloading {
 		if node.op in [.le, .ge] {
 			g.write('!')
 		}
@@ -424,12 +432,20 @@ fn (mut g Gen) infix_expr_cmp_op(node ast.InfixExpr) {
 			if operator_expects_ptr {
 				g.write('&')
 			}
-			g.expr(node.left)
+			if node.left is ast.ArrayInit && g.table.sym(node.left_type).kind == .array_fixed {
+				g.fixed_array_init_with_cast(node.left, node.left_type)
+			} else {
+				g.expr(node.left)
+			}
 			g.write2(', ', '*'.repeat(right.typ.nr_muls()))
 			if operator_expects_ptr {
 				g.write('&')
 			}
-			g.expr(node.right)
+			if node.right is ast.ArrayInit && g.table.sym(node.right_type).kind == .array_fixed {
+				g.fixed_array_init_with_cast(node.right, node.right_type)
+			} else {
+				g.expr(node.right)
+			}
 			g.write(')')
 		} else {
 			g.write2('(', '*'.repeat(right.typ.nr_muls()))

--- a/vlib/v/tests/aliases/alias_fixed_array_infix_expr_test.v
+++ b/vlib/v/tests/aliases/alias_fixed_array_infix_expr_test.v
@@ -1,0 +1,28 @@
+import encoding.binary
+
+pub type Addr = [4]u8
+
+pub fn (a Addr) u32() u32 {
+	return binary.big_endian_u32_fixed(a)
+}
+
+pub fn (a Addr) == (oth Addr) bool {
+	return a.u32() == oth.u32()
+}
+
+pub fn (a Addr) < (oth Addr) bool {
+	return a.u32() < oth.u32()
+}
+
+fn test_alias_fixed_array_infix_expr() {
+	addr := Addr([u8(127), 0, 0, 1]!)
+
+	assert addr == Addr([u8(127), 0, 0, 1]!)
+	assert Addr([u8(127), 0, 0, 1]!) == addr
+
+	assert addr == [u8(127), 0, 0, 1]!
+	assert [u8(127), 0, 0, 1]! == addr
+
+	assert addr < Addr([u8(127), 0, 0, 2]!)
+	assert addr < [u8(127), 0, 0, 2]!
+}


### PR DESCRIPTION
This PR fix aliases of fixed array infix expression (fix #22925).

- Fix aliases of fixed array infix expression.
- Add test.

```v
import encoding.binary

pub type Addr = [4]u8

pub fn (a Addr) u32() u32 {
	return binary.big_endian_u32_fixed(a)
}

pub fn (a Addr) == (oth Addr) bool {
	return a.u32() == oth.u32()
}

pub fn (a Addr) < (oth Addr) bool {
	return a.u32() < oth.u32()
}

fn main() {
	addr := Addr([u8(127), 0, 0, 1]!)

	assert addr == Addr([u8(127), 0, 0, 1]!)
	assert Addr([u8(127), 0, 0, 1]!) == addr

	assert addr == [u8(127), 0, 0, 1]!
	assert [u8(127), 0, 0, 1]! == addr

	assert addr < Addr([u8(127), 0, 0, 2]!)
	assert addr < [u8(127), 0, 0, 2]!
}

D:\Test\v\tt1> v run .
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNlOWQ2N2U3Y2M1YTc4NTQyZTcwZjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.5wwfBkCSVGKwOFl27eiLRbiZ-ix4tae4GZmvu_nyvns">Huly&reg;: <b>V_0.6-21370</b></a></sub>