### PR TITLE
checker: fix pushing enum value to channel (fix #23244)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -9,8 +9,14 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		c.expected_type = former_expected_type
 	}
 	mut left_type := c.expr(mut node.left)
+	mut left_sym := c.table.sym(left_type)
 	node.left_type = left_type
 	c.expected_type = left_type
+
+	if left_sym.kind == .chan {
+		chan_info := left_sym.chan_info()
+		c.expected_type = chan_info.elem_type
+	}
 
 	// `if n is ast.Ident && n.is_mut { ... }`
 	if !c.inside_sql && node.op == .and {
@@ -103,7 +109,6 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	}
 	mut right_sym := c.table.sym(right_type)
 	right_final_sym := c.table.final_sym(right_type)
-	mut left_sym := c.table.sym(left_type)
 	left_final_sym := c.table.final_sym(left_type)
 	left_pos := node.left.pos()
 	right_pos := node.right.pos()

--- a/vlib/v/tests/concurrency/chan_push_enum_test.v
+++ b/vlib/v/tests/concurrency/chan_push_enum_test.v
@@ -1,0 +1,11 @@
+enum FooBar {
+	foo
+	bar
+}
+
+fn test_chan_push_enum() {
+	ch := chan FooBar{cap: 10}
+	ch <- .foo
+	println(<-ch)
+	assert true
+}


### PR DESCRIPTION
This PR fix pushing enum value to channel (fix #23244).

- Fix pushing enum value to channel.
- Add test.

```v
enum FooBar {
	foo
	bar
}

fn test_chan_push_enum() {
	ch := chan FooBar{cap: 10}
	ch <- .foo
	println(<-ch)
	assert true
}

PS D:\Test\v\tt1> v run .    
foo
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY5MWEyY2YxNDRmNTg1YWU0ZWQ5NDMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.dqk-r-LQGjdesgJxpt9H1pfZkznjhZSVDMJ4bomfafc">Huly&reg;: <b>V_0.6-21681</b></a></sub>