### PR TITLE
checker: fix missing check on range expr when high var is same iteration value var

### DIFF
--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -68,10 +68,19 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		} else if high_type.has_option_or_result() {
 			c.error('the `high` value in a `for x in low..high {` loop, cannot be Result or Option',
 				node.high.pos())
+		} else if node.cond is ast.Ident && node.val_var == node.cond.name {
+			if node.is_range {
+				c.error('in a `for x in <range>` loop, the key or value iteration variable `${node.val_var}` can not be the same as the low variable',
+					node.cond.pos())
+			} else {
+				c.error('in a `for x in array` loop, the key or value iteration variable `${node.val_var}` can not be the same as the low variable',
+					node.cond.pos())
+			}
 		} else if node.high is ast.Ident && node.val_var == node.high.name {
-			c.error('the `high` variable cannot be the same value iteration variable',
+			c.error('in a `for x in <range>` loop, the key or value iteration variable `${node.val_var}` can not be the same as the high variable',
 				node.high.pos())
 		}
+
 		if high_type in [ast.int_type, ast.int_literal_type] {
 			node.val_type = typ
 		} else {
@@ -80,6 +89,10 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		node.high_type = high_type
 		node.scope.update_var_type(node.val_var, node.val_type)
 	} else {
+		if node.cond is ast.Ident && node.cond.name in [node.key_var, node.val_var] {
+			c.error('in a `for x in array` loop, the key or value iteration variable `${node.val_var}` can not be the same as the low variable',
+				node.cond.pos())
+		}
 		mut is_comptime := false
 		if (node.cond is ast.Ident && c.comptime.is_comptime_var(node.cond))
 			|| node.cond is ast.ComptimeSelector {

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -68,6 +68,9 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 		} else if high_type.has_option_or_result() {
 			c.error('the `high` value in a `for x in low..high {` loop, cannot be Result or Option',
 				node.high.pos())
+		} else if node.high is ast.Ident && node.val_var == node.high.name {
+			c.error('the `high` variable cannot be the same value iteration variable',
+				node.high.pos())
 		}
 		if high_type in [ast.int_type, ast.int_literal_type] {
 			node.val_type = typ

--- a/vlib/v/checker/for_in_same_var_err.out
+++ b/vlib/v/checker/for_in_same_var_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/for_in_same_var_err.vv:1:15: error: the `high` variable cannot be the same value iteration variable
+    1 | for v in 0 .. v {
+      |               ^
+    2 |     println(v)
+    3 | }

--- a/vlib/v/checker/for_in_same_var_err.out
+++ b/vlib/v/checker/for_in_same_var_err.out
@@ -1,5 +1,47 @@
-vlib/v/checker/for_in_same_var_err.vv:1:15: error: the `high` variable cannot be the same value iteration variable
-    1 | for v in 0 .. v {
-      |               ^
-    2 |     println(v)
+vlib/v/checker/for_in_same_var_err.vv:1:10: error: in a `for x in <range>` loop, the key or value iteration variable `x` can not be the same as the low variable
+    1 | for x in x .. 10 {
+      |          ^
+    2 |     dump(x)
     3 | }
+vlib/v/checker/for_in_same_var_err.vv:5:15: error: in a `for x in <range>` loop, the key or value iteration variable `y` can not be the same as the high variable
+    3 | }
+    4 | 
+    5 | for y in 0 .. y {
+      |               ^
+    6 |     dump(y)
+    7 | }
+vlib/v/checker/for_in_same_var_err.vv:9:10: error: in a `for x in <range>` loop, the key or value iteration variable `z` can not be the same as the low variable
+    7 | }
+    8 | 
+    9 | for z in z .. z {
+      |          ^
+   10 |     dump(z)
+   11 | }
+vlib/v/checker/for_in_same_var_err.vv:13:10: error: in a `for x in array` loop, the key or value iteration variable `w` can not be the same as the low variable
+   11 | }
+   12 | 
+   13 | for w in w {
+      |          ^
+   14 |     dump(w)
+   15 | }
+vlib/v/checker/for_in_same_var_err.vv:14:7: error: dump expression can not be void
+   12 | 
+   13 | for w in w {
+   14 |     dump(w)
+      |          ^
+   15 | }
+   16 |
+vlib/v/checker/for_in_same_var_err.vv:17:13: error: in a `for x in array` loop, the key or value iteration variable `_` can not be the same as the low variable
+   15 | }
+   16 | 
+   17 | for k, _ in k {
+      |             ^
+   18 |     dump(k)
+   19 | }
+vlib/v/checker/for_in_same_var_err.vv:17:13: error: for in: cannot index `int`
+   15 | }
+   16 | 
+   17 | for k, _ in k {
+      |             ^
+   18 |     dump(k)
+   19 | }

--- a/vlib/v/checker/for_in_same_var_err.vv
+++ b/vlib/v/checker/for_in_same_var_err.vv
@@ -1,0 +1,3 @@
+for v in 0 .. v {
+	println(v)
+}

--- a/vlib/v/checker/for_in_same_var_err.vv
+++ b/vlib/v/checker/for_in_same_var_err.vv
@@ -1,3 +1,19 @@
-for v in 0 .. v {
-	println(v)
+for x in x .. 10 {
+	dump(x)
+}
+
+for y in 0 .. y {
+	dump(y)
+}
+
+for z in z .. z {
+	dump(z)
+}
+
+for w in w {
+	dump(w)
+}
+
+for k, _ in k {
+	dump(k)
 }

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -146,9 +146,6 @@ fn (mut p Parser) for_stmt() ast.Stmt {
 		}
 		comments << p.eat_comments()
 		p.check(.key_in)
-		if p.tok.kind == .name && p.tok.lit in [key_var_name, val_var_name] {
-			return p.error('in a `for x in array` loop, the key or value iteration variable `${p.tok.lit}` can not be the same as the array variable')
-		}
 		comments << p.eat_comments()
 		// arr_expr
 		p.inside_for_expr = true


### PR DESCRIPTION
Fix bug spotted by @Bruno-Vdr

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU5NjNjNDFlMDYzMmRkMDhlMzE3NzMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.NJByJcoKfXeioCYv2d1cMhB3sfkg8ZTTjwsYYRedNFA">Huly&reg;: <b>V_0.6-21567</b></a></sub>