### PR TITLE
cgen,checker: minor optimizations

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -6,7 +6,6 @@ import v.ast
 import v.util
 import v.token
 
-@[direct_array_access]
 fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 	util.timing_start(@METHOD)
 	defer {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -6,6 +6,7 @@ import v.ast
 import v.util
 import v.token
 
+@[direct_array_access]
 fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 	util.timing_start(@METHOD)
 	defer {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -42,11 +42,12 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			} else if (embed_sym.info as ast.Struct).is_heap && !embed.typ.is_ptr() {
 				struct_sym.info.is_heap = true
 			}
-			if embed.typ.has_flag(.generic) {
+			embed_is_generic := embed.typ.has_flag(.generic)
+			if embed_is_generic {
 				has_generic_types = true
 			}
 			// Ensure each generic type of the embed was declared in the struct's definition
-			if node.generic_types.len > 0 && embed.typ.has_flag(.generic) {
+			if embed_is_generic && node.generic_types.len > 0 {
 				embed_generic_names := c.table.generic_type_names(embed.typ)
 				node_generic_names := node.generic_types.map(c.table.type_to_str(it))
 				for name in embed_generic_names {
@@ -163,14 +164,15 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			if !c.ensure_type_exists(field.typ, field.type_pos) {
 				continue
 			}
+			field_is_generic := field.typ.has_flag(.generic)
 			if !c.ensure_generic_type_specify_type_names(field.typ, field.type_pos, c.table.final_sym(field.typ).kind in [
 				.array,
 				.array_fixed,
 				.map,
-			], field.typ.has_flag(.generic)) {
+			], field_is_generic) {
 				continue
 			}
-			if field.typ.has_flag(.generic) {
+			if field_is_generic {
 				has_generic_types = true
 			}
 			if node.language == .v {
@@ -228,7 +230,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 
 			if field.has_default_expr {
 				c.expected_type = field.typ
-				if !field.typ.has_flag(.option) && !field.typ.has_flag(.result) {
+				if !field.typ.has_option_or_result() {
 					c.check_expr_option_or_result_call(field.default_expr, field.default_expr_typ)
 				}
 				if sym.info is ast.ArrayFixed && field.typ == field.default_expr_typ {
@@ -272,12 +274,14 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 								field.default_expr.pos)
 						}
 					}
-					if field.typ.has_flag(.option) && field.default_expr is ast.None {
-						c.warn('unnecessary default value of `none`: struct fields are zeroed by default',
-							field.default_expr.pos)
-					}
-					if field.typ.has_flag(.option) && field.default_expr.is_nil() {
-						c.error('cannot assign `nil` to option value', field.default_expr.pos())
+					field_is_option := field.typ.has_flag(.option)
+					if field_is_option {
+						if field.default_expr is ast.None {
+							c.warn('unnecessary default value of `none`: struct fields are zeroed by default',
+								field.default_expr.pos)
+						} else if field.default_expr.is_nil() {
+							c.error('cannot assign `nil` to option value', field.default_expr.pos())
+						}
 					}
 					continue
 				}
@@ -694,7 +698,8 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				if got_type == ast.void_type {
 					c.error('`${init_field.expr}` (no value) used as value', init_field.pos)
 				}
-				if !exp_type.has_flag(.option) {
+				exp_type_is_option := exp_type.has_flag(.option)
+				if !exp_type_is_option {
 					got_type = c.check_expr_option_or_result_call(init_field.expr, got_type)
 					if got_type.has_flag(.option) {
 						c.error('cannot assign an Option value to a non-option struct field',
@@ -707,7 +712,7 @@ fn (mut c Checker) struct_init(mut node ast.StructInit, is_field_zero_struct_ini
 				if got_type.has_flag(.result) {
 					c.check_expr_option_or_result_call(init_field.expr, init_field.typ)
 				}
-				if exp_type.has_flag(.option) && got_type.is_ptr() && !(exp_type.is_ptr()
+				if exp_type_is_option && got_type.is_ptr() && !(exp_type.is_ptr()
 					&& exp_type_sym.kind == .struct) {
 					c.error('cannot assign a pointer to option struct field', init_field.pos)
 				}
@@ -776,7 +781,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 				} else {
 					if !c.inside_unsafe && type_sym.language == .v && !(c.file.is_translated
 						|| c.pref.translated) && exp_type.is_ptr()
-						&& !got_type.is_any_kind_of_pointer() && !exp_type.has_flag(.option)
+						&& !got_type.is_any_kind_of_pointer() && !exp_type_is_option
 						&& !(init_field.expr is ast.UnsafeExpr && init_field.expr.expr.str() == '0') {
 						if init_field.expr.str() == '0' {
 							c.error('assigning `0` to a reference field is only allowed in `unsafe` blocks',
@@ -787,7 +792,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 						}
 					} else if exp_type.is_any_kind_of_pointer()
 						&& !got_type.is_any_kind_of_pointer() && !got_type.is_int()
-						&& (!exp_type.has_flag(.option) || got_type.idx() != ast.none_type_idx) {
+						&& (!exp_type_is_option || got_type.idx() != ast.none_type_idx) {
 						got_typ_str := c.table.type_to_str(got_type)
 						exp_typ_str := c.table.type_to_str(exp_type)
 						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6893,8 +6893,8 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 				} else {
 					mut is_array_fixed := false
 					mut return_wrapped := false
+					mut return_is_option := is_option && return_type.has_option_or_result()
 					if is_option {
-						return_is_option := return_type.has_option_or_result()
 						is_array_fixed = g.table.final_sym(return_type).kind == .array_fixed
 						if !is_array_fixed {
 							if g.inside_return && !g.inside_struct_init

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2165,7 +2165,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 // applicable to situations where the expr_typ does not have `option` and `result`,
 // e.g. field default: "foo ?int = 1", field assign: "foo = 1", field init: "foo: 1"
 fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.Type, tmp_var string) {
-	if !ret_typ.has_flag(.option) && !ret_typ.has_flag(.result) {
+	if !ret_typ.has_option_or_result() {
 		panic('cgen: parameter `ret_typ` of function `expr_with_tmp_var()` must be an Option or Result')
 	}
 
@@ -2182,6 +2182,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		g.writeln('${g.styp(ret_typ)} ${tmp_var} = {.state=2, .err=${expr.name}};')
 	} else {
 		mut simple_assign := false
+		expr_typ_is_option := expr_typ.has_flag(.option)
+		ret_typ_is_option := ret_typ.has_flag(.option)
 		if ret_typ.has_flag(.generic) {
 			if expr is ast.SelectorExpr && g.cur_concrete_types.len == 0 {
 				// resolve generic struct on selectorExpr inside non-generic function
@@ -2203,8 +2205,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		} else {
 			g.writeln('${g.styp(ret_typ)} ${tmp_var};')
 		}
-		if ret_typ.has_flag(.option) {
-			if expr_typ.has_flag(.option) && expr in [ast.StructInit, ast.ArrayInit, ast.MapInit] {
+		if ret_typ_is_option {
+			if expr_typ_is_option && expr in [ast.StructInit, ast.ArrayInit, ast.MapInit] {
 				simple_assign = expr is ast.StructInit
 				if simple_assign {
 					g.write('${tmp_var} = ')
@@ -2214,13 +2216,13 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 			} else {
 				simple_assign =
 					((expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
-					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ.has_flag(.option))
+					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ_is_option)
 					|| (expr_typ == ret_typ && !(expr_typ.has_option_or_result()
 					&& (expr_typ.is_ptr() || expr is ast.LambdaExpr)))
 				// option ptr assignment simplification
 				if simple_assign {
 					g.write('${tmp_var} = ')
-				} else if expr_typ.has_flag(.option) && expr is ast.PrefixExpr
+				} else if expr_typ_is_option && expr is ast.PrefixExpr
 					&& expr.right is ast.StructInit
 					&& (expr.right as ast.StructInit).init_fields.len == 0 {
 					g.write('_option_none(&(${styp}[]) { ')
@@ -2243,7 +2245,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 			g.write('_result_ok(&(${styp}[]) { ')
 		}
 		g.expr_with_cast(expr, expr_typ, ret_typ)
-		if ret_typ.has_flag(.option) {
+		if ret_typ_is_option {
 			if simple_assign {
 				g.writeln(';')
 			} else {
@@ -2448,8 +2450,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 					if method.return_type.has_flag(.option) {
 						// Register an option if it's not registered yet
 						g.register_option(method.return_type)
-					}
-					if method.return_type.has_flag(.result) {
+					} else if method.return_type.has_flag(.result) {
 						// Register a result if it's not registered yet
 						g.register_result(method.return_type)
 					}
@@ -2896,7 +2897,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 	neither_void := ast.voidptr_type !in [got_type, expected_type]
 		&& ast.nil_type !in [got_type, expected_type]
 	if expected_type.has_flag(.shared_f) && !got_type_raw.has_flag(.shared_f)
-		&& !expected_type.has_flag(.option) && !expected_type.has_flag(.result) {
+		&& !expected_type.has_option_or_result() {
 		shared_styp := exp_styp[0..exp_styp.len - 1] // `shared` implies ptr, so eat one `*`
 		if got_type_raw.is_ptr() {
 			g.error('cannot convert reference to `shared`', expr.pos())
@@ -2939,8 +2940,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			return
 		}
 	}
-	if exp_sym.kind == .function && !expected_type.has_flag(.option)
-		&& !expected_type.has_flag(.result) {
+	if exp_sym.kind == .function && !expected_type.has_option_or_result() {
 		g.write('(voidptr)')
 	}
 	// no cast
@@ -3626,7 +3626,8 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				node.return_type.clear_option_and_result()
 			}
 			mut shared_styp := ''
-			if g.is_shared && !ret_type.has_flag(.shared_f) && !g.inside_or_block {
+			ret_typ_is_shared := ret_type.has_flag(.shared_f)
+			if g.is_shared && !ret_typ_is_shared && !g.inside_or_block {
 				ret_sym := g.table.sym(ret_type)
 				shared_typ := if ret_type.is_ptr() {
 					ret_type.deref().set_flag(.shared_f)
@@ -3648,8 +3649,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				0
 			}
 
-			if g.is_shared && !ret_type.has_flag(.shared_f) && !g.inside_or_block
-				&& ret_type.is_ptr() {
+			if g.is_shared && !ret_typ_is_shared && !g.inside_or_block && ret_type.is_ptr() {
 				g.write('*'.repeat(ret_type.nr_muls()))
 			}
 			g.call_expr(node)
@@ -3665,7 +3665,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				}
 				g.strs_to_free0 = []
 			}
-			if g.is_shared && !ret_type.has_flag(.shared_f) && !g.inside_or_block {
+			if g.is_shared && !ret_typ_is_shared && !g.inside_or_block {
 				g.writeln('}, sizeof(${shared_styp}))')
 			}
 			/*
@@ -4524,10 +4524,10 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 				cast_sym := g.table.sym(var_typ)
 
 				mut param_var := strings.new_builder(50)
+				is_option := obj.typ.has_flag(.option)
+				var_typ_is_option := var_typ.has_flag(.option)
 				if obj.smartcasts.len > 0 {
-					is_option_unwrap := obj.typ.has_flag(.option)
-						&& var_typ == obj.typ.clear_flag(.option)
-					is_option := obj.typ.has_flag(.option)
+					is_option_unwrap := is_option && var_typ == obj.typ.clear_flag(.option)
 					mut opt_cast := false
 					mut func := if cast_sym.info is ast.Aggregate {
 						''
@@ -4571,7 +4571,7 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 							param_var.write_string('.data)')
 						}
 						param_var.write_string('${dot}_${cast_sym.cname}')
-					} else if obj.typ.has_flag(.option) && !var_typ.has_flag(.option) {
+					} else if is_option && !var_typ_is_option {
 						param_var.write_string('${obj.name}.data')
 					} else {
 						param_var.write_string('${obj.name}')
@@ -4581,7 +4581,7 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 					values.write_string('${func}(${param_var.str()})}')
 				} else {
 					func := g.get_str_fn(var_typ)
-					if obj.typ.has_flag(.option) && !var_typ.has_flag(.option) {
+					if is_option && !var_typ_is_option {
 						// option unwrap
 						base_typ := g.base_type(obj.typ)
 						values.write_string('${func}(*(${base_typ}*)${obj.name}.data)}')
@@ -4589,7 +4589,7 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 						_, str_method_expects_ptr, _ := cast_sym.str_method_info()
 
 						// eprintln(">> ${obj.name} | str expects ptr? ${str_method_expects_ptr} | ptr? ${var_typ.is_ptr()} || auto heap? ${obj.is_auto_heap} | auto deref? ${obj.is_auto_deref}")
-						deref := if var_typ.has_flag(.option) {
+						deref := if var_typ_is_option {
 							''
 						} else if str_method_expects_ptr && !obj.typ.is_ptr() {
 							'&'
@@ -5355,18 +5355,19 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 	if g.comptime.is_comptime_expr(node.expr) {
 		expr_type = g.unwrap_generic(g.comptime.get_type(node.expr))
 	}
+	node_typ_is_option := node.typ.has_flag(.option)
 	if sym.kind in [.sum_type, .interface] {
-		if node.typ.has_flag(.option) && node.expr is ast.None {
+		if node_typ_is_option && node.expr is ast.None {
 			g.gen_option_error(node.typ, node.expr)
 		} else if node.expr is ast.Ident && g.comptime.is_comptime_variant_var(node.expr) {
 			g.expr_with_cast(node.expr, g.comptime.type_map['${g.comptime.comptime_for_variant_var}.typ'],
 				node_typ)
-		} else if node.typ.has_flag(.option) {
+		} else if node_typ_is_option {
 			g.expr_with_opt(node.expr, expr_type, node.typ)
 		} else {
 			g.expr_with_cast(node.expr, expr_type, node_typ)
 		}
-	} else if !node.typ.has_flag(.option) && !node.typ.is_ptr() && sym.info is ast.Struct
+	} else if !node_typ_is_option && !node.typ.is_ptr() && sym.info is ast.Struct
 		&& !sym.info.is_typedef {
 		// deprecated, replaced by Struct{...exr}
 		styp := g.styp(node.typ)
@@ -5374,7 +5375,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		g.expr(node.expr)
 		g.write('))')
 	} else if sym.kind == .alias && g.table.final_sym(node.typ).kind == .array_fixed {
-		if node.typ.has_flag(.option) {
+		if node_typ_is_option {
 			g.expr_with_opt(node.expr, expr_type, node.typ)
 		} else {
 			if node.expr is ast.ArrayInit && g.assign_op != .decl_assign {
@@ -5409,9 +5410,9 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 				cast_label = '(${styp})'
 			}
 		}
-		if node.typ.has_flag(.option) && node.expr is ast.None {
+		if node_typ_is_option && node.expr is ast.None {
 			g.gen_option_error(node.typ, node.expr)
-		} else if node.typ.has_flag(.option) {
+		} else if node_typ_is_option {
 			if sym.info is ast.Alias {
 				if sym.info.parent_type.has_flag(.option) {
 					cur_stmt := g.go_before_last_stmt()

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6894,12 +6894,12 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 					mut is_array_fixed := false
 					mut return_wrapped := false
 					if is_option {
+						return_is_option := return_type.has_option_or_result()
 						is_array_fixed = g.table.final_sym(return_type).kind == .array_fixed
 						if !is_array_fixed {
 							if g.inside_return && !g.inside_struct_init
 								&& expr_stmt.expr is ast.CallExpr&& (expr_stmt.expr as ast.CallExpr).return_type.has_option_or_result()
-								&& g.cur_fn.return_type.has_option_or_result()
-								&& return_type.has_option_or_result()
+								&& g.cur_fn.return_type.has_option_or_result() && return_is_option
 								&& expr_stmt.expr.or_block.kind == .absent {
 								g.write('${cvar_name} = ')
 								return_wrapped = true
@@ -6919,7 +6919,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 					}
 					// return expr or { fn_returns_option() }
 					if is_option && g.inside_return && expr_stmt.expr is ast.CallExpr
-						&& return_type.has_option_or_result() {
+						&& return_is_option {
 						g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type)
 					} else {
 						old_inside_opt_data := g.inside_opt_data

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2577,7 +2577,6 @@ fn (mut g Gen) autofree_call_postgen(node_pos int) {
 	// g.doing_autofree_tmp = false
 }
 
-@[direct_array_access]
 fn (mut g Gen) call_args(node ast.CallExpr) {
 	g.expected_fixed_arr = true
 	defer {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2577,6 +2577,7 @@ fn (mut g Gen) autofree_call_postgen(node_pos int) {
 	// g.doing_autofree_tmp = false
 }
 
+@[direct_array_access]
 fn (mut g Gen) call_args(node ast.CallExpr) {
 	g.expected_fixed_arr = true
 	defer {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2260,7 +2260,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				g.writeln('));')
 				return
 			}
-			if g.is_autofree && !typ.has_flag(.option) && !typ.has_flag(.result) {
+			if g.is_autofree && !typ.has_option_or_result() {
 				// Create a temporary variable so that the value can be freed
 				tmp := g.new_tmp_var()
 				g.write('string ${tmp} = ')
@@ -2459,8 +2459,7 @@ fn (mut g Gen) autofree_call_pregen(node ast.CallExpr) {
 	// Create a temporary var before fn call for each argument in order to free it (only if it's a complex expression,
 	// like `foo(get_string())` or `foo(a + b)`
 	mut free_tmp_arg_vars := g.is_autofree && !g.is_builtin_mod && node.args.len > 0
-		&& !node.args[0].typ.has_flag(.option)
-		&& !node.args[0].typ.has_flag(.result) // TODO: copy pasta checker.v
+		&& !node.args[0].typ.has_option_or_result() // TODO: copy pasta checker.v
 	if !free_tmp_arg_vars {
 		return
 	}

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -161,6 +161,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 	} else {
 		g.styp(info.elem_type)
 	}
+	left_is_shared := node.left_type.has_flag(.shared_f)
 	// `vals[i].field = x` is an exception and requires `array_get`:
 	// `(*(Val*)array_get(vals, i)).field = x;`
 	if g.is_assign_lhs && node.is_setter {
@@ -170,14 +171,14 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			g.write('((${elem_type_str}*)')
 		} else if is_op_assign {
 			g.write('(*(${elem_type_str}*)array_get(')
-			if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+			if left_is_ptr && !left_is_shared {
 				g.write('*')
 			}
 		} else {
 			g.cur_indexexpr << node.pos.pos
 			g.is_arraymap_set = true // special handling of assign_op and closing with '})'
 			g.write('array_set(')
-			if !left_is_ptr || node.left_type.has_flag(.shared_f) {
+			if !left_is_ptr || left_is_shared {
 				g.write('&')
 			}
 		}
@@ -189,7 +190,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			g.expr(node.left)
 		}
 
-		if node.left_type.has_flag(.shared_f) {
+		if left_is_shared {
 			if left_is_ptr {
 				g.write('->val')
 			} else {
@@ -197,7 +198,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			}
 		}
 		if is_direct_array_access {
-			if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+			if left_is_ptr && !left_is_shared {
 				g.write('->')
 			} else {
 				g.write('.')
@@ -251,7 +252,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		tmp_opt_ptr := if gen_or { g.new_tmp_var() } else { '' }
 		if gen_or {
 			g.write('${elem_type_str}* ${tmp_opt_ptr} = (${elem_type_str}*)(array_get_with_check(')
-			if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+			if left_is_ptr && !left_is_shared {
 				g.write('*')
 			}
 		} else {
@@ -268,21 +269,21 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 						g.write(')(*(${elem_type_str}*)array_get(')
 					}
 				}
-				if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+				if left_is_ptr && !left_is_shared {
 					g.write('*')
 				}
 			} else if is_direct_array_access {
 				g.write('((${elem_type_str}*)')
 			} else {
 				g.write('(*(${elem_type_str}*)array_get(')
-				if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+				if left_is_ptr && !left_is_shared {
 					g.write('*')
 				}
 			}
 		}
 		g.expr(node.left)
 		// TODO: test direct_array_access when 'shared' is implemented
-		if node.left_type.has_flag(.shared_f) {
+		if left_is_shared {
 			if left_is_ptr {
 				g.write('->val')
 			} else {
@@ -290,7 +291,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			}
 		}
 		if is_direct_array_access && !gen_or {
-			if left_is_ptr && !node.left_type.has_flag(.shared_f) {
+			if left_is_ptr && !left_is_shared {
 				g.write('->')
 			} else {
 				g.write('.')

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -394,6 +394,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	key_type_str := g.styp(info.key_type)
 	val_type := info.value_type
 	val_sym := g.table.sym(val_type)
+	left_is_shared := node.left_type.has_flag(.shared_f)
 	val_type_str := if val_sym.kind == .function {
 		'voidptr'
 	} else {
@@ -416,7 +417,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.write('(*((${val_type_str}*)map_get((map*)')
 			}
 		}
-		if !left_is_ptr || node.left_type.has_flag(.shared_f) {
+		if !left_is_ptr || left_is_shared {
 			g.write('&')
 		}
 		if node.left is ast.IndexExpr {
@@ -426,7 +427,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		} else {
 			g.expr(node.left)
 		}
-		if node.left_type.has_flag(.shared_f) {
+		if left_is_shared {
 			g.write('->val')
 		}
 		g.write(', &(${key_type_str}[]){')
@@ -453,11 +454,11 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		} else {
 			g.write('(*(${val_type_str}*)map_get((map*)')
 		}
-		if !left_is_ptr || node.left_type.has_flag(.shared_f) {
+		if !left_is_ptr || left_is_shared {
 			g.write('&')
 		}
 		g.expr(node.left)
-		if node.left_type.has_flag(.shared_f) {
+		if left_is_shared {
 			g.write('->val')
 		}
 		g.write(', &(${key_type_str}[]){')
@@ -494,14 +495,14 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.write('(*(${val_type_str}*)map_get(')
 			}
 		}
-		if !left_is_ptr || node.left_type.has_flag(.shared_f) {
+		if !left_is_ptr || left_is_shared {
 			g.write('ADDR(map, ')
 			g.expr(node.left)
 		} else {
 			g.write('(')
 			g.expr(node.left)
 		}
-		if node.left_type.has_flag(.shared_f) {
+		if left_is_shared {
 			if left_is_ptr {
 				g.write('->val')
 			} else {

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -53,12 +53,11 @@ pub fn (mut w Walker) mark_builtin_map_method_as_used(method_name string) {
 pub fn (mut w Walker) mark_builtin_type_method_as_used(k string, rk string) {
 	if mut cfn := w.all_fns[k] {
 		w.fn_decl(mut cfn)
-	}
-	if mut cfn := w.all_fns[rk] {
+		w.mark_fn_as_used(k)
+	} else if mut cfn := w.all_fns[rk] {
 		w.fn_decl(mut cfn)
+		w.mark_fn_as_used(rk)
 	}
-	w.mark_fn_as_used(k)
-	w.mark_fn_as_used(rk)
 }
 
 pub fn (mut w Walker) mark_const_as_used(ckey string) {
@@ -721,6 +720,7 @@ pub fn (mut w Walker) const_fields(cfields []ast.ConstField) {
 	}
 }
 
+@[inline]
 pub fn (mut w Walker) or_block(node ast.OrExpr) {
 	if node.kind == .block {
 		w.stmts(node.stmts)


### PR DESCRIPTION
- Removed repetitive .has_flag() calls on fns
- Inline markused.walker or_block()
- Spread .has_option_or_result() instead of double check .has_flag(.option) + .has_flag(.result) calls.

![image](https://github.com/user-attachments/assets/17c4f028-3120-4fa3-b345-8d223173ef42)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYxNzU2MGYxNDRmNTg1YWU0ZGM2MjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.JKl35d2-H77ELwqaGU2ReqATb2xSX_cDlk3rFTuAsRE">Huly&reg;: <b>V_0.6-21628</b></a></sub>