### PR TITLE
cgen: fix struct field init with optional fixed array (fix #23195)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -157,6 +157,18 @@ fn (mut g Gen) expr_with_opt(expr ast.Expr, expr_typ ast.Type, ret_typ ast.Type)
 	return ''
 }
 
+fn (mut g Gen) expr_with_fixed_array_opt(expr ast.Expr, expr_typ ast.Type, ret_typ ast.Type) {
+	tmp_var := g.new_tmp_var()
+	stmt_str := g.go_before_last_stmt().trim_space()
+	styp := g.styp(expr_typ)
+	g.empty_line = true
+	g.writeln('${styp} ${tmp_var} = {.state = 0};')
+	g.write('memcpy(${tmp_var}.data, ')
+	g.expr(expr)
+	g.writeln(', sizeof(${g.styp(ret_typ)}));')
+	g.write2(stmt_str, tmp_var)
+}
+
 fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 	mut node := unsafe { node_ }
 	if node.is_static {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -688,13 +688,26 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 		if field_unwrap_sym.info is ast.ArrayFixed {
 			match sfield.expr {
 				ast.Ident, ast.SelectorExpr {
-					g.fixed_array_var_init(g.expr_string(sfield.expr), is_auto_deref_var,
-						field_unwrap_sym.info.elem_type, field_unwrap_sym.info.size)
+					if sfield.expected_type.has_flag(.option) {
+						if field_unwrap_typ.has_flag(.option) {
+							g.expr_with_opt(sfield.expr, sfield.expected_type, field_unwrap_typ)
+						} else {
+							g.expr_with_fixed_array_opt(sfield.expr, sfield.expected_type,
+								field_unwrap_typ)
+						}
+					} else {
+						g.fixed_array_var_init(g.expr_string(sfield.expr), is_auto_deref_var,
+							field_unwrap_sym.info.elem_type, field_unwrap_sym.info.size)
+					}
 				}
 				ast.CastExpr, ast.CallExpr {
-					if sfield.expected_type.has_flag(.option) && !field_unwrap_typ.has_flag(.option) {
-						g.expr_with_fixed_array_opt(sfield.expr, sfield.expected_type,
-							field_unwrap_typ)
+					if sfield.expected_type.has_flag(.option) {
+						if field_unwrap_typ.has_flag(.option) {
+							g.expr_with_opt(sfield.expr, sfield.expected_type, field_unwrap_typ)
+						} else {
+							g.expr_with_fixed_array_opt(sfield.expr, sfield.expected_type,
+								field_unwrap_typ)
+						}
 					} else {
 						tmp_var := g.expr_with_var(sfield.expr, sfield.expected_type,
 							false)

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -692,9 +692,15 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 						field_unwrap_sym.info.elem_type, field_unwrap_sym.info.size)
 				}
 				ast.CastExpr, ast.CallExpr {
-					tmp_var := g.expr_with_var(sfield.expr, sfield.expected_type, false)
-					g.fixed_array_var_init(tmp_var, false, field_unwrap_sym.info.elem_type,
-						field_unwrap_sym.info.size)
+					if sfield.expected_type.has_flag(.option) && !field_unwrap_typ.has_flag(.option) {
+						g.expr_with_fixed_array_opt(sfield.expr, sfield.expected_type,
+							field_unwrap_typ)
+					} else {
+						tmp_var := g.expr_with_var(sfield.expr, sfield.expected_type,
+							false)
+						g.fixed_array_var_init(tmp_var, false, field_unwrap_sym.info.elem_type,
+							field_unwrap_sym.info.size)
+					}
 				}
 				ast.ArrayInit {
 					if sfield.expr.has_index {

--- a/vlib/v/tests/structs/struct_field_init_with_fixed_array_opt_test.v
+++ b/vlib/v/tests/structs/struct_field_init_with_fixed_array_opt_test.v
@@ -6,10 +6,27 @@ struct Foo {
 }
 
 fn test_struct_field_init_with_fixed_array_opt() {
-	f := Foo{
+	f1 := Foo{
 		bar: 1
 		baz: Arr([u8(5), 4, 3, 2]!)
 	}
-	println(f)
-	assert f.baz as Arr == [u8(5), 4, 3, 2]!
+	println(f1)
+	assert f1.baz as Arr == [u8(5), 4, 3, 2]!
+
+	f2 := Foo{
+		bar: 1
+		baz: ?Arr(none)
+	}
+	println(f2)
+	assert f2.bar == 1
+	assert f2.baz == none
+
+	arr := Arr([u8(5), 4, 3, 2]!)
+	f3 := Foo{
+		bar: 1
+		baz: arr
+	}
+	println(f3)
+	assert f3.bar == 1
+	assert f3.baz as Arr == [u8(5), 4, 3, 2]!
 }

--- a/vlib/v/tests/structs/struct_field_init_with_fixed_array_opt_test.v
+++ b/vlib/v/tests/structs/struct_field_init_with_fixed_array_opt_test.v
@@ -1,0 +1,15 @@
+type Arr = [4]u8
+
+struct Foo {
+	bar int
+	baz ?Arr
+}
+
+fn test_struct_field_init_with_fixed_array_opt() {
+	f := Foo{
+		bar: 1
+		baz: Arr([u8(5), 4, 3, 2]!)
+	}
+	println(f)
+	assert f.baz as Arr == [u8(5), 4, 3, 2]!
+}


### PR DESCRIPTION
This PR fix struct field init with optional fixed array (fix #23195, fix #23193).

- Fix struct field init with optional fixed array.
- Add test.

```v
type Arr = [4]u8

struct Foo {
	bar int
	baz ?Arr
}

fn main() {
	f1 := Foo{
		bar: 1
		baz: Arr([u8(5), 4, 3, 2]!)
	}
	println(f1)
	assert f1.baz as Arr == [u8(5), 4, 3, 2]!

	f2 := Foo{
		bar: 1
		baz: ?Arr(none)
	}
	println(f2)
	assert f2.bar == 1
	assert f2.baz == none

	arr := Arr([u8(5), 4, 3, 2]!)
	f3 := Foo{
		bar: 1
		baz: arr
	}
	println(f3)
	assert f3.bar == 1
	assert f3.baz as Arr == [u8(5), 4, 3, 2]!
}

PS D:\Test\v\tt1> v run .
Foo{
    bar: 1
    baz: Option(    Arr([5, 4, 3, 2]))
}
Foo{
    bar: 1
    baz: Option(none)
}
Foo{
    bar: 1
    baz: Option(    Arr([5, 4, 3, 2]))
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYyNTdjMGYxNDRmNTg1YWU0ZGRkOWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.IRF-FLV5vcI4xBqru46dOyW5d_jmH6F4JSPwPbH0S5k">Huly&reg;: <b>V_0.6-21636</b></a></sub>