### PR TITLE
cgen: fix shared array fixed initializing with `-cstrict`

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -498,15 +498,21 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 		g.write(g.type_default_sumtype(field.typ, sym))
 		return true
 	} else if sym.info is ast.ArrayFixed {
+		elem_is_option := sym.info.elem_type.has_flag(.option)
 		g.write('{')
-		for i in 0 .. sym.info.size {
-			if sym.info.elem_type.has_flag(.option) {
-				g.expr_with_opt(ast.None{}, ast.none_type, sym.info.elem_type)
-			} else {
-				g.write(g.type_default(sym.info.elem_type))
-			}
-			if i != sym.info.size - 1 {
-				g.write(', ')
+		if !elem_is_option && field.typ.has_flag(.shared_f) {
+			g.write('0')
+		} else {
+			default_str := g.type_default(sym.info.elem_type)
+			for i in 0 .. sym.info.size {
+				if elem_is_option {
+					g.gen_option_error(sym.info.elem_type, ast.None{})
+				} else {
+					g.write(default_str)
+				}
+				if i != sym.info.size - 1 {
+					g.write(', ')
+				}
 			}
 		}
 		g.write('}')

--- a/vlib/v/tests/concurrency/shared_fixed_array_init_test.v
+++ b/vlib/v/tests/concurrency/shared_fixed_array_init_test.v
@@ -1,0 +1,9 @@
+struct Foo {
+mut:
+	bar shared [1024]bool
+}
+
+fn test_main() {
+	_ := Foo{}
+	assert true
+}


### PR DESCRIPTION
Fix build of chip8-v project.

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdlZjdlNmYxNDRmNTg1YWU1MzUwNWEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.bKpKtrXElF6jPqHzmXx-kHvqWzddBIGUZosEK2KpOFE">Huly&reg;: <b>V_0.6-21845</b></a></sub>