### PR TITLE
gg: add icon to gg.Config for easier access

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -58,7 +58,7 @@ pub:
 	create_window bool    // TODO: implement or deprecate
 	// window_user_ptr voidptr
 	window_title      string // the desired title of the window
-	window_icon       sapp.IconDesc
+	icon              sapp.IconDesc
 	html5_canvas_name string = 'canvas'
 	borderless_window bool     // TODO: implement or deprecate
 	always_on_top     bool     // TODO: implement or deprecate
@@ -478,7 +478,7 @@ pub fn new_context(cfg Config) &Context {
 			// fail_userdata_cb: gg_fail_fn
 			cleanup_userdata_cb: gg_cleanup_fn
 			window_title:        &char(cfg.window_title.str)
-			icon:                cfg.window_icon
+			icon:                cfg.icon
 			html5_canvas_name:   &char(cfg.html5_canvas_name.str)
 			width:               cfg.width
 			height:              cfg.height

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -58,6 +58,7 @@ pub:
 	create_window bool    // TODO: implement or deprecate
 	// window_user_ptr voidptr
 	window_title      string // the desired title of the window
+	window_icon       sapp.IconDesc
 	html5_canvas_name string = 'canvas'
 	borderless_window bool     // TODO: implement or deprecate
 	always_on_top     bool     // TODO: implement or deprecate
@@ -477,6 +478,7 @@ pub fn new_context(cfg Config) &Context {
 			// fail_userdata_cb: gg_fail_fn
 			cleanup_userdata_cb: gg_cleanup_fn
 			window_title:        &char(cfg.window_title.str)
+			icon:                cfg.window_icon
 			html5_canvas_name:   &char(cfg.html5_canvas_name.str)
 			width:               cfg.width
 			height:              cfg.height


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR adds `window_icon` to the gg.Config struct for easier access and use with the `gg.new_context` method.

This allows us to have the option to just pass `window_icon: sapp.IconDesc{}` directly into the `new_context` method without needing to directly make the window with sokol.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU5ZTA2ZTFlMDYzMmRkMDhlMzJhN2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.9DytsjoWi6xFaqShZ_oT_au92RanTQoBdbaKmdxft3I">Huly&reg;: <b>V_0.6-21575</b></a></sub>