### PR TITLE
cgen: fix aliases of fixed array append to array (fix #22926)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1011,7 +1011,11 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 				if needs_clone {
 					g.write('string_clone(')
 				}
-				g.expr_with_cast(node.right, right.typ, array_info.elem_type)
+				if node.right is ast.CastExpr && node.right.expr is ast.ArrayInit {
+					g.expr(node.right.expr)
+				} else {
+					g.expr_with_cast(node.right, right.typ, array_info.elem_type)
+				}
 				if needs_clone {
 					g.write(')')
 				}

--- a/vlib/v/tests/aliases/alias_fixed_array_append_to_array_test.v
+++ b/vlib/v/tests/aliases/alias_fixed_array_append_to_array_test.v
@@ -1,0 +1,13 @@
+pub type Addr = [4]u8
+
+fn test_alias_fixed_array_append_to_array() {
+	mut my_array := []Addr{}
+	for i := 0; i <= 3; i++ {
+		my_array << Addr([u8(10), 0, 0, u8(i)]!)
+	}
+	println(my_array)
+	assert my_array[0] == Addr([u8(10), 0, 0, 0]!)
+	assert my_array[1] == Addr([u8(10), 0, 0, 1]!)
+	assert my_array[2] == Addr([u8(10), 0, 0, 2]!)
+	assert my_array[3] == Addr([u8(10), 0, 0, 3]!)
+}


### PR DESCRIPTION
This PR fix aliases of fixed array append to array (fix #22926).

- Fix aliases of fixed array append to array.
- Add test.

```v
pub type Addr = [4]u8

fn main() {
	mut my_array := []Addr{}
	for i := 0; i <= 3; i++ {
		my_array << Addr([u8(10), 0, 0, u8(i)]!)
	}
	println(my_array)
	assert my_array[0] == Addr([u8(10), 0, 0, 0]!)
	assert my_array[1] == Addr([u8(10), 0, 0, 1]!)
	assert my_array[2] == Addr([u8(10), 0, 0, 2]!)
	assert my_array[3] == Addr([u8(10), 0, 0, 3]!)
}

PS D:\Test\v\tt1> v run .    
[[10, 0, 0, 0], [10, 0, 0, 1], [10, 0, 0, 2], [10, 0, 0, 3]]
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNlYzkwNmU3Y2M1YTc4NTQyZWEyZTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.kREmDVWndxm2tRcStWF3nZVDhIGVqLptwS7-Kj9FId8">Huly&reg;: <b>V_0.6-21371</b></a></sub>