### PR TITLE
crypto.ecdsa: migrate `ecdsa.PrivateKey.new()` to use high level api

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -27,7 +27,6 @@ module ecdsa
 struct C.EVP_PKEY {}
 
 fn C.EVP_PKEY_new() &C.EVP_PKEY
-fn C.EVP_EC_gen(curve &u8) &C.EVP_PKEY
 fn C.EVP_PKEY_free(key &C.EVP_PKEY)
 fn C.EVP_PKEY_get1_EC_KEY(pkey &C.EVP_PKEY) &C.EC_KEY
 fn C.EVP_PKEY_base_id(key &C.EVP_PKEY) int

--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -32,6 +32,17 @@ fn C.EVP_PKEY_free(key &C.EVP_PKEY)
 fn C.EVP_PKEY_get1_EC_KEY(pkey &C.EVP_PKEY) &C.EC_KEY
 fn C.EVP_PKEY_base_id(key &C.EVP_PKEY) int
 
+// EVP_PKEY Context
+@[typedef]
+struct C.EVP_PKEY_CTX {}
+
+fn C.EVP_PKEY_CTX_new_id(id int, e voidptr) &C.EVP_PKEY_CTX
+fn C.EVP_PKEY_keygen_init(ctx &C.EVP_PKEY_CTX) int
+fn C.EVP_PKEY_keygen(ctx &C.EVP_PKEY_CTX, ppkey &&C.EVP_PKEY) int
+fn C.EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx &C.EVP_PKEY_CTX, nid int) int
+fn C.EVP_PKEY_CTX_set_ec_param_enc(ctx &C.EVP_PKEY_CTX, param_enc int) int
+fn C.EVP_PKEY_CTX_free(ctx &C.EVP_PKEY_CTX)
+
 // Elliptic curve keypair declarations
 @[typedef]
 struct C.EC_KEY {}

--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -27,6 +27,7 @@ module ecdsa
 struct C.EVP_PKEY {}
 
 fn C.EVP_PKEY_new() &C.EVP_PKEY
+fn C.EVP_EC_gen(curve &u8) &C.EVP_PKEY
 fn C.EVP_PKEY_free(key &C.EVP_PKEY)
 fn C.EVP_PKEY_get1_EC_KEY(pkey &C.EVP_PKEY) &C.EC_KEY
 fn C.EVP_PKEY_base_id(key &C.EVP_PKEY) int

--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -31,15 +31,7 @@ const nid_evp_pkey_ec = C.EVP_PKEY_EC
 // we only support this
 const openssl_ec_named_curve = C.OPENSSL_EC_NAMED_CURVE
 
-// Constants of short name of the supported curve(s).
-// In the C parts, its defined as #define SN_X9_62_prime256v1  "prime256v1"
-// Its placed here to simplify the access.
-const sn_prime256v1 = 'prime256v1'
-const sn_secp384r1 = 'secp384r1'
-const sn_secp521r1 = 'secp521r1'
-const sn_secp256k1 = 'secp256k1'
-
-// The enum of supported curve(s)
+// Nid is an enumeration of the supported curves
 pub enum Nid {
 	prime256v1
 	secp384r1
@@ -58,14 +50,14 @@ pub mut:
 	fixed_size bool
 }
 
-// enum of hashing config for key signing (verifying).
+// HashConfig is an enumeration of the possible options for key signing (verifying).
 pub enum HashConfig {
 	with_recommended_hash
 	with_no_hash
 	with_custom_hash
 }
 
-// SignerOpts was configuration options to drive signing and verifying process.
+// SignerOpts represents configuration options to drive signing and verifying process.
 @[params]
 pub struct SignerOpts {
 pub mut:
@@ -78,7 +70,7 @@ pub mut:
 	custom_hash &hash.Hash = unsafe { nil }
 }
 
-// enum flag to allow flexible PrivateKey size
+// KeyFlag is an enumeration of possible options to support flexible of PrivateKey key size.
 enum KeyFlag {
 	// flexible flag to allow flexible-size of seed bytes
 	flexible


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR was a continuation of migration step of this [phase](https://discord.com/channels/592103645835821068/592320321995014154/1332203056707801138). In this PR, its only migrates one generator function `ecdsa.PrivateKey.new()` to use high level api. Its also still use old deprecated api to support old function that relies on `EC_KEY` function.
So, its does not changes the current behaviour, and the old opaque still avaialbles on there.
The other changes are:

- Add required C declarations
- Some bits of code reorganization to make its easy to read.
- Add some constants to easy the access
- Improves the function docs.

Its is..
Happy days..