### PR TITLE
cgen,json: fix default initialization

### DIFF
--- a/vlib/json/tests/json_decode_option_alias_test.v
+++ b/vlib/json/tests/json_decode_option_alias_test.v
@@ -1,0 +1,20 @@
+import json
+
+struct Empty {}
+
+struct SomeStruct {
+	random_field_a ?string
+	random_field_b ?string
+	empty_field    ?Empty
+}
+
+type Alias = SomeStruct
+
+fn test_main() {
+	data := json.decode(Alias, '{"empty_field":{}}')!
+	assert data.str() == 'Alias(SomeStruct{
+    random_field_a: Option(none)
+    random_field_b: Option(none)
+    empty_field: Option(none)
+})'
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7260,7 +7260,6 @@ fn (mut g Gen) type_default(typ_ ast.Type) string {
 							} else {
 								default_str := g.expr_string(field.default_expr)
 								if default_str.count('\n') > 1 {
-									println('>>> ${default_str.all_before_last('\n')}')
 									g.type_default_vars.writeln(default_str.all_before_last('\n'))
 									expr_str = default_str.all_after_last('\n')
 								} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7285,7 +7285,11 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 								&& field_sym.info.is_empty_struct() {
 								'{EMPTY_STRUCT_INITIALIZATION}'
 							} else if field_sym.kind == .sum_type {
-								g.type_default_sumtype(field.typ, field_sym)
+								if decode_sumtype {
+									g.type_default_sumtype(field.typ, field_sym)
+								} else {
+									'{0}'
+								}
 							} else {
 								g.type_default(field.typ)
 							}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7107,10 +7107,8 @@ fn (mut g Gen) type_default_sumtype(typ_ ast.Type, sym ast.TypeSymbol) string {
 		'(${first_styp}){.state=2, .err=_const_none__, .data={EMPTY_STRUCT_INITIALIZATION}}'
 	} else if first_sym.info is ast.Struct && first_sym.info.is_empty_struct() {
 		'{EMPTY_STRUCT_INITIALIZATION}'
-	} else if first_sym.kind == .struct {
-		'{0}'
 	} else {
-		g.type_default(first_typ)
+		g.type_default_no_sumtype(first_typ)
 	}
 	if default_str[0] == `{` {
 		return '(${g.styp(typ_)}){._${first_field}=HEAP(${first_styp}, ((${first_styp})${default_str})),._typ=${int(first_typ)}}'

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -75,18 +75,6 @@ fn (mut g Gen) gen_jsons() {
 					g.type_default_vars.clear()
 				}
 				init_styp += init_generated
-				// if utyp.is_ptr() {
-				// 	ptr_styp := g.styp(utyp.set_nr_muls(utyp.nr_muls() - 1))
-				// 	g.write('HEAP(${ptr_styp}, ')
-				// }
-				// g.expr(ast.Expr(ast.StructInit{
-				// 	typ:     utyp.set_nr_muls(0)
-				// 	typ_str: styp
-				// }))
-				// if utyp.is_ptr() {
-				// 	g.write(')')
-				// }
-				// init_styp = g.out.cut_to(pos).trim_space()
 			} else if utyp.is_ptr() {
 				ptr_styp := g.styp(utyp.set_nr_muls(utyp.nr_muls() - 1))
 				init_styp += ' = HEAP(${ptr_styp}, {0})'


### PR DESCRIPTION
Fix #23262

Makes `g.type_default()` more compatible with `g.expr(StructInit{})`.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZiZWRhNWYxNDRmNTg1YWU1MDQ2NTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.L-MZUny8nit4q_e-4cm_hgvFLELMu1430p9Iu2iLPEs">Huly&reg;: <b>V_0.6-21697</b></a></sub>