### PR TITLE
cgen: fix codegen for result/option propagation out of fn context

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7353,7 +7353,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			// the deferred statements are generated.
 			g.write_defer_stmts()
 			// Now that option types are distinct we need a cast here
-			if g.fn_decl.return_type == ast.void_type {
+			if g.fn_decl == unsafe { nil } || g.fn_decl.return_type == ast.void_type {
 				g.writeln('\treturn;')
 			} else {
 				styp := g.styp(g.fn_decl.return_type)
@@ -7381,7 +7381,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			// the deferred statements are generated.
 			g.write_defer_stmts()
 			// Now that option types are distinct we need a cast here
-			if g.fn_decl.return_type == ast.void_type {
+			if g.fn_decl == unsafe { nil } || g.fn_decl.return_type == ast.void_type {
 				g.writeln('\treturn;')
 			} else {
 				styp := g.styp(g.fn_decl.return_type).replace('*', '_ptr')

--- a/vlib/v/tests/options/modules/mymod/mod.v
+++ b/vlib/v/tests/options/modules/mymod/mod.v
@@ -1,0 +1,16 @@
+// mod.v
+
+module mymod
+
+import math.big
+
+pub struct BigintRange {
+pub mut:
+	start big.Integer
+	end   big.Integer
+}
+
+pub const range = BigintRange{
+	start: big.integer_from_string('338288524927261089654018896841347694592')!
+	end:   big.integer_from_string('338620831926207318622244848606417780735')!
+}

--- a/vlib/v/tests/options/modules/mymod/mod_test.v
+++ b/vlib/v/tests/options/modules/mymod/mod_test.v
@@ -1,0 +1,7 @@
+// mod_test.v
+
+module mymod
+
+fn test_dummy() {
+	assert range != BigintRange{}
+}


### PR DESCRIPTION
Fix #22961

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQzNjIxOWQyZWY0Y2JjYzQ2ODcxNTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.9gkfst2bAu9rNr9EE4qx8vAZWGkduyBEsi5RJ_PdyGE">Huly&reg;: <b>V_0.6-21404</b></a></sub>