### PR TITLE
crypto.ecdsa: migrate core routines for signing (and verifying)

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -15,7 +15,7 @@ module ecdsa
 #flag darwin -L/usr/local/opt/openssl/lib
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>
-#include <openssl/objects.h>
+#include <openssl/types.h>
 #include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/ec.h>
@@ -34,11 +34,37 @@ fn C.EVP_PKEY_new() &C.EVP_PKEY
 fn C.EVP_PKEY_free(key &C.EVP_PKEY)
 fn C.EVP_PKEY_get1_EC_KEY(pkey &C.EVP_PKEY) &C.EC_KEY
 fn C.EVP_PKEY_base_id(key &C.EVP_PKEY) int
+fn C.EVP_PKEY_get_bits(pkey &C.EVP_PKEY) int
+fn C.EVP_PKEY_size(key &C.EVP_PKEY) int
+
+// no-prehash signing (verifying)
+fn C.EVP_PKEY_sign(ctx &C.EVP_PKEY_CTX, sig &u8, siglen &usize, tbs &u8, tbslen int) int
+fn C.EVP_PKEY_sign_init(ctx &C.EVP_PKEY_CTX) int
+fn C.EVP_PKEY_verify_init(ctx &C.EVP_PKEY_CTX) int
+fn C.EVP_PKEY_verify(ctx &C.EVP_PKEY_CTX, sig &u8, siglen int, tbs &u8, tbslen int) int
+
+// single shoot digest signing (verifying) routine
+fn C.EVP_DigestSign(ctx &C.EVP_MD_CTX, sig &u8, siglen &usize, tbs &u8, tbslen int) int
+fn C.EVP_DigestVerify(ctx &C.EVP_MD_CTX, sig &u8, siglen int, tbs &u8, tbslen int) int
+
+// Message digest routines
+fn C.EVP_DigestInit(ctx &C.EVP_MD_CTX, md &C.EVP_MD) int
+fn C.EVP_DigestUpdate(ctx &C.EVP_MD_CTX, d voidptr, cnt int) int
+fn C.EVP_DigestFinal(ctx &C.EVP_MD_CTX, md &u8, s &usize) int
+
+// Recommended hashed signing/verifying routines
+fn C.EVP_DigestSignInit(ctx &C.EVP_MD_CTX, pctx &&C.EVP_PKEY_CTX, tipe &C.EVP_MD, e voidptr, pkey &C.EVP_PKEY) int
+fn C.EVP_DigestSignUpdate(ctx &C.EVP_MD_CTX, d voidptr, cnt int) int
+fn C.EVP_DigestSignFinal(ctx &C.EVP_MD_CTX, sig &u8, siglen &usize) int
+fn C.EVP_DigestVerifyInit(ctx &C.EVP_MD_CTX, pctx &&C.EVP_PKEY_CTX, tipe &C.EVP_MD, e voidptr, pkey &C.EVP_PKEY) int
+fn C.EVP_DigestVerifyUpdate(ctx &C.EVP_MD_CTX, d voidptr, cnt int) int
+fn C.EVP_DigestVerifyFinal(ctx &C.EVP_MD_CTX, sig &u8, siglen int) int
 
 // EVP_PKEY Context
 @[typedef]
 struct C.EVP_PKEY_CTX {}
 
+fn C.EVP_PKEY_CTX_new(pkey &C.EVP_PKEY, e voidptr) &C.EVP_PKEY_CTX
 fn C.EVP_PKEY_CTX_new_id(id int, e voidptr) &C.EVP_PKEY_CTX
 fn C.EVP_PKEY_keygen_init(ctx &C.EVP_PKEY_CTX) int
 fn C.EVP_PKEY_keygen(ctx &C.EVP_PKEY_CTX, ppkey &&C.EVP_PKEY) int
@@ -124,3 +150,18 @@ struct C.ECDSA_SIG {}
 fn C.ECDSA_size(key &C.EC_KEY) u32
 fn C.ECDSA_sign(type_ int, dgst &u8, dgstlen int, sig &u8, siglen &u32, eckey &C.EC_KEY) int
 fn C.ECDSA_verify(type_ int, dgst &u8, dgstlen int, sig &u8, siglen int, eckey &C.EC_KEY) int
+
+@[typedef]
+struct C.EVP_MD_CTX {}
+
+fn C.EVP_MD_CTX_new() &C.EVP_MD_CTX
+fn C.EVP_MD_CTX_free(ctx &C.EVP_MD_CTX)
+
+// Wrapper of digest and signing related of the C opaque and functions.
+@[typedef]
+struct C.EVP_MD {}
+
+fn C.EVP_sha256() &C.EVP_MD
+fn C.EVP_sha384() &C.EVP_MD
+fn C.EVP_sha512() &C.EVP_MD
+fn C.EVP_MD_get_size(md &C.EVP_MD) int // -1 failure

--- a/vlib/crypto/ecdsa/example/ecdsa_seed_test.v
+++ b/vlib/crypto/ecdsa/example/ecdsa_seed_test.v
@@ -25,7 +25,7 @@ fn test_new_key_from_seed_with_random_size_and_data() ! {
 			}
 			continue
 		}
-		ret_seed := pvkey.seed()!
+		ret_seed := pvkey.bytes()!
 		assert random_bytes == ret_seed
 		pvkey.free()
 	}

--- a/vlib/crypto/ecdsa/util_test.v
+++ b/vlib/crypto/ecdsa/util_test.v
@@ -47,7 +47,7 @@ fn test_for_pubkey_bytes() ! {
 	pb := '0421af184ac64c8a13e66c65d4f1ad31677edeaa97af791aef73b66ea26d1623a411f67b6c4d842ba22fa39d1216bd64acef00a1b924ac11a10af679ac3a7eb2fd'
 	pvkey := new_key_from_seed(hex.decode(pv)!)!
 
-	assert pvkey.seed()!.hex() == pv
+	assert pvkey.bytes()!.hex() == pv
 	pbkey := pvkey.public_key()!
 	assert pbkey.bytes()!.hex() == pb
 	pbkey.free()
@@ -87,7 +87,7 @@ fn test_for_pubkey_bytes() ! {
 fn test_load_privkey_from_string_sign_and_verify() ! {
 	pvkey := privkey_from_string(privatekey_sample)!
 	expected_pvkey_bytes := '30ce3da288965ac6093f0ba9a9a15b2476bea3eda925e1b3c1f094674f52795cd6cb3cafe235dfc15bec542448ffa715'
-	assert pvkey.seed()!.hex() == expected_pvkey_bytes
+	assert pvkey.bytes()!.hex() == expected_pvkey_bytes
 
 	// public key part	
 	pbkey := pvkey.public_key()!


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR is the main part of the migration efforts to the `crypto.ecdsa` module to support of the high level unobsoleted API. The old OpenSSL 1.1.1.  series has reached its End of Life (EOL). As such it will no longer receive publicly available security fixes, see [eol-of-ossl.1.1.1](https://openssl-library.org/post/2023-09-11-eol-111/) for more detail, so, maybe better to just upgrade your openssl to the 3.x series.

In this current PR, the main concerns was adding support to `.sign()` and `.verify()` routines to support the new api. Its done by using some changes to the internal detail of the current one, ie, in the form:
- Adds support to use a new high level opaque into `.sign()` and `.verify()` methods.
- Renames internal `.sign_message` into `.sign_digest` to reflect underlying its wrapped. Its sign the digest internally.
- Adds some helpers to cooperate with the rest. Some helpers are just redundant with the old one, because we supporting two opaque here, but, its can be removed (cleaned) on later pr.
- Adds some C required declarations.
- Some bits of cleans up 

Thats its. thanks