### PR TITLE
markused: remove 2 loops across `all_fns`

### DIFF
--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -441,17 +441,15 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 		all_globals: all_globals
 		pref:        pref_
 	)
-	walker.mark_markused_fn_decls() // tagged with `@[markused]`
 	walker.mark_markused_consts() // tagged with `@[markused]`
 	walker.mark_markused_globals() // tagged with `@[markused]`
-	walker.mark_exported_fns()
+	walker.mark_markused_fns() // tagged with `@[markused]`, `@[export]` and veb actions
 
 	for k, _ in table.used_features.comptime_calls {
 		walker.fn_by_name(k)
 	}
 
 	walker.mark_root_fns(all_fn_root_names)
-	walker.mark_veb_actions()
 
 	if table.used_features.used_maps > 0 {
 		for k, mut mfn in all_fns {

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -91,6 +91,27 @@ pub fn (mut w Walker) mark_global_as_used(ckey string) {
 	}
 }
 
+pub fn (mut w Walker) mark_markused_fns() {
+	for _, mut func in w.all_fns {
+		// @[export]
+		// @[markused]
+		if func.is_exported || func.is_markused {
+			$if trace_skip_unused_exported_fns ? {
+				println('>>>> walking exported func: ${func.name} ...')
+			}
+			w.fn_decl(mut func)
+			continue
+		}
+		// veb actions
+		if func.return_type == w.table.veb_res_idx_cache {
+			$if trace_skip_veb_actions ? {
+				println('>>>> walking veb action func: ${func.name} ...')
+			}
+			w.fn_decl(mut func)
+		}
+	}
+}
+
 pub fn (mut w Walker) mark_root_fns(all_fn_root_names []string) {
 	for fn_name in all_fn_root_names {
 		if fn_name !in w.used_fns {
@@ -98,41 +119,6 @@ pub fn (mut w Walker) mark_root_fns(all_fn_root_names []string) {
 				println('>>>> walking root func: ${fn_name} ...')
 			}
 			unsafe { w.fn_decl(mut w.all_fns[fn_name]) }
-		}
-	}
-}
-
-pub fn (mut w Walker) mark_veb_actions() {
-	for _, mut func in w.all_fns {
-		if func.return_type == w.table.veb_res_idx_cache {
-			// if fn_name !in w.used_fns {
-			$if trace_skip_veb_actions ? {
-				println('>>>> walking veb action func: ${func.name} ...')
-			}
-			w.fn_decl(mut func)
-		}
-		//}
-	}
-}
-
-pub fn (mut w Walker) mark_exported_fns() {
-	for _, mut func in w.all_fns {
-		if func.is_exported {
-			$if trace_skip_unused_exported_fns ? {
-				println('>>>> walking exported func: ${func.name} ...')
-			}
-			w.fn_decl(mut func)
-		}
-	}
-}
-
-pub fn (mut w Walker) mark_markused_fn_decls() {
-	for _, mut func in w.all_fns {
-		if func.is_markused {
-			$if trace_skip_unused_markused_fns ? {
-				println('>>>> walking markused func: ${func.name} ...')
-			}
-			w.fn_decl(mut func)
 		}
 	}
 }

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -97,7 +97,12 @@ pub fn (mut w Walker) mark_markused_fns() {
 		// @[markused]
 		if func.is_exported || func.is_markused {
 			$if trace_skip_unused_exported_fns ? {
-				println('>>>> walking exported func: ${func.name} ...')
+				if func.is_exported {
+					println('>>>> walking exported func: ${func.name} ...')
+				}
+				if func.is_markused {
+					println('>>>> walking markused func: ${func.name} ...')
+				}
 			}
 			w.fn_decl(mut func)
 			continue


### PR DESCRIPTION
markused simplification.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzUxODFlMWQyZWY0Y2JjYzQ2ZWNjNTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.iwb65deH3JOcQPQRmyr01YQB_asGq02uimImnejtvig">Huly&reg;: <b>V_0.6-21510</b></a></sub>