### PR TITLE
parser: allow `type` as plain attr value

### DIFF
--- a/vlib/v/fmt/tests/keyword_attr_keep.vv
+++ b/vlib/v/fmt/tests/keyword_attr_keep.vv
@@ -4,4 +4,6 @@ struct Type {
 
 pub struct Token {
 	foo Type @[json: type]
+	bar Type @[fn; json: if]
+	baz Type @[for; json: while; spawn]
 }

--- a/vlib/v/fmt/tests/type_attr_keep.vv
+++ b/vlib/v/fmt/tests/type_attr_keep.vv
@@ -1,0 +1,7 @@
+struct Type {
+	a int
+}
+
+pub struct Token {
+	foo Type @[json: type]
+}

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2045,7 +2045,7 @@ fn (mut p Parser) parse_attr(is_at bool) ast.Attr {
 		if p.tok.kind == .colon {
 			has_arg = true
 			p.next()
-			if p.tok.kind == .name || p.tok.kind == .key_type { // `name: arg`
+			if p.tok.kind == .name || (p.tok.kind != .string && token.is_key(p.tok.lit)) { // `name: arg`
 				kind = .plain
 				arg = p.check_name()
 			} else if p.tok.kind == .number { // `name: 123`

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2045,7 +2045,7 @@ fn (mut p Parser) parse_attr(is_at bool) ast.Attr {
 		if p.tok.kind == .colon {
 			has_arg = true
 			p.next()
-			if p.tok.kind == .name { // `name: arg`
+			if p.tok.kind == .name || p.tok.kind == .key_type { // `name: arg`
 				kind = .plain
 				arg = p.check_name()
 			} else if p.tok.kind == .number { // `name: 123`


### PR DESCRIPTION
Fix #23150

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVjYjkwYjFlMDYzMmRkMDhlMzhiNmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.DG1fSKB_kX2K5SQqKXO6k5qggTkH1zu6jTPOzVrFHCQ">Huly&reg;: <b>V_0.6-21591</b></a></sub>