### PR TITLE
checker: fix `index` validating for []i32

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -305,6 +305,9 @@ fn (mut c Checker) check_array_init_default_expr(mut node ast.ArrayInit) {
 	if !node.elem_type.has_flag(.option) && init_typ.has_flag(.option) {
 		c.error('cannot use unwrapped Option as initializer', init_expr.pos())
 	}
+	if init_typ.is_number() {
+		return
+	}
 	c.check_expected(init_typ, node.elem_type) or { c.error(err.msg(), init_expr.pos()) }
 }
 

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -305,7 +305,7 @@ fn (mut c Checker) check_array_init_default_expr(mut node ast.ArrayInit) {
 	if !node.elem_type.has_flag(.option) && init_typ.has_flag(.option) {
 		c.error('cannot use unwrapped Option as initializer', init_expr.pos())
 	}
-	if init_typ.is_number() {
+	if node.elem_type.is_number() && init_typ.is_number() {
 		return
 	}
 	c.check_expected(init_typ, node.elem_type) or { c.error(err.msg(), init_expr.pos()) }

--- a/vlib/v/tests/builtin_arrays/array_init_i32_test.v
+++ b/vlib/v/tests/builtin_arrays/array_init_i32_test.v
@@ -1,0 +1,8 @@
+fn test_main() {
+	a := []i64{len: 10, init: index}
+	assert a == [i64(0), 1, 2, 3, 4, 5, 6, 7, 8, 9]
+	b := []i32{len: 10, init: index}
+	assert b == [i32(0), 1, 2, 3, 4, 5, 6, 7, 8, 9]
+	c := [10]i32{init: index}
+	assert c == [i32(0), 1, 2, 3, 4, 5, 6, 7, 8, 9]!
+}


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY3MTdhZWYxNDRmNTg1YWU0ZWI4NjUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.BtN45L-C0rwBnXcgRMI8dn5Y3E0RExmAlh1sMXYBbdM">Huly&reg;: <b>V_0.6-21666</b></a></sub>