### PR TITLE
cgen: fix array fixed comparison from fn return

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2302,7 +2302,8 @@ pub:
 	typ    Type   // the type of the original expression
 	is_ptr bool   // whether the type is a pointer
 pub mut:
-	orig Expr // the original expression, which produced the C temp variable; used by x.str()
+	orig         Expr // the original expression, which produced the C temp variable; used by x.str()
+	is_fixed_ret bool // it is an array fixed returned from call
 }
 
 pub fn (node Node) pos() token.Pos {

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -426,13 +426,17 @@ fn (mut g Gen) gen_fixed_array_equality_fn(left_type ast.Type) string {
 	elem_info := left_typ.sym.array_fixed_info()
 	elem := g.unwrap(elem_info.elem_type)
 	size := elem_info.size
-	g.definitions.writeln('static bool ${ptr_styp}_arr_eq(${ptr_styp} a, ${ptr_styp} b); // auto')
+	mut arg_styp := ptr_styp
+	if elem_info.is_fn_ret {
+		arg_styp = ptr_styp[3..] // removes the _v_ prefix for returning fixed array
+	}
+	g.definitions.writeln('static bool ${ptr_styp}_arr_eq(${arg_styp} a, ${arg_styp} b); // auto')
 
 	left := if left_type.has_flag(.option) { 'a.data' } else { 'a' }
 	right := if left_type.has_flag(.option) { 'b.data' } else { 'b' }
 
 	mut fn_builder := strings.new_builder(512)
-	fn_builder.writeln('static inline bool ${ptr_styp}_arr_eq(${ptr_styp} a, ${ptr_styp} b) {')
+	fn_builder.writeln('static inline bool ${ptr_styp}_arr_eq(${arg_styp} a, ${arg_styp} b) {')
 	fn_builder.writeln('\tfor (int i = 0; i < ${size}; ++i) {')
 	// compare every pair of elements of the two fixed arrays
 	if elem.sym.kind == .string {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3598,6 +3598,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 		}
 		ast.CTempVar {
 			g.write(node.name)
+			if node.is_fixed_ret {
+				g.write('.ret_arr')
+			}
 		}
 		ast.DumpExpr {
 			g.dump_expr(node)

--- a/vlib/v/gen/c/ctempvars.v
+++ b/vlib/v/gen/c/ctempvars.v
@@ -12,18 +12,26 @@ fn (mut g Gen) new_ctemp_var(expr ast.Expr, expr_type ast.Type) ast.CTempVar {
 }
 
 fn (mut g Gen) new_ctemp_var_then_gen(expr ast.Expr, expr_type ast.Type) ast.CTempVar {
-	x := g.new_ctemp_var(expr, expr_type)
-	g.gen_ctemp_var(x)
+	mut x := g.new_ctemp_var(expr, expr_type)
+	g.gen_ctemp_var(mut x)
 	return x
 }
 
-fn (mut g Gen) gen_ctemp_var(tvar ast.CTempVar) {
+fn (mut g Gen) gen_ctemp_var(mut tvar ast.CTempVar) {
 	styp := g.styp(tvar.typ)
-	if g.table.final_sym(tvar.typ).kind == .array_fixed {
+	final_sym := g.table.final_sym(tvar.typ)
+	if final_sym.info is ast.ArrayFixed {
+		tvar.is_fixed_ret = final_sym.info.is_fn_ret
 		g.writeln('${styp} ${tvar.name};')
-		g.write('memcpy(&${tvar.name}, &')
-		g.expr(tvar.orig)
-		g.writeln(' , sizeof(${styp}));')
+		if tvar.is_fixed_ret {
+			g.write('memcpy(${tvar.name}.ret_arr, ')
+			g.expr(tvar.orig)
+			g.writeln(' , sizeof(${styp[3..]}));')
+		} else {
+			g.write('memcpy(&${tvar.name}, ')
+			g.expr(tvar.orig)
+			g.writeln(' , sizeof(${styp}));')
+		}
 	} else {
 		g.write('${styp} ${tvar.name} = ')
 		g.expr(tvar.orig)

--- a/vlib/v/tests/aliases/alias_fixed_array_compare_test.v
+++ b/vlib/v/tests/aliases/alias_fixed_array_compare_test.v
@@ -1,0 +1,20 @@
+type Arr = [4]u8
+
+fn (a Arr) u8_array_fixed() [4]u8 {
+	return a
+}
+
+fn test_main() {
+	a := Arr{}
+	b := Arr{}
+	assert a.u8_array_fixed() == [u8(0), 0, 0, 0]!
+	assert b.u8_array_fixed() == [u8(0), 0, 0, 0]!
+	assert a == b // true
+
+	// // this workaround works
+	a_ := a.u8_array_fixed()
+	b_ := b.u8_array_fixed()
+	assert a_ == b_
+
+	assert a.u8_array_fixed() == b.u8_array_fixed()
+}

--- a/vlib/v/tests/aliases/alias_fixed_array_compare_test.v
+++ b/vlib/v/tests/aliases/alias_fixed_array_compare_test.v
@@ -9,9 +9,8 @@ fn test_main() {
 	b := Arr{}
 	assert a.u8_array_fixed() == [u8(0), 0, 0, 0]!
 	assert b.u8_array_fixed() == [u8(0), 0, 0, 0]!
-	assert a == b // true
+	assert a == b
 
-	// // this workaround works
 	a_ := a.u8_array_fixed()
 	b_ := b.u8_array_fixed()
 	assert a_ == b_


### PR DESCRIPTION
Fix #23071

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU2ZTkyZjFlMDYzMmRkMDhlMjdkN2QiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.3Av6BWghh2qAL1QIooSIDYNHWKAm7KFUYUds2HMGRMY">Huly&reg;: <b>V_0.6-21551</b></a></sub>