### PR TITLE
cgen: fix codegen for generic selector expr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4278,7 +4278,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	alias_to_ptr := sym.info is ast.Alias && sym.info.parent_type.is_ptr()
 	if field_is_opt
-		|| ((node.expr_type.is_ptr() || sym.kind == .chan || alias_to_ptr)
+		|| ((g.unwrap_generic(node.expr_type).is_ptr() || sym.kind == .chan || alias_to_ptr)
 		&& node.from_embed_types.len == 0)
 		|| (node.expr.is_as_cast() && g.inside_smartcast) {
 		g.write('->')

--- a/vlib/v/tests/generic_selector_ptr_test.v
+++ b/vlib/v/tests/generic_selector_ptr_test.v
@@ -1,0 +1,19 @@
+module main
+
+struct Foo123 {
+	field string = 'foobar'
+}
+
+fn gen_func[T](value T) string {
+	$if T is i32 {
+		return '123'
+	} $else $if T is &Foo123 {
+		return value.field
+	} $else {
+		return '123'
+	}
+}
+
+fn test_main() {
+	assert gen_func[&Foo123](&Foo123{}) == 'foobar'
+}


### PR DESCRIPTION
Fix #22974

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU5N2Y5MTFlMDYzMmRkMDhlMzFlZDEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.GxP20X9wYRcXPxdxWunQ_tmkWUkTQaPEs8BO8mESqSc">Huly&reg;: <b>V_0.6-21569</b></a></sub>