### PR TITLE
docs: add missing keywords

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -8113,77 +8113,54 @@ instead use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp run`.
 
 ## Appendix I: Keywords
 
-V has 69 reserved keywords:
+V has 45 reserved keywords:
 
 ```v ignore
-!in
-!is
 __global
 __offsetof
 as
 asm
 assert
 atomic
-bool
 break
-byte
-char
 const
 continue
 defer
 dump
-else
 enum
-f32
-f64
+else
 false
 fn
 for
 go
 goto
-i16
-i64
-i8
 if
 implements
 import
 in
-int
 interface
 is
-isize
 isreftype
 lock
-map
 match
 module
 mut
-nil
 none
 or
 pub
 return
 rlock
-rune
 select
 shared
 sizeof
 spawn
 static
-string
 struct
-thread
 true
 type
 typeof
-u16
-u32
-u64
-u8
 union
 unsafe
-usize
-voidptr
 volatile
 ```
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -8113,54 +8113,78 @@ instead use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp run`.
 
 ## Appendix I: Keywords
 
-V has 45 reserved keywords (3 are literals):
+V has 69 reserved keywords:
 
 ```v ignore
+!in
+!is
+__global
+__offsetof
 as
 asm
 assert
 atomic
+bool
 break
+byte
+char
 const
 continue
 defer
+dump
 else
 enum
+f32
+f64
 false
 fn
 for
 go
 goto
+i16
+i64
+i8
 if
 implements
 import
 in
+int
 interface
 is
+isize
 isreftype
 lock
+map
 match
 module
 mut
+nil
 none
 or
 pub
 return
 rlock
+rune
 select
 shared
 sizeof
 spawn
 static
+string
 struct
+thread
 true
 type
 typeof
+u16
+u32
+u64
+u8
 union
 unsafe
+usize
+voidptr
 volatile
-__global
-__offsetof
 ```
 
 See also [V Types](#v-types).


### PR DESCRIPTION
When I was working on a [pr to c2v](https://github.com/vlang/c2v/pull/192) I noticed there were quite a few keywords missing from the *Keywords* section of the docs.

This may be intentional because most of these are type names but I can confirm that all of these are reserved by the compiler and therefore cannot be used as variable names.

I am unsure about `dump` because it is part of the ast but is technically a function.

Let me know if any changes should be made.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZmMDhmMmYxNDRmNTg1YWU1MTJjNTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.btHiN0mIjYEIBD5zJKhUG9FXQ64pjZEtugnMd5hc1HY">Huly&reg;: <b>V_0.6-21725</b></a></sub>