### PR TITLE
cgen: fix assigning option of array index  (fix #23451)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6721,7 +6721,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
 								g.write('_option_ok(&(${cast_typ}[]) { ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-								g.writeln(' }, (${option_name}*)${cvar_name}.data, sizeof(${cast_typ}));')
+								g.writeln(' }, (${option_name}*)&${cvar_name}, sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6719,13 +6719,15 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 									g.write('*(${cast_typ}*) ${cvar_name}.data = ')
 								}
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
+								tmp_var := g.new_tmp_var()
+								g.write('${cast_typ} ${tmp_var} = ')
+								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
+								g.writeln(';')
 								g.write('_option_ok(&(${cast_typ}[]) { ')
 								if return_type.idx() == ast.string_type_idx {
-									g.write('string_clone(')
-									g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-									g.write(')')
+									g.write('string_clone(${tmp_var})')
 								} else {
-									g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
+									g.write('${tmp_var}')
 								}
 								g.writeln(' }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
 								g.indent--

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6718,6 +6718,12 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 								if expr_stmt.expr.is_return_used {
 									g.write('*(${cast_typ}*) ${cvar_name}.data = ')
 								}
+							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
+								g.write('_option_ok(&(${cast_typ}[]) { ')
+								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
+								g.writeln(' }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
+								g.indent--
+								return
 							} else {
 								g.write('*(${cast_typ}*) ${cvar_name}.data = ')
 							}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6721,7 +6721,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
 								g.write('_option_ok(&(${cast_typ}[]) { ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-								g.writeln(' }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
+								g.writeln(' }, (${g.styp(return_type)}*)(&${cvar_name}.data), sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6723,13 +6723,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 								g.write('${cast_typ} ${tmp_var} = ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
 								g.writeln(';')
-								g.write('_option_ok(&(${cast_typ}[]) { ')
-								if return_type.idx() == ast.string_type_idx {
-									g.write('string_clone(${tmp_var})')
-								} else {
-									g.write('${tmp_var}')
-								}
-								g.writeln(' }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
+								g.writeln('_option_ok(&${tmp_var}, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6719,11 +6719,15 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 									g.write('*(${cast_typ}*) ${cvar_name}.data = ')
 								}
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
-								tmp_var := g.new_tmp_var()
-								g.write('${cast_typ} ${tmp_var} = ')
-								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-								g.writeln(';')
-								g.writeln('_option_ok(&(${cast_typ}[]) { ${tmp_var} }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
+								g.write('_option_ok(&(${cast_typ}[]) { ')
+								if return_type.idx() == ast.string_type_idx {
+									g.write('string_clone(')
+									g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
+									g.write(')')
+								} else {
+									g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
+								}
+								g.writeln(' }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6719,9 +6719,11 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 									g.write('*(${cast_typ}*) ${cvar_name}.data = ')
 								}
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
-								g.write('_option_ok(&(${cast_typ}[]) { ')
+								tmp_var := g.new_tmp_var()
+								g.write('${cast_typ} ${tmp_var} = ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-								g.writeln(' }, (${g.styp(return_type)}*)&(${cvar_name}.data), sizeof(${cast_typ}));')
+								g.writeln(';')
+								g.writeln('_option_ok(&(${cast_typ}[]) { ${tmp_var} }, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6721,7 +6721,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
 								g.write('_option_ok(&(${cast_typ}[]) { ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-								g.writeln(' }, (${g.styp(return_type)}*)(&${cvar_name}.data), sizeof(${cast_typ}));')
+								g.writeln(' }, (${g.styp(return_type)}*)&(${cvar_name}.data), sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6719,11 +6719,9 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 									g.write('*(${cast_typ}*) ${cvar_name}.data = ')
 								}
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
-								tmp_var := g.new_tmp_var()
-								g.write('${cast_typ} ${tmp_var} = ')
+								g.write('_option_ok(&(${cast_typ}[]) { ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
-								g.writeln(';')
-								g.writeln('_option_ok(&${tmp_var}, (${g.styp(return_type)}*)${cvar_name}.data, sizeof(${cast_typ}));')
+								g.writeln(' }, (${option_name}*)${cvar_name}.data, sizeof(${cast_typ}));')
 								g.indent--
 								return
 							} else {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -342,7 +342,11 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.or_block(tmp_opt, node.or_expr, elem_type)
 			}
 			if !g.is_amp {
-				g.write('\n${cur_line}(*(${elem_type_str}*)${tmp_opt}.data)')
+				if g.inside_opt_or_res && elem_type.has_flag(.option) && g.inside_assign {
+					g.write('\n${cur_line}(*(${elem_type_str}*)&${tmp_opt})')
+				} else {
+					g.write('\n${cur_line}(*(${elem_type_str}*)${tmp_opt}.data)')
+				}
 			} else {
 				g.write('\n${cur_line}*${tmp_opt_ptr}')
 			}

--- a/vlib/v/tests/assign/assign_option_of_array_index_test.v
+++ b/vlib/v/tests/assign/assign_option_of_array_index_test.v
@@ -1,0 +1,10 @@
+fn make_option() ?string {
+	return none
+}
+
+fn test_assign_option_of_array_index() {
+	arr := [make_option()]
+	unwrapped := arr[99] or { 'unknown' } // <- out of bounds access!
+	println('... ${unwrapped}')
+	assert '${unwrapped}' == "Option('unknown')"
+}

--- a/vlib/v/tests/assign/assign_option_of_array_index_test.v
+++ b/vlib/v/tests/assign/assign_option_of_array_index_test.v
@@ -5,6 +5,5 @@ fn make_option() ?string {
 fn test_assign_option_of_array_index() {
 	arr := [make_option()]
 	unwrapped := arr[99] or { 'unknown' } // <- out of bounds access!
-	println('... ${unwrapped}')
 	assert '${unwrapped}' == "Option('unknown')"
 }


### PR DESCRIPTION
This PR fix assigning option of array index  (fix #23451).

- Fix assigning option of array index.
- Add test.

```v
fn make_option() ?string {
	return none
}

fn main() {
	arr := [make_option()]
	unwrapped := arr[99] or { 'unknown' } // <- out of bounds access!
	println('... ${unwrapped}')
}

PS D:\Test\v\tt1> v run .
... Option('unknown')
```