### PR TITLE
v: fix compiler for -no-builtin

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -76,6 +76,7 @@ pub mut:
 	sumtypes           map[int]SumTypeDecl
 	cmod_prefix        string // needed for ast.type_to_str(Type) while vfmt; contains `os.`
 	is_fmt             bool
+	no_builtin         bool
 	used_features      &UsedFeatures = &UsedFeatures{} // filled in by the builder via markused module, when pref.skip_unused = true;
 	veb_res_idx_cache  int // Cache of `veb.Result` type
 	veb_ctx_idx_cache  int // Cache of `veb.Context` type
@@ -943,12 +944,20 @@ pub fn (t &Table) known_type_idx(typ Type) bool {
 			return sym.language != .v || sym.name.starts_with('C.')
 		}
 		.array {
+			if t.no_builtin {
+				util.verror('error', 'V builtin usage detected, but -no-builtin was supplied')
+				return false
+			}
 			return t.known_type_idx((sym.info as Array).elem_type)
 		}
 		.array_fixed {
 			return t.known_type_idx((sym.info as ArrayFixed).elem_type)
 		}
 		.map {
+			if t.no_builtin {
+				util.verror('error', 'V builtin usage detected, but -no-builtin was supplied')
+				return false
+			}
 			info := sym.info as Map
 			return t.known_type_idx(info.key_type) && t.known_type_idx(info.value_type)
 		}

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -51,6 +51,7 @@ pub fn new_builder(pref_ &pref.Preferences) Builder {
 	compiled_dir := if os.is_dir(rdir) { rdir } else { os.dir(rdir) }
 	mut table := ast.new_table()
 	table.is_fmt = false
+	table.no_builtin = pref_.no_builtin
 	if pref_.use_color == .always {
 		util.emanager.set_support_color(true)
 	}

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -149,7 +149,8 @@ fn (mut g Gen) gen_c_main_function_header() {
 
 fn (mut g Gen) gen_c_main_header() {
 	g.gen_c_main_function_header()
-	if g.pref.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm_leak] {
+	if !g.pref.no_builtin
+		&& g.pref.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm_leak] {
 		g.writeln('#if defined(_VGCBOEHM)')
 		if g.pref.gc_mode == .boehm_leak {
 			g.writeln('\tGC_set_find_leak(1);')


### PR DESCRIPTION
Before this patch, building such code with `-no-builtin` was failing because GC code (that belongs to builtin)

```
a := [2]int{}
```

With the following code:
```
module main

import v.builder.nativebuilder

fn main() {
	nativebuilder.start()
}
```
Now it displays:
`error: V builtin usage detected, but -no-builtin was supplied`