### PR TITLE
net.http: build Host headers with port (fix #22941)

### DIFF
--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -33,7 +33,7 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 		break
 	}
 
-	req_headers := req.build_request_headers(method, host_name, path)
+	req_headers := req.build_request_headers(method, host_name, port, path)
 	$if trace_http_request ? {
 		eprint('> ')
 		eprint(req_headers)

--- a/vlib/net/http/backend_vschannel_windows.c.v
+++ b/vlib/net/http/backend_vschannel_windows.c.v
@@ -20,7 +20,7 @@ fn vschannel_ssl_do(req &Request, port int, method Method, host_name string, pat
 	C.vschannel_init(&ctx)
 	mut buff := unsafe { malloc_noscan(C.vsc_init_resp_buff_size) }
 	addr := host_name
-	sdata := req.build_request_headers(method, host_name, path)
+	sdata := req.build_request_headers(method, host_name, port, path)
 	$if trace_http_request ? {
 		eprintln('> ${sdata}')
 	}

--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -85,9 +85,9 @@ fn (pr &HttpProxy) build_proxy_headers(host string) string {
 }
 
 fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Request) !Response {
-	host_name, _ := net.split_address(host.hostname())!
+	host_name, port := net.split_address(host.hostname())!
 
-	s := req.build_request_headers(req.method, host_name, path)
+	s := req.build_request_headers(req.method, host_name, port, path)
 	if host.scheme == 'https' {
 		mut client := pr.ssl_dial('${host.host}:443')!
 
@@ -99,7 +99,7 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 			// return response_text
 		} $else {
 			response_text := req.do_request(req.build_request_headers(req.method, host_name,
-				path), mut client)!
+				port, path), mut client)!
 			client.shutdown()!
 			return response_text
 		}


### PR DESCRIPTION
This PR tries to fix the `Host` header, making sure that the port is included when we are not using ports 80 and 443. 

Ignoring the port breaks allow rules for servers that check the Host header, Caddy for instance uses it for the Admin API `localhost:2019/config`.

## Fixes
 - https://github.com/vlang/v/issues/22941

## Reproduction and manual testing

```v
import net.http

fn main() {
	mut response := http.get('https://anything.vithorio.codes:2033/path') or { panic(err) }

	if response.status() != .ok {
		eprintln('Error executing start action. Status: ${response.status()}\n${response.body}')
	}

	eprintln('result: ${response.body}')
}
```
Should print:
```
result: yay \o/ host anything.vithorio.codes 2033 anything.vithorio.codes:2033
```

While a bad result will print:
```
result: NO PORT anything.vithorio.codes  anything.vithorio.codes
```

And you can also double check with curl:
```sh
curl -X GET "https://anything.vithorio.codes:2033/path"
```

OBS: I should probably open it as a Draft, but I actually want some feedback and help planning the Unit Tests, it's actually my first day coding V, I'm loving it, but I'm still a bit lost with how to do stuff.

## TBD

- [x] Create unit tests (I really need help here, is the only way pointing to a real server?)
- [x] Test on Windows
- [x] Check the proxy settings, should they send the port too or they shouldn't