### PR TITLE
cgen: fix selector call with reserved c name

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2180,7 +2180,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 		// Skip "C."
 		name = util.no_dots(name[2..])
 	} else {
-		name = c_fn_name(name)
+		name = if is_selector_call { c_name(name) } else { c_fn_name(name) }
 	}
 	if g.pref.translated || g.file.is_translated || node.is_file_translated {
 		// For `@[c: 'P_TryMove'] fn p_trymove( ... `

--- a/vlib/v/tests/selector_call_with_reserved_c_name_test.v
+++ b/vlib/v/tests/selector_call_with_reserved_c_name_test.v
@@ -1,0 +1,21 @@
+struct Foo {
+}
+
+struct Bar {
+	do fn () bool = unsafe { nil }
+}
+
+fn (f Foo) get() Bar {
+	return Bar{
+		do: foobar
+	}
+}
+
+fn foobar() bool {
+	return true
+}
+
+fn test_main() {
+	t := Foo{}
+	assert t.get().do() == true
+}


### PR DESCRIPTION
Fix #23170

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVmM2QxNWYxNDRmNTg1YWU0ZDY5OGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.F_WmKus1wn219oxgUlGYgogrMN8vsM56sIw_rb3BpkE">Huly&reg;: <b>V_0.6-21612</b></a></sub>