### PR TITLE
cgen: fix codegen for selector on shared var with embed

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4120,16 +4120,6 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if is_as_cast {
 		g.write(')')
 	}
-
-	left_is_shared := node.expr_type.has_flag(.shared_f)
-	alias_to_ptr := sym.info is ast.Alias && sym.info.parent_type.is_ptr()
-	is_dereferenced := node.expr is ast.SelectorExpr && node.expr.expr_type.is_ptr()
-		&& !node.expr.typ.is_ptr() && final_sym.kind in [.interface, .sum_type]
-	left_is_ptr := field_is_opt
-		|| (((!is_dereferenced && unwrapped_expr_type.is_ptr()) || sym.kind == .chan
-		|| alias_to_ptr) && node.from_embed_types.len == 0)
-		|| (node.expr.is_as_cast() && g.inside_smartcast)
-
 	// struct embedding
 	mut has_embed := false
 	if sym.info in [ast.Struct, ast.Aggregate] {
@@ -4165,6 +4155,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			g.write_selector_expr_embed_name(node, node.from_embed_types)
 		}
 	}
+	left_is_shared := node.expr_type.has_flag(.shared_f)
+	alias_to_ptr := sym.info is ast.Alias && sym.info.parent_type.is_ptr()
+	is_dereferenced := node.expr is ast.SelectorExpr && node.expr.expr_type.is_ptr()
+		&& !node.expr.typ.is_ptr() && final_sym.kind in [.interface, .sum_type]
+	left_is_ptr := field_is_opt
+		|| (((!is_dereferenced && unwrapped_expr_type.is_ptr()) || sym.kind == .chan
+		|| alias_to_ptr) && node.from_embed_types.len == 0)
+		|| (node.expr.is_as_cast() && g.inside_smartcast)
 	if !has_embed && left_is_ptr {
 		g.write('->')
 	} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4155,7 +4155,6 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			g.write_selector_expr_embed_name(node, node.from_embed_types)
 		}
 	}
-	left_is_shared := node.expr_type.has_flag(.shared_f)
 	alias_to_ptr := sym.info is ast.Alias && sym.info.parent_type.is_ptr()
 	is_dereferenced := node.expr is ast.SelectorExpr && node.expr.expr_type.is_ptr()
 		&& !node.expr.typ.is_ptr() && final_sym.kind in [.interface, .sum_type]
@@ -4168,7 +4167,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	} else {
 		g.write('.')
 	}
-	if !has_embed && left_is_shared {
+	if !has_embed && node.expr_type.has_flag(.shared_f) {
 		g.write('val.')
 	}
 	if node.expr_type == 0 {

--- a/vlib/v/tests/concurrency/selector_shared_var_test.v
+++ b/vlib/v/tests/concurrency/selector_shared_var_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+mut:
+	foo string
+}
+
+struct Bar {
+	Foo
+}
+
+fn test_main() {
+	shared bar := Bar{}
+	rlock bar {
+		assert bar.foo == ''
+	}
+}


### PR DESCRIPTION
Fix #23378

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdjNDcyZGYxNDRmNTg1YWU1MmU4OGIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.2f-rMxEBGbcMvBLC0gUyo0jheE9dajlQAECUtM123Co">Huly&reg;: <b>V_0.6-21825</b></a></sub>