### PR TITLE
math.big: fix `assert big.integer_from_int(1) == big.integer_from_bytes([u8(0), 0, 0, 0, 1])` (fix #23115)

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -849,3 +849,22 @@ fn test_set_bit() {
 	a.set_bit(100, false)
 	assert a == b
 }
+
+fn test_integer_from_bytes_ignores_potential_leading_zero_bytes() {
+	bint0 := big.integer_from_int(0)
+	for j in 0 .. 10 {
+		assert bint0 == big.integer_from_bytes([]u8{len: j}, signum: 0)
+		assert bint0 == big.integer_from_bytes([]u8{len: j}, signum: -1)
+	}
+	for i in 0 .. 10 {
+		bint := big.integer_from_int(i)
+		nbint := big.integer_from_int(-i)
+		for j in 0 .. 15 {
+			mut input := []u8{len: j}
+			input << i
+			assert bint == big.integer_from_bytes(input)
+			assert bint == big.integer_from_bytes(input, signum: 1)
+			assert nbint == big.integer_from_bytes(input, signum: -1)
+		}
+	}
+}

--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -853,6 +853,7 @@ fn test_set_bit() {
 fn test_integer_from_bytes_ignores_potential_leading_zero_bytes() {
 	bint0 := big.integer_from_int(0)
 	for j in 0 .. 10 {
+		assert bint0 == big.integer_from_bytes([]u8{len: j}, signum: 1)
 		assert bint0 == big.integer_from_bytes([]u8{len: j}, signum: 0)
 		assert bint0 == big.integer_from_bytes([]u8{len: j}, signum: -1)
 	}

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -131,7 +131,7 @@ pub fn integer_from_bytes(oinput []u8, config IntegerConfig) Integer {
 	if oinput.len == 0 {
 		return integer_from_int(0)
 	}
-	// pad input
+	// Ignore leading 0 bytes:
 	mut first_non_zero_index := -1
 	for i in 0 .. oinput.len {
 		if oinput[i] != 0 {
@@ -143,6 +143,7 @@ pub fn integer_from_bytes(oinput []u8, config IntegerConfig) Integer {
 		return integer_from_int(0)
 	}
 	input := oinput[first_non_zero_index..]
+	// pad input
 	mut padded_input := []u8{len: ((input.len + 3) & ~0x3) - input.len, cap: (input.len + 3) & ~0x3}
 	padded_input << input
 	mut digits := []u32{len: padded_input.len / 4}

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -126,12 +126,23 @@ pub:
 // If you want a negative integer, use in the following manner:
 // `value := big.integer_from_bytes(bytes, signum: -1)`
 @[direct_array_access]
-pub fn integer_from_bytes(input []u8, config IntegerConfig) Integer {
+pub fn integer_from_bytes(oinput []u8, config IntegerConfig) Integer {
 	// Thank you to Miccah (@mcastorina) for this implementation and relevant unit tests.
-	if input.len == 0 {
+	if oinput.len == 0 {
 		return integer_from_int(0)
 	}
 	// pad input
+	mut first_non_zero_index := -1
+	for i in 0 .. oinput.len {
+		if oinput[i] != 0 {
+			first_non_zero_index = i
+			break
+		}
+	}
+	if first_non_zero_index == -1 {
+		return integer_from_int(0)
+	}
+	input := oinput[first_non_zero_index..]
 	mut padded_input := []u8{len: ((input.len + 3) & ~0x3) - input.len, cap: (input.len + 3) & ~0x3}
 	padded_input << input
 	mut digits := []u32{len: padded_input.len / 4}


### PR DESCRIPTION
Fix: #23115 .

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU4NGVmMDFlMDYzMmRkMDhlMmI4MTUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.tgAtu8Fzgt-T9QuOtS5SFfbhJJ3VWxHtyEUwWo7vSks">Huly&reg;: <b>V_0.6-21561</b></a></sub>