### PR TITLE
tools: allow passing more V compiler arguments to `v bug file.v`

### DIFF
--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -84,6 +84,9 @@ fn main() {
 	is_yes := '-y' in os.args
 
 	for arg in os.args[1..] {
+		if arg == 'bug' {
+			continue
+		}
 		if arg.ends_with('.v') || arg.ends_with('.vsh') || arg.ends_with('.vv') {
 			if file_path != '' {
 				eprintln('v bug: only one V file can be submitted')

--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -24,8 +24,7 @@ fn get_v_build_output(is_verbose bool, is_yes bool, file_path string, compiler_a
 	os.chdir(vroot) or {}
 	verbose_flag := if is_verbose { '-v' } else { '' }
 	vdbg_path := $if windows { '${vroot}/vdbg.exe' } $else { '${vroot}/vdbg' }
-	vdbg_v_args := compiler_args.join(' ')
-	vdbg_compilation_cmd := '${os.quoted_path(vexe)} ${verbose_flag} -g ${vdbg_v_args} -o ${os.quoted_path(vdbg_path)} cmd/v'
+	vdbg_compilation_cmd := '${os.quoted_path(vexe)} ${verbose_flag} -g -o ${os.quoted_path(vdbg_path)} cmd/v'
 	vdbg_result := os.execute(vdbg_compilation_cmd)
 	os.chdir(wd) or {}
 	if vdbg_result.exit_code == 0 {
@@ -34,7 +33,8 @@ fn get_v_build_output(is_verbose bool, is_yes bool, file_path string, compiler_a
 		eprintln('unable to compile V in debug mode: ${vdbg_result.output}\ncommand: ${vdbg_compilation_cmd}\n')
 	}
 
-	mut result := os.execute('${os.quoted_path(vexe)} ${verbose_flag} ${os.quoted_path(file_path)}')
+	user_args := compiler_args.join(' ')
+	mut result := os.execute('${os.quoted_path(vexe)} ${verbose_flag} ${user_args} ${os.quoted_path(file_path)}')
 	defer {
 		os.rm(vdbg_path) or {
 			if is_verbose {

--- a/cmd/tools/vbug.v
+++ b/cmd/tools/vbug.v
@@ -16,14 +16,6 @@ fn get_vdoctor_output(is_verbose bool) string {
 	return result.output
 }
 
-fn compiler_flag_to_single_str(args []string) string {
-	mut str := ''
-	for arg in args {
-		str = str + arg + ' '
-	}
-	return str
-}
-
 // get output from `./v -g -compiler_args -o vdbg cmd/v && ./vdbg file.v`
 fn get_v_build_output(is_verbose bool, is_yes bool, file_path string, compiler_args []string) string {
 	mut vexe := os.getenv('VEXE')
@@ -32,7 +24,7 @@ fn get_v_build_output(is_verbose bool, is_yes bool, file_path string, compiler_a
 	os.chdir(vroot) or {}
 	verbose_flag := if is_verbose { '-v' } else { '' }
 	vdbg_path := $if windows { '${vroot}/vdbg.exe' } $else { '${vroot}/vdbg' }
-	vdbg_v_args := compiler_flag_to_single_str(compiler_args)
+	vdbg_v_args := compiler_args.join(' ')
 	vdbg_compilation_cmd := '${os.quoted_path(vexe)} ${verbose_flag} -g ${vdbg_v_args} -o ${os.quoted_path(vdbg_path)} cmd/v'
 	vdbg_result := os.execute(vdbg_compilation_cmd)
 	os.chdir(wd) or {}


### PR DESCRIPTION
- **Modified code in order to take any additional compiler flags.**
- **Replace compiler_flag_to_single_str function by a call to join(' ') on compiler_args string array.**

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc1NTY0MmYxNDRmNTg1YWU1MjAzYjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.bwwNPtstXO9XTdDXPSFiNZi3ziJpEvEzIg57gb5iUas">Huly&reg;: <b>V_0.6-21766</b></a></sub>