### PR TITLE
v.parser: fix broken link to riscv-card.pdf

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1303,7 +1303,7 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 	}
 
 	mut local_labels := []string{}
-	// riscv: https://github.com/jameslzhu/riscv-card/blob/master/riscv-card.pdf
+	// riscv: https://github.com/jameslzhu/riscv-card/releases/download/latest/riscv-card.pdf
 	// x86: https://www.felixcloutier.com/x86/
 	// arm: https://developer.arm.com/documentation/dui0068/b/arm-instruction-reference
 	mut templates := []ast.AsmTemplate{}


### PR DESCRIPTION
Hi!
Updated the broken link in [parser.v](https://github.com/vlang/v/blob/8a681bae6d1d8f31c0657e016fb54efdecbded22/vlib/v/parser/parser.v#L1306):
https://github.com/jameslzhu/riscv-card/releases/download/latest/riscv-card.pdf

This change aligns with the update made in [commit 6628be3](https://github.com/jameslzhu/riscv-card/commit/6628be3cca53b590896ae7a72a9d9446eee7bfd1).

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc2N2VlZGYxNDRmNTg1YWU1MjI1NmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.c8CO92lI375ga8kdsIXMA7rwNlQx9-UWqvHYWkgjXt4">Huly&reg;: <b>V_0.6-21774</b></a></sub>