### PR TITLE
crypto.ecdsa: migrate generate_key and makes it more simpler.

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -22,7 +22,9 @@ module ecdsa
 #include <openssl/x509.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
-#include <openssl/core.h>
+
+// The following header is available on OpenSSL 3.0, but not in OpenSSL 1.1.1f
+//#include <openssl/core.h>
 
 // The new opaque of public key pair high level API
 @[typedef]

--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -18,9 +18,11 @@ module ecdsa
 #include <openssl/objects.h>
 #include <openssl/bn.h>
 #include <openssl/evp.h>
+#include <openssl/ec.h>
 #include <openssl/x509.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
+#include <openssl/core.h>
 
 // The new opaque of public key pair high level API
 @[typedef]
@@ -73,6 +75,8 @@ fn C.BIO_write(b &C.BIO, buf &u8, length int) int
 fn C.PEM_read_bio_PrivateKey(bp &C.BIO, x &&C.EVP_PKEY, cb int, u &voidptr) &C.EVP_PKEY
 fn C.PEM_read_bio_PUBKEY(bp &C.BIO, x &&C.EVP_PKEY, cb int, u &voidptr) &C.EVP_PKEY
 fn C.d2i_PUBKEY(k &&C.EVP_PKEY, pp &&u8, length u32) &C.EVP_PKEY
+fn C.i2d_PUBKEY_bio(bo &C.BIO, pkey &C.EVP_PKEY) int
+fn C.d2i_PUBKEY_bio(bo &C.BIO, key &&C.EVP_PKEY) &C.EVP_PKEY
 
 // Elliptic curve point related declarations.
 @[typedef]

--- a/vlib/crypto/ecdsa/ecdsa_test.v
+++ b/vlib/crypto/ecdsa/ecdsa_test.v
@@ -47,7 +47,7 @@ fn test_new_key_from_seed() ! {
 	// Test generating a key from a seed
 	seed := [u8(1), 2, 3, 4, 5]
 	priv_key := new_key_from_seed(seed) or { panic(err) }
-	retrieved_seed := priv_key.seed() or { panic(err) }
+	retrieved_seed := priv_key.bytes() or { panic(err) }
 	assert seed == retrieved_seed
 	priv_key.free()
 }
@@ -56,7 +56,7 @@ fn test_new_key_from_seed_with_leading_zeros_bytes() ! {
 	// Test generating a key from a seed
 	seed := [u8(0), u8(1), 2, 3, 4, 5]
 	priv_key := new_key_from_seed(seed) or { panic(err) }
-	retrieved_seed := priv_key.seed() or { panic(err) }
+	retrieved_seed := priv_key.bytes() or { panic(err) }
 	assert seed == retrieved_seed
 	priv_key.free()
 }
@@ -76,7 +76,7 @@ fn test_sign_and_verify() ! {
 fn test_seed() ! {
 	// Test retrieving the seed from a private key
 	pub_key, priv_key := generate_key() or { panic(err) }
-	seed := priv_key.seed() or { panic(err) }
+	seed := priv_key.bytes() or { panic(err) }
 	assert seed.len > 0
 	priv_key.free()
 	pub_key.free()
@@ -99,7 +99,7 @@ fn test_public_key() ! {
 fn test_private_key_equal() ! {
 	// Test private key equality
 	pbk, priv_key1 := generate_key() or { panic(err) }
-	seed := priv_key1.seed() or { panic(err) }
+	seed := priv_key1.bytes() or { panic(err) }
 	priv_key2 := new_key_from_seed(seed) or { panic(err) }
 	assert priv_key1.equal(priv_key2)
 
@@ -111,7 +111,7 @@ fn test_private_key_equal() ! {
 fn test_private_key_equality_on_different_curve() ! {
 	// default group
 	pbk, priv_key1 := generate_key() or { panic(err) }
-	seed := priv_key1.seed() or { panic(err) }
+	seed := priv_key1.bytes() or { panic(err) }
 	// using different group
 	priv_key2 := new_key_from_seed(seed, nid: .secp384r1) or { panic(err) }
 	assert !priv_key1.equal(priv_key2)
@@ -186,7 +186,7 @@ fn test_private_key_new() ! {
 	assert is_valid
 
 	// new private key
-	seed := priv_key.seed()!
+	seed := priv_key.bytes()!
 	priv_key2 := new_key_from_seed(seed)!
 	pubkey2 := priv_key2.public_key()!
 	assert priv_key.equal(priv_key2)

--- a/vlib/crypto/ecdsa/ecdsa_test.v
+++ b/vlib/crypto/ecdsa/ecdsa_test.v
@@ -12,8 +12,9 @@ fn test_ecdsa() {
 	is_valid := pub_key.verify(message, signature) or { panic(err) }
 	println('Signature valid: ${is_valid}')
 	assert is_valid
-	key_free(priv_key.key)
-	key_free(pub_key.key)
+
+	priv_key.free()
+	pub_key.free()
 }
 
 fn test_ecdsa_signing_with_recommended_hash_options() {
@@ -27,9 +28,9 @@ fn test_ecdsa_signing_with_recommended_hash_options() {
 	// Verify the signature
 	is_valid := pub_key.verify(message, signature) or { panic(err) }
 	println('Signature valid: ${is_valid}')
-	key_free(pub_key.key)
-	key_free(priv_key.key)
 	assert is_valid
+	pub_key.free()
+	priv_key.free()
 }
 
 fn test_generate_key() ! {
@@ -37,8 +38,9 @@ fn test_generate_key() ! {
 	pub_key, priv_key := generate_key() or { panic(err) }
 	assert pub_key.key != unsafe { nil }
 	assert priv_key.key != unsafe { nil }
-	key_free(priv_key.key)
-	key_free(pub_key.key)
+
+	priv_key.free()
+	pub_key.free()
 }
 
 fn test_new_key_from_seed() ! {
@@ -47,7 +49,7 @@ fn test_new_key_from_seed() ! {
 	priv_key := new_key_from_seed(seed) or { panic(err) }
 	retrieved_seed := priv_key.seed() or { panic(err) }
 	assert seed == retrieved_seed
-	key_free(priv_key.key)
+	priv_key.free()
 }
 
 fn test_new_key_from_seed_with_leading_zeros_bytes() ! {
@@ -56,7 +58,7 @@ fn test_new_key_from_seed_with_leading_zeros_bytes() ! {
 	priv_key := new_key_from_seed(seed) or { panic(err) }
 	retrieved_seed := priv_key.seed() or { panic(err) }
 	assert seed == retrieved_seed
-	key_free(priv_key.key)
+	priv_key.free()
 }
 
 fn test_sign_and_verify() ! {
@@ -66,8 +68,9 @@ fn test_sign_and_verify() ! {
 	signature := priv_key.sign(message) or { panic(err) }
 	is_valid := pub_key.verify(message, signature) or { panic(err) }
 	assert is_valid
-	key_free(priv_key.key)
-	key_free(pub_key.key)
+
+	priv_key.free()
+	pub_key.free()
 }
 
 fn test_seed() ! {
@@ -75,8 +78,8 @@ fn test_seed() ! {
 	pub_key, priv_key := generate_key() or { panic(err) }
 	seed := priv_key.seed() or { panic(err) }
 	assert seed.len > 0
-	key_free(priv_key.key)
-	key_free(pub_key.key)
+	priv_key.free()
+	pub_key.free()
 }
 
 fn test_public_key() ! {
@@ -85,11 +88,12 @@ fn test_public_key() ! {
 	pub_key1 := priv_key.public_key() or { panic(err) }
 	pub_key2, privkk := generate_key() or { panic(err) }
 	assert !pub_key1.equal(pub_key2)
-	key_free(pubkk.key)
-	key_free(privkk.key)
-	key_free(priv_key.key)
-	key_free(pub_key1.key)
-	key_free(pub_key2.key)
+
+	pubkk.free()
+	privkk.free()
+	priv_key.free()
+	pub_key1.free()
+	pub_key2.free()
 }
 
 fn test_private_key_equal() ! {
@@ -98,9 +102,10 @@ fn test_private_key_equal() ! {
 	seed := priv_key1.seed() or { panic(err) }
 	priv_key2 := new_key_from_seed(seed) or { panic(err) }
 	assert priv_key1.equal(priv_key2)
-	key_free(pbk.key)
-	key_free(priv_key1.key)
-	key_free(priv_key2.key)
+
+	pbk.free()
+	priv_key1.free()
+	priv_key2.free()
 }
 
 fn test_private_key_equality_on_different_curve() ! {
@@ -110,9 +115,9 @@ fn test_private_key_equality_on_different_curve() ! {
 	// using different group
 	priv_key2 := new_key_from_seed(seed, nid: .secp384r1) or { panic(err) }
 	assert !priv_key1.equal(priv_key2)
-	key_free(pbk.key)
-	key_free(priv_key1.key)
-	key_free(priv_key2.key)
+	pbk.free()
+	priv_key1.free()
+	priv_key2.free()
 }
 
 fn test_public_key_equal() ! {
@@ -121,10 +126,10 @@ fn test_public_key_equal() ! {
 	pub_key1 := priv_key.public_key() or { panic(err) }
 	pub_key2 := priv_key.public_key() or { panic(err) }
 	assert pub_key1.equal(pub_key2)
-	key_free(pbk.key)
-	key_free(priv_key.key)
-	key_free(pub_key1.key)
-	key_free(pub_key2.key)
+	pbk.free()
+	priv_key.free()
+	pub_key1.free()
+	pub_key2.free()
 }
 
 fn test_sign_with_new_key_from_seed() ! {
@@ -136,8 +141,8 @@ fn test_sign_with_new_key_from_seed() ! {
 	pub_key := priv_key.public_key() or { panic(err) }
 	is_valid := pub_key.verify(message, signature) or { panic(err) }
 	assert is_valid
-	key_free(priv_key.key)
-	key_free(pub_key.key)
+	priv_key.free()
+	pub_key.free()
 }
 
 fn test_invalid_signature() ! {
@@ -148,13 +153,13 @@ fn test_invalid_signature() ! {
 	result := pub_key.verify(message, invalid_signature) or {
 		// Expecting verification to fail
 		assert err.msg() == 'Failed to verify signature'
-		key_free(pub_key.key)
-		key_free(pvk.key)
+		pub_key.free()
+		pvk.free()
 		return
 	}
 	assert !result
-	key_free(pub_key.key)
-	key_free(pvk.key)
+	pub_key.free()
+	pvk.free()
 }
 
 fn test_different_keys_not_equal() ! {
@@ -162,10 +167,10 @@ fn test_different_keys_not_equal() ! {
 	pbk1, priv_key1 := generate_key() or { panic(err) }
 	pbk2, priv_key2 := generate_key() or { panic(err) }
 	assert !priv_key1.equal(priv_key2)
-	key_free(pbk1.key)
-	key_free(pbk2.key)
-	key_free(priv_key1.key)
-	key_free(priv_key2.key)
+	pbk1.free()
+	pbk2.free()
+	priv_key1.free()
+	priv_key2.free()
 }
 
 fn test_private_key_new() ! {

--- a/vlib/crypto/ecdsa/util_test.v
+++ b/vlib/crypto/ecdsa/util_test.v
@@ -38,7 +38,7 @@ fn test_load_pubkey_from_der_serialized_bytes() ! {
 	// expected signature was comes from hashed message with sha384
 	status_with_hashed := pbkey.verify(message_tobe_signed, expected_signature)!
 	assert status_with_hashed == true
-	key_free(pbkey.key)
+	pbkey.free()
 }
 
 fn test_for_pubkey_bytes() ! {
@@ -50,8 +50,8 @@ fn test_for_pubkey_bytes() ! {
 	assert pvkey.seed()!.hex() == pv
 	pbkey := pvkey.public_key()!
 	assert pbkey.bytes()!.hex() == pb
-	key_free(pbkey.key)
-	key_free(pvkey.key)
+	pbkey.free()
+	pvkey.free()
 }
 
 // above pem-formatted private key read with


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This is a 3rd PR sent in efforts to migrate `crypto.ecdsa` module to use high level api. In this current PR, its basically migrates two thing, ie, in the form:

- Migrates `PrivateKey.public_key()` to use the new one. Its approach was done by serializing this high level opaque (if availables) to der serialized bytes and get its back into other opaque and use this as public key part. If this high level opaque (`evpkey` field) was not availables, it will use the old one.
- Simplify `generate_key` function to use this new approach , by just more simpler calling to the `.new()` and `.public_key()` .
- Removes `.key_free()` .. Its has been replaced by its explicit counterparts of `.free()` of the desired key.
- Just some cleansup of bits

Happy days