### PR TITLE
cgen: fix codegen for assign from unsafe fn returning fixed array

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -468,10 +468,10 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		is_fixed_array_var := !g.pref.translated && unaliased_right_sym.kind == .array_fixed
 			&& val !is ast.ArrayInit
-			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr, ast.InfixExpr, ast.UnsafeExpr]
+			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr, ast.InfixExpr]
 			|| (val is ast.CastExpr && val.expr !is ast.ArrayInit)
 			|| (val is ast.PrefixExpr && val.op == .arrow)
-			|| (val is ast.UnsafeExpr && val.expr in [ast.SelectorExpr, ast.Ident]))
+			|| (val is ast.UnsafeExpr && val.expr in [ast.SelectorExpr, ast.Ident, ast.CallExpr]))
 		g.is_assign_lhs = true
 		g.assign_op = node.op
 

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -468,7 +468,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		is_fixed_array_var := !g.pref.translated && unaliased_right_sym.kind == .array_fixed
 			&& val !is ast.ArrayInit
-			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr, ast.InfixExpr]
+			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.DumpExpr, ast.InfixExpr, ast.UnsafeExpr]
 			|| (val is ast.CastExpr && val.expr !is ast.ArrayInit)
 			|| (val is ast.PrefixExpr && val.op == .arrow)
 			|| (val is ast.UnsafeExpr && val.expr in [ast.SelectorExpr, ast.Ident]))

--- a/vlib/v/tests/builtin_arrays/array_fixed_from_unsafe_test.v
+++ b/vlib/v/tests/builtin_arrays/array_fixed_from_unsafe_test.v
@@ -1,0 +1,10 @@
+@[unsafe]
+fn test() [5]int {
+	return [5]int{}
+}
+
+fn test_main() {
+	foo := unsafe { test() }
+	assert foo.len == 5
+	assert foo == unsafe { test() }
+}


### PR DESCRIPTION
Fix #23546