### PR TITLE
ci: make the CI more robust, by retrying commands and `v download` instead of wget

### DIFF
--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -110,9 +110,10 @@ jobs:
       - name: Setup test tools
         run: |
           # Fetch the free ~4MB DOOM1.WAD from the link at https://doomwiki.org/wiki/DOOM1.WAD
-          v retry -- wget https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad -O ~/doom1.wad
+          v retry -- v download https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad
+          mv doom1.wad ~/doom1.wad
           # Get imgur upload script
-          v retry -- wget https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
+          v retry -- v download https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
           chmod +x ./imgur.sh
           # Get regression images to test against
           v retry -- git clone https://github.com/Larpon/doom-regression-images

--- a/.github/workflows/download_full_toml_test_suites.sh
+++ b/.github/workflows/download_full_toml_test_suites.sh
@@ -4,8 +4,7 @@ set -ex
 
 rm -rf vlib/toml/tests/testdata/burntsushi  vlib/toml/tests/testdata/iarna  vlib/toml/tests/testdata/alexcrichton  vlib/toml/tests/testdata/large_toml_file_test.toml
 
-./v retry -- ./v download https://gist.githubusercontent.com/Larpon/89b0e3d94c6903851ff15559e5df7a05/raw/62a1f87a4e37bf157f2e0bfb32d85d840c98e422/large_toml_file_test.toml
-mv large_toml_file_test.toml vlib/toml/tests/testdata/large_toml_file_test.toml
+./v retry -- ./v download --target-folder vlib/toml/tests/testdata https://gist.githubusercontent.com/Larpon/89b0e3d94c6903851ff15559e5df7a05/raw/62a1f87a4e37bf157f2e0bfb32d85d840c98e422/large_toml_file_test.toml
 
 ./v retry -- git clone -n https://github.com/iarna/toml-spec-tests.git vlib/toml/tests/testdata/iarna
 git -C vlib/toml/tests/testdata/iarna checkout 1880b1a

--- a/.github/workflows/download_full_toml_test_suites.sh
+++ b/.github/workflows/download_full_toml_test_suites.sh
@@ -4,7 +4,8 @@ set -ex
 
 rm -rf vlib/toml/tests/testdata/burntsushi  vlib/toml/tests/testdata/iarna  vlib/toml/tests/testdata/alexcrichton  vlib/toml/tests/testdata/large_toml_file_test.toml
 
-./v retry -- wget https://gist.githubusercontent.com/Larpon/89b0e3d94c6903851ff15559e5df7a05/raw/62a1f87a4e37bf157f2e0bfb32d85d840c98e422/large_toml_file_test.toml -O vlib/toml/tests/testdata/large_toml_file_test.toml
+./v retry -- ./v download https://gist.githubusercontent.com/Larpon/89b0e3d94c6903851ff15559e5df7a05/raw/62a1f87a4e37bf157f2e0bfb32d85d840c98e422/large_toml_file_test.toml
+mv large_toml_file_test.toml vlib/toml/tests/testdata/large_toml_file_test.toml
 
 ./v retry -- git clone -n https://github.com/iarna/toml-spec-tests.git vlib/toml/tests/testdata/iarna
 git -C vlib/toml/tests/testdata/iarna checkout 1880b1a

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -46,7 +46,7 @@ jobs:
           # freeglut3-dev            : Fixes graphic apps compilation with tcc
           ./v retry -- sudo apt update
           ./v retry -- sudo apt install imagemagick openimageio-tools libgl1-mesa-dri xvfb libxcursor-dev libxi-dev freeglut3-dev xsel xclip
-          ./v retry -- wget https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
+          ./v retry -- ./v download https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
           ./v retry -- git clone https://github.com/Larpon/gg-regression-images gg-regression-images
           chmod +x ./imgur.sh
 

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Download V
         run: |
-          wget https://github.com/vlang/v/releases/latest/download/v_linux.zip
+          .github/workflows/retry.sh https://github.com/vlang/v/releases/latest/download/v_linux.zip
           unzip v_linux.zip
           cd v
           ./v -version
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Download V
         run: |
-          wget https://github.com/vlang/v/releases/latest/download/v_macos_arm64.zip
+          .github/workflows/retry.sh https://github.com/vlang/v/releases/latest/download/v_macos_arm64.zip
           unzip v_macos_arm64.zip
           cd v
           ./v -version
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Download V
         run: |
-          wget https://github.com/vlang/v/releases/latest/download/v_macos_x86_64.zip
+          .github/workflows/retry.sh https://github.com/vlang/v/releases/latest/download/v_macos_x86_64.zip
           unzip v_macos_x86_64.zip
           cd v
           ./v -version

--- a/.github/workflows/vup_works.yml
+++ b/.github/workflows/vup_works.yml
@@ -46,7 +46,7 @@ jobs:
         run: make && ./v symlink && ./v version
 
       - name: Download latest release ZIP
-        run: wget https://github.com/vlang/v/releases/latest/download/${{ matrix.zip }}
+        run: ./v retry -- ./v download --sha256 https://github.com/vlang/v/releases/latest/download/${{ matrix.zip }}
 
       - name: Extract ZIP 1, no changes
         run: |


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYxYWIxYmYxNDRmNTg1YWU0ZGNkNDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ij74DNCWFELV5t9IFY4PnkjzLOZuusz5mCtR11maHb4">Huly&reg;: <b>V_0.6-21633</b></a></sub>