### PR TITLE
math: use libc wrappers for math.log2/1, math.log10/1, math.log1p/1 and math.log_b/1. Make `assert math.log10(10) == 1.0` pass.

### DIFF
--- a/vlib/math/log.c.v
+++ b/vlib/math/log.c.v
@@ -1,17 +1,45 @@
 module math
 
 fn C.log(x f64) f64
-
+fn C.log2(x f64) f64
+fn C.log10(x f64) f64
+fn C.log1p(x f64) f64
+fn C.logb(x f64) f64
 fn C.logf(x f32) f32
 
 // log returns the natural logarithm of x (float64)
 @[inline]
-pub fn log(a f64) f64 {
-	return C.log(a)
+pub fn log(x f64) f64 {
+	return C.log(x)
+}
+
+// log2 returns the binary logarithm of x (float64).
+// The special cases are the same as for log.
+@[inline]
+pub fn log2(x f64) f64 {
+	return C.log2(x)
+}
+
+// log10 returns the decimal logarithm of x (float64).
+// The special cases are the same as for log.
+@[inline]
+pub fn log10(x f64) f64 {
+	return C.log10(x)
+}
+
+// log1p returns log(1+x).
+@[inline]
+pub fn log1p(x f64) f64 {
+	return C.log1p(x)
+}
+
+// log_b returns the binary exponent of x.
+pub fn log_b(x f64) f64 {
+	return C.logb(x)
 }
 
 // log returns the natural logarithm of x (float32)
 @[inline]
-pub fn logf(a f32) f32 {
-	return C.logf(a)
+pub fn logf(x f32) f32 {
+	return C.logf(x)
 }

--- a/vlib/math/log_test.v
+++ b/vlib/math/log_test.v
@@ -1,0 +1,23 @@
+import math
+
+fn test_log_base() {
+	assert math.log(math.e) == 1.0
+}
+
+fn test_log2_base() {
+	assert math.log2(2.0) == 1.0
+}
+
+fn test_log10_base() {
+	// Note: `assert math.log10(10.0) == 1.0` currently fails, when the pure V implementation is used with
+	// `./v -exclude @vlib/math/*.c.v vlib/math/log_test.v`
+	assert math.veryclose(math.log10(10.0), 1.0)
+}
+
+fn test_log1p_base() {
+	assert math.log1p(math.e - 1) == 1.0
+}
+
+fn test_log_b_base() {
+	assert math.log_b(2.0) == 1.0
+}


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU5NThmODFlMDYzMmRkMDhlMzE0MWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.aeTsYNUBHaqHS9fpfRwCHgIgNZtXkb9XlXJFZoYmMEo">Huly&reg;: <b>V_0.6-21566</b></a></sub>