### PR TITLE
gg: fix incorrect `Event.mouse_x` and `Event.mouse_y` on  `gg.Context.event_fn` and `gg.Context.on_event`.

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -377,12 +377,18 @@ fn gg_event_fn(ce voidptr, user_data voidptr) {
 			e.mouse_button = .middle
 		}
 	}
-	ctx.mouse_pos_x = int(e.mouse_x / ctx.scale)
-	ctx.mouse_pos_y = int(e.mouse_y / ctx.scale)
-	ctx.mouse_dx = int(e.mouse_dx / ctx.scale)
-	ctx.mouse_dy = int(e.mouse_dy / ctx.scale)
-	ctx.scroll_x = int(e.scroll_x / ctx.scale)
-	ctx.scroll_y = int(e.scroll_y / ctx.scale)
+	e.mouse_x /= ctx.scale
+	e.mouse_y /= ctx.scale
+	e.mouse_dx /= ctx.scale
+	e.mouse_dy /= ctx.scale
+	e.scroll_x /= ctx.scale
+	e.scroll_y /= ctx.scale
+	ctx.mouse_pos_x = int(e.mouse_x)
+	ctx.mouse_pos_y = int(e.mouse_y)
+	ctx.mouse_dx = int(e.mouse_dx)
+	ctx.mouse_dy = int(e.mouse_dy)
+	ctx.scroll_x = int(e.scroll_x)
+	ctx.scroll_y = int(e.scroll_y)
 	ctx.key_modifiers = unsafe { Modifier(e.modifiers) }
 	ctx.key_repeat = e.key_repeat
 	if e.typ in [.key_down, .key_up] {
@@ -400,19 +406,17 @@ fn gg_event_fn(ce voidptr, user_data voidptr) {
 	match e.typ {
 		.mouse_move {
 			if ctx.config.move_fn != unsafe { nil } {
-				ctx.config.move_fn(e.mouse_x / ctx.scale, e.mouse_y / ctx.scale, ctx.config.user_data)
+				ctx.config.move_fn(e.mouse_x, e.mouse_y, ctx.config.user_data)
 			}
 		}
 		.mouse_down {
 			if ctx.config.click_fn != unsafe { nil } {
-				ctx.config.click_fn(e.mouse_x / ctx.scale, e.mouse_y / ctx.scale, e.mouse_button,
-					ctx.config.user_data)
+				ctx.config.click_fn(e.mouse_x, e.mouse_y, e.mouse_button, ctx.config.user_data)
 			}
 		}
 		.mouse_up {
 			if ctx.config.unclick_fn != unsafe { nil } {
-				ctx.config.unclick_fn(e.mouse_x / ctx.scale, e.mouse_y / ctx.scale, e.mouse_button,
-					ctx.config.user_data)
+				ctx.config.unclick_fn(e.mouse_x, e.mouse_y, e.mouse_button, ctx.config.user_data)
 			}
 		}
 		.mouse_leave {


### PR DESCRIPTION
Fixes #23667. I don't if this type of thing can have _test.v files written for it. But I have verified that this does work on Mac. The issue was caused by `Event.mouse_x/y` not being divided by the `Context.scale` before triggering the `Context.event_fn`. It needs to be tested on a high DPI display on Windows and Linux.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
