### PR TITLE
smtp: fix crash when reconnecting with encrypted=true

### DIFF
--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -88,7 +88,7 @@ pub fn (mut c Client) reconnect() ! {
 	conn := net.dial_tcp('${c.server}:${c.port}') or { return error('Connecting to server failed') }
 	c.conn = conn
 
-	if c.ssl {
+	if c.ssl || c.encrypted {
 		c.connect_ssl()!
 	} else {
 		c.reader = io.new_buffered_reader(reader: c.conn)


### PR DESCRIPTION
Fix #23289

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZlZWFkOWYxNDRmNTg1YWU1MTJhNGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.nZRxszcSWD2qC5x-N3aMt3uqfvJdmp8UAmQWDDJIx4k">Huly&reg;: <b>V_0.6-21722</b></a></sub>