### PR TITLE
tools: reduce: fix warnings

### DIFF
--- a/cmd/tools/vreduce.v
+++ b/cmd/tools/vreduce.v
@@ -353,5 +353,7 @@ fn show_code_stats(code string, params ShowParams) {
 }
 
 fn warn_on_false(res bool, what string, loc string) {
-	log.warn('${what} is false, at ${loc}')
+	if !res {
+		log.warn('${what} is false, at ${loc}')
+	}
 }


### PR DESCRIPTION
fix: warn_on_false did not check if it was false

Now it does not warn for nothing.