### PR TITLE
cgen: fix codegen for array append on indexexpr

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -348,13 +348,16 @@ fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		g.writeln(';')
 		g.past_tmp_var_done(past)
 	} else if node.left is ast.IndexExpr && node.left.is_setter {
-		past := g.past_tmp_var_new()
+		line := g.go_before_last_stmt().trim_space()
+		g.empty_line = true
+		tmp_var := g.new_tmp_var()
 		styp := g.styp(node.left_type)
-		g.write('${styp}* ${past.tmp_var} = &')
+		g.write('${styp}* ${tmp_var} = &')
 		g.expr(node.left)
 		g.writeln(';')
+		g.write(line)
 		g.write('(*')
-		g.past_tmp_var_done(past)
+		g.write(tmp_var)
 		g.write(')')
 	} else {
 		if is_fn_index_call {

--- a/vlib/v/tests/left_shift_array_fixed_test.v
+++ b/vlib/v/tests/left_shift_array_fixed_test.v
@@ -1,0 +1,7 @@
+fn test_main() {
+	mut space := [2][2][]int{}
+	space[1][1] << 123
+	space[0][0] << 321
+	assert space[1][1] == [123]
+	assert space[0][0] == [321]
+}


### PR DESCRIPTION
Fix #23156

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVkODAwYzFlMDYzMmRkMDhlMzk5NzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.jzfwwx9C3lYczTuHFP3jo9sXzXoOyz3fM4WiEjfrdXw">Huly&reg;: <b>V_0.6-21597</b></a></sub>