### PR TITLE
db.sqlite: added exec_map function 

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -220,7 +220,7 @@ pub fn (db &DB) exec_map(query string) ![]map[string]string {
 		C.sqlite3_finalize(stmt)
 	}
 	mut code := C.sqlite3_prepare_v2(db.conn, &char(query.str), query.len, &stmt, 0)
-	if code != sqlite.sqlite_ok {
+	if code != sqlite_ok {
 		return db.error_message(code, query)
 	}
 


### PR DESCRIPTION
New function exec_map returns an array of maps from query

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY4ZTdmNmYxNDRmNTg1YWU0ZWQzODAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.at5IgUm3JHPMaGqTvoYHBZIAsV0rmdV0E4l4nr60wIw">Huly&reg;: <b>V_0.6-21680</b></a></sub>