### PR TITLE
checker, cgen: fix if define comptime checking 

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -742,7 +742,7 @@ fn (mut c Checker) comptime_if_cond(mut cond ast.Expr, pos token.Pos) ComptimeBr
 				should_record_ident = true
 				is_user_ident = true
 				ident_name = cond.expr.name
-				return if cond.expr.name in c.pref.compile_defines_all { .eval } else { .skip }
+				return if cond.expr.name in c.pref.compile_defines { .eval } else { .skip }
 			} else {
 				c.error('invalid `\$if` condition', cond.pos)
 			}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -742,7 +742,15 @@ fn (mut c Checker) comptime_if_cond(mut cond ast.Expr, pos token.Pos) ComptimeBr
 				should_record_ident = true
 				is_user_ident = true
 				ident_name = cond.expr.name
-				return if cond.expr.name in c.pref.compile_defines { .eval } else { .skip }
+				return if cond.expr.name in c.pref.compile_defines {
+					.eval
+				} else {
+					if cond.expr.name in c.pref.compile_defines_all {
+						ComptimeBranchSkipState.unknown
+					} else {
+						ComptimeBranchSkipState.skip
+					}
+				}
 			} else {
 				c.error('invalid `\$if` condition', cond.pos)
 			}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -1324,7 +1324,7 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_option bool) !strin
 		}
 		else {
 			if is_comptime_option
-				|| (g.pref.compile_defines_all.len > 0 && name in g.pref.compile_defines_all) {
+				|| (g.pref.compile_defines.len > 0 && name in g.pref.compile_defines) {
 				return 'CUSTOM_DEFINE_${name}'
 			}
 			return error('bad os ifdef name "${name}"') // should never happen, caught in the checker

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -1324,7 +1324,7 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_option bool) !strin
 		}
 		else {
 			if is_comptime_option
-				|| (g.pref.compile_defines.len > 0 && name in g.pref.compile_defines) {
+				|| (g.pref.compile_defines_all.len > 0 && name in g.pref.compile_defines_all) {
 				return 'CUSTOM_DEFINE_${name}'
 			}
 			return error('bad os ifdef name "${name}"') // should never happen, caught in the checker

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -511,12 +511,17 @@ fn (mut g Gen) comptime_if_cond(cond ast.Expr, pkg_exist bool) (bool, bool) {
 			return is_cond_true, false
 		}
 		ast.PostfixExpr {
-			ifdef := g.comptime_if_to_ifdef((cond.expr as ast.Ident).name, true) or {
+			dname := (cond.expr as ast.Ident).name
+			ifdef := g.comptime_if_to_ifdef(dname, true) or {
 				verror(err.str())
 				return false, true
 			}
 			g.write('defined(${ifdef})')
-			return true, false
+			if dname in g.pref.compile_defines_all && dname !in g.pref.compile_defines {
+				return false, true
+			} else {
+				return true, false
+			}
 		}
 		ast.InfixExpr {
 			match cond.op {

--- a/vlib/v/gen/c/testdata/if_define_check_not_set.out
+++ b/vlib/v/gen/c/testdata/if_define_check_not_set.out
@@ -1,0 +1,2 @@
+some_define was not passed
+

--- a/vlib/v/gen/c/testdata/if_define_check_not_set.vv
+++ b/vlib/v/gen/c/testdata/if_define_check_not_set.vv
@@ -1,0 +1,12 @@
+module main
+
+// vtest vflags: -d some_define=
+
+fn main() {
+	$if some_define ? {
+		println('some_define was passed')
+	} $else {
+		println('some_define was not passed')
+	}
+	println($d('some_define', 'unknown'))
+}

--- a/vlib/v/gen/c/testdata/if_define_check_set.out
+++ b/vlib/v/gen/c/testdata/if_define_check_set.out
@@ -1,0 +1,2 @@
+some_define was passed
+true

--- a/vlib/v/gen/c/testdata/if_define_check_set.vv
+++ b/vlib/v/gen/c/testdata/if_define_check_set.vv
@@ -1,0 +1,12 @@
+module main
+
+// vtest vflags: -d some_define
+
+fn main() {
+	$if some_define ? {
+		println('some_define was passed')
+	} $else {
+		println('some_define was not passed')
+	}
+	println($d('some_define', 'unknown'))
+}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1228,11 +1228,10 @@ fn (mut prefs Preferences) parse_define(define string) {
 	prefs.compile_values[dname] = dvalue
 	prefs.compile_defines_all << dname
 	match dvalue {
-		'0' {}
-		'1' {
+		'' {}
+		else {
 			prefs.compile_defines << dname
 		}
-		else {}
 	}
 }
 

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -438,6 +438,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-nofloat' {
 				res.nofloat = true
 				res.compile_defines_all << 'nofloat' // so that `$if nofloat? {` works
+				res.compile_defines << 'nofloat'
 			}
 			'-fast-math' {
 				res.fast_math = true


### PR DESCRIPTION
Fix #22906

This PR treats `-d custom_define` and `-d custom_define=<something>` as set. And `-d custom_define=` as unset.

Currently `-d custom_define=foo` was not treated as defined.

PS: With this PR `-d foo=0` is a set one.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQxZDIzYWQyZWY0Y2JjYzQ2ODMyZjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.rr9k-IYqRXXG_riEPzR2l_yjB1ChmF798_wCYA2jJ3o">Huly&reg;: <b>V_0.6-21388</b></a></sub>