### PR TITLE
fmt: fix shared receiver formatting

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1721,6 +1721,7 @@ pub fn (mut f Fmt) fn_type_decl(node ast.FnTypeDecl) {
 			if s.starts_with('&') {
 				s = s[1..]
 			}
+			s = s.trim_left('shared ')
 		}
 		is_last_arg := i == fn_info.params.len - 1
 		should_add_type := true || is_last_arg

--- a/vlib/v/fmt/tests/receiver_state_keep.vv
+++ b/vlib/v/fmt/tests/receiver_state_keep.vv
@@ -1,0 +1,5 @@
+module main
+
+struct State {}
+
+type Func = fn (shared state State) string


### PR DESCRIPTION
Fix #23151

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVjYjQ1NjFlMDYzMmRkMDhlMzhiMzAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.4FBN4uvFq0XtsyN0LKxSbIwcKdpervNJHOE_mqCJQtA">Huly&reg;: <b>V_0.6-21590</b></a></sub>