### PR TITLE
v.reflection: fix codegen to work with quoted strings on attr value

### DIFF
--- a/vlib/v/gen/c/reflection.v
+++ b/vlib/v/gen/c/reflection.v
@@ -95,7 +95,11 @@ fn (g &Gen) gen_attrs_array(attrs []ast.Attr) string {
 	}
 	mut out := 'new_array_from_c_array(${attrs.len},${attrs.len},sizeof(string),'
 	out += '_MOV((string[${attrs.len}]){'
-	out += attrs.map(if it.has_arg { '_SLIT("${it.name}=${it.arg}")' } else { '_SLIT("${it.name}")' }).join(',')
+	out += attrs.map(if it.has_arg {
+		'_SLIT("${it.name}=${escape_quotes(it.arg)}")'
+	} else {
+		'_SLIT("${it.name}")'
+	}).join(',')
 	out += '}))'
 	return out
 }

--- a/vlib/v/tests/reflection_attr_quotes_test.v
+++ b/vlib/v/tests/reflection_attr_quotes_test.v
@@ -1,0 +1,16 @@
+import v.reflection as r
+
+struct MyParams {
+	p_fpga_ver string @[long: fp_ver; name: 'FPGA Version'; xdoc: 'String to use as simulated FPGA version in Version responses. Must be in the form "a.bb.cccc"']
+	p_cm_ver   string @[long: cm_ver; name: 'CM Version'; xdoc: 'String to use as simulated CM version in Version responses. Must be in the form "a.bb.cccc"']
+}
+
+fn test_main() {
+	a := MyParams{}
+	t := r.type_of(a)
+	if t.sym.info is r.Struct {
+		assert t.sym.info.fields[0].attrs[2] == 'xdoc=String to use as simulated FPGA version in Version responses. Must be in the form "a.bb.cccc"'
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
Fix #23046

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRkYmMyMGQyZWY0Y2JjYzQ2ZDY3MzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lZenE7HlN8O_EHluxQssFehJHuU_kt6TkLGJyx_brIo">Huly&reg;: <b>V_0.6-21490</b></a></sub>