### PR TITLE
json: fix default struct field initialization with long array

### DIFF
--- a/vlib/json/tests/json_decode_struct_default_test.v
+++ b/vlib/json/tests/json_decode_struct_default_test.v
@@ -1,0 +1,20 @@
+import json
+
+struct Bar {
+	b []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}
+
+struct Foo {
+	Bar
+	a []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}
+
+fn test_main() {
+	str := json.encode(Foo{})
+	assert json.decode(Foo, str)!.str() == 'Foo{
+    Bar: Bar{
+        b: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    }
+    a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}'
+}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -848,8 +848,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				if field.has_default_expr {
 					dec.writeln('\t} else {')
 					default_str := g.expr_string_opt(field.typ, field.default_expr)
-					lines := default_str.count('\n')
-					if lines > 1 {
+					if default_str.count(';\n') > 1 {
 						dec.writeln(default_str.all_before_last('\n'))
 						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${default_str.all_after_last('\n')};')
 					} else {

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -202,8 +202,6 @@ fn decode_struct[T](_ T, res map[string]Any) !T {
 					}
 				} $else $if field.is_array {
 					arr := res[field.name]! as []Any
-					println(arr)
-					println(typ.$(field.name))
 					decode_array_item(mut typ.$(field.name), arr)
 				} $else $if field.is_struct {
 					typ.$(field.name) = decode_struct(typ.$(field.name), res[field.name]!.as_map())!
@@ -237,7 +235,6 @@ fn decode_struct[T](_ T, res map[string]Any) !T {
 }
 
 fn decode_array_item[T](mut field T, arr []Any) {
-	println('item> ${typeof[T]().name}')
 	// vfmt off
 	match typeof[T]().idx {
 		typeof[[]bool]().idx  { field = arr.map(it.bool()) }

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -202,6 +202,8 @@ fn decode_struct[T](_ T, res map[string]Any) !T {
 					}
 				} $else $if field.is_array {
 					arr := res[field.name]! as []Any
+					println(arr)
+					println(typ.$(field.name))
 					decode_array_item(mut typ.$(field.name), arr)
 				} $else $if field.is_struct {
 					typ.$(field.name) = decode_struct(typ.$(field.name), res[field.name]!.as_map())!
@@ -235,6 +237,7 @@ fn decode_struct[T](_ T, res map[string]Any) !T {
 }
 
 fn decode_array_item[T](mut field T, arr []Any) {
+	println('item> ${typeof[T]().name}')
 	// vfmt off
 	match typeof[T]().idx {
 		typeof[[]bool]().idx  { field = arr.map(it.bool()) }


### PR DESCRIPTION
Fix

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc3Zjc2ZGYxNDRmNTg1YWU1MjVlMTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.8Dx4ssMCkhWzMVIkmc5wSA89T9kzYnqhlVHDM-mM9b0">Huly&reg;: <b>V_0.6-21786</b></a></sub>