### PR TITLE
v: cache repeated `node.args.len`, `method.generic_names.len`, `node.concrete_types.len` and `node.op.str()`

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2256,7 +2256,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 		left_type.has_flag(.generic)
 	}
 	mut rec_concrete_types := []ast.Type{}
-	method_generic_names_len := method.generic_names.len
+	mut method_generic_names_len := method.generic_names.len
 	match rec_sym.info {
 		ast.Struct, ast.SumType, ast.Interface {
 			if rec_sym.info.concrete_types.len > 0 {
@@ -2608,6 +2608,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 	if left_sym.kind == .interface && is_method_from_embed && method.return_type.has_flag(.generic)
 		&& method_generic_names_len == 0 {
 		method.generic_names = c.table.get_generic_names((rec_sym.info as ast.Interface).generic_types)
+		method_generic_names_len = method.generic_names.len
 	}
 	if method_generic_names_len != node.concrete_types.len {
 		// no type arguments given in call, attempt implicit instantiation

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2261,18 +2261,19 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 			if rec_sym.info.concrete_types.len > 0 {
 				rec_concrete_types = rec_sym.info.concrete_types.clone()
 			}
-			if rec_is_generic && node.concrete_types.len == 0
+			concrete_types_len := node.concrete_types.len
+			if rec_is_generic && concrete_types_len == 0
 				&& method.generic_names.len == rec_sym.info.generic_types.len {
 				node.concrete_types = rec_sym.info.generic_types
-			} else if rec_is_generic && node.concrete_types.len > 0
-				&& method.generic_names.len > node.concrete_types.len
-				&& rec_sym.info.generic_types.len + node.concrete_types.len == method.generic_names.len {
+			} else if rec_is_generic && concrete_types_len > 0
+				&& method.generic_names.len > concrete_types_len
+				&& rec_sym.info.generic_types.len + concrete_types_len == method.generic_names.len {
 				t_concrete_types := node.concrete_types.clone()
 				node.concrete_types = rec_sym.info.generic_types
 				node.concrete_types << t_concrete_types
 			} else if !rec_is_generic && rec_sym.info.concrete_types.len > 0
-				&& node.concrete_types.len > 0
-				&& rec_sym.info.concrete_types.len + node.concrete_types.len == method.generic_names.len {
+				&& concrete_types_len > 0
+				&& rec_sym.info.concrete_types.len + concrete_types_len == method.generic_names.len {
 				t_concrete_types := node.concrete_types.clone()
 				node.concrete_types = rec_sym.info.concrete_types
 				node.concrete_types << t_concrete_types

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3460,11 +3460,12 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 	} else {
 		c.table.sym(unaliased_left_type).info as ast.ArrayFixed
 	}
-	mut arg0 := if node.args.len > 0 { node.args[0] } else { ast.CallArg{} }
+	node_args_len := node.args.len
+	mut arg0 := if node_args_len > 0 { node.args[0] } else { ast.CallArg{} }
 	elem_typ := array_info.elem_type
 	if method_name == 'index' {
-		if node.args.len != 1 {
-			c.error('`.index()` expected 1 argument, but got ${node.args.len}', node.pos)
+		if node_args_len != 1 {
+			c.error('`.index()` expected 1 argument, but got ${node_args_len}', node.pos)
 			return ast.int_type
 		} else if !left_sym.has_method('index') {
 			arg_typ := c.expr(mut arg0.expr)
@@ -3478,8 +3479,8 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 		}
 		node.return_type = ast.int_type
 	} else if method_name == 'contains' {
-		if node.args.len != 1 {
-			c.error('`.contains()` expected 1 argument, but got ${node.args.len}', node.pos)
+		if node_args_len != 1 {
+			c.error('`.contains()` expected 1 argument, but got ${node_args_len}', node.pos)
 			return ast.bool_type
 		} else if !left_sym.has_method('contains') {
 			arg_typ := c.expr(mut arg0.expr)
@@ -3493,12 +3494,12 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 		}
 		node.return_type = ast.bool_type
 	} else if method_name in ['any', 'all'] {
-		if node.args.len != 1 {
-			c.error('`.${method_name}` expected 1 argument, but got ${node.args.len}',
+		if node_args_len != 1 {
+			c.error('`.${method_name}` expected 1 argument, but got ${node_args_len}',
 				node.pos)
 			return ast.bool_type
 		}
-		if node.args.len > 0 && mut arg0.expr is ast.LambdaExpr {
+		if node_args_len > 0 && mut arg0.expr is ast.LambdaExpr {
 			if arg0.expr.params.len != 1 {
 				c.error('lambda expressions used in the builtin array methods require exactly 1 parameter',
 					arg0.expr.pos)
@@ -3513,12 +3514,12 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 		c.check_predicate_param(false, elem_typ, node)
 		node.return_type = ast.bool_type
 	} else if method_name == 'count' {
-		if node.args.len != 1 {
-			c.error('`.${method_name}` expected 1 argument, but got ${node.args.len}',
+		if node_args_len != 1 {
+			c.error('`.${method_name}` expected 1 argument, but got ${node_args_len}',
 				node.pos)
 			return ast.bool_type
 		}
-		if node.args.len > 0 && mut arg0.expr is ast.LambdaExpr {
+		if node_args_len > 0 && mut arg0.expr is ast.LambdaExpr {
 			if arg0.expr.params.len != 1 {
 				c.error('lambda expressions used in the builtin array methods require exactly 1 parameter',
 					arg0.expr.pos)
@@ -3535,7 +3536,7 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 	} else if method_name == 'wait' {
 		elem_sym := c.table.sym(elem_typ)
 		if elem_sym.kind == .thread {
-			if node.args.len != 0 {
+			if node_args_len != 0 {
 				c.error('`.wait()` does not have any arguments', arg0.pos)
 			}
 			thread_ret_type := c.unwrap_generic(elem_sym.thread_info().return_type)
@@ -3552,8 +3553,8 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 				node.left.pos())
 		}
 	} else if method_name == 'map' {
-		if node.args.len != 1 {
-			c.error('`.${method_name}` expected 1 argument, but got ${node.args.len}',
+		if node_args_len != 1 {
+			c.error('`.${method_name}` expected 1 argument, but got ${node_args_len}',
 				node.pos)
 			return ast.void_type
 		}
@@ -3606,9 +3607,9 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 		// position of `a` and `b` doesn't matter, they're the same
 		scope_register_a_b(mut node.scope, node.pos, elem_typ)
 
-		if node.args.len > 1 {
-			c.error('expected 0 or 1 argument, but got ${node.args.len}', node.pos)
-		} else if node.args.len == 1 {
+		if node_args_len > 1 {
+			c.error('expected 0 or 1 argument, but got ${node_args_len}', node.pos)
+		} else if node_args_len == 1 {
 			if mut arg0.expr is ast.LambdaExpr {
 				c.support_lambda_expr_in_sort(elem_typ.ref(), ast.bool_type, mut arg0.expr)
 			} else if mut arg0.expr is ast.InfixExpr {
@@ -3649,8 +3650,8 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 			node.return_type = node.left_type
 		}
 	} else if method_name in ['sort_with_compare', 'sorted_with_compare'] {
-		if node.args.len != 1 {
-			c.error('`.${method_name}()` expected 1 argument, but got ${node.args.len}',
+		if node_args_len != 1 {
+			c.error('`.${method_name}()` expected 1 argument, but got ${node_args_len}',
 				node.pos)
 		} else {
 			if mut arg0.expr is ast.LambdaExpr {
@@ -3696,7 +3697,7 @@ fn (mut c Checker) fixed_array_builtin_method_call(mut node ast.CallExpr, left_t
 			}
 		}
 	} else if method_name in ['reverse', 'reverse_in_place'] {
-		if node.args.len != 0 {
+		if node_args_len != 0 {
 			c.error('`.${method_name}` does not have any arguments', arg0.pos)
 		} else {
 			if method_name == 'reverse' {

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -337,21 +337,21 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				&& (left_final_sym.is_primitive() || left_final_sym.kind == .enum)) {
 				left_sym = unsafe { left_final_sym }
 			}
-
+			op_str := node.op.str()
 			if c.pref.translated && node.op in [.plus, .minus, .mul]
 				&& unwrapped_left_type.is_any_kind_of_pointer()
 				&& unwrapped_right_type.is_any_kind_of_pointer() {
 				return_type = left_type
 			} else if !c.pref.translated && left_sym.info is ast.Alias
 				&& !left_final_sym.is_primitive() {
-				if left_sym.has_method(node.op.str()) {
-					if method := left_sym.find_method(node.op.str()) {
+				if left_sym.has_method(op_str) {
+					if method := left_sym.find_method(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type
 					}
-				} else if left_final_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := left_final_sym.find_method_with_generic_parent(node.op.str()) {
+				} else if left_final_sym.has_method_with_generic_parent(op_str) {
+					if method := left_final_sym.find_method_with_generic_parent(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type
@@ -360,7 +360,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					left_name := c.table.type_to_str(unwrapped_left_type)
 					right_name := c.table.type_to_str(unwrapped_right_type)
 					if left_name == right_name {
-						c.error('undefined operation `${left_name}` ${node.op.str()} `${right_name}`',
+						c.error('undefined operation `${left_name}` ${op_str} `${right_name}`',
 							left_right_pos)
 					} else {
 						c.error('mismatched types `${left_name}` and `${right_name}`',
@@ -369,26 +369,26 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				}
 			} else if !c.pref.translated && right_sym.info is ast.Alias
 				&& !right_final_sym.is_primitive() {
-				if right_sym.has_method(node.op.str()) {
-					if method := right_sym.find_method(node.op.str()) {
+				if right_sym.has_method(op_str) {
+					if method := right_sym.find_method(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = right_type
 					}
-				} else if right_final_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := right_final_sym.find_method_with_generic_parent(node.op.str()) {
+				} else if right_final_sym.has_method_with_generic_parent(op_str) {
+					if method := right_final_sym.find_method_with_generic_parent(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = right_type
 					}
-				} else if left_sym.has_method(node.op.str()) {
-					if method := left_sym.find_method(node.op.str()) {
+				} else if left_sym.has_method(op_str) {
+					if method := left_sym.find_method(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type
 					}
-				} else if left_final_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := left_final_sym.find_method_with_generic_parent(node.op.str()) {
+				} else if left_final_sym.has_method_with_generic_parent(op_str) {
+					if method := left_final_sym.find_method_with_generic_parent(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type
@@ -397,7 +397,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					left_name := c.table.type_to_str(unwrapped_left_type)
 					right_name := c.table.type_to_str(unwrapped_right_type)
 					if left_name == right_name {
-						c.error('undefined operation `${left_name}` ${node.op.str()} `${right_name}`',
+						c.error('undefined operation `${left_name}` ${op_str} `${right_name}`',
 							left_right_pos)
 					} else {
 						c.error('mismatched types `${left_name}` and `${right_name}`',
@@ -413,8 +413,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			}
 
 			if !c.pref.translated && left_sym.kind in [.array, .array_fixed, .map, .struct] {
-				if left_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := left_sym.find_method_with_generic_parent(node.op.str()) {
+				if left_sym.has_method_with_generic_parent(op_str) {
+					if method := left_sym.find_method_with_generic_parent(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = left_type
@@ -423,7 +423,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					left_name := c.table.type_to_str(unwrapped_left_type)
 					right_name := c.table.type_to_str(unwrapped_right_type)
 					if left_name == right_name {
-						c.error('undefined operation `${left_name}` ${node.op.str()} `${right_name}`',
+						c.error('undefined operation `${left_name}` ${op_str} `${right_name}`',
 							left_right_pos)
 					} else {
 						c.error('mismatched types `${left_name}` and `${right_name}`',
@@ -431,8 +431,8 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					}
 				}
 			} else if !c.pref.translated && right_sym.kind in [.array, .array_fixed, .map, .struct] {
-				if right_sym.has_method_with_generic_parent(node.op.str()) {
-					if method := right_sym.find_method_with_generic_parent(node.op.str()) {
+				if right_sym.has_method_with_generic_parent(op_str) {
+					if method := right_sym.find_method_with_generic_parent(op_str) {
 						return_type = method.return_type
 					} else {
 						return_type = right_type
@@ -441,7 +441,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 					left_name := c.table.type_to_str(unwrapped_left_type)
 					right_name := c.table.type_to_str(unwrapped_right_type)
 					if left_name == right_name {
-						c.error('undefined operation `${left_name}` ${node.op.str()} `${right_name}`',
+						c.error('undefined operation `${left_name}` ${op_str} `${right_name}`',
 							left_right_pos)
 					} else {
 						c.error('mismatched types `${left_name}` and `${right_name}`',
@@ -499,7 +499,7 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 							c.error('float modulo not allowed, use math.fmod() instead',
 								pos)
 						} else {
-							c.error('${side} type of `${node.op.str()}` cannot be non-integer type `${name}`',
+							c.error('${side} type of `${op_str}` cannot be non-integer type `${name}`',
 								pos)
 						}
 					}
@@ -511,14 +511,14 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 				left_sym = c.table.sym(unwrapped_left_type)
 				right_sym = c.table.sym(unwrapped_right_type)
 				if left_sym.info is ast.Alias && left_final_sym.is_primitive() {
-					if left_sym.has_method(node.op.str()) {
-						if method := left_sym.find_method(node.op.str()) {
+					if left_sym.has_method(op_str) {
+						if method := left_sym.find_method(op_str) {
 							return_type = method.return_type
 						}
 					}
 				} else if right_sym.info is ast.Alias && right_final_sym.is_primitive() {
-					if right_sym.has_method(node.op.str()) {
-						if method := right_sym.find_method(node.op.str()) {
+					if right_sym.has_method(op_str) {
+						if method := right_sym.find_method(op_str) {
 							return_type = method.return_type
 						}
 					}


### PR DESCRIPTION
Minor optimization.