### PR TITLE
comptime: fix missing bool AttributeKind.kind

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -153,7 +153,8 @@ pub enum AttributeKind {
 	plain           // [name]
 	string          // ['name']
 	number          // [123]
-	comptime_define // [if name]
+	bool            // [true] || [false]
+	comptime_define // [if name]	
 }
 
 pub struct VAttribute {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2045,7 +2045,7 @@ fn (mut p Parser) parse_attr(is_at bool) ast.Attr {
 		if p.tok.kind == .colon {
 			has_arg = true
 			p.next()
-			if p.tok.kind == .name || (p.tok.kind != .string && token.is_key(p.tok.lit)) { // `name: arg`
+			if p.tok.kind == .name { // `name: arg`
 				kind = .plain
 				arg = p.check_name()
 			} else if p.tok.kind == .number { // `name: 123`
@@ -2060,6 +2060,9 @@ fn (mut p Parser) parse_attr(is_at bool) ast.Attr {
 				kind = .bool
 				arg = p.tok.kind.str()
 				p.next()
+			} else if token.is_key(p.tok.lit) { // // `name: keyword`
+				kind = .plain
+				arg = p.check_name()
 			} else {
 				p.unexpected(additional_msg: 'an argument is expected after `:`')
 			}

--- a/vlib/v/tests/comptime/comptime_attribute_selector_test.v
+++ b/vlib/v/tests/comptime/comptime_attribute_selector_test.v
@@ -1,3 +1,4 @@
+@[foo: true]
 @[name: 'abc']
 @[amount: 2]
 @[abc]
@@ -26,8 +27,19 @@ fn test_attributes() {
 		} else if attr.has_arg && attr.kind == .number {
 			assert attr.name == 'amount'
 			assert attr.arg == '2'
-		} else {
+		} else if attr.kind != .bool {
 			assert attr.name == 'abc'
 		}
 	}
+}
+
+fn test_attr_boolean() {
+	mut bool_fields := []string{}
+	$for attr in Abc.attributes {
+		if attr.kind == .bool {
+			bool_fields << attr.name
+		}
+	}
+	assert bool_fields.len == 1
+	assert bool_fields[0] == 'foo'
 }


### PR DESCRIPTION
This PR fixes a recent bug introduced by my PR override bool attributes identification. And fixes missing .bool kind for comptime .attributes kind.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVkNmFhMTFlMDYzMmRkMDhlMzk4OGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.dOZjFumQCbmtaxXZXfOmCDhRaCW99tus0Ls28Z-TEAo">Huly&reg;: <b>V_0.6-21596</b></a></sub>