### PR TITLE
v.util, v.builder, v.cgen: add thread timing stats too, on `-show-timings -stats`

### DIFF
--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -8,6 +8,7 @@ import strings
 import v.util
 import v.pref
 import v.vcache
+import runtime
 
 pub fn (mut b Builder) rebuild_modules() {
 	if !b.pref.use_cache || b.pref.build_mode == .build_module {
@@ -359,7 +360,8 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 		//
 		vlines_per_second := int(1_000_000.0 * f64(all_v_source_lines) / f64(compilation_time_micros))
 		svlines_per_second := util.bold(vlines_per_second.str())
-		println('compilation took: ${scompilation_time_ms} ms, compilation speed: ${svlines_per_second} vlines/s')
+		used_cgen_threads := if b.pref.no_parallel { 1 } else { runtime.nr_jobs() }
+		println('compilation took: ${scompilation_time_ms} ms, compilation speed: ${svlines_per_second} vlines/s, cgen threads: ${used_cgen_threads}')
 	}
 }
 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -667,6 +667,11 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 
 fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) &Gen {
 	file := p.get_item[&ast.File](idx)
+	timing_label_for_thread := 'C GEN thread ${wid}'
+	util.timing_start(timing_label_for_thread)
+	defer {
+		util.timing_measure_cumulative(timing_label_for_thread)
+	}
 	mut global_g := unsafe { &Gen(p.get_shared_context()) }
 	mut g := &Gen{
 		file:                  file


### PR DESCRIPTION
- **builder,cgen: add thread timing stats too when using `-show-timings -stats`**
- **v.util: make thread safe the timing functions**

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ3MWI1YmQyZWY0Y2JjYzQ2YmM5NDUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.cqi7eYE1zV9VDGqtTnjvSY5jl4mrwFizqzAnv2et0ik">Huly&reg;: <b>V_0.6-21431</b></a></sub>