### PR TITLE
`x.encoding.asn1`: another minor  cleanup

### DIFF
--- a/vlib/x/encoding/asn1/element.v
+++ b/vlib/x/encoding/asn1/element.v
@@ -67,8 +67,7 @@ pub fn (el Element) into_object[T]() !T {
 
 // length tells the payload length of this element.
 pub fn (el Element) length() !int {
-	payload := el.payload()!
-	return payload.len
+	return el.payload()!.len
 }
 
 // UTILITY HELPER FOR ELEMENT
@@ -225,8 +224,7 @@ fn (el Element) equal_payload(other Element) bool {
 }
 
 fn Element.decode(src []u8) !(Element, int) {
-	el, pos := Element.decode_with_rule(src, 0, .der)!
-	return el, pos
+	return Element.decode_with_rule(src, 0, .der)!
 }
 
 // decode deserializes back bytes in src from offet `loc` into Element.

--- a/vlib/x/encoding/asn1/element_decode.v
+++ b/vlib/x/encoding/asn1/element_decode.v
@@ -99,8 +99,7 @@ pub fn decode_with_field_options(bytes []u8, fo FieldOptions) !Element {
 		return error('Get different tag number')
 	}
 	// TODO: default
-	el := tlv.unwrap_with_field_options(fo)!
-	return el
+	return tlv.unwrap_with_field_options(fo)!
 }
 
 fn decode_optional(bytes []u8, expected_tag Tag) !Element {

--- a/vlib/x/encoding/asn1/field_options.v
+++ b/vlib/x/encoding/asn1/field_options.v
@@ -115,10 +115,11 @@ pub fn FieldOptions.from_attrs(attrs []string) !FieldOptions {
 
 	// The item has space-trimmed
 	for item in filtered {
-		if !is_tag_marker(item) && !is_optional_marker(item) && !is_default_marker(item)
-			&& !is_mode_marker(item) && !is_inner_tag_marker(item) {
-			return error('unsupported keyword')
-		}
+		// no need to check this again, its already filtered
+		// if !is_tag_marker(item) && !is_optional_marker(item) && !is_default_marker(item)
+		//		&& !is_mode_marker(item) && !is_inner_tag_marker(item) {
+		//		return error('unsupported keyword')
+		// }
 		if is_tag_marker(item) {
 			cls, num := parse_tag_marker(item)!
 			tag_ctr += 1

--- a/vlib/x/encoding/asn1/field_options.v
+++ b/vlib/x/encoding/asn1/field_options.v
@@ -115,11 +115,6 @@ pub fn FieldOptions.from_attrs(attrs []string) !FieldOptions {
 
 	// The item has space-trimmed
 	for item in filtered {
-		// no need to check this again, its already filtered
-		// if !is_tag_marker(item) && !is_optional_marker(item) && !is_default_marker(item)
-		//		&& !is_mode_marker(item) && !is_inner_tag_marker(item) {
-		//		return error('unsupported keyword')
-		// }
 		if is_tag_marker(item) {
 			cls, num := parse_tag_marker(item)!
 			tag_ctr += 1

--- a/vlib/x/encoding/asn1/other_element.v
+++ b/vlib/x/encoding/asn1/other_element.v
@@ -104,9 +104,9 @@ pub fn (mut r RawElement) set_inner_tag(inner_tag Tag, force bool) ! {
 	if r.tag.class == .universal {
 		return error('No need it on universal class')
 	}
-
+	mode := r.mode or { return error('You dont set any mode') }
 	// when its in explicit mode, compares the provided tag with tag from the inner element.
-	if r.mode? == .explicit {
+	if mode == .explicit {
 		if !r.tag.constructed {
 			return error('unmeet_requirement, explicit should be constructed')
 		}
@@ -154,14 +154,14 @@ pub fn (r RawElement) inner_element() !Element {
 		return error('inner element from universal class is not availables')
 	}
 	inner_tag := r.inner_tag or { return err }
-
-	if r.mode? == .explicit {
+	mode := r.mode or { return error('You dont set any mode') }
+	if mode == .explicit {
 		if !r.tag.constructed {
 			return error('tag should be constructed when in explicit')
 		}
 	}
 	// in implicit, r.content is inner element content with inner tag
-	if r.mode? == .implicit {
+	if mode == .implicit {
 		elem := parse_element(inner_tag, r.content)!
 		return elem
 	}
@@ -182,8 +182,8 @@ fn (r RawElement) check_inner_tag() ! {
 	if r.tag.class == .universal {
 		return error('Universal class does not have inner tag')
 	}
-	// This option unwrap handling already has been fixed in latest v.
-	if r.mode? != .explicit {
+	mode := r.mode or { return error('You dont set any mode') }
+	if mode != .explicit {
 		return
 	}
 	// read an inner tag from content

--- a/vlib/x/encoding/asn1/other_element.v
+++ b/vlib/x/encoding/asn1/other_element.v
@@ -46,19 +46,6 @@ pub fn RawElement.new(tag Tag, content []u8) !RawElement {
 	return RawElement{
 		tag:     tag
 		content: content
-		// Issues: without set this to `none`, when compiled with `-cstrict` options, its would bring
-		// into failed compiles error:
-		// ================= C compilation error (from clang): ==============
-		// error: incompatible pointer types passing '_option_x__encoding__asn1__Tag *'
-		// (aka 'struct _option_x__encoding__asn1__Tag *') to parameter of type '_option *'
-		// (aka 'struct _option *') [-Werror,-Wincompatible-pointer-types]
-		// cc:         _option_none(&(x__encoding__asn1__Tag[])
-		// { ((x__encoding__asn1__Tag){.__v_class =
-		// x__encoding__asn1__TagClass__universal,.constructed = 0,.number = 0,})},
-		// &_t6, sizeof(x__encoding__asn1__Tag));                                            ```
-		inner_tag:     none
-		mode:          none
-		default_value: none
 	}
 }
 
@@ -93,19 +80,9 @@ pub fn (r RawElement) payload() ![]u8 {
 	return r.content
 }
 
-// force_set_mode forces to change tagged mode of RawElement into mode.
-// It will change how the element was interpreted.
-pub fn (mut r RawElement) force_set_mode(mode TaggedMode) ! {
-	r.set_mode_with_flag(mode, true)!
-}
-
-// set_mode sets the tagged mode of the RawElement into mode.
-// If you want force it to use the mode, use `force_set_mode`.
-pub fn (mut r RawElement) set_mode(mode TaggedMode) ! {
-	r.set_mode_with_flag(mode, false)!
-}
-
-fn (mut r RawElement) set_mode_with_flag(mode TaggedMode, force bool) ! {
+// set_mode sets the RawElement tagged mode, in explicit or implicit mode. If the mode has been set,
+// it would drop into error until you forces it by setting force flag into true value, ie, replaces the old one.
+pub fn (mut r RawElement) set_mode(mode TaggedMode, force bool) ! {
 	if r.tag.class == .universal {
 		return error('No need it on universal class')
 	}
@@ -120,29 +97,16 @@ fn (mut r RawElement) set_mode_with_flag(mode TaggedMode, force bool) ! {
 	r.mode = mode
 }
 
-// set_inner_tag sets the inner tag of the RawElement into inner_tag.
-// If its already set, it would return error.
-// Use `force_set_inner_tag` instead to force it.
-pub fn (mut r RawElement) set_inner_tag(inner_tag Tag) ! {
-	r.set_inner_tag_with_flag(inner_tag, false)!
-}
-
-// force_set_inner_tag forces to set the inner tag of the RawElement into inner_tag
-// even its has been set previously.
-pub fn (mut r RawElement) force_set_inner_tag(inner_tag Tag) ! {
-	r.set_inner_tag_with_flag(inner_tag, true)!
-}
-
-fn (mut r RawElement) set_inner_tag_with_flag(inner_tag Tag, force bool) ! {
+// set_inner_tag sets the inner tag of the RawElement into inner_tag value. If it has been already set,
+// it would be an error until you setting force flag into true value to replace the old one.
+pub fn (mut r RawElement) set_inner_tag(inner_tag Tag, force bool) ! {
 	// not needed in universal class
 	if r.tag.class == .universal {
 		return error('No need it on universal class')
 	}
-	// we need mode first
-	mode := r.mode or { return error('unmeet_requirement, set the mode first') }
 
-	// when its explicit, compares the provided tag with tag from the inner element.
-	if mode == .explicit {
+	// when its in explicit mode, compares the provided tag with tag from the inner element.
+	if r.mode? == .explicit {
 		if !r.tag.constructed {
 			return error('unmeet_requirement, explicit should be constructed')
 		}
@@ -164,17 +128,8 @@ fn (mut r RawElement) set_inner_tag_with_flag(inner_tag Tag, force bool) ! {
 }
 
 // force_set_default_value forces set default value of this RawElement into value.
-pub fn (mut r RawElement) force_set_default_value(value Element) ! {
-	r.set_default_value_with_flag(value, true)!
-}
-
-// set_default_value sets the default value of this RawElement to some value.
-pub fn (mut r RawElement) set_default_value(value Element) ! {
-	r.set_default_value_with_flag(value, false)!
-}
-
-fn (mut r RawElement) set_default_value_with_flag(value Element, force bool) ! {
-	// default value of this element should have equal tag.
+fn (mut r RawElement) set_default_value(value Element, force bool) ! {
+	// default value of this element should have an equal tag.
 	if !value.tag().equal(r.tag) {
 		return error('You provides unequal tag for default value')
 	}
@@ -189,10 +144,8 @@ fn (mut r RawElement) set_default_value_with_flag(value Element, force bool) ! {
 }
 
 // inner_tag returns the inner tag of the RawElement if it exists, or error on fails.
-pub fn (r RawElement) inner_tag() !Tag {
-	inner_tag := r.inner_tag or { return error(' r.inner_tag is not set') }
-
-	return inner_tag
+pub fn (r RawElement) inner_tag() ?Tag {
+	return r.inner_tag
 }
 
 // inner_element returns the inner element of the RawElement if its exists.
@@ -200,16 +153,15 @@ pub fn (r RawElement) inner_element() !Element {
 	if r.tag.class == .universal {
 		return error('inner element from universal class is not availables')
 	}
-	mode := r.mode or { return err }
 	inner_tag := r.inner_tag or { return err }
 
-	if mode == .explicit {
+	if r.mode? == .explicit {
 		if !r.tag.constructed {
 			return error('tag should be constructed when in explicit')
 		}
 	}
 	// in implicit, r.content is inner element content with inner tag
-	if mode == .implicit {
+	if r.mode? == .implicit {
 		elem := parse_element(inner_tag, r.content)!
 		return elem
 	}
@@ -230,8 +182,8 @@ fn (r RawElement) check_inner_tag() ! {
 	if r.tag.class == .universal {
 		return error('Universal class does not have inner tag')
 	}
-	mode := r.mode or { return error('You dont set any mode') }
-	if mode != .explicit {
+	// This option unwrap handling already has been fixed in latest v.
+	if r.mode? != .explicit {
 		return
 	}
 	// read an inner tag from content
@@ -302,11 +254,8 @@ fn ContextElement.decode_raw(bytes []u8) !(ContextElement, int) {
 	next := content_pos + length
 	// Raw ContextElement, you should provide mode and inner tag.
 	ctx := ContextElement{
-		tag:           tag
-		content:       content
-		inner_tag:     none
-		mode:          none
-		default_value: none
+		tag:     tag
+		content: content
 	}
 	return ctx, next
 }

--- a/vlib/x/encoding/asn1/sequence.v
+++ b/vlib/x/encoding/asn1/sequence.v
@@ -32,13 +32,6 @@ mut:
 	fields []Element
 }
 
-fn (s Sequence) str() string {
-	if s.fields.len == 0 {
-		return 'SEQUENCE: <empty>'
-	}
-	return 'SEQUENCE: ${s.fields.len} elements.'
-}
-
 // new creates new Sequence with default size.
 pub fn Sequence.new() !Sequence {
 	return Sequence.new_with_size(default_sequence_size)!
@@ -238,13 +231,6 @@ pub struct SequenceOf[T] {
 mut:
 	size   int = default_sequence_size
 	fields []T
-}
-
-fn (s SequenceOf[T]) str() string {
-	if s.fields.len == 0 {
-		return 'SEQUENCE OF (<empty>)'
-	}
-	return 'SEQUENCE OF (${s.fields.len} ${typeof(s).name})'
 }
 
 // SequenceOf.new creates a new SequenceOf[T]

--- a/vlib/x/encoding/asn1/set.v
+++ b/vlib/x/encoding/asn1/set.v
@@ -23,13 +23,6 @@ mut:
 	fields []Element
 }
 
-fn (s Set) str() string {
-	if s.fields.len == 0 {
-		return 'SET (<empty>)'
-	}
-	return 'SET (${s.fields.len} Elements)'
-}
-
 // creates a new Set with default size.
 pub fn Set.new() !Set {
 	return Set.new_with_size(default_set_size)!
@@ -245,13 +238,6 @@ pub fn SetOf.new[T]() !SetOf[T] {
 		return error('Yur T is not Element')
 	}
 	return SetOf[T]{}
-}
-
-fn (s SetOf[T]) str() string {
-	if s.fields.len == 0 {
-		return 'SET OF (<empty>)'
-	}
-	return 'SET OF (${s.fields.len} ${typeof(s).name})'
 }
 
 // from_list creates new SetOf type T from arrays of T.

--- a/vlib/x/encoding/asn1/tagged_test.v
+++ b/vlib/x/encoding/asn1/tagged_test.v
@@ -59,8 +59,8 @@ Example ::= SEQUENCE {
 	assert els[1] is Integer
 	mut els2 := els[2] as ContextElement
 
-	els2.set_mode(.explicit)!
-	els2.set_inner_tag(default_oid_tag)!
+	els2.set_mode(.explicit, true)!
+	els2.set_inner_tag(default_oid_tag, true)!
 
 	out.clear()
 	out = encode(els2)!

--- a/vlib/x/encoding/asn1/time.v
+++ b/vlib/x/encoding/asn1/time.v
@@ -50,7 +50,8 @@ pub fn UtcTime.new(s string) !UtcTime {
 	}
 }
 
-fn UtcTime.from_time(t time.Time) !UtcTime {
+// from_time creates a new UtcTime element from standard `time.Time` in UTC time format.
+pub fn UtcTime.from_time(t time.Time) !UtcTime {
 	// changes into utc time
 	utime := t.local_to_utc()
 	s := utime.custom_format(default_utctime_format) //  20241113060446+0
@@ -226,7 +227,7 @@ pub fn GeneralizedTime.new(s string) !GeneralizedTime {
 	}
 }
 
-// from_time creates GeneralizedTime element from tine.Time (as an UTC time).
+// from_time creates GeneralizedTime element from standard `time.Time` (as an UTC time).
 pub fn GeneralizedTime.from_time(t time.Time) !GeneralizedTime {
 	u := t.local_to_utc()
 	s := u.custom_format(default_genztime_format)

--- a/vlib/x/encoding/asn1/time_test.v
+++ b/vlib/x/encoding/asn1/time_test.v
@@ -116,6 +116,8 @@ fn test_create_generalizedtime_from_std_time() ! {
 	gtc := GeneralizedTime.from_time(now)!
 
 	assert gtb.value == gtc.value
+	assert gtb.value == '20241113174550Z'
+	assert gtc.value == '20241113174550Z'
 
 	tt := gtc.into_utctime()!
 	assert now == tt


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR is rather of
follow-up from previous PR in attempt to improves `x.encoding.asn1` module, as availables  in [22948](https://github.com/vlang/v/pull/22948), [22932](https://github.com/vlang/v/pull/22932), [22861](https://github.com/vlang/v/pull/22861), and [22847](https://github.com/vlang/v/pull/22847) PRs.
This PR contains some small changes to the module:

- Refinement to align with the latest fix of Option unwrapping. (mostly from @felipensp, thank guys)
- Just removes `.str()` from sequence and set for now, its needed to allow just dump current sequence fields.
- Unifies some of `RawElement` methods
- Some small refinements.

The latest bench run with `-prod` flag results in

```v
Benchmarking ASN.1 encode...
Average example encode time: 1 µs
Benchmarking ASN.1 decode (with asn1.decode)...
Average (asn1.decode) decode time: 1 µs
Benchmarking ASN.1 decode with Example.decode)...
Average (Example.decode) decode time: 1 µs
```

Its likely on par with the `go` version bench availables on `bench` dir. The previous patch help reduces some overhead of it.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ0MTM5NWQyZWY0Y2JjYzQ2ODk2NjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.F1jx8tLoVe3St_QIHHTjvAFqKjq-1RRKt3XW4S81Pkg">Huly&reg;: <b>V_0.6-21409</b></a></sub>