### PR TITLE
cgen: fix shared array indexing

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -372,6 +372,9 @@ fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		} else {
 			g.expr(node.left)
 		}
+		if node.left_type.has_flag(.shared_f) {
+			g.write('.val')
+		}
 	}
 	g.write('[')
 	if g.is_direct_array_access || g.pref.translated || node.index is ast.IntegerLiteral {

--- a/vlib/v/tests/concurrency/shared_array_indexing_test.v
+++ b/vlib/v/tests/concurrency/shared_array_indexing_test.v
@@ -1,0 +1,18 @@
+struct Foo {
+mut:
+	bar shared [10]bool
+}
+
+fn test_main() {
+	mut a := Foo{
+		bar: [10]bool{}
+	}
+	lock a.bar {
+		a.bar[0] = true
+		a.bar[1] = false
+	}
+	rlock a.bar {
+		assert a.bar[0] == true
+		assert a.bar[1] == false
+	}
+}


### PR DESCRIPTION
Fix #23410

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdlZjFlN2YxNDRmNTg1YWU1MzRmZjIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.QsO_7z6jrGq391oBYhtRBkklgVa82pdckKruLuG19Ko">Huly&reg;: <b>V_0.6-21844</b></a></sub>