### PR TITLE
checker: turn `option_var.str()` an error without unwrapping first

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -906,10 +906,11 @@ pub mut:
 	// 10 <- original type (orig_type)
 	//   [11, 12, 13] <- cast order (smartcasts)
 	//        12 <- the current casted type (typ)
-	pos         token.Pos
-	is_used     bool            // whether the local variable was used in other expressions
-	is_changed  bool            // to detect mutable vars that are never changed
-	ct_type_var ComptimeVarKind // comptime variable type
+	pos               token.Pos
+	is_used           bool            // whether the local variable was used in other expressions
+	is_changed        bool            // to detect mutable vars that are never changed
+	ct_type_var       ComptimeVarKind // comptime variable type
+	ct_type_unwrapped bool            // true when the comptime variable gets unwrapped
 	// (for setting the position after the or block for autofree)
 	is_or        bool // `x := foo() or { ... }`
 	is_tmp       bool // for tmp for loop vars, so that autofree can skip them
@@ -1995,6 +1996,7 @@ pub struct ComptimeSelector {
 pub:
 	has_parens bool // if $() is used, for vfmt
 	pos        token.Pos
+	or_block   OrExpr
 pub mut:
 	left       Expr
 	left_type  Type

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -925,8 +925,12 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 fn (mut c Checker) change_flags_if_comptime_expr(mut left ast.Ident, right ast.Expr) {
 	if mut left.obj is ast.Var {
 		if right is ast.ComptimeSelector {
-			left.obj.ct_type_var = .field_var
 			left.obj.typ = c.comptime.comptime_for_field_type
+			if right.or_block.kind == .propagate_option {
+				left.obj.typ = left.obj.typ.clear_flag(.option)
+			} else if right.or_block.kind == .absent {
+				left.obj.ct_type_var = .field_var
+			}
 		} else if right is ast.InfixExpr {
 			right_ct_var := c.comptime.get_ct_type_var(right.left)
 			if right_ct_var != .no_comptime {
@@ -959,6 +963,13 @@ fn (mut c Checker) change_flags_if_comptime_expr(mut left ast.Ident, right ast.E
 				&& !right.comptime_ret_val && c.type_resolver.is_generic_expr(right) {
 				// mark variable as generic var because its type changes according to fn return generic resolution type
 				left.obj.ct_type_var = .generic_var
+			}
+		} else if right is ast.PostfixExpr && right.op == .question {
+			if right.expr is ast.Ident && right.expr.ct_expr {
+				right_obj_var := right.expr.obj as ast.Var
+				left.obj.ct_type_unwrapped = true
+				left.obj.ct_type_var = right_obj_var.ct_type_var
+				left.obj.typ = c.comptime.comptime_for_field_type.clear_flag(.option)
 			}
 		}
 	}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -223,6 +223,9 @@ fn (mut c Checker) comptime_selector(mut node ast.ComptimeSelector) ast.Type {
 		}
 		expr_type = c.type_resolver.get_comptime_selector_type(node, ast.void_type)
 		if expr_type != ast.void_type {
+			if node.or_block.kind == .propagate_option {
+				return expr_type.clear_flag(.option)
+			}
 			return expr_type
 		}
 		expr_name := node.field_expr.expr.str()

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1973,8 +1973,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 	final_left_sym := c.table.final_sym(unwrapped_left_type)
 
 	method_name := node.name
-	if left_type.has_flag(.option) && method_name != 'str' {
-		c.error('Option type cannot be called directly', node.left.pos())
+	if left_type.has_flag(.option) {
+		c.error('Option type cannot be called directly, you should unwrap it first', node.left.pos())
 		return ast.void_type
 	} else if left_type.has_flag(.result) {
 		c.error('Result type cannot be called directly', node.left.pos())

--- a/vlib/v/checker/postfix.v
+++ b/vlib/v/checker/postfix.v
@@ -36,8 +36,12 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 		typ_str := c.table.type_to_str(typ)
 		c.error('invalid operation: ${node.op.str()} (non-numeric type `${typ_str}`)',
 			node.pos)
-	} else if node.op != .question {
-		node.auto_locked, _ = c.fail_if_immutable(mut node.expr)
+	} else {
+		if node.op == .question {
+			c.table.used_features.option_or_result = true
+		} else {
+			node.auto_locked, _ = c.fail_if_immutable(mut node.expr)
+		}
 	}
 	node.typ = typ
 	return typ

--- a/vlib/v/checker/postfix.v
+++ b/vlib/v/checker/postfix.v
@@ -3,7 +3,7 @@ module checker
 import v.ast
 
 fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
-	typ := c.unwrap_generic(c.expr(mut node.expr))
+	typ := c.unwrap_generic(c.type_resolver.get_type_or_default(node, c.expr(mut node.expr)))
 	typ_sym := c.table.sym(typ)
 	is_non_void_pointer := typ.is_any_kind_of_pointer() && typ_sym.kind != .voidptr
 
@@ -36,7 +36,7 @@ fn (mut c Checker) postfix_expr(mut node ast.PostfixExpr) ast.Type {
 		typ_str := c.table.type_to_str(typ)
 		c.error('invalid operation: ${node.op.str()} (non-numeric type `${typ_str}`)',
 			node.pos)
-	} else {
+	} else if node.op != .question {
 		node.auto_locked, _ = c.fail_if_immutable(mut node.expr)
 	}
 	node.typ = typ

--- a/vlib/v/checker/tests/option_str_call.out
+++ b/vlib/v/checker/tests/option_str_call.out
@@ -1,12 +1,12 @@
-vlib/v/checker/tests/option_str_call.vv:8:10: error: Option type cannot be called directly, you should unwrap it first
-    6 |     footer := doc.get_tags_by_class_name('Box-footer')[0]
-    7 |     invalid := footer.get_tag_by_class_name('invalid')
-    8 |     println(invalid.str()) // runtime error, invalid memory access
+vlib/v/checker/tests/option_str_call.vv:7:10: error: Option type cannot be called directly, you should unwrap it first
+    5 |     footer := doc.get_tags_by_class_name('Box-footer')[0]
+    6 |     invalid := footer.get_tag_by_class_name('invalid')
+    7 |     println(invalid.str())
       |             ~~~~~~~
-    9 | }
-vlib/v/checker/tests/option_str_call.vv:8:2: error: `println` can not print void expressions
-    6 |     footer := doc.get_tags_by_class_name('Box-footer')[0]
-    7 |     invalid := footer.get_tag_by_class_name('invalid')
-    8 |     println(invalid.str()) // runtime error, invalid memory access
+    8 | }
+vlib/v/checker/tests/option_str_call.vv:7:2: error: `println` can not print void expressions
+    5 |     footer := doc.get_tags_by_class_name('Box-footer')[0]
+    6 |     invalid := footer.get_tag_by_class_name('invalid')
+    7 |     println(invalid.str())
       |     ~~~~~~~~~~~~~~~~~~~~~~
-    9 | }
+    8 | }

--- a/vlib/v/checker/tests/option_str_call.out
+++ b/vlib/v/checker/tests/option_str_call.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/option_str_call.vv:8:10: error: Option type cannot be called directly, you should unwrap it first
+    6 |     footer := doc.get_tags_by_class_name('Box-footer')[0]
+    7 |     invalid := footer.get_tag_by_class_name('invalid')
+    8 |     println(invalid.str()) // runtime error, invalid memory access
+      |             ~~~~~~~
+    9 | }
+vlib/v/checker/tests/option_str_call.vv:8:2: error: `println` can not print void expressions
+    6 |     footer := doc.get_tags_by_class_name('Box-footer')[0]
+    7 |     invalid := footer.get_tag_by_class_name('invalid')
+    8 |     println(invalid.str()) // runtime error, invalid memory access
+      |     ~~~~~~~~~~~~~~~~~~~~~~
+    9 | }

--- a/vlib/v/checker/tests/option_str_call.vv
+++ b/vlib/v/checker/tests/option_str_call.vv
@@ -1,0 +1,8 @@
+import net.html
+
+fn main() {
+	mut doc := html.parse('<body><div class="Box-footer"><div class="Truncate">abc</div></div></body>')
+	footer := doc.get_tags_by_class_name('Box-footer')[0]
+	invalid := footer.get_tag_by_class_name('invalid')
+	println(invalid.str()) // runtime error, invalid memory access
+}

--- a/vlib/v/checker/tests/option_str_call.vv
+++ b/vlib/v/checker/tests/option_str_call.vv
@@ -4,5 +4,5 @@ fn main() {
 	mut doc := html.parse('<body><div class="Box-footer"><div class="Truncate">abc</div></div></body>')
 	footer := doc.get_tags_by_class_name('Box-footer')[0]
 	invalid := footer.get_tag_by_class_name('invalid')
-	println(invalid.str()) // runtime error, invalid memory access
+	println(invalid.str())
 }

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -387,6 +387,20 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							left.obj.typ = var_type
 							g.assign_ct_type = var_type
 						}
+					} else if val is ast.PostfixExpr && val.op == .question
+						&& (val.expr is ast.Ident && val.expr.ct_expr) {
+						ctyp := g.unwrap_generic(g.type_resolver.get_type(val))
+						if ctyp != ast.void_type {
+							var_type = ctyp
+							val_type = var_type
+							left.obj.typ = var_type
+							g.assign_ct_type = var_type
+
+							ct_type_var := g.comptime.get_ct_type_var(val.expr)
+							if ct_type_var == .field_var {
+								g.type_resolver.update_ct_type(left.name, ctyp)
+							}
+						}
 					}
 				}
 				is_auto_heap = left.obj.is_auto_heap

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3654,17 +3654,19 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			} else if node.op == .question {
 				cur_line := g.go_before_last_stmt().trim_space()
 				mut expr_str := ''
+				mut is_unwrapped := true
 				if mut node.expr is ast.ComptimeSelector && node.expr.left is ast.Ident {
 					// val.$(field.name)?
 					expr_str = '${node.expr.left.str()}.${g.comptime.comptime_for_field_value.name}'
 				} else if mut node.expr is ast.Ident && node.expr.ct_expr {
 					// val?
 					expr_str = node.expr.name
+					is_unwrapped = g.type_resolver.get_type(node.expr).has_flag(.option)
 				}
 				g.writeln('if (${expr_str}.state != 0) {')
 				g.writeln2('\tpanic_option_not_set(_SLIT("none"));', '}')
 				g.write(cur_line)
-				if node.expr is ast.ComptimeSelector {
+				if is_unwrapped {
 					typ := g.resolve_comptime_type(node.expr, node.typ)
 					g.write('*(${g.base_type(typ)}*)&')
 					g.expr(node.expr)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3661,7 +3661,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				} else if mut node.expr is ast.Ident && node.expr.ct_expr {
 					// val?
 					expr_str = node.expr.name
-					is_unwrapped = g.type_resolver.get_type(node.expr).has_flag(.option)
+					is_unwrapped = !g.inside_assign
 				}
 				g.writeln('if (${expr_str}.state != 0) {')
 				g.writeln2('\tpanic_option_not_set(_SLIT("none"));', '}')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3664,10 +3664,14 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				g.writeln('if (${expr_str}.state != 0) {')
 				g.writeln2('\tpanic_option_not_set(_SLIT("none"));', '}')
 				g.write(cur_line)
-				typ := g.resolve_comptime_type(node.expr, node.typ)
-				g.write('*(${g.base_type(typ)}*)&')
-				g.expr(node.expr)
-				g.write('.data')
+				if node.expr is ast.ComptimeSelector {
+					typ := g.resolve_comptime_type(node.expr, node.typ)
+					g.write('*(${g.base_type(typ)}*)&')
+					g.expr(node.expr)
+					g.write('.data')
+				} else {
+					g.expr(node.expr)
+				}
 			} else {
 				g.expr(node.expr)
 			}

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -526,5 +526,10 @@ fn (mut p Parser) comptime_selector(left ast.Expr) ast.Expr {
 		left:       left
 		field_expr: expr
 		pos:        start_pos.extend(p.prev_tok.pos())
+		or_block:   ast.OrExpr{
+			stmts: []ast.Stmt{}
+			kind:  if p.tok.kind == .question { .propagate_option } else { .absent }
+			pos:   p.tok.pos()
+		}
 	}
 }

--- a/vlib/v/tests/c_struct_with_reserved_field_name_test.v
+++ b/vlib/v/tests/c_struct_with_reserved_field_name_test.v
@@ -17,6 +17,6 @@ fn test_c_struct_with_reserved_field_name() {
 		window_title: 'Polygons'
 	)
 	game.gg = cont
-	game.gg.str()
+	game.gg?.str()
 	assert true
 }

--- a/vlib/v/tests/comptime/comptime_unwrap_test.v
+++ b/vlib/v/tests/comptime/comptime_unwrap_test.v
@@ -1,0 +1,35 @@
+struct Foo {
+	a ?int
+	b ?string
+}
+
+fn receives_int(a int) {}
+
+fn receives_string(a string) {}
+
+fn test_main() {
+	t := Foo{
+		a: 1
+		b: 'foo'
+	}
+	mut c := 0
+	$for f in t.fields {
+		$if f.typ is ?int {
+			assert t.$(f.name) ?.str() == '1'
+			w := t.$(f.name) ?
+			assert w == 1
+			receives_int(w)
+			receives_int(t.$(f.name) ?)
+			c++
+		}
+		$if f.typ is ?string {
+			assert t.$(f.name) ?.str() == 'foo'
+			a := t.$(f.name) ?
+			assert a == 'foo'
+			receives_string(a)
+			receives_string(t.$(f.name) ?)
+			c++
+		}
+	}
+	assert c == 2
+}

--- a/vlib/v/tests/comptime/comptime_var_assignment_test.v
+++ b/vlib/v/tests/comptime/comptime_var_assignment_test.v
@@ -10,9 +10,9 @@ fn encode_struct[T](val T) []string {
 	$for field in T.fields {
 		value := val.$(field.name)
 		$if field.is_option {
-			gg := value
+			gg := value ?
 			println(gg)
-			out << gg.str()
+			out << '${value}'
 		} $else {
 			gg := value
 			println(gg)

--- a/vlib/v/tests/options/option_var_cast_test.v
+++ b/vlib/v/tests/options/option_var_cast_test.v
@@ -54,8 +54,8 @@ fn test_cast() {
 }
 
 fn test_cast_alias() {
-	assert ?MyByte(0).str() == 'Option(MyByte(0))'
-	assert ?MyByte(255).str() == 'Option(MyByte(255))'
-	assert ?MyByte(?u8(0)).str() == 'Option(MyByte(0))'
-	assert ?MyByte(?u8(255)).str() == 'Option(MyByte(255))'
+	assert '${?MyByte(0)}' == 'Option(MyByte(0))'
+	assert '${?MyByte(255)}' == 'Option(MyByte(255))'
+	assert '${?MyByte(?u8(0))}' == 'Option(MyByte(0))'
+	assert '${?MyByte(?u8(255))}' == 'Option(MyByte(255))'
 }

--- a/vlib/v/tests/sumtypes/sumtype_generic_checking_test.v
+++ b/vlib/v/tests/sumtypes/sumtype_generic_checking_test.v
@@ -15,6 +15,6 @@ fn generic_fn[T]() ?T {
 }
 
 fn test_main() {
-	assert generic_fn[string]().str() == "Option('123')"
-	assert generic_fn[int]().str() == 'Option(123)'
+	assert '${generic_fn[string]()}' == "Option('123')"
+	assert '${generic_fn[int]()}' == 'Option(123)'
 }

--- a/vlib/v/type_resolver/comptime_resolver.v
+++ b/vlib/v/type_resolver/comptime_resolver.v
@@ -19,6 +19,7 @@ pub fn (t &ResolverInfo) is_comptime_expr(node ast.Expr) bool {
 	return (node is ast.Ident && node.ct_expr)
 		|| (node is ast.IndexExpr && t.is_comptime_expr(node.left))
 		|| node is ast.ComptimeSelector
+		|| (node is ast.PostfixExpr && t.is_comptime_expr(node.expr))
 }
 
 // has_comptime_expr checks if the expr contains some comptime expr
@@ -27,6 +28,7 @@ pub fn (t &ResolverInfo) has_comptime_expr(node ast.Expr) bool {
 	return (node is ast.Ident && node.ct_expr)
 		|| (node is ast.IndexExpr && t.has_comptime_expr(node.left))
 		|| node is ast.ComptimeSelector
+		|| (node is ast.PostfixExpr && t.has_comptime_expr(node.expr))
 		|| (node is ast.SelectorExpr && t.has_comptime_expr(node.expr))
 		|| (node is ast.InfixExpr && (t.has_comptime_expr(node.left)
 		|| t.has_comptime_expr(node.right)))
@@ -57,6 +59,9 @@ pub fn (t &ResolverInfo) is_comptime(node ast.Expr) bool {
 		}
 		ast.ComptimeSelector {
 			return true
+		}
+		ast.PostfixExpr {
+			return t.is_comptime(node.expr)
 		}
 		else {
 			false

--- a/vlib/v/type_resolver/type_resolver.v
+++ b/vlib/v/type_resolver/type_resolver.v
@@ -238,7 +238,9 @@ pub fn (mut t TypeResolver) get_type(node ast.Expr) ast.Type {
 		// T(expr)
 		return t.resolver.unwrap_generic(node.typ)
 	} else if node is ast.PostfixExpr && node.op == .question
-		&& (node.expr is ast.Ident && node.expr.ct_expr) {
+		&& node.expr in [ast.Ident, ast.ComptimeSelector] {
+		// var?
+		// f.$(field.name)?
 		ctyp := t.get_type(node.expr)
 		return ctyp.clear_flag(.option)
 	}

--- a/vlib/v/type_resolver/type_resolver.v
+++ b/vlib/v/type_resolver/type_resolver.v
@@ -134,6 +134,12 @@ pub fn (mut t TypeResolver) get_type_or_default(node ast.Expr, default_typ ast.T
 				return t.resolver.unwrap_generic(node.typ)
 			}
 		}
+		ast.PostfixExpr {
+			if node.op == .question && node.expr is ast.Ident && node.expr.ct_expr {
+				ctyp := t.get_type(node)
+				return if ctyp != ast.void_type { ctyp } else { default_typ }
+			}
+		}
 		else {
 			return default_typ
 		}
@@ -174,7 +180,11 @@ pub fn (mut t TypeResolver) get_type(node ast.Expr) ast.Type {
 				}
 				.field_var {
 					// field var from $for loop
-					t.info.comptime_for_field_type
+					if node.obj.ct_type_unwrapped {
+						t.info.comptime_for_field_type.clear_flag(.option)
+					} else {
+						t.info.comptime_for_field_type
+					}
 				}
 				else {
 					ast.void_type
@@ -183,7 +193,11 @@ pub fn (mut t TypeResolver) get_type(node ast.Expr) ast.Type {
 		}
 	} else if node is ast.ComptimeSelector {
 		// val.$(field.name)
-		return t.get_comptime_selector_type(node, ast.void_type)
+		ctyp := t.get_comptime_selector_type(node, ast.void_type)
+		if node.or_block.kind == .propagate_option {
+			return ctyp.clear_flag(.option)
+		}
+		return ctyp
 	} else if node is ast.SelectorExpr {
 		if t.info.is_comptime_selector_type(node) {
 			return t.get_type_from_comptime_var(node.expr as ast.Ident)
@@ -223,6 +237,10 @@ pub fn (mut t TypeResolver) get_type(node ast.Expr) ast.Type {
 	} else if node is ast.CastExpr && node.typ.has_flag(.generic) {
 		// T(expr)
 		return t.resolver.unwrap_generic(node.typ)
+	} else if node is ast.PostfixExpr && node.op == .question
+		&& (node.expr is ast.Ident && node.expr.ct_expr) {
+		ctyp := t.get_type(node.expr)
+		return ctyp.clear_flag(.option)
 	}
 	return ast.void_type
 }

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -229,9 +229,14 @@ fn (e &Encoder) encode_struct[U](val U, level int, mut buf []u8) ! {
 		mut ignore_field := false
 
 		value := val.$(field.name)
-
-		is_nil := val.$(field.name).str() == '&nil'
-
+		mut is_nil := false
+		$if value is $option {
+			if field.indirections > 0 {
+				is_nil = value == none
+			}
+		} $else $if field.indirections > 0 {
+			is_nil = value == unsafe { nil }
+		}
 		mut json_name := ''
 
 		for attr in field.attrs {

--- a/vlib/x/sessions/tests/session_app_test.v
+++ b/vlib/x/sessions/tests/session_app_test.v
@@ -40,7 +40,7 @@ pub fn (mut app App) before_accept_loop() {
 }
 
 pub fn (app &App) session_data(mut ctx Context) veb.Result {
-	return ctx.text(ctx.session_data.str())
+	return ctx.text('${ctx.session_data}')
 }
 
 pub fn (app &App) protected(mut ctx Context) veb.Result {
@@ -122,7 +122,7 @@ fn test_save_session() {
 	x := make_request_with_session_id(.get, '/session_data', sid)!
 
 	// cast to `?User` since, session_data is of type `?T`
-	assert x.body == ?User(default_user).str()
+	assert x.body == '${?User(default_user)}'
 }
 
 fn test_update_session() {
@@ -133,7 +133,7 @@ fn test_update_session() {
 
 	mut updated_user := default_user
 	updated_user.age++
-	assert x.body == ?User(updated_user).str()
+	assert x.body == '${?User(updated_user)}'
 }
 
 fn test_destroy_session() {


### PR DESCRIPTION
Fix #23558
Fix #23557