### PR TITLE
cgen: fix codegen for casting aliased fixed array to sumtype array

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2695,8 +2695,9 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 	}
 	g.write('${fname}(')
 	if !got_is_ptr && !got_is_fn {
-		if is_comptime_variant || !expr.is_lvalue()
-			|| (expr is ast.Ident && expr.obj.is_simple_define_const()) {
+		is_cast_array_init := expr is ast.CastExpr && expr.expr is ast.ArrayInit
+		if !is_cast_array_init && (is_comptime_variant || !expr.is_lvalue()
+			|| (expr is ast.Ident && expr.obj.is_simple_define_const())) {
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:
 			if expr.is_as_cast() {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2695,8 +2695,9 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 	}
 	g.write('${fname}(')
 	if !got_is_ptr && !got_is_fn {
-		is_cast_array_init := expr is ast.CastExpr && expr.expr is ast.ArrayInit
-		if !is_cast_array_init && (is_comptime_variant || !expr.is_lvalue()
+		is_cast_fixed_array_init := expr is ast.CastExpr
+			&& (expr.expr is ast.ArrayInit && expr.expr.is_fixed)
+		if !is_cast_fixed_array_init && (is_comptime_variant || !expr.is_lvalue()
 			|| (expr is ast.Ident && expr.obj.is_simple_define_const())) {
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:

--- a/vlib/v/tests/aliases/alias_array_fixed_sumtype_test.v
+++ b/vlib/v/tests/aliases/alias_array_fixed_sumtype_test.v
@@ -1,0 +1,12 @@
+module main
+
+type IPv4 = [4]u8
+type IPv6 = [16]u8
+type IP = IPv4 | IPv6
+
+fn test_main() {
+	mut arr := []IP{}
+	arr << IP(IPv4([4]u8{}))
+	arr << IP(IPv6([16]u8{}))
+	assert arr.str() == '[IP(IPv4([0, 0, 0, 0])), IP(IPv6([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))]'
+}


### PR DESCRIPTION
Fix #23009

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY5NGM5NWYxNDRmNTg1YWU0ZjM4OTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lYl_mAX_xGzJXOt6y5uKNOIO5ipxgwr11WtCZd808Bo">Huly&reg;: <b>V_0.6-21682</b></a></sub>