### PR TITLE
checker: allow array sort with callexpr

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3423,9 +3423,9 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 				} else if left_name == right_name {
 					c.error('`.${method_name}()` cannot use same argument', node.pos)
 				}
-				if node.args[0].expr.left !in [ast.Ident, ast.SelectorExpr, ast.IndexExpr]
-					|| node.args[0].expr.right !in [ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
-					c.error('`.${method_name}()` can only use ident, index or selector as argument, \ne.g. `arr.${method_name}(a < b)`, `arr.${method_name}(a.id < b.id)`, `arr.${method_name}(a[0] < b[0])`',
+				if node.args[0].expr.left !in [ast.CallExpr, ast.Ident, ast.SelectorExpr, ast.IndexExpr]
+					|| node.args[0].expr.right !in [ast.CallExpr, ast.Ident, ast.SelectorExpr, ast.IndexExpr] {
+					c.error('`.${method_name}()` can only use ident, index, selector or call as argument, \ne.g. `arr.${method_name}(a < b)`, `arr.${method_name}(a.id < b.id)`, `arr.${method_name}(a[0] < b[0])`',
 						node.pos)
 				}
 			} else {

--- a/vlib/v/checker/tests/array_fancy_sort_err.out
+++ b/vlib/v/checker/tests/array_fancy_sort_err.out
@@ -1,8 +1,22 @@
-vlib/v/checker/tests/array_fancy_sort_err.vv:6:8: error: `.sort()` can only use ident, index or selector as argument,
+vlib/v/checker/tests/array_fancy_sort_err.vv:6:8: error: `.sort()` can only use `a` or `b` as argument, e.g. `arr.sort(a < b)`
+    4 |     text := os.read_file(os.args[0])!
+    5 |     mut lines := text.split_into_lines()
+    6 |     lines.sort((go a.split('/').last()) < b.split('/').last())
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    7 |     println(lines.join('\n'))
+    8 | }
+vlib/v/checker/tests/array_fancy_sort_err.vv:6:8: error: `.sort()` can only use ident, index, selector or call as argument, 
 e.g. `arr.sort(a < b)`, `arr.sort(a.id < b.id)`, `arr.sort(a[0] < b[0])`
     4 |     text := os.read_file(os.args[0])!
     5 |     mut lines := text.split_into_lines()
-    6 |     lines.sort(a.split('/').last() < b.split('/').last())
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    6 |     lines.sort((go a.split('/').last()) < b.split('/').last())
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    7 |     println(lines.join('\n'))
+    8 | }
+vlib/v/checker/tests/array_fancy_sort_err.vv:6:13: error: infix expr: cannot use `string` (right expression) as `thread string`
+    4 |     text := os.read_file(os.args[0])!
+    5 |     mut lines := text.split_into_lines()
+    6 |     lines.sort((go a.split('/').last()) < b.split('/').last())
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     7 |     println(lines.join('\n'))
     8 | }

--- a/vlib/v/checker/tests/array_fancy_sort_err.vv
+++ b/vlib/v/checker/tests/array_fancy_sort_err.vv
@@ -3,6 +3,6 @@ import os
 fn main() {
 	text := os.read_file(os.args[0])!
 	mut lines := text.split_into_lines()
-	lines.sort(a.split('/').last() < b.split('/').last())
+	lines.sort((go a.split('/').last()) < b.split('/').last())
 	println(lines.join('\n'))
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -707,7 +707,7 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 		left_name := infix_expr.left.str()
 		if left_name.len > 1 {
 			compare_fn += '_by' +
-				left_name[1..].replace_each(['.', '_', '[', '_', ']', '_', "'", '_', '"', '_', '(', '', ')', '', ',', ''])
+				left_name[1..].replace_each(['.', '_', '[', '_', ']', '_', "'", '_', '"', '_', '(', '', ')', '', ',', '', '/', '_'])
 		}
 		// is_reverse is `true` for `.sort(a > b)` and `.sort(b < a)`
 		is_reverse := (left_name.starts_with('a') && infix_expr.op == .gt)

--- a/vlib/v/tests/builtin_arrays/array_sort_with_call_test.v
+++ b/vlib/v/tests/builtin_arrays/array_sort_with_call_test.v
@@ -1,0 +1,16 @@
+struct AB {
+	a int
+	b int
+}
+
+fn (ab AB) value() int {
+	return ab.a + ab.b
+}
+
+fn test_main() {
+	mut values := [AB{5, 6}, AB{3, 4}, AB{1, 2}]
+	values.sort(a.value() < b.value())
+	assert values[0] == AB{1, 2}
+	assert values[1] == AB{3, 4}
+	assert values[2] == AB{5, 6}
+}


### PR DESCRIPTION
Fix #22988

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ3MGEzN2QyZWY0Y2JjYzQ2YmM2NzkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.TgtBjxDiMvVQKOSQwnA1OwmhwcbWlDXFxcnH0ASRJL4">Huly&reg;: <b>V_0.6-21430</b></a></sub>