### PR TITLE
builtin: add string.split_by_space()

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -1108,6 +1108,18 @@ pub fn (s string) split_into_lines() []string {
 	return res
 }
 
+// split_by_space splits the string by whitespace (any of ` `, `\n`, `\t`, `\v`, `\f`, `\r`).
+// Repeated, trailing or leading whitespaces will be omitted.
+pub fn (s string) split_by_space() []string {
+	mut res := []string{}
+	for word in s.split_any(' \n\t\v\f\r') {
+		if word != '' {
+			res << word
+		}
+	}
+	return res
+}
+
 // substr returns the string between index positions `start` and `end`.
 // Example: assert 'ABCD'.substr(1,3) == 'BC'
 @[direct_array_access]

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -442,6 +442,13 @@ fn test_rsplit_once() ? {
 	assert ext3 == ''
 }
 
+fn test_split_by_space() {
+	assert 'a     b    c'.split_by_space() == ['a', 'b', 'c']
+	assert '  a\t\tb\tc'.split_by_space() == ['a', 'b', 'c']
+	assert 'a b c \n\r'.split_by_space() == ['a', 'b', 'c']
+	assert '\ta b \t \tc \r\n'.split_by_space() == ['a', 'b', 'c']
+}
+
 fn test_is_bin() {
 	assert ''.is_bin() == false
 	assert '0b1'.is_bin() == true


### PR DESCRIPTION
This PR:

- Add new fn `split_by_space()` for `string` builtin.
- Add test

Usecase:

```shell
>>> cmd := os.execute('ip -br link show wlan0')
>>> cmd.output
wlan0            UP             14:75:7b:ca:a2:c4 <BROADCAST,MULTICAST,UP,LOWER_UP> 
>>> cmd.output.split_by_space()
['wlan0', 'UP', '14:75:7b:ca:a2:c4', '<BROADCAST,MULTICAST,UP,LOWER_UP>']
>>> mac := cmd.output.split_by_space()[2]
>>> mac
14:75:7b:ca:a2:c4
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
