### PR TITLE
checker: fix assign expected type on rechecking enum assigns 

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -24,6 +24,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 	mut right_len := node.right.len
 	mut right_first_type := ast.void_type
 	old_recheck := c.inside_recheck
+
 	// check if we are rechecking an already checked expression on generic rechecking
 	c.inside_recheck = old_recheck || node.right_types.len > 0
 	defer {
@@ -75,6 +76,7 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				c.error('cannot use `<-` on the right-hand side of an assignment, as it does not return any values',
 					right.pos)
 			} else if c.inside_recheck {
+				c.expected_type = node.right_types[i]
 				mut right_type := c.expr(mut right)
 				right_type_sym := c.table.sym(right_type)
 				// fixed array returns an struct, but when assigning it must be the array type

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -76,7 +76,9 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 				c.error('cannot use `<-` on the right-hand side of an assignment, as it does not return any values',
 					right.pos)
 			} else if c.inside_recheck {
-				c.expected_type = node.right_types[i]
+				if i < node.right_types.len {
+					c.expected_type = node.right_types[i]
+				}
 				mut right_type := c.expr(mut right)
 				right_type_sym := c.table.sym(right_type)
 				// fixed array returns an struct, but when assigning it must be the array type

--- a/vlib/v/tests/enums/enum_assign_on_anon_fn_test.v
+++ b/vlib/v/tests/enums/enum_assign_on_anon_fn_test.v
@@ -1,0 +1,43 @@
+pub type FnGridObject = fn (mut object GridObject)
+
+@[flag]
+pub enum GridObjectAuto {
+	drag
+	drop
+	scale_on_hover
+	pickup
+	sound
+	off // auto "deactivation"
+}
+
+@[params]
+pub struct GridObjectConfig {
+	auto GridObjectAuto = ~GridObjectAuto.zero()
+	on   ?FnGridObject
+}
+
+@[heap]
+struct GridObject {
+mut:
+	config GridObjectConfig
+	auto   GridObjectAuto = ~GridObjectAuto.zero()
+}
+
+pub fn on(config GridObjectConfig) &GridObject {
+	mut ob := &GridObject{}
+	ob.config = config
+	ob.auto = config.auto
+	if func := ob.config.on {
+		func(mut ob)
+	}
+	return ob
+}
+
+fn test_main() {
+	_ := on(
+		on: fn (mut o GridObject) {
+			o.auto = .off | .pickup | .sound
+		}
+	)
+	assert true
+}


### PR DESCRIPTION
Fix #23366

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc5MjQ1YWYxNDRmNTg1YWU1MjdhOTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.NwmbTphj9Pm1LsUo3pV7heu4_vyOPRaxZW2yjQSG9ZE">Huly&reg;: <b>V_0.6-21798</b></a></sub>