### PR TITLE
v: allow option array element comparison `==` and `!=`

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -893,9 +893,9 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	right_is_option := right_type.has_flag(.option)
 	if left_is_option || right_is_option {
 		opt_infix_pos := if left_is_option { left_pos } else { right_pos }
-		if (node.left !in [ast.Ident, ast.SelectorExpr, ast.ComptimeSelector]
+		if (node.left !in [ast.Ident, ast.IndexExpr, ast.SelectorExpr, ast.ComptimeSelector]
 			|| node.op in [.eq, .ne, .lt, .gt, .le, .ge]) && right_sym.kind != .none
-			&& !c.inside_sql {
+			&& !right_is_option && !c.inside_sql {
 			c.error('unwrapped Option cannot be used in an infix expression', opt_infix_pos)
 		}
 	}

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -894,8 +894,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	if left_is_option || right_is_option {
 		opt_infix_pos := if left_is_option { left_pos } else { right_pos }
 		if (node.left !in [ast.Ident, ast.IndexExpr, ast.SelectorExpr, ast.ComptimeSelector]
-			|| node.op in [.eq, .ne, .lt, .gt, .le, .ge]) && right_sym.kind != .none
-			&& !right_is_option && !c.inside_sql {
+			|| (node.op in [.eq, .ne] && !right_is_option)
+			|| node.op in [.lt, .gt, .le, .ge]) && right_sym.kind != .none && !c.inside_sql {
 			c.error('unwrapped Option cannot be used in an infix expression', opt_infix_pos)
 		}
 	}

--- a/vlib/v/tests/options/option_indexexpr_eq_test.v
+++ b/vlib/v/tests/options/option_indexexpr_eq_test.v
@@ -1,0 +1,7 @@
+fn test_main() {
+	x := []?int{len: 5, init: 1}
+	assert x[0] == x[1]
+
+	y := []?int{len: 4, init: 2}
+	assert !(x[0] == y[1])
+}


### PR DESCRIPTION
Fix #23108

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU2ZDNkZjFlMDYzMmRkMDhlMjdiOTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.FMtTxVtLg9MMHG-mwIQz615q3GHUBQStJu7L2gcTbhA">Huly&reg;: <b>V_0.6-21550</b></a></sub>