### PR TITLE
markused,builtin,strconv,vlib: reduce generated C sizes for compilers != tcc, for short programs, by simplifying the generation of backtraces, and reducing string interpolations in panics

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -563,13 +563,15 @@ fn (a array) slice(start int, _end int) array {
 	end := if _end == max_int { a.len } else { _end } // max_int
 	$if !no_bounds_checking {
 		if start > end {
-			panic_n2('array.slice: invalid slice index (start>end):', start, end)
+			panic('array.slice: invalid slice index (start>end):' + i64(start).str() + ', ' +
+				i64(end).str())
 		}
 		if end > a.len {
-			panic_n2('array.slice: slice bounds out of range (end>=a.len):', end, a.len)
+			panic('array.slice: slice bounds out of range (' + i64(end).str() + ' >= ' +
+				i64(a.len).str() + ')')
 		}
 		if start < 0 {
-			panic_n('array.slice: slice bounds out of range (start<0):', start)
+			panic('array.slice: slice bounds out of range (start<0):' + start.str())
 		}
 	}
 	// TODO: integrate reference counting

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -103,7 +103,8 @@ fn (mut a array) ensure_cap_noscan(required int) {
 		return
 	}
 	if a.flags.has(.nogrow) {
-		panic('array.ensure_cap_noscan: array with the flag `.nogrow` cannot grow in size, array required new size: ${required}')
+		panic_n('array.ensure_cap_noscan: array with the flag `.nogrow` cannot grow in size, array required new size:',
+			required)
 	}
 	mut cap := if a.cap > 0 { i64(a.cap) } else { i64(2) }
 	for required > cap {
@@ -114,7 +115,8 @@ fn (mut a array) ensure_cap_noscan(required int) {
 			// limit the capacity, since bigger values, will overflow the 32bit integer used to store it
 			cap = max_int
 		} else {
-			panic('array.ensure_cap_noscan: array needs to grow to cap = ${cap}, which is > 2^31')
+			panic_n('array.ensure_cap_noscan: array needs to grow to cap (which is > 2^31):',
+				cap)
 		}
 	}
 	new_size := u64(cap) * u64(a.element_size)
@@ -136,7 +138,7 @@ fn (mut a array) ensure_cap_noscan(required int) {
 @[unsafe]
 fn (a array) repeat_to_depth_noscan(count int, depth int) array {
 	if count < 0 {
-		panic('array.repeat: count is negative: ${count}')
+		panic_n('array.repeat: count is negative:', count)
 	}
 	mut size := u64(count) * u64(a.len) * u64(a.element_size)
 	if size == 0 {
@@ -170,7 +172,7 @@ fn (a array) repeat_to_depth_noscan(count int, depth int) array {
 // insert inserts a value in the array at index `i`
 fn (mut a array) insert_noscan(i int, val voidptr) {
 	if i < 0 || i > a.len {
-		panic('array.insert_noscan: index out of range (i == ${i}, a.len == ${a.len})')
+		panic_n2('array.insert_noscan: index out of range (i,a.len):', i, a.len)
 	}
 	if a.len == max_int {
 		panic('array.insert_noscan: a.len reached max_int')
@@ -187,11 +189,11 @@ fn (mut a array) insert_noscan(i int, val voidptr) {
 @[unsafe]
 fn (mut a array) insert_many_noscan(i int, val voidptr, size int) {
 	if i < 0 || i > a.len {
-		panic('array.insert_many: index out of range (i == ${i}, a.len == ${a.len})')
+		panic_n2('array.insert_many: index out of range (i, a.len):', i, a.len)
 	}
 	new_len := i64(a.len) + i64(size)
 	if new_len > max_int {
-		panic('array.insert_many_noscan: a.len = ${new_len} will exceed max_int')
+		panic_n('array.insert_many_noscan: max_int will be exceeded by a.len:', new_len)
 	}
 	a.ensure_cap_noscan(a.len + size)
 	elem_size := a.element_size
@@ -328,7 +330,7 @@ fn (a array) reverse_noscan() array {
 fn (mut a array) grow_cap_noscan(amount int) {
 	new_cap := i64(amount) + i64(a.cap)
 	if new_cap > max_int {
-		panic('array.grow_cap: new capacity ${new_cap} will exceed max_int')
+		panic_n('array.grow_cap: max_int will be exceeded by new cap:', new_cap)
 	}
 	a.ensure_cap_noscan(int(new_cap))
 }
@@ -338,7 +340,7 @@ fn (mut a array) grow_cap_noscan(amount int) {
 fn (mut a array) grow_len_noscan(amount int) {
 	new_len := i64(amount) + i64(a.len)
 	if new_len > max_int {
-		panic('array.grow_len: new len ${new_len} will exceed max_int')
+		panic_n('array.grow_len: max_int will be exceeded by new len:', new_len)
 	}
 	a.ensure_cap_noscan(int(new_len))
 	a.len = int(new_len)

--- a/vlib/builtin/backtraces.c.v
+++ b/vlib/builtin/backtraces.c.v
@@ -10,19 +10,15 @@ pub fn print_backtrace() {
 	$if !no_backtrace ? {
 		$if freestanding {
 			println(bare_backtrace())
+		} $else $if native {
+			// TODO: native backtrace solution
+		} $else $if tinyc {
+			C.tcc_backtrace(c'Backtrace')
+		} $else $if use_libbacktrace ? {
+			// NOTE: TCC doesn't have the unwind library
+			print_libbacktrace(1)
 		} $else {
-			$if native {
-				// TODO: native backtrace solution
-			} $else $if tinyc {
-				C.tcc_backtrace(c'Backtrace')
-			} $else {
-				// NOTE: TCC doesn't have the unwind library
-				$if use_libbacktrace ? {
-					print_libbacktrace(1)
-				} $else {
-					print_backtrace_skipping_top_frames(2)
-				}
-			}
+			print_backtrace_skipping_top_frames(2)
 		}
 	}
 }

--- a/vlib/builtin/backtraces.c.v
+++ b/vlib/builtin/backtraces.c.v
@@ -22,3 +22,12 @@ pub fn print_backtrace() {
 		}
 	}
 }
+
+fn eprint_space_padding(output string, max_len int) {
+	padding_len := max_len - output.len
+	if padding_len > 0 {
+		for _ in 0 .. padding_len {
+			eprint(' ')
+		}
+	}
+}

--- a/vlib/builtin/backtraces_nix.c.v
+++ b/vlib/builtin/backtraces_nix.c.v
@@ -116,12 +116,3 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 	}
 	return true
 }
-
-fn eprint_space_padding(output string, max_len int) {
-	padding_len := max_len - output.len
-	if padding_len > 0 {
-		for _ in 0 .. padding_len {
-			eprint(' ')
-		}
-	}
-}

--- a/vlib/builtin/backtraces_nix.c.v
+++ b/vlib/builtin/backtraces_nix.c.v
@@ -77,7 +77,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 					executable := sframe.all_before('(')
 					addr := sframe.all_after('[').all_before(']')
 					beforeaddr := sframe.all_before('[')
-					cmd := 'addr2line -e ${executable} ${addr}'
+					cmd := 'addr2line -e ' + executable + ' ' + addr
 					// taken from os, to avoid depending on the os module inside builtin.v
 					f := C.popen(&char(cmd.str), c'r')
 					if f == unsafe { nil } {
@@ -104,7 +104,12 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 					// Note: it is shortened here to just d. , just so that it fits, and so
 					// that the common error file:lineno: line format is enforced.
 					output = output.replace(' (discriminator', ': (d.')
-					eprintln('${output:-55s} | ${addr:14s} | ${beforeaddr}')
+					eprint(output)
+					eprint_space_padding(output, 55)
+					eprint(' | ')
+					eprint(addr)
+					eprint(' | ')
+					eprintln(beforeaddr)
 				}
 				if sframes.len > 0 {
 					unsafe { C.free(csymbols) }
@@ -113,4 +118,13 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 		}
 	}
 	return true
+}
+
+fn eprint_space_padding(output string, max_len int) {
+	padding_len := max_len - output.len
+	if padding_len > 0 {
+		for _ in 0 .. padding_len {
+			eprint(' ')
+		}
+	}
 }

--- a/vlib/builtin/backtraces_nix.c.v
+++ b/vlib/builtin/backtraces_nix.c.v
@@ -67,13 +67,10 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 					return false
 				}
 				nr_actual_frames := nr_ptrs - skipframes
-				mut sframes := []string{}
 				//////csymbols := backtrace_symbols(*voidptr(&buffer[skipframes]), nr_actual_frames)
 				csymbols := C.backtrace_symbols(voidptr(&buffer[skipframes]), nr_actual_frames)
 				for i in 0 .. nr_actual_frames {
-					sframes << unsafe { tos2(&u8(csymbols[i])) }
-				}
-				for sframe in sframes {
+					sframe := unsafe { tos2(&u8(csymbols[i])) }
 					executable := sframe.all_before('(')
 					addr := sframe.all_after('[').all_before(']')
 					beforeaddr := sframe.all_before('[')
@@ -92,7 +89,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 							output += tos(bp, vstrlen(bp))
 						}
 					}
-					output = output.trim_space() + ':'
+					output = output.trim_chars(' \t\n', .trim_both) + ':'
 					if C.pclose(f) != 0 {
 						eprintln(sframe)
 						continue
@@ -111,7 +108,7 @@ fn print_backtrace_skipping_top_frames_linux(skipframes int) bool {
 					eprint(' | ')
 					eprintln(beforeaddr)
 				}
-				if sframes.len > 0 {
+				if nr_actual_frames > 0 {
 					unsafe { C.free(csymbols) }
 				}
 			}

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -175,16 +175,19 @@ pub fn c_error_number_str(errnum int) string {
 	return err_msg
 }
 
+// panic prints an error message, followed by the given number, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic_n(s string, number1 i64) {
 	panic(s + number1.str())
 }
 
+// panic prints an error message, followed by the given numbers, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic_n2(s string, number1 i64, number2 i64) {
 	panic(s + number1.str() + ', ' + number2.str())
 }
 
+// panic prints an error message, followed by the given numbers, then exits the process with exit code of 1.
 @[noreturn]
 fn panic_n3(s string, number1 i64, number2 i64, number3 i64) {
 	panic(s + number1.str() + ', ' + number2.str() + ', ' + number2.str())

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -175,19 +175,19 @@ pub fn c_error_number_str(errnum int) string {
 	return err_msg
 }
 
-// panic prints an error message, followed by the given number, then exits the process with exit code of 1.
+// panic_n prints an error message, followed by the given number, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic_n(s string, number1 i64) {
 	panic(s + number1.str())
 }
 
-// panic prints an error message, followed by the given numbers, then exits the process with exit code of 1.
+// panic_n2 prints an error message, followed by the given numbers, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic_n2(s string, number1 i64, number2 i64) {
 	panic(s + number1.str() + ', ' + number2.str())
 }
 
-// panic prints an error message, followed by the given numbers, then exits the process with exit code of 1.
+// panic_n3 prints an error message, followed by the given numbers, then exits the process with exit code of 1.
 @[noreturn]
 fn panic_n3(s string, number1 i64, number2 i64, number3 i64) {
 	panic(s + number1.str() + ', ' + number2.str() + ', ' + number2.str())

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -769,7 +769,8 @@ pub fn gc_memory_use() usize {
 fn v_fixed_index(i int, len int) int {
 	$if !no_bounds_checking {
 		if i < 0 || i >= len {
-			panic_n2('fixed array index out of range (index, len):', i, len)
+			panic('fixed array index out of range (index: ' + i64(i).str() + ', len: ' +
+				i64(len).str() + ')')
 		}
 	}
 	return i

--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -106,14 +106,14 @@ fn panic_debug(line_no int, file string, mod string, fn_name string, s string) {
 // It ends the program with a panic.
 @[noreturn]
 pub fn panic_option_not_set(s string) {
-	panic('option not set (${s})')
+	panic('option not set (' + s + ')')
 }
 
 // panic_result_not_set is called by V, when you use result error propagation in your main function
 // It ends the program with a panic.
 @[noreturn]
 pub fn panic_result_not_set(s string) {
-	panic('result not set (${s})')
+	panic('result not set (' + s + ')')
 }
 
 // panic prints a nice error message, then exits the process with exit code of 1.
@@ -173,6 +173,21 @@ pub fn c_error_number_str(errnum int) string {
 		}
 	}
 	return err_msg
+}
+
+@[noreturn]
+pub fn panic_n(s string, number1 i64) {
+	panic(s + number1.str())
+}
+
+@[noreturn]
+pub fn panic_n2(s string, number1 i64, number2 i64) {
+	panic(s + number1.str() + ', ' + number2.str())
+}
+
+@[noreturn]
+fn panic_n3(s string, number1 i64, number2 i64, number3 i64) {
+	panic(s + number1.str() + ', ' + number2.str() + ', ' + number2.str())
 }
 
 // panic with a C-API error message matching `errnum`
@@ -751,8 +766,7 @@ pub fn gc_memory_use() usize {
 fn v_fixed_index(i int, len int) int {
 	$if !no_bounds_checking {
 		if i < 0 || i >= len {
-			s := 'fixed array index out of range (index: ${i}, len: ${len})'
-			panic(s)
+			panic_n2('fixed array index out of range (index, len):', i, len)
 		}
 	}
 	return i

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -10,12 +10,6 @@ pub fn isnil(v voidptr) bool {
 	return v == 0
 }
 
-/*
-fn on_panic(f fn(int)int) {
-	// TODO
-}
-*/
-
 struct VCastTypeIndexName {
 	tindex int
 	tname  string
@@ -37,7 +31,7 @@ fn __as_cast(obj voidptr, obj_type int, expected_type int) voidptr {
 				expected_name = x.tname.clone()
 			}
 		}
-		panic('as cast: cannot cast `${obj_name}` to `${expected_name}`')
+		panic('as cast: cannot cast `' + obj_name + '` to `' + expected_name + '`')
 	}
 	return obj
 }

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -112,7 +112,7 @@ fn unhandled_exception_handler(e &ExceptionPointers) int {
 			return 0
 		}
 		else {
-			println('Unhandled Exception 0x${e.exception_record.code:X}')
+			println('Unhandled Exception 0x' + ptr_str(e.exception_record.code))
 			print_backtrace_skipping_top_frames(5)
 		}
 	}

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -67,6 +67,9 @@ fn builtin_init() {
 	$if !no_backtrace ? {
 		add_unhandled_exception_handler()
 	}
+	// On windows, the default buffering is block based (~4096bytes), which interferes badly with non cmd shells
+	// It is much better to have it off by default instead.
+	unbuffer_stdout()
 }
 
 // TODO: copypaste from os

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -3,28 +3,17 @@
 // that can be found in the LICENSE file.
 module builtin
 
-//
-// ----- value to string functions -----
-//
-
 pub struct VContext {
 	allocator int
 }
 
-// type u8 = byte
 type byte = u8
-
-// type i32 = int
 
 // ptr_str returns the address of `ptr` as a `string`.
 pub fn ptr_str(ptr voidptr) string {
 	buf1 := u64(ptr).hex()
 	return buf1
 }
-
-// pub fn nil_str(x voidptr) string {
-// return 'nil'
-//}
 
 // str returns string equivalent of x
 pub fn (x isize) str() string {
@@ -118,18 +107,7 @@ fn (nn int) str_l(max int) string {
 		}
 		diff := max - index
 		vmemmove(buf, voidptr(buf + index), diff + 1)
-		/*
-		// === manual memory move for bare metal ===
-		mut c:= 0
-		for c < diff {
-			buf[c] = buf[c+index]
-			c++
-		}
-		buf[c] = 0
-		*/
 		return tos(buf, diff)
-
-		// return tos(memdup(&buf[0] + index, (max - index)), (max - index))
 	}
 }
 
@@ -165,10 +143,6 @@ pub fn (n int) str() string {
 	return n.str_l(12)
 }
 
-// pub fn int_str(n int) string {
-// return i64(n).str()
-//}
-
 // str returns the value of the `u32` as a `string`.
 // Example: assert u32(20000).str() == '20000'
 @[direct_array_access; inline]
@@ -202,8 +176,6 @@ pub fn (nn u32) str() string {
 		diff := max - index
 		vmemmove(buf, voidptr(buf + index), diff + 1)
 		return tos(buf, diff)
-
-		// return tos(memdup(&buf[0] + index, (max - index)), (max - index))
 	}
 }
 
@@ -258,7 +230,6 @@ pub fn (nn i64) str() string {
 		diff := max - index
 		vmemmove(buf, voidptr(buf + index), diff + 1)
 		return tos(buf, diff)
-		// return tos(memdup(&buf[0] + index, (max - index)), (max - index))
 	}
 }
 
@@ -295,7 +266,6 @@ pub fn (nn u64) str() string {
 		diff := max - index
 		vmemmove(buf, voidptr(buf + index), diff + 1)
 		return tos(buf, diff)
-		// return tos(memdup(&buf[0] + index, (max - index)), (max - index))
 	}
 }
 
@@ -307,10 +277,6 @@ pub fn (b bool) str() string {
 	}
 	return 'false'
 }
-
-//
-// ----- value to hex string functions -----
-//
 
 // u64_to_hex converts the number `nn` to a (zero padded if necessary) hexadecimal `string`.
 @[direct_array_access; inline]

--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -6,6 +6,7 @@ module builtin
 
 fn (a any) toString()
 
+// panic prints an error message, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic(s string) {
 	eprintln('V panic: ${s}')
@@ -13,6 +14,7 @@ pub fn panic(s string) {
 	exit(1)
 }
 
+// panic_n prints an error message, followed by the given number, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic_n(s string, n i64) {
 	eprintln('V panic: ${s}')

--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -8,7 +8,15 @@ fn (a any) toString()
 
 @[noreturn]
 pub fn panic(s string) {
-	eprintln('V panic: ${s}\n${js_stacktrace()}')
+	eprintln('V panic: ${s}')
+	eprintln(js_stacktrace())
+	exit(1)
+}
+
+@[noreturn]
+pub fn panic_n(s string, n i64) {
+	eprintln('V panic: ${s}')
+	eprintln(js_stacktrace())
 	exit(1)
 }
 

--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -9,7 +9,7 @@ fn (a any) toString()
 // panic prints an error message, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic(s string) {
-	eprintln('V panic: ${s}')
+	eprintln('V panic: ' + s)
 	eprintln(js_stacktrace())
 	exit(1)
 }
@@ -17,7 +17,7 @@ pub fn panic(s string) {
 // panic_n prints an error message, followed by the given number, then exits the process with exit code of 1.
 @[noreturn]
 pub fn panic_n(s string, n i64) {
-	eprintln('V panic: ${s}')
+	eprintln('V panic: ' + s)
 	eprintln(js_stacktrace())
 	exit(1)
 }

--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -158,6 +158,7 @@ fn (mut n mapnode) split_child(child_index int, mut y mapnode) {
 	n.len++
 }
 
+@[direct_array_access]
 fn (m SortedMap) get(key string, out voidptr) bool {
 	mut node := m.root
 	for {

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1115,7 +1115,8 @@ pub fn (s string) substr(start int, _end int) string {
 	end := if _end == max_int { s.len } else { _end } // max_int
 	$if !no_bounds_checking {
 		if start > end || start > s.len || end > s.len || start < 0 || end < 0 {
-			panic('substr(${start}, ${end}) out of bounds (len=${s.len}) s="${s}"')
+			panic('substr(' + start.str() + ', ' + end.str() + ') out of bounds (len=' +
+				s.len.str() + ') s=' + s)
 		}
 	}
 	len := end - start
@@ -1962,7 +1963,7 @@ pub fn (s string) str() string {
 fn (s string) at(idx int) u8 {
 	$if !no_bounds_checking {
 		if idx < 0 || idx >= s.len {
-			panic('string index out of range: ${idx} / ${s.len}')
+			panic_n2('string index out of range(idx,s.len):', idx, s.len)
 		}
 	}
 	return unsafe { s.str[idx] }

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1154,7 +1154,8 @@ pub fn (s string) substr_unsafe(start int, _end int) string {
 pub fn (s string) substr_with_check(start int, _end int) !string {
 	end := if _end == max_int { s.len } else { _end } // max_int
 	if start > end || start > s.len || end > s.len || start < 0 || end < 0 {
-		return error('substr(${start}, ${end}) out of bounds (len=${s.len})')
+		return error('substr(' + start.str() + ', ' + end.str() + ') out of bounds (len=' +
+			s.len.str() + ')')
 	}
 	len := end - start
 	if len == s.len {

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -78,14 +78,15 @@ pub fn utf32_decode_to_buffer(code u32, mut buf &u8) int {
 // it is used in vlib/builtin/string.v,
 // and also in vlib/v/gen/c/cgen.v
 pub fn (_rune string) utf32_code() int {
-	return int(_rune.bytes().utf8_to_utf32() or {
-		// error('more than one utf-8 rune found in this string')
-		rune(0)
-	})
+	if res := _rune.bytes().utf8_to_utf32() {
+		return int(res)
+	}
+	return 0
 }
 
 // convert array of utf8 bytes to single utf32 value
 // will error if more than 4 bytes are submitted
+@[direct_array_access]
 pub fn (_bytes []u8) utf8_to_utf32() !rune {
 	if _bytes.len == 0 {
 		return 0

--- a/vlib/coroutines/coroutines.c.v
+++ b/vlib/coroutines/coroutines.c.v
@@ -113,6 +113,6 @@ fn init() {
 	}
 
 	if ret < 0 {
-		panic('failed to initialize coroutines via photon (ret=${ret})')
+		panic_n('failed to initialize coroutines via photon ret:', ret)
 	}
 }

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -72,7 +72,7 @@ pub fn (mut l Log) set_output_path(output_file_path string) {
 	l.output_target = .file
 	l.output_file_name = os.join_path(os.real_path(output_file_path), l.output_label)
 	ofile := os.open_append(l.output_file_name) or {
-		panic('error while opening log file ${l.output_file_name} for appending')
+		panic('error while opening log file ' + l.output_file_name + ' for appending')
 	}
 	l.ofile = ofile
 }
@@ -160,7 +160,7 @@ pub fn (mut l Log) fatal(s string) {
 		l.send_output(s, .fatal)
 		l.ofile.close()
 	}
-	panic('${l.output_label}: ${s}')
+	panic(l.output_label + ': ' + s)
 }
 
 // error logs line `s` via `send_output` if `Log.level` is greater than or equal to the `Level.error` category.

--- a/vlib/math/limit.v
+++ b/vlib/math/limit.v
@@ -36,7 +36,7 @@ pub fn maxof[T]() T {
 		}
 		return int(max_i32)
 	} $else {
-		panic('A maximum value of the type `${typeof[T]().name}` is not defined.')
+		panic('A maximum value of the type `' + typeof[T]().name + '` is not defined.')
 	}
 }
 
@@ -73,6 +73,6 @@ pub fn minof[T]() T {
 		}
 		return int(min_i32)
 	} $else {
-		panic('A minimum value of the type `${typeof[T]().name}` is not defined.')
+		panic('A minimum value of the type `' + typeof[T]().name + '` is not defined.')
 	}
 }

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -70,7 +70,7 @@ pub fn digits(num i64, params DigitParams) []int {
 	// set base to 10 initially and change only if base is explicitly set.
 	mut b := params.base
 	if b < 2 {
-		panic('digits: Cannot find digits of n with base ${b}')
+		panic_n('digits: Cannot find digits of n with base:', b)
 	}
 	mut n := num
 	mut sign := 1

--- a/vlib/net/address.c.v
+++ b/vlib/net/address.c.v
@@ -254,7 +254,7 @@ pub fn resolve_ipaddrs(addr string, family AddrFamily, typ SocketType) ![]Addr {
 				addresses << new_addr
 			}
 			else {
-				panic('Unexpected address family ${result.ai_family}')
+				panic('Unexpected address family ' + result.ai_family.str())
 			}
 		}
 	}

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -743,7 +743,7 @@ pub fn (h Header) join(other Header) Header {
 		for v in other.custom_values(k, exact: true) {
 			combined.add_custom(k, v) or {
 				// panic because this should never fail
-				panic('unexpected error: ${err}')
+				panic('unexpected error: ' + err.str())
 			}
 		}
 	}

--- a/vlib/os/file_le_be.c.v
+++ b/vlib/os/file_le_be.c.v
@@ -93,7 +93,7 @@ fn swap_bytes[T](input T) T {
 	} $else $if T is i64 {
 		return i64(swap_bytes_u64(u64(input)))
 	} $else {
-		panic('type is not supported: ${typeof[T]()}')
+		panic('type is not supported: ' + typeof[T]().str())
 	}
 }
 

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -606,7 +606,7 @@ pub fn read_file_array[T](path string) []T {
 	// On some systems C.ftell can return values in the 64-bit range
 	// that, when cast to `int`, can result in values below 0.
 	if i64(allocate) < fsize {
-		panic('${fsize} cast to int results in ${int(fsize)})')
+		panic_n2('cast to int results in (fsize, int(fsize)):', i64(fsize), i64(int(fsize)))
 	}
 	buf := unsafe {
 		malloc_noscan(allocate)

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -40,7 +40,7 @@ fn test_open_file() {
 	file.write_string(hello) or { panic(err) }
 	file.close()
 	assert u64(hello.len) == os.file_size(filename)
-	read_hello := os.read_file(filename) or { panic('error reading file ${filename}') }
+	read_hello := os.read_file(filename) or { panic('error reading file ' + filename) }
 	assert hello == read_hello
 	os.rm(filename) or { panic(err) }
 }
@@ -80,7 +80,7 @@ fn test_open_file_binary() {
 	unsafe { file.write_ptr(bytes.data, bytes.len) }
 	file.close()
 	assert u64(hello.len) == os.file_size(filename)
-	read_hello := os.read_bytes(filename) or { panic('error reading file ${filename}') }
+	read_hello := os.read_bytes(filename) or { panic('error reading file ' + filename) }
 	assert bytes == read_hello
 	os.rm(filename) or { panic(err) }
 }
@@ -160,7 +160,7 @@ fn test_write_and_read_string_to_file() {
 	hello := 'hello world!'
 	os.write_file(filename, hello) or { panic(err) }
 	assert u64(hello.len) == os.file_size(filename)
-	read_hello := os.read_file(filename) or { panic('error reading file ${filename}') }
+	read_hello := os.read_file(filename) or { panic('error reading file ' + filename) }
 	assert hello == read_hello
 	os.rm(filename) or { panic(err) }
 }
@@ -322,7 +322,7 @@ fn test_cp() {
 	old_file_name := 'cp_example.txt'
 	new_file_name := 'cp_new_example.txt'
 	os.write_file(old_file_name, 'Test data 1 2 3, V is awesome #$%^[]!~⭐') or { panic(err) }
-	os.cp(old_file_name, new_file_name) or { panic('${err}') }
+	os.cp(old_file_name, new_file_name) or { panic(err) }
 	old_file := os.read_file(old_file_name) or { panic(err) }
 	new_file := os.read_file(new_file_name) or { panic(err) }
 	assert old_file == new_file

--- a/vlib/os/process.c.v
+++ b/vlib/os/process.c.v
@@ -258,10 +258,10 @@ fn (mut p Process) _is_pending(pkind ChildProcessPipeKind) bool {
 // _check_redirection_call - should be called just by stdxxx methods
 fn (mut p Process) _check_redirection_call(fn_name string) {
 	if !p.use_stdio_ctl {
-		panic('Call p.set_redirect_stdio() before calling p.${fn_name}')
+		panic('Call p.set_redirect_stdio() before calling p.' + fn_name)
 	}
 	if p.status == .not_started {
-		panic('Call p.${fn_name}() after you have called p.run()')
+		panic('Call p.' + fn_name + '() after you have called p.run()')
 	}
 }
 

--- a/vlib/os/process_windows.c.v
+++ b/vlib/os/process_windows.c.v
@@ -198,7 +198,7 @@ fn (mut p Process) win_is_alive() bool {
 ///////////////
 
 fn (mut p Process) win_write_string(idx int, _s string) {
-	panic('Process.write_string ${idx} is not implemented yet')
+	panic_n('Process.write_string is not implemented yet, idx:', idx)
 }
 
 fn (mut p Process) win_read_string(idx int, _maxbytes int) (string, int) {

--- a/vlib/strconv/number_to_base.c.v
+++ b/vlib/strconv/number_to_base.c.v
@@ -8,7 +8,7 @@ const base_digits = '0123456789abcdefghijklmnopqrstuvwxyz'
 pub fn format_int(n i64, radix int) string {
 	unsafe {
 		if radix < 2 || radix > 36 {
-			panic('invalid radix: ${radix} . It should be => 2 and <= 36')
+			panic_n('invalid radix, it should be => 2 and <= 36, actual:', radix)
 		}
 		if n == 0 {
 			return '0'
@@ -45,7 +45,7 @@ pub fn format_int(n i64, radix int) string {
 pub fn format_uint(n u64, radix int) string {
 	unsafe {
 		if radix < 2 || radix > 36 {
-			panic('invalid radix: ${radix} . It should be => 2 and <= 36')
+			panic_n('invalid radix, it should be => 2 and <= 36, actual:', radix)
 		}
 		if n == 0 {
 			return '0'

--- a/vlib/strconv/vprintf.c.v
+++ b/vlib/strconv/vprintf.c.v
@@ -551,7 +551,8 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 	}
 
 	if p_index != pt.len {
-		panic('${p_index} % conversion specifiers, but given ${pt.len} args')
+		panic_n2('% conversion specifiers number mismatch (expected %, given args)', p_index,
+			pt.len)
 	}
 
 	return res.str()
@@ -560,7 +561,8 @@ pub fn v_sprintf(str string, pt ...voidptr) string {
 @[inline]
 fn v_sprintf_panic(idx int, len int) {
 	if idx >= len {
-		panic('${idx + 1} % conversion specifiers, but given only ${len} args')
+		panic_n2('% conversion specifiers number mismatch (expected %, given args)', idx + 1,
+			len)
 	}
 }
 

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -523,6 +523,9 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 	if table.used_features.range_index {
 		walker.fn_by_name(string_idx_str + '.substr')
 	}
+	if walker.as_cast_type_names.len > 0 {
+		walker.fn_by_name('new_array_from_c_array')
+	}
 
 	table.used_features.used_fns = walker.used_fns.move()
 	table.used_features.used_consts = walker.used_consts.move()

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -520,6 +520,10 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 		}
 	}
 
+	if table.used_features.range_index {
+		walker.fn_by_name(string_idx_str + '.substr')
+	}
+
 	table.used_features.used_fns = walker.used_fns.move()
 	table.used_features.used_consts = walker.used_consts.move()
 	table.used_features.used_globals = walker.used_globals.move()

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -69,7 +69,7 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 		if pref_.autofree {
 			core_fns << string_idx_str + '.clone_static'
 		}
-		if table.used_features.as_cast || table.used_features.auto_str || pref_.is_shared {
+		if table.used_features.auto_str || pref_.is_shared {
 			include_panic_deps = true
 			core_fns << 'isnil'
 			core_fns << '__new_array'
@@ -133,15 +133,8 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 		if table.used_features.arr_last {
 			core_fns << array_idx_str + '.last'
 		}
-		if table.used_features.arr_delete {
-			include_panic_deps = true
-		}
 		if table.used_features.arr_insert {
 			core_fns << ref_array_idx_str + '.insert_many'
-		}
-		if pref_.ccompiler_type != .tinyc && 'no_backtrace' !in pref_.compile_defines {
-			// with backtrace on gcc/clang more code needs be generated
-			include_panic_deps = true
 		}
 		if table.used_features.interpolation {
 			include_panic_deps = true

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -735,7 +735,17 @@ pub fn (mut w Walker) or_block(node ast.OrExpr) {
 }
 
 pub fn (mut w Walker) as_cast(node ast.AsCast) {
-	if node.typ.has_flag(.generic) || node.expr_type.has_flag(.generic) {
+	if node.typ == 0 {
+		return
+	}
+	if node.typ.has_flag(.generic) {
+		w.as_cast_type_names['some_generic_type'] = 'some_generic_name'
+		return
+	}
+	if node.expr_type == 0 {
+		return
+	}
+	if node.expr_type.has_flag(.generic) {
 		w.as_cast_type_names['some_generic_type'] = 'some_generic_name'
 		return
 	}

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -367,6 +367,10 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 				w.features.used_maps++
 			} else if sym.kind == .array {
 				w.features.used_arrays++
+			} else if sym.kind == .string {
+				if node.index is ast.RangeExpr {
+					w.features.range_index = true
+				}
 			}
 		}
 		ast.InfixExpr {

--- a/vlib/vweb/assets/assets.v
+++ b/vlib/vweb/assets/assets.v
@@ -188,7 +188,7 @@ pub fn (mut am AssetManager) add(asset_type string, file string) bool {
 	} else if asset_type == 'js' {
 		am.js << asset
 	} else {
-		panic('${unknown_asset_type_error} (${asset_type}).')
+		panic(unknown_asset_type_error + ' ' + asset_type + ' .')
 	}
 	return true
 }
@@ -205,7 +205,7 @@ fn (am AssetManager) exists(asset_type string, file string) bool {
 
 fn (am AssetManager) get_assets(asset_type string) []Asset {
 	if asset_type != 'css' && asset_type != 'js' {
-		panic('${unknown_asset_type_error} (${asset_type}).')
+		panic(unknown_asset_type_error + ' ' + asset_type + ' .')
 	}
 	assets := if asset_type == 'css' { am.css } else { am.js }
 	return assets

--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -1124,6 +1124,6 @@ pub fn string_buffer_to_generic_number[T](result &T, data []u8) {
 		}
 		*result = T(enumeration)
 	} $else {
-		panic('unsupported type ${typeof[T]().name}')
+		panic('unsupported type ' + typeof[T]().name)
 	}
 }

--- a/vlib/x/json2/strict/strict.v
+++ b/vlib/x/json2/strict/strict.v
@@ -39,7 +39,7 @@ pub fn strict_check[T](json_data string) StructCheckResult {
 				field_name := field.name
 				last_key := arrays.find_last(key_struct, fn [field_name] (k KeyStruct) bool {
 					return k.key == field_name
-				}) or { panic('${field.name} not found') }
+				}) or { panic('field not found: ' + field.name) }
 
 				// TODO: get path here from `last_key.key`
 				if last_key.value_type == .map {


### PR DESCRIPTION
With this PR, clang/gcc should also get smaller inputs, so should work a bit faster for smaller .v programs (like most tests):
![image](https://github.com/user-attachments/assets/5b062c1b-0f6c-4405-aaf3-f321fa350e32)

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdhNjljNmYxNDRmNTg1YWU1MjhkODYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.MnNgV13pBhq1JLHCMynjbbDT_H_dialjsldKpb9jSFk">Huly&reg;: <b>V_0.6-21811</b></a></sub>