### PR TITLE
orm: fix list generation and escape loose backtick

### DIFF
--- a/vlib/orm/README.md
+++ b/vlib/orm/README.md
@@ -33,7 +33,8 @@ struct Foo {
 - `[sql_type: 'SQL TYPE']` explicitly sets the type in SQL
 - `[default: 'raw_sql']` inserts `raw_sql` verbatim in a "DEFAULT" clause when
   creating a new table, allowing for SQL functions like `CURRENT_TIME`. For raw strings, 
-  surround `raw_sql` with backticks (`).
+  surround `raw_sql` with backticks (\`).
+
 - `[fkey: 'parent_id']` sets foreign key for an field which holds an array
 
 ## Usage


### PR DESCRIPTION
The loose backtick will look ahead to the next backtick, which is on the next line, which messes up the whole list. Also I had to insert a newline for some reason to get it to generate properly.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRjYWIzMWQyZWY0Y2JjYzQ2ZDBjYjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Bzh8pfKPXQmjcmmrTg1VKxpeYhnMUYWoyNv9XERAxZM">Huly&reg;: <b>V_0.6-21479</b></a></sub>