### PR TITLE
checker: fix array method error message with generic type

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3568,7 +3568,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		if node.args.len != 1 {
 			c.error('`.contains()` expected 1 argument, but got ${node.args.len}', node.pos)
 		} else if !left_sym.has_method('contains') {
-			arg_typ := c.expr(mut node.args[0].expr)
+			arg_typ := c.unwrap_generic(c.expr(mut node.args[0].expr))
 			c.check_expected_call_arg(arg_typ, c.unwrap_generic(elem_typ), node.language,
 				node.args[0]) or {
 				c.error('${err.msg()} in argument 1 to `.contains()`', node.args[0].pos)
@@ -3582,8 +3582,9 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		if node.args.len != 1 {
 			c.error('`.index()` expected 1 argument, but got ${node.args.len}', node.pos)
 		} else if !left_sym.has_method('index') {
-			arg_typ := c.expr(mut node.args[0].expr)
-			c.check_expected_call_arg(arg_typ, elem_typ, node.language, node.args[0]) or {
+			arg_typ := c.unwrap_generic(c.expr(mut node.args[0].expr))
+			c.check_expected_call_arg(arg_typ, c.unwrap_generic(elem_typ), node.language,
+				node.args[0]) or {
 				c.error('${err.msg()} in argument 1 to `.index()`', node.args[0].pos)
 			}
 		}
@@ -3625,7 +3626,7 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 		if node.args.len != 1 {
 			c.error('`.delete()` expected 1 argument, but got ${node.args.len}', node.pos)
 		} else {
-			arg_typ := c.expr(mut node.args[0].expr)
+			arg_typ := c.unwrap_generic(c.expr(mut node.args[0].expr))
 			c.check_expected_call_arg(arg_typ, ast.int_type, node.language, node.args[0]) or {
 				c.error('${err.msg()} in argument 1 to `.delete()`', node.args[0].pos)
 			}

--- a/vlib/v/checker/tests/array_generic_methods_err.out
+++ b/vlib/v/checker/tests/array_generic_methods_err.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/array_generic_methods_err.vv:4:23: error: cannot use `[]string` as `string` in argument 1 to `.contains()`
+    2 | fn generic_fn[T]() {
+    3 |     mut arr := []T{}
+    4 |     println(arr.contains(arr))
+      |                          ~~~
+    5 |     arr.delete(arr)
+    6 |     arr.index(arr)
+vlib/v/checker/tests/array_generic_methods_err.vv:5:13: error: cannot use `[]string` as `int` in argument 1 to `.delete()`
+    3 |     mut arr := []T{}
+    4 |     println(arr.contains(arr))
+    5 |     arr.delete(arr)
+      |                ~~~
+    6 |     arr.index(arr)
+    7 | }
+vlib/v/checker/tests/array_generic_methods_err.vv:6:12: error: cannot use `[]string` as `string` in argument 1 to `.index()`
+    4 |     println(arr.contains(arr))
+    5 |     arr.delete(arr)
+    6 |     arr.index(arr)
+      |               ~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/array_generic_methods_err.out
+++ b/vlib/v/checker/tests/array_generic_methods_err.out
@@ -1,21 +1,21 @@
-vlib/v/checker/tests/array_generic_methods_err.vv:4:23: error: cannot use `[]string` as `string` in argument 1 to `.contains()`
-    2 | fn generic_fn[T]() {
-    3 |     mut arr := []T{}
-    4 |     println(arr.contains(arr))
+vlib/v/checker/tests/array_generic_methods_err.vv:3:23: error: cannot use `[]string` as `string` in argument 1 to `.contains()`
+    1 | fn generic_fn[T]() {
+    2 |     mut arr := []T{}
+    3 |     println(arr.contains(arr))
       |                          ~~~
-    5 |     arr.delete(arr)
-    6 |     arr.index(arr)
-vlib/v/checker/tests/array_generic_methods_err.vv:5:13: error: cannot use `[]string` as `int` in argument 1 to `.delete()`
-    3 |     mut arr := []T{}
-    4 |     println(arr.contains(arr))
-    5 |     arr.delete(arr)
+    4 |     arr.delete(arr)
+    5 |     arr.index(arr)
+vlib/v/checker/tests/array_generic_methods_err.vv:4:13: error: cannot use `[]string` as `int` in argument 1 to `.delete()`
+    2 |     mut arr := []T{}
+    3 |     println(arr.contains(arr))
+    4 |     arr.delete(arr)
       |                ~~~
-    6 |     arr.index(arr)
-    7 | }
-vlib/v/checker/tests/array_generic_methods_err.vv:6:12: error: cannot use `[]string` as `string` in argument 1 to `.index()`
-    4 |     println(arr.contains(arr))
-    5 |     arr.delete(arr)
-    6 |     arr.index(arr)
+    5 |     arr.index(arr)
+    6 | }
+vlib/v/checker/tests/array_generic_methods_err.vv:5:12: error: cannot use `[]string` as `string` in argument 1 to `.index()`
+    3 |     println(arr.contains(arr))
+    4 |     arr.delete(arr)
+    5 |     arr.index(arr)
       |               ~~~
-    7 | }
-    8 |
+    6 | }
+    7 |

--- a/vlib/v/checker/tests/array_generic_methods_err.vv
+++ b/vlib/v/checker/tests/array_generic_methods_err.vv
@@ -1,0 +1,10 @@
+fn generic_fn[T]() {
+	mut arr := []T{}
+	println(arr.contains(arr))
+	arr.delete(arr)
+	arr.index(arr)
+}
+
+fn main() {
+	generic_fn[string]()
+}


### PR DESCRIPTION
Fix #23283

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcxNDZkNGYxNDRmNTg1YWU1MTQ0ZTUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.EZYh_gf-EdlsoY1zLt32X51ptngpmtKvE9QxA10XGko">Huly&reg;: <b>V_0.6-21736</b></a></sub>