### PR TITLE
cgen: fix codegen for returning option reference from indexexpr

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -325,7 +325,11 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			if !node.is_option {
 				g.or_block(tmp_opt, node.or_expr, elem_type)
 			}
-			g.write('\n${cur_line}(*(${elem_type_str}*)${tmp_opt}.data)')
+			if !g.is_amp {
+				g.write('\n${cur_line}(*(${elem_type_str}*)${tmp_opt}.data)')
+			} else {
+				g.write('\n${cur_line}*${tmp_opt_ptr}')
+			}
 		}
 	}
 }

--- a/vlib/v/tests/options/option_index_amp_test.v
+++ b/vlib/v/tests/options/option_index_amp_test.v
@@ -1,0 +1,41 @@
+module main
+
+struct Bar {
+	name string
+}
+
+struct Foo333 {
+	bars []Bar
+}
+
+fn (f Foo333) find() ?&Bar {
+	bar1_2 := &f.bars[1] or { return none }
+	bar1_4 := &f.bars[1]
+	println('bar1_2 `${ptr_str(bar1_2)}`')
+	println('bar1_4 `${ptr_str(bar1_4)}`')
+	return &f.bars[1] or { return none }
+}
+
+fn test_main() {
+	foo := Foo333{
+		bars: [Bar{
+			name: '123'
+		}, Bar{
+			name: 'aaa'
+		}, Bar{
+			name: 's34'
+		}]
+	}
+
+	println('o bar1 1 `${ptr_str(foo.bars[1])}`')
+	println('o bar1 2 `${ptr_str(&foo.bars[1])}`')
+
+	bar := foo.find() or { panic('not found') }
+	println('o bar1 3 `${ptr_str(bar)}`')
+	println(bar.name)
+	assert bar.name == 'aaa'
+
+	bar2 := foo.find() or { panic('not found') }
+	println(bar2.name)
+	assert bar2.name == 'aaa'
+}

--- a/vlib/v/tests/options/option_index_amp_test.v
+++ b/vlib/v/tests/options/option_index_amp_test.v
@@ -4,20 +4,16 @@ struct Bar {
 	name string
 }
 
-struct Foo333 {
+struct Foo {
 	bars []Bar
 }
 
-fn (f Foo333) find() ?&Bar {
-	bar1_2 := &f.bars[1] or { return none }
-	bar1_4 := &f.bars[1]
-	println('bar1_2 `${ptr_str(bar1_2)}`')
-	println('bar1_4 `${ptr_str(bar1_4)}`')
+fn (f Foo) find() ?&Bar {
 	return &f.bars[1] or { return none }
 }
 
 fn test_main() {
-	foo := Foo333{
+	foo := Foo{
 		bars: [Bar{
 			name: '123'
 		}, Bar{
@@ -26,16 +22,7 @@ fn test_main() {
 			name: 's34'
 		}]
 	}
-
-	println('o bar1 1 `${ptr_str(foo.bars[1])}`')
-	println('o bar1 2 `${ptr_str(&foo.bars[1])}`')
-
 	bar := foo.find() or { panic('not found') }
-	println('o bar1 3 `${ptr_str(bar)}`')
 	println(bar.name)
 	assert bar.name == 'aaa'
-
-	bar2 := foo.find() or { panic('not found') }
-	println(bar2.name)
-	assert bar2.name == 'aaa'
 }


### PR DESCRIPTION
Fix #23133 (stack-use-after-return bug)
 
<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU5ZTk0ZDFlMDYzMmRkMDhlMzJiNDgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.9E9sPjMgUZJvlCrePdv8k1qPylSZ3c4D773YoDwFGm8">Huly&reg;: <b>V_0.6-21576</b></a></sub>