### PR TITLE
checker: fix call from unknown enum

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1560,8 +1560,7 @@ fn (mut c Checker) check_or_last_stmt(mut stmt ast.Stmt, ret_type ast.Type, expr
 				}
 			}
 			else {
-				if expr_return_type == 0 || stmt.typ == ast.void_type
-					|| expr_return_type == ast.void_type {
+				if stmt.typ == ast.void_type || expr_return_type == ast.void_type {
 					return
 				}
 				if is_noreturn_callexpr(stmt.expr) {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1560,7 +1560,8 @@ fn (mut c Checker) check_or_last_stmt(mut stmt ast.Stmt, ret_type ast.Type, expr
 				}
 			}
 			else {
-				if stmt.typ == ast.void_type || expr_return_type == ast.void_type {
+				if expr_return_type == 0 || stmt.typ == ast.void_type
+					|| expr_return_type == ast.void_type {
 					return
 				}
 				if is_noreturn_callexpr(stmt.expr) {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1154,6 +1154,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 			if idx == 0 {
 				c.error('unknown enum `${enum_name}`', node.pos)
+				continue_check = false
 				return ast.void_type
 			}
 

--- a/vlib/v/checker/tests/unkown_enum_call_err.out
+++ b/vlib/v/checker/tests/unkown_enum_call_err.out
@@ -1,0 +1,18 @@
+vlib/v/checker/tests/unkown_enum_call_err.vv:8:9: error: unknown enum `HashFnX`
+    6 | 
+    7 | fn test_main() {
+    8 |     assert HashFnX.from_string('sha256') or { HashFn.sha1 } == HashFn.sha256
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 | }
+vlib/v/checker/tests/unkown_enum_call_err.vv:8:39: error: unexpected `or` block, the function `HashFnX__static__from_string` does not return an Option or a Result
+    6 | 
+    7 | fn test_main() {
+    8 |     assert HashFnX.from_string('sha256') or { HashFn.sha1 } == HashFn.sha256
+      |                                          ~~~~~~~~~~~~~~~~~~
+    9 | }
+vlib/v/checker/tests/unkown_enum_call_err.vv:8:9: error: assert can be used only with `bool` expressions, but found `void` instead
+    6 | 
+    7 | fn test_main() {
+    8 |     assert HashFnX.from_string('sha256') or { HashFn.sha1 } == HashFn.sha256
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 | }

--- a/vlib/v/checker/tests/unkown_enum_call_err.vv
+++ b/vlib/v/checker/tests/unkown_enum_call_err.vv
@@ -1,0 +1,9 @@
+enum HashFn {
+	sha1
+	sha256
+	sha512
+}
+
+fn test_main() {
+	assert HashFnX.from_string('sha256') or { HashFn.sha1 } == HashFn.sha256
+}


### PR DESCRIPTION
Fix #23728