### PR TITLE
x.json2.decoder2: nested map

### DIFF
--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -322,7 +322,7 @@ fn (mut checker Decoder) check_json_format(val string) ! {
 					}
 				}
 			}
-			if checker.checker_idx < checker_end - 1 {
+			if checker.checker_idx < checker_end - 2 {
 				checker.checker_idx++
 			}
 		}
@@ -748,9 +748,12 @@ fn (mut decoder Decoder) decode_map[K, V](mut val map[K]V) ! {
 
 			mut map_value := V{}
 
-			decoder.decode_value(mut map_value)!
-
-			val[key] = map_value
+			$if V is $map {
+				val[key] = map_value.move()
+			} $else {
+				val[key] = map_value
+			}
+			decoder.decode_value(mut val[key])!
 		}
 	}
 }

--- a/vlib/x/json2/decoder2/tests/decode_object_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_object_test.v
@@ -39,14 +39,16 @@ fn test_array_of_strings() {
 	assert json.decode[map[string]string]('{"val": "2"}')! == {
 		'val': '2'
 	}
-	// assert json.decode[map[string]int]('{"val": 2}')! == {"val": 2}
+	assert json.decode[map[string]int]('{"val": 2}')! == {
+		'val': 2
+	}
 
-	// // nested map
-	// assert json.decode[map[string]map[string]string]('{"val": {"val2": "2"}}')! == {
-	// 	'val': {
-	// 		'val2': '2'
-	// 	}
-	// }
+	// nested map
+	assert json.decode[map[string]map[string]string]('{"val": {"val2": "2"}}')! == {
+		'val': {
+			'val2': '2'
+		}
+	}
 
 	// nested struct
 	assert json.decode[Stru]('{"val": 1, "val2": "lala", "val3": {"a": 2, "brazilian_steak": "leleu"}}')! == Stru{


### PR DESCRIPTION
Note: pretty useful code to find and fix json related bugs. maybe I should bind it in debug a day

```v
@[direct_array_access; manualfree]
pub fn push_bytes_repeatedly_into_the_buffer(byte_ u8, repetitions int, mut buffer []u8) {
	if repetitions <= 0 {
		return
	}

	mut bytes_ptr := unsafe { malloc_noscan(repetitions + 1) }

	unsafe {
		C.memset(bytes_ptr, byte_, repetitions)

		buffer.push_many(bytes_ptr, repetitions)

		free(bytes_ptr)
	}
}

// str_info returns a string representation of the linked list.
pub fn (list LinkedList) str_info(json string) string {
	mut result_buffer := []u8{}
	result_buffer << u8(\n)

	mut current := list.head
	for current != unsafe { nil } {
		value_kind_as_string := current.value.value_kind.str()
		unsafe {
			result_buffer.push_many(json.str + current.value.position, current.value.length)
			result_buffer << u8(` `)
			result_buffer << u8(<)
			result_buffer << u8(-)
			result_buffer << u8(` `)
			result_buffer.push_many(value_kind_as_string.str, value_kind_as_string.len)
			result_buffer << u8(\n)

			push_bytes_repeatedly_into_the_buffer(u8(^), current.value.length, mut result_buffer)

			result_buffer << u8(\n)
		}
		current = current.next
	}
	return result_buffer.bytestr()
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRiYzVlMGQyZWY0Y2JjYzQ2Y2Y1OGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.mPn2FVtcAwCmpcnJuZ-0A1GgTry_AWXwFYPV-_HgNpg">Huly&reg;: <b>V_0.6-21468</b></a></sub>