### PR TITLE
pref: -use-coroutines download photonwrapper to root

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -974,7 +974,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					arch := $if arm64 { 'arm64' } $else { 'amd64' }
 					vexe := vexe_path()
 					vroot := os.dir(vexe)
-					so_path := os.join_path(vroot, 'photonwrapper.so')
+					so_path := os.join_path(vroot, 'thirdparty', 'photon', 'photonwrapper.so')
 					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_${os.user_os()}_${arch}.so'
 					if !os.exists(so_path) {
 						println('coroutines .so not found, downloading...')
@@ -987,6 +987,14 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					}
 					res.compile_defines << 'is_coroutine'
 					res.compile_defines_all << 'is_coroutine'
+					$if macos {
+						dyld_fallback_paths := os.getenv('DYLD_FALLBACK_LIBRARY_PATH')
+						so_dir := os.dir(so_path)
+						if !dyld_fallback_paths.contains(so_dir) {
+							env := [dyld_fallback_paths, so_dir].filter(it.len).join(':')
+							os.setenv('DYLD_FALLBACK_LIBRARY_PATH', env, true)
+						}
+					}
 				} $else {
 					println('coroutines only work on macos & linux for now')
 				}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -974,7 +974,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					arch := $if arm64 { 'arm64' } $else { 'amd64' }
 					vexe := vexe_path()
 					vroot := os.dir(vexe)
-					so_path := os.join_path(vroot, 'thirdparty', 'photon', 'photonwrapper.so')
+					so_path := os.join_path(vroot, 'photonwrapper.so')
 					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_${os.user_os()}_${arch}.so'
 					if !os.exists(so_path) {
 						println('coroutines .so not found, downloading...')


### PR DESCRIPTION
Running the coroutine example was failing on darwin/arm64:

```
$ git clone --depth=1 https://github.com/vlang/v
$ cd v
$ make                                                     
cd ./vc && git clean -xf && git pull --quiet
cd ./thirdparty/tcc && git clean -xf && git pull --quiet
cc  -std=gnu99 -w -o v1.exe ./vc/v.c -lm -lpthread 
./v1.exe -no-parallel -o v2.exe  cmd/v
./v2.exe -nocache -o ./v  cmd/v
rm -rf v1.exe v2.exe
V has been successfully built
V 0.4.9 1b9f15d
$ v -use-coroutines run ./examples/coroutines/simple_coroutines.v
coroutines .so not found, downloading...
done!
dyld[41752]: Library not loaded: photonwrapper.so
  Referenced from: <7E4605BF-8E27-3070-8498-3EE37E5AC4BB> /Users/u/Projects/v/v/examples/coroutines/simple_coroutines
  Reason: tried: 'photonwrapper.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OSphotonwrapper.so' (no such file), 'photonwrapper.so' (no such file), '/Users/u/Projects/v/v/photonwrapper.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/u/Projects/v/v/photonwrapper.so' (no such file), '/Users/u/Projects/v/v/photonwrapper.so' (no such file)
Terminated by signal  6 (SIGABRT)
```

It was looking for `photonwrapper.so` in the root dir of V repo, but downloaded into `v/thirdparty/photon` dir. Manual copy of the file to root dir resulted in segfault:

```
$ cp thirdparty/photon/photonwrapper.so .
$ v -use-coroutines run ./examples/coroutines/simple_coroutines.v
signal 11: segmentation fault
0   libsystem_platform.dylib            0x000000018675f584 _sigtramp + 56
1   simple_coroutines                   0x0000000102a4c5b0 realloc_data + 40
2   simple_coroutines                   0x0000000102a4c5b0 realloc_data + 40
3   simple_coroutines                   0x0000000102a4e670 DenseArray_expand + 204
4   simple_coroutines                   0x0000000102a4ed2c map_set + 384
5   simple_coroutines                   0x0000000102a50ae0 new_map_init_noscan_value + 148
6   simple_coroutines                   0x0000000102a7c6e4 _vinit + 1548
7   simple_coroutines                   0x0000000102a7c7c0 main + 88
8   dyld                                0x00000001863a60e0 start + 2360
``` 

So now it downloads the wrapper right away to the path where it is expected later. 