### PR TITLE
cgen: fix type_default for option type when the default expr is `none`

### DIFF
--- a/vlib/json/tests/json_encode_default_option_none_test.v
+++ b/vlib/json/tests/json_encode_default_option_none_test.v
@@ -1,0 +1,11 @@
+module main
+
+import json
+
+struct Test {
+	id ?string = none
+}
+
+fn test_main() {
+	assert json.encode(Test{}) == '{}'
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1236,6 +1236,14 @@ fn (mut g Gen) expr_string(expr ast.Expr) string {
 	return g.out.cut_to(pos).trim_space()
 }
 
+fn (mut g Gen) expr_string_opt(typ ast.Type, expr ast.Expr) string {
+	expr_str := g.expr_string(expr)
+	if expr is ast.None {
+		return '(${g.styp(typ)}){.state=2, .err=${expr_str}, .data={EMPTY_STRUCT_INITIALIZATION}}'
+	}
+	return expr_str
+}
+
 fn (mut g Gen) expr_string_with_cast(expr ast.Expr, typ ast.Type, exp ast.Type) string {
 	pos := g.out.len
 	// pos2 := 	g.out_parallel[g.out_idx].len
@@ -7034,7 +7042,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 									}
 								}
 							} else {
-								default_str := g.expr_string(field.default_expr)
+								default_str := g.expr_string_opt(field.typ, field.default_expr)
 								if default_str.count('\n') > 1 {
 									g.type_default_vars.writeln(default_str.all_before_last('\n'))
 									expr_str = default_str.all_after_last('\n')

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -721,7 +721,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${dec_name}(jsonroot_${tmp});')
 				if field.has_default_expr {
 					dec.writeln('\t} else {')
-					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string(field.default_expr)};')
+					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string_opt(field.typ,
+						field.default_expr)};')
 				}
 				dec.writeln('\t}')
 			} else if field_sym.kind == .enum {
@@ -755,7 +756,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				}
 				if field.has_default_expr {
 					dec.writeln('\t} else {')
-					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string(field.default_expr)};')
+					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string_opt(field.typ,
+						field.default_expr)};')
 				}
 				dec.writeln('\t}')
 			} else if field_sym.name == 'time.Time' {
@@ -767,7 +769,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = time__unix(json__decode_u64(jsonroot_${tmp}));')
 				if field.has_default_expr {
 					dec.writeln('\t} else {')
-					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string(field.default_expr)};')
+					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string_opt(field.typ,
+						field.default_expr)};')
 				}
 				dec.writeln('\t}')
 			} else if field_sym.kind == .alias {
@@ -788,7 +791,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${parent_dec_name} (jsonroot_${tmp});')
 					if field.has_default_expr {
 						dec.writeln('\t} else {')
-						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string(field.default_expr)};')
+						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string_opt(field.typ,
+							field.default_expr)};')
 					}
 					dec.writeln('\t}')
 				} else {
@@ -799,7 +803,8 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = *(${field_type}*) ${tmp}.data;')
 					if field.has_default_expr {
 						dec.writeln('\t} else {')
-						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string(field.default_expr)};')
+						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${g.expr_string_opt(field.typ,
+							field.default_expr)};')
 					}
 					dec.writeln('\t}')
 				}
@@ -838,7 +843,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				}
 				if field.has_default_expr {
 					dec.writeln('\t} else {')
-					default_str := g.expr_string(field.default_expr)
+					default_str := g.expr_string_opt(field.typ, field.default_expr)
 					lines := default_str.count('\n')
 					if lines > 1 {
 						dec.writeln(default_str.all_before_last('\n'))


### PR DESCRIPTION
Fix #23318

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcyZDcyMWYxNDRmNTg1YWU1MTcxY2YiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.Sjgbkgei8ZEgXo03zz2Onn1IojO5CJVK_5CJjmtiMY8">Huly&reg;: <b>V_0.6-21752</b></a></sub>