### PR TITLE
cgen: dump expr ignore ptr ampersands

### DIFF
--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -217,11 +217,6 @@ fn (mut g Gen) dump_expr_definitions() {
 		dump_fns.writeln('\tstrings__Builder_write_string(&sb, sexpr);')
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, ':');")
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, ' ');")
-		if is_ptr {
-			for i := 0; i < typ.nr_muls(); i++ {
-				dump_fns.writeln("\tstrings__Builder_write_rune(&sb, '&');")
-			}
-		}
 		dump_fns.writeln('\tstrings__Builder_write_string(&sb, value);')
 		dump_fns.writeln("\tstrings__Builder_write_rune(&sb, '\\n');")
 		surrounder.builder_write_afters(mut dump_fns)

--- a/vlib/v/slow_tests/inout/dump_array_of_ref.out
+++ b/vlib/v/slow_tests/inout/dump_array_of_ref.out
@@ -1,4 +1,4 @@
-[vlib/v/slow_tests/inout/dump_array_of_ref.vv:6] parents: &[Balise{
+[vlib/v/slow_tests/inout/dump_array_of_ref.vv:6] parents: [Balise{
     a: 11
 }, Balise{
     a: 22

--- a/vlib/v/slow_tests/inout/dump_expression.out
+++ b/vlib/v/slow_tests/inout/dump_expression.out
@@ -27,7 +27,7 @@
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:37] p_ptr: &Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:37] p_ptr: Point{
     x: 1
     y: 2
     z: 3

--- a/vlib/v/slow_tests/inout/dump_generic_fn_mut_arg.out
+++ b/vlib/v/slow_tests/inout/dump_generic_fn_mut_arg.out
@@ -1,1 +1,1 @@
-[vlib/v/slow_tests/inout/dump_generic_fn_mut_arg.vv:11] t: &Reptile{}
+[vlib/v/slow_tests/inout/dump_generic_fn_mut_arg.vv:11] t: Reptile{}

--- a/vlib/v/slow_tests/inout/dump_multiple_ptr.out
+++ b/vlib/v/slow_tests/inout/dump_multiple_ptr.out
@@ -1,4 +1,4 @@
 [vlib/v/slow_tests/inout/dump_multiple_ptr.vv:3] i: 42
-[vlib/v/slow_tests/inout/dump_multiple_ptr.vv:5] ir: &42
-[vlib/v/slow_tests/inout/dump_multiple_ptr.vv:7] irr: &&42
-[vlib/v/slow_tests/inout/dump_multiple_ptr.vv:9] irrr: &&&42
+[vlib/v/slow_tests/inout/dump_multiple_ptr.vv:5] ir: 42
+[vlib/v/slow_tests/inout/dump_multiple_ptr.vv:7] irr: 42
+[vlib/v/slow_tests/inout/dump_multiple_ptr.vv:9] irrr: 42

--- a/vlib/v/slow_tests/inout/dump_nil_voidptr.out
+++ b/vlib/v/slow_tests/inout/dump_nil_voidptr.out
@@ -1,2 +1,2 @@
-[vlib/v/slow_tests/inout/dump_nil_voidptr.vv:11] a: &nil
-[vlib/v/slow_tests/inout/dump_nil_voidptr.vv:13] a: &nil
+[vlib/v/slow_tests/inout/dump_nil_voidptr.vv:11] a: nil
+[vlib/v/slow_tests/inout/dump_nil_voidptr.vv:13] a: nil

--- a/vlib/v/slow_tests/inout/dump_shared_arg.out
+++ b/vlib/v/slow_tests/inout/dump_shared_arg.out
@@ -1,3 +1,3 @@
-[vlib/v/slow_tests/inout/dump_shared_arg.vv:12] inst: &AtomicStruct{
+[vlib/v/slow_tests/inout/dump_shared_arg.vv:12] inst: AtomicStruct{
     a: 1
 }


### PR DESCRIPTION
Fixes #22794

Printing a pointer outputs only the value, but dumping it prepends '&'.

This pr removes the part in cgen::dump_expr_defintions that prepends ampersand for the number of '*'s, matching the same output as print. The part was added in #10912

Not sure if they should actually be removed from dump though. First time contributor :)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNmMDIyNGU3Y2M1YTc4NTQzMDU0NGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.h__1mNk8y87JG9c5ox-S0t0ckc6AYypkyp8dj1vMPwU">Huly&reg;: <b>V_0.6-21375</b></a></sub>