### PR TITLE
cgen: fix codegen for sumtype casting on selector on as cast with field non ptr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2713,9 +2713,9 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:
 			if expr.is_as_cast() {
-				if got_is_ptr && expr is ast.SelectorExpr {
+				if !got_is_ptr && expr is ast.SelectorExpr {
 					// (var as Type).field_non_ptr
-					// g.write('&')
+					g.write('&')
 				}
 				old_inside_smartcast := g.inside_smartcast
 				g.inside_smartcast = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2713,6 +2713,10 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp_is_ptr
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
 			// another duplicate with the HEAP macro is redundant, so use ADDR instead:
 			if expr.is_as_cast() {
+				if got_is_ptr && expr is ast.SelectorExpr {
+					// (var as Type).field_non_ptr
+					// g.write('&')
+				}
 				old_inside_smartcast := g.inside_smartcast
 				g.inside_smartcast = true
 				defer {

--- a/vlib/v/tests/selector_as_cast_test.v
+++ b/vlib/v/tests/selector_as_cast_test.v
@@ -1,0 +1,26 @@
+struct Foo {
+	expr SumType
+}
+
+struct Bar {
+	expr SumType
+}
+
+type SumType = Foo | string | Bar
+type SumType2 = SumType | int
+
+struct Gen {}
+
+fn (g Gen) t(arg SumType2) {
+}
+
+fn test_main() {
+	gen := Gen{}
+	s := Bar{
+		expr: Foo{
+			expr: 'foobar'
+		}
+	}
+	gen.t((s.expr as Foo).expr)
+	assert true
+}


### PR DESCRIPTION
Fix #23387 