### PR TITLE
cgen: fix assign optional aliases of fixed array (fix #23185)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -492,11 +492,21 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				g.write(' = ')
 				g.expr_with_opt(val, val_type, var_type)
 			} else if unaliased_right_sym.kind == .array_fixed && val is ast.CastExpr {
-				g.write('memcpy(')
-				g.expr(left)
-				g.write(', ')
-				g.expr(val)
-				g.writeln(', sizeof(${g.styp(var_type)}));')
+				if var_type.has_flag(.option) {
+					g.expr(left)
+					g.writeln('.state = 0;')
+					g.write('memcpy(')
+					g.expr(left)
+					g.write('.data, ')
+					g.expr(val)
+					g.writeln(', sizeof(${g.styp(var_type.clear_flag(.option))}));')
+				} else {
+					g.write('memcpy(')
+					g.expr(left)
+					g.write(', ')
+					g.expr(val)
+					g.writeln(', sizeof(${g.styp(var_type)}));')
+				}
 			} else {
 				mut v_var := ''
 				arr_typ := styp.trim('*')

--- a/vlib/v/tests/assign/assign_option_of_fixed_array_test.v
+++ b/vlib/v/tests/assign/assign_option_of_fixed_array_test.v
@@ -1,0 +1,8 @@
+type Addr = [4]u8
+
+fn test_assign_option_of_fixed_array() {
+	mut addr := ?Addr(none)
+	addr = Addr([u8(1), 2, 3, 4]!)
+	println(addr)
+	assert '${addr}' == 'Option(Addr([1, 2, 3, 4]))'
+}


### PR DESCRIPTION
This PR fix assign optional aliases of fixed array (fix #23185).

- Fix assign optional aliases of fixed array.
- Add test.

```v
type Addr = [4]u8

fn main() {
	mut addr := ?Addr(none)
	addr = Addr([u8(1), 2, 3, 4]!)
	println(addr)
	assert '${addr}' == 'Option(Addr([1, 2, 3, 4]))'
}

PS D:\Test\v\tt1> v run .
Option(Addr([1, 2, 3, 4]))
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYwZWJhYmYxNDRmNTg1YWU0ZGFmMmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.vOUcabZaFlGthgllihnOowINlpNAmBiQzyOfrozCDwU">Huly&reg;: <b>V_0.6-21625</b></a></sub>