### PR TITLE
cgen: fix codegen for array fixed const initialized with unsafe exprs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6102,6 +6102,9 @@ fn (mut g Gen) check_expr_is_const(expr ast.Expr) bool {
 		ast.PrefixExpr {
 			return expr.right is ast.Ident || g.check_expr_is_const(expr.right)
 		}
+		ast.UnsafeExpr {
+			return g.check_expr_is_const(expr.expr)
+		}
 		else {
 			return false
 		}

--- a/vlib/v/gen/c/testdata/fixed_arr_const_unsafe.c.must_have
+++ b/vlib/v/gen/c/testdata/fixed_arr_const_unsafe.c.must_have
@@ -1,0 +1,1 @@
+Array_fixed_int_literal_ptr1_8 weapon_keys = {&_const_main__key_weapon1, &_const_main__key_weapon2, &_const_main__key_weapon3, &_const_main__key_weapon4, &_const_main__key_weapon5, &_const_main__key_weapon6, &_const_main__key_weapon7, &_const_main__key_weapon8}; // fixed array const

--- a/vlib/v/gen/c/testdata/fixed_arr_const_unsafe.vv
+++ b/vlib/v/gen/c/testdata/fixed_arr_const_unsafe.vv
@@ -1,0 +1,15 @@
+// vtest vflags: -no-skip-unused
+
+const key_weapon1 = 1
+const key_weapon2 = 1
+const key_weapon3 = 1
+const key_weapon4 = 1
+const key_weapon5 = 1
+const key_weapon6 = 1
+const key_weapon7 = 1
+const key_weapon8 = 1
+
+@[export: 'weapon_keys']
+const weapon_keys = [unsafe { &key_weapon1 }, unsafe { &key_weapon2 }, unsafe { &key_weapon3 },
+	unsafe { &key_weapon4 }, unsafe { &key_weapon5 }, unsafe { &key_weapon6 }, unsafe { &key_weapon7 },
+	unsafe { &key_weapon8 }]!


### PR DESCRIPTION
Fix #23674