### PR TITLE
checker: fix sumtype variant option type mismatch

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3402,8 +3402,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			node.expr_type = c.promote_num(node.expr_type, xx)
 			from_type = node.expr_type
 		}
-		if !c.table.sumtype_has_variant(to_type, from_type, false) && !to_type.has_flag(.option)
-			&& !to_type.has_flag(.result) {
+		if !c.table.sumtype_has_variant(to_type, from_type, false) {
 			ft := c.table.type_to_str(from_type)
 			tt := c.table.type_to_str(to_type)
 			c.error('cannot cast `${ft}` to `${tt}`', node.pos)

--- a/vlib/v/checker/tests/sumtype_variant_mismatch.out
+++ b/vlib/v/checker/tests/sumtype_variant_mismatch.out
@@ -1,0 +1,18 @@
+vlib/v/checker/tests/sumtype_variant_mismatch.vv:4:7: error: cannot cast `?string` to `?Any`
+    2 | type Any2 = ?int | ?string
+    3 | 
+    4 | _ := ?Any(?string('baz'))
+      |       ~~~~~~~~~~~~~~~~~~~
+    5 | _ := ?Any(string('baz'))
+    6 | _ := ?Any('baz')
+vlib/v/checker/tests/sumtype_variant_mismatch.vv:10:7: error: cannot cast `string` to `?Any2`
+    8 | 
+    9 | _ := ?Any2(?string('baz'))
+   10 | _ := ?Any2(string('baz'))
+      |       ~~~~~~~~~~~~~~~~~~~
+   11 | _ := ?Any2('baz')
+vlib/v/checker/tests/sumtype_variant_mismatch.vv:11:7: error: cannot cast `string` to `?Any2`
+    9 | _ := ?Any2(?string('baz'))
+   10 | _ := ?Any2(string('baz'))
+   11 | _ := ?Any2('baz')
+      |       ~~~~~~~~~~~

--- a/vlib/v/checker/tests/sumtype_variant_mismatch.vv
+++ b/vlib/v/checker/tests/sumtype_variant_mismatch.vv
@@ -1,0 +1,10 @@
+type Any = ?int | string
+type Any2 = ?int | ?string
+
+_ := ?Any(?string('baz'))
+_ := ?Any(string('baz'))
+_ := ?Any('baz')
+
+_ := ?Any2(?string('baz'))
+_ := ?Any2(string('baz'))
+_ := ?Any2('baz')


### PR DESCRIPTION
```v
type Any = ?int | string
type Any2 = ?int | ?string

_ := ?Any(?string('baz')) // must be an error
_ := ?Any(string('baz')) // must be ok
_ := ?Any('baz') // must be ok

_ := ?Any2(?string('baz')) // must be ok
_ := ?Any2(string('baz')) // must be an error
_ := ?Any2('baz') // must be an error
```