### PR TITLE
cgen: reduce code for returning and extra whitespaces on `return`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5910,8 +5910,10 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			if expr is ast.Ident {
 				g.returned_var_name = expr.name
 			}
+			if !use_tmp_var && !g.is_builtin_mod {
+				use_tmp_var = expr is ast.CallExpr
+			}
 		}
-		// free := g.is_autofree && !g.is_builtin_mod // node.exprs[0] is ast.CallExpr
 		// Create a temporary variable for the return expression
 		if use_tmp_var || !g.is_builtin_mod {
 			// `return foo(a, b, c)`
@@ -5924,7 +5926,6 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				use_tmp_var = true
 				g.write('${ret_typ} ${tmpvar} = ')
 			} else {
-				use_tmp_var = false
 				if !g.is_builtin_mod {
 					g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5528,9 +5528,10 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	g.set_current_pos_as_last_stmt_pos()
 	g.write_v_source_line_info_stmt(node)
 
+	old_inside_return := g.inside_return
 	g.inside_return = true
 	defer {
-		g.inside_return = false
+		g.inside_return = old_inside_return
 	}
 
 	if node.exprs.len > 0 {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5919,7 +5919,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			// Don't use a tmp var if a variable is simply returned: `return x`
 			// Just in case of defer statements exists, that the return values cannot
 			// be modified.
-			if use_tmp_var || g.return_needs_tmp_var(node.exprs[0]) {
+			if use_tmp_var {
 				use_tmp_var = true
 				g.write('${ret_typ} ${tmpvar} = ')
 			} else {
@@ -6012,41 +6012,6 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 	if !has_semicolon {
 		g.writeln(';')
-	}
-}
-
-fn (mut g Gen) return_needs_tmp_var(expr ast.Expr) bool {
-	return match expr {
-		ast.InfixExpr {
-			g.return_needs_tmp_var(expr.left) || g.return_needs_tmp_var(expr.right)
-		}
-		ast.CastExpr {
-			false
-		}
-		ast.CallExpr {
-			if expr.is_method {
-				if g.return_needs_tmp_var(expr.left) {
-					return true
-				}
-			}
-			if expr.args.len > 0 && expr.args.any(g.return_needs_tmp_var(it.expr)) {
-				return true
-			}
-			expr.or_block.kind != .absent
-		}
-		ast.IndexExpr, ast.Ident, ast.IfExpr, ast.MatchExpr, ast.StructInit, ast.ArrayInit,
-		ast.PostfixExpr {
-			false
-		}
-		ast.PrefixExpr {
-			g.return_needs_tmp_var(expr.right)
-		}
-		ast.SelectorExpr {
-			expr.or_block.kind != .absent
-		}
-		else {
-			return !expr.is_literal()
-		}
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5919,7 +5919,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			// Don't use a tmp var if a variable is simply returned: `return x`
 			// Just in case of defer statements exists, that the return values cannot
 			// be modified.
-			if use_tmp_var || !(node.exprs[0].is_literal() || node.exprs[0] is ast.Ident) {
+			if use_tmp_var || g.return_needs_tmp_var(node.exprs[0]) {
 				use_tmp_var = true
 				g.write('${ret_typ} ${tmpvar} = ')
 			} else {
@@ -6012,6 +6012,41 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 	if !has_semicolon {
 		g.writeln(';')
+	}
+}
+
+fn (mut g Gen) return_needs_tmp_var(expr ast.Expr) bool {
+	return match expr {
+		ast.InfixExpr {
+			g.return_needs_tmp_var(expr.left) || g.return_needs_tmp_var(expr.right)
+		}
+		ast.CastExpr {
+			false
+		}
+		ast.CallExpr {
+			if expr.is_method {
+				if g.return_needs_tmp_var(expr.left) {
+					return true
+				}
+			}
+			if expr.args.len > 0 && expr.args.any(g.return_needs_tmp_var(it.expr)) {
+				return true
+			}
+			expr.or_block.kind != .absent
+		}
+		ast.IndexExpr, ast.Ident, ast.IfExpr, ast.MatchExpr, ast.StructInit, ast.ArrayInit,
+		ast.PostfixExpr {
+			false
+		}
+		ast.PrefixExpr {
+			g.return_needs_tmp_var(expr.right)
+		}
+		ast.SelectorExpr {
+			expr.or_block.kind != .absent
+		}
+		else {
+			return !expr.is_literal()
+		}
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6908,7 +6908,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 					if variant in idxs {
 						continue
 					}
-					g.type_definitions.writeln('//          | ${variant:4d} = ${g.styp(variant.idx_type()):-20s}')
+					g.type_definitions.writeln('//          | ${variant:4d} = ${g.styp(variant.idx_type())}')
 					idxs << variant
 				}
 				idxs.clear()

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -452,7 +452,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 	g.defer_ifdef = ''
 	g.writeln('#endif')
 	if node.is_expr {
-		g.write('${line} ${tmp_var}')
+		g.write('${line}${tmp_var}')
 	}
 }
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1021,7 +1021,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 				}
 				if node.is_return_used {
 					// return value is used, so we need to write the unwrapped temporary var
-					g.write('\n ${cur_line} (*(${unwrapped_styp}*)${tmp_opt}.data)')
+					g.write('\n ${cur_line}(*(${unwrapped_styp}*)${tmp_opt}.data)')
 				} else {
 					g.write('\n ${cur_line}')
 				}

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -427,6 +427,6 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			g.set_current_pos_as_last_stmt_pos()
 		}
 		g.empty_line = false
-		g.write('${cur_line} ${tmp}')
+		g.write('${cur_line}${tmp}')
 	}
 }

--- a/vlib/v/gen/c/past_tmp_var.v
+++ b/vlib/v/gen/c/past_tmp_var.v
@@ -47,6 +47,10 @@ fn (mut g Gen) past_tmp_var_done(p &PastTmpVar) {
 		} else {
 			g.write(p.s)
 		}
-		g.write2(' ', p.tmp_var)
+		if g.inside_return {
+			g.write2(' ', p.tmp_var)
+		} else {
+			g.write(p.tmp_var)
+		}
 	}
 }

--- a/vlib/v/gen/c/past_tmp_var.v
+++ b/vlib/v/gen/c/past_tmp_var.v
@@ -47,6 +47,6 @@ fn (mut g Gen) past_tmp_var_done(p &PastTmpVar) {
 		} else {
 			g.write(p.s)
 		}
-		g.write(p.tmp_var)
+		g.write2(' ', p.tmp_var)
 	}
 }

--- a/vlib/v/gen/c/past_tmp_var.v
+++ b/vlib/v/gen/c/past_tmp_var.v
@@ -48,9 +48,8 @@ fn (mut g Gen) past_tmp_var_done(p &PastTmpVar) {
 			g.write(p.s)
 		}
 		if g.inside_return {
-			g.write2(' ', p.tmp_var)
-		} else {
-			g.write(p.tmp_var)
+			g.write(' ')
 		}
+		g.write(p.tmp_var)
 	}
 }

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -140,7 +140,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				} else {
 					g.expr(expr)
 				}
-				g.write2('.data', ') ? _SLIT("Option(&nil)") : ')
+				g.write('.data) ? _SLIT("Option(&nil)") : ')
 			} else {
 				inside_interface_deref_old := g.inside_interface_deref
 				g.inside_interface_deref = false

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -256,7 +256,7 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			}
 		}
 	}
-	g.write2(' str_intp(', node.vals.len.str())
+	g.write2('str_intp(', node.vals.len.str())
 	g.write(', _MOV((StrIntpData[]){')
 	for i, val in node.vals {
 		mut escaped_val := cescape_nonascii(util.smart_quote(val, false))

--- a/vlib/v/gen/c/testdata/alias_char_ptr_to_ptr.c.must_have
+++ b/vlib/v/gen/c/testdata/alias_char_ptr_to_ptr.c.must_have
@@ -1,10 +1,8 @@
 VV_LOCAL_SYMBOL string main__get_two(void) {
 char* s = main__return_text_two();
-string _t1 = cstring_to_vstring(s);
-return _t1;
+return cstring_to_vstring(s);
 }
 VV_LOCAL_SYMBOL string main__get_one(void) {
 main__ALcharptr s = main__return_text_one();
-string _t1 = cstring_to_vstring(s);
-return _t1;
+return cstring_to_vstring(s);
 }

--- a/vlib/v/gen/c/testdata/if_else_return.c.must_have
+++ b/vlib/v/gen/c/testdata/if_else_return.c.must_have
@@ -5,6 +5,5 @@ _result_ok(&(string[]) { s }, (_result*)(&_t2), sizeof(string));
 } else {
 return (_result_string){ .is_error=true, .err=_v_error(_SLIT("empty")), .data={EMPTY_STRUCT_INITIALIZATION} };
 }
-_result_string _t1 =  _t2;
 return _t1;
 }


### PR DESCRIPTION
This PR aims to reduce code generated for returning values when possible.

![image](https://github.com/user-attachments/assets/3730af38-cd07-4e2a-9269-d6a20f24f585)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQzOWJkY2QyZWY0Y2JjYzQ2ODdiYjUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.03brLuMMcP1Ehc4BYtRkcxEekeB7C9H5vrWt7SqyKus">Huly&reg;: <b>V_0.6-21408</b></a></sub>