### PR TITLE
ast: fix const map init order (fix #23255)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2552,6 +2552,9 @@ pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
 			names << t.dependent_names_in_expr(expr.right)
 		}
 		MapInit {
+			for key in expr.keys {
+				names << t.dependent_names_in_expr(key)
+			}
 			for val in expr.vals {
 				names << t.dependent_names_in_expr(val)
 			}

--- a/vlib/v/tests/consts/const_map_init_order_test.v
+++ b/vlib/v/tests/consts/const_map_init_order_test.v
@@ -1,0 +1,26 @@
+const bit = f64(1)
+const nibble = bit * 4
+const bytes = bit * 8
+const kb = bytes * 1000
+const mb = kb * 1000
+
+const units_map = {
+	bit:    'bit'
+	nibble: 'nibble'
+	bytes:  'byte'
+	kb:     'kB'
+	mb:     'MB'
+}
+
+fn test_const_map_init_order() {
+	println(units_map.len)
+	println(units_map)
+	assert units_map.len == 5
+	assert units_map == {
+		1.0:    'bit'
+		4.0:    'nibble'
+		8.0:    'byte'
+		8000.0: 'kB'
+		8.e+06: 'MB'
+	}
+}


### PR DESCRIPTION
This PR fix const map init order (fix #23255).

- Fix const map init order.
- Add test.

```v
const bit = f64(1)
const nibble = bit * 4
const bytes = bit * 8
const kb = bytes * 1000
const mb = kb * 1000

const units_map = {
	bit:    'bit'
	nibble: 'nibble'
	bytes:  'byte'
	kb:     'kB'
	mb:     'MB'
}

fn main() {
	println(units_map.len)
	println(units_map)
	assert units_map.len == 5
	assert units_map == {
		1.0:    'bit'
		4.0:    'nibble'
		8.0:    'byte'
		8000.0: 'kB'
		8.e+06: 'MB'
	}
}

PS D:\Test\v\tt1> v run .
5
{1.0: 'bit', 4.0: 'nibble', 8.0: 'byte', 8000.0: 'kB', 8.e+06: 'MB'}
```