### PR TITLE
checker: cleanup infix - reduce `as` casting

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -538,8 +538,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			}
 			if left_sym.kind in [.array, .array_fixed] && right_sym.kind in [.array, .array_fixed] {
 				c.error('only `==` and `!=` are defined on arrays', node.pos)
-			} else if left_sym.kind == .struct
-				&& (left_sym.info as ast.Struct).generic_types.len > 0 {
+			} else if left_sym.info is ast.Struct && left_sym.info.generic_types.len > 0 {
 				node.promoted_type = ast.bool_type
 				return ast.bool_type
 			} else if left_sym.kind == .struct && right_sym.kind == .struct && node.op in [.eq, .lt] {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -876,10 +876,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		// TODO: broken !in
 		c.error('string types only have the following operators defined: `==`, `!=`, `<`, `>`, `<=`, `>=`, and `+`',
 			node.pos)
-	} else if left_sym.kind == .enum && right_sym.kind == .enum && !eq_ne {
-		left_enum := left_sym.info as ast.Enum
-		right_enum := right_sym.info as ast.Enum
-		if left_enum.is_flag && right_enum.is_flag {
+	} else if !eq_ne && mut left_sym.info is ast.Enum && mut right_sym.info is ast.Enum {
+		if left_sym.info.is_flag && right_sym.info.is_flag {
 			// `@[flag]` tagged enums are a special case that allow also `|` and `&` binary operators
 			if node.op !in [.pipe, .amp, .xor, .bit_not] {
 				c.error('only `==`, `!=`, `|`, `&`, `^` and `~` are defined on `@[flag]` tagged `enum`, use an explicit cast to `int` if needed',
@@ -894,9 +892,9 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	}
 	// sum types can't have any infix operation except of `is`, `eq`, `ne`.
 	// `is` is checked before and doesn't reach this.
-	if c.table.type_kind(left_type) == .sum_type && !eq_ne {
+	if left_sym.kind == .sum_type && !eq_ne {
 		c.error('cannot use operator `${node.op}` with `${left_sym.name}`', node.pos)
-	} else if c.table.type_kind(right_type) == .sum_type && !eq_ne {
+	} else if right_sym.kind == .sum_type && !eq_ne {
 		c.error('cannot use operator `${node.op}` with `${right_sym.name}`', node.pos)
 	}
 	// TODO: move this to symmetric_check? Right now it would break `return 0` for `fn()?int `

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -892,9 +892,9 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	}
 	// sum types can't have any infix operation except of `is`, `eq`, `ne`.
 	// `is` is checked before and doesn't reach this.
-	if left_sym.kind == .sum_type && !eq_ne {
+	if c.table.type_kind(left_type) == .sum_type && !eq_ne {
 		c.error('cannot use operator `${node.op}` with `${left_sym.name}`', node.pos)
-	} else if right_sym.kind == .sum_type && !eq_ne {
+	} else if c.table.type_kind(right_type) == .sum_type && !eq_ne {
 		c.error('cannot use operator `${node.op}` with `${right_sym.name}`', node.pos)
 	}
 	// TODO: move this to symmetric_check? Right now it would break `return 0` for `fn()?int `


### PR DESCRIPTION
Minor optimize

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc0NzYwMGYxNDRmNTg1YWU1MWNmYjMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.8qCdec9Tx6kDxwYOmXZgzUZ-vPPZjq4wgG-lNGYnPvQ">Huly&reg;: <b>V_0.6-21758</b></a></sub>