### PR TITLE
cgen, checker: fix option unwrapping and call from option struct field

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -834,6 +834,7 @@ pub mut:
 	is_return_used         bool // return value is used for another expr
 	//
 	is_expand_simple_interpolation bool // true, when the function/method is marked as @[expand_simple_interpolation]
+	is_unwrapped_fn_selector       bool // true, when the call is from an unwrapped selector (e.g. if t.foo != none { t.foo() })
 	// Calls to it with an interpolation argument like `b.f('x ${y}')`, will be converted to `b.f('x ')` followed by `b.f(y)`.
 	// The same type, has to support also a .write_decimal(n i64) method.
 }

--- a/vlib/v/tests/options/option_method_selector_test.v
+++ b/vlib/v/tests/options/option_method_selector_test.v
@@ -1,0 +1,29 @@
+struct Foo {
+mut:
+	func ?fn (voidptr) bool = unsafe { nil }
+}
+
+fn callback(foo &Foo) bool {
+	return foo.func? == callback
+}
+
+type OptFn = fn (&Foo) bool
+
+fn test_main() {
+	t := Foo{
+		func: callback
+	}
+	assert t.func? == callback
+	if t.func != none {
+		assert t.func(&t)
+	} else {
+		assert false
+	}
+
+	a := ?OptFn(callback)
+	if a != none {
+		assert a(&t)
+	} else {
+		assert false
+	}
+}

--- a/vlib/v/tests/options/option_method_selector_test.v
+++ b/vlib/v/tests/options/option_method_selector_test.v
@@ -4,7 +4,7 @@ mut:
 }
 
 fn callback(foo &Foo) bool {
-	return foo.func? == callback
+	return foo.func != none
 }
 
 type OptFn = fn (&Foo) bool


### PR DESCRIPTION
Make works:

```v
struct Foo {
mut:
	func ?fn (voidptr) ?bool = unsafe { nil }
}

fn callback(foo &Foo) ?bool {
	return foo.func? == callback
}

fn test_main() {
	t := Foo{
		func: callback
	}
	assert t.func? == callback
	if t.func != none {
		assert t.func(&t)
	} else {
		assert false
	}
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYwMWEwZGYxNDRmNTg1YWU0ZDg1NWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.RdjTIOlzQoGbLltZtzsF3jZC49AGek8GkTHNEkpkExI">Huly&reg;: <b>V_0.6-21619</b></a></sub>