### PR TITLE
cgen: fix sumtype with embedded struct of option field (fix #22984)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6937,7 +6937,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				if sym.info.fields.len > 0 {
 					g.writeln('\t// pointers to common sumtype fields')
 					for field in sym.info.fields {
-						g.type_definitions.writeln('\t${g.styp(field.typ.ref())} ${c_name(field.name)};')
+						g.type_definitions.writeln('\t${g.styp(field.typ)}* ${c_name(field.name)};')
 					}
 				}
 				g.type_definitions.writeln('};')

--- a/vlib/v/tests/sumtypes/sumtype_with_embedded_struct_of_option_field_test.v
+++ b/vlib/v/tests/sumtypes/sumtype_with_embedded_struct_of_option_field_test.v
@@ -1,0 +1,30 @@
+struct Value {
+	x int
+}
+
+struct BValue {
+	v ?Value
+}
+
+struct Word {
+	BValue
+}
+
+struct Long {
+	BValue
+}
+
+struct Variadic {
+	BValue
+}
+
+type Param = Word | Long | Variadic
+
+fn test_sumtype_with_embedded_struct_of_option_field() {
+	a := [Param(Word{}), Long{}, Variadic{}]
+	dump(a)
+	f := a[0]
+	v := f.v
+	dump(v)
+	assert v == none
+}


### PR DESCRIPTION
This PR fix sumtype with embedded struct of option field (fix #22984).

- Fix sumtype with embedded struct of option field.
- Add test.

```v
struct Value {
	x int
}

struct BValue {
	v ?Value
}

struct Word {
	BValue
}

struct Long {
	BValue
}

struct Variadic {
	BValue
}

type Param = Word | Long | Variadic

fn main() {
	a := [Param(Word{}), Long{}, Variadic{}]
	dump(a)
	f := a[0]
	v := f.v
	dump(v)
	assert v == none
}

PS D:\Test\v\tt1> v run .
[.\\tt1.v:25] a: [Param(Word{
    BValue: BValue{
        v: Option(none)
    }
}), Param(Long{
    BValue: BValue{
        v: Option(none)
    }
}), Param(Variadic{
    BValue: BValue{
        v: Option(none)
    }
})]
[.\\tt1.v:28] v: Option(none)
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ4MDc4MWQyZWY0Y2JjYzQ2YmU1MGUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.eY5HlxzqggwOQICYeCKkZYjWV-77N8DojQdm1wL09b8">Huly&reg;: <b>V_0.6-21437</b></a></sub>