### PR TITLE
checker: fix structinit validation on nested generic Map[K]V

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1509,7 +1509,8 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 		if call_arg.expr is ast.MapInit && e_sym.kind == .struct {
 			c.error('cannot initialize a struct with a map', call_arg.pos)
 			continue
-		} else if call_arg.expr is ast.StructInit && e_sym.kind == .map {
+		} else if call_arg.expr is ast.StructInit && e_sym.kind == .map
+			&& !call_arg.expr.typ.has_flag(.generic) {
 			c.error('cannot initialize a map with a struct', call_arg.pos)
 			continue
 		}

--- a/vlib/x/json2/tests/decode_map_of_map_test.v
+++ b/vlib/x/json2/tests/decode_map_of_map_test.v
@@ -1,0 +1,13 @@
+import x.json2
+
+struct CrossVerifyResult {
+	confusion_matrix_map map[string]map[string]f64
+}
+
+fn test_main() {
+	x := json2.decode[CrossVerifyResult]('') or {
+		assert err.msg().contains('invalid token')
+		return
+	}
+	assert false
+}


### PR DESCRIPTION
Fix #23329

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc1MzVlZmYxNDRmNTg1YWU1MjAxMmUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.nRewa03mH6iz6opilCyJs-7i5ZYQ6-VsxSrzHGrHVK0">Huly&reg;: <b>V_0.6-21763</b></a></sub>