### PR TITLE
cgen: fix codegen for option value on `map_set`

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -138,7 +138,7 @@ fn (mut g Gen) expr_with_opt(expr ast.Expr, expr_typ ast.Type, ret_typ ast.Type)
 	defer {
 		g.inside_opt_or_res = old_inside_opt_or_res
 	}
-	if expr_typ.has_flag(.option) && ret_typ.has_flag(.option)
+	if expr_typ.has_flag(.option) && ret_typ.has_flag(.option) && !g.is_arraymap_set
 		&& expr in [ast.SelectorExpr, ast.DumpExpr, ast.Ident, ast.ComptimeSelector, ast.AsCast, ast.CallExpr, ast.MatchExpr, ast.IfExpr, ast.IndexExpr, ast.UnsafeExpr, ast.CastExpr] {
 		if expr in [ast.Ident, ast.CastExpr] {
 			if expr_typ.idx() != ret_typ.idx() {

--- a/vlib/v/tests/options/option_map_set_test.v
+++ b/vlib/v/tests/options/option_map_set_test.v
@@ -1,0 +1,12 @@
+type Any = ?int | ?string
+
+struct TestConfig {
+	timeout ?int
+}
+
+fn test_main() {
+	mut r := TestConfig{}
+	mut m := map[string]?Any{}
+	m['timeout'] = r.timeout
+	assert m.str() == "{'timeout': Option(Any(Option(none)))}"
+}


### PR DESCRIPTION
Fix #23650