### PR TITLE
builtin: add runtime checks for `[]u8{len: negative}`

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -30,6 +30,7 @@ pub enum ArrayFlags {
 
 // Internal function, used by V (`nums := []int`)
 fn __new_array(mylen int, cap int, elm_size int) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	arr := array{
 		element_size: elm_size
@@ -41,6 +42,7 @@ fn __new_array(mylen int, cap int, elm_size int) array {
 }
 
 fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -79,6 +81,7 @@ fn __new_array_with_default(mylen int, cap int, elm_size int, val voidptr) array
 }
 
 fn __new_array_with_multi_default(mylen int, cap int, elm_size int, val voidptr) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -106,6 +109,7 @@ fn __new_array_with_multi_default(mylen int, cap int, elm_size int, val voidptr)
 }
 
 fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array, depth int) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -127,6 +131,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array, d
 }
 
 fn __new_array_with_map_default(mylen int, cap int, elm_size int, val map) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -149,6 +154,7 @@ fn __new_array_with_map_default(mylen int, cap int, elm_size int, val map) array
 
 // Private function, used by V (`nums := [1, 2, 3]`)
 fn new_array_from_c_array(len int, cap int, elm_size int, c_array voidptr) array {
+	panic_on_negative_len(len)
 	cap_ := if cap < len { len } else { cap }
 	arr := array{
 		element_size: elm_size
@@ -163,6 +169,7 @@ fn new_array_from_c_array(len int, cap int, elm_size int, c_array voidptr) array
 
 // Private function, used by V (`nums := [1, 2, 3] !`)
 fn new_array_from_c_array_no_alloc(len int, cap int, elm_size int, c_array voidptr) array {
+	panic_on_negative_len(len)
 	arr := array{
 		element_size: elm_size
 		data:         c_array
@@ -1034,4 +1041,11 @@ pub fn (data voidptr) vbytes(len int) []u8 {
 @[unsafe]
 pub fn (data &u8) vbytes(len int) []u8 {
 	return unsafe { voidptr(data).vbytes(len) }
+}
+
+@[if !no_bounds_checking ?; inline]
+fn panic_on_negative_len(len int) {
+	if len < 0 {
+		panic('negative .len')
+	}
 }

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -6,6 +6,7 @@
 module builtin
 
 fn __new_array_noscan(mylen int, cap int, elm_size int) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	arr := array{
 		element_size: elm_size
@@ -17,6 +18,7 @@ fn __new_array_noscan(mylen int, cap int, elm_size int) array {
 }
 
 fn __new_array_with_default_noscan(mylen int, cap int, elm_size int, val voidptr) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -43,6 +45,7 @@ fn __new_array_with_default_noscan(mylen int, cap int, elm_size int, val voidptr
 }
 
 fn __new_array_with_multi_default_noscan(mylen int, cap int, elm_size int, val voidptr) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -59,6 +62,7 @@ fn __new_array_with_multi_default_noscan(mylen int, cap int, elm_size int, val v
 }
 
 fn __new_array_with_array_default_noscan(mylen int, cap int, elm_size int, val array) array {
+	panic_on_negative_len(mylen)
 	cap_ := if cap < mylen { mylen } else { cap }
 	mut arr := array{
 		element_size: elm_size
@@ -75,6 +79,7 @@ fn __new_array_with_array_default_noscan(mylen int, cap int, elm_size int, val a
 
 // Private function, used by V (`nums := [1, 2, 3]`)
 fn new_array_from_c_array_noscan(len int, cap int, elm_size int, c_array voidptr) array {
+	panic_on_negative_len(len)
 	cap_ := if cap < len { len } else { cap }
 	arr := array{
 		element_size: elm_size


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZmZWQwMmYxNDRmNTg1YWU1MTM2YjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.WcCEKQv7Pjow_4b5Hnlk4ZOdWzkdJjFuQBjFvZy5DBw">Huly&reg;: <b>V_0.6-21726</b></a></sub>