### PR TITLE
checker: disallow constant modification on `unsafe {}` 

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -921,7 +921,7 @@ fn (mut c Checker) fail_if_immutable(mut expr ast.Expr) (string, token.Pos) {
 					}
 				}
 			} else if expr.obj is ast.ConstField && expr.name in c.const_names {
-				if !c.inside_unsafe && !c.pref.translated {
+				if !c.pref.translated {
 					// TODO: fix this in c2v, do not allow modification of all consts
 					// in translated code
 					c.error('cannot modify constant `${expr.name}`', expr.pos)


### PR DESCRIPTION
Fix #23582