### PR TITLE
cgen: fix sort fn definitions

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -766,7 +766,7 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	}
 
 	stype_arg := g.styp(elem_type)
-	g.definitions.writeln('VV_LOCAL_SYMBOL ${g.static_modifier} int ${compare_fn}(${stype_arg}* a, ${stype_arg}* b) {')
+	g.sort_fn_definitions.writeln('VV_LOCAL_SYMBOL ${g.static_modifier} int ${compare_fn}(${stype_arg}* a, ${stype_arg}* b) {')
 	c_condition := if comparison_type.sym.has_method('<') {
 		'${g.styp(comparison_type.typ)}__lt(${left_expr}, ${right_expr})'
 	} else if comparison_type.unaliased_sym.has_method('<') {
@@ -776,9 +776,9 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	} else {
 		'${left_expr} < ${right_expr}'
 	}
-	g.definitions.writeln('\tif (${c_condition}) return -1;')
-	g.definitions.writeln('\telse return 1;')
-	g.definitions.writeln('}\n')
+	g.sort_fn_definitions.writeln('\tif (${c_condition}) return -1;')
+	g.sort_fn_definitions.writeln('\telse return 1;')
+	g.sort_fn_definitions.writeln('}\n')
 
 	// write call to the generated function
 	g.gen_array_sort_call(node, compare_fn, left_is_array)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -59,6 +59,7 @@ mut:
 	enum_typedefs             strings.Builder // enum types
 	definitions               strings.Builder // typedefs, defines etc (everything that goes to the top of the file)
 	type_definitions          strings.Builder // typedefs, defines etc (everything that goes to the top of the file)
+	sort_fn_definitions       strings.Builder // sort fns
 	alias_definitions         strings.Builder // alias fixed array of non-builtin
 	hotcode_definitions       strings.Builder // -live declarations & functions
 	channel_definitions       strings.Builder // channel related code
@@ -304,6 +305,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 		typedefs:             strings.new_builder(100)
 		enum_typedefs:        strings.new_builder(100)
 		type_definitions:     strings.new_builder(100)
+		sort_fn_definitions:  strings.new_builder(100)
 		alias_definitions:    strings.new_builder(100)
 		hotcode_definitions:  strings.new_builder(100)
 		channel_definitions:  strings.new_builder(100)
@@ -392,6 +394,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 			global_g.includes.write(g.includes) or { panic(err) }
 			global_g.typedefs.write(g.typedefs) or { panic(err) }
 			global_g.type_definitions.write(g.type_definitions) or { panic(err) }
+			global_g.sort_fn_definitions.write(g.sort_fn_definitions) or { panic(err) }
 			global_g.alias_definitions.write(g.alias_definitions) or { panic(err) }
 			global_g.definitions.write(g.definitions) or { panic(err) }
 			global_g.gowrappers.write(g.gowrappers) or { panic(err) }
@@ -590,6 +593,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	b.write_string2('\n// V result_xxx definitions:\n', g.out_results.str())
 	b.write_string2('\n// V json forward decls:\n', g.json_forward_decls.str())
 	b.write_string2('\n// V definitions:\n', g.definitions.str())
+	b.write_string2('\n// V sort fn definitions:\n', g.sort_fn_definitions.str())
 	b.writeln('\n// V global/const non-precomputed definitions:')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
@@ -682,6 +686,7 @@ fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) &Gen {
 		includes:              strings.new_builder(100)
 		typedefs:              strings.new_builder(100)
 		type_definitions:      strings.new_builder(100)
+		sort_fn_definitions:   strings.new_builder(100)
 		alias_definitions:     strings.new_builder(100)
 		definitions:           strings.new_builder(100)
 		gowrappers:            strings.new_builder(100)
@@ -754,6 +759,7 @@ pub fn (mut g Gen) free_builders() {
 		g.includes.free()
 		g.typedefs.free()
 		g.type_definitions.free()
+		g.sort_fn_definitions.free()
 		g.alias_definitions.free()
 		g.definitions.free()
 		g.cleanup.free()

--- a/vlib/v/tests/sort_fn_def_test.v
+++ b/vlib/v/tests/sort_fn_def_test.v
@@ -1,0 +1,15 @@
+import arrays
+
+struct Abc {
+	x int
+}
+
+fn (s1 Abc) < (s2 Abc) bool {
+	return s1.x < s2.x
+}
+
+fn test_main() {
+	a := [Abc{123}, Abc{42}, Abc{999}, Abc{42}, Abc{123}]
+	dump(arrays.distinct(a))
+	assert true
+}


### PR DESCRIPTION
Fix #23120

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU4MzEwMDFlMDYzMmRkMDhlMmFmYjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.6g05kxiz4wDCKtBHMpcfIpXDSEwtWwlRKLk1cbgXm8s">Huly&reg;: <b>V_0.6-21558</b></a></sub>