### PR TITLE
all: update copyright year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2024 Alexander Medvednikov
+Copyright (c) 2019-2025 Alexander Medvednikov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import os

--- a/cmd/tools/fast/fast_job.v
+++ b/cmd/tools/fast/fast_job.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import os

--- a/cmd/tools/translate.v
+++ b/cmd/tools/translate.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module main
 

--- a/cmd/tools/vbump.v
+++ b/cmd/tools/vbump.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Subhomoy Haldar. All rights reserved.
+// Copyright (c) 2019-2025 Subhomoy Haldar. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module main
 

--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module main
 

--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/cmd/tools/vvet/errors.v
+++ b/cmd/tools/vvet/errors.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 import v.token
 import term

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module main
 

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/examples/gg/worker_thread.v
+++ b/examples/gg/worker_thread.v
@@ -1,4 +1,4 @@
-// Copyright(C) 2019 Lars Pontoppidan. All rights reserved.
+// Copyright (c) 2019-2025 Lars Pontoppidan. All rights reserved.
 // Use of this source code is governed by an MIT license file distributed with this software package.
 module main
 

--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import net.http

--- a/examples/path_tracing.v
+++ b/examples/path_tracing.v
@@ -1,7 +1,7 @@
 /**********************************************************************
 * path tracing demo
 *
-* Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+* Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 * Use of this source code is governed by an MIT license
 * that can be found in the LICENSE file.
 *

--- a/examples/regex/regex_example.v
+++ b/examples/regex/regex_example.v
@@ -1,7 +1,7 @@
 /**********************************************************************
 * regex samples
 *
-* Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+* Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 * Use of this source code is governed by an MIT license
 * that can be found in the LICENSE file.
 *

--- a/examples/sokol/particles/modules/particle/LICENSE
+++ b/examples/sokol/particles/modules/particle/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Lars Pontoppidan
+Copyright (c) 2019-2025 Lars Pontoppidan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/sokol/particles/modules/particle/color.v
+++ b/examples/sokol/particles/modules/particle/color.v
@@ -1,4 +1,4 @@
-// Copyright(C) 2019 Lars Pontoppidan. All rights reserved.
+// Copyright (c) 2019-2025 Lars Pontoppidan. All rights reserved.
 // Use of this source code is governed by an MIT license file distributed with this software package
 module particle
 

--- a/examples/sokol/particles/modules/particle/particle.v
+++ b/examples/sokol/particles/modules/particle/particle.v
@@ -1,4 +1,4 @@
-// Copyright(C) 2019 Lars Pontoppidan. All rights reserved.
+// Copyright (c) 2019-2025 Lars Pontoppidan. All rights reserved.
 // Use of this source code is governed by an MIT license file distributed with this software package
 module particle
 

--- a/examples/sokol/particles/modules/particle/system.v
+++ b/examples/sokol/particles/modules/particle/system.v
@@ -1,4 +1,4 @@
-// Copyright(C) 2019 Lars Pontoppidan. All rights reserved.
+// Copyright (c) 2019-2025 Lars Pontoppidan. All rights reserved.
 // Use of this source code is governed by an MIT license file distributed with this software package
 module particle
 

--- a/examples/sokol/particles/particles.v
+++ b/examples/sokol/particles/particles.v
@@ -1,4 +1,4 @@
-// Copyright(C) 2019 Lars Pontoppidan. All rights reserved.
+// Copyright (c) 2019-2025 Lars Pontoppidan. All rights reserved.
 // Use of this source code is governed by an MIT license file distributed with this software package
 module main
 

--- a/examples/tetris/tetris.js.v
+++ b/examples/tetris/tetris.js.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/examples/tetris/tetris.v
+++ b/examples/tetris/tetris.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module main

--- a/examples/word_counter/word_counter.v
+++ b/examples/word_counter/word_counter.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import os

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]
@@ -148,7 +148,7 @@ pub enum AttributeKind {
 	string          // ['name']
 	number          // [123]
 	bool            // [true] || [false]
-	comptime_define // [if name]	
+	comptime_define // [if name]
 }
 
 pub struct VAttribute {

--- a/vlib/builtin/builtin_nix.c.v
+++ b/vlib/builtin/builtin_nix.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/builtin/float.c.v
+++ b/vlib/builtin/float.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module builtin
 

--- a/vlib/builtin/float_x64.v
+++ b/vlib/builtin/float_x64.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module builtin
 

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/js/builtin.v
+++ b/vlib/builtin/js/builtin.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/js/jsfns.js.v
+++ b/vlib/builtin/js/jsfns.js.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/js/jsfns_browser.js.v
+++ b/vlib/builtin/js/jsfns_browser.js.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/js/jsfns_node.js.v
+++ b/vlib/builtin/js/jsfns_node.js.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/js/string_test.js.v
+++ b/vlib/builtin/js/string_test.js.v
@@ -3,7 +3,7 @@
 
 // import strings
 
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/option.v
+++ b/vlib/builtin/option.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/result.v
+++ b/vlib/builtin/result.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/rune.v
+++ b/vlib/builtin/rune.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module builtin
 

--- a/vlib/builtin/sorted_map.v
+++ b/vlib/builtin/sorted_map.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -4,7 +4,7 @@ import strconv
 import strings
 
 /*=============================================================================
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/builtin/string_strip_margin_test.v
+++ b/vlib/builtin/string_strip_margin_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/string_trim_indent_test.v
+++ b/vlib/builtin/string_trim_indent_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builtin

--- a/vlib/coroutines/coroutines.c.v
+++ b/vlib/coroutines/coroutines.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module coroutines

--- a/vlib/crypto/aes/aes.v
+++ b/vlib/crypto/aes/aes.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Based off:   https://github.com/golang/go/blob/master/src/crypto/aes

--- a/vlib/crypto/aes/aes_test.v
+++ b/vlib/crypto/aes/aes_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.aes

--- a/vlib/crypto/aes/block_generic.v
+++ b/vlib/crypto/aes/block_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // This implementation is derived from the golang implementation

--- a/vlib/crypto/aes/const.v
+++ b/vlib/crypto/aes/const.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/aes/cypher_generic.v
+++ b/vlib/crypto/aes/cypher_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module aes

--- a/vlib/crypto/cipher/aes_cbc_test.v
+++ b/vlib/crypto/cipher/aes_cbc_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.aes

--- a/vlib/crypto/cipher/xor_generic.v
+++ b/vlib/crypto/cipher/xor_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module cipher

--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module ecdsa

--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module ecdsa

--- a/vlib/crypto/internal/subtle/aliasing.v
+++ b/vlib/crypto/internal/subtle/aliasing.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Package subtle implements functions that are often useful in cryptographic

--- a/vlib/crypto/md5/md5.v
+++ b/vlib/crypto/md5/md5.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Package md5 implements the MD5 hash algorithm as defined in RFC 1321.

--- a/vlib/crypto/md5/md5_test.v
+++ b/vlib/crypto/md5/md5_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.md5

--- a/vlib/crypto/md5/md5block_generic.v
+++ b/vlib/crypto/md5/md5block_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/rand/rand.v
+++ b/vlib/crypto/rand/rand.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/rand/rand_darwin.c.v
+++ b/vlib/crypto/rand/rand_darwin.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/rand/rand_default.c.v
+++ b/vlib/crypto/rand/rand_default.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module rand

--- a/vlib/crypto/rand/rand_linux.c.v
+++ b/vlib/crypto/rand/rand_linux.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module rand

--- a/vlib/crypto/rand/rand_solaris.c.v
+++ b/vlib/crypto/rand/rand_solaris.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/rand/rand_windows.c.v
+++ b/vlib/crypto/rand/rand_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/crypto/rc4/rc4.v
+++ b/vlib/crypto/rc4/rc4.v
@@ -1,6 +1,6 @@
 module rc4
 
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Package rc4 implements RC4 encryption, as defined in Bruce Schneier's

--- a/vlib/crypto/rc4/rc4_test.v
+++ b/vlib/crypto/rc4/rc4_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.cipher

--- a/vlib/crypto/sha1/sha1.v
+++ b/vlib/crypto/sha1/sha1.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Package sha1 implements the SHA-1 hash algorithm as defined in RFC 3174.

--- a/vlib/crypto/sha1/sha1_test.v
+++ b/vlib/crypto/sha1/sha1_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.sha1

--- a/vlib/crypto/sha1/sha1block_generic.v
+++ b/vlib/crypto/sha1/sha1block_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // This is the generic version with no architecture optimizations.

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Package sha256 implements the SHA224 and SHA256 hash algorithms as defined

--- a/vlib/crypto/sha256/sha256_test.v
+++ b/vlib/crypto/sha256/sha256_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.sha256

--- a/vlib/crypto/sha256/sha256block_generic.v
+++ b/vlib/crypto/sha256/sha256block_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // SHA256 block step.

--- a/vlib/crypto/sha512/sha512.v
+++ b/vlib/crypto/sha512/sha512.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Package sha512 implements the SHA-384, SHA-512, SHA-512/224, and SHA-512/256

--- a/vlib/crypto/sha512/sha512_test.v
+++ b/vlib/crypto/sha512/sha512_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import crypto.sha512

--- a/vlib/crypto/sha512/sha512block_generic.v
+++ b/vlib/crypto/sha512/sha512block_generic.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // SHA512 block step.

--- a/vlib/encoding/base32/base32.v
+++ b/vlib/encoding/base32/base32.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/encoding/base64/base64.v
+++ b/vlib/encoding/base64/base64.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Based off:   https://github.com/golang/go/blob/master/src/encoding/base64/base64.go

--- a/vlib/encoding/binary/big_endian.v
+++ b/vlib/encoding/binary/big_endian.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module binary

--- a/vlib/encoding/binary/big_endian_fixed.v
+++ b/vlib/encoding/binary/big_endian_fixed.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module binary

--- a/vlib/encoding/binary/little_endian.v
+++ b/vlib/encoding/binary/little_endian.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module binary

--- a/vlib/encoding/binary/little_endian_fixed.v
+++ b/vlib/encoding/binary/little_endian_fixed.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module binary

--- a/vlib/encoding/csv/reader.v
+++ b/vlib/encoding/csv/reader.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module csv

--- a/vlib/encoding/csv/utils.v
+++ b/vlib/encoding/csv/utils.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module csv

--- a/vlib/encoding/csv/utils_test.v
+++ b/vlib/encoding/csv/utils_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module csv

--- a/vlib/encoding/csv/writer.v
+++ b/vlib/encoding/csv/writer.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module csv

--- a/vlib/encoding/utf8/utf8_tables.v
+++ b/vlib/encoding/utf8/utf8_tables.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module utf8
 

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -1,6 +1,6 @@
 // utf-8 utility string functions
 //
-// Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+// Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module utf8

--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 

--- a/vlib/gg/enums.v
+++ b/vlib/gg/enums.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 
 module gg

--- a/vlib/gg/gg.v
+++ b/vlib/gg/gg.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 
 module gg

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 

--- a/vlib/gg/image.v
+++ b/vlib/gg/image.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 

--- a/vlib/gg/text_rendering.v
+++ b/vlib/gg/text_rendering.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 

--- a/vlib/hash/crc32/crc32.v
+++ b/vlib/hash/crc32/crc32.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/hash/hash.v
+++ b/vlib/hash/hash.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module hash

--- a/vlib/hash/wyhash.v
+++ b/vlib/hash/wyhash.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/json/cjson/cjson_wrapper.c.v
+++ b/vlib/json/cjson/cjson_wrapper.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module cjson

--- a/vlib/json/json_primitives.c.v
+++ b/vlib/json/json_primitives.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module json

--- a/vlib/log/default.c.v
+++ b/vlib/log/default.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/log/default.v
+++ b/vlib/log/default.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module log

--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module log

--- a/vlib/math/bits.v
+++ b/vlib/math/bits.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module bits

--- a/vlib/math/bits/bits_tables.v
+++ b/vlib/math/bits/bits_tables.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module bits

--- a/vlib/math/bits/unsafe_bits.v
+++ b/vlib/math/bits/unsafe_bits.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module bits

--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/math/const.v
+++ b/vlib/math/const.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/math/fractions/approximations.v
+++ b/vlib/math/fractions/approximations.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fractions

--- a/vlib/math/fractions/approximations_test.v
+++ b/vlib/math/fractions/approximations_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import math.fractions

--- a/vlib/math/fractions/fraction.v
+++ b/vlib/math/fractions/fraction.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fractions

--- a/vlib/math/fractions/fraction_test.v
+++ b/vlib/math/fractions/fraction_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import math.fractions

--- a/vlib/math/limit.v
+++ b/vlib/math/limit.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/math/math.c.v
+++ b/vlib/math/math.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/math/min_max_abs.v
+++ b/vlib/math/min_max_abs.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/math/unsafe.v
+++ b/vlib/math/unsafe.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module math

--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/backend_vschannel_windows.c.v
+++ b/vlib/net/http/backend_vschannel_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/cookie.v
+++ b/vlib/net/http/cookie.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/download_nix.c.v
+++ b/vlib/net/http/download_nix.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/download_windows.c.v
+++ b/vlib/net/http/download_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/method.v
+++ b/vlib/net/http/method.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/util.v
+++ b/vlib/net/http/util.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/http/version.v
+++ b/vlib/net/http/version.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module http

--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import net.urllib

--- a/vlib/net/urllib/values.v
+++ b/vlib/net/urllib/values.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module urllib

--- a/vlib/net/urllib/values_test.v
+++ b/vlib/net/urllib/values_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module urllib

--- a/vlib/os/args.v
+++ b/vlib/os/args.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module os

--- a/vlib/os/environment.c.v
+++ b/vlib/os/environment.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module os

--- a/vlib/os/font/font.v
+++ b/vlib/os/font/font.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 
 module font

--- a/vlib/os/inode.c.v
+++ b/vlib/os/inode.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module os

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module os

--- a/vlib/os/os_darwin.c.v
+++ b/vlib/os/os_darwin.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module os

--- a/vlib/os/os_linux.c.v
+++ b/vlib/os/os_linux.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module os

--- a/vlib/rand/buffer/buffer.v
+++ b/vlib/rand/buffer/buffer.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module buffer

--- a/vlib/rand/config/config.v
+++ b/vlib/rand/config/config.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module config

--- a/vlib/rand/mini_math.v
+++ b/vlib/rand/mini_math.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module rand

--- a/vlib/rand/mt19937/mt19937.v
+++ b/vlib/rand/mt19937/mt19937.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module mt19937

--- a/vlib/rand/musl/musl_rng.v
+++ b/vlib/rand/musl/musl_rng.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module musl

--- a/vlib/rand/pcg32/pcg32.v
+++ b/vlib/rand/pcg32/pcg32.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module pcg32

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/rand/seed/seed.v
+++ b/vlib/rand/seed/seed.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module seed

--- a/vlib/rand/splitmix64/splitmix64.v
+++ b/vlib/rand/splitmix64/splitmix64.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module splitmix64

--- a/vlib/rand/sys/system_rng.c.v
+++ b/vlib/rand/sys/system_rng.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sys

--- a/vlib/rand/sys/system_rng.js.v
+++ b/vlib/rand/sys/system_rng.js.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sys

--- a/vlib/rand/wyrand/wyrand.v
+++ b/vlib/rand/wyrand/wyrand.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module wyrand

--- a/vlib/readline/readline.v
+++ b/vlib/readline/readline.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/readline/readline_default.c.v
+++ b/vlib/readline/readline_default.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/readline/readline_nix.c.v
+++ b/vlib/readline/readline_nix.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/readline/readline_windows.c.v
+++ b/vlib/readline/readline_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/regex/regex.v
+++ b/vlib/regex/regex.v
@@ -1,7 +1,7 @@
 /*
 regex 1.0 alpha
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/regex/regex_util.v
+++ b/vlib/regex/regex_util.v
@@ -1,7 +1,7 @@
 /*
 regex 1.0 alpha
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 */

--- a/vlib/runtime/runtime.v
+++ b/vlib/runtime/runtime.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/stbi/link_to_libm.c.v
+++ b/vlib/stbi/link_to_libm.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module stbi

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -1,6 +1,6 @@
 module strconv
 
-// Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+// Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/strconv/atofq.c.v
+++ b/vlib/strconv/atofq.c.v
@@ -3,7 +3,7 @@ module strconv
 /*
 atof util
 
-Copyright (c) 2019 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strconv/atoi.v
+++ b/vlib/strconv/atoi.v
@@ -1,6 +1,6 @@
 module strconv
 
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // TODO: use options, or some way to return default with error.

--- a/vlib/strconv/f32_str.c.v
+++ b/vlib/strconv/f32_str.c.v
@@ -4,7 +4,7 @@ module strconv
 
 f32 to string
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strconv/f64_str.c.v
+++ b/vlib/strconv/f64_str.c.v
@@ -4,7 +4,7 @@ module strconv
 
 f64 to string
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strconv/format_mem.c.v
+++ b/vlib/strconv/format_mem.c.v
@@ -1,5 +1,5 @@
 /*=============================================================================
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strconv/ftoa.c.v
+++ b/vlib/strconv/ftoa.c.v
@@ -3,7 +3,7 @@ module strconv
 /*
 f32/f64 ftoa functions
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strconv/utilities.c.v
+++ b/vlib/strconv/utilities.c.v
@@ -3,7 +3,7 @@ module strconv
 /*
 f32/f64 to string utilities
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strconv/vprintf.c.v
+++ b/vlib/strconv/vprintf.c.v
@@ -1,5 +1,5 @@
 /*=============================================================================
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module strings

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module strings

--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sync

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sync

--- a/vlib/sync/sync_freebsd.c.v
+++ b/vlib/sync/sync_freebsd.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sync

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sync

--- a/vlib/sync/waitgroup.c.v
+++ b/vlib/sync/waitgroup.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module sync

--- a/vlib/term/colors.v
+++ b/vlib/term/colors.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module term

--- a/vlib/term/control.v
+++ b/vlib/term/control.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module term

--- a/vlib/term/termios/termios_android.c.v
+++ b/vlib/term/termios/termios_android.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_darwin.c.v
+++ b/vlib/term/termios/termios_darwin.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_default.c.v
+++ b/vlib/term/termios/termios_default.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module termios

--- a/vlib/term/termios/termios_dragonfly.c.v
+++ b/vlib/term/termios/termios_dragonfly.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_freebsd.c.v
+++ b/vlib/term/termios/termios_freebsd.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_linux.c.v
+++ b/vlib/term/termios/termios_linux.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_openbsd.c.v
+++ b/vlib/term/termios/termios_openbsd.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_qnx.c.v
+++ b/vlib/term/termios/termios_qnx.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_solaris.c.v
+++ b/vlib/term/termios/termios_solaris.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/term/termios/termios_windows.c.v
+++ b/vlib/term/termios/termios_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/time/format.v
+++ b/vlib/time/format.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/parse.v
+++ b/vlib/time/parse.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/stopwatch.v
+++ b/vlib/time/stopwatch.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/time.c.v
+++ b/vlib/time/time.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/time/unix.v
+++ b/vlib/time/unix.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module time

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]
@@ -1564,7 +1564,7 @@ pub:
 	has_len       bool
 	has_cap       bool
 	has_init      bool
-	has_index     bool // true if temp variable index is used	
+	has_index     bool // true if temp variable index is used
 pub mut:
 	exprs        []Expr // `[expr, expr]` or `[expr]Type{}` for fixed array
 	len_expr     Expr   // len: expr

--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module ast

--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module ast

--- a/vlib/v/ast/embed_file.v
+++ b/vlib/v/ast/embed_file.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module ast

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module ast

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builder

--- a/vlib/v/builder/cc_windows.v
+++ b/vlib/v/builder/cc_windows.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builder

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module builder

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module cflag

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/autocomplete.v
+++ b/vlib/v/checker/autocomplete.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module checker

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/errors.v
+++ b/vlib/v/checker/errors.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/interface.v
+++ b/vlib/v/checker/interface.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module checker

--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module checker

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module checker
 

--- a/vlib/v/debug/callstack.c.v
+++ b/vlib/v/debug/callstack.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Felipe Pena. All rights reserved.
+// Copyright (c) 2019-2025 Felipe Pena. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 @[has_globals]
 module debug

--- a/vlib/v/debug/debug.v
+++ b/vlib/v/debug/debug.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Felipe Pena. All rights reserved.
+// Copyright (c) 2019-2025 Felipe Pena. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 @[has_globals]
 module debug

--- a/vlib/v/depgraph/depgraph.v
+++ b/vlib/v/depgraph/depgraph.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 // Directed acyclic graph

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module eval

--- a/vlib/v/fmt/align.v
+++ b/vlib/v/fmt/align.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fmt

--- a/vlib/v/fmt/asm.v
+++ b/vlib/v/fmt/asm.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fmt

--- a/vlib/v/fmt/attrs.v
+++ b/vlib/v/fmt/attrs.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fmt

--- a/vlib/v/fmt/comments.v
+++ b/vlib/v/fmt/comments.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fmt

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fmt

--- a/vlib/v/fmt/fmt_keep_test.v
+++ b/vlib/v/fmt/fmt_keep_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import os

--- a/vlib/v/fmt/fmt_test.v
+++ b/vlib/v/fmt/fmt_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import os

--- a/vlib/v/fmt/fmt_vlib_test.v
+++ b/vlib/v/fmt/fmt_vlib_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import os

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module fmt

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module c
 

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module c
 

--- a/vlib/v/gen/c/auto_free_methods.v
+++ b/vlib/v/gen/c/auto_free_methods.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module c
 

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module c
 

--- a/vlib/v/gen/c/autofree.v
+++ b/vlib/v/gen/c/autofree.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c
@@ -272,7 +272,7 @@ pub:
 	header           string          // produced output for out.h (-parallel-cc)
 	res_builder      strings.Builder // produced output (complete)
 	out_str          string          // produced output from g.out
-	out0_str         string          // helpers output (auto fns, dump fns) for out_0.c (-parallel-cc)	
+	out0_str         string          // helpers output (auto fns, dump fns) for out_0.c (-parallel-cc)
 	extern_str       string          // extern chunk for (-parallel-cc)
 	out_fn_start_pos []int           // fn decl positions
 }

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module c
 

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module c
 

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -1,7 +1,7 @@
 /*
 str_intp.v
 
-Copyright (c) 2019-2024 Dario Deledda. All rights reserved.
+Copyright (c) 2019-2025 Dario Deledda. All rights reserved.
 Use of this source code is governed by an MIT license
 that can be found in the LICENSE file.
 

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/text_manipulation.v
+++ b/vlib/v/gen/c/text_manipulation.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module c

--- a/vlib/v/gen/golang/attrs.v
+++ b/vlib/v/gen/golang/attrs.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module golang

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module golang

--- a/vlib/v/gen/golang/struct.v
+++ b/vlib/v/gen/golang/struct.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module golang

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module js
 

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/arm64.v
+++ b/vlib/v/gen/native/arm64.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/array.v
+++ b/vlib/v/gen/native/array.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/blacklist.v
+++ b/vlib/v/gen/native/blacklist.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native
@@ -8,7 +8,7 @@ module native
 
 /*
 already compiling functions:
-	string.+	
+	string.+
 	string.clone
 	string.free
 	ArrayFlags.set

--- a/vlib/v/gen/native/builtins.v
+++ b/vlib/v/gen/native/builtins.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/comptime.v
+++ b/vlib/v/gen/native/comptime.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/dos.v
+++ b/vlib/v/gen/native/dos.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/elf.v
+++ b/vlib/v/gen/native/elf.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/expr.v
+++ b/vlib/v/gen/native/expr.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/macho.v
+++ b/vlib/v/gen/native/macho.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/pe.v
+++ b/vlib/v/gen/native/pe.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/readdll.c.v
+++ b/vlib/v/gen/native/readdll.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/stmt.c.v
+++ b/vlib/v/gen/native/stmt.c.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/gen/native/syscall.v
+++ b/vlib/v/gen/native/syscall.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module native

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module markused
 

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module markused
 

--- a/vlib/v/mathutil/mathutil.v
+++ b/vlib/v/mathutil/mathutil.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module mathutil

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/for.v
+++ b/vlib/v/parser/for.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/orm.v
+++ b/vlib/v/parser/orm.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/parser/tmpl.v
+++ b/vlib/v/parser/tmpl.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module parser

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module pref

--- a/vlib/v/pref/line_info.v
+++ b/vlib/v/pref/line_info.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module pref
 

--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module pref

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module pref
@@ -104,7 +104,7 @@ pub mut:
 	is_liveshared      bool   // a shared library, that will be used in a -live main program
 	is_shared          bool   // an ordinary shared library, -shared, no matter if it is live or not
 	is_o               bool   // building an .o file
-	is_prof            bool   // benchmark every function	
+	is_prof            bool   // benchmark every function
 	is_prod            bool   // use "-O3"
 	no_prod_options    bool   // `-no-prod-options`, means do not pass any optimization flags to the C compilation, while still allowing the user to use for example `-cflags -Os` to pass custom ones
 	is_repl            bool

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module scanner

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module scanner

--- a/vlib/v/token/pos.v
+++ b/vlib/v/token/pos.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module token

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module token

--- a/vlib/v/type_resolver/comptime_resolver.v
+++ b/vlib/v/type_resolver/comptime_resolver.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 V devs. All rights reserved.
+// Copyright (c) 2019-2025 V devs. All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module type_resolver
 

--- a/vlib/v/type_resolver/generic_resolver.v
+++ b/vlib/v/type_resolver/generic_resolver.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Felipe Pena All rights reserved.
+// Copyright (c) 2019-2025 Felipe Pena All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module type_resolver
 

--- a/vlib/v/type_resolver/type_resolver.v
+++ b/vlib/v/type_resolver/type_resolver.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Felipe Pena All rights reserved.
+// Copyright (c) 2019-2025 Felipe Pena All rights reserved.
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module type_resolver
 

--- a/vlib/v/util/errors.v
+++ b/vlib/v/util/errors.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/v/util/timers.v
+++ b/vlib/v/util/timers.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 @[has_globals]

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module util

--- a/vlib/v/util/vflags/vflags.v
+++ b/vlib/v/util/vflags/vflags.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Delyan Angelov. All rights reserved.
+// Copyright (c) 2019-2025 Delyan Angelov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module vflags

--- a/vlib/veb/auth/auth.v
+++ b/vlib/veb/auth/auth.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module auth

--- a/vlib/veb/tr.v
+++ b/vlib/veb/tr.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module veb

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module veb

--- a/vlib/vweb/vweb.v
+++ b/vlib/vweb/vweb.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 //@[deprecated: '`vweb` is deprecated `veb`. Please use `veb` instead.']

--- a/vlib/x/json2/decoder.v
+++ b/vlib/x/json2/decoder.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module json2

--- a/vlib/x/json2/encoder.v
+++ b/vlib/x/json2/encoder.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module json2

--- a/vlib/x/json2/json2.v
+++ b/vlib/x/json2/json2.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module json2

--- a/vlib/x/json2/scanner.v
+++ b/vlib/x/json2/scanner.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 module json2

--- a/vlib/x/templating/dtm/tmpl.v
+++ b/vlib/x/templating/dtm/tmpl.v
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Copyright (c) 2019-2025 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 


### PR DESCRIPTION
This PR updates the copyright year to 2025 across multiple files to ensure consistency and reflect the current year.

No functional changes were made; this is purely a maintenance update.