### PR TITLE
cgen: fix enum value to print like its declared enum underlying type

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -763,6 +763,25 @@ pub fn (t &Table) final_sym(typ Type) &TypeSymbol {
 	return invalid_type_symbol
 }
 
+// final_type returns the underlying type, if the final type is an Enum it returns the enum defined type (int one) otherwise the aliased/real type is returned
+pub fn (t &Table) final_type(typ Type) Type {
+	mut idx := typ.idx()
+	if idx > 0 && idx < t.type_symbols.len {
+		cur_sym := t.type_symbols[idx]
+		if cur_sym.info is Alias {
+			idx = cur_sym.info.parent_type.idx()
+			aliased_sym := t.type_symbols[idx]
+			if aliased_sym.info is Enum {
+				return aliased_sym.info.typ
+			}
+			return cur_sym.info.parent_type
+		} else if cur_sym.info is Enum {
+			return cur_sym.info.typ
+		}
+	}
+	return typ
+}
+
 @[inline]
 pub fn (t &Table) get_type_name(typ Type) string {
 	return t.sym(typ).name

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -53,11 +53,7 @@ fn (mut g Gen) str_format(node ast.StringInterLiteral, i int, fmts []u8) (u64, s
 	if node.exprs[i].is_auto_deref_var() {
 		typ = typ.deref()
 	}
-	sym := g.table.sym(typ)
-
-	if sym.kind == .alias {
-		typ = (sym.info as ast.Alias).parent_type
-	}
+	typ = g.table.final_type(typ)
 	mut remove_tail_zeros := false
 	fspec := fmts[i]
 	mut fmt_type := StrIntpType.si_no_str

--- a/vlib/v/tests/enums/enum_print_test.v
+++ b/vlib/v/tests/enums/enum_print_test.v
@@ -1,0 +1,14 @@
+@[type]
+enum Nums {
+	one = 1
+	two = 2
+	ten = 10
+}
+
+fn test_main() {
+	mut str := []string{}
+	$for n in Nums.values {
+		str << '${n.name} ${n.value} ${n.value:d} ${int(n.value)} | ${n.value:o} ${n.value:x} ${n.value:X} ${n.value:b}'
+	}
+	assert str == ['one one 1 1 | 1 1 1 1', 'two two 2 2 | 2 2 2 10', 'ten ten 10 10 | 12 a A 1010']
+}


### PR DESCRIPTION
Fix #22938

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQxYmNhZmQyZWY0Y2JjYzQ2ODFkOTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.d0-yvSZoOuyQgbyJWZxFyMJGBvze_KVTMmHMUjvkaWs">Huly&reg;: <b>V_0.6-21387</b></a></sub>