### PR TITLE
str_intp: autofree memory leak fix 1

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -255,6 +255,14 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			}
 		}
 	}
+
+	mut tmp_var := ''
+	mut curr_line := ''
+	if g.is_autofree {
+		curr_line = g.go_before_ternary().trim_space() + ' '
+		tmp_var = g.new_tmp_var()
+		g.write('\tstring ${tmp_var} = ')
+	}
 	g.write2('str_intp(', node.vals.len.str())
 	g.write(', _MOV((StrIntpData[]){')
 	for i, val in node.vals {
@@ -294,4 +302,15 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 		}
 	}
 	g.write('}))')
+	if g.is_autofree {
+		g.writeln(';')
+		g.write(curr_line + tmp_var)
+		mut scope := g.file.scope.innermost(node.pos.pos)
+		scope.register(ast.Var{
+			name:            tmp_var
+			typ:             ast.string_type
+			is_autofree_tmp: true
+			pos:             node.pos
+		})
+	}
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR try to fix memory leak cause by `str_intp()`. 

leak.v:
```v
struct Test {
        a string
}

fn main() {
        cmd1 := 'ls'
        cmd2 := 'rm'
        _ := Test {
                a : 'cmd ${cmd1} ${cmd2} failed'
        }
}
```

without `autofree`, generate c:
```c
VV_LOCAL_SYMBOL void main__main(void) {
        string cmd1 = _SLIT("ls");
        string cmd2 = _SLIT("rm");
        {main__Test _ = ((main__Test){.a = str_intp(3, _MOV((StrIntpData[]){{_SLIT("cmd "), 0xfe10, {.d_s = cmd1}}, {_SLIT(" "), 0xfe10, {.d_s = cmd2}}, {_SLIT(" failed"), 0, { .d_c = 0 }}})),});}
        ;
}
```

with `autofree`, generate c:
```c
VV_LOCAL_SYMBOL void main__main(void) {
        string cmd1 = _SLIT("ls");
        string cmd2 = _SLIT("rm");
        string _t1 = str_intp(3, _MOV((StrIntpData[]){{_SLIT("cmd "), 0xfe10, {.d_s = cmd1}}, {_SLIT(" "), 0xfe10, {.d_s = cmd2}}, {_SLIT(" failed"), 0, { .d_c = 0 }}}));
        {main__Test _ = ((main__Test){.a = _t1,});}
        ;
        string_free(&_t1); // autofreed var main false
        string_free(&cmd2); // autofreed var main false
        string_free(&cmd1); // autofreed var main false
}
```

and run valgrind  will get a clean result.
```sh
valgrind --error-exitcode=1 --leak-check=full --show-reachable=yes ./leak

==510777== Memcheck, a memory error detector
==510777== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==510777== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==510777== Command: ./leak
==510777==
==510777==
==510777== HEAP SUMMARY:
==510777==     in use at exit: 0 bytes in 0 blocks
==510777==   total heap usage: 3 allocs, 3 frees, 274 bytes allocated
==510777==
==510777== All heap blocks were freed -- no leaks are possible
==510777==
==510777== For lists of detected and suppressed errors, rerun with: -s
==510777== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
#-gc boehm_leak

```
