### PR TITLE
cgen: fix codegen for assigning from infixexpr with generic operand

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -375,8 +375,10 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							g.assign_ct_type = var_type
 						}
 					} else if val is ast.InfixExpr && val.op in [.plus, .minus, .mul, .div, .mod]
-						&& val.left_ct_expr && val.right_ct_expr {
-						ctyp := g.unwrap_generic(g.type_resolver.get_type(val.left))
+						&& val.left_ct_expr {
+						ctyp := g.type_resolver.promote_type(g.unwrap_generic(g.type_resolver.get_type(val.left)),
+							g.unwrap_generic(g.type_resolver.get_type_or_default(val.right,
+							val.right_type)))
 						if ctyp != ast.void_type {
 							ct_type_var := g.comptime.get_ct_type_var(val.left)
 							if ct_type_var in [.key_var, .value_var] {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -375,7 +375,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							g.assign_ct_type = var_type
 						}
 					} else if val is ast.InfixExpr && val.op in [.plus, .minus, .mul, .div, .mod]
-						&& val.left_ct_expr {
+						&& val.left_ct_expr && val.right_ct_expr {
 						ctyp := g.unwrap_generic(g.type_resolver.get_type(val.left))
 						if ctyp != ast.void_type {
 							ct_type_var := g.comptime.get_ct_type_var(val.left)

--- a/vlib/v/tests/generics/generic_selector_infix_test.v
+++ b/vlib/v/tests/generics/generic_selector_infix_test.v
@@ -1,0 +1,19 @@
+fn lerp[T](x T) T {
+	return x
+}
+
+struct Foo[T] {
+mut:
+	value T
+}
+
+fn (mut t Foo[T]) r[T](dt f64) {
+	mut value := t.value + dt
+	lerp(value)
+}
+
+fn test_main() {
+	mut t2 := Foo[f32]{}
+	t2.r(2.1)
+	assert true
+}

--- a/vlib/v/type_resolver/type_resolver.v
+++ b/vlib/v/type_resolver/type_resolver.v
@@ -89,6 +89,14 @@ fn (t &TypeResolver) error(s string, pos token.Pos) {
 	exit(1)
 }
 
+// promote_type resolves the final type of different generic/comptime operand types
+pub fn (t &TypeResolver) promote_type(left_type ast.Type, right_type ast.Type) ast.Type {
+	if left_type == ast.f32_type && right_type == ast.f64_type {
+		return right_type
+	}
+	return left_type
+}
+
 // get_type_or_default retries the comptime value if the AST node is related to comptime otherwise default_typ is returned
 @[inline]
 pub fn (mut t TypeResolver) get_type_or_default(node ast.Expr, default_typ ast.Type) ast.Type {


### PR DESCRIPTION
Fix #23560