### PR TITLE
log,sync: fix macos CI failure when log.ThreadSafeLog is used explicitly in `v download`

### DIFF
--- a/vlib/log/safe_log.v
+++ b/vlib/log/safe_log.v
@@ -7,7 +7,7 @@ import sync
 pub struct ThreadSafeLog {
 	Log
 pub mut:
-	mu sync.Mutex
+	mu &sync.Mutex = sync.new_mutex()
 }
 
 // new_thread_safe_log returns a new log structure, whose methods are safe
@@ -16,7 +16,6 @@ pub fn new_thread_safe_log() &ThreadSafeLog {
 	mut x := &ThreadSafeLog{
 		level: .info
 	}
-	x.mu.init()
 	return x
 }
 

--- a/vlib/log/safe_log.v
+++ b/vlib/log/safe_log.v
@@ -25,6 +25,7 @@ pub fn (mut x ThreadSafeLog) free() {
 	unsafe {
 		x.Log.free()
 		x.mu.destroy()
+		free(x.mu)
 		// C.printf(c'ThreadSafeLog free(x), x: %p\n', x)
 	}
 }

--- a/vlib/sync/sync.c.v
+++ b/vlib/sync/sync.c.v
@@ -9,3 +9,9 @@ fn cpanic(res int) {
 fn cpanic_errno() {
 	cpanic(C.errno)
 }
+
+fn should_be_zero(res int) {
+	if res != 0 {
+		cpanic(res)
+	}
+}

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -126,10 +126,7 @@ pub fn (mut m Mutex) unlock() {
 // destroy frees the resources associated with the mutex instance.
 // Note: the mutex itself is not freed.
 pub fn (mut m Mutex) destroy() {
-	res := C.pthread_mutex_destroy(&m.mutex)
-	if res != 0 {
-		cpanic(res)
-	}
+	should_be_zero(C.pthread_mutex_destroy(&m.mutex))
 }
 
 // rlock locks the given RwMutex instance for reading.
@@ -171,10 +168,7 @@ pub fn (mut m RwMutex) try_wlock() bool {
 // destroy frees the resources associated with the rwmutex instance.
 // Note: the mutex itself is not freed.
 pub fn (mut m RwMutex) destroy() {
-	res := C.pthread_rwlock_destroy(&m.mutex)
-	if res != 0 {
-		cpanic(res)
-	}
+	should_be_zero(C.pthread_rwlock_destroy(&m.mutex))
 }
 
 // runlock unlocks the RwMutex instance, locked for reading.
@@ -307,8 +301,5 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 // destroy frees the resources associated with the Semaphore instance.
 // Note: the semaphore instance itself is not freed.
 pub fn (mut sem Semaphore) destroy() {
-	res := C.sem_destroy(&sem.sem)
-	if res != 0 {
-		cpanic(res)
-	}
+	should_be_zero(C.sem_destroy(&sem.sem))
 }

--- a/vlib/sync/sync_freebsd.c.v
+++ b/vlib/sync/sync_freebsd.c.v
@@ -124,10 +124,7 @@ pub fn (mut m Mutex) unlock() {
 // destroy frees the resources associated with the mutex instance.
 // Note: the mutex itself is not freed.
 pub fn (mut m Mutex) destroy() {
-	res := C.pthread_mutex_destroy(&m.mutex)
-	if res != 0 {
-		cpanic(res)
-	}
+	should_be_zero(C.pthread_mutex_destroy(&m.mutex))
 }
 
 // rlock locks the given RwMutex instance for reading.
@@ -169,10 +166,7 @@ pub fn (mut m RwMutex) try_wlock() bool {
 // destroy frees the resources associated with the rwmutex instance.
 // Note: the mutex itself is not freed.
 pub fn (mut m RwMutex) destroy() {
-	res := C.pthread_rwlock_destroy(&m.mutex)
-	if res != 0 {
-		cpanic(res)
-	}
+	should_be_zero(C.pthread_rwlock_destroy(&m.mutex))
 }
 
 // runlock unlocks the RwMutex instance, locked for reading.
@@ -305,8 +299,5 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 // destroy frees the resources associated with the Semaphore instance.
 // Note: the semaphore instance itself is not freed.
 pub fn (mut sem Semaphore) destroy() {
-	res := C.sem_destroy(&sem.sem)
-	if res != 0 {
-		cpanic(res)
-	}
+	should_be_zero(C.sem_destroy(&sem.sem))
 }


### PR DESCRIPTION
- **log,sync: fix macos failure with log.ThreadSafeLog**
- **log: add missing free(x.mu), since now `mu` is heap allocated**