### PR TITLE
ci: remove extra EOL from linux_ci.yml

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -177,4 +177,3 @@ jobs:
         run: v run ci/linux_ci.vsh build_modules_clang
       - name: native machine code generation
         run: v run ci/linux_ci.vsh native_machine_code_generation_clang
-


### PR DESCRIPTION
Extra blank line was failing `prettier` check.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYwYzRlM2YxNDRmNTg1YWU0ZGE4OTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.KhpAQbBfj7aWa2jFd6Jf1ffakl0wfewiOfwueSoEdz8">Huly&reg;: <b>V_0.6-21624</b></a></sub>