### PR TITLE
checker: fix or-expr check on invalid method call 

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -745,6 +745,11 @@ fn (mut c Checker) call_expr(mut node ast.CallExpr) ast.Type {
 	if node.or_block.kind == .block {
 		old_inside_or_block_value := c.inside_or_block_value
 		c.inside_or_block_value = true
+		if typ == ast.void_type {
+			// No need to print this error, since this means that the variable is unknown,
+			// and there already was an error before.
+			return typ
+		}
 		c.check_or_expr(node.or_block, typ, c.expected_or_type, node)
 		c.inside_or_block_value = old_inside_or_block_value
 	}

--- a/vlib/v/checker/tests/method_call_on_undefined_err.out
+++ b/vlib/v/checker/tests/method_call_on_undefined_err.out
@@ -1,0 +1,65 @@
+vlib/v/checker/tests/method_call_on_undefined_err.vv:6:10: error: undefined ident: `input`
+    4 | fn foo() !string {
+    5 |     // without next error does not occurs
+    6 |     a, b := input.split_once('%') or { '', 'empty' }
+      |             ~~~~~
+    7 |     if b == '' {
+    8 |         return error('')
+vlib/v/checker/tests/method_call_on_undefined_err.vv:6:32: error: unexpected `or` block, the function `split_once` does not return an Option or a Result
+    4 | fn foo() !string {
+    5 |     // without next error does not occurs
+    6 |     a, b := input.split_once('%') or { '', 'empty' }
+      |                                   ~~~~~~~~~~~~~~~~~~
+    7 |     if b == '' {
+    8 |         return error('')
+vlib/v/checker/tests/method_call_on_undefined_err.vv:6:7: error: assignment mismatch: 2 variables but `split_once()` returns 0 values
+    4 | fn foo() !string {
+    5 |     // without next error does not occurs
+    6 |     a, b := input.split_once('%') or { '', 'empty' }
+      |          ~~
+    7 |     if b == '' {
+    8 |         return error('')
+vlib/v/checker/tests/method_call_on_undefined_err.vv:7:5: error: invalid variable `b`
+    5 |     // without next error does not occurs
+    6 |     a, b := input.split_once('%') or { '', 'empty' }
+    7 |     if b == '' {
+      |        ^
+    8 |         return error('')
+    9 |     }
+vlib/v/checker/tests/method_call_on_undefined_err.vv:7:5: error: non-bool type `void` used as if condition
+    5 |     // without next error does not occurs
+    6 |     a, b := input.split_once('%') or { '', 'empty' }
+    7 |     if b == '' {
+      |        ~~~~~~~
+    8 |         return error('')
+    9 |     }
+vlib/v/checker/tests/method_call_on_undefined_err.vv:10:9: error: invalid variable `a`
+    8 |         return error('')
+    9 |     }
+   10 |     return a
+      |            ^
+   11 | }
+   12 |
+vlib/v/checker/tests/method_call_on_undefined_err.vv:10:2: error: `a` used as value
+    8 |         return error('')
+    9 |     }
+   10 |     return a
+      |     ~~~~~~~~
+   11 | }
+   12 |
+vlib/v/checker/tests/method_call_on_undefined_err.vv:14:13: error: expected 0 arguments, but got 1
+   12 | 
+   13 | fn main() {
+   14 |     res := foo('fe80::1234%ne0') or {
+      |                ~~~~~~~~~~~~~~~~
+   15 |         eprintln(err)
+   16 |         exit(1)
+Details: have (string)
+         want ()
+vlib/v/checker/tests/method_call_on_undefined_err.vv:14:31: error: unexpected `or` block, the function `foo` does not return an Option or a Result
+   12 | 
+   13 | fn main() {
+   14 |     res := foo('fe80::1234%ne0') or {
+      |                                  ~~~~
+   15 |         eprintln(err)
+   16 |         exit(1)

--- a/vlib/v/checker/tests/method_call_on_undefined_err.vv
+++ b/vlib/v/checker/tests/method_call_on_undefined_err.vv
@@ -1,0 +1,19 @@
+module main
+
+// note missing `input` argument in fn signature
+fn foo() !string {
+	// without next error does not occurs
+	a, b := input.split_once('%') or { '', 'empty' }
+	if b == '' {
+		return error('')
+	}
+	return a
+}
+
+fn main() {
+	res := foo('fe80::1234%ne0') or {
+		eprintln(err)
+		exit(1)
+	}
+	println(res)
+}


### PR DESCRIPTION
Fix #22949

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQxZWM4OWQyZWY0Y2JjYzQ2ODQ1MzQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.jxdSbAfF_pKo0PnkhTolIFcIVBNfMLcBut25vDy4gYc">Huly&reg;: <b>V_0.6-21392</b></a></sub>