### PR TITLE
ci: rename `discord.v`'s org name to `vcv88`

### DIFF
--- a/.github/workflows/compile_discordv.sh
+++ b/.github/workflows/compile_discordv.sh
@@ -8,8 +8,8 @@ function show() {
 
 rm -rf discord/
 
-show "Clone https://github.com/DarpHome/discord.v"
-v retry -- git clone --filter=blob:none --quiet https://github.com/DarpHome/discord.v discord/
+show "Clone https://github.com/vcv88/discord.v"
+v retry -- git clone --filter=blob:none --quiet https://github.com/vcv88/discord.v discord/
 cd discord/
 show "Checkout last known good commit"
 git checkout ce9ff457fce92d5bb15df2974440cd8292457ee0


### PR DESCRIPTION
I've renamed organization as I don't like the name anymore.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU3N2EyMjFlMDYzMmRkMDhlMjk1Y2UiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.VXEks84WDh-GnV2iI3kJZQ29tFHs8QSDB5lTRovvRYY">Huly&reg;: <b>V_0.6-21554</b></a></sub>