### PR TITLE
v: fix identification of abstract vs real interface methods

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1722,8 +1722,8 @@ pub fn (t &TypeSymbol) has_method(name string) bool {
 }
 
 pub fn (t &TypeSymbol) has_method_with_generic_parent(name string) bool {
-	t.find_method_with_generic_parent(name) or { return false }
-	return true
+	m := t.find_method_with_generic_parent(name) or { return false }
+	return t.kind != .interface || !m.no_body
 }
 
 pub fn (t &TypeSymbol) find_method(name string) ?Fn {
@@ -1813,7 +1813,7 @@ pub fn (t &TypeSymbol) str_method_info() (bool, bool, int) {
 	mut expects_ptr := false
 	mut nr_args := 0
 	if sym_str_method := t.find_method_with_generic_parent('str') {
-		has_str_method = true
+		has_str_method = t.kind != .interface || !sym_str_method.no_body
 		nr_args = sym_str_method.params.len
 		if nr_args > 0 {
 			expects_ptr = sym_str_method.params[0].typ.is_ptr()

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2552,7 +2552,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 		c.fail_if_unreadable(node.left, left_type, 'receiver')
 	}
 	if left_sym.language != .js && (!left_sym.is_builtin() && method.mod != 'builtin')
-		&& method.language == .v && method.no_body && left_sym.kind != .interface {
+		&& method.language == .v && final_left_sym.kind != .interface && method.no_body {
 		c.error('cannot call a method that does not have a body', node.pos)
 	}
 	if node.concrete_types.len > 0 && method.generic_names.len > 0

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2552,7 +2552,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 		c.fail_if_unreadable(node.left, left_type, 'receiver')
 	}
 	if left_sym.language != .js && (!left_sym.is_builtin() && method.mod != 'builtin')
-		&& method.language == .v && method.no_body {
+		&& method.language == .v && method.no_body && left_sym.kind != .interface {
 		c.error('cannot call a method that does not have a body', node.pos)
 	}
 	if node.concrete_types.len > 0 && method.generic_names.len > 0

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -738,6 +738,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 				is_pub:        true
 				is_method:     true
 				receiver_type: typ
+				no_body:       true
 			}
 			ts.register_method(tmethod)
 			info.methods << tmethod

--- a/vlib/v/tests/interfaces/interface_arr_auto_str_test.v
+++ b/vlib/v/tests/interfaces/interface_arr_auto_str_test.v
@@ -1,0 +1,25 @@
+interface Interface {
+	str() string
+}
+
+struct Result[T] {
+	data []T
+}
+
+struct Foobar {
+}
+
+fn (f Foobar) str() string {
+	return 'foobar'
+}
+
+fn test_main() {
+	assert Result[Interface]{}.str() == 'Result[Interface]{
+    data: []
+}'
+	assert Result[Foobar]{
+		data: [Foobar{}]
+	}.str() == 'Result[Foobar]{
+    data: [foobar]
+}'
+}


### PR DESCRIPTION
Fix #23006

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY3NzNiZmYxNDRmNTg1YWU0ZWJiZGIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.X0jFjdb01RWnijiF1Y5vc0AiK323HtoU53K5k_mtAU8">Huly&reg;: <b>V_0.6-21672</b></a></sub>