### PR TITLE
cgen: fix try_push string literal to channel  (fix #23242)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2924,7 +2924,10 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 						g.expr_with_opt(arg.expr, arg_typ, expected_type)
 						return
 					} else if arg.expr.is_literal() {
-						g.write('(voidptr)')
+						g.write('(voidptr)ADDR(${g.styp(arg_typ)}, ')
+						g.expr(arg.expr)
+						g.write(')')
+						return
 					} else {
 						if arg_typ_sym.kind in [.sum_type, .interface] {
 							atype = arg_typ

--- a/vlib/v/tests/concurrency/chan_try_push_literal_test.v
+++ b/vlib/v/tests/concurrency/chan_try_push_literal_test.v
@@ -1,0 +1,5 @@
+fn test_chan_try_push_literal() {
+	foo := chan string{}
+	foo.try_push('some string')
+	assert true
+}


### PR DESCRIPTION
This PR fix try_push string literal to channel  (fix #23242).

- Fix try_push string literal to channel.
- Add test.

```v
fn main() {
	foo := chan string{}
	foo.try_push('some string')
	assert true
}

PS D:\Test\v\tt1> v run .  
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZhN2I3N2YxNDRmNTg1YWU0ZmZmOWQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.sW_kbs8wcryM0crDD4d51Tgd4P0Kse7fgoXD1Arkzd8">Huly&reg;: <b>V_0.6-21693</b></a></sub>