### PR TITLE
cgen: fix codegen for array's grow_cap, grow_len method from generic array

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1190,6 +1190,13 @@ fn (mut g Gen) gen_array_method_call(node ast.CallExpr, left_type ast.Type, left
 			}
 			g.write(')')
 		}
+		'grow_cap', 'grow_len' {
+			g.write('array_${node.name}(')
+			g.gen_arg_from_type(left_type, node.left)
+			g.write(', ')
+			g.expr(node.args[0].expr)
+			g.write(')')
+		}
 		'first', 'last', 'pop' {
 			mut noscan := ''
 			array_info := left_sym.info as ast.Array

--- a/vlib/v/tests/builtin_arrays/array_grow_cap_test.v
+++ b/vlib/v/tests/builtin_arrays/array_grow_cap_test.v
@@ -1,0 +1,9 @@
+fn grow[T](mut arr []T) {
+	arr.grow_cap(10)
+	unsafe { arr.grow_len(10) }
+}
+
+fn test_main() {
+	mut arr := []int{}
+	grow(mut arr)
+}


### PR DESCRIPTION
Fix #23566