### PR TITLE
breaking,log: set stderr as default log output, add .set_output_stream()

### DIFF
--- a/vlib/log/README.md
+++ b/vlib/log/README.md
@@ -52,3 +52,22 @@ fn main() {
 	l.fatal('fatal') // panic, marked as [noreturn]
 }
 ```
+
+## Backwards compatibility
+
+After 2025/01/21, the `log` module outputs to `stderr` by default.
+Before that, it used `stdout` by default.
+
+If you want to restore the previous behaviour, you have to explicitly call l.set_output_stream():
+```v
+import os
+import log
+
+fn main() {
+	// log.info('this will be printed to stderr after 2025/01/21 by default')
+	mut l := log.ThreadSafeLog{}
+	l.set_output_stream(os.stdout())
+	log.set_logger(l)
+	log.info('this will be printed to stdout')
+}
+```

--- a/vlib/log/common.v
+++ b/vlib/log/common.v
@@ -19,8 +19,8 @@ pub enum LogTarget {
 	both
 }
 
-// tag_to_cli returns the tag for log level `l` as a colored string.
-fn tag_to_cli(l Level, short_tag bool) string {
+// tag_to_console returns the tag for log level `l` as a colored string.
+fn tag_to_console(l Level, short_tag bool) string {
 	if short_tag {
 		return match l {
 			.disabled { ' ' }

--- a/vlib/v/slow_tests/inout/dump_expression.out
+++ b/vlib/v/slow_tests/inout/dump_expression.out
@@ -1,36 +1,28 @@
-[vlib/v/slow_tests/inout/dump_expression.vv:5] 1: 1
-[vlib/v/slow_tests/inout/dump_expression.vv:10] 'a': a
-[vlib/v/slow_tests/inout/dump_expression.vv:34] a: Aa{
-    log: &log.Logger(log.Log{
-        level: disabled
-        output_label: ''
-        ofile: os.File{
-            cfile: 0
-            fd: 0
-            is_opened: false
-        }
-        output_target: console
-        time_format: tf_rfc3339_micro
-        custom_time_format: 'MMMM Do YY N kk:mm:ss A'
-        short_tag: false
-        always_flush: false
-        output_file_name: ''
-    })
+[vlib/v/slow_tests/inout/dump_expression.vv:4] 1: 1
+[vlib/v/slow_tests/inout/dump_expression.vv:9] 'a': a
+[vlib/v/slow_tests/inout/dump_expression.vv:33] a: Aa{
+    cmd: &os.Command{
+        f: 0
+        eof: false
+        exit_code: 0
+        path: ''
+        redirect_stdout: false
+    }
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:35] p: Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:34] p: Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:36] p_mut: Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:35] p_mut: Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:37] p_ptr: &Point{
+[vlib/v/slow_tests/inout/dump_expression.vv:36] p_ptr: &Point{
     x: 1
     y: 2
     z: 3
 }
-[vlib/v/slow_tests/inout/dump_expression.vv:48] os.file_name(vfile): dump_expression.vv
-[vlib/v/slow_tests/inout/dump_expression.vv:51] f.read(mut buf): 10
+[vlib/v/slow_tests/inout/dump_expression.vv:47] os.file_name(vfile): dump_expression.vv
+[vlib/v/slow_tests/inout/dump_expression.vv:50] f.read(mut buf): 10

--- a/vlib/v/slow_tests/inout/dump_expression.vv
+++ b/vlib/v/slow_tests/inout/dump_expression.vv
@@ -1,5 +1,4 @@
 import os
-import log
 
 fn dump_of_int() {
 	x := dump(1) + 1
@@ -19,16 +18,16 @@ mut:
 }
 
 struct Aa {
-	log &log.Logger
+	cmd &os.Command
 }
 
 fn dump_of_struct() {
 	p := Point{1, 2, 3}
 	mut p_mut := Point{1, 2, 3}
 	p_ptr := &Point{1, 2, 3}
-	l := &log.Log{}
+	c := &os.Command{}
 	a := Aa{
-		log: l
+		cmd: c
 	}
 
 	dump(a)


### PR DESCRIPTION
This PR is second try of https://github.com/vlang/v/pull/23296

In short:

- Makes possible set log output to `io.Writer` via new `.set_output_stream()` fn
- Sets `os.stderr()` as default log output.