### PR TITLE
fix: add @[noreturn] to log.fatal

### DIFF
--- a/vlib/log/default.v
+++ b/vlib/log/default.v
@@ -30,6 +30,7 @@ pub fn set_level(level Level) {
 }
 
 // fatal logs a `fatal` message, using the default Logger instance
+@[noreturn]
 pub fn fatal(s string) {
 	default_logger.fatal(s)
 }

--- a/vlib/log/default.v
+++ b/vlib/log/default.v
@@ -33,6 +33,9 @@ pub fn set_level(level Level) {
 @[noreturn]
 pub fn fatal(s string) {
 	default_logger.fatal(s)
+	// the compiler currently has no way to mark functions in an interface
+	// as @[noreturn], so we need to make sure this is never returning ourselves
+	exit(1)
 }
 
 // error logs an `error` message, using the default Logger instance

--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -136,3 +136,13 @@ fn test_log_time_format() {
 	assert true
 	println(@FN + ' end')
 }
+
+fn make_error() ?string {
+	return 'ok'
+}
+
+fn test_log_default_fatal_has_noreturn() {
+	_ := make_error() or {
+		log.fatal('error')
+	}
+}


### PR DESCRIPTION
fixes #22985

Copilot summary:

This pull request includes changes to the logging functionality in the `vlib/log` module. The most important changes include adding the `@[noreturn]` attribute to the `fatal` function and introducing new test cases to ensure the correct behavior of the logging functions.

Improvements to logging functionality:

* [`vlib/log/default.v`](diffhunk://#diff-7671eb5e782297e259983cc77bc1228d162d6c920b24aa21fd04dc58db41b0f2R33-R38): Added the `@[noreturn]` attribute to the `fatal` function to indicate that it will not return, and ensured the function exits the program with `exit(1)` after logging a fatal message.

Enhancements to test cases:

* [`vlib/log/log_test.v`](diffhunk://#diff-4ff05d5b170e6045f6d902c527dfc1e97480a30ebcb196e116a83b558104d777R139-R148): Added a new function `make_error` and a test case `test_log_default_fatal_has_noreturn` to verify that the `fatal` function behaves as expected and does not return.