### PR TITLE
orm: fix mark as used var on insert statement

### DIFF
--- a/vlib/v/checker/tests/orm_unused_var.out
+++ b/vlib/v/checker/tests/orm_unused_var.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/orm_unused_var.vv:15:2: warning: unused variable: `x_id`
+   13 | 
+   14 |     x := Test{}
+   15 |     x_id := sql db {
+      |     ~~~~
+   16 |         insert x into Test
+   17 |     } or { panic(err) }

--- a/vlib/v/checker/tests/orm_unused_var.vv
+++ b/vlib/v/checker/tests/orm_unused_var.vv
@@ -1,0 +1,18 @@
+import db.sqlite
+
+struct Test {
+	id int @[primary; serial]
+}
+
+fn main() {
+	db := sqlite.connect(':memory:')!
+
+	sql db {
+		create table Test
+	}!
+
+	x := Test{}
+	x_id := sql db {
+		insert x into Test
+	} or { panic(err) }
+}

--- a/vlib/v/compiler_errors_test.v
+++ b/vlib/v/compiler_errors_test.v
@@ -20,6 +20,7 @@ const skip_on_ubuntu_musl = [
 	'vlib/v/checker/tests/vweb_tmpl_used_var.vv',
 	'vlib/v/checker/tests/vweb_routing_checks.vv',
 	'vlib/v/checker/tests/orm_op_with_option_and_none.vv',
+	'vlib/v/checker/tests/orm_unused_var.vv',
 	'vlib/v/tests/skip_unused/gg_code.vv',
 ]
 

--- a/vlib/v/parser/orm.v
+++ b/vlib/v/parser/orm.v
@@ -30,6 +30,7 @@ fn (mut p Parser) sql_expr() ast.Expr {
 	mut is_count := false
 	if is_insert {
 		inserted_var = p.check_name()
+		p.scope.mark_var_as_used(inserted_var)
 		into := p.check_name()
 		if into != 'into' {
 			p.error('expecting `into`')


### PR DESCRIPTION
Fix #23032

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRjYTBkOWQyZWY0Y2JjYzQ2ZDA5ZTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.HvWcDQWAigqr5yLpIVAT9nxUBZgO22j3naRbnQHmzbQ">Huly&reg;: <b>V_0.6-21478</b></a></sub>