### PR TITLE
cgen: fix array map to fixed array (fix #23116)

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -576,6 +576,28 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 			g.write('${ret_elem_styp} ${tmp_map_expr_result_name} = ')
 			g.expr(expr.expr)
 		}
+		ast.SelectorExpr {
+			if expr.typ != ast.void_type && g.table.final_sym(expr.typ).kind == .array_fixed {
+				atype := g.styp(expr.typ)
+				if closure_var_decl != '' {
+					g.write('memcpy(&${closure_var_decl}, &')
+					g.expr(expr)
+					g.write(', sizeof(${atype}))')
+				} else {
+					g.writeln('${ret_elem_styp} ${tmp_map_expr_result_name};')
+					g.write('memcpy(&${tmp_map_expr_result_name}, &')
+					g.expr(expr)
+					g.write(', sizeof(${atype}))')
+				}
+			} else {
+				if closure_var_decl != '' {
+					g.write('${closure_var_decl} = ')
+				} else {
+					g.write('${ret_elem_styp} ${tmp_map_expr_result_name} = ')
+				}
+				g.expr(expr)
+			}
+		}
 		else {
 			if closure_var_decl != '' {
 				g.write('${closure_var_decl} = ')

--- a/vlib/v/tests/builtin_arrays/array_map_to_fixed_array_test.v
+++ b/vlib/v/tests/builtin_arrays/array_map_to_fixed_array_test.v
@@ -1,0 +1,13 @@
+type Mat4 = [16]f32
+
+struct GameObject {
+mut:
+	transform Mat4
+	children  []&GameObject
+}
+
+fn test_array_map_to_fixed_array() {
+	mut v1 := &GameObject{}
+	eprintln('children: ${v1.children.map(it.transform)}')
+	assert '${v1.children.map(it.transform)}' == '[]'
+}


### PR DESCRIPTION
This PR fix array map to fixed array (fix #23116).

- Fix array map to fixed array.
- Add test.

```v
module main

type Mat4 = [16]f32

struct GameObject  {
mut:
	transform Mat4
	children []&GameObject
}

fn main() {
	mut v1 := &GameObject{}
	eprintln("children: ${v1.children.map(it.transform)}")
	assert '${v1.children.map(it.transform)}' == '[]'
}

PS D:\Test\v\tt1> v run .    
children: []
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU3YTU1OTFlMDYzMmRkMDhlMjk3ZjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.l6DWVvqGCRfGM3e18pS2ln5kma1IZW0R9UFxU9jdCoc">Huly&reg;: <b>V_0.6-21555</b></a></sub>