### PR TITLE
crypto.ecdsa: expand ecdsa module to support another curve.

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -250,6 +250,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 			skip_files << 'examples/websocket/client-server/server.v' // requires OpenSSL
 			skip_files << 'vlib/v/tests/websocket_logger_interface_should_compile_test.v' // requires OpenSSL
 			skip_files << 'vlib/crypto/ecdsa/ecdsa_test.v' // requires OpenSSL
+			skip_files << 'vlib/crypto/ecdsa/util_test.v' // requires OpenSSL
 			$if tinyc {
 				skip_files << 'examples/database/orm.v' // try fix it
 			}
@@ -280,13 +281,15 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		}
 		if github_job == 'docker-ubuntu-musl' {
 			skip_files << 'vlib/net/openssl/openssl_compiles_test.c.v'
-			skip_files << 'vlib/crypto/ecdsa/ecdsa_test.v'
+			skip_files << 'vlib/crypto/ecdsa/ecdsa_test.v' // requires OpenSSL
+			skip_files << 'vlib/crypto/ecdsa/util_test.v' // requires OpenSSL
 			skip_files << 'vlib/x/ttf/ttf_test.v'
 			skip_files << 'vlib/encoding/iconv/iconv_test.v' // needs libiconv to be installed
 		}
 		if github_job == 'tests-sanitize-memory-clang' {
 			skip_files << 'vlib/net/openssl/openssl_compiles_test.c.v'
-			skip_files << 'vlib/crypto/ecdsa/ecdsa_test.v'
+			skip_files << 'vlib/crypto/ecdsa/ecdsa_test.v' // requires OpenSSL
+			skip_files << 'vlib/crypto/ecdsa/util_test.v' // requires OpenSSL
 			// Fails compilation with: `/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line`
 			skip_files << 'examples/sokol/sounds/simple_sin_tones.v'
 		}

--- a/vlib/crypto/ecdsa/README.md
+++ b/vlib/crypto/ecdsa/README.md
@@ -5,4 +5,4 @@ Its currently (expanded) to support the following curves:
 - NIST P-256 curve, commonly referred as prime256v1 or secp256r1
 - NIST P-384 curve, commonly referred as secp384r1 
 - NIST P-521 curve, commonly referred as secp521r1
-- A famous BITCOIN curve, commonly referred as secp256k1
+- A famous Bitcoin curve, commonly referred as secp256k1

--- a/vlib/crypto/ecdsa/README.md
+++ b/vlib/crypto/ecdsa/README.md
@@ -1,0 +1,8 @@
+## ecdsa
+
+`ecdsa` module for V language. Its a wrapper on top of openssl ecdsa functionality.
+Its currently (expanded) to support the following curves:
+- NIST P-256 curve, commonly referred as prime256v1 or secp256r1
+- NIST P-384 curve, commonly referred as secp384r1 
+- NIST P-521 curve, commonly referred as secp521r1
+- A famous BITCOIN curve, commonly referred as secp256k1

--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -69,7 +69,8 @@ pub enum Nid {
 }
 
 @[params]
-struct CurveOptions {
+pub struct CurveOptions {
+pub mut:
 	nid Nid = .prime256v1 // default to NIST P-256 curve
 }
 
@@ -344,7 +345,7 @@ pub enum HashConfig {
 
 @[params]
 pub struct SignerOpts {
-mut:
+pub mut:
 	hash_config HashConfig = .with_recomended_hash
 	// make sense when HashConfig != with_recomended_hash
 	allow_smaller_size bool

--- a/vlib/crypto/ecdsa/ecdsa_test.v
+++ b/vlib/crypto/ecdsa/ecdsa_test.v
@@ -146,5 +146,3 @@ fn test_different_keys_not_equal() ! {
 	key_free(priv_key1.key)
 	key_free(priv_key2.key)
 }
-
-// Example was taken from https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/P384_SHA384.pdf

--- a/vlib/crypto/ecdsa/ecdsa_test.v
+++ b/vlib/crypto/ecdsa/ecdsa_test.v
@@ -15,6 +15,25 @@ fn test_ecdsa() {
 	key_free(priv_key.key)
 }
 
+// This test should exactly has the same behaviour with default sign(message),
+// because we passed .with_no_hash flag as an option.
+fn test_ecdsa_signing_with_options() {
+	// Generate key pair
+	pub_key, priv_key := generate_key() or { panic(err) }
+
+	// Sign a message
+	message := 'Hello, ECDSA!'.bytes()
+	opts := SignerOpts{
+		hash_config: .with_no_hash
+	}
+	signature := priv_key.sign_with_options(message, opts) or { panic(err) }
+
+	// Verify the signature
+	is_valid := pub_key.verify(message, signature) or { panic(err) }
+	println('Signature valid: ${is_valid}')
+	assert is_valid
+}
+
 fn test_generate_key() ! {
 	// Test key generation
 	pub_key, priv_key := generate_key() or { panic(err) }
@@ -71,6 +90,15 @@ fn test_private_key_equal() ! {
 	key_free(priv_key2.key)
 }
 
+fn test_private_key_equality_on_different_curve() ! {
+	// default group
+	_, priv_key1 := generate_key() or { panic(err) }
+	seed := priv_key1.seed() or { panic(err) }
+	// using different group
+	priv_key2 := new_key_from_seed(seed, nid: .secp384r1) or { panic(err) }
+	assert !priv_key1.equal(priv_key2)
+}
+
 fn test_public_key_equal() ! {
 	// Test public key equality
 	_, priv_key := generate_key() or { panic(err) }
@@ -118,3 +146,5 @@ fn test_different_keys_not_equal() ! {
 	key_free(priv_key1.key)
 	key_free(priv_key2.key)
 }
+
+// Example was taken from https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/P384_SHA384.pdf

--- a/vlib/crypto/ecdsa/util.v
+++ b/vlib/crypto/ecdsa/util.v
@@ -1,0 +1,138 @@
+module ecdsa
+
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+// #define NID_X9_62_id_ecPublicKey                408
+const nid_ec_publickey = C.NID_X9_62_id_ecPublicKey
+
+@[typedef]
+struct C.EVP_PKEY {}
+
+// EVP_PKEY *EVP_PKEY_new(void);
+fn C.EVP_PKEY_new() &C.EVP_PKEY
+
+// EVP_PKEY_free(EVP_PKEY *key);
+fn C.EVP_PKEY_free(key &C.EVP_PKEY)
+
+// EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey);
+fn C.EVP_PKEY_get1_EC_KEY(pkey &C.EVP_PKEY) &C.EC_KEY
+
+// EVP_PKEY *d2i_PUBKEY(EVP_PKEY **a, const unsigned char **pp, long length);
+fn C.d2i_PUBKEY(mut k &C.EVP_PKEY, pp &u8, length u32) &C.EVP_PKEY
+
+// point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
+fn C.EC_KEY_get_conv_form(k &C.EC_KEY) int
+
+// EC_GROUP_get_degree
+fn C.EC_GROUP_get_degree(g &C.EC_GROUP) int
+
+// const EC_POINT *EC_KEY_get0_public_key(const EC_KEY *key);
+fn C.EC_KEY_get0_public_key(key &C.EC_KEY) &C.EC_POINT
+
+// size_t EC_POINT_point2oct(const EC_GROUP *group, const EC_POINT *point, point_conversion_form_t form, uint8_t *buf, size_t max_out, BN_CTX *ctx);
+fn C.EC_POINT_point2oct(g &C.EC_GROUP, p &C.EC_POINT, form int, buf &u8, max_out int, ctx &C.BN_CTX) int
+
+// int EVP_PKEY_get_base_id(const EVP_PKEY *pkey);
+fn C.EVP_PKEY_base_id(key &C.EVP_PKEY) int
+
+// int EC_GROUP_get_curve_name(const EC_GROUP *group);
+fn C.EC_GROUP_get_curve_name(g &C.EC_GROUP) int
+fn C.EC_GROUP_free(group &C.EC_GROUP)
+
+// pubkey_from_bytes loads ECDSA Public Key from bytes array.
+// The bytes of data should be a valid of ASN.1 DER serialized SubjectPublicKeyInfo structrue of RFC 5480.
+// Otherwise, its should an error.
+// Typically, you can load the bytes from pem formatted of ecdsa public key.
+//
+// Examples:
+// ```codeblock
+// import crypto.pem
+//
+// const pubkey_sample = '-----BEGIN PUBLIC KEY-----
+// MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+P3rhFkT1fXHYbY3CpcBdh6xTC74MQFx
+// cftNVD3zEPVzo//OalIVatY162ksg8uRWBdvFFuHZ9OMVXkbjwWwhcXP7qmI9rOS
+// LR3AGUldy+bBpV2nT306qCIwgUAMeOJP
+// -----END PUBLIC KEY-----'
+//
+// block, _ := pem.decode(pubkey_sample) or { panic(err) }
+// pubkey := pubkey_from_bytes(block.data)!
+// ```
+pub fn pubkey_from_bytes(bytes []u8) !PublicKey {
+	if bytes.len == 0 {
+		return error('Invalid bytes')
+	}
+	mut pub_key := C.EVP_PKEY_new()
+	pub_key = C.d2i_PUBKEY(mut &pub_key, &bytes.data, bytes.len)
+	if pub_key == 0 {
+		C.EVP_PKEY_free(pub_key)
+		return error('Error loading public key')
+	}
+	// Get the NID of this pubkey, and check if the pubkey object was
+	// have the correct NID of ec public key type, ie, NID_X9_62_id_ecPublicKey
+	nid := C.EVP_PKEY_base_id(pub_key)
+	if nid != nid_ec_publickey {
+		C.EVP_PKEY_free(pub_key)
+		return error('Get an nid of non ecPublicKey')
+	}
+
+	eckey := C.EVP_PKEY_get1_EC_KEY(pub_key)
+	if eckey == 0 {
+		C.EC_KEY_free(eckey)
+		return error('Failed to get ec key')
+	}
+	// check the group for the supported curve(s)
+	group := C.EC_KEY_get0_group(eckey)
+	if group == 0 {
+		C.EC_GROUP_free(group)
+		return error('Failed to load group from key')
+	}
+	nidgroup := C.EC_GROUP_get_curve_name(group)
+	if nidgroup != nid_prime256v1 && nidgroup != nid_secp384r1 && nidgroup != nid_secp521r1
+		&& nidgroup != nid_secp256k1 {
+		return error('Unsupported group')
+	}
+	// Its OK to return
+	return PublicKey{
+		key: eckey
+	}
+}
+
+// bytes gets the bytes of public key parts of this keypair.
+pub fn (pbk PublicKey) bytes() ![]u8 {
+	point := C.EC_KEY_get0_public_key(pbk.key)
+	if point == 0 {
+		C.EC_POINT_free(point)
+		return error('Failed to get public key BIGNUM')
+	}
+
+	group := C.EC_KEY_get0_group(pbk.key)
+	num_bits := C.EC_GROUP_get_degree(group)
+	// 1 byte of conversion format || x || y of EC_POINT
+	num_bytes := 1 + 2 * ((num_bits + 7) / 8)
+
+	ctx := C.BN_CTX_new()
+	defer {
+		C.BN_CTX_free(ctx)
+	}
+
+	if ctx == 0 {
+		C.EC_POINT_free(point)
+		C.BN_CTX_free(ctx)
+		return error('Failed to create BN_CTX')
+	}
+	mut buf := []u8{len: num_bytes}
+
+	// Get conversion format.
+	// The uncompressed form is indicated by 0x04 and the compressed form is indicated
+	// by either 0x02 or 0x03, hybrid 0x06
+	// The public key MUST be rejected if any other value is included in the first octet.
+	conv_form := C.EC_KEY_get_conv_form(pbk.key)
+	if conv_form !in [2, 3, 4, 6] {
+		return error('bad conversion format')
+	}
+	n := C.EC_POINT_point2oct(group, point, conv_form, buf.data, buf.len, ctx)
+
+	// returns the clone of the buffer[..n]
+	return buf[..n].clone()
+}

--- a/vlib/crypto/ecdsa/util_test.v
+++ b/vlib/crypto/ecdsa/util_test.v
@@ -35,3 +35,14 @@ fn test_load_pubkey_from_der_serialized_bytes() ! {
 	status_with_hashed := pbkey.verify(hashed_msg, expected_signature)!
 	assert status_with_hashed == true
 }
+
+fn test_for_pubkey_bytes() ! {
+	// material generated with online ecdsa generator https://emn178.github.io/online-tools/ecdsa/key-generator/
+	pv := '62e998bea8a15f52ff0b76cf3fe281cfcd8042ce4479b6e652ca7b5a36f6fb40'
+	pb := '0421af184ac64c8a13e66c65d4f1ad31677edeaa97af791aef73b66ea26d1623a411f67b6c4d842ba22fa39d1216bd64acef00a1b924ac11a10af679ac3a7eb2fd'
+	pvkey := new_key_from_seed(hex.decode(pv)!)!
+
+	assert pvkey.seed()!.hex() == pv
+	pbkey := pvkey.public_key()!
+	assert pbkey.bytes()!.hex() == pb
+}

--- a/vlib/crypto/ecdsa/util_test.v
+++ b/vlib/crypto/ecdsa/util_test.v
@@ -1,0 +1,37 @@
+module ecdsa
+
+import encoding.hex
+import crypto.pem
+import crypto.sha512
+
+// This material wss generated with https://emn178.github.io/online-tools/ecdsa/key-generator
+// with curve SECG secp384r1 aka NIST P-384
+const privatekey_sample = '-----BEGIN PRIVATE KEY-----
+MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDAwzj2iiJZaxgk/C6mp
+oVskdr6j7akl4bPB8JRnT1J5XNbLPK/iNd/BW+xUJEj/pxWhZANiAAT4/euEWRPV
+9cdhtjcKlwF2HrFMLvgxAXFx+01UPfMQ9XOj/85qUhVq1jXraSyDy5FYF28UW4dn
+04xVeRuPBbCFxc/uqYj2s5ItHcAZSV3L5sGlXadPfTqoIjCBQAx44k8=
+-----END PRIVATE KEY-----'
+
+const public_key_sample = '-----BEGIN PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+P3rhFkT1fXHYbY3CpcBdh6xTC74MQFx
+cftNVD3zEPVzo//OalIVatY162ksg8uRWBdvFFuHZ9OMVXkbjwWwhcXP7qmI9rOS
+LR3AGUldy+bBpV2nT306qCIwgUAMeOJP
+-----END PUBLIC KEY-----'
+
+// Message tobe signed and verified
+const message_tobe_signed = 'Example of ECDSA with P-384'
+// Message signature created with SHA384 digest with associated above key
+const expected_signature = hex.decode('3066023100b08f6ec77bb319fdb7bce55a2714d7e79cc645d834ee539d8903cfcc88c6fa90df1558856cb840b2dd82e82cd89d7046023100d9d482ca8a6545a3b081fbdd4bb9643a2b4eda4e21fd624833216596032471faae646891f8d2f0bbb86b796c36d3c390')!
+
+fn test_load_pubkey_from_der_serialized_bytes() ! {
+	block, _ := pem.decode(public_key_sample) or { panic(err) }
+	pbkey := pubkey_from_bytes(block.data)!
+
+	status_without_hashed := pbkey.verify(message_tobe_signed.bytes(), expected_signature)!
+	assert status_without_hashed == false
+
+	hashed_msg := sha512.sum384(message_tobe_signed.bytes())
+	status_with_hashed := pbkey.verify(hashed_msg, expected_signature)!
+	assert status_with_hashed == true
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

There are lack of functionality commonly
needed in the `crypto.ecdsa` module.
Some of them are

- Currently, only support for NIST  P-256 curve, we need more curve on the stock.
- Current `ecdaa.PrivateKey.sign(message)`  does not work on hash (digest) of the message, but its work on message directly.. Its not recommended working on signing messages directly.

This PR  address some of them issue,  by adding and expand support for another popular ecc curve, ie,

- Add support for NIST P-384, ie, `secp384r1` curve
- Add support for NIST P-521, ie, `secp521r1` curve
- Add support for famous `|secp256k1` curve used in bitcoin ecosystem.

This PR also add a routine to sign message with options to use irecommended hash function or custom hash (maybe its can be unified with the current sign routine)

This PR also add a routine to load a public key part from bytes array, commonly parsed from pem-formatted public key file.

This PR was a first time i was working with c wrapping, so, i'm totally noob in the sense, please give its a review.