### PR TITLE
cgen: fix callexpr or-expr codegen on const decl

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -949,6 +949,10 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	tmp_opt := if gen_or || gen_keep_alive {
 		if g.inside_curry_call && g.last_tmp_call_var.len > 0 {
 			g.last_tmp_call_var.pop()
+		} else if !g.inside_or_block {
+			new_tmp := g.new_tmp_var()
+			g.last_tmp_call_var << new_tmp
+			new_tmp
 		} else {
 			g.new_tmp_var()
 		}
@@ -1031,7 +1035,11 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 					g.write('\n ${cur_line}')
 				}
 			} else {
-				g.write('\n ${cur_line} ${tmp_opt}')
+				if !g.inside_or_block && g.last_tmp_call_var.len > 0 {
+					g.write('\n\t*(${unwrapped_styp}*)${g.last_tmp_call_var.pop()}.data = ${cur_line}(*(${unwrapped_styp}*)${tmp_opt}.data)')
+				} else {
+					g.write('\n ${cur_line}(*(${unwrapped_styp}*)${tmp_opt}.data)')
+				}
 			}
 		}
 	} else if gen_keep_alive {

--- a/vlib/v/tests/fns/const_call_or_expr_test.v
+++ b/vlib/v/tests/fns/const_call_or_expr_test.v
@@ -1,7 +1,11 @@
 import os
 
 const vdir = os.getenv_opt('VDIR') or { os.dir(os.getenv_opt('VEXE') or { os.getwd() }) }
+const vdir2 = os.getenv_opt('NON_EXISTENT')
+const vdir3 = os.getenv_opt('NON_EXISTENT') or { '' }
 
 fn test_main() {
 	assert vdir.len > 0
+	assert vdir2 == none
+	assert vdir3 == ''
 }

--- a/vlib/v/tests/fns/const_call_or_expr_test.v
+++ b/vlib/v/tests/fns/const_call_or_expr_test.v
@@ -1,0 +1,7 @@
+import os
+
+const vdir = os.getenv_opt('VDIR') or { os.dir(os.getenv_opt('VEXE') or { os.getwd() }) }
+
+fn test_main() {
+	assert vdir.len > 0
+}


### PR DESCRIPTION
Fix #23029

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRjZDNmMGQyZWY0Y2JjYzQ2ZDEyNzciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.yHSnjgbAPOPAPB9h--dlvCTCBshNboyWavPuUpQiHUg">Huly&reg;: <b>V_0.6-21483</b></a></sub>