### PR TITLE
cgen: fix printing fn call of returning c struct value (fix #23104)

### DIFF
--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -112,14 +112,14 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 			g.write('")')
 		}
 	} else if sym_has_str_method
-		|| sym.kind in [.array, .array_fixed, .map, .struct, .multi_return, .sum_type, .interface] {
+		|| sym.kind in [.alias, .array, .array_fixed, .map, .struct, .multi_return, .sum_type, .interface] {
 		unwrap_option := expr is ast.Ident && expr.or_expr.kind == .propagate_option
 		exp_typ := if unwrap_option { typ.clear_flag(.option) } else { typ }
 		is_dump_expr := expr is ast.DumpExpr
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.get_str_fn(exp_typ)
 		temp_var_needed := expr is ast.CallExpr
-			&& (expr.return_type.is_ptr() || g.table.final_sym(expr.return_type).is_c_struct())
+			&& (expr.return_type.is_ptr() || g.table.sym(expr.return_type).is_c_struct())
 		mut tmp_var := ''
 		if temp_var_needed {
 			tmp_var = g.new_tmp_var()

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -118,7 +118,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		is_dump_expr := expr is ast.DumpExpr
 		is_var_mut := expr.is_auto_deref_var()
 		str_fn_name := g.get_str_fn(exp_typ)
-		temp_var_needed := expr is ast.CallExpr && expr.return_type.is_ptr()
+		temp_var_needed := expr is ast.CallExpr
+			&& (expr.return_type.is_ptr() || g.table.final_sym(expr.return_type).is_c_struct())
 		mut tmp_var := ''
 		if temp_var_needed {
 			tmp_var = g.new_tmp_var()

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -231,7 +231,11 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 					g.write(c_struct_ptr(sym, typ, str_method_expects_ptr))
 				}
 			}
-			g.expr_with_cast(expr, typ, typ)
+			if temp_var_needed {
+				g.write(tmp_var)
+			} else {
+				g.expr_with_cast(expr, typ, typ)
+			}
 		} else if typ.has_flag(.option) {
 			// only Option fn receive argument
 			g.expr_with_cast(expr, typ, typ)

--- a/vlib/v/slow_tests/inout/printing_reference_alias.out
+++ b/vlib/v/slow_tests/inout/printing_reference_alias.out
@@ -1,4 +1,4 @@
-Point(Quad{
+&Point(Quad{
     x: 1.0
     y: 2.0
     z: 3.0

--- a/vlib/v/slow_tests/inout/printing_reference_alias.out
+++ b/vlib/v/slow_tests/inout/printing_reference_alias.out
@@ -1,4 +1,4 @@
-&Point(Quad{
+Point(Quad{
     x: 1.0
     y: 2.0
     z: 3.0

--- a/vlib/v/tests/c_structs/csize.h
+++ b/vlib/v/tests/c_structs/csize.h
@@ -1,0 +1,4 @@
+struct Size {
+   int width;
+	int height;
+};

--- a/vlib/v/tests/c_structs/return_csize_test.v
+++ b/vlib/v/tests/c_structs/return_csize_test.v
@@ -1,0 +1,15 @@
+#include "@VMODROOT/csize.h"
+
+struct C.Size {
+	width  int
+	height int
+}
+
+fn get_size() C.Size {
+	return C.Size{11, 22}
+}
+
+fn test_return_csize() {
+	println(get_size())
+	assert true
+}

--- a/vlib/v/tests/c_structs/return_csize_test.v
+++ b/vlib/v/tests/c_structs/return_csize_test.v
@@ -5,11 +5,19 @@ struct C.Size {
 	height int
 }
 
+type Size = C.Size
+
 fn get_size() C.Size {
 	return C.Size{11, 22}
 }
 
+fn get_csize() Size {
+	return Size(C.Size{11, 22})
+}
+
 fn test_return_csize() {
 	println(get_size())
+	assert true
+	println(get_csize())
 	assert true
 }


### PR DESCRIPTION
This PR fix printing fn call of returning c struct value (fix #23104).

- Fix printing fn call of returning c struct value.
- Add test.

csize.h

```v
struct Size {
   int width;
	int height;
};
```

```v
#include "@VMODROOT/csize.h"

struct C.Size {
	width  int
	height int
}

type Size = C.Size

fn get_size() C.Size {
	return C.Size{11, 22}
}

fn get_csize() Size {
	return Size(C.Size{11, 22})
}

fn main() {
	println(get_size())
	assert true
	println(get_csize())
	assert true
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU2NzdiYTFlMDYzMmRkMDhlMjZkNTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.c-Ghf8Iom_rocSryn0Wk9_zP2eDXee947yq1BqflXS4">Huly&reg;: <b>V_0.6-21543</b></a></sub>