### PR TITLE
checker: make `byte(0)` an error; use `u8(0)` (fix #23236)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -870,7 +870,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 			c.error('cannot assign anonymous `struct` to a typed `struct`', right.pos())
 		}
 		if right_sym.kind == .alias && right_sym.name == 'byte' {
-			c.warn('byte is deprecated, use u8 instead', right.pos())
+			c.error('byte is deprecated, use u8 instead', right.pos())
 		}
 	}
 	// this needs to run after the assign stmt left exprs have been run through checker

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -36,7 +36,7 @@ pub const fixed_array_builtin_methods = ['contains', 'index', 'any', 'all', 'wai
 	'sorted', 'sort_with_compare', 'sorted_with_compare', 'reverse', 'reverse_in_place', 'count']
 pub const fixed_array_builtin_methods_chk = token.new_keywords_matcher_from_array_trie(fixed_array_builtin_methods)
 // TODO: remove `byte` from this list when it is no longer supported
-pub const reserved_type_names = ['byte', 'bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8', 'u16',
+pub const reserved_type_names = ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8', 'u16',
 	'u32', 'u64', 'f32', 'f64', 'map', 'string', 'rune', 'usize', 'isize', 'voidptr', 'thread']
 pub const reserved_type_names_chk = token.new_keywords_matcher_from_array_trie(reserved_type_names)
 pub const vroot_is_deprecated_message = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -36,8 +36,8 @@ pub const fixed_array_builtin_methods = ['contains', 'index', 'any', 'all', 'wai
 	'sorted', 'sort_with_compare', 'sorted_with_compare', 'reverse', 'reverse_in_place', 'count']
 pub const fixed_array_builtin_methods_chk = token.new_keywords_matcher_from_array_trie(fixed_array_builtin_methods)
 // TODO: remove `byte` from this list when it is no longer supported
-pub const reserved_type_names = ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8', 'u16',
-	'u32', 'u64', 'f32', 'f64', 'map', 'string', 'rune', 'usize', 'isize', 'voidptr', 'thread']
+pub const reserved_type_names = ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'u8', 'u16', 'u32',
+	'u64', 'f32', 'f64', 'map', 'string', 'rune', 'usize', 'isize', 'voidptr', 'thread']
 pub const reserved_type_names_chk = token.new_keywords_matcher_from_array_trie(reserved_type_names)
 pub const vroot_is_deprecated_message = '@VROOT is deprecated, use @VMODROOT or @VEXEROOT instead'
 

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -61,7 +61,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				}
 				ast.Alias {
 					if elem_sym.name == 'byte' {
-						c.warn('byte is deprecated, use u8 instead', node.elem_type_pos)
+						c.error('byte is deprecated, use u8 instead', node.elem_type_pos)
 					}
 				}
 				ast.Map {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -167,7 +167,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					parent_sym.info.size_expr, true)
 			}
 			if return_sym.name == 'byte' {
-				c.warn('byte is deprecated, use u8 instead', node.return_type_pos)
+				c.error('byte is deprecated, use u8 instead', node.return_type_pos)
 			}
 		}
 		if return_sym.info is ast.ArrayFixed && c.array_fixed_has_unresolved_size(return_sym.info) {
@@ -337,7 +337,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('duplicate of an import symbol `${param.name}`', param.pos)
 			}
 			if arg_typ_sym.kind == .alias && arg_typ_sym.name == 'byte' {
-				c.warn('byte is deprecated, use u8 instead', param.type_pos)
+				c.error('byte is deprecated, use u8 instead', param.type_pos)
 			}
 		}
 		if !node.is_method {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -220,7 +220,7 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 				}
 				.alias {
 					if sym.name == 'byte' {
-						c.warn('byte is deprecated, use u8 instead', field.type_pos)
+						c.error('byte is deprecated, use u8 instead', field.type_pos)
 					}
 				}
 				else {

--- a/vlib/v/checker/tests/dump_char.out
+++ b/vlib/v/checker/tests/dump_char.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/dump_char.vv:3:6: error: `char` values cannot be dumped directly, use dump(u8(x)) or dump(int(x)) instead
     1 | c := char(67)
-    2 | dump(byte(c))
+    2 | dump(u8(c))
     3 | dump(c)
       |      ^

--- a/vlib/v/checker/tests/dump_char.vv
+++ b/vlib/v/checker/tests/dump_char.vv
@@ -1,3 +1,3 @@
 c := char(67)
-dump(byte(c))
+dump(u8(c))
 dump(c)

--- a/vlib/v/checker/tests/struct_type_cast_err.out
+++ b/vlib/v/checker/tests/struct_type_cast_err.out
@@ -1,10 +1,3 @@
-vlib/v/checker/tests/struct_type_cast_err.vv:10:7: warning: byte is deprecated, use u8 instead
-    8 |     _ := u32(foo)
-    9 |     _ := rune(foo)
-   10 |     _ := byte(foo)
-      |          ~~~~~~~~~
-   11 |     _ := i8(foo)
-   12 |     _ := i64(foo)
 vlib/v/checker/tests/struct_type_cast_err.vv:5:7: error: cannot cast struct `Foo` to `string`
     3 | fn main() {
     4 |     foo := Foo{}
@@ -32,30 +25,30 @@ vlib/v/checker/tests/struct_type_cast_err.vv:8:7: error: cannot cast struct `Foo
     8 |     _ := u32(foo)
       |          ~~~~~~~~
     9 |     _ := rune(foo)
-   10 |     _ := byte(foo)
+   10 |     _ := u8(foo)
 vlib/v/checker/tests/struct_type_cast_err.vv:9:7: error: cannot cast struct `Foo` to `rune`
     7 |     _ := u64(foo)
     8 |     _ := u32(foo)
     9 |     _ := rune(foo)
       |          ~~~~~~~~~
-   10 |     _ := byte(foo)
+   10 |     _ := u8(foo)
    11 |     _ := i8(foo)
-vlib/v/checker/tests/struct_type_cast_err.vv:10:7: error: cannot cast `Foo` to `byte` (alias to `u8`)
+vlib/v/checker/tests/struct_type_cast_err.vv:10:7: error: cannot cast struct `Foo` to `u8`
     8 |     _ := u32(foo)
     9 |     _ := rune(foo)
-   10 |     _ := byte(foo)
-      |          ~~~~~~~~~
+   10 |     _ := u8(foo)
+      |          ~~~~~~~
    11 |     _ := i8(foo)
    12 |     _ := i64(foo)
 vlib/v/checker/tests/struct_type_cast_err.vv:11:7: error: cannot cast struct `Foo` to `i8`
     9 |     _ := rune(foo)
-   10 |     _ := byte(foo)
+   10 |     _ := u8(foo)
    11 |     _ := i8(foo)
       |          ~~~~~~~
    12 |     _ := i64(foo)
    13 |     _ := int(foo)
 vlib/v/checker/tests/struct_type_cast_err.vv:12:7: error: cannot cast struct `Foo` to `i64`
-   10 |     _ := byte(foo)
+   10 |     _ := u8(foo)
    11 |     _ := i8(foo)
    12 |     _ := i64(foo)
       |          ~~~~~~~~

--- a/vlib/v/checker/tests/struct_type_cast_err.vv
+++ b/vlib/v/checker/tests/struct_type_cast_err.vv
@@ -7,7 +7,7 @@ fn main() {
 	_ := u64(foo)
 	_ := u32(foo)
 	_ := rune(foo)
-	_ := byte(foo)
+	_ := u8(foo)
 	_ := i8(foo)
 	_ := i64(foo)
 	_ := int(foo)

--- a/vlib/v/checker/tests/top_level_fn_builtin_decl_err.out
+++ b/vlib/v/checker/tests/top_level_fn_builtin_decl_err.out
@@ -1,59 +1,53 @@
-vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:2:12: warning: byte is deprecated, use u8 instead
-    1 | @[inline]
-    2 | fn char(ch byte) fn (string) !(byte, string) {
-      |            ~~~~
-    3 |     return fn [ch] (input string) !(byte, string) {
-    4 |         return if input[0] == ch {
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:2:1: error: top level declaration cannot shadow builtin type
     1 | @[inline]
-    2 | fn char(ch byte) fn (string) !(byte, string) {
-      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    3 |     return fn [ch] (input string) !(byte, string) {
+    2 | fn char(ch u8) fn (string) !(u8, string) {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3 |     return fn [ch] (input string) !(u8, string) {
     4 |         return if input[0] == ch {
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:18:18: error: unknown function: a_char
-   16 | 
+   16 |
    17 |     for i, input in inputs {
    18 |         got, remain := a_char(input)!
       |                        ~~~~~~~~~~~~~
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:18:31: error: unexpected `!`, the function `a_char` does not return a Result
-   16 | 
+   16 |
    17 |     for i, input in inputs {
    18 |         got, remain := a_char(input)!
       |                                     ^
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:18:15: error: assignment mismatch: 2 variables but `a_char()` returns 0 values
-   16 | 
+   16 |
    17 |     for i, input in inputs {
    18 |         got, remain := a_char(input)!
       |                     ~~
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:20:10: error: invalid variable `got`
    18 |         got, remain := a_char(input)!
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
       |                ~~~
    21 |         assert remain == remains[i]
    22 |     }
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:20:10: error: assert can be used only with `bool` expressions, but found `void` instead
    18 |         got, remain := a_char(input)!
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
       |                ~~~~~~~~~~~~~
    21 |         assert remain == remains[i]
    22 |     }
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:21:10: error: invalid variable `remain`
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
    21 |         assert remain == remains[i]
       |                ~~~~~~
    22 |     }
    23 | }
 vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv:21:10: error: assert can be used only with `bool` expressions, but found `void` instead
-   19 | 
+   19 |
    20 |         assert got == 'a'[0]
    21 |         assert remain == remains[i]
       |                ~~~~~~~~~~~~~~~~~~~~

--- a/vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv
+++ b/vlib/v/checker/tests/top_level_fn_builtin_decl_err.vv
@@ -1,6 +1,6 @@
 @[inline]
-fn char(ch byte) fn (string) !(byte, string) {
-	return fn [ch] (input string) !(byte, string) {
+fn char(ch u8) fn (string) !(u8, string) {
+	return fn [ch] (input string) !(u8, string) {
 		return if input[0] == ch {
 			ch, input[1..]
 		} else {

--- a/vlib/v/checker/tests/use_byte_instead_of_u8_err.out
+++ b/vlib/v/checker/tests/use_byte_instead_of_u8_err.out
@@ -1,0 +1,25 @@
+vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:1:13: error: type `byte` is an alias, use the original alias type `u8` instead
+    1 | type Byte = byte
+      |             ~~~~
+    2 |
+    3 | fn foo(_ byte) {}
+vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:3:10: error: byte is deprecated, use u8 instead
+    1 | type Byte = byte
+    2 |
+    3 | fn foo(_ byte) {}
+      |          ~~~~
+    4 |
+    5 | fn main() {
+vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:6:7: error: byte is deprecated, use u8 instead
+    4 |
+    5 | fn main() {
+    6 |     _ := byte(0)
+      |          ~~~~~~~
+    7 |     _ := fn(_ byte) {}
+    8 | }
+vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:7:12: error: byte is deprecated, use u8 instead
+    5 | fn main() {
+    6 |     _ := byte(0)
+    7 |     _ := fn(_ byte) {}
+      |               ~~~~
+    8 | }

--- a/vlib/v/checker/tests/use_byte_instead_of_u8_err.vv
+++ b/vlib/v/checker/tests/use_byte_instead_of_u8_err.vv
@@ -1,0 +1,8 @@
+type Byte = byte
+
+fn foo(_ byte) {}
+
+fn main() {
+	_ := byte(0)
+	_ := fn(_ byte) {}
+}

--- a/vlib/v/fmt/tests/import_selective_keep.vv
+++ b/vlib/v/fmt/tests/import_selective_keep.vv
@@ -11,6 +11,6 @@ fn generic[T]() {}
 
 fn main() {
 	_ := Duration(10) // keep cast type
-	assert *(&f64(&byte(&num) + __offsetof(Complex, re))) == 1.0
+	assert *(&f64(&u8(&num) + __offsetof(Complex, re))) == 1.0
 	generic[Test]()
 }

--- a/vlib/v/fmt/tests/pointer_casts_keep.vv
+++ b/vlib/v/fmt/tests/pointer_casts_keep.vv
@@ -5,10 +5,10 @@ struct Struct {
 
 fn main() {
 	unsafe {
-		pb := &byte(0)
-		ppb := &&byte(0)
-		pppb := &&&byte(0)
-		ppppb := &&&&byte(0)
+		pb := &u8(0)
+		ppb := &&u8(0)
+		pppb := &&&u8(0)
+		ppppb := &&&&u8(0)
 		dump(voidptr(pb))
 		dump(voidptr(ppb))
 		dump(voidptr(pppb))


### PR DESCRIPTION
This PR fix cannot use "byte" as const name (#23236)

- Remove `byte` from reserved keywords.
- Make use of `byte` error. Use `u8` instead.
- Add checker test.

use_byte_insead_of_u8_err.vv:

```v
type Byte = byte

fn foo(_ byte) {}

fn main() {
    _ := byte(0)
    _ := fn(_ byte) {}
}
```

use_byte_insead_of_u8_err.out:

```
vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:1:13: error: type `byte` is an alias, use the original alias type `u8` instead
    1 | type Byte = byte
      |             ~~~~
    2 |
    3 | fn foo(_ byte) {}
vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:3:10: error: byte is deprecated, use u8 instead
    1 | type Byte = byte
    2 |
    3 | fn foo(_ byte) {}
      |          ~~~~
    4 |
    5 | fn main() {
vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:6:7: error: byte is deprecated, use u8 instead
    4 |
    5 | fn main() {
    6 |     _ := byte(0)
      |          ~~~~~~~
    7 |     _ := fn(_ byte) {}
    8 | }
vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:7:12: error: byte is deprecated, use u8 instead
    5 | fn main() {
    6 |     _ := byte(0)
    7 |     _ := fn(_ byte) {}
      |               ~~~~
    8 | }
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcxZGI4N2YxNDRmNTg1YWU1MTU0NzMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.m3TawTltGE6hhy6HiSlczeAdt8k3dRBLIwxMJj01Q8U">Huly&reg;: <b>V_0.6-21743</b></a></sub>