### PR TITLE
cgen: fix codegen for array fixed comparison on MatchExpr

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -482,6 +482,9 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 					.array_fixed {
 						ptr_typ := g.equality_fn(node.cond_type)
 						g.write('${ptr_typ}_arr_eq(${cond_var}, ')
+						if expr is ast.ArrayInit {
+							g.write('(${g.styp(node.cond_type)})')
+						}
 						g.expr(expr)
 						g.write(')')
 					}

--- a/vlib/v/tests/match_array_fixed_test.v
+++ b/vlib/v/tests/match_array_fixed_test.v
@@ -1,0 +1,14 @@
+fn test_main() {
+	on_event()
+}
+
+fn on_event() {
+	match [0, 0]! {
+		[0, 1]! {
+			assert false
+		}
+		else {
+			assert true
+		}
+	}
+}


### PR DESCRIPTION
Fix #23403