### PR TITLE
net.http.cookie: handle value with `=` better

### DIFF
--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -67,13 +67,7 @@ pub fn read_cookies(h Header, filter string) []&Cookie {
 			if part.len == 0 {
 				continue
 			}
-			mut name := part
-			mut val := ''
-			if part.contains('=') {
-				val_parts := part.split('=')
-				name = val_parts[0]
-				val = val_parts[1]
-			}
+			mut name, mut val := part.split_once('=') or { part, '' }
 			if !is_cookie_name_valid(name) {
 				continue
 			}


### PR DESCRIPTION
Fixes #23297

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcwM2U5ZmYxNDRmNTg1YWU1MTNhMTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.fvhHU20pBrvo7okaZQsENP3IY-_rP4yQuzvzd6GumcQ">Huly&reg;: <b>V_0.6-21732</b></a></sub>