### PR TITLE
checker: fix missing option variable checking when casting using `as` operator

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2959,10 +2959,17 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 				c.table.used_features.as_cast = true
 			}
 			if mut node.expr is ast.Ident {
-				if !node.typ.has_flag(.option) && node.expr.obj.typ.has_flag(.option)
-					&& node.expr.or_expr.kind == .absent {
-					c.error('variable `${node.expr.name}` is an Option, it must be unwrapped first',
-						node.expr.pos)
+				if mut node.expr.obj is ast.Var {
+					ident_typ := if node.expr.obj.smartcasts.len > 0 {
+						node.expr.obj.smartcasts.last()
+					} else {
+						node.expr.obj.typ
+					}
+					if !node.typ.has_flag(.option) && ident_typ.has_flag(.option)
+						&& node.expr.or_expr.kind == .absent {
+						c.error('variable `${node.expr.name}` is an Option, it must be unwrapped first',
+							node.expr.pos)
+					}
 				}
 			}
 			if expr_type_sym.kind == .sum_type {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1386,13 +1386,6 @@ fn (mut c Checker) check_expr_option_or_result_call(expr ast.Expr, ret_type ast.
 			c.check_expr_option_or_result_call(expr.expr, ret_type)
 		}
 		ast.AsCast {
-			if expr.expr is ast.Ident {
-				if !ret_type.has_flag(.option) && expr.expr.obj.typ.has_flag(.option)
-					&& expr.expr.or_expr.kind == .absent {
-					c.error('variable `${expr.expr.name}` is an Option, it must be unwrapped first',
-						expr.expr.pos)
-				}
-			}
 			c.check_expr_option_or_result_call(expr.expr, ret_type)
 		}
 		ast.ParExpr {
@@ -2965,7 +2958,13 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 			if !c.is_builtin_mod {
 				c.table.used_features.as_cast = true
 			}
-			c.check_expr_option_or_result_call(node.expr, node.typ)
+			if mut node.expr is ast.Ident {
+				if !node.typ.has_flag(.option) && node.expr.obj.typ.has_flag(.option)
+					&& node.expr.or_expr.kind == .absent {
+					c.error('variable `${node.expr.name}` is an Option, it must be unwrapped first',
+						node.expr.pos)
+				}
+			}
 			if expr_type_sym.kind == .sum_type {
 				c.ensure_type_exists(node.typ, node.pos)
 				if !c.table.sumtype_has_variant(c.unwrap_generic(node.expr_type), c.unwrap_generic(node.typ),

--- a/vlib/v/checker/tests/option_as_cast_err.out
+++ b/vlib/v/checker/tests/option_as_cast_err.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/option_as_cast_err.vv:12:9: error: variable `b` is an Option, it must be unwrapped first
+   10 | println(b)
+   11 | println(b? as int)
+   12 | println(b as int)
+      |         ^

--- a/vlib/v/checker/tests/option_as_cast_err.vv
+++ b/vlib/v/checker/tests/option_as_cast_err.vv
@@ -1,0 +1,12 @@
+type Sum = int | string
+
+fn sum() ?Sum {
+	return Sum(5)
+}
+
+a := sum()?
+println(a as int)
+b := sum()
+println(b)
+println(b? as int)
+println(b as int)

--- a/vlib/v/tests/options/option_concatexpr_test.v
+++ b/vlib/v/tests/options/option_concatexpr_test.v
@@ -12,17 +12,17 @@ fn foo(f int) !(int, ?int) {
 
 fn test_main() {
 	a, b := foo(-1) or { 2, 2 }
-	c := b as int
+	c := b? as int
 	assert a == 2
 	assert c == 2
 
 	a2, b2 := foo(0) or { 2, 2 }
-	c2 := b2 as int
+	c2 := b2? as int
 	assert a2 == 0
 	assert c2 == 0
 
 	a3, b3 := foo(1) or { 2, 2 }
-	c3 := b3 as int
+	c3 := b3? as int
 	assert a3 == 1
 	assert c3 == 1
 }

--- a/vlib/v/tests/options/option_unwrap_as_cast_test.v
+++ b/vlib/v/tests/options/option_unwrap_as_cast_test.v
@@ -15,9 +15,9 @@ fn get_opt_int(a int) ?int {
 fn test_option_unwrap_as_cast() {
 	x := get_opt(1)
 	d := get_opt_int(12)
-	dump(d as int == 12)
-	dump('${x as string}' == 'success')
+	dump(d? as int == 12)
+	dump('${x? as string}' == 'success')
 
-	assert d as int == 12
-	assert x as string == 'success'
+	assert d? as int == 12
+	assert x? as string == 'success'
 }


### PR DESCRIPTION
Fix #23349

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc4NGY3ZWYxNDRmNTg1YWU1MjY3MGEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.QKmzY0zea19BgkOCSPTtiGI_VY1aElQNtHdmBkbJDZo">Huly&reg;: <b>V_0.6-21789</b></a></sub>