### PR TITLE
veb: add ctx.no_content() + prevent content-type being set if empty

### DIFF
--- a/vlib/veb/README.md
+++ b/vlib/veb/README.md
@@ -758,6 +758,8 @@ ctx.json(User{
 	name: 'test'
 	age: 20
 })
+// send response HTTP_NO_CONTENT (204) without a content-type and body
+ctx.no_content()
 ```
 
 #### Sending files

--- a/vlib/veb/context.v
+++ b/vlib/veb/context.v
@@ -99,7 +99,9 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, response strin
 
 	// set Content-Type and Content-Length headers
 	mut custom_mimetype := if ctx.content_type.len == 0 { mimetype } else { ctx.content_type }
-	ctx.res.header.set(.content_type, custom_mimetype)
+	if custom_mimetype.len != '' {
+		ctx.res.header.set(.content_type, custom_mimetype)
+	}
 	if ctx.res.body != '' {
 		ctx.res.header.set(.content_length, ctx.res.body.len.str())
 	}
@@ -223,6 +225,12 @@ pub fn (mut ctx Context) request_error(msg string) Result {
 pub fn (mut ctx Context) server_error(msg string) Result {
 	ctx.res.set_status(.internal_server_error)
 	return ctx.send_response_to_client('text/plain', msg)
+}
+
+// send a 204 No Content response without body and content-type
+pub fn (mut ctx Context) no_content() Result {
+	ctx.res.set_status(.no_content)
+	return ctx.send_response_to_client('', '')
 }
 
 @[params]

--- a/vlib/veb/context.v
+++ b/vlib/veb/context.v
@@ -99,7 +99,7 @@ pub fn (mut ctx Context) send_response_to_client(mimetype string, response strin
 
 	// set Content-Type and Content-Length headers
 	mut custom_mimetype := if ctx.content_type.len == 0 { mimetype } else { ctx.content_type }
-	if custom_mimetype.len != '' {
+	if custom_mimetype != '' {
 		ctx.res.header.set(.content_type, custom_mimetype)
 	}
 	if ctx.res.body != '' {


### PR DESCRIPTION
`veb` currently lacks a convenient way to return a **204 No Content** response without a body and no content-type header.

This PR adds such a method and prevents `ctx.send_response_to_client` to always set a content-type header, even if it is set to an empty string.

```
// send a 204 No Content response without body and content-type
pub fn (mut ctx Context) no_content() Result {
	ctx.res.set_status(.no_content)
	return ctx.send_response_to_client('', '')
}
```

Using `curl`, the response looks like this:

```
> GET / HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 204 No Content
< Server: veb
```

<sub><a href="https://huly.app/guest/vlang-66f40c4d-a476b54c67-771fdd?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzgxMWY5M2JjMjA5NGNjMDE4MmY1ZjgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctYWxleGFuZGVyLXZsYW5nLTY2ZjQwYzRkLWE0NzZiNTRjNjctNzcxZmRjIn0.e7wtb2UPXDc8ip-OJSr-DOUvfZRe2sssa7RuUaMYBjQ">Huly&reg;: <b>V_0.6-21855</b></a></sub>