### PR TITLE
cgen: minor cleanup in gen_jsons()

### DIFF
--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -139,7 +139,7 @@ ${enc_fn_dec} {
 \tcJSON *o;')
 		if is_js_prim(sym.name) && utyp.is_ptr() {
 			g.gen_prim_enc_dec(utyp, mut enc, mut dec)
-		} else if sym.kind == .array || sym.kind == .array_fixed {
+		} else if sym.kind in [.array, .array_fixed] {
 			array_size := if sym.kind == .array_fixed {
 				(sym.info as ast.ArrayFixed).size
 			} else {


### PR DESCRIPTION
This PR makes a minor cleanup in gen_jsons().

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRkMjY5MGQyZWY0Y2JjYzQ2ZDQxMTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.KSm4u9l3dPk9M8SN-qfMXwUjPXe1eXm6CCdX_Kyoxp8">Huly&reg;: <b>V_0.6-21484</b></a></sub>