### PR TITLE
cgen: fix thread struct name for same fn var name on different scope

### DIFF
--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -26,9 +26,14 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	mut handle := ''
 	tmp := g.new_tmp_var()
 	mut expr := node.call_expr
-	mut name := '${expr.name}_${expr.pos.pos}'
+	mut name := expr.name
 	mut use_tmp_fn_var := false
 	tmp_fn := g.new_tmp_var()
+
+	if expr.is_fn_var {
+		// generate a name different for same var fn name declared in another scope
+		name = '${name}_${node.pos.pos}'
+	}
 
 	if expr.concrete_types.len > 0 {
 		name = g.generic_fn_name(expr.concrete_types, name)

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -26,7 +26,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	mut handle := ''
 	tmp := g.new_tmp_var()
 	mut expr := node.call_expr
-	mut name := expr.name
+	mut name := '${expr.name}_${expr.pos.pos}'
 	mut use_tmp_fn_var := false
 	tmp_fn := g.new_tmp_var()
 

--- a/vlib/v/tests/chan_same_fn_name_test.v
+++ b/vlib/v/tests/chan_same_fn_name_test.v
@@ -1,0 +1,24 @@
+fn a() chan string {
+	ch_out := chan string{}
+	f := fn (a chan string) {
+		a <- 'foo'
+	}
+	spawn f(ch_out)
+	return ch_out
+}
+
+fn b(ch_in chan string) string {
+	f := fn (a chan string, b chan string) {
+		val := <-a
+		{}
+		b <- val
+	}
+	ch_out := chan string{}
+	spawn f(ch_in, ch_out)
+	return <-ch_out
+}
+
+fn test_main() {
+	ch0 := a()
+	assert b(ch0) == 'foo'
+}


### PR DESCRIPTION
Fix #21746

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZiNGQ2M2YxNDRmNTg1YWU1MDFhM2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.oyEkm765TzTOyUACuQzqaBCwUw7D_a0OevnAJBcseZ0">Huly&reg;: <b>V_0.6-21695</b></a></sub>