### PR TITLE
cgen: fix type_default for array init >= 8 items

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7043,8 +7043,8 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 								}
 							} else {
 								default_str := g.expr_string_opt(field.typ, field.default_expr)
-								if field.default_expr !is ast.ArrayInit
-									&& default_str.count('\n') > 1 {
+								if !(field.default_expr is ast.ArrayInit
+									&& field.default_expr.has_init) && default_str.count(';\n') > 1 {
 									g.type_default_vars.writeln(default_str.all_before_last('\n'))
 									expr_str = default_str.all_after_last('\n')
 								} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7043,8 +7043,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 								}
 							} else {
 								default_str := g.expr_string_opt(field.typ, field.default_expr)
-								if !(field.default_expr is ast.ArrayInit
-									&& field.default_expr.has_init) && default_str.count(';\n') > 1 {
+								if default_str.count(';\n') > 1 {
 									g.type_default_vars.writeln(default_str.all_before_last('\n'))
 									expr_str = default_str.all_after_last('\n')
 								} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7043,7 +7043,8 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 								}
 							} else {
 								default_str := g.expr_string_opt(field.typ, field.default_expr)
-								if default_str.count('\n') > 1 {
+								if field.default_expr !is ast.ArrayInit
+									&& default_str.count('\n') > 1 {
 									g.type_default_vars.writeln(default_str.all_before_last('\n'))
 									expr_str = default_str.all_after_last('\n')
 								} else {

--- a/vlib/v/tests/structs/default_expr_array_init_test.v
+++ b/vlib/v/tests/structs/default_expr_array_init_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+pub mut:
+	integer_range_for_discrete []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+}
+
+fn foo(a string) Foo {
+	return match a {
+		'a' { Foo{} }
+		else { panic('foo') }
+	}
+}
+
+fn test_main() {
+	assert foo('a') == Foo{}
+}


### PR DESCRIPTION
Spoted when building vhamll project.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc1NTYwN2YxNDRmNTg1YWU1MjAzOTkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.6YuDFqgB89hMFKCeg_J1Ns27KEFhwBI9rf5T0bPOPjQ">Huly&reg;: <b>V_0.6-21765</b></a></sub>