### PR TITLE
encoding: remove/modify deprecated tests for utf8/utf8_util

### DIFF
--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -23,7 +23,6 @@ fn test_utf8_util() {
 	a := '.abc?abcòàè.'
 	assert utf8.is_punct(a, 0) == true
 	assert utf8.is_punct('b', 0) == false
-	assert utf8.is_uchar_punct(0x002E) == true // Test deprecated
 	assert utf8.is_rune_punct(0x002E) == true
 	assert utf8.is_punct(a, 4) == true // ?
 	assert utf8.is_punct(a, 14) == true // last .
@@ -34,13 +33,12 @@ fn test_utf8_util() {
 	b := '.ĂĂa. ÔÔ TESTO Æ€'
 	assert utf8.is_global_punct(b, 0) == true
 	assert utf8.is_global_punct('.', 0) == true
-	assert utf8.is_uchar_punct(0x002E) == true // Test deprecated
 	assert utf8.is_rune_punct(0x002E) == true
 	assert utf8.is_global_punct(b, 6) == true // .
 	assert utf8.is_global_punct(b, 1) == false // a
 
 	// test utility functions
-	assert utf8.get_uchar(b, 0) == 0x002E // Test deprecated
+	assert utf8.get_rune(b, 0) == 0x002E
 	c := 'a©★🚀'
 	assert utf8.get_rune(c, 0) == `a` // 1 byte
 	assert utf8.get_rune(c, 1) == `©` // 2 bytes


### PR DESCRIPTION
Fix vlang/v#23599