### PR TITLE
cgen: fix interface casting in anon fn (fix #23530)

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -605,7 +605,6 @@ fn (mut g Gen) gen_interface_equality_fn(left_type ast.Type) string {
 	left_arg := g.read_field(left_type, '_typ', 'a')
 	right_arg := g.read_field(left_type, '_typ', 'b')
 
-	fn_builder.writeln('${g.static_non_parallel}int v_typeof_interface_idx_${idx_fn}(int sidx); // for auto eq method')
 	fn_builder.writeln('${g.static_non_parallel}inline bool ${fn_name}_interface_eq(${ptr_styp} a, ${ptr_styp} b) {')
 	fn_builder.writeln('\tif (${left_arg} == ${right_arg}) {')
 	fn_builder.writeln('\t\tint idx = v_typeof_interface_idx_${idx_fn}(${left_arg});')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1157,6 +1157,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return "${util.strip_main_name(sub_sym.name)}";')
 			}
 			g.writeln2('\treturn "unknown ${util.strip_main_name(sym.name)}";', '}')
+			g.definitions.writeln('int v_typeof_interface_idx_${sym.cname}(int sidx);')
 			g.writeln2('', 'int v_typeof_interface_idx_${sym.cname}(int sidx) {')
 			if g.pref.parallel_cc {
 				g.extern_out.writeln('extern int v_typeof_interface_idx_${sym.cname}(int sidx);')

--- a/vlib/v/tests/interfaces/interface_as_cast_in_anon_fn_test.v
+++ b/vlib/v/tests/interfaces/interface_as_cast_in_anon_fn_test.v
@@ -1,0 +1,26 @@
+@[heap]
+struct Foo {
+mut:
+	val int
+}
+
+@[heap]
+struct Bar {
+mut:
+	val int
+}
+
+interface FooBar {
+mut:
+	val int
+}
+
+fn test_interface_as_cast_in_anon_fn() {
+	mut fbs := []&FooBar{}
+	fbs << &Foo{1}
+	do_something := fn [mut fbs] () {
+		_ := fbs.last() as Foo // this line works outside of anon fn
+	}
+	do_something()
+	assert true
+}


### PR DESCRIPTION
This PR fix interface casting in anon fn (fix #23530).

- Fix interface casting in anon fn.
- Add test.

```v
@[heap]
struct Foo {
mut:
	val int
}

@[heap]
struct Bar {
mut:
	val int
}

interface FooBar {
mut:
	val int
}

fn main() {
	mut fbs := []&FooBar{}
	fbs << &Foo{1}
	do_something := fn [mut fbs] () {
		_ := fbs.last() as Foo // this line works outside of anon fn
	}
	do_something()
        assert true
}

PS D:\Test\v\tt1> v run .
```