### PR TITLE
cgen: fix codegen for nested selectorexpr on unwrapped option

### DIFF
--- a/vlib/v/tests/options/option_selector_nested_unwrapped_test.v
+++ b/vlib/v/tests/options/option_selector_nested_unwrapped_test.v
@@ -1,0 +1,44 @@
+module main
+
+interface IGameObject {
+mut:
+	name     string
+	parent   ?&IGameObject
+	children []&IGameObject
+	add_child(mut o IGameObject)
+	advance()
+}
+
+@[heap]
+struct GameObject implements IGameObject {
+mut:
+	name     string
+	parent   ?&IGameObject
+	children []&IGameObject
+}
+
+fn (mut gameobject GameObject) add_child(mut o IGameObject) {
+	o.parent = &gameobject
+	gameobject.children << o
+}
+
+fn (mut gameobject GameObject) advance() {
+	if gameobject.parent != none {
+		eprintln('parent:  ${gameobject.parent.name} ')
+	}
+	for mut child in gameobject.children {
+		child.advance()
+	}
+}
+
+fn test_main() {
+	mut v1 := &GameObject{
+		name: 'v1'
+	}
+	mut v2 := &GameObject{
+		name: 'v2'
+	}
+	v1.add_child(mut v2)
+	v1.advance()
+	assert true
+}


### PR DESCRIPTION
Fix #23406

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdlNmYzMGYxNDRmNTg1YWU1MzM3NmMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.L_YHUEgeus099xxT6LLHzkDVVBR5PBOpy33vzHrCObg">Huly&reg;: <b>V_0.6-21840</b></a></sub>