### PR TITLE
fix windows CI for `v -W build-tools`

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -265,7 +265,6 @@ fn (mut a App) git_info() string {
 fn (mut a App) report_tcc_version(tccfolder string) {
 	cmd := os.join_path(tccfolder, 'tcc.exe') + ' -v'
 	x := os.execute(cmd)
-	os_kind := os.user_os()
 	if x.exit_code == 0 {
 		a.line('tcc version', '${x.output.trim_space()}')
 	} else {


### PR DESCRIPTION
Fix

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc5MmJkYWYxNDRmNTg1YWU1MjdhZjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.9dDgpJGyiXXDM-85MRMNFgNNvDHp1xkxOqp_VAjL7D0">Huly&reg;: <b>V_0.6-21799</b></a></sub>