### PR TITLE
scanner: fix string interpolation for float e format

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -505,7 +505,7 @@ fn (mut s Scanner) ident_dec_number() string {
 		if !s.pref.translated {
 			s.error('this number has unsuitable digit `${first_wrong_digit.str()}`')
 		}
-	} else if s.text[s.pos - 1] in [`e`, `E`] {
+	} else if s.text[s.pos - 1] in [`e`, `E`] && !s.is_inside_string {
 		// error check: 5e
 		s.pos-- // adjust error position
 		s.error('exponent has no digits')

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -475,7 +475,7 @@ fn (mut s Scanner) ident_dec_number() string {
 	}
 	// scan exponential part
 	mut has_exp := false
-	if s.pos < s.text.len && s.text[s.pos] in [`e`, `E`] {
+	if s.pos < s.text.len && s.text[s.pos] in [`e`, `E`] && !s.is_inside_string {
 		has_exp = true
 		s.pos++
 		if s.pos < s.text.len && s.text[s.pos] in [`-`, `+`] {

--- a/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_test.v
+++ b/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_test.v
@@ -235,8 +235,8 @@ fn test_interpo_non_ascii_characters() {
 }
 
 fn test_float_exponent_sign() {
-	a := 1.234567
-	assert '${a:4.1}' == ' 1.2'
-	assert '${a:4.2}' == '1.23'
-	assert '${a:4.3}' == '1.235'
+	a := 1234567.0123456e03
+	assert '${a:6.1e}' == '1.2e+09'
+	assert '${a:6.2e}' == '1.23e+09'
+	assert '${a:6.5e}' == '1.23457e+09'
 }

--- a/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_test.v
+++ b/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_test.v
@@ -233,3 +233,10 @@ fn test_interpo_non_ascii_characters() {
 	hello := '你好'
 	assert '${hello},世界！' == '你好,世界！'
 }
+
+fn test_float_exponent_sign() {
+	a := 1.234567
+	assert '${a:4.1}' == ' 1.2'
+	assert '${a:4.2}' == '1.23'
+	assert '${a:4.3}' == '1.235'
+}


### PR DESCRIPTION
Fix #22429

This is really a PR #22453 with improve tests.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVjMDI3YzFlMDYzMmRkMDhlMzczZDciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.H-uIw596IwSYUZNssJPwKAHVlzIyrFmXQ9kJYezN_68">Huly&reg;: <b>V_0.6-21584</b></a></sub>