### PR TITLE
checker: fix missing detection for `return` on lockexpr stmts

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -359,6 +359,8 @@ fn has_top_return(stmts []ast.Stmt) bool {
 					if stmt.expr.method_name == 'compile_error' {
 						return true
 					}
+				} else if stmt.expr is ast.LockExpr {
+					return has_top_return(stmt.expr.stmts)
 				}
 			}
 			else {}

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -360,7 +360,9 @@ fn has_top_return(stmts []ast.Stmt) bool {
 						return true
 					}
 				} else if stmt.expr is ast.LockExpr {
-					return has_top_return(stmt.expr.stmts)
+					if has_top_return(stmt.expr.stmts) {
+						return true
+					}
 				}
 			}
 			else {}

--- a/vlib/v/checker/tests/lockexpr_missing_return_err.out
+++ b/vlib/v/checker/tests/lockexpr_missing_return_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/lockexpr_missing_return_err.vv:4:1: error: missing return at end of function `baz`
+    2 | }
+    3 | 
+    4 | fn baz(shared foo Foo) int {
+      | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5 |     lock foo {
+    6 |     }

--- a/vlib/v/checker/tests/lockexpr_missing_return_err.vv
+++ b/vlib/v/checker/tests/lockexpr_missing_return_err.vv
@@ -1,0 +1,18 @@
+struct Foo {
+}
+
+fn baz(shared foo Foo) int {
+	lock foo {
+	}
+}
+
+fn bar(shared foo Foo) int {
+	lock foo {
+		return 1
+	}
+}
+
+fn main() {
+	shared foo := Foo{}
+	bar(shared foo)
+}


### PR DESCRIPTION
Fix #23434