### PR TITLE
tools: fix doctor output on OpenBSD

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -136,7 +136,11 @@ fn (mut a App) collect_info() {
 	a.line('.git/config present', os.is_file('.git/config').str())
 	a.line('', '')
 	a.line('cc version', a.cmd(command: 'cc --version'))
-	a.line('gcc version', a.cmd(command: 'gcc --version'))
+	if os_kind == 'openbsd' {
+		a.line('gcc version', a.cmd(command: 'egcc --version'))
+	} else {
+		a.line('gcc version', a.cmd(command: 'gcc --version'))
+	}
 	a.line('clang version', a.cmd(command: 'clang --version'))
 	if os_kind == 'windows' {
 		// Check for MSVC on windows
@@ -144,7 +148,11 @@ fn (mut a App) collect_info() {
 	}
 	a.report_tcc_version('thirdparty/tcc')
 	a.line('emcc version', a.cmd(command: 'emcc --version'))
-	a.line('glibc version', a.cmd(command: 'ldd --version'))
+	if os_kind != 'openbsd' {
+		a.line('glibc version', a.cmd(command: 'ldd --version'))
+	} else {
+		a.line('glibc version', 'N/A')
+	}
 }
 
 struct CmdConfig {


### PR DESCRIPTION
- get gcc version via `egcc --version`
- don't run `ldd` to get glibc version

Fix vlang/v#23576

---

**vdoctor output OK on OpenBSD and Linux**

- OpenBSD/amd64
```shell
$ ./v doctor
|V full version      |V 0.4.9 d710d9e.62d618e
|:-------------------|:-------------------
|OS                  |openbsd, 7.6, GENERIC.MP#518
|Processor           |4 cpus, 64bit, little endian
|Memory              |9.3e-10GB/3.98GB
|                    |
|V executable        |/home/fox/dev/vlang.git/v
|V last modified time|2025-01-25 17:44:17
|                    |
|V home dir          |OK, value: /home/fox/dev/vlang.git
|VMODULES            |OK, value: /home/fox/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |OK, value: /home/fox/dev/vlang.git
|                    |
|Git version         |git version 2.48.1
|V git status        |weekly.2025.03-40-ga1c67509
|.git/config present |true
|                    |
|cc version          |OpenBSD clang version 16.0.6
|gcc version         |egcc (GCC) 11.2.0
|clang version       |OpenBSD clang version 16.0.6
|tcc version         |tcc version 0.9.28rc 2024-09-14 HEAD@b8b6a5fd (x86_64 OpenBSD)
|tcc git status      |thirdparty-openbsd-amd64 8205cc59
|emcc version        |N/A
|glibc version       |N/A
```

- Linux Debian/testing
```shell
$ ./v doctor
|V full version      |V 0.4.9 5b27233.62d618e
|:-------------------|:-------------------
|OS                  |linux, Debian GNU/Linux trixie/sid
|Processor           |8 cpus, 64bit, little endian, Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
|Memory              |0.55GB/15.5GB
|                    |
|V executable        |/home/fox/dev/vlang.git/v
|V last modified time|2025-01-25 17:49:25
|                    |
|V home dir          |OK, value: /home/fox/dev/vlang.git
|VMODULES            |OK, value: /home/fox/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |OK, value: /home/fox/dev/vlang.git
|                    |
|Git version         |git version 2.45.2
|V git status        |weekly.2025.03-40-ga1c67509
|.git/config present |true
|                    |
|cc version          |cc (Debian 14.2.0-12) 14.2.0
|gcc version         |gcc (Debian 14.2.0-12) 14.2.0
|clang version       |Debian clang version 19.1.6 (1+b1)
|tcc version         |tcc version 0.9.28rc 2024-07-31 HEAD@1cee0908 (x86_64 Linux)
|tcc git status      |thirdparty-linux-amd64 0134e9b9
|emcc version        |N/A
|glibc version       |ldd (Debian GLIBC 2.40-5) 2.40
```

```
