### PR TITLE
cgen: fix option unwrap for fields of interface type (fixes #22930)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4059,7 +4059,8 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 							g.write('*')
 						}
 						cast_sym := g.table.sym(g.unwrap_generic(typ))
-						if field_sym.kind == .interface && cast_sym.kind == .interface && !is_option_unwrap {
+						if field_sym.kind == .interface && cast_sym.kind == .interface
+							&& !is_option_unwrap {
 							ptr := '*'.repeat(field.typ.nr_muls())
 							dot := if node.expr_type.is_ptr() { '->' } else { '.' }
 							g.write('I_${field_sym.cname}_as_I_${cast_sym.cname}(${ptr}${node.expr}${dot}${node.field_name}))')

--- a/vlib/v/tests/options/option_selector_unwrap_types_test.v
+++ b/vlib/v/tests/options/option_selector_unwrap_types_test.v
@@ -1,5 +1,9 @@
 type SumType = int | string
 
+interface Interface {
+	a int
+}
+
 struct Struct {
 	a int
 }
@@ -9,6 +13,7 @@ struct Foo {
 	b ?string
 	c ?SumType
 	d ?Struct
+	e ?Interface
 }
 
 fn test_main() {
@@ -18,6 +23,9 @@ fn test_main() {
 		c: SumType(123)
 		d: Struct{
 			a: 123
+		}
+		e: Struct{
+			a: 456
 		}
 	}
 	if w.a != none {
@@ -41,6 +49,12 @@ fn test_main() {
 	if w.d != none {
 		dump(w.d)
 		assert w.d.a == 123
+	} else {
+		assert false
+	}
+	if w.e != none {
+		dump(w.e)
+		assert w.e.a == 456
 	} else {
 		assert false
 	}


### PR DESCRIPTION
Fixes #22930 .

Adds a ```!is_option_unwrap``` check.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
