### PR TITLE
cgen: fix member call when arg variable has more than 1 indirection

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1879,7 +1879,15 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 				g.write('(*(${g.styp(fn_typ)}*)')
 			}
 		}
+		needs_deref := node.left_type.nr_muls() > 1
+		if needs_deref {
+			g.write('(')
+			g.write('*'.repeat(node.left_type.nr_muls() - 1))
+		}
 		g.expr(node.left)
+		if needs_deref {
+			g.write(')')
+		}
 		if node.left_type.is_ptr() {
 			g.write('->')
 		} else {

--- a/vlib/v/tests/fns/call_member_from_ptr_ptr_test.v
+++ b/vlib/v/tests/fns/call_member_from_ptr_ptr_test.v
@@ -1,0 +1,43 @@
+import gg
+
+pub type WindowResizeFn = fn (window &Window, w int, h int)
+
+@[heap]
+pub struct Window {
+	id string = '_window_'
+pub mut:
+	resize_fn WindowResizeFn = unsafe { nil }
+}
+
+@[params]
+pub struct WindowParams {
+pub:
+	on_resize WindowResizeFn = unsafe { nil }
+}
+
+fn window_resized(event gg.Event, mut w &Window) {
+	window_width, window_height := 200, 100
+
+	if w.resize_fn != WindowResizeFn(0) {
+		w.resize_fn(w, window_width, window_height)
+	}
+}
+
+fn on_event(e &gg.Event, mut w Window) {
+	window_resized(e, mut w)
+}
+
+fn on_resize(window &Window, w int, h int) {
+	assert w == 200
+	assert h == 100
+}
+
+fn test_main() {
+	e := gg.Event{}
+	mut w := &Window{
+		resize_fn: on_resize
+	}
+
+	on_event(e, mut w)
+	assert true
+}


### PR DESCRIPTION
Fix #23157

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzgxMGE5N2JjMjA5NGNjMDE4MmE5MjgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.bY08AN3_rJcbfVWZA_u1Rbw21BcGsApKd8b0iZC7g30">Huly&reg;: <b>V_0.6-21853</b></a></sub>