### PR TITLE
crypt.bcrypt: limit max password length to 72 bytes

### DIFF
--- a/vlib/crypto/bcrypt/bcrypt.v
+++ b/vlib/crypto/bcrypt/bcrypt.v
@@ -15,6 +15,8 @@ pub const min_hash_size = 59
 pub const major_version = '2'
 pub const minor_version = 'a'
 
+const error_msg_max_length_exceed_72 = 'Maximum password length is 72 bytes'
+
 pub struct Hashed {
 mut:
 	hash  []u8
@@ -40,10 +42,9 @@ const magic_cipher_data = [u8(0x4f), 0x72, 0x70, 0x68, 0x65, 0x61, 0x6e, 0x42, 0
 	0x6c, 0x64, 0x65, 0x72, 0x53, 0x63, 0x72, 0x79, 0x44, 0x6f, 0x75, 0x62, 0x74]
 
 // generate_from_password return a bcrypt string from Hashed struct.
-//
 pub fn generate_from_password(password []u8, cost int) !string {
 	if password.len > 72 {
-		return error('Maximum password length is 72 bytes')
+		return error(error_msg_max_length_exceed_72)
 	}
 	mut p := new_from_password(password, cost) or { return error('Error: ${err}') }
 	x := p.hash_u8()
@@ -53,7 +54,7 @@ pub fn generate_from_password(password []u8, cost int) !string {
 // compare_hash_and_password compares a bcrypt hashed password with its possible hashed version.
 pub fn compare_hash_and_password(password []u8, hashed_password []u8) ! {
 	if password.len > 72 {
-		return error('Maximum password length is 72 bytes')
+		return error(error_msg_max_length_exceed_72)
 	}
 	mut p := new_from_hash(hashed_password) or { return error('Error: ${err}') }
 	p.salt << `=`

--- a/vlib/crypto/bcrypt/bcrypt.v
+++ b/vlib/crypto/bcrypt/bcrypt.v
@@ -40,7 +40,11 @@ const magic_cipher_data = [u8(0x4f), 0x72, 0x70, 0x68, 0x65, 0x61, 0x6e, 0x42, 0
 	0x6c, 0x64, 0x65, 0x72, 0x53, 0x63, 0x72, 0x79, 0x44, 0x6f, 0x75, 0x62, 0x74]
 
 // generate_from_password return a bcrypt string from Hashed struct.
+//
 pub fn generate_from_password(password []u8, cost int) !string {
+	if password.len > 72 {
+		return error('Maximum password length is 72 bytes')
+	}
 	mut p := new_from_password(password, cost) or { return error('Error: ${err}') }
 	x := p.hash_u8()
 	return x.bytestr()
@@ -48,6 +52,9 @@ pub fn generate_from_password(password []u8, cost int) !string {
 
 // compare_hash_and_password compares a bcrypt hashed password with its possible hashed version.
 pub fn compare_hash_and_password(password []u8, hashed_password []u8) ! {
+	if password.len > 72 {
+		return error('Maximum password length is 72 bytes')
+	}
 	mut p := new_from_hash(hashed_password) or { return error('Error: ${err}') }
 	p.salt << `=`
 	p.salt << `=`

--- a/vlib/crypto/bcrypt/bcrypt_test.v
+++ b/vlib/crypto/bcrypt/bcrypt_test.v
@@ -18,4 +18,13 @@ fn test_crypto_bcrypt() {
 	}
 
 	assert hash2_must_mismatch
+
+	long_password := 'jvaqhblwxtoytiaglflbisdeyoieianidksglxyitwopxgrjurhjvrsuydlcguaiueliuoikabibownvfcrcaogheq'
+	assert long_password.len > 72
+	bcrypt.generate_from_password(long_password.bytes(), 5) or {
+		assert err.msg() == 'Maximum password length is 72 bytes'
+	}
+	bcrypt.compare_hash_and_password(long_password.bytes(), hash2.bytes()) or {
+		assert err.msg() == 'Maximum password length is 72 bytes'
+	}
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #18923

Some discussion here: https://security.stackexchange.com/questions/39849/does-bcrypt-have-a-maximum-password-length

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY2OGNhOWYxNDRmNTg1YWU0ZWFjOGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.jLXAtyW4Oxy14ccr3YJKyHqsUbipcbw8bn9KrGulvWM">Huly&reg;: <b>V_0.6-21663</b></a></sub>