### PR TITLE
v: fix `-skip-unused` feature for some broken tests

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -33,6 +33,8 @@ pub mut:
 	used_maps        int             // how many times maps were used, filled in by markused
 	used_arrays      int             // how many times arrays were used, filled in by markused
 	// json             bool            // json is imported
+	debugger       bool            // debugger is used
+	comptime_calls map[string]bool // resolved $method() names
 }
 
 @[unsafe]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2150,7 +2150,9 @@ fn (mut c Checker) stmt(mut node ast.Stmt) {
 			}
 		}
 		ast.NodeError {}
-		ast.DebuggerStmt {}
+		ast.DebuggerStmt {
+			c.table.used_features.debugger = true
+		}
 		ast.AsmStmt {
 			c.asm_stmt(mut node)
 		}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -129,6 +129,12 @@ fn (mut c Checker) comptime_call(mut node ast.ComptimeCall) ast.Type {
 		if c.inside_anon_fn && 'method' !in c.cur_anon_fn.inherited_vars.map(it.name) {
 			c.error('undefined ident `method` in the anonymous function', node.pos)
 		}
+		if c.pref.skip_unused && node.method_name == 'method' {
+			sym := c.table.sym(c.unwrap_generic(node.left_type))
+			if m := sym.find_method(c.comptime.comptime_for_method.name) {
+				c.table.used_features.comptime_calls['${int(c.unwrap_generic(m.receiver_type))}.${c.comptime.comptime_for_method.name}'] = true
+			}
+		}
 		for i, mut arg in node.args {
 			// check each arg expression
 			node.args[i].typ = c.expr(mut arg.expr)

--- a/vlib/v/debug/debug.v
+++ b/vlib/v/debug/debug.v
@@ -8,6 +8,7 @@ import readline
 import strings
 import term
 
+@[markused]
 __global g_debugger = Debugger{}
 
 // Debugger holds the V debug information for REPL

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -13,7 +13,6 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 	defer {
 		util.timing_measure(@METHOD)
 	}
-	// println('>>>> ${all_fns}')
 	mut allow_noscan := true
 	// Functions that must be generated and can't be skipped
 	mut all_fn_root_names := []string{}
@@ -143,8 +142,6 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 		all_fn_root_names << core_fns
 	}
 
-	// all_fn_root_names << ['115.from_toml', '115.to_toml', '133.to_toml','136.to_toml', '138.to_toml', '131.to_toml']
-
 	if pref_.is_bare {
 		all_fn_root_names << [
 			'strlen',
@@ -158,7 +155,6 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 
 	is_noscan_whitelisted := pref_.gc_mode in [.boehm_full_opt, .boehm_incr_opt]
 
-	println(table.used_features.comptime_calls)
 	for k, mut mfn in all_fns {
 		$if trace_skip_unused_all_fns ? {
 			println('k: ${k} | mfn: ${mfn.name}')

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1137,7 +1137,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 	// eprintln('>> res.build_options: $res.build_options')
 	res.fill_with_defaults()
 	if res.backend == .c {
-		res.skip_unused = true
+		// res.skip_unused = true
 		if no_skip_unused {
 			res.skip_unused = false
 		}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1137,7 +1137,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 	// eprintln('>> res.build_options: $res.build_options')
 	res.fill_with_defaults()
 	if res.backend == .c {
-		// res.skip_unused = true
+		res.skip_unused = true
 		if no_skip_unused {
 			res.skip_unused = false
 		}


### PR DESCRIPTION
This PR fixes:

 v -skip-unused test vlib/toml/tests/encode_and_decode_test.v 
 v -skip-unused test vlib/v/debug/interactive_test.v