### PR TITLE
runtime: add free_memory implementation for OpenBSD

### DIFF
--- a/vlib/runtime/free_memory_impl_openbsd.c.v
+++ b/vlib/runtime/free_memory_impl_openbsd.c.v
@@ -1,0 +1,15 @@
+module runtime
+
+fn free_memory_impl() usize {
+	$if cross ? {
+		return 1
+	}
+	$if !cross ? {
+		$if openbsd {
+			page_size := usize(C.sysconf(C._SC_PAGESIZE))
+			av_phys_pages := usize(C.sysconf(C._SC_AVPHYS_PAGES))
+			return page_size * av_phys_pages
+		}
+	}
+	return 1
+}


### PR DESCRIPTION
Implementation of `free_memory` function for OpenBSD => add specific implementation in `vlib/runtime/free_memory_impl_openbsd.c.v`

Closes vlang/v#23579

---

**Tests OK for `runtime` on OpenBSD/amd64**

```shell
$ uname -mrs
OpenBSD 7.6 amd64

$ ./v -stats test vlib/runtime/runtime_test.v
---- Testing... ----
running tests in: /home/fox/dev/vlang.git/vlib/runtime/runtime_test.v
total memory: 4278042624
free  memory: 1288601600
      OK    [1/9]     0.018 ms     1 assert  | main.test_physical_memory()
     nr cpus: 4
      OK    [2/9]     0.008 ms     1 assert  | main.test_nr_cpus()
     nr jobs: 3
      OK    [3/9]     0.009 ms     1 assert  | main.test_nr_jobs()
    is_32bit: false
      OK    [4/9]     0.006 ms     1 assert  | main.test_is_32bit()
    is_64bit: true
      OK    [5/9]     0.008 ms     1 assert  | main.test_is_64bit()
       is_le: true
      OK    [6/9]     0.002 ms     1 assert  | main.test_is_little_endian()
       is_be: false
      OK    [7/9]     0.008 ms     1 assert  | main.test_is_big_endian()
      OK    [8/9]     0.001 ms     1 assert  | main.test_is_big_endian_different_than_is_little_endian()
      OK    [9/9]     0.001 ms     1 assert  | main.test_is_32bit_different_than_is_64bit()
     Summary for running V tests in "runtime_test.v": 9 passed, 9 total. Elapsed time: 0 ms.
        V  source  code size:      29210 lines,     785098 bytes,   277 types,    13 modules,   132 files
generated  target  code size:      10460 lines,     373742 bytes
compilation took: 772.641 ms, compilation speed: 37805 vlines/s, cgen threads: 3

 OK     861.216 ms vlib/runtime/runtime_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 864 ms, on 1 job. Comptime: 0 ms. Runtime: 861 ms.
```