### PR TITLE
Fix teamcity reporter message formatting

### DIFF
--- a/vlib/v/preludes/test_runner_teamcity.v
+++ b/vlib/v/preludes/test_runner_teamcity.v
@@ -65,8 +65,8 @@ fn (mut runner TeamcityTestRunner) fn_start() bool {
 	println(term.gray(msg))
 
 	runner.print_service("
-		|##teamcity[
-		|testStarted name='${runner.fname}'
+		|##teamcity[testStarted
+		|name='${runner.fname}'
 		|locationHint='v_qn://${runner.file_test_info.file}:${runner.fname}'
 		|]".strip_margin())
 	return true
@@ -124,8 +124,8 @@ fn (mut runner TeamcityTestRunner) fn_fail() {
 	details := 'See failed assertion: ${assertion.fpath}:${assertion.line_nr + 1}'
 
 	runner.print_service("
-		 |##teamcity[
-		 |testFailed name='${runner.fname}'
+		 |##teamcity[testFailed
+		 |name='${runner.fname}'
 		 |duration='${duration}'
 		 |details='${details}'
 		 |type='comparisonFailure'
@@ -161,6 +161,7 @@ fn (mut runner TeamcityTestRunner) print_service(msg string) {
 	without_new_lines := msg
 		.trim('\n\r ')
 		.replace('\r', '')
+		.replace('\n]', ']')
 		.replace('\n', ' ')
 	eprintln(without_new_lines)
 }


### PR DESCRIPTION
Running tests in intellij idea 2024.3 makes IDE panic and report following error:

```Failed to parse service message
Details: ##teamcity[ testFailed name='test_failing' duration='0' details='See failed assertion: /home/jakub/repos/villmo/src/villmo/gen/llvm/simple_test.v:12' type='comparisonFailure' actual='4' expected='100' message='Assertion "four == 100" failed' ]
testFramework:V Test

java.text.ParseException: Error while parsing TeamCity service message: Incorrect property name "testFailed name": should not contain spaces. Valid service message has a form of "##teamcity[messageName name1='escaped_value' name2='escaped_value']" where escaped_value uses substitutions: '->|', [->|[, ]->|], |->||, newline->|n
	at jetbrains.buildServer.messages.serviceMessages.MapSerializerUtil.parseName(MapSerializerUtil.java:156)
	at jetbrains.buildServer.messages.serviceMessages.MapSerializerUtil.stringToProperties(MapSerializerUtil.java:116)
	at jetbrains.buildServer.messages.serviceMessages.ServiceMessage.parseAttributes(ServiceMessage.java:237)
	at jetbrains.buildServer.messages.serviceMessages.ServiceMessage.init(ServiceMessage.java:371)
(...)
```

Apparently whitespaces are significant in the protocol and spaces cannot occur before message name and before closing tag. This PR fixes this.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzUwYmVkZmQyZWY0Y2JjYzQ2ZWEwOWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.orVn5N3med_foR5BWhrSTPbLcmy7wSxTj9bmE5IZoN0">Huly&reg;: <b>V_0.6-21505</b></a></sub>