### PR TITLE
cgen: fix generic alias option assigning

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5223,7 +5223,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 					g.writeln('_option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
 					g.write2(cur_stmt, tmp_var)
 				} else if node.expr_type.has_flag(.option) {
-					g.expr_opt_with_cast(node.expr, expr_type, node.typ)
+					g.expr_opt_with_alias(node.expr, expr_type, node.typ)
 				} else {
 					g.expr_with_opt(node.expr, expr_type, node.typ)
 				}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2771,8 +2771,8 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 		g.write('->val')
 		return
 	} else if expected_type.has_flag(.option) {
-		if arg_sym.info is ast.Alias && expected_type != arg_typ {
-			g.expr_opt_with_alias(arg.expr, arg_typ, expected_type, '')
+		if (arg_sym.info is ast.Alias || exp_sym.info is ast.Alias) && expected_type != arg_typ {
+			g.expr_opt_with_alias(arg.expr, arg_typ, expected_type)
 		} else {
 			g.expr_with_opt(arg.expr, arg_typ, expected_type)
 		}

--- a/vlib/v/tests/options/option_generic_alias_test.v
+++ b/vlib/v/tests/options/option_generic_alias_test.v
@@ -1,0 +1,17 @@
+type I64 = i64
+
+fn test[T](a ?T) ?T {
+	w := ?T(a)
+	return w
+}
+
+fn test_main() {
+	a := ?i64(123)
+	b := test[I64](a)
+	println(b)
+	assert b != none
+	assert b? == 123
+	c := test[I64](none)
+	println(c)
+	assert c == none
+}


### PR DESCRIPTION
Fix #23382

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdjMmNmOGYxNDRmNTg1YWU1MmU3NDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.lkUwounqQaCE_jaXFViDCAZAdYlfTgDJCTMtf7NufSM">Huly&reg;: <b>V_0.6-21824</b></a></sub>