### PR TITLE
parser: allow `type` as field type on params struct construction

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -144,6 +144,8 @@ fn (mut p Parser) call_args() []ast.CallArg {
 		if p.tok.kind == .name && p.peek_tok.kind == .colon {
 			// `foo(key:val, key2:val2)`
 			expr = p.struct_init('void_type', .short_syntax, false)
+		} else if p.tok.kind == .key_type && p.peek_tok.kind == .colon {
+			expr = p.struct_init('void_type', .short_syntax, false)
 		} else {
 			expr = p.expr(0)
 		}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -141,10 +141,8 @@ fn (mut p Parser) call_args() []ast.CallArg {
 			array_decompose = true
 		}
 		mut expr := ast.empty_expr
-		if p.tok.kind == .name && p.peek_tok.kind == .colon {
+		if p.tok.kind in [.name, .key_type] && p.peek_tok.kind == .colon {
 			// `foo(key:val, key2:val2)`
-			expr = p.struct_init('void_type', .short_syntax, false)
-		} else if p.tok.kind == .key_type && p.peek_tok.kind == .colon {
 			expr = p.struct_init('void_type', .short_syntax, false)
 		} else {
 			expr = p.expr(0)

--- a/vlib/v/tests/keyword_as_params_field_test.v
+++ b/vlib/v/tests/keyword_as_params_field_test.v
@@ -1,0 +1,24 @@
+@[params]
+struct FooParams {
+	type FooType = .first
+}
+
+enum FooType {
+	first
+	second
+}
+
+fn foo(params FooParams) string {
+	match params.type {
+		.first {
+			return 'First'
+		}
+		.second {
+			return 'Second'
+		}
+	}
+}
+
+fn test_main() {
+	assert foo(type: .second) == 'Second'
+}


### PR DESCRIPTION
Fix #23091

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU0YWRlNGQyZWY0Y2JjYzQ2ZjgwNTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Cg02VkEKULKBQgf4xQBwcaqbRV0x9qvElJxpWosPHTY">Huly&reg;: <b>V_0.6-21536</b></a></sub>