### PR TITLE
v.builder: fail v compilation, if linking or compiling during `-parallel-cc` fails

### DIFF
--- a/vlib/v/builder/cbuilder/cbuilder.v
+++ b/vlib/v/builder/cbuilder/cbuilder.v
@@ -82,7 +82,7 @@ pub fn gen_c(mut b builder.Builder, v_files []string) string {
 	if b.pref.parallel_cc {
 		b.cc() // Call it just to gen b.str_args
 		util.timing_start('Parallel C compilation')
-		parallel_cc(mut b, result)
+		parallel_cc(mut b, result) or { builder.verror(err.msg()) }
 		util.timing_measure('Parallel C compilation')
 	}
 

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -12,7 +12,7 @@ const cc_ldflags = os.getenv_opt('LDFLAGS') or { '' }
 const cc_cflags = os.getenv_opt('CFLAGS') or { '' }
 const cc_cflags_opt = os.getenv_opt('CFLAGS_OPT') or { '' } // '-O3' }
 
-fn parallel_cc(mut b builder.Builder, result c.GenOutput) {
+fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	tmp_dir := os.vtmp_dir()
 	sw_total := time.new_stopwatch()
 	defer {
@@ -94,25 +94,37 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) {
 	for postfix in o_postfixes {
 		cmds << '${cc} ${cc_cflags} ${cc_cflags_opt} ${scompile_args} -w -o ${tmp_dir}/out_${postfix}.o -c ${tmp_dir}/out_${postfix}.c'
 	}
+	mut failed := 0
 	sw := time.new_stopwatch()
 	mut pp := pool.new_pool_processor(callback: build_parallel_o_cb)
 	pp.set_max_jobs(util.nr_jobs)
 	pp.work_on_items(cmds)
-	eprint_time(sw, 'C compilation on ${util.nr_jobs} thread(s), processing ${cmds.len} commands')
+	for x in pp.get_results[os.Result]() {
+		failed += if x.exit_code == 0 { 0 } else { 1 }
+	}
+	eprint_time(sw, 'C compilation on ${util.nr_jobs} thread(s), processing ${cmds.len} commands, failed: ${failed}')
+	if failed > 0 {
+		return error_with_code('failed parallel C compilation', failed)
+	}
 
 	obj_files := fnames.map(it.replace('.c', '.o')).join(' ')
 	link_cmd := '${cc} ${scompile_args_for_linker} -o ${os.quoted_path(b.pref.out_name)} ${tmp_dir}/out_0.o ${obj_files} ${tmp_dir}/out_x.o ${slinker_args} ${cc_ldflags}'
 	sw_link := time.new_stopwatch()
 	link_res := os.execute(link_cmd)
 	eprint_result_time(sw_link, 'link_cmd', link_cmd, link_res)
+	if link_res.exit_code != 0 {
+		return error_with_code('failed to link after parallel C compilation', 1)
+	}
 }
 
-fn build_parallel_o_cb(mut p pool.PoolProcessor, idx int, _wid int) voidptr {
+fn build_parallel_o_cb(mut p pool.PoolProcessor, idx int, _wid int) &os.Result {
 	cmd := p.get_item[string](idx)
 	sw := time.new_stopwatch()
 	res := os.execute(cmd)
 	eprint_result_time(sw, 'cc_cmd', cmd, res)
-	return unsafe { nil }
+	return &os.Result{
+		...res
+	}
 }
 
 fn eprint_result_time(sw time.StopWatch, label string, cmd string, res os.Result) {


### PR DESCRIPTION
Related: https://github.com/vlang/v/issues/23209

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY0ODk0OWYxNDRmNTg1YWU0ZTYwOWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.inJE0K2SgtiFsxbgWga_2AB91uKOdG01H46qBjXCyOw">Huly&reg;: <b>V_0.6-21647</b></a></sub>