### PR TITLE
checker: fix generic fn returning generic closure (fix #23035)

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -267,6 +267,11 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				if c.inside_lambda && exp_type.has_flag(.generic) {
 					continue
 				}
+				// ignore return closure
+				if node.exprs[expr_idxs[i]] is ast.AnonFn
+					&& node.exprs[expr_idxs[i]].inherited_vars.len > 0 {
+					continue
+				}
 				c.error('cannot use `${got_type_name}` as ${c.error_type_name(exp_type)} in return argument',
 					pos)
 			}

--- a/vlib/v/tests/generics/generics_return_closure_test.v
+++ b/vlib/v/tests/generics/generics_return_closure_test.v
@@ -1,0 +1,19 @@
+fn vectorize[T](op fn (T) T) fn ([]T) []T {
+	return fn [op] [T](values []T) []T {
+		mut result := []T{len: values.len}
+		for i in 0 .. values.len {
+			result[i] = op(values[i])
+		}
+		return result
+	}
+}
+
+fn add_one(x f64) f64 {
+	return x + 1
+}
+
+fn test_return_generic_closure() {
+	vadd := vectorize[f64](add_one)
+	v := [1.0, 2, 3, 4]
+	assert vadd(v) == [2.0, 3, 4, 5]
+}


### PR DESCRIPTION
This PR fix generic fn returning generic closure (fix #23035).

- Fix generic fn returning generic closure.
- Add test.

```v
fn vectorize[T](op fn (T) T) fn ([]T) []T {
	return fn [op] [T](values []T) []T {
		mut result := []T{len: values.len}
		for i in 0 .. values.len {
			result[i] = op(values[i])
		}
		return result
	}
}

fn add_one(x f64) f64 {
	return x + 1
}

fn main() {
	vadd := vectorize[f64](add_one)
	v := [1.0, 2, 3, 4]
	println(vadd(v))
	assert vadd(v) == [2.0, 3, 4, 5]
}

PS D:\Test\v\tt1> v run .
[2.0, 3.0, 4.0, 5.0]
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRkNzIxZGQyZWY0Y2JjYzQ2ZDU3NjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.OvAiBrRSa1WUB3TTldBWANHTjg7JLbizSoUA4eaeBHU">Huly&reg;: <b>V_0.6-21487</b></a></sub>