### PR TITLE
vet: make `v vet` produce a nicer note, including the offending files, instead of the example `file.v`

### DIFF
--- a/cmd/tools/vvet/tests/array_init_one_val.out
+++ b/cmd/tools/vvet/tests/array_init_one_val.out
@@ -1,3 +1,3 @@
 cmd/tools/vvet/tests/array_init_one_val.vv:2: error: Use `1 == 1` instead of `1 in [1]`
 cmd/tools/vvet/tests/array_init_one_val.vv:6: error: Use `'foo' != bar` instead of `'foo' !in [bar]`
-Note: You can run `v fmt -w file.v` to fix these errors automatically
+Note: You can run `v fmt -w cmd/tools/vvet/tests/array_init_one_val.vv` to fix these errors automatically

--- a/cmd/tools/vvet/tests/indent_with_space.out
+++ b/cmd/tools/vvet/tests/indent_with_space.out
@@ -3,4 +3,4 @@ cmd/tools/vvet/tests/indent_with_space.vv:10: error: Looks like you are using sp
 cmd/tools/vvet/tests/indent_with_space.vv:17: error: Looks like you are using spaces for indentation.
 cmd/tools/vvet/tests/indent_with_space.vv:20: error: Looks like you are using spaces for indentation.
 cmd/tools/vvet/tests/indent_with_space.vv:22: error: Looks like you are using spaces for indentation.
-Note: You can run `v fmt -w file.v` to fix these errors automatically
+Note: You can run `v fmt -w cmd/tools/vvet/tests/indent_with_space.vv` to fix these errors automatically

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -94,7 +94,7 @@ fn main() {
 		eprintln(vt.e2string(err))
 	}
 	if vfmt_err_count > 0 {
-		eprintln('Note: You can run `v fmt -w file.v` to fix these errors automatically')
+		eprintln('Note: You can run `v fmt -w ${paths.map(it.str()).join(" ")}` to fix these errors automatically')
 	}
 	if vt.errors.len > 0 {
 		exit(1)

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -94,7 +94,8 @@ fn main() {
 		eprintln(vt.e2string(err))
 	}
 	if vfmt_err_count > 0 {
-		eprintln('Note: You can run `v fmt -w ${vt.errors.map(it.file_path.str()).join(" ")}` to fix these errors automatically')
+		filtered_out := remove_duplicates(vt.errors.map(it.file_path.str()).clone())
+		eprintln('Note: You can run `v fmt -w ${filtered_out.join(' ')}` to fix these errors automatically')
 	}
 	if vt.errors.len > 0 {
 		exit(1)
@@ -145,6 +146,16 @@ fn (mut vt Vet) vet_space_usage(line string, lnumber int) {
 			vt.error('Looks like you have trailing whitespace.', lnumber, .unknown)
 		}
 	}
+}
+
+fn remove_duplicates[T](arr []T) []T {
+	mut results := []T{}
+	for val in arr {
+		if !results.contains(val) {
+			results << val
+		}
+	}
+	return results
 }
 
 fn collect_tags(line string) []string {

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -95,7 +95,7 @@ fn main() {
 		eprintln(vt.e2string(err))
 	}
 	if vfmt_err_count > 0 {
-		filtered_out := arrays.distinct(vt.errors.map(it.file_path.str()))
+		filtered_out := arrays.distinct(vt.errors.map(it.file_path))
 		eprintln('Note: You can run `v fmt -w ${filtered_out.join(' ')}` to fix these errors automatically')
 	}
 	if vt.errors.len > 0 {

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -9,6 +9,7 @@ import v.parser
 import v.ast
 import v.help
 import term
+import arrays
 
 struct Vet {
 mut:
@@ -94,7 +95,7 @@ fn main() {
 		eprintln(vt.e2string(err))
 	}
 	if vfmt_err_count > 0 {
-		filtered_out := remove_duplicates(vt.errors.map(it.file_path.str()).clone())
+		filtered_out := arrays.distinct(vt.errors.map(it.file_path.str()))
 		eprintln('Note: You can run `v fmt -w ${filtered_out.join(' ')}` to fix these errors automatically')
 	}
 	if vt.errors.len > 0 {
@@ -146,16 +147,6 @@ fn (mut vt Vet) vet_space_usage(line string, lnumber int) {
 			vt.error('Looks like you have trailing whitespace.', lnumber, .unknown)
 		}
 	}
-}
-
-fn remove_duplicates[T](arr []T) []T {
-	mut results := []T{}
-	for val in arr {
-		if !results.contains(val) {
-			results << val
-		}
-	}
-	return results
 }
 
 fn collect_tags(line string) []string {

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -94,7 +94,7 @@ fn main() {
 		eprintln(vt.e2string(err))
 	}
 	if vfmt_err_count > 0 {
-		eprintln('Note: You can run `v fmt -w ${paths.map(it.str()).join(" ")}` to fix these errors automatically')
+		eprintln('Note: You can run `v fmt -w ${vt.errors.map(it.file_path.str()).join(" ")}` to fix these errors automatically')
 	}
 	if vt.errors.len > 0 {
 		exit(1)


### PR DESCRIPTION
This PR makes the output for `v vet` a little nicer by making the notice print include the actual offending files instead of the example file `file.v` (which may or may not exist, or be offending):

## Before

![image](https://github.com/user-attachments/assets/0ffa614a-46e9-4c91-a28f-9c8da31b7b99)

## After

![image](https://github.com/user-attachments/assets/be6dee07-3529-4f78-be8f-d3e66433dcbc)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQyOWE4M2QyZWY0Y2JjYzQ2ODUzNjQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.5Ot7lMtWc7zhSmpkIn0MQrv5jQ_8tGlpeQFuiQ1hSTk">Huly&reg;: <b>V_0.6-21398</b></a></sub>