### PR TITLE
json: use `@[required]` to disallow parsing nulls

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4690,8 +4690,6 @@ struct User {
 	foo Foo @[skip]
 	// If the field name is different in JSON, it can be specified
 	last_name string @[json: lastName]
-	// Use the `json_allow_null` to allow null values
-	nullable string @[json_allow_null]
 }
 
 data := '{ "name": "Frodo", "lastName": "Baggins", "age": 25, "nullable": null }'

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4690,9 +4690,11 @@ struct User {
 	foo Foo @[skip]
 	// If the field name is different in JSON, it can be specified
 	last_name string @[json: lastName]
+	// Use the `json_allow_null` to allow null values
+	nullable @[json_allow_null]
 }
 
-data := '{ "name": "Frodo", "lastName": "Baggins", "age": 25 }'
+data := '{ "name": "Frodo", "lastName": "Baggins", "age": 25, "nullable": null }'
 user := json.decode(User, data) or {
 	eprintln('Failed to decode json, error: ${err}')
 	return

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4691,7 +4691,7 @@ struct User {
 	// If the field name is different in JSON, it can be specified
 	last_name string @[json: lastName]
 	// Use the `json_allow_null` to allow null values
-	nullable @[json_allow_null]
+	nullable string @[json_allow_null]
 }
 
 data := '{ "name": "Frodo", "lastName": "Baggins", "age": 25, "nullable": null }'

--- a/vlib/json/tests/json_test.v
+++ b/vlib/json/tests/json_test.v
@@ -516,11 +516,8 @@ fn test_encode_alias_field() {
 			a: 1
 		}
 	})
-	println(s)
 	assert s == '{"sub":{"a":1}}'
 }
-
-//
 
 struct APrice {}
 
@@ -545,13 +542,18 @@ struct ChildNullish {
 
 struct NullishStruct {
 	name     string
-	lastname string @[json_allow_null]
+	lastname string
 	age      int
 	salary   f32
-	child    ChildNullish @[json_allow_null]
+	child    ChildNullish
 }
 
-fn test_nullish() {
+struct RequiredStruct {
+	name     string @[required]
+	lastname string
+}
+
+fn test_required() {
 	nullish_one := json.decode(NullishStruct, '{"name":"Peter", "lastname":null, "age":28,"salary":95000.5,"title":"worker"}')!
 	assert nullish_one.name == 'Peter'
 	assert nullish_one.lastname == ''
@@ -572,4 +574,16 @@ fn test_nullish() {
 	assert nullish_third.age == 28
 	assert nullish_third.salary == 95000.5
 	assert nullish_third.child.name == 'Nullish'
+
+	required_struct := json.decode(RequiredStruct, '{"name":"Peter", "lastname": "Parker"}')!
+	assert required_struct.name == 'Peter'
+	assert required_struct.lastname == 'Parker'
+
+	required_struct_err := json.decode(RequiredStruct, '{"name": null, "lastname": "Parker"}') or {
+		assert err.msg() == "type mismatch for field 'name', expecting `string` type, got: null"
+		RequiredStruct{
+			name:     'Peter'
+			lastname: 'Parker'
+		}
+	}
 }

--- a/vlib/json/tests/json_test.v
+++ b/vlib/json/tests/json_test.v
@@ -544,11 +544,11 @@ struct ChildNullish {
 }
 
 struct NullishStruct {
-	name   string
+	name     string
 	lastname string @[json_allow_null]
-	age    int
-	salary f32
-	child ChildNullish @[json_allow_null]
+	age      int
+	salary   f32
+	child    ChildNullish @[json_allow_null]
 }
 
 fn test_nullish() {

--- a/vlib/json/tests/json_test.v
+++ b/vlib/json/tests/json_test.v
@@ -538,3 +538,38 @@ fn test_encoding_struct_with_pointers() {
 	}
 	assert json.encode(value) == '{"association":{"price":{}},"price":{}}'
 }
+
+struct ChildNullish {
+	name string
+}
+
+struct NullishStruct {
+	name   string
+	lastname string @[json_allow_null]
+	age    int
+	salary f32
+	child ChildNullish @[json_allow_null]
+}
+
+fn test_nullish() {
+	nullish_one := json.decode(NullishStruct, '{"name":"Peter", "lastname":null, "age":28,"salary":95000.5,"title":"worker"}')!
+	assert nullish_one.name == 'Peter'
+	assert nullish_one.lastname == ''
+	assert nullish_one.age == 28
+	assert nullish_one.salary == 95000.5
+	assert nullish_one.child.name == ''
+
+	nullish_two := json.decode(NullishStruct, '{"name":"Peter", "lastname": "Parker", "age":28,"salary":95000.5,"title":"worker"}')!
+	assert nullish_two.name == 'Peter'
+	assert nullish_two.lastname == 'Parker'
+	assert nullish_two.age == 28
+	assert nullish_two.salary == 95000.5
+	assert nullish_two.child.name == ''
+
+	nullish_third := json.decode(NullishStruct, '{"name":"Peter", "age":28,"salary":95000.5,"title":"worker", "child": {"name":"Nullish"}}')!
+	assert nullish_third.name == 'Peter'
+	assert nullish_third.lastname == ''
+	assert nullish_third.age == 28
+	assert nullish_third.salary == 95000.5
+	assert nullish_third.child.name == 'Nullish'
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -653,7 +653,7 @@ fn (mut g Gen) gen_prim_type_validation(name string, typ ast.Type, tmp string, a
 
 @[inline]
 fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp string, mut enc strings.Builder,
-	mut dec strings.Builder, embed_prefix string, allow_null_father bool) {
+	mut dec strings.Builder, embed_prefix string, allow_null_parent bool) {
 	info := type_info as ast.Struct
 	for field in info.fields {
 		mut name := field.name
@@ -662,7 +662,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 		mut is_required := false
 		mut is_omit_empty := false
 		mut skip_embed := false
-		mut allow_null := allow_null_father
+		mut allow_null := allow_null_parent
 
 		for attr in field.attrs {
 			match attr.name {

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -175,7 +175,8 @@ ${enc_fn_dec} {
 				}
 			} else if psym.info is ast.Struct {
 				enc.writeln('\to = cJSON_CreateObject();')
-				g.gen_struct_enc_dec(utyp, psym.info, ret_styp, mut enc, mut dec, '', false)
+				g.gen_struct_enc_dec(utyp, psym.info, ret_styp, mut enc, mut dec, '',
+					false)
 			} else if psym.kind == .enum {
 				g.gen_enum_enc_dec(utyp, psym, mut enc, mut dec)
 			} else if psym.kind == .sum_type {
@@ -628,7 +629,11 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 }
 
 fn (mut g Gen) gen_prim_type_validation(name string, typ ast.Type, tmp string, allow_null bool, ret_styp string, mut dec strings.Builder) {
-	none_check := if allow_null || typ.has_flag(.option) { 'cJSON_IsNull(jsonroot_${tmp}) || ' } else { '' }
+	none_check := if allow_null || typ.has_flag(.option) {
+		'cJSON_IsNull(jsonroot_${tmp}) || '
+	} else {
+		''
+	}
 	type_check := if typ.is_int() || typ.is_float() {
 		'${none_check}cJSON_IsNumber(jsonroot_${tmp}) || (cJSON_IsString(jsonroot_${tmp}) && strlen(jsonroot_${tmp}->valuestring))'
 	} else if typ.is_string() {
@@ -685,7 +690,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					allow_null = true
 				}
 				else {}
-			} 
+			}
 		}
 		if is_skip {
 			continue
@@ -795,8 +800,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					tmp := g.new_tmp_var()
 					gen_js_get(styp, tmp, name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
-					g.gen_prim_type_validation(field.name, parent_type, tmp, allow_null, '${result_name}_${styp}', mut
-						dec)
+					g.gen_prim_type_validation(field.name, parent_type, tmp, allow_null,
+						'${result_name}_${styp}', mut dec)
 					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${parent_dec_name} (jsonroot_${tmp});')
 					if field.has_default_expr {
 						dec.writeln('\t} else {')
@@ -836,8 +841,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				gen_js_get_opt(dec_name, field_type, styp, tmp, name, mut dec, is_required)
 				dec.writeln('\tif (jsonroot_${tmp}) {')
 				if is_js_prim(g.styp(field.typ.clear_option_and_result())) {
-					g.gen_prim_type_validation(field.name, field.typ, tmp, allow_null, '${result_name}_${styp}', mut
-						dec)
+					g.gen_prim_type_validation(field.name, field.typ, tmp, allow_null,
+						'${result_name}_${styp}', mut dec)
 				}
 				if field.typ.has_flag(.option) {
 					dec.writeln('\t\tvmemcpy(&${prefix}${op}${c_name(field.name)}, (${field_type}*)${tmp}.data, sizeof(${field_type}));')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -175,7 +175,7 @@ ${enc_fn_dec} {
 				}
 			} else if psym.info is ast.Struct {
 				enc.writeln('\to = cJSON_CreateObject();')
-				g.gen_struct_enc_dec(utyp, psym.info, ret_styp, mut enc, mut dec, '')
+				g.gen_struct_enc_dec(utyp, psym.info, ret_styp, mut enc, mut dec, '', false)
 			} else if psym.kind == .enum {
 				g.gen_enum_enc_dec(utyp, psym, mut enc, mut dec)
 			} else if psym.kind == .sum_type {
@@ -209,7 +209,7 @@ ${enc_fn_dec} {
 			if sym.info !is ast.Struct {
 				verror('json: ${sym.name} is not struct')
 			}
-			g.gen_struct_enc_dec(utyp, sym.info, ret_styp, mut enc, mut dec, '')
+			g.gen_struct_enc_dec(utyp, sym.info, ret_styp, mut enc, mut dec, '', false)
 		}
 		// cJSON_delete
 		dec.writeln('\t${result_name}_${ret_styp} ret;')
@@ -627,8 +627,8 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 	}
 }
 
-fn (mut g Gen) gen_prim_type_validation(name string, typ ast.Type, tmp string, ret_styp string, mut dec strings.Builder) {
-	none_check := if typ.has_flag(.option) { 'cJSON_IsNull(jsonroot_${tmp}) || ' } else { '' }
+fn (mut g Gen) gen_prim_type_validation(name string, typ ast.Type, tmp string, allow_null bool, ret_styp string, mut dec strings.Builder) {
+	none_check := if allow_null || typ.has_flag(.option) { 'cJSON_IsNull(jsonroot_${tmp}) || ' } else { '' }
 	type_check := if typ.is_int() || typ.is_float() {
 		'${none_check}cJSON_IsNumber(jsonroot_${tmp}) || (cJSON_IsString(jsonroot_${tmp}) && strlen(jsonroot_${tmp}->valuestring))'
 	} else if typ.is_string() {
@@ -648,7 +648,7 @@ fn (mut g Gen) gen_prim_type_validation(name string, typ ast.Type, tmp string, r
 
 @[inline]
 fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp string, mut enc strings.Builder,
-	mut dec strings.Builder, embed_prefix string) {
+	mut dec strings.Builder, embed_prefix string, allow_null_father bool) {
 	info := type_info as ast.Struct
 	for field in info.fields {
 		mut name := field.name
@@ -657,6 +657,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 		mut is_required := false
 		mut is_omit_empty := false
 		mut skip_embed := false
+		mut allow_null := allow_null_father
 
 		for attr in field.attrs {
 			match attr.name {
@@ -680,8 +681,11 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				'omitempty' {
 					is_omit_empty = true
 				}
+				'json_allow_null' {
+					allow_null = true
+				}
 				else {}
-			}
+			} 
 		}
 		if is_skip {
 			continue
@@ -724,7 +728,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				if utyp.has_flag(.option) {
 					dec.writeln('\t\tres.state = 0;')
 				}
-				g.gen_prim_type_validation(field.name, field.typ, tmp, '${result_name}_${styp}', mut
+				g.gen_prim_type_validation(field.name, field.typ, tmp, allow_null, '${result_name}_${styp}', mut
 					dec)
 				dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${dec_name}(jsonroot_${tmp});')
 				if field.has_default_expr {
@@ -791,7 +795,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					tmp := g.new_tmp_var()
 					gen_js_get(styp, tmp, name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
-					g.gen_prim_type_validation(field.name, parent_type, tmp, '${result_name}_${styp}', mut
+					g.gen_prim_type_validation(field.name, parent_type, tmp, allow_null, '${result_name}_${styp}', mut
 						dec)
 					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${parent_dec_name} (jsonroot_${tmp});')
 					if field.has_default_expr {
@@ -822,7 +826,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 								name
 							}
 							g.gen_struct_enc_dec(field.typ, g.table.sym(field.typ).info,
-								styp, mut enc, mut dec, prefix_embed)
+								styp, mut enc, mut dec, prefix_embed, allow_null)
 							skip_embed = true
 							break
 						}
@@ -832,7 +836,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				gen_js_get_opt(dec_name, field_type, styp, tmp, name, mut dec, is_required)
 				dec.writeln('\tif (jsonroot_${tmp}) {')
 				if is_js_prim(g.styp(field.typ.clear_option_and_result())) {
-					g.gen_prim_type_validation(field.name, field.typ, tmp, '${result_name}_${styp}', mut
+					g.gen_prim_type_validation(field.name, field.typ, tmp, allow_null, '${result_name}_${styp}', mut
 						dec)
 				}
 				if field.typ.has_flag(.option) {


### PR DESCRIPTION
By default, allow parsing a json with nulls, validate only the null if in the field has the attribute `@[required]`.

Resolves: #23207

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY1MzMwNGYxNDRmNTg1YWU0ZTczNTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.C9k24rXfCqVsREHelGxbV32S1jcciM4G3q259qeHN_s">Huly&reg;: <b>V_0.6-21653</b></a></sub>