### PR TITLE
crypto.ecdsa: fix handling sign with custom_hash

### DIFF
--- a/vlib/crypto/ecdsa/util_test.v
+++ b/vlib/crypto/ecdsa/util_test.v
@@ -2,6 +2,8 @@ module ecdsa
 
 import encoding.hex
 import crypto.pem
+import crypto.sha1
+import crypto.sha512
 
 // This material wss generated with https://emn178.github.io/online-tools/ecdsa/key-generator
 // with curve SECG secp384r1 aka NIST P-384
@@ -125,4 +127,69 @@ UHhnmmVRraSwrVkPdYIeXhH/Ob4+8OLcwrQBMv4RXsD1GVFsgkvEYDTEb/vnMA==
 		assert err == error('Unsupported group')
 		return
 	}
+}
+
+fn test_key_signing_verifying_with_custom_hash() ! {
+	// privatekey_sample was P-384 key
+	pvkey := privkey_from_string(privatekey_sample)!
+	// public key part	
+	pbkey := pvkey.public_key()!
+	pbk := pubkey_from_string(public_key_sample)!
+
+	// lets sign the message with default hash, ie, sha384
+	signature := pvkey.sign(message_tobe_signed)!
+	verified := pbkey.verify(message_tobe_signed, signature)!
+	assert verified == true
+
+	// Use the bigger custom hash
+	opt0 := SignerOpts{
+		hash_config:       .with_custom_hash
+		allow_custom_hash: true
+		custom_hash:       sha512.new()
+	}
+	// online-generated signature with sha512 digest with the same params from https://emn178.github.io/online-tools/ecdsa/sign/
+	online_sign0 := hex.decode('3066023100b54b479b64961481074c4200a9dec83fb8a42bb7db53cf97f1da131504a058ead85d0a9e4e32be14098bc9b4d1a5a8dd023100f9c7de178a286329103f684d1eab1ccfe359c65a41a1459d7f535b703c57048f25931b1670ab4ec7a812d94c69063522')!
+	// library generated signature
+	sign0 := pvkey.sign(message_tobe_signed, opt0)!
+	v00 := pbkey.verify(message_tobe_signed, sign0, opt0)!
+	// this own signature should assert into true
+	assert v00 == true
+
+	// verify online-generated signature
+	v01 := pbkey.verify(message_tobe_signed, online_sign0, opt0)!
+	assert v01 == true
+
+	// with public_key_sample key
+	v02 := pbk.verify(message_tobe_signed, sign0, opt0)!
+	assert v02 == true
+	v03 := pbk.verify(message_tobe_signed, online_sign0, opt0)!
+	assert v03 == true
+
+	// Use smaller custom hash
+	opt1 := SignerOpts{
+		hash_config:        .with_custom_hash
+		allow_custom_hash:  true
+		allow_smaller_size: true
+		custom_hash:        sha1.new()
+	}
+	// online-generated signature with SHA1 digest
+	online_sign1 := hex.decode('306602310084299d8a70bf512c25cd2b79ae36509572f2bd6f198baeee074683578a70b4af8008e1cf451a2df1a887cf43daff4eea023100dceb267fe5037025c2af9f37911e05a36cbe666dd90fd6904020b5db056e86f25f9439a0ccb443d113b174cab6e2ad61')!
+	// library generated signature
+	sign1 := pvkey.sign(message_tobe_signed, opt1)!
+	verified1 := pbkey.verify(message_tobe_signed, sign1, opt1)!
+	// this own signature should assert into true
+	assert verified1 == true
+	// verify online-generated signature
+	verified11 := pbkey.verify(message_tobe_signed, online_sign1, opt1)!
+	assert verified11 == true
+
+	// verify with public_key_sample key
+	v11 := pbk.verify(message_tobe_signed, sign1, opt1)!
+	assert v11 == true
+	v12 := pbk.verify(message_tobe_signed, online_sign1, opt1)!
+	assert v12 == true
+
+	pvkey.free()
+	pbkey.free()
+	pbk.free()
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This small PR following previously already merged PR in [fix-no-hash](https://github.com/vlang/v/pull/23612) commit.
The current handling with custom hash was still contains some bogus thing without additional test (sorry, its my bad).
Its resolved in the current PR, by the way with:

- call `.reset()` on the custom hash before writing messages
- previously, its not call `.write()` before `.sum()` ..its does not matching to expected result, when compared, for examples digest produced with `sha256.sum256(message)` directly.  The equivalent of `sum(message)` was

```v
_ := custom_hash.write(message)!
digest := custom_hash.sum([]u8{})
```

- Add some test to verify expected behaviour

Thanks ...