### PR TITLE
checker: fix veb route method param with non ctx name (fix #23105)

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -482,8 +482,8 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			ctx_idx = c.table.find_type('veb.Context')
 		}
 		typ_veb_context := ctx_idx.set_nr_muls(1)
-		// No `ctx` param? Add it
-		if !node.params.any(it.name == 'ctx') && node.params.len >= 1 {
+		// No Context type param? Add it
+		if !node.params.any(c.has_veb_context(it.typ)) && node.params.len >= 1 {
 			params := node.params.clone()
 			ctx_param := ast.Param{
 				name:   'ctx'
@@ -4053,4 +4053,18 @@ fn (mut c Checker) check_must_use_call_result(node &ast.CallExpr, f &ast.Fn, lab
 	if c.pref.is_check_return {
 		c.note('return value must be used', node.pos)
 	}
+}
+
+fn (mut c Checker) has_veb_context(typ ast.Type) bool {
+	sym := c.table.sym(typ)
+	if sym.name == 'veb.Context' {
+		return true
+	} else if sym.info is ast.Struct {
+		for embed in sym.info.embeds {
+			if global_table.sym(embed).name == 'veb.Context' {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -4061,7 +4061,7 @@ fn (mut c Checker) has_veb_context(typ ast.Type) bool {
 		return true
 	} else if sym.info is ast.Struct {
 		for embed in sym.info.embeds {
-			if global_table.sym(embed).name == 'veb.Context' {
+			if c.table.sym(embed).name == 'veb.Context' {
 				return true
 			}
 		}

--- a/vlib/veb/tests/cors_2_test.v
+++ b/vlib/veb/tests/cors_2_test.v
@@ -1,0 +1,107 @@
+import veb
+import net.http
+import os
+import time
+
+const port = 13012
+const localserver = 'http://localhost:${port}'
+const exit_after = time.second * 10
+const allowed_origin = 'https://vlang.io'
+const cors_options = veb.CorsOptions{
+	origins:         [allowed_origin]
+	allowed_methods: [.get, .head]
+}
+
+pub struct Context {
+	veb.Context
+}
+
+pub struct App {
+	veb.Middleware[Context]
+mut:
+	started chan bool
+}
+
+pub fn (mut app App) before_accept_loop() {
+	app.started <- true
+}
+
+pub fn (app &App) index(mut context Context) veb.Result {
+	return context.text('index')
+}
+
+@[post]
+pub fn (app &App) post(mut context Context) veb.Result {
+	return context.text('post')
+}
+
+fn testsuite_begin() {
+	os.chdir(os.dir(@FILE))!
+	spawn fn () {
+		time.sleep(exit_after)
+		assert true == false, 'timeout reached!'
+		exit(1)
+	}()
+
+	mut app := &App{}
+	app.use(veb.cors[Context](cors_options))
+
+	spawn veb.run_at[App, Context](mut app, port: port, timeout_in_seconds: 2)
+	// app startup time
+	_ := <-app.started
+}
+
+fn test_valid_cors() {
+	x := http.fetch(http.FetchConfig{
+		url:    localserver
+		method: .get
+		header: http.new_header_from_map({
+			.origin: allowed_origin
+		})
+	})!
+
+	assert x.status() == .ok
+	assert x.body == 'index'
+}
+
+fn test_preflight() {
+	x := http.fetch(http.FetchConfig{
+		url:    localserver
+		method: .options
+		header: http.new_header_from_map({
+			.origin: allowed_origin
+		})
+	})!
+	assert x.status() == .ok
+	assert x.body == 'ok'
+
+	assert x.header.get(.access_control_allow_origin)! == allowed_origin
+	if _ := x.header.get(.access_control_allow_credentials) {
+		assert false, 'Access-Control-Allow-Credentials should not be present the value is `false`'
+	}
+	assert x.header.get(.access_control_allow_methods)! == 'GET, HEAD'
+}
+
+fn test_invalid_origin() {
+	x := http.fetch(http.FetchConfig{
+		url:    localserver
+		method: .get
+		header: http.new_header_from_map({
+			.origin: 'https://google.com'
+		})
+	})!
+
+	assert x.status() == .forbidden
+}
+
+fn test_invalid_method() {
+	x := http.fetch(http.FetchConfig{
+		url:    '${localserver}/post'
+		method: .post
+		header: http.new_header_from_map({
+			.origin: allowed_origin
+		})
+	})!
+
+	assert x.status() == .method_not_allowed
+}


### PR DESCRIPTION
This PR fix veb route method param with non ctx name (fix #23105).

- Fix veb route method param with non ctx name.
- Add test.

```v
import veb

pub struct User {
pub mut:
	name string
	id   int
}

// Our context struct must embed `veb.Context`!
pub struct Context {
	veb.Context
pub mut:
	// In the context struct we store data that could be different
	// for each request. Like a User struct or a session id
	user       User
	session_id string
}

pub struct App {
pub:
	// In the app struct we store data that should be accessible by all endpoints.
	// For example, a database or configuration values.
	secret_key string
}

// This is how endpoints are defined in veb. This is the index route
pub fn (app &App) index(mut context Context) veb.Result {
	return context.text('Hello V! The secret key is "${app.secret_key}"')
}

fn main() {
	mut app := &App{
		secret_key: 'secret'
	}
	// Pass the App and context type and start the web server on port 8080
	veb.run[App, Context](mut app, 8080)
}

PS D:\Test\v\tt1> v run .
[veb] Running app on http://localhost:8080/
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU2OTQ5MzFlMDYzMmRkMDhlMjcwOTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.J5N1UNvvJLlLx4fP2bh61n6zxkssrHUK2JE1ALaQLlk">Huly&reg;: <b>V_0.6-21544</b></a></sub>