### PR TITLE
cgen: fix profile time on windows 

### DIFF
--- a/vlib/v/gen/c/profile.v
+++ b/vlib/v/gen/c/profile.v
@@ -50,30 +50,23 @@ fn (mut g Gen) profile_fn(fn_decl ast.FnDecl) {
 pub fn (mut g Gen) gen_vprint_profile_stats() {
 	g.pcs_declarations.writeln('void vprint_profile_stats(){')
 	fstring := '"%14llu %14.3fms %14.0fns %s \\n"'
+	g.pcs_declarations.writeln('\tf64 f = 1.0;')
 	if g.pref.os == .windows {
-		g.pcs_declarations.writeln('\t// QueryPerformanceCounter() / QueryPerformanceFrequency()')
-		g.pcs_declarations.writeln('\t// https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps')
+		// QueryPerformanceCounter() / QueryPerformanceFrequency()
+		// https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps
 		g.pcs_declarations.writeln('\tu64 freq_time = 0;')
 		g.pcs_declarations.writeln('\tQueryPerformanceFrequency(((voidptr)(&freq_time)));')
-		g.pcs_declarations.writeln('\tf64 f = (f64)1000000000.0/(f64)freq_time;')
+		g.pcs_declarations.writeln('\tf = (f64)1000000000.0/(f64)freq_time;')
 	}
 	if g.pref.profile_file == '-' {
 		for pc_meta in g.pcs {
-			if g.pref.os == .windows {
-				g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) printf(${fstring}, ${pc_meta.vpc_calls}, (${pc_meta.vpc_name}*f)/1000000.0, (${pc_meta.vpc_name}*f)/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
-			} else {
-				g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) printf(${fstring}, ${pc_meta.vpc_calls}, ${pc_meta.vpc_name}/1000000.0, ${pc_meta.vpc_name}/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
-			}
+			g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) printf(${fstring}, ${pc_meta.vpc_calls}, (${pc_meta.vpc_name}*f)/1000000.0, (${pc_meta.vpc_name}*f)/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
 		}
 	} else {
 		g.pcs_declarations.writeln('\tFILE * fp;')
 		g.pcs_declarations.writeln('\tfp = fopen ("${g.pref.profile_file}", "w+");')
 		for pc_meta in g.pcs {
-			if g.pref.os == .windows {
-				g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) fprintf(fp, ${fstring}, ${pc_meta.vpc_calls}, (${pc_meta.vpc_name}*f)/1000000.0, (${pc_meta.vpc_name}*f)/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
-			} else {
-				g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) fprintf(fp, ${fstring}, ${pc_meta.vpc_calls}, ${pc_meta.vpc_name}/1000000.0, ${pc_meta.vpc_name}/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
-			}
+			g.pcs_declarations.writeln('\tif (${pc_meta.vpc_calls}) fprintf(fp, ${fstring}, ${pc_meta.vpc_calls}, (${pc_meta.vpc_name}*f)/1000000.0, (${pc_meta.vpc_name}*f)/${pc_meta.vpc_calls}, "${pc_meta.fn_name}" );')
 		}
 		g.pcs_declarations.writeln('\tfclose(fp);')
 	}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #19130

`QueryPerformanceCounter()` only a counter value, it need to divide `QueryPerformanceFrequency()` to get real time.

As `time.vpc_now()` return only a counter value:

```v
@[inline]
fn vpc_now() u64 {
	tm := u64(0)
	C.QueryPerformanceCounter(voidptr(&tm))
	return tm
}
```

https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY2MDBlMGYxNDRmNTg1YWU0ZWE3YTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.TAnCyBuaaKqlaEIArhch8pBwz4dtIBEZNOAL22wFtnA">Huly&reg;: <b>V_0.6-21661</b></a></sub>