### PR TITLE
v: optimize arr.filter(...).len operation

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -832,6 +832,7 @@ pub mut:
 	from_embed_types       []Type // holds the type of the embed that the method is called from
 	comments               []Comment
 	is_return_used         bool // return value is used for another expr
+	is_return_discarded    bool // return value will not be stored (e.g. a.filter(...).len)
 	//
 	is_expand_simple_interpolation bool // true, when the function/method is marked as @[expand_simple_interpolation]
 	// Calls to it with an interpolation argument like `b.f('x ${y}')`, will be converted to `b.f('x ')` followed by `b.f(y)`.

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4207,6 +4207,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if is_as_cast {
 		g.write(')')
 	}
+	optmized_filter := final_sym.kind == .array && node.field_name == 'len'
+		&& node.expr is ast.CallExpr && node.expr.name == 'filter' && node.expr.is_return_discarded
+	if optmized_filter {
+		return
+	}
 	// struct embedding
 	if sym.info in [ast.Struct, ast.Aggregate] {
 		if node.generic_from_embed_types.len > 0 && sym.info is ast.Struct {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -3432,6 +3432,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	mut left_node := unsafe { left }
 	if mut left_node is ast.CallExpr {
 		left_node.is_return_used = true
+		left_node.is_return_discarded = true
 	}
 	return sel_expr
 }


### PR DESCRIPTION
This PR removes the array allocation for result on `array.filter()` when its result is used to check only its `.len`.

Related to #23028

```v
a := []int{len: 20000000, init:index}
assert a.filter(it%2).len > 0
```

816ms (master)
422ms (pr)

Before:

```c
Array_int _t2 = {0};
        Array_int _t2_orig = a;
        int _t2_len = _t2_orig.len;
        _t2 = __new_array_noscan(0, _t2_len, sizeof(int));

        for (int _t3 = 0; _t3 < _t2_len; ++_t3) {
                int it = ((int*) _t2_orig.data)[_t3];
                if ((int)(it % 2)) {
                        array_push_noscan((array*)&_t2, &it);
                }
        }
        println(int_str(_t2.len));
```

After:

```c
int _t2 = 0;
        Array_int _t2_orig = a;
        int _t2_len = _t2_orig.len;
        for (int _t3 = 0; _t3 < _t2_len; ++_t3) {
                int it = ((int*) _t2_orig.data)[_t3];
                if ((int)(it % 2)) {
                        ++_t2;
                }
        }
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRjNDc4NGQyZWY0Y2JjYzQ2Y2ZlYTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.idehsCidtK8Bs4-hy9iwoXXLfQMiD1A_H6Ii9gXyFGs">Huly&reg;: <b>V_0.6-21471</b></a></sub>