### PR TITLE
checker: fix generic var inferring to be passed to `[]T`

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1992,7 +1992,12 @@ fn (mut c Checker) resolve_comptime_args(func &ast.Fn, node_ ast.CallExpr, concr
 							}
 						}
 					} else if call_arg.expr.obj.ct_type_var == .generic_var {
-						mut ctyp := c.type_resolver.get_type(call_arg.expr)
+						mut ctyp := c.unwrap_generic(c.type_resolver.get_type(call_arg.expr))
+						cparam_type_sym := c.table.sym(c.unwrap_generic(ctyp))
+						param_typ_sym := c.table.sym(param_typ)
+						if param_typ_sym.kind == .array && cparam_type_sym.info is ast.Array {
+							ctyp = cparam_type_sym.info.elem_type
+						}
 						if node_.args[i].expr.is_auto_deref_var() {
 							ctyp = ctyp.deref()
 						}

--- a/vlib/v/tests/generics/generic_fn_array_infer_var_test.v
+++ b/vlib/v/tests/generics/generic_fn_array_infer_var_test.v
@@ -1,0 +1,18 @@
+fn function_that_receives_an_array_of_generic_type[T](array []T) {
+	return
+}
+
+fn function_that_returns_an_array_of_generic_type[T]() []T {
+	return []
+}
+
+fn func[T]() {
+	res := function_that_returns_an_array_of_generic_type[T]()
+	function_that_receives_an_array_of_generic_type(res)
+	function_that_receives_an_array_of_generic_type[T](res)
+	return
+}
+
+fn test_main() {
+	func[string]()
+}

--- a/vlib/v/tests/generics/generic_fn_array_infer_var_test.v
+++ b/vlib/v/tests/generics/generic_fn_array_infer_var_test.v
@@ -1,5 +1,5 @@
 fn function_that_receives_an_array_of_generic_type[T](array []T) {
-	return
+	assert array.len == 0
 }
 
 fn function_that_returns_an_array_of_generic_type[T]() []T {
@@ -9,10 +9,12 @@ fn function_that_returns_an_array_of_generic_type[T]() []T {
 fn func[T]() {
 	res := function_that_returns_an_array_of_generic_type[T]()
 	function_that_receives_an_array_of_generic_type(res)
+	assert res.len == 0
 	function_that_receives_an_array_of_generic_type[T](res)
-	return
 }
 
 fn test_main() {
 	func[string]()
+	func[int]()
+	func[f64]()
 }


### PR DESCRIPTION
Fix #23315

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcyZWMzM2YxNDRmNTg1YWU1MThhMDMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.8bawvd-akhDZT87qOeY05vifQTENOkJXfAb0pR4zdCw">Huly&reg;: <b>V_0.6-21754</b></a></sub>