### PR TITLE
parser: allow map cast syntax `map[k]v(expr)`

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2719,10 +2719,23 @@ fn (mut p Parser) name_expr() ast.Expr {
 		if is_option {
 			map_type = map_type.set_flag(.option)
 		}
-		return ast.MapInit{
+		node = ast.MapInit{
 			typ: map_type
 			pos: pos
 		}
+		if p.tok.kind == .lpar {
+			// ?map[int]int(none) cast expr
+			p.check(.lpar)
+			expr := p.expr(0)
+			p.check(.rpar)
+			return ast.CastExpr{
+				typ:     map_type
+				typname: p.table.sym(map_type).name
+				expr:    expr
+				pos:     pos.extend(p.tok.pos())
+			}
+		}
+		return node
 	}
 	// `chan typ{...}`
 	if p.tok.lit == 'chan' {

--- a/vlib/v/tests/map_cast_test.v
+++ b/vlib/v/tests/map_cast_test.v
@@ -1,0 +1,25 @@
+fn foo() map[int]int {
+	return {
+		1: 2
+	}
+}
+
+fn test_main() {
+	a := ?map[int]int(none)
+	assert a == none
+
+	b := ?map[int]int({
+		1: 2
+	})
+	assert b?[1] == 2
+
+	c := ?map[int]map[string]string({
+		1: {
+			'foo': 'bar'
+		}
+	})
+	assert c?[1]['foo'] == 'bar'
+
+	d := ?map[int]int(foo())
+	assert d?[1] == 2
+}


### PR DESCRIPTION
Allow

```v
fn foo() map[int]int {
	return {
		1: 2
	}
}

fn test_main() {
	a := ?map[int]int(none)
	assert a == none

	b := ?map[int]int({
		1: 2
	})
	assert b?[1] == 2

	c := ?map[int]map[string]string({
		1: {
			'foo': 'bar'
		}
	})
	assert c?[1]['foo'] == 'bar'

	d := ?map[int]int(foo())
	assert d?[1] == 2
}
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdkNWRkOGYxNDRmNTg1YWU1MzE0MTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.sszAYnovv-8EKL6B89JWetKkXtyKLmBO7HUxjFs4gMs">Huly&reg;: <b>V_0.6-21832</b></a></sub>