### PR TITLE
checker: fix mut var option unwrap with `!= none`

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1086,15 +1086,6 @@ pub fn (mut i Ident) full_name() string {
 	return i.full_name
 }
 
-// is_unwrapped returns true if the variable is related to `var != none` block
-@[inline]
-pub fn (i &Ident) is_unwrapped() bool {
-	return match i.obj {
-		Var { i.obj.ct_type_var != .smartcast && i.obj.is_unwrapped }
-		else { false }
-	}
-}
-
 @[inline]
 pub fn (i &Ident) is_auto_heap() bool {
 	return match i.obj {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1086,6 +1086,16 @@ pub fn (mut i Ident) full_name() string {
 	return i.full_name
 }
 
+// is_unwrapped returns true if the variable is related to `var != none` block
+@[inline]
+pub fn (i &Ident) is_unwrapped() bool {
+	return match i.obj {
+		Var { i.obj.ct_type_var != .smartcast && i.obj.is_unwrapped }
+		else { false }
+	}
+}
+
+@[inline]
 pub fn (i &Ident) is_auto_heap() bool {
 	return match i.obj {
 		Var { i.obj.is_auto_heap }
@@ -1093,6 +1103,7 @@ pub fn (i &Ident) is_auto_heap() bool {
 	}
 }
 
+@[inline]
 pub fn (i &Ident) is_mut() bool {
 	match i.obj {
 		Var { return i.obj.is_mut }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4271,6 +4271,7 @@ fn (mut c Checker) smartcast(mut expr ast.Expr, cur_type ast.Type, to_type_ ast.
 					is_used:      true
 					is_mut:       expr.is_mut
 					is_inherited: is_inherited
+					is_unwrapped: is_option_unwrap
 					smartcasts:   smartcasts
 					orig_type:    orig_type
 					ct_type_var:  ct_type_var

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -289,7 +289,7 @@ fn (mut c Checker) for_stmt(mut node ast.ForStmt) {
 			if node.cond.right is ast.TypeNode && node.cond.left in [ast.Ident, ast.SelectorExpr] {
 				if c.table.type_kind(node.cond.left_type) in [.sum_type, .interface] {
 					c.smartcast(mut node.cond.left, node.cond.left_type, node.cond.right_type, mut
-						node.scope, false)
+						node.scope, false, false)
 				}
 			}
 		}

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -573,10 +573,10 @@ fn (mut c Checker) smartcast_if_conds(mut node ast.Expr, mut scope ast.Scope, co
 			if node.left is ast.Ident && c.comptime.get_ct_type_var(node.left) == .smartcast {
 				node.left_type = c.comptime.get_type(node.left)
 				c.smartcast(mut node.left, node.left_type, node.left_type.clear_flag(.option), mut
-					scope, true)
+					scope, true, true)
 			} else {
 				c.smartcast(mut node.left, node.left_type, node.left_type.clear_flag(.option), mut
-					scope, false)
+					scope, false, true)
 			}
 		} else if node.op == .key_is {
 			if node.left is ast.Ident && c.comptime.is_comptime_var(node.left) {
@@ -646,7 +646,7 @@ fn (mut c Checker) smartcast_if_conds(mut node ast.Expr, mut scope ast.Scope, co
 						}
 						if left_sym.kind in [.interface, .sum_type] {
 							c.smartcast(mut node.left, node.left_type, right_type, mut
-								scope, is_comptime)
+								scope, is_comptime, false)
 						}
 					}
 				}
@@ -666,10 +666,10 @@ fn (mut c Checker) smartcast_if_conds(mut node ast.Expr, mut scope ast.Scope, co
 					&& c.comptime.get_ct_type_var(first_cond.left) == .smartcast {
 					first_cond.left_type = c.comptime.get_type(first_cond.left)
 					c.smartcast(mut first_cond.left, first_cond.left_type, first_cond.left_type.clear_flag(.option), mut
-						scope, true)
+						scope, true, true)
 				} else {
 					c.smartcast(mut first_cond.left, first_cond.left_type, first_cond.left_type.clear_flag(.option), mut
-						scope, false)
+						scope, false, true)
 				}
 			}
 		}

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -140,8 +140,11 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	if node.op != .key_is {
 		match mut node.left {
 			ast.Ident, ast.SelectorExpr {
-				if node.left.is_mut {
-					c.error('the `mut` keyword is invalid here', node.left.mut_pos)
+				// mut foo != none is allowed for unwrapping option
+				if !(node.op == .ne && node.right is ast.None) {
+					if node.left.is_mut {
+						c.error('the `mut` keyword is invalid here', node.left.mut_pos)
+					}
 				}
 			}
 			else {}

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -506,7 +506,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				}
 
 				c.smartcast(mut node.cond, node.cond_type, expr_type, mut branch.scope,
-					false)
+					false, false)
 			}
 		}
 	}

--- a/vlib/v/tests/generics/generic_selector_test.v
+++ b/vlib/v/tests/generics/generic_selector_test.v
@@ -26,9 +26,6 @@ pub fn (mut l List[T]) append(mut node Node[T]) ?int {
 
 	mut curr_node := l.head
 	for {
-		if curr_node == none {
-			break
-		}
 		if next_node := curr_node?.next {
 			curr_node = next_node
 		} else {

--- a/vlib/v/tests/generics/generic_selector_test.v
+++ b/vlib/v/tests/generics/generic_selector_test.v
@@ -26,14 +26,15 @@ pub fn (mut l List[T]) append(mut node Node[T]) ?int {
 
 	mut curr_node := l.head
 	for {
-		if curr_node != none {
-			if next_node := curr_node?.next {
-				curr_node = next_node
-			} else {
-				curr_node?.next = &node
-				l.size = l.size + 1
-				break
-			}
+		if curr_node == none {
+			break
+		}
+		if next_node := curr_node?.next {
+			curr_node = next_node
+		} else {
+			curr_node?.next = &node
+			l.size = l.size + 1
+			break
 		}
 	}
 	return l.size

--- a/vlib/v/tests/generics/generic_selector_test.v
+++ b/vlib/v/tests/generics/generic_selector_test.v
@@ -26,12 +26,14 @@ pub fn (mut l List[T]) append(mut node Node[T]) ?int {
 
 	mut curr_node := l.head
 	for {
-		if next_node := curr_node?.next {
-			curr_node = next_node
-		} else {
-			curr_node?.next = &node
-			l.size = l.size + 1
-			break
+		if mut curr_node != none {
+			if next_node := curr_node.next {
+				curr_node = next_node
+			} else {
+				curr_node.next = &node
+				l.size = l.size + 1
+				break
+			}
 		}
 	}
 	return l.size

--- a/vlib/v/tests/options/option_var_mut_test.v
+++ b/vlib/v/tests/options/option_var_mut_test.v
@@ -11,3 +11,13 @@ fn test_main() {
 	}
 	assert !res
 }
+
+fn test_non_none() {
+	mut entrykey := ?string('foobar')
+	if entrykey != none {
+		println(entrykey)
+		assert entrykey.len == 6
+	} else {
+		assert false
+	}
+}

--- a/vlib/v/tests/options/option_var_mut_test.v
+++ b/vlib/v/tests/options/option_var_mut_test.v
@@ -1,0 +1,13 @@
+fn test_main() {
+	mut entrykey := ?string(none)
+	mut res := false
+	if entrykey != none {
+		println('entrykey is a string')
+		println(entrykey.len)
+		println(entrykey)
+		res = entrykey.len > 0
+	} else {
+		assert true
+	}
+	assert !res
+}

--- a/vlib/v/tests/options/option_var_test.v
+++ b/vlib/v/tests/options/option_var_test.v
@@ -205,7 +205,7 @@ fn test_opt_none() {
 	t7 := {
 		'foo': 'bar'
 	}
-	t6 := if t5 != none { t5?.clone() } else { t7 }
+	t6 := if t5 != none { t5.clone() } else { t7 }
 	assert t5 == none
 	assert t6.len == 1
 }


### PR DESCRIPTION
Fix #22936

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQxMWQ5ZWQyZWY0Y2JjYzQ2ODE0ZTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lZlq6S-antknaTur7zc7jHVoVGeTmiGFukJlMVhrFu0">Huly&reg;: <b>V_0.6-21385</b></a></sub>