### PR TITLE
checker: check shared variables types (fix #23313)

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -217,6 +217,10 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		} else if right is ast.ComptimeSelector {
 			right_type = c.comptime.comptime_for_field_type
 		}
+		if is_decl && left is ast.Ident && left.info is ast.IdentVar
+			&& (left.info as ast.IdentVar).share == .shared_t && c.table.sym(right_type).kind !in [.array, .map, .struct] {
+			c.fatal('shared variables must be structs, arrays or maps', right.pos())
+		}
 		if is_decl || is_shared_re_assign {
 			// check generic struct init and return unwrap generic struct type
 			if mut right is ast.StructInit {

--- a/vlib/v/checker/tests/globals/assign_global_to_shared_err.out
+++ b/vlib/v/checker/tests/globals/assign_global_to_shared_err.out
@@ -10,3 +10,9 @@ vlib/v/checker/tests/globals/assign_global_to_shared_err.vv:5:14: error: cannot 
     5 |     shared b := a
       |                 ^
     6 | }
+vlib/v/checker/tests/globals/assign_global_to_shared_err.vv:5:14: error: cannot copy map: call `move` or `clone` method (or use a reference)
+    3 | 
+    4 | fn main() {
+    5 |     shared b := a
+      |                 ^
+    6 | }

--- a/vlib/v/checker/tests/globals/assign_global_to_shared_err.vv
+++ b/vlib/v/checker/tests/globals/assign_global_to_shared_err.vv
@@ -1,5 +1,5 @@
 @[has_globals]
-__global a = 0
+__global a = {1: 'one', 2: 'two'}
 
 fn main() {
 	shared b := a

--- a/vlib/v/checker/tests/shared_variables_type_err.out
+++ b/vlib/v/checker/tests/shared_variables_type_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/shared_variables_type_err.vv:7:16: error: shared variables must be structs, arrays or maps
+    5 | 
+    6 | fn main() {
+    7 |     shared foo := Foo.one
+      |                   ~~~~~~~
+    8 |     rlock foo {
+    9 |         match foo {

--- a/vlib/v/checker/tests/shared_variables_type_err.vv
+++ b/vlib/v/checker/tests/shared_variables_type_err.vv
@@ -1,0 +1,14 @@
+enum Foo {
+	zero
+	one
+}
+
+fn main() {
+	shared foo := Foo.one
+	rlock foo {
+		match foo {
+			.zero { println('0000') }
+			.one { println('1111') }
+		}
+	}
+}


### PR DESCRIPTION
This PR check shared variables types (fix #23313, fix #23314)

- Check shared variables types.
- Add test.

```v
enum Foo {
	zero
	one
}

fn main() {
	shared foo := Foo.one
	rlock foo {
		match foo {
			.zero { println('0000') }
			.one { println('1111') }
		}
	}
}

PS D:\Test\v\tt1> v run .
tt1.v:7:16: error: shared variables must be structs, arrays or maps
    5 | 
    6 | fn main() {
    7 |     shared foo := Foo.one
      |                   ~~~~~~~
    8 |     rlock foo {
    9 |         match foo {
```