### PR TITLE
ci: force all tools to build without warnings/notices in tools_ci.yml

### DIFF
--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -37,9 +37,11 @@ jobs:
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Code in cmd/ is formatted
         run: ./v fmt -verify cmd/
-      - name: Test
+      - name: Check build-tools
+        run: ./v -N -W -check build-tools
+      - name: Test tools
         run: ./v test-self cmd
-      - name: Test (-cstrict)
+      - name: Test tools (-cstrict)
         if: ${{ matrix.cc != 'tcc' }}
         run: ./v -W -cstrict test-self cmd
       - name: Test sanitized
@@ -72,9 +74,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
-      - name: Test
+      - name: Check build-tools
+        run: ./v -N -W -check build-tools
+      - name: Test tools
         run: ./v test-self cmd
-      - name: Test (-cstrict)
+      - name: Test tools (-cstrict)
         run: ./v -W -cstrict test-self cmd
 
   windows:
@@ -89,9 +93,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build V
         run: ./make.bat -${{ matrix.cc }} && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
-      - name: Test
+      - name: Check build tools
+        run: ./v -N -W -check build-tools
+      - name: Test tools
         run: ./v test-self cmd
-      - name: Test (-cstrict)
+      - name: Test tools (-cstrict)
         if: ${{ matrix.cc == 'msvc' }}
         run: ./v -W -cstrict test-self cmd
 
@@ -117,7 +123,9 @@ jobs:
         run: |
           ./v cmd/tools/test_if_v_test_system_works.v
           ./cmd/tools/test_if_v_test_system_works
-      - name: Test
+      - name: Check build tools
+        run: ./v -N -W -check build-tools
+      - name: Test tools
         run: ./v test-self cmd
-      - name: Test (-cstrict)
+      - name: Test tools (-cstrict)
         run: ./v -W -cstrict test-self cmd


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc5MzczMWYxNDRmNTg1YWU1MjdjMDAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.eoStn-ocUl_1ZDLzv5MRxSpTZbSm5L1DAAn0nwkpnqo">Huly&reg;: <b>V_0.6-21802</b></a></sub>