### PR TITLE
json: support `@[json_null]` tag to enforce `null`, when encoding `none` option values

### DIFF
--- a/vlib/json/tests/json_is_null_attr_test.v
+++ b/vlib/json/tests/json_is_null_attr_test.v
@@ -1,0 +1,26 @@
+import json
+
+struct Bar {
+	name ?string @[json_null]
+}
+
+struct Foo {
+	name   ?string @[json_null]
+	age    ?int    @[json_null]
+	text   ?string
+	other  ?Bar
+	other2 ?Bar @[json_null]
+}
+
+fn test_main() {
+	assert json.encode(Foo{}) == '{"name":null,"age":null,"other2":null}'
+	assert json.encode(Foo{ name: '' }) == '{"name":"","age":null,"other2":null}'
+	assert json.encode(Foo{ age: 10 }) == '{"name":null,"age":10,"other2":null}'
+	assert json.encode(Foo{
+		age:    10
+		other2: Bar{
+			name: none
+		}
+	}) == '{"name":null,"age":10,"other2":{"name":null}}'
+	assert json.decode(Foo, json.encode(Foo{}))! == Foo{}
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -337,7 +337,7 @@ fn (mut g Gen) gen_prim_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec s
 @[inline]
 fn (mut g Gen) gen_option_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec strings.Builder) {
 	enc.writeln('\tif (val.state == 2) {')
-	enc.writeln('\t\treturn cJSON_CreateNull();')
+	enc.writeln('\t\treturn NULL;')
 	enc.writeln('\t}')
 	type_str := g.styp(typ.clear_flag(.option))
 	encode_name := js_enc_name(type_str)


### PR DESCRIPTION
Implementing feature request.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcyYmM3NmYxNDRmNTg1YWU1MTZmMmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.IuqTMFe-F_ZEWbZgfl9dlS5Z2iuZ5myuO48HUP_kkqA">Huly&reg;: <b>V_0.6-21751</b></a></sub>