### PR TITLE
cgen: fix autostr for interface with circular type

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -420,17 +420,22 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 			fn_builder.write_string2('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
 				' return ${res};')
 		} else {
-			mut val := '${func_name}(${deref}(${sub_sym.cname}*)x._${sub_sym.cname}'
-			if should_use_indent_func(sub_sym.kind) && !sym_has_str_method {
-				val += ', indent_count'
+			if !(sub_sym.kind == .array && g.table.sym(g.table.value_type(typ)).cname == styp) {
+				mut val := '${func_name}(${deref}(${sub_sym.cname}*)x._${sub_sym.cname}'
+				if should_use_indent_func(sub_sym.kind) && !sym_has_str_method {
+					val += ', indent_count'
+				}
+				val += ')'
+				res := 'str_intp(2, _MOV((StrIntpData[]){
+					{_SLIT("${clean_interface_v_type_name}("), ${si_s_code}, {.d_s = ${val}}},
+					{_SLIT(")"), 0, {.d_c = 0 }}
+				}))'
+				fn_builder.write_string2('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
+					' return ${res};\n')
+			} else {
+				fn_builder.write_string2('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
+					' return _SLIT("<circular>");\n')
 			}
-			val += ')'
-			res := 'str_intp(2, _MOV((StrIntpData[]){
-				{_SLIT("${clean_interface_v_type_name}("), ${si_s_code}, {.d_s = ${val}}},
-				{_SLIT(")"), 0, {.d_c = 0 }}
-			}))'
-			fn_builder.write_string2('\tif (x._typ == _${styp}_${sub_sym.cname}_index)',
-				' return ${res};\n')
 		}
 	}
 	fn_builder.writeln('\treturn _SLIT("unknown interface value");')

--- a/vlib/v/tests/printing/dump_interface_circular_test.v
+++ b/vlib/v/tests/printing/dump_interface_circular_test.v
@@ -1,0 +1,10 @@
+interface Any {}
+
+fn test_main() {
+	mut a := []Any{}
+	a.insert(0, Any(5))
+	a.insert(1, Any(5.0))
+	a.insert(2, Any(a[0]))
+	a.insert(3, Any(a)) // Terminated by signal 11 (SIGSEGV)
+	assert dump('${a}') == '[Any(5), Any(5.0), Any(5), <circular>]'
+}


### PR DESCRIPTION
Fix #23022

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRiOTg0YmQyZWY0Y2JjYzQ2Y2YxOTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.1ob6u5fq9YfonAJfeJ2UYB08XCTs4XogPo1uUjGQPJM">Huly&reg;: <b>V_0.6-21467</b></a></sub>