### PR TITLE
vdoctor: fix format, windows, tcc

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -116,7 +116,7 @@ fn (mut a App) collect_info() {
 	a.line2('V home dir', diagnose_dir(vroot), vroot)
 	a.line2('VMODULES', diagnose_dir(vmodules), vmodules)
 	a.line2('VTMP', diagnose_dir(vtmp_dir), vtmp_dir)
-	a.line2('Current dir', diagnose_dir(getwd), getwd)
+	a.line2('Current working dir', diagnose_dir(getwd), getwd)
 	vflags := os.getenv('VFLAGS')
 	a.line('', '')
 	if vflags != '' {

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -123,7 +123,7 @@ fn (mut a App) collect_info() {
 	a.line('V executable', vexe)
 	a.line('V last modified time', time.unix(os.file_last_mod_unix(vexe)).str())
 	a.line('', '')
-	a.line2('vroot', diagnose_dir(vroot), vroot)
+	a.line2('V home dir', diagnose_dir(vroot), vroot)
 	a.line2('VMODULES', diagnose_dir(vmodules), vmodules)
 	a.line2('VTMP', diagnose_dir(vtmp_dir), vtmp_dir)
 	vflags := os.getenv('VFLAGS')

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -119,7 +119,7 @@ fn (mut a App) collect_info() {
 		vexe = iconv.encoding_to_vstring(vexe.bytes(), 'ANSI') or { vexe }
 		vroot = iconv.encoding_to_vstring(vroot.bytes(), 'ANSI') or { vroot }
 	}
-	a.line('getwd', getwd)
+	a.line('V home dir', getwd)
 	a.line('vexe', vexe)
 	a.line('vexe mtime', time.unix(os.file_last_mod_unix(vexe)).str())
 	a.line('', '')

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -120,7 +120,7 @@ fn (mut a App) collect_info() {
 		vroot = iconv.encoding_to_vstring(vroot.bytes(), 'ANSI') or { vroot }
 	}
 	a.line('V home dir', getwd)
-	a.line('vexe', vexe)
+	a.line('V executable', vexe)
 	a.line('vexe mtime', time.unix(os.file_last_mod_unix(vexe)).str())
 	a.line('', '')
 	a.line2('vroot', diagnose_dir(vroot), vroot)

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -133,7 +133,7 @@ fn (mut a App) collect_info() {
 		a.line('', '')
 	}
 	a.line('Git version', a.cmd(command: 'git --version'))
-	a.line('Git vroot status', a.git_info())
+	a.line('V git status', a.git_info())
 	a.line('.git/config present', os.is_file('.git/config').str())
 	a.line('', '')
 	a.line('CC version', a.cmd(command: 'cc --version'))

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -121,7 +121,7 @@ fn (mut a App) collect_info() {
 	}
 	a.line('V home dir', getwd)
 	a.line('V executable', vexe)
-	a.line('vexe mtime', time.unix(os.file_last_mod_unix(vexe)).str())
+	a.line('V last modified time', time.unix(os.file_last_mod_unix(vexe)).str())
 	a.line('', '')
 	a.line2('vroot', diagnose_dir(vroot), vroot)
 	a.line2('VMODULES', diagnose_dir(vmodules), vmodules)

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -3,6 +3,7 @@ import time
 import term
 import v.util.version
 import runtime
+import encoding.iconv
 
 struct App {
 mut:
@@ -16,6 +17,7 @@ fn (mut a App) println(s string) {
 
 fn (mut a App) collect_info() {
 	a.line('V full version', version.full_v_version(true))
+	a.line(':-------------------', ':-------------------')
 
 	mut os_kind := os.user_os()
 	mut arch_details := []string{}
@@ -51,7 +53,7 @@ fn (mut a App) collect_info() {
 	if os_kind == 'windows' {
 		arch_details << a.cmd(
 			command: 'wmic cpu get name /format:table'
-			line:    1
+			line:    2
 		)
 	}
 
@@ -91,14 +93,20 @@ fn (mut a App) collect_info() {
 		)
 		p := a.parse(wmic_info, '=')
 		caption, build_number, os_arch := p['caption'], p['buildnumber'], p['osarchitecture']
-		os_details = '${caption} v${build_number} ${os_arch}'
+		caption_utf := iconv.encoding_to_vstring(caption.bytes(), 'ANSI') or { caption }
+		build_number_utf := iconv.encoding_to_vstring(build_number.bytes(), 'ANSI') or {
+			build_number
+		}
+		os_arch_utf := iconv.encoding_to_vstring(os_arch.bytes(), 'ANSI') or { os_arch }
+		os_details = '${caption_utf} ${build_number_utf} ${os_arch_utf}'
 	} else {
 		ouname := os.uname()
 		os_details = '${ouname.release}, ${ouname.version}'
 	}
 	a.line('OS', '${os_kind}, ${os_details}')
 	a.line('Processor', arch_details.join(', '))
-	a.println('')
+	a.line('', '')
+	// a.println('')
 	getwd := os.getwd()
 	vmodules := os.vmodules_dir()
 	vtmp_dir := os.vtmp_dir()
@@ -108,20 +116,20 @@ fn (mut a App) collect_info() {
 	a.line('getwd', getwd)
 	a.line('vexe', vexe)
 	a.line('vexe mtime', time.unix(os.file_last_mod_unix(vexe)).str())
-	a.println('')
+	a.line('', '')
 	a.line2('vroot', diagnose_dir(vroot), vroot)
 	a.line2('VMODULES', diagnose_dir(vmodules), vmodules)
 	a.line2('VTMP', diagnose_dir(vtmp_dir), vtmp_dir)
 	vflags := os.getenv('VFLAGS')
-	a.println('')
+	a.line('', '')
 	if vflags != '' {
 		a.line('env VFLAGS', '"${vflags}"')
-		a.println('')
+		a.line('', '')
 	}
 	a.line('Git version', a.cmd(command: 'git --version'))
 	a.line('Git vroot status', a.git_info())
 	a.line('.git/config present', os.is_file('.git/config').str())
-	a.println('')
+	a.line('', '')
 	a.line('CC version', a.cmd(command: 'cc --version'))
 	a.line('emcc version', a.cmd(command: 'emcc --version'))
 	a.report_tcc_version('thirdparty/tcc')
@@ -134,7 +142,8 @@ struct CmdConfig {
 
 fn (mut a App) cmd(c CmdConfig) string {
 	x := os.execute(c.command)
-	if x.exit_code < 0 || x.exit_code == 127 {
+	os_kind := os.user_os()
+	if x.exit_code < 0 || x.exit_code == 127 || (os_kind == 'windows' && x.exit_code == 1) {
 		return 'N/A'
 	}
 	if x.exit_code == 0 {
@@ -150,11 +159,11 @@ fn (mut a App) cmd(c CmdConfig) string {
 }
 
 fn (mut a App) line(label string, value string) {
-	a.println('${label}: ${term.colorize(term.bold, value)}')
+	a.println('|${label:-20}|${term.colorize(term.bold, value)}')
 }
 
 fn (mut a App) line2(label string, value string, value2 string) {
-	a.println('${label}: ${term.colorize(term.bold, value)}, value: ${term.colorize(term.bold,
+	a.println('|${label:-20}|${term.colorize(term.bold, value)}, value: ${term.colorize(term.bold,
 		value2)}')
 }
 
@@ -243,16 +252,24 @@ fn (mut a App) git_info() string {
 
 fn (mut a App) report_tcc_version(tccfolder string) {
 	if !os.is_file(os.join_path(tccfolder, '.git', 'config')) {
-		a.line(tccfolder, 'N/A')
-		return
+		a.line('tcc git status', 'N/A')
+	} else {
+		tcc_branch_name := a.cmd(
+			command: 'git -C ${os.quoted_path(tccfolder)} rev-parse --abbrev-ref HEAD'
+		)
+		tcc_commit := a.cmd(
+			command: 'git -C ${os.quoted_path(tccfolder)} describe --abbrev=8 --dirty --always --tags'
+		)
+		a.line('tcc git status', '${tcc_branch_name} ${tcc_commit}')
 	}
-	tcc_branch_name := a.cmd(
-		command: 'git -C ${os.quoted_path(tccfolder)} rev-parse --abbrev-ref HEAD'
-	)
-	tcc_commit := a.cmd(
-		command: 'git -C ${os.quoted_path(tccfolder)} describe --abbrev=8 --dirty --always --tags'
-	)
-	a.line('${tccfolder} status', '${tcc_branch_name} ${tcc_commit}')
+	cmd := os.join_path(tccfolder, 'tcc.exe') + ' -v'
+	x := os.execute(cmd)
+	os_kind := os.user_os()
+	if x.exit_code == 0 {
+		a.line('tcc version', '${x.output.trim_space()}')
+	} else {
+		a.line('tcc version', 'N/A')
+	}
 }
 
 fn (mut a App) report_info() {

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -92,13 +92,11 @@ fn (mut a App) collect_info() {
 			line:    -1
 		)
 		p := a.parse(wmic_info, '=')
-		caption, build_number, os_arch := p['caption'], p['buildnumber'], p['osarchitecture']
-		caption_utf := iconv.encoding_to_vstring(caption.bytes(), 'ANSI') or { caption }
-		build_number_utf := iconv.encoding_to_vstring(build_number.bytes(), 'ANSI') or {
-			build_number
-		}
-		os_arch_utf := iconv.encoding_to_vstring(os_arch.bytes(), 'ANSI') or { os_arch }
-		os_details = '${caption_utf} ${build_number_utf} ${os_arch_utf}'
+		mut caption, mut build_number, mut os_arch := p['caption'], p['buildnumber'], p['osarchitecture']
+		caption = iconv.encoding_to_vstring(caption.bytes(), 'ANSI') or { caption }
+		build_number = iconv.encoding_to_vstring(build_number.bytes(), 'ANSI') or { build_number }
+		os_arch = iconv.encoding_to_vstring(os_arch.bytes(), 'ANSI') or { os_arch }
+		os_details = '${caption} ${build_number} ${os_arch}'
 	} else {
 		ouname := os.uname()
 		os_details = '${ouname.release}, ${ouname.version}'
@@ -107,12 +105,20 @@ fn (mut a App) collect_info() {
 	a.line('Processor', arch_details.join(', '))
 	a.line('', '')
 	// a.println('')
-	getwd := os.getwd()
-	vmodules := os.vmodules_dir()
-	vtmp_dir := os.vtmp_dir()
-	vexe := os.getenv('VEXE')
-	vroot := os.dir(vexe)
+	mut getwd := os.getwd()
+	mut vmodules := os.vmodules_dir()
+	mut vtmp_dir := os.vtmp_dir()
+	mut vexe := os.getenv('VEXE')
+	mut vroot := os.dir(vexe)
 	os.chdir(vroot) or {}
+	if os_kind == 'windows' {
+		// Windows use ANSI encoding
+		getwd = iconv.encoding_to_vstring(getwd.bytes(), 'ANSI') or { getwd }
+		vmodules = iconv.encoding_to_vstring(vmodules.bytes(), 'ANSI') or { vmodules }
+		vtmp_dir = iconv.encoding_to_vstring(vtmp_dir.bytes(), 'ANSI') or { vtmp_dir }
+		vexe = iconv.encoding_to_vstring(vexe.bytes(), 'ANSI') or { vexe }
+		vroot = iconv.encoding_to_vstring(vroot.bytes(), 'ANSI') or { vroot }
+	}
 	a.line('getwd', getwd)
 	a.line('vexe', vexe)
 	a.line('vexe mtime', time.unix(os.file_last_mod_unix(vexe)).str())

--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -103,6 +103,10 @@ fn (mut a App) collect_info() {
 	}
 	a.line('OS', '${os_kind}, ${os_details}')
 	a.line('Processor', arch_details.join(', '))
+	total_memory := f64(runtime.total_memory()) / (1024.0 * 1024.0 * 1024.0)
+	free_memory := f64(runtime.free_memory()) / (1024.0 * 1024.0 * 1024.0)
+	a.line('Memory', '${free_memory:.2}GB/${total_memory:.2}GB')
+
 	a.line('', '')
 	mut vexe := os.getenv('VEXE')
 	mut vroot := os.dir(vexe)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR will 
1. create a nice looking vdoctor output;
2. fix windows ANSI->UTF-8 text encoding;
3. fix windows get CPU name;
4. add `tcc -v` to output;
5. add `gcc`,`clang`,`glibc` version detect;
6. add `msvc` version detect under Windows;
7. remove path contains non-ANSI character/spaces warning;
8. add free memory / total memory;
9. remove `emcc` detection;


New `v doctor` will output:
```sh
~/v/测试/dir contains spaces$ v doctor
|V full version      |V 0.4.9 3ed799e
|:-------------------|:-------------------
|OS                  |linux, Ubuntu 24.04.1 LTS
|Processor           |8 cpus, 64bit, little endian, Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz
|Memory              |2.97GB/15.51GB
|                    |
|V executable        |/media/HD/github/kbkpbot/v/v
|V last modified time|2025-01-03 23:45:18
|                    |
|V home dir          |OK, value: /media/HD/github/kbkpbot/v
|VMODULES            |OK, value: /home/mars/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |contains spaces, contains these non ASCII characters: [`测`, `试`], value: /home/mars/v/测试/dir contains spaces
|                    |
|Git version         |git version 2.43.0
|V git status        |weekly.2024.53-29-g1fbb77e1-dirty (2 commit(s) behind V master)
|.git/config present |true
|                    |
|CC version          |cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
|gcc version         |gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
|clang version       |Ubuntu clang version 18.1.3 (1ubuntu1)
|tcc version         |tcc version 0.9.28rc 2024-07-31 HEAD@1cee0908 (x86_64 Linux)
|tcc git status      |thirdparty-linux-amd64 0134e9b9
|glibc version       |ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39


```

By copy this `vdoctor` output to `github`, you will get a nice looking `markdown` format:


Linux:

|V full version      |V 0.4.9 3ed799e
|:-------------------|:-------------------
|OS                  |linux, Ubuntu 24.04.1 LTS
|Processor           |8 cpus, 64bit, little endian, Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz
|Memory              |2.97GB/15.51GB
|                    |
|V executable        |/media/HD/github/kbkpbot/v/v
|V last modified time|2025-01-03 23:45:18
|                    |
|V home dir          |OK, value: /media/HD/github/kbkpbot/v
|VMODULES            |OK, value: /home/mars/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |contains spaces, contains these non ASCII characters: [`测`, `试`], value: /home/mars/v/测试/dir contains spaces
|                    |
|Git version         |git version 2.43.0
|V git status        |weekly.2024.53-29-g1fbb77e1-dirty (2 commit(s) behind V master)
|.git/config present |true
|                    |
|CC version          |cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
|gcc version         |gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
|clang version       |Ubuntu clang version 18.1.3 (1ubuntu1)
|tcc version         |tcc version 0.9.28rc 2024-07-31 HEAD@1cee0908 (x86_64 Linux)
|tcc git status      |thirdparty-linux-amd64 0134e9b9
|glibc version       |ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39




Windows :

V full version      |V 0.4.9 3ed799e
|:-------------------|:-------------------
|OS                  |windows, Microsoft Windows 10 企业版 LTSC 19044 64 位
|Processor           |16 cpus, 64bit, little endian, AMD Ryzen 7 7840H with Radeon 780M Graphics
|Memory              |1.36GB/27.69GB
|                    |
|V executable        |D:\v\v\v\v.exe
|V last modified time|2025-01-03 23:42:23
|                    |
|V home dir          |OK, value: D:\v\v\v
|VMODULES            |OK, value: C:\Users\DDT\.vmodules
|VTMP                |OK, value: C:\Users\DDT\AppData\Local\Temp\v_0
|Current working dir |contains spaces, contains these non ASCII characters: [`测`, `试`], value: D:\测试tmp\v test dir contain space
|                    |
|Git version         |git version 2.43.0.windows.1
|V git status        |weekly.2024.53-19-g3ed799ef-dirty (2 commit(s) behind V master)
|.git/config present |true
|                    |
|CC version          |N/A
|gcc version         |N/A
|clang version       |N/A
|msvc version        |用于 x64 的 Microsoft (R) C/C++ 优化编译器 19.39.33523 版
|tcc version         |tcc version 0.9.28rc 2024-12-30_mob@68000c01* (x86_64 Windows)
|tcc git status      |N/A
|glibc version       |N/A

