### PR TITLE
cgen: reduce RAM usage, by avoiding a .str() call, for the final string builder, containing the final C program, used to write it to a file

### DIFF
--- a/vlib/v/builder/cbuilder/cbuilder.v
+++ b/vlib/v/builder/cbuilder/cbuilder.v
@@ -1,6 +1,7 @@
 module cbuilder
 
 import os
+import strings
 import v.pref
 import v.util
 import v.builder
@@ -60,17 +61,17 @@ pub fn build_c(mut b builder.Builder, v_files []string, out_file string) {
 	if b.pref.is_vlines {
 		output2 = c.fix_reset_dbg_line(output2, out_file)
 	}
-	os.write_file(out_file, output2) or { panic(err) }
+	os.write_file_array(out_file, output2) or { panic(err) }
 	if b.pref.is_stats {
-		b.stats_lines = output2.count('\n') + 1
+		b.stats_lines = output2.count(it == `\n`) + 1
 		b.stats_bytes = output2.len
 	}
 }
 
-pub fn gen_c(mut b builder.Builder, v_files []string) string {
+pub fn gen_c(mut b builder.Builder, v_files []string) strings.Builder {
 	b.front_and_middle_stages(v_files) or {
 		if err.code() > 7000 {
-			return ''
+			return []u8{}
 		}
 		builder.verror(err.msg())
 	}
@@ -86,5 +87,5 @@ pub fn gen_c(mut b builder.Builder, v_files []string) string {
 		util.timing_measure('Parallel C compilation')
 	}
 
-	return result.res
+	return result.res_builder
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -276,12 +276,12 @@ mut:
 @[heap]
 pub struct GenOutput {
 pub:
-	header           string // produced output for out.h (-parallel-cc)
-	res              string // produced output (complete)
-	out_str          string // produced output from g.out
-	out0_str         string // helpers output (auto fns, dump fns) for out_0.c (-parallel-cc)	
-	extern_str       string // extern chunk for (-parallel-cc)
-	out_fn_start_pos []int  // fn decl positions
+	header           string          // produced output for out.h (-parallel-cc)
+	res_builder      strings.Builder // produced output (complete)
+	out_str          string          // produced output from g.out
+	out0_str         string          // helpers output (auto fns, dump fns) for out_0.c (-parallel-cc)	
+	extern_str       string          // extern chunk for (-parallel-cc)
+	out_fn_start_pos []int           // fn decl positions
 }
 
 pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenOutput {
@@ -723,18 +723,18 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	}
 	// End of out_0.c
 
+	shelpers := helpers.str()
+
 	if !g.pref.parallel_cc {
-		b.write_string(helpers.str())
+		b.write_string(shelpers)
 	}
 
 	// The rest of the output
 	out_str := g.out.str()
-	out0_str := helpers.str()
 	extern_out_str := g.extern_out.str()
 	b.write_string(out_str)
 	b.writeln('// THE END.')
 	util.timing_measure('cgen common')
-	res := b.str()
 	$if trace_all_generic_fn_keys ? {
 		gkeys := g.table.fn_generic_types.keys()
 		for gkey in gkeys {
@@ -742,15 +742,14 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 		}
 	}
 	out_fn_start_pos := g.out_fn_start_pos.clone()
-	unsafe { b.free() }
 	unsafe { helpers.free() }
 	unsafe { g.free_builders() }
 
 	return GenOutput{
 		header:           header
-		res:              res
+		res_builder:      b
 		out_str:          out_str
-		out0_str:         out0_str
+		out0_str:         shelpers
 		extern_str:       extern_out_str
 		out_fn_start_pos: out_fn_start_pos
 	}

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -110,7 +110,7 @@ fn test_one() {
 	mut checker_ := checker.new_checker(table, vpref)
 	checker_.check(mut program)
 	result := c.gen([program], mut table, vpref)
-	res := result.res.replace('\n', '').trim_space().after('#endif')
+	res := result.res_builder.bytestr().replace('\n', '').trim_space().after('#endif')
 	println(res)
 	ok := expected == res
 	println(res)
@@ -153,7 +153,7 @@ fn test_parse_expr() {
 	}
 	chk.check(mut program)
 	result := c.gen([program], mut table, vpref)
-	res := result.res.after('#endif')
+	res := result.res_builder.bytestr().after('#endif')
 	println('========')
 	println(res)
 	println('========')


### PR DESCRIPTION
```
#0 22:33:59 ^ cgen_avoid_making_a_string_from_the_final_builder /v/oo>xtime ./vold -o x.c cmd/v
CPU: 2.56s      Real: 2.52s     Elapsed: 0:02.52        RAM: 428828KB   ./vold -o x.c cmd/v
#0 22:38:55 ^ cgen_avoid_making_a_string_from_the_final_builder /v/oo>xtime ./vnew -o x.c cmd/v
CPU: 2.54s      Real: 2.24s     Elapsed: 0:02.24        RAM: 422624KB   ./vnew -o x.c cmd/v
#0 22:39:01 ^ cgen_avoid_making_a_string_from_the_final_builder /v/oo>
```

The difference for V itself is ~6MB less, due to the avoidance of the final .str() creation.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY1ZDRiZGYxNDRmNTg1YWU0ZWEzMDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.eQtx0otVMfKGdFsbQ8L2dUoRC5PDFt3ChnsuoT0mkfQ">Huly&reg;: <b>V_0.6-21660</b></a></sub>