### PR TITLE
cgen: fix smartcast codegen for msvc

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2151,9 +2151,9 @@ pub fn (expr Expr) is_blank_ident() bool {
 @[inline]
 pub fn (expr Expr) is_as_cast() bool {
 	if expr is ParExpr {
-		return expr.expr.is_ascast()
+		return expr.expr.is_as_cast()
 	} else if expr is SelectorExpr {
-		return expr.expr.is_ascast()
+		return expr.expr.is_as_cast()
 	} else {
 		return expr is AsCast
 	}

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2149,7 +2149,7 @@ pub fn (expr Expr) is_blank_ident() bool {
 }
 
 @[inline]
-pub fn (expr Expr) is_ascast() bool {
+pub fn (expr Expr) is_as_cast() bool {
 	if expr is ParExpr {
 		return expr.expr.is_ascast()
 	} else if expr is SelectorExpr {

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2148,6 +2148,17 @@ pub fn (expr Expr) is_blank_ident() bool {
 	return false
 }
 
+@[inline]
+pub fn (expr Expr) is_ascast() bool {
+	if expr is ParExpr {
+		return expr.expr.is_ascast()
+	} else if expr is SelectorExpr {
+		return expr.expr.is_ascast()
+	} else {
+		return expr is AsCast
+	}
+}
+
 __global nested_expr_pos_calls = i64(0)
 // values above 14000 risk stack overflow by default on macos in Expr.pos() calls
 const max_nested_expr_pos_calls = 5000

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7748,6 +7748,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.write('; ')
 			if sym.info is ast.FnType {
 				g.write('(${styp})__as_cast(')
+			} else if g.inside_smartcast {
+				g.write('(${styp}*)__as_cast(')
 			} else {
 				g.write('*(${styp}*)__as_cast(')
 			}
@@ -7810,6 +7812,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.write('; ')
 			if sym.info is ast.FnType {
 				g.write('(${styp})__as_cast(')
+			} else if g.inside_smartcast {
+				g.write('(${styp}*)__as_cast(')
 			} else {
 				g.write('*(${styp}*)__as_cast(')
 			}
@@ -7821,6 +7825,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		} else {
 			if sym.info is ast.FnType {
 				g.write('(${styp})__as_cast(')
+			} else if g.inside_smartcast {
+				g.write('(${styp}*)__as_cast(')
 			} else {
 				g.write('*(${styp}*)__as_cast(')
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2574,7 +2574,7 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 			|| (expr is ast.Ident && expr.obj.is_simple_define_const()) {
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:
-			if expr.is_ascast() {
+			if expr.is_as_cast() {
 				old_inside_smartcast := g.inside_smartcast
 				g.inside_smartcast = true
 				defer {
@@ -4249,7 +4249,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if field_is_opt
 		|| ((node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
 		&& node.from_embed_types.len == 0)
-		|| (node.expr.is_ascast() && g.inside_smartcast) {
+		|| (node.expr.is_as_cast() && g.inside_smartcast) {
 		g.write('->')
 	} else {
 		g.write('.')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2574,7 +2574,7 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 			|| (expr is ast.Ident && expr.obj.is_simple_define_const()) {
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:
-			if expr.is_smartcast() {
+			if expr.is_ascast() {
 				old_expect_ascast_ptr := g.expect_ascast_ptr
 				g.expect_ascast_ptr = true
 				defer {
@@ -4249,7 +4249,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if field_is_opt
 		|| ((node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
 		&& node.from_embed_types.len == 0)
-		|| (node.expr.is_smartcast() && g.expect_ascast_ptr) {
+		|| (node.expr.is_ascast() && g.expect_ascast_ptr) {
 		g.write('->')
 	} else {
 		g.write('.')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -128,6 +128,7 @@ mut:
 	cur_indexexpr             []int          // list of nested indexexpr which generates array_set/map_set
 	shareds                   map[int]string // types with hidden mutex for which decl has been emitted
 	coverage_files            map[u64]&CoverageInfo
+	expect_ascast_ptr         bool
 	inside_ternary            int  // ?: comma separated statements on a single line
 	inside_map_postfix        bool // inside map++/-- postfix expr
 	inside_map_infix          bool // inside map<</+=/-= infix expr
@@ -2573,9 +2574,17 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 			|| (expr is ast.Ident && expr.obj.is_simple_define_const()) {
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:
-			promotion_macro_name := if fname.contains('_to_sumtype_') { 'ADDR' } else { 'HEAP' }
-			g.write('${promotion_macro_name}(${got_styp}, (')
-			rparen_n += 2
+			if expr.is_smartcast() {
+				old_expect_ascast_ptr := g.expect_ascast_ptr
+				g.expect_ascast_ptr = true
+				defer {
+					g.expect_ascast_ptr = old_expect_ascast_ptr
+				}
+			} else {
+				promotion_macro_name := if fname.contains('_to_sumtype_') { 'ADDR' } else { 'HEAP' }
+				g.write('${promotion_macro_name}(${got_styp}, (')
+				rparen_n += 2
+			}
 		} else {
 			g.write('&')
 		}
@@ -4239,7 +4248,8 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	alias_to_ptr := sym.info is ast.Alias && sym.info.parent_type.is_ptr()
 	if field_is_opt
 		|| ((node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
-		&& node.from_embed_types.len == 0) {
+		&& node.from_embed_types.len == 0)
+		|| (node.expr.is_smartcast() && g.expect_ascast_ptr) {
 		g.write('->')
 	} else {
 		g.write('.')
@@ -7749,6 +7759,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		} else {
 			if sym.info is ast.FnType {
 				g.write('(${styp})__as_cast(')
+			} else if g.expect_ascast_ptr {
+				g.write('(${styp}*)__as_cast(')
 			} else {
 				g.write('*(${styp}*)__as_cast(')
 			}
@@ -7833,6 +7845,9 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		}
 	} else {
 		mut is_optional_ident_var := false
+		if g.expect_ascast_ptr {
+			g.write('&')
+		}
 		if node.expr is ast.Ident {
 			if node.expr.info is ast.IdentVar && node.expr.info.is_option
 				&& !unwrapped_node_typ.has_flag(.option) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1922,7 +1922,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		// TODO: same logic in call_args()
 		if !is_range_slice {
 			if !node.left.is_lvalue() {
-				if node.left.is_smartcast() {
+				if node.left.is_ascast() {
 					g.expect_ascast_ptr = true
 					if node.left is ast.SelectorExpr && !left_type.is_ptr() {
 						g.write('&')
@@ -2910,7 +2910,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 						if arg_typ_sym.kind in [.sum_type, .interface] {
 							atype = arg_typ
 						}
-						if arg.expr.is_smartcast() {
+						if arg.expr.is_ascast() {
 							old_expect_ascast_ptr := g.expect_ascast_ptr
 							g.expect_ascast_ptr = true
 							defer {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1922,7 +1922,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		// TODO: same logic in call_args()
 		if !is_range_slice {
 			if !node.left.is_lvalue() {
-				if node.left.is_ascast() {
+				if node.left.is_as_cast() {
 					g.inside_smartcast = true
 					if node.left is ast.SelectorExpr && !left_type.is_ptr() {
 						g.write('&')
@@ -2911,7 +2911,7 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 						if arg_typ_sym.kind in [.sum_type, .interface] {
 							atype = arg_typ
 						}
-						if arg.expr.is_ascast() {
+						if arg.expr.is_as_cast() {
 							g.inside_smartcast = true
 						} else {
 							g.write('ADDR(${g.styp(atype)}, ')

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -355,7 +355,10 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 		p.check(.rcbr)
 		end_comments = p.eat_comments(same_line: true)
 	}
-	scoped_name := if !is_anon && p.inside_fn { '_${name}_${p.cur_fn_scope.start_pos}' } else { '' }
+	mut scoped_name := ''
+	if !is_anon && p.inside_fn && p.cur_fn_scope != unsafe { nil } {
+		scoped_name = '_${name}_${p.cur_fn_scope.start_pos}'
+	}
 	is_minify := attrs.contains('minify')
 	mut sym := ast.TypeSymbol{
 		kind:       .struct


### PR DESCRIPTION
This PR aims to fix msvc build removing usage of `ADDR` macro on `__as_cast()` calls which makes msvc messed up with precedence order (even on non-prod builds)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzUzOTNmN2QyZWY0Y2JjYzQ2ZjcxYmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.sCHpATrHoctpB5Alh9H8mKV6ZBRDWmJiB9H6DISV6bk">Huly&reg;: <b>V_0.6-21522</b></a></sub>