### PR TITLE
cgen: fix lambda inferring generic type on method call

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1125,7 +1125,9 @@ fn (mut c Checker) infer_fn_generic_types(func &ast.Fn, mut node ast.CallExpr) {
 								if typ.has_flag(.generic) {
 									lambda_ret_gt_name := c.table.type_to_str(typ)
 									idx := func.generic_names.index(lambda_ret_gt_name)
-									typ = node.concrete_types[idx]
+									if idx < node.concrete_types.len {
+										typ = node.concrete_types[idx]
+									}
 								}
 							}
 						}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1127,6 +1127,8 @@ fn (mut c Checker) infer_fn_generic_types(func &ast.Fn, mut node ast.CallExpr) {
 									idx := func.generic_names.index(lambda_ret_gt_name)
 									if idx < node.concrete_types.len {
 										typ = node.concrete_types[idx]
+									} else {
+										typ = ast.void_type
 									}
 								}
 							}

--- a/vlib/v/tests/generics/generic_method_lambda_arg_test.v
+++ b/vlib/v/tests/generics/generic_method_lambda_arg_test.v
@@ -1,0 +1,34 @@
+module main
+
+fn test_main() {
+	my := MyError{
+		path: 'err msg'
+	}
+	p := my.to[string](|m| m.path)
+	p2 := my.to_str(|m| m.path)
+	println(p)
+	println(p2)
+
+	assert p == p2
+}
+
+struct MyError {
+pub:
+	path string
+}
+
+fn (e &MyError) msg() string {
+	return e.path
+}
+
+fn (e &MyError) code() int {
+	return 1
+}
+
+fn (e &MyError) to[T](func fn (MyError) T) T {
+	return func(e)
+}
+
+fn (e &MyError) to_str(func fn (MyError) string) string {
+	return func(e)
+}


### PR DESCRIPTION
Fix #23221

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY3NDc5N2YxNDRmNTg1YWU0ZWJhMzciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.cSbZePVqoJRU5hFTLi1bO2OeXmflGh7iqcA_R_HxzFk">Huly&reg;: <b>V_0.6-21668</b></a></sub>