### PR TITLE
parser,checker,cgen,fmt: fix array fixed option initialization (`none`)

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -1645,6 +1645,7 @@ fn (t Tree) array_init(node ast.ArrayInit) &Node {
 	obj.add('pre_cmnts', t.array_node_comment(node.pre_cmnts))
 	obj.add('elem_type_pos', t.pos(node.elem_type_pos))
 	obj.add_terse('is_fixed', t.bool_node(node.is_fixed))
+	obj.add_terse('is_option', t.bool_node(node.is_option))
 	obj.add_terse('has_val', t.bool_node(node.has_val))
 	obj.add_terse('mod', t.string_node(node.mod))
 	obj.add_terse('len_expr', t.expr(node.len_expr))

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1546,12 +1546,13 @@ pub:
 	ecmnts        [][]Comment // optional iembed comments after each expr
 	pre_cmnts     []Comment
 	is_fixed      bool
+	is_option     bool // true if it was declared as ?[2]Type or ?[]Type
 	has_val       bool // fixed size literal `[expr, expr]!`
 	mod           string
 	has_len       bool
 	has_cap       bool
 	has_init      bool
-	has_index     bool // true if temp variable index is used
+	has_index     bool // true if temp variable index is used	
 pub mut:
 	exprs        []Expr // `[expr, expr]` or `[expr]Type{}` for fixed array
 	len_expr     Expr   // len: expr

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -285,6 +285,9 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			|| c.array_fixed_has_unresolved_size(sym.info as ast.ArrayFixed) {
 			mut size_expr := node.exprs[0]
 			node.typ = c.eval_array_fixed_sizes(mut size_expr, 0, node.elem_type)
+			if node.is_option {
+				node.typ = node.typ.set_flag(.option)
+			}
 			node.elem_type = (c.table.sym(node.typ).info as ast.ArrayFixed).elem_type
 		}
 		if node.has_init {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1818,6 +1818,9 @@ pub fn (mut f Fmt) array_decompose(node ast.ArrayDecompose) {
 }
 
 pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
+	if node.is_fixed && node.is_option {
+		f.write('?')
+	}
 	if node.exprs.len == 0 && node.typ != 0 && node.typ != ast.void_type {
 		// `x := []string{}`
 		f.mark_types_import_as_used(node.typ)

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -127,7 +127,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 	}
 	is_none := node.is_option && !node.has_init && !node.has_val
 
-	if (g.inside_struct_init && g.inside_cast && !g.inside_memset) || node.is_option {
+	if (g.inside_struct_init && g.inside_cast && !g.inside_memset) || (node.is_option && !is_none) {
 		ret_typ_str := g.styp(node.typ)
 		g.write('(${ret_typ_str})')
 	}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -131,7 +131,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 	}
 	elem_sym := g.table.final_sym(node.elem_type)
 	is_struct := g.inside_array_fixed_struct && elem_sym.kind == .struct
-	if !is_struct {
+	if !is_struct && !node.is_option {
 		g.write('{')
 	}
 	if node.has_val {
@@ -212,6 +212,8 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			})
 			schan_expr := g.out.cut_to(before_chan_expr_pos)
 			g.write_c99_elements_for_array(array_info.size, schan_expr)
+		} else if node.is_option {
+			g.gen_option_error(node.typ, ast.None{})
 		} else {
 			std := g.type_default(node.elem_type)
 			if g.can_use_c99_designators() && std == '0' {
@@ -226,7 +228,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			}
 		}
 	}
-	if !is_struct {
+	if !is_struct && !node.is_option {
 		g.write('}')
 	}
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -125,14 +125,19 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 		g.set_current_pos_as_last_stmt_pos()
 		return
 	}
-	if g.inside_struct_init && g.inside_cast && !g.inside_memset {
+	is_none := node.is_option && !node.has_init && !node.has_val
+
+	if (g.inside_struct_init && g.inside_cast && !g.inside_memset) || node.is_option {
 		ret_typ_str := g.styp(node.typ)
 		g.write('(${ret_typ_str})')
 	}
 	elem_sym := g.table.final_sym(node.elem_type)
 	is_struct := g.inside_array_fixed_struct && elem_sym.kind == .struct
-	if !is_struct && !node.is_option {
+	if !is_struct && !is_none {
 		g.write('{')
+	}
+	if node.is_option && !is_none {
+		g.write('.state=0, .err=_const_none__, .data={')
 	}
 	if node.has_val {
 		tmp_inside_array := g.inside_array_item
@@ -212,7 +217,7 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			})
 			schan_expr := g.out.cut_to(before_chan_expr_pos)
 			g.write_c99_elements_for_array(array_info.size, schan_expr)
-		} else if node.is_option {
+		} else if is_none {
 			g.gen_option_error(node.typ, ast.None{})
 		} else {
 			std := g.type_default(node.elem_type)
@@ -228,7 +233,10 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			}
 		}
 	}
-	if !is_struct && !node.is_option {
+	if node.is_option && !is_none {
+		g.write('}')
+	}
+	if !is_struct && !is_none {
 		g.write('}')
 	}
 }

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -192,6 +192,7 @@ fn (mut p Parser) array_init(is_option bool, alias_array_type ast.Type) ast.Arra
 		has_index:     has_index
 		cap_expr:      cap_expr
 		init_expr:     init_expr
+		is_option:     is_option
 	}
 }
 

--- a/vlib/v/tests/array_fixed_none_init_test.v
+++ b/vlib/v/tests/array_fixed_none_init_test.v
@@ -1,0 +1,13 @@
+fn test_none_init() {
+	a := ?[3]u8(none)
+	println(a)
+	assert a == none
+
+	b := [3]u8{}
+	println(b)
+	assert b == none
+
+	c := [3]u8{}
+	println(c)
+	assert c == none
+}

--- a/vlib/v/tests/array_fixed_none_init_test.v
+++ b/vlib/v/tests/array_fixed_none_init_test.v
@@ -9,8 +9,15 @@ fn test_none_init() {
 	assert c == none
 }
 
+fn foo() u8 {
+	return 123
+}
+
 fn test_non_none_init() {
 	c := ?[3]u8{init: 2}
 	assert c? == [u8(2), 2, 2]!
 	assert c != none
+
+	d := ?[3]u8{init: foo()}
+	assert d? == [u8(123), 123, 123]!
 }

--- a/vlib/v/tests/array_fixed_none_init_test.v
+++ b/vlib/v/tests/array_fixed_none_init_test.v
@@ -1,13 +1,16 @@
 fn test_none_init() {
 	a := ?[3]u8(none)
-	println(a)
 	assert a == none
 
-	b := [3]u8{}
-	println(b)
+	b := ?[3]u8{}
 	assert b == none
 
-	c := [3]u8{}
-	println(c)
+	c := ?[3]u8{}
 	assert c == none
+}
+
+fn test_non_none_init() {
+	c := ?[3]u8{init: 2}
+	assert c? == [u8(2), 2, 2]!
+	assert c != none
 }


### PR DESCRIPTION
Complement fix for #23164

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVmNDZhNGYxNDRmNTg1YWU0ZDY5YjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ALUSJcKuZxmjXkqSfUEAmqPiaqYl9_rwkNJibg3k19E">Huly&reg;: <b>V_0.6-21613</b></a></sub>