### PR TITLE
encoding.iconv: add flag for OpenBSD to find iconv include and library

### DIFF
--- a/vlib/encoding/iconv/iconv_nix.c.v
+++ b/vlib/encoding/iconv/iconv_nix.c.v
@@ -2,8 +2,12 @@ module iconv
 
 // Module iconv provides functions convert between vstring(UTF8) to/from different encodings.
 
+#flag openbsd -I/usr/local/include
+
 #include <iconv.h>
+
 #flag darwin -liconv
+#flag openbsd -L/usr/local/lib -liconv
 
 fn C.iconv_open(tocode charptr, fromcode charptr) voidptr
 fn C.iconv_close(cd voidptr) int


### PR DESCRIPTION
Fix vlang/v#23573

----

**Tests for iconv OK on OpenBSD current/amd64 with tcc, egcc and clang**

- Tests with tcc
```shell
$ ./v -stats test vlib/encoding/iconv/                                                                                                                                                                    
---- Testing... -----
running tests in: /home/fox/dev/vlang.git/vlib/encoding/iconv/iconv_test.v                                                                                                                                                                                                        
      OK    [1/5]     0.124 ms     8 asserts | main.test_vstring_to_encoding()                                                                                                                                                                                                    
      OK    [2/5]     0.060 ms     8 asserts | main.test_encoding_to_vstring()                                                                                                                                                                                                    
      OK    [3/5]     0.033 ms     5 asserts | main.test_create_utf_string_with_bom()                                                                                                                                                                                             
      OK    [4/5]     0.027 ms     5 asserts | main.test_remove_utf_string_with_bom()
      OK    [5/5]     3.168 ms    30 asserts | main.test_read_file_encoding_write_file_encoding()
     Summary for running V tests in "iconv_test.v": 56 passed, 56 total. Elapsed time: 3 ms.
        V  source  code size:      29427 lines,     794873 bytes,   278 types,    13 modules,   131 files
generated  target  code size:      11673 lines,     447037 bytes
compilation took: 664.205 ms, compilation speed: 44304 vlines/s, cgen threads: 3

 OK     723.901 ms vlib/encoding/iconv/iconv_test.v
-----
```

- Tests with gcc (binary = `egcc`)
```shell
$ ./v -cc egcc -stats test vlib/encoding/iconv/
---- Testing... ----
running tests in: /home/fox/dev/vlang.git/vlib/encoding/iconv/iconv_test.v
      OK    [1/5]     0.192 ms     8 asserts | main.test_vstring_to_encoding()
      OK    [2/5]     0.061 ms     8 asserts | main.test_encoding_to_vstring()
      OK    [3/5]     0.082 ms     5 asserts | main.test_create_utf_string_with_bom()
      OK    [4/5]     0.024 ms     5 asserts | main.test_remove_utf_string_with_bom()
      OK    [5/5]     2.673 ms    30 asserts | main.test_read_file_encoding_write_file_encoding()
     Summary for running V tests in "iconv_test.v": 56 passed, 56 total. Elapsed time: 3 ms.
        V  source  code size:      29427 lines,     794873 bytes,   278 types,    13 modules,   131 files
generated  target  code size:      11659 lines,     446835 bytes
compilation took: 2658.985 ms, compilation speed: 11067 vlines/s, cgen threads: 3

 OK    2717.165 ms vlib/encoding/iconv/iconv_test.v
----
```

- Tests with cglang
```shell
$ ./v -cc clang -stats test vlib/encoding/iconv/
---- Testing... ----
running tests in: /home/fox/dev/vlang.git/vlib/encoding/iconv/iconv_test.v
      OK    [1/5]     0.248 ms     8 asserts | main.test_vstring_to_encoding()
      OK    [2/5]     0.059 ms     8 asserts | main.test_encoding_to_vstring()
      OK    [3/5]     0.176 ms     5 asserts | main.test_create_utf_string_with_bom()
      OK    [4/5]     0.022 ms     5 asserts | main.test_remove_utf_string_with_bom()
      OK    [5/5]     4.773 ms    30 asserts | main.test_read_file_encoding_write_file_encoding()
     Summary for running V tests in "iconv_test.v": 56 passed, 56 total. Elapsed time: 5 ms.
        V  source  code size:      29427 lines,     794873 bytes,   278 types,    13 modules,   131 files
generated  target  code size:      11659 lines,     446835 bytes
compilation took: 1972.469 ms, compilation speed: 14918 vlines/s, cgen threads: 3

 OK    2057.521 ms vlib/encoding/iconv/iconv_test.v
----
```
