### PR TITLE
cgen: fix codegen for alias struct embed

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -197,7 +197,11 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 				embed_sym := g.table.sym(embed)
 				embed_name := embed_sym.embed_name()
 				if embed_name !in inited_fields {
-					embed_info := embed_sym.info as ast.Struct
+					embed_info := if embed_sym.info is ast.Struct {
+						embed_sym.info
+					} else {
+						g.table.final_sym(embed).info as ast.Struct
+					}
 					embed_field_names := embed_info.fields.map(it.name)
 					fields_to_embed := init_fields_to_embed.filter(it.name !in used_embed_fields
 						&& it.name in embed_field_names)

--- a/vlib/v/tests/struct_with_alias_embed_test.v
+++ b/vlib/v/tests/struct_with_alias_embed_test.v
@@ -1,0 +1,13 @@
+struct Foo1 {}
+
+type Foo2 = Foo1
+
+struct Bar {
+	Foo2
+}
+
+fn test_main() {
+	assert Bar{}.str() == 'Bar{
+    Foo2:     Foo2(Foo1{})
+}'
+}


### PR DESCRIPTION
Fix #23347

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc3Y2RjZWYxNDRmNTg1YWU1MjU2NjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lEVKoNoZO1vQm2DWzMA45Y64ucEXefFc74efKyhUAWg">Huly&reg;: <b>V_0.6-21784</b></a></sub>