### PR TITLE
checker: fix missing checker for cast from mut var to non-ptr type

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3614,9 +3614,8 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.error('cannot cast `${ft}` ${kind_name} value to `${tt}`, use `${node.expr} as ${tt}` instead',
 			node.pos)
 	}
-	if from_sym.language == .v && from_type.is_ptr() && !to_type.is_ptr() && !to_type.is_int()
-		&& to_type != ast.voidptr_type && !node.expr.is_auto_deref_var()
-		&& final_to_sym.kind != .interface {
+	if from_sym.language == .v && from_type.is_ptr() && !to_type.is_ptr()
+		&& !node.expr.is_auto_deref_var() && final_to_sym.kind == .struct {
 		ft := c.table.type_to_str(from_type)
 		tt := c.table.type_to_str(to_type)
 		c.error('cannot cast `${ft}` to `${tt}`, you must dereference it first (e.g. ${tt}(*var))',

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3614,6 +3614,14 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.error('cannot cast `${ft}` ${kind_name} value to `${tt}`, use `${node.expr} as ${tt}` instead',
 			node.pos)
 	}
+	if from_sym.language == .v && from_type.is_ptr() && !to_type.is_ptr() && !to_type.is_int()
+		&& to_type != ast.voidptr_type && !node.expr.is_auto_deref_var()
+		&& final_to_sym.kind != .interface {
+		ft := c.table.type_to_str(from_type)
+		tt := c.table.type_to_str(to_type)
+		c.error('cannot cast `${ft}` to `${tt}`, you must dereference it first (e.g. ${tt}(*var))',
+			node.pos)
+	}
 
 	if node.has_arg {
 		c.expr(mut node.arg)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3614,7 +3614,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.error('cannot cast `${ft}` ${kind_name} value to `${tt}`, use `${node.expr} as ${tt}` instead',
 			node.pos)
 	}
-	if from_sym.language == .v && from_type.is_ptr() && !to_type.is_ptr()
+	if from_sym.language == .v && from_type.is_ptr() && !final_to_type.is_ptr()
 		&& !node.expr.is_auto_deref_var() && final_to_sym.kind == .struct
 		&& final_from_sym.kind == .struct {
 		if c.check_struct_signature(final_from_sym.info as ast.Struct, final_to_sym.info as ast.Struct) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3615,11 +3615,14 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			node.pos)
 	}
 	if from_sym.language == .v && from_type.is_ptr() && !to_type.is_ptr()
-		&& !node.expr.is_auto_deref_var() && final_to_sym.kind == .struct {
-		ft := c.table.type_to_str(from_type)
-		tt := c.table.type_to_str(to_type)
-		c.error('cannot cast `${ft}` to `${tt}`, you must dereference it first (e.g. ${tt}(*var))',
-			node.pos)
+		&& !node.expr.is_auto_deref_var() && final_to_sym.kind == .struct
+		&& final_from_sym.kind == .struct {
+		if c.check_struct_signature(final_from_sym.info as ast.Struct, final_to_sym.info as ast.Struct) {
+			ft := c.table.type_to_str(from_type)
+			tt := c.table.type_to_str(to_type)
+			c.error('cannot cast `${ft}` to `${tt}`, you must dereference it first (e.g. ${tt}(*var))',
+				node.pos)
+		}
 	}
 
 	if node.has_arg {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3614,7 +3614,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.error('cannot cast `${ft}` ${kind_name} value to `${tt}`, use `${node.expr} as ${tt}` instead',
 			node.pos)
 	}
-	if from_sym.language == .v && from_type.is_ptr() && !final_to_type.is_ptr()
+	if from_sym.language == .v && from_type.is_ptr() && !to_type.is_ptr() && !final_to_type.is_ptr()
 		&& !node.expr.is_auto_deref_var() && final_to_sym.kind == .struct
 		&& final_from_sym.kind == .struct {
 		if c.check_struct_signature(final_from_sym.info as ast.Struct, final_to_sym.info as ast.Struct) {

--- a/vlib/v/checker/tests/cast_to_concrete_mut_err.out
+++ b/vlib/v/checker/tests/cast_to_concrete_mut_err.out
@@ -1,13 +1,13 @@
 vlib/v/checker/tests/cast_to_concrete_mut_err.vv:37:12: warning: casting `&Message` to `&LocalMessageType` is only allowed in `unsafe` code
    35 |     if mut mdef is Message {
-   36 |         mut a := LocalMessageType(*mdef) // works. with -live: Unhandled Exception 0xC0000005
-   37 |         mut b := &LocalMessageType(mdef) // works, warning. with -live: Unhandled Exception 0xC0000005
+   36 |         mut a := LocalMessageType(*mdef)
+   37 |         mut b := &LocalMessageType(mdef)
       |                  ~~~~~~~~~~~~~~~~~~~~~~~
    38 |         mut c := LocalMessageType(mdef)
    39 |
 vlib/v/checker/tests/cast_to_concrete_mut_err.vv:38:12: error: cannot cast `&Message` to `LocalMessageType`, you must dereference it first (e.g. LocalMessageType(*var))
-   36 |         mut a := LocalMessageType(*mdef) // works. with -live: Unhandled Exception 0xC0000005
-   37 |         mut b := &LocalMessageType(mdef) // works, warning. with -live: Unhandled Exception 0xC0000005
+   36 |         mut a := LocalMessageType(*mdef)
+   37 |         mut b := &LocalMessageType(mdef)
    38 |         mut c := LocalMessageType(mdef)
       |                  ~~~~~~~~~~~~~~~~~~~~~~
    39 | 

--- a/vlib/v/checker/tests/cast_to_concrete_mut_err.out
+++ b/vlib/v/checker/tests/cast_to_concrete_mut_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/cast_to_concrete_mut_err.vv:37:12: warning: casting `&Message` to `&LocalMessageType` is only allowed in `unsafe` code
+   35 |     if mut mdef is Message {
+   36 |         mut a := LocalMessageType(*mdef) // works. with -live: Unhandled Exception 0xC0000005
+   37 |         mut b := &LocalMessageType(mdef) // works, warning. with -live: Unhandled Exception 0xC0000005
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~
+   38 |         mut c := LocalMessageType(mdef)
+   39 |
+vlib/v/checker/tests/cast_to_concrete_mut_err.vv:38:12: error: cannot cast `&Message` to `LocalMessageType`, you must dereference it first (e.g. LocalMessageType(*var))
+   36 |         mut a := LocalMessageType(*mdef) // works. with -live: Unhandled Exception 0xC0000005
+   37 |         mut b := &LocalMessageType(mdef) // works, warning. with -live: Unhandled Exception 0xC0000005
+   38 |         mut c := LocalMessageType(mdef)
+      |                  ~~~~~~~~~~~~~~~~~~~~~~
+   39 | 
+   40 |         dump(a)

--- a/vlib/v/checker/tests/cast_to_concrete_mut_err.vv
+++ b/vlib/v/checker/tests/cast_to_concrete_mut_err.vv
@@ -1,0 +1,58 @@
+module main
+
+pub struct Message {
+pub mut:
+	text string = 'Init'
+	m2   ?&Message
+}
+
+pub fn (mut m Message) update_text(new_text string) {
+	m.text = new_text
+}
+
+pub fn (mut m Message) update_ext_text(new_text string) {
+	m.m2?.text = new_text
+}
+
+type LocalMessageType = Message
+
+interface IMessage {
+mut:
+	text string
+	update_text(new_text string)
+}
+
+struct App {
+mut:
+	message &IMessage
+}
+
+pub fn (mut m LocalMessageType) update_text_externally(new_text string) {
+	m.text = new_text
+}
+
+fn print_message(mut mdef IMessage) {
+	if mut mdef is Message {
+		mut a := LocalMessageType(*mdef) // works. with -live: Unhandled Exception 0xC0000005
+		mut b := &LocalMessageType(mdef) // works, warning. with -live: Unhandled Exception 0xC0000005
+		mut c := LocalMessageType(mdef)
+
+		dump(a)
+		dump(b)
+		dump(c)
+	}
+}
+
+fn test_main() {
+	mut m2 := &Message{
+		text: 'Init External'
+	}
+	mut mdef := &Message{
+		text: 'Init'
+		m2:   m2
+	}
+	mut app := &App{
+		message: mdef
+	}
+	print_message(mut app.message)
+}

--- a/vlib/v/checker/tests/cast_to_concrete_mut_err.vv
+++ b/vlib/v/checker/tests/cast_to_concrete_mut_err.vv
@@ -33,8 +33,8 @@ pub fn (mut m LocalMessageType) update_text_externally(new_text string) {
 
 fn print_message(mut mdef IMessage) {
 	if mut mdef is Message {
-		mut a := LocalMessageType(*mdef) // works. with -live: Unhandled Exception 0xC0000005
-		mut b := &LocalMessageType(mdef) // works, warning. with -live: Unhandled Exception 0xC0000005
+		mut a := LocalMessageType(*mdef)
+		mut b := &LocalMessageType(mdef)
 		mut c := LocalMessageType(mdef)
 
 		dump(a)


### PR DESCRIPTION
Fix #23017

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRlZTRmOWQyZWY0Y2JjYzQ2ZGM0NjMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Xvf9dfnmx4nG4Q5Qwc4efAuEUF4imrk7fNFWv1rsPJ0">Huly&reg;: <b>V_0.6-21496</b></a></sub>