### PR TITLE
cgen: fix cast interface value in match expr (fix #23060)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5302,6 +5302,12 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 			g.expr_with_opt(node.expr, expr_type, sym.info.parent_type)
 		} else {
 			g.write('(${cast_label}(')
+			if node.expr is ast.Ident {
+				if !node.typ.is_ptr() && node.expr_type.is_ptr() && node.expr.obj is ast.Var
+					&& node.expr.obj.smartcasts.len > 0 {
+					g.write('*'.repeat(node.expr_type.nr_muls()))
+				}
+			}
 			if sym.kind == .alias && g.table.final_sym(node.typ).kind == .string {
 				ptr_cnt := node.typ.nr_muls() - expr_type.nr_muls()
 				if ptr_cnt > 0 {

--- a/vlib/v/tests/casts/cast_interface_value_in_match_test.v
+++ b/vlib/v/tests/casts/cast_interface_value_in_match_test.v
@@ -1,0 +1,24 @@
+interface Number2 {}
+
+fn t(v Number2) {
+	match v {
+		int, i32, isize, i64 {
+			x := isize(v)
+			println(x)
+			assert x == 42
+		}
+		else {}
+	}
+	match v {
+		int {
+			x := isize(v)
+			println(x)
+			assert x == 42
+		}
+		else {}
+	}
+}
+
+fn test_cast_interface_value_in_match() {
+	t(int(42))
+}


### PR DESCRIPTION
This PR fix cast interface value in match expr (fix #23060).

- Fix cast interface value in match expr.
- Add test.

```v
interface Number2 {}

fn t(v Number2) {
	match v {
		int, i32, isize, i64 {
			x := isize(v)
			println(x)
			assert x == 42
		}
		else {}
	}
	match v {
		int {
			x := isize(v)
			println(x)
			assert x == 42
		}
		else {}
	}
}

fn main() {
	t(int(42))
}

PS D:\Test\v\tt1> v run .       
42
42
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzUxNjc4ZGQyZWY0Y2JjYzQ2ZWM2YjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.aHvyD-V7Y-Og3FNwlRihPRUiamOnfC8gRUMx6_Pyhlg">Huly&reg;: <b>V_0.6-21508</b></a></sub>