### PR TITLE
parser: fix anon fn return type option/result parsing  

### DIFF
--- a/vlib/v/fmt/tests/anon_fn_result_return_with_comment_keep.vv
+++ b/vlib/v/fmt/tests/anon_fn_result_return_with_comment_keep.vv
@@ -1,0 +1,14 @@
+module main
+
+pub interface Command {
+	name    string            // Command name as used on CLI
+	desc    string            // Single line description
+	help    string            // Detailed and formated description
+	arg_min int               // Minimal argument number expected
+	arg_max int               // Maximal argument number expected
+	exec    fn (s []string) ! // Command callback.
+}
+
+fn main() {
+	println('Hello')
+}

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -479,7 +479,7 @@ fn (mut p Parser) parse_type() ast.Type {
 		is_attr := p.tok.kind == .at
 
 		if p.tok.line_nr > line_nr || p.tok.kind in [.comma, .rpar, .assign]
-			|| (is_attr || is_required_field) {
+			|| (is_attr || is_required_field) || p.tok.kind == .comment {
 			mut typ := ast.void_type
 			if is_option {
 				typ = typ.set_flag(.option)


### PR DESCRIPTION
Fix #23607