### PR TITLE
net.smtp: public mail attachment

### DIFF
--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -61,9 +61,10 @@ pub:
 }
 
 pub struct Attachment {
+pub:
+	cid      string
 	filename string
 	bytes    []u8
-	cid      string
 }
 
 // new_client returns a new SMTP client and connects to it


### PR DESCRIPTION
This should fix adding mail attachments if not inside v module.

See also https://github.com/vlang/v/pull/20640

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
