### PR TITLE
v.pref: support `-debug` and `-cdebug`, as more explicit alternative names for `-g` and `-cg`

### DIFF
--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -262,7 +262,7 @@ see also `v help build`.
       your custom one loaded from specified <path>.
 
 # Debugging:
-   -g
+   -g, -debug
       Generate more debug information in the compiled executable.
       This makes program backtraces more useful.
       Using debuggers like gdb/lldb with such executables is easier too.
@@ -270,7 +270,7 @@ see also `v help build`.
       so that your debugger and the stacktraces will show you directly
       what .v file is responsible for each call/panic.
 
-   -cg
+   -cg, -cdebug
       Like -g, but do not use V source line numbers.
       When debugging code that wraps C libraries, this option may be
       more useful than -g, since it will reduce the amount of context

--- a/vlib/v/help/default.txt
+++ b/vlib/v/help/default.txt
@@ -8,7 +8,7 @@ Examples:
                                `hello` or `hello.exe`.
   v run hello.v                Same as above but also run the produced
                                executable immediately after compilation.
-  v -cg run hello.v            Same as above, but make debugging easier
+  v -g run hello.v             Same as above, but make debugging easier
                                (in case your program crashes).
   v crun hello.v               Same as above, but do not recompile, if the
                                executable already exists, and is newer than the

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -110,7 +110,7 @@ pub mut:
 	is_eval_argument   bool // true for `v -e 'println(2+2)'`. `println(2+2)` will be in pref.eval_argument .
 	is_run             bool // compile and run a v program, passing arguments to it, and deleting the executable afterwards
 	is_crun            bool // similar to run, but does not recompile the executable, if there were no changes to the sources
-	is_debug           bool // turned on by -g or -cg, it tells v to pass -g to the C backend compiler.
+	is_debug           bool // turned on by -g/-debug or -cg/-cdebug, it tells v to pass -g to the C backend compiler.
 	is_vlines          bool // turned on by -g (it slows down .tmp.c generation slightly).
 	is_stats           bool // `v -stats file.v` will produce more detailed statistics for the file that is compiled
 	show_asserts       bool // `VTEST_SHOW_ASSERTS=1 v file_test.v` will show details about the asserts done by a test file. Also activated for `-stats` and `-show-asserts`.
@@ -516,12 +516,12 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				}
 				i++
 			}
-			'-g' {
+			'-g', '-debug' {
 				res.is_debug = true
 				res.is_vlines = true
 				res.build_options << arg
 			}
-			'-cg' {
+			'-cg', '-cdebug' {
 				res.is_debug = true
 				res.is_vlines = false
 				res.build_options << arg


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY0NjlmOWYxNDRmNTg1YWU0ZTRkYTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.ZTc06I_H11BsPSVtI8-zRaQRgFr5Foul_-CrxqZYTQ4">Huly&reg;: <b>V_0.6-21644</b></a></sub>