### PR TITLE
Verbiage: Fix Verbiage Context in Hello World

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -262,7 +262,7 @@ As in many other languages (such as C, Go, and Rust), `main` is the entry point 
 [`println`](#println) is one of the few [built-in functions](#builtin-functions).
 It prints the value passed to it to standard output.
 
-`fn main()` declaration can be skipped in one file programs.
+`fn main()` declaration can be skipped in single file programs.
 This is useful when writing small programs, "scripts", or just learning the language.
 For brevity, `fn main()` will be skipped in this tutorial.
 


### PR DESCRIPTION
Fixing verbiage removing potential confusion of statement context in the Hello World section of documentation.

Documentation uses `one file programs`, which can cause confusion and cause the user to think it can only be utilized in one file/program.

Changing to `single file programs` to prevent any confusion when it is being read.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcxYmQ5Y2YxNDRmNTg1YWU1MTUxZjciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.kauIFzq3xVHuAGsbCjYi8G61hzxGbs_hftBzGkLXDT8">Huly&reg;: <b>V_0.6-21742</b></a></sub>