### PR TITLE
runtime: add note for the availability of the free_memory/0 implementation

### DIFF
--- a/vlib/runtime/runtime_nix.c.v
+++ b/vlib/runtime/runtime_nix.c.v
@@ -15,6 +15,8 @@ pub fn total_memory() usize {
 }
 
 // free_memory returns free physical memory found on the system.
+// Note: implementation available only on Darwin, FreeBSD, Linux, OpenBSD and
+// Windows. Otherwise, returns 1.
 pub fn free_memory() usize {
 	return free_memory_impl()
 }


### PR DESCRIPTION
Implementation available only on Darwin, FreeBSD, Linux, OpenBSD and Windows.