### PR TITLE
log: set stderr as default log output, add .set_output_stream()

### DIFF
--- a/vlib/log/common.v
+++ b/vlib/log/common.v
@@ -19,8 +19,8 @@ pub enum LogTarget {
 	both
 }
 
-// tag_to_cli returns the tag for log level `l` as a colored string.
-fn tag_to_cli(l Level, short_tag bool) string {
+// tag_to_console returns the tag for log level `l` as a colored string.
+fn tag_to_console(l Level, short_tag bool) string {
 	if short_tag {
 		return match l {
 			.disabled { ' ' }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -37,9 +37,9 @@ mut:
 	custom_time_format string     = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
 	short_tag          bool
 	always_flush       bool // flush after every single .fatal(), .error(), .warn(), .info(), .debug() call
+	output_stream      io.Writer = os.stderr()
 pub mut:
 	output_file_name string // log output to this file
-	output_stream    io.Writer = os.stderr()
 }
 
 // get_level gets the internal logging level.
@@ -142,7 +142,9 @@ fn (mut l Log) log_file(s string, level Level) {
 fn (mut l Log) log_stream(s string, level Level) {
 	timestamp := l.time_format(time.utc())
 	tag := tag_to_console(level, l.short_tag)
-	l.output_stream.write('${timestamp} [${tag}] ${s}\n'.bytes()) or {}
+	msg := '${timestamp} [${tag}] ${s}\n'
+	arr := msg.bytes()
+	l.output_stream.write(arr) or {}
 	if l.always_flush {
 		match (l.output_stream as os.File).fd {
 			1 { flush_stdout() }
@@ -213,6 +215,7 @@ pub fn (mut f Log) free() {
 		f.output_label.free()
 		f.ofile.close()
 		f.output_file_name.free()
+		f.output_stream.free()
 	}
 }
 

--- a/vlib/v/slow_tests/inout/dump_expression.out
+++ b/vlib/v/slow_tests/inout/dump_expression.out
@@ -1,36 +1,28 @@
-[vlib/v/slow_tests/inout/dump_expression.vv:5] 1: 1
-[vlib/v/slow_tests/inout/dump_expression.vv:10] 'a': a
-[vlib/v/slow_tests/inout/dump_expression.vv:34] a: Aa{
-    log: &log.Logger(log.Log{
-        level: disabled
-        output_label: ''
-        ofile: os.File{
-            cfile: 0
-            fd: 0
-            is_opened: false
-        }
-        output_target: console
-        time_format: tf_rfc3339_micro
-        custom_time_format: 'MMMM Do YY N kk:mm:ss A'
-        short_tag: false
-        always_flush: false
-        output_file_name: ''
-    })
+[vlib/v/slow_tests/inout/dump_expression.vv:4] 1: 1
+[vlib/v/slow_tests/inout/dump_expression.vv:9] 'a': a
+[vlib/v/slow_tests/inout/dump_expression.vv:33] a: Aa{
+    cmd: &os.Command{
+        f: 0
+        eof: false
+        exit_code: 0
+        path: ''
+        redirect_stdout: false
+    }
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:35] p: Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:34] p: Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:36] p_mut: Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:35] p_mut: Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:37] p_ptr: &Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:36] p_ptr: &Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:48] os.file_name(vfile): dump_expression.vv
-[vlib/v/slow_tests/inout/dump_expression.vv:51] f.read(mut buf): 10
+[vlib/v/slow_tests/inout/dump_expression.vv:47] os.file_name(vfile): dump_expression.vv
+[vlib/v/slow_tests/inout/dump_expression.vv:50] f.read(mut buf): 10

--- a/vlib/v/slow_tests/inout/dump_expression.vv
+++ b/vlib/v/slow_tests/inout/dump_expression.vv
@@ -1,5 +1,4 @@
 import os
-import log
 
 fn dump_of_int() {
 	x := dump(1) + 1
@@ -19,16 +18,16 @@ mut:
 }
 
 struct Aa {
-	log &log.Logger
+	cmd &os.Command
 }
 
 fn dump_of_struct() {
 	p := Point{1, 2, 3}
 	mut p_mut := Point{1, 2, 3}
 	p_ptr := &Point{1, 2, 3}
-	l := &log.Log{}
+	c := &os.Command{}
 	a := Aa{
-		log: l
+		cmd: c
 	}
 
 	dump(a)


### PR DESCRIPTION
This PR:

- Adds `set_output_stream()` fn to `log.Log` struct which allows setting `io.Writer` as log output. It makes possible send logs to arbitrary targets such as sockets. Use cases: write logs to system journal e.g. syslog, send logs to remote server over UDP.
- Makes STDERR the default output stream (be STDOUT before). Sending logs to STOUT is not generally used in logging libraries e.g. Go, Python stdlibs etc.
- Edit test, since `log.Log` now have `output_stream` field with file address which can change at runtime and therefore cannot be tested in "inout" tests.

Example:

```v
import log
import os
import net

fn main() {
	mut logger := log.Log{}
	logger.set_level(.info)
	log.set_logger(logger)

	logger.info('hello stderr')
	logger.set_output_stream(os.stdout())
	logger.info('hello stdout')

	mut udp_sock := net.dial_udp('127.0.0.1:8889')!
	logger.set_output_stream(udp_sock)
	logger.info('hello udp')
}
```

![Screenshot From 2024-12-28 17-52-38](https://github.com/user-attachments/assets/62d69773-cb8d-4294-947f-7aea38e61c9e)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcwMTZiZGYxNDRmNTg1YWU1MTM4NDIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.2rSSSthRbF0_I19-1HsJMgVWY3W0s-JBJO6aIP5OYLo">Huly&reg;: <b>V_0.6-21728</b></a></sub>