### PR TITLE
cgen: cannot convert int to struct string

### DIFF
--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -60,7 +60,7 @@ fn (mut p Process) unix_spawn_process() int {
 		chdir(p.work_folder) or {}
 	}
 	execve(p.filename, p.args, p.env) or {
-		eprintln(err)
+		eprintln('${err}')
 		exit(1)
 	}
 	return 0


### PR DESCRIPTION
This is just a workaround for something that shouldnt be necessary if the codegen worked well, but i'm pushing it as a PR for testing. Compiling v-r2pipe results in this error:

```
v-r2pipe$ make
v -show-c-output -shared .
======== Output of the C Compiler (/home/pancake/prg/v/thirdparty/tcc/tcc.exe) ========
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:16029: warning: implicit declaration of function 'IError_str'
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:16029: warning: assignment makes pointer from integer without a cast
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:16029: warning: cast between pointer and integer of different size
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:17034: error: cannot convert 'int' to 'struct string'
=======================================================================================
======== Output of the C Compiler (cc) ========
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c: In function ‘os__mkdir_all’:
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:16029:189: warning: implicit declaration of function ‘IError_str’ [-Wimplicit-function-declaration]
16029 |                         return (_result_void){ .is_error=true, .err=_v_error(str_intp(3, _MOV((StrIntpData[]){{_SLIT("folder: "), 0xfe10, {.d_s = p}}, {_SLIT(", error: "), 0xfe10, {.d_s = IError_str(err)}}, {_SLIT0, 0, { .d_c = 0 }}}))), .data={EMPTY_STRUCT_INITIALIZATION} };
      |                                                                                                                                                                                             ^~~~~~~~~~
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:16029:189: warning: initialization of ‘u8 *’ {aka ‘unsigned char *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:16029:189: note: (near initialization for ‘(anonymous)[1].d.d_s.str’)
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c: In function ‘os__Process_unix_spawn_process’:
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:17034:26: error: incompatible type for argument 1 of ‘eprintln’
17034 |                 eprintln(IError_str(err));
      |                          ^~~~~~~~~~~~~~~
      |                          |
      |                          int
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:8095:22: note: expected ‘string’ but argument is of type ‘int’
 8095 | void eprintln(string s) {
      |               ~~~~~~~^
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c: In function ‘r2pipe__R2Pipe_on’:
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:17425:17: warning: braces around scalar initializer
17425 |                 .th = {0},
      |                 ^
/tmp/v_1000/v-r2pipe.01JHSX9DHAW6TD23X9GFMN9BFJ.tmp.so.c:17425:17: note: (near initialization for ‘(anonymous).th’)
===============================================
```

to reproduce:

```bash
git clone https://github.com/radare/v-r2pipe
cd v-r2pipe
make
```