### PR TITLE
db.pg: add support for prepared statements

### DIFF
--- a/vlib/db/pg/pg_test.v
+++ b/vlib/db/pg/pg_test.v
@@ -28,3 +28,16 @@ WHERE
 		row.str()
 	}
 }
+
+fn test_prepared() {
+	db := pg.connect(pg.Config{ user: 'postgres', password: 'secret', dbname: 'postgres' })!
+	defer {
+		db.close()
+	}
+
+	db.prepare('test_prepared', 'SELECT NOW(), $1 AS NAME', 1) or { panic(err) }
+
+	result := db.exec_prepared('test_prepared', ['hello world']) or { panic(err) }
+
+	assert result.len == 1
+}


### PR DESCRIPTION
PostgreSQL has two separate calls to support prepared statements. This PR adds the following two public functions to `db.pg`:

```vlang
pub fn (db DB) prepare(name string, query string, num_params int) !
pub fn (db DB) exec_prepared(name string, params []string) ![]Row
```

plus one to handle an empty result to check for an error when `prepare` is called.

Also an appropriate test has been added.