### PR TITLE
cgen: define _GNU_SOURCE on Linux

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -906,6 +906,10 @@ pub fn (mut g Gen) init() {
 #endif
 ')
 		}
+		if g.pref.os == .linux {
+			// For gettid() declaration (and other GNU-specific bits).
+			g.cheaders.writeln('#define _GNU_SOURCE')
+		}
 		if g.pref.os == .wasm32 {
 			g.cheaders.writeln('#define VWASM 1')
 			// Include <stdint.h> instead of <inttypes.h> for WASM target


### PR DESCRIPTION
For `gettid()` declaration (and other GNU-specific bits).

Fixes #23351.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc4YTMxOWYxNDRmNTg1YWU1MjZjYjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.YSwkyXv9mScCDLP38t0WfbitH3AUm5g307R4MTyN_vk">Huly&reg;: <b>V_0.6-21795</b></a></sub>