### PR TITLE
cgen: fix map with Enum minor than 4 bytes on tcc

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3395,6 +3395,11 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 		}
 		.enum {
 			einfo := (key_sym.info) as ast.Enum
+			if g.pref.ccompiler_type == .tinyc
+				&& einfo.typ in [ast.u8_type, ast.u16_type, ast.i8_type, ast.i16_type] {
+				// workaround for tcc, since we can not generate a packed Enum with size < 4 bytes
+				return g.map_fn_ptrs(g.table.sym(ast.int_type))
+			}
 			return g.map_fn_ptrs(g.table.sym(einfo.typ))
 		}
 		.int, .i32, .u32, .rune, .f32 {

--- a/vlib/v/tests/enum_packed_test.v
+++ b/vlib/v/tests/enum_packed_test.v
@@ -1,0 +1,19 @@
+module main
+
+import flag
+import os
+
+pub enum Number as u8 {
+	zero = 0
+	one  = 1
+	six  = 6
+}
+
+fn test_main() {
+	mut fp := flag.new_flag_parser(os.args)
+	_ := fp.finalize()!
+	mut numbers := map[Number]string{}
+	numbers[.zero] = '0'
+	numbers[.one] = '1'
+	assert numbers.str() == "{zero: '0', one: '1'}"
+}


### PR DESCRIPTION
Fix #23714