### PR TITLE
parallel-cc: make it working on gcc, clang and tcc + restore static on non-parallel builds + cleanups

### DIFF
--- a/vlib/v/builder/cbuilder/cbuilder.v
+++ b/vlib/v/builder/cbuilder/cbuilder.v
@@ -76,12 +76,13 @@ pub fn gen_c(mut b builder.Builder, v_files []string) string {
 	}
 
 	util.timing_start('C GEN')
-	header, res, out_str, out_fn_start_pos := c.gen(b.parsed_files, mut b.table, b.pref)
+	header, res, out_str, extern_str, out_fn_start_pos := c.gen(b.parsed_files, mut b.table,
+		b.pref)
 	util.timing_measure('C GEN')
 
 	if b.pref.parallel_cc {
 		util.timing_start('Parallel C compilation')
-		parallel_cc(mut b, header, res, out_str, out_fn_start_pos)
+		parallel_cc(mut b, header, res, out_str, extern_str, out_fn_start_pos)
 		util.timing_measure('Parallel C compilation')
 	}
 

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -68,8 +68,10 @@ fn parallel_cc(mut b builder.Builder, header string, _res string, out_str string
 	pp.work_on_items(o_postfixes)
 	eprintln('> C compilation on ${nr_threads} threads, working on ${o_postfixes.len} files took: ${sw.elapsed().milliseconds()} ms')
 	// cc := os.quoted_path(cc_compiler)
-	link_cmd := '${cc} -o ${os.quoted_path(b.pref.out_name)} out_0.o ${fnames.map(it.replace('.c',
-		'.o')).join(' ')} out_x.o -lpthread -lgc ${cc_ldflags}'
+	gc_flag := if b.pref.gc_mode != .no_gc { '-lgc ' } else { '' }
+	obj_files := fnames.map(it.replace('.c', '.o')).join(' ')
+	ld_flags := '${gc_flag}${cc_ldflags}'
+	link_cmd := '${cc} -o ${os.quoted_path(b.pref.out_name)} out_0.o ${obj_files} out_x.o -lpthread ${ld_flags}'
 	sw_link := time.new_stopwatch()
 	link_res := os.execute(link_cmd)
 	eprint_time('link_cmd', link_cmd, link_res, sw_link)

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -6,7 +6,7 @@ import v.util
 import v.builder
 import sync.pool
 
-fn parallel_cc(mut b builder.Builder, header string, _res string, out_str string, out_fn_start_pos []int) {
+fn parallel_cc(mut b builder.Builder, header string, _res string, out_str string, extern_str string, out_fn_start_pos []int) {
 	c_files := util.nr_jobs - 1
 	println('> c_files: ${c_files} | util.nr_jobs: ${util.nr_jobs}')
 	out_h := header.replace_once('static char * v_typeof_interface_IError', 'char * v_typeof_interface_IError')
@@ -23,9 +23,8 @@ fn parallel_cc(mut b builder.Builder, header string, _res string, out_str string
 	os.write_file('out.h', out_h) or { panic(err) }
 	os.write_file('out_0.c', '#include "out.h"\n' + out0 + '\n//X:\n' + x) or { panic(err) }
 	// os.write_file('out_0.c', out0) or { panic(err) }
-	os.write_file('out_x.c', '#include "out.h"\n' + out_str[out_fn_start_pos.last()..]) or {
-		panic(err)
-	}
+	os.write_file('out_x.c', '#include "out.h"\n' + extern_str + '\n' +
+		out_str[out_fn_start_pos.last()..]) or { panic(err) }
 
 	mut prev_fn_pos := 0
 	mut out_files := []os.File{len: c_files}
@@ -35,6 +34,7 @@ fn parallel_cc(mut b builder.Builder, header string, _res string, out_str string
 		fnames << fname
 		out_files[i] = os.create(fname) or { panic(err) }
 		out_files[i].writeln('#include "out.h"\n') or { panic(err) }
+		out_files[i].writeln(extern_str) or { panic(err) }
 	}
 	// out_fn_start_pos.sort()
 	for i, fn_pos in out_fn_start_pos {
@@ -69,7 +69,7 @@ fn parallel_cc(mut b builder.Builder, header string, _res string, out_str string
 	eprintln('> C compilation on ${nr_threads} threads, working on ${o_postfixes.len} files took: ${sw.elapsed().milliseconds()} ms')
 	// cc := os.quoted_path(cc_compiler)
 	link_cmd := '${cc} -o ${os.quoted_path(b.pref.out_name)} out_0.o ${fnames.map(it.replace('.c',
-		'.o')).join(' ')} out_x.o -lpthread ${cc_ldflags}'
+		'.o')).join(' ')} out_x.o -lpthread -lgc ${cc_ldflags}'
 	sw_link := time.new_stopwatch()
 	link_res := os.execute(link_cmd)
 	eprint_time('link_cmd', link_cmd, link_res, sw_link)

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1096,8 +1096,8 @@ fn (mut g Gen) gen_array_contains_methods() {
 				left_type_str = 'Array_voidptr'
 				elem_type_str = 'voidptr'
 			}
-			g.type_definitions.writeln('bool ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
-			fn_builder.writeln('bool ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
+			g.type_definitions.writeln('${g.static_non_parallel}bool ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
+			fn_builder.writeln('${g.static_non_parallel}bool ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i) {')
 			if elem_kind == .string {
 				fn_builder.writeln('\t\tif (fast_string_eq(((string*)a.data)[i], v)) {')
@@ -1138,8 +1138,8 @@ fn (mut g Gen) gen_array_contains_methods() {
 			if elem_kind == .function {
 				elem_type_str = 'voidptr'
 			}
-			g.type_definitions.writeln('/*KU*/bool ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
-			fn_builder.writeln('bool ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
+			g.type_definitions.writeln('${g.static_non_parallel}bool ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
+			fn_builder.writeln('${g.static_non_parallel}bool ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\tfor (int i = 0; i < ${size}; ++i) {')
 			if elem_kind == .string {
 				fn_builder.writeln('\t\tif (fast_string_eq(a[i], v)) {')
@@ -1244,8 +1244,8 @@ fn (mut g Gen) gen_array_index_methods() {
 				left_type_str = 'Array_voidptr'
 				elem_type_str = 'voidptr'
 			}
-			g.type_definitions.writeln('int ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
-			fn_builder.writeln('int ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
+			g.type_definitions.writeln('${g.static_non_parallel}int ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
+			fn_builder.writeln('${g.static_non_parallel}int ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\t${elem_type_str}* pelem = a.data;')
 			fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i, ++pelem) {')
 			if elem_sym.kind == .string {
@@ -1288,8 +1288,8 @@ fn (mut g Gen) gen_array_index_methods() {
 			if elem_sym.kind == .function {
 				elem_type_str = 'voidptr'
 			}
-			g.type_definitions.writeln('int ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
-			fn_builder.writeln('int ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
+			g.type_definitions.writeln('${g.static_non_parallel}int ${fn_name}(${left_type_str} a, ${elem_type_str} v); // auto')
+			fn_builder.writeln('${g.static_non_parallel}int ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\tfor (int i = 0; i < ${info.size}; ++i) {')
 			if elem_sym.kind == .string {
 				fn_builder.writeln('\t\tif (fast_string_eq(a[i], v)) {')

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -580,7 +580,7 @@ fn (mut g Gen) gen_interface_equality_fn(left_type ast.Type) string {
 	g.generated_eq_fns << left_no_ptr
 
 	info := left.sym.info
-	g.definitions.writeln('bool ${ptr_styp}_interface_eq(${ptr_styp} a, ${ptr_styp} b); // auto')
+	g.definitions.writeln('${g.static_non_parallel}bool ${ptr_styp}_interface_eq(${ptr_styp} a, ${ptr_styp} b); // auto')
 
 	mut fn_builder := strings.new_builder(512)
 	defer {
@@ -590,8 +590,8 @@ fn (mut g Gen) gen_interface_equality_fn(left_type ast.Type) string {
 	left_arg := g.read_field(left_type, '_typ', 'a')
 	right_arg := g.read_field(left_type, '_typ', 'b')
 
-	fn_builder.writeln('int v_typeof_interface_idx_${idx_fn}(int sidx); // for auto eq method')
-	fn_builder.writeln('inline bool ${fn_name}_interface_eq(${ptr_styp} a, ${ptr_styp} b) {')
+	fn_builder.writeln('${g.static_non_parallel}int v_typeof_interface_idx_${idx_fn}(int sidx); // for auto eq method')
+	fn_builder.writeln('${g.static_non_parallel}inline bool ${fn_name}_interface_eq(${ptr_styp} a, ${ptr_styp} b) {')
 	fn_builder.writeln('\tif (${left_arg} == ${right_arg}) {')
 	fn_builder.writeln('\t\tint idx = v_typeof_interface_idx_${idx_fn}(${left_arg});')
 	if info is ast.Interface {

--- a/vlib/v/gen/c/auto_free_methods.v
+++ b/vlib/v/gen/c/auto_free_methods.v
@@ -84,12 +84,12 @@ fn (mut g Gen) gen_free_method(typ ast.Type) string {
 }
 
 fn (mut g Gen) gen_free_for_interface(sym ast.TypeSymbol, info ast.Interface, styp string, fn_name string) {
-	g.definitions.writeln('void ${fn_name}(${styp}* it); // auto')
+	g.definitions.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it); // auto')
 	mut fn_builder := strings.new_builder(128)
 	defer {
 		g.auto_fn_definitions << fn_builder.str()
 	}
-	fn_builder.writeln('void ${fn_name}(${styp}* it) {')
+	fn_builder.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it) {')
 	for t in info.types {
 		typ_ := g.unwrap_generic(t)
 		sub_sym := g.table.sym(typ_)
@@ -106,12 +106,12 @@ fn (mut g Gen) gen_free_for_interface(sym ast.TypeSymbol, info ast.Interface, st
 }
 
 fn (mut g Gen) gen_free_for_struct(typ ast.Type, info ast.Struct, styp string, fn_name string) {
-	g.definitions.writeln('void ${fn_name}(${styp}* it); // auto')
+	g.definitions.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it); // auto')
 	mut fn_builder := strings.new_builder(128)
 	defer {
 		g.auto_fn_definitions << fn_builder.str()
 	}
-	fn_builder.writeln('void ${fn_name}(${styp}* it) {')
+	fn_builder.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it) {')
 	for field in info.fields {
 		field_name := c_name(field.name)
 		sym := g.table.sym(g.unwrap_generic(field.typ))
@@ -176,12 +176,12 @@ fn (mut g Gen) gen_type_name_for_free_call(typ ast.Type) string {
 }
 
 fn (mut g Gen) gen_free_for_array(info ast.Array, styp string, fn_name string) {
-	g.definitions.writeln('void ${fn_name}(${styp}* it); // auto')
+	g.definitions.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it); // auto')
 	mut fn_builder := strings.new_builder(128)
 	defer {
 		g.auto_fn_definitions << fn_builder.str()
 	}
-	fn_builder.writeln('void ${fn_name}(${styp}* it) {')
+	fn_builder.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it) {')
 
 	sym := g.table.sym(g.unwrap_generic(info.elem_type))
 	if sym.kind in [.string, .array, .map, .struct] {
@@ -201,12 +201,12 @@ fn (mut g Gen) gen_free_for_array(info ast.Array, styp string, fn_name string) {
 }
 
 fn (mut g Gen) gen_free_for_map(typ ast.Type, styp string, fn_name string) {
-	g.definitions.writeln('void ${fn_name}(${styp}* it); // auto')
+	g.definitions.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it); // auto')
 	mut fn_builder := strings.new_builder(128)
 	defer {
 		g.auto_fn_definitions << fn_builder.str()
 	}
-	fn_builder.writeln('void ${fn_name}(${styp}* it) {')
+	fn_builder.writeln('${g.static_non_parallel}void ${fn_name}(${styp}* it) {')
 
 	if typ.has_flag(.option) {
 		fn_builder.writeln('\tif (it->state != 2) {')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -279,10 +279,10 @@ fn (mut g Gen) gen_str_for_alias(info ast.Alias, styp string, str_fn_name string
 	is_c_struct := parent_sym.is_c_struct() && str_method_expects_ptr
 	arg_def := if is_c_struct { '${styp}* it' } else { '${styp} it' }
 
-	g.definitions.writeln('string ${str_fn_name}(${arg_def}); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${arg_def}) { return indent_${str_fn_name}(it, 0); }')
-	g.definitions.writeln('string indent_${str_fn_name}(${arg_def}, int indent_count); // auto')
-	g.auto_str_funcs.writeln('string indent_${str_fn_name}(${arg_def}, int indent_count) {')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${arg_def}); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${arg_def}) { return indent_${str_fn_name}(it, 0); }')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${arg_def}, int indent_count); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${arg_def}, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstring indents = string_repeat(_SLIT("    "), indent_count);')
 	if str_method_expects_ptr {
 		it_arg := if is_c_struct { 'it' } else { '&it' }
@@ -306,9 +306,9 @@ fn (mut g Gen) gen_str_for_multi_return(info ast.MultiReturn, styp string, str_f
 	$if trace_autostr ? {
 		eprintln('> gen_str_for_multi_return: ${info.types} | ${styp} | ${str_fn_name}')
 	}
-	g.definitions.writeln('string ${str_fn_name}(${styp} a); // auto')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} a); // auto')
 	mut fn_builder := strings.new_builder(512)
-	fn_builder.writeln('string ${str_fn_name}(${styp} a) {')
+	fn_builder.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} a) {')
 	fn_builder.writeln('\tstrings__Builder sb = strings__new_builder(${info.types.len} * 10);')
 	fn_builder.writeln('\tstrings__Builder_write_string(&sb, _SLIT("("));')
 	for i, typ in info.types {
@@ -354,8 +354,8 @@ fn (mut g Gen) gen_str_for_enum(info ast.Enum, styp string, str_fn_name string) 
 		eprintln('> gen_str_for_enum: ${info} | ${styp} | ${str_fn_name}')
 	}
 	s := util.no_dots(styp)
-	g.definitions.writeln('string ${str_fn_name}(${styp} it); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} it) { /* gen_str_for_enum */')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} it); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} it) { /* gen_str_for_enum */')
 	// Enums tagged with `@[flag]` are special in that they can be a combination of enum values
 	if info.is_flag {
 		clean_name := util.strip_main_name(styp.replace('__', '.'))
@@ -391,12 +391,12 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 		eprintln('> gen_str_for_interface: ${info.types} | ${styp} | ${str_fn_name}')
 	}
 	// _str() functions should have a single argument, the indenting ones take 2:
-	g.definitions.writeln('string ${str_fn_name}(${styp} x); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} x) { return indent_${str_fn_name}(x, 0); }')
-	g.definitions.writeln('string indent_${str_fn_name}(${styp} x, int indent_count); // auto')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x) { return indent_${str_fn_name}(x, 0); }')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} x, int indent_count); // auto')
 	mut fn_builder := strings.new_builder(512)
 	clean_interface_v_type_name := util.strip_main_name(typ_str)
-	fn_builder.writeln('string indent_${str_fn_name}(${styp} x, int indent_count) { /* gen_str_for_interface */')
+	fn_builder.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} x, int indent_count) { /* gen_str_for_interface */')
 	for typ in info.types {
 		sub_sym := g.table.sym(ast.mktyp(typ))
 		mut func_name := g.get_str_fn(typ)
@@ -448,11 +448,11 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, typ_str
 		eprintln('> gen_str_for_union_sum_type: ${info.variants} | ${styp} | ${str_fn_name}')
 	}
 	// _str() functions should have a single argument, the indenting ones take 2:
-	g.definitions.writeln('string ${str_fn_name}(${styp} x); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} x) { return indent_${str_fn_name}(x, 0); }')
-	g.definitions.writeln('string indent_${str_fn_name}(${styp} x, int indent_count); // auto')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x) { return indent_${str_fn_name}(x, 0); }')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} x, int indent_count); // auto')
 	mut fn_builder := strings.new_builder(512)
-	fn_builder.writeln('string indent_${str_fn_name}(${styp} x, int indent_count) {')
+	fn_builder.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} x, int indent_count) {')
 	mut clean_sum_type_v_type_name := ''
 	if info.is_anon {
 		variant_names := info.variants.map(util.strip_main_name(g.table.sym(it).name))
@@ -549,8 +549,8 @@ fn (mut g Gen) gen_str_for_fn_type(info ast.FnType, styp string, str_fn_name str
 	$if trace_autostr ? {
 		eprintln('> gen_str_for_fn_type: ${info.func.name} | ${styp} | ${str_fn_name}')
 	}
-	g.definitions.writeln('string ${str_fn_name}(); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}() { return _SLIT("${g.fn_decl_str(info)}");}')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}() { return _SLIT("${g.fn_decl_str(info)}");}')
 }
 
 fn (mut g Gen) gen_str_for_chan(info ast.Chan, styp string, str_fn_name string) {
@@ -558,8 +558,8 @@ fn (mut g Gen) gen_str_for_chan(info ast.Chan, styp string, str_fn_name string) 
 		eprintln('> gen_str_for_chan: ${info.elem_type.debug()} | ${styp} | ${str_fn_name}')
 	}
 	elem_type_name := util.strip_main_name(g.table.get_type_name(g.unwrap_generic(info.elem_type)))
-	g.definitions.writeln('string ${str_fn_name}(${styp} x); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} x) { return sync__Channel_auto_str(x, _SLIT("${elem_type_name}")); }')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x) { return sync__Channel_auto_str(x, _SLIT("${elem_type_name}")); }')
 }
 
 fn (mut g Gen) gen_str_for_thread(info ast.Thread, styp string, str_fn_name string) {
@@ -567,8 +567,8 @@ fn (mut g Gen) gen_str_for_thread(info ast.Thread, styp string, str_fn_name stri
 		eprintln('> gen_str_for_thread: ${info.return_type.debug()} | ${styp} | ${str_fn_name}')
 	}
 	ret_type_name := util.strip_main_name(g.table.get_type_name(info.return_type))
-	g.definitions.writeln('string ${str_fn_name}(${styp} _); // auto}')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} _) { return _SLIT("thread(${ret_type_name})");}')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} _); // auto}')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} _) { return _SLIT("thread(${ret_type_name})");}')
 }
 
 @[inline]
@@ -607,10 +607,10 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 	sym_has_str_method, str_method_expects_ptr, _ := sym.str_method_info()
 	elem_str_fn_name := g.get_str_fn(typ)
 
-	g.definitions.writeln('string ${str_fn_name}(${styp} a); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} a) { return indent_${str_fn_name}(a, 0);}')
-	g.definitions.writeln('string indent_${str_fn_name}(${styp} a, int indent_count); // auto')
-	g.auto_str_funcs.writeln('string indent_${str_fn_name}(${styp} a, int indent_count) {')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} a); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} a) { return indent_${str_fn_name}(a, 0);}')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} a, int indent_count); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} a, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(a.len * 10);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("["));')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < a.len; ++i) {')
@@ -714,10 +714,10 @@ fn (mut g Gen) gen_str_for_array_fixed(info ast.ArrayFixed, styp string, str_fn_
 	elem_str_fn_name := g.get_str_fn(typ)
 	def_arg := if info.is_fn_ret { '${g.styp(typ)} a[${info.size}]' } else { '${styp} a' }
 
-	g.definitions.writeln('string ${str_fn_name}(${def_arg}); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${def_arg}) { return indent_${str_fn_name}(a, 0);}')
-	g.definitions.writeln('string indent_${str_fn_name}(${def_arg}, int indent_count); // auto')
-	g.auto_str_funcs.writeln('string indent_${str_fn_name}(${def_arg}, int indent_count) {')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${def_arg}); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${def_arg}) { return indent_${str_fn_name}(a, 0);}')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${def_arg}, int indent_count); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${def_arg}, int indent_count) {')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(${info.size} * 10);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("["));')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < ${info.size}; ++i) {')
@@ -810,10 +810,10 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		g.get_str_fn(val_typ)
 	}
 
-	g.definitions.writeln('string ${str_fn_name}(${styp} m); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} m) { return indent_${str_fn_name}(m, 0);}')
-	g.definitions.writeln('string indent_${str_fn_name}(${styp} m, int indent_count); // auto')
-	g.auto_str_funcs.writeln('string indent_${str_fn_name}(${styp} m, int indent_count) { /* gen_str_for_map */')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} m); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} m) { return indent_${str_fn_name}(m, 0);}')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} m, int indent_count); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} m, int indent_count) { /* gen_str_for_map */')
 	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(m.key_values.len*10);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _SLIT("{"));')
 	g.auto_str_funcs.writeln('\tbool is_first = true;')
@@ -945,9 +945,9 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 	// _str() functions should have a single argument, the indenting ones take 2:
 	is_c_struct := lang == .c
 	arg_def := if is_c_struct { '${styp}* it' } else { '${styp} it' }
-	g.definitions.writeln('string ${str_fn_name}(${arg_def}); // auto')
-	g.auto_str_funcs.writeln('string ${str_fn_name}(${arg_def}) { return indent_${str_fn_name}(it, 0);}')
-	g.definitions.writeln('string indent_${str_fn_name}(${arg_def}, int indent_count); // auto')
+	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${arg_def}); // auto')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${arg_def}) { return indent_${str_fn_name}(it, 0);}')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${arg_def}, int indent_count); // auto')
 	mut fn_builder := strings.new_builder(512)
 	defer {
 		g.auto_fn_definitions << fn_builder.str()
@@ -1281,9 +1281,9 @@ fn (mut g Gen) gen_enum_static_from_string(fn_name string, mod_enum_name string,
 	enum_field_vals := g.table.get_enum_field_vals(mod_enum_name)
 
 	mut fn_builder := strings.new_builder(512)
-	g.definitions.writeln('${option_enum_styp} ${fn_name}(string name); // auto')
+	g.definitions.writeln('${g.static_non_parallel}${option_enum_styp} ${fn_name}(string name); // auto')
 
-	fn_builder.writeln('${option_enum_styp} ${fn_name}(string name) {')
+	fn_builder.writeln('${g.static_non_parallel}${option_enum_styp} ${fn_name}(string name) {')
 	fn_builder.writeln('\t${option_enum_styp} t1;')
 	fn_builder.writeln('\tbool exists = false;')
 	fn_builder.writeln('\tint inx = 0;')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -607,12 +607,13 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	if g.sort_fn_definitions.len > 0 {
 		b.write_string2('\n// V sort fn definitions:\n', g.sort_fn_definitions.str())
 	}
-	b.writeln('\n// V global/const non-precomputed definitions:')
-	for var_name in g.sorted_global_const_names {
-		if var := g.global_const_defs[var_name] {
-			if !var.def.starts_with('#define')
-				&& (!g.pref.parallel_cc || !var.def.ends_with('// global4\n')) {
-				b.writeln(var.def)
+	if !pref_.parallel_cc {
+		b.writeln('\n// V global/const non-precomputed definitions:')
+		for var_name in g.sorted_global_const_names {
+			if var := g.global_const_defs[var_name] {
+				if !var.def.starts_with('#define') {
+					b.writeln(var.def)
+				}
 			}
 		}
 	}
@@ -681,8 +682,13 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 		b.writeln('\n// V global/const non-precomputed definitions:')
 		for var_name in g.sorted_global_const_names {
 			if var := g.global_const_defs[var_name] {
-				if !var.def.starts_with('#define') && var.def.ends_with('// global4\n') {
+				if !var.def.starts_with('#define') {
 					b.writeln(var.def)
+					if var.def.contains(' = ') {
+						g.extern_out.writeln('extern ${var.def.all_before(' = ')};')
+					} else {
+						g.extern_out.writeln('extern ${var.def}')
+					}
 				}
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -51,7 +51,8 @@ pub struct Gen {
 	module_built        string
 	timers_should_print bool
 mut:
-	out strings.Builder
+	out        strings.Builder
+	extern_out strings.Builder // extern declarations for -parallel-cc
 	// line_nr                   int
 	cheaders                  strings.Builder
 	preincludes               strings.Builder // allows includes to go before `definitions`
@@ -272,7 +273,7 @@ mut:
 	vweb_filter_fn_name  string // vweb__filter or x__vweb__filter, used by $vweb.html() for escaping strings in the templates, depending on which `vweb` import is used
 }
 
-pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (string, string, string, []int) {
+pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (string, string, string, string, []int) {
 	mut module_built := ''
 	if pref_.build_mode == .build_module {
 		for file in files {
@@ -607,7 +608,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	b.writeln('\n// V global/const non-precomputed definitions:')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
-			if !var.def.starts_with('#define') {
+			if !var.def.starts_with('#define') && !var.def.ends_with('// global4\n') {
 				b.writeln(var.def)
 			}
 		}
@@ -658,6 +659,14 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	// Code added here (after the header) goes to out_0.c in parallel cc mode
 	// Previously it went to the header which resulted in duplicated code and more code
 	// to compile for the C compiler
+	b.writeln('\n// V global/const non-precomputed definitions:')
+	for var_name in g.sorted_global_const_names {
+		if var := g.global_const_defs[var_name] {
+			if !var.def.starts_with('#define') && var.def.ends_with('// global4\n') {
+				b.writeln(var.def)
+			}
+		}
+	}
 	if g.auto_str_funcs.len > 0 {
 		b.write_string2('\n// V auto str functions:\n', g.auto_str_funcs.str())
 	}
@@ -681,6 +690,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	b.writeln('// ZULUL2')
 	// The rest of the output
 	out_str := g.out.str()
+	extern_out_str := g.extern_out.str()
 	b.write_string(out_str)
 	b.writeln('// THE END.')
 	util.timing_measure('cgen common')
@@ -695,7 +705,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	unsafe { b.free() }
 	unsafe { g.free_builders() }
 
-	return header, res, out_str, out_fn_start_pos
+	return header, res, out_str, extern_out_str, out_fn_start_pos
 }
 
 fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) &Gen {
@@ -1089,8 +1099,12 @@ pub fn (mut g Gen) write_typeof_functions() {
 			if inter_info.is_generic {
 				continue
 			}
-			g.definitions.writeln('static char * v_typeof_interface_${sym.cname}(int sidx);')
-			g.writeln('static char * v_typeof_interface_${sym.cname}(int sidx) {')
+			static_modifier := if g.pref.parallel_cc { '' } else { 'static ' }
+			g.definitions.writeln('${static_modifier}char * v_typeof_interface_${sym.cname}(int sidx);')
+			if g.pref.parallel_cc {
+				g.extern_out.writeln('extern char * v_typeof_interface_${sym.cname}(int sidx);')
+			}
+			g.writeln('${static_modifier}char * v_typeof_interface_${sym.cname}(int sidx) {')
 			for t in inter_info.types {
 				sub_sym := g.table.sym(ast.mktyp(t))
 				if sub_sym.info is ast.Struct && sub_sym.info.is_unresolved_generic() {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -662,6 +662,21 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	// Code added here (after the header) goes to out_0.c in parallel cc mode
 	// Previously it went to the header which resulted in duplicated code and more code
 	// to compile for the C compiler
+	if g.anon_fn_definitions.len > 0 {
+		if g.nr_closures > 0 {
+			b.writeln2('\n// V closure helpers', c_closure_fn_helpers(g.pref))
+		}
+		/*
+		b.writeln('\n// V anon functions:')
+		for fn_def in g.anon_fn_definitions {
+			b.writeln(fn_def)
+		}
+		*/
+		if g.pref.parallel_cc {
+			g.extern_out.writeln('extern void* __closure_create(void* fn, void* data);')
+			g.extern_out.writeln('extern void __closure_init();')
+		}
+	}
 	if g.pref.parallel_cc {
 		b.writeln('\n// V global/const non-precomputed definitions:')
 		for var_name in g.sorted_global_const_names {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -608,7 +608,8 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	b.writeln('\n// V global/const non-precomputed definitions:')
 	for var_name in g.sorted_global_const_names {
 		if var := g.global_const_defs[var_name] {
-			if !var.def.starts_with('#define') && !var.def.ends_with('// global4\n') {
+			if !var.def.starts_with('#define')
+				&& (!g.pref.parallel_cc || !var.def.ends_with('// global4\n')) {
 				b.writeln(var.def)
 			}
 		}
@@ -659,11 +660,13 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) (str
 	// Code added here (after the header) goes to out_0.c in parallel cc mode
 	// Previously it went to the header which resulted in duplicated code and more code
 	// to compile for the C compiler
-	b.writeln('\n// V global/const non-precomputed definitions:')
-	for var_name in g.sorted_global_const_names {
-		if var := g.global_const_defs[var_name] {
-			if !var.def.starts_with('#define') && var.def.ends_with('// global4\n') {
-				b.writeln(var.def)
+	if g.pref.parallel_cc {
+		b.writeln('\n// V global/const non-precomputed definitions:')
+		for var_name in g.sorted_global_const_names {
+			if var := g.global_const_defs[var_name] {
+				if !var.def.starts_with('#define') && var.def.ends_with('// global4\n') {
+					b.writeln(var.def)
+				}
 			}
 		}
 	}

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -169,8 +169,17 @@ static pthread_mutex_t _closure_mtx;
 #define _closure_mtx_lock() pthread_mutex_lock(&_closure_mtx)
 #define _closure_mtx_unlock() pthread_mutex_unlock(&_closure_mtx)
 #endif
-static char* _closure_ptr = 0;
-static int _closure_cap = 0;
+')
+	return builder.str()
+}
+
+fn c_closure_fn_helpers(pref_ &pref.Preferences) string {
+	static_non_parallel := if pref_.parallel_cc { '' } else { 'static ' }
+
+	mut builder := strings.new_builder(2048)
+	builder.write_string('
+	${static_non_parallel}char* _closure_ptr = 0;
+	${static_non_parallel}int _closure_cap = 0;
 
 static void __closure_alloc(void) {
 #ifdef _WIN32
@@ -213,7 +222,7 @@ void __closure_init() {
 	_closure_cap--;
 }
 #else
-static void __closure_init() {
+${static_non_parallel}void __closure_init() {
 	uint32_t page_size = sysconf(_SC_PAGESIZE);
 	page_size = page_size * (((ASSUMED_PAGE_SIZE - 1) / page_size) + 1);
 	_V_page_size = page_size;
@@ -227,7 +236,7 @@ static void __closure_init() {
 }
 #endif
 
-static void* __closure_create(void* fn, void* data) {
+${static_non_parallel}void* __closure_create(void* fn, void* data) {
 	_closure_mtx_lock();
 	if (_closure_cap == 0) {
 		__closure_alloc();

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -57,7 +57,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 					val := g.expr_string(field.expr)
 					g.global_const_defs[util.no_dots(field.name)] = GlobalConstDef{
 						mod:       field.mod
-						def:       '${g.static_modifier} ${styp} ${const_name} = ${val}; // fixed array const'
+						def:       '${g.static_non_parallel}${styp} ${const_name} = ${val}; // fixed array const'
 						dep_names: g.table.dependent_names_in_expr(field_expr)
 					}
 				} else if field.expr.is_fixed && !field.expr.has_index
@@ -123,7 +123,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 							val := g.expr_string(field.expr.expr)
 							g.global_const_defs[util.no_dots(field.name)] = GlobalConstDef{
 								mod:       field.mod
-								def:       '${g.static_modifier} ${styp} ${const_name} = ${val}; // fixed array const'
+								def:       '${g.static_non_parallel}${styp} ${const_name} = ${val}; // fixed array const'
 								dep_names: g.table.dependent_names_in_expr(field_expr)
 							}
 							continue
@@ -262,7 +262,7 @@ fn (mut g Gen) const_decl_write_precomputed(mod string, styp string, cname strin
 	}
 	g.global_const_defs[util.no_dots(field_name)] = GlobalConstDef{
 		mod: mod
-		def: '${g.static_modifier}const ${styp} ${cname} = ${ct_value}; // precomputed2'
+		def: '${g.static_non_parallel}const ${styp} ${cname} = ${ct_value}; // precomputed2'
 		// is_precomputed: true
 	}
 }
@@ -450,9 +450,6 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		extern := if cextern { 'extern ' } else { '' }
 		modifier := if field.is_volatile { ' volatile ' } else { '' }
 		def_builder.write_string('${extern}${visibility_kw}${modifier}${styp} ${attributes}${field.name}')
-		if g.pref.parallel_cc {
-			g.extern_out.writeln('extern ${visibility_kw}${modifier}${styp} ${attributes}${field.name};')
-		}
 		if cextern {
 			def_builder.writeln('; // global5')
 			g.global_const_defs[util.no_dots(field.name)] = GlobalConstDef{

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -450,6 +450,9 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		extern := if cextern { 'extern ' } else { '' }
 		modifier := if field.is_volatile { ' volatile ' } else { '' }
 		def_builder.write_string('${extern}${visibility_kw}${modifier}${styp} ${attributes}${field.name}')
+		if g.pref.parallel_cc {
+			g.extern_out.writeln('extern ${visibility_kw}${modifier}${styp} ${attributes}${field.name};')
+		}
 		if cextern {
 			def_builder.writeln('; // global5')
 			g.global_const_defs[util.no_dots(field.name)] = GlobalConstDef{

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -675,7 +675,7 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	}
 	node.has_gen[fn_name] = true
 	mut builder := strings.new_builder(256)
-	builder.writeln('/*F1*/')
+	// builder.writeln('/*F1*/')
 	// Generate a closure struct
 	if node.inherited_vars.len > 0 {
 		ctx_struct := g.closure_ctx(node.decl)
@@ -701,9 +701,9 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	g.anon_fn = true
 	g.fn_decl(node.decl)
 	g.anon_fn = was_anon_fn
-	builder.write_string('/*LOL*/')
+	// builder.write_string('/*LOL*/')
 	builder.write_string(g.out.cut_to(pos))
-	builder.writeln('/*F2*/')
+	// builder.writeln('/*F2*/')
 	g.anon_fn_definitions << builder.str()
 }
 

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -375,9 +375,11 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 			if g.pref.build_mode != .build_module && !g.pref.use_cache {
 				// If we are building vlib/builtin, we need all private functions like array_get
 				// to be public, so that all V programs can access them.
-				g.write('VV_LOCAL_SYMBOL ')
-				// g.definitions.write_string('${g.static_modifier} VV_LOCAL_SYMBOL ')
-				g.definitions.write_string('VV_LOCAL_SYMBOL ')
+				if !(node.is_anon && g.pref.parallel_cc) {
+					g.write('VV_LOCAL_SYMBOL ')
+					// g.definitions.write_string('${g.static_modifier} VV_LOCAL_SYMBOL ')
+					g.definitions.write_string('VV_LOCAL_SYMBOL ')
+				}
 			}
 		}
 		// as a temp solution generic functions are marked static
@@ -704,7 +706,11 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	// builder.write_string('/*LOL*/')
 	builder.write_string(g.out.cut_to(pos))
 	// builder.writeln('/*F2*/')
-	g.anon_fn_definitions << builder.str()
+	out := builder.str()
+	g.anon_fn_definitions << out
+	if g.pref.parallel_cc {
+		g.extern_out.writeln('extern ${out.all_before(' {')};')
+	}
 }
 
 fn (g &Gen) defer_flag_var(stmt &ast.DeferStmt) string {

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -109,7 +109,7 @@ fn test_one() {
 	}
 	mut checker_ := checker.new_checker(table, vpref)
 	checker_.check(mut program)
-	mut res, _, _, _ := c.gen([program], mut table, vpref)
+	mut res, _, _, _, _ := c.gen([program], mut table, vpref)
 	res = res.replace('\n', '').trim_space().after('#endif')
 	println(res)
 	ok := expected == res

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -152,7 +152,7 @@ fn test_parse_expr() {
 		global_scope: scope
 	}
 	chk.check(mut program)
-	mut res, _, _, _ := c.gen([program], mut table, vpref)
+	mut res, _, _, _, _ := c.gen([program], mut table, vpref)
 	res = res.after('#endif')
 	println('========')
 	println(res)


### PR DESCRIPTION
This PR fixes the global codegen on `-parallel-cc`.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVjMTk5OTFlMDYzMmRkMDhlMzc4YjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.wKMQAiLCSBl4E_anzdTuv0n-gUuTmxaQknBp9S40SO0">Huly&reg;: <b>V_0.6-21585</b></a></sub>