### PR TITLE
cgen: fix fixed array option cast with `none`

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5364,10 +5364,14 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.expr(node.expr)
 		g.write('))')
 	} else if sym.kind == .alias && g.table.final_sym(node.typ).kind == .array_fixed {
-		if node.expr is ast.ArrayInit && g.assign_op != .decl_assign {
-			g.write('(${g.styp(node.expr.typ)})')
+		if node.typ.has_flag(.option) {
+			g.expr_with_opt(node.expr, expr_type, node.typ)
+		} else {
+			if node.expr is ast.ArrayInit && g.assign_op != .decl_assign {
+				g.write('(${g.styp(node.expr.typ)})')
+			}
+			g.expr(node.expr)
 		}
-		g.expr(node.expr)
 	} else if expr_type == ast.bool_type && node.typ.is_int() {
 		styp := g.styp(node_typ)
 		g.write('(${styp}[]){(')

--- a/vlib/v/tests/alias_cast_to_fixed_array_test.v
+++ b/vlib/v/tests/alias_cast_to_fixed_array_test.v
@@ -1,0 +1,24 @@
+type Bytes = [3]u8
+type Strs = [3]string
+
+fn test_none() {
+	b := ?Bytes(none)
+	println(b)
+	assert b == none
+
+	c := ?Strs(none)
+	println(c)
+	assert c == none
+}
+
+fn test_non_none() {
+	b := ?Bytes([u8(1), 2, 3]!)
+	println(b)
+	assert b != none
+	assert b?[2] == 3
+
+	c := ?Strs(['a', 'b', 'c']!)
+	println(c)
+	assert c != none
+	assert c?[2] == 'c'
+}


### PR DESCRIPTION
Fix #23164

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVlMjg3MjFlMDYzMmRkMDhlM2FhZTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.JFMwLBqzPkJ2x_D-RGdIZtabK7Grj3NUXV97eiVOmlg">Huly&reg;: <b>V_0.6-21605</b></a></sub>