### PR TITLE
ast: reduce allocations in empty_comptime_const_expr

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -205,6 +205,7 @@ pub:
 pub const empty_expr = Expr(EmptyExpr(0))
 pub const empty_stmt = Stmt(EmptyStmt{})
 pub const empty_node = Node(EmptyNode{})
+pub const empty_comptime_const_value = ComptTimeConstValue(EmptyExpr(0))
 
 // `{stmts}` or `unsafe {stmts}`
 pub struct Block {
@@ -398,7 +399,7 @@ pub mut:
 	end_comments []Comment // comments that after const field
 	// the comptime_expr_value field is filled by the checker, when it has enough
 	// info to evaluate the constant at compile time
-	comptime_expr_value ComptTimeConstValue = empty_comptime_const_expr()
+	comptime_expr_value ComptTimeConstValue = empty_comptime_const_value
 }
 
 // const declaration
@@ -1132,9 +1133,9 @@ pub mut:
 	or_block      OrExpr
 
 	ct_left_value_evaled  bool
-	ct_left_value         ComptTimeConstValue = empty_comptime_const_expr()
+	ct_left_value         ComptTimeConstValue = empty_comptime_const_value
 	ct_right_value_evaled bool
-	ct_right_value        ComptTimeConstValue = empty_comptime_const_expr()
+	ct_right_value        ComptTimeConstValue = empty_comptime_const_value
 
 	before_op_comments []Comment
 	after_op_comments  []Comment

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -17,9 +17,11 @@ pub type ComptTimeConstValue = EmptyExpr
 
 //| int
 
+const ectcv = ComptTimeConstValue(EmptyExpr(0))
+
 // empty_comptime_const_expr return an EmptyExpr.
 pub fn empty_comptime_const_expr() ComptTimeConstValue {
-	return EmptyExpr(0)
+	return ectcv
 }
 
 // i8 tries to return a `ComptTimeConstValue` as `i8` type.

--- a/vlib/v/ast/comptime_const_values.v
+++ b/vlib/v/ast/comptime_const_values.v
@@ -17,13 +17,6 @@ pub type ComptTimeConstValue = EmptyExpr
 
 //| int
 
-const ectcv = ComptTimeConstValue(EmptyExpr(0))
-
-// empty_comptime_const_expr return an EmptyExpr.
-pub fn empty_comptime_const_expr() ComptTimeConstValue {
-	return ectcv
-}
-
 // i8 tries to return a `ComptTimeConstValue` as `i8` type.
 pub fn (val ComptTimeConstValue) i8() ?i8 {
 	x := val.i64()?


### PR DESCRIPTION
Improve compiler performance a bit, by reducing the amount of small allocations, for creating `ComptTimeConstValue(EmptyExpr(0))` for the default field values of the AST nodes.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzczMGUxYWYxNDRmNTg1YWU1MTk5NTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.XXeFx25-_bL8OcieiJ5Hdx-d_-zUfQcgGHhCiLoTLgE">Huly&reg;: <b>V_0.6-21756</b></a></sub>