### PR TITLE
cgen: fix dump fixed array on array append (fix #22935)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -998,7 +998,7 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 		} else {
 			// push a single element
 			elem_type_str := g.styp(array_info.elem_type)
-			elem_sym := g.table.sym(array_info.elem_type)
+			elem_sym := g.table.final_sym(array_info.elem_type)
 			elem_is_array_var := elem_sym.kind in [.array, .array_fixed] && node.right is ast.Ident
 			g.write('array_push${noscan}((array*)')
 			if !left.typ.is_ptr()
@@ -1029,6 +1029,11 @@ fn (mut g Gen) infix_expr_left_shift_op(node ast.InfixExpr) {
 				}
 				if node.right is ast.CastExpr && node.right.expr is ast.ArrayInit {
 					g.expr(node.right.expr)
+				} else if elem_sym.kind == .array_fixed
+					&& node.right in [ast.CallExpr, ast.DumpExpr] {
+					info := elem_sym.info as ast.ArrayFixed
+					tmpvar := g.expr_with_var(node.right, array_info.elem_type)
+					g.fixed_array_var_init(tmpvar, false, info.elem_type, info.size)
 				} else {
 					g.expr_with_cast(node.right, right.typ, array_info.elem_type)
 				}

--- a/vlib/v/tests/builtin_arrays/dump_fixed_array_on_array_append_test.v
+++ b/vlib/v/tests/builtin_arrays/dump_fixed_array_on_array_append_test.v
@@ -1,0 +1,19 @@
+fn test_dump_fixed_array_on_array_append() {
+	mut myarr := [][3]u8{}
+	myarr << [u8(1), 2, 3]!
+	myarr << [u8(4), 5, 6]!
+	myarr << [u8(7), 8, 9]!
+	println(myarr)
+	assert myarr[0] == [u8(1), 2, 3]!
+	assert myarr[1] == [u8(4), 5, 6]!
+	assert myarr[2] == [u8(7), 8, 9]!
+
+	mut myarr2 := [][3]u8{}
+	myarr2 << dump([u8(1), 2, 3]!)
+	myarr2 << dump([u8(4), 5, 6]!)
+	myarr2 << dump([u8(7), 8, 9]!)
+	println(myarr2)
+	assert myarr2[0] == [u8(1), 2, 3]!
+	assert myarr2[1] == [u8(4), 5, 6]!
+	assert myarr2[2] == [u8(7), 8, 9]!
+}


### PR DESCRIPTION
This PR fix dump fixed array on array append (fix #22935).

- Fix dump fixed array on array append.
- Add test.

```v
fn main() {
	mut myarr := [][3]u8{}
	myarr << [u8(1), 2, 3]!
	myarr << [u8(4), 5, 6]!
	myarr << [u8(7), 8, 9]!
	println(myarr)
	assert myarr[0] == [u8(1), 2, 3]!
	assert myarr[1] == [u8(4), 5, 6]!
	assert myarr[2] == [u8(7), 8, 9]!

	mut myarr2 := [][3]u8{}
	myarr2 << dump([u8(1), 2, 3]!)
	myarr2 << dump([u8(4), 5, 6]!)
	myarr2 << dump([u8(7), 8, 9]!)
	println(myarr2)
	assert myarr2[0] == [u8(1), 2, 3]!
	assert myarr2[1] == [u8(4), 5, 6]!
	assert myarr2[2] == [u8(7), 8, 9]!
}

PS D:\Test\v\tt1> v run .
[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
[.\\tt1.v:12] [u8(1), 2, 3]u8{}: [1, 2, 3]
[.\\tt1.v:13] [u8(4), 5, 6]u8{}: [4, 5, 6]
[.\\tt1.v:14] [u8(7), 8, 9]u8{}: [7, 8, 9]
[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNmZmNhMmQyZWY0Y2JjYzQ2NzljOTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.MobOzKcFdZ6c-Wo8Byy0iUeIGXwfnaLMeF13dmotgHQ">Huly&reg;: <b>V_0.6-21382</b></a></sub>