### PR TITLE
builtin: fix tests for map

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -211,10 +211,10 @@ fn test_various_map_value() {
 	// assert m13['test'] == rune(0)
 	mut m14 := map[string]voidptr{}
 	m14['test'] = unsafe { nil }
-	assert m14['test'] == unsafe { nil }
+	assert unsafe { m14['test'] } == unsafe { nil }
 	mut m15 := map[string]&u8{}
 	m15['test'] = &u8(0)
-	assert m15['test'] == &u8(0)
+	assert unsafe { m15['test'] } == &u8(0)
 	mut m16 := map[string]i64{}
 	m16['test'] = i64(0)
 	assert m16['test'] == i64(0)
@@ -223,7 +223,7 @@ fn test_various_map_value() {
 	assert m17['test'] == u64(0)
 	mut m18 := map[string]&int{}
 	m18['test'] = &int(0)
-	assert m18['test'] == &int(0)
+	assert unsafe { m18['test'] } == &int(0)
 }
 
 fn test_string_arr() {
@@ -668,8 +668,8 @@ fn test_voidptr_values() {
 	v := 5
 	m['var'] = &v
 	m['map'] = &m
-	assert m['var'] == &v
-	assert m['map'] == &m
+	assert unsafe { m['var'] } == &v
+	assert unsafe { m['map'] } == &m
 	assert m.values().len == 2
 }
 


### PR DESCRIPTION
Fix vlang/v#23601

---

**Tests OK** for `vlib/builtin/map_test.v`: no warning/error

```sh
$ ./v -stats test vlib/builtin/map_test.v                                                                                                                                                                                                     
---- Testing... ----------------------------------------------------------------------------------------------------------------------------                                                                                                                                      
running tests in: /home/fox/dev/vlang.git/vlib/builtin/map_test.v                                                                                                                                                                                                                 
      OK    [ 1/54]     7.128 ms 21001 asserts | main.test_get_and_set_many()                                                                                                                                                                                                     
      OK    [ 2/54]     3.585 ms  7000 asserts | main.test_for_in_many()                                                                                                                                                                                                          
      OK    [ 3/54]     2.493 ms     3 asserts | main.test_keys_many()                                                                                                                                                                                                            
      OK    [ 4/54]     2.148 ms     2 asserts | main.test_values_many()                                                                                                                                                                                                          
      OK    [ 5/54]     6.490 ms 14003 asserts | main.test_deletes_many()                                                                                                                                                                                                         
      OK    [ 6/54]     0.020 ms    24 asserts | main.test_map()                                                                                                                                                                                                                  
      OK    [ 7/54]     0.003 ms     4 asserts | main.test_map_init()                                                                                                                                                                                                             
      OK    [ 8/54]     0.000 ms    NO asserts | main.test_string_map()                                                                                                                                                                                                           
      OK    [ 9/54]    11.824 ms     3 asserts | main.test_large_map()                                                                                                                                                                                                            
      OK    [10/54]     0.018 ms    15 asserts | main.test_various_map_value()                                                                                                                                                                                                    
      OK    [11/54]     0.003 ms     3 asserts | main.test_string_arr()                                                                                                                                                                                                           
      OK    [12/54]     0.000 ms     1 assert  | main.test_mut_arg()                                                                                                                                                                                                              
      OK    [13/54]     0.000 ms     1 assert  | main.test_clear()                                                                                                                                                                                                                
2                                                                                                                                                                                                                                                                                 
0                                                                                                                                                                                                                                                                                 
false                                                                                                                                                                                                                                                                             
      OK    [14/54]     0.003 ms     1 assert  | main.test_delete()                                                                                                                                                                                                               
10                                                                                                                                                                                                                                                                                
10                                                                                                                                                                                                                                                                                
10
10
10
10
10
10
10
10
      OK    [15/54]     0.069 ms    10 asserts | main.test_delete_size()
      OK    [16/54]   190.915 ms 1001000 asserts | main.test_nested_for_in()
      OK    [17/54]     0.874 ms  1002 asserts | main.test_delete_in_for_in()
      OK    [18/54]     0.007 ms    12 asserts | main.test_set_in_for_in()
      OK    [19/54]     1.354 ms  2002 asserts | main.test_delete_and_set_in_for_in()
      OK    [20/54]     0.005 ms    NO asserts | main.test_map_assign()
      OK    [21/54]     0.008 ms     4 asserts | main.test_postfix_op_directly()
      OK    [22/54]     0.002 ms     2 asserts | main.test_map_push_directly()
      OK    [23/54]     0.001 ms     2 asserts | main.test_assign_directly()
      OK    [24/54]     0.001 ms     2 asserts | main.test_map_in_directly()
      OK    [25/54]     0.001 ms     2 asserts | main.test_plus_assign_string()
['a', 'c']
      OK    [26/54]     0.002 ms     1 assert  | main.test_map_keys_to_array()
      OK    [27/54]     0.001 ms     1 assert  | main.test_map_in_mut()
      OK    [28/54]     0.001 ms     1 assert  | main.test_map_in()
      OK    [29/54]     0.006 ms     6 asserts | main.test_mut_map_with_relation_op_in_fn()
m: {'first': 1, 'third': 3}
      OK    [30/54]     0.008 ms     2 asserts | main.test_map_str_after_delete()
      OK    [31/54]     0.001 ms     2 asserts | main.test_modify_map_value()
      OK    [32/54]     0.007 ms     4 asserts | main.test_map_clone()

      OK    [33/54]     0.002 ms     1 assert  | main.test_map_default_zero()
      OK    [34/54]     0.000 ms    NO asserts | main.test_map_or()
      OK    [35/54]     0.012 ms    19 asserts | main.test_int_keys()
      OK    [36/54]     0.000 ms     1 assert  | main.test_alias_enum()
      OK    [37/54]     0.001 ms     3 asserts | main.test_enum_in_map()
      OK    [38/54]     0.004 ms     3 asserts | main.test_voidptr_keys()
      OK    [39/54]     0.001 ms     3 asserts | main.test_voidptr_values()
{`!`: 2, `%`: 3, `@`: 7}
      OK    [40/54]     0.006 ms     5 asserts | main.test_rune_keys()
      OK    [41/54]     0.013 ms     4 asserts | main.test_eq()
      OK    [42/54]     0.007 ms     3 asserts | main.test_non_string_key_map_str()
{}
      OK    [43/54]     0.002 ms     2 asserts | main.test_map_assign_empty_map_init()
      OK    [44/54]     0.000 ms     1 assert  | main.test_in_map_literal()
      OK    [45/54]     0.289 ms  1122 asserts | main.test_byte_keys()
      OK    [46/54]     0.970 ms  4502 asserts | main.test_i16_keys()
      OK    [47/54]     1.145 ms  4502 asserts | main.test_u16_keys()
      OK    [48/54]     0.993 ms  4502 asserts | main.test_u32_keys()
      OK    [49/54]     0.982 ms  4502 asserts | main.test_int_keys2()
      OK    [50/54]     1.032 ms  4502 asserts | main.test_i64_keys()
      OK    [51/54]     1.209 ms  4502 asserts | main.test_u64_keys()
{'A': [1.1, 2.2]}
{'A': [1.1, 2.2]}
      OK    [52/54]     0.015 ms     2 asserts | main.test_map_set_fixed_array_variable()
Map({11: 111, 22: 222})
Map({22: 222})
      OK    [53/54]     0.003 ms     2 asserts | main.test_alias_of_map_delete()
      OK    [54/54]     0.003 ms     2 asserts | main.test_map_clear()
     Summary for running V tests in "map_test.v": 1074301 passed, 1074301 total. Elapsed time: 234 ms.
        V  source  code size:      31684 lines,     842011 bytes,   338 types,    19 modules,   144 files
generated  target  code size:      19572 lines,     814176 bytes
compilation took: 363.876 ms, compilation speed: 87073 vlines/s, cgen threads: 7

 OK     825.759 ms vlib/builtin/map_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 827 ms, on 1 job. Comptime: 0 ms. Runtime: 825 ms.
```