### PR TITLE
markused: make some attrs on `@[translated]` be implicit `@[markused]` + fix FnDecl visitor (when no_body is present)

### DIFF
--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -610,6 +610,9 @@ pub fn (mut w Walker) fn_decl(mut node ast.FnDecl) {
 	if w.used_fns[fkey] {
 		return
 	}
+	if node.no_body {
+		return
+	}
 	w.mark_fn_as_used(fkey)
 	w.stmts(node.stmts)
 	w.defer_stmts(node.defer_stmts)


### PR DESCRIPTION
This PR fixes V DOOM build with `-skip-unused` without code changes on the project.

On `-translated` ... with this PR:
Functions tagged by `@[c:'foo']` are implicitly marked as useds.
Constantes tagged by `@[export: '']` are implicitly marked as useds.

This PR also fixes markused on source that has fn prototype + fn declaration. Before this PR the declaration that was traversed was the no_body one, so no code was visited.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRkZGMzNWQyZWY0Y2JjYzQ2ZDZkMzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.5pOmGOzW3u1WwAbqkMmUpencV41jCo-QWLl-H9BnA9I">Huly&reg;: <b>V_0.6-21492</b></a></sub>