### PR TITLE
json: fix memleak on sumtype decoding

### DIFF
--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -146,12 +146,12 @@ jobs:
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self vlib
+        run: ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self vlib
       - name: Self tests (V compiled with -fsanitize=address)
         run: ./v -cflags -fsanitize=address -o v cmd/v &&
-          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler vlib
+          ./v -cc tcc test-self -asan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
+        run: ./v build-examples
 
   tests-sanitize-address-msvc:
     runs-on: windows-2019
@@ -199,13 +199,13 @@ jobs:
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-self vlib
+        run: ./v -cflags -fsanitize=address test-self vlib
       - name: Self tests (V compiled with -fsanitize=address)
         run:
           ./v -cflags -fsanitize=address,pointer-compare,pointer-subtract -o v cmd/v &&
-          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler vlib
+          ./v -cc tcc test-self -asan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=address)
-        run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
+        run: ./v build-examples
 
   tests-sanitize-memory-clang:
     runs-on: ubuntu-20.04

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -146,12 +146,12 @@ jobs:
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=address)
-        run: ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self vlib
+        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags "-fsanitize=address,pointer-compare,pointer-subtract" test-self vlib
       - name: Self tests (V compiled with -fsanitize=address)
         run: ./v -cflags -fsanitize=address -o v cmd/v &&
-          ./v -cc tcc test-self -asan-compiler vlib
+          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=address)
-        run: ./v build-examples
+        run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
   tests-sanitize-address-msvc:
     runs-on: windows-2019
@@ -199,13 +199,13 @@ jobs:
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=address)
-        run: ./v -cflags -fsanitize=address test-self vlib
+        run: ASAN_OPTIONS=detect_leaks=0 ./v -cflags -fsanitize=address test-self vlib
       - name: Self tests (V compiled with -fsanitize=address)
         run:
           ./v -cflags -fsanitize=address,pointer-compare,pointer-subtract -o v cmd/v &&
-          ./v -cc tcc test-self -asan-compiler vlib
+          ASAN_OPTIONS=detect_leaks=0 ./v -cc tcc test-self -asan-compiler vlib
       - name: Build examples (V compiled with -fsanitize=address)
-        run: ./v build-examples
+        run: ASAN_OPTIONS=detect_leaks=0 ./v build-examples
 
   tests-sanitize-memory-clang:
     runs-on: ubuntu-20.04

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -420,7 +420,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 
 		// Helpers for decoding
 		g.get_sumtype_casting_fn(variant, typ)
-		g.definitions.writeln('/*KEK*/static inline ${sym.cname} ${variant_typ}_to_sumtype_${sym.cname}(${variant_typ}* x);')
+		g.definitions.writeln('static inline ${sym.cname} ${variant_typ}_to_sumtype_${sym.cname}(${variant_typ}* x);')
 
 		// ENCODING
 		enc.writeln('\tif (${var_data}${field_op}_typ == ${int(variant.idx())}) {')
@@ -455,6 +455,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 				enc.writeln('\t\tcJSON_AddItemToObject(o, "_type", cJSON_CreateString("${unmangled_variant_name}"));')
 				enc.writeln('\t\tcJSON_AddItemToObject(o, "value", ${js_enc_name('i64')}(${var_data}${field_op}_${variant_typ}->__v_unix));')
 			} else {
+				enc.writeln('\t\tcJSON_free(o);')
 				enc.writeln('\t\to = ${js_enc_name(variant_typ)}(*${var_data}${field_op}_${variant_typ});')
 				if variant_sym.kind == .array {
 					enc.writeln('\t\tif (cJSON_IsObject(o->child)) {')


### PR DESCRIPTION
Fix leftover memleak on json lib.

To test use: 
`v -cc clang-17 -cflags -fsanitize=address,pointer-compare,pointer-subtract test vlib/json/tests/json_sumtype_test.v`

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYxZDcwM2YxNDRmNTg1YWU0ZGQyYmUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.aWIKp7n_ob6loUUajFtncqj3thtgKLgqKqYvmeQSUxA">Huly&reg;: <b>V_0.6-21634</b></a></sub>